### PR TITLE
Domains: Hide Premium Plan upsell when renewing premium domain names

### DIFF
--- a/client/my-sites/checkout/cart/cart-plan-ad.jsx
+++ b/client/my-sites/checkout/cart/cart-plan-ad.jsx
@@ -1,10 +1,14 @@
 /**
  * External dependencies
  */
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import page from 'page';
-import React, { Component, PropTypes } from 'react';
+import {
+	get,
+} from 'lodash';
 
 /**
  * Internal dependencies
@@ -26,11 +30,15 @@ class CartPlanAd extends Component {
 
 	shouldDisplayAd = () => {
 		const { cart, isDomainOnly, selectedSite } = this.props;
+		const domainRegistrations = cartItems.getDomainRegistrations( cart );
+		const isDomainPremium = domainRegistrations.length === 1 && get( domainRegistrations[ 0 ], 'extra.premium', false );
 
 		return ! isDomainOnly &&
 			cart.hasLoadedFromServer &&
+			! cart.hasPendingServerUpdates &&
 			! cartItems.hasDomainCredit( cart ) &&
-			cartItems.getDomainRegistrations( cart ).length === 1 &&
+			domainRegistrations.length === 1 &&
+			! isDomainPremium &&
 			selectedSite &&
 			selectedSite.plan &&
 			! isPlan( selectedSite.plan );


### PR DESCRIPTION
PDNs are not allowed to be bundled with Plans, so we should prevent this upsell from showing up.

### Testing
You need a domain marked as premium and `D7032-code` on the backend for testing. See the testing details there on how to mark the domain as premium.

See the `shouldDisplayAd` for the conditions to show the ad:
* non-DWPO user
* site without a plan
* domain registration in cart (doh...)

If the domain is a regular one, you should see the upsell:
<img width="285" alt="screen shot 2017-08-25 at 13 28 33" src="https://user-images.githubusercontent.com/3392497/29712565-cc33f2dc-899a-11e7-8e68-186913fac12e.png">
and the `extra.premium` field for that cart item should be `false`.

If the domain is a premium one, you should not see the upsell:
<img width="281" alt="screen shot 2017-08-25 at 13 22 01" src="https://user-images.githubusercontent.com/3392497/29712576-dde3fad6-899a-11e7-8c7c-23d815037747.png">
and the `extra.premium` field for that cart item should be `true`.

New domain registrations should not be impacted.
Non-domain registration renewals should not be impacted.

cc @mikeshelton1503, since this part of #16932
cc @markryall for awareness since this touches an upsell nudge :)