### PR TITLE
WPSC: Remove warning about non-matching home and site URL

### DIFF
--- a/client/extensions/wp-super-cache/components/cdn/index.jsx
+++ b/client/extensions/wp-super-cache/components/cdn/index.jsx
@@ -15,7 +15,6 @@ import FormLabel from 'components/forms/form-label';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import FormTextInput from 'components/forms/form-text-input';
 import FormToggle from 'components/forms/form-toggle/compact';
-import Notice from 'components/notice';
 import SectionHeader from 'components/section-header';
 import WrapSettingsForm from '../wrap-settings-form';
 
@@ -66,19 +65,6 @@ const CdnTab = ( {
 					</FormFieldset>
 
 					<div className="wp-super-cache__cdn-fieldsets">
-						{ ossdl_off_blog_url && get( site, 'URL' ) && ( ossdl_off_blog_url !== get( site, 'URL' ) ) &&
-							<Notice showDismiss={ false } status="is-warning">
-								{ translate(
-									'Your siteurl and homeurl are different. The plugin is using ' +
-									'{{code}}%(ossdl_off_blog_url)s{{/code}} as the homepage URL of your site ' +
-									'but if that is wrong please use the filter "ossdl_off_blog_url" to fix it.',
-									{
-										args: { ossdl_off_blog_url },
-										components: { code: <code /> }
-									}
-								) }
-							</Notice>
-						}
 						<FormFieldset>
 							<FormLabel htmlFor="ossdl_off_blog_url">
 								{ translate( 'Site URL' ) }


### PR DESCRIPTION
This is actually obsolete now that users can set the Site URL (i.e. `ossdl_off_blog_url`) themselves (see #17055).

Essentially reverts #16589. Props to @donnchawp for pointing this out!

To test -- make sure the CDN tab still works.