### PR TITLE
Plugin Uploads: Pass file to AT init API as plugin_zip

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -2363,7 +2363,7 @@ Undocumented.prototype.initiateTransfer = function( siteId, plugin, theme, onPro
 			post.body = { plugin };
 		}
 		if ( theme ) {
-			post.formData = [ [ 'theme', theme ] ];
+			post.formData = [ [ 'plugin_zip', theme ] ];
 		}
 
 		const req = this.wpcom.req.post( post, resolver );


### PR DESCRIPTION
**Testing only! Do not merge**

Will pass the uploaded from the theme uploads screen at /themes/upload to the API as `plugin_zip` instead of `theme`. Temporary way to test API changes for initiating a transfer with a plugin zip. Use with D6656-code and D6654-code.
