### PR TITLE
Reader: Move Conversations action items up

### DIFF
--- a/client/blocks/comments/style.scss
+++ b/client/blocks/comments/style.scss
@@ -404,6 +404,7 @@ a.comments__comment-username {
 .comments__comment-content {
 	@extend %content-font;
 	font-size: 15px;
+	line-height: 1.56;
 	word-break: break-word;
 
 	p {
@@ -428,6 +429,7 @@ a.comments__comment-username {
 	list-style: none;
 	color: $gray;
 	font-size: 14px;
+	margin-top: -5px;
 
 	button {
 		display: inline-block;

--- a/client/blocks/comments/style.scss
+++ b/client/blocks/comments/style.scss
@@ -404,7 +404,6 @@ a.comments__comment-username {
 .comments__comment-content {
 	@extend %content-font;
 	font-size: 15px;
-	line-height: 1.56;
 	word-break: break-word;
 
 	p {
@@ -429,7 +428,6 @@ a.comments__comment-username {
 	list-style: none;
 	color: $gray;
 	font-size: 14px;
-	margin-top: -5px;
 
 	button {
 		display: inline-block;

--- a/client/blocks/comments/style.scss
+++ b/client/blocks/comments/style.scss
@@ -429,7 +429,7 @@ a.comments__comment-username {
 	list-style: none;
 	color: $gray;
 	font-size: 14px;
-	margin-top: 2px;
+	margin-top: -4px;
 
 	button {
 		display: inline-block;

--- a/client/blocks/comments/style.scss
+++ b/client/blocks/comments/style.scss
@@ -404,7 +404,7 @@ a.comments__comment-username {
 .comments__comment-content {
 	@extend %content-font;
 	font-size: 15px;
-	line-height: 25px;
+	line-height: 1.56;
 	word-break: break-word;
 
 	p {
@@ -429,7 +429,7 @@ a.comments__comment-username {
 	list-style: none;
 	color: $gray;
 	font-size: 14px;
-	margin-top: -4px;
+	margin-top: -5px;
 
 	button {
 		display: inline-block;

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -151,7 +151,6 @@
 .reader-full-post__story {
 	max-width: 720px;
 	font-size: 17px;
-	line-height: 28px;
 
 	@include breakpoint( "<480px" ) {
 		font-size: 15px;
@@ -165,6 +164,7 @@
 
 .reader-full-post__story-content {
 	color: $gray-dark;
+	line-height: 28px;
 }
 
 .reader-full-post__story-content img {

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -150,7 +150,6 @@
 
 .reader-full-post__story {
 	max-width: 720px;
-	font-size: 17px;
 
 	@include breakpoint( "<480px" ) {
 		font-size: 15px;
@@ -164,6 +163,7 @@
 
 .reader-full-post__story-content {
 	color: $gray-dark;
+	font-size: 17px;
 	line-height: 28px;
 }
 


### PR DESCRIPTION
This fixes: https://github.com/Automattic/wp-calypso/issues/17509 and https://github.com/Automattic/wp-calypso/issues/17506

**Before:**
![screenshot 2017-08-25 10 45 56](https://user-images.githubusercontent.com/4924246/29725962-cce9e3e8-8982-11e7-983a-fcd090184cc7.png)

**After:**
![screenshot 2017-08-25 10 46 47](https://user-images.githubusercontent.com/4924246/29725970-d1199314-8982-11e7-8fd8-6c5fa3c5ed56.png)
