### PR TITLE
Let EditorMediaModal parent component control media actions activation

### DIFF
--- a/client/my-sites/site-settings/site-icon-setting/index.jsx
+++ b/client/my-sites/site-settings/site-icon-setting/index.jsx
@@ -215,6 +215,10 @@ class SiteIconSetting extends Component {
 		asyncRequire( 'post-editor/media-modal' );
 	}
 
+	isParentReady( selectedMedia ) {
+		return ! selectedMedia.some( item => item.external );
+	}
+
 	render() {
 		const { isJetpack, isPrivate, iconUrl, customizerUrl, generalOptionsUrl, siteSupportsImageEditor } = this.props;
 		const { isModalVisible, hasToggledModal, isEditingSiteIcon } = this.state;
@@ -293,6 +297,7 @@ class SiteIconSetting extends Component {
 							) }
 							siteId={ siteId }
 							onClose={ this.editSelectedMedia }
+							isParentReady={ this.isParentReady }
 							enabledFilters={ [ 'images' ] }
 							{ ...( isEditingSiteIcon ? {
 								imageEditorProps: {


### PR DESCRIPTION
Parent PR: https://github.com/Automattic/wp-calypso/pull/17384

SiteIconSettings will render an error when fed with external transients because they don't have the proper CORS headers. Because of this, we need a mechanism to tell MediaModal to wait until images are uploaded if, and only if, its parent is SiteIconSettings. There are other screens that manage gracefully external transients and we don't want to prevent them from working.


# How to test

* Open post editor media modal, open google photos, and copy and insert it in the editor. Do this quickly, before the image has finished uploading. It should be added to the editor.
* Open set feature image modal, choose google photos, and copy and select an image. Do this quickly, before the image has finished uploading. It should be selected as feature image.
* Open site settings, tap change icon, choose google photos, and copy an image. Continue button should not be enabled until the image finishes uploading.
* Test that other random actions are not affected.
