### PR TITLE
Reader Pretty: add @format and es5 commas

### DIFF
--- a/client/blocks/reader-author-link/index.jsx
+++ b/client/blocks/reader-author-link/index.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */

--- a/client/blocks/reader-avatar/index.jsx
+++ b/client/blocks/reader-avatar/index.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */

--- a/client/blocks/reader-combined-card/index.jsx
+++ b/client/blocks/reader-combined-card/index.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External Dependencies
  */
@@ -124,7 +125,7 @@ class ReaderCombinedCard extends React.Component {
 							isDiscover={ isDiscover }
 							isSelected={ isSelectedPost( post ) }
 							showFeaturedAsset={ mediaCount > 0 }
-						/>,
+						/>
 					) }
 				</ul>
 				{ feedId && <QueryReaderFeed feedId={ +feedId } includeMeta={ false } /> }

--- a/client/blocks/reader-combined-card/post.jsx
+++ b/client/blocks/reader-combined-card/post.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External Dependencies
  */

--- a/client/blocks/reader-email-settings/index.jsx
+++ b/client/blocks/reader-email-settings/index.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */

--- a/client/blocks/reader-excerpt/index.jsx
+++ b/client/blocks/reader-excerpt/index.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External Dependencies
  */

--- a/client/blocks/reader-export-button/index.jsx
+++ b/client/blocks/reader-export-button/index.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -44,7 +45,7 @@ class ReaderExportButton extends React.Component {
 
 		if ( ! err && ! data.success ) {
 			this.props.errorNotice(
-				this.props.translate( 'Sorry, there was a problem creating your export file.' ),
+				this.props.translate( 'Sorry, there was a problem creating your export file.' )
 			);
 			return;
 		}

--- a/client/blocks/reader-featured-image/index.jsx
+++ b/client/blocks/reader-featured-image/index.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External Dependencies
  */

--- a/client/blocks/reader-featured-video/index.jsx
+++ b/client/blocks/reader-featured-video/index.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External Dependencies
  */

--- a/client/blocks/reader-feed-header/badge.jsx
+++ b/client/blocks/reader-feed-header/badge.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External Dependencies
  */

--- a/client/blocks/reader-feed-header/index.jsx
+++ b/client/blocks/reader-feed-header/index.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External Dependencies
  */

--- a/client/blocks/reader-full-post/back.jsx
+++ b/client/blocks/reader-full-post/back.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */

--- a/client/blocks/reader-full-post/featured-image.jsx
+++ b/client/blocks/reader-full-post/featured-image.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
 * External dependencies
 */

--- a/client/blocks/reader-full-post/header-tags.jsx
+++ b/client/blocks/reader-full-post/header-tags.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */

--- a/client/blocks/reader-full-post/header.jsx
+++ b/client/blocks/reader-full-post/header.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External Dependencies
  */
@@ -163,7 +164,7 @@ export class FullPostView extends React.Component {
 		recordTrackForPost(
 			liked ? 'calypso_reader_article_liked' : 'calypso_reader_article_unliked',
 			this.props.post,
-			{ context: 'full-post', event_source: 'keyboard' },
+			{ context: 'full-post', event_source: 'keyboard' }
 		);
 	};
 
@@ -284,7 +285,7 @@ export class FullPostView extends React.Component {
 				components: {
 					wpLink: <a href="/" className="reader-related-card-v2__link" />,
 				},
-			},
+			}
 		);
 
 		if ( post.site_ID ) {
@@ -466,7 +467,7 @@ const ConnectedFullPostView = connect(
 
 		return props;
 	},
-	{ setSection },
+	{ setSection }
 )( FullPostView );
 
 /**

--- a/client/blocks/reader-full-post/unavailable.jsx
+++ b/client/blocks/reader-full-post/unavailable.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */

--- a/client/blocks/reader-import-button/index.jsx
+++ b/client/blocks/reader-import-button/index.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -72,7 +73,7 @@ class ReaderImportButton extends React.Component {
 			{
 				args: { name: feedImport.fileName },
 				components: { em: <em /> },
-			},
+			}
 		);
 		this.props.successNotice( message );
 	};
@@ -86,7 +87,7 @@ class ReaderImportButton extends React.Component {
 			'Whoops, something went wrong. %(message)s Please try again.',
 			{
 				args: { message: error.message ? error.message + '.' : null },
-			},
+			}
 		);
 		this.props.errorNotice( message );
 	};

--- a/client/blocks/reader-post-actions/index.jsx
+++ b/client/blocks/reader-post-actions/index.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */

--- a/client/blocks/reader-post-card/blocked.jsx
+++ b/client/blocks/reader-post-card/blocked.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */

--- a/client/blocks/reader-post-card/byline.jsx
+++ b/client/blocks/reader-post-card/byline.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External Dependencies
  */

--- a/client/blocks/reader-post-card/compact.jsx
+++ b/client/blocks/reader-post-card/compact.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External Dependencies
  */

--- a/client/blocks/reader-post-card/conversation-post.jsx
+++ b/client/blocks/reader-post-card/conversation-post.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External Dependencies
  */
@@ -23,10 +24,7 @@ class ConversationPost extends React.Component {
 		return (
 			<div className="reader-post-card__conversation-post">
 				<CompactPostCard { ...this.props } />
-				<ConversationPostList
-					post={ this.props.post }
-					commentIds={ commentIdsToShow }
-				/>
+				<ConversationPostList post={ this.props.post } commentIds={ commentIdsToShow } />
 			</div>
 		);
 	}

--- a/client/blocks/reader-post-card/featured-asset.jsx
+++ b/client/blocks/reader-post-card/featured-asset.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External Dependencies
  */

--- a/client/blocks/reader-post-card/gallery.jsx
+++ b/client/blocks/reader-post-card/gallery.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External Dependencies
  */

--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External Dependencies
  */
@@ -269,5 +270,5 @@ export default connect(
 	( state, ownProps ) => ( {
 		isExpanded: isReaderCardExpanded( state, ownProps.postKey ),
 	} ),
-	{ expandCard: expandCardAction },
+	{ expandCard: expandCardAction }
 )( ReaderPostCard );

--- a/client/blocks/reader-post-card/photo.jsx
+++ b/client/blocks/reader-post-card/photo.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External Dependencies
  */

--- a/client/blocks/reader-post-card/standard.jsx
+++ b/client/blocks/reader-post-card/standard.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External Dependencies
  */

--- a/client/blocks/reader-post-options-menu/blog-sticker-menu-item.jsx
+++ b/client/blocks/reader-post-options-menu/blog-sticker-menu-item.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External Dependencies
  */
@@ -43,5 +44,5 @@ class ReaderPostOptionsMenuBlogStickerMenuItem extends React.Component {
 }
 
 export default connect( null, { addBlogSticker, removeBlogSticker } )(
-	ReaderPostOptionsMenuBlogStickerMenuItem,
+	ReaderPostOptionsMenuBlogStickerMenuItem
 );

--- a/client/blocks/reader-post-options-menu/blog-stickers.jsx
+++ b/client/blocks/reader-post-options-menu/blog-stickers.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -31,7 +32,7 @@ class ReaderPostOptionsMenuBlogStickers extends React.Component {
 						hasSticker={ includes( stickers, blogStickerName ) }
 					>
 						{ blogStickerName }
-					</ReaderPostOptionsMenuBlogStickerMenuItem>,
+					</ReaderPostOptionsMenuBlogStickerMenuItem>
 				) }
 				{ ! stickers && <QueryBlogStickers blogId={ blogId } /> }
 			</div>

--- a/client/blocks/reader-post-options-menu/index.jsx
+++ b/client/blocks/reader-post-options-menu/index.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -61,7 +62,7 @@ class ReaderPostOptionsMenu extends React.Component {
 
 		window.open(
 			'https://wordpress.com/abuse/?report_url=' + encodeURIComponent( this.props.post.URL ),
-			'_blank',
+			'_blank'
 		);
 	};
 
@@ -76,7 +77,7 @@ class ReaderPostOptionsMenu extends React.Component {
 		stats.recordGaEvent( isMenuVisible ? 'Open Post Options Menu' : 'Close Post Options Menu' );
 		stats.recordTrackForPost(
 			'calypso_reader_post_options_menu_' + ( isMenuVisible ? 'opened' : 'closed' ),
-			this.props.post,
+			this.props.post
 		);
 	};
 
@@ -199,5 +200,5 @@ export default connect(
 	},
 	{
 		requestSiteBlock,
-	},
+	}
 )( localize( ReaderPostOptionsMenu ) );

--- a/client/blocks/reader-recommended-sites/index.jsx
+++ b/client/blocks/reader-recommended-sites/index.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External Dependencies
  */

--- a/client/blocks/reader-related-card-v2/index.jsx
+++ b/client/blocks/reader-related-card-v2/index.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External Dependencies
  */

--- a/client/blocks/reader-share/helper.jsx
+++ b/client/blocks/reader-share/helper.jsx
@@ -1,3 +1,4 @@
+/** @format */
 const exported = {
 	shouldShowShare: function( post ) {
 		return ! post.site_is_private;

--- a/client/blocks/reader-share/index.jsx
+++ b/client/blocks/reader-share/index.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -229,7 +230,7 @@ class ReaderShare extends React.Component {
 									<span>Facebook</span>
 								</PopoverMenuItem>
 							</PopoverMenu> ),
-			],
+			]
 		);
 	}
 }

--- a/client/blocks/reader-site-stream-link/index.jsx
+++ b/client/blocks/reader-site-stream-link/index.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */

--- a/client/blocks/reader-subscription-list-item/connected.jsx
+++ b/client/blocks/reader-subscription-list-item/connected.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External Dependencies
  */

--- a/client/blocks/reader-subscription-list-item/index.jsx
+++ b/client/blocks/reader-subscription-list-item/index.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External Dependencies
  */

--- a/client/blocks/reader-subscription-list-item/placeholder.jsx
+++ b/client/blocks/reader-subscription-list-item/placeholder.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */

--- a/client/blocks/reader-visit-link/index.jsx
+++ b/client/blocks/reader-visit-link/index.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */

--- a/client/reader/controller-helper.js
+++ b/client/reader/controller-helper.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External Dependencies
  */
@@ -42,7 +43,7 @@ export function trackPageLoad( path, title, readerView ) {
 	analytics.pageView.record( path, title );
 	analytics.mc.bumpStat(
 		'reader_views',
-		readerView === 'full_post' ? readerView : readerView + '_load',
+		readerView === 'full_post' ? readerView : readerView + '_load'
 	);
 }
 

--- a/client/reader/controller.js
+++ b/client/reader/controller.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External Dependencies
  */
@@ -43,7 +44,7 @@ function renderFeedError( context ) {
 	renderWithReduxStore(
 		React.createElement( FeedError ),
 		document.getElementById( 'primary' ),
-		context.store,
+		context.store
 	);
 }
 
@@ -124,7 +125,7 @@ const exported = {
 		renderWithReduxStore(
 			<AsyncLoad require="reader/sidebar" path={ context.path } />,
 			document.getElementById( 'secondary' ),
-			context.store,
+			context.store
 		);
 
 		next();
@@ -164,12 +165,12 @@ const exported = {
 					basePath,
 					fullAnalyticsPageTitle,
 					analyticsPageTitle,
-					mcKey,
+					mcKey
 				),
 				onUpdatesShown: trackUpdatesLoaded.bind( null, mcKey ),
 			} ),
 			'primary',
-			context.store,
+			context.store
 		);
 	},
 
@@ -211,7 +212,7 @@ const exported = {
 					basePath,
 					fullAnalyticsPageTitle,
 					analyticsPageTitle,
-					mcKey,
+					mcKey
 				) }
 				onUpdatesShown={ trackUpdatesLoaded.bind( null, mcKey ) }
 				showPrimaryFollowButtonOnCards={ false }
@@ -219,7 +220,7 @@ const exported = {
 				showBack={ userHasHistory( context ) }
 			/>,
 			document.getElementById( 'primary' ),
-			context.store,
+			context.store
 		);
 	},
 
@@ -247,7 +248,7 @@ const exported = {
 					basePath,
 					fullAnalyticsPageTitle,
 					analyticsPageTitle,
-					mcKey,
+					mcKey
 				) }
 				onUpdatesShown={ trackUpdatesLoaded.bind( null, mcKey ) }
 				showPrimaryFollowButtonOnCards={ false }
@@ -255,7 +256,7 @@ const exported = {
 				showBack={ userHasHistory( context ) }
 			/>,
 			document.getElementById( 'primary' ),
-			context.store,
+			context.store
 		);
 	},
 
@@ -283,13 +284,13 @@ const exported = {
 					basePath,
 					fullAnalyticsPageTitle,
 					analyticsPageTitle,
-					mcKey,
+					mcKey
 				) }
 				showPrimaryFollowButtonOnCards={ false }
 				onUpdatesShown={ trackUpdatesLoaded.bind( null, mcKey ) }
 			/>,
 			document.getElementById( 'primary' ),
-			context.store,
+			context.store
 		);
 	},
 };

--- a/client/reader/conversations/controller.js
+++ b/client/reader/conversations/controller.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -35,7 +36,7 @@ export function conversations( context ) {
 			trackScrollPage={ scrollTracker }
 		/>,
 		document.getElementById( 'primary' ),
-		context.store,
+		context.store
 	);
 }
 
@@ -50,7 +51,13 @@ export function conversationsA8c( context ) {
 	const convoStream = feedStreamStore( 'conversations-a8c' );
 	ensureStoreLoading( convoStream, context );
 
-	const scrollTracker = trackScrollPage.bind( null, '/read/conversations/a8c', title, 'Reader', mcKey );
+	const scrollTracker = trackScrollPage.bind(
+		null,
+		'/read/conversations/a8c',
+		title,
+		'Reader',
+		mcKey
+	);
 
 	renderWithReduxStore(
 		<AsyncLoad
@@ -61,6 +68,6 @@ export function conversationsA8c( context ) {
 			trackScrollPage={ scrollTracker }
 		/>,
 		document.getElementById( 'primary' ),
-		context.store,
+		context.store
 	);
 }

--- a/client/reader/conversations/index.js
+++ b/client/reader/conversations/index.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -16,7 +17,7 @@ export default function() {
 		updateLastRoute,
 		initAbTests,
 		sidebar,
-		conversations,
+		conversations
 	);
 
 	page(
@@ -25,6 +26,6 @@ export default function() {
 		updateLastRoute,
 		initAbTests,
 		sidebar,
-		conversationsA8c,
+		conversationsA8c
 	);
 }

--- a/client/reader/conversations/stream.js
+++ b/client/reader/conversations/stream.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External Dependencies
  */

--- a/client/reader/discover/controller.js
+++ b/client/reader/discover/controller.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -49,7 +50,7 @@ const exported = {
 					basePath,
 					fullAnalyticsPageTitle,
 					ANALYTICS_PAGE_TITLE,
-					mcKey,
+					mcKey
 				) }
 				onUpdatesShown={ trackUpdatesLoaded.bind( null, mcKey ) }
 				suppressSiteNameLink={ true }
@@ -60,7 +61,7 @@ const exported = {
 				featuredStore={ featuredStore }
 			/>,
 			document.getElementById( 'primary' ),
-			context.store,
+			context.store
 		);
 	},
 };

