### PR TITLE
App Banner: prevent notifications panel from toggling on banner click

### DIFF
--- a/client/blocks/app-banner/index.jsx
+++ b/client/blocks/app-banner/index.jsx
@@ -66,14 +66,22 @@ class AppBanner extends Component {
 		userAgent: ( typeof window !== 'undefined' ) ? navigator.userAgent : '',
 	};
 
-	preventNotificationsClose( appBanner ) {
-		const appBannerNode = ReactDom.findDOMNode( appBanner );
-		if ( ! appBannerNode ) {
+	stopBubblingEvents = ( event ) => {
+		event.stopPropagation();
+	};
+
+	preventNotificationsClose = ( appBanner ) => {
+		if ( ! appBanner ) {
+			this.appBannerNode.removeEventListener( 'mousedown', this.stopBubblingEvents, false );
+			this.appBannerNode.removeEventListener( 'touchstart', this.stopBubblingEvents, false );
 			return;
 		}
-		appBannerNode.addEventListener( 'mousedown', event => event.stopPropagation(), false );
-		appBannerNode.addEventListener( 'touchstart', event => event.stopPropagation(), false );
-	}
+		if ( appBanner ) {
+			this.appBannerNode = ReactDom.findDOMNode( appBanner );
+			this.appBannerNode.addEventListener( 'mousedown', this.stopBubblingEvents, false );
+			this.appBannerNode.addEventListener( 'touchstart', this.stopBubblingEvents, false );
+		}
+	};
 
 	isVisible() {
 		const { dismissedUntil, currentSection } = this.props;

--- a/client/blocks/app-banner/index.jsx
+++ b/client/blocks/app-banner/index.jsx
@@ -71,7 +71,7 @@ class AppBanner extends Component {
 	};
 
 	preventNotificationsClose = ( appBanner ) => {
-		if ( ! appBanner ) {
+		if ( ! appBanner && this.appBannerNode ) {
 			this.appBannerNode.removeEventListener( 'mousedown', this.stopBubblingEvents, false );
 			this.appBannerNode.removeEventListener( 'touchstart', this.stopBubblingEvents, false );
 			return;

--- a/client/blocks/app-banner/index.jsx
+++ b/client/blocks/app-banner/index.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React, { Component, PropTypes } from 'react';
+import ReactDom from 'react-dom';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
@@ -64,6 +65,15 @@ class AppBanner extends Component {
 		recordAppBannerOpen: noop,
 		userAgent: ( typeof window !== 'undefined' ) ? navigator.userAgent : '',
 	};
+
+	preventNotificationsClose( appBanner ) {
+		const appBannerNode = ReactDom.findDOMNode( appBanner );
+		if ( ! appBannerNode ) {
+			return;
+		}
+		appBannerNode.addEventListener( 'mousedown', event => event.stopPropagation(), false );
+		appBannerNode.addEventListener( 'touchstart', event => event.stopPropagation(), false );
+	}
 
 	isVisible() {
 		const { dismissedUntil, currentSection } = this.props;
@@ -140,7 +150,7 @@ class AppBanner extends Component {
 		const { title, copy } = getAppBannerData( translate, currentSection );
 
 		return (
-			<Card className={ classNames( 'app-banner', 'is-compact', currentSection ) }>
+			<Card className={ classNames( 'app-banner', 'is-compact', currentSection ) } ref={ this.preventNotificationsClose }>
 				<TrackComponentView
 					eventName="calypso_mobile_app_banner_impression"
 					eventProperties={ {


### PR DESCRIPTION
Fixes #16768, where clicking on the app banner when notifications were open would close the panel.

### Testing instructions
1. Use your physical Mobile device using this calypso.live branch: https://calypso.live/?branch=fix/app-open-notifications
2. Visit the reader, stats, editor, and notifications
3. Banners should be visible and behave as expected.
4. Open notifications again. Click on any part of the banner should not toggle notifications. Open in app and dismiss banner should work as expected.

In Desktop Chrome:
1. This banner should not be visible on any page in non-mobile browsers.
2. In order to test it, you can open up DevTools in Chrome and use `Toggle device toolbar`. Along making the screen size smaller, this will also change the `userAgent` which we use to test whether the app banner should be shown. Another option would be to select the `userAgent` manually in Chrome DevTools by following option 2 of [this guide](https://www.technipages.com/google-chrome-change-user-agent-string).
3. Verify that app banner is shown on stats, reader, and editor pages. It should also be shown on any page when notification panel is open.
4. Verify that correct text and icons are shown for each page as described in https://github.com/Automattic/wp-calypso/issues/15228.
5. Verify that impression tracks event has been recorded upon banner rendering.
6. Verify that `Open in app` redirects to app store and that appropriate tracks event/stat bump is recorded.
7. Verify that `No thanks` closes the banner and that appropriate tracks event/stat bump is recorded.

**_Note:_** If you've dismissed the widget and want to bring it back for testing in current session, you can run the following line in your console: 
```javascript
dispatch( { type: 'PREFERENCES_SET', key: 'appBannerDismissTimes', value: null } );
```

### Visual changes (stats example):

<img src="https://user-images.githubusercontent.com/1182160/28293508-bdd14fa0-6b54-11e7-94bf-77cec8f282cb.png" width="300px" alt="stats-example" />

### Expected Analytics Events:
You can see this by setting `localStorage.debug = 'calypso:analytics:*'`
<img width="802" alt="screen shot 2017-07-21 at 3 27 14 pm" src="https://user-images.githubusercontent.com/1270189/28484823-912ce25c-6e29-11e7-8842-f4558cb7a879.png">