### PR TITLE
Domains: Harden contact details cache reducer

### DIFF
--- a/client/state/domains/management/reducer.js
+++ b/client/state/domains/management/reducer.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { isArray, merge, omit, stubFalse, stubTrue } from 'lodash';
+import { get, isArray, merge, omit, stubFalse, stubTrue } from 'lodash';
 
 /**
  * Internal dependencies

--- a/client/state/domains/management/reducer.js
+++ b/client/state/domains/management/reducer.js
@@ -83,7 +83,7 @@ export const items = createReducer( {}, {
 		( state, { data } ) => {
 			return merge(
 				{},
-				state,
+				sanitizeExtra( state ),
 				{ _contactDetailsCache: sanitizeExtra( data ) }
 			);
 		},
@@ -121,7 +121,10 @@ export default combineReducers( {
  * @return {Object}        Sanitized contact details
  */
 function sanitizeExtra( data ) {
-	return data && isArray( data.extra )
-		? omit( data, 'extra' )
+	const path = data._contactDetailsCache
+		? [ '_contactDetailsCache', 'extra' ]
+		: 'extra';
+	return data && isArray( get( data, path ) )
+		? omit( data, path )
 		: data;
 }

--- a/client/state/domains/management/test/reducer.js
+++ b/client/state/domains/management/test/reducer.js
@@ -155,6 +155,8 @@ describe( 'reducer', () => {
 			} );
 
 			it( 'should handle corrupt values', () => {
+				const initialState = {};
+
 				const dataSequence = [
 					{ before: "I'm still standing" },
 					[ '' ],
@@ -168,7 +170,7 @@ describe( 'reducer', () => {
 							type: DOMAIN_MANAGEMENT_CONTACT_DETAILS_CACHE_UPDATE,
 							data: { extra: data }
 						} ),
-					{}
+					initialState
 				);
 
 				expect( state._contactDetailsCache ).to.have.property( 'extra' )

--- a/client/state/domains/management/test/reducer.js
+++ b/client/state/domains/management/test/reducer.js
@@ -1,0 +1,183 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+import { get, reduce } from 'lodash';
+// import deepFreeze from 'deep-freeze';
+
+/**
+ * Internal dependencies
+ */
+import { useSandbox } from 'test/helpers/use-sinon';
+import {
+	DOMAIN_MANAGEMENT_CONTACT_DETAILS_CACHE_RECEIVE,
+	DOMAIN_MANAGEMENT_CONTACT_DETAILS_CACHE_UPDATE,
+} from 'state/action-types';
+import reducer, {
+	items,
+} from '../reducer';
+
+describe( 'reducer', () => {
+	useSandbox( ( sandbox ) => {
+		sandbox.stub( console, 'warn' );
+	} );
+
+	it( 'should include expected keys in return value', () => {
+		expect( reducer( undefined, {} ) ).to.have.keys( [
+			'items',
+			'isRequestingContactDetailsCache',
+			'isRequestingWhois',
+			'isSaving',
+		] );
+	} );
+
+	describe( '#items()', () => {
+		it( 'should default to empty object', () => {
+			const state = items( undefined, {} );
+
+			expect( state._contactDetailsCache ).to.be.empty;
+		} );
+
+		describe( 'Receive extra', function() {
+			it( 'should overwrite previous data', function() {
+				const preexistingData = {
+					firstName: 'Cronus',
+					organization: 'titans'
+				};
+
+				const newData = {
+					firstName: 'Zeus',
+					extra: {
+						registrantType: 'individual'
+					}
+				};
+
+				const state = items( preexistingData, {
+					type: DOMAIN_MANAGEMENT_CONTACT_DETAILS_CACHE_RECEIVE,
+					data: newData,
+				} );
+
+				expect( state ).to.have.property( '_contactDetailsCache', newData );
+			} );
+
+			it( "should ignore an extra if it's an array", function() {
+				const state = items( {}, {
+					type: DOMAIN_MANAGEMENT_CONTACT_DETAILS_CACHE_RECEIVE,
+					data: { firstName: 'New', extra: [ '' ] }
+				} );
+
+				expect( get( state, [ '_contactDetailsCache', 'extra' ] ) )
+					.to.not.be.an( 'array' );
+			} );
+
+			it( 'should take other fields if extra is corrupt', function() {
+				const preexistingData = { firstName: 'Hera' };
+				const state = items( preexistingData, {
+					type: DOMAIN_MANAGEMENT_CONTACT_DETAILS_CACHE_RECEIVE,
+					data: { firstName: 'New', extra: [ '' ] }
+				} );
+
+				expect( state._contactDetailsCache )
+					.to.have.property( 'firstName', 'New' );
+			} );
+		} );
+
+		describe( 'Update extra', function() {
+			it( 'should add new values', () => {
+				const newData = {
+					extra: {
+						testAdd: 'testAddValue'
+					}
+				};
+
+				const state = items( {}, {
+					type: DOMAIN_MANAGEMENT_CONTACT_DETAILS_CACHE_UPDATE,
+					data: newData
+				} );
+
+				expect( state._contactDetailsCache ).to.eql( newData );
+			} );
+
+			it( 'should preserve existing values', () => {
+				const firstData = {
+					extra: {
+						testPreserve: "I'm still here",
+					}
+				};
+				const secondData = {
+					extra: {
+						additionalField: 'second',
+					}
+				};
+
+				const intermediateState = items( {}, {
+					type: DOMAIN_MANAGEMENT_CONTACT_DETAILS_CACHE_UPDATE,
+					data: firstData
+				} );
+
+				const finalState = items( intermediateState, {
+					type: DOMAIN_MANAGEMENT_CONTACT_DETAILS_CACHE_UPDATE,
+					data: secondData
+				} );
+
+				expect( finalState._contactDetailsCache ).to.have.deep.property(
+					'extra.testPreserve',
+					"I'm still here"
+				);
+			} );
+
+			it( 'should update existing values', () => {
+				const firstData = {
+					extra: {
+						testUpdate: 'old',
+					},
+				};
+				const secondData = {
+					extra: {
+						testUpdate: 'new',
+					},
+				};
+
+				const intermediateState = items( {}, {
+					type: DOMAIN_MANAGEMENT_CONTACT_DETAILS_CACHE_UPDATE,
+					data: firstData
+				} );
+
+				const finalState = items( intermediateState, {
+					type: DOMAIN_MANAGEMENT_CONTACT_DETAILS_CACHE_UPDATE,
+					data: secondData
+				} );
+
+				expect( finalState._contactDetailsCache ).to.have.deep.property(
+					'extra.testUpdate',
+					'new',
+				);
+			} );
+
+			it( 'should handle corrupt values', () => {
+				const dataSequence = [
+					{ before: "I'm still standing" },
+					[ '' ],
+					{ after: 'better than I ever did' },
+				];
+
+				const state = reduce(
+					dataSequence,
+					( intermediateState, data ) =>
+						items( intermediateState, {
+							type: DOMAIN_MANAGEMENT_CONTACT_DETAILS_CACHE_UPDATE,
+							data: { extra: data }
+						} ),
+					{}
+				);
+
+				expect( state._contactDetailsCache ).to.have.property( 'extra' )
+					.that.is.an( 'object' )
+					.with.all.keys( {
+						before: "I'm still standing",
+						after: 'better than I ever did'
+					} );
+			} );
+		} );
+	} );
+} );

--- a/client/state/domains/management/test/reducer.js
+++ b/client/state/domains/management/test/reducer.js
@@ -178,6 +178,34 @@ describe( 'reducer', () => {
 						after: 'better than I ever did'
 					} );
 			} );
