### PR TITLE
Send the access token along with the id token when creating an account from Google

### DIFF
--- a/client/blocks/login/social-connect-prompt.jsx
+++ b/client/blocks/login/social-connect-prompt.jsx
@@ -13,7 +13,7 @@ import SocialLogo from 'social-logos';
 import Button from 'components/button';
 import Card from 'components/card';
 import {
-	getLinkingSocialToken,
+	getLinkingSocialAuthInfo,
 	getLinkingSocialService,
 	getRedirectTo,
 } from 'state/login/selectors';
@@ -22,7 +22,7 @@ import { recordTracksEvent } from 'state/analytics/actions';
 
 class SocialConnectPrompt extends Component {
 	static propTypes = {
-		linkingSocialToken: PropTypes.string,
+		linkingSocialAuthInfo: PropTypes.object,
 		linkingSocialService: PropTypes.string,
 		onSuccess: PropTypes.func.isRequired,
 		redirectTo: PropTypes.string,
@@ -31,7 +31,7 @@ class SocialConnectPrompt extends Component {
 
 	handleClick = ( event ) => {
 		const {
-			linkingSocialToken,
+			linkingSocialAuthInfo,
 			linkingSocialService,
 			onSuccess,
 			redirectTo,
@@ -39,7 +39,7 @@ class SocialConnectPrompt extends Component {
 
 		event.preventDefault();
 
-		this.props.connectSocialUser( linkingSocialService, linkingSocialToken, redirectTo )
+		this.props.connectSocialUser( linkingSocialAuthInfo, redirectTo )
 			.then(
 				() => {
 					this.props.recordTracksEvent( 'calypso_login_social_connect_success', {
@@ -105,8 +105,8 @@ class SocialConnectPrompt extends Component {
 
 export default connect(
 	( state ) => ( {
+		linkingSocialAuthInfo: getLinkingSocialAuthInfo( state ),
 		linkingSocialService: getLinkingSocialService( state ),
-		linkingSocialToken: getLinkingSocialToken( state ),
 		redirectTo: getRedirectTo( state ),
 	} ),
 	{

--- a/client/blocks/login/social.jsx
+++ b/client/blocks/login/social.jsx
@@ -40,11 +40,17 @@ class SocialLoginForm extends Component {
 	handleGoogleResponse = ( response ) => {
 		const { onSuccess, redirectTo } = this.props;
 
-		if ( ! response.Zi || ! response.Zi.id_token ) {
+		if ( ! response.Zi || ! response.Zi.access_token || ! response.Zi.id_token ) {
 			return;
 		}
 
-		this.props.loginSocialUser( 'google', response.Zi.id_token, redirectTo )
+		const socialInfo = {
+			service: 'google',
+			access_token: response.Zi.access_token,
+			id_token: response.Zi.id_token,
+		};
+
+		this.props.loginSocialUser( socialInfo, redirectTo )
 			.then(
 				() => {
 					this.recordEvent( 'calypso_login_social_login_success' );
@@ -53,7 +59,7 @@ class SocialLoginForm extends Component {
 				},
 				error => {
 					if ( error.code === 'unknown_user' ) {
-						return this.props.createSocialUser( 'google', response.Zi.id_token, 'login' )
+						return this.props.createSocialUser( socialInfo, 'login' )
 							.then(
 								() => this.recordEvent( 'calypso_login_social_signup_success' ),
 								createAccountError => this.recordEvent( 'calypso_login_social_signup_failure', {

--- a/client/components/signup-form/social.jsx
+++ b/client/components/signup-form/social.jsx
@@ -31,7 +31,7 @@ class SocialSignupForm extends Component {
 			return;
 		}
 
-		this.props.handleResponse( 'google', response.Zi.id_token );
+		this.props.handleResponse( 'google', response.Zi.access_token, response.Zi.id_token );
 	}
 
 	handleFacebookResponse( response ) {

--- a/client/components/signup-form/social.jsx
+++ b/client/components/signup-form/social.jsx
@@ -27,7 +27,7 @@ class SocialSignupForm extends Component {
 	}
 
 	handleGoogleResponse( response ) {
-		if ( ! response.Zi || ! response.Zi.id_token ) {
+		if ( ! response.Zi || ! response.Zi.access_token || ! response.Zi.id_token ) {
 			return;
 		}
 

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -285,13 +285,18 @@ module.exports = {
 		SignupCart.addToCart( siteId, newCartItems, error => callback( error, { cartItem, privacyItem } ) );
 	},
 
-	createAccount( callback, dependencies, { userData, flowName, queryArgs, service, token }, reduxStore ) {
+	createAccount( callback, dependencies, { userData, flowName, queryArgs, service, access_token, id_token }, reduxStore ) {
 		const surveyVertical = getSurveyVertical( reduxStore.getState() ).trim();
 		const surveySiteType = getSurveySiteType( reduxStore.getState() ).trim();
 
 		if ( service ) {
 			// We're creating a new social account
-			wpcom.undocumented().usersSocialNew( service, token, flowName, ( error, response ) => {
+			wpcom.undocumented().usersSocialNew( {
+				service,
+				access_token,
+				id_token,
+				signup_flow_name: flowName,
+			}, ( error, response ) => {
 				const errors = error && error.error ? [ { error: error.error, message: error.message } ] : undefined;
 
 				if ( errors ) {

--- a/client/lib/wpcom-undocumented/lib/me.js
+++ b/client/lib/wpcom-undocumented/lib/me.js
@@ -370,16 +370,18 @@ UndocumentedMe.prototype.deletePurchase = function( purchaseId, fn ) {
  * Connect the current account with a social service (e.g. Google/Facebook).
  *
  * @param {string} service - Social service associated with token, e.g. google.
- * @param {string} token - Token returned from service.
+ * @param {string} access_token - OAuth2 Token returned from service.
+ * @param {string} id_token - (Optional) OpenID Connect Token returned from service.
  * @param {string} redirectTo - The URL to redirect to after connecting.
  * @param {Function} fn - callback
  *
  * @return {Promise} A promise for the request
  */
-UndocumentedMe.prototype.socialConnect = function( service, token, redirectTo, fn ) {
+UndocumentedMe.prototype.socialConnect = function( { service, access_token, id_token, redirectTo }, fn ) {
 	const body = {
 		service,
-		token,
+		access_token,
+		id_token,
 		redirectTo,
 
 		// This API call is restricted to these OAuth keys

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1414,7 +1414,7 @@ Undocumented.prototype.saveABTestData = function( name, variation, fn ) {
  * Sign up for a new user account
  * Create a new user
  *
- * @param {string} query - an object with three values: email, username, password
+ * @param {object} query - an object with three values: email, username, password
  * @param {Function} fn - Function to invoke when request is complete
  */
 Undocumented.prototype.usersNew = function( query, fn ) {
@@ -1436,26 +1436,20 @@ Undocumented.prototype.usersNew = function( query, fn ) {
 /**
  * Sign up for a new account with a social service (e.g. Google/Facebook).
  *
- * @param {string} service - Social service associated with token, e.g. google.
- * @param {string} token - Token returned from service.
+ * @param {object} query - an object with the following values: service, access_token, id_token (optional), signup_flow_name
  * @param {Function} fn - callback
  *
  * @return {Promise} A promise for the request
  */
-Undocumented.prototype.usersSocialNew = function( service, token, flowName, fn ) {
-	const body = {
-		service,
-		token,
-		signup_flow_name: flowName,
-		locale: i18n.getLocaleSlug()
-	};
+Undocumented.prototype.usersSocialNew = function( query, fn ) {
+	query.locale = i18n.getLocaleSlug();
 
 	// This API call is restricted to these OAuth keys
 	restrictByOauthKeys( body );
 
 	const args = {
 		path: '/users/social/new',
-		body
+		body: query
 	};
 
 	return this.wpcom.req.post( args, fn );
@@ -1464,7 +1458,7 @@ Undocumented.prototype.usersSocialNew = function( service, token, flowName, fn )
 /**
  * Sign up for a new phone account
  *
- * @param {string} query - a key/value pair; key: 'phone_number', value: 'the users phone number'
+ * @param {object} query - a key/value pair; key: 'phone_number', value: 'the users phone number'
  * @param {Function} fn - Function to invoke when request is complete
  */
 Undocumented.prototype.usersPhoneNew = function( query, fn ) {
@@ -1484,7 +1478,7 @@ Undocumented.prototype.usersPhoneNew = function( query, fn ) {
 /**
  * Log in to an existing phone account
  *
- * @param {string} query - a key/value pair; key: 'phone_number', value: 'the users phone number'
+ * @param {object} query - a key/value pair; key: 'phone_number', value: 'the users phone number'
  * @param {Function} fn - Function to invoke when request is complete
  */
 Undocumented.prototype.usersPhone = function( query, fn ) {
@@ -1504,7 +1498,7 @@ Undocumented.prototype.usersPhone = function( query, fn ) {
 /**
  * Verify a record in the signups table and create a new user from it
  *
- * @param {string} query - two key/value pairs; { 'phone_number': 'the users phone number', 'code': 'the verification code we sent to the phone number' }
+ * @param {object} query - two key/value pairs; { 'phone_number': 'the users phone number', 'code': 'the verification code we sent to the phone number' }
  * @param {Function} fn - Function to invoke when request is complete
  */
 Undocumented.prototype.usersPhoneVerification = function( query, fn ) {
@@ -1525,7 +1519,7 @@ Undocumented.prototype.usersPhoneVerification = function( query, fn ) {
 /**
  * Sign up for a new email only account
  *
- * @param {string} query - a key/value pair; key: 'email', value: 'the users email address'
+ * @param {object} query - a key/value pair; key: 'email', value: 'the users email address'
  * @param {Function} fn - Function to invoke when request is complete
  */
 Undocumented.prototype.usersEmailNew = function( query, fn ) {
@@ -1545,7 +1539,7 @@ Undocumented.prototype.usersEmailNew = function( query, fn ) {
 /**
  * Log in to an existing email account
  *
- * @param {string} query - a key/value pair; key: 'email', value: 'the users email address'
+ * @param {object} query - a key/value pair; key: 'email', value: 'the users email address'
  * @param {Function} fn - Function to invoke when request is complete
  */
 Undocumented.prototype.usersEmail = function( query, fn ) {
@@ -1565,7 +1559,7 @@ Undocumented.prototype.usersEmail = function( query, fn ) {
 /**
  * Verify a record in wp_signups and create a new user from it
  *
- * @param {string} query - two key/value pairs; { 'email': 'the users email address', 'code': 'the verification code we sent to the email address' }
+ * @param {object} query - two key/value pairs; { 'email': 'the users email address', 'code': 'the verification code we sent to the email address' }
  * @param {Function} fn - Function to invoke when request is complete
  */
 Undocumented.prototype.usersEmailVerification = function( query, fn ) {

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1445,7 +1445,7 @@ Undocumented.prototype.usersSocialNew = function( query, fn ) {
 	query.locale = i18n.getLocaleSlug();
 
 	// This API call is restricted to these OAuth keys
-	restrictByOauthKeys( body );
+	restrictByOauthKeys( query );
 
 	const args = {
 		path: '/users/social/new',

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1498,7 +1498,8 @@ Undocumented.prototype.usersPhone = function( query, fn ) {
 /**
  * Verify a record in the signups table and create a new user from it
  *
- * @param {object} query - two key/value pairs; { 'phone_number': 'the users phone number', 'code': 'the verification code we sent to the phone number' }
+ * @param {object} query - two key/value pairs;
+ *           { 'phone_number': 'the users phone number', 'code': 'the verification code we sent to the phone number' }
  * @param {Function} fn - Function to invoke when request is complete
  */
 Undocumented.prototype.usersPhoneVerification = function( query, fn ) {
@@ -1559,7 +1560,8 @@ Undocumented.prototype.usersEmail = function( query, fn ) {
 /**
  * Verify a record in wp_signups and create a new user from it
  *
- * @param {object} query - two key/value pairs; { 'email': 'the users email address', 'code': 'the verification code we sent to the email address' }
+ * @param {object} query - two key/value pairs;
+ *            { 'email': 'the users email address', 'code': 'the verification code we sent to the email address' }
  * @param {Function} fn - Function to invoke when request is complete
  */
 Undocumented.prototype.usersEmailVerification = function( query, fn ) {

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -104,8 +104,16 @@ export class UserStep extends Component {
 		} );
 	};
 
-	handleSocialResponse = ( service, token ) => {
-		this.submit( { service, token } );
+	/**
+	 * Handle Social service authentication flow result (OAuth2 or OpenID Connect)
+	 *
+	 * @param {String} service      The name of the social service
+	 * @param {String} access_token An OAuth2 acccess token
+	 * @param {String} id_token     (Optional) a JWT id_token which contains the signed user info
+	 *                              So our server doesn't have to request the user profile on its end.
+	 */
+	handleSocialResponse = ( service, access_token, id_token = null ) => {
+		this.submit( { service, access_token, id_token } );
 	};
 
 	userCreationComplete() {

--- a/client/state/login/reducer.js
+++ b/client/state/login/reducer.js
@@ -172,12 +172,11 @@ export const socialAccount = createReducer( { isCreating: false }, {
 		username,
 		bearerToken
 	} ),
-	[ SOCIAL_LOGIN_REQUEST_FAILURE ]: ( state, { error, service, token } ) => ( {
+	[ SOCIAL_LOGIN_REQUEST_FAILURE ]: ( state, { error, authInfo } ) => ( {
 		...state,
 		requestError: error,
 		email: error.email,
-		service: service,
-		token: token,
+		authInfo
 	} ),
 	[ USER_RECEIVE ]: state => ( { ...state, bearerToken: null, username: null } ),
 	[ LOGIN_REQUEST ]: state => ( { ...state, createError: null } ),

--- a/client/state/login/selectors.js
+++ b/client/state/login/selectors.js
@@ -231,12 +231,12 @@ export const getLinkingSocialUser = ( state ) => get( state, 'login.socialAccoun
  * @param  {Object}   state  Global state tree
  * @return {?String}         Service name of the social account.
  */
-export const getLinkingSocialService = ( state ) => get( state, 'login.socialAccount.service', null );
+export const getLinkingSocialService = ( state ) => get( state, 'login.socialAccount.authInfo.service', null );
 
 /***
- * Gets the token of the social account to be linked.
+ * Gets the auth information of the social account to be linked.
  *
  * @param  {Object}   state  Global state tree
- * @return {?String}         Token of the social account.
+ * @return {?String}         Email address of the social account.
  */
-export const getLinkingSocialToken = ( state ) => get( state, 'login.socialAccount.token', null );
+export const getLinkingSocialAuthInfo = ( state ) => get( state, 'login.socialAccount.authInfo', null );

--- a/client/state/login/test/selectors.js
+++ b/client/state/login/test/selectors.js
@@ -24,7 +24,7 @@ import {
 	isFormDisabled,
 	getLinkingSocialUser,
 	getLinkingSocialService,
-	getLinkingSocialToken,
+	getLinkingSocialAuthInfo,
 } from '../selectors';
 
 describe( 'selectors', () => {
@@ -310,27 +310,46 @@ describe( 'selectors', () => {
 				}
 			} ) ).to.eql( account );
 		} );
+	} );
+
+	describe( 'getLinkingSocialAuthInfo()', () => {
+		it( 'should return null if there is no information yet', () => {
+			expect( getLinkingSocialService( undefined ) ).to.be.null;
+		} );
 
 		it( 'should return the social service when available', () => {
-			const service = 'google';
 			expect( getLinkingSocialService( {
 				login: {
 					socialAccount: {
-						service: service,
+						authInfo: {
+							service: 'google',
+							access_token: 'a_token',
+							id_token: 'another_token',
+						}
 					}
 				}
-			} ) ).to.eql( service );
+			} ) ).to.eql( 'google' );
+		} );
+	} );
+
+	describe( 'getLinkingSocialAuthInfo()', () => {
+		it( 'should return null if there is no information yet', () => {
+			expect( getLinkingSocialAuthInfo( undefined ) ).to.be.null;
 		} );
 
-		it( 'should return the social account token when available', () => {
-			const token = 'this-is-probably-not-a-real-token';
-			expect( getLinkingSocialToken( {
+		it( 'should return the social account authentication information when available', () => {
+			const socialAccountInfo = {
+				service: 'google',
+				access_token: 'a_token',
+				id_token: 'another_token',
+			};
+			expect( getLinkingSocialAuthInfo( {
 				login: {
 					socialAccount: {
-						token: token,
+						authInfo: socialAccountInfo,
 					}
 				}
-			} ) ).to.eql( token );
+			} ) ).to.deep.eql( socialAccountInfo );
 		} );
 	} );
 } );


### PR DESCRIPTION
Requires server patch D6682.

This PR updates social login and social sign up (as well as social linking) to include the access_token given by google in the request payload.
This is necessary to fetch the user's avatar on the server on signup and might serve other purposes in the future.

### Testing Instructions

### Social signup from login page
- Go to https://plus.google.com/u/0/me and upload an avatar if you don't already have one
- Go to http://calypso.localhost:3000/log-in and click on "Continue with Google"
- Authenticate with the same google account
- Follow to the server patch instruction to execute the avatar update job
- Go to http://calypso.localhost:3000/me and check that `First name`, `Last Name` and `Public Display Name` are filled. Check that your google avatar has been uploaded

#### Test that all other flows still work
- Follow to the server patch instruction to unlink your google account and/or reset your password
- Social signup at http://calypso.localhost:3000/start/social
- Test social linking
- Test social login

### Reviews
- [x] Product
- [x] Code