### PR TITLE
Editor: Restore Flux actions to post editor on visiblity change

### DIFF
--- a/client/post-editor/editor-visibility/index.jsx
+++ b/client/post-editor/editor-visibility/index.jsx
@@ -186,6 +186,13 @@ const EditorVisibility = React.createClass( {
 		this.updateVisibility( event.target.value );
 	},
 
+	updatePostStatus() {
+		const defaultVisibility = 'draft' === this.props.status ? 'draft' : 'publish';
+		const postEdits = { status: defaultVisibility };
+
+		postActions.edit( postEdits );
+	},
+
 	updateVisibility( newVisibility ) {
 		const { siteId, postId } = this.props;
 		let reduxPostEdits;
@@ -208,6 +215,10 @@ const EditorVisibility = React.createClass( {
 		recordStat( 'visibility-set-' + newVisibility );
 		recordEvent( 'Changed visibility', newVisibility );
 		tracks.recordEvent( 'calypso_editor_visibility_set', { context: this.props.context, visibility: newVisibility } );
+
+		// This is necessary for cases when the post is changed from private to another visibility
+		// since private has its own post status.
+		this.updatePostStatus();
 
 		if ( reduxPostEdits ) {
 			this.props.editPost( siteId, postId, reduxPostEdits );


### PR DESCRIPTION
This restores some necessary Flux actions to the Post Editor when changing from private to a public or password protected post. Since changing a post to privately published automatically changes the status to "private," we need to update the status back to either "draft" or "publish" when changing to another visibility.

## To test
1. Open a new post at http://calypso.localhost:3000/post/
2. Change the post to "Private." It will get published right away.
3. Try to change it back to "Public." Notice the change is accepted now.

## GIF
![visibility](https://user-images.githubusercontent.com/7240478/28969451-e2bd317c-78e1-11e7-98a4-4234ee4212b4.gif)

Fixes #16898 and #16822