### PR TITLE
Reader: only show unique authors with avatars in conversation caterpillar

### DIFF
--- a/client/blocks/conversation-caterpillar/docs/fixtures.js
+++ b/client/blocks/conversation-caterpillar/docs/fixtures.js
@@ -1,8 +1,10 @@
+/** @format */
 export const comments = [
 	{
 		ID: 1,
 		content: '<p>Excellent!</p>',
 		author: {
+			ID: 1,
 			name: 'Christophe',
 			avatar_URL:
 				'https://2.gravatar.com/avatar/5512fbf07ae3dd340fb6ed4924861c8e?s=96&d=identicon&r=G',
@@ -13,6 +15,7 @@ export const comments = [
 		ID: 2,
 		content: '<p>Tremendous!</p>',
 		author: {
+			ID: 2,
 			name: 'Boris',
 			avatar_URL: 'https://2.gravatar.com/avatar/22d41e5b6ff197cd7900c0514d1bd305?d=mm&r=G',
 		},
@@ -22,9 +25,21 @@ export const comments = [
 		ID: 3,
 		content: '<p>Splendid!</p>',
 		author: {
+			ID: 3,
 			name: 'Matt',
 			avatar_URL: 'https://1.gravatar.com/avatar/767fc9c115a1b989744c755db47feb60?d=mm&r=G',
 		},
 		date: '2016-04-18T14:59:22+00:00',
+	},
+	{
+		ID: 4,
+		content: '<p>Marvellous!</p>',
+		author: {
+			ID: 1,
+			name: 'Christophe',
+			avatar_URL:
+				'https://2.gravatar.com/avatar/5512fbf07ae3dd340fb6ed4924861c8e?s=96&d=identicon&r=G',
+		},
+		date: '2016-04-18T15:22:00+00:00',
 	},
 ];

--- a/client/blocks/conversation-caterpillar/docs/fixtures.js
+++ b/client/blocks/conversation-caterpillar/docs/fixtures.js
@@ -26,7 +26,7 @@ export const comments = [
 		content: '<p>Splendid!</p>',
 		author: {
 			ID: 3,
-			name: 'Matt',
+			name: 'Matt Mullenweg',
 			avatar_URL: 'https://1.gravatar.com/avatar/767fc9c115a1b989744c755db47feb60?d=mm&r=G',
 		},
 		date: '2016-04-18T14:59:22+00:00',
@@ -41,5 +41,15 @@ export const comments = [
 				'https://2.gravatar.com/avatar/5512fbf07ae3dd340fb6ed4924861c8e?s=96&d=identicon&r=G',
 		},
 		date: '2016-04-18T15:22:00+00:00',
+	},
+	{
+		ID: 5,
+		content: '<p>I have no avatar, sad panda</p>',
+		author: {
+			ID: 1,
+			name: 'Anon',
+			avatar_URL: null,
+		},
+		date: '2016-04-18T15:23:00+00:00',
 	},
 ];

--- a/client/blocks/conversation-caterpillar/index.jsx
+++ b/client/blocks/conversation-caterpillar/index.jsx
@@ -4,7 +4,7 @@
  */
 import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
-import { map, get, last, uniqBy, size } from 'lodash';
+import { map, get, last, uniqBy, size, filter } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /***
@@ -22,16 +22,18 @@ class ConversationCaterpillarComponent extends React.Component {
 
 	render() {
 		const { comments, translate } = this.props;
-		const lastComment = last( comments );
-		const lastCommenterName = get( lastComment, 'author.name' );
 		const commentCount = size( comments );
+
+		// Only display authors with a gravatar, and only display each author once
 		const uniqueAuthors = uniqBy( map( comments, 'author' ), 'ID' );
-		const uniqueAuthorsCount = size( uniqueAuthors );
+		const displayedAuthors = filter( uniqueAuthors, author => !! author.avatar_URL );
+		const displayedAuthorsCount = size( displayedAuthors );
+		const lastAuthorName = get( last( displayedAuthors ), 'name' );
 
 		// At the moment, we just show authors for the entire comments array
 		return (
 			<div className="conversation-caterpillar">
-				{ map( uniqueAuthors, author => {
+				{ map( displayedAuthors, author => {
 					return (
 						<Gravatar
 							className="conversation-caterpillar__gravatar"
@@ -48,13 +50,13 @@ class ConversationCaterpillarComponent extends React.Component {
 						commentCount > 1
 							? translate( 'View comments from %(commenterName)s and %(count)d more', {
 									args: {
-										commenterName: lastCommenterName,
-										count: uniqueAuthorsCount - 1,
+										commenterName: lastAuthorName,
+										count: displayedAuthorsCount - 1,
 									},
 								} )
 							: translate( 'View comment from %(commenterName)s', {
 									args: {
-										commenterName: lastCommenterName,
+										commenterName: lastAuthorName,
 									},
 								} )
 					}
@@ -62,13 +64,13 @@ class ConversationCaterpillarComponent extends React.Component {
 					{ commentCount > 1
 						? translate( '%(commenterName)s and %(count)d more', {
 								args: {
-									commenterName: lastCommenterName,
-									count: uniqueAuthorsCount - 1,
+									commenterName: lastAuthorName,
+									count: displayedAuthorsCount - 1,
 								},
 							} )
 						: translate( '%(commenterName)s commented', {
 								args: {
-									commenterName: lastCommenterName,
+									commenterName: lastAuthorName,
 								},
 							} ) }
 				</button>

--- a/client/blocks/conversation-caterpillar/index.jsx
+++ b/client/blocks/conversation-caterpillar/index.jsx
@@ -26,7 +26,7 @@ class ConversationCaterpillarComponent extends React.Component {
 
 		// Only display authors with a gravatar, and only display each author once
 		const uniqueAuthors = uniqBy( map( comments, 'author' ), 'ID' );
-		const displayedAuthors = filter( uniqueAuthors, author => !! author.avatar_URL );
+		const displayedAuthors = filter( uniqueAuthors, 'avatar_URL' );
 		const lastAuthorName = get( last( displayedAuthors ), 'name' );
 
 		// At the moment, we just show authors for the entire comments array

--- a/client/blocks/conversation-caterpillar/index.jsx
+++ b/client/blocks/conversation-caterpillar/index.jsx
@@ -27,7 +27,6 @@ class ConversationCaterpillarComponent extends React.Component {
 		// Only display authors with a gravatar, and only display each author once
 		const uniqueAuthors = uniqBy( map( comments, 'author' ), 'ID' );
 		const displayedAuthors = filter( uniqueAuthors, author => !! author.avatar_URL );
-		const displayedAuthorsCount = size( displayedAuthors );
 		const lastAuthorName = get( last( displayedAuthors ), 'name' );
 
 		// At the moment, we just show authors for the entire comments array
@@ -51,7 +50,7 @@ class ConversationCaterpillarComponent extends React.Component {
 							? translate( 'View comments from %(commenterName)s and %(count)d more', {
 									args: {
 										commenterName: lastAuthorName,
-										count: displayedAuthorsCount - 1,
+										count: commentCount - 1,
 									},
 								} )
 							: translate( 'View comment from %(commenterName)s', {
@@ -65,7 +64,7 @@ class ConversationCaterpillarComponent extends React.Component {
 						? translate( '%(commenterName)s and %(count)d more', {
 								args: {
 									commenterName: lastAuthorName,
-									count: displayedAuthorsCount - 1,
+									count: commentCount - 1,
 								},
 							} )
 						: translate( '%(commenterName)s commented', {

--- a/client/blocks/conversation-caterpillar/index.jsx
+++ b/client/blocks/conversation-caterpillar/index.jsx
@@ -1,9 +1,10 @@
+/** @format */
 /**
  * External dependencies
  */
 import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
-import { map, get, last } from 'lodash';
+import { map, get, last, uniqBy, size } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /***
@@ -23,17 +24,19 @@ class ConversationCaterpillarComponent extends React.Component {
 		const { comments, translate } = this.props;
 		const lastComment = last( comments );
 		const lastCommenterName = get( lastComment, 'author.name' );
-		const commentCount = comments.length;
+		const commentCount = size( comments );
+		const uniqueAuthors = uniqBy( map( comments, 'author' ), 'ID' );
+		const uniqueAuthorsCount = size( uniqueAuthors );
 
 		// At the moment, we just show authors for the entire comments array
 		return (
 			<div className="conversation-caterpillar">
-				{ map( comments, comment => {
+				{ map( uniqueAuthors, author => {
 					return (
 						<Gravatar
 							className="conversation-caterpillar__gravatar"
-							key={ comment.ID }
-							user={ comment.author }
+							key={ author.ID }
+							user={ author }
 							size={ 32 }
 							aria-hidden="true"
 						/>
@@ -46,7 +49,7 @@ class ConversationCaterpillarComponent extends React.Component {
 							? translate( 'View comments from %(commenterName)s and %(count)d more', {
 									args: {
 										commenterName: lastCommenterName,
-										count: commentCount - 1,
+										count: uniqueAuthorsCount - 1,
 									},
 								} )
 							: translate( 'View comment from %(commenterName)s', {
@@ -60,7 +63,7 @@ class ConversationCaterpillarComponent extends React.Component {
 						? translate( '%(commenterName)s and %(count)d more', {
 								args: {
 									commenterName: lastCommenterName,
-									count: commentCount - 1,
+									count: uniqueAuthorsCount - 1,
 								},
 							} )
 						: translate( '%(commenterName)s commented', {

--- a/client/blocks/conversations/list.jsx
+++ b/client/blocks/conversations/list.jsx
@@ -20,7 +20,7 @@ export class ConversationCommentList extends React.Component {
 	};
 
 	static defaultProps = {
-		showCaterpillar: true,
+		showCaterpillar: false,
 	};
 
 	render() {

--- a/client/blocks/conversations/list.jsx
+++ b/client/blocks/conversations/list.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -19,7 +20,7 @@ export class ConversationCommentList extends React.Component {
 	};
 
 	static defaultProps = {
-		showCaterpillar: false,
+		showCaterpillar: true,
 	};
 
 	render() {

--- a/client/blocks/reader-post-card/conversation-post.jsx
+++ b/client/blocks/reader-post-card/conversation-post.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External Dependencies
  */
@@ -15,7 +16,7 @@ import { getDateSortedPostComments } from 'state/comments/selectors';
 class ConversationPost extends React.Component {
 	static propTypes = {
 		post: React.PropTypes.object.isRequired,
-		comments: React.PropTypes.object.isRequired,
+		comments: React.PropTypes.array.isRequired,
 	};
 
 	render() {
@@ -23,10 +24,7 @@ class ConversationPost extends React.Component {
 		return (
 			<div className="reader-post-card__conversation-post">
 				<CompactPostCard { ...this.props } />
-				<ConversationPostList
-					post={ this.props.post }
-					commentIds={ commentIdsToShow }
-				/>
+				<ConversationPostList post={ this.props.post } commentIds={ commentIdsToShow } />
 			</div>
 		);
 	}


### PR DESCRIPTION
In the Reader conversation caterpillar:
- [x] show only unique author avatars
- [x] omit authors without an avatar URL
- [x] count should reflect ~unique authors~ comment count
- [x] last author name should reflect last displayed avatar

<img width="466" alt="screen shot 2017-08-03 at 18 24 38" src="https://user-images.githubusercontent.com/17325/28934492-0f6a9ec6-7879-11e7-8503-ff6165ecc82d.png">

### To test

http://calypso.localhost:3000/devdocs/blocks/conversation-caterpillar

