### PR TITLE
Stats: Inconsistent blog_id in calypso_page_view stats

### DIFF
--- a/client/lib/analytics/index.js
+++ b/client/lib/analytics/index.js
@@ -204,11 +204,12 @@ const analytics = {
 			}
 
 			if ( _superProps ) {
+				_dispatch && _dispatch( { type: ANALYTICS_SUPER_PROPS_UPDATE } );
 				// HACK: _selectedSite should only be used if path contains `:site`.
 				// This hack is enabled only for `calypso_page_view` event but may need to be expanded
 				// if other events require same special handling.
-				const useSelectedSite = eventName !== 'calypso_page_view' || eventProperties.path.indexOf( ':site' ) !== -1;
-				_dispatch && _dispatch( { type: ANALYTICS_SUPER_PROPS_UPDATE } );
+				const hasPathWithSite = eventProperties.path && eventProperties.path.indexOf( ':site' ) !== -1;
+				const useSelectedSite = hasPathWithSite || eventName !== 'calypso_page_view';
 				superProperties = _superProps.getAll( useSelectedSite ? _selectedSite : null, _siteCount );
 				eventProperties = assign( {}, eventProperties, superProperties ); // assign to a new object so we don't modify the argument
 			}

--- a/client/lib/analytics/index.js
+++ b/client/lib/analytics/index.js
@@ -204,8 +204,12 @@ const analytics = {
 			}
 
 			if ( _superProps ) {
+				// HACK: _selectedSite should only be used if path contains `:site`.
+				// This hack is enabled only for `calypso_page_view` event but may need to be expanded
+				// if other events require same special handling.
+				const useSelectedSite = eventName !== 'calypso_page_view' || eventProperties.path.indexOf( ':site' ) !== -1;
 				_dispatch && _dispatch( { type: ANALYTICS_SUPER_PROPS_UPDATE } );
-				superProperties = _superProps.getAll( _selectedSite, _siteCount );
+				superProperties = _superProps.getAll( useSelectedSite ? _selectedSite : null, _siteCount );
 				eventProperties = assign( {}, eventProperties, superProperties ); // assign to a new object so we don't modify the argument
 			}
 


### PR DESCRIPTION
`blog_id` should be null for paths without `:site`, like `/me` or `/read/search`.

Addresses first part of issue #16900 

Test Plan:

1. Open console and enable stat event tracking
```
localStorage.setItem('debug', 'calypso:analytics:tracks')`
```
2. Click on user avatar to navigate to `/me`.
3. Find console line starting with `calypso:analytics:tracks Recording event "calypso_page_view" with actual props` and expand it.
4. You should **not** see `blog_id`.
5. Click on "Reader" then "Search" to navigate to `/reader/search`.
6. Repeat step 3 and 4.
7. Navigate to a post and repeat 3 and 4 except now `blog_id` should be present.
