### PR TITLE
Components: Add Suggestions component

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -199,6 +199,7 @@
 @import 'components/stat-update-indicator/style';
 @import 'components/sticky-panel/style';
 @import 'components/sub-masterbar-nav/style';
+@import 'components/suggestions/style';
 @import 'components/textarea-autosize/style';
 @import 'components/thank-you-card/style';
 @import 'components/theme/style';

--- a/client/components/suggestions/docs/example.jsx
+++ b/client/components/suggestions/docs/example.jsx
@@ -14,7 +14,7 @@ class SuggestionsExample extends Component {
 
 	static displayName = 'Suggestions';
 
-	static hints = [ "Foo", "Bar", "Baz" ];
+	static hints = [ 'Foo', 'Bar', 'Baz' ];
 
 	state = {
 		query: '',

--- a/client/components/suggestions/docs/example.jsx
+++ b/client/components/suggestions/docs/example.jsx
@@ -20,11 +20,13 @@ class SuggestionsExample extends Component {
 		query: '',
 	}
 
+	setSuggestionsRef = ref => this.suggestionsRef = ref;
+
 	hideSuggestions = () => this.setState( { query: '' } );
 
 	handleSearch = query => this.setState( { query: query } );
 
-	handleKeyDown = event => this.refs.suggestions.handleKeyEvent( event );
+	handleKeyDown = event => this.suggestionsRef.handleKeyEvent( event );
 
 	getSuggestions() {
 		return SuggestionsExample.hints
@@ -37,13 +39,12 @@ class SuggestionsExample extends Component {
 			<div className="docs__suggestions-container">
 				<SearchCard
 					disableAutocorrect
-					ref="search"
 					onSearch={ this.handleSearch }
 					onBlur={ this.hideSuggestions }
 					onKeyDown={ this.handleKeyDown }
 					placeholder="Type something..." />
 				<Suggestions
-					ref="suggestions"
+					ref={ this.setSuggestionsRef }
 					query={ this.state.query }
 					suggestions={ this.getSuggestions() }
 					suggest={ noop } />

--- a/client/components/suggestions/docs/example.jsx
+++ b/client/components/suggestions/docs/example.jsx
@@ -1,0 +1,55 @@
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import { noop } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import SearchCard from 'components/search-card';
+import Suggestions from 'components/suggestions';
+
+class SuggestionsExample extends Component {
+
+	static displayName = 'Suggestions';
+
+	static hints = [ "Foo", "Bar", "Baz" ];
+
+	state = {
+		query: '',
+	}
+
+	hideSuggestions = () => this.setState( { query: '' } );
+
+	handleSearch = query => this.setState( { query: query } );
+
+	handleKeyDown = event => this.refs.suggestions.handleKeyEvent( event );
+
+	getSuggestions() {
+		return SuggestionsExample.hints
+			.filter( hint => this.state.query && hint.match( new RegExp( this.state.query, 'i' ) ) )
+			.map( hint => ( { label: hint } ) );
+	}
+
+	render() {
+		return (
+			<div className="docs__suggestions-container">
+				<SearchCard
+					disableAutocorrect
+					ref="search"
+					onSearch={ this.handleSearch }
+					onBlur={ this.hideSuggestions }
+					onKeyDown={ this.handleKeyDown }
+					placeholder="Type something..." />
+				<Suggestions
+					ref="suggestions"
+					query={ this.state.query }
+					suggestions={ this.getSuggestions() }
+					suggest={ noop } />
+			</div>
+		);
+	}
+}
+
+export default SuggestionsExample;

--- a/client/components/suggestions/index.jsx
+++ b/client/components/suggestions/index.jsx
@@ -1,0 +1,106 @@
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { findIndex, isEqual, map } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import Item from './item';
+
+class Suggestions extends Component {
+
+	static propTypes = {
+		query: PropTypes.string,
+		suggestions: PropTypes.arrayOf( PropTypes.shape( {
+			label: PropTypes.string,
+		} ) ).isRequired,
+		suggest: PropTypes.func.isRequired,
+	}
+
+	static defaultProps = {
+		query: '',
+	}
+
+	state = {
+		suggestionPosition: 0,
+	}
+
+	componentWillReceiveProps( nextProps ) {
+		if ( isEqual( nextProps.suggestions, this.props.suggestions ) ) {
+			return;
+		}
+
+		this.setState( { suggestionPosition: 0 } );
+	}
+
+	getSuggestionsCount = () => this.props.suggestions.length;
+
+	getPositionForSuggestion = label => findIndex( this.props.suggestions, { label } );
+
+	suggest = position => this.props.suggest( this.props.suggestions[ position ] );
+
+	increasePosition = () => this.setState( {
+		suggestionPosition: ( this.state.suggestionPosition + 1 ) % this.getSuggestionsCount(),
+	} );
+
+	decreasePosition = () => this.setState( {
+		suggestionPosition: ( this.getSuggestionsCount() + this.state.suggestionPosition - 1 ) % this.getSuggestionsCount(),
+	} );
+
+	handleKeyEvent = ( event ) => {
+		if ( this.getSuggestionsCount() === 0 ) {
+			return;
+		}
+
+		switch ( event.key ) {
+			case 'ArrowDown':
+				this.increasePosition();
+				event.preventDefault();
+				break;
+
+			case 'ArrowUp':
+				this.decreasePosition();
+				event.preventDefault();
+				break;
+
+			case 'Enter':
+				this.state.suggestionPosition >= 0 && this.props.suggest( this.state.suggestionPosition );
+				break;
+		}
+	}
+
+	handleMouseDown = label => this.props.suggest( this.getPositionForSuggestion( label ) );
+
+	handleMouseOver = label => this.setState( {
+		suggestionPosition: this.getPositionForSuggestion( label ),
+	} );
+
+	render() {
+		const { query } = this.props;
+		const showSuggestions = this.getSuggestionsCount() > 0;
+
+		return (
+			<div>
+				{
+					showSuggestions &&
+					<div className="suggestions__wrapper">
+						{ map( this.props.suggestions, ( { label }, index ) => (
+							<Item
+								key={ index }
+								hasHighlight={ index === this.state.suggestionPosition }
+								query={ query }
+								onMouseDown={ this.handleMouseDown }
+								onMouseOver={ this.handleMouseOver }
+								label={ label } />
+						) ) }
+					</div>
+				}
+			</div>
+		);
+	}
+}
+
+export default Suggestions;

--- a/client/components/suggestions/item.jsx
+++ b/client/components/suggestions/item.jsx
@@ -1,0 +1,74 @@
+/**
+ * External dependencies
+ */
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+
+class Item extends PureComponent {
+
+	static propTypes = {
+		label: PropTypes.string.isRequired,
+		hasHighlight: PropTypes.bool,
+		query: PropTypes.string,
+		onMouseDown: PropTypes.func.isRequired,
+		onMouseOver: PropTypes.func.isRequired,
+	};
+
+	static defaultProps = {
+		hasHighlight: false,
+		query: '',
+	};
+
+	/**
+	 * Highlights the part of the text that matches the query.
+	 * @param  {string} text  Text.
+	 * @param  {string} query The text to be matched.
+	 * @return {element}      A React element including the highlighted text.
+	 */
+	createTextWithHighlight( text, query ) {
+		const re = new RegExp( '(' + query + ')', 'gi' );
+		const parts = text.split( re );
+
+		return parts.map( ( part, i ) => {
+			const key = text + i;
+			const lowercasePart = part.toLowerCase();
+			const spanClass = classNames( 'suggestions__label', {
+				'is-emphasized': lowercasePart === query,
+			} );
+
+			return <span key={ key } className={ spanClass } >{ part }</span>;
+		} );
+	}
+
+	handleMouseDown = ( event ) => {
+		event.stopPropagation();
+		event.preventDefault();
+
+		this.props.onMouseDown( this.props.label );
+	}
+
+	handleMouseOver = () => {
+		this.props.onMouseOver( this.props.label );
+	}
+
+	render() {
+		const { hasHighlight, label, query } = this.props;
+
+		const className = classNames(
+			'suggestions__item',
+			{ 'has-highlight': hasHighlight }
+		);
+
+		return (
+			<span
+				className={ className }
+				onMouseDown={ this.handleMouseDown }
+				onMouseOver={ this.handleMouseOver }>
+				{ this.createTextWithHighlight( label, query ) }
+			</span>
+		);
+	}
+}
+
+export default Item;

--- a/client/components/suggestions/style.scss
+++ b/client/components/suggestions/style.scss
@@ -1,0 +1,27 @@
+.suggestions__wrapper {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  z-index: 10;
+}
+
+.suggestions__item {
+  display: flex;
+  padding: 10px 10px;
+  background: $white;
+  border: 1px solid darken( $gray-light, 10% );
+  border-top: 0px;
+  font-size: 15px;
+  cursor: pointer;
+
+  &.has-highlight {
+    background-color: $blue-medium;
+    color: $white;
+  }
+}
+
+.suggestions__label {
+  &.is-emphasized {
+    font-weight: bold;
+  }
+}

--- a/client/devdocs/design/index.jsx
+++ b/client/devdocs/design/index.jsx
@@ -77,6 +77,7 @@ import ScreenReaderTextExample from 'components/screen-reader-text/docs/example'
 import PaginationExample from 'components/pagination/docs/example';
 import ListEnd from 'components/list-end/docs/example';
 import Wizard from 'components/wizard/docs/example';
+import Suggestions from 'components/suggestions/docs/example';
 
 let DesignAssets = React.createClass( {
 	displayName: 'DesignAssets',
@@ -169,6 +170,7 @@ let DesignAssets = React.createClass( {
 					<Spinner searchKeywords="loading" />
 					<SpinnerButton searchKeywords="loading input submit" />
 					<SpinnerLine searchKeywords="loading" />
+					<Suggestions />
 					<Timezone />
 					<TokenFields />
 					<VerticalMenu />

--- a/client/devdocs/design/style.scss
+++ b/client/devdocs/design/style.scss
@@ -148,3 +148,13 @@
 		}
 	}
 }
+
+.docs__suggestions-container {
+	.search-card {
+		margin-bottom: 4px;
+	}
+
+	.search.has-focus {
+		box-shadow: 0 0 0 1px $blue-wordpress, 0 0 0 4px $blue-light;
+	}
+}


### PR DESCRIPTION
This PR adds a 'dumb' `Suggestions` component that can be used for displaying simple auto-complete suggestions and supports keyboard navigation.  
Required by #16497.

![screen shot 2017-08-28 at 19 14 48](https://user-images.githubusercontent.com/8056203/29784679-373c05ba-8c25-11e7-996a-e0a2b33d22e2.png)

**Note:** I intentionally left out the positioning of the block, as I think it's quite context dependent.

# Testing

You can see the component in action at `/devdocs/design/suggestions`. 