### PR TITLE
WPSC: Import PropTypes from dedicated npm

### DIFF
--- a/client/extensions/wp-super-cache/components/advanced/accepted-filenames.jsx
+++ b/client/extensions/wp-super-cache/components/advanced/accepted-filenames.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { pick } from 'lodash';
 
 /**

--- a/client/extensions/wp-super-cache/components/advanced/fix-config.jsx
+++ b/client/extensions/wp-super-cache/components/advanced/fix-config.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { flowRight } from 'lodash';

--- a/client/extensions/wp-super-cache/components/contents/cache-stats.jsx
+++ b/client/extensions/wp-super-cache/components/contents/cache-stats.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { flowRight, get, map } from 'lodash';

--- a/client/extensions/wp-super-cache/components/contents/index.jsx
+++ b/client/extensions/wp-super-cache/components/contents/index.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { flowRight, get, isEmpty, pick } from 'lodash';
 

--- a/client/extensions/wp-super-cache/components/data/query-settings/index.jsx
+++ b/client/extensions/wp-super-cache/components/data/query-settings/index.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import { Component, PropTypes } from 'react';
+import { Component } from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
 /**

--- a/client/extensions/wp-super-cache/components/data/query-status/index.jsx
+++ b/client/extensions/wp-super-cache/components/data/query-status/index.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import { Component, PropTypes } from 'react';
+import { Component } from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
 /**

--- a/client/extensions/wp-super-cache/components/debug/index.jsx
+++ b/client/extensions/wp-super-cache/components/debug/index.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { pick } from 'lodash';
 import moment from 'moment';
 

--- a/client/extensions/wp-super-cache/components/easy/index.jsx
+++ b/client/extensions/wp-super-cache/components/easy/index.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import Gridicon from 'gridicons';
 import { flowRight, get, isEmpty, pick } from 'lodash';


### PR DESCRIPTION
Title says it 😉 

To test -- Make sure the extension still works.