### PR TITLE
Plugins: Modify 'installed' selectors to accept site IDs instead of objects

### DIFF
--- a/client/blocks/extension-redirect/index.jsx
+++ b/client/blocks/extension-redirect/index.jsx
@@ -11,7 +11,7 @@ import page from 'page';
  * Internal dependencies
  */
 import versionCompare from 'lib/version-compare';
-import { getSite, getSiteSlug } from 'state/sites/selectors';
+import { getSiteSlug } from 'state/sites/selectors';
 import { getPluginOnSite, isRequesting } from 'state/plugins/installed/selectors';
 import QueryJetpackPlugins from 'components/data/query-jetpack-plugins';
 
@@ -57,14 +57,10 @@ class ExtensionRedirect extends Component {
 }
 
 export default connect(
-	( state, { pluginId, siteId } ) => {
-		const site = getSite( state, siteId );
-
-		return {
-			pluginActive: !! site && get( getPluginOnSite( state, site, pluginId ), 'active', false ),
-			pluginVersion: site && get( getPluginOnSite( state, site, pluginId ), 'version' ),
-			requestingPlugins: isRequesting( state, siteId ),
-			siteSlug: getSiteSlug( state, siteId ),
-		};
-	}
+	( state, { pluginId, siteId } ) => ( {
+		pluginActive: get( getPluginOnSite( state, siteId, pluginId ), 'active', false ),
+		pluginVersion: get( getPluginOnSite( state, siteId, pluginId ), 'version' ),
+		requestingPlugins: isRequesting( state, siteId ),
+		siteSlug: getSiteSlug( state, siteId ),
+	} )
 )( ExtensionRedirect );

