### PR TITLE
Sharing: add selector to get service by name

### DIFF
--- a/client/state/sharing/services/selectors.js
+++ b/client/state/sharing/services/selectors.js
@@ -31,6 +31,19 @@ export function getKeyringServicesByType( state, type ) {
 }
 
 /**
+ * Returns an object for the specified service name
+ *
+ * @param  {Object} state Global state tree
+ * @param  {String} name  Service name
+ * @return {Object}        Keyring service, if known, or false.
+ */
+export function getKeyringServiceByName( state, name ) {
+	const services = getKeyringServices( state );
+
+	return services[ name ] ? services[ name ] : false;
+}
+
+/**
  * Returns an array of eligible service objects with the specified type.
  *
  * A service is eligible for a given site if

--- a/client/state/sharing/services/test/selectors.js
+++ b/client/state/sharing/services/test/selectors.js
@@ -99,7 +99,7 @@ describe( 'selectors', () => {
 	} );
 
 	describe( 'getKeyringServiceByName()', () => {
-		it( 'should return empty object if there is no service', () => {
+		it( 'should return false if there is no service', () => {
 			const service = getKeyringServiceByName( defaultState, 'thingy' );
 
 			expect( service ).to.be.false;

--- a/client/state/sharing/services/test/selectors.js
+++ b/client/state/sharing/services/test/selectors.js
@@ -9,6 +9,7 @@ import { expect } from 'chai';
 import {
 	getKeyringServices,
 	getKeyringServicesByType,
+	getKeyringServiceByName,
 	getEligibleKeyringServices,
 	isKeyringServicesFetching,
 } from '../selectors';
@@ -94,6 +95,20 @@ describe( 'selectors', () => {
 				{ ID: 'facebook', type: 'publicize', jetpack_support: true },
 				{ ID: 'twitter', type: 'publicize', jetpack_support: true },
 			] );
+		} );
+	} );
+
+	describe( 'getKeyringServiceByName()', () => {
+		it( 'should return empty object if there is no service', () => {
+			const service = getKeyringServiceByName( defaultState, 'thingy' );
+
+			expect( service ).to.be.false;
+		} );
+
+		it( 'should return the named keyring service', () => {
+			const service = getKeyringServiceByName( activeState, 'eventbrite' );
+
+			expect( service ).to.eql( activeState.sharing.services.items.eventbrite );
 		} );
 	} );
 


### PR DESCRIPTION
Add a sharing selector function to get a service by name. For example, 'google_photos'.

This PR does not affect any other part of Calypso

## Testing

Run included unit test that tests getting a known and unknown service.

`npm run test-client client/state/sharing/services/test/selectors.js`