### PR TITLE
Update wpcom-xhr-request to 1.1.1

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1853,7 +1853,7 @@
           "dev": true
         },
         "cli-width": {
-          "version": "2.1.0",
+          "version": "2.2.0",
           "dev": true
         },
         "doctrine": {
@@ -5208,7 +5208,7 @@
           "dev": true
         },
         "cli-width": {
-          "version": "2.1.0",
+          "version": "2.2.0",
           "dev": true
         },
         "doctrine": {
@@ -7023,7 +7023,7 @@
       "version": "4.0.5"
     },
     "wpcom-xhr-request": {
-      "version": "1.1.0"
+      "version": "1.1.1"
     },
     "wrap-ansi": {
       "version": "2.1.0"

--- a/package.json
+++ b/package.json
@@ -163,7 +163,7 @@
     "wpcom": "5.4.0",
     "wpcom-oauth": "0.3.3",
     "wpcom-proxy-request": "4.0.5",
-    "wpcom-xhr-request": "1.1.0"
+    "wpcom-xhr-request": "1.1.1"
   },
   "engines": {
     "node": "6.11.2",


### PR DESCRIPTION
Includes https://github.com/Automattic/wpcom-xhr-request/pull/27 which should allow using the Gravatar upload feature with OAuth enabled (ie: in [wp-desktop](https://github.com/Automattic/wp-desktop)).

This change shouldn't actually effect anything in web Calypso, only when using the desktop app, but we need to get it merged here before it can be used there.

## Testing

1. Load Calypso, and visit http://calypso.localhost:3000/me 
2. Try to upload a new Gravatar image.
3. Make sure it works.