### PR TITLE
Media library: ES6ify the index file

### DIFF
--- a/client/my-sites/media-library/content.jsx
+++ b/client/my-sites/media-library/content.jsx
@@ -6,6 +6,7 @@ import { connect } from 'react-redux';
 import createFragment from 'react-addons-create-fragment';
 import { groupBy, head, mapValues, noop, some, toArray, values } from 'lodash';
 import { translate } from 'i18n-calypso';
+import PropTypes from 'prop-types';
 import page from 'page';
 
 /**
@@ -36,43 +37,40 @@ import {
 
 const isConnected = props => some( props.connectedServices, item => item.service === props.source );
 
-const MediaLibraryContent = React.createClass( {
-	propTypes: {
-		site: React.PropTypes.object,
-		mediaValidationErrors: React.PropTypes.object,
-		filter: React.PropTypes.string,
-		filterRequiresUpgrade: React.PropTypes.bool,
-		search: React.PropTypes.string,
-		source: React.PropTypes.string,
-		containerWidth: React.PropTypes.number,
-		single: React.PropTypes.bool,
-		scrollable: React.PropTypes.bool,
-		onAddMedia: React.PropTypes.func,
-		onMediaScaleChange: React.PropTypes.func,
-		onEditItem: React.PropTypes.func,
-		postId: React.PropTypes.number
-	},
+class MediaLibraryContent extends React.Component {
+	static propTypes = {
+		site: PropTypes.object,
+		mediaValidationErrors: PropTypes.object,
+		filter: PropTypes.string,
+		filterRequiresUpgrade: PropTypes.bool,
+		search: PropTypes.string,
+		source: PropTypes.string,
+		containerWidth: PropTypes.number,
+		single: PropTypes.bool,
+		scrollable: PropTypes.bool,
+		onAddMedia: PropTypes.func,
+		onMediaScaleChange: PropTypes.func,
+		onEditItem: PropTypes.func,
+		postId: PropTypes.number,
+		isConnected: PropTypes.bool,
+	};
 
-	getDefaultProps: function() {
-		return {
-			mediaValidationErrors: Object.freeze( {} ),
-			onAddMedia: noop,
-			source: '',
-		};
-	},
+	static defaultProps = {
+		mediaValidationErrors: Object.freeze( {} ),
+		onAddMedia: noop,
+		source: '',
+	}
 
-	componentWillMount: function() {
+	componentWillMount() {
 		if ( ! this.props.isRequesting && this.props.source !== '' && this.props.connectedServices.length === 0 ) {
 			// Are we connected to anything yet?
 			this.props.requestKeyringConnections();
 		}
-	},
+	}
 
-	renderErrors: function() {
-		var errorTypes, notices;
-
-		errorTypes = values( this.props.mediaValidationErrors ).map( head );
-		notices = mapValues( groupBy( errorTypes ), ( occurrences, errorType ) => {
+	renderErrors() {
+		const errorTypes = values( this.props.mediaValidationErrors ).map( head );
+		const notices = mapValues( groupBy( errorTypes ), ( occurrences, errorType ) => {
 			let message, onDismiss;
 			const i18nOptions = {
 				count: occurrences.length,
@@ -160,7 +158,7 @@ const MediaLibraryContent = React.createClass( {
 		} );
 
 		return createFragment( notices );
-	},
+	}
 
 	renderTryAgain() {
 		return (
@@ -168,14 +166,14 @@ const MediaLibraryContent = React.createClass( {
 				{ translate( 'Retry' ) }
 			</NoticeAction>
 		);
-	},
+	}
 
 	retryList() {
 		MediaActions.sourceChanged( this.props.site.ID );
-	},
+	}
 
 	renderNoticeAction( upgradeNudgeName, upgradeNudgeFeature ) {
-		if ( !upgradeNudgeName ) {
+		if ( ! upgradeNudgeName ) {
 			return null;
 		}
 		const eventName = 'calypso_upgrade_nudge_impression';
@@ -192,17 +190,17 @@ const MediaLibraryContent = React.createClass( {
 				<TrackComponentView eventName={ eventName } eventProperties={ eventProperties } />
 			</NoticeAction>
 		);
-	},
+	}
 
 	recordPlansNavigation( tracksEvent, tracksData ) {
 		analytics.ga.recordEvent( 'Media', 'Clicked Upload Error Action' );
 		analytics.tracks.recordEvent( tracksEvent, tracksData );
-	},
+	}
 
 	goToSharing( ev ) {
 		ev.preventDefault();
 		page( `/sharing/${ this.props.site.slug }` );
-	},
+	}
 
 	renderExternalMedia() {
 		const connectMessage = translate(
@@ -219,7 +217,7 @@ const MediaLibraryContent = React.createClass( {
 				<p>{ connectMessage }</p>
 			</div>
 		);
-	},
+	}
 
 	getThumbnailType() {
 		if ( this.props.source !== '' ) {
@@ -231,9 +229,9 @@ const MediaLibraryContent = React.createClass( {
 		}
 
 		return MEDIA_IMAGE_PHOTON;
-	},
+	}
 
-	renderMediaList: function() {
+	renderMediaList() {
 		if ( ! this.props.site || this.props.isRequesting ) {
 			return <MediaLibraryList key="list-loading" filterRequiresUpgrade={ this.props.filterRequiresUpgrade } />;
 		}
@@ -264,7 +262,7 @@ const MediaLibraryContent = React.createClass( {
 				</MediaLibrarySelectedData>
 			</MediaListData>
 		);
-	},
+	}
 
 	renderHeader() {
 		if ( this.props.source !== '' ) {
@@ -294,9 +292,9 @@ const MediaLibraryContent = React.createClass( {
 		}
 
 		return null;
-	},
+	}
 
-	render: function() {
+	render() {
 		return (
 			<div className="media-library__content">
 				{ this.renderHeader() }
@@ -305,7 +303,7 @@ const MediaLibraryContent = React.createClass( {
 			</div>
 		);
 	}
-} );
+}
 
 export default connect( ( state, ownProps ) => {
 	return {

--- a/client/my-sites/media-library/filter-bar.jsx
+++ b/client/my-sites/media-library/filter-bar.jsx
@@ -9,6 +9,7 @@ import {
 	noop,
 	pull,
 } from 'lodash';
+import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies
@@ -23,17 +24,17 @@ import TitleItem from './title-item';
 
 export class MediaLibraryFilterBar extends Component {
 	static propTypes = {
-		basePath: React.PropTypes.string,
-		enabledFilters: React.PropTypes.arrayOf( React.PropTypes.string ),
-		filter: React.PropTypes.string,
-		filterRequiresUpgrade: React.PropTypes.bool,
-		search: React.PropTypes.string,
-		source: React.PropTypes.string,
-		site: React.PropTypes.object,
-		onFilterChange: React.PropTypes.func,
-		onSearch: React.PropTypes.func,
-		translate: React.PropTypes.func,
-		post: React.PropTypes.bool
+		basePath: PropTypes.string,
+		enabledFilters: PropTypes.arrayOf( PropTypes.string ),
+		filter: PropTypes.string,
+		filterRequiresUpgrade: PropTypes.bool,
+		search: PropTypes.string,
+		source: PropTypes.string,
+		site: PropTypes.object,
+		onFilterChange: PropTypes.func,
+		onSearch: PropTypes.func,
+		translate: PropTypes.func,
+		post: PropTypes.bool,
 	};
 
 	static defaultProps ={

--- a/client/my-sites/media-library/index.jsx
+++ b/client/my-sites/media-library/index.jsx
@@ -1,73 +1,61 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	classNames = require( 'classnames' ),
-	isEqual = require( 'lodash/isEqual' );
+import React, { Component } from 'react';
+import classNames from 'classnames';
+import { isEqual } from 'lodash';
+import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies
  */
