### PR TITLE
Reader: add Tracks and Google Analytics stats to Reader sidebar

### DIFF
--- a/client/reader/sidebar/index.jsx
+++ b/client/reader/sidebar/index.jsx
@@ -41,6 +41,7 @@ import viewport from 'lib/viewport';
 import { localize } from 'i18n-calypso';
 import { getTagStreamUrl } from 'reader/route';
 import { isAutomatticTeamMember } from 'reader/lib/teams';
+import { recordAction, recordGaEvent, recordTrack } from 'reader/stats';
 
 export const ReaderSidebar = createReactClass( {
 	displayName: 'ReaderSidebar',
@@ -104,6 +105,48 @@ export const ReaderSidebar = createReactClass( {
 		}
 	},
 
+	handleReaderSidebarFollowedSitesClicked() {
+		recordAction( 'clicked_reader_sidebar_followed_sites' );
+		recordGaEvent( 'Clicked Reader Sidebar Followed Sites' );
+		recordTrack( 'calypso_reader_sidebar_followed_sites_clicked' );
+	},
+
+	handleReaderSidebarFollowManageClicked() {
+		recordAction( 'clicked_reader_sidebar_follow_manage' );
+		recordGaEvent( 'Clicked Reader Sidebar Follow Manage' );
+		recordTrack( 'calypso_reader_sidebar_follow_manage_clicked' );
+	},
+
+	handleReaderSidebarConversationsClicked() {
+		recordAction( 'clicked_reader_sidebar_conversations' );
+		recordGaEvent( 'Clicked Reader Sidebar Conversations' );
+		recordTrack( 'calypso_reader_sidebar_conversations_clicked' );
+	},
+
+	handleReaderSidebarA8cConversationsClicked() {
+		recordAction( 'clicked_reader_sidebar_a8c_conversations' );
+		recordGaEvent( 'Clicked Reader Sidebar A8C Conversations' );
+		recordTrack( 'calypso_reader_sidebar_a8c_conversations_clicked' );
+	},
+
+	handleReaderSidebarDiscoverClicked() {
+		recordAction( 'clicked_reader_sidebar_discover' );
+		recordGaEvent( 'Clicked Reader Sidebar Discover' );
+		recordTrack( 'calypso_reader_sidebar_discover_clicked' );
+	},
+
+	handleReaderSidebarSearchClicked() {
+		recordAction( 'clicked_reader_sidebar_search' );
+		recordGaEvent( 'Clicked Reader Sidebar Search' );
+		recordTrack( 'calypso_reader_sidebar_search_clicked' );
+	},
+
+	handleReaderSidebarLikeActivityClicked() {
+		recordAction( 'clicked_reader_sidebar_like_activity' );
+		recordGaEvent( 'Clicked Reader Sidebar Like Activity' );
+		recordTrack( 'calypso_reader_sidebar_like_activity_clicked' );
+	},
+
 	render() {
 		/* eslint-disable wpcalypso/jsx-classname-namespace,max-len */
 		return (
@@ -119,13 +162,20 @@ export const ReaderSidebar = createReactClass( {
 									'sidebar-streams__following': true,
 								} ) }
 							>
-								<a href="/">
+								<a
+									href="/"
+									onClick={ this.handleReaderSidebarFollowedSitesClicked }
+								>
 									<Gridicon icon="checkmark-circle" size={ 24 } />
 									<span className="menu-link-text">
 										{ this.props.translate( 'Followed Sites' ) }
 									</span>
 								</a>
-								<a href="/following/manage" className="sidebar__button">
+								<a
+									href="/following/manage"
+									onClick={ this.handleReaderSidebarFollowManageClicked }
+									className="sidebar__button"
+								>
 									{ this.props.translate( 'Manage' ) }
 								</a>
 							</li>
@@ -139,7 +189,10 @@ export const ReaderSidebar = createReactClass( {
 										},
 									) }
 								>
-									<a href="/read/conversations">
+									<a
+										href="/read/conversations"
+										onClick={ this.handleReaderSidebarConversationsClicked }
+									>
 										<Gridicon icon="comment" size={ 24 } />
 										<span className="menu-link-text">
 											{ this.props.translate( 'Conversations' ) }
@@ -158,7 +211,10 @@ export const ReaderSidebar = createReactClass( {
 										},
 									) }
 								>
-									<a href="/read/conversations/a8c">
+									<a
+										href="/read/conversations/a8c"
+										onClick={ this.handleReaderSidebarA8cConversationsClicked }
+									>
 										<svg
 											className={ 'gridicon gridicon-automattic' }
 											width="24"
@@ -181,7 +237,10 @@ export const ReaderSidebar = createReactClass( {
 											'sidebar-streams__discover': true,
 										} ) }
 									>
-										<a href="/discover">
+										<a
+											href="/discover"
+											onClick={ this.handleReaderSidebarDiscoverClicked }
+										>
 											<Gridicon icon="my-sites" />
 											<span className="menu-link-text">
 												{ this.props.translate( 'Discover' ) }
@@ -196,7 +255,10 @@ export const ReaderSidebar = createReactClass( {
 										'sidebar-streams__search': true,
 									} ) }
 								>
-									<a href="/read/search">
+									<a
+										href="/read/search"
+										onClick={ this.handleReaderSidebarSearchClicked }
+									>
 										<Gridicon icon="search" size={ 24 } />
 										<span className="menu-link-text">
 											{ this.props.translate( 'Search' ) }
