### PR TITLE
Plans: Add plugin upload feature to My Plan for Business plan

### DIFF
--- a/client/blocks/product-purchase-features/product-purchase-features-list/index.jsx
+++ b/client/blocks/product-purchase-features/product-purchase-features-list/index.jsx
@@ -22,6 +22,7 @@ import {
 	PLAN_JETPACK_PERSONAL_MONTHLY
 } from 'lib/plans/constants';
 import FindNewTheme from './find-new-theme';
+import UploadPlugins from './upload-plugins';
 import AdvertisingRemoved from './advertising-removed';
 import GoogleVouchers from './google-vouchers';
 import CustomizeTheme from './customize-theme';
@@ -101,6 +102,10 @@ class ProductPurchaseFeaturesList extends Component {
 			<FindNewTheme
 				selectedSite={ selectedSite }
 				key="findNewThemeFeature"
+			/>,
+			<UploadPlugins
+				selectedSite={ selectedSite }
+				key="uploadPluginsFeature"
 			/>,
 			isWordadsInstantActivationEligible( selectedSite )
 				? <MonetizeSite

--- a/client/blocks/product-purchase-features/product-purchase-features-list/index.jsx
+++ b/client/blocks/product-purchase-features/product-purchase-features-list/index.jsx
@@ -35,6 +35,7 @@ import JetpackAntiSpam from './jetpack-anti-spam';
 import JetpackBackupSecurity from './jetpack-backup-security';
 import JetpackReturnToDashboard from './jetpack-return-to-dashboard';
 import JetpackWordPressCom from './jetpack-wordpress-com';
+import { isEnabled } from 'config';
 import { isWordadsInstantActivationEligible } from 'lib/ads/utils';
 import { hasDomainCredit } from 'state/sites/plans/selectors';
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
@@ -103,10 +104,12 @@ class ProductPurchaseFeaturesList extends Component {
 				selectedSite={ selectedSite }
 				key="findNewThemeFeature"
 			/>,
-			<UploadPlugins
-				selectedSite={ selectedSite }
-				key="uploadPluginsFeature"
-			/>,
+			isEnabled( 'manage/plugins/upload' )
+				? <UploadPlugins
+					selectedSite={ selectedSite }
+					key="uploadPluginsFeature"
+				/>
+				: null,
 			isWordadsInstantActivationEligible( selectedSite )
 				? <MonetizeSite
 					selectedSite={ selectedSite }

--- a/client/blocks/product-purchase-features/product-purchase-features-list/upload-plugins.jsx
+++ b/client/blocks/product-purchase-features/product-purchase-features-list/upload-plugins.jsx
@@ -1,0 +1,26 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import PurchaseDetail from 'components/purchase-detail';
+
+export default localize( ( { selectedSite, translate } ) => {
+	return (
+		<div className="product-purchase-features-list__item">
+			<PurchaseDetail
+				icon="plugins"
+				title={ translate( 'Upload a Plugin' ) }
+				description={ translate(
+					'You can now upload your own plugins, or ones you\'ve downloaded, directly through a drag and drop interface.'
+				) }
+				buttonText={ translate( 'Upload a plugin now' ) }
+				href={ '/plugins/upload/' + selectedSite.slug }
+			/>
+		</div>
+	);
+} );

--- a/client/blocks/product-purchase-features/product-purchase-features-list/upload-plugins.jsx
+++ b/client/blocks/product-purchase-features/product-purchase-features-list/upload-plugins.jsx
@@ -14,9 +14,10 @@ export default localize( ( { selectedSite, translate } ) => {
 		<div className="product-purchase-features-list__item">
 			<PurchaseDetail
 				icon="plugins"
-				title={ translate( 'Upload a Plugin' ) }
+				title={ translate( 'Add a Plugin' ) }
 				description={ translate(
-					'You can now upload your own plugins, or ones you\'ve downloaded, directly through a drag and drop interface.'
+					'Search and add plugins right from your dashboard, or upload a plugin ' +
+					'from your computer with a drag-and-drop interface.'
 				) }
 				buttonText={ translate( 'Upload a plugin now' ) }
 				href={ '/plugins/upload/' + selectedSite.slug }


### PR DESCRIPTION
This PR adds a "Upload a Plugin" feature to the "My Plan" page for Business plan owners:

![](https://cldup.com/U9jfIoNXZ2.png)

Fixes #17242

To test:
* Checkout this branch
* Go to `/plans/my-plan/:site`, where `:site` is a .com site on a Business plan.
* Verify you can see the plugin upload feature.
* Verify the plugin upload feature takes you to the plugin upload page (even though it's disabled for now).

In addition to a code and design review, this could use a copy review, cc @Automattic/editorial 