### PR TITLE
Plugins: Show description for custom plugins

### DIFF
--- a/client/lib/plugins/utils.js
+++ b/client/lib/plugins/utils.js
@@ -145,6 +145,28 @@ PluginUtils = {
 		} );
 	},
 
+	sanitizeSectionContent: ( content ) => {
+		return sanitizeHtml( content, {
+			allowedTags: [ 'h4', 'h5', 'h6', 'blockquote', 'code', 'b', 'i', 'em', 'strong', 'a', 'p', 'img', 'ul', 'ol', 'li' ],
+			allowedAttributes: { a: [ 'href', 'target', 'rel' ], img: [ 'src' ] },
+			allowedSchemes: [ 'http', 'https' ],
+			transformTags: {
+				h1: 'h3',
+				h2: 'h3',
+				a: ( tagName, attribs ) => {
+					return {
+						tagName: 'a',
+						attribs: {
+							...pick( attribs, [ 'href' ] ),
+							target: '_blank',
+							rel: 'external noopener noreferrer'
+						}
+					};
+				}
+			}
+		} );
+	},
+
 	normalizePluginData: function( plugin, pluginData ) {
 		plugin = this.whiteListPluginData( assign( plugin, pluginData ) );
 
@@ -164,25 +186,7 @@ PluginUtils = {
 				case 'sections':
 					let cleanItem = {};
 					for ( let sectionKey of Object.keys( item ) ) {
-						cleanItem[ sectionKey ] = sanitizeHtml( item[ sectionKey ], {
-							allowedTags: [ 'h4', 'h5', 'h6', 'blockquote', 'code', 'b', 'i', 'em', 'strong', 'a', 'p', 'img', 'ul', 'ol', 'li' ],
-							allowedAttributes: { a: [ 'href', 'target', 'rel' ], img: [ 'src' ] },
-							allowedSchemes: [ 'http', 'https' ],
-							transformTags: {
-								h1: 'h3',
-								h2: 'h3',
-								a: function( tagName, attribs ) {
-									return {
-										tagName: 'a',
-										attribs: {
-											...pick( attribs, [ 'href' ] ),
-											target: '_blank',
-											rel: 'external noopener noreferrer'
-										}
-									};
-								}
-							}
-						} );
+						cleanItem[ sectionKey ] = PluginUtils.sanitizeSectionContent( item[ sectionKey ] );
 					}
 					returnData.sections = cleanItem;
 					returnData.screenshots = cleanItem.screenshots ? PluginUtils.extractScreenshots( cleanItem.screenshots ) : null;

--- a/client/my-sites/plugins/plugin-sections/custom.jsx
+++ b/client/my-sites/plugins/plugin-sections/custom.jsx
@@ -1,0 +1,43 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Card from 'components/card';
+import NavItem from 'components/section-nav/item';
+import NavTabs from 'components/section-nav/tabs';
+import SectionNav from 'components/section-nav';
+import { sanitizeSectionContent } from 'lib/plugins/utils';
+
+const PluginSectionsCustom = ( { plugin, translate } ) => {
+	const description = sanitizeSectionContent( plugin.description );
+	if ( ! description.length ) {
+		return null;
+	}
+
+	return (
+		<div className="plugin-sections__custom plugin-sections">
+			<div className="plugin-sections__header">
+				<SectionNav selectedText={ translate( 'Description' ) }>
+					<NavTabs>
+						<NavItem selected>
+							{ translate( 'Description' ) }
+						</NavItem>
+					</NavTabs>
+				</SectionNav>
+			</div>
+			<Card>
+				<div
+					className="plugin-sections__content"
+					dangerouslySetInnerHTML={ { __html: description } } // eslint-disable-line react/no-danger
+				/>
+			</Card>
+		</div>
+	);
+};
+
+export default localize( PluginSectionsCustom );

--- a/client/my-sites/plugins/plugin.jsx
+++ b/client/my-sites/plugins/plugin.jsx
@@ -23,6 +23,7 @@ import MainComponent from 'components/main';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import JetpackManageErrorPage from 'my-sites/jetpack-manage-error-page';
 import PluginSections from 'my-sites/plugins/plugin-sections';
+import PluginSectionsCustom from 'my-sites/plugins/plugin-sections/custom';
 import DocumentHead from 'components/data/document-head';
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 import { recordGoogleEvent } from 'state/analytics/actions';
@@ -387,7 +388,11 @@ const SinglePlugin = React.createClass( {
 						}
 						isInstalling={ installing }
 						allowedActions={ allowedPluginActions } />
-					{ plugin.wporg && <PluginSections plugin={ plugin } isWpcom={ isWpcom } /> }
+					{
+						plugin.wporg
+							? <PluginSections plugin={ plugin } isWpcom={ isWpcom } />
+							: <PluginSectionsCustom plugin={ plugin } />
+					}
 					{ this.renderSitesList( plugin ) }
 				</div>
 			</MainComponent>


### PR DESCRIPTION
This PR updates the plugin page to display the description (if any) for custom plugins. Fixes #16839

Before:
![](https://cldup.com/HX1ZiNKSfX.png)

After:
![](https://cldup.com/U6vdbyMrnw.png)

To test:
* Checkout this branch, or get it going on calypso.live.
* Choose one of your Jetpack sites and upload a custom plugin to it (you can use this one if you don't have any: https://gist.github.com/tyxla/485bbe4357befa5d1be9eec406bb3643 - the Download ZIP button downloads a zip file that you can upload as a plugin)
* Go to `/plugins/:pluginSlug/:siteSlug`, where `:pluginSlug` is the slug of your plugin, and `:siteSlug` is your Jetpack site.
* Test the following cases:
  * If the plugin has a description, it should be visible in a Description section, safe HTML must be preserved and unsafe HTML should be cleared.
  * If the plugin doesn't have a description, no description tab should be visible.
* Go to `/plugins/akismet/:siteSlug` or any other .org plugin, change some sections and verify they work like they did before.