### PR TITLE
Activity log: Add ActivityQueryManager

### DIFF
--- a/client/lib/query-manager/activity/index.js
+++ b/client/lib/query-manager/activity/index.js
@@ -1,0 +1,17 @@
+/** @format */
+/**
+ * Internal dependencies
+ */
+import QueryManager from 'lib/query-manager';
+
+/**
+ * ActivityQueryManager manages Activity which can be queried
+ */
+export default class ActivityQueryManager extends QueryManager {
+	constructor( data, options ) {
+		super( data, {
+			itemKey: 'ts_utc',
+			...options,
+		} );
+	}
+}

--- a/client/lib/query-manager/activity/index.js
+++ b/client/lib/query-manager/activity/index.js
@@ -1,5 +1,10 @@
 /** @format */
 /**
+ * External dependencies
+ */
+import { overEvery, get } from 'lodash';
+
+/**
  * Internal dependencies
  */
 import QueryManager from 'lib/query-manager';
@@ -13,5 +18,48 @@ export default class ActivityQueryManager extends QueryManager {
 			itemKey: 'ts_utc',
 			...options,
 		} );
+	}
+
+	/**
+	 * Returns true if the item matches the given query, or false otherwise.
+	 *
+	 * @param  {Object}  query Query object
+	 * @param  {Object}  item  Item to consider
+	 * @return {Boolean}       Whether item matches query
+	 */
+	matches = ActivityQueryManager.matches;
+
+	/**
+	 * Returns true if the item matches the given query, or false otherwise.
+	 *
+	 * @param  {Object}  query Query object
+	 * @param  {Object}  item  Item to consider
+	 * @return {Boolean}       Whether item matches query
+	 */
+	static matches = overEvery( [
+		ActivityQueryManager.matchDateStart,
+		ActivityQueryManager.matchDateEnd,
+	] );
+
+	/**
+	 * Returns true if the item matches query.dateStart if provided
+	 *
+	 * @param  {Object}  query Query object
+	 * @param  {Object}  item  Item to consider
+	 * @return {Boolean}       Whether item matches query.dateStart
+	 */
+	static matchDateStart( query, { ts_utc } ) {
+		return get( query, 'dateStart', -Infinity ) <= ts_utc;
+	}
+
+	/**
+	 * Returns true if the item matches query.dateEnd if provided
+	 *
+	 * @param  {Object}  query Query object
+	 * @param  {Object}  item  Item to consider
+	 * @return {Boolean}       Whether item matches query.dateEnd
+	 */
+	static matchDateEnd( query, { ts_utc } ) {
+		return ts_utc <= get( query, 'dateEnd', Infinity );
 	}
 }

