### PR TITLE
Roll out the cart abandonment notice to all users

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -76,15 +76,6 @@ module.exports = {
 		},
 		defaultVariation: 'original',
 	},
-	showCartAbandonmentNotice: {
-		datestamp: '20170630',
-		variations: {
-			doNotShowNotice: 50,
-			showNotice: 50,
-		},
-		defaultVariation: 'doNotShowNotice',
-		allowExistingUsers: true,
-	},
 	postPublishConfirmation: {
 		datestamp: '20170801',
 		allowExistingUsers: true,

--- a/client/my-sites/current-site/index.jsx
+++ b/client/my-sites/current-site/index.jsx
@@ -30,7 +30,6 @@ import { getSelectedOrAllSites } from 'state/selectors';
 import { infoNotice, removeNotice } from 'state/notices/actions';
 import { getNoticeLastTimeShown } from 'state/notices/selectors';
 import { getSectionName } from 'state/ui/selectors';
-import { abtest } from 'lib/abtest';
 
 class CurrentSite extends Component {
 	static propTypes = {
@@ -89,18 +88,16 @@ class CurrentSite extends Component {
 
 		// Show a notice if there are stale items in the cart and it hasn't been shown in the last 10 minutes (cart abandonment)
 		if ( cartItems.hasStaleItem( CartStore.get() ) && this.props.staleCartItemNoticeLastTimeShown < Date.now() - ( 10 * 60 * 1000 ) ) {
-			if ( abtest( 'showCartAbandonmentNotice' ) === 'showNotice' ) {
-				this.props.infoNotice(
-					this.props.translate( 'Your site deserves a boost!' ),
-					{
-						id: staleCartItemNoticeId,
-						isPersistent: false,
-						duration: 10000,
-						button: this.props.translate( 'Complete your purchase' ),
-						href: '/checkout/' + selectedSite.slug,
-					}
-				);
-			}
+			this.props.infoNotice(
+				this.props.translate( 'Your site deserves a boost!' ),
+				{
+					id: staleCartItemNoticeId,
+					isPersistent: false,
+					duration: 10000,
+					button: this.props.translate( 'Complete your purchase' ),
+					href: '/checkout/' + selectedSite.slug,
+				}
+			);
 		}
 	}
 


### PR DESCRIPTION
* Remove abtest config element
* Remove the condition that checks for an abtest variation

> After 3 weeks of data, A funnel with a 1-day conversion window shows a 5% lift in purchase rate for the test vs. control at 96% significance and a 7-day conversion window shows a smaller 2% lift (not statistically significant).


**Test Plan**
* With a test user and site, add any plan to your cart.
* Wait 10+ minutes.
* Click "My Sites" to navigate to the stats page.
* As soon as the cart data is synced again (~30 sec.), you should see a notice in the top right of the page similar to this.
<img width="515" alt="screen shot 2017-06-30 at 6 49 28 pm" src="https://user-images.githubusercontent.com/690843/28933828-7877a6c0-7833-11e7-852d-397a7e3a31e5.png">

