### PR TITLE
Confirmation Sidebar: Close on editor keyup only

### DIFF
--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -378,7 +378,7 @@ export const PostEditor = React.createClass( {
 								onFocus={ this.onEditorFocus }
 								onMouseUp={ this.copySelectedText }
 								onBlur={ this.copySelectedText }
-								onTextEditorChange={ this.onEditorContentChange } />
+								onTextEditorChange={ this.onEditorTextContentChange } />
 						</div>
 						<EditorWordCount
 							selectedText={ this.state.selectedText }
@@ -522,6 +522,11 @@ export const PostEditor = React.createClass( {
 	},
 
 	onEditorContentChange: function() {
+		this.debouncedSaveRawContent();
+		this.debouncedAutosave();
+	},
+
+	onEditorTextContentChange: function() {
 		if ( 'open' === this.state.confirmationSidebar ) {
 			this.setConfirmationSidebar( { status: 'closed', context: 'content_edit' } );
 		}


### PR DESCRIPTION
This PR fixes an issue where on ipad tapping on the `EditorVisibility` component could cause the confirmation sidebar to close. Tapping on the component was causing `onEditorContentChange` to be triggered. This change removes the closure of the confirmation sidebar from `onEditorContentChange`, and introduces a new handler `onEditorTextContentChange` to handle closure for changes in the text editor.

Steps to reproduce the original issue:
* Checkout `master` and run with the feature enabled: `ENABLE_FEATURES=post-editor/delta-post-publish-flow make run`
* Setup your ipad such that you can run calypso.localhost. For example, you could use Charles (see PCYsg-1Uq-p2).
* Make sure you're part of the ab test by entering the following in your console: `localStorage.setItem('ABTests','{"postPublishConfirmation_20170801":"showPublishConfirmation"}')` or update the AB test config such that you're always included.
* Start on a page of Calypso that isn't the Editor (such as the Reader).
* In the masterbar, select "Write" and being composing a post for one of your sites.
* Select "Publish..." to trigger the confirmation sidebar.
* Attempt to change the visibility in the confirmation sidebar by clicking on "Public".
* Notice that the confirmation sidebar closes.

To test fix:
* Checkout this PR, and repeat the steps above.
* Verify that the confirmation sidebar doesn't close.
* Test in other browsers that while the confirmation sidebar is open typing text in the title or body of the editor still results in closure of the confirmation sidebar.