### PR TITLE
Extensions: WPJM - Add UI for the first step of the setup wizard

### DIFF
--- a/client/extensions/wp-job-manager/app/controller.js
+++ b/client/extensions/wp-job-manager/app/controller.js
@@ -2,6 +2,7 @@
  * External Dependencies
  */
 import React from 'react';
+import { get } from 'lodash';
 
 /**
  * Internal Dependencies
@@ -11,6 +12,7 @@ import titlecase from 'to-title-case';
 import { getSiteFragment, sectionify } from 'lib/route';
 import { renderWithReduxStore } from 'lib/react-helpers';
 import Settings from '../components/settings';
+import SetupWizard from '../components/setup';
 
 export const renderTab = ( component, tab = '' ) => ( context ) => {
 	const siteId = getSiteFragment( context.path );
@@ -37,6 +39,16 @@ export const renderTab = ( component, tab = '' ) => ( context ) => {
 		<Settings tab={ tab }>
 			{ React.createElement( component ) }
 		</Settings>,
+		document.getElementById( 'primary' ),
+		context.store
+	);
+};
+
+export const renderSetupWizard = context => {
+	const stepName = get( context, [ 'params', 'stepName' ] );
+
+	renderWithReduxStore(
+		<SetupWizard stepName={ stepName } />,
 		document.getElementById( 'primary' ),
 		context.store
 	);

--- a/client/extensions/wp-job-manager/components/setup/constants.js
+++ b/client/extensions/wp-job-manager/components/setup/constants.js
@@ -1,0 +1,5 @@
+export const Steps = {
+	FINAL: 'final',
+	INTRO: 'intro',
+	PAGE_SETUP: 'page-setup',
+};

--- a/client/extensions/wp-job-manager/components/setup/index.jsx
+++ b/client/extensions/wp-job-manager/components/setup/index.jsx
@@ -26,9 +26,10 @@ const SetupWizard = ( {
 	const components = {
 		[ Steps.INTRO ]: <Intro />,
 	};
+	const mainClassName = 'wp-job-manager__setup';
 
 	return (
-		<Main>
+		<Main className={ mainClassName }>
 			<DocumentHead title={ translate( 'Setup' ) } />
 			<Wizard
 				basePath={ `/extensions/wp-job-manager/setup/${ slug }` }

--- a/client/extensions/wp-job-manager/components/setup/index.jsx
+++ b/client/extensions/wp-job-manager/components/setup/index.jsx
@@ -1,0 +1,59 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import { Steps } from './constants';
+import DocumentHead from 'components/data/document-head';
+import Intro from './intro';
+import Main from 'components/main';
+import Wizard from 'components/wizard';
+import { getSiteSlug } from 'state/sites/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
+
+const SetupWizard = ( {
+	slug,
+	stepName = Steps.INTRO,
+	translate,
+} ) => {
+	const steps = [ Steps.INTRO ];
+	const components = {
+		[ Steps.INTRO ]: <Intro />,
+	};
+
+	return (
+		<Main>
+			<DocumentHead title={ translate( 'Setup' ) } />
+			<Wizard
+				basePath={ `/extensions/wp-job-manager/setup/${ slug }` }
+				components={ components }
+				forwardText={ translate( 'Continue' ) }
+				steps={ steps }
+				stepName={ stepName } />
+		</Main>
+	);
+};
+
+const connectComponent = connect(
+	state => {
+		const siteId = getSelectedSiteId( state );
+
+		return {
+			slug: getSiteSlug( state, siteId ),
+		};
+	}
+);
+
+SetupWizard.propTypes = {
+	slug: PropTypes.string,
+	stepName: PropTypes.string,
+	translate: PropTypes.func.isRequired,
+};
+
+export default connectComponent( localize( SetupWizard ) );

--- a/client/extensions/wp-job-manager/components/setup/index.jsx
+++ b/client/extensions/wp-job-manager/components/setup/index.jsx
@@ -40,9 +40,9 @@ const SetupWizard = ( {
 	);
 };
 
-const connectComponent = connect( state => ( {
+const mapStateToProps = state => ( {
 	slug: getSelectedSiteSlug( state ),
-} ) );
+} );
 
 SetupWizard.propTypes = {
 	slug: PropTypes.string,
@@ -50,4 +50,4 @@ SetupWizard.propTypes = {
 	translate: PropTypes.func.isRequired,
 };
 
-export default connectComponent( localize( SetupWizard ) );
+export default connect( mapStateToProps )( localize( SetupWizard ) );

--- a/client/extensions/wp-job-manager/components/setup/index.jsx
+++ b/client/extensions/wp-job-manager/components/setup/index.jsx
@@ -14,8 +14,7 @@ import DocumentHead from 'components/data/document-head';
 import Intro from './intro';
 import Main from 'components/main';
 import Wizard from 'components/wizard';
-import { getSiteSlug } from 'state/sites/selectors';
-import { getSelectedSiteId } from 'state/ui/selectors';
+import { getSelectedSiteSlug } from 'state/ui/selectors';
 
 const SetupWizard = ( {
 	slug,
@@ -41,15 +40,9 @@ const SetupWizard = ( {
 	);
 };
 
-const connectComponent = connect(
-	state => {
-		const siteId = getSelectedSiteId( state );
-
-		return {
-			slug: getSiteSlug( state, siteId ),
-		};
-	}
-);
+const connectComponent = connect( state => ( {
+	slug: getSelectedSiteSlug( state ),
+} ) );
 
 SetupWizard.propTypes = {
 	slug: PropTypes.string,

--- a/client/extensions/wp-job-manager/components/setup/intro/index.jsx
+++ b/client/extensions/wp-job-manager/components/setup/intro/index.jsx
@@ -9,7 +9,7 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import Button from 'components/button';
-import Card from 'components/card';
+import CompactCard from 'components/card/compact';
 import ExternalLink from 'components/external-link';
 import SectionHeader from 'components/section-header';
 
@@ -24,7 +24,7 @@ class Intro extends Component {
 		return (
 			<div>
 				<SectionHeader label={ translate( 'Welcome to the Setup Wizard!' ) } />
-				<Card>
+				<CompactCard>
 					<p>
 						{ translate(
 							'Thanks for installing {{em}}WP Job Manager{{/em}}! Let\'s get your site ready to accept job listings.',
@@ -56,10 +56,19 @@ class Intro extends Component {
 							}
 						) }
 					</p>
-					<Button compact>
-						{ translate( 'Skip setup. I will set up the plugin manually' ) }
+				</CompactCard>
+
+				<CompactCard>
+					<a
+						className="intro__skip-setup"
+						href="#">
+						{ translate( 'Skip setup. I will set up the plugin manually.' ) }
+					</a>
+					<Button primary
+						className="intro__continue">
+						{ translate( 'Continue' ) }
 					</Button>
-				</Card>
+				</CompactCard>
 			</div>
 		);
 	}

--- a/client/extensions/wp-job-manager/components/setup/intro/index.jsx
+++ b/client/extensions/wp-job-manager/components/setup/intro/index.jsx
@@ -1,0 +1,68 @@
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Button from 'components/button';
+import Card from 'components/card';
+import ExternalLink from 'components/external-link';
+import SectionHeader from 'components/section-header';
+
+class Intro extends Component {
+	static propTypes = {
+		translate: PropTypes.func.isRequired,
+	};
+
+	render() {
+		const { translate } = this.props;
+
+		return (
+			<div>
+				<SectionHeader label={ translate( 'Setup Wizard Introduction' ) } />
+				<Card>
+					<p>
+						{ translate(
+							'Thanks for installing {{em}}WP Job Manager{{/em}}!',
+							{ components: { em: <em /> } }
+						) }
+					</p>
+
+					<p>
+						{ translate(
+							'This setup wizard will help you get started by creating the pages for job submission, ' +
+							'job management, and listing your jobs.'
+						) }
+					</p>
+
+					<p>
+						{ translate(
+							'If you want to skip the wizard and setup the pages and shortcodes yourself manually, ' +
+							'the process is still relatively simple. Refer to the {{docs}}documentation{{/docs}} for help.',
+							{
+								components: {
+									docs: (
+										<ExternalLink
+											icon={ true }
+											target="_blank"
+											href="https://wpjobmanager.com/documentation/"
+										/>
+									),
+								}
+							}
+						) }
+					</p>
+					<Button compact>
+						{ translate( 'Skip setup. I will set up the plugin manually' ) }
+					</Button>
+				</Card>
+			</div>
+		);
+	}
+}
+
+export default localize( Intro );

--- a/client/extensions/wp-job-manager/components/setup/intro/index.jsx
+++ b/client/extensions/wp-job-manager/components/setup/intro/index.jsx
@@ -23,26 +23,26 @@ class Intro extends Component {
 
 		return (
 			<div>
-				<SectionHeader label={ translate( 'Setup Wizard Introduction' ) } />
+				<SectionHeader label={ translate( 'Welcome to the Setup Wizard!' ) } />
 				<Card>
 					<p>
 						{ translate(
-							'Thanks for installing {{em}}WP Job Manager{{/em}}!',
+							'Thanks for installing {{em}}WP Job Manager{{/em}}! Let\'s get your site ready to accept job listings.',
 							{ components: { em: <em /> } }
 						) }
 					</p>
 
 					<p>
 						{ translate(
-							'This setup wizard will help you get started by creating the pages for job submission, ' +
-							'job management, and listing your jobs.'
+							'This setup wizard will walk you through the process of creating pages for job submissions, ' +
+							'management, and listings.'
 						) }
 					</p>
 
 					<p>
 						{ translate(
-							'If you want to skip the wizard and setup the pages and shortcodes yourself manually, ' +
-							'the process is still relatively simple. Refer to the {{docs}}documentation{{/docs}} for help.',
+							'If you\'d prefer to skip this and set up your pages manually, our {{docs}}documentation{{/docs}} ' +
+							'will walk you through each step.',
 							{
 								components: {
 									docs: (

--- a/client/extensions/wp-job-manager/components/setup/intro/index.jsx
+++ b/client/extensions/wp-job-manager/components/setup/intro/index.jsx
@@ -65,8 +65,8 @@ class Intro extends Component {
 						{ translate( 'Skip setup. I will set up the plugin manually.' ) }
 					</a>
 					<Button primary
-						className="intro__continue">
-						{ translate( 'Continue' ) }
+						className="intro__start-setup">
+						{ translate( 'Start Setup' ) }
 					</Button>
 				</CompactCard>
 			</div>

--- a/client/extensions/wp-job-manager/components/setup/style.scss
+++ b/client/extensions/wp-job-manager/components/setup/style.scss
@@ -1,0 +1,25 @@
+.wp-job-manager__setup .intro__skip-setup {
+	color: $blue-medium;
+	display: block;
+	font-size: 13px;
+	text-align: center;
+
+	@include breakpoint( ">660px" ) {
+		float: left;
+		line-height: 38px;
+	}
+}
+
+.wp-job-manager__setup .intro__continue {
+	margin-top: 10px;
+
+	@include breakpoint( "<660px" ) {
+		margin-bottom: 18px;
+		width: 100%;
+	}
+
+	@include breakpoint( ">660px" ) {
+		float: right;
+		margin: 0;
+	}
+}

--- a/client/extensions/wp-job-manager/components/setup/style.scss
+++ b/client/extensions/wp-job-manager/components/setup/style.scss
@@ -10,7 +10,7 @@
 	}
 }
 
-.wp-job-manager__setup .intro__continue {
+.wp-job-manager__setup .intro__start-setup {
 	margin-top: 10px;
 
 	@include breakpoint( "<660px" ) {

--- a/client/extensions/wp-job-manager/index.js
+++ b/client/extensions/wp-job-manager/index.js
@@ -8,7 +8,7 @@ import { get } from 'lodash';
  * Internal dependencies
  */
 import { navigation, sites, siteSelection } from 'my-sites/controller';
