### PR TITLE
Notifications: version bump to open sites from panel

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4528,7 +4528,7 @@
       "dev": true
     },
     "notifications-panel": {
-      "version": "1.2.1"
+      "version": "1.2.2"
     },
     "npm-path": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "ms": "0.7.1",
     "name-all-modules-plugin": "1.0.1",
     "node-sass": "3.7.0",
-    "notifications-panel": "1.2.1",
+    "notifications-panel": "1.2.2",
     "npm-run-all": "4.0.2",
     "numeral": "2.0.4",
     "page": "1.6.4",


### PR DESCRIPTION
Clicking here now brings you to the site stream instead of the frontend (while in Calypso)

<img width="882" alt="site titles" src="https://user-images.githubusercontent.com/4656974/28941413-f9912718-7865-11e7-9776-5f1dbf5a06a8.png">
