### PR TITLE
Simple Payments: Use empty-content in upgrade jetpack dialog

### DIFF
--- a/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
@@ -387,15 +387,13 @@ class SimplePaymentsDialog extends Component {
 				<EmptyContent
 					className="upgrade-jetpack"
 					illustration="/calypso/images/illustrations/illustration-jetpack.svg"
-					title={ translate( 'Upgrade Jetpack to use Simple Payments feature' ) }
+					title={ translate( 'Upgrade Jetpack to use Simple Payments' ) }
 					illustrationWidth={ 600 }
 					action={
 						<Banner
 							icon="star"
 							title={ translate( 'Upgrade your Jetpack!' ) }
-							description={ translate(
-								'Simple Payments feature requires Jetpack version 5.2 or later.'
-							) }
+							description={ translate( 'Simple Payments requires Jetpack version 5.2 or later.' ) }
 							feature={ FEATURE_SIMPLE_PAYMENTS }
 							plan={ PLAN_PREMIUM }
 							href={ '../../plugins/jetpack/' + siteSlug }

--- a/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
@@ -385,12 +385,12 @@ class SimplePaymentsDialog extends Component {
 		if ( ! shouldQuerySitePlans && isJetpackNotSupported ) {
 			return this.renderEmptyDialog(
 				<EmptyContent
+					className="upgrade-jetpack"
 					illustration="/calypso/images/illustrations/illustration-jetpack.svg"
 					title={ translate( 'Upgrade Jetpack to use Simple Payments feature' ) }
 					illustrationWidth={ 600 }
 					action={
 						<Banner
-							className="upgrade-jetpack"
 							icon="star"
 							title={ translate( 'Upgrade your Jetpack!' ) }
 							description={ translate(

--- a/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
@@ -13,6 +13,7 @@ import { find, isNumber, pick, noop, get } from 'lodash';
  * Internal dependencies
  */
 import { getSelectedSiteId } from 'state/ui/selectors';
+import { getSiteSlug } from 'state/sites/selectors';
 import { isJetpackSite, isJetpackMinimumVersion } from 'state/sites/selectors';
 import { getSimplePayments } from 'state/selectors';
 import QuerySimplePayments from 'components/data/query-simple-payments';
@@ -35,12 +36,13 @@ import {
 	receiveUpdateProduct,
 	receiveDeleteProduct,
 } from 'state/simple-payments/product-list/actions';
-import { FEATURE_SIMPLE_PAYMENTS } from 'lib/plans/constants';
+import { PLAN_PREMIUM, FEATURE_SIMPLE_PAYMENTS } from 'lib/plans/constants';
 import { hasFeature, getSitePlanSlug } from 'state/sites/plans/selectors';
 import UpgradeNudge from 'my-sites/upgrade-nudge';
 import TrackComponentView from 'lib/analytics/track-component-view';
 import { recordTracksEvent } from 'state/analytics/actions';
 import EmptyContent from 'components/empty-content';
+import Banner from 'components/banner';
 
 // Utility function for checking the state of the Payment Buttons list
 const isEmptyArray = a => Array.isArray( a ) && a.length === 0;
@@ -364,6 +366,7 @@ class SimplePaymentsDialog extends Component {
 			showDialog,
 			onClose,
 			siteId,
+			siteSlug,
 			paymentButtons,
 			currencyCode,
 			isJetpackNotSupported,
@@ -381,11 +384,25 @@ class SimplePaymentsDialog extends Component {
 
 		if ( ! shouldQuerySitePlans && isJetpackNotSupported ) {
 			return this.renderEmptyDialog(
-				<Notice
-					status="is-error"
-					text={ translate( 'Please upgrade to Jetpack 5.2 to use Simple Payments feature' ) }
-					onDismissClick={ onClose }
-				/>
+				<EmptyContent
+					illustration="/calypso/images/illustrations/illustration-jetpack.svg"
+					title={ translate( 'Upgrade Jetpack to use Simple Payments feature' ) }
+					illustrationWidth={ 600 }
+					action={
+						<Banner
+							className="upgrade-jetpack"
+							icon="star"
+							title={ translate( 'Upgrade your Jetpack!' ) }
+							description={ translate(
+								'Simple Payments feature requires Jetpack version 5.2 or later.'
+							) }
+							feature={ FEATURE_SIMPLE_PAYMENTS }
+							plan={ PLAN_PREMIUM }
+							href={ '../../plugins/jetpack/' + siteSlug }
+						/>
+					}
+				/>,
+				true
 			);
 		}
 
@@ -457,6 +474,7 @@ export default connect( ( state, { siteId } ) => {
 
 	return {
 		siteId,
+		siteSlug: getSiteSlug( state, siteId ),
 		paymentButtons: getSimplePayments( state, siteId ),
 		currencyCode: getCurrentUserCurrencyCode( state ),
 		shouldQuerySitePlans: getSitePlanSlug( state, siteId ) === null,

--- a/client/components/tinymce/plugins/simple-payments/style.scss
+++ b/client/components/tinymce/plugins/simple-payments/style.scss
@@ -76,8 +76,15 @@
 		width: 70%;
 	}
 
-	.upgrade-jetpack.banner {
-		text-align: left;
+	.upgrade-jetpack {
+		.empty-content__illustration {
+			margin-bottom: -35px;
+			min-height: 0;
+		}
+		.banner {
+			text-align: left;
+			text-decoration: none;
+		}
 	}
 }
 

--- a/client/components/tinymce/plugins/simple-payments/style.scss
+++ b/client/components/tinymce/plugins/simple-payments/style.scss
@@ -75,6 +75,10 @@
 		text-align: left;
 		width: 70%;
 	}
+
+	.upgrade-jetpack.banner {
+		text-align: left;
+	}
 }
 
 .editor-simple-payments-modal__nudge-nudge {


### PR DESCRIPTION
This PR enhances Upgrade Jetpack dialog using `empty-content` as mentioned in PR #16825 and `banner`.

<img width="856" alt="screenshot_333" src="https://user-images.githubusercontent.com/127594/29328428-5d3345c2-81a7-11e7-9af2-b2c6fb5779e5.png">

Test Plan:

1. Start editing a post on site with Jetpack version older than 5.2
2. Try using "Add Payment Button" menu item.
3. You should see the dialog above.
4. Clicking on the upgrade banner should navigate to Jetpack plugin page.
 