### PR TITLE
Activity Log: Remove expanded activity descriptions

### DIFF
--- a/client/my-sites/stats/activity-log-item/index.jsx
+++ b/client/my-sites/stats/activity-log-item/index.jsx
@@ -89,7 +89,10 @@ class ActivityLogItem extends Component {
 		} );
 	};
 
-	// FIXME: Just for demonstration purposes
+	//
+	// TODO: Descriptions are temporarily disabled and this method is not called.
+	// Rich descriptions will be added after designs have been prepared for all types of activity.
+	//
 	renderDescription() {
 		const {
 			log,
@@ -192,11 +195,9 @@ class ActivityLogItem extends Component {
 					clickableHeader
 					expandedSummary={ this.renderSummary() }
 					header={ this.renderHeader() }
-					onOpen={ this.handleOpen }
+					onClick={ this.handleOpen }
 					summary={ this.renderSummary() }
-				>
-					{ this.renderDescription() }
-				</FoldableCard>
+				/>
 			</div>
 		);
 	}

--- a/client/my-sites/stats/activity-log-item/style.scss
+++ b/client/my-sites/stats/activity-log-item/style.scss
@@ -7,6 +7,11 @@
 	align-items: center;
 	position: relative;
 
+	// TODO: Remove when foldable cards become "expandable"
+	.foldable-card__header.is-clickable {
+		cursor: default;
+	}
+
 	&:first-of-type {
 		margin-top: 24px;
 	}


### PR DESCRIPTION
This PR removes the "foldable" part of `ActivityLogItem` `FoldableCard`s. The change is minimal and unused methods have been left in place, as part of the roadmap is to add rich contents to the cards.

Per discussions (p2JiWH-2fw-p2), `ActivityLogItem` contents are removed.

## Testing
1. https://calypso.live/stats/activity?branch=update/activity-log/no-expandable-cards
1. Verify that Activity items are no longer foldable.

## Screens

### Before

![before](https://user-images.githubusercontent.com/841763/29819596-9ddbc4c6-8cc1-11e7-85cd-be35a5aab315.png)

### After

![after](https://user-images.githubusercontent.com/841763/29819598-a04f2536-8cc1-11e7-9c43-3b5228fe2ddd.png)
