### PR TITLE
FormCurrencyInput: make the currency value editable

### DIFF
--- a/client/components/forms/docs/example.jsx
+++ b/client/components/forms/docs/example.jsx
@@ -35,7 +35,8 @@ import PhoneInput from 'components/phone-input';
 /**
  * Internal dependencies
  */
-var countriesList = require( 'lib/countries-list' ).forSms();
+const countriesList = require( 'lib/countries-list' ).forSms();
+const currencyList = Object.keys( require( 'lib/format-currency/currencies' ).CURRENCIES );
 
 class FormFields extends React.PureComponent {
 	static displayName = 'FormFields'; // Needed for devdocs/design
@@ -45,6 +46,7 @@ class FormFields extends React.PureComponent {
 		toggled: false,
 		compactToggled: false,
 		phoneInput: { countryCode: 'US', value: '' },
+		currencyInput: { currency: 'USD', value: '' },
 	};
 
 	handleRadioChange = event => {
@@ -65,6 +67,20 @@ class FormFields extends React.PureComponent {
 
 	handlePhoneInputChange = data => {
 		this.setState( { phoneInput: data } );
+	};
+
+	handleCurrencyChange = event => {
+		const { value: currency } = event.currentTarget;
+		this.setState( state => ( {
+			currencyInput: { ...state.currencyInput, currency }
+		} ) );
+	};
+
+	handlePriceChange = event => {
+		const { value } = event.currentTarget;
+		this.setState( state => ( {
+			currencyInput: { ...state.currencyInput, value }
+		} ) );
 	};
 
 	render() {
@@ -307,6 +323,20 @@ class FormFields extends React.PureComponent {
 							isError
 						/>
 						<FormInputValidation isError text="The price is invalid." />
+					</FormFieldset>
+
+					<FormFieldset>
+						<FormLabel htmlFor="currency_input_editable">Editable Form Currency Input</FormLabel>
+						<FormCurrencyInput
+							name="currency_input_editable"
+							id="currency_input_editable"
+							value={ this.state.currencyInput.value }
+							onChange={ this.handlePriceChange }
+							currencySymbolPrefix={ this.state.currencyInput.currency }
+							onCurrencyChange={ this.handleCurrencyChange }
+							currencyList={ currencyList }
+							placeholder="Placeholder text..."
+						/>
 					</FormFieldset>
 
 					<FormFieldset>

--- a/client/components/forms/form-currency-input/index.jsx
+++ b/client/components/forms/form-currency-input/index.jsx
@@ -1,7 +1,9 @@
+/** @format */
 /**
  * External dependencies
  */
 import React from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 /**
@@ -9,22 +11,67 @@ import classNames from 'classnames';
  */
 import FormTextInputWithAffixes from 'components/forms/form-text-input-with-affixes';
 
-export default function FormCurrencyInput( {
+function renderAffix( currencyValue, onCurrencyChange, currencyList ) {
+	// If the currency value is not defined, don't render this affix at all
+	if ( ! currencyValue ) {
+		return null;
+	}
+
+	// If the currency is not editable, i.e., when `currencyList` is not defined, then just
+	// render the plain value.
+	if ( ! currencyList ) {
+		return currencyValue;
+	}
+
+	// For an editable currency, display a <select> overlay
+	return (
+		<span className="form-currency-input__affix">
+			{ currencyValue }
+			<select
+				className="form-currency-input__select"
+				value={ currencyValue }
+				onChange={ onCurrencyChange }
+			>
+				{ currencyList.map( code =>
+					<option key={ code } value={ code }>
+						{ code }
+					</option>
+				) }
+			</select>
+		</span>
+	);
+}
+
+function FormCurrencyInput( {
 	className,
 	currencySymbolPrefix,
 	currencySymbolSuffix,
+	onCurrencyChange,
+	currencyList,
+	placeholder = '0.00',
 	...props
 } ) {
 	const classes = classNames( 'form-currency-input', className );
+	const prefix = renderAffix( currencySymbolPrefix, onCurrencyChange, currencyList );
+	const suffix = renderAffix( currencySymbolSuffix, onCurrencyChange, currencyList );
 
 	return (
 		<FormTextInputWithAffixes
 			{ ...props }
 			type="number"
 			className={ classes }
-			prefix={ currencySymbolPrefix }
-			suffix={ currencySymbolSuffix }
-			placeholder="0.00"
+			prefix={ prefix }
+			suffix={ suffix }
+			placeholder={ placeholder }
 		/>
 	);
 }
+
+FormCurrencyInput.propTypes = {
+	currencySymbolPrefix: PropTypes.string,
+	currencySymbolSuffix: PropTypes.string,
+	onCurrencyChange: PropTypes.func,
+	currencyList: PropTypes.array,
+};
+
+export default FormCurrencyInput;

--- a/client/components/forms/form-currency-input/style.scss
+++ b/client/components/forms/form-currency-input/style.scss
@@ -1,3 +1,16 @@
 .form-currency-input {
 	-webkit-appearance: none;
 }
+
+.form-currency-input__select {
+	position: absolute;
+	top: 0;
+	bottom: 0;
+	left: 0;
+	right: 0;
+	width: 100%;
+	padding: 0;
+	border: 0;
+	background-image: none;
+	opacity: 0;
+}


### PR DESCRIPTION
If the component has a `currencyList` prop (array of possible values), then make the currency affix editable. The `onCurrencyChange` prop is a handler that gets called when the currency is changed.

Implemented by overlaying a transparent, absolutely positioned `<select>` over the affix. The same technique is already used to select the country code in the `PhoneInput` component.

Depends on the changes in #17385.

Cc: @Automattic/stark 