### PR TITLE
Media: fixes context bug after ES6ifying the media library

### DIFF
--- a/client/my-sites/media-library/index.jsx
+++ b/client/my-sites/media-library/index.jsx
@@ -53,7 +53,7 @@ class MediaLibrary extends Component {
 		searchUrl( keywords, this.props.search, this.props.onSearch );
 	};
 
-	onAddMedia() {
+	onAddMedia = () => {
 		const selectedItems = MediaLibrarySelectedStore.getAll( this.props.site.ID );
 		let filteredItems = selectedItems;
 


### PR DESCRIPTION
Dropping files on the media library was broken in #17083 beacuse the onAddMedia callback wasnt bound. This fixes it.

## Testing

- Drop a file onto the media library without this PR and with dev tools open - error
- Drop a file onto the media library with this PR and dev tools open - works
