### PR TITLE
Store landing page: update copy per marketing's review

### DIFF
--- a/client/extensions/woocommerce/app/dashboard/required-plugins-install-view.js
+++ b/client/extensions/woocommerce/app/dashboard/required-plugins-install-view.js
@@ -339,9 +339,9 @@ class RequiredPluginsInstallView extends Component {
 					imageWidth={ 160 }
 					title={ translate( 'Have something to sell?' ) }
 					subtitle={ translate(
-						'If you\'re located in the {{strong}}United States{{/strong}} ' +
-						'or {{strong}}Canada{{/strong}}, you can now add a store to sell your physical ' +
-						'products right on your site!',
+						'If you\'re in the {{strong}}United States{{/strong}} ' +
+						'or {{strong}}Canada{{/strong}}, you can sell your products right on ' +
+						'your site and ship them to customers in a snap!',
 						{
 							components: { strong: <strong /> }
 						}


### PR DESCRIPTION
When you first click on Store, you reach this landing page: 
![screen shot 2017-08-10 at 12 42 36 pm](https://user-images.githubusercontent.com/5835847/29284071-84a23a58-80e6-11e7-8223-0c39b26cd790.png)

After a copy review by @avivapinchas, the copy here has been changed to read: 

> If you’re in the United States or Canada, you can sell your products right on your site and ship them to customers in a snap!

To test: 
1. Click on "Store" on a site that has not had store set up on it
2. Notice that the copy now reads: `If you’re in the United States or Canada, you can sell your products right on your site and ship them to customers in a snap!`