### PR TITLE
Fix scroll jumping when opening a dialog in the editor

### DIFF
--- a/client/components/dialog/style.scss
+++ b/client/components/dialog/style.scss
@@ -110,7 +110,3 @@
 .dialog__action-buttons .is-left-aligned {
 	float: left;
 }
-
-.ReactModal__Body--open {
-	overflow: hidden;
-}


### PR DESCRIPTION
react-modal doesn’t apply the ‘open’ class consistently, so removing this style won’t cause any noticeable repercussions.