--- a/client/lib/query-manager/activity/index.js
+++ b/client/lib/query-manager/activity/index.js
@@ -15,7 +15,7 @@ import QueryManager from 'lib/query-manager';
 export default class ActivityQueryManager extends QueryManager {
 	constructor( data, options ) {
 		super( data, {
-			itemKey: 'ts_utc',
+			itemKey: 'activityId',
 			...options,
 		} );
 	}
@@ -29,8 +29,8 @@ export default class ActivityQueryManager extends QueryManager {
 	 * @return {Number}       0 if equal, less than 0 if itemA is first,
 	 *                        greater than 0 if itemB is first.
 	 */
-	compare( query, { ts_utc: tsA }, { ts_utc: tsB } ) {
-		return tsB - tsA;
+	compare( query, { published: pubA }, { published: pubB } ) {
+		return Date.parse( pubB ) - Date.parse( pubA );
 	}
 
 	/**
@@ -61,8 +61,8 @@ export default class ActivityQueryManager extends QueryManager {
 	 * @param  {Object}  item  Item to consider
 	 * @return {Boolean}       Whether item matches query.dateStart
 	 */
-	static matchDateStart( query, { ts_utc } ) {
-		return get( query, 'dateStart', -Infinity ) <= ts_utc;
+	static matchDateStart( query, { published } ) {
+		return get( query, 'dateStart', -Infinity ) <= Date.parse( published );
 	}
 
 	/**
@@ -72,7 +72,7 @@ export default class ActivityQueryManager extends QueryManager {
 	 * @param  {Object}  item  Item to consider
 	 * @return {Boolean}       Whether item matches query.dateEnd
 	 */
-	static matchDateEnd( query, { ts_utc } ) {
-		return ts_utc <= get( query, 'dateEnd', Infinity );
+	static matchDateEnd( query, { published } ) {
+		return Date.parse( published ) <= get( query, 'dateEnd', Infinity );
 	}
 }

--- a/client/lib/query-manager/activity/index.js
+++ b/client/lib/query-manager/activity/index.js
@@ -29,8 +29,8 @@ export default class ActivityQueryManager extends QueryManager {
 	 * @return {Number}       0 if equal, less than 0 if itemA is first,
 	 *                        greater than 0 if itemB is first.
 	 */
-	compare( query, { published: pubA }, { published: pubB } ) {
-		return Date.parse( pubB ) - Date.parse( pubA );
+	compare( query, { activityTs: tsA }, { activityTs: tsB } ) {
+		return Date.parse( tsB ) - Date.parse( tsA );
 	}
 
 	/**
@@ -52,8 +52,8 @@ export default class ActivityQueryManager extends QueryManager {
 	 * @param  {Object}  item  Item to consider
 	 * @return {Boolean}       Whether item matches query.dateStart
 	 */
-	static matchDateStart( query, { published } ) {
-		return get( query, 'dateStart', -Infinity ) <= Date.parse( published );
+	static matchDateStart( query, { activityTs } ) {
+		return get( query, 'dateStart', -Infinity ) <= activityTs;
 	}
 
 	/**
@@ -63,7 +63,7 @@ export default class ActivityQueryManager extends QueryManager {
 	 * @param  {Object}  item  Item to consider
 	 * @return {Boolean}       Whether item matches query.dateEnd
 	 */
-	static matchDateEnd( query, { published } ) {
-		return Date.parse( published ) <= get( query, 'dateEnd', Infinity );
+	static matchDateEnd( query, { activityTs } ) {
+		return activityTs <= get( query, 'dateEnd', Infinity );
 	}
 }

--- a/client/lib/query-manager/activity/index.js
+++ b/client/lib/query-manager/activity/index.js
@@ -40,15 +40,6 @@ export default class ActivityQueryManager extends QueryManager {
 	 * @param  {Object}  item  Item to consider
 	 * @return {Boolean}       Whether item matches query
 	 */
-	matches = ActivityQueryManager.matches;
-
-	/**
-	 * Returns true if the item matches the given query, or false otherwise.
-	 *
-	 * @param  {Object}  query Query object
-	 * @param  {Object}  item  Item to consider
-	 * @return {Boolean}       Whether item matches query
-	 */
 	static matches = overEvery( [
 		ActivityQueryManager.matchDateStart,
 		ActivityQueryManager.matchDateEnd,

--- a/client/lib/query-manager/activity/index.js
+++ b/client/lib/query-manager/activity/index.js
@@ -21,6 +21,19 @@ export default class ActivityQueryManager extends QueryManager {
 	}
 
 	/**
+	 * Sort descending order, defaulting to end of list if unknown.
+	 *
+	 * @param  {Object} query Query object (unused).
+	 * @param  {Object} itemA First item
+	 * @param  {Object} itemB Second item
+	 * @return {Number}       0 if equal, less than 0 if itemA is first,
+	 *                        greater than 0 if itemB is first.
+	 */
+	compare( query, { ts_utc: tsA }, { ts_utc: tsB } ) {
+		return tsB - tsA;
+	}
+
+	/**
 	 * Returns true if the item matches the given query, or false otherwise.
 	 *
 	 * @param  {Object}  query Query object

--- a/client/lib/query-manager/activity/test/index.js
+++ b/client/lib/query-manager/activity/test/index.js
@@ -12,43 +12,13 @@ import ActivityQueryManager from '..';
 /**
  * Module constants
  */
-const DEFAULT_ACTIVITY_TS = 1410647400000; // "2014-09-14T00:30:00+02:00"
+const DEFAULT_ACTIVITY_PUBLISHED = '2014-09-14T00:30:00+02:00';
+const DEFAULT_ACTIVITY_TS = Date.parse( DEFAULT_ACTIVITY_PUBLISHED );
 
+// TODO: Update with wpcom/v2 style activity stream data
 const DEFAULT_ACTIVITY = {
-	action: 'update_available',
-	action_trigger: 'jetpack_update_plugins_change',
-	actor: {
-		avatar_url: 'https://www.gravatar.com/avatar/0?d=mm',
-		display_name: "User's display name",
-		external_user_id: 1,
-		is_ajax: false,
-		is_cron: false,
-		is_rest: true,
-		is_wp_admin: false,
-		is_wp_rest: false,
-		is_xmlrpc: true,
-		login: 'site-user',
-		translated_role: 'administrator',
-		user_email: 'user@example.com',
-		user_roles: 'administrator',
-		wpcom_user_id: 123456,
-	},
-	blog_id: 123456,
-	group: 'plugin',
-	jetpack_version: '5.3-alpha',
-	name: 'plugin__update_available',
-	object: {
-		plugin: [
-			{
-				name: 'Jetpack by WordPress.com',
-				slug: 'jetpack-dev/jetpack.php',
-				version: '5.3-beta-12478-27f866d-master',
-			},
-		],
-	},
-	site_id: 2,
-	ts_utc: DEFAULT_ACTIVITY_TS,
-	type: 'jetpack-audit',
+	activityId: 'foobarbaz',
+	published: DEFAULT_ACTIVITY_PUBLISHED,
 };
 
 describe( 'ActivityQueryManager', () => {
@@ -182,9 +152,20 @@ describe( 'ActivityQueryManager', () => {
 	describe( '#compare()', () => {
 		it( 'should sort by timestamp descending', () => {
 			const sortFunc = manager.compare.bind( manager, {} );
-			expect( [ { ts_utc: 1 }, { ts_utc: 2 } ].sort( sortFunc ) ).to.eql( [
-				{ ts_utc: 2 },
-				{ ts_utc: 1 },
+			const activityA = { activityId: 'a', published: new Date( 100000 ).toISOString() };
+			const activityB = { activityId: 'b', published: new Date( 200000 ).toISOString() };
+
+			expect( [ activityA, activityB ].sort( sortFunc ) ).to.eql( [ activityB, activityA ] );
+		} );
+
+		it( 'should include simultaneous events (in any order, sort is unstable)', () => {
+			const sortFunc = manager.compare.bind( manager, {} );
+			const activityA = { activityId: 'a', published: new Date( 100000 ).toISOString() };
+			const activityB = { activityId: 'b', published: new Date( 100000 ).toISOString() };
+
+			expect( [ activityA, activityB ].sort( sortFunc ) ).to.include.members( [
+				activityA,
+				activityB,
 			] );
 		} );
 	} );

--- a/client/lib/query-manager/activity/test/index.js
+++ b/client/lib/query-manager/activity/test/index.js
@@ -127,6 +127,56 @@ describe( 'ActivityQueryManager', () => {
 				expect( isMatch ).to.be.true;
 			} );
 		} );
+
+		context( 'date range query', () => {
+			it( 'should return true if activity is within a range of dates', () => {
+				const isMatch = manager.matches(
+					{
+						dateEnd: DEFAULT_ACTIVITY_TS + 1,
+						dateStart: DEFAULT_ACTIVITY_TS - 1,
+					},
+					DEFAULT_ACTIVITY
+				);
+
+				expect( isMatch ).to.be.true;
+			} );
+
+			it( 'should return false if activity is before a range of dates', () => {
+				const isMatch = manager.matches(
+					{
+						dateEnd: DEFAULT_ACTIVITY_TS + 2,
+						dateStart: DEFAULT_ACTIVITY_TS + 1,
+					},
+					DEFAULT_ACTIVITY
+				);
+
+				expect( isMatch ).to.be.false;
+			} );
+
+			it( 'should return false if activity is after a range of dates', () => {
+				const isMatch = manager.matches(
+					{
+						dateEnd: DEFAULT_ACTIVITY_TS - 1,
+						dateStart: DEFAULT_ACTIVITY_TS - 2,
+					},
+					DEFAULT_ACTIVITY
+				);
+
+				expect( isMatch ).to.be.false;
+			} );
+
+			it( 'should be impossible to match if dateStart is after dateEnd', () => {
+				const isMatch = manager.matches(
+					{
+						dateEnd: DEFAULT_ACTIVITY_TS - 1,
+						dateStart: DEFAULT_ACTIVITY_TS + 1,
+					},
+					DEFAULT_ACTIVITY
+				);
+
+				expect( isMatch ).to.be.false;
+			} );
+		} );
 	} );
 
 	describe( '#compare()', () => {

--- a/client/lib/query-manager/activity/test/index.js
+++ b/client/lib/query-manager/activity/test/index.js
@@ -128,4 +128,14 @@ describe( 'ActivityQueryManager', () => {
 			} );
 		} );
 	} );
+
+	describe( '#compare()', () => {
+		it( 'should sort by timestamp descending', () => {
+			const sortFunc = manager.compare.bind( manager, {} );
+			expect( [ { ts_utc: 1 }, { ts_utc: 2 } ].sort( sortFunc ) ).to.eql( [
+				{ ts_utc: 2 },
+				{ ts_utc: 1 },
+			] );
+		} );
+	} );
 } );

--- a/client/lib/query-manager/activity/test/index.js
+++ b/client/lib/query-manager/activity/test/index.js
@@ -1,0 +1,131 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import ActivityQueryManager from '..';
+
+/**
+ * Module constants
+ */
+const DEFAULT_ACTIVITY_TS = 1410647400000; // "2014-09-14T00:30:00+02:00"
+
+const DEFAULT_ACTIVITY = {
+	action: 'update_available',
+	action_trigger: 'jetpack_update_plugins_change',
+	actor: {
+		avatar_url: 'https://www.gravatar.com/avatar/0?d=mm',
+		display_name: "User's display name",
+		external_user_id: 1,
+		is_ajax: false,
+		is_cron: false,
+		is_rest: true,
+		is_wp_admin: false,
+		is_wp_rest: false,
+		is_xmlrpc: true,
+		login: 'site-user',
+		translated_role: 'administrator',
+		user_email: 'user@example.com',
+		user_roles: 'administrator',
+		wpcom_user_id: 123456,
+	},
+	blog_id: 123456,
+	group: 'plugin',
+	jetpack_version: '5.3-alpha',
+	name: 'plugin__update_available',
+	object: {
+		plugin: [
+			{
+				name: 'Jetpack by WordPress.com',
+				slug: 'jetpack-dev/jetpack.php',
+				version: '5.3-beta-12478-27f866d-master',
+			},
+		],
+	},
+	site_id: 2,
+	ts_utc: DEFAULT_ACTIVITY_TS,
+	type: 'jetpack-audit',
+};
+
+describe( 'ActivityQueryManager', () => {
+	let manager;
+	beforeEach( () => {
+		manager = new ActivityQueryManager();
+	} );
+
+	describe( '#matches()', () => {
+		context( 'query.dateStart', () => {
+			it( 'should return true if activity is at the specified time', () => {
+				const isMatch = manager.matches(
+					{
+						dateStart: DEFAULT_ACTIVITY_TS,
+					},
+					DEFAULT_ACTIVITY
+				);
+
+				expect( isMatch ).to.be.true;
+			} );
+
+			it( 'should return true if activity is after the specified time', () => {
+				const isMatch = manager.matches(
+					{
+						dateStart: DEFAULT_ACTIVITY_TS - 1,
+					},
+					DEFAULT_ACTIVITY
+				);
+
+				expect( isMatch ).to.be.true;
+			} );
+
+			it( 'should return false if activity is before the specified time', () => {
+				const isMatch = manager.matches(
+					{
+						dateStart: DEFAULT_ACTIVITY_TS + 1,
+					},
+					DEFAULT_ACTIVITY
+				);
+
+				expect( isMatch ).to.be.false;
+			} );
+		} );
+
+		context( 'query.dateEnd', () => {
+			it( 'should return true if activity is at the specified time', () => {
+				const isMatch = manager.matches(
+					{
+						dateEnd: DEFAULT_ACTIVITY_TS,
+					},
+					DEFAULT_ACTIVITY
+				);
+
+				expect( isMatch ).to.be.true;
+			} );
+
+			it( 'should return false if activity is after the specified time', () => {
+				const isMatch = manager.matches(
+					{
+						dateEnd: DEFAULT_ACTIVITY_TS - 1,
+					},
+					DEFAULT_ACTIVITY
+				);
+
+				expect( isMatch ).to.be.false;
+			} );
+
+			it( 'should return true if activity is before the specified time', () => {
+				const isMatch = manager.matches(
+					{
+						dateEnd: DEFAULT_ACTIVITY_TS + 1,
+					},
+					DEFAULT_ACTIVITY
+				);
+
+				expect( isMatch ).to.be.true;
+			} );
+		} );
+	} );
+} );

--- a/client/lib/query-manager/activity/test/index.js
+++ b/client/lib/query-manager/activity/test/index.js
@@ -2,6 +2,7 @@
 /**
  * External dependencies
  */
+import deepFreeze from 'deep-freeze';
 import { expect } from 'chai';
 
 /**
@@ -12,14 +13,24 @@ import ActivityQueryManager from '..';
 /**
  * Module constants
  */
-const DEFAULT_ACTIVITY_PUBLISHED = '2014-09-14T00:30:00+02:00';
-const DEFAULT_ACTIVITY_TS = Date.parse( DEFAULT_ACTIVITY_PUBLISHED );
+const DEFAULT_ACTIVITY_DATE = '2014-09-14T00:30:00+02:00';
+const DEFAULT_ACTIVITY_TS = Date.parse( DEFAULT_ACTIVITY_DATE );
 
 // TODO: Update with wpcom/v2 style activity stream data
-const DEFAULT_ACTIVITY = {
-	activityId: 'foobarbaz',
-	published: DEFAULT_ACTIVITY_PUBLISHED,
-};
+const DEFAULT_ACTIVITY = deepFreeze( {
+	activityDate: DEFAULT_ACTIVITY_DATE,
+	activityGroup: 'plugin',
+	activityIcon: 'plugins',
+	activityId: 'foo_bar_BaZ',
+	activityName: 'plugin__activated',
+	activityTitle: 'User name activated plugin My Test Plugin',
+	activityTs: DEFAULT_ACTIVITY_TS,
+	actorAvatarUrl: 'https://secure.gravatar.com/avatar/0?s=96&d=mm&r=g',
+	actorName: 'User name',
+	actorRemoteId: 345,
+	actorRole: 'administrator',
+	actorWpcomId: 678,
+} );
 
 describe( 'ActivityQueryManager', () => {
 	let manager;
@@ -152,16 +163,16 @@ describe( 'ActivityQueryManager', () => {
 	describe( '#compare()', () => {
 		it( 'should sort by timestamp descending', () => {
 			const sortFunc = manager.compare.bind( manager, {} );
-			const activityA = { activityId: 'a', published: new Date( 100000 ).toISOString() };
-			const activityB = { activityId: 'b', published: new Date( 200000 ).toISOString() };
+			const activityA = { activityId: 'a', activityTs: 100000 };
+			const activityB = { activityId: 'b', activityTs: 200000 };
 
 			expect( [ activityA, activityB ].sort( sortFunc ) ).to.eql( [ activityB, activityA ] );
 		} );
 
 		it( 'should include simultaneous events (in any order, sort is unstable)', () => {
 			const sortFunc = manager.compare.bind( manager, {} );
-			const activityA = { activityId: 'a', published: new Date( 100000 ).toISOString() };
-			const activityB = { activityId: 'b', published: new Date( 100000 ).toISOString() };
+			const activityA = { activityId: 'a', activityTs: 100000 };
+			const activityB = { activityId: 'b', activityTs: 100000 };
 
 			expect( [ activityA, activityB ].sort( sortFunc ) ).to.include.members( [
 				activityA,

--- a/client/lib/query-manager/activity/test/index.js
+++ b/client/lib/query-manager/activity/test/index.js
@@ -30,7 +30,7 @@ describe( 'ActivityQueryManager', () => {
 	describe( '#matches()', () => {
 		context( 'query.dateStart', () => {
 			it( 'should return true if activity is at the specified time', () => {
-				const isMatch = manager.matches(
+				const isMatch = ActivityQueryManager.matches(
 					{
 						dateStart: DEFAULT_ACTIVITY_TS,
 					},
@@ -41,7 +41,7 @@ describe( 'ActivityQueryManager', () => {
 			} );
 
 			it( 'should return true if activity is after the specified time', () => {
-				const isMatch = manager.matches(
+				const isMatch = ActivityQueryManager.matches(
 					{
 						dateStart: DEFAULT_ACTIVITY_TS - 1,
 					},
@@ -52,7 +52,7 @@ describe( 'ActivityQueryManager', () => {
 			} );
 
 			it( 'should return false if activity is before the specified time', () => {
-				const isMatch = manager.matches(
+				const isMatch = ActivityQueryManager.matches(
 					{
 						dateStart: DEFAULT_ACTIVITY_TS + 1,
 					},
@@ -65,7 +65,7 @@ describe( 'ActivityQueryManager', () => {
 
 		context( 'query.dateEnd', () => {
 			it( 'should return true if activity is at the specified time', () => {
-				const isMatch = manager.matches(
+				const isMatch = ActivityQueryManager.matches(
 					{
 						dateEnd: DEFAULT_ACTIVITY_TS,
 					},
@@ -76,7 +76,7 @@ describe( 'ActivityQueryManager', () => {
 			} );
 
 			it( 'should return false if activity is after the specified time', () => {
-				const isMatch = manager.matches(
+				const isMatch = ActivityQueryManager.matches(
 					{
 						dateEnd: DEFAULT_ACTIVITY_TS - 1,
 					},
@@ -87,7 +87,7 @@ describe( 'ActivityQueryManager', () => {
 			} );
 
 			it( 'should return true if activity is before the specified time', () => {
-				const isMatch = manager.matches(
+				const isMatch = ActivityQueryManager.matches(
 					{
 						dateEnd: DEFAULT_ACTIVITY_TS + 1,
 					},
@@ -100,7 +100,7 @@ describe( 'ActivityQueryManager', () => {
 
 		context( 'date range query', () => {
 			it( 'should return true if activity is within a range of dates', () => {
-				const isMatch = manager.matches(
+				const isMatch = ActivityQueryManager.matches(
 					{
 						dateEnd: DEFAULT_ACTIVITY_TS + 1,
 						dateStart: DEFAULT_ACTIVITY_TS - 1,
@@ -112,7 +112,7 @@ describe( 'ActivityQueryManager', () => {
 			} );
 
 			it( 'should return false if activity is before a range of dates', () => {
-				const isMatch = manager.matches(
+				const isMatch = ActivityQueryManager.matches(
 					{
 						dateEnd: DEFAULT_ACTIVITY_TS + 2,
 						dateStart: DEFAULT_ACTIVITY_TS + 1,
@@ -124,7 +124,7 @@ describe( 'ActivityQueryManager', () => {
 			} );
 
 			it( 'should return false if activity is after a range of dates', () => {
-				const isMatch = manager.matches(
+				const isMatch = ActivityQueryManager.matches(
 					{
 						dateEnd: DEFAULT_ACTIVITY_TS - 1,
 						dateStart: DEFAULT_ACTIVITY_TS - 2,
@@ -136,7 +136,7 @@ describe( 'ActivityQueryManager', () => {
 			} );
 
 			it( 'should be impossible to match if dateStart is after dateEnd', () => {
-				const isMatch = manager.matches(
+				const isMatch = ActivityQueryManager.matches(
 					{
 						dateEnd: DEFAULT_ACTIVITY_TS - 1,
 						dateStart: DEFAULT_ACTIVITY_TS + 1,


### PR DESCRIPTION
Add an ActivityQueryManager class for managing Activity Log data.

## Testing

* The AQM isn't connected to any part of the application in this PR.
* Just ensure the code and tests look correct and everything passes.

## Follow up

* Use in application state
* When paging lands on the endpoint, update to use paging and extend `PaginatedQueryManager` (26-gh-action-to-activity-log)

Related: #17135