### PR TITLE
Revert "Plugins: Remove auto updateing of plugins."

### DIFF
--- a/client/lib/plugins/actions.js
+++ b/client/lib/plugins/actions.js
@@ -127,6 +127,52 @@ const recordEvent = ( eventType, plugin, site, error ) => {
 	analytics.mc.bumpStat( eventType, 'succeeded' );
 };
 
+// Updates a plugin without launching the events that notifies
+// the user that an update is going on.
+// Used for updating plugins automatically on the background.
+const autoupdatePlugin = ( site, plugin ) => {
+	Dispatcher.handleViewAction( {
+		type: 'AUTOUPDATE_PLUGIN',
+		action: 'AUTOUPDATE_PLUGIN',
+		site: site,
+		plugin: plugin
+	} );
+
+	analytics.tracks.recordEvent( 'calypso_plugin_update_automatic', {
+		site: site.ID,
+		plugin: plugin.slug
+	} );
+
+	analytics.mc.bumpStat( 'calypso_plugin_update_automatic' );
+
+	const boundEnableAU = getPluginBoundMethod( site, plugin.id, 'updateVersion' );
+	queueSitePluginAction( boundEnableAU, site.ID, plugin.id, ( error, data ) => {
+		Dispatcher.handleServerAction( {
+			type: 'RECEIVE_AUTOUPDATE_PLUGIN',
+			action: 'AUTOUPDATE_PLUGIN',
+			site: site,
+			plugin: plugin,
+			data: data,
+			error: error
+		} );
+		recordEvent( 'calypso_plugin_updated_automatic', plugin, site, error );
+	} );
+};
+
+const processAutoupdates = ( site, plugins ) => {
+	if ( site.canAutoupdateFiles &&
+		site.jetpack &&
+		site.canManage() &&
+		utils.userCan( 'manage_options', site )
+	) {
+		plugins.forEach( plugin => {
+			if ( plugin.update && plugin.autoupdate ) {
+				autoupdatePlugin( site, plugin );
+			}
+		} );
+	}
+};
+
 const PluginsActions = {
 	removePluginsNotices: logs => {
 		Dispatcher.handleViewAction( {
@@ -156,6 +202,9 @@ const PluginsActions = {
 				data: data,
 				error: error
 			} );
+			if ( ! error ) {
+				processAutoupdates( site, data.plugins );
+			}
 		};
 
 		if ( site.jetpack ) {


### PR DESCRIPTION
This reverts commit 05b4101063911080f4680dbe78b93dbfe6347489.

We should never show the user that they are updates if they marked a plugin as it should be autoupdated. 

Previous PR https://github.com/Automattic/wp-calypso/pull/16771

To test: 
- set a plugin to be autoupdated. 
- Update the version number. 
- Go to Plugins/example.com and notice that the plugin doesn't need updating.


