### PR TITLE
Reader: add ReaderPopover component

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -165,6 +165,7 @@
 @import 'components/rating/style';
 @import 'components/reader-main/style';
 @import 'components/reader-infinite-stream/style';
+@import 'components/reader-popover/style';
 @import 'components/ribbon/style';
 @import 'components/screen-reader-text/style';
 @import 'components/search/style';

--- a/client/blocks/reader-email-settings/index.jsx
+++ b/client/blocks/reader-email-settings/index.jsx
@@ -11,7 +11,7 @@ import { find, get } from 'lodash';
  */
 import { localize } from 'i18n-calypso';
 import Gridicon from 'gridicons';
-import Popover from 'components/popover/index';
+import ReaderPopover from 'components/reader-popover';
 import SegmentedControl from 'components/segmented-control';
 import ControlItem from 'components/segmented-control/item';
 import FormToggle from 'components/forms/form-toggle';
@@ -98,49 +98,45 @@ class ReaderEmailSettings extends Component {
 					</span>
 				</span>
 
-				<Popover
+				<ReaderPopover
 					onClose={ this.closePopover }
 					isVisible={ this.state.showPopover }
 					context={ this.iconRef }
 					ignoreContext={ this.spanRef }
 					position={ 'bottom left' }
 					className="reader-email-settings__popout"
+					popoverTitle={ translate( 'Email me' ) }
 				>
-					<div className="reader-email-settings__popout-wrapper">
-						<h3 className="reader-email-settings__popout-header">
-							{ translate( 'Email me' ) }
-						</h3>
-						<div className="reader-email-settings__popout-toggle">
-							{ translate( 'New posts' ) }
-							<FormToggle onChange={ this.toggleNewPostEmail } checked={ notifyOnNewPosts } />
-						</div>
-						{ notifyOnNewPosts &&
-							<SegmentedControl>
-								<ControlItem
-									selected={ this.state.selected === 'instantly' }
-									onClick={ this.setSelected( 'instantly' ) }
-								>
-									{ translate( 'Instantly' ) }
-								</ControlItem>
-								<ControlItem
-									selected={ this.state.selected === 'daily' }
-									onClick={ this.setSelected( 'daily' ) }
-								>
-									{ translate( 'Daily' ) }
-								</ControlItem>
-								<ControlItem
-									selected={ this.state.selected === 'weekly' }
-									onClick={ this.setSelected( 'weekly' ) }
-								>
-									{ translate( 'Weekly' ) }
-								</ControlItem>
-							</SegmentedControl> }
-						<div className="reader-email-settings__popout-toggle">
-							{ translate( 'New comments' ) }
-							<FormToggle onChange={ this.toggleNewCommentEmail } checked={ notifyOnNewComments } />
-						</div>
+					<div className="reader-email-settings__popout-toggle">
+						{ translate( 'New posts' ) }
+						<FormToggle onChange={ this.toggleNewPostEmail } checked={ notifyOnNewPosts } />
 					</div>
-				</Popover>
+					{ notifyOnNewPosts &&
+						<SegmentedControl>
+							<ControlItem
+								selected={ this.state.selected === 'instantly' }
+								onClick={ this.setSelected( 'instantly' ) }
+							>
+								{ translate( 'Instantly' ) }
+							</ControlItem>
+							<ControlItem
+								selected={ this.state.selected === 'daily' }
+								onClick={ this.setSelected( 'daily' ) }
+							>
+								{ translate( 'Daily' ) }
+							</ControlItem>
+							<ControlItem
+								selected={ this.state.selected === 'weekly' }
+								onClick={ this.setSelected( 'weekly' ) }
+							>
+								{ translate( 'Weekly' ) }
+							</ControlItem>
+						</SegmentedControl> }
+					<div className="reader-email-settings__popout-toggle">
+						{ translate( 'New comments' ) }
+						<FormToggle onChange={ this.toggleNewCommentEmail } checked={ notifyOnNewComments } />
+					</div>
+				</ReaderPopover>
 			</div>
 		);
 	}

--- a/client/blocks/reader-email-settings/style.scss
+++ b/client/blocks/reader-email-settings/style.scss
@@ -14,40 +14,7 @@
 	}
 }
 
