### PR TITLE
Checkout: Update business plan Google Analytics feature copy

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/business-plan-details.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/business-plan-details.jsx
@@ -48,8 +48,10 @@ const BusinessPlanDetails = ( { selectedSite, sitePlans, selectedFeature } ) => 
 
 			<PurchaseDetail
 				icon="stats-alt"
-				title={ i18n.translate( 'Stats from Google Analytics' ) }
-				description={ i18n.translate( 'Connect to Google Analytics for the perfect complement to WordPress.com stats.' ) }
+				title={ i18n.translate( 'Connect to Google Analytics' ) }
+				description={ i18n.translate(
+					'Complement WordPress.com\'s stats with Google\'s in-depth look at your visitors and traffic patterns.'
+				) }
 				buttonText={ i18n.translate( 'Connect Google Analytics' ) }
 				href={ '/settings/analytics/' + selectedSite.slug } />
 		</div>


### PR DESCRIPTION
This PR updates the copy of the Google Analytics feature in the checkout "Thank You" page after a  business plan purchase. Suggested by @michelleweber in https://github.com/Automattic/wp-calypso/pull/17245#issuecomment-322860269.

Before:
![](https://cldup.com/7NCh5xXRdN.png)

After:
![](https://cldup.com/FHK8KW0TLW.png)

To test:
* Checkout this branch
* Purchase a Business plan for one of your .com sites.
* Verify you can see the updated Google Analytics feature in the thank you page, and it looks well, as shown on the screenshot.