### PR TITLE
Extensions: Zoninator - Add a settingsPath constant

### DIFF
--- a/client/extensions/zoninator/app/util.js
+++ b/client/extensions/zoninator/app/util.js
@@ -1,0 +1,18 @@
+/**
+ * External dependencies
+ */
+import { find, get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import sectionsModule from 'sections';
+
+const getSettingsPath = () => {
+	const sections = sectionsModule.get();
+	const section = find( sections, value => value.name === 'zoninator' );
+
+	return get( section, 'settings_path' );
+};
+
+export const settingsPath = getSettingsPath();

--- a/client/extensions/zoninator/components/settings/zone-creator/index.jsx
+++ b/client/extensions/zoninator/components/settings/zone-creator/index.jsx
@@ -19,12 +19,13 @@ import ReduxFormTextarea from 'components/redux-forms/redux-form-textarea';
 import ReduxFormTextInput from 'components/redux-forms/redux-form-text-input';
 import SectionHeader from 'components/section-header';
 import { getSelectedSiteSlug } from 'state/ui/selectors';
+import { settingsPath } from '../../../app/util';
 
 const form = 'extensions.zoninator.newZone';
 
 const ZoneCreator = ( { siteSlug, translate } ) => (
 	<div>
-		<HeaderCake backHref={ `/extensions/zoninator/${ siteSlug }` }>
+		<HeaderCake backHref={ `${ settingsPath }/${ siteSlug }` }>
 			{ translate( 'Add a zone' ) }
 		</HeaderCake>
 

--- a/client/extensions/zoninator/components/settings/zones-dashboard/index.jsx
+++ b/client/extensions/zoninator/components/settings/zones-dashboard/index.jsx
@@ -4,7 +4,7 @@
 import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { find, flowRight, get, times } from 'lodash';
+import { flowRight, times } from 'lodash';
 
 /**
  * Internal dependencies
@@ -12,42 +12,36 @@ import { find, flowRight, get, times } from 'lodash';
 import Button from 'components/button';
 import HeaderCake from 'components/header-cake';
 import SectionHeader from 'components/section-header';
-import sectionsModule from 'sections';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import QueryZones from '../../data/query-zones';
 import ZoneItem from './zone-item';
 import ZonePlaceholder from './zone-placeholder';
 import { getZones, isRequestingZones } from '../../../state/zones/selectors';
+import { settingsPath } from '../../../app/util';
 
 const placeholderCount = 5;
 
-const ZonesDashboard = ( { isRequesting, siteId, siteSlug, translate, zones } ) => {
-	const sections = sectionsModule.get();
-	const section = find( sections, ( value => value.name === 'zoninator' ) );
-	const settingsPath = get( section, 'settings_path' );
+const ZonesDashboard = ( { isRequesting, siteId, siteSlug, translate, zones } ) => (
+	<div>
+		<QueryZones siteId={ siteId } />
 
-	return (
-		<div>
-			<QueryZones siteId={ siteId } />
+		<HeaderCake backHref={ `/plugins/zoninator/${ siteSlug }` }>
+			Zoninator Settings
+		</HeaderCake>
 
-			<HeaderCake backHref={ `/plugins/zoninator/${ siteSlug }` }>
-				Zoninator Settings
-			</HeaderCake>
-
-			<SectionHeader label={ translate( 'Zones' ) }>
-				<Button compact href={ `${ settingsPath }/new/${ siteSlug }` }>
-					{ translate( 'Add a zone' ) }
-				</Button>
-			</SectionHeader>
-			{ isRequesting && zones.length === 0 && times( placeholderCount, i => (
-				<ZonePlaceholder key={ i } />
-			) ) }
-			{ zones.map( ( zone ) => (
-				<ZoneItem key={ zone.slug } zone={ zone } />
-			) ) }
-		</div>
-	);
-};
+		<SectionHeader label={ translate( 'Zones' ) }>
+			<Button compact href={ `${ settingsPath }/new/${ siteSlug }` }>
+				{ translate( 'Add a zone' ) }
+			</Button>
+		</SectionHeader>
+		{ isRequesting && zones.length === 0 && times( placeholderCount, i => (
+			<ZonePlaceholder key={ i } />
+		) ) }
+		{ zones.map( ( zone ) => (
+			<ZoneItem key={ zone.slug } zone={ zone } />
+		) ) }
+	</div>
+);
 
 ZonesDashboard.propTypes = {
 	siteSlug: PropTypes.string,

--- a/client/extensions/zoninator/components/settings/zones-dashboard/index.jsx
+++ b/client/extensions/zoninator/components/settings/zones-dashboard/index.jsx
@@ -26,7 +26,7 @@ const ZonesDashboard = ( { isRequesting, siteId, siteSlug, translate, zones } ) 
 		<QueryZones siteId={ siteId } />
 
 		<HeaderCake backHref={ `/plugins/zoninator/${ siteSlug }` }>
-			Zoninator Settings
+			{ translate( 'Zoninator Settings' ) }
 		</HeaderCake>
 
 		<SectionHeader label={ translate( 'Zones' ) }>

--- a/client/extensions/zoninator/components/settings/zones-dashboard/zone-item.jsx
+++ b/client/extensions/zoninator/components/settings/zones-dashboard/zone-item.jsx
@@ -3,20 +3,15 @@
  */
 import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
-import { find, get } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import CompactCard from 'components/card/compact';
-import sectionsModule from 'sections';
 import { getSelectedSiteSlug } from 'state/ui/selectors';
+import { settingsPath } from '../../../app/util';
 
 const ZoneItem = ( { siteSlug, zone } ) => {
-	const sections = sectionsModule.get();
-	const section = find( sections, ( value => value.name === 'zoninator' ) );
-	const settingsPath = get( section, 'settings_path' );
-
 	const { slug, name, description } = zone;
 
 	return (


### PR DESCRIPTION
This PR adds a `settingsPath` constant for the Zoninator extension, to prevent some code duplication in the extension components.

# Testing

- Open Zoninator extension settings
- Make sure `New zone` button and the zones on the list redirect to correct URLs.
- Make sure the `back` button on 'New zone' and 'Edit zone' pages redirects to zones overview.