### PR TITLE
Don't allow /en in the login URL

### DIFF
--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import React from 'react';
-import page from 'page';
 
 /**
  * Internal dependencies
@@ -35,11 +34,6 @@ const enhanceContextWithLogin = context => {
 export default {
 	login( context, next ) {
 		const { query: { client_id } } = context;
-
-		if ( 'en' === context.params.lang ) {
-			page.redirect( path.replace( /\/en\/?$/, '' ) );
-			return;
-		}
 
 		if ( client_id ) {
 			context.store.dispatch( fetchOAuth2ClientData( Number( client_id ) ) )

--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react';
+import page from 'page';
 
 /**
  * Internal dependencies
@@ -34,6 +35,11 @@ const enhanceContextWithLogin = context => {
 export default {
 	login( context, next ) {
 		const { query: { client_id } } = context;
+
+		if ( 'en' === context.params.lang ) {
+			page.redirect( path.replace( /\/en\/?$/, '' ) );
+			return;
+		}
 
 		if ( client_id ) {
 			context.store.dispatch( fetchOAuth2ClientData( Number( client_id ) ) )

--- a/client/login/index.node.js
+++ b/client/login/index.node.js
@@ -1,0 +1,17 @@
+/**
+ * Internal dependencies
+ */
+import config from 'config';
+import webRouter from './index.web';
+
+export default router => {
+	if ( config.isEnabled( 'login/wp-login' ) ) {
+		router(
+			'/log-in/en', ( { res } ) => {
+				res.redirect( 301, '/log-in' );
+			}
+		);
+	}
+
+	webRouter( router );
+};

--- a/client/login/index.web.js
+++ b/client/login/index.web.js
@@ -1,4 +1,10 @@
 /**
+ * External dependencies
+ */
+
+import page from 'page';
+
+/**
  * Internal dependencies
  */
 import config from 'config';
@@ -29,6 +35,11 @@ export default router => {
 	}
 
 	if ( config.isEnabled( 'login/wp-login' ) ) {
+		router(
+			'/log-in/en', () => {
+				page.redirect( '/log-in' );
+			}
+		);
 		router(
 			[
 				'/log-in/:twoFactorAuthType(authenticator|backup|sms|push)/:lang?',

--- a/client/login/index.web.js
+++ b/client/login/index.web.js
@@ -1,10 +1,4 @@
 /**
- * External dependencies
- */
-
-import page from 'page';
-
-/**
  * Internal dependencies
  */
 import config from 'config';
@@ -35,11 +29,7 @@ export default router => {
 	}
 
 	if ( config.isEnabled( 'login/wp-login' ) ) {
-		router(
-			'/log-in/en', () => {
-				page.redirect( '/log-in' );
-			}
-		);
+		router( '/log-in/en', '/log-in' );
 		router(
 			[
 				'/log-in/:twoFactorAuthType(authenticator|backup|sms|push)/:lang?',

--- a/client/login/package.json
+++ b/client/login/package.json
@@ -1,0 +1,4 @@
+{
+	"main": "index.node.js",
+	"browser": "index.web.js"
+}


### PR DESCRIPTION
This pull request fixes #14965 by redirecting the URL to the base log-in URL, when `/en` is encountered.

#### Testing instructions

1. Run `git checkout fix/14965-english-locale-url` and start your server, or open a [live branch](https://calypso.live/?branch=fix/14965-english-locale-url)
2. Open the [`Log In` page](http://calypso.localhost:3000/log-in)
3. Check that the [en locale](http://calypso.localhost:3000/log-in/en) redirects correctly
4. Check that loading a [non-en locale](http://calypso.localhost:3000/log-in/fr) works correctly
5. While on the non-en locale, click the "Also available in English" link in the locale switcher, check that it redirects correctly

#### Reviews

- [x] Code
- [x] Product