### PR TITLE
Activity Log: don't use uppercase in small text

### DIFF
--- a/client/my-sites/stats/activity-log-day/style.scss
+++ b/client/my-sites/stats/activity-log-day/style.scss
@@ -35,7 +35,6 @@
 }
 
 .activity-log-day__events {
-	text-transform: uppercase;
 	font-size: 12px;
 	color: $gray;
 }
@@ -56,8 +55,4 @@
 		width: 10em;
 		margin-top: .2em;
 	}
-}
-
-.activity-log-day__rewind-button {
-	text-transform: uppercase;
 }

--- a/client/my-sites/stats/activity-log-item/style.scss
+++ b/client/my-sites/stats/activity-log-item/style.scss
@@ -119,7 +119,7 @@
 }
 
 .activity-log-item__actor-role {
-	text-transform: uppercase;
+	text-transform: capitalize;
 	font-size: 12px;
 	color: $gray;
 }


### PR DESCRIPTION
This PR removes all caps from these elements:

- Day block: Events count.
- Day block: Rewind button.
- Event block: Author role.

### Before

![image](https://user-images.githubusercontent.com/390760/29419008-e348e3d2-8365-11e7-9bff-cb5e11daec37.png)


### After

![image](https://user-images.githubusercontent.com/390760/29418975-c5cd1b66-8365-11e7-9770-d88206bb18ab.png)

Fixes #17290