### PR TITLE
Simple payments: add special tooltip for inserter menu

### DIFF
--- a/client/components/tinymce/plugins/insert-menu/plugin.jsx
+++ b/client/components/tinymce/plugins/insert-menu/plugin.jsx
@@ -1,3 +1,4 @@
+/** @format */
 import React from 'react';
 import ReactDOM from 'react-dom';
 import tinymce from 'tinymce/tinymce';
@@ -15,7 +16,7 @@ const initialize = editor => {
 			cmd: item.cmd,
 			onPostRender() {
 				this.innerHtml( renderToString( item.item ) );
-			}
+			},
 		} )
 	);
 
@@ -26,11 +27,48 @@ const initialize = editor => {
 		cmd: menuItems[ 0 ].cmd,
 		menu: menuItems.map( ( { name } ) => editor.menuItems[ name ] ),
 		onPostRender() {
-			ReactDOM.render(
-				<Gridicon icon="add-outline" />,
-				this.$el[ 0 ].children[ 0 ]
-			);
-		}
+			ReactDOM.render( <Gridicon icon="add-outline" />, this.$el[ 0 ].children[ 0 ] );
+
+			// Listen to `mouseenter` events on the (+) part of the Inserter menu to show
+			// the "Insert content" tooltip.
+			const insertContentElm = this.$el[ 0 ].children[ 0 ];
+
+			insertContentElm.addEventListener( 'mouseenter', () => {
+				// We need to select the tooltip during the `mouseenter` event and not outside.
+				// Otherwise, Tinymce renders an empty tooltip somewhere in the editor.
+				const btnTooltip = this.tooltip();
+
+				btnTooltip.text( i18n.translate( 'Insert content' ) );
+
+				btnTooltip.moveBy( -10, 0 );
+			} );
+
+			insertContentElm.addEventListener( 'mouseleave', () => {
+				const btnTooltip = this.tooltip();
+
+				btnTooltip.moveBy( 10, 0 );
+			} );
+
+			// Listen to `mouseenter` events on the (v) part of the Inserter menu to show
+			// the "Insert special" tooltip.
+			const insertSpecialElm = this.$el[ 0 ].children[ 1 ];
+
+			insertSpecialElm.addEventListener( 'mouseenter', () => {
+				// We need to select the tooltip during the `mouseenter` event and not outside.
+				// Otherwise, Tinymce renders an empty tooltip somewhere in the editor.
+				const btnTooltip = this.tooltip();
+
+				btnTooltip.text( i18n.translate( 'Insert special' ) );
+
+				btnTooltip.moveBy( 24, 0 );
+			} );
+
+			insertSpecialElm.addEventListener( 'mouseleave', () => {
+				const btnTooltip = this.tooltip();
+
+				btnTooltip.moveBy( -24, 0 );
+			} );
+		},
 	} );
 };
 


### PR DESCRIPTION
> Right now there is a single tooltip across the controls for adding an image and for adding other items, like google docs, contact form, and payment button. The idea is to highlight the difference by creating separate tooltips. More details and context here: p58i-6nm-p2#comment-36478

When hovering over the (+) button, show "Insert content" tooltip:
![selection_081](https://user-images.githubusercontent.com/4988512/29262637-be14d3b0-80d5-11e7-951c-bd471160a2b9.png)

 When hovering over (v) button, show "Insert special" tooltip:

![selection_082](https://user-images.githubusercontent.com/4988512/29262643-c3a6a0ce-80d5-11e7-8e35-735ee1a67ce0.png)

## Testing

Navigate to post/page editor. Hover over the (+) and (v) buttons. Are you getting the expected tooltips? No errors? No strange behavior?

Note: Tinymce's `SplitButton` doesn't provide an API to set different tooltips based on what you hover. That's why I had to make this work manually and the code is not the nicest. If you have any ideas on how to make it better, feel free to share.

/cc @Automattic/stark
