### PR TITLE
Store Orders: Add new components for the status label & select dropdown

### DIFF
--- a/client/extensions/woocommerce/app/order/order-details.js
+++ b/client/extensions/woocommerce/app/order/order-details.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { find } from 'lodash';
 import { localize } from 'i18n-calypso';
 import React, { Component, PropTypes } from 'react';
 
@@ -9,12 +8,13 @@ import React, { Component, PropTypes } from 'react';
  * Internal dependencies
  */
 import Card from 'components/card';
-import FormSelect from 'components/forms/form-select';
-import { getOrderStatusList } from 'woocommerce/lib/order-status';
+import { isOrderWaitingPayment } from 'woocommerce/lib/order-status';
 import OrderCreated from './order-created';
 import OrderDetailsTable from './order-details-table';
 import OrderFulfillment from './order-fulfillment';
 import OrderRefundCard from './order-refund-card';
+import OrderStatus from 'woocommerce/components/order-status';
+import OrderStatusSelect from 'woocommerce/components/order-status/select';
 import SectionHeader from 'components/section-header';
 
 class OrderDetails extends Component {
@@ -42,25 +42,10 @@ class OrderDetails extends Component {
 
 	renderStatus = () => {
 		const { order } = this.props;
-		const classes = `order__status is-${ order.status }`;
-		const statuses = getOrderStatusList();
 
-		if ( 'pending' === order.status || 'on-hold' === order.status ) {
-			return (
-				<FormSelect id="select" value={ this.state.status } onChange={ this.updateStatus }>
-					{ statuses.map( ( status, i ) => {
-						return (
-							<option key={ i } value={ status.value }>{ status.name }</option>
-						);
-					} ) }
-				</FormSelect>
-			);
-		}
-
-		const statusLabel = find( statuses, { value: order.status } );
-		return (
-			<span className={ classes }>{ statusLabel.name }</span>
-		);
+		return isOrderWaitingPayment( order.status )
+			? <OrderStatusSelect value={ this.state.status } onChange={ this.updateStatus } />
+			: <OrderStatus status={ order.status } showShipping={ false } />;
 	}
 
 	render() {

--- a/client/extensions/woocommerce/app/order/order-refund-card.js
+++ b/client/extensions/woocommerce/app/order/order-refund-card.js
@@ -128,7 +128,7 @@ class OrderRefundCard extends Component {
 		const refundObj = {
 			amount: this.state.refundTotal + '', // API expects a string
 			reason: this.state.refundNote,
-			api_refund: ( -1 !== paymentMethod.method_supports.indexOf( 'refunds' ) ),
+			api_refund: ( paymentMethod && ( -1 !== paymentMethod.method_supports.indexOf( 'refunds' ) ) ),
 		};
 		this.props.sendRefund( site.ID, order.id, refundObj );
 	}
@@ -139,7 +139,7 @@ class OrderRefundCard extends Component {
 			return null;
 		}
 
-		if ( -1 === paymentMethod.method_supports.indexOf( 'refunds' ) ) {
+		if ( paymentMethod && ( -1 === paymentMethod.method_supports.indexOf( 'refunds' ) ) ) {
 			return (
 				<div className="order__refund-method">
 					<h3>{ translate( 'Manual Refund' ) }</h3>

--- a/client/extensions/woocommerce/app/order/style.scss
+++ b/client/extensions/woocommerce/app/order/style.scss
@@ -35,31 +35,6 @@
 	}
 }
 
-.order__status {
-	display: inline-flex;
-	padding: 0px 12px;
-	line-height: 32px;
-	background: lighten( $gray, 20% );
-	border-radius: 4px;
-
-	&.is-failed {
-		background: lighten( $alert-red, 20% );
-		color: darken( $alert-red, 30% );
-	}
-
-	&.is-cancelled,
-	&.is-refunded,
-	&.is-completed {
-		background: $gray-light;
-		color: $gray-dark;
-	}
-
-	&.is-on-hold {
-		background: lighten( $alert-yellow, 20% );
-		color: darken( $alert-yellow, 30% );
-	}
-}
-
 .order__details-card {
 	padding-top: 0;
 	padding-bottom: 0;

--- a/client/extensions/woocommerce/app/orders/orders-list.js
+++ b/client/extensions/woocommerce/app/orders/orders-list.js
@@ -30,6 +30,7 @@ import {
 	ORDER_COMPLETED,
 } from 'woocommerce/lib/order-status';
 import OrdersFilterNav from './orders-filter-nav';
+import OrderStatus from 'woocommerce/components/order-status';
 import Pagination from 'components/pagination';
 import Table from 'woocommerce/components/table';
 import TableRow from 'woocommerce/components/table/table-row';
@@ -82,47 +83,6 @@ class Orders extends Component {
 		this.search.closeSearch( event );
 		this.props.updateCurrentOrdersQuery( siteId, { page: 1, search: '' } );
 		page( getLink( '/store/orders/:site', site ) );
-	}
-
-	getOrderStatus = ( status ) => {
-		const { translate } = this.props;
-		const classes = `orders__item-status is-${ status }`;
-		let paymentLabel;
-		let shippingLabel;
-		switch ( status ) {
-			case 'pending':
-				shippingLabel = translate( 'New order' );
-				paymentLabel = translate( 'Payment pending' );
-				break;
-			case 'processing':
-				shippingLabel = translate( 'New order' );
-				paymentLabel = translate( 'Paid in full' );
-				break;
-			case 'on-hold':
-				shippingLabel = translate( 'On hold' );
-				paymentLabel = translate( 'Payment pending' );
-				break;
-			case 'completed':
-				shippingLabel = translate( 'Fulfilled' );
-				paymentLabel = translate( 'Paid in full' );
-				break;
-			case 'cancelled':
-				paymentLabel = translate( 'Cancelled' );
-				break;
-			case 'refunded':
-				paymentLabel = translate( 'Refunded' );
-				break;
-			case 'failed':
-				paymentLabel = translate( 'Payment Failed' );
-				break;
-		}
-
-		return (
-			<span className={ classes }>
-				{ shippingLabel ? <span className="orders__shipping-status">{ shippingLabel }</span> : null }
-				<span className="orders__payment-status">{ paymentLabel }</span>
-			</span>
-		);
 	}
 
 	renderPlaceholders = () => {
@@ -179,7 +139,7 @@ class Orders extends Component {
 					{ humanDate( order.date_created_gmt + 'Z' ) }
 				</TableItem>
 				<TableItem className="orders__table-status">
-					{ this.getOrderStatus( order.status ) }
+					<OrderStatus status={ order.status } />
 				</TableItem>
 				<TableItem className="orders__table-total">
 					{ formatCurrency( order.total, order.currency ) || order.total }

--- a/client/extensions/woocommerce/app/orders/style.scss
+++ b/client/extensions/woocommerce/app/orders/style.scss
@@ -36,58 +36,6 @@
 	margin-right: 5px;
 }
 
-.orders__item-status {
-	display: inline-flex;
-	padding: 0px 12px;
-	line-height: 32px;
-	background: lighten( $gray, 20% );
-	border-radius: 4px;
-
-	&.is-failed {
-		background: lighten( $alert-red, 20% );
-		color: darken( $alert-red, 30% );
-
-		span + span {
-			border-color: $alert-red;
-		}
-	}
-	
-	&.is-pending {
-		background: lighten( $alert-green, 20% );
-		color: darken( $alert-green, 30% );
-
-		span + span {
-			border-color: $alert-green;
-		}
-	}
-
-	&.is-cancelled,
-	&.is-refunded,
-	&.is-completed {
-		background: $gray-light;
-		color: $gray-dark;
-
-		span + span {
-			border-color: lighten( $gray, 20% );
-		}
-	}
-
-	&.is-on-hold {
-		background: lighten( $alert-yellow, 20% );
-		color: darken( $alert-yellow, 30% );
-
-		span + span {
-			border-color: $alert-yellow;
-		}
-	}
-
-	span + span {
-		margin-left: 12px;
-		padding-left: 12px;
-		border-left: 1px solid $gray;
-	}
-}
-
 .orders__table-total {
 	text-align: right;
 }

--- a/client/extensions/woocommerce/components/order-status/index.js
+++ b/client/extensions/woocommerce/components/order-status/index.js
@@ -1,0 +1,47 @@
+/**
+ * External dependencies
+ */
+import { localize } from 'i18n-calypso';
+import React from 'react';
+
+function OrderStatus( { showPayment = true, showShipping = true, status, translate } ) {
+	const classes = `order-status__item is-${ status }`;
+	let paymentLabel;
+	let shippingLabel;
+	switch ( status ) {
+		case 'pending':
+			shippingLabel = translate( 'New order' );
+			paymentLabel = translate( 'Payment pending' );
+			break;
+		case 'processing':
+			shippingLabel = translate( 'New order' );
+			paymentLabel = translate( 'Paid in full' );
+			break;
+		case 'on-hold':
+			shippingLabel = translate( 'On hold' );
+			paymentLabel = translate( 'Payment pending' );
+			break;
+		case 'completed':
+			shippingLabel = translate( 'Fulfilled' );
+			paymentLabel = translate( 'Paid in full' );
+			break;
+		case 'cancelled':
+			paymentLabel = translate( 'Cancelled' );
+			break;
+		case 'refunded':
+			paymentLabel = translate( 'Refunded' );
+			break;
+		case 'failed':
+			paymentLabel = translate( 'Payment Failed' );
+			break;
+	}
+
+	return (
+		<span className={ classes }>
+			{ ( shippingLabel && showShipping ) ? <span className="order-status__shipping">{ shippingLabel }</span> : null }
+			{ showPayment ? <span className="order-status__payment">{ paymentLabel }</span> : null }
+		</span>
+	);
+}
+
+export default localize( OrderStatus );

--- a/client/extensions/woocommerce/components/order-status/select.js
+++ b/client/extensions/woocommerce/components/order-status/select.js
@@ -1,0 +1,26 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { getOrderStatusList } from 'woocommerce/lib/order-status';
+import FormSelect from 'components/forms/form-select';
+
+function OrderStatusSelect( { onChange, value } ) {
+	const statuses = getOrderStatusList();
+
+	return (
+		<FormSelect id="select" value={ value } onChange={ onChange }>
+			{ statuses.map( ( status, i ) => {
+				return (
+					<option key={ i } value={ status.value }>{ status.name }</option>
+				);
+			} ) }
+		</FormSelect>
+	);
+}
+
+export default OrderStatusSelect;

--- a/client/extensions/woocommerce/components/order-status/style.scss
+++ b/client/extensions/woocommerce/components/order-status/style.scss
@@ -1,0 +1,42 @@
+.order-status__item {
+	display: inline-flex;
+	padding: 0px 12px;
+	line-height: 32px;
+	background: lighten( $gray, 20% );
+	border-radius: 4px;
+
+	&.is-failed {
+		background: lighten( $alert-red, 20% );
+		color: darken( $alert-red, 30% );
+
+		span + span {
+			border-color: $alert-red;
+		}
+	}
+
+	&.is-cancelled,
+	&.is-refunded,
+	&.is-completed {
+		background: $gray-light;
+		color: $gray-dark;
+
+		span + span {
+			border-color: lighten( $gray, 20% );
+		}
+	}
+
+	&.is-on-hold {
+		background: lighten( $alert-yellow, 20% );
+		color: darken( $alert-yellow, 30% );
+
+		span + span {
+			border-color: $alert-yellow;
+		}
+	}
+
+	span + span {
+		margin-left: 12px;
+		padding-left: 12px;
+		border-left: 1px solid $gray;
+	}
+}

--- a/client/extensions/woocommerce/style.scss
+++ b/client/extensions/woocommerce/style.scss
@@ -22,6 +22,7 @@
 	@import 'app/dashboard/style';
 	@import 'app/order/style';
 	@import 'app/orders/style';
+	@import 'components/order-status/style';
 	@import 'components/basic-widget/style';
 	@import 'components/share-widget/style';
 	@import 'components/reading-widget/style';


### PR DESCRIPTION
This PR splits out the order status label into a reusable component in `/components`. It's used on both the orders list and order details page. It also breaks out an "order status dropdown" which is currently only used on payment-pending orders on the detail screen.

There should be no visible or functional changes.

<img width="255" alt="screen shot 2017-08-04 at 2 29 07 pm" src="https://user-images.githubusercontent.com/541093/28981796-4bb6df04-7921-11e7-8f36-bb7a451f8cb3.png">

There's also a small fix in `client/extensions/woocommerce/app/order/order-refund-card.js` because I noticed a JS error.

To test:

- View your orders list, make sure the status labels appear correctly
- View a few order detail pages, make sure the status label appears correctly (this only contains the payment status)
- View a pending or on-hold order, and make sure the status dropdown appears correctly, and updating it to a different status saves correctly.

(This is currently in-progress because I forgot a readme 😣)