### PR TITLE
Comments: Hide all placeholders after the first

### DIFF
--- a/client/blocks/comment-detail/index.jsx
+++ b/client/blocks/comment-detail/index.jsx
@@ -218,7 +218,7 @@ export class CommentDetail extends Component {
 
 		const classes = classNames( 'comment-detail', {
 			'author-is-blocked': authorIsBlocked,
-			'comment-detail__placeholder': isLoading,
+			'comment-detail__placeholder is-loading': isLoading,
 			'is-approved': 'approved' === commentStatus,
 			'is-unapproved': 'unapproved' === commentStatus,
 			'is-bulk-edit': isBulkEdit,

--- a/client/blocks/comment-detail/style.scss
+++ b/client/blocks/comment-detail/style.scss
@@ -9,6 +9,10 @@
 		z-index: z-index( 'root', '.comment-detail.card.accessible-focus:focus' );
 	}
 
+	&.is-loading:not(:first-of-type) {
+		display: none;
+	}
+
 	&.is-expanded {
 		margin: 16px auto;
 


### PR DESCRIPTION
In Comment Management we load comments in two steps.
First we retrieve the comments tree (which is basically a list of comment IDs), then we fetch all the comments in a page, one by one, thanks to the `QueryComment` component inside each of them.

While all the `CommentDetail` components are requesting their own content, they appear as placeholders.

This PR hides all placeholders except the first one, which is a bit more aesthetically pleasing.

There are downsides, though:
- The pagination nav is displayed as soon as we receive the comment tree, and it looks a bit odd when we have the single placeholder.
- If the first comment is not the first to load, we'd still have its placeholder visible while the following comments show up complete.

| Before | After |
| --- | --- |
| ![aug-03-2017 19-41-40](https://user-images.githubusercontent.com/2070010/28937799-f27f2bbe-7883-11e7-9d6d-618d415bac12.gif) | ![aug-03-2017 19-42-34](https://user-images.githubusercontent.com/2070010/28937806-f9a33372-7883-11e7-97a2-aaec1d5b1ade.gif) |