### PR TITLE
Conversations: Set the page title when a conversation mounts

### DIFF
--- a/client/reader/conversations/stream.js
+++ b/client/reader/conversations/stream.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External Dependencies
  */
@@ -7,6 +8,7 @@ import React from 'react';
  * Internal Dependencies
  */
 import Stream from 'reader/stream';
+import DocumentHead from 'components/data/document-head';
 
 export default function( props ) {
 	return (
@@ -18,6 +20,8 @@ export default function( props ) {
 			followSource="conversations"
 			useCompactCards={ true }
 			trackScrollPage={ props.trackScrollPage }
-		/>
+		>
+			<DocumentHead title={ props.title } />
+		</Stream>
 	);
 }


### PR DESCRIPTION
To test, pull up /read/conversations. Notice that the title has been set on the browser tab. Click through to a post and notice that the history entry in the browser now says "Conversations - WordPress.com"