### PR TITLE
Updated stats logic to accept null in site option as a representation of no data exists

### DIFF
--- a/client/my-sites/stats/controller.jsx
+++ b/client/my-sites/stats/controller.jsx
@@ -15,7 +15,7 @@ import titlecase from 'to-title-case';
 import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
 import { renderWithReduxStore } from 'lib/react-helpers';
 import { savePreference } from 'state/preferences/actions';
-import { getSite, isJetpackSite } from 'state/sites/selectors';
+import { getSite, isJetpackSite, getSiteOption } from 'state/sites/selectors';
 import { getCurrentLayoutFocus } from 'state/ui/layout-focus/selectors';
 import { setNextLayoutFocus } from 'state/ui/layout-focus/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
@@ -165,7 +165,6 @@ module.exports = {
 		let date;
 		let chartTab;
 		let period;
-		let siteOffset = 0;
 		let numPeriodAgo = 0;
 		const basePath = route.sectionify( context.path );
 		let baseAnalyticsPath;
@@ -188,10 +187,8 @@ module.exports = {
 				context.store.dispatch( setTitle( i18n.translate( 'Stats', { textOnly: true } ) ) );
 			}
 
-			if ( currentSite && 'object' === typeof currentSite.options && 'undefined' !== typeof currentSite.options.gmt_offset ) {
-				siteOffset = currentSite.options.gmt_offset;
-			}
-			const momentSiteZone = i18n.moment().utcOffset( siteOffset );
+			const gmtOffset = getSiteOption( context.store.getState(), siteId, 'gmt_offset' );
+			const momentSiteZone = i18n.moment().utcOffset( Number.isFinite( gmtOffset ) ? gmtOffset : 0 );
 			if ( queryOptions.startDate && i18n.moment( queryOptions.startDate ).isValid ) {
 				date = i18n.moment( queryOptions.startDate ).locale( 'en' );
 				numPeriodAgo = getNumPeriodAgo( momentSiteZone, date, activeFilter.period );
@@ -268,8 +265,9 @@ module.exports = {
 		} else if ( ! activeFilter || -1 === validModules.indexOf( context.params.module ) ) {
 			next();
 		} else {
-			if ( 'object' === typeof( site.options ) && 'undefined' !== typeof( site.options.gmt_offset ) ) {
-				momentSiteZone = i18n.moment().utcOffset( site.options.gmt_offset );
+			const gmtOffset = getSiteOption( context.store.getState(), siteId, 'gmt_offset' );
+			if ( Number.isFinite( gmtOffset ) ) {
+				momentSiteZone = i18n.moment().utcOffset( gmtOffset );
 			}
 			if ( queryOptions.startDate && i18n.moment( queryOptions.startDate ).isValid ) {
 				date = i18n.moment( queryOptions.startDate );

--- a/client/my-sites/stats/overview.jsx
+++ b/client/my-sites/stats/overview.jsx
@@ -3,6 +3,7 @@
  */
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
+import { get } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -32,8 +33,9 @@ class StatsOverview extends Component {
 		const statsPath = ( path === '/stats' ) ? '/stats/day' : path;
 		const sitesSorted = sites.map( ( site ) => {
 			let momentSiteZone = moment();
-			if ( 'object' === typeof ( site.options ) && 'undefined' !== typeof ( site.options.gmt_offset ) ) {
-				momentSiteZone = moment().utcOffset( site.options.gmt_offset );
+			const gmtOffset = get( site, 'options.gmt_offset' );
+			if ( Number.isFinite( gmtOffset ) ) {
+				momentSiteZone = moment().utcOffset( gmtOffset );
 			}
 			site.periodEnd = momentSiteZone.endOf( period ).format( 'YYYY-MM-DD' );
 			return site;
@@ -62,14 +64,10 @@ class StatsOverview extends Component {
 		} );
 
 		const sitesList = sitesSorted.map( ( site, index ) => {
-			let siteOffset = 0;
 			const overview = [];
 
-			if ( 'object' === typeof ( site.options ) && 'undefined' !== typeof ( site.options.gmt_offset ) ) {
-				siteOffset = site.options.gmt_offset;
-			}
-
-			const date = moment().utcOffset( siteOffset ).format( 'YYYY-MM-DD' );
+			const gmtOffset = get( site, 'options.gmt_offset' );
+			const date = moment().utcOffset( Number.isFinite( gmtOffset ) ? gmtOffset : 0 ).format( 'YYYY-MM-DD' );
 
 			if ( 0 === index || sitesSorted[ index - 1 ].periodEnd !== site.periodEnd ) {
 				overview.push( <DatePicker period={ period } date={ date } /> );

--- a/client/state/stats/lists/selectors.js
+++ b/client/state/stats/lists/selectors.js
@@ -72,7 +72,7 @@ export function getSiteStatsForQuery( state, siteId, statType, query ) {
  */
 export const getSiteStatsPostStreakData = createSelector(
 	( state, siteId, query ) => {
-		const { gmtOffset = 0 } = query;
+		const gmtOffset = query.gmtOffset || 0;
 		const response = {};
 		const streakData = getSiteStatsForQuery( state, siteId, 'statsStreak', query );
 		// ensure streakData.data exists and it is not an array


### PR DESCRIPTION
This change happens because most of our selectors return null if no data exists and we should not be expecting undefined.

PR https://github.com/Automattic/wp-calypso/pull/16939, changes get site option to return null if no option exists so this change is required to be consistent with the new version of the selector.

**To test** 
Navigate around the stats section, (Insights, Days, Weeks etc..), verify that things are working as expected and no error are show in the console.
