### PR TITLE
Sidebar: Highlight 'Plugins' item when in an Extension

### DIFF
--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -252,7 +252,7 @@ export class MySitesSidebar extends Component {
 		return (
 			<SidebarItem
 				label={ this.props.translate( 'Plugins' ) }
-				className={ this.itemLinkClass( '/plugins', 'plugins' ) }
+				className={ this.itemLinkClass( [ '/extensions', '/plugins' ], 'plugins' ) }
 				link={ pluginsLink }
 				onNavigate={ this.onNavigate }
 				icon="plugins"


### PR DESCRIPTION
Fixes https://horizonfeedback.wordpress.com/2017/08/17/call-for-testing-calypso-wp-super-cache-extension/comment-page-1/#comment-390.

Before:

![screencapture-wordpress-extensions-wp-super-cache-bernhardreiter-wpsandbox-me-1503057433452](https://user-images.githubusercontent.com/96308/29457966-2ccd3cd0-841d-11e7-9c38-9a5419997022.png)

After:

![screencapture-calypso-localhost-3000-extensions-wp-super-cache-bernhardreiter-wpsandbox-me-1503057351978](https://user-images.githubusercontent.com/96308/29457952-1922ca06-841d-11e7-83bd-f049c01327cb.png)
