### PR TITLE
Reader: Use lighter color for respondee text

### DIFF
--- a/client/blocks/comments/style.scss
+++ b/client/blocks/comments/style.scss
@@ -262,7 +262,7 @@
 }
 
 .comments__comment-respondee .comments__comment-respondee-link {
-	color: darken( $gray, 10% );
+	color: $gray;
 	margin-left: -2px;
 
 	&:hover {

--- a/client/blocks/comments/style.scss
+++ b/client/blocks/comments/style.scss
@@ -255,6 +255,7 @@
 	margin-right: 12px;
 
 	.gridicon {
+		fill: $gray;
 		position: relative;
 			left: -5px;
 			top: 3px;
@@ -263,6 +264,7 @@
 
 .comments__comment-respondee .comments__comment-respondee-link {
 	color: $gray;
+	font-weight: normal;
 	margin-left: -2px;
 
 	&:hover {
@@ -321,7 +323,7 @@ a.comments__comment-username {
 }
 
 .comments__comment-timestamp a {
-	color: lighten( $gray, 10% );
+	color: $gray;
 	font-weight: normal;
 	text-decoration: none;
 
@@ -380,6 +382,11 @@ a.comments__comment-username {
 			position: relative;
 			top: 4px;
 			margin-right: 4px;
+		}
+
+		.gridicons-star,
+		.gridicons-star-outline {
+			top: 3px;
 		}
 
 		.like-button__like-icons {


### PR DESCRIPTION
Before (`darken( $gray, 10% )`):
![screenshot 2017-08-08 15 11 21](https://user-images.githubusercontent.com/4924246/29096945-16564b0a-7c4c-11e7-8762-7c43f7e8af07.png)

After (`$gray`):
![screenshot 2017-08-08 15 11 31](https://user-images.githubusercontent.com/4924246/29096999-547d151c-7c4c-11e7-9f22-1cc51ca8032b.png)

The original mockup was using `darken( $gray, 10% )`, too, but I think it appeared lighter because I was using a fallback font.