### PR TITLE
Add getCurrentPlanPurchaseId selector

### DIFF
--- a/client/state/selectors/get-current-plan-purchase-id.js
+++ b/client/state/selectors/get-current-plan-purchase-id.js
@@ -1,0 +1,33 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { get, isNaN } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { getCurrentPlan } from 'state/sites/plans/selectors';
+
+/**
+ * Returns a site's current plan purchase ID or null if the site doesn't exist or the purchase ID
+ * is unknown.
+ *
+ * The ID returned by this selector is retrieved from the site plan. It is intended to provide a
+ * means of retrieving full purchase information based on a site and its plan information.
+ * Caution! It _does not_ retrieve the ID from a purchase.
+ *
+ * @param  {Object}  state  Global state tree
+ * @param  {Number}  siteId Site ID
+ * @return {?Number}        Purchase ID if known
+ */
+export default function getCurrentPlanPurchaseId( state, siteId ) {
+	const result = get( getCurrentPlan( state, siteId ), 'id', null );
+
+	// getCurrentPlan uses an "assembler" which may have NaN in the `id`.
+	if ( isNaN( result ) ) {
+		return null;
+	}
+
+	return result;
+}

--- a/client/state/selectors/index.js
+++ b/client/state/selectors/index.js
@@ -38,6 +38,7 @@ export getBlogStickers from './get-blog-stickers';
 export getContactDetailsCache from './get-contact-details-cache';
 export getContactDetailsExtraCache from './get-contact-details-extra-cache';
 export getCurrentLocaleSlug from './get-current-locale-slug';
+export getCurrentPlanPurchaseId from './get-current-plan-purchase-id';
 export getCurrentUserPaymentMethods from './get-current-user-payment-methods';
 export getImageEditorIsGreaterThanMinimumDimensions from './get-image-editor-is-greater-than-minimum-dimensions';
 export getImageEditorOriginalAspectRatio from './get-image-editor-original-aspect-ratio';

--- a/client/state/selectors/test/get-current-plan-purchase-id.js
+++ b/client/state/selectors/test/get-current-plan-purchase-id.js
@@ -1,0 +1,107 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { getCurrentPlanPurchaseId } from '..';
+
+describe( 'getCurrentPlanPurchaseId()', () => {
+	it( 'should return null if the site is unknown', () => {
+		const state = {
+			sites: {
+				plans: {
+					456: {
+						data: [
+							{
+								currentPlan: true,
+								id: 98765,
+							},
+						],
+					},
+				},
+				items: {
+					456: {},
+				},
+			},
+		};
+
+		expect( getCurrentPlanPurchaseId( state ) ).to.be.null;
+		expect( getCurrentPlanPurchaseId( state, 123 ) ).to.be.null;
+	} );
+
+	it( 'should return null if the current purchase ID is unknown', () => {
+		const siteId = 123;
+		const state = {
+			sites: {
+				plans: {
+					[ siteId ]: {
+						data: [
+							{
+								currentPlan: false,
+								id: 98765,
+							},
+							{
+								currentPlan: true,
+							},
+						],
+					},
+				},
+				items: {
+					[ siteId ]: {},
+				},
+			},
+		};
+
+		expect( getCurrentPlanPurchaseId( state, siteId ) ).to.be.null;
+	} );
+
+	it( 'should return null if there is no plans data, but there is site plan data', () => {
+		const siteId = 123;
+		const state = {
+			sites: {
+				plans: {
+					[ siteId ]: {
+						data: [],
+					},
+				},
+				items: {
+					[ siteId ]: {
+						plan: {},
+					},
+				},
+			},
+		};
+
+		expect( getCurrentPlanPurchaseId( state, siteId ) ).to.be.null;
+	} );
+
+	it( 'should return the purchase ID for a site', () => {
+		const siteId = 123;
+		const purchaseId = 123456;
+		const state = {
+			sites: {
+				plans: {
+					[ siteId ]: {
+						data: [
+							{
+								currentPlan: true,
+								id: purchaseId,
+							},
+						],
+					},
+				},
+				items: {
+					[ siteId ]: {
+						plan: { some: 'plan' },
+					},
+				},
+			},
+		};
+
+		expect( getCurrentPlanPurchaseId( state, siteId ) ).to.equal( purchaseId );
+	} );
+} );

--- a/client/state/selectors/test/get-current-plan-purchase-id.js
+++ b/client/state/selectors/test/get-current-plan-purchase-id.js
@@ -12,6 +12,9 @@ import { getCurrentPlanPurchaseId } from '..';
 describe( 'getCurrentPlanPurchaseId()', () => {
 	it( 'should return null if the site is unknown', () => {
 		const state = {
+			currentUser: {
+				capabilities: {},
+			},
 			sites: {
 				plans: {
 					456: {
@@ -36,6 +39,9 @@ describe( 'getCurrentPlanPurchaseId()', () => {
 	it( 'should return null if the current purchase ID is unknown', () => {
 		const siteId = 123;
 		const state = {
+			currentUser: {
+				capabilities: {},
+			},
 			sites: {
 				plans: {
 					[ siteId ]: {
@@ -62,6 +68,9 @@ describe( 'getCurrentPlanPurchaseId()', () => {
 	it( 'should return null if there is no plans data, but there is site plan data', () => {
 		const siteId = 123;
 		const state = {
+			currentUser: {
+				capabilities: {},
+			},
 			sites: {
 				plans: {
 					[ siteId ]: {
@@ -83,6 +92,9 @@ describe( 'getCurrentPlanPurchaseId()', () => {
 		const siteId = 123;
 		const purchaseId = 123456;
 		const state = {
+			currentUser: {
+				capabilities: {},
+			},
 			sites: {
 				plans: {
 					[ siteId ]: {


### PR DESCRIPTION
Add `getCurrentPlanPurchaseId` selector which will provide the purchase id from the site's current plan. This will make it possible to obtain purchase information about a site's current plan.

The motivation for this change is that plans contain some information about expiration and renewal, but it does not appear to be very reliable. [Different logic](https://github.com/Automattic/wp-calypso/blob/7b57ac64f77bcd764a21a649b619659800e7767e/client/me/purchases/manage-purchase/purchase-meta.jsx#L149-L183) is applied on the purchases page and much of it is based on a specific purchase object obtained by ID.

## Testing
1. Run the tests (CI should be sufficient 🙂 )

## Context

Working on #14516 to add accurate expire/renewal data to the plans page.