### PR TITLE
Activate View Site for Staging

### DIFF
--- a/config/stage.json
+++ b/config/stage.json
@@ -99,6 +99,7 @@
 		"settings/theme-setup": false,
 		"signup/domain-first-flow": true,
 		"signup/social": false,
+		"standalone-site-preview": true,
 		"support-user": true,
 		"sync-handler": true,
 		"ui/first-view": true,


### PR DESCRIPTION
Already live in development environments and wp-calypso, we should take this further. 

Announcement in p58i-6oM-p2
