### PR TITLE
Media: ES6ify media library index file

### DIFF
--- a/client/my-sites/media-library/index.jsx
+++ b/client/my-sites/media-library/index.jsx
@@ -1,73 +1,61 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	classNames = require( 'classnames' ),
-	isEqual = require( 'lodash/isEqual' );
+import React, { Component } from 'react';
+import classNames from 'classnames';
+import { isEqual } from 'lodash';
+import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies
  */
-var Content = require( './content' ),
-	MediaActions = require( 'lib/media/actions' ),
-	MediaLibraryDropZone = require( './drop-zone' ),
-	MediaLibrarySelectedStore = require( 'lib/media/library-selected-store' ),
-	MediaUtils = require( 'lib/media/utils' ),
-	filterToMimePrefix = require( './filter-to-mime-prefix' ),
-	FilterBar = require( './filter-bar' ).default,
-	MediaValidationData = require( 'components/data/media-validation-data' ),
-	urlSearch = require( 'lib/mixins/url-search' );
+import Content from './content';
+import MediaActions from 'lib/media/actions';
+import MediaLibraryDropZone from './drop-zone';
+import MediaLibrarySelectedStore from 'lib/media/library-selected-store';
+import MediaUtils from 'lib/media/utils';
+import filterToMimePrefix from './filter-to-mime-prefix';
+import FilterBar from './filter-bar';
+import MediaValidationData from 'components/data/media-validation-data';
 import QueryPreferences from 'components/data/query-preferences';
+import searchUrl from 'lib/search-url';
 
-module.exports = React.createClass( {
-	displayName: 'MediaLibrary',
+class MediaLibrary extends Component {
+	static propTypes = {
+		className: PropTypes.string,
+		site: PropTypes.object,
+		filter: PropTypes.string,
+		enabledFilters: PropTypes.arrayOf( PropTypes.string ),
+		search: PropTypes.string,
+		source: PropTypes.string,
+		onAddMedia: PropTypes.func,
+		onFilterChange: PropTypes.func,
+		onSourceChange: PropTypes.func,
+		onSearch: PropTypes.func,
+		onScaleChange: PropTypes.func,
+		onEditItem: PropTypes.func,
+		fullScreenDropZone: PropTypes.bool,
+		containerWidth: PropTypes.number,
+		single: PropTypes.bool,
+		scrollable: PropTypes.bool,
+		postId: PropTypes.number,
+	};
 
-	mixins: [ urlSearch ],
+	static defaultProps = {
+		fullScreenDropZone: true,
+		onAddMedia: () => {},
+		onScaleChange: () => {},
+		scrollable: false,
+		source: '',
+	};
 
-	propTypes: {
-		className: React.PropTypes.string,
-		site: React.PropTypes.object,
-		filter: React.PropTypes.string,
-		enabledFilters: React.PropTypes.arrayOf( React.PropTypes.string ),
-		search: React.PropTypes.string,
-		source: React.PropTypes.string,
-		onAddMedia: React.PropTypes.func,
-		onFilterChange: React.PropTypes.func,
-		onSearch: React.PropTypes.func,
-		onScaleChange: React.PropTypes.func,
-		onEditItem: React.PropTypes.func,
-		fullScreenDropZone: React.PropTypes.bool,
-		containerWidth: React.PropTypes.number,
-		single: React.PropTypes.bool,
-		scrollable: React.PropTypes.bool,
-		postId: React.PropTypes.number,
-	},
+	doSearch = keywords => {
+		searchUrl( keywords, this.props.search, this.props.onSearch );
+	};
 
-	getDefaultProps: function() {
-		return {
-			fullScreenDropZone: true,
-			onAddMedia: () => {},
-			onScaleChange: () => {},
-			scrollable: false,
-			source: '',
-		};
-	},
-
-	componentDidMount: function() {
-		this.onSearch = this.props.onSearch;
-	},
-
-	componentDidUpdate: function() {
-		this.onSearch = this.props.onSearch;
-	},
-
-	componentWillUnmount: function() {
-		delete this.onSearch;
-	},
-
-	onAddMedia: function() {
-		let selectedItems = MediaLibrarySelectedStore.getAll( this.props.site.ID ),
-			filteredItems = selectedItems;
+	onAddMedia = () => {
+		const selectedItems = MediaLibrarySelectedStore.getAll( this.props.site.ID );
+		let filteredItems = selectedItems;
 
 		if ( ! this.props.site ) {
 			return;
@@ -93,9 +81,9 @@ module.exports = React.createClass( {
 		}
 
 		this.props.onAddMedia();
-	},
+	}
 
-	filterRequiresUpgrade: function() {
+	filterRequiresUpgrade() {
 		const { filter, site } = this.props;
 		switch ( filter ) {
 			case 'audio':
@@ -106,9 +94,9 @@ module.exports = React.createClass( {
 		}
 
 		return false;
-	},
+	}
 
-	renderDropZone: function() {
+	renderDropZone() {
 		if ( this.props.source !== '' ) {
 			return null;
 		}
@@ -120,10 +108,10 @@ module.exports = React.createClass( {
 				fullScreen={ this.props.fullScreenDropZone }
 				onAddMedia={ this.onAddMedia } />
 		);
-	},
+	}
 
-	render: function() {
-		var classes, content;
+	render() {
+		let content;
 
 		content = (
 			<Content
@@ -153,7 +141,7 @@ module.exports = React.createClass( {
 			);
 		}
 
-		classes = classNames(
+		const classes = classNames(
 			'media-library',
 			{ 'is-single': this.props.single },
 			this.props.className,
@@ -177,4 +165,6 @@ module.exports = React.createClass( {
 			</div>
 		);
 	}
-} );
+}
+
+export default MediaLibrary;


### PR DESCRIPTION
Convert to ES6 imports, class, and const/let

The `url-search` mixin has been replaced with `lib/search-url` via the `doSearch` function.

Note that `addMedia` and `doSearch` are arrow functions so they are bound to the current object. There should be no other class functions that are called or passed by this file.

# Testing
- Verify that media can be dropped onto the media modal and media library page
- Verify that when searching the media library page the URL is changed to reflect the search query
- Verify that when searching the media modal the URL is not changed when searching
- Verify that files can be uploaded
- General verify that media works