### PR TITLE
Extensions: Zoninator - Update data layer handlers signatures

### DIFF
--- a/client/extensions/zoninator/state/data-layer/zones/index.js
+++ b/client/extensions/zoninator/state/data-layer/zones/index.js
@@ -21,7 +21,7 @@ export const requestZonesList = ( { dispatch }, action ) => {
 export const requestZonesError = ( { dispatch }, { siteId } ) =>
 	dispatch( requestError( siteId ) );
 
-export const updateZonesList = ( { dispatch }, { siteId }, next, { data } ) =>
+export const updateZonesList = ( { dispatch }, { siteId }, { data } ) =>
 	dispatch( updateZones( siteId, data ) );
 
 const dispatchFetchZonesRequest = dispatchRequest( requestZonesList, updateZonesList, requestZonesError );

--- a/client/extensions/zoninator/state/data-layer/zones/test/index.js
+++ b/client/extensions/zoninator/state/data-layer/zones/test/index.js
@@ -47,7 +47,7 @@ describe( '#updateZonesList', () => {
 		const dispatch = sinon.spy();
 		const action = requestZones( 123456 );
 
-		updateZonesList( { dispatch }, action, null, apiResponse );
+		updateZonesList( { dispatch }, action, apiResponse );
 
 		expect( dispatch ).to.have.been.calledOnce;
 		expect( dispatch ).to.have.been.calledWith( updateZones( 123456, [


### PR DESCRIPTION
This PR updates the data layer handler signatures within Zoninator extension according to changes introduced in #17061.

# Testing

Unit tests: `npm run test-client client/extensions/zoninator/state/data-layer`