### PR TITLE
Codemods: Accept arguments in codemod wrappers

### DIFF
--- a/bin/codemods/combine-reducer-with-persistence
+++ b/bin/codemods/combine-reducer-with-persistence
@@ -31,7 +31,7 @@ const binArgs = [
 	...config.jscodeshiftArgs,
 
 	// Transform target
-	args[ 0 ],
+	...args,
 ];
 const binPath = path.join( '.', 'node_modules', '.bin', 'jscodeshift' );
 const jscodeshift = child_process.spawn( binPath, binArgs );

--- a/bin/codemods/combine-state-utils-imports
+++ b/bin/codemods/combine-state-utils-imports
@@ -31,7 +31,7 @@ const binArgs = [
 	...config.jscodeshiftArgs,
 
 	// Transform target
-	args[ 0 ],
+	...args,
 ];
 const binPath = path.join( '.', 'node_modules', '.bin', 'jscodeshift' );
 const jscodeshift = child_process.spawn( binPath, binArgs );

--- a/bin/codemods/commonjs-exports
+++ b/bin/codemods/commonjs-exports
@@ -34,7 +34,7 @@ const binArgs = [
 	...config.recastArgs,
 
 	// Transform target
-	args[ 0 ],
+	...args,
 ];
 const binPath = path.join( '.', 'node_modules', '.bin', 'jscodeshift' );
 const jscodeshift = child_process.spawn( binPath, binArgs );

--- a/bin/codemods/commonjs-imports
+++ b/bin/codemods/commonjs-imports
@@ -36,7 +36,7 @@ const binArgs = [
 	...config.recastArgs,
 
 	// Transform target
-	args[ 0 ],
+	...args,
 ];
 const binPath = path.join( '.', 'node_modules', '.bin', 'jscodeshift' );
 const jscodeshift = child_process.spawn( binPath, binArgs );

--- a/bin/codemods/commonjs-imports-hoist
+++ b/bin/codemods/commonjs-imports-hoist
@@ -38,7 +38,7 @@ const binArgs = [
 	'--hoist=true',
 
 	// Transform target
-	args[ 0 ],
+	...args,
 ];
 const binPath = path.join( '.', 'node_modules', '.bin', 'jscodeshift' );
 const jscodeshift = child_process.spawn( binPath, binArgs );

--- a/bin/codemods/i18n-mixin
+++ b/bin/codemods/i18n-mixin
@@ -35,7 +35,7 @@ const binArgs = [
 	...config.recastArgs,
 
 	// Transform target
-	args[ 0 ],
+	...args,
 ];
 const binPath = path.join( '.', 'node_modules', '.bin', 'jscodeshift' );
 const jscodeshift = child_process.spawn( binPath, binArgs );

--- a/bin/codemods/merge-lodash-imports
+++ b/bin/codemods/merge-lodash-imports
@@ -31,7 +31,7 @@ const binArgs = [
 	...config.jscodeshiftArgs,
 
 	// Transform target
-	args[ 0 ],
+	...args,
 ];
 const binPath = path.join( '.', 'node_modules', '.bin', 'jscodeshift' );
 const jscodeshift = child_process.spawn( binPath, binArgs );

--- a/bin/codemods/modular-lodash-no-more
+++ b/bin/codemods/modular-lodash-no-more
@@ -31,7 +31,7 @@ const binArgs = [
 	...config.jscodeshiftArgs,
 
 	// Transform target
-	args[ 0 ],
+	...args,
 ];
 const binPath = path.join( '.', 'node_modules', '.bin', 'jscodeshift' );
 const jscodeshift = child_process.spawn( binPath, binArgs );

--- a/bin/codemods/named-exports-from-default
+++ b/bin/codemods/named-exports-from-default
@@ -36,7 +36,7 @@ const binArgs = [
 	...config.recastArgs,
 
 	// Transform target
-	args[ 0 ],
+	...args,
 ];
 const binPath = path.join( '.', 'node_modules', '.bin', 'jscodeshift' );
 const jscodeshift = child_process.spawn( binPath, binArgs );

--- a/bin/codemods/react-create-class
+++ b/bin/codemods/react-create-class
@@ -38,7 +38,7 @@ const binArgs = [
 	'--mixin-module-name="react-pure-render/mixin"', // Your days are numbered, pure-render-mixin!
 
 	// Transform target
-	args[ 0 ],
+	...args,
 ];
 const binPath = path.join( '.', 'node_modules', '.bin', 'jscodeshift' );
 const jscodeshift = child_process.spawn( binPath, binArgs );

--- a/bin/codemods/react-prop-types
+++ b/bin/codemods/react-prop-types
@@ -34,7 +34,7 @@ const binArgs = [
 	`--printOptions=${ JSON.stringify( config.recastOptions ) }`,
 
 	// Transform target
-	args[ 0 ],
+	...args,
 ];
 const binPath = path.join( '.', 'node_modules', '.bin', 'jscodeshift' );
 const jscodeshift = child_process.spawn( binPath, binArgs );

--- a/bin/codemods/rename-combine-reducers
+++ b/bin/codemods/rename-combine-reducers
@@ -31,7 +31,7 @@ const binArgs = [
 	...config.jscodeshiftArgs,
 
 	// Transform target
-	args[ 0 ],
+	...args,
 ];
 const binPath = path.join( '.', 'node_modules', '.bin', 'jscodeshift' );
 const jscodeshift = child_process.spawn( binPath, binArgs );


### PR DESCRIPTION
Previously, codemods wrappers used `args[ 0 ]` to accept the first
argument to the codemod. Codemods can accept multiple file arguments, so
we pass the complete args array as `...args`.

## Testing

Try running a codemod with multiple file arguments, for example:

```bash
./bin/codemods/react-create-class client/components/button client/components/card/
```

## Results

### Before

Only the first argument is accepted:

```
./bin/codemods/react-create-class client/components/button client/components/card/
Processing 3 files...
Spawning 3 workers...
Sending 1 files to free worker...
Sending 1 files to free worker...
Sending 1 files to free worker...
All done.
Results:
0 errors
3 unmodified
0 skipped
0 ok
Time elapsed: 2.002seconds
```

### After

All arguments are passed:

```
./bin/codemods/react-create-class client/components/button client/components/card/
Processing 7 files...
Spawning 7 workers...
Sending 1 files to free worker...
Sending 1 files to free worker...
Sending 1 files to free worker...
Sending 1 files to free worker...
Sending 1 files to free worker...
Sending 1 files to free worker...
Sending 1 files to free worker...
All done.
Results:
0 errors
3 unmodified
0 skipped
4 ok
Time elapsed: 7.131seconds
```

## Context

Discovered this limitation while exporing in #17111 