### PR TITLE
Components: support isValid/isError props for more form field types

### DIFF
--- a/assets/stylesheets/shared/_forms.scss
+++ b/assets/stylesheets/shared/_forms.scss
@@ -54,6 +54,40 @@
 			color: lighten( $gray, 10% );
 		}
 	}
+
+	&.is-valid {
+		border-color: $alert-green;
+	}
+
+	&.is-valid:hover {
+		border-color: darken( $alert-green, 10 );
+	}
+
+	&.is-error {
+		border-color: $alert-red;
+	}
+
+	&.is-error:hover {
+		border-color: darken( $alert-red, 10 );
+	}
+
+	&:focus {
+		&.is-valid {
+			box-shadow: 0 0 0 2px lighten( $alert-green, 35 );
+		}
+
+		&.is-valid:hover {
+			box-shadow: 0 0 0 2px lighten( $alert-green, 25 );
+		}
+
+		&.is-error {
+			box-shadow: 0 0 0 2px lighten( $alert-red, 35 );
+		}
+
+		&.is-error:hover {
+			box-shadow: 0 0 0 2px lighten( $alert-red, 25 );
+		}
+	}
 }
 
 %textarea {

--- a/client/components/forms/docs/example.jsx
+++ b/client/components/forms/docs/example.jsx
@@ -245,6 +245,18 @@ class FormFields extends React.PureComponent {
 					</FormFieldset>
 
 					<FormFieldset>
+						<FormLabel htmlFor="telInput_valid">Form Tel Input</FormLabel>
+						<FormTelInput name="telInput" id="telInput_valid" placeholder="Placeholder text..." isValid />
+						<FormInputValidation text="The phone number can be saved." />
+					</FormFieldset>
+
+					<FormFieldset>
+						<FormLabel htmlFor="telInput_error">Form Tel Input</FormLabel>
+						<FormTelInput name="telInput" id="telInput_error" placeholder="Placeholder text..." isError />
+						<FormInputValidation isError text="The phone number is invalid." />
+					</FormFieldset>
+
+					<FormFieldset>
 						<FormLabel>Form Phone Input</FormLabel>
 						<FormPhoneInput
 							initialCountryCode="US"
@@ -274,8 +286,44 @@ class FormFields extends React.PureComponent {
 					</FormFieldset>
 
 					<FormFieldset>
+						<FormLabel htmlFor="currency_input_valid">Form Currency Input</FormLabel>
+						<FormCurrencyInput
+							name="currency_input"
+							id="currency_input_valid"
+							currencySymbolPrefix="$"
+							placeholder="Placeholder text..."
+							isValid
+						/>
+						<FormInputValidation text="The price is very good." />
+					</FormFieldset>
+
+					<FormFieldset>
+						<FormLabel htmlFor="currency_input_error">Form Currency Input</FormLabel>
+						<FormCurrencyInput
+							name="currency_input"
+							id="currency_input_error"
+							currencySymbolPrefix="$"
+							placeholder="Placeholder text..."
+							isError
+						/>
+						<FormInputValidation isError text="The price is invalid." />
+					</FormFieldset>
+
+					<FormFieldset>
 						<FormLabel htmlFor="textarea">Form Textarea</FormLabel>
 						<FormTextarea name="textarea" id="textarea" placeholder="Placeholder text..." />
+					</FormFieldset>
+
+					<FormFieldset>
+						<FormLabel htmlFor="textarea_valid">Form Textarea</FormLabel>
+						<FormTextarea name="textarea" id="textarea_valid" placeholder="Placeholder text..." isValid />
+						<FormInputValidation text="Your text can be saved." />
+					</FormFieldset>
+
+					<FormFieldset>
+						<FormLabel htmlFor="textarea_error">Form Textarea</FormLabel>
+						<FormTextarea name="textarea" id="textarea_error" placeholder="Placeholder text..." isError />
+						<FormInputValidation isError text="Your text is invalid." />
 					</FormFieldset>
 
 					<FormButtonsBar>

--- a/client/components/forms/form-currency-input/style.scss
+++ b/client/components/forms/form-currency-input/style.scss
@@ -1,13 +1,3 @@
 .form-currency-input {
 	-webkit-appearance: none;
-
-	&:not( :focus ) {
-		&.is-error {
-			border-color: $alert-red;
-		}
-
-		&.is-error:hover {
-			border-color: darken( $alert-red, 10 );
-		}
-	}
 }

--- a/client/components/forms/form-tel-input/index.jsx
+++ b/client/components/forms/form-tel-input/index.jsx
@@ -5,9 +5,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
-export default function FormTelInput( { className, isError, ...props } ) {
+export default function FormTelInput( { className, isError, isValid, ...props } ) {
 	const classes = classNames( 'form-tel-input', className, {
 		'is-error': isError,
+		'is-valid': isValid,
 	} );
 
 	return <input { ...props } type="tel" pattern="[0-9]*" className={ classes } />;
@@ -16,8 +17,10 @@ export default function FormTelInput( { className, isError, ...props } ) {
 FormTelInput.propTypes = {
 	className: PropTypes.string,
 	isError: PropTypes.bool,
+	isValid: PropTypes.bool,
 };
 
 FormTelInput.defaultProps = {
 	isError: false,
+	isValid: false,
 };

--- a/client/components/forms/form-tel-input/style.scss
+++ b/client/components/forms/form-tel-input/style.scss
@@ -1,13 +1,3 @@
 .form-tel-input {
 	-webkit-appearance: none;
-
-	&:not( :focus ) {
-		&.is-error {
-			border-color: $alert-red;
-		}
-
-		&.is-error:hover {
-			border-color: darken( $alert-red, 10 );
-		}
-	}
 }

--- a/client/components/forms/form-text-input/style.scss
+++ b/client/components/forms/form-text-input/style.scss
@@ -3,39 +3,4 @@ input[type="password"].form-text-input,
 input[type="url"].form-text-input,
 input[type="text"].form-text-input { // input[type="text"] is needed to override the default styles
 	-webkit-appearance: none;
-
-	&.is-valid {
-		border-color: $alert-green;
-	}
-
-	&.is-valid:hover {
-		border-color: darken( $alert-green, 10 );
-	}
-
-	&.is-error {
-		border-color: $alert-red;
-	}
-
-	&.is-error:hover {
-		border-color: darken( $alert-red, 10 );
-	}
-
-	&:focus {
-		&.is-valid {
-			box-shadow: 0 0 0 2px lighten( $alert-green, 35 );
-		}
-
-		&.is-valid:hover {
-			box-shadow: 0 0 0 2px lighten( $alert-green, 25 );
-		}
-
-		&.is-error {
-			box-shadow: 0 0 0 2px lighten( $alert-red, 35 );
-
-		}
-
-		&.is-error:hover {
-			box-shadow: 0 0 0 2px lighten( $alert-red, 25 );
-		}
-	}
 }

--- a/client/components/forms/form-textarea/index.jsx
+++ b/client/components/forms/form-textarea/index.jsx
@@ -1,15 +1,19 @@
+/** @format */
 /**
  * External dependencies
  */
 import React from 'react';
 import classnames from 'classnames';
 
-const FormTextarea = ( { className, children, ...otherProps } ) => (
-	<textarea { ...otherProps }
-		className={ classnames( className, 'form-textarea' ) }
+const FormTextarea = ( { className, isError, isValid, children, ...otherProps } ) =>
+	<textarea
+		{ ...otherProps }
+		className={ classnames( className, 'form-textarea', {
+			'is-error': isError,
+			'is-valid': isValid,
+		} ) }
 	>
 		{ children }
-	</textarea>
-);
+	</textarea>;
 
 export default FormTextarea;


### PR DESCRIPTION
This PR adds support for `isValid` and `isError` props to `FormTextarea`, `FormCurrencyInput` and `FormTelInput`.

Before that, they either didn't support them at all, or the support was buggy. For example, a `<FormCurrencyInput isError>` would display a red border when not focused, but that border (and the outline) would turn blue on focus and hover.

The way the fix is implemented can be a bit controversial: I'm dropping `FormCurrencyInput` and `FormTelInput`'s own stylesheets, because they are buggy and incomplete, and instead I'm adding all three components' selectors to the `form-text-input/style.scss` stylesheet. I.e., a component is styled not by its own stylesheet, but by another's one.

The only alternative I'm aware of is either copy and pasting the CSS code at several places, or extracting it into a mixin. Maybe @mtias and other CSS experts will have better suggestions?

This PR will be very useful for #16960, where we use Redux Form. Components will stop warning us about unknown `isValid` and `isError` properties, and validation errors will be displayed correctly.

To test: open the `/devdocs/design/form-fields` example and check how the components render -- I added examples for all the cases that are being fixed.

<img width="653" alt="input-validations" src="https://user-images.githubusercontent.com/664258/29063524-78a74014-7c26-11e7-8e0a-33ebd0f28785.png">
