### PR TITLE
Components: Rename Suggestions to KeyedSuggestions

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -141,6 +141,7 @@
 @import 'components/infinite-list/style';
 @import 'components/info-popover/style';
 @import 'components/input-chrono/style';
+@import 'components/keyed-suggestions/style';
 @import 'components/list-end/style';
 @import 'components/logged-out-form/style';
 @import 'components/language-picker/style';
@@ -198,7 +199,6 @@
 @import 'components/stat-update-indicator/style';
 @import 'components/sticky-panel/style';
 @import 'components/sub-masterbar-nav/style';
-@import 'components/suggestions/style';
 @import 'components/textarea-autosize/style';
 @import 'components/thank-you-card/style';
 @import 'components/theme/style';

--- a/client/components/keyed-suggestions/index.jsx
+++ b/client/components/keyed-suggestions/index.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react';
+import PropTypes from 'prop-types';
 import {
 	has,
 	noop,
@@ -25,18 +26,18 @@ function SuggestionsButtonAll( props ) {
 	}
 
 	return <span
-		className="suggestions__category-show-all"
+		className="keyed-suggestions__category-show-all"
 		onClick={ click }>
 		{ props.label }
 	</span>;
 }
 
-class Suggestions extends React.Component {
+class KeyedSuggestions extends React.Component {
 
 	static propTypes = {
-		suggest: React.PropTypes.func,
-		terms: React.PropTypes.object,
-		input: React.PropTypes.string,
+		suggest: PropTypes.func,
+		terms: PropTypes.object,
+		input: PropTypes.string,
 	}
 
 	static defaultProps = {
@@ -252,9 +253,9 @@ class Suggestions extends React.Component {
 			const key = text + i;
 			const lowercasePart = part.toLowerCase();
 			if ( lowercasePart === highlightedText ) {
-				return <span key={ key } className="suggestions__value-emphasis" >{ part }</span>;
+				return <span key={ key } className="keyed-suggestions__value-emphasis" >{ part }</span>;
 			}
-			return <span key={ key } className="suggestions__value-normal" >{ part }</span>;
+			return <span key={ key } className="keyed-suggestions__value-normal" >{ part }</span>;
 		} );
 
 		return token;
@@ -282,9 +283,9 @@ class Suggestions extends React.Component {
 			const total = Object.keys( this.props.terms[ key ] ).length.toString();
 			//Add header
 			rendered.push(
-				<div className="suggestions__category" key={ key }>
-					<span className="suggestions__category-name">{ key }</span>
-					<span className="suggestions__category-counter">
+				<div className="keyed-suggestions__category" key={ key }>
+					<span className="keyed-suggestions__category-name">{ key }</span>
+					<span className="keyed-suggestions__category-counter">
 						{ i18n.translate( '%(filtered)s of %(total)s', {
 							args: { filtered, total }
 						} ) }
@@ -306,15 +307,15 @@ class Suggestions extends React.Component {
 			rendered.push( suggestions[ key ].map( ( value, i ) => {
 				const taxonomyName = terms[ key ][ value ].name;
 				const hasHighlight = ( noOfSuggestions + i ) === this.state.suggestionPosition;
-				const className = classNames( 'suggestions__value', { 'has-highlight': hasHighlight } );
+				const className = classNames( 'keyed-suggestions__value', { 'has-highlight': hasHighlight } );
 				return (
 					<span className={ className } onMouseDown={ this.onMouseDown } onMouseOver={ this.onMouseOver } key={ key + '_' + i }>
-						<span className="suggestions__value-category">{ key + ':' + value + ' '}</span>
-						<span className="suggestions__value-label-wigh-highlight">
+						<span className="keyed-suggestions__value-category">{ key + ':' + value + ' '}</span>
+						<span className="keyed-suggestions__value-label-wigh-highlight">
 							{ this.createTextWithHighlight( taxonomyName, this.state.filterTerm ) }
 						</span>
 						{ terms[ key ][ value ].description !== '' &&
-							<span className="suggestions__value-description">{ terms[ key ][ value ].description }</span>
+							<span className="keyed-suggestions__value-description">{ terms[ key ][ value ].description }</span>
 						}
 					</span>
 				);
@@ -323,15 +324,15 @@ class Suggestions extends React.Component {
 			noOfSuggestions += suggestions[ key ].length;
 		}
 
-		return <div className="suggestions__suggestions">{ rendered }</div>;
+		return <div className="keyed-suggestions__suggestions">{ rendered }</div>;
 	}
 
 	render() {
 		return (
-			<div className="suggestions">{ this.createSuggestions( this.state.suggestions ) }</div>
+			<div className="keyed-suggestions">{ this.createSuggestions( this.state.suggestions ) }</div>
 		);
 	}
 
 }
 
-export default Suggestions;
+export default KeyedSuggestions;

--- a/client/components/keyed-suggestions/style.scss
+++ b/client/components/keyed-suggestions/style.scss
@@ -2,12 +2,12 @@
 /*
  * Suggestions start out invisible, and they show up only when triggered.
  */
-.suggestions {
+.keyed-suggestions {
 	display: none;
 }
 
-.has-suggestions {
-	.suggestions {
+.has-keyed-suggestions {
+	.keyed-suggestions {
 		display: block;
 	}
 }
@@ -16,36 +16,36 @@
 /*
  * Suggestions list
  */
-.suggestions__suggestions {
+.keyed-suggestions__suggestions {
 	display: flex;
 	flex-direction: column;
 }
 
-.suggestions__category {
+.keyed-suggestions__category {
 	background-color: $gray-light;
 	border: 1px solid darken( $gray-light, 10% );
 	border-top: 0px;
 	padding: 4px 8px;
 	font-size: 13px;
 
-	.suggestions__category-name {
+	.keyed-suggestions__category-name {
 		text-transform: uppercase;
 		color: $gray-dark;
 	}
 
-	.suggestions__category-counter {
+	.keyed-suggestions__category-counter {
 		margin-left: 6px;
 		text-transform: uppercase;
 		color: $gray-text-min;
 	}
 
-	.suggestions__category-show-all {
+	.keyed-suggestions__category-show-all {
 		float: right;
 		cursor: pointer;
 	}
 }
 
-.suggestions__value {
+.keyed-suggestions__value {
 	display: flex;
 	padding: 10px 10px;
 	background: $white;
@@ -58,31 +58,31 @@
 		background-color: $blue-medium;
 		color: $white;
 
-		.suggestions__value-description {
+		.keyed-suggestions__value-description {
 			color: $white;
 		}
 	}
 }
 
-.suggestions__value-category {
+.keyed-suggestions__value-category {
 	display: none;
 }
 
-.suggestions__value-label-wigh-highlight {
+.keyed-suggestions__value-label-wigh-highlight {
 	flex: 0 0 auto;
 
-	.suggestions__value-emphasis,
-	.suggestions__value-normal {
+	.keyed-suggestions__value-emphasis,
+	.keyed-suggestions__value-normal {
 		pointer-events: none; /* Required to allow clicks pass-through */
 	}
 
-	.suggestions__value-emphasis {
+	.keyed-suggestions__value-emphasis {
 		font-weight: bold;
 		color: inherit;
 	}
 }
 
-.suggestions__value-description {
+.keyed-suggestions__value-description {
 	position: relative; /* Required to allow :before positioning to work */
 	pointer-events: none; /* Required to allow clicks pass-through */
 	flex: 1 1 auto;

--- a/client/my-sites/themes/themes-magic-search-card/index.jsx
+++ b/client/my-sites/themes/themes-magic-search-card/index.jsx
@@ -13,7 +13,7 @@ import Gridicon from 'gridicons';
  */
 import Search from 'components/search';
 import SegmentedControl from 'components/segmented-control';
-import Suggestions from 'components/suggestions';
+import KeyedSuggestions from 'components/keyed-suggestions';
 import StickyPanel from 'components/sticky-panel';
 import config from 'config';
 import { isMobile } from 'lib/viewport';
@@ -263,7 +263,7 @@ class ThemesMagicSearchCard extends React.Component {
 		);
 
 		const magicSearchClass = classNames( 'themes-magic-search', {
-			'has-suggestions': this.state.searchIsOpen
+			'has-keyed-suggestions': this.state.searchIsOpen
 		} );
 
 		const themesSearchCardClass = classNames( 'themes-magic-search-card', {
@@ -305,7 +305,7 @@ class ThemesMagicSearchCard extends React.Component {
 				</StickyPanel>
 				<div onClick={ this.handleClickInside }>
 					{ renderSuggestions &&
-						<Suggestions
+						<KeyedSuggestions
 							ref="suggestions"
 							terms={ this.props.filters }
 							input={ this.state.editedSearchElement }


### PR DESCRIPTION
This PR renames the `Suggestions` component to `KeyedSuggestions` to make place for the `Suggestions` component from #16497.

The idea was to merge the two components into a generic version, but unfortunately they differ to much in functionality for a simple solution.  
As the main difference between the two is that the current `Suggestions` works with taxnomies/categories, we decided to rename it to `KeyedSuggestions` and leave `Suggestions` open for the simple suggestions list.

# Testing

Go to `/themes` and verify themes search suggestions work as expected.