### PR TITLE
Extensions: WPJM - Add UI for the second step of the setup wizard

### DIFF
--- a/client/extensions/wp-job-manager/app/controller.js
+++ b/client/extensions/wp-job-manager/app/controller.js
@@ -2,6 +2,7 @@
  * External Dependencies
  */
 import React from 'react';
+import { get } from 'lodash';
 
 /**
  * Internal Dependencies
@@ -11,6 +12,7 @@ import titlecase from 'to-title-case';
 import { getSiteFragment, sectionify } from 'lib/route';
 import { renderWithReduxStore } from 'lib/react-helpers';
 import Settings from '../components/settings';
+import SetupWizard from '../components/setup';
 
 export const renderTab = ( component, tab = '' ) => ( context ) => {
 	const siteId = getSiteFragment( context.path );
@@ -37,6 +39,16 @@ export const renderTab = ( component, tab = '' ) => ( context ) => {
 		<Settings tab={ tab }>
 			{ React.createElement( component ) }
 		</Settings>,
+		document.getElementById( 'primary' ),
+		context.store
+	);
+};
+
+export const renderSetupWizard = context => {
+	const stepName = get( context, [ 'params', 'stepName' ] );
+
+	renderWithReduxStore(
+		<SetupWizard stepName={ stepName } />,
 		document.getElementById( 'primary' ),
 		context.store
 	);

--- a/client/extensions/wp-job-manager/components/setup/constants.js
+++ b/client/extensions/wp-job-manager/components/setup/constants.js
@@ -1,0 +1,5 @@
+export const Steps = {
+	CONFIRMATION: 'confirmation',
+	INTRO: 'intro',
+	PAGE_SETUP: 'page-setup',
+};

--- a/client/extensions/wp-job-manager/components/setup/index.jsx
+++ b/client/extensions/wp-job-manager/components/setup/index.jsx
@@ -1,0 +1,59 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import { Steps } from './constants';
+import DocumentHead from 'components/data/document-head';
+import Intro from './intro';
+import Main from 'components/main';
+import Wizard from 'components/wizard';
+import { getSiteSlug } from 'state/sites/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
+
+const SetupWizard = ( {
+	slug,
+	stepName = Steps.INTRO,
+	translate,
+} ) => {
+	const steps = [ Steps.INTRO ];
+	const components = {
+		[ Steps.INTRO ]: Intro,
+	};
+
+	return (
+		<Main>
+			<DocumentHead title={ translate( 'Setup' ) } />
+			<Wizard
+				basePath={ `/extensions/wp-job-manager/setup/${ slug }` }
+				components={ components }
+				forwardText={ translate( 'Continue' ) }
+				steps={ steps }
+				stepName={ stepName } />
+		</Main>
+	);
+};
+
+const connectComponent = connect(
+	state => {
+		const siteId = getSelectedSiteId( state );
+
+		return {
+			slug: getSiteSlug( state, siteId ),
+		};
+	}
+);
+
+SetupWizard.propTypes = {
+	slug: PropTypes.string,
+	stepName: PropTypes.string,
+	translate: PropTypes.func.isRequired,
+};
+
+export default connectComponent( localize( SetupWizard ) );

--- a/client/extensions/wp-job-manager/components/setup/index.jsx
+++ b/client/extensions/wp-job-manager/components/setup/index.jsx
@@ -13,6 +13,7 @@ import { Steps } from './constants';
 import DocumentHead from 'components/data/document-head';
 import Intro from './intro';
 import Main from 'components/main';
+import PageSetup from './page-setup';
 import Wizard from 'components/wizard';
 import { getSiteSlug } from 'state/sites/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
@@ -22,9 +23,10 @@ const SetupWizard = ( {
 	stepName = Steps.INTRO,
 	translate,
 } ) => {
-	const steps = [ Steps.INTRO ];
+	const steps = [ Steps.INTRO, Steps.PAGE_SETUP ];
 	const components = {
 		[ Steps.INTRO ]: Intro,
+		[ Steps.PAGE_SETUP ]: PageSetup,
 	};
 
 	return (

--- a/client/extensions/wp-job-manager/components/setup/index.jsx
+++ b/client/extensions/wp-job-manager/components/setup/index.jsx
@@ -36,6 +36,7 @@ const SetupWizard = ( {
 				basePath={ `/extensions/wp-job-manager/setup/${ slug }` }
 				components={ components }
 				forwardText={ translate( 'Continue' ) }
+				hideNavigation={ stepName !== Steps.INTRO }
 				steps={ steps }
 				stepName={ stepName } />
 		</Main>

--- a/client/extensions/wp-job-manager/components/setup/index.jsx
+++ b/client/extensions/wp-job-manager/components/setup/index.jsx
@@ -28,15 +28,15 @@ const SetupWizard = ( {
 		[ Steps.INTRO ]: Intro,
 		[ Steps.PAGE_SETUP ]: PageSetup,
 	};
+	const mainClassName = 'wp-job-manager__setup';
 
 	return (
-		<Main>
+		<Main className={ mainClassName }>
 			<DocumentHead title={ translate( 'Setup' ) } />
 			<Wizard
 				basePath={ `/extensions/wp-job-manager/setup/${ slug }` }
 				components={ components }
-				forwardText={ translate( 'Continue' ) }
-				hideNavigation={ stepName !== Steps.INTRO }
+				hideNavigation={ true }
 				steps={ steps }
 				stepName={ stepName } />
 		</Main>

--- a/client/extensions/wp-job-manager/components/setup/index.jsx
+++ b/client/extensions/wp-job-manager/components/setup/index.jsx
@@ -25,8 +25,8 @@ const SetupWizard = ( {
 } ) => {
 	const steps = [ Steps.INTRO, Steps.PAGE_SETUP ];
 	const components = {
-		[ Steps.INTRO ]: Intro,
-		[ Steps.PAGE_SETUP ]: PageSetup,
+		[ Steps.INTRO ]: <Intro />,
+		[ Steps.PAGE_SETUP ]: <PageSetup />
 	};
 	const mainClassName = 'wp-job-manager__setup';
 

--- a/client/extensions/wp-job-manager/components/setup/intro/index.jsx
+++ b/client/extensions/wp-job-manager/components/setup/intro/index.jsx
@@ -1,0 +1,73 @@
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import { Steps } from '../constants';
+import Button from 'components/button';
+import Card from 'components/card';
+import ExternalLink from 'components/external-link';
+import SectionHeader from 'components/section-header';
+
+class Intro extends Component {
+	skipSetup = () => this.props.goToStep( Steps.CONFIRMATION );
+
+	render() {
+		const { translate } = this.props;
+
+		return (
+			<div>
+				<SectionHeader label={ translate( 'Setup Wizard Introduction' ) } />
+				<Card>
+					<p>
+						{ translate(
+							'Thanks for installing {{em}}WP Job Manager{{/em}}!',
+							{ components: { em: <em /> } }
+						) }
+					</p>
+
+					<p>
+						{ translate(
+							'This setup wizard will help you get started by creating the pages for job submission, ' +
+							'job management, and listing your jobs.'
+						) }
+					</p>
+
+					<p>
+						{ translate(
+							'If you want to skip the wizard and setup the pages and shortcodes yourself manually, ' +
+							'the process is still relatively simple. Refer to the {{docs}}documentation{{/docs}} for help.',
+							{
+								components: {
+									docs: (
+										<ExternalLink
+											icon={ true }
+											target="_blank"
+											href="https://wpjobmanager.com/documentation/"
+										/>
+									),
+								}
+							}
+						) }
+					</p>
+					<Button compact
+						onClick={ this.skipSetup }>
+						{ translate( 'Skip setup. I will set up the plugin manually' ) }
+					</Button>
+				</Card>
+			</div>
+		);
+	}
+}
+
+Intro.propTypes = {
+	goToStep: PropTypes.func.isRequired,
+	translate: PropTypes.func.isRequired,
+};
+
+export default localize( Intro );

--- a/client/extensions/wp-job-manager/components/setup/intro/index.jsx
+++ b/client/extensions/wp-job-manager/components/setup/intro/index.jsx
@@ -8,40 +8,41 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import { Steps } from '../constants';
 import Button from 'components/button';
-import Card from 'components/card';
+import CompactCard from 'components/card/compact';
 import ExternalLink from 'components/external-link';
 import SectionHeader from 'components/section-header';
 
 class Intro extends Component {
-	skipSetup = () => this.props.goToStep( Steps.CONFIRMATION );
+	static propTypes = {
+		translate: PropTypes.func.isRequired,
+	};
 
 	render() {
 		const { translate } = this.props;
 
 		return (
 			<div>
-				<SectionHeader label={ translate( 'Setup Wizard Introduction' ) } />
-				<Card>
+				<SectionHeader label={ translate( 'Welcome to the Setup Wizard!' ) } />
+				<CompactCard>
 					<p>
 						{ translate(
-							'Thanks for installing {{em}}WP Job Manager{{/em}}!',
+							'Thanks for installing {{em}}WP Job Manager{{/em}}! Let\'s get your site ready to accept job listings.',
 							{ components: { em: <em /> } }
 						) }
 					</p>
 
 					<p>
 						{ translate(
-							'This setup wizard will help you get started by creating the pages for job submission, ' +
-							'job management, and listing your jobs.'
+							'This setup wizard will walk you through the process of creating pages for job submissions, ' +
+							'management, and listings.'
 						) }
 					</p>
 
 					<p>
 						{ translate(
-							'If you want to skip the wizard and setup the pages and shortcodes yourself manually, ' +
-							'the process is still relatively simple. Refer to the {{docs}}documentation{{/docs}} for help.',
+							'If you\'d prefer to skip this and set up your pages manually, our {{docs}}documentation{{/docs}} ' +
+							'will walk you through each step.',
 							{
 								components: {
 									docs: (
@@ -55,19 +56,22 @@ class Intro extends Component {
 							}
 						) }
 					</p>
-					<Button compact
-						onClick={ this.skipSetup }>
-						{ translate( 'Skip setup. I will set up the plugin manually' ) }
+				</CompactCard>
+
+				<CompactCard>
+					<a
+						className="intro__skip-setup"
+						href="#">
+						{ translate( 'Skip setup. I will set up the plugin manually.' ) }
+					</a>
+					<Button primary
+						className="intro__continue">
+						{ translate( 'Continue' ) }
 					</Button>
-				</Card>
+				</CompactCard>
 			</div>
 		);
 	}
 }
-
-Intro.propTypes = {
-	goToStep: PropTypes.func.isRequired,
-	translate: PropTypes.func.isRequired,
-};
 
 export default localize( Intro );

--- a/client/extensions/wp-job-manager/components/setup/page-setup/index.jsx
+++ b/client/extensions/wp-job-manager/components/setup/page-setup/index.jsx
@@ -1,0 +1,156 @@
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Button from 'components/button';
+import Card from 'components/card';
+import CompactFormToggle from 'components/forms/form-toggle/compact';
+import ExternalLink from 'components/external-link';
+import FormFieldset from 'components/forms/form-fieldset';
+import FormSettingExplanation from 'components/forms/form-setting-explanation';
+import FormTextInput from 'components/forms/form-text-input';
+import SectionHeader from 'components/section-header';
+
+class PageSetup extends Component {
+	static propTypes = {
+		translate: PropTypes.func.isRequired,
+	};
+
+	state = {
+		dashboard: true,
+		dashboardPage: this.props.translate( 'Job Dashboard' ),
+		jobs: true,
+		jobsPage: this.props.translate( 'Jobs' ),
+		postJob: true,
+		postJobPage: this.props.translate( 'Post a Job' ),
+	}
+
+	updateText = name => event => this.setState( { [ name ]: event.target.value } );
+
+	updateToggle = name => () => this.setState( { [ name ]: ! this.state[ name ] } );
+
+	render() {
+		const { translate } = this.props;
+		const {
+			dashboard,
+			dashboardPage,
+			jobs,
+			jobsPage,
+			postJob,
+			postJobPage,
+		} = this.state;
+
+		return (
+			<div>
+				<SectionHeader label={ translate( 'Page Setup' ) } />
+				<Card>
+					<p>
+						{ translate(
+							'{{em}}WP Job Manager{{/em}} includes {{shortcodes}}shortcodes{{/shortcodes}} which can ' +
+							'be used within your {{pages}}pages{{/pages}} to output content. These can be created ' +
+							'for you below. For more information on the job shortcodes view the ' +
+							'{{shortcodeRef}}shortcode documentation{{/shortcodeRef}}.',
+							{ components: {
+								em: <em />,
+								pages: (
+									<ExternalLink
+										icon={ true }
+										target="_blank"
+										href="https://codex.wordpress.org/Pages"
+									/>
+								),
+								shortcodes: (
+									<ExternalLink
+										icon={ true }
+										target="_blank"
+										href="https://codex.wordpress.org/Shortcode"
+									/>
+								),
+								shortcodeRef: (
+									<ExternalLink
+										icon={ true }
+										target="_blank"
+										href="https://wpjobmanager.com/document/shortcode-reference/"
+									/>
+								)
+							} }
+						) }
+					</p>
+
+					<div className="page-setup__pages">
+						<form>
+							<FormFieldset>
+								<CompactFormToggle
+									checked={ postJob }
+									onChange={ this.updateToggle( 'postJob' ) }>
+									<FormTextInput
+										disabled={ ! postJob }
+										onChange={ this.updateText( 'postJobPage' ) }
+										value={ postJobPage } />
+								</CompactFormToggle>
+
+								<FormSettingExplanation>
+									{ translate(
+										'This page allows employers to post jobs to your website from the front-end. ' +
+										'If you do not want to accept submissions from users in this way (for example, you ' +
+										'just want to post jobs from the admin dashboard), you can skip creating this page. ' +
+										'Alternatively, you can add the [submit_job_form] shortcode to an existing page.'
+									) }
+								</FormSettingExplanation>
+							</FormFieldset>
+
+							<FormFieldset>
+								<CompactFormToggle
+									checked={ dashboard }
+									onChange={ this.updateToggle( 'dashboard' ) }>
+									<FormTextInput
+										disabled={ ! dashboard }
+										onChange={ this.updateText( 'dashboardPage' ) }
+										value={ dashboardPage } />
+								</CompactFormToggle>
+
+								<FormSettingExplanation>
+									{ translate(
+										'This page allows employers to manage and edit their own jobs from the front-end. ' +
+										'If you plan on managing all listings from the admin dashboard, you can skip creating ' +
+										'this page. Alternatively, you can add the [job_dashboard] shortcode to an existing page.'
+									) }
+								</FormSettingExplanation>
+							</FormFieldset>
+
+							<FormFieldset>
+								<CompactFormToggle
+									checked={ jobs }
+									onChange={ this.updateToggle( 'jobs' ) }>
+									<FormTextInput
+										disabled={ ! jobs }
+										onChange={ this.updateText( 'jobsPage' ) }
+										value={ jobsPage } />
+								</CompactFormToggle>
+
+								<FormSettingExplanation>
+									{ translate(
+										'This page allows users to browse, search, and filter job listings on the front-end ' +
+										'of your site. Alternatively, you can add the [jobs] shortcode to an existing page.'
+									) }
+								</FormSettingExplanation>
+							</FormFieldset>
+						</form>
+					</div>
+
+					<Button compact primary>
+						{ translate( 'Create selected pages' ) }
+					</Button>
+				</Card>
+			</div>
+		);
+	}
+}
+
+export default localize( PageSetup );

--- a/client/extensions/wp-job-manager/components/setup/page-setup/index.jsx
+++ b/client/extensions/wp-job-manager/components/setup/page-setup/index.jsx
@@ -141,12 +141,15 @@ class PageSetup extends Component {
 									) }
 								</FormSettingExplanation>
 							</FormFieldset>
+
+							<Button compact primary>
+								{ translate( 'Create selected pages' ) }
+							</Button>
+							<Button compact>
+								{ translate( 'Skip this step' ) }
+							</Button>
 						</form>
 					</div>
-
-					<Button compact primary>
-						{ translate( 'Create selected pages' ) }
-					</Button>
 				</Card>
 			</div>
 		);

--- a/client/extensions/wp-job-manager/components/setup/page-setup/index.jsx
+++ b/client/extensions/wp-job-manager/components/setup/page-setup/index.jsx
@@ -9,7 +9,7 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import Button from 'components/button';
-import Card from 'components/card';
+import CompactCard from 'components/card/compact';
 import CompactFormToggle from 'components/forms/form-toggle/compact';
 import ExternalLink from 'components/external-link';
 import FormFieldset from 'components/forms/form-fieldset';
@@ -49,7 +49,7 @@ class PageSetup extends Component {
 		return (
 			<div>
 				<SectionHeader label={ translate( 'Page Setup' ) } />
-				<Card>
+				<CompactCard>
 					<p>
 						{ translate(
 							'{{em}}WP Job Manager{{/em}} includes {{shortcodes}}shortcodes{{/shortcodes}} which can ' +
@@ -141,16 +141,21 @@ class PageSetup extends Component {
 									) }
 								</FormSettingExplanation>
 							</FormFieldset>
-
-							<Button compact primary>
-								{ translate( 'Create selected pages' ) }
-							</Button>
-							<Button compact>
-								{ translate( 'Skip this step' ) }
-							</Button>
 						</form>
 					</div>
-				</Card>
+				</CompactCard>
+
+				<CompactCard>
+					<a
+						className="page-setup__skip"
+						href="#">
+						{ translate( 'Skip this step' ) }
+					</a>
+					<Button primary
+						className="page-setup__create-pages">
+						{ translate( 'Create selected pages' ) }
+					</Button>
+				</CompactCard>
 			</div>
 		);
 	}

--- a/client/extensions/wp-job-manager/components/setup/page-setup/index.jsx
+++ b/client/extensions/wp-job-manager/components/setup/page-setup/index.jsx
@@ -152,7 +152,8 @@ class PageSetup extends Component {
 						{ translate( 'Skip this step' ) }
 					</a>
 					<Button primary
-						className="page-setup__create-pages">
+						className="page-setup__create-pages"
+						disabled={ ! postJob && ! dashboard && ! jobs }>
 						{ translate( 'Create selected pages' ) }
 					</Button>
 				</CompactCard>

--- a/client/extensions/wp-job-manager/components/setup/style.scss
+++ b/client/extensions/wp-job-manager/components/setup/style.scss
@@ -1,0 +1,7 @@
+.page-setup__pages .form-text-input {
+	width: 250px;
+}
+
+.page-setup__pages .form-setting-explanation {
+	margin-left: 36px;
+}

--- a/client/extensions/wp-job-manager/components/setup/style.scss
+++ b/client/extensions/wp-job-manager/components/setup/style.scss
@@ -5,3 +5,7 @@
 .page-setup__pages .form-setting-explanation {
 	margin-left: 36px;
 }
+
+.page-setup__pages .button {
+	margin-right: 8px;
+}

--- a/client/extensions/wp-job-manager/components/setup/style.scss
+++ b/client/extensions/wp-job-manager/components/setup/style.scss
@@ -1,11 +1,37 @@
-.page-setup__pages .form-text-input {
+.wp-job-manager__setup .intro__skip-setup {
+	color: $blue-medium;
+	display: block;
+	font-size: 13px;
+	text-align: center;
+
+	@include breakpoint( ">660px" ) {
+		float: left;
+		line-height: 38px;
+	}
+}
+
+.wp-job-manager__setup .intro__continue {
+	margin-top: 10px;
+
+	@include breakpoint( "<660px" ) {
+		margin-bottom: 18px;
+		width: 100%;
+	}
+
+	@include breakpoint( ">660px" ) {
+		float: right;
+		margin: 0;
+	}
+}
+
+.wp-job-manager__setup .page-setup__pages .form-text-input {
 	width: 250px;
 }
 
-.page-setup__pages .form-setting-explanation {
+.wp-job-manager__setup .page-setup__pages .form-setting-explanation {
 	margin-left: 36px;
 }
 
-.page-setup__pages .button {
+.wp-job-manager__setup .page-setup__pages .button {
 	margin-right: 8px;
 }

--- a/client/extensions/wp-job-manager/components/setup/style.scss
+++ b/client/extensions/wp-job-manager/components/setup/style.scss
@@ -1,4 +1,5 @@
-.wp-job-manager__setup .intro__skip-setup {
+.wp-job-manager__setup .intro__skip-setup,
+.wp-job-manager__setup .page-setup__skip {
 	color: $blue-medium;
 	display: block;
 	font-size: 13px;
@@ -10,7 +11,8 @@
 	}
 }
 
-.wp-job-manager__setup .intro__continue {
+.wp-job-manager__setup .intro__continue,
+.wp-job-manager__setup .page-setup__create-pages {
 	margin-top: 10px;
 
 	@include breakpoint( "<660px" ) {

--- a/client/extensions/wp-job-manager/index.js
+++ b/client/extensions/wp-job-manager/index.js
@@ -8,7 +8,7 @@ import { get } from 'lodash';
  * Internal dependencies
  */
 import { navigation, sites, siteSelection } from 'my-sites/controller';
