### PR TITLE
Activity log: Query activity by month

### DIFF
--- a/client/components/data/query-activity-log/README.md
+++ b/client/components/data/query-activity-log/README.md
@@ -40,8 +40,8 @@ Unix millisecond timestamp to fetch activity on or after.
 
 ### `number`
 
-Type   | Required
------- | --------
-Number | No
+Type   | Required | Default
+------ | -------- | ---
+Number | No       | 20
 
 Number of results to fetch.

--- a/client/components/data/query-activity-log/README.md
+++ b/client/components/data/query-activity-log/README.md
@@ -16,9 +16,32 @@ This component renders nothing. It ensures that any activity logs for the given 
 
 ### `siteId`
 
-<table>
-	<tr><th>Type</th><td>Number</td></tr>
-	<tr><th>Required</th><td>Yes</td></tr>
-</table>
+Type   | Required
+------ | --------
+Number | Yes
 
 Site to fetch activities for.
+
+### `dateEnd`
+
+Type   | Required
+------ | --------
+Number | No
+
+Unix millisecond timestamp to fetch activity on or before.
+
+### `dateStart`
+
+Type   | Required
+------ | --------
+Number | No
+
+Unix millisecond timestamp to fetch activity on or after.
+
+### `number`
+
+Type   | Required
+------ | --------
+Number | No
+
+Number of results to fetch.

--- a/client/components/data/query-activity-log/index.jsx
+++ b/client/components/data/query-activity-log/index.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import { Component, PropTypes } from 'react';
+import { PureComponent } from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
 /**
@@ -9,9 +10,16 @@ import { connect } from 'react-redux';
  */
 import { activityLogRequest as activityLogRequestAction } from 'state/activity-log/actions';
 
