### PR TITLE
Comments: Only show one error notice per site for failed single comments request

### DIFF
--- a/client/state/data-layer/wpcom/sites/comments/index.js
+++ b/client/state/data-layer/wpcom/sites/comments/index.js
@@ -113,7 +113,8 @@ export const receiveCommentError = ( { dispatch, getState }, { siteId, commentId
 			errorNotice(
 				translate( 'Failed to retrieve comment for site “%(siteName)s”', {
 					args: { siteName },
-				} )
+				} ),
+				{ id: `request-comment-error-${ siteId }` }
 			)
 		);
 	} else {
@@ -125,7 +126,7 @@ export const receiveCommentError = ( { dispatch, getState }, { siteId, commentId
 				} )
 				: translate( 'Failed to retrieve comment for your site' );
 
-		dispatch( errorNotice( error ) );
+		dispatch( errorNotice( error, { id: `request-comment-error-${ siteId }` } ) );
 	}
 
 	dispatch( {


### PR DESCRIPTION
Fixes #16927 

Only show one error notice per site for failed `requestComment`, no matter how many comments fail to load.

| Before | After |
| --- | --- |
| <img width="473" alt="screen shot 2017-08-06 at 18 12 32" src="https://user-images.githubusercontent.com/2070010/29005516-b89c1f12-7ad4-11e7-8f53-9af8b8e9858b.png"> | <img width="468" alt="screen shot 2017-08-06 at 18 20 01" src="https://user-images.githubusercontent.com/2070010/29005517-b8bc406c-7ad4-11e7-87a0-17d04f1040b7.png"> |