### PR TITLE
WPSC: Indent Nested Page Types Correctly

### DIFF
--- a/client/extensions/wp-super-cache/components/advanced/accepted-filenames.jsx
+++ b/client/extensions/wp-super-cache/components/advanced/accepted-filenames.jsx
@@ -133,10 +133,14 @@ class AcceptedFilenames extends Component {
 							{ this.renderToggle( 'single', translate( 'Single Posts (is_single)' ) ) }
 							{ this.renderToggle( 'pages', translate( 'Pages (is_page)' ) ) }
 							{ this.renderToggle( 'frontpage', translate( 'Front Page (is_front_page)' ) ) }
-							{ this.renderToggle( 'home', translate( 'Home (is_home)' ) ) }
+							<div className="wp-super-cache__nested-page-types">
+								{ this.renderToggle( 'home', translate( 'Home (is_home)' ) ) }
+							</div>
 							{ this.renderToggle( 'archives', translate( 'Archives (is_archive)' ) ) }
-							{ this.renderToggle( 'tag', translate( 'Tags (is_tag)' ) ) }
-							{ this.renderToggle( 'category', translate( 'Category (is_category)' ) ) }
+							<div className="wp-super-cache__nested-page-types">
+								{ this.renderToggle( 'tag', translate( 'Tags (is_tag)' ) ) }
+								{ this.renderToggle( 'category', translate( 'Category (is_category)' ) ) }
+							</div>
 							{ this.renderToggle( 'feed', translate( 'Feeds (is_feed)' ) ) }
 							{ this.renderToggle( 'search', translate( 'Search Pages (is_search)' ) ) }
 							{ this.renderToggle( 'author', translate( 'Author Pages (is_author)' ) ) }

--- a/client/extensions/wp-super-cache/components/advanced/accepted-filenames.jsx
+++ b/client/extensions/wp-super-cache/components/advanced/accepted-filenames.jsx
@@ -47,7 +47,7 @@ class AcceptedFilenames extends Component {
 
 		return (
 			<FormToggle
-				checked={ !! pages && !! pages[ fieldName ] }
+				checked={ get( pages, fieldName, false ) }
 				disabled={ isRequesting || isSaving || isReadOnly || ! get( pages, parent, true ) }
 				onChange={ this.handleToggle( fieldName ) }>
 				<span>

--- a/client/extensions/wp-super-cache/components/advanced/accepted-filenames.jsx
+++ b/client/extensions/wp-super-cache/components/advanced/accepted-filenames.jsx
@@ -3,7 +3,7 @@
  */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { pick } from 'lodash';
+import { get, pick } from 'lodash';
 
 /**
  * Internal dependencies
@@ -37,7 +37,7 @@ class AcceptedFilenames extends Component {
 		isSaving: false,
 	};
 
-	renderToggle = ( fieldName, fieldLabel ) => {
+	renderToggle = ( fieldName, fieldLabel, parent ) => {
 		const {
 			fields: { pages },
 			isReadOnly,
@@ -48,7 +48,7 @@ class AcceptedFilenames extends Component {
 		return (
 			<FormToggle
 				checked={ !! pages && !! pages[ fieldName ] }
-				disabled={ isRequesting || isSaving || isReadOnly }
+				disabled={ isRequesting || isSaving || isReadOnly || ! get( pages, parent, true ) }
 				onChange={ this.handleToggle( fieldName ) }>
 				<span>
 					{ fieldLabel }
@@ -134,12 +134,12 @@ class AcceptedFilenames extends Component {
 							{ this.renderToggle( 'pages', translate( 'Pages (is_page)' ) ) }
 							{ this.renderToggle( 'frontpage', translate( 'Front Page (is_front_page)' ) ) }
 							<div className="wp-super-cache__nested-page-types">
-								{ this.renderToggle( 'home', translate( 'Home (is_home)' ) ) }
+								{ this.renderToggle( 'home', translate( 'Home (is_home)' ), 'frontpage' ) }
 							</div>
 							{ this.renderToggle( 'archives', translate( 'Archives (is_archive)' ) ) }
 							<div className="wp-super-cache__nested-page-types">
-								{ this.renderToggle( 'tag', translate( 'Tags (is_tag)' ) ) }
-								{ this.renderToggle( 'category', translate( 'Category (is_category)' ) ) }
+								{ this.renderToggle( 'tag', translate( 'Tags (is_tag)' ), 'archives' ) }
+								{ this.renderToggle( 'category', translate( 'Category (is_category)' ), 'archives' ) }
 							</div>
 							{ this.renderToggle( 'feed', translate( 'Feeds (is_feed)' ) ) }
 							{ this.renderToggle( 'search', translate( 'Search Pages (is_search)' ) ) }

--- a/client/extensions/wp-super-cache/style.scss
+++ b/client/extensions/wp-super-cache/style.scss
@@ -75,6 +75,10 @@
 	margin: 10px 0 0 24px;
 }
 
+.wp-super-cache__nested-page-types {
+	margin-left: 36px;
+}
+
 .wp-super-cache__directly-cached-files .form-text-input,
 .wp-super-cache__directly-cached-files .form-text-input-with-action {
 	width: 300px;


### PR DESCRIPTION
Fixes indentation as mentioned in the first paragraph of  https://horizonfeedback.wordpress.com/2017/08/17/call-for-testing-calypso-wp-super-cache-extension/#comment-399

Before:

<img width="720" alt="bildschirmfoto 2017-08-21 um 15 17 36" src="https://user-images.githubusercontent.com/96308/29521000-e5671730-8683-11e7-9b10-f4a7d683f4cb.png">

After:

<img width="721" alt="bildschirmfoto 2017-08-21 um 15 12 21" src="https://user-images.githubusercontent.com/96308/29520977-d301eae8-8683-11e7-9106-3d257412132d.png">

wp-admin:

<img width="341" alt="bildschirmfoto 2017-08-21 um 15 14 57" src="https://user-images.githubusercontent.com/96308/29520970-cf8715fa-8683-11e7-999f-4335c4a648d7.png">
