### PR TITLE
Changed isRequestingSites selector to hasLoadedSites selector in client/me.

### DIFF
--- a/client/me/notification-settings/blogs-settings/index.jsx
+++ b/client/me/notification-settings/blogs-settings/index.jsx
@@ -14,8 +14,7 @@ import Immutable from 'immutable';
 /**
  * Internal dependencies
  */
-import { getSites } from 'state/selectors';
-import { isRequestingSites } from 'state/sites/selectors';
+import { hasLoadedSites, getSites } from 'state/selectors';
 import EmptyContentComponent from 'components/empty-content';
 import Blog from './blog';
 import InfiniteList from 'components/infinite-list';
@@ -28,8 +27,8 @@ const getItemRef = ( { ID } ) => `blog-${ ID }`;
 
 class BlogsSettings extends Component {
 	static propTypes = {
+		hasLoadedSites: PropTypes.bool.isRequired,
 		sites: PropTypes.array.isRequired,
-		requestingSites: PropTypes.bool.isRequired,
 		settings: PropTypes.instanceOf( Immutable.List ),
 		hasUnsavedChanges: PropTypes.bool.isRequired,
 		onToggle: PropTypes.func.isRequired,
@@ -38,13 +37,13 @@ class BlogsSettings extends Component {
 	};
 
 	render() {
-		const { sites, requestingSites, translate } = this.props;
+		const { sites, translate } = this.props;
 
 		if ( ! sites || ! this.props.settings ) {
 			return <Placeholder />;
 		}
 
-		if ( sites.length === 0 && ! requestingSites ) {
+		if ( sites.length === 0 && this.props.hasLoadedSites ) {
 			return (
 				<EmptyContentComponent
 					title={ translate( "You don't have any WordPress sites yet." ) }
@@ -95,7 +94,7 @@ class BlogsSettings extends Component {
 
 const mapStateToProps = state => ( {
 	sites: getSites( state ),
-	requestingSites: isRequestingSites( state ),
+	hasLoadedSites: hasLoadedSites( state ),
 } );
 
 export default connect( mapStateToProps )( localize( BlogsSettings ) );

--- a/client/me/purchases/cancel-privacy-protection/index.jsx
+++ b/client/me/purchases/cancel-privacy-protection/index.jsx
@@ -24,7 +24,7 @@ import {
 import { getPurchase, isDataLoading, goToManagePurchase, recordPageView } from '../utils';
 import { getSelectedSite as getSelectedSiteSelector } from 'state/ui/selectors';
 import { hasPrivacyProtection, isRefundable } from 'lib/purchases';
-import { isRequestingSites } from 'state/sites/selectors';
+import { hasLoadedSites } from 'state/selectors';
 import Main from 'components/main';
 import notices from 'notices';
 import Notice from 'components/notice';
@@ -227,7 +227,7 @@ class CancelPrivacyProtection extends Component {
 export default connect(
 	( state, props ) => ( {
 		error: getPurchasesError( state ),
-		hasLoadedSites: ! isRequestingSites( state ),
+		hasLoadedSites: hasLoadedSites( state ),
 		hasLoadedUserPurchasesFromServer: hasLoadedUserPurchasesFromServer( state ),
 		selectedPurchase: getByPurchaseId( state, props.purchaseId ),
 		selectedSite: getSelectedSiteSelector( state ),

--- a/client/me/purchases/cancel-purchase/index.jsx
+++ b/client/me/purchases/cancel-purchase/index.jsx
@@ -36,7 +36,7 @@ import { getSelectedSite as getSelectedSiteSelector } from 'state/ui/selectors';
 import HeaderCake from 'components/header-cake';
 import { isDataLoading } from 'me/purchases/utils';
 import { isDomainRegistration, isDomainTransfer } from 'lib/products-values';
-import { isRequestingSites } from 'state/sites/selectors';
+import { hasLoadedSites } from 'state/selectors';
 import Main from 'components/main';
 import paths from '../paths';
 import QueryUserPurchases from 'components/data/query-user-purchases';
@@ -190,7 +190,7 @@ class CancelPurchase extends React.Component {
 }
 
 export default connect( ( state, props ) => ( {
-	hasLoadedSites: ! isRequestingSites( state ),
+	hasLoadedSites: hasLoadedSites( state ),
 	hasLoadedUserPurchasesFromServer: hasLoadedUserPurchasesFromServer( state ),
 	selectedPurchase: getByPurchaseId( state, props.purchaseId ),
 	selectedSite: getSelectedSiteSelector( state ),

--- a/client/me/purchases/confirm-cancel-domain/index.jsx
+++ b/client/me/purchases/confirm-cancel-domain/index.jsx
@@ -25,13 +25,12 @@ import FormLabel from 'components/forms/form-label';
 import FormSectionHeading from 'components/forms/form-section-heading';
 import FormTextarea from 'components/forms/form-textarea';
 import HeaderCake from 'components/header-cake';
-import { isDomainOnlySite as isDomainOnly } from 'state/selectors';
+import { hasLoadedSites, isDomainOnlySite as isDomainOnly } from 'state/selectors';
 import { getByPurchaseId, hasLoadedUserPurchasesFromServer } from 'state/purchases/selectors';
 import { getName as getDomainName } from 'lib/purchases';
 import { getPurchase, goToCancelPurchase, isDataLoading, recordPageView } from '../utils';
 import { getSelectedSite as getSelectedSiteSelector } from 'state/ui/selectors';
 import { isDomainRegistration } from 'lib/products-values';
-import { isRequestingSites } from 'state/sites/selectors';
 import Main from 'components/main';
 import notices from 'notices';
 import paths from 'me/purchases/paths';
@@ -304,7 +303,7 @@ export default connect(
 		const selectedSite = getSelectedSiteSelector( state );
 
 		return {
-			hasLoadedSites: ! isRequestingSites( state ),
+			hasLoadedSites: hasLoadedSites( state ),
 			hasLoadedUserPurchasesFromServer: hasLoadedUserPurchasesFromServer( state ),
 			isDomainOnlySite: isDomainOnly( state, selectedSite && selectedSite.ID ),
 			selectedPurchase: getByPurchaseId( state, props.purchaseId ),

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -62,7 +62,7 @@ import {
 	isDomainTransfer,
 	isTheme,
 } from 'lib/products-values';
-import { isRequestingSites } from 'state/sites/selectors';
+import { hasLoadedSites } from 'state/selectors';
 import Main from 'components/main';
 import PlanIcon from 'components/plans/plan-icon';
 import PlanPrice from 'my-sites/plan-price';
@@ -471,7 +471,7 @@ export default connect( ( state, props ) => {
 	const isPurchasePlan = selectedPurchase && isPlan( selectedPurchase );
 	const isPurchaseTheme = selectedPurchase && isTheme( selectedPurchase );
 	return {
-		hasLoadedSites: ! isRequestingSites( state ),
+		hasLoadedSites: hasLoadedSites( state ),
 		hasLoadedUserPurchasesFromServer: hasLoadedUserPurchasesFromServer( state ),
 		selectedPurchase,
 		selectedSiteId,

--- a/client/me/purchases/manage-purchase/plan-details/index.jsx
+++ b/client/me/purchases/manage-purchase/plan-details/index.jsx
@@ -18,7 +18,7 @@ import FormLabel from 'components/forms/form-label';
 import QueryPluginKeys from 'components/data/query-plugin-keys';
 import SectionHeader from 'components/section-header';
 import PlanBillingPeriod from './billing-period';
-import { isRequestingSites } from 'state/sites/selectors';
+import { hasLoadedSites } from 'state/selectors';
 import { getByPurchaseId, hasLoadedUserPurchasesFromServer } from 'state/purchases/selectors';
 import { getPurchase, isDataLoading } from 'me/purchases/utils';
 import { getName, isExpired } from 'lib/purchases';
@@ -96,7 +96,7 @@ class PurchasePlanDetails extends Component {
 // hasLoadedSites & hasLoadedUserPurchasesFromServer are used in isDataLoading,
 // selectedPurchase is used in getPurchase
 export default connect( ( state, props ) => ( {
-	hasLoadedSites: ! isRequestingSites( state ),
+	hasLoadedSites: hasLoadedSites( state ),
 	hasLoadedUserPurchasesFromServer: hasLoadedUserPurchasesFromServer( state ),
 	selectedPurchase: getByPurchaseId( state, props.purchaseId ),
 	pluginList: props.selectedSite ? getPluginsForSite( state, props.selectedSite.ID ) : [],

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -30,7 +30,7 @@ import {
 import { isMonthly } from 'lib/plans/constants';
 import { isDomainRegistration, isDomainTransfer } from 'lib/products-values';
 import { getByPurchaseId, hasLoadedUserPurchasesFromServer } from 'state/purchases/selectors';
-import { isRequestingSites } from 'state/sites/selectors';
+import { hasLoadedSites } from 'state/selectors';
 import { getSelectedSite as getSelectedSiteSelector } from 'state/ui/selectors';
 import { getUser } from 'state/users/selectors';
 import paths from '../paths';
@@ -343,7 +343,7 @@ export default connect( ( state, props ) => {
 	const purchase = getByPurchaseId( state, props.purchaseId );
 
 	return {
-		hasLoadedSites: ! isRequestingSites( state ),
+		hasLoadedSites: hasLoadedSites( state ),
 		hasLoadedUserPurchasesFromServer: hasLoadedUserPurchasesFromServer( state ),
 		selectedPurchase: purchase,
 		selectedSite: getSelectedSiteSelector( state ),

--- a/client/me/purchases/payment/add-card-details/index.jsx
+++ b/client/me/purchases/payment/add-card-details/index.jsx
@@ -18,7 +18,7 @@ import { getByPurchaseId, hasLoadedUserPurchasesFromServer } from 'state/purchas
 import { getSelectedSite as getSelectedSiteSelector } from 'state/ui/selectors';
 import HeaderCake from 'components/header-cake';
 import { isDataLoading, recordPageView } from 'me/purchases/utils';
-import { isRequestingSites } from 'state/sites/selectors';
+import { hasLoadedSites } from 'state/selectors';
 import Main from 'components/main';
 import PurchaseCardDetails from 'me/purchases/components/purchase-card-details';
 import QueryUserPurchases from 'components/data/query-user-purchases';
@@ -76,7 +76,7 @@ class AddCardDetails extends PurchaseCardDetails {
 
 const mapStateToProps = ( state, { purchaseId } ) => {
 	return {
-		hasLoadedSites: ! isRequestingSites( state ),
+		hasLoadedSites: hasLoadedSites( state ),
 		hasLoadedUserPurchasesFromServer: hasLoadedUserPurchasesFromServer( state ),
 		selectedPurchase: getByPurchaseId( state, purchaseId ),
 		selectedSite: getSelectedSiteSelector( state ),

--- a/client/me/purchases/payment/edit-card-details/index.jsx
+++ b/client/me/purchases/payment/edit-card-details/index.jsx
@@ -19,7 +19,7 @@ import { getSelectedSite as getSelectedSiteSelector } from 'state/ui/selectors';
 import { getStoredCardById, hasLoadedStoredCardsFromServer } from 'state/stored-cards/selectors';
 import HeaderCake from 'components/header-cake';
 import { isDataLoading, recordPageView } from 'me/purchases/utils';
-import { isRequestingSites } from 'state/sites/selectors';
+import { hasLoadedSites } from 'state/selectors';
 import Main from 'components/main';
 import PurchaseCardDetails from 'me/purchases/components/purchase-card-details';
 import QueryStoredCards from 'components/data/query-stored-cards';
@@ -84,7 +84,7 @@ class EditCardDetails extends PurchaseCardDetails {
 const mapStateToProps = ( state, { cardId, purchaseId } ) => {
 	return {
 		card: getStoredCardById( state, cardId ),
-		hasLoadedSites: ! isRequestingSites( state ),
+		hasLoadedSites: hasLoadedSites( state ),
 		hasLoadedStoredCardsFromServer: hasLoadedStoredCardsFromServer( state ),
 		hasLoadedUserPurchasesFromServer: hasLoadedUserPurchasesFromServer( state ),
 		selectedPurchase: getByPurchaseId( state, purchaseId ),


### PR DESCRIPTION
This PR is part of an action plan (https://github.com/Automattic/wp-calypso/issues/17376) to make sites requests in the data-layer philosophy.

isRequestingSites uses flags in the state to check if a request is in progress. With the move to the data-layer there is an effort in progress to not use this kind of flags and directly check in the state if the data is there or not, hasLoadedSites does that.