### PR TITLE
JPC: Disable pre-selected site functionality

### DIFF
--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -145,8 +145,6 @@ export default {
 				path={ context.path }
 				interval={ interval }
 				locale={ locale }
-				preSelectedSite={ context.query.preSelectedSite || null }
-				selectedPlan={ context.query.selectedPlan || null }
 			/>,
 			document.getElementById( 'primary' ),
 			context.store
@@ -195,7 +193,6 @@ export default {
 				interval={ context.params.interval }
 				basePlansPath={ '/jetpack/connect/store' }
 				url={ context.query.site }
-				preSelectedSite={ context.query.preSelectedSite }
 			/>,
 			document.getElementById( 'primary' ),
 			context.store


### PR DESCRIPTION
Disable pre-selected site functionality while we investigate a possibly related bug.

I'm going to merge this straight away since it reverts something I deployed with https://github.com/Automattic/wp-calypso/pull/16995 and it may (or not) be causing an infinite loop in some cases