### PR TITLE
Insert externals directly in the editor

### DIFF
--- a/client/lib/media/list-store.js
+++ b/client/lib/media/list-store.js
@@ -143,6 +143,22 @@ MediaListStore.isItemMatchingQuery = function( siteId, item ) {
 		matches = item.title && -1 !== item.title.toLowerCase().indexOf( query.search.toLowerCase() );
 	}
 
+	if ( query.source === 'google_photos' && matches ) {
+		// On uploading external images, the stores will receive the CREATE_MEDIA_ITEM  event
+		// and will update the list of media including the new one, but we don't want this new media
+		// to be shown in the google photos list - hence the filtering.
+		//
+		// One use case where this happened was:
+		//
+		// - go to site icon settings and open google modal
+		// - select and image and tap continue
+		// - cancel the editing process and you'll be send back to the google modal
+		//
+		// without this change, the new upload would be shown there.
+
+		matches = ! item.external;
+	}
+
 	if ( query.mime_type && matches ) {
 		// Mime type query can contain a fragment, e.g. "image/", so match
 		// item mime type at beginning

--- a/client/post-editor/media-modal/index.jsx
+++ b/client/post-editor/media-modal/index.jsx
@@ -143,6 +143,29 @@ export class EditorMediaModal extends Component {
 		};
 	}
 
