### PR TITLE
Notices: Fix so the action is right aligned

### DIFF
--- a/client/my-sites/current-site/domain-to-paid-plan-notice.jsx
+++ b/client/my-sites/current-site/domain-to-paid-plan-notice.jsx
@@ -25,15 +25,15 @@ const eventProperties = { cta_name: 'domain-to-paid-sidebar' };
 export class DomainToPaidPlanNotice extends Component {
 	static propTypes = {
 		translate: PropTypes.func.isRequired,
-	}
+	};
 
 	static defaultProps = {
 		translate: noop,
-	}
+	};
 
 	onClick = () => {
 		this.props.recordTracksEvent( clickEventName, eventProperties );
-	}
+	};
 
 	render() {
 		const { eligible, site, translate } = this.props;
@@ -43,11 +43,19 @@ export class DomainToPaidPlanNotice extends Component {
 		}
 
 		return (
-			<Notice isCompact status="is-success" icon="info-outline">
-				{ translate( 'Upgrade your site and save.' ) }
+			<Notice
+				icon="info-outline"
+				isCompact
+				status="is-success"
+				showDismiss={ false }
+				text={ translate( 'Upgrade your site and save.' ) }
+			>
 				<NoticeAction onClick={ this.onClick } href={ `/plans/my-plan/${ site.slug }` }>
 					{ translate( 'Go' ) }
-					<TrackComponentView eventName={ impressionEventName } eventProperties={ eventProperties } />
+					<TrackComponentView
+						eventName={ impressionEventName }
+						eventProperties={ eventProperties }
+					/>
 				</NoticeAction>
 			</Notice>
 		);

--- a/client/my-sites/current-site/domain-to-paid-plan-notice.jsx
+++ b/client/my-sites/current-site/domain-to-paid-plan-notice.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import {


### PR DESCRIPTION
The notice looked broken on smaller screens. Right align action, as for domain notices.

Before:
<img width="272" alt="screen shot 2017-08-18 at 15 08 26" src="https://user-images.githubusercontent.com/1103398/29460143-1e0739e4-8427-11e7-9636-53fdfeda963e.png">

After:
<img width="279" alt="screen shot 2017-08-18 at 15 07 18" src="https://user-images.githubusercontent.com/1103398/29460157-2bb5ddfc-8427-11e7-96f5-23da9c29a204.png">
