### PR TITLE
Store Orders: Create a new note

### DIFF
--- a/client/extensions/woocommerce/app/order/order-notes/index.js
+++ b/client/extensions/woocommerce/app/order/order-notes/index.js
@@ -13,6 +13,7 @@ import { sortBy, keys } from 'lodash';
  */
 import { areOrderNotesLoaded, getOrderNotes } from 'woocommerce/state/sites/orders/notes/selectors';
 import Card from 'components/card';
+import CreateOrderNote from './new-note';
 import OrderNote from './note';
 import OrderNotesByDay from './day';
 import SectionHeader from 'components/section-header';
@@ -82,7 +83,7 @@ class OrderNotes extends Component {
 	}
 
 	render() {
-		const { areNotesLoaded, translate } = this.props;
+		const { areNotesLoaded, orderId, siteId, translate } = this.props;
 		const classes = classNames( {
 			'is-placeholder': ! areNotesLoaded
 		} );
@@ -95,6 +96,7 @@ class OrderNotes extends Component {
 						? this.renderNotes()
 						: this.renderPlaceholder()
 					}
+					<CreateOrderNote orderId={ orderId } siteId={ siteId } />
 				</Card>
 			</div>
 		);

--- a/client/extensions/woocommerce/app/order/order-notes/new-note.js
+++ b/client/extensions/woocommerce/app/order/order-notes/new-note.js
@@ -1,0 +1,81 @@
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+
+/**
+ * Internal dependencies
+ */
+import { createNote } from 'woocommerce/state/sites/orders/notes/actions';
+import Button from 'components/button';
+import FormFieldSet from 'components/forms/form-fieldset';
+import FormLabel from 'components/forms/form-label';
+import FormTextarea from 'components/forms/form-textarea';
+import FormSelect from 'components/forms/form-select';
+
+class CreateOrderNote extends Component {
+	static propTypes = {
+		orderId: PropTypes.number.isRequired,
+		siteId: PropTypes.number.isRequired,
+	}
+
+	state = {
+		note: '',
+		type: 'internal',
+	}
+
+	setNote = ( event ) => {
+		this.setState( {
+			note: event.target.value,
+		} );
+	}
+
+	setType = ( event ) => {
+		this.setState( {
+			type: event.target.value,
+		} );
+	}
+
+	saveNote = () => {
+		const { orderId, siteId } = this.props;
+		const note = {
+			note: this.state.note,
+			customer_note: 'email' === this.state.type,
+		};
+		this.props.createNote( siteId, orderId, note );
+		this.setState( { note: '' } );
+	}
+
+	render() {
+		const { translate } = this.props;
+
+		return (
+			<div className="order-notes__new-note">
+				<FormFieldSet className="order-notes__new-note-content">
+					<FormLabel htmlFor="note">{ translate( 'Add a note' ) }</FormLabel>
+					<FormTextarea
+						id="note"
+						value={ this.state.note }
+						onChange={ this.setNote }
+					/>
+				</FormFieldSet>
+				<FormFieldSet className="order-notes__new-note-type">
+					<FormSelect onChange={ this.setType } value={ this.state.type }>
+						<option value={ 'internal' }>{ translate( 'Private Note' ) }</option>
+						<option value={ 'email' }>{ translate( 'Send to Customer' ) }</option>
+					</FormSelect>
+				</FormFieldSet>
+				<Button primary onClick={ this.saveNote }>{ translate( 'Add Note' ) }</Button>
+			</div>
+		);
+	}
+}
+
+export default connect(
+	undefined,
+	dispatch => bindActionCreators( { createNote }, dispatch )
+)( localize( CreateOrderNote ) );

--- a/client/extensions/woocommerce/app/order/order-notes/new-note.js
+++ b/client/extensions/woocommerce/app/order/order-notes/new-note.js
@@ -63,13 +63,13 @@ class CreateOrderNote extends Component {
 						onChange={ this.setNote }
 					/>
 				</FormFieldSet>
-				<FormFieldSet className="order-notes__new-note-type">
+				<div className="order-notes__new-note-type">
 					<FormSelect onChange={ this.setType } value={ this.state.type }>
 						<option value={ 'internal' }>{ translate( 'Private Note' ) }</option>
 						<option value={ 'email' }>{ translate( 'Send to Customer' ) }</option>
 					</FormSelect>
-				</FormFieldSet>
-				<Button primary onClick={ this.saveNote }>{ translate( 'Add Note' ) }</Button>
+					<Button primary onClick={ this.saveNote }>{ translate( 'Add Note' ) }</Button>
+				</div>
 			</div>
 		);
 	}

