### PR TITLE
Track clicks on the cart abandonment nudge via the 'onClick' property.

### DIFF
--- a/client/my-sites/current-site/index.jsx
+++ b/client/my-sites/current-site/index.jsx
@@ -30,6 +30,7 @@ import { getSelectedOrAllSites } from 'state/selectors';
 import { infoNotice, removeNotice } from 'state/notices/actions';
 import { getNoticeLastTimeShown } from 'state/notices/selectors';
 import { getSectionName } from 'state/ui/selectors';
+import { recordTracksEvent } from 'state/analytics/actions';
 
 class CurrentSite extends Component {
 	static propTypes = {
@@ -96,9 +97,14 @@ class CurrentSite extends Component {
 					duration: 10000,
 					button: this.props.translate( 'Complete your purchase' ),
 					href: '/checkout/' + selectedSite.slug,
+					onClick: this.clickStaleCartItemsNotice
 				}
 			);
 		}
+	}
+
+	clickStaleCartItemsNotice = () => {
+		this.props.recordTracksEvent( 'calypso_cart_abandonment_notice_click' );
 	}
 
 	switchSites = ( event ) => {
@@ -238,5 +244,5 @@ export default connect(
 			sectionName: getSectionName( state ),
 		};
 	},
-	{ setLayoutFocus, infoNotice, removeNotice },
+	{ setLayoutFocus, infoNotice, removeNotice, recordTracksEvent },
 )( localize( CurrentSite ) );


### PR DESCRIPTION
This adds click tracking to the cart abandonment nudge

## Test Plan
* With a test user and site, add any plan to your cart.
* Wait 10+ minutes.
* Click "My Sites" to navigate to the stats page.
* In the network tab of your browser console search for `calypso_cart_abandonment_notice_click`.
* Refresh the page. Once you see the cart abandonment nudge pop up in the top right of your screen, click "Complete your purchase". You should see the request in your browser console.

<img width="585" alt="screen shot 2017-08-15 at 5 59 33 pm" src="https://user-images.githubusercontent.com/690843/29343083-a9ef78c2-81e3-11e7-92df-c19204969f99.png">

<img width="1863" alt="screen shot 2017-08-15 at 5 59 59 pm" src="https://user-images.githubusercontent.com/690843/29343085-ae5f5792-81e3-11e7-8f10-6bc10c698228.png">
