### PR TITLE
View Site: Add an "external" button to the sidebar pointing to the site

### DIFF
--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -99,6 +99,14 @@
 				border-bottom: 1px solid lighten( $gray, 20% );
 			}
 		}
+
+		&.preview .sidebar__button {
+			padding-left: 24px;
+			& .sidebar__external {
+				top: 2px;
+				right: 4px;
+			}
+		}
 	}
 
 	a:first-child {
@@ -241,6 +249,11 @@ form.sidebar__button {
 			fill: $white;
 		}
 
+		&.preview .gridicons-external {
+			fill: $gray-text;
+		}
+
+
 		&.is-action-button-selected a {
 			&:first-child:after {
 				background: linear-gradient(
@@ -278,6 +291,18 @@ form.sidebar__button {
 		.gridicon,
 		.jetpack-logo {
 			fill: $blue-medium;
+		}
+
+		&.preview {
+			& .sidebar__button {
+				.gridicons-external {
+					fill: $gray-text;
+				}
+				&:hover .gridicons-external {
+					fill: $blue-medium;
+				}
+
+			}
 		}
 	}
 

--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -87,6 +87,10 @@
 	li {
 		display: flex;
 
+		&.preview .sidebar__button {
+			padding-left: 24px;
+		}
+
 		@include breakpoint( "<660px" ) {
 			background-color: $gray-light;
 			border-bottom: 1px solid rgba( lighten( $gray, 20% ), 0.5 );
@@ -97,14 +101,6 @@
 
 			&:last-child {
 				border-bottom: 1px solid lighten( $gray, 20% );
-			}
-		}
-
-		&.preview .sidebar__button {
-			padding-left: 24px;
-			& .sidebar__external {
-				top: 2px;
-				right: 4px;
 			}
 		}
 	}
@@ -190,6 +186,14 @@
 			height: 18px;
 			margin-right: 0;
 
+			&.sidebar__view-site-external {
+				top: 2px;
+				right: 4px;
+
+				@include breakpoint( "<660px" ) {
+					top: 5px;
+				}
+			}
 
 		}
 	}
@@ -249,11 +253,6 @@ form.sidebar__button {
 			fill: $white;
 		}
 
-		&.preview .gridicons-external {
-			fill: $gray-text;
-		}
-
-
 		&.is-action-button-selected a {
 			&:first-child:after {
 				background: linear-gradient(
@@ -261,6 +260,9 @@ form.sidebar__button {
 					rgba( $gray-light, 0 ),
 					rgba( $gray-light, 1 ) 50% );
 			}
+		}
+		& .sidebar__view-site-external {
+			fill: $gray-text;
 		}
 	}
 }
@@ -294,14 +296,11 @@ form.sidebar__button {
 		}
 
 		&.preview {
-			& .sidebar__button {
-				.gridicons-external {
-					fill: $gray-text;
-				}
-				&:hover .gridicons-external {
-					fill: $blue-medium;
-				}
-
+			.sidebar__view-site-external {
+				fill: $gray-text;
+			}
+			.sidebar__button:hover .sidebar__view-site-external {
+				fill: $blue-medium;
 			}
 		}
 	}

--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -187,6 +187,7 @@
 			margin-right: 0;
 
 			&.sidebar__view-site-external {
+				fill: darken( $gray, 20% );
 				top: 2px;
 				right: 4px;
 
@@ -260,9 +261,6 @@ form.sidebar__button {
 					rgba( $gray-light, 0 ),
 					rgba( $gray-light, 1 ) 50% );
 			}
-		}
-		& .sidebar__view-site-external {
-			fill: $gray-text;
 		}
 	}
 }

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -156,6 +156,10 @@ export class MySitesSidebar extends Component {
 
 		const { site, isPreviewable } = this.props;
 		const siteUrl = site && site.URL || '';
+		const externalButton = isPreviewable && (
+			<SidebarButton href={ siteUrl }>
+				<Gridicon className="sidebar__external" icon="external" size={ 12 } />
+			</SidebarButton> );
 
 		return (
 			<SidebarItem
@@ -165,8 +169,10 @@ export class MySitesSidebar extends Component {
 				link={ isPreviewable ? '/view' + this.props.siteSuffix : siteUrl }
 				onNavigate={ this.onNavigate }
 				icon="computer"
-				preloadSectionName="preview"
-			/>
+				preloadSectionName="preview">{
+					externalButton
+				}
+			</SidebarItem>
 		);
 	}
 

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -158,7 +158,7 @@ export class MySitesSidebar extends Component {
 		const siteUrl = site && site.URL || '';
 		const externalButton = isPreviewable && (
 			<SidebarButton href={ siteUrl }>
-				<Gridicon className="sidebar__external" icon="external" size={ 12 } />
+				<Gridicon className="sidebar__view-site-external" icon="external" size={ 12 } />
 			</SidebarButton> );
 
 		return (


### PR DESCRIPTION
Fixes #17212 -- This adds an easy & explicit way to view the front end of the site without having to Cmd+click, etc. & will also work on mobile.

Before:
<img width="274" alt="screen shot 2017-09-01 at 1 07 27 am" src="https://user-images.githubusercontent.com/1587282/29956003-f9fe54ac-8eb1-11e7-96f1-b42be5216c95.png">

After:
<img width="274" alt="screen shot 2017-09-01 at 1 07 20 am" src="https://user-images.githubusercontent.com/1587282/29956005-fefc8a78-8eb1-11e7-96da-0014ce3f2a80.png">

#### To Test

* Run this branch
* Click My Site(s) or browse to a site context
* Click `View Site` -- it should open the section in calypso
* Click the `external` icon -- it should open the front end of the site in a new tab / window
* Test hover states while the section is selected & not -- it should be consistent with the rest of the sidebar UI
* "Unpreviewable" sites should not have this button. Instead the whole menu item should open the front end in a new tab.
* Run this branch on a mobile device -- the button should be easily tappable and should behave as expected