### PR TITLE
Comments: Fix checkbox position on small screens

### DIFF
--- a/client/blocks/comment-detail/comment-detail-header.jsx
+++ b/client/blocks/comment-detail/comment-detail-header.jsx
@@ -74,12 +74,12 @@ export const CommentDetailHeader = ( {
 			className={ classNames( 'comment-detail__header', 'is-preview', { 'is-bulk-edit': isBulkEdit } ) }
 			onClick={ isBulkEdit ? toggleSelected : toggleExpanded }
 		>
-			{ isBulkEdit &&
-				<label className="comment-detail__checkbox">
-					<FormCheckbox checked={ commentIsSelected } onChange={ noop } />
-				</label>
-			}
 			<div className="comment-detail__author-preview">
+				{ isBulkEdit &&
+					<label className="comment-detail__checkbox">
+						<FormCheckbox checked={ commentIsSelected } onChange={ noop } />
+					</label>
+				}
 				<Gravatar user={ author } />
 				<div className="comment-detail__author-info">
 					<div className="comment-detail__author-info-element">

--- a/client/blocks/comment-detail/style.scss
+++ b/client/blocks/comment-detail/style.scss
@@ -89,13 +89,12 @@
 
 	&.is-bulk-edit {
 		.comment-detail__checkbox {
-			padding-left: 8px;
+			padding-right: 12px;
 			.form-checkbox {
 				margin: 0;
 			}
 		}
 		.comment-detail__author-preview {
-			padding: 0 12px;
 			.external-link:hover,
 			.external-link:focus {
 				outline: none;


### PR DESCRIPTION
Fix the incorrect position of the bulk edit checkbox on small screens.
No visible changes on large screens.

| Before | After |
| --- | --- |
| <img width="657" alt="screen shot 2017-08-20 at 10 18 56" src="https://user-images.githubusercontent.com/2070010/29493145-229ee3ec-8591-11e7-84d2-933c503341bf.png"> | <img width="661" alt="screen shot 2017-08-20 at 10 19 14" src="https://user-images.githubusercontent.com/2070010/29493148-27ea25c8-8591-11e7-9a47-23fc90d819dd.png"> |
| <img width="850" alt="screen shot 2017-08-20 at 10 10 35" src="https://user-images.githubusercontent.com/2070010/29493139-160945aa-8591-11e7-8297-7ad0057cfbd4.png"> | <img width="848" alt="screen shot 2017-08-20 at 10 14 21" src="https://user-images.githubusercontent.com/2070010/29493142-1ac990ae-8591-11e7-9f93-d12ec8e34cfb.png"> |

To test, run the branch with `ENABLE_FEATURES=manage/comments/bulk-actions npm start`