### PR TITLE
Refactor `deterministicStringify`

### DIFF
--- a/client/lib/deterministic-stringify/index.js
+++ b/client/lib/deterministic-stringify/index.js
@@ -21,6 +21,7 @@ export function deterministicStringify( source ) {
 	// manually ask if this is _also_ an array
 	if ( Array.isArray( source ) ) {
 		return source
+			.slice() // sort mutates the original array!
 			.sort()
 			.map( deterministicStringify )
 			.join( ',' );

--- a/client/lib/deterministic-stringify/index.js
+++ b/client/lib/deterministic-stringify/index.js
@@ -1,32 +1,38 @@
-function deterministStringify( source ) {
-	var namespace = [],
-		keys;
-	if ( typeof source !== 'object' ) {
-		if ( typeof source === 'undefined' ) {
-			return 'undefined';
-		}
-		if ( typeof source === 'string' ) {
-			return "'" + source.toString() + "'";
-		}
-		return source.toString();
-	}
-	if ( Array.isArray( source ) ) {
-		source = source.sort();
-		source.forEach( function( item ) {
-			namespace.push( deterministStringify( item ) );
-		} );
-		return namespace.join( ',' );
-	}
+export function deterministicStringify( source ) {
 	if ( source === null ) {
 		return 'null';
 	}
 
-	keys = Object.keys( source );
-	keys.sort();
-	keys.forEach( function( key ) {
-		namespace.push( key + '=' + deterministStringify( source[ key ] ) );
-	} );
-	return namespace.join( '&' );
+	// Handle primitive data types:
+	// boolean, number, string, undefined
+	if ( typeof source !== 'object' ) {
+		if ( typeof source === 'undefined' ) {
+			return 'undefined';
+		}
+
+		if ( typeof source === 'string' ) {
+			return `'${ source.toString() }'`;
+		}
+
+		return source.toString();
+	}
+
+	// arrays are objects too so we have to
+	// manually ask if this is _also_ an array
+	if ( Array.isArray( source ) ) {
+		return source
+			.sort()
+			.map( deterministicStringify )
+			.join( ',' );
+	}
+
+	// else return stringified object with
+	// keys in alphabetical order
+	return Object
+		.keys( source )
+		.sort()
+		.map( key => `${ key }=${ deterministicStringify( source[ key ] ) }` )
+		.join( '&' );
 }
 
-module.exports = deterministStringify;
+export default deterministicStringify;

--- a/client/lib/deterministic-stringify/index.js
+++ b/client/lib/deterministic-stringify/index.js
@@ -12,9 +12,7 @@
  *
  * The sort values are unstable so in some cases two values
  * could produce different keys even though we would consider
- * them to be otherwise equivalent. Since we aren't using a
- * multi-key sort or a custom comparison function, however,
- * this _may_ not affect us here.
+ * them to be otherwise equivalent.
  *
  * Additionally the built-in universal sort is lexicographic,
  * meaning that it won't properly sort numeric values, though

--- a/client/lib/deterministic-stringify/index.js
+++ b/client/lib/deterministic-stringify/index.js
@@ -1,3 +1,41 @@
+/**
+ * Collapses a value into a string key with set-equality
+ *
+ * This function can be used to create a mostly-deterministic
+ * reference key for a value such that varieties of the same
+ * values which don't actually change the nominal meaning of
+ * the values will collapse to the same key.
+ *
+ * Arrays are compared set-wise and so two
+ * arrays with the same elements but having different
+ * orderings will be treated as equals.
+ *
+ * The sort values are unstable so in some cases two values
+ * could produce different keys even though we would consider
+ * them to be otherwise equivalent. Since we aren't using a
+ * multi-key sort or a custom comparison function, however,
+ * this _may_ not affect us here.
+ *
+ * Additionally the built-in universal sort is lexicographic,
+ * meaning that it won't properly sort numeric values, though
+ * it should sort them stably.
+ *
+ * The sort implementation may be different depending on the
+ * browser. At the time of this commit Chrome is still unstable
+ * while Safari is stable.
+ *
+ * This function is recursive to the depth
+ * that the input value itself is nested..
+ *
+ * @example
+ * deterministicStringify( [ 1, 2, 3 ] ) === "1,2,3"
+ * deterministicStringify( [ 3, 2, 1 ] ) === "1,2,3"
+ * deterministicStringify( { a: 5, b: null } ) = "'a'=5&'b'='null'"
+ * deterministicStringify( { b: null, a: 5 } ) = "'a'=5&'b'='null'"
+ *
+ * @param {*} source input value to collapse
+ * @returns {String} key associated with input value
+ */
 export function deterministicStringify( source ) {
 	if ( source === null ) {
 		return 'null';
@@ -6,15 +44,9 @@ export function deterministicStringify( source ) {
 	// Handle primitive data types:
 	// boolean, number, string, undefined
 	if ( typeof source !== 'object' ) {
-		if ( typeof source === 'undefined' ) {
-			return 'undefined';
-		}
-
-		if ( typeof source === 'string' ) {
-			return `'${ source.toString() }'`;
-		}
-
-		return source.toString();
+		return typeof source === 'string'
+			? `'${ source }'`
+			: String( source );
 	}
 
 	// arrays are objects too so we have to
@@ -31,7 +63,7 @@ export function deterministicStringify( source ) {
 	// keys in alphabetical order
 	return Object
 		.keys( source )
-		.sort()
+		.sort() // Note that Array.prototype.sort is _unstable_, bugs may hide here
 		.map( key => `${ key }=${ deterministicStringify( source[ key ] ) }` )
 		.join( '&' );
 }

--- a/client/lib/deterministic-stringify/test/index.js
+++ b/client/lib/deterministic-stringify/test/index.js
@@ -52,6 +52,16 @@ describe( 'deterministicStringify', function() {
 		expect( stringify( [ 10, 2 ] ) ).to.equal( '10,2' );
 	} );
 
+	/**
+	 * This is another test used to indicate an actual behavior more
+	 * than a nominal behavior. It's worth noting that it's possible
+	 * that the behavior here is different across browsers, but in
+	 * the current Node version we're specifically testing V8
+	 */
+	it( 'probably sorts unstably', () => {
+		expect( stringify( [ 1, { b: 2 }, { c: 3 } ] ) ).to.not.eql( stringify( [ 1, { c: 3 }, { b: 2 } ] ) );
+	} );
+
 	it( 'should handle nested objects', () => {
 		expect( stringify( [ 1, { a: 1 } ] ) ).to.equal( '1,a=1' );
 	} );

--- a/client/lib/deterministic-stringify/test/index.js
+++ b/client/lib/deterministic-stringify/test/index.js
@@ -1,46 +1,84 @@
-var deterministicStringify = require( 'lib/deterministic-stringify' );
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
 
-var assert = require( 'assert' );
+/**
+ * Internal dependencies
+ */
+import stringify from 'lib/deterministic-stringify';
 
-describe( 'index', function() {
-	it( 'should handle boolean', function() {
-		assert.equal( 'true', deterministicStringify( true ) );
-		assert.equal( 'false', deterministicStringify( false ) );
+describe( 'deterministicStringify', function() {
+	it( 'should stringify boolean', () => {
+		expect( stringify( true ) ).to.equal( 'true' );
+		expect( stringify( false ) ).to.equal( 'false' );
 	} );
-	it( 'should handle number', function() {
-		assert.equal( '1', deterministicStringify( 1 ) );
+
+	it( 'should produce an integer from a whole number', () => {
+		expect( stringify( 1 ) ).to.equal( '1' );
+		expect( stringify( -1 ) ).to.equal( '-1' );
+		expect( stringify( 1.0 ) ).to.equal( '1' );
 	} );
-	it( 'should handle null', function() {
-		assert.equal( 'null', deterministicStringify( null ) );
+
+	it( 'should product a fractional value from a floating-point number', () => {
+		expect( stringify( 1.2 ) ).to.equal( '1.2' );
 	} );
-	it( 'should handle undefined', function() {
-		assert.equal( 'undefined', deterministicStringify( undefined ) );
+
+	it( 'should stringify numeric extremes', () => {
+		expect( stringify( NaN ) ).to.equal( 'NaN' );
+		expect( stringify( Infinity ) ).to.equal( 'Infinity' );
+		expect( stringify( -Infinity ) ).to.equal( '-Infinity' );
 	} );
-	it( 'should sort arrays', function() {
-		assert.equal( '1,2,3', deterministicStringify( [ 2, 1, 3 ] ) );
+
+	it( 'should stringify null', () => {
+		expect( stringify( null ) ).to.equal( 'null' );
 	} );
-	it( 'should handle nested objects', function() {
-		assert.equal( '1,a=1', deterministicStringify( [ 1, { a: 1 } ] ) );
+
+	it( 'should stringify undefined', () => {
+		expect( stringify( undefined ) ).to.equal( 'undefined' );
 	} );
-	it( 'should handle boolean as object values', function() {
-		assert.equal( 'a=true', deterministicStringify( { a: true } ) );
+
+	it( 'should sort arrays', () => {
+		expect( stringify( [ 2, 1, 3 ] ) ).to.equal( '1,2,3' );
+		expect( stringify( [ 2, 1, 3 ] ) ).to.equal( stringify( [ 1, 2, 3 ] ) );
 	} );
-	it( 'should alphabetize object attributes', function() {
-		assert.equal( "a='a','b'&b=1", deterministicStringify( { b: 1, a: [ 'b', 'a' ] } ) );
+
+	/**
+	 * This test doesn't need to indicate nominal behavior so much
+	 * as check for changes in behavior and point out an aspect of
+	 * the function that may not be obvious to the caller.
+	 */
+	it( 'actually sorts lexicographically', () => {
+		expect( stringify( [ 10, 2 ] ) ).to.equal( '10,2' );
 	} );
-	it( 'should allow nesting and sort nested arrays', function() {
-		assert.equal( "a='a','blah','c'", deterministicStringify( { a: [ 'blah', 'a', 'c' ] } ) );
+
+	it( 'should handle nested objects', () => {
+		expect( stringify( [ 1, { a: 1 } ] ) ).to.equal( '1,a=1' );
 	} );
-	it( 'should produce deterministic strings regardless of attribute or array order', function() {
-		var options, optionsDifferentSort;
-		options = {
+
+	it( 'should handle boolean as object values', () => {
+		expect( stringify( { a: true } ) ).to.equal( 'a=true' );
+	} );
+
+	it( 'should alphabetize object attributes', () => {
+		expect( stringify( { b: 1, a: [ 'b', 'a' ] } ) ).to.equal( "a='a','b'&b=1" );
+	} );
+
+	it( 'should allow nesting and sort nested arrays', () => {
+		expect( stringify( { a: [ 'blah', 'a', 'c' ] } ) ).to.equal( "a='a','blah','c'" );
+	} );
+
+	it( 'should produce deterministic strings regardless of attribute or array order', () => {
+		const options = {
 			b: [ 2, 1 ],
 			a: true
 		};
-		optionsDifferentSort = {
+
+		const optionsDifferentSort = {
 			a: true,
 			b: [ 1, 2 ]
 		};
-		assert.equal( deterministicStringify( options ), deterministicStringify( optionsDifferentSort ) );
+
+		expect( stringify( options ) ).to.eql( stringify( optionsDifferentSort ) );
 	} );
 } );

--- a/client/lib/followers/store.js
+++ b/client/lib/followers/store.js
@@ -8,9 +8,9 @@ var debug = require( 'debug' )( 'calypso:wpcom-followers-store' ),
 /**
  * Internal dependencies
  */
+import deterministicStringify from 'lib/deterministic-stringify';
 var Dispatcher = require( 'dispatcher' ),
-	emitter = require( 'lib/mixins/emitter' ),
-	deterministicStringify = require( 'lib/deterministic-stringify' );
+	emitter = require( 'lib/mixins/emitter' );
 
 var _fetchingFollowersByNamespace = {}, // store fetching state (boolean)
 	_followersBySite = {}, // store user objects

--- a/client/lib/users/store.js
+++ b/client/lib/users/store.js
@@ -9,9 +9,9 @@ var debug = require( 'debug' )( 'calypso:users:store' ),
 /**
  * Internal dependencies
  */
+import deterministicStringify from 'lib/deterministic-stringify';
 var Dispatcher = require( 'dispatcher' ),
 	emitter = require( 'lib/mixins/emitter' ),
-	deterministicStringify = require( 'lib/deterministic-stringify' );
 
 var _fetchingUsersByNamespace = {},        // store fetching state (boolean)
 	_fetchingUpdatedUsersByNamespace = {}, // store fetching state (boolean)

--- a/client/my-sites/people/followers-list/index.jsx
+++ b/client/my-sites/people/followers-list/index.jsx
@@ -20,11 +20,11 @@ const PeopleListItem = require( 'my-sites/people/people-list-item' ),
 	EmptyContent = require( 'components/empty-content' ),
 	FollowersStore = require( 'lib/followers/store' ),
 	EmailFollowersStore = require( 'lib/email-followers/store' ),
-	deterministicStringify = require( 'lib/deterministic-stringify' ),
 	accept = require( 'lib/accept' ),
 	analytics = require( 'lib/analytics' );
 import Button from 'components/button';
 import ListEnd from 'components/list-end';
+import deterministicStringify from 'lib/deterministic-stringify';
 
 const maxFollowers = 1000;
 

--- a/client/my-sites/people/team-list/index.jsx
+++ b/client/my-sites/people/team-list/index.jsx
@@ -13,11 +13,11 @@ var Card = require( 'components/card' ),
 	SiteUsersFetcher = require( 'components/site-users-fetcher' ),
 	UsersActions = require( 'lib/users/actions' ),
 	InfiniteList = require( 'components/infinite-list' ),
-	deterministicStringify = require( 'lib/deterministic-stringify' ),
 	NoResults = require( 'my-sites/no-results' ),
 	analytics = require( 'lib/analytics' ),
 	PeopleListSectionHeader = require( 'my-sites/people/people-list-section-header' );
 import ListEnd from 'components/list-end';
+import deterministicStringify from 'lib/deterministic-stringify';
 
 /**
  * Module Variables


### PR DESCRIPTION
Originally I did this because it had a spelling typo in the name of the
function (not present outside due to exporting of that function) but
then I decided to update to ES2015 standards.

**Testing**
Audit the code.

I changed the way we sort arrays because the existing function mutates the passed-in argument, which, in my opinion, is terrible.

```js
const l = [4, 3, 2, 1];
console.log( deterministicStringify( l ) ); // prints "1,2,3,4"
l[ 0 ] !== 4; // ??? bad 🐒
l[ 0 ] === 1; // grrr…
```

So by slicing the array we clone it and only sort the clone.