### PR TITLE
Jetpack Connect: Don't show site-deleted notice when removing the site from the sites state list.

### DIFF
--- a/client/state/jetpack-connect/actions.js
+++ b/client/state/jetpack-connect/actions.js
@@ -360,7 +360,7 @@ export default {
 				debug( 'user is not connected from', error );
 				if ( siteIsOnSitesList ) {
 					debug( 'removing site from sites list', siteId );
-					dispatch( receiveDeletedSite( siteId ) );
+					dispatch( receiveDeletedSite( siteId, true ) );
 				}
 			} );
 		};

--- a/client/state/notices/middleware.js
+++ b/client/state/notices/middleware.js
@@ -212,11 +212,17 @@ const onSiteDelete = ( dispatch, { siteId }, getState ) => dispatch(
 	} ), { duration: 5000, id: 'site-delete' } )
 );
 
-const onSiteDeleteReceive = ( dispatch, { siteId }, getState ) => dispatch(
-	successNotice( translate( '%(siteDomain)s has been deleted.', {
-		args: { siteDomain: getSiteDomain( getState(), siteId ) }
-	} ), { duration: 5000, id: 'site-delete' } )
-);
+const onSiteDeleteReceive = ( dispatch, { siteId, silent }, getState ) => {
+	if ( silent ) {
+		return;
+	}
+
+	return dispatch(
+		successNotice( translate( '%(siteDomain)s has been deleted.', {
+			args: { siteDomain: getSiteDomain( getState(), siteId ) }
+		} ), { duration: 5000, id: 'site-delete' } )
+	);
+};
 
 const onSiteDeleteFailure = ( dispatch, { error } ) => {
 	if ( error.error === 'active-subscriptions' ) {

--- a/client/state/sites/actions.js
+++ b/client/state/sites/actions.js
@@ -27,13 +27,15 @@ import {
  * Returns an action object to be used in signalling that a site has been
  * deleted.
  *
- * @param  {Number} siteId ID of deleted site
- * @return {Object}        Action object
+ * @param  {Number} siteId  ID of deleted site
+ * @param  {Boolean} silent Indicates to not show the global notice after the site is removed from the state.
+ * @return {Object}         Action object
  */
-export function receiveDeletedSite( siteId ) {
+export function receiveDeletedSite( siteId, silent = false ) {
 	return {
 		type: SITE_DELETE_RECEIVE,
-		siteId
+		siteId,
+		silent
 	};
 }
 


### PR DESCRIPTION
#### Changes introduced by this PR

* Updates `receiveDeletedSite()` selector to use silent flag for not showing a notices when the action is processed by the notices redux middleware.
* Makes the Jetpack Connect action call `receiveDeletedSite()` with this flag set to `false`.

#### Testing instructions...