### PR TITLE
Fix/focus phone input on error - try 2

### DIFF
--- a/client/components/forms/form-phone-media-input/index.jsx
+++ b/client/components/forms/form-phone-media-input/index.jsx
@@ -17,10 +17,15 @@ export default class extends React.Component {
 		isError: false,
 	};
 
+	focus = () => this.phoneInput.numberInput.focus();
+
+	setPhoneInput = ( ref ) => this.phoneInput = ref;
+
 	render() {
 		const classes = classnames( this.props.className, {
 			'is-error': this.props.isError,
 		} );
+
 		return (
 			<div className={ classnames( this.props.additionalClasses, 'phone' ) }>
 				<div>
@@ -30,6 +35,7 @@ export default class extends React.Component {
 					<PhoneInput
 						{ ...omit( this.props, [ 'className', 'countryCode' ] ) }
 						ref="input"
+						setComponentReference={ this.setPhoneInput }
 						countryCode={ this.props.countryCode.toUpperCase() }
 						className={ classes }
 					/>

--- a/client/components/phone-input/index.jsx
+++ b/client/components/phone-input/index.jsx
@@ -22,6 +22,10 @@ class PhoneInput extends React.PureComponent {
 		countriesList: React.PropTypes.object.isRequired
 	};
 
+	static defaultProps = {
+		setComponentReference: noop,
+	};
+
 	constructor( props ) {
 		super( props );
 
@@ -224,9 +228,5 @@ class PhoneInput extends React.PureComponent {
 		);
 	}
 }
-
-PhoneInput.defaultProps = {
-	setComponentReference: noop,
-};
 
 export default localize( PhoneInput );

--- a/client/components/phone-input/index.jsx
+++ b/client/components/phone-input/index.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React from 'react';
-import { find, identity } from 'lodash';
+import { find, identity, noop } from 'lodash';
 import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
 
@@ -60,6 +60,11 @@ class PhoneInput extends React.PureComponent {
 		if ( value !== this.props.value || countryCode !== this.props.countryCode ) {
 			this.props.onChange( { value, countryCode } );
 		}
+		this.props.setComponentReference( this );
+	}
+
+	componentWillUnmount() {
+		this.props.setComponentReference( undefined );
 	}
 
 	componentWillReceiveProps( nextProps ) {
@@ -219,5 +224,9 @@ class PhoneInput extends React.PureComponent {
 		);
 	}
 }
+
+PhoneInput.defaultProps = {
+	setComponentReference: noop,
+};
 
 export default localize( PhoneInput );


### PR DESCRIPTION
Setting focus for FormPhoneMediaInput fails when there is an error in that field and the user clicks submit. This is because FormPhoneMediaInput does not support focus().

The PhoneInput child component (which encapsulates the actual input element), already uses a ref to that input internally. So instead of passing an inputRef prop into PhoneInput, I am retrieving a ref to PhoneInput using onRef and accessing that from FormPhoneMediaInput in a focus() method that I implemented there.

I know it may not be ideal to implement focus like this, but I could not figure out another way to set the ref in the parent component to point to the actual input element.

Other suggestions are welcome.

To test this PR:

Build the branch locally.
Browse to My Sites / Domains / Add Domain
Select a domain
Click "No Thanks" on the G Suite dialog
On the Domain Contact Information page, enter an invalid phone number (but make all other data valid)
Ensure that the focus is on some other input besides the phone number input field.
Click "Continue to Checkout"
The focus should be returned to the phone number input field and there should be no errors in the console.