### PR TITLE
Login: Tweak styles on OAuth login form for Woo

### DIFF
--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -19,6 +19,7 @@ import FormTextInput from 'components/forms/form-text-input';
 import FormCheckbox from 'components/forms/form-checkbox';
 import { getCurrentQueryArguments } from 'state/ui/selectors';
 import { getCurrentUserId } from 'state/current-user/selectors';
+import { getOAuth2ClientData } from 'state/login/oauth2/selectors';
 import { loginUser, formUpdate } from 'state/login/actions';
 import { preventWidows } from 'lib/formatting';
 import { recordTracksEvent } from 'state/analytics/actions';
@@ -46,6 +47,7 @@ export class LoginForm extends Component {
 		socialAccountLinkService: PropTypes.string,
 		translate: PropTypes.func.isRequired,
 		isFormDisabled: PropTypes.bool,
+		oauth2ClientData: PropTypes.object,
 	};
 
 	state = {
@@ -152,6 +154,7 @@ export class LoginForm extends Component {
 
 		const { requestError } = this.props;
 		const linkingSocialUser = this.props.socialAccountIsLinking;
+		const isOauthLogin = !! this.props.oauth2ClientData;
 
 		return (
 			<form onSubmit={ this.onSubmitForm } method="post">
@@ -255,15 +258,17 @@ export class LoginForm extends Component {
 						</FormsButton>
 					</div>
 
-					<div className="login__form-signup-link">
-						{ this.props.translate( 'Not on WordPress.com? {{signupLink}}Create an Account{{/signupLink}}.',
-							{
-								components: {
-									signupLink: <a href={ config( 'signup_url' ) } />,
+					{ isOauthLogin && (
+						<div className="login__form-signup-link">
+							{ this.props.translate( 'Not on WordPress.com? {{signupLink}}Create an Account{{/signupLink}}.',
+								{
+									components: {
+										signupLink: <a href={ config( 'signup_url' ) } />,
+									}
 								}
-							}
-						) }
-					</div>
+							) }
+						</div>
+					) }
 				</Card>
 				{ config.isEnabled( 'signup/social' ) && (
 					<Card className="login__form-social">
@@ -288,7 +293,8 @@ export default connect(
 		socialAccountIsLinking: getSocialAccountIsLinking( state ),
 		socialAccountLinkEmail: getSocialAccountLinkEmail( state ),
 		socialAccountLinkService: getSocialAccountLinkService( state ),
-		isLoggedIn: Boolean( getCurrentUserId( state ) )
+		isLoggedIn: Boolean( getCurrentUserId( state ) ),
+		oauth2ClientData: getOAuth2ClientData( state ),
 	} ),
 	{
 		formUpdate,

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -254,6 +254,16 @@ export class LoginForm extends Component {
 							{ this.props.translate( 'Log In' ) }
 						</FormsButton>
 					</div>
+
+					<div className="login__form-signup-link">
+						{ this.props.translate( 'Not on WordPress.com? {{signupLink}}Create an Account{{/signupLink}}.',
+							{
+								components: {
+									signupLink: <a href={ config( 'signup_url' ) } />,
+								}
+							}
+						) }
+					</div>
 				</Card>
 				{ config.isEnabled( 'signup/social' ) && (
 					<Card className="login__form-social">

--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -63,13 +63,19 @@
 	}
 }
 
-.login__form-terms {
+.login__form-terms,
+.login__form-signup-link {
 	font-size: 11px;
 	text-align: center;
 
 	a {
 		white-space: pre;
 	}
+}
+
+.login__form-signup-link {
+	font-size: 13px;
+	margin-top: 20px;
 }
 
 .login__social-text {

--- a/client/layout/masterbar/oauth-client.scss
+++ b/client/layout/masterbar/oauth-client.scss
@@ -222,6 +222,10 @@
 		font-weight: normal;
 	}
 
+	.login__form-signup-link {
+		font-size: 15px;
+	}
+
 	.login__form-social {
 		border-top: 1px solid #e6e6e6;
 		margin: 10px -16px 0;

--- a/client/layout/masterbar/oauth-client.scss
+++ b/client/layout/masterbar/oauth-client.scss
@@ -190,20 +190,24 @@
 		max-width: 778px;
 	}
 
+	$woo-form-whitespace: 16px;
+	$woo-form-whitespace-480: 24px;
+	$woo-form-whitespace-660: 100px;
+
 	.wp-login__container {
 		background: #fff;
 		border: 1px solid #d3d3d3;
 		border-radius: 5px;
 		box-sizing: border-box;
-		padding: 20px 16px;
+		padding: 20px $woo-form-whitespace;
 		width: 100%;
 
 		@include breakpoint( '>480px' ) {
-			padding: 20px 24px;
+			padding: 20px $woo-form-whitespace-480;
 		}
 
 		@include breakpoint( '>660px' ) {
-			padding: 20px 100px;
+			padding: 20px $woo-form-whitespace-660;
 		}
 	}
 
@@ -220,6 +224,19 @@
 
 	.login__form-social {
 		border-top: 1px solid #e6e6e6;
+		margin: 10px -16px 0;
+		padding-top: 30px;
+		width: calc( 100% + ( $woo-form-whitespace * 2 ) );
+
+		@include breakpoint( '>480px' ) {
+			margin: 10px -24px 0;
+			width: calc( 100% + ( $woo-form-whitespace-480 * 2 ) );
+		}
+
+		@include breakpoint( '>660px' ) {
+			margin: 20px -100px 0;
+			width: calc( 100% + ( $woo-form-whitespace-660 * 2 ) );
+		}
 	}
 
 	.wp-login__links {

--- a/client/layout/masterbar/oauth-client.scss
+++ b/client/layout/masterbar/oauth-client.scss
@@ -147,6 +147,7 @@
 
 	button {
 		float: none;
+		margin-left: 0;
 		max-width: 300px;
 	}
 
@@ -194,8 +195,16 @@
 		border: 1px solid #d3d3d3;
 		border-radius: 5px;
 		box-sizing: border-box;
-		padding: 20px 100px;
+		padding: 20px 16px;
 		width: 100%;
+
+		@include breakpoint( '>480px' ) {
+			padding: 20px 24px;
+		}
+
+		@include breakpoint( '>660px' ) {
+			padding: 20px 100px;
+		}
 	}
 
 	.card {

--- a/client/layout/masterbar/oauth-client.scss
+++ b/client/layout/masterbar/oauth-client.scss
@@ -186,11 +186,14 @@
 	}
 
 	.wp-login__main.main {
+		max-width: 778px;
+	}
+
+	.wp-login__container {
 		background: #fff;
 		border: 1px solid #d3d3d3;
-    	border-radius: 5px;
-    	box-sizing: border-box;
-		max-width: 778px;
+		border-radius: 5px;
+		box-sizing: border-box;
 		padding: 20px 100px;
 		width: 100%;
 	}
@@ -206,10 +209,19 @@
 		font-weight: normal;
 	}
 
+	.login__form-social {
+		border-top: 1px solid #e6e6e6;
+	}
+
+	.wp-login__links {
+		margin-top: 20px;
+	}
+
 	.wp-login__links a {
 		border: none;
 		font-size: 16px;
 		font-weight: normal;
+		line-height: 3em;
 		text-align: center;
 	}
 }


### PR DESCRIPTION
WIP

Making some tweaks to the styles of the WooCommerce OAuth login form:

* Adding some responsive fixes for better usability on small screens.
* Adding sign up link.
* Other small polish.

Before | After
------------ | -------------
<img width="907" alt="screen shot 2017-08-18 at 10 57 30" src="https://user-images.githubusercontent.com/448298/29464511-110d07f0-8404-11e7-9788-77f8f7f8b6f0.png"> | <img width="903" alt="screen shot 2017-08-18 at 11 33 31" src="https://user-images.githubusercontent.com/448298/29466079-908cc5a6-8409-11e7-8898-65129573a205.png">
<img width="372" alt="screen shot 2017-08-18 at 10 42 10" src="https://user-images.githubusercontent.com/448298/29464421-d9afaa6a-8403-11e7-9480-cd28bd8b897a.png"> | <img width="373" alt="screen shot 2017-08-18 at 10 40 00" src="https://user-images.githubusercontent.com/448298/29464411-d5ee979c-8403-11e7-8079-e981f68cef3d.png">

#### Testing instructions

1. Run `git checkout update/woo-oauth-styles` and start your server.
2. Check the layout of the Woo OAuth page at http://calypso.localhost:3000/log-in?client_id=50916
3. Assert it looks like the screenshots above and the signup link works.

#### Review
- [x] Product
- [x] Code