### PR TITLE
Analytics: updated PII protection rules

### DIFF
--- a/client/lib/analytics/utils.js
+++ b/client/lib/analytics/utils.js
@@ -7,46 +7,43 @@ function doNotTrack() {
 	return '1' === navigator.doNotTrack;
 }
 
+// If this list catches things that are not necessarily forbidden we're ok with
+// a little bit of approximation as long as we do catch the ones that we have to.
+// We need to be quite aggressive with how we filter candiate pages as failing
+// to protect our users' privacy puts us in breach of our own TOS and our
+// retargeting partners' TOS. We also see personally identifiable information in
+// unexpected places like email addresses in users' posts URLs and titles for
+// various (usually accidental) reasons. We also pass PII in URLs like
+// `wordpress.com/jetpack/connect` and `wordpress.com/error-report`.
+const forbiddenPiiPatterns = [
+	'@',
+	'email=',
+	'email_address=',
+	'first=',
+	'last=',
+	'first-name=',
+	'last-name=',
+	'address-1=',
+	'phone=',
+];
+
+const forbiddenPiiPatternsEnc = forbiddenPiiPatterns.map( pattern => {
+	return encodeURIComponent( pattern );
+} );
+
 /**
  * Whether the current URL can potentially contain personally identifiable info.
  *
  * @returns {Boolean} true if the current URL can potentially contain personally identifiable info.
  */
 function isPiiUrl() {
-	// If this list catches things that are not necessarily forbidden we're ok with
-	// a little bit of approximation as long as we do catch the ones that we have to.
-	// We need to be quite aggressive with how we filter candiate pages as failing
-	// to protect our users' privacy puts us in breach of our own TOS and our
-	// retargeting partners' TOS. We also see personally identifiable information in
-	// unexpected places like email addresses in users' posts URLs and titles for
-	// various (usually accidental) reasons. We also pass PII in URLs like
-	// `wordpress.com/jetpack/connect` etc.
-	const forbiddenPatterns = [
-		'@',
-		'%40',
-		'first=',
-		'last=',
-		'email=',
-		'email_address=',
-		'user_email=',
-		'address-1=',
-		'country-code=',
-		'phone=',
-		'last-name=',
-		'first-name=',
-		'wordpress.com/jetpack/connect',
-		'wordpress.com/error-report',
-	];
-
 	const href = document.location.href;
 
-	for ( const pattern of forbiddenPatterns ) {
-		if ( href.indexOf( pattern ) !== -1 ) {
-			return true;
-		}
+	const match = pattern => {
+		return href.indexOf( pattern ) !== -1;
 	}
 
-	return false;
+	return forbiddenPiiPatterns.some( match ) || forbiddenPiiPatternsEnc.some( match );
 }
 
 module.exports = {


### PR DESCRIPTION
I've updated the list of URL patterns that block Google Analytics and the other marketing scripts.

Fixes issue #16318.

# Context

In order to protect our user's personally identifiable information (emails, names, addresses, phone numbers etc.) found in URLs, we prevent GA and other marketing scripts from tracking those URLs. This is to comply with both ours and our partners' TOS.

The previous list of PII patterns was only capturing unencoded data, so I've updated the list to include the encoded versions as well.

# Implementation Details

An alternative implementation would have been to have one single list of unencoded patterns and match it against both `document.location.href` and `decodeURIComponent( document.location.href )`. This kind of worked but it'd throw an exception when a malformed URL was given (malformed URLs were actually present in the list of offending addresses Google sent us).

So a more robust solution seemed to be to just encode the list of patterns and test them against the plain `document.location.href`.

# Testing Plan

- Edit `config/development.json` and set `"google_analytics_enabled": true` and `"ad-tracking": true`
- Restart Calypso
- Visit http://calypso.localhost:3000
- Enable debugging logs from JS console: `localStorage.setItem( 'debug', 'calypso:analytics:*' );`

- When visiting the following URLs you **should not** see any `calypso:analytics:ad-tracking` or `calypso:analytics:ga` entries, which means that they are **being blocked**. You should still see the `calypso:analytics:tracks` and `calypso:analytics:mc` ones though.

  - http://calypso.localhost:3000/?email%3Dsomething
  - http://calypso.localhost:3000/?email=something
  - http://calypso.localhost:3000/?info=redacted@example.com
  - http://calypso.localhost:3000/?info=redacted%40example.com

Example:

![calypso-pii-blocked](https://user-images.githubusercontent.com/10284338/28969090-698a5ef0-7923-11e7-9c6c-2ed165a66400.png)

- When visiting the following URLs you **should** see various `calypso:analytics:ad-tracking` and `calypso:analytics:ga` entries, which means that they are **not being blocked**.

  - http://calypso.localhost:3000/
  - http://calypso.localhost:3000/?nomail%3Dsomething
  - http://calypso.localhost:3000/?nomail=something

Example:

![calypso-pii](https://user-images.githubusercontent.com/10284338/28969027-2bf47170-7923-11e7-9649-98626d474ebf.png)

Thanks!
