### PR TITLE
Simple Payments: Upgrade nudge using empty-content

### DIFF
--- a/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
@@ -390,15 +390,14 @@ class SimplePaymentsDialog extends Component {
 			return this.renderEmptyDialog(
 				<EmptyContent
 					illustration="/calypso/images/illustrations/type-e-Commerce.svg"
-					illustrationWidth={ 250 }
-					title={ translate( 'Insert payment button' ) }
-					line={ translate( 'To insert Payment Button to your site, upgrade your plan.' ) }
+					illustrationWidth={ 300 }
+					title={ translate( 'Want to add a payment button to your site?' ) }
 					action={
 						<UpgradeNudge
 							className="editor-simple-payments-modal__nudge-nudge"
-							title={ translate( 'Upgrade to a Premium Plan!' ) }
+							title={ translate( 'Upgrade your plan!' ) }
 							message={ translate(
-								'And get simple payments, advanced social media, your own domain, and more.'
+								'Get simple payments, advanced social media tools, your own domain, and more.'
 							) }
 							feature={ FEATURE_SIMPLE_PAYMENTS }
 							shouldDisplay={ this.returnTrue }

--- a/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
@@ -37,9 +37,9 @@ import {
 } from 'state/simple-payments/product-list/actions';
 import { FEATURE_SIMPLE_PAYMENTS } from 'lib/plans/constants';
 import { hasFeature, getSitePlanSlug } from 'state/sites/plans/selectors';
-import UpgradeNudge from 'my-sites/upgrade-nudge';
 import TrackComponentView from 'lib/analytics/track-component-view';
 import { recordTracksEvent } from 'state/analytics/actions';
+import EmptyContentComponent from 'components/empty-content';
 
 // Utility function for checking the state of the Payment Buttons list
 const isEmptyArray = a => Array.isArray( a ) && a.length === 0;
@@ -350,10 +350,6 @@ class SimplePaymentsDialog extends Component {
 		);
 	}
 
-	returnTrue() {
-		return true;
-	}
-
 	render() {
 		const {
 			showDialog,
@@ -386,23 +382,16 @@ class SimplePaymentsDialog extends Component {
 
 		if ( ! shouldQuerySitePlans && ! planHasSimplePaymentsFeature ) {
 			return this.renderEmptyDialog(
-				<div className="editor-simple-payments-modal__nudge-wrapper">
-					<div className="editor-simple-payments-modal__nudge-title">
-						{ translate( 'Insert payment button' ) }
-					</div>
-					<div className="editor-simple-payments-modal__nudge-subtitle">
-						{ translate( 'To insert Payment Button to your site, upgrade your plan.' ) }
-					</div>
-					<UpgradeNudge
-						className="editor-simple-payments-modal__nudge-nudge"
-						title={ translate( 'Upgrade to a Premium Plan!' ) }
-						message={ translate(
-							'And get simple payments, advanced social media, your own domain, and more.'
-						) }
-						feature={ FEATURE_SIMPLE_PAYMENTS }
-						shouldDisplay={ this.returnTrue }
-					/>
-				</div>
+				<EmptyContentComponent
+					illustration="/calypso/images/illustrations/type-e-Commerce.svg"
+					illustrationWidth="40%"
+					title={ translate( 'To insert Payment Button to your site, upgrade your plan.' ) }
+					line={ translate(
+						'And get simple payments, advanced social media, your own domain, and more.'
+					) }
+					action={ translate( 'Upgrade to a Premium Plan!' ) }
+					actionURL={ '/plans' }
+				/>
 			);
 		}
 

--- a/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
@@ -37,9 +37,10 @@ import {
 } from 'state/simple-payments/product-list/actions';
 import { FEATURE_SIMPLE_PAYMENTS } from 'lib/plans/constants';
 import { hasFeature, getSitePlanSlug } from 'state/sites/plans/selectors';
+import UpgradeNudge from 'my-sites/upgrade-nudge';
 import TrackComponentView from 'lib/analytics/track-component-view';
 import { recordTracksEvent } from 'state/analytics/actions';
-import EmptyContentComponent from 'components/empty-content';
+import EmptyContent from 'components/empty-content';
 
 // Utility function for checking the state of the Payment Buttons list
 const isEmptyArray = a => Array.isArray( a ) && a.length === 0;
@@ -330,7 +331,7 @@ class SimplePaymentsDialog extends Component {
 		return buttons;
 	}
 
-	renderEmptyDialog( content ) {
+	renderEmptyDialog( content, disableNavigation = false ) {
 		const { onClose, translate, showDialog } = this.props;
 		return (
 			<Dialog
@@ -344,10 +345,15 @@ class SimplePaymentsDialog extends Component {
 				additionalClassNames="editor-simple-payments-modal"
 			>
 				<TrackComponentView eventName="calypso_simple_payments_dialog_view" />
-				<Navigation activeTab={ 'list' } paymentButtons={ [] } onChangeTabs={ noop } />
+				{ ! disableNavigation &&
+					<Navigation activeTab={ 'list' } paymentButtons={ [] } onChangeTabs={ noop } /> }
 				{ content }
 			</Dialog>
 		);
+	}
+
+	returnTrue() {
+		return true;
 	}
 
 	render() {
@@ -382,16 +388,24 @@ class SimplePaymentsDialog extends Component {
 
 		if ( ! shouldQuerySitePlans && ! planHasSimplePaymentsFeature ) {
 			return this.renderEmptyDialog(
-				<EmptyContentComponent
+				<EmptyContent
 					illustration="/calypso/images/illustrations/type-e-Commerce.svg"
-					illustrationWidth="40%"
-					title={ translate( 'To insert Payment Button to your site, upgrade your plan.' ) }
-					line={ translate(
-						'And get simple payments, advanced social media, your own domain, and more.'
-					) }
-					action={ translate( 'Upgrade to a Premium Plan!' ) }
-					actionURL={ '/plans' }
-				/>
+					illustrationWidth={ 250 }
+					title={ translate( 'Insert payment button' ) }
+					line={ translate( 'To insert Payment Button to your site, upgrade your plan.' ) }
+					action={
+						<UpgradeNudge
+							className="editor-simple-payments-modal__nudge-nudge"
+							title={ translate( 'Upgrade to a Premium Plan!' ) }
+							message={ translate(
+								'And get simple payments, advanced social media, your own domain, and more.'
+							) }
+							feature={ FEATURE_SIMPLE_PAYMENTS }
+							shouldDisplay={ this.returnTrue }
+						/>
+					}
+				/>,
+				true
 			);
 		}
 

--- a/client/components/tinymce/plugins/simple-payments/style.scss
+++ b/client/components/tinymce/plugins/simple-payments/style.scss
@@ -55,7 +55,7 @@
 		flex-direction: column;
 		flex-grow: 1;
 		justify-content: center;
-		margin: 0;
+		margin: 0 auto;
 		overflow-y: auto;
 		padding: 16px;
 

--- a/client/components/tinymce/plugins/simple-payments/style.scss
+++ b/client/components/tinymce/plugins/simple-payments/style.scss
@@ -50,33 +50,30 @@
 	}
 
 	.empty-content {
-		position: absolute;
-			top: 50%;
-			left: 50%;
-		transform: translate( -50%, -50% );
-		padding-top: 0;
-		padding-bottom: 73px;
+		align-items: center;
+		display: flex;
+		flex-direction: column;
+		flex-grow: 1;
+		justify-content: center;
 		margin: 0;
-		width: 80%;
-		overflow: visible;
+		overflow-y: auto;
+		padding: 16px;
+
+		@include breakpoint( ">480px" ) {
+			padding: 24px;
+		}
 	}
 
 	.empty-content__illustration {
-		margin-bottom: 20px;
-	
-		@media ( max-height: 470px ) {
-			display: none;
-		}
-	
-		@include breakpoint( ">660px" ) {
-			@media ( max-height: 600px ) {
-				display: none;
-			}
-		}
+		margin-bottom: 16px;
+		min-height: 0;
 	}
 
-	.editor-simple-payments-modal__nudge-nudge {
+	.upgrade-nudge.card.editor-simple-payments-modal__nudge-nudge {
+		flex-shrink: 0;
+		margin: 0;
 		text-align: left;
+		width: 70%;
 	}
 }
 

--- a/client/components/tinymce/plugins/simple-payments/style.scss
+++ b/client/components/tinymce/plugins/simple-payments/style.scss
@@ -80,23 +80,6 @@
 	}
 }
 
-// .editor-simple-payments-modal__nudge-wrapper {
-// 	margin: 24px;
-// }
-
-// .editor-simple-payments-modal__nudge-title {
-// 	text-align: center;
-// 	margin-top: 100px;
-// 	font-size: 40px;
-// }
-
-// .editor-simple-payments-modal__nudge-subtitle {
-// 	text-align: center;
-// 	font-size: 18px;
-// 	margin-top: 24px;
-// 	margin-bottom: 60px;
-// }
-
 .editor-simple-payments-modal__nudge-nudge {
 	text-decoration: none;
 }

--- a/client/components/tinymce/plugins/simple-payments/style.scss
+++ b/client/components/tinymce/plugins/simple-payments/style.scss
@@ -48,29 +48,53 @@
 		flex: none;
 		margin-bottom: 0;
 	}
+
+	.empty-content {
+		position: absolute;
+			top: 50%;
+			left: 50%;
+		transform: translate( -50%, -50% );
+		padding-top: 0;
+		padding-bottom: 73px;
+		margin: 0;
+		width: 80%;
+	}
+
+	.empty-content__illustration {
+		margin-bottom: 20px;
+	
+		@media ( max-height: 470px ) {
+			display: none;
+		}
+	
+		@include breakpoint( ">660px" ) {
+			@media ( max-height: 600px ) {
+				display: none;
+			}
+		}
+	}
 }
 
-.editor-simple-payments-modal__nudge-wrapper {
-	margin: 24px;
-}
+// .editor-simple-payments-modal__nudge-wrapper {
+// 	margin: 24px;
+// }
 
-.editor-simple-payments-modal__nudge-title {
-	text-align: center;
-	margin-top: 100px;
-	font-size: 40px;
-}
+// .editor-simple-payments-modal__nudge-title {
+// 	text-align: center;
+// 	margin-top: 100px;
+// 	font-size: 40px;
+// }
 
-.editor-simple-payments-modal__nudge-subtitle {
-	text-align: center;
-	font-size: 18px;
-	margin-top: 24px;
-	margin-bottom: 60px;
-}
+// .editor-simple-payments-modal__nudge-subtitle {
+// 	text-align: center;
+// 	font-size: 18px;
+// 	margin-top: 24px;
+// 	margin-bottom: 60px;
+// }
 
 .editor-simple-payments-modal__nudge-nudge {
 	text-decoration: none;
 }
-
 
 .editor-simple-payments-modal__navigation {
 	margin: 0;

--- a/client/components/tinymce/plugins/simple-payments/style.scss
+++ b/client/components/tinymce/plugins/simple-payments/style.scss
@@ -74,6 +74,10 @@
 			}
 		}
 	}
+
+	.editor-simple-payments-modal__nudge-nudge {
+		text-align: left;
+	}
 }
 
 // .editor-simple-payments-modal__nudge-wrapper {

--- a/client/components/tinymce/plugins/simple-payments/style.scss
+++ b/client/components/tinymce/plugins/simple-payments/style.scss
@@ -58,6 +58,7 @@
 		padding-bottom: 73px;
 		margin: 0;
 		width: 80%;
+		overflow: visible;
 	}
 
 	.empty-content__illustration {


### PR DESCRIPTION
This PR addresses suggestion by @iamtakashi in PR #16875 re using `empty-content` for Simple Payments upgrade nudge UI.

<img width="802" alt="screenshot_320" src="https://user-images.githubusercontent.com/127594/29211910-ac5be19a-7e50-11e7-9e9b-a295fdc83bb3.png">



