### PR TITLE
AT: Trigger a transfer to Atomic site with a plugin zip upload

### DIFF
--- a/client/my-sites/plugins/plugin-upload/index.jsx
+++ b/client/my-sites/plugins/plugin-upload/index.jsx
@@ -145,12 +145,12 @@ class PluginUpload extends React.Component {
 					backUrl={ `/plugins/${ siteSlug }` }
 					onProceed={ this.onProceedClick } /> }
 				{ ! upgradeJetpack && ! isJetpackMultisite && ! showEligibility && this.renderUploadCard() }
-			</export>
+			</Main>
 		);
 	}
 }
 
-Main default connect(
+export default connect(
 	( state ) => {
 		const siteId = getSelectedSiteId( state );
 		const error = getPluginUploadError( state, siteId );

--- a/client/my-sites/plugins/plugin-upload/index.jsx
+++ b/client/my-sites/plugins/plugin-upload/index.jsx
@@ -20,6 +20,7 @@ import EligibilityWarnings from 'blocks/eligibility-warnings';
 import EmptyContent from 'components/empty-content';
 import QueryEligibility from 'components/data/query-atat-eligibility';
 import { uploadPlugin, clearPluginUpload } from 'state/plugins/upload/actions';
+import { initiateAutomatedTransfer } from 'state/automated-transfer/actions';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import {
 	getPluginUploadError,
@@ -74,11 +75,14 @@ class PluginUpload extends React.Component {
 
 	renderUploadCard() {
 		const { inProgress, complete, isEligible, isJetpack } = this.props;
+
+		const uploadAction = isJetpack ? this.props.uploadPlugin : this.props.initiateAutomatedTransfer;
+
 		return (
 			<Card>
 				{ ! inProgress && ! complete && <UploadDropZone
-					doUpload={ this.props.uploadPlugin }
-					disabled={ ! isJetpack && ! isEligible } /> }
+					doUpload={ uploadAction }
+					disabled={ ! isEligible } /> }
 				{ inProgress && this.renderProgressBar() }
 			</Card>
 		);
@@ -141,12 +145,12 @@ class PluginUpload extends React.Component {
 					backUrl={ `/plugins/${ siteSlug }` }
 					onProceed={ this.onProceedClick } /> }
 				{ ! upgradeJetpack && ! isJetpackMultisite && ! showEligibility && this.renderUploadCard() }
-			</Main>
+			</export>
 		);
 	}
 }
 
-export default connect(
+Main default connect(
 	( state ) => {
 		const siteId = getSelectedSiteId( state );
 		const error = getPluginUploadError( state, siteId );
@@ -180,6 +184,6 @@ export default connect(
 			isEligible,
 		};
 	},
-	{ uploadPlugin, clearPluginUpload }
+	{ uploadPlugin, clearPluginUpload, initiateAutomatedTransfer }
 )( localize( PluginUpload ) );
 

--- a/client/my-sites/plugins/plugin-upload/index.jsx
+++ b/client/my-sites/plugins/plugin-upload/index.jsx
@@ -20,7 +20,7 @@ import EligibilityWarnings from 'blocks/eligibility-warnings';
 import EmptyContent from 'components/empty-content';
 import QueryEligibility from 'components/data/query-atat-eligibility';
 import { uploadPlugin, clearPluginUpload } from 'state/plugins/upload/actions';
-import { initiateAutomatedTransfer } from 'state/automated-transfer/actions';
+import { initiateAutomatedTransferWithPluginZip } from 'state/automated-transfer/actions';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import {
 	getPluginUploadError,
@@ -76,7 +76,7 @@ class PluginUpload extends React.Component {
 	renderUploadCard() {
 		const { inProgress, complete, isEligible, isJetpack } = this.props;
 
-		const uploadAction = isJetpack ? this.props.uploadPlugin : this.props.initiateAutomatedTransfer;
+		const uploadAction = isJetpack ? this.props.uploadPlugin : this.props.initiateAutomatedTransferWithPluginZip;
 
 		return (
 			<Card>
@@ -184,6 +184,6 @@ export default connect(
 			isEligible,
 		};
 	},
-	{ uploadPlugin, clearPluginUpload, initiateAutomatedTransfer }
+	{ uploadPlugin, clearPluginUpload, initiateAutomatedTransferWithPluginZip }
 )( localize( PluginUpload ) );
 

--- a/client/state/plugins/upload/reducer.js
+++ b/client/state/plugins/upload/reducer.js
@@ -8,6 +8,7 @@ import {
 } from 'state/utils';
 
 import {
+	AUTOMATED_TRANSFER_INITIATE,
 	AUTOMATED_TRANSFER_STATUS_SET,
 	PLUGIN_UPLOAD,
 	PLUGIN_UPLOAD_CLEAR,
@@ -43,6 +44,7 @@ export const inProgress = keyedReducer( 'siteId', createReducer( {}, {
 	[ PLUGIN_UPLOAD_COMPLETE ]: () => false,
 	[ PLUGIN_UPLOAD_ERROR ]: () => false,
 	[ PLUGIN_UPLOAD_CLEAR ]: () => false,
+	[ AUTOMATED_TRANSFER_INITIATE ]: () => true,
 	[ AUTOMATED_TRANSFER_STATUS_SET ]: ( state, { status } ) => status !== 'complete',
 } ) );
 

--- a/client/state/plugins/upload/reducer.js
+++ b/client/state/plugins/upload/reducer.js
@@ -8,6 +8,7 @@ import {
 } from 'state/utils';
 
 import {
+	AUTOMATED_TRANSFER_STATUS_SET,
 	PLUGIN_UPLOAD,
 	PLUGIN_UPLOAD_CLEAR,
 	PLUGIN_UPLOAD_COMPLETE,
@@ -20,6 +21,7 @@ export const uploadedPluginId = keyedReducer( 'siteId', createReducer( {}, {
 	[ PLUGIN_UPLOAD_COMPLETE ]: ( state, { pluginId } ) => pluginId,
 	[ PLUGIN_UPLOAD_CLEAR ]: () => null,
 	[ PLUGIN_UPLOAD_ERROR ]: () => null,
+	[ AUTOMATED_TRANSFER_STATUS_SET ]: ( state, { uploadedPluginId: pluginId } ) => pluginId,
 } ) );
 
 export const uploadError = keyedReducer( 'siteId', createReducer( {}, {

--- a/client/state/plugins/upload/reducer.js
+++ b/client/state/plugins/upload/reducer.js
@@ -43,6 +43,7 @@ export const inProgress = keyedReducer( 'siteId', createReducer( {}, {
 	[ PLUGIN_UPLOAD_COMPLETE ]: () => false,
 	[ PLUGIN_UPLOAD_ERROR ]: () => false,
 	[ PLUGIN_UPLOAD_CLEAR ]: () => false,
+	[ AUTOMATED_TRANSFER_STATUS_SET ]: ( state, { status } ) => status !== 'complete',
 } ) );
 
 export default combineReducers( {

--- a/client/state/plugins/upload/reducer.js
+++ b/client/state/plugins/upload/reducer.js
@@ -8,7 +8,7 @@ import {
 } from 'state/utils';
 
 import {
-	AUTOMATED_TRANSFER_INITIATE,
+	AUTOMATED_TRANSFER_INITIATE_WITH_PLUGIN_ZIP,
 	AUTOMATED_TRANSFER_STATUS_SET,
 	PLUGIN_UPLOAD,
 	PLUGIN_UPLOAD_CLEAR,
@@ -44,7 +44,7 @@ export const inProgress = keyedReducer( 'siteId', createReducer( {}, {
 	[ PLUGIN_UPLOAD_COMPLETE ]: () => false,
 	[ PLUGIN_UPLOAD_ERROR ]: () => false,
 	[ PLUGIN_UPLOAD_CLEAR ]: () => false,
-	[ AUTOMATED_TRANSFER_INITIATE ]: () => true,
+	[ AUTOMATED_TRANSFER_INITIATE_WITH_PLUGIN_ZIP ]: () => true,
 	[ AUTOMATED_TRANSFER_STATUS_SET ]: ( state, { status } ) => status !== 'complete',
 } ) );
 

--- a/client/state/plugins/upload/test/reducer.js
+++ b/client/state/plugins/upload/test/reducer.js
@@ -19,6 +19,10 @@ import {
 	uploadedPluginId,
 	uploadError,
 } from '../reducer';
+import {
+	initiateAutomatedTransfer,
+	setAutomatedTransferStatus,
+} from 'state/automated-transfer/actions';
 
 const siteId = 2916284;
 const pluginId = 'hello-dolly';
@@ -30,6 +34,11 @@ const error = {
 describe( 'uploadedPluginId', () => {
 	it( 'should contain plugin id after upload completes', () => {
 		const state = uploadedPluginId( {}, completePluginUpload( siteId, pluginId ) );
+		expect( state[ siteId ] ).to.equal( pluginId );
+	} );
+
+	it( 'should contain plugin id after transfer status', () => {
+		const state = uploadedPluginId( {}, setAutomatedTransferStatus( siteId, 'complete', pluginId ) );
 		expect( state[ siteId ] ).to.equal( pluginId );
 	} );
 
@@ -100,17 +109,27 @@ describe( 'inProgress', () => {
 	} );
 
 	it( 'should not be true after completed upload', () => {
-		const state = inProgress( { [ siteId ]: error }, completePluginUpload( siteId, pluginId ) );
+		const state = inProgress( { [ siteId ]: true }, completePluginUpload( siteId, pluginId ) );
 		expect( state[ siteId ] ).to.not.be.true;
 	} );
 
 	it( 'should not be true after upload error', () => {
-		const state = inProgress( { [ siteId ]: error }, pluginUploadError( siteId, error ) );
+		const state = inProgress( { [ siteId ]: true }, pluginUploadError( siteId, error ) );
 		expect( state[ siteId ] ).to.not.be.true;
 	} );
 
 	it( 'should not be true after upload clear', () => {
-		const state = inProgress( { [ siteId ]: error }, clearPluginUpload( siteId ) );
+		const state = inProgress( { [ siteId ]: true }, clearPluginUpload( siteId ) );
+		expect( state[ siteId ] ).to.not.be.true;
+	} );
+
+	it( 'should be true on transfer start', () => {
+		const state = inProgress( {}, initiateAutomatedTransfer( siteId ) );
+		expect( state[ siteId ] ).to.be.true;
+	} );
+
+	it( 'should not be true after completed transfer', () => {
+		const state = inProgress( { [ siteId ]: true }, setAutomatedTransferStatus( siteId, 'complete' ) );
 		expect( state[ siteId ] ).to.not.be.true;
 	} );
 } );

--- a/client/state/plugins/upload/test/reducer.js
+++ b/client/state/plugins/upload/test/reducer.js
@@ -20,7 +20,7 @@ import {
 	uploadError,
 } from '../reducer';
 import {
-	initiateAutomatedTransfer,
+	initiateAutomatedTransferWithPluginZip,
 	setAutomatedTransferStatus,
 } from 'state/automated-transfer/actions';
 
@@ -124,7 +124,7 @@ describe( 'inProgress', () => {
 	} );
 
 	it( 'should be true on transfer start', () => {
-		const state = inProgress( {}, initiateAutomatedTransfer( siteId ) );
+		const state = inProgress( {}, initiateAutomatedTransferWithPluginZip( siteId ) );
 		expect( state[ siteId ] ).to.be.true;
 	} );
 


### PR DESCRIPTION
Adds the final changes for enabling automated transfers on business sites with a plugin zip:
* Call the `initiateAutomatedTransferWithPluginZip` action creator from the UI for non-jetpack sites
* Tweak the plugin upload reducers to handle the transfer actions (plus unit tests)

Transfers can be triggered for eligible .com sites with a business plan at /plugins/upload/{site}.

<img width="1250" alt="screen shot 2017-09-06 at 13 18 20" src="https://user-images.githubusercontent.com/7767559/30111575-178fccbe-9306-11e7-9f15-7558f28d90b0.png">


**To Test**
* Testing transfers to atomic sites can be a long process, so don't feel you need to do a full test for a review of this PR. However, if you are interested:
* Follow the instructions at p58i-4Uy-p2, but...
* To trigger a transfer, go to /plugins/upload/{new_site} on this branch

