### PR TITLE
Notifications: bump version for panel.  allows for opening in new tab…

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -42,7 +42,7 @@
       "version": "1.1.0"
     },
     "abstract-leveldown": {
-      "version": "2.4.1"
+      "version": "2.6.2"
     },
     "accepts": {
       "version": "1.2.13"
@@ -836,7 +836,7 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000708"
+      "version": "1.0.30000709"
     },
     "cardinal": {
       "version": "1.0.0",
@@ -1358,7 +1358,7 @@
       }
     },
     "deferred-leveldown": {
-      "version": "1.2.1"
+      "version": "1.2.2"
     },
     "define-properties": {
       "version": "1.1.2"
@@ -1469,6 +1469,9 @@
         }
       }
     },
+    "dom-walk": {
+      "version": "0.1.1"
+    },
     "domain-browser": {
       "version": "1.1.7"
     },
@@ -1534,7 +1537,7 @@
       "version": "1.1.1"
     },
     "ejs": {
-      "version": "2.5.6",
+      "version": "2.5.7",
       "dev": true
     },
     "element-class": {
@@ -2717,6 +2720,14 @@
         }
       }
     },
+    "global": {
+      "version": "4.3.2",
+      "dependencies": {
+        "process": {
+          "version": "0.5.2"
+        }
+      }
+    },
     "globals": {
       "version": "9.18.0"
     },
@@ -3698,7 +3709,7 @@
       "version": "3.0.2"
     },
     "js-yaml": {
-      "version": "3.9.0",
+      "version": "3.9.1",
       "dev": true,
       "dependencies": {
         "esprima": {
@@ -3943,12 +3954,7 @@
       "version": "1.2.1"
     },
     "leveldown": {
-      "version": "1.7.2",
-      "dependencies": {
-        "abstract-leveldown": {
-          "version": "2.6.1"
-        }
-      }
+      "version": "1.7.2"
     },
     "levelup": {
       "version": "1.3.9",
@@ -4250,6 +4256,9 @@
     "mime-types": {
       "version": "2.1.16"
     },
+    "min-document": {
+      "version": "2.19.0"
+    },
     "minimalistic-assert": {
       "version": "1.0.0"
     },
@@ -4515,7 +4524,7 @@
       "dev": true
     },
     "notifications-panel": {
-      "version": "1.2.0"
+      "version": "1.2.1"
     },
     "npm-path": {
       "version": "1.1.0",
@@ -6206,7 +6215,7 @@
       "dev": true
     },
     "timers-browserify": {
-      "version": "2.0.2"
+      "version": "2.0.3"
     },
     "tiny-emitter": {
       "version": "1.2.0"
@@ -6837,7 +6846,7 @@
       "optional": true
     },
     "which": {
-      "version": "1.2.14"
+      "version": "1.3.0"
     },
     "which-module": {
       "version": "1.0.0"

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "ms": "0.7.1",
     "name-all-modules-plugin": "1.0.1",
     "node-sass": "3.7.0",
-    "notifications-panel": "1.2.0",
+    "notifications-panel": "1.2.1",
     "npm-run-all": "4.0.2",
     "numeral": "2.0.4",
     "page": "1.6.4",


### PR DESCRIPTION
open links in new tab if meta/ctrl are pressed

- See https://github.com/Automattic/notifications-panel/pull/172 for the code change
- this pr just bumps notifications-panel and runs `make shrinkwrap`

testing:
- [x] ensure the notifications panel still works + that opening in new tab works in wpcalypso