### PR TITLE
Signup: Refactor PreviousStepButton with test cases.

### DIFF
--- a/client/signup/previous-step-button/index.jsx
+++ b/client/signup/previous-step-button/index.jsx
@@ -2,8 +2,9 @@
  * External dependencies
  */
 import React from 'react';
+import PropTypes from 'prop-types';
 import { find } from 'lodash';
-import i18n from 'i18n-calypso';
+import { localize, getLocaleSlug } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -11,16 +12,13 @@ import i18n from 'i18n-calypso';
 import analytics from 'lib/analytics';
 import signupUtils from 'signup/utils';
 
-export default React.createClass( {
-	displayName: 'PreviousStepButton',
-
-	propTypes: {
-		flowName: React.PropTypes.string.isRequired,
-		stepName: React.PropTypes.string.isRequired,
-		previousPath: React.PropTypes.string,
-		positionInFlow: React.PropTypes.number.isRequired,
-		signupProgress: React.PropTypes.array.isRequired
-	},
+export class PreviousStepButton extends React.Component {
+	static propTypes = {
+		flowName: PropTypes.string.isRequired,
+		stepName: PropTypes.string.isRequired,
+		positionInFlow: PropTypes.number.isRequired,
+		signupProgress: PropTypes.array.isRequired,
+	};
 
 	backUrl() {
 		if ( this.props.backUrl ) {
@@ -30,22 +28,23 @@ export default React.createClass( {
 		const previousStepName = signupUtils.getPreviousStepName( this.props.flowName, this.props.stepName ),
 			{ stepSectionName } = find( this.props.signupProgress, { stepName: previousStepName } );
 
-		return signupUtils.getStepUrl( this.props.flowName, previousStepName, stepSectionName, i18n.getLocaleSlug() );
-	},
+		return signupUtils.getStepUrl( this.props.flowName, previousStepName, stepSectionName, getLocaleSlug() );
+	}
 
-	recordClick() {
+	recordClick = () => {
 		analytics.tracks.recordEvent( 'calypso_signup_previous_step_button_click', {
 			flow: this.props.flowName,
-			step: this.props.stepName
+			step: this.props.stepName,
 		} );
-	},
+	}
 
 	render() {
+		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		if ( this.props.positionInFlow > 0 ) {
 			return (
 				<a className="previous-step" href={ this.backUrl() } onClick={ this.recordClick }>
 					<span className="previous-step__label">
-						{ this.translate( 'Back' ) }
+						{ this.props.translate( 'Back' ) }
 					</span>
 				</a>
 			);
@@ -53,4 +52,7 @@ export default React.createClass( {
 
 		return null;
 	}
-} );
+	/* eslint-enable wpcalypso/jsx-classname-namespace */
+}
+
+export default localize( PreviousStepButton );

--- a/client/signup/previous-step-button/test/index.jsx
+++ b/client/signup/previous-step-button/test/index.jsx
@@ -1,0 +1,80 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+import { stub, spy } from 'sinon';
+import { noop } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import useMockery from 'test/helpers/use-mockery';
+
+describe( 'PreviousStepButton', () => {
+	const defaultProps = {
+		flowName: 'test:flow',
+		stepName: 'test:step2',
+		positionInFlow: 1,
+		signupProgress: [
+			{ stepName: 'test:step1', stepSectionName: 'test:section1', wasSkipped: false },
+			{ stepName: 'test:step2', stepSectionName: 'test:section2', wasSkipped: false },
+			{ stepName: 'test:step3', stepSectionName: 'test:section3', wasSkipped: false },
+		],
+		translate: ( str ) => `translated:${ str }`,
+	};
+	const signupUtils = { getStepUrl: noop };
+	const tracks = { recordEvent: noop };
+	let PreviousStepButton, props;
+
+	useMockery( mockery => {
+		mockery.registerMock( 'lib/analytics', { tracks } );
+		mockery.registerMock( 'signup/utils', signupUtils );
+		mockery.registerMock( 'i18n-calypso', { getLocaleSlug: () => 'en', localize: () => {} } );
+	} );
+
+	before( () => {
+		PreviousStepButton = require( '..' ).PreviousStepButton;
+	} );
+
+	beforeEach( () => {
+		props = Object.assign( {}, defaultProps );
+
+		signupUtils.getStepUrl = stub();
+		signupUtils.getPreviousStepName = stub().returns( 'test:step1' );
+		tracks.recordEvent = spy();
+	} );
+
+	it( 'should render an anchor element', () => {
+		const wrapper = shallow( <PreviousStepButton { ...props } /> );
+
+		const anchor = wrapper.find( 'a' );
+		expect( anchor ).to.have.length( 1 );
+
+		// The anchor element should have a span element contains translated text
+		expect( anchor.find( 'span' ) ).to.have.length( 1 );
+		expect( anchor.find( 'span' ).text() ).to.equal( 'translated:Back' );
+	} );
+
+	it( 'should render null if positionInFlow prop == 0.', () => {
+		const wrapper = shallow( <PreviousStepButton { ...props } positionInFlow={ 0 } /> );
+
+		expect( wrapper.type() ).to.be.null;
+	} );
+
+	it( 'should trigger a track event if the rendered anchor is clicked', () => {
+		const wrapper = shallow( <PreviousStepButton { ...props } /> );
+
+		expect( tracks.recordEvent ).not.to.be.called;
+		wrapper.simulate( 'click' );
+		expect( tracks.recordEvent ).to.be.calledWith( 'calypso_signup_previous_step_button_click' );
+	} );
+
+	it( 'should use the value of backUrl prop as href attribute if the prop exists', () => {
+		const wrapper = shallow( <PreviousStepButton { ...props } backUrl="test:back-url" /> );
+
+		const anchor = wrapper.find( 'a' );
+		expect( anchor.prop( 'href' ) ).to.equal( 'test:back-url' );
+	} );
+} );


### PR DESCRIPTION
- ES6-fy PreviousStepButton component.
- Add test cases for the component.