### PR TITLE
Store: Use GEOIP country to filter "Store (BETA)"

### DIFF
--- a/client/extensions/woocommerce/lib/countries/index.js
+++ b/client/extensions/woocommerce/lib/countries/index.js
@@ -14,6 +14,9 @@ import US from './US';
 // want to decorate these objects further in a subsequent PR
 // with things like origin vs destination based tax booleans
 
+// IMPORTANT: If you add a country to this list, you must also add it
+// to ../../my-sites/sidebar/sidebar.jsx in the allowedCountryCodes
+
 export const getCountries = () => {
 	return [
 		US(),

--- a/client/lib/user/shared-utils.js
+++ b/client/lib/user/shared-utils.js
@@ -53,6 +53,7 @@ module.exports = {
 				'email',
 				'email_verified',
 				'is_valid_google_apps_country',
+				'user_ip_country_code',
 				'logout_URL',
 				'primary_blog',
 				'primary_blog_url',

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -359,7 +359,9 @@ export class MySitesSidebar extends Component {
 		}
 
 		const countryCode = currentUser.user_ip_country_code;
-		const isCountryAllowed = includes( allowedCountryCodes, countryCode );
+		const isCountryAllowed =
+			includes( allowedCountryCodes, countryCode ) ||
+			( 'development' === config( 'env' ) );
 
 		return (
 			isCountryAllowed &&

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -7,6 +7,7 @@ import { localize } from 'i18n-calypso';
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import Gridicon from 'gridicons';
+import { includes } from 'lodash';
 
 /**
  * Internal dependencies
@@ -345,13 +346,23 @@ export class MySitesSidebar extends Component {
 	};
 
 	store() {
-		const { canUserManageOptions, isJetpack, site, siteSuffix, translate } = this.props;
+		// IMPORTANT: If you add a country to this list, you must also add it
+		// to ../../extensions/woocommerce/lib/countries in the getCountries function
+		const allowedCountryCodes = [ 'US', 'CA' ];
+		const { currentUser, canUserManageOptions, isJetpack, site, siteSuffix, translate } = this.props;
 		const storeLink = '/store' + siteSuffix;
 		const showStoreLink = config.isEnabled( 'woocommerce/extension-dashboard' ) &&
 			site && isJetpack && canUserManageOptions && this.props.isSiteAutomatedTransfer;
 
+		if ( ! showStoreLink ) {
+			return null;
+		}
+
+		const countryCode = currentUser.user_ip_country_code;
+		const isCountryAllowed = includes( allowedCountryCodes, countryCode );
+
 		return (
-			showStoreLink &&
+			isCountryAllowed &&
 			<SidebarItem
 				label={ translate( 'Store (BETA)' ) }
 				link={ storeLink }


### PR DESCRIPTION
Fixes #16758

This filters the display of the "Store (BETA)" sidebar item based on an
allowed country list. This information is obtained via GEOIP and passed
through the /me user data. (D6669-code)

Note: This has been adjusted to *always* show the Store item in development builds.

To test:

1. Log in to a business Atomic site on the live test site: https://calypso.live/?branch=fix/16758-hide-store-link-based-on-geoip
4. Select the Atomic site from your sites
5. If your country is US or CA, you should see the "Store (BETA)" item. If not, it should not be visible.

Performance notes:

This now uses user data, and the code uses `currentUser` which is retrieved already via `mapStateToProps` on each re-mount of the component. It does not result in additional fetches of user data from the API. I verified this with some console.log lines and `calypso:user` debug:

![developer_tools_-_http___calypso_localhost_3000_stats_day_coderkevintest-automated-transfer_blog_retry_1](https://user-images.githubusercontent.com/945228/28935199-5a961a7c-7849-11e7-9fa8-d5cb5f858c17.png)
