### PR TITLE
Color Schemes: Add Feature Detection

### DIFF
--- a/client/lib/feature-detection/README.md
+++ b/client/lib/feature-detection/README.md
@@ -1,0 +1,20 @@
+feature-detection
+=============
+
+`feature-detection` is a collection of feature detection tests to see if a certain feature is supported by the browser/environment. The test functions should be kept simple and return either `true` or `false` depending on whether or not a feature is supported.
+
+## Usage
+
+```javascript
+import { supportsFeatureToDetect } from 'lib/feature-detection';
+
+if ( supportsFeatureToDetect() ) {
+	doSomething();
+}
+```
+
+## Available Tests
+
+### supportsCssCustomProperties
+
+A simple test to check if the browser supports CSS custom properties.

--- a/client/lib/feature-detection/index.js
+++ b/client/lib/feature-detection/index.js
@@ -8,10 +8,10 @@ const featureDetection = {
 	 */
 	supportsCssCustomProperties: () => {
 		return (
-			window &&
-			( window.CSS &&
-				window.CSS.supports &&
-				( window.CSS.supports( '--a', 0 ) || window.CSS.supports( 'color', 'var(--a)' ) ) )
+			typeof window !== 'undefined' &&
+			window.CSS &&
+			window.CSS.supports &&
+			( window.CSS.supports( '--a', 0 ) || window.CSS.supports( 'color', 'var(--a)' ) )
 		);
 	},
 };

--- a/client/lib/feature-detection/index.js
+++ b/client/lib/feature-detection/index.js
@@ -1,0 +1,19 @@
+/** @format */
+
+const featureDetection = {
+	/**
+	 * Detects if CSS custom properties are supported
+	 *
+	 * @return {boolean} true when feature is supported
+	 */
+	supportsCssCustomProperties: () => {
+		return (
+			window &&
+			( window.CSS &&
+				window.CSS.supports &&
+				( window.CSS.supports( '--a', 0 ) || window.CSS.supports( 'color', 'var(--a)' ) ) )
+		);
+	},
+};
+
+export default featureDetection;

--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -24,6 +24,7 @@ import MeSidebarNavigation from 'me/sidebar-navigation';
 import { protectForm } from 'lib/protect-form';
 import formBase from 'me/form-base';
 import config from 'config';
+import { supportsCssCustomProperties } from 'lib/feature-detection';
 import Card from 'components/card';
 import FormTextInput from 'components/forms/form-text-input';
 import FormTextValidation from 'components/forms/form-input-validation';
@@ -546,6 +547,7 @@ const Account = React.createClass( {
 				{ this.communityTranslator() }
 
 				{ config.isEnabled( 'me/account/color-scheme-picker' ) &&
+					supportsCssCustomProperties() &&
 					<FormFieldset>
 						<FormLabel htmlFor="color_scheme">
 							{ translate( 'Admin Color Scheme' ) }


### PR DESCRIPTION
This PR is part of a series of PRs aiming to provide support for Color Schemes in Calypso.
This PR focuses on adding feature detection for CSS custom properties.

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/1562646/29429773-1397e1b0-8392-11e7-8492-c6326f92f6c6.gif)



### Notable additions in this PR:
- This PR adds `lib/feature-detection` as a hub for future feature detection tests
- `supportsCssCustomProperties` is added as a test for CSS custom property support
- The new test is used on Account Settings to conditionally display the Color Scheme picker

### Considerations

A single location for feature detection tests would make it easy to import them throughout the project. Initially, the one file approach should be sufficient. Once there would be an extended number of feature detection tests, a sub folder (e.g. `features/css-custom-properties`) could help with order.

### How to test
- Visit https://calypso.live/?branch=add/color-schemes/add-feature-detection or test locally.
- Navigate to the `Accounts Settings` page and scroll down to the `Admin Color Scheme` section. 
- Depending on whether the browser supports CSS custom properties, the Admin Color Scheme Picker should be available or not.
- For browser support see http://caniuse.com/#feat=css-variables

### Suggestions as to what to test
- Does the feature detection work as expected ([see browser support](http://caniuse.com/#feat=css-variables))?
- Does the suggested setup for `feature-detection` cover current use cases?

### Note 
This PR currently compares its changes to PR https://github.com/Automattic/wp-calypso/pull/17307 which in turn compares to PR https://github.com/Automattic/wp-calypso/pull/17259, PR https://github.com/Automattic/wp-calypso/pull/17157 and PR https://github.com/Automattic/wp-calypso/pull/17200. This is so the changes can be easily identified. This PR will be pointed at `master` once PR https://github.com/Automattic/wp-calypso/pull/17259, PR https://github.com/Automattic/wp-calypso/pull/17259, PR https://github.com/Automattic/wp-calypso/pull/17200 and PR https://github.com/Automattic/wp-calypso/pull/17157 have been merged.

For a more detailed description of the feature, the chosen approach and its advantages feel free to check out my post on the subject: p4TIVU-75d-p2 (internal reference).