### PR TITLE
Stats: Add delay to avoid stale `_dl` in `calypso_page_view` events

### DIFF
--- a/client/lib/analytics/index.js
+++ b/client/lib/analytics/index.js
@@ -161,7 +161,8 @@ const analytics = {
 	// pageView is a wrapper for pageview events across Tracks and GA
 	pageView: {
 		record: function( urlPath, pageTitle ) {
-			// add delay to avoid stale `_dl` (browserdocumentlocation) in recorded calypso_page_view event details
+			// add delay to avoid stale `_dl` in recorded calypso_page_view event details
+			// `_dl` (browserdocumentlocation) is read from the current URL by external JavaScript
 			setTimeout( () => {
 				mostRecentUrlPath = urlPath;
 				analytics.tracks.recordPageView( urlPath );

--- a/client/lib/analytics/index.js
+++ b/client/lib/analytics/index.js
@@ -161,10 +161,13 @@ const analytics = {
 	// pageView is a wrapper for pageview events across Tracks and GA
 	pageView: {
 		record: function( urlPath, pageTitle ) {
-			mostRecentUrlPath = urlPath;
-			analytics.tracks.recordPageView( urlPath );
-			analytics.ga.recordPageView( urlPath, pageTitle );
-			analytics.emit( 'page-view', urlPath, pageTitle );
+			// add delay to avoid stale `_dl` (browserdocumentlocation) in recorded calypso_page_view event details
+			setTimeout( () => {
+				mostRecentUrlPath = urlPath;
+				analytics.tracks.recordPageView( urlPath );
+				analytics.ga.recordPageView( urlPath, pageTitle );
+				analytics.emit( 'page-view', urlPath, pageTitle );
+			}, 0 );
 		}
 	},
 


### PR DESCRIPTION
This PR fixes issue #17491 which was caused by race condition between `analytics.pageView.record` call and `page` routing that resulted in stale `_dl` event property.

Implemented solution adds a delay to allow page routing to complete before proceeding.

Test Plan:

1. Enable tracks debugging by entering localStorage.setItem('debug', 'calypso:analytics:tracks') into browser console.
2. Click on "Site Pages"
3. Click on "Media"
4. Notice `_dl` event property of calypso_page_view event matches `path`.
5. Try other pages

On `_dl` event property, it's part of a bundle of extra properties added by Tracks client-side code when following statement is executed in `lib/analytics` module:

    window._tkq.push( [ 'recordEvent', eventName, eventProperties ] );

While it appears to be a push to an array, it's actually a call to Tracks client-side API (`recordEvent` function) that eventually results in HTTP GET to `pixel.wp.com/t.gif` with data as query parameter.

Actual code that sets `_dl` is this:

    query._dl = document.location.toString();

So if `page` hasn't called `history.pushState` when `analytics.pageView.record` is called, wrong value (URL of the page navigating from instead of destination which is what `path` describes) is recorded.