### PR TITLE
A/B Test: Privacy protection auto added

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -114,4 +114,13 @@ module.exports = {
 		defaultVariation: 'original',
 		allowExistingUsers: true,
 	},
+	privacyNoPopup: {
+		datestamp: '20170828',
+		variations: {
+			original: 50,
+			nopopup: 50,
+		},
+		defaultVariation: 'original',
+		allowExistingUsers: true,
+	},
 };

--- a/client/my-sites/checkout/checkout/privacy-protection.jsx
+++ b/client/my-sites/checkout/checkout/privacy-protection.jsx
@@ -11,34 +11,38 @@ import { localize } from 'i18n-calypso';
 import { cartItems } from 'lib/cart-values';
 import PrivacyProtectionDialog from './privacy-protection-dialog';
 import Card from 'components/card';
+import { abtest } from 'lib/abtest';
+import FormFieldset from 'components/forms/form-fieldset';
+import FormLabel from 'components/forms/form-label';
+import FormRadio from 'components/forms/form-radio';
 
 class PrivacyProtection extends Component {
 	handleDialogSelect = ( options, event ) => {
 		event.preventDefault();
 		this.props.onDialogSelect( Object.assign( options, this.state ) );
 		this.setState( { skipFinish: false } );
-	}
+	};
 
 	handleDialogOpen = () => {
 		this.setState( { skipFinish: true } );
 		this.props.onDialogOpen();
-	}
+	};
 
 	handleDialogClose = () => {
 		this.props.onDialogClose();
-	}
+	};
 
 	hasDomainPartOfPlan = () => {
 		const cart = this.props.cart;
 		return cart.has_bundle_credit || cartItems.hasPlan( cart );
-	}
+	};
 
 	getPrivacyProtectionCost() {
 		const products = this.props.productsList.get();
 		return products.private_whois.cost_display;
 	}
 
