### PR TITLE
Site Settings: Make VideoPress settings compatible with Atomic sites

### DIFF
--- a/client/my-sites/site-settings/media-settings.jsx
+++ b/client/my-sites/site-settings/media-settings.jsx
@@ -20,6 +20,7 @@ import CompactFormToggle from 'components/forms/form-toggle/compact';
 import InfoPopover from 'components/info-popover';
 import ExternalLink from 'components/external-link';
 import {
+	PLAN_BUSINESS,
 	PLAN_JETPACK_BUSINESS,
 	PLAN_JETPACK_BUSINESS_MONTHLY,
 	PLAN_JETPACK_PREMIUM,
@@ -50,6 +51,7 @@ import FormSettingExplanation from 'components/forms/form-setting-explanation';
  * Module constants
  */
 const plansIncludingVideoPress = [
+	PLAN_BUSINESS,
 	PLAN_JETPACK_BUSINESS,
 	PLAN_JETPACK_BUSINESS_MONTHLY,
 	PLAN_JETPACK_PREMIUM,


### PR DESCRIPTION
This PR makes the VideoPress setting compatible with Atomic sites. The previous implementation will always display an upgrade nudge, because it does not recognize the Business plan as a valid plan with VideoPress support.

This is an alternative approach to #16988, easier to review and test and probably [makes more sense](https://github.com/Automattic/wp-calypso/pull/16988#discussion_r131885469).

To test:
* Checkout this branch
* Go to `http://calypso.localhost:3000/settings/writing/:site`, where `:site` is an Atomic site.
* Verify you can see the video toggle and actual upload storage information.