--- a/client/reader/discover/follow-button.jsx
+++ b/client/reader/discover/follow-button.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */

--- a/client/reader/discover/helper.js
+++ b/client/reader/discover/helper.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */

--- a/client/reader/discover/index.js
+++ b/client/reader/discover/index.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */

--- a/client/reader/discover/site-attribution.jsx
+++ b/client/reader/discover/site-attribution.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */

--- a/client/reader/discover/stats.js
+++ b/client/reader/discover/stats.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
 * Internal dependencies
 */

--- a/client/reader/discover/test/fixtures/index.js
+++ b/client/reader/discover/test/fixtures/index.js
@@ -1,3 +1,4 @@
+/** @format */
 /* eslint-disable max-len, quote-props*/
 /**
  * External dependencies

--- a/client/reader/discover/test/helper.js
+++ b/client/reader/discover/test/helper.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -112,7 +113,7 @@ describe( 'helper', () => {
 			const fixtureData = {
 				blogId: get(
 					fixtures.discoverSiteFormat,
-					'discover_metadata.featured_post_wpcom_data.blog_id',
+					'discover_metadata.featured_post_wpcom_data.blog_id'
 				),
 				postId: undefined,
 			};

--- a/client/reader/embed-helper.jsx
+++ b/client/reader/embed-helper.jsx
@@ -1,3 +1,4 @@
+/** @format */
 import percentageFactory from 'percentage-regex';
 
 const percentageRegex = percentageFactory( { exact: true } );

--- a/client/reader/feed-error/index.jsx
+++ b/client/reader/feed-error/index.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */

--- a/client/reader/feed-stream/empty.jsx
+++ b/client/reader/feed-stream/empty.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External Dependencies
  */

--- a/client/reader/feed-stream/index.jsx
+++ b/client/reader/feed-stream/index.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */

--- a/client/reader/follow-button/follow-sources.jsx
+++ b/client/reader/follow-button/follow-sources.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /* Follow Source Constants */
 export const IN_STREAM_RECOMMENDATION = 'in-stream-recommendation';
 export const EMPTY_SEARCH_RECOMMENDATIONS = 'empty-search-rec';
@@ -11,4 +12,3 @@ export const READER_FOLLOWING_MANAGE_SEARCH_RESULT = 'reader-following-manage-se
 export const READER_FOLLOWING_MANAGE_RECOMMENDATION = 'reader-following-manage-recommendation';
 export const TAG_PAGE = 'reader-tag-page';
 export const DISCOVER_POST = 'reader-discover-post';
-

--- a/client/reader/follow-button/index.jsx
+++ b/client/reader/follow-button/index.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */

--- a/client/reader/following-manage/empty.jsx
+++ b/client/reader/following-manage/empty.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */

--- a/client/reader/following-manage/feed-search-results.jsx
+++ b/client/reader/following-manage/feed-search-results.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External Dependencies
  */
@@ -62,7 +63,7 @@ class FollowingManageSearchFeedsResults extends React.Component {
 			return (
 				<div className={ classNames }>
 					{ times( 10, i =>
-						<ReaderSubscriptionListItemPlaceholder key={ `placeholder-${ i }` } />,
+						<ReaderSubscriptionListItemPlaceholder key={ `placeholder-${ i }` } />
 					) }
 				</div>
 			);
@@ -109,5 +110,5 @@ class FollowingManageSearchFeedsResults extends React.Component {
 }
 
 export default connect( null, { requestFeedSearch } )(
-	localize( FollowingManageSearchFeedsResults ),
+	localize( FollowingManageSearchFeedsResults )
 );

--- a/client/reader/following-manage/index.jsx
+++ b/client/reader/following-manage/index.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External Dependencies
  */
@@ -143,7 +144,7 @@ class FollowingManage extends Component {
 		recordTrack( 'calypso_reader_following_manage_search_more_click' );
 		recordAction( 'manage_feed_search_more' );
 		page.replace(
-			addQueryArgs( { showMoreResults: true }, window.location.pathname + window.location.search ),
+			addQueryArgs( { showMoreResults: true }, window.location.pathname + window.location.search )
 		);
 	};
 
@@ -188,7 +189,7 @@ class FollowingManage extends Component {
 		const showFollowByUrl = this.shouldShowFollowByUrl();
 		const isFollowByUrlWithNoSearchResults = showFollowByUrl && searchResultsCount === 0;
 		const filteredRecommendedSites = reject( recommendedSites, site =>
-			includes( blockedSites, site.blogId ),
+			includes( blockedSites, site.blogId )
 		);
 
 		return (

--- a/client/reader/following-manage/search-followed.jsx
+++ b/client/reader/following-manage/search-followed.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External Dependencies
  */

--- a/client/reader/following-manage/sort-controls.jsx
+++ b/client/reader/following-manage/sort-controls.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */

--- a/client/reader/following-manage/subscriptions.jsx
+++ b/client/reader/following-manage/subscriptions.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External Dependencies
  */
@@ -56,7 +57,7 @@ class FollowingManageSubscriptions extends Component {
 
 			return (
 				`${ follow.URL }${ siteName }${ siteUrl }${ siteDescription }${ siteAuthor }`.search(
-					phraseRe,
+					phraseRe
 				) !== -1
 			);
 		} );

--- a/client/reader/following/controller.js
+++ b/client/reader/following/controller.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -39,7 +40,7 @@ const exported = {
 				userSettings={ userSettings }
 			/>,
 			document.getElementById( 'primary' ),
-			context.store,
+			context.store
 		);
 	},
 };

--- a/client/reader/following/index.js
+++ b/client/reader/following/index.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */

--- a/client/reader/following/intro.jsx
+++ b/client/reader/following/intro.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -76,7 +77,7 @@ class FollowingIntro extends React.Component {
 										strong: <strong />,
 										span: <span className="following__intro-copy-hidden" />,
 									},
-								},
+								}
 							) }
 						</span>
 					</div>
@@ -121,6 +122,6 @@ export default connect(
 					return savePreference( 'is_new_reader', false );
 				},
 			},
-			dispatch,
-		),
+			dispatch
+		)
 )( localize( FollowingIntro ) );

--- a/client/reader/following/main.jsx
+++ b/client/reader/following/main.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -35,7 +36,7 @@ const FollowingStream = props => {
 			flatMap( props.suggestions, query => [
 				<Suggestion suggestion={ query.text } source="following" railcar={ query.railcar } />,
 				', ',
-			] ),
+			] )
 		);
 
 	return (

--- a/client/reader/full-post/controller.js
+++ b/client/reader/full-post/controller.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External Dependencies
  */
@@ -27,15 +28,16 @@ function renderPostNotFound() {
 			message={ i18n.translate( 'Post Not Found' ) }
 		/>,
 		document.getElementById( 'primary' ),
-		context.store,
+		context.store
 	);
 }
 
-const scrollTopIfNoHash = () => defer( () => {
-	if ( typeof window !== 'undefined' && ! window.location.hash ) {
-		window.scrollTo( 0, 0 );
-	}
-} );
+const scrollTopIfNoHash = () =>
+	defer( () => {
+		if ( typeof window !== 'undefined' && ! window.location.hash ) {
+			window.scrollTo( 0, 0 );
+		}
+	} );
 
 export function blogPost( context ) {
 	const blogId = context.params.blog,
@@ -61,7 +63,7 @@ export function blogPost( context ) {
 			onPostNotFound={ renderPostNotFound }
 		/>,
 		document.getElementById( 'primary' ),
-		context.store,
+		context.store
 	);
 	scrollTopIfNoHash();
 }
@@ -87,7 +89,7 @@ export function feedPost( context ) {
 			onPostNotFound={ renderPostNotFound }
 		/>,
 		document.getElementById( 'primary' ),
-		context.store,
+		context.store
 	);
 	scrollTopIfNoHash();
 }

--- a/client/reader/full-post/index.js
+++ b/client/reader/full-post/index.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */

--- a/client/reader/get-helpers.js
+++ b/client/reader/get-helpers.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External Dependencies
  */

--- a/client/reader/header-back/index.jsx
+++ b/client/reader/header-back/index.jsx
@@ -1,3 +1,4 @@
+/** @format */
 import React from 'react';
 
 import HeaderCake from 'components/header-cake';

--- a/client/reader/id-helpers.js
+++ b/client/reader/id-helpers.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * Convert a string or number to valid reader ID
  *

--- a/client/reader/index.js
+++ b/client/reader/index.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -50,7 +51,7 @@ export default function() {
 			prettyRedirects,
 			sidebar,
 			feedDiscovery,
-			feedListing,
+			feedListing
 		);
 
 		// Blog stream

--- a/client/reader/lib/author-name-blacklist/index.js
+++ b/client/reader/lib/author-name-blacklist/index.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External Dependencies
  */

--- a/client/reader/lib/content-width/index.js
+++ b/client/reader/lib/content-width/index.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External Dependencies
  */

--- a/client/reader/lib/feed-display-helper/index.js
+++ b/client/reader/lib/feed-display-helper/index.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * Internal dependencies
  */

--- a/client/reader/lib/site-description-blacklist/index.js
+++ b/client/reader/lib/site-description-blacklist/index.js
@@ -1,3 +1,4 @@
+/** @format */
 const siteDescriptionBlacklist = new Set( [
 	'Just another WordPress.com site',
 	'Just another WordPress site',

--- a/client/reader/lib/site-description-blacklist/test/index.js
+++ b/client/reader/lib/site-description-blacklist/test/index.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */

--- a/client/reader/lib/teams/index.js
+++ b/client/reader/lib/teams/index.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External Dependencies
  */

--- a/client/reader/lib/teams/test/index.js
+++ b/client/reader/lib/teams/test/index.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */

--- a/client/reader/like-button/index.jsx
+++ b/client/reader/like-button/index.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -25,7 +26,7 @@ class ReaderLikeButton extends React.Component {
 		recordTrackForPost(
 			liked ? 'calypso_reader_article_liked' : 'calypso_reader_article_unliked',
 			post,
-			{ context: this.props.fullPost ? 'full-post' : 'card' },
+			{ context: this.props.fullPost ? 'full-post' : 'card' }
 		);
 		if ( liked && ! this.props.fullPost && ! post._seen ) {
 			markSeen( post, this.props.site );

--- a/client/reader/like-helper.jsx
+++ b/client/reader/like-helper.jsx
@@ -1,3 +1,4 @@
+/** @format */
 // Internal dependencies
 import { isDiscoverPost, isInternalDiscoverPost, isDiscoverSitePick } from 'reader/discover/helper';
 

--- a/client/reader/liked-stream/controller.js
+++ b/client/reader/liked-stream/controller.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -39,12 +40,12 @@ const exported = {
 					basePath,
 					fullAnalyticsPageTitle,
 					analyticsPageTitle,
-					mcKey,
+					mcKey
 				),
 				onUpdatesShown: trackUpdatesLoaded.bind( null, mcKey ),
 			} ),
 			document.getElementById( 'primary' ),
-			context.store,
+			context.store
 		);
 	},
 };

--- a/client/reader/liked-stream/empty.jsx
+++ b/client/reader/liked-stream/empty.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */

--- a/client/reader/liked-stream/index.js
+++ b/client/reader/liked-stream/index.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */

--- a/client/reader/liked-stream/main.jsx
+++ b/client/reader/liked-stream/main.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */

--- a/client/reader/list-gap/index.jsx
+++ b/client/reader/list-gap/index.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External Dependencies
  */

--- a/client/reader/list-item/actions.jsx
+++ b/client/reader/list-item/actions.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */

--- a/client/reader/list-item/description.jsx
+++ b/client/reader/list-item/description.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */

--- a/client/reader/list-item/icon.jsx
+++ b/client/reader/list-item/icon.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */

--- a/client/reader/list-item/index.jsx
+++ b/client/reader/list-item/index.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */

--- a/client/reader/list-item/title.jsx
+++ b/client/reader/list-item/title.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */

--- a/client/reader/list-stream/empty.jsx
+++ b/client/reader/list-stream/empty.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */

--- a/client/reader/list-stream/header.jsx
+++ b/client/reader/list-stream/header.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */

--- a/client/reader/list-stream/index.jsx
+++ b/client/reader/list-stream/index.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -36,7 +37,7 @@ class ListStream extends React.Component {
 		recordAction( isFollowRequested ? 'followed_list' : 'unfollowed_list' );
 		recordGaEvent(
 			isFollowRequested ? 'Clicked Follow List' : 'Clicked Unfollow List',
-			list.owner + ':' + list.slug,
+			list.owner + ':' + list.slug
 		);
 		recordTrack(
 			isFollowRequested
@@ -45,7 +46,7 @@ class ListStream extends React.Component {
 			{
 				list_owner: list.owner,
 				list_slug: list.slug,
-			},
+			}
 		);
 	};
 
@@ -119,7 +120,7 @@ export default connect(
 				followList,
 				unfollowList,
 			},
-			dispatch,
+			dispatch
 		);
-	},
+	}
 )( localize( ListStream ) );

--- a/client/reader/list-stream/missing.jsx
+++ b/client/reader/list-stream/missing.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */

--- a/client/reader/list/controller.js
+++ b/client/reader/list/controller.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -48,12 +49,12 @@ const exported = {
 					basePath,
 					fullAnalyticsPageTitle,
 					analyticsPageTitle,
-					mcKey,
+					mcKey
 				) }
 				onUpdatesShown={ trackUpdatesLoaded.bind( null, mcKey ) }
 			/>,
 			document.getElementById( 'primary' ),
-			context.store,
+			context.store
 		);
 	},
 };

--- a/client/reader/list/index.js
+++ b/client/reader/list/index.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */

--- a/client/reader/post-excerpt-link/index.jsx
+++ b/client/reader/post-excerpt-link/index.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -69,7 +70,7 @@ class PostExcerptLink extends React.Component {
 				</svg>
 				<p className="post-excerpt-link__helper">
 					{ this.props.translate(
-						"The owner of this site only allows us to show a brief summary of their content. To view the full post, you'll have to visit their site.",
+						"The owner of this site only allows us to show a brief summary of their content. To view the full post, you'll have to visit their site."
 					) }
 				</p>
 			</div>

--- a/client/reader/post-excerpt-link/index.jsx
+++ b/client/reader/post-excerpt-link/index.jsx
@@ -53,7 +53,8 @@ class PostExcerptLink extends React.Component {
 			'post-excerpt-link': true,
 			'is-showing-notice': this.state.isShowingNotice,
 		} );
-
+		/*eslint-disable wpcalypso/jsx-classname-namespace*/
+		/*eslint-disable max-len*/
 		return (
 			<div className={ classes }>
 				{ this.props.translate( 'Visit {{siteName/}} for the full post.', {
@@ -70,7 +71,8 @@ class PostExcerptLink extends React.Component {
 				</svg>
 				<p className="post-excerpt-link__helper">
 					{ this.props.translate(
-						"The owner of this site only allows us to show a brief summary of their content. To view the full post, you'll have to visit their site."
+						'The owner of this site only allows us to show a brief summary of their content.' +
+							"To view the full post, you'll have to visit their site."
 					) }
 				</p>
 			</div>

--- a/client/reader/post-time/index.jsx
+++ b/client/reader/post-time/index.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */

--- a/client/reader/reading-time/index.jsx
+++ b/client/reader/reading-time/index.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */

--- a/client/reader/recommendations/controller.js
+++ b/client/reader/recommendations/controller.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -73,13 +74,13 @@ const exported = {
 					basePath,
 					fullAnalyticsPageTitle,
 					ANALYTICS_PAGE_TITLE,
-					mcKey,
+					mcKey
 				),
 				onUpdatesShown: trackUpdatesLoaded.bind( null, mcKey ),
 				showBack: userHasHistory( context ),
 			} ),
 			document.getElementById( 'primary' ),
-			context.store,
+			context.store
 		);
 	},
 };

