### PR TITLE
Reader: Handle errors in the teams reducer

### DIFF
--- a/client/state/reader/teams/reducer.js
+++ b/client/state/reader/teams/reducer.js
@@ -1,5 +1,10 @@
 /** @format */
 /**
+ * External Dependencies
+ */
+import { get } from 'lodash';
+
+/**
  * Internal dependencies
  */
 import { READER_TEAMS_REQUEST, READER_TEAMS_RECEIVE } from 'state/action-types';
@@ -9,7 +14,12 @@ import { itemsSchema } from './schema';
 export const items = createReducer(
 	[],
 	{
-		[ READER_TEAMS_RECEIVE ]: ( state, action ) => action.payload.teams,
+		[ READER_TEAMS_RECEIVE ]: ( state, action ) => {
+			if ( action.error ) {
+				return state;
+			}
+			return get( action, [ 'payload', 'teams' ], state );
+		},
 	},
 	itemsSchema
 );

--- a/client/state/reader/teams/test/reducer.js
+++ b/client/state/reader/teams/test/reducer.js
@@ -3,6 +3,7 @@
  * External dependencies
  */
 import { assert, expect } from 'chai';
+import deepfreeze from 'deep-freeze';
 
 /**
  * Internal dependencies
@@ -51,6 +52,17 @@ describe( 'reducer', () => {
 					}
 				)
 			).to.deep.equal( [ TEAM1, TEAM2 ] );
+		} );
+
+		it( 'should ignore errors', () => {
+			const initialState = deepfreeze( {} );
+			expect(
+				items( initialState, {
+					type: READER_TEAMS_RECEIVE,
+					payload: { some: 'error' },
+					error: true,
+				} )
+			).to.equal( initialState );
 		} );
 
 		it( 'deserialize: should succeed with good data', () => {


### PR DESCRIPTION
We were blindly trying to access 'teams' on the payload, even when we encountered an error or the payload was not an object.