### PR TITLE
Framework: Remove component-uid dependency

### DIFF
--- a/client/components/popover/index.jsx
+++ b/client/components/popover/index.jsx
@@ -7,7 +7,7 @@ import { connect } from 'react-redux';
 import debugFactory from 'debug';
 import classNames from 'classnames';
 import clickOutside from 'click-outside';
-import uid from 'component-uid';
+import { uniqueId } from 'lodash';
 
 /**
  * Internal dependencies
@@ -361,7 +361,7 @@ class Popover extends Component {
 	}
 
 	setPopoverId( id ) {
-		this.id = id || `pop__${ uid( 16 ) }`;
+		this.id = id || uniqueId( 'pop__' );
 		__popovers.add( this.id );
 
 		this.debug( 'creating ...' );

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3,7 +3,7 @@
   "version": "0.17.0",
   "dependencies": {
     "@types/node": {
-      "version": "6.0.87",
+      "version": "6.0.88",
       "dev": true
     },
     "5to6-codemod": {
@@ -606,7 +606,7 @@
       "version": "1.6.0",
       "dependencies": {
         "browserslist": {
-          "version": "2.3.3"
+          "version": "2.4.0"
         },
         "semver": {
           "version": "5.4.1"
@@ -879,10 +879,10 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000717"
+      "version": "1.0.30000718"
     },
     "caniuse-lite": {
-      "version": "1.0.30000717"
+      "version": "1.0.30000718"
     },
     "cardinal": {
       "version": "1.0.0",
@@ -1141,9 +1141,6 @@
     },
     "component-query": {
       "version": "0.0.3"
-    },
-    "component-uid": {
-      "version": "0.0.2"
     },
     "concat-map": {
       "version": "0.0.1"
@@ -1683,7 +1680,7 @@
       }
     },
     "es5-ext": {
-      "version": "0.10.29"
+      "version": "0.10.30"
     },
     "es6-error": {
       "version": "4.0.2"
@@ -1853,7 +1850,7 @@
           "dev": true
         },
         "cli-width": {
-          "version": "2.1.0",
+          "version": "2.2.0",
           "dev": true
         },
         "doctrine": {
@@ -1966,7 +1963,7 @@
       "version": "1.8.2"
     },
     "expand-template": {
-      "version": "1.0.3"
+      "version": "1.1.0"
     },
     "expand-year": {
       "version": "1.0.0"
@@ -2680,7 +2677,7 @@
       "version": "1.0.11"
     },
     "function-bind": {
-      "version": "1.1.0"
+      "version": "1.1.1"
     },
     "fuse.js": {
       "version": "2.6.1"
@@ -3064,7 +3061,7 @@
       "version": "1.1.8"
     },
     "ignore": {
-      "version": "3.3.3",
+      "version": "3.3.4",
       "dev": true
     },
     "immediate": {
@@ -3336,7 +3333,7 @@
       }
     },
     "istanbul-api": {
-      "version": "1.1.11",
+      "version": "1.1.13",
       "dev": true,
       "dependencies": {
         "async": {
@@ -3354,7 +3351,7 @@
       "dev": true
     },
     "istanbul-lib-instrument": {
-      "version": "1.7.4",
+      "version": "1.7.5",
       "dev": true,
       "dependencies": {
         "semver": {
@@ -3386,7 +3383,7 @@
       }
     },
     "istanbul-reports": {
-      "version": "1.1.1",
+      "version": "1.1.2",
       "dev": true
     },
     "iterall": {
@@ -4931,7 +4928,7 @@
           "dev": true
         },
         "postcss": {
-          "version": "6.0.9",
+          "version": "6.0.10",
           "dev": true
         },
         "source-map": {
@@ -5015,7 +5012,7 @@
           "dev": true
         },
         "postcss": {
-          "version": "6.0.9",
+          "version": "6.0.10",
           "dev": true,
           "dependencies": {
             "ansi-styles": {
@@ -5208,7 +5205,7 @@
           "dev": true
         },
         "cli-width": {
-          "version": "2.1.0",
+          "version": "2.2.0",
           "dev": true
         },
         "doctrine": {
@@ -6677,7 +6674,7 @@
       "dev": true,
       "dependencies": {
         "accepts": {
-          "version": "1.3.3",
+          "version": "1.3.4",
           "dev": true
         },
         "acorn": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "commander": "2.3.0",
     "component-closest": "0.1.4",
     "component-file-picker": "0.2.1",
-    "component-uid": "0.0.2",
     "cookie": "0.1.2",
     "cookie-parser": "1.3.2",
     "copy-webpack-plugin": "4.0.1",


### PR DESCRIPTION
This PR updates the `Popover` component to use lodash's `uniqueId` instead of `component-uid`. `uniqueId` does work a little differently (it uses an incremental ID instead of a randomly generated one), but that's just fine for this use case, as long as it is still unique.

This is also the last usage of `component-uid`, so we can remove it altogether - this is also suggested in this PR.

To test:
* Checkout this branch.
* Go to a page with more than one popover and verify that they works well.
* Verify Calypso boots, loads and works properly and tests still pass. 