### PR TITLE
WCS-stats: Add Tracks event for Order and ListView

### DIFF
--- a/client/extensions/woocommerce/app/store-stats/controller.js
+++ b/client/extensions/woocommerce/app/store-stats/controller.js
@@ -50,6 +50,8 @@ export default function StatsController( context ) {
 	// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
 	context.store.dispatch( setTitle( translate( 'Stats', { textOnly: true } ) ) );
 
+	analytics.tracks.recordEvent( `calypso_woocommerce_stats_${ props.type }_page`, props );
+
 	const asyncComponent = ( props.type === 'orders' )
 		? <AsyncLoad
 			/* eslint-disable wpcalypso/jsx-classname-namespace */


### PR DESCRIPTION
### Explicitly Add Tracks Event for Orders and ListViews

`calypso_page_view` event is being logged via this code in the controller.

```js
analytics.pageView.record(
    `/store/stats/${ context.params.type }/${ context.params.unit }`,
    `Store > Stats > ${ titlecase( context.params.type ) } > ${ titlecase( context.params.unit ) }`
);
```
In order to make use of Tracks events for A/B tests or evaluation via funnels, pages in Stats will need their own event name. This PR adds the following events
```
calypso_woocommerce_stats_orders_page
calypso_woocommerce_stats_products_page
calypso_woocommerce_stats_categories_page
calypso_woocommerce_stats_coupons_page
```