### PR TITLE
Jetpack Plans: Enable jetpack auto-config Thank You Page v2 in staging and production

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -70,6 +70,7 @@
 		"perfmon": true,
 		"persist-redux": true,
 		"plans/personal-plan": true,
+		"plans/jetpack-config-v2": true,
 		"post-editor/author-selector": true,
 		"post-editor/html-toolbar": true,
 		"post-editor/image-editor": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -75,7 +75,7 @@
 		"perfmon": true,
 		"persist-redux": true,
 		"plans/personal-plan": true,
-		"plans/jetpack-config-v2": false,
+		"plans/jetpack-config-v2": true,
 		"post-editor/html-toolbar": true,
 		"post-editor/image-editor": true,
 		"press-this": true,


### PR DESCRIPTION
This PR enables the new Jetpack auto-config v2 Thank You Page in staging and production.

#### Testing instructions

1. Buy a plan for a Jetpack site.
1. Expect to be redirected to the new thank you page and watch it install and autoconfigure the plugins.

