### PR TITLE
Comments: Clear comment notices when leaving a comment route

### DIFF
--- a/client/my-sites/comments/controller.js
+++ b/client/my-sites/comments/controller.js
@@ -64,8 +64,8 @@ export const comments = function( context ) {
 };
 
 export const clearCommentNotices = ( { store }, next ) => {
-	// `page.current` is the "next" path
-	if ( ! startsWith( page.current, '/comments' ) ) {
+	const nextPath = page.current;
+	if ( ! startsWith( nextPath, '/comments' ) ) {
 		const { getState, dispatch } = store;
 		const notices = getNotices( getState() );
 		each( notices, ( { noticeId } ) => {

--- a/client/my-sites/comments/controller.js
+++ b/client/my-sites/comments/controller.js
@@ -4,7 +4,7 @@
 import { renderWithReduxStore } from 'lib/react-helpers';
 import React from 'react';
 import page from 'page';
-import { includes } from 'lodash';
+import { each, includes, startsWith } from 'lodash';
 
 /**
  * Internal dependencies
@@ -12,6 +12,8 @@ import { includes } from 'lodash';
 import CommentsManagement from './main';
 import config from 'config';
 import route from 'lib/route';
+import { removeNotice } from 'state/notices/actions';
+import { getNotices } from 'state/notices/selectors';
 
 const VALID_STATUSES = [ 'pending', 'approved', 'spam', 'trash' ];
 if ( config.isEnabled( 'comments/management/all-list' ) ) {
@@ -59,4 +61,18 @@ export const comments = function( context ) {
 		'primary',
 		context.store
 	);
+};
+
+export const clearCommentNotices = ( { store }, next ) => {
+	// `page.current` is the "next" path
+	if ( ! startsWith( page.current, '/comments' ) ) {
+		const { getState, dispatch } = store;
+		const notices = getNotices( getState() );
+		each( notices, ( { noticeId } ) => {
+			if ( startsWith( noticeId, 'comment-notice' ) ) {
+				dispatch( removeNotice( noticeId ) );
+			}
+		} );
+	}
+	next();
 };

--- a/client/my-sites/comments/index.js
+++ b/client/my-sites/comments/index.js
@@ -7,7 +7,7 @@ import page from 'page';
  * Internal dependencies
  */
 import controller from 'my-sites/controller';
-import { comments, redirect } from './controller';
+import { clearCommentNotices, comments, redirect } from './controller';
 import config from 'config';
 
 export default function() {
@@ -24,5 +24,7 @@ export default function() {
 			controller.navigation,
 			comments
 		);
+
+		page.exit( '/comments/*', clearCommentNotices );
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/14689

Most notices in Comment Management have Undo buttons tied to `CommentList` methods.
These notices have to persist on navigation, or they would disappear even when browsing different tabs of the Comment Management section.
Though, clicking on an Undo when _outside_ Comment Management, throws an error as `CommentList` has unmounted and the Undo methods aren't available anymore.

This PR adds a `page.exit` handler that checks if the next route is not `/comments` anymore.
In that case, it simply removes all the notices with ID starting with `comment-notice`.

![aug-02-2017 18-58-13](https://user-images.githubusercontent.com/2070010/28887658-efc05a84-77b5-11e7-9e19-124928f568bc.gif)

cc @Automattic/lannister 

## Test

- Open Comment Management route, e.g. `/comments/unapproved/{ siteSlug }`
- Perform an action, such as `approve`.

### Case 1

- Change comments list (e.g. navigating to `spam`), while the notice is still visible.
- The notice remains visible until its 5s timeout.

### Case 2

- Navigate away from Comment Management to any other section, while the notice is still visible.
- The notice will immediately disappear.