### PR TITLE
Add 2FA to social accounts

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -64,7 +64,7 @@ class Login extends Component {
 		}
 	};
 
-	handleValidUsernamePassword = () => {
+	handleValidLogin = () => {
 		if ( this.props.twoFactorEnabled ) {
 			page( login( {
 				isNative: true,
@@ -198,12 +198,12 @@ class Login extends Component {
 
 		if ( socialConnect ) {
 			return (
-				<SocialConnectPrompt onSuccess={ this.rebootAfterLogin } />
+				<SocialConnectPrompt onSuccess={ this.handleValidLogin } />
 			);
 		}
 
 		return (
-			<LoginForm onSuccess={ this.handleValidUsernamePassword } privateSite={ privateSite } />
+			<LoginForm onSuccess={ this.handleValidLogin } privateSite={ privateSite } />
 		);
 	}
 

--- a/client/state/login/actions.js
+++ b/client/state/login/actions.js
@@ -241,7 +241,19 @@ export const loginSocialUser = ( socialInfo, redirectTo ) => dispatch => {
 			dispatch( {
 				type: SOCIAL_LOGIN_REQUEST_SUCCESS,
 				redirectTo: get( response, 'body.data.redirect_to' ),
+				data: get( response, 'body.data' )
 			} );
+
+			if ( get( response, 'body.data.two_step_notification_sent' ) === 'sms' ) {
+				dispatch( {
+					type: TWO_FACTOR_AUTHENTICATION_SEND_SMS_CODE_REQUEST_SUCCESS,
+					notice: {
+						message: getSMSMessageFromResponse( response ),
+						status: 'is-success'
+					},
+					twoStepNonce: get( response, 'body.data.two_step_nonce_sms' )
+				} );
+			}
 		} )
 		.catch( ( httpError ) => {
 			const error = getErrorFromHTTPError( httpError );

--- a/client/state/login/reducer.js
+++ b/client/state/login/reducer.js
@@ -138,6 +138,19 @@ export const twoFactorAuth = createReducer( null, {
 		return null;
 	},
 	[ LOGIN_REQUEST_FAILURE ]: () => null,
+	[ SOCIAL_LOGIN_REQUEST ]: () => null,
+	[ SOCIAL_LOGIN_REQUEST_SUCCESS ]: ( state, { data } ) => {
+		if ( data ) {
+			const rest = omit( data, 'redirect_to' );
+
+			if ( ! isEmpty( rest ) ) {
+				return rest;
+			}
+		}
+
+		return null;
+	},
+	[ SOCIAL_LOGIN_REQUEST_FAILURE ]: () => null,
 	[ TWO_FACTOR_AUTHENTICATION_SEND_SMS_CODE_REQUEST_FAILURE ]: ( state, { twoStepNonce } ) =>
 		updateTwoStepNonce( state, { twoStepNonce, nonceType: 'sms' } ),
 	[ TWO_FACTOR_AUTHENTICATION_SEND_SMS_CODE_REQUEST_SUCCESS ]: ( state, { twoStepNonce } ) =>

--- a/client/state/login/test/reducer.js
+++ b/client/state/login/test/reducer.js
@@ -490,6 +490,14 @@ describe( 'reducer', () => {
 			expect( state ).to.be.null;
 		} );
 
+		it( 'should set twoFactorAuth to null value if a social request is initiated', () => {
+			const state = twoFactorAuth( undefined, {
+				type: SOCIAL_LOGIN_REQUEST,
+			} );
+
+			expect( state ).to.be.null;
+		} );
+
 		it( 'should set twoFactorAuth to the response value if a request was successful', () => {
 			const data = {
 				result: true,
@@ -508,6 +516,29 @@ describe( 'reducer', () => {
 		it( 'should set twoFactorAuth to null value if a request is unsuccessful', () => {
 			const state = twoFactorAuth( null, {
 				type: LOGIN_REQUEST_FAILURE,
+			} );
+
+			expect( state ).to.be.null;
+		} );
+
+		it( 'should set twoFactorAuth to the response value if a social request was successful', () => {
+			const data = {
+				result: true,
+				two_step_id: 12345678,
+				two_step_nonce: 'abcdefgh1234',
+			};
+			const state = twoFactorAuth( null, {
+				type: SOCIAL_LOGIN_REQUEST_SUCCESS,
+				data,
+				rememberMe: true
+			} );
+
+			expect( state ).to.eql( { ...data } );
+		} );
+
+		it( 'should set twoFactorAuth to null value if a social request is unsuccessful', () => {
+			const state = twoFactorAuth( null, {
+				type: SOCIAL_LOGIN_REQUEST_FAILURE,
 			} );
 
 			expect( state ).to.be.null;


### PR DESCRIPTION
This pull request addresses #16544 by prompting for the appropriate 2FA response on social accounts that have 2FA enabled on the WPCOM side:

#### Testing instructions

Pre-testing: ensure you have WPCOM account linked to a social service, with 2FA enabled.

1. Apply D6835 to your sandbox, and sandbox wordpress.com
2. Run `git checkout add/16544-2fa-for-social-accounts` and start your server, or open a [live branch](https://calypso.live/log-in?branch=add/16544-2fa-for-social-accounts)
3. Open the [`Log In` page](http://calypso.localhost:3000/)
4. Click the "Continue with Google" button, and login to the linked Google account
5. Confirm that you're shown the appropriate 2FA prompt for your account (SMS, push, authenticator app)
6. In a different tab, confirm that visiting a wordpress.com or Calypso URL does _not_ show you logged in
7. Enter your 2FA code / approve 2FA push notification
8. Observe that you're logged in correctly

#### Reviews

- [ ] Code
- [x] Product
- [x] Tests