### PR TITLE
Jetpack Connect: Update the names for plan selection tracking events.

### DIFF
--- a/client/jetpack-connect/plans.jsx
+++ b/client/jetpack-connect/plans.jsx
@@ -220,37 +220,37 @@ class Plans extends Component {
 		}
 
 		if ( cartItem.product_slug === PLAN_JETPACK_PERSONAL ) {
-			this.props.recordTracksEvent( 'calypso_jpc_plans_submit_39', {
+			this.props.recordTracksEvent( 'calypso_jpc_plans_submit_personal', {
 				user: this.props.userId
 			} );
 			mc.bumpStat( 'calypso_jpc_plan_selection', 'jetpack_personal' );
 		}
 		if ( cartItem.product_slug === PLAN_JETPACK_PERSONAL_MONTHLY ) {
-			this.props.recordTracksEvent( 'calypso_jpc_plans_submit_3', {
+			this.props.recordTracksEvent( 'calypso_jpc_plans_submit_personal_monthly', {
 				user: this.props.userId
 			} );
 			mc.bumpStat( 'calypso_jpc_plan_selection', 'jetpack_personal_monthly' );
 		}
 		if ( cartItem.product_slug === PLAN_JETPACK_PREMIUM ) {
-			this.props.recordTracksEvent( 'calypso_jpc_plans_submit_99', {
+			this.props.recordTracksEvent( 'calypso_jpc_plans_submit_premium', {
 				user: this.props.userId
 			} );
 			mc.bumpStat( 'calypso_jpc_plan_selection', 'jetpack_premium' );
 		}
 		if ( cartItem.product_slug === PLAN_JETPACK_PREMIUM_MONTHLY ) {
-			this.props.recordTracksEvent( 'calypso_jpc_plans_submit_12', {
+			this.props.recordTracksEvent( 'calypso_jpc_plans_submit_premium_monthly', {
 				user: this.props.userId
 			} );
 			mc.bumpStat( 'calypso_jpc_plan_selection', 'jetpack_premium_monthly' );
 		}
 		if ( cartItem.product_slug === PLAN_JETPACK_BUSINESS ) {
-			this.props.recordTracksEvent( 'calypso_jpc_plans_submit_299', {
+			this.props.recordTracksEvent( 'calypso_jpc_plans_submit_business', {
 				user: this.props.userId
 			} );
 			mc.bumpStat( 'calypso_jpc_plan_selection', 'jetpack_business' );
 		}
 		if ( cartItem.product_slug === PLAN_JETPACK_BUSINESS_MONTHLY ) {
-			this.props.recordTracksEvent( 'calypso_jpc_plans_submit_29', {
+			this.props.recordTracksEvent( 'calypso_jpc_plans_submit_business_monthly', {
 				user: this.props.userId
 			} );
 			mc.bumpStat( 'calypso_jpc_plan_selection', 'jetpack_business_monthly' );


### PR DESCRIPTION
To ensure that our tracking is not negatively affected by (potential)
future pricing changes, the plan selection event names should use the
product slug, not the price point.

To test, simply go through the Jetpack Connect flow, select any plan to
trigger these events, and check on the backend to make sure that the
new event was fired correctly.