### PR TITLE
Store Orders: Add activity log (order notes) back to single orders

### DIFF
--- a/client/extensions/woocommerce/app/order/index.js
+++ b/client/extensions/woocommerce/app/order/index.js
@@ -18,6 +18,7 @@ import { isOrderUpdating, getOrder } from 'woocommerce/state/sites/orders/select
 import Main from 'components/main';
 import OrderCustomer from './order-customer';
 import OrderDetails from './order-details';
+import OrderNotes from './order-notes';
 import { updateOrder } from 'woocommerce/state/sites/orders/actions';
 
 class Order extends Component {
@@ -71,6 +72,7 @@ class Order extends Component {
 
 				<div className="order__container">
 					<OrderDetails order={ order } onUpdate={ this.onUpdate } site={ site } />
+					<OrderNotes orderId={ order.id } siteId={ site.ID } />
 					<OrderCustomer order={ order } />
 				</div>
 			</Main>

--- a/client/extensions/woocommerce/app/order/order-customer/style.scss
+++ b/client/extensions/woocommerce/app/order/order-customer/style.scss
@@ -6,6 +6,10 @@
 		font-size: 12px;
 		text-transform: uppercase;
 	}
+	
+	.order-customer__shipping-details {
+		margin-top: 32px;
+	}
 
 	h4 {
 		font-weight: bold;

--- a/client/extensions/woocommerce/app/order/order-customer/style.scss
+++ b/client/extensions/woocommerce/app/order/order-customer/style.scss
@@ -11,15 +11,6 @@
 		font-weight: bold;
 	}
 
-	.order-customer__container {
-		display: flex;
-	}
-
-	.order-customer__billing,
-	.order-customer__shipping {
-		flex: 1 0 50%;
-	}
-
 	.order-customer__shipping {
 		.order__shipping-address {
 			margin-bottom: 0;

--- a/client/extensions/woocommerce/app/order/order-notes/day.js
+++ b/client/extensions/woocommerce/app/order/order-notes/day.js
@@ -12,11 +12,11 @@ import FoldableCard from 'components/foldable-card';
 
 class OrderNotesByDay extends Component {
 	static propTypes = {
-		count: PropTypes.number,
-		date: PropTypes.string,
-		index: PropTypes.number,
-		isOpen: PropTypes.bool,
-		onClick: PropTypes.func,
+		count: PropTypes.number.isRequired,
+		date: PropTypes.string.isRequired,
+		index: PropTypes.number.isRequired,
+		isOpen: PropTypes.bool.isRequired,
+		onClick: PropTypes.func.isRequired,
 	}
 
 	onClick = () => {
@@ -25,12 +25,12 @@ class OrderNotesByDay extends Component {
 
 	render() {
 		const { count, date, isOpen, moment, translate } = this.props;
-		const displayDate = moment( date, 'YYYYMMDD' ).format( 'L' );
+		const displayDate = moment( date, 'YYYYMMDD' ).format( 'll' );
 
 		const header = (
 			<div>
 				<h3>{ displayDate }</h3>
-				<small>{ translate( '%(count)s events', { args: { count } } ) }</small>
+				<small>{ translate( '%(count)s event', '%(count)s events', { count, args: { count } } ) }</small>
 			</div>
 		);
 

--- a/client/extensions/woocommerce/app/order/order-notes/day.js
+++ b/client/extensions/woocommerce/app/order/order-notes/day.js
@@ -30,9 +30,7 @@ class OrderNotesByDay extends Component {
 		const header = (
 			<div>
 				<h3>{ displayDate }</h3>
-				<div>
-					<small>{ translate( '%(count)s events', { args: { count } } ) }</small>
-				</div>
+				<small>{ translate( '%(count)s events', { args: { count } } ) }</small>
 			</div>
 		);
 

--- a/client/extensions/woocommerce/app/order/order-notes/day.js
+++ b/client/extensions/woocommerce/app/order/order-notes/day.js
@@ -1,0 +1,54 @@
+/**
+ * External dependencies
+ */
+import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import FoldableCard from 'components/foldable-card';
+
+class OrderNotesByDay extends Component {
+	static propTypes = {
+		count: PropTypes.number,
+		date: PropTypes.string,
+		index: PropTypes.number,
+		isOpen: PropTypes.bool,
+		onClick: PropTypes.func,
+	}
+
+	onClick = () => {
+		this.props.onClick( this.props.index );
+	}
+
+	render() {
+		const { count, date, isOpen, moment, translate } = this.props;
+		const displayDate = moment( date, 'YYYYMMDD' ).format( 'L' );
+
+		const header = (
+			<div>
+				<h3>{ displayDate }</h3>
+				<div>
+					<small>{ translate( '%(count)s events', { args: { count } } ) }</small>
+				</div>
+			</div>
+		);
+
+		return (
+			<div className="order-notes__day">
+				<FoldableCard
+					onClick={ this.onClick }
+					className="order-notes__day-header"
+					expanded={ isOpen }
+					header={ header }
+					screenReaderText={ translate( 'Show notes from %(date)s', { args: { date: displayDate } } ) }>
+					{ this.props.children }
+				</FoldableCard>
+			</div>
+		);
+	}
+}
+
+export default localize( OrderNotesByDay );

--- a/client/extensions/woocommerce/app/order/order-notes/index.js
+++ b/client/extensions/woocommerce/app/order/order-notes/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { bindActionCreators } from 'redux';
+import classNames from 'classnames';
 import { connect } from 'react-redux';
 import { localize, moment } from 'i18n-calypso';
 import PropTypes from 'prop-types';
@@ -87,16 +88,28 @@ class OrderNotes extends Component {
 		} );
 	}
 
+	renderPlaceholder = () => {
+		const noop = () => {};
+		return (
+			<OrderNotesByDay count={ 0 } date="" isOpen={ true } index={ 1 } onClick={ noop }>
+				<OrderNote note="" />
+			</OrderNotesByDay>
+		);
+	}
+
 	render() {
 		const { areNotesLoaded, translate } = this.props;
+		const classes = classNames( {
+			'is-placeholder': ! areNotesLoaded
+		} );
 
 		return (
 			<div className="order-notes">
 				<SectionHeader label={ translate( 'Activity Log' ) } />
-				<Card>
+				<Card className={ classes }>
 					{ areNotesLoaded
 						? this.renderNotes()
-						: translate( 'Loading…' )
+						: this.renderPlaceholder()
 					}
 				</Card>
 			</div>

--- a/client/extensions/woocommerce/app/order/order-notes/index.js
+++ b/client/extensions/woocommerce/app/order/order-notes/index.js
@@ -76,11 +76,11 @@ class OrderNotes extends Component {
 			return (
 				<OrderNotesByDay
 					key={ day }
+					count={ notes.length }
 					date={ day }
 					index={ index }
-					count={ notes.length }
-					onClick={ this.toggleOpenDay }
-					isOpen={ index === this.state.openIndex }>
+					isOpen={ index === this.state.openIndex }
+					onClick={ this.toggleOpenDay } >
 					{ notes.map( note => <OrderNote { ...note } key={ note.id } /> ) }
 				</OrderNotesByDay>
 			);

--- a/client/extensions/woocommerce/app/order/order-notes/index.js
+++ b/client/extensions/woocommerce/app/order/order-notes/index.js
@@ -64,10 +64,11 @@ class OrderNotes extends Component {
 	}
 
 	renderNotes = () => {
-		const { days, notesByDay } = this.props;
-		if ( ! days ) {
-			// @todo empty: We've loaded, but have no notes
-			return null;
+		const { days, notesByDay, translate } = this.props;
+		if ( ! days.length ) {
+			return (
+				<p>{ translate( 'No activity yet' ) }</p>
+			);
 		}
 
 		return days.map( ( day, index ) => {
@@ -95,7 +96,7 @@ class OrderNotes extends Component {
 				<Card>
 					{ areNotesLoaded
 						? this.renderNotes()
-						: 'Loading…'
+						: translate( 'Loading…' )
 					}
 				</Card>
 			</div>

--- a/client/extensions/woocommerce/app/order/order-notes/index.js
+++ b/client/extensions/woocommerce/app/order/order-notes/index.js
@@ -1,34 +1,126 @@
 /**
  * External dependencies
  */
-import React, { Component } from 'react';
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
+import { localize, moment } from 'i18n-calypso';
 import PropTypes from 'prop-types';
-import { localize } from 'i18n-calypso';
+import React, { Component } from 'react';
+import { sortBy, keys } from 'lodash';
 
 /**
  * Internal dependencies
  */
+import { areOrderNotesLoaded, getOrderNotes } from 'woocommerce/state/sites/orders/notes/selectors';
 import Card from 'components/card';
+import { fetchNotes } from 'woocommerce/state/sites/orders/notes/actions';
+import OrderNote from './note';
+import OrderNotesByDay from './day';
 import SectionHeader from 'components/section-header';
+
+function getSortedNotes( notes ) {
+	const notesByDay = {};
+	notes.forEach( note => {
+		const day = moment( note.date_created_gmt ).format( 'YYYYMMDD' );
+		if ( notesByDay[ day ] ) {
+			notesByDay[ day ].push( note );
+			notesByDay[ day ] = sortBy( notesByDay[ day ], 'date_created' ).reverse();
+		} else {
+			notesByDay[ day ] = [ note ];
+		}
+	} );
+	return notesByDay;
+}
 
 class OrderNotes extends Component {
 	static propTypes = {
-		order: PropTypes.object,
+		orderId: PropTypes.number.isRequired,
+		siteId: PropTypes.number.isRequired,
+	}
+
+	constructor( props ) {
+		super( props );
+		this.state = {
+			openIndex: 0,
+		};
+	}
+
+	componentDidMount() {
+		const { siteId, orderId } = this.props;
+
+		if ( siteId ) {
+			this.props.fetchNotes( siteId, orderId );
+		}
+	}
+
+	componentWillReceiveProps( newProps ) {
+		if ( newProps.orderId !== this.props.orderId || newProps.siteId !== this.props.siteId ) {
+			this.props.fetchNotes( newProps.siteId, newProps.orderId );
+		}
+	}
+
+	toggleOpenDay = ( index ) => {
+		this.setState( () => ( { openIndex: index } ) );
+	}
+
+	renderNotes = () => {
+		const { days, notesByDay } = this.props;
+		if ( ! days ) {
+			// @todo empty: We've loaded, but have no notes
+			return null;
+		}
+
+		return days.map( ( day, index ) => {
+			const notes = notesByDay[ day ];
+			return (
+				<OrderNotesByDay
+					key={ day }
+					date={ day }
+					index={ index }
+					count={ notes.length }
+					onClick={ this.toggleOpenDay }
+					isOpen={ index === this.state.openIndex }>
+					{ notes.map( note => <OrderNote { ...note } key={ note.id } /> ) }
+				</OrderNotesByDay>
+			);
+		} );
 	}
 
 	render() {
-		const { order, translate } = this.props;
-		if ( ! order ) {
-			return null;
-		}
+		const { areNotesLoaded, translate } = this.props;
 
 		return (
 			<div className="order-notes">
 				<SectionHeader label={ translate( 'Activity Log' ) } />
-				<Card></Card>
+				<Card>
+					{ areNotesLoaded
+						? this.renderNotes()
+						: 'Loading…'
+					}
+				</Card>
 			</div>
 		);
 	}
 }
 
-export default localize( OrderNotes );
+export default connect(
+	( state, props ) => {
+		const orderId = props.orderId || false;
+		const siteId = props.siteId || false;
+		const areNotesLoaded = areOrderNotesLoaded( state, orderId );
+		const notes = getOrderNotes( state, orderId );
+		const notesByDay = notes.length ? getSortedNotes( notes ) : false;
+		const days = notesByDay ? keys( notesByDay ) : [];
+		days.sort().reverse();
+
+		return {
+			areNotesLoaded,
+			days,
+			notes,
+			notesByDay,
+			orderId,
+			siteId,
+		};
+	},
+	dispatch => bindActionCreators( { fetchNotes }, dispatch )
+)( localize( OrderNotes ) );

--- a/client/extensions/woocommerce/app/order/order-notes/note.js
+++ b/client/extensions/woocommerce/app/order/order-notes/note.js
@@ -14,7 +14,7 @@ import { decodeEntities, stripHTML } from 'lib/formatting';
 class OrderNote extends Component {
 	static propTypes = {
 		customer_note: PropTypes.bool,
-		date_created_gmt: PropTypes.string.isRequired,
+		date_created_gmt: PropTypes.string,
 		note: PropTypes.string.isRequired,
 	}
 
@@ -27,7 +27,7 @@ class OrderNote extends Component {
 			translate
 		} = this.props;
 
-		const createdMoment = moment( date_created_gmt + 'Z' );
+		const createdMoment = date_created_gmt ? moment( date_created_gmt + 'Z' ) : moment();
 
 		// @todo Add comment author once we have that info
 		let icon = 'aside';

--- a/client/extensions/woocommerce/app/order/order-notes/note.js
+++ b/client/extensions/woocommerce/app/order/order-notes/note.js
@@ -1,0 +1,34 @@
+/**
+ * External dependencies
+ */
+import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { stripHTML } from 'lib/formatting';
+
+class OrderNote extends Component {
+	static propTypes = {
+		customer_note: PropTypes.bool,
+		date_created: PropTypes.string,
+		date_created_gmt: PropTypes.string,
+		id: PropTypes.number,
+		note: PropTypes.string,
+	}
+
+	render() {
+		const { note, translate } = this.props;
+
+		return (
+			<div className="order-notes__note">
+				<h4>{ translate( 'Note' ) }</h4>
+				{ stripHTML( note ) }
+			</div>
+		);
+	}
+}
+
+export default localize( OrderNote );

--- a/client/extensions/woocommerce/app/order/order-notes/note.js
+++ b/client/extensions/woocommerce/app/order/order-notes/note.js
@@ -14,20 +14,20 @@ import { decodeEntities, stripHTML } from 'lib/formatting';
 class OrderNote extends Component {
 	static propTypes = {
 		customer_note: PropTypes.bool,
-		date_created: PropTypes.string,
-		date_created_gmt: PropTypes.string,
-		id: PropTypes.number,
-		note: PropTypes.string,
+		date_created_gmt: PropTypes.string.isRequired,
+		note: PropTypes.string.isRequired,
 	}
 
 	render() {
 		const {
 			customer_note,
-			date_created,
+			date_created_gmt,
 			note,
 			moment,
 			translate
 		} = this.props;
+
+		const createdMoment = moment( date_created_gmt + 'Z' );
 
 		// @todo Add comment author once we have that info
 		let icon = 'aside';
@@ -40,7 +40,7 @@ class OrderNote extends Component {
 		return (
 			<div className="order-notes__note">
 				<div className="order-notes__note-meta">
-					<span className="order-notes__note-time">{ moment( date_created ).format( 'LT' ) }</span>
+					<span className="order-notes__note-time">{ createdMoment.format( 'LT' ) }</span>
 					<Gridicon icon={ icon } size={ 24 } />
 				</div>
 				<div className="order-notes__note-body">

--- a/client/extensions/woocommerce/app/order/order-notes/note.js
+++ b/client/extensions/woocommerce/app/order/order-notes/note.js
@@ -2,13 +2,14 @@
  * External dependencies
  */
 import { localize } from 'i18n-calypso';
+import Gridicon from 'gridicons';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 
 /**
  * Internal dependencies
  */
-import { stripHTML } from 'lib/formatting';
+import { decodeEntities, stripHTML } from 'lib/formatting';
 
 class OrderNote extends Component {
 	static propTypes = {
@@ -20,12 +21,34 @@ class OrderNote extends Component {
 	}
 
 	render() {
-		const { note, translate } = this.props;
+		const {
+			customer_note,
+			date_created,
+			note,
+			moment,
+			translate
+		} = this.props;
+
+		// @todo Add comment author once we have that info
+		let icon = 'aside';
+		let note_type = translate( 'Internal note' );
+		if ( customer_note ) {
+			icon = 'mail';
+			note_type = translate( 'Note sent to customer' );
+		}
 
 		return (
 			<div className="order-notes__note">
-				<h4>{ translate( 'Note' ) }</h4>
-				{ stripHTML( note ) }
+				<div className="order-notes__note-meta">
+					<span className="order-notes__note-time">{ moment( date_created ).format( 'LT' ) }</span>
+					<Gridicon icon={ icon } size={ 24 } />
+				</div>
+				<div className="order-notes__note-body">
+					<div className="order-notes__note-type">{ note_type }</div>
+					<div className="order-notes__note-content">
+						{ decodeEntities( stripHTML( note ) ) }
+					</div>
+				</div>
 			</div>
 		);
 	}

--- a/client/extensions/woocommerce/app/order/order-notes/style.scss
+++ b/client/extensions/woocommerce/app/order/order-notes/style.scss
@@ -1,0 +1,60 @@
+.order-notes__day .foldable-card__content {
+	position: relative;
+	z-index: 0;
+
+	&:before {
+		content: '';
+		z-index: -1;
+		position: absolute;
+		top: 0;
+		left: 41px;
+		bottom: 0;
+		width: 1px;
+		background: transparentize( lighten( $gray, 20% ), .5 );
+	}
+}
+
+.order-notes__note {
+	display: flex;
+
+	& + .order-notes__note {
+		margin-top: 16px;
+	}
+
+	.order-notes__note-meta {
+		flex: 1 0 60px;
+		width: 60px;
+		text-align: center;
+
+		.gridicon {
+			display: inline-block;
+			padding: 4px;
+			background: $blue-medium;
+			fill: $white;
+			border-radius: 50%;
+			border: 4px solid white;
+		}
+	}
+
+	.order-notes__note-time {
+		display: block;
+		font-size: 12px;
+		background: white;
+	}
+
+	.order-notes__note-body {
+		flex: 1 0 calc( 100% - 76px );
+		width: calc( 100% - 76px );
+		box-sizing: border-box;
+		margin-left: 16px;
+		padding: 12px 16px 16px;
+		font-size: 13px;
+		box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 );
+	}
+
+	.order-notes__note-content {
+		margin: 8px 8px 0 0;
+		padding-left: 8px;
+		border-left: 1px solid transparentize( lighten( $gray, 20% ), .5 );
+	}
+}

--- a/client/extensions/woocommerce/app/order/order-notes/style.scss
+++ b/client/extensions/woocommerce/app/order/order-notes/style.scss
@@ -7,9 +7,9 @@
 		z-index: -1;
 		position: absolute;
 		top: 0;
-		left: 41px;
+		left: 45px;
 		bottom: 0;
-		width: 1px;
+		width: 2px;
 		background: transparentize( lighten( $gray, 20% ), .5 );
 	}
 }
@@ -48,13 +48,16 @@
 		box-sizing: border-box;
 		margin-left: 16px;
 		padding: 12px 16px 16px;
-		font-size: 13px;
 		box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 );
+	}
+	
+	.order-notes__note-type {
+		font-size: 12px;
+		color: $gray-text-min;
+		text-transform: uppercase;
 	}
 
 	.order-notes__note-content {
 		margin: 8px 8px 0 0;
-		padding-left: 8px;
-		border-left: 1px solid transparentize( lighten( $gray, 20% ), .5 );
 	}
 }

--- a/client/extensions/woocommerce/app/order/order-notes/style.scss
+++ b/client/extensions/woocommerce/app/order/order-notes/style.scss
@@ -14,6 +14,25 @@
 	}
 }
 
+.order-notes .is-placeholder {
+	.foldable-card__main h3,
+	.foldable-card__main small,
+	.order-notes__note-time,
+	.order-notes__note-type,
+	.order-notes__note-content,
+	.order-notes__note-meta .gridicon {
+		@include placeholder();
+	}
+
+	.order-notes__note-time {
+		height: 1.3em;
+	}
+
+	.order-notes__note-meta .gridicon {
+		fill: transparent;
+	}
+}
+
 .order-notes__note {
 	display: flex;
 
@@ -50,7 +69,7 @@
 		padding: 12px 16px 16px;
 		box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 );
 	}
-	
+
 	.order-notes__note-type {
 		font-size: 12px;
 		color: $gray-text-min;


### PR DESCRIPTION
Fixes #13687 

This PR brings the Activity log card back to the single order view, and in it lists out the notes associated with an order. These are status updates on the order, saved as comments on the order. They show updates to the order status, such as when a transaction succeeds/fails, stock is reduced, a refunded granted, etc.

There is no indication in the content of the note to say what kind of note it is, except whether it was sent to the customer or not. The design has different icons for refunding & labels, but I don't think we'll be able to do that. I was going to try a few ways of testing the note content to check the "type", but notes are also translated into the admin's language, so if I search for "Refund ID", it'll only work for English sites.

Pretty sure this'll also mean we can't add the refund label/reprint label actions. But I can add "resend email" to any notes that were emailed to the customer.

![screen shot 2017-08-15 at 3 59 40 pm](https://user-images.githubusercontent.com/541093/29335607-42f2b6f2-81d9-11e7-992d-1381697b0d22.png)

These two states could use a design 👀  :

Loading
![screen shot 2017-08-15 at 4 36 20 pm](https://user-images.githubusercontent.com/541093/29335605-42e976d2-81d9-11e7-8b8e-93a89475c066.png)

No notes (this would not show by default, the user would have to delete the automated "order created" notes)
![screen shot 2017-08-15 at 4 35 35 pm](https://user-images.githubusercontent.com/541093/29335606-42ebc9be-81d9-11e7-8889-cac8aa27a928.png)

**To test**

- View an order
- There should be two boxes under the order details now (Activity Log & Customer Info)
- The Activity Log should load in pretty quickly, and you'll see any notes on the order (probably at least something like "Order status changed from Pending payment to Processing.")
- Check this against the notes list in wp-admin to make sure nothing's missing.
- You can create a customer note by fulfilling the order using the Fulfill modal, and emailing the user a tracking number.