+	copyExternalAfterLoadingWordPressLibrary( selectedMedia, originalSource ) {
+		const { site } = this.props;
+
+		// Trigger the action to clear pointers/selected items
+		MediaActions.sourceChanged( site.ID );
+
+		// Change our state back to WordPress
+		this.setState( {
+			source: '',
+			search: undefined,
+		}, () => {
+			// Copy the selected item from the external source. Note we pass the actual media data as we need this to generate
+			// transient placeholders. This is done after the state changes so our transients and external items appear
+			// in the WordPress library that we've just switched to
+			MediaActions.addExternal( site.ID, selectedMedia, originalSource );
+		} );
+	}
+
+	copyExternal( selectedMedia, originalSource ) {
+		const { site } = this.props;
+		MediaActions.addExternal( site.ID, selectedMedia, originalSource );
+	}
+
 	confirmSelection = () => {
 		const { view, mediaLibrarySelectedItems } = this.props;
 
@@ -152,9 +175,17 @@ export class EditorMediaModal extends Component {
 
 		if ( mediaLibrarySelectedItems.length && this.state.source !== '' ) {
 			const itemsWithTransientId = mediaLibrarySelectedItems.map(
-				( item ) => Object.assign( {}, item, { ID: uniqueId( 'media-' ) } )
+				( item ) => Object.assign( {}, item, { ID: uniqueId( 'media-' ), 'transient': true } )
 			);
-			this.copyExternal( itemsWithTransientId, this.state.source );
+			if ( mediaLibrarySelectedItems.length === 1 ) {
+				this.copyExternal( itemsWithTransientId, this.state.source );
+				this.props.onClose( {
+					type: 'media',
+					items: itemsWithTransientId
+				} );
+			} else {
+				this.copyExternalAfterLoadingWordPressLibrary( itemsWithTransientId, this.state.source );
+			}
 		} else {
 			const value = mediaLibrarySelectedItems.length
 			? {
@@ -354,24 +385,6 @@ export class EditorMediaModal extends Component {
 		}
 	};
 
-	copyExternal = ( selectedItems, originalSource ) => {
-		const { site } = this.props;
-
-		// Trigger the action to clear pointers/selected items
-		MediaActions.sourceChanged( site.ID );
-
-		// Change our state back to WordPress
-		this.setState( {
-			source: '',
-			search: undefined,
-		}, () => {
-			// Copy the selected item from the external source. Note we pass the actual media data as we need this to generate
-			// transient placeholders. This is done after the state changes so our transients and external items appear
-			// in the WordPress library that we've just switched to
-			MediaActions.addExternal( this.props.site.ID, selectedItems, originalSource );
-		} );
-	};
-
 	onSourceChange = source => {
 		MediaActions.sourceChanged( this.props.site.ID );
 		this.setState( { source, search: undefined } );
@@ -430,7 +443,7 @@ export class EditorMediaModal extends Component {
 		if ( this.state.source !== '' ) {
 			buttons.push( {
 				action: 'confirm',
-				label: this.props.translate( 'Copy to media library' ),
+				label: selectedItems.length > 1 ? this.props.translate( 'Copy to media library' ) : this.props.translate( 'Insert' ),
 				isPrimary: true,
 				disabled: isDisabled || 0 === selectedItems.length,
 				onClick: this.confirmSelection

--- a/client/post-editor/media-modal/index.jsx
+++ b/client/post-editor/media-modal/index.jsx
@@ -452,7 +452,7 @@ export class EditorMediaModal extends Component {
 		if ( this.state.source !== '' ) {
 			buttons.push( {
 				action: 'confirm',
-				label: getConfirmButtonLabelForExternal(),
+				label: this.props.labels.confirm || getConfirmButtonLabelForExternal(),
 				isPrimary: true,
 				disabled: isDisabled || 0 === selectedItems.length,
 				onClick: this.confirmSelection

--- a/client/post-editor/media-modal/index.jsx
+++ b/client/post-editor/media-modal/index.jsx
@@ -177,7 +177,7 @@ export class EditorMediaModal extends Component {
 			const itemsWithTransientId = mediaLibrarySelectedItems.map(
 				( item ) => Object.assign( {}, item, { ID: uniqueId( 'media-' ), 'transient': true } )
 			);
-			if ( mediaLibrarySelectedItems.length === 1 ) {
+			if ( itemsWithTransientId.length === 1 && MediaUtils.getMimePrefix( itemsWithTransientId[ 0 ] ) === 'image' ) {
 				this.copyExternal( itemsWithTransientId, this.state.source );
 				this.props.onClose( {
 					type: 'media',
@@ -440,10 +440,19 @@ export class EditorMediaModal extends Component {
 			}
 		];
 
+		const getConfirmButtonLabelForExternal = ( ) => {
+			let label = this.props.translate( 'Insert' );
+			if ( selectedItems.length > 1 ||
+				( selectedItems.length === 1 && MediaUtils.getMimePrefix( selectedItems[ 0 ] ) !== 'image' ) ) {
+				label = this.props.translate( 'Copy to media library' );
+			}
+			return label;
+		};
+
 		if ( this.state.source !== '' ) {
 			buttons.push( {
 				action: 'confirm',
-				label: selectedItems.length > 1 ? this.props.translate( 'Copy to media library' ) : this.props.translate( 'Insert' ),
+				label: getConfirmButtonLabelForExternal(),
 				isPrimary: true,
 				disabled: isDisabled || 0 === selectedItems.length,
 				onClick: this.confirmSelection

--- a/client/post-editor/media-modal/markup.js
+++ b/client/post-editor/media-modal/markup.js
@@ -31,7 +31,7 @@ Markup = {
 	get: function( site, media, options ) {
 		var mimePrefix;
 
-		if ( ! media ) {
+		if ( ! media || media.hasOwnProperty( 'status' ) ) {
 			return '';
 		}
 

--- a/client/post-editor/media-modal/test/index.jsx
+++ b/client/post-editor/media-modal/test/index.jsx
@@ -23,6 +23,7 @@ const DUMMY_MEDIA = [
 	{ ID: 100, date: '2015-06-19T11:36:09-04:00', mime_type: 'image/jpeg' },
 	{ ID: 200, date: '2015-06-19T09:36:09-04:00', mime_type: 'image/jpeg' }
 ];
+const DUMMY_VIDEO_MEDIA = [ { ID: 100, date: '2015-06-19T11:36:09-04:00', mime_type: 'video/mp4' } ];
 const EMPTY_COMPONENT = React.createClass( {
 	render: function() {
 		return <div />;
@@ -179,7 +180,7 @@ describe( 'EditorMediaModal', function() {
 		expect( buttons ).to.be.undefined;
 	} );
 
-	it( 'should show a insert button when viewing external media', () => {
+	it( 'should show an insert button when viewing external media (no selection)', () => {
 		const tree = shallow(
 			<EditorMediaModal
 				site={ DUMMY_SITE }
@@ -194,7 +195,7 @@ describe( 'EditorMediaModal', function() {
 		expect( buttons[ 1 ].label ).to.be.equals( 'Insert' );
 	} );
 
-	it( 'should show a insert button when 1 external media is selected', () => {
+	it( 'should show a insert button when 1 external image is selected', () => {
 		const tree = shallow(
 			<EditorMediaModal
 				site={ DUMMY_SITE }
@@ -208,6 +209,22 @@ describe( 'EditorMediaModal', function() {
 
 		expect( buttons.length ).to.be.equals( 2 );
 		expect( buttons[ 1 ].label ).to.be.equals( 'Insert' );
+	} );
+
+	it( 'should show a copy button when 1 external video is selected', () => {
+		const tree = shallow(
+			<EditorMediaModal
+				site={ DUMMY_SITE }
+				view={ ModalViews.DETAIL }
+				mediaLibrarySelectedItems={ DUMMY_VIDEO_MEDIA }
+				setView={ spy } />
+		).instance();
+
+		tree.setState( { source: 'external' } );
+		const buttons = tree.getModalButtons();
+
+		expect( buttons.length ).to.be.equals( 2 );
+		expect( buttons[ 1 ].label ).to.be.equals( 'Copy to media library' );
 	} );
 
 	it( 'should show a copy button when 2 or more external media are selected', () => {
@@ -302,7 +319,7 @@ describe( 'EditorMediaModal', function() {
 			} );
 		} );
 
-		it( 'should copy external media and insert it in the editor if 1 media is selected and button is pressed', done => {
+		it( 'should copy external media and insert it in the editor if 1 image is selected and button is pressed', done => {
 			const SINGLE_ITEM_MEDIA = DUMMY_MEDIA.slice( 0, 1 );
 			const tree = shallow(
 				<EditorMediaModal
@@ -320,6 +337,30 @@ describe( 'EditorMediaModal', function() {
 			// by using uniqueId, which increments its value within the same session.
 			const transientItems = [
 				Object.assign( {}, SINGLE_ITEM_MEDIA[ 0 ], { ID: 'media-3', 'transient': true } )
+			];
+			process.nextTick( () => {
+				expect( onClose ).to.have.been.calledWith( transientItems, 'external' );
+				done();
+			} );
+		} );
+
+		it( 'should copy external after loading WordPress library if 1 video is selected and button is pressed', done => {
+			const tree = shallow(
+				<EditorMediaModal
+					site={ DUMMY_SITE }
+					mediaLibrarySelectedItems={ DUMMY_VIDEO_MEDIA }
+					view={ ModalViews.DETAIL }
+					setView={ spy } />
+			).instance();
+
+			tree.setState( { source: 'external' } );
+			tree.copyExternalAfterLoadingWordPressLibrary = onClose;
+			tree.confirmSelection();
+
+			// EditorMediaModal will generate transient ID for the media selected
+			// by using uniqueId, which increments its value within the same session.
+			const transientItems = [
+				Object.assign( {}, DUMMY_VIDEO_MEDIA[ 0 ], { ID: 'media-4', 'transient': true } )
 			];
 			process.nextTick( () => {
 				expect( onClose ).to.have.been.calledWith( transientItems, 'external' );


### PR DESCRIPTION
# How to test

* Open the media modal, choose Google source, and select 1 picture. Confirm button should have "Insert" text and upon clicking it, should insert the image as a transient in the editor.
* Open the media modal, choose Google source, and select 2 or more pictures. Confirm button should have "Copy to library" text and upon clicking it, should copy items to library and change the screen to the media library.
* Check that set feature image and site settings icon behavior is not affected.

Also, run automatic tests:

    npm run test-client client/post-editor/media-modal/test/index.jsx
