### PR TITLE
JPO: fix redirection to Jetpack connection screen

### DIFF
--- a/client/signup/steps/jpo-summary/index.jsx
+++ b/client/signup/steps/jpo-summary/index.jsx
@@ -57,10 +57,6 @@ const JPOSummaryStep = React.createClass( {
 		page.redirect( jetpackConnectUrl );
 	},
 
-	skipStep() {
-		this.props.goToNextStep();
-	},
-
 	renderStepContent() {
 		const connectionToJetpackComplete = true;
 
@@ -192,7 +188,7 @@ const JPOSummaryStep = React.createClass( {
 					fallbackSubHeaderText={ subHeaderText }
 					signupProgress={ this.props.signupProgress }
 					stepContent={ this.renderStepContent() }
-					goToNextStep={ this.skipStep }
+					goToNextStep={ false }
 				/>
 			</div>
 		);

--- a/client/signup/steps/jpo-summary/index.jsx
+++ b/client/signup/steps/jpo-summary/index.jsx
@@ -15,18 +15,26 @@ import Button from 'components/button';
 import { translate } from 'i18n-calypso';
 import { setJPOSummary } from 'state/signup/steps/jpo-summary/actions';
 
-const JPOSummaryStep = React.createClass( {
-	propTypes: {
+class JPOSummaryStep extends React.Component {
+
+	static propTypes = {
 		flowName: PropTypes.string,
 		goToNextStep: PropTypes.func.isRequired,
 		positionInFlow: PropTypes.number,
 		setJPOSummary: PropTypes.func.isRequired,
 		signupProgress: PropTypes.array,
-		stepName: PropTypes.string,
-	},
+		stepName: PropTypes.string
+	};
+
+	constructor( props ) {
+		super( props );
+		this.getFormattedPayload = this.getFormattedPayload.bind( this );
+		this.completeOnboarding = this.completeOnboarding.bind( this );
+		this.renderStepContent = this.renderStepContent.bind( this );
+	}
 
 	getFormattedPayload() {
-		let payload = this.props.signupProgress;
+		const payload = this.props.signupProgress;
 		return {
 			siteTitle: get( payload[ 0 ], [ 'jpoSiteTitle', 'siteTitle' ], '' ),
 			siteDescription: get( payload[ 0 ], [ 'jpoSiteTitle', 'siteDescription' ], '' ),
@@ -40,7 +48,7 @@ const JPOSummaryStep = React.createClass( {
 			homepageFormat: get( payload[ 2 ], 'jpoHomepage', '' ),
 			addContactForm: get( payload[ 3 ], 'jpoContactForm', '' )
 		};
-	},
+	}
 
 	completeOnboarding() {
 		// Get the payload and original JPC url
@@ -55,7 +63,7 @@ const JPOSummaryStep = React.createClass( {
 
 		// Redirect to the original JPC URL
 		page.redirect( jetpackConnectUrl );
-	},
+	}
 
 	renderStepContent() {
 		const connectionToJetpackComplete = true;
@@ -125,7 +133,11 @@ const JPOSummaryStep = React.createClass( {
 								</ul>
 							</td>
 							<td>
-								<div className="jpo__summary-col-header">Configure more of your site:</div>
+								<div className="jpo__summary-col-header jpo-summary__col-header">
+									{
+										translate( 'Configure more of your site:' )
+									}
+								</div>
 								<ul className="jpo-summary__more-onboarding">
 									{
 										jpoSiteTitle
@@ -166,7 +178,7 @@ const JPOSummaryStep = React.createClass( {
 				</div>
 			</div>
 		);
-	},
+	}
 
 	render() {
 		const headerText = translate( 'Congratulations! %s is on its way.', {
@@ -193,7 +205,7 @@ const JPOSummaryStep = React.createClass( {
 			</div>
 		);
 	}
-} );
+}
 
 export default connect(
 	null,

--- a/client/signup/steps/jpo-summary/index.jsx
+++ b/client/signup/steps/jpo-summary/index.jsx
@@ -5,6 +5,7 @@ import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
 import Gridicon from 'gridicons';
 import get from 'lodash/get';
+import page from 'page';
 
 /**
  * Internal dependencies
@@ -49,14 +50,11 @@ const JPOSummaryStep = React.createClass( {
 		// Flag the flow as complete for use in JPC
 		localStorage.setItem( 'jpoFlowComplete', '1' );
 
-		/**
-		 * Store the payload in localStorage for use after the connection
-		 * to Jetpack has been authorized
-		 */
+		// Store the payload in localStorage for use after Jetpack is connected
 		localStorage.setItem( 'jpoPayload', JSON.stringify( payload ) );
 
 		// Redirect to the original JPC URL
-		window.location.href = jetpackConnectUrl;
+		page.redirect( jetpackConnectUrl );
 	},
 
 	skipStep() {


### PR DESCRIPTION
This PR fixes the redirection when flow is completed and user is taken to connection screen.
Other fixes include:
- remove unnecessary skip button at the summary step
- makes a string available for translation
- refactor code to be an ES6 class