### PR TITLE
Modernize security section of "me"

### DIFF
--- a/client/me/connected-applications/index.jsx
+++ b/client/me/connected-applications/index.jsx
@@ -1,28 +1,42 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	debug = require( 'debug' )( 'calypso:me:connected-applications' ),
-	bindActionCreators = require( 'redux' ).bindActionCreators,
-	connect = require( 'react-redux' ).connect;
+import createReactClass from 'create-react-class';
+import debugFactory from 'debug';
+import PropTypes from 'prop-types';
+import React from 'react';
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+const debug = debugFactory( 'calypso:me:connected-applications' );
 
 /**
  * Internal dependencies
  */
-var ConnectedAppItem = require( 'me/connected-application-item' ),
-	EmptyContent = require( 'components/empty-content' ),
-	MeSidebarNavigation = require( 'me/sidebar-navigation' ),
-	observe = require( 'lib/mixins/data-observe' ),
-	ReauthRequired = require( 'me/reauth-required' ),
-	twoStepAuthorization = require( 'lib/two-step-authorization' ),
-	notices = require( 'notices' ),
-	SecuritySectionNav = require( 'me/security-section-nav' ),
-	Main = require( 'components/main' ),
-	successNotice = require( 'state/notices/actions' ).successNotice;
+import ConnectedAppItem from 'me/connected-application-item';
+import DocumentHead from 'components/data/document-head';
+import EmptyContent from 'components/empty-content';
+import Main from 'components/main';
+import MeSidebarNavigation from 'me/sidebar-navigation';
+import notices from 'notices';
+/* eslint-disable no-restricted-imports */
+// FIXME: Remove use of this mixin
+import observe from 'lib/mixins/data-observe';
+/* eslint-enable no-restricted-imports */
+import ReauthRequired from 'me/reauth-required';
+import SecuritySectionNav from 'me/security-section-nav';
+import twoStepAuthorization from 'lib/two-step-authorization';
+import { successNotice } from 'state/notices/actions';
 
