### PR TITLE
SimplePaymentsDialog: rewrite the form to Redux Form

### DIFF
--- a/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
@@ -99,7 +99,7 @@ class SimplePaymentsDialog extends Component {
 				this.editPaymentButton( null );
 			} else {
 				// If the list is loading or is non-empty, show it
-				this.setState( { activeTab: 'list' } );
+				this.showButtonList();
 			}
 		}
 
@@ -185,7 +185,22 @@ class SimplePaymentsDialog extends Component {
 		return new Promise( resolve => this.formStateController.handleSubmit( resolve ) );
 	}
 
-	handleChangeTabs = activeTab => this.setState( { activeTab } );
+	handleChangeTabs = activeTab => {
+		if ( activeTab === 'form' ) {
+			this.editPaymentButton( null );
+		} else {
+			this.showButtonList();
+		}
+	};
+
+	showButtonList() {
+		this.setState( { activeTab: 'list' } );
+	}
+
+	editPaymentButton = editedPaymentId => {
+		this.setState( { activeTab: 'form', editedPaymentId } );
+		this.formStateController.resetFields( this.getInitialFormFields( editedPaymentId ) );
+	};
 
 	handleSelectedChange = selectedPaymentId => this.setState( { selectedPaymentId } );
 
@@ -253,11 +268,6 @@ class SimplePaymentsDialog extends Component {
 				}
 			} );
 		} );
-	};
-
-	editPaymentButton = paymentId => {
-		this.setState( { activeTab: 'form', editedPaymentId: paymentId } );
-		this.formStateController.resetFields( this.getInitialFormFields( paymentId ) );
 	};
 
 	updatePaymentButton() {

--- a/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 
 /**
@@ -319,7 +320,7 @@ class SimplePaymentsDialog extends Component {
 					primary
 				>
 					{ translate( 'Save' ) }
-				</Button>,
+				</Button>
 			);
 		} else {
 			const insertDisabled =
@@ -334,7 +335,7 @@ class SimplePaymentsDialog extends Component {
 					primary
 				>
 					{ translate( 'Insert' ) }
-				</Button>,
+				</Button>
 			);
 		}
 
@@ -354,11 +355,7 @@ class SimplePaymentsDialog extends Component {
 				] }
 				additionalClassNames="editor-simple-payments-modal"
 			>
-				<Navigation
-					activeTab={ 'list' }
-					paymentButtons={ [] }
-					onChangeTabs={ noop }
-				/>
+				<Navigation activeTab={ 'list' } paymentButtons={ [] } onChangeTabs={ noop } />
 				{ content }
 			</Dialog>
 		);
@@ -378,7 +375,7 @@ class SimplePaymentsDialog extends Component {
 			isJetpackNotSupported,
 			translate,
 			planHasSimplePaymentsFeature,
-			shouldQuerySitePlans
+			shouldQuerySitePlans,
 		} = this.props;
 		const { activeTab, errorMessage } = this.state;
 
@@ -390,23 +387,29 @@ class SimplePaymentsDialog extends Component {
 
 		if ( ! shouldQuerySitePlans && isJetpackNotSupported ) {
 			return this.renderEmptyDialog(
-				<Notice status="is-error" text={
-					translate( 'Please upgrade to Jetpack 5.2 to use Simple Payments feature' )
-				} onDismissClick={ onClose } />
+				<Notice
+					status="is-error"
+					text={ translate( 'Please upgrade to Jetpack 5.2 to use Simple Payments feature' ) }
+					onDismissClick={ onClose }
+				/>
 			);
 		}
 
 		if ( ! shouldQuerySitePlans && ! planHasSimplePaymentsFeature ) {
 			return this.renderEmptyDialog(
 				<div className="editor-simple-payments-modal__nudge-wrapper">
-					<div className="editor-simple-payments-modal__nudge-title">{ translate( 'Insert payment button' ) }</div>
+					<div className="editor-simple-payments-modal__nudge-title">
+						{ translate( 'Insert payment button' ) }
+					</div>
 					<div className="editor-simple-payments-modal__nudge-subtitle">
 						{ translate( 'To insert Payment Button to your site, upgrade your plan.' ) }
 					</div>
 					<UpgradeNudge
 						className="editor-simple-payments-modal__nudge-nudge"
 						title={ translate( 'Upgrade to a Premium Plan!' ) }
-						message={ translate( 'And get simple payments, advanced social media, your own domain, and more.' ) }
+						message={ translate(
+							'And get simple payments, advanced social media, your own domain, and more.'
+						) }
 						feature={ FEATURE_SIMPLE_PAYMENTS }
 						shouldDisplay={ this.returnTrue }
 					/>
@@ -465,8 +468,9 @@ export default connect( ( state, { siteId } ) => {
 		siteId,
 		paymentButtons: getSimplePayments( state, siteId ),
 		currencyCode: getCurrentUserCurrencyCode( state ),
-		shouldQuerySitePlans: ( getSitePlanSlug( state, siteId ) === null ),
-		isJetpackNotSupported: isJetpackSite( state, siteId ) && ! isJetpackMinimumVersion( state, siteId, '5.2' ),
-		planHasSimplePaymentsFeature: hasFeature( state, siteId, FEATURE_SIMPLE_PAYMENTS )
+		shouldQuerySitePlans: getSitePlanSlug( state, siteId ) === null,
+		isJetpackNotSupported:
+			isJetpackSite( state, siteId ) && ! isJetpackMinimumVersion( state, siteId, '5.2' ),
+		planHasSimplePaymentsFeature: hasFeature( state, siteId, FEATURE_SIMPLE_PAYMENTS ),
 	};
 } )( localize( SimplePaymentsDialog ) );


### PR DESCRIPTION
Stop using `lib/form-state` and migrate the form to `redux-form`.

This simplifies the code a lot: the PR removes 50 more lines of code than it adds. And I added a lot of comments, too :)

The `ProductForm` is now connected to the Redux state and the `form` module also exports a few selectors that are needed to submit the form from outside the component. The fact that the submit buttons and the submissions logic lives outside the form component makes matters a bit complicated, but the Redux Form API is so well designed so that it's still very elegant and concise.

Moving the form state to Redux allowed to extract a lot of the API logic to separate thunk actions that are independent from the UI component. These can be further moved to the `client/state` directory and maybe refactored to data layer one day.

Validation is improved validation a lot: that's the main user-visible outcome of the rewrite. Redux Form tracks a "dirty" state for each field (has it been changed from the initial value) and also a "touched" state (set to `true` after the field has been focused and blurred again). The
validation can now be immediate and non-intrusive. The submit button is enabled if and only if the form is valid. Validation errors are displayed only when the field is "touched", i.e., the form doesn't shout at me that fields that I haven't even started to fill are invalid (empty).

To test:
- edit an existing button: is the form filled with proper initial values? Does the form validate correctly? Is the "Insert" and "Save" button disabled when it should be? Are errors reported (i.e., when network is offline)?
- add new button: is the form empty initially? Does editing and saving work?
- images: can you upload an image? Is the form updated and can it be saved? Is the change persisted?
