### PR TITLE
Add getStartMoment to handle month site-time parsing

### DIFF
--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -107,18 +107,7 @@ class ActivityLog extends Component {
 			return moment.tz( startDate, timezone );
 		}
 		if ( null !== gmtOffset ) {
-			const time = 'T00:00:00';
-			let offset = 'Z';
-			let pad = '';
-			let sign = '';
-
-			if ( 0 !== gmtOffset ) {
-				offset = `${ Math.abs( gmtOffset ) }`;
-				pad = 10 > Math.abs( gmtOffset ) ? '0' : '';
-				sign = 0 > gmtOffset ? '-' : '+';
-			}
-
-			return moment( `${ startDate }${ time }${ sign }${ pad }${ offset }` );
+			return moment.utc( startDate ).subtract( gmtOffset, 'hours' ).utcOffset( gmtOffset );
 		}
 		return moment.utc( startDate );
 	}

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -292,8 +292,8 @@ class ActivityLog extends Component {
 
 		// loop backwards through each day in the month
 		for (
-			const m = this.applySiteOffset( moment.utc( startDate ) ).endOf( 'month' ).startOf( 'day' ),
-				startOfMonth = this.applySiteOffset( moment.utc( startDate ) ).startOf( 'month' ).valueOf();
+			const m = startMoment.endOf( 'month' ).startOf( 'day' ),
+				startOfMonth = startMoment.startOf( 'month' ).valueOf();
 			startOfMonth <= m.valueOf();
 			m.subtract( 1, 'day' )
 		) {

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -98,17 +98,18 @@ class ActivityLog extends Component {
 	getStartMoment() {
 		const { gmtOffset, moment, startDate, timezone } = this.props;
 
-		// Use current site time if no startDate is supplied
-		if ( ! startDate ) {
-			return this.applySiteOffset( moment(), true );
-		}
-
 		if ( timezone ) {
+			if ( ! startDate ) {
+				return moment().tz( timezone );
+			}
+
 			return moment.tz( startDate, timezone );
 		}
+
 		if ( null !== gmtOffset ) {
 			return moment.utc( startDate ).subtract( gmtOffset, 'hours' ).utcOffset( gmtOffset );
 		}
+
 		return moment.utc( startDate );
 	}
 
@@ -281,8 +282,8 @@ class ActivityLog extends Component {
 
 		// loop backwards through each day in the month
 		for (
-			const m = startMoment.endOf( 'month' ).startOf( 'day' ),
-				startOfMonth = startMoment.startOf( 'month' ).valueOf();
+			const m = startMoment.clone().endOf( 'month' ).startOf( 'day' ),
+				startOfMonth = startMoment.clone().startOf( 'month' ).valueOf();
 			startOfMonth <= m.valueOf();
 			m.subtract( 1, 'day' )
 		) {
@@ -311,8 +312,7 @@ class ActivityLog extends Component {
 
 	renderMonthNavigation( position ) {
 		const { slug } = this.props;
-		const startMoment = this.getStartMoment();
-		const startOfMonth = startMoment.startOf( 'month' );
+		const startOfMonth = this.getStartMoment().startOf( 'month' );
 		const query = {
 			period: 'month',
 			date: startOfMonth.format( 'YYYY-MM-DD' ),

--- a/client/my-sites/stats/controller.jsx
+++ b/client/my-sites/stats/controller.jsx
@@ -383,7 +383,9 @@ module.exports = {
 		const state = context.store.getState();
 		const siteId = getSelectedSiteId( state );
 		const isJetpack = isJetpackSite( state, siteId );
-		const { startDate } = context.query;
+		const startDate = i18n.moment( context.query.startDate, 'YYYY-MM-DD' ).isValid()
+			? context.query.startDate
+			: undefined;
 
 		if ( siteId && ! isJetpack ) {
 			page.redirect( '/stats' );

--- a/client/state/data-layer/wpcom/sites/activity/index.js
+++ b/client/state/data-layer/wpcom/sites/activity/index.js
@@ -2,6 +2,7 @@
 /**
  * External dependencies
  */
+import debugFactory from 'debug';
 import { get, includes, pick, reduce } from 'lodash';
 
 /**
@@ -16,6 +17,7 @@ import { activityLogError, activityLogUpdate } from 'state/activity-log/actions'
 /**
  * Module constants
  */
+const debug = debugFactory( 'calypso:data-layer:activity' );
 const CALYPSO_TO_API_PARAMS = {
 	dateEnd: 'date_end',
 	dateStart: 'date_start',
@@ -41,6 +43,8 @@ export const handleActivityLogRequest = ( { dispatch }, action ) => {
 		},
 		{}
 	);
+
+	debug( 'Handling activity request', query );
 
 	dispatch(
 		http(


### PR DESCRIPTION
@enejb reported that monthly navigation was not working correctly in #17285. This was related to the way dates were being parsed.

This PR adds a method `getStartDate` to the activity log which improves parsing of these site-time dates.

It also adds date string validation to the controller to ensure that invalid dates are not passed to the component.

## Testing
1. Visit https://calypso.live/stats/activity?branch=fix/17285-bad-date-parsing
1. Navigate months
1. Ensure the query is correct for _site-time_ month start and end
   * See queries by executing `localStorage.setItem( 'debug', 'calypso:data-layer:activity' )` in the console.
   * Debug dates timestamps by running `new Date( 1501570799999 ).toISOString()` to see a human readable date.

Make sure you test conditions on a site with an offset (`UTC-8`) and with a timezone (`Los Angeles`) in `/wp-admin/options-general.php`. Also test with the date string present (`startDate=2017-09-01`) and no string.

Fixes #17285 