### PR TITLE
JPO: Design updates to the homepage step-3

### DIFF
--- a/client/signup/steps/jpo-homepage/index.jsx
+++ b/client/signup/steps/jpo-homepage/index.jsx
@@ -56,32 +56,45 @@ const JPOHomepageStep = React.createClass( {
 		return (
 			<div className="jpo__homepage-wrapper">
 				<div className="jpo__homepage-row">
-					<a className="jpo-homepage__select-news" href="#" onClick={ this.onSelectNews }>
-						<Card
-							className={ classNames( {
-								'is-selected': 'news' === get( this.props.signupDependencies, 'jpoHomepage', '' )
-							} ) }
-							>
-							<NewsGraphic />
-							<Button onClick={ this.onSelectNews }>{ translate( 'Recent news or updates' ) }</Button>
-							<div className="jpo__homepage-description">
-								{ translate( 'We can pull the latest information into your homepage for you.' ) }
+					<Card
+						className={ classNames( 'jpo-homepage__choice', {
+							'is-selected': 'news' === get( this.props.signupDependencies, 'jpoHomepage', '' )
+						} ) }
+						>
+						<a className="jpo-homepage__select-news" href="#" onClick={ this.onSelectNews }>
+							<div className="jpo-homepage__image">
+								<NewsGraphic />
 							</div>
-						</Card>
-					</a>
-					<a className="jpo-homepage__select-static" href="#" onClick={ this.onSelectStatic }>
-						<Card
-							className={ classNames( {
-								'is-selected': 'static' === get( this.props.signupDependencies, 'jpoHomepage', '' )
-							} ) }
-							>
-							<StaticGraphic />
-							<Button onClick={ this.onSelectStatic }>{ translate( 'A static welcome page' ) }</Button>
-							<div className="jpo__homepage-description">
-								{ translate( 'Have your homepage stay the same as time goes on.' ) }
+							<div className="jpo-homepage__choice-copy">
+								<Button onClick={ this.onSelectNews }>
+									{ translate( 'Recent news or updates' ) }
+								</Button>
+								<div className="jpo-homepage__description">
+									{ translate( 'We can pull the latest information into your homepage for you.' ) }
+								</div>
 							</div>
-						</Card>
-					</a>
+						</a>
+					</Card>
+					<Card
+						className={ classNames( 'jpo-homepage__choice', {
+							'is-selected': 'static' === get( this.props.signupDependencies, 'jpoHomepage', '' )
+						} ) }
+						>
+						<a className="jpo-homepage__select-static" href="#" onClick={ this.onSelectStatic }>
+
+							<div className="jpo-homepage__image">
+								<StaticGraphic />
+							</div>
+							<div className="jpo-homepage__choice-copy">
+								<Button onClick={ this.onSelectStatic }>
+									{ translate( 'A static welcome page' ) }
+								</Button>
+								<div className="jpo-homepage__description">
+									{ translate( 'Have your homepage stay the same as time goes on.' ) }
+								</div>
+							</div>
+						</a>
+					</Card>
 				</div>
 			</div>
 		);

--- a/client/signup/steps/jpo-homepage/index.jsx
+++ b/client/signup/steps/jpo-homepage/index.jsx
@@ -61,7 +61,7 @@ const JPOHomepageStep = React.createClass( {
 							'is-selected': 'news' === get( this.props.signupDependencies, 'jpoHomepage', '' )
 						} ) }
 						>
-						<a className="jpo-homepage__select-news" href="#" onClick={ this.onSelectNews }>
+						<a className="jpo-homepage__select-news jpo-homepage__choice-link" href="#" onClick={ this.onSelectNews }>
 							<div className="jpo-homepage__image">
 								<NewsGraphic />
 							</div>
@@ -80,7 +80,7 @@ const JPOHomepageStep = React.createClass( {
 							'is-selected': 'static' === get( this.props.signupDependencies, 'jpoHomepage', '' )
 						} ) }
 						>
-						<a className="jpo-homepage__select-static" href="#" onClick={ this.onSelectStatic }>
+						<a className="jpo-homepage__select-static jpo-homepage__choice-link" href="#" onClick={ this.onSelectStatic }>
 
 							<div className="jpo-homepage__image">
 								<StaticGraphic />

