### PR TITLE
Simple payments: pre-populate email on new payment buttons

### DIFF
--- a/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
@@ -7,7 +7,7 @@
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { find, isNumber, pick, noop } from 'lodash';
+import { find, isNumber, pick, noop, get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -23,7 +23,7 @@ import Notice from 'components/notice';
 import Navigation from './navigation';
 import ProductForm, { getProductFormValues, isProductFormValid, isProductFormDirty } from './form';
 import ProductList from './list';
-import { getCurrentUserCurrencyCode } from 'state/current-user/selectors';
+import { getCurrentUserCurrencyCode, getCurrentUserEmail } from 'state/current-user/selectors';
 import { getCurrencyDefaults } from 'lib/format-currency';
 import wpcom from 'lib/wp';
 import accept from 'lib/accept';
@@ -161,16 +161,23 @@ class SimplePaymentsDialog extends Component {
 	// or the default values for a new one.
 	getInitialFormFields( paymentId ) {
 		const { initialFields } = this.constructor;
+		const { paymentButtons, currentUserEmail } = this.props;
 
 		if ( isNumber( paymentId ) ) {
-			const editedPayment = find( this.props.paymentButtons, p => p.ID === paymentId );
+			const editedPayment = find( paymentButtons, p => p.ID === paymentId );
 			if ( editedPayment ) {
 				// Pick only the fields supported by the form -- drop the rest
 				return pick( editedPayment, Object.keys( initialFields ) );
 			}
 		}
 
-		return initialFields;
+		const lastPaymentButtonEmail = get( paymentButtons, '0.email', null );
+
+		if ( ! paymentButtons || ! paymentButtons.length ) {
+			return { ...initialFields, email: currentUserEmail || lastPaymentButtonEmail };
+		}
+
+		return { ...initialFields, email: lastPaymentButtonEmail };
 	}
 
 	isDirectEdit() {
@@ -459,5 +466,6 @@ export default connect( ( state, { siteId } ) => {
 			isJetpackSite( state, siteId ) && ! isJetpackMinimumVersion( state, siteId, '5.2' ),
 		planHasSimplePaymentsFeature: hasFeature( state, siteId, FEATURE_SIMPLE_PAYMENTS ),
 		formCanBeSubmitted: isProductFormValid( state ) && isProductFormDirty( state ),
+		currentUserEmail: getCurrentUserEmail( state ),
 	};
 } )( localize( SimplePaymentsDialog ) );

--- a/client/state/selectors/get-simple-payments.js
+++ b/client/state/selectors/get-simple-payments.js
@@ -17,29 +17,29 @@ import createSelector from 'lib/create-selector';
  * @param {int}    simplePaymentId The ID of the Simple Payment to get. Optional.
  * @return {Array|Object|null}     Array of Simple Payment objects or an object if `simplePaymentId` specified.
  */
-export default createSelector(
-	( state, siteId, simplePaymentId = null ) => {
-		if ( ! siteId ) {
+export default createSelector( ( state, siteId, simplePaymentId = null ) => {
+	if ( ! siteId ) {
+		return null;
+	}
+
+	const simplePaymentProducts = get( state, `simplePayments.productList.items.${ siteId }`, null );
+
+	if ( ! simplePaymentId ) {
+		if ( ! simplePaymentProducts ) {
 			return null;
 		}
 
-		const simplePaymentProducts = get( state, `simplePayments.productList.items.${ siteId }`, null );
+		return orderBy( simplePaymentProducts, 'ID', 'desc' );
+	}
 
-		if ( ! simplePaymentId ) {
-			if ( ! simplePaymentProducts ) {
-				return null;
-			}
+	const simplePaymentProduct = find(
+		simplePaymentProducts,
+		product => product.ID === simplePaymentId,
+	);
 
-			return orderBy( simplePaymentProducts, 'ID', 'desc' );
-		}
+	if ( ! simplePaymentProduct ) {
+		return null;
+	}
 
-		const simplePaymentProduct = find( simplePaymentProducts, ( product ) => product.ID === simplePaymentId );
-
-		if ( ! simplePaymentProduct ) {
-			return null;
-		}
-
-		return simplePaymentProduct;
-	},
-	( state ) => state.simplePayments.productList.items
-);
+	return simplePaymentProduct;
+}, state => state.simplePayments.productList.items );

--- a/client/state/selectors/get-simple-payments.js
+++ b/client/state/selectors/get-simple-payments.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { get, find } from 'lodash';
+import { get, find, orderBy } from 'lodash';
 
 /**
  * Internal dependencies
@@ -9,7 +9,8 @@ import { get, find } from 'lodash';
 import createSelector from 'lib/create-selector';
 
 /**
- * Get all Simple Payment or the one specified by `simplePaymentId`
+ * Get all Simple Payment or the one specified by `simplePaymentId`. They will be returned ordered by
+ * ID from the largest to the lowest number (the same as ordering by creation date DESC).
  *
  * @param {Object} state           Global state tree
  * @param {int}    siteId          Site which the Simple Payment belongs to.
@@ -25,7 +26,11 @@ export default createSelector(
 		const simplePaymentProducts = get( state, `simplePayments.productList.items.${ siteId }`, null );
 
 		if ( ! simplePaymentId ) {
-			return simplePaymentProducts;
+			if ( ! simplePaymentProducts ) {
+				return null;
+			}
+
+			return orderBy( simplePaymentProducts, 'ID', 'desc' );
 		}
 
 		const simplePaymentProduct = find( simplePaymentProducts, ( product ) => product.ID === simplePaymentId );

--- a/client/state/selectors/test/get-simple-payments.js
+++ b/client/state/selectors/test/get-simple-payments.js
@@ -20,6 +20,12 @@ const simplePayment2 = {
 	description: 'Simple Payment 2 description',
 };
 
+const simplePayment3 = {
+	ID: 3,
+	title: 'Simple Payment 3',
+	description: 'Simple Payment 3 description',
+};
+
 describe( 'getSimplePayments()', () => {
 	it( 'should return null if siteId is not specified', () => {
 		const state = {
@@ -67,10 +73,11 @@ describe( 'getSimplePayments()', () => {
 		expect( simplePayments ).to.eql( [] );
 	} );
 
-	it( 'should return all Simple Payments for a given siteId', () => {
+	it( 'should return all Simple Payments for a given siteId ordered by ID DESC', () => {
 		const simplePaymentsInState = [
-			simplePayment1,
 			simplePayment2,
+			simplePayment3,
+			simplePayment1,
 		];
 
 		const state = {
@@ -85,7 +92,7 @@ describe( 'getSimplePayments()', () => {
 
 		const simplePayments = getSimplePayments( state, 1234 );
 
-		expect( simplePayments ).to.eql( simplePaymentsInState );
+		expect( simplePayments ).to.eql( [ simplePayment3, simplePayment2, simplePayment1 ] );
 	} );
 
 	it( 'should return null if simplePaymentId was specified but is not found', () => {

--- a/client/state/selectors/test/get-simple-payments.js
+++ b/client/state/selectors/test/get-simple-payments.js
@@ -31,9 +31,9 @@ describe( 'getSimplePayments()', () => {
 		const state = {
 			simplePayments: {
 				productList: {
-					items: {}
-				}
-			}
+					items: {},
+				},
+			},
 		};
 
 		const simplePayments = getSimplePayments( state );
@@ -46,10 +46,10 @@ describe( 'getSimplePayments()', () => {
 			simplePayments: {
 				productList: {
 					items: {
-						1111: []
-					}
-				}
-			}
+						1111: [],
+					},
+				},
+			},
 		};
 
 		const simplePayments = getSimplePayments( state, 1234 );
@@ -63,9 +63,9 @@ describe( 'getSimplePayments()', () => {
 				productList: {
 					items: {
 						1234: [],
-					}
-				}
-			}
+					},
+				},
+			},
 		};
 
 		const simplePayments = getSimplePayments( state, 1234 );
@@ -74,20 +74,16 @@ describe( 'getSimplePayments()', () => {
 	} );
 
 	it( 'should return all Simple Payments for a given siteId ordered by ID DESC', () => {
-		const simplePaymentsInState = [
-			simplePayment2,
-			simplePayment3,
-			simplePayment1,
-		];
+		const simplePaymentsInState = [ simplePayment2, simplePayment3, simplePayment1 ];
 
 		const state = {
 			simplePayments: {
 				productList: {
 					items: {
 						1234: simplePaymentsInState,
-					}
-				}
-			}
+					},
+				},
+			},
 		};
 
 		const simplePayments = getSimplePayments( state, 1234 );
@@ -96,19 +92,16 @@ describe( 'getSimplePayments()', () => {
 	} );
 
 	it( 'should return null if simplePaymentId was specified but is not found', () => {
-		const simplePaymentsInState = [
-			simplePayment1,
-			simplePayment2,
-		];
+		const simplePaymentsInState = [ simplePayment1, simplePayment2 ];
 
 		const state = {
 			simplePayments: {
 				productList: {
 					items: {
 						1234: simplePaymentsInState,
-					}
-				}
-			}
+					},
+				},
+			},
 		};
 
 		const simplePayment = getSimplePayments( state, 1234, 10 );
@@ -117,19 +110,16 @@ describe( 'getSimplePayments()', () => {
 	} );
 
 	it( 'should return a Simple Payment object if simplePaymentId is specified and found', () => {
-		const simplePaymentsInState = [
-			simplePayment1,
-			simplePayment2,
-		];
+		const simplePaymentsInState = [ simplePayment1, simplePayment2 ];
 
 		const state = {
 			simplePayments: {
 				productList: {
 					items: {
 						1234: simplePaymentsInState,
-					}
-				}
-			}
+					},
+				},
+			},
 		};
 
 		const simplePayment = getSimplePayments( state, 1234, 1 );


### PR DESCRIPTION
Makes it easier to fill in the Simple Payments product form: if it's the first payment button on a site, customer's email address will be used as the default value for the "email" field. On the other hand, if there are some previously created payment buttons, the email address of the last payment button will be used.

This PR also orders the payment buttons retrieved with the `getSimplePayments` selector in a descending order by default.

## Testing

Run unit tests of `getSimplePayments` selector by the following command from the root of Calypso directory:

```
npm run test-client client/state/selectors/test/
```

Select a site with no payment buttons and navigate to add a new one. Is your email address pre-filled in the "email" field? Create a few payment buttons but use a different email address than your own. Now, when creating a new payment button, is it pre-populated with the email address used on the previous payment button?

/cc @Automattic/stark 