### PR TITLE
Simple Payments: Better Trash Confirmation

### DIFF
--- a/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
@@ -247,21 +247,29 @@ class SimplePaymentsDialog extends Component {
 	handleTrash = paymentId => {
 		const { translate } = this.props;
 		const areYouSure = translate(
-			'Are you sure you want to permanently delete this payment button?'
+			'Are you sure you want to delete this item? It will be disabled and removed from all locations where it currently appears.'
 		);
-		accept( areYouSure, accepted => {
-			if ( ! accepted ) {
-				return;
+		accept(
+			areYouSure,
+			accepted => {
+				if ( ! accepted ) {
+					return;
+				}
+
+				this.setIsSubmitting( true );
+
+				const { siteId, dispatch } = this.props;
+
+				dispatch( trashPaymentButton( siteId, paymentId ) )
+					.catch( () => this.showError( translate( 'The payment button could not be deleted.' ) ) )
+					.then( () => this.setIsSubmitting( false ) );
+			},
+			translate( 'Delete' ),
+			null,
+			{
+				isScary: true,
 			}
-
-			this.setIsSubmitting( true );
-
-			const { siteId, dispatch } = this.props;
-
-			dispatch( trashPaymentButton( siteId, paymentId ) )
-				.catch( () => this.showError( translate( 'The payment button could not be deleted.' ) ) )
-				.then( () => this.setIsSubmitting( false ) );
-		} );
+		);
 	};
 
 	getActionButtons() {

--- a/client/lib/accept/README.md
+++ b/client/lib/accept/README.md
@@ -11,6 +11,11 @@ Accept is a stylized substitute to the browser `confirm` dialog.
 * `callback` - A callback that gets called after confirms or cancels the dialog.
 * `confirmButtonText` - Optional confirm button text, defaults to 'OK'.
 * `cancelButtonText` - Optional cancel button text, defaults to 'Cancel'.
+* `options` - Optional parameters
+
+## Options
+
+* `isScary` - if `true`, confirm button will look scary.
 
 ## Usage
 
@@ -25,5 +30,21 @@ accept( 'Are you sure you want to perform this action?', function( accepted ) {
 	} else {
 		// User cancelled or otherwise closed the prompt
 	}
+} );
+```
+
+This will make the confirmation button look scary:
+
+```js
+var accept = require( 'lib/accept' );
+
+accept( 'Are you sure you want to perform this action?', function( accepted ) {
+	if ( accepted ) {
+		// User accepted the prompt
+	} else {
+		// User cancelled or otherwise closed the prompt
+	}
+}, translate( 'Destroy Everything' ), translate( 'Nevermind' ), {
+	isScary: true
 } );
 ```

--- a/client/lib/accept/dialog.jsx
+++ b/client/lib/accept/dialog.jsx
@@ -3,6 +3,7 @@
  */
 import React, { PropTypes } from 'react';
 import { localize } from 'i18n-calypso';
+import classnames from 'classnames';
 
 /**
  * Internal dependencies
@@ -33,8 +34,8 @@ const AcceptDialog = React.createClass( {
 
 	getActionButtons: function() {
 		const { options } = this.props;
-		const isScary = options ? options.isScary : false;
-		const additionalClassNames = isScary ? 'is-scary' : null;
+		const isScary = options && options.isScary;
+		const additionalClassNames = classnames( { 'is-scary': isScary } );
 		return [
 			{
 				action: 'cancel',

--- a/client/lib/accept/dialog.jsx
+++ b/client/lib/accept/dialog.jsx
@@ -15,7 +15,8 @@ const AcceptDialog = React.createClass( {
 		message: PropTypes.node,
 		onClose: PropTypes.func.isRequired,
 		confirmButtonText: PropTypes.node,
-		cancelButtonText: PropTypes.node
+		cancelButtonText: PropTypes.node,
+		options: PropTypes.object
 	},
 
 	getInitialState: function() {
@@ -31,6 +32,9 @@ const AcceptDialog = React.createClass( {
 	},
 
 	getActionButtons: function() {
+		const { options } = this.props;
+		const isScary = options ? options.isScary : false;
+		const additionalClassNames = isScary ? 'is-scary' : null;
 		return [
 			{
 				action: 'cancel',
@@ -39,7 +43,8 @@ const AcceptDialog = React.createClass( {
 			{
 				action: 'accept',
 				label: this.props.confirmButtonText ? this.props.confirmButtonText : this.props.translate( 'OK' ),
-				isPrimary: true
+				isPrimary: true,
+				additionalClassNames
 			}
 		];
 	},

--- a/client/lib/accept/index.js
+++ b/client/lib/accept/index.js
@@ -9,7 +9,7 @@ var ReactDom = require( 'react-dom' ),
  */
 var AcceptDialog = require( './dialog' );
 
-module.exports = function( message, callback, confirmButtonText, cancelButtonText ) {
+module.exports = function( message, callback, confirmButtonText, cancelButtonText, options ) {
 	var wrapper = document.createElement( 'div' );
 	document.body.appendChild( wrapper );
 
@@ -31,6 +31,7 @@ module.exports = function( message, callback, confirmButtonText, cancelButtonTex
 			onClose: onClose,
 			confirmButtonText: confirmButtonText,
 			cancelButtonText: cancelButtonText,
+			options
 		} ),
 		wrapper
 	);


### PR DESCRIPTION
With this PR, Simple Payment Button trash confirmation dialog looks like this:

<img width="604" alt="screenshot_306" src="https://user-images.githubusercontent.com/127594/29141784-7cf6c494-7d04-11e7-8427-d2fbaab2ef11.png">

Test Plan:

1. Open Simple Payments button list.
2. Trash a payment button.
3. Confirmation dialog should look like above image.
