### PR TITLE
Post Editor: Prevent error loading posts with certain slug sequences

### DIFF
--- a/client/lib/url/index.js
+++ b/client/lib/url/index.js
@@ -182,12 +182,13 @@ function omitUrlParams( url, paramsToOmit ) {
 
 /**
  * Wrap decodeURI in a try / catch block to prevent `URIError` on invalid input
+ * Passing a non-string value will return an empty string.
  * @param  {String} encodedURI URI to attempt to decode
  * @return {String}            Decoded URI (or passed in value on error)
  */
 function decodeURIIfValid( encodedURI ) {
 	if ( ! ( isString( encodedURI ) || has( encodedURI, 'toString' ) ) ) {
-		throw new Error( 'Invalid input' );
+		return '';
 	}
 	try {
 		return decodeURI( encodedURI );
@@ -198,12 +199,13 @@ function decodeURIIfValid( encodedURI ) {
 
 /**
  * Wrap decodeURIComponent in a try / catch block to prevent `URIError` on invalid input
+ * Passing a non-string value will return an empty string.
  * @param  {String} encodedURIComponent URI component to attempt to decode
  * @return {String}            Decoded URI component (or passed in value on error)
  */
 function decodeURIComponentIfValid( encodedURIComponent ) {
 	if ( ! ( isString( encodedURIComponent ) || has( encodedURIComponent, 'toString' ) ) ) {
-		throw new Error( 'Invalid input' );
+		return '';
 	}
 	try {
 		return decodeURIComponent( encodedURIComponent );

--- a/client/lib/url/index.js
+++ b/client/lib/url/index.js
@@ -5,7 +5,7 @@ import {
 	format as formatUrl,
 	parse as parseUrl,
 } from 'url';
-import { omit, startsWith } from 'lodash';
+import { has, isString, omit, startsWith } from 'lodash';
 
 /**
  * Internal dependencies
@@ -180,7 +180,41 @@ function omitUrlParams( url, paramsToOmit ) {
 	return formatUrl( parsed );
 }
 
+/**
+ * Wrap decodeURI in a try / catch block to prevent `URIError` on invalid input
+ * @param  {String} encodedURI URI to attempt to decode
+ * @return {String}            Decoded URI (or passed in value on error)
+ */
+function decodeURIIfValid( encodedURI ) {
+	if ( ! ( isString( encodedURI ) || has( encodedURI, 'toString' ) ) ) {
+		throw new Error( 'Invalid input' );
+	}
+	try {
+		return decodeURI( encodedURI );
+	} catch ( e ) {
+		return encodedURI;
+	}
+}
+
+/**
+ * Wrap decodeURIComponent in a try / catch block to prevent `URIError` on invalid input
+ * @param  {String} encodedURIComponent URI component to attempt to decode
+ * @return {String}            Decoded URI component (or passed in value on error)
+ */
+function decodeURIComponentIfValid( encodedURIComponent ) {
+	if ( ! ( isString( encodedURIComponent ) || has( encodedURIComponent, 'toString' ) ) ) {
+		throw new Error( 'Invalid input' );
+	}
+	try {
+		return decodeURIComponent( encodedURIComponent );
+	} catch ( e ) {
+		return encodedURIComponent;
+	}
+}
+
 export default {
+	decodeURIIfValid,
+	decodeURIComponentIfValid,
 	isOutsideCalypso,
 	isExternal,
 	isHttps,

--- a/client/state/posts/selectors.js
+++ b/client/state/posts/selectors.js
@@ -17,6 +17,7 @@ import {
 	normalizePostForEditing,
 	normalizePostForDisplay
 } from './utils';
+import { decodeURIIfValid } from 'lib/url';
 import { getSite } from 'state/sites/selectors';
 import { DEFAULT_POST_QUERY, DEFAULT_NEW_POST_VALUES } from './constants';
 import addQueryArgs from 'lib/route/add-query-args';
@@ -431,7 +432,7 @@ export function getEditedPostSlug( state, siteId, postId ) {
 
 	// when post is published, return the slug
 	if ( isPostPublished( state, siteId, postId ) ) {
-		return decodeURI( postSlug );
+		return decodeURIIfValid( postSlug );
 	}
 
 	// only return suggested_slug if slug has not been edited

--- a/client/state/posts/test/selectors.js
+++ b/client/state/posts/test/selectors.js
@@ -1847,6 +1847,54 @@ describe( 'selectors', () => {
 			expect( slug ).to.eql( 'זהו עין הנמר' );
 		} );
 
+		it( 'should return undecoded post.slug if post with malformed URI sequence is published', () => {
+			const slug = getEditedPostSlug( {
+				posts: {
+					queries: {
+						2916284: new PostQueryManager( {
+							items: {
+								841: {
+									ID: 841,
+									site_ID: 2916284,
+									global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64',
+									status: 'publish',
+									slug: 'most-of-this-slug-is-fine-%F0%9F%99%88%-but-the-following-is-not-%e42',
+								}
+							}
+						} )
+					},
+					edits: {
+					}
+				}
+			}, 2916284, 841 );
+
+			expect( slug ).to.eql( 'most-of-this-slug-is-fine-%F0%9F%99%88%-but-the-following-is-not-%e42' );
+		} );
+
+		it( 'should return decoded post.slug with emoji sequences if post is published', () => {
+			const slug = getEditedPostSlug( {
+				posts: {
+					queries: {
+						2916284: new PostQueryManager( {
+							items: {
+								841: {
+									ID: 841,
+									site_ID: 2916284,
+									global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64',
+									status: 'publish',
+									slug: '%F0%9F%99%88%F0%9F%99%8A%F0%9F%99%89',
+								}
+							}
+						} )
+					},
+					edits: {
+					}
+				}
+			}, 2916284, 841 );
+
+			expect( slug ).to.eql( '🙈🙊🙉' );
+		} );
+
 		it( 'should return edited slug if post is not published', () => {
 			const slug = getEditedPostSlug( {
 				posts: {


### PR DESCRIPTION
"Malformed" character sequences in post slugs are preventing loading because the slugs are [passed](https://github.com/Automattic/wp-calypso/blob/ba56bddbe087af6ec000dd2f9f85eeda77f13c50/client/state/posts/selectors.js#L434) through [`decodeURI`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/decodeURI) which throws under certain circumstances.

This adds a utility function to `lib/url` called `decodeURIIfValid` which wraps `decodeURI` in a try / catch block.

Since `decodeURIComponent` is subject to the same error and is used in various places across the codebase, an analog called `decodeURIComponentIfValid` is added here as well.

Fixes #17572

### To Test

#### Run automated tests

`npm run test-client client/state/posts/`

#### Manually test

* Starting at URL: `/post/` (choose a site if your user has more than one)
* Enter a post title with in invalid UTF sequence -- for example `%e42`
* Click `Publish`

The post should be published without error.

* Starting at URL: `/posts/` (choose a site if your user has more than one)
* Locate the post you just created
* Click `Edit`

The post editor should be loaded without error.
