### PR TITLE
Activity log: Add ListEnd cap to end of ActivityLog lists

### DIFF
--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -11,6 +11,7 @@ import {
 	groupBy,
 	includes,
 	map,
+	isEmpty,
 } from 'lodash';
 
 /**
@@ -39,6 +40,7 @@ import QuerySiteSettings from 'components/data/query-site-settings';
 import DatePicker from 'my-sites/stats/stats-date-picker';
 import StatsPeriodNavigation from 'my-sites/stats/stats-period-navigation';
 import ActivityLogRewindToggle from './activity-log-rewind-toggle';
+import ListEnd from 'components/list-end';
 import { recordTracksEvent as recordTracksEventAction } from 'state/analytics/actions';
 import { rewindRestore as rewindRestoreAction } from 'state/activity-log/actions';
 import {
@@ -309,6 +311,7 @@ class ActivityLog extends Component {
 				<section className="activity-log__wrapper">
 					{ logsGroupedByDay }
 				</section>
+				{ ! isEmpty( logsGroupedByDay ) && <ListEnd /> }
 			</div>
 		);
 	}


### PR DESCRIPTION
Add a `ListEnd` cap to the end of Activity Log lists.

This matches other lists throughout Calypso like in Posts or Reader.

## Testing
1. https://calypso.live/stats/activity?branch=add/activitylog-list-end
1. Ensure you can see activity and the cap at the end.
1. Enjoy!
1. Should not display if there's no activity.

## Screens

### Collapsed

![collapsed](https://user-images.githubusercontent.com/841763/29127847-7f3e3f3e-7d22-11e7-92ed-7e94716d7591.png)

### Expanded day

![ex](https://user-images.githubusercontent.com/841763/29127839-7abf81fc-7d22-11e7-8c0a-8cb836b84834.png)

### Expanded day and item

![exp-exp](https://user-images.githubusercontent.com/841763/29127835-78242cea-7d22-11e7-9cef-761f446c9001.png)

/cc @beaulebens who requested this in a testing doc