### PR TITLE
Me: Allow more width for navigation dropdown

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -288,6 +288,7 @@
 @import 'me/purchases/manage-purchase/plan-details/style';
 @import 'me/purchases/remove-purchase/style';
 @import 'me/reauth-required/style';
+@import 'me/security/style';
 @import 'me/security-2fa-backup-codes-list/style';
 @import 'me/security-2fa-backup-codes-prompt/style';
 @import 'me/security-2fa-backup-codes/style';

--- a/client/me/security/style.scss
+++ b/client/me/security/style.scss
@@ -1,0 +1,3 @@
+.security .select-dropdown__container {
+	max-width: 400px;
+}


### PR DESCRIPTION
The navigation dropdown on [me/security](https://wordpress.com/me/security) is unnecessarily narrow. This causes truncation on longer translations.

New:
<img width="338" alt="screen shot 2017-08-11 at 15 15 47" src="https://user-images.githubusercontent.com/203408/29214907-33e56822-7ea9-11e7-93ca-c0a85dc72cba.png">

Old:
<img width="368" alt="screen shot 2017-08-11 at 15 16 32" src="https://user-images.githubusercontent.com/203408/29214902-310d3c92-7ea9-11e7-9b9b-cb597da58975.png">

cc @retrofox because you last modified the `max-width` in #7392
