### PR TITLE
Login: Update the OAuth login form to match the Woo styles

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -149,9 +149,10 @@ class Login extends Component {
 				);
 				postHeader = (
 					<p>
-						{ translate( 'WooCommerce.com now uses WordPress.com Accounts. {{a}}Learn more about the benefits{{/a}}', {
+						{ translate( 'WooCommerce.com now uses WordPress.com Accounts.{{br/}}{{a}}Learn more about the benefits{{/a}}', {
 							components: {
-								a: <a href="https://woocommerce.com/2017/01/woocommerce-requires-wordpress-account/" />
+								a: <a href="https://woocommerce.com/2017/01/woocommerce-requires-wordpress-account/" />,
+								br: <br />,
 							}
 						} ) }
 					</p>

--- a/client/layout/masterbar/oauth-client.jsx
+++ b/client/layout/masterbar/oauth-client.jsx
@@ -18,14 +18,20 @@ const OauthClientMasterbar = ( { oauth2ClientData } ) => (
 					</a>
 				</li>
 			</ul>
-			<ul className="masterbar__oauth-client-user-nav">
-				<li className="masterbar__oauth-client-wpcc-sign-in">
-					<a href="https://wordpress.com/" className="masterbar__oauth-client-wpcom">
-						<Gridicon icon="my-sites" size={ 24 } />
-						WordPress.com
-					</a>
+			{ oauth2ClientData.name === 'woo' ? (
+				<li className="masterbar__oauth-client-close">
+					<a href="https://woocommerce.com">Cancel <span>X</span></a>
 				</li>
-			</ul>
+			) : (
+				<ul className="masterbar__oauth-client-user-nav">
+					<li className="masterbar__oauth-client-wpcc-sign-in">
+						<a href="https://wordpress.com/" className="masterbar__oauth-client-wpcom">
+							<Gridicon icon="my-sites" size={ 24 } />
+							WordPress.com
+						</a>
+					</li>
+				</ul>
+			) }
 		</nav>
 	</header>
 );

--- a/client/layout/masterbar/oauth-client.scss
+++ b/client/layout/masterbar/oauth-client.scss
@@ -59,6 +59,11 @@
 		color: #fff;
 	}
 
+	&:visited {
+		color: rgba(255, 255, 255, 0.8);
+	}
+
+
 	.gridicon {
 		margin-bottom: 5px;
 		margin-right: 5px;
@@ -73,13 +78,15 @@
 }
 
 .woo {
+	background: #e6e6e6;
+
 	.layout__content {
-		padding-top: 100px;
+		padding-top: 150px;
 	}
 
 	.masterbar__oauth-client {
 		background-color: #fff;
-		border: none;
+		border: 1px solid #d3d3d3;
 		box-sizing: border-box;
 		height: 83px;
 		line-height: 83px;
@@ -106,22 +113,19 @@
 		margin: 0;
 	}
 
-	.masterbar__oauth-client-wpcc-sign-in {
-		background-color: rgba(0, 0, 0, 0.15);
-		display: block;
-		top: 14px;
+	.masterbar__oauth-client-close {
+		float: right;
+		padding-top: 13px;
 
-		&:hover {
-			background-color: rgba(0, 0, 0, 0.2);
+		a {
+			color: #999;
+			cursor: pointer;
+			float: right;
+			font-size: 0.9em;
+			text-decoration: none;
+			text-transform: uppercase;
+			font-weight: bold;
 		}
-
-		@include breakpoint( "<480px" ) {
-			display: none;
-		}
-	}
-
-	a.masterbar__oauth-client-wpcom {
-		color: #000;
 	}
 
 	.button.is-primary {
@@ -139,6 +143,11 @@
 		&:focus {
 			background: #696969;
 		}
+	}
+
+	button {
+		float: none;
+		max-width: 300px;
 	}
 
 	input[type='text'],
@@ -168,6 +177,39 @@
 	}
 
 	.login__form-header-wrapper {
+		text-align: center;
+	}
+
+	.login__form-action,
+	.login__social-buttons {
+		text-align: center;
+	}
+
+	.wp-login__main.main {
+		background: #fff;
+		border: 1px solid #d3d3d3;
+    	border-radius: 5px;
+    	box-sizing: border-box;
+		max-width: 778px;
+		padding: 20px 100px;
+		width: 100%;
+	}
+
+	.card {
+		box-shadow: none;
+		padding-left: 0;
+		padding-right: 0;
+	}
+
+	.login__form-userdata label {
+		font-size: 16px;
+		font-weight: normal;
+	}
+
+	.wp-login__links a {
+		border: none;
+		font-size: 16px;
+		font-weight: normal;
 		text-align: center;
 	}
 }


### PR DESCRIPTION
This pull request updates the Woo version of the OAuth login to match the old one:

Old:
<img width="997" alt="screen shot 2017-08-18 at 10 52 29" src="https://user-images.githubusercontent.com/275961/29453984-79e4fb62-8403-11e7-9bc5-e709d7b6875c.png">

New:
<img width="998" alt="screen shot 2017-08-18 at 10 52 50" src="https://user-images.githubusercontent.com/275961/29453990-7cdd0602-8403-11e7-80bc-23fd8d7d3037.png">
  
#### Testing instructions
  
1. Run `git checkout [branch]` and start your server, or open a [live branch](https://delphin.live/?branch=[branch])
2. Open the [`Home` page](http://delphin.localhost:1337/)
3. Check that [...]
 
#### Reviews
  
- [x] Code
- [x] Product