### PR TITLE
Store Orders: Pull real tax values from the order, not rounded display values

### DIFF
--- a/client/extensions/woocommerce/app/order/order-details/row-discount.js
+++ b/client/extensions/woocommerce/app/order/order-details/row-discount.js
@@ -9,12 +9,12 @@ import React, { Component } from 'react';
  * Internal dependencies
  */
 import formatCurrency from 'lib/format-currency';
+import { getOrderDiscountTax } from 'woocommerce/lib/order-taxes';
 
 class OrderDiscountRow extends Component {
 	static propTypes = {
 		order: PropTypes.shape( {
 			currency: PropTypes.string.isRequired,
-			discount_tax: PropTypes.string.isRequired,
 			discount_total: PropTypes.string.isRequired,
 		} ),
 		showTax: PropTypes.bool,
@@ -26,9 +26,10 @@ class OrderDiscountRow extends Component {
 			return null;
 		}
 
+		const taxValue = getOrderDiscountTax( order );
 		const tax = (
 			<div className="order-details__totals-tax">
-				{ formatCurrency( order.discount_tax, order.currency ) }
+				{ formatCurrency( taxValue, order.currency ) }
 			</div>
 		);
 

--- a/client/extensions/woocommerce/app/order/order-details/row-shipping-refund.js
+++ b/client/extensions/woocommerce/app/order/order-details/row-shipping-refund.js
@@ -8,6 +8,7 @@ import React, { Component } from 'react';
 /**
  * Internal dependencies
  */
+import { getCurrencyDefaults } from 'lib/format-currency';
 import PriceInput from 'woocommerce/components/price-input';
 
 class OrderShippingRefundRow extends Component {
@@ -23,11 +24,17 @@ class OrderShippingRefundRow extends Component {
 	render() {
 		const {
 			currency,
+			numberFormat,
 			onChange,
 			shippingTotal,
 			translate
 		} = this.props;
-		const total = Math.round( shippingTotal * 100 ) / 100;
+		const { decimal, grouping, precision } = getCurrencyDefaults( currency );
+		const total = numberFormat( Math.abs( shippingTotal ), {
+			decimals: precision,
+			decPoint: decimal,
+			thousandsSep: grouping,
+		} );
 
 		return (
 			<div className="order-details__total-shipping-refund">

--- a/client/extensions/woocommerce/app/order/order-details/row-shipping-refund.js
+++ b/client/extensions/woocommerce/app/order/order-details/row-shipping-refund.js
@@ -27,6 +27,7 @@ class OrderShippingRefundRow extends Component {
 			shippingTotal,
 			translate
 		} = this.props;
+		const total = Math.round( shippingTotal * 100 ) / 100;
 
 		return (
 			<div className="order-details__total-shipping-refund">
@@ -36,7 +37,7 @@ class OrderShippingRefundRow extends Component {
 						name="shipping_total"
 						onChange={ onChange }
 						currency={ currency }
-						value={ shippingTotal } />
+						value={ total } />
 				</div>
 			</div>
 		);

--- a/client/extensions/woocommerce/app/order/order-details/row-shipping.js
+++ b/client/extensions/woocommerce/app/order/order-details/row-shipping.js
@@ -9,12 +9,12 @@ import React, { Component } from 'react';
  * Internal dependencies
  */
 import formatCurrency from 'lib/format-currency';
+import { getOrderShippingTax } from 'woocommerce/lib/order-taxes';
 
 class OrderShippingRow extends Component {
 	static propTypes = {
 		order: PropTypes.shape( {
 			currency: PropTypes.string.isRequired,
-			shipping_tax: PropTypes.string.isRequired,
 			shipping_total: PropTypes.string.isRequired,
 		} ),
 		showTax: PropTypes.bool,
@@ -26,9 +26,10 @@ class OrderShippingRow extends Component {
 			return null;
 		}
 
+		const taxValue = getOrderShippingTax( order );
 		const tax = (
 			<div className="order-details__totals-tax">
-				{ formatCurrency( order.shipping_tax, order.currency ) }
+				{ formatCurrency( taxValue, order.currency ) }
 			</div>
 		);
 

--- a/client/extensions/woocommerce/app/order/order-details/row-total.js
+++ b/client/extensions/woocommerce/app/order/order-details/row-total.js
@@ -9,13 +9,13 @@ import React, { Component } from 'react';
  * Internal dependencies
  */
 import formatCurrency from 'lib/format-currency';
+import { getOrderTotalTax } from 'woocommerce/lib/order-taxes';
 
 class OrderTotalRow extends Component {
 	static propTypes = {
 		order: PropTypes.shape( {
 			currency: PropTypes.string.isRequired,
 			total: PropTypes.string.isRequired,
-			total_tax: PropTypes.string.isRequired,
 		} ),
 		showTax: PropTypes.bool,
 	}
@@ -26,9 +26,10 @@ class OrderTotalRow extends Component {
 			return null;
 		}
 
+		const taxValue = getOrderTotalTax( order );
 		const tax = (
 			<div className="order-details__totals-tax">
-				{ formatCurrency( order.total_tax, order.currency ) }
+				{ formatCurrency( taxValue, order.currency ) }
 			</div>
 		);
 

--- a/client/extensions/woocommerce/app/order/order-details/table.js
+++ b/client/extensions/woocommerce/app/order/order-details/table.js
@@ -68,13 +68,14 @@ class OrderDetailsTable extends Component {
 			if ( ! order.line_items[ i ] ) {
 				return 0;
 			}
+
 			const price = parseFloat( order.line_items[ i ].price );
-			const tax = getOrderLineItemTax( order, i ) / order.line_items[ i ].quantity;
-			const taxIncludedPrice = price + tax;
 			if ( order.prices_include_tax ) {
 				return price * q;
 			}
-			return taxIncludedPrice * q;
+
+			const tax = getOrderLineItemTax( order, i ) / order.line_items[ i ].quantity;
+			return ( price + tax ) * q;
 		} ) );
 		const total = subtotal + ( parseFloat( this.state.shippingTotal ) || 0 );
 		this.props.onChange( total );

--- a/client/extensions/woocommerce/app/order/order-details/table.js
+++ b/client/extensions/woocommerce/app/order/order-details/table.js
@@ -13,6 +13,7 @@ import { sum } from 'lodash';
 import formatCurrency from 'lib/format-currency';
 import FormTextInput from 'components/forms/form-text-input';
 import { getLink } from 'woocommerce/lib/nav-utils';
+import { getOrderLineItemTax, getOrderShippingTax } from 'woocommerce/lib/order-taxes';
 import OrderDiscountRow from './row-discount';
 import OrderRefundRow from './row-refund';
 import OrderShippingRefundRow from './row-shipping-refund';
@@ -42,9 +43,10 @@ class OrderDetailsTable extends Component {
 
 	constructor( props ) {
 		super( props );
+		const shippingTax = getOrderShippingTax( props.order );
 		this.state = {
 			quantities: [],
-			shippingTotal: parseFloat( props.order.shipping_tax ) + parseFloat( props.order.shipping_total ),
+			shippingTotal: parseFloat( shippingTax ) + parseFloat( props.order.shipping_total ),
 		};
 	}
 
@@ -58,17 +60,18 @@ class OrderDetailsTable extends Component {
 	}
 
 	recalculateRefund = () => {
-		if ( ! this.props.order ) {
+		const { order } = this.props;
+		if ( ! order ) {
 			return 0;
 		}
 		const subtotal = sum( this.state.quantities.map( ( q, i ) => {
-			if ( ! this.props.order.line_items[ i ] ) {
+			if ( ! order.line_items[ i ] ) {
 				return 0;
 			}
-			const price = parseFloat( this.props.order.line_items[ i ].price );
-			const tax = parseFloat( this.props.order.line_items[ i ].total_tax ) / this.props.order.line_items[ i ].quantity;
+			const price = parseFloat( order.line_items[ i ].price );
+			const tax = getOrderLineItemTax( order, i ) / order.line_items[ i ].quantity;
 			const taxIncludedPrice = price + tax;
-			if ( this.props.order.prices_include_tax ) {
+			if ( order.prices_include_tax ) {
 				return price * q;
 			}
 			return taxIncludedPrice * q;
@@ -105,6 +108,7 @@ class OrderDetailsTable extends Component {
 
 	renderOrderItems = ( item, i ) => {
 		const { isEditable, order, site } = this.props;
+		const tax = getOrderLineItemTax( order, i );
 		return (
 			<TableRow key={ i } className="order-details__items">
 				<TableItem isRowHeader className="order-details__item-product">
@@ -127,7 +131,7 @@ class OrderDetailsTable extends Component {
 					}
 				</TableItem>
 				<TableItem className="order-details__item-tax">
-					{ formatCurrency( item.total_tax, order.currency ) }
+					{ formatCurrency( tax, order.currency ) }
 				</TableItem>
 				<TableItem className="order-details__item-total">{ formatCurrency( item.total, order.currency ) }</TableItem>
 			</TableRow>

--- a/client/extensions/woocommerce/lib/order-taxes/index.js
+++ b/client/extensions/woocommerce/lib/order-taxes/index.js
@@ -1,0 +1,61 @@
+/**
+ * External dependencies
+ */
+import { get, reduce } from 'lodash';
+
+/**
+ * Get the total tax for the discount value
+ *
+ * @param {Object} order An order as returned from API
+ * @return {Float} Tax amount as a decimal number
+ */
+export function getOrderDiscountTax( order ) {
+	const tax = get( order, 'coupon_lines[0].discount_tax', 0 );
+	return parseFloat( tax ) || 0;
+}
+
+/**
+ * Get the total tax for a given line item's value
+ *
+ * @param {Object} order An order as returned from API
+ * @param {Number} index The index of a line item in this order
+ * @return {Float} Tax amount as a decimal number
+ */
+export function getOrderLineItemTax( order, index ) {
+	const tax = get( order, `line_items[${ index }].taxes[0].total`, 0 );
+	return parseFloat( tax ) || 0;
+}
+
+/**
+ * Get the total tax for the shipping value
+ *
+ * @param {Object} order An order as returned from API
+ * @return {Float} Tax amount as a decimal number
+ */
+export function getOrderShippingTax( order ) {
+	const tax = get( order, 'shipping_lines[0].taxes[0].total', 0 );
+	return parseFloat( tax ) || 0;
+}
+
+/**
+ * Get the total tax for the subtotal value (total of all line items)
+ *
+ * @param {Object} order An order as returned from API
+ * @return {Float} Tax amount as a decimal number
+ */
+export function getOrderSubtotalTax( order ) {
+	const items = get( order, 'line_items', [] );
+	return reduce( items, ( sum, value, key ) => sum + getOrderLineItemTax( order, key ), 0 );
+}
+
+/**
+ * Get the total tax for the total value
+ *
+ * @param {Object} order An order as returned from API
+ * @return {Float} Tax amount as a decimal number
+ */
+export function getOrderTotalTax( order ) {
+	const subtotal = getOrderSubtotalTax( order );
+	const shipping = getOrderShippingTax( order );
+	return subtotal + shipping;
+}

--- a/client/extensions/woocommerce/lib/order-taxes/index.js
+++ b/client/extensions/woocommerce/lib/order-taxes/index.js
@@ -10,7 +10,8 @@ import { get, reduce } from 'lodash';
  * @return {Float} Tax amount as a decimal number
  */
 export function getOrderDiscountTax( order ) {
-	const tax = get( order, 'coupon_lines[0].discount_tax', 0 );
+	const coupons = get( order, 'coupon_lines', [] );
+	const tax = reduce( coupons, ( sum, value ) => sum + parseFloat( value.discount_tax ), 0 );
 	return parseFloat( tax ) || 0;
 }
 

--- a/client/extensions/woocommerce/lib/order-taxes/test/fixtures/order-no-tax.js
+++ b/client/extensions/woocommerce/lib/order-taxes/test/fixtures/order-no-tax.js
@@ -1,0 +1,17 @@
+/* eslint-disable */
+export default {
+	"line_items": [
+		{
+			"id": 1,
+			"name": "Scarf",
+			"product_id": 49,
+			"taxes": [],
+			"price": 25
+		}
+	],
+	"tax_lines": [],
+	"shipping_lines": [],
+	"fee_lines": [],
+	"coupon_lines": [],
+	"refunds": []
+}

--- a/client/extensions/woocommerce/lib/order-taxes/test/fixtures/order-with-coupons.js
+++ b/client/extensions/woocommerce/lib/order-taxes/test/fixtures/order-with-coupons.js
@@ -1,0 +1,73 @@
+/* eslint-disable */
+export default {
+	"line_items": [
+		{
+			"id": 26,
+			"name": "Mug",
+			"product_id": 71,
+			"taxes": [
+				{
+					"id": 4,
+					"total": "1.4784",
+					"subtotal": "2.0307"
+				}
+			],
+			"price": 11.6408
+		},
+		{
+			"id": 27,
+			"name": "Scarf - Blue",
+			"taxes": [
+				{
+					"id": 4,
+					"total": "2.3109",
+					"subtotal": "3.1744"
+				}
+			],
+			"price": 36.3929
+		}
+	],
+	"tax_lines": [
+		{
+			"id": 29,
+			"rate_code": "US-CT-CT TAX-1",
+			"rate_id": 4,
+			"label": "CT Tax",
+			"compound": false,
+			"tax_total": "3.78",
+			"shipping_tax_total": "0.64",
+		}
+	],
+	"shipping_lines": [
+		{
+			"id": 28,
+			"method_title": "USPS",
+			"method_id": "fallback:0:0",
+			"total": "10.00",
+			"total_tax": "0.64",
+			"taxes": [
+				{
+					"id": 4,
+					"total": "0.635",
+					"subtotal": ""
+				}
+			],
+		}
+	],
+	"fee_lines": [],
+	"coupon_lines": [
+		{
+			"id": 30,
+			"code": "store-launch",
+			"discount": "12.3",
+			"discount_tax": "0.78",
+		},
+		{
+			"id": 31,
+			"code": "additional-discount",
+			"discount": "10",
+			"discount_tax": "0.64",
+		}
+	],
+	"refunds": [],
+}

--- a/client/extensions/woocommerce/lib/order-taxes/test/fixtures/order.js
+++ b/client/extensions/woocommerce/lib/order-taxes/test/fixtures/order.js
@@ -1,0 +1,68 @@
+/* eslint-disable */
+export default {
+	"line_items": [
+		{
+			"id": 15,
+			"name": "Scarf - Striped",
+			"product_id": 49,
+			"taxes": [
+				{
+					"id": 4,
+					"total": "5.3964",
+					"subtotal": "6.3487"
+				}
+			],
+			"price": 42.4915
+		},
+		{
+			"id": 19,
+			"name": "T-Shirt",
+			"product_id": 62,
+			"taxes": [
+				{
+					"id": 4,
+					"total": "1.1424",
+					"subtotal": "1.1424"
+				}
+			],
+			"price": 17.99
+		}
+	],
+	"tax_lines": [
+		{
+			"id": 17,
+			"rate_code": "US-CT-CT TAX-1",
+			"rate_id": 4,
+			"label": "CT Tax",
+			"compound": false,
+			"tax_total": "6.54",
+			"shipping_tax_total": "0.64",
+		}
+	],
+	"shipping_lines": [
+		{
+			"id": 16,
+			"method_title": "USPS",
+			"method_id": "usps:3:0",
+			"total": "10.00",
+			"total_tax": "0.64",
+			"taxes": [
+				{
+					"id": 4,
+					"total": "0.635",
+					"subtotal": ""
+				}
+			]
+		}
+	],
+	"fee_lines": [],
+	"coupon_lines": [
+		{
+			"id": 18,
+			"code": "store-launch",
+			"discount": "15",
+			"discount_tax": "0.95",
+		}
+	],
+	"refunds": [],
+}

--- a/client/extensions/woocommerce/lib/order-taxes/test/index.js
+++ b/client/extensions/woocommerce/lib/order-taxes/test/index.js
@@ -1,0 +1,95 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import {
+	getOrderDiscountTax,
+	getOrderLineItemTax,
+	getOrderShippingTax,
+	getOrderSubtotalTax,
+	getOrderTotalTax,
+} from '../index';
+import orderWithTax from './fixtures/order';
+import orderWithoutTax from './fixtures/order-no-tax';
+
+describe( 'getOrderDiscountTax', () => {
+	it( 'should be a function', () => {
+		expect( getOrderDiscountTax ).to.be.a( 'function' );
+	} );
+
+	it( 'should get the correct tax amount', () => {
+		expect( getOrderDiscountTax( orderWithTax ) ).to.eql( 0.95 );
+	} );
+
+	it( 'should return 0 if there is no tax', () => {
+		expect( getOrderDiscountTax( orderWithoutTax ) ).to.eql( 0 );
+	} );
+
+	it( 'should return 0 if the order is malformed', () => {
+		expect( getOrderDiscountTax( {} ) ).to.eql( 0 );
+	} );
+} );
+
+describe( 'getOrderLineItemTax', () => {
+	it( 'should be a function', () => {
+		expect( getOrderLineItemTax ).to.be.a( 'function' );
+	} );
+
+	it( 'should get the correct tax amount', () => {
+		expect( getOrderLineItemTax( orderWithTax, 0 ) ).to.eql( 5.3964 );
+	} );
+
+	it( 'should get the correct tax amount for the second item', () => {
+		expect( getOrderLineItemTax( orderWithTax, 1 ) ).to.eql( 1.1424 );
+	} );
+
+	it( 'should return 0 if there is no tax', () => {
+		expect( getOrderLineItemTax( orderWithoutTax, 0 ) ).to.eql( 0 );
+	} );
+} );
+
+describe( 'getOrderShippingTax', () => {
+	it( 'should be a function', () => {
+		expect( getOrderShippingTax ).to.be.a( 'function' );
+	} );
+
+	it( 'should get the correct tax amount', () => {
+		expect( getOrderShippingTax( orderWithTax ) ).to.eql( 0.635 );
+	} );
+
+	it( 'should return 0 if there is no tax', () => {
+		expect( getOrderShippingTax( orderWithoutTax ) ).to.eql( 0 );
+	} );
+} );
+
+describe( 'getOrderSubtotalTax', () => {
+	it( 'should be a function', () => {
+		expect( getOrderSubtotalTax ).to.be.a( 'function' );
+	} );
+
+	it( 'should get the correct tax amount', () => {
+		expect( getOrderSubtotalTax( orderWithTax ) ).to.eql( 6.5388 );
+	} );
+
+	it( 'should return 0 if there is no tax', () => {
+		expect( getOrderSubtotalTax( orderWithoutTax ) ).to.eql( 0 );
+	} );
+} );
+
+describe( 'getOrderTotalTax', () => {
+	it( 'should be a function', () => {
+		expect( getOrderTotalTax ).to.be.a( 'function' );
+	} );
+
+	it( 'should get the correct tax amount', () => {
+		expect( getOrderTotalTax( orderWithTax ) ).to.eql( 7.1738 );
+	} );
+
+	it( 'should return 0 if there is no tax', () => {
+		expect( getOrderTotalTax( orderWithoutTax ) ).to.eql( 0 );
+	} );
+} );

--- a/client/extensions/woocommerce/lib/order-taxes/test/index.js
+++ b/client/extensions/woocommerce/lib/order-taxes/test/index.js
@@ -15,6 +15,7 @@ import {
 } from '../index';
 import orderWithTax from './fixtures/order';
 import orderWithoutTax from './fixtures/order-no-tax';
+import orderWithCoupons from './fixtures/order-with-coupons';
 
 describe( 'getOrderDiscountTax', () => {
 	it( 'should be a function', () => {
@@ -23,6 +24,10 @@ describe( 'getOrderDiscountTax', () => {
 
 	it( 'should get the correct tax amount', () => {
 		expect( getOrderDiscountTax( orderWithTax ) ).to.eql( 0.95 );
+	} );
+
+	it( 'should get the correct tax amount with multiple coupons', () => {
+		expect( getOrderDiscountTax( orderWithCoupons ) ).to.eql( 1.42 );
 	} );
 
 	it( 'should return 0 if there is no tax', () => {
@@ -50,6 +55,10 @@ describe( 'getOrderLineItemTax', () => {
 	it( 'should return 0 if there is no tax', () => {
 		expect( getOrderLineItemTax( orderWithoutTax, 0 ) ).to.eql( 0 );
 	} );
+
+	it( 'should get the correct tax amount for an item with multiple coupons', () => {
+		expect( getOrderLineItemTax( orderWithCoupons, 1 ) ).to.eql( 2.3109 );
+	} );
 } );
 
 describe( 'getOrderShippingTax', () => {
@@ -63,6 +72,10 @@ describe( 'getOrderShippingTax', () => {
 
 	it( 'should return 0 if there is no tax', () => {
 		expect( getOrderShippingTax( orderWithoutTax ) ).to.eql( 0 );
+	} );
+
+	it( 'should get the correct tax amount with multiple coupons', () => {
+		expect( getOrderShippingTax( orderWithCoupons ) ).to.eql( 0.635 );
 	} );
 } );
 
@@ -78,6 +91,10 @@ describe( 'getOrderSubtotalTax', () => {
 	it( 'should return 0 if there is no tax', () => {
 		expect( getOrderSubtotalTax( orderWithoutTax ) ).to.eql( 0 );
 	} );
+
+	it( 'should get the correct tax amount with multiple coupons', () => {
+		expect( getOrderSubtotalTax( orderWithCoupons ) ).to.eql( 3.7893 );
+	} );
 } );
 
 describe( 'getOrderTotalTax', () => {
@@ -91,5 +108,9 @@ describe( 'getOrderTotalTax', () => {
 
 	it( 'should return 0 if there is no tax', () => {
 		expect( getOrderTotalTax( orderWithoutTax ) ).to.eql( 0 );
+	} );
+
+	it( 'should get the correct tax amount with multiple coupons', () => {
+		expect( getOrderTotalTax( orderWithCoupons ) ).to.eql( 4.4243 );
 	} );
 } );


### PR DESCRIPTION
Fixes #17218 

The API response for an order includes multiple tax value properties, and the values we'd been using are already rounded to the cent for display. This caused a problem in refunding, because tax can be a fraction of a cent, and when rounding up, you can end up with an extra cent over the real total.

This PR adds a few helper functions to pull the exact tax out of the API response, along with tests for each. Then we use these functions to get the tax values in the order details table, and refunds modal.

The `formatCurrency` function takes care of rounding the tax to the right decimal place, but we do round the value in the shipping refund input for display.

**To test**

- Run the tests:

```
npm run test-client client/extensions/woocommerce/lib/order-taxes/test/index.js
```

- View an order that includes taxes
- Check that your taxes display correctly
- Go to refund the order, leave shipping alone and refund the full quantity of items
- Make sure the refund total matches the actual order total