-var Content = require( './content' ),
-	MediaActions = require( 'lib/media/actions' ),
-	MediaLibraryDropZone = require( './drop-zone' ),
-	MediaLibrarySelectedStore = require( 'lib/media/library-selected-store' ),
-	MediaUtils = require( 'lib/media/utils' ),
-	filterToMimePrefix = require( './filter-to-mime-prefix' ),
-	FilterBar = require( './filter-bar' ).default,
-	MediaValidationData = require( 'components/data/media-validation-data' ),
-	urlSearch = require( 'lib/mixins/url-search' );
+import Content from './content';
+import MediaActions from 'lib/media/actions';
+import MediaLibraryDropZone from './drop-zone';
+import MediaLibrarySelectedStore from 'lib/media/library-selected-store';
+import MediaUtils from 'lib/media/utils';
+import filterToMimePrefix from './filter-to-mime-prefix';
+import FilterBar from './filter-bar';
+import MediaValidationData from 'components/data/media-validation-data';
 import QueryPreferences from 'components/data/query-preferences';
+import searchUrl from 'lib/search-url';
 
-module.exports = React.createClass( {
-	displayName: 'MediaLibrary',
+class MediaLibrary extends Component {
+	static propTypes = {
+		className: PropTypes.string,
+		site: PropTypes.object,
+		filter: PropTypes.string,
+		enabledFilters: PropTypes.arrayOf( PropTypes.string ),
+		search: PropTypes.string,
+		source: PropTypes.string,
+		onAddMedia: PropTypes.func,
+		onFilterChange: PropTypes.func,
+		onSourceChange: PropTypes.func,
+		onSearch: PropTypes.func,
+		onScaleChange: PropTypes.func,
+		onEditItem: PropTypes.func,
+		fullScreenDropZone: PropTypes.bool,
+		containerWidth: PropTypes.number,
+		single: PropTypes.bool,
+		scrollable: PropTypes.bool,
+		postId: PropTypes.number,
+	};
 
-	mixins: [ urlSearch ],
+	static getDefaultProps = {
+		fullScreenDropZone: true,
+		onAddMedia: () => {},
+		onScaleChange: () => {},
+		scrollable: false,
+		source: '',
+	};
 
-	propTypes: {
-		className: React.PropTypes.string,
-		site: React.PropTypes.object,
-		filter: React.PropTypes.string,
-		enabledFilters: React.PropTypes.arrayOf( React.PropTypes.string ),
-		search: React.PropTypes.string,
-		source: React.PropTypes.string,
-		onAddMedia: React.PropTypes.func,
-		onFilterChange: React.PropTypes.func,
-		onSearch: React.PropTypes.func,
-		onScaleChange: React.PropTypes.func,
-		onEditItem: React.PropTypes.func,
-		fullScreenDropZone: React.PropTypes.bool,
-		containerWidth: React.PropTypes.number,
-		single: React.PropTypes.bool,
-		scrollable: React.PropTypes.bool,
-		postId: React.PropTypes.number,
-	},
+	doSearch = keywords => {
+		searchUrl( keywords, this.props.search, this.props.onSearch );
+	};
 
-	getDefaultProps: function() {
-		return {
-			fullScreenDropZone: true,
-			onAddMedia: () => {},
-			onScaleChange: () => {},
-			scrollable: false,
-			source: '',
-		};
-	},
-
-	componentDidMount: function() {
-		this.onSearch = this.props.onSearch;
-	},
-
-	componentDidUpdate: function() {
-		this.onSearch = this.props.onSearch;
-	},
-
-	componentWillUnmount: function() {
-		delete this.onSearch;
-	},
-
-	onAddMedia: function() {
-		let selectedItems = MediaLibrarySelectedStore.getAll( this.props.site.ID ),
-			filteredItems = selectedItems;
+	onAddMedia() {
+		const selectedItems = MediaLibrarySelectedStore.getAll( this.props.site.ID );
+		let filteredItems = selectedItems;
 
 		if ( ! this.props.site ) {
 			return;
@@ -93,9 +81,9 @@ module.exports = React.createClass( {
 		}
 
 		this.props.onAddMedia();
-	},
+	}
 
-	filterRequiresUpgrade: function() {
+	filterRequiresUpgrade() {
 		const { filter, site } = this.props;
 		switch ( filter ) {
 			case 'audio':
@@ -106,9 +94,9 @@ module.exports = React.createClass( {
 		}
 
 		return false;
-	},
+	}
 
-	renderDropZone: function() {
+	renderDropZone() {
 		if ( this.props.source !== '' ) {
 			return null;
 		}
@@ -120,10 +108,10 @@ module.exports = React.createClass( {
 				fullScreen={ this.props.fullScreenDropZone }
 				onAddMedia={ this.onAddMedia } />
 		);
-	},
+	}
 
-	render: function() {
-		var classes, content;
+	render() {
+		let content;
 
 		content = (
 			<Content
@@ -153,7 +141,7 @@ module.exports = React.createClass( {
 			);
 		}
 
-		classes = classNames(
+		const classes = classNames(
 			'media-library',
 			{ 'is-single': this.props.single },
 			this.props.className,
@@ -177,4 +165,6 @@ module.exports = React.createClass( {
 			</div>
 		);
 	}
-} );
+}
+
+export default MediaLibrary;


### PR DESCRIPTION
ES6ify the media library index file. I have further changes to make here and it makes sense to convert it over before starting those.

In the move to ES6 the url-search mixin has been dropped and replaced with lib/search-url

## Testing

Manually:
- Open the main media library page
- Perform a media search and note that the URL changes to reflect the search query, and that the search is performed
- Edit a post and open the media library modal
- Perform a search and note that the URL does not change but the search is still performed
- General check that the media library works as expected