### PR TITLE
Changed isRequestingSites selector to hasLoadedSites selector in jetpack-connect.

### DIFF
--- a/client/jetpack-connect/auth-logged-in-form.jsx
+++ b/client/jetpack-connect/auth-logged-in-form.jsx
@@ -46,7 +46,7 @@ class LoggedInForm extends Component {
 		calypsoStartedConnection: PropTypes.bool,
 		goBackToWpAdmin: PropTypes.func.isRequired,
 		isAlreadyOnSitesList: PropTypes.bool,
-		isFetchingSites: PropTypes.bool,
+		hasLoadedSites: PropTypes.bool,
 		isFetchingAuthorizationSite: PropTypes.bool,
 		isSSO: PropTypes.bool,
 		isWCS: PropTypes.bool,
@@ -207,7 +207,7 @@ class LoggedInForm extends Component {
 		} = this.props.jetpackConnectAuthorize;
 
 		if ( ! this.props.isAlreadyOnSitesList &&
-			! this.props.isFetchingSites,
+			this.props.hasLoadedSites,
 			queryObject.already_authorized ) {
 			this.props.recordTracksEvent( 'calypso_jpc_back_wpadmin_click' );
 			return this.props.goBackToWpAdmin( queryObject.redirect_after_auth );
@@ -287,7 +287,7 @@ class LoggedInForm extends Component {
 
 	renderNotices() {
 		const { authorizeError, queryObject, isAuthorizing, authorizeSuccess, userAlreadyConnected } = this.props.jetpackConnectAuthorize;
-		if ( queryObject.already_authorized && ! this.props.isFetchingSites && ! this.props.isAlreadyOnSitesList ) {
+		if ( queryObject.already_authorized && this.props.hasLoadedSites && ! this.props.isAlreadyOnSitesList ) {
 			// For users who start their journey at `wordpress.com/jetpack/connect` or similar flows, we will discourage
 			// additional users from linking. Although it is possible to link multiple users with Jetpack, the `jetpack/connect`
 			// flows will be reserved for brand new connections.
@@ -341,7 +341,7 @@ class LoggedInForm extends Component {
 		} = this.props.jetpackConnectAuthorize;
 
 		if ( ! this.props.isAlreadyOnSitesList &&
-			! this.props.isFetchingSites &&
+			this.props.hasLoadedSites &&
 			queryObject.already_authorized ) {
 			return translate( 'Go back to your site' );
 		}

--- a/client/jetpack-connect/authorize-form.jsx
+++ b/client/jetpack-connect/authorize-form.jsx
@@ -33,7 +33,8 @@ import { getCurrentUser } from 'state/current-user/selectors';
 import { recordTracksEvent } from 'state/analytics/actions';
 import EmptyContent from 'components/empty-content';
 import { requestSites } from 'state/sites/actions';
-import { isRequestingSites, isRequestingSite } from 'state/sites/selectors';
+import { hasLoadedSites } from 'state/selectors';
+import { isRequestingSite } from 'state/sites/selectors';
 import MainWrapper from './main-wrapper';
 import HelpButton from './help-button';
 import { urlToSlug } from 'lib/url';
@@ -50,7 +51,7 @@ class JetpackConnectAuthorizeForm extends Component {
 		goToXmlrpcErrorFallbackUrl: PropTypes.func,
 		isAlreadyOnSitesList: PropTypes.bool,
 		isFetchingAuthorizationSite: PropTypes.bool,
-		isFetchingSites: PropTypes.bool,
+		hasLoadedSites: PropTypes.bool,
 		jetpackConnectAuthorize: PropTypes.shape( {
 			queryObject: PropTypes.shape( {
 				client_id: PropTypes.string,
@@ -158,7 +159,7 @@ export default connect(
 			calypsoStartedConnection: isCalypsoStartedConnection( state, remoteSiteUrl ),
 			isAlreadyOnSitesList: isRemoteSiteOnSitesList( state ),
 			isFetchingAuthorizationSite: isRequestingSite( state, siteId ),
-			isFetchingSites: isRequestingSites( state ),
+			hasLoadedSites: hasLoadedSites( state ),
 			jetpackConnectAuthorize: getAuthorizationData( state ),
 			requestHasExpiredSecretError,
 			requestHasXmlrpcError,

--- a/client/jetpack-connect/main.jsx
+++ b/client/jetpack-connect/main.jsx
@@ -21,7 +21,7 @@ import {
 	getConnectingSite,
 	getJetpackSiteByUrl
 } from 'state/jetpack-connect/selectors';
-import { isRequestingSites } from 'state/sites/selectors';
+import { hasLoadedSites } from 'state/selectors';
 import QuerySites from 'components/data/query-sites';
 import JetpackInstallStep from './install-step';
 import versionCompare from 'lib/version-compare';
@@ -108,7 +108,7 @@ class JetpackConnectMain extends Component {
 			return this.props.goToPlans( this.state.currentUrl );
 		}
 
-		if ( this.state.waitingForSites && ! this.props.isRequestingSites ) {
+		if ( this.state.waitingForSites && this.props.hasLoadedSites ) {
 			// eslint-disable-next-line react/no-did-update-set-state
 			this.setState( { waitingForSites: false } );
 			this.checkUrl( this.state.currentUrl );
@@ -158,7 +158,7 @@ class JetpackConnectMain extends Component {
 		this.props.recordTracksEvent( 'calypso_jpc_url_submit', {
 			jetpack_url: this.state.currentUrl
 		} );
-		if ( this.props.isRequestingSites ) {
+		if ( ! this.props.hasLoadedSites ) {
 			this.setState( { waitingForSites: true } );
 		} else {
 			this.checkUrl( this.state.currentUrl );
@@ -481,7 +481,7 @@ const connectComponent = connect(
 	state => ( {
 		jetpackConnectSite: getConnectingSite( state ),
 		getJetpackSiteByUrl: ( url ) => getJetpackSiteByUrl( state, url ),
-		isRequestingSites: isRequestingSites( state ),
+		hasLoadedSites: hasLoadedSites( state ),
 		selectedPlan: getGlobalSelectedPlan( state )
 	} ),
 	{


### PR DESCRIPTION
This PR is part of an action plan (https://github.com/Automattic/wp-calypso/issues/17376) to make sites requests in the data-layer philosophy.

isRequestingSites uses flags in the state to check if a request is in progress. With the move to the data-layer there is an effort in progress to not use this kind of flags and directly check in the state if the data is there or not, hasLoadedSites does that.