### PR TITLE
Reader: Use uniform value for max-height in RelatedPostCard

### DIFF
--- a/client/blocks/reader-related-card-v2/style.scss
+++ b/client/blocks/reader-related-card-v2/style.scss
@@ -9,7 +9,7 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 	margin-bottom: 20px;
 	display: -webkit-box;
 	letter-spacing: 0.01em;
-	max-height: 22px;
+	max-height: 14px * 1.6;
 	overflow: hidden;
 	position: relative;
 	text-transform: uppercase;
@@ -17,7 +17,7 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 	-webkit-box-orient: vertical;
 
 	&::after{
-		@include long-content-fade( $size: 10% );
+		@include long-content-fade( $size: 35px );
 	}
 
 	@include breakpoint( "<660px" ) {
@@ -154,7 +154,7 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 		}
 
 		&::after {
-			@include long-content-fade( $size: 25% );
+			@include long-content-fade( $size: 35px );
 				bottom: 0;
 				height: 23px;
 				top: inherit;
@@ -201,7 +201,7 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 		max-height: 206px;
 
 		&::after {
-			@include long-content-fade( $size: 30% );
+			@include long-content-fade( $size: 35px );
 			bottom: 0;
 			height: 22px;
 			top: inherit;
@@ -226,14 +226,14 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 		.has-thumbnail {
 
 			.reader-related-card-v2__post {
-				max-height: 106px;
+				max-height: 17px * 1.6 * 4;
 
 				@media #{$reader-related-card-v2-breakpoint-medium} {
-					max-height: 108px;
+					max-height: 17px * 1.6 * 4;
 				}
 
 				@media #{$reader-related-card-v2-breakpoint-small} {
-					max-height: 104px;
+					max-height: 17px * 1.6 * 4;
 				}
 			}
 		}
@@ -258,18 +258,18 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 		margin-top: 40px;
 
 		.reader-related-card-v2__post {
-			max-height: 206px;
+			max-height: 17px * 1.6 * 7.5;
 
 			@media #{$reader-related-card-v2-breakpoint-medium} {
-				max-height: 108px;
+				max-height: 17px * 1.6 * 4;
 			}
 
 			@media #{$reader-related-card-v2-breakpoint-small} {
-				max-height: 108px;
+				max-height: 17px * 1.6 * 4;
 			}
 
 			@include breakpoint( "<480px" ) {
-				max-height: 104px;
+				max-height: 17px * 1.6 * 4;
 			}
 		}
 
@@ -299,11 +299,11 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 		.reader-related-card-v2__post {
 
 			@media #{$reader-related-card-v2-breakpoint-medium} {
-				margin-top: 55px;
+				margin-top: 50px;
 			}
 
 			@media #{$reader-related-card-v2-breakpoint-small} {
-				margin-top: 55px;
+				margin-top: 50px;
 			}
 		}
 
@@ -337,22 +337,18 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 			}
 
 			.reader-related-card-v2__post {
-				max-height: 106px;
+				max-height: 17px * 1.6 * 4;
 
 				@media #{$reader-related-card-v2-breakpoint-medium} {
 					flex: 3 0 0;
 					margin-top: 25px;
-					max-height: 125px;
+					max-height: 17px * 1.6 * 4.7;
 				}
 
 				@media #{$reader-related-card-v2-breakpoint-small} {
 					flex: 3 0 0;
 					margin-top: 25px;
-					max-height: 130px;
-				}
-
-				@include breakpoint( "<480px" ) {
-					max-height: 121px;
+					max-height: 17px * 1.6 * 4.7;
 				}
 			}
 		}
@@ -402,197 +398,16 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 	border-top: 1px solid lighten( $gray, 20% );
 	padding-top: 11px;
 
