### PR TITLE
Login: Oauth: Redirect_to undefined

### DIFF
--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -36,21 +36,30 @@ const enhanceContextWithLogin = context => {
 	);
 };
 
+const showErrorForBadOAuthQueryStringParameters = context => {
+	context.primary = (
+		<EmptyContent
+			title={ translate( 'Something went wrong' ) }
+			line={ translate( "It looks like there's a problem" ) } />
+	);
+};
+
 export default {
 	login( context, next ) {
 		const { query: { client_id, redirect_to } } = context;
 
 		if ( client_id ) {
+			if ( ! redirect_to ) {
+				showErrorForBadOAuthQueryStringParameters( context );
+				next();
+			}
+
 			const parsedRedirectUrl = parseUrl( redirect_to );
 			const redirectQueryString = qs.parse( parsedRedirectUrl.query );
+
 			if ( client_id !== redirectQueryString.client_id ) {
 				recordTracksEvent( 'calypso_login_phishing_attempt', context.query );
-				context.primary = (
-					<EmptyContent
-						title={ translate( 'Something went wrong' ) }
-						line={ translate( "It looks like there's a problem" ) } />
-				);
-
+				showErrorForBadOAuthQueryStringParameters( context );
 				next();
 			}
 

--- a/server/isomorphic-routing/index.js
+++ b/server/isomorphic-routing/index.js
@@ -7,7 +7,7 @@ import qs from 'qs';
 /**
  * Internal dependencies
  */
-import { serverRender } from 'render';
+import { serverRender, serverRenderError } from 'render';
 import { setSection as setSectionMiddlewareFactory } from '../../client/controller';
 import { setRoute as setRouteAction } from 'state/ui/actions';
 
@@ -23,12 +23,7 @@ export function serverRouter( expressApp, setUpRoute, section ) {
 				( err, req, res, next ) => {
 					route( err, req.context, next );
 				},
-				// We need 4 args so Express knows this is an error-handling middleware
-				// TODO: Ideally, there'd be a dedicated serverRenderError middleware in server/render
-				( err, req, res, next ) => { // eslint-disable-line no-unused-vars
-					req.error = err;
-					serverRender( req, res.status( err.status ) );
-				}
+				serverRenderError
 			);
 		} else {
 			expressApp.get(
@@ -39,7 +34,8 @@ export function serverRouter( expressApp, setUpRoute, section ) {
 					setRouteMiddleware,
 					...middlewares
 				),
-				serverRender
+				serverRender,
+				serverRenderError
 			);
 		}
 	};

--- a/server/render/index.js
+++ b/server/render/index.js
@@ -127,3 +127,17 @@ export function serverRender( req, res ) {
 		res.render( 'index.jade', context );
 	}
 }
+
+export function serverRenderError( err, req, res, next ) {
+	if ( err ) {
+		if ( config( 'env' ) !== 'production' ) {
+			console.error( err );
+		}
+		req.error = err;
+		res.status( err.status || 500 );
+		res.render( '500.jade', req.context );
+		return;
+	}
+
+	next();
+}


### PR DESCRIPTION
This pull request catches the case when a user tries to access log in with a client_id but no redirect_to parameter. In this case we should show an error.

  
#### Testing instructions
  
1. Run `git checkout fix/oauth-login` and start your server
2. Open http://calypso.localhost:3000/log-in?client_id=123
3. Check that you see an error page, not the log in form.
 
#### Reviews
  
- [ ] Code
- [ ] Product