### PR TITLE
Framework: Created 1 new selectors getSiteOptions and an utils function getSiteComputedAttributes.

### DIFF
--- a/client/state/selectors/get-site-options.js
+++ b/client/state/selectors/get-site-options.js
@@ -1,0 +1,25 @@
+/**
+ * Internal dependencies
+ */
+import { getRawSite } from 'state/sites/selectors';
+
+/**
+ * Returns the site options
+ *
+ * @param    {Object}    state    Global state tree
+ * @param    {Number}    siteId   Site ID
+ * @returns  {?Object}            Site options or null
+ */
+export default ( state, siteId ) => {
+	const site = getRawSite( state, siteId );
+	if ( ! site ) {
+		return null;
+	}
+	let options = site.options || {};
+	const defaultPostFormat = options.default_post_format;
+	// The 'standard' post format is saved as an option of '0'
+	if ( ! defaultPostFormat || defaultPostFormat === '0' ) {
+		options = { ...options, default_post_format: 'standard' };
+	}
+	return options;
+};

--- a/client/state/selectors/index.js
+++ b/client/state/selectors/index.js
@@ -113,6 +113,7 @@ export getSiteIconId from './get-site-icon-id';
 export getSiteIconUrl from './get-site-icon-url';
 export getSiteId from './get-site-id';
 export getSiteMonitorSettings from './get-site-monitor-settings';
+export getSiteOptions from './get-site-options';
 export getSites from './get-sites';
 export getSiteSetting from './get-site-setting';
 export getSiteSlugsForUpcomingTransactions from './get-site-slugs-for-upcoming-transactions';

--- a/client/state/selectors/test/get-site-options.js
+++ b/client/state/selectors/test/get-site-options.js
@@ -1,0 +1,107 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { getSiteOptions } from '../';
+import { userState } from './fixtures/user-state';
+
+describe( 'getSiteOptions()', () => {
+	it( 'should return null if site is not found', () => {
+		const state = {
+			...userState,
+			sites: {
+				items: {}
+			}
+		};
+		const siteOptions = getSiteOptions( state, 2916288 );
+		expect( siteOptions ).to.be.null;
+	} );
+
+	it( 'should return default options object if no options are found', () => {
+		const state = {
+			...userState,
+			sites: {
+				items: {
+					2916288: { ID: 2916288, name: 'WordPress.com Example Blog' }
+				}
+			}
+		};
+
+		const siteOptions = getSiteOptions( state, 2916288 );
+		expect( siteOptions ).to.eql( {
+			default_post_format: 'standard'
+		} );
+	} );
+
+	it( 'should return the options of the site if they exist with default_post_format added if it was not set', () => {
+		const state = {
+			...userState,
+			sites: {
+				items: {
+					2916288: {
+						ID: 2916288,
+						name: 'WordPress.com Example Blog',
+						options: {
+							option1: 'ok'
+						} },
+				}
+			}
+		};
+
+		const siteOptions = getSiteOptions( state, 2916288 );
+		expect( siteOptions ).to.eql( {
+			default_post_format: 'standard',
+			option1: 'ok'
+		} );
+	} );
+
+	it( 'should return the options of the site with correct default_post_format added if it was set to 0', () => {
+		const state = {
+			...userState,
+			sites: {
+				items: {
+					2916288: {
+						ID: 2916288,
+						name: 'WordPress.com Example Blog',
+						options: {
+							option1: 'ok',
+							default_post_format: '0'
+						} },
+				}
+			}
+		};
+
+		const siteOptions = getSiteOptions( state, 2916288 );
+		expect( siteOptions ).to.eql( {
+			default_post_format: 'standard',
+			option1: 'ok'
+		} );
+	} );
+
+	it( 'should return the options of the site if they exist', () => {
+		const state = {
+			...userState,
+			sites: {
+				items: {
+					2916288: {
+						ID: 2916288,
+						name: 'WordPress.com Example Blog',
+						options: {
+							option2: 'not-ok',
+							default_post_format: 'test',
+						} },
+				}
+			}
+		};
+
+		const siteOptions = getSiteOptions( state, 2916288 );
+		expect( siteOptions ).to.eql( {
+			default_post_format: 'test',
+			option2: 'not-ok',
+		} );
+	} );
+} );

