### PR TITLE
Site Settings: Show an upgrade banner in Antispam card for free plan

### DIFF
--- a/client/my-sites/site-settings/spam-filtering-settings.jsx
+++ b/client/my-sites/site-settings/spam-filtering-settings.jsx
@@ -51,11 +51,11 @@ const SpamFilteringSettings = ( {
 	if ( ! inTransition && ! hasAkismetFeature && ! isValidKey ) {
 		return (
 			<Banner
-				description={ translate( 'Add state-of-the-art spam defense powered by Akismet.' ) }
+				description={ translate( 'Detect and tweeze spam automatically, with Akismet.' ) }
 				event={ 'calypso_akismet_settings_upgrade_nudge' }
 				feature={ FEATURE_SPAM_AKISMET_PLUS }
 				plan={ PLAN_JETPACK_PERSONAL }
-				title={ translate( 'Enable spam filtering by upgrading to Jetpack Personal' ) }
+				title={ translate( 'Defend your site against spam! Upgrade to Jetpack Personal.' ) }
 			/>
 		);
 	}

--- a/client/my-sites/site-settings/spam-filtering-settings.jsx
+++ b/client/my-sites/site-settings/spam-filtering-settings.jsx
@@ -9,6 +9,7 @@ import { includes } from 'lodash';
 /**
  * Internal dependencies
  */
+import Banner from 'components/banner';
 import FoldableCard from 'components/foldable-card';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
@@ -20,11 +21,17 @@ import ExternalLink from 'components/external-link';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getJetpackSettingsSaveError, getJetpackSettingsSaveRequestStatus } from 'state/selectors';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
+import { hasFeature } from 'state/sites/plans/selectors';
+import {
+	FEATURE_SPAM_AKISMET_PLUS,
+	PLAN_JETPACK_PERSONAL,
+} from 'lib/plans/constants';
 
 const SpamFilteringSettings = ( {
 	currentAkismetKey,
 	dirtyFields,
 	fields,
+	hasAkismetFeature,
 	hasAkismetKeyError,
 	isRequestingSettings,
 	isSavingSettings,
@@ -40,6 +47,19 @@ const SpamFilteringSettings = ( {
 		( wordpress_api_key && isDirty && isStoredKey && ! hasAkismetKeyError );
 	const isInvalidKey = isDirty && hasAkismetKeyError && ! isStoredKey;
 	let validationText, className, header = null;
+
+	if ( ! inTransition && ! hasAkismetFeature && ! isValidKey ) {
+		return (
+			<Banner
+				description={ translate( 'Add state-of-the-art spam defense powered by Akismet.' ) }
+				event={ 'calypso_akismet_settings_upgrade_nudge' }
+				feature={ FEATURE_SPAM_AKISMET_PLUS }
+				plan={ PLAN_JETPACK_PERSONAL }
+				title={ translate( 'Enable spam filtering by upgrading to Jetpack Personal' ) }
+			/>
+		);
+	}
+
 	if ( ! inTransition && isValidKey ) {
 		validationText = translate( 'Your Antispam key is valid.' );
 		className = 'is-valid';
@@ -127,7 +147,10 @@ export default connect( state => {
 		jetpackSettingsSaveStatus &&
 		jetpackSettingsSaveStatus === 'error' &&
 		includes( jetpackSettingsSaveError, 'wordpress_api_key' );
+	const hasAkismetFeature = hasFeature( state, selectedSiteId, FEATURE_SPAM_AKISMET_PLUS );
+
 	return {
+		hasAkismetFeature,
 		hasAkismetKeyError,
 	};
 } )( localize( SpamFilteringSettings ) );


### PR DESCRIPTION
This PR updates the Antispam card to show an upgrade banner when the user is on a free plan and does not have Akismet setup.

Fixes #14654.

I've used the copy from the plans, but I can still use some copy feedback, maybe folks from @Automattic/editorial can have a look.

Preview:
![](https://cldup.com/r3-P1JOTtJ.png)

To test:
* Checkout this branch, or get it going on calypso.live
* Go to `/settings/security/:site`, where `:site` is a Jetpack site on a Free plan.
* Verify you can see the banner, and it leads to the plans page with the Antispam feature highlighted.
* Test with a Jetpack site with a paid plan and verify it works like it did before.