### PR TITLE
Activity log: Add jetpack/activity-log/rewind config

### DIFF
--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -4,6 +4,7 @@
  */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import config from 'config';
 import debugFactory from 'debug';
 import scrollTo from 'lib/scroll-to';
 import { connect } from 'react-redux';
@@ -46,7 +47,11 @@ import {
 	isRewindActive as isRewindActiveSelector,
 } from 'state/selectors';
 
+/**
+ * Module constants
+ */
 const debug = debugFactory( 'calypso:activity-log' );
+const rewindEnabledByConfig = config.isEnabled( 'jetpack/activity-log/rewind' );
 
 class ActivityLog extends Component {
 	static propTypes = {
@@ -226,6 +231,10 @@ class ActivityLog extends Component {
 	}
 
 	renderErrorMessage() {
+		if ( ! rewindEnabledByConfig ) {
+			return null;
+		}
+
 		const { isPressable, rewindStatusError, translate } = this.props;
 
 		// Do not match null
@@ -295,7 +304,7 @@ class ActivityLog extends Component {
 				<ActivityLogDay
 					applySiteOffset={ this.applySiteOffset }
 					disableRestore={ disableRestore }
-					hideRestore={ ! isPressable }
+					hideRestore={ ! rewindEnabledByConfig || ! isPressable }
 					isRewindActive={ isRewindActive }
 					key={ dayEnd }
 					logs={ get( logsGroupedByDay, dayEnd, [] ) }
@@ -344,7 +353,7 @@ class ActivityLog extends Component {
 
 		return (
 			<Main wideLayout>
-				<QueryRewindStatus siteId={ siteId } />
+				{ rewindEnabledByConfig && <QueryRewindStatus siteId={ siteId } /> }
 				<QueryActivityLog
 					siteId={ siteId }
 					dateStart={ queryStart }

--- a/config/development.json
+++ b/config/development.json
@@ -61,6 +61,7 @@
 		"jetpack_core_inline_update": true,
 		"jetpack/api-cache": true,
 		"jetpack/activity-log": true,
+		"jetpack/activity-log/rewind": true,
 		"keyboard-shortcuts": true,
 		"login/magic-login": true,
 		"login/native-login-links": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -31,6 +31,7 @@
 		"help": true,
 		"help/courses": true,
 		"jetpack/activity-log": true,
+		"jetpack/activity-log/rewind": true,
 		"jetpack/api-cache": true,
 		"jetpack_core_inline_update": true,
 		"login/wp-login": true,


### PR DESCRIPTION
Activity Log is being prepared to move into more environments independently of Rewind (which will come later).

This PR adds another config setting for Rewind, and enables it in dev and staging (same as activity-log currently).

**UPDATE** Thanks to p4TIVU-7YE-p2 we can test this feature on calypso.live 🎉 

## Testing
1. Visit (Rewind enabled) https://calypso.live/stats/activity?branch=add/activity-log/rewind-config
1. Visit (Rewind disabled) https://calypso.live/stats/activity?branch=add/activity-log/rewind-config&flags=-jetpack/activity-log/rewind
1. Everything should remain the same.
1. Try disabling the dev config locally.
1. Rewind features should be hidden.

## Screens

### Enabled

![enabled](https://user-images.githubusercontent.com/841763/29821275-9a43982e-8cc7-11e7-93a7-fbae2d63d6aa.png)

### Disabled

![disabled](https://user-images.githubusercontent.com/841763/29821278-9c907caa-8cc7-11e7-9031-da2aa01337c8.png)
