### PR TITLE
Components: Add wizard component

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -220,6 +220,7 @@
 @import 'components/vertical-menu/style';
 @import 'components/web-preview/style';
 @import 'components/webpack-build-monitor/style';
+@import 'components/wizard/style';
 @import 'blocks/credit-card-form/style';
 @import 'devdocs/docs-example/style';
 @import 'devdocs/docs-selectors/style';

--- a/client/components/wizard/README.md
+++ b/client/components/wizard/README.md
@@ -1,0 +1,62 @@
+Wizard
+======
+`Wizard` is a component that leads the user through a series of pre-defined steps.
+It keeps track of progress and enables navigating back or forward through the steps.
+
+## Usage
+
+```js
+const components = {
+	'first': <First />,
+	'second': <Second />,
+};
+const steps = [ 'first', 'second' ];
+
+<Wizard
+	basePath="/section/wizard"
+	components={ components }
+	steps={ steps }
+	stepName="first" />
+```
+
+## Props
+
+The following props can be passed to the `Wizard` component:
+
+### `basePath`
+
+<table>
+	<tr><td>Type</td><td>String</td></tr>
+	<tr><td>Required</td><td>No</td></tr>
+</table>
+
+Used when navigating between steps. The URL that the user is sent to will be constructed using
+`basePath` and `stepName` (see below).
+
+### `components`
+
+<table>
+	<tr><td>Type</td><td>Object</td></tr>
+	<tr><td>Required</td><td>Yes</td></tr>
+</table>
+
+An object of React components that will be rendered at each step in the wizard. Each key should map
+to one of the values in the `steps` array (see below).
+
+### `steps`
+
+<table>
+	<tr><td>Type</td><td>Array</td></tr>
+	<tr><td>Required</td><td>Yes</td></tr>
+</table>
+
+An array of strings denoting each of the steps in the wizard.
+
+### `stepName`
+
+<table>
+	<tr><td>Type</td><td>String</td></tr>
+	<tr><td>Required</td><td>Yes</td></tr>
+</table>
+
+The name of the current step (one of the values in `steps`).

--- a/client/components/wizard/docs/example.jsx
+++ b/client/components/wizard/docs/example.jsx
@@ -1,0 +1,42 @@
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import Wizard from '../index';
+
+const First = () => <div style={ { textAlign: 'center' } }>This is the first step.</div>;
+const Second = () => <div style={ { textAlign: 'center' } }>This is the second step.</div>;
+const Third = () => <div style={ { textAlign: 'center' } }>This is the third step.</div>;
+const STEPS = {
+	FIRST: 'first',
+	SECOND: 'second',
+	THIRD: 'third',
+};
+const steps = [ STEPS.FIRST, STEPS.SECOND, STEPS.THIRD ];
+const components = {
+	[ STEPS.FIRST ]: <First />,
+	[ STEPS.SECOND ]: <Second />,
+	[ STEPS.THIRD ]: <Third />,
+};
+
+export default class WizardExample extends Component {
+	render() {
+		const { stepName } = this.props;
+
+		return (
+			<div>
+				<Wizard
+					basePath="/devdocs/design/wizard"
+					components={ components }
+					steps={ steps }
+					stepName={ stepName || steps[ 0 ] } />
+			</div>
+		);
+	}
+}
+
+WizardExample.displayName = 'Wizard';

