### PR TITLE
Analytics: added Yandex tracking

### DIFF
--- a/client/lib/analytics/ad-tracking.js
+++ b/client/lib/analytics/ad-tracking.js
@@ -46,6 +46,7 @@ const FACEBOOK_TRACKING_SCRIPT_URL = 'https://connect.facebook.net/en_US/fbevent
 	TWITTER_TRACKING_SCRIPT_URL = 'https://static.ads-twitter.com/uwt.js',
 	DCM_FLOODLIGHT_IFRAME_URL = 'https://6355556.fls.doubleclick.net/activityi',
 	LINKED_IN_SCRIPT_URL = 'https://snap.licdn.com/li.lms-analytics/insight.min.js',
+	YANDEX_SCRIPT_URL = 'https://mc.yandex.ru/metrika/watch.js',
 	MEDIA_WALLAH_URL = 'https://d3ir0rz7vxwgq5.cloudfront.net/mwData.min.js',
 	QUORA_URL = 'https://a.quora.com/qevents.js',
 	TRACKING_IDS = {
@@ -216,6 +217,9 @@ function loadTrackingScripts( callback ) {
 			loadScript.loadScript( LINKED_IN_SCRIPT_URL, onComplete );
 		},
 		function( onComplete ) {
+			loadScript.loadScript( YANDEX_SCRIPT_URL, onComplete );
+		},
+		function( onComplete ) {
 			loadScript.loadScript( MEDIA_WALLAH_URL, onComplete );
 		},
 		function( onComplete ) {
@@ -234,6 +238,9 @@ function loadTrackingScripts( callback ) {
 
 			// init Twitter's tracking global
 			window.twq( 'init', TRACKING_IDS.twitterPixelId );
+
+			// init Yandex counter
+			window.yaCounter45268389 = new window.Ya.Metrika( { id: 45268389 } );
 
 			// init Media Wallah tracking
 			initMediaWallah();
@@ -315,6 +322,9 @@ function retarget() {
 		qacct: TRACKING_IDS.quantcast,
 		event: 'refresh'
 	} );
+
+	// Yandex
+	window.yaCounter45268389.hit( document.location.href );
 
 	// One by AOL
 	new Image().src = ONE_BY_AOL_AUDIENCE_BUILDING_PIXEL_URL;
@@ -496,19 +506,6 @@ function recordProduct( product, orderId ) {
 			}
 		);
 
-		// Bing
-		if ( isSupportedCurrency( product.currency ) ) {
-			const bingParams = {
-				ec: 'purchase',
-				gv: costUSD
-			};
-			if ( isJetpackPlan ) {
-				// `el` must be included only for jetpack plans
-				bingParams.el = 'jetpack';
-			}
-			window.uetq.push( bingParams );
-		}
-
 		// Google AdWords
 		if ( window.google_trackConversion ) {
 			window.google_trackConversion( {
@@ -537,7 +534,26 @@ function recordProduct( product, orderId ) {
 			currency: product.currency
 		} );
 
+		// Yandex Goal
+		window.yaCounter45268389.reachGoal( 'ProductPurchase', {
+			order_id: orderId,
+			product_slug: product.product_slug,
+			order_price: product.cost,
+			currency: product.currency
+		} );
+
 		if ( isSupportedCurrency( product.currency ) ) {
+			// Bing
+			const bingParams = {
+				ec: 'purchase',
+				gv: costUSD
+			};
+			if ( isJetpackPlan ) {
+				// `el` must be included only for jetpack plans
+				bingParams.el = 'jetpack';
+			}
+			window.uetq.push( bingParams );
+
 			// Quantcast
 			// Note that all properties have to be strings or they won't get tracked
 			window._qevents.push( {


### PR DESCRIPTION
Adds Yandex tracking code for conversion tracking and retargeting.

## Testing

**Setup**

- Edit `/config/development.json` and set `"ad-tracking": true`.
- Restart Calypso

**Check Page View Events**

- In Chrome's network tab filter by 45268389
- For each page visited in Calypso you should see a https://mc.yandex.ru/watch/45268389 event being fired in the Network panel with a `page-url` parameter corresponding to the current page.

![yandex-page-view](https://user-images.githubusercontent.com/10284338/29122879-1e53c102-7d14-11e7-9bbf-86a87de3c9e5.png)

**Conversion Tracking**

- While keeping the Network tab open (you may want to check on the "Preserve log" option) make a purchase like upgrading a plan on a site, you can use your free credits.

- Once you're in the "thank you" page, filter the Network panel by "ProductPurchase".

- You should see an entry similar to:

![yandex-conversion](https://user-images.githubusercontent.com/10284338/29124458-41368ea2-7d19-11e7-97fc-0b43caeba110.png)

Note that the payload when decoded with `decodeURIComponent()` contains info similar to `site-info={"order_id":"24827349","product_slug":"value_bundle","order_price":85,"currency":"GBP"}`.

Thank you!
