### PR TITLE
Color Schemes: Add new form components as basis for color scheme switcher

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -120,6 +120,7 @@
 @import 'components/forms/form-label/style';
 @import 'components/forms/form-legend/style';
 @import 'components/forms/form-password-input/style';
+@import 'components/forms/form-radio-with-thumbnail/style';
 @import 'components/forms/form-range/style';
 @import 'components/forms/form-section-heading/style';
 @import 'components/forms/form-select/style';

--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -121,6 +121,7 @@
 @import 'components/forms/form-legend/style';
 @import 'components/forms/form-password-input/style';
 @import 'components/forms/form-radio-with-thumbnail/style';
+@import 'components/forms/form-radios-bar/style';
 @import 'components/forms/form-range/style';
 @import 'components/forms/form-section-heading/style';
 @import 'components/forms/form-select/style';

--- a/client/components/forms/docs/example.jsx
+++ b/client/components/forms/docs/example.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -20,6 +21,8 @@ import FormLegend from 'components/forms/form-legend';
 import FormPasswordInput from 'components/forms/form-password-input';
 import FormPhoneInput from 'components/forms/form-phone-input';
 import FormRadio from 'components/forms/form-radio';
+import FormRadioWithThumbnail from 'components/forms/form-radio-with-thumbnail';
+import FormRadiosBarExample from 'components/forms/form-radios-bar/docs/example';
 import FormSectionHeading from 'components/forms/form-section-heading';
 import FormSelect from 'components/forms/form-select';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
