### PR TITLE
Store: Add TaxJar notice to tax settings

### DIFF
--- a/client/extensions/woocommerce/app/settings/taxes/style.scss
+++ b/client/extensions/woocommerce/app/settings/taxes/style.scss
@@ -25,6 +25,10 @@
 	.notice.is-error {
 		margin-bottom: 0;
 	}
+
+	a.external-link {
+		margin-left: 8px;
+	}
 }
 
 .taxes__taxes-options {

--- a/client/extensions/woocommerce/app/settings/taxes/style.scss
+++ b/client/extensions/woocommerce/app/settings/taxes/style.scss
@@ -29,6 +29,10 @@
 	a.external-link {
 		margin-left: 8px;
 	}
+	
+	a.external-link .gridicons-external {
+		margin-left: 4px;
+	}
 }
 
 .taxes__taxes-options {

--- a/client/extensions/woocommerce/app/settings/taxes/taxes-rates.js
+++ b/client/extensions/woocommerce/app/settings/taxes/taxes-rates.js
@@ -260,7 +260,7 @@ class TaxesRates extends Component {
 		const { translate } = this.props;
 
 		return (
-			<p>
+			<div className="taxes__taxes-taxjar-notice">
 				{ translate( 'Sales tax calculations are provided by a third party: TaxJar. By enabling this option, ' +
 					'TaxJar will have access to some of your data.' )
 				}
@@ -270,9 +270,9 @@ class TaxesRates extends Component {
 					target="_blank"
 					rel="noopener noreferrer"
 				>
-					{ translate( 'Learn more.' ) }
+					{ translate( 'Learn more' ) }
 				</ExternalLink>
-			</p>
+			</div>
 		);
 	}
 

--- a/client/extensions/woocommerce/app/settings/taxes/taxes-rates.js
+++ b/client/extensions/woocommerce/app/settings/taxes/taxes-rates.js
@@ -255,6 +255,21 @@ class TaxesRates extends Component {
 		);
 	}
 
+	renderPolicyNotice = () => {
+		const { translate } = this.props;
+
+		return (
+			<p>
+				{ translate( 'Sales tax calculations are provided by a third party: TaxJar. By enabling this option, ' +
+					'TaxJar will have access to some of your data. {{a}}Learn more.{{/a}}',
+					{
+						components: { a: <a href="https://en.support.wordpress.com/taxjar/" target="_blank" rel="noopener noreferrer" /> }
+					}
+				) }
+			</p>
+		);
+	}
+
 	render = () => {
 		const { site, loadedSettingsGeneral, loadedTaxRates, onEnabledChange, taxesEnabled, translate } = this.props;
 
@@ -285,6 +300,7 @@ class TaxesRates extends Component {
 					{ this.renderInfo() }
 					{ this.renderCalculationStatus() }
 					{ this.possiblyRenderRates() }
+					{ this.renderPolicyNotice() }
 				</Card>
 			</div>
 		);

--- a/client/extensions/woocommerce/app/settings/taxes/taxes-rates.js
+++ b/client/extensions/woocommerce/app/settings/taxes/taxes-rates.js
@@ -29,6 +29,7 @@ import {
 } from 'woocommerce/lib/countries/constants';
 import { getCountryData, getStateData } from 'woocommerce/lib/countries';
 import ExtendedHeader from 'woocommerce/components/extended-header';
+import ExternalLink from 'components/external-link';
 import { fetchTaxRates } from 'woocommerce/state/sites/meta/taxrates/actions';
 import FormToggle from 'components/forms/form-toggle';
 import Notice from 'components/notice';
@@ -261,11 +262,16 @@ class TaxesRates extends Component {
 		return (
 			<p>
 				{ translate( 'Sales tax calculations are provided by a third party: TaxJar. By enabling this option, ' +
-					'TaxJar will have access to some of your data. {{a}}Learn more.{{/a}}',
-					{
-						components: { a: <a href="https://en.support.wordpress.com/taxjar/" target="_blank" rel="noopener noreferrer" /> }
-					}
-				) }
+					'TaxJar will have access to some of your data.' )
+				}
+				<ExternalLink
+					icon
+					href="https://en.support.wordpress.com/taxjar/"
+					target="_blank"
+					rel="noopener noreferrer"
+				>
+					{ translate( 'Learn more.' ) }
+				</ExternalLink>
 			</p>
 		);
 	}


### PR DESCRIPTION
Fixes #17501 

cc @kellychoffman and @jennyzhu 

I tweaked the copy a bit - the multiple commas were bugging me and i wanted to use the plural since that's how we have it on the enable toggle too. Looks like this:

<img width="740" alt="screen shot 2017-08-31 at 12 29 52 pm" src="https://user-images.githubusercontent.com/1595739/29941730-5cb128aa-8e48-11e7-99ef-b1df127917a1.png">
