### PR TITLE
Pretty format the stats.json file saved by WEBPACK_OUTPUT_JSON

### DIFF
--- a/server/bundler/bin/bundler.js
+++ b/server/bundler/bin/bundler.js
@@ -105,7 +105,7 @@ webpack( webpackConfig, function( error, stats ) {
 	if ( process.env.WEBPACK_OUTPUT_JSON ) {
 		fs.writeFile(
 			path.join( process.cwd(), 'stats.json' ),
-			JSON.stringify( stats.toJson() )
+			JSON.stringify( stats.toJson(), null, '\t' )
 		);
 	}
 


### PR DESCRIPTION
The file is over 100MB big and common editors (I tried Atom and TextMate) have serious trouble trying to open it and pretty format the JSON. That makes it hard to read by a human.

Let's add some pretty formatting and indentation (with tabs) to the file. Its size increases by 8% and that shouldn't be a big deal.

To test: check that `npm run analyze-bundles` still works like a charm.