### PR TITLE
Hide nav buttons on first step

### DIFF
--- a/client/signup/steps/jpo-site-title/index.jsx
+++ b/client/signup/steps/jpo-site-title/index.jsx
@@ -156,6 +156,7 @@ const JPOSiteTitleStep = React.createClass( {
 					signupProgress={ this.props.signupProgress }
 					stepContent={ this.renderStepContent() }
 					goToNextStep={ this.skipStep }
+					shouldHideNavButtons={ true }
 				/>
 			</div>
 		);


### PR DESCRIPTION
**This PR removes the skip button on the first JPO step:**

![screen shot 2017-08-24 at 2 21 33 pm](https://user-images.githubusercontent.com/5528445/29682041-9cead716-88d7-11e7-88c9-f30478d69abb.png)

**Testing instructions:**

1. Apply the patch to `feature/jpo` branch.
2. Ensure the "Skip for now" hyperlink is gone from first step.