### PR TITLE
Update footer for OAuth login page

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -19,7 +19,6 @@ import {
 	isTwoFactorEnabled,
 	getLinkingSocialUser,
 	getLinkingSocialService,
-	getOAuth2ClientData,
 } from 'state/login/selectors';
 import { recordTracksEvent } from 'state/analytics/actions';
 import VerificationCodeForm from './two-factor-authentication/verification-code-form';
@@ -231,7 +230,6 @@ export default connect(
 		twoFactorNotificationSent: getTwoFactorNotificationSent( state ),
 		linkingSocialUser: getLinkingSocialUser( state ),
 		linkingSocialService: getLinkingSocialService( state ),
-		oauth2ClientData: getOAuth2ClientData( state ),
 	} ), {
 		recordTracksEvent,
 	}

--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -99,7 +99,7 @@
 	margin: 0 10px 10px;
 }
 
-.wp-login__footer {
+.wp-login__links {
 	a {
 		font-size: 14px;
 
@@ -158,4 +158,3 @@
 .login__social-connect-prompt-action .button {
 	width: 100%;
 }
-

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -12,6 +12,7 @@ import { localize } from 'i18n-calypso';
 import DocumentHead from 'components/data/document-head';
 import LoginLinks from './login-links';
 import { getCurrentUserId } from 'state/current-user/selectors';
+import { getOAuth2ClientData } from 'state/login/selectors';
 import Main from 'components/main';
 import LocaleSuggestions from 'components/locale-suggestions';
 import LoginBlock from 'blocks/login';
@@ -25,6 +26,7 @@ export class Login extends React.Component {
 		clientId: PropTypes.string,
 		isLoggedIn: PropTypes.bool.isRequired,
 		locale: PropTypes.string.isRequired,
+		oauth2ClientData: PropTypes.object,
 		path: PropTypes.string.isRequired,
 		privateSite: PropTypes.bool,
 		recordPageView: PropTypes.func.isRequired,
@@ -88,6 +90,7 @@ export class Login extends React.Component {
 		const {
 			clientId,
 			isLoggedIn,
+			oauth2ClientData,
 			privateSite,
 			socialConnect,
 			twoFactorAuthType,
@@ -105,6 +108,7 @@ export class Login extends React.Component {
 				socialConnect={ socialConnect }
 				privateSite={ privateSite }
 				clientId={ clientId }
+				oauth2ClientData={ oauth2ClientData }
 			/>
 		);
 	}
@@ -149,7 +153,8 @@ export class Login extends React.Component {
 
 export default connect(
 	( state ) => ( {
-		isLoggedIn: Boolean( getCurrentUserId( state ) )
+		isLoggedIn: Boolean( getCurrentUserId( state ) ),
+		oauth2ClientData: getOAuth2ClientData( state ),
 	} ),
 	{
 		recordPageView,

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import classNames from 'classnames';
 import React, { PropTypes } from 'react';
 import { startCase } from 'lodash';
 import { connect } from 'react-redux';
@@ -79,9 +80,23 @@ export class Login extends React.Component {
 	}
 
 	renderFooter() {
+		const isOauthLogin = !! this.props.oauth2ClientData;
 		return (
-			<div className="wp-login__jetpack-footer">
-				<img src="/calypso/images/jetpack/powered-by-jetpack.svg" alt="Powered by Jetpack" />
+			<div
+				className={ classNames( 'wp-login__footer', {
+					'wp-login__footer--oauth': isOauthLogin,
+					'wp-login__footer--jetpack': ! isOauthLogin,
+				} ) }
+			>
+				{ isOauthLogin ? (
+					<div className="wp-login__footer-links">
+						<a href="https://en.wordpress.com/about/" key="about">About</a>
+						<a href="https://automattic.com/privacy/" key="privacy">Privacy</a>
+						<a href="https://en.wordpress.com/tos/" key="tos">Terms of Service</a>
+					</div>
+				) : (
+					<img src="/calypso/images/jetpack/powered-by-jetpack.svg" alt="Powered by Jetpack" />
+				) }
 			</div>
 		);
 	}

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -80,6 +80,7 @@ export class Login extends React.Component {
 	}
 
 	renderFooter() {
+		const { translate } = this.props;
 		const isOauthLogin = !! this.props.oauth2ClientData;
 		return (
 			<div
@@ -90,9 +91,30 @@ export class Login extends React.Component {
 			>
 				{ isOauthLogin ? (
 					<div className="wp-login__footer-links">
-						<a href="https://en.wordpress.com/about/" key="about">About</a>
-						<a href="https://automattic.com/privacy/" key="privacy">Privacy</a>
-						<a href="https://en.wordpress.com/tos/" key="tos">Terms of Service</a>
+						<a
+							href="https://wordpress.com/about/"
+							rel="noopener noreferrer"
+							target="_blank"
+							title={ translate( 'About' ) }
+						>
+							{ translate( 'About' ) }
+						</a>
+						<a
+							href="https://automattic.com/privacy/"
+							rel="noopener noreferrer"
+							target="_blank"
+							title={ translate( 'Privacy' ) }
+						>
+							{ translate( 'Privacy' ) }
+						</a>
+						<a
+							href="https://wordpress.com/tos/"
+							rel="noopener noreferrer"
+							target="_blank"
+							title={ translate( 'Terms of Service' ) }
+						>
+							{ translate( 'Terms of Service' ) }
+						</a>
 					</div>
 				) : (
 					<img src="/calypso/images/jetpack/powered-by-jetpack.svg" alt="Powered by Jetpack" />

--- a/client/login/wp-login/login-links.jsx
+++ b/client/login/wp-login/login-links.jsx
@@ -158,7 +158,7 @@ export class LoginLinks extends React.Component {
 
 	render() {
 		return (
-			<div className="wp-login__footer">
+			<div className="wp-login__links">
 				{ this.renderLostPhoneLink() }
 				{ this.renderHelpLink() }
 				{ this.renderMagicLoginLink() }

--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -19,7 +19,7 @@
 	text-align: center;
 }
 
-.wp-login__footer {
+.wp-login__links {
 	a {
 		border-bottom: 1px solid lighten( $gray, 20% );
 		color: darken( $gray, 20% );

--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -21,15 +21,21 @@ $image-height: 47px;
 	text-align: center;
 }
 
+.wp-login__links,
+.wp-login__footer {
+	a {
+		color: darken( $gray, 20% );
+		text-decoration: none;
+	}
+}
+
 .wp-login__links {
 	a {
 		border-bottom: 1px solid lighten( $gray, 20% );
-		color: darken( $gray, 20% );
 		display: block;
 		font-weight: 500;
 		line-height: 4em;
 		padding: 0 24px;
-		text-decoration: none;
 	}
 
 	a:last-of-type {
@@ -37,20 +43,32 @@ $image-height: 47px;
 	}
 }
 
-.wp-login__jetpack-footer {
-	background: #fff;
-	border-top: solid 1px #f9fbfc;
+.wp-login__footer {
+	position: absolute;
+	bottom: 0;
+	left: 0;
 	height: $image-height;
 	line-height: $image-height;
-	position: absolute;
-		bottom: 0;
-		left: 0;
-	text-align: center;
 	width: 100%;
+}
+
+.wp-login__footer--jetpack {
+	background: #fff;
+	border-top: solid 1px #f9fbfc;
+	text-align: center;
 
 	img {
 		display: block;
 		margin: 0 auto;
+	}
+}
+
+.wp-login__footer--oauth {
+	display: flex;
+	justify-content: center;
+
+	a {
+		padding: 0 1em;
 	}
 }
 

--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -1,7 +1,9 @@
+$image-height: 47px;
+
 .is-section-login {
-	padding-bottom: 47px;
+	padding-bottom: $image-height;
 	position: relative;
-	min-height: calc( 100% - 47px );
+	min-height: calc( 100% - #{$image-height} );
 
 	.layout__content {
 		position: static;
@@ -38,8 +40,8 @@
 .wp-login__jetpack-footer {
 	background: #fff;
 	border-top: solid 1px #f9fbfc;
-	height: 47px;
-	line-height: 47px;
+	height: $image-height;
+	line-height: $image-height;
 	position: absolute;
 		bottom: 0;
 		left: 0;


### PR DESCRIPTION
This adds a new footer to the OAuth login page per @danhauk's new design:

<img width="768" alt="image 2017-08-11 at 12 27 38" src="https://user-images.githubusercontent.com/4044428/29234671-e9c01e24-7eb5-11e7-901c-323dff8d11ec.png">

#### Testing instructions

- Each commit in this PR is broken down into logical chunks. Hopefully this makes it easier to follow along.
1. Check out locally (`git checkout update/oauth-login-footer`) and start your server. You can also use a [live branch](https://calypso.live/?branch=update/oauth-login-footer)
2. Open the OAuth Log In page ([`/log-in?client_id=1`](http://calypso.localhost:3000/log-in?client_id=1))
3. Confirm that the Jetpack footer has been replaced with a new OAuth footer with links for `About`, `Privacy`, and `Terms of Service`.
5. Repeat steps 2 and 3 with ([`/log-in?client_id=973`](http://calypso.localhost:3000/log-in?client_id=973)).
6. Verify that the Jetpack footer still shows on the regular Log In page ([`/log-in`](http://calypso.localhost:3000/log-in))

#### Sanity checks

- [x] Are we using the correct links for `About`?
- [x] Are we using the correct links for `Privacy`?
- [x] Are we using the correct links for `ToS`?
- [x] Can we use Flexbox styling for Calypso?
  - Edit by @jsnmoon: The Masterbar uses flexbox, so yeah. It's fine here.

#### Reviews

- [x] Code
- [x] Product