### PR TITLE
PostItem: Only show share menu when publicize is enabled

### DIFF
--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/share.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/share.jsx
@@ -14,6 +14,7 @@ import PopoverMenuItem from 'components/popover/menu-item';
 import { mc } from 'lib/analytics';
 import { getPost } from 'state/posts/selectors';
 import { toggleSharePanel } from 'state/ui/post-type-list/actions';
+import { isPublicizeEnabled } from 'state/selectors';
 import config from 'config';
 
 class PostActionsEllipsisMenuShare extends Component {
@@ -37,8 +38,12 @@ class PostActionsEllipsisMenuShare extends Component {
 	}
 
 	render() {
-		const { translate, status } = this.props;
-		if ( ! config.isEnabled( 'posts/post-type-list' ) || ! includes( [ 'publish' ], status ) ) {
+		const { translate, status, isPublicizeEnabled: isPublicizeEnabledForSite } = this.props;
+		if (
+			! config.isEnabled( 'posts/post-type-list' ) ||
+			! includes( [ 'publish' ], status ) ||
+			! isPublicizeEnabledForSite
+		) {
 			return null;
 		}
 
@@ -59,6 +64,7 @@ export default connect(
 
 		return {
 			status: post.status,
+			isPublicizeEnabled: isPublicizeEnabled( state, post.site_ID, post.type ),
 		};
 	}, {
 		toggleSharePanel,


### PR DESCRIPTION
This PR fixes an issue that caused the "Share" menu item to be shown on sites where publicize was disabled.

Before:
![image](https://user-images.githubusercontent.com/363749/29731280-75be0c44-89a9-11e7-8efb-3be5181b7bae.png)

After:
![image](https://user-images.githubusercontent.com/363749/29731289-80a8de9a-89a9-11e7-8eb7-85dc58e1022e.png)


To test:
* Checkout branch
* `ENABLE_FEATURES=posts/post-type-list npm start`
* Navigate to the "Blog Posts" page
* For sites that have publicize disabled, you should no longer see "Share" in the ellipsis menu