### PR TITLE
Editor: Remove post format icon from editor action bar

### DIFF
--- a/client/post-editor/editor-action-bar/index.jsx
+++ b/client/post-editor/editor-action-bar/index.jsx
@@ -13,7 +13,6 @@ import EditorSticky from 'post-editor/editor-sticky';
 import utils from 'lib/posts/utils';
 import Tooltip from 'components/tooltip';
 import Button from 'components/button';
-import PostFormat from 'components/post-format';
 import EditorActionBarViewLabel from './view-label';
 import EditorStatusLabel from 'post-editor/editor-status-label';
 import { getSelectedSiteId } from 'state/ui/selectors';
@@ -43,8 +42,7 @@ class EditorActionBar extends Component {
 		// update based on post changes. Flux changes are passed down from parent components.
 		const multiUserSite = this.props.site && ! this.props.site.single_user_site;
 		const isPasswordProtected = utils.getVisibility( this.props.post ) === 'password';
-		const { isPostPrivate, post, postAuthor } = this.props;
-		const postFormat = post && post.format;
+		const { isPostPrivate, postAuthor } = this.props;
 
 		return (
 			<div className="editor-action-bar">
@@ -70,7 +68,6 @@ class EditorActionBar extends Component {
 						! isPasswordProtected && ! isPostPrivate &&
 						<EditorSticky />
 					}
-					<PostFormat format={ postFormat } size={ 26 } />
 					{ utils.isPublished( this.props.savedPost ) && (
 						<Button
 							href={ this.props.savedPost.URL }

--- a/client/post-editor/editor-action-bar/style.scss
+++ b/client/post-editor/editor-action-bar/style.scss
@@ -60,16 +60,6 @@
 	&.is-right {
 		justify-content: flex-end;
 	}
-
-	.post-format__icon {
-		color: darken( $gray, 10% );
-		margin-left: 18px;
-		margin-top: 3px;
-
-		.gridicon {
-			vertical-align: top;
-		}
-	}
 }
 
 .post-editor__content .editor-action-bar {


### PR DESCRIPTION
Fixes #16557 

Keep the icons in Posts (`/posts/`), though.

cc @drw158 