### PR TITLE
Media library: move keyring request for external media

### DIFF
--- a/client/my-sites/media-library/content.jsx
+++ b/client/my-sites/media-library/content.jsx
@@ -4,7 +4,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import createFragment from 'react-addons-create-fragment';
-import { groupBy, head, mapValues, noop, some, toArray, values } from 'lodash';
+import { groupBy, head, mapValues, noop, values } from 'lodash';
 import { translate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import page from 'page';
@@ -29,13 +29,7 @@ import { getSiteSlug } from 'state/sites/selectors';
 import MediaLibraryHeader from './header';
 import MediaLibraryExternalHeader from './external-media-header';
 import MediaLibraryList from './list';
-import { requestKeyringConnections } from 'state/sharing/keyring/actions';
-import {
-	isKeyringConnectionsFetching,
-	getKeyringConnections,
-} from 'state/sharing/keyring/selectors';
-
-const isConnected = props => some( props.connectedServices, item => item.service === props.source );
+import { isKeyringConnectionsFetching } from 'state/sharing/keyring/selectors';
 
 class MediaLibraryContent extends React.Component {
 	static propTypes = {
@@ -59,13 +53,6 @@ class MediaLibraryContent extends React.Component {
 		mediaValidationErrors: Object.freeze( {} ),
 		onAddMedia: noop,
 		source: '',
-	}
-
-	componentWillMount() {
-		if ( ! this.props.isRequesting && this.props.source !== '' && this.props.connectedServices.length === 0 ) {
-			// Are we connected to anything yet?
-			this.props.requestKeyringConnections();
-		}
 	}
 
 	renderErrors() {
@@ -168,7 +155,7 @@ class MediaLibraryContent extends React.Component {
 		);
 	}
 
-	retryList() {
+	retryList = () => {
 		MediaActions.sourceChanged( this.props.site.ID );
 	}
 
@@ -197,7 +184,7 @@ class MediaLibraryContent extends React.Component {
 		analytics.tracks.recordEvent( tracksEvent, tracksData );
 	}
 
-	goToSharing( ev ) {
+	goToSharing = ev => {
 		ev.preventDefault();
 		page( `/sharing/${ this.props.site.slug }` );
 	}
@@ -232,11 +219,12 @@ class MediaLibraryContent extends React.Component {
 	}
 
 	renderMediaList() {
-		if ( ! this.props.site || this.props.isRequesting ) {
+		if ( ! this.props.site || ( this.props.isRequesting && ! this.hasRequested ) ) {
+			this.hasRequested = true;   // We only want to do this once
 			return <MediaLibraryList key="list-loading" filterRequiresUpgrade={ this.props.filterRequiresUpgrade } />;
 		}
 
-		if ( this.props.source !== '' && ! isConnected( this.props ) ) {
+		if ( this.props.source !== '' && ! this.props.isConnected ) {
 			return this.renderExternalMedia();
 		}
 
@@ -265,6 +253,10 @@ class MediaLibraryContent extends React.Component {
 	}
 
 	renderHeader() {
+		if ( ! this.props.isConnected ) {
+			return null;
+		}
+
 		if ( this.props.source !== '' ) {
 			return (
 				<MediaLibraryExternalHeader
@@ -305,12 +297,7 @@ class MediaLibraryContent extends React.Component {
 	}
 }
 
-export default connect( ( state, ownProps ) => {
-	return {
-		siteSlug: ownProps.site ? getSiteSlug( state, ownProps.site.ID ) : '',
-		connectedServices: toArray( getKeyringConnections( state ) ).filter( item => item.type === 'other' && item.status === 'ok' ),
-		isRequesting: isKeyringConnectionsFetching( state ),
-	};
-}, {
-	requestKeyringConnections,
-}, null, { pure: false } )( MediaLibraryContent );
+export default connect( ( state, ownProps ) => ( {
+	siteSlug: ownProps.site ? getSiteSlug( state, ownProps.site.ID ) : '',
+	isRequesting: isKeyringConnectionsFetching( state ),
+} ), null, null, { pure: false } )( MediaLibraryContent );

--- a/client/my-sites/media-library/content.scss
+++ b/client/my-sites/media-library/content.scss
@@ -24,7 +24,7 @@
 }
 
 .media-library__connect-message {
-	max-width: 480px;
+	max-width: 520px;
 	padding: 36px;
 	margin: 0 auto;
 	text-align: center;

--- a/client/my-sites/media-library/test/index.jsx
+++ b/client/my-sites/media-library/test/index.jsx
@@ -1,0 +1,84 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+import React from 'react';
+import { mount } from 'enzyme';
+import { stub } from 'sinon';
+
+/**
+ * Internal dependencies
+ */
+import useFakeDom from 'test/helpers/use-fake-dom';
+import useMockery from 'test/helpers/use-mockery';
+
+const emptyComponent = () => null;
+
+describe( 'MediaLibrary', () => {
+	let MediaLibrary, requestStub;
+
+	useFakeDom();
+	useMockery();
+
+	const store = {
+		getState: () => ( {} ),
+		dispatch: () => false,
+		subscribe: () => false,
+	};
+
+	useMockery( mockery => {
+		requestStub = stub();
+		mockery.registerMock( 'components/data/query-preferences', emptyComponent );
+		mockery.registerMock( './filter-bar', emptyComponent );
+		mockery.registerMock( './content', emptyComponent );
+		mockery.registerMock( './drop-zone', emptyComponent );
+		mockery.registerMock( 'components/data/media-validation-data', emptyComponent );
+		mockery.registerMock( 'lib/media/library-selected-store', emptyComponent );
+		mockery.registerMock( 'lib/media/actions', emptyComponent );
+		mockery.registerMock( 'state/sharing/keyring/selectors', {
+			getKeyringConnections: emptyComponent,
+			isKeyringConnectionsFetching: emptyComponent,
+		} );
+		mockery.registerMock( 'state/sharing/keyring/actions', {
+			requestKeyringConnections: requestStub
+		} );
+	} );
+
+	before( () => {
+		MediaLibrary = require( '..' );
+	} );
+
+	beforeEach( () => {
+		requestStub.reset();
+	} );
+
+	const getItem = source => mount( <MediaLibrary store={ store } source={ source } /> );
+
+	context( 'keyring request', () => {
+		it( 'is issued when component mounted and viewing an external source', () => {
+			getItem( 'google_photos' );
+
+			expect( requestStub ).to.have.been.calledOnce;
+		} );
+
+		it( 'is not issued when component mounted and viewing wordpress', () => {
+			getItem( '' );
+
+			expect( requestStub ).to.have.not.been.notCalled;
+		} );
+
+		it( 'is issued when component source changes and now viewing an external source', () => {
+			const library = getItem( '' );
+
+			library.setProps( { source: 'google_photos' } );
+			expect( requestStub ).to.have.been.calledOnce;
+		} );
+
+		it( 'is not issued when component source changes and not viewing an external source', () => {
+			const library = getItem( '' );
+
+			library.setProps( { source: '' } );
+			expect( requestStub ).to.have.not.been.notCalled;
+		} );
+	} );
+} );


### PR DESCRIPTION
When trying to view external we make a keyring request to see if we are connected. This currently happens in the media library content.

This PR moves the request into the root of the media library, making the result available to all components. This is needed to allow us to disable the search box when the service is unconnected.

One side benefit of this is that we now only make the request once when the media library is opened, not every time we switch to Google Photos.

No functionality should change here, it's just moving things up a level.

## Testing

Run the included unit test:

`npm run test-client client/my-sites/media-library/test/index.jsx`

Manually check:
1. Open Google Photos in the media library modal when connected. Verify that media library shows Google results
1. Open Google Photos when disconnected. Verify that the media library shows a message prompting you to connect