### PR TITLE
Data Layer: Remove references to deprecated `next()`

### DIFF
--- a/client/state/data-layer/test/extensions-middleware.js
+++ b/client/state/data-layer/test/extensions-middleware.js
@@ -105,7 +105,7 @@ describe( 'Calypso Extensions Data Layer Middleware', () => {
 	} );
 
 	it( 'should allow continuing the action down the chain', () => {
-		const adder = spy( ( _store, _action, _next ) => _next( _action ) );
+		const adder = spy( () => {} );
 
 		const handlers = {
 			[ 'ADD' ]: [ adder ],

--- a/client/state/data-layer/test/wpcom-api-middleware.js
+++ b/client/state/data-layer/test/wpcom-api-middleware.js
@@ -91,7 +91,7 @@ describe( 'WordPress.com API Middleware', () => {
 	} );
 
 	it( 'should allow continuing the action down the chain', () => {
-		const adder = spy( ( _store, _action, _next ) => _next( _action ) );
+		const adder = spy( () => {} );
 		const handlers = mergeHandlers( {
 			[ 'ADD' ]: [ adder ],
 		} );

--- a/client/state/data-layer/wpcom-api-middleware.js
+++ b/client/state/data-layer/wpcom-api-middleware.js
@@ -60,8 +60,6 @@ const shouldNext = action => {
  * @returns {Function} middleware handler
  */
 export const middleware = handlers => store => next => {
-	const localNext = action => next( local( action ) );
-
 	/**
 	 * Middleware handler
 	 *
@@ -90,24 +88,11 @@ export const middleware = handlers => store => next => {
 			}
 		}
 
-		// as we transition to making next() implicit we want
-		// to limit the extent of our changes so make this new
-		// function which gives us the ability to incrementally
-		// remove the uses of `next( action )` inside the handlers
-		//
-		// this guarantees that we don't double-dispatch
-		const nextActions = new Set();
-		const safeNext = a => nextActions.add( a );
+		handlerChain.forEach( handler => handler( store, action ) );
 
-		handlerChain.forEach( handler => handler( store, action, safeNext ) );
-
-		// make sure we pass along this action
-		// eventually this will return to the
-		// simpler `return next( action )`
 		if ( shouldNext( action ) ) {
-			nextActions.add( action );
+			next( local( action ) );
 		}
-		nextActions.forEach( localNext );
 	};
 };
 

--- a/client/state/data-layer/wpcom-http/test/utils.js
+++ b/client/state/data-layer/wpcom-http/test/utils.js
@@ -66,7 +66,6 @@ describe( 'WPCOM HTTP Data Layer', () => {
 			let onProgress;
 			let dispatcher;
 			let store;
-			let next;
 
 			beforeEach( () => {
 				initiator = spy();
@@ -75,57 +74,56 @@ describe( 'WPCOM HTTP Data Layer', () => {
 				onProgress = spy();
 				dispatcher = dispatchRequest( initiator, onSuccess, onFailure, onProgress );
 				store = spy();
-				next = spy();
 			} );
 
 			it( 'should call the initiator if meta information missing', () => {
-				dispatcher( store, empty, next );
+				dispatcher( store, empty );
 
-				expect( initiator ).to.have.been.calledWith( store, empty, next );
+				expect( initiator ).to.have.been.calledWith( store, empty );
 				expect( onSuccess ).to.not.have.been.called;
 				expect( onFailure ).to.not.have.been.called;
 				expect( onProgress ).to.not.have.been.called;
 			} );
 
 			it( 'should call onSuccess if meta includes response data', () => {
-				dispatcher( store, success, next );
+				dispatcher( store, success );
 
 				expect( initiator ).to.not.have.been.called;
-				expect( onSuccess ).to.have.been.calledWith( store, success, next, data );
+				expect( onSuccess ).to.have.been.calledWith( store, success, data );
 				expect( onFailure ).to.not.have.been.called;
 				expect( onProgress ).to.not.have.been.called;
 			} );
 
 			it( 'should call onFailure if meta includes error data', () => {
-				dispatcher( store, failure, next );
+				dispatcher( store, failure );
 
 				expect( initiator ).to.not.have.been.called;
 				expect( onSuccess ).to.not.have.been.called;
-				expect( onFailure ).to.have.been.calledWith( store, failure, next, error );
+				expect( onFailure ).to.have.been.calledWith( store, failure, error );
 				expect( onProgress ).to.not.have.been.called;
 			} );
 
 			it( 'should call onFailure if meta includes both response data and error data', () => {
-				dispatcher( store, both, next );
+				dispatcher( store, both );
 
 				expect( initiator ).to.not.have.been.called;
 				expect( onSuccess ).to.not.have.been.called;
-				expect( onFailure ).to.have.been.calledWith( store, both, next, error );
+				expect( onFailure ).to.have.been.calledWith( store, both, error );
 				expect( onProgress ).to.not.have.been.called;
 			} );
 
 			it( 'should call onProgress if meta includes progress data', () => {
-				dispatcher( store, progress, next );
+				dispatcher( store, progress );
 
 				expect( initiator ).to.not.have.been.called;
 				expect( onSuccess ).to.not.have.been.called;
 				expect( onFailure ).to.not.have.been.called;
-				expect( onProgress ).to.have.been.calledWith( store, progress, next, progressInfo );
+				expect( onProgress ).to.have.been.calledWith( store, progress, progressInfo );
 			} );
 
 			it( 'should not throw runtime error if onProgress is not specified', () => {
 				dispatcher = dispatchRequest( initiator, onSuccess, onFailure );
-				expect( () => dispatcher( store, progress, next ) ).to.not.throw( TypeError );
+				expect( () => dispatcher( store, progress ) ).to.not.throw( TypeError );
 			} );
 		} );
 	} );

--- a/client/state/data-layer/wpcom-http/utils.js
+++ b/client/state/data-layer/wpcom-http/utils.js
@@ -73,21 +73,21 @@ export const getProgress = action => get( action, 'meta.dataLayer.progress', nul
  *                                behavior of this optional handler is to do nothing.
  * @returns {?*} please ignore return values, they are undefined
  */
-export const dispatchRequest = ( initiator, onSuccess, onError, onProgress = noop ) => ( store, action, next ) => {
+export const dispatchRequest = ( initiator, onSuccess, onError, onProgress = noop ) => ( store, action ) => {
 	const error = getError( action );
 	if ( error ) {
-		return onError( store, action, next, error );
+		return onError( store, action, error );
 	}
 
 	const data = getData( action );
 	if ( data ) {
-		return onSuccess( store, action, next, data );
+		return onSuccess( store, action, data );
 	}
 
 	const progress = getProgress( action );
 	if ( progress ) {
-		return onProgress( store, action, next, progress );
+		return onProgress( store, action, progress );
 	}
 
-	return initiator( store, action, next );
+	return initiator( store, action );
 };

--- a/client/state/data-layer/wpcom/activity-log/activate/index.js
+++ b/client/state/data-layer/wpcom/activity-log/activate/index.js
@@ -29,7 +29,7 @@ export const activateSucceeded = ( { dispatch }, { siteId } ) => {
 	dispatch( rewindActivateSuccess( siteId ) );
 };
 
-export const activateFailed = ( { dispatch }, { siteId }, next, { message } ) => {
+export const activateFailed = ( { dispatch }, { siteId }, { message } ) => {
 	dispatch( errorNotice( translate(
 		'Problem activating rewind: %(message)s',
 		{ args: { message } }

--- a/client/state/data-layer/wpcom/activity-log/activate/test/index.js
+++ b/client/state/data-layer/wpcom/activity-log/activate/test/index.js
@@ -31,7 +31,7 @@ describe( 'activateSucceeded', () => {
 describe( 'activateFailed', () => {
 	it( 'should dispatch rewind activate failed action', () => {
 		const dispatch = sinon.spy();
-		activateFailed( { dispatch }, { siteId }, null, { message: 'some problem' } );
+		activateFailed( { dispatch }, { siteId }, { message: 'some problem' } );
 		expect( dispatch ).to.have.been.calledWith(
 			rewindActivateFailure( siteId )
 		);
@@ -39,7 +39,7 @@ describe( 'activateFailed', () => {
 
 	it( 'should dispatch an error notice', () => {
 		const dispatch = sinon.spy();
-		activateFailed( { dispatch }, { siteId }, null, { message: 'some problem' } );
+		activateFailed( { dispatch }, { siteId }, { message: 'some problem' } );
 		expect( dispatch ).to.have.been.calledWith( sinon.match( {
 			notice: {
 				status: 'is-error',

--- a/client/state/data-layer/wpcom/activity-log/deactivate/index.js
+++ b/client/state/data-layer/wpcom/activity-log/deactivate/index.js
@@ -29,7 +29,7 @@ export const deactivateSucceeded = ( { dispatch }, { siteId } ) => {
 	dispatch( rewindDeactivateSuccess( siteId ) );
 };
 
-export const deactivateFailed = ( { dispatch }, { siteId }, next, { message } ) => {
+export const deactivateFailed = ( { dispatch }, { siteId }, { message } ) => {
 	dispatch( errorNotice( translate(
 		'Problem deactivating rewind: %(message)s',
 		{ args: { message } }

--- a/client/state/data-layer/wpcom/activity-log/deactivate/test/index.js
+++ b/client/state/data-layer/wpcom/activity-log/deactivate/test/index.js
@@ -31,7 +31,7 @@ describe( 'dectivateSucceeded', () => {
 describe( 'deactivateFailed', () => {
 	it( 'should dispatch rewind deactivate failed action', () => {
 		const dispatch = sinon.spy();
-		deactivateFailed( { dispatch }, { siteId }, null, { message: 'some problem' } );
+		deactivateFailed( { dispatch }, { siteId }, { message: 'some problem' } );
 		expect( dispatch ).to.have.been.calledWith(
 			rewindDeactivateFailure( siteId )
 		);
@@ -39,7 +39,7 @@ describe( 'deactivateFailed', () => {
 
 	it( 'should dispatch an error notice', () => {
 		const dispatch = sinon.spy();
-		deactivateFailed( { dispatch }, { siteId }, null, { message: 'some problem' } );
+		deactivateFailed( { dispatch }, { siteId }, { message: 'some problem' } );
 		expect( dispatch ).to.have.been.calledWith( sinon.match( {
 			notice: {
 				status: 'is-error',

--- a/client/state/data-layer/wpcom/activity-log/rewind/index.js
+++ b/client/state/data-layer/wpcom/activity-log/rewind/index.js
@@ -34,11 +34,11 @@ const fromApi = response => ( {
 	plan: response.plan,
 } );
 
-export const receiveRewindStatus = ( { dispatch }, { siteId }, next, data ) => {
+export const receiveRewindStatus = ( { dispatch }, { siteId }, data ) => {
 	dispatch( updateRewindStatus( siteId, fromApi( data ) ) );
 };
 
-export const receiveRewindStatusError = ( { dispatch }, { siteId }, next, error ) => {
+export const receiveRewindStatusError = ( { dispatch }, { siteId }, error ) => {
 	dispatch( rewindStatusError(
 		siteId,
 		pick( error, [ 'error', 'status', 'message' ] )

--- a/client/state/data-layer/wpcom/activity-log/rewind/restore-status/index.js
+++ b/client/state/data-layer/wpcom/activity-log/rewind/restore-status/index.js
@@ -41,7 +41,7 @@ const fromApi = ( { restore_status = {} } ) => {
 	};
 };
 
-export const receiveRestoreProgress = ( { dispatch }, { siteId, timestamp, restoreId }, next, apiData ) => {
+export const receiveRestoreProgress = ( { dispatch }, { siteId, timestamp, restoreId }, apiData ) => {
 	const data = fromApi( apiData );
 
 	debug( 'Restore progress', data );
@@ -50,7 +50,7 @@ export const receiveRestoreProgress = ( { dispatch }, { siteId, timestamp, resto
 };
 
 // FIXME: Could be a network Error (instanceof Error) or an API error. Handle each case correctly.
-export const receiveRestoreError = ( { dispatch }, { siteId, timestamp, restoreId }, next, error ) => {
+export const receiveRestoreError = ( { dispatch }, { siteId, timestamp, restoreId }, error ) => {
 	debug( 'Restore progress error', error );
 
 	dispatch( createNotice(

--- a/client/state/data-layer/wpcom/activity-log/rewind/restore-status/test/index.js
+++ b/client/state/data-layer/wpcom/activity-log/rewind/restore-status/test/index.js
@@ -30,7 +30,7 @@ const FINISHED_RESPONSE = deepFreeze( {
 describe( 'receiveRestoreProgress', () => {
 	it( 'should dispatch updateRewindRestoreProgress', () => {
 		const dispatch = sinon.spy();
-		receiveRestoreProgress( { dispatch }, { siteId, timestamp, restoreId }, null, FINISHED_RESPONSE );
+		receiveRestoreProgress( { dispatch }, { siteId, timestamp, restoreId }, FINISHED_RESPONSE );
 		const expectedAction = updateRewindRestoreProgress(
 			siteId, timestamp, restoreId, {
 				errorCode: '',

--- a/client/state/data-layer/wpcom/activity-log/rewind/test/index.js
+++ b/client/state/data-layer/wpcom/activity-log/rewind/test/index.js
@@ -44,7 +44,7 @@ const ERROR_RESPONSE = deepFreeze( {
 describe( 'receiveRewindStatus', () => {
 	it( 'should dispatch rewind status update action', () => {
 		const dispatch = sinon.spy();
-		receiveRewindStatus( { dispatch }, { siteId: SITE_ID }, null, SUCCESS_RESPONSE );
+		receiveRewindStatus( { dispatch }, { siteId: SITE_ID }, SUCCESS_RESPONSE );
 		expect( dispatch ).to.have.been.calledWith(
 			updateRewindStatus(
 				SITE_ID, {
@@ -61,7 +61,7 @@ describe( 'receiveRewindStatus', () => {
 describe( 'receiveRewindStatusError', () => {
 	it( 'should dispatch rewind status error action', () => {
 		const dispatch = sinon.spy();
-		receiveRewindStatusError( { dispatch }, { siteId: SITE_ID }, null, ERROR_RESPONSE );
+		receiveRewindStatusError( { dispatch }, { siteId: SITE_ID }, ERROR_RESPONSE );
 		expect( dispatch ).to.have.been.calledWith(
 			rewindStatusError(
 				SITE_ID, {

--- a/client/state/data-layer/wpcom/activity-log/rewind/to/index.js
+++ b/client/state/data-layer/wpcom/activity-log/rewind/to/index.js
@@ -31,7 +31,7 @@ const requestRestore = ( { dispatch }, action ) => {
 	}, action ) );
 };
 
-export const receiveRestoreSuccess = ( { dispatch }, { siteId, timestamp }, next, apiData ) => {
+export const receiveRestoreSuccess = ( { dispatch }, { siteId, timestamp }, apiData ) => {
 	const { restoreId } = fromApi( apiData );
 	if ( restoreId ) {
 		debug( 'Request restore success, restore id:', restoreId );
@@ -50,7 +50,7 @@ export const receiveRestoreSuccess = ( { dispatch }, { siteId, timestamp }, next
 	}
 };
 
-export const receiveRestoreError = ( { dispatch }, { siteId, timestamp }, next, error ) => {
+export const receiveRestoreError = ( { dispatch }, { siteId, timestamp }, error ) => {
 	debug( 'Request restore fail', error );
 	dispatch( rewindRestoreUpdateError(
 		siteId,

--- a/client/state/data-layer/wpcom/activity-log/rewind/to/test/index.js
+++ b/client/state/data-layer/wpcom/activity-log/rewind/to/test/index.js
@@ -36,7 +36,7 @@ const ERROR_RESPONSE = deepFreeze( {
 describe( 'receiveRestoreSuccess', () => {
 	it( 'should dispatch get restore progress on success', () => {
 		const dispatch = sinon.spy();
-		receiveRestoreSuccess( { dispatch }, { siteId, timestamp }, null, SUCCESS_RESPONSE );
+		receiveRestoreSuccess( { dispatch }, { siteId, timestamp }, SUCCESS_RESPONSE );
 		expect( dispatch ).to.have.been.calledWith(
 			getRewindRestoreProgress( siteId, timestamp, restoreId )
 		);
@@ -46,7 +46,7 @@ describe( 'receiveRestoreSuccess', () => {
 describe( 'receiveRestoreError', () => {
 	it( 'should dispatch update error on error', () => {
 		const dispatch = sinon.spy();
-		receiveRestoreError( { dispatch }, { siteId, timestamp }, null, ERROR_RESPONSE );
+		receiveRestoreError( { dispatch }, { siteId, timestamp }, ERROR_RESPONSE );
 		expect( dispatch ).to.have.been.calledWith(
 			rewindRestoreUpdateError(
 				siteId, timestamp, {

--- a/client/state/data-layer/wpcom/comments/index.js
+++ b/client/state/data-layer/wpcom/comments/index.js
@@ -115,7 +115,7 @@ export const writePostComment = ( { dispatch }, action ) => {
 	);
 };
 
-export const addComments = ( { dispatch }, action, next, { comments, found } ) => {
+export const addComments = ( { dispatch }, action, { comments, found } ) => {
 	const { siteId, postId, direction } = action;
 	dispatch( {
 		type: COMMENTS_RECEIVE,
@@ -142,7 +142,6 @@ export const addComments = ( { dispatch }, action, next, { comments, found } ) =
 export const writePostCommentSuccess = (
 	{ dispatch },
 	{ siteId, postId, parentCommentId, placeholderId },
-	next,
 	comment,
 ) => {
 	// remove placeholder from state

--- a/client/state/data-layer/wpcom/comments/test/index.js
+++ b/client/state/data-layer/wpcom/comments/test/index.js
@@ -111,7 +111,7 @@ describe( 'wpcom-api', () => {
 					found: -1,
 				};
 
-				addComments( { dispatch }, action, null, data );
+				addComments( { dispatch }, action, data );
 
 				expect( dispatch ).to.have.been.calledOnce;
 				expect( dispatch ).to.have.been.calledWith( {
@@ -135,7 +135,7 @@ describe( 'wpcom-api', () => {
 					found: 2,
 				};
 
-				addComments( { dispatch }, action, null, data );
+				addComments( { dispatch }, action, data );
 
 				expect( dispatch ).to.have.been.calledTwice;
 				expect( dispatch ).to.have.been.calledWith( {

--- a/client/state/data-layer/wpcom/login-2fa/index.js
+++ b/client/state/data-layer/wpcom/login-2fa/index.js
@@ -25,7 +25,7 @@ import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { local } from 'state/data-layer/utils';
 import { addLocaleToWpcomUrl, getLocaleSlug } from 'lib/i18n-utils';
 
-/***
+/**
  * Module constants
  */
 const POLL_APP_PUSH_INTERVAL_SECONDS = 5;
@@ -58,15 +58,14 @@ const requestTwoFactorPushNotificationStatus = ( store, action ) => {
 const receivedTwoFactorPushNotificationApproved = ( { dispatch } ) =>
 	dispatch( { type: TWO_FACTOR_AUTHENTICATION_PUSH_POLL_COMPLETED } );
 
-/***
+/**
  * Receive error from the two factor push notification status http request
  *
  * @param {Object}	 store  Global redux store
  * @param {Object}	 action dispatched action
- * @param {Function} next   dispatches to next middleware in chain
  * @param {Object}	 error  the error object
  */
-const receivedTwoFactorPushNotificationError = ( store, action, next, error ) => {
+const receivedTwoFactorPushNotificationError = ( store, action, error ) => {
 	const isNetworkFailure = ! error.status;
 	const twoStepNonce = get( error, 'response.body.data.two_step_nonce' );
 

--- a/client/state/data-layer/wpcom/me/devices/index.js
+++ b/client/state/data-layer/wpcom/me/devices/index.js
@@ -36,11 +36,10 @@ export const requestUserDevices = ( { dispatch }, action ) => dispatch( http( {
  *
  * @param   {Function} dispatch Redux dispatcher
  * @param   {Object}   action   Redux action
- * @param   {Function} next     data-layer-bypassing dispatcher
  * @param   {Array}    devices  array of raw device data returned from the endpoint
  * @returns {Object}            disparched user devices add action
  */
-export const handleSuccess = ( { dispatch }, action, next, devices ) => dispatch( userDevicesAdd( {
+export const handleSuccess = ( { dispatch }, action, devices ) => dispatch( userDevicesAdd( {
 	devices: devicesFromApi( devices )
 } ) );
 

--- a/client/state/data-layer/wpcom/me/devices/test/index.js
+++ b/client/state/data-layer/wpcom/me/devices/test/index.js
@@ -40,7 +40,7 @@ describe( 'wpcom-api', () => {
 				];
 				const dispatch = spy();
 
-				handleSuccess( { dispatch }, null, null, devices );
+				handleSuccess( { dispatch }, null, devices );
 
 				expect( dispatch ).to.have.been.calledOnce;
 				expect( dispatch ).to.have.been.calledWith( {

--- a/client/state/data-layer/wpcom/me/notification/settings/index.js
+++ b/client/state/data-layer/wpcom/me/notification/settings/index.js
@@ -30,11 +30,10 @@ export const requestNotificationSettings = ( { dispatch }, action ) => dispatch(
  *
  * @param   {Function} dispatch  Redux dispatcher
  * @param   {Object}   action    Redux action
- * @param   {Function} next      data-layer-bypassing dispatcher
  * @param   {Object}   settings  raw notification settings object returned by the endpoint
  * @returns {Object}             disparched user devices add action
  */
-export const updateSettings = ( { dispatch }, action, next, settings ) => dispatch( updateNotificationSettings( {
+export const updateSettings = ( { dispatch }, action, settings ) => dispatch( updateNotificationSettings( {
 	settings
 } ) );
 

--- a/client/state/data-layer/wpcom/me/notification/settings/test/index.js
+++ b/client/state/data-layer/wpcom/me/notification/settings/test/index.js
@@ -34,7 +34,7 @@ describe( '#updateSettings()', () => {
 	it( 'should dispatch notification settings', () => {
 		const dispatch = spy();
 
-		updateSettings( { dispatch }, null, null, {} );
+		updateSettings( { dispatch }, null, {} );
 
 		expect( dispatch ).to.have.been.calledOnce;
 		expect( dispatch ).to.have.been.calledWith( {

--- a/client/state/data-layer/wpcom/me/send-verification-email/index.js
+++ b/client/state/data-layer/wpcom/me/send-verification-email/index.js
@@ -17,7 +17,7 @@ export const requestEmailVerification = function( { dispatch }, action ) {
 	}, action ) );
 };
 
-export const handleError = ( { dispatch }, action, next, rawError ) => {
+export const handleError = ( { dispatch }, action, rawError ) => {
 	dispatch( {
 		type: EMAIL_VERIFY_REQUEST_FAILURE,
 		message: rawError.message,

--- a/client/state/data-layer/wpcom/me/send-verification-email/test/index.js
+++ b/client/state/data-layer/wpcom/me/send-verification-email/test/index.js
@@ -40,7 +40,7 @@ describe( 'send-email-verification', () => {
 		const message = 'This is an error message.';
 		const rawError = Error( message );
 
-		handleError( { dispatch: dispatchSpy }, null, null, rawError );
+		handleError( { dispatch: dispatchSpy }, null, rawError );
 
 		it( 'should dispatch failure action with error message', () => {
 			expect( dispatchSpy ).to.have.been.calledWith( {

--- a/client/state/data-layer/wpcom/me/settings/index.js
+++ b/client/state/data-layer/wpcom/me/settings/index.js
@@ -44,7 +44,7 @@ export const requestUserSettings = ( { dispatch }, action ) => dispatch( http( {
 /*
  * Store the fetched user settings to Redux state
  */
-export const storeFetchedUserSettings = ( { dispatch }, action, next, data ) => {
+export const storeFetchedUserSettings = ( { dispatch }, action, data ) => {
 	dispatch( updateUserSettings( fromApi( data ) ) );
 };
 
@@ -69,7 +69,7 @@ export function saveUserSettings( { dispatch, getState }, action ) {
  * After settings were successfully saved, update the settings stored in the Redux state,
  * clear the unsaved settings list, and re-fetch info about the user.
  */
-export const finishUserSettingsSave = ( { dispatch }, { settingsOverride }, next, data ) => {
+export const finishUserSettingsSave = ( { dispatch }, { settingsOverride }, data ) => {
 	dispatch( updateUserSettings( fromApi( data ) ) );
 	dispatch( clearUnsavedUserSettings( settingsOverride ? keys( settingsOverride ) : null ) );
 

--- a/client/state/data-layer/wpcom/me/settings/test/index.js
+++ b/client/state/data-layer/wpcom/me/settings/test/index.js
@@ -49,7 +49,7 @@ describe( 'wpcom-api', () => {
 			it( 'should dispatch user settings update', () => {
 				const action = { type: 'DUMMY' };
 
-				settingsModule.storeFetchedUserSettings( { dispatch }, action, null, {
+				settingsModule.storeFetchedUserSettings( { dispatch }, action, {
 					language: 'qix',
 				} );
 
@@ -62,7 +62,7 @@ describe( 'wpcom-api', () => {
 			it( 'should decode HTML entities returned in some fields of HTTP response', () => {
 				const action = { type: 'DUMMY' };
 
-				settingsModule.storeFetchedUserSettings( { dispatch }, action, null, {
+				settingsModule.storeFetchedUserSettings( { dispatch }, action, {
 					display_name: 'baz &amp; qix',
 					description: 'foo &amp; bar',
 					user_URL: 'http://example.com?a=b&amp;c=d',
@@ -136,7 +136,7 @@ describe( 'wpcom-api', () => {
 			it( 'should dispatch user settings update and clear all unsaved settings on full save', () => {
 				const action = { type: 'DUMMY' };
 
-				settingsModule.finishUserSettingsSave( { dispatch }, action, null, {
+				settingsModule.finishUserSettingsSave( { dispatch }, action, {
 					language: 'qix',
 				} );
 
@@ -153,7 +153,7 @@ describe( 'wpcom-api', () => {
 				};
 				const action = { type: 'DUMMY', settingsOverride: data };
 
-				settingsModule.finishUserSettingsSave( { dispatch }, action, null, data );
+				settingsModule.finishUserSettingsSave( { dispatch }, action, data );
 
 				expect( dispatch ).to.have.been.calledTwice;
 				expect( dispatch ).to.have.been.calledWith( updateUserSettings( {
@@ -167,7 +167,7 @@ describe( 'wpcom-api', () => {
 			it( 'should decode HTML entities returned in some fields of HTTP response', () => {
 				const action = { type: 'DUMMY' };
 
-				settingsModule.finishUserSettingsSave( { dispatch }, action, null, {
+				settingsModule.finishUserSettingsSave( { dispatch }, action, {
 					display_name: 'baz &amp; qix',
 					description: 'foo &amp; bar',
 					user_URL: 'http://example.com?a=b&amp;c=d',

--- a/client/state/data-layer/wpcom/plans/index.js
+++ b/client/state/data-layer/wpcom/plans/index.js
@@ -19,7 +19,6 @@ import {
  *
  * @param {Function} dispatch Redux dispatcher
  * @param {Object} action Redux action
- * @param {Function} next data-layer-bypassing dispatcher
  * @returns {Object} original action
  */
 export const requestPlans = ( { dispatch }, action ) => dispatch( http( {
@@ -35,10 +34,9 @@ export const requestPlans = ( { dispatch }, action ) => dispatch( http( {
  *
  * @param {Function} dispatch Redux dispatcher
  * @param {Object} action Redux action
- * @param {Function} next dispatches to next middleware in chain
  * @param {Array} plans raw data from plans API
  */
-export const receivePlans = ( { dispatch }, action, next, plans ) => {
+export const receivePlans = ( { dispatch }, action, plans ) => {
 	dispatch( plansRequestSuccessAction() );
 	dispatch( plansReceiveAction( plans ) );
 };
@@ -48,10 +46,9 @@ export const receivePlans = ( { dispatch }, action, next, plans ) => {
  *
  * @param {Function} dispatch Redux dispatcher
  * @param {Object} action Redux action
- * @param {Function} next dispatches to next middleware in chain
  * @param {Object} rawError raw error from HTTP request
  */
-export const receiveError = ( { dispatch }, action, next, rawError ) => {
+export const receiveError = ( { dispatch }, action, rawError ) => {
 	const error = rawError instanceof Error
 		? rawError.message
 		: rawError;

--- a/client/state/data-layer/wpcom/plans/test/index.js
+++ b/client/state/data-layer/wpcom/plans/test/index.js
@@ -47,7 +47,7 @@ describe( 'wpcom-api', () => {
 				const action = plansReceiveAction( plans );
 				const dispatch = spy();
 
-				receivePlans( { dispatch }, action, null, plans );
+				receivePlans( { dispatch }, action, plans );
 
 				expect( dispatch ).to.have.been.calledTwice;
 				expect( dispatch ).to.have.been.calledWith( plansRequestSuccessAction() );
@@ -61,7 +61,7 @@ describe( 'wpcom-api', () => {
 				const action = plansRequestFailureAction( error );
 				const dispatch = spy();
 
-				receiveError( { dispatch }, action, null, error );
+				receiveError( { dispatch }, action, error );
 
 				expect( dispatch ).to.have.been.calledOnce;
 				expect( dispatch ).to.have.been.calledWith( plansRequestFailureAction( error ) );

--- a/client/state/data-layer/wpcom/posts/revisions/index.js
+++ b/client/state/data-layer/wpcom/posts/revisions/index.js
@@ -50,11 +50,10 @@ export function normalizeRevision( revision ) {
  * @param {Object} action Redux action
  * @param {String} action.siteId of the revisions
  * @param {String} action.postId of the revisions
- * @param {Function} next dispatches to next middleware in chain
  * @param {Object} rawError from HTTP request
  * @returns {Object} the dispatched action
  */
-export const receiveError = ( { dispatch }, { siteId, postId }, next, rawError ) =>
+export const receiveError = ( { dispatch }, { siteId, postId }, rawError ) =>
 	dispatch( receivePostRevisionsFailure( siteId, postId, rawError ) );
 
 /**
@@ -64,10 +63,9 @@ export const receiveError = ( { dispatch }, { siteId, postId }, next, rawError )
  * @param {Object} action Redux action
  * @param {String} action.siteId of the revisions
  * @param {String} action.postId of the revisions
- * @param {Function} next dispatches to next middleware in chain
  * @param {Array} revisions raw data from post revisions API
  */
-export const receiveSuccess = ( { dispatch }, { siteId, postId }, next, revisions ) => {
+export const receiveSuccess = ( { dispatch }, { siteId, postId }, revisions ) => {
 	const normalizedRevisions = map( revisions, normalizeRevision );
 
 	forEach( normalizedRevisions, ( revision, index ) => {

--- a/client/state/data-layer/wpcom/posts/revisions/test/index.js
+++ b/client/state/data-layer/wpcom/posts/revisions/test/index.js
@@ -115,7 +115,7 @@ describe( '#receiveSuccess', () => {
 		const action = requestPostRevisions( 12345678, 10 );
 		const dispatch = sinon.spy();
 
-		receiveSuccess( { dispatch }, action, null, successfulPostRevisionsResponse );
+		receiveSuccess( { dispatch }, action, successfulPostRevisionsResponse );
 
 		const expectedRevisions = cloneDeep( normalizedPostRevisions );
 		forEach( expectedRevisions, revision => {
@@ -134,7 +134,7 @@ describe( '#receiveError', () => {
 		const dispatch = sinon.spy();
 		const rawError = new Error( 'Foo Bar' );
 
-		receiveError( { dispatch }, action, null, rawError );
+		receiveError( { dispatch }, action, rawError );
 
 		expect( dispatch ).to.have.been.calledOnce;
 		expect( dispatch ).to.have.been.calledWith( receivePostRevisionsFailure( 12345678, 10, rawError ) );

--- a/client/state/data-layer/wpcom/read/feed/index.js
+++ b/client/state/data-layer/wpcom/read/feed/index.js
@@ -38,7 +38,7 @@ export function initiateFeedSearch( store, action ) {
 	);
 }
 
-export function receiveFeeds( store, action, next, apiResponse ) {
+export function receiveFeeds( store, action, apiResponse ) {
 	const feeds = map( apiResponse.feeds, feed => ( {
 		...feed,
 		feed_URL: feed.subscribe_URL,
@@ -48,7 +48,7 @@ export function receiveFeeds( store, action, next, apiResponse ) {
 	store.dispatch( receiveFeedSearch( queryKey( action.payload ), feeds, total ) );
 }
 
-export function receiveError( store, action, next, error ) {
+export function receiveError( store, action, error ) {
 	if ( process.env.NODE_ENV === 'development' ) {
 		console.error( action, error ); // eslint-disable-line no-console
 	}

--- a/client/state/data-layer/wpcom/read/feed/test/index.js
+++ b/client/state/data-layer/wpcom/read/feed/test/index.js
@@ -86,7 +86,7 @@ describe( 'wpcom-api', () => {
 				const dispatch = sinon.spy();
 				const apiResponse = { feeds, total: 500 };
 
-				receiveFeeds( { dispatch }, action, null, apiResponse );
+				receiveFeeds( { dispatch }, action, apiResponse );
 
 				expect( dispatch ).to.have.been.calledOnce;
 				expect( dispatch ).to.have.been.calledWith(

--- a/client/state/data-layer/wpcom/read/following/mine/delete/index.js
+++ b/client/state/data-layer/wpcom/read/following/mine/delete/index.js
@@ -49,7 +49,7 @@ export function requestUnfollow( { dispatch, getState }, action ) {
 	);
 }
 
-export function receiveUnfollow( store, action, next, response ) {
+export function receiveUnfollow( store, action, response ) {
 	if ( response && ! response.subscribed ) {
 		store.dispatch( local( action ) );
 	} else {

--- a/client/state/data-layer/wpcom/read/following/mine/delete/test/index.js
+++ b/client/state/data-layer/wpcom/read/following/mine/delete/test/index.js
@@ -49,16 +49,6 @@ describe( 'following/mine/delete', () => {
 	} );
 
 	describe( 'receiveUnfollow', () => {
-		it( 'should next the original action', () => {
-			const dispatch = spy();
-			const action = unfollow( 'http://example.com' );
-			const response = {
-				subscribed: false,
-			};
-			receiveUnfollow( { dispatch }, action, null, response );
-			expect( dispatch ).to.be.calledWith( local( action ) );
-		} );
-
 		it( 'should dispatch an error notice and refollow when subscribed is true', () => {
 			const dispatch = spy();
 			const action = unfollow( 'http://example.com' );
@@ -76,7 +66,7 @@ describe( 'following/mine/delete', () => {
 				subscribed: true,
 			};
 
-			receiveUnfollow( { dispatch, getState }, action, null, response );
+			receiveUnfollow( { dispatch, getState }, action, response );
 			expect( dispatch ).to.be.calledWithMatch( { type: NOTICE_CREATE } );
 			expect( dispatch ).to.be.calledWith( local( follow( 'http://example.com' ) ) );
 		} );

--- a/client/state/data-layer/wpcom/read/following/mine/index.js
+++ b/client/state/data-layer/wpcom/read/following/mine/index.js
@@ -65,7 +65,7 @@ export function requestPage( store, action ) {
 
 const MAX_PAGES_TO_FETCH = MAX_ITEMS / ITEMS_PER_PAGE;
 
-export function receivePage( store, action, next, apiResponse ) {
+export function receivePage( store, action, apiResponse ) {
 	if ( ! isValidApiResponse( apiResponse ) ) {
 		receiveError( store );
 		return;

--- a/client/state/data-layer/wpcom/read/following/mine/new/index.js
+++ b/client/state/data-layer/wpcom/read/following/mine/new/index.js
@@ -47,16 +47,16 @@ export function requestFollow( { dispatch, getState }, action ) {
 	);
 }
 
-export function receiveFollow( store, action, next, response ) {
+export function receiveFollow( store, action, response ) {
 	if ( response && response.subscribed ) {
 		const subscription = subscriptionFromApi( response.subscription );
 		store.dispatch( local( follow( action.payload.feedUrl, subscription ) ) );
 	} else {
-		followError( store, action, next, response );
+		followError( store, action, response );
 	}
 }
 
-export function followError( { dispatch }, action, next, response ) {
+export function followError( { dispatch }, action, response ) {
 	dispatch(
 		errorNotice(
 			translate( 'Sorry, there was a problem following %(url)s. Please try again.', {

--- a/client/state/data-layer/wpcom/read/following/mine/new/test/index.js
+++ b/client/state/data-layer/wpcom/read/following/mine/new/test/index.js
@@ -67,7 +67,7 @@ describe( 'receiveFollow', () => {
 				is_owner: false,
 			},
 		};
-		receiveFollow( { dispatch }, action, null, response );
+		receiveFollow( { dispatch }, action, response );
 		expect( dispatch ).to.be.calledWith(
 			local(
 				follow( 'http://example.com', {
@@ -91,7 +91,7 @@ describe( 'receiveFollow', () => {
 			subscribed: false,
 		};
 
-		receiveFollow( { dispatch }, action, null, response );
+		receiveFollow( { dispatch }, action, response );
 		expect( dispatch ).to.be.calledWithMatch( {
 			type: NOTICE_CREATE,
 			notice: { status: 'is-error' },

--- a/client/state/data-layer/wpcom/read/following/mine/test/index.js
+++ b/client/state/data-layer/wpcom/read/following/mine/test/index.js
@@ -97,7 +97,7 @@ describe( 'get follow subscriptions', () => {
 			const dispatch = sinon.spy();
 
 			syncReaderFollows( { dispatch }, startSyncAction );
-			receivePage( { dispatch }, action, null, successfulApiResponse );
+			receivePage( { dispatch }, action, successfulApiResponse );
 
 			expect( dispatch ).to.have.been.calledThrice;
 			expect( dispatch ).to.have.been.calledWith( requestPageAction( 1 ) );
@@ -131,8 +131,8 @@ describe( 'get follow subscriptions', () => {
 			} );
 
 			syncReaderFollows( { dispatch: ignoredDispatch }, startSyncAction );
-			receivePage( { dispatch: ignoredDispatch }, action, null, successfulApiResponse );
-			receivePage( { dispatch, getState }, action, null, {
+			receivePage( { dispatch: ignoredDispatch }, action, successfulApiResponse );
+			receivePage( { dispatch, getState }, action, {
 				number: 0,
 				page: 2,
 				total_subscriptions: 10,
@@ -172,11 +172,11 @@ describe( 'get follow subscriptions', () => {
 			} );
 
 			syncReaderFollows( { dispatch: ignoredDispatch }, startSyncAction );
-			receivePage( { dispatch: ignoredDispatch }, action, null, successfulApiResponse );
+			receivePage( { dispatch: ignoredDispatch }, action, successfulApiResponse );
 
 			updateSeenOnFollow( { dispatch: ignoredDispatch }, follow( 'http://feed.example.com' ) );
 
-			receivePage( { dispatch, getState }, action, null, {
+			receivePage( { dispatch, getState }, action, {
 				number: 0,
 				page: 2,
 				total_subscriptions: 10,

--- a/client/state/data-layer/wpcom/read/recommendations/sites/index.js
+++ b/client/state/data-layer/wpcom/read/recommendations/sites/index.js
@@ -42,7 +42,7 @@ export const fromApi = response => {
 	} ) );
 };
 
-export const receiveRecommendedSitesResponse = ( store, action, next, response ) => {
+export const receiveRecommendedSitesResponse = ( store, action, response ) => {
 	if ( ! response.sites ) {
 		return;
 	}

--- a/client/state/data-layer/wpcom/read/recommendations/sites/test/index.js
+++ b/client/state/data-layer/wpcom/read/recommendations/sites/test/index.js
@@ -68,7 +68,7 @@ describe( 'recommended sites', () => {
 			const dispatch = spy();
 			const action = requestRecommendedSitesAction( { seed } );
 
-			receiveRecommendedSitesResponse( { dispatch }, action, null, response );
+			receiveRecommendedSitesResponse( { dispatch }, action, response );
 			expect( dispatch ).calledWith(
 				receiveRecommendedSites( {
 					sites: fromApi( response ),

--- a/client/state/data-layer/wpcom/read/site/comment-email-subscriptions/delete/index.js
+++ b/client/state/data-layer/wpcom/read/site/comment-email-subscriptions/delete/index.js
@@ -27,7 +27,7 @@ export function requestCommentEmailUnsubscription( { dispatch }, action ) {
 	);
 }
 
-export function receiveCommentEmailUnsubscription( store, action, next, response ) {
+export function receiveCommentEmailUnsubscription( store, action, response ) {
 	// validate that it worked
 	// if it did, just swallow this response, as we don't need to pass it along.
 	const subscribed = !! ( response && response.subscribed );

--- a/client/state/data-layer/wpcom/read/site/comment-email-subscriptions/delete/test/index.js
+++ b/client/state/data-layer/wpcom/read/site/comment-email-subscriptions/delete/test/index.js
@@ -43,15 +43,19 @@ describe( 'comment-email-subscriptions', () => {
 		it( 'should do nothing if successful', () => {
 			const dispatch = spy();
 
-			receiveCommentEmailUnsubscription( { dispatch }, null, null, { subscribed: false } );
+			receiveCommentEmailUnsubscription( { dispatch }, null, { subscribed: false } );
 			expect( dispatch ).to.not.have.been.called;
 		} );
 
 		it( 'should dispatch a subscribe if it fails using next', () => {
 			const dispatch = spy();
-			receiveCommentEmailUnsubscription( { dispatch }, { payload: { blogId: 1234 } }, null, {
-				subscribed: true,
-			} );
+			receiveCommentEmailUnsubscription(
+				{ dispatch },
+				{ payload: { blogId: 1234 } },
+				{
+					subscribed: true,
+				}
+			);
 			expect( dispatch ).to.have.been.calledWithMatch( {
 				notice: {
 					text: 'Sorry, we had a problem unsubscribing. Please try again.',

--- a/client/state/data-layer/wpcom/read/site/comment-email-subscriptions/new/index.js
+++ b/client/state/data-layer/wpcom/read/site/comment-email-subscriptions/new/index.js
@@ -27,7 +27,7 @@ export function requestCommentEmailSubscription( { dispatch }, action ) {
 	);
 }
 
-export function receiveCommentEmailSubscription( store, action, next, response ) {
+export function receiveCommentEmailSubscription( store, action, response ) {
 	// validate that it worked
 	const subscribed = !! ( response && response.subscribed );
 	if ( ! subscribed ) {

--- a/client/state/data-layer/wpcom/read/site/comment-email-subscriptions/new/test/index.js
+++ b/client/state/data-layer/wpcom/read/site/comment-email-subscriptions/new/test/index.js
@@ -42,15 +42,19 @@ describe( 'comment-email-subscriptions', () => {
 	describe( 'receiveCommentEmailSubscription', () => {
 		it( 'should do nothing if successful', () => {
 			const dispatch = spy();
-			receiveCommentEmailSubscription( { dispatch }, null, null, { subscribed: true } );
+			receiveCommentEmailSubscription( { dispatch }, null, { subscribed: true } );
 			expect( dispatch ).to.not.have.been.called;
 		} );
 
 		it( 'should dispatch an unsubscribe if it fails using next', () => {
 			const dispatch = spy();
-			receiveCommentEmailSubscription( { dispatch }, { payload: { blogId: 1234 } }, null, {
-				subscribed: false,
-			} );
+			receiveCommentEmailSubscription(
+				{ dispatch },
+				{ payload: { blogId: 1234 } },
+				{
+					subscribed: false,
+				}
+			);
 			expect( dispatch ).to.have.been.calledWith( local( unsubscribeToNewCommentEmail( 1234 ) ) );
 			expect( dispatch ).to.have.been.calledWithMatch( {
 				notice: {

--- a/client/state/data-layer/wpcom/read/site/post-email-subscriptions/delete/index.js
+++ b/client/state/data-layer/wpcom/read/site/post-email-subscriptions/delete/index.js
@@ -27,7 +27,7 @@ export function requestPostEmailUnsubscription( { dispatch }, action ) {
 	);
 }
 
-export function receivePostEmailUnsubscription( store, action, next, response ) {
+export function receivePostEmailUnsubscription( store, action, response ) {
 	// validate that it worked
 	// if it did, just swallow this response, as we don't need to pass it along.
 	const subscribed = !! ( response && response.subscribed );

--- a/client/state/data-layer/wpcom/read/site/post-email-subscriptions/delete/test/index.js
+++ b/client/state/data-layer/wpcom/read/site/post-email-subscriptions/delete/test/index.js
@@ -39,15 +39,19 @@ describe( 'comment-email-subscriptions', () => {
 	describe( 'receivePostEmailUnsubscription', () => {
 		it( 'should do nothing if successful', () => {
 			const dispatch = spy();
-			receivePostEmailUnsubscription( { dispatch }, null, null, { subscribed: false } );
+			receivePostEmailUnsubscription( { dispatch }, null, { subscribed: false } );
 			expect( dispatch ).to.not.have.been.called;
 		} );
 
 		it( 'should dispatch a subscribe if it fails using next', () => {
 			const dispatch = spy();
-			receivePostEmailUnsubscription( { dispatch }, { payload: { blogId: 1234 } }, null, {
-				subscribed: true,
-			} );
+			receivePostEmailUnsubscription(
+				{ dispatch },
+				{ payload: { blogId: 1234 } },
+				{
+					subscribed: true,
+				}
+			);
 
 			expect( dispatch ).to.have.been.calledWithMatch( {
 				notice: {

--- a/client/state/data-layer/wpcom/read/site/post-email-subscriptions/new/index.js
+++ b/client/state/data-layer/wpcom/read/site/post-email-subscriptions/new/index.js
@@ -32,7 +32,7 @@ export function requestPostEmailSubscription( { dispatch }, action ) {
 	);
 }
 
-export function receivePostEmailSubscription( store, action, next, response ) {
+export function receivePostEmailSubscription( store, action, response ) {
 	// validate that it worked
 	const subscribed = !! ( response && response.subscribed );
 	if ( ! subscribed ) {

--- a/client/state/data-layer/wpcom/read/site/post-email-subscriptions/new/test/index.js
+++ b/client/state/data-layer/wpcom/read/site/post-email-subscriptions/new/test/index.js
@@ -43,7 +43,7 @@ describe( 'comment-email-subscriptions', () => {
 	describe( 'receivePostEmailSubscription', () => {
 		it( 'should call next to update the subscription with the delivery frequency from the response', () => {
 			const dispatch = spy();
-			receivePostEmailSubscription( { dispatch }, subscribeToNewPostEmail( 1234 ), null, {
+			receivePostEmailSubscription( { dispatch }, subscribeToNewPostEmail( 1234 ), {
 				subscribed: true,
 				subscription: {
 					delivery_frequency: 'daily',
@@ -56,9 +56,13 @@ describe( 'comment-email-subscriptions', () => {
 
 		it( 'should dispatch an unsubscribe if it fails using next', () => {
 			const dispatch = spy();
-			receivePostEmailSubscription( { dispatch }, { payload: { blogId: 1234 } }, null, {
-				subscribed: false,
-			} );
+			receivePostEmailSubscription(
+				{ dispatch },
+				{ payload: { blogId: 1234 } },
+				{
+					subscribed: false,
+				}
+			);
 			expect( dispatch ).to.have.been.calledWithMatch( {
 				notice: {
 					text: 'Sorry, we had a problem subscribing. Please try again.',

--- a/client/state/data-layer/wpcom/read/site/post-email-subscriptions/update/index.js
+++ b/client/state/data-layer/wpcom/read/site/post-email-subscriptions/update/index.js
@@ -39,7 +39,7 @@ export function requestUpdatePostEmailSubscription( { dispatch, getState }, acti
 	);
 }
 
-export function receiveUpdatePostEmailSubscription( store, action, next, response ) {
+export function receiveUpdatePostEmailSubscription( store, action, response ) {
 	if ( ! ( response && response.success ) ) {
 		// revert
 		receiveUpdatePostEmailSubscriptionError( store, action );

--- a/client/state/data-layer/wpcom/read/site/post-email-subscriptions/update/test/index.js
+++ b/client/state/data-layer/wpcom/read/site/post-email-subscriptions/update/test/index.js
@@ -64,20 +64,6 @@ describe( 'comment-email-subscriptions', () => {
 	} );
 
 	describe( 'receiveUpdatePostEmailSubscription', () => {
-		it( 'should do nothing on success', () => {
-			const dispatch = spy();
-			receiveUpdatePostEmailSubscription(
-				{ dispatch },
-				{
-					payload: { blogId: 1234 },
-					meta: { previousState: 'instantly' },
-				},
-				null,
-				{ success: true }
-			);
-			expect( dispatch ).to.have.not.been.called;
-		} );
-
 		it( 'should dispatch an update with the previous state if it is called with null', () => {
 			const dispatch = spy();
 			const previousState = 'instantly';
@@ -87,7 +73,6 @@ describe( 'comment-email-subscriptions', () => {
 					payload: { blogId: 1234 },
 					meta: { previousState },
 				},
-				null,
 				null
 			);
 			expect( dispatch ).to.have.been.calledWith(
@@ -104,7 +89,6 @@ describe( 'comment-email-subscriptions', () => {
 					payload: { blogId: 1234 },
 					meta: { previousState },
 				},
-				null,
 				{ success: false }
 			);
 			expect( dispatch ).to.have.been.calledWith(
@@ -122,8 +106,7 @@ describe( 'comment-email-subscriptions', () => {
 				{
 					payload: { blogId: 1234 },
 					meta: { previousState },
-				},
-				null
+				}
 			);
 			expect( dispatch ).to.have.been.calledWith(
 				local( updateNewPostEmailSubscription( 1234, previousState ) )

--- a/client/state/data-layer/wpcom/read/tags/index.js
+++ b/client/state/data-layer/wpcom/read/tags/index.js
@@ -33,7 +33,7 @@ export function requestTags( store, action ) {
 	);
 }
 
-export function receiveTagsSuccess( store, action, next, apiResponse ) {
+export function receiveTagsSuccess( store, action, apiResponse ) {
 	let tags = fromApi( apiResponse );
 	if ( ! apiResponse || ( ! apiResponse.tag && ! apiResponse.tags ) ) {
 		receiveTagsError( store, action );
@@ -53,7 +53,7 @@ export function receiveTagsSuccess( store, action, next, apiResponse ) {
 	);
 }
 
-export function receiveTagsError( store, action, next, error ) {
+export function receiveTagsError( store, action, error ) {
 	const errorText =
 		action.payload && action.payload.slug
 			? translate( 'Could not load tag, try refreshing the page' )

--- a/client/state/data-layer/wpcom/read/tags/mine/delete/index.js
+++ b/client/state/data-layer/wpcom/read/tags/mine/delete/index.js
@@ -34,7 +34,7 @@ export function requestUnfollow( store, action ) {
  */
 export const fromApi = apiResponse => apiResponse.removed_tag;
 
-export function receiveUnfollowTag( store, action, next, apiResponse ) {
+export function receiveUnfollowTag( store, action, apiResponse ) {
 	if ( apiResponse.subscribed ) {
 		receiveError( store, action );
 		return;
@@ -47,7 +47,7 @@ export function receiveUnfollowTag( store, action, next, apiResponse ) {
 	);
 }
 
-export function receiveError( store, action, next, error ) {
+export function receiveError( store, action, error ) {
 	const errorText = translate( 'Could not unfollow tag: %(tag)s', {
 		args: { tag: action.payload.slug },
 	} );

--- a/client/state/data-layer/wpcom/read/tags/mine/delete/test/index.js
+++ b/client/state/data-layer/wpcom/read/tags/mine/delete/test/index.js
@@ -70,7 +70,7 @@ describe( 'unfollow tag request', () => {
 			const action = requestUnfollowAction( slug );
 			const dispatch = sinon.spy();
 
-			receiveUnfollowTag( { dispatch }, action, null, successfulUnfollowResponse );
+			receiveUnfollowTag( { dispatch }, action, successfulUnfollowResponse );
 
 			expect( dispatch ).to.have.been.calledOnce;
 			expect( dispatch ).to.have.been.calledWith(
@@ -84,7 +84,7 @@ describe( 'unfollow tag request', () => {
 			const action = requestUnfollowAction( slug );
 			const dispatch = sinon.spy();
 
-			receiveUnfollowTag( { dispatch }, action, null, unsuccessfulResponse );
+			receiveUnfollowTag( { dispatch }, action, unsuccessfulResponse );
 
 			expect( dispatch ).to.have.been.calledOnce;
 			expect( dispatch ).to.have.been.calledWithMatch( {
@@ -99,7 +99,7 @@ describe( 'unfollow tag request', () => {
 			const dispatch = sinon.spy();
 			const error = 'could not find tag';
 
-			receiveError( { dispatch }, action, null, error );
+			receiveError( { dispatch }, action, error );
 
 			expect( dispatch ).to.have.been.calledOnce;
 			expect( dispatch ).to.have.been.calledWithMatch( {

--- a/client/state/data-layer/wpcom/read/tags/mine/new/index.js
+++ b/client/state/data-layer/wpcom/read/tags/mine/new/index.js
@@ -28,7 +28,7 @@ export function requestFollowTag( store, action ) {
 	);
 }
 
-export function receiveFollowTag( store, action, next, apiResponse ) {
+export function receiveFollowTag( store, action, apiResponse ) {
 	if ( apiResponse.subscribed === false ) {
 		receiveError( store, action );
 		return;
@@ -47,7 +47,7 @@ export function receiveFollowTag( store, action, next, apiResponse ) {
 	);
 }
 
-export function receiveError( store, action, next, error ) {
+export function receiveError( store, action, error ) {
 	// exit early and do nothing if the error is that the user is already following the tag
 	if ( error && error.error === 'already_subscribed' ) {
 		return;

--- a/client/state/data-layer/wpcom/read/tags/mine/new/test/index.js
+++ b/client/state/data-layer/wpcom/read/tags/mine/new/test/index.js
@@ -73,7 +73,7 @@ describe( 'follow tag request', () => {
 			const action = requestFollowAction( slug );
 			const dispatch = sinon.spy();
 
-			receiveFollowTag( { dispatch }, action, null, successfulFollowResponse );
+			receiveFollowTag( { dispatch }, action, successfulFollowResponse );
 
 			const followedTagId = successfulFollowResponse.added_tag;
 			const followedTag = find( successfulFollowResponse.tags, { ID: followedTagId } );
@@ -94,7 +94,7 @@ describe( 'follow tag request', () => {
 			const action = requestFollowAction( slug );
 			const dispatch = sinon.spy();
 
-			receiveFollowTag( { dispatch }, action, null, unsuccessfulResponse );
+			receiveFollowTag( { dispatch }, action, unsuccessfulResponse );
 			expect( dispatch ).to.have.been.calledWithMatch( {
 				type: NOTICE_CREATE,
 			} );
@@ -107,7 +107,7 @@ describe( 'follow tag request', () => {
 			const dispatch = sinon.spy();
 			const error = 'could not find tag';
 
-			receiveError( { dispatch }, action, null, error );
+			receiveError( { dispatch }, action, error );
 
 			expect( dispatch ).to.have.been.calledOnce;
 			expect( dispatch ).to.have.been.calledWithMatch( {

--- a/client/state/data-layer/wpcom/read/tags/test/index.js
+++ b/client/state/data-layer/wpcom/read/tags/test/index.js
@@ -95,7 +95,7 @@ describe( 'wpcom-api', () => {
 				const action = requestTagsAction( slug );
 				const dispatch = sinon.spy();
 
-				receiveTagsSuccess( { dispatch }, action, null, successfulSingleTagResponse );
+				receiveTagsSuccess( { dispatch }, action, successfulSingleTagResponse );
 
 				expect( dispatch ).to.have.been.calledOnce;
 				expect( dispatch ).to.have.been.calledWith(
@@ -110,7 +110,7 @@ describe( 'wpcom-api', () => {
 				const action = requestTagsAction();
 				const dispatch = sinon.spy();
 
-				receiveTagsSuccess( { dispatch }, action, null, successfulFollowedTagsResponse );
+				receiveTagsSuccess( { dispatch }, action, successfulFollowedTagsResponse );
 
 				const transformedResponse = map( fromApi( successfulFollowedTagsResponse ), tag => ( {
 					...tag,
@@ -133,7 +133,7 @@ describe( 'wpcom-api', () => {
 				const dispatch = sinon.spy();
 				const error = 'could not find tag(s)';
 
-				receiveTagsError( { dispatch }, action, null, error );
+				receiveTagsError( { dispatch }, action, error );
 
 				expect( dispatch ).to.have.been.calledTwice;
 				expect( dispatch ).to.have.been.calledWithMatch( {

--- a/client/state/data-layer/wpcom/sites/activity/index.js
+++ b/client/state/data-layer/wpcom/sites/activity/index.js
@@ -29,11 +29,11 @@ export const handleActivityLogRequest = ( { dispatch }, action ) => {
 // FIXME: Implement fromApi
 const fromApi = ( { activities } ) => activities;
 
-export const receiveActivityLog = ( { dispatch }, { siteId }, next, data ) => {
+export const receiveActivityLog = ( { dispatch }, { siteId }, data ) => {
 	dispatch( activityLogUpdate( siteId, fromApi( data ) ) );
 };
 
-export const receiveActivityLogError = ( { dispatch }, { siteId }, next, error ) => {
+export const receiveActivityLogError = ( { dispatch }, { siteId }, error ) => {
 	dispatch( activityLogError(
 		siteId,
 		pick( error, [ 'error', 'status', 'message' ]

--- a/client/state/data-layer/wpcom/sites/activity/test/index.js
+++ b/client/state/data-layer/wpcom/sites/activity/test/index.js
@@ -59,7 +59,7 @@ const ERROR_RESPONSE = deepFreeze( {
 describe( 'receiveActivityLog', () => {
 	it( 'should dispatch activity log update action', () => {
 		const dispatch = sinon.spy();
-		receiveActivityLog( { dispatch }, { siteId: SITE_ID }, null, SUCCESS_RESPONSE );
+		receiveActivityLog( { dispatch }, { siteId: SITE_ID }, SUCCESS_RESPONSE );
 		expect( dispatch ).to.have.been.calledWithMatch(
 			activityLogUpdate( SITE_ID, [
 				{
@@ -93,7 +93,7 @@ describe( 'receiveActivityLog', () => {
 describe( 'receiveActivityLogError', () => {
 	it( 'should dispatch activity log error action', () => {
 		const dispatch = sinon.spy();
-		receiveActivityLogError( { dispatch }, { siteId: SITE_ID }, null, ERROR_RESPONSE );
+		receiveActivityLogError( { dispatch }, { siteId: SITE_ID }, ERROR_RESPONSE );
 		expect( dispatch ).to.have.been.calledWith(
 			activityLogError( SITE_ID, {
 				error: 'unknown_blog',

--- a/client/state/data-layer/wpcom/sites/blog-stickers/add/index.js
+++ b/client/state/data-layer/wpcom/sites/blog-stickers/add/index.js
@@ -27,7 +27,7 @@ export function requestBlogStickerAdd( { dispatch }, action ) {
 	);
 }
 
-export function receiveBlogStickerAdd( store, action, next, response ) {
+export function receiveBlogStickerAdd( store, action, response ) {
 	// validate that it worked
 	const isAdded = !! ( response && response.success );
 	if ( ! isAdded ) {

--- a/client/state/data-layer/wpcom/sites/blog-stickers/add/test/index.js
+++ b/client/state/data-layer/wpcom/sites/blog-stickers/add/test/index.js
@@ -37,7 +37,6 @@ describe( 'blog-sticker-add', () => {
 			receiveBlogStickerAdd(
 				{ dispatch },
 				{ payload: { blogId: 123, stickerName: 'broken-in-reader' } },
-				null,
 				{ success: true },
 			);
 			expect( dispatch ).to.have.been.calledWithMatch( {
@@ -52,7 +51,6 @@ describe( 'blog-sticker-add', () => {
 			receiveBlogStickerAdd(
 				{ dispatch },
 				{ payload: { blogId: 123, stickerName: 'broken-in-reader' } },
-				null,
 				{
 					success: false,
 				},

--- a/client/state/data-layer/wpcom/sites/blog-stickers/index.js
+++ b/client/state/data-layer/wpcom/sites/blog-stickers/index.js
@@ -29,7 +29,7 @@ export function requestBlogStickerList( { dispatch }, action ) {
 	);
 }
 
-export function receiveBlogStickerList( store, action, next, response ) {
+export function receiveBlogStickerList( store, action, response ) {
 	// validate that it worked
 	if ( ! response || ! isArray( response ) ) {
 		receiveBlogStickerListError( store, action );

--- a/client/state/data-layer/wpcom/sites/blog-stickers/remove/index.js
+++ b/client/state/data-layer/wpcom/sites/blog-stickers/remove/index.js
@@ -27,7 +27,7 @@ export function requestBlogStickerRemove( { dispatch }, action ) {
 	);
 }
 
-export function receiveBlogStickerRemove( store, action, next, response ) {
+export function receiveBlogStickerRemove( store, action, response ) {
 	// validate that it worked
 	const isRemoved = !! ( response && response.success );
 	if ( ! isRemoved ) {

--- a/client/state/data-layer/wpcom/sites/blog-stickers/remove/test/index.js
+++ b/client/state/data-layer/wpcom/sites/blog-stickers/remove/test/index.js
@@ -41,7 +41,6 @@ describe( 'blog-sticker-remove', () => {
 			receiveBlogStickerRemove(
 				{ dispatch },
 				{ payload: { blogId: 123, stickerName: 'broken-in-reader' } },
-				null,
 				{ success: true },
 			);
 			expect( dispatch ).to.have.been.calledWithMatch( {
@@ -56,7 +55,6 @@ describe( 'blog-sticker-remove', () => {
 			receiveBlogStickerRemove(
 				{ dispatch },
 				{ payload: { blogId: 123, stickerName: 'broken-in-reader' } },
-				null,
 				{
 					success: false,
 				},

--- a/client/state/data-layer/wpcom/sites/comments/comment-tree/index.js
+++ b/client/state/data-layer/wpcom/sites/comments/comment-tree/index.js
@@ -35,7 +35,7 @@ const fetchCommentsTreeForSite = ( { dispatch }, action ) => {
 	);
 };
 
-const addCommentsTree = ( { dispatch }, { query }, next, data ) => {
+const addCommentsTree = ( { dispatch }, { query }, data ) => {
 	const { siteId, status } = query;
 	const commentsTree = data[ 1 ];
 

--- a/client/state/data-layer/wpcom/sites/comments/index.js
+++ b/client/state/data-layer/wpcom/sites/comments/index.js
@@ -93,7 +93,7 @@ export const requestComment = ( store, action ) => {
 	);
 };
 
-export const receiveCommentSuccess = ( store, action, next, response ) => {
+export const receiveCommentSuccess = ( store, action, response ) => {
 	const { siteId } = action;
 	const postId = response && response.post && response.post.ID;
 	store.dispatch( {
@@ -164,7 +164,7 @@ export const fetchCommentsList = ( { dispatch }, action ) => {
 	);
 };
 
-export const addComments = ( { dispatch }, { query: { siteId, status } }, next, { comments } ) => {
+export const addComments = ( { dispatch }, { query: { siteId, status } }, { comments } ) => {
 	// Initialize the comments tree to let CommentList know if a tree is actually loaded and empty.
 	// This is needed as a workaround for Jetpack sites populating their comments trees
 	// via `fetchCommentsList` instead of `fetchCommentsTreeForSite`.

--- a/client/state/data-layer/wpcom/sites/comments/likes/mine/delete/index.js
+++ b/client/state/data-layer/wpcom/sites/comments/likes/mine/delete/index.js
@@ -28,7 +28,6 @@ export const unlikeComment = ( { dispatch }, action ) => {
 export const updateCommentLikes = (
 	{ dispatch },
 	{ siteId, postId, commentId },
-	next,
 	{ like_count },
 ) =>
 	dispatch(

--- a/client/state/data-layer/wpcom/sites/comments/likes/mine/delete/test/index.js
+++ b/client/state/data-layer/wpcom/sites/comments/likes/mine/delete/test/index.js
@@ -45,7 +45,7 @@ describe( '#updateCommentLikes()', () => {
 	it( 'should dispatch a comment like update action', () => {
 		const dispatch = spy();
 
-		updateCommentLikes( { dispatch }, { siteId: SITE_ID, postId: POST_ID, commentId: 1 }, null, {
+		updateCommentLikes( { dispatch }, { siteId: SITE_ID, postId: POST_ID, commentId: 1 }, {
 			like_count: 4,
 		} );
 

--- a/client/state/data-layer/wpcom/sites/comments/likes/new/index.js
+++ b/client/state/data-layer/wpcom/sites/comments/likes/new/index.js
@@ -28,7 +28,6 @@ export const likeComment = ( { dispatch }, action ) => {
 export const updateCommentLikes = (
 	{ dispatch },
 	{ siteId, postId, commentId },
-	next,
 	{ like_count },
 ) =>
 	dispatch(

--- a/client/state/data-layer/wpcom/sites/comments/likes/new/test/index.js
+++ b/client/state/data-layer/wpcom/sites/comments/likes/new/test/index.js
@@ -45,7 +45,7 @@ describe( '#updateCommentLikes()', () => {
 	it( 'should dispatch a comment like update action', () => {
 		const dispatch = spy();
 
-		updateCommentLikes( { dispatch }, { siteId: SITE_ID, postId: POST_ID, commentId: 1 }, null, {
+		updateCommentLikes( { dispatch }, { siteId: SITE_ID, postId: POST_ID, commentId: 1 }, {
 			like_count: 4,
 		} );
 

--- a/client/state/data-layer/wpcom/sites/comments/test/index.js
+++ b/client/state/data-layer/wpcom/sites/comments/test/index.js
@@ -30,7 +30,7 @@ describe( '#addComments', () => {
 	beforeEach( () => ( dispatch = spy() ) );
 
 	it( 'should dispatch a tree initialization action for no comments', () => {
-		addComments( { dispatch }, { query }, null, { comments: [] } );
+		addComments( { dispatch }, { query }, { comments: [] } );
 
 		expect( dispatch ).to.have.been.calledOnce;
 		expect( dispatch.lastCall ).to.have.been.calledWith( {
@@ -44,7 +44,7 @@ describe( '#addComments', () => {
 	it( 'should dispatch to add received comments into state', () => {
 		const comments = [ { ID: 5, post: { ID: 1 } }, { ID: 6, post: { ID: 1 } } ];
 
-		addComments( { dispatch }, { query }, null, { comments } );
+		addComments( { dispatch }, { query }, { comments } );
 
 		expect( dispatch ).to.have.been.calledOnce;
 		expect( dispatch.lastCall ).to.have.been.calledWith( {
@@ -62,7 +62,7 @@ describe( '#addComments', () => {
 			{ ID: 2, post: { ID: 1 } },
 		];
 
-		addComments( { dispatch }, { query }, null, { comments } );
+		addComments( { dispatch }, { query }, { comments } );
 
 		expect( dispatch ).to.have.been.calledTwice;
 
@@ -148,7 +148,7 @@ describe( '#receiveCommentSuccess', () => {
 		const response = { post: { ID: 1 } };
 		const action = requestCommentAction( { siteId, commentId } );
 
-		receiveCommentSuccess( { dispatch }, action, null, response );
+		receiveCommentSuccess( { dispatch }, action, response );
 
 		expect( dispatch ).calledWith( {
 			type: COMMENTS_RECEIVE,
@@ -179,7 +179,7 @@ describe( '#receiveCommentError', () => {
 			},
 		} );
 
-		receiveCommentError( { dispatch, getState }, action, null, response );
+		receiveCommentError( { dispatch, getState }, action, response );
 		expect( dispatch ).to.have.been.calledWithMatch( {
 			notice: {
 				text: 'Failed to retrieve comment for site “sqeeeeee!”',

--- a/client/state/data-layer/wpcom/sites/plugins/new/index.js
+++ b/client/state/data-layer/wpcom/sites/plugins/new/index.js
@@ -63,7 +63,7 @@ const showErrorNotice = ( dispatch, error ) => {
 	dispatch( errorNotice( translate( 'Problem installing the plugin.' ) ) );
 };
 
-export const uploadComplete = ( { dispatch }, { siteId }, next, data ) => {
+export const uploadComplete = ( { dispatch }, { siteId }, data ) => {
 	const { slug: pluginId } = data;
 
 	dispatch( recordTracksEvent( 'calypso_plugin_upload_complete', {
@@ -81,8 +81,7 @@ export const uploadComplete = ( { dispatch }, { siteId }, next, data ) => {
 	showSuccessNotice( dispatch, data );
 };
 
-export const receiveError = ( { dispatch }, { siteId }, next, error ) => {
-
+export const receiveError = ( { dispatch }, { siteId }, error ) => {
 	dispatch( recordTracksEvent( 'calypso_plugin_upload_error', {
 		error_code: error.error,
 		error_message: error.message
@@ -92,7 +91,7 @@ export const receiveError = ( { dispatch }, { siteId }, next, error ) => {
 	dispatch( pluginUploadError( siteId, error ) );
 };
 
-export const updateUploadProgress = ( { dispatch }, { siteId }, next, { loaded, total } ) => {
+export const updateUploadProgress = ( { dispatch }, { siteId }, { loaded, total } ) => {
 	const progress = total ? ( loaded / total ) * 100 : total;
 	dispatch( updatePluginUploadProgress( siteId, progress ) );
 };

--- a/client/state/data-layer/wpcom/sites/plugins/new/test/index.js
+++ b/client/state/data-layer/wpcom/sites/plugins/new/test/index.js
@@ -58,7 +58,7 @@ describe( 'uploadPlugin', () => {
 describe( 'uploadComplete', () => {
 	it( 'should dispatch plugin upload complete action', () => {
 		const dispatch = sinon.spy();
-		uploadComplete( { dispatch }, { siteId }, null, SUCCESS_RESPONSE );
+		uploadComplete( { dispatch }, { siteId }, SUCCESS_RESPONSE );
 		expect( dispatch ).to.have.been.calledWith(
 			completePluginUpload( siteId, pluginId )
 		);
@@ -66,7 +66,7 @@ describe( 'uploadComplete', () => {
 
 	it( 'should dispatch plugin install request success', () => {
 		const dispatch = sinon.spy();
-		uploadComplete( { dispatch }, { siteId }, null, SUCCESS_RESPONSE );
+		uploadComplete( { dispatch }, { siteId }, SUCCESS_RESPONSE );
 		expect( dispatch ).to.have.been.calledWith( {
 			type: PLUGIN_INSTALL_REQUEST_SUCCESS,
 			siteId,
@@ -79,7 +79,7 @@ describe( 'uploadComplete', () => {
 describe( 'receiveError', () => {
 	it( 'should dispatch plugin upload error', () => {
 		const dispatch = sinon.spy();
-		receiveError( { dispatch }, { siteId }, null, ERROR_RESPONSE );
+		receiveError( { dispatch }, { siteId }, ERROR_RESPONSE );
 		expect( dispatch ).to.have.been.calledWith(
 			pluginUploadError( siteId, ERROR_RESPONSE )
 		);
@@ -89,7 +89,7 @@ describe( 'receiveError', () => {
 describe( 'updateUploadProgress', () => {
 	it( 'should dispatch plugin upload progress update', () => {
 		const dispatch = sinon.spy();
-		updateUploadProgress( { dispatch }, { siteId }, null, { loaded: 200, total: 400 } );
+		updateUploadProgress( { dispatch }, { siteId }, { loaded: 200, total: 400 } );
 		expect( dispatch ).to.have.been.calledWith(
 			updatePluginUploadProgress( siteId, 50 )
 		);

--- a/client/state/data-layer/wpcom/sites/simple-payments/index.js
+++ b/client/state/data-layer/wpcom/sites/simple-payments/index.js
@@ -217,13 +217,13 @@ export function requestSimplePaymentsProductDelete( { dispatch }, action ) {
 	);
 }
 
-export const addProduct = ( { dispatch }, { siteId }, next, newProduct ) =>
+export const addProduct = ( { dispatch }, { siteId }, newProduct ) =>
 	dispatch( receiveUpdateProduct( siteId, customPostToProduct( newProduct ) ) );
 
-export const deleteProduct = ( { dispatch }, { siteId }, next, deletedProduct ) =>
+export const deleteProduct = ( { dispatch }, { siteId }, deletedProduct ) =>
 	dispatch( receiveDeleteProduct( siteId, deletedProduct.ID ) );
 
-export const listProduct = ( { dispatch }, { siteId }, next, product ) => {
+export const listProduct = ( { dispatch }, { siteId }, product ) => {
 	if ( ! isValidSimplePaymentsProduct( product ) ) {
 		return;
 	}
@@ -231,7 +231,7 @@ export const listProduct = ( { dispatch }, { siteId }, next, product ) => {
 	dispatch( receiveProduct( siteId, customPostToProduct( product ) ) );
 };
 
-export const listProducts = ( { dispatch }, { siteId }, next, { posts: products } ) => {
+export const listProducts = ( { dispatch }, { siteId }, { posts: products } ) => {
 	const validProducts = filter( products, isValidSimplePaymentsProduct );
 
 	dispatch( receiveProductsList( siteId, validProducts.map( customPostToProduct ) ) );

--- a/client/state/data-layer/wpcom/sites/test/utils.js
+++ b/client/state/data-layer/wpcom/sites/test/utils.js
@@ -97,7 +97,7 @@ describe( 'utility functions', () => {
 			};
 			const comment = { ID: 1, content: 'this is the content' };
 
-			updatePlaceholderComment( { dispatch }, action, null, comment );
+			updatePlaceholderComment( { dispatch }, action, comment );
 
 			expect( dispatch ).to.have.been.calledThrice;
 			expect( dispatch ).to.have.been.calledWith( {
@@ -118,7 +118,7 @@ describe( 'utility functions', () => {
 			};
 			const comment = { ID: 1, content: 'this is the content' };
 
-			updatePlaceholderComment( { dispatch }, action, null, comment );
+			updatePlaceholderComment( { dispatch }, action, comment );
 
 			expect( dispatch ).to.have.been.calledThrice;
 			expect( dispatch ).to.have.been.calledWith( {
@@ -140,7 +140,7 @@ describe( 'utility functions', () => {
 			};
 			const comment = { ID: 1, content: 'this is the content' };
 
-			updatePlaceholderComment( { dispatch }, action, null, comment );
+			updatePlaceholderComment( { dispatch }, action, comment );
 
 			expect( dispatch ).to.have.been.calledThrice;
 			expect( dispatch ).to.have.been.calledWith( {

--- a/client/state/data-layer/wpcom/sites/utils.js
+++ b/client/state/data-layer/wpcom/sites/utils.js
@@ -15,7 +15,7 @@ import { http } from 'state/data-layer/wpcom-http/actions';
 import { getSitePost } from 'state/posts/selectors';
 import { errorNotice } from 'state/notices/actions';
 
-/***
+/**
  * Creates a placeholder comment for a given text and postId
  * We need placehodler id to be unique in the context of siteId, postId for that specific user,
  * date milliseconds will do for that purpose.
@@ -37,7 +37,7 @@ export const createPlaceholderComment = ( commentText, postId, parentCommentId )
 	placeholderState: 'PENDING'
 } );
 
-/***
+/**
  * Creates a placeholder comment for a given text and postId
  * We need placehodler id to be unique in the context of siteId, postId for that specific user,
  * date milliseconds will do for that purpose.
@@ -74,15 +74,14 @@ export const dispatchNewCommentRequest = ( dispatch, action, path ) => {
 	} ) );
 };
 
-/***
+/**
  * updates the placeholder comments with server values
  *
  * @param {Function} dispatch redux dispatcher
  * @param {Object}   action   redux action
- * @param {Function} next     dispatches to next middleware in chain
  * @param {Object}   comment  updated comment from the request response
  */
-export const updatePlaceholderComment = ( { dispatch }, { siteId, postId, parentCommentId, placeholderId }, next, comment ) => {
+export const updatePlaceholderComment = ( { dispatch }, { siteId, postId, parentCommentId, placeholderId }, comment ) => {
 	// remove placeholder from state
 	dispatch( { type: COMMENTS_DELETE, siteId, postId, commentId: placeholderId } );
 	// add new comment to state with updated values from server
@@ -91,7 +90,7 @@ export const updatePlaceholderComment = ( { dispatch }, { siteId, postId, parent
 	dispatch( { type: COMMENTS_COUNT_INCREMENT, siteId, postId } );
 };
 
-/***
+/**
  * dispatches a error notice if creating a new comment request failed
  *
  * @param {Function} dispatch redux dispatcher

--- a/client/state/data-layer/wpcom/theme-filters/index.js
+++ b/client/state/data-layer/wpcom/theme-filters/index.js
@@ -22,7 +22,7 @@ const fetchFilters = ( { dispatch }, action ) => {
 	}, action ) );
 };
 
-const storeFilters = ( { dispatch }, action, next, data ) =>
+const storeFilters = ( { dispatch }, action, data ) =>
 	dispatch( { type: THEME_FILTERS_ADD, filters: data } );
 
 const reportError = ( { dispatch } ) =>

--- a/client/state/data-layer/wpcom/users/index.js
+++ b/client/state/data-layer/wpcom/users/index.js
@@ -53,10 +53,9 @@ export const fetchUsers = ( { dispatch }, action ) => {
  *
  * @param {Function} dispatch Redux dispatcher
  * @param {Object} action Redux action
- * @param {Function} next dispatches to next middleware in chain
  * @param {Array} users raw data from post revisions API
  */
-export const receiveSuccess = ( { dispatch }, action, next, users ) => {
+export const receiveSuccess = ( { dispatch }, action, users ) => {
 	const { page = 1, perPage = DEFAULT_PER_PAGE } = action;
 	const normalizedUsers = map( users, normalizeUser );
 

--- a/client/state/data-layer/wpcom/users/test/index.js
+++ b/client/state/data-layer/wpcom/users/test/index.js
@@ -89,7 +89,7 @@ describe( '#receiveSuccess', () => {
 		const action = requestUsers( 12345678, [ 10, 11 ] );
 		const dispatch = sinon.spy();
 
-		receiveSuccess( { dispatch }, action, null, [
+		receiveSuccess( { dispatch }, action, [
 			{ id: 10 },
 			{ id: 11 },
 		] );
@@ -125,7 +125,6 @@ describe( '#receiveSuccess', () => {
 					},
 				},
 			},
-			null,
 			usersChunks[ 0 ]
 		);
 
@@ -171,7 +170,6 @@ describe( '#receiveSuccess', () => {
 					},
 				},
 			},
-			null,
 			usersChunks[ 0 ]
 		);
 

--- a/client/state/data-layer/wpcom/videos/poster/index.js
+++ b/client/state/data-layer/wpcom/videos/poster/index.js
@@ -15,7 +15,6 @@ import {
  *
  * @param  {Object} store Redux store
  * @param  {Object} action Action object
- * @param {Function} next Dispatches to next middleware in chain
  */
 export const updatePoster = ( { dispatch }, action ) => {
 	if ( ! ( 'file' in action.params || 'atTime' in action.params ) ) {
@@ -36,7 +35,7 @@ export const updatePoster = ( { dispatch }, action ) => {
 	dispatch( http( params, action ) );
 };
 
-export const receivePosterUrl = ( { dispatch }, action, next, { poster: posterUrl } ) => {
+export const receivePosterUrl = ( { dispatch }, action, { poster: posterUrl } ) => {
 	dispatch( setPosterUrl( posterUrl ) );
 };
 
@@ -44,7 +43,7 @@ export const receivePosterError = ( { dispatch } ) => {
 	dispatch( showError() );
 };
 
-export const receiveUploadProgress = ( { dispatch }, action, next, progress ) => {
+export const receiveUploadProgress = ( { dispatch }, action, progress ) => {
 	let percentage = 0;
 
 	if ( 'loaded' in progress && 'total' in progress ) {


### PR DESCRIPTION
@see #14354
@see #15981

In response to deprecating the `next()` in the data layer API this
change removes the usage of it in the existing handlers and tests.

Prior to this change the `next()` function passed into the handlers was
a fake meant to protect against double-dispatching actions until
`next()` was completely eliminated. `next()` had already been removed
from the tests.

This finishes the work by actually removing the function from the
handler signature.

> Waiting on tests for extensions to resolve before deploying…

**Testing**

Test your components, smoke test. The unit tests are working.