### PR TITLE
Purchases: fix purchase removal error handling

### DIFF
--- a/client/state/purchases/selectors.js
+++ b/client/state/purchases/selectors.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { find } from 'lodash';
+import { get, find } from 'lodash';
 
 /**
  * Internal Dependencies
@@ -38,7 +38,9 @@ export const getUserPurchases = ( state, userId ) => (
  * @param {Object} state - current state object
  * @return {Object} an error object from the server
  */
-export const getPurchasesError = state => state.purchases.error;
+export const getPurchasesError = state => (
+	get( state, 'purchases.error', '' )
+);
 
 /**
  * Returns a Purchase object from the state using its id


### PR DESCRIPTION
Right now a failure in purchase removal gives the user a success error message because the `removePurchase` action [catches any error situation](https://github.com/Automattic/wp-calypso/blob/a70587157b33783ba4d5e0e4a1e136680d459d51/client/state/purchases/actions.js#L124) and dispatches an error Redux action to save in global state. The calling `RemovePurchase` component never gets any sort of error from the function so the error messaging in its catch block never triggered.

This change adds a check for error state in the `then` block to rectify.

![aug-30-2017 22-56-29](https://user-images.githubusercontent.com/2006764/29904394-a111ec7c-8dd6-11e7-8c8e-9eed664bd61b.gif)

vs

![aug-30-2017 23-03-00](https://user-images.githubusercontent.com/2006764/29904561-6f0ba4e2-8dd7-11e7-8ba2-43ea3167a3a0.gif)



To test:
1. Intentionally return an error from the purchase remove API endpoint. You should see success notice.
2. Apply this patch.
3. Try again. You should see error notice.