### PR TITLE
Codemods: Add bash batch modding script

### DIFF
--- a/bin/runmods.sh
+++ b/bin/runmods.sh
@@ -41,6 +41,6 @@ for MOD in "${MODS[@]}"; do
 		git add $TARGET
 
 		# Commit! (skip pre-commit checks)
-		git ci -nm "Apply codemod $MOD"
+		git commit -nm "Apply codemod $MOD"
 	fi
 done

--- a/bin/runmods.sh
+++ b/bin/runmods.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# Uncomment the following lines to print commands as they are executed
+# set -o xtrace
+
+set -o errexit
+set -o nounset
+
+# Initialize from the provided arguments
+TARGET="${1:?No target supplied. Please provide a target directory or file.}"
+
+# Codemods to be run in sequence
+MODS=(
+  'commonjs-imports-hoist'
+  'commonjs-imports'
+  'commonjs-exports'
+  'i18n-mixin'
+  'react-create-class'
+  'react-prop-types'
+  # 'combine-reducer-with-persistence'
+  # 'combine-state-utils-imports'
+  # 'merge-lodash-imports'
+  # 'modular-lodash-no-more'
+  # 'named-exports-from-default'
+  # 'rename-combine-reducers'
+)
+
+for MOD in "${MODS[@]}"; do
+	echo "Running $MOD on $TARGET"
+	echo
+	read -p "Press any key to continue."
+
+	"./bin/codemods/$MOD" $TARGET
+
+	# Check for changes
+	if [[ -n "$( git diff --name-only )" ]]; then
+		# Try to fix lint issues (but don't fail on lint errors)
+		"./node_modules/.bin/eslint-eslines" --fix "$TARGET" -- --diff=index || true
+
+		# Add anything that was modded
+		git add $TARGET
+
+		# Commit! (skip pre-commit checks)
+		git ci -nm "Apply codemod $MOD"
+	fi
+done


### PR DESCRIPTION
Codemods are tricky, in part because you need to get the order right.

This PR shares a bash script 😱  I worked on to handle the process of running a sequence of codemods on a given target.

Originally I wasn't planning on sharing this, but @ockham encouraged me to create a PR.

## What does it do

It will attempt to run these codemods in this order: 

- `commonjs-imports-hoist`
- `commonjs-imports`
- `commonjs-exports`
- `i18n-mixin`
- `react-create-class`
- `react-prop-types`

After each codemod, it will try to `eslint --fix` what it can, then commits with a description of the codemod that's run. _It will create commits for you._

## Usage
From the project root, run

```sh
./bin/runmods.sh $TARGET
```

where `$TARGET` is a path to the part of Calypso you want to codemod, for example `client/components/button`.