### PR TITLE
Plugin Upload: Add eligibility checks to upload page

### DIFF
--- a/client/my-sites/plugins/plugin-upload/index.jsx
+++ b/client/my-sites/plugins/plugin-upload/index.jsx
@@ -5,6 +5,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import page from 'page';
 import { localize } from 'i18n-calypso';
+import { isEmpty } from 'lodash';
 
 /**
  * Internal dependencies
@@ -15,7 +16,9 @@ import Card from 'components/card';
 import ProgressBar from 'components/progress-bar';
 import UploadDropZone from 'blocks/upload-drop-zone';
 import JetpackManageErrorPage from 'my-sites/jetpack-manage-error-page';
+import EligibilityWarnings from 'blocks/eligibility-warnings';
 import EmptyContent from 'components/empty-content';
+import QueryEligibility from 'components/data/query-atat-eligibility';
 import { uploadPlugin, clearPluginUpload } from 'state/plugins/upload/actions';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import {
@@ -31,8 +34,15 @@ import {
 	isJetpackSite,
 	isJetpackSiteMultiSite,
 } from 'state/sites/selectors';
+import {
+	getEligibility,
+	isEligibleForAutomatedTransfer
+} from 'state/automated-transfer/selectors';
 
 class PluginUpload extends React.Component {
+	state = {
+		showEligibility: this.props.showEligibility,
+	}
 
 	componentDidMount() {
 		const { siteId, inProgress } = this.props;
@@ -45,6 +55,10 @@ class PluginUpload extends React.Component {
 			! inProgress && this.props.clearPluginUpload( siteId );
 		}
 
+		if ( nextProps.showEligibility !== this.props.showEligibility ) {
+			this.setState( { showEligibility: nextProps.showEligibility } );
+		}
+
 		if ( nextProps.complete ) {
 			page( `/plugins/${ nextProps.pluginId }/${ nextProps.siteSlug }` );
 		}
@@ -54,13 +68,17 @@ class PluginUpload extends React.Component {
 		page.back();
 	}
 
+	onProceedClick = () => {
+		this.setState( { showEligibility: false } );
+	}
+
 	renderUploadCard() {
-		const { inProgress, complete, isJetpack } = this.props;
+		const { inProgress, complete, isEligible, isJetpack } = this.props;
 		return (
 			<Card>
 				{ ! inProgress && ! complete && <UploadDropZone
 					doUpload={ this.props.uploadPlugin }
-					disabled={ ! isJetpack } /> }
+					disabled={ ! isJetpack && ! isEligible } /> }
 				{ inProgress && this.renderProgressBar() }
 			</Card>
 		);
@@ -105,10 +123,13 @@ class PluginUpload extends React.Component {
 			isJetpackMultisite,
 			upgradeJetpack,
 			siteId,
+			siteSlug,
 		} = this.props;
+		const { showEligibility } = this.state;
 
 		return (
 			<Main>
+				<QueryEligibility siteId={ siteId } />
 				<HeaderCake onClick={ this.back }>{ translate( 'Upload plugin' ) }</HeaderCake>
 				{ upgradeJetpack && <JetpackManageErrorPage
 					template="updateJetpack"
@@ -116,7 +137,10 @@ class PluginUpload extends React.Component {
 					featureExample={ this.renderUploadCard() }
 					version="5.1" /> }
 				{ isJetpackMultisite && this.renderNotAvailableForMultisite() }
-				{ ! upgradeJetpack && ! isJetpackMultisite && this.renderUploadCard() }
+				{ showEligibility && <EligibilityWarnings
+					backUrl={ `/plugins/${ siteSlug }` }
+					onProceed={ this.onProceedClick } /> }
+				{ ! upgradeJetpack && ! isJetpackMultisite && ! showEligibility && this.renderUploadCard() }
 			</Main>
 		);
 	}
@@ -129,6 +153,15 @@ export default connect(
 		const progress = getPluginUploadProgress( state, siteId );
 		const isJetpack = isJetpackSite( state, siteId );
 		const isJetpackMultisite = isJetpackSiteMultiSite( state, siteId );
+		const { eligibilityHolds, eligibilityWarnings } = getEligibility( state, siteId );
+		// Use this selector to take advantage of eligibility card placeholders
+		// before data has loaded.
+		const isEligible = isEligibleForAutomatedTransfer( state, siteId );
+		const hasEligibilityMessages = ! (
+			isEmpty( eligibilityHolds ) &&
+			isEmpty( eligibilityWarnings )
+		);
+
 		return {
 			siteId,
 			siteSlug: getSelectedSiteSlug( state ),
@@ -143,6 +176,8 @@ export default connect(
 			upgradeJetpack: isJetpack && ! isJetpackMultisite && ! isJetpackMinimumVersion( state, siteId, '5.1' ),
 			isJetpackMultisite,
 			siteAdminUrl: getSiteAdminUrl( state, siteId ),
+			showEligibility: ! isJetpack && ( hasEligibilityMessages || ! isEligible ),
+			isEligible,
 		};
 	},
 	{ uploadPlugin, clearPluginUpload }


### PR DESCRIPTION
This PR adds AT eligibility checks to the plugin upload page, so it would allow sites that are eligible to AT to upload a plugin, and kickoff the transfer process with that action.

This PR relies on D6656-code and D6654-code for allowing AT initiation by using an uploaded plugin zip file. DO NOT merge if these haven't landed. See #16843 for testing them.

To test:
* Go to `/plugins/upload/:site`, and test with various types of sites.
* Eligibility warnings and errors should be shown for an ineligible WP.com site.
* Uploading should be allowed for eligible WP.com sites.
* Uploading should be allowed for Jetpack sites, and should work like it did before.
* Uploading should be allowed for Atomic sites, and should work like it did before.
* Proceed button should be active only if there are no errors/warnings
* Clicking **Proceed** should hide the eligibility warnings
* Clicking **Cancel** should navigate back to `/plugins/:site`

Note: If you test with a clean Redux state, you'll see an error occurs. This is reported in #16908, and a diagnose and a fix for it are coming in #16909.