### PR TITLE
Signup: Fix too small browser icons on the post-signup screen.

### DIFF
--- a/client/signup/processing-screen/style.scss
+++ b/client/signup/processing-screen/style.scss
@@ -379,12 +379,16 @@
 	fill: $gray-dark;
 	margin-right: 10px;
 	align-self: center;
+	flex: 0 0 24px;
 }
 .signup-pricessing__address-field {
 	flex: 1;
 	background: $white;
 	margin: 0 0 0 5px;
 	padding: 8px;
+	box-sizing: border-box;
+	width: 100%;
+	overflow: auto;
 }
 .signup-pricessing__address-field.is-placeholder:after {
 	content: 'placeholder.wordpress.com';


### PR DESCRIPTION
The browser icons look so small when the title is long. This PR will fix the styles to keep the icons and the title bar look good even if the title is longer than the address field.

![pasted image at 2017_08_18 08_21 am](https://user-images.githubusercontent.com/212034/29461171-abfc5750-8465-11e7-8630-45782cd22be0.png)

## How to test
* Create a new free site with a long domain name over 60 chars.
* When you reach the post-signup screen, the icons and the title bar should look okay as follows:

![screen shot 2017-08-18 at 22 41 42](https://user-images.githubusercontent.com/212034/29461392-81150018-8466-11e7-920f-430341880215.png)

