### PR TITLE
Comments: Fix the position of the user display name on RTL languages

### DIFF
--- a/client/blocks/comment-detail/style.scss
+++ b/client/blocks/comment-detail/style.scss
@@ -53,6 +53,7 @@
 
 	strong {
 		color: $gray-text;
+		float: left;
 		margin-right: 8px;
 	}
 


### PR DESCRIPTION
Fix the position of the user display name on RTL languages.

Props to @yoavf for the solution!

| Before | After |
| --- | --- |
| <img width="365" alt="screen shot 2017-08-10 at 15 53 40" src="https://user-images.githubusercontent.com/2070010/29176663-62e770b8-7de4-11e7-872f-86ca16487b81.png"> | <img width="358" alt="screen shot 2017-08-10 at 15 53 19" src="https://user-images.githubusercontent.com/2070010/29176664-62e7e764-7de4-11e7-943f-67f70ca8ecd3.png"> |
