### PR TITLE
Site Settings: Improve "Manage your connection" description

### DIFF
--- a/client/my-sites/site-settings/site-tools/index.jsx
+++ b/client/my-sites/site-settings/site-tools/index.jsx
@@ -76,7 +76,7 @@ class SiteTools extends Component {
 		);
 		const manageConnectionTitle = translate( 'Manage your connection' );
 		const manageConnectionText = translate(
-			'Sync your site content for a faster experience, change site owner, cycle or terminate your connection.'
+			'Sync your site content for a faster experience, change site owner, repair or terminate your connection.'
 		);
 
 		const importTitle = translate( 'Import' );


### PR DESCRIPTION
This changes the description of the "Manage connection" link by replacing "cycle" with "repair" which is easier to understand. This was brought up by a translator and I think it's also worth changing in English.

![screen shot 2017-08-09 at 17 30 47](https://user-images.githubusercontent.com/203408/29129888-8ebcba20-7d28-11e7-9775-db398ec45a80.png)
