### PR TITLE
Plans: Improve spacing of interval toggle for Jetpack plans

### DIFF
--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -435,6 +435,10 @@ $plan-features-sidebar-width: 272px;
 .price-toggle {
 	width: 250px;
 	margin: 0 auto 20px;
+
+	& + .plans-features-main__group {
+		padding-top: 8px;
+	}
 }
 
 .plans-wrapper {


### PR DESCRIPTION
In #17462 we introduced the master interval toggle for Jetpack plans, but there were several things to polish, suggested by @rickybanister in https://github.com/Automattic/wp-calypso/pull/17462#issuecomment-324338131.

This PR updates the space below the toggle to be the same as the space above it.

Before:
![](https://cldup.com/gYhpHRgfsq.png)

After:
![](https://cldup.com/cXBoQOL4_0.png)

To test:
* Checkout this branch, or get it going on calypso.live.
* Go to `https://calypso.live/plans/:site`, where `:site` is one of your Jetpack sites.
* Verify the space above and below the interval toggle is equal and looks as in the screenshot.