### PR TITLE
Site Settings: Delete Atomic sites

### DIFF
--- a/client/my-sites/site-settings/controller.js
+++ b/client/my-sites/site-settings/controller.js
@@ -24,7 +24,7 @@ import ThemeSetup from './theme-setup';
 import ManageConnection from './manage-connection';
 import { getSelectedSite, getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
-import { canCurrentUser, isVipSite } from 'state/selectors';
+import { canCurrentUser, isSiteAutomatedTransfer, isVipSite } from 'state/selectors';
 import { SITES_ONCE_CHANGED } from 'state/action-types';
 import { setSection } from 'state/ui/actions';
 
@@ -36,8 +36,8 @@ function canDeleteSite( state, siteId ) {
 		return false;
 	}
 
-	if ( isJetpackSite( state, siteId ) ) {
-		// Current user can't delete a jetpack site
+	if ( isJetpackSite( state, siteId ) && ! isSiteAutomatedTransfer( state, siteId ) ) {
+		// Current user can't delete a Jetpack site, but can request to delete an Atomic site
 		return false;
 	}
 

--- a/client/my-sites/site-settings/delete-site/index.jsx
+++ b/client/my-sites/site-settings/delete-site/index.jsx
@@ -217,14 +217,15 @@ class DeleteSite extends Component {
 						<ActionPanelTitle>{ strings.exportContentFirst }</ActionPanelTitle>
 						<p>
 							{ translate(
-								'Before deleting your site, please take the time to export your content now. ' +
-									'All your posts, pages, and settings will be packaged into a .zip file that you can use in ' +
-									'the future to resume where you left off.'
+								'Before deleting your site, take a moment to export your content. ' +
+									'This will package the content of all your posts and pages, ' +
+									"along with your site's settings, into a .zip file. " +
+									"If you ever want to re-create your site, you'll be able to import the .zip file to a new site."
 							) }
 						</p>
 						<p>
 							{ translate(
-								'Keep in mind that this content {{strong}}can not{{/strong}} be recovered in the future.',
+								'This content {{strong}}can not{{/strong}} be recovered once your delete this site.',
 								{
 									components: {
 										strong: <strong />,
@@ -266,31 +267,51 @@ class DeleteSite extends Component {
 								</li>
 							</ul>
 						</ActionPanelFigure>
-						<p>
-							{ translate(
-								'This action {{strong}}can not{{/strong}} be undone. Deleting the site will remove all content, ' +
-									'contributors, domains, and upgrades from the site.',
-								{
-									components: {
-										strong: <strong />,
-									},
-								}
-							) }
-						</p>
-						<p>
-							{ translate(
-								"If you're unsure about what will be deleted or need any help, not to worry, our support team " +
-									'is here to answer any questions you might have.'
-							) }
-						</p>
-						<p>
-							<a
-								className="delete-site__body-text-link settings-action-panel__body-text-link"
-								href="/help/contact"
-							>
-								{ strings.contactSupport }
-							</a>
-						</p>
+						{ ! isAtomic && (
+							<div>
+								<p>
+									{ translate(
+										'Deletion {{strong}}can not{{/strong}} be undone, ' +
+											'and will remove all content, contributors, domains, and upgrades from this site.',
+										{
+											components: {
+												strong: <strong />,
+											},
+										}
+									) }
+								</p>
+								<p>
+									{ translate(
+										"If you're unsure about what deletion means or have any other questions, " +
+											'please chat with someone from our support team before proceeding.'
+									) }
+								</p>
+								<p>
+									<a
+										className="delete-site__body-text-link settings-action-panel__body-text-link"
+										href="/help/contact"
+									>
+										{ strings.contactSupport }
+									</a>
+								</p>
+							</div>
+						) }
+						{ isAtomic && (
+							<div>
+								<p>
+									{ translate(
+										"To delete this site, you'll need to contact our support team. Deletion can not be undone, " +
+											'and will remove all content, contributors, domains, and upgrades from this site.'
+									) }
+								</p>
+								<p>
+									{ translate(
+										"If you're unsure about what deletion means or have any other questions, " +
+											"you'll have a chance to chat with someone from our support team before anything happens."
+									) }
+								</p>
+							</div>
+						) }
 					</ActionPanelBody>
 					<ActionPanelFooter>
 						{ ! isAtomic && (

--- a/client/my-sites/site-settings/delete-site/index.jsx
+++ b/client/my-sites/site-settings/delete-site/index.jsx
@@ -4,8 +4,8 @@
  * @format
  */
 
-import PropTypes from 'prop-types';
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import page from 'page';
 import { some } from 'lodash';
@@ -31,6 +31,7 @@ import Notice from 'components/notice';
 import QuerySitePurchases from 'components/data/query-site-purchases';
 import { deleteSite } from 'state/sites/actions';
 import { setSelectedSiteId } from 'state/ui/actions';
+import { isSiteAutomatedTransfer } from 'state/selectors';
 
 class DeleteSite extends Component {
 	static propTypes = {
@@ -131,7 +132,7 @@ class DeleteSite extends Component {
 	};
 
 	render() {
-		const { siteDomain, siteId, siteSlug, translate } = this.props;
+		const { isAtomic, siteDomain, siteId, siteSlug, translate } = this.props;
 		const exportLink = '/settings/export/' + siteSlug;
 		const deleteDisabled =
 			typeof this.state.confirmDomain !== 'string' ||
@@ -234,7 +235,7 @@ class DeleteSite extends Component {
 					</ActionPanelBody>
 					<ActionPanelFooter>
 						<Button
-							className="settings-action-panel__export-button"
+							className="delete-site__export-button settings-action-panel__export-button"
 							disabled={ ! siteId }
 							onClick={ this._checkSiteLoaded }
 							href={ exportLink }
@@ -283,20 +284,30 @@ class DeleteSite extends Component {
 							) }
 						</p>
 						<p>
-							<a className="settings-action-panel__body-text-link" href="/help/contact">
+							<a
+								className="delete-site__body-text-link settings-action-panel__body-text-link"
+								href="/help/contact"
+							>
 								{ strings.contactSupport }
 							</a>
 						</p>
 					</ActionPanelBody>
 					<ActionPanelFooter>
-						<Button
-							scary
-							disabled={ ! siteId || ! this.props.hasLoadedSitePurchasesFromServer }
-							onClick={ this.handleDeleteSiteClick }
-						>
-							<Gridicon icon="trash" />
-							{ strings.deleteSite }
-						</Button>
+						{ ! isAtomic && (
+							<Button
+								scary
+								disabled={ ! siteId || ! this.props.hasLoadedSitePurchasesFromServer }
+								onClick={ this.handleDeleteSiteClick }
+							>
+								<Gridicon icon="trash" />
+								{ strings.deleteSite }
+							</Button>
+						) }
+						{ isAtomic && (
+							<Button primary href="/help/contact">
+								{ strings.contactSupport }
+							</Button>
+						) }
 					</ActionPanelFooter>
 					<DeleteSiteWarningDialog
 						isVisible={ this.state.showWarningDialog }
@@ -344,6 +355,7 @@ export default connect(
 		const siteSlug = getSelectedSiteSlug( state );
 		return {
 			hasLoadedSitePurchasesFromServer: hasLoadedSitePurchasesFromServer( state ),
+			isAtomic: isSiteAutomatedTransfer( state, siteId ),
 			siteDomain,
 			siteId,
 			sitePurchases: getSitePurchases( state, siteId ),

--- a/client/my-sites/site-settings/site-tools/index.jsx
+++ b/client/my-sites/site-settings/site-tools/index.jsx
@@ -156,7 +156,7 @@ class SiteTools extends Component {
 	checkForSubscriptions = event => {
 		trackDeleteSiteOption( 'delete-site' );
 
-		if ( ! some( this.props.sitePurchases, 'active' ) ) {
+		if ( this.props.isAtomic || ! some( this.props.sitePurchases, 'active' ) ) {
 			return true;
 		}
 
@@ -185,6 +185,7 @@ export default connect( state => {
 	}
 
 	return {
+		isAtomic,
 		siteSlug,
 		sitePurchases: getSitePurchases( state, siteId ),
 		purchasesError: getPurchasesError( state ),
@@ -193,7 +194,7 @@ export default connect( state => {
 		showChangeAddress: ! isJetpack && ! isVip,
 		showThemeSetup: config.isEnabled( 'settings/theme-setup' ) && ! isJetpack && ! isVip,
 		showDeleteContent: ! isJetpack && ! isVip,
-		showDeleteSite: ! isJetpack && ! isVip && sitePurchasesLoaded,
+		showDeleteSite: ( ! isJetpack || isAtomic ) && ! isVip && sitePurchasesLoaded,
 		showManageConnection: isJetpack && ! isAtomic,
 	};
 } )( localize( SiteTools ) );

--- a/client/my-sites/site-settings/site-tools/index.jsx
+++ b/client/my-sites/site-settings/site-tools/index.jsx
@@ -74,7 +74,7 @@ class SiteTools extends Component {
 		);
 		const deleteSite = translate( 'Delete your site permanently' );
 		const deleteSiteText = translate(
-			'Delete all your posts, pages, media and data, ' + "and give up your site's address."
+			"Delete all your posts, pages, media, and data, and give up your site's address."
 		);
 		const manageConnectionTitle = translate( 'Manage your connection' );
 		const manageConnectionText = translate(
@@ -84,7 +84,9 @@ class SiteTools extends Component {
 		const importTitle = translate( 'Import' );
 		const importText = translate( 'Import content from another WordPress or Medium site.' );
 		const exportTitle = translate( 'Export' );
-		const exportText = translate( 'Export content from your site. You own your data.' );
+		const exportText = translate(
+			'Export content from your site. You own your data — take it anywhere!'
+		);
 
 		let changeAddressText = translate( "Register a new domain or change your site's address." );
 		if ( ! config.isEnabled( 'upgrades/domain-search' ) ) {


### PR DESCRIPTION
Fixes 290-gh-automated-transfer

Add the Delete Site flow to Atomic sites.
As there isn't an automated Atomic sites deletion, instead of showing a "Delete Site" button, we prompt the user to contact support.

This also improves the copy of both the Site Tools and the Delete Site pages.

### Screenshots

| Simple Site | Atomic Site |
| --- | --- |
| <img width="733" alt="screen shot 2017-11-09 at 11 34 11" src="https://user-images.githubusercontent.com/2070010/32603564-15ce279a-c542-11e7-9a7f-92d89e03dab7.png"> | <img width="737" alt="screen shot 2017-11-09 at 11 34 44" src="https://user-images.githubusercontent.com/2070010/32603570-1b86d77c-c542-11e7-8795-8fe042bb86ab.png"> |
| <img width="733" alt="screen shot 2017-11-09 at 11 33 59" src="https://user-images.githubusercontent.com/2070010/32603573-1fa980b6-c542-11e7-8459-d373b1655167.png"> | <img width="733" alt="screen shot 2017-11-09 at 11 34 30" src="https://user-images.githubusercontent.com/2070010/32603578-23be8a3e-c542-11e7-8313-4f31b79441bc.png"> |