### PR TITLE
Feature branch: Plugins: make "browse" the default route and improve behavior

### DIFF
--- a/client/my-sites/plugins/plugin-action/style.scss
+++ b/client/my-sites/plugins/plugin-action/style.scss
@@ -33,12 +33,10 @@
 }
 
 .plugin-action__label {
-	color: $gray;
-	font-size: 11px;
+	font-size: 12px;
 	line-height: 16px;
 	margin-right: 8px;
 	vertical-align: top;
-	text-transform: uppercase;
 	cursor: pointer;
 
 	.is-disabled & {
@@ -47,7 +45,7 @@
 	}
 
 	.has-disabled-info & {
-		cursor: pointer;
+		cursor: default;
 	}
 }
 
@@ -62,9 +60,15 @@
 .plugin-action__children .noticon {
 	margin-left: 8px;
 }
+
 .plugin-action__disabled-info.info-popover {
 	float: right;
-	margin: -2px 4px 0 2px;
+	height: 16px;
+	width: 24px;
+}
+
+.plugin-action__disabled-info.info-popover .gridicons-info-outline {
+	transform: translate(-4px, -2px);
 }
 
 .plugin-action__disabled-info-list {

--- a/client/my-sites/plugins/plugin-activate-toggle/style.scss
+++ b/client/my-sites/plugins/plugin-activate-toggle/style.scss
@@ -1,48 +1,42 @@
 .plugin-activate-toggle .plugin-action__children {
 	float: none;
 }
+
 .plugin-activate-toggle__disabled,
 .plugin-activate-toggle__link {
-	font-size: 11px;
+	font-size: 12px;
 	line-height: 16px;
-	margin-right: 12px;
+	margin-right: 8px;
 	vertical-align: top;
-	text-transform: uppercase;
-	color: $gray;
-
-	@include breakpoint( '<480px' ) {
-		color: $gray-dark;
-	}
 }
-.plugin-activate-toggle__link:hover {
+
+.plugin-activate-toggle__link:hover,
+.plugin-activate-toggle__link:hover .plugin-activate-toggle__icon {
 	color: $link-highlight;
 }
+
 .plugin-activate-toggle__disabled {
 	color: lighten( $gray, 30% );
 }
-.plugin-activate-toggle__link {
-	a {
-		color: currentcolor;
-		line-height: 18px;
-		vertical-align: top;
-		@include breakpoint( '<480px' ) {
-			color: $gray-dark;
-		}
-	}
-	.plugin-activate-toggle__icon {
-		@include breakpoint( '<480px' ) {
-			color: $gray;
-		}
-	}
+
+.plugin-activate-toggle__link a {
+	color: currentcolor;
+	line-height: 16px;
+	vertical-align: top;
+}
+
+.plugin-activate-toggle__link .plugin-activate-toggle__icon {
+	color: $gray;
 }
 
 .plugin-activate-toggle__icon {
 	display: inline-block;
 	vertical-align: inherit;
 	float: right;
-	margin: -1px 3px 0 -1px;
+	height: 16px;
+	width: 24px;
+}
 
-	.gridicons-cog {
-		transform: translate(.5px, .5px);
-	}
+.plugin-activate-toggle__icon .gridicons-cog {
+	transform: translate(3px, -1px);
 }

--- a/client/my-sites/plugins/plugin-install-button/style.scss
+++ b/client/my-sites/plugins/plugin-install-button/style.scss
@@ -2,7 +2,6 @@
 	position: absolute;
 	top: 0;
 	right: 0;
-	margin: 18px 0 0 0;
 	display: flex;
 	align-items: center;
 
@@ -10,7 +9,7 @@
 			color: $gray;
 			height: 100%;
 			position: initial;
-			margin-right: 16px;
+			margin: 18px 16px 0 0;
 		}
 
 	@include breakpoint( "<480px" ) {

--- a/client/my-sites/plugins/plugin-item/README.md
+++ b/client/my-sites/plugins/plugin-item/README.md
@@ -34,7 +34,6 @@ render: function() {
 * `allowedActions`: an object of allowed plugin actions: `activation`, `autoupdate`. Used to display/hide plugin actions.
 * `isAutoManaged`: a boolean if the plugin is auto managed. If true it will dispaly an auto managed message. Defaults to false.
 * `progress`: an array of progress steps.
-* `errors`: an array of update errors.
 * `notices`: an object of plugin notices: `completed`, `errors`, `inProgress`.
 * `hasAllNoManageSites`: a boolean to display an non managed plugin.
 * `hasUpdate`: a function to determine if a plugin has an update available. Defaults to a function returning false.

--- a/client/my-sites/plugins/plugin-item/plugin-item.jsx
+++ b/client/my-sites/plugins/plugin-item/plugin-item.jsx
@@ -257,16 +257,14 @@ class PluginItem extends Component {
 
 	renderPlaceholder() {
 		return (
-			<div className="plugin-item__wrapper">
-				<CompactCard className="plugin-item is-placeholder">
-					<div className="plugin-item__link">
-						<PluginIcon isPlaceholder />
-						<div className="plugin-item__info">
-							<div className="plugin-item__title is-placeholder"></div>
-						</div>
+			<CompactCard className="plugin-item is-placeholder">
+				<div className="plugin-item__link">
+					<PluginIcon isPlaceholder />
+					<div className="plugin-item__info">
+						<div className="plugin-item__title is-placeholder"></div>
 					</div>
-				</CompactCard>
-			</div>
+				</div>
+			</CompactCard>
 		);
 	}
 
@@ -305,32 +303,30 @@ class PluginItem extends Component {
 		const pluginItemClasses = classNames( 'plugin-item', { disabled } );
 
 		return (
-			<div className="plugin-item__wrapper">
-				<CompactCard className={ pluginItemClasses }>
-					{ disabled || ! this.props.isSelectable
-						? null
-						: <input
-								className="plugin-item__checkbox"
-								id={ plugin.slug }
-								type="checkbox"
-								onClick={ this.props.onClick }
-								checked={ this.props.isSelected }
-								readOnly={ true } />
-					}
-					<a
-						className="plugin-item__link"
-						href={ this.props.pluginLink }
-						onClick={ this.onItemClick }
-					>
-						<PluginIcon image={ plugin.icon } />
-						<div className="plugin-item__info">
-							{ pluginTitle }
-							{ this.pluginMeta( plugin ) }
-						</div>
-					</a>
-					{ pluginActions }
-				</CompactCard>
-			</div>
+			<CompactCard className={ pluginItemClasses }>
+				{ disabled || ! this.props.isSelectable
+					? null
+					: <input
+							className="plugin-item__checkbox"
+							id={ plugin.slug }
+							type="checkbox"
+							onClick={ this.props.onClick }
+							checked={ this.props.isSelected }
+							readOnly={ true } />
+				}
+				<a
+					className="plugin-item__link"
+					href={ this.props.pluginLink }
+					onClick={ this.onItemClick }
+				>
+					<PluginIcon image={ plugin.icon } />
+					<div className="plugin-item__info">
+						{ pluginTitle }
+						{ this.pluginMeta( plugin ) }
+					</div>
+				</a>
+				{ pluginActions }
+			</CompactCard>
 		);
 	}
 }

--- a/client/my-sites/plugins/plugin-item/plugin-item.jsx
+++ b/client/my-sites/plugins/plugin-item/plugin-item.jsx
@@ -10,7 +10,6 @@ import { localize, moment } from 'i18n-calypso';
  * Internal dependencies
  */
 import CompactCard from 'components/card/compact';
-import Card from 'components/card';
 import PluginIcon from 'my-sites/plugins/plugin-icon/plugin-icon';
 import PluginsActions from 'lib/plugins/actions';
 import PluginActivateToggle from 'my-sites/plugins/plugin-activate-toggle';
@@ -196,7 +195,7 @@ class PluginItem extends Component {
 		}
 		if ( this.props.isAutoManaged ) {
 			return (
-				<div className="plugin-item__last_updated">
+				<div className="plugin-item__last-updated">
 					{ translate( '%(pluginName)s is automatically managed on this site', { args: { pluginName: pluginData.name } } ) }
 				</div>
 			);
@@ -208,7 +207,7 @@ class PluginItem extends Component {
 
 		if ( pluginData.last_updated ) {
 			return (
-				<div className="plugin-item__last_updated">
+				<div className="plugin-item__last-updated">
 					{ translate( 'Last updated %(ago)s', { args: { ago: this.ago( pluginData.last_updated ) } } ) }
 				</div>
 			);
@@ -267,11 +266,16 @@ class PluginItem extends Component {
 
 	renderPlaceholder() {
 		return (
-			<CompactCard className="plugin-item is-placeholder ">
-				<PluginIcon isPlaceholder={ true } />
-				<div className="plugin-item__title is-placeholder"></div>
-				<div className="plugin-item__meta is-placeholder"></div>
-			</CompactCard>
+			<div className="plugin-item__wrapper">
+				<CompactCard className="plugin-item is-placeholder">
+					<div className="plugin-item__link">
+						<PluginIcon isPlaceholder />
+						<div className="plugin-item__info">
+							<div className="plugin-item__title is-placeholder"></div>
+						</div>
+					</div>
+				</CompactCard>
+			</div>
 		);
 	}
 
@@ -344,11 +348,10 @@ class PluginItem extends Component {
 			);
 		}
 
-		const CardType = this.props.isCompact ? CompactCard : Card;
 		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		return (
-			<div>
-				<CardType className="plugin-item">
+			<div className="plugin-item__wrapper">
+				<CompactCard className="plugin-item">
 					{ ! this.props.isSelectable
 						? null
 						: <input className="plugin-item__checkbox"
@@ -360,11 +363,13 @@ class PluginItem extends Component {
 					}
 					<a href={ this.props.pluginLink } onClick={ this.onItemClick } className="plugin-item__link">
 						<PluginIcon image={ plugin.icon } />
-						{ pluginTitle }
-						{ this.pluginMeta( plugin ) }
+						<div className="plugin-item__info">
+							{ pluginTitle }
+							{ this.pluginMeta( plugin ) }
+						</div>
 					</a>
 					{ this.props.selectedSite ? this.renderActions() : this.renderSiteCount() }
-				</CardType>
+				</CompactCard>
 				{ errorNotices }
 			</div>
 		);

--- a/client/my-sites/plugins/plugin-item/plugin-item.jsx
+++ b/client/my-sites/plugins/plugin-item/plugin-item.jsx
@@ -2,8 +2,9 @@
  * External dependencies
  */
 import React, { PropTypes, Component } from 'react';
+import { connect } from 'react-redux';
 import classNames from 'classnames';
-import { isEqual, uniqBy } from 'lodash';
+import { flowRight as compose, isEqual, uniqBy } from 'lodash';
 import { localize, moment } from 'i18n-calypso';
 
 /**
@@ -16,6 +17,7 @@ import PluginAutoupdateToggle from 'my-sites/plugins/plugin-autoupdate-toggle';
 import Count from 'components/count';
 import Notice from 'components/notice';
 import PluginNotices from 'lib/plugins/notices';
+import { errorNotice } from 'state/notices/actions';
 
 function checkPropsChange( nextProps, propArr ) {
 	let i;
@@ -31,11 +33,6 @@ function checkPropsChange( nextProps, propArr ) {
 }
 
 class PluginItem extends Component {
-
-	state = {
-		clicked: false
-	};
-
 	static propTypes = {
 		plugin: PropTypes.object,
 		sites: PropTypes.array,
@@ -68,7 +65,7 @@ class PluginItem extends Component {
 		hasUpdate: () => false,
 	};
 
-	shouldComponentUpdate( nextProps, nextState ) {
+	shouldComponentUpdate( nextProps ) {
 		const propsToCheck = [ 'plugin', 'sites', 'selectedSite', 'isMock', 'isSelectable', 'isSelected' ];
 		if ( checkPropsChange.call( this, nextProps, propsToCheck ) ) {
 			return true;
@@ -82,9 +79,6 @@ class PluginItem extends Component {
 			return true;
 		}
 
-		if ( this.state.clicked !== nextState.clicked ) {
-			return true;
-		}
 		return false;
 	}
 
@@ -215,13 +209,12 @@ class PluginItem extends Component {
 	}
 
 	clickNoManageItem = () => {
-		this.setState( { clicked: true } );
-	}
-
-	getNoManageWarning() {
-		return <Notice text={ this.props.translate( 'Jetpack Manage is disabled for all the sites where this plugin is installed' ) }
-			status="is-error"
-			showDismiss={ false } />;
+		this.props.errorNotice(
+			this.props.translate(
+				'Jetpack Manage is disabled for all the sites where this plugin is installed'
+			),
+			{ id: 'plugin-no-manage-error' } // Display the notice only once on repeated clicks
+		);
 	}
 
 	renderActions() {
@@ -322,9 +315,6 @@ class PluginItem extends Component {
 						</span>
 						{ this.props.selectedSite ? null : this.renderSiteCount() }
 					</CompactCard>
-					<div>
-					{ this.state.clicked ? this.getNoManageWarning() : null }
-					</div>
 				</div>
 			);
 		}
@@ -357,4 +347,7 @@ class PluginItem extends Component {
 	}
 }
 
-export default localize( PluginItem );
+export default compose(
+	connect( null, { errorNotice } ),
+	localize
+)( PluginItem );

--- a/client/my-sites/plugins/plugin-item/plugin-item.jsx
+++ b/client/my-sites/plugins/plugin-item/plugin-item.jsx
@@ -287,25 +287,13 @@ class PluginItem extends Component {
 			return this.renderPlaceholder();
 		}
 
-		let numberOfWarningIcons = 0;
-
-		if ( this.props.hasNoManageSite ) {
-			numberOfWarningIcons++;
-		}
-
-		if ( this.props.hasUpdate( plugin ) ) {
-			numberOfWarningIcons++;
-		}
-
-		const pluginTitle = (
-			<div className="plugin-item__title" data-warnings={ numberOfWarningIcons }>
-				{ plugin.name }
-			</div>
-			);
-
 		const disabled = this.props.hasAllNoManageSites;
 
-		const pluginItemClasses = classNames( 'plugin-item', { disabled } );
+		const pluginTitle = (
+			<div className="plugin-item__title">
+				{ plugin.name }
+			</div>
+		);
 
 		let pluginActions = null;
 		if ( ! this.props.selectedSite ) {
@@ -313,6 +301,8 @@ class PluginItem extends Component {
 		} else if ( ! disabled ) {
 			pluginActions = this.renderActions();
 		}
+
+		const pluginItemClasses = classNames( 'plugin-item', { disabled } );
 
 		return (
 			<div className="plugin-item__wrapper">

--- a/client/my-sites/plugins/plugin-item/plugin-item.jsx
+++ b/client/my-sites/plugins/plugin-item/plugin-item.jsx
@@ -208,7 +208,7 @@ class PluginItem extends Component {
 		return null;
 	}
 
-	clickNoManageItem = () => {
+	showNoManageNotice() {
 		this.props.errorNotice(
 			this.props.translate(
 				'Jetpack Manage is disabled for all the sites where this plugin is installed'
@@ -271,7 +271,10 @@ class PluginItem extends Component {
 	}
 
 	onItemClick = ( event ) => {
-		if ( this.props.isSelectable ) {
+		if ( this.props.hasAllNoManageSites ) {
+			event.preventDefault();
+			this.showNoManageNotice();
+		} else if ( this.props.isSelectable ) {
 			event.preventDefault();
 			this.props.onClick( this );
 		}
@@ -300,50 +303,45 @@ class PluginItem extends Component {
 			</div>
 			);
 
-		if ( this.props.hasAllNoManageSites ) {
-			const pluginItemClasses = classNames( 'plugin-item', {
-				disabled: this.props.hasAllNoManageSites,
-			} );
-			return (
-				<div className="plugin-item__wrapper">
-					<CompactCard className={ pluginItemClasses }
-						onClick={ this.clickNoManageItem }>
-						<span className="plugin-item__disabled">
-							<PluginIcon image={ plugin.icon } />
-							{ pluginTitle }
-							{ this.pluginMeta( plugin ) }
-						</span>
-						{ this.props.selectedSite ? null : this.renderSiteCount() }
-					</CompactCard>
-				</div>
-			);
+		const disabled = this.props.hasAllNoManageSites;
+
+		const pluginItemClasses = classNames( 'plugin-item', { disabled } );
+
+		let pluginActions = null;
+		if ( ! this.props.selectedSite ) {
+			pluginActions = this.renderSiteCount();
+		} else if ( ! disabled ) {
+			pluginActions = this.renderActions();
 		}
 
-		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		return (
 			<div className="plugin-item__wrapper">
-				<CompactCard className="plugin-item">
-					{ ! this.props.isSelectable
+				<CompactCard className={ pluginItemClasses }>
+					{ disabled || ! this.props.isSelectable
 						? null
-						: <input className="plugin-item__checkbox"
+						: <input
+								className="plugin-item__checkbox"
 								id={ plugin.slug }
 								type="checkbox"
 								onClick={ this.props.onClick }
 								checked={ this.props.isSelected }
 								readOnly={ true } />
 					}
-					<a href={ this.props.pluginLink } onClick={ this.onItemClick } className="plugin-item__link">
+					<a
+						className="plugin-item__link"
+						href={ this.props.pluginLink }
+						onClick={ this.onItemClick }
+					>
 						<PluginIcon image={ plugin.icon } />
 						<div className="plugin-item__info">
 							{ pluginTitle }
 							{ this.pluginMeta( plugin ) }
 						</div>
 					</a>
-					{ this.props.selectedSite ? this.renderActions() : this.renderSiteCount() }
+					{ pluginActions }
 				</CompactCard>
 			</div>
 		);
-		/* eslint-enable wpcalypso/jsx-classname-namespace */
 	}
 }
 

--- a/client/my-sites/plugins/plugin-item/plugin-item.jsx
+++ b/client/my-sites/plugins/plugin-item/plugin-item.jsx
@@ -11,7 +11,6 @@ import { localize, moment } from 'i18n-calypso';
  */
 import CompactCard from 'components/card/compact';
 import PluginIcon from 'my-sites/plugins/plugin-icon/plugin-icon';
-import PluginsActions from 'lib/plugins/actions';
 import PluginActivateToggle from 'my-sites/plugins/plugin-activate-toggle';
 import PluginAutoupdateToggle from 'my-sites/plugins/plugin-autoupdate-toggle';
 import Count from 'components/count';
@@ -50,7 +49,6 @@ class PluginItem extends Component {
 		} ),
 		isAutoManaged: PropTypes.bool,
 		progress: PropTypes.array,
-		errors: PropTypes.array,
 		notices: PropTypes.shape( {
 			completed: PropTypes.array,
 			errors: PropTypes.array,
@@ -288,29 +286,12 @@ class PluginItem extends Component {
 
 	render() {
 		const plugin = this.props.plugin;
-		const errors = this.props.errors ? this.props.errors : [];
 
 		if ( ! plugin ) {
 			return this.renderPlaceholder();
 		}
 
 		let numberOfWarningIcons = 0;
-		const errorNotices = errors.map( ( error, index ) => {
-			const dismissErrorNotice = function() {
-				PluginsActions.removePluginsNotices( [ error ] );
-			};
-			return (
-				<Notice
-					type="message"
-					status="is-error"
-					text={ PluginNotices.getMessage( [ error ], PluginNotices.errorMessage.bind( PluginNotices ) ) }
-					button={ PluginNotices.getErrorButton( error ) }
-					href={ PluginNotices.getErrorHref( error ) }
-					inline={ true }
-					onDismissClick={ dismissErrorNotice }
-					key={ 'notice-' + index } />
-			);
-		} );
 
 		if ( this.props.hasNoManageSite ) {
 			numberOfWarningIcons++;
@@ -370,7 +351,6 @@ class PluginItem extends Component {
 					</a>
 					{ this.props.selectedSite ? this.renderActions() : this.renderSiteCount() }
 				</CompactCard>
-				{ errorNotices }
 			</div>
 		);
 		/* eslint-enable wpcalypso/jsx-classname-namespace */

--- a/client/my-sites/plugins/plugin-item/style.scss
+++ b/client/my-sites/plugins/plugin-item/style.scss
@@ -47,26 +47,16 @@
 	}
 }
 
-.plugin-item__link,
-.plugin-item__disabled {
-	display: block;
+.plugin-item__link {
+	display: flex;
 	flex-grow: 1;
 	padding: 16px;
 	overflow: hidden; // lazy clearfix
 	cursor: pointer;
-}
-
-.plugin-item__link {
-	display: flex;
 
 	.is-bulk-editing & {
 		padding-left: 32px;
 	}
-}
-
-.plugin-item__disabled {
-	opacity: 0.5;
-	background: $gray-light;
 }
 
 // Checkbox for multiselect purposes

--- a/client/my-sites/plugins/plugin-item/style.scss
+++ b/client/my-sites/plugins/plugin-item/style.scss
@@ -37,8 +37,6 @@
 
 	@include breakpoint( '>1040px' ) {
 		flex-direction: column;
-		width: 100%;
-		height: 100%;
 	}
 
 	&.disabled {
@@ -249,7 +247,7 @@
 	}
 }
 
-.plugin-item__wrapper {
+.plugin-item {
 	box-sizing: border-box;
 	border: 0 solid lighten( $gray, 30% );
 

--- a/client/my-sites/plugins/plugin-item/style.scss
+++ b/client/my-sites/plugins/plugin-item/style.scss
@@ -1,8 +1,10 @@
 .plugin-item.card {
 	padding: 0;
+	margin: 0;
+	box-shadow: none;
 
 	.is-bulk-editing & {
-		padding-left: 24px;
+		padding-left: 16px;
 	}
 
 	& ~ .notice.is-error {
@@ -31,11 +33,10 @@
 .plugin-item {
 	position: relative;
 	display: flex;
+	flex-direction: column;
 	overflow: hidden; // lazy clearfix
-
-	@include breakpoint( '<480px' ) {
-		flex-wrap: wrap;
-	}
+	width: 100%;
+	height: 100%;
 
 	&.disabled {
 		opacity: 0.5;
@@ -44,25 +45,19 @@
 }
 
 .plugin-item__link,
-.plugin-item__disabled,
-.plugin-item.is-placeholder {
+.plugin-item__disabled {
 	display: block;
 	flex-grow: 1;
 	padding: 16px;
 	overflow: hidden; // lazy clearfix
 	cursor: pointer;
-
-	@include breakpoint( '<480px' ) {
-		flex-basis: 100%;
-	}
-	@include breakpoint( '>660px' ) {
-		padding: 24px;
-	}
 }
 
 .plugin-item__link {
+	display: flex;
+
 	.is-bulk-editing & {
-		padding-left: 40px;
+		padding-left: 32px;
 	}
 }
 
@@ -99,33 +94,24 @@
 }
 
 
-// Wraps plugin title and secondary info in bulk edit mode
+// Wraps plugin title and secondary info
 .plugin-item__info {
-	margin-left: 32px;
-
-	@include breakpoint( '>480px' ) {
-		margin-left: 40px;
-	}
+	flex: auto;
+	min-width: 0;
 }
 
 // Plugin title
 .plugin-item__title {
 	color: $gray-dark;
 	display: block;
-	font-size: 14px;
+	font-size: 15px;
 	line-height: 21px;
 	font-weight: 600;
 	overflow: hidden;
 	text-align: left;
 	text-overflow: ellipsis;
-	white-space: pre;
+	white-space: nowrap;
 
-	@include breakpoint( '>480px' ) {
-		font-size: 24px;
-		line-height: 32px;
-		font-weight: 700;
-		font-family: $serif;
-	}
 	@include breakpoint( '<480px') {
 		&[data-warnings="1"] {
 			padding-right: 32px;
@@ -136,20 +122,7 @@
 	}
 
 	&.is-placeholder {
-		width: 56%;
-		background-color: lighten( $gray, 30% );
-		animation: loading-fade 1.6s ease-in-out infinite;
-
-		&:before {
-			content: ' ';
-		}
-	}
-	.bulk-editing & {
-		margin-top: -4px;
-
-		@include breakpoint( '>480px' ) {
-			margin-top: -6px;
-		}
+		@include placeholder();
 	}
 }
 
@@ -165,18 +138,15 @@
 .plugin-item__count,
 .plugin-item__actions {
 	padding: 16px;
-	flex-grow: 1;
-	flex-shrink: 0;
-	align-self: center;
+	padding-top: 0;
+	margin-top: -6px;
+	flex: none;
+	display: flex;
+	flex-direction: row;
+	flex-wrap: wrap;
 
-	@include breakpoint( '>480px' ) {
-		flex-grow: 0;
-		text-align: right;
-	}
-
-	@include breakpoint( '>660px' ) {
-		padding-right: 24px;
-		padding-left: 24px;
+	.is-bulk-editing & {
+		padding-left: 32px;
 	}
 }
 
@@ -197,13 +167,90 @@
 	display: none;
 
 	@include breakpoint( '>480px' ) {
-		display: block;
+		display: flex;
 	}
 }
 
-.plugin-item__last_updated {
+.plugin-item__last-updated {
 	color: $gray;
 	font-size: 12px;
 	line-height: 1;
 	padding: 6px 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.plugin-item {
+	.plugin-icon {
+		flex: none;
+		margin-right: 16px;
+	}
+
+	.plugin-action {
+		margin-top: 6px;
+
+		& .form-toggle__switch {
+			float: left;
+		}
+
+		.form-toggle__label-content {
+			margin-left: 0;
+			margin-right: 12px;
+		}
+
+		.plugin-action__label {
+			margin-right: 0;
+			margin-left: 8px;
+		}
+
+		.plugin-activate-toggle__link {
+			margin-left: 8px;
+		}
+
+		.plugin-activate-toggle__icon {
+			float: left;
+			margin: 0;
+		}
+	}
+}
+
+.plugin-item__wrapper {
+	box-sizing: border-box;
+	border: 0 solid lighten( $gray, 30% );
+
+	@include breakpoint( ">1040px" ) {
+		width: 33.33%;
+
+		border-right-width: 1px;
+
+		&:nth-child( 3n ) {
+			border-right-width: 0;
+		}
+
+		&:nth-last-child( n + 4 ) {
+			border-bottom-width: 1px;
+		}
+
+		// Provider proper bottom borders in the second-last row when the number
+		// of items is not multiple of 3.
+		&:nth-child( 3n ) {
+			&:nth-last-child( 3 ),
+			&:nth-last-child( 2 ) {
+				border-bottom-width: 1px;
+			}
+		}
+
+		&:nth-child( 3n - 1 ):nth-last-child( 3 ) {
+			border-bottom-width: 1px;
+		}
+	}
+
+	@include breakpoint( "<1040px" ) {
+		width: 100%;
+
+		&:nth-last-child( n + 2 ) {
+			border-bottom-width: 1px;
+		}
+	}
 }

--- a/client/my-sites/plugins/plugin-item/style.scss
+++ b/client/my-sites/plugins/plugin-item/style.scss
@@ -104,15 +104,6 @@
 	text-overflow: ellipsis;
 	white-space: nowrap;
 
-	@include breakpoint( '<480px') {
-		&[data-warnings="1"] {
-			padding-right: 32px;
-		}
-		&[data-warnings="2"] {
-			padding-right: 64px;
-		}
-	}
-
 	&.is-placeholder {
 		@include placeholder();
 	}

--- a/client/my-sites/plugins/plugin-item/style.scss
+++ b/client/my-sites/plugins/plugin-item/style.scss
@@ -33,10 +33,13 @@
 .plugin-item {
 	position: relative;
 	display: flex;
-	flex-direction: column;
 	overflow: hidden; // lazy clearfix
-	width: 100%;
-	height: 100%;
+
+	@include breakpoint( '>1040px' ) {
+		flex-direction: column;
+		width: 100%;
+		height: 100%;
+	}
 
 	&.disabled {
 		opacity: 0.5;
@@ -93,7 +96,6 @@
 	cursor: pointer;
 }
 
-
 // Wraps plugin title and secondary info
 .plugin-item__info {
 	flex: auto;
@@ -105,8 +107,8 @@
 	color: $gray-dark;
 	display: block;
 	font-size: 15px;
-	line-height: 21px;
 	font-weight: 600;
+	margin-top: 3px;
 	overflow: hidden;
 	text-align: left;
 	text-overflow: ellipsis;
@@ -138,8 +140,6 @@
 .plugin-item__count,
 .plugin-item__actions {
 	padding: 16px;
-	padding-top: 0;
-	margin-top: -6px;
 	flex: none;
 	display: flex;
 	flex-direction: row;
@@ -151,10 +151,9 @@
 }
 
 .plugin-item__count {
-	font-size: 11px;
+	font-size: 12px;
 	line-height: 18px;
-	color: $gray;
-	text-transform: uppercase;
+	color: $gray-text-min;
 }
 
 .plugin-item__count .count {
@@ -162,56 +161,110 @@
 	float: right;
 }
 
-.plugin-item  .plugin-item__count,
+.plugin-item .plugin-item__count,
 .plugin-item .plugin-item__actions {
 	display: none;
 
 	@include breakpoint( '>480px' ) {
+		align-self: center;
 		display: flex;
+		flex-direction: column;
+		text-align: right;
+	}
+
+	@include breakpoint( '>1040px' ) {
+		align-self: flex-start;
+		flex-direction: row;
+		margin-top: -6px;
+		padding-top: 0;
+		text-align: left;
 	}
 }
 
+.plugin-item .plugin-item__count {
+	flex-direction: row;
+}
+
 .plugin-item__last-updated {
-	color: $gray;
-	font-size: 12px;
-	line-height: 1;
-	padding: 6px 0;
+	color: $gray-text-min;
+	font-size: 13px;
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
 }
 
-.plugin-item {
-	.plugin-icon {
-		flex: none;
-		margin-right: 16px;
+.plugin-item .plugin-icon {
+	flex: none;
+	margin-right: 12px;
+	width: 48px;
+	height: 48px;
+}
+
+.plugin-item .plugin-action {
+	@include breakpoint( '>1040px' ) {
+		margin-top: 6px;
 	}
 
-	.plugin-action {
-		margin-top: 6px;
-
-		& .form-toggle__switch {
-			float: left;
+	&:first-child {
+		@include breakpoint( '<1040px' ) {
+			margin-top: 0;
 		}
+	}
+}
 
-		.form-toggle__label-content {
-			margin-left: 0;
-			margin-right: 12px;
-		}
+.plugin-item .plugin-action__label {
+	@include breakpoint( '>1040px' ) {
+		margin-right: 0;
+		margin-left: 8px;
+	}
+}
 
-		.plugin-action__label {
-			margin-right: 0;
-			margin-left: 8px;
-		}
+.plugin-item .has-disabled-info .plugin-action__label {
+	@include breakpoint( '>1040px' ) {
+		margin-right: 8px;
+		margin-left: 0px;
+	}
+}
 
-		.plugin-activate-toggle__link {
-			margin-left: 8px;
-		}
+.plugin-item .plugin-action .form-toggle__label .form-toggle__switch {
+	@include breakpoint( '>1040px' ) {
+		float: left;
+	}
+}
 
-		.plugin-activate-toggle__icon {
-			float: left;
-			margin: 0;
-		}
+.plugin-item .form-toggle__label .form-toggle__label-content {
+	@include breakpoint( '>1040px' ) {
+		margin-right: 12px;
+		margin-left: 0;
+	}
+}
+
+.plugin-item .plugin-action__disabled-info.info-popover .gridicons-info-outline {
+	@include breakpoint( '>1040px' ) {
+		transform: translate(-2px, -2px);
+	}
+}
+
+.plugin-item .plugin-action .plugin-activate-toggle__link {
+	@include breakpoint( '>1040px' ) {
+		margin-right: 12px;
+		margin-left: 8px;
+	}
+}
+
+.plugin-item .plugin-activate-toggle__icon {
+	@include breakpoint( '>1040px' ) {
+		float: left;
+	}
+}
+
+.plugin-item .plugin-activate-toggle__icon .gridicons-cog {
+	@include breakpoint( '>480px' ) {
+		transform: translate(-3px, -1px);
+	}
+
+	@include breakpoint( '>1040px' ) {
+		transform: translate(3px, -1px);
 	}
 }
 

--- a/client/my-sites/plugins/plugin-meta/style.scss
+++ b/client/my-sites/plugins/plugin-meta/style.scss
@@ -52,8 +52,6 @@
 
 	@include breakpoint( '>480px' ) {
 		font-size: 24px;
-		font-weight: 700;
-		font-family: $serif;
 	}
 
 	.is-placeholder & {
@@ -132,6 +130,10 @@
 	}
 }
 
+.plugin-meta__actions .plugin-activate-toggle__icon .gridicons-cog {
+	transform: translate(-3px, -1px);
+}
+
 .plugin-meta__version-notice {
 	margin-top: -9px;
 
@@ -141,7 +143,12 @@
 }
 
 .plugin-meta__actions .plugin-item__count {
+	justify-content: space-between;
 	padding: 0;
+
+	@include breakpoint( '>480px' ) {
+		justify-content: flex-end;
+	}
 }
 
 .plugin-meta__actions .plugin-meta__active {

--- a/client/my-sites/plugins/plugins-browser-item/style.scss
+++ b/client/my-sites/plugins/plugins-browser-item/style.scss
@@ -80,7 +80,7 @@
 }
 
 .plugins-browser-item__author {
-	color: $gray;
+	color: $gray-text-min;
 	font-size: 13px;
 }
 

--- a/client/my-sites/plugins/plugins-browser-list/style.scss
+++ b/client/my-sites/plugins/plugins-browser-list/style.scss
@@ -1,5 +1,5 @@
 .plugins-browser-list {
-	margin: 24px 0;
+	margin-bottom: 16px;
 	background: $white;
 	box-shadow: 0 1px 2px lighten( $gray, 30% );
 
@@ -17,11 +17,10 @@
 .button.plugins-browser-list__select-all,
 .plugins-browser-list__title {
 	display: inline-block;
-	padding: 6px 0px 7px;
-	color: $gray;
-	font-size: 11px;
-	line-height: 1.6;
-	text-transform: uppercase;
+	padding: 5px 0px;
+	color: $gray-dark;
+	font-size: 12px;
+	line-height: 1.5;
 
 	&.is-expanded {
 		padding-left: 24px;

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -374,7 +374,7 @@ const PluginsBrowser = React.createClass( {
 		}
 
 		return (
-			<MainComponent className="is-wide-layout">
+			<MainComponent wideLayout>
 				<NonSupportedJetpackVersionNotice />
 				{ this.renderDocumentHead() }
 				<SidebarNavigation />

--- a/client/my-sites/plugins/plugins-list/index.jsx
+++ b/client/my-sites/plugins/plugins-list/index.jsx
@@ -18,6 +18,7 @@ import PluginsActions from 'lib/plugins/actions';
 import PluginsListHeader from 'my-sites/plugins/plugin-list-header';
 import PluginsLog from 'lib/plugins/log-store';
 import PluginNotices from 'lib/plugins/notices';
+import Card from 'components/card';
 import SectionHeader from 'components/section-header';
 import { getSelectedSite, getSelectedSiteSlug } from 'state/ui/selectors';
 import { isSiteAutomatedTransfer } from 'state/selectors';
@@ -421,7 +422,7 @@ export const PluginsList = React.createClass( {
 
 	// Renders
 	render() {
-		const itemListClasses = classNames( 'list-cards-compact', 'plugins-list', {
+		const itemListClasses = classNames( 'plugins-list__elements', {
 			'is-bulk-editing': this.state.bulkManagementActive
 		} );
 
@@ -435,9 +436,9 @@ export const PluginsList = React.createClass( {
 						label={ this.props.header }
 						className="plugins-list__section-actions is-placeholder"
 					/>
-					<div className={ itemListClasses }>{ this.renderPlaceholders() }</div>
+					<Card className={ itemListClasses }>{ this.renderPlaceholders() }</Card>
 				</div>
-				);
+			);
 		}
 
 		if ( isEmpty( this.props.plugins ) ) {
@@ -465,9 +466,9 @@ export const PluginsList = React.createClass( {
 					haveActiveSelected={ this.props.plugins.some( this.filterSelection.active.bind( this ) ) }
 					haveInactiveSelected={ this.props.plugins.some( this.filterSelection.inactive.bind( this ) ) }
 					haveUpdatesSelected= { this.props.plugins.some( this.filterSelection.updates.bind( this ) ) } />
-				<div className={ itemListClasses }>
+				<Card className={ itemListClasses }>
 					{ this.orderPluginsByUpdates( this.props.plugins ).map( this.renderPlugin ) }
-				</div>
+				</Card>
 			</div>
 		);
 	},
@@ -493,7 +494,7 @@ export const PluginsList = React.createClass( {
 		} );
 	},
 
-	renderPlugin( plugin, index ) {
+	renderPlugin( plugin ) {
 		const selectThisPlugin = this.togglePlugin.bind( this, plugin );
 		const allowedPluginActions = this.getAllowedPluginActions( plugin );
 		const isSelectable = this.state.bulkManagementActive && ( allowedPluginActions.autoupdate || allowedPluginActions.activation );
@@ -513,13 +514,12 @@ export const PluginsList = React.createClass( {
 				selectedSite={ this.props.selectedSite }
 				pluginLink={ '/plugins/' + encodeURIComponent( plugin.slug ) + this.siteSuffix() }
 				allowedActions = { allowedPluginActions }
-				isCompact={ index !== this.props.pluginUpdateCount - 1 }
 				isAutoManaged = { ! allowedPluginActions.autoupdate } />
 		);
 	},
 
 	renderPlaceholders() {
-		const placeholderCount = 16;
+		const placeholderCount = 18;
 		return range( placeholderCount ).map( i => <PluginItem key={ 'placeholder-' + i } /> );
 	}
 } );

--- a/client/my-sites/plugins/plugins-list/index.jsx
+++ b/client/my-sites/plugins/plugins-list/index.jsx
@@ -505,7 +505,6 @@ export const PluginsList = React.createClass( {
 				plugin={ plugin }
 				sites={ plugin.sites }
 				progress={ this.state.notices.inProgress.filter( log => log.plugin.slug === plugin.slug ) }
-				errors={ this.state.notices.errors.filter( log => log.plugin && log.plugin.slug === plugin.slug ) }
 				notices={ this.state.notices }
 				isSelected={ this.isSelected( plugin ) }
 				isSelectable={ isSelectable }

--- a/client/my-sites/plugins/plugins-list/style.scss
+++ b/client/my-sites/plugins/plugins-list/style.scss
@@ -1,3 +1,9 @@
 .plugins-list {
 	margin-bottom: 16px;
 }
+
+.plugins-list__elements {
+	display: flex;
+	flex-flow: row wrap;
+	padding: 0;
+}


### PR DESCRIPTION
This is a work-in-progress PR to update the Plugins page so that browsing plugins happens at `/plugins` (previously `/plugins/browse`, although that will still work) and managing plugins happens at `/plugins/manage` (previously `/plugins`).

There are several other improvements as part of this effort, and this PR may end up becoming multiple PRs as it progresses.

Here's a brief list of the changes this project is meant to address:

- [x] Make /plugins go to browse page
- [x] Make sure browse page still supports filter 
- [x] Make sure browse page still supports category 
- [x] Make sure browse page still supports search
- [x] Make sure browse page still supports multi-site
- [x] Move manage page to /plugins/manage
- [x] Add suggested search tabs to browse page
- [x] Add "Manage" button to Browse page header
- [x] Add "Manage" button to sidebar
- [x] Make sure manage page still supports filters
- [x] Make sure manage page still supports search
- [x] Change manage page to 3 columns
- [x] Add featured and popular plugins below installed on Manage page
- [x] Add "add plugin" button to Manage page header
- [x] Make sure bulk management still works
- [ ] Redirect /plugins/browse to /plugins, keeping filter, site, and search
- [ ] Add Jetpack features as "plugin" blocks in browse page
- [ ] Add error message notice inside plugin item; click error notice to show error
- [ ] Move "Upload Plugin" button in Manage page to header