-import { renderTab } from './app/controller';
+import { renderSetupWizard, renderTab } from './app/controller';
 import { Tabs } from './constants';
 import JobListings from './components/settings/job-listings';
 import JobSubmission from './components/settings/job-submission';
@@ -29,6 +29,7 @@ export default function() {
 		renderTab( JobSubmission, jobSubmissionSlug ) );
 	page( `/extensions/wp-job-manager/${ pagesSlug }/:site`, siteSelection, navigation,
 		renderTab( Pages, pagesSlug ) );
+	page( '/extensions/wp-job-manager/setup/:site/:stepName?', siteSelection, navigation, renderSetupWizard );
 }
 
 initExtension();

--- a/client/extensions/wp-job-manager/style.scss
+++ b/client/extensions/wp-job-manager/style.scss
@@ -1,1 +1,2 @@
 @import 'components/settings/style';
+@import 'components/setup/style';


### PR DESCRIPTION
This PR adds the UI (no functionality) for the first (intro) step of the WPJM setup wizard. The wizard will be triggered when the plugin is first activated. Note that there will ultimately be 3 steps in the wizard. Here is what the first one looks like:

![wpjm-setup-wizard-intro](https://user-images.githubusercontent.com/1190420/29420149-29a605f2-833f-11e7-9d94-59df322318b6.jpg)

For comparison's sake, here is what the intro step looks like in the plugin itself:

![plugin-setup-wizard-intro](https://user-images.githubusercontent.com/1190420/29420752-e86acb20-8340-11e7-8dcf-1b9200d5936f.jpg)

_Note: Because of the dependency on #17217, the calypso.live link doesn't work. Please use the screenshot for design or copy review._