### PR TITLE
Comments: fix ui count styling

### DIFF
--- a/client/my-sites/comments/style.scss
+++ b/client/my-sites/comments/style.scss
@@ -38,6 +38,14 @@
 	}
 }
 
+.comment-navigation__bulk-count {
+	display: inline-flex;
+}
+
+.comment-navigation__bulk-count .count {
+	margin-left: 8px;
+}
+
 .comment-navigation__tab {
 	padding: 16px;
 }


### PR DESCRIPTION
Fixes #16011, where the bulk count could look strange at small viewports.

Before:
![27979998-211b5b10-632f-11e7-8fdd-f84a93f36df0](https://user-images.githubusercontent.com/1270189/29478398-81be76ce-8421-11e7-8d00-4db9f807aec7.png)

After:
<img width="400" alt="screen shot 2017-08-18 at 2 25 29 pm" src="https://user-images.githubusercontent.com/1270189/29478409-90040f96-8421-11e7-8175-99a3441c16ef.png">

### Testing Instructions
- Until #17304 lands, bulk actions don't work on this branch
- Start Calypso with `ENABLE_FEATURES=manage/comments/bulk-actions npm start`
- In a small viewport size (either small browser window or emulated phone)
- Navigate to /comments
- Select a site you can moderate comments on
- Click on "Bulk Edit"
- We should no longer see the count label take up most of the screen