--- a/client/reader/recommendations/global-tags/index.jsx
+++ b/client/reader/recommendations/global-tags/index.jsx
@@ -1,3 +1,4 @@
+/** @format */
 import React from 'react';
 import Main from 'components/main';
 import Navigation from 'reader/recommendations/navigation';

--- a/client/reader/recommendations/index.js
+++ b/client/reader/recommendations/index.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -37,7 +38,7 @@ export default function() {
 					sidebar,
 					recommendedPosts,
 				] );
-			},
+			}
 		);
 	}
 }

--- a/client/reader/recommendations/navigation/index.jsx
+++ b/client/reader/recommendations/navigation/index.jsx
@@ -1,3 +1,4 @@
+/** @format */
 import React, { PropTypes } from 'react';
 import { localize } from 'i18n-calypso';
 import SectionNav from 'components/section-nav';

--- a/client/reader/recommendations/posts/empty.jsx
+++ b/client/reader/recommendations/posts/empty.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -52,7 +53,7 @@ class RecommendedPostsEmptyContent extends React.Component {
 			<EmptyContent
 				title={ this.props.translate( 'No Post Recommendations yet' ) }
 				line={ this.props.translate(
-					'Posts we recommend based on your WordPress.com activity will appear here.',
+					'Posts we recommend based on your WordPress.com activity will appear here.'
 				) }
 				action={ action }
 				secondaryAction={ secondaryAction }

--- a/client/reader/recommendations/posts/index.jsx
+++ b/client/reader/recommendations/posts/index.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */

--- a/client/reader/recommendations/sites/index.jsx
+++ b/client/reader/recommendations/sites/index.jsx
@@ -1,3 +1,4 @@
+/** @format */
 import React from 'react';
 import Main from 'components/main';
 import Navigation from 'reader/recommendations/navigation';

--- a/client/reader/route/index.js
+++ b/client/reader/route/index.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * Internal dependencies
  */

--- a/client/reader/route/test/index.js
+++ b/client/reader/route/test/index.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */

--- a/client/reader/search-stream/empty.jsx
+++ b/client/reader/search-stream/empty.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */

--- a/client/reader/search-stream/index.jsx
+++ b/client/reader/search-stream/index.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External Dependencies
  */
@@ -44,13 +45,12 @@ const SpacerDiv = withDimensions( ( { width, height } ) =>
 			width: `${ width }px`,
 			height: `${ height }px`,
 		} }
-	/>,
+	/>
 );
 
 class SearchStream extends React.Component {
 	static propTypes = {
 		query: PropTypes.string,
-
 	};
 
 	componentWillReceiveProps( nextProps ) {
@@ -156,7 +156,7 @@ class SearchStream extends React.Component {
 					railcar={ suggestion.railcar }
 				/>,
 				', ',
-			] ),
+			] )
 		);
 
 		return (

--- a/client/reader/search-stream/post-results.jsx
+++ b/client/reader/search-stream/post-results.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External Dependencies
  */

--- a/client/reader/search-stream/search-stream-header.jsx
+++ b/client/reader/search-stream/search-stream-header.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External Dependencies
  */

--- a/client/reader/search-stream/site-results.jsx
+++ b/client/reader/search-stream/site-results.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External Dependencies
  */
@@ -73,5 +74,5 @@ export default connect(
 			sort: ownProps.sort,
 		} ),
 	} ),
-	{ requestFeedSearch },
+	{ requestFeedSearch }
 )( localize( withDimensions( SiteResults ) ) );

--- a/client/reader/search-stream/suggestion-provider.jsx
+++ b/client/reader/search-stream/suggestion-provider.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External Dependencies
  */

--- a/client/reader/search-stream/suggestion.jsx
+++ b/client/reader/search-stream/suggestion.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External Dependencies
  */

--- a/client/reader/search-stream/suggestions.js
+++ b/client/reader/search-stream/suggestions.js
@@ -1,3 +1,4 @@
+/** @format */
 export const suggestions = {
 	en: [
 		'Anime',

--- a/client/reader/search/controller.js
+++ b/client/reader/search/controller.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -80,7 +81,7 @@ const exported = {
 					basePath,
 					fullAnalyticsPageTitle,
 					analyticsPageTitle,
-					mcKey,
+					mcKey
 				) }
 				onUpdatesShown={ trackUpdatesLoaded.bind( null, mcKey ) }
 				showBack={ false }
@@ -91,7 +92,7 @@ const exported = {
 				searchType={ show }
 			/>,
 			document.getElementById( 'primary' ),
-			context.store,
+			context.store
 		);
 	},
 };

--- a/client/reader/search/index.js
+++ b/client/reader/search/index.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */

--- a/client/reader/sidebar/expandable-add-form.jsx
+++ b/client/reader/sidebar/expandable-add-form.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External Dependencies
  */

--- a/client/reader/sidebar/expandable-heading.jsx
+++ b/client/reader/sidebar/expandable-heading.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */

--- a/client/reader/sidebar/expandable.jsx
+++ b/client/reader/sidebar/expandable.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External Dependencies
  */

--- a/client/reader/sidebar/helper.js
+++ b/client/reader/sidebar/helper.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -31,8 +32,8 @@ const exported = {
 		return classNames(
 			assign(
 				{ selected: selected, 'is-action-button-selected': isActionButtonSelected },
-				additionalClasses,
-			),
+				additionalClasses
+			)
 		);
 	},
 

--- a/client/reader/sidebar/index.jsx
+++ b/client/reader/sidebar/index.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -162,10 +163,7 @@ export const ReaderSidebar = createReactClass( {
 									'sidebar-streams__following': true,
 								} ) }
 							>
-								<a
-									href="/"
-									onClick={ this.handleReaderSidebarFollowedSitesClicked }
-								>
+								<a href="/" onClick={ this.handleReaderSidebarFollowedSitesClicked }>
 									<Gridicon icon="checkmark-circle" size={ 24 } />
 									<span className="menu-link-text">
 										{ this.props.translate( 'Followed Sites' ) }
@@ -186,7 +184,7 @@ export const ReaderSidebar = createReactClass( {
 										this.props.path,
 										{
 											'sidebar-streams__conversations': true,
-										},
+										}
 									) }
 								>
 									<a
@@ -201,14 +199,14 @@ export const ReaderSidebar = createReactClass( {
 								</li> }
 							<ReaderSidebarTeams teams={ this.props.teams } path={ this.props.path } />
 							{ config.isEnabled( 'reader/conversations' ) &&
-									isAutomatticTeamMember( this.props.teams ) &&
+								isAutomatticTeamMember( this.props.teams ) &&
 								<li
 									className={ ReaderSidebarHelper.itemLinkClass(
 										'/read/conversations/a8c',
 										this.props.path,
 										{
 											'sidebar-streams__conversations': true,
-										},
+										}
 									) }
 								>
 									<a
@@ -225,9 +223,7 @@ export const ReaderSidebar = createReactClass( {
 											<path d="M7.99 1.57C3.75 1.57 1 4.57 1 7.8v0.4c0 3.18 2.75 6.24 6.99 6.24 4.26 0 7.01-3.05 7.01-6.24V7.8C15 4.57 12.25 1.57 7.99 1.57zM12.74 8.13c0 2.32-1.69 4.42-4.74 4.42 -3.05 0-4.73-2.1-4.73-4.42V7.84c0-2.32 1.67-4.38 4.73-4.38 3.06 0 4.75 2.07 4.75 4.39V8.13z" />
 											<path d="M9.47 5.73C9.07 5.47 8.52 5.59 8.26 6L6.21 9.17c-0.26 0.41-0.15 0.95 0.26 1.21 0.4 0.26 0.95 0.14 1.21-0.26l2.05-3.17C9.99 6.53 9.88 5.99 9.47 5.73z" />
 										</svg>
-										<span className="menu-link-text">
-											A8C Conversations
-										</span>
+										<span className="menu-link-text">A8C Conversations</span>
 									</a>
 								</li> }
 
@@ -237,10 +233,7 @@ export const ReaderSidebar = createReactClass( {
 											'sidebar-streams__discover': true,
 										} ) }
 									>
-										<a
-											href="/discover"
-											onClick={ this.handleReaderSidebarDiscoverClicked }
-										>
+										<a href="/discover" onClick={ this.handleReaderSidebarDiscoverClicked }>
 											<Gridicon icon="my-sites" />
 											<span className="menu-link-text">
 												{ this.props.translate( 'Discover' ) }
@@ -255,10 +248,7 @@ export const ReaderSidebar = createReactClass( {
 										'sidebar-streams__search': true,
 									} ) }
 								>
-									<a
-										href="/read/search"
-										onClick={ this.handleReaderSidebarSearchClicked }
-									>
+									<a href="/read/search" onClick={ this.handleReaderSidebarSearchClicked }>
 										<Gridicon icon="search" size={ 24 } />
 										<span className="menu-link-text">
 											{ this.props.translate( 'Search' ) }
@@ -270,13 +260,10 @@ export const ReaderSidebar = createReactClass( {
 								className={ ReaderSidebarHelper.itemLinkClass(
 									'/activities/likes',
 									this.props.path,
-									{ 'sidebar-activity__likes': true },
+									{ 'sidebar-activity__likes': true }
 								) }
 							>
-								<a
-									href="/activities/likes"
-									onClick={ this.handleReaderSidebarLikeActivityClicked }
-								>
+								<a href="/activities/likes" onClick={ this.handleReaderSidebarLikeActivityClicked }>
 									<Gridicon icon="star" size={ 24 } />
 									<span className="menu-link-text">
 										{ this.props.translate( 'My Likes' ) }
@@ -369,7 +356,7 @@ export default connect(
 				toggleTagsVisibility: toggleReaderSidebarTags,
 				setNextLayoutFocus,
 			},
-			dispatch,
+			dispatch
 		);
-	},
+	}
 )( localize( ReaderSidebar ) );

--- a/client/reader/sidebar/reader-sidebar-lists/index.jsx
+++ b/client/reader/sidebar/reader-sidebar-lists/index.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External Dependencies
  */

--- a/client/reader/sidebar/reader-sidebar-lists/list-item.jsx
+++ b/client/reader/sidebar/reader-sidebar-lists/list-item.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External Dependencies
  */

--- a/client/reader/sidebar/reader-sidebar-lists/list.jsx
+++ b/client/reader/sidebar/reader-sidebar-lists/list.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External Dependencies
  */

--- a/client/reader/sidebar/reader-sidebar-tags/index.jsx
+++ b/client/reader/sidebar/reader-sidebar-tags/index.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External Dependencies
  */
@@ -93,5 +94,5 @@ export default connect(
 	{
 		followTag: requestFollowTag,
 		unfollowTag: requestUnfollowTag,
-	},
+	}
 )( localize( ReaderSidebarTags ) );

--- a/client/reader/sidebar/reader-sidebar-tags/list-item.jsx
+++ b/client/reader/sidebar/reader-sidebar-tags/list-item.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External Dependencies
  */

--- a/client/reader/sidebar/reader-sidebar-tags/list.jsx
+++ b/client/reader/sidebar/reader-sidebar-tags/list.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External Dependencies
  */

--- a/client/reader/sidebar/reader-sidebar-teams/index.jsx
+++ b/client/reader/sidebar/reader-sidebar-teams/index.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External Dependencies
  */
@@ -11,7 +12,7 @@ import ReaderSidebarTeamsListItem from './list-item';
 
 const renderItems = ( teams, path ) =>
 	map( teams, team =>
-		<ReaderSidebarTeamsListItem key={ team.slug } team={ team } path={ path } />,
+		<ReaderSidebarTeamsListItem key={ team.slug } team={ team } path={ path } />
 	);
 
 export class ReaderSidebarTeams extends Component {

--- a/client/reader/sidebar/reader-sidebar-teams/list-item.jsx
+++ b/client/reader/sidebar/reader-sidebar-teams/list-item.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External Dependencies
  */

--- a/client/reader/sidebar/test/index.jsx
+++ b/client/reader/sidebar/test/index.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -70,7 +71,7 @@ describe( 'ReaderSidebar', () => {
 					shouldRenderAppPromo( {
 						...shouldRenderAppPromoDefaultProps,
 						isDesktopPromoDisabled: true,
-					} ),
+					} )
 				).to.be.false;
 			} );
 
@@ -79,19 +80,19 @@ describe( 'ReaderSidebar', () => {
 					shouldRenderAppPromo( {
 						...shouldRenderAppPromoDefaultProps,
 						isUserLocaleEnglish: false,
-					} ),
+					} )
 				).to.be.false;
 			} );
 
 			it( 'should not render if the viewport is mobile', () => {
 				expect(
-					shouldRenderAppPromo( { ...shouldRenderAppPromoDefaultProps, isViewportMobile: true } ),
+					shouldRenderAppPromo( { ...shouldRenderAppPromoDefaultProps, isViewportMobile: true } )
 				).to.be.false;
 			} );
 
 			it( "should not render if it's ChromeOS", () => {
 				expect(
-					shouldRenderAppPromo( { ...shouldRenderAppPromoDefaultProps, isUserOnChromeOs: true } ),
+					shouldRenderAppPromo( { ...shouldRenderAppPromoDefaultProps, isUserOnChromeOs: true } )
 				).to.be.false;
 			} );
 
@@ -100,7 +101,7 @@ describe( 'ReaderSidebar', () => {
 					shouldRenderAppPromo( {
 						...shouldRenderAppPromoDefaultProps,
 						isDesktopPromoConfiguredToRun: false,
-					} ),
+					} )
 				).to.be.false;
 			} );
 
@@ -109,7 +110,7 @@ describe( 'ReaderSidebar', () => {
 					shouldRenderAppPromo( {
 						...shouldRenderAppPromoDefaultProps,
 						isUserDesktopAppUser: true,
-					} ),
+					} )
 				).to.be.false;
 			} );
 

--- a/client/reader/site-stream/empty.jsx
+++ b/client/reader/site-stream/empty.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */

--- a/client/reader/site-stream/featured.jsx
+++ b/client/reader/site-stream/featured.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External Dependencies
  */
@@ -148,5 +149,5 @@ export default localize(
 				</Card>
 			);
 		}
-	},
+	}
 );

--- a/client/reader/site-stream/index.jsx
+++ b/client/reader/site-stream/index.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */

--- a/client/reader/stats.js
+++ b/client/reader/stats.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External Dependencies
  */
