### PR TITLE
Store: Fix product error when inventory/stock is set and then unset

### DIFF
--- a/client/extensions/woocommerce/app/products/product-form-simple-card.js
+++ b/client/extensions/woocommerce/app/products/product-form-simple-card.js
@@ -1,9 +1,10 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
-import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
+import { isNull } from 'lodash';
+import { localize } from 'i18n-calypso';
+import React, { PropTypes } from 'react';
 
 /**
  * Internal dependencies
@@ -34,8 +35,15 @@ const ProductFormSimpleCard = ( { siteId, product, editProduct, translate } ) =>
 	};
 
 	const setStockQuantity = ( e ) => {
-		const stock_quantity = Number( e.target.value ) >= 0 ? e.target.value : '';
-		const manage_stock = stock_quantity !== '';
+		let stock_quantity;
+		let manage_stock;
+		if ( e.target.value !== '' ) {
+			stock_quantity = Number( e.target.value );
+			manage_stock = true;
+		} else {
+			stock_quantity = null;
+			manage_stock = false;
+		}
 		editProduct( siteId, product, { manage_stock, stock_quantity } );
 	};
 
@@ -87,6 +95,9 @@ const ProductFormSimpleCard = ( { siteId, product, editProduct, translate } ) =>
 		'products__product-form-stock-disabled': ! product.manage_stock,
 	} );
 
+	const { stock_quantity } = product;
+	const quantity = ! isNull( stock_quantity ) ? stock_quantity : '';
+
 	const renderStock = () => (
 		<Card className={ stockClasses }>
 			<div className="products__product-stock-options-wrapper">
@@ -94,7 +105,7 @@ const ProductFormSimpleCard = ( { siteId, product, editProduct, translate } ) =>
 					<FormLabel>{ translate( 'Inventory' ) }</FormLabel>
 					<FormTextInput
 						name="stock_quantity"
-						value={ product.stock_quantity || '' }
+						value={ quantity }
 						type="number"
 						min="0"
 						onChange={ setStockQuantity }


### PR DESCRIPTION
Fixes #16779.

If you made an edit to the stock, backspaced to unset it, and then tried to save, an API error would occur griping about `stock_quantity` being invalid since it would get passed an empty string.

This PR fixes that and passes something the API can handle.

To Test:
* Create a product with a price but without filling the inventory. Save.
* View your product on the front end to make sure it is purchasable (add to cart button visible)
* Update the product with inventory set to 1, but don't save it yet
* Empty the inventory again (backspace / empty input)
* Click update and make sure you get a success message and not an error
* View your product on the front end to make sure it is purchasable
* Update the product with inventory set to 1 and save this time
* View your product on the front end to make sure it is purchasable
