### PR TITLE
StatsNavigation: Remove bad plugins queries

### DIFF
--- a/client/components/data/query-jetpack-plugins/index.jsx
+++ b/client/components/data/query-jetpack-plugins/index.jsx
@@ -15,7 +15,7 @@ import { isRequestingForSites } from 'state/plugins/installed/selectors';
 class QueryJetpackPlugins extends Component {
 	static propTypes = {
 		siteIds: PropTypes.arrayOf(
-			PropTypes.oneOf( [ PropTypes.string, PropTypes.number ] ).isRequired
+			PropTypes.oneOfType( [ PropTypes.string, PropTypes.number ] ).isRequired
 		).isRequired,
 		isRequestingForSites: PropTypes.bool,
 		fetchPlugins: PropTypes.func,

--- a/client/components/data/query-jetpack-plugins/index.jsx
+++ b/client/components/data/query-jetpack-plugins/index.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -12,6 +13,14 @@ import { fetchPlugins } from 'state/plugins/installed/actions';
 import { isRequestingForSites } from 'state/plugins/installed/selectors';
 
 class QueryJetpackPlugins extends Component {
+	static propTypes = {
+		siteIds: PropTypes.arrayOf(
+			PropTypes.oneOf( [ PropTypes.string, PropTypes.number ] ).isRequired
+		).isRequired,
+		isRequestingForSites: PropTypes.bool,
+		fetchPlugins: PropTypes.func,
+	};
+
 	componentWillMount() {
 		if ( this.props.siteIds && ! this.props.isRequestingForSites ) {
 			this.props.fetchPlugins( this.props.siteIds );
@@ -35,12 +44,6 @@ class QueryJetpackPlugins extends Component {
 		return null;
 	}
 }
-
-QueryJetpackPlugins.propTypes = {
-	siteIds: PropTypes.array.isRequired,
-	isRequestingForSites: PropTypes.bool,
-	fetchPlugins: PropTypes.func
-};
 
 export default connect(
 	( state, props ) => {

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -331,8 +331,8 @@ class ActivityLog extends Component {
 				<StatsFirstView />
 				<SidebarNavigation />
 				<StatsNavigation
-					siteId={ siteId }
 					section="activity"
+					siteId={ siteId }
 					slug={ slug }
 				/>
 				{ this.renderErrorMessage() }

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -21,7 +21,6 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 import {
 	getSiteSlug,
 	getSiteTitle,
-	isJetpackSite,
 } from 'state/sites/selectors';
 import StatsFirstView from '../stats-first-view';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
@@ -54,7 +53,6 @@ const debug = debugFactory( 'calypso:activity-log' );
 
 class ActivityLog extends Component {
 	static propTypes = {
-		isJetpack: PropTypes.bool,
 		restoreProgress: PropTypes.shape( {
 			errorCode: PropTypes.string.isRequired,
 			failureReason: PropTypes.string.isRequired,
@@ -315,7 +313,6 @@ class ActivityLog extends Component {
 
 	render() {
 		const {
-			isJetpack,
 			siteId,
 			siteTitle,
 			slug,
@@ -334,9 +331,9 @@ class ActivityLog extends Component {
 				<StatsFirstView />
 				<SidebarNavigation />
 				<StatsNavigation
-					isJetpack={ isJetpack }
-					slug={ slug }
+					siteId={ siteId }
 					section="activity"
+					slug={ slug }
 				/>
 				{ this.renderErrorMessage() }
 				{ this.renderContent() }
@@ -358,7 +355,6 @@ export default connect(
 		const siteId = getSelectedSiteId( state );
 
 		return {
-			isJetpack: isJetpackSite( state, siteId ),
 			logs: getActivityLogs( state, siteId ),
 			siteId,
 			siteTitle: getSiteTitle( state, siteId ),

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -110,8 +110,8 @@ class StatsSite extends Component {
 				<StatsFirstView />
 				<SidebarNavigation />
 				<StatsNavigation
-					siteId={ siteId }
 					section={ period }
+					siteId={ siteId }
 					slug={ slug }
 				/>
 				<div id="my-stats-content">

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -24,7 +24,6 @@ import StickyPanel from 'components/sticky-panel';
 import config from 'config';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import { getSiteOption, isJetpackSite } from 'state/sites/selectors';
-import { isPluginActive } from 'state/selectors';
 import { recordGoogleEvent } from 'state/analytics/actions';
 
 class StatsSite extends Component {
@@ -61,7 +60,7 @@ class StatsSite extends Component {
 	};
 
 	render() {
-		const { date, isJetpack, hasPodcasts, slug, translate } = this.props;
+		const { date, isJetpack, hasPodcasts, siteId, slug, translate } = this.props;
 		const charts = [
 			{ attr: 'views', legendOptions: [ 'visitors' ], gridicon: 'visible',
 				label: translate( 'Views', { context: 'noun' } ) },
@@ -111,8 +110,9 @@ class StatsSite extends Component {
 				<StatsFirstView />
 				<SidebarNavigation />
 				<StatsNavigation
-					{ ...this.props }
+					siteId={ siteId }
 					section={ period }
+					slug={ slug }
 				/>
 				<div id="my-stats-content">
 					<ChartTabs
@@ -201,7 +201,6 @@ export default connect(
 		return {
 			isJetpack,
 			hasPodcasts: getSiteOption( state, siteId, 'podcasting_archive' ),
-			isStore: isJetpack && isPluginActive( state, siteId, 'woocommerce' ),
 			siteId,
 			slug: getSelectedSiteSlug( state )
 		};

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -22,9 +22,9 @@ import titlecase from 'to-title-case';
 import StatsFirstView from './stats-first-view';
 import StickyPanel from 'components/sticky-panel';
 import config from 'config';
-import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
-import { getSiteOption, isJetpackSite } from 'state/sites/selectors';
-import { recordGoogleEvent } from 'state/analytics/actions';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
+import { getSiteOption, isJetpackSite } from 'state/sites/selectors';
+import { recordGoogleEvent } from 'state/analytics/actions';
 
 class StatsSite extends Component {
 	constructor( props ) {

--- a/client/my-sites/stats/stats-insights/index.jsx
+++ b/client/my-sites/stats/stats-insights/index.jsx
@@ -49,7 +49,7 @@ const StatsInsights = ( props ) => {
 			<StatsFirstView />
 			<SidebarNavigation />
 			<StatsNavigation
-				isJetpack={ isJetpack }
+				siteId={ siteId }
 				section="insights"
 				slug={ siteSlug }
 			/>

--- a/client/my-sites/stats/stats-navigation/index.jsx
+++ b/client/my-sites/stats/stats-navigation/index.jsx
@@ -57,7 +57,7 @@ const StatsNavigation = ( props ) => {
 
 	return (
 		<SectionNav selectedText={ sectionTitles[ section ] }>
-			{ isJetpack && <QueryJetpackPlugins siteIds={ [ siteId ] } /> }
+			{ isJetpack && siteId && <QueryJetpackPlugins siteIds={ [ siteId ] } /> }
 			<NavTabs label={ translate( 'Stats' ) }>
 				<NavItem path={ '/stats/insights' + siteFragment } selected={ section === 'insights' }>
 					{ sectionTitles.insights }

--- a/client/my-sites/stats/stats-navigation/index.jsx
+++ b/client/my-sites/stats/stats-navigation/index.jsx
@@ -1,7 +1,8 @@
 /**
  * External Dependencies
  */
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
 

--- a/client/my-sites/stats/stats-navigation/index.jsx
+++ b/client/my-sites/stats/stats-navigation/index.jsx
@@ -36,7 +36,6 @@ const StatsNavigation = ( props ) => {
 	if ( isStore ) {
 		statsControl = (
 			<SegmentedControl
-				// eslint-disable-next-line wpcalypso/jsx-classname-namespace
 				className="stats-navigation__control is-store"
 				initialSelected="site"
 				options={ [

--- a/client/my-sites/stats/stats-navigation/index.jsx
+++ b/client/my-sites/stats/stats-navigation/index.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External Dependencies
  */
@@ -5,6 +6,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
+import { includes } from 'lodash';
 
 /**
  * Internal dependencies
@@ -17,9 +19,10 @@ import SegmentedControl from 'components/segmented-control';
 import QueryJetpackPlugins from 'components/data/query-jetpack-plugins';
 import { isPluginActive } from 'state/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
+import { UNITS as StoreStatsTabs } from 'extensions/woocommerce/app/store-stats/constants';
 import config from 'config';
 
-const StatsNavigation = ( props ) => {
+const StatsNavigation = props => {
 	const { translate, section, slug, siteId, isJetpack, isStore } = props;
 	const siteFragment = slug ? '/' + slug : '';
 	const sectionTitles = {
@@ -34,6 +37,7 @@ const StatsNavigation = ( props ) => {
 	let statsControl;
 
 	if ( isStore ) {
+		const validSection = includes( Object.keys( StoreStatsTabs ), section ) ? section : 'day';
 		statsControl = (
 			<SegmentedControl
 				className="stats-navigation__control is-store"
@@ -41,22 +45,24 @@ const StatsNavigation = ( props ) => {
 				options={ [
 					{
 						value: 'site',
-						label: translate( 'Site' )
+						label: translate( 'Site' ),
 					},
 					{
 						value: 'store',
 						label: translate( 'Store' ),
-						path: `/store/stats/orders/${ section }/${ slug }` }
+						path: `/store/stats/orders/${ validSection }/${ slug }`,
+					},
 				] }
 			/>
 		);
 	}
 
-	const ActivityTab = config.isEnabled( 'jetpack/activity-log' ) && isJetpack
-		? <NavItem path={ '/stats/activity' + siteFragment } selected={ section === 'activity' }>
-				{ sectionTitles.activity }
-			</NavItem>
-		: null;
+	const ActivityTab =
+		config.isEnabled( 'jetpack/activity-log' ) && isJetpack
+			? <NavItem path={ '/stats/activity' + siteFragment } selected={ section === 'activity' }>
+					{ sectionTitles.activity }
+				</NavItem>
+			: null;
 
 	return (
 		<SectionNav selectedText={ sectionTitles[ section ] }>
@@ -90,18 +96,16 @@ StatsNavigation.propTypes = {
 	isStore: PropTypes.bool,
 	section: PropTypes.string.isRequired,
 	slug: PropTypes.string,
-	siteId: PropTypes.number.isRequired,
+	siteId: PropTypes.number,
 };
 
 const localized = localize( StatsNavigation );
 
-export default connect(
-	( state, { siteId } ) => {
-		const isJetpack = isJetpackSite( state, siteId );
-		return {
-			isJetpack,
-			isStore: isJetpack && isPluginActive( state, siteId, 'woocommerce' ),
-			siteId,
-		};
-	}
-)( localized );
+export default connect( ( state, { siteId } ) => {
+	const isJetpack = isJetpackSite( state, siteId );
+	return {
+		isJetpack,
+		isStore: isJetpack && isPluginActive( state, siteId, 'woocommerce' ),
+		siteId,
+	};
+} )( localized );

--- a/client/my-sites/stats/stats-navigation/index.jsx
+++ b/client/my-sites/stats/stats-navigation/index.jsx
@@ -90,7 +90,7 @@ StatsNavigation.propTypes = {
 	isStore: PropTypes.bool,
 	section: PropTypes.string.isRequired,
 	slug: PropTypes.string,
-	siteId: PropTypes.number,
+	siteId: PropTypes.number.isRequired,
 };
 
 const localized = localize( StatsNavigation );

--- a/client/my-sites/stats/stats-navigation/index.jsx
+++ b/client/my-sites/stats/stats-navigation/index.jsx
@@ -3,6 +3,7 @@
  */
 import React, { PropTypes } from 'react';
 import { localize } from 'i18n-calypso';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
@@ -13,6 +14,8 @@ import NavItem from 'components/section-nav/item';
 import FollowersCount from 'blocks/followers-count';
 import SegmentedControl from 'components/segmented-control';
 import QueryJetpackPlugins from 'components/data/query-jetpack-plugins';
+import { isPluginActive } from 'state/selectors';
+import { isJetpackSite } from 'state/sites/selectors';
 import config from 'config';
 
 const StatsNavigation = ( props ) => {
@@ -90,4 +93,15 @@ StatsNavigation.propTypes = {
 	siteId: PropTypes.number,
 };
 
-export default localize( StatsNavigation );
+const localized = localize( StatsNavigation );
+
+export default connect(
+	( state, { siteId } ) => {
+		const isJetpack = isJetpackSite( state, siteId );
+		return {
+			isJetpack,
+			isStore: isJetpack && isPluginActive( state, siteId, 'woocommerce' ),
+			siteId,
+		};
+	}
+)( localized );


### PR DESCRIPTION
While working on the Activity Log, I noticed bad plugin queries being fired to `/sites/undefined/plugins` on every request.

This PR addresses the problem by correcting the logic and not mounting the query component when a `siteId` is missing.

The PR also improves the query component's `propTypes` to better validate the array of `siteIds` which should help prevent future problems.

The issue appears to have been introduced in 6488094ccb. I'm curious about the motivation for querying plugins from `StatsNavigation` cc/ @psealock. It seems we should either do a better job of querying or move this query component to a different location.

## Testing
* URLs which exhibited the bug are `/stats/insights` and `/stats/activity` for Jetpack sites
* In production, you would see a bad network request to `/sites/undefined/plugins`.
* Visit https://calypso.live/stats/insights?branch=fix/sites-undefined-plugins-request and ensure you _do not_ see the bad request.
* Revert the change from a780648 to see the `propTypes` warning if bad props are passed to the query component.
* Ensure you don't see the store toggle on any of the global stats pages (day, month, year at `/stats` with no site selected).
* Ensure that using the store toggle is visibile works well from all the sections at `/stats/$SECTION/$SITE`. Insights and Activity should both navigate to Day on the store, as they don't have a corresponding seciton.