### PR TITLE
Query manager: Make matches method static

### DIFF
--- a/client/lib/query-manager/README.md
+++ b/client/lib/query-manager/README.md
@@ -44,10 +44,13 @@ Currently, the following implementations exist:
 
 Depending on the level of customization you need, you'll likely only need to implement the `matches` and `compare` (or possibly `sort`) methods.
 
-- `matches( query: object, item: object )` should return true if the passed item should be included in the query set
+- `matches( query: object, item: object )`: This **`static`** method should return true if the passed item should be included in the query set.
 - `compare( itemA: object, itemB: object )` is a sort comparator function, returning -1 to indicate "A before B", 1 to indicate "A after B", or 0 to indicate equality ([see `Array.prototype.sort`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort)). Note that the latter doesn't work in all browsers and environments!
-- `sort( keys: array, items: array, query: object )` is a sorting function that sorts `keys` by comparing their corresponding `items`. It will normally just use `compare` for the comparison. Its main purpose is to allow for a `QueryManager` to leave
-the order of keys unchanged (and rely on the REST API for ordering) by overriding it with a function that just returns the untouched `keys` argument. This wouldn't be feasible by overloading `compare`, since `Array.prototype.sort` isn't guaranteed to be a stable sort; in some environments ([such as Chrome and node!](https://bugs.chromium.org/p/v8/issues/detail?id=90)), it will change the order of the array's items even if the compare function always returns zero.
+- `sort( keys: array, items: array, query: object )` is a sorting function that sorts `keys` by comparing their corresponding `items`.
+It will normally just use `compare` for the comparison.
+Its main purpose is to allow for a `QueryManager` to leave the order of keys unchanged (and rely on the REST API for ordering) by overriding it with a function that just returns the untouched `keys` argument.
+This wouldn't be feasible by overloading `compare`, since `Array.prototype.sort` isn't guaranteed to be a stable sort;
+in some environments ([such as Chrome and node!](https://bugs.chromium.org/p/v8/issues/detail?id=90)), it will change the order of the array's items even if the compare function always returns zero.
 
 Sometimes you may need to make further customizations. Some examples include:
 

--- a/client/lib/query-manager/index.js
+++ b/client/lib/query-manager/index.js
@@ -74,7 +74,7 @@ export default class QueryManager {
 	 * @param  {Object}  item  Item to consider
 	 * @return {Boolean}       Whether item matches query
 	 */
-	matches( query, item ) {
+	static matches( query, item ) {
 		return !! item;
 	}
 
@@ -326,7 +326,7 @@ export default class QueryManager {
 				if ( -1 !== index ) {
 					// Item already exists in query, check to see whether the
 					// updated item is being removed or no longer matches
-					if ( ! updatedItem || ! this.matches( query, updatedItem ) ) {
+					if ( ! updatedItem || ! this.constructor.matches( query, updatedItem ) ) {
 						// Create a copy of the original details to avoid mutating
 						if ( memo[ queryKey ] === queryDetails ) {
 							memo[ queryKey ] = cloneDeep( queryDetails );
@@ -343,7 +343,7 @@ export default class QueryManager {
 							memo[ queryKey ].found--;
 						}
 					}
-				} else if ( updatedItem && this.matches( query, updatedItem ) ) {
+				} else if ( updatedItem && this.constructor.matches( query, updatedItem ) ) {
 					// Item doesn't currently exist in query but is a match, so
 					// insert item into set
 

--- a/client/lib/query-manager/media/index.js
+++ b/client/lib/query-manager/media/index.js
@@ -23,7 +23,7 @@ export default class MediaQueryManager extends PaginatedQueryManager {
 	 * @param  {Object}  media Item to consider
 	 * @return {Boolean}       Whether media item matches query
 	 */
-	matches( query, media ) {
+	static matches( query, media ) {
 		return every( { ...DEFAULT_MEDIA_QUERY, ...query }, ( value, key ) => {
 			switch ( key ) {
 				case 'search':

--- a/client/lib/query-manager/media/test/index.js
+++ b/client/lib/query-manager/media/test/index.js
@@ -41,7 +41,7 @@ describe( 'MediaQueryManager', () => {
 	describe( '#matches()', () => {
 		context( 'query.search', () => {
 			it( 'should return false for a non-matching search', () => {
-				const isMatch = manager.matches( {
+				const isMatch = MediaQueryManager.matches( {
 					search: 'Cars'
 				}, DEFAULT_MEDIA );
 
@@ -49,7 +49,7 @@ describe( 'MediaQueryManager', () => {
 			} );
 
 			it( 'should return true for an empty search', () => {
-				const isMatch = manager.matches( {
+				const isMatch = MediaQueryManager.matches( {
 					search: ''
 				}, DEFAULT_MEDIA );
 
@@ -57,7 +57,7 @@ describe( 'MediaQueryManager', () => {
 			} );
 
 			it( 'should return true for a matching title search', () => {
-				const isMatch = manager.matches( {
+				const isMatch = MediaQueryManager.matches( {
 					search: 'lower'
 				}, DEFAULT_MEDIA );
 
@@ -65,7 +65,7 @@ describe( 'MediaQueryManager', () => {
 			} );
 
 			it( 'should search case-insensitive', () => {
-				const isMatch = manager.matches( {
+				const isMatch = MediaQueryManager.matches( {
 					search: 'fLoWeR'
 				}, DEFAULT_MEDIA );
 
@@ -75,7 +75,7 @@ describe( 'MediaQueryManager', () => {
 
 		context( 'query.mime_type', () => {
 			it( 'should return true for an empty mime type', () => {
-				const isMatch = manager.matches( {
+				const isMatch = MediaQueryManager.matches( {
 					mime_type: ''
 				}, DEFAULT_MEDIA );
 
@@ -83,7 +83,7 @@ describe( 'MediaQueryManager', () => {
 			} );
 
 			it( 'should return true an exact match', () => {
-				const isMatch = manager.matches( {
+				const isMatch = MediaQueryManager.matches( {
 					mime_type: 'image/gif'
 				}, DEFAULT_MEDIA );
 
@@ -91,7 +91,7 @@ describe( 'MediaQueryManager', () => {
 			} );
 
 			it( 'should return true for mime subgroup exact match', () => {
-				const isMatch = manager.matches( {
+				const isMatch = MediaQueryManager.matches( {
 					mime_type: 'image'
 				}, DEFAULT_MEDIA );
 
@@ -99,7 +99,7 @@ describe( 'MediaQueryManager', () => {
 			} );
 
 			it( 'should return true for mime subgroup exact match with trailing slash', () => {
-				const isMatch = manager.matches( {
+				const isMatch = MediaQueryManager.matches( {
 					mime_type: 'image/'
 				}, DEFAULT_MEDIA );
 
@@ -107,7 +107,7 @@ describe( 'MediaQueryManager', () => {
 			} );
 
 			it( 'should return false for mime subgroup partial match', () => {
-				const isMatch = manager.matches( {
+				const isMatch = MediaQueryManager.matches( {
 					mime_type: 'imag'
 				}, DEFAULT_MEDIA );
 
@@ -115,7 +115,7 @@ describe( 'MediaQueryManager', () => {
 			} );
 
 			it( 'should return false for mime group partial match', () => {
-				const isMatch = manager.matches( {
+				const isMatch = MediaQueryManager.matches( {
 					mime_type: 'image/gi'
 				}, DEFAULT_MEDIA );
 
@@ -123,7 +123,7 @@ describe( 'MediaQueryManager', () => {
 			} );
 
 			it( 'should return true for wildcard match', () => {
-				const isMatch = manager.matches( {
+				const isMatch = MediaQueryManager.matches( {
 					mime_type: '%'
 				}, DEFAULT_MEDIA );
 
@@ -131,7 +131,7 @@ describe( 'MediaQueryManager', () => {
 			} );
 
 			it( 'should return false for mime subgroup wildcard match', () => {
-				const isMatch = manager.matches( {
+				const isMatch = MediaQueryManager.matches( {
 					mime_type: '%/gif'
 				}, DEFAULT_MEDIA );
 
@@ -139,7 +139,7 @@ describe( 'MediaQueryManager', () => {
 			} );
 
 			it( 'should return true for mime group wildcard match', () => {
-				const isMatch = manager.matches( {
+				const isMatch = MediaQueryManager.matches( {
 					mime_type: 'image/%'
 				}, DEFAULT_MEDIA );
 
@@ -147,7 +147,7 @@ describe( 'MediaQueryManager', () => {
 			} );
 
 			it( 'should return false for mime subgroup partial wildcard match', () => {
-				const isMatch = manager.matches( {
+				const isMatch = MediaQueryManager.matches( {
 					mime_type: 'ima%/%'
 				}, DEFAULT_MEDIA );
 
@@ -155,7 +155,7 @@ describe( 'MediaQueryManager', () => {
 			} );
 
 			it( 'should return false for mime group partial wildcard match', () => {
-				const isMatch = manager.matches( {
+				const isMatch = MediaQueryManager.matches( {
 					mime_type: 'image/gi%'
 				}, DEFAULT_MEDIA );
 
@@ -165,7 +165,7 @@ describe( 'MediaQueryManager', () => {
 
 		context( 'query.post_ID', () => {
 			it( 'should return false if post ID does not match', () => {
-				const isMatch = manager.matches( {
+				const isMatch = MediaQueryManager.matches( {
 					post_ID: 0
 				}, DEFAULT_MEDIA );
 
@@ -173,7 +173,7 @@ describe( 'MediaQueryManager', () => {
 			} );
 
 			it( 'should return true if post ID matches', () => {
-				const isMatch = manager.matches( {
+				const isMatch = MediaQueryManager.matches( {
 					post_ID: 41
 				}, DEFAULT_MEDIA );
 
@@ -183,7 +183,7 @@ describe( 'MediaQueryManager', () => {
 
 		context( 'query.before', () => {
 			it( 'should return false if query is not ISO 8601', () => {
-				const isMatch = manager.matches( {
+				const isMatch = MediaQueryManager.matches( {
 					before: '2018'
 				}, DEFAULT_MEDIA );
 
@@ -191,7 +191,7 @@ describe( 'MediaQueryManager', () => {
 			} );
 
 			it( 'should return false if media is not before date', () => {
-				const isMatch = manager.matches( {
+				const isMatch = MediaQueryManager.matches( {
 					before: '2010-04-25T15:47:33-04:00'
 				}, DEFAULT_MEDIA );
 
@@ -199,7 +199,7 @@ describe( 'MediaQueryManager', () => {
 			} );
 
 			it( 'should return true if media is before date', () => {
-				const isMatch = manager.matches( {
+				const isMatch = MediaQueryManager.matches( {
 					before: '2018-04-25T15:47:33-04:00'
 				}, DEFAULT_MEDIA );
 
@@ -209,7 +209,7 @@ describe( 'MediaQueryManager', () => {
 
 		context( 'query.after', () => {
 			it( 'should return false if query is not ISO 8601', () => {
-				const isMatch = manager.matches( {
+				const isMatch = MediaQueryManager.matches( {
 					after: '2010'
 				}, DEFAULT_MEDIA );
 
@@ -217,7 +217,7 @@ describe( 'MediaQueryManager', () => {
 			} );
 
 			it( 'should return false if media is not after date', () => {
-				const isMatch = manager.matches( {
+				const isMatch = MediaQueryManager.matches( {
 					after: '2018-04-25T15:47:33-04:00'
 				}, DEFAULT_MEDIA );
 
@@ -225,7 +225,7 @@ describe( 'MediaQueryManager', () => {
 			} );
 
 			it( 'should return true if media is after date', () => {
-				const isMatch = manager.matches( {
+				const isMatch = MediaQueryManager.matches( {
 					after: '2010-04-25T15:47:33-04:00'
 				}, DEFAULT_MEDIA );
 

--- a/client/lib/query-manager/paginated/test/index.js
+++ b/client/lib/query-manager/paginated/test/index.js
@@ -22,11 +22,16 @@ describe( 'PaginatedQueryManager', () => {
 
 	useSandbox( ( _sandbox ) => {
 		sandbox = _sandbox;
-		sandbox.stub( PaginatedQueryManager.prototype, 'compare', ( query, a, b ) => a.ID - b.ID );
 	} );
 
 	beforeEach( () => {
 		manager = new PaginatedQueryManager();
+		sandbox.create();
+		sandbox.stub( PaginatedQueryManager.prototype, 'compare', ( query, a, b ) => a.ID - b.ID );
+	} );
+
+	afterEach( () => {
+		sandbox.restore();
 	} );
 
 	describe( '.hasQueryPaginationKeys()', () => {
@@ -217,7 +222,7 @@ describe( 'PaginatedQueryManager', () => {
 			manager = manager.receive( [ { ID: 144 }, { ID: 152 } ], { query: { search: 'title', number: 2 }, found: 6 } );
 			manager = manager.receive( [ { ID: 160 }, { ID: 168 } ], { query: { search: 'title', number: 2, page: 2 } } );
 			manager = manager.receive( [ { ID: 176 }, { ID: 184 } ], { query: { search: 'title', number: 2, page: 3 } } );
-			sandbox.stub( manager, 'matches' ).returns( false );
+			sandbox.stub( PaginatedQueryManager, 'matches' ).returns( false );
 			manager = manager.receive( { ID: 160, changed: true } );
 
 			expect( manager.getFound( { search: 'title' } ) ).to.equal( 5 );

--- a/client/lib/query-manager/paginated/test/index.js
+++ b/client/lib/query-manager/paginated/test/index.js
@@ -26,7 +26,6 @@ describe( 'PaginatedQueryManager', () => {
 
 	beforeEach( () => {
 		manager = new PaginatedQueryManager();
-		sandbox.create();
 		sandbox.stub( PaginatedQueryManager.prototype, 'compare', ( query, a, b ) => a.ID - b.ID );
 	} );
 

--- a/client/lib/query-manager/post/index.js
+++ b/client/lib/query-manager/post/index.js
@@ -22,7 +22,7 @@ export default class PostQueryManager extends PaginatedQueryManager {
 	 * @param  {Object}  post  Item to consider
 	 * @return {Boolean}       Whether post matches query
 	 */
-	matches( query, post ) {
+	static matches( query, post ) {
 		const queryWithDefaults = Object.assign( {}, DEFAULT_POST_QUERY, query );
 		return every( queryWithDefaults, ( value, key ) => {
 			switch ( key ) {

--- a/client/lib/query-manager/post/test/index.js
+++ b/client/lib/query-manager/post/test/index.js
@@ -93,7 +93,7 @@ describe( 'PostQueryManager', () => {
 	describe( '#matches()', () => {
 		context( 'query.search', () => {
 			it( 'should return false for a non-matching search', () => {
-				const isMatch = manager.matches( {
+				const isMatch = PostQueryManager.matches( {
 					search: 'disgusting'
 				}, DEFAULT_POST );
 
@@ -101,7 +101,7 @@ describe( 'PostQueryManager', () => {
 			} );
 
 			it( 'should return true for a matching title search', () => {
-				const isMatch = manager.matches( {
+				const isMatch = PostQueryManager.matches( {
 					search: 'Ribs'
 				}, DEFAULT_POST );
 
@@ -109,7 +109,7 @@ describe( 'PostQueryManager', () => {
 			} );
 
 			it( 'should return true for a falsey title search', () => {
-				const isMatch = manager.matches( {
+				const isMatch = PostQueryManager.matches( {
 					search: null
 				}, DEFAULT_POST );
 
@@ -117,7 +117,7 @@ describe( 'PostQueryManager', () => {
 			} );
 
 			it( 'should return true for a matching content search', () => {
-				const isMatch = manager.matches( {
+				const isMatch = PostQueryManager.matches( {
 					search: 'delicious'
 				}, DEFAULT_POST );
 
@@ -125,7 +125,7 @@ describe( 'PostQueryManager', () => {
 			} );
 
 			it( 'should search case-insensitive', () => {
-				const isMatch = manager.matches( {
+				const isMatch = PostQueryManager.matches( {
 					search: 'ribs'
 				}, DEFAULT_POST );
 
@@ -133,7 +133,7 @@ describe( 'PostQueryManager', () => {
 			} );
 
 			it( 'should separately test title and content fields', () => {
-				const isMatch = manager.matches( {
+				const isMatch = PostQueryManager.matches( {
 					search: 'ChickenAre'
 				}, DEFAULT_POST );
 
@@ -143,7 +143,7 @@ describe( 'PostQueryManager', () => {
 
 		context( 'query.after', () => {
 			it( 'should return false if query is not ISO 8601', () => {
-				const isMatch = manager.matches( {
+				const isMatch = PostQueryManager.matches( {
 					after: '2014'
 				}, DEFAULT_POST );
 
@@ -151,7 +151,7 @@ describe( 'PostQueryManager', () => {
 			} );
 
 			it( 'should return false if post is not after date', () => {
-				const isMatch = manager.matches( {
+				const isMatch = PostQueryManager.matches( {
 					after: '2018-04-25T15:47:33-04:00'
 				}, DEFAULT_POST );
 
@@ -159,7 +159,7 @@ describe( 'PostQueryManager', () => {
 			} );
 
 			it( 'should return true if post is after date', () => {
-				const isMatch = manager.matches( {
+				const isMatch = PostQueryManager.matches( {
 					after: '2014-04-25T15:47:33-04:00'
 				}, DEFAULT_POST );
 
@@ -169,7 +169,7 @@ describe( 'PostQueryManager', () => {
 
 		context( 'query.before', () => {
 			it( 'should return false if query is not ISO 8601', () => {
-				const isMatch = manager.matches( {
+				const isMatch = PostQueryManager.matches( {
 					before: '2018'
 				}, DEFAULT_POST );
 
@@ -177,7 +177,7 @@ describe( 'PostQueryManager', () => {
 			} );
 
 			it( 'should return false if post is not before date', () => {
-				const isMatch = manager.matches( {
+				const isMatch = PostQueryManager.matches( {
 					before: '2014-04-25T15:47:33-04:00'
 				}, DEFAULT_POST );
 
@@ -185,7 +185,7 @@ describe( 'PostQueryManager', () => {
 			} );
 
 			it( 'should return true if post is before date', () => {
-				const isMatch = manager.matches( {
+				const isMatch = PostQueryManager.matches( {
 					before: '2018-04-25T15:47:33-04:00'
 				}, DEFAULT_POST );
 
@@ -195,7 +195,7 @@ describe( 'PostQueryManager', () => {
 
 		context( 'query.modified_after', () => {
 			it( 'should return false if query is not ISO 8601', () => {
-				const isMatch = manager.matches( {
+				const isMatch = PostQueryManager.matches( {
 					modified_after: '2014'
 				}, DEFAULT_POST );
 
@@ -203,7 +203,7 @@ describe( 'PostQueryManager', () => {
 			} );
 
 			it( 'should return false if post is not modified after date', () => {
-				const isMatch = manager.matches( {
+				const isMatch = PostQueryManager.matches( {
 					modified_after: '2018-04-25T15:47:33-04:00'
 				}, DEFAULT_POST );
 
@@ -211,7 +211,7 @@ describe( 'PostQueryManager', () => {
 			} );
 
 			it( 'should return true if post is modified after date', () => {
-				const isMatch = manager.matches( {
+				const isMatch = PostQueryManager.matches( {
 					modified_after: '2014-04-25T15:47:33-04:00'
 				}, DEFAULT_POST );
 
@@ -221,7 +221,7 @@ describe( 'PostQueryManager', () => {
 
 		context( 'query.modified_before', () => {
 			it( 'should return false if query is not ISO 8601', () => {
-				const isMatch = manager.matches( {
+				const isMatch = PostQueryManager.matches( {
 					modified_before: '2018'
 				}, DEFAULT_POST );
 
@@ -229,7 +229,7 @@ describe( 'PostQueryManager', () => {
 			} );
 
 			it( 'should return false if post is not modified before date', () => {
-				const isMatch = manager.matches( {
+				const isMatch = PostQueryManager.matches( {
 					modified_before: '2014-04-25T15:47:33-04:00'
 				}, DEFAULT_POST );
 
@@ -237,7 +237,7 @@ describe( 'PostQueryManager', () => {
 			} );
 
 			it( 'should return true if post is modified before date', () => {
-				const isMatch = manager.matches( {
+				const isMatch = PostQueryManager.matches( {
 					modified_before: '2018-04-25T15:47:33-04:00'
 				}, DEFAULT_POST );
 
@@ -247,7 +247,7 @@ describe( 'PostQueryManager', () => {
 
 		context( 'query.tag', () => {
 			it( 'should return false if post does not include tag', () => {
-				const isMatch = manager.matches( {
+				const isMatch = PostQueryManager.matches( {
 					tag: 'Nottag'
 				}, DEFAULT_POST );
 
@@ -255,7 +255,7 @@ describe( 'PostQueryManager', () => {
 			} );
 
 			it( 'should return false on a partial match', () => {
-				const isMatch = manager.matches( {
+				const isMatch = PostQueryManager.matches( {
 					tag: 'agg'
 				}, DEFAULT_POST );
 
@@ -263,7 +263,7 @@ describe( 'PostQueryManager', () => {
 			} );
 
 			it( 'should return true if post includes tag by name', () => {
-				const isMatch = manager.matches( {
+				const isMatch = PostQueryManager.matches( {
 					tag: 'Tagged!'
 				}, DEFAULT_POST );
 
@@ -271,7 +271,7 @@ describe( 'PostQueryManager', () => {
 			} );
 
 			it( 'should return true if post includes tag by slug', () => {
-				const isMatch = manager.matches( {
+				const isMatch = PostQueryManager.matches( {
 					tag: 'tagged'
 				}, DEFAULT_POST );
 
@@ -279,7 +279,7 @@ describe( 'PostQueryManager', () => {
 			} );
 
 			it( 'should search case-insensitive', () => {
-				const isMatch = manager.matches( {
+				const isMatch = PostQueryManager.matches( {
 					tag: 'taGgEd'
 				}, DEFAULT_POST );
 
@@ -289,7 +289,7 @@ describe( 'PostQueryManager', () => {
 
 		context( 'query.category', () => {
 			it( 'should return false if post does not include category', () => {
-				const isMatch = manager.matches( {
+				const isMatch = PostQueryManager.matches( {
 					category: 'Notcategory'
 				}, DEFAULT_POST );
 
@@ -297,7 +297,7 @@ describe( 'PostQueryManager', () => {
 			} );
 
 			it( 'should return false on a partial match', () => {
-				const isMatch = manager.matches( {
+				const isMatch = PostQueryManager.matches( {
 					category: 'egori'
 				}, DEFAULT_POST );
 
@@ -305,7 +305,7 @@ describe( 'PostQueryManager', () => {
 			} );
 
 			it( 'should return true if post includes category by name', () => {
-				const isMatch = manager.matches( {
+				const isMatch = PostQueryManager.matches( {
 					category: 'Categorized!'
 				}, DEFAULT_POST );
 
@@ -313,7 +313,7 @@ describe( 'PostQueryManager', () => {
 			} );
 
 			it( 'should return true if post includes category by slug', () => {
-				const isMatch = manager.matches( {
+				const isMatch = PostQueryManager.matches( {
 					category: 'categorized'
 				}, DEFAULT_POST );
 
@@ -321,7 +321,7 @@ describe( 'PostQueryManager', () => {
 			} );
 
 			it( 'should search case-insensitive', () => {
-				const isMatch = manager.matches( {
+				const isMatch = PostQueryManager.matches( {
 					category: 'caTegoriZed'
 				}, DEFAULT_POST );
 
@@ -331,7 +331,7 @@ describe( 'PostQueryManager', () => {
 
 		context( 'query.term', () => {
 			it( 'should return false if post does not include term', () => {
-				const isMatch = manager.matches( {
+				const isMatch = PostQueryManager.matches( {
 					term: {
 						genre: 'non-fiction'
 					}
@@ -341,7 +341,7 @@ describe( 'PostQueryManager', () => {
 			} );
 
 			it( 'should return false if one but not both term slug queries match', () => {
-				const isMatch = manager.matches( {
+				const isMatch = PostQueryManager.matches( {
 					term: {
 						genre: 'fiction',
 						category: 'notcategory'
@@ -352,7 +352,7 @@ describe( 'PostQueryManager', () => {
 			} );
 
 			it( 'should return true if post includes term by slug', () => {
-				const isMatch = manager.matches( {
+				const isMatch = PostQueryManager.matches( {
 					term: {
 						genre: 'fiction'
 					}
@@ -362,7 +362,7 @@ describe( 'PostQueryManager', () => {
 			} );
 
 			it( 'should return true if post includes one of comma-separated term slugs', () => {
-				const isMatch = manager.matches( {
+				const isMatch = PostQueryManager.matches( {
 					term: {
 						genre: 'fiction,non-fiction'
 					}
@@ -372,7 +372,7 @@ describe( 'PostQueryManager', () => {
 			} );
 
 			it( 'should return true if post includes both of comma-separated term slugs', () => {
-				const isMatch = manager.matches( {
+				const isMatch = PostQueryManager.matches( {
 					term: {
 						genre: 'fiction,sci-fi'
 					}
@@ -387,7 +387,7 @@ describe( 'PostQueryManager', () => {
 				const post = Object.assign( {}, DEFAULT_POST, {
 					type: 'cpt-book'
 				} );
-				const isMatch = manager.matches( {
+				const isMatch = PostQueryManager.matches( {
 					type: 'any'
 				}, post );
 
@@ -395,7 +395,7 @@ describe( 'PostQueryManager', () => {
 			} );
 
 			it( 'should return false if type does not match', () => {
-				const isMatch = manager.matches( {
+				const isMatch = PostQueryManager.matches( {
 					type: 'page'
 				}, DEFAULT_POST );
 
@@ -403,7 +403,7 @@ describe( 'PostQueryManager', () => {
 			} );
 
 			it( 'should return true if type matches', () => {
-				const isMatch = manager.matches( {
+				const isMatch = PostQueryManager.matches( {
 					type: 'post'
 				}, DEFAULT_POST );
 
@@ -413,7 +413,7 @@ describe( 'PostQueryManager', () => {
 
 		context( 'query.parent_id', () => {
 			it( 'should return false if parent does not match', () => {
-				const isMatch = manager.matches( {
+				const isMatch = PostQueryManager.matches( {
 					parent_id: 10
 				}, DEFAULT_POST );
 
@@ -424,7 +424,7 @@ describe( 'PostQueryManager', () => {
 				const post = Object.assign( {}, DEFAULT_POST, {
 					parent: 10
 				} );
-				const isMatch = manager.matches( {
+				const isMatch = PostQueryManager.matches( {
 					parent_id: 10
 				}, post );
 
@@ -437,7 +437,7 @@ describe( 'PostQueryManager', () => {
 						ID: 10
 					}
 				} );
-				const isMatch = manager.matches( {
+				const isMatch = PostQueryManager.matches( {
 					parent_id: 10
 				}, post );
 
@@ -447,7 +447,7 @@ describe( 'PostQueryManager', () => {
 
 		context( 'query.exclude', () => {
 			it( 'should return false if ID matches single exclude', () => {
-				const isMatch = manager.matches( {
+				const isMatch = PostQueryManager.matches( {
 					exclude: 144
 				}, DEFAULT_POST );
 
@@ -455,7 +455,7 @@ describe( 'PostQueryManager', () => {
 			} );
 
 			it( 'should return false if ID matches array of excludes', () => {
-				const isMatch = manager.matches( {
+				const isMatch = PostQueryManager.matches( {
 					exclude: [ 144, 152 ]
 				}, DEFAULT_POST );
 
@@ -463,7 +463,7 @@ describe( 'PostQueryManager', () => {
 			} );
 
 			it( 'should return true if ID does not match single exclude', () => {
-				const isMatch = manager.matches( {
+				const isMatch = PostQueryManager.matches( {
 					exclude: 152
 				}, DEFAULT_POST );
 
@@ -471,7 +471,7 @@ describe( 'PostQueryManager', () => {
 			} );
 
 			it( 'should return true if ID does not match array of excludes', () => {
-				const isMatch = manager.matches( {
+				const isMatch = PostQueryManager.matches( {
 					exclude: [ 152, 160 ]
 				}, DEFAULT_POST );
 
@@ -485,7 +485,7 @@ describe( 'PostQueryManager', () => {
 			} );
 
 			it( 'should return true if "include" and sticky', () => {
-				const isMatch = manager.matches( {
+				const isMatch = PostQueryManager.matches( {
 					sticky: 'include'
 				}, stickyPost );
 
@@ -493,7 +493,7 @@ describe( 'PostQueryManager', () => {
 			} );
 
 			it( 'should return true if "include" and not sticky', () => {
-				const isMatch = manager.matches( {
+				const isMatch = PostQueryManager.matches( {
 					sticky: 'include'
 				}, DEFAULT_POST );
 
@@ -501,7 +501,7 @@ describe( 'PostQueryManager', () => {
 			} );
 
 			it( 'should return true if "require" and sticky', () => {
-				const isMatch = manager.matches( {
+				const isMatch = PostQueryManager.matches( {
 					sticky: 'require'
 				}, stickyPost );
 
@@ -509,7 +509,7 @@ describe( 'PostQueryManager', () => {
 			} );
 
 			it( 'should return false if "require" and not sticky', () => {
-				const isMatch = manager.matches( {
+				const isMatch = PostQueryManager.matches( {
 					sticky: 'require'
 				}, DEFAULT_POST );
 
@@ -517,7 +517,7 @@ describe( 'PostQueryManager', () => {
 			} );
 
 			it( 'should return false if "exclude" and sticky', () => {
-				const isMatch = manager.matches( {
+				const isMatch = PostQueryManager.matches( {
 					sticky: 'exclude'
 				}, stickyPost );
 
@@ -525,7 +525,7 @@ describe( 'PostQueryManager', () => {
 			} );
 
 			it( 'should return true if "exclude" and not sticky', () => {
-				const isMatch = manager.matches( {
+				const isMatch = PostQueryManager.matches( {
 					sticky: 'exclude'
 				}, DEFAULT_POST );
 
@@ -539,7 +539,7 @@ describe( 'PostQueryManager', () => {
 			} );
 
 			it( 'should return false if author does not match by nested object', () => {
-				const isMatch = manager.matches( {
+				const isMatch = PostQueryManager.matches( {
 					author: 73705672
 				}, DEFAULT_POST );
 
@@ -547,7 +547,7 @@ describe( 'PostQueryManager', () => {
 			} );
 
 			it( 'should return true if author matches by nested object', () => {
-				const isMatch = manager.matches( {
+				const isMatch = PostQueryManager.matches( {
 					author: 73705554
 				}, DEFAULT_POST );
 
@@ -555,7 +555,7 @@ describe( 'PostQueryManager', () => {
 			} );
 
 			it( 'should return false if author does not match by scalar value', () => {
-				const isMatch = manager.matches( {
+				const isMatch = PostQueryManager.matches( {
 					author: 73705672
 				}, postWithScalarAuthor );
 
@@ -563,7 +563,7 @@ describe( 'PostQueryManager', () => {
 			} );
 
 			it( 'should return true if author matches by scalar value', () => {
-				const isMatch = manager.matches( {
+				const isMatch = PostQueryManager.matches( {
 					author: 73705554
 				}, postWithScalarAuthor );
 
@@ -573,7 +573,7 @@ describe( 'PostQueryManager', () => {
 
 		context( 'query.status', () => {
 			it( 'should return false if status is "any"', () => {
-				const isMatch = manager.matches( {
+				const isMatch = PostQueryManager.matches( {
 					status: 'any'
 				}, DEFAULT_POST );
 
@@ -581,7 +581,7 @@ describe( 'PostQueryManager', () => {
 			} );
 
 			it( 'should return false if status does not match', () => {
-				const isMatch = manager.matches( {
+				const isMatch = PostQueryManager.matches( {
 					status: 'draft'
 				}, DEFAULT_POST );
 
@@ -589,7 +589,7 @@ describe( 'PostQueryManager', () => {
 			} );
 
 			it( 'should return true if status matches', () => {
-				const isMatch = manager.matches( {
+				const isMatch = PostQueryManager.matches( {
 					status: 'publish'
 				}, DEFAULT_POST );
 
@@ -597,7 +597,7 @@ describe( 'PostQueryManager', () => {
 			} );
 
 			it( 'should return false if none of comma-separated values match', () => {
-				const isMatch = manager.matches( {
+				const isMatch = PostQueryManager.matches( {
 					status: 'draft,trash'
 				}, DEFAULT_POST );
 
@@ -605,7 +605,7 @@ describe( 'PostQueryManager', () => {
 			} );
 
 			it( 'should return true if one of comma-separated values match', () => {
-				const isMatch = manager.matches( {
+				const isMatch = PostQueryManager.matches( {
 					status: 'draft,publish'
 				}, DEFAULT_POST );
 
@@ -613,7 +613,7 @@ describe( 'PostQueryManager', () => {
 			} );
 
 			it( 'should gracefully handle non-string search values', () => {
-				const isMatch = manager.matches( {
+				const isMatch = PostQueryManager.matches( {
 					status: undefined
 				}, DEFAULT_POST );
 

--- a/client/lib/query-manager/term/index.js
+++ b/client/lib/query-manager/term/index.js
@@ -21,7 +21,7 @@ export default class TermQueryManager extends PaginatedQueryManager {
 	 * @param  {Object}  term  Item to consider
 	 * @return {Boolean}       Whether term matches query
 	 */
-	matches( query, term ) {
+	static matches( query, term ) {
 		if ( ! query.search ) {
 			return true;
 		}

--- a/client/lib/query-manager/term/test/index.js
+++ b/client/lib/query-manager/term/test/index.js
@@ -28,7 +28,7 @@ describe( 'TermQueryManager', () => {
 	describe( '#matches()', () => {
 		context( 'query.search', () => {
 			it( 'should return false for a non-matching search', () => {
-				const isMatch = manager.matches( {
+				const isMatch = TermQueryManager.matches( {
 					search: 'Cars'
 				}, DEFAULT_TERM );
 
@@ -36,7 +36,7 @@ describe( 'TermQueryManager', () => {
 			} );
 
 			it( 'should return true for an empty search', () => {
-				const isMatch = manager.matches( {
+				const isMatch = TermQueryManager.matches( {
 					search: ''
 				}, DEFAULT_TERM );
 
@@ -44,7 +44,7 @@ describe( 'TermQueryManager', () => {
 			} );
 
 			it( 'should return true for a matching name search', () => {
-				const isMatch = manager.matches( {
+				const isMatch = TermQueryManager.matches( {
 					search: 'ood'
 				}, DEFAULT_TERM );
 
@@ -52,7 +52,7 @@ describe( 'TermQueryManager', () => {
 			} );
 
 			it( 'should return true for a matching slug search', () => {
-				const isMatch = manager.matches( {
+				const isMatch = TermQueryManager.matches( {
 					search: 'y-sl'
 				}, DEFAULT_TERM );
 
@@ -60,7 +60,7 @@ describe( 'TermQueryManager', () => {
 			} );
 
 			it( 'should search case-insensitive', () => {
-				const isMatch = manager.matches( {
+				const isMatch = TermQueryManager.matches( {
 					search: 'fOoD'
 				}, DEFAULT_TERM );
 

--- a/client/lib/query-manager/test/index.js
+++ b/client/lib/query-manager/test/index.js
@@ -16,6 +16,11 @@ describe( 'QueryManager', () => {
 
 	beforeEach( () => {
 		manager = new QueryManager();
+		sandbox.create();
+	} );
+
+	afterEach( () => {
+		sandbox.restore();
 	} );
 
 	describe( '#constructor()', () => {
@@ -74,11 +79,11 @@ describe( 'QueryManager', () => {
 
 	describe( '#matches()', () => {
 		it( 'should return false if item is not truthy', () => {
-			expect( manager.matches() ).to.be.false;
+			expect( QueryManager.matches() ).to.be.false;
 		} );
 
 		it( 'should return true if item is truthy', () => {
-			expect( manager.matches( {}, {} ) ).to.be.true;
+			expect( QueryManager.matches( {}, {} ) ).to.be.true;
 		} );
 	} );
 
@@ -331,7 +336,7 @@ describe( 'QueryManager', () => {
 
 		it( 'should remove a tracked query item when it no longer matches', () => {
 			manager = manager.receive( { ID: 144 }, { query: {} } );
-			sandbox.stub( manager, 'matches' ).returns( false );
+			sandbox.stub( QueryManager, 'matches' ).returns( false );
 			const newManager = manager.receive( { ID: 144, changed: true } );
 
 			expect( manager.getItems() ).to.eql( [ { ID: 144 } ] );
@@ -419,7 +424,7 @@ describe( 'QueryManager', () => {
 
 		it( 'should decrement found count if removing an unmatched item', () => {
 			manager = manager.receive( { ID: 144 }, { query: {}, found: 1 } );
-			sandbox.stub( manager, 'matches' ).returns( false );
+			sandbox.stub( QueryManager, 'matches' ).returns( false );
 			const newManager = manager.receive( { ID: 144, changed: true } );
 
 			expect( manager.getFound( {} ) ).to.equal( 1 );

--- a/client/lib/query-manager/test/index.js
+++ b/client/lib/query-manager/test/index.js
@@ -16,7 +16,6 @@ describe( 'QueryManager', () => {
 
 	beforeEach( () => {
 		manager = new QueryManager();
-		sandbox.create();
 	} );
 
 	afterEach( () => {


### PR DESCRIPTION
The `matches` method shouldn't depend on any internal state, it should be a pure function.

This PR updates QueryManager, subclasses that implement their own `matches`, and tests to use a static `matches` method.
* QueryManager
* TermQueryManager
* PaginatedQueryManager
* PostQueryManager
* MediaQueryManager

Came out of this discussion: https://github.com/Automattic/wp-calypso/pull/17423#discussion_r134436169

## Testing
* Tests should be correctly updated and passing.
* Ensure the different QM implementations continue to function properly.

## Follow up
Make `compare` static 🙂 