### PR TITLE
Comments: In error notices, only display the site name if available

### DIFF
--- a/client/state/data-layer/wpcom/sites/comments/index.js
+++ b/client/state/data-layer/wpcom/sites/comments/index.js
@@ -54,13 +54,13 @@ export const receiveCommentError = ( store, action ) => {
 	const site = getReaderSite( store.getState(), action.siteId );
 	const siteName = getReaderSiteName( { site } );
 
-	store.dispatch(
-		errorNotice(
-			translate( 'Failed to retrieve comment for site “%(siteName)s”', {
-				args: { siteName },
-			} ),
-		),
-	);
+	const error = siteName
+		? translate( 'Failed to retrieve comments for site “%(siteName)s”', {
+			args: { siteName },
+		} )
+		: translate( 'Failed to retrieve comments for your site' );
+
+	store.dispatch( errorNotice( error ) );
 
 	store.dispatch( {
 		type: COMMENTS_ERROR,

--- a/client/state/data-layer/wpcom/sites/comments/index.js
+++ b/client/state/data-layer/wpcom/sites/comments/index.js
@@ -57,7 +57,7 @@ export const receiveCommentError = ( { dispatch, getState }, { siteId, commentId
 	if ( siteName ) {
 		dispatch(
 			errorNotice(
-				translate( 'Failed to retrieve comments for site “%(siteName)s”', {
+				translate( 'Failed to retrieve comment for site “%(siteName)s”', {
 					args: { siteName },
 				} )
 			)
@@ -66,10 +66,10 @@ export const receiveCommentError = ( { dispatch, getState }, { siteId, commentId
 		const rawSite = getRawSite( getState(), siteId );
 		const error =
 			rawSite && rawSite.name
-				? translate( 'Failed to retrieve comments for site “%(siteName)s”', {
+				? translate( 'Failed to retrieve comment for site “%(siteName)s”', {
 					args: { siteName: rawSite.name },
 				} )
-				: translate( 'Failed to retrieve comments for your site' );
+				: translate( 'Failed to retrieve comment for your site' );
 
 		dispatch( errorNotice( error ) );
 	}

--- a/client/state/data-layer/wpcom/sites/comments/index.js
+++ b/client/state/data-layer/wpcom/sites/comments/index.js
@@ -50,22 +50,34 @@ export const receiveCommentSuccess = ( store, action, next, response ) => {
 	} );
 };
 
-export const receiveCommentError = ( store, action ) => {
-	const site = getReaderSite( store.getState(), action.siteId );
+export const receiveCommentError = ( { dispatch, getState }, { siteId, commentId } ) => {
+	const site = getReaderSite( getState(), siteId );
 	const siteName = getReaderSiteName( { site } );
 
-	const error = siteName
-		? translate( 'Failed to retrieve comments for site “%(siteName)s”', {
-			args: { siteName },
-		} )
-		: translate( 'Failed to retrieve comments for your site' );
+	if ( siteName ) {
+		dispatch(
+			errorNotice(
+				translate( 'Failed to retrieve comments for site “%(siteName)s”', {
+					args: { siteName },
+				} )
+			)
+		);
+	} else {
+		const rawSite = getRawSite( getState(), siteId );
+		const error =
+			rawSite && rawSite.name
+				? translate( 'Failed to retrieve comments for site “%(siteName)s”', {
+					args: { siteName: rawSite.name },
+				} )
+				: translate( 'Failed to retrieve comments for your site' );
 
-	store.dispatch( errorNotice( error ) );
+		dispatch( errorNotice( error ) );
+	}
 
-	store.dispatch( {
+	dispatch( {
 		type: COMMENTS_ERROR,
-		siteId: action.siteId,
-		commentId: action.commentId,
+		siteId,
+		commentId,
 	} );
 };
 


### PR DESCRIPTION
Add a check to prevent displaying an empty site name in comments error notices, if the site name is not available.

| Before | After |
| --- | --- |
| <img width="384" alt="screen shot 2017-08-03 at 12 44 05" src="https://user-images.githubusercontent.com/2070010/28920385-829a0088-7849-11e7-9eec-94235c25e9aa.png"> | <img width="411" alt="screen shot 2017-08-03 at 12 43 30" src="https://user-images.githubusercontent.com/2070010/28920384-8299c488-7849-11e7-8743-c4864eb5be4a.png"><br><img width="460" alt="screen shot 2017-08-03 at 12 55 14" src="https://user-images.githubusercontent.com/2070010/28920754-0a52c342-784b-11e7-813b-d8c9b2248864.png"> |