--- a/client/components/wizard/docs/example.jsx
+++ b/client/components/wizard/docs/example.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { Component } from 'react';
+import React from 'react';
 
 /**
  * Internal dependencies
@@ -23,20 +23,14 @@ const components = {
 	[ STEPS.THIRD ]: <Third />,
 };
 
-export default class WizardExample extends Component {
-	render() {
-		const { stepName } = this.props;
+const WizardExample = ( { stepName = steps[ 0 ] } ) => (
+	<div>
+		<Wizard
+			basePath="/devdocs/design/wizard"
+			components={ components }
+			steps={ steps }
+			stepName={ stepName } />
+	</div>
+);
 
-		return (
-			<div>
-				<Wizard
-					basePath="/devdocs/design/wizard"
-					components={ components }
-					steps={ steps }
-					stepName={ stepName || steps[ 0 ] } />
-			</div>
-		);
-	}
-}
-
-WizardExample.displayName = 'Wizard';
+export default WizardExample;

--- a/client/components/wizard/index.jsx
+++ b/client/components/wizard/index.jsx
@@ -1,0 +1,98 @@
+/**
+ * External dependencies
+ */
+import React, { Component, PropTypes } from 'react';
+import { get, indexOf } from 'lodash';
+import page from 'page';
+
+/**
+ * Internal dependencies
+ */
+import NavigationLink from './navigation-link';
+import ProgressIndicator from 'components/wizard/progress-indicator';
+
+class Wizard extends Component {
+	static propTypes = {
+		basePath: PropTypes.string,
+		components: PropTypes.objectOf( PropTypes.element ).isRequired,
+		steps: PropTypes.arrayOf( PropTypes.string ).isRequired,
+		stepName: PropTypes.string.isRequired,
+	}
+
+	static defaultProps = {
+		basePath: '',
+	}
+
+	getStepIndex = () => indexOf( this.props.steps, this.props.stepName );
+
+	goBack = () => {
+		const stepIndex = this.getStepIndex();
+
+		if ( stepIndex < 1 ) {
+			return;
+		}
+
+		const { basePath, steps } = this.props;
+		const previousStepName = steps[ stepIndex - 1 ];
+
+		if ( ! previousStepName ) {
+			return;
+		}
+
+		page( `${ basePath }/${ previousStepName }` );
+	}
+
+	skip = () => {
+		const { basePath, steps } = this.props;
+		const stepIndex = this.getStepIndex();
+
+		if ( stepIndex === -1 || ( stepIndex === steps.length - 1 ) ) {
+			return;
+		}
+
+		const nextStepName = steps[ stepIndex + 1 ];
+
+		if ( ! nextStepName ) {
+			return;
+		}
+
+		page( `${ basePath }/${ nextStepName }` );
+	}
+
+	render() {
+		const { components, steps, stepName } = this.props;
+		const component = get( components, stepName );
+		const stepIndex = this.getStepIndex();
+		const totalSteps = steps.length;
+
+		return (
+			<div className="wizard">
+				{ totalSteps > 1 &&
+					<ProgressIndicator
+						stepNumber={ stepIndex }
+						totalSteps={ totalSteps } />
+				}
+
+				{ component }
+
+				{ totalSteps > 1 &&
+					<div className="wizard__navigation-links">
+						{ stepIndex > 0 &&
+							<NavigationLink
+								direction="back"
+								onClick={ this.goBack } />
+						}
+
+						{ stepIndex < totalSteps - 1 &&
+							<NavigationLink
+								direction="forward"
+								onClick={ this.skip } />
+						}
+					</div>
+				}
+			</div>
+		);
+	}
+}
+
+export default Wizard;

--- a/client/components/wizard/index.jsx
+++ b/client/components/wizard/index.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { get, indexOf } from 'lodash';
 import page from 'page';
 

