### PR TITLE
Start happychat connection only after we get sites info

### DIFF
--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -666,7 +666,7 @@ const HelpContact = React.createClass( {
 				<Card className={ this.canShowChatbox() ? 'help-contact__chat-form' : 'help-contact__form' }>
 					{ this.getView() }
 				</Card>
-				<HappychatConnection />
+				{ this.props.shouldStartHappychatConnection && <HappychatConnection /> }
 				<QueryOlark />
 				<QueryTicketSupportConfiguration />
 				<QueryUserPurchases userId={ this.props.currentUser.ID } />
@@ -692,6 +692,7 @@ export default connect(
 			ticketSupportEligible: isTicketSupportEligible( state ),
 			ticketSupportRequestError: getTicketSupportRequestError( state ),
 			hasMoreThanOneSite: getCurrentUserSiteCount( state ) > 1,
+			shouldStartHappychatConnection: ! isRequestingSites( state ) && helpSelectedSiteId,
 			isRequestingSites: isRequestingSites( state ),
 			isSelectedHelpSiteOnPaidPlan: isCurrentPlanPaid( state, helpSelectedSiteId ),
 		};


### PR DESCRIPTION
## Summary
This  PR should partially fix https://github.com/Automattic/wp-calypso/issues/16990, one of the issues with incorrect chat routing is due to how Happychat connectivity works. 

When `help/contact` is accessed `HappychatConnection` will initialize a socket connection with Happychat. This operation is asynchronous, which means that if it's the first load ( or after cache clear ) probably we don't have the `sites` or `primarySite` info ready when the connection is initialized. Resulting in the connection being initialized using default group (`WP.com`) even if your primary site is a `JPOP` one. If the customer does not change the selected site in the dropdown the chat for a JPOP site will be routed to a WP.com operator.

## Implementation details
`HappychatConnection` will be rendered only after we get the sites and primary site's info.

### Steps to reproduce
0. Use `master` branch
1. Change your primary site to a JPOP site  ( from `/me/account`)
2. Go to `help/contact`
3. Clear all Application Cache ( https://cloudup.com/cgt3T_ITyss )
4. Open Inspector ( WS tab )
5. Refresh -> Login
6. After the form is loaded your jetpack site should be selected
7. Check Websocket Frames tab ( the `init` message should have sent `groups`: ['WP.com'] https://cloudup.com/cH7kdCfbOKt )

## Testing
0. Use this branch
1. Change your primary site to a JPOP site  ( from `/me/account`)
2. Go to `help/contact`
3. Clear all Application Cache ( https://cloudup.com/cgt3T_ITyss )
4. Open Inspector ( WS tab )
5. Refresh -> Login (**Go back to development url, after login you will be redirected to wordpress.com**)
6. After the form is loaded your jetpack site should be selected
7. Check Websocket Frames tab ( the `init` message should have sent `groups`: ['jpop'] https://cloudup.com/cbxdnPWXXBM )
