### PR TITLE
Comments: On disapprove, only unlike if the comment was liked

### DIFF
--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -154,7 +154,7 @@ export class CommentList extends Component {
 	};
 
 	setCommentStatus = ( comment, status, options = { isUndo: false, doPersist: false, showNotice: true } ) => {
-		const { commentId, postId } = comment;
+		const { commentId, postId, isLiked } = comment;
 		const { isUndo, doPersist, showNotice } = options;
 
 		if ( doPersist ) {
@@ -172,7 +172,7 @@ export class CommentList extends Component {
 		this.props.changeCommentStatus( commentId, postId, status );
 
 		// If the comment is not approved anymore, also remove the like
-		if ( 'approved' !== status ) {
+		if ( isLiked && 'approved' !== status ) {
 			this.props.unlikeComment( commentId, postId );
 		}
 	}


### PR DESCRIPTION
When disapproving a comment (i.e. setting status to `unapproved`, `spam`, `trash`), prevent dispatching the `unlikeComment` Redux action and consequent network request if the comment was not liked.

cc @Automattic/lannister 