### PR TITLE
Extensions: Zoninator - Fix zones data layer returning incorrect data format

### DIFF
--- a/client/extensions/zoninator/state/data-layer/zones/index.js
+++ b/client/extensions/zoninator/state/data-layer/zones/index.js
@@ -4,7 +4,7 @@
 import page from 'page';
 import { translate } from 'i18n-calypso';
 import { startSubmit, stopSubmit } from 'redux-form';
-import { map } from 'lodash';
+import { reduce } from 'lodash';
 
 /**
  * Internal dependencies
@@ -33,7 +33,15 @@ export const requestZonesError = ( { dispatch }, { siteId } ) =>
 	dispatch( requestError( siteId ) );
 
 export const updateZonesList = ( { dispatch }, { siteId }, { data } ) =>
-	dispatch( updateZones( siteId, map( data, fromApi ) ) );
+	dispatch( updateZones( siteId, reduce(
+		data,
+		( zones, rawZone ) => {
+			const zone = fromApi( rawZone );
+			zones[ zone.id ] = zone;
+			return zones;
+		},
+		{},
+	) ) );
 
 export const createZone = ( { dispatch }, action ) => {
 	const { data, form, siteId } = action;

--- a/client/extensions/zoninator/state/data-layer/zones/test/index.js
+++ b/client/extensions/zoninator/state/data-layer/zones/test/index.js
@@ -8,7 +8,6 @@ import {
 	startSubmit as startSave,
 	stopSubmit as stopSave,
 } from 'redux-form';
-import { map } from 'lodash';
 
 /**
  * Internal dependencies
@@ -34,6 +33,7 @@ import { fromApi } from '../utils';
 const apiResponse = {
 	data: [
 		{
+			term_id: 23,
 			name: 'Test zone',
 			slug: 'test-zone',
 			description: 'A test zone.',
@@ -75,13 +75,9 @@ describe( '#updateZonesList()', () => {
 		updateZonesList( { dispatch }, action, apiResponse );
 
 		expect( dispatch ).to.have.been.calledOnce;
-		expect( dispatch ).to.have.been.calledWith( updateZones( 123456, map( [
-			{
-				name: 'Test zone',
-				slug: 'test-zone',
-				description: 'A test zone.',
-			}
-		], fromApi ) ) );
+		expect( dispatch ).to.have.been.calledWith( updateZones( 123456, {
+			23: fromApi( apiResponse.data[ 0 ] ),
+		}, fromApi ) );
 	} );
 } );
 


### PR DESCRIPTION
This PR addresses the issue with invalid state format for `zones` as found and described by @donnapep [here](https://github.com/Automattic/wp-calypso/pull/16497#issuecomment-324010899).

The issue was caused by the data-layer sending the data as an array while the schema has been switched to a map.

![zoninator-schema](https://user-images.githubusercontent.com/1190420/29565176-da616a7c-8712-11e7-9be1-20e6d4d1b35d.jpg)

# Testing

Head over to zoninator settings and make sure the zones are loaded properly.  
Reload the page and make sure no warnings regarding the zones state show up in the console.