### PR TITLE
Refactor oauth2 client state and prefill it with initial values

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -19,8 +19,8 @@ import {
 	isTwoFactorEnabled,
 	getLinkingSocialUser,
 	getLinkingSocialService,
-	getOAuth2ClientData,
 } from 'state/login/selectors';
+import { getOAuth2ClientData } from 'state/login/oauth2/selectors';
 import { recordTracksEvent } from 'state/analytics/actions';
 import VerificationCodeForm from './two-factor-authentication/verification-code-form';
 import WaitingTwoFactorNotificationApproval from './two-factor-authentication/waiting-notification-approval';

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -12,7 +12,7 @@ import { connect } from 'react-redux';
 import MasterbarLoggedOut from 'layout/masterbar/logged-out';
 import { getSection } from 'state/ui/selectors';
 import OauthClientLayout from 'layout/oauth-client';
-import { showOAuth2Layout } from 'state/login/selectors';
+import { showOAuth2Layout } from 'state/login/oauth2/selectors';
 
 const LayoutLoggedOut = ( {
 	primary,

--- a/client/layout/oauth-client.jsx
+++ b/client/layout/oauth-client.jsx
@@ -10,7 +10,7 @@ import { connect } from 'react-redux';
  * Internal dependencies
  */
 import { getSection } from 'state/ui/selectors';
-import { getOAuth2ClientData } from 'state/login/selectors';
+import { getOAuth2ClientData } from 'state/login/oauth2/selectors';
 
 const OauthClientLayout = ( {
 	primary,
@@ -18,50 +18,14 @@ const OauthClientLayout = ( {
 	section,
 	oauth2ClientData,
 } ) => {
-	const clients = {
-		930: {
-			name: 'vaultpress',
-			img_url: 'https://vaultpress.com/images/vaultpress-wpcc-nav-2x.png',
-		},
-		973: {
-			name: 'akismet',
-			img_url: 'https://akismet.com/img/akismet-wpcc-logo-2x.png',
-		},
-		978: {
-			name: 'polldaddy',
-			img_url: 'https://polldaddy.com/images/polldaddy-wpcc-logo-2x.png',
-		},
-		1854: {
-			name: 'gravatar',
-			img_url: 'https://gravatar.com/images/grav-logo-2x.png',
-		},
-		50019: {
-			name: 'woo',
-			img_url: 'https://woocommerce.com/wp-content/themes/woomattic/images/logo-woocommerce@2x.png',
-		},
-		50915: {
-			name: 'woo',
-			img_url: 'https://woocommerce.com/wp-content/themes/woomattic/images/logo-woocommerce@2x.png',
-		},
-		50916: {
-			name: 'woo',
-			img_url: 'https://woocommerce.com/wp-content/themes/woomattic/images/logo-woocommerce@2x.png',
-		},
-	};
-
-	let client = false;
-	if ( oauth2ClientData && oauth2ClientData.id in clients ) {
-		client = clients[ oauth2ClientData.id ];
-	}
-
 	const classes = classNames( 'layout', {
 		[ 'is-group-' + section.group ]: !! section,
 		[ 'is-section-' + section.name ]: !! section,
 		'focus-content': true,
 		'has-no-sidebar': true, // Logged-out never has a sidebar
 		'wp-singletree-layout': !! primary,
-		dops: !! client,
-		[ client.name ]: !! client,
+		dops: !! oauth2ClientData,
+		[ oauth2ClientData.name ]: !! oauth2ClientData,
 	} );
 
 	return (

--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -9,7 +9,7 @@ import React from 'react';
 import WPLogin from './wp-login';
 import MagicLogin from './magic-login';
 import HandleEmailedLinkForm from './magic-login/handle-emailed-link-form';
-import { fetchOAuth2ClientData } from 'state/login/actions';
+import { fetchOAuth2ClientData } from 'state/login/oauth2/actions';
 
 export default {
 	login( context, next ) {

--- a/client/login/wp-login/login-links.jsx
+++ b/client/login/wp-login/login-links.jsx
@@ -18,7 +18,7 @@ import { getCurrentUserId } from 'state/current-user/selectors';
 import { recordPageView, recordTracksEvent } from 'state/analytics/actions';
 import { resetMagicLoginRequestForm } from 'state/login/magic-login/actions';
 import { login } from 'lib/paths';
-import { getOAuth2ClientData } from 'state/login/selectors';
+import { getOAuth2ClientData } from 'state/login/oauth2/selectors';
 
 export class LoginLinks extends React.Component {
 	static propTypes = {

--- a/client/state/login/actions.js
+++ b/client/state/login/actions.js
@@ -17,9 +17,6 @@ import {
 	LOGOUT_REQUEST,
 	LOGOUT_REQUEST_FAILURE,
 	LOGOUT_REQUEST_SUCCESS,
-	OAUTH2_CLIENT_DATA_REQUEST,
-	OAUTH2_CLIENT_DATA_REQUEST_FAILURE,
-	OAUTH2_CLIENT_DATA_REQUEST_SUCCESS,
 	SOCIAL_LOGIN_REQUEST,
 	SOCIAL_LOGIN_REQUEST_FAILURE,
 	SOCIAL_LOGIN_REQUEST_SUCCESS,
@@ -107,7 +104,7 @@ function getErrorFromHTTPError( httpError ) {
  * @param {Object} wpcomError HTTP error
  * @returns {{message: string, field: string, code: string}} an error message and the id of the corresponding field
  */
-const getErrorFromWPCOMError = ( wpcomError ) => ( {
+export const getErrorFromWPCOMError = ( wpcomError ) => ( {
 	message: wpcomError.message,
 	code: wpcomError.error,
 	field: 'global',
@@ -430,25 +427,4 @@ export const logoutUser = ( redirectTo ) => ( dispatch, getState ) => {
 
 			return Promise.reject( error );
 		} );
-};
-
-export const fetchOAuth2ClientData = ( clientId ) => dispatch => {
-	dispatch( {
-		type: OAUTH2_CLIENT_DATA_REQUEST
-	} );
-
-	return wpcom.undocumented().oauth2ClientId( clientId ).then( wpcomResponse => {
-		dispatch( { type: OAUTH2_CLIENT_DATA_REQUEST_SUCCESS, data: wpcomResponse } );
-
-		return wpcomResponse;
-	}, wpcomError => {
-		const error = getErrorFromWPCOMError( wpcomError );
-
-		dispatch( {
-			type: OAUTH2_CLIENT_DATA_REQUEST_FAILURE,
-			error,
-		} );
-
-		return Promise.reject( error );
-	} );
 };

--- a/client/state/login/oauth2/actions.js
+++ b/client/state/login/oauth2/actions.js
@@ -1,0 +1,34 @@
+/**
+ * Internal dependencies
+ */
+import {
+	OAUTH2_CLIENT_DATA_REQUEST,
+	OAUTH2_CLIENT_DATA_REQUEST_FAILURE,
+	OAUTH2_CLIENT_DATA_REQUEST_SUCCESS,
+} from 'state/action-types';
+import wpcom from 'lib/wp';
+
+export const fetchOAuth2ClientData = ( clientId ) => dispatch => {
+	dispatch( {
+		type: OAUTH2_CLIENT_DATA_REQUEST,
+		clientId,
+	} );
+
+	return wpcom.undocumented().oauth2ClientId( clientId ).then( wpcomResponse => {
+		dispatch( { type: OAUTH2_CLIENT_DATA_REQUEST_SUCCESS, data: wpcomResponse } );
+
+		return wpcomResponse;
+	}, wpcomError => {
+		const error = {
+			message: wpcomError.message,
+			code: wpcomError.error,
+		};
+
+		dispatch( {
+			type: OAUTH2_CLIENT_DATA_REQUEST_FAILURE,
+			error,
+		} );
+
+		return Promise.reject( error );
+	} );
+};

--- a/client/state/login/oauth2/reducer.js
+++ b/client/state/login/oauth2/reducer.js
@@ -1,0 +1,71 @@
+/**
+ * External dependencies
+ */
+import { startsWith } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { combineReducers, createReducer } from 'state/utils';
+import {
+	ROUTE_SET,
+	OAUTH2_CLIENT_DATA_REQUEST_SUCCESS,
+} from 'state/action-types';
+
+const initialClientsData = {
+	930: {
+		id: 930,
+		name: 'vaultpress',
+		title: 'Vaultpress',
+		icon: 'https://vaultpress.com/images/vaultpress-wpcc-nav-2x.png',
+	},
+	973: {
+		id: 973,
+		name: 'akismet',
+		title: 'Akismet',
+		icon: 'https://akismet.com/img/akismet-wpcc-logo-2x.png',
+	},
+	978: {
+		id: 978,
+		name: 'polldaddy',
+		title: 'Polldaddy',
+		icon: 'https://polldaddy.com/images/polldaddy-wpcc-logo-2x.png',
+	},
+	1854: {
+		id: 1854,
+		name: 'gravatar',
+		title: 'Gravatar',
+		icon: 'https://gravatar.com/images/grav-logo-2x.png',
+	},
+	50019: {
+		id: 50019,
+		name: 'woo',
+		title: 'WooCommerce',
+		icon: 'https://woocommerce.com/wp-content/themes/woomattic/images/logo-woocommerce@2x.png',
+	},
+	50915: {
+		id: 50915,
+		name: 'woo',
+		title: 'WooCommerce',
+		icon: 'https://woocommerce.com/wp-content/themes/woomattic/images/logo-woocommerce@2x.png',
+	},
+	50916: {
+		id: 50916,
+		name: 'woo',
+		title: 'WooCommerce',
+		icon: 'https://woocommerce.com/wp-content/themes/woomattic/images/logo-woocommerce@2x.png',
+	},
+};
+
+export const clients = createReducer( initialClientsData, {
+	[ OAUTH2_CLIENT_DATA_REQUEST_SUCCESS ]: ( state, { data } ) => Object.assign( state, { [ data.id ]: data } ),
+} );
+
+export const currentClientId = createReducer( null, {
+	[ ROUTE_SET ]: ( state, { path, query } ) => startsWith( path, '/log-in' ) && query.client_id,
+} );
+
+export default combineReducers( {
+	clients,
+	currentClientId,
+} );

--- a/client/state/login/oauth2/reducer.js
+++ b/client/state/login/oauth2/reducer.js
@@ -12,7 +12,7 @@ import {
 	OAUTH2_CLIENT_DATA_REQUEST_SUCCESS,
 } from 'state/action-types';
 
-const initialClientsData = {
+export const initialClientsData = {
 	930: {
 		id: 930,
 		name: 'vaultpress',
@@ -58,7 +58,7 @@ const initialClientsData = {
 };
 
 export const clients = createReducer( initialClientsData, {
-	[ OAUTH2_CLIENT_DATA_REQUEST_SUCCESS ]: ( state, { data } ) => Object.assign( state, { [ data.id ]: data } ),
+	[ OAUTH2_CLIENT_DATA_REQUEST_SUCCESS ]: ( state, { data } ) => Object.assign( {}, state, { [ data.id ]: data } ),
 } );
 
 export const currentClientId = createReducer( null, {

--- a/client/state/login/oauth2/selectors.js
+++ b/client/state/login/oauth2/selectors.js
@@ -1,0 +1,28 @@
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/***
+ * Gets the OAuth2 client data.
+ *
+ * @param  {Object}   state  Global state tree
+ * @return {Object}          OAuth2 client data
+ */
+export const getOAuth2ClientData = ( state ) => {
+	const currentClientId = get( state, 'login.oauth2.currentClientId', null );
+
+	if ( ! currentClientId ) {
+		return null;
+	}
+
+	return get( state, 'login.oauth2.clients', {} )[ currentClientId ];
+};
+
+/***
+ * Determines if the OAuth2 layout should be used.
+ *
+ * @param  {Object}   state  Global state tree
+ * @return {Boolean}         Whether the OAuth2 layout should be used.
+ */
+export const showOAuth2Layout = ( state ) => !! get( state, 'login.oauth2.currentClientId', null );

--- a/client/state/login/oauth2/test/reducer.js
+++ b/client/state/login/oauth2/test/reducer.js
@@ -1,0 +1,137 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import {
+	OAUTH2_CLIENT_DATA_REQUEST,
+	OAUTH2_CLIENT_DATA_REQUEST_SUCCESS,
+	ROUTE_SET,
+	SERIALIZE,
+	DESERIALIZE,
+} from 'state/action-types';
+import reducer, {
+	clients,
+	currentClientId,
+	initialClientsData,
+} from '../reducer';
+
+describe( 'reducer', () => {
+	it( 'should include expected keys in return value', () => {
+		expect( reducer( undefined, {} ) ).to.have.keys( [
+			'clients',
+			'currentClientId',
+		] );
+	} );
+
+	describe( 'clients', () => {
+		const testState = {
+			930: {
+				id: 930,
+				name: 'vaultpress',
+				title: 'Vaultpress',
+				icon: 'https://vaultpress.com/images/vaultpress-wpcc-nav-2x.png',
+			},
+			973: {
+				id: 973,
+				name: 'akismet',
+				title: 'Akismet',
+				icon: 'https://akismet.com/img/akismet-wpcc-logo-2x.png',
+			}
+		};
+
+		it( 'should default to a non empty object', () => {
+			const state = clients( undefined, {} );
+
+			expect( state ).to.be.an( 'object' ).that.is.not.empty;
+		} );
+
+		it( 'should keep using stale client data when a fetch request for this client id is emitted', () => {
+			const state = clients( testState, {
+				type: OAUTH2_CLIENT_DATA_REQUEST,
+				clientId: 930
+			} );
+
+			expect( state ).to.deep.equal( testState );
+		} );
+
+		it( 'should update the client data from the list of clients on response from the server', () => {
+			const state = clients( testState, {
+				type: OAUTH2_CLIENT_DATA_REQUEST_SUCCESS,
+				data: {
+					id: 930,
+					name: 'vaultpress2',
+					title: 'Vaultpress 2',
+					icon: 'https://vaultpress.com/images/vaultpress-wpcc-nav-2x.png',
+				}
+			} );
+
+			expect( state ).to.deep.equal( {
+				930: {
+					id: 930,
+					name: 'vaultpress2',
+					title: 'Vaultpress 2',
+					icon: 'https://vaultpress.com/images/vaultpress-wpcc-nav-2x.png',
+				},
+				973: {
+					id: 973,
+					name: 'akismet',
+					title: 'Akismet',
+					icon: 'https://akismet.com/img/akismet-wpcc-logo-2x.png',
+				}
+			} );
+		} );
+
+		it( 'should not persist state', () => {
+			const state = clients( undefined, {
+				type: SERIALIZE
+			} );
+			expect( state ).to.deep.equal( initialClientsData );
+		} );
+
+		it( 'should not load persisted state', () => {
+			const state = clients( undefined, {
+				type: DESERIALIZE
+			} );
+			expect( state ).to.deep.equal( initialClientsData );
+		} );
+	} );
+
+	describe( 'currentClientId', () => {
+		it( 'should default to undefined', () => {
+			const state = currentClientId( undefined, {} );
+
+			expect( state ).to.be.null;
+		} );
+
+		it( 'should be updated on ROUTE_SET when the route starts with /log-in', () => {
+			const state = currentClientId( undefined, {
+				type: ROUTE_SET,
+				path: '/log-in/fr',
+				query: {
+					client_id: 42,
+					retry: 1,
+				},
+			} );
+
+			expect( state ).to.equal( 42 );
+		} );
+
+		it( 'should not persist state', () => {
+			const state = currentClientId( true, {
+				type: SERIALIZE
+			} );
+			expect( state ).to.be.null;
+		} );
+
+		it( 'should not load persisted state', () => {
+			const state = currentClientId( true, {
+				type: DESERIALIZE
+			} );
+			expect( state ).to.be.null;
+		} );
+	} );
+} );

--- a/client/state/login/oauth2/test/selectors.js
+++ b/client/state/login/oauth2/test/selectors.js
@@ -1,0 +1,95 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import {
+	getOAuth2ClientData,
+	showOAuth2Layout,
+} from '../selectors';
+
+describe( 'selectors', () => {
+	describe( 'getOAuth2ClientData()', () => {
+		it( 'should return null if there is no information yet', () => {
+			const clientData = getOAuth2ClientData( undefined );
+
+			expect( clientData ).to.be.null;
+		} );
+
+		it( 'should return the oauth2 client information if there is one', () => {
+			const clientData = getOAuth2ClientData( {
+				login: {
+					oauth2: {
+						clients: {
+							1: {
+								id: 1,
+								name: 'test',
+								title: 'WordPress.com Test Client',
+								url: 'https://wordpres.com/calypso/images/wordpress/logo-stars.svg'
+							}
+						},
+						currentClientId: 1,
+					}
+				}
+			} );
+
+			expect( clientData ).to.deep.equal( {
+				id: 1,
+				name: 'test',
+				title: 'WordPress.com Test Client',
+				url: 'https://wordpres.com/calypso/images/wordpress/logo-stars.svg'
+			} );
+		} );
+	} );
+
+	describe( 'showOAuth2Layout()', () => {
+		it( 'should return false if there is no information yet', () => {
+			const showOAuth2 = showOAuth2Layout( undefined );
+
+			expect( showOAuth2 ).to.be.false;
+		} );
+
+		it( 'should return false if there is no current oauth2 client set', () => {
+			const showOAuth2 = showOAuth2Layout( {
+				login: {
+					oauth2: {
+						clients: {
+							1: {
+								id: 1,
+								name: 'test',
+								title: 'WordPress.com Test Client',
+								url: 'https://wordpres.com/calypso/images/wordpress/logo-stars.svg'
+							}
+						},
+						currentClientId: undefined,
+					}
+				}
+			} );
+
+			expect( showOAuth2 ).to.be.false;
+		} );
+
+		it( 'should return true if there is a current client id set', () => {
+			const showOAuth2 = showOAuth2Layout( {
+				login: {
+					oauth2: {
+						clients: {
+							1: {
+								id: 1,
+								name: 'test',
+								title: 'WordPress.com Test Client',
+								url: 'https://wordpres.com/calypso/images/wordpress/logo-stars.svg'
+							}
+						},
+						currentClientId: 42,
+					}
+				}
+			} );
+
+			expect( showOAuth2 ).to.be.true;
+		} );
+	} );
+} );

--- a/client/state/login/reducer.js
+++ b/client/state/login/reducer.js
@@ -1,13 +1,14 @@
 /**
  * External dependencies
  */
-import { get, isEmpty, omit, startsWith } from 'lodash';
+import { get, isEmpty, omit } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import { combineReducers, createReducer } from 'state/utils';
 import magicLogin from './magic-login/reducer';
+import oauth2 from './oauth2/reducer';
 import {
 	LOGIN_FORM_UPDATE,
 	LOGIN_REQUEST,
@@ -17,9 +18,6 @@ import {
 	LOGOUT_REQUEST_FAILURE,
 	LOGOUT_REQUEST_SUCCESS,
 	ROUTE_SET,
-	OAUTH2_CLIENT_DATA_REQUEST,
-	OAUTH2_CLIENT_DATA_REQUEST_FAILURE,
-	OAUTH2_CLIENT_DATA_REQUEST_SUCCESS,
 	SOCIAL_LOGIN_REQUEST,
 	SOCIAL_LOGIN_REQUEST_FAILURE,
 	SOCIAL_LOGIN_REQUEST_SUCCESS,
@@ -186,16 +184,6 @@ export const socialAccount = createReducer( { isCreating: false, createError: nu
 	[ LOGIN_REQUEST ]: state => ( { ...state, createError: null } ),
 } );
 
-export const oauth2ClientData = createReducer( null, {
-	[ OAUTH2_CLIENT_DATA_REQUEST ]: () => null,
-	[ OAUTH2_CLIENT_DATA_REQUEST_FAILURE ]: ( state, { error } ) => error,
-	[ OAUTH2_CLIENT_DATA_REQUEST_SUCCESS ]: ( state, { data } ) => data,
-} );
-
-export const showOAuth2Layout = createReducer( false, {
-	[ ROUTE_SET ]: ( state, { path, query } ) => startsWith( path, '/log-in' ) && !! query.client_id,
-} );
-
 export const socialAccountLink = createReducer( { isLinking: false }, {
 	[ SOCIAL_CREATE_ACCOUNT_REQUEST_FAILURE ]: ( state, { error, token, service } ) => {
 		if ( error.code === 'user_exists' ) {
@@ -227,7 +215,6 @@ export default combineReducers( {
 	twoFactorAuthRequestError,
 	twoFactorAuthPushPoll,
 	socialAccount,
-	oauth2ClientData,
-	showOAuth2Layout,
 	socialAccountLink,
+	oauth2,
 } );

--- a/client/state/login/test/reducer.js
+++ b/client/state/login/test/reducer.js
@@ -60,8 +60,7 @@ describe( 'reducer', () => {
 			'isRequestingTwoFactorAuth',
 			'twoFactorAuthRequestError',
 			'twoFactorAuthPushPoll',
-			'oauth2ClientData',
-			'showOAuth2Layout',
+			'oauth2',
 		] );
 	} );
 


### PR DESCRIPTION
This PR is a refactoring and moves the oauth2 clients data from the new oauth2 layout to the `login.oauth2.clients` state.

### Testing Instructions
- Boot this branch
- Navigate to http://calypso.localhost:3000/log-in?client_id=930 while logged out
- check that the Master Bar is removed
- check that VaultPress is mentioned: `Howdy! Log in to VaultPress with your WordPress.com account.` and `Back to VaultPress` link at the bottom.

### Reviews
- [x] Code
- [x] Product
- [x] Tests