### PR TITLE
Simple Payments: Convert the `multiple` value to boolean when working with API responses

### DIFF
--- a/client/components/tinymce/plugins/wpcom-view/views/simple-payments/index.jsx
+++ b/client/components/tinymce/plugins/wpcom-view/views/simple-payments/index.jsx
@@ -31,10 +31,6 @@ class SimplePaymentsView extends Component {
 		const { productImage } = this.props;
 		const { title, description, price, currency, multiple, featuredImageId: productImageId } = product;
 
-		// TODO: product.multiple should be normalized to a boolean value
-		// see https://github.com/Automattic/wp-calypso/pull/16772#discussion_r130579768
-		const multipleIsEnabled = multiple === '1';
-
 		return (
 			<div className="wpview-content wpview-type-simple-payments">
 				{ productImageId && <QueryMedia siteId={ siteId } mediaId={ productImageId } /> }
@@ -60,7 +56,7 @@ class SimplePaymentsView extends Component {
 							{ formatCurrency( price, currency ) }
 						</div>
 						<div className="wpview-type-simple-payments__pay-part">
-							{ multipleIsEnabled &&
+							{ multiple &&
 							<div className="wpview-type-simple-payments__pay-quantity">
 								<input
 									className="wpview-type-simple-payments__pay-quantity-input"

--- a/client/state/data-layer/wpcom/sites/simple-payments/index.js
+++ b/client/state/data-layer/wpcom/sites/simple-payments/index.js
@@ -43,6 +43,7 @@ function customPostMetadataToProductAttributes( metadata ) {
 
 		// If the property's type is marked as boolean in the schema,
 		// convert the value from PHP-ish truthy/falsy numbers to a plain boolean.
+		// Strings "0" and "" are converted to false, "1" is converted to true.
 		if ( metadataSchema[ schemaKey ].type === 'boolean' ) {
 			value = !! Number( value );
 		}
@@ -89,12 +90,16 @@ export function productToCustomPost( product ) {
 
 	// Convert the `product` entries into a metadata array
 	const metadata = metadataEntries.map( ( [ key, value ] ) => {
-		if ( typeof value === 'boolean' ) {
+		const entrySchema = metadataSchema[ key ];
+
+		// If the property's type is marked as boolean in the schema,
+		// convert the value to PHP-ish truthy/falsy numbers.
+		if ( entrySchema.type === 'boolean' ) {
 			value = value ? 1 : 0;
 		}
 
 		return {
-			key: metadataSchema[ key ].metaKey,
+			key: entrySchema.metaKey,
 			value,
 		};
 	} );

--- a/client/state/data-layer/wpcom/sites/simple-payments/test/index.js
+++ b/client/state/data-layer/wpcom/sites/simple-payments/test/index.js
@@ -1,0 +1,69 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { customPostToProduct, productToCustomPost } from '../';
+
+describe( '#simplePayments', () => {
+	it( 'should convert customPost to product', () => {
+		const customPost = {
+			type: 'jp_pay_product',
+			ID: 1,
+			title: 'The Button',
+			content: 'A very nice button for sale',
+			featured_image: 2,
+			metadata: [
+				{ key: 'spay_price', value: 100 },
+				{ key: 'spay_currency', value: 'EUR' },
+				{ key: 'spay_multiple', value: '0' },
+				{ key: 'spay_bogus', value: 'ignore' },
+			],
+		};
+
+		const product = {
+			ID: 1,
+			title: 'The Button',
+			description: 'A very nice button for sale',
+			featuredImageId: 2,
+			price: 100,
+			currency: 'EUR',
+			multiple: false,
+		};
+
+		const convertedProduct = customPostToProduct( customPost );
+		expect( convertedProduct ).to.deep.equal( product );
+	} );
+
+	it( 'should convert product to customPost', () => {
+		const product = {
+			ID: 1,
+			title: 'The Button',
+			description: 'A very nice button for sale',
+			featuredImageId: 2,
+			price: 100,
+			currency: 'USD',
+			multiple: true,
+		};
+
+		const customPost = {
+			type: 'jp_pay_product',
+			title: 'The Button',
+			content: 'A very nice button for sale',
+			featured_image: 2,
+			metadata: [
+				{ key: 'spay_price', value: 100 },
+				{ key: 'spay_currency', value: 'USD' },
+				{ key: 'spay_multiple', value: 1 },
+				{ key: 'spay_formatted_price', value: '$100.00' },
+			],
+		};
+
+		const convertedCustomPost = productToCustomPost( product );
+		expect( convertedCustomPost ).to.deep.equal( customPost );
+	} );
+} );

--- a/client/state/simple-payments/product-list/schema.js
+++ b/client/state/simple-payments/product-list/schema.js
@@ -4,7 +4,7 @@
 export const metadataSchema = {
 	currency: { type: 'string', metaKey: 'spay_currency' },
 	price: { type: 'string', metaKey: 'spay_price' },
-	multiple: { type: 'number', metaKey: 'spay_multiple' },
+	multiple: { type: 'boolean', metaKey: 'spay_multiple' },
 	status: { type: 'number', metaKey: 'spay_status' },
 	email: { type: 'string', metaKey: 'spay_email' },
 	formatted_price: { type: 'string', metaKey: 'spay_formatted_price' },


### PR DESCRIPTION
Fixes the issue discussed in https://github.com/Automattic/wp-calypso/pull/16772#discussion_r130579768 where `multiple` is not a simple boolean, but a string (`""`, `"0"`, `"1"`, ...) and where JS and PHP have different interpretations of what is truthy and what is falsy.

This PR is divided into several commits:
- the first two are refactorings of `customPostToProduct` and `productToCustomPost` -- the `reduce` calls were quite challenging to understand, so I hope I made them a bit clear
- the real meat is in the following two commits, which introduce converting the `boolean` values and simplify the `SimplePaymentsView`

It took some effort, but the conversion functions should be more clear and less buggy now.

To test:
- edit a payment button and change the "Allow people to buy more than one item at a time" toggle
- check that the button preview in the editor shows or doesn't show the field for specifying the item count
- check that the frontend shows/doesn't show the input, too
- in short, do all the components both in Calypso and on frontend interpret `multiple` the same way?
