### PR TITLE
Simple payments: prevent product saving if image not uploaded

### DIFF
--- a/client/blocks/upload-image/index.jsx
+++ b/client/blocks/upload-image/index.jsx
@@ -125,7 +125,7 @@ class UploadImage extends Component {
 
 	onImageEditorDone = ( error, imageBlob, imageEditorProps ) => {
 		if ( error ) {
-			this.handleError( ERROR_IMAGE_EDITOR_DONE, error );
+			return this.handleError( ERROR_IMAGE_EDITOR_DONE, error );
 		}
 
 		this.setState( {

--- a/client/components/tinymce/plugins/simple-payments/dialog/form.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/form.jsx
@@ -80,6 +80,7 @@ const renderField = memoize(
 
 // helper to render UploadImage as a form field
 class UploadImageField extends Component {
+	handleImageEditorDone = () => this.props.input.onChange( 'uploading' );
 	handleImageUploadDone = uploadedImage => this.props.input.onChange( uploadedImage.ID );
 	handleImageRemove = () => this.props.input.onChange( null );
 
@@ -87,6 +88,7 @@ class UploadImageField extends Component {
 		return (
 			<UploadImage
 				defaultImage={ this.props.input.value }
+				onImageEditorDone={ this.handleImageEditorDone }
 				onImageUploadDone={ this.handleImageUploadDone }
 				onImageRemove={ this.handleImageRemove }
 				onError={ this.props.onError }

--- a/client/components/tinymce/plugins/simple-payments/dialog/form.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/form.jsx
@@ -52,6 +52,10 @@ const validate = ( values, props ) => {
 		} );
 	}
 
+	if ( values.featuredImageId && values.featuredImageId === 'uploading' ) {
+		errors.featuredImageId = 'uploading';
+	}
+
 	return errors;
 };
 

--- a/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
@@ -414,6 +414,13 @@ export default connect( ( state, { siteId } ) => {
 		siteId = getSelectedSiteId( state );
 	}
 
+	const productFormValues = getProductFormValues( state );
+	let isProductImageBeingUploaded = false;
+
+	if ( productFormValues ) {
+		isProductImageBeingUploaded = productFormValues.featuredImageId === 'uploading';
+	}
+
 	return {
 		siteId,
 		paymentButtons: getSimplePayments( state, siteId ),
@@ -422,6 +429,7 @@ export default connect( ( state, { siteId } ) => {
 		isJetpackNotSupported:
 			isJetpackSite( state, siteId ) && ! isJetpackMinimumVersion( state, siteId, '5.2' ),
 		planHasSimplePaymentsFeature: hasFeature( state, siteId, FEATURE_SIMPLE_PAYMENTS ),
-		formCanBeSubmitted: isProductFormValid( state ) && isProductFormDirty( state ),
+		formCanBeSubmitted:
+			isProductFormValid( state ) && isProductFormDirty( state ) && ! isProductImageBeingUploaded,
 	};
 } )( localize( SimplePaymentsDialog ) );

--- a/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
@@ -414,13 +414,6 @@ export default connect( ( state, { siteId } ) => {
 		siteId = getSelectedSiteId( state );
 	}
 
-	const productFormValues = getProductFormValues( state );
-	let isProductImageBeingUploaded = false;
-
-	if ( productFormValues ) {
-		isProductImageBeingUploaded = productFormValues.featuredImageId === 'uploading';
-	}
-
 	return {
 		siteId,
 		paymentButtons: getSimplePayments( state, siteId ),
@@ -429,7 +422,6 @@ export default connect( ( state, { siteId } ) => {
 		isJetpackNotSupported:
 			isJetpackSite( state, siteId ) && ! isJetpackMinimumVersion( state, siteId, '5.2' ),
 		planHasSimplePaymentsFeature: hasFeature( state, siteId, FEATURE_SIMPLE_PAYMENTS ),
-		formCanBeSubmitted:
-			isProductFormValid( state ) && isProductFormDirty( state ) && ! isProductImageBeingUploaded,
+		formCanBeSubmitted: isProductFormValid( state ) && isProductFormDirty( state ),
 	};
 } )( localize( SimplePaymentsDialog ) );


### PR DESCRIPTION
When inserting a new Simple Payments product into a post or editing an already inserted one, we have the ability to upload a product image. Unfortunately, we don't have the product image ID until it's not fully uploaded to our servers. That's why we need to prevent product insertion/saving if product image is being uploaded.

## Testing

1. Try to insert or update a product;
2. Try uploading a product image -- are you able to hit "Insert" or "Save" while the image is being uploaded? If not, great.

/cc @Automattic/stark 