### PR TITLE
Move Store plugin installation process along more swiftly

### DIFF
--- a/client/extensions/woocommerce/app/dashboard/required-plugins-install-view.js
+++ b/client/extensions/woocommerce/app/dashboard/required-plugins-install-view.js
@@ -59,7 +59,7 @@ class RequiredPluginsInstallView extends Component {
 
 		this.updateTimer = window.setInterval( () => {
 			this.updateEngine();
-		}, 1000 );
+		}, 17 );
 	}
 
 	destroyUpdateTimer = () => {
@@ -83,6 +83,7 @@ class RequiredPluginsInstallView extends Component {
 
 	doInitialization = () => {
 		const { site, sitePlugins, translate, wporg } = this.props;
+		const { workingOn } = this.state;
 
 		if ( ! site ) {
 			return;
@@ -98,10 +99,13 @@ class RequiredPluginsInstallView extends Component {
 		}
 
 		if ( waitingForPluginListFromSite ) {
-			this.setState( {
-				message: translate( 'Waiting for plugin list from site' ),
-				progress: 0,
-			} );
+			if ( workingOn !== 'WAITING_FOR_PLUGIN_LIST_FROM_SITE' ) {
+				this.setState( {
+					message: translate( 'Waiting for plugin list from site' ),
+					progress: 0,
+					workingOn: 'WAITING_FOR_PLUGIN_LIST_FROM_SITE',
+				} );
+			}
 			return;
 		}
 
@@ -123,10 +127,13 @@ class RequiredPluginsInstallView extends Component {
 			}
 		}
 		if ( ! pluginDataLoaded ) {
-			this.setState( {
-				message: translate( 'Loading plugin data' ),
-				progress: 0,
-			} );
+			if ( workingOn !== 'LOAD_PLUGIN_DATA' ) {
+				this.setState( {
+					message: translate( 'Loading plugin data' ),
+					progress: 0,
+					workingOn: 'LOAD_PLUGIN_DATA',
+				} );
+			}
 			return;
 		}
 
@@ -149,6 +156,7 @@ class RequiredPluginsInstallView extends Component {
 				progress: 25,
 				toActivate,
 				toInstall,
+				workingOn: '',
 			} );
 			return;
 		}
@@ -159,6 +167,7 @@ class RequiredPluginsInstallView extends Component {
 				message: '',
 				progress: 50,
 				toActivate,
+				workingOn: '',
 			} );
 			return;
 		}

--- a/client/extensions/woocommerce/app/dashboard/required-plugins-install-view.js
+++ b/client/extensions/woocommerce/app/dashboard/required-plugins-install-view.js
@@ -57,6 +57,7 @@ class RequiredPluginsInstallView extends Component {
 			return;
 		}
 
+		// Proceed at rate of approximately 60 fps
 		this.updateTimer = window.setInterval( () => {
 			this.updateEngine();
 		}, 17 );
@@ -99,12 +100,14 @@ class RequiredPluginsInstallView extends Component {
 		}
 
 		if ( waitingForPluginListFromSite ) {
-			if ( workingOn !== 'WAITING_FOR_PLUGIN_LIST_FROM_SITE' ) {
-				this.setState( {
-					message: translate( 'Waiting for plugin list from site' ),
-					workingOn: 'WAITING_FOR_PLUGIN_LIST_FROM_SITE',
-				} );
+			if ( workingOn === 'WAITING_FOR_PLUGIN_LIST_FROM_SITE' ) {
+				return;
 			}
+
+			this.setState( {
+				message: translate( 'Waiting for plugin list from site' ),
+				workingOn: 'WAITING_FOR_PLUGIN_LIST_FROM_SITE',
+			} );
 			return;
 		}
 
@@ -126,12 +129,14 @@ class RequiredPluginsInstallView extends Component {
 			}
 		}
 		if ( ! pluginDataLoaded ) {
-			if ( workingOn !== 'LOAD_PLUGIN_DATA' ) {
-				this.setState( {
-					message: translate( 'Loading plugin data' ),
-					workingOn: 'LOAD_PLUGIN_DATA',
-				} );
+			if ( workingOn === 'LOAD_PLUGIN_DATA' ) {
+				return;
 			}
+
+			this.setState( {
+				message: translate( 'Loading plugin data' ),
+				workingOn: 'LOAD_PLUGIN_DATA',
+			} );
 			return;
 		}
 


### PR DESCRIPTION
Slight optimization of Store plugin installation process: more eagerly checks for completion of previous step and/or readiness for next step, in order to shave off idle time, taking total time for fresh install from 50-60 seconds to 30-40 seconds. Also avoids calling `setState` more than necessary in initialization step to ensure performant `updateEngine` calls.

Can modify the timer to use requestAnimationFrame if it makes sense, or on the other hand, can increase the interval if necessary.

Note that if the plugins were not already installed, those `doActivation` calls go by in a flash now, since the plugins are already being [activated](https://github.com/Automattic/wp-calypso/blob/24f6d41c364591e1e9dfe2433ff874bcecd8a79b/client/state/plugins/installed/actions.js#L245) as part of the `doInstallation` step, barring exceptional cases, perhaps. (Discussed and resolved in https://github.com/Automattic/wp-calypso/pull/16482#discussion_r129141519.) To better reflect what it actually needs to do on any given site, the progress bar calculation has also been adjusted to reflect the steps that are actually queued by the initialization step.