### PR TITLE
DevDocs: Show title of wizard component in devdocs

### DIFF
--- a/client/components/wizard/docs/example.jsx
+++ b/client/components/wizard/docs/example.jsx
@@ -33,4 +33,6 @@ const WizardExample = ( { stepName = steps[ 0 ] } ) => (
 	</div>
 );
 
+WizardExample.displayName = 'Wizard';
+
 export default WizardExample;


### PR DESCRIPTION
The Wizard component currently has no title in the dev docs on `wpcalypso`. This is likely because it currently has no `displayName`.

![screen shot 2017-08-15 at 6 37 26 am](https://user-images.githubusercontent.com/1190420/29312632-5c4473b6-8184-11e7-8f69-b9a4fe805be5.jpg)