### PR TITLE
Media: Convert FilterBar proptypes

### DIFF
--- a/client/my-sites/media-library/filter-bar.jsx
+++ b/client/my-sites/media-library/filter-bar.jsx
@@ -9,6 +9,7 @@ import {
 	noop,
 	pull,
 } from 'lodash';
+import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies
@@ -23,17 +24,17 @@ import TitleItem from './title-item';
 
 export class MediaLibraryFilterBar extends Component {
 	static propTypes = {
-		basePath: React.PropTypes.string,
-		enabledFilters: React.PropTypes.arrayOf( React.PropTypes.string ),
-		filter: React.PropTypes.string,
-		filterRequiresUpgrade: React.PropTypes.bool,
-		search: React.PropTypes.string,
-		source: React.PropTypes.string,
-		site: React.PropTypes.object,
-		onFilterChange: React.PropTypes.func,
-		onSearch: React.PropTypes.func,
-		translate: React.PropTypes.func,
-		post: React.PropTypes.bool
+		basePath: PropTypes.string,
+		enabledFilters: PropTypes.arrayOf( PropTypes.string ),
+		filter: PropTypes.string,
+		filterRequiresUpgrade: PropTypes.bool,
+		search: PropTypes.string,
+		source: PropTypes.string,
+		site: PropTypes.object,
+		onFilterChange: PropTypes.func,
+		onSearch: PropTypes.func,
+		translate: PropTypes.func,
+		post: PropTypes.bool,
 	};
 
 	static defaultProps ={


### PR DESCRIPTION
Uses the `prop-types` import rather than the deprecated `React.PropTypes`

Should be a low impact change - if the code compiles then its good!