### PR TITLE
Framework: Use upstream react-codemod

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -836,7 +836,7 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000709"
+      "version": "1.0.30000710"
     },
     "cardinal": {
       "version": "1.0.0",
@@ -1623,7 +1623,7 @@
       "version": "1.3.1"
     },
     "es-abstract": {
-      "version": "1.7.0"
+      "version": "1.8.0"
     },
     "es-to-primitive": {
       "version": "1.1.1"
@@ -5162,8 +5162,8 @@
     },
     "react-codemod": {
       "version": "4.0.0",
-      "from": "git://github.com/jsnmoon/react-codemod.git#650171db5f316d4a98df8b9d2897547aec314f37",
-      "resolved": "git://github.com/jsnmoon/react-codemod.git#650171db5f316d4a98df8b9d2897547aec314f37",
+      "from": "git://github.com/reactjs/react-codemod.git#d8a1d474b6b208cfdbec339b672617270ef78ac5",
+      "resolved": "git://github.com/reactjs/react-codemod.git#d8a1d474b6b208cfdbec339b672617270ef78ac5",
       "dev": true,
       "dependencies": {
         "chalk": {
@@ -6691,8 +6691,14 @@
           "dev": true
         },
         "finalhandler": {
-          "version": "1.0.3",
-          "dev": true
+          "version": "1.0.4",
+          "dev": true,
+          "dependencies": {
+            "debug": {
+              "version": "2.6.8",
+              "dev": true
+            }
+          }
         },
         "fresh": {
           "version": "0.5.0",

--- a/package.json
+++ b/package.json
@@ -259,7 +259,7 @@
     "nodemon": "1.4.1",
     "prettier": "Automattic/calypso-prettier#0cbd77dcfc7bb82bff5f4485a6f078dec5cc9595",
     "react-addons-test-utils": "15.4.0",
-    "react-codemod": "jsnmoon/react-codemod#2017-06-12-fix",
+    "react-codemod": "reactjs/react-codemod",
     "react-test-env": "0.2.0",
     "readline-sync": "1.4.5",
     "sinon": "1.17.7",


### PR DESCRIPTION
Since @jsnmoon's patches that originally necessitated the fork have been merged upstream, we can start to use that again! 🎉 

Upstream PRs, as listed in #13070:

> - reactjs/react-codemod#122
> - reactjs/react-codemod#132
> - reactjs/react-codemod#156
> - reactjs/react-codemod#157

Upstream now also has a [fix](https://github.com/reactjs/react-codemod/pull/152) in the `prop-types` codemod that will preserve leading comments (such as our `/* External dependencies */` stuff!