### PR TITLE
Components: Use PureComponent for WebPreview and WebPreviewContent

### DIFF
--- a/client/components/web-preview/content.jsx
+++ b/client/components/web-preview/content.jsx
@@ -1,13 +1,13 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
 import debugModule from 'debug';
 import { noop, isFunction } from 'lodash';
 import page from 'page';
-import shallowCompare from 'react-addons-shallow-compare';
 import { v4 as uuid } from 'uuid';
 import addQueryArgs from 'lib/route/add-query-args';
 
@@ -24,7 +24,7 @@ import { recordTracksEvent } from 'state/analytics/actions';
 
 const debug = debugModule( 'calypso:web-preview' );
 
-export class WebPreviewContent extends Component {
+export class WebPreviewContent extends PureComponent {
 	previewId = uuid();
 	_hasTouch = false;
 
@@ -58,10 +58,6 @@ export class WebPreviewContent extends Component {
 
 	componentWillUnmount() {
 		window.removeEventListener( 'message', this.handleMessage );
-	}
-
-	shouldComponentUpdate( nextProps, nextState ) {
-		return shallowCompare( this, nextProps, nextState );
 	}
 
 	componentDidUpdate( prevProps ) {

--- a/client/components/web-preview/index.jsx
+++ b/client/components/web-preview/index.jsx
@@ -1,11 +1,11 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
 import { noop } from 'lodash';
-import shallowCompare from 'react-addons-shallow-compare';
 
 /**
  * Internal dependencies
@@ -18,7 +18,7 @@ import { setPreviewShowing } from 'state/ui/actions';
 import { recordTracksEvent } from 'state/analytics/actions';
 import WebPreviewContent from './content';
 
-export class WebPreview extends Component {
+export class WebPreview extends PureComponent {
 	constructor( props ) {
 		super( props );
 
@@ -44,10 +44,6 @@ export class WebPreview extends Component {
 			document.documentElement.classList.add( 'no-scroll', 'is-previewing' );
 		}
 		this.props.setPreviewShowing( this.props.showPreview );
-	}
-
-	shouldComponentUpdate( nextProps, nextState ) {
-		return shallowCompare( this, nextProps, nextState );
 	}
 
 	componentDidUpdate( prevProps ) {


### PR DESCRIPTION
This PR updates `WebPreview` and `WebPreviewContent` to use `React.PureComponent` instead of the legacy `shallowCompare`.

These are the last usages of `shallowCompare`, so we should consider removing it (see https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html#discontinuing-support-for-react-addons).

Removing `react-addons-shallow-compare` will be done in a separate PR.

To test:
* Checkout this branch
* Play with `WebPreview` in several locations:
  * Theme Preview
  * Editor Preview
  * SEO Settings Preview
  * Site Preview
* Verify there are no regressions.
