### PR TITLE
Revert "Signup: Add a new WPCC flow to accept signups coming from DOPS"

### DIFF
--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -6,7 +6,6 @@ import { defer } from 'lodash';
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import qs from 'qs';
 
 /**
  * Internal dependencies
@@ -159,16 +158,9 @@ export class LoginForm extends Component {
 			isDisabled.disabled = true;
 		}
 
-		const { requestError, redirectTo, oauth2ClientData } = this.props;
+		const { requestError, oauth2ClientData } = this.props;
 		const linkingSocialUser = this.props.socialAccountIsLinking;
 		const isOauthLogin = !! oauth2ClientData;
-		let signupUrl = config( 'signup_url' );
-
-		if ( isOauthLogin ) {
-			signupUrl = '/start/wpcc?' + qs.stringify( { oauth2_client_id: oauth2ClientData.id, oauth2_redirect: redirectTo } );
-			// TODO remove the following line when WPCC signup is ready
-			signupUrl = oauth2ClientData.signupUrl;
-		}
 
 		return (
 			<form onSubmit={ this.onSubmitForm } method="post">
@@ -279,7 +271,7 @@ export class LoginForm extends Component {
 							{ this.props.translate( 'Not on WordPress.com? {{signupLink}}Create an Account{{/signupLink}}.',
 								{
 									components: {
-										signupLink: <a href={ signupUrl } />,
+										signupLink: <a href={ oauth2ClientData.signupUrl } />,
 									}
 								}
 							) }

--- a/client/boot/app.js
+++ b/client/boot/app.js
@@ -42,7 +42,7 @@ const boot = currentUser => {
 		setupMiddlewares( currentUser, reduxStore );
 		invoke( project, 'setupMiddlewares', currentUser, reduxStore );
 		detectHistoryNavigation.start();
-		page.start( { decodeURLComponents: false } );
+		page.start();
 	} );
 };
 

--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -37,9 +37,6 @@ const setupContextMiddleware = reduxStore => {
 	page( '*', ( context, next ) => {
 		const parsed = url.parse( location.href, true );
 
-		// Decode the pathname by default (now disabled in page.js)
-		context.pathname = decodeURIComponent( context.pathname );
-
 		context.store = reduxStore;
 
 		// Break routing and do full load for logout link in /me

--- a/client/components/signup-form/README.md
+++ b/client/components/signup-form/README.md
@@ -7,7 +7,7 @@ This component renders a Signup Form. It magically handles email, username, and 
 
 A Signup Form instance expects `save` and `submitForm` properties, `save` is called `onBlur` of each field. `submitForm` is called when the form is submitted.
 Optional:
-redirectToAfterLoginUrl={ this.getRedirectToAfterLoginUrl }
+getRedirectToAfterLoginUrl={ this.getRedirectToAfterLoginUrl }
 disabled={ this.isDisabled() }
 submitting={ this.isSubmitting() }
 
@@ -18,7 +18,7 @@ render: function() {
 	return (
 		<SignupForm
 			{ ...this.props }
-			redirectToAfterLoginUrl={ this.getRedirectToAfterLoginUrl }
+			getRedirectToAfterLoginUrl={ this.getRedirectToAfterLoginUrl }
 			disabled={ this.isDisabled() }
 			submitting={ this.isSubmitting() }
 			save={ this.save }

--- a/client/components/signup-form/index.jsx
+++ b/client/components/signup-form/index.jsx
@@ -57,7 +57,7 @@ class SignupForm extends Component {
 		email: PropTypes.string,
 		footerLink: PropTypes.node,
 		formHeader: PropTypes.node,
-		redirectToAfterLoginUrl: PropTypes.string.isRequired,
+		getRedirectToAfterLoginUrl: PropTypes.string.isRequired,
 		goToNextStep: PropTypes.func,
 		handleSocialResponse: PropTypes.func,
 		isSocialSignupEnabled: PropTypes.bool,
@@ -151,7 +151,7 @@ class SignupForm extends Component {
 			page(
 				login( {
 					isNative: config.isEnabled( 'login/native-login-links' ),
-					redirectTo: this.props.redirectToAfterLoginUrl,
+					redirectTo: this.props.getRedirectToAfterLoginUrl,
 				} )
 			);
 		}
@@ -332,7 +332,7 @@ class SignupForm extends Component {
 
 		let link = login( {
 			isNative: config.isEnabled( 'login/native-login-links' ),
-			redirectTo: this.props.redirectToAfterLoginUrl
+			redirectTo: this.props.getRedirectToAfterLoginUrl
 		} );
 
 		return map( messages, ( message, error_code ) => {
@@ -528,7 +528,7 @@ class SignupForm extends Component {
 		}
 
 		const logInUrl = config.isEnabled( 'login/native-login-links' )
-			? login( { isNative: true, redirectTo: this.props.redirectToAfterLoginUrl } )
+			? login( { isNative: true } )
 			: this.localizeUrlWithSubdomain( config( 'login_url' ) );
 
 		return (

--- a/client/jetpack-connect/auth-logged-out-form.jsx
+++ b/client/jetpack-connect/auth-logged-out-form.jsx
@@ -116,7 +116,7 @@ class LoggedOutForm extends Component {
 				{ this.renderLocaleSuggestions() }
 				{ this.renderFormHeader() }
 				<SignupForm
-					redirectToAfterLoginUrl={ this.getRedirectAfterLoginUrl() }
+					getRedirectToAfterLoginUrl={ this.getRedirectAfterLoginUrl() }
 					disabled={ isAuthorizing }
 					submitting={ isAuthorizing }
 					submitForm={ this.handleSubmitSignup }

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -309,7 +309,6 @@ module.exports = {
 				}
 			} );
 		} else {
-			const isOauth2Flow = !! queryArgs.oauth2_client_id;
 			wpcom.undocumented().usersNew( assign(
 				{}, userData, {
 					ab_test_variations: getSavedVariations(),
@@ -317,14 +316,8 @@ module.exports = {
 					signup_flow_name: flowName,
 					nux_q_site_type: surveySiteType,
 					nux_q_question_primary: surveyVertical,
-					// url sent in the confirmation email
-					jetpack_redirect: queryArgs.jetpack_redirect,
-				}, isOauth2Flow ? {
-					oauth2_client_id: queryArgs.oauth2_client_id,
-					// url of the WordPress.com authorize page for this OAuth2 client
-					// convert to legacy oauth2_redirect format: %s@https://public-api.wordpress.com/oauth2/authorize/...
-					oauth2_redirect: queryArgs.oauth2_redirect && '0@' + queryArgs.oauth2_redirect,
-				} : null
+					jetpack_redirect: queryArgs.jetpackRedirect
+				}
 			), ( error, response ) => {
 				const errors = error && error.error ? [ { error: error.error, message: error.message } ] : undefined,
 					bearerToken = error && error.error ? {} : { bearer_token: response.bearer_token };
@@ -335,7 +328,7 @@ module.exports = {
 					analytics.ga.recordEvent( 'Signup', 'calypso_user_registration_complete' );
 				}
 
-				callback( errors, assign( {}, { username: userData.username, oauth2_redirect: queryArgs.oauth2_redirect }, bearerToken ) );
+				callback( errors, assign( {}, { username: userData.username }, bearerToken ) );
 			} );
 		}
 	},

--- a/client/my-sites/invites/invite-accept-logged-out/index.jsx
+++ b/client/my-sites/invites/invite-accept-logged-out/index.jsx
@@ -153,7 +153,7 @@ let InviteAcceptLoggedOut = React.createClass( {
 		return (
 			<div>
 				<SignupForm
-					redirectToAfterLoginUrl={ window.location.href }
+					getRedirectToAfterLoginUrl={ window.location.href }
 					disabled={ this.state.submitting }
 					formHeader={ this.renderFormHeader() }
 					submitting={ this.state.submitting }

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -225,17 +225,6 @@ const flows = {
 		description: 'Used by `get.blog` users that connect their site to WordPress.com',
 		lastModified: '2016-11-14'
 	},
-
-	wpcc: {
-		steps: [ 'oauth2-user' ],
-		destination: function( dependencies ) {
-			return dependencies.oauth2_redirect || '/';
-		},
-		description: 'WordPress.com Connect signup flow',
-		lastModified: '2017-08-24',
-		disallowResume: true, // don't allow resume so we don't clear query params when we go back in the history
-		autoContinue: true,
-	}
 };
 
 if ( config.isEnabled( 'signup/domain-first-flow' ) ) {

--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -41,5 +41,4 @@ export default {
 	'themes-site-selected': ThemeSelectionComponent,
 	user: UserSignupComponent,
 	'user-social': UserSignupComponent,
-	'oauth2-user': UserSignupComponent
 };

--- a/client/signup/config/steps.js
+++ b/client/signup/config/steps.js
@@ -147,16 +147,6 @@ export default {
 		providesDependencies: [ 'bearer_token', 'username' ]
 	},
 
-	'oauth2-user': {
-		stepName: 'oauth2-user',
-		apiRequestFunction: stepActions.createAccount,
-		props: {
-			oauth2Signup: true
-		},
-		providesToken: true,
-		providesDependencies: [ 'bearer_token', 'username', 'oauth2_client_id', 'oauth2_redirect' ]
-	},
-
 	'get-dot-blog-plans': {
 		apiRequestFunction: stepActions.createSiteWithCart,
 		stepName: 'get-dot-blog-plans',

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -236,10 +236,9 @@ const Signup = React.createClass( {
 			}.bind( this ) );
 		}
 
-		if ( ! userIsLoggedIn && ( config.isEnabled( 'oauth' ) || dependencies.oauth2_client_id ) ) {
+		if ( ! userIsLoggedIn && config.isEnabled( 'oauth' ) ) {
 			oauthToken.setToken( dependencies.bearer_token );
 			window.location.href = destination;
-			return;
 		}
 
 		if ( ! userIsLoggedIn && ! config.isEnabled( 'oauth' ) ) {

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -4,7 +4,7 @@
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { identity, omit } from 'lodash';
+import { identity, omit, get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -72,24 +72,21 @@ export class UserStep extends Component {
 	};
 
 	submit = ( data ) => {
-		const dependencies = {};
-
-		if ( this.props.oauth2Signup ) {
-			dependencies.oauth2_client_id = data.queryArgs.oauth2_client_id;
-			dependencies.oauth2_redirect = data.queryArgs.oauth2_redirect;
-		}
-
 		SignupActions.submitSignupStep( {
 			processingMessage: this.props.translate( 'Creating your account' ),
 			flowName: this.props.flowName,
 			stepName: this.props.stepName,
 			...data
-		}, null, dependencies );
+		} );
 
 		this.props.goToNextStep();
 	};
 
 	submitForm = ( form, userData, analyticsData ) => {
+		const queryArgs = {
+			jetpackRedirect: get( this.props, 'queryObject.jetpack_redirect' )
+		};
+
 		const formWithoutPassword = {
 			...form,
 			password: {
@@ -103,7 +100,7 @@ export class UserStep extends Component {
 		this.submit( {
 			userData,
 			form: formWithoutPassword,
-			queryArgs: this.props.queryObject || {},
+			queryArgs
 		} );
 	};
 
@@ -132,10 +129,6 @@ export class UserStep extends Component {
 	}
 
 	getRedirectToAfterLoginUrl() {
-		if ( this.props.oauth2Signup && this.props.queryObject.oauth2_redirect ) {
-			return this.props.queryObject.oauth2_redirect;
-		}
-
 		const stepAfterRedirect = signupUtils.getNextStepName( this.props.flowName, this.props.stepName ) ||
 			signupUtils.getPreviousStepName( this.props.flowName, this.props.stepName );
 		return this.originUrl() + signupUtils.getStepUrl(
@@ -167,7 +160,7 @@ export class UserStep extends Component {
 		return (
 			<SignupForm
 				{ ...omit( this.props, [ 'translate' ] ) }
-				redirectToAfterLoginUrl={ this.getRedirectToAfterLoginUrl() }
+				getRedirectToAfterLoginUrl={ this.getRedirectToAfterLoginUrl() }
 				disabled={ this.userCreationStarted() }
 				submitting={ this.userCreationStarted() }
 				save={ this.save }
@@ -198,7 +191,7 @@ export class UserStep extends Component {
 
 export default connect(
 	( state ) => ( {
-		suggestedUsername: getSuggestedUsername( state ),
+		suggestedUsername: getSuggestedUsername( state )
 	} ),
 	{
 		recordTracksEvent


### PR DESCRIPTION
Reverts Automattic/wp-calypso#12810

e2e tests are failing. The cause is the following js error at the end of the signup flow:
```
Uncaught Error: This step (user) provides an unspecified dependency [oauth2_redirect]. Make sure to specify it in /signup/config/steps.js, using the providesDependencies property.
```

Will need to fix this before we deploy again