### PR TITLE
Store Orders: Show newly created notes immediately after saving

### DIFF
--- a/client/extensions/woocommerce/state/sites/orders/notes/reducer.js
+++ b/client/extensions/woocommerce/state/sites/orders/notes/reducer.js
@@ -64,11 +64,13 @@ export function isSaving( state = {}, action ) {
  * @return {Object}        Updated state
  */
 export function items( state = {}, action ) {
-	let notes;
 	switch ( action.type ) {
 		case WOOCOMMERCE_ORDER_NOTES_REQUEST_SUCCESS:
-			notes = keyBy( action.notes, 'id' );
+			const notes = keyBy( action.notes, 'id' );
 			return Object.assign( {}, state, notes );
+		case WOOCOMMERCE_ORDER_NOTE_CREATE_SUCCESS:
+			const note = action.note;
+			return Object.assign( {}, state, { [ note.id ]: note } );
 		default:
 			return state;
 	}

--- a/client/extensions/woocommerce/state/sites/orders/notes/reducer.js
+++ b/client/extensions/woocommerce/state/sites/orders/notes/reducer.js
@@ -86,9 +86,15 @@ export function items( state = {}, action ) {
  */
 export function orders( state = {}, action ) {
 	switch ( action.type ) {
-		case WOOCOMMERCE_ORDER_NOTES_REQUEST_SUCCESS:
+		case WOOCOMMERCE_ORDER_NOTES_REQUEST_SUCCESS: {
 			const idList = action.notes.map( note => note.id );
 			return Object.assign( {}, state, { [ action.orderId ]: idList } );
+		}
+		case WOOCOMMERCE_ORDER_NOTE_CREATE_SUCCESS: {
+			const { note, orderId } = action;
+			const idList = [ ...state[ orderId ], note.id ];
+			return Object.assign( {}, state, { [ orderId ]: idList } );
+		}
 		default:
 			return state;
 	}

--- a/client/extensions/woocommerce/state/sites/orders/notes/test/reducer.js
+++ b/client/extensions/woocommerce/state/sites/orders/notes/test/reducer.js
@@ -161,7 +161,7 @@ describe( 'reducer', () => {
 		} );
 	} );
 
-	describe( 'queries', () => {
+	describe( 'orders', () => {
 		it( 'should have no change by default', () => {
 			const newState = orders( undefined, {} );
 			expect( newState ).to.eql( {} );
@@ -188,6 +188,18 @@ describe( 'reducer', () => {
 			const originalState = deepFreeze( { 45: [ 1, 2 ] } );
 			const newState = orders( originalState, action );
 			expect( newState ).to.eql( { ...originalState, 50: [ 3 ] } );
+		} );
+
+		it( 'should add the created note to order\'s note list', () => {
+			const action = {
+				type: WOOCOMMERCE_ORDER_NOTE_CREATE_SUCCESS,
+				siteId: 123,
+				orderId: 45,
+				note,
+			};
+			const originalState = deepFreeze( { 45: [ 1, 2 ] } );
+			const newState = orders( originalState, action );
+			expect( newState ).to.eql( { 45: [ 1, 2, 3 ] } );
 		} );
 
 		it( 'should do nothing on a failure', () => {

--- a/client/extensions/woocommerce/state/sites/orders/notes/test/reducer.js
+++ b/client/extensions/woocommerce/state/sites/orders/notes/test/reducer.js
@@ -136,6 +136,18 @@ describe( 'reducer', () => {
 			expect( newState ).to.eql( { ...originalState, 3: note } );
 		} );
 
+		it( 'should add the created note to the note list', () => {
+			const action = {
+				type: WOOCOMMERCE_ORDER_NOTE_CREATE_SUCCESS,
+				siteId: 123,
+				orderId: 50,
+				note,
+			};
+			const originalState = deepFreeze( keyBy( notes, 'id' ) );
+			const newState = items( originalState, action );
+			expect( newState ).to.eql( { ...originalState, 3: note } );
+		} );
+
 		it( 'should do nothing on a failure', () => {
 			const action = {
 				type: WOOCOMMERCE_ORDER_NOTES_REQUEST_FAILURE,

--- a/client/extensions/woocommerce/state/sites/orders/notes/test/reducer.js
+++ b/client/extensions/woocommerce/state/sites/orders/notes/test/reducer.js
@@ -86,7 +86,7 @@ describe( 'reducer', () => {
 				type: WOOCOMMERCE_ORDER_NOTE_CREATE_SUCCESS,
 				siteId: 123,
 				orderId: 45,
-				notes,
+				note,
 			};
 			const originalState = deepFreeze( { 45: true } );
 			const newState = isSaving( originalState, action );


### PR DESCRIPTION
This PR updates the state so that new notes can be displayed on the page as soon as they're saved, without waiting for a page refresh. See https://github.com/Automattic/wp-calypso/pull/17230#issuecomment-323087464

**To test**

- View an order
- Create a customer note by fulfilling the order using the Fulfill modal, and emailing the user a tracking number.
- The tracking number note should appear right away (unless there was a problem saving it).