### PR TITLE
Add video press block

### DIFF
--- a/client/blocks/product-purchase-features/product-purchase-features-list/index.jsx
+++ b/client/blocks/product-purchase-features/product-purchase-features-list/index.jsx
@@ -32,6 +32,7 @@ import BusinessOnboarding from './business-onboarding';
 import CustomDomain from './custom-domain';
 import GoogleAnalyticsStats from './google-analytics-stats';
 import JetpackAntiSpam from './jetpack-anti-spam';
+import JetpackVideo from './jetpack-video';
 import JetpackBackupSecurity from './jetpack-backup-security';
 import JetpackReturnToDashboard from './jetpack-return-to-dashboard';
 import JetpackWordPressCom from './jetpack-wordpress-com';
@@ -200,6 +201,9 @@ class ProductPurchaseFeaturesList extends Component {
 			<JetpackAntiSpam
 				key="jetpackAntiSpam"
 			/>,
+			<JetpackVideo
+				key="jetpackVideo"
+			/>,
 			<JetpackWordPressCom
 				selectedSite={ selectedSite }
 				key="jetpackWordPressCom"
@@ -241,6 +245,9 @@ class ProductPurchaseFeaturesList extends Component {
 			/>,
 			<JetpackAntiSpam
 				key="jetpackAntiSpam"
+			/>,
+			<JetpackVideo
+				key="jetpackVideo"
 			/>,
 			<JetpackWordPressCom
 				selectedSite={ selectedSite }

--- a/client/blocks/product-purchase-features/product-purchase-features-list/jetpack-video.jsx
+++ b/client/blocks/product-purchase-features/product-purchase-features-list/jetpack-video.jsx
@@ -1,0 +1,25 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import PurchaseDetail from 'components/purchase-detail';
+
+export default localize( ( { translate } ) => {
+	return (
+		<div className="product-purchase-features-list__item">
+			<PurchaseDetail
+				icon="image-multiple"
+				title={ translate( 'Video Hosting' ) }
+				description={ translate(
+					'High-speed video hosting that doesn\'t eat up your server space. ' +
+					'High-definition and no third-party ads.'
+				) }
+			/>
+		</div>
+	);
+} );


### PR DESCRIPTION
Add a new component for video hosting and include it in Jetpack Premium and Professional plan.

<img width="477" alt="plans_ _serious_simplicity_ _wordpress_com" src="https://user-images.githubusercontent.com/2287740/29662215-6990fea4-88be-11e7-862a-b2be6032c9a7.png">
