### PR TITLE
Site block: improve title and change misleading aria-label

### DIFF
--- a/client/blocks/site/docs/example.jsx
+++ b/client/blocks/site/docs/example.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
 * External dependencies
 */
@@ -13,18 +14,15 @@ import Card from 'components/card';
 import { getCurrentUser } from 'state/current-user/selectors';
 import { getSite } from 'state/sites/selectors';
 
-const SiteExample = ( { site } ) => (
+const SiteExample = ( { site } ) =>
 	<Card style={ { padding: 0 } }>
 		<Site site={ site } />
-		<Site compact site={ site } />
-	</Card>
-);
+		<Site compact site={ site } homeLink={ true } />
+	</Card>;
 
-const ConnectedSiteExample = connect(
-	( state ) => ( {
-		site: getSite( state, get( getCurrentUser( state ), 'primary_blog', null ) ),
-	} )
-)( SiteExample );
+const ConnectedSiteExample = connect( state => ( {
+	site: getSite( state, get( getCurrentUser( state ), 'primary_blog', null ) ),
+} ) )( SiteExample );
 
 ConnectedSiteExample.displayName = 'Site';
 

--- a/client/blocks/site/index.jsx
+++ b/client/blocks/site/index.jsx
@@ -1,18 +1,21 @@
+/** @format */
 /**
  * External dependencies
  */
 import React from 'react';
-import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
 import classnames from 'classnames';
 import { noop } from 'lodash';
 import Gridicon from 'gridicons';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
 import SiteIcon from 'blocks/site-icon';
 import SiteIndicator from 'my-sites/site-indicator';
