### PR TITLE
SimplePayments: Add external link to Paypal site.

### DIFF
--- a/client/components/tinymce/plugins/simple-payments/dialog/form.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/form.jsx
@@ -13,6 +13,7 @@ import { flowRight as compose, memoize } from 'lodash';
 /**
  * Internal dependencies
  */
+import ExternalLink from 'components/external-link';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
 import FormTextInput from 'components/forms/form-text-input';
@@ -173,7 +174,13 @@ class ProductForm extends Component {
 						label={ translate( 'Email' ) }
 						explanation={ translate(
 							'This is where PayPal will send your money.' +
-								" To claim a payment, you'll need a PayPal account connected to a bank account."
+								" To claim a payment, you'll need a {{paypalLink}}Paypal account{{/paypalLink}}" +
+								' connected to a bank account.',
+							{
+								components: {
+									paypalLink: <ExternalLink href="https://paypal.com" target="_blank" />,
+								},
+							}
 						) }
 						component={ renderField( FormTextInput ) }
 					/>


### PR DESCRIPTION
This PR adds an external link to Paypal site into the SimplePayments dialog.

![image](https://user-images.githubusercontent.com/77539/29315864-d2cce15a-819b-11e7-8732-eb775f04b176.png)

### Testing

1) After updating your local app, go to SimplePaymentDialog devdocs testing page
http://calypso.localhost:3000/devdocs/blocks/simple-payments-dialog

2) Open the dialog

3) Create or Edit a button. The dialog should open.

4) You should be able to see and test the Paypal link below to the email field.

