### PR TITLE
Comments: reply-to-comment post links open Reader instead of front end

### DIFF
--- a/client/blocks/comment-detail/comment-detail-post.jsx
+++ b/client/blocks/comment-detail/comment-detail-post.jsx
@@ -7,15 +7,14 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import ExternalLink from 'components/external-link';
 import Gravatar from 'components/gravatar';
 import SiteIcon from 'blocks/site-icon';
 
 export const CommentDetailPost = ( {
+	commentId,
 	parentCommentAuthorAvatarUrl,
 	parentCommentAuthorDisplayName,
 	parentCommentContent,
-	parentCommentUrl,
 	postAuthorDisplayName,
 	postTitle,
 	postUrl,
@@ -40,9 +39,9 @@ export const CommentDetailPost = ( {
 							{ translate( '%(authorName)s:', { args: { authorName: parentCommentAuthorDisplayName } } ) }
 						</span>
 					}
-					<ExternalLink href={ parentCommentUrl }>
+					<a href={ `${ postUrl }#comment-${ commentId }` }>
 						{ parentCommentContent }
-					</ExternalLink>
+					</a>
 				</div>
 			</div>
 		);

--- a/client/blocks/comment-detail/comment-detail-post.jsx
+++ b/client/blocks/comment-detail/comment-detail-post.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react';
+import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -9,6 +10,11 @@ import { localize } from 'i18n-calypso';
  */
 import Gravatar from 'components/gravatar';
 import SiteIcon from 'blocks/site-icon';
+import {
+	bumpStat,
+	composeAnalytics,
+	recordTracksEvent,
+} from 'state/analytics/actions';
 
 export const CommentDetailPost = ( {
 	commentId,
@@ -18,6 +24,8 @@ export const CommentDetailPost = ( {
 	postAuthorDisplayName,
 	postTitle,
 	postUrl,
+	recordReaderArticleOpened,
+	recordReaderCommentOpened,
 	siteId,
 	translate,
 } ) => {
@@ -39,7 +47,7 @@ export const CommentDetailPost = ( {
 							{ translate( '%(authorName)s:', { args: { authorName: parentCommentAuthorDisplayName } } ) }
 						</span>
 					}
-					<a href={ `${ postUrl }#comment-${ commentId }` }>
+					<a href={ `${ postUrl }#comment-${ commentId }` } onClick={ recordReaderCommentOpened }>
 						{ parentCommentContent }
 					</a>
 				</div>
@@ -56,7 +64,7 @@ export const CommentDetailPost = ( {
 						{ translate( '%(authorName)s:', { args: { authorName: postAuthorDisplayName } } ) }
 					</span>
 				}
-				<a href={ postUrl }>
+				<a href={ postUrl } onClick={ recordReaderArticleOpened }>
 					{ postTitle || translate( 'Untitled' ) }
 				</a>
 			</div>
@@ -64,4 +72,15 @@ export const CommentDetailPost = ( {
 	);
 };
 
-export default localize( CommentDetailPost );
+const mapDispatchToProps = dispatch => ( {
+	recordReaderArticleOpened: () => dispatch( composeAnalytics(
+		recordTracksEvent( 'calypso_comment_management_article_opened' ),
+		bumpStat( 'calypso_comment_management', 'article_opened' )
+	) ),
+	recordReaderCommentOpened: () => dispatch( composeAnalytics(
+		recordTracksEvent( 'calypso_comment_management_comment_opened' ),
+		bumpStat( 'calypso_comment_management', 'comment_opened' )
+	) ),
+} );
+
+export default connect( null, mapDispatchToProps )( localize( CommentDetailPost ) );

--- a/client/blocks/comment-detail/index.jsx
+++ b/client/blocks/comment-detail/index.jsx
@@ -199,7 +199,6 @@ export class CommentDetail extends Component {
 			parentCommentAuthorAvatarUrl,
 			parentCommentAuthorDisplayName,
 			parentCommentContent,
-			parentCommentUrl,
 			postAuthorDisplayName,
 			postId,
 			postTitle,
@@ -263,10 +262,10 @@ export class CommentDetail extends Component {
 				{ isExpanded &&
 					<div className="comment-detail__content">
 						<CommentDetailPost
+							commentId={ commentId }
 							parentCommentAuthorAvatarUrl={ parentCommentAuthorAvatarUrl }
 							parentCommentAuthorDisplayName={ parentCommentAuthorDisplayName }
 							parentCommentContent={ parentCommentContent }
-							parentCommentUrl={ parentCommentUrl }
 							postAuthorDisplayName={ postAuthorDisplayName }
 							postTitle={ postTitle }
 							postUrl={ postUrl }
@@ -338,7 +337,6 @@ const mapStateToProps = ( state, ownProps ) => {
 		parentCommentAuthorAvatarUrl: get( parentComment, 'author.avatar_URL' ),
 		parentCommentAuthorDisplayName: get( parentComment, 'author.name' ),
 		parentCommentContent,
-		parentCommentUrl: get( parentComment, 'URL', '' ),
 		postAuthorDisplayName: get( comment, 'post.author.name' ), // TODO: not available in the current data structure
 		postId,
 		postTitle,


### PR DESCRIPTION
Fixes #16926 

For reply-to-comment post links: replace external link to front end with internal link to Reader.

Also add analytics for both rely-to-post and reply-to-comment links:


Tracks Events
- `calypso_comment_management_article_opened`
- `calypso_comment_management_comment_opened`

Bump Stat for:
`calypso_comment_management`, (`article_opened`, `comment_opened`)

cc @samouri, @aaronyan 