### PR TITLE
Store Orders: Don't show the refund card if the order is cancelled or if payment failed

### DIFF
--- a/client/extensions/woocommerce/app/order/order-refund-card.js
+++ b/client/extensions/woocommerce/app/order/order-refund-card.js
@@ -165,6 +165,11 @@ class OrderRefundCard extends Component {
 		const { isPaymentLoading, order, site, translate } = this.props;
 		const { errorMessage, refundNote, showDialog } = this.state;
 		const dialogClass = 'woocommerce'; // eslint/css specificity hack
+
+		if ( 'cancelled' === order.status || 'failed' === order.status ) {
+			return null;
+		}
+
 		let refundTotal = formatCurrency( 0, order.currency );
 		if ( this.state.refundTotal ) {
 			refundTotal = formatCurrency( this.state.refundTotal, order.currency ) || this.state.refundTotal;


### PR DESCRIPTION
This PR removes the refund section on order details if the order is cancelled or if the payment failed. This fixes #16734

<img width="739" alt="screen shot 2017-08-01 at 11 26 02 am" src="https://user-images.githubusercontent.com/541093/28835485-746db578-76b3-11e7-863f-dad2c2eb9311.png">

**To test**

- View your orders `https://calypso.live/store/orders/:site?branch=update/store-orders-cancelled-refund`
- Click into a cancelled order
- You should not see the payment/refund card
- Go back to a successful order
- You should see the payment/refund card