### PR TITLE
Store Stats: Fix nested tracks call error

### DIFF
--- a/client/extensions/woocommerce/app/store-stats/store-stats-chart/index.js
+++ b/client/extensions/woocommerce/app/store-stats/store-stats-chart/index.js
@@ -51,7 +51,7 @@ class StoreStatsChart extends Component {
 		} );
 
 		analytics.tracks.recordEvent( 'calypso_woocommerce_stats_chart_tab_click', {
-			tab: tabs[ tab.index ]
+			tab: tabs[ tab.index ].attr
 		} );
 	};
 


### PR DESCRIPTION
When you tab switch in store stats there is this error in the console:

```Unable to record event "calypso_woocommerce_stats_chart_tab_click" because nestedproperties are not supported by Tracks.```

I believe the actual intent is as detailed in my change which is to track the tab the user clicked on in an unambiguous manner.

Alternatively if we want to pass everything in `chartTabs` for the tab we want something like this:

`analytics.tracks.recordEvent( 'calypso_woocommerce_stats_chart_tab_click', tabs[ tab.index ] );`

So that we don't have any nesting.

@psealock let me know what you think.
