### PR TITLE
Store Orders: Refresh notes list when the order status changes

### DIFF
--- a/client/extensions/woocommerce/app/order/index.js
+++ b/client/extensions/woocommerce/app/order/index.js
@@ -11,6 +11,7 @@ import React, { Component } from 'react';
  */
 import ActionHeader from 'woocommerce/components/action-header';
 import Button from 'components/button';
+import { fetchNotes } from 'woocommerce/state/sites/orders/notes/actions';
 import { fetchOrder } from 'woocommerce/state/sites/orders/actions';
 import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
 import { getLink } from 'woocommerce/lib/nav-utils';
@@ -33,12 +34,17 @@ class Order extends Component {
 
 		if ( siteId ) {
 			this.props.fetchOrder( siteId, orderId );
+			this.props.fetchNotes( siteId, orderId );
 		}
 	}
 
 	componentWillReceiveProps( newProps ) {
 		if ( newProps.orderId !== this.props.orderId || newProps.siteId !== this.props.siteId ) {
 			this.props.fetchOrder( newProps.siteId, newProps.orderId );
+			this.props.fetchNotes( newProps.siteId, newProps.orderId );
+		} else if ( newProps.order && this.props.order && newProps.order.status !== this.props.order.status ) {
+			// A status change should force a notes refresh
+			this.props.fetchNotes( newProps.siteId, newProps.orderId, true );
 		}
 	}
 
@@ -96,5 +102,5 @@ export default connect(
 			siteId,
 		};
 	},
-	dispatch => bindActionCreators( { fetchOrder, updateOrder }, dispatch )
+	dispatch => bindActionCreators( { fetchNotes, fetchOrder, updateOrder }, dispatch )
 )( localize( Order ) );

--- a/client/extensions/woocommerce/app/order/order-notes/index.js
+++ b/client/extensions/woocommerce/app/order/order-notes/index.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { bindActionCreators } from 'redux';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
 import { localize, moment } from 'i18n-calypso';
@@ -14,7 +13,6 @@ import { sortBy, keys } from 'lodash';
  */
 import { areOrderNotesLoaded, getOrderNotes } from 'woocommerce/state/sites/orders/notes/selectors';
 import Card from 'components/card';
-import { fetchNotes } from 'woocommerce/state/sites/orders/notes/actions';
 import OrderNote from './note';
 import OrderNotesByDay from './day';
 import SectionHeader from 'components/section-header';
@@ -44,20 +42,6 @@ class OrderNotes extends Component {
 		this.state = {
 			openIndex: 0,
 		};
-	}
-
-	componentDidMount() {
-		const { siteId, orderId } = this.props;
-
-		if ( siteId ) {
-			this.props.fetchNotes( siteId, orderId );
-		}
-	}
-
-	componentWillReceiveProps( newProps ) {
-		if ( newProps.orderId !== this.props.orderId || newProps.siteId !== this.props.siteId ) {
-			this.props.fetchNotes( newProps.siteId, newProps.orderId );
-		}
 	}
 
 	toggleOpenDay = ( index ) => {
@@ -135,6 +119,5 @@ export default connect(
 			orderId,
 			siteId,
 		};
-	},
-	dispatch => bindActionCreators( { fetchNotes }, dispatch )
+	}
 )( localize( OrderNotes ) );

--- a/client/extensions/woocommerce/state/sites/orders/notes/actions.js
+++ b/client/extensions/woocommerce/state/sites/orders/notes/actions.js
@@ -13,12 +13,16 @@ import {
 	WOOCOMMERCE_ORDER_NOTES_REQUEST_SUCCESS,
 } from 'woocommerce/state/action-types';
 
-export const fetchNotes = ( siteId, orderId ) => ( dispatch, getState ) => {
+export const fetchNotes = ( siteId, orderId, refresh = false ) => ( dispatch, getState ) => {
 	const state = getState();
 	if ( ! siteId ) {
 		siteId = getSelectedSiteId( state );
 	}
-	if ( areOrderNotesLoaded( state, orderId, siteId ) || areOrderNotesLoading( state, orderId, siteId ) ) {
+	if ( areOrderNotesLoading( state, orderId, siteId ) ) {
+		return;
+	}
+	// Bail if the order notes are loaded, and we don't want to force a refresh
+	if ( ! refresh && areOrderNotesLoaded( state, orderId, siteId ) ) {
 		return;
 	}
 


### PR DESCRIPTION
Currently the orders "Activity Log" doesn't update when the order status changes, even though that does create a new system note. This PR updates the way notes are requested to fetch notes when the order is fetched, and to re-fetch notes if the order status updates.

The only kind of wonky thing here (IMO) is that when refreshing, the entire notes list goes to the loading state, but I don't want to dive into "fixing" that if it's not a big deal.

**To test**

- View an order
- Make sure notes load

---

- View an "on hold" or "pending" order (ex: made with check payments)
- Change the status using the dropdown, save the order
- When saved, the notes should refresh and you should see the status changed note

---

- View an order awaiting fulfillment
- Fulfill the order with the button + modal, optionally add a fake tracking number and check "email to customer"
- Once "Fulfilled", the notes should update with the status change, and the tracking number message (if emailed).