### PR TITLE
Fix Follow button alignment Tag streams

### DIFF
--- a/client/reader/tag-stream/style.scss
+++ b/client/reader/tag-stream/style.scss
@@ -7,6 +7,11 @@
 	}
 }
 
+.tag-stream__header-follow {
+	display: flex;
+	justify-content: flex-end;
+}
+
 .tag-stream__header .follow-button {
 
 	@include breakpoint( "<660px" ) {
@@ -91,7 +96,6 @@
 }
 
 // Back button in Tag streams
-
 .is-reader-page .card.header-cake {
 	background: none;
 	box-shadow: none;


### PR DESCRIPTION
The Follow(ing) button in Tag streams should be located on the right instead of left because it overlaps with the "Back" button when there is one. 

I forgot about this as I was cleaning up its styles in: https://github.com/Automattic/wp-calypso/pull/17352

**Before:**
![screenshot 2017-08-21 13 37 08](https://user-images.githubusercontent.com/4924246/29537537-f7fd8c88-8676-11e7-90e1-dc86213dd5f4.png)
![screenshot 2017-08-21 13 38 02](https://user-images.githubusercontent.com/4924246/29537536-f7fd76bc-8676-11e7-8cfa-af21ccbb0454.png)

**After:**
![screenshot 2017-08-21 13 37 26](https://user-images.githubusercontent.com/4924246/29537547-fc8a0cc2-8676-11e7-87a4-6011e667005a.png)
![screenshot 2017-08-21 13 38 09](https://user-images.githubusercontent.com/4924246/29537548-fc905d8e-8676-11e7-829b-cd48884d2623.png)

