### PR TITLE
Components: FormPasswordInput doesn't play nicely with SSR

### DIFF
--- a/client/components/forms/form-password-input/index.jsx
+++ b/client/components/forms/form-password-input/index.jsx
@@ -15,8 +15,11 @@ import viewport from 'lib/viewport';
 export default class extends React.Component {
 	static displayName = 'FormPasswordInput';
 
-	constructor( props ) {
-		super( props );
+	state = {
+		hidePassword: true,
+	};
+
+	componentDidMount() {
 		var isMobile = viewport.isMobile();
 
 		if ( isMobile ) {


### PR DESCRIPTION
This pull request fixes #17265 by waiting until `componentDidMount` before deciding if the client is mobile or not.

#### Testing instructions

1. Run `git checkout fix/17265-formpasswordinput-ssr` and start your server, or open a [live branch](https://calypso.live/log-in?branch=fix/17265-formpasswordinput-ssr)
2. Open the [`Log In` page](http://calypso.localhost:3000/log-in)
3. In your dev tools, toggle a mobile device on
4. Reload the page, ensure their are no warnings in the console

#### Reviews

- [x] Code
