### PR TITLE
Sibyl: add question click tracking

### DIFF
--- a/client/me/help/help-contact-form/index.jsx
+++ b/client/me/help/help-contact-form/index.jsx
@@ -28,11 +28,21 @@ import { selectSiteId } from 'state/help/actions';
 import { getHelpSelectedSite } from 'state/help/selectors';
 import wpcomLib from 'lib/wp';
 import HelpResults from 'me/help/help-results';
+import {
+	bumpStat,
+	recordTracksEvent,
+	composeAnalytics,
+} from 'state/analytics/actions';
 
 /**
  * Module variables
  */
 const wpcom = wpcomLib.undocumented();
+
+const trackSibylClick = ( event, helpLink ) => composeAnalytics(
+	bumpStat( 'sibyl_question_clicks', helpLink.id ),
+	recordTracksEvent( 'calypso_sibyl_question_click', {} )
+);
 
 export const HelpContactForm = React.createClass( {
 	mixins: [ LinkedStateMixin, PureRenderMixin ],
@@ -206,19 +216,6 @@ export const HelpContactForm = React.createClass( {
 	},
 
 	/**
-	 * Tracks clicks on the questions returned by Sibyl.
-	 * @param {object} event Click event
-	 * @param {object} helpLink Help link, including id for tracking
-	 */
-	trackSibylClick( event, helpLink ) {
-		// bump the clicks stat for the question in MC
-		analytics.mc.bumpStat( 'sibyl_question_clicks', helpLink.id );
-		// track that the user clicked the question, so we can see how
-		// effective questions are at preventing unnessecary chat sessions
-		analytics.tracks.recordEvent( 'calypso_sibyl_question_click' );
-	},
-
-	/**
 	 * Render the contact form
 	 * @return {object} ReactJS JSX object
 	 */
@@ -305,7 +302,7 @@ export const HelpContactForm = React.createClass( {
 					header={ translate( 'Do you want the answer to any of these questions?' ) }
 					helpLinks={ this.state.qanda }
 					iconTypeDescription="book"
-					onClick={ this.trackSibylClick }
+					onClick={ this.props.trackSibylClick }
 				/>
 
 				<FormButton disabled={ ! this.canSubmitForm() } type="button" onClick={ this.submitForm }>{ buttonLabel }</FormButton>
@@ -319,7 +316,8 @@ const mapStateToProps = ( state ) => ( {
 } );
 
 const mapDispatchToProps = {
-	onChangeSite: selectSiteId
+	onChangeSite: selectSiteId,
+	trackSibylClick
 };
 
 export default connect( mapStateToProps, mapDispatchToProps )( localize( HelpContactForm ) );

--- a/client/me/help/help-contact-form/index.jsx
+++ b/client/me/help/help-contact-form/index.jsx
@@ -211,7 +211,11 @@ export const HelpContactForm = React.createClass( {
 	 * @param {object} helpLink Help link, including id for tracking
 	 */
 	trackSibylClick( event, helpLink ) {
+		// bump the clicks stat for the question in MC
 		analytics.mc.bumpStat( 'sibyl_question_clicks', helpLink.id );
+		// track that the user clicked the question, so we can see how
+		// effective questions are at preventing unnessecary chat sessions
+		analytics.tracks.recordEvent( 'calypso_sibyl_question_click' );
 	},
 
 	/**

--- a/client/me/help/help-contact-form/index.jsx
+++ b/client/me/help/help-contact-form/index.jsx
@@ -206,6 +206,15 @@ export const HelpContactForm = React.createClass( {
 	},
 
 	/**
+	 * Tracks clicks on the questions returned by Sibyl.
+	 * @param {object} event Click event
+	 * @param {object} helpLink Help link, including id for tracking
+	 */
+	trackSibylClick( event, helpLink ) {
+		analytics.mc.bumpStat( 'sibyl_question_clicks', helpLink.id );
+	},
+
+	/**
 	 * Render the contact form
 	 * @return {object} ReactJS JSX object
 	 */
@@ -292,6 +301,7 @@ export const HelpContactForm = React.createClass( {
 					header={ translate( 'Do you want the answer to any of these questions?' ) }
 					helpLinks={ this.state.qanda }
 					iconTypeDescription="book"
+					onClick={ this.trackSibylClick }
 				/>
 
 				<FormButton disabled={ ! this.canSubmitForm() } type="button" onClick={ this.submitForm }>{ buttonLabel }</FormButton>

--- a/client/me/help/help-contact-form/index.jsx
+++ b/client/me/help/help-contact-form/index.jsx
@@ -41,7 +41,9 @@ const wpcom = wpcomLib.undocumented();
 
 const trackSibylClick = ( event, helpLink ) => composeAnalytics(
 	bumpStat( 'sibyl_question_clicks', helpLink.id ),
-	recordTracksEvent( 'calypso_sibyl_question_click', {} )
+	recordTracksEvent( 'calypso_sibyl_question_click', {
+		question_id: helpLink.id
+	} )
 );
 
 export const HelpContactForm = React.createClass( {

--- a/client/me/help/help-results/index.jsx
+++ b/client/me/help/help-results/index.jsx
@@ -16,21 +16,6 @@ module.exports = React.createClass( {
 
 	mixins: [ PureRenderMixin ],
 
-	/**
-	 * Creates an onClick handler that has access to the helpLink.
-	 *
-	 * This is so we can use any additional data returned in the helpLink
-	 * for tracking purposes.
-	 * @param {function} onClick onClick handler
-	 * @param {object} helpLink Help link data
-	 * @return {function} Function that takes an event, and help link data
-	 */
-	createOnClick: function( onClick, helpLink ) {
-		return function( event ) {
-			return onClick( event, helpLink );
-		};
-	},
-
 	render: function() {
 		if ( ! this.props.helpLinks.length ) {
 			return null;
@@ -42,7 +27,7 @@ module.exports = React.createClass( {
 				{ this.props.helpLinks.map( helpLink =>
 					<HelpResult
 						key={ helpLink.link } helpLink={ helpLink } iconTypeDescription={ this.props.iconTypeDescription }
-						onClick={ this.props.onClick ? this.createOnClick( this.props.onClick, helpLink ) : undefined } /> )
+						onClick={ this.props.onClick } /> )
 				}
 				<a href={ this.props.searchLink } target="__blank">
 					<CompactCard className="help-results__footer">

--- a/client/me/help/help-results/index.jsx
+++ b/client/me/help/help-results/index.jsx
@@ -16,6 +16,21 @@ module.exports = React.createClass( {
 
 	mixins: [ PureRenderMixin ],
 
+	/**
+	 * Creates an onClick handler that has access to the helpLink.
+	 *
+	 * This is so we can use any additional data returned in the helpLink
+	 * for tracking purposes.
+	 * @param {function} onClick onClick handler
+	 * @param {object} helpLink Help link data
+	 * @return {function} Function that takes an event, and help link data
+	 */
+	createOnClick: function( onClick, helpLink ) {
+		return function( event ) {
+			return onClick( event, helpLink );
+		};
+	},
+
 	render: function() {
 		if ( ! this.props.helpLinks.length ) {
 			return null;
@@ -24,7 +39,11 @@ module.exports = React.createClass( {
 		return (
 			<div className="help-results">
 				<SectionHeader label={ this.props.header }/>
-				{ this.props.helpLinks.map( helpLink => <HelpResult key={ helpLink.link } helpLink={ helpLink } iconTypeDescription={ this.props.iconTypeDescription } /> ) }
+				{ this.props.helpLinks.map( helpLink =>
+					<HelpResult
+						key={ helpLink.link } helpLink={ helpLink } iconTypeDescription={ this.props.iconTypeDescription }
+						onClick={ this.props.onClick ? this.createOnClick( this.props.onClick, helpLink ) : undefined } /> )
+				}
 				<a href={ this.props.searchLink } target="__blank">
 					<CompactCard className="help-results__footer">
 						<span className="help-results__footer-text">

--- a/client/me/help/help-results/item.jsx
+++ b/client/me/help/help-results/item.jsx
@@ -21,7 +21,7 @@ module.exports = React.createClass( {
 			return event.preventDefault();
 		}
 
-		this.props.onClick && this.props.onClick( event );
+		this.props.onClick && this.props.onClick( event, this.props.helpLink );
 	},
 
 	getResultIcon: function() {


### PR DESCRIPTION
Sibyl returns a question identifier in its results, used to
track which questions are getting clicks.

This change adds onClick support to HelpResults, which passes
the helpLink object to the onClick handler, so that it's easy
to track things.