### PR TITLE
Custom plan headings for Jetpack plans

### DIFF
--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -293,6 +293,9 @@ export const PLANS_LIST = {
 				}
 			} );
 		},
+		getTagline: () => i18n.translate(
+			'Learn more about everything included with Business and take advantage of its professional features.'
+		),
 		getFeatures: () => compact( [ // pay attention to ordering, shared features should align on /plan page
 			FEATURE_CUSTOM_DOMAIN,
 			FEATURE_JETPACK_ESSENTIAL,
@@ -389,6 +392,9 @@ export const PLANS_LIST = {
 				'Automated backups and malware scanning, expert priority ' +
 				'support, marketing automation, and more.'
 		),
+		getTagline: () => i18n.translate(
+			'Your site is being secured and you have access to marketing tools and priority support.'
+		),
 		getFeatures: () => compact( [  // pay attention to ordering, shared features should align on /plan page
 			FEATURE_OFFSITE_BACKUP_VAULTPRESS_DAILY,
 			FEATURE_BACKUP_ARCHIVE_30,
@@ -430,6 +436,9 @@ export const PLANS_LIST = {
 		getDescription: () => i18n.translate(
 				'Automated backups and malware scanning, expert priority ' +
 				'support, marketing automation, and more.'
+		),
+		getTagline: () => i18n.translate(
+			'Your site is being secured and you have access to marketing tools and priority support.'
 		),
 		getFeatures: () => compact( [  // pay attention to ordering, shared features should align on /plan page
 			FEATURE_OFFSITE_BACKUP_VAULTPRESS_DAILY,
@@ -473,6 +482,9 @@ export const PLANS_LIST = {
 				'Security essentials for every WordPress site including ' +
 				'automated backups and priority support.'
 		),
+		getTagline: () => i18n.translate(
+			'Your data is being securely backed up and you have access to priority support.'
+		),
 		getFeatures: () => [  // pay attention to ordering, shared features should align on /plan page
 			FEATURE_OFFSITE_BACKUP_VAULTPRESS_DAILY,
 			FEATURE_BACKUP_ARCHIVE_30,
@@ -509,6 +521,9 @@ export const PLANS_LIST = {
 		getDescription: () => i18n.translate(
 				'Security essentials for every WordPress site including ' +
 				'automated backups and priority support.'
+		),
+		getTagline: () => i18n.translate(
+			'Your data is being securely backed up and you have access to priority support.'
 		),
 		getFeatures: () => [  // pay attention to ordering, shared features should align on /plan page
 			FEATURE_OFFSITE_BACKUP_VAULTPRESS_DAILY,
@@ -552,6 +567,9 @@ export const PLANS_LIST = {
 		getDescription: () => i18n.translate(
 			'WordPress sites from start to finish: unlimited premium ' +
 			'themes, business class security, and marketing automation.'
+		),
+		getTagline: () => i18n.translate(
+			'You have full access to premium themes, marketing tools, and priority support.'
 		),
 		getFeatures: () => compact( [  // pay attention to ordering, shared features should align on /plan page
 			FEATURE_OFFSITE_BACKUP_VAULTPRESS_REALTIME,
@@ -604,6 +622,9 @@ export const PLANS_LIST = {
 		getDescription: () => i18n.translate(
 			'WordPress sites from start to finish: unlimited premium ' +
 			'themes, business class security, and marketing automation.'
+		),
+		getTagline: () => i18n.translate(
+			'You have full access to premium themes, marketing tools, and priority support.'
 		),
 		getFeatures: () => compact( [  // pay attention to ordering, shared features should align on /plan page
 			FEATURE_OFFSITE_BACKUP_VAULTPRESS_REALTIME,

--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -24,7 +24,7 @@ import ProductPurchaseFeaturesList from 'blocks/product-purchase-features/produc
 import CurrentPlanHeader from './header';
 import QuerySites from 'components/data/query-sites';
 import QuerySitePlans from 'components/data/query-site-plans';
-import { PLAN_BUSINESS } from 'lib/plans/constants';
+import { PLAN_BUSINESS, PLAN_JETPACK_PREMIUM, PLAN_JETPACK_BUSINESS, PLAN_JETPACK_PERSONAL, PLAN_JETPACK_PREMIUM_MONTHLY, PLAN_JETPACK_BUSINESS_MONTHLY, PLAN_JETPACK_PERSONAL_MONTHLY } from 'lib/plans/constants';
 import { getPlan } from 'lib/plans';
 import QuerySiteDomains from 'components/data/query-site-domains';
 import { getDecoratedSiteDomains } from 'state/sites/domains/selectors';

--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -24,15 +24,6 @@ import ProductPurchaseFeaturesList from 'blocks/product-purchase-features/produc
 import CurrentPlanHeader from './header';
 import QuerySites from 'components/data/query-sites';
 import QuerySitePlans from 'components/data/query-site-plans';
-import {
-	PLAN_BUSINESS,
-	PLAN_JETPACK_PREMIUM,
-	PLAN_JETPACK_BUSINESS,
-	PLAN_JETPACK_PERSONAL,
-	PLAN_JETPACK_PREMIUM_MONTHLY,
-	PLAN_JETPACK_BUSINESS_MONTHLY,
-	PLAN_JETPACK_PERSONAL_MONTHLY
-} from 'lib/plans/constants';
 import { getPlan } from 'lib/plans';
 import QuerySiteDomains from 'components/data/query-site-domains';
 import { getDecoratedSiteDomains } from 'state/sites/domains/selectors';
@@ -70,27 +61,9 @@ class CurrentPlan extends Component {
 				}
 			} );
 
-		let tagLine = translate( 'Unlock the full potential of your site with all the features included in your plan.' );
-
-		if ( plan === PLAN_BUSINESS ) {
-			tagLine = translate( 'Learn more about everything included with Business and take advantage of' +
-				' its professional features.' );
-		}
-
-		if ( plan === PLAN_JETPACK_PERSONAL || plan === PLAN_JETPACK_PERSONAL_MONTHLY ) {
-			tagLine = translate( 'Your data is being securely backed up and you have access to priority' +
-				' support.' );
-		}
-
-		if ( plan === PLAN_JETPACK_PREMIUM || plan === PLAN_JETPACK_PREMIUM_MONTHLY ) {
-			tagLine = translate( 'Your site is being secured and you have access to marketing tools and' +
-				' priority support.' );
-		}
-
-		if ( plan === PLAN_JETPACK_BUSINESS || plan === PLAN_JETPACK_BUSINESS_MONTHLY ) {
-			tagLine = translate( 'You have full access to premium themes, marketing tools, and' +
-				' priority support.' );
-		}
+		const tagLine = planConstObj.getTagline
+			? planConstObj.getTagline()
+			: translate( 'Unlock the full potential of your site with all the features included in your plan.' );
 
 		return {
 			title: title,

--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -69,6 +69,21 @@ class CurrentPlan extends Component {
 				' its professional features.' );
 		}
 
+		if ( plan === PLAN_JETPACK_PERSONAL || plan === PLAN_JETPACK_PERSONAL_MONTHLY ) {
+			tagLine = translate( 'Your data is being securely backed up and you have access to priority' +
+				' support.' );
+		}
+
+		if ( plan === PLAN_JETPACK_PREMIUM || plan === PLAN_JETPACK_PREMIUM_MONTHLY ) {
+			tagLine = translate( 'Your site is being secured and you have access to marketing tools and' +
+				' priority support.' );
+		}
+
+		if ( plan === PLAN_JETPACK_BUSINESS || plan === PLAN_JETPACK_BUSINESS_MONTHLY ) {
+			tagLine = translate( 'You have full access to premium themes, marketing tools, and' +
+				' priority support.' );
+		}
+
 		return {
 			title: title,
 			tagLine: tagLine

--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -24,7 +24,15 @@ import ProductPurchaseFeaturesList from 'blocks/product-purchase-features/produc
 import CurrentPlanHeader from './header';
 import QuerySites from 'components/data/query-sites';
 import QuerySitePlans from 'components/data/query-site-plans';
-import { PLAN_BUSINESS, PLAN_JETPACK_PREMIUM, PLAN_JETPACK_BUSINESS, PLAN_JETPACK_PERSONAL, PLAN_JETPACK_PREMIUM_MONTHLY, PLAN_JETPACK_BUSINESS_MONTHLY, PLAN_JETPACK_PERSONAL_MONTHLY } from 'lib/plans/constants';
+import {
+	PLAN_BUSINESS,
+	PLAN_JETPACK_PREMIUM,
+	PLAN_JETPACK_BUSINESS,
+	PLAN_JETPACK_PERSONAL,
+	PLAN_JETPACK_PREMIUM_MONTHLY,
+	PLAN_JETPACK_BUSINESS_MONTHLY,
+	PLAN_JETPACK_PERSONAL_MONTHLY
+} from 'lib/plans/constants';
 import { getPlan } from 'lib/plans';
 import QuerySiteDomains from 'components/data/query-site-domains';
 import { getDecoratedSiteDomains } from 'state/sites/domains/selectors';


### PR DESCRIPTION
Add custom plan header text for the different Jetpack plans.

<img width="476" alt="myplan-personal" src="https://user-images.githubusercontent.com/2287740/29660641-b7b96d1e-88b9-11e7-8021-f2d942ec6df5.png">
<img width="476" alt="myplan-premium" src="https://user-images.githubusercontent.com/2287740/29660642-b7ba6dc2-88b9-11e7-8700-b56dd1b2cf6e.png">
<img width="476" alt="myplan-pro" src="https://user-images.githubusercontent.com/2287740/29660643-b7bb212c-88b9-11e7-83b6-f0d75fbf9e1f.png">
