### PR TITLE
Components: HeaderCake - Allow for custom action buttons

### DIFF
--- a/client/components/header-cake/README.md
+++ b/client/components/header-cake/README.md
@@ -18,6 +18,7 @@ The "header cake" component should be used at the top of an item's detail page. 
 * `backText` - React Element or string to use in place of default "Back" text
 * `backHref` - URL to specify where the back button should redirect
 * `isCompact` - Optional variant of a more visually compact header cake
+* `actionButton` - A React element to be used in place of the standard action button
 * `actionText` - You can optionally add a button to the right side of the header, this is the text shown
 * `actionHref` - You can optionally add a button to the right side of the header, this the link on that button
 * `actionIcon` - You can optionally add a button to the right side of the header, this is the Gridicon used

--- a/client/components/header-cake/docs/example.jsx
+++ b/client/components/header-cake/docs/example.jsx
@@ -7,12 +7,15 @@ import PureRenderMixin from 'react-pure-render/mixin';
 /**
  * Internal dependencies
  */
+import Button from 'components/button';
 import HeaderCake from 'components/header-cake';
 
 /**
  * Module vars
  */
 const noop = function() {};
+
+const action = () => alert( 'i <3 cake' );
 
 module.exports = React.createClass( {
 	displayName: 'Headers',
@@ -26,8 +29,11 @@ module.exports = React.createClass( {
 					Subsection Header aka Header Cake
 				</HeaderCake>
 				<p>Clicking header cake returns to previous section.</p>
-				<HeaderCake onClick={ noop } actionIcon="status" actionText="Action" actionOnClick={ () => { alert( 'i <3 cake' ) } }>
+				<HeaderCake onClick={ noop } actionIcon="status" actionText="Action" actionOnClick={ action }>
 					Header Cake with optional Action Button
+				</HeaderCake>
+				<HeaderCake onClick={ noop } actionButton={ <Button compact primary onClick={ action }>An action</Button> }>
+					Header Cake with a custom action button
 				</HeaderCake>
 			</div>
 		);

--- a/client/components/header-cake/index.jsx
+++ b/client/components/header-cake/index.jsx
@@ -12,7 +12,7 @@ import HeaderCakeBack from './back';
 
 export default class HeaderCake extends Component {
 	render() {
-		const { backText, backHref, actionText, actionIcon, actionHref, actionOnClick } = this.props;
+		const { backText, backHref, actionButton, actionText, actionIcon, actionHref, actionOnClick } = this.props;
 		const classes = classNames(
 			'header-cake',
 			this.props.className,
@@ -34,12 +34,14 @@ export default class HeaderCake extends Component {
 					{ this.props.children }
 				</div>
 
-				<HeaderCakeBack
-					text={ actionText || backText }
-					href={ actionHref || backHref }
-					onClick={ actionOnClick }
-					icon={ actionIcon }
-					spacer={ ! actionOnClick } />
+				{ actionButton ||
+					<HeaderCakeBack
+						text={ actionText || backText }
+						href={ actionHref || backHref }
+						onClick={ actionOnClick }
+						icon={ actionIcon }
+						spacer={ ! actionOnClick } />
+				}
 			</Card>
 		);
 	}
@@ -52,6 +54,7 @@ HeaderCake.propTypes = {
 	onTitleClick: PropTypes.func,
 	backText: PropTypes.string,
 	backHref: PropTypes.string,
+	actionButton: PropTypes.element,
 	actionText: PropTypes.string,
 	actionHref: PropTypes.string,
 	actionIcon: PropTypes.string,


### PR DESCRIPTION
This PR aims to improve the flexibility of `HeaderCake` by allowing custom action buttons rather than forcing the style and use of an icon.

Required by #16497.

![screen shot 2017-08-21 at 13 05 16](https://user-images.githubusercontent.com/8056203/29516660-7c734a58-8671-11e7-96dd-0f4559b9908a.png)

# Testing

The change doesn't break compatibility and all existing `HeaderCake` instances should work as expected.  
To see the version with a custom button, head over to the example at `/devdocs/design/headers`.