### PR TITLE
OAuth2: Don't display the back link if there's no URL to use.

### DIFF
--- a/client/login/wp-login/login-links.jsx
+++ b/client/login/wp-login/login-links.jsx
@@ -74,6 +74,10 @@ export class LoginLinks extends React.Component {
 
 		if ( oauth2ClientData ) {
 			url = oauth2ClientData.url;
+			if ( ! url ) {
+				return null;
+			}
+
 			message = translate( 'Back to %(clientTitle)s', {
 				args: {
 					clientTitle: oauth2ClientData.title

--- a/client/login/wp-login/login-links.jsx
+++ b/client/login/wp-login/login-links.jsx
@@ -12,6 +12,7 @@ import page from 'page';
 import { addQueryArgs } from 'lib/url';
 import { addLocaleToWpcomUrl } from 'lib/i18n-utils';
 import { isEnabled } from 'config';
+import safeProtocolUrl from 'lib/safe-protocol-url';
 import ExternalLink from 'components/external-link';
 import Gridicon from 'gridicons';
 import { getCurrentUserId } from 'state/current-user/selectors';
@@ -73,8 +74,8 @@ export class LoginLinks extends React.Component {
 		let message = translate( 'Back to WordPress.com' );
 
 		if ( oauth2ClientData ) {
-			url = oauth2ClientData.url;
-			if ( ! url ) {
+			url = safeProtocolUrl( oauth2ClientData.url );
+			if ( ! url || url === 'http:' ) {
 				return null;
 			}
 


### PR DESCRIPTION
This works in conjunction with D6925.

#### Testing instructions

1. Apply D6925 to your sandbox, and sandbox public-api.wordpress.com.
1. Run `git checkout fix/oauth-return-link-empty-url` and start your server, or open a [live branch](https://calypso.live/?branch=fix/oauth-return-link-empty-url)
2. Open the [`Log In` page](http://calypso.localhost:3000/log-in?client_id=928)
3. Check that the Return link doesn't display
4. Visit a different OAuth2 [`Log In` page](http://calypso.localhost:3000/log-in?client_id=1)
5. Check that the Return link does display

#### Additional notes

This is determined by the return value from the OAuth client data API call, so you can also check that the API response is sending an empty URL, too.

#### Reviews

- [x] Code
- [x] Product
