### PR TITLE
Build monitor: Make needs refresh notices clickable

### DIFF
--- a/client/components/webpack-build-monitor/index.jsx
+++ b/client/components/webpack-build-monitor/index.jsx
@@ -7,13 +7,15 @@
 import React from 'react';
 import { createStore } from 'redux';
 import classNames from 'classnames';
-import { find, includes, startsWith, identity } from 'lodash';
+import { find, identity, includes, startsWith } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import Spinner from 'components/spinner';
 import { combineReducers } from 'state/utils';
+
+const refreshPage = () => window.location.reload();
 
 // Action dispatched by wrapped console
 const CONSOLE_MESSAGE = 'CONSOLE_MESSAGE';
@@ -99,7 +101,9 @@ const STATUS_TEXTS = {
 
 const RELOAD_REQUIRED_ELEMENT = (
 	// eslint-disable-next-line wpcalypso/jsx-classname-namespace
-	<div className="webpack-build-monitor is-warning">Need to refresh</div>
+	<div className="webpack-build-monitor is-warning">
+		<a onClick={ refreshPage }>Need to refresh</a>
+	</div>
 );
 
 class WebpackBuildMonitor extends React.Component {
@@ -139,7 +143,11 @@ class WebpackBuildMonitor extends React.Component {
 			<div className={ classnames }>
 				{ includes( [ BUILDING_BOTH, BUILDING_CSS, BUILDING_JS ], buildStatus ) &&
 					<Spinner size={ 11 } className="webpack-build-monitor__spinner" /> }
-				{ text }
+				{ reloadRequired
+					? <a onClick={ refreshPage }>
+							{ text }
+						</a>
+					: text }
 			</div>
 		);
 	}

--- a/client/components/webpack-build-monitor/style.scss
+++ b/client/components/webpack-build-monitor/style.scss
@@ -21,6 +21,11 @@
 	&.is-error {
 		background: $alert-red;
 	}
+
+	> a {
+		cursor: pointer;
+		color: $white;
+	}
 }
 
 .webpack-build-monitor__spinner {


### PR DESCRIPTION
Now you can click your fancy notice if a refresh is required! 🎉 

Is this helpful? I will probably keep using keyboard shortcuts. I would like to implement a checkable automatic-reloading functionality, this PR starts to explore in that direction.

## Testing
See if it works!

## Screens

![click-reload](https://user-images.githubusercontent.com/841763/29627538-ad3496de-8832-11e7-930b-974b61972217.gif)
