### PR TITLE
Comments: Add edit form

### DIFF
--- a/client/blocks/comment-detail/comment-detail-actions.jsx
+++ b/client/blocks/comment-detail/comment-detail-actions.jsx
@@ -11,6 +11,7 @@ import { includes } from 'lodash';
  * Internal dependencies
  */
 import Button from 'components/button';
+import { isEnabled } from 'config';
 
 const commentActions = {
 	unapproved: [ 'like', 'approve', 'edit', 'spam', 'trash' ],
@@ -71,7 +72,7 @@ export const CommentDetailActions = ( {
 				</Button>
 			}
 
-			{ hasAction( commentStatus, 'edit' ) &&
+			{ hasAction( commentStatus, 'edit' ) && isEnabled( 'comments/management/edit' ) &&
 				<Button
 					borderless
 					className="comment-detail__action-edit"

--- a/client/blocks/comment-detail/comment-detail-actions.jsx
+++ b/client/blocks/comment-detail/comment-detail-actions.jsx
@@ -13,8 +13,8 @@ import { includes } from 'lodash';
 import Button from 'components/button';
 
 const commentActions = {
-	unapproved: [ 'like', 'approve', 'spam', 'trash' ],
-	approved: [ 'like', 'approve', 'spam', 'trash' ],
+	unapproved: [ 'like', 'approve', 'edit', 'spam', 'trash' ],
+	approved: [ 'like', 'approve', 'edit', 'spam', 'trash' ],
 	spam: [ 'approve', 'delete' ],
 	trash: [ 'approve', 'spam', 'delete' ],
 };
@@ -26,6 +26,7 @@ export const CommentDetailActions = ( {
 	commentIsLiked,
 	commentStatus,
 	deleteCommentPermanently,
+	isEditMode,
 	toggleApprove,
 	toggleLike,
 	toggleSpam,
@@ -42,6 +43,7 @@ export const CommentDetailActions = ( {
 				<Button
 					borderless
 					className={ classNames( 'comment-detail__action-like', { 'is-liked': commentIsLiked } ) }
+					disabled={ isEditMode }
 					onClick={ toggleLike }
 				>
 					<Gridicon icon={ commentIsLiked ? 'star' : 'star-outline' } />
@@ -57,6 +59,7 @@ export const CommentDetailActions = ( {
 				<Button
 					borderless
 					className={ classNames( 'comment-detail__action-approve', { 'is-approved': isApproved } ) }
+					disabled={ isEditMode }
 					onClick={ toggleApprove }
 				>
 					<Gridicon icon={ isApproved ? 'checkmark-circle' : 'checkmark' } />
@@ -83,6 +86,7 @@ export const CommentDetailActions = ( {
 				<Button
 					borderless
 					className={ classNames( 'comment-detail__action-spam', { 'is-spam': isSpam } ) }
+					disabled={ isEditMode }
 					onClick={ toggleSpam }
 				>
 					<Gridicon icon="spam" />
@@ -98,6 +102,7 @@ export const CommentDetailActions = ( {
 				<Button
 					borderless
 					className={ classNames( 'comment-detail__action-trash', { 'is-trash': isTrash } ) }
+					disabled={ isEditMode }
 					onClick={ toggleTrash }
 				>
 					<Gridicon icon="trash" />

--- a/client/blocks/comment-detail/comment-detail-actions.jsx
+++ b/client/blocks/comment-detail/comment-detail-actions.jsx
@@ -27,7 +27,6 @@ export const CommentDetailActions = ( {
 	commentIsLiked,
 	commentStatus,
 	deleteCommentPermanently,
-	isEditMode,
 	toggleApprove,
 	toggleLike,
 	toggleSpam,
@@ -44,7 +43,6 @@ export const CommentDetailActions = ( {
 				<Button
 					borderless
 					className={ classNames( 'comment-detail__action-like', { 'is-liked': commentIsLiked } ) }
-					disabled={ isEditMode }
 					onClick={ toggleLike }
 				>
 					<Gridicon icon={ commentIsLiked ? 'star' : 'star-outline' } />
@@ -60,7 +58,6 @@ export const CommentDetailActions = ( {
 				<Button
 					borderless
 					className={ classNames( 'comment-detail__action-approve', { 'is-approved': isApproved } ) }
-					disabled={ isEditMode }
 					onClick={ toggleApprove }
 				>
 					<Gridicon icon={ isApproved ? 'checkmark-circle' : 'checkmark' } />
@@ -87,7 +84,6 @@ export const CommentDetailActions = ( {
 				<Button
 					borderless
 					className={ classNames( 'comment-detail__action-spam', { 'is-spam': isSpam } ) }
-					disabled={ isEditMode }
 					onClick={ toggleSpam }
 				>
 					<Gridicon icon="spam" />
@@ -103,7 +99,6 @@ export const CommentDetailActions = ( {
 				<Button
 					borderless
 					className={ classNames( 'comment-detail__action-trash', { 'is-trash': isTrash } ) }
-					disabled={ isEditMode }
 					onClick={ toggleTrash }
 				>
 					<Gridicon icon="trash" />

--- a/client/blocks/comment-detail/comment-detail-actions.jsx
+++ b/client/blocks/comment-detail/comment-detail-actions.jsx
@@ -23,11 +23,11 @@ const commentActions = {
 const hasAction = ( status, action ) => includes( commentActions[ status ], action );
 
 export const CommentDetailActions = ( {
-	edit,
 	commentIsLiked,
 	commentStatus,
 	deleteCommentPermanently,
 	toggleApprove,
+	toggleEditMode,
 	toggleLike,
 	toggleSpam,
 	toggleTrash,
@@ -73,7 +73,7 @@ export const CommentDetailActions = ( {
 				<Button
 					borderless
 					className="comment-detail__action-edit"
-					onClick={ edit }
+					onClick={ toggleEditMode }
 				>
 					<Gridicon icon="pencil" />
 					<span>{ translate( 'Edit' ) }</span>

--- a/client/blocks/comment-detail/comment-detail-edit.jsx
+++ b/client/blocks/comment-detail/comment-detail-edit.jsx
@@ -25,6 +25,12 @@ export class CommentDetailEdit extends Component {
 		updateComment: PropTypes.func,
 	};
 
+	state = {
+		authorDisplayName: '',
+		authorUrl: '',
+		commentContent: '',
+	};
+
 	componentWillMount() {
 		const { authorDisplayName, authorUrl, commentContent } = this.props;
 		this.setState( { authorDisplayName, authorUrl, commentContent } );

--- a/client/blocks/comment-detail/comment-detail-edit.jsx
+++ b/client/blocks/comment-detail/comment-detail-edit.jsx
@@ -20,6 +20,8 @@ export class CommentDetailEdit extends Component {
 		authorUrl: PropTypes.string,
 		closeEditMode: PropTypes.func,
 		commentContent: PropTypes.string,
+		commentId: PropTypes.number,
+		postId: PropTypes.number,
 		updateComment: PropTypes.func,
 	};
 
@@ -33,6 +35,11 @@ export class CommentDetailEdit extends Component {
 	setAuthorUrlValue = event => this.setState( { authorUrl: event.target.value } );
 
 	setCommentContentValue = event => this.setState( { commentContent: event.target.value } );
+
+	updateCommentAndCloseEditMode = () => {
+		this.props.updateComment( this.props.commentId, this.props.postId, this.state );
+		this.props.closeEditMode();
+	};
 
 	render() {
 		const {
@@ -73,7 +80,10 @@ export class CommentDetailEdit extends Component {
 				/>
 
 				<div className="comment-detail__edit-buttons">
-					<FormButton compact>
+					<FormButton
+						compact
+						onClick={ this.updateCommentAndCloseEditMode }
+					>
 						{ translate( 'Save' ) }
 					</FormButton>
 					<FormButton

--- a/client/blocks/comment-detail/comment-detail-edit.jsx
+++ b/client/blocks/comment-detail/comment-detail-edit.jsx
@@ -1,0 +1,93 @@
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import FormButton from 'components/forms/form-button';
+import FormFieldset from 'components/forms/form-fieldset';
+import FormLabel from 'components/forms/form-label';
+import FormTextarea from 'components/forms/form-textarea';
+import FormTextInput from 'components/forms/form-text-input';
+
+export class CommentDetailEdit extends Component {
+	static propTypes = {
+		authorDisplayName: PropTypes.string,
+		authorUrl: PropTypes.string,
+		closeEditMode: PropTypes.func,
+		commentContent: PropTypes.string,
+		updateComment: PropTypes.func,
+	};
+
+	componentWillMount() {
+		const { authorDisplayName, authorUrl, commentContent } = this.props;
+		this.setState( { authorDisplayName, authorUrl, commentContent } );
+	}
+
+	setAuthorDisplayNameValue = event => this.setState( { authorDisplayName: event.target.value } );
+
+	setAuthorUrlValue = event => this.setState( { authorUrl: event.target.value } );
+
+	setCommentContentValue = event => this.setState( { commentContent: event.target.value } );
+
+	render() {
+		const {
+			closeEditMode,
+			translate,
+		} = this.props;
+		const {
+			authorDisplayName,
+			authorUrl,
+			commentContent,
+		} = this.state;
+
+		return (
+			<div className="comment-detail__edit">
+				<FormFieldset>
+					<FormLabel htmlFor="author">
+						{ translate( 'Name' ) }
+					</FormLabel>
+					<FormTextInput
+						onChange={ this.setAuthorDisplayNameValue }
+						value={ authorDisplayName }
+					/>
+				</FormFieldset>
+
+				<FormFieldset>
+					<FormLabel htmlFor="author_url">
+						{ translate( 'URL' ) }
+					</FormLabel>
+					<FormTextInput
+						onChange={ this.setAuthorUrlValue }
+						value={ authorUrl }
+					/>
+				</FormFieldset>
+
+				<FormTextarea
+					onChange={ this.setCommentContentValue }
+					value={ commentContent }
+				/>
+
+				<div className="comment-detail__edit-buttons">
+					<FormButton compact>
+						{ translate( 'Save' ) }
+					</FormButton>
+					<FormButton
+						compact
+						isPrimary={ false }
+						onClick={ closeEditMode }
+						type="button"
+					>
+						{ translate( 'Cancel' ) }
+					</FormButton>
+				</div>
+			</div>
+		);
+	}
+}
+
+export default localize( CommentDetailEdit );

--- a/client/blocks/comment-detail/comment-detail-edit.jsx
+++ b/client/blocks/comment-detail/comment-detail-edit.jsx
@@ -21,9 +21,9 @@ export class CommentDetailEdit extends Component {
 		closeEditMode: PropTypes.func,
 		commentContent: PropTypes.string,
 		commentId: PropTypes.number,
+		editComment: PropTypes.func,
 		isAuthorRegistered: PropTypes.bool,
 		postId: PropTypes.number,
-		updateComment: PropTypes.func,
 	};
 
 	state = {
@@ -43,8 +43,8 @@ export class CommentDetailEdit extends Component {
 
 	setCommentContentValue = event => this.setState( { commentContent: event.target.value } );
 
-	updateCommentAndCloseEditMode = () => {
-		this.props.updateComment( this.props.commentId, this.props.postId, this.state );
+	editCommentAndCloseEditMode = () => {
+		this.props.editComment( this.props.commentId, this.props.postId, this.state );
 		this.props.closeEditMode();
 	};
 
@@ -92,7 +92,7 @@ export class CommentDetailEdit extends Component {
 				<div className="comment-detail__edit-buttons">
 					<FormButton
 						compact
-						onClick={ this.updateCommentAndCloseEditMode }
+						onClick={ this.editCommentAndCloseEditMode }
 					>
 						{ translate( 'Save' ) }
 					</FormButton>

--- a/client/blocks/comment-detail/comment-detail-edit.jsx
+++ b/client/blocks/comment-detail/comment-detail-edit.jsx
@@ -21,6 +21,7 @@ export class CommentDetailEdit extends Component {
 		closeEditMode: PropTypes.func,
 		commentContent: PropTypes.string,
 		commentId: PropTypes.number,
+		isAuthorRegistered: PropTypes.bool,
 		postId: PropTypes.number,
 		updateComment: PropTypes.func,
 	};
@@ -50,6 +51,7 @@ export class CommentDetailEdit extends Component {
 	render() {
 		const {
 			closeEditMode,
+			isAuthorRegistered,
 			translate,
 		} = this.props;
 		const {
@@ -65,6 +67,7 @@ export class CommentDetailEdit extends Component {
 						{ translate( 'Name' ) }
 					</FormLabel>
 					<FormTextInput
+						disabled={ isAuthorRegistered }
 						onChange={ this.setAuthorDisplayNameValue }
 						value={ authorDisplayName }
 					/>
@@ -75,6 +78,7 @@ export class CommentDetailEdit extends Component {
 						{ translate( 'URL' ) }
 					</FormLabel>
 					<FormTextInput
+						disabled={ isAuthorRegistered }
 						onChange={ this.setAuthorUrlValue }
 						value={ authorUrl }
 					/>

--- a/client/blocks/comment-detail/comment-detail-header.jsx
+++ b/client/blocks/comment-detail/comment-detail-header.jsx
@@ -29,6 +29,7 @@ export const CommentDetailHeader = ( {
 	deleteCommentPermanently,
 	edit,
 	isBulkEdit,
+	isEditMode,
 	isExpanded,
 	postTitle,
 	toggleApprove,
@@ -62,6 +63,7 @@ export const CommentDetailHeader = ( {
 					commentIsLiked={ commentIsLiked }
 					commentStatus={ commentStatus }
 					deleteCommentPermanently={ deleteCommentPermanently }
+					isEditMode={ isEditMode }
 					toggleApprove={ toggleApprove }
 					toggleLike={ toggleLike }
 					toggleSpam={ toggleSpam }
@@ -106,6 +108,7 @@ export const CommentDetailHeader = ( {
 				<Button
 					borderless
 					className="comment-detail__action-collapse"
+					disabled={ isEditMode }
 					onClick={ isExpanded ? toggleExpanded : noop }
 				>
 					<Gridicon icon="chevron-down" />

--- a/client/blocks/comment-detail/comment-detail-header.jsx
+++ b/client/blocks/comment-detail/comment-detail-header.jsx
@@ -27,12 +27,12 @@ export const CommentDetailHeader = ( {
 	commentIsSelected,
 	commentStatus,
 	deleteCommentPermanently,
-	edit,
 	isBulkEdit,
 	isEditMode,
 	isExpanded,
 	postTitle,
 	toggleApprove,
+	toggleEditMode,
 	toggleExpanded,
 	toggleLike,
 	toggleSelected,
@@ -59,11 +59,11 @@ export const CommentDetailHeader = ( {
 		>
 			{ isExpanded && ! isEditMode &&
 				<CommentDetailActions
-					edit={ edit }
 					commentIsLiked={ commentIsLiked }
 					commentStatus={ commentStatus }
 					deleteCommentPermanently={ deleteCommentPermanently }
 					toggleApprove={ toggleApprove }
+					toggleEditMode={ toggleEditMode }
 					toggleLike={ toggleLike }
 					toggleSpam={ toggleSpam }
 					toggleTrash={ toggleTrash }
@@ -79,7 +79,7 @@ export const CommentDetailHeader = ( {
 					<Button
 						borderless
 						className="comment-detail__action-collapse"
-						onClick={ edit }
+						onClick={ toggleEditMode }
 					>
 						<Gridicon icon="cross" />
 					</Button>

--- a/client/blocks/comment-detail/comment-detail-header.jsx
+++ b/client/blocks/comment-detail/comment-detail-header.jsx
@@ -57,18 +57,33 @@ export const CommentDetailHeader = ( {
 			className={ classes }
 			onClick={ isExpanded ? noop : handleFullHeaderClick }
 		>
-			{ isExpanded &&
+			{ isExpanded && ! isEditMode &&
 				<CommentDetailActions
 					edit={ edit }
 					commentIsLiked={ commentIsLiked }
 					commentStatus={ commentStatus }
 					deleteCommentPermanently={ deleteCommentPermanently }
-					isEditMode={ isEditMode }
 					toggleApprove={ toggleApprove }
 					toggleLike={ toggleLike }
 					toggleSpam={ toggleSpam }
 					toggleTrash={ toggleTrash }
 				/>
+			}
+
+			{ isExpanded && isEditMode &&
+				<div className="comment-detail__header-edit-mode">
+					<div className="comment-detail__header-edit-title">
+						<Gridicon icon="pencil" />
+						<span>{ translate( 'Edit Comment' ) }</span>
+					</div>
+					<Button
+						borderless
+						className="comment-detail__action-collapse"
+						onClick={ edit }
+					>
+						<Gridicon icon="cross" />
+					</Button>
+				</div>
 			}
 
 			{ ! isExpanded &&
@@ -104,7 +119,7 @@ export const CommentDetailHeader = ( {
 				</div>
 			}
 
-			{ ! isBulkEdit &&
+			{ ! isBulkEdit && ! isEditMode &&
 				<Button
 					borderless
 					className="comment-detail__action-collapse"

--- a/client/blocks/comment-detail/index.jsx
+++ b/client/blocks/comment-detail/index.jsx
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
-import { get, isUndefined, noop } from 'lodash';
+import { get, isUndefined } from 'lodash';
 import ReactDom from 'react-dom';
 
 /**
@@ -70,6 +70,7 @@ export class CommentDetail extends Component {
 		siteId: PropTypes.number,
 		toggleCommentLike: PropTypes.func,
 		toggleCommentSelected: PropTypes.func,
+		updateComment: PropTypes.func,
 	};
 
 	static defaultProps = {
@@ -220,6 +221,7 @@ export class CommentDetail extends Component {
 			replyComment,
 			siteId,
 			translate,
+			updateComment,
 		} = this.props;
 
 		const postUrl = `/read/blogs/${ siteId }/posts/${ postId }`;
@@ -297,7 +299,9 @@ export class CommentDetail extends Component {
 								authorUrl={ authorUrl }
 								closeEditMode={ this.edit }
 								commentContent={ commentContent }
-								updateComment={ noop }
+								commentId={ commentId }
+								postId={ postId }
+								updateComment={ updateComment }
 							/>
 						}
 

--- a/client/blocks/comment-detail/index.jsx
+++ b/client/blocks/comment-detail/index.jsx
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
-import { get, isUndefined } from 'lodash';
+import { get, isUndefined, noop } from 'lodash';
 import ReactDom from 'react-dom';
 
 /**
@@ -15,6 +15,7 @@ import ReactDom from 'react-dom';
 import Card from 'components/card';
 import QueryComment from 'components/data/query-comment';
 import CommentDetailComment from './comment-detail-comment';
+import CommentDetailEdit from './comment-detail-edit';
 import CommentDetailHeader from './comment-detail-header';
 import CommentDetailPost from './comment-detail-post';
 import CommentDetailReply from './comment-detail-reply';
@@ -289,28 +290,43 @@ export class CommentDetail extends Component {
 							postUrl={ postUrl }
 							siteId={ siteId }
 						/>
-						<CommentDetailComment
-							authorAvatarUrl={ authorAvatarUrl }
-							authorDisplayName={ authorDisplayName }
-							authorEmail={ authorEmail }
-							authorIp={ authorIp }
-							authorIsBlocked={ authorIsBlocked }
-							authorUrl={ authorUrl }
-							authorUsername={ authorUsername }
-							blockUser={ this.blockUser }
-							commentContent={ commentContent }
-							commentDate={ commentDate }
-							commentStatus={ commentStatus }
-							commentUrl={ commentUrl }
-							repliedToComment={ repliedToComment }
-							siteId={ siteId }
-						/>
-						<CommentDetailReply
-							authorDisplayName={ authorDisplayName }
-							comment={ getCommentStatusAction( this.props ) }
-							postTitle={ postTitle }
-							replyComment={ replyComment }
-						/>
+
+						{ isEditMode &&
+							<CommentDetailEdit
+								authorDisplayName={ authorDisplayName }
+								authorUrl={ authorUrl }
+								closeEditMode={ this.edit }
+								commentContent={ commentContent }
+								updateComment={ noop }
+							/>
+						}
+
+						{ ! isEditMode &&
+							<div>
+								<CommentDetailComment
+									authorAvatarUrl={ authorAvatarUrl }
+									authorDisplayName={ authorDisplayName }
+									authorEmail={ authorEmail }
+									authorIp={ authorIp }
+									authorIsBlocked={ authorIsBlocked }
+									authorUrl={ authorUrl }
+									authorUsername={ authorUsername }
+									blockUser={ this.blockUser }
+									commentContent={ commentContent }
+									commentDate={ commentDate }
+									commentStatus={ commentStatus }
+									commentUrl={ commentUrl }
+									repliedToComment={ repliedToComment }
+									siteId={ siteId }
+								/>
+								<CommentDetailReply
+									authorDisplayName={ authorDisplayName }
+									comment={ getCommentStatusAction( this.props ) }
+									postTitle={ postTitle }
+									replyComment={ replyComment }
+								/>
+							</div>
+						}
 					</div>
 				}
 			</Card>

--- a/client/blocks/comment-detail/index.jsx
+++ b/client/blocks/comment-detail/index.jsx
@@ -61,6 +61,7 @@ export class CommentDetail extends Component {
 		commentStatus: PropTypes.string,
 		commentUrl: PropTypes.string,
 		deleteCommentPermanently: PropTypes.func,
+		editComment: PropTypes.func,
 		isBulkEdit: PropTypes.bool,
 		isLoading: PropTypes.bool,
 		isRawContentSupported: PropTypes.bool,
@@ -73,7 +74,6 @@ export class CommentDetail extends Component {
 		siteId: PropTypes.number,
 		toggleCommentLike: PropTypes.func,
 		toggleCommentSelected: PropTypes.func,
-		updateComment: PropTypes.func,
 	};
 
 	static defaultProps = {
@@ -114,8 +114,6 @@ export class CommentDetail extends Component {
 		}
 	}
 
-	edit = () => this.setState( ( { isEditMode } ) => ( { isEditMode: ! isEditMode } ) );
-
 	toggleApprove = () => {
 		if ( this.state.isEditMode ) {
 			return;
@@ -137,6 +135,8 @@ export class CommentDetail extends Component {
 			this.setState( { isExpanded: false } );
 		}
 	}
+
+	toggleEditMode = () => this.setState( ( { isEditMode } ) => ( { isEditMode: ! isEditMode } ) );
 
 	toggleExpanded = () => {
 		if ( ! this.props.isLoading && ! this.state.isEditMode ) {
@@ -213,6 +213,7 @@ export class CommentDetail extends Component {
 			commentRawContent,
 			commentStatus,
 			commentUrl,
+			editComment,
 			isBulkEdit,
 			isLoading,
 			isRawContentSupported,
@@ -227,7 +228,6 @@ export class CommentDetail extends Component {
 			replyComment,
 			siteId,
 			translate,
-			updateComment,
 		} = this.props;
 
 		const postUrl = `/read/blogs/${ siteId }/posts/${ postId }`;
@@ -273,13 +273,13 @@ export class CommentDetail extends Component {
 					commentIsSelected={ commentIsSelected }
 					commentStatus={ commentStatus }
 					deleteCommentPermanently={ this.deleteCommentPermanently }
-					edit={ this.edit }
 					isBulkEdit={ isBulkEdit }
 					isEditMode={ isEditMode }
 					isExpanded={ isExpanded }
 					postId={ postId }
 					postTitle={ postTitle }
 					toggleApprove={ this.toggleApprove }
+					toggleEditMode={ this.toggleEditMode }
 					toggleExpanded={ this.toggleExpanded }
 					toggleLike={ this.toggleLike }
 					toggleSelected={ this.toggleSelected }
@@ -303,12 +303,12 @@ export class CommentDetail extends Component {
 							<CommentDetailEdit
 								authorDisplayName={ authorDisplayName }
 								authorUrl={ authorUrl }
-								closeEditMode={ this.edit }
+								closeEditMode={ this.toggleEditMode }
 								commentContent={ isRawContentSupported ? commentRawContent : commentContent }
 								commentId={ commentId }
+								editComment={ editComment }
 								isAuthorRegistered={ authorId !== 0 }
 								postId={ postId }
-								updateComment={ updateComment }
 							/>
 						}
 

--- a/client/blocks/comment-detail/index.jsx
+++ b/client/blocks/comment-detail/index.jsx
@@ -200,6 +200,7 @@ export class CommentDetail extends Component {
 		const {
 			authorAvatarUrl,
 			authorEmail,
+			authorId,
 			authorIp,
 			authorName,
 			authorUrl,
@@ -305,6 +306,7 @@ export class CommentDetail extends Component {
 								closeEditMode={ this.edit }
 								commentContent={ isRawContentSupported ? commentRawContent : commentContent }
 								commentId={ commentId }
+								isAuthorRegistered={ authorId !== 0 }
 								postId={ postId }
 								updateComment={ updateComment }
 							/>

--- a/client/blocks/comment-detail/index.jsx
+++ b/client/blocks/comment-detail/index.jsx
@@ -56,6 +56,7 @@ export class CommentDetail extends Component {
 		commentId: PropTypes.oneOfType( [ PropTypes.string, PropTypes.number ] ),
 		commentIsLiked: PropTypes.bool,
 		commentIsSelected: PropTypes.bool,
+		commentRawContent: PropTypes.string,
 		commentStatus: PropTypes.string,
 		commentUrl: PropTypes.string,
 		deleteCommentPermanently: PropTypes.func,
@@ -206,6 +207,7 @@ export class CommentDetail extends Component {
 			commentId,
 			commentIsLiked,
 			commentIsSelected,
+			commentRawContent,
 			commentStatus,
 			commentUrl,
 			isBulkEdit,
@@ -298,7 +300,7 @@ export class CommentDetail extends Component {
 								authorDisplayName={ authorDisplayName }
 								authorUrl={ authorUrl }
 								closeEditMode={ this.edit }
-								commentContent={ commentContent }
+								commentContent={ commentRawContent }
 								commentId={ commentId }
 								postId={ postId }
 								updateComment={ updateComment }
@@ -369,6 +371,7 @@ const mapStateToProps = ( state, ownProps ) => {
 		commentDate: get( comment, 'date' ),
 		commentId,
 		commentIsLiked: get( comment, 'i_like' ),
+		commentRawContent: get( comment, 'raw_content' ),
 		commentStatus: get( comment, 'status' ),
 		commentUrl: get( comment, 'URL' ),
 		isLoading,

--- a/client/blocks/comment-detail/index.jsx
+++ b/client/blocks/comment-detail/index.jsx
@@ -22,6 +22,7 @@ import CommentDetailReply from './comment-detail-reply';
 import { decodeEntities, stripHTML } from 'lib/formatting';
 import { getPostCommentsTree } from 'state/comments/selectors';
 import getSiteComment from 'state/selectors/get-site-comment';
+import { isJetpackMinimumVersion, isJetpackSite } from 'state/sites/selectors';
 
 /**
  * Creates a stripped down comment object containing only the information needed by
@@ -62,6 +63,7 @@ export class CommentDetail extends Component {
 		deleteCommentPermanently: PropTypes.func,
 		isBulkEdit: PropTypes.bool,
 		isLoading: PropTypes.bool,
+		isRawContentSupported: PropTypes.bool,
 		postAuthorDisplayName: PropTypes.string,
 		postTitle: PropTypes.string,
 		refreshCommentData: PropTypes.bool,
@@ -212,6 +214,7 @@ export class CommentDetail extends Component {
 			commentUrl,
 			isBulkEdit,
 			isLoading,
+			isRawContentSupported,
 			parentCommentAuthorAvatarUrl,
 			parentCommentAuthorDisplayName,
 			parentCommentContent,
@@ -300,7 +303,7 @@ export class CommentDetail extends Component {
 								authorDisplayName={ authorDisplayName }
 								authorUrl={ authorUrl }
 								closeEditMode={ this.edit }
-								commentContent={ commentRawContent }
+								commentContent={ isRawContentSupported ? commentRawContent : commentContent }
 								commentId={ commentId }
 								postId={ postId }
 								updateComment={ updateComment }
@@ -375,6 +378,7 @@ const mapStateToProps = ( state, ownProps ) => {
 		commentStatus: get( comment, 'status' ),
 		commentUrl: get( comment, 'URL' ),
 		isLoading,
+		isRawContentSupported: ! isJetpackSite( state, siteId ) || isJetpackMinimumVersion( state, siteId, '5.3' ),
 		parentCommentAuthorAvatarUrl: get( parentComment, 'author.avatar_URL' ),
 		parentCommentAuthorDisplayName: get( parentComment, 'author.name' ),
 		parentCommentContent,

--- a/client/blocks/comment-detail/style.scss
+++ b/client/blocks/comment-detail/style.scss
@@ -565,6 +565,33 @@ a.comment-detail__author-more-element {
 	}
 }
 
+.comment-detail__edit {
+	display: flex;
+	flex-wrap: wrap;
+	padding: 16px 8px;
+
+	.form-fieldset {
+		padding: 0 8px;
+		width: 50%;
+	}
+
+	.form-textarea {
+		margin: 0px 8px 20px 8px;
+		transition: none;
+		width: 100%;
+	}
+
+	input[ type="text" ],
+	textarea {
+		font-size: 14px;
+	}
+
+	.comment-detail__edit-buttons {
+		padding: 0 8px;
+		width: 100%;
+	}
+}
+
 .comment-detail__placeholder {
 	@include placeholder();
 

--- a/client/blocks/comment-detail/style.scss
+++ b/client/blocks/comment-detail/style.scss
@@ -238,41 +238,56 @@
 			}
 		}
 
-		&.comment-detail__action-like {
-			&:focus,
-			&:hover {
-				color: $orange-jazzy;
-			}
-		}
-
-		&.comment-detail__action-approve {
-			&:focus,
-			&:hover {
-				color: $alert-green;
-			}
-		}
-
-		&.comment-detail__action-spam,
-		&.comment-detail__action-trash,
-		&.comment-detail__action-delete {
-			&:focus,
-			&:hover {
-				color: $alert-red;
-			}
-		}
 
 		&.is-approved {
-			color: $alert-green;
+			color: lighten( $alert-green, 30% );
 		}
 		&.is-liked {
-			color: $orange-jazzy;
+			color: lighten( $orange-jazzy, 30% );
 		}
 		&.is-spam {
-			color: $alert-red;
+			color: lighten( $alert-red, 30% );
 		}
 		&.is-trash {
-			color: $gray-dark;
+			color: lighten( $gray-dark, 30% );
 		}
+	}
+}
+.comment-detail.card:not( .is-edit-mode ) .comment-detail__actions .button.is-borderless {
+	&.comment-detail__action-like {
+		&:focus,
+		&:hover {
+			color: $orange-jazzy;
+		}
+	}
+
+	&.comment-detail__action-approve {
+		&:focus,
+		&:hover {
+			color: $alert-green;
+		}
+	}
+
+	&.comment-detail__action-spam,
+	&.comment-detail__action-trash,
+	&.comment-detail__action-delete {
+		&:focus,
+		&:hover {
+			color: $alert-red;
+		}
+	}
+
+	&.is-approved {
+		color: $alert-green;
+	}
+	&.is-liked {
+		color: $orange-jazzy;
+	}
+	&.is-spam {
+		color: $alert-red;
+	}
+	&.is-trash {
+		color: $gray-dark;
 	}
 }
 

--- a/client/blocks/comment-detail/style.scss
+++ b/client/blocks/comment-detail/style.scss
@@ -82,6 +82,10 @@
 		display: flex;
 		flex-wrap: nowrap;
 		width: calc( 100% - 36px );
+
+		@supports( -webkit-line-clamp: 2 ) {
+			align-items: center;
+		}
 	}
 
 	&.is-preview {
@@ -291,6 +295,16 @@
 	}
 }
 
+.comment-detail__header-edit-mode {
+	align-items: center;
+	display: flex;
+	justify-content: space-between;
+	width: 100%;
+
+	.comment-detail__header-edit-title {
+		padding: 0 16px;
+	}
+}
 
 .comment-detail__post {
 	border-bottom: 1px solid lighten( $gray, 30% );

--- a/client/blocks/comment-detail/style.scss
+++ b/client/blocks/comment-detail/style.scss
@@ -242,56 +242,41 @@
 			}
 		}
 
+		&.comment-detail__action-like {
+			&:focus,
+			&:hover {
+				color: $orange-jazzy;
+			}
+		}
+
+		&.comment-detail__action-approve {
+			&:focus,
+			&:hover {
+				color: $alert-green;
+			}
+		}
+
+		&.comment-detail__action-spam,
+		&.comment-detail__action-trash,
+		&.comment-detail__action-delete {
+			&:focus,
+			&:hover {
+				color: $alert-red;
+			}
+		}
 
 		&.is-approved {
-			color: lighten( $alert-green, 30% );
-		}
-		&.is-liked {
-			color: lighten( $orange-jazzy, 30% );
-		}
-		&.is-spam {
-			color: lighten( $alert-red, 30% );
-		}
-		&.is-trash {
-			color: lighten( $gray-dark, 30% );
-		}
-	}
-}
-.comment-detail.card:not( .is-edit-mode ) .comment-detail__actions .button.is-borderless {
-	&.comment-detail__action-like {
-		&:focus,
-		&:hover {
-			color: $orange-jazzy;
-		}
-	}
-
-	&.comment-detail__action-approve {
-		&:focus,
-		&:hover {
 			color: $alert-green;
 		}
-	}
-
-	&.comment-detail__action-spam,
-	&.comment-detail__action-trash,
-	&.comment-detail__action-delete {
-		&:focus,
-		&:hover {
+		&.is-liked {
+			color: $orange-jazzy;
+		}
+		&.is-spam {
 			color: $alert-red;
 		}
-	}
-
-	&.is-approved {
-		color: $alert-green;
-	}
-	&.is-liked {
-		color: $orange-jazzy;
-	}
-	&.is-spam {
-		color: $alert-red;
-	}
-	&.is-trash {
-		color: $gray-dark;
+		&.is-trash {
+			color: $gray-dark;
+		}
 	}
 }
 
@@ -302,6 +287,7 @@
 	width: 100%;
 
 	.comment-detail__header-edit-title {
+		color: lighten( $gray-dark, 30% );
 		padding: 0 16px;
 	}
 }

--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -14,6 +14,7 @@ import ReactCSSTransitionGroup from 'react-addons-css-transition-group';
 import {
 	changeCommentStatus,
 	deleteComment,
+	editComment,
 	likeComment,
 	replyComment,
 	unlikeComment,
@@ -416,6 +417,7 @@ export class CommentList extends Component {
 							siteId={ siteId }
 							toggleCommentLike={ this.toggleCommentLike }
 							toggleCommentSelected={ this.toggleCommentSelected }
+							updateComment={ this.props.editComment }
 						/>
 					) }
 
@@ -478,6 +480,14 @@ const mapDispatchToProps = ( dispatch, { siteId } ) => ( {
 			bumpStat( 'calypso_comment_management', 'comment_deleted' )
 		),
 		deleteComment( siteId, postId, commentId, options )
+	) ),
+
+	editComment: ( commentId, postId, commentData ) => dispatch( withAnalytics(
+		composeAnalytics(
+			recordTracksEvent( 'calypso_comment_management_edit' ),
+			bumpStat( 'calypso_comment_management', 'comment_updated' )
+		),
+		editComment( siteId, postId, commentId, commentData )
 	) ),
 
 	likeComment: ( commentId, postId, analytics = { alsoApprove: false } ) => dispatch( withAnalytics(

--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -337,6 +337,15 @@ export class CommentList extends Component {
 
 	toggleSelectAll = selectedComments => this.setState( { selectedComments } );
 
+	updateComment = ( commentId, postId, commentData ) => {
+		this.props.editComment( commentId, postId, commentData.commentContent );
+		this.props.successNotice( this.props.translate( 'Comment updated.' ), {
+			duration: 5000,
+			id: `comment-notice-${ commentId }`,
+			isPersistent: true,
+		} );
+	}
+
 	updatePersistedComments = ( commentId, isUndo ) => {
 		if ( isUndo ) {
 			this.removeFromPersistedComments( commentId );
@@ -417,7 +426,7 @@ export class CommentList extends Component {
 							siteId={ siteId }
 							toggleCommentLike={ this.toggleCommentLike }
 							toggleCommentSelected={ this.toggleCommentSelected }
-							updateComment={ this.props.editComment }
+							updateComment={ this.updateComment }
 						/>
 					) }
 
@@ -482,12 +491,12 @@ const mapDispatchToProps = ( dispatch, { siteId } ) => ( {
 		deleteComment( siteId, postId, commentId, options )
 	) ),
 
-	editComment: ( commentId, postId, commentData ) => dispatch( withAnalytics(
+	editComment: ( commentId, postId, content ) => dispatch( withAnalytics(
 		composeAnalytics(
 			recordTracksEvent( 'calypso_comment_management_edit' ),
 			bumpStat( 'calypso_comment_management', 'comment_updated' )
 		),
-		editComment( siteId, postId, commentId, commentData )
+		editComment( siteId, postId, commentId, content )
 	) ),
 
 	likeComment: ( commentId, postId, analytics = { alsoApprove: false } ) => dispatch( withAnalytics(

--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -338,7 +338,7 @@ export class CommentList extends Component {
 	toggleSelectAll = selectedComments => this.setState( { selectedComments } );
 
 	updateComment = ( commentId, postId, commentData ) => {
-		this.props.editComment( commentId, postId, commentData.commentContent );
+		this.props.editComment( commentId, postId, commentData );
 		this.props.successNotice( this.props.translate( 'Comment updated.' ), {
 			duration: 5000,
 			id: `comment-notice-${ commentId }`,
@@ -491,12 +491,12 @@ const mapDispatchToProps = ( dispatch, { siteId } ) => ( {
 		deleteComment( siteId, postId, commentId, options )
 	) ),
 
-	editComment: ( commentId, postId, content ) => dispatch( withAnalytics(
+	editComment: ( commentId, postId, comment ) => dispatch( withAnalytics(
 		composeAnalytics(
 			recordTracksEvent( 'calypso_comment_management_edit' ),
 			bumpStat( 'calypso_comment_management', 'comment_updated' )
 		),
-		editComment( siteId, postId, commentId, content )
+		editComment( siteId, postId, commentId, comment )
 	) ),
 
 	likeComment: ( commentId, postId, analytics = { alsoApprove: false } ) => dispatch( withAnalytics(

--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -93,6 +93,15 @@ export class CommentList extends Component {
 		this.props.deleteComment( commentId, postId );
 	}
 
+	editComment = ( commentId, postId, commentData ) => {
+		this.props.editComment( commentId, postId, commentData );
+		this.props.successNotice( this.props.translate( 'Comment updated.' ), {
+			duration: 5000,
+			id: `comment-notice-${ commentId }`,
+			isPersistent: true,
+		} );
+	}
+
 	getComments = () => uniq( [ ...this.state.persistedComments, ...this.props.comments ] ).sort( ( a, b ) => b - a );
 
 	getCommentsPage = ( comments, page ) => {
@@ -337,15 +346,6 @@ export class CommentList extends Component {
 
 	toggleSelectAll = selectedComments => this.setState( { selectedComments } );
 
-	updateComment = ( commentId, postId, commentData ) => {
-		this.props.editComment( commentId, postId, commentData );
-		this.props.successNotice( this.props.translate( 'Comment updated.' ), {
-			duration: 5000,
-			id: `comment-notice-${ commentId }`,
-			isPersistent: true,
-		} );
-	}
-
 	updatePersistedComments = ( commentId, isUndo ) => {
 		if ( isUndo ) {
 			this.removeFromPersistedComments( commentId );
@@ -416,9 +416,10 @@ export class CommentList extends Component {
 					{ map( commentsPage, commentId =>
 						<CommentDetail
 							commentId={ commentId }
-							deleteCommentPermanently={ this.deleteCommentPermanently }
-							isBulkEdit={ isBulkEdit }
 							commentIsSelected={ this.isCommentSelected( commentId ) }
+							deleteCommentPermanently={ this.deleteCommentPermanently }
+							editComment={ this.editComment }
+							isBulkEdit={ isBulkEdit }
 							key={ `comment-${ siteId }-${ commentId }` }
 							refreshCommentData={ ! isJetpack && ! this.hasCommentJustMovedBackToCurrentStatus( commentId ) }
 							replyComment={ this.replyComment }
@@ -426,7 +427,6 @@ export class CommentList extends Component {
 							siteId={ siteId }
 							toggleCommentLike={ this.toggleCommentLike }
 							toggleCommentSelected={ this.toggleCommentSelected }
-							updateComment={ this.updateComment }
 						/>
 					) }
 

--- a/client/state/comments/test/reducer.js
+++ b/client/state/comments/test/reducer.js
@@ -155,6 +155,47 @@ describe( 'reducer', () => {
 			expect( result ).to.eql( { '1-1': [ { ID: 123, content: 'lorem ipsum dolor' } ] } );
 			expect( result[ '1-1' ] ).to.have.lengthOf( 1 );
 		} );
+
+		it( 'should allow Comment Management to edit content and author details', () => {
+			const state = deepFreeze( {
+				'1-1': [
+					{
+						ID: 123,
+						author: {
+							name: 'Foo',
+							url: 'https://example.com/',
+						},
+						content: 'Lorem ipsum',
+					},
+				],
+			} );
+
+			const result = items( state, {
+				type: COMMENTS_EDIT,
+				siteId: 1,
+				postId: 1,
+				commentId: 123,
+				comment: {
+					authorDisplayName: 'Bar',
+					authorUrl: 'https://wordpress.com/',
+					commentContent: 'Lorem ipsum dolor sit amet',
+				},
+			} );
+
+			expect( result ).to.eql( {
+				'1-1': [
+					{
+						ID: 123,
+						author: {
+							name: 'Bar',
+							url: 'https://wordpress.com/',
+						},
+						content: 'Lorem ipsum dolor sit amet',
+					},
+				],
+			} );
+			expect( result[ '1-1' ] ).to.have.lengthOf( 1 );
+		} );
 	} );
 
 	describe( '#fetchStatus', () => {

--- a/client/state/data-layer/wpcom/sites/comments/index.js
+++ b/client/state/data-layer/wpcom/sites/comments/index.js
@@ -211,7 +211,7 @@ export const editComment = ( { dispatch, getState }, action ) => {
 	// Comment Management allows for modifying nested fields, such as `author.name` and `author.url`.
 	// Though, there is no direct match between the GET response (which feeds the state) and the POST request.
 	// This ternary matches the updated fields sent by Comment Management's Edit form to the fields expected by the API.
-	const body = ( comment.authorDisplayName && comment.authorUrl && comment.commentContent )
+	const body = ( comment.authorDisplayName || comment.authorUrl || comment.commentContent )
 		? {
 			author: comment.authorDisplayName,
 			author_url: comment.authorUrl,

--- a/config/development.json
+++ b/config/development.json
@@ -42,6 +42,7 @@
 		"comments/moderation-tools-in-posts": true,
 		"comments/management": true,
 		"comments/management/all-list": false,
+		"comments/management/edit": true,
 		"manage/comments/bulk-actions": true,
 		"css-hot-reload": true,
 		"desktop-promo": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -20,6 +20,7 @@
 		"code-splitting": true,
 		"comments/management": true,
 		"comments/management/all-list": false,
+		"comments/management/edit": true,
 		"manage/comments/bulk-actions": true,
 		"devdocs": false,
 		"domains/cctlds": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -19,6 +19,7 @@
 		"apple-pay": true,
 		"comments/management": true,
 		"comments/management/all-list": false,
+		"comments/management/edit": true,
 		"manage/comments/bulk-actions": true,
 		"catch-js-errors": true,
 		"code-splitting": true,


### PR DESCRIPTION
Close #13905

Introduce the Comment Management Edit Form and enable it to development, wpcalypso, and horizon environments.

![sep-04-2017 18-50-45](https://user-images.githubusercontent.com/2070010/30035536-1bf47c96-91a3-11e7-96cf-ac220673241c.gif)

| Not Edit Mode | Edit Mode | Edit Mode (Registered User) |
| --- | --- | --- |
| <img width="682" alt="screen shot 2017-08-17 at 11 02 51" src="https://user-images.githubusercontent.com/2070010/29407257-bc3ec682-833b-11e7-9bb2-2a98250abbdc.png"> | <img width="597" alt="screen shot 2017-09-05 at 12 31 31" src="https://user-images.githubusercontent.com/2070010/30059240-2f1d93d2-9236-11e7-9f91-0e28aca6d915.png"> | <img width="597" alt="screen shot 2017-09-05 at 12 32 30" src="https://user-images.githubusercontent.com/2070010/30059281-549e94bc-9236-11e7-83c0-589a5803fa1f.png"> |

Clicking on the **Edit** button in the action bar activates the Edit Mode.
In Edit Mode the actions are replaced by a simple "Edit Comment" text, and the Collapse button is replaced by an X button.
The only ways to exit Edit Mode are:
- Clicking the X button that replaces the Collapse button.
- Clicking the Cancel button.
- Clicking the Save button (which also updates the comment).

The author name and URL fields are only enabled for unregistered users.

On WP.com and JP > 5.3 sites, the editable content is the comment's `raw_content`.
Otherwise it's the formatted `content`.

# Action Items

- [x] Add the author name and URL to the editable fields in the endpoint.

- [x] Replace the `editComment` action with a data layer one, to take better advantage of the whole success/error flow, with optimistic updates and notices. (https://github.com/Automattic/wp-calypso/pull/17252)

- [x] Find out how to juggle `context: 'display'` and `context: 'edit'` in the request, to switch between raw and rendered content, when the Edit Mode is respectively enabled and disabled. (see: https://github.com/Automattic/wp-calypso/pull/17251#issuecomment-322829231 and following comments)