### PR TITLE
Simplify the implementation of ReduxForm components

### DIFF
--- a/client/components/redux-forms/redux-form-fieldset/index.jsx
+++ b/client/components/redux-forms/redux-form-fieldset/index.jsx
@@ -19,7 +19,7 @@ import FormSettingExplanation from 'components/forms/form-setting-explanation';
  * It accepts props that are compatible with what Redux Form `Field` passes down to renderers.
  * See the `Field` documentation for info about the props.
  */
-export const RenderFieldset = ( {
+export const FieldsetRenderer = ( {
 	inputComponent: InputComponent,
 	input,
 	meta,
@@ -50,7 +50,7 @@ export const RenderFieldset = ( {
  *   <ReduxFormFieldset name="firstName" label="First Name" component={ FormTextInput } />
  */
 const ReduxFormFieldset = ( { component, ...props } ) =>
-	<Field component={ RenderFieldset } inputComponent={ component } { ...props } />;
+	<Field component={ FieldsetRenderer } inputComponent={ component } { ...props } />;
 
 ReduxFormFieldset.propTypes = {
 	name: PropTypes.string.isRequired, // name of the Redux Form field to connect to

--- a/client/components/redux-forms/redux-form-radio/index.jsx
+++ b/client/components/redux-forms/redux-form-radio/index.jsx
@@ -1,43 +1,24 @@
+/** @format */
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { Field } from 'redux-form';
-import { omit } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import FormRadio from 'components/forms/form-radio';
 
-class ReduxFormRadio extends Component {
-	static propTypes = {
-		name: PropTypes.string,
-		value: PropTypes.string,
-	};
+// eslint-disable-next-line no-unused-vars
+const RenderRadio = ( { input, meta, type, ...props } ) => <FormRadio { ...input } { ...props } />;
 
-	renderRadio = defaultValue => ( { input: { name, onChange, value } } ) => {
-		const otherProps = omit( this.props, [ 'name', 'value' ] );
+const ReduxFormRadio = props => <Field component={ RenderRadio } type="radio" { ...props } />;
 
-		return (
-			<FormRadio
-				{ ...otherProps }
-				checked={ value === defaultValue }
-				name={ name }
-				onChange={ this.updateRadio( onChange ) }
-				value={ defaultValue } />
-		);
-	}
-
-	updateRadio = onChange => event => onChange( event.target.value );
-
-	render() {
-		return (
-			<Field
-				component={ this.renderRadio( this.props.value ) }
-				name={ this.props.name } />
-		);
-	}
-}
+ReduxFormRadio.propTypes = {
+	name: PropTypes.string.isRequired,
+	value: PropTypes.string.isRequired,
+};
 
 export default ReduxFormRadio;

--- a/client/components/redux-forms/redux-form-radio/index.jsx
+++ b/client/components/redux-forms/redux-form-radio/index.jsx
@@ -12,9 +12,10 @@ import { Field } from 'redux-form';
 import FormRadio from 'components/forms/form-radio';
 
 // eslint-disable-next-line no-unused-vars
-const RenderRadio = ( { input, meta, type, ...props } ) => <FormRadio { ...input } { ...props } />;
+const RadioRenderer = ( { input, meta, type, ...props } ) =>
+	<FormRadio { ...input } { ...props } />;
 
-const ReduxFormRadio = props => <Field component={ RenderRadio } type="radio" { ...props } />;
+const ReduxFormRadio = props => <Field component={ RadioRenderer } type="radio" { ...props } />;
 
 ReduxFormRadio.propTypes = {
 	name: PropTypes.string.isRequired,

--- a/client/components/redux-forms/redux-form-select/index.jsx
+++ b/client/components/redux-forms/redux-form-select/index.jsx
@@ -12,9 +12,9 @@ import { Field } from 'redux-form';
 import FormSelect from 'components/forms/form-select';
 
 // eslint-disable-next-line no-unused-vars
-const RenderSelect = ( { input, meta, ...props } ) => <FormSelect { ...input } { ...props } />;
+const SelectRenderer = ( { input, meta, ...props } ) => <FormSelect { ...input } { ...props } />;
 
-const ReduxFormSelect = props => <Field component={ RenderSelect } { ...props } />;
+const ReduxFormSelect = props => <Field component={ SelectRenderer } { ...props } />;
 
 ReduxFormSelect.propTypes = {
 	name: PropTypes.string.isRequired,

--- a/client/components/redux-forms/redux-form-select/index.jsx
+++ b/client/components/redux-forms/redux-form-select/index.jsx
@@ -1,41 +1,23 @@
+/** @format */
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { Field } from 'redux-form';
-import { omit } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import FormSelect from 'components/forms/form-select';
 
-class ReduxFormSelect extends Component {
-	static propTypes = {
-		name: PropTypes.string.isRequired,
-	};
+// eslint-disable-next-line no-unused-vars
+const RenderSelect = ( { input, meta, ...props } ) => <FormSelect { ...input } { ...props } />;
 
-	renderSelect = ( { input: { onChange, value } } ) => {
-		const otherProps = omit( this.props, 'name' );
+const ReduxFormSelect = props => <Field component={ RenderSelect } { ...props } />;
 
-		return (
-			<FormSelect
-				{ ...otherProps }
-				onChange={ this.updateSelect( onChange ) }
-				value={ value } />
-		);
-	}
-
-	updateSelect = onChange => event => onChange( event.target.value );
-
-	render() {
-		return (
-			<Field
-				{ ...this.props }
-				component={ this.renderSelect }
-				name={ this.props.name } />
-		);
-	}
-}
+ReduxFormSelect.propTypes = {
+	name: PropTypes.string.isRequired,
+};
 
 export default ReduxFormSelect;

--- a/client/components/redux-forms/redux-form-text-input/index.jsx
+++ b/client/components/redux-forms/redux-form-text-input/index.jsx
@@ -12,10 +12,10 @@ import { Field } from 'redux-form';
 import FormTextInput from 'components/forms/form-text-input';
 
 // eslint-disable-next-line no-unused-vars
-const RenderFormTextInput = ( { input, meta, ...props } ) =>
+const TextInputRenderer = ( { input, meta, ...props } ) =>
 	<FormTextInput { ...input } { ...props } />;
 
-const ReduxFormTextInput = props => <Field component={ RenderFormTextInput } { ...props } />;
+const ReduxFormTextInput = props => <Field component={ TextInputRenderer } { ...props } />;
 
 ReduxFormTextInput.propTypes = {
 	name: PropTypes.string.isRequired,

--- a/client/components/redux-forms/redux-form-text-input/index.jsx
+++ b/client/components/redux-forms/redux-form-text-input/index.jsx
@@ -1,41 +1,24 @@
+/** @format */
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { Field } from 'redux-form';
-import { omit } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import FormTextInput from 'components/forms/form-text-input';
 
-class ReduxFormTextInput extends Component {
-	static propTypes = {
-		name: PropTypes.string,
-	};
+// eslint-disable-next-line no-unused-vars
+const RenderFormTextInput = ( { input, meta, ...props } ) =>
+	<FormTextInput { ...input } { ...props } />;
 
-	renderTextInput = ( { input: { onChange, value } } ) => {
-		const otherProps = omit( this.props, 'name' );
+const ReduxFormTextInput = props => <Field component={ RenderFormTextInput } { ...props } />;
 
-		return (
-			<FormTextInput
-				{ ...otherProps }
-				onChange={ this.updateTextInput( onChange ) }
-				value={ value } />
-		);
-	}
-
-	updateTextInput = onChange => event => onChange( event.target.value );
-
-	render() {
-		return (
-			<Field
-				{ ...this.props }
-				component={ this.renderTextInput }
-				name={ this.props.name } />
-		);
-	}
-}
+ReduxFormTextInput.propTypes = {
+	name: PropTypes.string.isRequired,
+};
 
 export default ReduxFormTextInput;

--- a/client/components/redux-forms/redux-form-textarea/index.jsx
+++ b/client/components/redux-forms/redux-form-textarea/index.jsx
@@ -12,9 +12,10 @@ import { Field } from 'redux-form';
 import FormTextarea from 'components/forms/form-textarea';
 
 // eslint-disable-next-line no-unused-vars
-const RenderTextarea = ( { input, meta, ...props } ) => <FormTextarea { ...input } { ...props } />;
+const TextareaRenderer = ( { input, meta, ...props } ) =>
+	<FormTextarea { ...input } { ...props } />;
 
-const ReduxFormTextarea = props => <Field component={ RenderTextarea } { ...props } />;
+const ReduxFormTextarea = props => <Field component={ TextareaRenderer } { ...props } />;
 
 ReduxFormTextarea.propTypes = {
 	name: PropTypes.string.isRequired,

--- a/client/components/redux-forms/redux-form-textarea/index.jsx
+++ b/client/components/redux-forms/redux-form-textarea/index.jsx
@@ -1,7 +1,9 @@
+/** @format */
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { Field } from 'redux-form';
 
 /**
@@ -10,15 +12,9 @@ import { Field } from 'redux-form';
 import FormTextarea from 'components/forms/form-textarea';
 
 // eslint-disable-next-line no-unused-vars
-const RenderTextarea = ( { input, meta, type, ...otherProps } ) => {
-	return (
-		<FormTextarea { ...input } { ...otherProps } />
-	);
-};
+const RenderTextarea = ( { input, meta, ...props } ) => <FormTextarea { ...input } { ...props } />;
 
-const ReduxFormTextarea = ( props ) => (
-	<Field component={ RenderTextarea } type="text" { ...props } />
-);
+const ReduxFormTextarea = props => <Field component={ RenderTextarea } { ...props } />;
 
 ReduxFormTextarea.propTypes = {
 	name: PropTypes.string.isRequired,

--- a/client/components/redux-forms/redux-form-toggle/index.jsx
+++ b/client/components/redux-forms/redux-form-toggle/index.jsx
@@ -10,7 +10,7 @@ import { Field } from 'redux-form';
 import FormToggle from 'components/forms/form-toggle/compact';
 
 // eslint-disable-next-line no-unused-vars
-const RenderToggle = ( { input, meta, text, type, ...otherProps } ) => (
+const ToggleRenderer = ( { input, meta, text, type, ...otherProps } ) => (
 	<FormToggle { ...input } { ...otherProps }>
 		{ text }
 	</FormToggle>
@@ -23,7 +23,7 @@ class ReduxFormToggle extends Component {
 	};
 
 	render() {
-		return <Field component={ RenderToggle } type="checkbox" { ...this.props } />;
+		return <Field component={ ToggleRenderer } type="checkbox" { ...this.props } />;
 	}
 }
 

--- a/client/components/tinymce/plugins/simple-payments/dialog/form.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/form.jsx
@@ -18,7 +18,7 @@ import FormTextInput from 'components/forms/form-text-input';
 import FormTextarea from 'components/forms/form-textarea';
 import FormCurrencyInput from 'components/forms/form-currency-input';
 import CompactFormToggle from 'components/forms/form-toggle/compact';
-import ReduxFormFieldset, { RenderFieldset } from 'components/redux-forms/redux-form-fieldset';
+import ReduxFormFieldset, { FieldsetRenderer } from 'components/redux-forms/redux-form-fieldset';
 import UploadImage from 'blocks/upload-image';
 import { getCurrencyDefaults } from 'lib/format-currency';
 
@@ -154,7 +154,7 @@ const renderPriceField = ( { price, currency, ...props } ) => {
 	// Tune the placeholder to the precision value: 0 -> '0', 1 -> '0.0', 2 -> '0.00'
 	const placeholder = precision > 0 ? padEnd( '0.', precision + 2, '0' ) : '0';
 	return (
-		<RenderFieldset
+		<FieldsetRenderer
 			inputComponent={ FormCurrencyInput }
 			{ ...price }
 			{ ...props }


### PR DESCRIPTION
This PR is very similar to #16131 and simplifies the implementation of the Redux Form wrappers for ReduxFormRadio, ReduxFormSelect and ReduxFormTextInput. It does a few little changes to ReduxFormTextarea, too.

The Calypso `Form*` components have an API compatible with native HTML `<input>` elements, and Redux Form can wrap these with very little boilerplate. See the description of #16131 for more info about it -- it could be copy&pasted verbatim to this PR as well.

When we pass `type="radio"` prop to the Redux Form `<Field>` component, it will pass the right `input` props to the wrapper, taking into account that radio is somewhat special: it has both `value` and `checked` fields, where `value` is constant and `checked` changes on click.

**How to test:**
Go to `/extensions/wp-job-manager` and test the 'Job Listings' and 'Job Submission' tabs that are implemented using Redux Form. Click on the various form fields and check that the form values are updates as expected. I used Redux devtools extension to check the dispatched actions and the state.
