### PR TITLE
Editor: Keep editor cursor while switching between Visual and HTML modes

### DIFF
--- a/client/components/tinymce/index.jsx
+++ b/client/components/tinymce/index.jsx
@@ -368,12 +368,60 @@ module.exports = React.createClass( {
 		}.bind( this ) );
 	},
 
+	beforeSetContentHook: function( ed ) {
+		if ( ! ed ) {
+			return;
+		}
+
+		const htmlModeCursorStartPosition = ed.target.getElement().selectionStart;
+		const htmlModeCursorEndPosition = ed.target.getElement().selectionEnd;
+
+		let mode = 'single';
+		if ( htmlModeCursorStartPosition !== htmlModeCursorEndPosition ) {
+			mode = 'range';
+		}
+
+		let bookMarkStart = null;
+		if ( mode === 'single' ) {
+			// single mode - insert a single bookmark
+			bookMarkStart = '<span data-mce-type="bookmark"	' +
+				'id="mce_SELREST_start" ' +
+				'data-mce-style="overflow:hidden;line-height:0px" ' +
+				'style="overflow:hidden;line-height:0px">' +
+				'&#65279;' +
+				'</span>';
+		}
+		else {
+			debugger;
+		}
+
+		// TODO detect if you're not in a tag to not break things
+		ed.content = [
+			ed.content.slice( 0, htmlModeCursorStartPosition ),
+			bookMarkStart,
+			ed.content.slice( htmlModeCursorStartPosition )
+		].join( '' );
+
+		console.log(ed.content);
+
+		ed.target.off( 'BeforeSetContent', this.beforeSetContentHook );
+	},
+
 	toggleEditor: function( options = { autofocus: true } ) {
 		if ( ! this._editor ) {
 			return;
 		}
 
 		if ( this.props.mode === 'html' ) {
+			console.log( 'BEFORE SET CONTENT' );
+
+			this._editor.on( 'BeforeSetContent', this.beforeSetContentHook );
+
+
+			this._editor.on( 'SetContent', ( ed ) => {
+				console.log( 'CONTENT SET' );
+			} );
+
 			this._editor.hide();
 			this.doAutosizeUpdate();
 			if ( options.autofocus ) {

--- a/client/components/tinymce/index.jsx
+++ b/client/components/tinymce/index.jsx
@@ -394,7 +394,6 @@ module.exports = React.createClass( {
 			const textNode = ReactDom.findDOMNode( this.refs.text );
 
 			// Collapse selection to avoid scrolling to the bottom of the textarea
-			console.error( 'SELECTING: ', this.state.selection );
 			if ( this.state.selection ) {
 				this.selectTextInTextArea( this.state.selection );
 			} else {

--- a/client/components/tinymce/index.jsx
+++ b/client/components/tinymce/index.jsx
@@ -471,7 +471,7 @@ module.exports = React.createClass( {
 		const textNode = ReactDom.findDOMNode( this.refs.text );
 
 		const start = selection.start;
-		const end = selection.end ? selection.end : selection.start;
+		const end = selection.end || selection.start;
 		// Collapse selection to avoid scrolling to the bottom of the textarea
 		textNode.setSelectionRange( start, end );
 

--- a/client/components/tinymce/index.jsx
+++ b/client/components/tinymce/index.jsx
@@ -368,60 +368,12 @@ module.exports = React.createClass( {
 		}.bind( this ) );
 	},
 
-	beforeSetContentHook: function( ed ) {
-		if ( ! ed ) {
-			return;
-		}
-
-		const htmlModeCursorStartPosition = ed.target.getElement().selectionStart;
-		const htmlModeCursorEndPosition = ed.target.getElement().selectionEnd;
-
-		let mode = 'single';
-		if ( htmlModeCursorStartPosition !== htmlModeCursorEndPosition ) {
-			mode = 'range';
-		}
-
-		let bookMarkStart = null;
-		if ( mode === 'single' ) {
-			// single mode - insert a single bookmark
-			bookMarkStart = '<span data-mce-type="bookmark"	' +
-				'id="mce_SELREST_start" ' +
-				'data-mce-style="overflow:hidden;line-height:0px" ' +
-				'style="overflow:hidden;line-height:0px">' +
-				'&#65279;' +
-				'</span>';
-		}
-		else {
-			debugger;
-		}
-
-		// TODO detect if you're not in a tag to not break things
-		ed.content = [
-			ed.content.slice( 0, htmlModeCursorStartPosition ),
-			bookMarkStart,
-			ed.content.slice( htmlModeCursorStartPosition )
-		].join( '' );
-
-		console.log(ed.content);
-
-		ed.target.off( 'BeforeSetContent', this.beforeSetContentHook );
-	},
-
 	toggleEditor: function( options = { autofocus: true } ) {
 		if ( ! this._editor ) {
 			return;
 		}
 
 		if ( this.props.mode === 'html' ) {
-			console.log( 'BEFORE SET CONTENT' );
-
-			this._editor.on( 'BeforeSetContent', this.beforeSetContentHook );
-
-
-			this._editor.on( 'SetContent', ( ed ) => {
-				console.log( 'CONTENT SET' );
-			} );
-
 			this._editor.hide();
 			this.doAutosizeUpdate();
 			if ( options.autofocus ) {
@@ -441,14 +393,14 @@ module.exports = React.createClass( {
 			const textNode = ReactDom.findDOMNode( this.refs.text );
 
 			// Collapse selection to avoid scrolling to the bottom of the textarea
-			textNode.setSelectionRange( 0, 0 );
+			//textNode.setSelectionRange( 0, 0 );
 
 			// Browser is not Internet Explorer 11
 			if ( 11 !== tinymce.Env.ie ) {
-				textNode.focus();
+			//	textNode.focus();
 			}
 		} else if ( this._editor ) {
-			this._editor.focus();
+			//this._editor.focus();
 		}
 	},
 

--- a/client/components/tinymce/index.jsx
+++ b/client/components/tinymce/index.jsx
@@ -195,7 +195,8 @@ module.exports = React.createClass( {
 
 	getInitialState: function() {
 		return {
-			content: ''
+			content: '',
+			selection: null,
 		};
 	},
 
@@ -393,14 +394,19 @@ module.exports = React.createClass( {
 			const textNode = ReactDom.findDOMNode( this.refs.text );
 
 			// Collapse selection to avoid scrolling to the bottom of the textarea
-			//textNode.setSelectionRange( 0, 0 );
+			console.error( 'SELECTING: ', this.state.selection );
+			if ( this.state.selection ) {
+				this.selectTextInTextArea( this.state.selection );
+			} else {
+				textNode.setSelectionRange( 0, 0 );
+			}
 
 			// Browser is not Internet Explorer 11
 			if ( 11 !== tinymce.Env.ie ) {
-			//	textNode.focus();
+				textNode.focus();
 			}
 		} else if ( this._editor ) {
-			//this._editor.focus();
+			this._editor.focus();
 		}
 	},
 
@@ -449,6 +455,29 @@ module.exports = React.createClass( {
 		}
 
 		this.setTextAreaContent( content );
+	},
+
+	setSelection: function( selection ) {
+		this.setState( {
+			selection
+		} );
+	},
+
+	selectTextInTextArea: function( selection ) {
+		// only valid in the text area mode and if we have selection
+		if ( ! selection ) {
+			return;
+		}
+
+		const textNode = ReactDom.findDOMNode( this.refs.text );
+
+		const start = selection.start;
+		const end = selection.end ? selection.end : selection.start;
+		// Collapse selection to avoid scrolling to the bottom of the textarea
+		textNode.setSelectionRange( start, end );
+
+		// clear out the selection from the state
+		this.setState( { selection: null } );
 	},
 
 	onTextAreaChange: function( event ) {

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -1152,11 +1152,11 @@ export const PostEditor = React.createClass( {
 		if ( ! endNode ) {
 			ed.target.selection.select( startNode );
 		} else {
-			const sel = document.createRange();
-			sel.setStart( startNode, 0 );
-			sel.setEnd( endNode, 0 );
+			const selection = document.createRange();
+			selection.setStart( startNode, 0 );
+			selection.setEnd( endNode, 0 );
 
-			ed.target.selection.setRng( sel );
+			ed.target.selection.setRng( selection );
 			endNode.parentNode.removeChild( endNode );
 		}
 

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -1072,17 +1072,17 @@ export const PostEditor = React.createClass( {
 		// Defer actions until next available tick to avoid
 		// dispatching inside a dispatch which can happen if for example the
 		// title field is focused when toggling the editor.
-		this._switchEditorTimeout = setTimeout( function() {
-			// TODO: REDUX - remove flux actions when whole post-editor is reduxified
-			actions.edit( { content: content } );
-
-			if ( mode === 'html' ) {
-				// Set raw content directly to avoid race conditions
-				actions.editRawContent( content );
-			} else {
-				this.saveRawContent();
-			}
-		}.bind( this ), 0 );
+		// this._switchEditorTimeout = setTimeout( function() {
+		// 	// TODO: REDUX - remove flux actions when whole post-editor is reduxified
+		// 	actions.edit( { content: content } );
+		//
+		// 	if ( mode === 'html' ) {
+		// 		// Set raw content directly to avoid race conditions
+		// 		actions.editRawContent( content );
+		// 	} else {
+		// 		this.saveRawContent();
+		// 	}
+		// }.bind( this ), 0 );
 	}
 
 } );

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -1272,26 +1272,20 @@ export const PostEditor = React.createClass( {
 			'<span[^>]*\\s*class="mce_SELRES_end"[^>]+>\\s*' + selectionID + '[^<]*<\\/span>'
 		);
 
-		// Find the `_start` node
 		const startMatch = content.match( startRegex );
+		const endMatch = content.match( endRegex );
 		if ( ! startMatch ) {
 			return null;
 		}
 
-		const selectionRange = {
+		return {
 			start: startMatch.index,
+
+			// We need to adjust the end position to discard the length of the range start marker
+			end: endMatch
+				? endMatch.index - startMatch[ 0 ].length
+				: null
 		};
-
-		// Find the `_end` node
-		const endMatch = content.match( endRegex );
-		if ( ! endMatch ) {
-			return selection;
-		}
-
-		// We need to adjust the end position to discard the length of the range start marker
-		selectionRange.end = endMatch.index - startMatch[ 0 ].length;
-
-		return selectionRange;
 	},
 
 	switchEditorMode: function( mode ) {

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -1100,10 +1100,10 @@ export const PostEditor = React.createClass( {
 			htmlModeCursorEndPosition = isCursorEndInTag.gtPos;
 		}
 
-		let mode = 'single';
-		if ( htmlModeCursorStartPosition !== htmlModeCursorEndPosition ) {
-			mode = 'range';
-		}
+		const mode =
+			htmlModeCursorStartPosition !== htmlModeCursorEndPosition
+			? 'range'
+			: 'single';
 
 		const bookMarkStart = '<span ' +
 			'data-mce-type="bookmark"	' +

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -63,6 +63,7 @@ import { isWithinBreakpoint } from 'lib/viewport';
 import { isSitePreviewable } from 'state/sites/selectors';
 import EditorDiffViewer from 'post-editor/editor-diff-viewer';
 import { NESTED_SIDEBAR_NONE, NESTED_SIDEBAR_REVISIONS } from 'post-editor/editor-sidebar/constants';
+import { removep } from 'lib/formatting';
 
 export const PostEditor = React.createClass( {
 	propTypes: {
@@ -1259,10 +1260,7 @@ export const PostEditor = React.createClass( {
 		 * Unfortunately the content goes through some more changes after this step, before it gets inserted
 		 * in the `textarea`. This means that we have to do some minor cleanup on our own here.
 		 */
-		const content = editor.getContent()
-			.replace( /(\[\/[^\]]+\]\s*)<p>/g, '$1\n\n' ) // fix short codes
-			.replace( /<p>/g, '' ) // remove `<p>`s, as they don't play any role
-			.replace( /<\/p>/g, '\n\n' ); // replace `</p>` with two new lines.
+		const content = removep( editor.getContent() );
 
 		const startRegex = new RegExp(
 			'<span[^>]*\\s*class="mce_SELRES_start"[^>]+>\\s*' + selectionID + '[^<]*<\\/span>'

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -11,6 +11,7 @@ import { bindActionCreators } from 'redux';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
 import tinyMce from 'tinymce/tinymce';
+import { v4 as uuid } from 'uuid';
 
 /**
  * Internal dependencies
@@ -1194,7 +1195,7 @@ export const PostEditor = React.createClass( {
 		 * format specified below.
 		 * @type {string}
 		 */
-		const selectionID = 'SELRES_' + Math.random();
+		const selectionID = 'SELRES_' + uuid();
 
 		/**
 		 * Create two marker elements that will be used to mark the start and the end of the range.

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -1108,7 +1108,6 @@ export const PostEditor = React.createClass( {
 	},
 
 	focusHTMLBookmarkInVisualEditor: function( ed ) {
-		console.log( 'CONTENT SET' );
 		const startNode = ed.target.getDoc().getElementById( 'mce_SELREST_start' );
 		const endNode = ed.target.getDoc().getElementById( 'mce_SELREST_end' );
 
@@ -1146,14 +1145,8 @@ export const PostEditor = React.createClass( {
 				// This resets the word count if it exists
 				this.copySelectedText();
 			}
-		}
-		else if ( mode === 'tinymce' ) {
-			console.log( 'BEFORE SET CONTENT' );
-			//debugger;
+		} else if ( mode === 'tinymce' ) {
 			this.addHTMLBookmarkInTextAreaContent();
-			this.editor._editor.on( 'BeforeSetContent', ( ed ) => {
-				console.log( 'EVENT CONTENT: ', ed.content )
-			} );
 			this.editor._editor.on( 'SetContent', this.focusHTMLBookmarkInVisualEditor );
 		}
 
@@ -1162,17 +1155,17 @@ export const PostEditor = React.createClass( {
 		// Defer actions until next available tick to avoid
 		// dispatching inside a dispatch which can happen if for example the
 		// title field is focused when toggling the editor.
-		// this._switchEditorTimeout = setTimeout( function() {
-		// 	// TODO: REDUX - remove flux actions when whole post-editor is reduxified
-		// 	actions.edit( { content: content } );
-		//
-		// 	if ( mode === 'html' ) {
-		// 		// Set raw content directly to avoid race conditions
-		// 		actions.editRawContent( content );
-		// 	} else {
-		// 		this.saveRawContent();
-		// 	}
-		// }.bind( this ), 0 );
+		this._switchEditorTimeout = setTimeout( function() {
+			// TODO: REDUX - remove flux actions when whole post-editor is reduxified
+			actions.edit( { content: content } );
+
+			if ( mode === 'html' ) {
+				// Set raw content directly to avoid race conditions
+				actions.editRawContent( content );
+			} else {
+				this.saveRawContent();
+			}
+		}.bind( this ), 0 );
 	}
 
 } );

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -1159,7 +1159,6 @@ export const PostEditor = React.createClass( {
 			endNode.parentNode.removeChild( endNode );
 		}
 
-		// TODO: Scroll to cursor position?
 		startNode.parentNode.removeChild( startNode );
 
 		ed.target.off( 'SetContent', this.focusHTMLBookmarkInVisualEditor );

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -1054,7 +1054,7 @@ export const PostEditor = React.createClass( {
 		return editorMode;
 	},
 
-	isCursorInATag: function( content, cursorPosition ) {
+	getContainingTagInfo: function( content, cursorPosition ) {
 		const lastLtPos = content.lastIndexOf( '<', cursorPosition );
 		const lastGtPos = content.lastIndexOf( '>', cursorPosition );
 
@@ -1089,12 +1089,12 @@ export const PostEditor = React.createClass( {
 		let htmlModeCursorEndPosition = textArea.selectionEnd;
 
 		// check if the cursor is in a tag and if so, adjust it
-		const isCursorStartInTag = this.isCursorInATag( textArea.value, htmlModeCursorStartPosition );
+		const isCursorStartInTag = this.getContainingTagInfo( textArea.value, htmlModeCursorStartPosition );
 		if ( isCursorStartInTag ) {
 			htmlModeCursorStartPosition = isCursorStartInTag.ltPos;
 		}
 
-		const isCursorEndInTag = this.isCursorInATag( textArea.value, htmlModeCursorEndPosition );
+		const isCursorEndInTag = this.getContainingTagInfo( textArea.value, htmlModeCursorEndPosition );
 		if ( isCursorEndInTag ) {
 			htmlModeCursorEndPosition = isCursorEndInTag.gtPos;
 		}

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -554,7 +554,6 @@ export const PostEditor = React.createClass( {
 				// incorrect post type in URL
 				page.redirect( utils.getEditURL( post, site ) );
 			}
-			//debugger;
 			this.setState( postEditState, function() {
 				if ( this.editor && ( didLoad || this.state.isLoadingRevision ) ) {
 					this.editor.setEditorContent( this.state.post.content, { initial: true } );

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -1071,7 +1071,7 @@ export const PostEditor = React.createClass( {
 
 			const tagType = tagMatch[ 2 ];
 			const closingGt = tagContent.indexOf( '>' );
-			const isClosingTag = ! ! tagMatch[ 1 ];
+			const isClosingTag = !! tagMatch[ 1 ];
 
 			return {
 				ltPos: lastLtPos,

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -1083,6 +1083,19 @@ export const PostEditor = React.createClass( {
 		return null;
 	},
 
+	getCursorMarkerSpan: function( type ) {
+		const tagType = type ? type : 'start';
+
+		return '<span ' +
+			'data-mce-type="bookmark"	' +
+			'id="mce_SELREST_' + tagType + '" ' +
+			'data-mce-style="overflow:hidden;line-height:0px" ' +
+			'style="overflow:hidden;line-height:0px"' +
+			'>' +
+			'&#65279;' +
+			'</span>';
+	},
+
 	addHTMLBookmarkInTextAreaContent: function() {
 		const textArea = this.editor._editor.getElement();
 
@@ -1105,41 +1118,25 @@ export const PostEditor = React.createClass( {
 			? 'range'
 			: 'single';
 
-		const bookMarkStart = '<span ' +
-			'data-mce-type="bookmark"	' +
-			'id="mce_SELREST_start" ' +
-			'data-mce-style="overflow:hidden;line-height:0px" ' +
-			'style="overflow:hidden;line-height:0px"' +
-			'>' +
-			'&#65279;' +
-			'</span>';
+		const bookMarkStart = this.getCursorMarkerSpan( 'start' );
 
-		let bookMarkEnd = null;
+		let selectedText = null;
+
 		if ( mode === 'range' ) {
-			bookMarkEnd = '<span ' +
-				'data-mce-type="bookmark"	' +
-				'id="mce_SELREST_end" ' +
-				'data-mce-style="overflow:hidden;line-height:0px" ' +
-				'style="overflow:hidden;line-height:0px"' +
-				'>' +
-				'&#65279;' +
-				'</span>';
+			const bookMarkEnd = this.getCursorMarkerSpan( 'end' );
 
-			// // TODO detect if you're not in a tag to not break things
-			textArea.value = [
-				textArea.value.slice( 0, htmlModeCursorStartPosition ),
-				bookMarkStart,
+			selectedText = [
 				textArea.value.slice( htmlModeCursorStartPosition, htmlModeCursorEndPosition ),
 				bookMarkEnd,
-				textArea.value.slice( htmlModeCursorEndPosition ),
-			].join( '' );
-		} else {
-			textArea.value = [
-				textArea.value.slice( 0, htmlModeCursorStartPosition ),
-				bookMarkStart,
-				textArea.value.slice( htmlModeCursorStartPosition )
 			].join( '' );
 		}
+
+		textArea.value = [
+			textArea.value.slice( 0, htmlModeCursorStartPosition ),
+			bookMarkStart,
+			selectedText,
+			textArea.value.slice( htmlModeCursorEndPosition )
+		].join( '' );
 
 		this.editor.onTextAreaChange( { target: { value: textArea.value } } );
 	},

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -1087,14 +1087,12 @@ export const PostEditor = React.createClass( {
 	getCursorMarkerSpan: function( type ) {
 		const tagType = type ? type : 'start';
 
-		return '<span ' +
-			'data-mce-type="bookmark"	' +
-			'id="mce_SELREST_' + tagType + '" ' +
-			'data-mce-style="overflow:hidden;line-height:0px" ' +
-			'style="overflow:hidden;line-height:0px"' +
-			'>' +
-			'&#65279;' +
-			'</span>';
+		return `<span
+				data-mce-type="bookmark"	
+				id="mce_SELREST_${ tagType }"
+				data-mce-style="overflow:hidden;line-height:0"
+				style="overflow:hidden;line-height:0"
+			>&#65279;</span>`;
 	},
 
 	addHTMLBookmarkInTextAreaContent: function() {

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -1168,7 +1168,7 @@ export const PostEditor = React.createClass( {
 	/**
 	 * Finds the current selection position in the Visual editor.
 	 *
-	 * It uses some black magic raw JS magic. Not for the faint-hearted.
+	 * It uses some black magic raw JS trickery. Not for the faint-hearted.
 	 *
 	 * @param {Object} editor The editor where we must find the selection
 	 * @returns {null | Object} The selection range position in the editor

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -1118,8 +1118,6 @@ export const PostEditor = React.createClass( {
 			? 'range'
 			: 'single';
 
-		const bookMarkStart = this.getCursorMarkerSpan( 'start' );
-
 		let selectedText = null;
 
 		if ( mode === 'range' ) {
@@ -1132,10 +1130,10 @@ export const PostEditor = React.createClass( {
 		}
 
 		textArea.value = [
-			textArea.value.slice( 0, htmlModeCursorStartPosition ),
-			bookMarkStart,
-			selectedText,
-			textArea.value.slice( htmlModeCursorEndPosition )
+			textArea.value.slice( 0, htmlModeCursorStartPosition ), // text until the cursor/selection position
+			this.getCursorMarkerSpan( 'start' ), 					// cursor/selection start marker
+			selectedText, 											// selected text with end cursor/position marker
+			textArea.value.slice( htmlModeCursorEndPosition )		// text from last cursor/selection position to end
 		].join( '' );
 
 		this.editor.onTextAreaChange( { target: { value: textArea.value } } );

--- a/client/state/initial-state.js
+++ b/client/state/initial-state.js
@@ -68,6 +68,7 @@ function addSympathy( initialStateLoader ) {
 		! config.isEnabled( 'no-force-sympathy' ) // unless purposefully disabled
 	);
 
+	return initialStateLoader;
 	if ( ! shouldAdd ) {
 		return initialStateLoader;
 	}

--- a/client/state/initial-state.js
+++ b/client/state/initial-state.js
@@ -68,7 +68,6 @@ function addSympathy( initialStateLoader ) {
 		! config.isEnabled( 'no-force-sympathy' ) // unless purposefully disabled
 	);
 
-	return initialStateLoader;
 	if ( ! shouldAdd ) {
 		return initialStateLoader;
 	}


### PR DESCRIPTION
This PR aims to improve the Editor experience by keeping the selection persistent between Visual and HTML modes. The issue was originally reported in #8592.

### A GIF is worth a thousand words
![save-cursor-position](https://user-images.githubusercontent.com/184938/29719904-bdfe6370-89c0-11e7-8661-4e7249b14250.gif)

### What is this?

The editor had no functionality to save the selection from one mode and transfer it to other. This PR adds a basic functionality that does that.

Currently the following is supported:
 * Cursor position preserved
 * Selection range preserved
 * Clicking inside a tag, in HTML mode, will select the whole tag, avoiding breaking the tag when switching modes
 * Selecting an object in Visual mode should select the whole object it in HTML mode.

What is not supported by this PR:
 * Keeping the scroll position. This issue needs design work, since in order to keep the scroll position, the switcher buttons should be visible at all times, which is not the case at the moment.

### To test:

1. Checkout branch or use Calypso.live link
2. Open the editor
3. Add content, click around, select things
4. Try embeds
5. Try shortcodes
6. Look for JS errors in the console, weird behavior, etc.

### Known issues:

- [ ] Unable to select images in Caption shortcode. There's a weird behavior with shortcodes and HTML tags inside.