-const ConnectedApplications = React.createClass( {
-
+/* eslint-disable react/prefer-es6-class */
+// FIXME: Remove use of createReactClass
+const ConnectedApplications = createReactClass( {
+	/* eslint-enable react/prefer-es6-class */
 	displayName: 'ConnectedApplications',
+
+	propTypes: {
+		translate: PropTypes.func.isRequired,
+	},
 
 	mixins: [ observe( 'connectedAppsData' ) ],
 
@@ -41,7 +55,7 @@ const ConnectedApplications = React.createClass( {
 	},
 
 	revokeConnection: function( applicationID, callback ) {
-		var application = this.props.connectedAppsData.getApplication( applicationID );
+		const application = this.props.connectedAppsData.getApplication( applicationID );
 		if ( 'undefined' !== typeof application ) {
 			this.props.connectedAppsData.revoke( parseInt( applicationID, 10 ), function( error ) {
 				debug( 'API call to revoke application is completed.' );
@@ -52,7 +66,7 @@ const ConnectedApplications = React.createClass( {
 				} else {
 					debug( 'Application connection was successfully revoked.' );
 					this.props.successNotice(
-						this.translate( '%(applicationTitle)s no longer has access to your WordPress.com account.', {
+						this.props.translate( '%(applicationTitle)s no longer has access to your WordPress.com account.', {
 							args: {
 								applicationTitle: application.title
 							}
@@ -64,28 +78,38 @@ const ConnectedApplications = React.createClass( {
 	},
 
 	renderEmptyContent: function() {
+		const { translate } = this.props;
 		return (
 			<EmptyContent
-				title={ this.translate( "You haven't connected any apps yet." ) }
-				line={ this.translate( 'You can get started with the {{link}}WordPress mobile apps!{{/link}}', {
-					components: {
-						link: <a href="https://apps.wordpress.org/" target="_blank" rel="noopener noreferrer" title="WordPress Mobile Apps" />
+				title={ translate( "You haven't connected any apps yet." ) }
+				line={ translate(
+					'You can get started with the {{link}}WordPress mobile apps!{{/link}}',
+					{
+						components: {
+							link: (
+								<a
+									href="https://apps.wordpress.org/"
+									target="_blank"
+									rel="noopener noreferrer"
+									title="WordPress Mobile Apps"
+								/>
+							),
+						},
 					}
-				} ) }
+				) }
 			/>
 		);
 	},
 
 	renderPlaceholders: function() {
-		var i,
-			placeholders = [];
+		const placeholders = [];
 
-		for ( i = 0; i < 5; i++ ) {
+		for ( let i = 0; i < 5; i++ ) {
 			placeholders.push(
 				<ConnectedAppItem
 					connection={ {
 						ID: i,
-						title: this.translate( 'Loading Connected Applications' )
+						title: this.props.translate( 'Loading Connected Applications' ),
 					} }
 					key={ i }
 					isPlaceholder
@@ -97,22 +121,23 @@ const ConnectedApplications = React.createClass( {
 	},
 
 	renderConnectedApps: function() {
-		return this.props.connectedAppsData.initialized
+		return ( this.props.connectedAppsData.initialized
 		? this.props.connectedAppsData.get().map( function( connection ) {
-				return (
+			return (
 					<ConnectedAppItem
 						connection={ connection }
 						key={ connection.ID }
 						connectedApplications={ this.props.connectedAppsData }
-						revoke={ this.revokeConnection } />
+						revoke={ this.revokeConnection }
+					/>
 				);
-			}, this )
-		: this.renderPlaceholders();
+		}, this )
+		: this.renderPlaceholders() );
 	},
 
 	renderConnectedAppsList: function() {
-		var connectedApps,
-			hasConnectedApps = this.props.connectedAppsData.get().length;
+		let connectedApps;
+		const hasConnectedApps = this.props.connectedAppsData.get().length;
 
 		if ( this.props.connectedAppsData.initialized ) {
 			connectedApps = hasConnectedApps ? this.renderConnectedApps() : this.renderEmptyContent();
@@ -135,13 +160,17 @@ const ConnectedApplications = React.createClass( {
 				<ReauthRequired twoStepAuthorization={ twoStepAuthorization } />
 				<MeSidebarNavigation />
 
+				<DocumentHead
+					title={ this.props.translate( 'Connected Applications', { textOnly: true } ) }
+				/>
+
 				{ this.renderConnectedAppsList() }
 			</Main>
 		);
-	}
+	},
 } );
 
 export default connect(
 	null,
 	dispatch => bindActionCreators( { successNotice }, dispatch )
-)( ConnectedApplications );
+)( localize( ConnectedApplications ) );

--- a/client/me/security-account-recovery/index.jsx
+++ b/client/me/security-account-recovery/index.jsx
@@ -8,17 +8,18 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import Main from 'components/main';
 import CompactCard from 'components/card/compact';
-import QueryAccountRecoverySettings from 'components/data/query-account-recovery-settings';
+import DocumentHead from 'components/data/document-head';
+import Main from 'components/main';
 import MeSidebarNavigation from 'me/sidebar-navigation';
-import SecuritySectionNav from 'me/security-section-nav';
+import QueryAccountRecoverySettings from 'components/data/query-account-recovery-settings';
 import ReauthRequired from 'me/reauth-required';
-import twoStepAuthorization from 'lib/two-step-authorization';
 import RecoveryEmail from './recovery-email';
-import RecoveryPhone from './recovery-phone';
 import RecoveryEmailValidationNotice from './recovery-email-validation-notice';
+import RecoveryPhone from './recovery-phone';
 import RecoveryPhoneValidationNotice from './recovery-phone-validation-notice';
+import SecuritySectionNav from 'me/security-section-nav';
+import twoStepAuthorization from 'lib/two-step-authorization';
 
 import {
 	updateAccountRecoveryEmail,
@@ -46,7 +47,7 @@ import {
 
 import { getCurrentUserEmail } from 'state/current-user/selectors';
 
-const SecurityAccountRecovery = ( props ) => (
+const SecurityAccountRecovery = props =>
 	<Main className="security-account-recovery">
 		<QueryAccountRecoverySettings />
 
@@ -56,11 +57,14 @@ const SecurityAccountRecovery = ( props ) => (
 
 		<ReauthRequired twoStepAuthorization={ twoStepAuthorization } />
 
+		<DocumentHead title={ props.translate( 'Account Recovery', { textOnly: true } ) } />
+
 		<CompactCard>
 			<p className="security-account-recovery__text">
 				{ props.translate( 'Keep your account safe by adding a backup email address and phone number. ' +
 						'If you ever have problems accessing your account, WordPress.com will use what ' +
-						'you enter here to verify your identity.' ) }
+						'you enter here to verify your identity.'
+				) }
 			</p>
 		</CompactCard>
 
@@ -96,11 +100,10 @@ const SecurityAccountRecovery = ( props ) => (
 				/>
 			}
 		</CompactCard>
-	</Main>
-);
+	</Main>;
 
 export default connect(
-	( state ) => ( {
+	state => ( {
 		accountRecoveryEmail: getAccountRecoveryEmail( state ),
 		accountRecoveryEmailActionInProgress: isAccountRecoveryEmailActionInProgress( state ),
 		accountRecoveryEmailValidated: isAccountRecoveryEmailValidated( state ),

--- a/client/me/security/controller.js
+++ b/client/me/security/controller.js
@@ -25,7 +25,9 @@ export default {
 		context.store.dispatch( setTitle( i18n.translate( 'Password', { textOnly: true } ) ) ); // FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
 
 		if ( context.query && context.query.updated === 'password' ) {
-			notices.success( i18n.translate( 'Your password was saved successfully.' ), { displayOnNextPage: true } );
+			notices.success( i18n.translate( 'Your password was saved successfully.' ), {
+				displayOnNextPage: true,
+			} );
 
 			page.replace( window.location.pathname );
 		}

--- a/client/me/security/controller.js
+++ b/client/me/security/controller.js
@@ -11,7 +11,6 @@ import i18n from 'i18n-calypso';
 import analytics from 'lib/analytics';
 import notices from 'notices';
 import userSettings from 'lib/user-settings';
-import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
 import { renderWithReduxStore } from 'lib/react-helpers';
 
 const ANALYTICS_PAGE_TITLE = 'Me';
@@ -89,15 +88,13 @@ export default {
 		const AccountRecoveryComponent = require( 'me/security-account-recovery' ),
 			basePath = context.path;
 
-		context.store.dispatch( setTitle( i18n.translate( 'Account Recovery', { textOnly: true } ) ) ); // FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
-
 		analytics.pageView.record( basePath, ANALYTICS_PAGE_TITLE + ' > Account Recovery' );
 
 		renderWithReduxStore(
 			React.createElement( AccountRecoveryComponent,
 				{
 					userSettings: userSettings,
-					path: context.path
+					path: basePath
 				}
 			),
 			document.getElementById( 'primary' ),

--- a/client/me/security/controller.js
+++ b/client/me/security/controller.js
@@ -22,8 +22,6 @@ export default {
 		const basePath = context.path;
 		const accountPasswordData = require( 'lib/account-password-data' );
 
-		context.store.dispatch( setTitle( i18n.translate( 'Password', { textOnly: true } ) ) ); // FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
-
 		if ( context.query && context.query.updated === 'password' ) {
 			notices.success( i18n.translate( 'Your password was saved successfully.' ), {
 				displayOnNextPage: true,

--- a/client/me/security/controller.js
+++ b/client/me/security/controller.js
@@ -50,8 +50,6 @@ export default {
 			basePath = context.path,
 			appPasswordsData = require( 'lib/application-passwords-data' );
 
-		context.store.dispatch( setTitle( i18n.translate( 'Two-Step Authentication', { textOnly: true } ) ) ); // FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
-
 		analytics.pageView.record( basePath, ANALYTICS_PAGE_TITLE + ' > Two-Step Authentication' );
 
 		renderWithReduxStore(

--- a/client/me/security/controller.js
+++ b/client/me/security/controller.js
@@ -70,8 +70,6 @@ export default {
 			basePath = context.path,
 			connectedAppsData = require( 'lib/connected-applications-data' );
 
-		context.store.dispatch( setTitle( i18n.translate( 'Connected Applications', { textOnly: true } ) ) ); // FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
-
 		analytics.pageView.record( basePath, ANALYTICS_PAGE_TITLE + ' > Connected Applications' );
 
 		renderWithReduxStore(

--- a/client/me/security/main.jsx
+++ b/client/me/security/main.jsx
@@ -1,43 +1,53 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	debug = require( 'debug' )( 'calypso:me:security:password' );
+import debugFactory from 'debug';
+import PropTypes from 'prop-types';
+import React from 'react';
+import { localize } from 'i18n-calypso';
+const debug = debugFactory( 'calypso:me:security:password' );
 
 /**
  * Internal dependencies
  */
-var MeSidebarNavigation = require( 'me/sidebar-navigation' ),
-	Card = require( 'components/card' ),
-	AccountPassword = require( 'me/account-password' ),
-	ReauthRequired = require( 'me/reauth-required' ),
-	twoStepAuthorization = require( 'lib/two-step-authorization' ),
-	SecuritySectionNav = require( 'me/security-section-nav' ),
-	Main = require( 'components/main' );
+import AccountPassword from 'me/account-password';
+import Card from 'components/card';
+import DocumentHead from 'components/data/document-head';
+import Main from 'components/main';
+import MeSidebarNavigation from 'me/sidebar-navigation';
+import ReauthRequired from 'me/reauth-required';
+import SecuritySectionNav from 'me/security-section-nav';
+import twoStepAuthorization from 'lib/two-step-authorization';
 
-module.exports = React.createClass( {
+class Security extends React.Component {
+	static displayName = 'Security';
 
-	displayName: 'Security',
+	static propTypes = {
+		translate: PropTypes.func.isRequired,
+	};
 
-	componentDidMount: function() {
+	componentDidMount() {
 		debug( this.constructor.displayName + ' React component is mounted.' );
-	},
+	}
 
-	componentWillUnmount: function() {
+	componentWillUnmount() {
 		debug( this.constructor.displayName + ' React component is unmounting.' );
-	},
+	}
 
-	render: function() {
+	render() {
+		const { translate } = this.props;
+
 		return (
 			<Main className="security">
+				<DocumentHead title={ translate( 'Password', { textOnly: true } ) } />
 				<MeSidebarNavigation />
 
 				<SecuritySectionNav path={ this.props.path } />
 
 				<ReauthRequired twoStepAuthorization={ twoStepAuthorization } />
-				<Card className="me-security-settings">
+				<Card className="me-security-settings security__settings">
 					<p>
-						{ this.translate(
+						{ translate(
 							'To update your password enter a new one below. Your password should be at least six characters long. ' +
 							'To make it stronger, use upper and lower case letters, numbers and symbols like ! " ? $ % ^ & ).'
 						) }
@@ -51,4 +61,6 @@ module.exports = React.createClass( {
 			</Main>
 		);
 	}
-} );
+}
+
+export default localize( Security );

--- a/client/me/security/main.jsx
+++ b/client/me/security/main.jsx
@@ -5,7 +5,6 @@ import debugFactory from 'debug';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { localize } from 'i18n-calypso';
-const debug = debugFactory( 'calypso:me:security:password' );
 
 /**
  * Internal dependencies
@@ -18,6 +17,8 @@ import MeSidebarNavigation from 'me/sidebar-navigation';
 import ReauthRequired from 'me/reauth-required';
 import SecuritySectionNav from 'me/security-section-nav';
 import twoStepAuthorization from 'lib/two-step-authorization';
+
+const debug = debugFactory( 'calypso:me:security:password' );
 
 class Security extends React.Component {
 	static displayName = 'Security';

--- a/client/me/two-step/index.jsx
+++ b/client/me/two-step/index.jsx
@@ -1,49 +1,56 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	debug = require( 'debug' )( 'calypso:me:two-step' );
+import debugFactory from 'debug';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { localize } from 'i18n-calypso';
+const debug = debugFactory( 'calypso:me:two-step' );
 
 /**
  * Internal dependencies
  */
-var MeSidebarNavigation = require( 'me/sidebar-navigation' ),
-	Card = require( 'components/card' ),
-	AppPasswords = require( 'me/application-passwords' ),
-	Security2faBackupCodes = require( 'me/security-2fa-backup-codes' ),
-	Security2faDisable = require( 'me/security-2fa-disable' ),
-	Security2faSetup = require( 'me/security-2fa-setup' ),
-	ReauthRequired = require( 'me/reauth-required' ),
-	twoStepAuthorization = require( 'lib/two-step-authorization' ),
-	SecuritySectionNav = require( 'me/security-section-nav' ),
-	Main = require( 'components/main' );
+import AppPasswords from 'me/application-passwords';
+import Card from 'components/card';
+import DocumentHead from 'components/data/document-head';
+import Main from 'components/main';
+import MeSidebarNavigation from 'me/sidebar-navigation';
+import ReauthRequired from 'me/reauth-required';
+import Security2faBackupCodes from 'me/security-2fa-backup-codes';
+import Security2faDisable from 'me/security-2fa-disable';
+import Security2faSetup from 'me/security-2fa-setup';
+import SecuritySectionNav from 'me/security-section-nav';
+import twoStepAuthorization from 'lib/two-step-authorization';
 
-module.exports = React.createClass( {
+class TwoStep extends Component {
+	static displayName = 'TwoStep';
 
-	displayName: 'TwoStep',
+	static propTypes = {
+		translate: PropTypes.func.isRequired,
+	};
 
-	componentDidMount: function() {
+	state = {
+		initialized: false,
+		doingSetup: false
+	};
+
+	componentDidMount() {
 		debug( this.constructor.displayName + ' React component is mounted.' );
 		this.props.userSettings.on( 'change', this.onUserSettingsChange );
 		this.props.userSettings.fetchSettings();
-	},
+	}
 
-	componentWillUnmount: function() {
+	componentWillUnmount() {
 		debug( this.constructor.displayName + ' React component is unmounting.' );
 		this.props.userSettings.off( 'change', this.onUserSettingsChange );
-	},
+	}
 
-	getInitialState: function() {
-		return {
-			initialized: false,
-			doingSetup: false
-		};
-	},
-
-	onUserSettingsChange: function() {
-		if ( ! this.isMounted() ) {
-			return;
-		}
+	onUserSettingsChange = () => {
+		// NOTE: This was removed to transform to React.Component.
+		// Ensure no behavior change from this omission.
+		// if ( ! this.isMounted() ) {
+		// 	return;
+		// }
 
 		if ( ! this.state.initialized ) {
 			this.setState( {
@@ -59,42 +66,46 @@ module.exports = React.createClass( {
 		}
 
 		this.forceUpdate();
-	},
+	};
 
-	onSetupFinished: function() {
+	onSetupFinished = () => {
 		this.setState(
 			{
 				doingSetup: false
 			},
 			this.refetchSettings
 		);
-	},
+	};
 
-	onDisableFinished: function() {
+	onDisableFinished = () => {
 		this.setState(
 			{
 				doingSetup: true
 			},
 			this.refetchSettings
 		);
-	},
+	};
 
-	refetchSettings: function() {
+	refetchSettings = () => {
 		this.props.userSettings.fetchSettings();
-	},
+	};
 
-	renderPlaceholders: function() {
-		var i,
-			placeholders = [];
+	renderPlaceholders = () => {
+		const placeholders = [];
 
-		for ( i = 0; i < 5; i++ ) {
-			placeholders.push( <p className="two-step__placeholder-text" key={ '2fa-placeholder' + i } > &nbsp; </p> );
+		for ( let i = 0; i < 5; i++ ) {
+			placeholders.push(
+				<p className="two-step__placeholder-text" key={ '2fa-placeholder' + i }>
+					{' '}
+					&nbsp;{' '}
+				</p>
+			);
 		}
 
 		return placeholders;
-	},
+	};
 
-	renderTwoStepSection: function() {
+	renderTwoStepSection = () => {
 		if ( ! this.state.initialized ) {
 			return this.renderPlaceholders();
 		}
@@ -114,9 +125,9 @@ module.exports = React.createClass( {
 				onFinished={ this.onDisableFinished }
 			/>
 		);
-	},
+	};
 
-	renderApplicationPasswords: function() {
+	renderApplicationPasswords = () => {
 		if ( ! this.state.initialized || this.state.doingSetup ) {
 			return null;
 		}
@@ -124,9 +135,9 @@ module.exports = React.createClass( {
 		return (
 			<AppPasswords appPasswordsData={ this.props.appPasswordsData } />
 		);
-	},
+	};
 
-	renderBackupCodes: function() {
+	renderBackupCodes = () => {
 		if ( ! this.state.initialized || this.state.doingSetup ) {
 			return null;
 		}
@@ -134,9 +145,9 @@ module.exports = React.createClass( {
 		return (
 			<Security2faBackupCodes userSettings={ this.props.userSettings } />
 		);
-	},
+	};
 
-	render: function() {
+	render() {
 		return (
 			<Main className="two-step">
 				<MeSidebarNavigation />
@@ -144,6 +155,11 @@ module.exports = React.createClass( {
 				<SecuritySectionNav path={ this.props.path } />
 
 				<ReauthRequired twoStepAuthorization={ twoStepAuthorization } />
+
+				<DocumentHead
+					title={ this.props.translate( 'Two-Step Authentication', { textOnly: true } ) }
+				/>
+
 				<Card>
 					{ this.renderTwoStepSection() }
 				</Card>
@@ -153,4 +169,6 @@ module.exports = React.createClass( {
 			</Main>
 		);
 	}
-} );
+}
+
+export default localize( TwoStep );

--- a/client/me/two-step/index.jsx
+++ b/client/me/two-step/index.jsx
@@ -5,7 +5,6 @@ import debugFactory from 'debug';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
-const debug = debugFactory( 'calypso:me:two-step' );
 
 /**
  * Internal dependencies
@@ -21,6 +20,8 @@ import Security2faDisable from 'me/security-2fa-disable';
 import Security2faSetup from 'me/security-2fa-setup';
 import SecuritySectionNav from 'me/security-section-nav';
 import twoStepAuthorization from 'lib/two-step-authorization';
+
+const debug = debugFactory( 'calypso:me:two-step' );
 
 class TwoStep extends Component {
 	static displayName = 'TwoStep';


### PR DESCRIPTION
Spun off from #17234. 

This PR aims to do the following:
- Fix linting errors that would inhibit commits ✊ 
- Transform CommonJS modules to ECMAScript modules 🎆 
- Uses `<DocumentHead />` instead of `setTitle` action for setting window title 📛 

#### Testing instructions

1. Check out locally (`git checkout modernize/client-me-security`) and start your server. You can also use a [live branch](https://calypso.live/?branch=modernize/client-me-security).
2. Verify that the following pages work identically to before this change:
    - [Password](http://calypso.localhost:3000/me/security)
    - [Two-step Auth](http://calypso.localhost:3000/me/security/two-step)
    - [Connected Apps](http://calypso.localhost:3000/me/security/connected-applications)
    - [Account Recovery](http://calypso.localhost:3000/me/security/account-recovery)

With the exception of `onUserSettingsChange` in `client/me/two-step/index.jsx`, functions have not been modified. 