### PR TITLE
Social signup: Launching social signup on staging

### DIFF
--- a/config/stage.json
+++ b/config/stage.json
@@ -100,7 +100,7 @@
 		"settings/security/monitor/wp-note": true,
 		"settings/theme-setup": false,
 		"signup/domain-first-flow": true,
-		"signup/social": false,
+		"signup/social": true,
 		"simple-payments": true,
 		"standalone-site-preview": true,
 		"support-user": true,


### PR DESCRIPTION
This pull request launches social signup on staging

#### Testing instructions
  
1. Run `git checkout update/social-signup-staging` and start your server with the following command: `NODE_ENV=stage npm start`
2. Open the [`Login` page](http://calypso.localhost:3000/log-in)
3. Check that you see the Contiune with Google button
  
#### Reviews
  
- [ ] Code
- [ ] Product