### PR TITLE
Confirmation Sidebar: alter header text based on post type

### DIFF
--- a/client/post-editor/editor-confirmation-sidebar/header.jsx
+++ b/client/post-editor/editor-confirmation-sidebar/header.jsx
@@ -1,0 +1,160 @@
+/**
+ * External dependencies
+ */
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { getPostTypes } from 'state/post-types/selectors';
+import utils from 'lib/posts/utils';
+
+class EditorConfirmationSidebarHeader extends PureComponent {
+	static propTypes = {
+		post: PropTypes.object,
+	};
+
+	renderPublishHeader() {
+		const { post, postTypeLabel, translate } = this.props;
+
+		switch ( post.type ) {
+			case 'post':
+				return (
+					<div className="editor-confirmation-sidebar__header">
+						{
+							translate( '{{strong}}Almost there!{{/strong}} ' +
+								'You can double-check your post’s settings below. When you’re happy, ' +
+								'use the big green button to send your post out into the world!', {
+									comment: 'This string appears as the header for the confirmation sidebar ' +
+									'when a user publishes a post.',
+									components: {
+										strong: <strong />
+									},
+								} )
+						}
+					</div>
+				);
+			case 'page':
+				return (
+					<div className="editor-confirmation-sidebar__header">
+						{
+							translate( '{{strong}}Almost there!{{/strong}} ' +
+								'You can double-check your page’s settings below. When you’re happy, ' +
+								'use the big green button to send your page out into the world!', {
+									comment: 'This string appears as the header for the confirmation sidebar ' +
+									'when a user publishes a page.',
+									components: {
+										strong: <strong />
+									},
+								} )
+						}
+					</div>
+				);
+			default:
+				return (
+					<div className="editor-confirmation-sidebar__header">
+						{
+							translate( '{{strong}}Almost there!{{/strong}} ' +
+								'You can double-check your settings below. When you’re happy, ' +
+								'use the big green button to send your %(postTypeLabel)s out into the world!', {
+									comment: 'This string appears as the header for the confirmation sidebar ' +
+									'when a user publishes a custom post type. `postTypeLabel` is the singular ' +
+									'name of the custom post type.',
+									args: {
+										postTypeLabel
+									},
+									components: {
+										strong: <strong />
+									},
+								} )
+						}
+					</div>
+				);
+		}
+	}
+
+	renderScheduleHeader() {
+		const { post, postTypeLabel, translate } = this.props;
+
+		switch ( post.type ) {
+			case 'post':
+				return (
+					<div className="editor-confirmation-sidebar__header">
+						{
+							translate( '{{strong}}Almost there!{{/strong}} ' +
+								'You can double-check your post’s settings below. When you’re happy, ' +
+								'use the big green button to schedule your post!', {
+									comment: 'This string appears as the header for the confirmation sidebar ' +
+									'when a user schedules the publishing of a post.',
+									components: {
+										strong: <strong />
+									},
+								} )
+						}
+					</div>
+				);
+			case 'page':
+				return (
+					<div className="editor-confirmation-sidebar__header">
+						{
+							translate( '{{strong}}Almost there!{{/strong}} ' +
+								'You can double-check your page’s settings below. When you’re happy, ' +
+								'use the big green button to schedule your page!', {
+									comment: 'This string appears as the header for the confirmation sidebar ' +
+									'when a user schedules the publishing of a page.',
+									components: {
+										strong: <strong />
+									},
+								} )
+						}
+					</div>
+				);
+			default:
+				return (
+					<div className="editor-confirmation-sidebar__header">
+						{
+							translate( '{{strong}}Almost there!{{/strong}} ' +
+								'You can double-check your settings below. When you’re happy, ' +
+								'use the big green button to schedule your %(postTypeLabel)s!', {
+									comment: 'This string appears as the header for the confirmation sidebar ' +
+									'when a user schedules a custom post type. `postTypeLabel` is the singular ' +
+									'name of the custom post type.',
+									args: {
+										postTypeLabel
+									},
+									components: {
+										strong: <strong />
+									},
+								} )
+						}
+					</div>
+				);
+		}
+	}
+
+	render() {
+		const isScheduled = utils.isFutureDated( this.props.post );
+
+		if ( isScheduled ) {
+			return this.renderScheduleHeader();
+		}
+
+		return this.renderPublishHeader();
+	}
+}
+
+export default connect( ( state, { post } ) => {
+	const siteId = getSelectedSiteId( state );
+	const postTypes = getPostTypes( state, siteId );
+	const postTypeLabel = post && postTypes &&
+		postTypes[ post.type ] && get( postTypes[ post.type ], 'labels.singular_name' );
+
+	return {
+		postTypeLabel,
+	};
+} )( localize( EditorConfirmationSidebarHeader ) );

