### PR TITLE
JPO: fill title and description fields if they're stored

### DIFF
--- a/client/signup/steps/jpo-site-title/index.jsx
+++ b/client/signup/steps/jpo-site-title/index.jsx
@@ -21,7 +21,7 @@ import Button from 'components/button';
 import { translate } from 'i18n-calypso';
 
 import { setJPOSiteTitle } from 'state/signup/steps/jpo-site-title/actions';
-import { getJPOSiteTitle } from 'state/signup/steps/jpo-site-title/selectors';
+import { getJPOSiteTitle, getJPOSiteDescription } from 'state/signup/steps/jpo-site-title/selectors';
 
 const JPOSiteTitleStep = React.createClass( {
 	errorMessage: '',
@@ -36,6 +36,10 @@ const JPOSiteTitleStep = React.createClass( {
 	},
 
 	componentWillMount() {
+		const {
+			storeJpoSiteTitle,
+			storeJpoSiteDescription,
+		} = this.props;
 		this.formStateController = new formState.Controller( {
 			fieldNames: [ 'siteTitle', 'siteDescription' ],
 			validatorFunction: noop,
@@ -43,10 +47,10 @@ const JPOSiteTitleStep = React.createClass( {
 			hideFieldErrorsOnChange: true,
 			initialState: {
 				siteTitle: {
-					value: ''
+					value: storeJpoSiteTitle
 				},
 				siteDescription: {
-					value: ''
+					value: storeJpoSiteDescription
 				}
 			}
 		} );
@@ -93,8 +97,6 @@ const JPOSiteTitleStep = React.createClass( {
 			this.setState( { siteDescriptionInvalid: true } );
 		}
 
-		console.log( jpoSiteTitle.siteTitle, jpoSiteTitle.siteDescription );
-
 		if ( ! ( jpoSiteTitle.siteTitle && jpoSiteTitle.siteDescription ) ) {
 			return false;
 		}
@@ -115,6 +117,7 @@ const JPOSiteTitleStep = React.createClass( {
 	},
 
 	renderStepContent() {
+		const { siteTitle, siteDescription } = this.getPayload();
 		return (
 			<Card className="jpo__site-title-card">
 				<FormFieldset>
@@ -124,6 +127,7 @@ const JPOSiteTitleStep = React.createClass( {
 						className="jpo__site-title-input"
 						name="siteTitle"
 						onChange={ this.handleChangeEvent }
+						value={ siteTitle }
 					/>
 					<FormLabel>{ translate( 'Site Description' ) }</FormLabel>
 					<JPOTextarea
@@ -131,6 +135,7 @@ const JPOSiteTitleStep = React.createClass( {
 						className="jpo__site-description-input" 
 						name="siteDescription"
 						onChange={ this.handleChangeEvent }
+						value={ siteDescription }
 					/>
 					<FormLabel className="jpo__validation-error">{ this.errorMessage }</FormLabel>
 					<Button primary onClick={ this.submitStep } className="jpo__site-title-submit">{ translate( 'Next Step' ) }</Button>
@@ -163,6 +168,13 @@ const JPOSiteTitleStep = React.createClass( {
 } );
 
 export default connect(
-	null,
-	{ setJPOSiteTitle }
+	state => {
+		return {
+			storeJpoSiteTitle: getJPOSiteTitle( state ),
+			storeJpoSiteDescription: getJPOSiteDescription( state )
+		};
+	},
+	{
+		setJPOSiteTitle
+	}
 )( JPOSiteTitleStep );

--- a/client/state/signup/steps/jpo-site-title/selectors.js
+++ b/client/state/signup/steps/jpo-site-title/selectors.js
@@ -1,8 +1,22 @@
 /**
  * External dependencies
  */
-import { get } from 'lodash';
+import get from 'lodash/get';
 
+/**
+ * Get stored site title as was last input by user.
+ * @param  {Object} state Global state tree
+ * @return {String} Site title in state tree.
+ */
 export function getJPOSiteTitle( state ) {
-	return get( state, 'signup.steps.jpoSiteTitle', '' );
+	return get( state, [ 'signup', 'dependencyStore', 'jpoSiteTitle', 'siteTitle' ], '' );
+}
+
+/**
+ * Get stored site description as was last input by user.
+ * @param  {Object} state Global state tree
+ * @return {String} Site title in state tree.
+ */
+export function getJPOSiteDescription( state ) {
+	return get( state, [ 'signup', 'dependencyStore', 'jpoSiteTitle', 'siteDescription' ], '' );
 }


### PR DESCRIPTION
Before this PR the title and description fields are empty as soon as you go to the next step and back. This fixes it and now they're filled in when user returns to that step:

![persistent](https://user-images.githubusercontent.com/1041600/29228266-8922ade4-7eaf-11e7-93f3-a7a52fb5ae55.gif)

- introduce selector `getJPOSiteDescription`
- if there's a site title and description, fill in the fields 