-class QueryActivityLog extends Component {
+class QueryActivityLog extends PureComponent {
 	static propTypes = {
 		siteId: PropTypes.number,
+
+		// Unix millisecond timestamps ( moment.valueOf() )
+		dateEnd: PropTypes.number,
+		dateStart: PropTypes.number,
+
+		// Number of results
+		number: PropTypes.number,
 	};
 
 	componentWillMount() {
@@ -26,9 +34,18 @@ class QueryActivityLog extends Component {
 		this.request( nextProps );
 	}
 
-	request( { siteId } ) {
+	request( {
+		siteId,
+		dateEnd,
+		dateStart,
+		number,
+	} ) {
 		if ( siteId ) {
-			this.props.activityLogRequest( siteId );
+			this.props.activityLogRequest( siteId, {
+				dateEnd,
+				dateStart,
+				number,
+			} );
 		}
 	}
 

--- a/client/components/data/query-activity-log/index.jsx
+++ b/client/components/data/query-activity-log/index.jsx
@@ -28,10 +28,6 @@ class QueryActivityLog extends PureComponent {
 	}
 
 	componentWillReceiveProps( nextProps ) {
-		if ( this.props.siteId === nextProps.siteId ) {
-			return;
-		}
-
 		this.request( nextProps );
 	}
 

--- a/client/components/data/query-activity-log/index.jsx
+++ b/client/components/data/query-activity-log/index.jsx
@@ -23,6 +23,10 @@ class QueryActivityLog extends PureComponent {
 		number: PropTypes.number,
 	};
 
+	static defaultProps = {
+		number: 20,
+	};
+
 	componentWillMount() {
 		this.request( this.props );
 	}

--- a/client/components/data/query-activity-log/index.jsx
+++ b/client/components/data/query-activity-log/index.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -34,12 +35,7 @@ class QueryActivityLog extends PureComponent {
 		this.request( nextProps );
 	}
 
-	request( {
-		siteId,
-		dateEnd,
-		dateStart,
-		number,
-	} ) {
+	request( { siteId, dateEnd, dateStart, number } ) {
 		if ( siteId ) {
 			this.props.activityLogRequest( siteId, {
 				dateEnd,
@@ -55,5 +51,5 @@ class QueryActivityLog extends PureComponent {
 }
 
 export default connect( null, {
-	activityLogRequest: activityLogRequestAction
+	activityLogRequest: activityLogRequestAction,
 } )( QueryActivityLog );

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -2,7 +2,8 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import debugFactory from 'debug';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -302,14 +302,17 @@ class ActivityLog extends Component {
 	}
 
 	render() {
-		const { isPressable, isRewindActive, siteId, siteTitle, slug } = this.props;
+		const { isPressable, isRewindActive, moment, siteId, siteTitle, slug, startDate } = this.props;
 		const { requestedRestoreTimestamp, showRestoreConfirmDialog } = this.state;
 		const applySiteOffset = this.getSiteOffsetFunc();
+
+		const queryStart = applySiteOffset( moment.utc( startDate ) ).startOf( 'month' ).valueOf();
+		const queryEnd = applySiteOffset( moment.utc( startDate ) ).endOf( 'month' ).valueOf();
 
 		return (
 			<Main wideLayout>
 				<QueryRewindStatus siteId={ siteId } />
-				<QueryActivityLog siteId={ siteId } />
+				<QueryActivityLog siteId={ siteId } dateStart={ queryStart } dateEnd={ queryEnd } />
 				<QuerySiteSettings siteId={ siteId } />
 				<StatsFirstView />
 				<SidebarNavigation />

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -312,7 +312,7 @@ class ActivityLog extends Component {
 		return (
 			<Main wideLayout>
 				<QueryRewindStatus siteId={ siteId } />
-				<QueryActivityLog siteId={ siteId } dateStart={ queryStart } dateEnd={ queryEnd } />
+				<QueryActivityLog siteId={ siteId } dateStart={ queryStart } dateEnd={ queryEnd } number={ 1000 } />
 				<QuerySiteSettings siteId={ siteId } />
 				<StatsFirstView />
 				<SidebarNavigation />

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -6,7 +6,7 @@ import React, { Component, PropTypes } from 'react';
 import debugFactory from 'debug';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { filter, get, groupBy, includes, isEmpty, isNull, map } from 'lodash';
+import { get, groupBy, includes, isEmpty, isNull, map } from 'lodash';
 
 /**
  * Internal dependencies
@@ -238,13 +238,7 @@ class ActivityLog extends Component {
 
 		const applySiteOffset = this.getSiteOffsetFunc();
 
-		const YEAR_MONTH = 'YYYY-MM';
-		const selectedMonthAndYear = moment( startDate ).format( YEAR_MONTH );
-		const logsForMonth = filter( logs, ( { ts_utc } ) => {
-			return applySiteOffset( moment.utc( ts_utc ) ).format( YEAR_MONTH ) === selectedMonthAndYear;
-		} );
-
-		if ( isEmpty( logsForMonth ) ) {
+		if ( isEmpty( logs ) ) {
 			return (
 				<EmptyContent
 					title={ translate( 'No activity for %s', {
@@ -255,9 +249,7 @@ class ActivityLog extends Component {
 		}
 
 		const logsGroupedByDay = map(
-			groupBy( logsForMonth, log =>
-				applySiteOffset( moment.utc( log.ts_utc ) ).endOf( 'day' ).valueOf()
-			),
+			groupBy( logs, log => applySiteOffset( moment.utc( log.ts_utc ) ).endOf( 'day' ).valueOf() ),
 			( daily_logs, tsEndOfSiteDay ) =>
 				<ActivityLogDay
 					applySiteOffset={ applySiteOffset }
@@ -312,7 +304,12 @@ class ActivityLog extends Component {
 		return (
 			<Main wideLayout>
 				<QueryRewindStatus siteId={ siteId } />
-				<QueryActivityLog siteId={ siteId } dateStart={ queryStart } dateEnd={ queryEnd } number={ 1000 } />
+				<QueryActivityLog
+					siteId={ siteId }
+					dateStart={ queryStart }
+					dateEnd={ queryEnd }
+					number={ 1000 }
+				/>
 				<QuerySiteSettings siteId={ siteId } />
 				<StatsFirstView />
 				<SidebarNavigation />

--- a/client/state/activity-log/actions.js
+++ b/client/state/activity-log/actions.js
@@ -56,9 +56,9 @@ export function rewindActivateFailure( siteId ) {
  *
  * @typdef {Object} ActivityParams
  *
- * @property {number} date_start Filter activity after this date (utc microtime timestamp).
- * @property {number} date_end   Filter activity before this date (utc microtime timestamp).
- * @property {number} number     Maximum number of results to return.
+ * @property {number} dateStart Filter activity after this date (Unix millisecond timestamp).
+ * @property {number} dateEnd   Filter activity before this date (Unix millisecond timestamp).
+ * @property {number} number    Maximum number of results to return.
  */
 
 /**

--- a/client/state/data-layer/wpcom/sites/activity/index.js
+++ b/client/state/data-layer/wpcom/sites/activity/index.js
@@ -14,15 +14,31 @@ import {
 	activityLogUpdate,
 } from 'state/activity-log/actions';
 
+const KNOWN_PARAMS = [
+	'action',
+	'date_end',
+	'date_start',
+	'group',
+	'name',
+	'number',
+];
+
 export const handleActivityLogRequest = ( { dispatch }, action ) => {
+	const { params, siteId } = action;
+
+	if ( params.dateEnd ) {
+		params.date_end = params.dateEnd;
+	}
+
+	if ( params.dateStart ) {
+		params.date_start = params.dateStart;
+	}
+
 	dispatch( http( {
 		apiVersion: '1',
 		method: 'GET',
-		path: `/sites/${ action.siteId }/activity`,
-		query: {
-			number: 1000,
-			...action.params,
-		},
+		path: `/sites/${ siteId }/activity`,
+		query: pick( KNOWN_PARAMS, params ),
 	}, action ) );
 };
 

--- a/client/state/data-layer/wpcom/sites/activity/index.js
+++ b/client/state/data-layer/wpcom/sites/activity/index.js
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import { get, pick } from 'lodash';
+import { get, includes, reduce } from 'lodash';
 
 /**
  * Internal dependencies
@@ -12,22 +12,34 @@ import { http } from 'state/data-layer/wpcom-http/actions';
 import { ACTIVITY_LOG_REQUEST } from 'state/action-types';
 import { activityLogError, activityLogUpdate } from 'state/activity-log/actions';
 
-const KNOWN_PARAMS = [ 'action', 'date_end', 'date_start', 'group', 'name', 'number' ];
+/**
+ * Module constants
+ */
+const CALYPSO_TO_API_PARAMS = {
+	dateEnd: 'date_end',
+	dateStart: 'date_start',
+};
+const KNOWN_API_PARAMS = [ 'action', 'date_end', 'date_start', 'group', 'name', 'number' ];
 
 export const handleActivityLogRequest = ( { dispatch }, action ) => {
 	const { siteId } = action;
 
-	const query = pick( action.params, KNOWN_PARAMS );
+	const query = reduce(
+		action.params,
+		( acc, value, param ) => {
+			const paramToStore = get( CALYPSO_TO_API_PARAMS, param, param );
 
-	const dateEnd = get( action.params, 'dateEnd' );
-	if ( dateEnd ) {
-		query.date_end = dateEnd;
-	}
+			if ( includes( KNOWN_API_PARAMS, paramToStore ) ) {
+				return {
+					...acc,
+					[ paramToStore ]: value,
+				};
+			}
 
-	const dateStart = get( action.params, 'dateStart' );
-	if ( dateStart ) {
-		query.date_start = dateStart;
-	}
+			return acc;
+		},
+		{}
+	);
 
 	dispatch(
 		http(

--- a/client/state/data-layer/wpcom/sites/activity/index.js
+++ b/client/state/data-layer/wpcom/sites/activity/index.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -9,19 +10,9 @@ import { pick } from 'lodash';
 import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { ACTIVITY_LOG_REQUEST } from 'state/action-types';
-import {
-	activityLogError,
-	activityLogUpdate,
-} from 'state/activity-log/actions';
+import { activityLogError, activityLogUpdate } from 'state/activity-log/actions';
 
-const KNOWN_PARAMS = [
-	'action',
-	'date_end',
-	'date_start',
-	'group',
-	'name',
-	'number',
-];
+const KNOWN_PARAMS = [ 'action', 'date_end', 'date_start', 'group', 'name', 'number' ];
 
 export const handleActivityLogRequest = ( { dispatch }, action ) => {
 	const { params, siteId } = action;
@@ -34,12 +25,17 @@ export const handleActivityLogRequest = ( { dispatch }, action ) => {
 		params.date_start = params.dateStart;
 	}
 
-	dispatch( http( {
-		apiVersion: '1',
-		method: 'GET',
-		path: `/sites/${ siteId }/activity`,
-		query: pick( KNOWN_PARAMS, params ),
-	}, action ) );
+	dispatch(
+		http(
+			{
+				apiVersion: '1',
+				method: 'GET',
+				path: `/sites/${ siteId }/activity`,
+				query: pick( KNOWN_PARAMS, params ),
+			},
+			action
+		)
+	);
 };
 
 // FIXME: Implement fromApi
@@ -50,16 +46,11 @@ export const receiveActivityLog = ( { dispatch }, { siteId }, data ) => {
 };
 
 export const receiveActivityLogError = ( { dispatch }, { siteId }, error ) => {
-	dispatch( activityLogError(
-		siteId,
-		pick( error, [ 'error', 'status', 'message' ]
-	) ) );
+	dispatch( activityLogError( siteId, pick( error, [ 'error', 'status', 'message' ] ) ) );
 };
 
 export default {
-	[ ACTIVITY_LOG_REQUEST ]: [ dispatchRequest(
-		handleActivityLogRequest,
-		receiveActivityLog,
-		receiveActivityLogError
-	) ],
+	[ ACTIVITY_LOG_REQUEST ]: [
+		dispatchRequest( handleActivityLogRequest, receiveActivityLog, receiveActivityLogError ),
+	],
 };

--- a/client/state/data-layer/wpcom/sites/activity/index.js
+++ b/client/state/data-layer/wpcom/sites/activity/index.js
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import { pick } from 'lodash';
+import { get, pick } from 'lodash';
 
 /**
  * Internal dependencies
@@ -15,14 +15,18 @@ import { activityLogError, activityLogUpdate } from 'state/activity-log/actions'
 const KNOWN_PARAMS = [ 'action', 'date_end', 'date_start', 'group', 'name', 'number' ];
 
 export const handleActivityLogRequest = ( { dispatch }, action ) => {
-	const { params, siteId } = action;
+	const { siteId } = action;
 
-	if ( params.dateEnd ) {
-		params.date_end = params.dateEnd;
+	const query = pick( action.params, KNOWN_PARAMS );
+
+	const dateEnd = get( action.params, 'dateEnd' );
+	if ( dateEnd ) {
+		query.date_end = dateEnd;
 	}
 
-	if ( params.dateStart ) {
-		params.date_start = params.dateStart;
+	const dateStart = get( action.params, 'dateStart' );
+	if ( dateStart ) {
+		query.date_start = dateStart;
 	}
 
 	dispatch(
@@ -31,7 +35,7 @@ export const handleActivityLogRequest = ( { dispatch }, action ) => {
 				apiVersion: '1',
 				method: 'GET',
 				path: `/sites/${ siteId }/activity`,
-				query: pick( KNOWN_PARAMS, params ),
+				query,
 			},
 			action
 		)

--- a/client/state/data-layer/wpcom/sites/activity/index.js
+++ b/client/state/data-layer/wpcom/sites/activity/index.js
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import { get, includes, reduce } from 'lodash';
+import { get, includes, pick, reduce } from 'lodash';
 
 /**
  * Internal dependencies

--- a/client/state/data-layer/wpcom/sites/activity/test/index.js
+++ b/client/state/data-layer/wpcom/sites/activity/test/index.js
@@ -115,9 +115,7 @@ describe( 'handleActivityLogRequest', () => {
 			apiVersion: '1',
 			method: 'GET',
 			path: `/sites/${ SITE_ID }/activity`,
-			query: {
-				number: 1000,
-			},
+			query: {},
 		}, action ) );
 	} );
 


### PR DESCRIPTION
Adds by-month querying to Activity Log.
Adds props to `QueryActivityLog` component.
Handles query parameters in data-layer.
Removes log period (month) from `ActivityLog` component. This should be handled elsewhere (e.g. via selector).

## Testing
1. Visit https://calypso.live/stats/activity?branch=update/activitylog-query-month
1. Navigate between months.
1. Verify that the activity updates by month.
1. A short delay while the network responds with new activity is expected. Log filtering has been removed from the component and will be restored at the data/selector level (see #17135).

## Screens

![activity-month](https://user-images.githubusercontent.com/841763/29285431-ca2ef7f8-812e-11e7-94ba-b2c8e672fb52.gif)