### PR TITLE
Store: Restructure the files for single order components

### DIFF
--- a/client/extensions/woocommerce/app/order/index.js
+++ b/client/extensions/woocommerce/app/order/index.js
@@ -16,7 +16,7 @@ import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
 import { getLink } from 'woocommerce/lib/nav-utils';
 import { isOrderUpdating, getOrder } from 'woocommerce/state/sites/orders/selectors';
 import Main from 'components/main';
-import OrderCustomerInfo from './order-customer-info';
+import OrderCustomer from './order-customer';
 import OrderDetails from './order-details';
 import { updateOrder } from 'woocommerce/state/sites/orders/actions';
 
@@ -71,7 +71,7 @@ class Order extends Component {
 
 				<div className="order__container">
 					<OrderDetails order={ order } onUpdate={ this.onUpdate } site={ site } />
-					<OrderCustomerInfo order={ order } />
+					<OrderCustomer order={ order } />
 				</div>
 			</Main>
 		);

--- a/client/extensions/woocommerce/app/order/order-created/index.js
+++ b/client/extensions/woocommerce/app/order/order-created/index.js
@@ -31,8 +31,8 @@ class OrderCreated extends Component {
 		);
 
 		return (
-			<div className="order__details-created">
-				<div className="order__details-created-label">
+			<div className="order-created">
+				<div className="order-created__label">
 					<Gridicon icon="time" size={ 24 } />
 					{ createdLabel }
 				</div>

--- a/client/extensions/woocommerce/app/order/order-created/style.scss
+++ b/client/extensions/woocommerce/app/order/order-created/style.scss
@@ -1,0 +1,10 @@
+.order-created {
+	border-top-width: 0;
+	border-bottom: 1px solid lighten( $gray, 20% );
+	padding-top: 16px;
+	padding-bottom: 16px;
+
+	.order-created__label {
+		font-size: 14px;
+	}
+}

--- a/client/extensions/woocommerce/app/order/order-customer/index.js
+++ b/client/extensions/woocommerce/app/order/order-customer/index.js
@@ -28,14 +28,14 @@ class OrderCustomerInfo extends Component {
 		const { billing, shipping } = order;
 
 		return (
-			<div className="order__customer-info">
+			<div className="order-customer">
 				<SectionHeader label={ translate( 'Customer Information' ) } />
 				<Card>
-					<div className="order__customer-info-container">
-					<div className="order__customer-billing">
-					<h3 className="order__billing-details">{ translate( 'Billing Details' ) }</h3>
+				<div className="order-customer__container">
+					<div className="order-customer__billing">
+					<h3 className="order-customer__billing-details">{ translate( 'Billing Details' ) }</h3>
 						<h4>{ translate( 'Address' ) }</h4>
-						<div className="order__billing-address">
+						<div className="order-customer__billing-address">
 							<p>{ `${ billing.first_name } ${ billing.last_name }` }</p>
 							<p>{ billing.address_1 }</p>
 							<p>{ billing.address_2 }</p>
@@ -50,10 +50,10 @@ class OrderCustomerInfo extends Component {
 						<span>{ billing.phone }</span>
 					</div>
 
-					<div className="order__customer-shipping">
-					<h3 className="order__shipping-details">{ translate( 'Shipping Details' ) }</h3>
+					<div className="order-customer__shipping">
+						<h3 className="order-customer__shipping-details">{ translate( 'Shipping Details' ) }</h3>
 						<h4>{ translate( 'Address' ) }</h4>
-						<div className="order__shipping-address">
+						<div className="order-customer__shipping-address">
 							<p>{ `${ shipping.first_name } ${ shipping.last_name }` }</p>
 							<p>{ shipping.address_1 }</p>
 							<p>{ shipping.address_2 }</p>

--- a/client/extensions/woocommerce/app/order/order-customer/style.scss
+++ b/client/extensions/woocommerce/app/order/order-customer/style.scss
@@ -1,0 +1,37 @@
+.order-customer {
+	.order-customer__billing-details,
+	.order-customer__shipping-details {
+		margin-bottom: 16px;
+		color: $gray-text-min;
+		font-size: 12px;
+		text-transform: uppercase;
+	}
+
+	h4 {
+		font-weight: bold;
+	}
+
+	.order-customer__container {
+		display: flex;
+	}
+
+	.order-customer__billing,
+	.order-customer__shipping {
+		flex: 1 0 50%;
+	}
+
+	.order-customer__shipping {
+		.order__shipping-address {
+			margin-bottom: 0;
+		}
+	}
+
+	.order-customer__billing-address,
+	.order-customer__shipping-address {
+		margin-bottom: 1.5em;
+
+		p {
+			margin-bottom: 0;
+		}
+	}
+}

--- a/client/extensions/woocommerce/app/order/order-details/index.js
+++ b/client/extensions/woocommerce/app/order/order-details/index.js
@@ -10,10 +10,10 @@ import { localize } from 'i18n-calypso';
  */
 import Card from 'components/card';
 import { isOrderWaitingPayment } from 'woocommerce/lib/order-status';
-import OrderCreated from './order-created';
-import OrderDetailsTable from './order-details-table';
-import OrderFulfillment from './order-fulfillment';
-import OrderRefundCard from './order-refund-card';
+import OrderCreated from '../order-created';
+import OrderDetailsTable from './table';
+import OrderFulfillment from '../order-fulfillment';
+import OrderRefundCard from '../order-refund';
 import OrderStatus from 'woocommerce/components/order-status';
 import OrderStatusSelect from 'woocommerce/components/order-status/select';
 import SectionHeader from 'components/section-header';
@@ -56,11 +56,11 @@ class OrderDetails extends Component {
 		}
 
 		return (
-			<div className="order__details">
+			<div className="order-details">
 				<SectionHeader label={ translate( 'Order %(orderId)s Details', { args: { orderId: `#${ order.id }` } } ) }>
 					<span>{ this.renderStatus() }</span>
 				</SectionHeader>
-				<Card className="order__details-card">
+				<Card className="order-details__card">
 					<OrderCreated order={ order } site={ site } />
 					<OrderDetailsTable order={ order } site={ site } />
 					<OrderRefundCard order={ order } site={ site } />

--- a/client/extensions/woocommerce/app/order/order-details/row-discount.js
+++ b/client/extensions/woocommerce/app/order/order-details/row-discount.js
@@ -2,7 +2,8 @@
  * External dependencies
  */
 import { localize } from 'i18n-calypso';
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 
 /**
  * Internal dependencies
@@ -26,16 +27,16 @@ class OrderDiscountRow extends Component {
 		}
 
 		const tax = (
-			<div className="order__details-totals-tax">
+			<div className="order-details__totals-tax">
 				{ formatCurrency( order.discount_tax, order.currency ) }
 			</div>
 		);
 
 		return (
-			<div className="order__details-total-discount">
-				<div className="order__details-totals-label">{ translate( 'Discount' ) }</div>
+			<div className="order-details__total-discount">
+				<div className="order-details__totals-label">{ translate( 'Discount' ) }</div>
 				{ showTax && tax }
-				<div className="order__details-totals-value">
+				<div className="order-details__totals-value">
 					{ formatCurrency( order.discount_total, order.currency ) }
 				</div>
 			</div>

--- a/client/extensions/woocommerce/app/order/order-details/row-refund.js
+++ b/client/extensions/woocommerce/app/order/order-details/row-refund.js
@@ -2,7 +2,8 @@
  * External dependencies
  */
 import { localize } from 'i18n-calypso';
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 
 /**
  * Internal dependencies
@@ -30,10 +31,10 @@ class OrderRefundRow extends Component {
 		}
 
 		return (
-			<div className="order__details-total-refund">
-				<div className="order__details-totals-label">{ translate( 'Refunded' ) }</div>
-				{ showTax && <div className="order__details-totals-tax"></div> }
-				<div className="order__details-totals-value">
+			<div className="order-details__total-refund">
+				<div className="order-details__totals-label">{ translate( 'Refunded' ) }</div>
+				{ showTax && <div className="order-details__totals-tax"></div> }
+				<div className="order-details__totals-value">
 					{ formatCurrency( refundValue, order.currency ) }
 				</div>
 			</div>

--- a/client/extensions/woocommerce/app/order/order-details/row-shipping-refund.js
+++ b/client/extensions/woocommerce/app/order/order-details/row-shipping-refund.js
@@ -2,7 +2,8 @@
  * External dependencies
  */
 import { localize } from 'i18n-calypso';
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 
 /**
  * Internal dependencies
@@ -28,9 +29,9 @@ class OrderShippingRefundRow extends Component {
 		} = this.props;
 
 		return (
-			<div className="order__details-total-shipping-refund">
-				<div className="order__details-totals-label">{ translate( 'Shipping' ) }</div>
-				<div className="order__details-totals-value">
+			<div className="order-details__total-shipping-refund">
+				<div className="order-details__totals-label">{ translate( 'Shipping' ) }</div>
+				<div className="order-details__totals-value">
 					<PriceInput
 						name="shipping_total"
 						onChange={ onChange }

--- a/client/extensions/woocommerce/app/order/order-details/row-shipping.js
+++ b/client/extensions/woocommerce/app/order/order-details/row-shipping.js
@@ -2,7 +2,8 @@
  * External dependencies
  */
 import { localize } from 'i18n-calypso';
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 
 /**
  * Internal dependencies
@@ -26,16 +27,16 @@ class OrderShippingRow extends Component {
 		}
 
 		const tax = (
-			<div className="order__details-totals-tax">
+			<div className="order-details__totals-tax">
 				{ formatCurrency( order.shipping_tax, order.currency ) }
 			</div>
 		);
 
 		return (
-			<div className="order__details-total-shipping">
-				<div className="order__details-totals-label">{ translate( 'Shipping' ) }</div>
+			<div className="order-details__total-shipping">
+				<div className="order-details__totals-label">{ translate( 'Shipping' ) }</div>
 				{ showTax && tax }
-				<div className="order__details-totals-value">
+				<div className="order-details__totals-value">
 					{ formatCurrency( order.shipping_total, order.currency ) }
 				</div>
 			</div>

--- a/client/extensions/woocommerce/app/order/order-details/row-total.js
+++ b/client/extensions/woocommerce/app/order/order-details/row-total.js
@@ -2,7 +2,8 @@
  * External dependencies
  */
 import { localize } from 'i18n-calypso';
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 
 /**
  * Internal dependencies
@@ -26,16 +27,16 @@ class OrderTotalRow extends Component {
 		}
 
 		const tax = (
-			<div className="order__details-totals-tax">
+			<div className="order-details__totals-tax">
 				{ formatCurrency( order.total_tax, order.currency ) }
 			</div>
 		);
 
 		return (
-			<div className="order__details-total">
-				<div className="order__details-totals-label">{ translate( 'Total' ) }</div>
+			<div className="order-details__total">
+				<div className="order-details__totals-label">{ translate( 'Total' ) }</div>
 				{ showTax && tax }
-				<div className="order__details-totals-value">
+				<div className="order-details__totals-value">
 					{ formatCurrency( order.total, order.currency ) }
 				</div>
 			</div>

--- a/client/extensions/woocommerce/app/order/order-details/style.scss
+++ b/client/extensions/woocommerce/app/order/order-details/style.scss
@@ -1,0 +1,98 @@
+.order-details__table {
+	margin: 0 -24px;
+	box-shadow: none;
+	border-bottom: 1px solid lighten( $gray, 30% );
+
+	.order-details__item-cost,
+	.order-details__item-quantity,
+	.order-details__item-tax,
+	.order-details__item-total {
+		text-align: right;
+		width: 70px;
+
+		input {
+			width: 70px;
+		}
+	}
+
+	.order-details__item-sku {
+		display: block;
+		margin-top: 6px;
+		color: $gray-text-min;
+		font-size: 11px;
+		text-transform: uppercase;
+	}
+
+	thead .table-heading {
+		border-bottom: 1px solid lighten( $gray, 30% );
+	}
+
+	.table-row {
+		&:hover {
+			background: transparent;
+		}
+	}
+}
+
+.order-details__totals {
+	padding: 24px 0;
+	text-align: right;
+	font-size: 14px;
+
+	.order-details__total-discount,
+	.order-details__total-shipping,
+	.order-details__total-shipping-refund,
+	.order-details__total-refund,
+	.order-details__total {
+		margin-bottom: 8px;
+		display: flex;
+		align-items: center;
+
+		.order-details__totals-label {
+			flex: 1 0 calc( 100% - 104px );
+		}
+
+		.order-details__totals-tax,
+		.order-details__totals-value {
+			flex: 1 0 92px;
+		}
+	}
+
+	&.is-refund-modal,
+	&.has-taxes {
+		.order-details__total-discount,
+		.order-details__total-refund,
+		.order-details__total-shipping,
+		.order-details__total-shipping-refund,
+		.order-details__total {
+			.order-details__totals-label {
+				flex: 1 0 calc( 100% - 204px );
+			}
+		}
+	}
+
+	&.has-taxes {
+		.order-details__total-shipping-refund .order-details__totals-value {
+			flex: 1 0 192px;
+		}
+	}
+
+	.order-details__total-shipping-refund {
+		.form-text-input-with-affixes {
+			width: 130px;
+		}
+	}
+
+	.order-details__total-refund {
+		color: $alert-red;
+	}
+
+	& > div:last-child {
+		margin-bottom: 0;
+	}
+
+	.order-details__total .order-details__totals-label,
+	.order-details__total .order-details__totals-value {
+		font-weight: 600;
+	}
+}

--- a/client/extensions/woocommerce/app/order/order-details/table.js
+++ b/client/extensions/woocommerce/app/order/order-details/table.js
@@ -13,11 +13,11 @@ import { sum } from 'lodash';
 import formatCurrency from 'lib/format-currency';
 import FormTextInput from 'components/forms/form-text-input';
 import { getLink } from 'woocommerce/lib/nav-utils';
-import OrderDiscountRow from './order-discount-row';
-import OrderRefundRow from './order-refund-row';
-import OrderShippingRefundRow from './order-shipping-refund-row';
-import OrderShippingRow from './order-shipping-row';
-import OrderTotalRow from './order-total-row';
+import OrderDiscountRow from './row-discount';
+import OrderRefundRow from './row-refund';
+import OrderShippingRefundRow from './row-shipping-refund';
+import OrderShippingRow from './row-shipping';
+import OrderTotalRow from './row-total';
 import Table from 'woocommerce/components/table';
 import TableRow from 'woocommerce/components/table/table-row';
 import TableItem from 'woocommerce/components/table/table-item';
@@ -93,12 +93,12 @@ class OrderDetailsTable extends Component {
 	renderTableHeader = () => {
 		const { translate } = this.props;
 		return (
-			<TableRow className="order__detail-header">
-				<TableItem isHeader className="order__detail-item-product">{ translate( 'Product' ) }</TableItem>
-				<TableItem isHeader className="order__detail-item-cost">{ translate( 'Cost' ) }</TableItem>
-				<TableItem isHeader className="order__detail-item-quantity">{ translate( 'Quantity' ) }</TableItem>
-				<TableItem isHeader className="order__detail-item-tax">{ translate( 'Tax' ) }</TableItem>
-				<TableItem isHeader className="order__detail-item-total">{ translate( 'Total' ) }</TableItem>
+			<TableRow className="order-details__header">
+				<TableItem isHeader className="order-details__item-product">{ translate( 'Product' ) }</TableItem>
+				<TableItem isHeader className="order-details__item-cost">{ translate( 'Cost' ) }</TableItem>
+				<TableItem isHeader className="order-details__item-quantity">{ translate( 'Quantity' ) }</TableItem>
+				<TableItem isHeader className="order-details__item-tax">{ translate( 'Tax' ) }</TableItem>
+				<TableItem isHeader className="order-details__item-total">{ translate( 'Total' ) }</TableItem>
 			</TableRow>
 		);
 	}
@@ -106,15 +106,15 @@ class OrderDetailsTable extends Component {
 	renderOrderItems = ( item, i ) => {
 		const { isEditable, order, site } = this.props;
 		return (
-			<TableRow key={ i } className="order__detail-items">
-				<TableItem isRowHeader className="order__detail-item-product">
-					<a href={ getLink( `/store/product/:site/${ item.product_id }`, site ) } className="order__detail-item-link">
+			<TableRow key={ i } className="order-details__items">
+				<TableItem isRowHeader className="order-details__item-product">
+					<a href={ getLink( `/store/product/:site/${ item.product_id }`, site ) } className="order-details__item-link">
 						{ item.name }
 					</a>
-					<span className="order__detail-item-sku">{ item.sku }</span>
+					<span className="order-details__item-sku">{ item.sku }</span>
 				</TableItem>
-				<TableItem className="order__detail-item-cost">{ formatCurrency( item.price, order.currency ) }</TableItem>
-				<TableItem className="order__detail-item-quantity">
+				<TableItem className="order-details__item-cost">{ formatCurrency( item.price, order.currency ) }</TableItem>
+				<TableItem className="order-details__item-quantity">
 					{ isEditable
 						? <FormTextInput
 							type="number"
@@ -126,10 +126,10 @@ class OrderDetailsTable extends Component {
 						: item.quantity
 					}
 				</TableItem>
-				<TableItem className="order__detail-item-tax">
+				<TableItem className="order-details__item-tax">
 					{ formatCurrency( item.total_tax, order.currency ) }
 				</TableItem>
-				<TableItem className="order__detail-item-total">{ formatCurrency( item.total, order.currency ) }</TableItem>
+				<TableItem className="order-details__item-total">{ formatCurrency( item.total, order.currency ) }</TableItem>
 			</TableRow>
 		);
 	}
@@ -142,14 +142,14 @@ class OrderDetailsTable extends Component {
 
 		const showTax = this.shouldShowTax();
 		const totalsClasses = classnames( {
-			'order__details-totals': true,
+			'order-details__totals': true,
 			'has-taxes': showTax,
 			'is-refund-modal': isEditable,
 		} );
 
 		return (
 			<div>
-				<Table className="order__details-table" header={ this.renderTableHeader() }>
+				<Table className="order-details__table" header={ this.renderTableHeader() }>
 					{ order.line_items.map( this.renderOrderItems ) }
 				</Table>
 

--- a/client/extensions/woocommerce/app/order/order-fulfillment/index.js
+++ b/client/extensions/woocommerce/app/order/order-fulfillment/index.js
@@ -109,7 +109,7 @@ class OrderFulfillment extends Component {
 	render() {
 		const { order, translate } = this.props;
 		const { errorMessage, showDialog, trackingNumber } = this.state;
-		const dialogClass = 'woocommerce order__fulfillment'; // eslint/css specificity hack
+		const dialogClass = 'woocommerce order-fulfillment'; // eslint/css specificity hack
 		if ( ! order ) {
 			return null;
 		}
@@ -120,17 +120,17 @@ class OrderFulfillment extends Component {
 		];
 
 		const classes = classNames( {
-			'order__details-fulfillment': true,
+			'order-fulfillment': true,
 			'is-completed': 'completed' === order.status,
 		} );
 
 		return (
 			<div className={ classes }>
-				<div className="order__details-fulfillment-label">
+				<div className="order-fulfillment__label">
 					<Gridicon icon={ 'completed' === order.status ? 'checkmark' : 'shipping' } />
 					{ this.getFulfillmentStatus() }
 				</div>
-				<div className="order__details-fulfillment-action">
+				<div className="order-fulfillment__action">
 					{ ( this.isShippable( order ) )
 						? <Button primary onClick={ this.toggleDialog }>{ translate( 'Fulfill' ) }</Button>
 						: null
@@ -140,18 +140,18 @@ class OrderFulfillment extends Component {
 				<Dialog isVisible={ showDialog } onClose={ this.toggleDialog } className={ dialogClass } buttons={ dialogButtons }>
 					<h1>{ translate( 'Fulfill order' ) }</h1>
 					<form>
-						<FormFieldset className="order__fulfillment-tracking">
-							<FormLabel className="order__fulfillment-tracking-label" htmlFor="tracking-number">
+						<FormFieldset className="order-fulfillment__tracking">
+							<FormLabel className="order-fulfillment__tracking-label" htmlFor="tracking-number">
 								{ translate( 'Enter a tracking number (optional)' ) }
 							</FormLabel>
 							<FormTextInput
 								id="tracking-number"
-								className="order__fulfillment-value"
+								className="order-fulfillment__value"
 								value={ trackingNumber }
 								onChange={ this.updateTrackingNumber }
 								placeholder={ translate( 'Tracking Number' ) } />
 						</FormFieldset>
-						<FormLabel className="order__fulfillment-email">
+						<FormLabel className="order-fulfillment__email">
 							<FormInputCheckbox checked={ this.state.shouldEmail } onChange={ this.updateCustomerEmail } />
 							<span>{ translate( 'Email tracking number to customer' ) }</span>
 						</FormLabel>

--- a/client/extensions/woocommerce/app/order/order-fulfillment/style.scss
+++ b/client/extensions/woocommerce/app/order/order-fulfillment/style.scss
@@ -1,0 +1,22 @@
+.order-fulfillment {
+	background: lighten( $blue-light, 25% );
+
+	&.is-completed {
+		background: transparent;
+
+		.order-fulfillment__label .gridicon {
+			color: $alert-green;
+		}
+	}
+}
+
+.order-fulfillment__tracking,
+.order-fulfillment__email {
+	margin: 0 0 24px;
+}
+
+&.dialog__content.order-fulfillment {
+	.form-text-input {
+		text-align: left;
+	}
+}

--- a/client/extensions/woocommerce/app/order/order-notes/index.js
+++ b/client/extensions/woocommerce/app/order/order-notes/index.js
@@ -11,7 +11,7 @@ import { localize } from 'i18n-calypso';
 import Card from 'components/card';
 import SectionHeader from 'components/section-header';
 
-class OrderActivityLog extends Component {
+class OrderNotes extends Component {
 	static propTypes = {
 		order: PropTypes.object,
 	}
@@ -23,7 +23,7 @@ class OrderActivityLog extends Component {
 		}
 
 		return (
-			<div className="order__activity-log">
+			<div className="order-notes">
 				<SectionHeader label={ translate( 'Activity Log' ) } />
 				<Card></Card>
 			</div>
@@ -31,4 +31,4 @@ class OrderActivityLog extends Component {
 	}
 }
 
-export default localize( OrderActivityLog );
+export default localize( OrderNotes );

--- a/client/extensions/woocommerce/app/order/order-refund/index.js
+++ b/client/extensions/woocommerce/app/order/order-refund/index.js
@@ -20,7 +20,7 @@ import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
 import FormTextarea from 'components/forms/form-textarea';
 import Notice from 'components/notice';
-import OrderDetailsTable from './order-details-table';
+import OrderDetailsTable from '../order-details/table';
 import PriceInput from 'woocommerce/components/price-input';
 import { sendRefund } from 'woocommerce/state/sites/orders/refunds/actions';
 
@@ -142,7 +142,7 @@ class OrderRefundCard extends Component {
 
 		if ( paymentMethod && ( -1 === paymentMethod.method_supports.indexOf( 'refunds' ) ) ) {
 			return (
-				<div className="order__refund-method">
+				<div className="order-refund__method">
 					<h3>{ translate( 'Manual Refund' ) }</h3>
 					<p>{ translate( 'This payment method doesn\'t support automated refunds and must be submitted manually.' ) }</p>
 				</div>
@@ -150,7 +150,7 @@ class OrderRefundCard extends Component {
 		}
 
 		return (
-			<div className="order__refund-method">
+			<div className="order-refund__method">
 				<h3>
 					{ translate( 'Refunding payment via %(method)s', {
 						args: {
@@ -183,12 +183,12 @@ class OrderRefundCard extends Component {
 		];
 
 		return (
-			<div className="order__details-refund">
-				<div className="order__details-refund-label">
+			<div className="order-refund">
+				<div className="order-refund__label">
 					<Gridicon icon="checkmark" />
 					{ this.getRefundStatus() }
 				</div>
-				<div className="order__details-refund-action">
+				<div className="order-refund__action">
 					{ ( 'refunded' !== order.status )
 						? <Button onClick={ this.toggleDialog }>{ translate( 'Submit Refund' ) }</Button>
 						: null
@@ -200,19 +200,19 @@ class OrderRefundCard extends Component {
 					onClose={ this.toggleDialog }
 					className={ dialogClass }
 					buttons={ dialogButtons }
-					additionalClassNames="order__refund-dialog woocommerce">
+					additionalClassNames="order-refund__dialog woocommerce">
 					<h1>{ translate( 'Refund order' ) }</h1>
 					<OrderDetailsTable order={ order } isEditable onChange={ this.recalculateRefund } site={ site } />
-					<form className="order__refund-container">
-						<FormLabel className="order__refund-note">
+					<form className="order-refund__container">
+						<FormLabel className="order-refund__note">
 							{ translate( 'Refund note' ) }
 							<FormTextarea onChange={ this.updateNote } name="refund_note" value={ refundNote } />
 						</FormLabel>
 
-						<FormFieldset className="order__refund-details">
-							<FormLabel className="order__refund-amount">
-								<span className="order__refund-amount-label">{ translate( 'Total refund amount' ) }</span>
-								<div className="order__refund-amount-value">
+						<FormFieldset className="order-refund__details">
+							<FormLabel className="order-refund__amount">
+								<span className="order-refund__amount-label">{ translate( 'Total refund amount' ) }</span>
+								<div className="order-refund__amount-value">
 									<PriceInput
 										name="refund_total"
 										readOnly

--- a/client/extensions/woocommerce/app/order/order-refund/style.scss
+++ b/client/extensions/woocommerce/app/order/order-refund/style.scss
@@ -1,0 +1,71 @@
+&.order-refund__dialog {
+	max-width: 720px;
+	display: flex;
+	flex-direction: column;
+	padding: 0;
+
+	.order__detail-header,
+	.order__details-total {
+		color: $gray-dark;
+	}
+
+	.form-text-input,
+	.form-text-input-with-affixes input {
+		text-align: right;
+	}
+
+	.form-label {
+		.form-text-input-with-affixes {
+			font-weight: normal;
+		}
+	}
+}
+
+.order-refund__container {
+	display: flex;
+	flex-wrap: wrap;
+	justify-content: space-between;
+	margin: 0 -24px -24px;
+	padding: 24px;
+	border-top: 1px solid lighten( $gray, 30% );
+	background: lighten( $gray, 35% );
+
+	.order-refund__note,
+	.order-refund__details {
+		flex: 1;
+	}
+
+	.order-refund__note {
+		margin-bottom: 0;
+
+		.form-textarea {
+			margin-top: 8px;
+		}
+	}
+
+	.order-refund__details {
+		margin-left: 50px;
+		margin-bottom: 0;
+	}
+
+	.order-refund__amount {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: center;
+		padding-bottom: 16px;
+		margin-bottom: 16px;
+		border-bottom: 1px solid lighten( $gray, 30% );
+
+		.order-refund__amount-label,
+		.order-refund__amount-value {
+			flex: 1;
+		}
+	}
+
+	.order-refund__method h3 {
+		font-size: 11px;
+		text-transform: uppercase;
+		margin-bottom: 8px;
+		color: $gray-text-min;
+	}
+}

--- a/client/extensions/woocommerce/app/order/style.scss
+++ b/client/extensions/woocommerce/app/order/style.scss
@@ -10,16 +10,16 @@
 		flex-wrap: wrap;
 		justify-content: space-between;
 
-		.order__details {
+		.order-details {
 			flex: 1 1 100%;
 		}
 
-		.order__activity-log {
+		.order-notes {
 			flex: 2;
 			margin-right: 16px;
 		}
 
-		.order__customer-info {
+		.order-customer {
 			flex: 1;
 		}
 	}
@@ -35,136 +35,14 @@
 	}
 }
 
-.order__details-card {
+.order-details__card {
 	padding-top: 0;
 	padding-bottom: 0;
 }
 
-.order__details-table {
-	margin: 0 -24px;
-	box-shadow: none;
-	border-bottom: 1px solid lighten( $gray, 30% );
-
-	.order__detail-item-cost,
-	.order__detail-item-quantity,
-	.order__detail-item-tax,
-	.order__detail-item-total {
-		text-align: right;
-		width: 70px;
-
-		input {
-			width: 70px;
-		}
-	}
-
-	.order__detail-item-sku {
-		display: block;
-		margin-top: 6px;
-		color: $gray-text-min;
-		font-size: 11px;
-		text-transform: uppercase;
-	}
-
-	thead .table-heading {
-		border-bottom: 1px solid lighten( $gray, 30% );
-	}
-
-	.table-row {
-		&:hover {
-			background: transparent;
-		}
-	}
-}
-
-&.order__refund-dialog {
-	max-width: 720px;
-	display: flex;
-	flex-direction: column;
-	padding: 0;
-
-	.order__detail-header,
-	.order__details-total {
-		color: $gray-dark;
-	}
-
-	.form-text-input,
-	.form-text-input-with-affixes input {
-		text-align: right;
-	}
-
-	.form-label {
-		.form-text-input-with-affixes {
-			font-weight: normal;
-		}
-	}
-}
-
-.order__details-totals {
-	padding: 24px 0;
-	text-align: right;
-	font-size: 14px;
-
-	.order__details-total-discount,
-	.order__details-total-shipping,
-	.order__details-total-shipping-refund,
-	.order__details-total-refund,
-	.order__details-total {
-		margin-bottom: 8px;
-		display: flex;
-		align-items: center;
-
-		.order__details-totals-label {
-			flex: 1 0 calc( 100% - 104px );
-		}
-
-		.order__details-totals-tax,
-		.order__details-totals-value {
-			flex: 1 0 92px;
-		}
-	}
-
-	&.is-refund-modal,
-	&.has-taxes {
-		.order__details-total-discount,
-		.order__details-total-refund,
-		.order__details-total-shipping,
-		.order__details-total-shipping-refund,
-		.order__details-total {
-			.order__details-totals-label {
-				flex: 1 0 calc( 100% - 204px );
-			}
-		}
-	}
-
-	&.has-taxes {
-		.order__details-total-shipping-refund .order__details-totals-value {
-			flex: 1 0 192px;
-		}
-	}
-
-	.order__details-total-shipping-refund {
-		.form-text-input-with-affixes {
-			width: 130px;
-		}
-	}
-
-	.order__details-total-refund {
-		color: $alert-red;
-	}
-
-	& > div:last-child {
-		margin-bottom: 0;
-	}
-
-	.order__details-total .order__details-totals-label,
-	.order__details-total .order__details-totals-value {
-		font-weight: 600;
-	}
-}
-
-.order__details-created,
-.order__details-refund,
-.order__details-fulfillment {
+.order-created,
+.order-refund,
+.order-fulfillment {
 	margin: 0 -16px;
 	padding: 16px;
 	border-top: 1px solid lighten( $gray, 30% );
@@ -176,29 +54,25 @@
 		padding: 24px;
 	}
 
-	.order__details-created-label,
-	.order__details-refund-label,
-	.order__details-fulfillment-label {
+	.order-created__label,
+	.order-refund__label,
+	.order-fulfillment__label {
 		display: flex;
 		align-items: center;
 		flex-grow: 1;
 	}
-	
-	.order__details-created-label {
-		font-size: 14px;
-	}
-	
-	.order__details-created-label .gridicon,
-	.order__details-fulfillment-label .gridicon {
+
+	.order-created__label .gridicon,
+	.order-fulfillment__label .gridicon {
 		color: $gray;
 	}
 
-	.order__details-refund-label .gridicon {
+	.order-refund__label .gridicon {
 		color: $alert-green;
 	}
 
-	.order__details-refund-action,
-	.order__details-fulfillment-action {
+	.order-refund__action,
+	.order-fulfillment__action {
 		flex-grow: 0;
 
 		.button {
@@ -218,126 +92,9 @@
 	}
 }
 
-.order__details-created {
-	border-top-width: 0;
-	border-bottom: 1px solid lighten( $gray, 20% );
-	padding-top: 16px;
-	padding-bottom: 16px;
-}
-
-.order__details-fulfillment {
-	background: lighten( $blue-light, 25% );
-
-	&.is-completed {
-		background: transparent;
-
-		.order__details-fulfillment-label .gridicon {
-			color: $alert-green;
-		}
-	}
-}
-
-.order__customer-info-container {
-	display: flex;
-}
-
-.order__customer-billing {
-	width: 50%;
-}
-
-.order__customer-info {
-	.order__billing-details,
-	.order__shipping-details {
-		margin-bottom: 16px;
-		color: $gray-text-min;
-		font-size: 12px;
-		text-transform: uppercase;
-	}
-
-	h4 {
-		font-weight: bold;
-	}
-
-	.order__customer-shipping {
-		.order__shipping-address {
-			margin-bottom: 0;
-		}
-	}
-}
-
-.order__billing-address,
-.order__shipping-address {
-	margin-bottom: 1.5em;
-
-	p {
-		margin-bottom: 0;
-	}
-}
-
-
 &.dialog__content {
 	.form-text-input,
 	.form-text-input-with-affixes input {
 		text-align: right;
 	}
-
-	&.order__fulfillment {
-		.form-text-input {
-			text-align: left;
-		}
-	}
-}
-
-.order__refund-container {
-	display: flex;
-	flex-wrap: wrap;
-	justify-content: space-between;
-	margin: 0 -24px -24px;
-	padding: 24px;
-	border-top: 1px solid lighten( $gray, 30% );
-	background: lighten( $gray, 35% );
-
-	.order__refund-note,
-	.order__refund-details {
-		flex: 1;
-	}
-
-	.order__refund-note {
-		margin-bottom: 0;
-
-		.form-textarea {
-			margin-top: 8px;
-		}
-	}
-
-	.order__refund-details {
-		margin-left: 50px;
-		margin-bottom: 0;
-	}
-
-	.order__refund-amount {
-		display: flex;
-		flex-wrap: wrap;
-		align-items: center;
-		padding-bottom: 16px;
-		margin-bottom: 16px;
-		border-bottom: 1px solid lighten( $gray, 30% );
-
-		.order__refund-amount-label,
-		.order__refund-amount-value {
-			flex: 1;
-		}
-	}
-
-	.order__refund-method h3 {
-		font-size: 11px;
-		text-transform: uppercase;
-		margin-bottom: 8px;
-		color: $gray-text-min;
-	}
-}
-
-.order__fulfillment-tracking,
-.order__fulfillment-email {
-	margin: 0 0 24px;
 }

--- a/client/extensions/woocommerce/style.scss
+++ b/client/extensions/woocommerce/style.scss
@@ -3,6 +3,12 @@
 
 	@import 'app/dashboard/style';
 	@import 'app/order/style';
+	@import 'app/order/order-created/style';
+	@import 'app/order/order-customer/style';
+	@import 'app/order/order-details/style';
+	@import 'app/order/order-fulfillment/style';
+	@import 'app/order/order-notes/style';
+	@import 'app/order/order-refund/style';
 	@import 'app/orders/style';
 	@import 'app/settings/payments/style';
 	@import 'app/products/product-form';


### PR DESCRIPTION
This PR shouldn't touch anything functionality-wise. The `app/order/` folder was getting a little out of hand, as was `app/order/style.scss`, so this PR moves a lot of the components into their own folders, with `style.scss`s for each section. This makes keeping up with development easier, if the files are more organized.

The only changes in the components should be to `className`s, because the parent folder changes the accepted className rule.

**To test**

- Look at a few single orders, make sure nothing's changed visually, and that there are no errors.

I'd suggest using https://calypso.live/?branch=update/store--order-file-cleanup to test faster :)