### PR TITLE
Sidebar: Retrieve site URL safely for preview item

### DIFF
--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -155,13 +155,14 @@ export class MySitesSidebar extends Component {
 		}
 
 		const { site, isPreviewable } = this.props;
+		const siteUrl = site && site.URL || '';
 
 		return (
 			<SidebarItem
 				tipTarget="sitePreview"
 				label={ this.props.translate( 'View Site' ) }
 				className={ this.itemLinkClass( [ '/view' ], 'preview' ) }
-				link={ isPreviewable ? '/view' + this.props.siteSuffix : site.URL }
+				link={ isPreviewable ? '/view' + this.props.siteSuffix : siteUrl }
 				onNavigate={ this.onNavigate }
 				icon="computer"
 				preloadSectionName="preview"


### PR DESCRIPTION
This PR introduces a safe retrieval for `site.URL` when building the URL for the **View Site** item in the sidebar. Fixes #17458.

The safe retrieval is necessary, because at the time when we're building the sidebar menu item, `site` might have not exist in state yet. The regression seems to have been introduced in #15431. 

To test:

* Start Calypso with forced sympathy, e.g. `ENABLE_FEATURES=force-sympathy npm start`
* Login as a single site user (a user who has only one WordPress.com site).
* Load http://calypso.localhost:3000/stats/day/:site
* Verify the page loads correctly without errors.
