### PR TITLE
Store: Small updates to setup flow

### DIFF
--- a/client/extensions/woocommerce/app/dashboard/required-plugins-install-view.js
+++ b/client/extensions/woocommerce/app/dashboard/required-plugins-install-view.js
@@ -83,7 +83,7 @@ class RequiredPluginsInstallView extends Component {
 	}
 
 	doInitialization = () => {
-		const { site, sitePlugins, translate, wporg } = this.props;
+		const { site, sitePlugins, wporg } = this.props;
 		const { workingOn } = this.state;
 
 		if ( ! site ) {
@@ -105,8 +105,8 @@ class RequiredPluginsInstallView extends Component {
 			}
 
 			this.setState( {
-				message: translate( 'Waiting for plugin list from site' ),
 				workingOn: 'WAITING_FOR_PLUGIN_LIST_FROM_SITE',
+				progress: 0,
 			} );
 			return;
 		}
@@ -134,8 +134,8 @@ class RequiredPluginsInstallView extends Component {
 			}
 
 			this.setState( {
-				message: translate( 'Loading plugin data' ),
 				workingOn: 'LOAD_PLUGIN_DATA',
+				progress: 0,
 			} );
 			return;
 		}
@@ -185,8 +185,7 @@ class RequiredPluginsInstallView extends Component {
 	}
 
 	doInstallation = () => {
-		const { site, sitePlugins, translate, wporg } = this.props;
-		const requiredPlugins = this.getRequiredPluginsList();
+		const { site, sitePlugins, wporg } = this.props;
 
 		// If we are working on nothing presently, get the next thing to install and install it
 		if ( 0 === this.state.workingOn.length ) {
@@ -215,7 +214,7 @@ class RequiredPluginsInstallView extends Component {
 			}
 
 			this.setState( {
-				message: translate( 'Installing %(plugin)s', { args: { plugin: requiredPlugins[ workingOn ] } } ),
+				message: '',
 				toInstall,
 				workingOn,
 			} );
@@ -233,8 +232,7 @@ class RequiredPluginsInstallView extends Component {
 	}
 
 	doActivation = () => {
-		const { site, sitePlugins, translate } = this.props;
-		const requiredPlugins = this.getRequiredPluginsList();
+		const { site, sitePlugins } = this.props;
 
 		// If we are working on nothing presently, get the next thing to activate and activate it
 		if ( 0 === this.state.workingOn.length ) {
@@ -268,7 +266,7 @@ class RequiredPluginsInstallView extends Component {
 			this.props.activatePlugin( site.ID, pluginToActivate );
 
 			this.setState( {
-				message: translate( 'Activating %(plugin)s', { args: { plugin: requiredPlugins[ workingOn ] } } ),
+				message: '',
 				toActivate,
 				workingOn,
 			} );
@@ -286,12 +284,12 @@ class RequiredPluginsInstallView extends Component {
 	}
 
 	doneSuccess = () => {
-		const { site, translate } = this.props;
+		const { site } = this.props;
 		this.props.setFinishedInstallOfRequiredPlugins( site.ID, true );
 
 		this.setState( {
 			engineState: 'IDLE',
-			message: translate( 'All required plugins are installed and activated' ),
+			progress: 100,
 		} );
 	}
 

--- a/client/extensions/woocommerce/app/dashboard/required-plugins-install-view.js
+++ b/client/extensions/woocommerce/app/dashboard/required-plugins-install-view.js
@@ -35,7 +35,7 @@ class RequiredPluginsInstallView extends Component {
 		super( props );
 		this.state = {
 			engineState: 'CONFIRMING',
-			message: '',
+			progress: 0,
 			toActivate: [],
 			toInstall: [],
 			workingOn: '',
@@ -158,7 +158,7 @@ class RequiredPluginsInstallView extends Component {
 		if ( toInstall.length ) {
 			this.setState( {
 				engineState: 'INSTALLING',
-				message: '',
+				progress: 25,
 				toActivate,
 				toInstall,
 				workingOn: '',
@@ -170,7 +170,7 @@ class RequiredPluginsInstallView extends Component {
 		if ( toActivate.length ) {
 			this.setState( {
 				engineState: 'ACTIVATING',
-				message: '',
+				progress: 50,
 				toActivate,
 				workingOn: '',
 				numTotalSteps,
@@ -180,7 +180,6 @@ class RequiredPluginsInstallView extends Component {
 
 		this.setState( {
 			engineState: 'DONESUCCESS',
-			message: '',
 		} );
 	}
 
@@ -195,7 +194,7 @@ class RequiredPluginsInstallView extends Component {
 			if ( 0 === toInstall.length ) {
 				this.setState( {
 					engineState: 'ACTIVATING',
-					message: '',
+					progress: 50,
 				} );
 				return;
 			}
@@ -214,7 +213,6 @@ class RequiredPluginsInstallView extends Component {
 			}
 
 			this.setState( {
-				message: '',
 				toInstall,
 				workingOn,
 			} );
@@ -242,7 +240,7 @@ class RequiredPluginsInstallView extends Component {
 			if ( 0 === toActivate.length ) {
 				this.setState( {
 					engineState: 'DONESUCCESS',
-					message: '',
+					progress: 100,
 				} );
 				return;
 			}
@@ -266,7 +264,6 @@ class RequiredPluginsInstallView extends Component {
 			this.props.activatePlugin( site.ID, pluginToActivate );
 
 			this.setState( {
-				message: '',
 				toActivate,
 				workingOn,
 			} );
@@ -374,9 +371,6 @@ class RequiredPluginsInstallView extends Component {
 					subtitle={ translate( 'Give us a minute and we\'ll move right along.' ) }
 				>
 					<ProgressBar value={ progress } isPulsing />
-					<p>
-						{ this.state.message }
-					</p>
 				</SetupHeader>
 			</div>
 		);

--- a/client/extensions/woocommerce/app/dashboard/required-plugins-install-view.js
+++ b/client/extensions/woocommerce/app/dashboard/required-plugins-install-view.js
@@ -35,7 +35,6 @@ class RequiredPluginsInstallView extends Component {
 		super( props );
 		this.state = {
 			engineState: 'CONFIRMING',
-			progress: 0,
 			toActivate: [],
 			toInstall: [],
 			workingOn: '',
@@ -106,7 +105,6 @@ class RequiredPluginsInstallView extends Component {
 
 			this.setState( {
 				workingOn: 'WAITING_FOR_PLUGIN_LIST_FROM_SITE',
-				progress: 0,
 			} );
 			return;
 		}
@@ -135,7 +133,6 @@ class RequiredPluginsInstallView extends Component {
 
 			this.setState( {
 				workingOn: 'LOAD_PLUGIN_DATA',
-				progress: 0,
 			} );
 			return;
 		}
@@ -158,7 +155,6 @@ class RequiredPluginsInstallView extends Component {
 		if ( toInstall.length ) {
 			this.setState( {
 				engineState: 'INSTALLING',
-				progress: 25,
 				toActivate,
 				toInstall,
 				workingOn: '',
@@ -170,7 +166,6 @@ class RequiredPluginsInstallView extends Component {
 		if ( toActivate.length ) {
 			this.setState( {
 				engineState: 'ACTIVATING',
-				progress: 50,
 				toActivate,
 				workingOn: '',
 				numTotalSteps,
@@ -194,7 +189,6 @@ class RequiredPluginsInstallView extends Component {
 			if ( 0 === toInstall.length ) {
 				this.setState( {
 					engineState: 'ACTIVATING',
-					progress: 50,
 				} );
 				return;
 			}
@@ -240,7 +234,6 @@ class RequiredPluginsInstallView extends Component {
 			if ( 0 === toActivate.length ) {
 				this.setState( {
 					engineState: 'DONESUCCESS',
-					progress: 100,
 				} );
 				return;
 			}
@@ -286,7 +279,6 @@ class RequiredPluginsInstallView extends Component {
 
 		this.setState( {
 			engineState: 'IDLE',
-			progress: 100,
 		} );
 	}
 

--- a/client/extensions/woocommerce/app/dashboard/setup-task.js
+++ b/client/extensions/woocommerce/app/dashboard/setup-task.js
@@ -93,9 +93,8 @@ class SetupTask extends Component {
 
 	render = () => {
 		const { actions, checked, explanation, label } = this.props;
-
 		return (
-			<div className="dashboard__setup-task">
+			<div className={ checked ? 'dashboard__setup-task is-checked' : 'dashboard__setup-task' }>
 				<div className="dashboard__setup-task-status">
 					{ checked ? <Gridicon icon="checkmark" size={ 36 } /> : null }
 				</div>

--- a/client/extensions/woocommerce/app/dashboard/setup-task.js
+++ b/client/extensions/woocommerce/app/dashboard/setup-task.js
@@ -45,6 +45,8 @@ class SetupTask extends Component {
 					primaryActions.map( ( action, index ) => {
 						// Only the last primary action gets to be a primary button
 						const primary = ( index === primaryActions.length - 1 ) && ! taskCompleted;
+						// Make buttons borderless if the task is completed
+						const borderless = taskCompleted;
 						const target = '/' === action.path.substring( 0, 1 ) ? '_self' : '_blank';
 						const trackClick = ( e ) => {
 							this.track( action.analyticsProp );
@@ -62,6 +64,7 @@ class SetupTask extends Component {
 								onClick={ trackClick }
 								key={ index }
 								primary={ primary }
+								borderless={ borderless }
 								target={ target }>
 								{ action.label }
 							</Button>

--- a/client/extensions/woocommerce/app/dashboard/setup-tasks.js
+++ b/client/extensions/woocommerce/app/dashboard/setup-tasks.js
@@ -143,7 +143,9 @@ class SetupTasks extends Component {
 				show: true,
 				actions: [
 					{
-						label: translate( 'Set up payments' ),
+						label: paymentsAreSetUp && (
+							translate( 'Review payments' )
+						) || translate( 'Set up payments' ),
 						path: getLink( '/store/settings/payments/:site', site ),
 						analyticsProp: 'set-up-payments',
 					}

--- a/client/extensions/woocommerce/app/dashboard/setup-tasks.js
+++ b/client/extensions/woocommerce/app/dashboard/setup-tasks.js
@@ -112,7 +112,7 @@ class SetupTasks extends Component {
 		return [
 			{
 				checked: hasProducts,
-				explanation: translate( 'Start by adding the first product to your store.' ),
+				explanation: translate( 'Start by adding the first product to your\u00a0store.' ),
 				label: translate( 'Add a product' ),
 				show: true,
 				actions: [
@@ -126,11 +126,11 @@ class SetupTasks extends Component {
 			{
 				checked: shippingIsSetUp,
 				explanation: translate( 'We\'ve set up shipping based on your store location.' ),
-				label: translate( 'Review shipping settings' ),
+				label: translate( 'Review shipping' ),
 				show: this.state.showShippingTask,
 				actions: [
 					{
-						label: translate( 'Review settings' ),
+						label: translate( 'Review shipping' ),
 						path: getLink( '/store/settings/shipping/:site', site ),
 						analyticsProp: 'set-up-shipping',
 					}
@@ -152,11 +152,11 @@ class SetupTasks extends Component {
 			{
 				checked: taxesAreSetUp,
 				explanation: translate( 'We\'ve set up automatic tax calculations for you.' ),
-				label: translate( 'Review tax settings' ),
+				label: translate( 'Review taxes' ),
 				show: true,
 				actions: [
 					{
-						label: translate( 'Review settings' ),
+						label: translate( 'Review taxes' ),
 						path: getLink( '/store/settings/taxes/:site', site ),
 						onClick: this.onClickTaxSettings,
 						analyticsProp: 'set-up-taxes',
@@ -170,7 +170,7 @@ class SetupTasks extends Component {
 				show: true,
 				actions: [
 					{
-						label: translate( 'Customize' ),
+						label: translate( 'View and customize' ),
 						path: getLink( 'https://:site/wp-admin/customize.php?return=' + encodeURIComponent( '//' + site.slug ), site ),
 						onClick: this.onClickOpenCustomizer,
 						analyticsProp: 'view-and-customize',

--- a/client/extensions/woocommerce/app/dashboard/setup-tasks.js
+++ b/client/extensions/woocommerce/app/dashboard/setup-tasks.js
@@ -113,11 +113,16 @@ class SetupTasks extends Component {
 			{
 				checked: hasProducts,
 				explanation: translate( 'Start by adding the first product to your\u00a0store.' ),
-				label: translate( 'Add a product' ),
+				label: hasProducts && (
+					( 1 === getTotalProducts() ) && (
+						translate( 'Product added' )
+					) || translate( 'Products added' )
+				) || translate( 'Add a product' ),
+
 				show: true,
 				actions: [
 					{
-						label: 'Add a product',
+						label: translate( 'Add a product' ),
 						path: getLink( '/store/product/:site', site ),
 						analyticsProp: 'add-product',
 					}
@@ -126,7 +131,9 @@ class SetupTasks extends Component {
 			{
 				checked: shippingIsSetUp,
 				explanation: translate( 'We\'ve set up shipping based on your store location.' ),
-				label: translate( 'Review shipping' ),
+				label: shippingIsSetUp && (
+					translate( 'Shipping is set up' )
+				) || translate( 'Review shipping' ),
 				show: this.state.showShippingTask,
 				actions: [
 					{
@@ -139,7 +146,9 @@ class SetupTasks extends Component {
 			{
 				checked: paymentsAreSetUp,
 				explanation: translate( 'Choose how you would like your customers to pay you.' ),
-				label: translate( 'Set up payments' ),
+				label: paymentsAreSetUp && (
+					translate( 'Payments are set up' )
+				) || translate( 'Review payments' ),
 				show: true,
 				actions: [
 					{
@@ -154,7 +163,9 @@ class SetupTasks extends Component {
 			{
 				checked: taxesAreSetUp,
 				explanation: translate( 'We\'ve set up automatic tax calculations for you.' ),
-				label: translate( 'Review taxes' ),
+				label: taxesAreSetUp && (
+					translate( 'Taxes are set up' )
+				) || translate( 'Review taxes' ),
 				show: true,
 				actions: [
 					{

--- a/client/extensions/woocommerce/app/dashboard/setup-tasks.js
+++ b/client/extensions/woocommerce/app/dashboard/setup-tasks.js
@@ -114,7 +114,7 @@ class SetupTasks extends Component {
 				checked: hasProducts,
 				explanation: translate( 'Start by adding the first product to your\u00a0store.' ),
 				label: hasProducts && (
-					( 1 === getTotalProducts() ) && (
+					( 1 === getTotalProducts ) && (
 						translate( 'Product added' )
 					) || translate( 'Products added' )
 				) || translate( 'Add a product' ),

--- a/client/extensions/woocommerce/app/dashboard/style.scss
+++ b/client/extensions/woocommerce/app/dashboard/style.scss
@@ -93,7 +93,7 @@
 		align-items: center;
 
 		&:before {
-			left: 48px;
+			left: 42px;
 		}
 	}
 
@@ -104,7 +104,7 @@
 
 	.dashboard__setup-task-status:empty {
 		background:  lighten( $gray, 30% );
-		border: 6px solid $white;
+		border: 4px solid $white;
 		box-sizing: border-box;
 	}
 
@@ -120,8 +120,8 @@
 		margin-top: 2px;
 
 		@include breakpoint( ">960px" ) {
-			height: 48px;
-			width: 48px;
+			height: 36px;
+			width: 36px;
 		}
 
 		.gridicon {
@@ -132,8 +132,8 @@
 
 			@include breakpoint( ">960px" ) {
 				padding: 6px;
-				height: 36px;
-				width: 36px;
+				height: 24px;
+				width: 24px;
 			}
 		}
 	}

--- a/client/extensions/woocommerce/app/dashboard/style.scss
+++ b/client/extensions/woocommerce/app/dashboard/style.scss
@@ -61,6 +61,11 @@
 				display: none;
 			}
 		}
+
+		@include breakpoint( ">480px" ) {
+			padding-top: 16px;
+			padding-bottom: 16px;
+		}
 	}
 
 	&:before {

--- a/client/extensions/woocommerce/app/dashboard/style.scss
+++ b/client/extensions/woocommerce/app/dashboard/style.scss
@@ -25,7 +25,7 @@
 		margin: 0 auto 24px;
 		max-width: 400px;
 	}
-	
+
 	.button {
 		margin-bottom: 8px;
 	}
@@ -37,24 +37,27 @@
 }
 
 .dashboard__setup-task {
-	padding: 24px;
-	margin-left: -24px;
-	margin-right: -24px;
+	padding: 16px;
+	margin-left: -16px;
+	margin-right: -16px;
 	border-top: 1px solid lighten( $gray, 30% );
 	display: flex;
 
+	@include breakpoint( ">480px" ) {
+		margin-left: -24px;
+		margin-right: -24px;
+		padding: 24px;
+	}
+
 	@include breakpoint( ">960px" ) {
-		margin-left: -32px;
-		margin-right: -32px;
-		padding: 24px 32px;
 		align-items: center;
 	}
-	
+
 	.dashboard__setup-task-status:not(.dashboard__setup-task-status .gridicon){
 		background-color: black;
 		color: black;
 	}
-	
+
 	.dashboard__setup-task-status:empty {
 		background:  lighten( $alert-green, 35% );
 		border:  1px solid lighten( $alert-green, 20% );
@@ -100,7 +103,7 @@
 
 	.dashboard__setup-task-label {
 		flex: 2;
-		
+
 		h2 {
 			color: $gray-text;
 			font-size: 20px;

--- a/client/extensions/woocommerce/app/dashboard/style.scss
+++ b/client/extensions/woocommerce/app/dashboard/style.scss
@@ -22,13 +22,18 @@
 
 	.dashboard__setup-header-subtitle {
 		color: $gray;
-		margin: 0 auto 32px;
-		max-width: 450px;
+		margin: 0 auto 24px;
+		max-width: 400px;
+	}
+	
+	.button {
+		margin-bottom: 8px;
 	}
 }
 
 .dashboard__setup-confirm .dashboard__setup-header-subtitle {
 	color: $gray-dark;
+	max-width: 490px;
 }
 
 .dashboard__setup-task {
@@ -44,15 +49,25 @@
 		padding: 24px 32px;
 		align-items: center;
 	}
+	
+	.dashboard__setup-task-status:not(.dashboard__setup-task-status .gridicon){
+		background-color: black;
+		color: black;
+	}
+	
+	.dashboard__setup-task-status:empty {
+		background:  lighten( $alert-green, 35% );
+		border:  1px solid lighten( $alert-green, 20% );
+	}
 
 	.dashboard__setup-task-status {
-		background:  lighten( $gray, 30% );
-		border:  1px solid lighten( $gray, 20% );
+		background:  $alert-green;
+		border:  1px solid darken( $alert-green, 10% );
 		height: 24px;
 		text-align: center;
 		width: 24px;
 		flex-shrink: 0;
-		border-radius: 4px;
+		border-radius: 100%;
 		margin-right: 24px;
 		margin-top: 2px;
 
@@ -66,6 +81,7 @@
 			height: 18px;
 			width: 18px;
 			padding: 3px;
+			color: $white;
 
 			@include breakpoint( ">960px" ) {
 				padding: 6px;
@@ -83,6 +99,8 @@
 	}
 
 	.dashboard__setup-task-label {
+		flex: 2;
+		
 		h2 {
 			color: $gray-text;
 			font-size: 20px;

--- a/client/extensions/woocommerce/app/dashboard/style.scss
+++ b/client/extensions/woocommerce/app/dashboard/style.scss
@@ -48,9 +48,17 @@
 		background: lighten( $gray, 35% );
 
 		.dashboard__setup-task-label {
-			h2,
+			h2 {
+				color: $gray-text-min;
+				margin-bottom: 6px;
+
+				@include breakpoint( ">960px" ) {
+					margin-bottom: 0;
+				}
+			}
+
 			p {
-				color: $gray;
+				display: none;
 			}
 		}
 	}
@@ -109,7 +117,6 @@
 		@include breakpoint( ">960px" ) {
 			height: 48px;
 			width: 48px;
-			margin-top: -8px;
 		}
 
 		.gridicon {
@@ -130,6 +137,7 @@
 		@include breakpoint( ">960px" ) {
 			display: flex;
 			align-items: center;
+			width: 100%;
 		}
 	}
 

--- a/client/extensions/woocommerce/app/dashboard/style.scss
+++ b/client/extensions/woocommerce/app/dashboard/style.scss
@@ -16,13 +16,13 @@
 	}
 
 	.dashboard__setup-header-title {
-		margin: 0 auto 12px;
+		margin: 0 auto 6px;
 		max-width: 450px;
 	}
 
 	.dashboard__setup-header-subtitle {
-		color: $gray;
-		margin: 0 auto 24px;
+		color: $gray-text-min;
+		margin: 0 auto 32px;
 		max-width: 400px;
 	}
 

--- a/client/extensions/woocommerce/app/dashboard/style.scss
+++ b/client/extensions/woocommerce/app/dashboard/style.scss
@@ -42,15 +42,46 @@
 	margin-right: -16px;
 	border-top: 1px solid lighten( $gray, 30% );
 	display: flex;
+	position: relative;
+
+	&.is-checked {
+		background: lighten( $gray, 35% );
+
+		.dashboard__setup-task-label {
+			h2,
+			p {
+				color: $gray;
+			}
+		}
+	}
+
+	&:before {
+		content: "";
+		display: block;
+		position: absolute;
+		top: 0;
+		left: 27px;
+		bottom: 0;
+		width: 1px;
+		background: lighten( $gray, 30% );
+	}
 
 	@include breakpoint( ">480px" ) {
 		margin-left: -24px;
 		margin-right: -24px;
 		padding: 24px;
+
+		&:before {
+			left: 36px;
+		}
 	}
 
 	@include breakpoint( ">960px" ) {
 		align-items: center;
+
+		&:before {
+			left: 48px;
+		}
 	}
 
 	.dashboard__setup-task-status:not(.dashboard__setup-task-status .gridicon){
@@ -59,18 +90,19 @@
 	}
 
 	.dashboard__setup-task-status:empty {
-		background:  lighten( $alert-green, 35% );
-		border:  1px solid lighten( $alert-green, 20% );
+		background:  lighten( $gray, 30% );
+		border: 6px solid $white;
+		box-sizing: border-box;
 	}
 
 	.dashboard__setup-task-status {
 		background:  $alert-green;
-		border:  1px solid darken( $alert-green, 10% );
 		height: 24px;
 		text-align: center;
 		width: 24px;
 		flex-shrink: 0;
 		border-radius: 100%;
+		z-index: 3;
 		margin-right: 24px;
 		margin-top: 2px;
 
@@ -110,7 +142,7 @@
 		}
 
 		p {
-			color: $gray;
+			color: $gray-text-min;
 			font-size: 14px;
 			margin-bottom: 12px;
 		}

--- a/client/extensions/woocommerce/app/dashboard/style.scss
+++ b/client/extensions/woocommerce/app/dashboard/style.scss
@@ -49,7 +49,7 @@
 
 		.dashboard__setup-task-label {
 			h2 {
-				color: $gray-text-min;
+				color: darken( $gray, 25% );
 				margin-bottom: 6px;
 
 				@include breakpoint( ">960px" ) {

--- a/client/extensions/woocommerce/app/dashboard/style.scss
+++ b/client/extensions/woocommerce/app/dashboard/style.scss
@@ -179,6 +179,14 @@
 				@include breakpoint( ">960px" ) {
 					margin: 2px 0 2px 8px;
 				}
+
+				&.is-borderless {
+					color: $blue-wordpress;
+
+					&:hover {
+						color: $link-highlight;
+					}
+				}
 			}
 		}
 


### PR DESCRIPTION
- Remove plugin names and labels during plugin installation phase of setup. (Only show loading bar)
- Remove all the orphans on: initial landing page and setup dashboard
- Made checkboxes in setup dashboard more fun and celebratory
- Update copy in setup dashboard to be more consistent 

To test: run through setup (First time clicking on the Store nav to performing at least one task in the setup dashboard) and make sure everything looks and works as expected.

Biggest change is to the setup dashboard: 

![screen shot 2017-08-18 at 11 09 23 am](https://user-images.githubusercontent.com/5835847/29469488-b913d5e0-8405-11e7-95dd-392e9802796b.png)