### PR TITLE
Editor: Hide bottom status label when revisions open

### DIFF
--- a/client/post-editor/editor-action-bar/index.jsx
+++ b/client/post-editor/editor-action-bar/index.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import Gridicon from 'gridicons';
 import { connect } from 'react-redux';
 
@@ -22,14 +23,14 @@ import { getEditedPost } from 'state/posts/selectors';
 class EditorActionBar extends Component {
 
 	static propTypes = {
-		isNew: React.PropTypes.bool,
-		onPrivatePublish: React.PropTypes.func,
-		post: React.PropTypes.object,
-		savedPost: React.PropTypes.object,
-		site: React.PropTypes.object,
-		type: React.PropTypes.string,
-		isPostPrivate: React.PropTypes.bool,
-		postAuthor: React.PropTypes.object,
+		isNew: PropTypes.bool,
+		onPrivatePublish: PropTypes.func,
+		post: PropTypes.object,
+		savedPost: PropTypes.object,
+		site: PropTypes.object,
+		type: PropTypes.string,
+		isPostPrivate: PropTypes.bool,
+		postAuthor: PropTypes.object,
 	};
 
 	state = {

--- a/client/post-editor/editor-action-bar/index.jsx
+++ b/client/post-editor/editor-action-bar/index.jsx
@@ -31,6 +31,7 @@ class EditorActionBar extends Component {
 		type: PropTypes.string,
 		isPostPrivate: PropTypes.bool,
 		postAuthor: PropTypes.object,
+		hasEditorNestedSidebar: PropTypes.bool,
 	};
 
 	state = {
@@ -48,11 +49,13 @@ class EditorActionBar extends Component {
 		return (
 			<div className="editor-action-bar">
 				<div className="editor-action-bar__cell is-left">
-					<EditorStatusLabel
-						post={ this.props.savedPost }
-						advancedStatus
-						type={ this.props.type }
-					/>
+					{ ! this.props.hasEditorNestedSidebar &&
+						<EditorStatusLabel
+							post={ this.props.savedPost }
+							advancedStatus
+							type={ this.props.type }
+						/>
+					}
 				</div>
 				<div className="editor-action-bar__cell is-center">
 					{ multiUserSite &&

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -365,6 +365,7 @@ export const PostEditor = React.createClass( {
 								type={ this.props.type }
 								isPostPrivate={ utils.isPrivate( this.state.post ) }
 								postAuthor={ this.state.post ? this.state.post.author : null }
+								hasEditorNestedSidebar={ this.state.nestedSidebar !== NESTED_SIDEBAR_NONE }
 							/>
 							<div className="post-editor__site">
 								<Site


### PR DESCRIPTION
Fixes #17445 

For the record, I'm not too happy about this fix, but we do have a weird document structure in that `EditorStatusLabel` is a descendent of `EditorActionBar`, even though visually they sit in opposite places, as `EditorStatusLabel` is `fixed` to the bottom of the editor. /cc @mtias since this is partly traceable to #11536.