### PR TITLE
Activity log: Adapt for changes to paged API response

### DIFF
--- a/client/state/data-layer/wpcom/sites/activity/from-api.js
+++ b/client/state/data-layer/wpcom/sites/activity/from-api.js
@@ -24,18 +24,18 @@ import warn from 'lib/warn';
  * Module constants
  */
 export const ACTIVITY_REQUIRED_PROPS = [ 'activity_id', 'name', 'published', 'summary' ];
-
 export const DEFAULT_GRAVATAR_URL = 'https://www.gravatar.com/avatar/0';
 export const DEFAULT_GRIDICON = 'info-outline';
 
 /**
  * Transforms API response into array of activities
  *
- * @param  {object} _ API   response body
- * @param  {array}  _.items Array of item objects
- * @return {array}          Array of proccessed item objects
+ * @param  {object} apiResponse                      API response body
+ * @param  {array}  apiResponse.current.orderedItems Array of item objects
+ * @return {array}                                   Array of proccessed item objects
  */
-export default function fromApi( { orderedItems = [] } ) {
+export default function fromApi( apiResponse ) {
+	const orderedItems = get( apiResponse, [ 'current', 'orderedItems' ], [] );
 	return reduce( orderedItems, itemsReducer, [] );
 }
 

--- a/client/state/data-layer/wpcom/sites/activity/test/from-api.js
+++ b/client/state/data-layer/wpcom/sites/activity/test/from-api.js
@@ -16,6 +16,8 @@ import fromApi, {
 	validateItem,
 } from '../from-api';
 
+const SITE_ID = 123456;
+
 const VALID_API_ITEM = deepFreeze( {
 	summary: 'Jane Doe updated post I wrote a new post!',
 	name: 'post__updated',
@@ -43,7 +45,7 @@ const VALID_API_ITEM = deepFreeze( {
 	published: '2014-09-14T00:30:00+02:00',
 	generator: {
 		jetpack_version: 5.3,
-		blog_id: 123456,
+		blog_id: SITE_ID,
 	},
 	gridicon: 'posts',
 	activity_id: 'foobarbaz',
@@ -51,10 +53,20 @@ const VALID_API_ITEM = deepFreeze( {
 
 const API_RESPONSE_BODY = deepFreeze( {
 	'@context': 'https://www.w3.org/ns/activitystreams',
-	orderedItems: [ VALID_API_ITEM ],
+	id: `https://public-api.wordpress.com/wpcom/v2/sites/${ SITE_ID }/activity`,
+	itemsPerPage: 1000,
+	page: 1,
 	summary: 'Activity log',
 	totalItems: 1,
+	totalPages: 1,
 	type: 'OrderedCollection',
+
+	current: {
+		totalItems: 1,
+		orderedItems: [ VALID_API_ITEM ],
+		type: 'OrderedCollectionPage',
+		id: `https://public-api.wordpress.com/wpcom/v2/sites/${ SITE_ID }/activity?number=1000`,
+	},
 } );
 
 describe( 'fromApi', () => {
@@ -67,7 +79,11 @@ describe( 'fromApi', () => {
 			fromApi( {
 				...API_RESPONSE_BODY,
 				totalItems: 0,
-				orderedItems: [],
+				current: {
+					...API_RESPONSE_BODY.current,
+					totalItems: 0,
+					orderedItems: [],
+				},
 			} )
 		).to.be.an( 'array' ).that.is.empty;
 	} );


### PR DESCRIPTION
Adapt `fromApi` for the changes in D7104-code

## Testing
* sandbox `public-api.wordpress.com`
* apply the patch to the sandbox
* visit https://calypso.live/stats/activity?branch=update/activity-log/paged-queries
* Ensure activity appears as normal.