--- a/client/components/wizard/index.jsx
+++ b/client/components/wizard/index.jsx
@@ -4,7 +4,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { get, indexOf } from 'lodash';
-import page from 'page';
 
 /**
  * Internal dependencies
@@ -26,7 +25,7 @@ class Wizard extends Component {
 
 	getStepIndex = () => indexOf( this.props.steps, this.props.stepName );
 
-	goBack = () => {
+	getBackUrl = () => {
 		const stepIndex = this.getStepIndex();
 
 		if ( stepIndex < 1 ) {
@@ -40,10 +39,10 @@ class Wizard extends Component {
 			return;
 		}
 
-		page( `${ basePath }/${ previousStepName }` );
+		return `${ basePath }/${ previousStepName }`;
 	}
 
-	skip = () => {
+	getSkipUrl = () => {
 		const { basePath, steps } = this.props;
 		const stepIndex = this.getStepIndex();
 
@@ -57,7 +56,7 @@ class Wizard extends Component {
 			return;
 		}
 
-		page( `${ basePath }/${ nextStepName }` );
+		return `${ basePath }/${ nextStepName }`;
 	}
 
 	render() {
@@ -65,6 +64,8 @@ class Wizard extends Component {
 		const component = get( components, stepName );
 		const stepIndex = this.getStepIndex();
 		const totalSteps = steps.length;
+		const backUrl = this.getBackUrl() || '';
+		const skipUrl = this.getSkipUrl() || '';
 
 		return (
 			<div className="wizard">
@@ -81,13 +82,13 @@ class Wizard extends Component {
 						{ stepIndex > 0 &&
 							<NavigationLink
 								direction="back"
-								onClick={ this.goBack } />
+								href={ backUrl } />
 						}
 
 						{ stepIndex < totalSteps - 1 &&
 							<NavigationLink
 								direction="forward"
-								onClick={ this.skip } />
+								href={ skipUrl } />
 						}
 					</div>
 				}

--- a/client/components/wizard/navigation-link.jsx
+++ b/client/components/wizard/navigation-link.jsx
@@ -1,0 +1,33 @@
+/**
+ * External dependencies
+ */
+import React, { PropTypes } from 'react';
+import { localize } from 'i18n-calypso';
+import Gridicon from 'gridicons';
+
+/**
+ * Internal dependencies
+ */
+import Button from 'components/button';
+
+const NavigationLink = ( { direction, onClick, translate } ) => {
+	const text = ( direction === 'back' ) ? translate( 'Back' ) : translate( 'Skip for now' );
+
+	return (
+		<Button compact borderless
+			className="wizard__navigation-link"
+			onClick={ onClick }>
+			{ direction === 'back' && <Gridicon icon="arrow-left" size={ 18 } /> }
+			{ text }
+			{ direction === 'forward' && <Gridicon icon="arrow-right" size={ 18 } /> }
+		</Button>
+	);
+};
+
+NavigationLink.propTypes = {
+	direction: PropTypes.oneOf( [ 'back', 'forward' ] ).isRequired,
+	onClick: PropTypes.func.isRequired,
+	translate: PropTypes.func.isRequired,
+};
+
+export default localize( NavigationLink );

--- a/client/components/wizard/navigation-link.jsx
+++ b/client/components/wizard/navigation-link.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'gridicons';
 

--- a/client/components/wizard/navigation-link.jsx
+++ b/client/components/wizard/navigation-link.jsx
@@ -11,13 +11,13 @@ import Gridicon from 'gridicons';
  */
 import Button from 'components/button';
 
