### PR TITLE
Color Schemes: Add Color Scheme Picker to Account Settings

### DIFF
--- a/client/lib/user-settings/index.js
+++ b/client/lib/user-settings/index.js
@@ -235,7 +235,7 @@ UserSettings.prototype.getSetting = function( settingName ) {
  * @return {Boolean} updating successful response
  */
 UserSettings.prototype.updateSetting = function( settingName, value ) {
-	if ( this.settings && 'undefined' !== typeof get( this.settings, settingName ) ) {
+	if ( has( this.settings, settingName ) ) {
 		set( this.unsavedSettings, settingName, value );
 
 		/*

--- a/client/lib/user-settings/index.js
+++ b/client/lib/user-settings/index.js
@@ -216,7 +216,7 @@ UserSettings.prototype.getSetting = function( settingName ) {
 	var setting = null;
 
 	// If we haven't fetched settings, or if the setting doesn't exist return null
-	if ( this.settings && 'undefined' !== typeof get( this.settings, settingName ) ) {
+	if ( has( this.settings, settingName ) ) {
 		setting =
 			this.isSettingUnsaved( settingName )
 				? get( this.unsavedSettings, settingName )

--- a/client/lib/user-settings/index.js
+++ b/client/lib/user-settings/index.js
@@ -26,6 +26,26 @@ function decodeUserSettingsEntities( data ) {
 	return assign( {}, data, decodedValues );
 }
 
+/*
+ * Deletes a provided unsaved setting, then calls itself recursively
+ * to delete any empty parents of the setting passed to it
+ */
+function deleteUnsavedSetting( settings, settingName, recursive ) {
+	if ( ! isEmpty( get( settings, settingName ) ) || recursive ) {
+		unset( settings, settingName );
+
+		const settingKeys = settingName.split( '.' );
+		if ( settingKeys.length > 1 ) {
+			settingKeys.pop();
+			const parentKey = settingKeys.join( '.' );
+			//if parent is empty, call function again
+			if ( parentKey && isEmpty( get( settings, parentKey ) ) ) {
+				deleteUnsavedSetting( settings, parentKey, true );
+			}
+		}
+	}
+}
+
 /**
  * Initialize UserSettings with defaults
  *
@@ -196,10 +216,11 @@ UserSettings.prototype.getSetting = function( settingName ) {
 	var setting = null;
 
 	// If we haven't fetched settings, or if the setting doesn't exist return null
-	if ( this.settings && 'undefined' !== typeof this.settings[ settingName ] ) {
-		setting = ( 'undefined' !== typeof this.unsavedSettings[ settingName ] )
-			? this.unsavedSettings[ settingName ]
-			: this.settings[ settingName ];
+	if ( this.settings && 'undefined' !== typeof get( this.settings, settingName ) ) {
+		setting =
+			'undefined' !== typeof get( this.unsavedSettings, settingName )
+				? get( this.unsavedSettings, settingName )
+				: get( this.settings, settingName );
 	}
 
 	return setting;
@@ -214,8 +235,8 @@ UserSettings.prototype.getSetting = function( settingName ) {
  * @return {Boolean} updating successful response
  */
 UserSettings.prototype.updateSetting = function( settingName, value ) {
-	if ( this.settings && 'undefined' !== typeof this.settings[ settingName ] ) {
-		this.unsavedSettings[ settingName ] = value;
+	if ( this.settings && 'undefined' !== typeof get( this.settings, settingName ) ) {
+		set( this.unsavedSettings, settingName, value );
 
 		/*
 		 * If the two match, we don't consider the setting "changed".
@@ -223,11 +244,11 @@ UserSettings.prototype.updateSetting = function( settingName, value ) {
 		 * is more complicated.
 		 */
 		if (
-			this.settings[ settingName ] === this.unsavedSettings[ settingName ] &&
+			get( this.settings, settingName ) === get( this.unsavedSettings, settingName ) &&
 			'user_login' !== settingName
 		) {
 			debug( 'Removing ' + settingName + ' from changed settings.' );
-			delete this.unsavedSettings[ settingName ];
+			deleteUnsavedSetting( this.unsavedSettings, settingName );
 		}
 
 		this.emit( 'change' );
@@ -239,12 +260,13 @@ UserSettings.prototype.updateSetting = function( settingName, value ) {
 };
 
 UserSettings.prototype.isSettingUnsaved = function( settingName ) {
-	return ( settingName in this.unsavedSettings );
+	return has( this.unsavedSettings, settingName );
 };
 
 UserSettings.prototype.removeUnsavedSetting = function( settingName ) {
-	if ( settingName in this.unsavedSettings ) {
-		delete this.unsavedSettings[ settingName ];
+
+	if ( has( this.unsavedSettings, settingName ) ) {
+		deleteUnsavedSetting( this.unsavedSettings, settingName );
 
 		this.emit( 'change' );
 	}

--- a/client/lib/user-settings/index.js
+++ b/client/lib/user-settings/index.js
@@ -218,7 +218,7 @@ UserSettings.prototype.getSetting = function( settingName ) {
 	// If we haven't fetched settings, or if the setting doesn't exist return null
 	if ( this.settings && 'undefined' !== typeof get( this.settings, settingName ) ) {
 		setting =
-			'undefined' !== typeof get( this.unsavedSettings, settingName )
+			this.isSettingUnsaved( settingName )
 				? get( this.unsavedSettings, settingName )
 				: get( this.settings, settingName );
 	}
@@ -265,7 +265,7 @@ UserSettings.prototype.isSettingUnsaved = function( settingName ) {
 
 UserSettings.prototype.removeUnsavedSetting = function( settingName ) {
 
-	if ( has( this.unsavedSettings, settingName ) ) {
+	if ( this.isSettingUnsaved( settingName ) ) {
 		deleteUnsavedSetting( this.unsavedSettings, settingName );
 
 		this.emit( 'change' );

--- a/client/lib/user-settings/index.js
+++ b/client/lib/user-settings/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { assign, get, isEmpty, keys, merge } from 'lodash';
+import { assign, isEmpty, keys, merge, has, get, set, unset } from 'lodash';
 var debug = require( 'debug' )( 'calypso:user:settings' ),
 	decodeEntities = require( 'lib/formatting' ).decodeEntities;
 

--- a/client/lib/user-settings/test/index.js
+++ b/client/lib/user-settings/test/index.js
@@ -79,4 +79,26 @@ describe( 'User Settings', () => {
 			} );
 		} );
 	} );
+
+	it( 'should support flat and deep settings', done => {
+		assert.isFalse( userSettings.settings.lang_id );
+		assert.isFalse( userSettings.settings.testParent.testChild );
+
+		assert.isTrue( userSettings.updateSetting( 'lang_id', true ) );
+		assert.isTrue( userSettings.updateSetting( 'testParent.testChild', true ) );
+
+		assert.isTrue( userSettings.unsavedSettings.lang_id );
+		assert.isTrue( userSettings.unsavedSettings.testParent.testChild );
+
+		userSettings.saveSettings( assertCorrectSettingIsSaved );
+
+		function assertCorrectSettingIsSaved() {
+			assert.isUndefined( userSettings.unsavedSettings.lang_id );
+			assert.isUndefined( userSettings.unsavedSettings.testParent );
+			assert.isTrue( userSettings.settings.lang_id );
+			assert.isTrue( userSettings.settings.testParent.testChild );
+			done();
+		}
+	} );
+
 } );

--- a/client/lib/user-settings/test/mocks/wp.js
+++ b/client/lib/user-settings/test/mocks/wp.js
@@ -6,7 +6,10 @@ const me = function() {
 				get( callback ) {
 					callback( false, {
 						test: false,
-						lang_id: false
+						lang_id: false,
+						testParent: {
+							testChild: false,
+						}
 					} );
 				},
 				update( settings, callback ) {

--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -11,6 +11,7 @@ import {
 	flowRight as compose,
 	map,
 	size,
+	update,
 } from 'lodash';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
@@ -114,7 +115,15 @@ const Account = React.createClass( {
 	},
 
 	updateColorScheme( colorScheme ) {
-		this.updateUserSetting( 'calypso_preferences.colorScheme', colorScheme );
+		const settingName = 'calypso_preferences.colorScheme';
+
+		// Set a fallback color scheme if no default value is provided by the API.
+		// This is a workaround that allows us to use userSettings.updateSetting() without an
+		// existing value. Without this workaround the save button wouldn't become active.
+		// TODO: the API should provide a default value, which would make this line obsolete
+		update( this.props.userSettings.settings, settingName, value => value || 'default' );
+
+		this.updateUserSetting( settingName, colorScheme );
 	},
 
 	getEmailAddress() {

--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -538,11 +538,10 @@ const Account = React.createClass( {
 
 				{ config.isEnabled( 'me/account/color-scheme-picker' ) &&
 					<FormFieldset>
-						<FormLabel htmlFor="color_scheme">{ translate( 'Admin Color Scheme' ) }</FormLabel>
-						<ColorSchemePicker
-							temporarySelection={ true }
-							onSelection={ this.updateColorScheme }
-						/>
+						<FormLabel htmlFor="color_scheme">
+							{ translate( 'Admin Color Scheme' ) }
+						</FormLabel>
+						<ColorSchemePicker temporarySelection onSelection={ this.updateColorScheme } />
 					</FormFieldset> }
 
 				{ this.renderHolidaySnow() }

--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -43,6 +43,7 @@ import observe from 'lib/mixins/data-observe';
 import eventRecorder from 'me/event-recorder';
 import Main from 'components/main';
 import SitesDropdown from 'components/sites-dropdown';
+import ColorSchemePicker from 'blocks/color-scheme-picker';
 import { successNotice, errorNotice } from 'state/notices/actions';
 import { getLanguage } from 'lib/i18n-utils';
 import { isRequestingMissingSites } from 'state/selectors';
@@ -110,6 +111,10 @@ const Account = React.createClass( {
 		this.updateUserSetting( 'language', value );
 		const redirect = value !== originalLanguage ? '/me/account' : false;
 		this.setState( { redirect } );
+	},
+
+	updateColorScheme( colorScheme ) {
+		this.updateUserSetting( 'calypso_preferences.colorScheme', colorScheme );
 	},
 
 	getEmailAddress() {
@@ -530,6 +535,15 @@ const Account = React.createClass( {
 				</FormFieldset>
 
 				{ this.communityTranslator() }
+
+				{ config.isEnabled( 'me/account/color-scheme-picker' ) &&
+					<FormFieldset>
+						<FormLabel htmlFor="color_scheme">{ translate( 'Admin Color Scheme' ) }</FormLabel>
+						<ColorSchemePicker
+							temporarySelection={ true }
+							onSelection={ this.updateColorScheme }
+						/>
+					</FormFieldset> }
 
 				{ this.renderHolidaySnow() }
 

--- a/config/development.json
+++ b/config/development.json
@@ -99,6 +99,7 @@
 		"manage/themes/logged-out": true,
 		"manage/themes/upload": true,
 		"me/account": true,
+		"me/account/color-scheme-picker": true,
 		"me/find-friends": false,
 		"me/my-profile": true,
 		"me/next-steps": true,


### PR DESCRIPTION
This PR is part of a series of PRs aiming to provide support for Color Schemes in Calypso.
This PR focuses on integrating the Color Scheme Picker (PR https://github.com/Automattic/wp-calypso/pull/17200) in the Account Settings.

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/1562646/29387890-8aa8f9c0-82e2-11e7-9fd3-fcd73154e415.gif)


### Notable additions in this PR:
- This PR adds support for nested settings to `UserSettings` (`/lib/user-settings`).
- The feature flag `'me/account/color-scheme-picker'` is introduced.
- The `ColorSchemePicker` component is added to the `me/account/` page.

### Considerations
The `ColorSchemePicker` by default connects to/via `state/preferences/`. I initially contemplated using the same approach for the integration on `me/account/` but during development realized how deeply integrated with `/lib/user-settings` the whole page is (via `form-base`). In order to not having to duplicate all the functionality on that page, I then decided to add support for nested settings to `/lib/user-settings` instead. This way there's hardly any overhead involved in integrating the `ColorSchemePicker` on the Account Settings page.


### How to test
Visit https://calypso.live/?branch=add/color-schemes/account-me-integration or test locally.
Navigate to the `Accounts Settings` page and scroll down to the `Admin Color Scheme` section.

### Suggestions as to what to test
- Is the color scheme selection being persisted when saved and dropped when not?
- Do all combinations of different Account Settings changes work as expected?
- Double check other parts of the app making use of (`/lib/user-settings`).

### Note 
This PR currently compares its changes to PR https://github.com/Automattic/wp-calypso/pull/17200 which in turn compares to PR https://github.com/Automattic/wp-calypso/pull/17157. This is so the changes can be easily identified. This PR will be pointed at `master` once PR https://github.com/Automattic/wp-calypso/pull/17200 and https://github.com/Automattic/wp-calypso/pull/17157 have been merged.

For a more detailed description of the feature, the chosen approach and its advantages feel free to check out my post on the subject: p4TIVU-75d-p2 (internal reference).