### PR TITLE
A/B Test: Privacy protection auto added (try 2)

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -115,7 +115,7 @@ module.exports = {
 		allowExistingUsers: true,
 	},
 	privacyNoPopup: {
-		datestamp: '20170828',
+		datestamp: '20170829',
 		variations: {
 			original: 50,
 			nopopup: 50,

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -114,4 +114,13 @@ module.exports = {
 		defaultVariation: 'original',
 		allowExistingUsers: true,
 	},
+	privacyNoPopup: {
+		datestamp: '20170828',
+		variations: {
+			original: 50,
+			nopopup: 50,
+		},
+		defaultVariation: 'original',
+		allowExistingUsers: true,
+	},
 };

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -115,7 +115,7 @@ module.exports = {
 		allowExistingUsers: true,
 	},
 	privacyNoPopup: {
-		datestamp: '20170829',
+		datestamp: '20170830',
 		variations: {
 			original: 50,
 			nopopup: 50,

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -53,7 +53,7 @@ function createSiteOrDomain( callback, dependencies, data, reduxStore ) {
 		};
 
 		const domainChoiceCart = [ domainItem ];
-		if ( abtest( 'privacyNoPopup' ) === 'nopopup' ) {
+		if ( domainItem && abtest( 'privacyNoPopup' ) === 'nopopup' ) {
 			domainChoiceCart.push(
 				cartItems.domainPrivacyProtection( {
 					domain: domainItem.meta,
@@ -132,7 +132,7 @@ function createSiteWithCart( callback, dependencies, {
 		};
 		const addToCartAndProceed = () => {
 			let privacyItem = null;
-			if ( abtest( 'privacyNoPopup' ) === 'nopopup' ) {
+			if ( domainItem && abtest( 'privacyNoPopup' ) === 'nopopup' ) {
 				privacyItem = cartItems.domainPrivacyProtection( {
 					domain: domainItem.meta,
 					source: 'signup'

--- a/client/my-sites/checkout/checkout/domain-details-form.jsx
+++ b/client/my-sites/checkout/checkout/domain-details-form.jsx
@@ -79,7 +79,6 @@ export class DomainDetailsForm extends PureComponent {
 		this.state = {
 			form: null,
 			isDialogVisible: false,
-			privacyRadio: this.allDomainRegistrationsHavePrivacy() ? 'private' : 'public',
 			submissionCount: 0,
 			phoneCountryCode: 'US',
 			steps,
@@ -116,7 +115,7 @@ export class DomainDetailsForm extends PureComponent {
 	loadFormStateFromRedux = ( fn ) => {
 		// only load the properties relevant to the main form fields
 		fn( null, pick( this.props.contactDetails, this.fieldNames ) );
-	}
+	};
 
 	sanitize = ( fieldValues, onComplete ) => {
 		const sanitizedFieldValues = Object.assign( {}, fieldValues );
@@ -131,7 +130,7 @@ export class DomainDetailsForm extends PureComponent {
 		} );
 
 		onComplete( sanitizedFieldValues );
-	}
+	};
 
 	hasAnotherStep() {
 		return this.state.currentStep !== last( this.state.steps );
@@ -152,7 +151,7 @@ export class DomainDetailsForm extends PureComponent {
 		const allFieldValues = this.getMainFieldValues();
 		const domainNames = map( cartItems.getDomainRegistrations( this.props.cart ), 'meta' );
 		wpcom.validateDomainContactInformation( allFieldValues, domainNames, this.generateValidationHandler( onComplete ) );
-	}
+	};
 
 	generateValidationHandler( onComplete ) {
 		return ( error, data ) => {
@@ -167,7 +166,7 @@ export class DomainDetailsForm extends PureComponent {
 		}
 
 		this.setState( { form } );
-	}
+	};
 
 	needsOnlyGoogleAppsDetails() {
 		return cartItems.hasGoogleApps( this.props.cart ) && ! cartItems.hasDomainRegistration( this.props.cart );
@@ -175,7 +174,7 @@ export class DomainDetailsForm extends PureComponent {
 
 	handleFormControllerError = ( error ) => {
 		throw error;
-	}
+	};
 
 	handleChangeEvent = ( event ) => {
 		// Resets the state field every time the user selects a different country
@@ -197,7 +196,7 @@ export class DomainDetailsForm extends PureComponent {
 			name: event.target.name,
 			value: event.target.value
 		} );
-	}
+	};
 
 	handlePhoneChange = ( { value, countryCode } ) => {
 		this.formStateController.handleFieldChange( {
@@ -208,7 +207,7 @@ export class DomainDetailsForm extends PureComponent {
 		this.setState( {
 			phoneCountryCode: countryCode
 		} );
-	}
+	};
 
 	getMainFieldValues() {
 		const mainFieldValues = formState.getAllFieldValues( this.state.form );
@@ -277,13 +276,13 @@ export class DomainDetailsForm extends PureComponent {
 	renderPrivacySection() {
 		return (
 			<PrivacyProtection
+				allDomainsHavePrivacy={ this.allDomainRegistrationsHavePrivacy() }
 				cart={ this.props.cart }
 				countriesList={ countriesList }
 				disabled={ formState.isSubmitButtonDisabled( this.state.form ) }
 				fields={ this.state.form }
 				isChecked={ this.allDomainRegistrationsHavePrivacy() }
 				onCheckboxChange={ this.handleCheckboxChange }
-				radioSelect={ this.state.privacyRadio }
 				onRadioSelect={ this.handleRadioChange }
 				onDialogClose={ this.closeDialog }
 				onDialogOpen={ this.openDialog }
@@ -420,20 +419,19 @@ export class DomainDetailsForm extends PureComponent {
 
 	handleCheckboxChange = () => {
 		this.setPrivacyProtectionSubscriptions( ! this.allDomainRegistrationsHavePrivacy() );
-	}
+	};
 
 	handleRadioChange = ( enable ) => {
-		this.setState( { privacyRadio: enable ? 'private' : 'public' } );
 		this.setPrivacyProtectionSubscriptions( enable );
 	};
 
 	closeDialog = () => {
 		this.setState( { isDialogVisible: false } );
-	}
+	};
 
 	openDialog = () => {
 		this.setState( { isDialogVisible: true } );
-	}
+	};
 
 	focusFirstError() {
 		const firstErrorName = kebabCase( head( formState.getInvalidFields( this.state.form ) ).name );
@@ -498,7 +496,7 @@ export class DomainDetailsForm extends PureComponent {
 
 			this.finish();
 		} );
-	}
+	};
 
 	finish() {
 		const allFieldValues = this.props.contactDetails;

--- a/client/my-sites/checkout/checkout/privacy-protection.jsx
+++ b/client/my-sites/checkout/checkout/privacy-protection.jsx
@@ -145,7 +145,7 @@ class PrivacyProtection extends Component {
 								<FormRadio
 									value="private"
 									id="registrantType"
-									checked={ this.props.radioSelect === 'private' }
+									checked={ this.props.allDomainsHavePrivacy }
 									onChange={ this.enablePrivacy }
 								/>
 								<p className="checkout__privacy-protection-radio-text">
@@ -190,7 +190,7 @@ class PrivacyProtection extends Component {
 								<FormRadio
 									value="public"
 									id="registrantType"
-									checked={ this.props.radioSelect === 'public' }
+									checked={ ! this.props.allDomainsHavePrivacy }
 									onChange={ this.disablePrivacy }
 								/>
 								<p className="checkout__privacy-protection-radio-text">

--- a/client/my-sites/checkout/checkout/privacy-protection.jsx
+++ b/client/my-sites/checkout/checkout/privacy-protection.jsx
@@ -122,6 +122,28 @@ class PrivacyProtection extends Component {
 		const domainRegistrations = cartItems.getDomainRegistrations( this.props.cart );
 		const { translate } = this.props;
 		const numberOfDomainRegistrations = domainRegistrations.length;
+		const hasOneFreePrivacy = this.hasDomainPartOfPlan() && numberOfDomainRegistrations === 1;
+		let priceText = hasOneFreePrivacy &&
+			<span className="checkout__privacy-protection-free-text">
+				{ translate( 'Free with your plan' ) }
+			</span>;
+
+		if ( ! priceText ) {
+			priceText = (
+				<span className={ 'checkout__privacy-protection-radio-price-text' }>
+					{
+						translate(
+							'%(cost)s/year',
+							'%(cost)s per domain/year',
+							{
+								args: { cost: this.getPrivacyProtectionCost() },
+								count: numberOfDomainRegistrations
+							}
+						)
+					}
+				</span>
+			);
+		}
 
 		return (
 			<div>
@@ -162,18 +184,7 @@ class PrivacyProtection extends Component {
 											)
 										}
 									</span>
-									<span className={ 'checkout__privacy-protection-radio-price-text' }>
-										{
-											translate(
-												'%(cost)s/year',
-												'%(cost)s per domain/year',
-												{
-													args: { cost: this.getPrivacyProtectionCost() },
-													count: numberOfDomainRegistrations
-												}
-											)
-										}
-									</span>
+									{ ! this.props.cart.hasPendingServerUpdates && priceText }
 									<br />
 									<span className="checkout__privacy-protection-radio-text-description">
 									{

--- a/client/my-sites/checkout/checkout/privacy-protection.jsx
+++ b/client/my-sites/checkout/checkout/privacy-protection.jsx
@@ -123,24 +123,25 @@ class PrivacyProtection extends Component {
 		const { translate } = this.props;
 		const numberOfDomainRegistrations = domainRegistrations.length;
 		const hasOneFreePrivacy = this.hasDomainPartOfPlan() && numberOfDomainRegistrations === 1;
-		let priceText = hasOneFreePrivacy &&
-			<span className="checkout__privacy-protection-free-text">
-				{ translate( 'Free with your plan' ) }
-			</span>;
+		const priceText = [ (
+			<span className={ classnames( 'checkout__privacy-protection-radio-price-text', { 'free-with-plan': hasOneFreePrivacy } ) }>
+				{
+					translate(
+						'%(cost)s/year',
+						'%(cost)s per domain/year',
+						{
+							args: { cost: this.getPrivacyProtectionCost() },
+							count: numberOfDomainRegistrations
+						}
+					)
+				}
+			</span>
+		) ];
 
-		if ( ! priceText ) {
-			priceText = (
-				<span className={ 'checkout__privacy-protection-radio-price-text' }>
-					{
-						translate(
-							'%(cost)s/year',
-							'%(cost)s per domain/year',
-							{
-								args: { cost: this.getPrivacyProtectionCost() },
-								count: numberOfDomainRegistrations
-							}
-						)
-					}
+		if ( hasOneFreePrivacy ) {
+			priceText.push(
+				<span className="checkout__privacy-protection-free-text">
+					{ translate( 'Free with your plan' ) }
 				</span>
 			);
 		}
@@ -184,7 +185,7 @@ class PrivacyProtection extends Component {
 											)
 										}
 									</span>
-									{ ! this.props.cart.hasPendingServerUpdates && priceText }
+									{ priceText }
 									<br />
 									<span className="checkout__privacy-protection-radio-text-description">
 									{

--- a/client/my-sites/checkout/checkout/privacy-protection.jsx
+++ b/client/my-sites/checkout/checkout/privacy-protection.jsx
@@ -11,34 +11,39 @@ import { localize } from 'i18n-calypso';
 import { cartItems } from 'lib/cart-values';
 import PrivacyProtectionDialog from './privacy-protection-dialog';
 import Card from 'components/card';
+import SectionHeader from 'components/section-header';
+import { abtest } from 'lib/abtest';
+import FormFieldset from 'components/forms/form-fieldset';
+import FormLabel from 'components/forms/form-label';
+import FormRadio from 'components/forms/form-radio';
 
 class PrivacyProtection extends Component {
 	handleDialogSelect = ( options, event ) => {
 		event.preventDefault();
 		this.props.onDialogSelect( Object.assign( options, this.state ) );
 		this.setState( { skipFinish: false } );
-	}
+	};
 
 	handleDialogOpen = () => {
 		this.setState( { skipFinish: true } );
 		this.props.onDialogOpen();
-	}
+	};
 
 	handleDialogClose = () => {
 		this.props.onDialogClose();
-	}
+	};
 
 	hasDomainPartOfPlan = () => {
 		const cart = this.props.cart;
 		return cart.has_bundle_credit || cartItems.hasPlan( cart );
-	}
+	};
 
 	getPrivacyProtectionCost() {
 		const products = this.props.productsList.get();
 		return products.private_whois.cost_display;
 	}
 
-	render() {
+	renderOriginal() {
 		const domainRegistrations = cartItems.getDomainRegistrations( this.props.cart ),
 			{ translate } = this.props,
 			numberOfDomainRegistrations = domainRegistrations.length,
@@ -49,9 +54,9 @@ class PrivacyProtection extends Component {
 				'to protect your identity and prevent spam.'
 			),
 			freeWithPlan = hasOneFreePrivacy &&
-						<span className="checkout__privacy-protection-free-text">
-							{ translate( 'Free with your plan' ) }
-						</span>;
+					<span className="checkout__privacy-protection-free-text">
+						{ translate( 'Free with your plan' ) }
+					</span>;
 
 		return (
 			<div>
@@ -99,9 +104,132 @@ class PrivacyProtection extends Component {
 					isVisible={ this.props.isDialogVisible }
 					isFree={ hasOneFreePrivacy }
 					onSelect={ this.handleDialogSelect }
-					onClose={ this.handleDialogClose } />
+					onClose={ this.handleDialogClose }
+				/>
 			</div>
 		);
+	}
+
+	enablePrivacy = () => {
+		this.props.onRadioSelect( true );
+	};
+
+	disablePrivacy = () => {
+		this.props.onRadioSelect( false );
+	};
+
+	renderNoPopup() {
+		const domainRegistrations = cartItems.getDomainRegistrations( this.props.cart );
+		const { translate } = this.props;
+		const numberOfDomainRegistrations = domainRegistrations.length;
+
+		return (
+			<div>
+				<SectionHeader className="checkout__privacy-protection-header" label = { translate( 'Privacy Protection' ) } />
+				<Card className="checkout__privacy-protection-radio">
+					<div>
+						{ translate(
+							'Domain owners have to share contact information in a public database of all domains. ' +
+							'With {{strong}}Privacy Protection{{/strong}}, we publish our own information instead of yours,' +
+							'and privately forward any communication to you.',
+							{
+								components: {
+									strong: <strong />
+								},
+							}
+						) }
+					</div>
+					<div className="checkout__privacy-protection-radio-buttons">
+						<FormFieldset>
+							<FormLabel className="checkout__privacy-protection-radio-button">
+								<FormRadio
+									value="private"
+									id="registrantType"
+									checked={ this.props.radioSelect === 'private' }
+									onChange={ this.enablePrivacy }
+								/>
+								<p className="checkout__privacy-protection-radio-text">
+									<span>
+										{
+											translate(
+												'{{strong}}Register privately with Privacy Protection{{/strong}} (recommended)' +
+												'',
+												{
+													components: {
+														strong: <strong />,
+													},
+												}
+											)
+										}
+									</span>
+									<span className={ 'checkout__privacy-protection-radio-price-text' }>
+										{
+											translate(
+												'%(cost)s/year',
+												'%(cost)s per domain/year',
+												{
+													args: { cost: this.getPrivacyProtectionCost() },
+													count: numberOfDomainRegistrations
+												}
+											)
+										}
+									</span>
+									<br />
+									<span className="checkout__privacy-protection-radio-text-description">
+									{
+										translate(
+											'Protects your identity and prevents spam by keeping your contact information ' +
+											'off the Internet.'
+										)
+									}
+									</span>
+								</p>
+							</FormLabel>
+
+							<FormLabel className="checkout__privacy-protection-radio-button">
+								<FormRadio
+									value="public"
+									id="registrantType"
+									checked={ this.props.radioSelect === 'public' }
+									onChange={ this.disablePrivacy }
+								/>
+								<p className="checkout__privacy-protection-radio-text">
+									<span>
+									{
+										translate(
+											'{{strong}}Register publicly{{/strong}}',
+											{
+												components: {
+													strong: <strong />,
+												},
+											}
+										)
+									}
+									</span>
+									<br />
+									<span className="checkout__privacy-protection-radio-text-description">
+									{
+										translate(
+											'Your contact information will be listed in a public database and will be ' +
+											'susceptible to spam.'
+										)
+									}
+									</span>
+								</p>
+							</FormLabel>
+						</FormFieldset>
+					</div>
+				</Card>
+			</div>
+		);
+	}
+
+	render() {
+		if ( abtest( 'privacyNoPopup' ) === 'nopopup' ) {
+			return this.renderNoPopup();
+		}
+
+		return this.renderOriginal();
 	}
 }
 

--- a/client/my-sites/checkout/checkout/privacy-protection.jsx
+++ b/client/my-sites/checkout/checkout/privacy-protection.jsx
@@ -123,28 +123,6 @@ class PrivacyProtection extends Component {
 		const { translate } = this.props;
 		const numberOfDomainRegistrations = domainRegistrations.length;
 		const hasOneFreePrivacy = this.hasDomainPartOfPlan() && numberOfDomainRegistrations === 1;
-		const priceText = [ (
-			<span className={ classnames( 'checkout__privacy-protection-radio-price-text', { 'free-with-plan': hasOneFreePrivacy } ) }>
-				{
-					translate(
-						'%(cost)s/year',
-						'%(cost)s per domain/year',
-						{
-							args: { cost: this.getPrivacyProtectionCost() },
-							count: numberOfDomainRegistrations
-						}
-					)
-				}
-			</span>
-		) ];
-
-		if ( hasOneFreePrivacy ) {
-			priceText.push(
-				<span className="checkout__privacy-protection-free-text">
-					{ translate( 'Free with your plan' ) }
-				</span>
-			);
-		}
 
 		return (
 			<div>
@@ -185,7 +163,30 @@ class PrivacyProtection extends Component {
 											)
 										}
 									</span>
-									{ priceText }
+									<span
+										className={
+											classnames(
+												'checkout__privacy-protection-radio-price-text',
+												{ 'free-with-plan': hasOneFreePrivacy }
+											)
+										}
+									>
+										{
+											translate(
+												'%(cost)s/year',
+												'%(cost)s per domain/year',
+												{
+													args: { cost: this.getPrivacyProtectionCost() },
+													count: numberOfDomainRegistrations
+												}
+											)
+										}
+									</span>
+									{ hasOneFreePrivacy && (
+										<span className="checkout__privacy-protection-free-text">
+											{ translate( 'Free with your plan' ) }
+										</span>
+									) }
 									<br />
 									<span className="checkout__privacy-protection-radio-text-description">
 									{

--- a/client/my-sites/checkout/checkout/style.scss
+++ b/client/my-sites/checkout/checkout/style.scss
@@ -950,3 +950,38 @@
 	padding-bottom: 1em;
 	text-align: center;
 }
+
+.checkout__privacy-protection-radio {
+	&.card {
+		display: flex;
+		flex-direction: column;
+	}
+}
+
+.checkout__privacy-protection-radio-buttons {
+	margin-top: 20px;
+}
+
+.checkout__privacy-protection-radio-button {
+	display: flex;
+	margin-bottom: 15px;
+
+	&:last-child {
+		margin-bottom: 0;
+	}
+}
+
+.checkout__privacy-protection-radio-text {
+	font-weight: normal;
+	margin: 0 0 0 10px;
+}
+
+.checkout__privacy-protection-radio-text-description {
+	color: darken( $gray, 20% );
+}
+
+.checkout__privacy-protection-radio-price-text {
+	color: $blue-wordpress;
+	margin: 4px 0 0 10px;
+	font-size: 15px;
+}

--- a/client/my-sites/checkout/checkout/style.scss
+++ b/client/my-sites/checkout/checkout/style.scss
@@ -974,6 +974,12 @@
 .checkout__privacy-protection-radio-text {
 	font-weight: normal;
 	margin: 0 0 0 10px;
+
+	span {
+		&.free-with-plan {
+			text-decoration: line-through;
+		}
+	}
 }
 
 .checkout__privacy-protection-radio-text-description {

--- a/client/my-sites/domains/domain-search/domain-search.jsx
+++ b/client/my-sites/domains/domain-search/domain-search.jsx
@@ -25,6 +25,7 @@ import QueryProductsList from 'components/data/query-products-list';
 import { getProductsList } from 'state/products-list/selectors';
 import { recordAddDomainButtonClick, recordRemoveDomainButtonClick } from 'state/domains/actions';
 import EmailVerificationGate from 'components/email-verification/email-verification-gate';
+import { abtest } from 'lib/abtest';
 
 class DomainSearch extends Component {
 	static propTypes = {
@@ -82,7 +83,8 @@ class DomainSearch extends Component {
 			cartItems.domainRegistration( { domain: suggestion.domain_name, productSlug: suggestion.product_slug } )
 		];
 
-		if ( suggestion.supports_privacy && cartItems.isNextDomainFree( this.props.cart ) ) {
+		if ( suggestion.supports_privacy &&
+			( cartItems.isNextDomainFree( this.props.cart ) || abtest( 'privacyNoPopup' ) === 'nopopup' ) ) {
 			items.push( cartItems.domainPrivacyProtection( {
 				domain: suggestion.domain_name
 			} ) );


### PR DESCRIPTION
- Auto add privacy protection
- Change checkbox to a radio button
- Remove the privacy popup

Before:
![privacy old](https://user-images.githubusercontent.com/1103398/29637885-d6fb8ad6-8855-11e7-8b2d-d26fc131216f.png)
After:
![image](https://user-images.githubusercontent.com/12596797/29717134-0fedeb3c-897c-11e7-9338-394291d42832.png)

Test:
- Domains -> Add
- Select a domain
- Make sure it's auto-added
- Make sure the privacy form on details form works

Test Signup:
- http://calypso.localhost:3000/start/
- Get to the domains screen
- Pick a domain with plan
- Make sure privacy is added
-----------------------------------------
- http://calypso.localhost:3000/start/
- Free plan
- Get to the domains screen
- Pick the default wp.com subdomain
- Make sure you end on checkout properly
-----------------------------------
- Go to the site you created ^
- Plan 
- Pick a plan
- Make sure you end on checkout properly

Test /domains:
- calypso.localhost:3000/start/domain-first?new=testing-privacy-auto-add-hehe-666.blog
- Just buy a domain
- make sure privacy is auto added



https://github.com/Automattic/wp-calypso/pull/17475 with fixes for undefined.