-	// Wrapper for site title, thumbnail, excerpt
+	// Wrapper for site title and excerpt
 	.reader-related-card-v2__post {
-		max-height: 282px;
+		max-height: 17px * 1.6 * 4;
 
 		&::after {
-			@include long-content-fade( $size: 30% );
+			@include long-content-fade( $size: 35px );
 			bottom: 0;
 			height: 22px;
 			top: auto;
 			visibility: visible;
-		}
-	}
-
-	&.is-same-site {
-
-		.reader-related-card-v2 {
-			margin-top: -6px;
-		}
-
-		.reader-related-card-v2__meta {
-			display: none !important; // Hides meta info in "More In Site" recs
-		}
-
-		.reader-related-card-v2__featured-image {
-			margin: 0 0 14px;
-		}
-
-		.has-thumbnail .reader-related-card-v2__post {
-		 max-height: 106px;
-
-			@media #{$reader-related-card-v2-breakpoint-medium} {
-				max-height: 108px;
-			}
-
-			@media #{$reader-related-card-v2-breakpoint-small} {
-				max-height: 104px;
-			}
-		}
-
-		.reader-related-card-v2__post {
-
-			@media #{$reader-related-card-v2-breakpoint-medium} {
-				flex: 3 0 0;
-			}
-
-			@media #{$reader-related-card-v2-breakpoint-small} {
-				flex: 3 0 0;
-			}
-		}
-
-		.reader-related-card-v2.has-thumbnail {
-			margin-top: 0;
-		}
-	}
-
-	&.is-other-site {
-		margin-top: 40px;
-
-		.reader-related-card-v2__post {
-			max-height: 282px;
-
-			@media #{$reader-related-card-v2-breakpoint-medium} {
-				max-height: 108px;
-			}
-
-			@media #{$reader-related-card-v2-breakpoint-small} {
-				max-height: 108px;
-			}
-
-			@include breakpoint( "<480px" ) {
-				max-height: 104px;
-			}
-		}
-
-		.reader-related-card-v2__featured-image {
-
-			@media #{$reader-related-card-v2-breakpoint-medium} {
-				margin: 0 15px 0 0;
-			}
-
-			@media #{$reader-related-card-v2-breakpoint-small} {
-				margin: 0 15px 0 0;
-			}
-		}
-
-		.reader-related-card-v2__meta {
-
-			@media #{$reader-related-card-v2-breakpoint-medium} {
-				position: absolute;
-				width: 100%;
-			}
-
-			@media #{$reader-related-card-v2-breakpoint-small} {
-				position: absolute;
-			}
-		}
-
-		.reader-related-card-v2__post {
-
-			@media #{$reader-related-card-v2-breakpoint-medium} {
-				margin-top: 55px;
-			}
-
-			@media #{$reader-related-card-v2-breakpoint-small} {
-				margin-top: 55px;
-			}
-		}
-
-		.has-thumbnail .reader-related-card-v2__site-info {
-
-			@media #{$reader-related-card-v2-breakpoint-medium} {
-				margin-top: 20px;
-			}
-
-			@media #{$reader-related-card-v2-breakpoint-small} {
-				margin-top: 20px;
-			}
-
-			.reader-related-card-v2__meta {
-				margin-bottom: 19px;
-
-				@media #{$reader-related-card-v2-breakpoint-medium} {
-					margin-top: -4px;
-					right: 0;
-					width: calc( 100% - 97px );
-				}
-
-				@media #{$reader-related-card-v2-breakpoint-small} {
-					margin-top: -4px;
-					right: 0;
-					width: calc( 100% - 97px );
-				}
-			}
-
-			.reader-related-card-v2__post {
-				max-height: 106px;
-
-				@media #{$reader-related-card-v2-breakpoint-medium} {
-					flex: 3 0 0;
-					margin-top: 25px;
-					max-height: 125px;
-				}
-
-				@media #{$reader-related-card-v2-breakpoint-small} {
-					flex: 3 0 0;
-					margin-top: 25px;
-					max-height: 130px;
-				}
-
-				@include breakpoint( "<480px" ) {
-					max-height: 121px;
-				}
-			}
-		}
-
-		.reader-related-card-v2 {
-			margin-top: -5px;
-		}
-
-		.reader-related-card-v2__featured-image {
-			margin: 0 0 14px;
-		}
-	}
-
-	&.is-same-site,
-	&.is-other-site {
-
-		.reader-related-card-v2 {
-
-			@media #{$reader-related-card-v2-breakpoint-medium} {
-				flex-direction: row;
-			}
-
-			@media #{$reader-related-card-v2-breakpoint-small} {
-				flex-direction: row;
-			}
-		}
-
-		.reader-related-card-v2__featured-image {
-
-			@media #{$reader-related-card-v2-breakpoint-medium} {
-				flex: 0 0 80px;
-				margin: 0 15px 0 0;
-				width: 80px;
-			}
-
-			@media #{$reader-related-card-v2-breakpoint-small} {
-				flex: 0 0 80px;
-				margin: 0 15px 0 0;
-				width: 80px;
-			}
 		}
 	}
 }
