### PR TITLE
Simple payments: enable on wpcalypso

### DIFF
--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -112,6 +112,7 @@
 		"settings/theme-setup": true,
 		"signup/domain-first-flow": true,
 		"signup/social": true,
+		"simple-payments": true,
 		"standalone-site-preview": true,
 		"support-user": true,
 		"sync-handler": true,


### PR DESCRIPTION
This enables simple payments feature on wpcalypso env to make call4testing

## How to test

No way