### PR TITLE
AT: Use ID and slug selectors for eligibility warnings

### DIFF
--- a/client/blocks/eligibility-warnings/index.jsx
+++ b/client/blocks/eligibility-warnings/index.jsx
@@ -16,7 +16,7 @@ import { PLAN_BUSINESS, FEATURE_UPLOAD_PLUGINS, FEATURE_UPLOAD_THEMES } from 'li
 import { recordTracksEvent } from 'state/analytics/actions';
 import { getEligibility, isEligibleForAutomatedTransfer } from 'state/automated-transfer/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
-import { getSelectedSite } from 'state/ui/selectors';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import Banner from 'components/banner';
 import Button from 'components/button';
 import Card from 'components/card';
@@ -146,10 +146,8 @@ EligibilityWarnings.defaultProps = {
 };
 
 const mapStateToProps = state => {
-	const {
-		ID: siteId,
-		slug: siteSlug,
-	} = getSelectedSite( state );
+	const siteId = getSelectedSiteId( state );
+	const siteSlug = getSelectedSiteSlug( state );
 	const eligibilityData = getEligibility( state, siteId );
 	const isEligible = isEligibleForAutomatedTransfer( state, siteId );
 	const eligibilityHolds = get( eligibilityData, 'eligibilityHolds', [] );


### PR DESCRIPTION
This PR does a small update to the `EligibilityWarnings` block, replacing the way we destructure `siteId` and `siteSlug` out of the `site` object with usage of dedicated selectors.

While a small change, this fixes #16908, which is an issue, occurring when the `EligibilityWarnings` block is loaded on a page before the sites have been loaded.

This will also occur on the Plugins Upload page once we implement the `EligibilityWarnings` there.

Testing themes with clean Redux state can be tough because of how SSR is setup for them, so let's make sure this works just fine for the cases when sites are loaded. In production, this is also supposed to fix the WSOD failure, reported in #16908.

To test:
* Checkout this branch
* Go to `/themes/upload/:site`, where `:site` is a WP.com site, ineligible for AT.
* Verify the theme upload page with Eligibility Warnings has loaded and is displayed properly.