### PR TITLE
Activity log: Update today view

### DIFF
--- a/client/components/foldable-card/README.md
+++ b/client/components/foldable-card/README.md
@@ -36,7 +36,7 @@ render: function() {
 * `compact`: a boolean indicating if the foldable card is compact
 * `disabled`: boolean indicating if the component it's not interactive
 * `expandedSummary`: string or component to show next to the action button when expanded
-* `expanded`: boolean indicating if the component is expanded
+* `expanded`: boolean indicating whether the component should be expanded initially
 * `onClick`: function to be executed in addition to the expand action when the header is clicked
 * `onClose`: function to be executed in addition to the expand action when the card is closed
 * `onOpen`: function to be executed in addition to the expand action when the card is opened

--- a/client/my-sites/stats/activity-log-day/index.jsx
+++ b/client/my-sites/stats/activity-log-day/index.jsx
@@ -103,15 +103,20 @@ class ActivityLogDay extends Component {
 	getEventsHeading() {
 		const {
 			applySiteOffset,
+			isToday,
 			logs,
 			moment,
 			translate,
 			tsEndOfSiteDay,
 		} = this.props;
 
+		const formattedDate = applySiteOffset( moment.utc( tsEndOfSiteDay ) ).format( 'LL' );
+
 		return (
 			<div>
-				<div className="activity-log-day__day">{ applySiteOffset( moment.utc( tsEndOfSiteDay ) ).format( 'LL' ) }</div>
+				<div className="activity-log-day__day">
+					{ isToday ? translate( '%s — Today', { args: formattedDate } ) : formattedDate }
+				</div>
 				<div className="activity-log-day__events">{
 					translate( '%d Event', '%d Events', {
 						args: logs.length,

--- a/client/my-sites/stats/activity-log-day/index.jsx
+++ b/client/my-sites/stats/activity-log-day/index.jsx
@@ -127,6 +127,7 @@ class ActivityLogDay extends Component {
 			applySiteOffset,
 			disableRestore,
 			hideRestore,
+			isToday,
 			logs,
 			requestRestore,
 			siteId,
@@ -136,6 +137,7 @@ class ActivityLogDay extends Component {
 			<div className="activity-log-day">
 				<FoldableCard
 					clickableHeader
+					expanded={ isToday }
 					expandedSummary={ this.getRewindButton() }
 					header={ this.getEventsHeading() }
 					onOpen={ this.trackOpenDay }

--- a/client/my-sites/stats/activity-log-day/index.jsx
+++ b/client/my-sites/stats/activity-log-day/index.jsx
@@ -74,9 +74,10 @@ class ActivityLogDay extends Component {
 		const {
 			disableRestore,
 			hideRestore,
+			isToday,
 		} = this.props;
 
-		if ( hideRestore ) {
+		if ( hideRestore || isToday ) {
 			return null;
 		}
 

--- a/client/my-sites/stats/activity-log-day/index.jsx
+++ b/client/my-sites/stats/activity-log-day/index.jsx
@@ -167,11 +167,12 @@ class ActivityLogDay extends Component {
 }
 
 export default connect(
-	( state, { tsEndOfSiteDay } ) => ( {
-		isToday:
-			Date.now() <= tsEndOfSiteDay &&
-			tsEndOfSiteDay - DAY_IN_MILLISECONDS <= Date.now(),
-	} ),
+	( state, { tsEndOfSiteDay } ) => {
+		const now = Date.now();
+		return {
+			isToday: now <= tsEndOfSiteDay && tsEndOfSiteDay - DAY_IN_MILLISECONDS <= now,
+		};
+	},
 	{
 		recordTracksEvent: recordTracksEventAction,
 	}

--- a/client/my-sites/stats/activity-log-day/index.jsx
+++ b/client/my-sites/stats/activity-log-day/index.jsx
@@ -14,6 +14,11 @@ import Button from 'components/button';
 import FoldableCard from 'components/foldable-card';
 import { recordTracksEvent as recordTracksEventAction } from 'state/analytics/actions';
 
+/**
+ * Module constants
+ */
+const DAY_IN_MILLISECONDS = 1000 * 60 * 60 * 24;
+
 class ActivityLogDay extends Component {
 	static propTypes = {
 		applySiteOffset: PropTypes.func.isRequired,
@@ -26,6 +31,7 @@ class ActivityLogDay extends Component {
 		tsEndOfSiteDay: PropTypes.number.isRequired,
 
 		// Connected props
+		isToday: PropTypes.bool.isRequired,
 		recordTracksEvent: PropTypes.func.isRequired,
 	};
 
@@ -152,6 +158,13 @@ class ActivityLogDay extends Component {
 	}
 }
 
-export default connect( null, {
-	recordTracksEvent: recordTracksEventAction,
-} )( localize( ActivityLogDay ) );
+export default connect(
+	( state, { tsEndOfSiteDay } ) => ( {
+		isToday:
+			Date.now() <= tsEndOfSiteDay &&
+			tsEndOfSiteDay - DAY_IN_MILLISECONDS <= Date.now(),
+	} ),
+	{
+		recordTracksEvent: recordTracksEventAction,
+	}
+)( localize( ActivityLogDay ) );

--- a/client/my-sites/stats/activity-log-day/index.jsx
+++ b/client/my-sites/stats/activity-log-day/index.jsx
@@ -116,7 +116,13 @@ class ActivityLogDay extends Component {
 		return (
 			<div>
 				<div className="activity-log-day__day">
-					{ isToday ? translate( '%s — Today', { args: formattedDate } ) : formattedDate }
+					{ isToday
+						? translate( '%s — Today', {
+							args: formattedDate,
+							comment: 'Long date with today indicator, i.e. "January 1, 2017 — Today"',
+						} )
+						: formattedDate
+					}
 				</div>
 				<div className="activity-log-day__events">{
 					translate( '%d Event', '%d Events', {


### PR DESCRIPTION
- Expand current day by default.
- Add " — Today" to current day.
- Hide Rewind button on current day. Note, this removes the vertical separator before the caret which is normal `FoldableCard` behavior.
- Improve README on `FoldableCard.expanded` prop.

## Testing
* Visit https://calypso.live/stats/activity?branch=update/activitylog/today-view
* Confirm the changes I've described work well!

## Screens

### Before

![before](https://user-images.githubusercontent.com/841763/29457281-d0294468-8419-11e7-9b51-43b3ef63d9d1.png)

### After

![after](https://user-images.githubusercontent.com/841763/29457286-d334cefc-8419-11e7-868c-401d461dfcd6.png)

Fixes #17293
Fixes #17299