### PR TITLE
Reader: Clean up Follow button styles

### DIFF
--- a/client/blocks/follow-button/style.scss
+++ b/client/blocks/follow-button/style.scss
@@ -2,23 +2,16 @@ $follow-button-gray-disabled: lighten( $gray, 20% );
 
 .follow-button,
 button.follow-button {
-
-	&:focus {
-		box-shadow: none;
-	}
+	border: 0;
+	padding: 0;
 
 	.gridicon__follow {
-		opacity: 1;
+		fill: $blue-medium;
 		pointer-events: auto;
 	}
 
-	.gridicon__following {
-		display: none;
-		pointer-events: auto;
-	}
-
-	&::-moz-focus-inner {
-		border: 0;
+	.follow-button__label {
+		color: $blue-medium;
 	}
 
 	&:hover {
@@ -29,11 +22,46 @@ button.follow-button {
 		}
 	}
 
-	@include breakpoint( "<660px" ) {
-		padding: 7px 8px 9px 14px;
+	&:focus {
+		box-shadow: none;
 	}
 
-	// Menu Items with Icons
+	// Hides Following icon by default
+	.gridicon__following {
+		display: none;
+		pointer-events: none;
+	}
+
+	&.is-following {
+
+		.gridicon__following {
+			display: inline-block;
+			fill: $alert-green;
+			pointer-events: auto;
+		}
+
+		.follow-button__label {
+			color: $alert-green;
+		}
+
+		// Hides Follow icon if already following
+		.gridicon__follow {
+			display: none;
+			pointer-events: none;
+		}
+
+		&:hover {
+			color: $alert-green;
+
+			.gridicon__following {
+				fill: $alert-green;
+			}
+		}
+	}
+
+	.gridicon__following {
+		pointer-events: none;
+	}
 
 	.gridicon {
 		height: 18px;
@@ -42,57 +70,15 @@ button.follow-button {
 		width: 18px;
 	}
 
-	.gridicon__following {
-		opacity: 0;
-		pointer-events: none;
-	}
-
-	.gridicon__unfollow {
-
-		.gridicon__follow {
-			opacity: 0;
-			pointer-events: none;
-		}
-
-		.gridicon__following {
-			opacity: 1;
-			pointer-events: auto;
-		}
-	}
-
-	&.is-following {
-		color: $alert-green;
-
-		.gridicon {
-			fill: $alert-green;
-		}
-
-		.gridicon__follow {
-			display: none;
-			pointer-events: none;
-		}
-
-		.gridicon__following {
-			display: inline-block;
-			opacity: 1;
-			pointer-events: auto;
-		}
-
-		&:hover {
-			color: $alert-green;
-
-			.gridicon {
-				fill: $alert-green;
-			}
-		}
-	}
-
 	&.is-disabled {
+		@include no-select();
 		color: $follow-button-gray-disabled;
 		border-color: $follow-button-gray-disabled;
 		pointer-events: none;
 
-		@include no-select();
+		.follow-button__label {
+			color: $follow-button-gray-disabled;
+		}
 
 		.gridicon {
 			fill: $follow-button-gray-disabled;
@@ -114,6 +100,7 @@ button.follow-button {
 }
 
 .follow-button__label {
+
 	@include breakpoint( "<660px" ) {
 		display: none;
 	}

--- a/client/blocks/reader-feed-header/style.scss
+++ b/client/blocks/reader-feed-header/style.scss
@@ -93,19 +93,12 @@
 	}
 
 	.reader-feed-header__follow-button .follow-button {
-		padding: 0;
 
 		@include breakpoint( ">960px" ) {
 			margin-left: 20px;
-			margin-right: 0;
-		}
-
-		.gridicon {
-			fill: $blue-medium;
 		}
 
 		.follow-button__label {
-			color: $blue-medium;
 
 			@include breakpoint( "<660px" ) {
 				display: inline-block;
@@ -113,17 +106,6 @@
 
 			@include breakpoint( "<480px" ) {
 				display: none;
-			}
-		}
-
-		&.is-following {
-
-			.gridicon {
-				fill: $alert-green;
-			}
-
-			.follow-button__label {
-				color: $alert-green;
 			}
 		}
 	}

--- a/client/blocks/reader-post-options-menu/style.scss
+++ b/client/blocks/reader-post-options-menu/style.scss
@@ -24,12 +24,17 @@
 .reader-post-options-menu__popover {
 
 	.popover__menu .follow-button {
+		color: $blue-medium;
 		padding: 9px 16px;
 
 		.gridicon {
 			position: absolute;
 				left: 17px;
 				top: 12px;
+
+			&:hover {
+				fill: $white;
+			}
 		}
 
 		&:hover,
@@ -40,23 +45,14 @@
 			.gridicon {
 				fill: $white;
 			}
-		}
 
-		&.is-following {
-
-			&:hover,
-			&:focus {
+			.follow-button__label {
 				color: $white;
-				background: $alert-green;
-
-				.gridicon {
-					fill: $white;
-				}
 			}
 		}
 	}
 
-	.popover__menu .follow-button__label {
+	.follow-button__label {
 		display: inline-block;
 		margin-left: 26px;
 	}

--- a/client/blocks/reader-subscription-list-item/style.scss
+++ b/client/blocks/reader-subscription-list-item/style.scss
@@ -158,37 +158,10 @@
 	}
 }
 
-.reader-subscription-list-item .follow-button {
-	border: 0;
-	padding: 0;
+.reader-subscription-list-item .follow-button .gridicon {
 
-	.gridicon {
-		fill: $blue-medium;
-
-		@include breakpoint( "<660px" ) {
-			left: 3px;
-		}
-	}
-
-	.follow-button__label {
-		color: $blue-medium;
-	}
-
-	&.is-following {
-
-		.gridicon {
-			fill: $alert-green;
-		}
-
-		.follow-button__label {
-			color: $alert-green;
-		}
-	}
-}
-
-.reader-subscription-list-item .follow-button__label {
-	@include breakpoint( "<660px" ) {
-		display: none;
+ 	@include breakpoint( "<660px" ) {
+		left: 3px;
 	}
 }
 

--- a/client/reader/_style.scss
+++ b/client/reader/_style.scss
@@ -20,12 +20,6 @@
 	}
 }
 
-.is-reader-page .follow-button {
-	border: 0;
-	border-radius: 0;
-	float: right;
-}
-
 .is-reader-page .reader-full-post__story-content {
 	margin-top: 0;
 }

--- a/client/reader/tag-stream/style.scss
+++ b/client/reader/tag-stream/style.scss
@@ -8,31 +8,9 @@
 }
 
 .tag-stream__header .follow-button {
-	padding: 0;
-	position: relative;
-		top: 2px;
 
 	@include breakpoint( "<660px" ) {
-		margin: 12px 10px 0 0;
-	}
-
-	.gridicon {
-		fill: $blue-medium;
-	}
-
-	.follow-button__label {
-		color: $blue-medium;
-	}
-
-	&.is-following {
-
-		.gridicon {
-			fill: $alert-green;
-		}
-
-		.follow-button__label {
-			color: $alert-green;
-		}
+		margin: 12px 0 0 15px;
 	}
 }
 


### PR DESCRIPTION
We now use the borderless Follow(ing) button everywhere in Reader so this PR updates the main follow button stylesheet instead of having to override its styles in specific components/blocks.

## In Devdocs:

**Before:**
![screenshot 2017-08-18 14 10 12](https://user-images.githubusercontent.com/4924246/29477846-0c457bb0-841f-11e7-83a9-f56136851c79.png)

**After:**
![screenshot 2017-08-18 14 10 07](https://user-images.githubusercontent.com/4924246/29477850-0f779b74-841f-11e7-9d12-a3627a3e2095.png)

Double checking that it still looks good in other places:

## Manage:
![screenshot 2017-08-18 14 13 16](https://user-images.githubusercontent.com/4924246/29477949-6803cd62-841f-11e7-93cd-540e80d3b5f1.png)

## Tags:
![screenshot 2017-08-18 14 13 47](https://user-images.githubusercontent.com/4924246/29477968-781d41f6-841f-11e7-991a-08d9cda06ca9.png)

## Reader popover:
![screenshot 2017-08-18 14 15 16](https://user-images.githubusercontent.com/4924246/29478010-adbb283c-841f-11e7-88cc-5f4a9fe44a8f.png)
![screenshot 2017-08-18 14 15 20](https://user-images.githubusercontent.com/4924246/29478011-add09712-841f-11e7-9e88-1ca3db17ae30.png)
![screenshot 2017-08-18 14 14 27](https://user-images.githubusercontent.com/4924246/29477989-965f5f64-841f-11e7-81cd-93f338e4219a.png)
![screenshot 2017-08-18 14 14 35](https://user-images.githubusercontent.com/4924246/29477990-96618582-841f-11e7-8326-8bae857eb830.png)

## Site stream:
![screenshot 2017-08-18 14 16 42](https://user-images.githubusercontent.com/4924246/29478070-f30abaf6-841f-11e7-81a7-3138e3889f83.png)
![screenshot 2017-08-18 14 17 17](https://user-images.githubusercontent.com/4924246/29478069-f3041930-841f-11e7-8871-a22afbd73e8b.png)

## Likes:
![screenshot 2017-08-18 14 18 23](https://user-images.githubusercontent.com/4924246/29478093-1ab34730-8420-11e7-950d-141e1c8e3b55.png)

## Search recs:
![screenshot 2017-08-18 14 19 01](https://user-images.githubusercontent.com/4924246/29478115-33d7f670-8420-11e7-903d-81efae665c32.png)

## Search results:
![screenshot 2017-08-18 14 19 28](https://user-images.githubusercontent.com/4924246/29478128-42d727b8-8420-11e7-8c36-63de9766385c.png)
