### PR TITLE
Comments: Add persistence to like+approve actions

### DIFF
--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -279,6 +279,8 @@ export class CommentList extends Component {
 				} );
 				if ( previousIsLiked ) {
 					this.props.likeComment( commentId, postId );
+				} else if ( ! previousIsLiked && 'approved' !== previousStatus ) {
+					this.props.unlikeComment( commentId, postId );
 				}
 			},
 		};
@@ -301,12 +303,8 @@ export class CommentList extends Component {
 		this.props.likeComment( commentId, postId, { alsoApprove } );
 
 		if ( alsoApprove ) {
-			const updatedComment = {
-				...comment,
-				isLiked: true,
-			};
 			this.props.removeNotice( `comment-notice-${ commentId }` );
-			this.setCommentStatus( updatedComment, 'approved' );
+			this.setCommentStatus( comment, 'approved', { doPersist: true, showNotice: true } );
 			this.updatePersistedComments( commentId );
 		}
 	}


### PR DESCRIPTION
Fix issue reported in https://horizonfeedback.wordpress.com/2017/08/10/call-for-testing-comment-management/#comment-367

Enable the comment persistence in the current list after "like+approve" actions (which can only happen for pending comments) and their undos.

On "like+approve" undo, forces unliking the comment (previously it could have incurred in a race condition where the comment would stay liked anyway).

### Test

- Open the Comment Management's Pending list at `/comments/pending`.
- Expand an unapproved comment (in case, unapprove a comment first! 🙂).

Case 1
- Toggle the comment using the Like/Unlike and Approve/Unapprove buttons.
- Make sure the comment never disappears from the Pending list.

Case 2
- Start with the comment unapproved and unliked.
- Click the Like button.
- Make sure the comment is now both liked and approved.
- Click Undo in the success notice.
- Make sure the comment is now both unapproved and unliked.