### PR TITLE
OAuth: Update the create account link to Calypso signup

### DIFF
--- a/config/desktop.json
+++ b/config/desktop.json
@@ -83,6 +83,7 @@
 		"signup/social": false,
 		"signup/social-management": true,
 		"standalone-site-preview": true,
+		"signup/wpcc": true,
 		"ui/first-view": false,
 		"upgrades/checkout": true,
 		"upgrades/credit-cards": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -95,6 +95,7 @@
 		"signup/domain-first-flow": true,
 		"signup/social": true,
 		"signup/social-management": true,
+		"signup/wpcc": true,
 		"simple-payments": true,
 		"standalone-site-preview": true,
 		"support-user": true,

--- a/config/production.json
+++ b/config/production.json
@@ -95,6 +95,7 @@
 		"signup/domain-first-flow": true,
 		"signup/social": true,
 		"signup/social-management": true,
+		"signup/wpcc": true,
 		"simple-payments": true,
 		"standalone-site-preview": true,
 		"support-user": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -102,6 +102,7 @@
 		"signup/domain-first-flow": true,
 		"signup/social": true,
 		"signup/social-management": true,
+		"signup/wpcc": true,
 		"simple-payments": true,
 		"standalone-site-preview": true,
 		"support-user": true,


### PR DESCRIPTION
This pull request updates the "Create Account" button on the login form to go to the new Calypso OAuth signup flow.

#### Testing instructions
  
1. Run `git checkout update/oauth-login-link-to-signup` and start your server with NODE_ENV=production
2. Open akismet.com in an incognito window
3. Signup with WordPress.com
4. When you are redirected to https://wordpress.com/log-in.... replace with http://calypso.localhost/log-in...
5. Click the "Create account" button
6. Check that you are redirected to /start/wpcc

Note: We shouldn't merge this until the WPCC signup looks right for woo and DOPS services
  
#### Reviews
  
- [x] Code
- [x] Product