### PR TITLE
Comments: Re-enable the bulk actions loop

### DIFF
--- a/client/blocks/comment-detail/index.jsx
+++ b/client/blocks/comment-detail/index.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
@@ -131,10 +132,7 @@ export class CommentDetail extends Component {
 
 	toggleLike = () => this.props.toggleCommentLike( getCommentStatusAction( this.props ) );
 
-	toggleSelected = () => {
-		const { commentId, toggleCommentSelected } = this.props;
-		toggleCommentSelected( commentId );
-	}
+	toggleSelected = () => this.props.toggleCommentSelected( getCommentStatusAction( this.props ) );
 
 	toggleSpam = () => {
 		const { commentStatus, setCommentStatus } = this.props;

--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -1,10 +1,11 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { find, get, keyBy, keys, map, noop, omit, size, slice, uniq } from 'lodash';
+import { get, map, noop, size, slice, uniq } from 'lodash';
 import ReactCSSTransitionGroup from 'react-addons-css-transition-group';
 
 /**
@@ -59,16 +60,16 @@ export class CommentList extends Component {
 		lastUndo: null,
 		page: 1,
 		persistedComments: [],
-		// TODO: replace {} with [] after persistedComments is merged
-		selectedComments: {},
+		selectedComments: [],
 	};
+
 	componentWillReceiveProps( nextProps ) {
 		if ( this.props.status !== nextProps.status ) {
 			this.setState( {
 				lastUndo: null,
 				page: 1,
 				persistedComments: [],
-				selectedComments: {},
+				selectedComments: [],
 			} );
 		}
 	}
@@ -79,7 +80,7 @@ export class CommentList extends Component {
 
 		this.setState( {
 			page,
-			selectedComments: {},
+			selectedComments: [],
 		} );
 	};
 
@@ -88,9 +89,6 @@ export class CommentList extends Component {
 
 		this.props.deleteComment( commentId, postId );
 	}
-
-	// TODO: remove after persistedComments is merged
-	getComment = commentId => find( this.getComments(), [ 'ID', commentId ] );
 
 	getComments = () => uniq( [ ...this.state.persistedComments, ...this.props.comments ] ).sort( ( a, b ) => b - a );
 
@@ -117,10 +115,9 @@ export class CommentList extends Component {
 
 	isCommentPersisted = commentId => -1 !== this.state.persistedComments.indexOf( commentId );
 
-	// TODO: replace with array logic after persistedComments is merged
-	isCommentSelected = commentId => !! this.state.selectedComments[ commentId ];
+	isCommentSelected = () => false;
 
-	isSelectedAll = () => this.getComments().length === size( this.state.selectedComments );
+	isSelectedAll = () => false;
 
 	removeFromPersistedComments = commentId => this.setState(
 		( { persistedComments } ) => ( {
@@ -157,19 +154,7 @@ export class CommentList extends Component {
 		this.props.replyComment( commentText, postId, parentCommentId, { alsoApprove } );
 	}
 
-	// TODO: rewrite after persistedComments is merged
-	setBulkStatus = status => () => {
-		this.props.removeNotice( 'comment-notice-bulk' );
-
-		this.props.setBulkStatus( keys( this.state.selectedComments ), status );
-
-		this.showBulkNotice( status, this.state.selectedComments );
-
-		this.setState( {
-			isBulkEdit: false,
-			selectedComments: {},
-		} );
-	};
+	setBulkStatus = () => noop;
 
 	setCommentStatus = ( comment, status, options = { isUndo: false, doPersist: false, showNotice: true } ) => {
 		const {
@@ -211,36 +196,7 @@ export class CommentList extends Component {
 		}
 	}
 
-	// TODO: rewrite after persistedComments is merged
-	showBulkNotice = ( newStatus, selectedComments ) => {
-		const { translate } = this.props;
-
-		const message = get( {
-			approved: translate( 'All selected comments approved.' ),
-			unapproved: translate( 'All selected comments unapproved.' ),
-			spam: translate( 'All selected comments marked as spam.' ),
-			trash: translate( 'All selected comments moved to trash.' ),
-			'delete': translate( 'All selected comments deleted permanently.' ),
-		}, newStatus );
-
-		if ( ! message ) {
-			return;
-		}
-
-		const options = Object.assign(
-			{
-				duration: 5000,
-				id: 'comment-notice-bulk',
-				isPersistent: true,
-			},
-			'delete' !== newStatus && {
-				button: translate( 'Undo' ),
-				onClick: () => this.undoBulkStatus( selectedComments ),
-			}
-		);
-
-		this.props.successNotice( message, options );
-	}
+	showBulkNotice = () => noop;
 
 	showNotice = ( comment, newStatus, options = { doPersist: false } ) => {
 		const { translate } = this.props;
@@ -288,7 +244,7 @@ export class CommentList extends Component {
 		this.props.successNotice( message, noticeOptions );
 	}
 
-	toggleBulkEdit = () => this.setState( { isBulkEdit: ! this.state.isBulkEdit } );
+	toggleBulkEdit = () => this.setState( ( { isBulkEdit } ) => ( { isBulkEdit: ! isBulkEdit } ) );
 
 	toggleCommentLike = comment => {
 		const { commentId, isLiked, postId, status } = comment;
@@ -309,36 +265,7 @@ export class CommentList extends Component {
 		}
 	}
 
-	// TODO: rewrite after persistedComments is merged
-	toggleCommentSelected = commentId => {
-		// TODO: Replace with Redux getComment()
-		const { i_like, status } = this.getComment( commentId );
-		const { selectedComments } = this.state;
-
-		this.setState( {
-			selectedComments: this.isCommentSelected( commentId )
-				? omit( selectedComments, commentId )
-				: {
-					...selectedComments,
-					[ commentId ]: { i_like, status },
-				},
-		} );
-	}
-
-	// TODO: rewrite after persistedComments is merged
-	toggleSelectAll = () => {
-		this.setState( {
-			selectedComments: this.isSelectedAll()
-				? {}
-				: keyBy( map( this.getComments(), ( { ID, i_like, status } ) => ( { ID, i_like, status } ) ), 'ID' ),
-		} );
-	}
-
-	// TODO: rewrite after persistedComments is merged
-	undoBulkStatus = selectedComments => {
-		this.props.removeNotice( 'comment-notice-bulk' );
-		this.props.undoBulkStatus( selectedComments );
-	}
+	toggleCommentSelected = () => noop;
 
 	updatePersistedComments = ( commentId, isUndo ) => {
 		if ( isUndo ) {

--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -64,8 +64,10 @@ export class CommentList extends Component {
 	};
 
 	componentWillReceiveProps( nextProps ) {
-		if ( this.props.status !== nextProps.status ) {
+		const { siteId, status } = this.props;
+		if ( siteId !== nextProps.siteId || status !== nextProps.status ) {
 			this.setState( {
+				isBulkEdit: false,
 				lastUndo: null,
 				page: 1,
 				persistedComments: [],

--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -115,9 +115,12 @@ export class CommentList extends Component {
 
 	isCommentPersisted = commentId => -1 !== this.state.persistedComments.indexOf( commentId );
 
-	isCommentSelected = () => false;
+	isCommentSelected = commentId => -1 !== this.state.selectedComments.indexOf( commentId );
 
-	isSelectedAll = () => false;
+	isSelectedAll = () => {
+		const visibleComments = this.getCommentsPage( this.getComments(), this.state.page );
+		return visibleComments.length === this.state.selectedComments.length;
+	};
 
 	removeFromPersistedComments = commentId => this.setState(
 		( { persistedComments } ) => ( {
@@ -265,7 +268,28 @@ export class CommentList extends Component {
 		}
 	}
 
-	toggleCommentSelected = () => noop;
+	toggleCommentSelected = commentId => {
+		if ( this.isCommentSelected( commentId ) ) {
+			return this.setState(
+				( { selectedComments } ) => ( {
+					selectedComments: selectedComments.filter( c => c !== commentId ),
+				} )
+			);
+		}
+		this.setState(
+			( { selectedComments } ) => ( {
+				selectedComments: selectedComments.concat( commentId ),
+			} )
+		);
+	}
+
+	toggleSelectAll = () => {
+		const visibleComments = this.getCommentsPage( this.getComments(), this.state.page );
+		if ( this.isSelectedAll() ) {
+			return this.setState( { selectedComments: [] } );
+		}
+		this.setState( { selectedComments: visibleComments } );
+	}
 
 	updatePersistedComments = ( commentId, isUndo ) => {
 		if ( isUndo ) {

--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -5,7 +5,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { get, map, noop, size, slice, uniq } from 'lodash';
+import { find, get, map, noop, size, slice, uniq } from 'lodash';
 import ReactCSSTransitionGroup from 'react-addons-css-transition-group';
 
 /**
@@ -117,7 +117,7 @@ export class CommentList extends Component {
 
 	isCommentPersisted = commentId => -1 !== this.state.persistedComments.indexOf( commentId );
 
-	isCommentSelected = commentId => -1 !== this.state.selectedComments.indexOf( commentId );
+	isCommentSelected = commentId => !! find( this.state.selectedComments, { commentId } );
 
 	isSelectedAll = () => {
 		const visibleComments = this.getCommentsPage( this.getComments(), this.state.page );
@@ -270,28 +270,22 @@ export class CommentList extends Component {
 		}
 	}
 
-	toggleCommentSelected = commentId => {
-		if ( this.isCommentSelected( commentId ) ) {
+	toggleCommentSelected = comment => {
+		if ( this.isCommentSelected( comment.commentId ) ) {
 			return this.setState(
 				( { selectedComments } ) => ( {
-					selectedComments: selectedComments.filter( c => c !== commentId ),
+					selectedComments: selectedComments.filter( ( { commentId } ) => comment.commentId !== commentId ),
 				} )
 			);
 		}
 		this.setState(
 			( { selectedComments } ) => ( {
-				selectedComments: selectedComments.concat( commentId ),
+				selectedComments: selectedComments.concat( comment ),
 			} )
 		);
 	}
 
-	toggleSelectAll = () => {
-		const visibleComments = this.getCommentsPage( this.getComments(), this.state.page );
-		if ( this.isSelectedAll() ) {
-			return this.setState( { selectedComments: [] } );
-		}
-		this.setState( { selectedComments: visibleComments } );
-	}
+	toggleSelectAll = selectedComments => this.setState( { selectedComments } );
 
 	updatePersistedComments = ( commentId, isUndo ) => {
 		if ( isUndo ) {
@@ -343,10 +337,12 @@ export class CommentList extends Component {
 				}
 
 				<CommentNavigation
+					commentsPage={ commentsPage }
 					isBulkEdit={ isBulkEdit }
 					isSelectedAll={ this.isSelectedAll() }
 					selectedCount={ size( selectedComments ) }
 					setBulkStatus={ this.setBulkStatus }
+					siteId={ siteId }
 					siteFragment={ siteFragment }
 					status={ status }
 					toggleBulkEdit={ this.toggleBulkEdit }

--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -120,8 +120,9 @@ export class CommentList extends Component {
 	isCommentSelected = commentId => !! find( this.state.selectedComments, { commentId } );
 
 	isSelectedAll = () => {
-		const visibleComments = this.getCommentsPage( this.getComments(), this.state.page );
-		return visibleComments.length === this.state.selectedComments.length;
+		const { page, selectedComments } = this.state;
+		const visibleComments = this.getCommentsPage( this.getComments(), page );
+		return selectedComments.length && ( selectedComments.length === visibleComments.length );
 	};
 
 	removeFromPersistedComments = commentId => this.setState(

--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -169,7 +169,7 @@ export class CommentList extends Component {
 
 		each( this.state.selectedComments, comment => {
 			if ( 'delete' === status ) {
-				this.deleteCommentPermanently( comment.commentId, comment.postId );
+				this.props.deleteComment( comment.commentId, comment.postId, { showSuccessNotice: false } );
 				return;
 			}
 
@@ -469,12 +469,12 @@ const mapDispatchToProps = ( dispatch, { siteId } ) => ( {
 
 	successNotice: ( text, options ) => dispatch( successNotice( text, options ) ),
 
-	deleteComment: ( commentId, postId ) => dispatch( withAnalytics(
+	deleteComment: ( commentId, postId, options = { showSuccessNotice: true } ) => dispatch( withAnalytics(
 		composeAnalytics(
 			recordTracksEvent( 'calypso_comment_management_delete' ),
 			bumpStat( 'calypso_comment_management', 'comment_deleted' )
 		),
-		deleteComment( siteId, postId, commentId )
+		deleteComment( siteId, postId, commentId, options )
 	) ),
 
 	likeComment: ( commentId, postId, analytics = { alsoApprove: false } ) => dispatch( withAnalytics(

--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -296,7 +296,9 @@ export class CommentList extends Component {
 		this.props.successNotice( message, noticeOptions );
 	}
 
-	toggleBulkEdit = () => this.setState( ( { isBulkEdit } ) => ( { isBulkEdit: ! isBulkEdit } ) );
+	toggleBulkEdit = () => {
+		this.setState( ( { isBulkEdit } ) => ( { isBulkEdit: ! isBulkEdit } ) );
+	}
 
 	toggleCommentLike = comment => {
 		const { commentId, isLiked, postId, status } = comment;

--- a/client/my-sites/comments/comment-navigation/index.jsx
+++ b/client/my-sites/comments/comment-navigation/index.jsx
@@ -5,7 +5,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import Gridicon from 'gridicons';
 import { localize } from 'i18n-calypso';
-import { get, includes, map } from 'lodash';
+import { get, includes, isUndefined, map } from 'lodash';
 
 /**
  * Internal dependencies
@@ -42,6 +42,13 @@ export class CommentNavigation extends Component {
 		selectedCount: 0,
 		status: 'unapproved',
 	};
+
+	bulkDeletePermanently = () => {
+		const { setBulkStatus, translate } = this.props;
+		if ( isUndefined( window ) || window.confirm( translate( 'Delete these comments permanently?' ) ) ) {
+			setBulkStatus( 'delete' )();
+		}
+	}
 
 	changeFilter = status => () => this.props.recordChangeFilter( status );
 
@@ -158,7 +165,7 @@ export class CommentNavigation extends Component {
 								compact
 								scary
 								disabled={ ! selectedCount }
-								onClick={ setBulkStatus( 'delete' ) }
+								onClick={ this.bulkDeletePermanently }
 							>
 								{ translate( 'Delete' ) }
 							</Button>

--- a/client/state/comments/actions.js
+++ b/client/state/comments/actions.js
@@ -90,13 +90,16 @@ export const requestCommentsTreeForSite = query => ( {
  * @param {Number} siteId site identifier
  * @param {Number} postId post identifier
  * @param {Number|String} commentId comment or comment placeholder identifier
+ * @param {Object} options Action options
+ * @param {Boolean} options.showSuccessNotice Announce the delete success with a notice (default: true)
  * @returns {Object} action that deletes a comment
  */
-export const deleteComment = ( siteId, postId, commentId ) => ( {
+export const deleteComment = ( siteId, postId, commentId, options = { showSuccessNotice: true } ) => ( {
 	type: COMMENTS_DELETE,
 	siteId,
 	postId,
 	commentId,
+	options,
 } );
 
 /***

--- a/client/state/data-layer/wpcom/comments/index.js
+++ b/client/state/data-layer/wpcom/comments/index.js
@@ -193,7 +193,12 @@ export const deleteComment = ( { dispatch, getState }, action ) => {
 	);
 };
 
-export const announceDeleteSuccess = ( { dispatch } ) => {
+export const announceDeleteSuccess = ( { dispatch }, { options } ) => {
+	const showSuccessNotice = get( options, 'showSuccessNotice', false );
+	if ( ! showSuccessNotice ) {
+		return;
+	}
+
 	dispatch(
 		successNotice(
 			translate( 'Comment deleted permanently.' ),

--- a/config/development.json
+++ b/config/development.json
@@ -42,7 +42,7 @@
 		"comments/moderation-tools-in-posts": true,
 		"comments/management": true,
 		"comments/management/all-list": false,
-		"manage/comments/bulk-actions": false,
+		"manage/comments/bulk-actions": true,
 		"css-hot-reload": true,
 		"desktop-promo": true,
 		"devdocs": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -20,7 +20,7 @@
 		"code-splitting": true,
 		"comments/management": true,
 		"comments/management/all-list": false,
-		"manage/comments/bulk-actions": false,
+		"manage/comments/bulk-actions": true,
 		"devdocs": false,
 		"domains/cctlds": true,
 		"domains/cctlds/ca": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -19,7 +19,7 @@
 		"apple-pay": true,
 		"comments/management": true,
 		"comments/management/all-list": false,
-		"manage/comments/bulk-actions": false,
+		"manage/comments/bulk-actions": true,
 		"catch-js-errors": true,
 		"code-splitting": true,
 		"desktop-promo": true,


### PR DESCRIPTION
This PR enables the bulk actions with the loop approach in `development` and `wpcalypso`.
It implements all bulk actions (approve, unapprove, mark as spam, move to trash, delete permanently), but not its undo.
Toggling between approved and unapproved makes the comments persist, exactly like it happens for the single actions.

The `CommentList.state.selectedComments` is an array of objects containing the minimum amount of comments information needed (id, post id, previous status, previous like value) to handle the bulk status update and to be ready for the eventual undo logic.

Since the permanent delete notice is handled by the data layer, I've added a new optional parameter to the `deleteComment` action:
```js
options = { showSuccessNotice: true }
```
It defaults to true to remain completely compatible with previous uses, but if `showSuccessNotice: false`, then the data layer won't show the success notice anymore, leaving the burden to the `CommentList.showBulkNotice()` method.