### PR TITLE
Activity log: Fix gmtOffset date display handling

### DIFF
--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -366,7 +366,7 @@ export default connect(
 			siteId,
 			siteTitle: getSiteTitle( state, siteId ),
 			slug: getSiteSlug( state, siteId ),
-			timezone: getSiteTimezoneValue( state, siteId ),
+			timezone: null, //getSiteTimezoneValue( state, siteId ),
 
 			// FIXME: Testing only
 			isPressable: get( state.activityLog.rewindStatus, [ siteId, 'isPressable' ], null ),


### PR DESCRIPTION
# DO NOT MERGE
## This is a demonstration PR

ATM this PR is meant to exhibit a bug detected when displaying `gmtOffset` dates (no `timezone` provided).