### PR TITLE
Comments: Placeholders, Fix height and Gravatar width

### DIFF
--- a/client/blocks/comment-detail/style.scss
+++ b/client/blocks/comment-detail/style.scss
@@ -537,7 +537,9 @@ a.comment-detail__author-more-element {
 	}
 
 	.comment-detail__author-preview {
-		width: 48px;
+		margin-left: 8px;
+		padding: 3px 0;
+		width: 40px;
 	}
 
 	.comment-detail__author-info {


### PR DESCRIPTION
This PR fixes two visual glitches:

- While loading, the Gravatar didn't keep it's correct width. 

| Before | After |
| --- | --- |
| <img width="472" alt="screen shot 2017-08-02 at 18 01 18" src="https://user-images.githubusercontent.com/2070010/28885198-e199b116-77ac-11e7-84c3-f8cabcaba563.png"> | <img width="475" alt="screen shot 2017-08-02 at 18 02 19" src="https://user-images.githubusercontent.com/2070010/28885203-e620b07c-77ac-11e7-9065-8515224db5ee.png"> |

- Placeholders and real comments didn't have the same height. Now they do.

| Placeholder | Real Comment |
| --- | --- |
| <img width="854" alt="screen shot 2017-08-02 at 18 02 37" src="https://user-images.githubusercontent.com/2070010/28885243-143b10f6-77ad-11e7-8cd5-527511826e1c.png"> | <img width="853" alt="screen shot 2017-08-02 at 18 02 45" src="https://user-images.githubusercontent.com/2070010/28885246-191d7e88-77ad-11e7-9f86-c4621ddf41f6.png"> |

cc @Automattic/lannister 