### PR TITLE
Reader: use ReaderPopover for Share menu

### DIFF
--- a/client/blocks/reader-share/index.jsx
+++ b/client/blocks/reader-share/index.jsx
@@ -15,7 +15,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import PopoverMenu from 'components/popover/menu';
+import ReaderPopoverMenu from 'components/reader-popover/menu';
 import PopoverMenuItem from 'components/popover/menu-item';
 import Gridicon from 'gridicons';
 import * as stats from 'reader/stats';
@@ -174,6 +174,7 @@ class ReaderShare extends React.Component {
 	}
 
 	render() {
+		const { translate } = this.props;
 		const buttonClasses = classnames( {
 			'reader-share__button': true,
 			'ignore-click': true,
@@ -193,7 +194,7 @@ class ReaderShare extends React.Component {
 				<span key="button" ref="shareButton" className={ buttonClasses }>
 					<Gridicon icon="share" size={ this.props.iconSize } />
 					<span className="reader-share__button-label">
-						{ this.props.translate( 'Share', { comment: 'Share the post' } ) }
+						{ translate( 'Share', { comment: 'Share the post' } ) }
 					</span>
 				</span>,
 				this.state.showingMenu &&
@@ -213,23 +214,32 @@ class ReaderShare extends React.Component {
 								position={ this.props.position }
 								className="reader-share__sites-popover"
 							/>
-						: <PopoverMenu
+						: <ReaderPopoverMenu
 								key="menu"
 								context={ this.refs && this.refs.shareButton }
 								isVisible={ this.state.showingMenu }
 								onClose={ this.closeExternalShareMenu }
 								position={ this.props.position }
 								className="popover reader-share__popover"
+								popoverTitle={ translate( 'Share on' ) }
 							>
-								<PopoverMenuItem action="twitter" className="reader-share__popover-item">
+								<PopoverMenuItem
+									action="twitter"
+									className="reader-share__popover-item"
+									title={ translate( 'Share on Twitter' ) }
+								>
 									<SocialLogo icon="twitter" />
 									<span>Twitter</span>
 								</PopoverMenuItem>
-								<PopoverMenuItem action="facebook" className="reader-share__popover-item">
+								<PopoverMenuItem
+									action="facebook"
+									className="reader-share__popover-item"
+									title={ translate( 'Share on Facebook' ) }
+								>
 									<SocialLogo icon="facebook" />
 									<span>Facebook</span>
 								</PopoverMenuItem>
-							</PopoverMenu> ),
+							</ReaderPopoverMenu> ),
 			]
 		);
 	}

