### PR TITLE
Disable non-updateable whois fields

### DIFF
--- a/client/lib/domains/assembler.js
+++ b/client/lib/domains/assembler.js
@@ -8,7 +8,7 @@ import i18n from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import { getDomainType } from './utils';
+import { getDomainType, calypsoifyWhoisFieldNames } from './utils';
 
 function createDomainObjects( dataTransferObject ) {
 	let domains = [];
@@ -44,6 +44,7 @@ function createDomainObjects( dataTransferObject ) {
 			subscriptionId: domain.subscription_id,
 			transferLockOnWhoisUpdateOptional: domain.transfer_lock_on_whois_update_optional,
 			type: getDomainType( domain ),
+			whoisUnmodifiableContactFields: calypsoifyWhoisFieldNames( domain.whois_unmodifiable_contact_fields ),
 		};
 	} );
 

--- a/client/lib/domains/utils.js
+++ b/client/lib/domains/utils.js
@@ -1,7 +1,14 @@
 /**
  * External dependencies
  */
-import { isEmpty, find, values } from 'lodash';
+import {
+	castArray,
+	isEmpty,
+	find,
+	kebabCase,
+	map,
+	values,
+} from 'lodash';
 
 /**
  * Internal dependencies
@@ -53,7 +60,27 @@ function getDomainNameFromReceiptOrCart( receipt, cart ) {
 	return null;
 }
 
+/**
+ * Fix mis-alignment names for one or more whois contact fields used on the
+ * front and back ends.
+ *
+ * @param  {String|[String]} wpcomFieldNames - The wpcom name for a whois field.
+ * @return {String} The corresponding calypso field name(s).
+ */
+function calypsoifyWhoisFieldNames( wpcomFieldNames ) {
+	const explicitConversions = {
+		country: 'country-code',
+		org_name: 'organization',
+	};
+
+	return map(
+		castArray( wpcomFieldNames ),
+		name => explicitConversions[ name ] || kebabCase( name )
+	);
+}
+
 export {
 	getDomainNameFromReceiptOrCart,
 	getDomainType,
+	calypsoifyWhoisFieldNames,
 };

--- a/client/my-sites/domains/domain-management/edit-contact-info/form-card.jsx
+++ b/client/my-sites/domains/domain-management/edit-contact-info/form-card.jsx
@@ -5,6 +5,7 @@ import React from 'react';
 import {
 	deburr,
 	endsWith,
+	includes,
 	isEqual,
 	keys,
 	omit,
@@ -390,12 +391,19 @@ class EditContactInfoFormCard extends React.Component {
 
 	getField( Component, props ) {
 		const { name } = props;
+		const { whoisUnmodifiableContactFields } = this.props.selectedDomain;
+
+		const disabledForTld = includes( whoisUnmodifiableContactFields, name );
 
 		return (
 			<Component
 				{ ...props }
 				additionalClasses="edit-contact-info__form-field"
-				disabled={ this.state.formSubmitting || formState.isFieldDisabled( this.state.form, name ) }
+				disabled={
+					this.state.formSubmitting ||
+					disabledForTld ||
+					formState.isFieldDisabled( this.state.form, name )
+				}
 				isError={ formState.isFieldInvalid( this.state.form, name ) }
 				value={ formState.getFieldValue( this.state.form, name ) }
 				onChange={ this.onChange } />

--- a/client/state/sites/domains/assembler.js
+++ b/client/state/sites/domains/assembler.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { getDomainType } from 'lib/domains/utils';
+import { getDomainType, calypsoifyWhoisFieldNames } from 'lib/domains/utils';
 
 export const createSiteDomainObject = domain => {
 	return {
@@ -38,5 +38,6 @@ export const createSiteDomainObject = domain => {
 		subscriptionId: domain.subscription_id,
 		transferLockOnWhoisUpdateOptional: Boolean( domain.transfer_lock_on_whois_update_optional ),
 		type: getDomainType( domain ),
+		whoisUnmodifiableContactFields: Array( calypsoifyWhoisFieldNames( domain.whois_unmodifiable_contact_fields ) ),
 	};
 };


### PR DESCRIPTION
This is the front-end changes for updating whois .FR based on D6492-code and D6797-code

Still needs another pass, so WIP, but it's looking pretty good:

#### DOTFR:
![whois-edit-dotfr](https://user-images.githubusercontent.com/5952255/29513840-d99e3188-86a9-11e7-9d4e-86bbd854b96f.jpg)

#### DOTCOM:
![whois-edit-dotcom](https://user-images.githubusercontent.com/5952255/29513875-ea579ad2-86a9-11e7-9475-a78dd92fc54b.jpg)
