### PR TITLE
Add publicize block

### DIFF
--- a/client/blocks/product-purchase-features/product-purchase-features-list/index.jsx
+++ b/client/blocks/product-purchase-features/product-purchase-features-list/index.jsx
@@ -32,6 +32,7 @@ import BusinessOnboarding from './business-onboarding';
 import CustomDomain from './custom-domain';
 import GoogleAnalyticsStats from './google-analytics-stats';
 import JetpackAntiSpam from './jetpack-anti-spam';
+import JetpackPublicize from './jetpack-publicize';
 import JetpackVideo from './jetpack-video';
 import JetpackBackupSecurity from './jetpack-backup-security';
 import JetpackReturnToDashboard from './jetpack-return-to-dashboard';
@@ -205,6 +206,9 @@ class ProductPurchaseFeaturesList extends Component {
 			<JetpackAntiSpam
 				key="jetpackAntiSpam"
 			/>,
+			<JetpackPublicize
+				key="jetpackPublicize"
+			/>,
 			<JetpackVideo
 				key="jetpackVideo"
 			/>,
@@ -265,6 +269,9 @@ class ProductPurchaseFeaturesList extends Component {
 			/>,
 			<JetpackAntiSpam
 				key="jetpackAntiSpam"
+			/>,
+			<JetpackPublicize
+				key="jetpackPublicize"
 			/>,
 			<JetpackVideo
 				key="jetpackVideo"

--- a/client/blocks/product-purchase-features/product-purchase-features-list/jetpack-publicize.jsx
+++ b/client/blocks/product-purchase-features/product-purchase-features-list/jetpack-publicize.jsx
@@ -1,0 +1,25 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import PurchaseDetail from 'components/purchase-detail';
+
+export default localize( ( { translate } ) => {
+	return (
+		<div className="product-purchase-features-list__item">
+			<PurchaseDetail
+				icon="comment"
+				title={ translate( 'Marketing Automation' ) }
+				description={ translate(
+					'Schedule Tweets, Facebook posts, and other social posts in advance. ' +
+					'No limits.'
+				) }
+			/>
+		</div>
+	);
+} );

--- a/client/blocks/product-purchase-features/product-purchase-features-list/jetpack-publicize.jsx
+++ b/client/blocks/product-purchase-features/product-purchase-features-list/jetpack-publicize.jsx
@@ -16,7 +16,7 @@ export default localize( ( { translate } ) => {
 				icon="comment"
 				title={ translate( 'Marketing Automation' ) }
 				description={ translate(
-					'Schedule Tweets, Facebook posts, and other social posts in advance. ' +
+					'Schedule tweets, Facebook posts, and other social posts in advance. ' +
 					'No limits.'
 				) }
 			/>


### PR DESCRIPTION
Add a new component for publicize scheduling and include it in Jetpack Premium and Professional plan.

<img width="476" alt="plans_ _serious_simplicity_ _wordpress_com" src="https://user-images.githubusercontent.com/2287740/29662719-48bc7b84-88c0-11e7-8e72-f061228cfe7b.png">
