### PR TITLE
Themes: Fix CSS selector causing welcome dropdown to not appear

### DIFF
--- a/client/my-sites/themes/themes-magic-search-card/style.scss
+++ b/client/my-sites/themes/themes-magic-search-card/style.scss
@@ -147,7 +147,7 @@
 		display: none;
 	}
 
-	&.has-suggestions {
+	&.has-keyed-suggestions {
 		.themes-magic-search-card__welcome,
 		.suggestions {
 			display: block;


### PR DESCRIPTION
Fixes the issue causing the welcome dropdown to not appear when focusing the search on themes showcase.

# Testing

Go to `themes` and focus the search input - ensure the welcome dropdown appears.

![screen shot 2017-08-24 at 12 33 03](https://user-images.githubusercontent.com/8056203/29727682-410d6950-89d5-11e7-87d5-0175de08c92f.png)
