### PR TITLE
Logout: Redirect to wp-login.php?action=logout when ajax logout fails

### DIFF
--- a/client/me/sidebar/index.jsx
+++ b/client/me/sidebar/index.jsx
@@ -51,9 +51,13 @@ const MeSidebar = React.createClass( {
 		}
 
 		if ( config.isEnabled( 'login/wp-login' ) ) {
-			this.props.logoutUser( redirect ).then( ( { redirect_to } ) => {
-				user.clear( () => location.href = redirect_to || '/' );
-			} );
+			this.props.logoutUser( redirect )
+				.then(
+					( { redirect_to } ) => user.clear( () => location.href = redirect_to || '/' ),
+					// The logout endpoint might fail if the nonce has expired.
+					// In this case, redirect to wp-login.php?action=logout to get a new nonce generated
+					() => userUtilities.logout( redirect )
+				);
 		} else {
 			userUtilities.logout( redirect );
 		}


### PR DESCRIPTION
When the logout nonce (from `logout_URL`) is not valid anymore, `check_admin_referer` calls `wp_nonce_ays` which displays a confirmation page with a new nonce generated

![image](https://user-images.githubusercontent.com/230230/29129349-cec82f16-7d26-11e7-82d2-bc35ac6f4efa.png)

We should fallback to the logout redirect in case the logout endpoint fails.

### Testing Instructions
- Apply this patch and boot http://calypso.localhost:3000/me
- Sandbox wordpress.com and update `function wp_create_nonce` with:
```
if ( $action === 'log-out' ) {
	$i = wp_nonce_tick() - 5;
	return substr(wp_hash($i . $action . $uid, 'nonce'), -12, 10);
}
```
- From calypso, click on "Sign out"
- You should be redirected to http://wordpress.com/wp-login.php?action=logout&redirect=...
- Undo your changes on the server
- Click on "Log out" and assert that you are successfully logged out

### Reviews
- [x] Code
- [x] Product