### PR TITLE
Reader conversations: apply heavy handed excerpts to conversations

### DIFF
--- a/client/blocks/conversations/list.jsx
+++ b/client/blocks/conversations/list.jsx
@@ -9,7 +9,7 @@ import { map } from 'lodash';
 /***
  * Internal dependencies
  */
-import PostComment from 'blocks/comments/post-comment';
+import PostComment, { POST_COMMENT_DISPLAY_TYPES } from 'blocks/comments/post-comment';
 import { getPostCommentsTree } from 'state/comments/selectors';
 import ConversationCaterpillar from 'blocks/conversation-caterpillar';
 
@@ -41,6 +41,7 @@ export class ConversationCommentList extends React.Component {
 								commentId={ commentId }
 								maxChildrenToShow={ 0 }
 								post={ post }
+								displayType={ POST_COMMENT_DISPLAY_TYPES.excerpt }
 							/>
 						);
 					} ) }

--- a/client/blocks/reader-post-card/compact.jsx
+++ b/client/blocks/reader-post-card/compact.jsx
@@ -13,10 +13,10 @@ import ReaderExcerpt from 'blocks/reader-excerpt';
 import ReaderPostOptionsMenu from 'blocks/reader-post-options-menu';
 import FeaturedAsset from './featured-asset';
 
-const CompactPost = ( { post, postByline, children, isDiscover } ) => {
+const CompactPost = ( { post, postByline, children, isDiscover, onClick } ) => {
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	return (
-		<div className="reader-post-card__post">
+		<div className="reader-post-card__post" onClick={ onClick }>
 			<FeaturedAsset
 				canonicalMedia={ post.canonical_media }
 				postUrl={ post.URL }

--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -205,6 +205,7 @@ class ReaderPostCard extends React.Component {
 					isDiscover={ isDiscover }
 					postByline={ postByline }
 					commentIds={ postKey.comments }
+					onClick={ this.handleCardClick }
 				/>
 			);
 		} else if ( isPhotoPost ) {
@@ -251,7 +252,7 @@ class ReaderPostCard extends React.Component {
 		const followUrl = feed ? feed.feed_URL : post.site_URL;
 
 		return (
-			<Card className={ classes } onClick={ ! isPhotoPost && this.handleCardClick }>
+			<Card className={ classes } onClick={ ! isPhotoPost && ! compact && this.handleCardClick }>
 				{ ! compact && postByline }
 				{ showPrimaryFollowButton &&
 					followUrl &&


### PR DESCRIPTION
Using the new PostComment additions from https://github.com/Automattic/wp-calypso/pull/17225, apply excerpt styling to all top-level PostComments within convos

In later PRs the actual PostComment displayType will be gathered from redux.  This is just to get a feel for how the render in actual convo streams.

Changes introduced:
1. clickHandler only applies to comment header
2. excerpt style applied to top-level comments of convo tool