### PR TITLE
Store: Add 'back to dashboard' button to the product create success message while in setup mode

### DIFF
--- a/client/extensions/woocommerce/app/products/product-create.js
+++ b/client/extensions/woocommerce/app/products/product-create.js
@@ -25,12 +25,14 @@ import {
 	clearProductCategoryEdits,
 	editProductCategory,
 } from 'woocommerce/state/ui/product-categories/actions';
+import { fetchSetupChoices } from 'woocommerce/state/sites/setup-choices/actions';
 import { getActionList } from 'woocommerce/state/action-list/selectors';
 import {
 	getCurrentlyEditingId,
 	getProductWithLocalEdits,
 	getProductEdits
 } from 'woocommerce/state/ui/products/selectors';
+import { getFinishedInitialSetup } from 'woocommerce/state/sites/setup-choices/selectors';
 import { getProductVariationsWithLocalEdits } from 'woocommerce/state/ui/products/variations/selectors';
 import { fetchProductCategories } from 'woocommerce/state/sites/product-categories/actions';
 import {
@@ -68,6 +70,7 @@ class ProductCreate extends React.Component {
 				this.props.editProduct( site.ID, null, {} );
 			}
 			this.props.fetchProductCategories( site.ID );
+			this.props.fetchSetupChoices( site.ID );
 		}
 	}
 
@@ -78,6 +81,7 @@ class ProductCreate extends React.Component {
 		if ( oldSiteId !== newSiteId ) {
 			this.props.editProduct( newSiteId, null, {} );
 			this.props.fetchProductCategories( newSiteId );
+			this.props.fetchSetupChoices( newSiteId );
 		}
 	}
 
@@ -92,11 +96,28 @@ class ProductCreate extends React.Component {
 	}
 
 	onSave = () => {
-		const { site, product, translate } = this.props;
+		const { site, product, finishedInitialSetup, translate } = this.props;
 
-		const successAction = ( products ) => {
-			const newProduct = head( products );
-			page.redirect( getLink( '/store/products/:site', site ) );
+		const getSuccessNotice = ( newProduct ) => {
+			if ( ! finishedInitialSetup ) {
+				return successNotice(
+					translate( '%(product)s successfully created. {{productLink}}View{{/productLink}}', {
+						args: {
+							product: newProduct.name,
+						},
+						components: {
+							productLink: <a href={ newProduct.permalink } target="_blank" rel="noopener noreferrer" />,
+						},
+					} ),
+					{
+						displayOnNextPage: true,
+						showDismiss: false,
+						button: translate( 'Back to dashboard' ),
+						href: getLink( '/store/:site', site )
+					}
+				);
+			}
+
 			return successNotice(
 				translate( '%(product)s successfully created.', {
 					args: { product: product.name },
@@ -110,6 +131,12 @@ class ProductCreate extends React.Component {
 					},
 				}
 			);
+		};
+
+		const successAction = ( products ) => {
+			const newProduct = head( products );
+			page.redirect( getLink( '/store/products/:site', site ) );
+			return getSuccessNotice( newProduct );
 		};
 
 		const failureAction = errorNotice(
@@ -170,6 +197,7 @@ function mapStateToProps( state ) {
 	const variations = product && getProductVariationsWithLocalEdits( state, product.id );
 	const productCategories = getProductCategoriesWithLocalEdits( state );
 	const actionList = getActionList( state );
+	const finishedInitialSetup = getFinishedInitialSetup( state );
 
 	return {
 		site,
@@ -178,6 +206,7 @@ function mapStateToProps( state ) {
 		variations,
 		productCategories,
 		actionList,
+		finishedInitialSetup,
 	};
 }
 
@@ -191,6 +220,7 @@ function mapDispatchToProps( dispatch ) {
 			editProductAttribute,
 			editProductVariation,
 			fetchProductCategories,
+			fetchSetupChoices,
 			clearProductEdits,
 			clearProductCategoryEdits,
 			clearProductVariationEdits,


### PR DESCRIPTION
This PR changes up the message for product create if a user is still in setup mode (the checklist dashboard view). It contains a "Back to dashboard" link so users can easily continue on their way through the setup steps, per the comment here: https://github.com/Automattic/wp-calypso/issues/16626#issuecomment-318697464.

<img width="1026" alt="screen shot 2017-08-03 at 10 39 18 am" src="https://user-images.githubusercontent.com/689165/28935092-2ef636e2-7838-11e7-9a08-77b55421c86b.png">

To Test:
* Go to `https://developer.wordpress.com/docs/api/console/` and use the `calypso-preferences` endpoint to set `finished_initial_setup` to 0. Verify that you see the check box setup screen at `http://calypso.localhost:3000/store/:site`.
* Create a new product.
* Verify that you see the above success message, with a view link, and a button that takes you back to the dashboard.
* Click the "I'm finished" button.
* Create another new product.
* Verify that you see a normal success message with just a view option.

Closes #16626. @kellychoffman @jameskoster I agree with iterative changes mentioned in that ticket. If there is anything else we want to track for the future, can we open an Epic like Jay suggested?