### PR TITLE
Emojify comment content, author names and site titles

### DIFF
--- a/client/blocks/comments/post-comment-content.jsx
+++ b/client/blocks/comments/post-comment-content.jsx
@@ -4,7 +4,6 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import AutoDirection from 'components/auto-direction';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 
@@ -12,6 +11,8 @@ import { localize } from 'i18n-calypso';
  * Internal Dependencies
  */
 import withDimensions from 'lib/with-dimensions';
+import AutoDirection from 'components/auto-direction';
+import Emojify from 'components/emojify';
 
 class PostCommentContent extends React.Component {
 	static propTypes = {
@@ -42,11 +43,13 @@ class PostCommentContent extends React.Component {
 		return (
 			<AutoDirection>
 				<div className={ classNames( 'comments__comment-content-wrapper', this.props.className ) }>
-					<div
-						className="comments__comment-content"
-						ref={ this.props.setWithDimensionsRef }
-						dangerouslySetInnerHTML={ { __html: this.props.content } }
-					/>
+					<Emojify>
+						<div
+							className="comments__comment-content"
+							ref={ this.props.setWithDimensionsRef }
+							dangerouslySetInnerHTML={ { __html: this.props.content } }
+						/>
+					</Emojify>
 					{ this.props.overflowY &&
 						! this.props.hideMore &&
 						<span className="comments__comment-read-more" onClick={ this.props.onMoreClicked }>

--- a/client/blocks/comments/post-comment.jsx
+++ b/client/blocks/comments/post-comment.jsx
@@ -27,6 +27,7 @@ import { decodeEntities } from 'lib/formatting';
 import PostCommentWithError from './post-comment-with-error';
 import PostTrackback from './post-trackback.jsx';
 import CommentActions from './comment-actions';
+import Emojify from 'components/emojify';
 
 // values conveniently also correspond to css classNames to apply
 export const POST_COMMENT_DISPLAY_TYPES = {
@@ -189,10 +190,14 @@ class PostComment extends Component {
 					onClick={ this.handleAuthorClick }
 					id={ `comment-${ commentId }` }
 				>
-					{ authorName }
+					<Emojify>
+						{ authorName }
+					</Emojify>
 				</a>
 			: <strong className={ className } id={ `comment-${ commentId }` }>
-					{ authorName }
+					<Emojify>
+						{ authorName }
+					</Emojify>
 				</strong>;
 	};
 

--- a/client/blocks/reader-author-link/index.jsx
+++ b/client/blocks/reader-author-link/index.jsx
@@ -11,6 +11,7 @@ import classnames from 'classnames';
  */
 import { isAuthorNameBlacklisted } from 'reader/lib/author-name-blacklist';
 import * as stats from 'reader/stats';
+import Emojify from 'components/emojify';
 
 const ReaderAuthorLink = ( { author, post, siteUrl, children, className } ) => {
 	const recordAuthorClick = ( {} ) => {
@@ -38,14 +39,18 @@ const ReaderAuthorLink = ( { author, post, siteUrl, children, className } ) => {
 	if ( ! siteUrl ) {
 		return (
 			<span className={ classes }>
-				{ children }
+				<Emojify>
+					{ children }
+				</Emojify>
 			</span>
 		);
 	}
 
 	return (
 		<a className={ classes } href={ siteUrl } onClick={ recordAuthorClick }>
-			{ children }
+			<Emojify>
+				{ children }
+			</Emojify>
 		</a>
 	);
 };

--- a/client/blocks/reader-author-link/test/index.jsx
+++ b/client/blocks/reader-author-link/test/index.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -39,7 +40,9 @@ describe( 'ReaderAuthorLink', () => {
 
 	it( 'should accept a custom class of `test__ace`', () => {
 		const wrapper = shallow(
-			<ReaderAuthorLink author={ author } className="test__ace">xyz</ReaderAuthorLink>
+			<ReaderAuthorLink author={ author } className="test__ace">
+				xyz
+			</ReaderAuthorLink>
 		);
 		expect( wrapper.is( '.test__ace' ) ).to.equal( true );
 	} );
@@ -59,7 +62,9 @@ describe( 'ReaderAuthorLink', () => {
 	it( 'should use siteUrl if provided', () => {
 		const siteUrl = 'http://discover.wordpress.com';
 		const wrapper = shallow(
-			<ReaderAuthorLink author={ author } siteUrl={ siteUrl }>xyz</ReaderAuthorLink>
+			<ReaderAuthorLink author={ author } siteUrl={ siteUrl }>
+				xyz
+			</ReaderAuthorLink>
 		);
 		expect( wrapper.find( '.reader-author-link' ) ).to.have.prop( 'href' ).equal( siteUrl );
 	} );
@@ -73,6 +78,6 @@ describe( 'ReaderAuthorLink', () => {
 		author.URL = null;
 		const wrapper = shallow( <ReaderAuthorLink author={ author }>xyz</ReaderAuthorLink> );
 		// Should just return children
-		expect( wrapper.html() ).to.equal( '<span class="reader-author-link">xyz</span>' );
+		expect( wrapper.type() ).to.equal( 'span' );
 	} );
 } );

--- a/client/blocks/reader-site-stream-link/index.jsx
+++ b/client/blocks/reader-site-stream-link/index.jsx
@@ -3,6 +3,7 @@
  * External dependencies
  */
 import React from 'react';
+import PropTypes from 'prop-types';
 import { omit } from 'lodash';
 
 /**
@@ -10,13 +11,14 @@ import { omit } from 'lodash';
  */
 import { getStreamUrl } from 'reader/route';
 import { recordAction, recordGaEvent, recordTrackForPost } from 'reader/stats';
+import Emojify from 'components/emojify';
 
-const ReaderSiteStreamLink = React.createClass( {
-	propTypes: {
-		feedId: React.PropTypes.number,
-		siteId: React.PropTypes.number,
-		post: React.PropTypes.object, // for stats only
-	},
+class ReaderSiteStreamLink extends React.Component {
+	static propTypes = {
+		feedId: PropTypes.number,
+		siteId: PropTypes.number,
+		post: PropTypes.object, // for stats only
+	};
 
 	recordClick() {
 		recordAction( 'visit_blog_feed' );
@@ -24,14 +26,16 @@ const ReaderSiteStreamLink = React.createClass( {
 		if ( this.props.post ) {
 			recordTrackForPost( 'calypso_reader_feed_link_clicked', this.props.post );
 		}
-	},
+	}
 
 	render() {
 		// If we can't make a link, just return children
 		if ( ! this.props.feedId && ! this.props.siteId ) {
 			return (
 				<span>
-					{ this.props.children }
+					<Emojify>
+						{ this.props.children }
+					</Emojify>
 				</span>
 			);
 		}
@@ -41,10 +45,12 @@ const ReaderSiteStreamLink = React.createClass( {
 
 		return (
 			<a { ...omit( this.props, omitProps ) } href={ link } onClick={ this.recordClick }>
-				{ this.props.children }
+				<Emojify>
+					{ this.props.children }
+				</Emojify>
 			</a>
 		);
-	},
-} );
+	}
+}
 
 export default ReaderSiteStreamLink;


### PR DESCRIPTION
As noted by @jancavan and @fraying in https://github.com/Automattic/wp-calypso/issues/17541, we're not consistently converting emojis to the flat Twemoji style in the Conversations tool.

This PR adds the `Emojify` component in several places to ensure emojis are consistently displayed.

Post card site link
<img width="257" alt="screen shot 2017-08-30 at 16 40 14" src="https://user-images.githubusercontent.com/17325/29878493-f7fdcf1c-8da2-11e7-8353-cc876b05fb41.png">

Author name
<img width="348" alt="screen shot 2017-08-30 at 16 40 21" src="https://user-images.githubusercontent.com/17325/29878528-11e12b90-8da3-11e7-9447-0d8ed191371b.png">

Comment content
<img width="304" alt="screen shot 2017-08-30 at 16 40 26" src="https://user-images.githubusercontent.com/17325/29878536-184ae5ca-8da3-11e7-94ea-f00299c32ced.png">

Fixes #17541.