### PR TITLE
Add new posts screen

### DIFF
--- a/client/my-sites/posts/main.jsx
+++ b/client/my-sites/posts/main.jsx
@@ -12,7 +12,7 @@ import { map } from 'lodash';
  */
 import PostsNavigation from './posts-navigation';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
-import PostList from './post-list';
+import PostListWrapper from './post-list-wrapper';
 import config from 'config';
 import Main from 'components/main';
 import QueryPosts from 'components/data/query-posts';
@@ -117,7 +117,7 @@ const PostsMain = React.createClass( {
 				<SidebarNavigation />
 				<div className="posts__primary">
 					<PostsNavigation { ...this.props } />
-					<PostList { ...this.props } />
+					<PostListWrapper { ...this.props } />
 				</div>
 				{ path !== '/posts/drafts' && this.mostRecentDrafts() }
 			</Main>

--- a/client/my-sites/posts/post-list-wrapper.jsx
+++ b/client/my-sites/posts/post-list-wrapper.jsx
@@ -7,8 +7,10 @@ import React from 'react';
  * Internal dependencies
  */
 import PostList from './post-list';
+import PostListFetcher from 'components/post-list-fetcher';
 import PostTypeList from 'my-sites/post-type-list';
 import config from 'config';
+import { mapPostStatus } from 'lib/route/path';
 
 class PostListWrapper extends React.Component {
 
@@ -23,15 +25,33 @@ class PostListWrapper extends React.Component {
 	}
 
 	renderPostTypeList() {
+		const query = {
+			status: mapPostStatus( this.props.statusSlug ),
+			author: this.props.author,
+			search: this.props.search,
+			category: this.props.category,
+			tag: this.props.tag,
+		};
+
+		if ( this.props.withCounts ) {
+			query.meta = 'counts';
+		}
+
 		return (
-			<PostTypeList
-				query={
-					{
-						type: 'post',
-					}
-				}
-				siteId={ this.props.siteId }
-			/>
+			<div>
+				<PostListFetcher
+					siteId={ this.props.siteId }
+					status={ mapPostStatus( this.props.statusSlug ) }
+					author={ this.props.author }
+					withImages={ true }
+					withCounts={ true }
+					search={ this.props.search }
+					category={ this.props.category }
+					tag={ this.props.tag }
+				>
+					<PostTypeList query={ query } />
+				</PostListFetcher>
+			</div>
 		);
 	}
 

--- a/client/my-sites/posts/post-list-wrapper.jsx
+++ b/client/my-sites/posts/post-list-wrapper.jsx
@@ -1,0 +1,51 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import PostList from './post-list';
+import PostTypeList from 'my-sites/post-type-list';
+import config from 'config';
+
+class PostListWrapper extends React.Component {
+
+	constructor( props ) {
+		super( props );
+	}
+
+	renderPostList() {
+		return (
+			<PostList { ...this.props } />
+		);
+	}
+
+	renderPostTypeList() {
+		return (
+			<PostTypeList
+				query={
+					{
+						type: 'post',
+					}
+				}
+				siteId={ this.props.siteId }
+			/>
+		);
+	}
+
+	render() {
+		return (
+			<div>
+				{ config.isEnabled( 'posts/post-type-list' )
+					? this.renderPostTypeList()
+					: this.renderPostList()
+
+				}
+			</div>
+		);
+	}
+}
+
+export default PostListWrapper;

--- a/config/development.json
+++ b/config/development.json
@@ -124,6 +124,7 @@
 		"post-editor/image-editor": true,
 		"post-editor/media-advanced": false,
 		"post-editor/video-editor": true,
+		"posts/post-type-list": false,
 		"press-this": true,
 		"publicize-preview": true,
 		"push-notifications": true,


### PR DESCRIPTION
This PR adds a new posts screen using `PostTypeList` as that will allow us to consolidate code and also have a consistent listing of posts (and pages in the future) that takes up less vertical space.

This is part of a larger epic (See p8F9tW-fx-p2).

Since this is the start of our switching of posts to `PostTypeList`, and not all functionality that was there before is available initially, the feature is kept behind a feature flag.

Before:

![before](https://user-images.githubusercontent.com/1017839/29068426-14bdfe4c-7c37-11e7-90ae-64ad9236ed7e.png)

After:

![screen shot 2017-08-08 at 12 42 17 pm](https://user-images.githubusercontent.com/1017839/29068429-1948b376-7c37-11e7-85d9-9d7ac2c8660a.png)

To test the existing behavior:

- Check out branch.
- Run `make run`
- Navigate to Blog Posts (`/posts` and verify that the page works as before, both in All Sites mode and with a specific site.

To test the behavior behind the feature flag:

- Check out branch.
- Run `ENABLE_FEATURES=posts/post-type-list make run`
- Navigate to Blog Posts (`/posts` and verify that the page works as expected, both in All Sites mode and with a specific site.