### PR TITLE
Framework: Update Gridicons to v2.0.3

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2803,7 +2803,7 @@
       "dev": true
     },
     "gridicons": {
-      "version": "2.0.2"
+      "version": "2.0.3"
     },
     "growl": {
       "version": "1.9.2",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "fuse.js": "2.6.1",
     "get-video-id": "2.1.4",
     "globby": "6.1.0",
-    "gridicons": "2.0.2",
+    "gridicons": "2.0.3",
     "happypack": "4.0.0-beta.1",
     "hard-source-webpack-plugin": "0.3.12",
     "he": "0.5.0",


### PR DESCRIPTION
This PR updates Gridicons to `v2.0.3` following this change: https://github.com/Automattic/gridicons/pull/246

This version adds two new icons:
1. Reader Follow Conversation
![screenshot 2017-08-29 10 23 50](https://user-images.githubusercontent.com/4924246/29834589-3143f51c-8ca4-11e7-8d56-a9f7054c80b0.png)

2. Reader Following Conversation
![screenshot 2017-08-29 10 23 52](https://user-images.githubusercontent.com/4924246/29834594-373826aa-8ca4-11e7-8ec7-4c5ebbe6e275.png)

The old Comment and Chat icons have also been updated to match this new style:

Comment before:
![screenshot 2017-08-29 10 25 45](https://user-images.githubusercontent.com/4924246/29834683-71073c18-8ca4-11e7-9dde-a0e9d63ee84d.png)

Comment after:
![screenshot 2017-08-29 10 24 53](https://user-images.githubusercontent.com/4924246/29834692-76369152-8ca4-11e7-8f5c-fba60b474303.png)

Chat before:
![screenshot 2017-08-29 10 25 36](https://user-images.githubusercontent.com/4924246/29834703-7c455e02-8ca4-11e7-8a30-ccd75047dfb2.png)

Chat after:
![screenshot 2017-08-29 10 24 54](https://user-images.githubusercontent.com/4924246/29834714-8318ce80-8ca4-11e7-8712-2f2ab3c7e0b8.png)

