### PR TITLE
Signup: Do not show post landing upgrade screen if a user doesn't create a domain.

### DIFF
--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -426,7 +426,7 @@ const Signup = React.createClass( {
 						user={ this.state.user }
 						loginHandler={ this.state.loginHandler }
 						signupDependencies={ this.props.signupDependencies }
-						flow = { this.props.flowName }
+						flowSteps = { flow.steps }
 					/>
 					: <CurrentComponent
 						path={ this.props.path }

--- a/client/signup/processing-screen/index.jsx
+++ b/client/signup/processing-screen/index.jsx
@@ -177,7 +177,7 @@ export class SignupProcessingScreen extends Component {
 	}
 
 	handleClickUpgradeButton = () => {
-		this.handleClick( 'upgrade_plan', this.state.siteSlug ? `/plans/${ this.state.siteSlug }` : '' );
+		this.handleClick( 'upgrade`_plan', this.state.siteSlug ? `/plans/${ this.state.siteSlug }` : '' );
 	}
 
 	handleClickOldContinueButton = () => {
@@ -238,7 +238,7 @@ export class SignupProcessingScreen extends Component {
 	}
 
 	render() {
-		if ( abtest( 'postSignupUpgradeScreen' ) === 'modified' && ! this.state.hasPaidSubscription && this.currentFlowIncludesDomainStep() && ! this.props.useOAuth2Layout  ) {
+		if ( abtest( 'postSignupUpgradeScreen' ) === 'modified' && ! this.state.hasPaidSubscription && this.currentFlowIncludesDomainStep() && ! this.props.useOAuth2Layout ) {
 			return this.renderUpgradeScreen();
 		}
 

--- a/client/signup/processing-screen/index.jsx
+++ b/client/signup/processing-screen/index.jsx
@@ -25,7 +25,7 @@ export class SignupProcessingScreen extends Component {
 		steps: PropTypes.array.isRequired,
 		user: PropTypes.oneOfType( [ PropTypes.object, PropTypes.bool ] ),
 		signupProgress: PropTypes.array,
-		flow: PropTypes.string,
+		flowSteps: PropTypes.array,
 		useOAuth2Layout: PropTypes.bool.isRequired,
 	};
 
@@ -156,6 +156,10 @@ export class SignupProcessingScreen extends Component {
 			} );
 	}
 
+	currentFlowIncludesDomainStep() {
+		return this.props.flowSteps.indexOf( 'domains' ) !== -1;
+	}
+
 	handleClick( ctaName, redirectTo = '' ) {
 		if ( ! this.props.loginHandler ) {
 			return;
@@ -234,7 +238,7 @@ export class SignupProcessingScreen extends Component {
 	}
 
 	render() {
-		if ( abtest( 'postSignupUpgradeScreen' ) === 'modified' && ! this.state.hasPaidSubscription && this.props.flow !== 'rebrand-cities' && ! this.props.useOAuth2Layout ) {
+		if ( abtest( 'postSignupUpgradeScreen' ) === 'modified' && ! this.state.hasPaidSubscription && this.currentFlowIncludesDomainStep() && ! this.props.useOAuth2Layout  ) {
 			return this.renderUpgradeScreen();
 		}
 


### PR DESCRIPTION
The post-signup upgrade screen should appear only when a user creates a website with free domain because the screen contains site specific copy.

## How to test

1. Set the _postSignupUpgradeScreen_ A/B test to _modified_.
2. You shouldn't be able to see the upgrade screen in the following cases:
  - Create a new account from https://wordpress.com/start/account
  - Create a new account from https://wordpress.com/start/rebrand-cities
  - Create a site with a custom domain from https://wordpress.com/start
3. The upgrade screen should show up in the following case:
  - Create a site with free plan from https://wordpress.com/start

Close #17407