+
+			it( 'should replace an existing corrupt value', () => {
+				const corruptExistingData = {
+					_contactDetailsCache: {
+						extra: [ '' ],
+					}
+				};
+
+				const newData = {
+					extra: {
+						newData: 'exists',
+					}
+				};
+
+				const result = items( corruptExistingData, {
+					type: DOMAIN_MANAGEMENT_CONTACT_DETAILS_CACHE_UPDATE,
+					data: newData,
+				} );
+
+				expect( result._contactDetailsCache )
+					.to.have.property( 'extra' )
+					.that.is.not.an( 'array' );
+
+				expect( result._contactDetailsCache ).to.have.deep.property(
+					'extra.newData',
+					'exists'
+				);
+			} );
 		} );
 	} );
 } );

--- a/client/state/domains/management/test/reducer.js
+++ b/client/state/domains/management/test/reducer.js
@@ -3,12 +3,10 @@
  */
 import { expect } from 'chai';
 import { get, reduce } from 'lodash';
-// import deepFreeze from 'deep-freeze';
 
 /**
  * Internal dependencies
  */
-import { useSandbox } from 'test/helpers/use-sinon';
 import {
 	DOMAIN_MANAGEMENT_CONTACT_DETAILS_CACHE_RECEIVE,
 	DOMAIN_MANAGEMENT_CONTACT_DETAILS_CACHE_UPDATE,
@@ -18,10 +16,6 @@ import reducer, {
 } from '../reducer';
 
 describe( 'reducer', () => {
-	useSandbox( ( sandbox ) => {
-		sandbox.stub( console, 'warn' );
-	} );
-
 	it( 'should include expected keys in return value', () => {
 		expect( reducer( undefined, {} ) ).to.have.keys( [
 			'items',


### PR DESCRIPTION
This PR addresses https://github.com/Automattic/wp-calypso/issues/17078

It should no longer be possible to get the extra form into that broken state by sending it extra arrays whether it's in the initial value or an update.

Ideally we'd try this out with an account with the broken extra data ( @aidvu? ). Alternatively, you can You can deliberately break your extra details by setting them in the database, or just inject arrays by dispatching the appropriate actions.

We also need to check that other fields should also work fine. We can't get anything meaningful for the `extra` value out of an array, but we should still handle any other fields (name, address etc), and we should preserve existing extra data.

The actual behaviour was kind of interesting. It turns out that you can add properties to an array:
`Object.assign( [1,2,3], { foo:'bar' } )` evaluates to `[1, 2, 3, foo: "bar"]` ([wat?](https://archive.org/details/wat_destroyallsoftware)), but the extra values don't propagate through the system.

There's probably a more elegant solution if I can understand exactly where and how we lose them, but I'm not sure how widespread the problem is, and I think this works, so I'd like to launch now and make it pretty later.