### PR TITLE
Added an "X-Forwarded-For" header to the "/me" endpoint call in SSR so GeoIP doesn't always return US.

### DIFF
--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -225,7 +225,7 @@ function setUpLoggedInRoute( req, res, next ) {
 		start = new Date().getTime();
 
 		debug( 'Issuing API call to fetch user object' );
-		user( req.get( 'Cookie' ), function( error, data ) {
+		user( req.get( 'Cookie' ), req.ip, function( error, data ) {
 			let searchParam, errorMessage;
 
 			if ( error ) {

--- a/server/user-bootstrap/index.js
+++ b/server/user-bootstrap/index.js
@@ -12,7 +12,7 @@ var config = require( 'config' ),
 	*/
 	url = 'https://public-api.wordpress.com/rest/v1/me?meta=flags';
 
-module.exports = function( userCookie, callback ) {
+module.exports = function( userCookie, clientIp, callback ) {
 	// create HTTP Request object
 	var req = superagent.get( url ),
 		hmac, cookies, hash;
@@ -28,6 +28,7 @@ module.exports = function( userCookie, callback ) {
 			req.set( 'User-Agent', 'WordPress.com Calypso' );
 		}
 	}
+	req.set( 'X-Forwarded-For', clientIp );
 
 	// start the request
 	req.end( function( err, res ) {


### PR DESCRIPTION
For more context, Slack conversation: p1501843595741138-slack-woocommerce-on-wpcom

We are having problems hiding the `Store (BETA)` section if the user isn't in US/Canada. It's never hidden regardless of location. Digging on this issue, this is the problem:

- The `sidebar.jsx` code checks if the current user country (obtained by GeoIP) is US or Canada.
- If `wpcom-user-bootstrap` is enabled (which it is in `production`), the `/me` data is enbedded directly in the page HTML: https://github.com/Automattic/wp-calypso/blob/master/server/pages/index.jade#L146
- The `user` object comes from here: https://github.com/Automattic/wp-calypso/blob/master/server/pages/index.js#L209
- Which uses `user-bootstrap` to make a **server-side** request to `/me`: https://github.com/Automattic/wp-calypso/blob/master/server/user-bootstrap/index.js#L13

Since the Calypso server is located in the US (or proxied), the user will **always** be geo-located in US.

This also means that this check is bogus: https://github.com/Automattic/wp-calypso/blob/a70587157b33783ba4d5e0e4a1e136680d459d51/client/lib/upgrades/actions/domain-search.js#L11 , so we're mistakengly selling GApps to North Koreans / Cubans / Syrians etc.

The solution is to add an `X-Forwarded-For: {CLIENT_IP}` HTTP header to the `/me` request. It may require an `nginx` config tweak.

**To test**: I see no way to test it, since `wpcom-user-bootstrap` doesn't work on `dev` environments. I guess we'll just have to blind trust this one.