### PR TITLE
Simple Payments: Fix PayPal button text for Safari

### DIFF
--- a/client/components/tinymce/plugins/wpcom-view/views/simple-payments/style.scss
+++ b/client/components/tinymce/plugins/wpcom-view/views/simple-payments/style.scss
@@ -121,9 +121,7 @@
 	perspective-origin: 21.125px 6px;
 	font-family: "Helvetica Neue",Helvetica, Arial, sans-serif;
 	font-size: 10px;
-	font-stretch: normal;
 	font-style: normal;
-	font-variant: normal;
 	font-weight: 500;
 	line-height: normal;
 }

--- a/client/components/tinymce/plugins/wpcom-view/views/simple-payments/style.scss
+++ b/client/components/tinymce/plugins/wpcom-view/views/simple-payments/style.scss
@@ -119,7 +119,13 @@
 	top: -3px;
 	width: 43px;
 	perspective-origin: 21.125px 6px;
-	font: normal normal 500 normal 10px / normal "Helvetica Neue",Helvetica, Arial, sans-serif;
+	font-family: "Helvetica Neue",Helvetica, Arial, sans-serif;
+	font-size: 10px;
+	font-stretch: normal;
+	font-style: normal;
+	font-variant: normal;
+	font-weight: 500;
+	line-height: normal;
 }
 
 .wpview-type-simple-payments_paypal-logo {


### PR DESCRIPTION
I assume the CSS was from PayPal but Safari doesn't seem to like the shorthand, and this PR splits it.

Before on Safari:
<img width="312" alt="screen shot 2017-08-16 at 10 56 20" src="https://user-images.githubusercontent.com/908665/29358255-3fa854f4-8272-11e7-9f6e-f6baf10a08bb.png">

After:
<img width="327" alt="screen shot 2017-08-16 at 10 55 17" src="https://user-images.githubusercontent.com/908665/29358267-4b13a884-8272-11e7-85dd-9e8588449e7c.png">
