### PR TITLE
Added capabilities information and/or currentUser information to tests dependent on getSite.

### DIFF
--- a/client/state/happychat/test/middleware.js
+++ b/client/state/happychat/test/middleware.js
@@ -50,7 +50,7 @@ describe( 'middleware', () => {
 		let connection;
 		let dispatch, getState;
 		const uninitializedState = deepFreeze( {
-			currentUser: { id: 1 },
+			currentUser: { id: 1, capabilities: {} },
 			happychat: { connectionStatus: 'uninitialized' },
 			users: { items: { 1: {} } },
 			help: { selectedSiteId: 2647731 },
@@ -163,7 +163,7 @@ describe( 'middleware', () => {
 		// without errors. It may be worth pulling each of these helpers out into their
 		// own modules, so that we can stub them and simplify our tests.
 		const uninitializedState = deepFreeze( {
-			currentUser: { id: 1 },
+			currentUser: { id: 1, capabilities: {} },
 			happychat: { connectionStatus: 'uninitialized' },
 			users: { items: { 1: {} } },
 			help: { selectedSiteId: 2647731 },
@@ -271,6 +271,7 @@ describe( 'middleware', () => {
 				},
 				currentUser: {
 					locale: 'en',
+					capabilities: {}
 				},
 				sites: {
 					items: {
@@ -290,6 +291,7 @@ describe( 'middleware', () => {
 			const state = {
 				currentUser: {
 					locale: 'en',
+					capabilities: {}
 				},
 				sites: {
 					items: {

--- a/client/state/happychat/test/selectors.js
+++ b/client/state/happychat/test/selectors.js
@@ -27,6 +27,7 @@ import {
 	getGeoLocation,
 	getGroups,
 } from '../selectors';
+import { userState } from 'state/selectors/test/fixtures/user-state';
 import {
 	HAPPYCHAT_GROUP_WPCOM,
 	HAPPYCHAT_GROUP_JPOP
@@ -289,6 +290,7 @@ describe( 'selectors', () => {
 		it( 'should return default group for no sites', () => {
 			const siteId = 1;
 			const state = {
+				...userState,
 				sites: {
 					items: {}
 				}
@@ -300,6 +302,7 @@ describe( 'selectors', () => {
 		it( 'should return default group for no siteId', () => {
 			const siteId = undefined;
 			const state = {
+				...userState,
 				sites: {
 					items: {
 						1: {}
@@ -313,6 +316,7 @@ describe( 'selectors', () => {
 		it( 'should return JPOP group for jetpack paid sites', () => {
 			const siteId = 1;
 			const state = {
+				...userState,
 				currentUser: {
 					id: 1,
 					capabilities: {
@@ -340,6 +344,7 @@ describe( 'selectors', () => {
 		it( 'should return WPCOM for AT sites group for jetpack site', () => {
 			const siteId = 1;
 			const state = {
+				...userState,
 				currentUser: {
 					id: 1,
 					capabilities: {

--- a/client/state/posts/test/selectors.js
+++ b/client/state/posts/test/selectors.js
@@ -32,6 +32,7 @@ import {
 	getSitePostsByTerm
 } from '../selectors';
 import PostQueryManager from 'lib/query-manager/post';
+import { userState } from 'state/selectors/test/fixtures/user-state';
 
 describe( 'selectors', () => {
 	beforeEach( () => {
@@ -1484,6 +1485,7 @@ describe( 'selectors', () => {
 	describe( 'getPostPreviewUrl()', () => {
 		it( 'should return null if the post is not known', () => {
 			const previewUrl = getPostPreviewUrl( {
+				...userState,
 				posts: {
 					queries: {}
 				},
@@ -1497,6 +1499,7 @@ describe( 'selectors', () => {
 
 		it( 'should return null if the post has no URL', () => {
 			const previewUrl = getPostPreviewUrl( {
+				...userState,
 				posts: {
 					queries: {
 						2916284: new PostQueryManager( {
@@ -1520,6 +1523,7 @@ describe( 'selectors', () => {
 
 		it( 'should return null if the post is trashed', () => {
 			const previewUrl = getPostPreviewUrl( {
+				...userState,
 				posts: {
 					queries: {
 						2916284: new PostQueryManager( {
@@ -1545,6 +1549,7 @@ describe( 'selectors', () => {
 
 		it( 'should prefer the post preview URL if available', () => {
 			const previewUrl = getPostPreviewUrl( {
+				...userState,
 				posts: {
 					queries: {
 						2916284: new PostQueryManager( {
@@ -1571,6 +1576,7 @@ describe( 'selectors', () => {
 
 		it( 'should use post URL if preview URL not available', () => {
 			const previewUrl = getPostPreviewUrl( {
+				...userState,
 				posts: {
 					queries: {
 						2916284: new PostQueryManager( {
@@ -1596,6 +1602,7 @@ describe( 'selectors', () => {
 
 		it( 'should change http to https if mapped domain', () => {
 			const previewUrl = getPostPreviewUrl( {
+				...userState,
 				posts: {
 					queries: {
 						2916284: new PostQueryManager( {
@@ -1633,6 +1640,7 @@ describe( 'selectors', () => {
 
 		it( 'should append preview query argument to non-published posts', () => {
 			const previewUrl = getPostPreviewUrl( {
+				...userState,
 				posts: {
 					queries: {
 						2916284: new PostQueryManager( {

--- a/client/state/selectors/test/are-all-sites-single-user.js
+++ b/client/state/selectors/test/are-all-sites-single-user.js
@@ -7,10 +7,12 @@ import { expect } from 'chai';
  * Internal dependencies
  */
 import { areAllSitesSingleUser } from '../';
+import { userState } from './fixtures/user-state';
 
 describe( 'areAllSitesSingleUser()', () => {
 	it( 'should return false sites haven\'t been fetched yet', () => {
 		const state = {
+			...userState,
 			sites: {
 				items: {}
 			}
@@ -22,6 +24,7 @@ describe( 'areAllSitesSingleUser()', () => {
 
 	it( 'should return false if single_user_site isn\'t true for all sites', () => {
 		const state = {
+			...userState,
 			sites: {
 				items: {
 					2916284: {
@@ -45,6 +48,7 @@ describe( 'areAllSitesSingleUser()', () => {
 
 	it( 'should return true if single_user_site is true for all sites', () => {
 		const state = {
+			...userState,
 			sites: {
 				items: {
 					2916284: {

--- a/client/state/selectors/test/get-public-sites.js
+++ b/client/state/selectors/test/get-public-sites.js
@@ -7,10 +7,12 @@ import { expect } from 'chai';
  * Internal dependencies
  */
 import { getPublicSites } from '../';
+import { userState } from './fixtures/user-state';
 
 describe( 'getPublicSites()', () => {
 	it( 'should return an empty array if no sites in state', () => {
 		const state = {
+			...userState,
 			sites: {
 				items: {}
 			}
@@ -21,6 +23,7 @@ describe( 'getPublicSites()', () => {
 
 	it( 'should return the public sites in state', () => {
 		const state = {
+			...userState,
 			sites: {
 				items: {
 					2916284: {

--- a/client/state/selectors/test/get-reader-follows.js
+++ b/client/state/selectors/test/get-reader-follows.js
@@ -3,6 +3,7 @@
  */
 import { expect } from 'chai';
 import deepFreeze from 'deep-freeze';
+import { userState } from './fixtures/user-state';
 
 /**
  * Internal dependencies
@@ -23,6 +24,7 @@ describe( 'getReaderFollows()', () => {
 		feed_ID: 2,
 	};
 	const state = deepFreeze( {
+		...userState,
 		reader: {
 			follows: {
 				items: {

--- a/client/state/selectors/test/get-sites.js
+++ b/client/state/selectors/test/get-sites.js
@@ -10,7 +10,8 @@ import { getSites } from '../';
 
 const currentUserState = {
 	currentUser: {
-		id: 12345678
+		id: 12345678,
+		capabilities: {},
 	},
 	users: {
 		items: {

--- a/client/state/selectors/test/get-visible-sites.js
+++ b/client/state/selectors/test/get-visible-sites.js
@@ -7,6 +7,7 @@ import { expect } from 'chai';
  * Internal dependencies
  */
 import { getVisibleSites } from '../';
+import { userState } from './fixtures/user-state';
 
 describe( 'getVisibleSites()', () => {
 	it( 'should return an empty array if no sites in state', () => {
@@ -21,6 +22,7 @@ describe( 'getVisibleSites()', () => {
 
 	it( 'should return the visibles sites in state', () => {
 		const state = {
+			...userState,
 			sites: {
 				items: {
 					2916284: {

--- a/client/state/sites/plans/test/selectors.js
+++ b/client/state/sites/plans/test/selectors.js
@@ -23,6 +23,7 @@ import {
 	hasFeature
 } from '../selectors';
 import { PLAN_PREMIUM, PLAN_BUSINESS, FEATURE_UNLIMITED_PREMIUM_THEMES, FEATURE_BUSINESS_ONBOARDING } from 'lib/plans/constants';
+import { userState } from 'state/selectors/test/fixtures/user-state';
 
 describe( 'selectors', () => {
 	describe( '#getPlansBySite()', () => {
@@ -63,6 +64,7 @@ describe( 'selectors', () => {
 		context( 'when no plan data is found for the given siteId', () => {
 			const siteId = 77203074;
 			const state = deepFreeze( {
+				...userState,
 				sites: {
 					plans: {
 						[ siteId ]: {}
@@ -81,6 +83,7 @@ describe( 'selectors', () => {
 				const siteId = 77203074;
 				const plan1 = { currentPlan: true };
 				const state = deepFreeze( {
+					...userState,
 					sites: {
 						plans: {
 							[ siteId ]: {
@@ -105,6 +108,7 @@ describe( 'selectors', () => {
 				const siteId = 77203074;
 				const plan1 = { currentPlan: false };
 				const state = deepFreeze( {
+					...userState,
 					sites: {
 						plans: {
 							[ siteId ]: {

--- a/client/state/sites/test/enhancer.js
+++ b/client/state/sites/test/enhancer.js
@@ -13,6 +13,7 @@ import useFakeDom from 'test/helpers/use-fake-dom';
 import { useSandbox } from 'test/helpers/use-sinon';
 import { SITES_UPDATE, SITE_RECEIVE } from 'state/action-types';
 import sitesSync from '../enhancer';
+import { userState } from 'state/selectors/test/fixtures/user-state';
 
 /**
  * Example site used for testing mocked behavior.
@@ -27,6 +28,7 @@ const EXAMPLE_SITE = {
 describe( 'sitesSync()', () => {
 	let sitesListFactory, Site, store, sitesList;
 	const state = {
+		...userState,
 		sites: { items: {} },
 		siteSettings: { items: {} },
 	};

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -58,6 +58,7 @@ import {
 	hasDefaultSiteTitle,
 	siteSupportsJetpackSettingsUi
 } from '../selectors';
+import { userState } from 'state/selectors/test/fixtures/user-state';
 
 describe( 'selectors', () => {
 	const createStateWithItems = items => deepFreeze( {
@@ -109,6 +110,7 @@ describe( 'selectors', () => {
 
 		it( 'should return null if the site is not known', () => {
 			const site = getSite( {
+				...userState,
 				sites: {
 					items: {}
 				}
@@ -119,6 +121,7 @@ describe( 'selectors', () => {
 
 		it( 'should return a normalized site with computed attributes', () => {
 			const site = getSite( {
+				...userState,
 				sites: {
 					items: {
 						2916284: {
@@ -155,6 +158,7 @@ describe( 'selectors', () => {
 
 		it( 'should return a normalized site with correct slug when sites with collisions are passed in attributes', () => {
 			const site = getSite( {
+				...userState,
 				sites: {
 					items: {
 						2916284: {
@@ -273,6 +277,7 @@ describe( 'selectors', () => {
 	describe( '#isSingleUserSite()', () => {
 		it( 'should return null if the site is not known', () => {
 			const singleUserSite = isSingleUserSite( {
+				...userState,
 				sites: {
 					items: {}
 				}
@@ -283,6 +288,7 @@ describe( 'selectors', () => {
 
 		it( 'it should return true if the site is a single user site', () => {
 			const singleUserSite = isSingleUserSite( {
+				...userState,
 				sites: {
 					items: {
 						77203074: { ID: 77203074, URL: 'https://example.wordpress.com', single_user_site: true }
@@ -298,6 +304,7 @@ describe( 'selectors', () => {
 
 		it( 'it should return false if the site is not a single user site', () => {
 			const singleUserSite = isSingleUserSite( {
+				...userState,
 				sites: {
 					items: {
 						77203074: { ID: 77203074, URL: 'https://example.wordpress.com', single_user_site: false }

--- a/client/state/stats/lists/test/selectors.js
+++ b/client/state/stats/lists/test/selectors.js
@@ -17,6 +17,7 @@ import {
 	getSiteStatsCSVData,
 	hasSiteStatsQueryFailed,
 } from '../selectors';
+import { userState } from 'state/selectors/test/fixtures/user-state';
 
 describe( 'selectors', () => {
 	beforeEach( () => {
@@ -443,6 +444,7 @@ describe( 'selectors', () => {
 	describe( 'getSiteStatsNormalizedData()', () => {
 		it( 'should return null if no matching query results exist', () => {
 			const stats = getSiteStatsNormalizedData( {
+				...userState,
 				stats: {
 					lists: {
 						items: {}
@@ -458,6 +460,7 @@ describe( 'selectors', () => {
 
 		it( 'should return API payload data, if no normalizer exists', () => {
 			const stats = getSiteStatsNormalizedData( {
+				...userState,
 				stats: {
 					lists: {
 						items: {
@@ -483,6 +486,7 @@ describe( 'selectors', () => {
 
 		it( 'should return normalized data, if normalizer exists', () => {
 			const stats = getSiteStatsNormalizedData( {
+				...userState,
 				stats: {
 					lists: {
 						items: {
@@ -520,6 +524,7 @@ describe( 'selectors', () => {
 	describe( 'getSiteStatsCSVData()', () => {
 		it( 'should return an empty array if no matching query results exist', () => {
 			const stats = getSiteStatsCSVData( {
+				...userState,
 				stats: {
 					lists: {
 						items: {}
@@ -535,6 +540,7 @@ describe( 'selectors', () => {
 
 		it( 'should return normalized data, if normalizer exists', () => {
 			const stats = getSiteStatsCSVData( {
+				...userState,
 				stats: {
 					lists: {
 						items: {

--- a/client/state/ui/test/selectors.js
+++ b/client/state/ui/test/selectors.js
@@ -17,6 +17,7 @@ import {
 	isSectionIsomorphic,
 	hasSidebar
 } from '../selectors';
+import { userState } from 'state/selectors/test/fixtures/user-state';
 
 describe( 'selectors', () => {
 	describe( '#getSelectedSite()', () => {
@@ -32,6 +33,7 @@ describe( 'selectors', () => {
 
 		it( 'should return the object for the selected site', () => {
 			const selected = getSelectedSite( {
+				...userState,
 				sites: {
 					items: {
 						2916284: { ID: 2916284, name: 'WordPress.com Example Blog', URL: 'https://example.com' }
@@ -65,6 +67,7 @@ describe( 'selectors', () => {
 	describe( '#getSelectedSiteId()', () => {
 		it( 'should return null if no site is selected', () => {
 			const selected = getSelectedSiteId( {
+				...userState,
 				ui: {
 					selectedSiteId: null
 				}


### PR DESCRIPTION
With the changes of getSite selector to use getSiteComputedAttributes selector, now getSite selector is dependent on capabilities information from user-state. So that dependency needs to be taken into consideration in the state that tests of selectors use.

The changes consist in adding user state from 'state/selectors/test/fixtures/user-state' to state or adding and empty capabilities to the user state when it already existed.

This PR was extracted from https://github.com/Automattic/wp-calypso/pull/16211 to make things easier to review.