### PR TITLE
FormTextInputWithAffixes: allow passing PropTypes.node as prefix or suffix

### DIFF
--- a/client/components/forms/form-text-input-with-affixes/README.md
+++ b/client/components/forms/form-text-input-with-affixes/README.md
@@ -7,11 +7,11 @@ This component is a wrapper around the default form text input that adds support
 
 ### `prefix`
 
-A text to be inserted at the beginning of the input.
+Markup to be inserted at the beginning of the input.
 
 ### `suffix`
 
-A text to be appended at the end of the input.
+Markup to be appended at the end of the input.
 
 ### `noWrap`
 

--- a/client/components/forms/form-text-input-with-affixes/index.jsx
+++ b/client/components/forms/form-text-input-with-affixes/index.jsx
@@ -1,10 +1,10 @@
+/** @format */
 /**
  * External dependencies
  */
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { keys, omit } from 'lodash';
 
 /**
  * Internal dependencies
@@ -16,25 +16,25 @@ export default class extends React.Component {
 
 	static propTypes = {
 		noWrap: PropTypes.bool,
-		prefix: PropTypes.string,
-		suffix: PropTypes.string,
+		prefix: PropTypes.node,
+		suffix: PropTypes.node,
 	};
 
 	render() {
+		const { noWrap, prefix, suffix, ...rest } = this.props;
+
 		return (
-			<div
-				className={ classNames( 'form-text-input-with-affixes', { 'no-wrap': this.props.noWrap } ) }
-			>
-				{ this.props.prefix &&
+			<div className={ classNames( 'form-text-input-with-affixes', { 'no-wrap': noWrap } ) }>
+				{ prefix &&
 					<span className="form-text-input-with-affixes__prefix">
-						{ this.props.prefix }
+						{ prefix }
 					</span> }
 
-				<FormTextInput { ...omit( this.props, keys( this.constructor.propTypes ) ) } />
+				<FormTextInput { ...rest } />
 
-				{ this.props.suffix &&
+				{ suffix &&
 					<span className="form-text-input-with-affixes__suffix">
-						{ this.props.suffix }
+						{ suffix }
 					</span> }
 			</div>
 		);

--- a/client/components/forms/form-text-input-with-affixes/style.scss
+++ b/client/components/forms/form-text-input-with-affixes/style.scss
@@ -41,6 +41,7 @@
 
 .form-text-input-with-affixes__prefix,
 .form-text-input-with-affixes__suffix {
+	position: relative;
 	background: $gray-light;
 	border: 1px solid lighten( $gray, 20% );
 	color: darken( $gray, 20% );


### PR DESCRIPTION
Adding several improvements to the `FormTextInputWithAffixes` component:

Allow to pass `PropTypes.node`, not just `PropTypes.string`, as `prefix` or `suffix`. Enables to insert some rich markup into the field:
```jsx
<FormTextInputWithAffixes prefix={ <span>pre<strong>fix</strong></span> } value="text" />
```

Add `position: relative` CSS property to the affix elements. Allows for absolute positioning of the elements inside the affix, relative to this element. Useful for overlaying a `<select>` element over the affix in components like `PhoneInput` or `FormCurrencyInput`.

Don't use `this.constructor.propTypes` in the component implementation and use props destructuring instead. Enables a potential optimization where we remove the PropTypes definitions from production builds.

Apply Prettier formatting.

Cc: @Automattic/stark 