### PR TITLE
Fixed broken flow for rebrand cities signup

### DIFF
--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -425,6 +425,7 @@ const Signup = React.createClass( {
 						user={ this.state.user }
 						loginHandler={ this.state.loginHandler }
 						signupDependencies={ this.props.signupDependencies }
+						flow = { this.props.flowName }
 					/>
 					: <CurrentComponent
 						path={ this.props.path }

--- a/client/signup/processing-screen/index.jsx
+++ b/client/signup/processing-screen/index.jsx
@@ -23,6 +23,7 @@ export class SignupProcessingScreen extends Component {
 		steps: PropTypes.array.isRequired,
 		user: PropTypes.object,
 		signupProgress: PropTypes.array,
+		flow: PropTypes.string,
 	};
 
 	componentWillMount() {
@@ -230,7 +231,7 @@ export class SignupProcessingScreen extends Component {
 	}
 
 	render() {
-		if ( abtest( 'postSignupUpgradeScreen' ) === 'modified' && ! this.state.hasPaidSubscription ) {
+		if ( abtest( 'postSignupUpgradeScreen' ) === 'modified' && ! this.state.hasPaidSubscription && this.props.flow !== 'rebrand-cities' ) {
 			return this.renderUpgradeScreen();
 		}
 


### PR DESCRIPTION
This PR fixes an unexpected bug with the rebrand cities signup flow. The `postSignupUpgradeScreen` test is showing the upgrade screen during the flow. This PR adds a fix so that it does not show.

**How to test**
1. Go to /start/rebrand-cities
2. Ensure that `postSignupUpgradeScreen` test is set to modified.
3. You should not see the upgrade screen after you create your account.

![screen shot 2017-08-18 at 8 18 34 am](https://user-images.githubusercontent.com/6981253/29458585-db5c1a8a-83ed-11e7-8b56-c261db29372f.png)

**How to test**
1. Go to /start
2. Ensure that `postSignupUpgradeScreen` test is set to modified.
3. Signup as you normally would and you should see the upgrade screen after you create your account.

![screen shot 2017-08-18 at 8 01 57 am](https://user-images.githubusercontent.com/6981253/29458562-c3d11a0a-83ed-11e7-9f20-059f09a1b462.png)

cc @taggon 