### PR TITLE
Jetpack connect: Avoid connection

### DIFF
--- a/client/jetpack-connect/auth-logged-out-form.jsx
+++ b/client/jetpack-connect/auth-logged-out-form.jsx
@@ -30,9 +30,9 @@ class LoggedOutForm extends Component {
 		jetpackConnectAuthorize: PropTypes.shape( {
 			bearerToken: PropTypes.string,
 			isAuthorizing: PropTypes.bool,
-			queryObject: PropTypes.object.isRequired,
+			queryObject: PropTypes.object,
 			userData: PropTypes.object,
-		} ).isRequired,
+		} ),
 		locale: PropTypes.string,
 		path: PropTypes.string,
 		translate: PropTypes.func.isRequired,
@@ -43,7 +43,7 @@ class LoggedOutForm extends Component {
 	}
 
 	getRedirectAfterLoginUrl() {
-		const { queryObject } = this.props.jetpackConnectAuthorize;
+		const queryObject = get( this.props, 'jetpackConnectAuthorize.queryObject', {} );
 		return addQueryArgs( queryObject, window.location.href );
 	}
 
@@ -57,21 +57,23 @@ class LoggedOutForm extends Component {
 	}
 
 	renderLoginUser() {
-		const { userData, bearerToken } = this.props.jetpackConnectAuthorize;
+		if ( this.props.jetpackConnectAuthorize ) {
+			const { userData, bearerToken } = this.props.jetpackConnectAuthorize;
 
-		return (
-			<WpcomLoginForm
-				log={ userData.username }
-				authorization={ 'Bearer ' + bearerToken }
-				redirectTo={ this.getRedirectAfterLoginUrl() } />
-		);
+			return (
+				<WpcomLoginForm
+					log={ userData.username }
+					authorization={ 'Bearer ' + bearerToken }
+					redirectTo={ this.getRedirectAfterLoginUrl() } />
+			);
+		}
 	}
 
 	renderFormHeader() {
 		const { translate, isAlreadyOnSitesList } = this.props;
 		const headerText = translate( 'Create your account' );
 		const subHeaderText = translate( 'You are moments away from connecting your site.' );
-		const { queryObject } = this.props.jetpackConnectAuthorize;
+		const queryObject = get( this.props, 'jetpackConnectAuthorize.queryObject', {} );
 		const siteCard = versionCompare( queryObject.jp_version, '4.0.3', '>' )
 			? <SiteCard queryObject={ queryObject } isAlreadyOnSitesList={ isAlreadyOnSitesList } />
 			: null;
@@ -110,7 +112,6 @@ class LoggedOutForm extends Component {
 			isAuthorizing,
 			userData,
 		} = this.props.jetpackConnectAuthorize;
-
 		return (
 			<div>
 				{ this.renderLocaleSuggestions() }

--- a/client/jetpack-connect/authorize-form.jsx
+++ b/client/jetpack-connect/authorize-form.jsx
@@ -55,8 +55,9 @@ class JetpackConnectAuthorizeForm extends Component {
 			queryObject: PropTypes.shape( {
 				client_id: PropTypes.string,
 				from: PropTypes.string,
-			} ).isRequired,
-		} ).isRequired,
+			} ),
+		} ),
+		preSelectedSite: PropTypes.string,
 		recordTracksEvent: PropTypes.func,
 		requestHasExpiredSecretError: PropTypes.func,
 		requestHasXmlrpcError: PropTypes.func,
@@ -108,18 +109,19 @@ class JetpackConnectAuthorizeForm extends Component {
 		);
 	}
 
+
 	renderForm() {
 		return (
 			( this.props.user )
 				? <LoggedInForm
 					{ ...this.props }
-					isSSO={ this.isSSO() }
-					isWCS={ this.isWCS() }
+					isSSO={ ! this.props.preSelectedSite && this.isSSO() }
+					isWCS={ ! this.props.preSelectedSite && this.isWCS() }
 				/>
 				: <LoggedOutForm
 					{ ...this.props }
-					isSSO={ this.isSSO() }
-					isWCS={ this.isWCS() }
+					isSSO={ ! this.props.preSelectedSite && this.isSSO() }
+					isWCS={ ! this.props.preSelectedSite && this.isWCS() }
 				/>
 		);
 	}
