### PR TITLE
Add Pride Styling to the Masterbar

### DIFF
--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -135,7 +135,7 @@ $autobar-height: 20px;
 
 	@include breakpoint( "<480px" ) {
 		& {
-			margin-right: 10px;
+			padding-right: 14px;
 		}
 
 		.masterbar__item-content {

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -321,11 +321,14 @@ $autobar-height: 20px;
 .masterbar__login-links {
 	display: flex;
 	margin-left: auto;
-	margin-right: 5px;
 
 	.masterbar__item-content {
 		display: block;
 		padding-left: 0;
+	}
+
+	.masterbar__item:last-child {
+			padding-right: 20px;
 	}
 }
 

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -33,6 +33,36 @@ $autobar-height: 20px;
 	}
 }
 
+.pride .masterbar {
+	background: linear-gradient(
+		to bottom,
+		#e24c3e 0%,
+		#e24c3e 16.66666666666667%,
+		#f47d3b 16.66666666666667%,
+		#f47d3b 33.33333333333334%,
+		#fdb813 33.33333333333334%,
+		#fdb813 50%,
+		#74bb5d 50%,
+		#74bb5d 66.66666666666667%,
+		#38a6d7 66.66666666666667%,
+		#38a6d7 83.33333333333333%,
+		#8c7ab8 83.33333333333333%,
+		#8c7ab8 100%);
+
+	>.masterbar__item:not( .masterbar__item-title ),
+	>.masterbar__notifications,
+	>.masterbar__login-links a {
+		&:not( .is-active ) {
+			background: rgba( $blue-wordpress, 0.5 );
+		}
+
+		&:hover,
+		&:focus {
+			background: lighten( $masterbar-color, 5% );
+		}
+	}
+}
+
 .masterbar__item {
 	flex: 0 1 auto;
 	display: flex;

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -53,7 +53,7 @@ $autobar-height: 20px;
 	>.masterbar__notifications,
 	>.masterbar__login-links a {
 		&:not( .is-active ) {
-			background: rgba( $blue-wordpress, 0.5 );
+			background: rgba( $blue-wordpress, 0.85 );
 		}
 
 		&:hover,

--- a/client/lib/i18n-utils/utils.js
+++ b/client/lib/i18n-utils/utils.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { filter, find, map } from 'lodash';
+import { find } from 'lodash';
 import { parse } from 'url';
 
 /**
@@ -51,30 +51,6 @@ const i18nUtils = {
 		const locale = parts.pop();
 
 		return 'undefined' === typeof i18nUtils.getLanguage( locale ) ? undefined : locale;
-	},
-
-	/**
-	 * Given the content of an 'AcceptedLanguages' request header, returns an array of the languages.
-	 *
-	 * This differs slightly from other language functions, as it doesn't try to validate the language codes,
-	 * or merge similar language codes.
-	 *
-	 * @param  {string} header - The content of the AcceptedLanguages header.
-	 * @return {Array} An array of language codes in the header, all in lowercase.
-	 */
-	getAcceptedLanguagesFromHeader: function( header ) {
-		if ( ! header ) {
-			return [];
-		}
-
-		return filter( map( header.split( ',' ), lang => {
-			const match = lang.match( /^[A-Z]{2,3}(-[A-Z]{2,3})?/i );
-			if ( ! match ) {
-				return false;
-			}
-
-			return match[ 0 ].toLowerCase();
-		} ) );
 	},
 
 	/**

--- a/client/lib/i18n-utils/utils.js
+++ b/client/lib/i18n-utils/utils.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { find } from 'lodash';
+import { filter, find, map } from 'lodash';
 import { parse } from 'url';
 
 /**
@@ -51,6 +51,26 @@ const i18nUtils = {
 		const locale = parts.pop();
 
 		return 'undefined' === typeof i18nUtils.getLanguage( locale ) ? undefined : locale;
+	},
+
+	/**
+	 * Given the content of an 'AcceptedLanguages' request header, returns an array of the languages.
+	 *
+	 * This differs slightly from other language functions, as it doesn't try to validate the language codes,
+	 * or merge similar language codes.
+	 *
+	 * @param  {string} header - The content of the AcceptedLanguages header.
+	 * @return {array} An array of language codes in the header, all in lowercase.
+	 */
+	getAcceptedLanguagesFromHeader: function( header ) {
+		return filter( map( header.split( ',' ), lang => {
+			const match = lang.match( /^[A-Z]{2,3}(-[A-Z]{2,3})?/i );
+			if ( ! match ) {
+				return false;
+			}
+
+			return match[ 0 ].toLowerCase();
+		} ) );
 	},
 
 	/**

--- a/client/lib/i18n-utils/utils.js
+++ b/client/lib/i18n-utils/utils.js
@@ -60,9 +60,13 @@ const i18nUtils = {
 	 * or merge similar language codes.
 	 *
 	 * @param  {string} header - The content of the AcceptedLanguages header.
-	 * @return {array} An array of language codes in the header, all in lowercase.
+	 * @return {Array} An array of language codes in the header, all in lowercase.
 	 */
 	getAcceptedLanguagesFromHeader: function( header ) {
+		if ( ! header ) {
+			return [];
+		}
+
 		return filter( map( header.split( ',' ), lang => {
 			const match = lang.match( /^[A-Z]{2,3}(-[A-Z]{2,3})?/i );
 			if ( ! match ) {

--- a/server/pages/index.jade
+++ b/server/pages/index.jade
@@ -55,7 +55,7 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class=isFluidWidth ? 'is-fluid-width'
 			else
 				link(rel='stylesheet', href=urls['style.css'])
 
-	body( class=[ isRTL ? 'rtl' : '', pride ? 'pride' : '' ] )
+	body( class=bodyClasses )
 		if renderedLayout
 			#wpcom.wpcom-site!= renderedLayout
 		else

--- a/server/pages/index.jade
+++ b/server/pages/index.jade
@@ -55,7 +55,7 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class=isFluidWidth ? 'is-fluid-width'
 			else
 				link(rel='stylesheet', href=urls['style.css'])
 
-	body(class=isRTL ? 'rtl' : '')
+	body( class=[ isRTL ? 'rtl' : '', pride ? 'pride' : '' ] )
 		if renderedLayout
 			#wpcom.wpcom-site!= renderedLayout
 		else

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -138,7 +138,7 @@ function getDefaultContext( request ) {
 	}
 
 	const acceptedLanguages = getAcceptedLanguagesFromHeader( request.headers[ 'accept-language' ] );
-	const pride = indexOf( prideLanguages, '*' ) > -1 || intersection( prideLanguages, acceptedLanguages );
+	const pride = indexOf( prideLanguages, '*' ) > -1 || intersection( prideLanguages, acceptedLanguages ).length > 0;
 
 	const context = Object.assign( {}, request.context, {
 		compileDebug: config( 'env' ) === 'development' ? true : false,

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -153,6 +153,7 @@ function getAcceptedLanguagesFromHeader( header ) {
 
 function getDefaultContext( request ) {
 	let initialServerState = {};
+	const bodyClasses = [];
 	const cacheKey = getCacheKey( request );
 
 	if ( cacheKey ) {
@@ -161,7 +162,13 @@ function getDefaultContext( request ) {
 	}
 
 	const acceptedLanguages = getAcceptedLanguagesFromHeader( request.headers[ 'accept-language' ] );
-	const pride = prideLanguages.indexOf( '*' ) > -1 || intersection( prideLanguages, acceptedLanguages ).length > 0;
+	if ( prideLanguages.indexOf( '*' ) > -1 || intersection( prideLanguages, acceptedLanguages ).length > 0 ) {
+		bodyClasses.push( 'pride' );
+	}
+
+	if ( config( 'rtl' ) ) {
+		bodyClasses.push( 'rtl' );
+	}
 
 	const context = Object.assign( {}, request.context, {
 		compileDebug: config( 'env' ) === 'development' ? true : false,
@@ -179,7 +186,7 @@ function getDefaultContext( request ) {
 		abTestHelper: !! config.isEnabled( 'dev/test-helper' ),
 		devDocsURL: '/devdocs',
 		store: createReduxStore( initialServerState ),
-		pride: pride,
+		bodyClasses,
 	} );
 
 	context.app = {


### PR DESCRIPTION
Some years ago, we rainbow-ed the Masterbar in support of SCOTUS' marriage equality ruling.

To show our support for regional marriage equality initiatives, this PR allows the rainbow Masterbar to be enabled by browser language, giving us a way to target visitors based on a region they're probably associated with, not just where they're located.

For example, by adding `en-AU` as a `prideLanguage`, we catch most people in Australia, as well as Australians around the world.

Props @MichaelArestad for the first Masterbar rainbow design, which I've shamelessly copied.

#### Reviews

There are a few reviews needed for this:

- [x] Design - Does the CSS need any tweaking?
- [x] i18n - Is the `i18n-utils` module a good place for `getAcceptedLanguagesFromHeader()`?
- [x] Code - This is adding the class deep in the guts of the SSR code. Is it likely to cause any SSR problems?