### PR TITLE
Add scaffolding for social login management

### DIFF
--- a/client/me/security-section-nav/index.jsx
+++ b/client/me/security-section-nav/index.jsx
@@ -18,17 +18,22 @@ module.exports = React.createClass( {
 	},
 
 	getNavtabs: function() {
-		var tabs = [
+		const tabs = [
 			{
 				title: i18n.translate( 'Password', { textOnly: true } ),
 				path: '/me/security',
+			},
+			{
+				title: i18n.translate( 'Social Login', { textOnly: true } ),
+				path: '/me/security/social-login',
 			},
 			{
 				title: i18n.translate( 'Two-Step Authentication', { textOnly: true } ),
 				path: '/me/security/two-step',
 			},
 			{
-				title: i18n.translate( 'Connected Applications', { textOnly: true } ),
+				// This was shortened from 'Connected Applications' due to space constraints.
+				title: i18n.translate( 'Connected Apps', { textOnly: true } ),
 				path: '/me/security/connected-applications',
 			},
 			{

--- a/client/me/security-section-nav/index.jsx
+++ b/client/me/security-section-nav/index.jsx
@@ -8,9 +8,10 @@ var React = require( 'react' ),
 /**
  * Internal dependencies
  */
-var SectionNav = require( 'components/section-nav' ),
-	NavTabs = require( 'components/section-nav/tabs' ),
-	NavItem = require( 'components/section-nav/item' );
+import config from 'config';
+import NavItem from 'components/section-nav/item';
+import NavTabs from 'components/section-nav/tabs';
+import SectionNav from 'components/section-nav';
 
 module.exports = React.createClass( {
 	propTypes: {
@@ -23,24 +24,28 @@ module.exports = React.createClass( {
 				title: i18n.translate( 'Password', { textOnly: true } ),
 				path: '/me/security',
 			},
-			{
+			config.isEnabled( 'signup/social-management' ) ? {
 				title: i18n.translate( 'Social Login', { textOnly: true } ),
 				path: '/me/security/social-login',
-			},
+			} : null,
 			{
 				title: i18n.translate( 'Two-Step Authentication', { textOnly: true } ),
 				path: '/me/security/two-step',
 			},
 			{
-				// This was shortened from 'Connected Applications' due to space constraints.
-				title: i18n.translate( 'Connected Apps', { textOnly: true } ),
+				title: (
+					config.isEnabled( 'signup/social-management' )
+					// This was shortened from 'Connected Applications' due to space constraints.
+					? i18n.translate( 'Connected Apps', { textOnly: true } )
+					: i18n.translate( 'Connected Applications', { textOnly: true } )
+				),
 				path: '/me/security/connected-applications',
 			},
 			{
 				title: i18n.translate( 'Account Recovery', { textOnly: true } ),
 				path: '/me/security/account-recovery',
 			},
-		];
+		].filter( tab => tab !== null );
 
 		return tabs;
 	},

--- a/client/me/security/controller.js
+++ b/client/me/security/controller.js
@@ -107,5 +107,23 @@ export default {
 			document.getElementById( 'primary' ),
 			context.store
 		);
-	}
+	},
+
+	socialLogin( context ) {
+		const SocialLoginComponent = require( 'me/social-login' );
+		const basePath = context.path;
+
+		analytics.pageView.record( basePath, ANALYTICS_PAGE_TITLE + ' > Social Login' );
+
+		renderWithReduxStore(
+			React.createElement( SocialLoginComponent,
+				{
+					userSettings: userSettings,
+					path: basePath
+				}
+			),
+			document.getElementById( 'primary' ),
+			context.store
+		);
+	},
 };

--- a/client/me/security/index.js
+++ b/client/me/security/index.js
@@ -11,6 +11,7 @@ import controller from './controller';
 
 export default function() {
 	page( '/me/security', meController.sidebar, controller.password );
+	page( '/me/security/social-login', meController.sidebar, controller.socialLogin );
 	page( '/me/security/two-step', meController.sidebar, controller.twoStep );
 	page( '/me/security/connected-applications', meController.sidebar, controller.connectedApplications );
 	page( '/me/security/connected-applications/:application_id', meController.sidebar, controller.connectedApplication );

--- a/client/me/security/index.js
+++ b/client/me/security/index.js
@@ -6,12 +6,17 @@ import page from 'page';
 /**
  * Internal dependencies
  */
+import config from 'config';
 import meController from 'me/controller';
 import controller from './controller';
 
 export default function() {
 	page( '/me/security', meController.sidebar, controller.password );
-	page( '/me/security/social-login', meController.sidebar, controller.socialLogin );
+
+	if ( config.isEnabled( 'signup/social-management' ) ) {
+		page( '/me/security/social-login', meController.sidebar, controller.socialLogin );
+	}
+
 	page( '/me/security/two-step', meController.sidebar, controller.twoStep );
 	page( '/me/security/connected-applications', meController.sidebar, controller.connectedApplications );
 	page( '/me/security/connected-applications/:application_id', meController.sidebar, controller.connectedApplication );

--- a/client/me/sidebar/index.jsx
+++ b/client/me/sidebar/index.jsx
@@ -69,9 +69,10 @@ const MeSidebar = React.createClass( {
 		const { context } = this.props;
 		const filterMap = {
 			'/me': 'profile',
-			'/me/security/two-step': 'security',
-			'/me/security/connected-applications': 'security',
 			'/me/security/account-recovery': 'security',
+			'/me/security/connected-applications': 'security',
+			'/me/security/social-login': 'security',
+			'/me/security/two-step': 'security',
 			'/me/notifications/comments': 'notifications',
 			'/me/notifications/updates': 'notifications',
 			'/me/notifications/subscriptions': 'notifications',

--- a/client/me/social-login/index.jsx
+++ b/client/me/social-login/index.jsx
@@ -1,0 +1,58 @@
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import debugFactory from 'debug';
+import { localize } from 'i18n-calypso';
+const debug = debugFactory( 'calypso:me:security:social-login' );
+
+/**
+ * Internal dependencies
+ */
+import Card from 'components/card';
+import DocumentHead from 'components/data/document-head';
+import Main from 'components/main';
+import MeSidebarNavigation from 'me/sidebar-navigation';
+import ReauthRequired from 'me/reauth-required';
+import SecuritySectionNav from 'me/security-section-nav';
+import twoStepAuthorization from 'lib/two-step-authorization';
+
+class SocialLogin extends Component {
+	static displayName = 'SocialLogin';
+
+	static propTypes = {
+		moment: PropTypes.func,
+		path: PropTypes.string,
+		translate: PropTypes.func.isRequired,
+		userSettings: PropTypes.object,
+	};
+
+	componentDidMount() {
+		debug( this.constructor.displayName + ' React component has mounted.' );
+	}
+
+	componentWillUnmount() {
+		debug( this.constructor.displayName + ' React component is unmounting.' );
+	}
+
+	render() {
+		const title = this.props.translate( 'Social Login', { textOnly: true } );
+
+		return (
+			<Main className="social-login">
+				<DocumentHead title={ title } />
+				<MeSidebarNavigation />
+
+				<SecuritySectionNav path={ this.props.path } />
+
+				<ReauthRequired twoStepAuthorization={ twoStepAuthorization } />
+				<Card>
+					{ this.props.translate( 'Manage Social Login Connections' ) }
+				</Card>
+			</Main>
+		);
+	}
+}
+
+export default localize( SocialLogin );

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -180,6 +180,7 @@
 	"rtl": false,
 	"siftscience_key": false,
 	"signup_url": false,
+	"signup/social-management": false,
 	"twemoji_cdn_url": "https://s0.wp.com/wp-content/mu-plugins/wpcom-smileys/twemoji/2/",
 	"woocommerce_blog_id": 113771570,
 	"wpcom_signup_id": false,

--- a/config/development.json
+++ b/config/development.json
@@ -148,6 +148,7 @@
 		"settings/theme-setup": true,
 		"signup/domain-first-flow": true,
 		"signup/social": true,
+		"signup/social-management": true,
 		"simple-payments": true,
 		"standalone-site-preview": true,
 		"support-user": true,


### PR DESCRIPTION
Sets the groundwork for addressing #16690. This PR adds routing and static component to `/me/security/social-login` behind a feature wall.

#### Testing instructions

1. Check out locally (`git checkout add/security-social-login-management`) and start your server. You can also use a [live branch](https://calypso.live/?branch=add/security-social-login-management)
2. Log in and open the security page ([`/me/security`](http://calypso.localhost:3000/me/security))
3. Confirm that the link to "Social Login" is visible on the top navigation. 
4. Confirm that the link takes you to [`/me/security/social-login`](http://calypso.localhost:3000/me/security/social-login)
5. Verify that a placeholder message is visible on the social login page (`Manage Social Login Connections`).

#### Reviews

- [x] Code
- [x] Product