@@ -133,18 +134,18 @@ export function recordTracksRailcar( action, eventName, railcar, overrides = {} 
 		Object.assign(
 			eventName ? { action: eventName.replace( 'calypso_reader_', '' ) } : {},
 			railcar,
-			overrides,
-		),
+			overrides
+		)
 	);
 }
 
 export const recordTracksRailcarRender = partial(
 	recordTracksRailcar,
-	'calypso_traintracks_render',
+	'calypso_traintracks_render'
 );
 export const recordTracksRailcarInteract = partial(
 	recordTracksRailcar,
-	'calypso_traintracks_interact',
+	'calypso_traintracks_interact'
 );
 
 export function recordTrackForPost( eventName, post = {}, additionalProps = {} ) {
@@ -158,15 +159,15 @@ export function recordTrackForPost( eventName, post = {}, additionalProps = {} )
 				feed_item_id: post.feed_item_ID > 0 ? post.feed_item_ID : undefined,
 				is_jetpack: post.is_jetpack,
 			},
-			additionalProps,
-		),
+			additionalProps
+		)
 	);
 	if ( post.railcar && tracksRailcarEventWhitelist.has( eventName ) ) {
 		// check for overrides for the railcar
 		recordTracksRailcarInteract(
 			eventName,
 			post.railcar,
-			pick( additionalProps, [ 'ui_position', 'ui_algo' ] ),
+			pick( additionalProps, [ 'ui_position', 'ui_algo' ] )
 		);
 	} else if ( process.env.NODE_ENV !== 'production' && post.railcar ) {
 		console.warn( 'Consider whitelisting reader track', eventName ); //eslint-disable-line no-console
@@ -178,7 +179,7 @@ export function recordTrackWithRailcar( eventName, railcar, eventProperties ) {
 	recordTracksRailcarInteract(
 		eventName,
 		railcar,
-		pick( eventProperties, [ 'ui_position', 'ui_algo' ] ),
+		pick( eventProperties, [ 'ui_position', 'ui_algo' ] )
 	);
 }
 

--- a/client/reader/stream/empty-search-recommended-post.jsx
+++ b/client/reader/stream/empty-search-recommended-post.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */

--- a/client/reader/stream/empty.jsx
+++ b/client/reader/stream/empty.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -64,7 +65,7 @@ function getDistanceBetweenRecs( totalSubs ) {
 	const distance = clamp(
 		Math.floor( Math.log( totalSubs ) * Math.LOG2E * 5 - 6 ),
 		MIN_DISTANCE_BETWEEN_RECS,
-		MAX_DISTANCE_BETWEEN_RECS,
+		MAX_DISTANCE_BETWEEN_RECS
 	);
 	return distance;
 }
@@ -282,7 +283,7 @@ class ReaderStream extends React.Component {
 
 	isPostFullScreen() {
 		return !! window.location.pathname.match(
-			/^\/read\/(blogs|feeds)\/([0-9]+)\/posts\/([0-9]+)$/i,
+			/^\/read\/(blogs|feeds)\/([0-9]+)\/posts\/([0-9]+)$/i
 		);
 	}
 
@@ -408,7 +409,7 @@ class ReaderStream extends React.Component {
 			selectedPostKey &&
 			selectedPostKey.postId === postKey.postId &&
 			( selectedPostKey.blogId === postKey.blogId || selectedPostKey.feedId === postKey.feedId )
-		 );
+		);
 
 		const itemKey = this.getPostRef( postKey );
 		const showPost = args =>
@@ -484,9 +485,7 @@ class ReaderStream extends React.Component {
 				<UpdateNotice count={ this.state.updateCount } onClick={ this.showUpdates } />
 				{ this.props.children }
 				{ body }
-				{ showingStream && store.isLastPage() && this.state.posts.length
-					? <ListEnd />
-					: null }
+				{ showingStream && store.isLastPage() && this.state.posts.length ? <ListEnd /> : null }
 			</TopLevel>
 		);
 	}
@@ -498,6 +497,6 @@ export default localize(
 			blockedSites: getBlockedSites( state ),
 			totalSubs: getReaderFollows( state ).length,
 		} ),
-		{ resetCardExpansions },
-	)( ReaderStream ),
+		{ resetCardExpansions }
+	)( ReaderStream )
 );

--- a/client/reader/stream/post-lifecycle.jsx
+++ b/client/reader/stream/post-lifecycle.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External Dependencies
  */
@@ -126,7 +127,7 @@ export default class PostLifecycle extends React.PureComponent {
 		} else if ( isXPost( post ) ) {
 			const xMetadata = XPostHelper.getXPostMetadata( post );
 			const xPostedTo = this.props.store.getSitesCrossPostedTo(
-				xMetadata.commentURL || xMetadata.postURL,
+				xMetadata.commentURL || xMetadata.postURL
 			);
 			return (
 				<CrossPost

--- a/client/reader/stream/post-placeholder.jsx
+++ b/client/reader/stream/post-placeholder.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */

--- a/client/reader/stream/post-unavailable.jsx
+++ b/client/reader/stream/post-unavailable.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -14,7 +15,7 @@ class PostUnavailable extends React.PureComponent {
 	componentWillMount() {
 		this.errors = {
 			unauthorized: this.props.translate(
-				'This is a post on a private site that you’re following, but not currently a member of. Please request membership to display these posts in Reader.',
+				'This is a post on a private site that you’re following, but not currently a member of. Please request membership to display these posts in Reader.'
 			),
 			default: this.props.translate( 'An error occurred loading this post.' ),
 		};

--- a/client/reader/stream/post-unavailable.jsx
+++ b/client/reader/stream/post-unavailable.jsx
@@ -1,4 +1,5 @@
 /** @format */
+/** @format */
 /**
  * External dependencies
  */
@@ -15,7 +16,8 @@ class PostUnavailable extends React.PureComponent {
 	componentWillMount() {
 		this.errors = {
 			unauthorized: this.props.translate(
-				'This is a post on a private site that you’re following, but not currently a member of. Please request membership to display these posts in Reader.'
+				'This is a post on a private site that you’re following, but not currently a member of.' +
+					'Please request membership to display these posts in Reader.'
 			),
 			default: this.props.translate( 'An error occurred loading this post.' ),
 		};

--- a/client/reader/stream/post.jsx
+++ b/client/reader/stream/post.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */

--- a/client/reader/stream/recommended-posts.jsx
+++ b/client/reader/stream/recommended-posts.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External Dependencies
  */

--- a/client/reader/stream/test/utils.js
+++ b/client/reader/stream/test/utils.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -90,7 +91,7 @@ describe( 'reader stream', () => {
 		it( 'recs should never be marked as sameSite', () => {
 			const isSame = sameSite(
 				{ ...postKey1, isRecommendationBlock: 'isRecommendationBlock' },
-				postKey1,
+				postKey1
 			);
 			assert.isNotTrue( isSame );
 		} );

--- a/client/reader/stream/utils.js
+++ b/client/reader/stream/utils.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */

--- a/client/reader/stream/x-post.jsx
+++ b/client/reader/stream/x-post.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External Dependencies
  */
@@ -97,7 +98,7 @@ class CrossPost extends PureComponent {
 						label: <span className="reader__x-post-label" />,
 						blogNames: this.getXPostedToContent(),
 					},
-				},
+				}
 			);
 		} else {
 			label = this.props.translate(
@@ -112,7 +113,7 @@ class CrossPost extends PureComponent {
 						label: <span className="reader__x-post-label" />,
 						blogNames: this.getXPostedToContent(),
 					},
-				},
+				}
 			);
 		}
 		return label;

--- a/client/reader/tag-stream/controller.js
+++ b/client/reader/tag-stream/controller.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -52,7 +53,7 @@ export const tagListing = context => {
 				basePath,
 				fullAnalyticsPageTitle,
 				analyticsPageTitle,
-				mcKey,
+				mcKey
 			) }
 			onUpdatesShown={ trackUpdatesLoaded.bind( null, mcKey ) } // eslint-disable-line
 			showBack={ !! context.lastRoute }
@@ -60,6 +61,6 @@ export const tagListing = context => {
 			followSource={ TAG_PAGE }
 		/>,
 		document.getElementById( 'primary' ),
-		context.store,
+		context.store
 	);
 };

--- a/client/reader/tag-stream/empty.jsx
+++ b/client/reader/tag-stream/empty.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -59,7 +60,7 @@ class TagEmptyContent extends React.Component {
 						</em>
 					),
 				},
-			},
+			}
 		);
 
 		return (

--- a/client/reader/tag-stream/header.jsx
+++ b/client/reader/tag-stream/header.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */

--- a/client/reader/tag-stream/index.js
+++ b/client/reader/tag-stream/index.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */

--- a/client/reader/tag-stream/main.jsx
+++ b/client/reader/tag-stream/main.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External Dependencies
  */
@@ -83,13 +84,13 @@ class TagStream extends React.Component {
 		recordAction( isFollowing ? 'unfollowed_topic' : 'followed_topic' );
 		recordGaEvent(
 			isFollowing ? 'Clicked Unfollow Topic' : 'Clicked Follow Topic',
-			decodedTagSlug,
+			decodedTagSlug
 		);
 		recordTrack(
 			isFollowing ? 'calypso_reader_reader_tag_unfollowed' : 'calypso_reader_reader_tag_followed',
 			{
 				tag: decodedTagSlug,
-			},
+			}
 		);
 	};
 
@@ -139,5 +140,5 @@ export default connect(
 	{
 		followTag: requestFollowTag,
 		unfollowTag: requestUnfollowTag,
-	},
+	}
 )( localize( TagStream ) );

--- a/client/reader/team/main.jsx
+++ b/client/reader/team/main.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */

--- a/client/reader/test/get-helpers.js
+++ b/client/reader/test/get-helpers.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External Dependencies
  */
@@ -94,7 +95,7 @@ describe( '#getSiteName', () => {
 
 	it( 'should fallback to post if neither site or feed exist', () => {
 		expect( getSiteName( { site: {}, feed: {}, post: postWithSiteName } ) ).eql(
-			postWithSiteName.site_name,
+			postWithSiteName.site_name
 		);
 
 		expect( getSiteName( { post: postWithSiteName } ) ).eql( postWithSiteName.site_name );

--- a/client/reader/test/id-helpers.js
+++ b/client/reader/test/id-helpers.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External Dependencies
  */

--- a/client/reader/test/utils.js
+++ b/client/reader/test/utils.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */

--- a/client/reader/update-notice/index.jsx
+++ b/client/reader/update-notice/index.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External Dependencies
  */

--- a/client/reader/utils.js
+++ b/client/reader/utils.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External Dependencies
  */
@@ -105,7 +106,7 @@ export function showFullPost( { post, replaceHistory, comments } ) {
 	const method = replaceHistory ? 'replace' : 'show';
 	if ( post.feed_ID && post.feed_item_ID ) {
 		page[ method ](
-			`/read/feeds/${ post.feed_ID }/posts/${ post.feed_item_ID }${ hashtag }${ query }`,
+			`/read/feeds/${ post.feed_ID }/posts/${ post.feed_item_ID }${ hashtag }${ query }`
 		);
 	} else {
 		page[ method ]( `/read/blogs/${ post.site_ID }/posts/${ post.ID }${ hashtag }${ query }` );

--- a/client/reader/xpost-helper.js
+++ b/client/reader/xpost-helper.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */

--- a/client/state/data-layer/wpcom/read/feed/index.js
+++ b/client/state/data-layer/wpcom/read/feed/index.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -33,7 +34,7 @@ export function initiateFeedSearch( store, action ) {
 			},
 			onSuccess: action,
 			onFailure: action,
-		} ),
+		} )
 	);
 }
 

--- a/client/state/data-layer/wpcom/read/feed/test/index.js
+++ b/client/state/data-layer/wpcom/read/feed/test/index.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -36,7 +37,7 @@ describe( 'wpcom-api', () => {
 						query: { q: query, offset: 0, exclude_followed: true, sort: 'relevance' },
 						onSuccess: action,
 						onFailure: action,
-					} ),
+					} )
 				);
 			} );
 
@@ -55,7 +56,7 @@ describe( 'wpcom-api', () => {
 						query: { q: query, offset: 0, exclude_followed: false, sort: 'relevance' },
 						onSuccess: action,
 						onFailure: action,
-					} ),
+					} )
 				);
 			} );
 
@@ -74,7 +75,7 @@ describe( 'wpcom-api', () => {
 						query: { q: query, offset: 10, exclude_followed: true, sort: 'relevance' },
 						onSuccess: action,
 						onFailure: action,
-					} ),
+					} )
 				);
 			} );
 		} );
@@ -98,8 +99,8 @@ describe( 'wpcom-api', () => {
 								subscribe_URL: 'feedUrl',
 							},
 						],
-						200,
-					),
+						200
+					)
 				);
 			} );
 		} );

--- a/client/state/data-layer/wpcom/read/following/mine/delete/index.js
+++ b/client/state/data-layer/wpcom/read/following/mine/delete/index.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External Dependencies
  */
@@ -30,7 +31,7 @@ export function requestUnfollow( { dispatch, getState }, action ) {
 			},
 			onSuccess: action,
 			onFailure: action,
-		} ),
+		} )
 	);
 
 	// build up a notice to show
@@ -43,8 +44,8 @@ export function requestUnfollow( { dispatch, getState }, action ) {
 			translate( "You're no longer following %(siteTitle)s", { args: { siteTitle } } ),
 			{
 				duration: 5000,
-			},
-		),
+			}
+		)
 	);
 }
 
@@ -67,8 +68,8 @@ export function unfollowError( { dispatch, getState }, action ) {
 				args: {
 					siteTitle,
 				},
-			} ),
-		),
+			} )
+		)
 	);
 	dispatch( local( follow( action.payload.feedUrl ) ) );
 }

--- a/client/state/data-layer/wpcom/read/following/mine/delete/test/index.js
+++ b/client/state/data-layer/wpcom/read/following/mine/delete/test/index.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External Dependencies
  */
@@ -40,7 +41,7 @@ describe( 'following/mine/delete', () => {
 					},
 					onSuccess: action,
 					onFailure: action,
-				} ),
+				} )
 			);
 
 			expect( dispatch ).to.be.calledWithMatch( { type: NOTICE_CREATE, notice: { status: null } } );

--- a/client/state/data-layer/wpcom/read/following/mine/index.js
+++ b/client/state/data-layer/wpcom/read/following/mine/index.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -58,7 +59,7 @@ export function requestPage( store, action ) {
 			},
 			onSuccess: action,
 			onError: action,
-		} ),
+		} )
 	);
 }
 
@@ -76,7 +77,7 @@ export function receivePage( store, action, next, apiResponse ) {
 		receiveFollowsAction( {
 			follows,
 			totalCount: apiResponse.total_subscriptions,
-		} ),
+		} )
 	);
 
 	forEach( follows, follow => {
@@ -104,7 +105,7 @@ export function updateSeenOnFollow( store, action ) {
 export function receiveError( store ) {
 	syncingFollows = false;
 	store.dispatch(
-		errorNotice( translate( 'Sorry, we had a problem fetching your Reader subscriptions.' ) ),
+		errorNotice( translate( 'Sorry, we had a problem fetching your Reader subscriptions.' ) )
 	);
 }
 

--- a/client/state/data-layer/wpcom/read/following/mine/new/index.js
+++ b/client/state/data-layer/wpcom/read/following/mine/new/index.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External Dependencies
  */
@@ -32,7 +33,7 @@ export function requestFollow( { dispatch, getState }, action ) {
 			},
 			onSuccess: action,
 			onFailure: action,
-		} ),
+		} )
 	);
 
 	// build up a notice to show
