### PR TITLE
Add focus to FormPhoneMediaInput.

### DIFF
--- a/client/components/forms/form-phone-media-input/index.jsx
+++ b/client/components/forms/form-phone-media-input/index.jsx
@@ -17,12 +17,7 @@ export default class extends React.Component {
 		isError: false,
 	};
 
-	constructor( props ) {
-		super( props );
-		this.focus = this.focus.bind( this );
-	}
-
-	focus() {
+	focus = () => {
 		this.phoneInput.numberInput.focus();
 	}
 
@@ -39,6 +34,7 @@ export default class extends React.Component {
 					<PhoneInput
 						{ ...omit( this.props, [ 'className', 'countryCode' ] ) }
 						ref="input"
+						// eslint-disable-next-line react/jsx-no-bind
 						onRef={ ref => this.phoneInput = ref }
 						countryCode={ this.props.countryCode.toUpperCase() }
 						className={ classes }

--- a/client/components/forms/form-phone-media-input/index.jsx
+++ b/client/components/forms/form-phone-media-input/index.jsx
@@ -21,10 +21,13 @@ export default class extends React.Component {
 		this.phoneInput.numberInput.focus();
 	}
 
+	setPhoneInput = ( ref ) => this.phoneInput = ref;
+
 	render() {
 		const classes = classnames( this.props.className, {
 			'is-error': this.props.isError,
 		} );
+
 		return (
 			<div className={ classnames( this.props.additionalClasses, 'phone' ) }>
 				<div>
@@ -35,7 +38,7 @@ export default class extends React.Component {
 						{ ...omit( this.props, [ 'className', 'countryCode' ] ) }
 						ref="input"
 						// eslint-disable-next-line react/jsx-no-bind
-						onRef={ ref => this.phoneInput = ref }
+						setComponentReference={ this.setPhoneInput }
 						countryCode={ this.props.countryCode.toUpperCase() }
 						className={ classes }
 					/>

--- a/client/components/forms/form-phone-media-input/index.jsx
+++ b/client/components/forms/form-phone-media-input/index.jsx
@@ -17,6 +17,15 @@ export default class extends React.Component {
 		isError: false,
 	};
 
+	constructor( props ) {
+		super( props );
+		this.focus = this.focus.bind( this );
+	}
+
+	focus() {
+		this.phoneInput.numberInput.focus();
+	}
+
 	render() {
 		const classes = classnames( this.props.className, {
 			'is-error': this.props.isError,
@@ -30,6 +39,7 @@ export default class extends React.Component {
 					<PhoneInput
 						{ ...omit( this.props, [ 'className', 'countryCode' ] ) }
 						ref="input"
+						onRef={ ref => this.phoneInput = ref }
 						countryCode={ this.props.countryCode.toUpperCase() }
 						className={ classes }
 					/>

--- a/client/components/forms/form-phone-media-input/index.jsx
+++ b/client/components/forms/form-phone-media-input/index.jsx
@@ -17,9 +17,7 @@ export default class extends React.Component {
 		isError: false,
 	};
 
-	focus = () => {
-		this.phoneInput.numberInput.focus();
-	}
+	focus = () => this.phoneInput.numberInput.focus();
 
 	setPhoneInput = ( ref ) => this.phoneInput = ref;
 

--- a/client/components/forms/form-phone-media-input/index.jsx
+++ b/client/components/forms/form-phone-media-input/index.jsx
@@ -37,7 +37,6 @@ export default class extends React.Component {
 					<PhoneInput
 						{ ...omit( this.props, [ 'className', 'countryCode' ] ) }
 						ref="input"
-						// eslint-disable-next-line react/jsx-no-bind
 						setComponentReference={ this.setPhoneInput }
 						countryCode={ this.props.countryCode.toUpperCase() }
 						className={ classes }

--- a/client/components/phone-input/index.jsx
+++ b/client/components/phone-input/index.jsx
@@ -60,6 +60,11 @@ class PhoneInput extends React.PureComponent {
 		if ( value !== this.props.value || countryCode !== this.props.countryCode ) {
 			this.props.onChange( { value, countryCode } );
 		}
+		this.props.onRef( this );
+	}
+
+	componentWillUnmount() {
+		this.props.onRef( undefined );
 	}
 
 	componentWillReceiveProps( nextProps ) {

--- a/client/components/phone-input/index.jsx
+++ b/client/components/phone-input/index.jsx
@@ -60,11 +60,11 @@ class PhoneInput extends React.PureComponent {
 		if ( value !== this.props.value || countryCode !== this.props.countryCode ) {
 			this.props.onChange( { value, countryCode } );
 		}
-		this.props.onRef( this );
+		this.props.setComponentReference( this );
 	}
 
 	componentWillUnmount() {
-		this.props.onRef( undefined );
+		this.props.setComponentReference( undefined );
 	}
 
 	componentWillReceiveProps( nextProps ) {


### PR DESCRIPTION
Setting focus for FormPhoneMediaInput fails when there is an error in that field and the user clicks submit. This is because FormPhoneMediaInput does not support `focus()`.

The PhoneInput child component (which encapsulates the actual `input` element), already uses a ref to that input internally. So instead of passing an `inputRef` prop into `PhoneInput`, I am retrieving a ref to `PhoneInput` using `onRef` and accessing that from `FormPhoneMediaInput` in a `focus()` method that I implemented there.

I know it may not be ideal to implement `focus` like this, but I could not figure out another way to set the ref in the parent component to point to the actual input element.

Other suggestions are welcome.

To test this PR:

- Build the branch locally.
- Browse to My Sites / Domains / Add Domain
- Select a domain
- Click "No Thanks" on the G Suite dialog
- On the Domain Contact Information page, enter an invalid phone number (but make all other data valid)
- Ensure that the focus is on some other input besides the phone number input field.
- Click "Continue to Checkout"
- The focus should be returned to the phone number input field and there should be no errors in the console.