### PR TITLE
Plugin Upload: Vertically center plugin upload button icon

### DIFF
--- a/client/components/button/style.scss
+++ b/client/components/button/style.scss
@@ -73,7 +73,7 @@ button {
 			color: lighten( $gray, 30% );
 		}
 		.gridicon {
-			top: 4px;
+			top: 5px;
 			margin-top: -8px;
 			margin-right: 4px;
 		}
@@ -88,10 +88,6 @@ button {
 		// Make plus icon nudged closer to adjacent icons for add-people and add-plugin type buttons
 		.gridicons-plus-small + .gridicon {
 			margin-left: -4px;
-		}
-		// Move the upload icon a little lower to appear vertically centered
-		.gridicons-cloud-upload {
-			top: 6px;
 		}
 	}
 	&.is-busy {

--- a/client/components/button/style.scss
+++ b/client/components/button/style.scss
@@ -89,6 +89,10 @@ button {
 		.gridicons-plus-small + .gridicon {
 			margin-left: -4px;
 		}
+		// Move the upload icon a little lower to appear vertically centered
+		.gridicons-cloud-upload {
+			top: 6px;
+		}
 	}
 	&.is-busy {
 		animation: button__busy-animation 3000ms infinite linear;

--- a/client/my-sites/themes/style.scss
+++ b/client/my-sites/themes/style.scss
@@ -87,7 +87,6 @@
 		margin-top: 23px;
 		color: $gray-dark;
 		.gridicon {
-			top: 6px;
 			padding-right: 4px;
 		}
 


### PR DESCRIPTION
As suggested by @seear in https://github.com/Automattic/wp-calypso/pull/17535#issuecomment-325625403 it would be nice if we could align the icon vertically in the plugin upload button. This is what this PR suggests.

Before:
![](https://cldup.com/dhDgmwTueT.png)

After:
![](https://cldup.com/VX5lJdkS5e.png)

To test:
* Checkout this branch.
* Go to `/plugins/:site` where `:site` is a Jetpack site.
* Verify the icon looks like on the "After" screenshot.