@@ -42,7 +43,7 @@ export function requestFollow( { dispatch, getState }, action ) {
 	dispatch(
 		successNotice( translate( "You're now following %(siteTitle)s", { args: { siteTitle } } ), {
 			duration: 5000,
-		} ),
+		} )
 	);
 }
 
@@ -61,8 +62,8 @@ export function followError( { dispatch }, action, next, response ) {
 			translate( 'Sorry, there was a problem following %(url)s. Please try again.', {
 				args: { url: action.payload.feedUrl },
 			} ),
-			{ duration: 5000 },
-		),
+			{ duration: 5000 }
+		)
 	);
 
 	if ( response && response.info ) {

--- a/client/state/data-layer/wpcom/read/following/mine/new/test/index.js
+++ b/client/state/data-layer/wpcom/read/following/mine/new/test/index.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External Dependencies
  */
@@ -40,7 +41,7 @@ describe( 'requestFollow', () => {
 				},
 				onSuccess: action,
 				onFailure: action,
-			} ),
+			} )
 		);
 
 		expect( dispatch ).to.be.calledWithMatch( {
@@ -78,8 +79,8 @@ describe( 'receiveFollow', () => {
 					date_subscribed: 211636800000,
 					delivery_methods: {},
 					is_owner: false,
-				} ),
-			),
+				} )
+			)
 		);
 	} );
 

--- a/client/state/data-layer/wpcom/read/following/mine/test/index.js
+++ b/client/state/data-layer/wpcom/read/following/mine/test/index.js
@@ -1,3 +1,4 @@
+/** @format */
 /*
  * External dependencies
  */
@@ -84,7 +85,7 @@ describe( 'get follow subscriptions', () => {
 					query: { page: 1, number: 200, meta: '' },
 					onSuccess: action,
 					onError: action,
-				} ),
+				} )
 			);
 		} );
 	} );
@@ -105,7 +106,7 @@ describe( 'get follow subscriptions', () => {
 				receiveFollowsAction( {
 					follows: subscriptionsFromApi( successfulApiResponse ),
 					totalCount: successfulApiResponse.total_subscriptions,
-				} ),
+				} )
 			);
 		} );
 
@@ -143,10 +144,10 @@ describe( 'get follow subscriptions', () => {
 				receiveFollowsAction( {
 					follows: [],
 					totalCount: 10,
-				} ),
+				} )
 			);
 			expect( dispatch ).to.have.been.calledWith(
-				syncComplete( [ 'http://readerpostcards.wordpress.com', 'https://fivethirtyeight.com/' ] ),
+				syncComplete( [ 'http://readerpostcards.wordpress.com', 'https://fivethirtyeight.com/' ] )
 			);
 		} );
 
@@ -187,7 +188,7 @@ describe( 'get follow subscriptions', () => {
 				receiveFollowsAction( {
 					follows: [],
 					totalCount: 10,
-				} ),
+				} )
 			);
 
 			expect( dispatch ).to.have.been.calledWith(
@@ -195,7 +196,7 @@ describe( 'get follow subscriptions', () => {
 					'http://readerpostcards.wordpress.com',
 					'https://fivethirtyeight.com/',
 					'http://feed.example.com',
-				] ),
+				] )
 			);
 		} );
 	} );

--- a/client/state/data-layer/wpcom/read/following/mine/test/utils.js
+++ b/client/state/data-layer/wpcom/read/following/mine/test/utils.js
@@ -1,3 +1,4 @@
+/** @format */
 /*
  * External dependencies
  */

--- a/client/state/data-layer/wpcom/read/following/mine/utils.js
+++ b/client/state/data-layer/wpcom/read/following/mine/utils.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External Dependencies
  */
@@ -27,7 +28,7 @@ export const subscriptionFromApi = subscription =>
 			delivery_methods: subscription.delivery_methods,
 			is_owner: subscription.is_owner,
 		},
-		isUndefined,
+		isUndefined
 	);
 
 export const subscriptionsFromApi = apiResponse => {

--- a/client/state/data-layer/wpcom/read/index.js
+++ b/client/state/data-layer/wpcom/read/index.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * Internal dependencies
  */

--- a/client/state/data-layer/wpcom/read/recommendations/index.js
+++ b/client/state/data-layer/wpcom/read/recommendations/index.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * Internal Dependencies
  */

--- a/client/state/data-layer/wpcom/read/recommendations/sites/index.js
+++ b/client/state/data-layer/wpcom/read/recommendations/sites/index.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External Dependencies
  */
@@ -22,7 +23,7 @@ export const requestRecommendedSites = ( { dispatch }, action ) => {
 			apiVersion: '1.2',
 			onSuccess: action,
 			onFailure: action,
-		} ),
+		} )
 	);
 };
 
@@ -51,7 +52,7 @@ export const receiveRecommendedSitesResponse = ( store, action, next, response )
 			sites: fromApi( response ),
 			seed: action.payload.seed,
 			offset: action.payload.offset,
-		} ),
+		} )
 	);
 };
 

--- a/client/state/data-layer/wpcom/read/recommendations/sites/test/index.js
+++ b/client/state/data-layer/wpcom/read/recommendations/sites/test/index.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External Dependencies
  */
@@ -57,7 +58,7 @@ describe( 'recommended sites', () => {
 					apiVersion: '1.2',
 					onSuccess: action,
 					onFailure: action,
-				} ),
+				} )
 			);
 		} );
 	} );
@@ -73,7 +74,7 @@ describe( 'recommended sites', () => {
 					sites: fromApi( response ),
 					seed,
 					offset: 0,
-				} ),
+				} )
 			);
 		} );
 	} );

--- a/client/state/data-layer/wpcom/read/site/comment-email-subscriptions/delete/index.js
+++ b/client/state/data-layer/wpcom/read/site/comment-email-subscriptions/delete/index.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External Dependencies
  */
@@ -22,7 +23,7 @@ export function requestCommentEmailUnsubscription( { dispatch }, action ) {
 			body: {}, // have to have the empty body for now to make the middleware happy
 			onSuccess: action,
 			onFailure: action,
-		} ),
+		} )
 	);
 }
 
@@ -39,7 +40,7 @@ export function receiveCommentEmailUnsubscription( store, action, next, response
 
 export function receiveCommentEmailUnsubscriptionError( { dispatch }, action ) {
 	dispatch(
-		errorNotice( translate( 'Sorry, we had a problem unsubscribing. Please try again.' ) ),
+		errorNotice( translate( 'Sorry, we had a problem unsubscribing. Please try again.' ) )
 	);
 	dispatch( local( subscribeToNewCommentEmail( action.payload.blogId ) ) );
 }
@@ -49,7 +50,7 @@ export default {
 		dispatchRequest(
 			requestCommentEmailUnsubscription,
 			receiveCommentEmailUnsubscription,
-			receiveCommentEmailUnsubscriptionError,
+			receiveCommentEmailUnsubscriptionError
 		),
 	],
 };

--- a/client/state/data-layer/wpcom/read/site/comment-email-subscriptions/delete/test/index.js
+++ b/client/state/data-layer/wpcom/read/site/comment-email-subscriptions/delete/test/index.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External Dependencies
  */
@@ -33,7 +34,7 @@ describe( 'comment-email-subscriptions', () => {
 					apiVersion: '1.2',
 					onSuccess: action,
 					onFailure: action,
-				} ),
+				} )
 			);
 		} );
 	} );

--- a/client/state/data-layer/wpcom/read/site/comment-email-subscriptions/index.js
+++ b/client/state/data-layer/wpcom/read/site/comment-email-subscriptions/index.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External Dependencies
  */

--- a/client/state/data-layer/wpcom/read/site/comment-email-subscriptions/new/index.js
+++ b/client/state/data-layer/wpcom/read/site/comment-email-subscriptions/new/index.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External Dependencies
  */
@@ -22,7 +23,7 @@ export function requestCommentEmailSubscription( { dispatch }, action ) {
 			apiVersion: '1.2',
 			onSuccess: action,
 			onFailure: action,
-		} ),
+		} )
 	);
 }
 
@@ -45,7 +46,7 @@ export default {
 		dispatchRequest(
 			requestCommentEmailSubscription,
 			receiveCommentEmailSubscription,
-			receiveCommentEmailSubscriptionError,
+			receiveCommentEmailSubscriptionError
 		),
 	],
 };

--- a/client/state/data-layer/wpcom/read/site/comment-email-subscriptions/new/test/index.js
+++ b/client/state/data-layer/wpcom/read/site/comment-email-subscriptions/new/test/index.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External Dependencies
  */
@@ -33,7 +34,7 @@ describe( 'comment-email-subscriptions', () => {
 					apiVersion: '1.2',
 					onSuccess: action,
 					onFailure: action,
-				} ),
+				} )
 			);
 		} );
 	} );

--- a/client/state/data-layer/wpcom/read/site/index.js
+++ b/client/state/data-layer/wpcom/read/site/index.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * Internal Dependencies
  */

--- a/client/state/data-layer/wpcom/read/site/post-email-subscriptions/delete/index.js
+++ b/client/state/data-layer/wpcom/read/site/post-email-subscriptions/delete/index.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External Dependencies
  */
@@ -22,7 +23,7 @@ export function requestPostEmailUnsubscription( { dispatch }, action ) {
 			body: {}, // have to have the empty body for now to make the middleware happy
 			onSuccess: action,
 			onFailure: action,
-		} ),
+		} )
 	);
 }
 
@@ -39,7 +40,7 @@ export function receivePostEmailUnsubscription( store, action, next, response ) 
 
 export function receivePostEmailUnsubscriptionError( { dispatch }, action ) {
 	dispatch(
-		errorNotice( translate( 'Sorry, we had a problem unsubscribing. Please try again.' ) ),
+		errorNotice( translate( 'Sorry, we had a problem unsubscribing. Please try again.' ) )
 	);
 	dispatch( local( subscribeToNewPostEmail( action.payload.blogId ) ) );
 }
@@ -49,7 +50,7 @@ export default {
 		dispatchRequest(
 			requestPostEmailUnsubscription,
 			receivePostEmailUnsubscription,
-			receivePostEmailUnsubscriptionError,
+			receivePostEmailUnsubscriptionError
 		),
 	],
 };

--- a/client/state/data-layer/wpcom/read/site/post-email-subscriptions/delete/test/index.js
+++ b/client/state/data-layer/wpcom/read/site/post-email-subscriptions/delete/test/index.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External Dependencies
  */
@@ -30,7 +31,7 @@ describe( 'comment-email-subscriptions', () => {
 					apiVersion: '1.2',
 					onSuccess: action,
 					onFailure: action,
-				} ),
+				} )
 			);
 		} );
 	} );

--- a/client/state/data-layer/wpcom/read/site/post-email-subscriptions/index.js
+++ b/client/state/data-layer/wpcom/read/site/post-email-subscriptions/index.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * Internal Dependencies
  */

--- a/client/state/data-layer/wpcom/read/site/post-email-subscriptions/new/index.js
+++ b/client/state/data-layer/wpcom/read/site/post-email-subscriptions/new/index.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External Dependencies
  */
@@ -27,7 +28,7 @@ export function requestPostEmailSubscription( { dispatch }, action ) {
 			apiVersion: '1.2',
 			onSuccess: action,
 			onFailure: action,
-		} ),
+		} )
 	);
 }
 
@@ -44,9 +45,9 @@ export function receivePostEmailSubscription( store, action, next, response ) {
 		local(
 			updateNewPostEmailSubscription(
 				action.payload.blogId,
-				get( response, [ 'subscription', 'delivery_frequency' ] ),
-			),
-		),
+				get( response, [ 'subscription', 'delivery_frequency' ] )
+			)
+		)
 	);
 }
 
@@ -60,7 +61,7 @@ export default {
 		dispatchRequest(
 			requestPostEmailSubscription,
 			receivePostEmailSubscription,
-			receivePostEmailSubscriptionError,
+			receivePostEmailSubscriptionError
 		),
 	],
 };

--- a/client/state/data-layer/wpcom/read/site/post-email-subscriptions/new/test/index.js
+++ b/client/state/data-layer/wpcom/read/site/post-email-subscriptions/new/test/index.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External Dependencies
  */
@@ -34,7 +35,7 @@ describe( 'comment-email-subscriptions', () => {
 					apiVersion: '1.2',
 					onSuccess: action,
 					onFailure: action,
-				} ),
+				} )
 			);
 		} );
 	} );
@@ -49,7 +50,7 @@ describe( 'comment-email-subscriptions', () => {
 				},
 			} );
 			expect( dispatch ).to.have.been.calledWith(
-				local( updateNewPostEmailSubscription( 1234, 'daily' ) ),
+				local( updateNewPostEmailSubscription( 1234, 'daily' ) )
 			);
 		} );
 

--- a/client/state/data-layer/wpcom/read/site/post-email-subscriptions/update/index.js
+++ b/client/state/data-layer/wpcom/read/site/post-email-subscriptions/update/index.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External Dependencies
  */
@@ -34,7 +35,7 @@ export function requestUpdatePostEmailSubscription( { dispatch, getState }, acti
 			body: buildBody( get( action, [ 'payload', 'deliveryFrequency' ] ) ),
 			onSuccess: actionWithRevert,
 			onFailure: actionWithRevert,
-		} ),
+		} )
 	);
 }
 
@@ -47,12 +48,12 @@ export function receiveUpdatePostEmailSubscription( store, action, next, respons
 
 export function receiveUpdatePostEmailSubscriptionError(
 	{ dispatch },
-	{ payload: { blogId }, meta: { previousState } },
+	{ payload: { blogId }, meta: { previousState } }
 ) {
 	dispatch(
 		errorNotice(
-			translate( 'Sorry, we had a problem updating that subscription. Please try again.' ),
-		),
+			translate( 'Sorry, we had a problem updating that subscription. Please try again.' )
+		)
 	);
 	dispatch( local( updateNewPostEmailSubscription( blogId, previousState ) ) );
 }
@@ -62,7 +63,7 @@ export default {
 		dispatchRequest(
 			requestUpdatePostEmailSubscription,
 			receiveUpdatePostEmailSubscription,
-			receiveUpdatePostEmailSubscriptionError,
+			receiveUpdatePostEmailSubscriptionError
 		),
 	],
 };

--- a/client/state/data-layer/wpcom/read/site/post-email-subscriptions/update/test/index.js
+++ b/client/state/data-layer/wpcom/read/site/post-email-subscriptions/update/test/index.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External Dependencies
  */
@@ -57,7 +58,7 @@ describe( 'comment-email-subscriptions', () => {
 					apiVersion: '1.2',
 					onSuccess: actionWithRevert,
 					onFailure: actionWithRevert,
-				} ),
+				} )
 			);
 		} );
 	} );
@@ -72,7 +73,7 @@ describe( 'comment-email-subscriptions', () => {
 					meta: { previousState: 'instantly' },
 				},
 				null,
-				{ success: true },
+				{ success: true }
 			);
 			expect( dispatch ).to.have.not.been.called;
 		} );
