### PR TITLE
Components: Add the ability to go to a particular step of the wizard

### DIFF
--- a/client/components/wizard/README.md
+++ b/client/components/wizard/README.md
@@ -7,8 +7,8 @@ It keeps track of progress and enables navigating back or forward through the st
 
 ```js
 const components = {
-	'first': <First />,
-	'second': <Second />,
+	'first': First,
+	'second': Second,
 };
 const steps = [ 'first', 'second' ];
 
@@ -51,7 +51,7 @@ Used when navigating between steps. The URL that the user is sent to will be con
 	<tr><td>Required</td><td>Yes</td></tr>
 </table>
 
-An object of React components that will be rendered at each step in the wizard. Each key should map
+An object of React component types that will be rendered at each step in the wizard. Each key should map
 to one of the values in the `steps` array (see below).
 
 ### `forwardText`

--- a/client/components/wizard/docs/example.jsx
+++ b/client/components/wizard/docs/example.jsx
@@ -18,9 +18,9 @@ const STEPS = {
 };
 const steps = [ STEPS.FIRST, STEPS.SECOND, STEPS.THIRD ];
 const components = {
-	[ STEPS.FIRST ]: <First />,
-	[ STEPS.SECOND ]: <Second />,
-	[ STEPS.THIRD ]: <Third />,
+	[ STEPS.FIRST ]: First,
+	[ STEPS.SECOND ]: Second,
+	[ STEPS.THIRD ]: Third,
 };
 
 const WizardExample = ( { stepName = steps[ 0 ] } ) => (

--- a/client/components/wizard/index.jsx
+++ b/client/components/wizard/index.jsx
@@ -4,6 +4,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { get, indexOf } from 'lodash';
+import page from 'page';
 
 /**
  * Internal dependencies
@@ -15,7 +16,7 @@ class Wizard extends Component {
 	static propTypes = {
 		backText: PropTypes.string,
 		basePath: PropTypes.string,
-		components: PropTypes.objectOf( PropTypes.element ).isRequired,
+		components: PropTypes.objectOf( PropTypes.func ).isRequired,
 		forwardText: PropTypes.string,
 		steps: PropTypes.arrayOf( PropTypes.string ).isRequired,
 		stepName: PropTypes.string.isRequired,
@@ -61,6 +62,8 @@ class Wizard extends Component {
 		return `${ basePath }/${ nextStepName }`;
 	}
 
+	goToStep = ( stepName ) => page( `${ this.props.basePath }/${ stepName }` );
+
 	render() {
 		const {
 			backText,
@@ -83,7 +86,7 @@ class Wizard extends Component {
 						totalSteps={ totalSteps } />
 				}
 
-				{ component }
+				{ component && React.createElement( component, { goToStep: this.goToStep } ) }
 
 				{ totalSteps > 1 &&
 					<div className="wizard__navigation-links">


### PR DESCRIPTION
This PR adds the ability to go to a particular step of the wizard.

To facilitate this, the `components` prop now expects an object of React component types. This enables passing the `goToStep` event handler as a prop to the component.

## Testing

Navigate to the _UI Components_ section of the devdocs. Ensure that you can still navigate through each of the steps in the wizard.