### PR TITLE
Comments: add optional "read more" link to post actions

### DIFF
--- a/client/blocks/comments/comment-actions.jsx
+++ b/client/blocks/comments/comment-actions.jsx
@@ -36,6 +36,7 @@ const CommentActions = ( {
 	editComment,
 	editCommentCancel,
 	showReadMore,
+	onReadMore,
 } ) => {
 	const showReplyButton = post && post.discussion && post.discussion.comments_open === true;
 	const showCancelReplyButton = activeReplyCommentId === commentId;
@@ -50,7 +51,7 @@ const CommentActions = ( {
 	return (
 		<div className="comments__comment-actions">
 			{ showReadMore &&
-				<button className="comments__comment-actions-read-more" onClick={ noop }>
+				<button className="comments__comment-actions-read-more" onClick={ onReadMore }>
 					<Gridicon
 						icon="chevron-down"
 						size={ 18 }
@@ -125,6 +126,10 @@ const CommentActions = ( {
 				</div> }
 		</div>
 	);
+};
+
+CommentActions.defaultProps = {
+	onReadMore: noop,
 };
 
 const mapDispatchToProps = ( dispatch, ownProps ) => {

--- a/client/blocks/comments/comment-actions.jsx
+++ b/client/blocks/comments/comment-actions.jsx
@@ -57,7 +57,7 @@ const CommentActions = ( {
 						size={ 18 }
 						className="comments__comment-actions-read-more-icon"
 					/>
-					{ translate( 'Read more' ) }
+					{ translate( 'Read More' ) }
 				</button> }
 			{ showReplyButton &&
 				<button className="comments__comment-actions-reply" onClick={ handleReply }>

--- a/client/blocks/comments/comment-actions.jsx
+++ b/client/blocks/comments/comment-actions.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -6,6 +7,7 @@ import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'gridicons';
 import classnames from 'classnames';
+import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -33,6 +35,7 @@ const CommentActions = ( {
 	spamComment,
 	editComment,
 	editCommentCancel,
+	showReadMore,
 } ) => {
 	const showReplyButton = post && post.discussion && post.discussion.comments_open === true;
 	const showCancelReplyButton = activeReplyCommentId === commentId;
@@ -46,6 +49,15 @@ const CommentActions = ( {
 
 	return (
 		<div className="comments__comment-actions">
+			{ showReadMore &&
+				<button className="comments__comment-actions-read-more" onClick={ noop }>
+					<Gridicon
+						icon="chevron-down"
+						size={ 18 }
+						className="comments__comment-actions-read-more-icon"
+					/>
+					{ translate( 'Read more' ) }
+				</button> }
 			{ showReplyButton &&
 				<button className="comments__comment-actions-reply" onClick={ handleReply }>
 					<Gridicon icon="reply" size={ 18 } />

--- a/client/blocks/comments/docs/post-comment-example.jsx
+++ b/client/blocks/comments/docs/post-comment-example.jsx
@@ -79,6 +79,15 @@ const commentsTree = {
 	},
 };
 
+const { singleLine, excerpt, full } = POST_COMMENT_DISPLAY_TYPES;
+const commentsToShow = {
+	0: singleLine,
+	1: excerpt,
+	2: full,
+	3: excerpt,
+	4: excerpt,
+};
+
 export default class PostCommentExample extends React.Component {
 	static displayName = 'PostCommentExample';
 
@@ -88,45 +97,51 @@ export default class PostCommentExample extends React.Component {
 				<Card compact>
 					<PostComment
 						showNestingReplyArrow
+						enableCaterpillar
 						commentId={ 0 }
 						depth={ 0 }
 						commentsTree={ commentsTree }
-						displayType={ POST_COMMENT_DISPLAY_TYPES.singleLine }
+						commentsToShow={ commentsToShow }
 					/>
 					<PostComment
 						showNestingReplyArrow
+						enableCaterpillar
 						commentId={ 2 }
 						depth={ 0 }
 						commentsTree={ commentsTree }
-						displayType={ POST_COMMENT_DISPLAY_TYPES.excerpt }
+						commentsToShow={ commentsToShow }
 					/>
 					<PostComment
 						showNestingReplyArrow
+						enableCaterpillar
 						commentId={ 3 }
 						depth={ 0 }
 						commentsTree={ commentsTree }
-						displayType={ POST_COMMENT_DISPLAY_TYPES.excerpt }
+						commentsToShow={ commentsToShow }
 					/>
 					<PostComment
 						showNestingReplyArrow
+						enableCaterpillar
 						commentId={ 3 }
 						depth={ 0 }
 						commentsTree={ commentsTree }
-						displayType={ POST_COMMENT_DISPLAY_TYPES.singleLine }
+						commentsToShow={ commentsToShow }
 					/>
 					<PostComment
 						showNestingReplyArrow
+						enableCaterpillar
 						commentId={ 4 }
 						depth={ 0 }
 						commentsTree={ commentsTree }
-						displayType={ POST_COMMENT_DISPLAY_TYPES.excerpt }
+						commentsToShow={ commentsToShow }
 					/>
 					<PostComment
 						showNestingReplyArrow
+						enableCaterpillar
 						commentId={ 4 }
 						depth={ 0 }
 						commentsTree={ commentsTree }
-						displayType={ POST_COMMENT_DISPLAY_TYPES.singleLine }
+						commentsToShow={ commentsToShow }
 					/>
 				</Card>
 			</div>

--- a/client/blocks/comments/post-comment-content.jsx
+++ b/client/blocks/comments/post-comment-content.jsx
@@ -10,7 +10,6 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal Dependencies
  */
-import withDimensions from 'lib/with-dimensions';
 import AutoDirection from 'components/auto-direction';
 import Emojify from 'components/emojify';
 
@@ -19,8 +18,6 @@ class PostCommentContent extends React.Component {
 		content: PropTypes.string.isRequired,
 		isPlaceholder: PropTypes.bool,
 		className: PropTypes.string,
-		onMoreClicked: PropTypes.func,
-		hideMore: PropTypes.bool,
 	};
 
 	render() {
@@ -46,15 +43,9 @@ class PostCommentContent extends React.Component {
 					<Emojify>
 						<div
 							className="comments__comment-content"
-							ref={ this.props.setWithDimensionsRef }
 							dangerouslySetInnerHTML={ { __html: this.props.content } }
 						/>
 					</Emojify>
-					{ this.props.overflowY &&
-						! this.props.hideMore &&
-						<span className="comments__comment-read-more" onClick={ this.props.onMoreClicked }>
-							{ this.props.translate( 'Read More' ) }
-						</span> }
 				</div>
 			</AutoDirection>
 		);
@@ -62,4 +53,4 @@ class PostCommentContent extends React.Component {
 	}
 }
 
-export default localize( withDimensions( PostCommentContent ) );
+export default localize( PostCommentContent );

--- a/client/blocks/comments/post-comment-content.jsx
+++ b/client/blocks/comments/post-comment-content.jsx
@@ -18,6 +18,11 @@ class PostCommentContent extends React.Component {
 		content: PropTypes.string.isRequired,
 		isPlaceholder: PropTypes.bool,
 		className: PropTypes.string,
+		setWithDimensionsRef: PropTypes.func,
+	};
+
+	static defaultProps = {
+		setWithDimensionsRef: () => {},
 	};
 
 	render() {
@@ -43,6 +48,7 @@ class PostCommentContent extends React.Component {
 					<Emojify>
 						<div
 							className="comments__comment-content"
+							ref={ this.props.setWithDimensionsRef }
 							dangerouslySetInnerHTML={ { __html: this.props.content } }
 						/>
 					</Emojify>

--- a/client/blocks/comments/post-comment.jsx
+++ b/client/blocks/comments/post-comment.jsx
@@ -46,6 +46,7 @@ class PostComment extends React.PureComponent {
 		maxDepth: PropTypes.number,
 		showNestingReplyArrow: PropTypes.bool,
 		displayType: PropTypes.oneOf( values( POST_COMMENT_DISPLAY_TYPES ) ),
+		showReadMoreInActions: PropTypes.bool,
 
 		/**
 		 * If commentsToShow is not provided then it is assumed that all child comments should be displayed.
@@ -74,6 +75,7 @@ class PostComment extends React.PureComponent {
 		onCommentSubmit: noop,
 		showNestingReplyArrow: false,
 		displayType: POST_COMMENT_DISPLAY_TYPES.full,
+		showReadMoreInActions: false,
 	};
 
 	state = {
@@ -381,6 +383,7 @@ class PostComment extends React.PureComponent {
 					editCommentCancel={ this.props.onEditCommentCancel }
 					handleReply={ this.handleReply }
 					onReplyCancel={ this.props.onReplyCancel }
+					showReadMore={ this.props.showReadMoreInActions }
 				/>
 
 				{ haveReplyWithError ? null : this.renderCommentForm() }

--- a/client/blocks/comments/post-comment.jsx
+++ b/client/blocks/comments/post-comment.jsx
@@ -83,8 +83,6 @@ class PostComment extends React.PureComponent {
 		showFull: false,
 	};
 
-	handleReadMoreClicked = () => this.setState( { showFull: true } );
-
 	handleToggleRepliesClick = () => {
 		this.setState( { showReplies: ! this.state.showReplies } );
 	};
@@ -252,12 +250,14 @@ class PostComment extends React.PureComponent {
 	};
 
 	onReadMore = () => {
-		this.props.expandComments( {
-			siteId: this.props.post.site_ID,
-			commentIds: [ this.props.commentId ],
-			postId: this.props.post.ID,
-			displayType: POST_COMMENT_DISPLAY_TYPES.full,
-		} );
+		this.setState( { showFull: true } );
+		this.props.post &&
+			this.props.expandComments( {
+				siteId: this.props.post.site_ID,
+				commentIds: [ this.props.commentId ],
+				postId: this.props.post.ID,
+				displayType: POST_COMMENT_DISPLAY_TYPES.full,
+			} );
 	};
 
 	render() {
@@ -396,7 +396,7 @@ class PostComment extends React.PureComponent {
 					editCommentCancel={ this.props.onEditCommentCancel }
 					handleReply={ this.handleReply }
 					onReplyCancel={ this.props.onReplyCancel }
-					showReadMore={ this.props.overflowY }
+					showReadMore={ this.props.overflowY && ! this.state.showFull }
 					onReadMore={ this.onReadMore }
 				/>
 

--- a/client/blocks/comments/post-comment.jsx
+++ b/client/blocks/comments/post-comment.jsx
@@ -252,12 +252,12 @@ class PostComment extends React.PureComponent {
 	};
 
 	onReadMore = () => {
-		this.props.expandComments(
-			this.props.post.site_ID,
-			this.props.commentId,
-			this.props.post.ID,
-			POST_COMMENT_DISPLAY_TYPES.full
-		);
+		this.props.expandComments( {
+			siteId: this.props.post.site_ID,
+			commentId: this.props.commentId,
+			postId: this.props.post.ID,
+			displayType: POST_COMMENT_DISPLAY_TYPES.full,
+		} );
 	};
 
 	render() {

--- a/client/blocks/comments/post-comment.jsx
+++ b/client/blocks/comments/post-comment.jsx
@@ -31,6 +31,7 @@ import Emojify from 'components/emojify';
 import { POST_COMMENT_DISPLAY_TYPES } from 'state/comments/constants';
 import ConversationCaterpillar from 'blocks/conversation-caterpillar';
 import withDimensions from 'lib/with-dimensions';
+import { expandComments } from 'state/comments/actions';
 
 class PostComment extends React.PureComponent {
 	static propTypes = {
@@ -247,6 +248,15 @@ class PostComment extends React.PureComponent {
 				</strong>;
 	};
 
+	onReadMore = () => {
+		this.props.expandComments(
+			this.props.post.site_ID,
+			this.props.commentId,
+			this.props.post.ID,
+			POST_COMMENT_DISPLAY_TYPES.full
+		);
+	};
+
 	render() {
 		const {
 			commentsTree,
@@ -387,6 +397,7 @@ class PostComment extends React.PureComponent {
 					handleReply={ this.handleReply }
 					onReplyCancel={ this.props.onReplyCancel }
 					showReadMore={ this.props.showReadMoreInActions }
+					onReadMore={ this.onReadMore }
 				/>
 
 				{ haveReplyWithError ? null : this.renderCommentForm() }
@@ -405,6 +416,9 @@ class PostComment extends React.PureComponent {
 	}
 }
 
-export default connect( state => ( {
-	currentUser: getCurrentUser( state ),
-} ) )( withDimensions( PostComment ) );
+export default connect(
+	state => ( {
+		currentUser: getCurrentUser( state ),
+	} ),
+	{ expandComments }
+)( withDimensions( PostComment ) );

--- a/client/blocks/comments/post-comment.jsx
+++ b/client/blocks/comments/post-comment.jsx
@@ -356,14 +356,15 @@ class PostComment extends React.PureComponent {
 					: null }
 
 				{ this.props.activeEditCommentId !== this.props.commentId &&
-					<PostCommentContent
-						ref={ this.props.setWithDimensionsRef }
-						content={ comment.content }
-						isPlaceholder={ comment.isPlaceholder }
-						className={ displayType }
-						onMoreClicked={ this.handleReadMoreClicked }
-						hideMore={ displayType === POST_COMMENT_DISPLAY_TYPES.full }
-					/> }
+					<div className="comments__content-wrapper" ref={ this.props.setWithDimensionsRef }>
+						<PostCommentContent
+							content={ comment.content }
+							isPlaceholder={ comment.isPlaceholder }
+							className={ displayType }
+							onMoreClicked={ this.handleReadMoreClicked }
+							hideMore={ displayType === POST_COMMENT_DISPLAY_TYPES.full }
+						/>
+					</div> }
 
 				{ isEnabled( 'comments/moderation-tools-in-posts' ) &&
 					this.props.activeEditCommentId === this.props.commentId &&

--- a/client/blocks/comments/post-comment.jsx
+++ b/client/blocks/comments/post-comment.jsx
@@ -372,8 +372,6 @@ class PostComment extends React.PureComponent {
 						setWithDimensionsRef={ this.props.setWithDimensionsRef }
 						isPlaceholder={ comment.isPlaceholder }
 						className={ displayType }
-						onMoreClicked={ this.handleReadMoreClicked }
-						hideMore={ displayType === POST_COMMENT_DISPLAY_TYPES.full }
 					/> }
 
 				{ isEnabled( 'comments/moderation-tools-in-posts' ) &&
@@ -396,7 +394,7 @@ class PostComment extends React.PureComponent {
 					editCommentCancel={ this.props.onEditCommentCancel }
 					handleReply={ this.handleReply }
 					onReplyCancel={ this.props.onReplyCancel }
-					showReadMore={ this.props.showReadMoreInActions }
+					showReadMore={ this.props.overflowY }
 					onReadMore={ this.onReadMore }
 				/>
 
@@ -408,9 +406,6 @@ class PostComment extends React.PureComponent {
 						parentCommentId={ commentId }
 					/> }
 				{ this.renderRepliesList() }
-				<span>
-					overflowY: { this.props.overflowY }
-				</span>
 			</li>
 		);
 	}

--- a/client/blocks/comments/post-comment.jsx
+++ b/client/blocks/comments/post-comment.jsx
@@ -30,6 +30,7 @@ import CommentActions from './comment-actions';
 import Emojify from 'components/emojify';
 import { POST_COMMENT_DISPLAY_TYPES } from 'state/comments/constants';
 import ConversationCaterpillar from 'blocks/conversation-caterpillar';
+import withDimensions from 'lib/with-dimensions';
 
 class PostComment extends React.PureComponent {
 	static propTypes = {
@@ -356,6 +357,7 @@ class PostComment extends React.PureComponent {
 
 				{ this.props.activeEditCommentId !== this.props.commentId &&
 					<PostCommentContent
+						ref={ this.props.setWithDimensionsRef }
 						content={ comment.content }
 						isPlaceholder={ comment.isPlaceholder }
 						className={ displayType }
@@ -394,6 +396,9 @@ class PostComment extends React.PureComponent {
 						parentCommentId={ commentId }
 					/> }
 				{ this.renderRepliesList() }
+				<span>
+					overflowY: { this.props.overflowY }
+				</span>
 			</li>
 		);
 	}
@@ -401,4 +406,4 @@ class PostComment extends React.PureComponent {
 
 export default connect( state => ( {
 	currentUser: getCurrentUser( state ),
-} ) )( PostComment );
+} ) )( withDimensions( PostComment ) );

--- a/client/blocks/comments/post-comment.jsx
+++ b/client/blocks/comments/post-comment.jsx
@@ -142,6 +142,7 @@ class PostComment extends React.PureComponent {
 			commentsTree,
 			maxChildrenToShow,
 			enableCaterpillar,
+			post,
 		} = this.props;
 
 		const commentChildrenIds = get( commentsTree, [ commentId, 'children' ] );
@@ -196,6 +197,7 @@ class PostComment extends React.PureComponent {
 								commentId={ childId }
 								commentsTree={ commentsTree }
 								commentsToShow={ commentsToShow }
+								post={ post }
 							/>
 						) }
 					</ol> }

--- a/client/blocks/comments/post-comment.jsx
+++ b/client/blocks/comments/post-comment.jsx
@@ -4,7 +4,7 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { get, noop, some, values, omit, flatMap } from 'lodash';
+import { get, noop, some, flatMap } from 'lodash';
 import { connect } from 'react-redux';
 import { translate } from 'i18n-calypso';
 import Gridicon from 'gridicons';
@@ -47,7 +47,6 @@ class PostComment extends React.PureComponent {
 		onCommentSubmit: PropTypes.func,
 		maxDepth: PropTypes.number,
 		showNestingReplyArrow: PropTypes.bool,
-		displayType: PropTypes.oneOf( values( POST_COMMENT_DISPLAY_TYPES ) ),
 		showReadMoreInActions: PropTypes.bool,
 
 		/**
@@ -76,7 +75,6 @@ class PostComment extends React.PureComponent {
 		maxChildrenToShow: 5,
 		onCommentSubmit: noop,
 		showNestingReplyArrow: false,
-		displayType: POST_COMMENT_DISPLAY_TYPES.full,
 		showReadMoreInActions: false,
 	};
 
@@ -190,11 +188,14 @@ class PostComment extends React.PureComponent {
 				{ showReplies &&
 					<ol className="comments__list">
 						{ commentChildrenIds.map( childId =>
-							<PostComment
-								{ ...omit( this.props, 'displayType' ) }
+							<ConnectedPostComment
+								showNestingReplyArrow={ this.props.showNestingReplyArrow }
+								enableCaterpillar={ enableCaterpillar }
 								depth={ childDepth }
 								key={ childId }
 								commentId={ childId }
+								commentsTree={ commentsTree }
+								commentsToShow={ commentsToShow }
 							/>
 						) }
 					</ol> }
@@ -366,15 +367,14 @@ class PostComment extends React.PureComponent {
 					: null }
 
 				{ this.props.activeEditCommentId !== this.props.commentId &&
-					<div className="comments__content-wrapper" ref={ this.props.setWithDimensionsRef }>
-						<PostCommentContent
-							content={ comment.content }
-							isPlaceholder={ comment.isPlaceholder }
-							className={ displayType }
-							onMoreClicked={ this.handleReadMoreClicked }
-							hideMore={ displayType === POST_COMMENT_DISPLAY_TYPES.full }
-						/>
-					</div> }
+					<PostCommentContent
+						content={ comment.content }
+						setWithDimensionsRef={ this.props.setWithDimensionsRef }
+						isPlaceholder={ comment.isPlaceholder }
+						className={ displayType }
+						onMoreClicked={ this.handleReadMoreClicked }
+						hideMore={ displayType === POST_COMMENT_DISPLAY_TYPES.full }
+					/> }
 
 				{ isEnabled( 'comments/moderation-tools-in-posts' ) &&
 					this.props.activeEditCommentId === this.props.commentId &&
@@ -416,9 +416,11 @@ class PostComment extends React.PureComponent {
 	}
 }
 
-export default connect(
+const ConnectedPostComment = connect(
 	state => ( {
 		currentUser: getCurrentUser( state ),
 	} ),
 	{ expandComments }
 )( withDimensions( PostComment ) );
+
+export default ConnectedPostComment;

--- a/client/blocks/comments/post-comment.jsx
+++ b/client/blocks/comments/post-comment.jsx
@@ -254,7 +254,7 @@ class PostComment extends React.PureComponent {
 	onReadMore = () => {
 		this.props.expandComments( {
 			siteId: this.props.post.site_ID,
-			commentId: this.props.commentId,
+			commentIds: [ this.props.commentId ],
 			postId: this.props.post.ID,
 			displayType: POST_COMMENT_DISPLAY_TYPES.full,
 		} );

--- a/client/blocks/comments/style.scss
+++ b/client/blocks/comments/style.scss
@@ -339,32 +339,6 @@
 	margin-top: -5px;
 }
 
-.comments__comment-read-more {
-	background: linear-gradient( to right, rgba( 255, 255, 255, 0 ) 0%, rgba( 255, 255, 255, 1 ) 50%, rgba( 255, 255, 255, 1 ) 96%, rgba( 255, 255, 255, 1) 100% );
-	color: $blue-medium;
-	cursor: pointer;
-	display: inline-block;
-	float: right;
-	font-size: 15px;
-	max-height: 15px * 1.6 * 3;
-	min-width: 160px;
-	position: relative;
-	text-align: right;
-	width: 140px;
-
-	&:hover {
-		color: $blue-light;
-	}
-}
-
-.comments__comment-content-wrapper.is-single-line .comments__comment-content ~ .comments__comment-read-more {
-	top: -24px;
-}
-
-.comments__comment-content-wrapper.is-excerpt .comments__comment-content ~ .comments__comment-read-more {
-	top: -22px;
-}
-
 // Avoids long trackback links from wrapping
 // Using General Sibling Selector so this doesn't affect regular comment usernames
 .comments__comment-trackbackicon ~ .comments__comment-username {

--- a/client/blocks/comments/style.scss
+++ b/client/blocks/comments/style.scss
@@ -322,13 +322,21 @@
 
 	&.is-excerpt,
 	&.is-excerpt .comments__comment-content {
-		max-height: 15px * 1.6 * 3;
+		max-height: 16px * 1.4375 * 3; // Needs to be exactly 69px so a 3-liner only and 3-liner excerpt align
 	}
 
 	&.is-single-line .comments__comment-content,
 	&.is-excerpt .comments__comment-content {
 		overflow: hidden;
 	}
+}
+
+.comments__comment-content-wrapper.is-excerpt ~ .comments__comment-actions {
+	margin-top: -10px;
+}
+
+.comments__comment-content-wrapper.is-full ~ .comments__comment-actions {
+	margin-top: -5px;
 }
 
 .comments__comment-read-more {
@@ -429,7 +437,6 @@ a.comments__comment-username {
 	list-style: none;
 	color: $gray;
 	font-size: 14px;
-	margin-top: -5px;
 
 	button {
 		display: inline-block;
@@ -480,7 +487,7 @@ a.comments__comment-username {
 	}
 
 	// Aligns Like icon to comment text when it's by itself
-	:only-child {
+	> :only-child {
 		left: -3px;
 		top: 3px;
 	}
@@ -574,6 +581,12 @@ a.comments__comment-username {
 	text-transform: uppercase;
 }
 
-.comments__comment-actions button .comments__comment-actions-read-more-icon {
-	margin-right: -2px;
+.comments__comment-actions .comments__comment-actions-read-more {
+	color: $blue-medium;
+	margin: 0 10px 0 -3px;
+	padding-left: 0;
+}
+
+.comments__comment-actions-read-more-icon {
+	fill: $blue-medium;
 }

--- a/client/blocks/comments/style.scss
+++ b/client/blocks/comments/style.scss
@@ -339,6 +339,10 @@
 	margin-top: -5px;
 }
 
+.comments__comment-content-wrapper.is-excerpt .comments__comment-content p {
+	margin-bottom: 0;
+}
+
 // Avoids long trackback links from wrapping
 // Using General Sibling Selector so this doesn't affect regular comment usernames
 .comments__comment-trackbackicon ~ .comments__comment-username {

--- a/client/blocks/comments/style.scss
+++ b/client/blocks/comments/style.scss
@@ -573,3 +573,7 @@ a.comments__comment-username {
 .comments__comment-count-phrase {
 	text-transform: uppercase;
 }
+
+.comments__comment-actions button .comments__comment-actions-read-more-icon {
+	margin-right: -2px;
+}

--- a/client/blocks/conversation-caterpillar/style.scss
+++ b/client/blocks/conversation-caterpillar/style.scss
@@ -14,7 +14,6 @@
 .conversation-caterpillar__gravatars,
 .conversation-caterpillar__count {
 	display: flex;
-	height: 38px;
 	flex-shrink: 0;
 }
 

--- a/client/blocks/conversations/list.jsx
+++ b/client/blocks/conversations/list.jsx
@@ -113,6 +113,7 @@ export class ConversationCommentList extends React.Component {
 								onCommentSubmit={ this.resetActiveReplyComment }
 								commentText={ this.state.commentText }
 								showReadMoreInActions={ true }
+								displayType={ POST_COMMENT_DISPLAY_TYPES.excerpt }
 							/>
 						);
 					} ) }

--- a/client/blocks/conversations/list.jsx
+++ b/client/blocks/conversations/list.jsx
@@ -79,6 +79,11 @@ export class ConversationCommentList extends React.Component {
 
 	render() {
 		const { commentIds, commentsTree, post, expansions, enableCaterpillar } = this.props;
+
+		if ( ! post ) {
+			return null;
+		}
+
 		const startingExpanded = zipObject(
 			commentIds,
 			fill( Array( commentIds.length ), POST_COMMENT_DISPLAY_TYPES.excerpt )

--- a/client/blocks/conversations/list.jsx
+++ b/client/blocks/conversations/list.jsx
@@ -112,6 +112,7 @@ export class ConversationCommentList extends React.Component {
 								onUpdateCommentText={ this.onUpdateCommentText }
 								onCommentSubmit={ this.resetActiveReplyComment }
 								commentText={ this.state.commentText }
+								showReadMoreInActions={ true }
 							/>
 						);
 					} ) }

--- a/client/blocks/conversations/style.scss
+++ b/client/blocks/conversations/style.scss
@@ -58,10 +58,6 @@
 		top: 5px;
 	}
 
-	.comments__comment-content img {
-		margin-top: 10px;
-	}
-
 	&:not( :first-child ) {
 		margin-top: 16px;
 	}

--- a/client/lib/with-dimensions/index.jsx
+++ b/client/lib/with-dimensions/index.jsx
@@ -56,8 +56,14 @@ export default EnhancedComponent =>
 			window.removeEventListener( 'resize', this.resizeEventListener );
 		}
 
-		handleMount = ref => ( this.divRef = ref );
-		setWithDimensionsRef = ref => ( this.setRef = ref );
+		handleMount = ref => {
+			this.divRef = ref;
+			this.handleResize;
+		};
+		setWithDimensionsRef = ref => {
+			this.setRef = ref;
+			this.handleResize();
+		};
 
 		render() {
 			return (

--- a/client/lib/with-dimensions/index.jsx
+++ b/client/lib/with-dimensions/index.jsx
@@ -58,7 +58,7 @@ export default EnhancedComponent =>
 
 		handleMount = ref => {
 			this.divRef = ref;
-			this.handleResize;
+			this.handleResize();
 		};
 		setWithDimensionsRef = ref => {
 			this.setRef = ref;


### PR DESCRIPTION
As suggested in https://github.com/Automattic/wp-calypso/issues/17508, this PR adds a 'read more' link to the comment actions, intended for use in the Conversations tool.

<img width="428" alt="screen shot 2017-08-31 at 16 50 45" src="https://user-images.githubusercontent.com/17325/29929742-9786cfc4-8e6c-11e7-9d2e-38df7bc54482.png">


