### PR TITLE
Help: Show Happychat button for all paid plan users in Help contact form

### DIFF
--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -40,7 +40,7 @@ import {
 	getCurrentUserSiteCount,
 } from 'state/current-user/selectors';
 import { askQuestion as askDirectlyQuestion, initialize as initializeDirectly } from 'state/help/directly/actions';
-import { isRequestingSites } from 'state/sites/selectors';
+import { isCurrentPlanPaid, isRequestingSites } from 'state/sites/selectors';
 import {
 	hasUserAskedADirectlyQuestion,
 	isDirectlyFailed,
@@ -48,6 +48,7 @@ import {
 	isDirectlyUninitialized,
 } from 'state/selectors';
 import QueryUserPurchases from 'components/data/query-user-purchases';
+import { getHelpSelectedSiteId } from 'state/help/selectors';
 
 /**
  * Module variables
@@ -402,9 +403,8 @@ const HelpContact = React.createClass( {
 		if ( ! config.isEnabled( 'happychat' ) ) {
 			return false;
 		}
-
 		// if the happychat connection is able to accept chats, use it
-		return this.props.isHappychatAvailable && olark.isUserEligible;
+		return this.props.isHappychatAvailable && olark.isUserEligible && this.props.isSelectedHelpSiteOnPaidPlan;
 	},
 
 	shouldUseDirectly: function() {
@@ -675,6 +675,7 @@ const HelpContact = React.createClass( {
 
 export default connect(
 	( state ) => {
+		const helpSelectedSiteId = getHelpSelectedSiteId( state );
 		return {
 			currentUserLocale: getCurrentUserLocale( state ),
 			currentUser: getCurrentUser( state ),
@@ -690,6 +691,7 @@ export default connect(
 			ticketSupportRequestError: getTicketSupportRequestError( state ),
 			hasMoreThanOneSite: getCurrentUserSiteCount( state ) > 1,
 			isRequestingSites: isRequestingSites( state ),
+			isSelectedHelpSiteOnPaidPlan: isCurrentPlanPaid( state, helpSelectedSiteId ),
 		};
 	},
 	{

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -403,8 +403,10 @@ const HelpContact = React.createClass( {
 		if ( ! config.isEnabled( 'happychat' ) ) {
 			return false;
 		}
+
 		// if the happychat connection is able to accept chats, use it
-		return this.props.isHappychatAvailable && olark.isUserEligible && this.props.isSelectedHelpSiteOnPaidPlan;
+		return ( this.props.isHappychatAvailable && olark.isUserEligible &&
+			this.props.isSelectedHelpSiteOnPaidPlan );
 	},
 
 	shouldUseDirectly: function() {

--- a/client/state/happychat/middleware.js
+++ b/client/state/happychat/middleware.js
@@ -113,7 +113,13 @@ export const connectChat = ( connection, { getState, dispatch } ) => {
 
 	const user = getCurrentUser( state );
 	const locale = getCurrentUserLocale( state );
-	const groups = getGroups( state );
+	let groups = getGroups( state, );
+
+	// update the chat locale and groups when happychat is initialized
+	const selectedSite = getHelpSelectedSite( state );
+	if ( selectedSite && selectedSite.ID ) {
+		groups = getGroups( state, selectedSite.ID );
+	}
 
 	// Notify that a new connection is being established
 	dispatch( setConnecting() );
@@ -124,14 +130,6 @@ export const connectChat = ( connection, { getState, dispatch } ) => {
 	connection
 		.on( 'connected', () => {
 			dispatch( setConnected() );
-
-			// update the chat locale and groups after happychat connection is established
-			// this was added just to make sure the proper operators are targeted if the customer
-			// selects a different site in the help dropdown before happychat is connected
-			const selectedHelpSite = getHelpSelectedSite( getState() );
-			if ( selectedHelpSite && selectedHelpSite.ID ) {
-				updateChatPreferences( connection, { getState }, selectedHelpSite.ID );
-			}
 
 			// TODO: There's no need to dispatch a separate action to request a transcript.
 			// The HAPPYCHAT_CONNECTED action should have its own middleware handler that does this.

--- a/client/state/happychat/middleware.js
+++ b/client/state/happychat/middleware.js
@@ -113,7 +113,7 @@ export const connectChat = ( connection, { getState, dispatch } ) => {
 
 	const user = getCurrentUser( state );
 	const locale = getCurrentUserLocale( state );
-	let groups = getGroups( state, );
+	let groups = getGroups( state );
 
 	// update the chat locale and groups when happychat is initialized
 	const selectedSite = getHelpSelectedSite( state );

--- a/client/state/happychat/selectors.js
+++ b/client/state/happychat/selectors.js
@@ -17,7 +17,7 @@ import {
 	HAPPYCHAT_GROUP_JPOP,
 	HAPPYCHAT_CONNECTION_ERROR_PING_TIMEOUT
 } from './constants';
-import { isJetpackSite, getSite, isCurrentPlanPaid } from 'state/sites/selectors';
+import { isJetpackSite, getSite } from 'state/sites/selectors';
 import { isATEnabled } from 'lib/automated-transfer';
 
 // How much time needs to pass before we consider the session inactive:
@@ -46,7 +46,7 @@ export const getGroups = ( state, siteId ) => {
 	if ( isATEnabled( siteDetails ) ) {
 		// AT sites should go to WP.com even though they are jetpack also
 		groups.push( HAPPYCHAT_GROUP_WPCOM );
-	} else if ( isJetpackSite( state, siteId ) && isCurrentPlanPaid( state, siteId ) ) {
+	} else if ( isJetpackSite( state, siteId ) ) {
 		groups.push( HAPPYCHAT_GROUP_JPOP );
 	} else {
 		groups.push( HAPPYCHAT_GROUP_WPCOM );

--- a/client/state/help/selectors.js
+++ b/client/state/help/selectors.js
@@ -5,12 +5,21 @@ import { getSelectedOrPrimarySiteId } from 'state/selectors';
 import { getSite } from 'state/sites/selectors';
 import createSelector from 'lib/create-selector';
 
-export const getHelpSelectedSiteId = createSelector(
+export const getHelpSiteId = createSelector(
 	state => state.help.selectedSiteId
 );
 
 export const getHelpSelectedSite = ( state ) => {
-	const siteId = getHelpSelectedSiteId( state ) || getSelectedOrPrimarySiteId( state );
+	const siteId = getHelpSiteId( state ) || getSelectedOrPrimarySiteId( state );
 
 	return getSite( state, siteId );
+};
+
+export const getHelpSelectedSiteId = ( state ) => {
+	const site = getHelpSelectedSite( state );
+
+	if ( site && site.ID ) {
+		return site.ID;
+	}
+	return null;
 };

--- a/client/state/help/test/selectors.js
+++ b/client/state/help/test/selectors.js
@@ -8,11 +8,11 @@ import deepFreeze from 'deep-freeze';
  * Internal dependencies
  */
 import {
-	getHelpSelectedSiteId,
+	getHelpSiteId,
 } from '../selectors';
 
 describe( 'selectors', () => {
-	describe( '#getHelpSelectedSiteId()', () => {
+	describe( '#getHelpSiteId()', () => {
 		it( 'should return null for default state', () => {
 			const state = deepFreeze( {
 				help: {
@@ -20,7 +20,7 @@ describe( 'selectors', () => {
 				}
 			} );
 
-			expect( getHelpSelectedSiteId( state ) ).to.be.null;
+			expect( getHelpSiteId( state ) ).to.be.null;
 		} );
 
 		it( 'should return courses for given state', () => {
@@ -30,7 +30,7 @@ describe( 'selectors', () => {
 				}
 			} );
 
-			expect( getHelpSelectedSiteId( state ) ).to.eql( state.help.selectedSiteId );
+			expect( getHelpSiteId( state ) ).to.eql( state.help.selectedSiteId );
 		} );
 	} );
 } );


### PR DESCRIPTION
Adds a check for paid plans when checking elegibility for Happychat support in Contact form. 

The Happychat button will be shown only for sites with Paid Plans.

Note: _Even when this PR makes the Happychat button be shown for all paid plans, .org plans chats are still being routed to .com queues. 

#### Testing instructions

1. Start by logging into the staging HUD (this will make you an available operator).
1. Get to the help section in the live branch.
1. Click the "Contact us" button (this will lead you to the contact form.
1. Select a Jetpack site with a free plan (you should see the "Email us" form.
1. Select a Jetpack site with a paid plan (You should see the Happychat form)
1. Select a .com site on a free plan (you should see the Email us form).
1. Select a .com site with a paid plan (You should see the Happychat form)

**The problem right now is that even when you select a Jetpack site, you're still routed to the .com queue for chat support** 