### PR TITLE
Activity log: Add empty days

### DIFF
--- a/client/my-sites/stats/activity-log-day/index.jsx
+++ b/client/my-sites/stats/activity-log-day/index.jsx
@@ -131,7 +131,7 @@ class ActivityLogDay extends Component {
 				<div className="activity-log-day__events">
 					{ /* eslint-disable indent */ }
 					{ isEmpty( logs )
-						? translate( 'No Events' )
+						? translate( 'No activity' )
 						: translate( '%d Event', '%d Events', {
 								args: logs.length,
 								count: logs.length,

--- a/client/my-sites/stats/activity-log-day/index.jsx
+++ b/client/my-sites/stats/activity-log-day/index.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import Gridicon from 'gridicons';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';

--- a/client/my-sites/stats/activity-log-day/index.jsx
+++ b/client/my-sites/stats/activity-log-day/index.jsx
@@ -3,9 +3,11 @@
  */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import classnames from 'classnames';
 import Gridicon from 'gridicons';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
+import { isEmpty, map } from 'lodash';
 
 /**
  * Internal dependencies
@@ -117,20 +119,25 @@ class ActivityLogDay extends Component {
 		return (
 			<div>
 				<div className="activity-log-day__day">
+					{ /* eslint-disable indent */ }
 					{ isToday
 						? translate( '%s — Today', {
-							args: formattedDate,
-							comment: 'Long date with today indicator, i.e. "January 1, 2017 — Today"',
-						} )
-						: formattedDate
-					}
+								args: formattedDate,
+								comment: 'Long date with today indicator, i.e. "January 1, 2017 — Today"',
+							} )
+						: formattedDate }
+					{ /* eslint-enable indent */ }
 				</div>
-				<div className="activity-log-day__events">{
-					translate( '%d Event', '%d Events', {
-						args: logs.length,
-						count: logs.length,
-					} )
-				}</div>
+				<div className="activity-log-day__events">
+					{ /* eslint-disable indent */ }
+					{ isEmpty( logs )
+						? translate( 'No Events' )
+						: translate( '%d Event', '%d Events', {
+								args: logs.length,
+								count: logs.length,
+							} ) }
+					{ /* eslint-enable indent */ }
+				</div>
 			</div>
 		);
 	}
@@ -146,27 +153,30 @@ class ActivityLogDay extends Component {
 			siteId,
 		} = this.props;
 
+		const hasLogs = ! isEmpty( logs );
+
 		return (
-			<div className="activity-log-day">
+			<div className={ classnames( 'activity-log-day', { 'is-empty': ! hasLogs } ) }>
 				<FoldableCard
-					clickableHeader
+					clickableHeader={ hasLogs }
 					expanded={ isToday }
 					expandedSummary={ this.renderRewindButton() }
 					header={ this.renderEventsHeading() }
 					onOpen={ this.trackOpenDay }
 					summary={ this.renderRewindButton( 'primary' ) }
 				>
-					{ logs.map( ( log ) => (
-						<ActivityLogItem
-							applySiteOffset={ applySiteOffset }
-							disableRestore={ disableRestore }
-							hideRestore={ hideRestore }
-							key={ log.activityId }
-							log={ log }
-							requestRestore={ requestRestore }
-							siteId={ siteId }
-						/>
-					) ) }
+					{ hasLogs &&
+						map( logs, log =>
+							<ActivityLogItem
+								applySiteOffset={ applySiteOffset }
+								disableRestore={ disableRestore }
+								hideRestore={ hideRestore }
+								key={ log.activityId }
+								log={ log }
+								requestRestore={ requestRestore }
+								siteId={ siteId }
+							/>
+						) }
 				</FoldableCard>
 			</div>
 		);