@@ -87,10 +88,10 @@ describe( 'comment-email-subscriptions', () => {
 					meta: { previousState },
 				},
 				null,
-				null,
+				null
 			);
 			expect( dispatch ).to.have.been.calledWith(
-				local( updateNewPostEmailSubscription( 1234, previousState ) ),
+				local( updateNewPostEmailSubscription( 1234, previousState ) )
 			);
 		} );
 
@@ -104,10 +105,10 @@ describe( 'comment-email-subscriptions', () => {
 					meta: { previousState },
 				},
 				null,
-				{ success: false },
+				{ success: false }
 			);
 			expect( dispatch ).to.have.been.calledWith(
-				local( updateNewPostEmailSubscription( 1234, previousState ) ),
+				local( updateNewPostEmailSubscription( 1234, previousState ) )
 			);
 		} );
 	} );
@@ -122,10 +123,10 @@ describe( 'comment-email-subscriptions', () => {
 					payload: { blogId: 1234 },
 					meta: { previousState },
 				},
-				null,
+				null
 			);
 			expect( dispatch ).to.have.been.calledWith(
-				local( updateNewPostEmailSubscription( 1234, previousState ) ),
+				local( updateNewPostEmailSubscription( 1234, previousState ) )
 			);
 			expect( dispatch ).to.have.been.calledWithMatch( {
 				notice: { text: 'Sorry, we had a problem updating that subscription. Please try again.' },

--- a/client/state/data-layer/wpcom/read/site/post-email-subscriptions/utils.js
+++ b/client/state/data-layer/wpcom/read/site/post-email-subscriptions/utils.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External Dependencies
  */

--- a/client/state/data-layer/wpcom/read/tags/index.js
+++ b/client/state/data-layer/wpcom/read/tags/index.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -28,7 +29,7 @@ export function requestTags( store, action ) {
 			apiVersion: '1.2',
 			onSuccess: action,
 			onFailure: action,
-		} ),
+		} )
 	);
 }
 
@@ -48,7 +49,7 @@ export function receiveTagsSuccess( store, action, next, apiResponse ) {
 		receiveTags( {
 			payload: tags,
 			resetFollowingData: !! apiResponse.tags,
-		} ),
+		} )
 	);
 }
 

--- a/client/state/data-layer/wpcom/read/tags/mine/delete/index.js
+++ b/client/state/data-layer/wpcom/read/tags/mine/delete/index.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -21,7 +22,7 @@ export function requestUnfollow( store, action ) {
 			apiVersion: '1.1',
 			onSuccess: action,
 			onFailure: action,
-		} ),
+		} )
 	);
 }
 
@@ -42,7 +43,7 @@ export function receiveUnfollowTag( store, action, next, apiResponse ) {
 	store.dispatch(
 		receiveUnfollowTagAction( {
 			payload: fromApi( apiResponse ),
-		} ),
+		} )
 	);
 }
 

--- a/client/state/data-layer/wpcom/read/tags/mine/delete/test/index.js
+++ b/client/state/data-layer/wpcom/read/tags/mine/delete/test/index.js
@@ -1,3 +1,4 @@
+/** @format */
 /*
  * External dependencies
  */
@@ -59,7 +60,7 @@ describe( 'unfollow tag request', () => {
 					path: `/read/tags/${ slug }/mine/delete`,
 					onSuccess: action,
 					onFailure: action,
-				} ),
+				} )
 			);
 		} );
 	} );
@@ -75,7 +76,7 @@ describe( 'unfollow tag request', () => {
 			expect( dispatch ).to.have.been.calledWith(
 				receiveUnfollowAction( {
 					payload: successfulUnfollowResponse.removed_tag,
-				} ),
+				} )
 			);
 		} );
 

--- a/client/state/data-layer/wpcom/read/tags/mine/new/index.js
+++ b/client/state/data-layer/wpcom/read/tags/mine/new/index.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -23,7 +24,7 @@ export function requestFollowTag( store, action ) {
 			apiVersion: '1.1',
 			onSuccess: action,
 			onFailure: action,
-		} ),
+		} )
 	);
 }
 
@@ -42,7 +43,7 @@ export function receiveFollowTag( store, action, next, apiResponse ) {
 	store.dispatch(
 		receiveTagsAction( {
 			payload: [ followedTag ],
-		} ),
+		} )
 	);
 }
 

--- a/client/state/data-layer/wpcom/read/tags/mine/new/test/index.js
+++ b/client/state/data-layer/wpcom/read/tags/mine/new/test/index.js
@@ -1,3 +1,4 @@
+/** @format */
 /*
  * External dependencies
  */
@@ -62,7 +63,7 @@ describe( 'follow tag request', () => {
 					path: `/read/tags/${ slug }/mine/new`,
 					onSuccess: action,
 					onFailure: action,
-				} ),
+				} )
 			);
 		} );
 	} );
@@ -85,7 +86,7 @@ describe( 'follow tag request', () => {
 			expect( dispatch ).to.have.been.calledWith(
 				receiveTagsAction( {
 					payload: [ normalizedFollowedTag ],
-				} ),
+				} )
 			);
 		} );
 

--- a/client/state/data-layer/wpcom/read/tags/test/index.js
+++ b/client/state/data-layer/wpcom/read/tags/test/index.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -66,7 +67,7 @@ describe( 'wpcom-api', () => {
 						path: `/read/tags/${ slug }`,
 						onSuccess: action,
 						onFailure: action,
-					} ),
+					} )
 				);
 			} );
 
@@ -84,7 +85,7 @@ describe( 'wpcom-api', () => {
 						path: '/read/tags',
 						onSuccess: action,
 						onFailure: action,
-					} ),
+					} )
 				);
 			} );
 		} );
@@ -101,7 +102,7 @@ describe( 'wpcom-api', () => {
 					receiveTagsAction( {
 						payload: fromApi( successfulSingleTagResponse ),
 						resetFollowingData: false,
-					} ),
+					} )
 				);
 			} );
 
@@ -121,7 +122,7 @@ describe( 'wpcom-api', () => {
 					receiveTagsAction( {
 						payload: transformedResponse,
 						resetFollowingData: true,
-					} ),
+					} )
 				);
 			} );
 		} );

--- a/client/state/data-layer/wpcom/read/tags/test/utils.js
+++ b/client/state/data-layer/wpcom/read/tags/test/utils.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */

--- a/client/state/data-layer/wpcom/read/tags/utils.js
+++ b/client/state/data-layer/wpcom/read/tags/utils.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -26,8 +27,8 @@ export function fromApi( apiResponse ) {
 		concat(
 			[],
 			isObject( apiResponse.tag ) && apiResponse.tag,
-			isArray( apiResponse.tags ) && apiResponse.tags,
-		),
+			isArray( apiResponse.tags ) && apiResponse.tags
+		)
 	);
 
 	return map( tags, tag => ( {

--- a/client/state/data-layer/wpcom/read/teams/index.js
+++ b/client/state/data-layer/wpcom/read/teams/index.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * Internal dependencies
  */
@@ -18,7 +19,7 @@ export function handleTeamsRequest( store ) {
 				payload: error,
 				error: true,
 			} );
-		},
+		}
 	);
 }
 

--- a/client/state/data-layer/wpcom/read/teams/test/index.js
+++ b/client/state/data-layer/wpcom/read/teams/test/index.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -30,7 +31,7 @@ describe( 'wpcom-api', () => {
 				.get( '/rest/v1.2/read/teams' )
 				.reply( 200, successfulResponse )
 				.get( '/rest/v1.2/read/teams' )
-				.reply( 500, new Error() ),
+				.reply( 500, new Error() )
 		);
 
 		it( 'should dispatch RECEIVE action when request completes', done => {

--- a/client/state/reader/feed-searches/actions.js
+++ b/client/state/reader/feed-searches/actions.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * Internal dependencies
  */

--- a/client/state/reader/feed-searches/query-key.js
+++ b/client/state/reader/feed-searches/query-key.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * Build a key for feed search queries
  *

--- a/client/state/reader/feed-searches/reducer.js
+++ b/client/state/reader/feed-searches/reducer.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -32,7 +33,7 @@ export const items = keyedReducer(
 	createReducer( null, {
 		[ READER_FEED_SEARCH_RECEIVE ]: ( state, action ) =>
 			uniqBy( ( state || [] ).concat( action.payload.feeds ), 'feed_URL' ),
-	} ),
+	} )
 );
 
 /**
@@ -58,7 +59,7 @@ export const total = keyedReducer(
 	'queryKey',
 	createReducer( null, {
 		[ READER_FEED_SEARCH_RECEIVE ]: ( state, action ) => action.payload.total,
-	} ),
+	} )
 );
 
 export default combineReducers( {

--- a/client/state/reader/feed-searches/test/query-key.js
+++ b/client/state/reader/feed-searches/test/query-key.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External Dependencies
  */

--- a/client/state/reader/feed-searches/test/reducer.js
+++ b/client/state/reader/feed-searches/test/reducer.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */

--- a/client/state/reader/feeds/actions.js
+++ b/client/state/reader/feeds/actions.js
@@ -1,3 +1,4 @@
+/** @format */
 import isArray from 'lodash/isArray';
 
 import wpcom from 'lib/wp';
@@ -34,7 +35,7 @@ export function requestFeed( feedId ) {
 					error: err,
 				} );
 				throw err;
-			},
+			}
 		);
 	};
 }

--- a/client/state/reader/feeds/reducer.js
+++ b/client/state/reader/feeds/reducer.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External Dependencies
  */
@@ -51,7 +52,7 @@ function handleRequestFailure( state, action ) {
 				is_error: true,
 			},
 		},
-		state,
+		state
 	);
 }
 
@@ -115,11 +116,11 @@ export const lastFetched = createReducer(
 					memo[ feed.feed_ID ] = Date.now();
 					return memo;
 				},
-				{},
+				{}
 			);
 			return assign( {}, state, updates );
 		},
-	},
+	}
 );
 
 export default combineReducers( {

--- a/client/state/reader/feeds/schema.js
+++ b/client/state/reader/feeds/schema.js
@@ -1,3 +1,4 @@
+/** @format */
 export const itemsSchema = {
 	type: 'object',
 	patternProperties: {

--- a/client/state/reader/feeds/selectors.js
+++ b/client/state/reader/feeds/selectors.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External Dependencies
  */

--- a/client/state/reader/feeds/test/actions.js
+++ b/client/state/reader/feeds/test/actions.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -51,7 +52,7 @@ describe( 'actions', () => {
 				err => {
 					assert.fail( 'Errback should not be invoked!', err );
 					return err;
-				},
+				}
 			);
 		} );
 	} );
@@ -88,7 +89,7 @@ describe( 'actions', () => {
 						},
 						error: sinon.match.instanceOf( Error ),
 					} );
-				},
+				}
 			);
 		} );
 	} );

--- a/client/state/reader/feeds/test/reducer.js
+++ b/client/state/reader/feeds/test/reducer.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -37,8 +38,8 @@ describe( 'reducer', () => {
 							feed_URL: 'http://example.com',
 							is_following: true,
 						},
-					},
-				)[ 1 ],
+					}
+				)[ 1 ]
 			).to.deep.equal( {
 				feed_ID: 1,
 				blog_ID: 2,
@@ -65,8 +66,8 @@ describe( 'reducer', () => {
 							name: 'ben &amp; jerries',
 							description: 'peaches &amp; cream',
 						},
-					},
-				)[ 1 ],
+					}
+				)[ 1 ]
 			).to.deep.equal( {
 				feed_ID: 1,
 				blog_ID: 2,
@@ -105,7 +106,7 @@ describe( 'reducer', () => {
 				const unvalidatedObject = deepFreeze( { hi: 'there' } );
 				this.stub( console, 'warn' ); // stub warn to suppress the warning that validation failure emits
 				expect( items( unvalidatedObject, { type: DESERIALIZE } ) ).to.deep.equal( {} );
-			} ),
+			} )
 		);
 
 		it( 'should deserialize good things', () => {
@@ -133,8 +134,8 @@ describe( 'reducer', () => {
 						type: READER_FEED_REQUEST_FAILURE,
 						error: new Error( 'request failed' ),
 						payload: { feed_ID: 666 },
-					},
-				),
+					}
+				)
 			).to.deep.equal( { 666: { feed_ID: 666, is_error: true } } );
 		} );
 
@@ -150,7 +151,7 @@ describe( 'reducer', () => {
 						subscribers_count: 10,
 						image: 'http://example.com/image',
 					},
-				} ),
+				} )
 			).to.deep.equal( {
 				666: {
 					feed_ID: 666,
@@ -174,7 +175,7 @@ describe( 'reducer', () => {
 					type: READER_FEED_REQUEST_FAILURE,
 					error: new Error( 'request failed' ),
 					payload: { feed_ID: 666 },
-				} ),
+				} )
 			).to.deep.equal( startingState );
 		} );
 
@@ -188,7 +189,7 @@ describe( 'reducer', () => {
 						{ feed_ID: 1, blog_ID: 777, name: 'first &amp; one', is_following: true },
 						{ feed_ID: 2, blog_ID: 999, name: 'second', is_following: true },
 					],
-				} ),
+				} )
 			).to.deep.equal( {
 				666: {
 					feed_ID: 666,
@@ -238,8 +239,8 @@ describe( 'reducer', () => {
 					{
 						type: READER_FEED_REQUEST,
 						payload: { feed_ID: 1 },
-					},
-				),
+					}
+				)
 			).to.deep.equal( { 1: true } );
 		} );
 
@@ -248,7 +249,7 @@ describe( 'reducer', () => {
 				queuedRequests( deepFreeze( { 1: true } ), {
 					type: READER_FEED_REQUEST_SUCCESS,
 					payload: { feed_ID: 1 },
-				} ),
+				} )
 			).to.deep.equal( {} );
 		} );
 	} );

--- a/client/state/reader/feeds/test/schema.js
+++ b/client/state/reader/feeds/test/schema.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External Dependencies
  */
@@ -70,7 +71,7 @@ describe( 'schema', () => {
 					subscribers_count: null,
 					meta: null,
 				},
-			} ),
+			} )
 		);
 	} );
 } );

--- a/client/state/reader/feeds/test/selectors.js
+++ b/client/state/reader/feeds/test/selectors.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External Dependencies
  */
@@ -23,8 +24,8 @@ describe( 'selectors', () => {
 							},
 						},
 					},
-					1,
-				),
+					1
+				)
 			).to.be.false;
 		} );
 
@@ -44,8 +45,8 @@ describe( 'selectors', () => {
 							},
 						},
 					},
-					1,
-				),
+					1
+				)
 			).to.be.false;
 		} );
 
@@ -63,8 +64,8 @@ describe( 'selectors', () => {
 							},
 						},
 					},
-					1,
-				),
+					1
+				)
 			).to.be.true;
 		} );
 
@@ -84,8 +85,8 @@ describe( 'selectors', () => {
 							},
 						},
 					},
-					1,
-				),
+					1
+				)
 			).to.be.true;
 		} );
 
@@ -101,8 +102,8 @@ describe( 'selectors', () => {
 							},
 						},
 					},
-					1,
-				),
+					1
+				)
 			).to.be.true;
 		} );
 
@@ -122,8 +123,8 @@ describe( 'selectors', () => {
 							},
 						},
 					},
-					1,
-				),
+					1
+				)
 			).to.be.true;
 		} );
 	} );

