### PR TITLE
Simple Payments: fix the state schema for product list

### DIFF
--- a/client/state/simple-payments/product-list/schema.js
+++ b/client/state/simple-payments/product-list/schema.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * These are the parameters kept in metadata (custom fields)
  */
@@ -5,7 +6,7 @@ export const metadataSchema = {
 	currency: { type: 'string', metaKey: 'spay_currency' },
 	price: { type: 'string', metaKey: 'spay_price' },
 	multiple: { type: 'boolean', metaKey: 'spay_multiple' },
-	status: { type: 'number', metaKey: 'spay_status' },
+	status: { type: 'string', metaKey: 'spay_status' },
 	email: { type: 'string', metaKey: 'spay_email' },
 	formatted_price: { type: 'string', metaKey: 'spay_formatted_price' },
 };
@@ -16,21 +17,23 @@ export const metadataSchema = {
  */
 const productSchema = {
 	type: 'object',
-	properties: Object.assign(
-		{
-			title: { type: 'string' },
-			description: { type: 'string' },
-			ID: { type: 'number' },
-		},
-		metadataSchema
-	)
+	properties: {
+		title: { type: 'string' },
+		description: { type: 'string' },
+		ID: { type: 'number' },
+		...metadataSchema,
+	},
 };
 
 const productListSchema = {
 	type: 'object',
 	patternProperties: {
-		'^\\d+$': productSchema,
+		'^\\d+$': {
+			type: 'array',
+			items: productSchema,
+		},
 	},
+	additionalProperties: false,
 };
 
 /**


### PR DESCRIPTION
Fixed two bugs in the state schema:

1. Change the type of the `status` (`spay_status`) field from number to string. Its value is
either `'enabled'` or `'disabled'`.

2. The shape of the `simplePayments.productList.items` state is not:
```
{
  siteId1: product1,
  siteId2: product2
}
```

But there is an array of products:
```
{
  siteId1: [ product1, product2 ],
  siteId2: []
}
```

Fixed the schema to check for the array.

To test: use development build and have console open while Calypso is loading and deserializing the state from local storage. Check that after this patch, you're no longer seeing errors like this:

<img width="1265" alt="state-validation-error" src="https://user-images.githubusercontent.com/664258/29524399-01e1f040-8690-11e7-9578-3b36dfc98c88.png">

Cc: @Automattic/stark 