-	render() {
+	renderOriginal() {
 		const domainRegistrations = cartItems.getDomainRegistrations( this.props.cart ),
 			{ translate } = this.props,
 			numberOfDomainRegistrations = domainRegistrations.length,
@@ -49,9 +53,9 @@ class PrivacyProtection extends Component {
 				'to protect your identity and prevent spam.'
 			),
 			freeWithPlan = hasOneFreePrivacy &&
-						<span className="checkout__privacy-protection-free-text">
-							{ translate( 'Free with your plan' ) }
-						</span>;
+					<span className="checkout__privacy-protection-free-text">
+						{ translate( 'Free with your plan' ) }
+					</span>;
 
 		return (
 			<div>
@@ -99,9 +103,131 @@ class PrivacyProtection extends Component {
 					isVisible={ this.props.isDialogVisible }
 					isFree={ hasOneFreePrivacy }
 					onSelect={ this.handleDialogSelect }
-					onClose={ this.handleDialogClose } />
+					onClose={ this.handleDialogClose }
+				/>
 			</div>
 		);
+	}
+
+	enablePrivacy = () => {
+		this.props.onRadioSelect( true );
+	};
+
+	disablePrivacy = () => {
+		this.props.onRadioSelect( false );
+	};
+
+	renderNoPopup() {
+		const domainRegistrations = cartItems.getDomainRegistrations( this.props.cart );
+		const { translate } = this.props;
+		const numberOfDomainRegistrations = domainRegistrations.length;
+
+		return (
+			<div>
+				<Card className="checkout__privacy-protection-radio">
+					<div>
+						{ translate(
+							'Domain owners have to share contact information in a public database of all domains. ' +
+							'With {{strong}}Privacy Protection{{/strong}}, we publish our own information instead of yours,' +
+							'and privately forward any communication to you.',
+							{
+								components: {
+									strong: <strong />
+								},
+							}
+						) }
+					</div>
+					<div className="checkout__privacy-protection-radio-buttons">
+						<FormFieldset>
+							<FormLabel className="checkout__privacy-protection-radio-button">
+								<FormRadio
+									value="private"
+									id="registrantType"
+									checked={ this.props.radioSelect === 'private' }
+									onChange={ this.enablePrivacy }
+								/>
+								<p className="checkout__privacy-protection-radio-text">
+									<span>
+										{
+											translate(
+												'{{strong}}Register privately with Privacy Protection{{/strong}} (recommended)' +
+												'',
+												{
+													components: {
+														strong: <strong />,
+													},
+												}
+											)
+										}
+									</span>
+									<span className={ 'checkout__privacy-protection-radio-price-text' }>
+										{
+											translate(
+												'%(cost)s/year',
+												'%(cost)s per domain/year',
+												{
+													args: { cost: this.getPrivacyProtectionCost() },
+													count: numberOfDomainRegistrations
+												}
+											)
+										}
+									</span>
+									<br />
+									<span className="checkout__privacy-protection-radio-text-description">
+									{
+										translate(
+											'Protects your identity and prevents spam by keeping your contact information ' +
+											'off the Internet.'
+										)
+									}
+									</span>
+								</p>
+							</FormLabel>
+
+							<FormLabel className="checkout__privacy-protection-radio-button">
+								<FormRadio
+									value="public"
+									id="registrantType"
+									checked={ this.props.radioSelect === 'public' }
+									onChange={ this.disablePrivacy }
+								/>
+								<p className="checkout__privacy-protection-radio-text">
+									<span>
+									{
+										translate(
+											'{{strong}}Register publicly{{/strong}}',
+											{
+												components: {
+													strong: <strong />,
+												},
+											}
+										)
+									}
+									</span>
+									<br />
+									<span className="checkout__privacy-protection-radio-text-description">
+									{
+										translate(
+											'Your contact information will be listed in a public database and will be ' +
+											'susceptible to spam.'
+										)
+									}
+									</span>
+								</p>
+							</FormLabel>
+						</FormFieldset>
+					</div>
+				</Card>
+			</div>
+		);
+	}
+
+	render() {
+		if ( abtest( 'privacyNoPopup' ) === 'nopopup' ) {
+			return this.renderNoPopup();
+		}
+
+		return this.renderOriginal();
 	}
 }
 

--- a/client/my-sites/checkout/checkout/privacy-protection.jsx
+++ b/client/my-sites/checkout/checkout/privacy-protection.jsx
@@ -11,6 +11,7 @@ import { localize } from 'i18n-calypso';
 import { cartItems } from 'lib/cart-values';
 import PrivacyProtectionDialog from './privacy-protection-dialog';
 import Card from 'components/card';
+import SectionHeader from 'components/section-header';
 import { abtest } from 'lib/abtest';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
@@ -124,6 +125,7 @@ class PrivacyProtection extends Component {
 
 		return (
 			<div>
+				<SectionHeader className="checkout__privacy-protection-header" label = { translate( 'Privacy Protection' ) } />
 				<Card className="checkout__privacy-protection-radio">
 					<div>
 						{ translate(

--- a/client/my-sites/checkout/checkout/style.scss
+++ b/client/my-sites/checkout/checkout/style.scss
@@ -959,11 +959,16 @@
 }
 
 .checkout__privacy-protection-radio-buttons {
-	margin-top: 30px;
+	margin-top: 20px;
 }
 
 .checkout__privacy-protection-radio-button {
 	display: flex;
+	margin-bottom: 15px;
+
+	&:last-child {
+		margin-bottom: 0;
+	}
 }
 
 .checkout__privacy-protection-radio-text {
@@ -972,7 +977,7 @@
 }
 
 .checkout__privacy-protection-radio-text-description {
-	color: $gray;
+	color: darken( $gray, 20% );
 }
 
 .checkout__privacy-protection-radio-price-text {

--- a/client/my-sites/checkout/checkout/style.scss
+++ b/client/my-sites/checkout/checkout/style.scss
@@ -950,3 +950,33 @@
 	padding-bottom: 1em;
 	text-align: center;
 }
+
+.checkout__privacy-protection-radio {
+	&.card {
+		display: flex;
+		flex-direction: column;
+	}
+}
+
+.checkout__privacy-protection-radio-buttons {
+	margin-top: 30px;
+}
+
+.checkout__privacy-protection-radio-button {
+	display: flex;
+}
+
+.checkout__privacy-protection-radio-text {
+	font-weight: normal;
+	margin: 0 0 0 10px;
+}
+
+.checkout__privacy-protection-radio-text-description {
+	color: $gray;
+}
+
+.checkout__privacy-protection-radio-price-text {
+	color: $blue-wordpress;
+	margin: 4px 0 0 10px;
+	font-size: 15px;
+}

--- a/client/my-sites/domains/domain-search/domain-search.jsx
+++ b/client/my-sites/domains/domain-search/domain-search.jsx
@@ -25,6 +25,7 @@ import QueryProductsList from 'components/data/query-products-list';
 import { getProductsList } from 'state/products-list/selectors';
 import { recordAddDomainButtonClick, recordRemoveDomainButtonClick } from 'state/domains/actions';
 import EmailVerificationGate from 'components/email-verification/email-verification-gate';
+import { abtest } from 'lib/abtest';
 
 class DomainSearch extends Component {
 	static propTypes = {
@@ -82,7 +83,8 @@ class DomainSearch extends Component {
 			cartItems.domainRegistration( { domain: suggestion.domain_name, productSlug: suggestion.product_slug } )
 		];
 
-		if ( suggestion.supports_privacy && cartItems.isNextDomainFree( this.props.cart ) ) {
+		if ( suggestion.supports_privacy &&
+			( cartItems.isNextDomainFree( this.props.cart ) || abtest( 'privacyNoPopup' ) === 'nopopup' ) ) {
 			items.push( cartItems.domainPrivacyProtection( {
 				domain: suggestion.domain_name
 			} ) );


### PR DESCRIPTION
- Auto add privacy protection
- Change checkbox to a radio button
- Remove the privacy popup

Before:
![privacy old](https://user-images.githubusercontent.com/1103398/29637885-d6fb8ad6-8855-11e7-8b2d-d26fc131216f.png)
After:
![image](https://user-images.githubusercontent.com/12596797/29717134-0fedeb3c-897c-11e7-9338-394291d42832.png)


Test:
- Domains -> Add
- Select a domain
- Make sure it's auto-added
- Make sure the privacy form on details form works

Test Signup:
- http://calypso.localhost:3000/start/
- Get to the domains screen
- Pick a domain with plan
- Make sure privacy is added

Test /domains:
- calypso.localhost:3000/start/domain-first?new=testing-privacy-auto-add-hehe-666.blog
- Just buy a domain
- make sure privacy is auto added

