### PR TITLE
isSiteOnPaidPlan: Update to correctly handle Jetpack plans

### DIFF
--- a/client/state/selectors/is-site-on-paid-plan.js
+++ b/client/state/selectors/is-site-on-paid-plan.js
@@ -1,8 +1,9 @@
+/** @format */
 /**
  * Internal dependencies
  */
 import { getCurrentPlan } from 'state/sites/plans/selectors';
-import { PLAN_FREE } from 'lib/plans/constants';
+import { isFreePlan } from 'lib/plans';
 
 /**
  * Returns true if site is on a paid plan, false if the site is not
@@ -19,7 +20,7 @@ const isSiteOnPaidPlan = ( state, siteId ) => {
 		return false;
 	}
 
-	return currentPlan.productSlug !== PLAN_FREE;
+	return ! isFreePlan( currentPlan.productSlug );
 };
 
 export default isSiteOnPaidPlan;

--- a/client/state/selectors/test/is-site-on-paid-plan.js
+++ b/client/state/selectors/test/is-site-on-paid-plan.js
@@ -10,7 +10,9 @@ import { stub } from 'sinon';
  */
 import {
 	PLAN_BUSINESS,
-	PLAN_FREE
+	PLAN_FREE,
+	PLAN_JETPACK_BUSINESS,
+	PLAN_JETPACK_FREE,
 } from 'lib/plans/constants';
 import useMockery from 'test/helpers/use-mockery';
 
@@ -38,8 +40,18 @@ describe( 'isSiteOnPaidPlan', () => {
 		expect( isSiteOnPaidPlan( state, 'site1' ) ).to.be.false;
 	} );
 
+	it( 'should return false when on free Jetpack plan', () => {
+		getCurrentPlan.returns( { productSlug: PLAN_JETPACK_FREE } );
+		expect( isSiteOnPaidPlan( state, 'site1' ) ).to.be.false;
+	} );
+
 	it( 'should return true when on paid plan', () => {
 		getCurrentPlan.returns( { productSlug: PLAN_BUSINESS } );
+		expect( isSiteOnPaidPlan( state, 'site1' ) ).to.be.true;
+	} );
+
+	it( 'should return true when on paid Jetpack plan', () => {
+		getCurrentPlan.returns( { productSlug: PLAN_JETPACK_BUSINESS } );
 		expect( isSiteOnPaidPlan( state, 'site1' ) ).to.be.true;
 	} );
 } );


### PR DESCRIPTION
The `isSiteOnPaidPlan` selector introduced in #13842 does not handle Jetpack plans correctly.

This PR updates the selector to use `isFreePlan` from `lib/plans`, which correctly handles Jetpack and WordPress.com plans.

It also adds tests to the selector for Jetpack plans.

## Motivation

I'd like to be able to use this selector independently of Jetpack/WordPress.com plans.

## Testing

The only place this selector appears to be used is in domains:

https://github.com/Automattic/wp-calypso/blob/921675df658524fb403a685e66ca58082baff3bb/client/components/domains/domain-search-results/index.jsx#L93-L98

cc/ @rralian for testing help. Do you recall if the above usage relies on being `false` for paid Jetpack plans?