--- a/client/signup/steps/jpo-homepage/index.jsx
+++ b/client/signup/steps/jpo-homepage/index.jsx
@@ -66,7 +66,7 @@ const JPOHomepageStep = React.createClass( {
 								<NewsGraphic />
 							</div>
 							<div className="jpo-homepage__choice-copy">
-								<Button onClick={ this.onSelectNews }>
+								<Button className="jpo-homepage__cta" onClick={ this.onSelectNews }>
 									{ translate( 'Recent news or updates' ) }
 								</Button>
 								<div className="jpo-homepage__description">
@@ -86,7 +86,7 @@ const JPOHomepageStep = React.createClass( {
 								<StaticGraphic />
 							</div>
 							<div className="jpo-homepage__choice-copy">
-								<Button onClick={ this.onSelectStatic }>
+								<Button className="jpo-homepage__cta" onClick={ this.onSelectStatic }>
 									{ translate( 'A static welcome page' ) }
 								</Button>
 								<div className="jpo-homepage__description">

--- a/client/signup/steps/jpo-homepage/style.scss
+++ b/client/signup/steps/jpo-homepage/style.scss
@@ -5,15 +5,22 @@
 }
 
 .jpo__homepage-row {
-	max-width: 600px;
-	margin-left: auto;
-	margin-right: auto;
+	margin: 0 auto;
+	display: flex;
+	flex-flow: row wrap;
+	max-width: 640px;
 
 	.card {
-		width: 49%;
+		width: 46%;
 		display: inline-block;
 		vertical-align: top;
 		text-align: center;
+		padding: 0;
+
+		@media (max-width: 480px) {
+		width: 100%;
+		text-align: left;
+		}
 
 		&:hover,
 		&.is-selected {
@@ -40,11 +47,114 @@
 	}
 }
 
-.jpo__homepage-description {
+.jpo-homepage__row .card:first-child {
+	@include breakpoint( ">480px" ) {
+		margin-right: 2%;
+	}
+    
+    @media (max-width: 480px) {
+		margin-right: 10px;
+		width: 100%;
+   		text-align: left;
+	}
+}
+
+.jpo-homepage__description {
 	font-size: 1.25rem;
 	color: $gray;
 }
 
-.jpo__homepage-note {
+.jpo-homepage__note {
 	text-align: center;
+}
+
+.jpo-homepage__image {
+	padding:15px;
+}
+
+.jpo-homepage__choice {
+	transition: all 100ms ease-in-out;
+	position: relative;
+	border: 1px solid lighten( $gray, 20% );
+	border-bottom: 0;
+	margin: 0 10px;
+	
+	@include breakpoint( "<480px" ) {
+		box-shadow: none; //inherited from .card, remove for mobile only
+	}
+
+	@include breakpoint( ">480px" ) {
+		padding: 0;
+		margin-bottom: 20px;
+		width: 230px;
+		text-align: center;
+		flex-grow: 1;
+		border: 0;
+
+		&:hover,
+		&.is-selected {
+			box-shadow: 0 0 0 1px $gray, 0 2px 4px lighten( $gray, 20 );
+		}
+	}
+
+	&:active {
+		.jpo-site-type__cta {
+			color: $blue-dark;
+		}
+
+		.jpo-site-type__choice-link:after {
+			border-top-color: $blue-dark;
+			border-right-color: $blue-dark;
+		}
+	}
+
+	&:first-child {
+		border-top-right-radius: 6px;
+		border-top-left-radius: 6px;
+
+		@include breakpoint( ">480px" ) {
+			border-radius: 0;
+		}
+	}
+
+	&:last-of-type {
+		margin-bottom: 20px;
+		border: 1px solid lighten( $gray, 20% );
+		border-bottom-right-radius: 6px;
+		border-bottom-left-radius: 6px;
+
+		@include breakpoint( ">480px" ) {
+			border-radius: 0;
+			border: 0;
+		}
+	}
+
+	a, svg {
+		display: block;
+		width: 100%; // Safari fix
+	}
+}
+
+.jpo-homepage__choice-copy {
+	border-top: 1px solid rgba(200, 215, 225, 0.5);
+
+	@include breakpoint( "<480px" ) {
+		padding: 16px;
+		border-top: 0;
+	}
+}
+
+@include breakpoint( ">480px" ) {
+	.jpo-homepage__choice-copy {
+		padding: 15px;
+		border-top: 1px solid transparentize( lighten( $gray, 20% ), .5 );
+	}
+}
+
+.jpo-homepage__image {
+	display: none;
+
+	@include breakpoint( ">480px" ) {
+		display: block;
+	}
 }

--- a/client/signup/steps/jpo-homepage/style.scss
+++ b/client/signup/steps/jpo-homepage/style.scss
@@ -135,6 +135,32 @@
 	}
 }
 
+.jpo-homepage__choice-link {
+	padding-right: 40px;
+	display: block;
+	box-sizing: border-box;
+
+	&:after {
+		content: '';
+		display: block;
+		width: 8px; //Match the size of the cta copy
+		height: 8px; //Match the size of the cta copy
+		position: absolute;
+		top: 20px;
+		right: 15px;
+		border-top: 2px solid lighten( $gray, 20% );
+		border-right: 2px solid lighten( $gray, 20% );
+		transform: rotate(45deg);
+	}
+
+	@include breakpoint( ">480px" ) {
+		padding-right: 0;
+		&:after {
+			display: none;
+		}
+	}
+}
+
 .jpo-homepage__choice-copy {
 	border-top: 1px solid rgba(200, 215, 225, 0.5);
 

--- a/client/signup/steps/jpo-homepage/style.scss
+++ b/client/signup/steps/jpo-homepage/style.scss
@@ -34,7 +34,7 @@
 		}
 
 		.button {
-			font-size: 1.25rem;
+			font-size: 1.5rem;
 			margin-bottom: 1rem;
 			color: $blue-wordpress;
 			padding: 7px;

--- a/client/signup/steps/jpo-homepage/style.scss
+++ b/client/signup/steps/jpo-homepage/style.scss
@@ -17,7 +17,7 @@
 		text-align: center;
 		padding: 0;
 
-		@media (max-width: 480px) {
+		@include breakpoint( "<480px" ) {
 		width: 100%;
 		text-align: left;
 		}
@@ -34,11 +34,32 @@
 		}
 
 		.button {
-			font-size: 1.5rem;
+			font-size: 1.25rem;
 			margin-bottom: 1rem;
 			color: $blue-wordpress;
-			padding: 7px;
 			line-height: 1;
+
+			@include breakpoint( ">480px" ) {
+				padding: 7px;
+			}
+
+			@include breakpoint( "<480px" ) {
+				margin-bottom: 0;
+				font-size:1.5rem;
+				padding: 0;
+			}
+
+			.jpo-homepage__cta {
+				@include breakpoint( ">480px" ) {
+					background: none;
+					font-size: 1.1em;
+					border: 0;
+					padding: 0;
+					text-transform: none;
+					margin: 0;
+					line-height: 1.1em;
+				}
+			}
 		}
 	}
 
@@ -52,10 +73,10 @@
 		margin-right: 2%;
 	}
     
-    @media (max-width: 480px) {
+    @include breakpoint( "<480px" ) {
 		margin-right: 10px;
 		width: 100%;
-   		text-align: left;
+		text-align: left;
 	}
 }
 

--- a/client/signup/steps/jpo-site-type/style.scss
+++ b/client/signup/steps/jpo-site-type/style.scss
@@ -206,7 +206,7 @@ p.jpo-site-type__description {
 			color: $blue-dark;
 		}
 
-		.jpo-site-type__choice-link:after {
+		.jpo-site-type__choice-link {
 			border-top-color: $blue-dark;
 			border-right-color: $blue-dark;
 		}

--- a/client/signup/steps/jpo-site-type/style.scss
+++ b/client/signup/steps/jpo-site-type/style.scss
@@ -285,3 +285,11 @@ p.jpo-site-type__description {
 		}
 	}
 }
+
+.jpo-site-type__image {
+	display: none;
+
+	@include breakpoint( ">480px" ) {
+		display: block;
+	}
+}


### PR DESCRIPTION
Changes at largest breakpoint:
* updates margins
* updates the card formatting to allow for full horizontal rule between the image and button/text area 
* updates the image area padding

Changes at the smaller breakpoint:
_updates to match previous steps and WP.com sign up flow better_
* stacked & joined cards
* evened out the left and right card margins* made the full cards selectable 
* hid images
* added the arrows w/ `choice-link` (second commit)
* updating the card heading size (third commit)
