### PR TITLE
Simple Payments: double-delete to prevent deleted payment button from rendering on fro…

### DIFF
--- a/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
@@ -282,6 +282,8 @@ class SimplePaymentsDialog extends Component {
 
 		const { siteId, dispatch, translate } = this.props;
 
+		// TODO: Replace double-delete with single-delete call after server-side shortcode renderer
+		// is updated to ignore payment button posts with `trash` status.
 		const productAPI = wpcom.site( siteId ).post( paymentId );
 		productAPI.delete()
 			.then( () => productAPI.delete() )

--- a/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
@@ -282,10 +282,9 @@ class SimplePaymentsDialog extends Component {
 
 		const { siteId, dispatch, translate } = this.props;
 
-		wpcom
-			.site( siteId )
-			.post( paymentId )
-			.delete()
+		const productAPI = wpcom.site( siteId ).post( paymentId );
+		productAPI.delete()
+			.then( () => productAPI.delete() )
 			.then( () => dispatch( receiveDeleteProduct( siteId, paymentId ) ) )
 			.catch( () => this.showError( translate( 'The payment button could not be deleted.' ) ) )
 			.then( () => this.setIsSubmitting( false ) );

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -9,8 +9,13 @@
 		}
 	},
 	"exclude": [
-		"node_modules",
-		"public",
-		"build"
+		"**/node_modules/*",
+		"**/public/*",
+		"**/build/*",
+		"**/docs/*",
+		"**/server/*",
+		"**/test/*",
+		"**/config/*",
+		"**/bin/*"
 	]
 }

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -9,13 +9,8 @@
 		}
 	},
 	"exclude": [
-		"**/node_modules/*",
-		"**/public/*",
-		"**/build/*",
-		"**/docs/*",
-		"**/server/*",
-		"**/test/*",
-		"**/config/*",
-		"**/bin/*"
+		"node_modules",
+		"public",
+		"build"
 	]
 }


### PR DESCRIPTION
Payment button trashed from Simple Payments Button List were still being rendered on frontend because the payment button's post_status was `trash`.

This PR calls `delete` twice, first time to trash, second time to delete.

Test Plan:

1. Insert a payment button
2. Go to payment button list, trash it
3. Verify that the button is no longer rendered on site frontend
