### PR TITLE
Comments: invalidate createSelector cache based on state.comments.items instead of posts

### DIFF
--- a/client/state/comments/selectors.js
+++ b/client/state/comments/selectors.js
@@ -24,7 +24,7 @@ export const getDateSortedPostComments = createSelector(
 		const comments = getPostCommentItems( state, siteId, postId );
 		return sortBy( comments, comment => new Date( comment.date ) );
 	},
-	( state, siteId, postId ) => [ get( state.comments, 'items' )[ getStateKey( siteId, postId ) ] ]
+	( state ) => [ state.comments.items ]
 );
 
 export const getCommentById = createSelector(
@@ -40,9 +40,8 @@ export const getCommentById = createSelector(
 		);
 		return find( commentsForSite, comment => commentId === comment.ID );
 	},
-	( { state, commentId, siteId } ) => [
-		commentId,
-		siteId,
+	( { state } ) => [
+		state.comments.items,
 		get( state.comments, 'items' ),
 		get( state.comments, 'errors' ),
 	]
@@ -66,7 +65,7 @@ export const getPostTotalCommentsCount = ( state, siteId, postId ) =>
 export const getPostMostRecentCommentDate = createSelector( ( state, siteId, postId ) => {
 	const items = getPostCommentItems( state, siteId, postId );
 	return items && first( items ) ? new Date( get( first( items ), 'date' ) ) : undefined;
-}, getPostCommentItems );
+}, state => state.comments.items );
 
 /***
  * Get oldest comment date for a given post
@@ -78,7 +77,7 @@ export const getPostMostRecentCommentDate = createSelector( ( state, siteId, pos
 export const getPostOldestCommentDate = createSelector( ( state, siteId, postId ) => {
 	const items = getPostCommentItems( state, siteId, postId );
 	return items && last( items ) ? new Date( get( last( items ), 'date' ) ) : undefined;
-}, getPostCommentItems );
+}, state => state.comments.items );
 
 /***
  * Get newest comment date for a given post
@@ -90,7 +89,7 @@ export const getPostOldestCommentDate = createSelector( ( state, siteId, postId 
 export const getPostNewestCommentDate = createSelector( ( state, siteId, postId ) => {
 	const items = getPostCommentItems( state, siteId, postId );
 	return items && first( items ) ? new Date( get( first( items ), 'date' ) ) : undefined;
-}, getPostCommentItems );
+}, state => state.comments.items );
 
 /***
  * Gets comment tree for a given post
@@ -119,7 +118,7 @@ export const getPostCommentsTree = createSelector(
 			children: map( filter( items, { parent: false } ), 'ID' ).reverse(),
 		};
 	},
-	getPostCommentItems
+	state => state.comments.items
 );
 
 export const commentsFetchingStatus = ( state, siteId, postId, commentTotal = 0 ) => {
@@ -155,4 +154,4 @@ export const getCommentLike = createSelector( ( state, siteId, postId, commentId
 	}
 	const { i_like, like_count } = comment;
 	return { i_like, like_count };
-}, getPostCommentItems );
+}, state => state.comments.items );


### PR DESCRIPTION
This may be me misunderstanding how to use the `createSelector` helper function, but my current impression is that we are over-invalidating the cache.  Ideally we could invalidate the cache for specific posts when the comments for a post are modified, but thats not possible with the current implementation of `createSelector`.  

Something I am seeing regularly now is:
```
1. getTree( postId1 )
2. getTree( postId2 ) // this request clears the cache
3. getTree( postId1 ) // this ideally would use the cache if the comments for id1 never changed
```

This PR seeks to invalidate the cache when `state.comments.items`  changes instead of when the post selected for changes