-const NavigationLink = ( { direction, onClick, translate } ) => {
+const NavigationLink = ( { direction, href, translate } ) => {
 	const text = ( direction === 'back' ) ? translate( 'Back' ) : translate( 'Skip for now' );
 
 	return (
 		<Button compact borderless
 			className="wizard__navigation-link"
-			onClick={ onClick }>
+			href={ href }>
 			{ direction === 'back' && <Gridicon icon="arrow-left" size={ 18 } /> }
 			{ text }
 			{ direction === 'forward' && <Gridicon icon="arrow-right" size={ 18 } /> }
@@ -27,7 +27,7 @@ const NavigationLink = ( { direction, onClick, translate } ) => {
 
 NavigationLink.propTypes = {
 	direction: PropTypes.oneOf( [ 'back', 'forward' ] ).isRequired,
-	onClick: PropTypes.func.isRequired,
+	href: PropTypes.string,
 	translate: PropTypes.func.isRequired,
 };
 

--- a/client/components/wizard/progress-indicator.jsx
+++ b/client/components/wizard/progress-indicator.jsx
@@ -1,0 +1,28 @@
+/**
+ * External dependencies
+ */
+import React, { PropTypes } from 'react';
+import { localize } from 'i18n-calypso';
+
+const ProgressIndicator = ( { stepNumber, totalSteps, translate } ) => {
+	return (
+		<div className="wizard__progress-indicator">
+			{
+				translate( 'Step %(stepNumber)d of %(stepTotal)d', {
+					args: {
+						stepNumber: stepNumber + 1,
+						stepTotal: totalSteps,
+					}
+				} )
+			}
+		</div>
+	);
+};
+
+ProgressIndicator.propTypes = {
+	stepNumber: PropTypes.number.isRequired,
+	totalSteps: PropTypes.number.isRequired,
+	translate: PropTypes.func.isRequired,
+};
+
+export default localize( ProgressIndicator );

--- a/client/components/wizard/progress-indicator.jsx
+++ b/client/components/wizard/progress-indicator.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 
 const ProgressIndicator = ( { stepNumber, totalSteps, translate } ) => {

--- a/client/components/wizard/progress-indicator.jsx
+++ b/client/components/wizard/progress-indicator.jsx
@@ -5,20 +5,18 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 
-const ProgressIndicator = ( { stepNumber, totalSteps, translate } ) => {
-	return (
-		<div className="wizard__progress-indicator">
-			{
-				translate( 'Step %(stepNumber)d of %(stepTotal)d', {
-					args: {
-						stepNumber: stepNumber + 1,
-						stepTotal: totalSteps,
-					}
-				} )
-			}
-		</div>
-	);
-};
+const ProgressIndicator = ( { stepNumber, totalSteps, translate } ) => (
+	<div className="wizard__progress-indicator">
+		{
+			translate( 'Step %(stepNumber)d of %(stepTotal)d', {
+				args: {
+					stepNumber: stepNumber + 1,
+					stepTotal: totalSteps,
+				}
+			} )
+		}
+	</div>
+);
 
 ProgressIndicator.propTypes = {
 	stepNumber: PropTypes.number.isRequired,

--- a/client/components/wizard/style.scss
+++ b/client/components/wizard/style.scss
@@ -1,0 +1,36 @@
+/* Progress Indicator */
+.wizard__progress-indicator {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+
+	color: darken( $gray, 20 );
+	font-size: 14px;
+	font-weight: 300;
+	margin-bottom: 10px;
+	text-align: center;
+
+	@include breakpoint( '<660px' ) {
+		padding-top: 10px;
+	}
+}
+
+/* Navigation */
+.wizard__navigation-links {
+	text-align: center;
+}
+
+.wizard__navigation-links .button.is-borderless {
+	color: darken( $gray, 20 );
+
+	&:hover {
+		color: $gray-dark;
+	}
+}
+
+.wizard__navigation-link {
+	cursor: pointer;
+	display: inline-block;
+	margin: 24px 12px;
+	text-align: center;
+}

--- a/client/devdocs/controller.js
+++ b/client/devdocs/controller.js
@@ -23,6 +23,7 @@ import DevWelcome from './welcome';
 import Sidebar from './sidebar';
 import FormStateExamplesComponent from './form-state-examples';
 import EmptyContent from 'components/empty-content';
+import Wizard from 'components/wizard/docs/example';
 import { renderWithReduxStore } from 'lib/react-helpers';
 
 const devdocs = {
@@ -99,6 +100,16 @@ const devdocs = {
 		renderWithReduxStore(
 			React.createElement( DesignAssetsComponent, {
 				component: context.params.component
+			} ),
+			'primary',
+			context.store
+		);
+	},
+
+	wizard: function( context ) {
+		renderWithReduxStore(
+			React.createElement( Wizard, {
+				stepName: context.params.stepName
 			} ),
 			'primary',
 			context.store

--- a/client/devdocs/controller.js
+++ b/client/devdocs/controller.js
@@ -23,7 +23,7 @@ import DevWelcome from './welcome';
 import Sidebar from './sidebar';
 import FormStateExamplesComponent from './form-state-examples';
 import EmptyContent from 'components/empty-content';
-import Wizard from 'components/wizard/docs/example';
+import WizardComponent from './wizard-component';
 import { renderWithReduxStore } from 'lib/react-helpers';
 
 const devdocs = {
@@ -108,9 +108,7 @@ const devdocs = {
 
 	wizard: function( context ) {
 		renderWithReduxStore(
-			React.createElement( Wizard, {
-				stepName: context.params.stepName
-			} ),
+			<WizardComponent stepName={ context.params.stepName } />,
 			'primary',
 			context.store
 		);

--- a/client/devdocs/design/index.jsx
+++ b/client/devdocs/design/index.jsx
@@ -76,6 +76,7 @@ import EmptyContent from 'components/empty-content/docs/example';
 import ScreenReaderTextExample from 'components/screen-reader-text/docs/example';
 import PaginationExample from 'components/pagination/docs/example';
 import ListEnd from 'components/list-end/docs/example';
+import Wizard from 'components/wizard/docs/example';
 
 let DesignAssets = React.createClass( {
 	displayName: 'DesignAssets',
@@ -172,6 +173,7 @@ let DesignAssets = React.createClass( {
 					<TokenFields />
 					<VerticalMenu />
 					<Version />
+					<Wizard />
 				</Collection>
 			</Main>
 		);

--- a/client/devdocs/index.js
+++ b/client/devdocs/index.js
@@ -14,6 +14,7 @@ export default function() {
 		page( '/devdocs', controller.sidebar, controller.devdocs );
 		page( '/devdocs/form-state-examples/:component?', controller.sidebar, controller.formStateExamples );
 		page( '/devdocs/design/typography', controller.sidebar, controller.typography );
+		page( '/devdocs/design/wizard/:stepName?', controller.sidebar, controller.wizard );
 		page( '/devdocs/design/:component?', controller.sidebar, controller.design );
 		page( '/devdocs/app-components/:component?',
 			( context ) => page.redirect( '/devdocs/blocks/' + ( context.params.component || '' ) ) );

--- a/client/devdocs/style.scss
+++ b/client/devdocs/style.scss
@@ -1,5 +1,6 @@
 .devdocs,
-.design {
+.design,
+.wizard-component {
 	font-size: 18px;
 	line-height: 1.618;
 	color: $gray-dark;

--- a/client/devdocs/wizard-component/index.jsx
+++ b/client/devdocs/wizard-component/index.jsx
@@ -1,0 +1,31 @@
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import page from 'page';
+
+/**
+ * Internal dependencies
+ */
+import HeaderCake from 'components/header-cake';
+import Main from 'components/main';
+import Wizard from 'components/wizard/docs/example';
+
+class WizardComponent extends Component {
+	backToComponents = () => page( '/devdocs/design/' );
+
+	render() {
+		const { stepName } = this.props;
+
+		return (
+			<Main className="wizard-component">
+				<HeaderCake onClick={ this.backToComponents } backText="All Components">
+					Wizard
+				</HeaderCake>
+				<Wizard stepName={ stepName } />
+			</Main>
+		);
+	}
+}
+
+export default WizardComponent;


### PR DESCRIPTION
This PR adds a wizard component to Calypso to enable users to step through a setup wizard, for example. It is based on the wizard used for the signup flow, and currently includes a progress indicator at the top and navigation links at the bottom. The content itself is defined in a separate component that is passed to the wizard as part of a `prop`:

![wizard-component](https://user-images.githubusercontent.com/1190420/28939297-d45f1ee8-785e-11e7-9273-a40e885b0124.jpg)

For reference, this is what one of the screens in the signup flow looks like:

![signup-wizard](https://user-images.githubusercontent.com/1190420/28939345-fa317396-785e-11e7-8a4d-852c975d8210.jpg)

## Testing

Navigate to the _UI Components_ section of the devdocs. The wizard is the last component on the page. After clicking the _Skip for now_ link, you'll be taken to a page showing just the wizard, and you will be able to navigate through each of the steps.