### PR TITLE
Store: Move order date time to top of order details view

### DIFF
--- a/client/extensions/woocommerce/app/order/order-details.js
+++ b/client/extensions/woocommerce/app/order/order-details.js
@@ -96,8 +96,8 @@ class OrderDetails extends Component {
 					<span>{ this.renderStatus() }</span>
 				</SectionHeader>
 				<Card className="order__details-card">
-					<OrderDetailsTable order={ order } site={ site } />
 					<OrderCreated order={ order } site={ site } />
+					<OrderDetailsTable order={ order } site={ site } />
 					<OrderRefundCard order={ order } site={ site } />
 					<OrderFulfillment order={ order } site={ site } />
 				</Card>

--- a/client/extensions/woocommerce/app/order/style.scss
+++ b/client/extensions/woocommerce/app/order/style.scss
@@ -206,6 +206,11 @@
 	}
 }
 
+.order__details-created {
+	border-top-width: 0;
+	border-bottom: 1px solid lighten( $gray, 30% );
+}
+
 .order__details-fulfillment {
 	background: lighten( $blue-light, 25% );
 

--- a/client/extensions/woocommerce/app/order/style.scss
+++ b/client/extensions/woocommerce/app/order/style.scss
@@ -180,6 +180,15 @@
 		align-items: center;
 		flex-grow: 1;
 	}
+	
+	.order__details-created-label {
+		font-size: 14px;
+	}
+	
+	.order__details-created-label .gridicon,
+	.order__details-fulfillment-label .gridicon {
+		color: $gray;
+	}
 
 	.order__details-refund-label .gridicon {
 		color: $alert-green;
@@ -208,7 +217,9 @@
 
 .order__details-created {
 	border-top-width: 0;
-	border-bottom: 1px solid lighten( $gray, 30% );
+	border-bottom: 1px solid lighten( $gray, 20% );
+	padding-top: 16px;
+	padding-bottom: 16px;
 }
 
 .order__details-fulfillment {


### PR DESCRIPTION
Fixes #16381 - this time moving the order date time to the top of the view

To see this in action, navigate to http://calypso.localhost:3000/store/orders/{site} and then pick an order from the orders-list. Ensure the order date time is presented first in the Order Details, i.e. before the item list.