### PR TITLE
Replace Harmonic with Twenty Seventeen in signup

### DIFF
--- a/client/lib/signup/themes-data.js
+++ b/client/lib/signup/themes-data.js
@@ -126,12 +126,12 @@ export const themes = [
 		verticals: []
 	},
 	{
-		name: 'Harmonic',
-		slug: 'harmonic',
+		name: 'Twenty Seventeen',
+		slug: 'twentyseventeen',
 		repo: 'pub',
 		fallback: true,
 		design: 'page',
-		demo_uri: 'https://harmonicdemo.wordpress.com',
+		demo_uri: 'https://twentyseventeendemo.wordpress.com',
 		verticals: []
 	},
 	{


### PR DESCRIPTION
Harmonic is being retired; let's replace it with something similar but fresh and easier to use.

Testing instructions:

* Switch to this PR
* Go to calypso.local:3000(?)/start/
* Click “Start with a website“
* Make sure Twenty Seventeen shows up instead of Harmonic