### PR TITLE
Comments: Add stats to Comment Management actions

### DIFF
--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -33,8 +33,9 @@ import {
 	withAnalytics,
 } from 'state/analytics/actions';
 
+export const COMMENTS_STATS_GROUP = 'calypso_comment_management';
+
 const COMMENTS_PER_PAGE = 20;
-const COMMENTS_STATS_GROUP = 'calypso_comment_management';
 const LOADING_TIMEOUT = 2000;
 let loadingTimeoutRef;
 

--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -33,8 +33,6 @@ import {
 	withAnalytics,
 } from 'state/analytics/actions';
 
-export const COMMENTS_STATS_GROUP = 'calypso_comment_management';
-
 const COMMENTS_PER_PAGE = 20;
 const LOADING_TIMEOUT = 2000;
 let loadingTimeoutRef;
@@ -461,8 +459,8 @@ const mapStateToProps = ( state, { siteId, status } ) => {
 const mapDispatchToProps = ( dispatch, { siteId } ) => ( {
 	changeCommentStatus: ( commentId, postId, status, analytics = { alsoUnlike: false, isUndo: false } ) => dispatch( withAnalytics(
 		composeAnalytics(
-			recordTracksEvent( COMMENTS_STATS_GROUP + '_change_status', { ...analytics, status } ),
-			bumpStat( COMMENTS_STATS_GROUP, 'comment_status_changed_to_' + status )
+			recordTracksEvent( 'calypso_comment_management_change_status', { ...analytics, status } ),
+			bumpStat( 'calypso_comment_management', 'comment_status_changed_to_' + status )
 		),
 		changeCommentStatus( siteId, postId, commentId, status )
 	) ),
@@ -471,31 +469,31 @@ const mapDispatchToProps = ( dispatch, { siteId } ) => ( {
 
 	deleteComment: ( commentId, postId ) => dispatch( withAnalytics(
 		composeAnalytics(
-			recordTracksEvent( COMMENTS_STATS_GROUP + '_delete' ),
-			bumpStat( COMMENTS_STATS_GROUP, 'comment_deleted' )
+			recordTracksEvent( 'calypso_comment_management_delete' ),
+			bumpStat( 'calypso_comment_management', 'comment_deleted' )
 		),
 		deleteComment( siteId, postId, commentId )
 	) ),
 
 	likeComment: ( commentId, postId, analytics = { alsoApprove: false } ) => dispatch( withAnalytics(
 		composeAnalytics(
-			recordTracksEvent( COMMENTS_STATS_GROUP + '_like', analytics ),
-			bumpStat( COMMENTS_STATS_GROUP, 'comment_liked' )
+			recordTracksEvent( 'calypso_comment_management_like', analytics ),
+			bumpStat( 'calypso_comment_management', 'comment_liked' )
 		),
 		likeComment( siteId, postId, commentId )
 	) ),
 
 	recordChangePage: ( page, total ) => dispatch( composeAnalytics(
-		recordTracksEvent( COMMENTS_STATS_GROUP + '_change_page', { page, total } ),
-		bumpStat( COMMENTS_STATS_GROUP, 'change_page' )
+		recordTracksEvent( 'calypso_comment_management_change_page', { page, total } ),
+		bumpStat( 'calypso_comment_management', 'change_page' )
 	) ),
 
 	removeNotice: noticeId => dispatch( removeNotice( noticeId ) ),
 
 	replyComment: ( commentText, postId, parentCommentId, analytics = { alsoApprove: false } ) => dispatch( withAnalytics(
 		composeAnalytics(
-			recordTracksEvent( COMMENTS_STATS_GROUP + '_reply', analytics ),
-			bumpStat( COMMENTS_STATS_GROUP, 'comment_reply' )
+			recordTracksEvent( 'calypso_comment_management_reply', analytics ),
+			bumpStat( 'calypso_comment_management', 'comment_reply' )
 		),
 		replyComment( commentText, siteId, postId, parentCommentId )
 	) ),
@@ -505,8 +503,8 @@ const mapDispatchToProps = ( dispatch, { siteId } ) => ( {
 
 	unlikeComment: ( commentId, postId ) => dispatch( withAnalytics(
 		composeAnalytics(
-			recordTracksEvent( COMMENTS_STATS_GROUP + '_unlike' ),
-			bumpStat( COMMENTS_STATS_GROUP, 'comment_unliked' )
+			recordTracksEvent( 'calypso_comment_management_unlike' ),
+			bumpStat( 'calypso_comment_management', 'comment_unliked' )
 		),
 		unlikeComment( siteId, postId, commentId )
 	) ),

--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -34,7 +34,7 @@ import {
 } from 'state/analytics/actions';
 
 const COMMENTS_PER_PAGE = 20;
-const COMMENTS_TRACKS_NAME = 'calypso_comment_management';
+const COMMENTS_STATS_GROUP = 'calypso_comment_management';
 const LOADING_TIMEOUT = 2000;
 let loadingTimeoutRef;
 
@@ -459,8 +459,8 @@ const mapStateToProps = ( state, { siteId, status } ) => {
 const mapDispatchToProps = ( dispatch, { siteId } ) => ( {
 	changeCommentStatus: ( commentId, postId, status, analytics = { alsoUnlike: false, isUndo: false } ) => dispatch( withAnalytics(
 		composeAnalytics(
-			recordTracksEvent( COMMENTS_TRACKS_NAME + '_change_status', { ...analytics, status } ),
-			bumpStat( COMMENTS_TRACKS_NAME, 'comment_change_status_to_' + status )
+			recordTracksEvent( COMMENTS_STATS_GROUP + '_change_status', { ...analytics, status } ),
+			bumpStat( COMMENTS_STATS_GROUP, 'comment_change_status_to_' + status )
 		),
 		changeCommentStatus( siteId, postId, commentId, status )
 	) ),
@@ -469,31 +469,31 @@ const mapDispatchToProps = ( dispatch, { siteId } ) => ( {
 
 	deleteComment: ( commentId, postId ) => dispatch( withAnalytics(
 		composeAnalytics(
-			recordTracksEvent( COMMENTS_TRACKS_NAME + '_unlike' ),
-			bumpStat( COMMENTS_TRACKS_NAME, 'comment_unliked' )
+			recordTracksEvent( COMMENTS_STATS_GROUP + '_unlike' ),
+			bumpStat( COMMENTS_STATS_GROUP, 'comment_unliked' )
 		),
 		deleteComment( siteId, postId, commentId )
 	) ),
 
 	likeComment: ( commentId, postId, analytics = { alsoApprove: false } ) => dispatch( withAnalytics(
 		composeAnalytics(
-			recordTracksEvent( COMMENTS_TRACKS_NAME + '_like', analytics ),
-			bumpStat( COMMENTS_TRACKS_NAME, 'comment_liked' )
+			recordTracksEvent( COMMENTS_STATS_GROUP + '_like', analytics ),
+			bumpStat( COMMENTS_STATS_GROUP, 'comment_liked' )
 		),
 		likeComment( siteId, postId, commentId )
 	) ),
 
 	recordChangePage: ( page, total ) => dispatch( composeAnalytics(
-		recordTracksEvent( COMMENTS_TRACKS_NAME + '_change_page', { page, total } ),
-		bumpStat( COMMENTS_TRACKS_NAME, 'change_page' )
+		recordTracksEvent( COMMENTS_STATS_GROUP + '_change_page', { page, total } ),
+		bumpStat( COMMENTS_STATS_GROUP, 'change_page' )
 	) ),
 
 	removeNotice: noticeId => dispatch( removeNotice( noticeId ) ),
 
 	replyComment: ( commentText, postId, parentCommentId, analytics = { alsoApprove: false } ) => dispatch( withAnalytics(
 		composeAnalytics(
-			recordTracksEvent( COMMENTS_TRACKS_NAME + '_reply', analytics ),
-			bumpStat( COMMENTS_TRACKS_NAME, 'comment_reply' )
+			recordTracksEvent( COMMENTS_STATS_GROUP + '_reply', analytics ),
+			bumpStat( COMMENTS_STATS_GROUP, 'comment_reply' )
 		),
 		replyComment( commentText, siteId, postId, parentCommentId )
 	) ),
@@ -503,8 +503,8 @@ const mapDispatchToProps = ( dispatch, { siteId } ) => ( {
 
 	unlikeComment: ( commentId, postId ) => dispatch( withAnalytics(
 		composeAnalytics(
-			recordTracksEvent( COMMENTS_TRACKS_NAME + '_unlike' ),
-			bumpStat( COMMENTS_TRACKS_NAME, 'comment_unliked' )
+			recordTracksEvent( COMMENTS_STATS_GROUP + '_unlike' ),
+			bumpStat( COMMENTS_STATS_GROUP, 'comment_unliked' )
 		),
 		unlikeComment( siteId, postId, commentId )
 	) ),

--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -102,7 +102,8 @@ export class CommentList extends Component {
 	}
 
 	changePage = page => {
-		this.props.recordChangePage( page, ( this.props.comments.length + this.state.persistedComments.length ) );
+		const total = Math.ceil( ( this.props.comments.length + this.state.persistedComments.length ) / COMMENTS_PER_PAGE );
+		this.props.recordChangePage( page, total );
 
 		this.setState( {
 			page,
@@ -460,7 +461,7 @@ const mapDispatchToProps = ( dispatch, { siteId } ) => ( {
 	changeCommentStatus: ( commentId, postId, status, analytics = { alsoUnlike: false, isUndo: false } ) => dispatch( withAnalytics(
 		composeAnalytics(
 			recordTracksEvent( COMMENTS_STATS_GROUP + '_change_status', { ...analytics, status } ),
-			bumpStat( COMMENTS_STATS_GROUP, 'comment_change_status_to_' + status )
+			bumpStat( COMMENTS_STATS_GROUP, 'comment_status_changed_to_' + status )
 		),
 		changeCommentStatus( siteId, postId, commentId, status )
 	) ),

--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -469,8 +469,8 @@ const mapDispatchToProps = ( dispatch, { siteId } ) => ( {
 
 	deleteComment: ( commentId, postId ) => dispatch( withAnalytics(
 		composeAnalytics(
-			recordTracksEvent( COMMENTS_STATS_GROUP + '_unlike' ),
-			bumpStat( COMMENTS_STATS_GROUP, 'comment_unliked' )
+			recordTracksEvent( COMMENTS_STATS_GROUP + '_delete' ),
+			bumpStat( COMMENTS_STATS_GROUP, 'comment_deleted' )
 		),
 		deleteComment( siteId, postId, commentId )
 	) ),

--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -199,7 +199,12 @@ export class CommentList extends Component {
 	};
 
 	setCommentStatus = ( comment, status, options = { isUndo: false, doPersist: false, showNotice: true } ) => {
-		const { commentId, postId, isLiked } = comment;
+		const {
+			commentId,
+			postId,
+			isLiked,
+			status: previousStatus,
+		} = comment;
 		const { isUndo, doPersist, showNotice } = options;
 		const alsoUnlikeComment = isLiked && ( 'approved' !== status );
 
@@ -224,7 +229,7 @@ export class CommentList extends Component {
 		this.props.changeCommentStatus( commentId, postId, status, {
 			alsoUnlike: alsoUnlikeComment,
 			isUndo,
-			previousStatus: comment.status,
+			previousStatus,
 		} );
 
 		// If the comment is not approved anymore, also remove the like
@@ -290,7 +295,11 @@ export class CommentList extends Component {
 			id: `comment-notice-${ commentId }`,
 			isPersistent: true,
 			onClick: () => {
-				this.setCommentStatus( comment, previousStatus, {
+				const updatedComment = {
+					...comment,
+					status: newStatus,
+				};
+				this.setCommentStatus( updatedComment, previousStatus, {
 					isUndo: true,
 					doPersist: options.doPersist,
 					showNotice: false,

--- a/client/my-sites/comments/comment-navigation/index.jsx
+++ b/client/my-sites/comments/comment-navigation/index.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React, { Component } from 'react';
+import { connect } from 'react-redux';
 import Gridicon from 'gridicons';
 import { localize } from 'i18n-calypso';
 import { includes, map } from 'lodash';
@@ -20,6 +21,12 @@ import Search from 'components/search';
 import SectionNav from 'components/section-nav';
 import UrlSearch from 'lib/url-search';
 import { isEnabled } from 'config';
+import {
+	bumpStat,
+	composeAnalytics,
+	recordTracksEvent,
+} from 'state/analytics/actions';
+import { COMMENTS_STATS_GROUP } from 'my-sites/comments/comment-list';
 
 const bulkActions = {
 	unapproved: [ 'approve', 'spam', 'trash' ],
@@ -35,6 +42,8 @@ export class CommentNavigation extends Component {
 		selectedCount: 0,
 		status: 'unapproved',
 	};
+
+	changeFilter = status => () => this.props.recordChangeFilter( status );
 
 	getNavItems = () => {
 		const { translate } = this.props;
@@ -164,6 +173,7 @@ export class CommentNavigation extends Component {
 					{ map( navItems, ( { label }, status ) =>
 						<NavItem
 							key={ status }
+							onClick={ this.changeFilter( status ) }
 							path={ this.getStatusPath( status ) }
 							selected={ queryStatus === status }
 						>
@@ -194,4 +204,11 @@ export class CommentNavigation extends Component {
 	}
 }
 
-export default localize( UrlSearch( CommentNavigation ) );
+const mapDispatchToProps = {
+	recordChangeFilter: status => composeAnalytics(
+		recordTracksEvent( COMMENTS_STATS_GROUP + '_change_filter', { status } ),
+		bumpStat( COMMENTS_STATS_GROUP, 'change_filter_to_' + status )
+	),
+};
+
+export default connect( null, mapDispatchToProps )( localize( UrlSearch( CommentNavigation ) ) );

--- a/client/my-sites/comments/comment-navigation/index.jsx
+++ b/client/my-sites/comments/comment-navigation/index.jsx
@@ -26,7 +26,6 @@ import {
 	composeAnalytics,
 	recordTracksEvent,
 } from 'state/analytics/actions';
-import { COMMENTS_STATS_GROUP } from 'my-sites/comments/comment-list';
 
 const bulkActions = {
 	unapproved: [ 'approve', 'spam', 'trash' ],
@@ -206,8 +205,8 @@ export class CommentNavigation extends Component {
 
 const mapDispatchToProps = {
 	recordChangeFilter: status => composeAnalytics(
-		recordTracksEvent( COMMENTS_STATS_GROUP + '_change_filter', { status } ),
-		bumpStat( COMMENTS_STATS_GROUP, 'change_filter_to_' + status )
+		recordTracksEvent( 'calypso_comment_management_change_filter', { status } ),
+		bumpStat( 'calypso_comment_management', 'change_filter_to_' + status )
 	),
 };
 


### PR DESCRIPTION
Closes #16644 

Add stats tracking to all the Comment Management actions.

All Tracks event are namespaced as `calypso_comment_management_`.
All stats bump are on the `calypso_comment_management` group.

### Events

| Action | Bump | Tracks | Additional Info |
| --- | --- | --- | --- |
| Change Status | `comment_status_changed_to_{status}` | `change_status` | `alsoUnlike`<br>`isUndo`<br>`status` |
| Delete | `comment_deleted` | `delete` ||
| Like | `comment_liked` | `like` | `alsoApprove` |
| Change Page | `change_page` | `change_page` | `page`<br>`total` |
| Reply | `comment_reply` | `reply` | `alsoApprove` |
| Unlike | `comment_unliked` | `unlike` ||
| Change Filter | `change_filter` | `change_filter` | `status` |

### Additional Info

- Change Status
  - `alsoUnlike`: when a liked comment is unapproved, marked as spam, or moved to trash, it also loses its like.
  - `isUndo`: marks if the Change Status action was an undo.
  - `status`: the new comment status.
- Like
  - `alsoApprove`: when an unapproved comment is liked, it also becomes approved.
- Change Page
  - `page`: the page requested.
  - `total`: the total count of pages at the moment of request.
- Reply
  - `alsoApprove`: when replying to an unapproved, spam, or trash comment, that comment becomes approved.
- Change Filter
  - `status`: the new Comment List filter.