### PR TITLE
Update happychat info to send generic data instead of message

### DIFF
--- a/client/lib/happychat/connection.js
+++ b/client/lib/happychat/connection.js
@@ -6,6 +6,11 @@ import { EventEmitter } from 'events';
 import config from 'config';
 import { v4 as uuid } from 'uuid';
 
+/**
+ * Internal dependencies
+ */
+import { HAPPYCHAT_MESSAGE_TYPES } from 'state/happychat/constants';
+
 /*
  * Happychat client connection for Socket.IO
  */
@@ -74,8 +79,8 @@ class Connection extends EventEmitter {
 			socket => socket.emit( 'message', {
 				text: message,
 				id: uuid(),
-				type: 'customer-event',
-				meta: { forOperator: true, event_type: 'customer-event' }
+				type: HAPPYCHAT_MESSAGE_TYPES.CUSTOMER_EVENT,
+				meta: { forOperator: true, event_type: HAPPYCHAT_MESSAGE_TYPES.CUSTOMER_EVENT }
 			} ),
 			e => debug( 'failed to send message', e )
 		);
@@ -98,8 +103,8 @@ class Connection extends EventEmitter {
 			socket => socket.emit( 'message', {
 				text: message,
 				id: uuid(),
-				type: 'log',
-				meta: { forOperator: true, event_type: 'log' }
+				type: HAPPYCHAT_MESSAGE_TYPES.LOG,
+				meta: { forOperator: true, event_type: HAPPYCHAT_MESSAGE_TYPES.LOG }
 			} ),
 			e => debug( 'failed to send message', e )
 		);
