### PR TITLE
Stats: Remove imported extension code from Core Calypso

### DIFF
--- a/client/my-sites/stats/stats-navigation/index.jsx
+++ b/client/my-sites/stats/stats-navigation/index.jsx
@@ -19,7 +19,6 @@ import SegmentedControl from 'components/segmented-control';
 import QueryJetpackPlugins from 'components/data/query-jetpack-plugins';
 import { isPluginActive } from 'state/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
-import { UNITS as StoreStatsTabs } from 'extensions/woocommerce/app/store-stats/constants';
 import config from 'config';
 
 const StatsNavigation = props => {
@@ -37,7 +36,7 @@ const StatsNavigation = props => {
 	let statsControl;
 
 	if ( isStore ) {
-		const validSection = includes( Object.keys( StoreStatsTabs ), section ) ? section : 'day';
+		const validSection = includes( [ 'day', 'week', 'month', 'year' ], section ) ? section : 'day';
 		statsControl = (
 			<SegmentedControl
 				className="stats-navigation__control is-store"


### PR DESCRIPTION
In order to construct a link from Site Stats to Store Stats, config constants were being imported into StatsNavigation to make sure the tab exists in Store Stats.

### Problem
Importing code from Extensions into Core Calypso sets a bad precedent.

### Fix
Hard code the tabs. This fix is likely to be temporary because Stats navigation is being re-visited from a design perspective, https://github.com/Automattic/wp-calypso/issues/17291