### PR TITLE
Accept Dialog altButton support

### DIFF
--- a/client/lib/accept/README.md
+++ b/client/lib/accept/README.md
@@ -56,22 +56,6 @@ accept( 'Are you sure you want to perform this action?', function( accepted ) {
 } );
 ```
 
-This will make the confirmation button look scary:
-
-```js
-var accept = require( 'lib/accept' );
-
-accept( 'Are you sure you want to perform this action?', function( accepted ) {
-	if ( accepted ) {
-		// User accepted the prompt
-	} else {
-		// User cancelled or otherwise closed the prompt
-	}
-}, translate( 'Destroy Everything' ), translate( 'Nevermind' ), {
-	isScary: true
-} );
-```
-
 Alternate button example:
 
 ```js

--- a/client/lib/accept/README.md
+++ b/client/lib/accept/README.md
@@ -16,6 +16,13 @@ Accept is a stylized substitute to the browser `confirm` dialog.
 ## Options
 
 * `isScary` - if `true`, confirm button will look scary.
+* `altButton` - Optional alternate action button props.
+
+Currently supported `altButton` props are:
+
+* `label` - Alternate button label (required).
+* `action` - action value to return when clicked (defaults to `alt`).
+* `isScary` - if `true`, alternate button will look scary.
 
 ## Usage
 
@@ -46,5 +53,42 @@ accept( 'Are you sure you want to perform this action?', function( accepted ) {
 	}
 }, translate( 'Destroy Everything' ), translate( 'Nevermind' ), {
 	isScary: true
+} );
+```
+
+This will make the confirmation button look scary:
+
+```js
+var accept = require( 'lib/accept' );
+
+accept( 'Are you sure you want to perform this action?', function( accepted ) {
+	if ( accepted ) {
+		// User accepted the prompt
+	} else {
+		// User cancelled or otherwise closed the prompt
+	}
+}, translate( 'Destroy Everything' ), translate( 'Nevermind' ), {
+	isScary: true
+} );
+```
+
+Alternate button example:
+
+```js
+var accept = require( 'lib/accept' );
+
+accept( 'Are you sure you want to perform this action?', function( accepted, action ) {
+	if ( accepted ) {
+		// User accepted the prompt
+	} else if ( action === 'alt' ) {
+		// User chose alternate action
+	} else {
+		// User cancelled or otherwise closed the prompt
+	}
+}, translate( 'Destroy Everything' ), translate( 'Nevermind' ), {
+	isScary: true,
+	altButton: {
+		label: translate( 'Go back to Sleep' ) )
+	}
 } );
 ```

--- a/client/lib/accept/dialog.jsx
+++ b/client/lib/accept/dialog.jsx
@@ -25,7 +25,7 @@ const AcceptDialog = React.createClass( {
 	},
 
 	onClose: function( action ) {
-		this.props.onClose( 'accept' === action );
+		this.props.onClose( 'accept' === action, action );
 
 		if ( this.isMounted() ) {
 			this.setState( { isVisible: false } );
@@ -36,7 +36,7 @@ const AcceptDialog = React.createClass( {
 		const { options } = this.props;
 		const isScary = options && options.isScary;
 		const additionalClassNames = classnames( { 'is-scary': isScary } );
-		return [
+		const buttons = [
 			{
 				action: 'cancel',
 				label: this.props.cancelButtonText ? this.props.cancelButtonText : this.props.translate( 'Cancel' ),
@@ -48,6 +48,21 @@ const AcceptDialog = React.createClass( {
 				additionalClassNames
 			}
 		];
+
+		const altButton = options && options.altButton;
+		if ( altButton && altButton.label ) {
+			buttons.unshift( {
+				action: altButton.action || 'alt',
+				label: altButton.label,
+				additionalClassNames: classnames( {
+					'is-scary': altButton.isScary,
+					'is-borderless': true,
+					'is-left-aligned': true
+				} )
+			} );
+		}
+
+		return buttons;
 	},
 
 	render: function() {

--- a/client/lib/accept/index.js
+++ b/client/lib/accept/index.js
@@ -13,7 +13,7 @@ module.exports = function( message, callback, confirmButtonText, cancelButtonTex
 	var wrapper = document.createElement( 'div' );
 	document.body.appendChild( wrapper );
 
-	function onClose( result ) {
+	function onClose( result, action ) {
 		if ( wrapper ) {
 			ReactDom.unmountComponentAtNode( wrapper );
 			document.body.removeChild( wrapper );
@@ -21,7 +21,7 @@ module.exports = function( message, callback, confirmButtonText, cancelButtonTex
 		}
 
 		if ( callback ) {
-			callback( result );
+			callback( result, action );
 		}
 	}
 


### PR DESCRIPTION
This PR changes `lib/accept` dialog to have a third button called `altButton` which is, by default, left-aligned and borderless like below.

<img width="572" alt="screenshot_335" src="https://user-images.githubusercontent.com/127594/29375405-be4eade8-8269-11e7-8b1d-e0bc25fbfdb3.png">

Note that callback will receive `accepted` set to false when altButton is clicked. To detect altButton action, check newly added second parameter `action` which will be set to `alt` when alternate action is chosen.