### PR TITLE
Comments: Remove unnecessary author preview transition

### DIFF
--- a/client/blocks/comment-detail/style.scss
+++ b/client/blocks/comment-detail/style.scss
@@ -332,7 +332,6 @@
 	display: flex;
 	flex-flow: row nowrap;
 	padding: 0 16px;
-	transition: padding-bottom .3s linear;
 
 	.gravatar {
 		height: 32px;


### PR DESCRIPTION
Remove a tiny transition occurring when the comment placeholders are replaced by the real components.

| Before | After |
| --- | --- |
| ![before](https://user-images.githubusercontent.com/2070010/29038492-c40fd7a0-7b9f-11e7-92e7-a6a3f717f44f.gif) | ![after](https://user-images.githubusercontent.com/2070010/29038503-cdd5e0ae-7b9f-11e7-8eb6-a5c8732f85dd.gif) |

(please disregard the flickering caused by the gif capture app)