### PR TITLE
Editor Publish Date: Update component styles for IE11

### DIFF
--- a/client/post-editor/editor-publish-date/style.scss
+++ b/client/post-editor/editor-publish-date/style.scss
@@ -75,14 +75,17 @@
 }
 
 .editor-publish-date__header-description {
+	position: absolute;
+		top: 0;
+	line-height: 40px;
+
 	.editor-publish-date__header.is-scheduled &,
 	.editor-publish-date__header.is-back-dated &,
 	.editor-publish-date__header.is-published & {
-		margin-top: -4px;
+		top: 6px;
 		font-size: 10px;
-		line-height: initial;
+		line-height: 12px;
 	}
-	line-height: initial;
 }
 
 .editor-publish-date__immediate.button {
@@ -108,8 +111,10 @@
 }
 
 .editor-publish-date__header-chrono {
+	position: absolute;
+		top: 16px;
 	font-size: 12px;
-	line-height: initial;
+	line-height: 18px;
 	color: $gray-dark;
 }
 


### PR DESCRIPTION
This PR updates the styles for the Editor `PublishDate` component to fix some issues that existed in IE11.

Before:

![image](https://user-images.githubusercontent.com/363749/28893091-cd6b4202-7795-11e7-82ef-340e894a9dd2.png)
![image](https://user-images.githubusercontent.com/363749/28893107-db56226a-7795-11e7-8183-0cbbdea53bba.png)


After:

![image](https://user-images.githubusercontent.com/363749/28892848-ebb47608-7794-11e7-9498-7766c61a6ee0.png)
![image](https://user-images.githubusercontent.com/363749/28892859-f739c5a0-7794-11e7-94ad-781bd2514219.png)

To test:
* Checkout the branch and run with the feature enabled: `ENABLE_FEATURES=post-editor/delta-post-publish-flow make run`
* Make sure you're part of the ab test by entering the following in your console: `localStorage.setItem('ABTests','{"postPublishConfirmation_20170801":"showPublishConfirmation"}')`
* Verify that the component displays correctly in IE11 by publishing a post and changing the date on the confirmation screen or via post-settings.
