### PR TITLE
Domain Only Site: Allow transfer to other site

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/index.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.jsx
@@ -95,7 +95,7 @@ const CheckoutThankYou = React.createClass( {
 		selectedSite: PropTypes.oneOfType( [
 			PropTypes.bool,
 			PropTypes.object
-		] ).isRequired
+		] )
 	},
 
 	componentDidMount() {
@@ -246,6 +246,7 @@ const CheckoutThankYou = React.createClass( {
 
 		// Rebrand Cities thanks page
 		if (
+			this.props.selectedSite &&
 			isRebrandCitiesSiteUrl( this.props.selectedSite.slug ) &&
 			PLAN_BUSINESS === this.props.selectedSite.plan.product_slug
 		) {

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -55,7 +55,7 @@ import {
 	domainManagementRedirectSettings,
 	domainManagementTransfer,
 	domainManagementTransferOut,
-	domainManagementTransferToAnotherUser
+	domainManagementTransferToOtherSite,
 } from 'my-sites/domains/paths';
 import SitesComponent from 'my-sites/sites';
 import { isATEnabled } from 'lib/automated-transfer';
@@ -178,7 +178,7 @@ function isPathAllowedForDomainOnlySite( path, domainName ) {
 		domainManagementRedirectSettings,
 		domainManagementTransfer,
 		domainManagementTransferOut,
-		domainManagementTransferToAnotherUser
+		domainManagementTransferToOtherSite
 	].map( pathFactory => pathFactory( domainName, domainName ) );
 
 	const otherPaths = [

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/confirmation-dialog.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/confirmation-dialog.jsx
@@ -2,6 +2,7 @@
  * External Dependencies
  */
 import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import {
@@ -16,12 +17,12 @@ import Dialog from 'components/dialog';
 
 class TransferConfirmationDialog extends React.PureComponent {
 	static propTypes = {
-		isVisible: React.PropTypes.bool.isRequired,
-		targetSiteId: React.PropTypes.string.isRequired,
-		disableDialogButtons: React.PropTypes.bool.isRequired,
-		domainName: React.PropTypes.string.isRequired,
-		onConfirmTransfer: React.PropTypes.func.isRequired,
-		onClose: React.PropTypes.func.isRequired,
+		isVisible: PropTypes.bool.isRequired,
+		targetSiteId: PropTypes.number.isRequired,
+		disableDialogButtons: PropTypes.bool.isRequired,
+		domainName: PropTypes.string.isRequired,
+		onConfirmTransfer: PropTypes.func.isRequired,
+		onClose: PropTypes.func.isRequired,
 	};
 
 	onConfirm = ( closeDialog ) => {


### PR DESCRIPTION
The transfer to other site path wasn't allowed for domain only sites.
Allow the path, and redirect to the gaining site (as the domain only site is deleted). Also refetch sites list as the domain only site is gone.
Fix a bug with Checkout Thank You where we assume `selectedSite` is always there.

Test:
- calypso.localhost:3000/start/domain-first?new=testing-something-good-ol-1234.blog
- Buy the domain
- Make sure Thank You page works
- Transfer -> Transfer to other site
- Pick a site
- Make sure you're redirected to domain list of the gaining site
- Make sure sites list is refetched