### PR TITLE
Web Preview: Remove border radius on Back button in mobile view

### DIFF
--- a/client/components/web-preview/style.scss
+++ b/client/components/web-preview/style.scss
@@ -102,6 +102,8 @@ a.web-preview__external.button {
 
 	cursor: pointer;
 
+	border-radius: 0;
+
 	&:hover {
 		color: $gray-dark;
 	}


### PR DESCRIPTION
This PR removes a border radius that appeared on the Back button, that's visible in Web Preview when the browser width is within the mobile breakpoint.

Before:
<img width="319" alt="screen shot 2017-08-08 at 12 44 36" src="https://user-images.githubusercontent.com/184938/29070526-ab1ac780-7c37-11e7-857c-80fba3749c7e.png">

After:
<img width="314" alt="screen shot 2017-08-08 at 12 44 18" src="https://user-images.githubusercontent.com/184938/29070518-a59578dc-7c37-11e7-9bb0-e78e7e1faf3c.png">
