### PR TITLE
Atomic: update eligibility warning messages

### DIFF
--- a/client/blocks/eligibility-warnings/hold-list.jsx
+++ b/client/blocks/eligibility-warnings/hold-list.jsx
@@ -54,7 +54,7 @@ function getHoldMessages( siteSlug, translate ) {
 			title: translate( 'Domain not using WordPress.com name servers' ),
 			description: translate( 'Your domain must use WordPress.com name servers to support custom code. ' +
 			'Follow step 2 in "add domain mapping" to resolve this.' ),
-			supportUrl: 'https://en.support.wordpress.com/domains/map-existing-domain/',
+			supportUrl: 'https://support.wordpress.com/domains/map-existing-domain/',
 		},
 		NOT_RESOLVING_TO_WPCOM: {
 			title: translate( 'Domain not pointing to WordPress.com servers' ),

--- a/client/blocks/eligibility-warnings/hold-list.jsx
+++ b/client/blocks/eligibility-warnings/hold-list.jsx
@@ -51,24 +51,28 @@ function getHoldMessages( siteSlug, translate ) {
 			supportUrl: 'https://support.wordpress.com/domains/',
 		},
 		NO_WPCOM_NAMESERVERS: {
-			title: translate( 'No WordPress.com name servers' ),
-			description: translate( 'Use WordPress.com name servers on your custom domain to resolve.' ),
-			supportUrl: 'https://support.wordpress.com/domain-helper/',
+			title: translate( 'Domain not using WordPress.com name servers' ),
+			description: translate( 'Your domain must use WordPress.com name servers to support custom code. ' +
+			'Follow step 2 in "add domain mapping" to resolve this.' ),
+			supportUrl: 'https://en.support.wordpress.com/domains/map-existing-domain/',
 		},
 		NOT_RESOLVING_TO_WPCOM: {
-			title: translate( 'Primary domain not pointing to WordPress.com servers' ),
-			description: translate( 'Point your primary domain to WordPress.com servers to resolve.' ),
-			supportUrl: 'https://support.wordpress.com/domain-helper/',
+			title: translate( 'Domain not pointing to WordPress.com servers' ),
+			description: translate( 'We cannot manage your site because your domain is not pointing to WordPress.com servers. ' +
+			'Follow the instructions to reset your domain A records to resolve this.' ),
+			supportUrl: 'https://support.wordpress.com/move-domain/setting-custom-a-records/',
 		},
 		NO_SSL_CERTIFICATE: {
-			title: translate( "Primary domain doesn't have a valid SSL certificate" ),
+			title: translate( 'We are setting up a security certificate for your domain' ),
 			description: translate(
-				'Please try again in a few minutes: you will be able to proceed once we finish setting up your security settings.'
+				'Your domain must have a security certificate to allow custom code. We are processing your security certificate now. ' +
+				'Please come back in a few minutes to try again.'
 			),
 		},
 		EMAIL_UNVERIFIED: {
 			title: translate( 'Unconfirmed email' ),
 			description: translate(
+				'You must have verified your email address with WordPress.com to install custom code. ' +
 				'Please check your email to confirm your address.'
 			),
 		},

--- a/client/blocks/eligibility-warnings/hold-list.jsx
+++ b/client/blocks/eligibility-warnings/hold-list.jsx
@@ -53,8 +53,9 @@ function getHoldMessages( siteSlug, translate ) {
 		NO_WPCOM_NAMESERVERS: {
 			title: translate( 'Domain not using WordPress.com name servers' ),
 			description: translate( 'Your domain must use WordPress.com name servers to support custom code. ' +
-			'Follow step 2 in "add domain mapping" to resolve this.' ),
-			supportUrl: 'https://support.wordpress.com/domains/map-existing-domain/',
+			'Ask your domain provider to update your DNS settings.' ),
+			supportUrl: 'https://en.support.wordpress.com/domains/map-existing-domain/' +
+			'#2-ask-your-domain-provider-to-update-your-dns-settings',
 		},
 		NOT_RESOLVING_TO_WPCOM: {
 			title: translate( 'Domain not pointing to WordPress.com servers' ),

--- a/client/blocks/eligibility-warnings/hold-list.jsx
+++ b/client/blocks/eligibility-warnings/hold-list.jsx
@@ -66,7 +66,7 @@ function getHoldMessages( siteSlug, translate ) {
 		NO_SSL_CERTIFICATE: {
 			title: translate( 'Security certificate required' ),
 			description: translate(
-				'We are setting up a security certificate for you domain now. Please try again in a few minutes.'
+				'We are setting up a security certificate for your domain now. Please try again in a few minutes.'
 			),
 		},
 		EMAIL_UNVERIFIED: {

--- a/client/blocks/eligibility-warnings/hold-list.jsx
+++ b/client/blocks/eligibility-warnings/hold-list.jsx
@@ -58,15 +58,14 @@ function getHoldMessages( siteSlug, translate ) {
 		},
 		NOT_RESOLVING_TO_WPCOM: {
 			title: translate( 'Domain not pointing to WordPress.com servers' ),
-			description: translate( 'We cannot manage your site because your domain is not pointing to WordPress.com servers. ' +
-			'Follow the instructions to reset your domain A records to resolve this.' ),
+			description: translate( 'We cannot manage your site because your domain does not point to WordPress.com servers. ' +
+			'Follow the instructions to reset your domain\'s A records to resolve this.' ),
 			supportUrl: 'https://support.wordpress.com/move-domain/setting-custom-a-records/',
 		},
 		NO_SSL_CERTIFICATE: {
-			title: translate( 'We are setting up a security certificate for your domain' ),
+			title: translate( 'Security certificate required' ),
 			description: translate(
-				'Your domain must have a security certificate to allow custom code. We are processing your security certificate now. ' +
-				'Please come back in a few minutes to try again.'
+				'We are setting up a security certificate for you domain now. Please try again in a few minutes.'
 			),
 		},
 		EMAIL_UNVERIFIED: {

--- a/client/blocks/eligibility-warnings/index.jsx
+++ b/client/blocks/eligibility-warnings/index.jsx
@@ -108,7 +108,7 @@ export const EligibilityWarnings = ( {
 			<Card className="eligibility-warnings__confirm-box">
 				<div className="eligibility-warnings__confirm-text">
 					{ ! isEligible && translate(
-						'You must resolve the errors above before proceeding. '
+						'The errors above must be resolved before proceeding. '
 					) }
 					{ isEligible && warnings.length > 0 && translate(
 						'If you proceed you will no longer be able to use these features. '


### PR DESCRIPTION
This PR is to resolve confusing and unhelpful messaging regarding some of the blockers for using Automated Transfer. I'm also changing the "resolve" link to point to instructions to help resolve these issues. The warnings were previously pointing to the domain helper which in practice hasn't been helpful for resolving these issues.

### Testing
Unless you see any obvious syntax issues, you can probably just look at the copy and the linked support pages to confirm it all makes sense. But if you'd like to run a quick test, go through NUX, create a business site with free credits, and immediately try to install a plugin. You'll likely get caught by the missing SSL error.