### PR TITLE
Editor: add payments button step to Editor Basics Tour

### DIFF
--- a/client/layout/guided-tours/tours/editor-basics-tour.js
+++ b/client/layout/guided-tours/tours/editor-basics-tour.js
@@ -83,6 +83,30 @@ export const EditorBasicsTour = makeTour(
 				}
 			</p>
 			<ButtonRow>
+				<Next step="add-other" />
+				<Quit />
+			</ButtonRow>
+		</Step>
+		<Step
+			name="add-other"
+			arrow="top-left"
+			target=".editor-html-toolbar__button-insert-media, .mce-wpcom-insert-menu button"
+			placement="below"
+			style={ { marginLeft: '22px', zIndex: 'auto' } }
+		>
+			<p>
+				{
+					translate( 'The {{icon/}} lets you add other things, such as a contact form. ' +
+						"If you're on a business plan, you can even add {{strong}}payment buttons{{/strong}}!", {
+							components: {
+								strong: <strong />,
+								icon: <Gridicon icon="chevron-down" />,
+							}
+						}
+					)
+				}
+			</p>
+			<ButtonRow>
 				<Next step="sidebar-options" />
 				<Quit />
 			</ButtonRow>

--- a/client/layout/guided-tours/tours/editor-basics-tour.js
+++ b/client/layout/guided-tours/tours/editor-basics-tour.js
@@ -96,8 +96,8 @@ export const EditorBasicsTour = makeTour(
 		>
 			<p>
 				{
-					translate( 'The {{icon/}} lets you add other things, such as a contact form. ' +
-						"If you're on a business plan, you can even add {{strong}}payment buttons{{/strong}}!", {
+					translate( 'The {{icon/}} lets you add other things, like a contact form. ' +
+						'If your site is on the Premium or Business plan, you can even add {{strong}}payment buttons{{/strong}}!', {
 							components: {
 								strong: <strong />,
 								icon: <Gridicon icon="chevron-down" />,

--- a/client/layout/guided-tours/tours/editor-basics-tour.js
+++ b/client/layout/guided-tours/tours/editor-basics-tour.js
@@ -96,8 +96,10 @@ export const EditorBasicsTour = makeTour(
 		>
 			<p>
 				{
-					translate( 'The {{icon/}} lets you add other things, like a contact form. ' +
-						'If your site is on the Premium or Business plan, you can even add {{strong}}payment buttons{{/strong}}!', {
+					translate(
+						'The {{icon/}} lets you add other things, like a contact form. ' +
+						'If your site is on the Premium or Business plan, you can even add {{strong}}payment buttons{{/strong}}!',
+						{
 							components: {
 								strong: <strong />,
 								icon: <Gridicon icon="chevron-down" />,


### PR DESCRIPTION
This PR adds a step to the "Editor Basics Tour" that tells people about Simple Payments. 

Screenshot of the new step:

<img width="538" alt="screen shot 2017-08-16 at 1 53 15 pm" src="https://user-images.githubusercontent.com/23619/29362003-4e7132fe-828a-11e7-93ed-95f290367ba4.png">

To test:
- go to http://calypso.localhost:3000/post/SITE_URL?tour=editorBasicsTour
- see whether the new step is rendered correctly and check its copy
- make sure the tour as a whole makes sense
