### PR TITLE
Comments: store some state to mark that comments-tree has initialized

### DIFF
--- a/client/state/comments/reducer.js
+++ b/client/state/comments/reducer.js
@@ -16,8 +16,9 @@ import {
 	COMMENTS_COUNT_RECEIVE,
 	COMMENTS_LIKE,
 	COMMENTS_UNLIKE,
+	COMMENTS_TREE_SITE_ADD,
 } from '../action-types';
-import { combineReducers, createReducer } from 'state/utils';
+import { combineReducers, createReducer, keyedReducer } from 'state/utils';
 import { PLACEHOLDER_STATE, NUMBER_OF_COMMENTS_PER_FETCH } from './constants';
 import trees from './trees/reducer';
 
@@ -212,10 +213,20 @@ export const errors = createReducer(
 	},
 );
 
+export const treesInitializedReducer = ( state = {}, action ) => {
+	if ( action.type === COMMENTS_TREE_SITE_ADD ) {
+		return { ...state, [ action.status ]: true };
+	}
+	return state;
+};
+
+export const treesInitialized = keyedReducer( 'siteId', treesInitializedReducer );
+
 export default combineReducers( {
 	items,
 	fetchStatus,
 	errors,
 	totalCommentsCount,
 	trees,
+	treesInitialized,
 } );

--- a/client/state/comments/reducer.js
+++ b/client/state/comments/reducer.js
@@ -215,12 +215,12 @@ export const errors = createReducer(
 
 export const treesInitializedReducer = ( state = {}, action ) => {
 	if ( action.type === COMMENTS_TREE_SITE_ADD ) {
-		return { ...state, [ action.status ]: true };
+		return true;
 	}
 	return state;
 };
 
-export const treesInitialized = keyedReducer( 'siteId', treesInitializedReducer );
+export const treesInitialized = keyedReducer( 'siteId', keyedReducer( 'status', treesInitializedReducer ) );
 
 export default combineReducers( {
 	items,

--- a/client/state/comments/test/reducer.js
+++ b/client/state/comments/test/reducer.js
@@ -8,7 +8,13 @@ import deepFreeze from 'deep-freeze';
 /**
  * Internal dependencies
  */
-import { items, totalCommentsCount, fetchStatus, fetchStatusInitialState } from '../reducer';
+import {
+	items,
+	totalCommentsCount,
+	fetchStatus,
+	fetchStatusInitialState,
+	treesInitialized,
+} from '../reducer';
 import {
 	COMMENTS_LIKE,
 	COMMENTS_UNLIKE,
@@ -17,6 +23,7 @@ import {
 	COMMENTS_COUNT_RECEIVE,
 	COMMENTS_RECEIVE,
 	COMMENTS_DELETE,
+	COMMENTS_TREE_SITE_ADD,
 } from '../../action-types';
 import { PLACEHOLDER_STATE } from '../constants';
 
@@ -195,6 +202,47 @@ describe( 'reducer', () => {
 			);
 
 			expect( response[ '1-1' ] ).to.eql( 2 );
+		} );
+	} );
+	describe( '#treesInitialized()', () => {
+		it( 'should track when a tree is initialized for a given query', () => {
+			const state = treesInitialized(
+				undefined,
+				{
+					type: COMMENTS_TREE_SITE_ADD,
+					siteId: 77203074,
+					status: 'unapproved',
+				} );
+			expect( state ).to.eql( {
+				77203074: { unapproved: true }
+			} );
+		} );
+		it( 'can track init status of many states', () => {
+			const initState = deepFreeze( { 77203074: { unapproved: true } } );
+			const state = treesInitialized(
+				initState,
+				{
+					type: COMMENTS_TREE_SITE_ADD,
+					siteId: 77203074,
+					status: 'spam',
+				} );
+			expect( state ).to.eql( {
+				77203074: { unapproved: true, spam: true }
+			} );
+		} );
+		it( 'can track init status of many sites', () => {
+			const initState = deepFreeze( { 77203074: { unapproved: true } } );
+			const state = treesInitialized(
+				initState,
+				{
+					type: COMMENTS_TREE_SITE_ADD,
+					siteId: 2916284,
+					status: 'unapproved',
+				} );
+			expect( state ).to.eql( {
+				77203074: { unapproved: true },
+				2916284: { unapproved: true }
+			} );
 		} );
 	} );
 } );

