### PR TITLE
JPO: selectable blocks, state handling, form state and more

### DIFF
--- a/client/signup/steps/jpo-contact-form/index.jsx
+++ b/client/signup/steps/jpo-contact-form/index.jsx
@@ -49,11 +49,21 @@ const JPOContactFormStep = React.createClass( {
 	renderStepContent() {
 		return (
 			<div className="jpo__contact-form-wrapper">
-				<Card>
-					<ContactUsGraphic />
-					<Button onClick={ this.onSelect }>Add a contact form</Button>
-					<div className="jpo__contact-form-description">Not sure? You can skip this step and add a contact form later.</div>
-				</Card>
+				<a className="jpo-homepage__select-news" href="#" onClick={ this.onSelect }>
+					<Card>
+						<ContactUsGraphic />
+						<Button onClick={ this.onSelect }>
+							{
+								translate( 'Add a contact form' )
+							}
+						</Button>
+						<div className="jpo__contact-form-description">
+							{
+								translate( 'Not sure? You can skip this step and add a contact form later.' )
+							}
+						</div>
+					</Card>
+				</a>
 			</div>
 		);
 	},

--- a/client/signup/steps/jpo-contact-form/style.scss
+++ b/client/signup/steps/jpo-contact-form/style.scss
@@ -1,20 +1,25 @@
 .jpo__contact-form-wrapper .card {
 	max-width: 320px;
 	text-align: center;
-}
 
-.jpo__contact-form-wrapper .card svg {
-	width: 100%;
-	height: auto;
-	margin-bottom: 1rem;
-}
+	&:hover,
+	&.is-selected {
+		box-shadow: 0 0 0 1px $gray, 0 2px 4px lighten( $gray, 20 );
+	}
 
-.jpo__contact-form-wrapper .card .button {
-	font-size: 1.25rem;
-	margin-bottom: 1rem;
-	color: $blue-wordpress;
-	padding: 7px;
-    line-height: 1;
+	svg {
+		width: 100%;
+		height: auto;
+		margin-bottom: 1rem;
+	}
+
+	.button {
+		font-size: 1.25rem;
+		margin-bottom: 1rem;
+		color: $blue-wordpress;
+		padding: 7px;
+		line-height: 1;
+	}
 }
 
 .jpo__contact-form-description {

--- a/client/signup/steps/jpo-homepage/index.jsx
+++ b/client/signup/steps/jpo-homepage/index.jsx
@@ -52,19 +52,28 @@ const JPOHomepageStep = React.createClass( {
 	},
 
 	renderStepContent() {
+		console.log( this.props );
 		return (
 			<div className="jpo__homepage-wrapper">
 				<div className="jpo__homepage-row">
-					<Card>
-						<NewsGraphic />
-						<Button onClick={ this.onSelectNews }>{ translate( 'Recent news or updates' ) }</Button>
-						<div className="jpo__homepage-description">{ translate( 'We can pull the latest information into your homepage for you.' ) }</div>
-					</Card>
-					<Card>
-						<StaticGraphic />
-						<Button onClick={ this.onSelectStatic }>{ translate( 'A static welcome page' ) }</Button>
-						<div className="jpo__homepage-description">{ translate( 'Have your homepage stay the same as time goes on.' ) }</div>
-					</Card>
+					<a className="jpo-homepage__select-news" href="#" onClick={ this.onSelectNews }>
+						<Card>
+							<NewsGraphic />
+							<Button onClick={ this.onSelectNews }>{ translate( 'Recent news or updates' ) }</Button>
+							<div className="jpo__homepage-description">
+								{ translate( 'We can pull the latest information into your homepage for you.' ) }
+							</div>
+						</Card>
+					</a>
+					<a className="jpo-homepage__select-static" href="#" onClick={ this.onSelectStatic }>
+						<Card>
+							<StaticGraphic />
+							<Button onClick={ this.onSelectStatic }>{ translate( 'A static welcome page' ) }</Button>
+							<div className="jpo__homepage-description">
+								{ translate( 'Have your homepage stay the same as time goes on.' ) }
+							</div>
+						</Card>
+					</a>
 				</div>
 			</div>
 		);

--- a/client/signup/steps/jpo-homepage/index.jsx
+++ b/client/signup/steps/jpo-homepage/index.jsx
@@ -4,6 +4,7 @@
 import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
 import get from 'lodash/get';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies
@@ -52,12 +53,15 @@ const JPOHomepageStep = React.createClass( {
 	},
 
 	renderStepContent() {
-		console.log( this.props );
 		return (
 			<div className="jpo__homepage-wrapper">
 				<div className="jpo__homepage-row">
 					<a className="jpo-homepage__select-news" href="#" onClick={ this.onSelectNews }>
-						<Card>
+						<Card
+							className={ classNames( {
+								'is-selected': 'news' === get( this.props.signupDependencies, 'jpoHomepage', '' )
+							} ) }
+							>
 							<NewsGraphic />
 							<Button onClick={ this.onSelectNews }>{ translate( 'Recent news or updates' ) }</Button>
 							<div className="jpo__homepage-description">
@@ -66,7 +70,11 @@ const JPOHomepageStep = React.createClass( {
 						</Card>
 					</a>
 					<a className="jpo-homepage__select-static" href="#" onClick={ this.onSelectStatic }>
-						<Card>
+						<Card
+							className={ classNames( {
+								'is-selected': 'static' === get( this.props.signupDependencies, 'jpoHomepage', '' )
+							} ) }
+							>
 							<StaticGraphic />
 							<Button onClick={ this.onSelectStatic }>{ translate( 'A static welcome page' ) }</Button>
 							<div className="jpo__homepage-description">
@@ -106,5 +114,7 @@ const JPOHomepageStep = React.createClass( {
 
 export default connect(
 	null,
-	{ setJPOHomepage }
+	{
+		setJPOHomepage
+	}
 )( JPOHomepageStep );

--- a/client/signup/steps/jpo-homepage/style.scss
+++ b/client/signup/steps/jpo-homepage/style.scss
@@ -1,37 +1,43 @@
 .jpo__homepage-wrapper {
 	margin-left: auto;
 	margin-right: auto;
+	display: flex;
 }
 
 .jpo__homepage-row {
 	max-width: 600px;
 	margin-left: auto;
 	margin-right: auto;
-}
 
-.jpo__homepage-row .card {
-	width: 49%;
-	display: inline-block;
-	vertical-align: top;
-	text-align: center;
-}
+	.card {
+		width: 49%;
+		display: inline-block;
+		vertical-align: top;
+		text-align: center;
 
-.jpo__homepage-row .card svg {
-	width: 94%;
-	height: auto;
-	margin-bottom: 1rem;
-}
+		&:hover,
+		&.is-selected {
+			box-shadow: 0 0 0 1px $gray, 0 2px 4px lighten( $gray, 20 );
+		}
 
-.jpo__homepage-row .card:first-child {
-	margin-right: 2%;
-}
+		svg {
+			width: 94%;
+			height: auto;
+			margin-bottom: 1rem;
+		}
 
-.jpo__homepage-row .card .button {
-	font-size: 1.25rem;
-	margin-bottom: 1rem;
-	color: $blue-wordpress;
-	padding: 7px;
-    line-height: 1;
+		.button {
+			font-size: 1.25rem;
+			margin-bottom: 1rem;
+			color: $blue-wordpress;
+			padding: 7px;
+			line-height: 1;
+		}
+	}
+
+	a:first-child .card {
+		margin-right: 2%;
+	}
 }
 
 .jpo__homepage-description {

--- a/client/signup/steps/jpo-site-title/index.jsx
+++ b/client/signup/steps/jpo-site-title/index.jsx
@@ -4,6 +4,7 @@
 import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
 import noop from 'lodash/noop';
+import get from 'lodash/get';
 
 /**
  * Internal dependencies
@@ -20,7 +21,6 @@ import Button from 'components/button';
 import { translate } from 'i18n-calypso';
 
 import { setJPOSiteTitle } from 'state/signup/steps/jpo-site-title/actions';
-import { getJPOSiteTitle, getJPOSiteDescription } from 'state/signup/steps/jpo-site-title/selectors';
 
 const JPOSiteTitleStep = React.createClass( {
 	errorMessage: '',
@@ -35,10 +35,6 @@ const JPOSiteTitleStep = React.createClass( {
 	},
 
 	componentWillMount() {
-		const {
-			storeJpoSiteTitle,
-			storeJpoSiteDescription,
-		} = this.props;
 		this.formStateController = new formState.Controller( {
 			fieldNames: [ 'siteTitle', 'siteDescription' ],
 			validatorFunction: noop,
@@ -46,10 +42,10 @@ const JPOSiteTitleStep = React.createClass( {
 			hideFieldErrorsOnChange: true,
 			initialState: {
 				siteTitle: {
-					value: storeJpoSiteTitle
+					value: get( this.props.signupDependencies, [ 'jpoSiteTitle', 'siteTitle' ], '' )
 				},
 				siteDescription: {
-					value: storeJpoSiteDescription
+					value: get( this.props.signupDependencies, [ 'jpoSiteTitle', 'siteDescription' ], '' )
 				}
 			}
 		} );
@@ -167,12 +163,7 @@ const JPOSiteTitleStep = React.createClass( {
 } );
 
 export default connect(
-	state => {
-		return {
-			storeJpoSiteTitle: getJPOSiteTitle( state ),
-			storeJpoSiteDescription: getJPOSiteDescription( state )
-		};
-	},
+	null,
 	{
 		setJPOSiteTitle
 	}

--- a/client/signup/steps/jpo-site-type/select-business-address.jsx
+++ b/client/signup/steps/jpo-site-type/select-business-address.jsx
@@ -1,45 +1,82 @@
+/**
+ * External dependencies
+ */
 import React from 'react';
-
+import PropTypes from 'prop-types';
 import { translate } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
 import Card from 'components/card';
 import Button from 'components/button';
 import FormLabel from 'components/forms/form-label';
 import FormTextInput from 'components/forms/form-text-input';
-import FormTextarea from 'components/forms/form-textarea';
 
-import PersonalGraphic from './personal-graphic';
-import BusinessGraphic from './business-graphic';
+class SelectBusinessAddress extends React.Component {
 
-module.exports = React.createClass( {
+	static propTypes = {
+		signupDependencies: PropTypes.object,
+		handleBusinessInfo: PropTypes.func,
+		businessInfo: PropTypes.object,
+		required: PropTypes.bool,
+	};
 
-	displayName: 'SelectBusinessAddress',
-
-	propTypes: {
-		required: React.PropTypes.bool,
-	},
-
-	render: function() {
+	render() {
 		if ( ! this.props.current ) {
 			return ( <div /> );
 		}
+
+		const {
+			handleBusinessInfo,
+			businessInfo: {
+				businessName,
+				streetAddress,
+				city,
+				state,
+				zipCode
+			}
+		} = this.props;
 
 		return ( 
 			<div className="jpo__site-type-wrapper business-address">
 				<Card>
 					<FormLabel>{ translate( 'Business Name' ) }</FormLabel>
-					<FormTextInput onChange={ this.props.onInputBusinessName } />
+					<FormTextInput
+						name="businessName"
+						value={ businessName }
+						onChange={ handleBusinessInfo }
+						/>
 					<FormLabel>{ translate( 'Street Address' ) }</FormLabel>
-					<FormTextInput onChange={ this.props.onInputStreetAddress } />
+					<FormTextInput
+						name="streetAddress"
+						value={ streetAddress }
+						onChange={ handleBusinessInfo }
+						/>
 					<FormLabel>{ translate( 'City' ) }</FormLabel>
-					<FormTextInput onChange={ this.props.onInputCity } />
+					<FormTextInput
+						name="city"
+						value={ city }
+						onChange={ handleBusinessInfo }
+						/>
 					<FormLabel>{ translate( 'State' ) }</FormLabel>
-					<FormTextInput onChange={ this.props.onInputState } />
+					<FormTextInput
+						name="state"
+						value={ state }
+						onChange={ handleBusinessInfo }
+						/>
 					<FormLabel>{ translate( 'ZIP Code' ) }</FormLabel>
-					<FormTextInput onChange={ this.props.onInputZip } />
+					<FormTextInput
+						name="zipCode"
+						value={ zipCode }
+						onChange={ handleBusinessInfo }
+						/>
 					<Button primary onClick={ this.props.submitStep }>{ translate( 'Next Step' ) }</Button>
 				</Card>
 			</div>
 		);
 	}
 
-} );
+}
+
+export default SelectBusinessAddress;

--- a/client/signup/steps/jpo-site-type/select-business-personal.jsx
+++ b/client/signup/steps/jpo-site-type/select-business-personal.jsx
@@ -1,55 +1,68 @@
+/**
+ * External dependencies
+ */
 import React from 'react';
-
+import PropTypes from 'prop-types';
 import { translate } from 'i18n-calypso';
+import get from 'lodash/get';
+import classNames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
 import Card from 'components/card';
 import Button from 'components/button';
-
 import PersonalGraphic from './personal-graphic';
 import BusinessGraphic from './business-graphic';
 
-module.exports = React.createClass( {
+class SelectBusinessPersonal extends React.Component {
 
-	displayName: 'SelectBusinessPersonal',
+	static propTypes = {
+		signupDependencies: PropTypes.object,
+		required: PropTypes.bool
+	};
 
-	propTypes: {
-		required: React.PropTypes.bool,
-	},
-
-	render: function() {
+	render() {
 		if ( ! this.props.current ) {
 			return ( <div /> );
 		}
 
 		return ( 
-			<div className="jpo__site-type-wrapper">
-				<div className="jpo__site-type-row jpo__site-type-row-small">
-					<div className="card design-type-with-store__choice">
-						<a className="design-type-with-store__choice-link:after" href="#"
-						onClick={ this.props.onSelectPersonal }>
-						<div className="design-type-with-store__image">
-						<PersonalGraphic />
-						</div>
-						<div className="design-type-with-store__choice-copy">
-						<span className="button is-compact design-type-with-store__cta"
-						onClick={ this.props.onSelectPersonal }>{ translate( 'Personal site' ) }</span>
-						</div>
+			<div className="jpo-site-type__wrapper">
+				<div className="jpo-site-type__row jpo-site-type__row-small">
+					<Card className={ classNames( 'jpo-site-type__choice', {
+						'is-selected': 'personal' === get( this.props.signupDependencies, [ 'jpoSiteType', 'businessPersonal' ], '' )
+					} ) }>
+						<a className="jpo-site-type__choice-link" href="#" onClick={ this.props.onSelectPersonal }>
+							<div className="jpo-site-type__image">
+								<PersonalGraphic />
+							</div>
+							<div className="jpo-site-type__choice-copy">
+								<Button onClick={ this.props.onSelectPersonal }>
+									{ translate( 'Personal site' ) }
+								</Button>
+							</div>
 						</a>
-					</div>
-					<div className="card design-type-with-store__choice">
-						<a className="design-type-with-store__choice-link:after" href="#"
-						onClick={ this.props.onSelectBusiness }>
-						<div className="design-type-with-store__image">
-						<BusinessGraphic />
-						</div>
-						<div className="design-type-with-store__choice-copy">
-						<span className="button is-compact design-type-with-store__cta"
-						onClick={ this.props.onSelectBusiness }>{ translate( 'Business site' ) }</span>
-						</div>
+					</Card>
+					<Card className={ classNames( 'jpo-site-type__choice', {
+						'is-selected': 'business' === get( this.props.signupDependencies, [ 'jpoSiteType', 'businessPersonal' ], '' )
+					} ) }>
+						<a className="jpo-site-type__choice-link" href="#" onClick={ this.props.onSelectBusiness }>
+							<div className="jpo-site-type__image">
+								<BusinessGraphic />
+							</div>
+							<div className="jpo-site-type__choice-copy">
+								<Button onClick={ this.props.onSelectBusiness }>
+									{ translate( 'Business site' ) }
+								</Button>
+							</div>
 						</a>
-					</div>
+					</Card>
 				</div>
 			</div>
 		);
 	}
 
-} );
+}
+
+export default SelectBusinessPersonal;

--- a/client/signup/steps/jpo-site-type/select-genre.jsx
+++ b/client/signup/steps/jpo-site-type/select-genre.jsx
@@ -1,93 +1,113 @@
+/**
+ * External dependencies
+ */
 import React from 'react';
-
+import PropTypes from 'prop-types';
 import { translate } from 'i18n-calypso';
+import get from 'lodash/get';
+import classNames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
 import Card from 'components/card';
 import Button from 'components/button';
-
 import BlogGraphic from './blog-graphic';
 import WebsiteGraphic from './website-graphic';
 import PortfolioGraphic from './portfolio-graphic';
 import StoreGraphic from './store-graphic';
 
-module.exports = React.createClass( {
+class SelectGenre extends React.Component {
 
-	displayName: 'SelectGenre',
+	static propTypes = {
+		signupDependencies: PropTypes.object,
+		required: PropTypes.bool
+	};
 
-	propTypes: {
-		required: React.PropTypes.bool,
-	},
-
-	render: function() {
+	render() {
 		if ( ! this.props.current ) {
 			return ( <div /> );
 		}
 
-		return ( 
-
-			<div className="jpo__site-type-wrapper">
-				<div className="jpo__site-type-row">
-					<div className="card design-type-with-store__choice">
-						<a className="design-type-with-store__choice-link:after" href="#"
-						onClick={ this.props.onSelectBlog }>
-						<div className="design-type-with-store__image">
-						<BlogGraphic />
-						</div>
-						<div className="design-type-with-store__choice-copy">
-						<span className="button is-compact design-type-with-store__cta"
-						onClick={ this.props.onSelectBlog }>{
-							translate( 'Start with a blog' ) }</span>
-						<p className="jpo__site-type-description">{
-							translate( 'To share your ideas, stories, and photographs with your followers.' ) }</p>
-						</div>
+		return (
+			<div className="jpo-site-type__wrapper">
+				<div className="jpo-site-type__row">
+					<Card className={ classNames( 'jpo-site-type__choice', {
+						'is-selected': 'blog' === get( this.props.signupDependencies, [ 'jpoSiteType', 'genre' ], '' )
+					} ) }>
+						<a className="jpo-site-type__choice-link" href="#" onClick={ this.props.onSelectBlog }>
+							<div className="jpo-site-type__image">
+								<BlogGraphic />
+							</div>
+							<div className="jpo-site-type__choice-copy">
+								<Button onClick={ this.props.onSelectBlog }>
+									{ translate( 'Start with a blog' ) }
+								</Button>
+								<p className="jpo-site-type__description">
+									{ translate( 'To share your ideas, stories, and photographs with your followers.' ) }
+								</p>
+							</div>
 						</a>
-					</div>
-					<div className="card design-type-with-store__choice">
-						<a className="design-type-with-store__choice-link:after" href="#"
-						onClick={ this.props.onSelectWebsite }>
-						<div className="design-type-with-store__image">
-						<WebsiteGraphic />
-						</div>
-						<div className="design-type-with-store__choice-copy">
-						<span className="button is-compact design-type-with-store__cta"
-						onClick={ this.props.onSelectWebsite }>{
-							translate( 'Start with a website' ) }</span>
-						<p className="jpo__site-type-description">{
-							translate( 'To promote your business, organization, or brand and connect with your audience.' ) }</p>
-						</div>
+					</Card>
+					<Card className={ classNames( 'jpo-site-type__choice', {
+						'is-selected': 'website' === get( this.props.signupDependencies, [ 'jpoSiteType', 'genre' ], '' )
+					} ) }>
+						<a className="jpo-site-type__choice-link" href="#" onClick={ this.props.onSelectWebsite }>
+							<div className="jpo-site-type__image">
+								<WebsiteGraphic />
+							</div>
+							<div className="jpo-site-type__choice-copy">
+								<Button onClick={ this.props.onSelectWebsite }>
+									{ translate( 'Start with a website' ) }
+								</Button>
+								<p className="jpo-site-type__description">
+									{ translate( 'To promote your business, organization, or brand and connect with your audience.' ) }
+								</p>
+							</div>
 						</a>
-					</div>
-					<div className="card design-type-with-store__choice">
-						<a className="design-type-with-store__choice-link:after" href="#"
-						onClick={ this.props.onSelectWebsite }>
-						<div className="design-type-with-store__image">
-						<PortfolioGraphic />
-						</div>
-						<div className="design-type-with-store__choice-copy">
-						<span className="button is-compact design-type-with-store__cta"
-						onClick={ this.props.onSelectPortfolio }>{ translate( 'Start with a portfolio' ) }</span>
-						<p className="jpo__site-type-description">{
-							translate( 'To present your creative projects in a visual showcase.' ) }</p>
-						</div>
+					</Card>
+					<Card className={ classNames( 'jpo-site-type__choice', {
+						'is-selected': 'portfolio' === get( this.props.signupDependencies, [ 'jpoSiteType', 'genre' ], '' )
+					} ) }>
+						<a className="jpo-site-type__choice-link" href="#" onClick={ this.props.onSelectPortfolio }>
+							<div className="jpo-site-type__image">
+								<PortfolioGraphic />
+							</div>
+							<div className="jpo-site-type__choice-copy">
+								<Button onClick={ this.props.onSelectPortfolio }>
+									{ translate( 'Start with a portfolio' ) }
+								</Button>
+								<p className="jpo-site-type__description">
+									{ translate( 'To present your creative projects in a visual showcase.' ) }
+								</p>
+							</div>
 						</a>
-					</div>
-					<div className="card design-type-with-store__choice">
-						<a className="design-type-with-store__choice-link:after" href="#"
-						onClick={ this.props.onSelectWebsite }>
-						<div className="design-type-with-store__image">
-						<StoreGraphic />
-						</div>
-						<div className="design-type-with-store__choice-copy">
-						<span className="button is-compact design-type-with-store__cta"
-						onClick={ this.props.onSelectStore }>{ translate( 'Start with an online store' ) }</span>
-						<p className="jpo__site-type-description">{
-							translate( 'To sell your products or services and accept payments.' ) }</p>
-						</div>
+					</Card>
+					<Card className={ classNames( 'jpo-site-type__choice', {
+						'is-selected': 'store' === get( this.props.signupDependencies, [ 'jpoSiteType', 'genre' ], '' )
+					} ) }>
+						<a className="jpo-site-type__choice-link" href="#" onClick={ this.props.onSelectStore }>
+							<div className="jpo-site-type__image">
+								<StoreGraphic />
+							</div>
+							<div className="jpo-site-type__choice-copy">
+								<Button onClick={ this.props.onSelectStore }>
+									{ translate( 'Start with an online store' ) }
+								</Button>
+								<p className="jpo-site-type__description">
+									{ translate( 'To sell your products or services and accept payments.' ) }
+								</p>
+							</div>
 						</a>
-					</div>
+					</Card>
 				</div>
-				<div className="jpo__site-type-note">{ translate( 'Not sure? Pick the closest option. You can always change your settings later.' ) }</div>
+				<div className="jpo-site-type__note">
+					{ translate( 'Not sure? Pick the closest option. You can always change your settings later.' ) }
+				</div>
 			</div>
 		);
 	}
 
-} );
+}
+
+export default SelectGenre;

--- a/client/signup/steps/jpo-site-type/style.scss
+++ b/client/signup/steps/jpo-site-type/style.scss
@@ -1,13 +1,13 @@
-.jpo__site-type-wrapper {
+.jpo-site-type__wrapper {
 	margin-left: auto;
 	margin-right: auto;
 }
 
-.jpo__site-type-wrapper header {
+.jpo-site-type__wrapper header {
 	text-align: center;
 }
 
-.jpo__site-type-row {
+.jpo-site-type__row {
 	margin: 0 auto;
 	display: flex;
 	flex-flow: row wrap;
@@ -25,7 +25,7 @@
 	}
 }
 
-.jpo__site-type-row .card {
+.jpo-site-type__row .card {
 	width: 46%;
 	display: inline-block;
 	vertical-align: top;
@@ -38,16 +38,16 @@
 	}
 }
 
-.jpo__site-type-row .card svg {
+.jpo-site-type__row .card svg {
 	max-width: 100%;
 	max-height: 190px;
 }
 
-.jpo__site-type-row-small .card svg {
+.jpo-site-type__row-small .card svg {
 	max-height: 117px;
 }
 
-.jpo__site-type-row .card:first-child {
+.jpo-site-type__row .card:first-child {
 	@include breakpoint( ">480px" ) {
 		margin-right: 2%;
 	}
@@ -57,7 +57,7 @@
 	}
 }
 
-.jpo__site-type-row .card .button {
+.jpo-site-type__row .card .button {
 	font-size: 1.25rem;
 	margin-bottom: 1rem;
 	color: $blue-wordpress;
@@ -74,7 +74,7 @@
 	}
 }
 
-.jpo__site-type-row-small .card .button {
+.jpo-site-type__row-small .card .button {
 	text-transform: none;
 	margin-top: 1rem;
 	margin-bottom: 0;
@@ -82,7 +82,7 @@
     line-height: 1;
 }
 
-.button .design-type-with-store__cta {
+.button .jpo-site-type__cta {
 	@include breakpoint( ">480px" ) {
 		background: none;
 	    font-size: 1.1em;
@@ -94,7 +94,7 @@
 	}
 }
 
-p.jpo__site-type-description {
+p.jpo-site-type__description {
 	font-size: 1.25rem;
 	color: $gray;
 	margin: 0;
@@ -108,7 +108,7 @@ p.jpo__site-type-description {
 	}
 }
 
-.jpo__site-type-note {
+.jpo-site-type__note {
 	text-align: center;
 	color: darken( $gray, 20% );
 	font-size: 14px;
@@ -142,7 +142,7 @@ p.jpo__site-type-description {
 	}
 }
 
-.design-type-with-store__choice {
+.jpo-site-type__choice {
 	transition: all 100ms ease-in-out;
 	position: relative;
 	border: 1px solid lighten( $gray, 20% );
@@ -161,17 +161,18 @@ p.jpo__site-type-description {
 		flex-grow: 1;
 		border: 0;
 
-		&:hover {
+		&:hover,
+		&.is-selected {
 			box-shadow: 0 0 0 1px $gray, 0 2px 4px lighten( $gray, 20 );
 		}
 	}
 
 	&:active {
-		.design-type-with-store__cta {
+		.jpo-site-type__cta {
 			color: $blue-dark;
 		}
 
-		.design-type-with-store__choice-link:after {
+		.jpo-site-type__choice-link:after {
 			border-top-color: $blue-dark;
 			border-right-color: $blue-dark;
 		}
@@ -204,7 +205,7 @@ p.jpo__site-type-description {
 	}
 }
 
-.design-type-with-store__choice-copy {
+.jpo-site-type__choice-copy {
 	border-top: 1px solid rgba(200, 215, 225, 0.5);
 
 	@include breakpoint( "<480px" ) {
@@ -214,29 +215,29 @@ p.jpo__site-type-description {
 }
 
 @include breakpoint( ">480px" ) {
-	.design-type-with-store__choice-copy {
+	.jpo-site-type__choice-copy {
 		padding: 15px;
 		border-top: 1px solid transparentize( lighten( $gray, 20% ), .5 );
 	}
 }
 
 
-.design-type-with-store__image {
+.jpo-site-type__image {
 	padding:15px;
 }
 
 	&:active {
-		.design-type-with-store__cta {
+		.jpo-site-type__cta {
 			color: $blue-dark;
 		}
 
-		.design-type-with-store__choice-link:after {
+		.jpo-site-type__choice-link:after {
 			border-top-color: $blue-dark;
 			border-right-color: $blue-dark;
 		}
 	}
 
-.design-type-with-store__choice-link {
+.jpo-site-type__choice-link {
 	padding-right: 40px;
 	display: block;
 	box-sizing: border-box;

--- a/client/state/signup/steps/jpo-homepage/selectors.js
+++ b/client/state/signup/steps/jpo-homepage/selectors.js
@@ -1,8 +1,13 @@
 /**
  * External dependencies
  */
-import { get } from 'lodash';
+import get from 'lodash/get';
 
-export function getHomepage( state ) {
-	return get( state, 'signup.steps.jpoHomepage', '' );
+/**
+ * Get stored home page as was last chosen by user.
+ * @param  {Object} state Global state tree
+ * @return {String} Site title in state tree.
+ */
+export function getJPOHomepage( state ) {
+	return get( state, [ 'signup', 'dependencyStore', 'jpoHomepage' ], '' );
 }


### PR DESCRIPTION
In this PR:
- make blocks for home page and contact form selection fully clickable
- make form data for business data persistent
- show selection using a `is-selected` class applied to element
- make image selections persistent
- fix state handling in the site type screens
- make some strings available for translation
- refactor classes to be ES6
- fix CSS classes to have the proper prefix
- fix deprecated React.PropTypes to use prop-types package
- fix stray `:after` in class names in JSX
- fix rendered components (<a>) by their original versions (<Button>)

Gif shows how the image selection and form data are persistent, and how the button and full image can be clicked to select one
![persistent-select](https://user-images.githubusercontent.com/1041600/29367844-8d27561a-8274-11e7-9e2f-3de567648bb7.gif)
