### PR TITLE
WPSC: Bump minimum required version to 1.5.4

### DIFF
--- a/client/extensions/wp-super-cache/app/main.jsx
+++ b/client/extensions/wp-super-cache/app/main.jsx
@@ -66,7 +66,7 @@ class WPSuperCache extends Component {
 		return (
 			<Main className={ mainClassName }>
 				<ExtensionRedirect pluginId="wp-super-cache"
-					minimumVersion="1.5.3"
+					minimumVersion="1.5.4"
 					siteId={ siteId } />
 				<QueryStatus siteId={ siteId } />
 


### PR DESCRIPTION
To include the latest REST API fixes to issues found by Horizon testers.

Merge only after actually releasing 1.5.4! :slightly_smiling_face: 