### PR TITLE
Posts: Move post hover timestamp

### DIFF
--- a/client/my-sites/post-relative-time-status/index.jsx
+++ b/client/my-sites/post-relative-time-status/index.jsx
@@ -42,8 +42,6 @@ module.exports = React.createClass( {
 	},
 
 	getRelativeTimeText: function() {
-		const status = this.props.post.status;
-
 		const time = this.getTimestamp();
 		if ( ! time ) {
 			return;
@@ -112,7 +110,11 @@ module.exports = React.createClass( {
 
 		if ( this.props.link ) {
 			const rel = this.props.target === '_blank' ? 'noopener noreferrer' : null;
-			details = ( <p className={ realtiveTimeClass } title={ time }><a href={ this.props.link } target={ this.props.target } rel={ rel } onClick={ this.props.onClick }>{ innerText }</a></p> );
+			details = (
+				<p className={ realtiveTimeClass } title={ time }>
+					<a href={ this.props.link } target={ this.props.target } rel={ rel } onClick={ this.props.onClick }>{ innerText }</a>
+				</p>
+			);
 		} else {
 			details = ( <p className={ realtiveTimeClass } title={ time }>{ innerText }</p> );
 		}

--- a/client/my-sites/post-relative-time-status/index.jsx
+++ b/client/my-sites/post-relative-time-status/index.jsx
@@ -31,6 +31,8 @@ module.exports = React.createClass( {
 	},
 
 	getTimestamp: function() {
+		const status = this.props.post.status;
+
 		let time;
 		if ( status === 'draft' || status === 'pending' ) {
 			time = this.props.post.modified;

--- a/client/my-sites/post-relative-time-status/index.jsx
+++ b/client/my-sites/post-relative-time-status/index.jsx
@@ -30,9 +30,7 @@ module.exports = React.createClass( {
 		};
 	},
 
-	getRelativeTimeText: function() {
-		const status = this.props.post.status;
-
+	getTimestamp: function() {
 		let time;
 		if ( status === 'draft' || status === 'pending' ) {
 			time = this.props.post.modified;
@@ -40,6 +38,13 @@ module.exports = React.createClass( {
 			time = this.props.post.date;
 		}
 
+		return time;
+	},
+
+	getRelativeTimeText: function() {
+		const status = this.props.post.status;
+
+		const time = this.getTimestamp();
 		if ( ! time ) {
 			return;
 		}
@@ -47,7 +52,7 @@ module.exports = React.createClass( {
 		return (
 			<span className="post-relative-time-status__time">
 				<Gridicon icon="time" size={ 18 } />
-				<time className="post-relative-time-status__time-text" dateTime={ time } title={ time }>
+				<time className="post-relative-time-status__time-text" dateTime={ time }>
 					{ this.moment( time ).fromNow() }
 				</time>
 			</span>
@@ -102,13 +107,14 @@ module.exports = React.createClass( {
 			statusText = this.getStatusText(),
 			realtiveTimeClass = ( timeText ) ? 'post-relative-time-status' : null,
 			innerText = ( <span>{ timeText }{ statusText }</span> ),
+			time = this.getTimestamp(),
 			details;
 
 		if ( this.props.link ) {
 			const rel = this.props.target === '_blank' ? 'noopener noreferrer' : null;
-			details = ( <p className={ realtiveTimeClass }><a href={ this.props.link } target={ this.props.target } rel={ rel } onClick={ this.props.onClick }>{ innerText }</a></p> );
+			details = ( <p className={ realtiveTimeClass } title={ time }><a href={ this.props.link } target={ this.props.target } rel={ rel } onClick={ this.props.onClick }>{ innerText }</a></p> );
 		} else {
-			details = ( <p className={ realtiveTimeClass }>{ innerText }</p> );
+			details = ( <p className={ realtiveTimeClass } title={ time }>{ innerText }</p> );
 		}
 
 		return details;


### PR DESCRIPTION
Merging https://github.com/Automattic/wp-calypso/pull/16486 kinda helped, but when checking scheduled posts for better UX the timestamp should show up on hovering the whole row not just the human readable time.

### Timestamp should also appear when hovering on text _Scheduled_
![ss_2017-08-03-08-21-54](https://user-images.githubusercontent.com/454800/28908837-0fb74026-7826-11e7-8454-e1a847a667ea.jpg)

**Testing steps**
1. Visit http://calypso.localhost:3000/posts/
2. Hover human readable timestamp. Should see machine timestamp.
3. Go to http://calypso.localhost:3000/posts/scheduled
4. Hover text _Scheduled_ and should see machine timestamp.