### PR TITLE
Tweak gravatar description icon size and copy

### DIFF
--- a/client/blocks/edit-gravatar/index.jsx
+++ b/client/blocks/edit-gravatar/index.jsx
@@ -248,8 +248,7 @@ export class EditGravatar extends Component {
 										href={ gravatarLink }
 										target="_blank"
 										rel="noopener noreferrer"
-										icon={ true }
-										iconSize={ 14 } />,
+										icon={ true } />,
 									p: <p />
 								},
 								args: {

--- a/client/blocks/edit-gravatar/index.jsx
+++ b/client/blocks/edit-gravatar/index.jsx
@@ -239,7 +239,7 @@ export class EditGravatar extends Component {
 						position="left" >
 						{ translate( '{{p}}The avatar you use on WordPress.com comes ' +
 							'from {{ExternalLink}}Gravatar{{/ExternalLink}}, a universal avatar service ' +
-							'(it stands for "Global Avatar," get it?).{{/p}}' +
+							'(it stands for "Globally Recognized Avatar," get it?).{{/p}}' +
 							'{{p}}Your image may also appear on other sites using Gravatar ' +
 							"whenever you're logged in with your email address %(email)s.{{/p}}",
 							{
@@ -248,7 +248,8 @@ export class EditGravatar extends Component {
 										href={ gravatarLink }
 										target="_blank"
 										rel="noopener noreferrer"
-										icon={ true } />,
+										icon={ true }
+										iconSize={ 14 } />,
 									p: <p />
 								},
 								args: {


### PR DESCRIPTION
"Globally Recognized Avatar" is what "Gravatar" is an abbreviation for, according to https://en.gravatar.com/ (cc @michelleweber).

Also shrunk the external link icon to fit into the height of the line.

Before | After
-- | --
<img width="231" alt="screen shot 2017-08-03 at 6 31 26 pm" src="https://user-images.githubusercontent.com/1867547/28946794-63ffdefa-787a-11e7-8555-e2a2ca82ff67.png"> | <img width="235" alt="screen shot 2017-08-03 at 6 30 55 pm" src="https://user-images.githubusercontent.com/1867547/28946800-6a08161e-787a-11e7-89ad-25064916f79c.png">