### PR TITLE
Conversations Tool: allow for replying to comments inline

### DIFF
--- a/client/blocks/conversations/list.jsx
+++ b/client/blocks/conversations/list.jsx
@@ -2,7 +2,8 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { map } from 'lodash';
 
@@ -12,6 +13,8 @@ import { map } from 'lodash';
 import PostComment from 'blocks/comments/post-comment';
 import { getPostCommentsTree } from 'state/comments/selectors';
 import ConversationCaterpillar from 'blocks/conversation-caterpillar';
+import { recordAction, recordGaEvent, recordTrack } from 'reader/stats';
+import PostCommentForm from 'blocks/comments/form';
 
 export class ConversationCommentList extends React.Component {
 	static propTypes = {
@@ -21,6 +24,36 @@ export class ConversationCommentList extends React.Component {
 
 	static defaultProps = {
 		showCaterpillar: false,
+	};
+
+	state = {
+		activeReplyCommentId: null,
+		activeEditCommentId: null,
+	};
+
+	resetActiveReplyComment = () => this.setState( { activeReplyCommentId: null } );
+	onEditCommentClick = commentId => this.setState( { activeEditCommentId: commentId } );
+	onEditCommentCancel = () => this.setState( { activeEditCommentId: null } );
+	onUpdateCommentText = commentText => this.setState( { commentText: commentText } );
+
+	onReplyClick = commentId => {
+		this.setState( { activeReplyCommentId: commentId } );
+		recordAction( 'comment_reply_click' );
+		recordGaEvent( 'Clicked Reply to Comment' );
+		recordTrack( 'calypso_reader_comment_reply_click', {
+			blog_id: this.props.post.site_ID,
+			comment_id: commentId,
+		} );
+	};
+
+	onReplyCancel = () => {
+		recordAction( 'comment_reply_cancel_click' );
+		recordGaEvent( 'Clicked Cancel Reply to Comment' );
+		recordTrack( 'calypso_reader_comment_reply_cancel_click', {
+			blog_id: this.props.post.site_ID,
+			comment_id: this.state.activeReplyCommentId,
+		} );
+		this.resetActiveReplyComment();
 	};
 
 	render() {
@@ -40,10 +73,28 @@ export class ConversationCommentList extends React.Component {
 								key={ commentId }
 								commentId={ commentId }
 								maxChildrenToShow={ 0 }
+								maxDepth={ 2 }
 								post={ post }
+								onReplyClick={ this.onReplyClick }
+								onReplyCancel={ this.onReplyCancel }
+								activeReplyCommentId={ this.state.activeReplyCommentId }
+								onEditCommentClick={ this.onEditCommentClick }
+								onEditCommentCancel={ this.onEditCommentCancel }
+								activeEditCommentId={ this.state.activeEditCommentId }
+								onUpdateCommentText={ this.onUpdateCommentText }
+								onCommentSubmit={ this.resetActiveReplyComment }
+								commentText={ this.state.commentText }
 							/>
 						);
 					} ) }
+					{ ! this.state.activeReplyCommentId &&
+						<PostCommentForm
+							ref="postCommentForm"
+							post={ post }
+							parentCommentId={ null }
+							commentText={ this.state.commentText }
+							onUpdateCommentText={ this.onUpdateCommentText }
+						/> }
 				</ul>
 				{ showCaterpillar &&
 					<ConversationCaterpillar blogId={ post.site_ID } postId={ post.ID } /> }

--- a/client/blocks/reader-post-card/compact.jsx
+++ b/client/blocks/reader-post-card/compact.jsx
@@ -13,10 +13,10 @@ import ReaderExcerpt from 'blocks/reader-excerpt';
 import ReaderPostOptionsMenu from 'blocks/reader-post-options-menu';
 import FeaturedAsset from './featured-asset';
 
-const CompactPost = ( { post, postByline, children, isDiscover } ) => {
+const CompactPost = ( { post, postByline, children, isDiscover, onClick } ) => {
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	return (
-		<div className="reader-post-card__post">
+		<div className="reader-post-card__post" onClick={ onClick }>
 			<FeaturedAsset
 				canonicalMedia={ post.canonical_media }
 				postUrl={ post.URL }

--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -205,6 +205,7 @@ class ReaderPostCard extends React.Component {
 					isDiscover={ isDiscover }
 					postByline={ postByline }
 					commentIds={ postKey.comments }
+					onClick={ this.handleCardClick }
 				/>
 			);
 		} else if ( isPhotoPost ) {
@@ -251,7 +252,7 @@ class ReaderPostCard extends React.Component {
 		const followUrl = feed ? feed.feed_URL : post.site_URL;
 
 		return (
-			<Card className={ classes } onClick={ ! isPhotoPost && this.handleCardClick }>
+			<Card className={ classes } onClick={ ! isPhotoPost && ! compact && this.handleCardClick }>
 				{ ! compact && postByline }
 				{ showPrimaryFollowButton &&
 					followUrl &&

--- a/client/state/comments/constants.js
+++ b/client/state/comments/constants.js
@@ -5,10 +5,3 @@ export const PLACEHOLDER_STATE = {
 	PENDING: 'PENDING',
 	ERROR: 'ERROR',
 };
-
-export const APPROVED_STATUS = 'approved';
-export const DISAPPROVED_STATUS = 'unapproved';
-export const SPAM_STATUS = 'spam';
-export const UNSPAM_STATUS = 'unspam';
-export const TRASH_STATUS = 'trash';
-export const UNTRASH_STATUS = 'untrash';


### PR DESCRIPTION
This PR adds the ability to reply to comments to Conversations Tool.  Happily this is mostly copy-pasta from PostCommentsList.

Changes introduced:
1. Clicking anywhere on a Comments is fixed in this PR: clicking anywhere in the commentlist should be a noop. clicking anywhere on the header should take you to the fullpost.  right clickign and selecting "open in new tab" in the context menu (or cmd clicking) opens the original post on the frontend.
2. default empty comment box is now shown and clicking reply to any specific comment moves the empty box to right below the comment you are replying to.