### PR TITLE
Reader: Fix hover color for white intro banner variant

### DIFF
--- a/client/reader/following/style.scss
+++ b/client/reader/following/style.scss
@@ -19,11 +19,11 @@
 
 		a {
 			color: #c9eaf5;
-			border-bottom: 1px #c9eaf5 solid;
+			border-bottom: 1px solid #c9eaf5;
 
 			&:hover {
 				color: $white;
-				border-bottom: 1px $white solid;
+				border-bottom: 1px solid $white;
 			}
 		}
 	}
@@ -38,15 +38,15 @@
 	background: url( '/calypso/images/reader/reader-intro-background-light-blue.svg' ) #7fd3f1 no-repeat 100% 20px;
 
 	.following__intro-copy {
-		color: #045182;
+		color: $blue-dark;
 
 		a {
-			color: #1785be;
-			border-bottom: 1px #1785be solid;
+			color: 	$blue-wordpress;
+			border-bottom: 1px solid $blue-wordpress;
 
 			&:hover {
-				color: $white;
-				border-bottom: 1px $white solid;
+				color: $blue-dark;
+				border-bottom: 1px solid $blue-dark;
 			}
 		}
 	}
@@ -69,8 +69,8 @@
 			border-bottom: 1px #1785be solid;
 
 			&:hover {
-				color: $white;
-				border-bottom: 1px $white solid;
+				color: $blue-medium;
+				border-bottom: 1px solid $blue-medium;
 			}
 		}
 	}


### PR DESCRIPTION
This PR fixes the hover color for the white variant of the intro banner.

Thanks @martinremy for the report.

**Before:**
![screenshot 2017-08-21 20 20 19](https://user-images.githubusercontent.com/4924246/29547315-2e66951c-86ae-11e7-9699-832400bfbdc7.png)

**After:**
![screenshot 2017-08-21 20 13 35](https://user-images.githubusercontent.com/4924246/29547327-438cde4c-86ae-11e7-8d2b-a5249c88e55d.png)

Default state:
![screenshot 2017-08-21 20 13 41](https://user-images.githubusercontent.com/4924246/29547335-48ed1e06-86ae-11e7-83ff-06bc46ba98c6.png)

I've also just used standard Calypso colors for the other banners. These aren't drastic changes from the original colors.

Blue default:
![screenshot 2017-08-21 20 18 06](https://user-images.githubusercontent.com/4924246/29547366-75cec64a-86ae-11e7-8b59-d31f53c91087.png)

Blue hover:
![screenshot 2017-08-21 20 18 10](https://user-images.githubusercontent.com/4924246/29547365-75cde158-86ae-11e7-97cb-43893c50bd93.png)

Light blue default:
![screenshot 2017-08-21 20 17 02](https://user-images.githubusercontent.com/4924246/29547357-6acbac9a-86ae-11e7-9825-18365bf6db96.png)

Light blue hover:
![screenshot 2017-08-21 20 17 56](https://user-images.githubusercontent.com/4924246/29547358-6acc4f56-86ae-11e7-9381-96b43632bc13.png)
