### PR TITLE
Combine the social auth info in a single place

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -18,8 +18,8 @@ import {
 	getRequestNotice,
 	getTwoFactorNotificationSent,
 	isTwoFactorEnabled,
-	getLinkingSocialUser,
-	getLinkingSocialService,
+	getSocialAccountIsLinking,
+	getSocialAccountLinkService,
 } from 'state/login/selectors';
 import { getOAuth2ClientData } from 'state/login/oauth2/selectors';
 import { recordTracksEvent } from 'state/analytics/actions';
@@ -44,7 +44,7 @@ class Login extends Component {
 		twoFactorEnabled: PropTypes.bool,
 		twoFactorNotificationSent: PropTypes.string,
 		socialConnect: PropTypes.bool,
-		linkingSocialUser: PropTypes.string,
+		isLinking: PropTypes.bool,
 		linkingSocialService: PropTypes.string,
 	};
 
@@ -73,7 +73,7 @@ class Login extends Component {
 				// If no notification is sent, the user is using the authenticator for 2FA by default
 				twoFactorAuthType: this.props.twoFactorNotificationSent.replace( 'none', 'authenticator' )
 			} ) );
-		} else if ( this.props.linkingSocialUser ) {
+		} else if ( this.props.isLinking ) {
 			page( login( {
 				isNative: true,
 				socialConnect: true,
@@ -84,7 +84,7 @@ class Login extends Component {
 	};
 
 	handleValid2FACode = () => {
-		if ( this.props.linkingSocialUser ) {
+		if ( this.props.isLinking ) {
 			page( login( {
 				isNative: true,
 				socialConnect: true,
@@ -250,9 +250,9 @@ export default connect(
 		requestNotice: getRequestNotice( state ),
 		twoFactorEnabled: isTwoFactorEnabled( state ),
 		twoFactorNotificationSent: getTwoFactorNotificationSent( state ),
-		linkingSocialUser: getLinkingSocialUser( state ),
-		linkingSocialService: getLinkingSocialService( state ),
 		oauth2ClientData: getOAuth2ClientData( state ),
+		isLinking: getSocialAccountIsLinking( state ),
+		linkingSocialService: getSocialAccountLinkService( state ),
 	} ), {
 		recordTracksEvent,
 	}

--- a/client/blocks/login/social-connect-prompt.jsx
+++ b/client/blocks/login/social-connect-prompt.jsx
@@ -13,8 +13,8 @@ import SocialLogo from 'social-logos';
 import Button from 'components/button';
 import Card from 'components/card';
 import {
-	getLinkingSocialAuthInfo,
-	getLinkingSocialService,
+	getSocialAccountLinkAuthInfo,
+	getSocialAccountLinkService,
 	getRedirectTo,
 } from 'state/login/selectors';
 import { connectSocialUser } from 'state/login/actions';
@@ -105,8 +105,8 @@ class SocialConnectPrompt extends Component {
 
 export default connect(
 	( state ) => ( {
-		linkingSocialAuthInfo: getLinkingSocialAuthInfo( state ),
-		linkingSocialService: getLinkingSocialService( state ),
+		linkingSocialAuthInfo: getSocialAccountLinkAuthInfo( state ),
+		linkingSocialService: getSocialAccountLinkService( state ),
 		redirectTo: getRedirectTo( state ),
 	} ),
 	{

--- a/client/components/signup-form/index.jsx
+++ b/client/components/signup-form/index.jsx
@@ -144,8 +144,10 @@ class SignupForm extends Component {
 		const userExistsError = this.getUserExistsError( props );
 
 		if ( userExistsError ) {
-			const { service, token } = props.step;
-			this.props.createSocialUserFailed( service, token, userExistsError );
+			const { service, id_token, access_token } = props.step;
+			const socialInfo = { service, id_token, access_token };
+
+			this.props.createSocialUserFailed( socialInfo, userExistsError );
 			page(
 				login( {
 					isNative: config.isEnabled( 'login/native-login-links' ),

--- a/client/state/login/actions.js
+++ b/client/state/login/actions.js
@@ -341,10 +341,9 @@ export const connectSocialUser = ( socialInfo, redirectTo ) => dispatch => {
 	} );
 };
 
-export const createSocialUserFailed = ( service, token, error ) => ( {
+export const createSocialUserFailed = ( socialInfo, error ) => ( {
 	type: SOCIAL_CREATE_ACCOUNT_REQUEST_FAILURE,
-	service,
-	token,
+	authInfo: socialInfo,
 	error: error.field ? error : getErrorFromWPCOMError( error )
 } );
 

--- a/client/state/login/reducer.js
+++ b/client/state/login/reducer.js
@@ -197,19 +197,21 @@ export const socialAccount = createReducer( { isCreating: false, createError: nu
 	[ LOGIN_REQUEST ]: state => ( { ...state, createError: null } ),
 } );
 
-export const socialAccountLink = createReducer( { isLinking: false }, {
-	[ SOCIAL_CREATE_ACCOUNT_REQUEST_FAILURE ]: ( state, { error, token, service } ) => {
-		if ( error.code === 'user_exists' ) {
-			return {
-				isLinking: true,
-				email: error.email,
-				token,
-				service,
-			};
-		}
+const userExistsErrorHandler = ( state, { error, authInfo } ) => {
+	if ( error.code === 'user_exists' ) {
+		return {
+			isLinking: true,
+			email: error.email,
+			authInfo,
+		};
+	}
 
-		return state;
-	},
+	return state;
+};
+
+export const socialAccountLink = createReducer( { isLinking: false }, {
+	[ SOCIAL_CREATE_ACCOUNT_REQUEST_FAILURE ]: userExistsErrorHandler,
+	[ SOCIAL_LOGIN_REQUEST_FAILURE ]: userExistsErrorHandler,
 	[ SOCIAL_CREATE_ACCOUNT_REQUEST_SUCCESS ]: () => ( { isLinking: false } ),
 	[ USER_RECEIVE ]: () => ( { isLinking: false } ),
 } );

--- a/client/state/login/reducer.js
+++ b/client/state/login/reducer.js
@@ -187,11 +187,9 @@ export const socialAccount = createReducer( { isCreating: false, createError: nu
 		bearerToken,
 		createError: null,
 	} ),
-	[ SOCIAL_LOGIN_REQUEST_FAILURE ]: ( state, { error, authInfo } ) => ( {
+	[ SOCIAL_LOGIN_REQUEST_FAILURE ]: ( state, { error } ) => ( {
 		...state,
 		requestError: error,
-		email: error.email,
-		authInfo
 	} ),
 	[ USER_RECEIVE ]: state => ( { ...state, bearerToken: null, username: null, createError: null, } ),
 	[ LOGIN_REQUEST ]: state => ( { ...state, createError: null } ),

--- a/client/state/login/selectors.js
+++ b/client/state/login/selectors.js
@@ -218,28 +218,20 @@ export const getCreateSocialAccountError = ( state ) => get( state, 'login.socia
 export const getRequestSocialAccountError = ( state ) => get( state, 'login.socialAccount.requestError', null );
 
 /***
- * Gets the email address of the social account to be linked.
+ * Gets the OAuth2 client data.
  *
  * @param  {Object}   state  Global state tree
- * @return {?String}         Email address of the social account.
+ * @return {Object}          OAuth2 client data
  */
-export const getLinkingSocialUser = ( state ) => get( state, 'login.socialAccount.email', null );
+export const getOAuth2ClientData = ( state ) => get( state, 'login.oauth2ClientData', null );
 
 /***
- * Gets the Service name of the social account to be linked.
+ * Determines if the OAuth2 layout should be used.
  *
  * @param  {Object}   state  Global state tree
- * @return {?String}         Service name of the social account.
+ * @return {Boolean}         Whether the OAuth2 layout should be used.
  */
-export const getLinkingSocialService = ( state ) => get( state, 'login.socialAccount.authInfo.service', null );
-
-/***
- * Gets the auth information of the social account to be linked.
- *
- * @param  {Object}   state  Global state tree
- * @return {?String}         Email address of the social account.
- */
-export const getLinkingSocialAuthInfo = ( state ) => get( state, 'login.socialAccount.authInfo', null );
+export const showOAuth2Layout = ( state ) => get( state, 'login.showOAuth2Layout', false );
 
 /***
  * Gets social account linking status
@@ -263,4 +255,12 @@ export const getSocialAccountLinkEmail = ( state ) => get( state, 'login.socialA
  * @param  {Object}   state  Global state tree
  * @return {?String}         service name that is being linked
  */
-export const getSocialAccountLinkService = ( state ) => get( state, 'login.socialAccountLink.service', null );
+export const getSocialAccountLinkService = ( state ) => get( state, 'login.socialAccountLink.authInfo.service', null );
+
+/***
+ * Gets the auth information of the social account to be linked.
+ *
+ * @param  {Object}   state  Global state tree
+ * @return {?String}         Email address of the social account.
+ */
+export const getSocialAccountLinkAuthInfo = ( state ) => get( state, 'login.socialAccountLink.authInfo', null );

--- a/client/state/login/selectors.js
+++ b/client/state/login/selectors.js
@@ -218,22 +218,6 @@ export const getCreateSocialAccountError = ( state ) => get( state, 'login.socia
 export const getRequestSocialAccountError = ( state ) => get( state, 'login.socialAccount.requestError', null );
 
 /***
- * Gets the OAuth2 client data.
- *
- * @param  {Object}   state  Global state tree
- * @return {Object}          OAuth2 client data
- */
-export const getOAuth2ClientData = ( state ) => get( state, 'login.oauth2ClientData', null );
-
-/***
- * Determines if the OAuth2 layout should be used.
- *
- * @param  {Object}   state  Global state tree
- * @return {Boolean}         Whether the OAuth2 layout should be used.
- */
-export const showOAuth2Layout = ( state ) => get( state, 'login.showOAuth2Layout', false );
-
-/***
  * Gets social account linking status
  *
  * @param  {Object}   state  Global state tree

--- a/client/state/login/test/reducer.js
+++ b/client/state/login/test/reducer.js
@@ -682,20 +682,17 @@ describe( 'reducer', () => {
 	describe( 'socialAccountLink', () => {
 		it( 'should set linking mode on user_exists create error', () => {
 			const error = { message: 'Bad', code: 'user_exists', email: 'hello@test.com' };
-			const service = 'google';
-			const token = '123';
+			const authInfo = { id_token: '123', access_token: '123', service: 'google' };
 
 			const state = socialAccountLink( {}, {
 				type: SOCIAL_CREATE_ACCOUNT_REQUEST_FAILURE,
 				error,
-				service,
-				token,
+				authInfo
 			} );
 
 			expect( state ).to.eql( {
 				isLinking: true,
-				service,
-				token,
+				authInfo,
 				email: error.email
 			} );
 		} );

--- a/client/state/login/test/selectors.js
+++ b/client/state/login/test/selectors.js
@@ -22,9 +22,7 @@ import {
 	isTwoFactorAuthTypeSupported,
 	isTwoFactorEnabled,
 	isFormDisabled,
-	getLinkingSocialUser,
-	getLinkingSocialService,
-	getLinkingSocialAuthInfo,
+	getSocialAccountLinkAuthInfo,
 	getCreateSocialAccountError,
 	getSocialAccountIsLinking,
 	getSocialAccountLinkEmail,
@@ -299,46 +297,9 @@ describe( 'selectors', () => {
 		} );
 	} );
 
-	describe( 'getLinkingSocialUser()', () => {
+	describe( 'getSocialAccountLinkAuthInfo()', () => {
 		it( 'should return null if there is no information yet', () => {
-			expect( getLinkingSocialUser( undefined ) ).to.be.null;
-		} );
-
-		it( 'should return the social user account when available', () => {
-			const account = 'foo@bar.baz';
-			expect( getLinkingSocialUser( {
-				login: {
-					socialAccount: {
-						email: account,
-					}
-				}
-			} ) ).to.eql( account );
-		} );
-	} );
-
-	describe( 'getLinkingSocialAuthInfo()', () => {
-		it( 'should return null if there is no information yet', () => {
-			expect( getLinkingSocialService( undefined ) ).to.be.null;
-		} );
-
-		it( 'should return the social service when available', () => {
-			expect( getLinkingSocialService( {
-				login: {
-					socialAccount: {
-						authInfo: {
-							service: 'google',
-							access_token: 'a_token',
-							id_token: 'another_token',
-						}
-					}
-				}
-			} ) ).to.eql( 'google' );
-		} );
-	} );
-
-	describe( 'getLinkingSocialAuthInfo()', () => {
-		it( 'should return null if there is no information yet', () => {
-			expect( getLinkingSocialAuthInfo( undefined ) ).to.be.null;
+			expect( getSocialAccountLinkAuthInfo( undefined ) ).to.be.null;
 		} );
 
 		it( 'should return the social account authentication information when available', () => {
@@ -347,9 +308,9 @@ describe( 'selectors', () => {
 				access_token: 'a_token',
 				id_token: 'another_token',
 			};
-			expect( getLinkingSocialAuthInfo( {
+			expect( getSocialAccountLinkAuthInfo( {
 				login: {
-					socialAccount: {
+					socialAccountLink: {
 						authInfo: socialAccountInfo,
 					}
 				}
@@ -410,7 +371,7 @@ describe( 'selectors', () => {
 
 	describe( 'getSocialAccountLinkService()', () => {
 		it( 'return social account linking service', () => {
-			const socialAccountLink = { service: 'google' };
+			const socialAccountLink = { authInfo: { service: 'google' } };
 
 			expect( getSocialAccountLinkService( {
 				login: {


### PR DESCRIPTION
This fixes #16638 not properly rebased after #16955

The main change is in `client/state/login/reducer.js`, all others changes are derived from that change.

#### Testing

1. Run `git checkout update/social-linking` and start your server, or open a [live branch](https://calypso.live/?branch=update/social-linking)
2. Open the [`start/social` page](http://calypso.localhost:3000/start/social)
3. Check that "signup" with existing google account takes to social connect and you are able to connect the account and the account is actually linked
4. Check that in login [flow](http://calypso.localhost:3000/log-in) you can still link a social account to existing WPCOM account and it is actually being linked

#### Reviews
  
- [x] Code
- [x] Product
- [x] Tests

