### PR TITLE
Activity Log: Extract adjustMoment method to util

### DIFF
--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -32,6 +32,7 @@ import StatsFirstView from '../stats-first-view';
 import StatsNavigation from '../stats-navigation';
 import StatsPeriodNavigation from 'my-sites/stats/stats-period-navigation';
 import SuccessBanner from '../activity-log-banner/success-banner';
+import { adjustMoment } from './utils';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSiteSlug, getSiteTitle } from 'state/sites/selectors';
 import { recordTracksEvent as recordTracksEventAction } from 'state/analytics/actions';
@@ -154,15 +155,7 @@ class ActivityLog extends Component {
 	 */
 	getSiteOffsetFunc() {
 		const { timezone, gmtOffset } = this.props;
-		return moment => {
-			if ( timezone ) {
-				return moment.tz( timezone );
-			}
-			if ( gmtOffset ) {
-				return moment.utcOffset( gmtOffset );
-			}
-			return moment;
-		};
+		return moment => adjustMoment( { timezone, gmtOffset, moment } );
 	}
 
 	isRestoreInProgress() {
@@ -359,18 +352,18 @@ export default connect(
 		const siteId = getSelectedSiteId( state );
 
 		return {
+			gmtOffset: getSiteGmtOffset( state, siteId ),
+			isRewindActive: isRewindActiveSelector( state, siteId ),
 			logs: getActivityLogs( state, siteId ),
+			restoreProgress: getRestoreProgress( state, siteId ),
+			rewindStatusError: getRewindStatusError( state, siteId ),
 			siteId,
 			siteTitle: getSiteTitle( state, siteId ),
 			slug: getSiteSlug( state, siteId ),
-			rewindStatusError: getRewindStatusError( state, siteId ),
-			restoreProgress: getRestoreProgress( state, siteId ),
-			isRewindActive: isRewindActiveSelector( state, siteId ),
+			timezone: getSiteTimezoneValue( state, siteId ),
 
 			// FIXME: Testing only
 			isPressable: get( state.activityLog.rewindStatus, [ siteId, 'isPressable' ], null ),
-			timezone: getSiteTimezoneValue( state, siteId ),
-			gmtOffset: getSiteGmtOffset( state, siteId ),
 		};
 	},
 	{

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -146,17 +146,16 @@ class ActivityLog extends Component {
 	};
 
 	/**
-	 * Creates a function that will offset a moment by the site
-	 * timezone or gmt offset. Use the resulting function wherever
-	 * log times need to be formatted for display to ensure all times
-	 * are displayed as site times.
+	 * Adjust a moment by the site timezone or gmt offset. Use the resulting function wherever log
+	 * times need to be formatted for display to ensure all times are displayed as site times.
 	 *
-	 * @returns {function} func that takes a moment and returns moment offset by site timezone or offset
+	 * @param   {object} moment Moment to adjust.
+	 * @returns {object}        Moment adjusted for site timezone or gmtOffset.
 	 */
-	getSiteOffsetFunc() {
+	applySiteOffset = moment => {
 		const { timezone, gmtOffset } = this.props;
-		return moment => adjustMoment( { timezone, gmtOffset, moment } );
-	}
+		return adjustMoment( { timezone, gmtOffset, moment } );
+	};
 
 	isRestoreInProgress() {
 		return includes( [ 'queued', 'running' ], get( this.props, [ 'restoreProgress', 'status' ] ) );
@@ -247,8 +246,6 @@ class ActivityLog extends Component {
 
 		const disableRestore = this.isRestoreInProgress();
 
-		const applySiteOffset = this.getSiteOffsetFunc();
-
 		if ( isEmpty( logs ) ) {
 			return (
 				<EmptyContent
@@ -260,10 +257,12 @@ class ActivityLog extends Component {
 		}
 
 		const logsGroupedByDay = map(
-			groupBy( logs, log => applySiteOffset( moment.utc( log.ts_utc ) ).endOf( 'day' ).valueOf() ),
+			groupBy( logs, log =>
+				this.applySiteOffset( moment.utc( log.ts_utc ) ).endOf( 'day' ).valueOf()
+			),
 			( daily_logs, tsEndOfSiteDay ) =>
 				<ActivityLogDay
-					applySiteOffset={ applySiteOffset }
+					applySiteOffset={ this.applySiteOffset }
 					disableRestore={ disableRestore }
 					hideRestore={ ! isPressable }
 					isRewindActive={ isRewindActive }
@@ -309,10 +308,9 @@ class ActivityLog extends Component {
 	render() {
 		const { isPressable, isRewindActive, moment, siteId, siteTitle, slug, startDate } = this.props;
 		const { requestedRestoreTimestamp, showRestoreConfirmDialog } = this.state;
-		const applySiteOffset = this.getSiteOffsetFunc();
 
-		const queryStart = applySiteOffset( moment.utc( startDate ) ).startOf( 'month' ).valueOf();
-		const queryEnd = applySiteOffset( moment.utc( startDate ) ).endOf( 'month' ).valueOf();
+		const queryStart = this.applySiteOffset( moment.utc( startDate ) ).startOf( 'month' ).valueOf();
+		const queryEnd = this.applySiteOffset( moment.utc( startDate ) ).endOf( 'month' ).valueOf();
 
 		return (
 			<Main wideLayout>
@@ -335,7 +333,7 @@ class ActivityLog extends Component {
 				{ this.renderMonthNavigation( 'bottom' ) }
 
 				<ActivityLogConfirmDialog
-					applySiteOffset={ applySiteOffset }
+					applySiteOffset={ this.applySiteOffset }
 					isVisible={ showRestoreConfirmDialog }
 					siteTitle={ siteTitle }
 					timestamp={ requestedRestoreTimestamp }

--- a/client/my-sites/stats/activity-log/utils.js
+++ b/client/my-sites/stats/activity-log/utils.js
@@ -1,0 +1,26 @@
+/** @format */
+/**
+ * @typedef OffsetParams
+ * @property {?string} timezone  Timezone representation to apply.
+ * @property {?string} gmtOffset Offset to apply if timezone isn't supplied.
+ * @property {object}  moment    Moment object to which timezone or offset will be applied.
+ */
+
+/**
+ * Accepts nullable timezone and offset and applies one to the provided moment, preferring the
+ * timezone. If neither are provided, return the moment unchanged.
+ *
+ * @param  {OffsetParams} params Parameters
+ * @return {Object}       Moment with timezone applied if provided.
+ *                        Moment with gmtOffset applied if no timezone is provided.
+ *                        If neither is provided, the original moment is returned.
+ */
+export function adjustMoment( { timezone, gmtOffset, moment } ) {
+	if ( timezone ) {
+		return moment.tz( timezone );
+	}
+	if ( gmtOffset ) {
+		return moment.utcOffset( gmtOffset );
+	}
+	return moment;
+}


### PR DESCRIPTION
Extract component method to util function.
Depend on utility function from component method.

The `ActivityLog` component contains a method to modify a moment by applying a `timezone` or `gmtOffset` (`gmtOffset` is currently buggy: #17320).

As part of the migration to `ActivityQueryManager` (#17135) , the Activity selector will need to be aware of site-time start and end dates and translate them to timestamps in order to build a query. This exactly the functionality already available in the component method.

By moving this logic to a utility function, we'll be able to maintain the same functionality and share it between the component and the selector in the component's `connect`.

## Testing
1. Visit https://calypso.live/stats/activity?branch=update/activity-log/extract-getsiteoffsetfunc
1. Explore different parts of the Activity Log. There should be no changes to the way dates are rendered.