### PR TITLE
Store: Remove `next()` from settings/general, fixing TypeError on `data`

### DIFF
--- a/client/extensions/woocommerce/state/sites/settings/general/handlers.js
+++ b/client/extensions/woocommerce/state/sites/settings/general/handlers.js
@@ -12,27 +12,25 @@ import {
 	WOOCOMMERCE_SETTINGS_GENERAL_RECEIVE,
 } from 'woocommerce/state/action-types';
 
-export const handleSettingsGeneralSuccess = ( { dispatch }, action, next, { data } ) => {
+export const handleSettingsGeneralSuccess = ( { dispatch }, action, { data } ) => {
 	const { siteId } = action;
 	dispatch( {
 		type: WOOCOMMERCE_SETTINGS_GENERAL_RECEIVE,
 		siteId,
 		data,
 	} );
-	return next( action );
 };
 
-export const handleSettingsGeneralError = ( { dispatch }, action, next, error ) => {
+export const handleSettingsGeneralError = ( { dispatch }, action, error ) => {
 	const { siteId } = action;
 	dispatch( {
 		type: WOOCOMMERCE_SETTINGS_GENERAL_RECEIVE,
 		siteId,
 		error,
 	} );
-	return next( action );
 };
 
-export const handleSettingsGeneral = ( { dispatch, getState }, action, next ) => {
+export const handleSettingsGeneral = ( { dispatch, getState }, action ) => {
 	const { siteId } = action;
 
 	if ( areSettingsGeneralLoaded( getState(), siteId ) ) {
@@ -40,7 +38,6 @@ export const handleSettingsGeneral = ( { dispatch, getState }, action, next ) =>
 	}
 
 	dispatch( request( siteId, action ).get( 'settings/general' ) );
-	return next( action );
 };
 
 /**

--- a/client/extensions/woocommerce/state/sites/settings/general/test/handlers.js
+++ b/client/extensions/woocommerce/state/sites/settings/general/test/handlers.js
@@ -80,7 +80,7 @@ describe( 'handlers', () => {
 			const dispatch = spy();
 			const action = fetchSettingsGeneral( siteId );
 
-			handleSettingsGeneral( { dispatch, getState }, action, noop );
+			handleSettingsGeneral( { dispatch, getState }, action );
 			expect( dispatch ).to.not.have.beenCalled;
 		} );
 	} );
@@ -93,7 +93,7 @@ describe( 'handlers', () => {
 			const response = { data: settingsData };
 
 			const action = fetchSettingsGeneral( siteId );
-			handleSettingsGeneralSuccess( store, action, noop, response );
+			handleSettingsGeneralSuccess( store, action, response );
 
 			expect( store.dispatch ).calledWith( {
 				type: WOOCOMMERCE_SETTINGS_GENERAL_RECEIVE,
@@ -110,7 +110,7 @@ describe( 'handlers', () => {
 			};
 
 			const action = fetchSettingsGeneral( siteId );
-			handleSettingsGeneralError( store, action, noop, 'rest_no_route' );
+			handleSettingsGeneralError( store, action, 'rest_no_route' );
 
 			expect( store.dispatch ).to.have.been.calledWithMatch( {
 				type: WOOCOMMERCE_SETTINGS_GENERAL_RECEIVE,


### PR DESCRIPTION
`next` was removed from the data layer code, see p4TIVU-7EF-p2, so `data` and `error` are undefined in `handleSettingsGeneralSuccess` etc. This is currently causing an error in production:

<img width="505" alt="screen shot 2017-08-10 at 11 27 18 am" src="https://user-images.githubusercontent.com/541093/29178239-f3c12ad2-7dbe-11e7-8309-efd8f1110b5f.png">

**To test:**

- Try to load the store with console open. You should see no errors and it should load.
