### PR TITLE
Bump eslint-plugin-wpcalypso version to 3.4.1

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -836,7 +836,7 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000709"
+      "version": "1.0.30000710"
     },
     "cardinal": {
       "version": "1.0.0",
@@ -1855,7 +1855,7 @@
       }
     },
     "eslint-plugin-wpcalypso": {
-      "version": "3.3.0",
+      "version": "3.4.1",
       "dev": true
     },
     "esmangle-evaluator": {
@@ -6691,8 +6691,14 @@
           "dev": true
         },
         "finalhandler": {
-          "version": "1.0.3",
-          "dev": true
+          "version": "1.0.4",
+          "dev": true,
+          "dependencies": {
+            "debug": {
+              "version": "2.6.8",
+              "dev": true
+            }
+          }
         },
         "fresh": {
           "version": "0.5.0",

--- a/package.json
+++ b/package.json
@@ -246,7 +246,7 @@
     "eslint-config-wpcalypso": "0.8.0",
     "eslint-eslines": "0.0.3",
     "eslint-plugin-react": "6.4.1",
-    "eslint-plugin-wpcalypso": "3.3.0",
+    "eslint-plugin-wpcalypso": "3.4.1",
     "glob": "7.0.3",
     "husky": "0.13.3",
     "jscodeshift": "0.3.30",


### PR DESCRIPTION
There are a few nice updates in `eslint-plugin-wpcalypso` since 3.3.0 -- like Automattic/eslint-plugin-wpcalypso#42 that I did yesterday. Let's use them!