### PR TITLE
Editor: Add support for editing embeds inside a post

### DIFF
--- a/client/components/tinymce/index.jsx
+++ b/client/components/tinymce/index.jsx
@@ -42,6 +42,7 @@ import afterTheDeadlinePlugin from './plugins/after-the-deadline/plugin';
 import wptextpatternPlugin from './plugins/wptextpattern/plugin';
 import toolbarPinPlugin from './plugins/toolbar-pin/plugin';
 import insertMenuPlugin from './plugins/insert-menu/plugin';
+import embedPlugin from './plugins/embed/plugin';
 import embedReversalPlugin from './plugins/embed-reversal/plugin';
 import EditorHtmlToolbar from 'post-editor/editor-html-toolbar';
 import mentionsPlugin from './plugins/mentions/plugin';
@@ -69,6 +70,7 @@ import wpEmojiPlugin from './plugins/wpemoji/plugin';
 	afterTheDeadlinePlugin,
 	wptextpatternPlugin,
 	toolbarPinPlugin,
+	embedPlugin,
 	embedReversalPlugin,
 	markdownPlugin,
 	wpEmojiPlugin,
@@ -115,6 +117,7 @@ const EVENTS = {
 
 const PLUGINS = [
 	'colorpicker',
+	'embed',
 	'hr',
 	'lists',
 	'media',

--- a/client/components/tinymce/plugins/embed/dialog.jsx
+++ b/client/components/tinymce/plugins/embed/dialog.jsx
@@ -1,0 +1,109 @@
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import React from 'react';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Button from 'components/button';
+import Dialog from 'components/dialog';
+import FormTextInput from 'components/forms/form-text-input';
+
+/*
+ * Shows the URL of am embed and allows it to be edited.
+ */
+export class EmbedDialog extends React.Component {
+	static propTypes = {
+		embedUrl: PropTypes.string,
+		isVisible: PropTypes.bool,
+
+		// Event handlers
+		onCancel: PropTypes.func.isRequired,
+		onUpdate: PropTypes.func.isRequired,
+
+		// Inherited
+		translate: PropTypes.func.isRequired,
+	};
+
+	static defaultProps = {
+		embedUrl: '',
+		isVisible: false,
+	};
+
+	state = {
+		embedUrl: this.props.embedUrl,
+	};
+
+	/**
+	 * Reset `state.embedUrl` whenever the component's dialog is opened or closed.
+	 *
+	 * If this were not done, then switching back and forth between multiple embeds would result in
+	 * `state.embedUrl` being incorrect. For example, when the second embed was opened,
+	 * `state.embedUrl` would equal the value of the first embed, since it initially set the
+	 * state.
+	 *
+	 * @param {object} nextProps The properties that will be received.
+	 */
+	componentWillReceiveProps = ( nextProps ) => {
+		this.setState( {
+			embedUrl: nextProps.embedUrl,
+		} );
+	};
+
+	onChangeEmbedUrl = ( event ) => {
+		this.setState( { embedUrl: event.target.value } );
+	};
+
+	onUpdate = () => {
+		this.props.onUpdate( this.state.embedUrl );
+	};
+
+	onKeyDownEmbedUrl = ( event ) => {
+		if ( 'Enter' !== event.key ) {
+			return;
+		}
+
+		event.preventDefault();
+		this.onUpdate();
+	};
+
+	render() {
+		const { translate } = this.props;
+		const dialogButtons = [
+			<Button onClick={ this.props.onCancel }>
+				{ translate( 'Cancel' ) }
+			</Button>,
+			<Button primary onClick={ this.onUpdate }>
+				{ translate( 'Update' ) }
+			</Button>
+		];
+
+		return (
+			<Dialog
+				autoFocus={ false }
+				buttons={ dialogButtons }
+				additionalClassNames="embed__modal"
+				isVisible={ this.props.isVisible }
+				onCancel={ this.props.onCancel }
+				onClose={ this.props.onCancel }
+			>
+				<h3 className="embed__title">
+					{ translate( 'Embed URL' ) }
+				</h3>
+
+				<FormTextInput
+					autoFocus={ true }
+					className="embed__url"
+					defaultValue={ this.state.embedUrl }
+					onChange={ this.onChangeEmbedUrl }
+					onKeyDown={ this.onKeyDownEmbedUrl }
+				/>
+			</Dialog>
+		);
+	}
+}
+
+export default localize( EmbedDialog );

--- a/client/components/tinymce/plugins/embed/docs/example.jsx
+++ b/client/components/tinymce/plugins/embed/docs/example.jsx
@@ -1,0 +1,49 @@
+/**
+ * External dependencies
+ */
+import React, { PureComponent } from 'react';
+import { noop } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import Button from 'components/button';
+import Card from 'components/card';
+import EmbedDialog from '../dialog';
+
+export default class EmbedDialogExample extends PureComponent {
+	state = {
+		embedUrl: 'https://www.youtube.com/watch?v=R54QEvTyqO4',
+		showDialog: false,
+	};
+
+	openDialog = () => this.setState( { showDialog: true } );
+
+	onCancel = () => {
+		this.setState( { showDialog: false } );
+	};
+
+	onUpdate = ( newUrl ) => {
+		this.setState( {
+			embedUrl: newUrl,
+			showDialog: false,
+		} );
+	};
+
+	render() {
+		return (
+			<Card>
+				<Button onClick={ this.openDialog }>
+					Open Embed Dialog
+				</Button>
+
+				<EmbedDialog
+					embedUrl={ this.state.embedUrl }
+					isVisible={ this.state.showDialog }
+					onCancel={ this.onCancel }
+					onUpdate={ this.onUpdate }
+				/>
+			</Card>
+		);
+	}
+};

--- a/client/components/tinymce/plugins/embed/plugin.js
+++ b/client/components/tinymce/plugins/embed/plugin.js
@@ -1,0 +1,64 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import ReactDom from 'react-dom';
+import tinymce from 'tinymce/tinymce';
+
+/**
+ * Internal dependencies
+ */
+import EmbedDialog from './dialog';
+
+/**
+ * Manages an EmbedDialog to allow editing the URL of an embed inside the editor.
+ *
+ * @param {object} editor An instance of TinyMCE
+ */
+const embed = ( editor ) => {
+	let embedDialogContainer;
+
+	/**
+	 * Open or close the EmbedDialog
+	 *
+	 * @param {boolean} visible `true` makes the dialog visible; `false` hides it.
+	 */
+	const render = ( visible = true ) => {
+		const selectedEmbedNode = editor.selection.getNode();
+		const embedDialogProps = {
+			embedUrl: selectedEmbedNode.innerText || selectedEmbedNode.textContent,
+			isVisible: visible,
+			onCancel: () => render( false ),
+			onUpdate: ( newUrl ) => {
+				editor.execCommand( 'mceInsertContent', false, newUrl );
+				render( false );
+			},
+		};
+
+		ReactDom.render( React.createElement( EmbedDialog, embedDialogProps ), embedDialogContainer );
+
+		// Focus on the editor when closing the dialog, so that the user can start typing right away
+		// instead of having to tab back to the editor.
+		if ( ! visible ) {
+			editor.focus();
+		}
+	};
+
+	editor.addCommand( 'embedDialog', () => render() );
+
+	editor.on( 'init', () => {
+		embedDialogContainer = editor.getContainer().appendChild(
+			document.createElement( 'div' )
+		);
+	} );
+
+	editor.on( 'remove', () => {
+		ReactDom.unmountComponentAtNode( embedDialogContainer );
+		embedDialogContainer.parentNode.removeChild( embedDialogContainer );
+		embedDialogContainer = null;
+	} );
+};
+
+export default () => {
+	tinymce.PluginManager.add( 'embed', embed );
+};

--- a/client/components/tinymce/plugins/embed/style.scss
+++ b/client/components/tinymce/plugins/embed/style.scss
@@ -1,0 +1,17 @@
+.dialog.card.embed__modal {
+	width: 80%;
+	max-width: 600px;
+}
+
+.embed__modal .dialog__action-buttons:before {
+	background: none;
+}
+
+.embed__title {
+	color: #4b6476;
+	font-weight: bold;
+}
+
+input[type="text"].embed__url {
+	margin-top: 1em;
+}

--- a/client/components/tinymce/plugins/embed/test/dialog.js
+++ b/client/components/tinymce/plugins/embed/test/dialog.js
@@ -1,0 +1,118 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { assert } from 'chai';
+import { shallow } from 'enzyme';
+import { identity, noop } from 'lodash';
+import { spy } from 'sinon';
+
+/**
+ * Internal dependencies
+ */
+import Dialog from 'components/dialog';
+import FormTextInput from 'components/forms/form-text-input';
+import { EmbedDialog } from '../dialog';
+
+describe( 'EmbedDialog', function() {
+	it( 'should render', function() {
+		const url = 'https://www.youtube.com/watch?v=JkOIhs2mHpc';
+		const wrapper = shallow(
+			<EmbedDialog
+				embedUrl={ url }
+				onCancel={ noop }
+				onUpdate={ noop }
+				translate={ identity }
+			/>
+		);
+
+		assert.isFalse( wrapper.instance().props.isVisible );
+		assert.strictEqual( wrapper.find( '.embed__title' ).length, 1 );
+		assert.strictEqual( wrapper.find( FormTextInput ).length, 1 );
+		assert.strictEqual( wrapper.find( FormTextInput ).get( 0 ).props.defaultValue, url );
+	} );
+
+	it( "should update the input field's value when input changes", function() {
+		const originalUrl = 'https://www.youtube.com/watch?v=ghrL82cc-ss';
+		const newUrl = 'https://videopress.com/v/DNgJlco8';
+		const wrapper = shallow(
+			<EmbedDialog
+				embedUrl={ originalUrl }
+				onCancel={ noop }
+				onUpdate={ noop }
+				translate={ identity }
+			/>
+		);
+		const mockChangeEvent = {
+			target: {
+				value: newUrl,
+				focus: noop,
+			}
+		};
+		let inputField = wrapper.find( FormTextInput ).get( 0 );
+
+		assert.strictEqual( inputField.props.defaultValue, originalUrl );
+		wrapper.find( FormTextInput ).simulate( 'change', mockChangeEvent );
+		inputField = wrapper.find( FormTextInput ).get( 0 );
+		assert.strictEqual( inputField.props.defaultValue, newUrl );
+	} );
+
+	it( 'should return the new url to onUpdate when updating', function() {
+		const originalUrl = 'https://www.youtube.com/watch?v=R54QEvTyqO4';
+		const newUrl = 'https://videopress.com/v/x4IYthy7';
+		const mockChangeEvent = {
+			target: {
+				value: newUrl,
+				focus: noop,
+			}
+		};
+		let currentUrl = originalUrl;
+		const onUpdate = ( url ) => {
+			currentUrl = url;
+		};
+		const wrapper = shallow(
+			<EmbedDialog
+				embedUrl={ originalUrl }
+				onCancel={ noop }
+				onUpdate={ onUpdate }
+				translate={ identity }
+			/>
+		);
+
+		assert.strictEqual( currentUrl, originalUrl );
+		wrapper.find( FormTextInput ).simulate( 'change', mockChangeEvent );
+		wrapper.instance().onUpdate();
+		assert.strictEqual( currentUrl, newUrl );
+	} );
+
+	it( 'should not return the new url to onUpdate when canceling', function() {
+		const originalUrl = 'https://www.youtube.com/watch?v=JkOIhs2mHpc';
+		const newUrl = 'https://videopress.com/v/GtWYbzhZ';
+		const mockChangeEvent = {
+			target: {
+				value: newUrl,
+				focus: noop,
+			}
+		};
+		const noopSpy = spy( noop );
+		let currentUrl = originalUrl;
+		const onUpdate = ( url ) => {
+			currentUrl = url;
+		};
+		const wrapper = shallow(
+			<EmbedDialog
+				embedUrl={ originalUrl }
+				onCancel={ noopSpy }
+				onUpdate={ onUpdate }
+				translate={ identity }
+			/>
+		);
+
+		assert.strictEqual( currentUrl, originalUrl );
+		wrapper.find( FormTextInput ).simulate( 'change', mockChangeEvent );
+		assert.isFalse( noopSpy.called );
+		wrapper.find( Dialog ).simulate( 'cancel' );
+		assert.isTrue( noopSpy.called );
+		assert.strictEqual( currentUrl, originalUrl );
+	} );
+} );

--- a/client/components/tinymce/plugins/wpcom-view/plugin.js
+++ b/client/components/tinymce/plugins/wpcom-view/plugin.js
@@ -25,6 +25,8 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 
 /**
  * WordPress View plugin.
+ *
+ * @param {object} editor The TinyMCE instance.
  */
 function wpview( editor ) {
 	var $ = editor.$,
@@ -45,6 +47,8 @@ function wpview( editor ) {
 
 	/**
 	 * Replaces all marker nodes tied to this view instance.
+	 *
+	 * @return {boolean} True if the replacement succeeded; false if it failed.
 	 */
 	function replaceMarkers() {
 		var markers = $( '.wpview-marker' );
@@ -116,7 +120,12 @@ function wpview( editor ) {
 
 	/**
 	 * Returns the node or a parent of the node that has the passed className.
-	 * Doing this directly is about 40% faster
+	 * Doing this directly is about 40% faster.
+	 *
+	 * @param {object} node The node to search.
+	 * @param {string} className The class name to search for.
+	 *
+	 * @return {object|boolean} A node on success; false on failure.
 	 */
 	function getParent( node, className ) {
 		while ( node && node.parentNode ) {
@@ -271,7 +280,7 @@ function wpview( editor ) {
 		if ( event.level.content ) {
 			event.level.content = resetViews( event.level.content );
 		}
-	});
+	} );
 
 	// When the editor's content changes, scan the new content for
 	// matching view patterns, and transform the matches into
@@ -332,13 +341,13 @@ function wpview( editor ) {
 				event.content = pastedStr;
 			}
 		}
-	});
+	} );
 
 	// When the editor's content has been updated and the DOM has been
 	// processed, render the views in the document.
 	editor.on( 'SetContent', function() {
 		renderViews();
-	});
+	} );
 
 	// Set the cursor before or after a view when clicking next to it.
 	editor.on( 'click', function( event ) {
@@ -382,9 +391,9 @@ function wpview( editor ) {
 
 					return false;
 				}
-			});
+			} );
 		}