--- a/client/state/reader/follows/actions.js
+++ b/client/state/reader/follows/actions.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */

--- a/client/state/reader/follows/reducer.js
+++ b/client/state/reader/follows/reducer.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -125,7 +126,7 @@ export const items = createReducer(
 					{ feed_URL: actualFeedUrl },
 					state[ urlKey ],
 					action.payload.follow,
-					newValues,
+					newValues
 				),
 			} );
 		},
@@ -153,7 +154,7 @@ export const items = createReducer(
 					hash[ urlKey ] = newFollow;
 					return hash;
 				},
-				{},
+				{}
 			);
 			return merge( {}, state, keyedNewFollows );
 		},
@@ -180,7 +181,7 @@ export const items = createReducer(
 		},
 		[ SERIALIZE ]: state => pickBy( state, item => item.is_following ),
 	},
-	itemsSchema,
+	itemsSchema
 );
 
 export const itemsCount = createReducer( 0, {

--- a/client/state/reader/follows/schema.js
+++ b/client/state/reader/follows/schema.js
@@ -1,3 +1,4 @@
+/** @format */
 export const items = {
 	type: 'object',
 	patternProperties: {

--- a/client/state/reader/follows/test/actions.js
+++ b/client/state/reader/follows/test/actions.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */

--- a/client/state/reader/follows/test/reducer.js
+++ b/client/state/reader/follows/test/reducer.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */

--- a/client/state/reader/follows/utils.js
+++ b/client/state/reader/follows/utils.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * Internal Dependencies
  */

--- a/client/state/reader/lists/actions.js
+++ b/client/state/reader/lists/actions.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * Internal dependencies
  */

--- a/client/state/reader/lists/reducer.js
+++ b/client/state/reader/lists/reducer.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */

--- a/client/state/reader/lists/schema.js
+++ b/client/state/reader/lists/schema.js
@@ -1,3 +1,4 @@
+/** @format */
 export const itemsSchema = {
 	type: 'object',
 	patternProperties: {

--- a/client/state/reader/lists/selectors.js
+++ b/client/state/reader/lists/selectors.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -47,9 +48,9 @@ export const getSubscribedLists = createSelector(
 				// Is the user subscribed to this list?
 				return includes( state.reader.lists.subscribedLists, item.ID );
 			} ),
-			'slug',
+			'slug'
 		),
-	state => [ state.reader.lists.items, state.reader.lists.subscribedLists ],
+	state => [ state.reader.lists.items, state.reader.lists.subscribedLists ]
 );
 
 /**

--- a/client/state/reader/lists/test/actions.js
+++ b/client/state/reader/lists/test/actions.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */

--- a/client/state/reader/lists/test/reducer.js
+++ b/client/state/reader/lists/test/reducer.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -216,7 +217,7 @@ describe( 'reducer', () => {
 				subscribedLists( deepFreeze( [] ), {
 					type: READER_LISTS_RECEIVE,
 					lists: [ { ID: 1 }, { ID: 2 } ],
-				} ),
+				} )
 			).to.eql( [ 1, 2 ] );
 		} );
 
@@ -226,7 +227,7 @@ describe( 'reducer', () => {
 				subscribedLists( initial, {
 					type: READER_LISTS_RECEIVE,
 					lists: [ { ID: 3 }, { ID: 1 } ],
-				} ),
+				} )
 			).to.eql( [ 3, 1 ] );
 		} );
 
@@ -238,7 +239,7 @@ describe( 'reducer', () => {
 					data: {
 						list: { ID: 1 },
 					},
-				} ),
+				} )
 			).to.eql( [ 2 ] );
 		} );
 	} );

--- a/client/state/reader/lists/test/selectors.js
+++ b/client/state/reader/lists/test/selectors.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -125,7 +126,7 @@ describe( 'selectors', () => {
 						},
 					},
 				},
-				123,
+				123
 			);
 
 			expect( isUpdated ).to.be.false;
@@ -140,7 +141,7 @@ describe( 'selectors', () => {
 						},
 					},
 				},
-				123,
+				123
 			);
 
 			expect( isUpdated ).to.be.true;
@@ -156,7 +157,7 @@ describe( 'selectors', () => {
 					},
 				},
 				'lister',
-				'bananas',
+				'bananas'
 			);
 
 			expect( list ).to.eql( undefined );
@@ -183,7 +184,7 @@ describe( 'selectors', () => {
 					},
 				},
 				'lister',
-				'bananas',
+				'bananas'
 			);
 
 			expect( list ).to.eql( {
@@ -204,7 +205,7 @@ describe( 'selectors', () => {
 					},
 				},
 				'lister',
-				'bananas',
+				'bananas'
 			);
 
 			expect( isSubscribed ).to.eql( false );
@@ -232,7 +233,7 @@ describe( 'selectors', () => {
 					},
 				},
 				'lister',
-				'bananas',
+				'bananas'
 			);
 
 			expect( isSubscribed ).to.eql( true );
@@ -249,7 +250,7 @@ describe( 'selectors', () => {
 						},
 					},
 				},
-				456,
+				456
 			);
 
 			expect( result ).to.be.false;
@@ -264,7 +265,7 @@ describe( 'selectors', () => {
 						},
 					},
 				},
-				123,
+				123
 			);
 
 			expect( result ).to.be.true;
@@ -282,7 +283,7 @@ describe( 'selectors', () => {
 					},
 				},
 				'lister',
-				'bananas',
+				'bananas'
 			);
 
 			expect( isMissing ).to.eql( false );
@@ -298,7 +299,7 @@ describe( 'selectors', () => {
 					},
 				},
 				'lister',
-				'bananas',
+				'bananas'
 			);
 
 			expect( isMissing ).to.eql( true );

--- a/client/state/reader/posts/actions.js
+++ b/client/state/reader/posts/actions.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External Dependencies
  */
@@ -67,7 +68,7 @@ export function fetchPost( postKey ) {
 							error: err,
 						},
 					],
-				} ),
+				} )
 		);
 }
 

--- a/client/state/reader/posts/display-types.js
+++ b/client/state/reader/posts/display-types.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * Feed post display types
  * @type {Object} Types of post for display

--- a/client/state/reader/posts/normalization-rules.js
+++ b/client/state/reader/posts/normalization-rules.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External Dependencies
  */

--- a/client/state/reader/posts/reducer.js
+++ b/client/state/reader/posts/reducer.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */

--- a/client/state/reader/posts/schema.js
+++ b/client/state/reader/posts/schema.js
@@ -1,3 +1,4 @@
+/** @format */
 export const itemsSchema = {
 	type: 'object',
 };

--- a/client/state/reader/posts/selectors.js
+++ b/client/state/reader/posts/selectors.js
@@ -1,3 +1,4 @@
+/** @format */
 import keyBy from 'lodash/keyBy';
 import filter from 'lodash/filter';
 
@@ -35,7 +36,7 @@ export function getPostBySiteAndId( state, siteId, postId ) {
 			// only internal (wpcom / jetpack) posts have a valid site_ID and post ID
 			internalPosts = filter(
 				items,
-				post => post && post.site_ID && post.ID && ! post.is_external,
+				post => post && post.site_ID && post.ID && ! post.is_external
 			);
 
 		postMapBySiteAndPost = keyBy( internalPosts, post => {

--- a/client/state/reader/posts/test/actions.js
+++ b/client/state/reader/posts/test/actions.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -50,7 +51,7 @@ describe( 'actions', () => {
 					ID: 3,
 					feed_item_ID: 3,
 					is_external: true,
-				} ),
+				} )
 			).to.deep.equal( { feedId: 1, postId: 3 } );
 		} );
 
@@ -60,7 +61,7 @@ describe( 'actions', () => {
 					site_ID: 2,
 					ID: 4,
 					is_external: false,
-				} ),
+				} )
 			).to.deep.equal( { blogId: 2, postId: 4 } );
 		} );
 
@@ -72,7 +73,7 @@ describe( 'actions', () => {
 					ID: 4,
 					feed_item_ID: 3,
 					is_external: false,
-				} ),
+				} )
 			).to.deep.equal( { feedId: 1, postId: 3 } );
 		} );
 	} );

--- a/client/state/reader/posts/test/normalization-rules.js
+++ b/client/state/reader/posts/test/normalization-rules.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External Dependencies
  */
@@ -34,7 +35,7 @@ describe( 'normalization-rules', () => {
 					},
 					better_excerpt_no_html: repeat( 'no ', 10 ),
 				},
-				[ DISPLAY_TYPES.PHOTO_ONLY ],
+				[ DISPLAY_TYPES.PHOTO_ONLY ]
 			);
 		} );
 
@@ -47,7 +48,7 @@ describe( 'normalization-rules', () => {
 					},
 					better_excerpt_no_html: repeat( 'no ', 100 ),
 				},
-				[ DISPLAY_TYPES.UNCLASSIFIED ],
+				[ DISPLAY_TYPES.UNCLASSIFIED ]
 			);
 		} );
 
@@ -74,7 +75,7 @@ describe( 'normalization-rules', () => {
 					],
 					better_excerpt_no_html: repeat( 'no ', 5 ),
 				},
-				[ DISPLAY_TYPES.PHOTO_ONLY ],
+				[ DISPLAY_TYPES.PHOTO_ONLY ]
 			);
 		} );
 	} );

--- a/client/state/reader/posts/test/reducer.js
+++ b/client/state/reader/posts/test/reducer.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */

--- a/client/state/reader/posts/test/selectors.js
+++ b/client/state/reader/posts/test/selectors.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -19,7 +20,7 @@ describe( 'selectors', () => {
 						},
 					},
 				},
-				'nope',
+				'nope'
 			);
 
 			expect( post ).to.eql( undefined );
@@ -40,8 +41,8 @@ describe( 'selectors', () => {
 							},
 						},
 					},
-					'1234',
-				),
+					'1234'
+				)
 			).to.deep.equal( {
 				ID: 1,
 				global_ID: '1234',
@@ -71,8 +72,8 @@ describe( 'selectors', () => {
 						},
 					},
 					1,
-					1,
-				),
+					1
+				)
 			).to.be.undefined;
 		} );
 
@@ -95,7 +96,7 @@ describe( 'selectors', () => {
 				},
 			};
 			expect( getPostBySiteAndId( stateTree, 1, 1 ) ).to.equal(
-				stateTree.reader.posts.items[ '2' ],
+				stateTree.reader.posts.items[ '2' ]
 			);
 		} );
 	} );

--- a/client/state/reader/recommended-sites/actions.js
+++ b/client/state/reader/recommended-sites/actions.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * Internal dependencies
  */

--- a/client/state/reader/recommended-sites/reducer.js
+++ b/client/state/reader/recommended-sites/reducer.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -22,7 +23,7 @@ export const items = keyedReducer(
 	createReducer( [], {
 		[ READER_RECOMMENDED_SITES_RECEIVE ]: ( state, action ) =>
 			uniqBy( state.concat( action.payload.sites ), 'feedId' ),
-	} ),
+	} )
 );
 
 /**
@@ -38,7 +39,7 @@ export const pagingOffset = keyedReducer(
 	createReducer( null, {
 		[ READER_RECOMMENDED_SITES_RECEIVE ]: ( state, action ) =>
 			Math.max( action.payload.offset, state ),
-	} ),
+	} )
 );
 
 export default combineReducers( {

--- a/client/state/reader/recommended-sites/test/reducer.js
+++ b/client/state/reader/recommended-sites/test/reducer.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */

--- a/client/state/reader/reducer.js
+++ b/client/state/reader/reducer.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * Internal dependencies
  */

--- a/client/state/reader/related-posts/actions.js
+++ b/client/state/reader/related-posts/actions.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External Dependencies
  */
@@ -84,7 +85,7 @@ export function requestRelatedPosts( siteId, postId, scope = SCOPE_ALL ) {
 						posts: [],
 					},
 				} );
-			},
+			}
 		);
 	};
 }

--- a/client/state/reader/related-posts/reducer.js
+++ b/client/state/reader/related-posts/reducer.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External Dependencies
  */
@@ -25,12 +26,12 @@ export const items = createReducer(
 			state = assign( {}, state, {
 				[ key( action.payload.siteId, action.payload.postId, action.payload.scope ) ]: map(
 					action.payload.posts,
-					'global_ID',
+					'global_ID'
 				),
 			} );
 			return state;
 		},
-	},
+	}
 );
 
 function setRequestFlag( val, state, action ) {
@@ -46,7 +47,7 @@ export const queuedRequests = createReducer(
 		[ READER_RELATED_POSTS_REQUEST ]: partial( setRequestFlag, true ),
 		[ READER_RELATED_POSTS_REQUEST_SUCCESS ]: partial( setRequestFlag, false ),
 		[ READER_RELATED_POSTS_REQUEST_FAILURE ]: partial( setRequestFlag, false ),
-	},
+	}
 );
 
 export default combineReducers( {

--- a/client/state/reader/related-posts/selectors.js
+++ b/client/state/reader/related-posts/selectors.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External Dependencies
  */

--- a/client/state/reader/related-posts/test/actions.js
+++ b/client/state/reader/related-posts/test/actions.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External Dependencies
  */

--- a/client/state/reader/related-posts/test/reducer.js
+++ b/client/state/reader/related-posts/test/reducer.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External Dependencies
  */
@@ -26,8 +27,8 @@ describe( 'items', () => {
 						postId: 1,
 						posts: [ { global_ID: 2 }, { global_ID: 3 }, { global_ID: 4 } ],
 					},
-				},
-			),
+				}
+			)
 		).to.deep.equal( {
 			'1-1-all': [ 2, 3, 4 ],
 		} );
@@ -46,8 +47,8 @@ describe( 'items', () => {
 						postId: 1,
 						posts: [ { global_ID: 3 }, { global_ID: 4 }, { global_ID: 9 } ],
 					},
-				},
-			),
+				}
+			)
 		).to.deep.equal( {
 			'1-1-all': [ 3, 4, 9 ],
 		} );
@@ -65,8 +66,8 @@ describe( 'queuedRequests', () => {
 						siteId: 1,
 						postId: 1,
 					},
-				},
-			),
+				}
+			)
 		).to.deep.equal( {
 			'1-1-all': true,
 		} );
@@ -84,8 +85,8 @@ describe( 'queuedRequests', () => {
 						siteId: 1,
 						postId: 1,
 					},
-				},
-			),
+				}
+			)
 		).to.deep.equal( {
 			'1-1-all': false,
 		} );
@@ -101,8 +102,8 @@ describe( 'queuedRequests', () => {
 						siteId: 1,
 						postId: 1,
 					},
-				},
-			),
+				}
+			)
 		).to.deep.equal( {
 			'1-1-all': false,
 		} );

--- a/client/state/reader/related-posts/test/selectors.js
+++ b/client/state/reader/related-posts/test/selectors.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External Dependencies
  */
@@ -23,8 +24,8 @@ describe( 'selectors', () => {
 						},
 					},
 					1,
-					1,
-				),
+					1
+				)
 			).to.be.true;
 		} );
 		it( 'should return false if key present', () => {
@@ -41,8 +42,8 @@ describe( 'selectors', () => {
 						},
 					},
 					1,
-					1,
-				),
+					1
+				)
 			).to.be.false;
 		} );
 
@@ -60,8 +61,8 @@ describe( 'selectors', () => {
 						},
 					},
 					1,
