### PR TITLE
Simplified getSiteOption selector by using getSiteOptions

### DIFF
--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -36,7 +36,7 @@ import { fromApi as seoTitleFromApi } from 'components/seo/meta-title-editor/map
 import versionCompare from 'lib/version-compare';
 import { getCustomizerFocus } from 'my-sites/customize/panels';
 import { getSiteComputedAttributes } from './utils';
-import { isSiteUpgradeable } from 'state/selectors';
+import { isSiteUpgradeable, getSiteOptions } from 'state/selectors';
 
 /**
  * Returns a raw site object by its ID.
@@ -318,12 +318,7 @@ export function isSitePreviewable( state, siteId ) {
  * @return {*}  The value of that option or null
  */
 export function getSiteOption( state, siteId, optionName ) {
-	const site = getRawSite( state, siteId );
-	if ( ! site || ! site.options ) {
-		return null;
-	}
-
-	return site.options[ optionName ];
+	return get( getSiteOptions( state, siteId ), optionName, null );
 }
 
 /**

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -973,7 +973,7 @@ describe( 'selectors', () => {
 			expect( siteOption ).to.be.null;
 		} );
 
-		it( 'should return undefined if the option is not known for that site', () => {
+		it( 'should return null if the option is not known for that site', () => {
 			const siteOption = getSiteOption(
 				{
 					sites: {
@@ -992,7 +992,7 @@ describe( 'selectors', () => {
 				'example_option'
 			);
 
-			expect( siteOption ).to.be.undefined;
+			expect( siteOption ).to.be.null;
 		} );
 
 		it( 'should return the option value if the option is known for that site', () => {


### PR DESCRIPTION
The result of the selector was changed, now selector returns null when option does not exist in the state, following our convention for selectors.

This PR depends on https://github.com/Automattic/wp-calypso/pull/16940 that makes stats ready for the new return value of the selector. **Can not be merged before the dependencies.**

To test:
If testing before dependencies are merged please create a local branch with the dependencies merged.
Execute the automated tests:
npm test
Navigate around the stats section, (Insights, Days, Weeks etc..), verify that things are working as expected and no error are show in the console.
Navigate to sections that use getSiteOption much e.g: plugins, and settings.