### PR TITLE
View Site: Enable sidebar menu in dev and wpcalypso

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -148,7 +148,7 @@
 		"signup/domain-first-flow": true,
 		"signup/social": true,
 		"simple-payments": true,
-		"standalone-site-preview": false,
+		"standalone-site-preview": true,
 		"support-user": true,
 		"sync-handler": true,
 		"ui/first-view": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -112,6 +112,7 @@
 		"settings/theme-setup": true,
 		"signup/domain-first-flow": true,
 		"signup/social": true,
+		"standalone-site-preview": true,
 		"support-user": true,
 		"sync-handler": true,
 		"ui/first-view": true,


### PR DESCRIPTION
This enables "View Site" menu item for development and wpcalypso environments.

Test: 
- boot locally or on calypso.live
- we no longer have "Site Preview" button to open modal
- we have a new regular menu item called "View Site" that opens new Calypso page: `/view/:slug`
- after merging, the feature should be enabled on wpcalypso, but not in stage.

| current menu | new menu | 
| - | - |
| <img width="272" alt="screen shot 2017-07-26 at 15 33 53" src="https://user-images.githubusercontent.com/156676/28624052-25d338ce-7218-11e7-9482-ebe07f33f42f.png"> | <img width="271" alt="screen shot 2017-07-26 at 15 40 21" src="https://user-images.githubusercontent.com/156676/28624242-d677381a-7218-11e7-86c9-da11de2e12b1.png"> |

| current modal preview | new preview |
| - | - |
| <img width="1434" alt="screen shot 2017-07-26 at 15 41 42" src="https://user-images.githubusercontent.com/156676/28624300-07b6cc2e-7219-11e7-92a2-b4c12202cdb1.png"> | <img width="1435" alt="screen shot 2017-07-26 at 15 42 00" src="https://user-images.githubusercontent.com/156676/28624310-0f7378cc-7219-11e7-8968-de1f8e2f9bde.png"> |