### PR TITLE
Domains: restrict unmodifiable WHOIS update fields per selected domain

### DIFF
--- a/client/lib/domains/assembler.js
+++ b/client/lib/domains/assembler.js
@@ -44,6 +44,7 @@ function createDomainObjects( dataTransferObject ) {
 			subscriptionId: domain.subscription_id,
 			transferLockOnWhoisUpdateOptional: domain.transfer_lock_on_whois_update_optional,
 			type: getDomainType( domain ),
+			whoisUpdateUnmodifiableFields: domain.whois_update_unmodifiable_fields,
 		};
 	} );
 

--- a/client/lib/domains/test/assembler.js
+++ b/client/lib/domains/test/assembler.js
@@ -55,6 +55,7 @@ describe( 'assembler', () => {
 			subscriptionId: undefined,
 			type: domainTypes.SITE_REDIRECT,
 			transferLockOnWhoisUpdateOptional: undefined,
+			whoisUpdateUnmodifiableFields: undefined,
 			hasZone: undefined,
 			pointsToWpcom: undefined
 		},

--- a/client/my-sites/domains/domain-management/edit-contact-info/form-card.jsx
+++ b/client/my-sites/domains/domain-management/edit-contact-info/form-card.jsx
@@ -5,10 +5,13 @@ import React from 'react';
 import {
 	deburr,
 	endsWith,
+	get,
+	includes,
 	isEqual,
 	keys,
 	omit,
 	pick,
+	snakeCase,
 } from 'lodash';
 import page from 'page';
 import { bindActionCreators } from 'redux';
@@ -390,12 +393,16 @@ class EditContactInfoFormCard extends React.Component {
 
 	getField( Component, props ) {
 		const { name } = props;
+		const unmodifiableFields = get( this.props, [ 'selectedDomain', 'whoisUpdateUnmodifiableFields' ], [] );
+		const isDisabled = this.state.formSubmitting ||
+			formState.isFieldDisabled( this.state.form, name ) ||
+			includes( unmodifiableFields, snakeCase( name ) );
 
 		return (
 			<Component
 				{ ...props }
 				additionalClasses="edit-contact-info__form-field"
-				disabled={ this.state.formSubmitting || formState.isFieldDisabled( this.state.form, name ) }
+				disabled={ isDisabled }
 				isError={ formState.isFieldInvalid( this.state.form, name ) }
 				value={ formState.getFieldValue( this.state.form, name ) }
 				onChange={ this.onChange } />

--- a/client/state/sites/domains/assembler.js
+++ b/client/state/sites/domains/assembler.js
@@ -38,5 +38,6 @@ export const createSiteDomainObject = domain => {
 		subscriptionId: domain.subscription_id,
 		transferLockOnWhoisUpdateOptional: Boolean( domain.transfer_lock_on_whois_update_optional ),
 		type: getDomainType( domain ),
+		whoisUpdateUnmodifiableFields: domain.whois_update_unmodifiable_fields,
 	};
 };

--- a/client/state/sites/domains/test/fixture/index.js
+++ b/client/state/sites/domains/test/fixture/index.js
@@ -53,6 +53,7 @@ export const DOMAIN_PRIMARY = {
 	subscriptionId: SUBSCRIPTION_ID_FIRST,
 	type: 'MAPPED',
 	transferLockOnWhoisUpdateOptional: true,
+	whoisUpdateUnmodifiableFields: [],
 	isWPCOMDomain: false
 };
 
@@ -92,6 +93,7 @@ export const DOMAIN_NOT_PRIMARY = {
 	subscriptionId: SUBSCRIPTION_ID_SECOND,
 	type: 'WPCOM',
 	transferLockOnWhoisUpdateOptional: false,
+	whoisUpdateUnmodifiableFields: [ 'first_name', 'last_name' ],
 	isWPCOMDomain: true
 };
 
@@ -132,6 +134,7 @@ export const REST_API_SITE_DOMAIN_FIRST = {
 	subscription_id: SUBSCRIPTION_ID_FIRST,
 	type: 'mapping',
 	transfer_lock_on_whois_update_optional: true,
+	whois_update_unmodifiable_fields: [],
 	wpcom_domain: false
 };
 
@@ -167,6 +170,7 @@ export const REST_API_SITE_DOMAIN_SECOND = {
 	registration_date: '',
 	subscription_id: SUBSCRIPTION_ID_SECOND,
 	type: 'wpcom',
+	whois_update_unmodifiable_fields: [ 'first_name', 'last_name' ],
 	wpcom_domain: true
 };
 


### PR DESCRIPTION
Some TLDs (eg, .fr) have WHOIS fields that will be restricted from update here at WP.com due to ugly backend complications. This change enables pulling of that information from the TLD spec on the backend.