-	});
+	} );
 
 	editor.on( 'init', function() {
 		var scrolled = false,
@@ -405,7 +414,7 @@ function wpview( editor ) {
 			if ( ! view.nextSibling || getView( view.nextSibling ) ) {
 				// If there are no additional nodes or the next node is a
 				// view, create a text node after the current view.
-				target = editor.getDoc().createTextNode('');
+				target = editor.getDoc().createTextNode( '' );
 				editor.dom.insertAfter( target, view );
 			} else {
 				// Otherwise, find the next text node.
@@ -416,11 +425,11 @@ function wpview( editor ) {
 			// Select the `target` text node.
 			selection.select( target );
 			selection.collapse( true );
-		});
+		} );
 
 		editor.dom.bind( editor.getDoc(), 'touchmove', function() {
 			scrolled = true;
-		});
+		} );
 
 		editor.on( 'mousedown mouseup click touchend', function( event ) {
 			var view = getView( event.target );
@@ -459,7 +468,7 @@ function wpview( editor ) {
 				attributeFilter: [ 'class' ]
 			} );
 		}
-	});
+	} );
 
 	editor.on( 'preinit show', function() {
 		views.emitters.forEach( function( emitter ) {
@@ -490,7 +499,7 @@ function wpview( editor ) {
 	editor.on( 'hide', function() {
 		deselect();
 		emptyViewNodes();
-	});
+	} );
 
 	editor.on( 'GetContent', function( event ) {
 		if ( event.format === 'raw' && event.content && ! event.selection ) {
@@ -700,14 +709,14 @@ function wpview( editor ) {
 				event.preventDefault();
 			}
 		}
-	});
+	} );
 
 	editor.on( 'keyup', function() {
 		if ( toRemove ) {
 			removeView( toRemove );
 			toRemove = false;
 		}
-	});
+	} );
 
 	editor.on( 'focus', function() {
 		var view;
@@ -741,11 +750,11 @@ function wpview( editor ) {
 		clearInterval( cursorInterval );
 
 		// This runs a lot and is faster than replacing each class separately
-		tinymce.each( views, function ( view ) {
+		tinymce.each( views, function( view ) {
 			if ( view.className ) {
 				view.className = view.className.replace( / ?\bwpview-(?:selection-before|selection-after|cursor-hide)\b/g, '' );
 			}
-		});
+		} );
 
 		if ( focus && view ) {
 			if ( ( className === 'wpview-selection-before' || className === 'wpview-selection-after' ) &&
@@ -782,7 +791,7 @@ function wpview( editor ) {
 				setViewCursor( true, view );
 			}
 		}
-	});
+	} );
 
 	editor.on( 'BeforeExecCommand', function() {
 		var node = editor.selection.getNode(),
@@ -792,7 +801,7 @@ function wpview( editor ) {
 			handleEnter( view, execCommandBefore );
 			execCommandView = view;
 		}
-	});
+	} );
 
 	editor.on( 'ExecCommand', function() {
 		var toSelect, node;
@@ -813,7 +822,7 @@ function wpview( editor ) {
 
 			execCommandView = false;
 		}
-	});
+	} );
 
 	editor.on( 'ResolveName', function( event ) {
 		if ( editor.dom.hasClass( event.target, 'wpview-wrap' ) ) {
@@ -823,7 +832,7 @@ function wpview( editor ) {
 			event.preventDefault();
 			event.stopPropagation();
 		}
-	});
+	} );
 
 	editor.addButton( 'wp_view_edit', {
 		tooltip: i18n.translate( 'Edit', { context: 'verb' } ),

--- a/client/components/tinymce/plugins/wpcom-view/plugin.js
+++ b/client/components/tinymce/plugins/wpcom-view/plugin.js
@@ -803,8 +803,13 @@ function wpview( editor ) {
 		}
 	} );
 
