### PR TITLE
Notifications: OPEN_SITE to reader site-stream

### DIFF
--- a/client/notifications/index.jsx
+++ b/client/notifications/index.jsx
@@ -172,6 +172,14 @@ export class Notifications extends Component {
 					window.open( href, '_blank' );
 				}
 			} ],
+			OPEN_SITE: [ ( store, { siteId, href } ) => {
+				if ( config.isEnabled( 'notifications/link-to-reader' ) ) {
+					this.props.checkToggle();
+					page( `/read/blogs/${ siteId }` );
+				} else {
+					window.open( href, '_blank' );
+				}
+			} ],
 			VIEW_SETTINGS: [ () => {
 				this.props.checkToggle();
 				page( '/me/notifications' );


### PR DESCRIPTION
This should have no effect yet b/c notifications-panel isn't outputting this event. eventually will take users to a site stream instead of launching externally