### PR TITLE
Data layer: introduce response parser

### DIFF
--- a/client/state/data-layer/wpcom-http/test/utils.js
+++ b/client/state/data-layer/wpcom-http/test/utils.js
@@ -7,124 +7,205 @@ import { spy } from 'sinon';
 /**
  * Internal dependencies
  */
-import { getData, getError, getProgress, dispatchRequest } from '../utils.js';
+import { getData, getError, getProgress, dispatchRequest, makeParser } from '../utils.js';
 
 describe( 'WPCOM HTTP Data Layer', () => {
-	describe( 'Utils', () => {
-		describe( '#getData', () => {
-			it( 'should return successful response data if available', () => {
-				const data = { utterance: 'Bork bork' };
-				const action = { type: 'SLUGGER', meta: { dataLayer: { data } } };
+	describe( '#getData', () => {
+		it( 'should return successful response data if available', () => {
+			const data = { utterance: 'Bork bork' };
+			const action = { type: 'SLUGGER', meta: { dataLayer: { data } } };
 
-				expect( getData( action ) ).to.equal( data );
-			} );
-
-			it( 'should return null if no response data available', () => {
-				const action = { type: 'SLUGGER' };
-
-				expect( getData( action ) ).to.be.null;
-			} );
+			expect( getData( action ) ).to.equal( data );
 		} );
 
-		describe( '#getError', () => {
-			it( 'should return failing error data if available', () => {
-				const error = { utterance: 'Bork bork' };
-				const action = { type: 'SLUGGER', meta: { dataLayer: { error } } };
+		it( 'should return null if no response data available', () => {
+			const action = { type: 'SLUGGER' };
 
-				expect( getError( action ) ).to.equal( error );
-			} );
+			expect( getData( action ) ).to.be.null;
+		} );
+	} );
 
-			it( 'should return null if no error data available', () => {
-				const action = { type: 'SLUGGER' };
+	describe( '#getError', () => {
+		it( 'should return failing error data if available', () => {
+			const error = { utterance: 'Bork bork' };
+			const action = { type: 'SLUGGER', meta: { dataLayer: { error } } };
 
-				expect( getError( action ) ).to.be.null;
-			} );
+			expect( getError( action ) ).to.equal( error );
 		} );
 
-		describe( '#getProgress', () => {
-			it( 'should return progress data if available', () => {
-				const progress = { total: 1234, loaded: 123 };
-				const action = { type: 'UPLOAD_PROGRESS', meta: { dataLayer: { progress } } };
+		it( 'should return null if no error data available', () => {
+			const action = { type: 'SLUGGER' };
 
-				expect( getProgress( action ) ).to.equal( progress );
-			} );
+			expect( getError( action ) ).to.be.null;
+		} );
+	} );
+
+	describe( '#getProgress', () => {
+		it( 'should return progress data if available', () => {
+			const progress = { total: 1234, loaded: 123 };
+			const action = { type: 'UPLOAD_PROGRESS', meta: { dataLayer: { progress } } };
+
+			expect( getProgress( action ) ).to.equal( progress );
+		} );
+	} );
+
+	describe( '#dispatchRequest', () => {
+		const data = { count: 5 };
+		const error = { message: 'oh no!' };
+		const empty = { type: 'REFILL' };
+		const progressInfo = { loaded: 45, total: 80 };
+		const success = { type: 'REFILL', meta: { dataLayer: { data } } };
+		const failure = { type: 'REFILL', meta: { dataLayer: { error } } };
+		const progress = { type: 'REFILL', meta: { dataLayer: { progress: progressInfo } } };
+		const both = { type: 'REFILL', meta: { dataLayer: { data, error } } };
+
+		let initiator;
+		let onSuccess;
+		let onFailure;
+		let onProgress;
+		let dispatcher;
+		let store;
+
+		beforeEach( () => {
+			initiator = spy();
+			onSuccess = spy();
+			onFailure = spy();
+			onProgress = spy();
+			dispatcher = dispatchRequest( initiator, onSuccess, onFailure, { onProgress } );
+			store = spy();
 		} );
 
-		describe( '#dispatchRequest', () => {
-			const data = { count: 5 };
-			const error = { message: 'oh no!' };
-			const empty = { type: 'REFILL' };
-			const progressInfo = { loaded: 45, total: 80 };
-			const success = { type: 'REFILL', meta: { dataLayer: { data } } };
-			const failure = { type: 'REFILL', meta: { dataLayer: { error } } };
-			const progress = { type: 'REFILL', meta: { dataLayer: { progress: progressInfo } } };
-			const both = { type: 'REFILL', meta: { dataLayer: { data, error } } };
+		it( 'should call the initiator if meta information missing', () => {
+			dispatcher( store, empty );
 
-			let initiator;
-			let onSuccess;
-			let onFailure;
-			let onProgress;
-			let dispatcher;
-			let store;
+			expect( initiator ).to.have.been.calledWith( store, empty );
+			expect( onSuccess ).to.not.have.been.called;
+			expect( onFailure ).to.not.have.been.called;
+			expect( onProgress ).to.not.have.been.called;
+		} );
 
-			beforeEach( () => {
-				initiator = spy();
-				onSuccess = spy();
-				onFailure = spy();
-				onProgress = spy();
-				dispatcher = dispatchRequest( initiator, onSuccess, onFailure, { onProgress } );
-				store = spy();
-			} );
+		it( 'should call onSuccess if meta includes response data', () => {
+			dispatcher( store, success );
 
-			it( 'should call the initiator if meta information missing', () => {
-				dispatcher( store, empty );
+			expect( initiator ).to.not.have.been.called;
+			expect( onSuccess ).to.have.been.calledWith( store, success, data );
+			expect( onFailure ).to.not.have.been.called;
+			expect( onProgress ).to.not.have.been.called;
+		} );
 
-				expect( initiator ).to.have.been.calledWith( store, empty );
-				expect( onSuccess ).to.not.have.been.called;
-				expect( onFailure ).to.not.have.been.called;
-				expect( onProgress ).to.not.have.been.called;
-			} );
+		it( 'should call onFailure if meta includes error data', () => {
+			dispatcher( store, failure );
 
-			it( 'should call onSuccess if meta includes response data', () => {
-				dispatcher( store, success );
+			expect( initiator ).to.not.have.been.called;
+			expect( onSuccess ).to.not.have.been.called;
+			expect( onFailure ).to.have.been.calledWith( store, failure, error );
+			expect( onProgress ).to.not.have.been.called;
+		} );
 
-				expect( initiator ).to.not.have.been.called;
-				expect( onSuccess ).to.have.been.calledWith( store, success, data );
-				expect( onFailure ).to.not.have.been.called;
-				expect( onProgress ).to.not.have.been.called;
-			} );
+		it( 'should call onFailure if meta includes both response data and error data', () => {
+			dispatcher( store, both );
 
-			it( 'should call onFailure if meta includes error data', () => {
-				dispatcher( store, failure );
+			expect( initiator ).to.not.have.been.called;
+			expect( onSuccess ).to.not.have.been.called;
+			expect( onFailure ).to.have.been.calledWith( store, both, error );
+			expect( onProgress ).to.not.have.been.called;
+		} );
 
-				expect( initiator ).to.not.have.been.called;
-				expect( onSuccess ).to.not.have.been.called;
-				expect( onFailure ).to.have.been.calledWith( store, failure, error );
-				expect( onProgress ).to.not.have.been.called;
-			} );
+		it( 'should call onProgress if meta includes progress data', () => {
+			dispatcher( store, progress );
 
-			it( 'should call onFailure if meta includes both response data and error data', () => {
-				dispatcher( store, both );
+			expect( initiator ).to.not.have.been.called;
+			expect( onSuccess ).to.not.have.been.called;
+			expect( onFailure ).to.not.have.been.called;
+			expect( onProgress ).to.have.been.calledWith( store, progress, progressInfo );
+		} );
 
-				expect( initiator ).to.not.have.been.called;
-				expect( onSuccess ).to.not.have.been.called;
-				expect( onFailure ).to.have.been.calledWith( store, both, error );
-				expect( onProgress ).to.not.have.been.called;
-			} );
+		it( 'should not throw runtime error if onProgress is not specified', () => {
+			dispatcher = dispatchRequest( initiator, onSuccess, onFailure );
+			expect( () => dispatcher( store, progress ) ).to.not.throw( TypeError );
+		} );
 
-			it( 'should call onProgress if meta includes progress data', () => {
-				dispatcher( store, progress );
+		it( 'should validate response data', () => {
+			const schema = {
+				type: 'object',
+				properties: { count: { type: 'integer' } },
+			};
 
-				expect( initiator ).to.not.have.been.called;
-				expect( onSuccess ).to.not.have.been.called;
-				expect( onFailure ).to.not.have.been.called;
-				expect( onProgress ).to.have.been.calledWith( store, progress, progressInfo );
-			} );
+			const fromApi = makeParser( schema );
+			dispatchRequest( initiator, onSuccess, onFailure, { fromApi } )( store, success, data );
 
-			it( 'should not throw runtime error if onProgress is not specified', () => {
-				dispatcher = dispatchRequest( initiator, onSuccess, onFailure );
-				expect( () => dispatcher( store, progress ) ).to.not.throw( TypeError );
-			} );
+			expect( initiator ).to.not.have.been.called;
+			expect( onSuccess ).to.have.been.called;
+			expect( onFailure ).to.not.have.been.called;
+		} );
+
+		it( 'should fail-over on invalid response data', () => {
+			const schema = {
+				type: 'object',
+				properties: { count: { type: 'string' } },
+			};
+
+			const fromApi = makeParser( schema );
+			dispatchRequest( initiator, onSuccess, onFailure, { fromApi } )( store, success, data );
+
+			expect( initiator ).to.not.have.been.called;
+			expect( onSuccess ).to.not.have.been.called;
+			expect( onFailure ).to.have.been.called;
+		} );
+
+		it( 'should validate with additional fields', () => {
+			const schema = {
+				type: 'object',
+				properties: { count: { type: 'integer' } },
+			};
+
+			const extra = { count: 15, is_active: true };
+			const action = { type: 'REFILL', meta: { dataLayer: { data: extra } } };
+
+			const fromApi = makeParser( schema );
+			dispatchRequest( initiator, onSuccess, onFailure, { fromApi } )( store, action, extra );
+
+			expect( initiator ).to.not.have.been.called;
+			expect( onSuccess ).to.have.been.called;
+			expect( onFailure ).to.not.have.been.called;
+		} );
+
+		it( 'should filter out additional fields', () => {
+			const schema = {
+				type: 'object',
+				properties: { count: { type: 'integer' } },
+			};
+
+			const extra = { count: 15, is_active: true };
+			const action = { type: 'REFILL', meta: { dataLayer: { data: extra } } };
+
+			const fromApi = makeParser( schema );
+			dispatchRequest( initiator, onSuccess, onFailure, { fromApi } )( store, action, extra );
+
+			expect( initiator ).to.not.have.been.called;
+			expect( onSuccess ).to.have.been.called;
+			expect( onSuccess ).to.have.been.calledWithExactly( store, action, { count: 15 } );
+			expect( onFailure ).to.not.have.been.called;
+		} );
+
+		it( 'should transform validated output', () => {
+			const schema = {
+				type: 'object',
+				properties: { count: { type: 'integer' } },
+			};
+
+			const extra = { count: 15, is_active: true };
+			const action = { type: 'REFILL', meta: { dataLayer: { data: extra } } };
+
+			const transformer = ( { count } ) => ( { tribbleCount: count * 2, haveTrouble: true } );
+
+			const fromApi = makeParser( schema, {}, transformer );
+			dispatchRequest( initiator, onSuccess, onFailure, { fromApi } )( store, action, extra );
+
+			expect( initiator ).to.not.have.been.called;
+			expect( onSuccess ).to.have.been.called;
+			expect( onSuccess ).to.have.been.calledWithExactly( store, action, { tribbleCount: 30, haveTrouble: true } );
+			expect( onFailure ).to.not.have.been.called;
 		} );
 	} );
 } );

--- a/client/state/data-layer/wpcom-http/utils.js
+++ b/client/state/data-layer/wpcom-http/utils.js
@@ -56,13 +56,27 @@ export const makeParser = ( schema, schemaOptions = {}, transformer = identity )
 	// the actual parser
 	return responseData => {
 		if ( ! validator( responseData ) ) {
-			return [ false, validator.errors ];
+			return [
+				false,
+				{
+					errorType: 'Failed to validate with JSON schema',
+					message: 'Failed to validate with JSON schema',
+					errors: validator.errors,
+				},
+			];
 		}
 
 		try {
 			return [ true, transformer( filter( responseData ) ) ];
 		} catch ( e ) {
-			return [ false, { errorType: 'Exception when transforming API response', error: e.message, data: responseData } ];
+			return [
+				false,
+				{
+					errorType: 'Exception when transforming API response',
+					message: e.message,
+					data: responseData,
+				},
+			];
 		}
 	};
 };
@@ -111,10 +125,7 @@ const defaultOptions = {
  * @returns {?*} please ignore return values, they are undefined
  */
 export const dispatchRequest = ( initiator, onSuccess, onError, options ) => ( store, action ) => {
-	const {
-		fromApi,
-		onProgress,
-	} = { ...defaultOptions, ...options };
+	const { fromApi, onProgress } = { ...defaultOptions, ...options };
 
 	const error = getError( action );
 	if ( error ) {
@@ -125,9 +136,7 @@ export const dispatchRequest = ( initiator, onSuccess, onError, options ) => ( s
 	if ( data ) {
 		const [ isValid, response ] = fromApi( data );
 
-		return isValid
-			? onSuccess( store, action, response )
-			: onError( store, action, response );
+		return isValid ? onSuccess( store, action, response ) : onError( store, action, response );
 	}
 
 	const progress = getProgress( action );

--- a/client/state/data-layer/wpcom-http/utils.js
+++ b/client/state/data-layer/wpcom-http/utils.js
@@ -70,18 +70,24 @@ export const makeParser = ( schema, schemaOptions = {}, transformer = identity )
 	// level of properties are pruned
 	const filter = schemaValidator.filter( { ...schema, additionalProperties: false } );
 
-	// the actual parser
-	return responseData => {
-		if ( ! validator( responseData ) ) {
+	const validate = data => {
+		if ( ! validator( data ) ) {
 			throw new SchemaError( validator.errors );
 		}
 
+		return filter( data );
+	};
+
+	const transform = data => {
 		try {
-			return transformer( filter( responseData ) );
+			return transformer( data );
 		} catch ( e ) {
-			throw new TransformerError( e, transformer, responseData );
+			throw new TransformerError( e, transformer, data );
 		}
 	};
+
+	// the actual parser
+	return data => transform( validate( data ) );
 };
 
 /**

--- a/client/state/data-layer/wpcom-http/utils.js
+++ b/client/state/data-layer/wpcom-http/utils.js
@@ -43,22 +43,20 @@ export const getHeaders = action => get( action, 'meta.dataLayer.headers', null 
  */
 export const getProgress = action => get( action, 'meta.dataLayer.progress', null );
 
-function SchemaError( errors ) {
-	this.name = 'SchemaError';
-	this.message = 'Failed to validate with JSON schema';
-	this.schemaErrors = errors;
+class SchemaError extends Error {
+	constructor( errors ) {
+		super( 'Failed to validate with JSON schema' );
+		this.schemaErrors = errors;
+	}
 }
 
-SchemaError.prototype = new Error;
-
-function TransformerError( error, transformer, data ) {
-	this.name = 'TransformerError';
-	this.message = error.message;
-	this.transformer = transformer;
-	this.originalData = data;
+class TransformerError extends Error {
+	constructor( error, transformer, data ) {
+		super( error.message );
+		this.transformer = transformer;
+		this.inputData = data;
+	}
 }
-
-TransformerError.prototype = new Error;
 
 export const makeParser = ( schema, schemaOptions = {}, transformer = identity ) => {
 	const options = Object.assign( { verbose: true }, schemaOptions );

--- a/client/state/data-layer/wpcom-http/utils.js
+++ b/client/state/data-layer/wpcom-http/utils.js
@@ -46,7 +46,9 @@ export const getProgress = action => get( action, 'meta.dataLayer.progress', nul
 export const makeParser = ( schema, schemaOptions = {}, transformer = identity ) => {
 	const options = Object.assign( { verbose: true }, schemaOptions );
 	const validator = schemaValidator( schema, options );
-	const filter = schemaValidator.filter( schema );
+
+	// filter out unwanted properties even though we may have let them slip past validation
+	const filter = schemaValidator.filter( { ...schema, additionalProperties: false } );
 
 	return responseData => validator( responseData )
 		? [ true, transformer( filter( responseData ) ) ]
@@ -86,12 +88,13 @@ const defaultOptions = {
  *   onSuccess  :: ReduxStore -> Action -> Dispatcher -> ResponseData
  *   onError    :: ReduxStore -> Action -> Dispatcher -> ErrorData
  *   onProgress :: ReduxStore -> Action -> Dispatcher -> ProgressData
+ *   fromApi    :: ResponseData -> [ Boolean, Data ]
  *
  * @param {Function} initiator called if action lacks response meta; should create HTTP request
  * @param {Function} onSuccess called if the action meta includes response data
  * @param {Function} onError called if the action meta includes error data
  * @param {Object} options configures additional dispatching behaviors
- + @param {Function} [options.middleware] runs before the dispatch itself
+ + @param {Function} [options.fromApi] maps between API data and Calypso data
  + @param {Function} [options.onProgress] called on progress events when uploading
  * @returns {?*} please ignore return values, they are undefined
  */


### PR DESCRIPTION
This patch is motivated by two questions:
 - Is the response from the API something I expect?
 - Is the shape of the data in the API respnose what I need?

Previous work has been explored to form a sort of validator function and
an additional `fromAPI()` function to validate and transform data in the
`onSuccess` handlers in the data layer, but that leads to unecessary
code duplication and mess.

The code in this PR is motivated by the extremely capable system of
monadic JSON parsers available in Elm. It's built from the two key
components answering the questions above: using `is-my-json-valid` we
can validate response data and filter out only those fields listed in
the schema; using an optional transformer function we can then reshape
the data once we know it's good. Any failure in this process then leads
to an automatic flow into the `onError()` handler even though the
network request was a 2xx success.

For now this is a discussion PR and I don't have tests or READMEs. Please
provide feedback and your response to the idea.

```js
// API data model
const responseSchema = {
    "additionalProperties": false,
    "properties": {
        "device_count": {
            "exclusiveMinimum": true,
            "id": "/properties/deviceCount",
            "minimum": 0,
            "type": "integer"
        },
        "primary_email": {
            "id": "/properties/primary_email",
            "type": "string"
        },
        "secondary_email": {
            "id": "/properties/secondary_email",
            "type": [ "string", "null" ]
        }
    },
    "required": [
        "secondary_email",
        "deviceCount",
        "primary_email"
    ],
    "type": "object"
};

// Calypso data model
const responseTransformer = ( { primary_email, secondary_email, device_count } ) => ( {
  deviceCount: device_count,
  emails: compact( [ primary_email, secondary_email ] ),
} );

// and there was much rejoicing.
dispatchRequest( initiateFetch, updateState, announceFailure, {
  fromApi: makeParser( responseSchema, null, responseTransformer )
} );
```