### PR TITLE
Media: Enable video editor in all environments

### DIFF
--- a/client/post-editor/media-modal/detail/detail-item.jsx
+++ b/client/post-editor/media-modal/detail/detail-item.jsx
@@ -90,10 +90,6 @@ class EditorMediaModalDetailItem extends Component {
 	 * @return {Boolean} Whether the video editor can be enabled
 	 */
 	enableVideoEditing( item ) {
-		if ( ! config.isEnabled( 'post-editor/video-editor' ) ) {
-			return false;
-		}
-
 		const {
 			isJetpack,
 			isVideoPressEnabled,

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -68,7 +68,6 @@
 		"post-editor/author-selector": true,
 		"post-editor/html-toolbar": true,
 		"post-editor/image-editor": true,
-		"post-editor/video-editor": false,
 		"press-this": false,
 		"preview-layout": true,
 		"reader": true,

--- a/config/development.json
+++ b/config/development.json
@@ -123,7 +123,6 @@
 		"post-editor/image-editor": true,
 		"post-editor/media-advanced": false,
 		"post-editor/revisions": true,
-		"post-editor/video-editor": true,
 		"posts/post-type-list": false,
 		"press-this": true,
 		"publicize-preview": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -76,7 +76,6 @@
 		"post-editor/delta-post-publish-flow": true,
 		"post-editor/html-toolbar": true,
 		"post-editor/image-editor": true,
-		"post-editor/video-editor": true,
 		"publicize-preview": true,
 		"press-this": true,
 		"preview-layout": true,

--- a/config/production.json
+++ b/config/production.json
@@ -74,7 +74,6 @@
 		"post-editor/delta-post-publish-flow": true,
 		"post-editor/html-toolbar": true,
 		"post-editor/image-editor": true,
-		"post-editor/video-editor": false,
 		"press-this": true,
 		"preview-layout": true,
 		"publicize-preview": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -79,7 +79,6 @@
 		"post-editor/delta-post-publish-flow": true,
 		"post-editor/html-toolbar": true,
 		"post-editor/image-editor": true,
-		"post-editor/video-editor": true,
 		"press-this": true,
 		"preview-layout": true,
 		"publicize-preview": true,

--- a/config/test.json
+++ b/config/test.json
@@ -80,7 +80,6 @@
 		"plans/personal-plan": true,
 		"post-editor-github-link": false,
 		"post-editor/media-advanced": true,
-		"post-editor/video-editor": false,
 		"press-this": true,
 		"publicize-preview": true,
 		"reader": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -89,7 +89,6 @@
 		"post-editor/delta-post-publish-flow": true,
 		"post-editor/html-toolbar": true,
 		"post-editor/image-editor": true,
-		"post-editor/video-editor": true,
 		"press-this": true,
 		"preview-layout": true,
 		"publicize-preview": true,


### PR DESCRIPTION
Video editor is currently enabled in all environments except for production. This PR ensures that video editor now works everywhere.

## Testing

1. Edit a blog post.
2. Click the + button in the editor toolbar and then select _Add Media_.
3. Upload a video or select an existing video.
4. Click the _Edit_ button.
5. Ensure that the _Edit Thumbnail_ button is visible.