### PR TITLE
Site Indicator: Remove border below action buttons

### DIFF
--- a/client/my-sites/site-indicator/style.scss
+++ b/client/my-sites/site-indicator/style.scss
@@ -113,6 +113,8 @@
 	a,
 	.button.is-borderless.is-scary,
 	.site-indicator__action-button {
+		border-bottom: 1px solid rgba( 255, 255, 255, 0.6 );
+		border-radius: 0;
 		color: $white;
 		text-decoration: none;
 	}

--- a/client/my-sites/site-indicator/style.scss
+++ b/client/my-sites/site-indicator/style.scss
@@ -113,7 +113,6 @@
 	a,
 	.button.is-borderless.is-scary,
 	.site-indicator__action-button {
-		border-bottom: 1px solid rgba( 255, 255, 255, 0.6 );
 		color: $white;
 		text-decoration: none;
 	}


### PR DESCRIPTION
This PR removes the bottom border of site indicator action links, as it's unnecessary - see https://github.com/Automattic/wp-calypso/pull/16350#issuecomment-323813954 for details.

Warning - before: 
![](https://cldup.com/I1zFfpT4li.png)

Warning - after
![](https://cldup.com/gyMaMIwJct.png)

Error - before:
![](https://cldup.com/bZqJolZGk3.png)

Error - after
![](https://cldup.com/6rEJfuiLHo.png)

To test:
* Checkout this branch, or get it going on calypso.live
* Test site indicator in the sidebar with a Jetpack site with updates and verify it looks as on the screenshot
* Test site indicator in the sidebar with a Jetpack site with connection issues and verify it looks as on the screenshot
