### PR TITLE
Checkout: Update business plan theme upload feature copy

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/business-plan-details.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/business-plan-details.jsx
@@ -40,9 +40,11 @@ const BusinessPlanDetails = ( { selectedSite, sitePlans, selectedFeature } ) => 
 			{ ! selectedFeature &&
 				<PurchaseDetail
 					icon="customize"
-					title={ i18n.translate( 'Find a new theme' ) }
-					description={ i18n.translate( 'All our premium themes are now available at no extra cost. Try them out now.' ) }
-					buttonText={ i18n.translate( 'Browse premium themes' ) }
+					title={ i18n.translate( 'Try a New Theme' ) }
+					description={ i18n.translate(
+						'You\'ve now got access to every premium theme, at no extra cost - that\'s hundreds of new options. '
+					) }
+					buttonText={ i18n.translate( 'Give one a try!' ) }
 					href={ '/themes/' + selectedSite.slug } />
 			}
 

--- a/client/my-sites/checkout/checkout-thank-you/business-plan-details.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/business-plan-details.jsx
@@ -42,9 +42,10 @@ const BusinessPlanDetails = ( { selectedSite, sitePlans, selectedFeature } ) => 
 					icon="customize"
 					title={ i18n.translate( 'Try a New Theme' ) }
 					description={ i18n.translate(
-						'You\'ve now got access to every premium theme, at no extra cost - that\'s hundreds of new options. '
+						'You\'ve now got access to every premium theme, at no extra cost - that\'s hundreds of new options. ' +
+						'Give one a try!'
 					) }
-					buttonText={ i18n.translate( 'Give one a try!' ) }
+					buttonText={ i18n.translate( 'Browse premium themes' ) }
 					href={ '/themes/' + selectedSite.slug } />
 			}
 


### PR DESCRIPTION
This PR updates the copy of the theme upload feature in the checkout "Thank You" page after a  business plan purchase. Suggested by @michelleweber in https://github.com/Automattic/wp-calypso/pull/17245#issuecomment-322860269.

Before:
![](https://cldup.com/IHSKjSo3nF.png)

After:
![](https://cldup.com/VwaSkU64Yt.png)

To test:
* Checkout this branch
* Purchase a Business plan for one of your .com sites.
* Verify you can see the updated theme upload feature in the thank you page, and it looks well, as shown on the screenshot.