### PR TITLE
Simple Payments: make product currency editable

### DIFF
--- a/client/components/forms/docs/example.jsx
+++ b/client/components/forms/docs/example.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react';
+import { mapValues } from 'lodash';
 
 /**
  * Internal dependencies
@@ -36,7 +37,9 @@ import PhoneInput from 'components/phone-input';
  * Internal dependencies
  */
 const countriesList = require( 'lib/countries-list' ).forSms();
-const currencyList = Object.keys( require( 'lib/format-currency/currencies' ).CURRENCIES );
+const currencies = require( 'lib/format-currency/currencies' ).CURRENCIES
+const currencyList = Object.keys( currencies );
+const visualCurrencyList = mapValues( currencies, ( currency, key ) => `${ key } ${ currency.symbol }` );
 
 class FormFields extends React.PureComponent {
 	static displayName = 'FormFields'; // Needed for devdocs/design
@@ -335,6 +338,21 @@ class FormFields extends React.PureComponent {
 							currencySymbolPrefix={ this.state.currencyInput.currency }
 							onCurrencyChange={ this.handleCurrencyChange }
 							currencyList={ currencyList }
+							placeholder="Placeholder text..."
+						/>
+					</FormFieldset>
+
+					<FormFieldset>
+						<FormLabel htmlFor="currency_input_editable">Editable Form Currency Input (customized list)</FormLabel>
+						<FormCurrencyInput
+							name="currency_input_editable"
+							id="currency_input_editable"
+							value={ this.state.currencyInput.value }
+							onChange={ this.handlePriceChange }
+							currencySymbolPrefix={ this.state.currencyInput.currency }
+							onCurrencyChange={ this.handleCurrencyChange }
+							currencyList={ currencyList }
+							visualCurrencyList={ visualCurrencyList }
 							placeholder="Placeholder text..."
 						/>
 					</FormFieldset>

--- a/client/components/forms/form-currency-input/index.jsx
+++ b/client/components/forms/form-currency-input/index.jsx
@@ -11,7 +11,7 @@ import classNames from 'classnames';
  */
 import FormTextInputWithAffixes from 'components/forms/form-text-input-with-affixes';
 
-function renderAffix( currencyValue, onCurrencyChange, currencyList ) {
+function renderAffix( currencyValue, onCurrencyChange, currencyList, visualCurrencyList ) {
 	// If the currency value is not defined, don't render this affix at all
 	if ( ! currencyValue ) {
 		return null;
@@ -26,7 +26,7 @@ function renderAffix( currencyValue, onCurrencyChange, currencyList ) {
 	// For an editable currency, display a <select> overlay
 	return (
 		<span className="form-currency-input__affix">
-			{ currencyValue }
+			{ ( visualCurrencyList && visualCurrencyList[ currencyValue ] ) || currencyValue }
 			<select
 				className="form-currency-input__select"
 				value={ currencyValue }
@@ -34,7 +34,7 @@ function renderAffix( currencyValue, onCurrencyChange, currencyList ) {
 			>
 				{ currencyList.map( code =>
 					<option key={ code } value={ code }>
-						{ code }
+						{ ( visualCurrencyList && visualCurrencyList[ code ] ) || code }
 					</option>
 				) }
 			</select>
@@ -48,12 +48,23 @@ function FormCurrencyInput( {
 	currencySymbolSuffix,
 	onCurrencyChange,
 	currencyList,
+	visualCurrencyList,
 	placeholder = '0.00',
 	...props
 } ) {
 	const classes = classNames( 'form-currency-input', className );
-	const prefix = renderAffix( currencySymbolPrefix, onCurrencyChange, currencyList );
-	const suffix = renderAffix( currencySymbolSuffix, onCurrencyChange, currencyList );
+	const prefix = renderAffix(
+		currencySymbolPrefix,
+		onCurrencyChange,
+		currencyList,
+		visualCurrencyList
+	);
+	const suffix = renderAffix(
+		currencySymbolSuffix,
+		onCurrencyChange,
+		currencyList,
+		visualCurrencyList
+	);
 
 	return (
 		<FormTextInputWithAffixes
@@ -72,6 +83,7 @@ FormCurrencyInput.propTypes = {
 	currencySymbolSuffix: PropTypes.string,
 	onCurrencyChange: PropTypes.func,
 	currencyList: PropTypes.array,
+	visualCurrencyList: PropTypes.object,
 };
 
 export default FormCurrencyInput;

--- a/client/components/tinymce/plugins/simple-payments/dialog/form.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/form.jsx
@@ -57,6 +57,33 @@ const SUPPORTED_CURRENCY_LIST = [
 	'THB',
 ];
 
+const VISUAL_CURRENCY_LIST = {
+	USD: 'USD $',
+	EUR: 'EUR €',
+	AUD: 'AUD $',
+	BRL: 'BRL R$',
+	CAD: 'CAD $',
+	CZK: 'CZK Kč',
+	DKK: 'DKK kr',
+	HKD: 'HKD $',
+	HUF: 'HUF Ft',
+	ILS: 'ILS ₪',
+	JPY: 'JPY ¥',
+	MYR: 'MYR RM',
+	MXN: 'MXN $',
+	TWD: 'TWD NT$',
+	NZD: 'NZD $',
+	NOK: 'NOK kr',
+	PHP: 'PHP ₱',
+	PLN: 'PLN zł',
+	GBP: 'GBP £',
+	RUB: 'RUB ₽',
+	SGD: 'SGD $',
+	SEK: 'SEK kr',
+	CHF: 'CHF',
+	THB: 'THB ฿',
+};
+
 // based on https://stackoverflow.com/a/10454560/59752
 function decimalPlaces( number ) {
 	const match = ( '' + number ).match( /(?:\.(\d+))?(?:[eE]([+-]?\d+))?$/ );
@@ -134,6 +161,7 @@ const renderPriceField = ( { price, currency, ...props } ) => {
 			currencySymbolPrefix={ currency.input.value }
 			onCurrencyChange={ currency.input.onChange }
 			currencyList={ SUPPORTED_CURRENCY_LIST }
+			visualCurrencyList={ VISUAL_CURRENCY_LIST }
 			placeholder={ placeholder }
 		/>
 	);

--- a/client/components/tinymce/plugins/simple-payments/dialog/form.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/form.jsx
@@ -29,6 +29,34 @@ export const getProductFormValues = state => getFormValues( REDUX_FORM_NAME )( s
 export const isProductFormValid = state => isValid( REDUX_FORM_NAME )( state );
 export const isProductFormDirty = state => isDirty( REDUX_FORM_NAME )( state );
 
+// https://developer.paypal.com/docs/integration/direct/rest/currency-codes/
+const SUPPORTED_CURRENCY_LIST = [
+	'USD',
+	'EUR',
+	'AUD',
+	'BRL',
+	'CAD',
+	'CZK',
+	'DKK',
+	'HKD',
+	'HUF',
+	'ILS',
+	'JPY',
+	'MYR',
+	'MXN',
+	'TWD',
+	'NZD',
+	'NOK',
+	'PHP',
+	'PLN',
+	'GBP',
+	'RUB',
+	'SGD',
+	'SEK',
+	'CHF',
+	'THB',
+];
+
 // based on https://stackoverflow.com/a/10454560/59752
 function decimalPlaces( number ) {
 	const match = ( '' + number ).match( /(?:\.(\d+))?(?:[eE]([+-]?\d+))?$/ );
@@ -95,7 +123,7 @@ const validate = ( values, props ) => {
 // to transform the props from `{ price: { input, meta }, currency: { input, meta } }` that
 // `Fields` is receiving to `{ input, meta }` that `Field` expects.
 const renderPriceField = ( { price, currency, ...props } ) => {
-	const { symbol, precision } = getCurrencyDefaults( currency.input.value );
+	const { precision } = getCurrencyDefaults( currency.input.value );
 	// Tune the placeholder to the precision value: 0 -> '0', 1 -> '0.0', 2 -> '0.00'
 	const placeholder = precision > 0 ? padEnd( '0.', precision + 2, '0' ) : '0';
 	return (
@@ -103,7 +131,9 @@ const renderPriceField = ( { price, currency, ...props } ) => {
 			inputComponent={ FormCurrencyInput }
 			{ ...price }
 			{ ...props }
-			currencySymbolPrefix={ symbol }
+			currencySymbolPrefix={ currency.input.value }
+			onCurrencyChange={ currency.input.onChange }
+			currencyList={ SUPPORTED_CURRENCY_LIST }
 			placeholder={ placeholder }
 		/>
 	);

--- a/client/components/tinymce/plugins/simple-payments/dialog/list-item.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/list-item.jsx
@@ -10,7 +10,7 @@ import { noop } from 'lodash';
 /**
  * Internal dependencies
  */
-import formatCurrency from 'lib/format-currency';
+import { getCurrencyObject } from 'lib/format-currency';
 import CompactCard from 'components/card/compact';
 import EllipsisMenu from 'components/ellipsis-menu';
 import FormRadio from 'components/forms/form-radio';
@@ -33,6 +33,11 @@ class ProductListItem extends Component {
 	handleRadioChange = () => this.props.onSelectedChange( this.props.paymentId );
 	handleEditClick = () => this.props.onEditClick( this.props.paymentId );
 	handleTrashClick = () => this.props.onTrashClick( this.props.paymentId );
+
+	formatPrice( price, currency = 'USD' ) {
+		const { integer, fraction } = getCurrencyObject( price, currency );
+		return `${ integer }${ fraction } ${ currency }`;
+	}
 
 	render() {
 		const {
@@ -61,7 +66,7 @@ class ProductListItem extends Component {
 						{ title }
 					</div>
 					<div>
-						{ formatCurrency( price, currency ) }
+						{ this.formatPrice( price, currency ) }
 					</div>
 				</label>
 				<ProductImage siteId={ siteId } imageId={ featuredImageId } />


### PR DESCRIPTION
Uses the `FormCurrencyInput` improvements from #17385 and #17389 to make the product currency field editable:

![currency-change](https://user-images.githubusercontent.com/664258/29519179-b5c8e10e-867c-11e7-83cf-a4d1f41b2a12.gif)

The list of supported currencies was fetched from [PayPal's site](https://developer.paypal.com/docs/integration/direct/rest/currency-codes/) (props to @retrofox for the link)

I changed the way how product currency is displayed in Calypso. Instead of symbols ($, €) we now use three-letter codes like USD or EUR:

<img width="553" alt="usd-list" src="https://user-images.githubusercontent.com/664258/29519550-2709a49c-867e-11e7-846e-2f2e8beeccbc.png">

That's mainly because the `$` symbol is ambiguous -- it's used to denote many other currencies in addition to USD.

I'm interested in your opinions about making this change.

To test: change existing product's currency and check that it really gets changed.

Cc: @Automattic/stark 