### PR TITLE
Extensions: Zoninator - Link add new zone UI to state

### DIFF
--- a/client/extensions/zoninator/components/forms/zone-details-form/index.jsx
+++ b/client/extensions/zoninator/components/forms/zone-details-form/index.jsx
@@ -1,0 +1,71 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import PropTypes from 'prop-types';
+import { reduxForm } from 'redux-form';
+import { translate } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import CompactCard from 'components/card';
+import FormButton from 'components/forms/form-button';
+import FormTextInput from 'components/forms/form-text-input';
+import FormTextarea from 'components/forms/form-textarea';
+import ReduxFormFieldset from 'components/redux-forms/redux-form-fieldset';
+import SectionHeader from 'components/section-header';
+
+const form = 'extensions.zoninator.zoneDetails';
+
+const ZoneDetailsForm = ( {
+	handleSubmit,
+	label,
+	onSubmit,
+	submitting,
+} ) => {
+	const save = data => onSubmit( form, data );
+
+	return (
+		<form onSubmit={ handleSubmit( save ) }>
+			<SectionHeader label={ label }>
+				<FormButton
+					compact
+					disabled={ submitting }
+					isSubmitting={ submitting }>
+					{ translate( 'Save' ) }
+				</FormButton>
+			</SectionHeader>
+			<CompactCard>
+				<ReduxFormFieldset
+					name="name"
+					label={ translate( 'Zone name' ) }
+					component={ FormTextInput } />
+				<ReduxFormFieldset
+					name="description"
+					label={ translate( 'Zone description' ) }
+					component={ FormTextarea } />
+			</CompactCard>
+		</form>
+	);
+};
+
+ZoneDetailsForm.propTypes = {
+	label: PropTypes.string.isRequired,
+	onSubmit: PropTypes.func.isRequired,
+};
+
+const createReduxForm = reduxForm( {
+	form,
+	validate: ( data ) => {
+		const errors = {};
+
+		if ( ! data.name ) {
+			errors.name = translate( 'Zone name cannot be empty.' );
+		}
+
+		return errors;
+	},
+} );
+
+export default createReduxForm( ZoneDetailsForm );

--- a/client/extensions/zoninator/components/forms/zone-details-form/index.jsx
+++ b/client/extensions/zoninator/components/forms/zone-details-form/index.jsx
@@ -1,10 +1,11 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { reduxForm } from 'redux-form';
-import { translate } from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
+import { flowRight } from 'lodash';
 
 /**
  * Internal dependencies
@@ -18,46 +19,54 @@ import SectionHeader from 'components/section-header';
 
 const form = 'extensions.zoninator.zoneDetails';
 
-const ZoneDetailsForm = ( {
-	handleSubmit,
-	label,
-	onSubmit,
-	submitting,
-} ) => {
-	const save = data => onSubmit( form, data );
+class ZoneDetailsForm extends PureComponent {
+	static propTypes = {
+		handleSubmit: PropTypes.func.isRequired,
+		label: PropTypes.string.isRequired,
+		onSubmit: PropTypes.func.isRequired,
+		siteId: PropTypes.number.isRequired,
+		submitting: PropTypes.bool.isRequired,
+		translate: PropTypes.func.isRequired,
+	}
 
-	return (
-		<form onSubmit={ handleSubmit( save ) }>
-			<SectionHeader label={ label }>
-				<FormButton
-					compact
-					disabled={ submitting }
-					isSubmitting={ submitting }>
-					{ translate( 'Save' ) }
-				</FormButton>
-			</SectionHeader>
-			<CompactCard>
-				<ReduxFormFieldset
-					name="name"
-					label={ translate( 'Zone name' ) }
-					component={ FormTextInput } />
-				<ReduxFormFieldset
-					name="description"
-					label={ translate( 'Zone description' ) }
-					component={ FormTextarea } />
-			</CompactCard>
-		</form>
-	);
-};
+	save = data => this.props.onSubmit( this.props.siteId, form, data );
 
-ZoneDetailsForm.propTypes = {
-	label: PropTypes.string.isRequired,
-	onSubmit: PropTypes.func.isRequired,
-};
+	render() {
+		const {
+			handleSubmit,
+			label,
+			submitting,
+			translate,
+		} = this.props;
+
+		return (
+			<form onSubmit={ handleSubmit( this.save ) }>
+				<SectionHeader label={ label }>
+					<FormButton
+						compact
+						disabled={ submitting }
+						isSubmitting={ submitting }>
+						{ translate( 'Save' ) }
+					</FormButton>
+				</SectionHeader>
+				<CompactCard>
+					<ReduxFormFieldset
+						name="name"
+						label={ translate( 'Zone name' ) }
+						component={ FormTextInput } />
+					<ReduxFormFieldset
+						name="description"
+						label={ translate( 'Zone description' ) }
+						component={ FormTextarea } />
+				</CompactCard>
+			</form>
+		);
+	}
+}
 
 const createReduxForm = reduxForm( {
 	form,
-	validate: ( data ) => {
+	validate: ( data, { translate } ) => {
 		const errors = {};
 
 		if ( ! data.name ) {
@@ -68,4 +77,7 @@ const createReduxForm = reduxForm( {
 	},
 } );
 
-export default createReduxForm( ZoneDetailsForm );
+export default flowRight(
+	localize,
+	createReduxForm,
+)( ZoneDetailsForm );

--- a/client/extensions/zoninator/components/settings/zone-creator/index.jsx
+++ b/client/extensions/zoninator/components/settings/zone-creator/index.jsx
@@ -4,66 +4,50 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { reduxForm } from 'redux-form';
 import { localize } from 'i18n-calypso';
 import { flowRight } from 'lodash';
 
 /**
  * Internal dependencies
  */
