### PR TITLE
Activity log: Add rewind Activity handling

### DIFF
--- a/client/my-sites/stats/activity-log-item/activity-icon.jsx
+++ b/client/my-sites/stats/activity-log-item/activity-icon.jsx
@@ -94,6 +94,7 @@ export default class ActivityIcon extends PureComponent {
 		const suffix = name.split( '__' )[ 1 ];
 		switch ( suffix ) {
 			case 'deleted':
+			case 'error':
 			case 'trashed':
 				return 'is-error';
 

--- a/client/my-sites/stats/activity-log-item/activity-icon.jsx
+++ b/client/my-sites/stats/activity-log-item/activity-icon.jsx
@@ -16,13 +16,14 @@ export default class ActivityIcon extends PureComponent {
 			'menu',
 			'plugin',
 			'post',
+			'rewind',
 			'term',
 			'theme',
 			'user',
 			'widget',
 		] ).isRequired,
 		name: PropTypes.string.isRequired,
-		object: PropTypes.object.isRequired,
+		object: PropTypes.object,
 	};
 
 	getIcon() {

--- a/client/my-sites/stats/activity-log-item/activity-icon.jsx
+++ b/client/my-sites/stats/activity-log-item/activity-icon.jsx
@@ -54,6 +54,9 @@ export default class ActivityIcon extends PureComponent {
 			case 'post':
 				return 'posts';
 
+			case 'rewind':
+				return 'history';
+
 			case 'term':
 				return 'folder';
 

--- a/client/my-sites/stats/activity-log-item/activity-title.jsx
+++ b/client/my-sites/stats/activity-log-item/activity-title.jsx
@@ -353,6 +353,15 @@ class ActivityTitle extends Component {
 			}
 
 			/**
+			 * Rewind
+			 * @FIXME: Need data from API and activity to produce relevant titles
+			 */
+			case 'rewind__complete':
+				return 'A rewind was completed.';
+			case 'rewind__error':
+				return 'There was an error during rewind.';
+
+			/**
 			 * Term
 			 */
 			case 'term__created': {

--- a/client/my-sites/stats/activity-log-item/activity-title.jsx
+++ b/client/my-sites/stats/activity-log-item/activity-title.jsx
@@ -18,18 +18,6 @@ class ActivityTitle extends Component {
 			login: PropTypes.string,
 		} ),
 
-		group: PropTypes.oneOf( [
-			'attachment',
-			'comment',
-			'core',
-			'menu',
-			'plugin',
-			'post',
-			'term',
-			'theme',
-			'user',
-			'widget',
-		] ).isRequired,
 		name: PropTypes.string.isRequired,
 
 		object: PropTypes.shape( {

--- a/client/my-sites/stats/activity-log-item/index.jsx
+++ b/client/my-sites/stats/activity-log-item/index.jsx
@@ -39,6 +39,7 @@ class ActivityLogItem extends Component {
 				'menu',
 				'plugin',
 				'post',
+				'rewind',
 				'term',
 				'theme',
 				'user',
@@ -77,6 +78,11 @@ class ActivityLogItem extends Component {
 				core: PropTypes.shape( {
 					new_version: PropTypes.string,
 					old_version: PropTypes.string,
+				} ),
+
+				error: PropTypes.shape( {
+					error_code: PropTypes.string,
+					error_message: PropTypes.string,
 				} ),
 
 				menu: PropTypes.shape( {

--- a/client/my-sites/stats/activity-log-item/index.jsx
+++ b/client/my-sites/stats/activity-log-item/index.jsx
@@ -220,7 +220,6 @@ class ActivityLogItem extends Component {
 	renderHeader() {
 		const {
 			action,
-			group,
 			name,
 		} = this.props.log;
 		const actor = get( this.props, [ 'log', 'actor' ] );
@@ -232,7 +231,6 @@ class ActivityLogItem extends Component {
 				<ActivityTitle
 					action={ action }
 					actor={ actor }
-					group={ group }
 					name={ name }
 					object={ object }
 				/>


### PR DESCRIPTION
- Add Rewind activity handling.
- Update `propTypes` accordingly.
- Remove unused `group` prop from `ActivityTitle`.
- Add titles to `rewind__complete` and `rewind__error` activities. More data is likely needed to display relevant titles. Do you have any thoughts about what they should look like @keoshi?

See 58-gh-action-to-activity-log regarding more informative messages and data.

## Testing
1. Visit https://calypso.live/stats/activity?branch=update/activitylog-rewindactivity
1. Verify that rewind activity looks good
1. Verify there are no new console warnings.

## Screens

### Before

<img width="1068" alt="before" src="https://user-images.githubusercontent.com/841763/29177599-61ff4e86-7def-11e7-9c88-f0280740b209.png">

### After

<img width="1084" alt="rewind-activity" src="https://user-images.githubusercontent.com/841763/29177613-684eb452-7def-11e7-94d4-255b3b82fd63.png">
