### PR TITLE
SimplePaymentsDialog: fix horizontal centering of product list image

### DIFF
--- a/client/components/tinymce/plugins/simple-payments/style.scss
+++ b/client/components/tinymce/plugins/simple-payments/style.scss
@@ -166,6 +166,7 @@
 
 .editor-simple-payments-modal__figure {
 	display: flex;
+	justify-content: center;
 	align-items: center;
 	border: 1px solid lighten( $gray, 10% );
 	background-color: lighten( $gray, 30% );


### PR DESCRIPTION
The image wasn't property centered when it was tall, portait-mode one.

Before:
<img width="499" alt="screen shot 2017-08-10 at 10 37 52" src="https://user-images.githubusercontent.com/664258/29162065-9df289ee-7db8-11e7-91df-43c39c221e46.png">

After:
<img width="501" alt="screen shot 2017-08-10 at 10 38 56" src="https://user-images.githubusercontent.com/664258/29162068-a01d488a-7db8-11e7-8b68-495e5c78a275.png">