@@ -127,14 +129,9 @@ class JetpackConnectAuthorizeForm extends Component {
 	render() {
 		const { queryObject } = this.props.jetpackConnectAuthorize;
 
-		if ( typeof queryObject === 'undefined' ) {
+		if ( ! this.props.preSelectedSite && typeof queryObject === 'undefined' ) {
 			return this.renderNoQueryArgsError();
 		}
-
-		if ( queryObject && queryObject.already_authorized && ! this.props.isAlreadyOnSitesList ) {
-			this.renderForm();
-		}
-
 		return (
 			<MainWrapper>
 				<div className="jetpack-connect__authorize-form">

--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -145,6 +145,8 @@ export default {
 				path={ context.path }
 				interval={ interval }
 				locale={ locale }
+				preSelectedSite={ context.query.preSelectedSite || null }
+				selectedPlan={ context.query.selectedPlan || null }
 			/>,
 			document.getElementById( 'primary' ),
 			context.store
@@ -193,6 +195,7 @@ export default {
 				interval={ context.params.interval }
 				basePlansPath={ '/jetpack/connect/store' }
 				url={ context.query.site }
+				preSelectedSite={ context.query.preSelectedSite }
 			/>,
 			document.getElementById( 'primary' ),
 			context.store

--- a/client/jetpack-connect/plans-landing.jsx
+++ b/client/jetpack-connect/plans-landing.jsx
@@ -17,12 +17,14 @@ import QueryPlans from 'components/data/query-plans';
 import addQueryArgs from 'lib/route/add-query-args';
 
 const CALYPSO_JETPACK_CONNECT = '/jetpack/connect';
+const CALYPSO_JETPACK_CONNECT_CHECK_USER = '/jetpack/connect/authorize?preSelectedSite=';
 
 class PlansLanding extends Component {
 	static propTypes = {
 		basePlansPath: PropTypes.string,
 		interval: PropTypes.string,
 		url: PropTypes.string,
+		preSelectedSite: PropTypes.string
 	};
 
 	static defaultProps = {
@@ -50,8 +52,11 @@ class PlansLanding extends Component {
 	}
 
 	storeSelectedPlan = ( cartItem ) => {
-		const { url } = this.props;
-		let redirectUrl = CALYPSO_JETPACK_CONNECT;
+		const { url, preSelectedSite } = this.props;
+		const selectedPlanSlug = cartItem ? cartItem.product_slug : 'free';
+		let redirectUrl = preSelectedSite
+			? CALYPSO_JETPACK_CONNECT_CHECK_USER + preSelectedSite + '&selectedPlan=' + selectedPlanSlug
+			: CALYPSO_JETPACK_CONNECT;
 
 		if ( url ) {
 			redirectUrl = addQueryArgs( { url }, redirectUrl );
@@ -60,7 +65,7 @@ class PlansLanding extends Component {
 		this.props.recordTracksEvent( 'calypso_jpc_plans_store_plan', {
 			plan: cartItem ? cartItem.product_slug : 'free'
 		} );
-		this.props.selectPlanInAdvance( cartItem ? cartItem.product_slug : 'free', '*' );
+		this.props.selectPlanInAdvance( selectedPlanSlug, '*' );
 
 		setTimeout( () => {
 			page.redirect( redirectUrl );


### PR DESCRIPTION
Right now we have several flows that include sending users from sites we already know that are connected through JPC, just to be able to send them to the checkout page so they can buy an upgrade.

This is clearly a hack, and not even a very good one: It's causing problems to some of the sites. When we designed JPC first, we didn't have this use-case in mind, so we didn't optimize it for this. For example, the status-check we do when we start the connection process is optimized for speed, not for being 100 accurate. We know that it's going to throw some false negatives, but until now that wasn't a big deal, it was a trade-off we made in exchange for making the whole flow quicker. 

But when this trade-off affects to users who are with their money in hand, ready to pay for an upgrade, it doesn't look so good. 

What this PR do is introduce a new parameter that can be passed to most of the entry points for JPC, that indicates that we are 100% sure that the site is already connected, and that it makes it safe to totally skip the connection bits and redirect the user directly to the plans page / checkout.  It's supposed to be used only from parts that can only be shown if the user has a connected site (for example, a JITM in wp-admin).

How to test
=========

0. You need a jetpack connected site (of course)
1. Go to https://calypso.localhost:3000/jetpack/connect/store?branch=add/jpc-skip-connection-when-selling-stuff-to-connected-sites&preSelectedSite=[site_slug] 
2. You should see the plans page... pick one
3. You should reach the checkout page right away
4. Test again 1-3, but without being logged to wp.com. The result should be the same