### PR TITLE
Store: Add promotions create/update stubs

### DIFF
--- a/client/extensions/woocommerce/app/promotions/index.js
+++ b/client/extensions/woocommerce/app/promotions/index.js
@@ -11,6 +11,8 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import ActionHeader from 'woocommerce/components/action-header';
+import Button from 'components/button';
+import { getLink } from 'woocommerce/lib/nav-utils';
 import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
 import Main from 'components/main';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
@@ -23,13 +25,16 @@ class Promotions extends Component {
 	};
 
 	render() {
-		const { className, translate } = this.props;
+		const { site, className, translate } = this.props;
 		const classes = classNames( 'promotions__list', className );
 
 		return (
 			<Main className={ classes }>
 				<SidebarNavigation />
 				<ActionHeader breadcrumbs={ ( <span>{ translate( 'Promotions' ) }</span> ) }>
+					<Button primary href={ getLink( '/store/promotion/:site/', site ) }>
+						{ translate( 'Add promotion' ) }
+					</Button>
 				</ActionHeader>
 			</Main>
 		);

--- a/client/extensions/woocommerce/app/promotions/promotion-create.js
+++ b/client/extensions/woocommerce/app/promotions/promotion-create.js
@@ -1,0 +1,41 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Main from 'components/main';
+import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
+
+class PromotionCreate extends React.Component {
+	static propTypes = {
+		site: PropTypes.shape( {
+			ID: PropTypes.number,
+		} ),
+		className: PropTypes.string,
+	}
+
+	render() {
+		const { className } = this.props;
+
+		return (
+			<Main className={ className }>
+			</Main>
+		);
+	}
+}
+
+function mapStateToProps( state ) {
+	const site = getSelectedSiteWithFallback( state );
+
+	return {
+		site,
+	};
+}
+
+export default connect( mapStateToProps )( localize( PromotionCreate ) );

--- a/client/extensions/woocommerce/app/promotions/promotion-update.js
+++ b/client/extensions/woocommerce/app/promotions/promotion-update.js
@@ -1,0 +1,41 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Main from 'components/main';
+import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
+
+class PromotionUpdate extends React.Component {
+	static propTypes = {
+		site: PropTypes.shape( {
+			ID: PropTypes.number,
+		} ),
+		className: PropTypes.string,
+	}
+
+	render() {
+		const { className } = this.props;
+
+		return (
+			<Main className={ className }>
+			</Main>
+		);
+	}
+}
+
+function mapStateToProps( state ) {
+	const site = getSelectedSiteWithFallback( state );
+
+	return {
+		site,
+	};
+}
+
+export default connect( mapStateToProps )( localize( PromotionUpdate ) );

--- a/client/extensions/woocommerce/index.js
+++ b/client/extensions/woocommerce/index.js
@@ -22,6 +22,8 @@ import Products from './app/products';
 import ProductCreate from './app/products/product-create';
 import ProductUpdate from './app/products/product-update';
 import Promotions from './app/promotions';
+import PromotionCreate from './app/promotions/promotion-create';
+import PromotionUpdate from './app/promotions/promotion-update';
 import Dashboard from './app/dashboard';
 import SettingsPayments from './app/settings/payments';
 import SettingsTaxes from './app/settings/taxes';
@@ -82,6 +84,18 @@ const getStorePages = () => {
 			configKey: 'woocommerce/extension-promotions',
 			documentTitle: translate( 'Promotions' ),
 			path: '/store/promotions/:site',
+		},
+		{
+			container: PromotionCreate,
+			configKey: 'woocommerce/extension-promotions',
+			documentTitle: translate( 'New Promotion' ),
+			path: '/store/promotion/:site',
+		},
+		{
+			container: PromotionUpdate,
+			configKey: 'woocommerce/extension-promotions',
+			documentTitle: translate( 'Edit Promotion' ),
+			path: '/store/promotion/:site/:promotion',
 		},
 		{
 			container: SettingsPayments,

--- a/client/extensions/woocommerce/store-sidebar/index.js
+++ b/client/extensions/woocommerce/store-sidebar/index.js
@@ -148,8 +148,12 @@ class StoreSidebar extends Component {
 	promotions = () => {
 		const { site, siteSuffix, translate } = this.props;
 		const link = '/store/promotions' + siteSuffix;
+		const validLinks = [
+			'/store/promotions',
+			'/store/promotion',
+		];
 
-		const selected = this.isItemLinkSelected( [ link ] );
+		const selected = this.isItemLinkSelected( validLinks );
 		const classes = classNames( {
 			promotions: true,
 			'is-placeholder': ! site,


### PR DESCRIPTION
This adds page stubs for creating and updating a promotion.
Partially fulfills #17615

To Test:
1. `npm start`
2. Visit `http://calypso.localhost:3000/store/promotions/<site url>`
3. Click "Add Promotion" on top-right
4. Verify the title of the page is "New Promotion"
5. Verify that "Promotions" on the sidebar still shows as selected.
6. Visit `http://calypso.localhost:3000/store/promotions/<site url>/p123`
7. Verify the title of the page is "Edit Promotion"
8. Verify that "Promotions" on the sidebar still shows as selected.
