### PR TITLE
Only show and save shipping label settings for plan owner

### DIFF
--- a/client/extensions/woocommerce/state/data-layer/ui/woocommerce-services/index.js
+++ b/client/extensions/woocommerce/state/data-layer/ui/woocommerce-services/index.js
@@ -17,11 +17,12 @@ import { getLabelSettingsFormMeta } from 'woocommerce/woocommerce-services/state
 import { getPackagesForm } from 'woocommerce/woocommerce-services/state/packages/selectors';
 import { submit as submitLabels } from 'woocommerce/woocommerce-services/state/label-settings/actions';
 import { submit as submitPackages } from 'woocommerce/woocommerce-services/state/packages/actions';
-import { getSelectedSiteId } from 'state/ui/selectors';
+import { getSelectedSiteId, getSelectedSite } from 'state/ui/selectors';
 
 const getSaveLabelSettingsActionListSteps = ( state, siteId ) => {
+	const site = getSelectedSite( state );
 	const labelFormMeta = getLabelSettingsFormMeta( state, siteId );
-	if ( ! labelFormMeta || labelFormMeta.pristine ) {
+	if ( ! labelFormMeta || labelFormMeta.pristine || ! site.plan.user_is_owner ) {
 		return [];
 	}
 

--- a/client/extensions/woocommerce/state/data-layer/ui/woocommerce-services/index.js
+++ b/client/extensions/woocommerce/state/data-layer/ui/woocommerce-services/index.js
@@ -17,12 +17,11 @@ import { getLabelSettingsFormMeta } from 'woocommerce/woocommerce-services/state
 import { getPackagesForm } from 'woocommerce/woocommerce-services/state/packages/selectors';
 import { submit as submitLabels } from 'woocommerce/woocommerce-services/state/label-settings/actions';
 import { submit as submitPackages } from 'woocommerce/woocommerce-services/state/packages/actions';
-import { getSelectedSiteId, getSelectedSite } from 'state/ui/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
 
 const getSaveLabelSettingsActionListSteps = ( state, siteId ) => {
-	const site = getSelectedSite( state );
 	const labelFormMeta = getLabelSettingsFormMeta( state, siteId );
-	if ( ! labelFormMeta || labelFormMeta.pristine || ! site.plan.user_is_owner ) {
+	if ( ! labelFormMeta || labelFormMeta.pristine || ! labelFormMeta.can_manage_payments ) {
 		return [];
 	}
 

--- a/client/extensions/woocommerce/woocommerce-services/views/label-settings/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/label-settings/index.js
@@ -21,7 +21,7 @@ import {
 	fetchSettings,
 	setFormDataValue,
 } from '../../state/label-settings/actions';
-import { getSelectedSiteId, getSelectedSite } from 'state/ui/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
 import {
 	getLabelSettingsFormData,
 	getLabelSettingsFormMeta,
@@ -43,7 +43,7 @@ class AccountSettingsRootView extends Component {
 	}
 
 	render() {
-		const { formData, formMeta, storeOptions, siteId, site, translate } = this.props;
+		const { formData, formMeta, storeOptions, siteId, translate } = this.props;
 
 		if ( ! formMeta ) {
 			return null;
@@ -60,10 +60,15 @@ class AccountSettingsRootView extends Component {
 				);
 			}
 
-			if ( ! site.plan.user_is_owner ) {
+			if ( ! formMeta.isFetching && ! formMeta.can_manage_payments ) {
 				return (
 					<Notice showDismiss={ false } isCompact={ true }>
-						{ translate( 'Only the plan owner can manage shipping label settings.' ) }
+						{ translate( 'Only the plan owner, %(name)s (%(login)s), can manage shipping label settings.', {
+							args: {
+								name: formMeta.master_user_name,
+								login: formMeta.master_user_login,
+							},
+						} ) }
 					</Notice>
 				);
 			}
@@ -82,8 +87,9 @@ class AccountSettingsRootView extends Component {
 		};
 
 		//hide the toggle when the enabled flag is not present (older version of WCS) and respect the setting otherwise.
-		const renderToggle = formData && isBoolean( formData.enabled );
+		const renderToggle = formData && isBoolean( formData.enabled ) && formMeta.can_manage_payments;
 		const hidden = formData && isBoolean( formData.enabled ) && ! formData.enabled;
+
 
 		return (
 			<div>
@@ -107,7 +113,6 @@ AccountSettingsRootView.propTypes = {
 function mapStateToProps( state ) {
 	return {
 		siteId: getSelectedSiteId( state ),
-		site: getSelectedSite( state ),
 		storeOptions: getLabelSettingsStoreOptions( state ),
 		formData: getLabelSettingsFormData( state ),
 		formMeta: getLabelSettingsFormMeta( state ),

--- a/client/extensions/woocommerce/woocommerce-services/views/label-settings/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/label-settings/index.js
@@ -15,7 +15,6 @@ import { isBoolean } from 'lodash';
 import Card from 'components/card';
 import ExtendedHeader from 'woocommerce/components/extended-header';
 import FormToggle from 'components/forms/form-toggle';
-import Notice from 'components/notice';
 import LabelSettings from './label-settings';
 import {
 	fetchSettings,
@@ -45,7 +44,7 @@ class AccountSettingsRootView extends Component {
 	render() {
 		const { formData, formMeta, storeOptions, siteId, translate } = this.props;
 
-		if ( ! formMeta ) {
+		if ( ! formMeta || ( ! formMeta.isFetching && ! formMeta.can_manage_payments ) ) {
 			return null;
 		}
 		const setValue = ( key, value ) => ( this.props.setFormDataValue( siteId, key, value ) );
@@ -57,19 +56,6 @@ class AccountSettingsRootView extends Component {
 					<p>
 						{ translate( 'Unable to get your settings. Please refresh the page to try again.' ) }
 					</p>
-				);
-			}
-
-			if ( ! formMeta.isFetching && ! formMeta.can_manage_payments ) {
-				return (
-					<Notice showDismiss={ false } isCompact={ true }>
-						{ translate( 'Only the plan owner, %(name)s (%(login)s), can manage shipping label settings.', {
-							args: {
-								name: formMeta.master_user_name,
-								login: formMeta.master_user_login,
-							},
-						} ) }
-					</Notice>
 				);
 			}
 
@@ -87,9 +73,8 @@ class AccountSettingsRootView extends Component {
 		};
 
 		//hide the toggle when the enabled flag is not present (older version of WCS) and respect the setting otherwise.
-		const renderToggle = formData && isBoolean( formData.enabled ) && formMeta.can_manage_payments;
+		const renderToggle = formData && isBoolean( formData.enabled );
 		const hidden = formData && isBoolean( formData.enabled ) && ! formData.enabled;
-
 
 		return (
 			<div>

--- a/client/extensions/woocommerce/woocommerce-services/views/label-settings/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/label-settings/index.js
@@ -15,12 +15,13 @@ import { isBoolean } from 'lodash';
 import Card from 'components/card';
 import ExtendedHeader from 'woocommerce/components/extended-header';
 import FormToggle from 'components/forms/form-toggle';
+import Notice from 'components/notice';
 import LabelSettings from './label-settings';
 import {
 	fetchSettings,
 	setFormDataValue,
 } from '../../state/label-settings/actions';
-import { getSelectedSiteId } from 'state/ui/selectors';
+import { getSelectedSiteId, getSelectedSite } from 'state/ui/selectors';
 import {
 	getLabelSettingsFormData,
 	getLabelSettingsFormMeta,
@@ -42,7 +43,7 @@ class AccountSettingsRootView extends Component {
 	}
 
 	render() {
-		const { formData, formMeta, storeOptions, siteId, translate } = this.props;
+		const { formData, formMeta, storeOptions, siteId, site, translate } = this.props;
 
 		if ( ! formMeta ) {
 			return null;
@@ -56,6 +57,14 @@ class AccountSettingsRootView extends Component {
 					<p>
 						{ translate( 'Unable to get your settings. Please refresh the page to try again.' ) }
 					</p>
+				);
+			}
+
+			if ( ! site.plan.user_is_owner ) {
+				return (
+					<Notice showDismiss={ false } isCompact={ true }>
+						{ translate( 'Only the plan owner can manage shipping label settings.' ) }
+					</Notice>
 				);
 			}
 
@@ -98,6 +107,7 @@ AccountSettingsRootView.propTypes = {
 function mapStateToProps( state ) {
 	return {
 		siteId: getSelectedSiteId( state ),
+		site: getSelectedSite( state ),
 		storeOptions: getLabelSettingsStoreOptions( state ),
 		formData: getLabelSettingsFormData( state ),
 		formMeta: getLabelSettingsFormMeta( state ),


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/16958

If user is not the plan owner, it doesn't save label settings and displays a notice:

<img width="745" alt="screen shot 2017-08-18 at 10 48 26 am" src="https://user-images.githubusercontent.com/1867547/29464104-d24197f8-8402-11e7-94d9-f24d964924d3.png">

To test, navigate to shipping settings logged in as a second user added to the site.