### PR TITLE
Store: Add NUX screen so users can confirm that they want to setup a store

### DIFF
--- a/client/extensions/woocommerce/app/dashboard/index.js
+++ b/client/extensions/woocommerce/app/dashboard/index.js
@@ -88,7 +88,7 @@ class Dashboard extends Component {
 		} = this.props;
 
 		if ( ! finishedInstallOfRequiredPlugins ) {
-			return translate( 'Installing Plugins' );
+			return translate( 'Store' );
 		}
 
 		if ( ! finishedPageSetup && ! hasProducts ) {

--- a/client/extensions/woocommerce/app/dashboard/required-plugins-install-view.js
+++ b/client/extensions/woocommerce/app/dashboard/required-plugins-install-view.js
@@ -11,6 +11,7 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import { activatePlugin, fetchPlugins, installPlugin } from 'state/plugins/installed/actions';
+import analytics from 'lib/analytics';
 import Button from 'components/button';
 import { fetchPluginData } from 'state/plugins/wporg/actions';
 import { getPlugin } from 'state/plugins/wporg/selectors';
@@ -320,6 +321,9 @@ class RequiredPluginsInstallView extends Component {
 	}
 
 	startSetup = () => {
+		analytics.tracks.recordEvent( 'calypso_woocommerce_dashboard_action_click', {
+			action: 'initial-setup',
+		} );
 		this.setState( {
 			engineState: 'INITIALIZING',
 		} );

--- a/client/extensions/woocommerce/app/dashboard/required-plugins-install-view.js
+++ b/client/extensions/woocommerce/app/dashboard/required-plugins-install-view.js
@@ -11,6 +11,7 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import { activatePlugin, fetchPlugins, installPlugin } from 'state/plugins/installed/actions';
+import Button from 'components/button';
 import { fetchPluginData } from 'state/plugins/wporg/actions';
 import { getPlugin } from 'state/plugins/wporg/selectors';
 import { getPlugins } from 'state/plugins/installed/selectors';
@@ -31,7 +32,7 @@ class RequiredPluginsInstallView extends Component {
 	constructor( props ) {
 		super( props );
 		this.state = {
-			engineState: 'INITIALIZING',
+			engineState: 'CONFIRMING',
 			message: '',
 			progress: 0,
 			toActivate: [],
@@ -318,8 +319,45 @@ class RequiredPluginsInstallView extends Component {
 		return 100;
 	}
 
+	startSetup = () => {
+		this.setState( {
+			engineState: 'INITIALIZING',
+		} );
+	}
+
+	renderConfirmScreen = () => {
+		const { translate } = this.props;
+		return (
+			<div className="card dashboard__setup-wrapper dashboard__setup-confirm">
+				<SetupHeader
+					imageSource={ '/calypso/images/extensions/woocommerce/woocommerce-setup.svg' }
+					imageWidth={ 160 }
+					title={ translate( 'Have something to sell?' ) }
+					subtitle={ translate(
+						'If you\'re located in the {{strong}}United States{{/strong}} ' +
+						'or {{strong}}Canada{{/strong}}, you can now add a store to sell your physical ' +
+						'products right on your site!',
+						{
+							components: { strong: <strong /> }
+						}
+					) }
+				>
+					<Button onClick={ this.startSetup } primary>
+						{ translate( 'Set up my store!' ) }
+					</Button>
+				</SetupHeader>
+			</div>
+		);
+	}
+
 	render = () => {
 		const { site, translate } = this.props;
+		const { engineState } = this.state;
+
+		if ( 'CONFIRMING' === engineState ) {
+			return this.renderConfirmScreen();
+		}
+
 		const progress = this.getProgress();
 
 		return (

--- a/client/extensions/woocommerce/app/dashboard/setup-header.js
+++ b/client/extensions/woocommerce/app/dashboard/setup-header.js
@@ -18,7 +18,7 @@ SetupHeader.propTypes = {
 	imageSource: PropTypes.string,
 	imageWidth: PropTypes.number,
 	title: PropTypes.string.isRequired,
-	subtitle: PropTypes.string,
+	subtitle: PropTypes.oneOfType( [ PropTypes.array, PropTypes.string ] ),
 };
 
 export default SetupHeader;

--- a/client/extensions/woocommerce/app/dashboard/style.scss
+++ b/client/extensions/woocommerce/app/dashboard/style.scss
@@ -27,6 +27,10 @@
 	}
 }
 
+.dashboard__setup-confirm .dashboard__setup-header-subtitle {
+	color: $gray-dark;
+}
+
 .dashboard__setup-task {
 	padding: 24px;
 	margin-left: -24px;


### PR DESCRIPTION
Closes #16885.

This adds a introduction/nux screen for new users who have not had the required plugins installed yet. It prevents the plugin install from kicking off until the user clicks the setup button. 

This should 1) Prevent our plugins from getting setup on sites that were just clicking the `Store (BETA)` link, and give an additional confirmation/notice that only US & Canada stores can be run right now (which should help until #16758 is in place).

To Test:
* Go to `https://developer.wordpress.com/docs/api/console/` and use the calypso-preferences endpoint for your site to set `finished_initial_install_of_required_plugins` to `0`.
* Go to `http://calypso.localhost:3000/store/:site` and confirm that you can see the confirmation screen.
* Click the setup button and verify that the setup steps begin.

<img width="862" alt="screen shot 2017-08-08 at 10 55 24 am" src="https://user-images.githubusercontent.com/689165/29086652-290de858-7c28-11e7-84a5-69b477cb24f5.png">


cc @kellychoffman 