### PR TITLE
Updated site.items initial state to null.

### DIFF
--- a/client/state/selectors/are-all-sites-single-user.js
+++ b/client/state/selectors/are-all-sites-single-user.js
@@ -3,8 +3,8 @@
 /**
  * Internal dependencies
  */
-
 import createSelector from 'lib/create-selector';
+import { getSitesItems } from 'state/selectors';
 import { isSingleUserSite } from 'state/sites/selectors';
 
 /**
@@ -13,7 +13,10 @@ import { isSingleUserSite } from 'state/sites/selectors';
  * @param  {Object}  state Global state tree
  * @return {Boolean}       True if all sites are single user sites
  */
-export default createSelector( state => {
-	const siteIds = Object.keys( state.sites.items );
-	return !! siteIds.length && siteIds.every( siteId => isSingleUserSite( state, siteId ) );
-}, state => state.sites.items );
+export default createSelector(
+	state => {
+		const siteIds = Object.keys( getSitesItems( state ) );
+		return !! siteIds.length && siteIds.every( siteId => isSingleUserSite( state, siteId ) );
+	},
+	getSitesItems
+);

--- a/client/state/selectors/get-network-sites.js
+++ b/client/state/selectors/get-network-sites.js
@@ -10,7 +10,7 @@ import { filter } from 'lodash';
  * Internal dependencies
  */
 import createSelector from 'lib/create-selector';
-import { isMainSiteOf } from 'state/selectors';
+import { isMainSiteOf, getSitesItems } from 'state/selectors';
 import { getSite, isJetpackSiteMainNetworkSite } from 'state/sites/selectors';
 
 /**
@@ -28,9 +28,9 @@ export default createSelector(
 		}
 
 		return filter(
-			state.sites.items,
+			getSitesItems( state ),
 			site => mainSiteId === site.ID || isMainSiteOf( state, mainSiteId, site.ID )
 		).map( site => getSite( state, site.ID ) );
 	},
-	state => [ state.sites.items, state.currentUser.capabilities ]
+	state => [ getSitesItems( state ), state.currentUser.capabilities ]
 );

--- a/client/state/selectors/get-newest-site.js
+++ b/client/state/selectors/get-newest-site.js
@@ -10,6 +10,7 @@ import { sortBy } from 'lodash';
  */
 import { getSite } from 'state/sites/selectors';
 import createSelector from 'lib/create-selector';
+import { getSitesItems } from 'state/selectors';
 
 /**
  * Get the newest site of the current user
@@ -19,7 +20,7 @@ import createSelector from 'lib/create-selector';
  */
 export default createSelector(
 	state => {
-		const newestSite = sortBy( Object.values( state.sites.items ), 'ID' ).pop();
+		const newestSite = sortBy( Object.values( getSitesItems( state ) ), 'ID' ).pop();
 
 		if ( ! newestSite ) {
 			return null;
@@ -27,5 +28,5 @@ export default createSelector(
 
 		return getSite( state, newestSite.ID );
 	},
-	state => [ state.sites.items, state.currentUser.capabilities ]
+	state => [ getSitesItems( state ), state.currentUser.capabilities ]
 );

--- a/client/state/selectors/get-public-sites.js
+++ b/client/state/selectors/get-public-sites.js
@@ -3,7 +3,7 @@
 /**
  * Internal dependencies
  */
-
+import { getSitesItems } from 'state/selectors';
 import { getSite } from 'state/sites/selectors';
 import createSelector from 'lib/create-selector';
 
@@ -14,10 +14,9 @@ import createSelector from 'lib/create-selector';
  * @return {Array}        Site objects
  */
 export default createSelector(
-	state => {
-		return Object.values( state.sites.items )
+	state =>
+		Object.values( getSitesItems( state ) )
 			.filter( site => ! site.is_private )
-			.map( site => getSite( state, site.ID ) );
-	},
-	state => [ state.sites.items, state.currentUser.capabilities ]
+			.map( site => getSite( state, site.ID ) ),
+	state => [ getSitesItems( state ), state.currentUser.capabilities ]
 );

--- a/client/state/selectors/get-sites.js
+++ b/client/state/selectors/get-sites.js
@@ -11,7 +11,7 @@ import { partition, sortBy } from 'lodash';
  */
 import createSelector from 'lib/create-selector';
 import { getSite } from 'state/sites/selectors';
-import { getPrimarySiteId } from 'state/selectors';
+import { getPrimarySiteId, getSitesItems } from 'state/selectors';
 
 const sortByNameAndUrl = list => sortBy( list, [ 'name', 'URL' ] );
 
@@ -24,11 +24,11 @@ const sortByNameAndUrl = list => sortBy( list, [ 'name', 'URL' ] );
 export default createSelector(
 	state => {
 		const primarySiteId = getPrimarySiteId( state );
-		const [ primarySite, sites ] = partition( state.sites.items, { ID: primarySiteId } );
+		const [ primarySite, sites ] = partition( getSitesItems( state ), { ID: primarySiteId } );
 
 		return [ ...primarySite, ...sortByNameAndUrl( sites ) ].map( site =>
 			getSite( state, site.ID )
 		);
 	},
-	state => [ state.sites.items, state.currentUser.capabilities ]
+	state => [ getSitesItems( state ), state.currentUser.capabilities ]
 );

--- a/client/state/selectors/get-visible-sites.js
+++ b/client/state/selectors/get-visible-sites.js
@@ -5,6 +5,7 @@
  */
 
 import { getSite } from 'state/sites/selectors';
+import { getSitesItems } from 'state/selectors';
 
 /**
  * Get all visible sites
@@ -12,8 +13,7 @@ import { getSite } from 'state/sites/selectors';
  * @param {Object} state  Global state tree
  * @return {Array}        Sites objects
  */
-export default function getVisibleSites( state ) {
-	return Object.values( state.sites.items )
+export default state =>
+	Object.values( getSitesItems( state ) )
 		.filter( site => site.visible === true )
 		.map( site => getSite( state, site.ID ) );
-}

--- a/client/state/selectors/has-jetpack-sites.js
+++ b/client/state/selectors/has-jetpack-sites.js
@@ -6,6 +6,7 @@
 
 import createSelector from 'lib/create-selector';
 import { isJetpackSite } from 'state/sites/selectors';
+import { getSitesItems } from 'state/selectors';
 
 /**
  * Returns true if the user has one or more Jetpack sites, and false otherwise.
@@ -14,6 +15,6 @@ import { isJetpackSite } from 'state/sites/selectors';
  * @return {Boolean} Whether Jetpack sites exist or not
  */
 export default createSelector( state => {
-	const siteIds = Object.keys( state.sites.items );
+	const siteIds = Object.keys( getSitesItems( state ) );
 	return siteIds.some( siteId => isJetpackSite( state, siteId ) );
-}, state => state.sites.items );
+}, getSitesItems );

