### PR TITLE
Update enable flow for enabling Stripe.

### DIFF
--- a/client/extensions/woocommerce/app/settings/payments/payment-method-item.js
+++ b/client/extensions/woocommerce/app/settings/payments/payment-method-item.js
@@ -100,6 +100,21 @@ class PaymentMethodItem extends Component {
 		this.props.closeEditingPaymentMethod( site.ID, method.id );
 	}
 
+	onDoneAndEnable = () => {
+		const { method, site } = this.props;
+		this.props.closeEditingPaymentMethod( site.ID, method.id );
+		if ( ! method.enabled ) {
+			this.props.changePaymentMethodEnabled(
+				site.ID,
+				method.id,
+				true
+			);
+			analytics.tracks.recordEvent( 'calypso_woocommerce_payment_method_enabled', {
+				payment_method: method.id,
+			} );
+		}
+	}
+
 	outputEditComponent = () => {
 		const { currentlyEditingMethod, method, site } = this.props;
 		if ( method.id === 'paypal' ) {
@@ -117,7 +132,7 @@ class PaymentMethodItem extends Component {
 					method={ currentlyEditingMethod }
 					onCancel={ this.onCancel }
 					onEditField={ this.onEditField }
-					onDone={ this.onDone }
+					onDone={ this.onDoneAndEnable }
 					site={ site } />
 			);
 		}
@@ -161,6 +176,9 @@ class PaymentMethodItem extends Component {
 			this.props.currentlyEditingMethod.id;
 		const { method, translate } = this.props;
 		let editButtonText = method.enabled ? translate( 'Manage' ) : translate( 'Set up' );
+		if ( method.id === 'stripe' && hasStripeValidCredentials( method ) ) {
+			editButtonText = translate( 'Manage' );
+		}
 		if ( currentlyEditingId === method.id ) {
 			editButtonText = translate( 'Cancel' );
 		}

--- a/client/extensions/woocommerce/app/settings/payments/payment-method-item.js
+++ b/client/extensions/woocommerce/app/settings/payments/payment-method-item.js
@@ -28,7 +28,7 @@ import ListItemField from 'woocommerce/components/list/list-item-field';
 import PaymentMethodEditDialog from './payment-method-edit-dialog';
 import PaymentMethodEditFormToggle from './payment-method-edit-form-toggle';
 import PaymentMethodPaypal from './payment-method-paypal';
-import PaymentMethodStripe from './payment-method-stripe';
+import PaymentMethodStripe, { hasStripeValidCredentials } from './payment-method-stripe';
 import PaymentMethodCheque from './payment-method-cheque';
 
 class PaymentMethodItem extends Component {
@@ -139,13 +139,21 @@ class PaymentMethodItem extends Component {
 		);
 	}
 
-	renderEnabledField = ( isEnabled ) => {
-		return (
-			<PaymentMethodEditFormToggle
-				checked={ isEnabled }
-				name="enabled"
-				onChange={ this.onChangeEnabled } />
-		);
+	renderEnabledField = ( method ) => 	{
+		const { translate } = this.props;
+		let showEnableField = true;
+		if ( method.id === 'stripe' ) {
+			showEnableField = hasStripeValidCredentials( method );
+		}
+
+		return showEnableField &&
+			<div>
+				<FormLabel>{ translate( 'Enabled' ) }</FormLabel>
+				<PaymentMethodEditFormToggle
+					checked={ method.enabled }
+					name="enabled"
+					onChange={ this.onChangeEnabled } />
+			</div>;
 	}
 
 	render() {
@@ -186,10 +194,7 @@ class PaymentMethodItem extends Component {
 				</ListItemField>
 				<ListItemField className="payments__method-enable-container">
 					<FormFieldset className="payments__method-enable">
-						<div>
-							<FormLabel>{ translate( 'Enabled' ) }</FormLabel>
-							{ this.renderEnabledField( method.enabled ) }
-						</div>
+						{ this.renderEnabledField( method ) }
 					</FormFieldset>
 				</ListItemField>
 				<ListItemField className="payments__method-action-container">

--- a/client/extensions/woocommerce/app/settings/payments/payment-method-stripe.js
+++ b/client/extensions/woocommerce/app/settings/payments/payment-method-stripe.js
@@ -77,18 +77,23 @@ class PaymentMethodStripe extends Component {
 		};
 	}
 
-	renderEditKeyTextbox = ( setting, placeholder ) => {
+	renderEditKeyTextbox = ( setting, label, placeholder ) => {
 		const isError = this.state.missingFieldsNotice && ! setting.value.trim();
 
 		return (
 			<div>
-				<FormTextInput
-					name={ setting.id }
-					onChange={ this.onEditFieldHandler }
-					isError={ isError }
-					value={ setting.value }
-					placeholder={ placeholder } />
+				<FormFieldset className="payments__method-edit-field-container">
+					<FormLabel required={ true }>
+						{ label }
+					</FormLabel>
+					<FormTextInput
+						name={ setting.id }
+						onChange={ this.onEditFieldHandler }
+						isError={ isError }
+						value={ setting.value }
+						placeholder={ placeholder } />
 					{ isError && <FormInputValidation isError text="This field is required." /> }
+				</FormFieldset>
 			</div>
 		);
 	}
@@ -100,24 +105,16 @@ class PaymentMethodStripe extends Component {
 
 		return (
 			<div>
-				<FormFieldset className="payments__method-edit-field-container">
-					<FormLabel>
-						{ secretLabel }
-					</FormLabel>
 					{ this.renderEditKeyTextbox(
 						isLiveMode ? method.settings.secret_key : method.settings.test_secret_key,
+						secretLabel,
 						translate( 'Enter your secret key from your Stripe.com account' )
 					) }
-				</FormFieldset>
-				<FormFieldset className="payments__method-edit-field-container">
-					<FormLabel>
-						{ publishableLabel }
-					</FormLabel>
 					{ this.renderEditKeyTextbox(
 						isLiveMode ? method.settings.publishable_key : method.settings.test_publishable_key,
+						publishableLabel,
 						translate( 'Enter your publishable key from your Stripe.com account' )
 					) }
-				</FormFieldset>
 			</div>
 		);
 	}

--- a/client/extensions/woocommerce/app/settings/payments/payment-method-stripe.js
+++ b/client/extensions/woocommerce/app/settings/payments/payment-method-stripe.js
@@ -16,10 +16,20 @@ import FormLegend from 'components/forms/form-legend';
 import FormRadio from 'components/forms/form-radio';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import FormTextInput from 'components/forms/form-text-input';
+import FormInputValidation from 'components/forms/form-input-validation';
 import PaymentMethodEditFormToggle from './payment-method-edit-form-toggle';
 import SegmentedControl from 'components/segmented-control';
 import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
+
+export function hasStripeValidCredentials( method ) {
+	const { settings } = method;
+	const isLiveMode = method.settings.testmode.value !== 'yes';
+	if ( isLiveMode ) {
+		return settings.secret_key.value.trim() && settings.publishable_key.value.trim();
+	}
+	return settings.test_secret_key.value.trim() && settings.test_publishable_key.value.trim();
+}
 
 class PaymentMethodStripe extends Component {
 
@@ -43,6 +53,10 @@ class PaymentMethodStripe extends Component {
 		} ),
 	};
 
+	state = {
+		missingFieldsNotice: false,
+	};
+
 	onEditFieldHandler = ( e ) => {
 		// Limit the statement descriptor field to 22 characters
 		// since that is all Stripe will accept
@@ -63,25 +77,19 @@ class PaymentMethodStripe extends Component {
 		};
 	}
 
-	renderEditTextboxSecretKey = ( setting ) => {
-		const { translate } = this.props;
-		return (
-			<FormTextInput
-				name={ setting.id }
-				onChange={ this.onEditFieldHandler }
-				value={ setting.value }
-				placeholder={ translate( 'Enter your secret key from your Stripe.com account' ) } />
-		);
-	}
+	renderEditKeyTextbox = ( setting, placeholder ) => {
+		const isError = this.state.missingFieldsNotice && ! setting.value.trim();
 
-	renderEditTextboxPublishableKey = ( setting ) => {
-		const { translate } = this.props;
 		return (
-			<FormTextInput
-				name={ setting.id }
-				onChange={ this.onEditFieldHandler }
-				value={ setting.value }
-				placeholder={ translate( 'Enter your publishable key from your Stripe.com account' ) } />
+			<div>
+				<FormTextInput
+					name={ setting.id }
+					onChange={ this.onEditFieldHandler }
+					isError={ isError }
+					value={ setting.value }
+					placeholder={ placeholder } />
+					{ isError && <FormInputValidation isError text="This field is required." /> }
+			</div>
 		);
 	}
 
@@ -96,25 +104,35 @@ class PaymentMethodStripe extends Component {
 					<FormLabel>
 						{ secretLabel }
 					</FormLabel>
-					{ this.renderEditTextboxSecretKey(
-						isLiveMode ? method.settings.secret_key : method.settings.test_secret_key
+					{ this.renderEditKeyTextbox(
+						isLiveMode ? method.settings.secret_key : method.settings.test_secret_key,
+						translate( 'Enter your secret key from your Stripe.com account' )
 					) }
 				</FormFieldset>
 				<FormFieldset className="payments__method-edit-field-container">
 					<FormLabel>
 						{ publishableLabel }
 					</FormLabel>
-					{ this.renderEditTextboxPublishableKey(
-						isLiveMode ? method.settings.publishable_key : method.settings.test_publishable_key
+					{ this.renderEditKeyTextbox(
+						isLiveMode ? method.settings.publishable_key : method.settings.test_publishable_key,
+						translate( 'Enter your publishable key from your Stripe.com account' )
 					) }
 				</FormFieldset>
 			</div>
 		);
 	}
 
+	onDone = ( e ) => {
+		if ( hasStripeValidCredentials( this.props.method ) ) {
+			this.props.onDone( e );
+		} else {
+			this.setState( { missingFieldsNotice: true } );
+		}
+	}
+
 	buttons = [
 		{ action: 'cancel', label: this.props.translate( 'Cancel' ), onClick: this.props.onCancel },
-		{ action: 'save', label: this.props.translate( 'Done' ), onClick: this.props.onDone, isPrimary: true },
+		{ action: 'save', label: this.props.translate( 'Enable Stripe' ), onClick: this.onDone, isPrimary: true },
 	];
 
 	getStatementDescriptorPlaceholder = () => {


### PR DESCRIPTION
### Info
This fixes #16692 
This updates the Stripe flow according to the design presented in #16692. 
This is 99% ready for review - small change will be done after I will get an answer to the question below.

### Testing: go to Stripe settings and add/remove keys and hit Enable button. 

@kellychoffman There is one thing different from the design. Although I have changed the label to Enable Stripe I have not connected yet the enable function. I started to wonder if this is what we want - because it is not possible to enter the keys without Enabling Stripe. If the user just wants to enter data into the form he is forced to enable. 
