### PR TITLE
Components: ES6ify HeaderCakeBack

### DIFF
--- a/client/components/header-cake/back.jsx
+++ b/client/components/header-cake/back.jsx
@@ -35,6 +35,10 @@ class HeaderCakeBack extends Component {
 		disabled: false,
 	};
 
+	state = {
+		windowWidth: viewport.getWindowInnerWidth(),
+	};
+
 	componentDidMount() {
 		this.resizeThrottled = throttle( this.handleWindowResize, 100 );
 		window.addEventListener( 'resize', this.resizeThrottled );
@@ -44,17 +48,17 @@ class HeaderCakeBack extends Component {
 		window.removeEventListener( 'resize', this.resizeThrottled );
 	}
 
-	handleWindowResize() {
-		//this.forceUpdate();
+	handleWindowResize = () => {
+		this.setState( {
+			windowWidth: viewport.getWindowInnerWidth(),
+		} );
 	}
 
 	hideText( text ) {
-		const windowWidth = viewport.getWindowInnerWidth();
-
 		if (
-			windowWidth <= HIDE_BACK_CRITERIA.windowWidth &&
+			this.state.windowWidth <= HIDE_BACK_CRITERIA.windowWidth &&
 			text.length >= HIDE_BACK_CRITERIA.characterLength ||
-			windowWidth <= 300
+			this.state.windowWidth <= 300
 		) {
 			return true;
 		}

--- a/client/components/header-cake/back.jsx
+++ b/client/components/header-cake/back.jsx
@@ -1,9 +1,10 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import i18n from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
 import Gridicon from 'gridicons';
 import { throttle } from 'lodash';
 
@@ -21,35 +22,31 @@ const HIDE_BACK_CRITERIA = {
 	characterLength: 8
 };
 
-export default React.createClass( {
-	displayName: 'HeaderCakeBack',
-
-	propTypes: {
+class HeaderCakeBack extends Component {
+	static propTypes = {
 		onClick: PropTypes.func,
 		href: PropTypes.string,
 		text: PropTypes.string,
-		spacer: PropTypes.bool
-	},
+		spacer: PropTypes.bool,
+	};
 
-	getDefaultProps() {
-		return {
-			spacer: false,
-			disabled: false
-		};
-	},
+	static defaultProps = {
+		spacer: false,
+		disabled: false,
+	};
 
 	componentDidMount() {
 		this.resizeThrottled = throttle( this.handleWindowResize, 100 );
 		window.addEventListener( 'resize', this.resizeThrottled );
-	},
+	}
 
 	componentWillUnmount() {
 		window.removeEventListener( 'resize', this.resizeThrottled );
-	},
+	}
 
 	handleWindowResize() {
-		this.forceUpdate();
-	},
+		//this.forceUpdate();
+	}
 
 	hideText( text ) {
 		const windowWidth = viewport.getWindowInnerWidth();
@@ -63,10 +60,18 @@ export default React.createClass( {
 		}
 
 		return false;
-	},
+	}
 
 	render() {
-		const { text = i18n.translate( 'Back' ), href, onClick, spacer, icon } = this.props;
+		const {
+			href,
+			icon,
+			onClick,
+			spacer,
+			text,
+			translate,
+		} = this.props;
+		const backText = text || translate( 'Back' );
 		const linkClasses = classNames( {
 			'header-cake__back': true,
 			'is-spacer': spacer,
@@ -76,9 +81,10 @@ export default React.createClass( {
 		return (
 			<Button compact borderless className={ linkClasses } href={ href } onClick={ onClick } disabled={ spacer }>
 				<Gridicon icon={ icon || 'arrow-left' } size={ 18 } />
-				{ ! this.hideText( text ) && text }
+				{ ! this.hideText( backText ) && backText }
 			</Button>
 		);
 	}
+}
 
-} );
+export default localize( HeaderCakeBack );

--- a/client/components/header-cake/back.jsx
+++ b/client/components/header-cake/back.jsx
@@ -75,7 +75,9 @@ class HeaderCakeBack extends Component {
 			text,
 			translate,
 		} = this.props;
-		const backText = text || translate( 'Back' );
+		const backText = text === undefined
+			? translate( 'Back' )
+			: text;
 		const linkClasses = classNames( {
 			'header-cake__back': true,
 			'is-spacer': spacer,


### PR DESCRIPTION
A continuation of #17532 (currently contains it). ES6ifies the `HeaderCakeBack` component and removes the legacy `forceUpdate()` in favor of internal component state.

To test:
* Checkout this branch.
* Go to a theme page, for example http://calypso.localhost:3000/theme/apostrophe-2
* Verify the Back button looks and works properly like it did before.
* Resize your window to a mobile size (< 480 pixels)
* Verify the back button text is not visible.
* Resize your window to a large size again.
* Verify the back button text is visible.
* Verify there are no visual, functional or behavioral changes introduced by this PR.