### PR TITLE
Simple Payments: Show the product image in the product list

### DIFF
--- a/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
@@ -370,6 +370,7 @@ class SimplePaymentsDialog extends Component {
 							showError={ this.showError }
 						/>
 					: <ProductList
+							siteId={ siteId }
 							paymentButtons={ paymentButtons }
 							selectedPaymentId={ this.state.selectedPaymentId }
 							onSelectedChange={ this.handleSelectedChange }

--- a/client/components/tinymce/plugins/simple-payments/dialog/list-item.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/list-item.jsx
@@ -15,6 +15,7 @@ import CompactCard from 'components/card/compact';
 import EllipsisMenu from 'components/ellipsis-menu';
 import FormRadio from 'components/forms/form-radio';
 import PopoverMenuItem from 'components/popover/menu-item';
+import ProductImage from './product-image';
 
 class ProductListItem extends Component {
 	static propTypes = {
@@ -34,7 +35,16 @@ class ProductListItem extends Component {
 	handleTrashClick = () => this.props.onTrashClick( this.props.paymentId );
 
 	render() {
-		const { paymentId, title, price, currency, isSelected, translate } = this.props;
+		const {
+			siteId,
+			paymentId,
+			title,
+			price,
+			currency,
+			featuredImageId,
+			isSelected,
+			translate,
+		} = this.props;
 		const radioId = `simple-payments-list-item-radio-${ paymentId }`;
 
 		return (
@@ -54,6 +64,7 @@ class ProductListItem extends Component {
 						{ formatCurrency( price, currency ) }
 					</div>
 				</label>
+				<ProductImage siteId={ siteId } imageId={ featuredImageId } />
 				<EllipsisMenu
 					className="editor-simple-payments-modal__list-menu"
 					popoverClassName="is-dialog-visible"

--- a/client/components/tinymce/plugins/simple-payments/dialog/list.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/list.jsx
@@ -14,6 +14,7 @@ import ProductListItemPlaceholder from './list-item-placeholder';
 
 class ProductList extends Component {
 	static propTypes = {
+		siteId: PropTypes.number.isRequired,
 		paymentButtons: PropTypes.array,
 		selectedPaymentId: PropTypes.number,
 		onSelectedChange: PropTypes.func,
@@ -30,6 +31,7 @@ class ProductList extends Component {
 
 	renderListItems() {
 		const {
+			siteId,
 			paymentButtons,
 			selectedPaymentId,
 			onSelectedChange,
@@ -42,14 +44,16 @@ class ProductList extends Component {
 			return range( 2 ).map( i => <ProductListItemPlaceholder key={ i } /> );
 		}
 
-		return paymentButtons.map( ( { ID: paymentId, title, price, currency } ) =>
+		return paymentButtons.map( ( { ID: paymentId, title, price, currency, featuredImageId } ) =>
 			<ProductListItem
 				key={ paymentId }
+				siteId={ siteId }
 				paymentId={ paymentId }
 				isSelected={ selectedPaymentId === paymentId }
 				title={ title }
 				price={ price }
 				currency={ currency }
+				featuredImageId={ featuredImageId }
 				onSelectedChange={ onSelectedChange }
 				onEditClick={ onEditClick }
 				onTrashClick={ onTrashClick }

--- a/client/components/tinymce/plugins/simple-payments/dialog/product-image.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/product-image.jsx
@@ -1,0 +1,40 @@
+/* eslint-disable wpcalypso/jsx-classname-namespace */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import MediaUtils from 'lib/media/utils';
+import QueryMedia from 'components/data/query-media';
+import { getMediaItem } from 'state/selectors';
+
+const ProductImage = ( { siteId, imageId, image } ) => {
+	if ( ! siteId || ! imageId ) {
+		return null;
+	}
+
+	if ( ! image ) {
+		return (
+			<figure className="editor-simple-payments-modal__list-figure is-placeholder">
+				<QueryMedia siteId={ siteId } mediaId={ imageId } />
+			</figure>
+		);
+	}
+
+	const url = MediaUtils.url( image, { size: 'medium' } );
+
+	return (
+		<figure className="editor-simple-payments-modal__figure">
+			<img className="editor-simple-payments-modal__image" src={ url } />
+		</figure>
+	);
+};
+
+export default connect( ( state, { siteId, imageId } ) => ( {
+	image: imageId ? getMediaItem( state, siteId, imageId ) : null,
+} ) )( ProductImage );

--- a/client/components/tinymce/plugins/simple-payments/dialog/product-image.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/product-image.jsx
@@ -20,7 +20,7 @@ const ProductImage = ( { siteId, imageId, image } ) => {
 
 	if ( ! image ) {
 		return (
-			<figure className="editor-simple-payments-modal__list-figure is-placeholder">
+			<figure className="editor-simple-payments-modal__figure is-placeholder">
 				<QueryMedia siteId={ siteId } mediaId={ imageId } />
 			</figure>
 		);

--- a/client/components/tinymce/plugins/simple-payments/style.scss
+++ b/client/components/tinymce/plugins/simple-payments/style.scss
@@ -35,7 +35,6 @@
 		display: flex;
 		flex-direction: column;
 		flex: auto;
-		padding: 0;
 		min-height: 0; // permits the to shrink below its min height and scroll
 		padding: 0;
 	}
@@ -115,6 +114,13 @@
 		margin-right: 24px;
 	}
 
+	.editor-simple-payments-modal__figure {
+		flex: none;
+		margin-left: 16px;
+		height: 40px;
+		width: 40px;
+	}
+
 	&.is-placeholder {
 		padding-left: 64px; // 2*24px of padding + 16px of radio width
 		padding-right: 72px; // 2*24px of padding + 24px gridicon width
@@ -134,4 +140,20 @@
 .editor-simple-payments-modal__list-menu {
 	flex: none;
 	margin-left: 16px;
+}
+
+.editor-simple-payments-modal__figure {
+	display: flex;
+	align-items: center;
+	border: 1px solid lighten( $gray, 10% );
+	background-color: lighten( $gray, 30% );
+
+	&.is-placeholder {
+		@include placeholder();
+	}
+}
+
+.editor-simple-payments-modal__image {
+	max-width: 100%;
+	max-height: 100%;
 }


### PR DESCRIPTION
Added a new `ProductImage` component that takes the ID of the image in the media library,
retrieved the media info about the image and displays its resized version (`medium` size).
A placeholder is displayed until the image is loaded.

This component is used to display the product image in the product list:
<img width="777" alt="list-image" src="https://user-images.githubusercontent.com/664258/28872565-0d853354-778a-11e7-9842-1aa76831ddcb.png">

The image in the list has a fixed 40x40px size.