### PR TITLE
Changed isRequestingSites selector to hasLoadedSites selector in my-sites plugins

### DIFF
--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -32,12 +32,11 @@ import JetpackManageErrorPage from 'my-sites/jetpack-manage-error-page';
 import PluginsBrowser from './plugins-browser';
 import NonSupportedJetpackVersionNotice from './not-supported-jetpack-version';
 import NoPermissionsError from './no-permissions-error';
-import { canCurrentUser, canCurrentUserManagePlugins } from 'state/selectors';
+import { canCurrentUser, canCurrentUserManagePlugins, hasLoadedSites } from 'state/selectors';
 import {
 	canJetpackSiteManage,
 	canJetpackSiteUpdateFiles,
 	isJetpackSite,
-	isRequestingSites,
 } from 'state/sites/selectors';
 import { getSelectedSite, getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import { getSelectedOrAllSitesWithPlugins } from 'state/selectors';
@@ -419,7 +418,7 @@ const PluginsMain = createReactClass( {
 	render() {
 		const { selectedSiteId } = this.props;
 
-		if ( ! this.props.isRequestingSites && ! this.props.userCanManagePlugins ) {
+		if ( this.props.hasLoadedSites && ! this.props.userCanManagePlugins ) {
 			return <NoPermissionsError title={ this.props.translate( 'Plugins', { textOnly: true } ) } />;
 		}
 
@@ -501,7 +500,7 @@ export default connect(
 			canJetpackSiteUpdateFiles: siteId => canJetpackSiteUpdateFiles( state, siteId ),
 			isJetpackSite: siteId => isJetpackSite( state, siteId ),
 			wporgPlugins: state.plugins.wporg.items,
-			isRequestingSites: isRequestingSites( state ),
+			hasLoadedSites: hasLoadedSites( state ),
 			userCanManagePlugins: selectedSiteId
 				? canCurrentUser( state, selectedSiteId, 'manage_options' )
 				: canCurrentUserManagePlugins( state ),

--- a/client/my-sites/plugins/plugin.jsx
+++ b/client/my-sites/plugins/plugin.jsx
@@ -30,11 +30,12 @@ import PluginSectionsCustom from 'my-sites/plugins/plugin-sections/custom';
 import DocumentHead from 'components/data/document-head';
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 import { recordGoogleEvent } from 'state/analytics/actions';
-import { canJetpackSiteManage, isJetpackSite, isRequestingSites } from 'state/sites/selectors';
+import { canJetpackSiteManage, isJetpackSite } from 'state/sites/selectors';
 import {
 	canCurrentUser,
 	canCurrentUserManagePlugins,
 	getSelectedOrAllSitesWithPlugins,
+	hasLoadedSites,
 	isSiteAutomatedTransfer,
 } from 'state/selectors';
 import NonSupportedJetpackVersionNotice from './not-supported-jetpack-version';
@@ -326,7 +327,7 @@ const SinglePlugin = createReactClass( {
 	render() {
 		const { selectedSite } = this.props;
 
-		if ( ! this.props.isRequestingSites && ! this.props.userCanManagePlugins ) {
+		if ( this.props.hasLoadedSites && ! this.props.userCanManagePlugins ) {
 			return <NoPermissionsError title={ this.getPageTitle() } />;
 		}
 
@@ -415,7 +416,7 @@ export default connect(
 			isJetpackSite: siteId => isJetpackSite( state, siteId ),
 			canJetpackSiteManage: siteId => canJetpackSiteManage( state, siteId ),
 			isSiteAutomatedTransfer: isSiteAutomatedTransfer( state, selectedSiteId ),
-			isRequestingSites: isRequestingSites( state ),
+			hasLoadedSites: hasLoadedSites( state ),
 			userCanManagePlugins: selectedSiteId
 				? canCurrentUser( state, selectedSiteId, 'manage_options' )
 				: canCurrentUserManagePlugins( state ),

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -30,14 +30,10 @@ import {
 	canCurrentUser,
 	getSelectedOrAllSitesJetpackCanManage,
 	hasJetpackSites,
+	hasLoadedSites,
 } from 'state/selectors';
 import { getSelectedSite, getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
-import {
-	getSitePlan,
-	isJetpackSite,
-	isRequestingSites,
-	canJetpackSiteManage,
-} from 'state/sites/selectors';
+import { getSitePlan, isJetpackSite, canJetpackSiteManage } from 'state/sites/selectors';
 import NonSupportedJetpackVersionNotice from 'my-sites/plugins/not-supported-jetpack-version';
 import NoPermissionsError from 'my-sites/plugins/no-permissions-error';
 import HeaderButton from 'components/header-button';
@@ -494,7 +490,7 @@ const PluginsBrowser = createReactClass( {
 	},
 
 	render() {
-		if ( ! this.props.isRequestingSites && this.props.noPermissionsError ) {
+		if ( this.props.hasLoadedSites && this.props.noPermissionsError ) {
 			return (
 				<NoPermissionsError
 					title={ this.props.translate( 'Plugin Browser', { textOnly: true } ) }
@@ -537,7 +533,7 @@ export default connect(
 			jetpackManageError:
 				!! isJetpackSite( state, selectedSiteId ) &&
 				! canJetpackSiteManage( state, selectedSiteId ),
-			isRequestingSites: isRequestingSites( state ),
+			hasLoadedSites: hasLoadedSites( state ),
 			noPermissionsError:
 				!! selectedSiteId && ! canCurrentUser( state, selectedSiteId, 'manage_options' ),
 			selectedSite: getSelectedSite( state ),


### PR DESCRIPTION
This PR is part of an action plan (https://github.com/Automattic/wp-calypso/issues/17376) to make sites requests in the data-layer philosophy.

isRequestingSites uses flags in the state to check if a request is in progress. With the move to the data-layer there is an effort in progress to not use this kind of flags and directly check in the state if the data is there or not, hasLoadedSites does that.