### PR TITLE
Store Orders: Update pagination, no results style

### DIFF
--- a/client/extensions/woocommerce/app/orders/orders-list.js
+++ b/client/extensions/woocommerce/app/orders/orders-list.js
@@ -145,16 +145,12 @@ class Orders extends Component {
 		}
 
 		return (
-			<TableRow>
-				<TableItem colSpan={ 4 }>
-					<EmptyContent
-						title={ emptyMessage }
-						action={ translate( 'View all orders' ) }
-						actionURL={ getLink( '/store/orders/:site', site ) }
-						actionCallback={ this.clearSearch }
-					/>
-				</TableItem>
-			</TableRow>
+			<EmptyContent
+				title={ emptyMessage }
+				action={ translate( 'View all orders' ) }
+				actionURL={ getLink( '/store/orders/:site', site ) }
+				actionCallback={ this.clearSearch }
+			/>
 		);
 	}
 
@@ -181,6 +177,28 @@ class Orders extends Component {
 		);
 	}
 
+	renderOrderItems = () => {
+		const { orders, ordersLoading, translate } = this.props;
+
+		const headers = (
+			<TableRow isHeader>
+				<TableItem className="orders__table-name" isHeader>{ translate( 'Order' ) }</TableItem>
+				<TableItem className="orders__table-date" isHeader>{ translate( 'Date' ) }</TableItem>
+				<TableItem className="orders__table-status" isHeader>{ translate( 'Status' ) }</TableItem>
+				<TableItem className="orders__table-total" isHeader>{ translate( 'Total' ) }</TableItem>
+			</TableRow>
+		);
+
+		return (
+			<Table className="orders__table" header={ headers } horizontalScroll>
+				{ ordersLoading
+					? this.renderPlaceholders()
+					: orders.map( this.renderOrderItem )
+				}
+			</Table>
+		);
+	}
+
 	onPageClick = nextPage => {
 		this.props.updateCurrentOrdersQuery( this.props.siteId, {
 			page: nextPage,
@@ -194,7 +212,6 @@ class Orders extends Component {
 			currentStatus,
 			isDefaultPage,
 			orders,
-			ordersLoading,
 			ordersLoaded,
 			total,
 			translate
@@ -211,28 +228,16 @@ class Orders extends Component {
 			);
 		}
 
-		const headers = (
-			<TableRow isHeader>
-				<TableItem className="orders__table-name" isHeader>{ translate( 'Order' ) }</TableItem>
-				<TableItem className="orders__table-date" isHeader>{ translate( 'Date' ) }</TableItem>
-				<TableItem className="orders__table-status" isHeader>{ translate( 'Status' ) }</TableItem>
-				<TableItem className="orders__table-total" isHeader>{ translate( 'Total' ) }</TableItem>
-			</TableRow>
-		);
-
-		const ordersList = ( orders && orders.length ) ? orders.map( this.renderOrderItem ) : this.renderNoContent();
-
 		const setSearchRef = ref => this.search = ref;
 
 		return (
 			<div className="orders__container">
 				<OrdersFilterNav searchRef={ setSearchRef } status={ currentStatus } />
 
-				<Table className="orders__table" header={ headers } horizontalScroll>
-					{ ordersLoading
-						? this.renderPlaceholders()
-						: ordersList }
-				</Table>
+				{ ( ! ordersLoaded || ( orders && orders.length ) )
+					? this.renderOrderItems()
+					: this.renderNoContent()
+				}
 
 				<Pagination
 					page={ currentPage }

--- a/client/extensions/woocommerce/app/orders/style.scss
+++ b/client/extensions/woocommerce/app/orders/style.scss
@@ -23,6 +23,11 @@
 		width: 75%;
 		@include placeholder();
 	}
+
+	.search,
+	.search .search__open-icon {
+		z-index: initial;
+	}
 }
 
 .orders__item-link,
@@ -51,7 +56,7 @@
 			border-color: $alert-red;
 		}
 	}
-	
+
 	&.is-pending {
 		background: lighten( $alert-green, 20% );
 		color: darken( $alert-green, 30% );

--- a/client/extensions/woocommerce/app/products/products-list.scss
+++ b/client/extensions/woocommerce/app/products/products-list.scss
@@ -23,21 +23,6 @@
 		}
 	}
 
-	.pagination__list {
-		background: $white;
-		border: 1px solid lighten( $gray, 25% );
-		padding: 8px;
-	}
-
-	.pagination__list-item .button {
-		padding: 0 8px;
-		line-height: 34px;
-	}
-
-	.pagination__list-item.is-selected {
-		border: 1px solid lighten( $gray, 20% );
-	}
-
 	.products__list-placeholder {
 		@include placeholder();
 		background: $white;

--- a/client/extensions/woocommerce/style.scss
+++ b/client/extensions/woocommerce/style.scss
@@ -55,6 +55,22 @@
 			margin-top: 58px;
 		}
 	}
+
+	.pagination__list {
+		background: $white;
+		border: 1px solid lighten( $gray, 25% );
+		padding: 8px;
+	}
+
+	.pagination__list-item .button {
+		padding: 0 8px;
+		line-height: 34px;
+	}
+
+	.pagination__list-item.is-selected {
+		border: 1px solid lighten( $gray, 20% );
+	}
+
 }
 
 .is-section-woocommerce {


### PR DESCRIPTION
This follows up on the style feedback from https://github.com/Automattic/wp-calypso/pull/16548#issuecomment-318631119 and https://github.com/Automattic/wp-calypso/pull/16548#pullrequestreview-53257131

- Updates the orders list display when no results are found so that `EmptyContent` is not inside the table
- Moves the pagination CSS out of the product-specific context so that all pagination is consistent

<img width="746" alt="screen shot 2017-08-04 at 2 01 24 pm" src="https://user-images.githubusercontent.com/541093/28980865-6df8374c-791d-11e7-91cf-9ca99ec21417.png">

<img width="743" alt="screen shot 2017-08-04 at 1 59 36 pm" src="https://user-images.githubusercontent.com/541093/28980866-6dfc69c0-791d-11e7-855d-8f3a4f89e557.png">

**To test**

- Visit the orders list, and view an empty result set (search for something that doesn't exist, fulfill all open orders etc)
- View a paginated order list, either by creating over 50 orders or by tweaking the per_page count in  in `<Pagination…` in `order-list.js` and in `state/sites/orders/utils.js`