### PR TITLE
Extensions: WPJM - Remove use of next in data layer

### DIFF
--- a/client/extensions/wp-job-manager/state/data-layer/settings/index.js
+++ b/client/extensions/wp-job-manager/state/data-layer/settings/index.js
@@ -26,7 +26,7 @@ export const fetchExtensionSettings = ( { dispatch }, action ) => {
 	}, action ) );
 };
 
-export const updateExtensionSettings = ( { dispatch }, { siteId }, next, { data } ) =>
+export const updateExtensionSettings = ( { dispatch }, { siteId }, { data } ) =>
 	dispatch( updateSettings( siteId, fromApi( data ) ) );
 
 export const fetchExtensionError = ( { dispatch }, { siteId } ) =>
@@ -48,7 +48,7 @@ export const saveSettings = ( { dispatch, getState }, action ) => {
 	}, action ) );
 };
 
-export const announceSuccess = ( { dispatch }, { form, siteId }, next, { data } ) => {
+export const announceSuccess = ( { dispatch }, { form, siteId }, { data } ) => {
 	const updatedData = fromApi( data );
 
 	dispatch( stopSave( form ) );

--- a/client/extensions/wp-job-manager/state/data-layer/settings/test/index.js
+++ b/client/extensions/wp-job-manager/state/data-layer/settings/test/index.js
@@ -104,7 +104,7 @@ describe( '#updateExtensionSettings', () => {
 		const action = fetchSettings( 12345678 );
 		const dispatch = sinon.spy();
 
-		updateExtensionSettings( { dispatch }, action, null, apiResponse );
+		updateExtensionSettings( { dispatch }, action, apiResponse );
 
 		expect( dispatch ).to.have.been.calledOnce;
 		expect( dispatch ).to.have.been.calledWith( updateSettings( 12345678, transformedData ) );
@@ -161,7 +161,7 @@ describe( '#announceSuccess()', () => {
 	it( 'should dispatch `stopSave`', () => {
 		const dispatch = sinon.spy();
 
-		announceSuccess( { dispatch }, saveAction, null, apiResponse );
+		announceSuccess( { dispatch }, saveAction, apiResponse );
 
 		expect( dispatch ).to.have.been.calledWith( stopSave( 'my-form' ) );
 	} );
@@ -169,7 +169,7 @@ describe( '#announceSuccess()', () => {
 	it( 'should dispatch `initialize`', () => {
 		const dispatch = sinon.spy();
 
-		announceSuccess( { dispatch }, saveAction, null, apiResponse );
+		announceSuccess( { dispatch }, saveAction, apiResponse );
 
 		expect( dispatch ).to.have.been.calledWith( initialize( 'my-form', transformedData ) );
 	} );
@@ -177,7 +177,7 @@ describe( '#announceSuccess()', () => {
 	it( 'should dispatch `updateSettings`', () => {
 		const dispatch = sinon.spy();
 
-		announceSuccess( { dispatch }, saveAction, null, apiResponse );
+		announceSuccess( { dispatch }, saveAction, apiResponse );
 
 		expect( dispatch ).to.have.been.calledWith( updateSettings( 101010, transformedData ) );
 	} );
@@ -185,7 +185,7 @@ describe( '#announceSuccess()', () => {
 	it( 'should dispatch `successNotice`', () => {
 		const dispatch = sinon.spy();
 
-		announceSuccess( { dispatch }, saveAction, null, apiResponse );
+		announceSuccess( { dispatch }, saveAction, apiResponse );
 
 		expect( dispatch ).to.have.been.calledWith( successNotice( translate(
 			'Settings saved!' ),


### PR DESCRIPTION
`next()` has been removed from the data layer - p4TIVU-7EF-p2. This PR eliminates its use from WPJM's data layer as well.

## Testing
Confirm that WPJM settings are fetched and can be saved.