### PR TITLE
Comments: Prevent fetching the comment from the server on undo change status

### DIFF
--- a/client/blocks/comment-detail/index.jsx
+++ b/client/blocks/comment-detail/index.jsx
@@ -61,7 +61,7 @@ export class CommentDetail extends Component {
 		isLoading: PropTypes.bool,
 		postAuthorDisplayName: PropTypes.string,
 		postTitle: PropTypes.string,
-		preventServerRequest: PropTypes.bool,
+		refreshCommentData: PropTypes.bool,
 		repliedToComment: PropTypes.bool,
 		replyComment: PropTypes.func,
 		setCommentStatus: PropTypes.func,
@@ -74,7 +74,7 @@ export class CommentDetail extends Component {
 		commentIsSelected: false,
 		isBulkEdit: false,
 		isLoading: true,
-		preventServerRequest: false,
+		refreshCommentData: false,
 	};
 
 	state = {
@@ -203,7 +203,7 @@ export class CommentDetail extends Component {
 			postAuthorDisplayName,
 			postId,
 			postTitle,
-			preventServerRequest,
+			refreshCommentData,
 			repliedToComment,
 			replyComment,
 			siteId,
@@ -236,7 +236,7 @@ export class CommentDetail extends Component {
 				className={ classes }
 				tabIndex="0"
 			>
-				{ ! preventServerRequest &&
+				{ refreshCommentData &&
 					<QueryComment commentId={ commentId } siteId={ siteId } />
 				}
 

--- a/client/blocks/comment-detail/index.jsx
+++ b/client/blocks/comment-detail/index.jsx
@@ -61,6 +61,7 @@ export class CommentDetail extends Component {
 		isLoading: PropTypes.bool,
 		postAuthorDisplayName: PropTypes.string,
 		postTitle: PropTypes.string,
+		preventServerRequest: PropTypes.bool,
 		repliedToComment: PropTypes.bool,
 		replyComment: PropTypes.func,
 		setCommentStatus: PropTypes.func,
@@ -73,6 +74,7 @@ export class CommentDetail extends Component {
 		commentIsSelected: false,
 		isBulkEdit: false,
 		isLoading: true,
+		preventServerRequest: false,
 	};
 
 	state = {
@@ -201,6 +203,7 @@ export class CommentDetail extends Component {
 			postAuthorDisplayName,
 			postId,
 			postTitle,
+			preventServerRequest,
 			repliedToComment,
 			replyComment,
 			siteId,
@@ -233,7 +236,9 @@ export class CommentDetail extends Component {
 				className={ classes }
 				tabIndex="0"
 			>
-				<QueryComment commentId={ commentId } siteId={ siteId } />
+				{ ! preventServerRequest &&
+					<QueryComment commentId={ commentId } siteId={ siteId } />
+				}
 
 				<CommentDetailHeader
 					authorAvatarUrl={ authorAvatarUrl }

--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -46,6 +46,7 @@ export class CommentList extends Component {
 
 	state = {
 		isBulkEdit: false,
+		lastUndo: null,
 		page: 1,
 		persistedComments: [],
 		// TODO: replace {} with [] after persistedComments is merged
@@ -55,6 +56,7 @@ export class CommentList extends Component {
 	componentWillReceiveProps( nextProps ) {
 		if ( this.props.status !== nextProps.status ) {
 			this.setState( {
+				lastUndo: null,
 				page: 1,
 				persistedComments: [],
 				selectedComments: {},
@@ -96,6 +98,8 @@ export class CommentList extends Component {
 			all: [ translate( 'No comments yet.' ), defaultLine ],
 		}, status, [ '', '' ] );
 	}
+
+	hasCommentJustMovedBackToCurrentStatus = commentId => this.state.lastUndo === commentId;
 
 	isCommentPersisted = commentId => -1 !== this.state.persistedComments.indexOf( commentId );
 
@@ -156,6 +160,12 @@ export class CommentList extends Component {
 	setCommentStatus = ( comment, status, options = { isUndo: false, doPersist: false, showNotice: true } ) => {
 		const { commentId, postId } = comment;
 		const { isUndo, doPersist, showNotice } = options;
+
+		if ( isUndo ) {
+			this.setState( { lastUndo: commentId } );
+		} else {
+			this.setState( { lastUndo: null } );
+		}
 
 		if ( doPersist ) {
 			this.updatePersistedComments( commentId, isUndo );
@@ -359,6 +369,7 @@ export class CommentList extends Component {
 							isBulkEdit={ isBulkEdit }
 							commentIsSelected={ this.isCommentSelected( commentId ) }
 							key={ `comment-${ siteId }-${ commentId }` }
+							preventServerRequest={ this.hasCommentJustMovedBackToCurrentStatus( commentId ) }
 							replyComment={ this.replyComment }
 							setCommentStatus={ this.setCommentStatus }
 							siteId={ siteId }

--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -46,6 +46,7 @@ export class CommentList extends Component {
 
 	state = {
 		isBulkEdit: false,
+		// TODO: replace with [] when adding back Bulk Actions
 		lastUndo: null,
 		page: 1,
 		persistedComments: [],
@@ -369,7 +370,7 @@ export class CommentList extends Component {
 							isBulkEdit={ isBulkEdit }
 							commentIsSelected={ this.isCommentSelected( commentId ) }
 							key={ `comment-${ siteId }-${ commentId }` }
-							preventServerRequest={ this.hasCommentJustMovedBackToCurrentStatus( commentId ) }
+							refreshCommentData={ ! this.hasCommentJustMovedBackToCurrentStatus( commentId ) }
 							replyComment={ this.replyComment }
 							setCommentStatus={ this.setCommentStatus }
 							siteId={ siteId }


### PR DESCRIPTION
Fixes a race condition occurring in Comment Management, with comments disappearing when undoing an action.

## Issue

- Open a list of comments, such as `comments/approved/{ siteSlug }`.

- Perform an action that doesn't persist the comment in the list. Currently only toggling between `approved` and `unapproved` persists; so both `spam` and `trash` are valid status changes for this issue. Let's say we mark the comment as `spam`.

- Redux immediately updates the comment status in the state from `approved` to `spam`.
The **comment disappears** from the `approved` list
An API call to make the change permanent is dispatched.

- Click "Undo" on the notice.

- Redux immediately updates the comment status in the state back to its original value (from `spam` to `approved`.
The **comment reappears** in the `approved` list.
An API call to make the change permanent is dispatched.

- Meanwhile, the first API call is complete and the comment status is now officially `spam` in the DB.

- As soon as the comment reappears, its `QueryComment` fires `requestComment` that fetches a fresh copy of the comment.

- Since the undo API call has not been fired yet, `requestComments` returns a comment with status `spam`.
Therefore the **comment disappears again** from the `approved` list.

- At some point, the second API call completes, and the comment status is, correctly, `approved` in the DB.

- No one intercepts this new change, until we fetch the comment list from scratch (e.g. when changing status filter).

## Fix

Introduce a new `lastUndo` property to the `CommentList` internal state.
It keeps track of the ID of the last comment involved in an undo action.

When rendering the list of `CommentDetail`, if the comment is `lastUndo` or, in other words, it `hasJustMovedBackToCurrentStatus`, we enable a new `CommentDetail` prop: `preventServerRequest` which, self explanatorily, simply doesn't render its `QueryComponent`, effectively blocking the network request.

## Future

The work on the data layer freshness should really help this, but until then, this looks like an effective way to prevent unwanted and unexpected comment disappearances.

cc @Automattic/lannister 