--- a/client/my-sites/stats/activity-log-day/index.jsx
+++ b/client/my-sites/stats/activity-log-day/index.jsx
@@ -160,10 +160,10 @@ class ActivityLogDay extends Component {
 				<FoldableCard
 					clickableHeader={ hasLogs }
 					expanded={ isToday }
-					expandedSummary={ this.renderRewindButton() }
+					expandedSummary={ hasLogs ? this.renderRewindButton() : null }
 					header={ this.renderEventsHeading() }
 					onOpen={ this.trackOpenDay }
-					summary={ this.renderRewindButton( 'primary' ) }
+					summary={ hasLogs ? this.renderRewindButton( 'primary' ) : null }
 				>
 					{ hasLogs &&
 						map( logs, log =>

--- a/client/my-sites/stats/activity-log-day/index.jsx
+++ b/client/my-sites/stats/activity-log-day/index.jsx
@@ -70,7 +70,7 @@ class ActivityLogDay extends Component {
 	 * @param {string} type Whether the button will be a primary or not.
 	 * @returns { object } Button to display.
 	 */
-	getRewindButton( type = '' ) {
+	renderRewindButton( type = '' ) {
 		const {
 			disableRestore,
 			hideRestore,
@@ -101,7 +101,7 @@ class ActivityLogDay extends Component {
 	 *
 	 * @returns { object } Heading to display with date and number of events
 	 */
-	getEventsHeading() {
+	renderEventsHeading() {
 		const {
 			applySiteOffset,
 			isToday,
@@ -150,10 +150,10 @@ class ActivityLogDay extends Component {
 				<FoldableCard
 					clickableHeader
 					expanded={ isToday }
-					expandedSummary={ this.getRewindButton() }
-					header={ this.getEventsHeading() }
+					expandedSummary={ this.renderRewindButton() }
+					header={ this.renderEventsHeading() }
 					onOpen={ this.trackOpenDay }
-					summary={ this.getRewindButton( 'primary' ) }
+					summary={ this.renderRewindButton( 'primary' ) }
 				>
 					{ logs.map( ( log ) => (
 						<ActivityLogItem

--- a/client/my-sites/stats/activity-log-day/index.jsx
+++ b/client/my-sites/stats/activity-log-day/index.jsx
@@ -119,24 +119,20 @@ class ActivityLogDay extends Component {
 		return (
 			<div>
 				<div className="activity-log-day__day">
-					{ /* eslint-disable indent */ }
 					{ isToday
 						? translate( '%s — Today', {
-								args: formattedDate,
-								comment: 'Long date with today indicator, i.e. "January 1, 2017 — Today"',
-							} )
+							args: formattedDate,
+							comment: 'Long date with today indicator, i.e. "January 1, 2017 — Today"',
+						} )
 						: formattedDate }
-					{ /* eslint-enable indent */ }
 				</div>
 				<div className="activity-log-day__events">
-					{ /* eslint-disable indent */ }
 					{ isEmpty( logs )
 						? translate( 'No activity' )
 						: translate( '%d Event', '%d Events', {
-								args: logs.length,
-								count: logs.length,
-							} ) }
-					{ /* eslint-enable indent */ }
+							args: logs.length,
+							count: logs.length,
+						} ) }
 				</div>
 			</div>
 		);

--- a/client/my-sites/stats/activity-log-day/style.scss
+++ b/client/my-sites/stats/activity-log-day/style.scss
@@ -12,6 +12,19 @@
 		}
 	}
 
+	&.is-empty {
+		.card {
+			box-shadow: none;
+		}
+
+		.foldable-card__header {
+			background: $gray-light;
+			min-height: initial;
+			padding-bottom: 4px;
+			padding-top: 4px;
+		}
+	}
+
 	.foldable-card__header {
 		background: $white;
 

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -8,7 +8,7 @@ import debugFactory from 'debug';
 import scrollTo from 'lib/scroll-to';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { get, groupBy, includes, isEmpty, isNull, map } from 'lodash';
+import { get, groupBy, includes, isEmpty, isNull } from 'lodash';
 
 /**
  * Internal dependencies
@@ -256,27 +256,35 @@ class ActivityLog extends Component {
 			);
 		}
 
-		const logsGroupedByDay = map(
-			groupBy( logs, log =>
-				this.applySiteOffset( moment.utc( log.activityTs ) ).endOf( 'day' ).valueOf()
-			),
-			( dailyLogs, tsEndOfSiteDay ) =>
+		const logsGroupedByDay = groupBy( logs, log =>
+			this.applySiteOffset( moment.utc( log.activityTs ) ).endOf( 'day' ).valueOf()
+		);
+		const activityDays = [];
+		for (
+			const m = this.applySiteOffset( moment.utc( startDate ) ).endOf( 'month' ).startOf( 'day' ),
+				startOfMonth = this.applySiteOffset( moment.utc( startDate ) ).startOf( 'month' ).valueOf();
+			startOfMonth <= m.valueOf();
+			m.subtract( 1, 'day' )
+		) {
+			const dayEnd = m.endOf( 'day' ).valueOf();
+			activityDays.push(
 				<ActivityLogDay
 					applySiteOffset={ this.applySiteOffset }
 					disableRestore={ disableRestore }
 					hideRestore={ ! isPressable }
 					isRewindActive={ isRewindActive }
-					key={ tsEndOfSiteDay }
-					logs={ dailyLogs }
+					key={ dayEnd }
+					logs={ get( logsGroupedByDay, dayEnd, [] ) }
 					requestRestore={ this.handleRequestRestore }
 					siteId={ siteId }
-					tsEndOfSiteDay={ +tsEndOfSiteDay }
+					tsEndOfSiteDay={ dayEnd }
 				/>
-		);
+			);
+		}
 
 		return (
-			<section className="activity-log__wrapper" key="logs">
-				{ logsGroupedByDay }
+			<section className="activity-log__wrapper">
+				{ activityDays }
 			</section>
 		);
 	}

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -260,6 +260,8 @@ class ActivityLog extends Component {
 			this.applySiteOffset( moment.utc( log.activityTs ) ).endOf( 'day' ).valueOf()
 		);
 		const activityDays = [];
+
+		// loop backwards through each day in the month
 		for (
 			const m = this.applySiteOffset( moment.utc( startDate ) ).endOf( 'month' ).startOf( 'day' ),
 				startOfMonth = this.applySiteOffset( moment.utc( startDate ) ).startOf( 'month' ).valueOf();


### PR DESCRIPTION
Shows all the days in a month and provides special styling for empty days.

I've left the rewind button on the empty days for the moment. That may or may not make sense.

## Testing
1. Visit https://calypso.live/stats/activity?branch=add/activity-log/empty-days
1. Ensure all days in a month are included
1. Ensure empty days have different styling

## Screens

### Before

![before](https://user-images.githubusercontent.com/841763/29936578-0bc9c54c-8e83-11e7-9d4c-5f6f04c53309.png)

### After

![after](https://user-images.githubusercontent.com/841763/29936571-08ee676a-8e83-11e7-8f0f-4e0e5c7a28e9.png)

Fixes #17294