### PR TITLE
Data Layer: onProgress is optional and should be in the options param

### DIFF
--- a/client/state/data-layer/wpcom-http/README.md
+++ b/client/state/data-layer/wpcom-http/README.md
@@ -188,7 +188,7 @@ import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 dispatchRequest( fetchMenu, addMenuItems, alertFailure );
 
 // create request when no meta present, indicate on success, undo on failure, update on progress
-dispatchRequest( sendRecipe, indicateSuccess, removeRecipe, updateRecipeProgress );
+dispatchRequest( sendRecipe, indicateSuccess, removeRecipe, { onProgress: updateRecipeProgress } );
 ```
 
 ### Helpers
@@ -270,8 +270,8 @@ const updateProgress = ( store, { siteId, postId }, progress ) => {
 }
 
 export default {
-	// watch for this action       -> initiate, onSuccess,  onFailure, onProgress
-	[ LIKE_POST ]: [ dispatchRequest( likePost, verifyLike, undoLike, updateProgress ) ],
+	// watch for this action       -> initiate, onSuccess,  onFailure, options: { onProgress }
+	[ LIKE_POST ]: [ dispatchRequest( likePost, verifyLike, undoLike, { onProgress: updateProgress } ) ],
 };
 ```
 

--- a/client/state/data-layer/wpcom-http/test/utils.js
+++ b/client/state/data-layer/wpcom-http/test/utils.js
@@ -72,7 +72,7 @@ describe( 'WPCOM HTTP Data Layer', () => {
 				onSuccess = spy();
 				onFailure = spy();
 				onProgress = spy();
-				dispatcher = dispatchRequest( initiator, onSuccess, onFailure, onProgress );
+				dispatcher = dispatchRequest( initiator, onSuccess, onFailure, { onProgress } );
 				store = spy();
 			} );
 

--- a/client/state/data-layer/wpcom-http/utils.js
+++ b/client/state/data-layer/wpcom-http/utils.js
@@ -43,6 +43,14 @@ export const getHeaders = action => get( action, 'meta.dataLayer.headers', null 
 export const getProgress = action => get( action, 'meta.dataLayer.progress', null );
 
 /**
+ * @type Object default dispatchRequest options
+ * @property {Function} onProgress called on progress events
+ */
+const defaultOptions = {
+	onProgress: noop,
+};
+
+/**
  * Dispatches to appropriate function based on HTTP request meta
  *
  * @see state/data-layer/wpcom-http/actions#fetch creates HTTP requests
@@ -69,11 +77,14 @@ export const getProgress = action => get( action, 'meta.dataLayer.progress', nul
  * @param {Function} initiator called if action lacks response meta; should create HTTP request
  * @param {Function} onSuccess called if the action meta includes response data
  * @param {Function} onError called if the action meta includes error data
- * @param {Function} [onProgress] called on progress events when uploading. The default
- *                                behavior of this optional handler is to do nothing.
+ * @param {Object} options configures additional dispatching behaviors
+ + @param {Function} [options.middleware] runs before the dispatch itself
+ + @param {Function} [options.onProgress] called on progress events when uploading
  * @returns {?*} please ignore return values, they are undefined
  */
-export const dispatchRequest = ( initiator, onSuccess, onError, onProgress = noop ) => ( store, action ) => {
+export const dispatchRequest = ( initiator, onSuccess, onError, options ) => ( store, action ) => {
+	const { onProgress } = Object.assign( defaultOptions, options );
+
 	const error = getError( action );
 	if ( error ) {
 		return onError( store, action, error );

--- a/client/state/data-layer/wpcom/sites/plugins/new/index.js
+++ b/client/state/data-layer/wpcom/sites/plugins/new/index.js
@@ -101,7 +101,7 @@ export default {
 		uploadPlugin,
 		uploadComplete,
 		receiveError,
-		updateUploadProgress
+		{ onProgress: updateUploadProgress }
 	) ]
 };
 

--- a/client/state/data-layer/wpcom/sites/test/utils.js
+++ b/client/state/data-layer/wpcom/sites/test/utils.js
@@ -100,7 +100,7 @@ describe( 'utility functions', () => {
 			updatePlaceholderComment( { dispatch }, action, comment );
 
 			expect( dispatch ).to.have.been.calledThrice;
-			expect( dispatch ).to.have.been.calledWith( {
+			expect( dispatch ).to.have.been.calledWithMatch( {
 				type: COMMENTS_DELETE,
 				siteId: 2916284,
 				postId: 1010,

--- a/client/state/data-layer/wpcom/sites/utils.js
+++ b/client/state/data-layer/wpcom/sites/utils.js
@@ -11,6 +11,7 @@ import {
 	COMMENTS_RECEIVE,
 	COMMENTS_COUNT_INCREMENT,
 } from 'state/action-types';
+import { local } from 'state/data-layer/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { getSitePost } from 'state/posts/selectors';
 import { errorNotice } from 'state/notices/actions';
@@ -83,7 +84,7 @@ export const dispatchNewCommentRequest = ( dispatch, action, path ) => {
  */
 export const updatePlaceholderComment = ( { dispatch }, { siteId, postId, parentCommentId, placeholderId }, comment ) => {
 	// remove placeholder from state
-	dispatch( { type: COMMENTS_DELETE, siteId, postId, commentId: placeholderId } );
+	dispatch( local( { type: COMMENTS_DELETE, siteId, postId, commentId: placeholderId } ) );
 	// add new comment to state with updated values from server
 	dispatch( { type: COMMENTS_RECEIVE, siteId, postId, comments: [ comment ], skipSort: !! parentCommentId } );
 	// increment comments count

--- a/client/state/data-layer/wpcom/videos/poster/index.js
+++ b/client/state/data-layer/wpcom/videos/poster/index.js
@@ -54,7 +54,7 @@ export const receiveUploadProgress = ( { dispatch }, action, progress ) => {
 };
 
 export const dispatchPosterRequest =
-	dispatchRequest( updatePoster, receivePosterUrl, receivePosterError, receiveUploadProgress );
+	dispatchRequest( updatePoster, receivePosterUrl, receivePosterError, { onProgress: receiveUploadProgress } );
 
 export default {
 	[ VIDEO_EDITOR_UPDATE_POSTER ]: [ dispatchPosterRequest ],


### PR DESCRIPTION
Previously `onProgress` has been the final and optional parameter to
calls to `dispatchRequest()` whereas `onSuccess` and `onFailure` are
somewhat essential. To indicate this difference in the need for
`onProgress` and to allow for better integration of other
control-directives and optional parameters we are moving it into a new
options object which is the final parameter.

After these changes there should be no calls to `dispatchRequest()` which
have four parameters and when the last one isn't also an object with an
`onProgress` property.

**Testing**

Smoke test the features related to the changed files. This shouldn't change _any_ behavior in Calypso.