### PR TITLE
Plugin Uploads: Add a plugin upload feature to checkout thank you page

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/business-plan-details.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/business-plan-details.jsx
@@ -50,9 +50,10 @@ const BusinessPlanDetails = ( { selectedSite, sitePlans, selectedFeature } ) => 
 			{ ! selectedFeature && isEnabled( 'manage/plugins/upload' ) &&
 				<PurchaseDetail
 					icon="plugins"
-					title={ i18n.translate( 'Upload a Plugin' ) }
+					title={ i18n.translate( 'Add a Plugin' ) }
 					description={ i18n.translate(
-						'You can now upload your own plugins, or ones you\'ve downloaded, directly through a drag and drop interface.'
+						'Search and add plugins right from your dashboard, or upload a plugin ' +
+						'from your computer with a drag-and-drop interface.'
 					) }
 					buttonText={ i18n.translate( 'Upload a plugin now' ) }
 					href={ '/plugins/upload/' + selectedSite.slug } />

--- a/client/my-sites/checkout/checkout-thank-you/business-plan-details.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/business-plan-details.jsx
@@ -10,6 +10,7 @@ import i18n from 'i18n-calypso';
  */
 import analytics from 'lib/analytics';
 import CustomDomainPurchaseDetail from './custom-domain-purchase-detail';
+import { isEnabled } from 'config';
 import { isBusiness } from 'lib/products-values';
 import PurchaseDetail from 'components/purchase-detail';
 
@@ -46,7 +47,7 @@ const BusinessPlanDetails = ( { selectedSite, sitePlans, selectedFeature } ) => 
 					href={ '/themes/' + selectedSite.slug } />
 			}
 
-			{ ! selectedFeature &&
+			{ ! selectedFeature && isEnabled( 'manage/plugins/upload' ) &&
 				<PurchaseDetail
 					icon="plugins"
 					title={ i18n.translate( 'Upload a Plugin' ) }

--- a/client/my-sites/checkout/checkout-thank-you/business-plan-details.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/business-plan-details.jsx
@@ -46,6 +46,17 @@ const BusinessPlanDetails = ( { selectedSite, sitePlans, selectedFeature } ) => 
 					href={ '/themes/' + selectedSite.slug } />
 			}
 
+			{ ! selectedFeature &&
+				<PurchaseDetail
+					icon="plugins"
+					title={ i18n.translate( 'Upload a Plugin' ) }
+					description={ i18n.translate(
+						'You can now upload your own plugins, or ones you\'ve downloaded, directly through a drag and drop interface.'
+					) }
+					buttonText={ i18n.translate( 'Upload a plugin now' ) }
+					href={ '/plugins/upload/' + selectedSite.slug } />
+			}
+
 			<PurchaseDetail
 				icon="stats-alt"
 				title={ i18n.translate( 'Stats from Google Analytics' ) }


### PR DESCRIPTION
This PR adds a "Upload a Plugin" feature to the "Thank You" post checkout page for users who just bought a Business plan.

Before:
![](https://cldup.com/ZeMe8mDN4S.png)

After:
![](https://cldup.com/1d34y7k3x8.png)

Fixes #15673

To test:
* Checkout this branch
* Purchase a Business plan for one of your .com sites.
* Verify you can see the plugin upload feature in the thank you page.
* Verify the plugin upload feature takes you to the plugin upload page (even though it's disabled for now).

In addition to a code and design review, this could use a copy review, cc @Automattic/editorial 