### PR TITLE
Activity log: Add day placeholder while logs are fetched

### DIFF
--- a/client/my-sites/stats/activity-log-day/index.jsx
+++ b/client/my-sites/stats/activity-log-day/index.jsx
@@ -24,6 +24,9 @@ class ActivityLogDay extends Component {
 		requestRestore: PropTypes.func.isRequired,
 		siteId: PropTypes.number,
 		tsEndOfSiteDay: PropTypes.number.isRequired,
+
+		// Connected props
+		recordTracksEvent: PropTypes.func.isRequired,
 	};
 
 	static defaultProps = {

--- a/client/my-sites/stats/activity-log-day/placeholder.js
+++ b/client/my-sites/stats/activity-log-day/placeholder.js
@@ -1,0 +1,31 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import FoldableCard from 'components/foldable-card';
+
+function ActivityLogDayPlaceholder( { translate } ) {
+	return (
+		<FoldableCard
+			className="activity-log-day__placeholder"
+			header={
+				<div>
+					<div className="activity-log-day__day">
+						{ translate( 'Loading…' ) }
+					</div>
+					<div className="activity-log-day__events">
+						{ translate( 'Loading…' ) }
+					</div>
+				</div>
+			}
+		/>
+	);
+}
+
+export default localize( ActivityLogDayPlaceholder );

--- a/client/my-sites/stats/activity-log-day/placeholder.js
+++ b/client/my-sites/stats/activity-log-day/placeholder.js
@@ -3,29 +3,24 @@
  * External dependencies
  */
 import React from 'react';
-import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
 import FoldableCard from 'components/foldable-card';
 
-function ActivityLogDayPlaceholder( { translate } ) {
-	return (
-		<FoldableCard
-			className="activity-log-day__placeholder"
-			header={
-				<div>
-					<div className="activity-log-day__day">
-						{ translate( 'Loading…' ) }
-					</div>
-					<div className="activity-log-day__events">
-						{ translate( 'Loading…' ) }
-					</div>
-				</div>
-			}
-		/>
-	);
-}
+const component = (
+	<FoldableCard
+		className="activity-log-day__placeholder"
+		header={
+			<div>
+				<div className="activity-log-day__day" />
+				<div className="activity-log-day__events" />
+			</div>
+		}
+	/>
+);
 
-export default localize( ActivityLogDayPlaceholder );
+export default function ActivityLogDayPlaceholder() {
+	return component;
+}

--- a/client/my-sites/stats/activity-log-day/style.scss
+++ b/client/my-sites/stats/activity-log-day/style.scss
@@ -40,6 +40,15 @@
 	color: $gray;
 }
 
+.activity-log-day__placeholder {
+	@extend .activity-log-day;
+
+	.activity-log-day__day,
+	.activity-log-day__events {
+		@include placeholder();
+	}
+}
+
 .activity-log-day__rewind-button {
 	text-transform: uppercase;
 }

--- a/client/my-sites/stats/activity-log-day/style.scss
+++ b/client/my-sites/stats/activity-log-day/style.scss
@@ -47,6 +47,15 @@
 	.activity-log-day__events {
 		@include placeholder();
 	}
+
+	.activity-log-day__day {
+		width: 12em;
+	}
+
+	.activity-log-day__events {
+		width: 10em;
+		margin-top: .2em;
+	}
 }
 
 .activity-log-day__rewind-button {

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -14,6 +14,7 @@ import { filter, get, groupBy, includes, isEmpty, isNull, map } from 'lodash';
 import ActivityLogBanner from '../activity-log-banner';
 import ActivityLogConfirmDialog from '../activity-log-confirm-dialog';
 import ActivityLogDay from '../activity-log-day';
+import ActivityLogDayPlaceholder from '../activity-log-day/placeholder';
 import ActivityLogRewindToggle from './activity-log-rewind-toggle';
 import DatePicker from 'my-sites/stats/stats-date-picker';
 import EmptyContent from 'components/empty-content';
@@ -231,7 +232,13 @@ class ActivityLog extends Component {
 		const { isPressable, isRewindActive, logs, moment, translate, siteId, startDate } = this.props;
 
 		if ( isNull( logs ) ) {
-			return null;
+			return (
+				<div>
+					<ActivityLogDayPlaceholder />
+					<ActivityLogDayPlaceholder />
+					<ActivityLogDayPlaceholder />
+				</div>
+			);
 		}
 
 		const disableRestore = this.isRestoreInProgress();

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -233,11 +233,11 @@ class ActivityLog extends Component {
 
 		if ( isNull( logs ) ) {
 			return (
-				<div>
+				<section className="activity-log__wrapper" key="logs">
 					<ActivityLogDayPlaceholder />
 					<ActivityLogDayPlaceholder />
 					<ActivityLogDayPlaceholder />
-				</div>
+				</section>
 			);
 		}
 


### PR DESCRIPTION
Add placeholders for Activity Log views while log data is loading.

## Testing
1. Visit https://calypso.live/stats/activity?branch=update/activitylog-loading
1. Verify the placeholders before data is loaded.
1. You may not see the placeholders. It will be more relevant when month switching lands with #17179 lands
1. You can add a static null [here](https://github.com/Automattic/wp-calypso/blob/d0f2eeef61e7c123d157218bed96f4549f8f2143/client/my-sites/stats/activity-log/index.jsx#L348) to force placeholders to display.

## Screens

### Loaded view (no change)

![before](https://user-images.githubusercontent.com/841763/29361055-1cfbc8a0-8286-11e7-87df-c18db8d91638.png)

### Loading

![placeholder](https://user-images.githubusercontent.com/841763/29386475-48a59368-82dc-11e7-8f1a-06f68255be71.png)