--- a/client/components/popover/menu.jsx
+++ b/client/components/popover/menu.jsx
@@ -20,6 +20,7 @@ const PopoverMenu = React.createClass( {
 		className: React.PropTypes.string,
 		rootClassName: React.PropTypes.string,
 		popoverComponent: React.PropTypes.func,
+		popoverTitle: React.PropTypes.string, // used by ReaderPopover
 	},
 
 	getDefaultProps: function() {
@@ -48,6 +49,7 @@ const PopoverMenu = React.createClass( {
 				onShow={ this._onShow }
 				className={ this.props.className }
 				rootClassName={ this.props.rootClassName }
+				popoverTitle={ this.props.popoverTitle }
 			>
 				<div
 					ref="menu"

--- a/client/components/popover/menu.jsx
+++ b/client/components/popover/menu.jsx
@@ -1,26 +1,27 @@
 /** @format */
 /**
-* External dependencies
-*/
-const ReactDom = require( 'react-dom' ),
-	React = require( 'react' );
+ * External dependencies
+ */
+import React from 'react';
+import ReactDom from 'react-dom';
+import PropTypes from 'prop-types';
 import { over } from 'lodash';
 
 /**
-* Internal dependencies
-*/
-const Popover = require( 'components/popover' );
+ * Internal dependencies
+ */
+import Popover from 'components/popover';
 
 const PopoverMenu = React.createClass( {
 	propTypes: {
-		autoPosition: React.PropTypes.bool,
-		isVisible: React.PropTypes.bool.isRequired,
-		onClose: React.PropTypes.func.isRequired,
-		position: React.PropTypes.string,
-		className: React.PropTypes.string,
-		rootClassName: React.PropTypes.string,
-		popoverComponent: React.PropTypes.func,
-		popoverTitle: React.PropTypes.string, // used by ReaderPopover
+		autoPosition: PropTypes.bool,
+		isVisible: PropTypes.bool.isRequired,
+		onClose: PropTypes.func.isRequired,
+		position: PropTypes.string,
+		className: PropTypes.string,
+		rootClassName: PropTypes.string,
+		popoverComponent: PropTypes.func,
+		popoverTitle: PropTypes.string, // used by ReaderPopover
 	},
 
 	getDefaultProps: function() {

--- a/client/components/popover/menu.jsx
+++ b/client/components/popover/menu.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
 * External dependencies
 */
@@ -17,13 +18,15 @@ const PopoverMenu = React.createClass( {
 		onClose: React.PropTypes.func.isRequired,
 		position: React.PropTypes.string,
 		className: React.PropTypes.string,
-		rootClassName: React.PropTypes.string
+		rootClassName: React.PropTypes.string,
+		popoverComponent: React.PropTypes.func,
 	},
 
 	getDefaultProps: function() {
 		return {
 			autoPosition: true,
-			position: 'top'
+			position: 'top',
+			popoverComponent: Popover,
 		};
 	},
 
@@ -34,9 +37,9 @@ const PopoverMenu = React.createClass( {
 
 	render: function() {
 		const children = React.Children.map( this.props.children, this._setPropsOnChild, this );
-
+		const PopoverComponent = this.props.popoverComponent;
 		return (
-			<Popover
+			<PopoverComponent
 				isVisible={ this.props.isVisible }
 				context={ this.props.context }
 				autoPosition={ this.props.autoPosition }
@@ -44,11 +47,18 @@ const PopoverMenu = React.createClass( {
 				onClose={ this._onClose }
 				onShow={ this._onShow }
 				className={ this.props.className }
-				rootClassName={ this.props.rootClassName }>
-				<div ref="menu" role="menu" className="popover__menu" onKeyDown={ this._onKeyDown } tabIndex="-1">
+				rootClassName={ this.props.rootClassName }
+			>
+				<div
+					ref="menu"
+					role="menu"
+					className="popover__menu"
+					onKeyDown={ this._onKeyDown }
+					tabIndex="-1"
+				>
 					{ children }
 				</div>
-			</Popover>
+			</PopoverComponent>
 		);
 	},
 
@@ -65,7 +75,7 @@ const PopoverMenu = React.createClass( {
 		}
 
 		return React.cloneElement( child, {
-			onClick: onClick
+			onClick: onClick,
 		} );
 	},
 
@@ -104,8 +114,7 @@ const PopoverMenu = React.createClass( {
 			return first;
 		}
 
-		const closest = target[ isDownwardMotion
-			? 'nextSibling' : 'previousSibling' ];
+		const closest = target[ isDownwardMotion ? 'nextSibling' : 'previousSibling' ];
 
 		const sibling = closest || last;
 
@@ -154,7 +163,7 @@ const PopoverMenu = React.createClass( {
 		if ( this.props.onClose ) {
 			this.props.onClose( action );
 		}
-	}
+	},
 } );
 
 module.exports = PopoverMenu;

--- a/client/components/reader-popover/index.jsx
+++ b/client/components/reader-popover/index.jsx
@@ -7,7 +7,7 @@ import classnames from 'classnames';
 import { omit } from 'lodash';
 
 /**
- * External Dependencies
+ * Internal Dependencies
  */
 import Popover from 'components/popover';
 

--- a/client/components/reader-popover/menu.jsx
+++ b/client/components/reader-popover/menu.jsx
@@ -1,0 +1,27 @@
+/** @format */
+/**
+ * External Dependencies
+ */
+import React from 'react';
+import { omit } from 'lodash';
+
+/**
+ * Internal Dependencies
+ */
+import ReaderPopover from 'components/reader-popover';
+import PopoverMenu from 'components/popover/menu';
+
+const ReaderPopoverMenu = props => {
+	const popoverProps = omit( props, 'popoverComponent' );
+	return (
+		<PopoverMenu
+			className="reader-popover__menu"
+			popoverComponent={ ReaderPopover }
+			{ ...popoverProps }
+		>
+			{ props.children }
+		</PopoverMenu>
+	);
+};
+
+export default ReaderPopoverMenu;

--- a/client/components/reader-popover/style.scss
+++ b/client/components/reader-popover/style.scss
@@ -4,6 +4,7 @@
 }
 
 // Popover arrows
+.reader-popover.popover.is-bottom .popover__arrow,
 .reader-popover.popover.is-bottom-left .popover__arrow,
 .reader-popover.popover.is-bottom-right .popover__arrow,
 .reader-popover.popover.is-top-left .popover__arrow,
@@ -20,6 +21,7 @@
 	}
 }
 
+.reader-popover.popover.is-bottom .popover__arrow,
 .reader-popover.popover.is-bottom-left .popover__arrow,
 .reader-popover.popover.is-bottom-right .popover__arrow {
 

--- a/client/components/reader-popover/style.scss
+++ b/client/components/reader-popover/style.scss
@@ -45,7 +45,6 @@
 .reader-popover__wrapper {
 	display: flex;
 	flex-direction: column;
-	min-width: 250px;
 }
 
 .reader-popover__header {


### PR DESCRIPTION
Uses the new ReaderPopover component added in https://github.com/Automattic/wp-calypso/pull/16965 for our Share menu.

<img width="834" alt="screen shot 2017-08-09 at 18 30 52" src="https://user-images.githubusercontent.com/17325/29132573-f0062002-7d30-11e7-97f5-efea576ae4fe.png">

Note: this share menu will only appear to you if you are a **user with no sites**. A followup PR will merge the existing sites list menu with the revamped Twitter/Facebook share menu for all users.

### To test

Whilst logging in as a user with no sites, pull up a Reader stream and hit 'Share' on one of the posts.
