### PR TITLE
Activity log: Improve user messages

### DIFF
--- a/client/my-sites/stats/activity-log-item/activity-title.jsx
+++ b/client/my-sites/stats/activity-log-item/activity-title.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -66,7 +67,7 @@ class ActivityTitle extends Component {
 						previous_version: PropTypes.string,
 						slug: PropTypes.string,
 						version: PropTypes.string,
-					} ),
+					} )
 				),
 			] ),
 
@@ -432,7 +433,11 @@ class ActivityTitle extends Component {
 				return `${ actorName } deleted user ${ userName }.`;
 			}
 			case 'user__failed_login_attempt': {
-				const userLogin = get( this.props.object, [ 'user', 'user_login_attempt' ], 'An unknown user' );
+				const userLogin = get(
+					this.props.object,
+					[ 'user', 'user_login_attempt' ],
+					'An unknown user'
+				);
 				return `${ userLogin } attempted and failed to login.`;
 			}
 			case 'user__login': {
@@ -498,7 +503,10 @@ class ActivityTitle extends Component {
 				<div className="activity-log-item__title-title">
 					{ this.renderTitle() }
 				</div>
-				{ subTitle && <div className="activity-log-item__title-subtitle">{ subTitle }</div> }
+				{ subTitle &&
+					<div className="activity-log-item__title-subtitle">
+						{ subTitle }
+					</div> }
 			</div>
 		);
 	}

--- a/client/my-sites/stats/activity-log-item/activity-title.jsx
+++ b/client/my-sites/stats/activity-log-item/activity-title.jsx
@@ -435,8 +435,8 @@ class ActivityTitle extends Component {
 				return `${ actorName } attempted and failed to login.`;
 			}
 			case 'user__login': {
-				const actorName = this.getActorName();
-				return `${ actorName } logged in successfully.`;
+				const userName = this.getUserName();
+				return `${ userName } logged in successfully.`;
 			}
 			case 'user__registered': {
 				const actorName = this.getActorName();

--- a/client/my-sites/stats/activity-log-item/activity-title.jsx
+++ b/client/my-sites/stats/activity-log-item/activity-title.jsx
@@ -105,6 +105,7 @@ class ActivityTitle extends Component {
 				external_user_id: PropTypes.string,
 				login: PropTypes.string,
 				wpcom_user_id: PropTypes.number,
+				user_login_attempt: PropTypes.string,
 			} ),
 
 			widget: PropTypes.shape( {
@@ -431,8 +432,8 @@ class ActivityTitle extends Component {
 				return `${ actorName } deleted user ${ userName }.`;
 			}
 			case 'user__failed_login_attempt': {
-				const actorName = this.getActorName();
-				return `${ actorName } attempted and failed to login.`;
+				const userLogin = get( this.props.object, [ 'user', 'user_login_attempt' ], 'An unknown user' );
+				return `${ userLogin } attempted and failed to login.`;
 			}
 			case 'user__login': {
 				const userName = this.getUserName();


### PR DESCRIPTION
Improves messaging around user activity:

* `user__failed_login_attempt`
* `user__login`

## Testing

* Generate some login and failed login activity on a testing site
* Visit https://calypso.live/stats/activity/?branch=update/activitylog-userlogininfo

## Screens

### Before

![before](https://user-images.githubusercontent.com/841763/29066645-283c8508-7c30-11e7-9bf1-226b223d544d.png)

### After

![login](https://user-images.githubusercontent.com/841763/29066481-9a21e8da-7c2f-11e7-9f13-89a2085459d9.png)

## Caveats

Note that the actor (gravatar) is missing on the `user__login` but should be arriving soon (https://github.com/Automattic/jetpack/pull/7599).

The actor is also missing in `user__failed_login_attempt`, is that a candidate for the Jetpack actor @roccotripaldi @gititon @keoshi?