### PR TITLE
Remove domain availability notice when not necessary.

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -327,6 +327,7 @@ const RegisterDomainStep = React.createClass( {
 			[
 				callback => {
 					if ( ! domain.match( /^([a-z0-9]([a-z0-9-]*[a-z0-9])?\.)*[a-z0-9]([a-z0-9-]*[a-z0-9])?\.[a-z]{2,63}$/i ) ) {
+						this.setState( { lastDomainStatus: null } );
 						return callback();
 					}
 					const timestamp = Date.now();
@@ -339,7 +340,6 @@ const RegisterDomainStep = React.createClass( {
 							status = result && result.status ? result.status : error,
 							{ AVAILABLE, UNKNOWN } = domainAvailability,
 							isDomainAvailable = includes( [ AVAILABLE, UNKNOWN ], status );
-
 						this.setState( { lastDomainStatus: status } );
 						if ( isDomainAvailable ) {
 							this.setState( { notice: null } );

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -340,6 +340,7 @@ const RegisterDomainStep = React.createClass( {
 							status = result && result.status ? result.status : error,
 							{ AVAILABLE, UNKNOWN } = domainAvailability,
 							isDomainAvailable = includes( [ AVAILABLE, UNKNOWN ], status );
+
 						this.setState( { lastDomainStatus: status } );
 						if ( isDomainAvailable ) {
 							this.setState( { notice: null } );


### PR DESCRIPTION
This PR addresses issue #17199.

When a full domain is entered as a search term, `lastDomainStatus` is set which triggers the domain availability notice to be shown. But if the search term is changed to something else that is not a full domain name, then the value of `lastDomainStatus` is not updated to reflect this.

To test this, enter a search query that will trigger the availability notice such as "blah.baseball". Then shorten that to just "baseball". The availability notice should disappear.
