### PR TITLE
Reader: Design tweaks to comment nesting

### DIFF
--- a/client/blocks/comments/style.scss
+++ b/client/blocks/comments/style.scss
@@ -253,7 +253,6 @@
 .comments__comment-respondee {
 	color: $gray;
 	margin-right: 12px;
-	// border: 1px solid red;
 
 	.gridicon {
 		position: relative;
@@ -277,10 +276,6 @@
 	flex-wrap: wrap;
 	font-size: 14px;
 	font-weight: 500;
-
-	> a {
-		// border: 1px solid red;
-	}
 
 	.gravatar {
 		border-radius: 48px;
@@ -322,11 +317,6 @@ a.comments__comment-username {
 	&:hover {
 		color: $blue-light;
 	}
-}
-
-.comments__comment-timestamp {
-
-	// border: 1px solid red;
 }
 
 .comments__comment-timestamp a {

--- a/client/blocks/comments/style.scss
+++ b/client/blocks/comments/style.scss
@@ -307,12 +307,13 @@
 
 .comments__comment-username {
 	color: darken( $gray, 30% );
-	height: 22px;
+	height: 21px;
 	margin-right: 7px;
 }
 
 a.comments__comment-username {
 	color: $blue-medium;
+	height: 21px;
 
 	&:hover {
 		color: $blue-light;

--- a/client/blocks/comments/style.scss
+++ b/client/blocks/comments/style.scss
@@ -125,16 +125,7 @@
 	margin: 0;
 
 	&.is-root {
-		margin-top: 0;
-	}
-
-	&.is-children {
-		margin-left: -2px;
-		border-left: 2px solid lighten( $gray, 10% );
-
-		.comments__comment-author .gravatar {
-			left: -15px;
-		}
+		margin-top: 20px;
 	}
 
 	.comments__form {
@@ -227,16 +218,16 @@
 
 // Individual Comment
 .comments__comment {
-	padding: 6px 0 0;
-	margin: 24px 0 0;
+	margin-top: 20px;
 	position: relative;
 
-	&.depth-0, &.depth-1, &.depth-2 {
-		padding-left: 48px;
-		margin-top: 12px;
+	&.depth-0,
+	&.depth-1,
+	&.depth-2 {
+		padding-left: 42px;
 
 		> .comments__comment-author .gravatar {
-			left: 8px;
+			left: 1px;
 		}
 	}
 
@@ -262,17 +253,18 @@
 .comments__comment-respondee {
 	color: $gray;
 	margin-right: 12px;
-	margin-left: -12px;
+	// border: 1px solid red;
 
 	.gridicon {
-		margin-right: 3px;
 		position: relative;
-			top: 4px;
+			left: -5px;
+			top: 3px;
 	}
 }
 
 .comments__comment-respondee .comments__comment-respondee-link {
 	color: darken( $gray, 10% );
+	margin-left: -2px;
 
 	&:hover {
 		color: $blue-light;
@@ -282,22 +274,19 @@
 .comments__comment-author {
 	color: darken( $gray, 30% );
 	display: flex;
+	flex-wrap: wrap;
 	font-size: 14px;
 	font-weight: 500;
 
-	@include breakpoint( "<480px" ) {
-		flex-wrap: wrap;
+	> a {
+		// border: 1px solid red;
 	}
 
 	.gravatar {
-		position: absolute;
-			top: 12px;
-			left: -41px;
 		border-radius: 48px;
-
-		@include breakpoint( ">480px" ) {
-			top: 12px;
-		}
+		position: absolute;
+			top: 8px;
+			left: -41px;
 	}
 }
 
@@ -323,7 +312,8 @@
 
 .comments__comment-username {
 	color: darken( $gray, 30% );
-	margin-right: 12px;
+	height: 22px;
+	margin-right: 7px;
 }
 
 a.comments__comment-username {
@@ -332,6 +322,11 @@ a.comments__comment-username {
 	&:hover {
 		color: $blue-light;
 	}
+}
+
+.comments__comment-timestamp {
+
+	// border: 1px solid red;
 }
 
 .comments__comment-timestamp a {
@@ -354,7 +349,7 @@ a.comments__comment-username {
 .comments__comment-content {
 	@extend %content-font;
 	font-size: 15px;
-	line-height: 1.8;
+	line-height: 25px;
 	word-break: break-word;
 
 	p {
@@ -378,9 +373,9 @@ a.comments__comment-username {
 // Actions for Individual Comments
 .comments__comment-actions {
 	list-style: none;
-	margin-left: -4px;
 	color: $gray;
 	font-size: 14px;
+	margin-top: 2px;
 
 	button {
 		display: inline-block;
@@ -401,6 +396,8 @@ a.comments__comment-username {
 		}
 
 		&.comments__comment-actions-reply {
+			margin-left: -7px;
+
 			.gridicon {
 				transform: rotate( 180deg );
 			}

--- a/client/my-sites/posts/style.scss
+++ b/client/my-sites/posts/style.scss
@@ -388,10 +388,6 @@
 	animation: appear .3s ease-in-out;
 }
 
-.post .comments__comment-timestamp {
-	margin-top: -4px;
-}
-
 .post .comments__view-more {
 	margin-top: 15px;
 }

--- a/client/my-sites/posts/style.scss
+++ b/client/my-sites/posts/style.scss
@@ -388,6 +388,10 @@
 	animation: appear .3s ease-in-out;
 }
 
+.post .comments__comment-author .gravatar{
+	top: 5px;
+}
+
 .post .comments__view-more {
 	margin-top: 15px;
 }


### PR DESCRIPTION
This fixes: https://github.com/Automattic/wp-calypso/issues/16883

![nest-comments-1](https://user-images.githubusercontent.com/4924246/28998033-ca29ec22-79d6-11e7-99d3-d9370c0aa4cf.png)

I also added wrapping for when names are long:
![nest-comments-3](https://user-images.githubusercontent.com/4924246/28998091-fd7e210a-79d7-11e7-9432-71cb1c635b9b.png)

> the baseline of the first comment line should align with the bottom of the avatar

As discussed, aligning makes the comment paragraph a little too tight. Current line-height was also a bit much so updated it from 1.8 to 25px.

This is a part of: https://github.com/Automattic/wp-calypso/pull/16770