### PR TITLE
Jetpack: Redirect invalid routes under jetpack/new to jetpack/connect

### DIFF
--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -18,7 +18,7 @@ import JetpackConnect from './main';
 import JetpackNewSite from './jetpack-new-site/index';
 import JetpackConnectAuthorizeForm from './authorize-form';
 import { setSection } from 'state/ui/actions';
-import { renderWithReduxStore, renderPage } from 'lib/react-helpers';
+import { renderWithReduxStore } from 'lib/react-helpers';
 import { JETPACK_CONNECT_QUERY_SET } from 'state/action-types';
 import userFactory from 'lib/user';
 import jetpackSSOForm from './sso';
@@ -29,7 +29,6 @@ import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
 import PlansLanding from './plans-landing';
-import EmptyContent from 'components/empty-content';
 
 /**
  * Module variables
@@ -252,16 +251,5 @@ export default {
 			document.getElementById( 'primary' ),
 			context.store
 		);
-	},
-
-	notFoundError( context, next ) {
-		const emptyContent = (
-			<EmptyContent
-				illustration="/calypso/images/illustrations/illustration-404.svg"
-				title={ translate( 'Uh oh. Page not found.' ) }
-				line={ translate( 'Sorry, the page you were looking for doesn\'t exist or has been moved.' ) } />
-		);
-		renderPage( context, emptyContent );
-		next();
 	},
 };

--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -18,7 +18,7 @@ import JetpackConnect from './main';
 import JetpackNewSite from './jetpack-new-site/index';
 import JetpackConnectAuthorizeForm from './authorize-form';
 import { setSection } from 'state/ui/actions';
-import { renderWithReduxStore } from 'lib/react-helpers';
+import { renderWithReduxStore, renderPage } from 'lib/react-helpers';
 import { JETPACK_CONNECT_QUERY_SET } from 'state/action-types';
 import userFactory from 'lib/user';
 import jetpackSSOForm from './sso';
@@ -29,6 +29,7 @@ import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
 import PlansLanding from './plans-landing';
+import EmptyContent from 'components/empty-content';
 
 /**
  * Module variables
@@ -251,5 +252,16 @@ export default {
 			document.getElementById( 'primary' ),
 			context.store
 		);
+	},
+
+	notFoundError( context, next ) {
+		const emptyContent = (
+			<EmptyContent
+				illustration="/calypso/images/illustrations/illustration-404.svg"
+				title={ translate( 'Uh oh. Page not found.' ) }
+				line={ translate( 'Sorry, the page you were looking for doesn\'t exist or has been moved.' ) } />
+		);
+		renderPage( context, emptyContent );
+		next();
 	},
 };

--- a/client/jetpack-connect/index.js
+++ b/client/jetpack-connect/index.js
@@ -72,4 +72,5 @@ export default function() {
 	page( '/jetpack/sso/:siteId?/:ssoNonce?', controller.sso );
 	page( '/jetpack/sso/*', controller.sso );
 	page( '/jetpack/new', controller.newSite );
+	page( '/jetpack/new/*', controller.notFoundError );
 }

--- a/client/jetpack-connect/index.js
+++ b/client/jetpack-connect/index.js
@@ -72,5 +72,5 @@ export default function() {
 	page( '/jetpack/sso/:siteId?/:ssoNonce?', controller.sso );
 	page( '/jetpack/sso/*', controller.sso );
 	page( '/jetpack/new', controller.newSite );
-	page( '/jetpack/new/*', controller.notFoundError );
+	page( '/jetpack/new/*', '/jetpack/connect' );
 }


### PR DESCRIPTION
Any Calypso route `/jetpack/new/*` is invalid, so redirect to `/jetpack/connect`.

Preparation for whitelisting the `/jetpack/new` route: pMz3w-7v3-p2, /cc @rickybanister @richardmuscat 

**To Test**
* Checkout this brach
* http://calypso.localhost:3000/jetpack/new should show the 'add new site page'
* also query args should be allowed, like http://calypso.localhost:3000/jetpack/new?ref=calypso-selector
* Anything under /new/, for example http://calypso.localhost:3000/jetpack/new/invalid, should redirect to `/jetpack/connect`