### PR TITLE
simple payments: add event name to nudge

### DIFF
--- a/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
@@ -441,6 +441,7 @@ class SimplePaymentsDialog extends Component {
 								'Get simple payments, advanced social media tools, your own domain, and more.'
 							) }
 							feature={ FEATURE_SIMPLE_PAYMENTS }
+							event="editor_simple_payments_modal_nudge"
 							shouldDisplay={ this.returnTrue }
 						/>
 					}


### PR DESCRIPTION
this makes it easier for us to differentiate multiple upgrade nudges for a single feature.

It gives us the cta_name attribute which was null previously:

### Before
![upgrade nudge console](http://cld.wthms.co/rB0tm7+)

### After
![upgrade nudge with prop](http://cld.wthms.co/uma75M+)

## Testing
Apply the patch, go to the editor on a free site, and watch the events in your console. Expand this one to confirm the event name.