-					1,
-				),
+					1
+				)
 			).to.be.false;
 		} );
 	} );
@@ -80,8 +81,8 @@ describe( 'selectors', () => {
 						},
 					},
 					1,
-					1,
-				),
+					1
+				)
 			).to.eql( [ 1, 2 ] );
 		} );
 
@@ -98,8 +99,8 @@ describe( 'selectors', () => {
 						},
 					},
 					1,
-					1,
-				),
+					1
+				)
 			).to.be.undefined;
 		} );
 	} );

--- a/client/state/reader/related-posts/utils.js
+++ b/client/state/reader/related-posts/utils.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External Dependencies
  */

--- a/client/state/reader/site-blocks/actions.js
+++ b/client/state/reader/site-blocks/actions.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -58,7 +59,7 @@ export function requestSiteBlock( siteId ) {
 					dispatch( errorNotice( translate( 'Sorry, there was a problem blocking that site.' ) ) );
 
 					return Promise.reject( error );
-				},
+				}
 			);
 	};
 }
@@ -102,11 +103,11 @@ export function requestSiteUnblock( siteId ) {
 					} );
 
 					dispatch(
-						errorNotice( translate( 'Sorry, there was a problem unblocking that site.' ) ),
+						errorNotice( translate( 'Sorry, there was a problem unblocking that site.' ) )
 					);
 
 					return Promise.reject( error );
-				},
+				}
 			);
 	};
 }

--- a/client/state/reader/site-blocks/reducer.js
+++ b/client/state/reader/site-blocks/reducer.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * Internal dependencies
  */
@@ -26,8 +27,8 @@ export const items = keyedReducer(
 			[ READER_SITE_UNBLOCK_REQUEST ]: () => false, // optimistic update
 			[ READER_SITE_UNBLOCK_REQUEST_SUCCESS ]: () => false,
 			[ READER_SITE_UNBLOCK_REQUEST_FAILURE ]: () => true,
-		},
-	),
+		}
+	)
 );
 
 export default combineReducers( {

--- a/client/state/reader/site-blocks/test/actions.js
+++ b/client/state/reader/site-blocks/test/actions.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */

--- a/client/state/reader/site-blocks/test/reducer.js
+++ b/client/state/reader/site-blocks/test/reducer.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */

--- a/client/state/reader/sites/actions.js
+++ b/client/state/reader/sites/actions.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External Dependencies
  */
@@ -61,7 +62,7 @@ export function requestSite( siteId ) {
 						error: err,
 					} );
 					throw err;
-				},
+				}
 			);
 	};
 }

--- a/client/state/reader/sites/reducer.js
+++ b/client/state/reader/sites/reducer.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External Dependencies
  */
@@ -52,7 +53,7 @@ function handleRequestFailure( state, action ) {
 				is_error: true,
 			},
 		},
-		state,
+		state
 	);
 }
 
@@ -132,11 +133,11 @@ export const lastFetched = createReducer(
 					memo[ site.ID ] = Date.now();
 					return memo;
 				},
-				{},
+				{}
 			);
 			return assign( {}, state, updates );
 		},
-	},
+	}
 );
 
 export default combineReducers( {

--- a/client/state/reader/sites/schema.js
+++ b/client/state/reader/sites/schema.js
@@ -1,3 +1,4 @@
+/** @format */
 import { sitesSchema } from 'state/sites/schema';
 
 // we're based on the normal site endpoint schema, but we want to add in a feed_ID property

--- a/client/state/reader/sites/selectors.js
+++ b/client/state/reader/sites/selectors.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External Dependencies
  */

--- a/client/state/reader/sites/test/actions.js
+++ b/client/state/reader/sites/test/actions.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -71,7 +72,7 @@ describe( 'actions', () => {
 				err => {
 					assert.fail( 'Errback should not be invoked!', err );
 					return err;
-				},
+				}
 			);
 		} );
 	} );
@@ -108,7 +109,7 @@ describe( 'actions', () => {
 						},
 						error: sinon.match.instanceOf( Error ),
 					} );
-				},
+				}
 			);
 		} );
 	} );

--- a/client/state/reader/sites/test/reducer.js
+++ b/client/state/reader/sites/test/reducer.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -35,8 +36,8 @@ describe( 'reducer', () => {
 							ID: 1,
 							name: 'my site',
 						},
-					},
-				)[ 1 ],
+					}
+				)[ 1 ]
 			).to.deep.equal( {
 				ID: 1,
 				name: 'my site',
@@ -54,8 +55,8 @@ describe( 'reducer', () => {
 							ID: 1,
 							URL: 'http://example.com/foo/bar',
 						},
-					},
-				)[ 1 ],
+					}
+				)[ 1 ]
 			).to.deep.equal( {
 				ID: 1,
 				URL: 'http://example.com/foo/bar',
@@ -76,8 +77,8 @@ describe( 'reducer', () => {
 							URL: 'http://example.com/foo/bar',
 							name: 'example!',
 						},
-					},
-				)[ 1 ],
+					}
+				)[ 1 ]
 			).to.deep.equal( {
 				ID: 1,
 				URL: 'http://example.com/foo/bar',
@@ -103,8 +104,8 @@ describe( 'reducer', () => {
 								unmapped_url: 'http://formerlyexample.com/foo/bar',
 							},
 						},
-					},
-				)[ 1 ],
+					}
+				)[ 1 ]
 			).to.deep.equal( {
 				ID: 1,
 				URL: 'http://example.com/foo/bar',
@@ -129,8 +130,8 @@ describe( 'reducer', () => {
 							ID: 1,
 							description: 'Apples&amp;Pears',
 						},
-					},
-				)[ 1 ],
+					}
+				)[ 1 ]
 			).to.have.a
 				.property( 'description' )
 				.that.equals( 'Apples&Pears' );
@@ -160,7 +161,7 @@ describe( 'reducer', () => {
 				const unvalidatedObject = deepFreeze( { hi: 'there' } );
 				this.stub( console, 'warn' ); // stub warn to suppress the warning that validation failure emits
 				expect( items( unvalidatedObject, { type: DESERIALIZE } ) ).to.deep.equal( {} );
-			} ),
+			} )
 		);
 
 		it( 'should deserialize good things', () => {
@@ -181,8 +182,8 @@ describe( 'reducer', () => {
 						type: READER_SITE_REQUEST_FAILURE,
 						error: new Error( 'request failed' ),
 						payload: { ID: 666 },
-					},
-				),
+					}
+				)
 			).to.deep.equal( { 666: { ID: 666, is_error: true } } );
 		} );
 
@@ -195,7 +196,7 @@ describe( 'reducer', () => {
 						ID: 666,
 						name: 'new',
 					},
-				} ),
+				} )
 			).to.deep.equal( { 666: { ID: 666, name: 'new', title: 'new' } } );
 		} );
 
@@ -206,7 +207,7 @@ describe( 'reducer', () => {
 					type: READER_SITE_REQUEST_FAILURE,
 					error: new Error( 'request failed' ),
 					payload: { ID: 666 },
-				} ),
+				} )
 			).to.deep.equal( startingState );
 		} );
 
@@ -223,7 +224,7 @@ describe( 'reducer', () => {
 						{ ID: 2, name: 'second' },
 						{ ID: 666, name: 'valid but updated' },
 					],
-				} ),
+				} )
 			).to.deep.equal( {
 				1: { ID: 1, name: 'first', title: 'first' },
 				2: { ID: 2, name: 'second', title: 'second' },
@@ -241,8 +242,8 @@ describe( 'reducer', () => {
 					{
 						type: READER_SITE_REQUEST,
 						payload: { ID: 1 },
-					},
-				),
+					}
+				)
 			).to.deep.equal( { 1: true } );
 		} );
 
@@ -251,7 +252,7 @@ describe( 'reducer', () => {
 				queuedRequests( deepFreeze( { 1: true } ), {
 					type: READER_SITE_REQUEST_SUCCESS,
 					payload: { ID: 1 },
-				} ),
+				} )
 			).to.deep.equal( {} );
 		} );
 	} );

--- a/client/state/reader/sites/test/selectors.js
+++ b/client/state/reader/sites/test/selectors.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External Dependencies
  */
@@ -24,8 +25,8 @@ describe( 'selectors', () => {
 							},
 						},
 					},
-					1,
-				),
+					1
+				)
 			).to.be.false;
 		} );
 
@@ -45,8 +46,8 @@ describe( 'selectors', () => {
 							},
 						},
 					},
-					1,
-				),
+					1
+				)
 			).to.be.false;
 		} );
 
@@ -64,8 +65,8 @@ describe( 'selectors', () => {
 							},
 						},
 					},
-					1,
-				),
+					1
+				)
 			).to.be.true;
 		} );
 
@@ -85,8 +86,8 @@ describe( 'selectors', () => {
 							},
 						},
 					},
-					1,
-				),
+					1
+				)
 			).to.be.true;
 		} );
 
@@ -102,8 +103,8 @@ describe( 'selectors', () => {
 							},
 						},
 					},
-					1,
-				),
+					1
+				)
 			).to.be.true;
 		} );
 
@@ -123,8 +124,8 @@ describe( 'selectors', () => {
 							},
 						},
 					},
-					1,
-				),
+					1
+				)
 			).to.be.true;
 		} );
 	} );

--- a/client/state/reader/tags/images/actions.js
+++ b/client/state/reader/tags/images/actions.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -74,7 +75,7 @@ export function requestTagImages( tag, limit = 5 ) {
 					tag,
 					error,
 				} );
-			},
+			}
 		);
 	};
 }

--- a/client/state/reader/tags/images/reducer.js
+++ b/client/state/reader/tags/images/reducer.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * Internal dependencies
  */

--- a/client/state/reader/tags/images/selectors.js
+++ b/client/state/reader/tags/images/selectors.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */

--- a/client/state/reader/tags/images/test/actions.js
+++ b/client/state/reader/tags/images/test/actions.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */

--- a/client/state/reader/tags/images/test/reducer.js
+++ b/client/state/reader/tags/images/test/reducer.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */

--- a/client/state/reader/tags/images/test/selectors.js
+++ b/client/state/reader/tags/images/test/selectors.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */

--- a/client/state/reader/tags/items/actions.js
+++ b/client/state/reader/tags/items/actions.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */

--- a/client/state/reader/tags/items/reducer.js
+++ b/client/state/reader/tags/items/reducer.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */

--- a/client/state/reader/tags/items/test/actions.js
+++ b/client/state/reader/tags/items/test/actions.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */

--- a/client/state/reader/tags/items/test/reducer.js
+++ b/client/state/reader/tags/items/test/reducer.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */

--- a/client/state/reader/tags/reducer.js
+++ b/client/state/reader/tags/reducer.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * Internal dependencies
  */

--- a/client/state/reader/teams/actions.js
+++ b/client/state/reader/teams/actions.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */

--- a/client/state/reader/teams/reducer.js
+++ b/client/state/reader/teams/reducer.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * Internal dependencies
  */
@@ -10,7 +11,7 @@ export const items = createReducer(
 	{
 		[ READER_TEAMS_RECEIVE ]: ( state, action ) => action.payload.teams,
 	},
-	itemsSchema,
+	itemsSchema
 );
 
 export const isRequesting = createReducer( false, {

--- a/client/state/reader/teams/schema.js
+++ b/client/state/reader/teams/schema.js
@@ -1,3 +1,4 @@
+/** @format */
 export const itemsSchema = {
 	type: 'array',
 	items: {

--- a/client/state/reader/teams/test/reducer.js
+++ b/client/state/reader/teams/test/reducer.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -35,8 +36,8 @@ describe( 'reducer', () => {
 					{
 						type: READER_TEAMS_RECEIVE,
 						payload: { teams: [ TEAM1 ] },
-					},
-				),
+					}
+				)
 			).to.deep.equal( [ TEAM1 ] );
 		} );
 
@@ -47,8 +48,8 @@ describe( 'reducer', () => {
 					{
 						type: READER_TEAMS_RECEIVE,
 						payload: { teams: [ TEAM1, TEAM2 ] },
-					},
-				),
+					}
+				)
 			).to.deep.equal( [ TEAM1, TEAM2 ] );
 		} );
 
@@ -72,7 +73,7 @@ describe( 'reducer', () => {
 			expect(
 				isRequesting( false, {
 					type: READER_TEAMS_REQUEST,
-				} ),
+				} )
 			).to.equal( true );
 		} );
 
@@ -81,7 +82,7 @@ describe( 'reducer', () => {
 				isRequesting( true, {
 					type: READER_TEAMS_RECEIVE,
 					teams: [ {}, {}, {} ],
-				} ),
+				} )
 			).to.equal( false );
 		} );
 
@@ -90,7 +91,7 @@ describe( 'reducer', () => {
 				isRequesting( true, {
 					type: READER_TEAMS_RECEIVE,
 					error: new Error( 'test error' ),
-				} ),
+				} )
 			).to.equal( false );
 		} );
 	} );

--- a/client/state/reader/thumbnails/actions.js
+++ b/client/state/reader/thumbnails/actions.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -93,7 +94,7 @@ export const requestThumbnail = embedUrl => dispatch => {
 				},
 				error => {
 					dispatch( requestFailure( embedUrl, error ) );
-				},
+				}
 			);
 		}
 		default:

--- a/client/state/reader/thumbnails/reducer.js
+++ b/client/state/reader/thumbnails/reducer.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * Internal dependencies
  */

--- a/client/state/reader/thumbnails/selectors.js
+++ b/client/state/reader/thumbnails/selectors.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */

--- a/client/state/reader/thumbnails/test/actions.js
+++ b/client/state/reader/thumbnails/test/actions.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */

--- a/client/state/reader/thumbnails/test/reducer.js
+++ b/client/state/reader/thumbnails/test/reducer.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -32,7 +33,7 @@ describe( 'reducer', () => {
 					type: READER_THUMBNAIL_RECEIVE,
 					embedUrl,
 					thumbnailUrl,
-				},
+				}
 			);
 
 			expect( state[ embedUrl ] ).to.eql( thumbnailUrl );
@@ -44,7 +45,7 @@ describe( 'reducer', () => {
 				{
 					type: READER_THUMBNAIL_REQUEST_FAILURE,
 					embedUrl,
-				},
+				}
 			);
 
 			expect( state ).to.eql( {} );
@@ -63,7 +64,7 @@ describe( 'reducer', () => {
 				{
 					type: READER_THUMBNAIL_REQUEST,
 					embedUrl,
-				},
+				}
 			);
 
 			expect( state ).to.eql( {

--- a/client/state/reader/thumbnails/test/sample-vimeo-response.js
+++ b/client/state/reader/thumbnails/test/sample-vimeo-response.js
@@ -1,3 +1,4 @@
+/** @format */
 /* eslint-disable */
 export default [
 	{

--- a/client/state/reader/thumbnails/test/selectors.js
+++ b/client/state/reader/thumbnails/test/selectors.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */


### PR DESCRIPTION
There have been two changes to prettier formatting recently:
1. add the `@format` to the top of docs
2. es5 compat commas (less commas!)

This runs prettier on `data-layer/read`, `blocks/reader-*`, `state/reader/*`, and `client/reader`

In the diff you should just being seeing commas deleted and this docblock comment added.