### PR TITLE
Plugins: Switch fetch action semantics

### DIFF
--- a/client/state/plugins/installed/actions.js
+++ b/client/state/plugins/installed/actions.js
@@ -311,8 +311,8 @@ export function fetchPlugins( siteIds ) {
 			dispatch( { ...defaultAction, type: PLUGINS_REQUEST } );
 
 			const receivePluginsDispatchSuccess = ( data ) => {
-				dispatch( { ...defaultAction, type: PLUGINS_RECEIVE } );
-				dispatch( { ...defaultAction, type: PLUGINS_REQUEST_SUCCESS, data: data.plugins } );
+				dispatch( { ...defaultAction, type: PLUGINS_RECEIVE, data: data.plugins } );
+				dispatch( { ...defaultAction, type: PLUGINS_REQUEST_SUCCESS } );
 
 				data.plugins.map( plugin => {
 					if ( plugin.update && plugin.autoupdate ) {
@@ -322,7 +322,6 @@ export function fetchPlugins( siteIds ) {
 			};
 
 			const receivePluginsDispatchFail = ( error ) => {
-				dispatch( { ...defaultAction, type: PLUGINS_RECEIVE } );
 				dispatch( { ...defaultAction, type: PLUGINS_REQUEST_FAILURE, error } );
 			};
 

--- a/client/state/plugins/installed/reducer.js
+++ b/client/state/plugins/installed/reducer.js
@@ -32,7 +32,8 @@ export function isRequesting( state = {}, action ) {
 	switch ( action.type ) {
 		case PLUGINS_REQUEST:
 			return Object.assign( {}, state, { [ action.siteId ]: true } );
-		case PLUGINS_RECEIVE:
+		case PLUGINS_REQUEST_FAILURE:
+		case PLUGINS_REQUEST_SUCCESS:
 			return Object.assign( {}, state, { [ action.siteId ]: false } );
 		default:
 			return state;
@@ -56,11 +57,8 @@ const updatePlugin = function( state, action ) {
  * Tracks all known installed plugin objects indexed by site ID.
  */
 export const plugins = createReducer( {}, {
-	[ PLUGINS_REQUEST_SUCCESS ]: ( state, action ) => {
+	[ PLUGINS_RECEIVE ]: ( state, action ) => {
 		return { ...state, [ action.siteId ]: action.data };
-	},
-	[ PLUGINS_REQUEST_FAILURE ]: ( state, action ) => {
-		return { ...state, [ action.siteId ]: [] };
 	},
 	[ PLUGIN_ACTIVATE_REQUEST_SUCCESS ]: updatePlugin,
 	[ PLUGIN_DEACTIVATE_REQUEST_SUCCESS ]: updatePlugin,

--- a/client/state/plugins/installed/test/actions.js
+++ b/client/state/plugins/installed/test/actions.js
@@ -95,7 +95,8 @@ describe( 'actions', () => {
 			return Promise.all( responses ).then( () => {
 				expect( spy ).to.have.been.calledWith( {
 					type: PLUGINS_RECEIVE,
-					siteId: 2916284
+					siteId: 2916284,
+					data: [ akismet, helloDolly, jetpack ]
 				} );
 			} );
 		} );
@@ -106,7 +107,6 @@ describe( 'actions', () => {
 				expect( spy ).to.have.been.calledWith( {
 					type: PLUGINS_REQUEST_SUCCESS,
 					siteId: 2916284,
-					data: [ akismet, helloDolly, jetpack ]
 				} );
 			} );
 		} );

--- a/client/state/plugins/installed/test/reducer.js
+++ b/client/state/plugins/installed/test/reducer.js
@@ -40,9 +40,17 @@ describe( 'reducer:', () => {
 			expect( state ).to.eql( { 'one.site': true } );
 		} );
 
-		it( 'should track when fetches end', () => {
+		it( 'should track when fetches end successfully', () => {
 			const state = isRequesting( undefined, {
-				type: PLUGINS_RECEIVE,
+				type: PLUGINS_REQUEST_SUCCESS,
+				siteId: 'one.site'
+			} );
+			expect( state ).to.eql( { 'one.site': false } );
+		} );
+
+		it( 'should track when fetches end unsuccessfully', () => {
+			const state = isRequesting( undefined, {
+				type: PLUGINS_REQUEST_FAILURE,
 				siteId: 'one.site'
 			} );
 			expect( state ).to.eql( { 'one.site': false } );
@@ -53,23 +61,11 @@ describe( 'reducer:', () => {
 		it( 'should load the plugins on this site', () => {
 			const originalState = deepFreeze( { 'one.site': [] } );
 			const state = plugins( originalState, {
-				type: PLUGINS_REQUEST_SUCCESS,
+				type: PLUGINS_RECEIVE,
 				siteId: 'one.site',
 				data: [ akismet ]
 			} );
 			expect( state ).to.eql( { 'one.site': [ akismet ] } );
-		} );
-
-		it( 'should load an empty set if there is an error', () => {
-			const originalState = deepFreeze( { 'one.site': [] } );
-			const testError = new Error( 'Could not fetch plugins for Site One.' );
-			testError.name = 'RequestError';
-			const state = plugins( originalState, {
-				type: PLUGINS_REQUEST_FAILURE,
-				siteId: 'one.site',
-				error: testError
-			} );
-			expect( state ).to.eql( { 'one.site': [] } );
 		} );
 
 		it( 'should show an activated plugin as active', () => {


### PR DESCRIPTION
Switch semantics of `PLUGINS_RECEIVE` and `PLUGINS_REQUEST_SUCCESS`, to align better with the rest of Calypso:

* `_SUCCESS` (and `_FAILURE`) usually sets the corresponding `isRequesting` substate to false
* `_RECEIVE` receives the data fetched from the endpoint and passes it on to the data/items reducer (`plugins` in this case)

Note that this also means that the [order of invocation](https://github.com/Automattic/wp-calypso/pull/17219/files#diff-3e0733c0277e4c6c67f53c66dd7bf10cR314) is reversed for the `isRequesting` and `plugins` reducers. This is the actual motivation for this PR, as it is needed for #17190 to work:

#17190 uses the `componentWillReceiveProps` method to redirect iff `requestingPlugins` was previously `true` and is now `false` (indicating that a network fetch has just completed), and `pluginInstalled` is falsey.

Consider the following, which reflects the way those props change _without_ this PR applied, on a website that _does_ have the plugin installed:

![image](https://user-images.githubusercontent.com/96308/29328227-1a6c2c4a-81f2-11e7-828c-55872d754cdd.png)

1. Upon first mounting the component, no network fetch is underway, and no plugin data are present.
2. Network fetch initiated, no data received yet.
3. Network fetch done, data about to be added (but not there yet)!
4. Network fetch done, data added.

However, line 3 will trip our logic ( `requestingPlugins` was previously `true` and is now `false`, and `pluginInstalled` is falsey), since the component will falsely assume that we have completed fetching data for this plugin on the given site but didn't get any, and that thus, the plugin isn't installed.

Turns out that the order of items 3 and 4 is solely due to the order of actions being dispatched.

With this PR applied, the `plugins` reducer is called first, and only afterwards is the `isRequesting` reducer set to `false`:

![image](https://user-images.githubusercontent.com/96308/29328869-4915448a-81f4-11e7-8792-d9b9fbb2e6b6.png)

To test:
* Make sure that the 'Installed Plugins' section still works for JP sites, i.e. `calypso.localhost:3000/plugins/<JPsite>`