### PR TITLE
Components: Add a ReduxFormFieldset component

### DIFF
--- a/client/components/redux-forms/redux-form-fieldset/index.jsx
+++ b/client/components/redux-forms/redux-form-fieldset/index.jsx
@@ -1,0 +1,53 @@
+/** @format */
+/*
+ * External dependencies
+ */
+import React from 'react';
+import { Field } from 'redux-form';
+
+/**
+ * Internal dependencies
+ */
+import FormFieldset from 'components/forms/form-fieldset';
+import FormLabel from 'components/forms/form-label';
+import FormInputValidation from 'components/forms/form-input-validation';
+import FormSettingExplanation from 'components/forms/form-setting-explanation';
+
+/*
+ * Render a `FormFieldset` parametrized by the input field component type.
+ * It accepts props that are compatible with what Redux Form `Field` passes down to renderers.
+ */
+export const RenderFieldset = ( {
+	inputComponent: InputComponent,
+	input,
+	meta,
+	label,
+	explanation,
+	...props
+} ) => {
+	const isError = !! ( meta.touched && meta.error );
+
+	return (
+		<FormFieldset>
+			{ label &&
+				<FormLabel htmlFor={ input.name }>
+					{ label }
+				</FormLabel> }
+			<InputComponent id={ input.name } isError={ isError } { ...input } { ...props } />
+			{ isError && <FormInputValidation isError text={ meta.error } /> }
+			{ explanation &&
+				<FormSettingExplanation>
+					{ explanation }
+				</FormSettingExplanation> }
+		</FormFieldset>
+	);
+};
+
+/*
+ * Convenience wrapper around Redux Form `Field` to render a `FormFieldset`. Usage:
+ *   <ReduxFormFieldset name="firstName" label="First Name" component={ FormTextInput } />
+ */
+const ReduxFormFieldset = ( { component, ...props } ) =>
+	<Field component={ RenderFieldset } inputComponent={ component } { ...props } />;
+
+export default ReduxFormFieldset;

--- a/client/components/redux-forms/redux-form-fieldset/index.jsx
+++ b/client/components/redux-forms/redux-form-fieldset/index.jsx
@@ -2,6 +2,7 @@
 /*
  * External dependencies
  */
+import PropTypes from 'prop-types';
 import React from 'react';
 import { Field } from 'redux-form';
 
@@ -16,6 +17,7 @@ import FormSettingExplanation from 'components/forms/form-setting-explanation';
 /*
  * Render a `FormFieldset` parametrized by the input field component type.
  * It accepts props that are compatible with what Redux Form `Field` passes down to renderers.
+ * See the `Field` documentation for info about the props.
  */
 export const RenderFieldset = ( {
 	inputComponent: InputComponent,
@@ -49,5 +51,13 @@ export const RenderFieldset = ( {
  */
 const ReduxFormFieldset = ( { component, ...props } ) =>
 	<Field component={ RenderFieldset } inputComponent={ component } { ...props } />;
+
+ReduxFormFieldset.propTypes = {
+	name: PropTypes.string.isRequired, // name of the Redux Form field to connect to
+	component: PropTypes.func.isRequired, // input component to render inside the Fieldset
+	label: PropTypes.node, // optional label for the field
+	explanation: PropTypes.node, // optional explanation for the field
+	// all other props will be passed to the input component
+};
 
 export default ReduxFormFieldset;

--- a/client/components/tinymce/plugins/simple-payments/dialog/form.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/form.jsx
@@ -14,14 +14,11 @@ import { flowRight as compose, padEnd } from 'lodash';
  * Internal dependencies
  */
 import ExternalLink from 'components/external-link';
-import FormFieldset from 'components/forms/form-fieldset';
-import FormLabel from 'components/forms/form-label';
 import FormTextInput from 'components/forms/form-text-input';
 import FormTextarea from 'components/forms/form-textarea';
-import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import FormCurrencyInput from 'components/forms/form-currency-input';
 import CompactFormToggle from 'components/forms/form-toggle/compact';
-import FormInputValidation from 'components/forms/form-input-validation';
+import ReduxFormFieldset, { RenderFieldset } from 'components/redux-forms/redux-form-fieldset';
 import UploadImage from 'blocks/upload-image';
 import { getCurrencyDefaults } from 'lib/format-currency';
 
@@ -92,43 +89,6 @@ const validate = ( values, props ) => {
 
 	return errors;
 };
-
-/*
- * Render a `FormFieldset` parametrized by the input field component type.
- * It accepts props that are compatible with what Redux Form `Field` passes down to renderers.
- */
-const RenderFieldset = ( {
-	inputComponent: InputComponent,
-	input,
-	meta,
-	label,
-	explanation,
-	...props
-} ) => {
-	const isError = !! ( meta.touched && meta.error );
-
-	return (
-		<FormFieldset>
-			{ label &&
-				<FormLabel htmlFor={ input.name }>
-					{ label }
-				</FormLabel> }
-			<InputComponent id={ input.name } isError={ isError } { ...input } { ...props } />
-			{ isError && <FormInputValidation isError text={ meta.error } /> }
-			{ explanation &&
-				<FormSettingExplanation>
-					{ explanation }
-				</FormSettingExplanation> }
-		</FormFieldset>
-	);
-};
-
-/*
- * Convenience wrapper around Redux Form `Field` to render a `FormFieldset`. Usage:
- *   <ReduxFormFieldset name="firstName" label="First Name" component={ FormTextInput } />
- */
-const ReduxFormFieldset = ( { component, ...props } ) =>
-	<Field component={ RenderFieldset } inputComponent={ component } { ...props } />;
 
 // The 'price' input displays data from two fields: `price` and `currency`. That's why we
 // render it using the `Fields` component instead of `Field`. We need this rendering wrapper


### PR DESCRIPTION
Wrapper around a FormFieldset that can display a label, validation error and explanation. It can be parametrized by the type of input component it should render.

I'm actually moving an existing component from `SimplePaymentsDialog` to `components/redux-forms` rather that creating it from scratch.

The `components/tinymce/plugins/simple-payments/dialog/form.jsx` file has a very nice example how to use this.

To test, check that the Simple Payments form that uses the component really works:
1. Start editing a post
2. In the "Insert Content" menu, select "Add Payment Button"
3. Add new button or edit existing button
4. Verify that the form to edit the button info works

Cc: @Automattic/stark 