### PR TITLE
Site-settings: Rename DisconnectSite component to DisconnectSiteLink

### DIFF
--- a/client/my-sites/site-settings/manage-connection/disconnect-site-link.jsx
+++ b/client/my-sites/site-settings/manage-connection/disconnect-site-link.jsx
@@ -22,7 +22,7 @@ import { getPlanClass } from 'lib/plans/constants';
 import { isSiteAutomatedTransfer } from 'state/selectors';
 import { successNotice, errorNotice, infoNotice, removeNotice } from 'state/notices/actions';
 
-class DisconnectSite extends Component {
+class DisconnectSiteLink extends Component {
 	state = {
 		dialogVisible: false,
 	}
@@ -154,4 +154,4 @@ export default connect(
 		infoNotice,
 		removeNotice
 	}
-)( localize( DisconnectSite ) );
+)( localize( DisconnectSiteLink ) );

--- a/client/my-sites/site-settings/manage-connection/index.jsx
+++ b/client/my-sites/site-settings/manage-connection/index.jsx
@@ -10,7 +10,7 @@ import page from 'page';
  * Internal dependencies
  */
 import DataSynchronization from './data-synchronization';
-import DisconnectSite from './disconnect-site';
+import DisconnectSiteLink from './disconnect-site-link';
 import DocumentHead from 'components/data/document-head';
 import HeaderCake from 'components/header-cake';
 import Main from 'components/main';
@@ -53,7 +53,7 @@ class ManageConnection extends Component {
 
 				<SiteOwnership />
 				<DataSynchronization />
-				<DisconnectSite />
+				<DisconnectSiteLink />
 			</Main>
 		);
 	}


### PR DESCRIPTION
Rename a component in ```Manage Connection``` in favor of using the name in the upcoming ```Disconnect Site```, which will be a landing page for the Jetpack Disconnect Flow. 
It seems more aligned with the overall naming convention to use the name in the latter.

This is a preparatory step for the implementation of the Jetpack Disconnect Flow.