### PR TITLE
Plans: Update Google Analytics feature copy in My Plan

### DIFF
--- a/client/blocks/product-purchase-features/product-purchase-features-list/google-analytics-stats.jsx
+++ b/client/blocks/product-purchase-features/product-purchase-features-list/google-analytics-stats.jsx
@@ -14,8 +14,10 @@ export default localize( ( { selectedSite, translate } ) => {
 		<div className="product-purchase-features-list__item">
 			<PurchaseDetail
 				icon="stats-alt"
-				title={ translate( 'Stats from Google Analytics' ) }
-				description={ translate( 'Connect to Google Analytics for the perfect complement to WordPress.com stats.' ) }
+				title={ translate( 'Connect to Google Analytics' ) }
+				description={ translate(
+					'Complement WordPress.com\'s stats with Google\'s in-depth look at your visitors and traffic patterns.'
+				) }
 				buttonText={ translate( 'Connect Google Analytics' ) }
 				href={ '/settings/analytics/' + selectedSite.slug }
 			/>


### PR DESCRIPTION
This PR updates the copy of the Google Analytics feature in the My Plan page, as suggested by @michelleweber in https://github.com/Automattic/wp-calypso/pull/17245#issuecomment-322860269. It wasn't specifically suggested in https://github.com/Automattic/wp-calypso/pull/17243#issuecomment-322864136, but I'm updating this one for consistency with what #17268 suggests.

Before:
![](https://cldup.com/FdihEzSa6D.png)

After:
![](https://cldup.com/nPKoY2RQMD.png)

To test:
* Checkout this branch
* Go to `/plans/my-plan/:site`, where `:site` is a .com site on a Business plan.
* Verify you can see the updated Google Analytics feature, and it looks just fine as on the preview above.
