### PR TITLE
Framework: update gridicons to 2.0.2

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3,7 +3,7 @@
   "version": "0.17.0",
   "dependencies": {
     "@types/node": {
-      "version": "6.0.85",
+      "version": "6.0.86",
       "dev": true
     },
     "5to6-codemod": {
@@ -582,7 +582,7 @@
       "version": "1.6.0",
       "dependencies": {
         "browserslist": {
-          "version": "2.3.1"
+          "version": "2.3.3"
         },
         "semver": {
           "version": "5.4.1"
@@ -635,7 +635,7 @@
       "version": "6.25.0"
     },
     "babylon": {
-      "version": "6.17.4"
+      "version": "6.18.0"
     },
     "backo2": {
       "version": "1.0.2"
@@ -677,7 +677,7 @@
       "version": "3.1.3"
     },
     "binary-extensions": {
-      "version": "1.9.0"
+      "version": "1.10.0"
     },
     "binary-search-bounds": {
       "version": "1.0.0"
@@ -1469,9 +1469,6 @@
           "version": "1.1.1"
         }
       }
-    },
-    "dom-walk": {
-      "version": "0.1.1"
     },
     "domain-browser": {
       "version": "1.1.7"
@@ -2712,14 +2709,6 @@
         }
       }
     },
-    "global": {
-      "version": "4.3.2",
-      "dependencies": {
-        "process": {
-          "version": "0.5.2"
-        }
-      }
-    },
     "globals": {
       "version": "9.18.0"
     },
@@ -2769,7 +2758,7 @@
       "dev": true
     },
     "gridicons": {
-      "version": "2.0.1"
+      "version": "2.0.2"
     },
     "growl": {
       "version": "1.9.2",
@@ -3517,7 +3506,7 @@
           "dev": true
         },
         "webidl-conversions": {
-          "version": "4.0.1",
+          "version": "4.0.2",
           "dev": true
         }
       }
@@ -3935,10 +3924,10 @@
       "version": "1.7.0"
     },
     "level-codec": {
-      "version": "7.0.0"
+      "version": "7.0.1"
     },
     "level-errors": {
-      "version": "1.0.4"
+      "version": "1.0.5"
     },
     "level-iterator-stream": {
       "version": "1.3.1"
@@ -4260,9 +4249,6 @@
     },
     "mimic-fn": {
       "version": "1.1.0"
-    },
-    "min-document": {
-      "version": "2.19.0"
     },
     "minimalistic-assert": {
       "version": "1.0.0"
@@ -4892,7 +4878,7 @@
           "dev": true
         },
         "postcss": {
-          "version": "6.0.8",
+          "version": "6.0.9",
           "dev": true
         },
         "source-map": {
@@ -4976,7 +4962,7 @@
           "dev": true
         },
         "postcss": {
-          "version": "6.0.8",
+          "version": "6.0.9",
           "dev": true,
           "dependencies": {
             "ansi-styles": {
@@ -6232,7 +6218,7 @@
       "dev": true
     },
     "timers-browserify": {
-      "version": "2.0.3"
+      "version": "2.0.4"
     },
     "tiny-emitter": {
       "version": "1.2.0"
@@ -6933,7 +6919,7 @@
       "version": "0.0.2"
     },
     "worker-farm": {
-      "version": "1.4.1",
+      "version": "1.5.0",
       "dev": true
     },
     "wp-error": {

--- a/package.json
+++ b/package.json
@@ -9,13 +9,13 @@
     "url": "https://github.com/Automattic/wp-calypso.git"
   },
   "main": "index.js",
-	"browserlist": [
-		"last 2 versions",
-		"Safari >= 9",
-		"iOS >= 9",
-		"not ie <= 10",
-		"> 1%"
-	],
+  "browserlist": [
+    "last 2 versions",
+    "Safari >= 9",
+    "iOS >= 9",
+    "not ie <= 10",
+    "> 1%"
+  ],
   "dependencies": {
     "ajv": "5.2.1",
     "async": "0.9.0",
@@ -78,7 +78,7 @@
     "fuse.js": "2.6.1",
     "get-video-id": "2.1.4",
     "globby": "6.1.0",
-    "gridicons": "2.0.1",
+    "gridicons": "2.0.2",
     "happypack": "4.0.0-beta.1",
     "hard-source-webpack-plugin": "0.3.12",
     "he": "0.5.0",


### PR DESCRIPTION
This PR updates gridicons to 2.0.2. https://github.com/Automattic/gridicons/pull/244

The 2.0.2 release includes a new chat icon and some internal build updates.

![screen shot 2017-08-15 at 2 51 36 pm](https://user-images.githubusercontent.com/1270189/29338269-55757bb2-81c9-11e7-9b67-89ca3cdbe412.png)

### Testing Instructions
- No noticeable changes to Calypso
- Navigate to http://calypso.localhost:3000/devdocs/design/gridicons icons appear as expected
- Icons appear correctly in other sections