### PR TITLE
Analytics: limit ad-tracking events rate

### DIFF
--- a/client/lib/analytics/ad-tracking.js
+++ b/client/lib/analytics/ad-tracking.js
@@ -24,6 +24,15 @@ const user = userModule();
 let hasStartedFetchingScripts = false,
 	hasFinishedFetchingScripts = false;
 
+// Retargeting events are fired once every `retargetingPeriod` seconds.
+const retargetingPeriod = 60 * 60 * 24;
+
+// Last time the retarget() function effectively fired (Unix time in seconds).
+let lastRetargetTime = 0;
+
+// Last time the recordPageViewInFloodlight() function effectively fired (Unix time in seconds).
+let lastFloodlightPageViewTime = 0;
+
 /**
  * Constants
  */
@@ -290,6 +299,12 @@ function retarget() {
 	if ( ! hasFinishedFetchingScripts ) {
 		return;
 	}
+
+	const nowTimestamp = Date.now() / 1000;
+	if ( nowTimestamp < lastRetargetTime + retargetingPeriod ) {
+		return;
+	}
+	lastRetargetTime = nowTimestamp;
 
 	debug( 'Retargeting' );
 
@@ -701,6 +716,12 @@ function recordPageViewInFloodlight( urlPath ) {
 	if ( ! isAdTrackingAllowed() ) {
 		return;
 	}
+
+	const nowTimestamp = Date.now() / 1000;
+	if ( nowTimestamp < lastFloodlightPageViewTime + retargetingPeriod ) {
+		return;
+	}
+	lastFloodlightPageViewTime = nowTimestamp;
 
 	const sessionId = floodlightSessionId();
 


### PR DESCRIPTION
This PR limits the period around which we fire the ad-tracking events to once every 24 hours per session. If a user reloads Calypso or uses a different browser/device the events will be fired. This is the intended behavior as we want to follow a user across different browsers and devices.

# Background
We want to be able to perform the basic marketing functions of retargeting inclusion/exclusion and revenue tracking with minimal impact on the user's experience. For this reason ad-tracking events and Floodlight page view events will be fired once every 24 hours as opposed to once every page view.

Other Floodlight events and conversion events are not affected as they are already low in volume and of higher importance.

Also, note that if a user would like to opt out of third party tracking completely they can enable DNT from their browsers, which we actually observe (unlike most other sites).

# Testing
- Edit `config/development.json` and set`"ad-tracking": true` and restart Calypso.
- Change `retargetingPeriod` from `60 * 60 * 24` to something more easily testable like `5` seconds.
- Visit http://calypso.localhost:3000
- Enable debugging logs from JS console: `localStorage.setItem( 'debug', 'calypso:analytics:*' );`
- While clicking around in Calypso your JS console should show a series of `calypso:analytics:ad-tracking` entries not more often than every 5 seconds as opposed to once every page view. Example:

![2017-08-18 17 05 35 o6cr0](https://user-images.githubusercontent.com/10284338/29464907-b54d7650-8437-11e7-8bfb-8d0085c765d2.png)

