### PR TITLE
Update from React.PropTypes to prop-types

### DIFF
--- a/client/blocks/global-notice/index.js
+++ b/client/blocks/global-notice/index.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import { Component } from 'react';
 import { connect } from 'react-redux';
 
 /**

--- a/client/blocks/global-notice/index.js
+++ b/client/blocks/global-notice/index.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import { Component } from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
 /**

--- a/client/blocks/video-editor/video-editor-upload-button.js
+++ b/client/blocks/video-editor/video-editor-upload-button.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import { noop } from 'lodash';
 
 /**

--- a/client/blocks/video-editor/video-editor-upload-button.js
+++ b/client/blocks/video-editor/video-editor-upload-button.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { noop } from 'lodash';
 
 /**

--- a/client/components/data/query-rewind-restore-status/index.js
+++ b/client/components/data/query-rewind-restore-status/index.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import { PropTypes, PureComponent } from 'react';
+import PropTypes from 'prop-types';
+
+import { PureComponent } from 'react';
 import { connect } from 'react-redux';
 import { delay } from 'lodash';
 

--- a/client/components/data/query-rewind-restore-status/index.js
+++ b/client/components/data/query-rewind-restore-status/index.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import { PureComponent } from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { delay } from 'lodash';
 

--- a/client/components/data/query-sharing-buttons/index.js
+++ b/client/components/data/query-sharing-buttons/index.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import { Component } from 'react';
 import { connect } from 'react-redux';
 
 /**

--- a/client/components/data/query-sharing-buttons/index.js
+++ b/client/components/data/query-sharing-buttons/index.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import { Component } from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
 /**

--- a/client/components/data/query-simple-payments/index.js
+++ b/client/components/data/query-simple-payments/index.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import { Component } from 'react';
 import { connect } from 'react-redux';
 
 /**

--- a/client/components/data/query-simple-payments/index.js
+++ b/client/components/data/query-simple-payments/index.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import { Component } from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
 /**

--- a/client/components/data/query-site-settings/index.js
+++ b/client/components/data/query-site-settings/index.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import { Component } from 'react';
 import { connect } from 'react-redux';
 
 /**

--- a/client/components/data/query-site-settings/index.js
+++ b/client/components/data/query-site-settings/index.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import { Component } from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
 /**

--- a/client/components/data/query-site-updates/index.js
+++ b/client/components/data/query-site-updates/index.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import { Component } from 'react';
 import { connect } from 'react-redux';
 
 /**

--- a/client/components/data/query-site-updates/index.js
+++ b/client/components/data/query-site-updates/index.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import { Component } from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
 /**

--- a/client/components/reader-infinite-stream/index.js
+++ b/client/components/reader-infinite-stream/index.js
@@ -1,7 +1,9 @@
 /**
  * External Dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import {
 	List,
 	WindowScroller,

--- a/client/components/reader-infinite-stream/index.js
+++ b/client/components/reader-infinite-stream/index.js
@@ -1,9 +1,8 @@
 /**
  * External Dependencies
  */
