### PR TITLE
Comments: Update header style

### DIFF
--- a/client/blocks/comment-detail/comment-detail-header.jsx
+++ b/client/blocks/comment-detail/comment-detail-header.jsx
@@ -39,9 +39,24 @@ export const CommentDetailHeader = ( {
 	toggleTrash,
 	translate,
 } ) => {
-	if ( isExpanded ) {
-		return (
-			<div className="comment-detail__header">
+	const author = {
+		avatar_URL: authorAvatarUrl,
+		display_name: authorDisplayName,
+	};
+
+	const classes = classNames( 'comment-detail__header', {
+		'is-preview': ! isExpanded,
+		'is-bulk-edit': isBulkEdit,
+	} );
+
+	const handleFullHeaderClick = isBulkEdit ? toggleSelected : toggleExpanded;
+
+	return (
+		<div
+			className={ classes }
+			onClick={ isExpanded ? noop : handleFullHeaderClick }
+		>
+			{ isExpanded &&
 				<CommentDetailActions
 					edit={ edit }
 					commentIsLiked={ commentIsLiked }
@@ -52,55 +67,49 @@ export const CommentDetailHeader = ( {
 					toggleSpam={ toggleSpam }
 					toggleTrash={ toggleTrash }
 				/>
-				<Button
-					borderless
-					className="comment-detail__action-collapse"
-					onClick={ toggleExpanded }
-				>
-					<Gridicon icon="cross" />
-				</Button>
-			</div>
-		);
-	}
+			}
 
-	const author = {
-		avatar_URL: authorAvatarUrl,
-		display_name: authorDisplayName,
-	};
-
-	return (
-		<div
-			className={ classNames( 'comment-detail__header', 'is-preview', { 'is-bulk-edit': isBulkEdit } ) }
-			onClick={ isBulkEdit ? toggleSelected : toggleExpanded }
-		>
-			{ isBulkEdit &&
+			{ ! isExpanded && isBulkEdit &&
 				<label className="comment-detail__checkbox">
 					<FormCheckbox checked={ commentIsSelected } onChange={ noop } />
 				</label>
 			}
-			<div className="comment-detail__author-preview">
-				<Gravatar user={ author } />
-				<div className="comment-detail__author-info">
-					<div className="comment-detail__author-info-element">
-						<strong>
-							{ authorDisplayName }
-						</strong>
-						<span>
-							{ urlToDomainAndPath( authorUrl ) }
-						</span>
+
+			{ ! isExpanded &&
+				<div className="comment-detail__header-content">
+					<div className="comment-detail__author-preview">
+						<Gravatar user={ author } />
+						<div className="comment-detail__author-info">
+							<div className="comment-detail__author-info-element">
+								<strong>
+									{ authorDisplayName }
+								</strong>
+								<span>
+									{ urlToDomainAndPath( authorUrl ) }
+								</span>
+							</div>
+							<div className="comment-detail__author-info-element">
+								{ translate( 'on %(postTitle)s', { args: {
+									postTitle: postTitle ? decodeEntities( postTitle ) : translate( 'Untitled' ),
+								} } ) }
+							</div>
+						</div>
 					</div>
-					<div className="comment-detail__author-info-element">
-						{ translate( 'on %(postTitle)s', { args: {
-							postTitle: postTitle ? decodeEntities( postTitle ) : translate( 'Untitled' ),
-						} } ) }
-					</div>
+					<AutoDirection>
+						<div className="comment-detail__comment-preview">
+							{ decodeEntities( stripHTML( commentContent ) ) }
+						</div>
+					</AutoDirection>
 				</div>
-			</div>
-			<AutoDirection>
-				<div className="comment-detail__comment-preview">
-					{ decodeEntities( stripHTML( commentContent ) ) }
-				</div>
-			</AutoDirection>
+			}
+
+			<Button
+				borderless
+				className="comment-detail__action-collapse"
+				onClick={ isExpanded ? toggleExpanded : noop }
+			>
+				<Gridicon icon="cross" />
+			</Button>
 		</div>
 	);
 };

--- a/client/blocks/comment-detail/comment-detail-header.jsx
+++ b/client/blocks/comment-detail/comment-detail-header.jsx
@@ -69,15 +69,14 @@ export const CommentDetailHeader = ( {
 				/>
 			}
 
-			{ ! isExpanded && isBulkEdit &&
-				<label className="comment-detail__checkbox">
-					<FormCheckbox checked={ commentIsSelected } onChange={ noop } />
-				</label>
-			}
-
 			{ ! isExpanded &&
 				<div className="comment-detail__header-content">
 					<div className="comment-detail__author-preview">
+						{ isBulkEdit &&
+							<label className="comment-detail__checkbox">
+								<FormCheckbox checked={ commentIsSelected } onChange={ noop } />
+							</label>
+						}
 						<Gravatar user={ author } />
 						<div className="comment-detail__author-info">
 							<div className="comment-detail__author-info-element">
@@ -103,13 +102,15 @@ export const CommentDetailHeader = ( {
 				</div>
 			}
 
-			<Button
-				borderless
-				className="comment-detail__action-collapse"
-				onClick={ isExpanded ? toggleExpanded : noop }
-			>
-				<Gridicon icon="cross" />
-			</Button>
+			{ ! isBulkEdit &&
+				<Button
+					borderless
+					className="comment-detail__action-collapse"
+					onClick={ isExpanded ? toggleExpanded : noop }
+				>
+					<Gridicon icon="cross" />
+				</Button>
+			}
 		</div>
 	);
 };

--- a/client/blocks/comment-detail/comment-detail-header.jsx
+++ b/client/blocks/comment-detail/comment-detail-header.jsx
@@ -42,14 +42,6 @@ export const CommentDetailHeader = ( {
 	if ( isExpanded ) {
 		return (
 			<div className="comment-detail__header">
-				<Button
-					borderless
-					className="comment-detail__action-collapse"
-					onClick={ toggleExpanded }
-				>
-					<Gridicon icon="cross" />
-				</Button>
-
 				<CommentDetailActions
 					edit={ edit }
 					commentIsLiked={ commentIsLiked }
@@ -60,6 +52,13 @@ export const CommentDetailHeader = ( {
 					toggleSpam={ toggleSpam }
 					toggleTrash={ toggleTrash }
 				/>
+				<Button
+					borderless
+					className="comment-detail__action-collapse"
+					onClick={ toggleExpanded }
+				>
+					<Gridicon icon="cross" />
+				</Button>
 			</div>
 		);
 	}

--- a/client/blocks/comment-detail/comment-detail-header.jsx
+++ b/client/blocks/comment-detail/comment-detail-header.jsx
@@ -108,7 +108,7 @@ export const CommentDetailHeader = ( {
 					className="comment-detail__action-collapse"
 					onClick={ isExpanded ? toggleExpanded : noop }
 				>
-					<Gridicon icon="cross" />
+					<Gridicon icon="chevron-down" />
 				</Button>
 			}
 		</div>

--- a/client/blocks/comment-detail/style.scss
+++ b/client/blocks/comment-detail/style.scss
@@ -114,19 +114,30 @@
 		}
 	}
 
-	.comment-detail__action-collapse .gridicon {
-		transform: rotate( 180deg );
-		transition: transform .15s cubic-bezier(0.175, .885, .32, 1.275), color .20s ease-in;
+	.comment-detail__action-collapse {
+		.gridicon {
+			fill: $gray;
+			transform: rotate( 180deg );
+			transition: transform .15s cubic-bezier(0.175, .885, .32, 1.275), color .20s ease-in;
+		}
+		&:hover .gridicon {
+			fill: $blue-medium;
+		}
 	}
 
-	&.is-preview .comment-detail__action-collapse {
-		flex: none;
-		margin-top: -6px;
-		text-align: center;
-		width: 36px;
+	&.is-preview {
+		&:hover .comment-detail__action-collapse .gridicon {
+			fill: $blue-medium;
+		}
+		.comment-detail__action-collapse {
+			flex: none;
+			margin-top: -6px;
+			text-align: center;
+			width: 36px;
 
-		.gridicon {
-			transform: rotate( 0deg );
+			.gridicon {
+				transform: rotate( 0deg );
+			}
 		}
 	}
 

--- a/client/blocks/comment-detail/style.scss
+++ b/client/blocks/comment-detail/style.scss
@@ -96,14 +96,17 @@
 	}
 
 	&.is-bulk-edit {
+		.comment-detail__header-content {
+			width: 100%;
+		}
+
 		.comment-detail__checkbox {
-			padding-left: 8px;
+			padding-right: 12px;
 			.form-checkbox {
 				margin: 0;
 			}
 		}
 		.comment-detail__author-preview {
-			padding: 0 12px;
 			.external-link:hover,
 			.external-link:focus {
 				outline: none;

--- a/client/blocks/comment-detail/style.scss
+++ b/client/blocks/comment-detail/style.scss
@@ -114,11 +114,20 @@
 		}
 	}
 
+	.comment-detail__action-collapse .gridicon {
+		transform: rotate( 180deg );
+		transition: transform .15s cubic-bezier(0.175, .885, .32, 1.275), color .20s ease-in;
+	}
+
 	&.is-preview .comment-detail__action-collapse {
 		flex: none;
 		margin-top: -6px;
 		text-align: center;
 		width: 36px;
+
+		.gridicon {
+			transform: rotate( 0deg );
+		}
 	}
 
 	&:not( .is-preview ) .button.is-borderless {

--- a/client/blocks/comment-detail/style.scss
+++ b/client/blocks/comment-detail/style.scss
@@ -113,8 +113,8 @@
 
 		&.comment-detail__action-collapse {
 			flex-grow: 1;
-			padding-left: 12px;
-			text-align: left;
+			padding-right: 12px;
+			text-align: right;
 		}
 	}
 
@@ -189,7 +189,7 @@
 
 .comment-detail__actions {
 	color: $gray;
-	padding-right: 4px;
+	padding-left: 4px;
 	user-select: none;
 
 	.button.is-borderless {

--- a/client/blocks/comment-detail/style.scss
+++ b/client/blocks/comment-detail/style.scss
@@ -78,12 +78,20 @@
 	display: flex;
 	flex-flow: row nowrap;
 
+	.comment-detail__header-content {
+		display: flex;
+		flex-wrap: nowrap;
+		width: calc( 100% - 36px );
+	}
+
 	&.is-preview {
 		cursor: pointer;
 		padding: 12px 8px;
 
 		@include breakpoint( "<960px" ) {
-			flex-wrap: wrap;
+			.comment-detail__header-content {
+				flex-wrap: wrap;
+			}
 		}
 	}
 
@@ -103,7 +111,14 @@
 		}
 	}
 
-	.button.is-borderless {
+	&.is-preview .comment-detail__action-collapse {
+		flex: none;
+		margin-top: -6px;
+		text-align: center;
+		width: 36px;
+	}
+
+	&:not( .is-preview ) .button.is-borderless {
 		padding: 12px 8px;
 
 		.gridicon {

--- a/client/blocks/comment-detail/style.scss
+++ b/client/blocks/comment-detail/style.scss
@@ -114,15 +114,13 @@
 		}
 	}
 
-	.comment-detail__action-collapse {
-		.gridicon {
-			fill: $gray;
-			transform: rotate( 180deg );
-			transition: transform .15s cubic-bezier(0.175, .885, .32, 1.275), color .20s ease-in;
-		}
-		&:hover .gridicon {
-			fill: $blue-medium;
-		}
+	.comment-detail__action-collapse .gridicon {
+		fill: $gray;
+		transform: rotate( 180deg );
+		transition: transform .15s cubic-bezier(0.175, .885, .32, 1.275), color .20s ease-in;
+	}
+	.comment-detail__action-collapse:hover .gridicon {
+		fill: $blue-medium;
 	}
 
 	&.is-preview {


### PR DESCRIPTION
Closes #17224
Replaces #17369

Redesign of the Comment Management details cards header to look more like the established `FoldableCard` design and behaviour.
In particular, replace the X icon with a chevron.

| Mode | Small Screen | Large Screen |
| --- | --- | --- |
| Collapsed | <img width="497" alt="screen shot 2017-08-21 at 10 41 16" src="https://user-images.githubusercontent.com/2070010/29510884-ade97710-865d-11e7-8db8-d684800f3008.png"> | <img width="802" alt="screen shot 2017-08-21 at 10 40 40" src="https://user-images.githubusercontent.com/2070010/29510890-b3cec284-865d-11e7-8aaa-1d3152e5b4c4.png"> |
| Expanded | <img width="500" alt="screen shot 2017-08-21 at 10 41 21" src="https://user-images.githubusercontent.com/2070010/29510909-c0cd0400-865d-11e7-9b80-a0554d96b875.png"> | <img width="804" alt="screen shot 2017-08-21 at 10 40 50" src="https://user-images.githubusercontent.com/2070010/29510915-c598675e-865d-11e7-9d8c-cc7bba2c8a1e.png"> |
| Bulk | <img width="501" alt="screen shot 2017-08-21 at 10 41 28" src="https://user-images.githubusercontent.com/2070010/29510929-d2bffcf8-865d-11e7-8d82-ab2c6741e644.png"> | <img width="800" alt="screen shot 2017-08-21 at 10 41 00" src="https://user-images.githubusercontent.com/2070010/29510934-d880e6f2-865d-11e7-9953-fcf4b9a0efb4.png"> |

To test with Bulk Edit enabled, please run the branch with
```bash
env ENABLE_FEATURES=manage/comments/bulk-actions npm start
```

cc @rickybanister, @folletto 

---

This PR follows the changes as proposed here: https://github.com/Automattic/wp-calypso/issues/17224#issuecomment-323206471

> (in orange the clickable area)
>
> Collapsed:
> <img width="673" alt="screen shot 2017-08-17 at 22 42 10" src="https://user-images.githubusercontent.com/2070010/29435298-623d07a8-839e-11e7-9a5a-99cfee432c89.png">
> 
> Expanded:
> <img width="677" alt="screen shot 2017-08-17 at 22 41 59" src="https://user-images.githubusercontent.com/2070010/29435294-5d954788-839e-11e7-93a7-26ab9a45ade3.png">
>
> Bulk Edit:
> <img width="675" alt="screen shot 2017-08-17 at 22 40 36" src="https://user-images.githubusercontent.com/2070010/29435288-57b0d8aa-839e-11e7-820a-7d9da19225aa.png">
> 
> | Collapsed | Expanded | Bulk Edit |
> | --- | --- | --- |
> | No actions | Actions on the left | Checkbox on the left |
> | Chevron down on the right | Chevron up on the right | No chevron |
> | No separator on the chevron (_see note_) | No separator on the chevron | No chevron |
> | Fully clickable to expand | Empty area clickable to collapse | Fully clickable to select |
