### PR TITLE
Add a layout for DOPS

### DIFF
--- a/client/layout/masterbar/oauth-client-woo.scss
+++ b/client/layout/masterbar/oauth-client-woo.scss
@@ -1,5 +1,27 @@
-.masterbar__oauth-client-user-nav {
-	float: right;
+.masterbar__oauth-client {
+	background-color: $blue-wordpress;
+
+	nav {
+		display: flex;
+		justify-content: space-between;
+	}
+
+	ul {
+		margin: 0;
+		padding-left: 0;
+
+		li {
+			list-style-type: none;
+		}
+	}
+
+	a {
+		text-decoration: none;
+	}
+
+	img {
+		display: block;
+	}
 }
 
 .masterbar__oauth-client-wpcc-sign-in {
@@ -65,15 +87,6 @@
 		left: 0;
 		right: 0;
 		z-index: 100;
-
- 		ul {
-			margin: 0;
-			padding-left: 0;
-
-			li {
-				list-style-type: none;
-			}
-		}
 	}
 
 	.masterbar__oauth-client a {
@@ -81,7 +94,6 @@
 		float: left;
 		line-height: 55px;
 		padding: 0 15px;
-		text-decoration: none;
 		transition: 0.05 all ease-in-out;
 
 		&:active {


### PR DESCRIPTION
This adds layouts to the OAuth login screen for our DOPS:
  
<img width="407" alt="screen shot 2017-08-16 at 14 24 45" src="https://user-images.githubusercontent.com/275961/29365378-b817babc-828e-11e7-8fc1-c86226bc0289.png">
  
#### Testing instructions
  
1. Run `git checkout add/dops` and start your server
2. Check that we have DOPS layouts for the following pages:

AKISMET: http://calypso.localhost:3000/log-in?client_id=973
POLLDADDY: http://calypso.localhost:3000/log-in?client_id=978
VAULTPRESS: http://calypso.localhost:3000/log-in?client_id=930
GRAVATAR: http://calypso.localhost:3000/log-in?client_id=1854
We should check that Woo still looks ok: http://calypso.localhost:3000/log-in?client_id=50916

#### Reviews
  
- [ ] Code
- [ ] Product