### PR TITLE
View Site: Add spacing between non-previewable button copy and icon

### DIFF
--- a/client/my-sites/preview/main.jsx
+++ b/client/my-sites/preview/main.jsx
@@ -120,6 +120,7 @@ class PreviewMain extends React.Component {
 			const action = (
 				<Button primary icon href={ site.URL } target="_blank">
 					{ translate( 'Open' ) }
+					{ ' ' }
 					<Gridicon icon="external" />
 				</Button>
 			);


### PR DESCRIPTION
This PR updates button inside the View Site message for a non-previewable site to have a space between the text and the icon.

Before:
![](https://cldup.com/bEdEWnMQke.png)

After:
![](https://cldup.com/xTkELrnJPl.png)

To test:
* Checkout this branch
* Go to `/view/:site`, where `:site` is a non-https Jetpack site
* Verify you see a space between text and icon in the button.