### PR TITLE
Reader: Make <hr> same width as content column

### DIFF
--- a/client/blocks/reader-full-post/_content.scss
+++ b/client/blocks/reader-full-post/_content.scss
@@ -55,7 +55,7 @@
 
 	hr {
 		background: lighten( $gray, 30% );
-		margin: 24px -32px;
+		margin: 24px 0;
 	}
 
 	img {


### PR DESCRIPTION
This fixes: https://github.com/Automattic/wp-calypso/issues/17228

**Before:**
![screenshot 2017-08-17 10 02 58](https://user-images.githubusercontent.com/4924246/29424132-52663bd0-8333-11e7-832a-94626f238105.png)

**After:**
![screenshot 2017-08-17 10 03 03](https://user-images.githubusercontent.com/4924246/29424139-57216c9e-8333-11e7-8ae4-14fcb45a1307.png)
