### PR TITLE
Store: Add promotions page

### DIFF
--- a/client/extensions/woocommerce/app/promotions/index.js
+++ b/client/extensions/woocommerce/app/promotions/index.js
@@ -11,6 +11,8 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import ActionHeader from 'woocommerce/components/action-header';
+import Button from 'components/button';
+import { getLink } from 'woocommerce/lib/nav-utils';
 import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
 import Main from 'components/main';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
@@ -23,13 +25,16 @@ class Promotions extends Component {
 	};
 
 	render() {
-		const { className, translate } = this.props;
+		const { site, className, translate } = this.props;
 		const classes = classNames( 'promotions__list', className );
 
 		return (
 			<Main className={ classes }>
 				<SidebarNavigation />
 				<ActionHeader breadcrumbs={ ( <span>{ translate( 'Promotions' ) }</span> ) }>
+					<Button primary href={ getLink( '/store/promotion/:site/', site ) }>
+						{ translate( 'Add promotion' ) }
+					</Button>
 				</ActionHeader>
 			</Main>
 		);

--- a/client/extensions/woocommerce/app/promotions/index.js
+++ b/client/extensions/woocommerce/app/promotions/index.js
@@ -1,0 +1,47 @@
+/**
+ * External depedencies
+ */
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import ActionHeader from 'woocommerce/components/action-header';
+import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
+import Main from 'components/main';
+import SidebarNavigation from 'my-sites/sidebar-navigation';
+
+class Promotions extends Component {
+	static propTypes = {
+		site: PropTypes.shape( {
+			ID: PropTypes.number,
+		} )
+	};
+
+	render() {
+		const { className, translate } = this.props;
+		const classes = classNames( 'promotions__list', className );
+
+		return (
+			<Main className={ classes }>
+				<SidebarNavigation />
+				<ActionHeader breadcrumbs={ ( <span>{ translate( 'Promotions' ) }</span> ) }>
+				</ActionHeader>
+			</Main>
+		);
+	}
+}
+
+function mapStateToProps( state ) {
+	const site = getSelectedSiteWithFallback( state );
+
+	return {
+		site,
+	};
+}
+
+export default connect( mapStateToProps )( localize( Promotions ) );

--- a/client/extensions/woocommerce/app/promotions/promotion-create.js
+++ b/client/extensions/woocommerce/app/promotions/promotion-create.js
@@ -1,0 +1,41 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Main from 'components/main';
+import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
+
+class PromotionCreate extends React.Component {
+	static propTypes = {
+		site: PropTypes.shape( {
+			ID: PropTypes.number,
+		} ),
+		className: PropTypes.string,
+	}
+
+	render() {
+		const { className } = this.props;
+
+		return (
+			<Main className={ className }>
+			</Main>
+		);
+	}
+}
+
+function mapStateToProps( state ) {
+	const site = getSelectedSiteWithFallback( state );
+
+	return {
+		site,
+	};
+}
+
+export default connect( mapStateToProps )( localize( PromotionCreate ) );

--- a/client/extensions/woocommerce/app/promotions/promotion-update.js
+++ b/client/extensions/woocommerce/app/promotions/promotion-update.js
@@ -1,0 +1,41 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Main from 'components/main';
+import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
+
+class PromotionUpdate extends React.Component {
+	static propTypes = {
+		site: PropTypes.shape( {
+			ID: PropTypes.number,
+		} ),
+		className: PropTypes.string,
+	}
+
+	render() {
+		const { className } = this.props;
+
+		return (
+			<Main className={ className }>
+			</Main>
+		);
+	}
+}
+
+function mapStateToProps( state ) {
+	const site = getSelectedSiteWithFallback( state );
+
+	return {
+		site,
+	};
+}
+
+export default connect( mapStateToProps )( localize( PromotionUpdate ) );

--- a/client/extensions/woocommerce/index.js
+++ b/client/extensions/woocommerce/index.js
@@ -22,6 +22,8 @@ import Products from './app/products';
 import ProductCreate from './app/products/product-create';
 import ProductUpdate from './app/products/product-update';
 import Promotions from './app/promotions';
+import PromotionCreate from './app/promotions/promotion-create';
+import PromotionUpdate from './app/promotions/promotion-update';
 import Dashboard from './app/dashboard';
 import SettingsPayments from './app/settings/payments';
 import SettingsTaxes from './app/settings/taxes';
@@ -82,6 +84,18 @@ const getStorePages = () => {
 			configKey: 'woocommerce/extension-promotions',
 			documentTitle: translate( 'Promotions' ),
 			path: '/store/promotions/:site',
+		},
+		{
+			container: PromotionCreate,
+			configKey: 'woocommerce/extension-promotions',
+			documentTitle: translate( 'New Promotion' ),
+			path: '/store/promotion/:site',
+		},
+		{
+			container: PromotionUpdate,
+			configKey: 'woocommerce/extension-promotions',
+			documentTitle: translate( 'Edit Promotion' ),
+			path: '/store/promotion/:site/:promotion',
 		},
 		{
 			container: SettingsPayments,

--- a/client/extensions/woocommerce/index.js
+++ b/client/extensions/woocommerce/index.js
@@ -21,6 +21,7 @@ import Orders from './app/orders';
 import Products from './app/products';
 import ProductCreate from './app/products/product-create';
 import ProductUpdate from './app/products/product-update';
+import Promotions from './app/promotions';
 import Dashboard from './app/dashboard';
 import SettingsPayments from './app/settings/payments';
 import SettingsTaxes from './app/settings/taxes';
@@ -75,6 +76,12 @@ const getStorePages = () => {
 			configKey: 'woocommerce/extension-orders',
 			documentTitle: translate( 'Order Details' ),
 			path: '/store/order/:site/:order',
+		},
+		{
+			container: Promotions,
+			configKey: 'woocommerce/extension-promotions',
+			documentTitle: translate( 'Promotions' ),
+			path: '/store/promotions/:site',
 		},
 		{
 			container: SettingsPayments,

--- a/client/extensions/woocommerce/store-sidebar/index.js
+++ b/client/extensions/woocommerce/store-sidebar/index.js
@@ -154,8 +154,12 @@ class StoreSidebar extends Component {
 
 		const { site, siteSuffix, translate } = this.props;
 		const link = '/store/promotions' + siteSuffix;
+		const validLinks = [
+			'/store/promotions',
+			'/store/promotion',
+		];
 
-		const selected = this.isItemLinkSelected( [ link ] );
+		const selected = this.isItemLinkSelected( validLinks );
 		const classes = classNames( {
 			promotions: true,
 			'is-placeholder': ! site,

--- a/client/extensions/woocommerce/store-sidebar/index.js
+++ b/client/extensions/woocommerce/store-sidebar/index.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import config from 'config';
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { bindActionCreators } from 'redux';
@@ -146,6 +147,11 @@ class StoreSidebar extends Component {
 	}
 
 	promotions = () => {
+		// TODO: Remove this check when ready to release to production.
+		if ( ! config.isEnabled( 'woocommerce/extension-promotions' ) ) {
+			return null;
+		}
+
 		const { site, siteSuffix, translate } = this.props;
 		const link = '/store/promotions' + siteSuffix;
 

--- a/client/extensions/woocommerce/store-sidebar/index.js
+++ b/client/extensions/woocommerce/store-sidebar/index.js
@@ -145,6 +145,28 @@ class StoreSidebar extends Component {
 		);
 	}
 
+	promotions = () => {
+		const { site, siteSuffix, translate } = this.props;
+		const link = '/store/promotions' + siteSuffix;
+
+		const selected = this.isItemLinkSelected( [ link ] );
+		const classes = classNames( {
+			promotions: true,
+			'is-placeholder': ! site,
+			selected,
+		} );
+
+		return (
+			<SidebarItem
+				className={ classes }
+				icon="star-outline"
+				label={ translate( 'Promotions' ) }
+				link={ link }
+			>
+			</SidebarItem>
+		);
+	}
+
 	settings = () => {
 		const { site, siteSuffix, translate } = this.props;
 		const link = '/store/settings' + siteSuffix;
@@ -183,6 +205,7 @@ class StoreSidebar extends Component {
 						{ this.dashboard() }
 						{ showAllSidebarItems && this.products() }
 						{ showAllSidebarItems && this.orders() }
+						{ showAllSidebarItems && this.promotions() }
 						{ showAllSidebarItems && <SidebarSeparator /> }
 						{ showAllSidebarItems && this.settings() }
 					</ul>

--- a/config/development.json
+++ b/config/development.json
@@ -168,6 +168,7 @@
 		"woocommerce/extension-dashboard": true,
 		"woocommerce/extension-orders": true,
 		"woocommerce/extension-products": true,
+		"woocommerce/extension-promotions": true,
 		"woocommerce/extension-settings": true,
 		"woocommerce/extension-settings-payments": true,
 		"woocommerce/extension-settings-shipping": true,

--- a/config/production.json
+++ b/config/production.json
@@ -109,6 +109,7 @@
 		"woocommerce/extension-dashboard": true,
 		"woocommerce/extension-orders": true,
 		"woocommerce/extension-products": true,
+		"woocommerce/extension-promotions": false,
 		"woocommerce/extension-settings": true,
 		"woocommerce/extension-settings-payments": true,
 		"woocommerce/extension-settings-shipping": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -117,6 +117,7 @@
 		"woocommerce/extension-dashboard": true,
 		"woocommerce/extension-orders": true,
 		"woocommerce/extension-products": true,
+		"woocommerce/extension-promotions": false,
 		"woocommerce/extension-settings": true,
 		"woocommerce/extension-settings-payments": true,
 		"woocommerce/extension-settings-shipping": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -130,6 +130,7 @@
 		"woocommerce/extension-dashboard": true,
 		"woocommerce/extension-orders": true,
 		"woocommerce/extension-products": true,
+		"woocommerce/extension-promotions": false,
 		"woocommerce/extension-settings": true,
 		"woocommerce/extension-settings-payments": true,
 		"woocommerce/extension-settings-shipping": true,


### PR DESCRIPTION
This adds the base page for promotions and the sidebar menu item for it.
Partially fulfills #17615 

To Test:

1. `npm start`
2. Visit `http://calypso.localhost:3000/store/<site url>`
3. Observe the "Promotions" sidebar menu item.
4. Click on it.
5. Observe blank "Promotions" page.
