### PR TITLE
Janitorial: Refactor Register Domain Step (Signup/Search)

### DIFF
--- a/client/components/domains/domain-mapping-suggestion/index.jsx
+++ b/client/components/domains/domain-mapping-suggestion/index.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import PropTypes from 'prop-types';
 import React from 'react';
 import { localize } from 'i18n-calypso';
 
@@ -12,12 +13,12 @@ import { shouldBundleDomainWithPlan, getDomainPriceRule } from 'lib/cart-values/
 
 class DomainMappingSuggestion extends React.Component {
 	static propTypes = {
-		isSignupStep: React.PropTypes.bool,
-		cart: React.PropTypes.object,
-		products: React.PropTypes.object.isRequired,
-		onButtonClick: React.PropTypes.func.isRequired,
-		domainsWithPlansOnly: React.PropTypes.bool.isRequired,
-		selectedSite: React.PropTypes.oneOfType( [ React.PropTypes.object, React.PropTypes.bool ] )
+		isSignupStep: PropTypes.bool,
+		cart: PropTypes.object,
+		products: PropTypes.object.isRequired,
+		onButtonClick: PropTypes.func.isRequired,
+		domainsWithPlansOnly: PropTypes.bool.isRequired,
+		selectedSite: PropTypes.oneOfType( [ PropTypes.object, PropTypes.bool ] )
 	};
 
 	render() {

--- a/client/components/domains/domain-product-price/index.jsx
+++ b/client/components/domains/domain-product-price/index.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import PropTypes from 'prop-types';
 import React from 'react';
 import classnames from 'classnames';
 import { connect } from 'react-redux';
@@ -15,11 +16,11 @@ import { DOMAINS_WITH_PLANS_ONLY } from 'state/current-user/constants';
 
 class DomainProductPrice extends React.Component {
 	static propTypes = {
-		isLoading: React.PropTypes.bool,
-		price: React.PropTypes.string,
-		freeWithPlan: React.PropTypes.bool,
-		requiresPlan: React.PropTypes.bool,
-		domainsWithPlansOnly: React.PropTypes.bool.isRequired
+		isLoading: PropTypes.bool,
+		price: PropTypes.string,
+		freeWithPlan: PropTypes.bool,
+		requiresPlan: PropTypes.bool,
+		domainsWithPlansOnly: PropTypes.bool.isRequired
 	};
 
 	renderFreeWithPlan() {

--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -1,8 +1,9 @@
 /**
  * External dependencies
  */
-import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
 import React from 'react';
+import { connect } from 'react-redux';
 import { includes, isNumber } from 'lodash';
 import { localize } from 'i18n-calypso';
 
@@ -261,21 +262,21 @@ const newTLDs = [
 
 class DomainRegistrationSuggestion extends React.Component {
 	static propTypes = {
-		isSignupStep: React.PropTypes.bool,
-		cart: React.PropTypes.object,
-		suggestion: React.PropTypes.shape( {
-			domain_name: React.PropTypes.string.isRequired,
-			product_slug: React.PropTypes.string,
-			cost: React.PropTypes.string
+		isSignupStep: PropTypes.bool,
+		cart: PropTypes.object,
+		suggestion: PropTypes.shape( {
+			domain_name: PropTypes.string.isRequired,
+			product_slug: PropTypes.string,
+			cost: PropTypes.string
 		} ).isRequired,
-		onButtonClick: React.PropTypes.func.isRequired,
-		domainsWithPlansOnly: React.PropTypes.bool.isRequired,
-		selectedSite: React.PropTypes.object,
-		railcarId: React.PropTypes.string,
-		recordTracksEvent: React.PropTypes.func,
-		uiPosition: React.PropTypes.number,
-		fetchAlgo: React.PropTypes.string,
-		query: React.PropTypes.string
+		onButtonClick: PropTypes.func.isRequired,
+		domainsWithPlansOnly: PropTypes.bool.isRequired,
+		selectedSite: PropTypes.object,
+		railcarId: PropTypes.string,
+		recordTracksEvent: PropTypes.func,
+		uiPosition: PropTypes.number,
+		fetchAlgo: PropTypes.string,
+		query: PropTypes.string
 	};
 
 	componentDidMount() {

--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -1,11 +1,12 @@
 /**
  * External dependencies
  */
+import PropTypes from 'prop-types';
+import React from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import isSiteOnPaidPlan from 'state/selectors/is-site-on-paid-plan';
-import React from 'react';
 import classNames from 'classnames';
 import {
 	endsWith,
@@ -26,27 +27,27 @@ import { domainAvailability } from 'lib/domains/constants';
 
 class DomainSearchResults extends React.Component {
 	static propTypes = {
-		domainsWithPlansOnly: React.PropTypes.bool.isRequired,
-		lastDomainStatus: React.PropTypes.string,
-		lastDomainSearched: React.PropTypes.string,
-		cart: React.PropTypes.object,
-		products: React.PropTypes.object.isRequired,
-		selectedSite: React.PropTypes.object,
-		availableDomain: React.PropTypes.oneOfType( [
-			React.PropTypes.object,
-			React.PropTypes.bool
+		domainsWithPlansOnly: PropTypes.bool.isRequired,
+		lastDomainStatus: PropTypes.string,
+		lastDomainSearched: PropTypes.string,
+		cart: PropTypes.object,
+		products: PropTypes.object.isRequired,
+		selectedSite: PropTypes.object,
+		availableDomain: PropTypes.oneOfType( [
+			PropTypes.object,
+			PropTypes.bool
 		] ),
-		suggestions: React.PropTypes.array,
-		placeholderQuantity: React.PropTypes.number.isRequired,
-		buttonLabel: React.PropTypes.string,
-		mappingSuggestionLabel: React.PropTypes.string,
-		offerMappingOption: React.PropTypes.bool,
-		onClickResult: React.PropTypes.func.isRequired,
-		onAddMapping: React.PropTypes.func,
-		onClickMapping: React.PropTypes.func,
-		isSignupStep: React.PropTypes.bool,
-		railcarSeed: React.PropTypes.string,
-		fetchAlgo: React.PropTypes.string
+		suggestions: PropTypes.array,
+		placeholderQuantity: PropTypes.number.isRequired,
+		buttonLabel: PropTypes.string,
+		mappingSuggestionLabel: PropTypes.string,
+		offerMappingOption: PropTypes.bool,
+		onClickResult: PropTypes.func.isRequired,
+		onAddMapping: PropTypes.func,
+		onClickMapping: PropTypes.func,
+		isSignupStep: PropTypes.bool,
+		railcarSeed: PropTypes.string,
+		fetchAlgo: PropTypes.string
 	};
 
 	renderDomainAvailability() {

--- a/client/components/domains/domain-suggestion/index.jsx
+++ b/client/components/domains/domain-suggestion/index.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
 import Gridicon from 'gridicons';
@@ -12,13 +13,13 @@ import DomainProductPrice from 'components/domains/domain-product-price';
 
 class DomainSuggestion extends React.Component {
 	static propTypes = {
-		buttonContent: React.PropTypes.oneOfType( [ React.PropTypes.string, React.PropTypes.element ] ).isRequired,
-		buttonClasses: React.PropTypes.string,
-		extraClasses: React.PropTypes.string,
-		onButtonClick: React.PropTypes.func.isRequired,
-		priceRule: React.PropTypes.string.isRequired,
-		price: React.PropTypes.string,
-		domain: React.PropTypes.string
+		buttonContent: PropTypes.oneOfType( [ PropTypes.string, PropTypes.element ] ).isRequired,
+		buttonClasses: PropTypes.string,
+		extraClasses: PropTypes.string,
+		onButtonClick: PropTypes.func.isRequired,
+		priceRule: PropTypes.string.isRequired,
+		price: PropTypes.string,
+		domain: PropTypes.string
 	};
 
 	render() {

--- a/client/components/domains/example-domain-suggestions/index.jsx
+++ b/client/components/domains/example-domain-suggestions/index.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import PropTypes from 'prop-types';
 import React from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
@@ -12,7 +13,7 @@ import { recordTracksEvent } from 'state/analytics/actions';
 
 class DomainSuggestionsExample extends React.Component {
 	static propTypes = {
-		mapDomainUrl: React.PropTypes.string.isRequired
+		mapDomainUrl: PropTypes.string.isRequired
 	};
 
 	render() {

--- a/client/components/domains/map-domain-step/index.jsx
+++ b/client/components/domains/map-domain-step/index.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
@@ -26,15 +27,15 @@ import Notice from 'components/notice';
 
 class MapDomainStep extends React.Component {
 	static propTypes = {
-		products: React.PropTypes.object.isRequired,
-		cart: React.PropTypes.object,
-		selectedSite: React.PropTypes.oneOfType( [ React.PropTypes.object, React.PropTypes.bool ] ),
-		initialQuery: React.PropTypes.string,
-		analyticsSection: React.PropTypes.string.isRequired,
-		domainsWithPlansOnly: React.PropTypes.bool.isRequired,
-		onRegisterDomain: React.PropTypes.func.isRequired,
-		onMapDomain: React.PropTypes.func.isRequired,
-		onSave: React.PropTypes.func,
+		products: PropTypes.object.isRequired,
+		cart: PropTypes.object,
+		selectedSite: PropTypes.oneOfType( [ PropTypes.object, PropTypes.bool ] ),
+		initialQuery: PropTypes.string,
+		analyticsSection: PropTypes.string.isRequired,
+		domainsWithPlansOnly: PropTypes.bool.isRequired,
+		onRegisterDomain: PropTypes.func.isRequired,
+		onMapDomain: PropTypes.func.isRequired,
+		onSave: PropTypes.func,
 	};
 
 	static defaultProps = {

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -196,6 +196,7 @@ class RegisterDomainStep extends React.Component {
 
 	render() {
 		const queryObject = getQueryObject( this.props );
+
 		return (
 			<div className="register-domain-step">
 					<div className="register-domain-step__search">

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -167,6 +167,8 @@ class RegisterDomainStep extends React.Component {
 
 			this.setState( state );
 		}
+
+		this._isMounted = false;
 	}
 
 	componentDidMount() {
@@ -174,6 +176,8 @@ class RegisterDomainStep extends React.Component {
 			this.onSearch( this.state.lastQuery );
 		}
 		this.props.searchFormView( this.props.analyticsSection );
+
+		this._isMounted = true;
 	}
 
 	componentDidUpdate( prevProps ) {
@@ -365,7 +369,7 @@ class RegisterDomainStep extends React.Component {
 				}
 			],
 			( error, result ) => {
-				if ( ! this.state.loadingResults || domain !== this.state.lastDomainSearched || ! this.isMounted() ) {
+				if ( ! this.state.loadingResults || domain !== this.state.lastDomainSearched || ! this._isMounted ) {
 					// this callback is irrelevant now, a newer search has been made or the results were cleared OR
 					// domain registration was not available and component is unmounted
 					return;

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -59,6 +59,8 @@ const fetchAlgo = searchVendor + '/v1';
 
 let searchCount = 0;
 
+let initialState;
+
 function getQueryObject( props ) {
 	if ( ! props.selectedSite || ! props.selectedSite.domain ) {
 		return null;
@@ -105,7 +107,7 @@ class RegisterDomainStep extends React.Component {
 
 		const suggestion = this.props.suggestion ? getFixedDomainSearch( this.props.suggestion ) : '';
 
-		this.state = {
+		initialState = {
 			clickedExampleSuggestion: false,
 			lastQuery: suggestion,
 			lastDomainSearched: null,
@@ -114,6 +116,7 @@ class RegisterDomainStep extends React.Component {
 			notice: null,
 			searchResults: null,
 		};
+		this.state = initialState;
 	}
 
 	getNewRailcarSeed() {
@@ -126,7 +129,7 @@ class RegisterDomainStep extends React.Component {
 	componentWillReceiveProps( nextProps ) {
 		// Reset state on site change
 		if ( nextProps.selectedSite && nextProps.selectedSite.slug !== ( this.props.selectedSite || {} ).slug ) {
-			this.setState( this.getInitialState() );
+			this.setState( initialState );
 		}
 
 		if ( this.props.defaultSuggestionsError === nextProps.defaultSuggestionsError ||
@@ -171,11 +174,15 @@ class RegisterDomainStep extends React.Component {
 		this._isMounted = false;
 	}
 
+	componentWillUnmount() {
+		this._isMounted = false;
+	}
+
 	componentDidMount() {
 		if ( this.state.lastQuery ) {
 			this.onSearch( this.state.lastQuery );
 		}
-		this.props.searchFormView( this.props.analyticsSection );
+		this.props.recordSearchFormView( this.props.analyticsSection );
 
 		this._isMounted = true;
 	}
@@ -281,7 +288,7 @@ class RegisterDomainStep extends React.Component {
 			return;
 		}
 
-		this.props.searchFormSubmit( searchQuery, this.props.analyticsSection, searchCount, searchVendor );
+		this.props.recordSearchFormSubmit( searchQuery, this.props.analyticsSection, searchCount, searchVendor );
 		searchCount++;
 
 		this.setState( {
@@ -316,7 +323,7 @@ class RegisterDomainStep extends React.Component {
 							this.showValidationErrorMessage( domain, status );
 						}
 
-						this.props.domainAvailabilityReceive( domain, status, timeDiff, this.props.analyticsSection );
+						this.props.recordDomainAvailabilityReceive( domain, status, timeDiff, this.props.analyticsSection );
 
 						this.props.onDomainsAvailabilityChange( true );
 						callback( null, isDomainAvailable ? result : null );
@@ -338,7 +345,7 @@ class RegisterDomainStep extends React.Component {
 						const timeDiff = Date.now() - timestamp;
 						const analyticsResults = domainSuggestions.map( suggestion => suggestion.domain_name );
 
-						this.props.searchResultsReceive(
+						this.props.recordSearchResultsReceive(
 							domain,
 							analyticsResults,
 							timeDiff,
@@ -358,7 +365,7 @@ class RegisterDomainStep extends React.Component {
 						}
 
 						const analyticsResults = [ error.code || error.error || 'ERROR' + ( error.statusCode || '' ) ];
-						this.props.searchResultsReceive(
+						this.props.recordSearchResultsReceive(
 							domain,
 							analyticsResults,
 							timeDiff,
@@ -543,7 +550,7 @@ class RegisterDomainStep extends React.Component {
 	goToMapDomainStep = ( event ) => {
 		event.preventDefault();
 
-		this.props.mapDomainButtonClick( this.props.analyticsSection );
+		this.props.recordMapDomainButtonClick( this.props.analyticsSection );
 
 		page( this.getMapDomainUrl() );
 	};
@@ -554,7 +561,7 @@ class RegisterDomainStep extends React.Component {
 	}
 }
 
-const mapDomainButtonClick = ( section ) => composeAnalytics(
+const recordMapDomainButtonClick = ( section ) => composeAnalytics(
 	recordGoogleEvent(
 		'Domain Search',
 		'Clicked "Map it" Button'
@@ -565,7 +572,7 @@ const mapDomainButtonClick = ( section ) => composeAnalytics(
 	),
 );
 
-const searchFormSubmit = ( searchBoxValue, section, count, vendor ) => composeAnalytics(
+const recordSearchFormSubmit = ( searchBoxValue, section, count, vendor ) => composeAnalytics(
 	recordGoogleEvent(
 		'Domain Search',
 		'Submitted Search Form',
@@ -583,7 +590,7 @@ const searchFormSubmit = ( searchBoxValue, section, count, vendor ) => composeAn
 	),
 );
 
-const searchFormView = ( section ) => composeAnalytics(
+const recordSearchFormView = ( section ) => composeAnalytics(
 	recordGoogleEvent(
 		'Domain Search',
 		'Landed on Search'
@@ -594,7 +601,7 @@ const searchFormView = ( section ) => composeAnalytics(
 	),
 );
 
-const searchResultsReceive = ( searchQuery, searchResults, responseTimeInMs, resultCount, section ) => composeAnalytics(
+const recordSearchResultsReceive = ( searchQuery, searchResults, responseTimeInMs, resultCount, section ) => composeAnalytics(
 	recordGoogleEvent(
 		'Domain Search',
 		'Receive Results',
@@ -613,7 +620,7 @@ const searchResultsReceive = ( searchQuery, searchResults, responseTimeInMs, res
 	),
 );
 
-const domainAvailabilityReceive = ( searchQuery, availableStatus, responseTimeInMs, section ) => composeAnalytics(
+const recordDomainAvailabilityReceive = ( searchQuery, availableStatus, responseTimeInMs, section ) => composeAnalytics(
 	recordGoogleEvent(
 		'Domain Search',
 		'Domain Availability Result',
@@ -641,10 +648,10 @@ export default connect(
 		};
 	},
 	{
-		domainAvailabilityReceive,
-		mapDomainButtonClick,
-		searchFormSubmit,
-		searchFormView,
-		searchResultsReceive,
+		recordDomainAvailabilityReceive,
+		recordMapDomainButtonClick,
+		recordSearchFormSubmit,
+		recordSearchFormView,
+		recordSearchResultsReceive,
 	}
 )( localize( RegisterDomainStep ) );

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -63,8 +63,6 @@ let lastSearchTimestamp = null;
 let searchCount = 0;
 let recordSearchFormSubmitWithDispatch;
 
-let initialState;
-
 function getQueryObject( props ) {
 	if ( ! props.selectedSite || ! props.selectedSite.domain ) {
 		return null;
@@ -144,9 +142,15 @@ class RegisterDomainStep extends React.Component {
 	constructor( props ) {
 		super( props );
 
+		this.state = this.getState();
+
+		recordSearchFormSubmitWithDispatch = this.props.recordSearchFormSubmit;
+	}
+
+	getState() {
 		const suggestion = this.props.suggestion ? getFixedDomainSearch( this.props.suggestion ) : '';
 
-		initialState = {
+		return {
 			clickedExampleSuggestion: false,
 			lastQuery: suggestion,
 			lastDomainSearched: null,
@@ -155,9 +159,6 @@ class RegisterDomainStep extends React.Component {
 			notice: null,
 			searchResults: null,
 		};
-		this.state = initialState;
-
-		recordSearchFormSubmitWithDispatch = this.props.recordSearchFormSubmit;
 	}
 
 	getNewRailcarSeed() {
@@ -170,7 +171,7 @@ class RegisterDomainStep extends React.Component {
 	componentWillReceiveProps( nextProps ) {
 		// Reset state on site change
 		if ( nextProps.selectedSite && nextProps.selectedSite.slug !== ( this.props.selectedSite || {} ).slug ) {
-			this.setState( initialState );
+			this.setState( this.getState() );
 		}
 
 		if ( this.props.defaultSuggestionsError === nextProps.defaultSuggestionsError ||

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react';
+import PropTypes from 'prop-types';
 import async from 'async';
 import {
 	compact,
@@ -13,7 +14,7 @@ import {
 	reject,
 	startsWith,
 	times,
-	uniqBy
+	uniqBy,
 } from 'lodash';
 import page from 'page';
 import qs from 'qs';
@@ -34,7 +35,6 @@ import DomainMappingSuggestion from 'components/domains/domain-mapping-suggestio
 import DomainSuggestion from 'components/domains/domain-suggestion';
 import DomainSearchResults from 'components/domains/domain-search-results';
 import ExampleDomainSuggestions from 'components/domains/example-domain-suggestions';
-import analyticsMixin from 'lib/mixins/analytics';
 import { getCurrentUser } from 'state/current-user/selectors';
 import QueryContactDetailsCache from 'components/data/query-contact-details-cache';
 import QueryDomainsSuggestions from 'components/data/query-domains-suggestions';
@@ -42,6 +42,11 @@ import {
 	getDomainsSuggestions,
 	getDomainsSuggestionsError
 } from 'state/domains/suggestions/selectors';
+import {
+	composeAnalytics,
+	recordGoogleEvent,
+	recordTracksEvent,
+} from 'state/analytics/actions';
 
 const domains = wpcom.domains();
 
@@ -49,14 +54,10 @@ const domains = wpcom.domains();
 const SUGGESTION_QUANTITY = 10;
 const INITIAL_SUGGESTION_QUANTITY = 2;
 
-const analytics = analyticsMixin( 'registerDomain' ),
-	searchVendor = 'domainsbot',
-	fetchAlgo = searchVendor + '/v1';
+const searchVendor = 'domainsbot';
+const fetchAlgo = searchVendor + '/v1';
 
-let searchQueue = [],
-	searchStackTimer = null,
-	lastSearchTimestamp = null,
-	searchCount = 0;
+let searchCount = 0;
 
 function getQueryObject( props ) {
 	if ( ! props.selectedSite || ! props.selectedSite.domain ) {
@@ -71,77 +72,40 @@ function getQueryObject( props ) {
 	};
 }
 
-function processSearchStatQueue() {
-	const queue = searchQueue.slice();
-	window.clearTimeout( searchStackTimer );
-	searchStackTimer = null;
-	searchQueue = [];
+class RegisterDomainStep extends React.Component {
+	static propTypes = {
+		cart: PropTypes.object,
+		onDomainsAvailabilityChange: PropTypes.func,
+		products: PropTypes.object.isRequired,
+		selectedSite: PropTypes.oneOfType( [ PropTypes.object, PropTypes.bool ] ),
+		basePath: PropTypes.string.isRequired,
+		suggestion: PropTypes.string,
+		domainsWithPlansOnly: PropTypes.bool,
+		isSignupStep: PropTypes.bool,
+		surveyVertical: PropTypes.string,
+		includeWordPressDotCom: PropTypes.bool,
+		includeDotBlogSubdomain: PropTypes.bool,
+		showExampleSuggestions: PropTypes.bool,
+		onSave: PropTypes.func,
+		onAddMapping: PropTypes.func,
+		onAddDomain: PropTypes.func,
+		designType: PropTypes.string,
+	};
 
-	outerLoop:
-		for ( let i = 0; i < queue.length; i++ ) {
-			for ( let k = i + 1; k < queue.length; k++ ) {
-				if ( startsWith( queue[ k ].query, queue[ i ].query ) ) {
-					continue outerLoop;
-				}
-			}
-			reportSearchStats( queue[ i ] );
-		}
-}
+	static defaultProps = {
+		onDomainsAvailabilityChange: noop,
+		analyticsSection: 'domains',
+		onSave: noop,
+		onAddMapping: noop,
+		onAddDomain: noop,
+	};
 
-function reportSearchStats( { query, section, timestamp } ) {
-	let timeDiffFromLastSearchInSeconds = 0;
-	if ( lastSearchTimestamp ) {
-		timeDiffFromLastSearchInSeconds = Math.floor( ( timestamp - lastSearchTimestamp ) / 1000 );
-	}
-	lastSearchTimestamp = timestamp;
-	searchCount++;
-	analytics.recordEvent( 'searchFormSubmit', query, section, timeDiffFromLastSearchInSeconds, searchCount, searchVendor );
-}
+	constructor( props ) {
+		super( props );
 
-function enqueueSearchStatReport( search ) {
-	searchQueue.push( Object.assign( {}, search, { timestamp: Date.now() } ) );
-	if ( searchStackTimer ) {
-		window.clearTimeout( searchStackTimer );
-	}
-	searchStackTimer = window.setTimeout( processSearchStatQueue, 10000 );
-}
-
-const RegisterDomainStep = React.createClass( {
-	mixins: [ analytics ],
-
-	propTypes: {
-		cart: React.PropTypes.object,
-		onDomainsAvailabilityChange: React.PropTypes.func,
-		products: React.PropTypes.object.isRequired,
-		selectedSite: React.PropTypes.oneOfType( [ React.PropTypes.object, React.PropTypes.bool ] ),
-		basePath: React.PropTypes.string.isRequired,
-		suggestion: React.PropTypes.string,
-		domainsWithPlansOnly: React.PropTypes.bool,
-		isSignupStep: React.PropTypes.bool,
-		surveyVertical: React.PropTypes.string,
-		includeWordPressDotCom: React.PropTypes.bool,
-		includeDotBlogSubdomain: React.PropTypes.bool,
-		showExampleSuggestions: React.PropTypes.bool,
-		onSave: React.PropTypes.func,
-		onAddMapping: React.PropTypes.func,
-		onAddDomain: React.PropTypes.func,
-		designType: React.PropTypes.string,
-	},
-
-	getDefaultProps: function() {
-		return {
-			onDomainsAvailabilityChange: noop,
-			analyticsSection: 'domains',
-			onSave: noop,
-			onAddMapping: noop,
-			onAddDomain: noop,
-		};
-	},
-
-	getInitialState: function() {
 		const suggestion = this.props.suggestion ? getFixedDomainSearch( this.props.suggestion ) : '';
 
-		return {
+		this.state = {
 			clickedExampleSuggestion: false,
 			lastQuery: suggestion,
 			lastDomainSearched: null,
@@ -150,14 +114,14 @@ const RegisterDomainStep = React.createClass( {
 			notice: null,
 			searchResults: null,
 		};
-	},
+	}
 
 	getNewRailcarSeed() {
 		// Generate a 7 character random hash on base16. E.g. ac618a3
 		return Math.floor( ( 1 + Math.random() ) * 0x10000000 )
 			.toString( 16 )
 			.substring( 1 );
-	},
+	}
 
 	componentWillReceiveProps( nextProps ) {
 		// Reset state on site change
@@ -169,13 +133,16 @@ const RegisterDomainStep = React.createClass( {
 			( ! this.props.defaultSuggestionsError && ! nextProps.defaultSuggestionsError ) ) {
 			return;
 		}
+
 		const error = nextProps.defaultSuggestionsError;
+
 		if ( ! error ) {
 			return nextProps.onDomainsAvailabilityChange( true );
 		}
 		if ( error && error.statusCode === 503 ) {
 			return nextProps.onDomainsAvailabilityChange( false );
 		}
+
 		if ( error && error.error ) {
 			//don't modify global state
 			const domainError = new Error();
@@ -185,52 +152,45 @@ const RegisterDomainStep = React.createClass( {
 				this.showValidationErrorMessage( queryObject.query, domainError );
 			}
 		}
-	},
+	}
 
-	componentWillMount: function() {
+	componentWillMount() {
 		searchCount = 0; // reset the counter
-		lastSearchTimestamp = null; // reset timer
 
 		if ( this.props.initialState ) {
 			const state = { ...this.props.initialState, railcarSeed: this.getNewRailcarSeed() };
 
-			if ( state.lastSurveyVertical &&
-				( state.lastSurveyVertical !== this.props.surveyVertical ) ) {
+			if ( state.lastSurveyVertical && ( state.lastSurveyVertical !== this.props.surveyVertical ) ) {
 				state.loadingResults = true;
 				delete state.lastSurveyVertical;
 			}
 
 			this.setState( state );
 		}
-	},
+	}
 
-	componentDidMount: function() {
+	componentDidMount() {
 		if ( this.state.lastQuery ) {
 			this.onSearch( this.state.lastQuery );
 		}
-		this.recordEvent( 'searchFormView', this.props.analyticsSection );
-	},
+		this.props.searchFormView( this.props.analyticsSection );
+	}
 
-	componentDidUpdate: function( prevProps ) {
+	componentDidUpdate( prevProps ) {
 		if ( this.props.selectedSite && this.props.selectedSite.domain !== prevProps.selectedSite.domain ) {
 			this.focusSearchCard();
 		}
-	},
+	}
 
-	componentWillUnmount() {
-		// Don't wait for the timeout if the user is navigating away
-		processSearchStatQueue();
-	},
-
-	focusSearchCard: function() {
+	focusSearchCard = () => {
 		this.refs.searchCard.focus();
-	},
+	};
 
-	isLoadingSuggestions: function() {
+	isLoadingSuggestions() {
 		return ! this.props.defaultSuggestions && ! this.props.defaultSuggestionsError;
-	},
+	}
 
-	render: function() {
+	render() {
 		const queryObject = getQueryObject( this.props );
 		return (
 			<div className="register-domain-step">
@@ -259,15 +219,15 @@ const RegisterDomainStep = React.createClass( {
 				<QueryContactDetailsCache />
 			</div>
 		);
-	},
+	}
 
-	handleClickExampleSuggestion: function() {
+	handleClickExampleSuggestion = () => {
 		this.focusSearchCard();
 
 		this.setState( { clickedExampleSuggestion: true } );
-	},
+	};
 
-	content: function() {
+	content() {
 		if ( Array.isArray( this.state.searchResults ) || this.state.loadingResults ) {
 			return this.allSearchResults();
 		}
@@ -284,13 +244,13 @@ const RegisterDomainStep = React.createClass( {
 		}
 
 		return this.initialSuggestions();
-	},
+	}
 
-	save: function() {
+	save = () => {
 		this.props.onSave( this.state );
-	},
+	};
 
-	onSearchChange: function( searchQuery ) {
+	onSearchChange = ( searchQuery ) => {
 		this.setState( {
 			lastQuery: searchQuery,
 			lastDomainSearched: null,
@@ -298,14 +258,15 @@ const RegisterDomainStep = React.createClass( {
 			notice: null,
 			searchResults: null,
 		} );
-	},
+	};
 
-	getTldWeightOverrides: function() {
+	getTldWeightOverrides() {
 		const { designType } = this.props;
-		return designType && designType === 'blog' ? 'design_type_blog' : null;
-	},
 
-	onSearch: function( searchQuery ) {
+		return designType && designType === 'blog' ? 'design_type_blog' : null;
+	}
+
+	onSearch = ( searchQuery ) => {
 		const domain = getFixedDomainSearch( searchQuery );
 
 		this.setState( { lastQuery: searchQuery, lastSurveyVertical: this.props.surveyVertical }, this.save );
@@ -315,13 +276,16 @@ const RegisterDomainStep = React.createClass( {
 			return;
 		}
 
-		enqueueSearchStatReport( { query: searchQuery, section: this.props.analyticsSection } );
+		this.props.searchFormSubmit( searchQuery, this.props.analyticsSection, searchCount, searchVendor );
+		searchCount++;
 
 		this.setState( {
 			lastDomainSearched: domain,
 			searchResults: [],
 			railcarSeed: this.getNewRailcarSeed(),
 		} );
+
+		const timestamp = Date.now();
 
 		async.parallel(
 			[
@@ -330,16 +294,15 @@ const RegisterDomainStep = React.createClass( {
 						this.setState( { lastDomainStatus: null } );
 						return callback();
 					}
-					const timestamp = Date.now();
 					if ( this.props.isSignupStep && domain.match( /\.wordpress\.com$/ ) ) {
 						return callback();
 					}
 
 					checkDomainAvailability( domain, ( error, result ) => {
-						const timeDiff = Date.now() - timestamp,
-							status = result && result.status ? result.status : error,
-							{ AVAILABLE, UNKNOWN } = domainAvailability,
-							isDomainAvailable = includes( [ AVAILABLE, UNKNOWN ], status );
+						const timeDiff = Date.now() - timestamp;
+						const status = result && result.status ? result.status : error;
+						const { AVAILABLE, UNKNOWN } = domainAvailability;
+						const isDomainAvailable = includes( [ AVAILABLE, UNKNOWN ], status );
 
 						this.setState( { lastDomainStatus: status } );
 						if ( isDomainAvailable ) {
@@ -348,7 +311,7 @@ const RegisterDomainStep = React.createClass( {
 							this.showValidationErrorMessage( domain, status );
 						}
 
-						this.recordEvent( 'domainAvailabilityReceive', domain, status, timeDiff, this.props.analyticsSection );
+						this.props.domainAvailabilityReceive( domain, status, timeDiff, this.props.analyticsSection );
 
 						this.props.onDomainsAvailabilityChange( true );
 						callback( null, isDomainAvailable ? result : null );
@@ -356,27 +319,32 @@ const RegisterDomainStep = React.createClass( {
 				},
 				callback => {
 					const query = {
-							query: domain,
-							quantity: SUGGESTION_QUANTITY,
-							include_wordpressdotcom: this.props.includeWordPressDotCom,
-							include_dotblogsubdomain: this.props.includeDotBlogSubdomain,
-							tld_weight_overrides: this.getTldWeightOverrides(),
-							vendor: searchVendor,
-							vertical: this.props.surveyVertical,
-						},
-						timestamp = Date.now();
+						query: domain,
+						quantity: SUGGESTION_QUANTITY,
+						include_wordpressdotcom: this.props.includeWordPressDotCom,
+						include_dotblogsubdomain: this.props.includeDotBlogSubdomain,
+						tld_weight_overrides: this.getTldWeightOverrides(),
+						vendor: searchVendor,
+						vertical: this.props.surveyVertical,
+					};
 
 					domains.suggestions( query ).then( domainSuggestions => {
 						this.props.onDomainsAvailabilityChange( true );
-						const timeDiff = Date.now() - timestamp,
-							analyticsResults = domainSuggestions.map( suggestion => suggestion.domain_name );
+						const timeDiff = Date.now() - timestamp;
+						const analyticsResults = domainSuggestions.map( suggestion => suggestion.domain_name );
 
-						this.recordEvent( 'searchResultsReceive', domain, analyticsResults, timeDiff, domainSuggestions.length,
-							this.props.analyticsSection );
+						this.props.searchResultsReceive(
+							domain,
+							analyticsResults,
+							timeDiff,
+							domainSuggestions.length,
+							this.props.analyticsSection
+						);
 
 						callback( null, domainSuggestions );
 					} ).catch( error => {
 						const timeDiff = Date.now() - timestamp;
+
 						if ( error && error.statusCode === 503 ) {
 							this.props.onDomainsAvailabilityChange( false );
 						} else if ( error && error.error ) {
@@ -385,7 +353,13 @@ const RegisterDomainStep = React.createClass( {
 						}
 
 						const analyticsResults = [ error.code || error.error || 'ERROR' + ( error.statusCode || '' ) ];
-						this.recordEvent( 'searchResultsReceive', domain, analyticsResults, timeDiff, -1, this.props.analyticsSection );
+						this.props.searchResultsReceive(
+							domain,
+							analyticsResults,
+							timeDiff,
+							-1,
+							this.props.analyticsSection
+						);
 						callback( error, null );
 					} );
 				}
@@ -402,18 +376,18 @@ const RegisterDomainStep = React.createClass( {
 				} );
 
 				const isFreeOrUnknown = ( suggestion ) => (
-						suggestion.is_free === true ||
-						suggestion.status === domainAvailability.UNKNOWN
-					),
-					strippedDomainBase = this.getStrippedDomainBase( domain ),
-					exactMatchBeforeTld = ( suggestion ) => (
-						startsWith( suggestion.domain_name, `${ strippedDomainBase }.` )
-					),
-					bestAlternative = ( suggestion ) => (
-						! exactMatchBeforeTld( suggestion ) &&
-						suggestion.isRecommended !== true
-					),
-					availableSuggestions = reject( suggestions, isFreeOrUnknown );
+					suggestion.is_free === true ||
+					suggestion.status === domainAvailability.UNKNOWN
+				);
+				const strippedDomainBase = this.getStrippedDomainBase( domain );
+				const exactMatchBeforeTld = ( suggestion ) => (
+					startsWith( suggestion.domain_name, `${ strippedDomainBase }.` )
+				);
+				const bestAlternative = ( suggestion ) => (
+					! exactMatchBeforeTld( suggestion ) &&
+					suggestion.isRecommended !== true
+				);
+				const availableSuggestions = reject( suggestions, isFreeOrUnknown );
 
 				const recommendedSuggestion = find( availableSuggestions, exactMatchBeforeTld );
 				if ( recommendedSuggestion ) {
@@ -435,7 +409,7 @@ const RegisterDomainStep = React.createClass( {
 				}, this.save );
 			}
 		);
-	},
+	};
 
 	getStrippedDomainBase( domain ) {
 		let strippedDomainBase = domain;
@@ -445,12 +419,12 @@ const RegisterDomainStep = React.createClass( {
 			strippedDomainBase = strippedDomainBase.substring( 0, lastIndexOfDot );
 		}
 		return strippedDomainBase.replace( /[ .]/g, '' );
-	},
+	}
 
-	initialSuggestions: function() {
-		let domainRegistrationSuggestions,
-			domainMappingSuggestion,
-			suggestions;
+	initialSuggestions() {
+		let domainRegistrationSuggestions;
+		let domainMappingSuggestion;
+		let suggestions;
 
 		if ( this.isLoadingSuggestions() || isEmpty( this.props.products ) ) {
 			domainRegistrationSuggestions = times( INITIAL_SUGGESTION_QUANTITY + 1, function( n ) {
@@ -469,7 +443,8 @@ const RegisterDomainStep = React.createClass( {
 						cart={ this.props.cart }
 						selectedSite={ this.props.selectedSite }
 						domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
-						onButtonClick={ this.props.onAddDomain.bind( null, suggestion ) } />
+						onButtonClick={ this.props.onAddDomain }
+					/>
 				);
 			}, this );
 
@@ -480,8 +455,9 @@ const RegisterDomainStep = React.createClass( {
 					selectedSite={ this.props.selectedSite }
 					domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
 					cart={ this.props.cart }
-					products={ this.props.products } />
-				);
+					products={ this.props.products }
+				/>
+			);
 		}
 
 		return (
@@ -491,26 +467,29 @@ const RegisterDomainStep = React.createClass( {
 				{ domainMappingSuggestion }
 			</div>
 		);
-	},
+	}
 
-	allSearchResults: function() {
-		const { lastDomainSearched, lastDomainStatus } = this.state,
-			matchesSearchedDomain = ( suggestion ) => ( suggestion.domain_name === lastDomainSearched ),
-			availableDomain = lastDomainStatus === domainAvailability.AVAILABLE && find( this.state.searchResults, matchesSearchedDomain ),
-			onAddMapping = ( domain ) => this.props.onAddMapping( domain, this.state );
+	allSearchResults() {
+		const { lastDomainSearched, lastDomainStatus } = this.state;
+		const matchesSearchedDomain = ( suggestion ) => ( suggestion.domain_name === lastDomainSearched );
+		const availableDomain = (
+			lastDomainStatus === domainAvailability.AVAILABLE &&
+			find( this.state.searchResults, matchesSearchedDomain )
+		);
+		const onAddMapping = ( domain ) => this.props.onAddMapping( domain, this.state );
 
 		let suggestions = reject( this.state.searchResults, matchesSearchedDomain );
 
 		if ( suggestions.length === 0 && ! this.state.loadingResults ) {
 			// the search returned no results
-
 			if ( this.props.showExampleSuggestions ) {
 				return (
 					<ExampleDomainSuggestions
 						mapDomainUrl={ this.getMapDomainUrl() }
 						path={ this.props.path }
 						domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
-						products={ this.props.products } />
+						products={ this.props.products }
+					/>
 				);
 			}
 
@@ -535,11 +514,12 @@ const RegisterDomainStep = React.createClass( {
 				isSignupStep={ this.props.isSignupStep }
 				railcarSeed={ this.state.railcarSeed }
 				fetchAlgo={ fetchAlgo }
-				cart={ this.props.cart } />
+				cart={ this.props.cart }
+			/>
 		);
-	},
+	}
 
-	getMapDomainUrl: function() {
+	getMapDomainUrl() {
 		let mapDomainUrl;
 
 		if ( this.props.mapDomainUrl ) {
@@ -553,27 +533,113 @@ const RegisterDomainStep = React.createClass( {
 		}
 
 		return mapDomainUrl;
-	},
+	}
 
-	goToMapDomainStep: function( event ) {
+	goToMapDomainStep = ( event ) => {
 		event.preventDefault();
 
-		this.recordEvent( 'mapDomainButtonClick', this.props.analyticsSection );
+		this.props.mapDomainButtonClick( this.props.analyticsSection );
 
 		page( this.getMapDomainUrl() );
-	},
+	};
 
-	showValidationErrorMessage: function( domain, error ) {
+	showValidationErrorMessage( domain, error ) {
 		const { message, severity } = getAvailabilityNotice( domain, error );
 		this.setState( { notice: message, noticeSeverity: severity } );
 	}
-} );
+}
 
-module.exports = connect( ( state, props ) => {
-	const queryObject = getQueryObject( props );
-	return {
-		currentUser: getCurrentUser( state ),
-		defaultSuggestions: getDomainsSuggestions( state, queryObject ),
-		defaultSuggestionsError: getDomainsSuggestionsError( state, queryObject ),
-	};
-} )( localize( RegisterDomainStep ) );
+const mapDomainButtonClick = ( section ) => composeAnalytics(
+	recordGoogleEvent(
+		'Domain Search',
+		'Clicked "Map it" Button'
+	),
+	recordTracksEvent(
+		'calypso_domain_search_results_mapping_button_click',
+		{ section }
+	),
+);
+
+const searchFormSubmit = ( searchBoxValue, section, count, vendor ) => composeAnalytics(
+	recordGoogleEvent(
+		'Domain Search',
+		'Submitted Search Form',
+		'Search Box Value',
+		searchBoxValue
+	),
+	recordTracksEvent(
+		'calypso_domain_search',
+		{
+			search_box_value: searchBoxValue,
+			search_count: count,
+			search_vendor: vendor,
+			section
+		}
+	),
+);
+
+const searchFormView = ( section ) => composeAnalytics(
+	recordGoogleEvent(
+		'Domain Search',
+		'Landed on Search'
+	),
+	recordTracksEvent(
+		'calypso_domain_search_pageview',
+		{ section }
+	),
+);
+
+const searchResultsReceive = ( searchQuery, searchResults, responseTimeInMs, resultCount, section ) => composeAnalytics(
+	recordGoogleEvent(
+		'Domain Search',
+		'Receive Results',
+		'Response Time',
+		responseTimeInMs
+	),
+	recordTracksEvent(
+		'calypso_domain_search_results_suggestions_receive',
+		{
+			search_query: searchQuery,
+			results: searchResults.join( ';' ),
+			response_time_ms: responseTimeInMs,
+			result_count: resultCount,
+			section
+		}
+	),
+);
+
+const domainAvailabilityReceive = ( searchQuery, availableStatus, responseTimeInMs, section ) => composeAnalytics(
+	recordGoogleEvent(
+		'Domain Search',
+		'Domain Availability Result',
+		'Domain Available Status',
+		availableStatus
+	),
+	recordTracksEvent(
+		'calypso_domain_search_results_availability_receive',
+		{
+			search_query: searchQuery,
+			available_status: availableStatus,
+			response_time: responseTimeInMs,
+			section
+		}
+	),
+);
+
+export default connect(
+	( state, props ) => {
+		const queryObject = getQueryObject( props );
+		return {
+			currentUser: getCurrentUser( state ),
+			defaultSuggestions: getDomainsSuggestions( state, queryObject ),
+			defaultSuggestionsError: getDomainsSuggestionsError( state, queryObject ),
+		};
+	},
+	{
+		domainAvailabilityReceive,
+		mapDomainButtonClick,
+		searchFormSubmit,
+		searchFormView,
+		searchResultsReceive,
+	}
+)( localize( RegisterDomainStep ) );

--- a/client/components/domains/registrant-extra-info/ca-form.jsx
+++ b/client/components/domains/registrant-extra-info/ca-form.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import {
@@ -36,7 +37,7 @@ class RegistrantExtraInfoCaForm extends React.PureComponent {
 	static propTypes = {
 		contactDetailsExtra: PropTypes.object.isRequired,
 		translate: PropTypes.func.isRequired,
-	}
+	};
 
 	constructor( props ) {
 		super( props );

--- a/client/components/domains/registrant-extra-info/fr-form.jsx
+++ b/client/components/domains/registrant-extra-info/fr-form.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { connect } from 'react-redux';
 import { defaults, get, noop } from 'lodash';
 import { localize } from 'i18n-calypso';
@@ -34,12 +35,12 @@ class RegistrantExtraInfoFrForm extends React.PureComponent {
 	static propTypes = {
 		isVisible: PropTypes.bool,
 		onSubmit: PropTypes.func,
-	}
+	};
 
 	static defaultProps = {
 		isVisible: true,
 		onSubmit: noop,
-	}
+	};
 
 	componentWillMount() {
 		// We're pushing props out into the global state here because:

--- a/client/lib/mixins/analytics/index.js
+++ b/client/lib/mixins/analytics/index.js
@@ -3,7 +3,7 @@
  */
 import analytics from 'lib/analytics';
 import { type as domainTypes } from 'lib/domains/constants';
-import { snakeCase, endsWith } from 'lodash';
+import { snakeCase } from 'lodash';
 
 const getDomainTypeText = function( domain ) {
 	switch ( domain.type ) {
@@ -21,16 +21,6 @@ const getDomainTypeText = function( domain ) {
 	}
 };
 
-const getDomainTypeTextFromSearch = function( suggestion ) {
-	if ( suggestion.is_free ) {
-		if ( endsWith( suggestion.domain_name, '.blog' ) ) {
-			return 'dotblog_subdomain';
-		}
-		return 'wpcom_subdomain';
-	}
-	return 'domain_reg';
-};
-
 const EVENTS = {
 	popupCart: {
 		checkoutButtonClick() {
@@ -46,109 +36,6 @@ const EVENTS = {
 			);
 		}
 	},
-	registerDomain: {
-		mapDomainButtonClick( section ) {
-			analytics.ga.recordEvent(
-				'Domain Search',
-				'Clicked "Map it" Button'
-			);
-
-			analytics.tracks.recordEvent( 'calypso_domain_search_results_mapping_button_click', { section } );
-		},
-
-		searchFormSubmit( searchBoxValue, section, timeDiffFromLastSearch, searchCount, searchVendor ) {
-			analytics.ga.recordEvent(
-				'Domain Search',
-				'Submitted Search Form',
-				'Search Box Value',
-				searchBoxValue
-			);
-
-			analytics.tracks.recordEvent(
-				'calypso_domain_search',
-				{
-					search_box_value: searchBoxValue,
-					seconds_from_last_search: timeDiffFromLastSearch,
-					search_count: searchCount,
-					search_vendor: searchVendor,
-					section
-				}
-			);
-		},
-
-		searchFormView( section ) {
-			analytics.ga.recordEvent(
-				'Domain Search',
-				'Landed on Search'
-			);
-
-			analytics.tracks.recordEvent( 'calypso_domain_search_pageview', { section } );
-		},
-
-		searchResultsReceive( searchQuery, searchResults, responseTimeInMs, resultCount, section ) {
-			analytics.ga.recordEvent(
-				'Domain Search',
-				'Receive Results',
-				'Response Time',
-				responseTimeInMs
-			);
-
-			analytics.tracks.recordEvent(
-				'calypso_domain_search_results_suggestions_receive',
-				{
-					search_query: searchQuery,
-					results: searchResults.join( ';' ),
-					response_time_ms: responseTimeInMs,
-					result_count: resultCount,
-					section
-				}
-			);
-		},
-
-		domainAvailabilityReceive( searchQuery, availableStatus, responseTimeInMs, section ) {
-			analytics.ga.recordEvent(
-				'Domain Search',
-				'Domain Availability Result',
-				'Domain Available Status',
-				availableStatus
-			);
-
-			analytics.tracks.recordEvent(
-				'calypso_domain_search_results_availability_receive',
-				{
-					search_query: searchQuery,
-					available_status: availableStatus,
-					response_time: responseTimeInMs,
-					section
-				}
-			);
-		},
-
-		submitDomainStepSelection( suggestion, section ) {
-			const domainType = getDomainTypeTextFromSearch( suggestion );
-			analytics.ga.recordEvent(
-				'Domain Search',
-				`Submitted Domain Selection for a ${ domainType } on a Domain Registration`,
-				'Domain Name',
-				suggestion.domain_name
-			);
-
-			const tracksObjects = {
-				domain_name: suggestion.domain_name,
-				section,
-				type: domainType
-			};
-			if ( suggestion.isRecommended ) {
-				tracksObjects.label = 'recommended';
-			}
-			if ( suggestion.isBestAlternative ) {
-				tracksObjects.label = 'best-alternative';
-			}
-
-			analytics.tracks.recordEvent( 'calypso_domain_search_submit_step', tracksObjects );
-		}
-	},
-
 	domainManagement: {
 		addGoogleApps: {
 			addAnotherEmailAddressClick( domainName ) {

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -1,11 +1,12 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { defer } from 'lodash';
+import { defer, endsWith } from 'lodash';
 import page from 'page';
-import i18n from 'i18n-calypso';
+import { localize, getLocaleSlug } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -18,15 +19,16 @@ import MapDomainStep from 'components/domains/map-domain-step';
 import RegisterDomainStep from 'components/domains/register-domain-step';
 import { DOMAINS_WITH_PLANS_ONLY } from 'state/current-user/constants';
 import { getSurveyVertical } from 'state/signup/steps/survey/selectors.js';
-import analyticsMixin from 'lib/mixins/analytics';
 import signupUtils from 'signup/utils';
 import { getUsernameSuggestion } from 'lib/signup/step-actions';
 import { recordAddDomainButtonClick, recordAddDomainButtonClickInMapDomain } from 'state/domains/actions';
-
+import {
+	composeAnalytics,
+	recordGoogleEvent,
+	recordTracksEvent,
+} from 'state/analytics/actions';
 import { getCurrentUser, currentUserHasFlag } from 'state/current-user/selectors';
 import Notice from 'components/notice';
-
-const registerDomainAnalytics = analyticsMixin( 'registerDomain' );
 
 const DomainsStep = React.createClass( {
 	propTypes: {
@@ -45,7 +47,7 @@ const DomainsStep = React.createClass( {
 	},
 
 	contextTypes: {
-		store: React.PropTypes.object
+		store: PropTypes.object
 	},
 
 	showDomainSearch: function() {
@@ -110,7 +112,7 @@ const DomainsStep = React.createClass( {
 			return undefined;
 		}
 		const repo = this.isPurchasingTheme() ? 'premium' : 'pub';
-		return `${repo}/${themeSlug}`;
+		return `${ repo }/${ themeSlug }`;
 	},
 
 	submitWithDomain: function( googleAppsCartItem ) {
@@ -126,10 +128,10 @@ const DomainsStep = React.createClass( {
 				} )
 				: undefined;
 
-		registerDomainAnalytics.recordEvent( 'submitDomainStepSelection', suggestion, 'signup' );
+		this.props.submitDomainStepSelection( suggestion, 'signup' );
 
 		SignupActions.submitSignupStep( Object.assign( {
-			processingMessage: this.translate( 'Adding your domain' ),
+			processingMessage: this.props.translate( 'Adding your domain' ),
 			stepName: this.props.stepName,
 			domainItem,
 			googleAppsCartItem,
@@ -151,7 +153,7 @@ const DomainsStep = React.createClass( {
 		this.props.recordAddDomainButtonClickInMapDomain( domain, 'signup' );
 
 		SignupActions.submitSignupStep( Object.assign( {
-			processingMessage: this.translate( 'Adding your domain mapping' ),
+			processingMessage: this.props.translate( 'Adding your domain mapping' ),
 			stepName: this.props.stepName,
 			[ sectionName ]: state,
 			domainItem,
@@ -222,8 +224,9 @@ const DomainsStep = React.createClass( {
 
 	render: function() {
 		let content;
+		const { translate } = this.props;
 		const backUrl = this.props.stepSectionName
-			? signupUtils.getStepUrl( this.props.flowName, this.props.stepName, undefined, i18n.getLocaleSlug() )
+			? signupUtils.getStepUrl( this.props.flowName, this.props.stepName, undefined, getLocaleSlug() )
 			: undefined;
 
 		if ( 'mapping' === this.props.stepSectionName ) {
@@ -252,9 +255,9 @@ const DomainsStep = React.createClass( {
 				backUrl={ backUrl }
 				positionInFlow={ this.props.positionInFlow }
 				signupProgress={ this.props.signupProgress }
-				subHeaderText={ this.translate( 'First up, let\'s find a domain.' ) }
-				fallbackHeaderText={ this.translate( 'Let\'s give your site an address.' ) }
-				fallbackSubHeaderText={ this.translate(
+				subHeaderText={ translate( 'First up, let\'s find a domain.' ) }
+				fallbackHeaderText={ translate( 'Let\'s give your site an address.' ) }
+				fallbackSubHeaderText={ translate(
 					'Enter your site\'s name, or some key words that describe it - ' +
 					'we\'ll use this to create your new site\'s address.' ) }
 				stepContent={ content }
@@ -263,7 +266,42 @@ const DomainsStep = React.createClass( {
 	}
 } );
 
-module.exports = connect(
+const submitDomainStepSelection = ( suggestion, section ) => {
+	let domainType = 'domain_reg';
+	if ( suggestion.is_free ) {
+		domainType = 'wpcom_subdomain';
+		if ( endsWith( suggestion.domain_name, '.blog' ) ) {
+			domainType = 'dotblog_subdomain';
+		}
+	}
+
+	const tracksObjects = {
+		domain_name: suggestion.domain_name,
+		section,
+		type: domainType
+	};
+	if ( suggestion.isRecommended ) {
+		tracksObjects.label = 'recommended';
+	}
+	if ( suggestion.isBestAlternative ) {
+		tracksObjects.label = 'best-alternative';
+	}
+
+	return composeAnalytics(
+		recordGoogleEvent(
+			'Domain Search',
+			`Submitted Domain Selection for a ${ domainType } on a Domain Registration`,
+			'Domain Name',
+			suggestion.domain_name
+		),
+		recordTracksEvent(
+			'calypso_domain_search_submit_step',
+			tracksObjects
+		)
+	);
+};
+
+export default connect(
 	( state ) => ( {
 		// no user = DOMAINS_WITH_PLANS_ONLY
 		domainsWithPlansOnly: getCurrentUser( state ) ? currentUserHasFlag( state, DOMAINS_WITH_PLANS_ONLY ) : true,
@@ -272,5 +310,6 @@ module.exports = connect(
 	{
 		recordAddDomainButtonClick,
 		recordAddDomainButtonClickInMapDomain,
+		submitDomainStepSelection,
 	}
-)( DomainsStep );
+)( localize( DomainsStep ) );


### PR DESCRIPTION
- Migrate all domains components to `prop-types`

Register Domain Step
- Remove mixin
- move to redux actions
- remove code for tracking time between searches

Signup Domains Step:
- localize and remove mixin

Test:
- Go to `Domains -> Add`
- Search for a domain
- Make sure results are present
- Click on a domain
- Make sure it's tracked
- Click on mapping
- Make sure it's tracked

Test Signup:
- Go calypso.localhost:3000/start/
- Get to Domains step
- Search for something
- Make sure results are present
- Click on something
- Make sure it's tracked