### PR TITLE
Migrated sites requests to data layer

### DIFF
--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -28,6 +28,7 @@ import analytics from 'lib/analytics';
 
 import {
 	SIGNUP_OPTIONAL_DEPENDENCY_SUGGESTED_USERNAME_SET,
+	SITES_ONCE_CHANGED,
 } from 'state/action-types';
 
 import { getSiteTitle } from 'state/signup/steps/site-title/selectors';
@@ -170,11 +171,12 @@ function fetchReduxSite( siteSlug, { dispatch, getState }, callback ) {
 		return;
 	}
 
-	// Have to manually call the thunk in order to access the promise on which
-	// to call `then`.
 	debug( 'fetchReduxSite: requesting all sites', siteSlug );
-	requestSites()( dispatch ).then( () =>
-		fetchReduxSite( siteSlug, { dispatch, getState }, callback ) );
+	dispatch( {
+		type: SITES_ONCE_CHANGED,
+		listener: () =>	fetchReduxSite( siteSlug, { dispatch, getState }, callback )
+	} );
+	dispatch( requestSites() );
 }
 
 function fetchSitesAndUser( siteSlug, onComplete, reduxStore ) {

--- a/client/state/data-layer/wpcom/me/index.js
+++ b/client/state/data-layer/wpcom/me/index.js
@@ -6,10 +6,12 @@ import devices from './devices';
 import notification from './notification';
 import settings from './settings';
 import sendVerificationEmail from './send-verification-email';
+import sites from './sites';
 
 export default mergeHandlers(
 	devices,
 	notification,
 	settings,
 	sendVerificationEmail,
+	sites,
 );

--- a/client/state/data-layer/wpcom/me/sites/index.js
+++ b/client/state/data-layer/wpcom/me/sites/index.js
@@ -1,0 +1,69 @@
+/**
+ * Internal dependencies
+ */
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
+import { http } from 'state/data-layer/wpcom-http/actions';
+import { receiveSites } from 'state/sites/actions';
+import {
+	SITES_REQUEST,
+	SITES_REQUEST_FAILURE,
+	SITES_REQUEST_SUCCESS,
+} from 'state/action-types';
+
+/**
+ * Object holding query parameters for request all sites (exported for testing)
+ */
+export const SITES_REQUEST_QUERY_PARAMS = {
+	site_visibility: 'all',
+	include_domain_only: true,
+	site_activity: 'active',
+	fields: 'ID,URL,name,capabilities,jetpack,visible,is_private,is_vip,icon,plan,jetpack_modules,single_user_site,is_multisite,options', //eslint-disable-line max-len
+	options: 'is_mapped_domain,unmapped_url,admin_url,is_redirect,is_automated_transfer,allowed_file_types,show_on_front,main_network_site,jetpack_version,software_version,default_post_format,created_at,frame_nonce,publicize_permanently_disabled,page_on_front,page_for_posts,advanced_seo_front_page_description,advanced_seo_title_formats,verification_services_codes,podcasting_archive,is_domain_only,default_sharing_status,default_likes_enabled,wordads,upgraded_filetypes_enabled,videopress_enabled,permalink_structure,gmt_offset' //eslint-disable-line max-len
+};
+
+/**
+ * Dispatches a request to fetch all sites of the current user
+ *
+ * @param   {Function} dispatch Redux dispatcher
+ * @param   {Object}   action   Redux action
+ * @returns {Object}            dispatched http action
+ */
+export const requestSites = ( { dispatch }, action ) => dispatch( http( {
+	apiVersion: '1.1',
+	method: 'GET',
+	path: '/me/sites',
+	query: SITES_REQUEST_QUERY_PARAMS
+}, action ) );
+
+/**
+ * Dispatches an error action when the fetch all sites request fails
+ *
+ * @param   {Function} dispatch Redux dispatcher
+ * @param   {Object}   action   Redux action
+ * @param   {Object}   error    object containing error information
+ * @returns {Object}            dispatched error action
+ */
+export const receiveSitesError = ( { dispatch }, action, error ) => (
+	dispatch( {
+		type: SITES_REQUEST_FAILURE,
+		error
+	} )
+);
+
+/**
+ * Dispatches required actions when the fetch all sites request succeeds
+ *
+ * @param {Function} dispatch Redux dispatcher
+ * @param {Object}   action   Redux action
+ * @param {Object}   response object containing the fetched site
+ */
+export const receiveSitesSuccess = ( { dispatch }, action, response ) => {
+	dispatch( receiveSites( response.sites ) );
+	dispatch( {
+		type: SITES_REQUEST_SUCCESS
+	} );
+};
+
+export default {
+	[ SITES_REQUEST ]: [ dispatchRequest( requestSites, receiveSitesSuccess, receiveSitesError ) ],
+};

--- a/client/state/data-layer/wpcom/me/sites/test/index.js
+++ b/client/state/data-layer/wpcom/me/sites/test/index.js
@@ -1,0 +1,76 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+import { spy } from 'sinon';
+
+/**
+ * Internal dependencies
+ */
+import { http } from 'state/data-layer/wpcom-http/actions';
+import {
+	SITES_REQUEST,
+	SITES_REQUEST_FAILURE,
+	SITES_REQUEST_SUCCESS,
+} from 'state/action-types';
+import { receiveSites } from 'state/sites/actions';
+import { requestSites, receiveSitesError, receiveSitesSuccess, SITES_REQUEST_QUERY_PARAMS } from '../';
+
+describe( 'wpcom-api', () => {
+	describe( 'sites request', () => {
+		describe( '#requestSites()', () => {
+			it( 'should dispatch an HTTP request to the me/sites endpoint', () => {
+				const dispatch = spy();
+				const action = {
+					type: SITES_REQUEST,
+				};
+				requestSites( { dispatch }, action );
+
+				expect( dispatch ).to.have.been.calledOnce;
+				expect( dispatch ).to.have.been.calledWith(
+					http(
+						{
+							apiVersion: '1.1',
+							method: 'GET',
+							path: '/me/sites',
+							query: SITES_REQUEST_QUERY_PARAMS
+						},
+						action,
+					),
+				);
+			} );
+		} );
+
+		describe( '#receiveSitesError()', () => {
+			it( 'should dispatch an error action', () => {
+				const dispatch = spy();
+				const error = 'DUMMY_ERROR';
+
+				receiveSitesError( { dispatch }, null, error );
+
+				expect( dispatch ).to.have.been.calledOnce;
+				expect( dispatch ).to.have.been.calledWith( {
+					type: SITES_REQUEST_FAILURE,
+					error
+				} );
+			} );
+		} );
+
+		describe( '#receiveSitesSuccess()', () => {
+			it( 'should dispatch correct actions when request is successful', () => {
+				const dispatch = spy();
+				const response = {
+					sites: [ { ID: 'DUMMY' } ]
+				};
+
+				receiveSitesSuccess( { dispatch }, null, response );
+
+				expect( dispatch ).to.have.been.calledTwice;
+				expect( dispatch ).to.have.been.calledWith( receiveSites( response.sites ) );
+				expect( dispatch ).to.have.been.calledWith( {
+					type: SITES_REQUEST_SUCCESS
+				} );
+			} );
+		} );
+	} );
+} );

--- a/client/state/sites/actions.js
+++ b/client/state/sites/actions.js
@@ -18,8 +18,6 @@ import {
 	SITE_REQUEST_SUCCESS,
 	SITES_RECEIVE,
 	SITES_REQUEST,
-	SITES_REQUEST_SUCCESS,
-	SITES_REQUEST_FAILURE,
 	SITES_UPDATE
 } from 'state/action-types';
 
@@ -80,32 +78,12 @@ export function receiveSiteUpdates( sites ) {
 }
 
 /**
- * Triggers a network request to request all visible sites
- * @returns {Function}        Action thunk
+ * Returns an action object that signals the intention to request all visible sites
+ * @returns {Object} Action object
  */
 export function requestSites() {
-	return ( dispatch ) => {
-		dispatch( {
-			type: SITES_REQUEST
-		} );
-
-		return wpcom.me().sites( {
-			site_visibility: 'all',
-			include_domain_only: true,
-			site_activity: 'active',
-			fields: 'ID,URL,name,capabilities,jetpack,visible,is_private,is_vip,icon,plan,jetpack_modules,single_user_site,is_multisite,options', //eslint-disable-line max-len
-			options: 'is_mapped_domain,unmapped_url,admin_url,is_redirect,is_automated_transfer,allowed_file_types,show_on_front,main_network_site,jetpack_version,software_version,default_post_format,created_at,frame_nonce,publicize_permanently_disabled,page_on_front,page_for_posts,advanced_seo_front_page_description,advanced_seo_title_formats,verification_services_codes,podcasting_archive,is_domain_only,default_sharing_status,default_likes_enabled,wordads,upgraded_filetypes_enabled,videopress_enabled,permalink_structure,gmt_offset' //eslint-disable-line max-len
-		} ).then( ( response ) => {
-			dispatch( receiveSites( response.sites ) );
-			dispatch( {
-				type: SITES_REQUEST_SUCCESS
-			} );
-		} ).catch( ( error ) => {
-			dispatch( {
-				type: SITES_REQUEST_FAILURE,
-				error
-			} );
-		} );
+	return {
+		type: SITES_REQUEST
 	};
 }
 

--- a/client/state/sites/test/actions.js
+++ b/client/state/sites/test/actions.js
@@ -17,10 +17,8 @@ import {
 	SITE_REQUEST_FAILURE,
 	SITE_REQUEST_SUCCESS,
 	SITES_RECEIVE,
-	SITES_REQUEST,
-	SITES_REQUEST_FAILURE,
-	SITES_REQUEST_SUCCESS,
-	SITES_UPDATE
+	SITES_UPDATE,
+	SITES_REQUEST
 } from 'state/action-types';
 import {
 	deleteSite,
@@ -35,7 +33,6 @@ import {
 import { useSandbox } from 'test/helpers/use-sinon';
 
 describe( 'actions', () => {
-	const mySitesPath = '/rest/v1.1/me/sites?site_visibility=all&include_domain_only=true&site_activity=active';
 	let sandbox, spy;
 
 	useSandbox( newSandbox => {
@@ -82,65 +79,9 @@ describe( 'actions', () => {
 	} );
 
 	describe( '#requestSites()', () => {
-		describe( 'success', () => {
-			useNock( ( nock ) => {
-				nock( 'https://public-api.wordpress.com:443' )
-					.persist()
-					.filteringPath( () => mySitesPath )
-					.get( mySitesPath )
-					.reply( 200, {
-						sites: [
-							{ ID: 2916284, name: 'WordPress.com Example Blog' },
-							{ ID: 77203074, name: 'WordPress.com Example Blog 2' }
-						]
-					} );
-			} );
-
-			it( 'should dispatch request action when thunk triggered', () => {
-				requestSites()( spy );
-				expect( spy ).to.have.been.calledWith( {
-					type: SITES_REQUEST
-				} );
-			} );
-			it( 'should dispatch receive action when request completes', () => {
-				return requestSites()( spy ).then( () => {
-					expect( spy ).to.have.been.calledWith( {
-						type: SITES_RECEIVE,
-						sites: [
-							{ ID: 2916284, name: 'WordPress.com Example Blog' },
-							{ ID: 77203074, name: 'WordPress.com Example Blog 2' }
-						]
-					} );
-				} );
-			} );
-			it( 'should dispatch success action when request completes', () => {
-				return requestSites()( spy ).then( () => {
-					expect( spy ).to.have.been.calledWith( {
-						type: SITES_REQUEST_SUCCESS
-					} );
-				} );
-			} );
-		} );
-		describe( 'failure', () => {
-			useNock( ( nock ) => {
-				nock( 'https://public-api.wordpress.com:443' )
-					.persist()
-					.filteringPath( () => mySitesPath )
-					.get( mySitesPath )
-					.reply( 403, {
-						error: 'authorization_required',
-						message: 'An active access token must be used to access sites.'
-					} );
-			} );
-
-			it( 'should dispatch fail action when request fails', () => {
-				return requestSites()( spy ).then( () => {
-					expect( spy ).to.have.been.calledWith( {
-						type: SITES_REQUEST_FAILURE,
-						error: sandbox.match( { message: 'An active access token must be used to access sites.' } )
-					} );
-				} );
-			} );
+		const action = requestSites();
+		expect( action ).to.eql( {
+			type: SITES_REQUEST,
 		} );
 	} );
 


### PR DESCRIPTION
This PR comes in the sequence of PR https://github.com/Automattic/wp-calypso/pull/16727. It is shorter in scope and just migrates one request type. For more context of this change please check the original PR.

The approach used to receive an event in step-actions.js is different from  https://github.com/Automattic/wp-calypso/pull/16727. In this PR we pass clean serializable plain objects actions to the data-layer.

To have the same behavior as before we used SITES_ONCE_CHANGED functionality. This is an already existing action that is interpreted by the lib middleware that calls a listener when sites are received. Using SITES_ONCE_CHANGED allows us to keep data-layer “clean”.

To test:
Sites are used everywhere in the app so try to navigate around and check things look ok.

Open a plugin or other place that trigger a request to all sites and verify that requests are generated as expected (using dev-tools).
Add a new website and verify if things work as expected.