### PR TITLE
Comments: Prevent collapsing when liking unapproved comments

### DIFF
--- a/client/blocks/comment-detail/index.jsx
+++ b/client/blocks/comment-detail/index.jsx
@@ -129,16 +129,7 @@ export class CommentDetail extends Component {
 		}
 	}
 
-	toggleLike = () => {
-		const { commentIsLiked, commentStatus, toggleCommentLike } = this.props;
-		const shouldPersist = 'unapproved' === commentStatus && ! commentIsLiked;
-
-		toggleCommentLike( getCommentStatusAction( this.props ) );
-
-		if ( shouldPersist ) {
-			this.setState( { isExpanded: false } );
-		}
-	}
+	toggleLike = () => this.props.toggleCommentLike( getCommentStatusAction( this.props ) );
 
 	toggleSelected = () => {
 		const { commentId, toggleCommentSelected } = this.props;

--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -328,8 +328,12 @@ export class CommentList extends Component {
 		this.props.likeComment( commentId, postId, { alsoApprove } );
 
 		if ( alsoApprove ) {
+			const updatedComment = {
+				...comment,
+				isLiked: true,
+			};
 			this.props.removeNotice( `comment-notice-${ commentId }` );
-			this.setCommentStatus( comment, 'approved' );
+			this.setCommentStatus( updatedComment, 'approved' );
 			this.updatePersistedComments( commentId );
 		}
 	}


### PR DESCRIPTION
Fixes a visual issue where the comment detail is collapsed when liking an unapproved comment.

This happened because of the different behaviours in place: changing status collapse; toggling like doesn't. Liking an unapproved comment also approves it.

Also fixes a bug where undoing a like+approve didn't remove the like.