### PR TITLE
Simple Payments: confirm simple-payment button delete action

### DIFF
--- a/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
@@ -244,9 +244,17 @@ class SimplePaymentsDialog extends Component {
 	};
 
 	handleTrash = paymentId => {
+		const { translate } = this.props;
+
+		if (
+			! confirm( translate( 'Are you sure you want to permanently delete this payment button?' ) )
+		) {
+			return;
+		}
+
 		this.setIsSubmitting( true );
 
-		const { siteId, dispatch, translate } = this.props;
+		const { siteId, dispatch } = this.props;
 
 		dispatch( trashPaymentButton( siteId, paymentId ) )
 			.catch( () => this.showError( translate( 'The payment button could not be deleted.' ) ) )

--- a/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
@@ -26,6 +26,7 @@ import ProductList from './list';
 import { getCurrentUserCurrencyCode } from 'state/current-user/selectors';
 import { getCurrencyDefaults } from 'lib/format-currency';
 import wpcom from 'lib/wp';
+import accept from 'lib/accept';
 import {
 	customPostToProduct,
 	productToCustomPost,
@@ -245,20 +246,22 @@ class SimplePaymentsDialog extends Component {
 
 	handleTrash = paymentId => {
 		const { translate } = this.props;
+		const areYouSure = translate(
+			'Are you sure you want to permanently delete this payment button?'
+		);
+		accept( areYouSure, accepted => {
+			if ( ! accepted ) {
+				return;
+			}
 
-		if (
-			! confirm( translate( 'Are you sure you want to permanently delete this payment button?' ) )
-		) {
-			return;
-		}
+			this.setIsSubmitting( true );
 
-		this.setIsSubmitting( true );
+			const { siteId, dispatch } = this.props;
 
-		const { siteId, dispatch } = this.props;
-
-		dispatch( trashPaymentButton( siteId, paymentId ) )
-			.catch( () => this.showError( translate( 'The payment button could not be deleted.' ) ) )
-			.then( () => this.setIsSubmitting( false ) );
+			dispatch( trashPaymentButton( siteId, paymentId ) )
+				.catch( () => this.showError( translate( 'The payment button could not be deleted.' ) ) )
+				.then( () => this.setIsSubmitting( false ) );
+		} );
 	};
 
 	getActionButtons() {


### PR DESCRIPTION
Guards against unintentional deletion of simple-payments button with a simple delete dialog.

Test Plan:

1. Open Simple Payments Button List with at least one Payment Button.
2. Open a List Item's action popup and Select Trash action.

> <img width="399" alt="screenshot_303" src="https://user-images.githubusercontent.com/127594/29120626-f90bbeee-7cbf-11e7-80c8-1f2de34ae841.png">

3. Confirmation dialog asking "Are you sure you want to permanently delete this payment button?" should be displayed.

> <img width="578" alt="screenshot_305" src="https://user-images.githubusercontent.com/127594/29136998-c8a9a462-7cf3-11e7-95b9-16f1bce8ac76.png">

4. Check that clicking Cancel leaves the button as-is.
5. Check that clicking Delete removes the button.