@@ -211,7 +273,10 @@ export const ReaderSidebar = createReactClass( {
 									{ 'sidebar-activity__likes': true },
 								) }
 							>
-								<a href="/activities/likes">
+								<a
+									href="/activities/likes"
+									onClick={ this.handleReaderSidebarLikeActivityClicked }
+								>
 									<Gridicon icon="star" size={ 24 } />
 									<span className="menu-link-text">
 										{ this.props.translate( 'My Likes' ) }

--- a/client/reader/sidebar/reader-sidebar-lists/list-item.jsx
+++ b/client/reader/sidebar/reader-sidebar-lists/list-item.jsx
@@ -11,6 +11,7 @@ import { localize } from 'i18n-calypso';
  * Internal Dependencies
  */
 import ReaderSidebarHelper from '../helper';
+import { recordAction, recordGaEvent, recordTrack } from 'reader/stats';
 
 export class ReaderSidebarListsListItem extends Component {
 	static propTypes = {
@@ -30,6 +31,14 @@ export class ReaderSidebarListsListItem extends Component {
 			node.scrollIntoView();
 		}
 	}
+
+	handleListSidebarClick = () => {
+		recordAction( 'clicked_reader_sidebar_list_item' );
+		recordGaEvent( 'Clicked Reader Sidebar List Item' );
+		recordTrack( 'calypso_reader_sidebar_list_item_clicked', {
+			list: decodeURIComponent( this.props.list.slug ),
+		} );
+	};
 
 	render() {
 		const { list, translate } = this.props;
@@ -60,6 +69,7 @@ export class ReaderSidebarListsListItem extends Component {
 				<a
 					className="sidebar__menu-item-label"
 					href={ listRelativeUrl }
+					onClick={ this.handleListSidebarClick }
 					title={ translate( "View list '%(currentListName)s'", {
 						args: {
 							currentListName: list.title,

--- a/client/reader/sidebar/reader-sidebar-tags/list-item.jsx
+++ b/client/reader/sidebar/reader-sidebar-tags/list-item.jsx
@@ -5,13 +5,13 @@ import React, { Component } from 'react';
 import ReactDom from 'react-dom';
 import { localize } from 'i18n-calypso';
 import { identity } from 'lodash';
-import { recordTrack } from 'reader/stats';
 import Gridicon from 'gridicons';
 
 /**
  * Internal Dependencies
  */
 import ReaderSidebarHelper from '../helper';
+import { recordAction, recordGaEvent, recordTrack } from 'reader/stats';
 
 export class ReaderSidebarTagsListItem extends Component {
 	static propTypes = {
@@ -35,8 +35,10 @@ export class ReaderSidebarTagsListItem extends Component {
 	}
 
 	handleTagSidebarClick = () => {
-		recordTrack( 'calypso_reader_tag_sidebar_click', {
-			slug: this.props.tag.slug,
+		recordAction( 'clicked_reader_sidebar_tag_item' );
+		recordGaEvent( 'Clicked Reader Sidebar Tag Item' );
+		recordTrack( 'calypso_reader_sidebar_tag_item_clicked', {
+			tag: decodeURIComponent( this.props.tag.slug ),
 		} );
 	};
 

--- a/client/reader/sidebar/reader-sidebar-teams/list-item.jsx
+++ b/client/reader/sidebar/reader-sidebar-teams/list-item.jsx
@@ -8,6 +8,15 @@ import { localize } from 'i18n-calypso';
  * Internal Dependencies
  */
 import ReaderSidebarHelper from '../helper';
+import { recordAction, recordGaEvent, recordTrack } from 'reader/stats';
+
+const handleReaderSidebarTeamsListItemClicked = team => () => {
+	recordAction( 'clicked_reader_sidebar_teams_list_item' );
+	recordGaEvent( 'Clicked Reader Sidebar Teams List Item' );
+	recordTrack( 'calypso_reader_sidebar_teams_list_item_clicked', {
+		team: decodeURIComponent( team.slug ),
+	} );
+};
 
 export const ReaderSidebarTeamsListItem = ( { path, team, translate } ) => {
 	const teamUri = '/read/' + encodeURIComponent( team.slug );
@@ -21,6 +30,7 @@ export const ReaderSidebarTeamsListItem = ( { path, team, translate } ) => {
 		>
 			<a
 				href={ teamUri }
+				onClick={ handleReaderSidebarTeamsListItemClicked( team ) }
 				title={ translate( "View team '%(currentTeamName)s'", {
 					args: {
 						currentTeamName: team.title,

--- a/client/reader/stats.js
+++ b/client/reader/stats.js
@@ -98,11 +98,6 @@ export function recordTrack( eventName, eventProperties ) {
 		eventProperties = Object.assign( { subscription_count: subCount }, eventProperties );
 	}
 
-	if ( location === 'topic_page' && ! eventProperties.hasOwnProperty( 'tag' ) ) {
-		const tag = decodeURIComponent( window.location.pathname.split( '/tag/' ).pop() );
-		eventProperties = Object.assign( { tag: tag }, eventProperties );
-	}
-
 	if ( process.env.NODE_ENV !== 'production' ) {
 		if (
 			'blog_id' in eventProperties &&


### PR DESCRIPTION
Adds stats for whenever a user clicks on an item in the Reader sidebar.