### PR TITLE
Image Editor: Change aspect tool button label and icon to crop

### DIFF
--- a/client/blocks/image-editor/image-editor-toolbar.jsx
+++ b/client/blocks/image-editor/image-editor-toolbar.jsx
@@ -199,8 +199,8 @@ export class ImageEditorToolbar extends Component {
 				: {
 					tool: 'aspect',
 					ref: this.setAspectMenuContext,
-					icon: 'layout',
-					text: translate( 'Aspect' ),
+					icon: 'crop',
+					text: translate( 'Crop' ),
 					onClick: this.onAspectOpen,
 					disabled: isAspectRatioDisabled
 				},


### PR DESCRIPTION
This has come up with Simple Payments internal testing. The label "Aspect" is technically correct but it's not the most clear what it is and the layout icon doesn't help it.

<img width="430" alt="screen shot 2017-08-21 at 16 08 04" src="https://user-images.githubusercontent.com/908665/29525911-10076f00-868c-11e7-8ab3-f05bbc151fc2.png">

Changing the label to "Crop" and the much more universally recognisable crop icon should help.

<img width="396" alt="screen shot 2017-08-21 at 16 10 29" src="https://user-images.githubusercontent.com/908665/29525922-1722837e-868c-11e7-8017-bdd95372b562.png">