### PR TITLE
Media: ES6ify MediaLibraryContent

### DIFF
--- a/client/my-sites/media-library/content.jsx
+++ b/client/my-sites/media-library/content.jsx
@@ -6,6 +6,7 @@ import { connect } from 'react-redux';
 import createFragment from 'react-addons-create-fragment';
 import { groupBy, head, mapValues, noop, some, toArray, values } from 'lodash';
 import { translate } from 'i18n-calypso';
+import PropTypes from 'prop-types';
 import page from 'page';
 
 /**
@@ -36,43 +37,39 @@ import {
 
 const isConnected = props => some( props.connectedServices, item => item.service === props.source );
 
-const MediaLibraryContent = React.createClass( {
-	propTypes: {
-		site: React.PropTypes.object,
-		mediaValidationErrors: React.PropTypes.object,
-		filter: React.PropTypes.string,
-		filterRequiresUpgrade: React.PropTypes.bool,
-		search: React.PropTypes.string,
-		source: React.PropTypes.string,
-		containerWidth: React.PropTypes.number,
-		single: React.PropTypes.bool,
-		scrollable: React.PropTypes.bool,
-		onAddMedia: React.PropTypes.func,
-		onMediaScaleChange: React.PropTypes.func,
-		onEditItem: React.PropTypes.func,
-		postId: React.PropTypes.number
-	},
+class MediaLibraryContent extends React.Component {
+	static propTypes = {
+		site: PropTypes.object,
+		mediaValidationErrors: PropTypes.object,
+		filter: PropTypes.string,
+		filterRequiresUpgrade: PropTypes.bool,
+		search: PropTypes.string,
+		source: PropTypes.string,
+		containerWidth: PropTypes.number,
+		single: PropTypes.bool,
+		scrollable: PropTypes.bool,
+		onAddMedia: PropTypes.func,
+		onMediaScaleChange: PropTypes.func,
+		onEditItem: PropTypes.func,
+		postId: PropTypes.number,
+	};
 
-	getDefaultProps: function() {
-		return {
-			mediaValidationErrors: Object.freeze( {} ),
-			onAddMedia: noop,
-			source: '',
-		};
-	},
+	static defaultProps = {
+		mediaValidationErrors: Object.freeze( {} ),
+		onAddMedia: noop,
+		source: '',
+	}
 
-	componentWillMount: function() {
+	componentWillMount() {
 		if ( ! this.props.isRequesting && this.props.source !== '' && this.props.connectedServices.length === 0 ) {
 			// Are we connected to anything yet?
 			this.props.requestKeyringConnections();
 		}
-	},
+	}
 
-	renderErrors: function() {
-		var errorTypes, notices;
-
-		errorTypes = values( this.props.mediaValidationErrors ).map( head );
-		notices = mapValues( groupBy( errorTypes ), ( occurrences, errorType ) => {
+	renderErrors() {
+		const errorTypes = values( this.props.mediaValidationErrors ).map( head );
+		const notices = mapValues( groupBy( errorTypes ), ( occurrences, errorType ) => {
 			let message, onDismiss;
 			const i18nOptions = {
 				count: occurrences.length,
@@ -160,7 +157,7 @@ const MediaLibraryContent = React.createClass( {
 		} );
 
 		return createFragment( notices );
-	},
+	}
 
 	renderTryAgain() {
 		return (
@@ -168,14 +165,14 @@ const MediaLibraryContent = React.createClass( {
 				{ translate( 'Retry' ) }
 			</NoticeAction>
 		);
-	},
+	}
 
-	retryList() {
+	retryList = () => {
 		MediaActions.sourceChanged( this.props.site.ID );
-	},
+	}
 
 	renderNoticeAction( upgradeNudgeName, upgradeNudgeFeature ) {
-		if ( !upgradeNudgeName ) {
+		if ( ! upgradeNudgeName ) {
 			return null;
 		}
 		const eventName = 'calypso_upgrade_nudge_impression';
@@ -192,17 +189,17 @@ const MediaLibraryContent = React.createClass( {
 				<TrackComponentView eventName={ eventName } eventProperties={ eventProperties } />
 			</NoticeAction>
 		);
-	},
+	}
 
 	recordPlansNavigation( tracksEvent, tracksData ) {
 		analytics.ga.recordEvent( 'Media', 'Clicked Upload Error Action' );
 		analytics.tracks.recordEvent( tracksEvent, tracksData );
-	},
+	}
 
-	goToSharing( ev ) {
+	goToSharing = ev => {
 		ev.preventDefault();
 		page( `/sharing/${ this.props.site.slug }` );
-	},
+	}
 
 	renderExternalMedia() {
 		const connectMessage = translate(
@@ -219,7 +216,7 @@ const MediaLibraryContent = React.createClass( {
 				<p>{ connectMessage }</p>
 			</div>
 		);
-	},
+	}
 
 	getThumbnailType() {
 		if ( this.props.source !== '' ) {
@@ -231,9 +228,9 @@ const MediaLibraryContent = React.createClass( {
 		}
 
 		return MEDIA_IMAGE_PHOTON;
-	},
+	}
 
-	renderMediaList: function() {
+	renderMediaList() {
 		if ( ! this.props.site || this.props.isRequesting ) {
 			return <MediaLibraryList key="list-loading" filterRequiresUpgrade={ this.props.filterRequiresUpgrade } />;
 		}
@@ -264,7 +261,7 @@ const MediaLibraryContent = React.createClass( {
 				</MediaLibrarySelectedData>
 			</MediaListData>
 		);
-	},
+	}
 
 	renderHeader() {
 		if ( this.props.source !== '' ) {
@@ -294,9 +291,9 @@ const MediaLibraryContent = React.createClass( {
 		}
 
 		return null;
-	},
+	}
 
-	render: function() {
+	render() {
 		return (
 			<div className="media-library__content">
 				{ this.renderHeader() }
@@ -305,7 +302,7 @@ const MediaLibraryContent = React.createClass( {
 			</div>
 		);
 	}
-} );
+}
 
 export default connect( ( state, ownProps ) => {
 	return {


### PR DESCRIPTION
ES6ify the MediaLibraryContent class. Note that both the `retryList` and `goToSharing` are now arrow functions so are bound to the current object. There should be no other class functions that are called or passed by this file.

# Testing

- Verify that media library modal and media library page continue to operate
- To test `goToSharing` by disconnecting your Google Photos, viewing Google Photos, and then pressing the link to go to the sharing page - this should work
- To test `retryLink`, add this to the top of `renderErrors`:

```jsx
		return (
			<Notice status="is-error" text="Error" onDismissClick={ false } >
				{ this.renderTryAgain() }
			</Notice>
		);
```
   This fakes an error. Connect Google Photos and view your media. A red error bar should appear and clicking it should refresh the library