### PR TITLE
UploadImage: add defaultImage

### DIFF
--- a/client/blocks/upload-image/README.md
+++ b/client/blocks/upload-image/README.md
@@ -25,6 +25,21 @@ render: function() {
 }
 ```
 
+To use as changable image:
+
+```js
+import UploadImage from 'blocks/upload-image';
+
+render: function() {
+	return
+		<UploadImage 
+			siteId={ <your-site-id> or currently selected siteId if not specified }
+			defaultImage={ default image or its id }
+			onUploadImageDone={ ( uploadedImage ) => console.log( uploadedImage.ID ) }
+		/>;
+}
+```
+
 To see a more complex example, have a look at `blocks/upload-image/docs/example`.
 
 #### Props

--- a/client/blocks/upload-image/README.md
+++ b/client/blocks/upload-image/README.md
@@ -40,7 +40,6 @@ To see a more complex example, have a look at `blocks/upload-image/docs/example`
 - `addAnImageText`: text on the image picker when selecting an image.
 - `dragUploadText`: text which shows when dragging an image to upload.
 - `defaultImage`: previously uploaded image or its id to be used as default image.
-- `defaultImageId`: id of previously uploaded image to be used as default image.
 
 There's a way to design and supply your own HTML for the image picker (when no image is selected) by supplying the
 `imagePickerContent` prop and for the uploading process (when image is being uploaded) by supplying the

--- a/client/blocks/upload-image/README.md
+++ b/client/blocks/upload-image/README.md
@@ -39,6 +39,8 @@ To see a more complex example, have a look at `blocks/upload-image/docs/example`
 - `doneButtonText`: text on the "Done" button in Image Editor modal.
 - `addAnImageText`: text on the image picker when selecting an image.
 - `dragUploadText`: text which shows when dragging an image to upload.
+- `defaultImage`: previously uploaded image or its id to be used as default image.
+- `defaultImageId`: id of previously uploaded image to be used as default image.
 
 There's a way to design and supply your own HTML for the image picker (when no image is selected) by supplying the
 `imagePickerContent` prop and for the uploading process (when image is being uploaded) by supplying the

--- a/client/blocks/upload-image/index.jsx
+++ b/client/blocks/upload-image/index.jsx
@@ -249,7 +249,7 @@ class UploadImage extends Component {
 		this.setState( { uploadedImage: null } );
 	};
 
-	componentDidMount() {
+	componentWillMount() {
 		// use defaultImage as uploadedImage if set.
 		const { defaultImage } = this.props;
 		if ( defaultImage ) {
@@ -390,7 +390,8 @@ class UploadImage extends Component {
 
 export default connect(
 	( state, ownProps ) => {
-		let { siteId, defaultImage, defaultImageId } = ownProps;
+		let { siteId, defaultImage } = ownProps;
+		const { defaultImageId } = ownProps;
 
 		if ( ! siteId ) {
 			siteId = getSelectedSiteId( state );
@@ -399,7 +400,7 @@ export default connect(
 		if ( ! defaultImage && defaultImageId ) {
 			defaultImage = getMediaItem( state, siteId, defaultImageId );
 		}
-	
+
 		return {
 			siteId,
 			defaultImage,

--- a/client/blocks/upload-image/index.jsx
+++ b/client/blocks/upload-image/index.jsx
@@ -218,6 +218,7 @@ class UploadImage extends Component {
 	};
 
 	renderImageEditor() {
+		const { defaultImage } = this.props;
 		const { isEditingImage, selectedImage, selectedImageName } = this.state;
 
 		if ( ! isEditingImage ) {
@@ -228,14 +229,18 @@ class UploadImage extends Component {
 
 		const classes = classnames( 'upload-image-modal', additionalImageEditorClasses );
 
+		const isEditingDefaultImage = defaultImage && selectedImage === defaultImage.URL;
+
+		const media = isEditingDefaultImage ? defaultImage : {
+			src: selectedImage,
+			file: selectedImageName
+		};
+
 		return (
 			<Dialog additionalClassNames={ classes } isVisible={ true }>
 				<ImageEditor
 					{ ...imageEditorProps }
-					media={ {
-						src: selectedImage,
-						file: selectedImageName,
-					} }
+					media={ media }
 					onDone={ this.onImageEditorDone }
 					onCancel={ this.hideImageEditor }
 					doneButtonText={ doneButtonText ? doneButtonText : 'Done' }
@@ -254,6 +259,9 @@ class UploadImage extends Component {
 		if ( defaultImage ) {
 			this.setState( {
 				uploadedImage: defaultImage,
+				selectedImage: defaultImage.URL,
+				selectedImageName: path.basename( defaultImage.URL ),
+				editedImage: defaultImage.URL,
 			} );
 		}
 	}

--- a/client/blocks/upload-image/index.jsx
+++ b/client/blocks/upload-image/index.jsx
@@ -60,8 +60,7 @@ class UploadImage extends Component {
 		doneButtonText: PropTypes.string,
 		addAnImageText: PropTypes.string,
 		dragUploadText: PropTypes.string,
-		defaultImageId: PropTypes.number,
-		defaultImage: PropTypes.object,
+		defaultImage: PropTypes.any,
 		onError: PropTypes.func,
 		onImageEditorDone: PropTypes.func,
 		onUploadImageDone: PropTypes.func,
@@ -391,14 +390,13 @@ class UploadImage extends Component {
 export default connect(
 	( state, ownProps ) => {
 		let { siteId, defaultImage } = ownProps;
-		const { defaultImageId } = ownProps;
 
 		if ( ! siteId ) {
 			siteId = getSelectedSiteId( state );
 		}
 
-		if ( ! defaultImage && defaultImageId ) {
-			defaultImage = getMediaItem( state, siteId, defaultImageId );
+		if ( ! defaultImage || typeof( defaultImage ) !== 'object' ) {
+			defaultImage = getMediaItem( state, siteId, defaultImage );
 		}
 
 		return {

--- a/client/blocks/upload-image/index.jsx
+++ b/client/blocks/upload-image/index.jsx
@@ -20,6 +20,7 @@ import {
 } from './constants';
 import { AspectRatios } from 'state/ui/editor/image-editor/constants';
 import { getSelectedSiteId } from 'state/ui/selectors';
+import { getMediaItem } from 'state/selectors';
 import Dialog from 'components/dialog';
 import FilePicker from 'components/file-picker';
 import { resetAllImageEditorState } from 'state/ui/editor/image-editor/actions';
@@ -59,6 +60,8 @@ class UploadImage extends Component {
 		doneButtonText: PropTypes.string,
 		addAnImageText: PropTypes.string,
 		dragUploadText: PropTypes.string,
+		defaultImageId: PropTypes.number,
+		defaultImage: PropTypes.object,
 		onError: PropTypes.func,
 		onImageEditorDone: PropTypes.func,
 		onUploadImageDone: PropTypes.func,
@@ -246,6 +249,16 @@ class UploadImage extends Component {
 		this.setState( { uploadedImage: null } );
 	};
 
+	componentDidMount() {
+		// use defaultImage as uploadedImage if set.
+		const { defaultImage } = this.props;
+		if ( defaultImage ) {
+			this.setState( {
+				uploadedImage: defaultImage,
+			} );
+		}
+	}
+
 	componentWillUnmount() {
 		const { selectedImage, editedImage } = this.state;
 
@@ -377,14 +390,19 @@ class UploadImage extends Component {
 
 export default connect(
 	( state, ownProps ) => {
-		let { siteId } = ownProps;
+		let { siteId, defaultImage, defaultImageId } = ownProps;
 
 		if ( ! siteId ) {
 			siteId = getSelectedSiteId( state );
 		}
 
+		if ( ! defaultImage && defaultImageId ) {
+			defaultImage = getMediaItem( state, siteId, defaultImageId );
+		}
+	
 		return {
 			siteId,
+			defaultImage,
 		};
 	},
 	{

--- a/client/components/tinymce/plugins/simple-payments/dialog/form.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/form.jsx
@@ -50,7 +50,7 @@ class ProductForm extends Component {
 		return (
 			<form className="editor-simple-payments-modal__form">
 				<UploadImage
-					defaultImageId={ fieldValues.featuredImageId }
+					defaultImage={ fieldValues.featuredImageId }
 					onError={ this.handleUploadImageError }
 					onUploadImageDone={ onUploadImageDone }
 				/>

--- a/client/components/tinymce/plugins/simple-payments/dialog/form.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/form.jsx
@@ -50,6 +50,7 @@ class ProductForm extends Component {
 		return (
 			<form className="editor-simple-payments-modal__form">
 				<UploadImage
+					defaultImageId={ fieldValues.featuredImageId }
 					onError={ this.handleUploadImageError }
 					onUploadImageDone={ onUploadImageDone }
 				/>


### PR DESCRIPTION
This patch adds `defaultImage` prop to `UploadImage` component.

- `defaultImage` - media item or its id to use as default image.

~~NOTE: Image editing is broken and edit button (pencil) is shown.~~ Editing should now work.

TEST PLAN:

View product image in payment block editor:

1. In a post with payment buttons, select a payment button block and press pencil button to edit.
2. You should now see the product image in payment button block editor.

Edit product image:

3. While in the block editor, click on the pencil button on the image to edit the image.
4. You should now be in the image editor. Try editing the image, rotating, cropping, etc.
5. Save and check the edited image in the block editor.
6. Save block editor changes then check image in the edited payment block.

Replace product image:

7. Re-open payment block editor and click on the X button on the image to remove the image.
8. Click the image area to select, edit, and upload another image.
9. Save and check the edited image in the edited payment block.
