### PR TITLE
Simple Payments: Don't wrap the product name in the list to multiple lines

### DIFF
--- a/client/components/tinymce/plugins/simple-payments/dialog/list-item.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/list-item.jsx
@@ -57,7 +57,7 @@ class ProductListItem extends Component {
 					onChange={ this.handleRadioChange }
 				/>
 				<label className="editor-simple-payments-modal__list-label" htmlFor={ radioId }>
-					<div>
+					<div className="editor-simple-payments-modal__list-name">
 						{ title }
 					</div>
 					<div>

--- a/client/components/tinymce/plugins/simple-payments/style.scss
+++ b/client/components/tinymce/plugins/simple-payments/style.scss
@@ -164,8 +164,19 @@
 
 .editor-simple-payments-modal__list-label {
 	flex: auto;
+	min-width: 0;
 	font-family: $serif;
 	font-weight: bold;
+}
+
+.editor-simple-payments-modal__list-name {
+	white-space: nowrap;
+	overflow: hidden;
+	position: relative;
+
+	&::after {
+		@include long-content-fade();
+	}
 }
 
 .editor-simple-payments-modal__list-menu {


### PR DESCRIPTION
Limit to one line, add `long-content-fade` at the end.

Before:
<img width="448" alt="octopus-before" src="https://user-images.githubusercontent.com/664258/29274407-1e1fd96c-8108-11e7-9c4e-3f3ad9917622.png">

After:
<img width="449" alt="octopus-after" src="https://user-images.githubusercontent.com/664258/29274416-22068378-8108-11e7-9d20-5417834e0cb6.png">

Cc @Automattic/stark 