### PR TITLE
Extensions: Zoninator - Update routing

### DIFF
--- a/client/extensions/zoninator/app/controller.js
+++ b/client/extensions/zoninator/app/controller.js
@@ -7,14 +7,13 @@ import React from 'react';
  * Internal dependencies
  */
 import analytics from 'lib/analytics';
-import titlecase from 'to-title-case';
 import { getSiteFragment, sectionify } from 'lib/route';
 import { renderWithReduxStore } from 'lib/react-helpers';
 import Settings from '../components/settings';
 
 export const renderTab = ( component ) => ( context ) => {
 	const siteId = getSiteFragment( context.path );
-	const { zone = '' } = context.params;
+	const zoneId = context.params.zone;
 
 	let baseAnalyticsPath = sectionify( context.path );
 
@@ -22,14 +21,14 @@ export const renderTab = ( component ) => ( context ) => {
 		baseAnalyticsPath += '/:site';
 	}
 
-	if ( zone ) {
+	if ( zoneId ) {
 		baseAnalyticsPath += '/:zone';
 	}
 
 	let analyticsPageTitle = 'WP Zone Manager';
 
-	if ( zone.length ) {
-		analyticsPageTitle += ` > ${ titlecase( zone ) }`;
+	if ( zoneId ) {
+		analyticsPageTitle += ' > Edit zone';
 	}
 
 	if ( baseAnalyticsPath.match( /.*\/new\/:site$/ ) ) {
@@ -40,9 +39,9 @@ export const renderTab = ( component ) => ( context ) => {
 
 	renderWithReduxStore(
 		<Settings>
-			{ React.createElement( component ) }
+			{ React.createElement( component, { zoneId } ) }
 		</Settings>,
 		document.getElementById( 'primary' ),
-		context.store
+		context.store,
 	);
 };

--- a/client/extensions/zoninator/components/settings/zones-dashboard/zone-item.jsx
+++ b/client/extensions/zoninator/components/settings/zones-dashboard/zone-item.jsx
@@ -13,10 +13,10 @@ import { getSelectedSiteSlug } from 'state/ui/selectors';
 import { settingsPath } from '../../../app/util';
 
 const ZoneItem = ( { siteSlug, zone } ) => {
-	const { slug, name, description } = zone;
+	const { id, name, description } = zone;
 
 	return (
-		<CompactCard href={ `${ settingsPath }/${ siteSlug }/${ slug }` }>
+		<CompactCard href={ `${ settingsPath }/zone/${ siteSlug }/${ id }` }>
 			<div className="zones-dashboard__zone-label">{ name }</div>
 			<div className="zones-dashboard__zone-description">
 				<small className="zones-dashboard__zone-description-text">

--- a/client/extensions/zoninator/index.js
+++ b/client/extensions/zoninator/index.js
@@ -16,10 +16,11 @@ import installActionHandlers from './state/data-layer';
 export default function() {
 	page( '/extensions/zoninator', sites );
 	page( '/extensions/zoninator/new', sites );
+	page( '/extensions/zoninator/zone', sites );
 
 	page( '/extensions/zoninator/:site', siteSelection, navigation, renderTab( ZonesDashboard ) );
 	page( '/extensions/zoninator/new/:site', siteSelection, navigation, renderTab( ZoneCreator ) );
-	page( '/extensions/zoninator/:site/:zone', siteSelection, navigation, renderTab( Zone ) );
+	page( '/extensions/zoninator/zone/:site/:zone', siteSelection, navigation, renderTab( Zone ) );
 }
 
 installActionHandlers();


### PR DESCRIPTION
This PR updates Zoninator routing to use zone IDs instead of zone slugs as that's what's used to identify zones in the state & the REST API.

# Testing

Go to `/extensions/zoninator`, choose your site and make sure zone links are working and the URL features an ID at the end.