### PR TITLE
Extensions: Zoninator - Move QueryZones to Settings

### DIFF
--- a/client/extensions/zoninator/components/settings/index.jsx
+++ b/client/extensions/zoninator/components/settings/index.jsx
@@ -2,26 +2,39 @@
  * External dependencies
  */
 import React from 'react';
+import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
+import { flowRight } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import DocumentHead from 'components/data/document-head';
 import Main from 'components/main';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import QueryZones from '../data/query-zones';
 
 const Settings = ( {
 	children,
-	translate
+	siteId,
+	translate,
 } ) => {
 	const mainClassName = 'zoninator__main';
 
 	return (
 		<Main className={ mainClassName }>
+			<QueryZones siteId={ siteId } />
 			<DocumentHead title={ translate( 'WP Zone Manager' ) } />
 			{ children }
 		</Main>
 	);
 };
 
-export default localize( Settings );
+const connectComponent = connect( state => ( {
+	siteId: getSelectedSiteId( state ),
+} ) );
+
+export default flowRight(
+	connectComponent,
+	localize,
+)( Settings );

--- a/client/extensions/zoninator/components/settings/zones-dashboard/index.jsx
+++ b/client/extensions/zoninator/components/settings/zones-dashboard/index.jsx
@@ -14,7 +14,6 @@ import Button from 'components/button';
 import HeaderCake from 'components/header-cake';
 import SectionHeader from 'components/section-header';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
-import QueryZones from '../../data/query-zones';
 import ZoneItem from './zone-item';
 import ZonePlaceholder from './zone-placeholder';
 import { getZones, isRequestingZones } from '../../../state/zones/selectors';
@@ -22,12 +21,10 @@ import { settingsPath } from '../../../app/util';
 
 const placeholderCount = 5;
 
-const ZonesDashboard = ( { isRequesting, siteId, siteSlug, translate, zones } ) => (
+const ZonesDashboard = ( { isRequesting, siteSlug, translate, zones } ) => (
 	<div>
-		<QueryZones siteId={ siteId } />
-
 		<HeaderCake backHref={ `/plugins/zoninator/${ siteSlug }` }>
-			{ translate( 'Zoninator Settings' ) }
+			Zoninator Settings
 		</HeaderCake>
 
 		<SectionHeader label={ translate( 'Zones' ) }>
@@ -56,7 +53,6 @@ const connectComponent = connect( state => {
 		zones: getZones( state, siteId ),
 		isRequesting: isRequestingZones( state, siteId ),
 		siteSlug: getSelectedSiteSlug( state ),
-		siteId,
 	};
 } );
 


### PR DESCRIPTION
This PR moves the `QueryZones` instance up from `ZonesDashboard` to its parent - `Settings`.  
This will trigger the query on every page of the extension and only once each time the extension is accessed which seems both more flexible and efficient as that data is necessary on all subpages of the extension.

This shouldn't affect any existing functionality.

# Testing

- Open Zoninator settings.
- Ensure the dashboard is populated with actual zones.