### PR TITLE
OAuth login: Check that the client_id matches the client in the redirect parameter

### DIFF
--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -2,14 +2,18 @@
  * External dependencies
  */
 import React from 'react';
+import { parse as parseUrl } from 'url';
+import qs from 'qs';
 
 /**
  * Internal dependencies
  */
+import EmptyContent from 'components/empty-content';
 import WPLogin from './wp-login';
 import MagicLogin from './magic-login';
 import HandleEmailedLinkForm from './magic-login/handle-emailed-link-form';
 import { fetchOAuth2ClientData } from 'state/login/oauth2/actions';
+import { recordTracksEvent } from 'state/analytics/actions';
 
 const enhanceContextWithLogin = context => {
 	const {
@@ -33,9 +37,22 @@ const enhanceContextWithLogin = context => {
 
 export default {
 	login( context, next ) {
-		const { query: { client_id } } = context;
+		const { query: { client_id, redirect_to } } = context;
 
 		if ( client_id ) {
+			const parsedRedirectUrl = parseUrl( redirect_to );
+			const redirectQueryString = qs.parse( parsedRedirectUrl.query );
+			if ( client_id !== redirectQueryString.client_id ) {
+				recordTracksEvent( 'calypso_login_phishing_attempt', context.query );
+				context.primary = (
+					<EmptyContent
+						title="Something went wrong"
+						line="It looks like there's a problem" />
+				);
+
+				next();
+			}
+
 			context.store.dispatch( fetchOAuth2ClientData( Number( client_id ) ) )
 				.then( () => {
 					enhanceContextWithLogin( context );

--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -4,6 +4,7 @@
 import React from 'react';
 import { parse as parseUrl } from 'url';
 import qs from 'qs';
+import { translate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -46,8 +47,8 @@ export default {
 				recordTracksEvent( 'calypso_login_phishing_attempt', context.query );
 				context.primary = (
 					<EmptyContent
-						title="Something went wrong"
-						line="It looks like there's a problem" />
+						title={ translate( 'Something went wrong' ) }
+						line={ translate( "It looks like there's a problem" ) } />
 				);
 
 				next();


### PR DESCRIPTION
Right now it's possible to display the log in details for one client and redirect a user to a different client. We should check that the client id we are displaying data for matches the one we are redirecting to, and show an error if that's not the case.
  
#### Testing instructions
  
1. Run `git checkout fix/oauth-security` and start your server
2. Open vaultpress.com
3. Try to log in with WordPress.com Connect
4. When you hit the login page change https://wordpress.com to http://calypso.localhost:3000
3. Check that you see the Vaultpress login page
5. Change the client id to 928
6. Check that you see an empty content page saying "Something went wrong"
  
#### Additional notes
  
This is also a concern with the old implementation, but that's not a reason to not fix it.
  
#### Reviews
  
- [x] Code
- [x] Product