### PR TITLE
Extensions: Zoninator - Update PropTypes imports

### DIFF
--- a/client/extensions/zoninator/components/settings/zone-creator/index.jsx
+++ b/client/extensions/zoninator/components/settings/zone-creator/index.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { reduxForm } from 'redux-form';
 import { localize } from 'i18n-calypso';

--- a/client/extensions/zoninator/components/settings/zone/index.jsx
+++ b/client/extensions/zoninator/components/settings/zone/index.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { flowRight, noop } from 'lodash';

--- a/client/extensions/zoninator/components/settings/zones-dashboard/index.jsx
+++ b/client/extensions/zoninator/components/settings/zones-dashboard/index.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { find, flowRight, get, times } from 'lodash';

--- a/client/extensions/zoninator/components/settings/zones-dashboard/zone-item.jsx
+++ b/client/extensions/zoninator/components/settings/zones-dashboard/zone-item.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { find, get } from 'lodash';
 


### PR DESCRIPTION
This PR updates all `PropTypes` imports within the Zoninator extension to use `prop-types` library as explained [here](https://facebook.github.io/react/docs/typechecking-with-proptypes.html).