### PR TITLE
Fixed infinite routing loop in siteSelection controller

### DIFF
--- a/client/lib/route/path.js
+++ b/client/lib/route/path.js
@@ -63,12 +63,19 @@ function addSiteFragment( path, site ) {
 	return pieces.join( '/' );
 }
 
-function sectionify( path ) {
+function sectionify( path, siteFragment ) {
 	let basePath = path.split( '?' )[ 0 ];
-	const site = getSiteFragment( basePath );
 
-	if ( site ) {
-		basePath = trailingslashit( basePath ).replace( '/' + site + '/', '/' );
+	// Sometimes the caller knows better than `getSiteFragment` what the `siteFragment` is.
+	// For example, when the `:site` parameter is not the last or second-last part of the route
+	// and is retrieved from `context.params.site`. In that case, it can pass the `siteFragment`
+	// explicitly as the second parameter. We call `getSiteFragment` only as a fallback.
+	if ( ! siteFragment ) {
+		siteFragment = getSiteFragment( basePath );
+	}
+
+	if ( siteFragment ) {
+		basePath = trailingslashit( basePath ).replace( '/' + siteFragment + '/', '/' );
 	}
 	return untrailingslashit( basePath );
 }

--- a/client/lib/route/test/index.js
+++ b/client/lib/route/test/index.js
@@ -562,5 +562,12 @@ describe( 'route', function() {
 				).to.equal( '/stats/day' );
 			} );
 		} );
+		describe( 'for special paths', function() {
+			it( 'should remove the site when the fragment is passed explicitly', function() {
+				expect(
+					route.sectionify( '/domains/manage/not-a-site', 'not-a-site' )
+				).to.equal( '/domains/manage' );
+			} );
+		} );
 	} );
 } );

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -267,10 +267,10 @@ module.exports = {
 	siteSelection( context, next ) {
 		const { getState, dispatch } = getStore( context );
 		const siteFragment = context.params.site || route.getSiteFragment( context.path );
-		const basePath = route.sectionify( context.path );
+		const basePath = route.sectionify( context.path, siteFragment );
 		const currentUser = user.get();
 		const hasOneSite = currentUser.visible_site_count === 1;
-		const allSitesPath = route.sectionify( context.path );
+		const allSitesPath = route.sectionify( context.path, siteFragment );
 		const primaryId = getPrimarySiteId( getState() );
 		const primary = getSite( getState(), primaryId ) || '';
 


### PR DESCRIPTION
**Steps to reproduce:**
1. Choose a route that ends with `.../:site` and has `siteSelection` controller as a handler. For example, `/domains/manage/:site`
2. Go to a URL like `/domains/manage/not-a-site`. I.e., the `:site` parameter is there, but is not a valid site identifier: it's not a number and doesn't contain dots.
3. Watch your browser get really busy with an infinite loop where the page is redirected to `/domains/manage/not-a-site` over and over again.

**Why it happens?**
The `siteSelection` controller [assigns to](https://github.com/Automattic/wp-calypso/blob/8774885751d152c031d2aca42fa9cf1c614d9b2e/client/my-sites/controller.js#L269) `siteFragment` from `context.params.site`. The value is `'not-a-site'`.

Note that `getSiteFragment()` would return `false` for this path, because `'not-a-site'` is not a valid site identifier: it's not a number and doesn't contain dots.

Because the site identifier is not valid, `siteSelection` eventually redirects to `allSitesPath`. But `allSitesPath` is [assigned to](https://github.com/Automattic/wp-calypso/blob/8774885751d152c031d2aca42fa9cf1c614d9b2e/client/my-sites/controller.js#L273) this:
```js
const allSitesPath = route.sectionify( '/domains/manage/not-a-site' );
```
`route.sectionify` uses `getSiteFragment()` internally to find the site identifier. It doesn't find it though, and returns the route unchanged. The value of `allSitesPath` is `'/domains/manage/not-a-site'`. We'll be redirecting to the same path forever!

**How do I fix it?**
Note that `siteSelection` knows the site identifier better than `getSiteFragment()` does, because it has access to `context.params.site`. So, let's pass it as an optional second parameter to `route.sectionify` and change `route.sectionify` to call `getSiteFragment()` only as a fallback when the caller doesn't supply the value.

The bug was introduced in #13247 by adding the "look at `context.params.site`" part. Before that, `siteFragment` would just be `false` and `siteSelection` would go down a [different code path](https://github.com/Automattic/wp-calypso/blob/8774885751d152c031d2aca42fa9cf1c614d9b2e/client/my-sites/controller.js#L319-L322), with no redirect.

Looking at `context.params.site` continues to be extremely useful though, as it lets routes like `/me/purchases/:site/:purchaseId/payment/add` select the right site, even though the `:site` param is not at the end.
