### PR TITLE
Components: Clean up popover functionality from SiteSelectorAddSite

### DIFF
--- a/client/components/site-selector/add-site.jsx
+++ b/client/components/site-selector/add-site.jsx
@@ -18,12 +18,6 @@ import { abtest } from 'lib/abtest';
 import { hasJetpackSites } from 'state/selectors';
 
 class SiteSelectorAddSite extends Component {
-	constructor() {
-		super();
-
-		this.recordAddNewSite = this.recordAddNewSite.bind( this );
-	}
-
 	getAddNewSiteUrl() {
 		if ( this.props.hasJetpackSites || abtest( 'newSiteWithJetpack' ) === 'showNewJetpackSite' ) {
 			return '/jetpack/new/?ref=calypso-selector';
@@ -31,9 +25,9 @@ class SiteSelectorAddSite extends Component {
 		return config( 'signup_url' ) + '?ref=calypso-selector';
 	}
 
-	recordAddNewSite() {
+	recordAddNewSite = () => {
 		this.props.recordTracksEvent( 'calypso_add_new_wordpress_click' );
-	}
+	};
 
 	render() {
 		const { translate } = this.props;

--- a/client/components/site-selector/add-site.jsx
+++ b/client/components/site-selector/add-site.jsx
@@ -12,8 +12,6 @@ import Gridicon from 'gridicons';
  * Internal dependencies
  */
 import Button from 'components/button';
-import PopoverMenu from 'components/popover/menu';
-import PopoverMenuItem from 'components/popover/menu-item';
 import { recordTracksEvent } from 'state/analytics/actions';
 import config from 'config';
 import { abtest } from 'lib/abtest';
@@ -28,12 +26,7 @@ class SiteSelectorAddSite extends Component {
 			popoverPosition: 'top',
 		};
 
-		this.handleShowPopover = this.handleShowPopover.bind( this );
-		this.onPopoverButtonClick = this.onPopoverButtonClick.bind( this );
-		this.onClosePopover = this.onClosePopover.bind( this );
 		this.recordAddNewSite = this.recordAddNewSite.bind( this );
-		this.recordPopoverAddNewSite = this.recordPopoverAddNewSite.bind( this );
-		this.recordPopoverAddJetpackSite = this.recordPopoverAddJetpackSite.bind( this );
 	}
 
 	getAddNewSiteUrl() {
@@ -43,37 +36,11 @@ class SiteSelectorAddSite extends Component {
 		return config( 'signup_url' ) + '?ref=calypso-selector';
 	}
 
-	handleShowPopover( isShowing ) {
-		const action = isShowing ? 'show' : 'hide';
-
-		this.setState( {
-			showPopoverMenu: isShowing,
-		} );
-
-		this.props.recordTracksEvent( 'calypso_add_site_popover', { action } );
-	}
-
-	onPopoverButtonClick() {
-		this.handleShowPopover( ! this.state.showPopoverMenu );
-	}
-
-	onClosePopover() {
-		this.handleShowPopover( false );
-	}
-
 	recordAddNewSite() {
 		this.props.recordTracksEvent( 'calypso_add_new_wordpress_click' );
 	}
 
-	recordPopoverAddNewSite() {
-		this.props.recordTracksEvent( 'calypso_add_new_wordpress_popover_click' );
-	}
-
-	recordPopoverAddJetpackSite() {
-		this.props.recordTracksEvent( 'calypso_add_jetpack_site_popover_click' );
-	}
-
-	renderButton() {
+	render() {
 		const { translate } = this.props;
 		return (
 			<span className="site-selector__add-new-site">
@@ -82,38 +49,6 @@ class SiteSelectorAddSite extends Component {
 				</Button>
 			</span>
 		);
-	}
-
-	renderButtonWithPopover() {
-		const { translate } = this.props;
-		return (
-			<span className="site-selector__add-new-site" ref="popoverMenuTarget">
-				<PopoverMenu
-					isVisible={ this.state.showPopoverMenu }
-					onClose={ this.onClosePopover }
-					position={ this.state.popoverPosition }
-					context={ this.refs && this.refs.popoverMenuTarget }
-				>
-					<PopoverMenuItem
-						href={ this.getAddNewSiteUrl() }
-						onClick={ this.recordPopoverAddNewSite }
-					>
-						{ translate( 'New WordPress.com site' ) }
-					</PopoverMenuItem>
-					<PopoverMenuItem href="/jetpack/connect" onClick={ this.recordPopoverAddJetpackSite }>
-						{ translate( 'Self-hosted WordPress site' ) }
-					</PopoverMenuItem>
-				</PopoverMenu>
-
-				<Button borderless onClick={ this.onPopoverButtonClick }>
-					<Gridicon icon="add-outline" /> { translate( 'Add Site' ) }
-				</Button>
-			</span>
-		);
-	}
-
-	render() {
-		return this.renderButton();
 	}
 }
 

--- a/client/components/site-selector/add-site.jsx
+++ b/client/components/site-selector/add-site.jsx
@@ -4,7 +4,6 @@
  */
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'gridicons';
 
@@ -45,11 +44,7 @@ export default connect(
 	state => ( {
 		hasJetpackSites: hasJetpackSites( state ),
 	} ),
-	dispatch =>
-		bindActionCreators(
-			{
-				recordTracksEvent,
-			},
-			dispatch
-		)
+	{
+		recordTracksEvent,
+	}
 )( localize( SiteSelectorAddSite ) );

--- a/client/components/site-selector/add-site.jsx
+++ b/client/components/site-selector/add-site.jsx
@@ -21,11 +21,6 @@ class SiteSelectorAddSite extends Component {
 	constructor() {
 		super();
 
-		this.state = {
-			showPopoverMenu: false,
-			popoverPosition: 'top',
-		};
-
 		this.recordAddNewSite = this.recordAddNewSite.bind( this );
 	}
 


### PR DESCRIPTION
This PR cleans up all of the popover functionality from `SiteSelectorAddSite` that is no longer used since #10658 landed. 

It also uses the opportunity to remove the unnecessary `constructor`, as well as to use the short syntax for binding action creators to `dispatch`.

To test:
* Checkout this branch.
* Verify there is are no regressions in the Add Site button's behavior and functionality:
  * Login as a user with one or more Jetpack sites.
  * Click My Sites in the sidebar, then click "Switch Site".
  * Click the "Add New Site" button at the bottom, verify you're taken properly to the new site creation flow.
  * Login as a user with no Jetpack sites.
  * Verify you're taken to the .com site creation flow, or the new site creation flow (depending on the current `newSiteWithJetpack` AB test variation).