### PR TITLE
Store: Reduce height of sticky action bar

### DIFF
--- a/client/extensions/woocommerce/app/products/products-list.scss
+++ b/client/extensions/woocommerce/app/products/products-list.scss
@@ -8,10 +8,6 @@
 		margin-bottom: 24px;
 	}
 
-	.action-header__actions {
-		padding-bottom: 3px;
-	}
-
 	.table {
 		margin-bottom: 16px;
 		margin-top: 16px;

--- a/client/extensions/woocommerce/components/action-header/style.scss
+++ b/client/extensions/woocommerce/components/action-header/style.scss
@@ -1,7 +1,7 @@
 .action-header__header {
 	width: 100%;
-	min-height: 58px;
-	padding: 8px 16px 7px;
+	min-height: 46px;
+	padding: 2px 16px 2px;
 	display: flex;
 	flex-direction: row;
 	align-items: center;
@@ -39,6 +39,16 @@
 
 	.button {
 		white-space: nowrap;
+		padding: 5px 14px 7px;
+		
+		&.is-borderless {
+			padding: 0;
+			margin-top: -6px;
+		}
+		
+		&.is-borderless .gridicon{
+			margin-right: 2px;
+		}
 
 		&:not( :first-child ) {
 			margin-left: 24px;

--- a/client/extensions/woocommerce/style.scss
+++ b/client/extensions/woocommerce/style.scss
@@ -103,10 +103,6 @@
 .store-sidebar__sidebar {
 	display: block;
 
-	.site {
-		padding: 6px 0;
-	}
-
 	.store-sidebar__ground-control {
 		align-items: center;
 		border-bottom: 1px solid darken( $sidebar-bg-color, 10% );
@@ -125,7 +121,7 @@
 		border-left: 1px solid darken( $sidebar-bg-color, 10% );
 		display: inline-block;
 		flex-grow: 1;
-		min-height: 58px;
+		min-height: 46px;
 	}
 
 	.sidebar__menu {
@@ -187,7 +183,7 @@
 			a {
 				position: fixed;
 				z-index: 1;
-				margin-top: 10px;
+				margin-top: 4px;
 				background: transparent;
 				border: none;
 			}


### PR DESCRIPTION
The top sticky bar has always been relatively too large and out of place. This brings it to the same height as the sticky bar in the editor.

Before:
![screen shot 2017-08-17 at 2 31 03 pm](https://user-images.githubusercontent.com/5835847/29432493-28e6d834-8359-11e7-9074-65676294724f.png)

After:
![screen shot 2017-08-17 at 2 31 40 pm](https://user-images.githubusercontent.com/5835847/29432494-28fce002-8359-11e7-9da6-e588ab51927a.png)

Props @shaunandrews for calling this out. 