### PR TITLE
Store dashboard stats copy edits

### DIFF
--- a/client/extensions/woocommerce/app/dashboard/manage-no-orders-view.js
+++ b/client/extensions/woocommerce/app/dashboard/manage-no-orders-view.js
@@ -51,8 +51,8 @@ class ManageNoOrdersView extends Component {
 				title={ translate( 'Looking for stats?' ) }
 			>
 				<p>
-					{ translate( 'Store statistic and reports can be found on the site stats screen.' +
-						' Keep an eye on revenues, order totals, popular products and more.' ) }
+					{ translate( 'Store statistics and reports can be found on the site stats screen.' +
+						' Keep an eye on revenue, order totals, popular products, and more.' ) }
 				</p>
 			</BasicWidget>
 		);


### PR DESCRIPTION
Correcting some copy things in the "Looking for stats?" box on the Store dashboard:

- "Statistic" should be plural in this context
- "Revenue" is singular in this context
- Oxford commas! 