### PR TITLE
Pages: Show site icon and title in all sites mode

### DIFF
--- a/client/my-sites/pages/page-list.jsx
+++ b/client/my-sites/pages/page-list.jsx
@@ -292,7 +292,7 @@ const Pages = localize( React.createClass( {
 
 			// Render each page
 			return (
-				<Page key={ 'page-' + page.global_ID } page={ page } multisite={ ! this.props.siteId } />
+				<Page key={ 'page-' + page.global_ID } page={ page } multisite={ this.props.siteId === null } />
 			);
 		}, this );
 

--- a/client/my-sites/pages/page-list.jsx
+++ b/client/my-sites/pages/page-list.jsx
@@ -292,7 +292,7 @@ const Pages = localize( React.createClass( {
 
 			// Render each page
 			return (
-				<Page key={ 'page-' + page.global_ID } page={ page } multisite={ this.props.siteId === false } />
+				<Page key={ 'page-' + page.global_ID } page={ page } multisite={ ! this.props.siteId } />
 			);
 		}, this );
 


### PR DESCRIPTION
Fixes #16888 

This PR fixes an issue where when viewing Pages with "All My Sites" selected in the site-selector, the site icons and domain were not visible.

To test:
* Checkout branch, `npm start`
* Visit http://calypso.localhost:3000/pages using an account with multiple sites.
* Verify that the site icons and domains are now visible for your pages.