--- a/client/extensions/woocommerce/app/dashboard/required-plugins-install-view.js
+++ b/client/extensions/woocommerce/app/dashboard/required-plugins-install-view.js
@@ -386,7 +386,7 @@ class RequiredPluginsInstallView extends Component {
 
 function mapStateToProps( state ) {
 	const site = getSelectedSiteWithFallback( state );
-	const sitePlugins = site ? getPlugins( state, [ site ] ) : [];
+	const sitePlugins = site ? getPlugins( state, [ site.ID ] ) : [];
 
 	return {
 		site,

--- a/client/my-sites/site-settings/amp/jetpack.jsx
+++ b/client/my-sites/site-settings/amp/jetpack.jsx
@@ -11,20 +11,22 @@ import { connect } from 'react-redux';
 import CompactCard from 'components/card/compact';
 import SectionHeader from 'components/section-header';
 import QueryJetpackPlugins from 'components/data/query-jetpack-plugins';
-import { getSelectedSite, getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
+import { addQueryArgs } from 'lib/url';
+import { getCustomizerUrl, getSiteSlug } from 'state/sites/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
 import { isRequesting, getPluginOnSite } from 'state/plugins/installed/selectors';
 
 const AmpJetpack = ( {
 	ampPluginInstalled,
+	customizerAmpPanelUrl,
 	requestingPlugins,
-	site,
 	siteId,
 	siteSlug,
 	translate
 } ) => {
 	let linkUrl, linkText;
 	if ( ampPluginInstalled && ampPluginInstalled.active ) {
-		linkUrl = site.URL + '/wp-admin/customize.php?autofocus%5Bpanel%5D=amp_panel&customize_amp=1';
+		linkUrl = customizerAmpPanelUrl;
 		linkText = translate( 'Edit the design of your Accelerated Mobile Pages' );
 	} else {
 		linkUrl = '/plugins/amp/' + siteSlug;
@@ -62,15 +64,19 @@ const AmpJetpack = ( {
 
 export default connect(
 	( state ) => {
-		const site = getSelectedSite( state );
 		const siteId = getSelectedSiteId( state );
+		const customizerUrl = getCustomizerUrl( state, siteId );
+		const customizerAmpPanelUrl = addQueryArgs( {
+			'autofocus[panel]': 'amp_panel',
+			customize_amp: 1,
+		}, customizerUrl );
 
 		return {
-			site,
 			siteId,
-			ampPluginInstalled: getPluginOnSite( state, site, 'amp' ),
+			ampPluginInstalled: getPluginOnSite( state, siteId, 'amp' ),
+			customizerAmpPanelUrl,
 			requestingPlugins: isRequesting( state, siteId ),
-			siteSlug: getSelectedSiteSlug( state ),
+			siteSlug: getSiteSlug( state, siteId ),
 		};
 	}
 )( localize( AmpJetpack ) );

--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -566,7 +566,7 @@ const mapStateToProps = ( state, ownProps ) => {
 		isSeoToolsActive: isJetpackModuleActive( state, siteId, 'seo-tools' ),
 		isSiteHidden: isHiddenSite( state, siteId ),
 		isSitePrivate: isPrivateSite( state, siteId ),
-		activePlugins: getPlugins( state, [ { ID: siteId } ], 'active' ),
+		activePlugins: getPlugins( state, [ siteId ], 'active' ),
 		hasAdvancedSEOFeature: hasFeature( state, siteId, FEATURE_ADVANCED_SEO ),
 		isSaveSuccess: isSiteSettingsSaveSuccessful( state, siteId ),
 		saveError: getSiteSettingsSaveError( state, siteId ),

--- a/client/state/plugins/installed/README.md
+++ b/client/state/plugins/installed/README.md
@@ -29,11 +29,11 @@ A module for managing installed plugins on connected sites.
 
 ### `isRequestingForSites( state: Object, sites: Array )`
 
-### `getPlugins( state: Object, sites: Array, pluginFilter: Object )`
+### `getPlugins( state: Object, siteIds: Array, pluginFilter: Object )`
 
 Get plugins installed on a list of sites (can also be just one site, but it should still be an array). Each plugin returned also lists the sites it's installed on in a `sites` property. Can be filtered by `active`, `inactive`, `updates`.
 
-### `getPluginsWithUpdates( state: Object, sites: Array )`
+### `getPluginsWithUpdates( state: Object, siteIds: Array )`
 
 ### `getStatusForPlugin( state: Object, siteId: Number|String, pluginId: String )`
 

--- a/client/state/plugins/installed/selectors.js
+++ b/client/state/plugins/installed/selectors.js
@@ -1,13 +1,27 @@
+/**
+ * External dependencies
+ */
 import {
 	every,
 	filter,
 	find,
+	get,
 	pick,
 	reduce,
 	some,
 	sortBy,
 	values
 } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import {
+	getSite,
+	getSiteTitle,
+	isJetpackSite,
+	isJetpackSiteSecondaryNetworkSite
+} from 'state/sites/selectors';
 
 const _filters = {
 	none: function() {
@@ -48,18 +62,18 @@ export function isRequestingForSites( state, sites ) {
 	return some( sites, ( siteId ) => isRequesting( state, siteId ) );
 }
 
-export function getPlugins( state, sites, pluginFilter ) {
-	let pluginList = reduce( sites, ( memo, site ) => {
-		const list = state.plugins.installed.plugins[ site.ID ] || [];
+export function getPlugins( state, siteIds, pluginFilter ) {
+	let pluginList = reduce( siteIds, ( memo, siteId ) => {
+		const list = state.plugins.installed.plugins[ siteId ] || [];
 		list.forEach( ( item ) => {
 			const sitePluginInfo = pick( item, [ 'active', 'autoupdate', 'update' ] );
 			if ( memo[ item.slug ] ) {
 				memo[ item.slug ].sites = {
 					...memo[ item.slug ].sites,
-					[ site.ID ]: sitePluginInfo
+					[ siteId ]: sitePluginInfo
 				};
 			} else {
-				memo[ item.slug ] = { ...item, sites: { [ site.ID ]: sitePluginInfo } };
+				memo[ item.slug ] = { ...item, sites: { [ siteId ]: sitePluginInfo } };
 			}
 		} );
 		return memo;
@@ -71,43 +85,43 @@ export function getPlugins( state, sites, pluginFilter ) {
 	return values( sortBy( pluginList, item => item.slug.toLowerCase() ) );
 }
 
-export function getPluginsWithUpdates( state, sites ) {
-	return filter( getPlugins( state, sites ), _filters.updates );
+export function getPluginsWithUpdates( state, siteIds ) {
+	return filter( getPlugins( state, siteIds ), _filters.updates );
 }
 
-export function getPluginOnSite( state, site, pluginSlug ) {
-	const pluginList = getPlugins( state, [ site ] );
+export function getPluginOnSite( state, siteId, pluginSlug ) {
+	const pluginList = getPlugins( state, [ siteId ] );
 	return find( pluginList, { slug: pluginSlug } );
 }
 
-export function getSitesWithPlugin( state, sites, pluginSlug ) {
-	const pluginList = getPlugins( state, sites );
+export function getSitesWithPlugin( state, siteIds, pluginSlug ) {
+	const pluginList = getPlugins( state, siteIds );
 	const plugin = find( pluginList, { slug: pluginSlug } );
 	if ( ! plugin ) {
 		return [];
 	}
 
 	// Filter the requested sites list by the list of sites for this plugin
-	const pluginSites = filter( sites, ( site ) => {
-		return plugin.sites.hasOwnProperty( site.ID );
+	const pluginSites = filter( siteIds, ( siteId ) => {
+		return plugin.sites.hasOwnProperty( siteId );
 	} );
 
-	return sortBy( pluginSites, item => item.title.toLowerCase() );
+	return sortBy( pluginSites, siteId => getSiteTitle( state, siteId ).toLowerCase() );
 }
 
-export function getSitesWithoutPlugin( state, sites, pluginSlug ) {
-	const installedOnSites = getSitesWithPlugin( state, sites, pluginSlug ) || [];
-	return filter( sites, function( site ) {
-		if ( ! site.visible || ! site.jetpack ) {
+export function getSitesWithoutPlugin( state, siteIds, pluginSlug ) {
+	const installedOnSiteIds = getSitesWithPlugin( state, siteIds, pluginSlug ) || [];
+	return filter( siteIds, function( siteId ) {
+		if ( ! get( getSite( state, siteId ), 'visible' ) || ! isJetpackSite( state, siteId ) ) {
 			return false;
 		}
 
-		if ( site.jetpack && site.isSecondaryNetworkSite() ) {
+		if ( isJetpackSiteSecondaryNetworkSite( state, siteId ) ) {
 			return false;
 		}
 
-		return every( installedOnSites, function( installedOnSite ) {
-			return installedOnSite.slug !== site.slug;
+		return every( installedOnSiteIds, function( installedOnSiteId ) {
+			return installedOnSiteId !== siteId;
 		} );
 	} );
 }

--- a/client/state/plugins/installed/test/selectors.js
+++ b/client/state/plugins/installed/test/selectors.js
@@ -55,6 +55,24 @@ const state = deepFreeze( {
 				}
 			}
 		}
+	},
+	sites: {
+		items: {
+			'site.one': {
+				ID: 'site.one',
+				jetpack: true,
+				visible: true,
+				isSecondaryNetworkSite: ( () => false ),
+				name: 'One Site',
+			},
+			'site.two': {
+				ID: 'site.two',
+				jetpack: true,
+				visible: true,
+				isSecondaryNetworkSite: ( () => false ),
+				name: 'Two Site'
+			}
+		}
 	}
 } );
 
@@ -129,116 +147,96 @@ describe( 'Installed plugin selectors', function() {
 
 	describe( 'getPlugins', function() {
 		it( 'Should get an empty array if the requested site is not in the current state', function() {
-			const plugins = selectors.getPlugins( state, [ { ID: 'no.site' } ] );
+			const plugins = selectors.getPlugins( state, [ 'no.site' ] );
 			expect( plugins ).to.have.lengthOf( 0 );
 		} );
 
 		it( 'Should get a plugin list of length 3 if both sites are requested', function() {
-			const plugins = selectors.getPlugins( state, [ { ID: 'site.one' }, { ID: 'site.two' } ] );
+			const plugins = selectors.getPlugins( state, [ 'site.one', 'site.two' ] );
 			expect( plugins ).to.have.lengthOf( 3 );
 		} );
 
 		it( 'Should get a plugin list containing jetpack if both sites are requested', function() {
-			const siteOneObj = { ID: 'site.one' };
-			const siteTwoObj = { ID: 'site.two' };
-			const plugins = selectors.getPlugins( state, [ siteOneObj, siteTwoObj ] );
-			const siteWithPlugin = { [ siteTwoObj.ID ]: pick( jetpack, [ 'active', 'autoupdate', 'update' ] ) };
+			const siteOneId = 'site.one';
+			const siteTwoId = 'site.two';
+			const plugins = selectors.getPlugins( state, [ siteOneId, siteTwoId ] );
+			const siteWithPlugin = { [ siteTwoId ]: pick( jetpack, [ 'active', 'autoupdate', 'update' ] ) };
 			expect( plugins ).to.deep.include( { ...jetpack, sites: siteWithPlugin } );
 		} );
 
 		it( 'Should get a plugin list of length 2 if only site 1 is requested', function() {
-			const plugins = selectors.getPlugins( state, [ { ID: 'site.one' } ] );
+			const plugins = selectors.getPlugins( state, [ 'site.one' ] );
 			expect( plugins ).to.have.lengthOf( 2 );
 		} );
 
 		it( 'Should get a plugin list of length 2 if active plugins on both sites are requested', function() {
-			const siteOneObj = { ID: 'site.one' };
-			const siteTwoObj = { ID: 'site.two' };
-			const plugins = selectors.getPlugins( state, [ siteOneObj, siteTwoObj ], 'active' );
+			const plugins = selectors.getPlugins( state, [ 'site.one', 'site.two' ], 'active' );
 			expect( plugins ).to.have.lengthOf( 2 );
 		} );
 
 		it( 'Should get a plugin list of length 1 if inactive plugins on site 1 is requested', function() {
-			const plugins = selectors.getPlugins( state, [ { ID: 'site.one' } ], 'inactive' );
+			const plugins = selectors.getPlugins( state, [ 'site.one' ], 'inactive' );
 			expect( plugins ).to.have.lengthOf( 1 );
 		} );
 	} );
 
 	describe( 'getPluginsWithUpdates', function() {
 		it( 'Should get an empty array if the requested site is not in the current state', function() {
-			const plugins = selectors.getPluginsWithUpdates( state, [ { ID: 'no.site' } ] );
+			const plugins = selectors.getPluginsWithUpdates( state, [ 'no.site' ] );
 			expect( plugins ).to.have.lengthOf( 0 );
 		} );
 
 		it( 'Should get a plugin list of length 1 when we can update files on the site', function() {
-			const plugins = selectors.getPluginsWithUpdates( state, [ {
-				ID: 'site.one',
-				canUpdateFiles: true
-			}, {
-				ID: 'site.two',
-				canUpdateFiles: true
-			} ] );
+			const plugins = selectors.getPluginsWithUpdates( state, [ 'site.one', 'site.two' ] );
 			expect( plugins ).to.have.lengthOf( 1 );
 		} );
 	} );
 
 	describe( 'getPluginOnSite', function() {
 		it( 'Should get an undefined value if the requested site is not in the current state', function() {
-			expect( selectors.getPluginOnSite( state, { ID: 'no.site' }, 'akismet' ) ).to.be.undefined;
+			expect( selectors.getPluginOnSite( state, 'no.site', 'akismet' ) ).to.be.undefined;
 		} );
 
 		it( 'Should get an undefined value if the requested plugin on this site is not in the current state', function() {
-			expect( selectors.getPluginOnSite( state, { ID: 'site.one' }, 'jetpack' ) ).to.be.undefined;
+			expect( selectors.getPluginOnSite( state, 'site.one', 'jetpack' ) ).to.be.undefined;
 		} );
 
 		it( 'Should get the plugin if the it exists on the requested site', function() {
-			const siteOneObj = { ID: 'site.one' };
-			const plugin = selectors.getPluginOnSite( state, siteOneObj, 'akismet' );
-			const siteWithPlugin = { [ siteOneObj.ID ]: pick( akismet, [ 'active', 'autoupdate', 'update' ] ) };
+			const siteOneId = 'site.one';
+			const plugin = selectors.getPluginOnSite( state, siteOneId, 'akismet' );
+			const siteWithPlugin = { [ siteOneId ]: pick( akismet, [ 'active', 'autoupdate', 'update' ] ) };
 			expect( plugin ).to.eql( { ...akismet, sites: siteWithPlugin } );
 		} );
 	} );
 
 	describe( 'getSitesWithPlugin', function() {
-		const siteList = [
-			{ ID: 'site.one', slug: 'site.one', jetpack: true, visible: true, isSecondaryNetworkSite: ( () => false ), title: 'One Site' },
-			{ ID: 'site.two', slug: 'site.two', jetpack: true, visible: true, isSecondaryNetworkSite: ( () => false ), title: 'Two Site' }
-		];
-
 		it( 'Should get an empty array if the requested site is not in the current state', function() {
-			expect( selectors.getSitesWithPlugin( state, [ { ID: 'no.site' } ], 'akismet' ) ).to.have.lengthOf( 0 );
+			expect( selectors.getSitesWithPlugin( state, [ 'no.site' ], 'akismet' ) ).to.have.lengthOf( 0 );
 		} );
 
 		it( 'Should get an empty array if the requested plugin doesn\'t exist on any sites\' state', function() {
-			expect( selectors.getSitesWithPlugin( state, siteList, 'vaultpress' ) ).to.have.lengthOf( 0 );
+			expect( selectors.getSitesWithPlugin( state, [ 'site.one', 'site.two' ], 'vaultpress' ) ).to.have.lengthOf( 0 );
 		} );
 
 		it( 'Should get an array of sites with the requested plugin', function() {
-			const siteWithPlugin = siteList[ 1 ];
-			const sites = selectors.getSitesWithPlugin( state, siteList, 'jetpack' );
-			expect( sites ).to.eql( [ siteWithPlugin ] );
+			const siteIds = selectors.getSitesWithPlugin( state, [ 'site.one', 'site.two' ], 'jetpack' );
+			expect( siteIds ).to.eql( [ 'site.two' ] );
 		} );
 	} );
 
 	describe( 'getSitesWithoutPlugin', function() {
-		const siteList = [
-			{ ID: 'site.one', slug: 'site.one', jetpack: true, visible: true, isSecondaryNetworkSite: ( () => false ), title: 'One Site' },
-			{ ID: 'site.two', slug: 'site.two', jetpack: true, visible: true, isSecondaryNetworkSite: ( () => false ), title: 'Two Site' }
-		];
-
 		it( 'Should get an empty array if the requested site is not in the current state', function() {
-			expect( selectors.getSitesWithoutPlugin( state, [ { ID: 'no.site' } ], 'akismet' ) ).to.have.lengthOf( 0 );
+			expect( selectors.getSitesWithoutPlugin( state, [ 'no.site' ], 'akismet' ) ).to.have.lengthOf( 0 );
 		} );
 
 		it( 'Should get an array of sites that don\'t have the plugin in their state', function() {
-			const siteWithoutPlugin = siteList[ 1 ];
-			const sites = selectors.getSitesWithoutPlugin( state, siteList, 'akismet' );
-			expect( sites ).to.eql( [ siteWithoutPlugin ] );
+			const siteIds = selectors.getSitesWithoutPlugin( state, [ 'site.one', 'site.two' ], 'akismet' );
+			expect( siteIds ).to.eql( [ 'site.two' ] );
 		} );
 
 		it( 'Should get an empty array if the requested plugin exists on all requested sites', function() {
-			const sites = selectors.getSitesWithoutPlugin( state, siteList, 'hello-dolly' );
-			expect( sites ).to.have.lengthOf( 0 );
+			const siteIds = selectors.getSitesWithoutPlugin( state, [ 'site.one', 'site.two' ], 'hello-dolly' );
+			expect( siteIds ).to.have.lengthOf( 0 );
 		} );
 	} );
 


### PR DESCRIPTION
Allows for nicer invocation. Most of these selectors aren't widely used yet (but probably will be once the Plugins section is reduxified); some aren't at all (outside of unit tests). Affected selectors:

* `getPlugins`; used by
  * `extensions/woocommerce/app/dashboard/required-plugins-install-view`
  * `my-sites/site-settings/seo-settings/form`
* `getPluginsWithUpdates`; unused
* `getPluginOnSite`; used by:
   * `blocks/extension-redirect`
  * `my-sites/site-settings/amp/jetpack`
* `getSitesWithPlugin`; used by
  * `getSitesWithoutPlugin` selector (see below)
* `getSitesWithoutPlugin`; unused

Testing instructions (may appear to be lengthy, but are pretty simple step-by-step ones):
* Verify (by grepping for those selector names) that the above list of consumers is correct! (Note that there's another `getPlugins` function found in `lib/plugins` that's used a lot by legacy code. Don't confuse the two!)
* Verify that unit tests pass. (See CircleCI)
* We're mostly checking for correct links, or intact conflicting plugins checks (in case the following instructions appear to be a bit non-sequitur).
* `extensions/woocommerce/app/dashboard/required-plugins-install-view`:
  * On a JP site that has the WooCommerce installed _but not yet_ set up, navigate to `calypso.localhost:3000/store/<JPsite>`
  * Click 'Set up Store'
  * Watch the installation process. The text below the progress bar should inform you it's installing a number of required plugins, among them the 'WooCommerce API Dev' and 'WooCommerce Stripe Gateway' (but not WooCommerce itself).
  * Verify the process finishes successfully. (You'll be prompted with a form to fill with some data related to your business afterwards. Ignore.)
* `my-sites/site-settings/seo-settings/form`:
  * Make sure your JP test site has the Pro plan.
  * Install the 'Yoast SEO' plugin on that site, via `calypso.localhost:3000/plugins/wordpress-seo/<JPsite>`
  * Navigate to `calypso.localhost:3000/settings/traffic/<JPsite>`, and scroll down to SEO settings (you might have to enable JP's SEO module).
  * You should see a yellow warning saying 'Your SEO settings are managed by the following plugin: Yoast SEO'.
* `blocks/extension-redirect`:
  * Make sure the WP Super Cache plugin is _not_ installed on your JP test site.
  * Navigate to `calypso.localhost:3000/extensions/wp-super-cache/<JPsite>`.
  * Verify that you're redirected to `calypso.localhost:3000/plugins/wp-super-cache/<JPsite>`.
* `my-sites/site-settings/amp/jetpack`:
  * Navigate to `calypso.localhost:3000/settings/traffic/<JPsite>` on a JP site that doesn't have the AMP plugin installed.
  * In the 'AMP' section of that page, verify that there's an 'Install the AMP plugin' link, pointing to `calypso.localhost:3000/plugins/amp/<JPsite>`.
  * Follow that link and install the plugin.
  * Then, navigate back to `calypso.localhost:3000/settings/traffic/<JPsite>`.
  * Make sure the the link in the AMP section now reads 'Edit the design of your Accelerated Mobile Pages' and points to `<JPsite>/wp-admin/customize.php?autofocus%5Bpanel%5D=amp_panel&customize_amp=1`.
* You probably want to uninstall the AMP, Yoast SEO, and Woo related plugins again!