### PR TITLE
Login: Fix Google login popup being blocked in IE

### DIFF
--- a/client/components/social-buttons/google.js
+++ b/client/components/social-buttons/google.js
@@ -123,7 +123,7 @@ class GoogleLoginButton extends Component {
 
 		// Options are documented here:
 		// https://developers.google.com/api-client-library/javascript/reference/referencedocs#gapiauth2signinoptions
-		Promise.resolve( window.gapi.auth2.getAuthInstance().signIn( { prompt: 'select_account' } ) )
+		window.gapi.auth2.getAuthInstance().signIn( { prompt: 'select_account' } )
 			.then( responseHandler )
 			.catch( error => {
 				this.props.recordTracksEvent( 'calypso_login_social_button_failure', {

--- a/client/components/social-buttons/google.js
+++ b/client/components/social-buttons/google.js
@@ -104,6 +104,10 @@ class GoogleLoginButton extends Component {
 	handleClick( event ) {
 		event.preventDefault();
 
+		if ( this.state.isDisabled ) {
+			return;
+		}
+
 		this.props.onClick( event );
 
 		if ( this.state.error ) {
@@ -117,12 +121,10 @@ class GoogleLoginButton extends Component {
 
 		const { responseHandler } = this.props;
 
-		// Handle click async if the library is not loaded yet
-		// the popup might be blocked by the browser in that case
-		// options are documented here:
+		// Options are documented here:
 		// https://developers.google.com/api-client-library/javascript/reference/referencedocs#gapiauth2signinoptions
-		this.initialize()
-			.then( gapi => gapi.auth2.getAuthInstance().signIn( { prompt: 'select_account' } ).then( responseHandler ) )
+		Promise.resolve( window.gapi.auth2.getAuthInstance().signIn( { prompt: 'select_account' } ) )
+			.then( responseHandler )
 			.catch( error => {
 				this.props.recordTracksEvent( 'calypso_login_social_button_failure', {
 					social_account_type: 'google',


### PR DESCRIPTION
This pull request fixes #15554 and #15396.

#### Testing instructions

1. Run `git checkout fix/15554-google-login-popup-ie` and start your server, or open a [live branch](https://calypso.live/log-in?branch=fix/15554-google-login-popup-ie)
2. Open the [`Log In` page](http://calypso.localhost:3000/log-in) in IE or Windows Phone browser
3. Click/Tap the Google button, and confirm that the Google popup opens

#### Reviews

- [ ] Code
- [ ] Product
