### PR TITLE
Media: update keyring request

### DIFF
--- a/client/my-sites/media-library/content.scss
+++ b/client/my-sites/media-library/content.scss
@@ -24,7 +24,7 @@
 }
 
 .media-library__connect-message {
-	max-width: 480px;
+	max-width: 520px;
 	padding: 36px;
 	margin: 0 auto;
 	text-align: center;

--- a/client/my-sites/media-library/test/index.jsx
+++ b/client/my-sites/media-library/test/index.jsx
@@ -1,0 +1,84 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+import React from 'react';
+import { mount } from 'enzyme';
+import { stub } from 'sinon';
+
+/**
+ * Internal dependencies
+ */
+import useFakeDom from 'test/helpers/use-fake-dom';
+import useMockery from 'test/helpers/use-mockery';
+
+const emptyComponent = () => null;
+
+describe( 'MediaLibrary', () => {
+	let MediaLibrary, requestStub;
+
+	useFakeDom();
+	useMockery();
+
+	const store = {
+		getState: () => ( {} ),
+		dispatch: () => false,
+		subscribe: () => false,
+	};
+
+	useMockery( mockery => {
+		requestStub = stub();
+		mockery.registerMock( 'components/data/query-preferences', emptyComponent );
+		mockery.registerMock( './filter-bar', emptyComponent );
+		mockery.registerMock( './content', emptyComponent );
+		mockery.registerMock( './drop-zone', emptyComponent );
+		mockery.registerMock( 'components/data/media-validation-data', emptyComponent );
+		mockery.registerMock( 'lib/media/library-selected-store', emptyComponent );
+		mockery.registerMock( 'lib/media/actions', emptyComponent );
+		mockery.registerMock( 'state/sharing/keyring/selectors', {
+			getKeyringConnections: emptyComponent,
+			isKeyringConnectionsFetching: emptyComponent,
+		} );
+		mockery.registerMock( 'state/sharing/keyring/actions', {
+			requestKeyringConnections: requestStub
+		} );
+	} );
+
+	before( () => {
+		MediaLibrary = require( '..' );
+	} );
+
+	beforeEach( () => {
+		requestStub.reset();
+	} );
+
+	const getItem = source => mount( <MediaLibrary store={ store } source={ source } /> );
+
+	context( 'keyring request', () => {
+		it( 'is issued when component mounted and viewing an external source', () => {
+			getItem( 'google_photos' );
+
+			expect( requestStub ).to.have.been.calledOnce;
+		} );
+
+		it( 'is not issued when component mounted and viewing wordpress', () => {
+			getItem( '' );
+
+			expect( requestStub ).to.have.not.been.notCalled;
+		} );
+
+		it( 'is issued when component source changes and now viewing an external source', () => {
+			const library = getItem( '' );
+
+			library.setProps( { source: 'google_photos' } );
+			expect( requestStub ).to.have.been.calledOnce;
+		} );
+
+		it( 'is not issued when component source changes and not viewing an external source', () => {
+			const library = getItem( '' );
+
+			library.setProps( { source: '' } );
+			expect( requestStub ).to.have.not.been.notCalled;
+		} );
+	} );
+} );


### PR DESCRIPTION
When trying to view external media data we make a keyring request to see if we are connected. This currently happens in the media library content.

This PR moves the request into the root of the media library, making the result available to all child components. This is needed to allow us to disable the search box when the service is unconnected.

One side benefit of this is that we now only make the request once when the media library is opened, not every time we switch to Google Photos.

No other functionality should change here, it's just moving things up a level.

## Testing

Run the included unit test:

`npm run test-client client/my-sites/media-library/test/index.jsx`

Manually check:
1. Open Google Photos in the media library modal when connected. Verify that media library shows Google results
1. Open Google Photos when disconnected. Verify that the media library shows a message prompting you to connect
