### PR TITLE
Fetch OAuth client data from API on SSR

### DIFF
--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -11,7 +11,7 @@ import MagicLogin from './magic-login';
 import HandleEmailedLinkForm from './magic-login/handle-emailed-link-form';
 import { fetchOAuth2ClientData } from 'state/login/oauth2/actions';
 
-const enchanceContextWithWithLogin = context => {
+const enhanceContextWithLogin = context => {
 	const {
 		lang,
 		path,
@@ -38,11 +38,11 @@ export default {
 		if ( client_id ) {
 			context.store.dispatch( fetchOAuth2ClientData( Number( client_id ) ) )
 				.then( () => {
-					enchanceContextWithWithLogin( context );
+					enhanceContextWithLogin( context );
 					next();
 				} );
 		} else {
-			enchanceContextWithWithLogin( context );
+			enhanceContextWithLogin( context );
 			next();
 		}
 	},

--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -11,32 +11,40 @@ import MagicLogin from './magic-login';
 import HandleEmailedLinkForm from './magic-login/handle-emailed-link-form';
 import { fetchOAuth2ClientData } from 'state/login/oauth2/actions';
 
+const enchanceContextWithWithLogin = context => {
+	const {
+		lang,
+		path,
+		params: { flow, twoFactorAuthType },
+	} = context;
+
+	context.cacheQueryKeys = [ 'client_id' ];
+
+	context.primary = (
+		<WPLogin
+			locale={ lang }
+			path={ path }
+			twoFactorAuthType={ twoFactorAuthType }
+			socialConnect={ flow === 'social-connect' }
+			privateSite={ flow === 'private-site' }
+		/>
+	);
+};
+
 export default {
 	login( context, next ) {
-		const {
-			lang,
-			path,
-			params: { flow, twoFactorAuthType },
-			query: { client_id }
-		} = context;
+		const { query: { client_id } } = context;
 
 		if ( client_id ) {
-			context.store.dispatch( fetchOAuth2ClientData( Number( client_id ) ) );
+			context.store.dispatch( fetchOAuth2ClientData( Number( client_id ) ) )
+				.then( () => {
+					enchanceContextWithWithLogin( context );
+					next();
+				} );
+		} else {
+			enchanceContextWithWithLogin( context );
+			next();
 		}
-
-		context.cacheQueryKeys = [ 'client_id' ];
-
-		context.primary = (
-			<WPLogin
-				locale={ lang }
-				path={ path }
-				twoFactorAuthType={ twoFactorAuthType }
-				socialConnect={ flow === 'social-connect' }
-				privateSite={ flow === 'private-site' }
-			/>
-		);
-
-		next();
 	},
 
 	magicLogin( context, next ) {

--- a/client/state/login/oauth2/actions.js
+++ b/client/state/login/oauth2/actions.js
@@ -7,18 +7,13 @@ import {
 	OAUTH2_CLIENT_DATA_REQUEST_SUCCESS,
 } from 'state/action-types';
 import wpcom from 'lib/wp';
+import { cachingActionCreatorFactory } from 'state/utils';
 
-export const fetchOAuth2ClientData = ( clientId ) => dispatch => {
-	dispatch( {
-		type: OAUTH2_CLIENT_DATA_REQUEST,
-		clientId,
-	} );
-
-	return wpcom.undocumented().oauth2ClientId( clientId ).then( wpcomResponse => {
-		dispatch( { type: OAUTH2_CLIENT_DATA_REQUEST_SUCCESS, data: wpcomResponse } );
-
-		return wpcomResponse;
-	}, wpcomError => {
+export const fetchOAuth2ClientData = cachingActionCreatorFactory(
+	clientId => wpcom.undocumented().oauth2ClientId( clientId ),
+	dispatch => clientId => dispatch( { type: OAUTH2_CLIENT_DATA_REQUEST, clientId, } ),
+	dispatch => wpcomResponse => dispatch( { type: OAUTH2_CLIENT_DATA_REQUEST_SUCCESS, data: wpcomResponse } ),
+	dispatch => wpcomError => {
 		const error = {
 			message: wpcomError.message,
 			code: wpcomError.error,
@@ -30,5 +25,5 @@ export const fetchOAuth2ClientData = ( clientId ) => dispatch => {
 		} );
 
 		return Promise.reject( error );
-	} );
-};
+	},
+);

--- a/client/state/test/utils.js
+++ b/client/state/test/utils.js
@@ -684,11 +684,11 @@ describe( 'utils', () => {
 		} );
 	} );
 
-	describe.only( '#cachingActionCreatorFactory', () => {
+	describe( '#cachingActionCreatorFactory', () => {
 		let passThrough;
 		let dispatch;
-		let successfulWork;
-		let failingWork;
+		let successfulWorker;
+		let failingWorker;
 		let loadingActionCreator;
 		let successActionCreator;
 		let failureActionCreator;
@@ -701,8 +701,8 @@ describe( 'utils', () => {
 			passThrough = pass => pass;
 
 			dispatch = spy( passThrough );
-			successfulWork = spy( () => Promise.resolve( 'success_data' ) );
-			failingWork = spy( () => Promise.reject( 'error_data' ) );
+			successfulWorker = spy( () => Promise.resolve( 'success_data' ) );
+			failingWorker = spy( () => Promise.reject( 'error_data' ) );
 
 			loadingActionCreator = spy( () => dispatch( { type: 'loading' } ) );
 			successActionCreator = spy( () => dispatch( { type: 'success' } ) );
@@ -715,7 +715,7 @@ describe( 'utils', () => {
 
 		it( 'should call apropriate action creators on success', () => {
 			const actionCreator = cachingActionCreatorFactory(
-				successfulWork,
+				successfulWorker,
 				connectedLoadingActionCreator,
 				connectedSuccessActionCreator,
 				connectedFailureActionCreator
@@ -732,7 +732,7 @@ describe( 'utils', () => {
 
 		it( 'should call apropriate action creators on failure', () => {
 			const actionCreator = cachingActionCreatorFactory(
-				failingWork,
+				failingWorker,
 				connectedLoadingActionCreator,
 				connectedSuccessActionCreator,
 				connectedFailureActionCreator
@@ -749,7 +749,7 @@ describe( 'utils', () => {
 
 		it( 'should cache same parameters successful call', () => {
 			const actionCreator = cachingActionCreatorFactory(
-				successfulWork,
+				successfulWorker,
 				connectedLoadingActionCreator,
 				connectedSuccessActionCreator,
 				connectedFailureActionCreator
@@ -758,12 +758,12 @@ describe( 'utils', () => {
 			const firstCall = actionCreator( 123 )( dispatch );
 			const secondCall = firstCall.then( () => actionCreator( 123 )( dispatch ) );
 
-			return secondCall.then( () => expect( successfulWork ).to.be.calledOnce );
+			return secondCall.then( () => expect( successfulWorker ).to.be.calledOnce );
 		} );
 
 		it( 'should not cache same parameters failed call', () => {
 			const actionCreator = cachingActionCreatorFactory(
-				failingWork,
+				failingWorker,
 				connectedLoadingActionCreator,
 				connectedSuccessActionCreator,
 				connectedFailureActionCreator
@@ -774,7 +774,7 @@ describe( 'utils', () => {
 			const firstCall = callActionCreator();
 			const secondCall = firstCall.then( callActionCreator, callActionCreator );
 
-			return Promise.all( [ firstCall, secondCall ] ).then( () => expect( failingWork ).to.be.calledTwice );
+			return Promise.all( [ firstCall, secondCall ] ).then( () => expect( failingWorker ).to.be.calledTwice );
 		} );
 	} );
 } );

--- a/client/state/test/utils.js
+++ b/client/state/test/utils.js
@@ -687,7 +687,7 @@ describe( 'utils', () => {
 	describe.only( '#cachingActionCreatorFactory', () => {
 		let passThrough;
 		let dispatch;
-		let successfullWork;
+		let successfulWork;
 		let failingWork;
 		let loadingActionCreator;
 		let successActionCreator;
@@ -701,7 +701,7 @@ describe( 'utils', () => {
 			passThrough = pass => pass;
 
 			dispatch = spy( passThrough );
-			successfullWork = spy( () => Promise.resolve( 'success_data' ) );
+			successfulWork = spy( () => Promise.resolve( 'success_data' ) );
 			failingWork = spy( () => Promise.reject( 'error_data' ) );
 
 			loadingActionCreator = spy( () => dispatch( { type: 'loading' } ) );
@@ -715,7 +715,7 @@ describe( 'utils', () => {
 
 		it( 'should call apropriate action creators on success', () => {
 			const actionCreator = cachingActionCreatorFactory(
-				successfullWork,
+				successfulWork,
 				connectedLoadingActionCreator,
 				connectedSuccessActionCreator,
 				connectedFailureActionCreator
@@ -726,7 +726,6 @@ describe( 'utils', () => {
 
 			return dispatchResult.then( () => {
 				expect( successActionCreator ).to.be.calledWith( 'success_data' );
-				//console.log( 'spy', failureActionCreator.getCall( 0 ).args[ 0 ] );
 				expect( failureActionCreator ).not.to.be.called;
 			} );
 		} );
@@ -750,7 +749,7 @@ describe( 'utils', () => {
 
 		it( 'should cache same parameters successful call', () => {
 			const actionCreator = cachingActionCreatorFactory(
-				successfullWork,
+				successfulWork,
 				connectedLoadingActionCreator,
 				connectedSuccessActionCreator,
 				connectedFailureActionCreator
@@ -759,7 +758,7 @@ describe( 'utils', () => {
 			const firstCall = actionCreator( 123 )( dispatch );
 			const secondCall = firstCall.then( () => actionCreator( 123 )( dispatch ) );
 
-			return secondCall.then( () => expect( successfullWork ).to.be.calledOnce );
+			return secondCall.then( () => expect( successfulWork ).to.be.calledOnce );
 		} );
 
 		it( 'should not cache same parameters failed call', () => {

--- a/client/state/utils.js
+++ b/client/state/utils.js
@@ -434,7 +434,7 @@ export const withoutPersistence = reducer => ( state, action ) => {
  *	},
  *);
  *
- * @param {Function} work a worker function that returns the promise ( param1, param2, ... ) => Promise
+ * @param {Function} worker a worker function that returns the promise ( param1, param2, ... ) => Promise
  * @param {Function} loadingActionCreator an action creator for before the work is performed of the following signature:
  * 					dispatch => ( param1, param2, ... ) => dispatch( ... ),
  * @param {Function} successActionCreator an action creator for the success case of the work performed of the following signature:
@@ -448,7 +448,7 @@ export const withoutPersistence = reducer => ( state, action ) => {
  * 					( param1, param2, ... ) => dispatch => Promise
  */
 export const cachingActionCreatorFactory = (
-	work,
+	worker,
 	loadingActionCreator,
 	successActionCreator,
 	failureActionCreator,
@@ -465,9 +465,9 @@ export const cachingActionCreatorFactory = (
 
 		const cacheKey = parametersHashFunction( params );
 		const cachedValue = cache.get( cacheKey );
-		const workPromise = cachedValue ? Promise.resolve( cachedValue ) : work( ...params );
+		const resultPromise = cachedValue ? Promise.resolve( cachedValue ) : worker( ...params );
 
-		return workPromise.then( result => {
+		return resultPromise.then( result => {
 			cache.set( cacheKey, result );
 			return successActionCreator( dispatch )( result );
 		}, failureActionCreator( dispatch ) ); // we don't cache failures

--- a/client/state/utils.js
+++ b/client/state/utils.js
@@ -4,6 +4,7 @@
 import validator from 'is-my-json-valid';
 import { merge, flow, partialRight, reduce, isEqual, omit } from 'lodash';
 import { combineReducers as combine } from 'redux'; // eslint-disable-line wpcalypso/import-no-redux-combine-reducers
+import LRU from 'lru-cache';
 
 /**
  * Internal dependencies
@@ -408,4 +409,67 @@ export const withoutPersistence = reducer => ( state, action ) => {
 	}
 
 	return reducer( state, action );
+};
+
+/**
+ * Creates a caching action creator
+ *
+ * @example Here's a caching action creator:
+ * export const fetchOAuth2ClientData = cachingActionCreatorFactory(
+ *	clientId => wpcom.undocumented().oauth2ClientId( clientId ),
+ *	dispatch => clientId => dispatch( { type: OAUTH2_CLIENT_DATA_REQUEST, clientId, } ),
+ *	dispatch => wpcomResponse => dispatch( { type: OAUTH2_CLIENT_DATA_REQUEST_SUCCESS, data: wpcomResponse } ),
+ *	dispatch => wpcomError => {
+ *		const error = {
+ *			message: wpcomError.message,
+ *			code: wpcomError.error,
+ *		};
+ *
+ *		dispatch( {
+ *			type: OAUTH2_CLIENT_DATA_REQUEST_FAILURE,
+ *			error,
+ *		} );
+ *
+ *		return Promise.reject( error );
+ *	},
+ *);
+ *
+ * @param {Function} work a worker function that returns the promise ( param1, param2, ... ) => Promise
+ * @param {Function} loadingActionCreator an action creator for before the work is performed of the following signature:
+ * 					dispatch => ( param1, param2, ... ) => dispatch( ... ),
+ * @param {Function} successActionCreator an action creator for the success case of the work performed of the following signature:
+ * 					dispatch => ( param1, param2, ... ) => dispatch( ... ),
+ * @param {Function} failureActionCreator an action creator for the failure case of the work performed of the following signature:
+ * 					dispatch => ( param1, param2, ... ) => dispatch( ... ),
+ * @param {Function} parametersHashFunction a hash function for params, default is just array's join
+ * @param {Object} cacheOptions options that passed to LRU cache constructor
+ *
+ * @return {Function} a function that can be used as an action creator of the following signature:
+ * 					( param1, param2, ... ) => dispatch => Promise
+ */
+export const cachingActionCreatorFactory = (
+	work,
+	loadingActionCreator,
+	successActionCreator,
+	failureActionCreator,
+	parametersHashFunction = params => params.join( '' ),
+	cacheOptions = { // those are passed to LRU ctor directly
+		max: 100,
+		maxAge: 2 * 60 * 60, // 2 hours
+	}
+) => {
+	const cache = new LRU( cacheOptions );
+
+	return ( ...params ) => dispatch => {
+		loadingActionCreator( dispatch )( ...params );
+
+		const cacheKey = parametersHashFunction( params );
+		const cachedValue = cache.get( cacheKey );
+		const workPromise = cachedValue ? Promise.resolve( cachedValue ) : work( ...params );
+
+		return workPromise.then( result => {
+			cache.set( cacheKey, result );
+			return successActionCreator( dispatch )( result );
+		}, failureActionCreator( dispatch ) ); // we don't cache failures
+	};
 };


### PR DESCRIPTION
This PR changes how OAuth client data is fetched on SSR, it aims to get the data always from the API with caching
 
#### Testing instructions
  
1. Run `git checkout add/ssr-fetch-oauth-client-data` and start your server, or open a [live branch](https://calypso.live/?branch=add/ssr-fetch-oauth-client-data)
2. Make sure:
`curl --resolve calypso.localhost:3000:127.0.0.1 'http://calypso.localhost:3000/log-in?client_id=930' | grep "vaultpress"`
works
3. Make sure 
`curl --resolve calypso.localhost:3000:127.0.0.1 'http://calypso.localhost:3000/log-in?client_id=12' | grep "Picplz"`
works   
 4. Notice the subsequent requests take less time:
```
GET /log-in?client_id=12 200 2137.735 ms - 38078
...
GET /log-in?client_id=12 200 1300.737 ms - 37930
```

#### Reviews
  
- [x] Code
- [x] Product
- [x] Tests
