### PR TITLE
Site Settings/Disconnect Site: add Survey details to the first screen of the JP Disconnect Flow

### DIFF
--- a/client/my-sites/site-settings/disconnect-site/disconnect-survey.jsx
+++ b/client/my-sites/site-settings/disconnect-site/disconnect-survey.jsx
@@ -1,0 +1,90 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import SelectDropdown from 'components/select-dropdown';
+import { isJetpackSite } from 'state/sites/selectors';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
+
+class DisconnectSurvey extends Component {
+	constructor( props ) {
+		super( props );
+		const initialState = {
+			reasonSelected: 'missingFeature',
+			compactButtons: false,
+			renderFull: false,
+		};
+
+		this.state = initialState;
+	}
+
+	renderFull = () => {
+		// placeholder
+		return (
+			<div>
+				{' '}
+				{ ' follow-up selectable' }{' '}
+			</div>
+		);
+	};
+
+	logReason = option => {
+		this.setState( {
+			reasonSelected: option.value,
+			renderFull: true,
+		} );
+	};
+
+	render() {
+		const { translate, siteSlug } = this.props;
+		const { reasonSelected, compactButtons, renderFull } = this.state;
+
+		const textShareWhy =
+			translate( 'Would you mind sharing why you want to' + ' disconnect ' ) +
+			`${ siteSlug }` +
+			translate( ' from Wordpress.com ' );
+
+		const options = [
+			{ value: 'missingFeature', label: 'Jetpack is missing a feature' },
+			{ value: 'reason2', label: "I'm going to use WordPress somewhere else" },
+			{
+				value: 'reason3',
+				label: "I'm going to use a different service for " + 'my website or blog.',
+			},
+			{
+				value: 'reason4',
+				label: "I'm going to use a different service for " + 'my website or blog.',
+			},
+			{ value: 'reason5', label: 'I no longer need a website or blog.' },
+			{ value: 'reason6', label: 'Another reason.' },
+			{ value: 'reason7', label: 'I found a better plugin or service.' },
+			{ value: 'reason8', label: "I'm moving my site off of WordPress." },
+		];
+
+		return (
+			<div className="disconnect-site__survey main">
+				<div className="disconnect-site__question">
+					{ textShareWhy }
+				</div>
+				<SelectDropdown
+					compact={ compactButtons }
+					onSelect={ this.logReason }
+					options={ options }
+				/>
+				{ renderFull ? this.renderFull( reasonSelected ) : null }
+			</div>
+		);
+	}
+}
+
+export default connect( state => ( {
+	siteIsJetpack: isJetpackSite( state, getSelectedSiteId( state ) ),
+	siteSlug: getSelectedSiteSlug( state ),
+} ) )( localize( DisconnectSurvey ) );

--- a/client/my-sites/site-settings/disconnect-site/index.jsx
+++ b/client/my-sites/site-settings/disconnect-site/index.jsx
@@ -11,6 +11,7 @@ import page from 'page';
  * Internal dependencies
  */
 import Card from 'components/card';
+import DisconnectSurvey from './disconnect-survey';
 import DocumentHead from 'components/data/document-head';
 import FormattedHeader from 'components/formatted-header';
 import Main from 'components/main';
@@ -40,7 +41,9 @@ class DisconnectSite extends Component {
 						'Tell us why you want to disconnect your site from Wordpress.com.'
 					) }
 				/>
-				<Card className="disconnect-site__card"> </Card>
+				<Card className="disconnect-site__card">
+					<DisconnectSurvey />
+				</Card>
 				<PaginationFlow />
 			</Main>
 		);

--- a/client/my-sites/site-settings/disconnect-site/index.jsx
+++ b/client/my-sites/site-settings/disconnect-site/index.jsx
@@ -3,8 +3,10 @@
  * External dependencies
  */
 import React, { Component } from 'react';
+import { connect } from 'react-redux';
 import { flowRight } from 'lodash';
 import { localize } from 'i18n-calypso';
+import page from 'page';
 /**
  * Internal dependencies
  */
@@ -14,14 +16,24 @@ import FormattedHeader from 'components/formatted-header';
 import Main from 'components/main';
 import PaginationFlow from './pagination-flow';
 import redirectNonJetpackToGeneral from 'my-sites/site-settings/redirect-to-general';
