### PR TITLE
Media: Scarier media delete prompt

### DIFF
--- a/client/my-sites/media/main.jsx
+++ b/client/my-sites/media/main.jsx
@@ -192,12 +192,14 @@ class Media extends Component {
 	 * @param  {Function} [callback] - callback function
 	 */
 	deleteMedia( callback ) {
-		const site = this.props.selectedSite;
-		const selected = MediaLibrarySelectedStore.getAll( site.ID );
+		const { selectedSite, translate } = this.props;
+		const selected = MediaLibrarySelectedStore.getAll( selectedSite.ID );
 		const selectedCount = selected.length;
-		const confirmMessage = this.props.translate(
-			'Are you sure you want to permanently delete this item?',
-			'Are you sure you want to permanently delete these items?',
+		const confirmMessage = translate(
+			'Are you sure you want to delete this item? \
+It will be permanently removed from all other locations where it currently appears.',
+			'Are you sure you want to delete these items? \
+They will be permanently removed from all other locations where they currently appear.',
 			{ count: selectedCount }
 		);
 
@@ -210,6 +212,8 @@ class Media extends Component {
 			if ( callback ) {
 				callback();
 			}
+		}, translate( 'Delete' ), null, {
+			isScary: true
 		} );
 	}
 

--- a/client/my-sites/media/main.jsx
+++ b/client/my-sites/media/main.jsx
@@ -196,10 +196,10 @@ class Media extends Component {
 		const selected = MediaLibrarySelectedStore.getAll( selectedSite.ID );
 		const selectedCount = selected.length;
 		const confirmMessage = translate(
-			'Are you sure you want to delete this item? \
-It will be permanently removed from all other locations where it currently appears.',
-			'Are you sure you want to delete these items? \
-They will be permanently removed from all other locations where they currently appear.',
+			'Are you sure you want to delete this item? ' +
+			'It will be permanently removed from all other locations where it currently appears.',
+			'Are you sure you want to delete these items? ' +
+			'They will be permanently removed from all other locations where they currently appear.',
 			{ count: selectedCount }
 		);
 

--- a/client/post-editor/media-modal/index.jsx
+++ b/client/post-editor/media-modal/index.jsx
@@ -194,21 +194,26 @@ export class EditorMediaModal extends Component {
 	};
 
 	deleteMedia = () => {
+		const { view, mediaLibrarySelectedItems, translate } = this.props;
 		let selectedCount;
 
-		if ( ModalViews.DETAIL === this.props.view ) {
+		if ( ModalViews.DETAIL === view ) {
 			selectedCount = 1;
 		} else {
-			selectedCount = this.props.mediaLibrarySelectedItems.length;
+			selectedCount = mediaLibrarySelectedItems.length;
 		}
 
-		const confirmMessage = this.props.translate(
-			'Are you sure you want to permanently delete this item?',
-			'Are you sure you want to permanently delete these items?',
+		const confirmMessage = translate(
+			'Are you sure you want to delete this item? \
+It will be permanently removed from all other locations where it currently appears.',
+			'Are you sure you want to delete these items? \
+They will be permanently removed from all other locations where they currently appear.',
 			{ count: selectedCount }
 		);
 
-		accept( confirmMessage, this.confirmDeleteMedia );
+		accept( confirmMessage, this.confirmDeleteMedia, translate( 'Delete' ), null, {
+			isScary: true
+		} );
 	};
 
 	onAddMedia = () => {

--- a/client/post-editor/media-modal/index.jsx
+++ b/client/post-editor/media-modal/index.jsx
@@ -204,10 +204,10 @@ export class EditorMediaModal extends Component {
 		}
 
 		const confirmMessage = translate(
-			'Are you sure you want to delete this item? \
-It will be permanently removed from all other locations where it currently appears.',
-			'Are you sure you want to delete these items? \
-They will be permanently removed from all other locations where they currently appear.',
+			'Are you sure you want to delete this item? ' +
+			'It will be permanently removed from all other locations where it currently appears.',
+			'Are you sure you want to delete these items? ' +
+			'They will be permanently removed from all other locations where they currently appear.',
 			{ count: selectedCount }
 		);
 

--- a/client/post-editor/media-modal/test/index.jsx
+++ b/client/post-editor/media-modal/test/index.jsx
@@ -77,7 +77,8 @@ describe( 'EditorMediaModal', function() {
 		).instance();
 		tree.deleteMedia();
 
-		expect( accept ).to.have.been.calledWith( 'Are you sure you want to permanently delete this item?' );
+		expect( accept ).to.have.been.calledWith( 'Are you sure you want to delete this item? \
+It will be permanently removed from all other locations where it currently appears.' );
 		process.nextTick( function() {
 			expect( deleteMedia ).to.have.been.calledWith( DUMMY_SITE.ID, media );
 			done();
@@ -90,7 +91,8 @@ describe( 'EditorMediaModal', function() {
 		).instance();
 		tree.deleteMedia();
 
-		expect( accept ).to.have.been.calledWith( 'Are you sure you want to permanently delete these items?' );
+		expect( accept ).to.have.been.calledWith( 'Are you sure you want to delete these items? \
+They will be permanently removed from all other locations where they currently appear.' );
 		process.nextTick( function() {
 			expect( deleteMedia ).to.have.been.calledWith( DUMMY_SITE.ID, DUMMY_MEDIA );
 			done();
@@ -106,7 +108,8 @@ describe( 'EditorMediaModal', function() {
 		).instance();
 		tree.deleteMedia();
 
-		expect( accept ).to.have.been.calledWith( 'Are you sure you want to permanently delete this item?' );
+		expect( accept ).to.have.been.calledWith( 'Are you sure you want to delete this item? \
+It will be permanently removed from all other locations where it currently appears.' );
 		process.nextTick( function() {
 			expect( deleteMedia ).to.have.been.calledWith( DUMMY_SITE.ID, media );
 			done();
@@ -119,7 +122,8 @@ describe( 'EditorMediaModal', function() {
 		).instance();
 		tree.deleteMedia();
 
-		expect( accept ).to.have.been.calledWith( 'Are you sure you want to permanently delete this item?' );
+		expect( accept ).to.have.been.calledWith( 'Are you sure you want to delete this item? \
+It will be permanently removed from all other locations where it currently appears.' );
 		process.nextTick( function() {
 			expect( deleteMedia ).to.have.been.calledWith( DUMMY_SITE.ID, DUMMY_MEDIA[ 0 ] );
 			done();

--- a/client/post-editor/media-modal/test/index.jsx
+++ b/client/post-editor/media-modal/test/index.jsx
@@ -77,8 +77,8 @@ describe( 'EditorMediaModal', function() {
 		).instance();
 		tree.deleteMedia();
 
-		expect( accept ).to.have.been.calledWith( 'Are you sure you want to delete this item? \
-It will be permanently removed from all other locations where it currently appears.' );
+		expect( accept ).to.have.been.calledWith( 'Are you sure you want to delete this item? ' +
+			'It will be permanently removed from all other locations where it currently appears.' );
 		process.nextTick( function() {
 			expect( deleteMedia ).to.have.been.calledWith( DUMMY_SITE.ID, media );
 			done();
@@ -91,8 +91,8 @@ It will be permanently removed from all other locations where it currently appea
 		).instance();
 		tree.deleteMedia();
 
-		expect( accept ).to.have.been.calledWith( 'Are you sure you want to delete these items? \
-They will be permanently removed from all other locations where they currently appear.' );
+		expect( accept ).to.have.been.calledWith( 'Are you sure you want to delete these items? ' +
+			'They will be permanently removed from all other locations where they currently appear.' );
 		process.nextTick( function() {
 			expect( deleteMedia ).to.have.been.calledWith( DUMMY_SITE.ID, DUMMY_MEDIA );
 			done();
@@ -108,8 +108,8 @@ They will be permanently removed from all other locations where they currently a
 		).instance();
 		tree.deleteMedia();
 
-		expect( accept ).to.have.been.calledWith( 'Are you sure you want to delete this item? \
-It will be permanently removed from all other locations where it currently appears.' );
+		expect( accept ).to.have.been.calledWith( 'Are you sure you want to delete this item? ' +
+			'It will be permanently removed from all other locations where it currently appears.' );
 		process.nextTick( function() {
 			expect( deleteMedia ).to.have.been.calledWith( DUMMY_SITE.ID, media );
 			done();
@@ -122,8 +122,8 @@ It will be permanently removed from all other locations where it currently appea
 		).instance();
 		tree.deleteMedia();
 
-		expect( accept ).to.have.been.calledWith( 'Are you sure you want to delete this item? \
-It will be permanently removed from all other locations where it currently appears.' );
+		expect( accept ).to.have.been.calledWith( 'Are you sure you want to delete this item? ' +
+			'It will be permanently removed from all other locations where it currently appears.' );
 		process.nextTick( function() {
 			expect( deleteMedia ).to.have.been.calledWith( DUMMY_SITE.ID, DUMMY_MEDIA[ 0 ] );
 			done();


### PR DESCRIPTION
This PR makes media delete prompt scarier as requested in issue #10982.

Test Plans:

**Media Library**

1. Open My Sites > Media panel.

2. Select a media item then click Trash. You should see single item prompt as below.

<img width="480" alt="screenshot_329" src="https://user-images.githubusercontent.com/127594/29291827-adccf4aa-80f9-11e7-86bc-45a297cff0b1.png">

3. Select two media items then click Trash. You should see multi-item prompt as below.

<img width="480" alt="screenshot_330" src="https://user-images.githubusercontent.com/127594/29291837-b8ef2f92-80f9-11e7-9049-99c2de91088e.png">

**Media Dialog**

1. Edit a post then click Add Media from post editor.

2. Select a media item then click Trash. You should see single item prompt as below.

<img width="480" alt="screenshot_331" src="https://user-images.githubusercontent.com/127594/29291966-2ce432bc-80fa-11e7-8e5a-f583a39dd836.png">

3. Select two media items then click Trash. You should see multi-item prompt as below.

<img width="480" alt="screenshot_332" src="https://user-images.githubusercontent.com/127594/29291976-351266ca-80fa-11e7-8ed0-f7054139bd64.png">
