### PR TITLE
Store cleanup: Alphabetize CSS imports

### DIFF
--- a/client/extensions/woocommerce/style.scss
+++ b/client/extensions/woocommerce/style.scss
@@ -1,40 +1,42 @@
 .woocommerce {
 	flex-grow: 1;
 
-	@import 'app/products/products-list';
-	@import 'app/products/product-form';
-	@import 'app/settings/payments/style';
-	@import 'components/action-header/style';
-	@import 'components/address-view/style';
-	@import 'components/bulk-select/style';
-	@import 'components/compact-tinymce/style';
-	@import 'components/extended-header/style';
-	@import 'components/form-click-to-edit-input/style';
-	@import 'components/form-dimensions-input/style';
-	@import 'components/filtered-list/style';
-	@import 'components/process-orders-widget/style';
-	@import 'components/product-image-uploader/style';
-	@import 'app/settings/shipping/style';
-	@import 'app/settings/taxes/style';
-	@import 'components/list/style';
-	@import 'components/location-flag/style';
-	@import 'components/table/style';
 	@import 'app/dashboard/style';
 	@import 'app/order/style';
 	@import 'app/orders/style';
-	@import 'components/order-status/style';
-	@import 'components/basic-widget/style';
-	@import 'components/share-widget/style';
-	@import 'components/reading-widget/style';
-	@import 'components/widget-group/style';
-	@import 'components/sparkline/style';
-	@import 'components/store-address/style';
-	@import 'components/delta/style';
+	@import 'app/settings/payments/style';
+	@import 'app/products/product-form';
+	@import 'app/products/products-list';
+	@import 'app/settings/shipping/style';
+	@import 'app/settings/taxes/style';
 	@import 'app/store-stats/store-stats-chart/style';
 	@import 'app/store-stats/store-stats-module/style';
 	@import 'app/store-stats/store-stats-navigation/style';
 	@import 'app/store-stats/store-stats-widget-list/style';
 	@import 'app/store-stats/style';
+
+	@import 'components/action-header/style';
+	@import 'components/address-view/style';
+	@import 'components/basic-widget/style';
+	@import 'components/bulk-select/style';
+	@import 'components/compact-tinymce/style';
+	@import 'components/delta/style';
+	@import 'components/extended-header/style';
+	@import 'components/filtered-list/style';
+	@import 'components/form-click-to-edit-input/style';
+	@import 'components/form-dimensions-input/style';
+	@import 'components/list/style';
+	@import 'components/location-flag/style';
+	@import 'components/order-status/style';
+	@import 'components/process-orders-widget/style';
+	@import 'components/product-image-uploader/style';
+	@import 'components/reading-widget/style';
+	@import 'components/share-widget/style';
+	@import 'components/sparkline/style';
+	@import 'components/store-address/style';
+	@import 'components/table/style';
+	@import 'components/widget-group/style';
+
 	@import 'woocommerce-services/style';
 
 	.components__action-header {


### PR DESCRIPTION
Every time I open the main `style.scss` file, I notice the `@import`s are not alphabetical, while we alphabetize everywhere else. It's very hard to scan, and things seem haphazard. By best practices, these files should all be self-contained, so there shouldn't be any change in rearranging the file order.

One thing I went back and forth on was whether the `app/*` files should be below the `component/*` files, because we might want to override component styles in specific pages. On the other hand, ideally the components are flexible enough we don't need to do that.

**To test:**

- Open the store and click through pages, make sure nothing looks off.

Requesting reviews from lots of folks just so more people can see this.