@@ -237,6 +240,33 @@ class FormFields extends React.PureComponent {
 							/>
 							<span>Second radio</span>
 						</FormLabel>
+					</FormFieldset>
+
+					<FormFieldset>
+						<FormLegend>Form Radio With Thumbnail</FormLegend>
+						<div>
+							<FormRadioWithThumbnail
+								label="First radio"
+								thumbnail={ { cssClass: 'some-class' } }
+								value="first"
+								checked={ 'first' === this.state.checkedRadio }
+								onChange={ this.handleRadioChange }
+							/>
+						</div>
+					</FormFieldset>
+
+					<FormFieldset>
+						<FormLegend>Form Radios Bar</FormLegend>
+						<FormRadiosBarExample
+							isThumbnail={ false }
+							checked={ this.state.checkedRadio }
+							onChange={ this.handleRadioChange }
+						/>
+						<FormRadiosBarExample
+							isThumbnail={ true }
+							checked={ this.state.checkedRadio }
+							onChange={ this.handleRadioChange }
+						/>
 					</FormFieldset>
 
 					<FormFieldset>

--- a/client/components/forms/form-radio-with-thumbnail/index.jsx
+++ b/client/components/forms/form-radio-with-thumbnail/index.jsx
@@ -1,0 +1,45 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import React from 'react';
+import PropTypes from 'prop-types';
+import classnames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+
+import FormRadio from 'components/forms/form-radio';
+import FormLabel from 'components/forms/form-label';
+import cssSafeUrl from 'lib/css-safe-url';
+
+const FormRadioWithThumbnail = ( { label, thumbnail, ...otherProps } ) => {
+	const { cssClass, cssColor, imageUrl } = thumbnail;
+	const styles = {
+		backgroundColor: cssColor ? cssColor : '',
+		backgroundImage: imageUrl ? 'url(' + cssSafeUrl( imageUrl ) + ')' : '',
+	};
+
+	return (
+		<div className="form-radio-with-thumbnail">
+			<FormLabel>
+				<div
+					className={ classnames( 'form-radio-with-thumbnail__thumbnail', cssClass ) }
+					style={ styles }
+				/>
+				<FormRadio { ...otherProps } />
+				<span>
+					{ label }
+				</span>
+			</FormLabel>
+		</div>
+	);
+};
+
+FormRadioWithThumbnail.propTypes = {
+	label: PropTypes.string,
+	thumbnail: PropTypes.object,
+};
+
+export default FormRadioWithThumbnail;

--- a/client/components/forms/form-radio-with-thumbnail/index.jsx
+++ b/client/components/forms/form-radio-with-thumbnail/index.jsx
@@ -9,7 +9,6 @@ import classnames from 'classnames';
 /**
  * Internal dependencies
  */
-
 import FormRadio from 'components/forms/form-radio';
 import FormLabel from 'components/forms/form-label';
 import cssSafeUrl from 'lib/css-safe-url';
@@ -17,7 +16,7 @@ import cssSafeUrl from 'lib/css-safe-url';
 const FormRadioWithThumbnail = ( { label, thumbnail, ...otherProps } ) => {
 	const { cssClass, cssColor, imageUrl } = thumbnail;
 	const styles = {
-		backgroundColor: cssColor ? cssColor : '',
+		backgroundColor: cssColor,
 		backgroundImage: imageUrl ? 'url(' + cssSafeUrl( imageUrl ) + ')' : '',
 	};
 
@@ -39,7 +38,7 @@ const FormRadioWithThumbnail = ( { label, thumbnail, ...otherProps } ) => {
 
 FormRadioWithThumbnail.propTypes = {
 	label: PropTypes.string,
-	thumbnail: PropTypes.object,
+	thumbnail: PropTypes.object.isRequired,
 };
 
 export default FormRadioWithThumbnail;

--- a/client/components/forms/form-radio-with-thumbnail/index.jsx
+++ b/client/components/forms/form-radio-with-thumbnail/index.jsx
@@ -11,22 +11,19 @@ import classnames from 'classnames';
  */
 import FormRadio from 'components/forms/form-radio';
 import FormLabel from 'components/forms/form-label';
-import cssSafeUrl from 'lib/css-safe-url';
 
 const FormRadioWithThumbnail = ( { label, thumbnail, ...otherProps } ) => {
 	const { cssClass, cssColor, imageUrl } = thumbnail;
-	const styles = {
-		backgroundColor: cssColor,
-		backgroundImage: imageUrl ? 'url(' + cssSafeUrl( imageUrl ) + ')' : '',
-	};
 
 	return (
 		<div className="form-radio-with-thumbnail">
 			<FormLabel>
 				<div
 					className={ classnames( 'form-radio-with-thumbnail__thumbnail', cssClass ) }
-					style={ styles }
-				/>
+					style={ { backgroundColor: cssColor } }
+				>
+					{ imageUrl && <img src={ imageUrl } alt={ label } /> }
+				</div>
 				<FormRadio { ...otherProps } />
 				<span>
 					{ label }

--- a/client/components/forms/form-radio-with-thumbnail/style.scss
+++ b/client/components/forms/form-radio-with-thumbnail/style.scss
@@ -7,6 +7,11 @@
 	background-size: cover;
 	box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ),
 		0 1px 2px lighten( $gray, 30% );
+	transition: all 100ms ease-in-out;
+
+	&:hover {
+		box-shadow: 0 0 0 1px $gray, 0 2px 4px lighten( $gray, 20 );
+	}
 }
 
 .form-radio-with-thumbnail .form-label {

--- a/client/components/forms/form-radio-with-thumbnail/style.scss
+++ b/client/components/forms/form-radio-with-thumbnail/style.scss
@@ -1,0 +1,12 @@
+
+.form-radio-with-thumbnail__thumbnail {
+	width: 120px;
+	height: 90px;
+	margin: 20px 0;
+	background-color: $gray;
+	background-size: cover;
+}
+
+.form-radio-with-thumbnail .form-label {
+	display: inline-block;
+}

--- a/client/components/forms/form-radio-with-thumbnail/style.scss
+++ b/client/components/forms/form-radio-with-thumbnail/style.scss
@@ -4,6 +4,7 @@
 	height: 90px;
 	margin: 2px 0 8px;
 	background-color: $white;
+	background-position: 50% 0;
 	background-size: cover;
 	box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ),
 		0 1px 2px lighten( $gray, 30% );

--- a/client/components/forms/form-radio-with-thumbnail/style.scss
+++ b/client/components/forms/form-radio-with-thumbnail/style.scss
@@ -2,9 +2,11 @@
 .form-radio-with-thumbnail__thumbnail {
 	width: 120px;
 	height: 90px;
-	margin: 20px 0;
-	background-color: $gray;
+	margin: 2px 0 8px;
+	background-color: $white;
 	background-size: cover;
+	box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ),
+		0 1px 2px lighten( $gray, 30% );
 }
 
 .form-radio-with-thumbnail .form-label {

--- a/client/components/forms/form-radio-with-thumbnail/style.scss
+++ b/client/components/forms/form-radio-with-thumbnail/style.scss
@@ -9,6 +9,7 @@
 	box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ),
 		0 1px 2px lighten( $gray, 30% );
 	transition: all 100ms ease-in-out;
+	overflow: hidden;
 
 	&:hover {
 		box-shadow: 0 0 0 1px $gray, 0 2px 4px lighten( $gray, 20 );

--- a/client/components/forms/form-radio-with-thumbnail/style.scss
+++ b/client/components/forms/form-radio-with-thumbnail/style.scss
@@ -11,4 +11,5 @@
 
 .form-radio-with-thumbnail .form-label {
 	display: inline-block;
+	cursor: pointer;
 }

--- a/client/components/forms/form-radios-bar/docs/example.jsx
+++ b/client/components/forms/form-radios-bar/docs/example.jsx
@@ -13,7 +13,7 @@ import { radios, radiosWithThumbnails } from 'components/forms/form-radios-bar/d
 const FormRadiosBarExample = ( { isThumbnail, checked, onChange } ) => {
 	return (
 		<FormRadiosBar
-			isThumbnail={ isThumbnail ? true : false }
+			isThumbnail={ isThumbnail }
 			checked={ checked }
 			onChange={ onChange }
 			items={ isThumbnail ? radiosWithThumbnails : radios }

--- a/client/components/forms/form-radios-bar/docs/example.jsx
+++ b/client/components/forms/form-radios-bar/docs/example.jsx
@@ -1,0 +1,26 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import FormRadiosBar from 'components/forms/form-radios-bar';
+import { radios, radiosWithThumbnails } from 'components/forms/form-radios-bar/docs/fixtures';
+
+const FormRadiosBarExample = ( { isThumbnail, checked, onChange } ) => {
+	return (
+		<FormRadiosBar
+			isThumbnail={ isThumbnail ? true : false }
+			checked={ checked }
+			onChange={ onChange }
+			items={ isThumbnail ? radiosWithThumbnails : radios }
+		/>
+	);
+};
+
+FormRadiosBarExample.displayName = 'FormRadiosBar';
+
+export default FormRadiosBarExample;

--- a/client/components/forms/form-radios-bar/docs/fixtures.js
+++ b/client/components/forms/form-radios-bar/docs/fixtures.js
@@ -1,0 +1,39 @@
+/** @format */
+export const radios = [
+	{
+		label: 'First Radio',
+		value: 'first',
+	},
+	{
+		label: 'Second Radio',
+		value: 'second',
+	},
+	{
+		label: 'Third Radio',
+		value: 'third',
+	},
+];
+
+export const radiosWithThumbnails = [
+	{
+		label: 'First Radio',
+		value: 'first',
+		thumbnail: {
+			cssClass: 'some-css-class',
+		},
+	},
+	{
+		label: 'Second Radio',
+		value: 'second',
+		thumbnail: {
+			imageUrl: '/calypso/images/illustrations/illustration-empty-results.svg',
+		},
+	},
+	{
+		label: 'Third Radio',
+		value: 'third',
+		thumbnail: {
+			cssColor: '#0087be',
+		},
+	},
+];

--- a/client/components/forms/form-radios-bar/index.jsx
+++ b/client/components/forms/form-radios-bar/index.jsx
@@ -1,0 +1,45 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import React from 'react';
+import PropTypes from 'prop-types';
+import classnames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+
+import FormLabel from 'components/forms/form-label';
+import FormRadio from 'components/forms/form-radio';
+import FormRadioWithThumbnail from 'components/forms/form-radio-with-thumbnail';
+
+const FormRadiosBar = ( { isThumbnail, checked, onChange, items } ) => {
+	const addProps = ( Component, item, key ) =>
+		<Component key={ key } checked={ checked === item.value } onChange={ onChange } { ...item } />;
+
+	return (
+		<div className={ classnames( 'form-radios-bar', { 'is-thumbnail': isThumbnail } ) }>
+			{ items.map(
+				( item, i ) =>
+					isThumbnail
+						? addProps( FormRadioWithThumbnail, item, i )
+						: <FormLabel key={ i }>
+								{ addProps( FormRadio, item, i ) }
+								<span>
+									{ item.label }
+								</span>
+							</FormLabel>
+			) }
+		</div>
+	);
+};
+
+FormRadiosBar.propTypes = {
+	isThumbnail: PropTypes.bool,
+	checked: PropTypes.string,
+	onChange: PropTypes.func,
+	items: PropTypes.array,
+};
+
+export default FormRadiosBar;

--- a/client/components/forms/form-radios-bar/index.jsx
+++ b/client/components/forms/form-radios-bar/index.jsx
@@ -9,23 +9,24 @@ import classnames from 'classnames';
 /**
  * Internal dependencies
  */
-
 import FormLabel from 'components/forms/form-label';
 import FormRadio from 'components/forms/form-radio';
 import FormRadioWithThumbnail from 'components/forms/form-radio-with-thumbnail';
 
 const FormRadiosBar = ( { isThumbnail, checked, onChange, items } ) => {
-	const addProps = ( Component, item, key ) =>
-		<Component key={ key } checked={ checked === item.value } onChange={ onChange } { ...item } />;
-
 	return (
 		<div className={ classnames( 'form-radios-bar', { 'is-thumbnail': isThumbnail } ) }>
 			{ items.map(
 				( item, i ) =>
 					isThumbnail
-						? addProps( FormRadioWithThumbnail, item, i )
-						: <FormLabel key={ i }>
-								{ addProps( FormRadio, item, i ) }
+						? <FormRadioWithThumbnail
+								key={ item.value + i }
+								checked={ checked === item.value }
+								onChange={ onChange }
+								{ ...item }
+							/>
+						: <FormLabel key={ item.value + i }>
+								<FormRadio checked={ checked === item.value } onChange={ onChange } { ...item } />
 								<span>
 									{ item.label }
 								</span>
@@ -39,7 +40,7 @@ FormRadiosBar.propTypes = {
 	isThumbnail: PropTypes.bool,
 	checked: PropTypes.string,
 	onChange: PropTypes.func,
-	items: PropTypes.array,
+	items: PropTypes.array.isRequired,
 };
 
 export default FormRadiosBar;

--- a/client/components/forms/form-radios-bar/style.scss
+++ b/client/components/forms/form-radios-bar/style.scss
@@ -1,0 +1,14 @@
+.form-radios-bar {
+	display: block;
+
+	&.is-thumbnail {
+		display: flex;
+		flex-wrap: wrap;
+	}
+}
+
+.form-radios-bar .form-radio-with-thumbnail {
+	flex-grow: 1;
+	min-width: 136px;
+	max-width: 150px;
+}

--- a/client/components/forms/form-radios-bar/style.scss
+++ b/client/components/forms/form-radios-bar/style.scss
@@ -11,4 +11,5 @@
 	flex-grow: 1;
 	min-width: 136px;
 	max-width: 150px;
+	margin-bottom: 10px;
 }


### PR DESCRIPTION
This PR is part of a series of PRs aiming to provide support for Color Schemes in Calypso.
This PR focuses on adding the base components for the color scheme switcher.

<img width="946" alt="screen shot 2017-08-14 at 23 51 47" src="https://user-images.githubusercontent.com/1562646/29293501-abb7ec90-814b-11e7-9afb-663e82e193ee.png">

### Notable additions in this PR:
- The `<FormRadioWithThumbnail>` component adds a visual cue to radio buttons. The component takes either a CSS class, CSS color or an image URL and renders a thumbnail accordingly.
- The `<FormRadiosBar>` component takes an array of options and renders them as radio components. The bar supports both normal form radios, as well as form radios with thumbnails.
- Both components are added to the `UI Components` overview page for future reference.

### How to test

Visit https://calypso.live/devdocs/design/form-fields?branch=add/color-schemes/form-components or test locally.
Navigate to the `UI Components` overview page and proceed to the FormFields section.

### Suggestions as to what to test
- Are the components reusable enough?
- Do all thumbnail variations (CSS class, CSS color and image URL) work as expected?
- Is the current responsive behavior sufficient?

### Note

This PR needs to be merged prior to PR https://github.com/Automattic/wp-calypso/pull/17200 and PR https://github.com/Automattic/wp-calypso/pull/17259.

For a more detailed description of the feature, the chosen approach and its advantages feel free to check out my post on the subject: p4TIVU-75d-p2 (internal reference).