-import CompactCard from 'components/card';
-import FormFieldset from 'components/forms/form-fieldset';
-import FormButton from 'components/forms/form-button';
-import FormLabel from 'components/forms/form-label';
 import HeaderCake from 'components/header-cake';
-import ReduxFormTextarea from 'components/redux-forms/redux-form-textarea';
-import ReduxFormTextInput from 'components/redux-forms/redux-form-text-input';
-import SectionHeader from 'components/section-header';
-import { getSelectedSiteSlug } from 'state/ui/selectors';
-import { settingsPath } from '../../../app/util';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
+import ZoneDetailsForm from '../../forms/zone-details-form';
+import { addZone } from '../../../state/zones/actions';
 
-const form = 'extensions.zoninator.newZone';
+const ZoneCreator = ( {
+	saveZone,
+	siteId,
+	siteSlug,
+	translate,
+} ) => {
+	const save = ( form, data ) => saveZone( siteId, form, data );
 
-const ZoneCreator = ( { siteSlug, translate } ) => (
-	<div>
-		<HeaderCake backHref={ `${ settingsPath }/${ siteSlug }` }>
-			{ translate( 'Add a zone' ) }
-		</HeaderCake>
+	return (
+		<div>
+			<HeaderCake backHref={ `/extensions/zoninator/${ siteSlug }` }>
+				{ translate( 'Add a zone' ) }
+			</HeaderCake>
 
-		<form>
-			<SectionHeader label={ translate( 'New zone' ) }>
-				<FormButton compact>{ translate( 'Save' ) }</FormButton>
-			</SectionHeader>
-			<CompactCard>
-				<FormFieldset>
-					<FormLabel htmlFor="zoneName">{ translate( 'Zone name' ) }</FormLabel>
-					<ReduxFormTextInput name="zoneName" />
-				</FormFieldset>
-
-				<FormFieldset>
-					<FormLabel htmlFor="zoneDescription">{ translate( 'Zone description' ) }</FormLabel>
-					<ReduxFormTextarea name="zoneDescription" />
-				</FormFieldset>
-			</CompactCard>
-		</form>
-	</div>
-);
+			<ZoneDetailsForm label={ translate( 'New zone' ) } onSubmit={ save } />
+		</div>
+	);
+};
 
 ZoneCreator.propTypes = {
+	siteId: PropTypes.number,
 	siteSlug: PropTypes.string,
 };
 
-const connectComponent = connect( state => ( {
-	siteSlug: getSelectedSiteSlug( state ),
-} ) );
-
-const createReduxForm = reduxForm( {
-	enableReinitialize: true,
-	form,
-} );
+const connectComponent = connect(
+	state => ( {
+		siteId: getSelectedSiteId( state ),
+		siteSlug: getSelectedSiteSlug( state ),
+	} ),
+	{ saveZone: addZone },
+);
 
 export default flowRight(
 	connectComponent,
 	localize,
-	createReduxForm,
 )( ZoneCreator );

