### PR TITLE
Comments: make the proptypes for comments more consistent

### DIFF
--- a/client/blocks/comments/comment-actions.jsx
+++ b/client/blocks/comments/comment-actions.jsx
@@ -23,7 +23,7 @@ const CommentActions = ( {
 	showModerationTools,
 	translate,
 	activeEditCommentId,
-	activeReplyCommentID,
+	activeReplyCommentId,
 	commentId,
 	handleReply,
 	onReplyCancel,
@@ -35,7 +35,7 @@ const CommentActions = ( {
 	editCommentCancel,
 } ) => {
 	const showReplyButton = post && post.discussion && post.discussion.comments_open === true;
-	const showCancelReplyButton = activeReplyCommentID === commentId;
+	const showCancelReplyButton = activeReplyCommentId === commentId;
 	const showCancelEditButton = activeEditCommentId === commentId;
 	const isApproved = status === 'approved';
 

--- a/client/blocks/comments/comment-edit-form.jsx
+++ b/client/blocks/comments/comment-edit-form.jsx
@@ -34,7 +34,7 @@ class PostCommentForm extends Component {
 
 	componentDidMount() {
 		// If it's a reply, give the input focus if commentText exists ( can not exist if comments are closed )
-		if ( this.props.parentCommentID && this._textareaNode ) {
+		if ( this.props.parentCommentId && this._textareaNode ) {
 			this._textareaNode.focus();
 		}
 	}

--- a/client/blocks/comments/form.jsx
+++ b/client/blocks/comments/form.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
 import { noop } from 'lodash';
@@ -42,7 +43,7 @@ class PostCommentForm extends React.Component {
 
 	componentDidMount() {
 		// If it's a reply, give the input focus if commentText exists ( can not exist if comments are closed )
-		if ( this.props.parentCommentID && this._textareaNode ) {
+		if ( this.props.parentCommentId && this._textareaNode ) {
 			this._textareaNode.focus();
 		}
 	}
@@ -129,8 +130,8 @@ class PostCommentForm extends React.Component {
 			this.props.deleteComment( post.site_ID, post.ID, this.props.placeholderId );
 		}
 
-		if ( this.props.parentCommentID ) {
-			this.props.replyComment( commentText, post.site_ID, post.ID, this.props.parentCommentID );
+		if ( this.props.parentCommentId ) {
+			this.props.replyComment( commentText, post.site_ID, post.ID, this.props.parentCommentId );
 		} else {
 			this.props.writeComment( commentText, post.site_ID, post.ID );
 		}
@@ -138,7 +139,7 @@ class PostCommentForm extends React.Component {
 		recordAction( 'posted_comment' );
 		recordGaEvent( 'Clicked Post Comment Button' );
 		recordTrackForPost( 'calypso_reader_article_commented_on', post, {
-			parent_post_id: this.props.parentCommentID ? this.props.parentCommentID : undefined,
+			parent_post_id: this.props.parentCommentId ? this.props.parentCommentId : undefined,
 		} );
 
 		this.resetCommentText();
@@ -255,18 +256,18 @@ class PostCommentForm extends React.Component {
 }
 
 PostCommentForm.propTypes = {
-	post: React.PropTypes.object.isRequired,
-	parentCommentID: React.PropTypes.number,
-	placeholderId: React.PropTypes.string, // can only be 'placeholder-123'
-	commentText: React.PropTypes.string,
-	onUpdateCommentText: React.PropTypes.func.isRequired,
-	onCommentSubmit: React.PropTypes.func,
+	post: PropTypes.object.isRequired,
+	parentCommentId: PropTypes.number,
+	placeholderId: PropTypes.string, // can only be 'placeholder-123'
+	commentText: PropTypes.string,
+	onUpdateCommentText: PropTypes.func.isRequired,
+	onCommentSubmit: PropTypes.func,
 
 	// connect()ed props:
-	currentUser: React.PropTypes.object.isRequired,
-	writeComment: React.PropTypes.func.isRequired,
-	deleteComment: React.PropTypes.func.isRequired,
-	replyComment: React.PropTypes.func.isRequired,
+	currentUser: PropTypes.object.isRequired,
+	writeComment: PropTypes.func.isRequired,
+	deleteComment: PropTypes.func.isRequired,
+	replyComment: PropTypes.func.isRequired,
 };
 
 PostCommentForm.defaultProps = {

--- a/client/blocks/comments/post-comment-list.jsx
+++ b/client/blocks/comments/post-comment-list.jsx
@@ -69,7 +69,7 @@ class PostCommentList extends React.Component {
 	};
 
 	state = {
-		activeReplyCommentID: null,
+		activeReplyCommentId: null,
 		amountOfCommentsToTake: this.props.initialSize,
 		commentsFilter: 'all',
 		activeEditCommentId: null,
@@ -199,7 +199,7 @@ class PostCommentList extends React.Component {
 				key={ commentId }
 				showModerationTools={ this.props.showModerationTools }
 				activeEditCommentId={ this.state.activeEditCommentId }
-				activeReplyCommentID={ this.state.activeReplyCommentID }
+				activeReplyCommentId={ this.state.activeReplyCommentId }
 				onEditCommentClick={ onEditCommentClick }
 				onEditCommentCancel={ this.onEditCommentCancel }
 				onReplyClick={ this.onReplyClick }
@@ -221,7 +221,7 @@ class PostCommentList extends React.Component {
 	onEditCommentCancel = () => this.setState( { activeEditCommentId: null } );
 
 	onReplyClick = commentID => {
-		this.setState( { activeReplyCommentID: commentID } );
+		this.setState( { activeReplyCommentId: commentID } );
 		recordAction( 'comment_reply_click' );
 		recordGaEvent( 'Clicked Reply to Comment' );
 		recordTrack( 'calypso_reader_comment_reply_click', {
@@ -235,7 +235,7 @@ class PostCommentList extends React.Component {
 		recordGaEvent( 'Clicked Cancel Reply to Comment' );
 		recordTrack( 'calypso_reader_comment_reply_cancel_click', {
 			blog_id: this.props.post.site_ID,
-			comment_id: this.state.activeReplyCommentID,
+			comment_id: this.state.activeReplyCommentId,
 		} );
 		this.resetActiveReplyComment();
 	};
@@ -245,7 +245,7 @@ class PostCommentList extends React.Component {
 	};
 
 	resetActiveReplyComment = () => {
-		this.setState( { activeReplyCommentID: null } );
+		this.setState( { activeReplyCommentId: null } );
 	};
 
 	renderCommentsList = commentIds => {
@@ -261,7 +261,7 @@ class PostCommentList extends React.Component {
 		const commentText = this.state.commentText;
 
 		// Are we displaying the comment form at the top-level?
-		if ( this.state.activeReplyCommentID && ! this.state.errors ) {
+		if ( this.state.activeReplyCommentId && ! this.state.errors ) {
 			return null;
 		}
 
@@ -269,7 +269,7 @@ class PostCommentList extends React.Component {
 			<PostCommentForm
 				ref="postCommentForm"
 				post={ post }
-				parentCommentID={ null }
+				parentCommentId={ null }
 				commentText={ commentText }
 				onUpdateCommentText={ this.onUpdateCommentText }
 			/>

--- a/client/blocks/comments/post-comment-with-error.jsx
+++ b/client/blocks/comments/post-comment-with-error.jsx
@@ -28,7 +28,7 @@ export default class PostCommentWithError extends React.Component {
 			<PostCommentForm
 				ref="postCommentForm"
 				post={ post }
-				parentCommentID={ commentParentId }
+				parentCommentId={ commentParentId }
 				commentText={ commentText }
 				onUpdateCommentText={ onUpdateCommentText }
 				placeholderId={ this.props.commentId }

--- a/client/blocks/comments/post-comment.jsx
+++ b/client/blocks/comments/post-comment.jsx
@@ -155,7 +155,7 @@ class PostComment extends Component {
 	}
 
 	renderCommentForm() {
-		if ( this.props.activeReplyCommentID !== this.props.commentId ) {
+		if ( this.props.activeReplyCommentId !== this.props.commentId ) {
 			return null;
 		}
 
@@ -163,7 +163,7 @@ class PostComment extends Component {
 			<PostCommentForm
 				ref="postCommentForm"
 				post={ this.props.post }
-				parentCommentID={ this.props.commentId }
+				parentCommentId={ this.props.commentId }
 				commentText={ this.props.commentText }
 				onUpdateCommentText={ this.props.onUpdateCommentText }
 				onCommentSubmit={ this.props.onCommentSubmit }
@@ -303,7 +303,7 @@ class PostComment extends Component {
 					comment={ comment }
 					showModerationTools={ this.props.showModerationTools }
 					activeEditCommentId={ this.props.activeEditCommentId }
-					activeReplyCommentID={ this.props.activeReplyCommentID }
+					activeReplyCommentId={ this.props.activeReplyCommentId }
 					commentId={ this.props.commentId }
 					editComment={ this.props.onEditCommentClick }
 					editCommentCancel={ this.props.onEditCommentCancel }


### PR DESCRIPTION
I noticed a few inconsistencies with how we were naming identifiers.
This renames:
1. activeReplyCommentID --> activeReplyCommentId
2. parentCommentID --> parentCommentId

To Test:
- make sure there are no more references to the old identifiers in the codebase
- try to do things with comments from Reader.  add new, delete, etc.