### PR TITLE
Purchases: handle domains that lack explicit renew 

### DIFF
--- a/client/lib/purchases/assembler.js
+++ b/client/lib/purchases/assembler.js
@@ -16,6 +16,7 @@ function createPurchaseObject( purchase ) {
 		amount: Number( purchase.amount ),
 		attachedToPurchaseId: Number( purchase.attached_to_purchase_id ),
 		canDisableAutoRenew: Boolean( purchase.can_disable_auto_renew ),
+		canExplicitRenew: Boolean( purchase.can_explicit_renew ),
 		currencyCode: purchase.currency_code,
 		currencySymbol: purchase.currency_symbol,
 		domain: purchase.domain,

--- a/client/lib/purchases/index.js
+++ b/client/lib/purchases/index.js
@@ -171,6 +171,14 @@ function isRemovable( purchase ) {
 	return isExpiring( purchase ) || isExpired( purchase );
 }
 
+/**
+ * Checks whether the purchase is in a renewable state per alot of underlying
+ * business logic like "have we captured an auth?", "are we within 90 days of expiry?",
+ * "is this part of a bundle?", etc.
+ *
+ * @param {Object} purchase - the purchase with which we are concerned
+ * @return {boolean} true if the purchase is renewable per business logic, false otherwise
+ */
 function isRenewable( purchase ) {
 	return purchase.isRenewable;
 }
@@ -202,6 +210,18 @@ function isPaidWithPayPalDirect( purchase ) {
 
 function hasCreditCardData( purchase ) {
 	return Boolean( purchase.payment.creditCard.expiryMoment );
+}
+
+/**
+ * Checks whether the purchase is capable of being renewed by intentional
+ * action (eg, a button press by user). Some purchases (eg, .fr domains)
+ * are only renewable via auto-renew.
+ *
+ * @param {Object} purchase - the purchase with which we are concerned
+ * @return {boolean} true if the purchase is capable of explicit renew
+ */
+function canExplicitRenew( purchase ) {
+	return purchase.canExplicitRenew;
 }
 
 function creditCardExpiresBeforeSubscription( purchase ) {
@@ -256,6 +276,7 @@ function showCreditCardExpiringWarning( purchase ) {
 }
 
 export {
+	canExplicitRenew,
 	creditCardExpiresBeforeSubscription,
 	getIncludedDomain,
 	getName,

--- a/client/me/purchases/manage-purchase/notices.jsx
+++ b/client/me/purchases/manage-purchase/notices.jsx
@@ -11,6 +11,7 @@ import { connect } from 'react-redux';
 import { recordTracksEvent } from 'state/analytics/actions';
 import config from 'config';
 import {
+	canExplicitRenew,
 	creditCardExpiresBeforeSubscription,
 	getName,
 	isExpired,
@@ -80,9 +81,19 @@ class PurchaseNotice extends Component {
 	}
 
 	renderRenewNoticeAction( onClick ) {
-		const { translate } = this.props;
+		const purchase = getPurchase( this.props );
+		const { editCardDetailsPath, translate } = this.props;
+
 		if ( ! config.isEnabled( 'upgrades/checkout' ) || ! getSelectedSite( this.props ) ) {
 			return null;
+		}
+
+		if ( ! canExplicitRenew( purchase ) ) {
+			return (
+				<NoticeAction href={ editCardDetailsPath }>
+					{ translate( 'Enable Auto Renew' ) }
+				</NoticeAction>
+			);
 		}
 
 		return (

--- a/client/state/purchases/test/selectors.js
+++ b/client/state/purchases/test/selectors.js
@@ -70,6 +70,7 @@ describe( 'selectors', () => {
 				active: false,
 				amount: NaN,
 				attachedToPurchaseId: NaN,
+				canExplicitRenew: false,
 				canDisableAutoRenew: false,
 				currencyCode: undefined,
 				currencySymbol: undefined,


### PR DESCRIPTION
Some domains, eg fr and de, do not support explicit renewals. We shouldn’t provoke the user in that direction when it isn’t possible.