### PR TITLE
Created new selector that checks if sites have been loaded

### DIFF
--- a/client/state/selectors/has-loaded-sites.js
+++ b/client/state/selectors/has-loaded-sites.js
@@ -1,0 +1,8 @@
+/**
+ * Returns true if sites have been loaded in the state
+ * @param  {Object}  state Global state tree
+ * @return {Boolean}       Has sites been loaded
+ */
+export default function hasLoadedSites( state ) {
+	return state.sites.items !== null;
+}

--- a/client/state/selectors/test/has-loaded-sites.js
+++ b/client/state/selectors/test/has-loaded-sites.js
@@ -1,0 +1,21 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { hasLoadedSites } from 'state/selectors';
+
+describe( 'hasLoadedSites()', () => {
+	it( 'should return false if site items are null', () => {
+		expect( hasLoadedSites( { sites: { items: null } } ) ).to.be.false;
+	} );
+	it( 'should return true if site items are empty', () => {
+		expect( hasLoadedSites( { sites: { items: {} } } ) ).to.be.true;
+	} );
+	it( 'should return true if sites exist in state', () => {
+		expect( hasLoadedSites( { sites: { items: { 1: { ID: 1 } } } } ) ).to.be.true;
+	} );
+} );


### PR DESCRIPTION
This PR is part of an action plan (https://github.com/Automattic/wp-calypso/issues/17376) to make sites requests in the data-layer paradigm.

With the change from https://github.com/Automattic/wp-calypso/pull/17364 that changes initial state of sites.items to null, now to check if sites are loaded we don't need a flag and he can simply check if site.items is different from null. This allows to replace the requestingAll flag, and the isRequestingSites.
It should not be merged before https://github.com/Automattic/wp-calypso/pull/17364.

**To test**
This PR just creates the selector so automatic tests are probably enough.