### PR TITLE
Show time for scheduled post in tooltip

### DIFF
--- a/client/components/date-picker/events-tooltip.jsx
+++ b/client/components/date-picker/events-tooltip.jsx
@@ -76,7 +76,11 @@ class EventsTooltip extends Component {
 								icon={ event.icon }
 								socialIcon={ event.socialIcon }
 								socialIconColor={ event.socialIconColor }
-								title={ event.title } />
+								title={
+									event.date.getHours() +
+									':' + event.date.getMinutes() +
+									' ' + event.title
+								} />
 						</li>
 					) }
 


### PR DESCRIPTION
Fix #16473

Commit adds scheduled post's time

![ss_2017-08-03-13-09-40](https://user-images.githubusercontent.com/454800/28919503-0bfc74ce-784e-11e7-8443-0d9993accc52.jpg)
