### PR TITLE
Update Jetpack connect ToS agreement

### DIFF
--- a/client/jetpack-connect/site-url-input.jsx
+++ b/client/jetpack-connect/site-url-input.jsx
@@ -65,6 +65,10 @@ class JetpackConnectSiteUrlInput extends Component {
 		return translate( 'Connecting…' );
 	}
 
+	getTermsOfJetpackSyncUrl() {
+		return 'https://jetpack.com/support/what-data-does-jetpack-sync/';
+	}
+
 	getTermsOfServiceUrl() {
 		return 'https://' + getLocaleSlug() + '.wordpress.com/tos/';
 	}
@@ -73,13 +77,23 @@ class JetpackConnectSiteUrlInput extends Component {
 		return (
 			<p className="jetpack-connect__tos-link">
 				{ this.props.translate(
-					'By connecting your site you agree to our fascinating {{a}}Terms of Service{{/a}}.',
+					'By connecting you agree to our fascinating {{tosLinkText}}Terms of Service{{/tosLinkText}} ' +
+						'and to sync {{syncLinkText}}certain data and settings{{/syncLinkText}} to WordPress.com',
 					{
 						components: {
-							a: (
+							tosLinkText: (
 								<a
 									className="jetpack-connect__tos-link-text"
 									href={ this.getTermsOfServiceUrl() }
+									onClick={ this.props.handleOnClickTos }
+									target="_blank"
+									rel="noopener noreferrer"
+								/>
+							),
+							syncLinkText: (
+								<a
+									className="jetpack-connect__sync-link-text"
+									href={ this.getTermsOfJetpackSyncUrl() }
 									onClick={ this.props.handleOnClickTos }
 									target="_blank"
 									rel="noopener noreferrer"


### PR DESCRIPTION
Fixes #15319 

Add sync terms from https://jetpack.com/support/what-data-does-jetpack-sync/ to the agreement text when checking https://wordpress.com/jetpack/connect

I haven't removed the "fascinating Terms of Service" style due to consistency with other places where this shows up, like:

client/my-sites/checkout/checkout/terms-of-service.jsx
`"fascinating terms and conditions”`

client/components/signup-form/index.jsx
`By creating an account you agree to our {{a}}fascinating Terms of Service{{/a}}.’,`

On the same note I left [Connect Now] as it is, as the string will be translated, but any feedback / recommendation is appreciated :)

Example after the patch:
<img width="457" alt="screen shot 2017-08-29 at 20 37 00" src="https://user-images.githubusercontent.com/3812076/29838323-2914f0ce-8cfb-11e7-8737-d5e632051b33.png">
