### PR TITLE
WebpackBuildMonitor: defer the dispatch to avoid infinite loops

### DIFF
--- a/client/components/webpack-build-monitor/index.jsx
+++ b/client/components/webpack-build-monitor/index.jsx
@@ -81,7 +81,7 @@ const store = createStore(
 );
 
 const wrapConsole = fn => ( message, ...args ) => {
-	store.dispatch( { type: CONSOLE_MESSAGE, message } );
+	new Promise().then( () => store.dispatch( { type: CONSOLE_MESSAGE, message } ) );
 	fn.call( window, message, ...args );
 };
 

--- a/client/components/webpack-build-monitor/index.jsx
+++ b/client/components/webpack-build-monitor/index.jsx
@@ -7,7 +7,7 @@
 import React from 'react';
 import { createStore } from 'redux';
 import classNames from 'classnames';
-import { find, includes, startsWith, identity, isEqual } from 'lodash';
+import { find, includes, startsWith, identity } from 'lodash';
 
 /**
  * Internal dependencies

--- a/client/components/webpack-build-monitor/index.jsx
+++ b/client/components/webpack-build-monitor/index.jsx
@@ -81,7 +81,7 @@ const store = createStore(
 );
 
 const wrapConsole = fn => ( message, ...args ) => {
-	new Promise().then( () => store.dispatch( { type: CONSOLE_MESSAGE, message } ) );
+	Promise.resolve().then( () => store.dispatch( { type: CONSOLE_MESSAGE, message } ) );
 	fn.call( window, message, ...args );
 };
 
@@ -102,7 +102,7 @@ const RELOAD_REQUIRED_ELEMENT = (
 	<div className="webpack-build-monitor is-warning">Need to refresh</div>
 );
 
-class WebpackBuildMonitor extends React.Component {
+class WebpackBuildMonitor extends React.PureComponent {
 	state = {
 		buildStatus: IDLE,
 		reloadRequired: false,
@@ -110,9 +110,9 @@ class WebpackBuildMonitor extends React.Component {
 
 	componentDidMount() {
 		this.unsubscribe = store.subscribe( () => {
-			const status = store.getState();
-			if ( ! isEqual( status, this.state ) ) {
-				this.setState( store.getState() );
+			const state = store.getState();
+			if ( state !== this.state ) {
+				this.setState( state );
 			}
 		} );
 	}

--- a/client/components/webpack-build-monitor/index.jsx
+++ b/client/components/webpack-build-monitor/index.jsx
@@ -109,12 +109,18 @@ class WebpackBuildMonitor extends React.PureComponent {
 	};
 
 	componentDidMount() {
-		this.unsubscribe = store.subscribe( () => {
-			const state = store.getState();
-			if ( state !== this.state ) {
-				this.setState( state );
-			}
-		} );
+		this.unsubscribe = store.subscribe(
+			( function() {
+				let prevState = undefined;
+				return () => {
+					const nextState = store.getState();
+					if ( nextState !== prevState ) {
+						this.setState( nextState );
+						prevState = nextState;
+					}
+				};
+			} )()
+		);
 	}
 
 	componentWillUnmount() {


### PR DESCRIPTION
cc @jsnajdr

I'm not sure how it is currently possible, but there are cases where the [WBM is still causing an infinite loop](https://github.com/Automattic/wp-calypso/pull/17479) because of `setState` from `render` --> react warning --> infinite loop.