--- a/client/state/sites/test/utils.js
+++ b/client/state/sites/test/utils.js
@@ -1,0 +1,89 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { getSiteComputedAttributes } from '../utils';
+import { userState } from 'state/selectors/test/fixtures/user-state';
+describe( 'utils', () => {
+	describe( 'getSiteComputedAttributes()', () => {
+		it( 'should return null if site is not found', () => {
+			const state = {
+				...userState,
+				sites: {
+					items: {}
+				}
+			};
+			const computedAttributes = getSiteComputedAttributes( state, 2916288 );
+			expect( computedAttributes ).to.be.null;
+		} );
+
+		it( 'should return the "mandatory" attributes', () => {
+			const state = {
+				...userState,
+				sites: {
+					items: {
+						2916288: {
+							ID: 2916288,
+							name: 'WordPress.com Example Blog',
+							URL: 'https://example.wordpress.com',
+							jetpack: false
+						}
+					}
+				}
+			};
+
+			const computedAttributes = getSiteComputedAttributes( state, 2916288 );
+			expect( computedAttributes ).to.eql( {
+				title: 'WordPress.com Example Blog',
+				is_previewable: false,
+				is_customizable: false,
+				hasConflict: false,
+				domain: 'example.wordpress.com',
+				slug: 'example.wordpress.com',
+				options: {
+					default_post_format: 'standard'
+				}
+			} );
+		} );
+
+		it( 'should return the "mandatory" and optional attributes if conditions for those are met', () => {
+			const options = {
+				default_post_format: 'test',
+				is_mapped_domain: true,
+				unmapped_url: 'https://unmapped-url.wordpress.com',
+				is_redirect: true
+			};
+			const state = {
+				...userState,
+				sites: {
+					items: {
+						2916288: {
+							ID: 2916288,
+							name: 'WordPress.com Example Blog',
+							URL: 'https://example.wordpress.com',
+							jetpack: false,
+							options
+						}
+					}
+				}
+			};
+
+			const computedAttributes = getSiteComputedAttributes( state, 2916288 );
+			expect( computedAttributes ).to.eql( {
+				title: 'WordPress.com Example Blog',
+				is_previewable: false,
+				is_customizable: false,
+				hasConflict: false,
+				domain: 'unmapped-url.wordpress.com',
+				slug: 'unmapped-url.wordpress.com',
+				options,
+				wpcom_url: 'unmapped-url.wordpress.com',
+				URL: 'https://unmapped-url.wordpress.com',
+			} );
+		} );
+	} );
+} );

--- a/client/state/sites/utils.js
+++ b/client/state/sites/utils.js
@@ -1,0 +1,49 @@
+/**
+ * Internal dependencies
+ */
+import {
+	getRawSite,
+	getSiteDomain,
+	getSiteOption,
+	getSiteSlug,
+	getSiteTitle,
+	isJetpackSite,
+	isSiteConflicting,
+	isSitePreviewable
+} from 'state/sites/selectors';
+import { canCurrentUser, getSiteOptions } from 'state/selectors';
+import { withoutHttp } from 'lib/url';
+
+/**
+ * Returns computed properties of the site object.
+ *
+ * @param    {Object}      state    Global state tree
+ * @param    {Number}      siteId   Site ID
+ * @returns  {?Object}              Site computed properties or null
+ */
+export const getSiteComputedAttributes = ( state, siteId ) => {
+	const site = getRawSite( state, siteId );
+	if ( ! site ) {
+		return null;
+	}
+
+	const computedAttributes = {
+		domain: getSiteDomain( state, siteId ),
+		hasConflict: isSiteConflicting( state, siteId ),
+		is_customizable: !! canCurrentUser( state, siteId, 'edit_theme_options' ),
+		is_previewable: !! isSitePreviewable( state, siteId ),
+		options: getSiteOptions( state, siteId ),
+		slug: getSiteSlug( state, siteId ),
+		title: getSiteTitle( state, siteId )
+	};
+
+	if ( getSiteOption( state, siteId, 'is_mapped_domain' ) && ! isJetpackSite( state, siteId ) ) {
+		computedAttributes.wpcom_url = withoutHttp( getSiteOption( state, siteId, 'unmapped_url' ) );
+	}
+
+	if ( getSiteOption( state, siteId, 'is_redirect' ) || isSiteConflicting( state, siteId ) ) {
+		computedAttributes.URL = getSiteOption( state, siteId, 'unmapped_url' );
+	}
+
+	return computedAttributes;
+};


### PR DESCRIPTION
Created 1 new selector getSiteOptions and 1 utils function getSiteComputedAttributes.
These artifacts are required to remove the dependency from lib/site/computed-attributes.

It's the same content as in PR https://github.com/Automattic/wp-calypso/pull/16213 but this time we don't change getSiteOption selector yet. That change will go in another PR.

To test:
Execute the automated tests:
npm test