### PR TITLE
Components: Refactor HappinessSupport component

### DIFF
--- a/client/components/happiness-support/index.jsx
+++ b/client/components/happiness-support/index.jsx
@@ -31,15 +31,12 @@ export class HappinessSupport extends Component {
 		showLiveChatButton: false,
 	};
 
-	constructor( props ) {
-		super( props );
-		this.state = {
-			user: sample( [
-				{ display_name: 'Spencer', avatar_URL: '//gravatar.com/avatar/368dd11821ca7e9293d1707ab838f5c7' },
-				{ display_name: 'Luca', avatar_URL: '//gravatar.com/avatar/7f7ba3ba8305287770e0cba76d1eb3db' }
-			] )
-		};
-	}
+	state = {
+		user: sample( [
+			{ display_name: 'Spencer', avatar_URL: '//gravatar.com/avatar/368dd11821ca7e9293d1707ab838f5c7' },
+			{ display_name: 'Luca', avatar_URL: '//gravatar.com/avatar/7f7ba3ba8305287770e0cba76d1eb3db' }
+		] )
+	};
 
 	onLiveChatButtonClick = () => {
 		if ( this.props.liveChatButtonEventName ) {

--- a/client/components/happiness-support/index.jsx
+++ b/client/components/happiness-support/index.jsx
@@ -1,11 +1,11 @@
 /**
  * External dependencies
  */
-import analytics from 'lib/analytics';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import React from 'react';
 import { sample } from 'lodash';
 
 /**
@@ -17,35 +17,35 @@ import { isHappychatAvailable } from 'state/happychat/selectors';
 import support from 'lib/url/support';
 import HappychatButton from 'components/happychat/button';
 import HappychatConnection from 'components/happychat/connection';
+import { recordTracksEvent } from 'state/analytics/actions';
 
-const HappinessSupport = React.createClass( {
-	propTypes: {
-		isJetpack: React.PropTypes.bool,
-		isPlaceholder: React.PropTypes.bool,
-		liveChatButtonEventName: React.PropTypes.string,
-		showLiveChatButton: React.PropTypes.bool,
-	},
+export class HappinessSupport extends Component {
+	static propTypes = {
+		isJetpack: PropTypes.bool,
+		isPlaceholder: PropTypes.bool,
+		liveChatButtonEventName: PropTypes.string,
+		showLiveChatButton: PropTypes.bool,
+	};
 
-	getDefaultProps() {
-		return {
-			showLiveChatButton: false
-		};
-	},
+	static defaultProps = {
+		showLiveChatButton: false,
+	};
 
-	getInitialState() {
-		return {
+	constructor( props ) {
+		super( props );
+		this.state = {
 			user: sample( [
 				{ display_name: 'Spencer', avatar_URL: '//gravatar.com/avatar/368dd11821ca7e9293d1707ab838f5c7' },
 				{ display_name: 'Luca', avatar_URL: '//gravatar.com/avatar/7f7ba3ba8305287770e0cba76d1eb3db' }
 			] )
 		};
-	},
+	}
 
-	onLiveChatButtonClick() {
+	onLiveChatButtonClick = () => {
 		if ( this.props.liveChatButtonEventName ) {
-			analytics.tracks.recordEvent( this.props.liveChatButtonEventName );
+			this.props.recordTracksEvent( this.props.liveChatButtonEventName );
 		}
-	},
+	}
 
 	renderContactButton() {
 		let url = support.CALYPSO_CONTACT,
@@ -57,19 +57,19 @@ const HappinessSupport = React.createClass( {
 		}
 
 		return (
-			<Button href={ url } target={ target }>
+			<Button href={ url } target={ target } className="happiness-support__contact-button">
 				{ this.props.translate( 'Ask a question' ) }
 			</Button>
 		);
-	},
+	}
 
 	renderLiveChatButton() {
 		return (
-			<HappychatButton borderless={ false } onClick={ this.onLiveChatButtonClick }>
+			<HappychatButton borderless={ false } onClick={ this.onLiveChatButtonClick } className="happiness-support__livechat-button">
 				{ this.props.translate( 'Ask a question' ) }
 			</HappychatButton>
 		);
-	},
+	}
 
 	renderGravatar() {
 		return (
@@ -80,7 +80,7 @@ const HappinessSupport = React.createClass( {
 				</em>
 			</div>
 		);
-	},
+	}
 
 	renderSupportButton() {
 		let url = support.SUPPORT_ROOT;
@@ -90,30 +90,29 @@ const HappinessSupport = React.createClass( {
 		}
 
 		return (
-			<Button href={ url } target="_blank" rel="noopener noreferrer">
+			<Button href={ url } target="_blank" rel="noopener noreferrer" className="happiness-support__support-button">
 				{ this.props.translate( 'Search our support site' ) }
 			</Button>
 		);
-	},
+	}
 
 	render() {
 		const classes = {
-			'happiness-support': true,
-			'is-placeholder': this.props.isPlaceholder
+			'is-placeholder': this.props.isPlaceholder,
 		};
-		const { liveChatAvailable, showLiveChatButton } = this.props;
+		const { liveChatAvailable, showLiveChatButton, translate } = this.props;
 
 		return (
-			<div className={ classNames( classes ) }>
+			<div className={ classNames( 'happiness-support', classes ) }>
 				{ this.renderGravatar() }
 
 				<h3 className="happiness-support__heading">
-					{ this.props.translate( 'Enjoy priority support from our Happiness Engineers' ) }
+					{ translate( 'Enjoy priority support from our Happiness Engineers' ) }
 				</h3>
 
 				<p className="happiness-support__text">
-					{ this.props.translate(
-						'{{strong}}Need help?{{/strong}} A Happiness Engineer can answer questions about your site, your account or how to do just about anything.',
+					{ translate(
+						'{{strong}}Need help?{{/strong}} A Happiness Engineer can answer questions about your site, your account or how to do just about anything.', // eslint-disable-line max-len
 						{
 							components: {
 								strong: <strong />
@@ -130,12 +129,17 @@ const HappinessSupport = React.createClass( {
 			</div>
 		);
 	}
-} );
+}
 
 export default connect(
 	state => {
 		return {
 			liveChatAvailable: isHappychatAvailable( state ),
 		};
-	}
+	},
+	dispatch => ( {
+		recordTracksEvent( eventName ) {
+			dispatch( recordTracksEvent( eventName ) );
+		}
+	} )
 )( localize( HappinessSupport ) );

--- a/client/components/happiness-support/index.jsx
+++ b/client/components/happiness-support/index.jsx
@@ -134,9 +134,5 @@ export default connect(
 			liveChatAvailable: isHappychatAvailable( state ),
 		};
 	},
-	dispatch => ( {
-		recordTracksEvent( eventName ) {
-			dispatch( recordTracksEvent( eventName ) );
-		}
-	} )
+	{ recordTracksEvent }
 )( localize( HappinessSupport ) );

--- a/client/components/happiness-support/test/index.jsx
+++ b/client/components/happiness-support/test/index.jsx
@@ -1,0 +1,202 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+import { spy } from 'sinon';
+import { noop } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { HappinessSupport } from '..';
+import support from 'lib/url/support';
+import Gravatar from 'components/gravatar';
+import HappychatButton from 'components/happychat/button';
+import HappychatConnection from 'components/happychat/connection';
+
+describe( 'HappinessSupport', function() {
+	let wrapper;
+	const translate = ( content ) => `Translated: ${ content }`;
+
+	beforeEach( function() {
+		wrapper = shallow( <HappinessSupport translate={ translate } recordTracksEvent={ noop } /> );
+	} );
+
+	it( 'should render a <Gravatar />', function() {
+		expect( wrapper.find( Gravatar ) ).to.have.length( 1 );
+	} );
+
+	it( 'should render translated heading content', function() {
+		const heading = wrapper.find( 'h3' );
+		expect( heading ).to.have.length( 1 );
+		expect(
+			heading.props().children
+		).to.equal(
+			'Translated: Enjoy priority support from our Happiness Engineers'
+		);
+	} );
+
+	it( 'should render translated help content', function() {
+		const content = wrapper.find( 'p.happiness-support__text' );
+		expect( content ).to.have.length( 1 );
+		expect(
+			content.props().children
+		).to.equal(
+			'Translated: {{strong}}Need help?{{/strong}} A Happiness Engineer can answer questions about your site, your account or how to do just about anything.' // eslint-disable-line max-len
+		);
+	} );
+
+	it( 'should render a translated support button', function() {
+		expect(
+			wrapper.find( 'Button.happiness-support__support-button' ).props().children
+		).to.equal(
+			'Translated: Search our support site'
+		);
+	} );
+
+	it( 'should render a support button with link to SUPPORT_ROOT if it is not for JetPack', function() {
+		wrapper = shallow( <HappinessSupport translate={ translate } recordTracksEvent={ noop } isJetpack={ false } /> );
+		expect( wrapper.find( 'Button.happiness-support__support-button' ).props().href ).to.equal( support.SUPPORT_ROOT );
+	} );
+
+	it( 'should render a support button with link to JETPACK_SUPPORT if it is for JetPack', function() {
+		wrapper = shallow( <HappinessSupport translate={ translate } recordTracksEvent={ noop } isJetpack={ true } /> );
+		expect( wrapper.find( 'Button' ).last().prop( 'href' ) ).to.equal( support.JETPACK_SUPPORT );
+	} );
+
+	it( 'should have is-placeholder className only if it is a placeholder', function() {
+		expect( wrapper.find( '.happiness-support' ).hasClass( 'is-placeholder' ) ).to.be.false;
+
+		wrapper = shallow( <HappinessSupport translate={ translate } recordTracksEvent={ noop } isPlaceholder={ true } /> );
+		expect( wrapper.find( '.happiness-support' ).hasClass( 'is-placeholder' ) ).to.be.true;
+	} );
+
+	it( 'should render a <HappychatConnection /> when showLiveChat prop is true', function() {
+		wrapper = shallow( <HappinessSupport translate={ translate } recordTracksEvent={ noop } showLiveChatButton={ true } /> );
+		expect( wrapper.find( HappychatConnection ) ).to.have.length( 1 );
+	} );
+
+	describe( 'LiveChat button', function() {
+		const props = {
+			translate,
+			recordTracksEvent: noop
+		};
+
+		beforeEach( function() {
+			wrapper = shallow( <HappinessSupport { ...props } showLiveChatButton={ true } liveChatAvailable={ true } /> );
+		} );
+
+		it( 'should be rendered only when showLiveChatButton prop is true and LiveChat is available', function() {
+			// should be rendered here
+			expect( wrapper.find( HappychatButton ) ).to.have.length( 1 );
+
+			// false cases
+			wrapper = shallow( <HappinessSupport { ...props } /> );
+			expect( wrapper.find( HappychatButton ) ).to.have.length( 0 );
+
+			wrapper = shallow( <HappinessSupport { ...props } showLiveChatButton={ true } /> );
+			expect( wrapper.find( HappychatButton ) ).to.have.length( 0 );
+
+			wrapper = shallow( <HappinessSupport { ...props } showLiveChatButton={ false } /> );
+			expect( wrapper.find( HappychatButton ) ).to.have.length( 0 );
+
+			wrapper = shallow( <HappinessSupport { ...props } showLiveChatButton={ true } liveChatAvailable={ false } /> );
+			expect( wrapper.find( HappychatButton ) ).to.have.length( 0 );
+
+			wrapper = shallow( <HappinessSupport { ...props } showLiveChatButton={ false } liveChatAvailable={ true } /> );
+			expect( wrapper.find( HappychatButton ) ).to.have.length( 0 );
+
+			wrapper = shallow( <HappinessSupport { ...props } showLiveChatButton={ false } liveChatAvailable={ false } /> );
+			expect( wrapper.find( HappychatButton ) ).to.have.length( 0 );
+		} );
+
+		it( 'should render translated content', function() {
+			expect( wrapper.find( HappychatButton ).props().children ).to.equal( 'Translated: Ask a question' );
+		} );
+
+		it( 'should fire tracks event with given event name when clicked', function() {
+			const recordTracksEvent = spy();
+
+			wrapper = shallow(
+				<HappinessSupport
+					translate={ translate }
+					recordTracksEvent={ recordTracksEvent }
+					showLiveChatButton={ true }
+					liveChatAvailable={ true }
+					liveChatButtonEventName="test:eventName"
+				/>
+			);
+
+			expect( recordTracksEvent ).not.to.be.called;
+			wrapper.find( HappychatButton ).simulate( 'click' );
+			expect( recordTracksEvent ).to.be.calledWith( 'test:eventName' );
+		} );
+
+		it( 'should not fire tracks event when no event name is passed even if clicked', function() {
+			const recordTracksEvent = spy();
+
+			wrapper = shallow(
+				<HappinessSupport
+					translate={ translate }
+					recordTracksEvent={ recordTracksEvent }
+					showLiveChatButton={ true }
+					liveChatAvailable={ true }
+				/>
+			);
+
+			expect( recordTracksEvent ).not.to.be.called;
+			wrapper.find( HappychatButton ).simulate( 'click' );
+			expect( recordTracksEvent ).not.to.be.called;
+		} );
+	} );
+
+	describe( 'Contact button', function() {
+		const selector = 'Button.happiness-support__contact-button';
+		const props = {
+			translate,
+			recordTracksEvent: noop
+		};
+
+		it( 'should be rendered unless LiveChat button shows up', function() {
+			// should not be displayed here
+			wrapper = shallow( <HappinessSupport { ...props } showLiveChatButton={ true } liveChatAvailable={ true } /> );
+			expect( wrapper.find( selector ) ).to.have.length( 0 );
+
+			// should be rendered in the following cases
+			wrapper = shallow( <HappinessSupport { ...props } /> );
+			expect( wrapper.find( selector ) ).to.have.length( 1 );
+
+			wrapper = shallow( <HappinessSupport { ...props } showLiveChatButton={ true } /> );
+			expect( wrapper.find( selector ) ).to.have.length( 1 );
+
+			wrapper = shallow( <HappinessSupport { ...props } showLiveChatButton={ false } /> );
+			expect( wrapper.find( selector ) ).to.have.length( 1 );
+
+			wrapper = shallow( <HappinessSupport { ...props } showLiveChatButton={ true } liveChatAvailable={ false } /> );
+			expect( wrapper.find( selector ) ).to.have.length( 1 );
+
+			wrapper = shallow( <HappinessSupport { ...props } showLiveChatButton={ false } liveChatAvailable={ true } /> );
+			expect( wrapper.find( selector ) ).to.have.length( 1 );
+
+			wrapper = shallow( <HappinessSupport { ...props } showLiveChatButton={ false } liveChatAvailable={ false } /> );
+			expect( wrapper.find( selector ) ).to.have.length( 1 );
+		} );
+
+		it( 'should be rendered with link to CALYPSO_CONTACT if it is not for JetPack', function() {
+			wrapper = shallow( <HappinessSupport { ...props } /> );
+			expect( wrapper.find( selector ).prop( 'href' ) ).to.equal( support.CALYPSO_CONTACT );
+		} );
+
+		it( 'should be rendered with link to JETPACK_CONTACT_SUPPORT if it is for JetPack', function() {
+			wrapper = shallow( <HappinessSupport { ...props } isJetpack={ true } /> );
+			expect( wrapper.find( selector ).prop( 'href' ) ).to.equal( support.JETPACK_CONTACT_SUPPORT );
+		} );
+
+		it( 'should render translated content', function() {
+			wrapper = shallow( <HappinessSupport { ...props } /> );
+			expect( wrapper.find( selector ).props().children ).to.equal( 'Translated: Ask a question' );
+		} );
+	} );
+} );


### PR DESCRIPTION
This PR will:
- ES6-fy the component.
- Replace `recordTracksEvent` of `lib/analytics` with the corresponding redux action.
- Add test cases for the component.

## How to test

1. Plan page:
    - Open Plan page for your website not on a paid plan.
    - The Happiness Support card and its buttons should be working well.

2. Thank you screen:
    - Purchase a paid plan subscription.
    - When you accomplish the payment flow and reach out the thank you screen,
    you will find the Happiness Support component at the bottom of the screen.
    - The component and the buttons should be working.