### PR TITLE
WCS: Fix tracks eventname to naming convention

### DIFF
--- a/client/extensions/woocommerce/app/store-stats/controller.js
+++ b/client/extensions/woocommerce/app/store-stats/controller.js
@@ -50,7 +50,29 @@ export default function StatsController( context ) {
 	// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
 	context.store.dispatch( setTitle( translate( 'Stats', { textOnly: true } ) ) );
 
-	analytics.tracks.recordEvent( `calypso_woocommerce_stats_${ props.type }_page`, props );
+	let tracksEvent;
+	switch ( props.type ) {
+		case 'orders':
+			tracksEvent = 'calypso_woocommerce_stats_orders_page';
+			break;
+		case 'products':
+			tracksEvent = 'calypso_woocommerce_stats_products_page';
+			break;
+		case 'categories':
+			tracksEvent = 'calypso_woocommerce_stats_categories_page';
+			break;
+		case 'coupons':
+			tracksEvent = 'calypso_woocommerce_stats_coupons_page';
+			break;
+	}
+	if ( tracksEvent ) {
+		analytics.tracks.recordEvent( tracksEvent, {
+			unit: props.unit,
+			path: props.path,
+			query_date: props.queryDate,
+			selected_date: props.selectedDate,
+		} );
+	}
 
 	const asyncComponent = ( props.type === 'orders' )
 		? <AsyncLoad

--- a/client/extensions/woocommerce/app/store-stats/controller.js
+++ b/client/extensions/woocommerce/app/store-stats/controller.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -22,8 +23,9 @@ function isValidParameters( context ) {
 		type: [ 'orders', 'products', 'categories', 'coupons' ],
 		unit: [ 'day', 'week', 'month', 'year' ],
 	};
-	return Object.keys( validParameters )
-		.every( param => includes( validParameters[ param ], context.params[ param ] ) );
+	return Object.keys( validParameters ).every( param =>
+		includes( validParameters[ param ], context.params[ param ] )
+	);
 }
 
 export default function StatsController( context ) {
@@ -68,30 +70,26 @@ export default function StatsController( context ) {
 	if ( tracksEvent ) {
 		analytics.tracks.recordEvent( tracksEvent, {
 			unit: props.unit,
-			path: props.path,
 			query_date: props.queryDate,
 			selected_date: props.selectedDate,
 		} );
 	}
 
-	const asyncComponent = ( props.type === 'orders' )
-		? <AsyncLoad
-			/* eslint-disable wpcalypso/jsx-classname-namespace */
-			placeholder={ <StatsPagePlaceholder className="woocommerce" /> }
-			/* eslint-enable wpcalypso/jsx-classname-namespace */
-			require="extensions/woocommerce/app/store-stats"
-			{ ...props }
-		/>
-		: <AsyncLoad
-			/* eslint-disable wpcalypso/jsx-classname-namespace */
-			placeholder={ <StatsPagePlaceholder className="woocommerce" /> }
-			/* eslint-enable wpcalypso/jsx-classname-namespace */
-			require="extensions/woocommerce/app/store-stats/listview"
-			{ ...props }
-		/>;
-	renderWithReduxStore(
-		asyncComponent,
-		document.getElementById( 'primary' ),
-		context.store
-	);
+	const asyncComponent =
+		props.type === 'orders'
+			? <AsyncLoad
+					/* eslint-disable wpcalypso/jsx-classname-namespace */
+					placeholder={ <StatsPagePlaceholder className="woocommerce" /> }
+					/* eslint-enable wpcalypso/jsx-classname-namespace */
+					require="extensions/woocommerce/app/store-stats"
+					{ ...props }
+				/>
+			: <AsyncLoad
+					/* eslint-disable wpcalypso/jsx-classname-namespace */
+					placeholder={ <StatsPagePlaceholder className="woocommerce" /> }
+					/* eslint-enable wpcalypso/jsx-classname-namespace */
+					require="extensions/woocommerce/app/store-stats/listview"
+					{ ...props }
+				/>;
+	renderWithReduxStore( asyncComponent, document.getElementById( 'primary' ), context.store );
 }


### PR DESCRIPTION
Current naming results in Tracks events ending up in the rejects table.

>Don’t programmatically create event names. They should be hardcoded so they are easily searchable in the code base.

>Use lowercase letters in both event and property names. Separate words with underscores, not spaces or dashes. Events with names that don’t match ^[a-z_][a-z0-9_]*$ will be processed into a separate table tracks_rejects.

### Changes
* Make names searchable by writing them outright
* Fix property names
* [Edit] ran Prettier