### PR TITLE
Add development option to run Store on non Atomic sites.

### DIFF
--- a/client/extensions/woocommerce/app/index.js
+++ b/client/extensions/woocommerce/app/index.js
@@ -55,7 +55,7 @@ class App extends Component {
 
 		if ( 'wpcalypso' !== config( 'env_id' ) && 'development' !== config( 'env_id' ) ) {
 			// Show stats page for non Atomic sites for now
-			if ( ! isAtomicSite ) {
+			if ( ! isAtomicSite && ! config.isEnabled( 'woocommerce/store-on-non-atomic-sites' ) ) {
 				this.redirect();
 				return null;
 			}

--- a/client/extensions/woocommerce/components/action-header/index.js
+++ b/client/extensions/woocommerce/components/action-header/index.js
@@ -11,6 +11,8 @@ import { isArray } from 'lodash';
 import Card from 'components/card';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import StickyPanel from 'components/sticky-panel';
+import Notice from 'components/notice';
+import config from 'config';
 
 const ActionHeader = ( { children, breadcrumbs } ) => {
 	// TODO: Implement proper breadcrumbs component.
@@ -26,9 +28,19 @@ const ActionHeader = ( { children, breadcrumbs } ) => {
 			);
 		} );
 	}
+
+	const showNonAtomicWarrningNotice = config.isEnabled( 'woocommerce/store-on-non-atomic-sites' );
+
 	return (
 		<StickyPanel>
 			<SidebarNavigation />
+			{ showNonAtomicWarrningNotice && <Notice
+				status="is-warning"
+				className="action-header__notice"
+				isCompact={ true }
+				text={ 'Store on non Atomic Jetpack site development mode!' }
+				showDismiss={ false } />
+			}
 			<Card className="action-header__header">
 				<span className="action-header__breadcrumbs">{ breadcrumbsOutput }</span>
 				<div className="action-header__actions">

--- a/client/extensions/woocommerce/components/action-header/style.scss
+++ b/client/extensions/woocommerce/components/action-header/style.scss
@@ -50,6 +50,10 @@
 		}
 	}
 }
+.action-header__notice {
+		margin: 0;
+		width: 100%;
+}
 
 .sticky-panel {
 	@include breakpoint( ">960px" ) {

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -353,7 +353,8 @@ export class MySitesSidebar extends Component {
 		const { currentUser, canUserManageOptions, isJetpack, site, siteSuffix, translate } = this.props;
 		const storeLink = '/store' + siteSuffix;
 		const showStoreLink = config.isEnabled( 'woocommerce/extension-dashboard' ) &&
-			site && isJetpack && canUserManageOptions && this.props.isSiteAutomatedTransfer;
+			site && isJetpack && canUserManageOptions &&
+			( config.isEnabled( 'woocommerce/store-on-non-atomic-sites' ) || this.props.isSiteAutomatedTransfer );
 
 		if ( ! showStoreLink ) {
 			return null;

--- a/config/development.json
+++ b/config/development.json
@@ -172,6 +172,7 @@
 		"woocommerce/extension-settings-shipping": true,
 		"woocommerce/extension-settings-tax": true,
 		"woocommerce/extension-wcservices": true,
+		"woocommerce/store-on-non-atomic-sites": false,
 		"wpcom-user-bootstrap": false
 	}
 }


### PR DESCRIPTION
### Info

This is purely for development purposes. I believe that there should be an easy/quick option to start Calypso in a way that will allow running Store on for example Jetpack sandbox (Jetpack is required). This is important because sandbox gives much more friendly and flexible development environment for all things PHP.

The flag is `woocommerce/store-on-non-atomic-sites` - I had no better idea :man_shrugging: 
To enable it either change this flag to true in `config/development.json` (just don't commit this change) or start Calypso like this: 
`ENABLE_FEATURES=woocommerce/store-on-non-atomic-sites npm start`

@allendav had a great idea to add a warning banner so people would be alerted that they are in this mode:
![image](https://user-images.githubusercontent.com/17271089/29326963-65ad1a3e-81a2-11e7-9af4-fea9c1ee6f53.png)

I am not sure about the wording but - this is only devs facing and so we can make it better if needed. 

Jetpack ( non Atomic ) site should be as fresh as possible: no woocommerce or other plugins. 
Go to Calypso manage panel for jetpack site. There should be no `Store` option. Enable the flag. Check again `Store` is visible.  You should be now able to setup Store on your site. 