### PR TITLE
Activity log: Replace placeholder with plugin name

### DIFF
--- a/client/my-sites/stats/activity-log-item/activity-title.jsx
+++ b/client/my-sites/stats/activity-log-item/activity-title.jsx
@@ -334,7 +334,8 @@ class ActivityTitle extends Component {
 			}
 			case 'plugin__updated': {
 				const actorName = this.getActorName();
-				return `${ actorName } updated plugin <title, link>.`;
+				const pluginName = this.getPluginName();
+				return `${ actorName } updated plugin ${ pluginName }`;
 			}
 
 			/**


### PR DESCRIPTION
Fixes a leftover placeholder in UI:

## Testing
1. You'll need an AL site with `plugin__updated` activity.
1. Visit https://calypso.live/stats/activity?branch=fix/activitylog-pluginupdate-placeholder
1. Verify that the activity title is correct.

## Screens

### Before

![before](https://user-images.githubusercontent.com/841763/28833694-65ee01d8-76e0-11e7-8584-873c93624724.png)

### After

![after](https://user-images.githubusercontent.com/841763/28833701-6a81f498-76e0-11e7-8d96-8fae4529e91f.png)
