### PR TITLE
WPSC: Add Site URL field to CDN tab

### DIFF
--- a/client/extensions/wp-super-cache/components/cdn/index.jsx
+++ b/client/extensions/wp-super-cache/components/cdn/index.jsx
@@ -22,6 +22,7 @@ const CdnTab = ( {
 	fields: {
 		ossdl_cname,
 		ossdl_https,
+		ossdl_off_blog_url,
 		ossdl_off_cdn_url,
 		ossdl_off_exclude,
 		ossdl_off_include_dirs,
@@ -64,6 +65,22 @@ const CdnTab = ( {
 					</FormFieldset>
 
 					<div className="wp-super-cache__cdn-fieldsets">
+						<FormFieldset>
+							<FormLabel htmlFor="ossdl_off_blog_url">
+								{ translate( 'Site URL' ) }
+							</FormLabel>
+
+							<FormTextInput
+								disabled={ isRequesting || isSaving || ! ossdlcdn }
+								id="ossdl_off_cdn_url"
+								onChange={ handleChange( 'ossdl_off_blog_url' ) }
+								value={ ossdl_off_blog_url || '' } />
+
+							<FormSettingExplanation>
+								{ translate( 'The URL of your site. No trailing / please.' ) }
+							</FormSettingExplanation>
+						</FormFieldset>
+
 						<FormFieldset>
 							<FormLabel htmlFor="ossdl_off_cdn_url">
 								{ translate( 'Off-site URL' ) }
@@ -182,6 +199,7 @@ const getFormSettings = settings => {
 	return pick( settings, [
 		'ossdl_cname',
 		'ossdl_https',
+		'ossdl_off_blog_url',
 		'ossdl_off_cdn_url',
 		'ossdl_off_exclude',
 		'ossdl_off_include_dirs',


### PR DESCRIPTION
Companion PR to https://github.com/Automattic/wp-super-cache/pull/332. You need an up-to-date `master` branch of WPSC on your site.

To test: Change that setting, and verify that saving it works.

![image](https://user-images.githubusercontent.com/96308/29126353-6ae0d83e-7d1e-11e7-81aa-f718a4ccb788.png)

wp-admin:
![image](https://user-images.githubusercontent.com/96308/29126370-7737bb98-7d1e-11e7-90e5-a6af4daae384.png)