-	editor.on( 'ExecCommand', function() {
+	editor.on( 'ExecCommand', function( args ) {
 		var toSelect, node;
+
+		// Don't steal the focus from `.embed-dialog__url`
+		if ( 'embedDialog' === args.command ) {
+			return;
+		}
 
 		if ( selected ) {
 			toSelect = selected;

--- a/client/components/tinymce/plugins/wpcom-view/views/embed/index.js
+++ b/client/components/tinymce/plugins/wpcom-view/views/embed/index.js
@@ -135,4 +135,8 @@ export default class EmbedViewManager extends EventEmitter {
 	getComponent() {
 		return EmbedView;
 	}
+
+	edit( editor, content ) {
+		editor.execCommand( 'embedDialog', content );
+	}
 }

--- a/client/components/tinymce/style.scss
+++ b/client/components/tinymce/style.scss
@@ -3,6 +3,7 @@
 @import 'plugins/insert-menu/style';
 @import 'plugins/wpcom-help/style';
 @import 'plugins/wpcom-charmap/style';
+@import 'plugins/embed/style.scss';
 @import 'plugins/contact-form/style';
 @import 'plugins/mentions/style';
 @import 'plugins/simple-payments/style';

--- a/client/devdocs/design/index.jsx
+++ b/client/devdocs/design/index.jsx
@@ -37,6 +37,7 @@ import CountedTextareas from 'components/forms/counted-textarea/docs/example';
 import DatePicker from 'components/date-picker/docs/example';
 import DropZones from 'components/drop-zone/docs/example';
 import EllipsisMenu from 'components/ellipsis-menu/docs/example';
+import EmbedDialog from 'components/tinymce/plugins/embed/docs/example';
 import EmojifyExample from 'components/emojify/docs/example';
 import EmptyContent from 'components/empty-content/docs/example';
 import ExternalLink from 'components/external-link/docs/example';
@@ -139,6 +140,7 @@ class DesignAssets extends React.Component {
 					<DatePicker />
 					<DropZones searchKeywords="drag" />
 					<EllipsisMenu />
+					<EmbedDialog />
 					<EmojifyExample />
 					<EmptyContent />
 					<ExternalLink />


### PR DESCRIPTION
This is still a work in progress.

Currently embeds can't be edited after they've been inserted into a post. They can only be deleted and then re-created with the new parameters.

This PR adds a method for editing them. It doesn't add a preview of the new embed, but that will be done in #18171.

See #1729

### Test plan:
* Click on an embed, click the pencil icon to open the dialog, change the URL, click cancel button. Dialog should close, the embed should not be updated. Open dialog again, the original URL should be shown.
* Open the embed and change the URL, click update. The embed should be updated to the new URL.
* Test that `esc` and clicking outside the box will close the modal
* Test that `enter` in the text field will submit the new URL and update the embed
* The input field should be automatically focused when the dialog opens
* Add two embeds to page. Open one, cancel it, then open the other. The correct URLs should be shown for each embed (rather than showing the URL for the first embed when you edit the second embed).