### PR TITLE
Comments: Limit Comment Management to Admin and Editor roles

### DIFF
--- a/client/my-sites/comments/controller.js
+++ b/client/my-sites/comments/controller.js
@@ -55,7 +55,8 @@ export const comments = function( context ) {
 	const state = context.store.getState();
 	const siteId = getSelectedSiteId( state );
 
-	if ( ! canCurrentUser( state, siteId, 'moderate_comments' ) ) {
+	// TODO: replace with `moderate_comments` as soon as it's available from the endpoint
+	if ( ! canCurrentUser( state, siteId, 'edit_others_posts' ) ) {
 		return page.redirect( '/stats' );
 	}
 

--- a/client/my-sites/comments/controller.js
+++ b/client/my-sites/comments/controller.js
@@ -14,6 +14,8 @@ import config from 'config';
 import route from 'lib/route';
 import { removeNotice } from 'state/notices/actions';
 import { getNotices } from 'state/notices/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { canCurrentUser } from 'state/selectors';
 
 const VALID_STATUSES = [ 'pending', 'approved', 'spam', 'trash' ];
 if ( config.isEnabled( 'comments/management/all-list' ) ) {
@@ -50,6 +52,13 @@ export const redirect = function( context, next ) {
 };
 
 export const comments = function( context ) {
+	const state = context.store.getState();
+	const siteId = getSelectedSiteId( state );
+
+	if ( ! canCurrentUser( state, siteId, 'moderate_comments' ) ) {
+		return page.redirect( '/stats' );
+	}
+
 	const { status } = context.params;
 	const siteFragment = route.getSiteFragment( context.path );
 	renderWithReduxStore(

--- a/client/my-sites/sidebar/manage-menu.jsx
+++ b/client/my-sites/sidebar/manage-menu.jsx
@@ -106,7 +106,7 @@ class ManageMenu extends PureComponent {
 			items.push( {
 				name: 'comments',
 				label: this.props.translate( 'Comments' ),
-				capability: 'edit_posts',
+				capability: 'moderate_comments',
 				queryable: true,
 				config: 'comments/management',
 				link: '/comments',

--- a/client/my-sites/sidebar/manage-menu.jsx
+++ b/client/my-sites/sidebar/manage-menu.jsx
@@ -106,7 +106,8 @@ class ManageMenu extends PureComponent {
 			items.push( {
 				name: 'comments',
 				label: this.props.translate( 'Comments' ),
-				capability: 'moderate_comments',
+				// TODO: replace with `moderate_comments` as soon as it's available from the endpoint
+				capability: 'edit_others_posts',
 				queryable: true,
 				config: 'comments/management',
 				link: '/comments',


### PR DESCRIPTION
Fix #16925 

Limit the access to the Comment Management - by redirecting to the stats and hiding the sidebar item - to only Admin and Editor users.