### PR TITLE
Framework: Remove react-addons-shallow-compare dependency

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -29,7 +29,7 @@
           "dev": true
         },
         "source-map": {
-          "version": "0.5.6",
+          "version": "0.5.7",
           "dev": true
         }
       }
@@ -243,7 +243,7 @@
       "version": "6.25.0",
       "dependencies": {
         "source-map": {
-          "version": "0.5.6"
+          "version": "0.5.7"
         }
       }
     },
@@ -258,7 +258,7 @@
           "version": "4.17.4"
         },
         "source-map": {
-          "version": "0.5.6"
+          "version": "0.5.7"
         }
       }
     },
@@ -639,7 +639,7 @@
       "version": "6.24.1",
       "dependencies": {
         "source-map": {
-          "version": "0.5.6"
+          "version": "0.5.7"
         },
         "source-map-support": {
           "version": "0.4.16"
@@ -879,10 +879,10 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000716"
+      "version": "1.0.30000717"
     },
     "caniuse-lite": {
-      "version": "1.0.30000716"
+      "version": "1.0.30000717"
     },
     "cardinal": {
       "version": "1.0.0",
@@ -1939,7 +1939,7 @@
       "version": "1.0.2"
     },
     "evp_bytestokey": {
-      "version": "1.0.0"
+      "version": "1.0.2"
     },
     "exec-sh": {
       "version": "0.2.0",
@@ -2898,7 +2898,7 @@
           "version": "3.5.0"
         },
         "source-map": {
-          "version": "0.5.6"
+          "version": "0.5.7"
         }
       }
     },
@@ -2983,7 +2983,7 @@
           "version": "0.2.17"
         },
         "source-map": {
-          "version": "0.5.6"
+          "version": "0.5.7"
         }
       }
     },
@@ -3000,7 +3000,7 @@
           "version": "1.0.0"
         },
         "source-map": {
-          "version": "0.5.6"
+          "version": "0.5.7"
         },
         "uglify-js": {
           "version": "2.6.4"
@@ -3380,7 +3380,7 @@
           "dev": true
         },
         "source-map": {
-          "version": "0.5.6",
+          "version": "0.5.7",
           "dev": true
         }
       }
@@ -3820,7 +3820,7 @@
           "dev": true
         },
         "source-map": {
-          "version": "0.5.6",
+          "version": "0.5.7",
           "dev": true
         },
         "source-map-support": {
@@ -4230,6 +4230,14 @@
     "md5-file": {
       "version": "3.1.0",
       "dev": true
+    },
+    "md5.js": {
+      "version": "1.3.4",
+      "dependencies": {
+        "hash-base": {
+          "version": "3.0.4"
+        }
+      }
     },
     "media-typer": {
       "version": "0.3.0"
@@ -4865,7 +4873,7 @@
           }
         },
         "source-map": {
-          "version": "0.5.6"
+          "version": "0.5.7"
         }
       }
     },
@@ -4927,7 +4935,7 @@
           "dev": true
         },
         "source-map": {
-          "version": "0.5.6",
+          "version": "0.5.7",
           "dev": true
         },
         "supports-color": {
@@ -5029,7 +5037,7 @@
           }
         },
         "source-map": {
-          "version": "0.5.6",
+          "version": "0.5.7",
           "dev": true
         },
         "strip-bom": {
@@ -5177,9 +5185,6 @@
       "version": "15.4.0"
     },
     "react-addons-linked-state-mixin": {
-      "version": "15.4.0"
-    },
-    "react-addons-shallow-compare": {
       "version": "15.4.0"
     },
     "react-addons-test-utils": {
@@ -5387,7 +5392,7 @@
       "version": "0.11.23",
       "dependencies": {
         "source-map": {
-          "version": "0.5.6"
+          "version": "0.5.7"
         }
       }
     },
@@ -5444,7 +5449,7 @@
           "dev": true
         },
         "source-map": {
-          "version": "0.5.6",
+          "version": "0.5.7",
           "dev": true
         }
       }
@@ -5484,7 +5489,7 @@
           }
         },
         "source-map": {
-          "version": "0.5.6",
+          "version": "0.5.7",
           "dev": true
         }
       }
@@ -6401,7 +6406,7 @@
           "version": "0.2.10"
         },
         "source-map": {
-          "version": "0.5.6"
+          "version": "0.5.7"
         }
       }
     },
@@ -6415,7 +6420,7 @@
           "version": "2.0.0"
         },
         "source-map": {
-          "version": "0.5.6"
+          "version": "0.5.7"
         },
         "uglify-js": {
           "version": "2.8.29"
@@ -6459,7 +6464,7 @@
           "version": "0.10.43"
         },
         "source-map": {
-          "version": "0.5.6"
+          "version": "0.5.7"
         }
       }
     },
@@ -6634,7 +6639,7 @@
           "version": "2.0.0"
         },
         "source-map": {
-          "version": "0.5.6"
+          "version": "0.5.7"
         },
         "string-width": {
           "version": "2.1.1",
@@ -6910,7 +6915,7 @@
       "version": "0.1.5",
       "dependencies": {
         "source-map": {
-          "version": "0.5.6"
+          "version": "0.5.7"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -123,7 +123,6 @@
     "react-addons-create-fragment": "15.4.0",
     "react-addons-css-transition-group": "15.4.0",
     "react-addons-linked-state-mixin": "15.4.0",
-    "react-addons-shallow-compare": "15.4.0",
     "react-addons-update": "15.4.0",
     "react-click-outside": "2.1.0",
     "react-day-picker": "6.0.2",


### PR DESCRIPTION
Removes `react-addons-shallow-compare` as it will no longer be maintained (see https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html#discontinuing-support-for-react-addons for more information).

Depends on #17402, which removes the last usage of `shallowCompare`.

