### PR TITLE
Components: Add the ability to hide the navigation links in the wizard

### DIFF
--- a/client/components/wizard/README.md
+++ b/client/components/wizard/README.md
@@ -63,6 +63,15 @@ to one of the values in the `steps` array (see below).
 
 Link text for navigating to the next step in the wizard.
 
+### `hideNavigation`
+
+<table>
+	<tr><td>Type</td><td>Boolean</td></tr>
+	<tr><td>Required</td><td>No</td></tr>
+</table>
+
+Whether to hide the navigation links.
+
 ### `steps`
 
 <table>

--- a/client/components/wizard/index.jsx
+++ b/client/components/wizard/index.jsx
@@ -17,12 +17,14 @@ class Wizard extends Component {
 		basePath: PropTypes.string,
 		components: PropTypes.objectOf( PropTypes.element ).isRequired,
 		forwardText: PropTypes.string,
+		hideNavigation: PropTypes.bool,
 		steps: PropTypes.arrayOf( PropTypes.string ).isRequired,
 		stepName: PropTypes.string.isRequired,
 	}
 
 	static defaultProps = {
 		basePath: '',
+		hideNavigation: false,
 	}
 
 	getStepIndex = () => indexOf( this.props.steps, this.props.stepName );
@@ -66,6 +68,7 @@ class Wizard extends Component {
 			backText,
 			components,
 			forwardText,
+			hideNavigation,
 			steps,
 			stepName,
 		} = this.props;
@@ -85,7 +88,7 @@ class Wizard extends Component {
 
 				{ component }
 
-				{ totalSteps > 1 &&
+				{ ! hideNavigation && totalSteps > 1 &&
 					<div className="wizard__navigation-links">
 						{ stepIndex > 0 &&
 							<NavigationLink


### PR DESCRIPTION
This PR adds the ability to hide the navigation links in the wizard. The visibility of the navigation is specified by setting the `hideNavigation` prop. The default is `false`.

## Testing

Navigate to the _UI Components_ section of the devdocs. Ensure that you can still navigate through each of the steps in the wizard. The navigation links should be visible.