--- a/client/state/selectors/index.js
+++ b/client/state/selectors/index.js
@@ -158,6 +158,7 @@ export isAmbiguousThemeFilterTerm from './is-ambiguous-theme-filter-term';
 export isAutomatedTransferActive from './is-automated-transfer-active';
 export isAutomatedTransferFailed from './is-automated-transfer-failed';
 export isBusinessPlanUser from './is-business-plan-user';
+export isCommentsTreeInitialized from './is-comments-tree-initialized';
 export isConnectedSecondaryNetworkSite from './is-connected-secondary-network-site';
 export isDeactivatingJetpackJumpstart from './is-deactivating-jetpack-jumpstart';
 export isDeactivatingJetpackModule from './is-deactivating-jetpack-module';

--- a/client/state/selectors/is-comments-tree-initialized.js
+++ b/client/state/selectors/is-comments-tree-initialized.js
@@ -1,0 +1,16 @@
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * Returns true if a comment tree has been initialized.
+ *
+ * @param  {Object}  state    Global state tree
+ * @param  {Number}  siteId   The ID of the site we're querying
+ * @param  {String}  status   unapproved|approved|all|spam|trash
+ * @return {Boolean} True if the comment tree has been initialized
+ */
+export default function isCommentsTreeInitialized( state, siteId, status ) {
+	return get( state, [ 'comments', 'treesInitialized', siteId, status ], false );
+}

--- a/client/state/selectors/test/is-comments-tree-initialized.js
+++ b/client/state/selectors/test/is-comments-tree-initialized.js
@@ -1,0 +1,45 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { isCommentsTreeInitialized } from 'state/selectors';
+
+describe( 'isCommentsTreeInitialized()', () => {
+	it( 'should return false if no data is available', () => {
+		expect( isCommentsTreeInitialized( {}, 77203074, 'spam' ) ).to.equal( false );
+	} );
+	it( 'should return true if data is available', () => {
+		const state = {
+			comments: {
+				treesInitialized: {
+					77203074: { spam: true }
+				}
+			}
+		};
+		expect( isCommentsTreeInitialized( state, 77203074, 'spam' ) ).to.equal( true );
+	} );
+	it( 'should return false if no data is available for site', () => {
+		const state = {
+			comments: {
+				treesInitialized: {
+					2916284: { spam: true }
+				}
+			}
+		};
+		expect( isCommentsTreeInitialized( state, 77203074, 'spam' ) ).to.equal( false );
+	} );
+	it( 'should return false if no data is available for filter', () => {
+		const state = {
+			comments: {
+				treesInitialized: {
+					77203074: { spam: true }
+				}
+			}
+		};
+		expect( isCommentsTreeInitialized( state, 77203074, 'unapproved' ) ).to.equal( false );
+	} );
+} );


### PR DESCRIPTION
Fixes #16896, and follow up to #16814. This PR stores some state, so we know when the comments-tree endpoint has finished loading. This allows us to tell the difference between a 0 comments state, vs the client waiting for a result.

Since we want to know this per query, it is not possible to derive this information using initial state, since we keep the comments-tree reducer in a single list vs per individual status.

### Testing Instructions
- Navigate to http://calypso.localhost:3000/comments/pending
- Select a site with no comments
- The no comments placeholder should load quickly
- Switching filters also has correct behavior
- Navigate to http://calypso.localhost:3000/comments/pending
- Select a site with comments
- throttle your internet speed to something slow
- we should see a placeholder without a flash of the no comments placeholder
- switching filters work as expected
