### PR TITLE
Extensions: Zoninator - Add DeleteZoneDialog to Edit Zone tab

### DIFF
--- a/client/extensions/zoninator/components/settings/zone/delete-zone-dialog.jsx
+++ b/client/extensions/zoninator/components/settings/zone/delete-zone-dialog.jsx
@@ -8,29 +8,28 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import Button from 'components/button';
 import Dialog from 'components/dialog';
 
 const DeleteZoneDialog = ( {
 	onCancel,
 	onConfirm,
-	siteSlug,
 	translate,
 	zoneName,
 } ) => {
 	const buttons = [
-		{ action: 'cancel', label: translate( 'Cancel' ), onClick: onCancel },
-		{ action: 'delete', label: translate( 'Delete' ), onClick: onConfirm, isPrimary: true },
+		<Button onClick={ onCancel }>{ translate( 'Cancel' ) }</Button>,
+		<Button primary scary onClick={ onConfirm }>{ translate( 'Delete' ) }</Button>,
 	];
 
 	return (
 		<Dialog isVisible buttons={ buttons } onClose={ onCancel }>
 			{ translate(
-				'Are you sure you want to remove {{strong}}zone "%(zone)s"{{/strong}} from %(site)s?{{br/}}' +
+				'Are you sure you want to remove {{strong}}zone "%(zone)s"{{/strong}} from the site?{{br/}}' +
 					'{{em}}This action cannot be reversed once completed.{{/em}}',
 				{
 					args: {
 						zone: zoneName,
-						site: siteSlug,
 					},
 					components: {
 						br: <br />,
@@ -46,13 +45,11 @@ const DeleteZoneDialog = ( {
 DeleteZoneDialog.propTypes = {
 	onCancel: PropTypes.func.isRequired,
 	onConfirm: PropTypes.func.isRequired,
-	siteSlug: PropTypes.string,
 	translate: PropTypes.func.isRequired,
 	zoneName: PropTypes.string,
 };
 
 DeleteZoneDialog.defaultProps = {
-	siteSlug: '',
 	zoneName: '',
 };
 

--- a/client/extensions/zoninator/components/settings/zone/delete-zone-dialog.jsx
+++ b/client/extensions/zoninator/components/settings/zone/delete-zone-dialog.jsx
@@ -1,0 +1,59 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import PropTypes from 'prop-types';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Dialog from 'components/dialog';
+
+const DeleteZoneDialog = ( {
+	onCancel,
+	onConfirm,
+	siteSlug,
+	translate,
+	zoneName,
+} ) => {
+	const buttons = [
+		{ action: 'cancel', label: translate( 'Cancel' ), onClick: onCancel },
+		{ action: 'delete', label: translate( 'Delete' ), onClick: onConfirm, isPrimary: true },
+	];
+
+	return (
+		<Dialog isVisible buttons={ buttons } onClose={ onCancel }>
+			{ translate(
+				'Are you sure you want to remove {{strong}}zone "%(zone)s"{{/strong}} from %(site)s?{{br/}}' +
+					'{{em}}This action cannot be reversed once completed.{{/em}}',
+				{
+					args: {
+						zone: zoneName,
+						site: siteSlug,
+					},
+					components: {
+						br: <br />,
+						em: <em />,
+						strong: <strong />,
+					},
+				},
+			) }
+		</Dialog>
+	);
+};
+
+DeleteZoneDialog.propTypes = {
+	onCancel: PropTypes.func.isRequired,
+	onConfirm: PropTypes.func.isRequired,
+	siteSlug: PropTypes.string,
+	translate: PropTypes.func.isRequired,
+	zoneName: PropTypes.string,
+};
+
+DeleteZoneDialog.defaultProps = {
+	siteSlug: '',
+	zoneName: '',
+};
+
+export default localize( DeleteZoneDialog );

--- a/client/extensions/zoninator/components/settings/zone/index.jsx
+++ b/client/extensions/zoninator/components/settings/zone/index.jsx
@@ -13,6 +13,7 @@ import { flowRight, noop } from 'lodash';
 import Button from 'components/button';
 import HeaderCake from 'components/header-cake';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
+import DeleteZoneDialog from './delete-zone-dialog';
 import ZoneDetailsForm from '../../forms/zone-details-form';
 import ZoneContentForm from '../../forms/zone-content-form';
 import { settingsPath } from '../../../app/util';
@@ -25,16 +26,34 @@ class Zone extends Component {
 		translate: PropTypes.func.isRequired,
 	}
 
+	state = {
+		showDeleteDialog: false,
+	}
+
+	showDeleteDialog = () => this.setState( { showDeleteDialog: true } );
+
+	hideDeleteDialog = () => this.setState( { showDeleteDialog: false } );
+
 	render() {
 		const { siteId, siteSlug, translate } = this.props;
+		const { showDeleteDialog } = this.state;
 
 		return (
 			<div>
 				<HeaderCake
 					backHref={ `${ settingsPath }/${ siteSlug }` }
-					actionButton={ <Button compact primary scary>{ translate( 'Delete' ) }</Button> } >
+					actionButton={ <Button compact primary scary onClick={ this.showDeleteDialog }>{ translate( 'Delete' ) }</Button> } >
 					{ translate( 'Edit zone' ) }
 				</HeaderCake>
+
+				{
+					showDeleteDialog &&
+					<DeleteZoneDialog
+						siteSlug={ siteSlug }
+						zoneName="[zone name]"
+						onConfirm={ noop }
+						onCancel={ this.hideDeleteDialog } />
+					}
 
 				<ZoneDetailsForm label={ translate( 'Zone label' ) } siteId={ siteId } onSubmit={ noop } />
 
@@ -44,7 +63,7 @@ class Zone extends Component {
 	}
 }
 
-const connectComponent = connect( state => ( {
+const connectComponent = connect( ( state ) => ( {
 	siteId: getSelectedSiteId( state ),
 	siteSlug: getSelectedSiteSlug( state ),
 } ) );

--- a/client/extensions/zoninator/components/settings/zone/index.jsx
+++ b/client/extensions/zoninator/components/settings/zone/index.jsx
@@ -49,7 +49,6 @@ class Zone extends Component {
 				{
 					showDeleteDialog &&
 					<DeleteZoneDialog
-						siteSlug={ siteSlug }
 						zoneName="[zone name]"
 						onConfirm={ noop }
 						onCancel={ this.hideDeleteDialog } />


### PR DESCRIPTION
This PR adds a confirmation dialog to the **Delete** button on Edit Zone tab in Zoninator extension.
The component/tab is not wired to the state yet - hence the temporary **[zone name]** placeholder.

<img width="654" alt="screen shot 2017-08-31 at 12 29 37" src="https://user-images.githubusercontent.com/8056203/29919124-5e71b6c8-8e48-11e7-9fda-94fba6e3cd87.png">

# Testing

- Go to `/extensions/zoninator` and choose a site with Zoninator installed.
- Open the edit tab for one of the zones.
- Click **Delete** - the dialog should appear.
- Make sure you can close the dialog by clicking **Cancel** or clicking outside of it. No action is expected when clicking **Delete** on the dialog.