### PR TITLE
FormCurrencyInput: add a 'chevron-down' icon when currency is editable

### DIFF
--- a/client/components/forms/form-currency-input/index.jsx
+++ b/client/components/forms/form-currency-input/index.jsx
@@ -5,6 +5,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import Gridicon from 'gridicons';
 
 /**
  * Internal dependencies
@@ -27,6 +28,7 @@ function renderAffix( currencyValue, onCurrencyChange, currencyList, visualCurre
 	return (
 		<span className="form-currency-input__affix">
 			{ ( visualCurrencyList && visualCurrencyList[ currencyValue ] ) || currencyValue }
+			<Gridicon icon="chevron-down" size={ 18 } className="form-currency-input__select-icon" />
 			<select
 				className="form-currency-input__select"
 				value={ currencyValue }

--- a/client/components/forms/form-currency-input/style.scss
+++ b/client/components/forms/form-currency-input/style.scss
@@ -2,6 +2,24 @@
 	-webkit-appearance: none;
 }
 
+.form-currency-input__affix {
+	display: flex;
+	align-items: center;
+}
+
+.form-currency-input__select-icon {
+	color: $gray;
+	margin-left: 6px;
+	align-self: center;
+}
+
+.form-text-input-with-affixes__prefix,
+.form-text-input-with-affixes__suffix {
+	&:hover .form-currency-input__select-icon {
+		color: darken( $gray, 20% );
+	}
+}
+
 .form-currency-input__select {
 	position: absolute;
 	top: 0;


### PR DESCRIPTION
This is how the improved `FormCurrencyInput` looks now:

<img width="519" alt="currency-chevron" src="https://user-images.githubusercontent.com/664258/29557653-14c2a41c-872a-11e7-817f-f7c197d047a2.png">

@iamtakashi Please check if the chevron size, colors and margins could be improved.