### PR TITLE
View Site: Open the site in a new tab on cmd click

### DIFF
--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -86,6 +86,19 @@ export class MySitesSidebar extends Component {
 		}
 	};
 
+	onViewSiteClick = ( event ) => {
+		const { site } = this.props;
+		analytics.ga.recordEvent( 'Sidebar', 'Clicked View Site' );
+
+		if ( site.is_previewable && ! event.metaKey && ! event.ctrlKey ) {
+			return this.onNavigate();
+		}
+		if ( window && site.URL ) {
+			event.preventDefault();
+			window.open( site.URL );
+		}
+	};
+
 	itemLinkClass = ( paths, existingClasses ) => {
 		var classSet = {};
 
@@ -162,7 +175,7 @@ export class MySitesSidebar extends Component {
 				label={ this.props.translate( 'View Site' ) }
 				className={ this.itemLinkClass( [ '/view' ], 'preview' ) }
 				link={ isPreviewable ? '/view' + this.props.siteSuffix : site.URL }
-				onNavigate={ this.onNavigate }
+				onNavigate={ this.onViewSiteClick }
 				icon="computer"
 				preloadSectionName="preview"
 			/>


### PR DESCRIPTION
Also, triggers the `'Sidebar', 'Clicked View Site'` GA event from the old UI we weren't.

Fixes #17212

## To Test

* Click on `View Site` in various situations for various types of sites (wpcom, jetpack, ssl, not) -- all previewable sites should open the section within calypso. Non-previewable sites should open in a new tab.
* Repeat the above with the cmd (or ctrl on non mac keyboards) key pressed. It should always open the site in a new tab.
* After cmd+clicking, regular clicking should still open the view site section as above.