### PR TITLE
Activity log: Remove ListEnd from Activity Log

### DIFF
--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -21,7 +21,6 @@ import ActivityLogRewindToggle from './activity-log-rewind-toggle';
 import DatePicker from 'my-sites/stats/stats-date-picker';
 import EmptyContent from 'components/empty-content';
 import ErrorBanner from '../activity-log-banner/error-banner';
-import ListEnd from 'components/list-end';
 import Main from 'components/main';
 import ProgressBanner from '../activity-log-banner/progress-banner';
 import QueryActivityLog from 'components/data/query-activity-log';
@@ -275,14 +274,11 @@ class ActivityLog extends Component {
 				/>
 		);
 
-		// FIXME: Prefer not to return an array. Fix when background line issue is fixed:
-		// https://github.com/Automattic/wp-calypso/issues/17065
-		return [
+		return (
 			<section className="activity-log__wrapper" key="logs">
 				{ logsGroupedByDay }
-			</section>,
-			<ListEnd key="end-marker" />,
-		];
+			</section>
+		);
 	}
 
 	renderMonthNavigation( position ) {


### PR DESCRIPTION
Remove `ListEnd` ( (w) logo with line ) from Activity Log

## Testing
1. https://calypso.live/stats/activity?branch=remove/activity-log/list-end
1. Verify the component is not there.

## Screens

### Before

![before](https://user-images.githubusercontent.com/841763/29869379-ffcea0ba-8d82-11e7-8891-b4bd166f6040.png)

### After

![after](https://user-images.githubusercontent.com/841763/29869378-ffc369de-8d82-11e7-9c50-4741c40546c8.png)

## Context

@rickybanister via https://github.com/Automattic/wp-calypso/pull/17513#issuecomment-325703388