### PR TITLE
Add a search-url lib mixin alternative

### DIFF
--- a/client/lib/search-url/README.md
+++ b/client/lib/search-url/README.md
@@ -1,0 +1,14 @@
+search-url
+=============
+
+`search-url` is a semi-replacement for the deprecated `url-search` mixin, and contains a function that determines if the page URL needs updating during a search.
+
+In this example `doSearch` is a function to perform a search. If `doSearch` is undefined then the page URL is updated
+
+```js
+searchUrl( searchValue, previousSearchValue, doSearch );
+```
+
+## History
+`search-url` adds the first search result page to the browser history, and then uses push-state to update the page on subsequent searches. So only the most-recent
+search is persisted in the browser's history.

--- a/client/lib/search-url/index.js
+++ b/client/lib/search-url/index.js
@@ -1,0 +1,25 @@
+/**
+ * External dependencies
+ */
+import buildUrl from 'lib/mixins/url-search/build-url';
+import page from 'page';
+
+const debug = require( 'debug' )( 'calypso:search-url' );
+
+export default function searchUrl( keywords, initialSearch, onSearch ) {
+	if ( onSearch ) {
+		onSearch( keywords );
+		return;
+	}
+
+	const searchURL = buildUrl( window.location.href, keywords );
+
+	debug( 'search posts for:', keywords );
+	if ( initialSearch && keywords ) {
+		debug( 'replacing URL: ' + searchURL );
+		page.replace( searchURL );
+	} else {
+		debug( 'setting URL: ' + searchURL );
+		page.show( searchURL );
+	}
+}

--- a/client/lib/search-url/test/index.js
+++ b/client/lib/search-url/test/index.js
@@ -1,0 +1,56 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+import mockery from 'mockery';
+
+/**
+ * Internal dependencies
+ */
+import useMockery from 'test/helpers/use-mockery';
+import { useSandbox } from 'test/helpers/use-sinon';
+
+const SEARCH_KEYWORD = 'giraffe';
+
+describe( 'SearchUrl', () => {
+	let onSearch, searchUrl, onReplace, onPage;
+
+	useMockery();
+
+	useSandbox( sandbox => {
+		onSearch = sandbox.stub();
+		onReplace = sandbox.stub();
+		onPage = sandbox.stub();
+	} );
+
+	before( () => {
+		mockery.registerMock( 'page', {
+			replace: onReplace,
+			show: onPage,
+		} );
+
+		searchUrl = require( '..' );
+	} );
+
+	it( 'should call onSearch if provided', () => {
+		searchUrl( SEARCH_KEYWORD, '', onSearch );
+
+		expect( onSearch ).to.have.been.calledWith( SEARCH_KEYWORD );
+	} );
+
+	it( 'should replace existing search keyword', () => {
+		global.window = { location: { href: 'http://example.com/cat' } };
+
+		searchUrl( SEARCH_KEYWORD, 'existing' );
+
+		expect( onReplace ).to.have.been.calledWith( '/cat?s=' + SEARCH_KEYWORD );
+	} );
+
+	it( 'should set page URL if no existing keyword', () => {
+		global.window = { location: { href: 'http://example.com/cat' } };
+
+		searchUrl( SEARCH_KEYWORD );
+
+		expect( onPage ).to.have.been.calledWith( '/cat?s=' + SEARCH_KEYWORD );
+	} );
+} );


### PR DESCRIPTION
An almost alternative to the [lib/mixin/url-search](https://github.com/Automattic/wp-calypso/tree/master/client/lib/mixins/url-search) for ES6, which is [now deprecated](https://facebook.github.io/react/blog/2015/01/27/react-v0.13.0-beta-1.html#mixins).

Almost a direct copy in that it either adds the search term to the page URL or calls the search function directly. However it does not include any open/close status, and this is assumed to be performed in whatever component uses this code.

Note that the library is not currently used but will be in #17083 

## Testing

Run the include unit test for the search-url library:

`npm run test-client client/lib/search-url`