### PR TITLE
Me: Fix primary site field with clean Redux state

### DIFF
--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -45,6 +45,7 @@ import Main from 'components/main';
 import SitesDropdown from 'components/sites-dropdown';
 import { successNotice, errorNotice } from 'state/notices/actions';
 import { getLanguage } from 'lib/i18n-utils';
+import { isRequestingMissingSites } from 'state/selectors';
 
 import _user from 'lib/user';
 
@@ -410,7 +411,7 @@ const Account = React.createClass( {
 	},
 
 	renderPrimarySite() {
-		const { translate } = this.props;
+		const { requestingMissingSites, translate } = this.props;
 
 		if ( ! user.get().visible_site_count ) {
 			return (
@@ -429,7 +430,7 @@ const Account = React.createClass( {
 		return (
 			<SitesDropdown
 				key={ primarySiteId }
-				isPlaceholder={ ! primarySiteId }
+				isPlaceholder={ ! primarySiteId || requestingMissingSites }
 				selectedSiteId={ primarySiteId }
 				onSiteSelect={ this.onSiteSelect }
 			/>
@@ -708,7 +709,9 @@ const Account = React.createClass( {
 
 export default compose(
 	connect(
-		null,
+		( state ) => ( {
+			requestingMissingSites: isRequestingMissingSites( state ),
+		} ),
 		dispatch => bindActionCreators( { successNotice, errorNotice }, dispatch ),
 	),
 	localize,


### PR DESCRIPTION
Loading `/me/account` with a clean Redux state will display the primary site selector field as broken. This PR updates it so that it properly displays a placeholder while loading the sites.

While loading sites, before:
![](https://cldup.com/lwKKMRjZsf.png)

While loading sites, after:
![](https://cldup.com/2QXTO_ItoX.png)

To test:
* Clear your Redux state.
* Go to http://calypso.localhost:3000/me/account
* Verify you can see the placeholder while sites are loading.
* Test with sites loaded, verify it works as expected.