### PR TITLE
Editor: Add a featured image dropzone above the post title

### DIFF
--- a/client/components/drop-zone/style.scss
+++ b/client/components/drop-zone/style.scss
@@ -65,11 +65,13 @@
 	font-size: 30px;
 }
 
+.editor-drawer-well .drop-zone.editor-featured-image__dropzone {
+	margin: 0;
+}
+
 .drop-zone.editor-featured-image__dropzone {
 	background-color: rgba( $orange-jazzy, 0.7 );
 	border: 6px solid $orange-jazzy;
-
-	margin: 0;
 
 	&.is-dragging-over-element {
 		background-color: rgba( lighten( $orange-jazzy, 20 ), 0.8 );

--- a/client/components/tinymce/index.jsx
+++ b/client/components/tinymce/index.jsx
@@ -522,8 +522,18 @@ module.exports = React.createClass( {
 			'is-visible': mode === 'html'
 		} );
 
+		/*
+		 * Using `classnames()` here is just a hack to avoid the linter complaining that the
+		 * container is named `tinymce-container` instead of `tinymce`. Ideally the containing
+		 * `div` and the `textarea` should be refactored so that the `div` has the `tinymce`
+		 * class, but that would interfere with higher priority fixes. This component is slated
+		 * for some refactoring in the near future, so that will be a more convenient time to
+		 * clean this up.
+		 */
+		const containerClassName = classnames( 'tinymce-container' );
+
 		return (
-			<div>
+			<div className={ containerClassName }>
 				{ 'html' === mode && config.isEnabled( 'post-editor/html-toolbar' ) &&
 					<EditorHtmlToolbar
 						content={ this.refs.text }

--- a/client/post-editor/editor-featured-image/index.jsx
+++ b/client/post-editor/editor-featured-image/index.jsx
@@ -18,6 +18,8 @@ import PostActions from 'lib/posts/actions';
 import PostUtils from 'lib/posts/utils';
 import * as stats from 'lib/posts/stats';
 import EditorFeaturedImagePreviewContainer from './preview-container';
+import FeaturedImageDropZone from 'post-editor/editor-featured-image/dropzone';
+import isDropZoneVisible from 'state/selectors/is-drop-zone-visible';
 import Button from 'components/button';
 import RemoveButton from 'components/remove-button';
 import { getMediaItem } from 'state/selectors';
@@ -29,6 +31,8 @@ import { recordTracksEvent } from 'state/analytics/actions';
 class EditorFeaturedImage extends Component {
 	static propTypes = {
 		featuredImage: PropTypes.object,
+		hasDropZone: PropTypes.bool,
+		isDropZoneVisible: PropTypes.bool,
 		maxWidth: PropTypes.number,
 		site: PropTypes.object,
 		post: PropTypes.object,
@@ -39,8 +43,10 @@ class EditorFeaturedImage extends Component {
 	};
 
 	static defaultProps = {
+		hasDropZone: false,
+		isDropZoneVisible: false,
 		maxWidth: 450,
-		onImageSelected: () => {}
+		onImageSelected: () => {},
 	};
 
 	state = {
@@ -135,7 +141,8 @@ class EditorFeaturedImage extends Component {
 		const { site, post } = this.props;
 		const featuredImageId = getFeaturedImageId( post );
 		const classes = classnames( 'editor-featured-image', {
-			'is-assigned': !! PostUtils.getFeaturedImageId( this.props.post )
+			'is-assigned': PostUtils.getFeaturedImageId( this.props.post ),
+			'has-active-drop-zone': this.props.hasDropZone && this.props.isDropZoneVisible,
 		} );
 
 		return (
@@ -157,8 +164,10 @@ class EditorFeaturedImage extends Component {
 							icon="pencil"
 							className="editor-featured-image__edit-icon" />
 					</Button>
-					{ featuredImageId ? <RemoveButton onRemove={ EditorFeaturedImage.removeImage } /> : '' }
+					{ featuredImageId && <RemoveButton onRemove={ EditorFeaturedImage.removeImage } /> }
 				</div>
+
+				{ this.props.hasDropZone && <FeaturedImageDropZone /> }
 			</div>
 		);
 	}
@@ -172,6 +181,7 @@ export default connect(
 
 		return {
 			featuredImage: getMediaItem( state, siteId, featuredImageId ),
+			isDropZoneVisible: isDropZoneVisible( state, 'featuredImage' ),
 		};
 	},
 	{

--- a/client/post-editor/editor-featured-image/style.scss
+++ b/client/post-editor/editor-featured-image/style.scss
@@ -2,7 +2,18 @@
 	width: 100%;
 	padding: 0 0 7px 0;
 	text-align: center;
-	line-height: 0;
+}
+
+.editor-featured-image.has-active-drop-zone {
+	display: block;
+	position: relative;
+	min-height: 115px;
+	padding: 15px 0 20px;
+}
+
+.editor-featured-image__dropzone {
+	margin-top: 0;
+	margin-bottom: 0;
 }
 
 .editor-featured-image__current-image {

--- a/client/post-editor/editor-html-toolbar/index.jsx
+++ b/client/post-editor/editor-html-toolbar/index.jsx
@@ -684,6 +684,7 @@ export class EditorHtmlToolbar extends Component {
 				<MediaLibraryDropZone
 					onAddMedia={ this.onFilesDrop }
 					site={ site }
+					fullScreen={ false }
 				/>
 
 				<SimplePaymentsDialog

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -387,7 +387,8 @@ export const PostEditor = React.createClass( {
 								<FeaturedImage
 									site={ site }
 									post={ this.state.post }
-									maxWidth={ 1462 } />
+									maxWidth={ 1462 }
+									hasDropZone={ true } />
 								<div className="post-editor__header">
 									<EditorTitle
 										onChange={ this.onEditorTitleChange }

--- a/client/post-editor/style.scss
+++ b/client/post-editor/style.scss
@@ -133,6 +133,21 @@
 	}
 }
 
+/*
+ * Constrain the `MediaLibraryDropZone` to the editor content area, instead of taking up the entire
+ * screen. This allows room for the `FeaturedImageDropZone`.
+ *
+ * It's only done while an image is actively being dragged, because it interferes with TinyMCE
+ * toolbar pinning/unpinning.
+ */
+.post-editor__content-editor .editor-featured-image.has-active-drop-zone ~ div.tinymce-container {
+	position: relative;
+}
+
+.post-editor .tinymce-container .drop-zone.is-active {
+	top: 80px; /* Move it below the TinyMCE toolbar, because it looks bad when they overlap */
+}
+
 .post-editor .tinymce {
 	min-height: 100vh;
 	resize: none;


### PR DESCRIPTION
The old editor had the ability to drop a featured image above the post title, but that's missing from the current editor. This PR restores that ability.

In order to do that, the existing `MediaLibraryDropZone` has to be adjusted to allow room for the new `FeaturedImageDropZone`.

This currently works, but `dropZoneIsActive` is currently hardcoded, because I'm not sure what the best way to determine it would be. The overall approach may also need some refinement, or a change in direction.

Also, the adjustments made to the `MediaLibraryDropZone` introduce two unintended consequences that may need to be fixed before this is ready for merge:

1. It's now more likely that a user will drop a file into an area outside a dropzone, since we no longer have a large zone covering almost the entire screen. If they do this, then the browser will open the file as a new page in the history, taking them away from Calypso.
1. The TinyMCE toolbar pinning/unpinning breaks when the dropzones are active. It's unlikely the user will try to scroll while dragging-dropping a file, but it's worth noting regardless.

See #13277