### PR TITLE
Reader: Fix popover header padding in single sites

### DIFF
--- a/client/blocks/reader-share/style.scss
+++ b/client/blocks/reader-share/style.scss
@@ -97,3 +97,7 @@
 .sites-popover.reader-share__sites-popover .site-selector__sites {
 	max-height: 25vh;
 }
+
+.sites-popover.reader-share__sites-popover .popover__inner {
+	overflow: visible;
+}


### PR DESCRIPTION
This fixes: https://github.com/Automattic/wp-calypso/issues/16655

Before:
<img width="320" alt="screenshot 2017-08-14 22 03 10" src="https://user-images.githubusercontent.com/4924246/29302830-618dfe5c-813c-11e7-91a7-d24b7523ff58.png">

After:
<img width="320" alt="screenshot 2017-08-14 21 58 39" src="https://user-images.githubusercontent.com/4924246/29302837-6b9ccf0e-813c-11e7-9728-508dcbb313a3.png">

Still look good in Safari:
<img width="320" alt="screenshot 2017-08-14 21 58 39" src="https://user-images.githubusercontent.com/4924246/29302842-7dc7a938-813c-11e7-9d0f-5555251da7a9.png">

Popovers in multi-site accounts are unaffected by this change:
<img width="320" alt="screenshot 2017-08-14 22 01 37" src="https://user-images.githubusercontent.com/4924246/29302851-9331dd02-813c-11e7-8563-f75dab99a54c.png">