### PR TITLE
Comments: update to use moderate_comments capability

### DIFF
--- a/client/my-sites/comments/main.jsx
+++ b/client/my-sites/comments/main.jsx
@@ -65,7 +65,6 @@ export class CommentsManagement extends Component {
 
 const mapStateToProps = ( state, { siteFragment } ) => {
 	const siteId = getSiteId( state, siteFragment );
-	//update to moderate_comments when available
 	const canModerateComments = canCurrentUser( state, siteId, 'moderate_comments' );
 	return {
 		siteId,

--- a/client/my-sites/comments/main.jsx
+++ b/client/my-sites/comments/main.jsx
@@ -66,7 +66,7 @@ export class CommentsManagement extends Component {
 const mapStateToProps = ( state, { siteFragment } ) => {
 	const siteId = getSiteId( state, siteFragment );
 	//update to moderate_comments when available
-	const canModerateComments = canCurrentUser( state, siteId, 'edit_others_posts' );
+	const canModerateComments = canCurrentUser( state, siteId, 'moderate_comments' );
 	return {
 		siteId,
 		showPermissionError: canModerateComments === false,

--- a/client/my-sites/sidebar/manage-menu.jsx
+++ b/client/my-sites/sidebar/manage-menu.jsx
@@ -106,8 +106,7 @@ class ManageMenu extends PureComponent {
 			items.push( {
 				name: 'comments',
 				label: this.props.translate( 'Comments' ),
-				// TODO: replace with `moderate_comments` as soon as it's available from the endpoint
-				capability: 'edit_others_posts',
+				capability: 'moderate_comments',
 				queryable: true,
 				config: 'comments/management',
 				link: '/comments',


### PR DESCRIPTION
Now that the API endpoint has been updated to return `moderate_comments` we can now use this capability check over `edit_others_posts`. This was incorrect if folks were using custom roles.

It appears we're hitting the shadow site, since I also see the correct values for Jetpack. Please take care to test this on a few Jetpack / Atomic sites 

### Testing Instructions
- Checkout this branch
- Click on "My Sites"
- If your user has an role of Editor or Admin, we should see the comments section 
- inspecting in dev console `state.currentUser.capabilities[ state.ui.selectedSiteId ].moderate_comments` matches the role we expect