@@ -112,9 +117,9 @@ class Connection extends EventEmitter {
 	sendInfo( info ) {
 		this.openSocket.then(
 			socket => socket.emit( 'message', {
-				type: 'customer-info',
 				id: uuid(),
 				meta: { ...info, forOperator: true },
+				type: HAPPYCHAT_MESSAGE_TYPES.CUSTOMER_EVENT,
 			} ),
 			e => debug( 'failed to send message', e )
 		);

--- a/client/lib/happychat/connection.js
+++ b/client/lib/happychat/connection.js
@@ -119,7 +119,7 @@ class Connection extends EventEmitter {
 			socket => socket.emit( 'message', {
 				id: uuid(),
 				meta: { ...info, forOperator: true },
-				type: HAPPYCHAT_MESSAGE_TYPES.CUSTOMER_EVENT,
+				type: HAPPYCHAT_MESSAGE_TYPES.CUSTOMER_INFO,
 			} ),
 			e => debug( 'failed to send message', e )
 		);

--- a/client/lib/happychat/connection.js
+++ b/client/lib/happychat/connection.js
@@ -105,9 +105,17 @@ class Connection extends EventEmitter {
 		);
 	}
 
-	info( message ) {
+	/**
+	 * Send customer and browser information
+	 * @param { Object } info selected form fields, customer date time, user agent and browser info
+	 */
+	sendInfo( info ) {
 		this.openSocket.then(
-			socket => socket.emit( 'message', { text: message.text, id: uuid(), meta: { forOperator: true } } ),
+			socket => socket.emit( 'message', {
+				type: 'customer-info',
+				id: uuid(),
+				meta: { ...info, forOperator: true },
+			} ),
 			e => debug( 'failed to send message', e )
 		);
 	}

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -128,9 +128,9 @@ const HelpContact = React.createClass( {
 
 	startHappychat: function( contactForm ) {
 		this.props.openHappychat();
-		const { message, site } = contactForm;
+		const { howCanWeHelp, howYouFeel, message, site } = contactForm;
 
-		this.props.sendUserInfo( site.URL );
+		this.props.sendUserInfo( howCanWeHelp, howYouFeel, site );
 		this.props.sendHappychatMessage( message );
 
 		analytics.tracks.recordEvent( 'calypso_help_live_chat_begin', {

--- a/client/state/happychat/actions.js
+++ b/client/state/happychat/actions.js
@@ -54,7 +54,22 @@ export const clearChatMessage = () => setChatMessage( '' );
 
 export const receiveChatEvent = event => ( { type: HAPPYCHAT_RECEIVE_EVENT, event } );
 
-export const sendUserInfo = siteUrl => ( { type: HAPPYCHAT_SEND_USER_INFO, siteUrl } );
+/**
+ * Returns an action object that sends information about the customer to happychat
+ *
+ * @param  { String } howCanWeHelp Selected value of `How can we help?` form input
+ * @param  { String } howYouFeel Selected value of `Mind sharing how you feel?` form input
+ * @param  { Object } site Selected site info
+ * @return { Object } Action object
+ */
+export const sendUserInfo = ( howCanWeHelp, howYouFeel, site ) => {
+	return {
+		type: HAPPYCHAT_SEND_USER_INFO,
+		howCanWeHelp,
+		howYouFeel,
+		site
+	};
+};
 
 export const sendChatMessage = message => ( { type: HAPPYCHAT_SEND_MESSAGE, message } );
 

--- a/client/state/happychat/constants.js
+++ b/client/state/happychat/constants.js
@@ -13,3 +13,10 @@ export const HAPPYCHAT_GROUP_JPOP = 'jpop';
 export const HAPPYCHAT_GROUP_WOO = 'woo';
 export const HAPPYCHAT_GROUP_JPPHP = 'jpphp';
 export const HAPPYCHAT_GROUP_WPCOM = 'WP.com';
+
+// Message types
+export const HAPPYCHAT_MESSAGE_TYPES = {
+	CUSTOMER_EVENT: 'customer-event',
+	CUSTOMER_INFO: 'customer-info',
+	LOG: 'log',
+};

--- a/client/state/happychat/middleware.js
+++ b/client/state/happychat/middleware.js
@@ -178,24 +178,45 @@ const sendMessage = ( connection, message ) => {
 	connection.notTyping();
 };
 
-export const sendInfo = ( connection, { getState }, siteUrl ) => {
-	const siteHelp = `\nSite I need help with: ${ siteUrl }`;
-	const screenRes = ( typeof screen === 'object' ) && `\nScreen Resolution: ${ screen.width }x${ screen.height }`;
-	const browserSize = ( typeof window === 'object' ) && `\nBrowser Size: ${ window.innerWidth }x${ window.innerHeight }`;
-	const userAgent = ( typeof navigator === 'object' ) && `\nUser Agent: ${ navigator.userAgent }`;
-	const localDateTime = `\nLocal Date: ${ moment().format( 'h:mm:ss a, MMMM Do YYYY' ) }`;
-
-	// Geo location
-	const state = getState();
-	const geoLocation = getGeoLocation( state );
-	const userLocation = ( null !== geoLocation ) ? `\nLocation: ${ geoLocation.city }, ${ geoLocation.country_long }` : '';
-
-	const msg = {
-		text: `Info\n ${ siteHelp } ${ screenRes } ${ browserSize } ${ userAgent } ${ localDateTime } ${ userLocation }`,
+export const sendInfo = ( connection, { getState }, action ) => {
+	const { howCanWeHelp, howYouFeel, site } = action;
+	const info = {
+		howCanWeHelp,
+		howYouFeel,
+		site,
+		localDateTime: moment().format( 'h:mm:ss a, MMMM Do YYYY' ),
 	};
 
-	debug( 'sending info message', msg );
-	connection.info( msg );
+	// add screen size
+	if ( 'object' === typeof ( screen ) ) {
+		info.screenSize = {
+			width: screen.width,
+			height: screen.height
+		};
+	}
+
+	// add browser size
+	if ( 'object' === typeof ( window ) ) {
+		info.browserSize = {
+			width: window.innerWidth,
+			height: window.innerHeight
+		};
+	}
+
+	// add user agent
+	if ( 'object' === typeof ( navigator ) ) {
+		info.userAgent = navigator.userAgent;
+	}
+
+	//  add geo location
+	const state = getState();
+	const geoLocation = getGeoLocation( state );
+	if ( null !== geoLocation ) {
+		info.geoLocation = geoLocation;
+	}
+
+	debug( 'sending info message', info );
+	connection.sendInfo( info );
 };
 
 export const connectIfRecentlyActive = ( connection, store ) => {
@@ -336,7 +357,7 @@ export default function( connection = null ) {
 				break;
 
 			case HAPPYCHAT_SEND_USER_INFO:
-				sendInfo( connection, store, action.siteUrl );
+				sendInfo( connection, store, action );
 				break;
 
 			case HAPPYCHAT_SEND_MESSAGE:

--- a/client/state/happychat/middleware.js
+++ b/client/state/happychat/middleware.js
@@ -183,8 +183,9 @@ export const sendInfo = ( connection, { getState }, action ) => {
 	const info = {
 		howCanWeHelp,
 		howYouFeel,
-		site,
-		localDateTime: moment().format( 'h:mm:ss a, MMMM Do YYYY' ),
+		siteId: site.ID,
+		siteUrl: site.URL,
+		localDateTime: moment().format( 'h:mm a, MMMM Do YYYY' ),
 	};
 
 	// add screen size
@@ -211,7 +212,7 @@ export const sendInfo = ( connection, { getState }, action ) => {
 	//  add geo location
 	const state = getState();
 	const geoLocation = getGeoLocation( state );
-	if ( null !== geoLocation ) {
+	if ( geoLocation ) {
 		info.geoLocation = geoLocation;
 	}
 

--- a/client/state/happychat/test/middleware.js
+++ b/client/state/happychat/test/middleware.js
@@ -3,6 +3,7 @@
  */
 import { expect } from 'chai';
 import deepFreeze from 'deep-freeze';
+import moment from 'moment';
 import { spy, stub } from 'sinon';
 import { noop } from 'lodash';
 
@@ -145,14 +146,60 @@ describe( 'middleware', () => {
 			}
 		};
 
+		const previousGlobal = global;
+
+		before( () => {
+			global.window = {
+				innerWidth: 'windowInnerWidth',
+				innerHeight: 'windowInnerHeight',
+			};
+			global.screen = {
+				width: 'screenWidth',
+				height: 'screenHeight',
+			};
+			global.navigator = {
+				userAgent: 'navigatorUserAgent'
+			};
+		} );
+
+		after( () => {
+			global = previousGlobal;
+		} );
+
 		it( 'should send relevant browser information to the connection', () => {
+			const expectedInfo = {
+				howCanWeHelp: 'howCanWeHelp',
+				howYouFeel: 'howYouFeel',
+				siteId: 'siteId',
+				siteUrl: 'siteUrl',
+				localDateTime: moment().format( 'h:mm a, MMMM Do YYYY' ),
+				screenSize: {
+					width: 'screenWidth',
+					height: 'screenHeight',
+				},
+				browserSize: {
+					width: 'windowInnerWidth',
+					height: 'windowInnerHeight',
+				},
+				userAgent: 'navigatorUserAgent',
+				geoLocation: state.happychat.geoLocation
+			};
+
 			const getState = () => state;
 			const connection = { sendInfo: spy() };
-			const action = { type: HAPPYCHAT_SEND_USER_INFO, site: { URL: 'http://butt.holdings/' } };
+			const action = {
+				type: HAPPYCHAT_SEND_USER_INFO,
+				site: {
+					ID: 'siteId',
+					URL: 'siteUrl'
+				},
+				howCanWeHelp: 'howCanWeHelp',
+				howYouFeel: 'howYouFeel',
+			};
 			sendInfo( connection, { getState }, action );
 
 			expect( connection.sendInfo ).to.have.been.calledOnce;
-			expect( connection.sendInfo.firstCall.args[ 0 ].site.URL ).to.equal( action.site.URL );
+			expect( connection.sendInfo ).to.have.been.calledWithMatch( expectedInfo );
 		} );
 	} );
 

--- a/client/state/happychat/test/middleware.js
+++ b/client/state/happychat/test/middleware.js
@@ -147,12 +147,12 @@ describe( 'middleware', () => {
 
 		it( 'should send relevant browser information to the connection', () => {
 			const getState = () => state;
-			const connection = { info: spy() };
+			const connection = { sendInfo: spy() };
 			const action = { type: HAPPYCHAT_SEND_USER_INFO, siteUrl: 'http://butt.holdings/' };
 			sendInfo( connection, { getState }, action );
 
-			expect( connection.info ).to.have.been.calledOnce;
-			expect( connection.info.firstCall.args[ 0 ].text ).to.include( state.happychat.geoLocation.city );
+			expect( connection.sendInfo ).to.have.been.calledOnce;
+			expect( connection.sendInfo.firstCall.args[ 0 ].text ).to.include( state.happychat.geoLocation.city );
 		} );
 	} );
 

--- a/client/state/happychat/test/middleware.js
+++ b/client/state/happychat/test/middleware.js
@@ -148,11 +148,11 @@ describe( 'middleware', () => {
 		it( 'should send relevant browser information to the connection', () => {
 			const getState = () => state;
 			const connection = { sendInfo: spy() };
-			const action = { type: HAPPYCHAT_SEND_USER_INFO, siteUrl: 'http://butt.holdings/' };
+			const action = { type: HAPPYCHAT_SEND_USER_INFO, site: { URL: 'http://butt.holdings/' } };
 			sendInfo( connection, { getState }, action );
 
 			expect( connection.sendInfo ).to.have.been.calledOnce;
-			expect( connection.sendInfo.firstCall.args[ 0 ].text ).to.include( state.happychat.geoLocation.city );
+			expect( connection.sendInfo.firstCall.args[ 0 ].site.URL ).to.equal( action.site.URL );
 		} );
 	} );
 


### PR DESCRIPTION
## Summary
This PR updates the way we send information about customers to Happychat. Instead of sending a strongly typed message containing the information this PR makes it more generic sending an object containing the customer info and let the happychat UI decide how data will be displayed.

## Testing
Chatting should work as expected. This should be tested as part of gh-712-happychat.