### PR TITLE
Media: Use transient ID, to avoid issues with bigger than Integer values

### DIFF
--- a/client/lib/media/actions.js
+++ b/client/lib/media/actions.js
@@ -143,9 +143,6 @@ function uploadFiles( uploader, files, siteId ) {
 		// Generate a fake transient item that can be used immediately, even
 		// before the media has persisted to the server
 		const transientMedia = { date, ...MediaUtils.createTransientMedia( file ) };
-		if ( file.ID ) {
-			transientMedia.ID = file.ID;
-		}
 
 		Dispatcher.handleViewAction( {
 			type: 'CREATE_MEDIA_ITEM',


### PR DESCRIPTION
Part of fixing https://github.com/Automattic/wp-calypso/issues/16919

When operating with the ID we make some assumptions. The [updateMedia](https://github.com/Automattic/wp-calypso/blob/master/client/components/tinymce/plugins/media/plugin.jsx#L147) method in the TinyMCE media plugin [deserializes](https://github.com/Automattic/wp-calypso/blob/master/client/lib/media-serialization/strategies/dom.js#L46) the `<img >` tag into an object to query the MediaStore. It takes the ID from the class wp-image-* which will be:

1) wp-image-567 for a permanent media
2) wp-image-media-123 for a transient without file.ID
2) wp-image-XXXXXXXXX for a transient with file.ID

In 3, we can run into situations where the ID is something like '6451493182293668834', so we'll end up with a class such as wp-image-6451493182293668834.

The deserialization will parse it as a number and will convert it to:

    parseInt('6451493182293668834', 10) = 6451493182293669000

Due to the wrong ID, updateMedia won't find the media in the library.

## Testing

Upload a bunch of files and test that they are added to the media library. I tried every option: "add from URL" & "add new" buttons from the media modal, drag&drop, add from Google docs.
