### PR TITLE
View Site: Close dropdown on iframe focus

### DIFF
--- a/client/components/web-preview/content.jsx
+++ b/client/components/web-preview/content.jsx
@@ -113,6 +113,8 @@ export class WebPreviewContent extends Component {
 				return;
 			case 'focus':
 				this.removeSelection();
+				// we will fake a click here to close the dropdown
+				this.wrapperElementRef && this.wrapperElementRef.click();
 				return;
 			case 'loading':
 				this.setState( { isLoadingSubpage: true } );
@@ -123,6 +125,10 @@ export class WebPreviewContent extends Component {
 	handleLocationChange = ( payload ) => {
 		this.props.onLocationUpdate( payload.pathname );
 		this.setState( { isLoadingSubpage: false } );
+	}
+
+	setWrapperElement = ( el ) => {
+		this.wrapperElementRef = el;
 	}
 
 	removeSelection = () => {
@@ -240,7 +246,7 @@ export class WebPreviewContent extends Component {
 		);
 
 		return (
-			<div className={ className }>
+			<div className={ className } ref={ this.setWrapperElement }>
 				<Toolbar setDeviceViewport={ this.setDeviceViewport }
 					device={ this.state.device }
 					{ ...this.props }

--- a/client/components/web-preview/toolbar.jsx
+++ b/client/components/web-preview/toolbar.jsx
@@ -104,6 +104,7 @@ class PreviewToolbar extends Component {
 						className="web-preview__device-switcher"
 						selectedText={ selectedDevice.title }
 						selectedIcon={ <Gridicon size={ 18 } icon={ selectedDevice.icon } /> }
+						ref={ this.setDropdown }
 					>
 						{ devicesToShow.map( device => (
 							<DropdownItem


### PR DESCRIPTION
With the idea by @mcsf, we implemented a universal way for things to close/unfocus by firing a click event on wrapper `<div>`. It will make the browser do all the steps for us instead of addressing all possible components directly to close.

To test:
1. go to [calypso.live/view/](https://calypso.live/view?branch=fix/dropdown-focus-view-site) and pick your favorite site
2. open the device picker
3. click inside the preview frame
4. watch the dropdown close once you click