--- a/client/extensions/woocommerce/app/order/order-notes/new-note.js
+++ b/client/extensions/woocommerce/app/order/order-notes/new-note.js
@@ -13,9 +13,11 @@ import PropTypes from 'prop-types';
 import Button from 'components/button';
 import { createNote } from 'woocommerce/state/sites/orders/notes/actions';
 import FormFieldSet from 'components/forms/form-fieldset';
+import FormLabel from 'components/forms/form-label';
 import FormTextarea from 'components/forms/form-textarea';
 import FormSelect from 'components/forms/form-select';
 import { isOrderNoteSaving } from 'woocommerce/state/sites/orders/notes/selectors';
+import ScreenReaderText from 'components/screen-reader-text';
 
 class CreateOrderNote extends Component {
 	static propTypes = {
@@ -59,6 +61,7 @@ class CreateOrderNote extends Component {
 		return (
 			<div className="order-notes__new-note">
 				<FormFieldSet className="order-notes__new-note-content">
+					<ScreenReaderText><FormLabel htmlFor="note">{ translate( 'Add a note' ) }</FormLabel></ScreenReaderText>
 					<FormTextarea
 						id="note"
 						value={ this.state.note }

--- a/client/extensions/woocommerce/app/order/order-notes/new-note.js
+++ b/client/extensions/woocommerce/app/order/order-notes/new-note.js
@@ -13,7 +13,6 @@ import PropTypes from 'prop-types';
 import Button from 'components/button';
 import { createNote } from 'woocommerce/state/sites/orders/notes/actions';
 import FormFieldSet from 'components/forms/form-fieldset';
-import FormLabel from 'components/forms/form-label';
 import FormTextarea from 'components/forms/form-textarea';
 import FormSelect from 'components/forms/form-select';
 import { isOrderNoteSaving } from 'woocommerce/state/sites/orders/notes/selectors';
@@ -60,11 +59,11 @@ class CreateOrderNote extends Component {
 		return (
 			<div className="order-notes__new-note">
 				<FormFieldSet className="order-notes__new-note-content">
-					<FormLabel htmlFor="note">{ translate( 'Add a note' ) }</FormLabel>
 					<FormTextarea
 						id="note"
 						value={ this.state.note }
 						onChange={ this.setNote }
+						placeholder={ translate( 'Add a note' ) }
 					/>
 				</FormFieldSet>
 				<div className="order-notes__new-note-type">

--- a/client/extensions/woocommerce/app/order/order-notes/new-note.js
+++ b/client/extensions/woocommerce/app/order/order-notes/new-note.js
@@ -10,12 +10,13 @@ import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
-import { createNote } from 'woocommerce/state/sites/orders/notes/actions';
 import Button from 'components/button';
+import { createNote } from 'woocommerce/state/sites/orders/notes/actions';
 import FormFieldSet from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
 import FormTextarea from 'components/forms/form-textarea';
 import FormSelect from 'components/forms/form-select';
+import { isOrderNoteSaving } from 'woocommerce/state/sites/orders/notes/selectors';
 
 class CreateOrderNote extends Component {
 	static propTypes = {
@@ -42,6 +43,9 @@ class CreateOrderNote extends Component {
 
 	saveNote = () => {
 		const { orderId, siteId } = this.props;
+		if ( ! this.state.note ) {
+			return;
+		}
 		const note = {
 			note: this.state.note,
 			customer_note: 'email' === this.state.type,
@@ -51,7 +55,7 @@ class CreateOrderNote extends Component {
 	}
 
 	render() {
-		const { translate } = this.props;
+		const { isNoteSaving, translate } = this.props;
 
 		return (
 			<div className="order-notes__new-note">
@@ -68,7 +72,13 @@ class CreateOrderNote extends Component {
 						<option value={ 'internal' }>{ translate( 'Private Note' ) }</option>
 						<option value={ 'email' }>{ translate( 'Send to Customer' ) }</option>
 					</FormSelect>
-					<Button primary onClick={ this.saveNote }>{ translate( 'Add Note' ) }</Button>
+					<Button
+						primary
+						onClick={ this.saveNote }
+						busy={ isNoteSaving }
+						disabled={ isNoteSaving }>
+						{ translate( 'Add Note' ) }
+					</Button>
 				</div>
 			</div>
 		);
@@ -76,6 +86,8 @@ class CreateOrderNote extends Component {
 }
 
 export default connect(
-	undefined,
+	( state, props ) => ( {
+		isNoteSaving: isOrderNoteSaving( state, props.orderId )
+	} ),
 	dispatch => bindActionCreators( { createNote }, dispatch )
 )( localize( CreateOrderNote ) );

--- a/client/extensions/woocommerce/app/order/order-notes/style.scss
+++ b/client/extensions/woocommerce/app/order/order-notes/style.scss
@@ -91,9 +91,13 @@
 }
 
 .order-notes__new-note-content {
-	margin: 0 -24px 20px;
-	padding-top: 8px;
-	border-top: 1px solid transparentize( lighten( $gray, 20% ), .5 );
+	margin: 0 -15px 16px;
+	border: 1px solid $border-ultra-light-gray;
+	border-width: 1px 0;
+
+	@include breakpoint( ">480px" ) {
+		margin: 0 -24px 24px;
+	}
 
 	.form-label {
 		padding: 0 24px;
@@ -101,11 +105,18 @@
 	}
 
 	.form-textarea {
-		padding: 8px 24px;
-		border-color: transparentize( lighten( $gray, 20% ), .5 );
-		border-left: none;
-		border-right: none;
+		padding: 16px;
+		border-color: $white;
 		resize: vertical;
+		display: block;
+
+		&:focus {
+			border-color: $blue-wordpress;
+		}
+
+		@include breakpoint( ">480px" ) {
+			padding: 16px 24px;
+		}
 	}
 }
 

--- a/client/extensions/woocommerce/app/order/order-notes/style.scss
+++ b/client/extensions/woocommerce/app/order/order-notes/style.scss
@@ -109,6 +109,11 @@
 		border-color: $white;
 		resize: vertical;
 		display: block;
+		font-size: 14px;
+
+		&::placeholder {
+			color: $gray-text-min;
+		}
 
 		&:focus {
 			border-color: $blue-wordpress;

--- a/client/extensions/woocommerce/app/order/order-notes/style.scss
+++ b/client/extensions/woocommerce/app/order/order-notes/style.scss
@@ -1,3 +1,12 @@
+.foldable-card.card.order-notes__day-header,
+.foldable-card.card.order-notes__day-header.is-expanded {
+	margin: 0 0 16px;
+
+	@include breakpoint( ">480px" ) {
+		margin: 0 0 24px;
+	}
+}
+
 .order-notes__day .foldable-card__content {
 	position: relative;
 	z-index: 0;

--- a/client/extensions/woocommerce/app/order/order-notes/style.scss
+++ b/client/extensions/woocommerce/app/order/order-notes/style.scss
@@ -18,7 +18,7 @@
 		top: 0;
 		left: 45px;
 		bottom: 0;
-		width: 2px;
+		width: 1px;
 		background: transparentize( lighten( $gray, 20% ), .5 );
 	}
 }

--- a/client/extensions/woocommerce/app/order/order-notes/style.scss
+++ b/client/extensions/woocommerce/app/order/order-notes/style.scss
@@ -80,3 +80,28 @@
 		margin: 8px 8px 0 0;
 	}
 }
+
+.order-notes__new-note-content {
+	margin: 0 -24px 20px;
+	padding-top: 8px;
+	border-top: 1px solid transparentize( lighten( $gray, 20% ), .5 );
+
+	.form-label {
+		padding: 0 24px;
+		margin-bottom: 8px;
+	}
+
+	.form-textarea {
+		padding: 8px 24px;
+		border-color: transparentize( lighten( $gray, 20% ), .5 );
+		border-left: none;
+		border-right: none;
+		resize: vertical;
+	}
+}
+
+.order-notes__new-note-type {
+	.button {
+		float: right;
+	}
+}


### PR DESCRIPTION
Fixes #13686

This PR adds a textarea to the Activity Log section, for adding notes to an order:

<img width="487" alt="screen shot 2017-08-22 at 4 17 43 pm" src="https://user-images.githubusercontent.com/541093/29585621-cd75de9a-8755-11e7-919a-f490e437ea55.png">

The mockup had this as a TinyMCE input, but we don't show HTML in the notes field, so I've left it as a plain text input. The user can also select "Private Note" or "Send to Customer", if the latter it emails the note using the core note functionality.

This could probably use designer tweaks 🙂 

**To test**

- View an order
- Check that your notes display
- Add a custom note by entering text into the box and hitting "Add Note"
- The button goes "busy", then your note should appear in the activity log.
- Add a custom note and pick "Send to Customer", check that once saved, your note is emailed.