### PR TITLE
Fixed wrong option name

### DIFF
--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -212,7 +212,7 @@ function setUpLoggedInRoute( req, res, next ) {
 
 		redirectUrl = login( {
 			isNative: config.isEnabled( 'login/native-login-links' ),
-			redirect_to: protocol + '://' + config( 'hostname' ) + req.originalUrl
+			redirectTo: protocol + '://' + config( 'hostname' ) + req.originalUrl
 		} );
 
 		// if we don't have a wordpress cookie, we know the user needs to


### PR DESCRIPTION
props @pento for fixing #17444 
 
  
#### Testing instructions
  
1. Run `git checkout fix/logged-out-user-redirect` and start your server, or open a [live branch](https://calypso.live/?branch=fix/logged-out-user-redirect)
2. Open the [`Me` page](http://calypso.localhost:3000/me/)
3. Check that you're redirected with `redirect_to` param.
  
#### Reviews
  
- [x] Code
- [x] Product
