### PR TITLE
WPSC: Fix broken Navigation links

### DIFF
--- a/client/extensions/wp-super-cache/app/controller.js
+++ b/client/extensions/wp-super-cache/app/controller.js
@@ -11,13 +11,11 @@ import analytics from 'lib/analytics';
 import titlecase from 'to-title-case';
 import { getSiteFragment, sectionify } from 'lib/route';
 import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
-import { getSelectedSite } from 'state/ui/selectors';
 import { renderWithReduxStore } from 'lib/react-helpers';
 import WPSuperCache from './main';
 
 export function settings( context ) {
 	const siteId = getSiteFragment( context.path );
-	const site = getSelectedSite( context.store.getState() );
 	const { tab = '' } = context.params;
 
 	context.store.dispatch( setTitle( i18n.translate( 'WP Super Cache', { textOnly: true } ) ) );
@@ -42,11 +40,7 @@ export function settings( context ) {
 	analytics.pageView.record( baseAnalyticsPath, analyticsPageTitle );
 
 	renderWithReduxStore(
-		React.createElement( WPSuperCache, {
-			context,
-			site,
-			tab,
-		} ),
+		<WPSuperCache tab={ tab } />,
 		document.getElementById( 'primary' ),
 		context.store
 	);

--- a/client/extensions/wp-super-cache/app/main.jsx
+++ b/client/extensions/wp-super-cache/app/main.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
@@ -26,7 +27,6 @@ import { getStatus } from '../state/status/selectors';
 class WPSuperCache extends Component {
 	static propTypes = {
 		status: PropTypes.object.isRequired,
-		site: PropTypes.object,
 		siteId: PropTypes.number,
 		tab: PropTypes.string,
 	};
@@ -56,7 +56,6 @@ class WPSuperCache extends Component {
 
 	render() {
 		const {
-			site,
 			siteId,
 			status: { cache_disabled: cacheDisabled },
 			tab,
@@ -78,7 +77,7 @@ class WPSuperCache extends Component {
 					text={ translate( 'Read Only Mode. Configuration cannot be changed.' ) } />
 				}
 
-				<Navigation activeTab={ tab } site={ site } />
+				<Navigation activeTab={ tab } siteId={ siteId } />
 				{ this.renderTab( !! cacheDisabled ) }
 			</Main>
 		);
@@ -91,7 +90,7 @@ const connectComponent = connect(
 
 		return {
 			status: getStatus( state, siteId ),
-			siteId,
+			siteId
 		};
 	}
 );

--- a/client/extensions/wp-super-cache/components/navigation/index.jsx
+++ b/client/extensions/wp-super-cache/components/navigation/index.jsx
@@ -1,8 +1,9 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
-import { get } from 'lodash';
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -13,9 +14,10 @@ import SectionNav from 'components/section-nav';
 import SectionNavTabs from 'components/section-nav/tabs';
 import SectionNavTabItem from 'components/section-nav/item';
 import { addSiteFragment } from 'lib/route/path';
+import { getSiteSlug } from 'state/sites/selectors';
 import { Tabs } from '../../app/constants';
 
-const Navigation = ( { activeTab, site, translate } ) => {
+const Navigation = ( { activeTab, siteSlug, translate } ) => {
 	const getLabel = tab => {
 		switch ( tab ) {
 			case Tabs.EASY:
@@ -53,14 +55,10 @@ const Navigation = ( { activeTab, site, translate } ) => {
 				path = `${ path }/${ tab }`;
 			}
 
-			if ( site ) {
-				path += `/${ site.slug }`;
-			}
-
 			return (
 				<SectionNavTabItem
 					key={ `wp-super-cache-${ tab }` }
-					path={ path }
+					path={ siteSlug && addSiteFragment( path, siteSlug ) }
 					selected={ ( activeTab || Tabs.EASY ) === tab }>
 					{ getLabel( tab ) }
 				</SectionNavTabItem>
@@ -68,11 +66,11 @@ const Navigation = ( { activeTab, site, translate } ) => {
 		} );
 	};
 
-	const pluginUrl = addSiteFragment( '/plugins/wp-super-cache', get( site, 'slug' ) );
+	const pluginPath = '/plugins/wp-super-cache';
 	return (
 		<div>
 			<HeaderCake backText={ translate( 'Plugin Overview' ) }
-				backHref={ pluginUrl }>
+				backHref={ siteSlug && addSiteFragment( pluginPath, siteSlug ) }>
 				WP Super Cache
 			</HeaderCake>
 			<SectionNav selectedText="Settings">
@@ -86,7 +84,9 @@ const Navigation = ( { activeTab, site, translate } ) => {
 
 Navigation.propTypes = {
 	activeTab: PropTypes.string,
-	site: PropTypes.object,
+	siteId: PropTypes.number,
+	// connected props
+	siteSlug: PropTypes.string,
 	translate: PropTypes.func.isRequired,
 };
 
@@ -94,4 +94,10 @@ Navigation.defaultProps = {
 	activeTab: '',
 };
 
-export default localize( Navigation );
+const connectComponent = connect(
+	( state, { siteId } ) => ( {
+		siteSlug: getSiteSlug( state, siteId )
+	} )
+);
+
+export default connectComponent( localize( Navigation ) );


### PR DESCRIPTION
Fixes https://horizonfeedback.wordpress.com/2017/08/17/call-for-testing-calypso-wp-super-cache-extension/#comment-389.

The issue here was that we were relying on `site` being fetched from `state` in the controller, as opposed to inside a React component. The problem with that is that unlike a React component, the controller, like any other vanilla JS function, is called only once (and in this case, before sites data has been fetched and stored in state) -- as opposed to a `connect()`ed React component, which is conveniently re-rendered once state updates (when sites data has been fetched).

The fix is to do just that, and to disable the `<SectionNavTabItem />`'s `path` prop while `siteSlug` is falsey, so it simply can't be clicked while no site data is available. (Same for `<HeaderCake />`'s `backHref`.)

To test:
* Clean IndexedDb, and reload the extension. Links in the Navigation tab ('Easy', 'Advanced', 'CDN', 'Contents', etc) shouldn't be clickable for a brief while. Afterwards, they should point to the correct destinations. (Click them to verify.)