### PR TITLE
Reader: Better updates for Conversations

### DIFF
--- a/client/blocks/reader-post-card/conversation-post.jsx
+++ b/client/blocks/reader-post-card/conversation-post.jsx
@@ -4,46 +4,27 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
-import { map, takeRight, filter } from 'lodash';
 
 /**
  * Internal Dependencies
  */
 import ConversationPostList from 'blocks/conversations/list';
 import CompactPostCard from 'blocks/reader-post-card/compact';
-import { getDateSortedPostComments } from 'state/comments/selectors';
 
 class ConversationPost extends React.Component {
 	static propTypes = {
 		post: PropTypes.object.isRequired,
-		comments: PropTypes.array.isRequired,
+		commentIds: PropTypes.array.isRequired,
 	};
 
 	render() {
-		const commentIdsToShow = map(
-			takeRight(
-				filter(
-					this.props.comments,
-					comment => comment.type !== 'trackback' && comment.type !== 'pingback'
-				),
-				3
-			),
-			'ID'
-		);
-
 		return (
 			<div className="reader-post-card__conversation-post">
 				<CompactPostCard { ...this.props } />
-				<ConversationPostList post={ this.props.post } commentIds={ commentIdsToShow } />
+				<ConversationPostList post={ this.props.post } commentIds={ this.props.commentIds } />
 			</div>
 		);
 	}
 }
 
-export default connect( ( state, ownProps ) => {
-	const { site_ID: siteId, ID: postId } = ownProps.post;
-	return {
-		comments: getDateSortedPostComments( state, siteId, postId ),
-	};
-} )( ConversationPost );
+export default ConversationPost;

