### PR TITLE
Reader: Fix Manage popover arrow and width

### DIFF
--- a/client/components/reader-popover/style.scss
+++ b/client/components/reader-popover/style.scss
@@ -22,10 +22,10 @@
 }
 
 .reader-popover.popover.is-bottom .popover__arrow,
-.reader-popover.popover.is-bottom-left .popover__arrow
+.reader-popover.popover.is-bottom-left .popover__arrow,
 .reader-popover.popover.is-bottom-right .popover__arrow {
 
-	&::before{
+	&::before {
 		border: 10px solid $gray-light;
 		border-bottom-style: solid;
 		border-left-color: transparent;
@@ -56,6 +56,7 @@
 .reader-popover__wrapper {
 	display: flex;
 	flex-direction: column;
+	min-width: 200px;
 }
 
 .reader-popover__header {


### PR DESCRIPTION
This PR fixes the popovers in Manage:

1. Change arrow color from white to `$gray-light`
2. Add space in between "New comments" and toggle control

**Before:**
![screenshot 2017-08-18 16 45 44](https://user-images.githubusercontent.com/4924246/29481350-11edb382-8435-11e7-8e2b-925316995b9d.png)

**After:**
![screenshot 2017-08-18 16 45 54](https://user-images.githubusercontent.com/4924246/29481352-14ea6940-8435-11e7-879f-bb32fd049ad0.png)