--- a/client/state/selectors/is-connected-secondary-network-site.js
+++ b/client/state/selectors/is-connected-secondary-network-site.js
@@ -4,13 +4,13 @@
  * External dependencies
  */
 
-import { get, some } from 'lodash';
+import { some } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import createSelector from 'lib/create-selector';
-import { isMainSiteOf } from 'state/selectors';
+import { getSitesItems, isMainSiteOf } from 'state/selectors';
 
 /**
  * Returns true if site with id equal to siteId is a connected secondary network site and false otherwise
@@ -22,6 +22,6 @@ import { isMainSiteOf } from 'state/selectors';
  * @return {Boolean}             Whether site with id equal to siteId is a connected secondary network site
  */
 export default createSelector( ( state, siteId ) => {
-	const siteIds = Object.keys( get( state, 'sites.items', {} ) );
+	const siteIds = Object.keys( getSitesItems( state ) );
 	return some( siteIds, mainSiteId => isMainSiteOf( state, mainSiteId, siteId ) );
-}, state => state.sites.items );
+}, getSitesItems );

--- a/client/state/selectors/user-has-any-paid-plans.js
+++ b/client/state/selectors/user-has-any-paid-plans.js
@@ -9,6 +9,7 @@ import { some } from 'lodash';
  * Internal dependencies
  */
 import createSelector from 'lib/create-selector';
+import { getSitesItems } from 'state/selectors';
 import { isPlan } from 'lib/products-values';
 
 /**
@@ -18,6 +19,6 @@ import { isPlan } from 'lib/products-values';
  * @return {Object}       Site object
  */
 export default createSelector(
-	state => some( state.sites.items, site => isPlan( site.plan ) ),
-	state => [ state.sites.items ]
+	state => some( getSitesItems( state ), site => isPlan( site.plan ) ),
+	state => [ getSitesItems( state ) ]
 );

