### PR TITLE
Framework: Created new selector getSitesItems

### DIFF
--- a/client/state/selectors/get-sites-items.js
+++ b/client/state/selectors/get-sites-items.js
@@ -1,0 +1,9 @@
+/**
+ * Returns site items object or empty object.
+ *
+ * @param  {Object} state  Global state tree
+ * @return {Object}        Site items object or empty object
+ */
+export default function getSitesItems( state ) {
+	return state.sites.items || {};
+}

--- a/client/state/selectors/index.js
+++ b/client/state/selectors/index.js
@@ -116,6 +116,7 @@ export getSiteId from './get-site-id';
 export getSiteMonitorSettings from './get-site-monitor-settings';
 export getSiteOptions from './get-site-options';
 export getSites from './get-sites';
+export getSitesItems from './get-sites-items';
 export getSiteSetting from './get-site-setting';
 export getSiteSlugsForUpcomingTransactions from './get-site-slugs-for-upcoming-transactions';
 export getSiteStatsQueryDate from './get-site-stats-query-date';

--- a/client/state/selectors/test/get-sites-items.js
+++ b/client/state/selectors/test/get-sites-items.js
@@ -1,0 +1,38 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { getSitesItems } from '../';
+
+describe( 'getSitesItems()', () => {
+	it( 'should return site items if sites exist', () => {
+		const state = {
+			sites: {
+				items: { 1: { ID: 1 } },
+			},
+		};
+		expect( getSitesItems( state ) ).to.eql( { 1: { ID: 1 } } );
+	} );
+
+	it( 'should return empty object if site items are empty', () => {
+		const state = {
+			sites: {
+				items: {},
+			},
+		};
+		expect( getSitesItems( state ) ).to.eql( {} );
+	} );
+
+	it( 'should return empty object if site items are null (not loaded)', () => {
+		const state = {
+			sites: {
+				items: null,
+			},
+		};
+		expect( getSitesItems( state ) ).to.eql( {} );
+	} );
+} );


### PR DESCRIPTION
With the change of site items initial state to null a frequent use case of using the empty object when site.items is null appeared. This selector returns site.items object or an empty object if site items are null.

Use cases:
This selector is going to replace all usages of `state.sites.items || {}` in PR https://github.com/Automattic/wp-calypso/pull/17364.

To test:
This PR just creates a selector it is not used yet so executing automatic tests that include this selector should be enougth.
npm run test-client client/state/selectors/test