### PR TITLE
WPSC: Generate Stats on Load

### DIFF
--- a/client/extensions/wp-super-cache/components/contents/index.jsx
+++ b/client/extensions/wp-super-cache/components/contents/index.jsx
@@ -11,6 +11,7 @@ import { flowRight, get, isEmpty, pick } from 'lodash';
  */
 import Button from 'components/button';
 import CacheStats from './cache-stats';
+import QueryStats from '../data/query-stats';
 import Card from 'components/card';
 import SectionHeader from 'components/section-header';
 import WrapSettingsForm from '../wrap-settings-form';
@@ -86,6 +87,7 @@ class ContentsTab extends Component {
 			isGenerating,
 			isMultisite,
 			isReadOnly,
+			siteId,
 			stats,
 			translate,
 		} = this.props;
@@ -95,6 +97,7 @@ class ContentsTab extends Component {
 
 		return (
 			<div>
+				<QueryStats siteId={ siteId } />
 				<SectionHeader label={ translate( 'Cache Contents' ) } />
 				<Card compact>
 					<div>

--- a/client/extensions/wp-super-cache/components/data/query-stats/index.jsx
+++ b/client/extensions/wp-super-cache/components/data/query-stats/index.jsx
@@ -1,0 +1,55 @@
+/**
+ * External dependencies
+ */
+import { Component } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import { isGeneratingStats } from '../../../state/stats/selectors';
+import { generateStats } from '../../../state/stats/actions';
+
+class QueryStats extends Component {
+	componentWillMount() {
+		this.generateStats( this.props );
+	}
+
+	componentWillReceiveProps( nextProps ) {
+		const { siteId } = this.props;
+
+		if ( ! nextProps.siteId || siteId === nextProps.siteId ) {
+			return;
+		}
+
+		this.generateStats( nextProps );
+	}
+
+	generateStats( props ) {
+		const { generatingStats, siteId } = props;
+
+		if ( ! generatingStats && siteId ) {
+			props.generateStats( siteId );
+		}
+	}
+
+	render() {
+		return null;
+	}
+}
+
+QueryStats.propTypes = {
+	siteId: PropTypes.number,
+	generatingStats: PropTypes.bool,
+	generateStats: PropTypes.func,
+};
+
+export default connect(
+	( state, { siteId } ) => {
+		return {
+			generatingStats: isGeneratingStats( state, siteId ),
+		};
+	},
+	{ generateStats }
+)( QueryStats );


### PR DESCRIPTION
Create a new query component, `<QueryStats />`, and use that to generate and fetch stats upon loading the 'Contents' tab.

Addresses @hoverduck's p4Mypo-5b-p2#comment-349.

To test:
* Verify that stats are being generated upon landing at `calypso.localhost:3000/extensions/wp-super-cache/contents/<yourJPsite>` (in Redux DevTools, watch out for `WP_SUPER_CACHE_GENERATE_STATS`).

![image](https://user-images.githubusercontent.com/96308/29538636-f551337c-86c6-11e7-878a-7e2721bdfcc4.png)
