### PR TITLE
Purchases: Make empty billing details editable

### DIFF
--- a/client/me/billing-history/receipt.jsx
+++ b/client/me/billing-history/receipt.jsx
@@ -103,6 +103,17 @@ const BillingReceipt = React.createClass( {
 		);
 	},
 
+	renderEmptyBillingDetails() {
+		const { translate } = this.props;
+
+		return (
+			<li className="billing-history__billing-details">
+				<strong>{ translate( 'Billing Details' ) }</strong>
+				<div contentEditable="true"></div>
+			</li>
+		);
+	},
+
 	renderLineItems() {
 		const { transaction, translate } = this.props;
 		const items = transaction.items.map( ( item ) => {
@@ -185,7 +196,11 @@ const BillingReceipt = React.createClass( {
 						</li>
 						{ this.ref() }
 						{ this.paymentMethod() }
-						{ transaction.cc_num !== 'XXXX' ? this.renderBillingDetails() : null }
+						{
+							transaction.cc_num !== 'XXXX'
+								? this.renderBillingDetails()
+								: this.renderEmptyBillingDetails()
+						}
 					</ul>
 					{ this.renderLineItems() }
 				</Card>


### PR DESCRIPTION
This PR fixes the case where users can't edit their billing details in the printable receipt page if there is a different payment method. It suggests that we display an empty editable section in that case:

![](https://cldup.com/8EGiyrJigp.png)

To test:
* Go to `/me/purchases/billing/`
* Pick a purchase that you've paid for by PayPal.
* Click "View Receipt" on that purchase.
* Verify the Billing Details section appears, and it allows the user to edit it.