### PR TITLE
Color Schemes: Add selected Color Scheme to Layout

### DIFF
--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -31,6 +31,7 @@ var AsyncLoad = require( 'components/async-load' ),
 	Layout,
 	SupportUser;
 
+import PropTypes from 'prop-types';
 import QuerySites from 'components/data/query-sites';
 import { isOffline } from 'state/application/selectors';
 import { hasSidebar } from 'state/ui/selectors';
@@ -40,6 +41,7 @@ import { getCurrentLayoutFocus } from 'state/ui/layout-focus/selectors';
 import DocumentHead from 'components/data/document-head';
 import NpsSurveyNotice from 'layout/nps-survey-notice';
 import AppBanner from 'blocks/app-banner';
+import { getPreference } from 'state/preferences/selectors';
 
 if ( config.isEnabled( 'keyboard-shortcuts' ) ) {
 	KeyboardShortcutsMenu = require( 'lib/keyboard-shortcuts/menu' );
@@ -69,6 +71,7 @@ Layout = React.createClass( {
 			React.PropTypes.object,
 		] ),
 		isOffline: React.PropTypes.bool,
+		colorSchemePreference: PropTypes.string,
 	},
 
 	closeWelcome: function() {
@@ -133,7 +136,8 @@ Layout = React.createClass( {
 				{ 'is-support-user': this.props.isSupportUser },
 				{ 'has-no-sidebar': ! this.props.hasSidebar },
 				{ 'wp-singletree-layout': !! this.props.primary },
-				{ 'has-chat': this.props.chatIsOpen }
+				{ 'has-chat': this.props.chatIsOpen },
+				`is-${ this.props.colorSchemePreference }-theme`,
 			),
 			loadingClass = classnames( {
 				layout__loader: true,
@@ -184,7 +188,8 @@ export default connect(
 			hasSidebar: hasSidebar( state ),
 			isOffline: isOffline( state ),
 			currentLayoutFocus: getCurrentLayoutFocus( state ),
-			chatIsOpen: isHappychatOpen( state )
+			chatIsOpen: isHappychatOpen( state ),
+			colorSchemePreference: getPreference( state, 'colorScheme' ),
 		};
 	}
 )( Layout );


### PR DESCRIPTION
This PR is part of a series of PRs aiming to provide support for Color Schemes in Calypso.
This PR focuses on adding the selected color scheme to the Layout via a CSS class.

![ezgif com-video-to-gif 2](https://user-images.githubusercontent.com/1562646/29424752-2de62768-8381-11e7-81eb-5a960339f9bd.gif)



### Notable additions in this PR:
- This PR adds a CSS class based on the selected color scheme to the Layout component.

### How to test
- Visit https://calypso.live/?branch=add/color-schemes/connect-to-layout or test locally.
- Navigate to the `Accounts Settings` page and scroll down to the `Admin Color Scheme` section. 
- Open the DevTools and switch between themes to test if the CSS class is set as expected (see Screenshot above).

### Suggestions as to what to test
- Is the color scheme selection being persisted when saved and dropped when not?
- Is the CSS class active on the other pages throughout the admin area?
- Do all combinations of different Account Settings changes work as expected?

### Note 
This PR currently compares its changes to PR https://github.com/Automattic/wp-calypso/pull/17259 which in turn compares to PR https://github.com/Automattic/wp-calypso/pull/17157 and PR https://github.com/Automattic/wp-calypso/pull/17200. This is so the changes can be easily identified. This PR will be pointed at `master` once PR https://github.com/Automattic/wp-calypso/pull/17259, PR https://github.com/Automattic/wp-calypso/pull/17200 and PR https://github.com/Automattic/wp-calypso/pull/17157 have been merged.

For a more detailed description of the feature, the chosen approach and its advantages feel free to check out my post on the subject: p4TIVU-75d-p2 (internal reference).