### PR TITLE
Sibyl: track contact after clicking on question

### DIFF
--- a/client/me/help/help-contact-form/index.jsx
+++ b/client/me/help/help-contact-form/index.jsx
@@ -135,8 +135,21 @@ export const HelpContactForm = React.createClass( {
 
 	doQandASearch() {
 		const query = this.state.subject + ' ' + this.state.message;
+		const areSameQuestions = ( existingQuestions, newQuestions ) => {
+			const existingIDs = existingQuestions.map( question => question.id );
+			existingIDs.sort();
+			const newIDs = newQuestions.map( question => question.id );
+			newIDs.sort();
+			return existingIDs.toString() === newIDs.toString();
+		};
 		wpcom.getQandA( query, config( 'happychat_support_blog' ) )
-			.then( qanda => this.setState( { qanda, sibylClicked: false } ) )
+			.then( qanda => this.setState( {
+				qanda,
+				// only keep sibylClicked true if the user is seeing the same set of questions
+				// we don't want to track "questions -> question click -> different questions -> support click",
+				// so we need to set sibylClicked to false here if the questions have changed
+				sibylClicked: this.state.sibylClicked && areSameQuestions( this.state.qanda, qanda )
+			} ) )
 			.catch( () => this.setState( { qanda: [], sibylClicked: false } ) );
 	},
 


### PR DESCRIPTION
We want to track if a user still contacts support after
clicking a question that Sibyl suggested.

Testing:

1) Fill out the contact form, using the word 'quirkafleeg'
2) Click the "How do I perform a quirkafleeg" question
3) Submit the form
4) Check that the 'calypso_sibyl_support_after_question_click' event was tracked
5) Delete the contents of the contact form
6) Enter something about domains
7) Do not click any of the questions
8) Submit the form
9) Check that the 'calypso_sibyl_support_after_question_click' event was not tracked