-.reader-email-settings__popout.popover .popover__inner {
-	background-color: $gray-light;
-	border-color: lighten( $gray, 20% );
-}
-
-// Popover arrows
-.reader-email-settings__popout.popover.is-bottom-left .popover__arrow::before,
-.reader-email-settings__popout.popover.is-top-left .popover__arrow::before {
-	border: 10px solid $gray-light;
-	content: " ";
-	position: absolute;
-	left: 50%;
-	margin-left: -10px;
-	border-left-color: transparent;
-	border-right-color: transparent;
-}
-
-.reader-email-settings__popout.popover.is-bottom-left .popover__arrow::before {
-	top: 2px;
-	border-bottom-style: solid;
-	border-top: none;
-}
-
-.reader-email-settings__popout.popover.is-top-left .popover__arrow::before {
-	bottom: 2px;
-    border-top-style: solid;
-    border-bottom: none;
-}
-
-.reader-email-settings__popout-wrapper {
-	display: flex;
-	flex-direction: column;
-	min-width: 250px;
-
+.reader-popover__wrapper {
 	.segmented-control {
 		background: inherit;
 		padding: 0 12px 0 16px;
@@ -56,15 +23,6 @@
 	.segmented-control__link {
 		background: $white;
 	}
-}
-
-.reader-email-settings__popout-header {
-	border-bottom: 1px solid lighten( $gray, 20% );
-	font-size: 14px;
-	display: flex;
-	justify-content: flex-start;
-	color: $gray-dark;
-	padding: 10px 0 10px 15px;
 }
 
 .reader-email-settings__popout-toggle {

--- a/client/blocks/reader-email-settings/style.scss
+++ b/client/blocks/reader-email-settings/style.scss
@@ -7,6 +7,7 @@
 }
 
 .reader-email-settings__button-label {
+	font-size: 14px;
 	margin-left: -2px;
 
 	@include breakpoint( "<660px" ) {

--- a/client/blocks/reader-feed-header/style.scss
+++ b/client/blocks/reader-feed-header/style.scss
@@ -220,7 +220,6 @@
 }
 
 .reader-feed-header__email-settings .reader-email-settings__button-label {
-	font-size: 14px;
 	display: inline;
 	position: relative;
 		top: -2px;

--- a/client/components/reader-popover/README.md
+++ b/client/components/reader-popover/README.md
@@ -1,4 +1,4 @@
-# RedirectWhenLoggedIn
+# ReaderPopover
 
 This is a wrapper around Popover used in Reader. It behaves identically to Popover, but has a slightly different look and feel and adds an optional title. To avoid style duplication, it's wrapped up in this component.
 

--- a/client/components/reader-popover/README.md
+++ b/client/components/reader-popover/README.md
@@ -1,0 +1,13 @@
+# RedirectWhenLoggedIn
+
+This is a wrapper around Popover used in Reader. It behaves identically to Popover, but has a slightly different look and feel and adds an optional title. To avoid style duplication, it's wrapped up in this component.
+
+## Usage
+
+See components/popover/README.md.
+
+## Additional props
+
+### `popoverTitle`
+
+Optional. Shown as a title in the header of the popover.

--- a/client/components/reader-popover/index.jsx
+++ b/client/components/reader-popover/index.jsx
@@ -1,0 +1,30 @@
+/** @format */
+/**
+ * External Dependencies
+ */
+import React from 'react';
+import classnames from 'classnames';
+import { omit } from 'lodash';
+
+/**
+ * External Dependencies
+ */
+import Popover from 'components/popover';
+
+const ReaderPopover = props => {
+	const classes = classnames( 'reader-popover', props.className );
+	const popoverProps = omit( props, 'className' );
+	return (
+		<Popover className={ classes } { ...popoverProps }>
+			<div className="reader-popover__wrapper">
+				{ props.popoverTitle &&
+					<h3 className="reader-popover__header">
+						{ props.popoverTitle }
+					</h3> }
+				{ props.children }
+			</div>
+		</Popover>
+	);
+};
+
+export default ReaderPopover;

--- a/client/components/reader-popover/style.scss
+++ b/client/components/reader-popover/style.scss
@@ -5,7 +5,9 @@
 
 // Popover arrows
 .reader-popover.popover.is-bottom-left .popover__arrow,
-.reader-popover.popover.is-top-left .popover__arrow {
+.reader-popover.popover.is-bottom-right .popover__arrow,
+.reader-popover.popover.is-top-left .popover__arrow,
+.reader-popover.popover.is-top-right .popover__arrow {
 
 	&::before {
 		border: 10px solid $gray-light;
@@ -18,7 +20,8 @@
 	}
 }
 
-.reader-popover.popover.is-bottom-left .popover__arrow {
+.reader-popover.popover.is-bottom-left .popover__arrow,
+.reader-popover.popover.is-bottom-right .popover__arrow {
 
 	&::before {
 		top: 2px;
@@ -27,7 +30,8 @@
 	}
 }
 
-.reader-popover.popover.is-top-left .popover__arrow {
+.reader-popover.popover.is-top-left .popover__arrow,
+.reader-popover.popover.is-top-right .popover__arrow {
 
 	&::before {
 		bottom: 2px;

--- a/client/components/reader-popover/style.scss
+++ b/client/components/reader-popover/style.scss
@@ -4,27 +4,36 @@
 }
 
 // Popover arrows
-.reader-popover.popover.is-bottom-left .popover__arrow::before,
-.reader-popover.popover.is-top-left .popover__arrow::before {
-	border: 10px solid $gray-light;
-	content: " ";
-	position: absolute;
-	left: 50%;
-	margin-left: -10px;
-	border-left-color: transparent;
-	border-right-color: transparent;
+.reader-popover.popover.is-bottom-left .popover__arrow,
+.reader-popover.popover.is-top-left .popover__arrow {
+
+	&::before {
+		border: 10px solid $gray-light;
+		border-left-color: transparent;
+		border-right-color: transparent;
+		content: " ";
+		margin-left: -10px;
+		position: absolute;
+			left: 50%;
+	}
 }
 
-.reader-popover.popover.is-bottom-left .popover__arrow::before {
-	top: 2px;
-	border-bottom-style: solid;
-	border-top: none;
+.reader-popover.popover.is-bottom-left .popover__arrow {
+
+	&::before {
+		top: 2px;
+		border-bottom-style: solid;
+		border-top: none;
+	}
 }
 
-.reader-popover.popover.is-top-left .popover__arrow::before {
-	bottom: 2px;
-    border-top-style: solid;
-    border-bottom: none;
+.reader-popover.popover.is-top-left .popover__arrow {
+
+	&::before {
+		bottom: 2px;
+		border-bottom: none;
+		border-top-style: solid;
+	}
 }
 
 .reader-popover__wrapper {
@@ -35,9 +44,9 @@
 
 .reader-popover__header {
 	border-bottom: 1px solid lighten( $gray, 20% );
-	font-size: 14px;
-	display: flex;
-	justify-content: flex-start;
 	color: $gray-dark;
+	display: flex;
+	font-size: 14px;
+	justify-content: flex-start;
 	padding: 10px 0 10px 15px;
 }

--- a/client/components/reader-popover/style.scss
+++ b/client/components/reader-popover/style.scss
@@ -1,0 +1,43 @@
+.reader-popover.popover .popover__inner {
+	background-color: $gray-light;
+	border-color: lighten( $gray, 20% );
+}
+
+// Popover arrows
+.reader-popover.popover.is-bottom-left .popover__arrow::before,
+.reader-popover.popover.is-top-left .popover__arrow::before {
+	border: 10px solid $gray-light;
+	content: " ";
+	position: absolute;
+	left: 50%;
+	margin-left: -10px;
+	border-left-color: transparent;
+	border-right-color: transparent;
+}
+
+.reader-popover.popover.is-bottom-left .popover__arrow::before {
+	top: 2px;
+	border-bottom-style: solid;
+	border-top: none;
+}
+
+.reader-popover.popover.is-top-left .popover__arrow::before {
+	bottom: 2px;
+    border-top-style: solid;
+    border-bottom: none;
+}
+
+.reader-popover__wrapper {
+	display: flex;
+	flex-direction: column;
+	min-width: 250px;
+}
+
+.reader-popover__header {
+	border-bottom: 1px solid lighten( $gray, 20% );
+	font-size: 14px;
+	display: flex;
+	justify-content: flex-start;
+	color: $gray-dark;
+	padding: 10px 0 10px 15px;
+}


### PR DESCRIPTION
In Reader, we use a different style for the `Popover` component: a darker background and a header with title:

<img width="363" alt="screen shot 2017-08-07 at 17 53 48" src="https://user-images.githubusercontent.com/17325/29034730-8807ce9e-7b99-11e7-97cb-ea5f7ecf7e00.png">

It's currently used in the Email Settings popover, but as we're soon going to use it in the Share popover as well, I thought it was sensible to extract it and not duplicate the styles.

### To test

Check the EmailSettingsPopover component:

http://calypso.localhost:3000/devdocs/blocks/reader-email-settings

...and also in its usual homes on the site stream (email settings in header):

http://calypso.localhost:3000/read/feeds/49993097

...and Manage Following (email settings for existing subscriptions):

http://calypso.localhost:3000/following/manage

Make sure there are no styling regressions in the popover compared to the same pages on production.
