### PR TITLE
Store: Fix orders widget language when there is only 1 new order pending

### DIFF
--- a/client/extensions/woocommerce/components/process-orders-widget/index.js
+++ b/client/extensions/woocommerce/components/process-orders-widget/index.js
@@ -15,12 +15,15 @@ import { getLink } from 'woocommerce/lib/nav-utils';
 const ProcessOrdersWidget = ( { className, site, orders, currency, ordersRevenue, translate } ) => {
 	const classes = classNames( 'card', 'process-orders-widget__container', className );
 	const currencyValue = currency && currency.value || '';
+	const orderCountPhrase = translate( 'New order', 'New orders', {
+		count: orders.length
+	} );
 	return (
 		<div className={ classes } >
 			<div>
 				<span>{ orders.length }</span>
 				<span className="process-orders-widget__order-label">
-					{ translate( '✨ New orders' ) }
+					✨ { orderCountPhrase }
 				</span>
 			</div>
 			<div>


### PR DESCRIPTION
Fixes #16606.

This fixes the string so it correctly says "1 new order" or "x new orders" when there is more than one.

To Test:
* Apply this PR.
* Make sure you only have one order set to new/processing.
* Visit `http://calypso.localhost:3000/store/:site` and make sure that you have the "You have new orders" dashboard (not a setup dashboard screen).
* Verify you see the string "1 new order".
* Set an order to processing.
* Verify you see the string "2 new orders".