### PR TITLE
Enable social signup in production

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -92,7 +92,7 @@
 		"settings/security/monitor": true,
 		"settings/theme-setup": false,
 		"signup/domain-first-flow": true,
-		"signup/social": false,
+		"signup/social": true,
 		"simple-payments": true,
 		"support-user": true,
 		"sync-handler": true,

--- a/config/production.json
+++ b/config/production.json
@@ -93,7 +93,7 @@
 		"settings/security/monitor": true,
 		"settings/theme-setup": false,
 		"signup/domain-first-flow": true,
-		"signup/social": false,
+		"signup/social": true,
 		"simple-payments": true,
 		"support-user": true,
 		"sync-handler": true,

--- a/config/test.json
+++ b/config/test.json
@@ -92,7 +92,7 @@
 		"settings/security/monitor": true,
 		"settings/theme-setup": false,
 		"signup/domain-first-flow": true,
-		"signup/social": false,
+		"signup/social": true,
 		"support-user": true,
 		"sync-handler": true,
 		"ui/first-view": false,


### PR DESCRIPTION
This pull request soft launches social signup in production. We won't be pushing signups to this flow, so it will only be found on /log-in for now. This is to enable us to launch to a smaller subset of users to stress test the feature.
    
#### Testing instructions
  
1. Run `git checkout update/social-signup-config`
2. Start your server with NODE_ENV=production npm start
2. Open the [`Login` page](http://calypso.localhost:3000/log-in)
3. Check that you see the "Connect with Google" button
4. Check that social login works
5. Check that social login isn't available on signup


#### Reviews
  
- [x] Code
- [x] Product
