### PR TITLE
WPSC: Update cache stats when clearing cache

### DIFF
--- a/client/extensions/wp-super-cache/state/cache/actions.js
+++ b/client/extensions/wp-super-cache/state/cache/actions.js
@@ -75,6 +75,7 @@ export const deleteCache = ( siteId, deleteAll, deleteExpired ) => {
 			.then( () => {
 				dispatch( {
 					type: WP_SUPER_CACHE_DELETE_CACHE_SUCCESS,
+					deleteExpired,
 					siteId,
 				} );
 			} )

--- a/client/extensions/wp-super-cache/state/cache/test/actions.js
+++ b/client/extensions/wp-super-cache/state/cache/test/actions.js
@@ -108,9 +108,10 @@ describe( 'actions', () => {
 		} );
 
 		it( 'should dispatch request success action when request completes', () => {
-			return deleteCache( siteId, false )( spy ).then( () => {
+			return deleteCache( siteId, false, true )( spy ).then( () => {
 				expect( spy ).to.have.been.calledWith( {
 					type: WP_SUPER_CACHE_DELETE_CACHE_SUCCESS,
+					deleteExpired: true,
 					siteId,
 				} );
 			} );

--- a/client/extensions/wp-super-cache/state/stats/reducer.js
+++ b/client/extensions/wp-super-cache/state/stats/reducer.js
@@ -10,6 +10,7 @@ import { combineReducers, createReducer } from 'state/utils';
 
 import { statsSchema } from './schema';
 import {
+	WP_SUPER_CACHE_DELETE_CACHE_SUCCESS,
 	WP_SUPER_CACHE_DELETE_FILE,
 	WP_SUPER_CACHE_DELETE_FILE_FAILURE,
 	WP_SUPER_CACHE_DELETE_FILE_SUCCESS,
@@ -55,6 +56,34 @@ const deleting = createReducer( {}, {
  */
 const items = createReducer( {}, {
 	[ WP_SUPER_CACHE_GENERATE_STATS_SUCCESS ]: ( state, { siteId, stats } ) => ( { ...state, [ siteId ]: stats } ),
+	[ WP_SUPER_CACHE_DELETE_CACHE_SUCCESS ]: ( state, { siteId, deleteExpired } ) => {
+		let emptyCache = {
+			expired: 0,
+			expired_list: {},
+		};
+
+		if ( ! deleteExpired ) {
+			emptyCache = {
+				...emptyCache,
+				cached: 0,
+				cached_list: {},
+			};
+		}
+
+		return {
+			...state,
+			[ siteId ]: {
+				supercache: {
+					...state[ siteId ].supercache,
+					...emptyCache,
+				},
+				wpcache: {
+					...state[ siteId ].wpcache,
+					...emptyCache,
+				},
+			}
+		};
+	},
 	[ WP_SUPER_CACHE_DELETE_FILE_SUCCESS ]: ( state, { siteId, url, isSupercache, isCached } ) => {
 		const cacheType = isSupercache ? 'supercache' : 'wpcache';
 		const listType = isCached ? 'cached_list' : 'expired_list';

--- a/client/extensions/wp-super-cache/state/stats/test/reducer.js
+++ b/client/extensions/wp-super-cache/state/stats/test/reducer.js
@@ -9,6 +9,7 @@ import deepFreeze from 'deep-freeze';
  */
 import { useSandbox } from 'test/helpers/use-sinon';
 import {
+	WP_SUPER_CACHE_DELETE_CACHE_SUCCESS,
 	WP_SUPER_CACHE_DELETE_FILE,
 	WP_SUPER_CACHE_DELETE_FILE_FAILURE,
 	WP_SUPER_CACHE_DELETE_FILE_SUCCESS,
@@ -301,6 +302,119 @@ describe( 'reducer', () => {
 				} );
 
 				expect( state.items ).to.eql( {} );
+			} );
+		} );
+
+		describe( 'WP_SUPER_CACHE_DELETE_CACHE_SUCCESS', () => {
+			const previousState = deepFreeze( {
+				items: {
+					[ primarySiteId ]: {
+						supercache: {
+							cached: 2,
+							cached_list: {
+								'wordpress.com/supercache/cached-file': {
+									files: 2,
+									lower_age: 5500,
+									upper_age: 10000,
+								}
+							},
+							expired: 4,
+							expired_list: {
+								'wordpress.com/supercache/expired-file': {
+									files: 4,
+									lower_age: 535937,
+									upper_age: 538273,
+								}
+							},
+							fsize: 58272,
+						},
+						wpcache: {
+							cached: 3,
+							cached_list: {
+								'wordpress.com/cached-file': {
+									files: 3,
+									lower_age: 5500,
+									upper_age: 10000,
+								}
+							},
+							expired: 1,
+							expired_list: {
+								'wordpress.com/expired-file': {
+									files: 1,
+									lower_age: 535937,
+									upper_age: 538273,
+								}
+							},
+							fsize: 58272,
+						}
+					}
+				}
+			} );
+
+			it( 'should clear cache and supercache expired count and files list on expired cache clear', () => {
+				const state = reducer( previousState, {
+					type: WP_SUPER_CACHE_DELETE_CACHE_SUCCESS,
+					siteId: primarySiteId,
+					deleteExpired: true,
+				} );
+
+				expect( state.items ).to.eql( {
+					[ primarySiteId ]: {
+						supercache: {
+							cached: 2,
+							cached_list: {
+								'wordpress.com/supercache/cached-file': {
+									files: 2,
+									lower_age: 5500,
+									upper_age: 10000,
+								}
+							},
+							expired: 0,
+							expired_list: {},
+							fsize: 58272,
+						},
+						wpcache: {
+							cached: 3,
+							cached_list: {
+								'wordpress.com/cached-file': {
+									files: 3,
+									lower_age: 5500,
+									upper_age: 10000,
+								}
+							},
+							expired: 0,
+							expired_list: {},
+							fsize: 58272,
+						}
+					}
+				} );
+			} );
+
+			it( 'should clear cache and supercache cached and expired count and files list on cache clear', () => {
+				const state = reducer( previousState, {
+					type: WP_SUPER_CACHE_DELETE_CACHE_SUCCESS,
+					siteId: primarySiteId,
+					deleteExpired: false,
+				} );
+
+				expect( state.items ).to.eql( {
+					[ primarySiteId ]: {
+						supercache: {
+							cached: 0,
+							cached_list: {},
+							expired: 0,
+							expired_list: {},
+							fsize: 58272,
+						},
+						wpcache: {
+							cached: 0,
+							cached_list: {},
+							expired: 0,
+							expired_list: {},
+							fsize: 58272,
+						}
+					}
+				} );
 			} );
 		} );
 


### PR DESCRIPTION
Fixes what's described in the 3rd paragraph of https://horizonfeedback.wordpress.com/2017/08/17/call-for-testing-calypso-wp-super-cache-extension/comment-page-1/#comment-393.

To test:
* In the 'Contents' tab, click 'Regenerate Cache Stats', and verify that you have at least one cached or expired page (at least one non-null value).
* If you have an expired page, click 'Delete Expired', and verify that the expired counters are reset to 0, and that the 'Expired Cached Files' and/or 'Expired Super Cached Files' lists vanish.
* If you have a cached page, click 'Delete Cached'. Verify that _both_ _cached_ and _expired_ counters are reset to zero. All 'Fresh Cached Files', 'Fresh Super Cached Files', 'Expired Cached Files', and 'Expired Super Cached Files' lists should vanish.