### PR TITLE
SimplePayments: write `PayPal` rightly

### DIFF
--- a/client/components/tinymce/plugins/simple-payments/dialog/form.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/form.jsx
@@ -166,7 +166,7 @@ class ProductForm extends Component {
 						label={ translate( 'Email' ) }
 						explanation={ translate(
 							'This is where PayPal will send your money.' +
-								" To claim a payment, you'll need a {{paypalLink}}Paypal account{{/paypalLink}}" +
+								" To claim a payment, you'll need a {{paypalLink}}PayPal account{{/paypalLink}}" +
 								' connected to a bank account.',
 							{
 								components: {


### PR DESCRIPTION
It fixes the PayPal name writing both `P` letters in UpperCase.

<img src="https://user-images.githubusercontent.com/77539/29412114-cb1a8460-832d-11e7-83b3-5f5e64ea2b43.png" width="500px" />

###Testing

1) Go to Simple Payments dialog testing page: http://calypso.localhost:3000/devdocs/blocks/simple-payments-dialog

2) Verify that Paypal is written rightly.
