### PR TITLE
Media: connect to Google direct from media library

### DIFF
--- a/client/my-sites/media-library/content.jsx
+++ b/client/my-sites/media-library/content.jsx
@@ -29,6 +29,7 @@ import { getSiteSlug } from 'state/sites/selectors';
 import MediaLibraryHeader from './header';
 import MediaLibraryExternalHeader from './external-media-header';
 import MediaLibraryList from './list';
+import InlineConnection from 'my-sites/sharing/connections/inline-connection';
 import { isKeyringConnectionsFetching } from 'state/sharing/keyring/selectors';
 
 class MediaLibraryContent extends React.Component {
@@ -191,17 +192,15 @@ class MediaLibraryContent extends React.Component {
 
 	renderExternalMedia() {
 		const connectMessage = translate(
-			'To show Photos from Google, you need to connect your Google account. Do that from {{link}}your Sharing settings{{/link}}.', {
-				components: {
-					link: <a href={ `/sharing/${ this.props.site.slug }` } onClick={ this.goToSharing } />
-				}
-			}
+			'To show Photos from Google, you need to connect your Google account.'
 		);
 
 		return (
 			<div className="media-library__connect-message">
 				<p><img src="/calypso/images/sharing/google-photos-logo.svg" width="96" height="96" /></p>
 				<p>{ connectMessage }</p>
+
+				<InlineConnection serviceName="google_photos" />
 			</div>
 		);
 	}

--- a/client/my-sites/media-library/filter-bar.jsx
+++ b/client/my-sites/media-library/filter-bar.jsx
@@ -35,6 +35,7 @@ export class MediaLibraryFilterBar extends Component {
 		onSearch: PropTypes.func,
 		translate: PropTypes.func,
 		post: PropTypes.bool,
+		isConnected: PropTypes.bool,
 	};
 
 	static defaultProps ={
@@ -44,7 +45,8 @@ export class MediaLibraryFilterBar extends Component {
 		onSearch: noop,
 		translate: identity,
 		source: '',
-		post: false
+		post: false,
+		isConnected: true,
 	};
 
 	getSearchPlaceholderText() {
@@ -134,7 +136,7 @@ export class MediaLibraryFilterBar extends Component {
 	}
 
 	renderSearchSection() {
-		if ( this.props.filterRequiresUpgrade ) {
+		if ( this.props.filterRequiresUpgrade || ! this.props.isConnected ) {
 			return null;
 		}
 

--- a/client/my-sites/sharing/connections/inline-connection-action.jsx
+++ b/client/my-sites/sharing/connections/inline-connection-action.jsx
@@ -1,0 +1,127 @@
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+
+/**
+ * Internal dependencies
+ */
+import ServiceAction from './service-action';
+import { requestKeyringConnections } from 'state/sharing/keyring/actions';
+import { getKeyringConnections } from 'state/sharing/keyring/selectors';
+import { recordGoogleEvent } from 'state/analytics/actions';
+import requestExternalAccess from 'lib/sharing';
+import { isKeyringConnectionsFetching } from 'state/sharing/keyring/selectors';
+
+export const getNamedConnectedService = ( state, name ) => getKeyringConnections( state ).filter( item => item.service === name );
+
+const STATUS_UNKNOWN = 'unknown';
+const STATUS_NOT_CONNECTED = 'not-connected';
+const STATUS_RECONNECT = 'reconnect';
+const STATUS_CONNECTED = 'connected';
+
+class InlineConnectButton extends Component {
+	static propTypes = {
+		service: PropTypes.object.isRequired,
+		isFetching: PropTypes.bool.isRequired,
+		connectedService: PropTypes.object,
+	};
+
+	constructor( props ) {
+		super( props );
+
+		this.handleAction = this.onAction.bind( this );
+		this.state = {
+			isConnecting: false,
+			isRefreshing: false,
+		};
+	}
+
+	getConnectionStatus( service, isFetching ) {
+		if ( isFetching ) {
+			return STATUS_UNKNOWN;
+		}
+
+		if ( ! service ) {
+			return STATUS_NOT_CONNECTED;
+		}
+
+		if ( service.status === 'broken' ) {
+			return STATUS_RECONNECT;
+		}
+
+		return STATUS_CONNECTED;
+	}
+
+	onAction() {
+		const { service } = this.props;
+		const connectionStatus = this.getConnectionStatus( this.props.connectedService, this.state.isFetching );
+
+		if ( STATUS_RECONNECT === connectionStatus ) {
+			this.refresh( service );
+		} else {
+			this.addConnection( service );
+		}
+	}
+
+	refresh( service ) {
+		this.setState( { isRefreshing: true } );
+		this.requestAccess( service.refresh_URL );
+		this.trackEvent( service.ID, 'Clicked Connect Button' );
+	}
+
+	addConnection( service ) {
+		this.setState( { isConnecting: true } );
+		this.requestAccess( service.connect_URL );
+		this.trackEvent( service.ID, 'Clicked Reconnect Button' );
+	}
+
+	requestAccess( url ) {
+		requestExternalAccess( url, () => {
+			this.props.requestKeyringConnections();
+		} );
+	}
+
+	trackEvent( id, eventName ) {
+		this.props.recordGoogleEvent( 'Sharing', eventName, id );
+	}
+
+	componentWillReceiveProps( nextProps ) {
+		if ( nextProps.isFetching === true ) {
+			this.setState( { isConnecting: false, isRefreshing: false } );
+		}
+	}
+
+	render() {
+		const connectionStatus = this.getConnectionStatus( this.props.connectedService, this.props.isFetching );
+		const { isConnecting, isRefreshing } = this.state;
+		const { service } = this.props;
+
+		return (
+			<ServiceAction
+				status={ connectionStatus }
+				service={ service }
+				onAction={ this.handleAction }
+				isConnecting={ isConnecting }
+				isRefreshing={ isRefreshing }
+				isDisconnecting={ false } />
+		);
+	}
+}
+
+export default connect(
+	( state, props ) => {
+		const named = getNamedConnectedService( state, props.serviceName );
+
+		return {
+			isFetching: isKeyringConnectionsFetching( state ),
+			connectedService: named.length > 0 ? named[ 0 ] : null,
+		};
+	},
+	{
+		requestKeyringConnections,
+		recordGoogleEvent,
+	}
+)( InlineConnectButton );

--- a/client/my-sites/sharing/connections/inline-connection.jsx
+++ b/client/my-sites/sharing/connections/inline-connection.jsx
@@ -1,0 +1,37 @@
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+
+/**
+ * Internal dependencies
+ */
+import { getKeyringServiceByName } from 'state/sharing/services/selectors';
+import QueryKeyringServices from 'components/data/query-keyring-services';
+import QueryPublicizeConnections from 'components/data/query-publicize-connections';
+import InlineConnectionAction from 'my-sites/sharing/connections/inline-connection-action';
+
+class InlineConnection extends Component {
+	static propTypes = {
+		serviceName: PropTypes.string.isRequired,
+	};
+
+	render() {
+		const { service } = this.props;
+
+		return (
+			<div>
+				<QueryPublicizeConnections selectedSite />
+				<QueryKeyringServices />
+
+				{ service && <InlineConnectionAction service={ service } /> }
+			</div>
+		);
+	}
+}
+
+export default connect( ( state, props ) => ( {
+	service: getKeyringServiceByName( state, props.serviceName ),
+} ) )( InlineConnection );


### PR DESCRIPTION
Rather than link the user to the Sharing page we now let them connect to Google directly from the media library.

<img width="735" alt="sharing" src="https://user-images.githubusercontent.com/1277682/28874522-1ab29e2c-778a-11e7-9cf4-697a7d2254e5.png">

Clicking the connect button opens the standard Google connection window:

<img width="407" alt="popup" src="https://user-images.githubusercontent.com/1277682/28874536-33f998ea-778a-11e7-875b-401c3f38a633.png">

Once connected the media library will refresh with content from Google.

## Testing

Run included test:
`npm run test-client client/my-sites/media-library/test/index.jsx`

Also:
1. From the Sharing page disconnect from Google
1. Edit a post, pick Google photos from the media dropdown, and verify that the connect button is shown as above, and that the refresh button and search box are not shown
1. Click the connect button and verify that a popup window appears allowing you to connect to Google
1. Verify that the 'connect' button has now changed to 'connecting'
1. Close the popup window and verify the button changes back to 'Connect'
1. Repeat the connection and complete it - verify that the button and message is replaced with the contents of your Google Photos library