### PR TITLE
JPO: onboard redirect

### DIFF
--- a/client/jetpack-connect/authorize-form.jsx
+++ b/client/jetpack-connect/authorize-form.jsx
@@ -27,8 +27,7 @@ import {
 	isRemoteSiteOnSitesList,
 	getAuthAttempts,
 	getSiteIdFromQueryObject,
-	getUserAlreadyConnected,
-	getOnboardingFromQueryObject
+	getUserAlreadyConnected
 } from 'state/jetpack-connect/selectors';
 import { getCurrentUser } from 'state/current-user/selectors';
 import { recordTracksEvent } from 'state/analytics/actions';
@@ -68,45 +67,6 @@ class JetpackConnectAuthorizeForm extends Component {
 	};
 
 	componentWillMount() {
-		// Handle JPO redirect
-		if ( this.props.onboarding ) {
-			/**
-			 * The JPO flow has not been completed yet. Send the user to the flow but store the
-			 * connect URL so we can come back to it after the flow is complete.
-			 */
-			if ( ! localStorage.getItem( 'jpoFlowComplete' ) ) {
-				/**
-				 * Store the connect URL only on the first call, otherwise the localStorage
-				 * will be overwritten by itself without the query string
-				 */
-				if ( ! localStorage.getItem( 'jpoConnectUrl' ) ) {
-					localStorage.setItem( 'jpoConnectUrl', this.props.path );
-				}
-
-				// Do the redirect
-				window.location.href = '/start/jetpack-onboarding/';
-				return false;
-			/**
-			 * The onboarding flow is complete, and the user has returned here with the payload
-			 * stored in localStorage.
-			 */
-			} else {
-				const jpoPayload = JSON.parse( localStorage.getItem( 'jpoPayload' ) );
-
-				// Remove all the localStorage data. We don't need it anymore.
-				localStorage.removeItem( 'jpoPayload' );
-				localStorage.removeItem( 'jpoFlowComplete' );
-				localStorage.removeItem( 'jpoConnectUrl' );
-
-				/**
-				 * TBD - store the payload in authorize state, and upon authorization, make the
-				 * proper API requests to the site to set the site up as specified by the
-				 * onboarding flow.
-				 */
-				console.log( 'JPO Payload: ', jpoPayload );
-			}
-		}
-
 		this.props.recordTracksEvent( 'calypso_jpc_authorize_form_view' );
 	}
 
@@ -128,7 +88,7 @@ class JetpackConnectAuthorizeForm extends Component {
 
 	handleClickHelp = () => {
 		this.props.recordTracksEvent( 'calypso_jpc_help_link_click' );
-	}
+	};
 
 	renderNoQueryArgsError() {
 		return (
@@ -167,7 +127,7 @@ class JetpackConnectAuthorizeForm extends Component {
 	render() {
 		const { queryObject } = this.props.jetpackConnectAuthorize;
 
-		if ( typeof queryObject === 'undefined' ) {
+		if ( 'undefined' === typeof queryObject ) {
 			return this.renderNoQueryArgsError();
 		}
 
@@ -204,8 +164,7 @@ export default connect(
 			requestHasXmlrpcError,
 			siteSlug,
 			user: getCurrentUser( state ),
-			userAlreadyConnected: getUserAlreadyConnected( state ),
-			onboarding: getOnboardingFromQueryObject( state )
+			userAlreadyConnected: getUserAlreadyConnected( state )
 		};
 	},
 	{

--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -74,6 +74,47 @@ export default {
 		next();
 	},
 
+	maybeOnboard( context, next ) {
+		if ( context.query.onboarding ) {
+			/**
+			 * The JPO flow has not been completed yet. Send the user to the flow but store the
+			 * connect URL so we can come back to it after the flow is complete.
+			 */
+			if ( ! localStorage.getItem( 'jpoFlowComplete' ) ) {
+				/**
+				 * Store the connect URL only on the first call, otherwise the localStorage
+				 * will be overwritten by itself without the query string
+				 */
+				if ( ! localStorage.getItem( 'jpoConnectUrl' ) ) {
+					localStorage.setItem( 'jpoConnectUrl', context.path );
+				}
+
+				// Do the redirect
+				return page.redirect( '/start/jetpack-onboarding/' );
+				/**
+				 * The onboarding flow is complete, and the user has returned here with the payload
+				 * stored in localStorage.
+				 */
+			}
+
+			const jpoPayload = JSON.parse( localStorage.getItem( 'jpoPayload' ) );
+
+			// Remove all the localStorage data. We don't need it anymore.
+			localStorage.removeItem( 'jpoPayload' );
+			localStorage.removeItem( 'jpoFlowComplete' );
+			localStorage.removeItem( 'jpoConnectUrl' );
+
+			/**
+			 * TBD - store the payload in authorize state, and upon authorization, make the
+			 * proper API requests to the site to set the site up as specified by the
+			 * onboarding flow.
+			 */
+			console.log( 'JPO Payload: ', jpoPayload );
+		}
+
+		next();
+	},
+
 	saveQueryObject( context, next ) {
 		if ( ! isEmpty( context.query ) && context.query.redirect_uri ) {
 			debug( 'set initial query object', context.query );

--- a/client/jetpack-connect/index.js
+++ b/client/jetpack-connect/index.js
@@ -31,6 +31,7 @@ export default function() {
 	page(
 		'/jetpack/connect/authorize/:localeOrInterval?',
 		controller.redirectWithoutLocaleifLoggedIn,
+		controller.maybeOnboard,
 		controller.saveQueryObject,
 		controller.authorizeForm
 	);
@@ -38,6 +39,7 @@ export default function() {
 	page(
 		'/jetpack/connect/authorize/:interval/:locale',
 		controller.redirectWithoutLocaleifLoggedIn,
+		controller.maybeOnboard,
 		controller.saveQueryObject,
 		controller.authorizeForm
 	);

--- a/client/state/jetpack-connect/selectors.js
+++ b/client/state/jetpack-connect/selectors.js
@@ -159,16 +159,6 @@ const getSiteIdFromQueryObject = function( state ) {
 	return null;
 };
 
-const getOnboardingFromQueryObject = function( state ) {
-	const authorizationData = getAuthorizationData( state );
-
-	if ( authorizationData.queryObject && authorizationData.queryObject.onboarding ) {
-		return ( 1 === parseInt( authorizationData.queryObject.onboarding ) ) ? true : false;
-	} else {
-		return false;
-	}
-};
-
 export default {
 	getConnectingSite,
 	getAuthorizationData,
@@ -188,6 +178,5 @@ export default {
 	getGlobalSelectedPlan,
 	getAuthAttempts,
 	getSiteIdFromQueryObject,
-	getUserAlreadyConnected,
-	getOnboardingFromQueryObject
+	getUserAlreadyConnected
 };


### PR DESCRIPTION
Previously the logic to redirect was in the connect page and was showing the connect form briefly before going to the flow. This PR correctly goes straight to the flow:

![redirect](https://user-images.githubusercontent.com/1041600/29236041-c7b765a0-7edb-11e7-9eb7-2edcc7fd11ee.gif)

- remove unneeded selector `getOnboardingFromQueryObject`
- move logic to redirect to onboard users to connect controller