### PR TITLE
Components: Suggestions - Fix wrong data being passed to props.suggest

### DIFF
--- a/client/components/suggestions/index.jsx
+++ b/client/components/suggestions/index.jsx
@@ -67,12 +67,12 @@ class Suggestions extends Component {
 				break;
 
 			case 'Enter':
-				this.state.suggestionPosition >= 0 && this.props.suggest( this.state.suggestionPosition );
+				this.state.suggestionPosition >= 0 && this.suggest( this.state.suggestionPosition );
 				break;
 		}
 	}
 
-	handleMouseDown = label => this.props.suggest( this.getPositionForSuggestion( label ) );
+	handleMouseDown = label => this.suggest( this.getPositionForSuggestion( label ) );
 
 	handleMouseOver = label => this.setState( {
 		suggestionPosition: this.getPositionForSuggestion( label ),


### PR DESCRIPTION
This PR fixes an issue which causes the item position to be passed to `props.suggest` rather than the actual item.

Required by #16497.

# Testing

Currently the only place this is used is on the `Edit Zone` tab of Zoninator extension - implemented in #16497.