### PR TITLE
Comments: show permission error

### DIFF
--- a/client/my-sites/comments/controller.js
+++ b/client/my-sites/comments/controller.js
@@ -14,8 +14,6 @@ import config from 'config';
 import route from 'lib/route';
 import { removeNotice } from 'state/notices/actions';
 import { getNotices } from 'state/notices/selectors';
-import { getSelectedSiteId } from 'state/ui/selectors';
-import { canCurrentUser } from 'state/selectors';
 
 const VALID_STATUSES = [ 'pending', 'approved', 'spam', 'trash' ];
 if ( config.isEnabled( 'comments/management/all-list' ) ) {
@@ -52,14 +50,6 @@ export const redirect = function( context, next ) {
 };
 
 export const comments = function( context ) {
-	const state = context.store.getState();
-	const siteId = getSelectedSiteId( state );
-
-	// TODO: replace with `moderate_comments` as soon as it's available from the endpoint
-	if ( ! canCurrentUser( state, siteId, 'edit_others_posts' ) ) {
-		return page.redirect( '/stats' );
-	}
-
 	const { status } = context.params;
 	const siteFragment = route.getSiteFragment( context.path );
 	renderWithReduxStore(

--- a/client/my-sites/comments/main.jsx
+++ b/client/my-sites/comments/main.jsx
@@ -14,11 +14,15 @@ import PageViewTracker from 'lib/analytics/page-view-tracker';
 import DocumentHead from 'components/data/document-head';
 import CommentList from './comment-list';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
+import { canCurrentUser } from 'state/selectors';
+import { preventWidows } from 'lib/formatting';
+import EmptyContent from 'components/empty-content';
 
 export class CommentsManagement extends Component {
 	static propTypes = {
 		basePath: PropTypes.string,
 		comments: PropTypes.array,
+		showPermissionError: PropTypes.bool,
 		siteId: PropTypes.number,
 		siteFragment: PropTypes.oneOfType( [
 			PropTypes.string,
@@ -30,6 +34,7 @@ export class CommentsManagement extends Component {
 
 	render() {
 		const {
+			showPermissionError,
 			basePath,
 			siteId,
 			siteFragment,
@@ -42,19 +47,30 @@ export class CommentsManagement extends Component {
 				<PageViewTracker path={ basePath } title="Comments" />
 				<DocumentHead title={ translate( 'Comments' ) } />
 				<SidebarNavigation />
-				<CommentList
+				{ showPermissionError && <EmptyContent
+					title={ preventWidows( translate( 'Oops! You don\'t have permission to manage comments.' ) ) }
+					line={ preventWidows( translate( 'If you think you should, contact this site\'s administrator.' ) ) }
+					illustration="/calypso/images/illustrations/illustration-500.svg" />
+				}
+				{ ! showPermissionError && <CommentList
 					siteId={ siteId }
 					siteFragment={ siteFragment }
 					status={ status }
 					order={ 'desc' }
-				/>
+				/> }
 			</Main>
 		);
 	}
 }
 
-const mapStateToProps = ( state, { siteFragment } ) => ( {
-	siteId: getSiteId( state, siteFragment ),
-} );
+const mapStateToProps = ( state, { siteFragment } ) => {
+	const siteId = getSiteId( state, siteFragment );
+	//update to moderate_comments when available
+	const canModerateComments = canCurrentUser( state, siteId, 'edit_others_posts' );
+	return {
+		siteId,
+		showPermissionError: canModerateComments === false,
+	};
+};
 
 export default connect( mapStateToProps )( localize( CommentsManagement ) );


### PR DESCRIPTION
This fixes #17107. When users don't have the correct permissions to mange comments instead of redirecting to /stats, we display the following error:

<img width="1001" alt="screen shot 2017-08-10 at 12 31 00 pm" src="https://user-images.githubusercontent.com/1270189/29188607-76f8f282-7dc8-11e7-9877-147eebf345bb.png">

- Clear your browser cache (indexDB)
- To see this, as an user with the author role visit the following route directly http://calypso.localhost:3000/comments/pending/{siteSlug}
- we should see placeholders, and when the site has loaded, the error above should be visible.
- Visiting with an Editor or Admin role should load comments correctly.

I mimicked the styling here from what we do on /plugins with incorrect permissions. Note that some routes like /themes don't guard against this, and other routes use a different illustration like for /people/teams. We may want to revisit and clean these up.

I'm adding a design/copy label, since the text here looks a bit long. 