@@ -625,7 +440,7 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 .reader-related-card-v2__byline-site {
 	color: $blue-medium;
 	display: flex;
-	max-height: 23px;
+	max-height: 14px * 1.75;
 	max-width: 200px;
 	overflow: hidden;
 	overflow-wrap: break-word;
@@ -704,7 +519,7 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 		word-wrap: break-word;
 
 		&::after {
-			@include long-content-fade( $size: 20% );
+			@include long-content-fade( $size: 35px );
 			top: 16px * 1.4;
 			height: 16px * 1.4;
 		}
@@ -713,11 +528,11 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 	// Clamp to 3 lines on larger viewports
 	@include breakpoint( ">660px" ) {
 		overflow: hidden;
-		max-height: 16px * 1.6 * 3;
+		max-height: 17px * 1.56 * 3;
 		word-wrap: break-word;
 
 		&::after {
-			@include long-content-fade( $size: 20% );
+			@include long-content-fade( $size: 35px );
 			top: 16px * 1.5 * 2;
 			height: 16px * 1.5;
 		}


### PR DESCRIPTION
These are changes made in the PR. There are no visual/design changes.

1. In cards we use for Related Posts and Post Recommendations, we limit the number of lines shown to 4 (when a thumbnail exists) by using `max-height` with arbitrary values. I updated those values to use `font-size * line-height * number of lines` instead of arbitrary numbers.

Note though that when the byline exists, we aren't able to use 4 for `number of lines` since we have to account for the byline, but at least the `font-size` and `line-height` are the same.

2. Cleaned up code, lots of duplicated blocks.

3. Updated the fade to use a uniform value of `35px` instead of percentages.

`RelatedPostCardv2` is being used in:

## A. Fullpost recs (Same site)
![screenshot 2017-08-16 15 33 22](https://user-images.githubusercontent.com/4924246/29388136-4700b5cc-8298-11e7-9883-84bf77488528.png)
![screenshot 2017-08-16 15 33 30](https://user-images.githubusercontent.com/4924246/29388137-47016b48-8298-11e7-9045-c5b966582a90.png)
![screenshot 2017-08-16 15 35 16](https://user-images.githubusercontent.com/4924246/29388203-8dce9668-8298-11e7-9bf2-ef2a2568cf29.png)

## B. Fullpost recs (More in WPCOM):
![screenshot 2017-08-16 15 34 09](https://user-images.githubusercontent.com/4924246/29388167-5fe803f6-8298-11e7-8017-b645a7af5f67.png)
![screenshot 2017-08-16 15 34 16](https://user-images.githubusercontent.com/4924246/29388168-5febb88e-8298-11e7-8e59-0062d01b8ee5.png)
![screenshot 2017-08-16 15 35 30](https://user-images.githubusercontent.com/4924246/29388207-9168e80a-8298-11e7-8075-0a6311e5f9d0.png)

## C. Search recs:
![screenshot 2017-08-16 15 36 10](https://user-images.githubusercontent.com/4924246/29388225-a87dcf92-8298-11e7-8a20-13ccdcbf80c8.png)
![screenshot 2017-08-16 15 36 18](https://user-images.githubusercontent.com/4924246/29388226-a880b54a-8298-11e7-9372-d61e3b6b1d08.png)


