### PR TITLE
Add Site Name to Post Item in the new post list

### DIFF
--- a/client/blocks/post-item/index.jsx
+++ b/client/blocks/post-item/index.jsx
@@ -25,21 +25,25 @@ import PostTypePostAuthor from 'my-sites/post-type-list/post-type-post-author';
 
 function PostItem( { translate, globalId, post, site, editUrl, siteTitle, isAllSitesModeSelected, className, compact } ) {
 	const title = post ? post.title : null;
-	const classes = classnames( 'post-item', className, {
+	const postItemClasses = classnames( 'post-item', className, {
 		'is-untitled': ! title,
 		'is-mini': compact,
 		'is-placeholder': ! globalId
 	} );
 
+	const isSiteVisible = config.isEnabled( 'posts/post-type-list' ) && isAllSitesModeSelected;
+	const titleMetaClasses = classnames( 'post-item__title-meta', { 'site-is-visible': isSiteVisible } );
+
 	return (
-		<Card compact className={ classes }>
+		<Card compact className={ postItemClasses }>
 			<div className="post-item__detail">
-				<div className="post-item__title-meta">
-					{ config.isEnabled( 'posts/post-type-list' ) &&
-					isAllSitesModeSelected &&
-						<div>
+				<div className={ titleMetaClasses }>
+					{ isSiteVisible &&
+						<div className="post-item__site">
 							<SiteIcon size={ 16 } site={ site } />
-							{ siteTitle }
+							<div className="post-item__site-title">
+								{ siteTitle }
+							</div>
 						</div>
 					}
 					<h1 className="post-item__title">

--- a/client/blocks/post-item/index.jsx
+++ b/client/blocks/post-item/index.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';

--- a/client/blocks/post-item/index.jsx
+++ b/client/blocks/post-item/index.jsx
@@ -12,7 +12,8 @@ import { localize } from 'i18n-calypso';
  */
 import { getEditorPath } from 'state/ui/editor/selectors';
 import { getNormalizedPost } from 'state/posts/selectors';
-import { getSiteTitle } from 'state/sites/selectors';
+import { getSite, getSiteTitle } from 'state/sites/selectors';
+import SiteIcon from 'blocks/site-icon';
 import Card from 'components/card';
 import PostRelativeTime from 'blocks/post-relative-time';
 import PostStatus from 'blocks/post-status';
@@ -20,7 +21,7 @@ import PostTypeListPostThumbnail from 'my-sites/post-type-list/post-thumbnail';
 import PostActionsEllipsisMenu from 'my-sites/post-type-list/post-actions-ellipsis-menu';
 import PostTypePostAuthor from 'my-sites/post-type-list/post-type-post-author';
 
-function PostItem( { translate, globalId, post, editUrl, siteTitle, className, compact } ) {
+function PostItem( { translate, globalId, post, site, editUrl, siteTitle, className, compact } ) {
 	const title = post ? post.title : null;
 	const classes = classnames( 'post-item', className, {
 		'is-untitled': ! title,
@@ -32,6 +33,10 @@ function PostItem( { translate, globalId, post, editUrl, siteTitle, className, c
 		<Card compact className={ classes }>
 			<div className="post-item__detail">
 				<div className="post-item__title-meta">
+					<div>
+						<SiteIcon size={ 16 } site={ site } />
+						{ siteTitle }
+					</div>
 					<h1 className="post-item__title">
 						<a href={ editUrl } className="post-item__title-link">
 							{ title || translate( 'Untitled' ) }
@@ -54,6 +59,8 @@ PostItem.propTypes = {
 	translate: PropTypes.func,
 	globalId: PropTypes.string,
 	post: PropTypes.object,
+	site: PropTypes.object,
+	siteTitle: PropTypes.string,
 	className: PropTypes.string,
 	compact: PropTypes.bool
 };
@@ -64,9 +71,12 @@ export default connect( ( state, ownProps ) => {
 		return {};
 	}
 
+	const siteId = post.site_ID;
+
 	return {
 		post,
-		editUrl: getEditorPath( state, post.site_ID, post.ID ),
-		siteTitle: getSiteTitle( state, post.site_ID ),
+		site: getSite( state, siteId ),
+		siteTitle: getSiteTitle( state, siteId ),
+		editUrl: getEditorPath( state, siteId, post.ID ),
 	};
 } )( localize( PostItem ) );

--- a/client/blocks/post-item/index.jsx
+++ b/client/blocks/post-item/index.jsx
@@ -10,7 +10,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import config from 'config';
+import { isEnabled } from 'config';
 import { getEditorPath } from 'state/ui/editor/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getNormalizedPost } from 'state/posts/selectors';
@@ -31,7 +31,7 @@ function PostItem( { translate, globalId, post, site, editUrl, siteTitle, isAllS
 		'is-placeholder': ! globalId
 	} );
 
-	const isSiteVisible = config.isEnabled( 'posts/post-type-list' ) && isAllSitesModeSelected;
+	const isSiteVisible = isEnabled( 'posts/post-type-list' ) && isAllSitesModeSelected;
 	const titleMetaClasses = classnames( 'post-item__title-meta', { 'site-is-visible': isSiteVisible } );
 
 	return (

--- a/client/blocks/post-item/index.jsx
+++ b/client/blocks/post-item/index.jsx
@@ -10,7 +10,9 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import config from 'config';
 import { getEditorPath } from 'state/ui/editor/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
 import { getNormalizedPost } from 'state/posts/selectors';
 import { getSite, getSiteTitle } from 'state/sites/selectors';
 import SiteIcon from 'blocks/site-icon';
@@ -21,7 +23,7 @@ import PostTypeListPostThumbnail from 'my-sites/post-type-list/post-thumbnail';
 import PostActionsEllipsisMenu from 'my-sites/post-type-list/post-actions-ellipsis-menu';
 import PostTypePostAuthor from 'my-sites/post-type-list/post-type-post-author';
 
-function PostItem( { translate, globalId, post, site, editUrl, siteTitle, className, compact } ) {
+function PostItem( { translate, globalId, post, site, editUrl, siteTitle, isAllSitesModeSelected, className, compact } ) {
 	const title = post ? post.title : null;
 	const classes = classnames( 'post-item', className, {
 		'is-untitled': ! title,
@@ -33,10 +35,13 @@ function PostItem( { translate, globalId, post, site, editUrl, siteTitle, classN
 		<Card compact className={ classes }>
 			<div className="post-item__detail">
 				<div className="post-item__title-meta">
-					<div>
-						<SiteIcon size={ 16 } site={ site } />
-						{ siteTitle }
-					</div>
+					{ config.isEnabled( 'posts/post-type-list' ) &&
+					isAllSitesModeSelected &&
+						<div>
+							<SiteIcon size={ 16 } site={ site } />
+							{ siteTitle }
+						</div>
+					}
 					<h1 className="post-item__title">
 						<a href={ editUrl } className="post-item__title-link">
 							{ title || translate( 'Untitled' ) }
@@ -61,6 +66,7 @@ PostItem.propTypes = {
 	post: PropTypes.object,
 	site: PropTypes.object,
 	siteTitle: PropTypes.string,
+	isAllSitesModeSelected: PropTypes.bool,
 	className: PropTypes.string,
 	compact: PropTypes.bool
 };
@@ -77,6 +83,7 @@ export default connect( ( state, ownProps ) => {
 		post,
 		site: getSite( state, siteId ),
 		siteTitle: getSiteTitle( state, siteId ),
+		isAllSitesModeSelected: getSelectedSiteId( state ) === null,
 		editUrl: getEditorPath( state, siteId, post.ID ),
 	};
 } )( localize( PostItem ) );

--- a/client/blocks/post-item/index.jsx
+++ b/client/blocks/post-item/index.jsx
@@ -12,6 +12,7 @@ import { localize } from 'i18n-calypso';
  */
 import { getEditorPath } from 'state/ui/editor/selectors';
 import { getNormalizedPost } from 'state/posts/selectors';
+import { getSiteTitle } from 'state/sites/selectors';
 import Card from 'components/card';
 import PostRelativeTime from 'blocks/post-relative-time';
 import PostStatus from 'blocks/post-status';
@@ -19,7 +20,7 @@ import PostTypeListPostThumbnail from 'my-sites/post-type-list/post-thumbnail';
 import PostActionsEllipsisMenu from 'my-sites/post-type-list/post-actions-ellipsis-menu';
 import PostTypePostAuthor from 'my-sites/post-type-list/post-type-post-author';
 
-function PostItem( { translate, globalId, post, editUrl, className, compact } ) {
+function PostItem( { translate, globalId, post, editUrl, siteTitle, className, compact } ) {
 	const title = post ? post.title : null;
 	const classes = classnames( 'post-item', className, {
 		'is-untitled': ! title,
@@ -65,6 +66,7 @@ export default connect( ( state, ownProps ) => {
 
 	return {
 		post,
-		editUrl: getEditorPath( state, post.site_ID, post.ID )
+		editUrl: getEditorPath( state, post.site_ID, post.ID ),
+		siteTitle: getSiteTitle( state, post.site_ID ),
 	};
 } )( localize( PostItem ) );

--- a/client/blocks/post-item/style.scss
+++ b/client/blocks/post-item/style.scss
@@ -19,6 +19,27 @@
 
 .post-item__title-meta {
 	padding: 6px 0;
+
+	&.site-is-visible {
+		padding: 0;
+	}
+}
+
+.post-item__site {
+	display: flex;
+}
+
+.post-item__site .site-icon {
+	margin-right: 6px;
+}
+
+.post-item__site-title {
+	display: inline;
+	margin: 0;
+	line-height: 16px;
+	vertical-align: middle;
+	font-size: 13px;
+	color: $gray-dark;
 }
 
 .post-item__title {
@@ -81,6 +102,10 @@ a.post-item__title-link {
 		display: inline;
 		font-size: 13px;
 		margin: 0;
+	}
+
+	.post-item__site-title {
+		font-size: 11px;
 	}
 
 	.post-actions-ellipsis-menu {


### PR DESCRIPTION
This PR adds the site icon and the name of the site associated with a post when viewing a list of posts from multiple sites (All Sites mode) in the new post list.

This is part of a larger epic (See p8F9tW-fx-p2).

![image](https://user-images.githubusercontent.com/363749/29584372-246c9f66-8749-11e7-9b54-c86ca63d3b18.png)


To test the existing behavior:

- Check out branch.
- Run `npm start`
- Navigate to Blog Posts (/posts) and verify that the page hasn't changed compared to master, neither in All Sites mode nor with a specific site selected. Check the Latest drafts list as well.

To test the behavior behind the feature flag:

- Check out branch.
- Run `ENABLE_FEATURES=posts/post-type-list npm start`
- Navigate to Blog Posts (/posts) and verify that the new condensed post list is what you see, and the site icon and site name are present in All Sites mode but not when a site is selected.
- Verify that the draft list is compact (same as before) and the site icon and site name are *not* displayed