### PR TITLE
JPO: Authorize the Jetpack connection only after Onboarding is complete

### DIFF
--- a/client/state/jetpack-connect/selectors.js
+++ b/client/state/jetpack-connect/selectors.js
@@ -159,6 +159,16 @@ const getSiteIdFromQueryObject = function( state ) {
 	return null;
 };
 
+const getOnboardingFromQueryObject = function( state ) {
+	const authorizationData = getAuthorizationData( state );
+
+	if ( authorizationData.queryObject && authorizationData.queryObject.onboarding ) {
+		return ( 1 === parseInt( authorizationData.queryObject.onboarding ) ) ? true : false;
+	} else {
+		return false;
+	}
+};
+
 export default {
 	getConnectingSite,
 	getAuthorizationData,
@@ -178,5 +188,6 @@ export default {
 	getGlobalSelectedPlan,
 	getAuthAttempts,
 	getSiteIdFromQueryObject,
-	getUserAlreadyConnected
+	getUserAlreadyConnected,
+	getOnboardingFromQueryObject
 };


### PR DESCRIPTION
### This is still a work-in-progress.

The purpose of this PR is to cause JPC requests to be redirected to the onboarding flow before the user is connected to Jetpack. Upon completion of the onboarding flow, they will be redirected back to JPC to authorize the connection.

### Testing Instructions:

Coming soon :-)