### PR TITLE
Fix visible overflow of /me profile links

### DIFF
--- a/client/me/profile-link/style.scss
+++ b/client/me/profile-link/style.scss
@@ -55,6 +55,7 @@
 	line-height: 1.4;
 	overflow: hidden;
 	white-space: nowrap;
+	width: 100%;
 	text-decoration: none;
 
 	&:after {


### PR DESCRIPTION
A live chat user asked why their profile link description text was overflowing. This is a simple PR to address the issue.

Before:
<img width="1064" alt="screen shot 2017-08-30 at 10 17 49 am" src="https://user-images.githubusercontent.com/530877/29887275-bd1a59be-8d71-11e7-948c-7e54e027f80a.png">

After:
<img width="859" alt="screen shot 2017-08-30 at 10 49 31 am" src="https://user-images.githubusercontent.com/530877/29887295-cfdfab26-8d71-11e7-8c14-b187a40bde3b.png">

