### PR TITLE
OAuth Login: Fix top right WordPress.com button

### DIFF
--- a/client/layout/masterbar/oauth-client.jsx
+++ b/client/layout/masterbar/oauth-client.jsx
@@ -5,6 +5,11 @@ import Gridicon from 'gridicons';
 import React from 'react';
 import PropTypes from 'prop-types';
 
+/**
+ * Internal dependencies
+ */
+import { addLocaleToWpcomUrl, getLocaleSlug } from 'lib/i18n-utils';
+
 const OauthClientMasterbar = ( { oauth2ClientData } ) => (
 	<header className="masterbar masterbar__oauth-client">
 		<nav>
@@ -25,7 +30,11 @@ const OauthClientMasterbar = ( { oauth2ClientData } ) => (
 			) : (
 				<ul className="masterbar__oauth-client-user-nav">
 					<li className="masterbar__oauth-client-wpcc-sign-in">
-						<a href="https://wordpress.com/" className="masterbar__oauth-client-wpcom">
+						<a
+							href={ addLocaleToWpcomUrl( 'https://wordpress.com/', getLocaleSlug() ) }
+							className="masterbar__oauth-client-wpcom"
+							target="_self"
+						>
 							<Gridicon icon="my-sites" size={ 24 } />
 							WordPress.com
 						</a>


### PR DESCRIPTION
Fixes #17315. 

When a user clicks on the top right WordPress.com button in an [OAuth login page](https://wordpress.com/log-in?client_id=1854), nothing happens.

I believe this issue is occurring due to how we do routing in Calypso. When the user clicks the top right button, four Redux actions fire:

1) `{ type: "SECTION_SET", isLoading: true }`
2) `{ type: "SECTION_SET", isLoading: false }` 
3) 
```javascript
{
  type: 'SECTION_SET',
  section: {
    name: 'reader',
    paths: [
      '/',
      '/read'
    ],
    module: 'reader',
    secondary: true,
    group: 'reader'
  },
  hasSidebar: true
}
```
4. `{ type: 'LAYOUT_NEXT_FOCUS_ACTIVATE' }`

Can you see why action 3 might be an issue for logged out users? I don't know what happens when you try to render the reader for an unauthenticated user, but I can't imagine it'd be good.

My fix adds a click handler to the anchor that manually sets the window's location to `https://wordpress.com`. 

#### Testing instructions

1. Check out locally (`git checkout fix/oauth-login-wpcom-button-link`) and start your server. You can also use a [live branch](https://calypso.live/?branch=fix/oauth-login-wpcom-button-link)
2. Open a [OAuth login page](https://wordpress.com/log-in?client_id=1854)
3. Click on the WordPress.com button on the top right and ensure that your window location changes successfully. 
- Ideally, repeat steps 1~3 with WordPress.com... But I'm not quite sure how to do this. Ideas welcome!

#### Reviews

- [ ] Code
- [ ] Product