### PR TITLE
Media: create transientId before uploading process

### DIFF
--- a/client/post-editor/media-modal/index.jsx
+++ b/client/post-editor/media-modal/index.jsx
@@ -17,6 +17,7 @@ import {
 	isEmpty,
 	identity,
 	includes,
+	uniqueId,
 } from 'lodash';
 
 /**
@@ -145,16 +146,18 @@ export class EditorMediaModal extends Component {
 			return;
 		}
 
-		const value = mediaLibrarySelectedItems.length
+		if ( mediaLibrarySelectedItems.length && this.state.source !== '' ) {
+			const itemsWithTransientId = mediaLibrarySelectedItems.map(
+				( item ) => Object.assign( {}, item, { ID: uniqueId( 'media-' ) } )
+			);
+			this.copyExternal( itemsWithTransientId, this.state.source );
+		} else {
+			const value = mediaLibrarySelectedItems.length
 			? {
 				type: ModalViews.GALLERY === view ? 'gallery' : 'media',
 				items: mediaLibrarySelectedItems,
 				settings: this.state.gallerySettings
 			} : undefined;
-
-		if ( value && this.state.source !== '' ) {
-			this.copyExternal( mediaLibrarySelectedItems, this.state.source );
-		} else {
 			this.props.onClose( value );
 		}
 	};

--- a/client/post-editor/media-modal/test/index.jsx
+++ b/client/post-editor/media-modal/test/index.jsx
@@ -258,8 +258,14 @@ describe( 'EditorMediaModal', function() {
 			tree.copyExternal = onClose;
 			tree.confirmSelection();
 
+			// EditorMediaModal will generate transient ID for the media selected
+			// by using uniqueId, which increments its value within the same session.
+			const transientItems = [
+				Object.assign( {}, DUMMY_MEDIA[ 0 ], { ID: 'media-1' } ),
+				Object.assign( {}, DUMMY_MEDIA[ 1 ], { ID: 'media-2' } )
+			];
 			process.nextTick( () => {
-				expect( onClose ).to.have.been.calledWith( DUMMY_MEDIA, 'external' );
+				expect( onClose ).to.have.been.calledWith( transientItems, 'external' );
 				done();
 			} );
 		} );


### PR DESCRIPTION
Part of fixing https://github.com/Automattic/wp-calypso/pull/16919 
Replaces https://github.com/Automattic/wp-calypso/pull/16986

If a file.ID exists, the upload method won't substitute it by a transient ID - instead, the transient media will keep their ID. This is a problem with external sources. When operating with the ID we make some assumptions. The [updateMedia](https://github.com/Automattic/wp-calypso/blob/master/client/components/tinymce/plugins/media/plugin.jsx#L147) method in the TinyMCE media plugin [deserializes](https://github.com/Automattic/wp-calypso/blob/master/client/lib/media-serialization/strategies/dom.js#L46) the `<img >` tag into an object to query the MediaStore.

It takes the ID from the class wp-image-* which will be:

1) wp-image-567 for a permanent media
2) wp-image-media-123 for a transient without file.ID
2) wp-image-XXXXXXXXX for a transient with file.ID

In 3, we can run into situations where the ID is something like '6451493182293668834', so we'll end up with a class such as wp-image-6451493182293668834.

The deserialization will parse it as a number and will convert it to:

    parseInt('6451493182293668834', 10) = 6451493182293669000

Due to the wrong ID, updateMedia won't find the media in the library.

## Testing 

Run 

    npm run test-client client/post-editor/media-modal/test/index.jsx

Manually:

* Check that current behavior for stored images doesn't change:
    * Open the regular media modal.
    * Add a picture that is already stored in the media library and insert it in the editor.
    * Inspect the <img /> tag added to the post, and check that it has a class named `wp-image-ID`.
    * The class should never change - funny to test! I'd suggest just waiting a bit.
* Check that current behavior for uploading local images doesn't change:
    * Open the regular media modal.
    * Add a picture from a local computer (either by drag&drop or using the "add new" button) and (quickly!) insert the image in the editor, before the upload finishes.
    * Inspect the <img /> tag added to the post, and check that it has a class named `wp-image-media-ID`.
    * Wait a bit until the upload finishes, and check that the class is changed to `wp-image-ID`.
* Check that behavior for google pictures works like this:
    * Open the google media modal.
    * Click "copy to media library" button and (quickly!) insert the image in the editor before the upload finishes.
    * Inspect the <img /> tag added to the post, and check that it has a class named `wp-image-media-ID`. 
    * At this point, unlike the local images, the class won't change when the upload finishes. This is something we address in https://github.com/Automattic/wp-calypso/pull/17007 that should land before this one.