### PR TITLE
Magic Login: Pull the query args out of the link consumption URL

### DIFF
--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -3,6 +3,7 @@
  */
 import React from 'react';
 import { parse as parseUrl } from 'url';
+import page from 'page';
 import qs from 'qs';
 
 /**
@@ -76,12 +77,23 @@ export default {
 	},
 
 	magicLoginUse( context, next ) {
+		/**
+		 * Pull the query arguments out of the URL & into the state.
+		 * It unclutters the address bar & will keep tokens out of tracking pixels.
+		 */
+		if ( context.querystring ) {
+			page.replace( '/log-in/link/use', context.query );
+			return;
+		}
+
+		const magicLoginData = context.state || {};
+
 		const {
 			client_id,
 			email,
 			token,
 			tt,
-		} = context.query;
+		} = magicLoginData;
 
 		context.primary = (
 			<HandleEmailedLinkForm

--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -86,14 +86,14 @@ export default {
 			return;
 		}
 
-		const magicLoginData = context.state || {};
+		const previousQuery = context.state || {};
 
 		const {
 			client_id,
 			email,
 			token,
 			tt,
-		} = magicLoginData;
+		} = previousQuery;
 
 		context.primary = (
 			<HandleEmailedLinkForm

--- a/client/login/index.node.js
+++ b/client/login/index.node.js
@@ -3,6 +3,7 @@
  */
 import config from 'config';
 import webRouter from './index.web';
+import { makeLayout, redirectLoggedIn, setUpLocale } from 'controller';
 
 export default router => {
 	if ( config.isEnabled( 'login/wp-login' ) ) {
@@ -10,6 +11,16 @@ export default router => {
 			'/log-in/en', ( { res } ) => {
 				res.redirect( 301, '/log-in' );
 			}
+		);
+	}
+
+	if ( config.isEnabled( 'login/magic-login' ) ) {
+		// Only do the basics for layout on the server-side
+		router(
+			'/log-in/link/use/:lang?',
+			setUpLocale,
+			redirectLoggedIn,
+			makeLayout,
 		);
 	}
 

--- a/client/login/magic-login/handle-emailed-link-form.jsx
+++ b/client/login/magic-login/handle-emailed-link-form.jsx
@@ -1,9 +1,11 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
+import { isEmpty } from 'lodash';
 import page from 'page';
 
 /**
@@ -39,7 +41,7 @@ const user = userFactory();
 class HandleEmailedLinkForm extends React.Component {
 	static propTypes = {
 		// Passed props
-		clientId: PropTypes.string.isRequired,
+		clientId: PropTypes.string,
 		emailAddress: PropTypes.string.isRequired,
 		token: PropTypes.string.isRequired,
 		tokenTime: PropTypes.string.isRequired,
@@ -62,9 +64,22 @@ class HandleEmailedLinkForm extends React.Component {
 		showMagicLoginLinkExpiredPage: PropTypes.func.isRequired,
 	};
 
-	state = {
-		hasSubmitted: false,
-	};
+	constructor( props ) {
+		super( props );
+
+		this.state = {
+			hasSubmitted: false,
+		};
+
+		if (
+			isEmpty( props.emailAddress ) ||
+			isEmpty( props.token ) ||
+			isEmpty( props.tokenTime )
+		) {
+			// Required props are really required :)
+			this.props.showMagicLoginLinkExpiredPage();
+		}
+	}
 
 	handleSubmit = ( event ) => {
 		event.preventDefault();

--- a/client/login/magic-login/handle-emailed-link-form.jsx
+++ b/client/login/magic-login/handle-emailed-link-form.jsx
@@ -64,12 +64,12 @@ class HandleEmailedLinkForm extends React.Component {
 		showMagicLoginLinkExpiredPage: PropTypes.func.isRequired,
 	};
 
+	state = {
+		hasSubmitted: false,
+	};
+
 	constructor( props ) {
 		super( props );
-
-		this.state = {
-			hasSubmitted: false,
-		};
 
 		if (
 			isEmpty( props.emailAddress ) ||


### PR DESCRIPTION
Store the query args in the context.state & redirect to the consumption path (without the querystring).

For a better experience, show the "expired or invalid" page when required props are missing -- for example if someone clicks the back button after completing the login.

See: p5TWut-aG-p2 for more context.

### To Test
* Follow test plan in D7024-code 
* When you open the login link, you should see (in the following order):
  * the query arguments disappear
  * the "interstitial" page display with email address present
* Consumption of the link should otherwise work as before