### PR TITLE
Reader: Use updated Chat gridicon for Conversations

### DIFF
--- a/client/reader/sidebar/_style.scss
+++ b/client/reader/sidebar/_style.scss
@@ -306,8 +306,3 @@
 		display: none;
 	}
 }
-
-// Flips Conversations chat gridicon horizontally
-.sidebar-streams__conversations .gridicons-chat {
-	transform: rotateY( 180deg );
-}


### PR DESCRIPTION
In https://github.com/Automattic/wp-calypso/commit/23789caf3741ce504151612f898b4fc4eef83358, I flipped the original Chat gridicon using CSS `transform`.

In https://github.com/Automattic/gridicons/pull/243, we decided to just update and flip the actual gridicon so `transform` needs to be removed.

**Before:**
![screenshot 2017-08-15 17 34 13](https://user-images.githubusercontent.com/4924246/29342602-7ea5b418-81e0-11e7-81c2-7677712ea1b1.png)

**After:**
![screenshot 2017-08-15 17 37 48](https://user-images.githubusercontent.com/4924246/29342606-83453dcc-81e0-11e7-9b32-1e85582939c4.png)

