### PR TITLE
Login: Refactor social icons out of social login buttons

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -191,6 +191,7 @@
 @import 'components/sites-dropdown/style';
 @import 'components/sites-popover/style';
 @import 'components/social-buttons/style';
+@import 'components/social-icons/style';
 @import 'components/spinner/style';
 @import 'components/spinner-button/style';
 @import 'components/spinner-line/style';

--- a/client/components/social-buttons/facebook.js
+++ b/client/components/social-buttons/facebook.js
@@ -3,13 +3,22 @@
  */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import { connect } from 'react-redux';
 import { loadScript } from 'lib/load-script';
 import { localize } from 'i18n-calypso';
 import { noop } from 'lodash';
 
+/**
+ * Internal dependencies
+ */
+import FacebookIcon from 'components/social-icons/facebook';
+import { isFormDisabled } from 'state/login/selectors';
+
 class FacebookLoginButton extends Component {
 	// See: https://developers.facebook.com/docs/javascript/reference/FB.init/v2.8
 	static propTypes = {
+		isFormDisabled: PropTypes.bool,
 		appId: PropTypes.string.isRequired,
 		version: PropTypes.string,
 		cookie: PropTypes.bool,
@@ -91,14 +100,15 @@ class FacebookLoginButton extends Component {
 	}
 
 	render() {
+		const isDisabled = Boolean( this.props.isFormDisabled );
+
 		return (
 			<div className="social-buttons__button-container">
-				<button className="social-buttons__button button" onClick={ this.handleClick }>
-					<svg className="social-buttons__logo" width="20" height="20" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
-						{ /* eslint-disable max-len */ }
-						<path d="M18.86.041H1.14a1.1 1.1 0 0 0-1.099 1.1v17.718a1.1 1.1 0 0 0 1.1 1.1h9.539v-7.713H8.084V9.24h2.596V7.023c0-2.573 1.571-3.973 3.866-3.973 1.1 0 2.044.081 2.32.118v2.688l-1.592.001c-1.248 0-1.49.593-1.49 1.463v1.92h2.977l-.388 3.006h-2.59v7.713h5.076a1.1 1.1 0 0 0 1.1-1.1V1.14a1.1 1.1 0 0 0-1.1-1.099" fill="#3E68B5" fillRule="evenodd" />
-						{ /* eslint-enable max-len */ }
-					</svg>
+				<button
+					className={ classNames( 'social-buttons__button button', { disabled: isDisabled } ) }
+					onClick={ this.handleClick }
+				>
+					<FacebookIcon />
 
 					<span className="social-buttons__service-name">
 						{ this.props.translate( 'Continue with %(service)s', {
@@ -112,4 +122,8 @@ class FacebookLoginButton extends Component {
 	}
 }
 
-export default localize( FacebookLoginButton );
+export default connect(
+	( state ) => ( {
+		isFormDisabled: isFormDisabled( state ),
+	} ),
+)( localize( FacebookLoginButton ) );

--- a/client/components/social-buttons/google.js
+++ b/client/components/social-buttons/google.js
@@ -3,6 +3,7 @@
  */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 import { connect } from 'react-redux';
 import { loadScript } from 'lib/load-script';
 import { localize } from 'i18n-calypso';
@@ -11,6 +12,7 @@ import { noop } from 'lodash';
 /**
  * Internal dependencies
  */
+import GoogleIcon from 'components/social-icons/google';
 import Popover from 'components/popover';
 import { preventWidows } from 'lib/formatting';
 import { recordTracksEvent } from 'state/analytics/actions';
@@ -145,33 +147,17 @@ class GoogleLoginButton extends Component {
 	}
 
 	render() {
-		let classes = 'social-buttons__button button';
-		if ( this.state.isDisabled || this.props.isFormDisabled || this.state.error ) {
-			classes += ' disabled';
-		}
+		const isDisabled = Boolean( this.state.isDisabled || this.props.isFormDisabled || this.state.error );
 
 		return (
 			<div className="social-buttons__button-container">
-				<button className={ classes } onMouseOver={ this.showError } onMouseOut={ this.hideError } onClick={ this.handleClick }>
-					{ /* eslint-disable max-len */ }
-					<svg className="social-buttons__logo enabled" width="20" height="20" viewBox="0 0 20 20"xmlns="http://www.w3.org/2000/svg">
-						<g fill="none" fillRule="evenodd">
-							<path d="M19.6 10.227c0-.709-.064-1.39-.182-2.045H10v3.868h5.382a4.6 4.6 0 0 1-1.996 3.018v2.51h3.232c1.891-1.742 2.982-4.305 2.982-7.35z" fill="#4285F4" />
-							<path d="M10 20c2.7 0 4.964-.895 6.618-2.423l-3.232-2.509c-.895.6-2.04.955-3.386.955-2.605 0-4.81-1.76-5.595-4.123H1.064v2.59A9.996 9.996 0 0 0 10 20z" fill="#34A853" />
-							<path d="M4.405 11.9c-.2-.6-.314-1.24-.314-1.9 0-.66.114-1.3.314-1.9V5.51H1.064A9.996 9.996 0 0 0 0 10c0 1.614.386 3.14 1.064 4.49l3.34-2.59z" fill="#FBBC05" />
-							<path d="M10 3.977c1.468 0 2.786.505 3.823 1.496l2.868-2.868C14.959.99 12.695 0 10 0 6.09 0 2.71 2.24 1.064 5.51l3.34 2.59C5.192 5.736 7.396 3.977 10 3.977z" fill="#EA4335" />
-						</g>
-					</svg>
-
-					<svg className="social-buttons__logo disabled" width="20" height="20" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
-						<g fill="none" fillRule="evenodd">
-							<path d="M19.6 10.227c0-.709-.064-1.39-.182-2.045H10v3.868h5.382a4.6 4.6 0 0 1-1.996 3.018v2.51h3.232c1.891-1.742 2.982-4.305 2.982-7.35z" fill="#e9eff3" />
-							<path d="M10 20c2.7 0 4.964-.895 6.618-2.423l-3.232-2.509c-.895.6-2.04.955-3.386.955-2.605 0-4.81-1.76-5.595-4.123H1.064v2.59A9.996 9.996 0 0 0 10 20z" fill="#e9eff3" />
-							<path d="M4.405 11.9c-.2-.6-.314-1.24-.314-1.9 0-.66.114-1.3.314-1.9V5.51H1.064A9.996 9.996 0 0 0 0 10c0 1.614.386 3.14 1.064 4.49l3.34-2.59z" fill="#e9eff3" />
-							<path d="M10 3.977c1.468 0 2.786.505 3.823 1.496l2.868-2.868C14.959.99 12.695 0 10 0 6.09 0 2.71 2.24 1.064 5.51l3.34 2.59C5.192 5.736 7.396 3.977 10 3.977z" fill="#e9eff3" />
-						</g>
-					</svg>
-					{ /* eslint-enable max-len */ }
+				<button
+					className={ classNames( 'social-buttons__button button', { disabled: isDisabled } ) }
+					onMouseOver={ this.showError }
+					onMouseOut={ this.hideError }
+					onClick={ this.handleClick }
+				>
+					<GoogleIcon isDisabled={ isDisabled } />
 
 					<span className="social-buttons__service-name">
 						{ this.props.translate( 'Continue with %(service)s', {

--- a/client/components/social-buttons/style.scss
+++ b/client/components/social-buttons/style.scss
@@ -1,29 +1,5 @@
 /*rtl:ignore*/
 
-.social-buttons__button {
-	svg {
-		margin-top: -2px;
-
-		&.disabled {
-			display: none;
-		}
-	}
-}
-
-.social-buttons__button.disabled {
-	svg.enabled {
-		display: none;
-	}
-
-	svg.disabled {
-		display: inline;
-	}
-}
-
-.social-buttons__logo {
-	vertical-align: middle;
-}
-
 .social-buttons__service-name {
 	margin-left: 9px;
 }

--- a/client/components/social-icons/facebook.jsx
+++ b/client/components/social-icons/facebook.jsx
@@ -1,0 +1,38 @@
+/**
+ * External dependencies
+ */
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import { omit } from 'lodash';
+
+export default class FacebookIcon extends PureComponent {
+	static PropTypes = {
+		isDisabled: PropTypes.boolean,
+	};
+
+	static defaultProps = {
+		isDisabled: false,
+	};
+
+	render() {
+		const props = omit( this.props, [ 'isDisabled' ] );
+		return (
+			<svg
+				className={ classNames( 'social-icons social-icons__facebook', {
+					'social-icons--enabled': ! this.props.isDisabled,
+					'social-icons--disabled': !! this.props.isDisabled,
+				} ) }
+				width="20"
+				height="20"
+				viewBox="0 0 20 20"
+				xmlns="http://www.w3.org/2000/svg"
+				{ ... props }
+			>
+				{/* eslint-disable max-len */}
+				<path d="M18.86.041H1.14a1.1 1.1 0 0 0-1.099 1.1v17.718a1.1 1.1 0 0 0 1.1 1.1h9.539v-7.713H8.084V9.24h2.596V7.023c0-2.573 1.571-3.973 3.866-3.973 1.1 0 2.044.081 2.32.118v2.688l-1.592.001c-1.248 0-1.49.593-1.49 1.463v1.92h2.977l-.388 3.006h-2.59v7.713h5.076a1.1 1.1 0 0 0 1.1-1.1V1.14a1.1 1.1 0 0 0-1.1-1.099" fill="#3E68B5" fillRule="evenodd" />
+				{/* eslint-enable max-len */}
+			</svg>
+		);
+	}
+}

--- a/client/components/social-icons/google.jsx
+++ b/client/components/social-icons/google.jsx
@@ -1,0 +1,43 @@
+/**
+ * External dependencies
+ */
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import { omit } from 'lodash';
+
+export default class GoogleIcon extends PureComponent {
+	static PropTypes = {
+		isDisabled: PropTypes.boolean,
+	};
+
+	static defaultProps = {
+		isDisabled: false,
+	};
+
+	render() {
+		const props = omit( this.props, [ 'isDisabled' ] );
+		return (
+			<svg
+				className={ classNames( 'social-icons social-icons__google', {
+					'social-icons--enabled': ! this.props.isDisabled,
+					'social-icons--disabled': !! this.props.isDisabled,
+				} ) }
+				width="20"
+				height="20"
+				viewBox="0 0 20 20"
+				xmlns="http://www.w3.org/2000/svg"
+				{ ... props }
+			>
+				<g fill="none" fillRule="evenodd">
+					{/* eslint-disable max-len */}
+					<path d="M19.6 10.227c0-.709-.064-1.39-.182-2.045H10v3.868h5.382a4.6 4.6 0 0 1-1.996 3.018v2.51h3.232c1.891-1.742 2.982-4.305 2.982-7.35z" fill="#4285F4" />
+					<path d="M10 20c2.7 0 4.964-.895 6.618-2.423l-3.232-2.509c-.895.6-2.04.955-3.386.955-2.605 0-4.81-1.76-5.595-4.123H1.064v2.59A9.996 9.996 0 0 0 10 20z" fill="#34A853" />
+					<path d="M4.405 11.9c-.2-.6-.314-1.24-.314-1.9 0-.66.114-1.3.314-1.9V5.51H1.064A9.996 9.996 0 0 0 0 10c0 1.614.386 3.14 1.064 4.49l3.34-2.59z" fill="#FBBC05" />
+					<path d="M10 3.977c1.468 0 2.786.505 3.823 1.496l2.868-2.868C14.959.99 12.695 0 10 0 6.09 0 2.71 2.24 1.064 5.51l3.34 2.59C5.192 5.736 7.396 3.977 10 3.977z" fill="#EA4335" />
+					{/* eslint-enable max-len */}
+				</g>
+			</svg>
+		);
+	}
+}

--- a/client/components/social-icons/style.scss
+++ b/client/components/social-icons/style.scss
@@ -1,0 +1,10 @@
+.social-icons {
+	margin-top: -2px;
+	vertical-align: middle;
+}
+
+.social-icons--disabled {
+	path {
+		fill: lighten( $gray, 30% );
+	}
+}


### PR DESCRIPTION
This is in preparation for #17234 (social login management screen) which addresses #16690. We want to re-use the social icons from the login buttons in the management UI, so I've refactored it out to a separate component here.

#### Testing instructions

1. Check out locally (`git checkout refactor/social-login-buttons`) and start your server. You can also use a [live branch](https://calypso.live/?branch=refactor/social-login-buttons)
2. Open the social sign on page ([`/start/social`](http://calypso.localhost:3000/start/social/))
3. Verify that social login buttons behave identically to before the change.

#### Reviews

- [x] Code
- [x] Product