### PR TITLE
Simple Payments: add ability to delete product image

### DIFF
--- a/client/blocks/upload-image/README.md
+++ b/client/blocks/upload-image/README.md
@@ -47,9 +47,9 @@ To see a more complex example, have a look at `blocks/upload-image/docs/example`
 - `imageEditorProps`: (default: allowedAspectRatios set to 1X1) object of additional props to send to `ImageEditor`
 	component.
 - `onImageEditorDone`: (default: `noop`) function to call when user clicks on the "Done" button in `ImageEditor`.
+- `onImageUploadDone`: (default: `noop`) function to call when the image is uploaded to specified `siteId` Media library.
+- `onImageRemove`: (default: `noop`) function to call when user clicked the (X) button to remove uploaded image.
 - `onError`: (default: `noop`) function to call when there's any error during file uploading/image editing.
-- `onUploadImageDone`: (default: `noop`) function to call when the image is uploaded to specified `siteId` Media library.
-- `onUploadedImageRemove`: (default: `noop`) function to call when user clicked the (X) button to remove uploaded image.
 - `additionalImageEditorClasses`: string of additional CSS class names to apply to the `ImageEditor` modal.
 - `additionalClasses`: string of additional CSS class names to apply to the `UploadImage` component.
 - `doneButtonText`: text on the "Done" button in Image Editor modal.

--- a/client/blocks/upload-image/README.md
+++ b/client/blocks/upload-image/README.md
@@ -49,6 +49,7 @@ To see a more complex example, have a look at `blocks/upload-image/docs/example`
 - `onImageEditorDone`: (default: `noop`) function to call when user clicks on the "Done" button in `ImageEditor`.
 - `onError`: (default: `noop`) function to call when there's any error during file uploading/image editing.
 - `onUploadImageDone`: (default: `noop`) function to call when the image is uploaded to specified `siteId` Media library.
+- `onUploadedImageRemove`: (default: `noop`) function to call when user clicked the (X) button to remove uploaded image.
 - `additionalImageEditorClasses`: string of additional CSS class names to apply to the `ImageEditor` modal.
 - `additionalClasses`: string of additional CSS class names to apply to the `UploadImage` component.
 - `doneButtonText`: text on the "Done" button in Image Editor modal.

--- a/client/blocks/upload-image/docs/example.jsx
+++ b/client/blocks/upload-image/docs/example.jsx
@@ -39,6 +39,10 @@ class UploadImageExample extends Component {
 		}
 	};
 
