### PR TITLE
Reader: ensure calypso_reader_author_link_clicked event is fired from recommendations

### DIFF
--- a/client/blocks/reader-author-link/index.jsx
+++ b/client/blocks/reader-author-link/index.jsx
@@ -3,7 +3,7 @@
  * External dependencies
  */
 import React from 'react';
-import { get } from 'lodash';
+import { get, noop } from 'lodash';
 import classnames from 'classnames';
 
 /**
@@ -13,13 +13,14 @@ import { isAuthorNameBlacklisted } from 'reader/lib/author-name-blacklist';
 import * as stats from 'reader/stats';
 import Emojify from 'components/emojify';
 
-const ReaderAuthorLink = ( { author, post, siteUrl, children, className } ) => {
+const ReaderAuthorLink = ( { author, post, siteUrl, children, className, onClick } ) => {
 	const recordAuthorClick = ( {} ) => {
 		stats.recordAction( 'click_author' );
 		stats.recordGaEvent( 'Clicked Author Link' );
 		if ( post ) {
 			stats.recordTrackForPost( 'calypso_reader_author_link_clicked', post );
 		}
+		onClick();
 	};
 
 	if ( ! siteUrl ) {
@@ -59,6 +60,10 @@ ReaderAuthorLink.propTypes = {
 	author: React.PropTypes.object.isRequired,
 	post: React.PropTypes.object, // for stats only,
 	siteUrl: React.PropTypes.string, // used instead of author.URL if present
+};
+
+ReaderAuthorLink.defaultProps = {
+	onClick: noop,
 };
 
 export default ReaderAuthorLink;

--- a/client/blocks/reader-related-card-v2/index.jsx
+++ b/client/blocks/reader-related-card-v2/index.jsx
@@ -21,6 +21,7 @@ import { getPostUrl, getStreamUrl } from 'reader/route';
 import { areEqualIgnoringWhitespaceAndCase } from 'lib/string';
 import ReaderFeaturedVideo from 'blocks/reader-featured-video';
 import ReaderFeaturedImage from 'blocks/reader-featured-image';
+import ReaderAuthorLink from 'blocks/reader-author-link';
 
 const RELATED_IMAGE_WIDTH = 385; // usual width of featured images in related post card
 
@@ -39,9 +40,15 @@ function AuthorAndSiteFollow( { post, site, onSiteClick, followSource } ) {
 				{ authorName &&
 					authorAndSiteAreDifferent &&
 					<span className="reader-related-card-v2__byline-author">
-						<a href={ siteUrl } onClick={ onSiteClick } className="reader-related-card-v2__link">
+						<ReaderAuthorLink
+							author={ post.author }
+							siteUrl={ siteUrl }
+							post={ post }
+							onClick={ onSiteClick }
+							className="reader-related-card-v2__link"
+						>
 							{ authorName }
-						</a>
+						</ReaderAuthorLink>
 					</span> }
 				<span className="reader-related-card-v2__byline-site">
 					<a href={ siteUrl } onClick={ onSiteClick } className="reader-related-card-v2__link">


### PR DESCRIPTION
In 543-gh-tracks-events-validation-status, @aaronyan noticed that recommendations blocks were not firing the `calypso_reader_author_link_clicked` tracks event. 

This PR switches author links to use the `ReaderAuthorLink` component, which fires that event (along with any other onClick handler it was passed).

Fixes 543-gh-tracks-events-validation-status.

### To test

Visit Reader Search and click on an author name in the default recommendations:

<img width="501" alt="screen shot 2017-08-31 at 19 05 31" src="https://user-images.githubusercontent.com/17325/29935648-bd595e16-8e7f-11e7-9058-6546b9be7627.png">

Ensure that the `calypso_reader_author_link_clicked` event fires when the author link is clicked. Also ensure that the original `calypso_reader_recommended_site_clicked` event fires, too.

Repeat the test with a recommendation block at the end of a full post (e.g. http://calypso.localhost:3000/read/feeds/44002173/posts/1577535330).