### PR TITLE
Extensions: Zoninator - Add data layer for creating new zones

### DIFF
--- a/client/extensions/zoninator/state/data-layer/zones/index.js
+++ b/client/extensions/zoninator/state/data-layer/zones/index.js
@@ -49,7 +49,7 @@ export const createZone = ( { dispatch }, action ) => {
 	}, action ) );
 };
 
-export const announceZoneSaved = ( { dispatch }, { form, siteId }, next, { data } ) => {
+export const announceZoneSaved = ( dispatch, { form, siteId }, data ) => {
 	dispatch( stopSubmit( form ) );
 	dispatch( updateZone( siteId, data ) );
 	dispatch( successNotice(
@@ -58,11 +58,11 @@ export const announceZoneSaved = ( { dispatch }, { form, siteId }, next, { data 
 	) );
 };
 
-export const announceZoneCreated = ( { dispatch, getState }, action, next, response ) => {
+export const announceZoneCreated = ( { dispatch, getState }, action, response ) => {
 	const { siteId } = action;
 
 	page( `/extensions/zoninator/${ getSiteSlug( getState(), siteId ) }` );
-	announceZoneSaved( { dispatch }, action, next, response );
+	announceZoneSaved( dispatch, action, response.data );
 };
 
 export const announceFailure = ( { dispatch }, { form } ) => {

--- a/client/extensions/zoninator/state/data-layer/zones/index.js
+++ b/client/extensions/zoninator/state/data-layer/zones/index.js
@@ -4,6 +4,7 @@
 import page from 'page';
 import { translate } from 'i18n-calypso';
 import { startSubmit, stopSubmit } from 'redux-form';
+import { map } from 'lodash';
 
 /**
  * Internal dependencies
@@ -13,6 +14,7 @@ import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { errorNotice, removeNotice, successNotice } from 'state/notices/actions';
 import { getSiteSlug } from 'state/sites/selectors';
 import { requestError, updateZone, updateZones } from '../../zones/actions';
+import { fromApi } from './utils';
 import { ZONINATOR_REQUEST_ZONES, ZONINATOR_ADD_ZONE } from 'zoninator/state/action-types';
 
 export const requestZonesList = ( { dispatch }, action ) => {
@@ -31,7 +33,7 @@ export const requestZonesError = ( { dispatch }, { siteId } ) =>
 	dispatch( requestError( siteId ) );
 
 export const updateZonesList = ( { dispatch }, { siteId }, { data } ) =>
-	dispatch( updateZones( siteId, data ) );
+	dispatch( updateZones( siteId, map( data, fromApi ) ) );
 
 export const createZone = ( { dispatch }, action ) => {
 	const { data, form, siteId } = action;
@@ -51,7 +53,7 @@ export const createZone = ( { dispatch }, action ) => {
 
 export const announceZoneSaved = ( dispatch, { form, siteId }, data ) => {
 	dispatch( stopSubmit( form ) );
-	dispatch( updateZone( siteId, data ) );
+	dispatch( updateZone( siteId, fromApi( data ) ) );
 	dispatch( successNotice(
 		translate( 'Zone saved!' ),
 		{ id: 'zoninator-zone-create' },

--- a/client/extensions/zoninator/state/data-layer/zones/index.js
+++ b/client/extensions/zoninator/state/data-layer/zones/index.js
@@ -1,10 +1,19 @@
 /**
+ * External dependencies
+ */
+import page from 'page';
+import { translate } from 'i18n-calypso';
+import { startSubmit, stopSubmit } from 'redux-form';
+
+/**
  * Internal dependencies
  */
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
-import { requestError, updateZones } from '../../zones/actions';
-import { ZONINATOR_REQUEST_ZONES } from 'zoninator/state/action-types';
+import { errorNotice, removeNotice, successNotice } from 'state/notices/actions';
+import { getSiteSlug } from 'state/sites/selectors';
+import { requestError, updateZone, updateZones } from '../../zones/actions';
+import { ZONINATOR_REQUEST_ZONES, ZONINATOR_ADD_ZONE } from 'zoninator/state/action-types';
 
 export const requestZonesList = ( { dispatch }, action ) => {
 	const { siteId } = action;
@@ -24,8 +33,50 @@ export const requestZonesError = ( { dispatch }, { siteId } ) =>
 export const updateZonesList = ( { dispatch }, { siteId }, { data } ) =>
 	dispatch( updateZones( siteId, data ) );
 
+export const createZone = ( { dispatch }, action ) => {
+	const { data, form, siteId } = action;
+
+	dispatch( startSubmit( form ) );
+	dispatch( removeNotice( 'zoninator-zone-create' ) );
+	dispatch( http( {
+		method: 'POST',
+		path: `/jetpack-blogs/${ siteId }/rest-api/`,
+		query: {
+			body: JSON.stringify( data ),
+			json: true,
+			path: '/zoninator/v1/zones',
+		},
+	}, action ) );
+};
+
+export const announceZoneSaved = ( { dispatch }, { form, siteId }, next, { data } ) => {
+	dispatch( stopSubmit( form ) );
+	dispatch( updateZone( siteId, data ) );
+	dispatch( successNotice(
+		translate( 'Zone saved!' ),
+		{ id: 'zoninator-zone-create' },
+	) );
+};
+
+export const announceZoneCreated = ( { dispatch, getState }, action, next, response ) => {
+	const { siteId } = action;
+
+	page( `/extensions/zoninator/${ getSiteSlug( getState(), siteId ) }` );
+	announceZoneSaved( { dispatch }, action, next, response );
+};
+
+export const announceFailure = ( { dispatch }, { form } ) => {
+	dispatch( stopSubmit( form ) );
+	dispatch( errorNotice(
+		translate( 'There was a problem saving the zone. Please try again.' ),
+		{ id: 'zoninator-zone-create' },
+	) );
+};
+
 const dispatchFetchZonesRequest = dispatchRequest( requestZonesList, updateZonesList, requestZonesError );
+const dispatchAddZoneRequest = dispatchRequest( createZone, announceZoneCreated, announceFailure );
 
 export default {
 	[ ZONINATOR_REQUEST_ZONES ]: [ dispatchFetchZonesRequest ],
+	[ ZONINATOR_ADD_ZONE ]: [ dispatchAddZoneRequest ],
 };

--- a/client/extensions/zoninator/state/data-layer/zones/test/index.js
+++ b/client/extensions/zoninator/state/data-layer/zones/test/index.js
@@ -3,13 +3,31 @@
  */
 import { expect } from 'chai';
 import sinon from 'sinon';
+import { translate } from 'i18n-calypso';
+import {
+	startSubmit as startSave,
+	stopSubmit as stopSave,
+} from 'redux-form';
 
 /**
  * Internal dependencies
  */
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { requestZonesError, requestZonesList, updateZonesList } from '../';
-import { requestError, requestZones, updateZones } from 'zoninator/state/zones/actions';
+import { errorNotice, removeNotice, successNotice } from 'state/notices/actions';
+import {
+	announceFailure,
+	announceZoneSaved,
+	createZone,
+	requestZonesError,
+	requestZonesList,
+	updateZonesList
+} from '../';
+import {
+	requestError,
+	requestZones,
+	updateZone,
+	updateZones
+} from 'zoninator/state/zones/actions';
 
 const apiResponse = {
 	data: [
@@ -19,6 +37,11 @@ const apiResponse = {
 			description: 'A test zone.',
 		}
 	],
+};
+
+const zone = {
+	none: 'New zone',
+	description: 'A new zone',
 };
 
 describe( '#requestZonesList()', () => {
@@ -42,7 +65,7 @@ describe( '#requestZonesList()', () => {
 	} );
 } );
 
-describe( '#updateZonesList', () => {
+describe( '#updateZonesList()', () => {
 	it( 'should dispatch `updateZones`', () => {
 		const dispatch = sinon.spy();
 		const action = requestZones( 123456 );
@@ -60,7 +83,7 @@ describe( '#updateZonesList', () => {
 	} );
 } );
 
-describe( '#requestZonesError', () => {
+describe( '#requestZonesError()', () => {
 	it( 'should dispatch `requestError`', () => {
 		const dispatch = sinon.spy();
 		const action = requestError( 123456 );
@@ -69,5 +92,134 @@ describe( '#requestZonesError', () => {
 
 		expect( dispatch ).to.have.been.calledOnce;
 		expect( dispatch ).to.have.been.calledWith( requestError( 123456 ) );
+	} );
+} );
+
+describe( '#createZone()', () => {
+	it( 'should dispatch a HTTP request to create a new zone', () => {
+		const dispatch = sinon.spy();
+		const action = {
+			type: 'DUMMY_ACTION',
+			siteId: 123456,
+			data: zone,
+			form: 'form',
+		};
+
+		createZone( { dispatch }, action );
+
+		expect( dispatch ).to.have.been.calledWith( http( {
+			method: 'POST',
+			path: '/jetpack-blogs/123456/rest-api/',
+			query: {
+				body: JSON.stringify( zone ),
+				json: true,
+				path: '/zoninator/v1/zones',
+			},
+		}, action ) );
+	} );
+
+	it( 'should dispatch `startSave`', () => {
+		const dispatch = sinon.spy();
+		const action = {
+			type: 'DUMMY_ACTION',
+			siteId: 123456,
+			data: zone,
+			form: 'form',
+		};
+
+		createZone( { dispatch }, action );
+
+		expect( dispatch ).to.have.been.calledWith( startSave( 'form' ) );
+	} );
+
+	it( 'should dispatch `removeNotice`', () => {
+		const dispatch = sinon.spy();
+		const action = {
+			type: 'DUMMY_ACTION',
+			siteId: 123456,
+			data: zone,
+			form: 'form',
+		};
+
+		createZone( { dispatch }, action );
+
+		expect( dispatch ).to.have.been.calledWith( removeNotice( 'zoninator-zone-create' ) );
+	} );
+} );
+
+describe( '#announceZoneSaved()', () => {
+	it( 'should dispatch `stopSave`', () => {
+		const dispatch = sinon.spy();
+		const action = {
+			type: 'DUMMY_ACTION',
+			siteId: 123456,
+			data: zone,
+			form: 'form',
+		};
+
+		announceZoneSaved( { dispatch }, action, null, { data: zone } );
+
+		expect( dispatch ).to.have.been.calledWith( stopSave( 'form' ) );
+	} );
+
+	it( 'should dispatch `updateZone`', () => {
+		const dispatch = sinon.spy();
+		const action = {
+			type: 'DUMMY_ACTION',
+			siteId: 123456,
+			form: 'form',
+		};
+
+		announceZoneSaved( { dispatch }, action, null, { data: zone } );
+
+		expect( dispatch ).to.have.been.calledWith( updateZone( 123456, zone ) );
+	} );
+
+	it( 'should dispatch `successNotice`', () => {
+		const dispatch = sinon.spy();
+		const action = {
+			type: 'DUMMY_ACTION',
+			siteId: 123456,
+			form: 'form',
+		};
+
+		announceZoneSaved( { dispatch }, action, null, { data: zone } );
+
+		expect( dispatch ).to.have.been.calledWith( successNotice(
+			translate( 'Zone saved!' ),
+			{ id: 'zoninator-zone-create' },
+		) );
+	} );
+} );
+
+describe( '#announceFailure()', () => {
+	it( 'should dispatch `stopSave`', () => {
+		const dispatch = sinon.spy();
+		const action = {
+			type: 'DUMMY_ACTION',
+			siteId: 123456,
+			form: 'form',
+		};
+
+		announceFailure( { dispatch }, action );
+
+		expect( dispatch ).to.have.been.calledWith( stopSave( 'form' ) );
+	} );
+
+	it( 'should dispatch `errorNotice`', () => {
+		const dispatch = sinon.spy();
+		const action = {
+			type: 'DUMMY_ACTION',
+			siteId: 123456,
+			data: zone,
+			form: 'form',
+		};
+
+		announceFailure( { dispatch }, action );
+
+		expect( dispatch ).to.have.been.calledWith( errorNotice(
+			translate( 'There was a problem saving the zone. Please try again.' ),
+			{ id: 'zoninator-zone-create' },
+		) );
 	} );
 } );

--- a/client/extensions/zoninator/state/data-layer/zones/test/index.js
+++ b/client/extensions/zoninator/state/data-layer/zones/test/index.js
@@ -8,6 +8,7 @@ import {
 	startSubmit as startSave,
 	stopSubmit as stopSave,
 } from 'redux-form';
+import { map } from 'lodash';
 
 /**
  * Internal dependencies
@@ -28,6 +29,7 @@ import {
 	updateZone,
 	updateZones
 } from 'zoninator/state/zones/actions';
+import { fromApi } from '../utils';
 
 const apiResponse = {
 	data: [
@@ -73,13 +75,13 @@ describe( '#updateZonesList()', () => {
 		updateZonesList( { dispatch }, action, apiResponse );
 
 		expect( dispatch ).to.have.been.calledOnce;
-		expect( dispatch ).to.have.been.calledWith( updateZones( 123456, [
+		expect( dispatch ).to.have.been.calledWith( updateZones( 123456, map( [
 			{
 				name: 'Test zone',
 				slug: 'test-zone',
 				description: 'A test zone.',
 			}
-		] ) );
+		], fromApi ) ) );
 	} );
 } );
 
@@ -172,7 +174,7 @@ describe( '#announceZoneSaved()', () => {
 
 		announceZoneSaved( dispatch, action, zone );
 
-		expect( dispatch ).to.have.been.calledWith( updateZone( 123456, zone ) );
+		expect( dispatch ).to.have.been.calledWith( updateZone( 123456, fromApi( zone ) ) );
 	} );
 
 	it( 'should dispatch `successNotice`', () => {

--- a/client/extensions/zoninator/state/data-layer/zones/test/index.js
+++ b/client/extensions/zoninator/state/data-layer/zones/test/index.js
@@ -157,7 +157,7 @@ describe( '#announceZoneSaved()', () => {
 			form: 'form',
 		};
 
-		announceZoneSaved( { dispatch }, action, null, { data: zone } );
+		announceZoneSaved( dispatch, action, zone );
 
 		expect( dispatch ).to.have.been.calledWith( stopSave( 'form' ) );
 	} );
@@ -170,7 +170,7 @@ describe( '#announceZoneSaved()', () => {
 			form: 'form',
 		};
 
-		announceZoneSaved( { dispatch }, action, null, { data: zone } );
+		announceZoneSaved( dispatch, action, zone );
 
 		expect( dispatch ).to.have.been.calledWith( updateZone( 123456, zone ) );
 	} );
@@ -183,7 +183,7 @@ describe( '#announceZoneSaved()', () => {
 			form: 'form',
 		};
 
-		announceZoneSaved( { dispatch }, action, null, { data: zone } );
+		announceZoneSaved( dispatch, action, zone );
 
 		expect( dispatch ).to.have.been.calledWith( successNotice(
 			translate( 'Zone saved!' ),

--- a/client/extensions/zoninator/state/data-layer/zones/utils.js
+++ b/client/extensions/zoninator/state/data-layer/zones/utils.js
@@ -1,0 +1,6 @@
+export const fromApi = ( { description, name, slug, term_id } ) => ( {
+	description,
+	id: term_id,
+	name,
+	slug,
+} );

--- a/client/extensions/zoninator/state/zones/schema.js
+++ b/client/extensions/zoninator/state/zones/schema.js
@@ -7,7 +7,7 @@ export const itemsSchema = {
 			patternProperties: {
 				'^\\d+$': {
 					type: 'object',
-					term_id: { type: 'integer' },
+					id: { type: 'integer' },
 					name: { type: 'string' },
 					slug: { type: 'string' },
 					description: { type: 'string' },

--- a/client/extensions/zoninator/state/zones/test/actions.js
+++ b/client/extensions/zoninator/state/zones/test/actions.js
@@ -25,12 +25,12 @@ describe( 'actions', () => {
 	const siteId = 123456;
 	const zones = {
 		1: {
-			term_id: 1,
+			id: 1,
 			name: 'Foo',
 			description: 'A test zone.',
 		},
 		2: {
-			term_id: 2,
+			id: 2,
 			name: 'Bar',
 			description: 'Another zone.',
 		},

--- a/client/extensions/zoninator/state/zones/test/reducer.js
+++ b/client/extensions/zoninator/state/zones/test/reducer.js
@@ -102,20 +102,20 @@ describe( 'reducer', () => {
 
 	describe( 'items()', () => {
 		const primaryZone = {
-			term_id: 1,
+			id: 1,
 			name: 'Test zone',
 			description: 'A test zone',
 			slug: 'test-zone',
 		};
 		const secondaryZone = {
-			term_id: 2,
+			id: 2,
 			name: 'Test zone 2',
 			description: 'Another test zone',
 		};
 
 		const previousState = deepFreeze( {
 			[ primarySiteId ]: {
-				[ primaryZone.term_id ]: primaryZone,
+				[ primaryZone.id ]: primaryZone,
 			},
 		} );
 
@@ -130,13 +130,13 @@ describe( 'reducer', () => {
 				type: ZONINATOR_UPDATE_ZONES,
 				siteId: primarySiteId,
 				data: {
-					[ primaryZone.term_id ]: primaryZone,
+					[ primaryZone.id ]: primaryZone,
 				},
 			} );
 
 			expect( state ).to.deep.equal( {
 				[ primarySiteId ]: {
-					[ primaryZone.term_id ]: primaryZone,
+					[ primaryZone.id ]: primaryZone,
 				},
 			} );
 		} );
@@ -146,16 +146,16 @@ describe( 'reducer', () => {
 				type: ZONINATOR_UPDATE_ZONES,
 				siteId: secondarySiteId,
 				data: {
-					[ secondaryZone.term_id ]: secondaryZone,
+					[ secondaryZone.id ]: secondaryZone,
 				},
 			} );
 
 			expect( state ).to.deep.equal( {
 				[ primarySiteId ]: {
-					[ primaryZone.term_id ]: primaryZone,
+					[ primaryZone.id ]: primaryZone,
 				},
 				[ secondarySiteId ]: {
-					[ secondaryZone.term_id ]: secondaryZone,
+					[ secondaryZone.id ]: secondaryZone,
 				},
 			} );
 		} );
@@ -165,13 +165,13 @@ describe( 'reducer', () => {
 				type: ZONINATOR_UPDATE_ZONES,
 				siteId: primarySiteId,
 				data: {
-					[ secondaryZone.term_id ]: secondaryZone,
+					[ secondaryZone.id ]: secondaryZone,
 				},
 			} );
 
 			expect( state ).to.deep.equal( {
 				[ primarySiteId ]: {
-					[ secondaryZone.term_id ]: secondaryZone,
+					[ secondaryZone.id ]: secondaryZone,
 				},
 			} );
 		} );
@@ -180,13 +180,13 @@ describe( 'reducer', () => {
 			const state = items( undefined, {
 				type: ZONINATOR_UPDATE_ZONE,
 				siteId: primarySiteId,
-				zoneId: primaryZone.term_id,
+				zoneId: primaryZone.id,
 				data: primaryZone,
 			} );
 
 			expect( state ).to.deep.equal( {
 				[ primarySiteId ]: {
-					[ primaryZone.term_id ]: primaryZone,
+					[ primaryZone.id ]: primaryZone,
 				},
 			} );
 		} );
@@ -195,21 +195,21 @@ describe( 'reducer', () => {
 			const state = items( previousState, {
 				type: ZONINATOR_UPDATE_ZONE,
 				siteId: primarySiteId,
-				zoneId: secondaryZone.term_id,
+				zoneId: secondaryZone.id,
 				data: secondaryZone,
 			} );
 
 			expect( state ).to.deep.equal( {
 				[ primarySiteId ]: {
-					[ primaryZone.term_id ]: primaryZone,
-					[ secondaryZone.term_id ]: secondaryZone,
+					[ primaryZone.id ]: primaryZone,
+					[ secondaryZone.id ]: secondaryZone,
 				},
 			} );
 		} );
 
 		it( 'should update zones of the same site and zone ID', () => {
 			const updatedZone = {
-				term_id: primaryZone.term_id,
+				id: primaryZone.id,
 				name: 'Updated zone',
 				slug: 'updated-zone',
 				description: 'This zone has been updated.',
@@ -218,13 +218,13 @@ describe( 'reducer', () => {
 			const state = items( previousState, {
 				type: ZONINATOR_UPDATE_ZONE,
 				siteId: primarySiteId,
-				zoneId: updatedZone.term_id,
+				zoneId: updatedZone.id,
 				data: updatedZone,
 			} );
 
 			expect( state ).to.deep.equal( {
 				[ primarySiteId ]: {
-					[ primaryZone.term_id ]: updatedZone,
+					[ primaryZone.id ]: updatedZone,
 				},
 			} );
 		} );
@@ -236,7 +236,7 @@ describe( 'reducer', () => {
 
 			expect( state ).to.deep.equal( {
 				[ primarySiteId ]: {
-					[ primaryZone.term_id ]: primaryZone,
+					[ primaryZone.id ]: primaryZone,
 				},
 			} );
 		} );
@@ -248,7 +248,7 @@ describe( 'reducer', () => {
 
 			expect( state ).to.deep.equal( {
 				[ primarySiteId ]: {
-					[ primaryZone.term_id ]: primaryZone,
+					[ primaryZone.id ]: primaryZone,
 				}
 			} );
 		} );

--- a/client/extensions/zoninator/state/zones/test/selectors.js
+++ b/client/extensions/zoninator/state/zones/test/selectors.js
@@ -85,7 +85,7 @@ describe( 'selectors', () => {
 	describe( 'getZones()', () => {
 		const primaryZones = {
 			1: {
-				term_id: 1,
+				id: 1,
 				name: 'Foo',
 				description: 'A test zone.',
 			},


### PR DESCRIPTION
This PR implements the necessary data layer for creation of new zones.

# Testing

Unit tests: `npm run test-client client/extensions/zoninator/state`