### PR TITLE
Simple Payments: Reset form when Add New button is clicked

### DIFF
--- a/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
@@ -180,7 +180,13 @@ class SimplePaymentsDialog extends Component {
 		return new Promise( resolve => this.formStateController.handleSubmit( resolve ) );
 	}
 
-	handleChangeTabs = activeTab => this.setState( { activeTab } );
+	handleChangeTabs = ( activeTab, why ) => {
+		if ( why === 'add' ) {
+			this.addNewPaymentButton();
+		} else {
+			this.setState( { activeTab } );
+		}
+	}
 
 	handleSelectedChange = selectedPaymentId => this.setState( { selectedPaymentId } );
 
@@ -249,6 +255,11 @@ class SimplePaymentsDialog extends Component {
 			} );
 		} );
 	};
+
+	addNewPaymentButton = () => {
+		this.setState( { activeTab: 'form', editedPaymentId: null } );
+		this.formStateController.resetFields( this.getInitialFormFields( null ) );
+	}
 
 	editPaymentButton = paymentId => {
 		this.setState( { activeTab: 'form', editedPaymentId: paymentId } );

--- a/client/components/tinymce/plugins/simple-payments/dialog/navigation.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/navigation.jsx
@@ -19,7 +19,7 @@ class SimplePaymentsDialogNavigation extends Component {
 		paymentButtons: PropTypes.array,
 	};
 
-	onChangeTabs = tab => () => this.props.onChangeTabs( tab );
+	onChangeTabs = ( tab, why ) => () => this.props.onChangeTabs( tab, why );
 
 	render() {
 		const { paymentButtons, activeTab, translate } = this.props;
@@ -31,7 +31,7 @@ class SimplePaymentsDialogNavigation extends Component {
 			return (
 				<HeaderCake
 					className={ classNames }
-					onClick={ this.onChangeTabs( 'list' ) }
+					onClick={ this.onChangeTabs( 'list', 'back' ) }
 					backText={ translate( 'Payment Buttons' ) }
 				/>
 			);
@@ -49,7 +49,7 @@ class SimplePaymentsDialogNavigation extends Component {
 				label={ translate( 'Payment Buttons' ) }
 				count={ paymentButtons.length }
 			>
-				<Button compact icon onClick={ this.onChangeTabs( 'form' ) }>
+				<Button compact icon onClick={ this.onChangeTabs( 'form', 'add' ) }>
 					<Gridicon icon="plus-small" /> { translate( 'Add New' ) }
 				</Button>
 			</SectionHeader>


### PR DESCRIPTION
This PR fixes a bug in which editing a button prevents adding new buttons,

Bug Details: When "Add New" button is pressed, it simulates a switch to form tab. Since tab switch doesn't change SimplePaymentsDialog's `editedPaymentId` state, form tab is displayed using whatever it is set to.

Background: The bug is actually due to repurposing SimplePaymentsDialog's originally EDIT button to ADD_NEW without fully accounting for behavior change from edit to create. Underlying architectural flaw is overloading SimplePaymentsDialog for both list and form modes.

Test Plan:

1. Start with no buttons
2. Create a button and insert in page
3. open button list
4. edit first button and save
5. click add new button

Expected: The form should create a new button
