### PR TITLE
PlanStorageBar: Rename duplicate nested class

### DIFF
--- a/client/blocks/plan-storage/README.md
+++ b/client/blocks/plan-storage/README.md
@@ -23,7 +23,7 @@ media storage limits are fetched.
 #### Usage:
 
 ```javascript
-import PlanStorageButton from 'blocks/plan-storage/bar';
+import PlanStorageBar from 'blocks/plan-storage/bar';
 import QueryMediaStorage from 'components/data/query-media-storage';
 import { getMediaStorage } from 'state/sites/media-storage/selectors';
 

--- a/client/blocks/plan-storage/bar.jsx
+++ b/client/blocks/plan-storage/bar.jsx
@@ -58,7 +58,7 @@ class PlanStorageBar extends Component {
 		return (
 			<div className={ classes }>
 				<ProgressBar
-					className="plan-storage__bar"
+					className="plan-storage__storage-bar"
 					value={ percent }
 					total={ 100 }
 					compact={ true } />

--- a/client/blocks/plan-storage/bar.jsx
+++ b/client/blocks/plan-storage/bar.jsx
@@ -58,7 +58,6 @@ class PlanStorageBar extends Component {
 		return (
 			<div className={ classes }>
 				<ProgressBar
-					className="plan-storage__storage-bar"
 					value={ percent }
 					total={ 100 }
 					compact={ true } />


### PR DESCRIPTION
This PR renames a duplicated class used in PlanStorageBar. The parent class appears to be the relevant one and is left alone. The child is renamed, but appears to be unused for styling in the current codebase.

Duplicate nested classes make it unnecessarily difficult to correctly target the desired element for styling. This change renames the child class `.plan-storage__bar > .plan-storage__bar` to
`.plan-storage__bar > .plan-storage__storage-bar`, similar to its siblings.

Also fixes a component typo in the README

I ran into this issue when working on #16806.

## Testing
1. Visit https://calypso.live/media/?branch=fix/planstoragebar-duplicate-classname for a Simple site on a free plan
1. Ensure that the storage bar remains unchanged.
1. This appears to be the only `PlanStorage` or `PlanStorageBar` usage in the codebase.
1. Verify there are no unknown uses of this class. `ack plan-storage__bar client assets` reports:
   ```
   client/blocks/plan-storage/bar.jsx
   51:             const classes = classNames( className, 'plan-storage__bar', {

   client/blocks/plan-storage/style.scss
   5:.plan-storage__bar {
   31:.plan-storage__bar .progress-bar__progress {
   35:.plan-storage__bar.is-warn .progress-bar__progress {
   39:.plan-storage__bar.is-alert .progress-bar__progress {
   ```

## Screens

### Before

![before-0](https://user-images.githubusercontent.com/841763/28869336-a822e748-777c-11e7-9a97-ee5977af28e4.png)
![before-31](https://user-images.githubusercontent.com/841763/28869338-a82651c6-777c-11e7-864a-cc53502b7f5e.png)
![before-62](https://user-images.githubusercontent.com/841763/28869339-a82bf1b2-777c-11e7-8645-a355b1710baa.png)
![before-93](https://user-images.githubusercontent.com/841763/28869340-a831cfc4-777c-11e7-8e3b-259f6207d513.png)

### After

![after-0](https://user-images.githubusercontent.com/841763/28869222-4a667f2a-777c-11e7-8414-4e2a127868ab.png)
![after-31](https://user-images.githubusercontent.com/841763/28869221-4a437dae-777c-11e7-9347-7c4267ace6ac.png)
![after-61](https://user-images.githubusercontent.com/841763/28869220-4a3d32a0-777c-11e7-8e9d-3fee39f4cc7f.png)
![after-93](https://user-images.githubusercontent.com/841763/28869219-4a342b42-777c-11e7-8dfb-72a6d5ca89d1.png)
