### PR TITLE
Framework: Transpile untranspiled node_modules

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2180,6 +2180,10 @@
       "version": "0.3.0",
       "dev": true
     },
+    "find-root": {
+      "version": "1.1.0",
+      "dev": true
+    },
     "find-up": {
       "version": "2.1.0"
     },
@@ -4981,7 +4985,7 @@
       "dev": true
     },
     "notifications-panel": {
-      "version": "1.2.7"
+      "version": "2.1.0"
     },
     "npm-path": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -262,6 +262,7 @@
     "eslint-plugin-jest": "21.2.0",
     "eslint-plugin-react": "7.1.0",
     "eslint-plugin-wpcalypso": "3.4.1",
+    "find-root": "1.1.0",
     "glob": "7.0.3",
     "husky": "0.13.3",
     "ignore": "3.3.5",

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "ms": "0.7.1",
     "name-all-modules-plugin": "1.0.1",
     "node-sass": "4.5.3",
-    "notifications-panel": "1.2.7",
+    "notifications-panel": "2.1.0",
     "npm-run-all": "4.0.2",
     "numeral": "2.0.4",
     "page": "1.6.4",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -100,10 +100,7 @@ const webpackConfig = {
 			{
 				test: /\.jsx?$/,
 				// Should Babel transpile the file at `filepath`?
-				include: ( filepath ) => {
-					return ( ! pathIsInside( filepath, nodeModulesDir ) ||
-						hasPkgEsnext( filepath ) );
-				},
+				include: ( filepath ) => ( ! pathIsInside( filepath, nodeModulesDir ) || hasPkgEsnext( filepath ) ),
 				loader: [ 'happypack/loader' ]
 			},
 			{

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,10 +6,12 @@
 const _ = require( 'lodash' );
 const CopyWebpackPlugin = require( 'copy-webpack-plugin' );
 const DashboardPlugin = require( 'webpack-dashboard/plugin' );
+const findRoot = require( 'find-root' );
 const fs = require( 'fs' );
 const HappyPack = require( 'happypack' );
 const HardSourceWebpackPlugin = require( 'hard-source-webpack-plugin' );
 const path = require( 'path' );
+const pathIsInside = require( 'path-is-inside' );
 const webpack = require( 'webpack' );
 const NameAllModulesPlugin = require( 'name-all-modules-plugin' );
 const AssetsPlugin = require( 'assets-webpack-plugin' );
@@ -24,8 +26,10 @@ const UseMinifiedFiles = require( './server/bundler/webpack-plugins/use-minified
 /**
  * Internal variables
  */
+const PROPKEY_ESNEXT = 'esnext';
 const calypsoEnv = config( 'env_id' );
 const bundleEnv = config( 'env' );
+const nodeModulesDir = path.resolve( __dirname, 'node_modules' );
 
 /**
  * This function scans the /client/extensions directory in order to generate a map that looks like this:
@@ -49,6 +53,20 @@ function getAliasesForExtensions() {
 		aliasesMap[ extensionName ] = path.join( extensionsDirectory, extensionName )
 	);
 	return aliasesMap;
+}
+
+/*
+ * Find package.json for file at `filepath`.
+ * Return `true` if it has a property whose key is `PROPKEY_ESNEXT` or 'module'.
+ */
+function hasPkgEsnext( filepath ) {
+	const pkgRoot = findRoot( filepath );
+	const packageJsonPath = path.resolve( pkgRoot, 'package.json' );
+	const packageJsonText = fs.readFileSync( packageJsonPath,
+		{ encoding: 'utf-8' } );
+	const packageJson = JSON.parse( packageJsonText );
+	return {}.hasOwnProperty.call( packageJson, PROPKEY_ESNEXT ) ||
+		{}.hasOwnProperty.call( packageJson, 'module' );
 }
 
 const babelLoader = {
@@ -81,7 +99,11 @@ const webpackConfig = {
 		rules: [
 			{
 				test: /\.jsx?$/,
-				exclude: /node_modules[\/\\](?!notifications-panel)/,
+				// Should Babel transpile the file at `filepath`?
+				include: ( filepath ) => {
+					return ( ! pathIsInside( filepath, nodeModulesDir ) ||
+						hasPkgEsnext( filepath ) );
+				},
 				loader: [ 'happypack/loader' ]
 			},
 			{
@@ -110,6 +132,7 @@ const webpackConfig = {
 	},
 	resolve: {
 		extensions: [ '.json', '.js', '.jsx' ],
+		mainFields: [ PROPKEY_ESNEXT, 'browser', 'module', 'main' ],
 		modules: [
 			path.join( __dirname, 'client' ),
 			'node_modules',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -65,8 +65,7 @@ function hasPkgEsnext( filepath ) {
 	const packageJsonText = fs.readFileSync( packageJsonPath,
 		{ encoding: 'utf-8' } );
 	const packageJson = JSON.parse( packageJsonText );
-	return {}.hasOwnProperty.call( packageJson, PROPKEY_ESNEXT ) ||
-		{}.hasOwnProperty.call( packageJson, 'module' );
+	return packageJson.hasOwnProperty( PROPKEY_ESNEXT ) || packageJson.hasOwnProperty( 'module' );
 }
 
 const babelLoader = {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -58,6 +58,7 @@ function getAliasesForExtensions() {
 /*
  * Find package.json for file at `filepath`.
  * Return `true` if it has a property whose key is `PROPKEY_ESNEXT` or 'module'.
+ * Taken from http://2ality.com/2017/06/pkg-esnext.html
  */
 function hasPkgEsnext( filepath ) {
 	const pkgRoot = findRoot( filepath );


### PR DESCRIPTION
Requires https://github.com/Automattic/notifications-panel/pull/174

By looking for an `esnext` or `module` field in the module's `package.json`. Allows us to retain ES6+ features such as tree shaking.
For background, see http://2ality.com/2017/06/pkg-esnext.html

Suggested order:
* Merge https://github.com/Automattic/notifications-panel/pull/174
* Release new version of `notifications-panel`
* Include version bump with this PR
* Test
* Merge

We might also want to move `hasPkgEsnext` to a dedicated npm, since other consumers are going to use it too (see e.g. https://github.com/Automattic/WP-Job-Manager/pull/1108). However, since that code is lifted from http://2ality.com/2017/06/pkg-esnext.html, I'm not sure how to proceed with licensing etc.