### PR TITLE
[WIP] Atomic site: don't show Jetpack version and Manage errors

### DIFF
--- a/client/lib/site/utils.js
+++ b/client/lib/site/utils.js
@@ -62,6 +62,8 @@ export default {
 		if ( ! site ) {
 			return false;
 		}
+
+		return true;
 		if ( ! site.hasMinimumJetpackVersion ) {
 			return false;
 		}
@@ -89,6 +91,8 @@ export default {
 		if ( ! this.canUpdateFiles( site ) ) {
 			return false;
 		}
+
+		return true;
 
 		if ( site.options.file_mod_disabled &&
 			-1 < site.options.file_mod_disabled.indexOf( 'automatic_updater_disabled' ) ) {

--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -406,7 +406,7 @@ const PluginsMain = React.createClass( {
 			);
 		}
 
-		if ( this.props.selectedSiteIsJetpack && ! this.props.canSelectedJetpackSiteManage ) {
+		if ( false ) {
 			return (
 				<Main>
 					{ this.renderDocumentHead() }

--- a/client/my-sites/plugins/plugin-autoupdate-toggle/index.jsx
+++ b/client/my-sites/plugins/plugin-autoupdate-toggle/index.jsx
@@ -77,7 +77,7 @@ export class PluginAutoUpdateToggle extends Component {
 			} );
 		}
 
-		if ( ! site.canAutoupdateFiles && site.options.file_mod_disabled ) {
+		if ( false ) {
 			const reasons = utils.getSiteFileModDisableReason( site, 'autoupdateFiles' );
 			const html = [];
 

--- a/client/my-sites/plugins/plugin-install-button/index.jsx
+++ b/client/my-sites/plugins/plugin-install-button/index.jsx
@@ -97,7 +97,7 @@ export class PluginInstallButton extends Component {
 			} );
 		}
 
-		if ( ! selectedSite.canUpdateFiles && selectedSite.options.file_mod_disabled ) {
+		if ( false ) {
 			const reasons = utils.getSiteFileModDisableReason( selectedSite, 'modifyFiles' );
 			const html = [];
 

--- a/client/my-sites/plugins/plugin-remove-button/index.jsx
+++ b/client/my-sites/plugins/plugin-remove-button/index.jsx
@@ -83,7 +83,7 @@ module.exports = React.createClass( {
 			} );
 		}
 
-		if ( ! this.props.site.canUpdateFiles && this.props.site.options.file_mod_disabled ) {
+		if ( false ) {
 			const reasons = utils.getSiteFileModDisableReason( this.props.site, 'modifyFiles' );
 			const html = [];
 

--- a/client/my-sites/plugins/plugin.jsx
+++ b/client/my-sites/plugins/plugin.jsx
@@ -340,7 +340,7 @@ const SinglePlugin = React.createClass( {
 			return this.getPluginDoesNotExistView( selectedSite );
 		}
 
-		if ( false ) {
+		if ( selectedSite && this.props.isJetpackSite( selectedSite.ID ) && ! this.props.canJetpackSiteManage( selectedSite.ID ) ) {
 			return (
 				<MainComponent>
 					{ this.renderDocumentHead() }

--- a/client/my-sites/plugins/plugin.jsx
+++ b/client/my-sites/plugins/plugin.jsx
@@ -340,7 +340,7 @@ const SinglePlugin = React.createClass( {
 			return this.getPluginDoesNotExistView( selectedSite );
 		}
 
-		if ( selectedSite && this.props.isJetpackSite( selectedSite.ID ) && ! this.props.canJetpackSiteManage( selectedSite.ID ) ) {
+		if ( false ) {
 			return (
 				<MainComponent>
 					{ this.renderDocumentHead() }

--- a/client/my-sites/plugins/plugins-list/index.jsx
+++ b/client/my-sites/plugins/plugins-list/index.jsx
@@ -165,8 +165,8 @@ export const PluginsList = React.createClass( {
 		}
 	},
 
-	hasNoSitesThatCanManage( plugin ) {
-		return ! plugin.sites.some( site => includes( site.modules || [], 'manage' ) );
+	hasNoSitesThatCanManage() {
+		return false;
 	},
 
 	getSelected() {

--- a/client/my-sites/plugins/plugins-list/index.jsx
+++ b/client/my-sites/plugins/plugins-list/index.jsx
@@ -165,8 +165,10 @@ export const PluginsList = React.createClass( {
 		}
 	},
 
-	hasNoSitesThatCanManage() {
-		return false;
+	hasNoSitesThatCanManage( plugin ) {
+		// TODO: I think 'manage' will be there since we prefill the newly created shadow with it.
+		// Remove this comment if true.
+		return ! plugin.sites.some( site => includes( site.modules || [], 'manage' ) );
 	},
 
 	getSelected() {

--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -638,6 +638,8 @@ export function canJetpackSiteUpdateFiles( state, siteId ) {
 		return null;
 	}
 
+	return true;
+
 	if ( ! siteHasMinimumJetpackVersion( state, siteId ) ) {
 		return false;
 	}
@@ -677,6 +679,8 @@ export function canJetpackSiteAutoUpdateFiles( state, siteId ) {
 	if ( ! isJetpackSite( state, siteId ) ) {
 		return null;
 	}
+
+	return true;
 
 	if ( ! canJetpackSiteUpdateFiles( state, siteId ) ) {
 		return false;
@@ -943,6 +947,8 @@ export function siteHasMinimumJetpackVersion( state, siteId ) {
 	if ( ! isJetpackSite( state, siteId ) ) {
 		return null;
 	}
+
+	return true;
 
 	const siteJetpackVersion = getSiteOption( state, siteId, 'jetpack_version' );
 	if ( ! siteJetpackVersion ) {

--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -34,6 +34,7 @@ import versionCompare from 'lib/version-compare';
 import getComputedAttributes from 'lib/site/computed-attributes';
 import { getCustomizerFocus } from 'my-sites/customize/panels';
 import { isSiteUpgradeable } from 'state/selectors';
+import { isSiteAutomatedTransfer } from 'state/selectors';
 
 /**
  * Returns a raw site object by its ID.
@@ -203,6 +204,11 @@ export function isJetpackModuleActive( state, siteId, slug ) {
  * @return {?Boolean}         Whether running minimum version
  */
 export function isJetpackMinimumVersion( state, siteId, version ) {
+	// Skip the checks completely for Atomic sites.
+	if ( isSiteAutomatedTransfer( state, siteId ) ) {
+		return true;
+	}
+
 	const isJetpack = isJetpackSite( state, siteId );
 	if ( ! isJetpack ) {
 		return null;
@@ -609,6 +615,11 @@ export function hasStaticFrontPage( state, siteId ) {
  * @return {?Boolean} if the site can be managed from calypso
  */
 export function canJetpackSiteManage( state, siteId ) {
+	// Skip the checks completely for Atomic sites.
+	if ( isSiteAutomatedTransfer( state, siteId ) ) {
+		return true;
+	}
+
 	// for versions 3.4 and higher, canManage can be determined by the state of the Manage Module
 	const siteJetpackVersion = getSiteOption( state, siteId, 'jetpack_version' );
 
@@ -634,11 +645,14 @@ export function canJetpackSiteManage( state, siteId ) {
  * @return {?Boolean} true if the site can update its file
  */
 export function canJetpackSiteUpdateFiles( state, siteId ) {
+	// Skip the checks completely for Atomic sites.
+	if ( isSiteAutomatedTransfer( state, siteId ) ) {
+		return true;
+	}
+
 	if ( ! isJetpackSite( state, siteId ) ) {
 		return null;
 	}
-
-	return true;
 
 	if ( ! siteHasMinimumJetpackVersion( state, siteId ) ) {
 		return false;
@@ -676,11 +690,14 @@ export function canJetpackSiteUpdateFiles( state, siteId ) {
  * @return {?Boolean} true if the site can auto update
  */
 export function canJetpackSiteAutoUpdateFiles( state, siteId ) {
+	// Skip the checks completely for Atomic sites.
+	if ( isSiteAutomatedTransfer( state, siteId ) ) {
+		return true;
+	}
+
 	if ( ! isJetpackSite( state, siteId ) ) {
 		return null;
 	}
-
-	return true;
 
 	if ( ! canJetpackSiteUpdateFiles( state, siteId ) ) {
 		return false;
@@ -944,11 +961,14 @@ export function getJetpackSiteUpdateFilesDisabledReasons( state, siteId, action 
  * @return {?Boolean} true if the site has minimum jetpack version
  */
 export function siteHasMinimumJetpackVersion( state, siteId ) {
+	// Skip the checks completely for Atomic sites.
+	if ( isSiteAutomatedTransfer( state, siteId ) ) {
+		return true;
+	}
+
 	if ( ! isJetpackSite( state, siteId ) ) {
 		return null;
 	}
-
-	return true;
 
 	const siteJetpackVersion = getSiteOption( state, siteId, 'jetpack_version' );
 	if ( ! siteJetpackVersion ) {


### PR DESCRIPTION
This is an experiment.

Currently, when a WP.com site is transferred with AT, at the end of the transfer process, we run Jetpack full sync and wait until it finishes before marking site as `complete` and unlocking Calypso UI. However, we found out that relying on full Jetpack sync to finish a transfer sometimes causes issues such as transfer not finishing or taking too long.

I was experimenting with this, trying to bypass running Jetpack full sync when transferring a site. It seems to be working great. However, all the data changes confuse Calypso a little and make it show various Jetpack errors (such as not meeting minimum version or "Enable Jetpack Manage") intermittently while transferring and some time after.

After discussing this with the Poseidon team (specially @lezama and @enejb), we concluded that we should just avoid all the checks if a site is an Atomic one. In this PR, I'm not doing that yet. I'm just removing all the checks for all the Jetpack sites to see how it works.

WIP, do not merge

/cc @Automattic/stark @Automattic/lannister 