### PR TITLE
Components: Create ExtensionRedirect, use in WPSC

### DIFF
--- a/client/blocks/extension-redirect/README.md
+++ b/client/blocks/extension-redirect/README.md
@@ -1,0 +1,30 @@
+Extension Redirect
+==================
+
+`<ExtensionRedirect />` is a React component that conditionally redirects a user from an
+extension page to the corresponding plugin installation page, if the corresponding plugin
+isn't installed on the given site.
+
+## Usage
+
+Render the component, passing `siteId` and `pluginId`. It does not accept any children, nor does it render any elements to the page. Use it near the top level of your extension page.
+
+## Props
+
+### `pluginId`
+
+<table>
+	<tr><th>Type</th><td>String</td></tr>
+	<tr><th>Required</th><td>Yes</td></tr>
+</table>
+
+The ID of the plugin for which to check.
+
+### `siteId`
+
+<table>
+	<tr><th>Type</th><td>Number</td></tr>
+	<tr><th>Required</th><td>Yes</td></tr>
+</table>
+
+The ID of the site on which to check whether the plugin is installed.

--- a/client/blocks/extension-redirect/README.md
+++ b/client/blocks/extension-redirect/README.md
@@ -3,7 +3,7 @@ Extension Redirect
 
 `<ExtensionRedirect />` is a React component that conditionally redirects a user from an
 extension page to the corresponding plugin installation page, if the corresponding plugin
-isn't installed on the given site.
+isn't installed or activated on the given site.
 
 ## Usage
 
@@ -27,4 +27,4 @@ The ID of the plugin for which to check.
 	<tr><th>Required</th><td>Yes</td></tr>
 </table>
 
-The ID of the site on which to check whether the plugin is installed.
+The ID of the site on which to check whether the plugin is installed and activated.

--- a/client/blocks/extension-redirect/index.jsx
+++ b/client/blocks/extension-redirect/index.jsx
@@ -1,0 +1,52 @@
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import page from 'page';
+
+/**
+ * Internal dependencies
+ */
+import { getSite, getSiteSlug } from 'state/sites/selectors';
+import { getPluginOnSite, isRequesting } from 'state/plugins/installed/selectors';
+import QueryJetpackPlugins from 'components/data/query-jetpack-plugins';
+
+class ExtensionRedirect extends Component {
+	static propTypes = {
+		pluginId: PropTypes.string.isRequired,
+		pluginInstalled: PropTypes.bool.isRequired,
+		requestingPlugins: PropTypes.bool.isRequired,
+		siteId: PropTypes.number
+	}
+
+	componentWillReceiveProps( nextProps ) {
+		// Has the request completed, and no data have been fetched?
+		if ( this.props.requestingPlugins && ! nextProps.requestingPlugins && ! nextProps.pluginInstalled ) {
+			page.redirect( `/plugins/${ nextProps.pluginId }/${ nextProps.siteSlug }` );
+		}
+	}
+
+	render() {
+		if ( ! this.props.siteId ) {
+			return null;
+		}
+
+		return (
+			<QueryJetpackPlugins siteIds={ [ this.props.siteId ] } />
+		);
+	}
+}
+
+export default connect(
+	( state, { pluginId, siteId } ) => {
+		const site = getSite( state, siteId );
+
+		return {
+			pluginInstalled: !! ( site && getPluginOnSite( state, site, pluginId ) ),
+			requestingPlugins: isRequesting( state, siteId ),
+			siteSlug: getSiteSlug( state, siteId ),
+		};
+	}
+)( ExtensionRedirect );

