### PR TITLE
Store: Tax rates table styling fixes

### DIFF
--- a/client/extensions/woocommerce/app/settings/taxes/style.scss
+++ b/client/extensions/woocommerce/app/settings/taxes/style.scss
@@ -32,3 +32,11 @@
 		margin-bottom: 0;
 	}
 }
+
+.taxes__taxes-rates-table {
+	.table-row {
+		&:hover {
+			background-color: transparent;
+		}
+	}
+}

--- a/client/extensions/woocommerce/app/settings/taxes/style.scss
+++ b/client/extensions/woocommerce/app/settings/taxes/style.scss
@@ -7,6 +7,7 @@
 
 	.taxes__taxes-calculate {
 		color: $alert-green;
+		margin-bottom: 1.5em;
 	}
 
 	.taxes__taxes-calculate .gridicon {

--- a/client/extensions/woocommerce/app/settings/taxes/taxes-rates.js
+++ b/client/extensions/woocommerce/app/settings/taxes/taxes-rates.js
@@ -236,7 +236,7 @@ class TaxesRates extends Component {
 		} );
 
 		return (
-			<Table>
+			<Table className="taxes__taxes-rates-table">
 				<TableRow isHeader>
 					<TableItem isHeader>
 						{ translate( 'Name' ) }


### PR DESCRIPTION
Fixes the margin on the "We'll automatically calculate and charge sales tax..." message and removes the hover styles on the rates table.

![tax](https://cldup.com/RaKGrhDe4O-3000x3000.png)