-import { getSite } from 'state/sites/selectors';
+import { getSite } from 'state/sites/selectors';
 
 const Site = React.createClass( {
 	getDefaultProps() {
@@ -35,24 +38,24 @@ const Site = React.createClass( {
 			homeLink: false,
 			// if homeLink is enabled
 			showHomeIcon: true,
-			compact: false
+			compact: false,
 		};
 	},
 
 	propTypes: {
-		href: React.PropTypes.string,
-		externalLink: React.PropTypes.bool,
-		indicator: React.PropTypes.bool,
-		onSelect: React.PropTypes.func,
-		onMouseEnter: React.PropTypes.func,
-		onMouseLeave: React.PropTypes.func,
-		isSelected: React.PropTypes.bool,
-		isHighlighted: React.PropTypes.bool,
-		site: React.PropTypes.object,
-		siteId: React.PropTypes.number,
-		homeLink: React.PropTypes.bool,
-		showHomeIcon: React.PropTypes.bool,
-		compact: React.PropTypes.bool
+		href: PropTypes.string,
+		externalLink: PropTypes.bool,
+		indicator: PropTypes.bool,
+		onSelect: PropTypes.func,
+		onMouseEnter: PropTypes.func,
+		onMouseLeave: PropTypes.func,
+		isSelected: PropTypes.bool,
+		isHighlighted: PropTypes.bool,
+		site: PropTypes.object,
+		siteId: PropTypes.number,
+		homeLink: PropTypes.bool,
+		showHomeIcon: PropTypes.bool,
+		compact: PropTypes.bool,
 	},
 
 	onSelect( event ) {
@@ -68,7 +71,7 @@ const Site = React.createClass( {
 	},
 
 	render() {
-		const site = this.props.site;
+		const { site, translate } = this.props;
 
 		if ( ! site ) {
 			// we could move the placeholder state here
@@ -88,25 +91,23 @@ const Site = React.createClass( {
 
 		return (
 			<div className={ siteClass }>
-				<a className="site__content"
+				<a
+					className="site__content"
 					href={ this.props.homeLink ? site.URL : this.props.href }
 					data-tip-target={ this.props.tipTarget }
 					target={ this.props.externalLink && '_blank' }
-					title={ this.props.homeLink
-						? this.translate( 'View this site' )
-						: this.translate( 'Select this site' )
+					title={
+						this.props.homeLink
+							? translate( 'View site %(domain)s', {
+									args: { domain: site.domain },
+								} )
+							: translate( 'Select site %(domain)s', {
+									args: { domain: site.domain },
+								} )
 					}
 					onClick={ this.onSelect }
 					onMouseEnter={ this.onMouseEnter }
 					onMouseLeave={ this.onMouseLeave }
-					aria-label={ this.props.homeLink && site.is_previewable
-						? this.translate( 'Open site %(domain)s in a preview', {
-							args: { domain: site.domain }
-						} )
-						: this.translate( 'Open site %(domain)s in new tab', {
-							args: { domain: site.domain }
-						} )
-					}
 				>
 					<SiteIcon site={ site } size={ this.props.compact ? 24 : 32 } />
 					<div className="site__info">
@@ -115,38 +116,36 @@ const Site = React.createClass( {
 							{ this.props.site.is_private &&
 								<span className="site__badge">
 									<Gridicon icon="lock" size={ 14 } />
-								</span>
-							}
-							{ site.options && site.options.is_redirect &&
+								</span> }
+							{ site.options &&
+								site.options.is_redirect &&
 								<span className="site__badge">
 									<Gridicon icon="block" size={ 14 } />
-								</span>
-							}
-							{ site.options && site.options.is_domain_only &&
+								</span> }
+							{ site.options &&
+								site.options.is_domain_only &&
 								<span className="site__badge">
 									<Gridicon icon="domains" size={ 14 } />
-								</span>
-							}
+								</span> }
 							{ /* eslint-enable wpcalypso/jsx-gridicon-size */ }
 							{ site.title }
 						</div>
-						<div className="site__domain">{ site.domain }</div>
+						<div className="site__domain">
+							{ site.domain }
+						</div>
 					</div>
-					{ this.props.homeLink && this.props.showHomeIcon &&
+					{ this.props.homeLink &&
+						this.props.showHomeIcon &&
 						<span className="site__home">
 							<Gridicon icon="house" size={ 18 } />
-						</span>
-					}
+						</span> }
 				</a>
-				{ this.props.indicator
-					? <SiteIndicator site={ site } />
-					: null
-				}
+				{ this.props.indicator ? <SiteIndicator site={ site } /> : null }
 			</div>
 		);
-	}
+	},
 } );
 
-export default connect( ( state, { siteId, site } ) => ( {
-	site: siteId ? getSite( state, siteId ) : site
-} ) )( Site );
+export default connect( ( state, { siteId, site } ) => ( {
+	site: siteId ? getSite( state, siteId ) : site,
+} ) )( localize( Site ) );

--- a/client/blocks/site/index.jsx
+++ b/client/blocks/site/index.jsx
@@ -108,6 +108,15 @@ const Site = React.createClass( {
 					onClick={ this.onSelect }
 					onMouseEnter={ this.onMouseEnter }
 					onMouseLeave={ this.onMouseLeave }
+					aria-label={
+						this.props.homeLink
+							? translate( 'View site %(domain)s', {
+									args: { domain: site.domain },
+								} )
+							: translate( 'Select site %(domain)s', {
+									args: { domain: site.domain },
+								} )
+					}
 				>
 					<SiteIcon site={ site } size={ this.props.compact ? 24 : 32 } />
 					<div className="site__info">


### PR DESCRIPTION
The `Site` block helpfully provides an `aria-label` for screenreader users, but its only possible values are:
- Open site %(domain)s in new tab
- Open site %(domain)s in a preview

Now the block is used more widely, those two labels do not cover all of the possible actions. For example, in Reader Share, we use `SiteSelector` and it ends up rendering this:

<img width="843" alt="screen shot 2017-08-10 at 13 25 46" src="https://user-images.githubusercontent.com/17325/29169691-9db07974-7dd5-11e7-9d1e-40f930ab34df.png">

In this scenario, we are not opening bluefutontest5.wordpress.com in a new tab - we're selecting it to reblog a post to.

To support the wider range of uses for `Site`, this PR improves the `title` attribute. It now includes the site name:

Before: "View this site"
After: "View site bluefutontest5.wordpress.com"

Before: "Select this site"
After: "Select site bluefutontest5.wordpress.com"

... and uses the same values for `aria-label`, since `title` is sometimes unreliable on assistive technologies.

Would it also help to have a custom aria-label specified as a prop? Feedback most welcome.

### To test

Visit http://calypso.localhost:3000/devdocs/blocks/site and check the `title`/`aria-label` on the Site block examples.