### PR TITLE
Data Layer: Track data request meta information

### DIFF
--- a/client/state/data-layer/wpcom-http/utils.js
+++ b/client/state/data-layer/wpcom-http/utils.js
@@ -152,7 +152,7 @@ export const hasRequestLoaded = ( state, action ) =>
 export const trackRequests = next => ( store, action ) => {
 	// progress events don't affect
 	// any tracking meta at the moment
-	if ( getProgress( action ) ) {
+	if ( true !== get( action, 'meta.dataLayer.trackRequest' ) || getProgress( action ) ) {
 		return next( store, action );
 	}
 
@@ -219,26 +219,26 @@ export const requestDispatcher = middleware => ( initiator, onSuccess, onError, 
 	const { fromApi, onProgress } = { ...defaultOptions, ...options };
 
 	return middleware( ( store, action ) => {
-	const error = getError( action );
-	if ( undefined !== error ) {
-		return onError( store, action, error );
-	}
-
-	const data = getData( action );
-	if ( undefined !== data ) {
-		try {
-			return onSuccess( store, action, fromApi( data ) );
-		} catch ( err ) {
-			return onError( store, action, err );
+		const error = getError( action );
+		if ( undefined !== error ) {
+			return onError( store, action, error );
 		}
-	}
 
-	const progress = getProgress( action );
-	if ( undefined !== progress ) {
-		return onProgress( store, action, progress );
-	}
+		const data = getData( action );
+		if ( undefined !== data ) {
+			try {
+				return onSuccess( store, action, fromApi( data ) );
+			} catch ( err ) {
+				return onError( store, action, err );
+			}
+		}
 
-	return initiator( store, action );
+		const progress = getProgress( action );
+		if ( undefined !== progress ) {
+			return onProgress( store, action, progress );
+		}
+
+		return initiator( store, action );
 	} );
 };
 
@@ -309,8 +309,7 @@ export const exRequestDispatcher = middleware => options => {
 
 		return store.dispatch( requestAction );
 	} );
-
-	};
+};
 export const dispatchRequestEx = exRequestDispatcher( trackRequests );
 
 /*

--- a/client/state/data-layer/wpcom-http/utils.js
+++ b/client/state/data-layer/wpcom-http/utils.js
@@ -147,6 +147,7 @@ export const hasRequestLoaded = ( state, action ) =>
  * here operating on the _REQUEST actions and not in the HTTP
  * pipeline as a processor on HTTP_REQUEST actions.
  *
+ * @param {Function} next next link in HTTP middleware chain
  * @returns {Function} middleware function to track requests
  */
 export const trackRequests = next => ( store, action ) => {

--- a/client/state/data-layer/wpcom-http/utils.js
+++ b/client/state/data-layer/wpcom-http/utils.js
@@ -3,13 +3,14 @@
 /**
  * External dependencies
  */
-
+import deterministicStringify from 'json-stable-stringify';
 import schemaValidator from 'is-my-json-valid';
-import { get, identity, noop } from 'lodash';
+import { get, identity, merge, noop } from 'lodash';
 
 /**
  * Internal dependencies
  */
+import { keyedReducer } from 'state/utils';
 import warn from 'lib/warn';
 
 /**
@@ -95,10 +96,82 @@ export const makeParser = ( schema, schemaOptions = {}, transformer = identity )
 	// the actual parser
 	return data => transform( validate( data ) );
 };
+const getRequestStatus = action => {
+	if ( undefined !== getError( action ) ) {
+		return 'failure';
+	}
+
+	if ( undefined !== getData( action ) ) {
+		return 'success';
+	}
+
+	return 'pending';
+};
+
+export const getRequestKey = fullAction => {
+	const { meta, ...action } = fullAction; // eslint-disable-line no-unused-vars
+	const requestKey = get( meta, 'dataLayer.requestKey' );
+
+	return requestKey ? requestKey : deterministicStringify( action );
+};
+
+export const getRequest = ( state, key ) => state.dataRequests[ key ] || {};
+
+export const requestsReducerItem = (
+	state = null,
+	{ meta: { dataLayer: { lastUpdated, pendingSince, status } = {} } = {} }
+) => Object.assign( { status }, lastUpdated && { lastUpdated }, pendingSince && { pendingSince } );
+
+export const reducer = keyedReducer( 'meta.dataLayer.requestKey', requestsReducerItem );
+
+export const isRequestLoading = ( state, action ) =>
+	getRequest( state, getRequestKey( action ) ).status === 'pending';
+
+export const hasRequestLoaded = ( state, action ) =>
+	getRequest( state, getRequestKey( action ) ).lastUpdated > -Infinity;
+
+/**
+ * Tracks the state of network activity for a given request type
+ *
+ * When we issue _REQUEST type actions they usually create some
+ * associated network activity by means of an HTTP request.
+ * We may want to know what the status of those requests are, if
+ * they have completed or if they have failed.
+ *
+ * This tracker stores the meta data for those requests which
+ * can then be independently polled by React components which
+ * need to know about those data requests.
+ *
+ * Note that this is meta data about remote data requests and
+ * _not_ about network activity, which is why this is code is
+ * here operating on the _REQUEST actions and not in the HTTP
+ * pipeline as a processor on HTTP_REQUEST actions.
+ *
+ * @returns {Function} middleware function to track requests
+ */
+export const trackRequests = next => ( store, action ) => {
+	// progress events don't affect
+	// any tracking meta at the moment
+	if ( getProgress( action ) ) {
+		return next( store, action );
+	}
+
+	const requestKey = getRequestKey( action );
+	const status = getRequestStatus( action );
+	const dataLayer = Object.assign(
+		{ requestKey, status },
+		status === 'pending' ? { pendingSince: Date.now() } : { lastUpdated: Date.now() }
+	);
+
+	const dispatch = response => store.dispatch( merge( response, { meta: { dataLayer } } ) );
+
+	next( { ...store, dispatch }, action );
+};
 
 /**
  * @type Object default dispatchRequest options
  * @property {Function} fromApi validates and transforms API response data
+ * @property {Function} middleware chain of functions to process before dispatch
  * @property {Function} onProgress called on progress events
  */
 const defaultOptions = {
@@ -131,20 +204,21 @@ const defaultOptions = {
  *   onProgress :: ReduxStore -> Action -> Dispatcher -> ProgressData
  *   fromApi    :: ResponseData -> [ Boolean, Data ]
  *
+ * @param {Function} middleware intercepts requests moving through the system
  * @param {Function} initiator called if action lacks response meta; should create HTTP request
  * @param {Function} onSuccess called if the action meta includes response data
  * @param {Function} onError called if the action meta includes error data
  * @param {Object} options configures additional dispatching behaviors
  + @param {Function} [options.fromApi] maps between API data and Calypso data
  + @param {Function} [options.onProgress] called on progress events when uploading
+ * @param {Function} [options.middleware] runs before the dispatch itself
+ * @param {Function} [options.onProgress] called on progress events when uploading
  * @returns {?*} please ignore return values, they are undefined
  */
-export const dispatchRequest = ( initiator, onSuccess, onError, options = {} ) => (
-	store,
-	action
-) => {
+export const requestDispatcher = middleware => ( initiator, onSuccess, onError, options = {} ) => {
 	const { fromApi, onProgress } = { ...defaultOptions, ...options };
 
+	return middleware( ( store, action ) => {
 	const error = getError( action );
 	if ( undefined !== error ) {
 		return onError( store, action, error );
@@ -165,7 +239,10 @@ export const dispatchRequest = ( initiator, onSuccess, onError, options = {} ) =
 	}
 
 	return initiator( store, action );
+	} );
 };
+
+export const dispatchRequest = requestDispatcher( trackRequests );
 
 /**
  * Dispatches to appropriate function based on HTTP request meta
@@ -195,15 +272,16 @@ export const dispatchRequest = ( initiator, onSuccess, onError, options = {} ) =
  *   onProgress :: Action -> ProgressData -> Action
  *   fromApi    :: ResponseData -> TransformedData throws TransformerError|SchemaError
  *
+ * @param {Function} middleware intercepts requests moving through the system
  * @param {Object} options object with named parameters:
- * @param {Function} fetch called if action lacks response meta; should create HTTP request
- * @param {Function} onSuccess called if the action meta includes response data
- * @param {Function} onError called if the action meta includes error data
- * @param {Function} onProgress called on progress events when uploading
- * @param {Function} fromApi maps between API data and Calypso data
+ * @param {Function} options.fetch called if action lacks response meta; should create HTTP request
+ * @param {Function} options.onSuccess called if the action meta includes response data
+ * @param {Function} options.onError called if the action meta includes error data
+ * @param {Function} options.onProgress called on progress events when uploading
+ * @param {Function} options.fromApi maps between API data and Calypso data
  * @returns {Action} action or action thunk to be executed in response to HTTP event
  */
-export const dispatchRequestEx = options => {
+export const exRequestDispatcher = middleware => options => {
 	if ( ! options.fetch ) {
 		warn( 'fetch handler is not defined: no request will ever be issued' );
 	}
@@ -216,7 +294,7 @@ export const dispatchRequestEx = options => {
 		warn( 'onError handler is not defined: error during the request is being ignored' );
 	}
 
-	return ( store, action ) => {
+	return middleware( ( store, action ) => {
 		// create the low-level action we want to dispatch
 		const requestAction = createRequestAction( options, action );
 
@@ -230,8 +308,10 @@ export const dispatchRequestEx = options => {
 		}
 
 		return store.dispatch( requestAction );
+	} );
+
 	};
-};
+export const dispatchRequestEx = exRequestDispatcher( trackRequests );
 
 /*
  * Converts an application-level Calypso action that's handled by the data-layer middleware

--- a/client/state/data-layer/wpcom/plans/index.js
+++ b/client/state/data-layer/wpcom/plans/index.js
@@ -23,13 +23,14 @@ import {
  * @returns {Object} original action
  */
 export const requestPlans = action =>
-		http( {
+	http(
+		{
 			apiVersion: '1.4',
 			method: 'GET',
 			path: '/plans',
-			onSuccess: action,
-			onFailure: action,
-	} );
+		},
+		action
+	);
 
 /**
  * Dispatches returned WordPress.com plan data

--- a/client/state/data-layer/wpcom/plans/index.js
+++ b/client/state/data-layer/wpcom/plans/index.js
@@ -3,9 +3,8 @@
 /**
  * Internal dependencies
  */
-
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
 import { PLANS_REQUEST } from 'state/action-types';
 import {
 	plansReceiveAction,
@@ -20,47 +19,45 @@ import {
 /**
  * Dispatches a request to fetch all available WordPress.com plans
  *
- * @param {Function} dispatch Redux dispatcher
  * @param {Object} action Redux action
  * @returns {Object} original action
  */
-export const requestPlans = ( { dispatch }, action ) =>
-	dispatch(
+export const requestPlans = action =>
 		http( {
 			apiVersion: '1.4',
 			method: 'GET',
 			path: '/plans',
 			onSuccess: action,
 			onFailure: action,
-		} )
-	);
+	} );
 
 /**
  * Dispatches returned WordPress.com plan data
  *
- * @param {Function} dispatch Redux dispatcher
  * @param {Object} action Redux action
  * @param {Array} plans raw data from plans API
+ * @returns {Array<Object>} Redux actions
  */
-export const receivePlans = ( { dispatch }, action, plans ) => {
-	dispatch( plansRequestSuccessAction() );
-	dispatch( plansReceiveAction( plans ) );
-};
+export const receivePlans = ( action, plans ) => [
+	plansRequestSuccessAction(),
+	plansReceiveAction( plans ),
+];
 
 /**
  * Dispatches returned error from plans request
  *
- * @param {Function} dispatch Redux dispatcher
  * @param {Object} action Redux action
  * @param {Object} rawError raw error from HTTP request
+ * @returns {Object} Redux action
  */
-export const receiveError = ( { dispatch }, action, rawError ) => {
-	const error = rawError instanceof Error ? rawError.message : rawError;
+export const receiveError = ( action, rawError ) =>
+	plansRequestFailureAction( rawError instanceof Error ? rawError.message : rawError );
 
-	dispatch( plansRequestFailureAction( error ) );
-};
-
-export const dispatchPlansRequest = dispatchRequest( requestPlans, receivePlans, receiveError );
+export const dispatchPlansRequest = dispatchRequestEx( {
+	fetch: requestPlans,
+	onSuccess: receivePlans,
+	onError: receiveError,
+} );
 
 export default {
 	[ PLANS_REQUEST ]: [ dispatchPlansRequest ],

--- a/client/state/data-layer/wpcom/plans/test/index.js
+++ b/client/state/data-layer/wpcom/plans/test/index.js
@@ -1,11 +1,4 @@
 /** @format */
-
-/**
- * External dependencies
- */
-import { expect } from 'chai';
-import { spy } from 'sinon';
-
 /**
  * Internal dependencies
  */
@@ -21,49 +14,40 @@ import { WPCOM_RESPONSE } from 'state/plans/test/fixture';
 describe( 'wpcom-api', () => {
 	describe( 'plans request', () => {
 		describe( '#requestPlans', () => {
-			test( 'should dispatch HTTP request to plans endpoint', () => {
+			test( 'should return HTTP request to plans endpoint', () => {
 				const action = { type: 'DUMMY' };
-				const dispatch = spy();
 
-				requestPlans( { dispatch }, action );
-
-				expect( dispatch ).to.have.been.calledOnce;
-				expect( dispatch ).to.have.been.calledWith(
-					http( {
-						apiVersion: '1.4',
-						method: 'GET',
-						path: '/plans',
-						onSuccess: action,
-						onFailure: action,
-					} )
+				expect( requestPlans( action ) ).toEqual(
+					http(
+						{
+							apiVersion: '1.4',
+							method: 'GET',
+							path: '/plans',
+						},
+						action
+					)
 				);
 			} );
 		} );
 
 		describe( '#receivePlans', () => {
-			test( 'should dispatch plan updates', () => {
+			test( 'should return plan updates', () => {
 				const plans = WPCOM_RESPONSE;
 				const action = plansReceiveAction( plans );
-				const dispatch = spy();
 
-				receivePlans( { dispatch }, action, plans );
-
-				expect( dispatch ).to.have.been.calledTwice;
-				expect( dispatch ).to.have.been.calledWith( plansRequestSuccessAction() );
-				expect( dispatch ).to.have.been.calledWith( plansReceiveAction( plans ) );
+				expect( receivePlans( action, plans ) ).toEqual( [
+					plansRequestSuccessAction(),
+					plansReceiveAction( plans ),
+				] );
 			} );
 		} );
 
 		describe( '#receiveError', () => {
-			test( 'should dispatch error', () => {
+			test( 'should return error', () => {
 				const error = 'could not find plans';
 				const action = plansRequestFailureAction( error );
-				const dispatch = spy();
 
-				receiveError( { dispatch }, action, error );
-
-				expect( dispatch ).to.have.been.calledOnce;
-				expect( dispatch ).to.have.been.calledWith( plansRequestFailureAction( error ) );
+				expect( receiveError( action, error ) ).toEqual( plansRequestFailureAction( error ) );
 			} );
 		} );
 	} );

--- a/client/state/index.js
+++ b/client/state/index.js
@@ -29,6 +29,7 @@ import consoleDispatcher from './console-dispatch';
 import countries from './countries/reducer';
 import countryStates from './country-states/reducer';
 import currentUser from './current-user/reducer';
+import { reducer as dataRequests } from './data-layer/wpcom-http/utils';
 import documentHead from './document-head/reducer';
 import domains from './domains/reducer';
 import geo from './geo/reducer';
@@ -99,6 +100,7 @@ const reducers = {
 	countries,
 	countryStates,
 	currentUser,
+	dataRequests,
 	documentHead,
 	domains,
 	extensions,


### PR DESCRIPTION
We often have a legitimate need in a React component to know if data has
been requested yet or if requests for that data have failed (though not
as often as you might think!)

In this patch we're adding in a new system into the `dispatchRequest`
wrapper whereby requests are tracked and that meta information is
retrievable.

Currently we track two properties: what is the current state of a
request and when did we last receive an update in Calypso?

This tracking is based off of the assumption that we have a
correspondance between the `_REQUEST` Redux action and an associated
`HTTP_REQUEST` to get it _and_ that we pass in the original action to
the call to `http()`. However, if those conditions are met then we can
track the request successfully and key it by the original action.

That is, suppose we issue `{ type: SITE_REQUEST, siteId }`: Calypso UI
code only cares about declaring that the data is needed. How does it
know the answers to the following questions?

 - _Is the data in state?_ - just check state
 - _Have we attempted to get the data?_ - `getRequestMeta( { type:
   SITE_REQUEST, siteId } ).status !== 'null'`
 - _When was our last update?_ - `getRequestMeta( ... ).lastUpdate`
 - _Was it a failed request?_ - `getRequestMeta( ... ).status ===
   'failure'`
 - _Is a request for this data going on right now?_ - `getRequestMeta(
   ... ).status === 'pending'`

This is an attempt to provide wanted information without polluting the
Redux state tree. We need to ascertain if the assumptions it makes are
safe enough to use; I suspect they are.

Since it's looking at the original action passed through `dispatchRequest()` and is agnostic about the details of that action this should also work for `POST` requests and everything.

Note that by using the request action as the lookup key we can keep on reusing the persisted metadata to keep track of data freshness. That is, if we request the same comment twice, then the same metadata will be updated twice and we can use that to determine how old the data is based on `lastUpdated` (cc: @jorgefilipecosta we could implement the freshness validation as another link in the middleware chain of `dispatchRequest()` turning `trackRequests( … )` into `compose( trackRequests( … ), withFreshness )` or something like that)

**Usage**

I'm thinking that for now we just import the request action creators and use them in a component. Suppose we want to show the loading state for a comment…

```js
const Comment = props =>
	props.isLoading
		? <Loading />
		: <CommentDetail />

const mapStateToProps = ( state, { siteId, commentId } ) => ( {
	// note that this doesn't dispatch, it only creates the action itself
	// which is used as a lookup key for the metadata
	isLoading: dataLayer.isLoading( requestComment( siteId, commentId ) )
} );

export default connect( mapStateToProps )( Comment );
```

What I _don't_ like about this is coupling in the data layer. Could be resolved by persisting metadata in state but I'm not entirely sure I want to do that and it could also be hidden via a selector but that's basically cheating.

@coderkevin I feel like I'm circling back to your `fetchData` scheme were components are aware of the fact that data comes from a remote source and includes that metadata inline. On the other hand, I think that the number of places where we need this data is exceptional and limited mostly to data updates or new resource creation so maybe it's still best to be thinking about "rending basic data."

I also don't like that this is bound to encourage people to think in terms of fetch/wait/receive instead of using the presence or absence of state to determine if something is loading. Probably I need to document the heck out of that and indicate that this should probably be used very rarely and then less than that. If we don't hold to that paradigm we'll be doing ourselves a disservice as we adopt WebSocket-based loading.

**Testing**

This only adds a new unused behavior to the system so it just needs smoke-testing in order to be safe. However, you might enjoy opening it up in the live branch or locally, opening the console, and typing `dataRequests` to explore the meta data. If you set the network throttling to a slow value you can probably catch some requests in their pending state, then see it get updated to `success` or `failure`