--- a/client/post-editor/editor-confirmation-sidebar/header.jsx
+++ b/client/post-editor/editor-confirmation-sidebar/header.jsx
@@ -21,8 +21,9 @@ class EditorConfirmationSidebarHeader extends PureComponent {
 
 	renderPublishHeader() {
 		const { post, postTypeLabel, translate } = this.props;
+		const postType = get( post, 'type', 'post' );
 
-		switch ( post.type ) {
+		switch ( postType ) {
 			case 'post':
 				return (
 					<div className="editor-confirmation-sidebar__header">
@@ -80,8 +81,9 @@ class EditorConfirmationSidebarHeader extends PureComponent {
 
 	renderScheduleHeader() {
 		const { post, postTypeLabel, translate } = this.props;
+		const postType = get( post, 'type', 'post' );
 
-		switch ( post.type ) {
+		switch ( postType ) {
 			case 'post':
 				return (
 					<div className="editor-confirmation-sidebar__header">

--- a/client/post-editor/editor-confirmation-sidebar/index.jsx
+++ b/client/post-editor/editor-confirmation-sidebar/index.jsx
@@ -16,13 +16,13 @@ import EditorPublishDate from 'post-editor/editor-publish-date';
 import EditorVisibility from 'post-editor/editor-visibility';
 import FormCheckbox from 'components/forms/form-checkbox';
 import FormLabel from 'components/forms/form-label';
+import EditorConfirmationSidebarHeader from './header';
 import { editPost } from 'state/posts/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getEditorPostId } from 'state/ui/editor/selectors';
 import { getEditedPost } from 'state/posts/selectors';
 import { getPublishButtonStatus } from 'post-editor/editor-publish-button';
 import { isEditedPostPrivate, isPrivateEditedPostPasswordValid } from 'state/posts/selectors';
-import utils from 'lib/posts/utils';
 
 class EditorConfirmationSidebar extends React.Component {
 	static propTypes = {
@@ -150,44 +150,6 @@ class EditorConfirmationSidebar extends React.Component {
 		);
 	}
 
-	renderSidebarHeader() {
-		const isScheduled = utils.isFutureDated( this.props.post );
-
-		if ( isScheduled ) {
-			return (
-				<div className="editor-confirmation-sidebar__header">
-					{
-						this.props.translate( '{{strong}}Almost there!{{/strong}} ' +
-							'You can double-check your post’s settings below. When you’re happy, ' +
-							'use the big green button to schedule your post!', {
-								comment: 'This string appears as the header for the confirmation sidebar ' +
-								'when a user schedules the publishing of a post or page.',
-								components: {
-									strong: <strong />
-								},
-							} )
-					}
-				</div>
-			);
-		}
-
-		return (
-			<div className="editor-confirmation-sidebar__header">
-				{
-					this.props.translate( '{{strong}}Almost there!{{/strong}} ' +
-						'You can double-check your post’s settings below. When you’re happy, ' +
-						'use the big green button to send your post out into the world!', {
-							comment: 'This string appears as the header for the confirmation sidebar ' +
-							'when a user publishes a post or page.',
-							components: {
-								strong: <strong />
-							},
-						} )
-				}
-			</div>
-		);
-	}
-
 	render() {
 		const isSidebarActive = this.props.status === 'open';
 		const isOverlayActive = this.props.status !== 'closed';
@@ -218,7 +180,7 @@ class EditorConfirmationSidebar extends React.Component {
 						</div>
 					</div>
 					<div className="editor-confirmation-sidebar__content-wrap">
-						{ this.renderSidebarHeader() }
+						<EditorConfirmationSidebarHeader post={ this.props.post } />
 						<EditorPublishDate
 							post={ this.props.post }
 							setPostDate={ this.props.setPostDate }


### PR DESCRIPTION
This PR updates the header text for the confirmation sidebar to account for post type in addition to accounting for action (publish vs schedule).

![image](https://user-images.githubusercontent.com/363749/29686743-bf98dd00-88df-11e7-8582-f049f7748bbf.png)

To test:
* Checkout the branch and run with `npm start`
* Make sure you're part of the test group. In your console enter: `localStorage.setItem('ABTests','{"postPublishConfirmation_20170801":"showPublishConfirmation"}')`
* Draft a post. Trigger the confirmation sidebar for the post by selecting "Publish..." in the editor.
* Make sure the header text makes sense for a post to be scheduled immediately.
* Alter the publish date for the post to a time in the future.
* Make sure the header text updates and makes sense for a post to be scheduled in the future.
* Repeat the drafting process for a page. Again make sure the text makes sense for immediate and scheduled pages.