### PR TITLE
OAuth: Update url of API endpoint that returns client data

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -2433,7 +2433,7 @@ Undocumented.prototype.checkNPSSurveyEligibility = function( fn ) {
  * @returns {Promise}  A promise
  */
 Undocumented.prototype.oauth2ClientId = function( clientId, fn ) {
-	return this.wpcom.req.get( `/oauth2-client-data/${ clientId }`, { apiNamespace: 'wpcom/v2' }, fn );
+	return this.wpcom.req.get( `/oauth2/client-data/${ clientId }`, { apiNamespace: 'wpcom/v2' }, fn );
 };
 
 /**


### PR DESCRIPTION
This pull request makes urls of OAuth2 API endpoints consistent. With this change, these endpoints will be available from:

* https://public-api.wordpress.com/wpcom/v2/oauth2/client-data
* https://public-api.wordpress.com/wpcom/v2/oauth2/signup-url
  
#### Testing instructions

This is an example for Gravatar but feel free to try with any other DOPS service:

1. Run `git checkout update/oauth2-client-data-endpoint-url` and start your server
2. Apply patch D7084-code to your sandbox
3. Point `public-api.wordpress.com` to your sandbox
4. Enable your proxy
5. Open the Gravatar [`Home` page](https://fr.gravatar.com/) in French in an incognito window
6. Click the `Connexion` button in the upper right corner
7. Assert that you are redirected to the Calypso `Login` page for Gravatar
8. Replace `https://wordpress.com` with `http://calypso.localhost:3000` in your browser's address bar
9. Assert that you are presented with the same page, from your server this time
10. Assert that you can still log in to WordPress.com
 
#### Reviews
 
- [x] Code
- [x] Product
- [ ] Tests