### PR TITLE
Components: Add support for customizing the navigation link text in the wizard

### DIFF
--- a/client/components/wizard/README.md
+++ b/client/components/wizard/README.md
@@ -13,8 +13,10 @@ const components = {
 const steps = [ 'first', 'second' ];
 
 <Wizard
+	backText="Previous"
 	basePath="/section/wizard"
 	components={ components }
+	forwardText="Next"
 	steps={ steps }
 	stepName="first" />
 ```
@@ -22,6 +24,15 @@ const steps = [ 'first', 'second' ];
 ## Props
 
 The following props can be passed to the `Wizard` component:
+
+### `backText`
+
+<table>
+	<tr><td>Type</td><td>String</td></tr>
+	<tr><td>Required</td><td>No</td></tr>
+</table>
+
+Link text for navigating to the previous step in the wizard.
 
 ### `basePath`
 
@@ -42,6 +53,15 @@ Used when navigating between steps. The URL that the user is sent to will be con
 
 An object of React components that will be rendered at each step in the wizard. Each key should map
 to one of the values in the `steps` array (see below).
+
+### `forwardText`
+
+<table>
+	<tr><td>Type</td><td>String</td></tr>
+	<tr><td>Required</td><td>No</td></tr>
+</table>
+
+Link text for navigating to the next step in the wizard.
 
 ### `steps`
 

--- a/client/components/wizard/index.jsx
+++ b/client/components/wizard/index.jsx
@@ -13,8 +13,10 @@ import ProgressIndicator from 'components/wizard/progress-indicator';
 
 class Wizard extends Component {
 	static propTypes = {
+		backText: PropTypes.string,
 		basePath: PropTypes.string,
 		components: PropTypes.objectOf( PropTypes.element ).isRequired,
+		forwardText: PropTypes.string,
 		steps: PropTypes.arrayOf( PropTypes.string ).isRequired,
 		stepName: PropTypes.string.isRequired,
 	}
@@ -60,7 +62,13 @@ class Wizard extends Component {
 	}
 
 	render() {
-		const { components, steps, stepName } = this.props;
+		const {
+			backText,
+			components,
+			forwardText,
+			steps,
+			stepName,
+		} = this.props;
 		const component = get( components, stepName );
 		const stepIndex = this.getStepIndex();
 		const totalSteps = steps.length;
@@ -82,13 +90,15 @@ class Wizard extends Component {
 						{ stepIndex > 0 &&
 							<NavigationLink
 								direction="back"
-								href={ backUrl } />
+								href={ backUrl }
+								text={ backText } />
 						}
 
 						{ stepIndex < totalSteps - 1 &&
 							<NavigationLink
 								direction="forward"
-								href={ skipUrl } />
+								href={ skipUrl }
+								text={ forwardText } />
 						}
 					</div>
 				}

--- a/client/components/wizard/index.jsx
+++ b/client/components/wizard/index.jsx
@@ -44,7 +44,7 @@ class Wizard extends Component {
 		return `${ basePath }/${ previousStepName }`;
 	}
 
-	getSkipUrl = () => {
+	getForwardUrl = () => {
 		const { basePath, steps } = this.props;
 		const stepIndex = this.getStepIndex();
 
@@ -73,7 +73,7 @@ class Wizard extends Component {
 		const stepIndex = this.getStepIndex();
 		const totalSteps = steps.length;
 		const backUrl = this.getBackUrl() || '';
-		const skipUrl = this.getSkipUrl() || '';
+		const forwardUrl = this.getForwardUrl() || '';
 
 		return (
 			<div className="wizard">
@@ -97,7 +97,7 @@ class Wizard extends Component {
 						{ stepIndex < totalSteps - 1 &&
 							<NavigationLink
 								direction="forward"
-								href={ skipUrl }
+								href={ forwardUrl }
 								text={ forwardText } />
 						}
 					</div>

--- a/client/components/wizard/navigation-link.jsx
+++ b/client/components/wizard/navigation-link.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'gridicons';
@@ -11,24 +11,33 @@ import Gridicon from 'gridicons';
  */
 import Button from 'components/button';
 
-const NavigationLink = ( { direction, href, translate } ) => {
-	const text = ( direction === 'back' ) ? translate( 'Back' ) : translate( 'Skip for now' );
+class NavigationLink extends Component {
+	static propTypes = {
+		direction: PropTypes.oneOf( [ 'back', 'forward' ] ).isRequired,
+		href: PropTypes.string,
+		text: PropTypes.string,
+		translate: PropTypes.func.isRequired,
+	}
 
-	return (
-		<Button compact borderless
-			className="wizard__navigation-link"
-			href={ href }>
-			{ direction === 'back' && <Gridicon icon="arrow-left" size={ 18 } /> }
-			{ text }
-			{ direction === 'forward' && <Gridicon icon="arrow-right" size={ 18 } /> }
-		</Button>
-	);
-};
+	getText = () => {
+		const { direction, text, translate } = this.props;
 
-NavigationLink.propTypes = {
-	direction: PropTypes.oneOf( [ 'back', 'forward' ] ).isRequired,
-	href: PropTypes.string,
-	translate: PropTypes.func.isRequired,
-};
+		return direction === 'back' ? text || translate( 'Back' ) : text || translate( 'Skip for now' );
+	}
+
+	render() {
+		const { direction, href } = this.props;
+
+		return (
+			<Button compact borderless
+				className="wizard__navigation-link"
+				href={ href }>
+				{ direction === 'back' && <Gridicon icon="arrow-left" size={ 18 } /> }
+				{ this.getText() }
+				{ direction === 'forward' && <Gridicon icon="arrow-right" size={ 18 } /> }
+			</Button>
+		);
+	}
+}
 
 export default localize( NavigationLink );

--- a/client/components/wizard/navigation-link.jsx
+++ b/client/components/wizard/navigation-link.jsx
@@ -22,7 +22,7 @@ class NavigationLink extends Component {
 	getText = () => {
 		const { direction, text, translate } = this.props;
 
-		return direction === 'back' ? text || translate( 'Back' ) : text || translate( 'Skip for now' );
+		return text || ( direction === 'back' ? translate( 'Back' ) : translate( 'Skip for now' ) );
 	}
 
 	render() {


### PR DESCRIPTION
This PR adds the ability to customize the navigation link text in the Wizard component:

- To customize the back link text, the `backText` prop can be used. If not specified, "Back" will be shown.
- To customize the forward link text, the `forwardText` prop can be used. If not specified, "Skip for now" will be shown.

## Testing

Navigate to the _UI Components_ section of the devdocs. Ensure that you can still navigate through each of the steps in the wizard.