### PR TITLE
Remove Publish Confirmation AB test

### DIFF
--- a/client/layout/guided-tours/tours/editor-basics-tour.js
+++ b/client/layout/guided-tours/tours/editor-basics-tour.js
@@ -141,7 +141,7 @@ export const EditorBasicsTour = makeTour(
 		<Step
 			name="publish"
 			arrow="right-top"
-			target=".editor-ground-control__publish-combo"
+			target=".editor-ground-control__publish-button"
 			placement="beside"
 			style={ { marginTop: '-17px' } }
 		>

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -76,15 +76,6 @@ module.exports = {
 		},
 		defaultVariation: 'original',
 	},
-	postPublishConfirmation: {
-		datestamp: '20170801',
-		allowExistingUsers: true,
-		variations: {
-			showPublishConfirmation: 5,
-			noPublishConfirmation: 95,
-		},
-		defaultVariation: 'noPublishConfirmation',
-	},
 	readerIntroIllustration: {
 		datestamp: '20170718',
 		variations: {

--- a/client/lib/posts/stats.js
+++ b/client/lib/posts/stats.js
@@ -69,7 +69,7 @@ export function recordSaveEvent( context ) {
 	} else if ( 'publish' === nextStatus || 'private' === nextStatus ) {
 		tracksEventName += 'publish';
 		usageAction = 'new';
-		if ( context && context.isConfirmationFeatureEnabled ) {
+		if ( context && context.isConfirmationSidebarEnabled ) {
 			eventContext = 'confirmation_sidebar';
 		}
 	} else if ( 'pending' === nextStatus ) {
@@ -78,7 +78,7 @@ export function recordSaveEvent( context ) {
 		tracksEventName += 'schedule';
 		statName = 'status-schedule';
 		statEvent = 'Scheduled Post';
-		if ( context && context.isConfirmationFeatureEnabled ) {
+		if ( context && context.isConfirmationSidebarEnabled ) {
 			eventContext = 'confirmation_sidebar';
 		}
 	}

--- a/client/my-sites/site-settings/composing/index.jsx
+++ b/client/my-sites/site-settings/composing/index.jsx
@@ -19,7 +19,6 @@ import {
 	siteSupportsJetpackSettingsUi,
 } from 'state/sites/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import { abtest } from 'lib/abtest';
 
 const Composing = ( {
 	eventTracker,
@@ -39,11 +38,7 @@ const Composing = ( {
 	return (
 		<div>
 			<CardComponent className="composing__card site-settings">
-				{
-					abtest( 'postPublishConfirmation' ) === 'showPublishConfirmation' &&
-					<PublishConfirmation />
-				}
-
+				<PublishConfirmation />
 				<DefaultPostFormat
 					eventTracker={ eventTracker }
 					fields={ fields }

--- a/client/post-editor/edit-post-status/index.jsx
+++ b/client/post-editor/edit-post-status/index.jsx
@@ -3,7 +3,6 @@
  */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { noop } from 'lodash';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
 import Gridicon from 'gridicons';
@@ -11,16 +10,11 @@ import Gridicon from 'gridicons';
 /**
  * Internal dependencies
  */
-import { abtest } from 'lib/abtest';
-import AsyncLoad from 'components/async-load';
 import Button from 'components/button';
 import FormToggle from 'components/forms/form-toggle/compact';
 import Revisions from 'post-editor/editor-revisions';
 import postUtils from 'lib/posts/utils';
-import Popover from 'components/popover';
 import InfoPopover from 'components/info-popover';
-import Tooltip from 'components/tooltip';
-import postScheduleUtils from 'components/post-schedule/utils';
 import siteUtils from 'lib/site/utils';
 import { recordStat, recordEvent } from 'lib/posts/stats';
 import { editPost } from 'state/posts/actions';
@@ -52,10 +46,6 @@ export class EditPostStatus extends Component {
 
 	constructor( props ) {
 		super( props );
-		this.state = {
-			showTZTooltip: false,
-			showPostSchedulePopover: false
-		};
 	}
 
 	toggleStickyStatus = () => {
@@ -88,22 +78,8 @@ export class EditPostStatus extends Component {
 		} );
 	};
 
-	togglePostSchedulePopover = () => {
-		this.setState( {
-			showPostSchedulePopover: ! this.state.showPostSchedulePopover
-		} );
-	};
-
 	revertToDraft = () => {
 		this.props.onSave( 'draft' );
-	};
-
-	showTZTooltip = () => {
-		this.setState( { showTZTooltip: true } );
-	};
-
-	hideTZTooltip = () => {
-		this.setState( { showTZTooltip: false } );
 	};
 
 	render() {
@@ -123,16 +99,10 @@ export class EditPostStatus extends Component {
 			this.props.site.options &&
 			this.props.site.options.admin_url;
 
-		const isPostPublishFlow = abtest( 'postPublishConfirmation' ) === 'showPublishConfirmation';
-
 		return (
 			<div className="edit-post-status">
 				{ this.renderPostScheduling() }
-				{
-					isPostPublishFlow
-						? this.renderPostVisibility()
-						: null
-				}
+				{ this.renderPostVisibility() }
 				{ this.props.type === 'post' && ! isPostPrivate && ! isPasswordProtected &&
 					<label className="edit-post-status__sticky">
 						<span className="edit-post-status__label-text">
@@ -172,11 +142,6 @@ export class EditPostStatus extends Component {
 						<Gridicon icon="undo" size={ 18 } /> { translate( 'Revert to draft' ) }
 					</Button>
 				}
-				{
-					! isPostPublishFlow
-						? this.renderPostVisibility()
-						: null
-				}
 				<Revisions
 					revisions={ this.props.post && this.props.post.revisions }
 					adminUrl={ adminUrl }
@@ -188,43 +153,11 @@ export class EditPostStatus extends Component {
 	}
 
 	renderPostScheduling() {
-		const isPostPublishFlow = abtest( 'postPublishConfirmation' ) === 'showPublishConfirmation';
-
-		const fullDate = postScheduleUtils.convertDateToUserLocation(
-			( this.props.postDate || new Date() ),
-			siteUtils.timezone( this.props.site ),
-			siteUtils.gmtOffset( this.props.site )
-		).format( 'll LT' );
-
-		if ( isPostPublishFlow ) {
-			return (
-				<EditorPublishDate
-					post={ this.props.post }
-					setPostDate={ this.props.setPostDate }
-				/>
-			);
-		}
-
 		return (
-			<span
-				ref="postStatusTooltip"
-				className="edit-post-status__full-date"
-				onMouseEnter={ this.showTZTooltip }
-				onMouseLeave={ this.hideTZTooltip }
-				onClick={ this.togglePostSchedulePopover }
-			>
-				{
-					postUtils.isFutureDated( this.props.savedPost )
-						? <span className="edit-post-status__future-label">
-								{ this.props.translate( 'Future' ) }
-							</span>
-						: <Gridicon icon="time" size={ 18 } />
-				}
-
-				{ fullDate }
-				{ this.renderTZTooltop() }
-				{ this.renderPostSchedulePopover() }
-			</span>
+			<EditorPublishDate
+				post={ this.props.post }
+				setPostDate={ this.props.setPostDate }
+			/>
 		);
 	}
 
@@ -256,66 +189,6 @@ export class EditPostStatus extends Component {
 
 		return (
 			<EditorVisibility { ...props } />
-		);
-	}
-
-	renderPostSchedulePopover() {
-		const tz = siteUtils.timezone( this.props.site ),
-			gmt = siteUtils.gmtOffset( this.props.site ),
-			selectedDay = this.props.postDate
-				? this.props.moment( this.props.postDate )
-				: null;
-
-		return (
-			<Popover
-				context={ this.refs && this.refs.postStatusTooltip }
-				isVisible={ this.state.showPostSchedulePopover }
-				position="bottom left"
-				onClose={ this.togglePostSchedulePopover }
-			>
-				<div className="edit-post-status__post-schedule">
-					<AsyncLoad
-						require="components/post-schedule"
-						selectedDay={ selectedDay }
-						timezone={ tz }
-						gmtOffset={ gmt }
-						onDateChange={ this.props.setPostDate }
-					/>
-				</div>
-			</Popover>
-		);
-	}
-
-	renderTZTooltop() {
-		const timezone = siteUtils.timezone( this.props.site ),
-			gmtOffset = siteUtils.gmtOffset( this.props.site );
-
-		if ( ! ( timezone || postScheduleUtils.isValidGMTOffset( gmtOffset ) ) ) {
-			return;
-		}
-
-		if ( this.state.showPostSchedulePopover ) {
-			return;
-		}
-
-		return (
-			<Tooltip
-				context={ this.refs && this.refs.postStatusTooltip }
-				isVisible={ this.state.showTZTooltip }
-				position="left"
-				onClose={ noop }
-			>
-				<div className="edit-post-status__full-date__tooltip">
-					{ timezone ? timezone + ' ' : 'UTC' }
-					{
-						postScheduleUtils.getLocalizedDate(
-							postUtils.getEditedTime( this.props.post ),
-							timezone,
-							gmtOffset
-						).format( 'Z' )
-					}
-				</div>
-			</Tooltip>
 		);
 	}
 }

--- a/client/post-editor/editor-ground-control/index.jsx
+++ b/client/post-editor/editor-ground-control/index.jsx
@@ -4,7 +4,6 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { identity, noop } from 'lodash';
-import classNames from 'classnames';
 import moment from 'moment';
 import page from 'page';
 import i18n, { localize } from 'i18n-calypso';
@@ -14,7 +13,6 @@ import i18n, { localize } from 'i18n-calypso';
  */
 import Card from 'components/card';
 import Gridicon from 'gridicons';
-import Popover from 'components/popover';
 import Site from 'blocks/site';
 import postUtils from 'lib/posts/utils';
 import siteUtils from 'lib/site/utils';
@@ -22,7 +20,6 @@ import { recordEvent, recordStat } from 'lib/posts/stats';
 import EditorPublishButton, { getPublishButtonStatus } from 'post-editor/editor-publish-button';
 import Button from 'components/button';
 import EditorPostType from 'post-editor/editor-post-type';
-import PostScheduler from './post-scheduler';
 import { NESTED_SIDEBAR_REVISIONS, NestedSidebarPropType } from 'post-editor/editor-sidebar/constants';
 
 export class EditorGroundControl extends PureComponent {
@@ -72,7 +69,6 @@ export class EditorGroundControl extends PureComponent {
 	}
 
 	state = {
-		showSchedulePopover: false,
 		showAdvanceStatus: false,
 		needsVerification: this.props.userUtils && this.props.userUtils.needsVerificationForSite( this.props.site ),
 	}
@@ -141,40 +137,6 @@ export class EditorGroundControl extends PureComponent {
 		return buttonLabels[ primaryButtonState ];
 	}
 
-	toggleSchedulePopover = () => {
-		this.setState( { showSchedulePopover: ! this.state.showSchedulePopover } );
-	}
-
-	closeSchedulePopover = ( wasCanceled ) => {
-		if ( wasCanceled ) {
-			const date = this.props.savedPost && this.props.savedPost.date
-				? this.props.moment( this.props.savedPost.date )
-				: null;
-
-			this.props.setPostDate( date );
-		}
-
-		this.setState( { showSchedulePopover: false } );
-	}
-
-	schedulePostPopover() {
-		return (
-			<Popover
-				isVisible={ this.state.showSchedulePopover }
-				onClose={ this.closeSchedulePopover }
-				position={ 'bottom left' }
-				context={ this.refs && this.refs.schedulePost }
-				id="editor-post-schedule"
-				className="editor-ground-control__post-schedule-popover"
-			>
-				<PostScheduler initialDate={ this.props.moment() }
-					post={ this.props.post }
-					setPostDate= { this.props.setPostDate }
-					site={ this.props.site } />
-			</Popover>
-		);
-	}
-
 	getSaveStatusLabel() {
 		if ( this.props.isSaving ) {
 			return this.props.translate( 'Saving…' );
@@ -230,10 +192,6 @@ export class EditorGroundControl extends PureComponent {
 			return;
 		}
 
-		const publishComboClasses = classNames( 'editor-ground-control__publish-combo', {
-			'is-standalone': ! this.canPublishPost() || this.props.isConfirmationSidebarEnabled
-		} );
-
 		return (
 			<div className="editor-ground-control__action-buttons">
 				<Button
@@ -253,7 +211,7 @@ export class EditorGroundControl extends PureComponent {
 					<Gridicon icon={ this.props.nestedSidebar === NESTED_SIDEBAR_REVISIONS ? 'history' : 'cog' } />
 					<span className="editor-ground-control__button-label"> <EditorPostType isSettings /></span>
 				</Button>
-				<div className={ publishComboClasses }>
+				<div className="editor-ground-control__publish-button">
 					<EditorPublishButton
 						site={ this.props.site }
 						post={ this.props.post }
@@ -268,36 +226,7 @@ export class EditorGroundControl extends PureComponent {
 						needsVerification={ this.state.needsVerification }
 						busy={ this.props.isPublishing || ( postUtils.isPublished( this.props.savedPost ) && this.props.isSaving ) }
 					/>
-					{ this.canPublishPost() &&
-					! this.props.isConfirmationSidebarEnabled &&
-					<Button
-						primary
-						compact
-						ref="schedulePost"
-						className="editor-ground-control__time-button"
-						onClick={ this.toggleSchedulePopover }
-						aria-label={ this.props.translate( 'Schedule date and time to publish post.' ) }
-						aria-pressed={ !! this.state.showSchedulePopover }
-						title={ this.props.translate( 'Set date and time' ) }
-						tabIndex={ 6 }
-					>
-						{ postUtils.isFutureDated( this.props.post )
-							? <Gridicon icon="scheduled" />
-							: <Gridicon icon="calendar" />
-						}
-						<span className="editor-ground-control__time-button-label">
-										{ postUtils.isFutureDated( this.props.post )
-											? this.props.moment( this.props.post.date ).calendar()
-											: this.props.translate( 'Choose Date' )
-										}
-									</span>
-					</Button>
-					}
 				</div>
-				{ this.canPublishPost() &&
-				! this.props.isConfirmationSidebarEnabled &&
-				this.schedulePostPopover()
-				}
 			</div>
 		);
 	}

--- a/client/post-editor/editor-ground-control/style.scss
+++ b/client/post-editor/editor-ground-control/style.scss
@@ -102,17 +102,13 @@
 	font-size: 13px;
 }
 
-.editor-ground-control__publish-combo {
+.editor-ground-control__publish-button {
 	flex-grow: 1;
 	display: flex;
-	margin: 0 4px;
+	margin: 0 12px;
 
-	&.is-standalone {
-		margin: 0 12px;
-
-		@include breakpoint( "<480px" ) {
-			margin: 0;
-		}
+	@include breakpoint( "<480px" ) {
+		margin: 0;
 	}
 }
 
@@ -122,7 +118,7 @@
 	padding: 5px 14px 7px;
 }
 
-.editor-ground-control .is-standalone .editor-publish-button {
+.editor-ground-control .editor-publish-button {
 	border-radius: 4px;
 	padding: 7px 16px;
 

--- a/client/post-editor/editor-publish-button/index.jsx
+++ b/client/post-editor/editor-publish-button/index.jsx
@@ -7,7 +7,6 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
-import { abtest } from 'lib/abtest';
 import { recordEvent } from 'lib/posts/stats';
 import postUtils from 'lib/posts/utils';
 import siteUtils from 'lib/site/utils';
@@ -135,13 +134,11 @@ export class EditorPublishButton extends Component {
 	}
 
 	isEnabled() {
-		const isInPostPublishConfirmationFlow = abtest( 'postPublishConfirmation' ) === 'showPublishConfirmation';
-
 		return ! this.props.isPublishing &&
 			! this.props.isSaveBlocked &&
 			this.props.hasContent &&
 			! this.props.needsVerification &&
-			( ! isInPostPublishConfirmationFlow || ( ! this.props.privatePost || this.props.privatePostPasswordValid ) );
+			( ! this.props.privatePost || this.props.privatePostPasswordValid );
 	}
 
 	render() {

--- a/client/post-editor/editor-visibility/index.jsx
+++ b/client/post-editor/editor-visibility/index.jsx
@@ -3,7 +3,7 @@
  */
 import ReactDom from 'react-dom';
 import React from 'react';
-import { includes, find } from 'lodash';
+import { find } from 'lodash';
 import classNames from 'classnames';
 import Gridicon from 'gridicons';
 import { connect } from 'react-redux';
@@ -12,16 +12,9 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import { abtest } from 'lib/abtest';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormInputValidation from 'components/forms/form-input-validation';
-import FormLabel from 'components/forms/form-label';
-import FormLegend from 'components/forms/form-legend';
-import FormRadio from 'components/forms/form-radio';
 import FormTextInput from 'components/forms/form-text-input';
-import FormSettingExplanation from 'components/forms/form-setting-explanation';
-import Button from 'components/button';
-import Popover from 'components/popover';
 import SelectDropdown from 'components/select-dropdown';
 import DropdownItem from 'components/select-dropdown/item';
 import touchDetect from 'lib/touch-detect';
@@ -57,20 +50,12 @@ const EditorVisibility = React.createClass( {
 
 	getInitialState() {
 		return {
-			showPopover: false,
 			passwordIsValid: true,
-			showVisibilityInfotips: false,
 		};
 	},
 
 	componentWillReceiveProps( nextProps ) {
 		if ( this.props.password === nextProps.password ) {
-			return;
-		}
-
-		const isInPostPublishConfirmationFlow = abtest( 'postPublishConfirmation' ) === 'showPublishConfirmation';
-
-		if ( ! isInPostPublishConfirmationFlow ) {
 			return;
 		}
 
@@ -98,43 +83,6 @@ const EditorVisibility = React.createClass( {
 		return 'public';
 	},
 
-	togglePopover() {
-		if ( this.state.showPopover ) {
-			recordStat( 'visibility-dialog-closed' );
-			recordEvent( 'Closed visibility dialog' );
-			this.closePopover();
-		} else {
-			recordStat( 'visibility-dialog-opened' );
-			recordEvent( 'Opened visibility dialog' );
-			this.setState( {
-				showPopover: true
-			} );
-		}
-	},
-
-	closePopover( event ) {
-		if ( this.showingAcceptDialog && event ) {
-			event.preventDefault();
-			return;
-		}
-
-		// In order to avoid having the click outside handler and the React onClick handler
-		// both respond to a click on the label we stop propagation
-		if ( event && event.type === 'click' ) {
-			event.stopImmediatePropagation();
-		}
-
-		const stateChanges = {};
-
-		if ( this.isPasswordValid() ) {
-			stateChanges.showPopover = false;
-		} else {
-			stateChanges.passwordIsValid = false;
-		}
-
-		this.setState( stateChanges );
-	},
-
 	isPasswordValid() {
 		if ( 'password' !== this.getVisibility() ) {
 			return true;
@@ -143,45 +91,6 @@ const EditorVisibility = React.createClass( {
 		const password = ReactDom.findDOMNode( this.refs.postPassword ).value.trim();
 
 		return password.length;
-	},
-
-	renderVisibilityTip( visibility ) {
-		if ( ! this.state.showVisibilityInfotips ) {
-			return null;
-		}
-
-		let infotext;
-
-		switch ( visibility ) {
-			case 'public':
-				infotext = this.props.translate( 'Visible to everyone.',
-					{ context: 'Post visibility: info text shown when changing post visibility to public.' }
-				);
-				if ( this.props.isPrivateSite ) {
-					infotext = this.props.translate( 'Any member of the site can view this post.',
-						{ context: 'Post visibility: info text shown when changing post visibility to public on a members-only site.' }
-					);
-				}
-				break;
-			case 'private':
-				infotext = this.props.translate( 'Only visible to site admins and editors.',
-					{ context: 'Post visibility: info text shown when changing post visibility to private.' }
-				);
-				break;
-			case 'password':
-				infotext = this.props.translate( 'Protected with a password you choose. Only those with the password can view this post.',
-					{ context: 'Post visibility: info text shown when changing post visibility to password protected.' }
-				);
-				break;
-		}
-
-		return (
-			<FormSettingExplanation className={ visibility }>{ infotext }</FormSettingExplanation>
-		);
-	},
-
-	updateVisibilityFromRadioButton( event ) {
-		this.updateVisibility( event.target.value );
 	},
 
 	updatePostStatus() {
@@ -223,12 +132,6 @@ const EditorVisibility = React.createClass( {
 		}
 	},
 
-	onKey( event ) {
-		if ( includes( [ 'Enter', 'Escape' ], event.key ) ) {
-			this.closePopover();
-		}
-	},
-
 	setPostToPrivate() {
 		const { siteId, postId } = this.props;
 		// TODO: REDUX - remove flux actions when whole post-editor is reduxified
@@ -249,9 +152,6 @@ const EditorVisibility = React.createClass( {
 
 	onPrivatePublish() {
 		this.setPostToPrivate();
-		this.setState( {
-			showPopover: false
-		} );
 		setTimeout( () => this.props.onPrivatePublish( true ), 0 );
 	},
 
@@ -304,140 +204,22 @@ const EditorVisibility = React.createClass( {
 		const value = this.props.password ? this.props.password.trim() : null;
 		const isError = ! this.state.passwordIsValid;
 		const errorMessage = this.props.translate( 'Password is empty.', { context: 'Editor: Error shown when password is empty.' } );
-		const isInPostPublishConfirmationFlow = abtest( 'postPublishConfirmation' ) === 'showPublishConfirmation';
 
 		return (
 			<div>
 				<FormTextInput
-					autoFocus={ isInPostPublishConfirmationFlow }
+					autoFocus
 					onKeyUp={ this.onKey }
 					onChange={ this.onPasswordChange }
-					onBlur={ isInPostPublishConfirmationFlow ? this.onPasswordChange : () => {} }
+					onBlur={ this.onPasswordChange }
 					value={ value }
 					isError={ isError }
 					ref="postPassword"
-					className={ this.state.showVisibilityInfotips ? 'is-info-open' : null }
 					placeholder={ this.props.translate( 'Create password', { context: 'Editor: Create password for post' } ) }
 				/>
 
 				{ isError ? <FormInputValidation isError={ true } text={ errorMessage } /> : null }
 			</div>
-		);
-	},
-
-	toggleVisibilityInfotips() {
-		if ( this.state.showVisibilityInfotips ) {
-			recordEvent( 'InfoPopover: Visibility Closed' );
-			this.setState( {
-				showVisibilityInfotips: false
-			} );
-		} else {
-			recordEvent( 'InfoPopover: Visibility Opened' );
-			this.setState( {
-				showVisibilityInfotips: true
-			} );
-		}
-	},
-
-	renderPrivacyPopover( visibility ) {
-		const icons = {
-			password: 'lock',
-			'private': 'not-visible',
-			'public': 'visible'
-		};
-
-		return (
-			<Button
-					compact
-					borderless
-					onClick={ this.togglePopover }
-					ref="setVisibility"
-				>
-				<Gridicon icon={ icons[ visibility ] || 'visible' } /> { visibility }
-				<Popover
-					className="editor-visibility__popover"
-					isVisible={ this.state.showPopover }
-					onClose={ this.closePopover }
-					position={ 'bottom left' }
-					context={ this.refs && this.refs.setVisibility }
-				>
-					<div className="editor-visibility__dialog">
-						<FormFieldset className="editor-fieldset">
-							<FormLegend className="editor-fieldset__legend">
-								{ this.props.translate( 'Post Visibility' ) }
-								<Gridicon
-									icon="info-outline"
-									size={ 18 }
-									className={
-										classNames(
-											'editor-visibility__dialog-info',
-											{ is_active: this.state.showVisibilityInfotips }
-										) }
-									onClick={ this.toggleVisibilityInfotips }
-								/>
-							</FormLegend>
-							<FormLabel>
-								<FormRadio
-									name="site-visibility"
-									value="public"
-									onChange={ this.updateVisibilityFromRadioButton }
-									checked={ 'public' === visibility }
-								/>
-								<span>
-									{
-										this.props.isPrivateSite
-										? this.props.translate(
-											'Visible for members of the site',
-											{ context: 'Editor: Radio label to set post visibility' }
-										)
-										: this.props.translate(
-											'Public',
-											{ context: 'Editor: Radio label to set post visible to public'
-										} )
-									}
-								</span>
-							</FormLabel>
-							{ this.renderVisibilityTip( 'public' ) }
-
-							<FormLabel>
-								<FormRadio
-									name="site-visibility"
-									value="private"
-									onChange={ this.onSetToPrivate }
-									checked={ 'private' === visibility }
-								/>
-								<span>
-								{
-									this.props.translate(
-										'Private',
-										{ context: 'Editor: Radio label to set post to private' }
-									)
-								}
-								</span>
-							</FormLabel>
-							{ this.renderVisibilityTip( 'private' ) }
-							<FormLabel>
-								<FormRadio
-									name="site-visibility"
-									value="password"
-									onChange={ this.updateVisibilityFromRadioButton }
-									checked={ 'password' === visibility }
-								/>
-								<span>
-								{
-									this.props.translate(
-										'Password Protected',
-										{ context: 'Editor: Radio label to set post to password protected' }
-									)
-								}
-								</span>
-							</FormLabel>
-							{ this.renderVisibilityTip( 'password' ) }
-							{ visibility === 'password' ? this.renderPasswordInput() : null }
-						</FormFieldset>
-					</div>
-				</Popover>
-			</Button>
 		);
 	},
 
@@ -495,20 +277,13 @@ const EditorVisibility = React.createClass( {
 
 	render() {
 		const visibility = this.getVisibility();
-		const isDropdown = abtest( 'postPublishConfirmation' ) === 'showPublishConfirmation';
 		const classes = classNames( 'editor-visibility', {
-			'is-dialog-open': this.state.showPopover,
 			'is-touch': touchDetect.hasTouch(),
-			'is-dropdown': isDropdown,
 		} );
 
 		return (
 			<div className={ classes }>
-				{
-					isDropdown
-						? this.renderPrivacyDropdown( visibility )
-						: this.renderPrivacyPopover( visibility )
-				}
+				{ this.renderPrivacyDropdown( visibility ) }
 			</div>
 		);
 	}

--- a/client/post-editor/editor-visibility/style.scss
+++ b/client/post-editor/editor-visibility/style.scss
@@ -3,11 +3,7 @@
 	font-size: 13px;
 	justify-content: space-between;
 	align-items: center;
-	margin: 0;
-
-	&.is-dropdown {
-		margin: 8px 0;
-	}
+	margin: 8px 0;
 }
 
 .editor-visibility__dropdown {
@@ -73,7 +69,6 @@
 }
 
 .editor-visibility .button {
-	&.is-dialog-open,
 	&.is-touch,
 	&:hover {
 		.editor-visibility__label {
@@ -93,10 +88,6 @@
 
 	.form-text-input {
 		font-size: 13px;
-
-		&.is-info-open {
-			margin-top: 8px;
-		}
 	}
 
 	.form-input-validation {


### PR DESCRIPTION
This PR removes the publish confirmation AB test and enables the publish confirmation flow for all users. Cleanup of code that would become inaccessible is also included in this PR.

This is part of a larger epic (See p3Ex-2ri-p2).

To test:

- Check out branch.
- Run `npm start`
- Create a new post
- Verify that the publish flow works correctly:
    - Post Settings sidebar looks good, publish date and visibility dropdowns work
    - Remember to test the password protected post scenario with the password field that gives an error message if the password is empty, and disables the Publish… button
    - Remember to test the private post scenario (it should pop up a modal dialog)
    - Publish date component should work for both backdating, publishing immediately, and scheduling. Publish… button label should be updated accordingly.
    - Publish date and visibility dropdowns should work on the confirmation sidebar as well, and be synchronized with those on the editor sidebar
- Verify that the sidebar does not show up if you uncheck “Show this every time I publish”, and the Publish/Schedule button labels do not end in an ellipsis (…) in this case. Verify that Publish button is not a combo (the right half of it is not a calendar, see https://github.com/Automattic/wp-calypso/pull/14876, https://github.com/Automattic/wp-calypso/issues/15644, and https://github.com/Automattic/wp-calypso/pull/15688).
- Verify that you can toggle the confirmation sidebar visibility in Settings —> Writing —> Composing