### PR TITLE
Plugins: Add plugin upload button to plugins list

### DIFF
--- a/client/my-sites/plugins-wpcom/jetpack-plugins-panel.jsx
+++ b/client/my-sites/plugins-wpcom/jetpack-plugins-panel.jsx
@@ -29,6 +29,7 @@ import NavItem from 'components/section-nav/item';
 import Search from 'components/search';
 import jetpackPlugins from './jetpack-plugins';
 import Tooltip from 'components/tooltip';
+import { isEnabled } from 'config';
 
 const filterGroup = category => group => {
 	if ( category && category !== 'all' ) {
@@ -193,16 +194,20 @@ class JetpackPluginsPanel extends Component {
 						</Button>
 					</ButtonGroup>
 
-					<ButtonGroup key="plugin-list-header__buttons-upload">
-						<Button
-							compact
-							href={ uploadUrl }
-							aria-label={ translate( 'Upload plugin', { context: 'button label' } ) }
-						>
-							<Gridicon icon="cloud-upload" size={ 18 } />
-							{ translate( 'Upload plugin' ) }
-						</Button>
-					</ButtonGroup>
+					{
+						isEnabled( 'manage/plugins/upload' ) && (
+							<ButtonGroup key="plugin-list-header__buttons-upload">
+								<Button
+									compact
+									href={ uploadUrl }
+									aria-label={ translate( 'Upload plugin', { context: 'button label' } ) }
+								>
+									<Gridicon icon="cloud-upload" size={ 18 } />
+									{ translate( 'Upload plugin' ) }
+								</Button>
+							</ButtonGroup>
+						)
+					}
 				</SectionHeader>
 
 				<CompactCard className="plugins-wpcom__jetpack-main-plugin plugins-wpcom__jetpack-plugin-item">

--- a/client/my-sites/plugins-wpcom/jetpack-plugins-panel.jsx
+++ b/client/my-sites/plugins-wpcom/jetpack-plugins-panel.jsx
@@ -151,6 +151,7 @@ class JetpackPluginsPanel extends Component {
 			.filter( group => group.plugins.length > 0 );
 
 		const browserUrl = [ '/plugins/browse', this.props.siteSlug ].join( '/' );
+		const uploadUrl = '/plugins/upload' + ( this.props.siteSlug ? '/' + this.props.siteSlug : '' );
 
 		return (
 			<div className="plugins-wpcom__jetpack-plugins-panel">
@@ -189,6 +190,17 @@ class JetpackPluginsPanel extends Component {
 								position="bottom">
 								{ translate( 'Browse all plugins' ) }
 							</Tooltip>
+						</Button>
+					</ButtonGroup>
+
+					<ButtonGroup key="plugin-list-header__buttons-upload">
+						<Button
+							compact
+							href={ uploadUrl }
+							aria-label={ translate( 'Upload plugin', { context: 'button label' } ) }
+						>
+							<Gridicon icon="cloud-upload" size={ 18 } />
+							{ translate( 'Upload plugin' ) }
 						</Button>
 					</ButtonGroup>
 				</SectionHeader>

--- a/client/my-sites/plugins-wpcom/jetpack-plugins-panel.jsx
+++ b/client/my-sites/plugins-wpcom/jetpack-plugins-panel.jsx
@@ -200,10 +200,10 @@ class JetpackPluginsPanel extends Component {
 								<Button
 									compact
 									href={ uploadUrl }
-									aria-label={ translate( 'Upload plugin', { context: 'button label' } ) }
+									aria-label={ translate( 'Upload Plugin' ) }
 								>
 									<Gridicon icon="cloud-upload" size={ 18 } />
-									{ translate( 'Upload plugin' ) }
+									{ translate( 'Upload Plugin' ) }
 								</Button>
 							</ButtonGroup>
 						)

--- a/client/my-sites/plugins-wpcom/style.scss
+++ b/client/my-sites/plugins-wpcom/style.scss
@@ -152,6 +152,14 @@
 	margin: 0;
 }
 
+.plugins-wpcom__panel .section-header {
+	.button-group {
+		display: inline-block;
+		float: left;
+		margin-left: 8px;
+	}
+}
+
 .plugins-wpcom__header-text {
 	width: 100%;
 	padding: 16px 24px;

--- a/client/my-sites/plugins/plugin-list-header/index.jsx
+++ b/client/my-sites/plugins/plugin-list-header/index.jsx
@@ -201,10 +201,10 @@ export class PluginsListHeader extends PureComponent {
 							compact
 							href={ uploadUrl }
 							onClick={ this.onUploadLinkClick }
-							aria-label={ translate( 'Upload plugin', { context: 'button label' } ) }
+							aria-label={ translate( 'Upload Plugin' ) }
 						>
 							<Gridicon icon="cloud-upload" size={ 18 } />
-							{ translate( 'Upload plugin' ) }
+							{ translate( 'Upload Plugin' ) }
 						</Button>
 					</ButtonGroup>
 				);

--- a/client/my-sites/plugins/plugin-list-header/index.jsx
+++ b/client/my-sites/plugins/plugin-list-header/index.jsx
@@ -104,6 +104,10 @@ export class PluginsListHeader extends PureComponent {
 		analytics.ga.recordEvent( 'Plugins', 'Clicked Add New Plugins' );
 	}
 
+	onUploadLinkClick = () => {
+		analytics.ga.recordEvent( 'Plugins', 'Clicked Plugin Upload Link' );
+	}
+
 	unselectOrSelectAll = () => {
 		const { plugins, selected } = this.props;
 		const someSelected = selected.length > 0;
@@ -162,6 +166,7 @@ export class PluginsListHeader extends PureComponent {
 					</Button>
 				</ButtonGroup>
 			);
+
 			const browserUrl = '/plugins/browse' + ( this.props.selectedSiteSlug ? '/' + this.props.selectedSiteSlug : '' );
 
 			rightSideButtons.push(
@@ -182,6 +187,23 @@ export class PluginsListHeader extends PureComponent {
 							position="bottom">
 							{ translate( 'Browse all plugins', { context: 'button tooltip' } ) }
 						</Tooltip>
+					</Button>
+				</ButtonGroup>
+			);
+
+			const uploadUrl = '/plugins/upload' + ( this.props.selectedSiteSlug ? '/' + this.props.selectedSiteSlug : '' );
+
+			rightSideButtons.push(
+				<ButtonGroup key="plugin-list-header__buttons-upload">
+					<Button
+						compact
+						href={ uploadUrl }
+						onClick={ this.onUploadLinkClick }
+						className="plugin-list-header__upload-button"
+						aria-label={ translate( 'Upload plugin', { context: 'button label' } ) }
+					>
+						<Gridicon icon="cloud-upload" size={ 18 } />
+						{ translate( 'Upload plugin' ) }
 					</Button>
 				</ButtonGroup>
 			);

--- a/client/my-sites/plugins/plugin-list-header/index.jsx
+++ b/client/my-sites/plugins/plugin-list-header/index.jsx
@@ -20,6 +20,7 @@ import DropdownSeparator from 'components/select-dropdown/separator';
 import BulkSelect from 'components/bulk-select';
 import Tooltip from 'components/tooltip';
 import analytics from 'lib/analytics';
+import { isEnabled } from 'config';
 
 // Constants help determine if the action bar should be a dropdown
 const MAX_ACTIONBAR_HEIGHT = 57;
@@ -191,22 +192,23 @@ export class PluginsListHeader extends PureComponent {
 				</ButtonGroup>
 			);
 
-			const uploadUrl = '/plugins/upload' + ( this.props.selectedSiteSlug ? '/' + this.props.selectedSiteSlug : '' );
+			if ( isEnabled( 'manage/plugins/upload' ) ) {
+				const uploadUrl = '/plugins/upload' + ( this.props.selectedSiteSlug ? '/' + this.props.selectedSiteSlug : '' );
 
-			rightSideButtons.push(
-				<ButtonGroup key="plugin-list-header__buttons-upload">
-					<Button
-						compact
-						href={ uploadUrl }
-						onClick={ this.onUploadLinkClick }
-						className="plugin-list-header__upload-button"
-						aria-label={ translate( 'Upload plugin', { context: 'button label' } ) }
-					>
-						<Gridicon icon="cloud-upload" size={ 18 } />
-						{ translate( 'Upload plugin' ) }
-					</Button>
-				</ButtonGroup>
-			);
+				rightSideButtons.push(
+					<ButtonGroup key="plugin-list-header__buttons-upload">
+						<Button
+							compact
+							href={ uploadUrl }
+							onClick={ this.onUploadLinkClick }
+							aria-label={ translate( 'Upload plugin', { context: 'button label' } ) }
+						>
+							<Gridicon icon="cloud-upload" size={ 18 } />
+							{ translate( 'Upload plugin' ) }
+						</Button>
+					</ButtonGroup>
+				);
+			}
 		} else {
 			const updateButton = (
 				<Button


### PR DESCRIPTION
This PR adds plugin upload buttons to the plugins pages for both Jetpack and non-Jetpack sites (under a feature flag). Fixes #15667.

Preview (Jetpack sites):
![](https://cldup.com/D-crLVzA6q.png)

Preview (.com / Atomic sites):
![](https://cldup.com/YyWq02g2SM.png)

To test:
* Checkout this branch.
* Go to `/plugins/:site`, where `:site` is a Jetpack site.
* Verify the button appears as on the screenshot.
* Click the button and verify it leads to the plugin upload page.
* Test the above for a WordPress.com site.
* Test the above for an Atomic site.
