### PR TITLE
Reader: Update Conversations sidebar icon

### DIFF
--- a/client/reader/sidebar/index.jsx
+++ b/client/reader/sidebar/index.jsx
@@ -191,7 +191,7 @@ export const ReaderSidebar = createReactClass( {
 										href="/read/conversations"
 										onClick={ this.handleReaderSidebarConversationsClicked }
 									>
-										<Gridicon icon="comment" size={ 24 } />
+										<Gridicon icon="chat" size={ 24 } />
 										<span className="menu-link-text">
 											{ this.props.translate( 'Conversations' ) }
 										</span>


### PR DESCRIPTION
Update Conversations sidebar icon to use two comment bubbles instead of one.

**Before:**
<img width="148" alt="screenshot 2017-08-09 22 08 57" src="https://user-images.githubusercontent.com/4924246/29155273-d078f042-7d4f-11e7-91ef-f2f3192ad5cf.png">

**After:**
<img width="150" alt="screenshot 2017-08-09 22 09 11" src="https://user-images.githubusercontent.com/4924246/29155274-d0799088-7d4f-11e7-8c75-5eabf6397939.png">
