### PR TITLE
Store Orders: Update filters for orders list

### DIFF
--- a/client/extensions/woocommerce/app/order/order-details.js
+++ b/client/extensions/woocommerce/app/order/order-details.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { find } from 'lodash';
 import { localize } from 'i18n-calypso';
 import React, { Component, PropTypes } from 'react';
 
@@ -9,12 +8,13 @@ import React, { Component, PropTypes } from 'react';
  * Internal dependencies
  */
 import Card from 'components/card';
-import FormSelect from 'components/forms/form-select';
-import { getOrderStatusList } from 'woocommerce/lib/order-status';
+import { isOrderWaitingPayment } from 'woocommerce/lib/order-status';
 import OrderCreated from './order-created';
 import OrderDetailsTable from './order-details-table';
 import OrderFulfillment from './order-fulfillment';
 import OrderRefundCard from './order-refund-card';
+import OrderStatus from 'woocommerce/components/order-status';
+import OrderStatusSelect from 'woocommerce/components/order-status/select';
 import SectionHeader from 'components/section-header';
 
 class OrderDetails extends Component {
@@ -42,25 +42,10 @@ class OrderDetails extends Component {
 
 	renderStatus = () => {
 		const { order } = this.props;
-		const classes = `order__status is-${ order.status }`;
-		const statuses = getOrderStatusList();
 
-		if ( 'pending' === order.status || 'on-hold' === order.status ) {
-			return (
-				<FormSelect id="select" value={ this.state.status } onChange={ this.updateStatus }>
-					{ statuses.map( ( status, i ) => {
-						return (
-							<option key={ i } value={ status.value }>{ status.name }</option>
-						);
-					} ) }
-				</FormSelect>
-			);
-		}
-
-		const statusLabel = find( statuses, { value: order.status } );
-		return (
-			<span className={ classes }>{ statusLabel.name }</span>
-		);
+		return isOrderWaitingPayment( order.status )
+			? <OrderStatusSelect value={ this.state.status } onChange={ this.updateStatus } />
+			: <OrderStatus status={ order.status } showShipping={ false } />;
 	}
 
 	render() {

--- a/client/extensions/woocommerce/app/order/order-details.js
+++ b/client/extensions/woocommerce/app/order/order-details.js
@@ -10,6 +10,7 @@ import React, { Component, PropTypes } from 'react';
  */
 import Card from 'components/card';
 import FormSelect from 'components/forms/form-select';
+import { getOrderStatusList } from 'woocommerce/lib/order-status';
 import OrderCreated from './order-created';
 import OrderDetailsTable from './order-details-table';
 import OrderFulfillment from './order-fulfillment';
@@ -40,31 +41,9 @@ class OrderDetails extends Component {
 	}
 
 	renderStatus = () => {
-		const { order, translate } = this.props;
+		const { order } = this.props;
 		const classes = `order__status is-${ order.status }`;
-		// TODO: create a helper function for status labels
-		const statuses = [ {
-			value: 'pending',
-			name: translate( 'Pending payment' ),
-		}, {
-			value: 'processing',
-			name: translate( 'Processing' ),
-		}, {
-			value: 'on-hold',
-			name: translate( 'On Hold' ),
-		}, {
-			value: 'completed',
-			name: translate( 'Completed' ),
-		}, {
-			value: 'cancelled',
-			name: translate( 'Cancelled' ),
-		}, {
-			value: 'refunded',
-			name: translate( 'Refunded' ),
-		}, {
-			value: 'failed',
-			name: translate( 'Payment Failed' ),
-		} ];
+		const statuses = getOrderStatusList();
 
 		if ( 'pending' === order.status || 'on-hold' === order.status ) {
 			return (

--- a/client/extensions/woocommerce/app/order/order-refund-card.js
+++ b/client/extensions/woocommerce/app/order/order-refund-card.js
@@ -128,7 +128,7 @@ class OrderRefundCard extends Component {
 		const refundObj = {
 			amount: this.state.refundTotal + '', // API expects a string
 			reason: this.state.refundNote,
-			api_refund: ( -1 !== paymentMethod.method_supports.indexOf( 'refunds' ) ),
+			api_refund: ( paymentMethod && ( -1 !== paymentMethod.method_supports.indexOf( 'refunds' ) ) ),
 		};
 		this.props.sendRefund( site.ID, order.id, refundObj );
 	}
@@ -139,7 +139,7 @@ class OrderRefundCard extends Component {
 			return null;
 		}
 
-		if ( -1 === paymentMethod.method_supports.indexOf( 'refunds' ) ) {
+		if ( paymentMethod && ( -1 === paymentMethod.method_supports.indexOf( 'refunds' ) ) ) {
 			return (
 				<div className="order__refund-method">
 					<h3>{ translate( 'Manual Refund' ) }</h3>

--- a/client/extensions/woocommerce/app/order/style.scss
+++ b/client/extensions/woocommerce/app/order/style.scss
@@ -35,31 +35,6 @@
 	}
 }
 
-.order__status {
-	display: inline-flex;
-	padding: 0px 12px;
-	line-height: 32px;
-	background: lighten( $gray, 20% );
-	border-radius: 4px;
-
-	&.is-failed {
-		background: lighten( $alert-red, 20% );
-		color: darken( $alert-red, 30% );
-	}
-
-	&.is-cancelled,
-	&.is-refunded,
-	&.is-completed {
-		background: $gray-light;
-		color: $gray-dark;
-	}
-
-	&.is-on-hold {
-		background: lighten( $alert-yellow, 20% );
-		color: darken( $alert-yellow, 30% );
-	}
-}
-
 .order__details-card {
 	padding-top: 0;
 	padding-bottom: 0;

--- a/client/extensions/woocommerce/app/orders/orders-filter-nav.js
+++ b/client/extensions/woocommerce/app/orders/orders-filter-nav.js
@@ -35,10 +35,13 @@ class OrdersFilterNav extends Component {
 					<NavItem path={ getLink( '/store/orders/:site', site ) } selected={ 'any' === status }>
 						{ translate( 'All orders' ) }
 					</NavItem>
-					<NavItem path={ getLink( '/store/orders/processing/:site', site ) } selected={ 'processing' === status }>
-						{ translate( 'Processing' ) }
+					<NavItem path={ getLink( '/store/orders/pay/:site', site ) } selected={ 'pay' === status }>
+						{ translate( 'Awaiting Payment' ) }
 					</NavItem>
-					<NavItem path={ getLink( '/store/orders/completed/:site', site ) } selected={ 'completed' === status }>
+					<NavItem path={ getLink( '/store/orders/fulfill/:site', site ) } selected={ 'fulfill' === status }>
+						{ translate( 'Awaiting Fulfillment' ) }
+					</NavItem>
+					<NavItem path={ getLink( '/store/orders/finished/:site', site ) } selected={ 'finished' === status }>
 						{ translate( 'Completed' ) }
 					</NavItem>
 				</NavTabs>

--- a/client/extensions/woocommerce/app/orders/orders-filter-nav.js
+++ b/client/extensions/woocommerce/app/orders/orders-filter-nav.js
@@ -29,9 +29,18 @@ class OrdersFilterNav extends Component {
 
 	render() {
 		const { translate, site, status } = this.props;
+		let currentSelection = translate( 'All orders' );
+		if ( 'pay' === status ) {
+			currentSelection = translate( 'Awaiting Payment' );
+		} else if ( 'fulfill' === status ) {
+			currentSelection = translate( 'Awaiting Fulfillment' );
+		} else if ( 'finished' === status ) {
+			currentSelection = translate( 'Completed' );
+		}
+
 		return (
-			<SectionNav>
-				<NavTabs label={ translate( 'Status' ) } selectedText={ translate( 'All orders' ) }>
+			<SectionNav selectedText={ currentSelection }>
+				<NavTabs label={ translate( 'Status' ) } selectedText={ currentSelection }>
 					<NavItem path={ getLink( '/store/orders/:site', site ) } selected={ 'any' === status }>
 						{ translate( 'All orders' ) }
 					</NavItem>

--- a/client/extensions/woocommerce/app/orders/orders-filter-nav.js
+++ b/client/extensions/woocommerce/app/orders/orders-filter-nav.js
@@ -34,7 +34,7 @@ class OrdersFilterNav extends Component {
 
 	render() {
 		const { translate, site, status } = this.props;
-		let currentSelection = translate( 'All orders' );
+		let currentSelection = translate( 'All Orders' );
 		if ( ORDER_UNPAID === status ) {
 			currentSelection = translate( 'Awaiting Payment' );
 		} else if ( ORDER_UNFULFILLED === status ) {
@@ -49,7 +49,7 @@ class OrdersFilterNav extends Component {
 					<NavItem
 						path={ getLink( '/store/orders/:site', site ) }
 						selected={ 'any' === status }>
-						{ translate( 'All orders' ) }
+						{ translate( 'All Orders' ) }
 					</NavItem>
 					<NavItem
 						path={ getLink( `/store/orders/${ ORDER_UNPAID }/:site`, site ) }

--- a/client/extensions/woocommerce/app/orders/orders-filter-nav.js
+++ b/client/extensions/woocommerce/app/orders/orders-filter-nav.js
@@ -12,11 +12,16 @@ import React, { Component } from 'react';
 import { getLink } from 'woocommerce/lib/nav-utils';
 import { getOrdersCurrentSearch } from 'woocommerce/state/ui/orders/selectors';
 import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
-import { updateCurrentOrdersQuery } from 'woocommerce/state/ui/orders/actions';
 import NavItem from 'components/section-nav/item';
 import NavTabs from 'components/section-nav/tabs';
+import {
+	ORDER_UNPAID,
+	ORDER_UNFULFILLED,
+	ORDER_COMPLETED,
+} from 'woocommerce/lib/order-status';
 import Search from 'components/search';
 import SectionNav from 'components/section-nav';
+import { updateCurrentOrdersQuery } from 'woocommerce/state/ui/orders/actions';
 
 class OrdersFilterNav extends Component {
 	doSearch = ( search ) => {
@@ -30,27 +35,35 @@ class OrdersFilterNav extends Component {
 	render() {
 		const { translate, site, status } = this.props;
 		let currentSelection = translate( 'All orders' );
-		if ( 'pay' === status ) {
+		if ( ORDER_UNPAID === status ) {
 			currentSelection = translate( 'Awaiting Payment' );
-		} else if ( 'fulfill' === status ) {
+		} else if ( ORDER_UNFULFILLED === status ) {
 			currentSelection = translate( 'Awaiting Fulfillment' );
-		} else if ( 'finished' === status ) {
+		} else if ( ORDER_COMPLETED === status ) {
 			currentSelection = translate( 'Completed' );
 		}
 
 		return (
 			<SectionNav selectedText={ currentSelection }>
 				<NavTabs label={ translate( 'Status' ) } selectedText={ currentSelection }>
-					<NavItem path={ getLink( '/store/orders/:site', site ) } selected={ 'any' === status }>
+					<NavItem
+						path={ getLink( '/store/orders/:site', site ) }
+						selected={ 'any' === status }>
 						{ translate( 'All orders' ) }
 					</NavItem>
-					<NavItem path={ getLink( '/store/orders/pay/:site', site ) } selected={ 'pay' === status }>
+					<NavItem
+						path={ getLink( `/store/orders/${ ORDER_UNPAID }/:site`, site ) }
+						selected={ ORDER_UNPAID === status }>
 						{ translate( 'Awaiting Payment' ) }
 					</NavItem>
-					<NavItem path={ getLink( '/store/orders/fulfill/:site', site ) } selected={ 'fulfill' === status }>
+					<NavItem
+						path={ getLink( `/store/orders/${ ORDER_UNFULFILLED }/:site`, site ) }
+						selected={ ORDER_UNFULFILLED === status }>
 						{ translate( 'Awaiting Fulfillment' ) }
 					</NavItem>
-					<NavItem path={ getLink( '/store/orders/finished/:site', site ) } selected={ 'finished' === status }>
+					<NavItem
+						path={ getLink( `/store/orders/${ ORDER_COMPLETED }/:site`, site ) }
+						selected={ ORDER_COMPLETED === status }>
 						{ translate( 'Completed' ) }
 					</NavItem>
 				</NavTabs>

--- a/client/extensions/woocommerce/app/orders/orders-list.js
+++ b/client/extensions/woocommerce/app/orders/orders-list.js
@@ -24,12 +24,17 @@ import { getLink } from 'woocommerce/lib/nav-utils';
 import { getOrdersCurrentPage, getOrdersCurrentSearch } from 'woocommerce/state/ui/orders/selectors';
 import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
 import humanDate from 'lib/human-date';
-import { updateCurrentOrdersQuery } from 'woocommerce/state/ui/orders/actions';
+import {
+	ORDER_UNPAID,
+	ORDER_UNFULFILLED,
+	ORDER_COMPLETED,
+} from 'woocommerce/lib/order-status';
 import OrdersFilterNav from './orders-filter-nav';
 import Pagination from 'components/pagination';
 import Table from 'woocommerce/components/table';
 import TableRow from 'woocommerce/components/table/table-row';
 import TableItem from 'woocommerce/components/table/table-item';
+import { updateCurrentOrdersQuery } from 'woocommerce/state/ui/orders/actions';
 
 class Orders extends Component {
 	componentDidMount() {
@@ -138,10 +143,12 @@ class Orders extends Component {
 		let emptyMessage = translate( 'Your orders will appear here as they come in.' );
 		if ( currentSearch ) {
 			emptyMessage = translate( 'There are no orders matching your search.' );
-		} else if ( 'pay' === currentStatus ) {
+		} else if ( ORDER_UNPAID === currentStatus ) {
 			emptyMessage = translate( 'You don\'t have any orders awaiting payment.' );
-		} else if ( 'fulfill' === currentStatus ) {
+		} else if ( ORDER_UNFULFILLED === currentStatus ) {
 			emptyMessage = translate( 'You don\'t have any orders awaiting fulfillment.' );
+		} else if ( ORDER_COMPLETED === currentStatus ) {
+			emptyMessage = translate( 'You don\'t have any completed orders.' );
 		}
 
 		return (

--- a/client/extensions/woocommerce/app/orders/orders-list.js
+++ b/client/extensions/woocommerce/app/orders/orders-list.js
@@ -30,6 +30,7 @@ import {
 	ORDER_COMPLETED,
 } from 'woocommerce/lib/order-status';
 import OrdersFilterNav from './orders-filter-nav';
+import OrderStatus from 'woocommerce/components/order-status';
 import Pagination from 'components/pagination';
 import Table from 'woocommerce/components/table';
 import TableRow from 'woocommerce/components/table/table-row';
@@ -84,47 +85,6 @@ class Orders extends Component {
 		page( getLink( '/store/orders/:site', site ) );
 	}
 
-	getOrderStatus = ( status ) => {
-		const { translate } = this.props;
-		const classes = `orders__item-status is-${ status }`;
-		let paymentLabel;
-		let shippingLabel;
-		switch ( status ) {
-			case 'pending':
-				shippingLabel = translate( 'New order' );
-				paymentLabel = translate( 'Payment pending' );
-				break;
-			case 'processing':
-				shippingLabel = translate( 'New order' );
-				paymentLabel = translate( 'Paid in full' );
-				break;
-			case 'on-hold':
-				shippingLabel = translate( 'On hold' );
-				paymentLabel = translate( 'Payment pending' );
-				break;
-			case 'completed':
-				shippingLabel = translate( 'Fulfilled' );
-				paymentLabel = translate( 'Paid in full' );
-				break;
-			case 'cancelled':
-				paymentLabel = translate( 'Cancelled' );
-				break;
-			case 'refunded':
-				paymentLabel = translate( 'Refunded' );
-				break;
-			case 'failed':
-				paymentLabel = translate( 'Payment Failed' );
-				break;
-		}
-
-		return (
-			<span className={ classes }>
-				{ shippingLabel ? <span className="orders__shipping-status">{ shippingLabel }</span> : null }
-				<span className="orders__payment-status">{ paymentLabel }</span>
-			</span>
-		);
-	}
-
 	renderPlaceholders = () => {
 		return range( 5 ).map( ( i ) => {
 			return (
@@ -175,7 +135,7 @@ class Orders extends Component {
 					{ humanDate( order.date_created_gmt + 'Z' ) }
 				</TableItem>
 				<TableItem className="orders__table-status">
-					{ this.getOrderStatus( order.status ) }
+					<OrderStatus status={ order.status } />
 				</TableItem>
 				<TableItem className="orders__table-total">
 					{ formatCurrency( order.total, order.currency ) || order.total }

--- a/client/extensions/woocommerce/app/orders/orders-list.js
+++ b/client/extensions/woocommerce/app/orders/orders-list.js
@@ -138,9 +138,9 @@ class Orders extends Component {
 		let emptyMessage = translate( 'Your orders will appear here as they come in.' );
 		if ( currentSearch ) {
 			emptyMessage = translate( 'There are no orders matching your search.' );
-		} else if ( 'pending' === currentStatus ) {
+		} else if ( 'pay' === currentStatus ) {
 			emptyMessage = translate( 'You don\'t have any orders awaiting payment.' );
-		} else if ( 'processing' === currentStatus ) {
+		} else if ( 'fulfill' === currentStatus ) {
 			emptyMessage = translate( 'You don\'t have any orders awaiting fulfillment.' );
 		}
 

--- a/client/extensions/woocommerce/app/orders/style.scss
+++ b/client/extensions/woocommerce/app/orders/style.scss
@@ -1,4 +1,3 @@
-
 .orders__container {
 	@include breakpoint( ">660px" ) {
 		margin-top: 58px;
@@ -39,58 +38,6 @@
 
 .orders__item-link {
 	margin-right: 5px;
-}
-
-.orders__item-status {
-	display: inline-flex;
-	padding: 0px 12px;
-	line-height: 32px;
-	background: lighten( $gray, 20% );
-	border-radius: 4px;
-
-	&.is-failed {
-		background: lighten( $alert-red, 20% );
-		color: darken( $alert-red, 30% );
-
-		span + span {
-			border-color: $alert-red;
-		}
-	}
-
-	&.is-pending {
-		background: lighten( $alert-green, 20% );
-		color: darken( $alert-green, 30% );
-
-		span + span {
-			border-color: $alert-green;
-		}
-	}
-
-	&.is-cancelled,
-	&.is-refunded,
-	&.is-completed {
-		background: $gray-light;
-		color: $gray-dark;
-
-		span + span {
-			border-color: lighten( $gray, 20% );
-		}
-	}
-
-	&.is-on-hold {
-		background: lighten( $alert-yellow, 20% );
-		color: darken( $alert-yellow, 30% );
-
-		span + span {
-			border-color: $alert-yellow;
-		}
-	}
-
-	span + span {
-		margin-left: 12px;
-		padding-left: 12px;
-		border-left: 1px solid $gray;
-	}
 }
 
 .orders__table-total {

--- a/client/extensions/woocommerce/components/order-status/README.md
+++ b/client/extensions/woocommerce/components/order-status/README.md
@@ -1,0 +1,60 @@
+OrderStatus
+===========
+
+OrderStatus is a component that displays a badge with human-friendly text describing the payment and shipping status of an order. Payment and shipping statuses are considered separate for UI, so we can also individually show just payment or just shipping status.
+
+Some statuses don't have a shipping status: `cancelled`, `refunded`, and `failed`.
+
+## Usage
+
+```jsx
+render: function() {
+    return (
+        <SectionHeader label="Order Details">
+            <OrderStatus status={ 'pending' } />
+        </SectionHeader>
+    );
+}
+```
+
+## Props
+
+### `status`
+
+The WooCommerce order status string. See the [WC API docs](https://docs.woocommerce.com/document/managing-orders/) for statuses.
+
+### `showPayment`
+
+Boolean. Determines whether the payment label should be shown. Defaults to true.
+
+### `showShipping`
+
+Boolean. Determines whether the shipping label should be shown. Defaults to true.
+
+------------------------------
+
+OrderStatusSelect
+=================
+
+OrderStatusSelect is a component that displays a dropdown of order statuses.
+
+## Usage
+```jsx
+render: function() {
+    return (
+        <SectionHeader label="Order Details">
+            <OrderStatusSelect value={ this.state.status } onChange={ this.updateStatus } />
+        </SectionHeader>
+    );
+}
+```
+
+## Props
+
+### `value`
+
+The currently selected status. See `woocommerce/lib/order-status/index.js` for a list of available statuses.
+
+### `onChange`
+
+A function run when a new status is selected.

--- a/client/extensions/woocommerce/components/order-status/index.js
+++ b/client/extensions/woocommerce/components/order-status/index.js
@@ -1,0 +1,47 @@
+/**
+ * External dependencies
+ */
+import { localize } from 'i18n-calypso';
+import React from 'react';
+
+function OrderStatus( { showPayment = true, showShipping = true, status, translate } ) {
+	const classes = `order-status__item is-${ status }`;
+	let paymentLabel;
+	let shippingLabel;
+	switch ( status ) {
+		case 'pending':
+			shippingLabel = translate( 'New order' );
+			paymentLabel = translate( 'Payment pending' );
+			break;
+		case 'processing':
+			shippingLabel = translate( 'New order' );
+			paymentLabel = translate( 'Paid in full' );
+			break;
+		case 'on-hold':
+			shippingLabel = translate( 'On hold' );
+			paymentLabel = translate( 'Payment pending' );
+			break;
+		case 'completed':
+			shippingLabel = translate( 'Fulfilled' );
+			paymentLabel = translate( 'Paid in full' );
+			break;
+		case 'cancelled':
+			paymentLabel = translate( 'Cancelled' );
+			break;
+		case 'refunded':
+			paymentLabel = translate( 'Refunded' );
+			break;
+		case 'failed':
+			paymentLabel = translate( 'Payment Failed' );
+			break;
+	}
+
+	return (
+		<span className={ classes }>
+			{ ( shippingLabel && showShipping ) ? <span className="order-status__shipping">{ shippingLabel }</span> : null }
+			{ showPayment ? <span className="order-status__payment">{ paymentLabel }</span> : null }
+		</span>
+	);
+}
+
+export default localize( OrderStatus );

--- a/client/extensions/woocommerce/components/order-status/index.js
+++ b/client/extensions/woocommerce/components/order-status/index.js
@@ -32,7 +32,7 @@ function OrderStatus( { showPayment = true, showShipping = true, status, transla
 			paymentLabel = translate( 'Refunded' );
 			break;
 		case 'failed':
-			paymentLabel = translate( 'Payment Failed' );
+			paymentLabel = translate( 'Payment failed' );
 			break;
 	}
 

--- a/client/extensions/woocommerce/components/order-status/select.js
+++ b/client/extensions/woocommerce/components/order-status/select.js
@@ -1,0 +1,26 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { getOrderStatusList } from 'woocommerce/lib/order-status';
+import FormSelect from 'components/forms/form-select';
+
+function OrderStatusSelect( { onChange, value } ) {
+	const statuses = getOrderStatusList();
+
+	return (
+		<FormSelect id="select" value={ value } onChange={ onChange }>
+			{ statuses.map( ( status, i ) => {
+				return (
+					<option key={ i } value={ status.value }>{ status.name }</option>
+				);
+			} ) }
+		</FormSelect>
+	);
+}
+
+export default OrderStatusSelect;

--- a/client/extensions/woocommerce/components/order-status/style.scss
+++ b/client/extensions/woocommerce/components/order-status/style.scss
@@ -1,0 +1,42 @@
+.order-status__item {
+	display: inline-flex;
+	padding: 0px 12px;
+	line-height: 32px;
+	background: lighten( $gray, 20% );
+	border-radius: 4px;
+
+	&.is-failed {
+		background: lighten( $alert-red, 20% );
+		color: darken( $alert-red, 30% );
+
+		span + span {
+			border-color: $alert-red;
+		}
+	}
+
+	&.is-cancelled,
+	&.is-refunded,
+	&.is-completed {
+		background: $gray-light;
+		color: $gray-dark;
+
+		span + span {
+			border-color: lighten( $gray, 20% );
+		}
+	}
+
+	&.is-on-hold {
+		background: lighten( $alert-yellow, 20% );
+		color: darken( $alert-yellow, 30% );
+
+		span + span {
+			border-color: $alert-yellow;
+		}
+	}
+
+	span + span {
+		margin-left: 12px;
+		padding-left: 12px;
+		border-left: 1px solid $gray;
+	}
+}

--- a/client/extensions/woocommerce/lib/order-status/index.js
+++ b/client/extensions/woocommerce/lib/order-status/index.js
@@ -4,6 +4,16 @@
 import { translate } from 'i18n-calypso';
 
 /**
+ * Custom statuses for Calypso
+ *
+ * These are used as collective terms for the WC core statuses,
+ * grouping them by a more general point in an order lifecycle.
+ */
+export const ORDER_UNPAID = 'unpaid';
+export const ORDER_UNFULFILLED = 'unfulfilled';
+export const ORDER_COMPLETED = 'finished';
+
+/**
  * Lists of statuses in each group, waiting for payment, waiting for
  * fulfillment, and finished orders.
  */

--- a/client/extensions/woocommerce/lib/order-status/index.js
+++ b/client/extensions/woocommerce/lib/order-status/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { translate } from 'i18n-calypso';
+
+/**
  * Lists of statuses in each group, waiting for payment, waiting for
  * fulfillment, and finished orders.
  */
@@ -15,6 +20,36 @@ export const statusFinished = [
 	'failed',
 	'refunded',
 ];
+
+/**
+ * Get a list of order statuses for display (including a translated label)
+ *
+ * @return {Array} List of objects {name,value} for each status
+ */
+export function getOrderStatusList() {
+	return [ {
+		value: 'pending',
+		name: translate( 'Pending payment' ),
+	}, {
+		value: 'processing',
+		name: translate( 'Processing' ),
+	}, {
+		value: 'on-hold',
+		name: translate( 'On Hold' ),
+	}, {
+		value: 'completed',
+		name: translate( 'Completed' ),
+	}, {
+		value: 'cancelled',
+		name: translate( 'Cancelled' ),
+	}, {
+		value: 'refunded',
+		name: translate( 'Refunded' ),
+	}, {
+		value: 'failed',
+		name: translate( 'Payment Failed' ),
+	} ];
+}
 
 /**
  * Checks if this status (from an order) is in the "waiting for payment" group

--- a/client/extensions/woocommerce/lib/order-status/index.js
+++ b/client/extensions/woocommerce/lib/order-status/index.js
@@ -1,0 +1,47 @@
+/**
+ * Lists of statuses in each group, waiting for payment, waiting for
+ * fulfillment, and finished orders.
+ */
+export const statusWaitingPayment = [
+	'on-hold',
+	'pending',
+];
+export const statusWaitingFulfillment = [
+	'processing',
+];
+export const statusFinished = [
+	'cancelled',
+	'completed',
+	'failed',
+	'refunded',
+];
+
+/**
+ * Checks if this status (from an order) is in the "waiting for payment" group
+ *
+ * @param {String} status Order status
+ * @return {Boolean} true if the status is awaiting payment
+ */
+export function isOrderWaitingPayment( status ) {
+	return ( -1 !== statusWaitingPayment.indexOf( status ) );
+}
+
+/**
+ * Checks if this status (from an order) is in the "waiting for fulfillment" group
+ *
+ * @param {String} status Order status
+ * @return {Boolean} true if the status is awaiting fulfillment
+ */
+export function isOrderWaitingFulfillment( status ) {
+	return ( -1 !== statusWaitingFulfillment.indexOf( status ) );
+}
+
+/**
+ * Checks if this status (from an order) is in the "finished" group
+ *
+ * @param {String} status Order status
+ * @return {Boolean} true if the status is completed, cancelled, or otherwise has no further action
+ */
+export function isOrderFinished( status ) {
+	return ( -1 !== statusFinished.indexOf( status ) );
+}

--- a/client/extensions/woocommerce/lib/order-status/index.js
+++ b/client/extensions/woocommerce/lib/order-status/index.js
@@ -45,7 +45,7 @@ export function getOrderStatusList() {
 		name: translate( 'Processing' ),
 	}, {
 		value: 'on-hold',
-		name: translate( 'On Hold' ),
+		name: translate( 'On hold' ),
 	}, {
 		value: 'completed',
 		name: translate( 'Completed' ),
@@ -57,7 +57,7 @@ export function getOrderStatusList() {
 		name: translate( 'Refunded' ),
 	}, {
 		value: 'failed',
-		name: translate( 'Payment Failed' ),
+		name: translate( 'Payment failed' ),
 	} ];
 }
 

--- a/client/extensions/woocommerce/lib/order-status/test/index.js
+++ b/client/extensions/woocommerce/lib/order-status/test/index.js
@@ -1,0 +1,79 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import {
+	isOrderWaitingPayment,
+	isOrderWaitingFulfillment,
+	isOrderFinished,
+} from '../index';
+
+describe( 'isOrderWaitingPayment', () => {
+	it( 'should be true for a pending order', () => {
+		expect( isOrderWaitingPayment( 'pending' ) ).to.be.true;
+	} );
+
+	it( 'should be false for a processing order', () => {
+		expect( isOrderWaitingPayment( 'processing' ) ).to.be.false;
+	} );
+
+	it( 'should be false for a completed order', () => {
+		expect( isOrderWaitingPayment( 'completed' ) ).to.be.false;
+	} );
+
+	it( 'should be false for a failed order', () => {
+		expect( isOrderWaitingPayment( 'failed' ) ).to.be.false;
+	} );
+
+	it( 'should be false for a fake order status', () => {
+		expect( isOrderWaitingPayment( 'fake' ) ).to.be.false;
+	} );
+} );
+
+describe( 'isOrderWaitingFulfillment', () => {
+	it( 'should be false for a pending order', () => {
+		expect( isOrderWaitingFulfillment( 'pending' ) ).to.be.false;
+	} );
+
+	it( 'should be true for a processing order', () => {
+		expect( isOrderWaitingFulfillment( 'processing' ) ).to.be.true;
+	} );
+
+	it( 'should be false for a completed order', () => {
+		expect( isOrderWaitingFulfillment( 'completed' ) ).to.be.false;
+	} );
+
+	it( 'should be false for a failed order', () => {
+		expect( isOrderWaitingFulfillment( 'failed' ) ).to.be.false;
+	} );
+
+	it( 'should be false for a fake order status', () => {
+		expect( isOrderWaitingFulfillment( 'fake' ) ).to.be.false;
+	} );
+} );
+
+describe( 'isOrderFinished', () => {
+	it( 'should be false for a pending order', () => {
+		expect( isOrderFinished( 'pending' ) ).to.be.false;
+	} );
+
+	it( 'should be false for a processing order', () => {
+		expect( isOrderFinished( 'processing' ) ).to.be.false;
+	} );
+
+	it( 'should be true for a completed order', () => {
+		expect( isOrderFinished( 'completed' ) ).to.be.true;
+	} );
+
+	it( 'should be true for a failed order', () => {
+		expect( isOrderFinished( 'failed' ) ).to.be.true;
+	} );
+
+	it( 'should be false for a fake order status', () => {
+		expect( isOrderFinished( 'fake' ) ).to.be.false;
+	} );
+} );

--- a/client/extensions/woocommerce/lib/order-status/test/index.js
+++ b/client/extensions/woocommerce/lib/order-status/test/index.js
@@ -17,6 +17,10 @@ describe( 'isOrderWaitingPayment', () => {
 		expect( isOrderWaitingPayment( 'pending' ) ).to.be.true;
 	} );
 
+	it( 'should be true for an on-hold order', () => {
+		expect( isOrderWaitingPayment( 'on-hold' ) ).to.be.true;
+	} );
+
 	it( 'should be false for a processing order', () => {
 		expect( isOrderWaitingPayment( 'processing' ) ).to.be.false;
 	} );
@@ -39,6 +43,10 @@ describe( 'isOrderWaitingFulfillment', () => {
 		expect( isOrderWaitingFulfillment( 'pending' ) ).to.be.false;
 	} );
 
+	it( 'should be false for an on-hold order', () => {
+		expect( isOrderWaitingFulfillment( 'on-hold' ) ).to.be.false;
+	} );
+
 	it( 'should be true for a processing order', () => {
 		expect( isOrderWaitingFulfillment( 'processing' ) ).to.be.true;
 	} );
@@ -59,6 +67,10 @@ describe( 'isOrderWaitingFulfillment', () => {
 describe( 'isOrderFinished', () => {
 	it( 'should be false for a pending order', () => {
 		expect( isOrderFinished( 'pending' ) ).to.be.false;
+	} );
+
+	it( 'should be false for an on-hold order', () => {
+		expect( isOrderFinished( 'on-hold' ) ).to.be.false;
 	} );
 
 	it( 'should be false for a processing order', () => {

--- a/client/extensions/woocommerce/state/sites/orders/actions.js
+++ b/client/extensions/woocommerce/state/sites/orders/actions.js
@@ -17,6 +17,9 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 import request from '../request';
 import { setError } from '../status/wc-api/actions';
 import {
+	ORDER_UNPAID,
+	ORDER_UNFULFILLED,
+	ORDER_COMPLETED,
 	statusWaitingPayment,
 	statusWaitingFulfillment,
 	statusFinished,
@@ -55,11 +58,11 @@ export const fetchOrders = ( siteId, requestedQuery = {} ) => ( dispatch, getSta
 	dispatch( fetchAction );
 
 	// Convert URL status to status group
-	if ( 'pay' === query.status ) {
+	if ( ORDER_UNPAID === query.status ) {
 		query.status = statusWaitingPayment.join( ',' );
-	} else if ( 'fulfill' === query.status ) {
+	} else if ( ORDER_UNFULFILLED === query.status ) {
 		query.status = statusWaitingFulfillment.join( ',' );
-	} else if ( 'finished' === query.status ) {
+	} else if ( ORDER_COMPLETED === query.status ) {
 		query.status = statusFinished.join( ',' );
 	}
 

--- a/client/extensions/woocommerce/state/sites/orders/actions.js
+++ b/client/extensions/woocommerce/state/sites/orders/actions.js
@@ -16,6 +16,11 @@ import {
 import { getSelectedSiteId } from 'state/ui/selectors';
 import request from '../request';
 import { setError } from '../status/wc-api/actions';
+import {
+	statusWaitingPayment,
+	statusWaitingFulfillment,
+	statusFinished,
+} from 'woocommerce/lib/order-status';
 import { successNotice, errorNotice } from 'state/notices/actions';
 import { translate } from 'i18n-calypso';
 import {
@@ -48,6 +53,15 @@ export const fetchOrders = ( siteId, requestedQuery = {} ) => ( dispatch, getSta
 		query: normalizedQuery,
 	};
 	dispatch( fetchAction );
+
+	// Convert URL status to status group
+	if ( 'pay' === query.status ) {
+		query.status = statusWaitingPayment.join( ',' );
+	} else if ( 'fulfill' === query.status ) {
+		query.status = statusWaitingFulfillment.join( ',' );
+	} else if ( 'finished' === query.status ) {
+		query.status = statusFinished.join( ',' );
+	}
 
 	const queryString = qs.stringify( omitBy( query, val => '' === val ) );
 	return request( siteId ).getWithHeaders( 'orders?' + queryString ).then( ( response ) => {

--- a/client/extensions/woocommerce/style.scss
+++ b/client/extensions/woocommerce/style.scss
@@ -22,6 +22,7 @@
 	@import 'app/dashboard/style';
 	@import 'app/order/style';
 	@import 'app/orders/style';
+	@import 'components/order-status/style';
 	@import 'components/basic-widget/style';
 	@import 'components/share-widget/style';
 	@import 'components/reading-widget/style';


### PR DESCRIPTION
Following up on https://github.com/Automattic/wp-calypso/issues/16288#issuecomment-317385785

I've added new filters for "Awaiting Payment", "Awaiting Fulfillment", and "Completed". These map to groups of WC order statuses:

- Awaiting Payment lists orders `on-hold` and `pending`
- Awaiting Fulfillment lists orders `processing`
- Completed lists orders `completed`, `cancelled`, `refunded`, and `failed`.

This also fixes #16708 by adding the current filter to the SectionNav.

<img width="664" alt="screen shot 2017-08-03 at 1 30 37 pm" src="https://user-images.githubusercontent.com/541093/28934770-1fa33b1e-7850-11e7-9153-7e0406c6353d.png">

<img width="376" alt="screen shot 2017-08-03 at 1 31 38 pm" src="https://user-images.githubusercontent.com/541093/28934769-1f9a4f40-7850-11e7-8805-8f669032445b.png">

**To test:**

- Visit the orders list page: https://calypso.live/store/orders/:site?branch=update/store-orders-filters
- Click through the filters to see your orders
- Visit `/store/orders/pay/:site` directly to see that the correct orders list is loaded