### PR TITLE
Activity Log: Add month navigation to bottom

### DIFF
--- a/client/lib/scroll-to/README.md
+++ b/client/lib/scroll-to/README.md
@@ -6,7 +6,7 @@ A utility module to smoothly scroll to a window position.
 ## Usage
 
 ```es6
-import scrollTo from 'lib/scroll-to'; 
+import scrollTo from 'lib/scroll-to';
 
 scrollTo( {
 	x: 400,

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -327,6 +327,7 @@ class ActivityLog extends Component {
 				{ this.renderBanner() }
 				{ ! isRewindActive && !! isPressable && <ActivityLogRewindToggle siteId={ siteId } /> }
 				{ this.renderLogs() }
+				{ this.renderMonthNavigation() }
 
 				<ActivityLogConfirmDialog
 					applySiteOffset={ applySiteOffset }

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -5,6 +5,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import debugFactory from 'debug';
+import scrollTo from 'lib/scroll-to';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { get, groupBy, includes, isEmpty, isNull, map } from 'lodash';
@@ -101,7 +102,11 @@ class ActivityLog extends Component {
 	};
 
 	handlePeriodChangeBottom = ( ...args ) => {
-		window.scrollTo( 0, 0 );
+		scrollTo( {
+			x: 0,
+			y: 0,
+			duration: 250,
+		} );
 		this.handlePeriodChange( ...args );
 	};
 

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -100,6 +100,11 @@ class ActivityLog extends Component {
 		} );
 	};
 
+	handlePeriodChangeBottom = ( ...args ) => {
+		window.scrollTo( 0, 0 );
+		this.handlePeriodChange( ...args );
+	};
+
 	handleRequestRestore = ( requestedRestoreTimestamp, from ) => {
 		this.props.recordTracksEvent( 'calypso_activitylog_restore_request', {
 			from,
@@ -282,7 +287,7 @@ class ActivityLog extends Component {
 		];
 	}
 
-	renderMonthNavigation() {
+	renderMonthNavigation( position ) {
 		const { moment, slug, startDate } = this.props;
 		const startOfMonth = moment.utc( startDate ).startOf( 'month' );
 		const query = {
@@ -292,7 +297,9 @@ class ActivityLog extends Component {
 		return (
 			<StatsPeriodNavigation
 				date={ startOfMonth }
-				onPeriodChange={ this.handlePeriodChange }
+				onPeriodChange={
+					position === 'bottom' ? this.handlePeriodChangeBottom : this.handlePeriodChange
+				}
 				period="month"
 				url={ `/stats/activity/${ slug }` }
 			>
@@ -327,7 +334,7 @@ class ActivityLog extends Component {
 				{ this.renderBanner() }
 				{ ! isRewindActive && !! isPressable && <ActivityLogRewindToggle siteId={ siteId } /> }
 				{ this.renderLogs() }
-				{ this.renderMonthNavigation() }
+				{ this.renderMonthNavigation( 'bottom' ) }
 
 				<ActivityLogConfirmDialog
 					applySiteOffset={ applySiteOffset }


### PR DESCRIPTION
Add month navigation to bottom

## Testing
1. Visit https://calypso.live/stats/activity?branch=add/activitylog/17298-monthpicker-bottom
1. Navigate with the top and bottom month pickers!

## Screens

Showing empty views because the top and bottom fit 🙂 

### Before

![before](https://user-images.githubusercontent.com/841763/29456272-3b51d3ea-8415-11e7-8131-b19a47be446d.png)

### After

![after](https://user-images.githubusercontent.com/841763/29456228-12a1ff9c-8415-11e7-8ca5-e301bf7d9546.png)

Fixes #17298 