### PR TITLE
Simple Payments: Make Upgrade Nudge full width for small screens

### DIFF
--- a/client/components/tinymce/plugins/simple-payments/style.scss
+++ b/client/components/tinymce/plugins/simple-payments/style.scss
@@ -73,7 +73,10 @@
 		flex-shrink: 0;
 		margin: 0;
 		text-align: left;
-		width: 70%;
+
+		@include breakpoint( ">480px" ) {
+			width: 70%;
+		}
 	}
 }
 


### PR DESCRIPTION
A minor adjustment to make the upgrade nudge full with for small screens.

Before:
<img width="375" alt="screen shot 2017-08-14 at 11 26 45" src="https://user-images.githubusercontent.com/908665/29268157-8b823722-80e3-11e7-92e2-034f11afd270.png">

After:
<img width="376" alt="screen shot 2017-08-14 at 11 27 04" src="https://user-images.githubusercontent.com/908665/29268163-938d440c-80e3-11e7-81df-ca0d98fe4769.png">

