### PR TITLE
ExtensionRedirect: Add Minimum Version Check

### DIFF
--- a/client/blocks/extension-redirect/README.md
+++ b/client/blocks/extension-redirect/README.md
@@ -3,11 +3,12 @@ Extension Redirect
 
 `<ExtensionRedirect />` is a React component that conditionally redirects a user from an
 extension page to the corresponding plugin installation page, if the corresponding plugin
-isn't installed or activated on the given site.
+isn't installed or activated on the given site, or if the required minimum plugin version
+isn't met.
 
 ## Usage
 
-Render the component, passing `siteId` and `pluginId`. It does not accept any children, nor does it render any elements to the page. Use it near the top level of your extension page.
+Render the component, passing `siteId` and `pluginId` (and optionally, `minimumVersion`). It does not accept any children, nor does it render any elements to the page. Use it near the top level of your extension page.
 
 ## Props
 
@@ -19,6 +20,15 @@ Render the component, passing `siteId` and `pluginId`. It does not accept any ch
 </table>
 
 The ID of the plugin for which to check.
+
+### `minimumVersion`
+
+<table>
+	<tr><th>Type</th><td>String</td></tr>
+	<tr><th>Required</th><td>No</td></tr>
+</table>
+
+An optional plugin minimum version to check for.
 
 ### `siteId`
 

--- a/client/blocks/extension-redirect/index.jsx
+++ b/client/blocks/extension-redirect/index.jsx
@@ -10,12 +10,14 @@ import page from 'page';
 /**
  * Internal dependencies
  */
+import versionCompare from 'lib/version-compare';
 import { getSite, getSiteSlug } from 'state/sites/selectors';
 import { getPluginOnSite, isRequesting } from 'state/plugins/installed/selectors';
 import QueryJetpackPlugins from 'components/data/query-jetpack-plugins';
 
 class ExtensionRedirect extends Component {
 	static propTypes = {
+		minimumVersion: PropTypes.string,
 		pluginId: PropTypes.string.isRequired,
 		siteId: PropTypes.number,
 		// Connected props
@@ -25,8 +27,19 @@ class ExtensionRedirect extends Component {
 	}
 
 	componentWillReceiveProps( nextProps ) {
-		// Has the request completed? Is the plugin active?
-		if ( this.props.requestingPlugins && ! nextProps.requestingPlugins && ! nextProps.pluginActive ) {
+		// Check for the following:
+		// Is the plugin active? (That implicitly also checks if the plugin is installed)
+		// Do we require a minimum version? Have we received the plugin's version? Is it sufficient?
+		if ( nextProps.pluginActive && (
+			nextProps.minimumVersion && nextProps.pluginVersion &&
+			versionCompare( nextProps.minimumVersion, nextProps.pluginVersion, '<=' )
+		) ) {
+			return;
+		}
+
+		// Has the request completed?
+		// If it has, and the above criteria aren't fulfilled, we redirect.
+		if ( this.props.requestingPlugins && ! nextProps.requestingPlugins ) {
 			page.redirect( `/plugins/${ nextProps.pluginId }/${ nextProps.siteSlug }` );
 		}
 	}
@@ -48,6 +61,7 @@ export default connect(
 
 		return {
 			pluginActive: !! site && get( getPluginOnSite( state, site, pluginId ), 'active', false ),
+			pluginVersion: !! site && get( getPluginOnSite( state, site, pluginId ), 'version' ),
 			requestingPlugins: isRequesting( state, siteId ),
 			siteSlug: getSiteSlug( state, siteId ),
 		};

--- a/client/blocks/extension-redirect/index.jsx
+++ b/client/blocks/extension-redirect/index.jsx
@@ -62,7 +62,7 @@ export default connect(
 
 		return {
 			pluginActive: !! site && get( getPluginOnSite( state, site, pluginId ), 'active', false ),
-			pluginVersion: !! site && get( getPluginOnSite( state, site, pluginId ), 'version' ),
+			pluginVersion: site && get( getPluginOnSite( state, site, pluginId ), 'version' ),
 			requestingPlugins: isRequesting( state, siteId ),
 			siteSlug: getSiteSlug( state, siteId ),
 		};

--- a/client/blocks/extension-redirect/index.jsx
+++ b/client/blocks/extension-redirect/index.jsx
@@ -22,6 +22,7 @@ class ExtensionRedirect extends Component {
 		siteId: PropTypes.number,
 		// Connected props
 		pluginActive: PropTypes.bool.isRequired,
+		pluginVersion: PropTypes.string,
 		requestingPlugins: PropTypes.bool.isRequired,
 		siteSlug: PropTypes.string,
 	}

--- a/client/extensions/wp-super-cache/app/main.jsx
+++ b/client/extensions/wp-super-cache/app/main.jsx
@@ -66,7 +66,9 @@ class WPSuperCache extends Component {
 
 		return (
 			<Main className={ mainClassName }>
-				<ExtensionRedirect pluginId="wp-super-cache" siteId={ siteId } />
+				<ExtensionRedirect pluginId="wp-super-cache"
+					minimumVersion="1.5.3"
+					siteId={ siteId } />
 				<QueryStatus siteId={ siteId } />
 
 				{ cacheDisabled &&


### PR DESCRIPTION
To test:

* On a JP site with WPSC < 1.5.3 installed, navigate to `calypso.localhost:3000/extensions/wp-super-cache/<JPsite>`. You should be redirected to `calypso.localhost:3000/plugins/wp-super-cache/<JPsite>`. (Alternatively, if you're already running 1.5.3, you can tweak [this line](https://github.com/Automattic/wp-calypso/compare/add/version-check-to-extension-redirect?expand=1#diff-85fd19e3353aba0a126de919df099f49R70).)
* On a JP site with WPSC >= 1.5.3, navigate to `calypso.localhost:3000/extensions/wp-super-cache/<JPsite>`. You shouldn't be redirected.