### PR TITLE
Login: Move error messages to the API

### DIFF
--- a/client/auth/login.jsx
+++ b/client/auth/login.jsx
@@ -22,12 +22,14 @@ import * as AuthActions from 'lib/oauth-store/actions';
 import eventRecorder from 'me/event-recorder';
 import WordPressLogo from 'components/wordpress-logo';
 import AuthCodeButton from './auth-code-button';
+import { addLocaleToWpcomUrl, getLocaleSlug } from 'lib/i18n-utils';
 
 const LostPassword = React.createClass( {
 	render: function() {
+		const url = addLocaleToWpcomUrl( 'https://wordpress.com/wp-login.php?action=lostpassword', getLocaleSlug() );
 		return (
 			<p className="auth__lost-password">
-				<a href="https://wordpress.com/wp-login.php?action=lostpassword" target="_blank" rel="noopener noreferrer">
+				<a href={ url } target="_blank" rel="noopener noreferrer">
 					{ this.translate( 'Lost your password?' ) }
 				</a>
 			</p>

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1605,6 +1605,10 @@ Undocumented.prototype.validateNewUser = function( data, fn ) {
  */
 Undocumented.prototype.requestMagicLoginEmail = function( data, fn ) {
 	restrictByOauthKeys( data );
+
+	data.locale = i18n.getLocaleSlug();
+	data.lang_id = i18n.getLanguage( data.locale ).value;
+
 	return this.wpcom.req.post( '/auth/send-login-email', {
 		apiVersion: '1.2',
 	}, data, fn );

--- a/client/state/data-layer/wpcom/login-2fa/index.js
+++ b/client/state/data-layer/wpcom/login-2fa/index.js
@@ -23,6 +23,7 @@ import {
 import { http } from 'state/http/actions';
 import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { local } from 'state/data-layer/utils';
+import { addLocaleToWpcomUrl, getLocaleSlug } from 'lib/i18n-utils';
 
 /***
  * Module constants
@@ -34,7 +35,7 @@ const requestTwoFactorPushNotificationStatus = ( store, action ) => {
 
 	store.dispatch(
 		http( {
-			url: 'https://wordpress.com/wp-login.php?action=two-step-authentication-endpoint',
+			url: addLocaleToWpcomUrl( 'https://wordpress.com/wp-login.php?action=two-step-authentication-endpoint', getLocaleSlug() ),
 			method: 'POST',
 			headers: [
 				[ 'Content-Type', 'application/x-www-form-urlencoded' ],

--- a/client/state/login/actions.js
+++ b/client/state/login/actions.js
@@ -113,23 +113,23 @@ function getErrorFromHTTPError( httpError ) {
 		};
 	}
 
-	let code = get( httpError, 'response.body.data.errors.code' );
-	if ( code ) {
-		message = get( httpError, 'response.body.data.errors.message' );
+	// TODO: Simplify this block when we're done with the fallback.
+	let code = get( httpError, 'response.body.data.errors[0]' );
+	if ( typeof code === 'object' ) {
+		message = code.message;
+		code = code.code;
 	} else {
-		// TODO: Remove when we're done with the fallback.
-		code = get( httpError, 'response.body.data.errors[0]' );
 		message = getErrorMessageFromErrorCode( code );
 	}
 
 	if ( code ) {
-		message = getErrorMessageFromErrorCode( code );
-
 		if ( code in errorFields ) {
 			field = errorFields[ code ];
 		}
-	} else {
-		message = get( httpError, 'response.body.data', httpError.message );
+
+		if ( ! message ) {
+			message = get( httpError, 'response.body.data', httpError.message );
+		}
 	}
 
 	return { code, message, field };

--- a/client/state/login/actions.js
+++ b/client/state/login/actions.js
@@ -43,7 +43,7 @@ import {
 } from 'state/login/selectors';
 import { getCurrentUser } from 'state/current-user/selectors';
 import wpcom from 'lib/wp';
-import i18nUtils from 'lib/i18n-utils';
+import { addLocaleToWpcomUrl, getLocaleSlug } from 'lib/i18n-utils';
 
 // TODO: Remove when we're done with the fallback.
 function getErrorMessageFromErrorCode( code ) {
@@ -94,14 +94,6 @@ const errorFields = {
 	invalid_two_step_code: 'twoStepCode',
 	invalid_username: 'usernameOrEmail',
 };
-
-function getLocalizedLoginURL( action ) {
-	if ( 'en' === i18nUtils.getLocaleSlug() ) {
-		return 'https://wordpress.com/wp-login.php?action=' + action;
-	}
-
-	return 'https://' + i18nUtils.getLocaleSlug() + '.wordpress.com/wp-login.php?action=' + action;
-}
 
 /**
  * Retrieves the first error message from the specified HTTP error.
@@ -177,7 +169,7 @@ export const loginUser = ( usernameOrEmail, password, rememberMe, redirectTo ) =
 		type: LOGIN_REQUEST,
 	} );
 
-	return request.post( getLocalizedLoginURL( 'login-endpoint' ) )
+	return request.post( addLocaleToWpcomUrl( 'https://wordpress.com/wp-login.php?action=login-endpoint', getLocaleSlug() ) )
 		.withCredentials()
 		.set( 'Content-Type', 'application/x-www-form-urlencoded' )
 		.accept( 'application/json' )
@@ -227,7 +219,8 @@ export const loginUser = ( usernameOrEmail, password, rememberMe, redirectTo ) =
 export const loginUserWithTwoFactorVerificationCode = ( twoStepCode, twoFactorAuthType ) => ( dispatch, getState ) => {
 	dispatch( { type: TWO_FACTOR_AUTHENTICATION_LOGIN_REQUEST } );
 
-	return request.post( getLocalizedLoginURL( 'two-step-authentication-endpoint' ) )
+	return request.post(
+			addLocaleToWpcomUrl( 'https://wordpress.com/wp-login.php?action=two-step-authentication-endpoint', getLocaleSlug() ) )
 		.withCredentials()
 		.set( 'Content-Type', 'application/x-www-form-urlencoded' )
 		.accept( 'application/json' )
@@ -276,7 +269,7 @@ export const loginUserWithTwoFactorVerificationCode = ( twoStepCode, twoFactorAu
 export const loginSocialUser = ( service, token, redirectTo ) => dispatch => {
 	dispatch( { type: SOCIAL_LOGIN_REQUEST } );
 
-	return request.post( getLocalizedLoginURL( 'social-login-endpoint' ) )
+	return request.post( addLocaleToWpcomUrl( 'https://wordpress.com/wp-login.php?action=social-login-endpoint', getLocaleSlug() ) )
 		.withCredentials()
 		.set( 'Content-Type', 'application/x-www-form-urlencoded' )
 		.accept( 'application/json' )
@@ -389,7 +382,7 @@ export const sendSmsCode = () => ( dispatch, getState ) => {
 		},
 	} );
 
-	return request.post( getLocalizedLoginURL( 'send-sms-code-endpoint' ) )
+	return request.post( addLocaleToWpcomUrl( 'https://wordpress.com/wp-login.php?action=send-sms-code-endpoint', getLocaleSlug() ) )
 		.set( 'Content-Type', 'application/x-www-form-urlencoded' )
 		.accept( 'application/json' )
 		.send( {
@@ -439,7 +432,7 @@ export const logoutUser = ( redirectTo ) => ( dispatch, getState ) => {
 	const logoutNonceMatches = ( currentUser.logout_URL || '' ).match( /_wpnonce=([^&]*)/ );
 	const logoutNonce = logoutNonceMatches && logoutNonceMatches[ 1 ];
 
-	return request.post( getLocalizedLoginURL( 'logout-endpoint' ) )
+	return request.post( addLocaleToWpcomUrl( 'https://wordpress.com/wp-login.php?action=logout-endpoint', getLocaleSlug() ) )
 		.withCredentials()
 		.set( 'Content-Type', 'application/x-www-form-urlencoded' )
 		.accept( 'application/json' )

--- a/client/state/login/actions.js
+++ b/client/state/login/actions.js
@@ -110,7 +110,7 @@ function getLocalizedLoginURL( action ) {
  * @returns {{code: string?, message: string, field: string}} an error message and the id of the corresponding field, if not global
  */
 function getErrorFromHTTPError( httpError ) {
-	let message, code;
+	let message;
 	let field = 'global';
 
 	if ( ! httpError.status ) {
@@ -121,12 +121,12 @@ function getErrorFromHTTPError( httpError ) {
 		};
 	}
 
-	code = get( httpError, 'response.body.data.errors.code' );
+	let code = get( httpError, 'response.body.data.errors.code' );
 	if ( code ) {
 		message = get( httpError, 'response.body.data.errors.message' );
 	} else {
 		// TODO: Remove when we're done with the fallback.
-		code = get( httpError, 'response.body.data.errors[0]', false );
+		code = get( httpError, 'response.body.data.errors[0]' );
 		message = getErrorMessageFromErrorCode( code );
 	}
 


### PR DESCRIPTION
This pull request fixes #15476 by retrieving error messages from the API, instead of storing them in Calypso.

This is a repeat of the previously reverted #15485.

#### Testing instructions

1. Run `git checkout fix/15476-login-messages-from-api-second-attempt` and start your server, or open a [live branch](https://calypso.live/log-in?branch=fix/15476-login-messages-from-api-second-attempt)
2. Sandbox wordpress.com, and any localised domains you want to test. Ie, fr.wordpress.com, es.wordpress.com.
3. Open the [`Log In` page](http://calypso.localhost:3000/log-in)
4. Check appropriate error messages display throughout the login process.
5. Check that the error messages are translated correctly when using a different locale.
6. Apply D6126 to your sandbox.
7. Repeat steps 3-5, ensuring you get the same messages.

#### Additional Notes

~~This was previously reverted due to wordpress.com not being recognised as a valid CORS domain. D6692 will need to be deployed before this PR is merged.~~

D6692 has been deployed.

#### Deploy Notes

1. ~~D6692 must be deployed first.~~
2. This PR can then be merged and deployed.
3. Wait 24+ hours, to ensure everyone currently on the login page is using this code, rather than an older version.
4. Deploy D6126.
5. Merge and deploy #16738.

#### Reviews

- [ ] Code
