### PR TITLE
Framework: Don't install make in docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,6 @@ RUN     apt-get -y update && apt-get -y install \
           wget \
           git \
           python \
-          make \
           build-essential
 
 ENV NODE_VERSION 6.11.2


### PR DESCRIPTION
This is obsolete, since our build system is now entirely npm-based.

To test: Build and run Calypso in a local Docker environment, as described at PCYsg-5XR-p2