### PR TITLE
Adds chevron icon to Store (Beta)

### DIFF
--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -452,3 +452,6 @@ form.sidebar__button {
 		}
 	}
 }
+.sidebar__chevron-right {
+	padding-top: 10px;
+}

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -373,7 +373,9 @@ export class MySitesSidebar extends Component {
 				link={ storeLink }
 				onNavigate={ this.trackStoreClick }
 				icon="cart"
-			/>
+			>
+				<Gridicon className="sidebar__chevron-right" icon="chevron-right" />
+			</SidebarItem>
 		);
 	}
 


### PR DESCRIPTION
Fix #17311 

Adds a chevron icon to the Store (Beta) menu when going to http://wordpress.com/mydomain.com and the Store is enabled.

Desktop view:
<img width="1280" alt="screen shot 2017-08-30 at 14 49 02" src="https://user-images.githubusercontent.com/3812076/29873539-eef30770-8d93-11e7-8c8f-9ec81fec9fc8.png">

Mobile view:
<img width="323" alt="screen shot 2017-08-30 at 14 54 17" src="https://user-images.githubusercontent.com/3812076/29873541-f04b6482-8d93-11e7-9324-248946e062d9.png">
