### PR TITLE
FormCurrencyInput: merge currencyList and visualCurrencyList into one list

### DIFF
--- a/client/components/forms/docs/example.jsx
+++ b/client/components/forms/docs/example.jsx
@@ -36,8 +36,10 @@ import PhoneInput from 'components/phone-input';
 /**
  * Internal dependencies
  */
-const countriesList = require( 'lib/countries-list' ).forSms();
-const { CURRENCIES } = require( 'lib/format-currency/currencies' );
+import { forSms } from 'lib/countries-list';
+import { CURRENCIES } from 'lib/format-currency/currencies';
+
+const countriesList = forSms();
 const currencyList = entries( CURRENCIES ).map( ( [ code ] ) => ( { code } ) );
 const visualCurrencyList = entries( CURRENCIES ).map( ( [ code, { symbol } ] ) => ( {
 	code,

--- a/client/components/forms/docs/example.jsx
+++ b/client/components/forms/docs/example.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React from 'react';
-import { mapValues } from 'lodash';
+import { entries } from 'lodash';
 
 /**
  * Internal dependencies
@@ -37,9 +37,12 @@ import PhoneInput from 'components/phone-input';
  * Internal dependencies
  */
 const countriesList = require( 'lib/countries-list' ).forSms();
-const currencies = require( 'lib/format-currency/currencies' ).CURRENCIES
-const currencyList = Object.keys( currencies );
-const visualCurrencyList = mapValues( currencies, ( currency, key ) => `${ key } ${ currency.symbol }` );
+const { CURRENCIES } = require( 'lib/format-currency/currencies' );
+const currencyList = entries( CURRENCIES ).map( ( [ code ] ) => ( { code } ) );
+const visualCurrencyList = entries( CURRENCIES ).map( ( [ code, { symbol } ] ) => ( {
+	code,
+	label: `${ code } ${ symbol }`
+} ) );
 
 class FormFields extends React.PureComponent {
 	static displayName = 'FormFields'; // Needed for devdocs/design
@@ -351,8 +354,7 @@ class FormFields extends React.PureComponent {
 							onChange={ this.handlePriceChange }
 							currencySymbolPrefix={ this.state.currencyInput.currency }
 							onCurrencyChange={ this.handleCurrencyChange }
-							currencyList={ currencyList }
-							visualCurrencyList={ visualCurrencyList }
+							currencyList={ visualCurrencyList }
 							placeholder="Placeholder text..."
 						/>
 					</FormFieldset>

--- a/client/components/forms/form-currency-input/index.jsx
+++ b/client/components/forms/form-currency-input/index.jsx
@@ -6,13 +6,14 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import Gridicon from 'gridicons';
+import { find, get } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import FormTextInputWithAffixes from 'components/forms/form-text-input-with-affixes';
 
-function renderAffix( currencyValue, onCurrencyChange, currencyList, visualCurrencyList ) {
+function renderAffix( currencyValue, onCurrencyChange, currencyList ) {
 	// If the currency value is not defined, don't render this affix at all
 	if ( ! currencyValue ) {
 		return null;
@@ -24,19 +25,27 @@ function renderAffix( currencyValue, onCurrencyChange, currencyList, visualCurre
 		return currencyValue;
 	}
 
+	// Find the currency code in the `currencyList` and return the label. If not found,
+	// use the code itself as the label.
+	const currencyLabel = get(
+		find( currencyList, currency => currency.code === currencyValue ),
+		'label',
+		currencyValue
+	);
+
 	// For an editable currency, display a <select> overlay
 	return (
 		<span className="form-currency-input__affix">
-			{ ( visualCurrencyList && visualCurrencyList[ currencyValue ] ) || currencyValue }
+			{ currencyLabel }
 			<Gridicon icon="chevron-down" size={ 18 } className="form-currency-input__select-icon" />
 			<select
 				className="form-currency-input__select"
 				value={ currencyValue }
 				onChange={ onCurrencyChange }
 			>
-				{ currencyList.map( code =>
+				{ currencyList.map( ( { code, label = code } ) =>
 					<option key={ code } value={ code }>
-						{ ( visualCurrencyList && visualCurrencyList[ code ] ) || code }
+						{ label }
 					</option>
 				) }
 			</select>
@@ -50,23 +59,12 @@ function FormCurrencyInput( {
 	currencySymbolSuffix,
 	onCurrencyChange,
 	currencyList,
-	visualCurrencyList,
 	placeholder = '0.00',
 	...props
 } ) {
 	const classes = classNames( 'form-currency-input', className );
-	const prefix = renderAffix(
-		currencySymbolPrefix,
-		onCurrencyChange,
-		currencyList,
-		visualCurrencyList
-	);
-	const suffix = renderAffix(
-		currencySymbolSuffix,
-		onCurrencyChange,
-		currencyList,
-		visualCurrencyList
-	);
+	const prefix = renderAffix( currencySymbolPrefix, onCurrencyChange, currencyList );
+	const suffix = renderAffix( currencySymbolSuffix, onCurrencyChange, currencyList );
 
 	return (
 		<FormTextInputWithAffixes
@@ -80,12 +78,16 @@ function FormCurrencyInput( {
 	);
 }
 
+const CurrencyShape = PropTypes.shape( {
+	code: PropTypes.string.isRequired,
+	label: PropTypes.string,
+} );
+
 FormCurrencyInput.propTypes = {
 	currencySymbolPrefix: PropTypes.string,
 	currencySymbolSuffix: PropTypes.string,
 	onCurrencyChange: PropTypes.func,
-	currencyList: PropTypes.array,
-	visualCurrencyList: PropTypes.object,
+	currencyList: PropTypes.arrayOf( CurrencyShape ),
 };
 
 export default FormCurrencyInput;

--- a/client/components/tinymce/plugins/simple-payments/dialog/form.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/form.jsx
@@ -8,7 +8,7 @@ import React, { Component } from 'react';
 import { reduxForm, Field, Fields, getFormValues, isValid, isDirty } from 'redux-form';
 import { localize } from 'i18n-calypso';
 import emailValidator from 'email-validator';
-import { flowRight as compose, padEnd } from 'lodash';
+import { flowRight as compose, padEnd, trimEnd } from 'lodash';
 
 /**
  * Internal dependencies
@@ -57,32 +57,13 @@ const SUPPORTED_CURRENCY_LIST = [
 	'THB',
 ];
 
-const VISUAL_CURRENCY_LIST = {
-	USD: 'USD $',
-	EUR: 'EUR €',
-	AUD: 'AUD $',
-	BRL: 'BRL R$',
-	CAD: 'CAD $',
-	CZK: 'CZK Kč',
-	DKK: 'DKK kr',
-	HKD: 'HKD $',
-	HUF: 'HUF Ft',
-	ILS: 'ILS ₪',
-	JPY: 'JPY ¥',
-	MYR: 'MYR RM',
-	MXN: 'MXN $',
-	TWD: 'TWD NT$',
-	NZD: 'NZD $',
-	NOK: 'NOK kr',
-	PHP: 'PHP ₱',
-	PLN: 'PLN zł',
-	GBP: 'GBP £',
-	RUB: 'RUB ₽',
-	SGD: 'SGD $',
-	SEK: 'SEK kr',
-	CHF: 'CHF',
-	THB: 'THB ฿',
-};
+const VISUAL_CURRENCY_LIST = SUPPORTED_CURRENCY_LIST.map( code => {
+	const { symbol } = getCurrencyDefaults( code );
+	// if symbol is equal to the code (e.g., 'CHF' === 'CHF'), don't duplicate it.
+	// trim the dot at the end, e.g., 'kr.' becomes 'kr'
+	const label = symbol === code ? code : `${ code } ${ trimEnd( symbol, '.' ) }`;
+	return { code, label };
+} );
 
 // based on https://stackoverflow.com/a/10454560/59752
 function decimalPlaces( number ) {
@@ -160,8 +141,7 @@ const renderPriceField = ( { price, currency, ...props } ) => {
 			{ ...props }
 			currencySymbolPrefix={ currency.input.value }
 			onCurrencyChange={ currency.input.onChange }
-			currencyList={ SUPPORTED_CURRENCY_LIST }
-			visualCurrencyList={ VISUAL_CURRENCY_LIST }
+			currencyList={ VISUAL_CURRENCY_LIST }
 			placeholder={ placeholder }
 		/>
 	);


### PR DESCRIPTION
In #17393 @rralian added a new `visualCurrencyList` prop to `FormCurrencyInput` to provide support for custom labels. In this PR, I'm trying to simplify the API a little bit.

Instead of the `currencyList` being just an array of codes like `[ 'USD', 'EUR', 'GBP', ... ]`, what about making it a list of objects?
```js
[
  { code: 'USD', label: 'USD $' },
  { code: 'EUR', label: 'EUR €' },
  { code: 'GBP', label: 'GBP £' }
]
```
This makes `visualCurrencyList` obsolete and maps extremely well into the structure of the React `<select>` element:
```jsx
<select value="USD">
  <option value="USD">USD $</option>
  <option value="EUR">EUR €</option>
  <option value="GBP">GBP £</option>
</select>
```

The `label` property is optional and defaults to the `code`.

Also, I generate the list of `USD $` labels from the currency data instead of hardcoding it. I needed to do a few tricks to avoid labels `CHF CHF` and `DKK kr.` and turn the into `CHF` and `DKK kr` respectively.

Let me know what you think :)

**To test:**
1. In devdocs: go to `/devdocs/design/form-fields` and find the two Editable Form Currency Inputs. One of them doesn't specify `label`s and uses `code` to show in the UI. The other one specifies custom `label`s. They both share the underlying state, so changing one also changes the other. That's also a proof that the underlying field values are the same, although the labels are different.

2. In Simple Payments: create a new payment button in a post on your blog, or edit existing one. Check that the "Price" field's currency is editable, that the editing works, and that the correct value is being saved.