+import ReturnToPreviousPage from 'my-sites/site-settings/render-return-button/back';
+import { getSelectedSiteSlug } from 'state/ui/selectors';
 
 class DisconnectSite extends Component {
+	// when complete, the flow will start from /settings/manage-connection
+	handleClickBack = () => {
+		const { siteSlug } = this.props;
+
+		page( '/settings/manage-connection/' + siteSlug );
+	};
+
 	render() {
 		const { translate } = this.props;
 
 		return (
 			<Main className="disconnect-site site-settings">
 				<DocumentHead title={ translate( 'Site Settings' ) } />
+				<ReturnToPreviousPage onBackClick={ this.handleClickBack } { ...this.props } />
 				<FormattedHeader
 					headerText={ translate( 'Disconnect Site' ) }
 					subHeaderText={ translate(
@@ -35,4 +47,12 @@ class DisconnectSite extends Component {
 	}
 }
 
-export default flowRight( localize, redirectNonJetpackToGeneral )( DisconnectSite );
+const connectComponent = connect( state => {
+	return {
+		siteSlug: getSelectedSiteSlug( state ),
+	};
+} );
+
+export default flowRight( connectComponent, localize, redirectNonJetpackToGeneral )(
+	DisconnectSite
+);

--- a/client/my-sites/site-settings/disconnect-site/style.scss
+++ b/client/my-sites/site-settings/disconnect-site/style.scss
@@ -24,3 +24,9 @@
 			text-align: center;
 		}
 }
+
+.disconnect-site__question {
+		padding-bottom: 20px;
+		padding-bottom: 20px;
+		text-align: left;
+}

--- a/client/my-sites/site-settings/render-return-button/back.jsx
+++ b/client/my-sites/site-settings/render-return-button/back.jsx
@@ -1,0 +1,30 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { localize } from 'i18n-calypso';
+import Gridicon from 'gridicons';
+import PropTypes from 'prop-types';
+
+/**
+ * Internal dependencies
+ */
+import Button from 'components/button';
+
+const ReturnToPreviousPage = ( { onBackClick, translate } ) => {
+	return (
+		<Button className="render-return-button__container" borderless compact onClick={ onBackClick }>
+			<Gridicon icon="arrow-left" />
+			<span className="render-return-button__label">
+				{ translate( 'Back' ) }
+			</span>
+		</Button>
+	);
+};
+
+ReturnToPreviousPage.propTypes = {
+	onBackClick: PropTypes.func.isRequired,
+};
+
+export default localize( ReturnToPreviousPage );

--- a/client/my-sites/site-settings/render-return-button/style.scss
+++ b/client/my-sites/site-settings/render-return-button/style.scss
@@ -1,0 +1,30 @@
+.render-return-button__container {
+	margin: 0;
+	position: fixed;
+		top: 47px;
+		left: 600px;
+		bottom: 200px;
+
+	.button.is-compact.is-borderless {
+		padding: 18px 40px 18px 20px;
+
+		@include breakpoint( "<660px" ) {
+			padding: 20px 8px 16px;
+		}
+	}
+
+	@include breakpoint( "<660px" ) {
+		top: 0;
+		left: 0;
+		right: 0;
+		height: 46px;
+		background: $white;
+		border-bottom: 1px solid $gray-light;
+	}
+}
+
+.render-return-button__label {
+	@include breakpoint( "<660px") {
+		display: none;
+	}
+}


### PR DESCRIPTION
This PR completes the visual aspect of the first screen of the JP disconnect flow.
The design consists of two QAa, where the answers are selectable using Dropdown components.

The follow-up PR will deal with storing the survey data.

**Depends on**: https://github.com/Automattic/wp-calypso/pull/17691 and https://github.com/Automattic/wp-calypso/pull/17155

**To test**:
- Checkout this branch, or use calypso.live:

in progress

**Visuals**:
![screen shot 2017-09-01 at 12 41 56](https://user-images.githubusercontent.com/13561163/29966807-d39ad526-8f13-11e7-9446-fd610a6eb904.png)

