### PR TITLE
Change prefix for rebrand cities.

### DIFF
--- a/client/lib/rebrand-cities/index.js
+++ b/client/lib/rebrand-cities/index.js
@@ -13,7 +13,7 @@ function generateUniqueSiteUrl( prefix ) {
 	return `${ prefix }${ uuidWithoutHyphens() }`;
 }
 
-const rebrandCitiesPrefix = 'site';
+const rebrandCitiesPrefix = 'rebrandcitiessite';
 
 function generateUniqueRebrandCitiesSiteUrl() {
 	return generateUniqueSiteUrl( rebrandCitiesPrefix );


### PR DESCRIPTION
This tiny PR changes the site prefix for autogenerated rebrand cities sites to 'rebrandcitiessite'.