### PR TITLE
Simple Payments: fix special character rendering

### DIFF
--- a/client/lib/simple-payments/utils.js
+++ b/client/lib/simple-payments/utils.js
@@ -5,13 +5,3 @@ import { SIMPLE_PAYMENTS_PRODUCT_POST_TYPE } from 'lib/simple-payments/constants
 
 export const isValidSimplePaymentsProduct = product =>
 	product.type === SIMPLE_PAYMENTS_PRODUCT_POST_TYPE && product.status === 'publish';
-
-/**
- * Replace any encoded html entities ( i.e. '&#8220; or &amp; ) with their corresponding unicode value
- * @param { String } productAttribute a product attribute
- * @returns { String } The product attribute with any html entities decoded.
- */
-export const decodeProductAttribute = productAttribute =>
-	productAttribute.replace( /(?:&#(\d+);)|(&amp;)/g, ( match, charCode, amp ) =>
-		amp ? '\u0026' : String.fromCharCode( charCode )
-	);

--- a/client/lib/simple-payments/utils.js
+++ b/client/lib/simple-payments/utils.js
@@ -6,6 +6,11 @@ import { SIMPLE_PAYMENTS_PRODUCT_POST_TYPE } from 'lib/simple-payments/constants
 export const isValidSimplePaymentsProduct = product =>
 	product.type === SIMPLE_PAYMENTS_PRODUCT_POST_TYPE && product.status === 'publish';
 
+/**
+ * Replace any encoded html entities ( i.e. '&#8220; or &amp; ) with their corresponding unicode value
+ * @param { String } productAttribute a product attribute
+ * @returns { String } The product attribute with any html entities decoded.
+ */
 export const decodeProductAttribute = productAttribute =>
 	productAttribute.replace( /(?:&#(\d+);)|(&amp;)/g, ( match, charCode, amp ) =>
 		amp ? '\u0026' : String.fromCharCode( charCode )

--- a/client/lib/simple-payments/utils.js
+++ b/client/lib/simple-payments/utils.js
@@ -5,3 +5,8 @@ import { SIMPLE_PAYMENTS_PRODUCT_POST_TYPE } from 'lib/simple-payments/constants
 
 export const isValidSimplePaymentsProduct = product =>
 	product.type === SIMPLE_PAYMENTS_PRODUCT_POST_TYPE && product.status === 'publish';
+
+export const decodeProductAttribute = productAttribute =>
+	productAttribute.replace( /(?:&#(\d+);)|(&amp;)/g, ( match, charCode, amp ) =>
+		amp ? '\u0026' : String.fromCharCode( charCode )
+	);

--- a/client/state/data-layer/wpcom/sites/simple-payments/index.js
+++ b/client/state/data-layer/wpcom/sites/simple-payments/index.js
@@ -23,7 +23,10 @@ import { metaKeyToSchemaKeyMap, metadataSchema } from 'state/simple-payments/pro
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { SIMPLE_PAYMENTS_PRODUCT_POST_TYPE } from 'lib/simple-payments/constants';
-import { isValidSimplePaymentsProduct } from 'lib/simple-payments/utils';
+import {
+	isValidSimplePaymentsProduct,
+	decodeProductAttribute,
+} from 'lib/simple-payments/utils';
 import formatCurrency from 'lib/format-currency';
 import { getFeaturedImageId } from 'lib/posts/utils-ssr-ready';
 
@@ -64,8 +67,8 @@ export function customPostToProduct( customPost ) {
 
 	return {
 		ID: customPost.ID,
-		description: customPost.content,
-		title: customPost.title,
+		description: decodeProductAttribute( customPost.content ),
+		title: decodeProductAttribute( customPost.title ),
 		featuredImageId: getFeaturedImageId( customPost ),
 		...metadataAttributes,
 	};

--- a/client/state/data-layer/wpcom/sites/simple-payments/index.js
+++ b/client/state/data-layer/wpcom/sites/simple-payments/index.js
@@ -23,12 +23,10 @@ import { metaKeyToSchemaKeyMap, metadataSchema } from 'state/simple-payments/pro
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { SIMPLE_PAYMENTS_PRODUCT_POST_TYPE } from 'lib/simple-payments/constants';
-import {
-	isValidSimplePaymentsProduct,
-	decodeProductAttribute,
-} from 'lib/simple-payments/utils';
+import { isValidSimplePaymentsProduct } from 'lib/simple-payments/utils';
 import formatCurrency from 'lib/format-currency';
 import { getFeaturedImageId } from 'lib/posts/utils-ssr-ready';
+import { decodeEntities } from 'lib/formatting';
 
 /**
  * Convert custom post metadata array to product attributes
@@ -67,8 +65,8 @@ export function customPostToProduct( customPost ) {
 
 	return {
 		ID: customPost.ID,
-		description: decodeProductAttribute( customPost.content ),
-		title: decodeProductAttribute( customPost.title ),
+		description: decodeEntities( customPost.content ),
+		title: decodeEntities( customPost.title ),
 		featuredImageId: getFeaturedImageId( customPost ),
 		...metadataAttributes,
 	};

--- a/client/state/data-layer/wpcom/sites/simple-payments/test/index.js
+++ b/client/state/data-layer/wpcom/sites/simple-payments/test/index.js
@@ -39,6 +39,25 @@ describe( '#simplePayments', () => {
 		expect( convertedProduct ).to.deep.equal( product );
 	} );
 
+	it( 'should decode special characters when converting to product', () => {
+		const customPost = {
+			ID: 2,
+			title: '\u201d\u221e\u201d and &#8216;so much more&#8217;\u2122 \u2026',
+			content: 'Accepting $, \u20bf, &amp; \u2603',
+			featured_image: 2,
+			metadata: [
+				{ key: 'spay_price', value: 100 },
+				{ key: 'spay_currency', value: 'EUR' },
+				{ key: 'spay_multiple', value: '0' },
+				{ key: 'spay_bogus', value: 'ignore' },
+			],
+		};
+		const convertedProduct = customPostToProduct( customPost );
+
+		expect( convertedProduct.title ).to.equal( '”∞” and ‘so much more’™ …' );
+		expect( convertedProduct.description ).to.equal( 'Accepting $, ₿, & ☃' );
+	} );
+
 	it( 'should convert product to customPost', () => {
 		const product = {
 			ID: 1,


### PR DESCRIPTION
This fixes rendering unicode characters in product attributes when displaying the product in the button edit modal or the post editor.

**Screens**
Before:
<img width="673" alt="screen shot 2017-08-07 at 4 21 34 pm" src="https://user-images.githubusercontent.com/744755/29049942-b4a0ffe0-7b8d-11e7-9625-c9a94f49aa44.png">

After:
<img width="662" alt="screen shot 2017-08-07 at 4 23 55 pm" src="https://user-images.githubusercontent.com/744755/29049944-b8dfa2e6-7b8d-11e7-815f-cccb47da3b5a.png">

**Testing**
Acceptance:
- Use special characters for the payment button title or description, for example try `"`, `'`, `&` or `…`.
- Save and insert the button.
- The button should display special characters as expected.
- Edit the button.
- The edit modal form should display the special characters as expected.

Unit:
running `npm run test-client client/state/data-layer/wpcom/sites/simple-payments/test/` should pass