### PR TITLE
.org Plans: Use a master interval toggle for all Jetpack plan flows

### DIFF
--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -161,7 +161,11 @@ class PlanFeaturesHeader extends Component {
 			);
 		}
 
-		return null;
+		return (
+			<p className={ timeframeClasses }>
+				{ billingTimeFrame }
+			</p>
+		);
 	}
 
 	isPlanCurrent() {

--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -27,12 +27,8 @@ import {
 	PLAN_JETPACK_PERSONAL_MONTHLY,
 	PLAN_PERSONAL,
 	getPlanClass,
-	isMonthly,
 } from 'lib/plans/constants';
 import PlanIcon from 'components/plans/plan-icon';
-import { plansLink } from 'lib/plans';
-import SegmentedControl from 'components/segmented-control';
-import SegmentedControlItem from 'components/segmented-control/item';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getCurrentPlan } from 'state/sites/plans/selectors';
 import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
@@ -165,53 +161,7 @@ class PlanFeaturesHeader extends Component {
 			);
 		}
 
-		return this.getIntervalTypeToggle();
-	}
-
-	getIntervalTypeToggle() {
-		const {
-			translate,
-			rawPrice,
-			intervalType,
-			site,
-			basePlansPath,
-			hideMonthly,
-			currentSitePlan,
-		} = this.props;
-
-		if ( hideMonthly ||
-			! rawPrice ||
-			// Only monthly to yearly upgrades for the same plan are supported
-			( this.isPlanCurrent() && currentSitePlan && ! isMonthly( currentSitePlan.productSlug ) )
-		) {
-			return (
-				<div className="plan-features__interval-type is-placeholder">
-				</div>
-			);
-		}
-
-		let plansUrl = '/plans';
-		if ( basePlansPath ) {
-			plansUrl = basePlansPath;
-		}
-
-		return (
-			<SegmentedControl compact className="plan-features__interval-type" primary={ true }>
-				<SegmentedControlItem
-					selected={ intervalType === 'monthly' }
-					path={ plansLink( plansUrl, site, 'monthly' ) }
-				>
-					{ translate( 'Monthly' ) }
-				</SegmentedControlItem>
-
-				<SegmentedControlItem
-					selected={ intervalType === 'yearly' }
-					path={ plansLink( plansUrl, site, 'yearly' ) }
-				>
-					{ translate( 'Yearly' ) }
-				</SegmentedControlItem>
-			</SegmentedControl>
-		);
+		return null;
 	}
 
 	isPlanCurrent() {
@@ -325,7 +275,6 @@ PlanFeaturesHeader.propTypes = {
 	title: PropTypes.string.isRequired,
 	isPlaceholder: PropTypes.bool,
 	translate: PropTypes.func,
-	intervalType: PropTypes.string,
 	site: PropTypes.object,
 	isInJetpackConnect: PropTypes.bool,
 	currentSitePlan: PropTypes.object,
@@ -339,7 +288,6 @@ PlanFeaturesHeader.defaultProps = {
 	popular: false,
 	newPlan: false,
 	isPlaceholder: false,
-	intervalType: 'yearly',
 	site: {},
 	basePlansPath: null,
 	currentSitePlan: {},

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -148,7 +148,7 @@ class PlanFeatures extends Component {
 
 	renderMobileView() {
 		const {
-			canPurchase, translate, planProperties, isInSignup, isLandingPage, intervalType, site, basePlansPath
+			canPurchase, translate, planProperties, isInSignup, isLandingPage, site, basePlansPath
 		} = this.props;
 
 		// move any free plan to last place in mobile view
@@ -196,7 +196,6 @@ class PlanFeatures extends Component {
 						billingTimeFrame={ planConstantObj.getBillingTimeFrame() }
 						hideMonthly={ hideMonthly }
 						isPlaceholder={ isPlaceholder }
-						intervalType={ intervalType }
 						site={ site }
 						basePlansPath={ basePlansPath }
 						relatedMonthlyPlan={ relatedMonthlyPlan }
@@ -240,7 +239,6 @@ class PlanFeatures extends Component {
 	renderPlanHeaders() {
 		const {
 			planProperties,
-			intervalType,
 			site,
 			basePlansPath,
 			isInSignup,
@@ -296,7 +294,6 @@ class PlanFeatures extends Component {
 						discountPrice={ discountPrice }
 						billingTimeFrame={ billingTimeFrame }
 						isPlaceholder={ isPlaceholder }
-						intervalType={ intervalType }
 						site={ site }
 						hideMonthly={ hideMonthly }
 						basePlansPath={ basePlansPath }
@@ -510,7 +507,6 @@ PlanFeatures.propTypes = {
 	isInSignup: PropTypes.bool,
 	basePlansPath: PropTypes.string,
 	selectedFeature: PropTypes.string,
-	intervalType: PropTypes.string,
 	site: PropTypes.object,
 	displayJetpackPlans: PropTypes.bool,
 };
@@ -519,7 +515,6 @@ PlanFeatures.defaultProps = {
 	onUpgradeClick: noop,
 	isInSignup: false,
 	basePlansPath: null,
-	intervalType: 'yearly',
 	site: {},
 	displayJetpackPlans: false,
 };

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -68,7 +68,6 @@ class PlansFeaturesMain extends Component {
 						isInSignup={ isInSignup }
 						isLandingPage={ isLandingPage }
 						basePlansPath={ basePlansPath }
-						intervalType={ intervalType }
 						site={ site }
 						domainName={ domainName }
 						displayJetpackPlans = { displayJetpackPlans }
@@ -96,7 +95,6 @@ class PlansFeaturesMain extends Component {
 						isInSignup={ isInSignup }
 						isLandingPage={ isLandingPage }
 						basePlansPath={ basePlansPath }
-						intervalType={ intervalType }
 						site={ site }
 						domainName={ domainName }
 						displayJetpackPlans = { displayJetpackPlans }
@@ -124,7 +122,6 @@ class PlansFeaturesMain extends Component {
 					isLandingPage={ isLandingPage }
 					basePlansPath={ basePlansPath }
 					selectedFeature={ selectedFeature }
-					intervalType={ intervalType }
 					site={ site }
 					domainName={ domainName }
 					displayJetpackPlans = { displayJetpackPlans }
@@ -377,7 +374,7 @@ class PlansFeaturesMain extends Component {
 
 		return (
 			<div className="plans-features-main">
-				{ ( displayJetpackPlans && isInSignup ) ? this.getIntervalTypeToggle() : null }
+				{ displayJetpackPlans ? this.getIntervalTypeToggle() : null }
 				<QueryPlans />
 				<QuerySitePlans siteId={ get( site, 'ID' ) } />
 				{ this.getPlanFeatures() }


### PR DESCRIPTION
### Purpose

This PR updates the general plans page (`/plans/:site`) for Jetpack sites to use a master interval toggle, instead of having a toggle within the header of each plan. As suggested by @rickybanister in a discussion in p7rd6c-Qc-p2, and a follow-up of the great work done by @fditrapani in #15828.

### Preview

Monthly - Before:
![](https://cldup.com/VPJj5PN5hc.png)

Monthly - After:
![](https://cldup.com/100LisgHXF.png)

Yearly - Before:
![](https://cldup.com/sn6PECRWQM.png)

Yearly - After:
![](https://cldup.com/5G1duV2aZ2.png)

### Testing
* Checkout this branch, or get it going on calypso.live.
* Go to `/plans/:site` where `:site` is a Jetpack site.
* Play with the master monthly/yearly toggle and verify it works and looks correctly.
* Go to `/plans/:site` where `:site` is a WordPress.com or Atomic site.
* Verify there are no changes on the plans page.
* Go to `/jetpack/connect` and go through the flow to connect a site.
* Verify there are no changes on the JPC plans page.