### PR TITLE
Store: Fix prompt when deleting a product with local edits

### DIFF
--- a/client/extensions/woocommerce/state/ui/products/edits-reducer.js
+++ b/client/extensions/woocommerce/state/ui/products/edits-reducer.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { compact, isEqual, uniqueId } from 'lodash';
+import { compact, isEqual, uniqueId, filter } from 'lodash';
 import { createReducer } from 'state/utils';
 
 /**
@@ -9,6 +9,7 @@ import { createReducer } from 'state/utils';
  */
 import {
 	WOOCOMMERCE_PRODUCT_CREATE,
+	WOOCOMMERCE_PRODUCT_DELETE,
 	WOOCOMMERCE_PRODUCT_EDIT,
 	WOOCOMMERCE_PRODUCT_EDIT_CLEAR,
 	WOOCOMMERCE_PRODUCT_UPDATE,
@@ -21,6 +22,7 @@ import { getBucket } from '../helpers';
 
 export default createReducer( null, {
 	[ WOOCOMMERCE_PRODUCT_EDIT ]: editProductAction,
+	[ WOOCOMMERCE_PRODUCT_DELETE ]: deleteProductAction,
 	[ WOOCOMMERCE_PRODUCT_EDIT_CLEAR ]: clearEditsAction,
 	[ WOOCOMMERCE_PRODUCT_UPDATED ]: productUpdatedAction,
 	[ WOOCOMMERCE_PRODUCT_ATTRIBUTE_EDIT ]: editProductAttributeAction,
@@ -176,4 +178,18 @@ export function editProductAttribute( attributes, attribute, data ) {
 	}
 
 	return _attributes;
+}
+
+export function deleteProductAction( edits, action ) {
+	const { productId } = action;
+	const prevEdits = edits || {};
+
+	if ( prevEdits && prevEdits.updates ) {
+		const newUpdates = filter( prevEdits.updates, product => product.id !== productId );
+		return { ...prevEdits,
+			updates: newUpdates,
+		};
+	}
+
+	return edits;
 }

--- a/client/extensions/woocommerce/state/ui/products/test/edits-reducer.js
+++ b/client/extensions/woocommerce/state/ui/products/test/edits-reducer.js
@@ -21,6 +21,9 @@ import {
 	createProductCategory,
 	productCategoryUpdated,
 } from 'woocommerce/state/sites/product-categories/actions';
+import {
+	WOOCOMMERCE_PRODUCT_DELETE,
+} from 'woocommerce/state/action-types';
 
 const siteId = 123;
 
@@ -363,5 +366,33 @@ describe( 'edits-reducer', () => {
 		expect( edits1.updates ).to.exist;
 		expect( edits1.deletes ).to.exist;
 		expect( edits2 ).to.equal( null );
+	} );
+
+	it( 'should clear product from updates upon successful delete', () => {
+		const product1 = {
+			id: 5,
+			name: 'Product 1',
+		};
+
+		const product2 = {
+			id: 6,
+			name: 'Product 2',
+		};
+
+		const edits1 = {
+			updates: [ product1, product2 ],
+		};
+
+		const action = {
+			type: WOOCOMMERCE_PRODUCT_DELETE,
+			siteId,
+			productId: 6,
+		};
+
+		const edits2 = reducer( edits1, action );
+
+		expect( edits1.updates[ 0 ] ).to.eql( product1 );
+		expect( edits1.updates[ 1 ] ).to.eql( product2 );
+		expect( edits2.updates.length ).to.eql( 1 );
 	} );
 } );


### PR DESCRIPTION
Fixes #16780.

This PR clears the update edits state for a product when it is deleted. This prevents the "you have unsaved changes" dialog from showing if you make a few changes to the product update form and then decide to delete.

To Test:
* Run `npm run test-client client/extensions/woocommerce/state` and make sure all tests pass.
* Create and save a test product
* Go to the edit page for your product
* Update it (e.g. the description), but don't save it
* Delete the product
* Make sure you don't get the "you have unsaved changes" dialog before being redirected
