### PR TITLE
Comments: Set all successful notices as green

### DIFF
--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -242,15 +242,15 @@ export class CommentList extends Component {
 	showBulkNotice = ( newStatus, selectedComments ) => {
 		const { translate } = this.props;
 
-		const [ type, message ] = get( {
-			approved: [ 'is-success', translate( 'All selected comments approved.' ) ],
-			unapproved: [ 'is-info', translate( 'All selected comments unapproved.' ) ],
-			spam: [ 'is-warning', translate( 'All selected comments marked as spam.' ) ],
-			trash: [ 'is-error', translate( 'All selected comments moved to trash.' ) ],
-			'delete': [ 'is-error', translate( 'All selected comments deleted permanently.' ) ],
-		}, newStatus, [ null, null ] );
+		const message = get( {
+			approved: translate( 'All selected comments approved.' ),
+			unapproved: translate( 'All selected comments unapproved.' ),
+			spam: translate( 'All selected comments marked as spam.' ),
+			trash: translate( 'All selected comments moved to trash.' ),
+			'delete': translate( 'All selected comments deleted permanently.' ),
+		}, newStatus );
 
-		if ( ! type ) {
+		if ( ! message ) {
 			return;
 		}
 
@@ -266,7 +266,7 @@ export class CommentList extends Component {
 			}
 		);
 
-		this.props.createNotice( type, message, options );
+		this.props.createNotice( 'is-success', message, options );
 	}
 
 	showNotice = ( comment, newStatus, options = { doPersist: false } ) => {
@@ -278,14 +278,14 @@ export class CommentList extends Component {
 			status: previousStatus,
 		} = comment;
 
-		const [ type, message ] = get( {
-			approved: [ 'is-success', translate( 'Comment approved.' ) ],
-			unapproved: [ 'is-info', translate( 'Comment unapproved.' ) ],
-			spam: [ 'is-warning', translate( 'Comment marked as spam.' ) ],
-			trash: [ 'is-error', translate( 'Comment moved to trash.' ) ],
-		}, newStatus, [ null, null ] );
+		const message = get( {
+			approved: translate( 'Comment approved.' ),
+			unapproved: translate( 'Comment unapproved.' ),
+			spam: translate( 'Comment marked as spam.' ),
+			trash: translate( 'Comment moved to trash.' ),
+		}, newStatus );
 
-		if ( ! type ) {
+		if ( ! message ) {
 			return;
 		}
 
@@ -310,7 +310,7 @@ export class CommentList extends Component {
 			},
 		};
 
-		this.props.createNotice( type, message, noticeOptions );
+		this.props.createNotice( 'is-success', message, noticeOptions );
 	}
 
 	toggleBulkEdit = () => this.setState( { isBulkEdit: ! this.state.isBulkEdit } );

--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -17,7 +17,7 @@ import {
 	replyComment,
 	unlikeComment,
 } from 'state/comments/actions';
-import { createNotice, removeNotice } from 'state/notices/actions';
+import { removeNotice, successNotice } from 'state/notices/actions';
 import { getNotices } from 'state/notices/selectors';
 import CommentDetail from 'blocks/comment-detail';
 import CommentDetailPlaceholder from 'blocks/comment-detail/comment-detail-placeholder';
@@ -180,7 +180,7 @@ export class CommentList extends Component {
 			this.setCommentStatus( parentComment, 'approved', { doPersist: true, showNotice: false } );
 		}
 
-		this.props.createNotice( 'is-success', noticeMessage, noticeOptions );
+		this.props.successNotice( noticeMessage, noticeOptions );
 		this.props.replyComment( commentText, postId, parentCommentId, { alsoApprove } );
 	}
 
@@ -266,7 +266,7 @@ export class CommentList extends Component {
 			}
 		);
 
-		this.props.createNotice( 'is-success', message, options );
+		this.props.successNotice( message, options );
 	}
 
 	showNotice = ( comment, newStatus, options = { doPersist: false } ) => {
@@ -310,7 +310,7 @@ export class CommentList extends Component {
 			},
 		};
 
-		this.props.createNotice( 'is-success', message, noticeOptions );
+		this.props.successNotice( message, noticeOptions );
 	}
 
 	toggleBulkEdit = () => this.setState( { isBulkEdit: ! this.state.isBulkEdit } );
@@ -483,7 +483,7 @@ const mapDispatchToProps = ( dispatch, { siteId } ) => ( {
 		changeCommentStatus( siteId, postId, commentId, status )
 	) ),
 
-	createNotice: ( status, text, options ) => dispatch( createNotice( status, text, options ) ),
+	successNotice: ( text, options ) => dispatch( successNotice( text, options ) ),
 
 	deleteComment: ( commentId, postId ) => dispatch( withAnalytics(
 		composeAnalytics(

--- a/client/state/data-layer/wpcom/comments/index.js
+++ b/client/state/data-layer/wpcom/comments/index.js
@@ -16,7 +16,7 @@ import {
 } from 'state/action-types';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
-import { createNotice, errorNotice } from 'state/notices/actions';
+import { errorNotice, successNotice } from 'state/notices/actions';
 import { getSitePost } from 'state/posts/selectors';
 import { getPostOldestCommentDate, getPostNewestCommentDate } from 'state/comments/selectors';
 import getSiteComment from 'state/selectors/get-site-comment';
@@ -196,8 +196,7 @@ export const deleteComment = ( { dispatch, getState }, action ) => {
 
 export const announceDeleteSuccess = ( { dispatch } ) => {
 	dispatch(
-		createNotice(
-			'is-success',
+		successNotice(
 			translate( 'Comment deleted permanently.' ),
 			{
 				duration: 5000,

--- a/client/state/data-layer/wpcom/comments/index.js
+++ b/client/state/data-layer/wpcom/comments/index.js
@@ -197,7 +197,7 @@ export const deleteComment = ( { dispatch, getState }, action ) => {
 export const announceDeleteSuccess = ( { dispatch } ) => {
 	dispatch(
 		createNotice(
-			'is-error',
+			'is-success',
 			translate( 'Comment deleted permanently.' ),
 			{
 				duration: 5000,


### PR DESCRIPTION
Change all Comment Management success notices to green (type `is-success`).

Previously, all Comment Management success notices had a color somewhat related to the action performed.
- Approve = green
- Unapprove = blue
- Mark as spam = yellow
- Move to trash = red
- Delete permanently = red

Though, this causes confusion, as, for example, a red notice could be interpreted as an error, regardless of the success text.

| Before | After |
| --- | --- |
| <img width="391" alt="screen shot 2017-08-06 at 18 01 56" src="https://user-images.githubusercontent.com/2070010/29005349-685605a2-7ad1-11e7-895a-8687ac3fcede.png"> | <img width="376" alt="screen shot 2017-08-06 at 18 02 03" src="https://user-images.githubusercontent.com/2070010/29005350-6bf71886-7ad1-11e7-8310-ad88de8774db.png"> |