--- a/client/blocks/extension-redirect/index.jsx
+++ b/client/blocks/extension-redirect/index.jsx
@@ -47,7 +47,7 @@ export default connect(
 		const site = getSite( state, siteId );
 
 		return {
-			pluginActive: !! site && get( getPluginOnSite( state, site, pluginId ), 'active' ),
+			pluginActive: !! site && get( getPluginOnSite( state, site, pluginId ), 'active', false ),
 			requestingPlugins: isRequesting( state, siteId ),
 			siteSlug: getSiteSlug( state, siteId ),
 		};

--- a/client/blocks/extension-redirect/index.jsx
+++ b/client/blocks/extension-redirect/index.jsx
@@ -4,6 +4,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import { get } from 'lodash';
 import page from 'page';
 
 /**
@@ -16,14 +17,16 @@ import QueryJetpackPlugins from 'components/data/query-jetpack-plugins';
 class ExtensionRedirect extends Component {
 	static propTypes = {
 		pluginId: PropTypes.string.isRequired,
-		pluginInstalled: PropTypes.bool.isRequired,
+		siteId: PropTypes.number,
+		// Connected props
+		pluginActive: PropTypes.bool.isRequired,
 		requestingPlugins: PropTypes.bool.isRequired,
-		siteId: PropTypes.number
+		siteSlug: PropTypes.string,
 	}
 
 	componentWillReceiveProps( nextProps ) {
-		// Has the request completed, and no data have been fetched?
-		if ( this.props.requestingPlugins && ! nextProps.requestingPlugins && ! nextProps.pluginInstalled ) {
+		// Has the request completed? Is the plugin active?
+		if ( this.props.requestingPlugins && ! nextProps.requestingPlugins && ! nextProps.pluginActive ) {
 			page.redirect( `/plugins/${ nextProps.pluginId }/${ nextProps.siteSlug }` );
 		}
 	}
@@ -44,7 +47,7 @@ export default connect(
 		const site = getSite( state, siteId );
 
 		return {
-			pluginInstalled: !! ( site && getPluginOnSite( state, site, pluginId ) ),
+			pluginActive: !! site && get( getPluginOnSite( state, site, pluginId ), 'active' ),
 			requestingPlugins: isRequesting( state, siteId ),
 			siteSlug: getSiteSlug( state, siteId ),
 		};

--- a/client/extensions/wp-super-cache/app/main.jsx
+++ b/client/extensions/wp-super-cache/app/main.jsx
@@ -8,6 +8,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import ExtensionRedirect from 'blocks/extension-redirect';
 import AdvancedTab from '../components/advanced';
 import CdnTab from '../components/cdn';
 import ContentsTab from '../components/contents';
@@ -65,6 +66,7 @@ class WPSuperCache extends Component {
 
 		return (
 			<Main className={ mainClassName }>
+				<ExtensionRedirect pluginId="wp-super-cache" siteId={ siteId } />
 				<QueryStatus siteId={ siteId } />
 
 				{ cacheDisabled &&


### PR DESCRIPTION
On a site where the a plugin isn't installed and active, redirect `extensions/<extension>/<site>` to `plugins/<plugin>/<site>`, i.e. plugin installation/activation. Sort of implements the first two bullet points of p4TIVU-7vA-p2.

This will use the `componentDidReceiveProps` method to redirect iff `requestingPlugins` is `false`, and `pluginInstalled` is falsey. See #17219!

To test:
* Start from a JP site that has WPSC installed, e.g. `calypso.localhost:3000/extensions/wp-super-cache/<JPsiteWithWPSC>`
* Disable the plugin on that site, and try landing on `calypso.localhost:3000/extensions/wp-super-cache/<JPsiteWithWPSC>` again. Verify that you're redirected to  `calypso.localhost:3000/plugins/wp-super-cache/<JPsiteWithWPSC>` (where you can activate the plugin).
* Open the sidebar's site switcher, navigate to a JP site _without_ WPSC installed. Verify that you're redirected to  `calypso.localhost:3000/plugins/wp-super-cache/<JPsite>`, which sports an 'Install Now' button.
* Using the site switcher, navigate to a WP.com site without a Business upgrade. Verify that you're redirected to `calypso.localhost:3000/plugins/wp-super-cache/<WPCOMsite>`, which looks roughly the same, but with the 'Install Now' button disabled, and an upgrade prompt banner.