### PR TITLE
Auto-authorize Jetpack connections for Woo users

### DIFF
--- a/client/state/jetpack-connect/reducer/jetpack-connect-authorize.js
+++ b/client/state/jetpack-connect/reducer/jetpack-connect-authorize.js
@@ -2,7 +2,7 @@
 /**
  * External dependencis
  */
-import { isEmpty, omit } from 'lodash';
+import { includes, isEmpty, omit } from 'lodash';
 
 /**
  * Internal dependencies
@@ -34,6 +34,7 @@ function buildDefaultAuthorizeState() {
 		authorizeError: false,
 		timestamp: Date.now(),
 		userAlreadyConnected: false,
+		autoAuthorize: false,
 	};
 }
 
@@ -75,7 +76,17 @@ export default function jetpackConnectAuthorize( state = {}, action ) {
 			} );
 		case JETPACK_CONNECT_QUERY_SET:
 			const queryObject = Object.assign( {}, action.queryObject );
-			return Object.assign( {}, buildDefaultAuthorizeState(), { queryObject: queryObject } );
+			const shouldAutoAuthorize = includes(
+				[ 'woocommerce-services-auto-authorize', 'woocommerce-setup-wizard' ],
+				queryObject.from
+			);
+			const additionalQueryArgs = shouldAutoAuthorize ? { autoAuthorize: true } : {};
+			return Object.assign(
+				{},
+				buildDefaultAuthorizeState(),
+				{ queryObject },
+				additionalQueryArgs
+			);
 		case JETPACK_CONNECT_CREATE_ACCOUNT:
 			return Object.assign( {}, state, {
 				isAuthorizing: true,

--- a/client/state/jetpack-connect/reducer/test/jetpack-connect-authorize.js
+++ b/client/state/jetpack-connect/reducer/test/jetpack-connect-authorize.js
@@ -327,4 +327,39 @@ describe( '#jetpackConnectAuthorize()', () => {
 
 		expect( state ).toEqual( {} );
 	} );
+
+	test( 'should not auto-authorize by default', () => {
+		const state = jetpackConnectAuthorize( undefined, {
+			type: JETPACK_CONNECT_QUERY_SET,
+		} );
+		expect( state.autoAuthorize ).toEqual( false );
+	} );
+
+	test( 'should not auto-authorize non-Woo users', () => {
+		const state = jetpackConnectAuthorize( undefined, {
+			type: JETPACK_CONNECT_QUERY_SET,
+			queryObject: {
+				from: 'somewhere-else',
+			},
+		} );
+		expect( state.autoAuthorize ).toEqual( false );
+	} );
+
+	test( 'should auto-authorize Woo users', () => {
+		const stateFromWooCommerceServicesPlugin = jetpackConnectAuthorize( undefined, {
+			type: JETPACK_CONNECT_QUERY_SET,
+			queryObject: {
+				from: 'woocommerce-services-auto-authorize',
+			},
+		} );
+		expect( stateFromWooCommerceServicesPlugin.autoAuthorize ).toEqual( true );
+
+		const stateFromWooCommerceWizard = jetpackConnectAuthorize( undefined, {
+			type: JETPACK_CONNECT_QUERY_SET,
+			queryObject: {
+				from: 'woocommerce-setup-wizard',
+			},
+		} );
+		expect( stateFromWooCommerceWizard.autoAuthorize ).toEqual( true );
+	} );
 } );


### PR DESCRIPTION
This PR sets `autoAuthenticate` to `true` for users coming from the WooCommerce Services flow that includes privacy information about Jetpack.

Here's a video showing what it looks like:

https://cloudup.com/cpZ-fOFL7yV

Background info: p7bbVw-1Rl-p2

I tested the flow using a logged out and logged in user, and I tested the usual Jetpack flow as logged in + out, and from wordpress.com/jetpack/connect

# Testing Instructions
1. Install Jetpack on your site, and deactivate it
2. In the file `class.jetpack.php`, find the function `build_connect_url` and add this line to it right above `return $raw ? $url : esc_url( $url );`:  `$url = add_query_arg( 'calypso_env', 'development', $url );`
3. Check out the branch `update/wcs-jp-flow` from https://github.com/Automattic/woocommerce-services and run `npm start` - https://github.com/Automattic/woocommerce-services/pull/1114
4. Go to the plugins page on your site, and click the WooCommerce Services connect button to see the new flow