### PR TITLE
Activity Log: use the same history icon across the UI

### DIFF
--- a/client/my-sites/stats/activity-log-item/index.jsx
+++ b/client/my-sites/stats/activity-log-item/index.jsx
@@ -257,7 +257,7 @@ class ActivityLogItem extends Component {
 				>
 					<PopoverMenuItem
 						disabled={ disableRestore }
-						icon="undo"
+						icon="history"
 						onClick={ this.handleClickRestore }
 					>
 						{ translate( 'Rewind to this point' ) }


### PR DESCRIPTION
This replaces the undo icon in the options dropdown for the history icon that is used everywhere else in the UI.

### Before

![image](https://user-images.githubusercontent.com/390760/29420591-51f121e2-836a-11e7-9d15-dc5320faa3a7.png)

### After

![image](https://user-images.githubusercontent.com/390760/29420724-b74c528c-836a-11e7-9748-b0e28c32c86a.png)


Fixes #17295