### PR TITLE
Comments: Default user name as "Anonymous"

### DIFF
--- a/client/blocks/comment-detail/index.jsx
+++ b/client/blocks/comment-detail/index.jsx
@@ -42,11 +42,11 @@ const getCommentStatusAction = ( { commentId, commentIsLiked, commentStatus, pos
 export class CommentDetail extends Component {
 	static propTypes = {
 		authorAvatarUrl: PropTypes.string,
-		authorDisplayName: PropTypes.string,
 		authorEmail: PropTypes.oneOfType( [ PropTypes.bool, PropTypes.string ] ),
 		authorId: PropTypes.number,
 		authorIp: PropTypes.string,
 		authorIsBlocked: PropTypes.bool,
+		authorName: PropTypes.string,
 		authorUrl: PropTypes.string,
 		authorUsername: PropTypes.string,
 		commentContent: PropTypes.string,
@@ -173,9 +173,9 @@ export class CommentDetail extends Component {
 	render() {
 		const {
 			authorAvatarUrl,
-			authorDisplayName,
 			authorEmail,
 			authorIp,
+			authorName,
 			authorUrl,
 			authorUsername,
 			commentContent,
@@ -197,9 +197,11 @@ export class CommentDetail extends Component {
 			repliedToComment,
 			replyComment,
 			siteId,
+			translate,
 		} = this.props;
 
 		const postUrl = `/read/blogs/${ siteId }/posts/${ postId }`;
+		const authorDisplayName = authorName || translate( 'Anonymous' );
 
 		const {
 			authorIsBlocked,
@@ -311,11 +313,11 @@ const mapStateToProps = ( state, ownProps ) => {
 
 	return ( {
 		authorAvatarUrl: get( comment, 'author.avatar_URL' ),
-		authorDisplayName: get( comment, 'author.name' ),
 		authorEmail: get( comment, 'author.email' ),
 		authorId: get( comment, 'author.ID' ),
 		authorIp: get( comment, 'author.ip' ), // TODO: not available in the current data structure
 		authorIsBlocked: get( comment, 'author.isBlocked' ), // TODO: not available in the current data structure
+		authorName: get( comment, 'author.name' ),
 		authorUrl: get( comment, 'author.URL', '' ),
 		authorUsername: get( comment, 'author.nice_name' ),
 		commentContent: get( comment, 'content' ),


### PR DESCRIPTION
Fixes issue reported in the [Horizon call for testing](https://horizonfeedback.wordpress.com/2017/08/10/call-for-testing-comment-management/comment-page-1/#comment-381).

If the comment author is anonymous (the API returns `comment.author.name: ""`), display **Anonymous** as author name instead of nothing.