### PR TITLE
Post Actions Menu: add 'Duplicate' option

### DIFF
--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/duplicate.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/duplicate.jsx
@@ -1,0 +1,72 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import PopoverMenuItem from 'components/popover/menu-item';
+import QueryPostTypes from 'components/data/query-post-types';
+import { mc } from 'lib/analytics';
+import { canCurrentUser } from 'state/selectors';
+import { getPost } from 'state/posts/selectors';
+import { getPostType } from 'state/post-types/selectors';
+import { getCurrentUserId, isValidCapability } from 'state/current-user/selectors';
+import { getEditorDuplicatePostPath } from 'state/ui/editor/selectors';
+import config from 'config';
+
+function PostActionsEllipsisMenuDuplicate( { translate, siteId, canEdit, duplicateUrl, isKnownType } ) {
+	if ( ! config.isEnabled( 'posts/post-type-list' ) || ! canEdit ) {
+		return null;
+	}
+
+	function bumpStat() {
+		mc.bumpStat( 'calypso_cpt_actions', 'duplicate' );
+	}
+
+	return (
+		<PopoverMenuItem href={ duplicateUrl } onClick={ bumpStat } icon="pages">
+			{ siteId && ! isKnownType && <QueryPostTypes siteId={ siteId } /> }
+			{ translate( 'Duplicate', { context: 'verb' } ) }
+		</PopoverMenuItem>
+	);
+}
+
+PostActionsEllipsisMenuDuplicate.propTypes = {
+	globalId: PropTypes.string,
+	translate: PropTypes.func.isRequired,
+	siteId: PropTypes.number,
+	canEdit: PropTypes.bool,
+	status: PropTypes.string,
+	duplicateUrl: PropTypes.string,
+	isKnownType: PropTypes.bool
+};
+
+export default connect( ( state, ownProps ) => {
+	const post = getPost( state, ownProps.globalId );
+	if ( ! post ) {
+		return {};
+	}
+
+	const type = getPostType( state, post.site_ID, post.type );
+	const userId = getCurrentUserId( state );
+	const isAuthor = get( post.author, 'ID' ) === userId;
+
+	let capability = isAuthor ? 'edit_posts' : 'edit_others_posts';
+	const typeCapability = get( type, [ 'capabilities', capability ] );
+	if ( isValidCapability( state, post.site_ID, typeCapability ) ) {
+		capability = typeCapability;
+	}
+
+	return {
+		siteId: post.site_ID,
+		canEdit: canCurrentUser( state, post.site_ID, capability ),
+		duplicateUrl: getEditorDuplicatePostPath( state, post.site_ID, post.ID ),
+		isKnownType: !! type
+	};
+} )( localize( PostActionsEllipsisMenuDuplicate ) );

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/duplicate.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/duplicate.jsx
@@ -5,7 +5,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { get } from 'lodash';
+import { get, includes } from 'lodash';
 
 /**
  * Internal dependencies
@@ -22,8 +22,12 @@ import { bumpStat } from 'state/analytics/actions';
 
 const bumpDuplicateStat = () => bumpStat( 'calypso_cpt_actions', 'duplicate' );
 
-function PostActionsEllipsisMenuDuplicate( { translate, siteId, canEdit, duplicateUrl, isKnownType, bumpDuplicateStat: handleStatBump } ) {
-	if ( ! isEnabled( 'posts/post-type-list' ) || ! canEdit ) {
+function PostActionsEllipsisMenuDuplicate(
+	{ translate, siteId, canEdit, duplicateUrl, isKnownType, bumpDuplicateStat: handleStatBump, status }
+) {
+	const validStatus = includes( [ 'draft', 'future', 'pending', 'private', 'publish' ], status );
+
+	if ( ! isEnabled( 'posts/post-type-list' ) || ! canEdit || ! validStatus ) {
 		return null;
 	}
 
@@ -63,6 +67,7 @@ export default connect( ( state, { globalId } ) => {
 	}
 
 	return {
+		status: post.status,
 		siteId: post.site_ID,
 		canEdit: canCurrentUser( state, post.site_ID, capability ),
 		duplicateUrl: getEditorDuplicatePostPath( state, post.site_ID, post.ID ),

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/index.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/index.jsx
@@ -14,6 +14,7 @@ import PostActionsEllipsisMenuPublish from './publish';
 import PostActionsEllipsisMenuTrash from './trash';
 import PostActionsEllipsisMenuView from './view';
 import PostActionsEllipsisMenuRestore from './restore';
+import PostActionsEllipsisMenuDuplicate from './duplicate';
 
 export default function PostActionsEllipsisMenu( { globalId, includeDefaultActions, children } ) {
 	let actions = [];
@@ -25,6 +26,7 @@ export default function PostActionsEllipsisMenu( { globalId, includeDefaultActio
 			<PostActionsEllipsisMenuStats key="stats" />,
 			<PostActionsEllipsisMenuPublish key="publish" />,
 			<PostActionsEllipsisMenuRestore key="restore" />,
+			<PostActionsEllipsisMenuDuplicate key="duplicate" />,
 			<PostActionsEllipsisMenuTrash key="trash" />
 		);
 	}

--- a/client/state/ui/editor/selectors.js
+++ b/client/state/ui/editor/selectors.js
@@ -31,6 +31,19 @@ export function isEditorNewPost( state ) {
 }
 
 /**
+ * Returns the editor URL for duplicating a given site ID, post ID pair.
+ *
+ * @param  {Object}  state Global state tree
+ * @param  {Number} siteId      Site ID
+ * @param  {Number} postId      Post ID
+ * @param  {String} type        Post type
+ */
+export function getEditorDuplicatePostPath( state, siteId, postId, type = 'post' ) {
+	const editorNewPostPath = getEditorNewPostPath( state, siteId, type );
+	return `${ editorNewPostPath }?copy=${ postId }`;
+}
+
+/**
  * Returns the editor new post URL path for the given site ID and type.
  *
  * @param  {Object} state       Global state tree


### PR DESCRIPTION
This PR adds a "Duplicate" option to the `PostActionsEllipsisMenu`. Selecting that option takes you to the editor URL that duplicates an existing post. It also bumps a stat indicating that the menu item was used.

This PR is part of a larger epic and behind the `posts/post-type-list` feature flag.
See p8F9tW-hL-p2.

![duplicate](https://user-images.githubusercontent.com/363749/29229817-efdc259c-7ea5-11e7-9ec2-d7fcf835d319.png)

To test:
* Checkout the branch, and run with the feature flag enabled: `ENABLE_FEATURES=posts/post-type-list npm start`
* Visit the blog posts page for one of your sites. Verify that clicking on "Duplicate" from the ellipsis menu brings you to the editor and duplicates the content of the post on which you clicked.