### PR TITLE
Plans: Redirect non-Jetpack monthly view to yearly

### DIFF
--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -4,6 +4,7 @@
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import React from 'react';
+import page from 'page';
 
 /**
  * Internal dependencies
@@ -37,9 +38,27 @@ const Plans = React.createClass( {
 	},
 
 	componentDidMount() {
+		this.redirectIfNonJetpackMonthly();
+
 		// Scroll to the top
 		if ( typeof window !== 'undefined' ) {
 			window.scrollTo( 0, 0 );
+		}
+	},
+
+	componentDidUpdate() {
+		this.redirectIfNonJetpackMonthly();
+	},
+
+	redirectIfNonJetpackMonthly() {
+		const {
+			displayJetpackPlans,
+			intervalType,
+			selectedSite,
+		} = this.props;
+
+		if ( selectedSite && ! displayJetpackPlans && intervalType === 'monthly' ) {
+			page.redirect( '/plans/' + selectedSite.slug );
 		}
 	},
 


### PR DESCRIPTION
This PR updates the Plans page to redirect to yearly plans when accessing monthly plans view for a non-Jetpack site.

Fixes #17515.

### To test

**Scenario A** - switching from a Jetpack site on monthly view to a .com site
1. Go to https://wordpress.com/plans/`:site`, where `:site` is a Jetpack site.
2. Toggle to monthly plans view.
3. Switch to a WP.com site.
4. Verify you no longer have `/monthly` in the URL, but instead you're in the yearly view.

**Scenario B** - switching from a Jetpack site on monthly view to an Atomic site
1. Go to https://wordpress.com/plans/`:site`, where `:site` is a Jetpack site.
2. Toggle to monthly plans view.
3. Switch to an Atomic site.
4. Verify you no longer have `/monthly` in the URL, but instead you're redirected to the yearly view.

**Scenario C** - directly accessing plans monthly view on a .com site
1. Go to https://wordpress.com/plans/monthly/`:site`, where `:site` is a WordPress.com site.
2. Verify you no longer have `/monthly` in the URL, but instead you're redirected to the yearly view.

**Scenario D** - directly accessing plans monthly view on an Atomic site
1. Go to https://wordpress.com/plans/monthly/`:site`, where `:site` is an Atomic site.
2. Verify you no longer have `/monthly` in the URL, but instead you're redirected to the yearly view.