### PR TITLE
Comments: redirect to stats if comments management is not enabled

### DIFF
--- a/client/my-sites/comments/index.js
+++ b/client/my-sites/comments/index.js
@@ -11,6 +11,10 @@ import { clearCommentNotices, comments, redirect } from './controller';
 import config from 'config';
 
 export default function() {
+	if ( ! config.isEnabled( 'comments/management' ) ) {
+		page( '/stats' );
+	}
+
 	if ( config.isEnabled( 'comments/management' ) ) {
 		page( '/comments/:status?',
 			controller.siteSelection,


### PR DESCRIPTION
This PR adds a redirect to stats if comments management is not enabled. This will allow us to whitelist the route in production, and gives better behavior with an off default.

In the future we may want to add a generic 404 handler in the my-sites controller for cases like this. I wasn't able to find one.

### Testing
- Start Calypso with `DISABLE_FEATURES=comments/management npm start`
- Visit any /comments paths, we should redirect to /stats
- Start Calypso with `npm start`
- Comments management should work as expected.