### PR TITLE
When breadcrumbs wrap, don't allow them to take up too much space

### DIFF
--- a/client/extensions/woocommerce/app/settings/shipping/shipping-zone/style.scss
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-zone/style.scss
@@ -1,6 +1,8 @@
 .sticky-panel + .shipping-zone__locations-container,
 .sticky-panel + .shipping-zone__methods-container {
-	margin-top: 58px;
+	@include breakpoint( ">660px" ) {
+		margin-top: 58px;
+	}
 }
 
 .shipping-zone__name {

--- a/client/extensions/woocommerce/components/action-header/style.scss
+++ b/client/extensions/woocommerce/components/action-header/style.scss
@@ -15,7 +15,6 @@
 .action-header__breadcrumbs {
 	width: 60%;
 	font-size: 13px;
-	line-height: 43px;
 	@include breakpoint( "<660px" ) {
 		padding-left: 24px;
 	}


### PR DESCRIPTION
This line-height declaration is left over from an old implementation anyway, removing it makes no difference to the design on any pages, wrapping or no wrapping.

![wrap](https://cldup.com/reTsRJSW91-2000x2000.png)