### PR TITLE
Settings: Re-add Tracks recording for Site Verification Services

### DIFF
--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -247,7 +247,6 @@ export const SeoForm = React.createClass( {
 			trackFormSubmitted,
 			trackTitleFormatsUpdated,
 			trackFrontPageMetaUpdated,
-			trackSiteVerificationUpdated
 		} = this.props;
 
 		trackFormSubmitted();
@@ -258,22 +257,6 @@ export const SeoForm = React.createClass( {
 
 		if ( dirtyFields.has( 'frontPageMetaDescription' ) ) {
 			trackFrontPageMetaUpdated();
-		}
-
-		if ( dirtyFields.has( 'googleCode' ) ) {
-			trackSiteVerificationUpdated( 'google' );
-		}
-
-		if ( dirtyFields.has( 'bingCode' ) ) {
-			trackSiteVerificationUpdated( 'bing' );
-		}
-
-		if ( dirtyFields.has( 'pinterestCode' ) ) {
-			trackSiteVerificationUpdated( 'pinterest' );
-		}
-
-		if ( dirtyFields.has( 'yandexCode' ) ) {
-			trackSiteVerificationUpdated( 'yandex' );
 		}
 	},
 
@@ -580,7 +563,6 @@ const mapDispatchToProps = {
 	trackFormSubmitted: partial( recordTracksEvent, 'calypso_seo_settings_form_submit' ),
 	trackTitleFormatsUpdated: partial( recordTracksEvent, 'calypso_seo_tools_title_formats_updated' ),
 	trackFrontPageMetaUpdated: partial( recordTracksEvent, 'calypso_seo_tools_front_page_meta_updated' ),
-	trackSiteVerificationUpdated: ( service ) => recordTracksEvent( 'calypso_seo_tools_site_verification_updated', { service: service } ),
 	activateModule,
 };
 

--- a/client/my-sites/site-settings/seo-settings/site-verification.jsx
+++ b/client/my-sites/site-settings/seo-settings/site-verification.jsx
@@ -73,7 +73,10 @@ class SiteVerification extends Component {
 			this.props.markSaved();
 			this.props.requestSiteSettings( nextProps.siteId );
 			this.refreshSite();
-			this.setState( { isSubmittingForm: false } );
+			this.setState( {
+				isSubmittingForm: false,
+				dirtyFields: Set(),
+			} );
 		}
 
 		// save error
@@ -205,7 +208,9 @@ class SiteVerification extends Component {
 		const {
 			siteId,
 			translate,
+			trackSiteVerificationUpdated
 		} = this.props;
+		const { dirtyFields } = this.state;
 
 		if ( ! event.isDefaultPrevented() && event.nativeEvent ) {
 			event.preventDefault();
@@ -244,6 +249,22 @@ class SiteVerification extends Component {
 
 		this.props.saveSiteSettings( siteId, updatedOptions );
 		this.props.trackFormSubmitted();
+
+		if ( dirtyFields.has( 'googleCode' ) ) {
+			trackSiteVerificationUpdated( 'google' );
+		}
+
+		if ( dirtyFields.has( 'bingCode' ) ) {
+			trackSiteVerificationUpdated( 'bing' );
+		}
+
+		if ( dirtyFields.has( 'pinterestCode' ) ) {
+			trackSiteVerificationUpdated( 'pinterest' );
+		}
+
+		if ( dirtyFields.has( 'yandexCode' ) ) {
+			trackSiteVerificationUpdated( 'yandex' );
+		}
 	}
 
 	render() {
@@ -437,6 +458,11 @@ export default connect(
 		requestSite,
 		requestSiteSettings,
 		saveSiteSettings,
+		trackSiteVerificationUpdated: ( service ) => recordTracksEvent(
+			'calypso_seo_tools_site_verification_updated', {
+				service
+			}
+		),
 		trackFormSubmitted: partial( recordTracksEvent, 'calypso_seo_settings_form_submit' ),
 		activateModule,
 	},


### PR DESCRIPTION
Following #16244, Site Verification Services within the Traffic section was move to its own component. As a result, the Tracks stats were no longer recording properly. This re-adds tracking for that section.

While setting this up, I noticed the dirty fields persisted in state after saving. For example, if I setup a Google verification code and saved my changes, the correct Tracks event would fire. Without refreshing the page, if I added a Bing code and saved the changes, I would get two Tracks events (one for Bing and another for Google) because Google was still in the dirty fields. As a result, I added `dirtyFields: Set(),` [to `componentWillReceiveProps` called on save success](https://github.com/Automattic/wp-calypso/blob/7d901a6ecd198f11f805c7106561a28167330b5b/client/my-sites/site-settings/seo-settings/site-verification.jsx#L78). That fixes the issue by resetting the dirty fields, and I didn't experience any side effects.

### To test
1. Load up this branch. Use `localStorage.setItem('debug', 'calypso:analytics*');` to log out Tracks events to your console.
2. Try adding some of the verification services under http://calypso.localhost:3000/settings/traffic/. The `calypso_seo_tools_site_verification_updated` event should fire with a prop of the verified service. I've pasted example codes to use at the bottom here for ease of reference.

**Example codes**
These are the examples we provide to use for testing.
- Google: `<meta name="google-site-verification" content="f0w4NjmVso-ol9myrC9J4mbOnsZm_dj_rBK3VoOjNRo" />`
- Bing: `<meta name="msvalidate.01" content="1234" />`
- Pinterest: `<meta name="p:domain_verify" content="1234" />`
- Yandex: `<meta name="yandex-verification" content="1234" />`