### PR TITLE
Purchases: Redirect incorrect receipts to billing history

### DIFF
--- a/client/me/billing-history/receipt.jsx
+++ b/client/me/billing-history/receipt.jsx
@@ -4,6 +4,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
+import page from 'page';
 
 /**
  * Internal dependencies
@@ -17,10 +18,29 @@ import DocumentHead from 'components/data/document-head';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import QueryBillingTransactions from 'components/data/query-billing-transactions';
 import purchasesPaths from 'me/purchases/paths';
-import { getPastBillingTransaction } from 'state/selectors';
+import {
+	getPastBillingTransaction,
+	getPastBillingTransactions,
+} from 'state/selectors';
 
 const BillingReceipt = React.createClass( {
 	mixins: [ eventRecorder ],
+
+	componentDidMount() {
+		this.redirectIfInvalidTransaction();
+	},
+
+	componentDidUpdate() {
+		this.redirectIfInvalidTransaction();
+	},
+
+	redirectIfInvalidTransaction() {
+		const { totalTransactions, transaction } = this.props;
+
+		if ( ! transaction && totalTransactions !== null ) {
+			page.redirect( purchasesPaths.billingHistory() );
+		}
+	},
 
 	printReceipt( event ) {
 		event.preventDefault();
@@ -248,7 +268,12 @@ const BillingReceipt = React.createClass( {
 } );
 
 export default connect(
-	( state, ownProps ) => ( {
-		transaction: getPastBillingTransaction( state, ownProps.transactionId )
-	} ),
+	( state, ownProps ) => {
+		const transactions = getPastBillingTransactions( state );
+
+		return {
+			transaction: getPastBillingTransaction( state, ownProps.transactionId ),
+			totalTransactions: transactions ? transactions.length : null,
+		};
+	},
 )( localize( BillingReceipt ) );


### PR DESCRIPTION
This PR updates the billing history receipt page to redirect to the billing history page when an incorrect receipt (for an ID that does not exist or does not belong to this user) is being loaded. 

To test:
1. Checkout this branch.
2. Login as a user that has one or more purchases.
3. Go to http://calypso.localhost:3000/me/purchases/billing/
4. Click on the "View Receipt" link on a past purchase and verify it loads correctly.
5. Load the receipt page with a clean Redux state and verify it loads correctly after showing the placeholder while loading.
6. Replace the receipt ID in the URL with something of your choice - `loremipsum` will also work and load the page.
7. Verify you are redirected to the Billing History page.
8. Try loading the previous incorrect receipt URL with a clean Redux state.
9. Verify you can see the placeholder, but after the purchases load, you're redirected to the Billing History page.
10. Login as a user with no purchases.
11. Go through steps 6-9 and verify it works the same way for this user.