### PR TITLE
Add mediaStorage Limit and Used selectors

### DIFF
--- a/client/state/selectors/get-media-storage-limit.js
+++ b/client/state/selectors/get-media-storage-limit.js
@@ -1,0 +1,23 @@
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { getMediaStorage } from 'state/sites/media-storage/selectors';
+
+/**
+ * Returns a site's maximum storage in bytes or null if the site doesn't exist or the limit
+ * is unknown.
+ *
+ * Note that the API will return -1 to indicate unlimited storage.
+ *
+ * @param  {Object}  state  Global state tree
+ * @param  {Number}  siteId Site ID
+ * @return {?Number}        Storage limit in bytes
+ */
+export default function getMediaStorageLimit( state, siteId ) {
+	return get( getMediaStorage( state, siteId ), 'max_storage_bytes', null );
+}

--- a/client/state/selectors/get-media-storage-used.js
+++ b/client/state/selectors/get-media-storage-used.js
@@ -1,0 +1,23 @@
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { getMediaStorage } from 'state/sites/media-storage/selectors';
+
+/**
+ * Returns a site's used storage in bytes or null if the site doesn't exist or the usaged
+ * is unknown.
+ *
+ * Note that the API may return -1 in some cases rather than reporting usage.
+ *
+ * @param  {Object}  state  Global state tree
+ * @param  {Number}  siteId Site ID
+ * @return {?Number}        Storage used in bytes
+ */
+export default function getMediaStorageUsed( state, siteId ) {
+	return get( getMediaStorage( state, siteId ), 'storage_used_bytes', null );
+}

--- a/client/state/selectors/index.js
+++ b/client/state/selectors/index.js
@@ -56,6 +56,7 @@ export getMagicLoginRequestEmailError from './get-magic-login-request-email-erro
 export getMedia from './get-media';
 export getMediaItem from './get-media-item';
 export getMediaStorageLimit from './get-media-storage-limit';
+export getMediaStorageUsed from './get-media-storage-used';
 export getMediaUrl from './get-media-url';
 export getMenuItemTypes from './get-menu-item-types';
 export getMenusUrl from './get-menus-url';

--- a/client/state/selectors/index.js
+++ b/client/state/selectors/index.js
@@ -55,6 +55,7 @@ export getMagicLoginRequestedEmailSuccessfully from './get-magic-login-requested
 export getMagicLoginRequestEmailError from './get-magic-login-request-email-error';
 export getMedia from './get-media';
 export getMediaItem from './get-media-item';
+export getMediaStorageLimit from './get-media-storage-limit';
 export getMediaUrl from './get-media-url';
 export getMenuItemTypes from './get-menu-item-types';
 export getMenusUrl from './get-menus-url';

--- a/client/state/selectors/test/get-media-storage-limit.js
+++ b/client/state/selectors/test/get-media-storage-limit.js
@@ -1,0 +1,57 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { getMediaStorageLimit } from '..';
+
+describe( 'getMediaStorageLimit()', () => {
+	it( 'should return null if the site is unknown', () => {
+		const state = {
+			sites: {
+				mediaStorage: {
+					items: {
+						456: { max_storage_bytes: 12345 },
+					},
+				},
+			},
+		};
+
+		expect( getMediaStorageLimit( state ) ).to.be.null;
+		expect( getMediaStorageLimit( state, 123 ) ).to.be.null;
+	} );
+
+	it( 'should return null if the limit is unknown', () => {
+		const state = {
+			sites: {
+				mediaStorage: {
+					items: {
+						123: {},
+						456: { max_storage_bytes: 12345 },
+					},
+				},
+			},
+		};
+		expect( getMediaStorageLimit( state, 123 ) ).to.be.null;
+	} );
+
+	it( 'should return the limit for a site', () => {
+		const max_storage_bytes = 1029384756;
+		const result = getMediaStorageLimit( {
+			sites: {
+				mediaStorage: {
+					items: {
+						123: {
+							max_storage_bytes,
+						},
+					},
+				},
+			},
+		}, 123 );
+
+		expect( result ).to.equal( max_storage_bytes );
+	} );
+} );

--- a/client/state/selectors/test/get-media-storage-used.js
+++ b/client/state/selectors/test/get-media-storage-used.js
@@ -1,0 +1,57 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { getMediaStorageUsed } from '..';
+
+describe( 'getMediaStorageUsed()', () => {
+	it( 'should return null if the site is unknown', () => {
+		const state = {
+			sites: {
+				mediaStorage: {
+					items: {
+						456: { storage_used_bytes: 12345 },
+					},
+				},
+			},
+		};
+
+		expect( getMediaStorageUsed( state ) ).to.be.null;
+		expect( getMediaStorageUsed( state, 123 ) ).to.be.null;
+	} );
+
+	it( 'should return null if usage is unknown', () => {
+		const state = {
+			sites: {
+				mediaStorage: {
+					items: {
+						123: {},
+						456: { storage_used_bytes: 12345 },
+					},
+				},
+			},
+		};
+		expect( getMediaStorageUsed( state, 123 ) ).to.be.null;
+	} );
+
+	it( 'should return the storage used for a site', () => {
+		const storage_used_bytes = 1029384756;
+		const result = getMediaStorageUsed( {
+			sites: {
+				mediaStorage: {
+					items: {
+						123: {
+							storage_used_bytes,
+						},
+					},
+				},
+			},
+		}, 123 );
+
+		expect( result ).to.equal( storage_used_bytes );
+	} );
+} );


### PR DESCRIPTION
Add selectors for the `mediaStorage` object properties as suggested in #14229

`mediaStorage` contains two properties, `max_storage_bytes` and `storage_used_bytes`. These will be provided as the selectors `getMediaStorageLimit` and `getMediaStorageUsed`, respectively.

## Testing

1. Run the tests.