### PR TITLE
Reader: add missing spaces into strings

### DIFF
--- a/client/reader/post-excerpt-link/index.jsx
+++ b/client/reader/post-excerpt-link/index.jsx
@@ -72,6 +72,7 @@ class PostExcerptLink extends React.Component {
 				<p className="post-excerpt-link__helper">
 					{ this.props.translate(
 						'The owner of this site only allows us to show a brief summary of their content.' +
+							' ' +
 							"To view the full post, you'll have to visit their site."
 					) }
 				</p>

--- a/client/reader/stream/post-unavailable.jsx
+++ b/client/reader/stream/post-unavailable.jsx
@@ -1,5 +1,4 @@
 /** @format */
-/** @format */
 /**
  * External dependencies
  */
@@ -17,6 +16,7 @@ class PostUnavailable extends React.PureComponent {
 		this.errors = {
 			unauthorized: this.props.translate(
 				'This is a post on a private site that you’re following, but not currently a member of.' +
+					' ' +
 					'Please request membership to display these posts in Reader.'
 			),
 			default: this.props.translate( 'An error occurred loading this post.' ),


### PR DESCRIPTION
bug introduced here: https://github.com/Automattic/wp-calypso/commit/2082817a62c6e52f314e2f183bb247de68d84f2e