### PR TITLE
include designType in api request when creating new site.

### DIFF
--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -97,6 +97,7 @@ function createSiteWithCart( callback, dependencies, {
 			// step object itself depending on if the theme is provided in a
 			// query. See `getThemeSlug` in `DomainsStep`.
 			theme: dependencies.themeSlugWithRepo || themeSlugWithRepo,
+			designType: dependencies.designType,
 			vertical: surveyVertical || undefined,
 		},
 		validate: false,

--- a/client/signup/config/steps.js
+++ b/client/signup/config/steps.js
@@ -122,7 +122,7 @@ export default {
 		props: {
 			isDomainOnly: false
 		},
-		dependencies: [ 'themeSlugWithRepo' ],
+		dependencies: [ 'designType', 'themeSlugWithRepo' ],
 		delayApiRequestUntilComplete: true
 	},
 

--- a/client/signup/config/steps.js
+++ b/client/signup/config/steps.js
@@ -21,7 +21,7 @@ export default {
 	themes: {
 		stepName: 'themes',
 		dependencies: [ 'siteSlug' ],
-		providesDependencies: [ 'themeSlugWithRepo' ]
+		providesDependencies: [ 'themeSlugWithRepo', 'designType' ]
 	},
 
 	'portfolio-themes': {
@@ -30,7 +30,7 @@ export default {
 			designType: 'grid'
 		},
 		dependencies: [ 'siteSlug' ],
-		providesDependencies: [ 'themeSlugWithRepo' ]
+		providesDependencies: [ 'themeSlugWithRepo', 'designType' ]
 	},
 
 	// `themes` does not update the theme for an existing site as we normally
@@ -39,7 +39,7 @@ export default {
 	'themes-site-selected': {
 		stepName: 'themes-site-selected',
 		dependencies: [ 'siteSlug', 'themeSlugWithRepo' ],
-		providesDependencies: [ 'themeSlugWithRepo' ],
+		providesDependencies: [ 'themeSlugWithRepo', 'designType' ],
 		apiRequestFunction: stepActions.setThemeOnSite,
 		props: {
 			headerText: i18n.translate( 'Choose a theme for your new site.' ),
@@ -160,7 +160,7 @@ export default {
 			designType: 'blog'
 		},
 		dependencies: [ 'siteSlug' ],
-		providesDependencies: [ 'themeSlugWithRepo' ]
+		providesDependencies: [ 'themeSlugWithRepo', 'designType' ]
 	},
 
 	// Currently, these two steps explicitly submit other steps to skip them, and

--- a/client/signup/steps/theme-selection/index.jsx
+++ b/client/signup/steps/theme-selection/index.jsx
@@ -47,17 +47,22 @@ class ThemeSelectionStep extends Component {
 			processingMessage: this.props.translate( 'Adding your theme' ),
 			repoSlug
 		}, null, {
-			themeSlugWithRepo: repoSlug
+			themeSlugWithRepo: repoSlug,
+			designType: this.getDesignType()
 		} );
 
 		this.props.goToNextStep();
 	};
 
+	getDesignType() {
+		return this.props.designType || this.props.signupDependencies.designType;
+	}
+
 	renderThemesList() {
 		return (
 			<SignupThemesList
 				surveyQuestion={ this.props.chosenSurveyVertical }
-				designType={ this.props.designType || this.props.signupDependencies.designType }
+				designType={ this.getDesignType() }
 				handleScreenshotClick={ this.pickTheme }
 			/>
 		);


### PR DESCRIPTION
Currently new sites created from the domain step do not persist the designType selected in an earlier step (for those flows that include that step).

This change means that all flows including the domains step must either include the design-type step or another step that provides the designType dependency.  The only existing flow that does not use the design-type step is `/start/creative-mornings`.  All steps using the ThemeSelection component must also now explicitly declare that designType is provided.

# Testing instructions

* create a new site from `/start`
* create another new site from `/start/creative-mornings`

In both cases, using the network tab, you should see designType has been passed to the sitesNew api call (and persisted as a site option along with theme and vertical).  The fact that these attributes have been persisted can also be verified by querying wp with `get_blog_option( blog_id, 'options' )`