--- a/client/state/sites/reducer.js
+++ b/client/state/sites/reducer.js
@@ -56,7 +56,10 @@ const VALID_SITE_KEYS = Object.keys( sitesSchema.patternProperties[ '^\\d+$' ].p
  * @param  {Object} action Action payload
  * @return {Object}        Updated state
  */
-export function items( state = {}, action ) {
+export function items( state = null, action ) {
+	if ( state === null && action.type !== SITE_RECEIVE && action.type !== SITES_RECEIVE ) {
+		return null;
+	}
 	switch ( action.type ) {
 		case WORDADS_SITE_APPROVE_REQUEST_SUCCESS:
 			const prevSite = state[ action.siteId ];
@@ -93,12 +96,10 @@ export function items( state = {}, action ) {
 					memo[ site.ID ] = transformedSite;
 					return memo;
 				},
-				initialNextState
+				initialNextState || {}
 			);
 
 		case SITE_DELETE_RECEIVE:
-			return omit( state, action.siteId );
-
 		case JETPACK_DISCONNECT_RECEIVE:
 			return omit( state, action.siteId );
 

--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -35,7 +35,7 @@ import { fromApi as seoTitleFromApi } from 'components/seo/meta-title-editor/map
 import versionCompare from 'lib/version-compare';
 import { getCustomizerFocus } from 'my-sites/customize/panels';
 import { getSiteComputedAttributes } from './utils';
-import { isSiteUpgradeable, getSiteOptions } from 'state/selectors';
+import { isSiteUpgradeable, getSiteOptions, getSitesItems } from 'state/selectors';
 
 /**
  * Returns a raw site object by its ID.
@@ -45,7 +45,7 @@ import { isSiteUpgradeable, getSiteOptions } from 'state/selectors';
  * @return {?Object}        Site object
  */
 export const getRawSite = ( state, siteId ) => {
-	return state.sites.items[ siteId ] || null;
+	return getSitesItems( state )[ siteId ] || null;
 };
 
 /**
@@ -58,12 +58,12 @@ export const getRawSite = ( state, siteId ) => {
 export const getSiteBySlug = createSelector(
 	( state, siteSlug ) =>
 		find(
-			state.sites.items,
+			getSitesItems( state ),
 			( item, siteId ) =>
 				// find always passes the siteId as a string. We need it as a integer
 				getSiteSlug( state, parseInt( siteId, 10 ) ) === siteSlug
 		) || null,
-	state => state.sites.items
+	getSitesItems
 );
 
 /**
@@ -128,20 +128,24 @@ export function getJetpackComputedAttributes( state, siteId ) {
  * @param  {Object}   state Global state tree
  * @return {Number[]}       WordPress.com site IDs with collisions
  */
-export const getSiteCollisions = createSelector( state => {
-	return map(
-		filter( state.sites.items, wpcomSite => {
-			const wpcomSiteUrlSansProtocol = withoutHttp( wpcomSite.URL );
-			return (
-				! wpcomSite.jetpack &&
-				some( state.sites.items, jetpackSite => {
-					return jetpackSite.jetpack && wpcomSiteUrlSansProtocol === withoutHttp( jetpackSite.URL );
-				} )
-			);
-		} ),
-		'ID'
-	);
-}, state => state.sites.items );
+export const getSiteCollisions = createSelector(
+	state =>
+		map(
+			filter( getSitesItems( state ), wpcomSite => {
+				const wpcomSiteUrlSansProtocol = withoutHttp( wpcomSite.URL );
+				return (
+					! wpcomSite.jetpack &&
+					some(
+						getSitesItems( state ),
+						jetpackSite =>
+							jetpackSite.jetpack && wpcomSiteUrlSansProtocol === withoutHttp( jetpackSite.URL )
+					)
+				);
+			} ),
+			'ID'
+		),
+	getSitesItems
+);
 
 /**
  * Returns true if a collision exists for the specified WordPress.com site ID.

--- a/client/state/sites/test/reducer.js
+++ b/client/state/sites/test/reducer.js
@@ -94,10 +94,10 @@ describe( 'reducer', () => {
 	} );
 
 	describe( '#items()', () => {
-		test( 'should default to an empty object', () => {
+		test( 'should default to null', () => {
 			const state = items( undefined, {} );
 
-			expect( state ).to.eql( {} );
+			expect( state ).to.be.null;
 		} );
 
 		test( 'can receive all sites', () => {
@@ -607,7 +607,7 @@ describe( 'reducer', () => {
 			} );
 			const state = items( original, { type: DESERIALIZE } );
 
-			expect( state ).to.eql( {} );
+			expect( state ).to.be.null;
 		} );
 	} );
 


### PR DESCRIPTION
This PR is part of an action plan (https://github.com/Automattic/wp-calypso/issues/17376) to make sites requests in the data-layer paradigm.

Currently, site.items initial state is an empty object. That leaves us with a problem: "How can we differentiate between the state the user has no sites, and the state where sites were not loaded?".
Right now we are using flags that indicate if a request is in progress or not.
We want to move sites to the data-layer and the use of this flags is not in accordance with the "data-layer philosophy" (more details of this in (https://github.com/Automattic/wp-calypso/pull/17213).

This change affects the whole application, now we need to be resilient again state.sites.items being null, to do that I changed all the selectors not currently resilient against that. But we should test the most possible to check if there is any missing case.

**To test** 
Sites are used everywhere in the app so try to navigate around and check things look ok. This PR is risky a not easy to spot way where sites.items are being used and not resilient against null values may exist. I will continue the testing efforts but every help is welcome.

**Test live**
https://calypso.live/?branch=update/site-items-intial-null