### PR TITLE
WebpackBuildMonitor: fix setState infinite loop

### DIFF
--- a/client/components/webpack-build-monitor/index.jsx
+++ b/client/components/webpack-build-monitor/index.jsx
@@ -7,7 +7,7 @@
 import React from 'react';
 import { createStore } from 'redux';
 import classNames from 'classnames';
-import { find, includes, startsWith, identity } from 'lodash';
+import { find, includes, startsWith, identity, isEqual } from 'lodash';
 
 /**
  * Internal dependencies
@@ -111,7 +111,7 @@ class WebpackBuildMonitor extends React.Component {
 	componentDidMount() {
 		this.unsubscribe = store.subscribe( () => {
 			const status = store.getState();
-			if ( status !== this.state.status ) {
+			if ( ! isEqual( status, this.state ) ) {
 				this.setState( store.getState() );
 			}
 		} );


### PR DESCRIPTION
As things are now, I'm sometimes running into an infinite loop when trying to load run calypso in development.

We need to be extra careful about calling `setState` in WBM --  More than in other components.  A setState that occurs during a render will cause an infinite loop to occur because of how React shoots out warnings that then create new dispatches etc etc.

this pr fixes the infinite loop by checking that state has deeply changed before calling setState.