### PR TITLE
Color Schemes: Add Color Scheme Picker

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -26,6 +26,7 @@
 @import 'blocks/blog-stickers/style';
 @import 'blocks/calendar-button/style';
 @import 'blocks/calendar-popover/style';
+@import 'blocks/color-scheme-picker/style';
 @import 'blocks/comment-button/style';
 @import 'blocks/comment-detail/style';
 @import 'blocks/comments/style';

--- a/client/blocks/color-scheme-picker/README.md
+++ b/client/blocks/color-scheme-picker/README.md
@@ -18,7 +18,6 @@ handleColorSchemeSelection = event => {
 
 render() {
 	return (
-
 		<ColorSchemePicker
 			temporarySelection={ true }
 			onSelection={ this.handleColorSchemeSelection }

--- a/client/blocks/color-scheme-picker/README.md
+++ b/client/blocks/color-scheme-picker/README.md
@@ -9,7 +9,7 @@ When the props `temporarySelection` and `onSelection` are provided, a selection 
 
 ## Usage
 
-```es6
+```jsx
 import ColorSchemePicker from 'blocks/color-scheme-picker';
 
 handleColorSchemeSelection = event => {

--- a/client/blocks/color-scheme-picker/README.md
+++ b/client/blocks/color-scheme-picker/README.md
@@ -18,10 +18,7 @@ handleColorSchemeSelection = event => {
 
 render() {
 	return (
-		<ColorSchemePicker
-			temporarySelection={ true }
-			onSelection={ this.handleColorSchemeSelection }
-		/>
+		<ColorSchemePicker temporarySelection onSelection={ this.handleColorSchemeSelection } />
 	);
 }
 ```

--- a/client/blocks/color-scheme-picker/README.md
+++ b/client/blocks/color-scheme-picker/README.md
@@ -1,0 +1,67 @@
+Color Scheme Picker
+================
+
+This component renders a Color Scheme Picker.
+
+When using the component without any props, any selection will immediately be saved to the `colorSchemes` property in the `calypso_settings`.
+When the props `temporarySelection` and `onSelection` are provided, a selection will only be set locally and the provided onSelection handler called (e.g. to save the selection at a later stage via a save button).
+
+
+## Usage
+
+```es6
+import ColorSchemePicker from 'blocks/color-scheme-picker';
+
+handleColorSchemeSelection = event => {
+	console.log( event.currentTarget.value );
+};
+
+render() {
+	return (
+
+		<ColorSchemePicker
+			temporarySelection={ true }
+			onSelection={ this.handleColorSchemeSelection }
+		/>
+	);
+}
+```
+
+## Props
+
+The following props can be passed to the ColorSchemePicker component:
+
+### `temporarySelection`
+
+<table>
+	<tr><td>Type</td><td>Boolean</td></tr>
+	<tr><td>Required</td><td>No</td></tr>
+</table>
+
+### `onSelection`
+
+<table>
+	<tr><td>Type</td><td>Function</td></tr>
+	<tr><td>Required</td><td>No</td></tr>
+</table>
+
+
+#### Connect Props
+
+### `colorSchemePreference`
+
+<table>
+	<tr><td>Type</td><td>String</td></tr>
+</table>
+
+The selected color scheme (Default: default).
+
+### `saveColorSchemePreference`
+
+<table>
+	<tr><td>Type</td><td>Function</td></tr>
+</table>
+
+Set/Save the color scheme selection.
+
+

--- a/client/blocks/color-scheme-picker/constants.js
+++ b/client/blocks/color-scheme-picker/constants.js
@@ -6,21 +6,21 @@ export default function( translate ) {
 			label: translate( 'Default' ),
 			value: 'default',
 			thumbnail: {
-				cssClass: 'is-default-theme',
+				cssClass: 'is-default',
 			},
 		},
 		{
 			label: translate( 'Light' ),
 			value: 'light',
 			thumbnail: {
-				cssClass: 'is-light-theme',
+				cssClass: 'is-light',
 			},
 		},
 		{
 			label: translate( 'Dark' ),
 			value: 'dark',
 			thumbnail: {
-				cssClass: 'is-dark-theme',
+				cssClass: 'is-dark',
 			},
 		},
 	];

--- a/client/blocks/color-scheme-picker/constants.js
+++ b/client/blocks/color-scheme-picker/constants.js
@@ -1,29 +1,27 @@
 /** @format */
-/**
- * Internal dependencies
- */
-import { translate } from 'i18n-calypso';
 
-export const ColorSchemes = [
-	{
-		label: translate( 'Default' ),
-		value: 'default',
-		thumbnail: {
-			cssClass: 'is-default-theme',
+export default function( translate ) {
+	return [
+		{
+			label: translate( 'Default' ),
+			value: 'default',
+			thumbnail: {
+				cssClass: 'is-default-theme',
+			},
 		},
-	},
-	{
-		label: translate( 'Light' ),
-		value: 'light',
-		thumbnail: {
-			cssClass: 'is-light-theme',
+		{
+			label: translate( 'Light' ),
+			value: 'light',
+			thumbnail: {
+				cssClass: 'is-light-theme',
+			},
 		},
-	},
-	{
-		label: translate( 'Dark' ),
-		value: 'dark',
-		thumbnail: {
-			cssClass: 'is-dark-theme',
+		{
+			label: translate( 'Dark' ),
+			value: 'dark',
+			thumbnail: {
+				cssClass: 'is-dark-theme',
+			},
 		},
-	},
-];
+	];
+}

--- a/client/blocks/color-scheme-picker/constants.js
+++ b/client/blocks/color-scheme-picker/constants.js
@@ -1,0 +1,29 @@
+/** @format */
+/**
+ * Internal dependencies
+ */
+import { translate } from 'i18n-calypso';
+
+export const ColorSchemes = [
+	{
+		label: translate( 'Default' ),
+		value: 'default',
+		thumbnail: {
+			cssClass: 'is-default-theme',
+		},
+	},
+	{
+		label: translate( 'Light' ),
+		value: 'light',
+		thumbnail: {
+			cssClass: 'is-light-theme',
+		},
+	},
+	{
+		label: translate( 'Dark' ),
+		value: 'dark',
+		thumbnail: {
+			cssClass: 'is-dark-theme',
+		},
+	},
+];

--- a/client/blocks/color-scheme-picker/docs/example.jsx
+++ b/client/blocks/color-scheme-picker/docs/example.jsx
@@ -8,7 +8,6 @@ import React, { PureComponent } from 'react';
  * Internal dependencies
  */
 import Card from 'components/card';
-import Notice from 'components/notice';
 import ColorSchemePicker from 'blocks/color-scheme-picker';
 
 class ColorSchemePickerExample extends PureComponent {
@@ -26,12 +25,6 @@ class ColorSchemePickerExample extends PureComponent {
 		return (
 			<Card>
 				<ColorSchemePicker temporarySelection onSelection={ this.handleColorSchemeSelection } />
-
-				{ this.state.selectedColorScheme &&
-					<Notice
-						text={ `Selected color scheme: ${ this.state.selectedColorScheme }` }
-						showDismiss={ false }
-					/> }
 			</Card>
 		);
 	}

--- a/client/blocks/color-scheme-picker/docs/example.jsx
+++ b/client/blocks/color-scheme-picker/docs/example.jsx
@@ -25,10 +25,7 @@ class ColorSchemePickerExample extends PureComponent {
 	render() {
 		return (
 			<Card>
-				<ColorSchemePicker
-					temporarySelection={ true }
-					onSelection={ this.handleColorSchemeSelection }
-				/>
+				<ColorSchemePicker temporarySelection onSelection={ this.handleColorSchemeSelection } />
 
 				{ this.state.selectedColorScheme &&
 					<Notice

--- a/client/blocks/color-scheme-picker/docs/example.jsx
+++ b/client/blocks/color-scheme-picker/docs/example.jsx
@@ -1,0 +1,43 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import React, { PureComponent } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import Card from 'components/card';
+import Notice from 'components/notice';
+import ColorSchemePicker from 'blocks/color-scheme-picker';
+
+class ColorSchemePickerExample extends PureComponent {
+	static displayName = 'ColorSchemePicker';
+
+	state = {
+		selectedColorScheme: null,
+	};
+
+	handleColorSchemeSelection = colorScheme => {
+		this.setState( { selectedColorScheme: colorScheme } );
+	};
+
+	render() {
+		return (
+			<Card>
+				<ColorSchemePicker
+					temporarySelection={ true }
+					onSelection={ this.handleColorSchemeSelection }
+				/>
+
+				{ this.state.selectedColorScheme &&
+					<Notice
+						text={ `Selected color scheme: ${ this.state.selectedColorScheme }` }
+						showDismiss={ false }
+					/> }
+			</Card>
+		);
+	}
+}
+
+export default ColorSchemePickerExample;

--- a/client/blocks/color-scheme-picker/index.jsx
+++ b/client/blocks/color-scheme-picker/index.jsx
@@ -5,7 +5,7 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
+import { translate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -13,7 +13,7 @@ import { bindActionCreators } from 'redux';
 import QueryPreferences from 'components/data/query-preferences';
 import { savePreference, setPreference } from 'state/preferences/actions';
 import { getPreference } from 'state/preferences/selectors';
-import { ColorSchemes } from './constants';
+import getColorSchemesData from './constants';
 import FormRadiosBar from 'components/forms/form-radios-bar';
 
 class ColorSchemePicker extends PureComponent {
@@ -27,9 +27,11 @@ class ColorSchemePicker extends PureComponent {
 
 	handleColorSchemeSelection = event => {
 		const { temporarySelection, onSelection, saveColorSchemePreference } = this.props;
-		const addSelection = handleFunction => handleFunction( event.currentTarget.value );
-		temporarySelection && addSelection( onSelection );
-		addSelection( saveColorSchemePreference );
+		const { value } = event.currentTarget;
+		if ( temporarySelection ) {
+			onSelection( value );
+		}
+		saveColorSchemePreference( value, temporarySelection );
 	};
 
 	render() {
@@ -37,15 +39,20 @@ class ColorSchemePicker extends PureComponent {
 			<div className="color-scheme-picker">
 				<QueryPreferences />
 				<FormRadiosBar
-					isThumbnail={ true }
+					isThumbnail
 					checked={ this.props.colorSchemePreference }
 					onChange={ this.handleColorSchemeSelection }
-					items={ ColorSchemes }
+					items={ getColorSchemesData( translate ) }
 				/>
 			</div>
 		);
 	}
 }
+
+const saveColorSchemePreference = ( preference, temporarySelection ) =>
+	temporarySelection
+		? setPreference( 'colorScheme', preference )
+		: savePreference( 'colorScheme', preference );
 
 export default connect(
 	state => {
@@ -53,16 +60,5 @@ export default connect(
 			colorSchemePreference: getPreference( state, 'colorScheme' ),
 		};
 	},
-	( dispatch, ownProps ) =>
-		bindActionCreators(
-			{
-				saveColorSchemePreference: colorSchemePreference => {
-					if ( ownProps.temporarySelection ) {
-						return setPreference( 'colorScheme', colorSchemePreference );
-					}
-					return savePreference( 'colorScheme', colorSchemePreference );
-				},
-			},
-			dispatch
-		)
+	{ saveColorSchemePreference }
 )( ColorSchemePicker );

--- a/client/blocks/color-scheme-picker/index.jsx
+++ b/client/blocks/color-scheme-picker/index.jsx
@@ -1,0 +1,68 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+
+/**
+ * Internal dependencies
+ */
+import QueryPreferences from 'components/data/query-preferences';
+import { savePreference, setPreference } from 'state/preferences/actions';
+import { getPreference } from 'state/preferences/selectors';
+import { ColorSchemes } from './constants';
+import FormRadiosBar from 'components/forms/form-radios-bar';
+
+class ColorSchemePicker extends PureComponent {
+	static propTypes = {
+		temporarySelection: PropTypes.bool,
+		onSelection: PropTypes.func,
+		// Connected props
+		colorSchemePreference: PropTypes.string,
+		saveColorSchemePreference: PropTypes.func,
+	};
+
+	handleColorSchemeSelection = event => {
+		const { temporarySelection, onSelection, saveColorSchemePreference } = this.props;
+		const addSelection = handleFunction => handleFunction( event.currentTarget.value );
+		temporarySelection && addSelection( onSelection );
+		addSelection( saveColorSchemePreference );
+	};
+
+	render() {
+		return (
+			<div className="color-scheme-picker">
+				<QueryPreferences />
+				<FormRadiosBar
+					isThumbnail={ true }
+					checked={ this.props.colorSchemePreference }
+					onChange={ this.handleColorSchemeSelection }
+					items={ ColorSchemes }
+				/>
+			</div>
+		);
+	}
+}
+
+export default connect(
+	state => {
+		return {
+			colorSchemePreference: getPreference( state, 'colorScheme' ),
+		};
+	},
+	( dispatch, ownProps ) =>
+		bindActionCreators(
+			{
+				saveColorSchemePreference: colorSchemePreference => {
+					if ( ownProps.temporarySelection ) {
+						return setPreference( 'colorScheme', colorSchemePreference );
+					}
+					return savePreference( 'colorScheme', colorSchemePreference );
+				},
+			},
+			dispatch
+		)
+)( ColorSchemePicker );

--- a/client/blocks/color-scheme-picker/style.scss
+++ b/client/blocks/color-scheme-picker/style.scss
@@ -1,12 +1,12 @@
 .color-scheme-picker .form-radio-with-thumbnail__thumbnail {
 	height: 80px;
-	background-image: url( '/calypso/images/color-schemes/theme-default.png' );
+	background-image: url( '/calypso/images/color-schemes/color-scheme-thumbnail-default.svg' );
 
-	&.is-light-theme {
-		background-image: url( '/calypso/images/color-schemes/theme-light.png' );
+	&.is-light {
+		background-image: url( '/calypso/images/color-schemes/color-scheme-thumbnail-light.svg' );
 	}
 
-	&.is-dark-theme {
-		background-image: url( '/calypso/images/color-schemes/theme-dark.png' );
+	&.is-dark {
+		background-image: url( '/calypso/images/color-schemes/color-scheme-thumbnail-dark.svg' );
 	}
 }

--- a/client/blocks/color-scheme-picker/style.scss
+++ b/client/blocks/color-scheme-picker/style.scss
@@ -1,16 +1,12 @@
 .color-scheme-picker .form-radio-with-thumbnail__thumbnail {
-
 	height: 80px;
 	background-image: url( '/calypso/images/color-schemes/theme-default.png' );
 
 	&.is-light-theme {
-
 		background-image: url( '/calypso/images/color-schemes/theme-light.png' );
 	}
 
 	&.is-dark-theme {
-
 		background-image: url( '/calypso/images/color-schemes/theme-dark.png' );
-
 	}
 }

--- a/client/blocks/color-scheme-picker/style.scss
+++ b/client/blocks/color-scheme-picker/style.scss
@@ -1,0 +1,16 @@
+.color-scheme-picker .form-radio-with-thumbnail__thumbnail {
+
+	height: 80px;
+	background-image: url( '/calypso/images/color-schemes/theme-default.png' );
+
+	&.is-light-theme {
+
+		background-image: url( '/calypso/images/color-schemes/theme-light.png' );
+	}
+
+	&.is-dark-theme {
+
+		background-image: url( '/calypso/images/color-schemes/theme-dark.png' );
+
+	}
+}

--- a/client/components/forms/docs/example.jsx
+++ b/client/components/forms/docs/example.jsx
@@ -262,6 +262,7 @@ class FormFields extends React.PureComponent {
 							checked={ this.state.checkedRadio }
 							onChange={ this.handleRadioChange }
 						/>
+						<br />
 						<FormRadiosBarExample
 							isThumbnail={ true }
 							checked={ this.state.checkedRadio }

--- a/client/devdocs/design/blocks.jsx
+++ b/client/devdocs/design/blocks.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -77,6 +78,7 @@ import UploadImage from 'blocks/upload-image/docs/example';
 import ConversationCommentList from 'blocks/conversations/docs/example';
 import SimplePaymentsDialog from 'components/tinymce/plugins/simple-payments/dialog/docs/example';
 import ConversationCaterpillar from 'blocks/conversation-caterpillar/docs/example';
+import ColorSchemePicker from 'blocks/color-scheme-picker/docs/example';
 
 export default React.createClass( {
 	displayName: 'AppComponents',
@@ -170,6 +172,7 @@ export default React.createClass( {
 					<UploadImage />
 					<ConversationCommentList />
 					<ConversationCaterpillar />
+					<ColorSchemePicker />
 				</Collection>
 			</Main>
 		);

--- a/client/state/preferences/constants.js
+++ b/client/state/preferences/constants.js
@@ -1,3 +1,4 @@
+/** @format */
 export const USER_SETTING_KEY = 'calypso_preferences';
 
 export const DEFAULT_PREFERENCE_VALUES = {
@@ -10,4 +11,5 @@ export const DEFAULT_PREFERENCE_VALUES = {
 	mediaScale: 0.157,
 	editorAdvancedVisible: false,
 	editorConfirmationDisabledSites: [],
+	colorScheme: 'default',
 };

--- a/client/state/preferences/schema.js
+++ b/client/state/preferences/schema.js
@@ -56,5 +56,9 @@ export const remoteValuesSchema = {
 			type: 'array',
 			items: { type: 'number' }
 		},
+		colorScheme: {
+			type: 'string',
+			'enum': [ 'default', 'light', 'dark' ],
+		},
 	}
 };

--- a/public/images/color-schemes/color-scheme-thumbnail-dark.svg
+++ b/public/images/color-schemes/color-scheme-thumbnail-dark.svg
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="240px" height="160px" viewBox="0 0 240 160" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="background: #F3F6F8;">
+    <!-- Generator: Sketch 46.2 (44496) - http://www.bohemiancoding.com/sketch -->
+    <title>theme-color-scheme-thumbnail-dark</title>
+    <desc>Created with Sketch.</desc>
+    <defs></defs>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="theme-color-scheme-thumbnail-dark">
+            <rect id="sidebar-background" fill="#2E4453" x="0" y="20" width="70" height="140"></rect>
+            <rect id="sidebar-item-selected-background" fill="#537994" x="0" y="86" width="70" height="16"></rect>
+            <rect id="sidebar-item-selected" fill="#E9EFF3" x="7" y="91" width="55" height="6"></rect>
+            <rect id="sidebar-item" fill="#FFFFFF" x="7" y="75" width="37" height="6"></rect>
+            <rect id="sidebar-item" fill="#FFFFFF" x="7" y="107" width="29" height="6"></rect>
+            <rect id="sidebar-item" fill="#FFFFFF" x="7" y="123" width="45" height="6"></rect>
+            <circle id="avatar" fill="#C8D7E1" cx="35.5" cy="45.5" r="16.5"></circle>
+            <rect id="card" fill="#FFFFFF" x="90" y="36" width="130" height="107"></rect>
+            <rect id="masterbar" fill="#2E4453" x="0" y="0" width="240" height="20"></rect>
+        </g>
+    </g>
+</svg>

--- a/public/images/color-schemes/color-scheme-thumbnail-default.svg
+++ b/public/images/color-schemes/color-scheme-thumbnail-default.svg
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="240px" height="160px" viewBox="0 0 240 160" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="background: #F3F6F8;">
+    <!-- Generator: Sketch 46.2 (44496) - http://www.bohemiancoding.com/sketch -->
+    <title>theme-color-scheme-thumbnail-default</title>
+    <desc>Created with Sketch.</desc>
+    <defs></defs>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="theme-color-scheme-thumbnail-default">
+            <rect id="sidebar-background" fill="#E9EFF3" x="0" y="20" width="70" height="140"></rect>
+            <rect id="sidebar-item-selected-background" fill="#537994" x="0" y="86" width="70" height="16"></rect>
+            <rect id="sidebar-item-selected" fill="#FFFFFF" x="7" y="91" width="55" height="6"></rect>
+            <rect id="sidebar-item" fill="#2E4453" x="7" y="75" width="37" height="6"></rect>
+            <rect id="sidebar-item" fill="#2E4453" x="7" y="107" width="29" height="6"></rect>
+            <rect id="sidebar-item" fill="#2E4453" x="7" y="123" width="45" height="6"></rect>
+            <circle id="avatar" fill="#C8D7E1" cx="35.5" cy="45.5" r="16.5"></circle>
+            <rect id="card" fill="#FFFFFF" x="90" y="36" width="130" height="107"></rect>
+            <rect id="masterbar" fill="#0087BE" x="0" y="0" width="240" height="20"></rect>
+        </g>
+    </g>
+</svg>

--- a/public/images/color-schemes/color-scheme-thumbnail-light.svg
+++ b/public/images/color-schemes/color-scheme-thumbnail-light.svg
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="240px" height="160px" viewBox="0 0 240 160" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="background: #F3F6F8;">
+    <!-- Generator: Sketch 46.2 (44496) - http://www.bohemiancoding.com/sketch -->
+    <title>theme-color-scheme-thumbnail-light</title>
+    <desc>Created with Sketch.</desc>
+    <defs></defs>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="theme-color-scheme-thumbnail-light">
+            <rect id="sidebar-background" fill="#FFFFFF" x="0" y="20" width="70" height="140"></rect>
+            <rect id="sidebar-item-selected-background" fill="#E9EFF3" x="0" y="86" width="70" height="16"></rect>
+            <rect id="sidebar-item-selected" fill="#537994" x="7" y="91" width="55" height="6"></rect>
+            <rect id="sidebar-item" fill="#2E4453" x="7" y="75" width="37" height="6"></rect>
+            <rect id="sidebar-item" fill="#2E4453" x="7" y="107" width="29" height="6"></rect>
+            <rect id="sidebar-item" fill="#2E4453" x="7" y="123" width="45" height="6"></rect>
+            <circle id="avatar" fill="#C8D7E1" cx="35.5" cy="45.5" r="16.5"></circle>
+            <rect id="card" fill="#FFFFFF" x="90" y="36" width="130" height="107"></rect>
+            <rect id="masterbar" fill="#FFFFFF" x="0" y="0" width="240" height="20"></rect>
+        </g>
+    </g>
+</svg>


### PR DESCRIPTION
This PR is part of a series of PRs aiming to provide support for Color Schemes in Calypso.
This PR focuses on adding the color scheme picker based on the components added in PR https://github.com/Automattic/wp-calypso/pull/17157.

![color-scheme-picker](https://user-images.githubusercontent.com/1562646/29298929-969535be-816b-11e7-8291-c64b39e9d361.gif)

### Notable additions in this PR:
- The `<ColorSchemePicker>` component allows for the selection of a color scheme. 
- When using the component as is, any selection will immediately be saved to the `colorSchemes` property in the `calypso_settings`. When the props `temporarySelection` and `onSelection` are provided, any selection will only be set locally and the provided `onSelection` handler called (e.g. to save the selection via a save button in a form).
- The component is added to the `Blocks` overview page for future reference.


### How to test

Visit https://calypso.live/devdocs/blocks/color-scheme-picker?branch=add/color-schemes/color-scheme-picker or test locally.
Navigate to the `Blocks` overview page and proceed to the `ColorSchemePicker` section.

### Suggestions as to what to test
- Does the component behave as expected?
- Can the component easily be reused in the future?
- Is the current responsive behavior sufficient?

### Note
This PR currently compares its changes to PR https://github.com/Automattic/wp-calypso/pull/17157. This is so the changes can be easily identified. This PR will be pointed at `master` once PR https://github.com/Automattic/wp-calypso/pull/17157 has been merged. It also needs to be merged prior to PR https://github.com/Automattic/wp-calypso/pull/17259 which is based on this PR.

For a more detailed description of the feature, the chosen approach and its advantages feel free to check out my post on the subject: p4TIVU-75d-p2 (internal reference).