-import { renderTab } from './app/controller';
+import { renderSetupWizard, renderTab } from './app/controller';
 import { Tabs } from './constants';
 import JobListings from './components/settings/job-listings';
 import JobSubmission from './components/settings/job-submission';
@@ -29,6 +29,7 @@ export default function() {
 		renderTab( JobSubmission, jobSubmissionSlug ) );
 	page( `/extensions/wp-job-manager/${ pagesSlug }/:site`, siteSelection, navigation,
 		renderTab( Pages, pagesSlug ) );
+	page( '/extensions/wp-job-manager/setup/:site/:stepName?', siteSelection, navigation, renderSetupWizard );
 }
 
 initExtension();

--- a/client/extensions/wp-job-manager/style.scss
+++ b/client/extensions/wp-job-manager/style.scss
@@ -1,1 +1,2 @@
 @import 'components/settings/style';
+@import 'components/setup/style';


### PR DESCRIPTION
This PR adds the UI for the second (page setup) step of the WPJM setup wizard. The wizard will be triggered when the plugin is first activated. Here is what the second step looks like:

![wpjm-wizard-page-setup](https://user-images.githubusercontent.com/1190420/29425724-4afdcfba-8352-11e7-9daf-38f048298bf7.jpg)

For comparison's sake, here is what the page setup step looks like in the plugin itself:

![plugin-wizard-page-setup](https://user-images.githubusercontent.com/1190420/29425120-1ec6fb76-8350-11e7-9544-7733290e5e6c.jpg)

_Note: Because of the dependency on another PR, the calypso.live link doesn't work. Please use the first screenshot for design or copy review._