### PR TITLE
2FA: Auto-trim code input on changes

### DIFF
--- a/client/blocks/login/two-factor-authentication/verification-code-form.jsx
+++ b/client/blocks/login/two-factor-authentication/verification-code-form.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { defer } from 'lodash';
 import classNames from 'classnames';
@@ -64,10 +65,15 @@ class VerificationCodeForm extends Component {
 	};
 
 	onChangeField = ( event ) => {
+		const {
+			name,
+			value = '',
+		} = event.target;
+
 		this.props.formUpdate();
 
 		this.setState( {
-			[ event.target.name ]: event.target.value,
+			[ name ]: value.trim(),
 		} );
 	};
 


### PR DESCRIPTION
This fixes #14709 by auto-trimming the two-factor key input. This prevents invalid input states caused by leading/trailing spaces.


#### Testing instructions

1. Check out locally (`git checkout fix/login-verification-code-validation`) and start your server. You can also use a [live branch](https://calypso.live/?branch=fix/login-verification-code-validation)
2. Open the [{login page}](http://calypso.localhost:3000/log-in)
3. Try the SMS flow. Verify that leading and trailing spaces are not enterable.
4. Try the authenticator flow. Verify the same as above.
5. Try the backup codes flow. Verify the same as above.

#### Reviews

- [ ] Code
- [ ] Product