### PR TITLE
Comments: update copy to make it clear the default tab is pending comments

### DIFF
--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -132,7 +132,7 @@ export class CommentList extends Component {
 		const defaultLine = translate( 'Your queue is clear.' );
 
 		return get( {
-			unapproved: [ translate( 'No new comments yet.' ), defaultLine ],
+			unapproved: [ translate( 'No pending comments.' ), defaultLine ],
 			approved: [ translate( 'No approved comments.' ), defaultLine ],
 			spam: [ translate( 'No spam comments.' ), defaultLine ],
 			trash: [ translate( 'No deleted comments.' ), defaultLine ],


### PR DESCRIPTION
This PR updates copy to make it more clear that we're looking at pending comments, closes #16931 

Before:
<img width="452" alt="screen shot 2017-08-04 at 3 02 23 pm" src="https://user-images.githubusercontent.com/1270189/28989149-759fb7ee-7928-11e7-974b-fda458d4690c.png">

After:
<img width="529" alt="screen shot 2017-08-04 at 3 18 05 pm" src="https://user-images.githubusercontent.com/1270189/28989151-79eb27f2-7928-11e7-9f57-89aae945de08.png">

### Testing Instructions
- Navigate to http://calypso.localhost:3000/comments/pending
- Select a site with no pending comments