### PR TITLE
Extensions: Zoninator - Ensure consistent item site on zones dashboard

### DIFF
--- a/client/extensions/zoninator/components/settings/zones-dashboard/style.scss
+++ b/client/extensions/zoninator/components/settings/zones-dashboard/style.scss
@@ -12,11 +12,18 @@
 
 .zones-dashboard__zone-description {
 	color: $gray-dark;
+	height: 15px;
+	width: 56%;
+
+	small {
+		display: block;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
 
 	&.is-placeholder {
-		width: 56%;
-		height: 15px;
-		margin-top: 7px;
+		margin: 7px 0 0;
 		background-color: lighten( $gray, 30% );
 		animation: loading-fade 1.6s ease-in-out infinite;
 	}

--- a/client/extensions/zoninator/components/settings/zones-dashboard/style.scss
+++ b/client/extensions/zoninator/components/settings/zones-dashboard/style.scss
@@ -15,16 +15,16 @@
 	height: 15px;
 	width: 56%;
 
-	small {
-		display: block;
-		overflow: hidden;
-		text-overflow: ellipsis;
-		white-space: nowrap;
-	}
-
 	&.is-placeholder {
 		margin: 7px 0 0;
 		background-color: lighten( $gray, 30% );
 		animation: loading-fade 1.6s ease-in-out infinite;
 	}
+}
+
+.zones-dashboard__zone-description-text {
+	display: block;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
 }

--- a/client/extensions/zoninator/components/settings/zones-dashboard/zone-item.jsx
+++ b/client/extensions/zoninator/components/settings/zones-dashboard/zone-item.jsx
@@ -18,7 +18,11 @@ const ZoneItem = ( { siteSlug, zone } ) => {
 	return (
 		<CompactCard href={ `${ settingsPath }/${ siteSlug }/${ slug }` }>
 			<div className="zones-dashboard__zone-label">{ name }</div>
-			<div className="zones-dashboard__zone-description"><small>{ description }</small></div>
+			<div className="zones-dashboard__zone-description">
+				<small className="zones-dashboard__zone-description-text">
+					{ description }
+				</small>
+			</div>
 		</CompactCard>
 	);
 };


### PR DESCRIPTION
This PR ensures consistent item size on zones dashboard.

**Before**:

![screen shot 2017-08-08 at 17 23 49](https://user-images.githubusercontent.com/8056203/29079795-69768518-7c5e-11e7-94ca-69ddaac29459.png)


**After**:

![screen shot 2017-08-08 at 17 16 30](https://user-images.githubusercontent.com/8056203/29079802-6dc01d82-7c5e-11e7-83e1-bdbf06ba0307.png)


# Testing

You will need to checkout [Zoninator](https://github.com/Automattic/zoninator) to `add/rest-api` on  your site for the list to show the actual zones.