### PR TITLE
Themes: if Jetpack site is a multisite, hide the tier segmented control

### DIFF
--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -168,6 +168,7 @@ const ThemeShowcase = React.createClass( {
 			pathName,
 			title,
 			filterString,
+			isMultisite,
 		} = this.props;
 		const tier = config.isEnabled( 'upgrades/premium-themes' ) ? this.props.tier : 'free';
 
@@ -216,6 +217,7 @@ const ThemeShowcase = React.createClass( {
 						onSearch={ this.doSearch }
 						search={ filterString + search }
 						tier={ tier }
+						showTierThemesControl={ ! isMultisite }
 						select={ this.onTierSelect } />
 					{ this.showUploadButton() && <Button className="themes__upload-button" compact icon
 						onClick={ this.onUploadClick }

--- a/client/my-sites/themes/themes-magic-search-card/index.jsx
+++ b/client/my-sites/themes/themes-magic-search-card/index.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import wrapWithClickOutside from 'react-click-outside';
 import { connect } from 'react-redux';
 import { debounce, intersection, difference, includes } from 'lodash';
@@ -25,6 +26,15 @@ import { getThemeFilters, getThemeFilterToTermTable } from 'state/selectors';
 const preferredOrderOfTaxonomies = [ 'feature', 'layout', 'column', 'subject', 'style' ];
 
 class ThemesMagicSearchCard extends React.Component {
+
+	static propTypes = {
+		showTierThemesControl: PropTypes.bool,
+	};
+
+	static defaultProps = {
+		showTierThemesControl: true
+	};
+
 	constructor( props ) {
 		super( props );
 
@@ -228,7 +238,7 @@ class ThemesMagicSearchCard extends React.Component {
 	}
 
 	render() {
-		const { translate, filters } = this.props;
+		const { translate, filters, showTierThemesControl } = this.props;
 		const isPremiumThemesEnabled = config.isEnabled( 'upgrades/premium-themes' );
 
 		const tiers = [
@@ -294,7 +304,7 @@ class ThemesMagicSearchCard extends React.Component {
 							</div>
 						}
 						{
-							isPremiumThemesEnabled &&
+							( isPremiumThemesEnabled && showTierThemesControl ) &&
 								<SegmentedControl
 									initialSelected={ this.props.tier }
 									options={ tiers }


### PR DESCRIPTION
### Changes proposed
- introduce new prop `showTierThemesControl` that allows to hide the segmented control with labels All|Free|Premium.
- prop is true by default so it's always displayed.
- if the current Jetpack site is a multisite, the segmented control will be hidden

### Testing instructions
1. start testing with a Jetpack site that is a multisite
2. go to `http://calypso.localhost:3000/themes/%YourCoolSite.tld%`
3. make sure the segmented control is not displayed
<img width="840" alt="captura de pantalla 2017-08-28 a la s 19 42 44" src="https://user-images.githubusercontent.com/1041600/29796715-2488ad3e-8c29-11e7-967f-cfe99c83ab94.png">
