### PR TITLE
Reader: integrate sites list into new share popover

### DIFF
--- a/client/blocks/reader-share/index.jsx
+++ b/client/blocks/reader-share/index.jsx
@@ -19,9 +19,10 @@ import ReaderPopoverMenu from 'components/reader-popover/menu';
 import PopoverMenuItem from 'components/popover/menu-item';
 import Gridicon from 'gridicons';
 import * as stats from 'reader/stats';
-import SitesPopover from 'components/sites-popover';
 import { preload as preloadSection } from 'sections-preload';
 import User from 'lib/user';
+import { hasTouch } from 'lib/touch-detect';
+import SiteSelector from 'components/site-selector';
 
 /**
  * Local variables
@@ -198,48 +199,42 @@ class ReaderShare extends React.Component {
 					</span>
 				</span>,
 				this.state.showingMenu &&
-					( canShareToWordPress()
-						? <SitesPopover
-								key="menu"
-								header={
-									<div>
-										{ this.props.translate( 'Share on:' ) }
-									</div>
-								}
-								context={ this.refs && this.refs.shareButton }
-								visible={ this.state.showingMenu }
-								groups={ true }
-								onSiteSelect={ this.pickSiteToShareTo }
-								onClose={ this.closeMenu }
-								position={ this.props.position }
-								className="reader-share__sites-popover"
-							/>
-						: <ReaderPopoverMenu
-								key="menu"
-								context={ this.refs && this.refs.shareButton }
-								isVisible={ this.state.showingMenu }
-								onClose={ this.closeExternalShareMenu }
-								position={ this.props.position }
-								className="popover reader-share__popover"
-								popoverTitle={ translate( 'Share on' ) }
-							>
-								<PopoverMenuItem
-									action="twitter"
-									className="reader-share__popover-item"
-									title={ translate( 'Share on Twitter' ) }
-								>
-									<SocialLogo icon="twitter" />
-									<span>Twitter</span>
-								</PopoverMenuItem>
-								<PopoverMenuItem
-									action="facebook"
-									className="reader-share__popover-item"
-									title={ translate( 'Share on Facebook' ) }
-								>
-									<SocialLogo icon="facebook" />
-									<span>Facebook</span>
-								</PopoverMenuItem>
-							</ReaderPopoverMenu> ),
+					<ReaderPopoverMenu
+						key="menu"
+						context={ this.refs && this.refs.shareButton }
+						isVisible={ this.state.showingMenu }
+						onClose={ this.closeExternalShareMenu }
+						position={ this.props.position }
+						className="popover reader-share__popover"
+						popoverTitle={ translate( 'Share on' ) }
+					>
+						<PopoverMenuItem
+							action="twitter"
+							className="reader-share__popover-item"
+							title={ translate( 'Share on Twitter' ) }
+						>
+							<SocialLogo icon="twitter" />
+							<span>Twitter</span>
+						</PopoverMenuItem>
+						<PopoverMenuItem
+							action="facebook"
+							className="reader-share__popover-item"
+							title={ translate( 'Share on Facebook' ) }
+						>
+							<SocialLogo icon="facebook" />
+							<span>Facebook</span>
+						</PopoverMenuItem>
+						<SiteSelector
+							className="reader-share__site-selector"
+							siteBasePath="/post"
+							onSiteSelect={ this.pickSiteToShareTo }
+							showAddNewSite={ false }
+							indicator={ false }
+							autoFocus={ ! hasTouch() }
+							groups={ true }
+							onClose={ this.closeMenu }
+						/>
+					</ReaderPopoverMenu>,
 			]
 		);
 	}

--- a/client/blocks/reader-share/index.jsx
+++ b/client/blocks/reader-share/index.jsx
@@ -21,7 +21,6 @@ import PopoverMenuItem from 'components/popover/menu-item';
 import Gridicon from 'gridicons';
 import * as stats from 'reader/stats';
 import { preload as preloadSection } from 'sections-preload';
-import { hasTouch } from 'lib/touch-detect';
 import SiteSelector from 'components/site-selector';
 import { getPrimarySiteId } from 'state/selectors';
 
@@ -206,6 +205,7 @@ class ReaderShare extends React.Component {
 							action="facebook"
 							className="reader-share__popover-item"
 							title={ translate( 'Share on Facebook' ) }
+							focusOnHover={ false }
 						>
 							<SocialLogo icon="facebook" />
 							<span>Facebook</span>
@@ -214,22 +214,21 @@ class ReaderShare extends React.Component {
 							action="twitter"
 							className="reader-share__popover-item"
 							title={ translate( 'Share on Twitter' ) }
+							focusOnHover={ false }
 						>
 							<SocialLogo icon="twitter" />
 							<span>Twitter</span>
 						</PopoverMenuItem>
-						{ this.props.hasSites
-							? <SiteSelector
-									className="reader-share__site-selector"
-									siteBasePath="/post"
-									onSiteSelect={ this.pickSiteToShareTo }
-									showAddNewSite={ false }
-									indicator={ false }
-									autoFocus={ ! hasTouch() }
-									groups={ true }
-									onClose={ this.closeMenu }
-								/>
-							: null }
+						{ this.props.hasSites &&
+							<SiteSelector
+								className="reader-share__site-selector"
+								siteBasePath="/post"
+								onSiteSelect={ this.pickSiteToShareTo }
+								showAddNewSite={ false }
+								indicator={ false }
+								autoFocus={ false }
+								groups={ true }
+							/> }
 					</ReaderPopoverMenu>,
 			]
 		);

--- a/client/blocks/reader-share/index.jsx
+++ b/client/blocks/reader-share/index.jsx
@@ -209,20 +209,20 @@ class ReaderShare extends React.Component {
 						popoverTitle={ translate( 'Share on' ) }
 					>
 						<PopoverMenuItem
-							action="twitter"
-							className="reader-share__popover-item"
-							title={ translate( 'Share on Twitter' ) }
-						>
-							<SocialLogo icon="twitter" />
-							<span>Twitter</span>
-						</PopoverMenuItem>
-						<PopoverMenuItem
 							action="facebook"
 							className="reader-share__popover-item"
 							title={ translate( 'Share on Facebook' ) }
 						>
 							<SocialLogo icon="facebook" />
 							<span>Facebook</span>
+						</PopoverMenuItem>
+						<PopoverMenuItem
+							action="twitter"
+							className="reader-share__popover-item"
+							title={ translate( 'Share on Twitter' ) }
+						>
+							<SocialLogo icon="twitter" />
+							<span>Twitter</span>
 						</PopoverMenuItem>
 						<SiteSelector
 							className="reader-share__site-selector"

--- a/client/blocks/reader-share/style.scss
+++ b/client/blocks/reader-share/style.scss
@@ -44,10 +44,6 @@
 
 .reader-share__popover-item {
 
-	@include breakpoint( "<480px" ) {
-		width: 150px;
-	}
-
 	span {
 		display: inline-block;
 		line-height: 24px;
@@ -94,8 +90,29 @@
 	}
 }
 
+.reader-share__popover {
+	min-width: 240px;
+}
+
+.reader-share__site-selector.site-selector {
+	border-top: 1px solid lighten( $gray, 20% );
+}
+
 .reader-share__site-selector .site-selector__sites {
 	max-height: 25vh;
 	overflow-y: auto;
 	text-align: left;
+}
+
+.reader-share__site-selector .site__content {
+	padding: 12px 16px;
+}
+
+.reader-share__site-selector .site__title,
+.reader-share__site-selector .site__domain {
+
+	&::after {
+		background: linear-gradient(to right, rgba(255, 255, 255, 0), $gray-light 90%);
+		border-radius: 50%;
+	}
 }

--- a/client/blocks/reader-share/style.scss
+++ b/client/blocks/reader-share/style.scss
@@ -94,6 +94,8 @@
 	}
 }
 
-.sites-popover.reader-share__sites-popover .site-selector__sites {
+.reader-share__site-selector .site-selector__sites {
 	max-height: 25vh;
+	overflow-y: auto;
+	text-align: left;
 }

--- a/client/components/reader-popover/style.scss
+++ b/client/components/reader-popover/style.scss
@@ -8,7 +8,7 @@
 .reader-popover.popover.is-bottom-left .popover__arrow,
 .reader-popover.popover.is-bottom-right .popover__arrow,
 .reader-popover.popover.is-top-left .popover__arrow,
-.reader-popover.popover.is-top .popover__arrow  {
+.reader-popover.popover.is-top .popover__arrow {
 
 	&::before {
 		border: 10px solid $gray-light;

--- a/client/components/reader-popover/style.scss
+++ b/client/components/reader-popover/style.scss
@@ -8,7 +8,7 @@
 .reader-popover.popover.is-bottom-left .popover__arrow,
 .reader-popover.popover.is-bottom-right .popover__arrow,
 .reader-popover.popover.is-top-left .popover__arrow,
-.reader-popover.popover.is-top-right .popover__arrow {
+.reader-popover.popover.is-top .popover__arrow {
 
 	&::before {
 		border: 10px solid $gray-light;
@@ -32,8 +32,9 @@
 	}
 }
 
+.reader-popover.popover.is-top .popover__arrow,
 .reader-popover.popover.is-top-left .popover__arrow,
-.reader-popover.popover.is-top-right .popover__arrow {
+.reader-popover.popover.is-top-right .popover__arrow  {
 
 	&::before {
 		bottom: 2px;

--- a/client/components/reader-popover/style.scss
+++ b/client/components/reader-popover/style.scss
@@ -8,7 +8,7 @@
 .reader-popover.popover.is-bottom-left .popover__arrow,
 .reader-popover.popover.is-bottom-right .popover__arrow,
 .reader-popover.popover.is-top-left .popover__arrow,
-.reader-popover.popover.is-top .popover__arrow {
+.reader-popover.popover.is-top .popover__arrow  {
 
 	&::before {
 		border: 10px solid $gray-light;
@@ -18,6 +18,22 @@
 		margin-left: -10px;
 		position: absolute;
 			left: 50%;
+	}
+}
+
+.reader-popover.popover.is-left .popover__arrow,
+.reader-popover.popover.is-left-top .popover__arrow,
+.reader-popover.popover.is-bottom .popover__arrow {
+
+	&::before{
+		border: 10px solid $gray-light;
+		border-bottom-color: transparent;
+		border-right: none;
+		border-top-color: transparent;
+		content: " ";
+		margin-top: -10px;
+		position: absolute;
+			top: 50%;
 	}
 }
 

--- a/client/components/reader-popover/style.scss
+++ b/client/components/reader-popover/style.scss
@@ -4,26 +4,42 @@
 }
 
 // Popover arrows
-.reader-popover.popover.is-bottom .popover__arrow,
-.reader-popover.popover.is-bottom-left .popover__arrow,
-.reader-popover.popover.is-bottom-right .popover__arrow,
-.reader-popover.popover.is-top-left .popover__arrow,
-.reader-popover.popover.is-top .popover__arrow {
+.reader-popover.popover.is-top .popover__arrow,
+.reader-popover.popover.is-top-left .popover__arrow {
 
 	&::before {
 		border: 10px solid $gray-light;
+		border-bottom: none;
 		border-left-color: transparent;
 		border-right-color: transparent;
+		border-top-style: solid;
 		content: " ";
 		margin-left: -10px;
 		position: absolute;
+			bottom: 2px;
 			left: 50%;
 	}
 }
 
+.reader-popover.popover.is-bottom .popover__arrow,
+.reader-popover.popover.is-bottom-left .popover__arrow
+.reader-popover.popover.is-bottom-right .popover__arrow {
+
+	&::before{
+		border: 10px solid $gray-light;
+		border-bottom-style: solid;
+		border-left-color: transparent;
+		border-right-color: transparent;
+		border-top: none;
+		content: " ";
+		position: absolute;
+			left: 50%;
+			top: 2px;
+	}
+}
+
 .reader-popover.popover.is-left .popover__arrow,
-.reader-popover.popover.is-left-top .popover__arrow,
-.reader-popover.popover.is-bottom .popover__arrow {
+.reader-popover.popover.is-left-top .popover__arrow {
 
 	&::before{
 		border: 10px solid $gray-light;
@@ -34,28 +50,6 @@
 		margin-top: -10px;
 		position: absolute;
 			top: 50%;
-	}
-}
-
-.reader-popover.popover.is-bottom .popover__arrow,
-.reader-popover.popover.is-bottom-left .popover__arrow,
-.reader-popover.popover.is-bottom-right .popover__arrow {
-
-	&::before {
-		top: 2px;
-		border-bottom-style: solid;
-		border-top: none;
-	}
-}
-
-.reader-popover.popover.is-top .popover__arrow,
-.reader-popover.popover.is-top-left .popover__arrow,
-.reader-popover.popover.is-top-right .popover__arrow  {
-
-	&::before {
-		bottom: 2px;
-		border-bottom: none;
-		border-top-style: solid;
 	}
 }
 

--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -371,7 +371,7 @@ class SiteSelector extends Component {
 
 	render() {
 		const hiddenSitesCount = this.props.siteCount - this.props.visibleSiteCount;
-		const selectorClass = classNames( 'site-selector', 'sites-list', {
+		const selectorClass = classNames( 'site-selector', 'sites-list', this.props.className, {
 			'is-large': this.props.siteCount > 6 || hiddenSitesCount > 0 || this.state.showSearch,
 			'is-single': this.props.visibleSiteCount === 1,
 			'is-hover-enabled': ! this.state.isKeyboardEngaged,


### PR DESCRIPTION
Following on from #17066, this PR integrates the sites list into the new Reader Share popover, and displays the same popover for everybody.

<img width="339" alt="screen shot 2017-08-11 at 15 40 10" src="https://user-images.githubusercontent.com/17325/29215494-7aeef164-7eab-11e7-83a7-3fb588583acc.png">
