### PR TITLE
Comments: Add `context` to query components

### DIFF
--- a/client/blocks/comment-detail/index.jsx
+++ b/client/blocks/comment-detail/index.jsx
@@ -227,7 +227,7 @@ export class CommentDetail extends Component {
 				tabIndex="0"
 			>
 				{ refreshCommentData &&
-					<QueryComment commentId={ commentId } siteId={ siteId } />
+					<QueryComment commentId={ commentId } siteId={ siteId } context="edit" />
 				}
 
 				<CommentDetailHeader

--- a/client/components/data/query-comment/README.md
+++ b/client/components/data/query-comment/README.md
@@ -10,7 +10,7 @@ import QueryComment from 'components/query-comment';
 
 const CommentDetail = ( { comment, commentId, siteId } ) =>
 	<div>
-		<QueryComment commentId={ commentId } context={ query } siteId={ siteId } />
+		<QueryComment commentId={ commentId } siteId={ siteId } />
 		<div>{ comment.date }</div>
 		<div>{ comment.content }</div>
 	</div>;

--- a/client/components/data/query-comment/README.md
+++ b/client/components/data/query-comment/README.md
@@ -10,7 +10,7 @@ import QueryComment from 'components/query-comment';
 
 const CommentDetail = ( { comment, commentId, siteId } ) =>
 	<div>
-		<QueryComment commentId={ commentId } siteId={ siteId } />
+		<QueryComment commentId={ commentId } context={ query } siteId={ siteId } />
 		<div>{ comment.date }</div>
 		<div>{ comment.content }</div>
 	</div>;
@@ -21,4 +21,5 @@ const CommentDetail = ( { comment, commentId, siteId } ) =>
 | Name | Type | Description |
 | --- | --- | --- |
 | `commentId` | Number | The comment to request. |
+| `context` | String | The request context (default: "display")
 | `siteId` | Number | The site ID for which the comment should be queried. |

--- a/client/components/data/query-comment/README.md
+++ b/client/components/data/query-comment/README.md
@@ -21,5 +21,5 @@ const CommentDetail = ( { comment, commentId, siteId } ) =>
 | Name | Type | Description |
 | --- | --- | --- |
 | `commentId` | Number | The comment to request. |
-| `context` | String | The request context (default: "display")
+| `context` | String | The request context (default: "display") |
 | `siteId` | Number | The site ID for which the comment should be queried. |

--- a/client/components/data/query-comment/index.jsx
+++ b/client/components/data/query-comment/index.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import { Component, PropTypes } from 'react';
+import { Component } from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
 /**
@@ -12,7 +13,12 @@ import { requestComment } from 'state/comments/actions';
 export class QueryComment extends Component {
 	static propTypes = {
 		commentId: PropTypes.number,
+		context: PropTypes.string,
 		siteId: PropTypes.number,
+	};
+
+	static defaultProps = {
+		context: 'display',
 	};
 
 	componentDidMount() {
@@ -26,9 +32,13 @@ export class QueryComment extends Component {
 	}
 
 	request() {
-		const { siteId, commentId } = this.props;
+		const { siteId, commentId, context } = this.props;
 		if ( siteId && commentId ) {
-			this.props.requestComment( { siteId, commentId } );
+			this.props.requestComment( {
+				siteId,
+				commentId,
+				query: { context },
+			} );
 		}
 	}
 

--- a/client/components/data/query-site-comments-list/index.jsx
+++ b/client/components/data/query-site-comments-list/index.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import { PureComponent, PropTypes } from 'react';
+import { PureComponent } from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
 /**

--- a/client/components/data/query-site-comments-list/index.jsx
+++ b/client/components/data/query-site-comments-list/index.jsx
@@ -11,6 +11,7 @@ import { requestCommentsList } from 'state/comments/actions';
 
 export class QuerySiteCommentsList extends PureComponent {
 	static propTypes = {
+		context: PropTypes.string,
 		listType: PropTypes.string,
 		siteId: PropTypes.number,
 		status: PropTypes.string,
@@ -18,6 +19,7 @@ export class QuerySiteCommentsList extends PureComponent {
 	};
 
 	static defaultProps = {
+		context: 'display',
 		listType: 'site',
 		status: 'unapproved',
 		type: 'comment',

--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -375,6 +375,7 @@ export class CommentList extends Component {
 			<div className="comment-list">
 				{ isJetpack &&
 					<QuerySiteCommentsList
+						context="edit"
 						number={ 100 }
 						offset={ ( page - 1 ) * COMMENTS_PER_PAGE }
 						siteId={ siteId }

--- a/client/state/comments/actions.js
+++ b/client/state/comments/actions.js
@@ -19,10 +19,11 @@ import {
 } from '../action-types';
 import { NUMBER_OF_COMMENTS_PER_FETCH } from './constants';
 
-export const requestComment = ( { siteId, commentId } ) => ( {
+export const requestComment = ( { siteId, commentId, query } ) => ( {
 	type: COMMENT_REQUEST,
 	siteId,
 	commentId,
+	query,
 } );
 
 /***

--- a/client/state/data-layer/wpcom/sites/comments/index.js
+++ b/client/state/data-layer/wpcom/sites/comments/index.js
@@ -82,11 +82,14 @@ const announceStatusChangeFailure = ( { dispatch, getState }, action ) => {
 
 export const requestComment = ( store, action ) => {
 	const { siteId, commentId } = action;
+	const query = get( action, 'query', {} );
+
 	store.dispatch(
 		http( {
 			method: 'GET',
 			path: `/sites/${ siteId }/comments/${ commentId }`,
 			apiVersion: '1.1',
+			query,
 			onSuccess: action,
 			onFailure: action,
 		} ),


### PR DESCRIPTION
Add the `context` query param to the `QueryComment` and `QuerySiteCommentsList` component, in order to request comments in `edit` context in Comment Management.

#### Test

Open `/comments` on a Simple site and on a Jetpack site.
Check that, for both cases, in the Redux state `{ comment }.author.email` is a string.