### PR TITLE
Reader: Like and Pingback icon alignment

### DIFF
--- a/client/blocks/comments/style.scss
+++ b/client/blocks/comments/style.scss
@@ -295,7 +295,7 @@
 	margin-right: 9px;
 	position: absolute;
 		left: 1px;
-		top: -1px;
+		top: -5px;
 	width: 32px;
 
 	.gridicon {
@@ -477,6 +477,12 @@ a.comments__comment-username {
 			margin-top: 4px;
 			margin-right: 0;
 		}
+	}
+
+	// Aligns Like icon to comment text when it's by itself
+	:only-child {
+		left: -3px;
+		top: 3px;
 	}
 
 	.comments__comment-actions-approve,


### PR DESCRIPTION
Two small nits fixed in this PR.

1. Aligns Like icon when it's by itself (happens when Comments are closed). Also fixed in fullpost:

**Before:**
![screenshot 2017-08-29 15 50 50](https://user-images.githubusercontent.com/4924246/29847691-e27c325e-8cd1-11e7-9ea5-3bb7768bafa8.png)

**After:**
![screenshot 2017-08-29 15 50 57](https://user-images.githubusercontent.com/4924246/29847692-e27e56ec-8cd1-11e7-965d-5ae947510960.png)

2. Aligns pingback icon to its text:

**Before:**
![screenshot 2017-08-29 15 52 07](https://user-images.githubusercontent.com/4924246/29847754-29a21644-8cd2-11e7-9e50-c7b556447b47.png)

**After:**
![screenshot 2017-08-29 15 52 37](https://user-images.githubusercontent.com/4924246/29847762-2f8f998c-8cd2-11e7-8d6d-2160969bd4bf.png)

