### PR TITLE
Media: Hide edit button on private sites

### DIFF
--- a/client/post-editor/media-modal/detail/detail-item.jsx
+++ b/client/post-editor/media-modal/detail/detail-item.jsx
@@ -26,6 +26,7 @@ import MediaUtils, { isItemBeingUploaded } from 'lib/media/utils';
 import config from 'config';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSiteOption, isJetpackModuleActive, isJetpackSite } from 'state/sites/selectors';
+import { isPrivateSite } from 'state/selectors';
 
 /**
  * This function return true if the image editor can be
@@ -123,6 +124,10 @@ class EditorMediaModalDetailItem extends Component {
 		} = this.props;
 
 		if ( ! userCan( 'upload_files', site ) ) {
+			return null;
+		}
+
+		if ( this.props.isPrivateSite ) {
 			return null;
 		}
 
@@ -353,6 +358,7 @@ const connectComponent = connect(
 			isJetpack: isJetpackSite( state, siteId ),
 			isVideoPressEnabled: getSiteOption( state, siteId, 'videopress_enabled' ),
 			isVideoPressModuleActive: isJetpackModuleActive( state, siteId, 'videopress' ),
+			isPrivateSite: isPrivateSite( state, siteId ),
 			siteId,
 		};
 	}


### PR DESCRIPTION
This is a temporary workaround to hide the Edit button on media items on private sites. It's related to #13625, which has received a few user reports. Right now, if you try to edit a media item in Calypso on a private site, you receive this error:

![28747782-dc573464-746c-11e7-8dd7-105ac159b241](https://user-images.githubusercontent.com/7240478/29474903-df1a1dc0-841a-11e7-9ed3-eb4bc999de38.png)

It's not clear why the edit action didn't work since you _can_ edit media items in wp-admin.

My understanding ([from this comment](https://github.com/Automattic/wp-calypso/issues/13625#issuecomment-300244182)) is that this is a CORS limitation at the moment.

## To test
1. On a private site, open the following URL with the branch loaded: http://calypso.localhost:3000/media/
2. Click on an item in your media library and then click the blue "Edit" button in the header

You should not see an edit button on the image. This should only affect private sites on WordPress.com.

**Before**

<img width="952" alt="s9m9ew" src="https://user-images.githubusercontent.com/7240478/29475013-4d3e9c54-841b-11e7-9f00-5a23dca5a64f.png">

**After**

<img width="947" alt="screen shot 2017-08-18 at 1 43 05 pm" src="https://user-images.githubusercontent.com/7240478/29475050-5e666a3e-841b-11e7-928a-ccce00eb2033.png">