--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -204,6 +204,7 @@ class ReaderPostCard extends React.Component {
 					title={ title }
 					isDiscover={ isDiscover }
 					postByline={ postByline }
+					commentIds={ postKey.comments }
 				/>
 			);
 		} else if ( isPhotoPost ) {

--- a/client/lib/feed-stream-store/actions.js
+++ b/client/lib/feed-stream-store/actions.js
@@ -114,6 +114,20 @@ export function receivePage( id, error, data ) {
 }
 
 export function receiveUpdates( id, error, data ) {
+	if ( ! error && data && data.posts ) {
+		forEach( data.posts, post => {
+			if ( post.comments ) {
+				// conversations!
+				reduxDispatch( {
+					type: COMMENTS_RECEIVE,
+					siteId: post.site_ID,
+					postId: post.ID,
+					comments: post.comments,
+				} );
+			}
+		} );
+	}
+
 	Dispatcher.handleServerAction( {
 		type: ActionType.RECEIVE_UPDATES,
 		id,

--- a/client/lib/feed-stream-store/feed-stream-cache.js
+++ b/client/lib/feed-stream-store/feed-stream-cache.js
@@ -7,11 +7,11 @@ import LRU from 'lru';
  * Internal Dependencies
  */
 
-const cache = new LRU( 10 );
-const specialCache = {};
+let cache = new LRU( 10 );
+let specialCache = {};
 
 function isSpecialStream( id ) {
-	return /^following|a8c|likes/.test( id );
+	return /^following|a8c|likes|conversations/.test( id );
 }
 
 module.exports = {
@@ -27,5 +27,9 @@ module.exports = {
 		} else {
 			cache.set( id, store );
 		}
+	},
+	clear: function() {
+		specialCache = {};
+		cache = new LRU( 10 );
 	}
 };

--- a/client/lib/feed-stream-store/feed-stream.js
+++ b/client/lib/feed-stream-store/feed-stream.js
@@ -500,7 +500,11 @@ export default class FeedStream {
 				to: this.pendingDateAfter,
 			} );
 		}
-		this.postKeys = uniqBy( this.pendingPostKeys.concat( this.postKeys ), postKey => postKey.ID );
+
+		this.postKeys = uniqBy(
+			this.pendingPostKeys.concat( this.postKeys ),
+			postKey => postKey.postId
+		);
 		if ( this.selectedIndex > -1 ) {
 			//we already scroll to top of content, so deselect so we don't
 			//try to scroll down again.

--- a/client/lib/feed-stream-store/feed-stream.js
+++ b/client/lib/feed-stream-store/feed-stream.js
@@ -1,7 +1,8 @@
+/** @format */
 /**
  * External Dependencies
  */
-import { filter, findIndex, findLastIndex, forEach, get, map, noop, defer } from 'lodash';
+import { filter, findIndex, findLastIndex, forEach, get, map, noop, defer, uniqBy } from 'lodash';
 import moment from 'moment';
 import debugFactory from 'debug';
 
@@ -473,9 +474,7 @@ export default class FeedStream {
 			if ( postKeys.length > 0 ) {
 				this.pendingPostKeys = postKeys;
 				this.pendingDateAfter = moment(
-					this.keyMaker( data.posts[ data.posts.length - 1 ] )[
-						this.dateProperty
-					],
+					this.keyMaker( data.posts[ data.posts.length - 1 ] )[ this.dateProperty ]
 				);
 				this.emitChange();
 			}
@@ -492,9 +491,7 @@ export default class FeedStream {
 			postById.add( postKey.postId );
 		} );
 
-		const mostRecentPostDate = moment(
-			this.postKeys[ 0 ][ this.dateProperty ],
-		);
+		const mostRecentPostDate = moment( this.postKeys[ 0 ][ this.dateProperty ] );
 
 		if ( this.pendingDateAfter > mostRecentPostDate ) {
 			this.pendingPostKeys.push( {
@@ -503,7 +500,7 @@ export default class FeedStream {
 				to: this.pendingDateAfter,
 			} );
 		}
-		this.postKeys = this.pendingPostKeys.concat( this.postKeys );
+		this.postKeys = uniqBy( this.pendingPostKeys.concat( this.postKeys ), postKey => postKey.ID );
 		if ( this.selectedIndex > -1 ) {
 			//we already scroll to top of content, so deselect so we don't
 			//try to scroll down again.

--- a/client/lib/feed-stream-store/feed-stream.js
+++ b/client/lib/feed-stream-store/feed-stream.js
@@ -418,7 +418,7 @@ export default class FeedStream {
 
 	filterNewPosts( posts ) {
 		const postById = this.postById;
-		posts = filter( posts, function( post ) {
+		posts = filter( posts, post => {
 			return ! postById.has( keyToString( this.keyMaker( post ) ) );
 		} );
 		posts = this.filterFollowedXPosts( posts );

--- a/client/lib/feed-stream-store/index.js
+++ b/client/lib/feed-stream-store/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { forEach, map, random, startsWith } from 'lodash';
+import { filter, forEach, map, random, startsWith } from 'lodash';
 
 /**
  * Internal dependencies
@@ -327,6 +327,16 @@ export default function feedStoreFactory( storeId ) {
 			onGapFetch: limitSiteParamsForConversations,
 			dateProperty: 'last_comment_date_gmt',
 		} );
+		// monkey patching is the best patching
+		store.filterNewPosts = function filterConversationsPosts( posts ) {
+			// for conversations, we want to keep posts that we already have that have new comments attached
+			const postById = this.postById;
+			posts = filter( posts, function( post ) {
+				return ! postById.has( post.ID );
+			} );
+			posts = this.filterFollowedXPosts( posts );
+			return map( posts, this.keyMaker );
+		};
 	} else if ( storeId === 'conversations-a8c' ) {
 		store = new FeedStream( {
 			id: storeId,

--- a/client/lib/feed-stream-store/index.js
+++ b/client/lib/feed-stream-store/index.js
@@ -71,6 +71,27 @@ function conversationsPager( params ) {
 	params.page_handle = this.lastPageHandle;
 }
 
+function filterConversationsPosts( posts ) {
+	// turn the new ones into post keys
+	const newPosts = map( posts, this.keyMaker );
+	return filter( newPosts, post => {
+		// only keep things that we don't have or things that have new comments
+		if ( ! this.postById.has( post.postId ) ) {
+			return true; // new new
+		}
+		const existingPost = find( this.postKeys, { postId: post.postId } );
+		if ( ! existingPost ) {
+			// this should never happen
+			return true;
+		}
+
+		if ( isEqual( existingPost.comments, post.comments ) ) {
+			return false;
+		}
+		return true;
+	} );
+}
+
 function addMetaToNextPageFetch( params ) {
 	params.meta = 'post,discover_original_post';
 }
@@ -328,26 +349,7 @@ export default function feedStoreFactory( storeId ) {
 			dateProperty: 'last_comment_date_gmt',
 		} );
 		// monkey patching is the best patching
-		store.filterNewPosts = function filterConversationsPosts( posts ) {
-			// turn the new ones into post keys
-			const newPosts = map( posts, this.keyMaker );
-			return filter( newPosts, post => {
-				// only keep things that we don't have or things that have new comments
-				if ( ! this.postById.has( post.postId ) ) {
-					return true; // new new
-				}
-				const existingPost = find( this.postKeys, { postId: post.postId } );
-				if ( ! existingPost ) {
-					// this should never happen
-					return true;
-				}
-
-				if ( isEqual( existingPost.comments, post.comments ) ) {
-					return false;
-				}
-				return true;
-			} );
-		};
+		store.filterNewPosts = filterConversationsPosts;
 	} else if ( storeId === 'conversations-a8c' ) {
 		store = new FeedStream( {
 			id: storeId,
@@ -360,26 +362,7 @@ export default function feedStoreFactory( storeId ) {
 		} );
 
 		// monkey patching is the best patching
-		store.filterNewPosts = function filterConversationsPosts( posts ) {
-			// turn the new ones into post keys
-			const newPosts = map( posts, this.keyMaker );
-			return filter( newPosts, post => {
-				// only keep things that we don't have or things that have new comments
-				if ( ! this.postById.has( post.postId ) ) {
-					return true; // new new
-				}
-				const existingPost = find( this.postKeys, { postId: post.postId } );
-				if ( ! existingPost ) {
-					// this should never happen
-					return true;
-				}
-
-				if ( isEqual( existingPost.comments, post.comments ) ) {
-					return false;
-				}
-				return true;
-			} );
-		};
+		store.filterNewPosts = filterConversationsPosts;
 	} else if ( storeId === 'a8c' ) {
 		store = new FeedStream( {
 			id: storeId,

--- a/client/lib/feed-stream-store/index.js
+++ b/client/lib/feed-stream-store/index.js
@@ -13,6 +13,7 @@ import PagedStream from './paged-stream';
 import FeedStreamCache from './feed-stream-cache';
 import analytics from 'lib/analytics';
 import wpcom from 'lib/wp';
+import { keyToString, keysAreEqual } from './post-key';
 
 const wpcomUndoc = wpcom.undocumented();
 
@@ -58,7 +59,7 @@ const conversationsKeyMaker = ( function() {
 	const baseMaker = buildNamedKeyMaker( 'last_comment_date_gmt' );
 	return function keyMaker( post ) {
 		const key = baseMaker( post );
-		key.comments = map( post.comments, 'ID' );
+		key.comments = map( post.comments, 'ID' ).reverse();
 		return key;
 	};
 } )();
@@ -76,10 +77,10 @@ function filterConversationsPosts( posts ) {
 	const newPosts = map( posts, this.keyMaker );
 	return filter( newPosts, post => {
 		// only keep things that we don't have or things that have new comments
-		if ( ! this.postById.has( post.postId ) ) {
+		if ( ! this.postById.has( keyToString( post ) ) ) {
 			return true; // new new
 		}
-		const existingPost = find( this.postKeys, { postId: post.postId } );
+		const existingPost = find( this.postKeys, postKey => keysAreEqual( postKey, post ) );
 		if ( ! existingPost ) {
 			// this should never happen
 			return true;

--- a/client/lib/feed-stream-store/test/index.js
+++ b/client/lib/feed-stream-store/test/index.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External Dependencies
  */
@@ -11,7 +12,7 @@ import { set } from 'lodash';
 import useFilesystemMocks from 'test/helpers/use-filesystem-mocks';
 import useMockery from 'test/helpers/use-mockery';
 
-let PostListStore, FeedPostStore;
+let PostListStore, FeedPostStore, PostListFactory, FeedStreamCache;
 
 describe( 'FeedPostList', function() {
 	useFilesystemMocks( __dirname );
@@ -21,8 +22,10 @@ describe( 'FeedPostList', function() {
 	} );
 
 	before( function() {
+		PostListFactory = require( '../' );
 		PostListStore = require( '../feed-stream' );
 		FeedPostStore = require( 'lib/feed-post-store' );
+		FeedStreamCache = require( '../feed-stream-cache' );
 	} );
 
 	it( 'should require an id, a fetcher, a keyMaker', function() {
@@ -45,7 +48,7 @@ describe( 'FeedPostList', function() {
 		expect( function() {
 			return new PostListStore( {
 				id: 5,
-				fetcher: function() {}
+				fetcher: function() {},
 			} );
 		} ).to.throw( Error, /keyMaker/ );
 
@@ -55,7 +58,7 @@ describe( 'FeedPostList', function() {
 	} );
 
 	describe( 'A valid instance', function() {
-		var fetcherStub, store;
+		let fetcherStub, store;
 
 		beforeEach( function() {
 			fetcherStub = sinon.stub();
@@ -64,26 +67,28 @@ describe( 'FeedPostList', function() {
 				fetcher: fetcherStub,
 				keyMaker: function( post ) {
 					return post;
-				}
+				},
 			} );
 		} );
 
 		it( 'should receive a page', function() {
-			store.receivePage( 'test', null, { posts: [ { feed_ID: 1, ID: 1 }, { feed_ID: 1, ID: 2 } ] } );
+			store.receivePage( 'test', null, {
+				posts: [ { feed_ID: 1, ID: 1 }, { feed_ID: 1, ID: 2 } ],
+			} );
 
 			expect( store.get() ).to.have.lengthOf( 2 );
 		} );
 
 		describe( 'updates', function() {
 			beforeEach( function() {
-				let feedPostStoreStub = sinon.stub( FeedPostStore, 'get' );
+				const feedPostStoreStub = sinon.stub( FeedPostStore, 'get' );
 				feedPostStoreStub.returns( { date: '1999-12-31T23:58:00' } );
 				store.receiveUpdates( 'test', null, {
 					date_range: {
 						before: '1999-12-31T23:59:59',
-						after: '1999-12-31T23:58:00'
+						after: '1999-12-31T23:58:00',
 					},
-					posts: [ { feed_ID: 1, ID: 1 }, { feed_ID: 2, ID: 2 } ]
+					posts: [ { feed_ID: 1, ID: 1 }, { feed_ID: 2, ID: 2 } ],
 				} );
 			} );
 
@@ -96,33 +101,33 @@ describe( 'FeedPostList', function() {
 			} );
 
 			it( 'should treat each set of updates as definitive', function() {
-				var secondSet = {
+				const secondSet = {
 					date_range: {
 						before: '1999-12-31T23:59:59',
-						after: '1999-12-31T23:58:00'
+						after: '1999-12-31T23:58:00',
 					},
 					posts: [
 						{
 							feed_ID: 1,
 							ID: 6,
-							date: '1976-09-15T00:00:06+00:00'
+							date: '1976-09-15T00:00:06+00:00',
 						},
 						{
 							feed_ID: 1,
 							ID: 5,
-							date: '1976-09-15T00:00:05+00:00'
+							date: '1976-09-15T00:00:05+00:00',
 						},
 						{
 							feed_ID: 1,
 							ID: 4,
-							date: '1976-09-15T00:00:04+00:00'
+							date: '1976-09-15T00:00:04+00:00',
 						},
 						{
 							feed_ID: 1,
 							ID: 3,
-							date: '1976-09-15T00:00:03+00:00'
-						}
-					]
+							date: '1976-09-15T00:00:03+00:00',
+						},
+					],
 				};
 
 				// new updates, overlapping
@@ -133,7 +138,7 @@ describe( 'FeedPostList', function() {
 	} );
 
 	describe( 'Selected index', function() {
-		var fetcherStub, store, feedPostStoreStub, fakePosts;
+		let fetcherStub, store, feedPostStoreStub, fakePosts;
 		beforeEach( function() {
 			fetcherStub = sinon.stub();
 			feedPostStoreStub = sinon.stub( FeedPostStore, 'get' );
@@ -142,13 +147,13 @@ describe( 'FeedPostList', function() {
 				fetcher: fetcherStub,
 				keyMaker: function( post ) {
 					return post;
-				}
+				},
 			} );
 			fakePosts = [
 				{ feed_ID: 1, ID: 1 },
 				{ feed_ID: 1, ID: 2 },
 				{ feed_ID: 1, ID: 3 },
-				{ feed_ID: 1, ID: 4 }
+				{ feed_ID: 1, ID: 4 },
 			];
 			store.receivePage( 'test', null, { posts: fakePosts } );
 		} );
@@ -169,11 +174,16 @@ describe( 'FeedPostList', function() {
 
 		it( 'should select the next valid post', function() {
 			feedPostStoreStub
-				.onCall( 0 ).returns( {} )
-				.onCall( 1 ).returns( { _state: 'error'} )
-				.onCall( 2 ).returns( { _state: 'minimal' } )
-				.onCall( 3 ).returns( {} )
-				.onCall( 4 ).returns( {} );
+				.onCall( 0 )
+				.returns( {} )
+				.onCall( 1 )
+				.returns( { _state: 'error' } )
+				.onCall( 2 )
+				.returns( { _state: 'minimal' } )
+				.onCall( 3 )
+				.returns( {} )
+				.onCall( 4 )
+				.returns( {} );
 			store.selectItem( { feed_ID: 1, ID: 1 } );
 			store.selectNextItem();
 			expect( store.getSelectedPostKey() ).to.eql( { feed_ID: 1, ID: 4 } );
@@ -189,9 +199,12 @@ describe( 'FeedPostList', function() {
 
 		it( 'should select the prev valid post', function() {
 			feedPostStoreStub
-				.onCall( 0 ).returns( {} )
-				.onCall( 1 ).returns( { _state: 'error' } )
-				.onCall( 2 ).returns( {} );
+				.onCall( 0 )
+				.returns( {} )
+				.onCall( 1 )
+				.returns( { _state: 'error' } )
+				.onCall( 2 )
+				.returns( {} );
 			store.selectItem( { feed_ID: 1, ID: 3 } );
 			expect( store.getSelectedPostKey() ).to.eql( { feed_ID: 1, ID: 3 } );
 			store.selectPrevItem();
@@ -200,11 +213,7 @@ describe( 'FeedPostList', function() {
 	} );
 
 	describe( 'Filter followed x-posts', function() {
-		var fetcherStub,
-			store,
-			posts,
-			filteredPosts,
-			xPostedTo;
+		let fetcherStub, store, posts, filteredPosts, xPostedTo;
 		beforeEach( function() {
 			fetcherStub = sinon.stub();
 			sinon.stub( FeedPostStore, 'get' );
@@ -213,7 +222,7 @@ describe( 'FeedPostList', function() {
 				fetcher: fetcherStub,
 				keyMaker: function( post ) {
 					return post;
-				}
+				},
 			} );
 			posts = [
 				set( {}, 'meta.data.post', {
@@ -221,64 +230,64 @@ describe( 'FeedPostList', function() {
 					metadata: {
 						0: {
 							key: '_xpost_original_permalink',
-							value: 'https://restapiusertests.wordpress.com/2015/10/23/repeat-xposts'
-						}
+							value: 'https://restapiusertests.wordpress.com/2015/10/23/repeat-xposts',
+						},
 					},
 					site_name: 'Office Today',
-					site_URL: 'http://officetoday.wordpress.com'
+					site_URL: 'http://officetoday.wordpress.com',
 				} ),
 				set( {}, 'meta.data.post', {
 					tags: { 'p2-xpost': {} },
 					metadata: {
 						0: {
 							key: '_xpost_original_permalink',
-							value: 'https://restapiusertests.wordpress.com/2015/10/23/repeat-xposts'
-						}
+							value: 'https://restapiusertests.wordpress.com/2015/10/23/repeat-xposts',
+						},
 					},
 					site_name: 'WordPress.com News',
-					site_URL: 'http://en.blog.wordpress.com'
+					site_URL: 'http://en.blog.wordpress.com',
 				} ),
 				set( {}, 'meta.data.post', {
 					tags: { 'p2-xpost': {} },
 					metadata: {
 						0: {
 							key: '_xpost_original_permalink',
-							value: 'https://restapiusertests.wordpress.com/2015/10/23/repeat-xposts#comment-1234'
-						}
+							value: 'https://restapiusertests.wordpress.com/2015/10/23/repeat-xposts#comment-1234',
+						},
 					},
 					site_name: 'Foo Bar',
-					site_URL: 'http://foo.bar.com'
+					site_URL: 'http://foo.bar.com',
 				} ),
 				set( {}, 'meta.data.post', {
 					tags: { 'p2-xpost': {} },
 					metadata: {
 						0: {
 							key: '_xpost_original_permalink',
-							value: 'https://restapiusertests.wordpress.com/2015/10/23/repeat-xposts#comment-1234'
-						}
+							value: 'https://restapiusertests.wordpress.com/2015/10/23/repeat-xposts#comment-1234',
+						},
 					},
 					site_name: 'Developer Resources',
-					site_URL: 'https://developer.wordpress.com/blog'
+					site_URL: 'https://developer.wordpress.com/blog',
 				} ),
 				set( {}, 'meta.data.post', {
 					tags: { 'p2-xpost': {} },
 					metadata: {
 						0: {
 							key: '_xpost_original_permalink',
-							value: 'https://restapiusertests.wordpress.com/2015/10/23/repeat-xposts#comment-456'
-						}
+							value: 'https://restapiusertests.wordpress.com/2015/10/23/repeat-xposts#comment-456',
+						},
 					},
 					site_name: 'The Daily Post',
-					site_URL: 'http://dailypost.wordpress.com'
+					site_URL: 'http://dailypost.wordpress.com',
 				} ),
 				set( {}, 'meta.data.post', {
 					tags: { 'p2-xpost': {} },
 					metadata: false,
 					site_name: 'Example',
-					site_URL: 'http://example.wordpress.com'
+					site_URL: 'http://example.wordpress.com',
 				} ),
 				set( {}, 'meta.data.post', {
-					site_URL: 'https://restapiusertests.wordpress.com/'
+					site_URL: 'https://restapiusertests.wordpress.com/',
 				} ),
 			];
 		} );
@@ -294,46 +303,142 @@ describe( 'FeedPostList', function() {
 			expect( filteredPosts.length ).to.equal( 3 );
 		} );
 
-		it.skip( 'when following origin site, filters followed x-posts, but leaves comment notices', function() {
-			filteredPosts = store.filterFollowedXPosts( posts );
-			expect( filteredPosts.length ).to.equal( 3 );
-			expect( filteredPosts[ 0 ].meta.data.post.site_URL ).to.equal( 'http://foo.bar.com' );
-			expect( filteredPosts[ 1 ].meta.data.post.site_URL ).to.equal( 'http://dailypost.wordpress.com' );
-		} );
+		it.skip(
+			'when following origin site, filters followed x-posts, but leaves comment notices',
+			function() {
+				filteredPosts = store.filterFollowedXPosts( posts );
+				expect( filteredPosts.length ).to.equal( 3 );
+				expect( filteredPosts[ 0 ].meta.data.post.site_URL ).to.equal( 'http://foo.bar.com' );
+				expect( filteredPosts[ 1 ].meta.data.post.site_URL ).to.equal(
+					'http://dailypost.wordpress.com'
+				);
+			}
+		);
 
 		it.skip( 'updates sites x-posted to', function() {
 			filteredPosts = store.filterFollowedXPosts( posts );
-			xPostedTo = store.getSitesCrossPostedTo( 'https://restapiusertests.wordpress.com/2015/10/23/repeat-xposts' );
+			xPostedTo = store.getSitesCrossPostedTo(
+				'https://restapiusertests.wordpress.com/2015/10/23/repeat-xposts'
+			);
 			expect( xPostedTo.length ).to.equal( 5 );
 			expect( xPostedTo[ 0 ].siteName ).to.equal( '+officetoday' );
 			expect( xPostedTo[ 0 ].siteURL ).to.equal( 'http://officetoday.wordpress.com' );
 		} );
 
 		it.skip( 'filters xposts with no metadata', function() {
-			posts = [ set( {}, 'meta.data.post', {
-				tags: { 'p2-xpost': {} },
-				metadata: false,
-				site_name: 'Example',
-				site_URL: 'http://example.wordpress.com'
-			} ) ];
+			posts = [
+				set( {}, 'meta.data.post', {
+					tags: { 'p2-xpost': {} },
+					metadata: false,
+					site_name: 'Example',
+					site_URL: 'http://example.wordpress.com',
+				} ),
+			];
 			filteredPosts = store.filterFollowedXPosts( posts );
 			expect( filteredPosts.length ).to.equal( 0 );
 		} );
 
 		it.skip( 'filters xposts with missing xpost metadata', function() {
-			posts = [ set( {}, 'meta.data.post', {
-				tags: { 'p2-xpost': {} },
-				metadata: {
-					0: {
-						key: 'unrelated',
-						value: 'unrelated'
-					}
-				},
-				site_name: 'Example',
-				site_URL: 'http://example.wordpress.com'
-			} ) ];
+			posts = [
+				set( {}, 'meta.data.post', {
+					tags: { 'p2-xpost': {} },
+					metadata: {
+						0: {
+							key: 'unrelated',
+							value: 'unrelated',
+						},
+					},
+					site_name: 'Example',
+					site_URL: 'http://example.wordpress.com',
+				} ),
+			];
 			filteredPosts = store.filterFollowedXPosts( posts );
 			expect( filteredPosts.length ).to.equal( 0 );
+		} );
+	} );
+
+	describe( 'conversations store', () => {
+		let conversations;
+		beforeEach( () => {
+			FeedStreamCache.clear();
+			conversations = PostListFactory( 'conversations' );
+		} );
+
+		it( 'should build an instance', () => {
+			expect( conversations ).to.be.ok;
+		} );
+
+		context( 'when holding some posts', () => {
+			beforeEach( () => {
+				conversations.receivePage( conversations.id, null, {
+					posts: [
+						{
+							site_ID: 1,
+							ID: 1,
+							date: '2016-09-15T00:00:00Z',
+							last_comment_date_gmt: '2017-01-01T00:00:00Z',
+							comments: [ { ID: 1 }, { ID: 2 }, { ID: 3 } ],
+						},
+					],
+				} );
+				expect( conversations.postKeys ).to.have.lengthOf( 1 );
+			} );
+
+			it( 'should filter out posts that it already has which have the same comments', () => {
+				const filteredPosts = conversations.filterNewPosts( [
+					{
+						site_ID: 1,
+						ID: 1,
+						last_comment_date_gmt: '2017-01-01T00:00:00Z',
+						comments: [ { ID: 1 }, { ID: 2 }, { ID: 3 } ],
+					},
+				] );
+				expect( filteredPosts ).to.have.lengthOf( 0 );
+			} );
+
+			it( 'should retain posts that it already has with new comments', () => {
+				const filteredPosts = conversations.filterNewPosts( [
+					{
+						site_ID: 1,
+						ID: 1,
+						date: '2016-09-15T00:00:00Z',
+						last_comment_date_gmt: '2017-01-01T01:00:00Z',
+						comments: [ { ID: 2 }, { ID: 3 }, { ID: 4 } ],
+					},
+				] );
+				expect( filteredPosts ).to.have.lengthOf( 1 );
+				expect( filteredPosts ).to.eql( [
+					{
+						blogId: 1,
+						comments: [ 2, 3, 4 ],
+						date: new Date( '2016-09-15T00:00:00Z' ),
+						last_comment_date_gmt: '2017-01-01T01:00:00Z',
+						postId: 1,
+					},
+				] );
+			} );
+
+			it( 'should retain new posts', () => {
+				const filteredPosts = conversations.filterNewPosts( [
+					{
+						site_ID: 1,
+						ID: 2,
+						date: '2016-09-15T00:00:00Z',
+						last_comment_date_gmt: '2017-01-01T01:00:00Z',
+						comments: [ { ID: 5 } ],
+					},
+				] );
+				expect( filteredPosts ).to.have.lengthOf( 1 );
+				expect( filteredPosts ).to.eql( [
+					{
+						blogId: 1,
+						comments: [ 5 ],
+						date: new Date( '2016-09-15T00:00:00Z' ),
+						last_comment_date_gmt: '2017-01-01T01:00:00Z',
+						postId: 2,
+					},
+				] );
+			} );
 		} );
 	} );
 } );

--- a/client/lib/feed-stream-store/test/index.js
+++ b/client/lib/feed-stream-store/test/index.js
@@ -382,6 +382,7 @@ describe( 'FeedPostList', function() {
 					],
 				} );
 				expect( conversations.postKeys ).to.have.lengthOf( 1 );
+				expect( conversations.postKeys[ 0 ].comments ).to.eql( [ 3, 2, 1 ] );
 			} );
 
 			it( 'should filter out posts that it already has which have the same comments', () => {
@@ -410,7 +411,7 @@ describe( 'FeedPostList', function() {
 				expect( filteredPosts ).to.eql( [
 					{
 						blogId: 1,
-						comments: [ 2, 3, 4 ],
+						comments: [ 4, 3, 2 ],
 						date: new Date( '2016-09-15T00:00:00Z' ),
 						last_comment_date_gmt: '2017-01-01T01:00:00Z',
 						postId: 1,

--- a/client/lib/feed-stream-store/test/lib/wp.js
+++ b/client/lib/feed-stream-store/test/lib/wp.js
@@ -18,5 +18,6 @@ module.exports = {
 		};
 	},
 	me: returnSelf,
-	dismissSite: returnSelf
+	dismissSite: returnSelf,
+	readConversations: returnSelf,
 };


### PR DESCRIPTION
This PR seeks to improve how we detect and apply updates to the conversations stream. Currently, we tack new posts onto the top of the stream and discard any posts that we already have. We should check those posts for new comments and update the placement of the post in the stream if they have new comments.