### PR TITLE
Media: tag transient images with data-istransient attribute

### DIFF
--- a/client/lib/media-serialization/strategies/dom.js
+++ b/client/lib/media-serialization/strategies/dom.js
@@ -21,7 +21,9 @@ function parseImage( node, _parsed ) {
 	_parsed.type = MediaTypes.IMAGE;
 	_parsed.media.URL = node.getAttribute( 'src' );
 	_parsed.media.alt = node.getAttribute( 'alt' );
-	_parsed.media.transient = ( 0 === ( _parsed.media.URL || '' ).indexOf( 'blob:' ) );
+	// consider data-istransient a boolean attribute https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#boolean-attribute
+	// will only be false if it doesn't exist
+	_parsed.media.transient = node.hasAttribute( 'data-istransient' );
 
 	// Parse dimensions
 	[ 'width', 'height' ].forEach( ( dimension ) => {

--- a/client/lib/media-serialization/test/index.js
+++ b/client/lib/media-serialization/test/index.js
@@ -63,10 +63,16 @@ describe( 'MediaSerialization', function() {
 			expect( parsed.appearance.align ).to.equal( 'right' );
 		} );
 
-		it( 'should detect transient images', function() {
-			const parsed = deserialize( '<img src="blob:http%3A//wordpress.com/75205e1a-0f78-4a0b-b0e2-5f47a3471769" class="size-full wp-image-1627 alignright" alt="Example" width="660" height="660" />' );
+		it( 'should parse images with the data-istransient attribute as transient images', function() {
+			const parsed = deserialize( '<img data-istransient="istransient" src="https://andrewmduthietest.files.wordpress.com/2015/01/img_0372.jpg" class="size-full wp-image-1627 alignright" alt="Example" width="660" height="660" />' ); // eslint-disable-line max-len
 
 			expect( parsed.media.transient ).to.be.true;
+		} );
+
+		it( 'should parse images without the data-istransient attribute as not transient images', function() {
+			const parsed = deserialize( '<img src="blob:http%3A//wordpress.com/75205e1a-0f78-4a0b-b0e2-5f47a3471769" class="size-full wp-image-1627 alignright" alt="Example" width="660" height="660" />' ); // eslint-disable-line max-len
+
+			expect( parsed.media.transient ).to.be.false;
 		} );
 
 		it( 'should favor natural dimensions over inferred', function() {

--- a/client/post-editor/media-modal/markup.js
+++ b/client/post-editor/media-modal/markup.js
@@ -153,7 +153,10 @@ Markup = {
 				alt: media.alt || media.title,
 				width: isFinite( width ) ? width : null,
 				height: isFinite( height ) ? height : null,
-				className: classNames( 'align' + options.align, 'size-' + options.size, 'wp-image-' + media.ID )
+				className: classNames( 'align' + options.align, 'size-' + options.size, 'wp-image-' + media.ID ),
+				// make data-istransient a boolean att https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#boolean-attribute
+				// it is false if it doesn't exist
+				'data-istransient': media.transient ? 'istransient' : null
 			} );
 
 			let markup = ReactDomServer.renderToStaticMarkup( img );

--- a/client/post-editor/media-modal/test/markup.js
+++ b/client/post-editor/media-modal/test/markup.js
@@ -107,11 +107,11 @@ describe( 'markup', function() {
 			it( 'should not set width auto if media width cannot be determined', function() {
 				var value = markup.mimeTypes.image( site, {
 					ID: 'media-4',
-					URL: 'blob:http%3A//example.com/ddd1d6b0-f31b-4937-ae9e-97f1d660cf71',
+					URL: 'http%3A//example.com/ddd1d6b0-f31b-4937-ae9e-97f1d660cf71',
 					thumbnails: {}
 				} );
 
-				expect( value ).to.equal( '<img src="blob:http%3A//example.com/ddd1d6b0-f31b-4937-ae9e-97f1d660cf71" class="alignnone size-full wp-image-media-4"/>' );
+				expect( value ).to.equal( '<img src="http%3A//example.com/ddd1d6b0-f31b-4937-ae9e-97f1d660cf71" class="alignnone size-full wp-image-media-4"/>' ); // eslint-disable-line max-len
 			} );
 
 			it( 'should return an img element for an image', function() {
@@ -248,6 +248,35 @@ describe( 'markup', function() {
 
 				expect( value ).to.equal( '<img src="https://s1.wp.com/wp-content/themes/a8c/automattic-2011/images/automattic-logo.png?w=1024" alt="Automattic" width="1024" height="111" class="alignnone size-large wp-image-1"/>' );
 			} );
+
+			it( 'should include a data-istransient="istransient" attribute when media.transient is truthy', function() {
+				const value = markup.mimeTypes.image( site, {
+					ID: 1,
+					URL: 'https://s1.wp.com/wp-content/themes/a8c/automattic-2011/images/automattic-logo.png',
+					alt: 'Automattic',
+					thumbnails: {},
+					width: 2760,
+					height: 300,
+					'transient': true
+				} );
+
+				expect( value ).to.equal( '<img src="https://s1.wp.com/wp-content/themes/a8c/automattic-2011/images/automattic-logo.png" alt="Automattic" width="2760" height="300" class="alignnone size-full wp-image-1" data-istransient="istransient"/>' ); // eslint-disable-line max-len
+			} );
+
+			it( 'should not include a data-istransient attribute when media.transient is falsy', function() {
+				const value = markup.mimeTypes.image( site, {
+					ID: 1,
+					URL: 'https://s1.wp.com/wp-content/themes/a8c/automattic-2011/images/automattic-logo.png',
+					alt: 'Automattic',
+					thumbnails: {},
+					width: 2760,
+					height: 300,
+					'transient': false
+				} );
+
+				expect( value ).to.equal( '<img src="https://s1.wp.com/wp-content/themes/a8c/automattic-2011/images/automattic-logo.png" alt="Automattic" width="2760" height="300" class="alignnone size-full wp-image-1"/>' ); // eslint-disable-line max-len
+			} );
+
 		} );
 
 		describe( '#audio()', function() {


### PR DESCRIPTION
Part of fixing https://github.com/Automattic/wp-calypso/pull/16986

In adding support for external services in the media-library, transients from these services won't have the SRC as a blob but an external URL. We need to update how we tag and detect transients to incorporate this new use case.

This proposal uses a `data-istransient` attribute to serialize/deserialize images into/from markup.

## Testing 

**Automatted** 

`npm run test-client client/post-editor/media-modal/test/markup.js`
`npm run test-client client/lib/media-serialization/test/index.js`

**Manual**

* Upload an image from your local library.
* Quickly insert it in the editor, before its upload is completed.
* Check that the transient image is included in the editor, its src is a blob, contains the class `wp-image-media-transientid`, and has the attribute `data-istransient="istransient"`.
* Upon finishing the upload, check that the URL changes to the one provided by the media library, the classname is updated to `wp-image-id`, and doesn't have the `data-istransient` attribute.



