### PR TITLE
SimplePaymentsDialog: add an example to devdocs/blocks

### DIFF
--- a/client/components/tinymce/plugins/simple-payments/dialog/docs/example.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/docs/example.jsx
@@ -1,0 +1,42 @@
+/**
+ * External dependencies
+ */
+import React, { PureComponent } from 'react';
+import { connect } from 'react-redux';
+import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import Button from 'components/button';
+import Card from 'components/card';
+import SimplePaymentsDialog from 'components/tinymce/plugins/simple-payments/dialog';
+import { getCurrentUser } from 'state/current-user/selectors';
+
+class SimplePaymentsDialogExample extends PureComponent {
+	state = { showDialog: false };
+
+	openDialog = () => this.setState( { showDialog: true } );
+	handleClose = () => this.setState( { showDialog: false } );
+
+	render() {
+		return (
+			<Card>
+				<Button onClick={ this.openDialog }>Open Simple Payments Dialog</Button>
+				<SimplePaymentsDialog
+					siteId={ this.props.siteId }
+					showDialog={ this.state.showDialog }
+					onClose={ this.handleClose }
+				/>
+			</Card>
+		);
+	}
+}
+
+const ConnectedSimplePaymentsDialogExample = connect( state => ( {
+	siteId: get( getCurrentUser( state ), 'primary_blog' ),
+} ) )( SimplePaymentsDialogExample );
+
+ConnectedSimplePaymentsDialogExample.displayName = 'SimplePaymentsDialogExample';
+
+export default ConnectedSimplePaymentsDialogExample;

--- a/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
@@ -360,8 +360,10 @@ class SimplePaymentsDialog extends Component {
 	}
 }
 
-export default connect( state => {
-	const siteId = getSelectedSiteId( state );
+export default connect( ( state, { siteId } ) => {
+	if ( ! siteId ) {
+		siteId = getSelectedSiteId( state );
+	}
 
 	return {
 		siteId,

--- a/client/devdocs/design/blocks.jsx
+++ b/client/devdocs/design/blocks.jsx
@@ -75,6 +75,7 @@ import Login from 'blocks/login/docs/example';
 import ReaderEmailSettings from 'blocks/reader-email-settings/docs/example';
 import UploadImage from 'blocks/upload-image/docs/example';
 import ConversationCommentList from 'blocks/conversations/docs/example';
+import SimplePaymentsDialog from 'components/tinymce/plugins/simple-payments/dialog/docs/example';
 
 export default React.createClass( {
 	displayName: 'AppComponents',
@@ -162,6 +163,7 @@ export default React.createClass( {
 					<ReaderExportButton />
 					<ReaderImportButton />
 					<SharingPreviewPane />
+					<SimplePaymentsDialog />
 					<ReaderShare />
 					<ReaderEmailSettings />
 					<UploadImage />


### PR DESCRIPTION
Very useful for testing and development of the modal. Works with the primary site of the user.

In addition to just adding a _docs/example.jsx_ file, there's one tweak needed in the `SimplePaymentsDialog` component: one can now pass an explicit `siteId` prop to it from outside. Only if it's not specified, it will default to the selected site ID. The example works with the primary site of the user, as no site is selected while on the devdocs page.