+	onUploadedImageRemove = ( uploadedImage ) => {
+		console.log( 'The following uploaded image is going to be removed from screen:', uploadedImage );
+	};
+
 	render() {
 		const { primarySiteId } = this.props;
 
@@ -50,6 +54,7 @@ class UploadImageExample extends Component {
 					siteId={ primarySiteId }
 					onImageEditorDone={ this.onImageEditorDone }
 					onUploadImageDone={ this.onUploadImageDone }
+					onUploadedImageRemove={ this.onUploadedImageRemove }
 					onError={ this.onError }
 				/>
 			</div>

--- a/client/blocks/upload-image/docs/example.jsx
+++ b/client/blocks/upload-image/docs/example.jsx
@@ -27,7 +27,7 @@ class UploadImageExample extends Component {
 		console.log( 'Image Editor props:', imageEditorProps );
 	};
 
-	onUploadImageDone = ( uploadedImage ) => {
+	onImageUploadDone = ( uploadedImage ) => {
 		console.log( 'Uploaded image:', uploadedImage );
 	};
 
@@ -39,7 +39,7 @@ class UploadImageExample extends Component {
 		}
 	};
 
-	onUploadedImageRemove = ( uploadedImage ) => {
+	onImageRemove = ( uploadedImage ) => {
 		console.log( 'The following uploaded image is going to be removed from screen:', uploadedImage );
 	};
 
@@ -53,8 +53,8 @@ class UploadImageExample extends Component {
 				<UploadImage
 					siteId={ primarySiteId }
 					onImageEditorDone={ this.onImageEditorDone }
-					onUploadImageDone={ this.onUploadImageDone }
-					onUploadedImageRemove={ this.onUploadedImageRemove }
+					onImageUploadDone={ this.onImageUploadDone }
+					onImageRemove={ this.onImageRemove }
 					onError={ this.onError }
 				/>
 			</div>

--- a/client/blocks/upload-image/index.jsx
+++ b/client/blocks/upload-image/index.jsx
@@ -258,7 +258,14 @@ class UploadImage extends Component {
 		const { onUploadedImageRemove } = this.props;
 		const { uploadedImage } = this.state;
 
-		this.setState( { uploadedImage: null } );
+		this.revokeImageObjects();
+
+		this.setState( {
+			selectedImage: null,
+			selectedImageName: '',
+			editedImage: null,
+			uploadedImage: null,
+		} );
 
 		onUploadedImageRemove( uploadedImage );
 	};
@@ -276,11 +283,20 @@ class UploadImage extends Component {
 		}
 	}
 
-	componentWillUnmount() {
+	revokeImageObjects = () => {
 		const { selectedImage, editedImage } = this.state;
 
-		URL.revokeObjectURL( selectedImage );
-		URL.revokeObjectURL( editedImage );
+		if ( selectedImage ) {
+			URL.revokeObjectURL( selectedImage );
+		}
+
+		if ( editedImage ) {
+			URL.revokeObjectURL( editedImage );
+		}
+	};
+
+	componentWillUnmount() {
+		this.revokeImageObjects();
 
 		MediaStore.off( 'change', this.handleMediaStoreChange );
 		MediaValidationStore.off( 'change', this.storeValidationErrors );

--- a/client/blocks/upload-image/index.jsx
+++ b/client/blocks/upload-image/index.jsx
@@ -63,8 +63,8 @@ class UploadImage extends Component {
 		defaultImage: PropTypes.any,
 		onError: PropTypes.func,
 		onImageEditorDone: PropTypes.func,
-		onUploadImageDone: PropTypes.func,
-		onUploadedImageRemove: PropTypes.func,
+		onImageUploadDone: PropTypes.func,
+		onImageRemove: PropTypes.func,
 	};
 
 	static defaultProps = {
@@ -73,8 +73,8 @@ class UploadImage extends Component {
 		},
 		backgroundContent: null,
 		onImageEditorDone: noop,
-		onUploadImageDone: noop,
-		onUploadedImageRemove: noop,
+		onImageUploadDone: noop,
+		onImageRemove: noop,
 		onError: noop,
 		isUploading: false,
 	};
@@ -171,7 +171,7 @@ class UploadImage extends Component {
 
 	// Handle the uploading process.
 	handleMediaStoreChange = () => {
-		const { siteId, onUploadImageDone } = this.props;
+		const { siteId, onImageUploadDone } = this.props;
 
 		const { errors } = this.state;
 
@@ -194,7 +194,7 @@ class UploadImage extends Component {
 
 			MediaStore.off( 'change', this.handleMediaStoreChange );
 
-			onUploadImageDone( uploadedImage );
+			onImageUploadDone( uploadedImage );
 
 			return;
 		}
@@ -255,7 +255,7 @@ class UploadImage extends Component {
 	}
 
 	removeUploadedImage = () => {
-		const { onUploadedImageRemove } = this.props;
+		const { onImageRemove } = this.props;
 		const { uploadedImage } = this.state;
 
 		this.revokeImageObjects();
@@ -267,7 +267,7 @@ class UploadImage extends Component {
 			uploadedImage: null,
 		} );
 
-		onUploadedImageRemove( uploadedImage );
+		onImageRemove( uploadedImage );
 	};
 
 	componentWillMount() {

--- a/client/blocks/upload-image/index.jsx
+++ b/client/blocks/upload-image/index.jsx
@@ -64,6 +64,7 @@ class UploadImage extends Component {
 		onError: PropTypes.func,
 		onImageEditorDone: PropTypes.func,
 		onUploadImageDone: PropTypes.func,
+		onUploadedImageRemove: PropTypes.func,
 	};
 
 	static defaultProps = {
@@ -72,6 +73,8 @@ class UploadImage extends Component {
 		},
 		backgroundContent: null,
 		onImageEditorDone: noop,
+		onUploadImageDone: noop,
+		onUploadedImageRemove: noop,
 		onError: noop,
 		isUploading: false,
 	};
@@ -231,10 +234,12 @@ class UploadImage extends Component {
 
 		const isEditingDefaultImage = defaultImage && selectedImage === defaultImage.URL;
 
-		const media = isEditingDefaultImage ? defaultImage : {
-			src: selectedImage,
-			file: selectedImageName
-		};
+		const media = isEditingDefaultImage
+			? defaultImage
+			: {
+				src: selectedImage,
+				file: selectedImageName,
+			};
 
 		return (
 			<Dialog additionalClassNames={ classes } isVisible={ true }>
@@ -250,7 +255,12 @@ class UploadImage extends Component {
 	}
 
 	removeUploadedImage = () => {
+		const { onUploadedImageRemove } = this.props;
+		const { uploadedImage } = this.state;
+
 		this.setState( { uploadedImage: null } );
+
+		onUploadedImageRemove( uploadedImage );
 	};
 
 	componentWillMount() {
@@ -403,7 +413,7 @@ export default connect(
 			siteId = getSelectedSiteId( state );
 		}
 
-		if ( ! defaultImage || typeof( defaultImage ) !== 'object' ) {
+		if ( ! defaultImage || typeof defaultImage !== 'object' ) {
 			defaultImage = getMediaItem( state, siteId, defaultImage );
 		}
 

--- a/client/components/tinymce/plugins/simple-payments/dialog/form.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/form.jsx
@@ -41,6 +41,7 @@ class ProductForm extends Component {
 			fieldValues,
 			isFieldInvalid,
 			onUploadImageDone,
+			onUploadedImageRemove,
 		} = this.props;
 
 		const isTitleInvalid = isFieldInvalid( 'title' );
@@ -53,6 +54,7 @@ class ProductForm extends Component {
 					defaultImage={ fieldValues.featuredImageId }
 					onError={ this.handleUploadImageError }
 					onUploadImageDone={ onUploadImageDone }
+					onUploadedImageRemove={ onUploadedImageRemove }
 				/>
 				<div className="editor-simple-payments-modal__form-fields">
 					<FormFieldset>

--- a/client/components/tinymce/plugins/simple-payments/dialog/form.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/form.jsx
@@ -40,8 +40,8 @@ class ProductForm extends Component {
 			currencyDefaults,
 			fieldValues,
 			isFieldInvalid,
-			onUploadImageDone,
-			onUploadedImageRemove,
+			onImageUploadDone,
+			onImageRemove,
 		} = this.props;
 
 		const isTitleInvalid = isFieldInvalid( 'title' );
@@ -53,8 +53,8 @@ class ProductForm extends Component {
 				<UploadImage
 					defaultImage={ fieldValues.featuredImageId }
 					onError={ this.handleUploadImageError }
-					onUploadImageDone={ onUploadImageDone }
-					onUploadedImageRemove={ onUploadedImageRemove }
+					onImageUploadDone={ onImageUploadDone }
+					onImageRemove={ onImageRemove }
 				/>
 				<div className="editor-simple-payments-modal__form-fields">
 					<FormFieldset>

--- a/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
@@ -439,8 +439,8 @@ class SimplePaymentsDialog extends Component {
 							fieldValues={ this.getFormValues() }
 							isFieldInvalid={ this.isFormFieldInvalid }
 							onFieldChange={ this.handleFormFieldChange }
-							onUploadImageDone={ this.handleUploadedImage }
-							onUploadedImageRemove={ this.handleUploadedImageRemoval }
+							onImageUploadDone={ this.handleUploadedImage }
+							onImageRemove={ this.handleUploadedImageRemoval }
 							showError={ this.showError }
 						/>
 					: <ProductList

--- a/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
@@ -175,6 +175,10 @@ class SimplePaymentsDialog extends Component {
 		this.handleFormFieldChange( 'featuredImageId', uploadedImage.ID );
 	};
 
+	handleUploadedImageRemoval = () => {
+		this.handleFormFieldChange( 'featuredImageId', null );
+	};
+
 	handleFormSubmit() {
 		// will validate the form and return a promise of a `hasErrors` bool value
 		return new Promise( resolve => this.formStateController.handleSubmit( resolve ) );
@@ -436,6 +440,7 @@ class SimplePaymentsDialog extends Component {
 							isFieldInvalid={ this.isFormFieldInvalid }
 							onFieldChange={ this.handleFormFieldChange }
 							onUploadImageDone={ this.handleUploadedImage }
+							onUploadedImageRemove={ this.handleUploadedImageRemoval }
 							showError={ this.showError }
 						/>
 					: <ProductList


### PR DESCRIPTION
Previously, when adding an image to a Simple Payments product, it could not have been deleted since `UploadImage` block didn't support that flow. In this PR, we are adding the support to delete uploaded image with `UploadImage` block and implementing it in Simple Payments product modal.

## Testing

- Either editing or creating a new Simple Payments product, try adding a product image;
- Click on the (X) button on the uploaded product image;
- Click "Save" on the product;
- Did the product image got deleted? Both from Calypso and frontend. Also, when editing the same Simple Payments product, make sure it's not showing the previously deleted image;
- After clicking on the (X) button to remove a product image and then "Cancel" on the product dialog, open the dialog again. Did the image stay?

## Notes

The product image is actually not deleted from Media library and the site itself, only from the product. The reasons:
- we can't delete the image from Media library/site upon clicking on (X) button on `UploadImage` because if customer clicks on "Cancel" in product dialog, they should have the image back. But once we delete it from Media library/site, we can't get it back
- if we wanted to delete the image from Media library/site upon hitting "Save" in product dialog, we would have to remember that in `SimplePaymentsDialog`. Also, I don't think it's `SimplePaymentsDialog` responsibility to delete this image from Media library. We could decide that we want this functionality but we should wait till #16960 gets merged since it changes how creating/updating product works.

/cc @Automattic/stark 