-import PropTypes from 'prop-types';
-
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import {
 	List,
 	WindowScroller,

--- a/client/components/seo/reader-preview/index.js
+++ b/client/components/seo/reader-preview/index.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { PropTypes, PureComponent } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { PureComponent } from 'react';
 
 /**
  * Internal dependencies

--- a/client/components/seo/reader-preview/index.js
+++ b/client/components/seo/reader-preview/index.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies

--- a/client/components/share/google-plus-share-preview/index.js
+++ b/client/components/share/google-plus-share-preview/index.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { PureComponent, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { PureComponent } from 'react';
 import { localize } from 'i18n-calypso';
 import { truncateArticleContent } from '../helpers';
 

--- a/client/components/share/google-plus-share-preview/index.js
+++ b/client/components/share/google-plus-share-preview/index.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import { truncateArticleContent } from '../helpers';
 

--- a/client/components/signup-site-title/index.js
+++ b/client/components/signup-site-title/index.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import { connect } from 'react-redux';
 import { noop } from 'lodash';
 

--- a/client/components/signup-site-title/index.js
+++ b/client/components/signup-site-title/index.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { noop } from 'lodash';
 

--- a/client/components/social-buttons/facebook.js
+++ b/client/components/social-buttons/facebook.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { loadScript } from 'lib/load-script';
 import { localize } from 'i18n-calypso';
 import { noop } from 'lodash';

--- a/client/components/social-buttons/facebook.js
+++ b/client/components/social-buttons/facebook.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import { loadScript } from 'lib/load-script';
 import { localize } from 'i18n-calypso';
 import { noop } from 'lodash';

--- a/client/components/social-buttons/google.js
+++ b/client/components/social-buttons/google.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { loadScript } from 'lib/load-script';
 import { localize } from 'i18n-calypso';

--- a/client/components/social-buttons/google.js
+++ b/client/components/social-buttons/google.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { loadScript } from 'lib/load-script';
 import { localize } from 'i18n-calypso';

--- a/client/components/update-post-status/index.js
+++ b/client/components/update-post-status/index.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { flow, once } from 'lodash';

--- a/client/components/update-post-status/index.js
+++ b/client/components/update-post-status/index.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { flow, once } from 'lodash';

--- a/client/extensions/hello-dolly/hello-dolly-page.js
+++ b/client/extensions/hello-dolly/hello-dolly-page.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 

--- a/client/extensions/hello-dolly/hello-dolly-page.js
+++ b/client/extensions/hello-dolly/hello-dolly-page.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 

--- a/client/extensions/woocommerce/app/dashboard/index.js
+++ b/client/extensions/woocommerce/app/dashboard/index.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { bindActionCreators } from 'redux';
 import classNames from 'classnames';
 import { connect } from 'react-redux';

--- a/client/extensions/woocommerce/app/dashboard/index.js
+++ b/client/extensions/woocommerce/app/dashboard/index.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import { bindActionCreators } from 'redux';
 import classNames from 'classnames';
 import { connect } from 'react-redux';

--- a/client/extensions/woocommerce/app/dashboard/manage-no-orders-view.js
+++ b/client/extensions/woocommerce/app/dashboard/manage-no-orders-view.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import page from 'page';
 

--- a/client/extensions/woocommerce/app/dashboard/manage-no-orders-view.js
+++ b/client/extensions/woocommerce/app/dashboard/manage-no-orders-view.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
 import page from 'page';
 

--- a/client/extensions/woocommerce/app/dashboard/manage-orders-view.js
+++ b/client/extensions/woocommerce/app/dashboard/manage-orders-view.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';

--- a/client/extensions/woocommerce/app/dashboard/manage-orders-view.js
+++ b/client/extensions/woocommerce/app/dashboard/manage-orders-view.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';

--- a/client/extensions/woocommerce/app/dashboard/pre-setup-view.js
+++ b/client/extensions/woocommerce/app/dashboard/pre-setup-view.js
@@ -5,9 +5,8 @@ import { localize } from 'i18n-calypso';
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies

--- a/client/extensions/woocommerce/app/dashboard/pre-setup-view.js
+++ b/client/extensions/woocommerce/app/dashboard/pre-setup-view.js
@@ -1,10 +1,13 @@
-/**
- * External dependencies
- */
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import React, { Component, PropTypes } from 'react';
+
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 
 /**
  * Internal dependencies

--- a/client/extensions/woocommerce/app/dashboard/pre-setup-view.js
+++ b/client/extensions/woocommerce/app/dashboard/pre-setup-view.js
@@ -1,12 +1,11 @@
-import { bindActionCreators } from 'redux';
-import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
-
 /**
  * External dependencies
  */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies

--- a/client/extensions/woocommerce/app/dashboard/required-pages-setup-view.js
+++ b/client/extensions/woocommerce/app/dashboard/required-pages-setup-view.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';

--- a/client/extensions/woocommerce/app/dashboard/required-pages-setup-view.js
+++ b/client/extensions/woocommerce/app/dashboard/required-pages-setup-view.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';

--- a/client/extensions/woocommerce/app/dashboard/required-plugins-install-view.js
+++ b/client/extensions/woocommerce/app/dashboard/required-plugins-install-view.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { find, size } from 'lodash';

--- a/client/extensions/woocommerce/app/dashboard/required-plugins-install-view.js
+++ b/client/extensions/woocommerce/app/dashboard/required-plugins-install-view.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { find, size } from 'lodash';

--- a/client/extensions/woocommerce/app/dashboard/setup-footer.js
+++ b/client/extensions/woocommerce/app/dashboard/setup-footer.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 
 /**
  * Internal dependencies

--- a/client/extensions/woocommerce/app/dashboard/setup-footer.js
+++ b/client/extensions/woocommerce/app/dashboard/setup-footer.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React from 'react';
+import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies

--- a/client/extensions/woocommerce/app/dashboard/setup-header.js
+++ b/client/extensions/woocommerce/app/dashboard/setup-header.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 
 const SetupHeader = ( { imageSource, imageWidth, subtitle, title, children } ) => {
 	return (

--- a/client/extensions/woocommerce/app/dashboard/setup-header.js
+++ b/client/extensions/woocommerce/app/dashboard/setup-header.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React from 'react';
+import PropTypes from 'prop-types';
 
 const SetupHeader = ( { imageSource, imageWidth, subtitle, title, children } ) => {
 	return (

--- a/client/extensions/woocommerce/app/dashboard/setup-task.js
+++ b/client/extensions/woocommerce/app/dashboard/setup-task.js
@@ -1,12 +1,11 @@
-import Gridicon from 'gridicons';
-import { localize } from 'i18n-calypso';
-import page from 'page';
-
 /**
  * External dependencies
  */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import Gridicon from 'gridicons';
+import { localize } from 'i18n-calypso';
+import page from 'page';
 
 /**
  * Internal dependencies

--- a/client/extensions/woocommerce/app/dashboard/setup-task.js
+++ b/client/extensions/woocommerce/app/dashboard/setup-task.js
@@ -1,10 +1,13 @@
-/**
- * External dependencies
- */
 import Gridicon from 'gridicons';
 import { localize } from 'i18n-calypso';
 import page from 'page';
-import React, { Component, PropTypes } from 'react';
+
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 
 /**
  * Internal dependencies

--- a/client/extensions/woocommerce/app/dashboard/setup-task.js
+++ b/client/extensions/woocommerce/app/dashboard/setup-task.js
@@ -5,9 +5,8 @@ import page from 'page';
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies

--- a/client/extensions/woocommerce/app/dashboard/setup-tasks-view.js
+++ b/client/extensions/woocommerce/app/dashboard/setup-tasks-view.js
@@ -5,9 +5,8 @@ import { localize } from 'i18n-calypso';
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies

--- a/client/extensions/woocommerce/app/dashboard/setup-tasks-view.js
+++ b/client/extensions/woocommerce/app/dashboard/setup-tasks-view.js
@@ -1,10 +1,13 @@
-/**
- * External dependencies
- */
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import React, { Component, PropTypes } from 'react';
+
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 
 /**
  * Internal dependencies

--- a/client/extensions/woocommerce/app/dashboard/setup-tasks-view.js
+++ b/client/extensions/woocommerce/app/dashboard/setup-tasks-view.js
@@ -1,12 +1,11 @@
-import { bindActionCreators } from 'redux';
-import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
-
 /**
  * External dependencies
  */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies

--- a/client/extensions/woocommerce/app/dashboard/setup-tasks.js
+++ b/client/extensions/woocommerce/app/dashboard/setup-tasks.js
@@ -5,9 +5,8 @@ import { localize } from 'i18n-calypso';
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies

--- a/client/extensions/woocommerce/app/dashboard/setup-tasks.js
+++ b/client/extensions/woocommerce/app/dashboard/setup-tasks.js
@@ -1,10 +1,13 @@
-/**
- * External dependencies
- */
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import React, { Component, PropTypes } from 'react';
+
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 
 /**
  * Internal dependencies

--- a/client/extensions/woocommerce/app/dashboard/setup-tasks.js
+++ b/client/extensions/woocommerce/app/dashboard/setup-tasks.js
@@ -1,12 +1,11 @@
-import { bindActionCreators } from 'redux';
-import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
-
 /**
  * External dependencies
  */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies

--- a/client/extensions/woocommerce/app/index.js
+++ b/client/extensions/woocommerce/app/index.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import page from 'page';
 import { localize } from 'i18n-calypso';

--- a/client/extensions/woocommerce/app/index.js
+++ b/client/extensions/woocommerce/app/index.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import page from 'page';
 import { localize } from 'i18n-calypso';

--- a/client/extensions/woocommerce/app/order/order-activity-log.js
+++ b/client/extensions/woocommerce/app/order/order-activity-log.js
@@ -1,8 +1,11 @@
+import { localize } from 'i18n-calypso';
+
 /**
  * External dependencies
  */
-import { localize } from 'i18n-calypso';
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 
 /**
  * Internal dependencies

--- a/client/extensions/woocommerce/app/order/order-activity-log.js
+++ b/client/extensions/woocommerce/app/order/order-activity-log.js
@@ -1,10 +1,9 @@
-import { localize } from 'i18n-calypso';
-
 /**
  * External dependencies
  */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies

--- a/client/extensions/woocommerce/app/order/order-activity-log.js
+++ b/client/extensions/woocommerce/app/order/order-activity-log.js
@@ -3,9 +3,8 @@ import { localize } from 'i18n-calypso';
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies

--- a/client/extensions/woocommerce/app/order/order-created.js
+++ b/client/extensions/woocommerce/app/order/order-created.js
@@ -4,9 +4,8 @@ import { localize } from 'i18n-calypso';
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
 class OrderCreated extends Component {
 	static propTypes = {

--- a/client/extensions/woocommerce/app/order/order-created.js
+++ b/client/extensions/woocommerce/app/order/order-created.js
@@ -1,11 +1,10 @@
-import Gridicon from 'gridicons';
-import { localize } from 'i18n-calypso';
-
 /**
  * External dependencies
  */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import Gridicon from 'gridicons';
+import { localize } from 'i18n-calypso';
 
 class OrderCreated extends Component {
 	static propTypes = {

--- a/client/extensions/woocommerce/app/order/order-created.js
+++ b/client/extensions/woocommerce/app/order/order-created.js
@@ -1,9 +1,12 @@
+import Gridicon from 'gridicons';
+import { localize } from 'i18n-calypso';
+
 /**
  * External dependencies
  */
-import Gridicon from 'gridicons';
-import { localize } from 'i18n-calypso';
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 
 class OrderCreated extends Component {
 	static propTypes = {

--- a/client/extensions/woocommerce/app/order/order-customer-info.js
+++ b/client/extensions/woocommerce/app/order/order-customer-info.js
@@ -1,8 +1,11 @@
+import { localize } from 'i18n-calypso';
+
 /**
  * External dependencies
  */
-import { localize } from 'i18n-calypso';
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 
 /**
  * Internal dependencies

--- a/client/extensions/woocommerce/app/order/order-customer-info.js
+++ b/client/extensions/woocommerce/app/order/order-customer-info.js
@@ -1,10 +1,9 @@
-import { localize } from 'i18n-calypso';
-
 /**
  * External dependencies
  */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies

--- a/client/extensions/woocommerce/app/order/order-customer-info.js
+++ b/client/extensions/woocommerce/app/order/order-customer-info.js
@@ -3,9 +3,8 @@ import { localize } from 'i18n-calypso';
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies

--- a/client/extensions/woocommerce/app/order/order-details-table.js
+++ b/client/extensions/woocommerce/app/order/order-details-table.js
@@ -1,9 +1,12 @@
+import { localize } from 'i18n-calypso';
+
 /**
  * External dependencies
  */
 import classnames from 'classnames';
-import { localize } from 'i18n-calypso';
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import { sum } from 'lodash';
 
 /**

--- a/client/extensions/woocommerce/app/order/order-details-table.js
+++ b/client/extensions/woocommerce/app/order/order-details-table.js
@@ -1,11 +1,10 @@
-import { localize } from 'i18n-calypso';
-
 /**
  * External dependencies
  */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
+import { localize } from 'i18n-calypso';
 import { sum } from 'lodash';
 
 /**

--- a/client/extensions/woocommerce/app/order/order-details-table.js
+++ b/client/extensions/woocommerce/app/order/order-details-table.js
@@ -3,10 +3,9 @@ import { localize } from 'i18n-calypso';
 /**
  * External dependencies
  */
-import classnames from 'classnames';
-import PropTypes from 'prop-types';
-
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import classnames from 'classnames';
 import { sum } from 'lodash';
 
 /**

--- a/client/extensions/woocommerce/app/order/order-details.js
+++ b/client/extensions/woocommerce/app/order/order-details.js
@@ -1,8 +1,11 @@
+import { localize } from 'i18n-calypso';
+
 /**
  * External dependencies
  */
-import { localize } from 'i18n-calypso';
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 
 /**
  * Internal dependencies

--- a/client/extensions/woocommerce/app/order/order-details.js
+++ b/client/extensions/woocommerce/app/order/order-details.js
@@ -1,10 +1,9 @@
-import { localize } from 'i18n-calypso';
-
 /**
  * External dependencies
  */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies

--- a/client/extensions/woocommerce/app/order/order-details.js
+++ b/client/extensions/woocommerce/app/order/order-details.js
@@ -3,9 +3,8 @@ import { localize } from 'i18n-calypso';
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies

--- a/client/extensions/woocommerce/app/order/order-fulfillment.js
+++ b/client/extensions/woocommerce/app/order/order-fulfillment.js
@@ -1,14 +1,13 @@
-import { bindActionCreators } from 'redux';
-import classNames from 'classnames';
-import { connect } from 'react-redux';
-import Gridicon from 'gridicons';
-import { localize } from 'i18n-calypso';
-
 /**
  * External dependencies
  */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import { bindActionCreators } from 'redux';
+import classNames from 'classnames';
+import { connect } from 'react-redux';
+import Gridicon from 'gridicons';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies

--- a/client/extensions/woocommerce/app/order/order-fulfillment.js
+++ b/client/extensions/woocommerce/app/order/order-fulfillment.js
@@ -7,9 +7,8 @@ import { localize } from 'i18n-calypso';
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies

--- a/client/extensions/woocommerce/app/order/order-fulfillment.js
+++ b/client/extensions/woocommerce/app/order/order-fulfillment.js
@@ -1,12 +1,15 @@
-/**
- * External dependencies
- */
 import { bindActionCreators } from 'redux';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
 import Gridicon from 'gridicons';
 import { localize } from 'i18n-calypso';
-import React, { Component, PropTypes } from 'react';
+
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 
 /**
  * Internal dependencies

--- a/client/extensions/woocommerce/app/order/order-refund-card.js
+++ b/client/extensions/woocommerce/app/order/order-refund-card.js
@@ -1,11 +1,14 @@
-/**
- * External dependencies
- */
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import Gridicon from 'gridicons';
 import { localize } from 'i18n-calypso';
-import React, { Component, PropTypes } from 'react';
+
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 
 /**
  * Internal dependencies

--- a/client/extensions/woocommerce/app/order/order-refund-card.js
+++ b/client/extensions/woocommerce/app/order/order-refund-card.js
@@ -1,13 +1,12 @@
-import { bindActionCreators } from 'redux';
-import { connect } from 'react-redux';
-import Gridicon from 'gridicons';
-import { localize } from 'i18n-calypso';
-
 /**
  * External dependencies
  */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
+import Gridicon from 'gridicons';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies

--- a/client/extensions/woocommerce/app/order/order-refund-card.js
+++ b/client/extensions/woocommerce/app/order/order-refund-card.js
@@ -6,9 +6,8 @@ import { localize } from 'i18n-calypso';
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies

--- a/client/extensions/woocommerce/app/products/index.js
+++ b/client/extensions/woocommerce/app/products/index.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { bindActionCreators } from 'redux';
 import classNames from 'classnames';
 import { connect } from 'react-redux';

--- a/client/extensions/woocommerce/app/products/index.js
+++ b/client/extensions/woocommerce/app/products/index.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import { bindActionCreators } from 'redux';
 import classNames from 'classnames';
 import { connect } from 'react-redux';

--- a/client/extensions/woocommerce/app/products/product-create.js
+++ b/client/extensions/woocommerce/app/products/product-create.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React from 'react';
+import PropTypes from 'prop-types';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { head } from 'lodash';

--- a/client/extensions/woocommerce/app/products/product-create.js
+++ b/client/extensions/woocommerce/app/products/product-create.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { head } from 'lodash';

--- a/client/extensions/woocommerce/app/products/product-form-additional-details-card.js
+++ b/client/extensions/woocommerce/app/products/product-form-additional-details-card.js
@@ -1,11 +1,14 @@
-/**
- * External dependencies
- */
 import classNames from 'classnames';
 import { debounce, find } from 'lodash';
 import Gridicon from 'gridicons';
 import { localize } from 'i18n-calypso';
-import React, { PropTypes, Component } from 'react';
+
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 
 /**
  * Internal dependencies

--- a/client/extensions/woocommerce/app/products/product-form-additional-details-card.js
+++ b/client/extensions/woocommerce/app/products/product-form-additional-details-card.js
@@ -1,13 +1,12 @@
-import classNames from 'classnames';
-import { debounce, find } from 'lodash';
-import Gridicon from 'gridicons';
-import { localize } from 'i18n-calypso';
-
 /**
  * External dependencies
  */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import { debounce, find } from 'lodash';
+import Gridicon from 'gridicons';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies

--- a/client/extensions/woocommerce/app/products/product-form-additional-details-card.js
+++ b/client/extensions/woocommerce/app/products/product-form-additional-details-card.js
@@ -6,9 +6,8 @@ import { localize } from 'i18n-calypso';
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies

--- a/client/extensions/woocommerce/app/products/product-form-categories-card.js
+++ b/client/extensions/woocommerce/app/products/product-form-categories-card.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import { localize } from 'i18n-calypso';
 import { find, pick, compact, escape, unescape } from 'lodash';
 

--- a/client/extensions/woocommerce/app/products/product-form-categories-card.js
+++ b/client/extensions/woocommerce/app/products/product-form-categories-card.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React from 'react';
+import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import { find, pick, compact, escape, unescape } from 'lodash';
 

--- a/client/extensions/woocommerce/app/products/product-form-details-card.js
+++ b/client/extensions/woocommerce/app/products/product-form-details-card.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import i18n from 'i18n-calypso';
 import { trim, debounce, isNumber } from 'lodash';
 

--- a/client/extensions/woocommerce/app/products/product-form-details-card.js
+++ b/client/extensions/woocommerce/app/products/product-form-details-card.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import i18n from 'i18n-calypso';
 import { trim, debounce, isNumber } from 'lodash';
 

--- a/client/extensions/woocommerce/app/products/product-form-images.js
+++ b/client/extensions/woocommerce/app/products/product-form-images.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import classNames from 'classnames';
 import Gridicon from 'gridicons';
 import { localize } from 'i18n-calypso';

--- a/client/extensions/woocommerce/app/products/product-form-images.js
+++ b/client/extensions/woocommerce/app/products/product-form-images.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import Gridicon from 'gridicons';
 import { localize } from 'i18n-calypso';

--- a/client/extensions/woocommerce/app/products/product-form-simple-card.js
+++ b/client/extensions/woocommerce/app/products/product-form-simple-card.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React from 'react';
+import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
 import { isNull } from 'lodash';

--- a/client/extensions/woocommerce/app/products/product-form-simple-card.js
+++ b/client/extensions/woocommerce/app/products/product-form-simple-card.js
@@ -3,9 +3,9 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
 import { isNull } from 'lodash';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies

--- a/client/extensions/woocommerce/app/products/product-form-simple-card.js
+++ b/client/extensions/woocommerce/app/products/product-form-simple-card.js
@@ -1,10 +1,12 @@
 /**
  * External dependencies
  */
+import PropTypes from 'prop-types';
+
+import React from 'react';
+import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
 import { isNull } from 'lodash';
-import { localize } from 'i18n-calypso';
-import React, { PropTypes } from 'react';
 
 /**
  * Internal dependencies

--- a/client/extensions/woocommerce/app/products/product-form-variations-card.js
+++ b/client/extensions/woocommerce/app/products/product-form-variations-card.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
 
 /**

--- a/client/extensions/woocommerce/app/products/product-form-variations-card.js
+++ b/client/extensions/woocommerce/app/products/product-form-variations-card.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 
 /**

--- a/client/extensions/woocommerce/app/products/product-form-variations-modal.js
+++ b/client/extensions/woocommerce/app/products/product-form-variations-modal.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import { find, debounce } from 'lodash';

--- a/client/extensions/woocommerce/app/products/product-form-variations-modal.js
+++ b/client/extensions/woocommerce/app/products/product-form-variations-modal.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import { find, debounce } from 'lodash';

--- a/client/extensions/woocommerce/app/products/product-form-variations-row.js
+++ b/client/extensions/woocommerce/app/products/product-form-variations-row.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import classNames from 'classnames';
 import Gridicon from 'gridicons';
 import { localize } from 'i18n-calypso';

--- a/client/extensions/woocommerce/app/products/product-form-variations-row.js
+++ b/client/extensions/woocommerce/app/products/product-form-variations-row.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import Gridicon from 'gridicons';
 import { localize } from 'i18n-calypso';

--- a/client/extensions/woocommerce/app/products/product-form-variations-table.js
+++ b/client/extensions/woocommerce/app/products/product-form-variations-table.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React from 'react';
+import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import { find } from 'lodash';
 

--- a/client/extensions/woocommerce/app/products/product-form-variations-table.js
+++ b/client/extensions/woocommerce/app/products/product-form-variations-table.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import { localize } from 'i18n-calypso';
 import { find } from 'lodash';
 

--- a/client/extensions/woocommerce/app/products/product-form.js
+++ b/client/extensions/woocommerce/app/products/product-form.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import classNames from 'classnames';
 
 /**

--- a/client/extensions/woocommerce/app/products/product-form.js
+++ b/client/extensions/woocommerce/app/products/product-form.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 /**

--- a/client/extensions/woocommerce/app/products/product-header.js
+++ b/client/extensions/woocommerce/app/products/product-header.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React from 'react';
+import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'gridicons';
 import { isObject } from 'lodash';

--- a/client/extensions/woocommerce/app/products/product-header.js
+++ b/client/extensions/woocommerce/app/products/product-header.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'gridicons';
 import { isObject } from 'lodash';
@@ -87,8 +89,8 @@ ProductHeader.propTypes = {
 	viewEnabled: PropTypes.bool,
 	onTrash: PropTypes.func,
 	onSave: PropTypes.oneOfType( [
-		React.PropTypes.func,
-		React.PropTypes.bool,
+		PropTypes.func,
+		PropTypes.bool,
 	] ),
 };
 

--- a/client/extensions/woocommerce/app/products/product-update.js
+++ b/client/extensions/woocommerce/app/products/product-update.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { debounce } from 'lodash';

--- a/client/extensions/woocommerce/app/products/product-update.js
+++ b/client/extensions/woocommerce/app/products/product-update.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { debounce } from 'lodash';

--- a/client/extensions/woocommerce/app/products/product-variation-types-form.js
+++ b/client/extensions/woocommerce/app/products/product-variation-types-form.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import { find, debounce, isNumber } from 'lodash';
 import { localize } from 'i18n-calypso';
 

--- a/client/extensions/woocommerce/app/products/product-variation-types-form.js
+++ b/client/extensions/woocommerce/app/products/product-variation-types-form.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { find, debounce, isNumber } from 'lodash';
 import { localize } from 'i18n-calypso';
 

--- a/client/extensions/woocommerce/app/products/products-list-pagination.js
+++ b/client/extensions/woocommerce/app/products/products-list-pagination.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 
 /**
  * Internal dependencies

--- a/client/extensions/woocommerce/app/products/products-list-pagination.js
+++ b/client/extensions/woocommerce/app/products/products-list-pagination.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React from 'react';
+import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies

--- a/client/extensions/woocommerce/app/products/products-list-row.js
+++ b/client/extensions/woocommerce/app/products/products-list-row.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import classNames from 'classnames';
 
 /**

--- a/client/extensions/woocommerce/app/products/products-list-row.js
+++ b/client/extensions/woocommerce/app/products/products-list-row.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 /**

--- a/client/extensions/woocommerce/app/products/products-list-search-results.js
+++ b/client/extensions/woocommerce/app/products/products-list-search-results.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 

--- a/client/extensions/woocommerce/app/products/products-list-search-results.js
+++ b/client/extensions/woocommerce/app/products/products-list-search-results.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 

--- a/client/extensions/woocommerce/app/products/products-list-table.js
+++ b/client/extensions/woocommerce/app/products/products-list-table.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 

--- a/client/extensions/woocommerce/app/products/products-list-table.js
+++ b/client/extensions/woocommerce/app/products/products-list-table.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 

--- a/client/extensions/woocommerce/app/products/products-list.js
+++ b/client/extensions/woocommerce/app/products/products-list.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 

--- a/client/extensions/woocommerce/app/products/products-list.js
+++ b/client/extensions/woocommerce/app/products/products-list.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 

--- a/client/extensions/woocommerce/app/settings/navigation.js
+++ b/client/extensions/woocommerce/app/settings/navigation.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import { connect } from 'react-redux';
 import { find } from 'lodash';
 import { localize } from 'i18n-calypso';

--- a/client/extensions/woocommerce/app/settings/navigation.js
+++ b/client/extensions/woocommerce/app/settings/navigation.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { find } from 'lodash';
 import { localize } from 'i18n-calypso';

--- a/client/extensions/woocommerce/app/settings/payments/index.js
+++ b/client/extensions/woocommerce/app/settings/payments/index.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { bindActionCreators } from 'redux';
 import classNames from 'classnames';
 import { connect } from 'react-redux';

--- a/client/extensions/woocommerce/app/settings/payments/index.js
+++ b/client/extensions/woocommerce/app/settings/payments/index.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import { bindActionCreators } from 'redux';
 import classNames from 'classnames';
 import { connect } from 'react-redux';

--- a/client/extensions/woocommerce/app/settings/payments/payment-method-cheque.js
+++ b/client/extensions/woocommerce/app/settings/payments/payment-method-cheque.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
 
 /**

--- a/client/extensions/woocommerce/app/settings/payments/payment-method-cheque.js
+++ b/client/extensions/woocommerce/app/settings/payments/payment-method-cheque.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 
 /**

--- a/client/extensions/woocommerce/app/settings/payments/payment-method-edit-dialog.js
+++ b/client/extensions/woocommerce/app/settings/payments/payment-method-edit-dialog.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import { isArray } from 'lodash';
 

--- a/client/extensions/woocommerce/app/settings/payments/payment-method-edit-dialog.js
+++ b/client/extensions/woocommerce/app/settings/payments/payment-method-edit-dialog.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
 import { isArray } from 'lodash';
 

--- a/client/extensions/woocommerce/app/settings/payments/payment-method-edit-form-toggle.js
+++ b/client/extensions/woocommerce/app/settings/payments/payment-method-edit-form-toggle.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import { omit } from 'lodash';
 
 /**

--- a/client/extensions/woocommerce/app/settings/payments/payment-method-edit-form-toggle.js
+++ b/client/extensions/woocommerce/app/settings/payments/payment-method-edit-form-toggle.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React from 'react';
+import PropTypes from 'prop-types';
 import { omit } from 'lodash';
 
 /**

--- a/client/extensions/woocommerce/app/settings/payments/payment-method-item.js
+++ b/client/extensions/woocommerce/app/settings/payments/payment-method-item.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';

--- a/client/extensions/woocommerce/app/settings/payments/payment-method-item.js
+++ b/client/extensions/woocommerce/app/settings/payments/payment-method-item.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';

--- a/client/extensions/woocommerce/app/settings/payments/payment-method-list.js
+++ b/client/extensions/woocommerce/app/settings/payments/payment-method-list.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';

--- a/client/extensions/woocommerce/app/settings/payments/payment-method-list.js
+++ b/client/extensions/woocommerce/app/settings/payments/payment-method-list.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';

--- a/client/extensions/woocommerce/app/settings/payments/payment-method-paypal.js
+++ b/client/extensions/woocommerce/app/settings/payments/payment-method-paypal.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
 
 /**

--- a/client/extensions/woocommerce/app/settings/payments/payment-method-paypal.js
+++ b/client/extensions/woocommerce/app/settings/payments/payment-method-paypal.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 
 /**

--- a/client/extensions/woocommerce/app/settings/payments/payment-method-stripe.js
+++ b/client/extensions/woocommerce/app/settings/payments/payment-method-stripe.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
 
 /**

--- a/client/extensions/woocommerce/app/settings/payments/payment-method-stripe.js
+++ b/client/extensions/woocommerce/app/settings/payments/payment-method-stripe.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 
 /**

--- a/client/extensions/woocommerce/app/settings/payments/payments-location-currency.js
+++ b/client/extensions/woocommerce/app/settings/payments/payments-location-currency.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { find } from 'lodash';

--- a/client/extensions/woocommerce/app/settings/payments/payments-location-currency.js
+++ b/client/extensions/woocommerce/app/settings/payments/payments-location-currency.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { find } from 'lodash';

--- a/client/extensions/woocommerce/app/settings/shipping/index.js
+++ b/client/extensions/woocommerce/app/settings/shipping/index.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import classNames from 'classnames';
 
 /**

--- a/client/extensions/woocommerce/app/settings/shipping/index.js
+++ b/client/extensions/woocommerce/app/settings/shipping/index.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 /**

--- a/client/extensions/woocommerce/app/settings/shipping/shipping-header.js
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-header.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 

--- a/client/extensions/woocommerce/app/settings/shipping/shipping-header.js
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-header.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 

--- a/client/extensions/woocommerce/app/settings/shipping/shipping-zone-list-entry.js
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-zone-list-entry.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import Gridicon from 'gridicons';
 import { localize } from 'i18n-calypso';

--- a/client/extensions/woocommerce/app/settings/shipping/shipping-zone-list-entry.js
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-zone-list-entry.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import { connect } from 'react-redux';
 import Gridicon from 'gridicons';
 import { localize } from 'i18n-calypso';

--- a/client/extensions/woocommerce/app/settings/shipping/shipping-zone/index.js
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-zone/index.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';

--- a/client/extensions/woocommerce/app/settings/shipping/shipping-zone/index.js
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-zone/index.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';

--- a/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-methods/flat-rate.js
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-methods/flat-rate.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React from 'react';
+import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
 import { isString } from 'lodash';

--- a/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-methods/flat-rate.js
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-methods/flat-rate.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
 import { isString } from 'lodash';

--- a/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-methods/free-shipping.js
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-methods/free-shipping.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
 

--- a/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-methods/free-shipping.js
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-methods/free-shipping.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React from 'react';
+import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
 

--- a/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-methods/local-pickup.js
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-methods/local-pickup.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
 

--- a/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-methods/local-pickup.js
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-methods/local-pickup.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React from 'react';
+import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
 

--- a/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-zone-header.js
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-zone-header.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React from 'react';
+import PropTypes from 'prop-types';
 import Gridicon from 'gridicons';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';

--- a/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-zone-header.js
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-zone-header.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import Gridicon from 'gridicons';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';

--- a/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-zone-location-dialog-countries.js
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-zone-location-dialog-countries.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';

--- a/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-zone-location-dialog-countries.js
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-zone-location-dialog-countries.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';

--- a/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-zone-location-dialog-settings.js
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-zone-location-dialog-settings.js
@@ -2,7 +2,9 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 

--- a/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-zone-location-dialog-settings.js
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-zone-location-dialog-settings.js
@@ -2,9 +2,8 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 

--- a/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-zone-location-dialog.js
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-zone-location-dialog.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 

--- a/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-zone-location-dialog.js
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-zone-location-dialog.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 

--- a/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-zone-location-list.js
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-zone-location-list.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { isEmpty } from 'lodash';

--- a/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-zone-location-list.js
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-zone-location-list.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { isEmpty } from 'lodash';

--- a/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-zone-method-dialog.js
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-zone-method-dialog.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'gridicons';

--- a/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-zone-method-dialog.js
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-zone-method-dialog.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'gridicons';

--- a/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-zone-method-list.js
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-zone-method-list.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 

--- a/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-zone-method-list.js
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-zone-method-list.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 

--- a/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-zone-name.js
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-zone-name.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 

--- a/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-zone-name.js
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-zone-name.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 

--- a/client/extensions/woocommerce/app/settings/taxes/index.js
+++ b/client/extensions/woocommerce/app/settings/taxes/index.js
@@ -1,10 +1,9 @@
-import { bindActionCreators } from 'redux';
-
 /**
  * External dependencies
  */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import { bindActionCreators } from 'redux';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';

--- a/client/extensions/woocommerce/app/settings/taxes/index.js
+++ b/client/extensions/woocommerce/app/settings/taxes/index.js
@@ -1,8 +1,11 @@
+import { bindActionCreators } from 'redux';
+
 /**
  * External dependencies
  */
-import { bindActionCreators } from 'redux';
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';

--- a/client/extensions/woocommerce/app/settings/taxes/index.js
+++ b/client/extensions/woocommerce/app/settings/taxes/index.js
@@ -3,9 +3,8 @@ import { bindActionCreators } from 'redux';
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';

--- a/client/extensions/woocommerce/app/settings/taxes/save-button.js
+++ b/client/extensions/woocommerce/app/settings/taxes/save-button.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';

--- a/client/extensions/woocommerce/app/settings/taxes/save-button.js
+++ b/client/extensions/woocommerce/app/settings/taxes/save-button.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';

--- a/client/extensions/woocommerce/app/settings/taxes/taxes-options.js
+++ b/client/extensions/woocommerce/app/settings/taxes/taxes-options.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
 
 /**

--- a/client/extensions/woocommerce/app/settings/taxes/taxes-options.js
+++ b/client/extensions/woocommerce/app/settings/taxes/taxes-options.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 
 /**

--- a/client/extensions/woocommerce/app/settings/taxes/taxes-rates.js
+++ b/client/extensions/woocommerce/app/settings/taxes/taxes-rates.js
@@ -1,11 +1,14 @@
-/**
- * External dependencies
- */
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { isEmpty, round } from 'lodash';
 import { localize } from 'i18n-calypso';
-import React, { Component, PropTypes } from 'react';
+
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import Gridicon from 'gridicons';
 
 /**

--- a/client/extensions/woocommerce/app/settings/taxes/taxes-rates.js
+++ b/client/extensions/woocommerce/app/settings/taxes/taxes-rates.js
@@ -1,13 +1,12 @@
-import { bindActionCreators } from 'redux';
-import { connect } from 'react-redux';
-import { isEmpty, round } from 'lodash';
-import { localize } from 'i18n-calypso';
-
 /**
  * External dependencies
  */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
+import { isEmpty, round } from 'lodash';
+import { localize } from 'i18n-calypso';
 import Gridicon from 'gridicons';
 
 /**

--- a/client/extensions/woocommerce/app/settings/taxes/taxes-rates.js
+++ b/client/extensions/woocommerce/app/settings/taxes/taxes-rates.js
@@ -6,9 +6,8 @@ import { localize } from 'i18n-calypso';
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import Gridicon from 'gridicons';
 
 /**

--- a/client/extensions/woocommerce/app/store-stats/index.js
+++ b/client/extensions/woocommerce/app/store-stats/index.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { moment, translate } from 'i18n-calypso';
 

--- a/client/extensions/woocommerce/app/store-stats/index.js
+++ b/client/extensions/woocommerce/app/store-stats/index.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { moment, translate } from 'i18n-calypso';
 

--- a/client/extensions/woocommerce/app/store-stats/listview.js
+++ b/client/extensions/woocommerce/app/store-stats/listview.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import page from 'page';
 import { connect } from 'react-redux';
 import { moment } from 'i18n-calypso';

--- a/client/extensions/woocommerce/app/store-stats/listview.js
+++ b/client/extensions/woocommerce/app/store-stats/listview.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import page from 'page';
 import { connect } from 'react-redux';
 import { moment } from 'i18n-calypso';

--- a/client/extensions/woocommerce/app/store-stats/store-stats-chart/index.js
+++ b/client/extensions/woocommerce/app/store-stats/store-stats-chart/index.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import classnames from 'classnames';
 import page from 'page';

--- a/client/extensions/woocommerce/app/store-stats/store-stats-chart/index.js
+++ b/client/extensions/woocommerce/app/store-stats/store-stats-chart/index.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import classnames from 'classnames';
 import page from 'page';

--- a/client/extensions/woocommerce/app/store-stats/store-stats-list/index.js
+++ b/client/extensions/woocommerce/app/store-stats/store-stats-list/index.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import { connect } from 'react-redux';
 
 /**

--- a/client/extensions/woocommerce/app/store-stats/store-stats-list/index.js
+++ b/client/extensions/woocommerce/app/store-stats/store-stats-list/index.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
 /**

--- a/client/extensions/woocommerce/app/store-stats/store-stats-module/index.js
+++ b/client/extensions/woocommerce/app/store-stats/store-stats-module/index.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { isEqual } from 'lodash';
 

--- a/client/extensions/woocommerce/app/store-stats/store-stats-module/index.js
+++ b/client/extensions/woocommerce/app/store-stats/store-stats-module/index.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { PropTypes, Component } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { isEqual } from 'lodash';
 

--- a/client/extensions/woocommerce/app/store-stats/store-stats-navigation/index.js
+++ b/client/extensions/woocommerce/app/store-stats/store-stats-navigation/index.js
@@ -1,7 +1,9 @@
 /**
  * External Dependencies
  */
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import { localize } from 'i18n-calypso';
 
 /**

--- a/client/extensions/woocommerce/app/store-stats/store-stats-navigation/index.js
+++ b/client/extensions/woocommerce/app/store-stats/store-stats-navigation/index.js
@@ -1,9 +1,8 @@
 /**
  * External Dependencies
  */
-import PropTypes from 'prop-types';
-
 import React from 'react';
+import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 
 /**

--- a/client/extensions/woocommerce/app/store-stats/store-stats-navigation/navtabs.js
+++ b/client/extensions/woocommerce/app/store-stats/store-stats-navigation/navtabs.js
@@ -1,7 +1,9 @@
 /**
  * External Dependencies
  */
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 
 /**
  * Internal dependencies

--- a/client/extensions/woocommerce/app/store-stats/store-stats-navigation/navtabs.js
+++ b/client/extensions/woocommerce/app/store-stats/store-stats-navigation/navtabs.js
@@ -1,9 +1,8 @@
 /**
  * External Dependencies
  */
-import PropTypes from 'prop-types';
-
 import React from 'react';
+import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies

--- a/client/extensions/woocommerce/app/store-stats/store-stats-widget-list/index.js
+++ b/client/extensions/woocommerce/app/store-stats/store-stats-widget-list/index.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { connect } from 'react-redux';
 import { findIndex } from 'lodash';

--- a/client/extensions/woocommerce/app/store-stats/store-stats-widget-list/index.js
+++ b/client/extensions/woocommerce/app/store-stats/store-stats-widget-list/index.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { PropTypes, Component } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import classnames from 'classnames';
 import { connect } from 'react-redux';
 import { findIndex } from 'lodash';

--- a/client/extensions/woocommerce/components/action-header/index.js
+++ b/client/extensions/woocommerce/components/action-header/index.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import { isArray } from 'lodash';
 
 /**

--- a/client/extensions/woocommerce/components/action-header/index.js
+++ b/client/extensions/woocommerce/components/action-header/index.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React from 'react';
+import PropTypes from 'prop-types';
 import { isArray } from 'lodash';
 
 /**

--- a/client/extensions/woocommerce/components/address-view/index.js
+++ b/client/extensions/woocommerce/components/address-view/index.js
@@ -4,9 +4,8 @@ import { localize } from 'i18n-calypso';
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { find } from 'lodash';
 
 /**

--- a/client/extensions/woocommerce/components/address-view/index.js
+++ b/client/extensions/woocommerce/components/address-view/index.js
@@ -1,11 +1,10 @@
-import classNames from 'classnames';
-import { localize } from 'i18n-calypso';
-
 /**
  * External dependencies
  */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import { localize } from 'i18n-calypso';
 import { find } from 'lodash';
 
 /**

--- a/client/extensions/woocommerce/components/address-view/index.js
+++ b/client/extensions/woocommerce/components/address-view/index.js
@@ -1,9 +1,12 @@
+import classNames from 'classnames';
+import { localize } from 'i18n-calypso';
+
 /**
  * External dependencies
  */
-import classNames from 'classnames';
-import { localize } from 'i18n-calypso';
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import { find } from 'lodash';
 
 /**

--- a/client/extensions/woocommerce/components/basic-widget/index.js
+++ b/client/extensions/woocommerce/components/basic-widget/index.js
@@ -1,10 +1,9 @@
-import classNames from 'classnames';
-
 /**
  * External dependencies
  */
 import React from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 import { noop } from 'lodash';
 
 /**

--- a/client/extensions/woocommerce/components/basic-widget/index.js
+++ b/client/extensions/woocommerce/components/basic-widget/index.js
@@ -1,8 +1,11 @@
+import classNames from 'classnames';
+
 /**
  * External dependencies
  */
-import classNames from 'classnames';
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import { noop } from 'lodash';
 
 /**

--- a/client/extensions/woocommerce/components/basic-widget/index.js
+++ b/client/extensions/woocommerce/components/basic-widget/index.js
@@ -3,9 +3,8 @@ import classNames from 'classnames';
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React from 'react';
+import PropTypes from 'prop-types';
 import { noop } from 'lodash';
 
 /**

--- a/client/extensions/woocommerce/components/bulk-select/index.js
+++ b/client/extensions/woocommerce/components/bulk-select/index.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import classNames from 'classnames';
 import Gridicon from 'gridicons';
 

--- a/client/extensions/woocommerce/components/bulk-select/index.js
+++ b/client/extensions/woocommerce/components/bulk-select/index.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import Gridicon from 'gridicons';
 

--- a/client/extensions/woocommerce/components/compact-tinymce/index.js
+++ b/client/extensions/woocommerce/components/compact-tinymce/index.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { assign, uniqueId, noop } from 'lodash';
 import classNames from 'classnames';
 import tinymce from 'tinymce/tinymce';

--- a/client/extensions/woocommerce/components/compact-tinymce/index.js
+++ b/client/extensions/woocommerce/components/compact-tinymce/index.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import { assign, uniqueId, noop } from 'lodash';
 import classNames from 'classnames';
 import tinymce from 'tinymce/tinymce';

--- a/client/extensions/woocommerce/components/delta/index.js
+++ b/client/extensions/woocommerce/components/delta/index.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import classnames from 'classnames';
 import Gridicon from 'gridicons';
 import { includes } from 'lodash';

--- a/client/extensions/woocommerce/components/delta/index.js
+++ b/client/extensions/woocommerce/components/delta/index.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import Gridicon from 'gridicons';
 import { includes } from 'lodash';

--- a/client/extensions/woocommerce/components/filtered-list/index.js
+++ b/client/extensions/woocommerce/components/filtered-list/index.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import { filter, startsWith } from 'lodash';
 import classNames from 'classnames';
 

--- a/client/extensions/woocommerce/components/filtered-list/index.js
+++ b/client/extensions/woocommerce/components/filtered-list/index.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { filter, startsWith } from 'lodash';
 import classNames from 'classnames';
 

--- a/client/extensions/woocommerce/components/form-click-to-edit-input/index.js
+++ b/client/extensions/woocommerce/components/form-click-to-edit-input/index.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import classNames from 'classnames';
 import Gridicon from 'gridicons';
 import { noop, omit } from 'lodash';

--- a/client/extensions/woocommerce/components/form-click-to-edit-input/index.js
+++ b/client/extensions/woocommerce/components/form-click-to-edit-input/index.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import Gridicon from 'gridicons';
 import { noop, omit } from 'lodash';

--- a/client/extensions/woocommerce/components/form-weight-input/index.js
+++ b/client/extensions/woocommerce/components/form-weight-input/index.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import classNames from 'classnames';

--- a/client/extensions/woocommerce/components/form-weight-input/index.js
+++ b/client/extensions/woocommerce/components/form-weight-input/index.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import classNames from 'classnames';

--- a/client/extensions/woocommerce/components/list/list-item-field/index.js
+++ b/client/extensions/woocommerce/components/list/list-item-field/index.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import classNames from 'classnames';
 
 const ListItemField = ( { children, className } ) => {

--- a/client/extensions/woocommerce/components/list/list-item-field/index.js
+++ b/client/extensions/woocommerce/components/list/list-item-field/index.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 const ListItemField = ( { children, className } ) => {

--- a/client/extensions/woocommerce/components/location-flag/index.js
+++ b/client/extensions/woocommerce/components/location-flag/index.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import classNames from 'classnames';
 
 class LocationFlag extends Component {

--- a/client/extensions/woocommerce/components/location-flag/index.js
+++ b/client/extensions/woocommerce/components/location-flag/index.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 class LocationFlag extends Component {

--- a/client/extensions/woocommerce/components/price-input/index.js
+++ b/client/extensions/woocommerce/components/price-input/index.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { omit } from 'lodash';
 import { connect } from 'react-redux';
 

--- a/client/extensions/woocommerce/components/price-input/index.js
+++ b/client/extensions/woocommerce/components/price-input/index.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import { omit } from 'lodash';
 import { connect } from 'react-redux';
 

--- a/client/extensions/woocommerce/components/process-orders-widget/index.js
+++ b/client/extensions/woocommerce/components/process-orders-widget/index.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 

--- a/client/extensions/woocommerce/components/process-orders-widget/index.js
+++ b/client/extensions/woocommerce/components/process-orders-widget/index.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 

--- a/client/extensions/woocommerce/components/product-image-uploader/index.js
+++ b/client/extensions/woocommerce/components/product-image-uploader/index.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
 import { head, uniqueId, find, noop, trim } from 'lodash';

--- a/client/extensions/woocommerce/components/product-image-uploader/index.js
+++ b/client/extensions/woocommerce/components/product-image-uploader/index.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
 import { head, uniqueId, find, noop, trim } from 'lodash';

--- a/client/extensions/woocommerce/components/query-settings-general/index.js
+++ b/client/extensions/woocommerce/components/query-settings-general/index.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import { Component } from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { localize } from 'i18n-calypso';

--- a/client/extensions/woocommerce/components/query-settings-general/index.js
+++ b/client/extensions/woocommerce/components/query-settings-general/index.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import { Component } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { localize } from 'i18n-calypso';

--- a/client/extensions/woocommerce/components/query-shipping-zones/index.js
+++ b/client/extensions/woocommerce/components/query-shipping-zones/index.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import { Component } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 

--- a/client/extensions/woocommerce/components/query-shipping-zones/index.js
+++ b/client/extensions/woocommerce/components/query-shipping-zones/index.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import { Component } from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 

--- a/client/extensions/woocommerce/components/reading-widget/index.js
+++ b/client/extensions/woocommerce/components/reading-widget/index.js
@@ -5,9 +5,8 @@ import { localize } from 'i18n-calypso';
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies

--- a/client/extensions/woocommerce/components/reading-widget/index.js
+++ b/client/extensions/woocommerce/components/reading-widget/index.js
@@ -1,12 +1,11 @@
-import { connect } from 'react-redux';
-import emailValidator from 'email-validator';
-import { localize } from 'i18n-calypso';
-
 /**
  * External dependencies
  */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import emailValidator from 'email-validator';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies

--- a/client/extensions/woocommerce/components/reading-widget/index.js
+++ b/client/extensions/woocommerce/components/reading-widget/index.js
@@ -1,10 +1,13 @@
-/**
- * External dependencies
- */
 import { connect } from 'react-redux';
 import emailValidator from 'email-validator';
 import { localize } from 'i18n-calypso';
-import React, { Component, PropTypes } from 'react';
+
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 
 /**
  * Internal dependencies

--- a/client/extensions/woocommerce/components/share-widget/index.js
+++ b/client/extensions/woocommerce/components/share-widget/index.js
@@ -4,9 +4,8 @@ import { localize } from 'i18n-calypso';
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import SocialLogo from 'social-logos';
 import url from 'url';
 

--- a/client/extensions/woocommerce/components/share-widget/index.js
+++ b/client/extensions/woocommerce/components/share-widget/index.js
@@ -1,11 +1,10 @@
-import config from 'config';
-import { localize } from 'i18n-calypso';
-
 /**
  * External dependencies
  */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import config from 'config';
+import { localize } from 'i18n-calypso';
 import SocialLogo from 'social-logos';
 import url from 'url';
 

--- a/client/extensions/woocommerce/components/share-widget/index.js
+++ b/client/extensions/woocommerce/components/share-widget/index.js
@@ -1,9 +1,12 @@
+import config from 'config';
+import { localize } from 'i18n-calypso';
+
 /**
  * External dependencies
  */
-import config from 'config';
-import { localize } from 'i18n-calypso';
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import SocialLogo from 'social-logos';
 import url from 'url';
 

--- a/client/extensions/woocommerce/components/sparkline/index.js
+++ b/client/extensions/woocommerce/components/sparkline/index.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { PropTypes, Component } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import classNames from 'classnames';
 import { extent as d3Extent } from 'd3-array';
 import { scaleLinear as d3ScaleLinear } from 'd3-scale';

--- a/client/extensions/woocommerce/components/sparkline/index.js
+++ b/client/extensions/woocommerce/components/sparkline/index.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { extent as d3Extent } from 'd3-array';
 import { scaleLinear as d3ScaleLinear } from 'd3-scale';

--- a/client/extensions/woocommerce/components/table/index.js
+++ b/client/extensions/woocommerce/components/table/index.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import classnames from 'classnames';
 
 /**

--- a/client/extensions/woocommerce/components/table/index.js
+++ b/client/extensions/woocommerce/components/table/index.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
 /**

--- a/client/extensions/woocommerce/components/table/table-item/index.js
+++ b/client/extensions/woocommerce/components/table/table-item/index.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 function getScope( isHeader, isRowHeader ) {

--- a/client/extensions/woocommerce/components/table/table-item/index.js
+++ b/client/extensions/woocommerce/components/table/table-item/index.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import classNames from 'classnames';
 
 function getScope( isHeader, isRowHeader ) {

--- a/client/extensions/woocommerce/components/table/table-row/index.js
+++ b/client/extensions/woocommerce/components/table/table-row/index.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import page from 'page';
 

--- a/client/extensions/woocommerce/components/table/table-row/index.js
+++ b/client/extensions/woocommerce/components/table/table-row/index.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import classnames from 'classnames';
 import page from 'page';
 

--- a/client/extensions/woocommerce/components/widget-group/index.js
+++ b/client/extensions/woocommerce/components/widget-group/index.js
@@ -1,10 +1,9 @@
-import classNames from 'classnames';
-
 /**
  * External dependencies
  */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 
 class WidgetGroup extends Component {
 	static defaultProps = {

--- a/client/extensions/woocommerce/components/widget-group/index.js
+++ b/client/extensions/woocommerce/components/widget-group/index.js
@@ -1,8 +1,11 @@
+import classNames from 'classnames';
+
 /**
  * External dependencies
  */
-import classNames from 'classnames';
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 
 class WidgetGroup extends Component {
 	static defaultProps = {

--- a/client/extensions/woocommerce/components/widget-group/index.js
+++ b/client/extensions/woocommerce/components/widget-group/index.js
@@ -3,9 +3,8 @@ import classNames from 'classnames';
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
 class WidgetGroup extends Component {
 	static defaultProps = {

--- a/client/extensions/woocommerce/store-sidebar/index.js
+++ b/client/extensions/woocommerce/store-sidebar/index.js
@@ -1,12 +1,11 @@
-import { bindActionCreators } from 'redux';
-import classNames from 'classnames';
-import { connect } from 'react-redux';
-
 /**
  * External dependencies
  */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import { bindActionCreators } from 'redux';
+import classNames from 'classnames';
+import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
 /**

--- a/client/extensions/woocommerce/store-sidebar/index.js
+++ b/client/extensions/woocommerce/store-sidebar/index.js
@@ -5,9 +5,8 @@ import { connect } from 'react-redux';
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 
 /**

--- a/client/extensions/woocommerce/store-sidebar/index.js
+++ b/client/extensions/woocommerce/store-sidebar/index.js
@@ -1,10 +1,13 @@
-/**
- * External dependencies
- */
 import { bindActionCreators } from 'redux';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
-import React, { Component, PropTypes } from 'react';
+
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
 
 /**

--- a/client/extensions/woocommerce/store-sidebar/store-ground-control.js
+++ b/client/extensions/woocommerce/store-sidebar/store-ground-control.js
@@ -1,6 +1,8 @@
 /**
  * External dependencies
  */
+import PropTypes from 'prop-types';
+
 import React from 'react';
 import { localize } from 'i18n-calypso';
 
@@ -40,8 +42,8 @@ const StoreGroundControl = ( { site, translate } ) => {
 };
 
 StoreGroundControl.propTypes = {
-	site: React.PropTypes.shape( {
-		slug: React.PropTypes.string,
+	site: PropTypes.shape( {
+		slug: PropTypes.string,
 	} ),
 };
 

--- a/client/extensions/woocommerce/store-sidebar/store-ground-control.js
+++ b/client/extensions/woocommerce/store-sidebar/store-ground-control.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React from 'react';
+import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 
 /**

--- a/client/extensions/woocommerce/woocommerce-services/views/label-settings/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/label-settings/index.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import classNames from 'classnames';

--- a/client/extensions/woocommerce/woocommerce-services/views/label-settings/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/label-settings/index.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { PropTypes, Component } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import classNames from 'classnames';

--- a/client/extensions/woocommerce/woocommerce-services/views/label-settings/label-payment-method.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/label-settings/label-payment-method.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import { localize } from 'i18n-calypso';
 
 /**

--- a/client/extensions/woocommerce/woocommerce-services/views/label-settings/label-payment-method.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/label-settings/label-payment-method.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React from 'react';
+import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 
 /**

--- a/client/extensions/woocommerce/woocommerce-services/views/label-settings/label-settings.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/label-settings/label-settings.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { PropTypes, Component } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
 import { find } from 'lodash';
 

--- a/client/extensions/woocommerce/woocommerce-services/views/label-settings/label-settings.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/label-settings/label-settings.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import { find } from 'lodash';
 

--- a/client/extensions/woocommerce/woocommerce-services/views/packages/shipping-package.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/packages/shipping-package.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import Gridicon from 'gridicons';
 import { localize } from 'i18n-calypso';
 

--- a/client/extensions/woocommerce/woocommerce-services/views/packages/shipping-package.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/packages/shipping-package.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React from 'react';
+import PropTypes from 'prop-types';
 import Gridicon from 'gridicons';
 import { localize } from 'i18n-calypso';
 

--- a/client/layout/guided-tours/config-elements/continue.js
+++ b/client/layout/guided-tours/config-elements/continue.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import { translate } from 'i18n-calypso';
 import Gridicon from 'gridicons';
 

--- a/client/layout/guided-tours/config-elements/continue.js
+++ b/client/layout/guided-tours/config-elements/continue.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { translate } from 'i18n-calypso';
 import Gridicon from 'gridicons';
 

--- a/client/layout/guided-tours/config-elements/link-quit.js
+++ b/client/layout/guided-tours/config-elements/link-quit.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import { translate } from 'i18n-calypso';
 import classNames from 'classnames';
 

--- a/client/layout/guided-tours/config-elements/link-quit.js
+++ b/client/layout/guided-tours/config-elements/link-quit.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { translate } from 'i18n-calypso';
 import classNames from 'classnames';
 

--- a/client/layout/guided-tours/config-elements/make-tour.js
+++ b/client/layout/guided-tours/config-elements/make-tour.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import { Component } from 'react';
 import {
 	isEmpty,
 	omit,

--- a/client/layout/guided-tours/config-elements/make-tour.js
+++ b/client/layout/guided-tours/config-elements/make-tour.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import { Component } from 'react';
+import PropTypes from 'prop-types';
 import {
 	isEmpty,
 	omit,

--- a/client/layout/guided-tours/config-elements/next.js
+++ b/client/layout/guided-tours/config-elements/next.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { translate } from 'i18n-calypso';
 
 /**

--- a/client/layout/guided-tours/config-elements/next.js
+++ b/client/layout/guided-tours/config-elements/next.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import { translate } from 'i18n-calypso';
 
 /**

--- a/client/layout/guided-tours/config-elements/quit.js
+++ b/client/layout/guided-tours/config-elements/quit.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { translate } from 'i18n-calypso';
 
 /**

--- a/client/layout/guided-tours/config-elements/quit.js
+++ b/client/layout/guided-tours/config-elements/quit.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import { translate } from 'i18n-calypso';
 
 /**

--- a/client/layout/guided-tours/config-elements/step.js
+++ b/client/layout/guided-tours/config-elements/step.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import {
 	debounce,

--- a/client/layout/guided-tours/config-elements/step.js
+++ b/client/layout/guided-tours/config-elements/step.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import classNames from 'classnames';
 import {
 	debounce,

--- a/client/layout/guided-tours/config-elements/tour.js
+++ b/client/layout/guided-tours/config-elements/tour.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import { Component } from 'react';
 import {
 	find,
 } from 'lodash';

--- a/client/layout/guided-tours/config-elements/tour.js
+++ b/client/layout/guided-tours/config-elements/tour.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import { Component } from 'react';
+import PropTypes from 'prop-types';
 import {
 	find,
 } from 'lodash';

--- a/client/layout/guided-tours/context-types.js
+++ b/client/layout/guided-tours/context-types.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { PropTypes } from 'react';
+import PropTypes from 'prop-types';
 
 export default Object.freeze( {
 	branching: PropTypes.object.isRequired,

--- a/client/lib/interval/index.js
+++ b/client/lib/interval/index.js
@@ -1,6 +1,13 @@
-import React, { PropTypes } from 'react';
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import React from 'react';
 import omit from 'lodash/omit';
 
+/**
+ * Internal dependencies
+ */
 import {
 	add, remove,
 	EVERY_SECOND,

--- a/client/lib/reader-connect-site/index.js
+++ b/client/lib/reader-connect-site/index.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
 /*

--- a/client/lib/reader-connect-site/index.js
+++ b/client/lib/reader-connect-site/index.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import { connect } from 'react-redux';
 
 /*

--- a/client/lib/reader-post-flux-adapter/index.js
+++ b/client/lib/reader-post-flux-adapter/index.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React from 'react';
+import PropTypes from 'prop-types';
 import { map } from 'lodash';
 import { connect } from 'react-redux';
 

--- a/client/lib/reader-post-flux-adapter/index.js
+++ b/client/lib/reader-post-flux-adapter/index.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import { map } from 'lodash';
 import { connect } from 'react-redux';
 

--- a/client/my-sites/design-preview/index.js
+++ b/client/my-sites/design-preview/index.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import { connect } from 'react-redux';
 import debugFactory from 'debug';
 import page from 'page';

--- a/client/my-sites/design-preview/index.js
+++ b/client/my-sites/design-preview/index.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import debugFactory from 'debug';
 import page from 'page';

--- a/client/my-sites/media-library/list-plan-promo.js
+++ b/client/my-sites/media-library/list-plan-promo.js
@@ -1,6 +1,8 @@
 /**
  * External dependencies
  */
+import PropTypes from 'prop-types';
+
 import React from 'react';
 import page from 'page';
 import analytics from 'lib/analytics';
@@ -16,8 +18,8 @@ module.exports = React.createClass( {
 	displayName: 'MediaLibraryListPlanPromo',
 
 	propTypes: {
-		site: React.PropTypes.object,
-		filter: React.PropTypes.string
+		site: PropTypes.object,
+		filter: PropTypes.string
 	},
 
 	getTitle: function() {

--- a/client/my-sites/media-library/list-plan-promo.js
+++ b/client/my-sites/media-library/list-plan-promo.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React from 'react';
+import PropTypes from 'prop-types';
 import page from 'page';
 import analytics from 'lib/analytics';
 import { preventWidows } from 'lib/formatting';

--- a/client/my-sites/pages/page/index.js
+++ b/client/my-sites/pages/page/index.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import ReactCSSTransitionGroup from 'react-addons-css-transition-group';
 import createFragment from 'react-addons-create-fragment';
 import { localize } from 'i18n-calypso';

--- a/client/my-sites/pages/page/index.js
+++ b/client/my-sites/pages/page/index.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import ReactCSSTransitionGroup from 'react-addons-css-transition-group';
 import createFragment from 'react-addons-create-fragment';
 import { localize } from 'i18n-calypso';

--- a/client/my-sites/sharing/connections/services/eventbrite.js
+++ b/client/my-sites/sharing/connections/services/eventbrite.js
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
 import { last, isEqual } from 'lodash';
 
 /**

--- a/client/my-sites/sharing/connections/services/eventbrite.js
+++ b/client/my-sites/sharing/connections/services/eventbrite.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
-
 import { last, isEqual } from 'lodash';
 
 /**

--- a/client/my-sites/sharing/connections/services/google-photos.js
+++ b/client/my-sites/sharing/connections/services/google-photos.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import { last, isEqual } from 'lodash';
 
 /**

--- a/client/my-sites/sharing/connections/services/google-photos.js
+++ b/client/my-sites/sharing/connections/services/google-photos.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React from 'react';
+import PropTypes from 'prop-types';
 import { last, isEqual } from 'lodash';
 
 /**

--- a/client/my-sites/sharing/connections/services/instagram.js
+++ b/client/my-sites/sharing/connections/services/instagram.js
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
 import { last, isEqual } from 'lodash';
 
 /**

--- a/client/my-sites/sharing/connections/services/instagram.js
+++ b/client/my-sites/sharing/connections/services/instagram.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
-
 import { last, isEqual } from 'lodash';
 
 /**


### PR DESCRIPTION
Run the PropTypes codemod according to [official instructions](https://github.com/reactjs/react-codemod#react-proptypes-to-prop-types).

Also fixes an External/Internal dependecies comment block lint issue.

`React.PropTypes` will be depreceted in [React 15.5](https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html#react).

`PropTypes` will be moving into the `prop-types` module, which has been included in Calypso at least since 3adac1146e.

It's a bit unfortunate that the output is the following:

```js
import PropTypes from 'prop-types';

import React from 'react';
```

I would have preferred:

```js
import React from 'react';
import PropTypes from 'prop-types';
```

## Testing

Ensure the project builds, tests pass, and that `propTypes` validation continues to work as before.