### PR TITLE
Editor: add a simple payments tour

### DIFF
--- a/client/layout/guided-tours/config.js
+++ b/client/layout/guided-tours/config.js
@@ -5,6 +5,7 @@ import { combineTours } from 'layout/guided-tours/config-elements';
 import { MainTour } from 'layout/guided-tours/tours/main-tour';
 import { TutorialSitePreviewTour } from 'layout/guided-tours/tours/tutorial-site-preview-tour';
 import { GDocsIntegrationTour } from 'layout/guided-tours/tours/gdocs-integration-tour';
+import { SimplePaymentsTour } from 'layout/guided-tours/tours/simple-payments-tour';
 import { EditorBasicsTour } from 'layout/guided-tours/tours/editor-basics-tour';
 import { MediaBasicsTour } from 'layout/guided-tours/tours/media-basics-tour';
 
@@ -14,4 +15,5 @@ export default combineTours( {
 	mediaBasicsTour: MediaBasicsTour,
 	tutorialSitePreview: TutorialSitePreviewTour,
 	gdocsIntegrationTour: GDocsIntegrationTour,
+	simplePaymentsTour: SimplePaymentsTour,
 } );

--- a/client/layout/guided-tours/tours/simple-payments-tour.js
+++ b/client/layout/guided-tours/tours/simple-payments-tour.js
@@ -39,8 +39,10 @@ export const SimplePaymentsTour = makeTour(
 		>
 			<p>
 				{
-					translate( 'Did you know? ' +
-						'If your site is on the Premium or Business plan, you can add {{strong}}payment buttons{{/strong}} here!', {
+					translate(
+						'Did you know? ' +
+						'If your site is on the Premium or Business plan, you can add {{strong}}payment buttons{{/strong}} here!',
+						{
 							components: {
 								strong: <strong />,
 							}

--- a/client/layout/guided-tours/tours/simple-payments-tour.js
+++ b/client/layout/guided-tours/tours/simple-payments-tour.js
@@ -1,0 +1,61 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { translate } from 'i18n-calypso';
+import {
+	overEvery as and,
+} from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import {
+	makeTour,
+	Tour,
+	Step,
+	ButtonRow,
+	Link,
+	Quit,
+} from 'layout/guided-tours/config-elements';
+import {
+	isNotNewUser,
+} from 'state/ui/guided-tours/contexts';
+import { isDesktop } from 'lib/viewport';
+
+export const SimplePaymentsTour = makeTour(
+	<Tour
+		name="simplePaymentsTour"
+		version="20170816"
+		path="/post/"
+		when={ and( isDesktop, isNotNewUser ) }
+	>
+		<Step
+			name="init"
+			arrow="top-left"
+			target=".editor-html-toolbar__button-insert-media, .mce-wpcom-insert-menu button"
+			placement="below"
+			style={ { marginLeft: '22px', zIndex: 'auto' } }
+		>
+			<p>
+				{
+					translate( 'Did you know? ' +
+						'If your site is on the Premium or Business plan, you can add {{strong}}payment buttons{{/strong}} here!', {
+							components: {
+								strong: <strong />,
+							}
+						}
+					)
+				}
+			</p>
+			<ButtonRow>
+				<Quit primary>
+					{ translate( 'Got it, sounds good!' ) }
+				</Quit>
+			</ButtonRow>
+			<Link href="https://en.support.wordpress.com/simple-payments">
+				{ translate( 'Learn more about Simple Payments.' ) }
+			</Link>
+		</Step>
+	</Tour>
+);

--- a/client/state/ui/guided-tours/contexts.js
+++ b/client/state/ui/guided-tours/contexts.js
@@ -78,6 +78,16 @@ export const isNewUser = state => {
 };
 
 /**
+ * Returns true if the user is NOT considered "new" (less than a week since registration)
+ *
+ * @param {Object} state Global state tree
+ * @return {Boolean} True if user is NOT new, false otherwise
+ */
+export const isNotNewUser = state => {
+	return ! isNewUser( state );
+};
+
+/**
  * Returns a selector that tests if the user is older than a given time
  *
  * @param {Number} age Number of milliseconds


### PR DESCRIPTION
This PR adds a one-step tour to introduce people to Simple Payments when they visit the editor and are NOT new users (new users will see it as part of the "editor basics" tour, cf. #17214). 

Screenshot:

<img width="766" alt="screen shot 2017-08-16 at 5 46 13 pm" src="https://user-images.githubusercontent.com/23619/29372645-03e24706-82ac-11e7-90ef-5e875043cf60.png">


To check:

- go to http://calypso.localhost:3000/post/SITE_URL?tour=simplePaymentsTour
- see whether the step is rendered correctly and check its copy
- check whether the trigger makes sense, especially in interplay with #17214