--- a/client/extensions/zoninator/components/settings/zone-creator/index.jsx
+++ b/client/extensions/zoninator/components/settings/zone-creator/index.jsx
@@ -14,6 +14,7 @@ import HeaderCake from 'components/header-cake';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import ZoneDetailsForm from '../../forms/zone-details-form';
 import { addZone } from '../../../state/zones/actions';
+import { settingsPath } from '../../../app/util';
 
 const ZoneCreator = ( {
 	saveZone,
@@ -22,7 +23,7 @@ const ZoneCreator = ( {
 	translate,
 } ) => (
 	<div>
-		<HeaderCake backHref={ `/extensions/zoninator/${ siteSlug }` }>
+		<HeaderCake backHref={ `${ settingsPath }/${ siteSlug }` }>
 			{ translate( 'Add a zone' ) }
 		</HeaderCake>
 

--- a/client/extensions/zoninator/components/settings/zone-creator/index.jsx
+++ b/client/extensions/zoninator/components/settings/zone-creator/index.jsx
@@ -20,23 +20,21 @@ const ZoneCreator = ( {
 	siteId,
 	siteSlug,
 	translate,
-} ) => {
-	const save = ( form, data ) => saveZone( siteId, form, data );
+} ) => (
+	<div>
+		<HeaderCake backHref={ `/extensions/zoninator/${ siteSlug }` }>
+			{ translate( 'Add a zone' ) }
+		</HeaderCake>
 
-	return (
-		<div>
-			<HeaderCake backHref={ `/extensions/zoninator/${ siteSlug }` }>
-				{ translate( 'Add a zone' ) }
-			</HeaderCake>
-
-			<ZoneDetailsForm label={ translate( 'New zone' ) } onSubmit={ save } />
-		</div>
-	);
-};
+		<ZoneDetailsForm label={ translate( 'New zone' ) } siteId={ siteId } onSubmit={ saveZone } />
+	</div>
+);
 
 ZoneCreator.propTypes = {
 	siteId: PropTypes.number,
 	siteSlug: PropTypes.string,
+	saveZone: PropTypes.func.isRequired,
+	translate: PropTypes.func.isRequired,
 };
 
 const connectComponent = connect(

--- a/client/extensions/zoninator/state/data-layer/zones/index.js
+++ b/client/extensions/zoninator/state/data-layer/zones/index.js
@@ -60,8 +60,10 @@ export const createZone = ( { dispatch }, action ) => {
 };
 
 export const announceZoneSaved = ( dispatch, { form, siteId }, data ) => {
+	const zone = fromApi( data );
+
 	dispatch( stopSubmit( form ) );
-	dispatch( updateZone( siteId, fromApi( data ) ) );
+	dispatch( updateZone( siteId, zone.id, zone ) );
 	dispatch( successNotice(
 		translate( 'Zone saved!' ),
 		{ id: 'zoninator-zone-create' },

--- a/client/extensions/zoninator/state/data-layer/zones/test/index.js
+++ b/client/extensions/zoninator/state/data-layer/zones/test/index.js
@@ -42,6 +42,7 @@ const apiResponse = {
 };
 
 const zone = {
+	term_id: 43,
 	none: 'New zone',
 	description: 'A new zone',
 };
@@ -170,7 +171,7 @@ describe( '#announceZoneSaved()', () => {
 
 		announceZoneSaved( dispatch, action, zone );
 
-		expect( dispatch ).to.have.been.calledWith( updateZone( 123456, fromApi( zone ) ) );
+		expect( dispatch ).to.have.been.calledWith( updateZone( 123456, zone.term_id, fromApi( zone ) ) );
 	} );
 
 	it( 'should dispatch `successNotice`', () => {


### PR DESCRIPTION
This PR makes 'Add new zone' tab in the Zoninator extension functional.

# Testing

This PR requires the following development branch of the [plugin](https://github.com/Automattic/zoninator) to be checked out on the server: `update/create-zone`.

- Open zoninator settings and click new zone.
- Click `save` - an error should appear under the `name` input.
- Enter a name and a description and click `save` - the zone should be saved and the user redirected to the zones dashboard. A success notice should be visible.