### PR TITLE
Plans: Update theme upload feature copy in My Plan

### DIFF
--- a/client/blocks/product-purchase-features/product-purchase-features-list/find-new-theme.jsx
+++ b/client/blocks/product-purchase-features/product-purchase-features-list/find-new-theme.jsx
@@ -14,9 +14,11 @@ export default localize( ( { selectedSite, translate } ) => {
 		<div className="product-purchase-features-list__item">
 			<PurchaseDetail
 				icon="customize"
-				title={ translate( 'Find a new theme' ) }
-				description={ translate( 'All our premium themes are now available at no extra cost. Try them out now.' ) }
-				buttonText={ translate( 'Browse premium themes' ) }
+				title={ translate( 'Try a New Theme' ) }
+				description={ translate(
+					'You\'ve now got access to every premium theme, at no extra cost - that\'s hundreds of new options.'
+				) }
+				buttonText={ translate( 'Give one a try!' ) }
 				href={ '/themes/' + selectedSite.slug }
 			/>
 		</div>

--- a/client/blocks/product-purchase-features/product-purchase-features-list/find-new-theme.jsx
+++ b/client/blocks/product-purchase-features/product-purchase-features-list/find-new-theme.jsx
@@ -16,9 +16,9 @@ export default localize( ( { selectedSite, translate } ) => {
 				icon="customize"
 				title={ translate( 'Try a New Theme' ) }
 				description={ translate(
-					'You\'ve now got access to every premium theme, at no extra cost - that\'s hundreds of new options.'
+					'You\'ve now got access to every premium theme, at no extra cost - that\'s hundreds of new options. Give one a try!'
 				) }
-				buttonText={ translate( 'Give one a try!' ) }
+				buttonText={ translate( 'Browse premium themes' ) }
 				href={ '/themes/' + selectedSite.slug }
 			/>
 		</div>


### PR DESCRIPTION
This PR updates the copy of the theme upload feature in the My Plan page, as suggested by @michelleweber in https://github.com/Automattic/wp-calypso/pull/17243#issuecomment-322864136.

Before:
![](https://cldup.com/8XDGCZjQXk.png)

After:
![](https://cldup.com/_SGsJzYZTc.png)

To test:
* Checkout this branch
* Go to `/plans/my-plan/:site`, where `:site` is a .com site on a Business plan.
* Verify you can see the updated theme upload feature, and it looks just fine as on the preview above.
