### PR TITLE
Login: Fix wrong master bar displayed for non DOPS services

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -23,6 +23,7 @@ import {
 	getSocialAccountLinkService,
 } from 'state/login/selectors';
 import { getCurrentOAuth2Client } from 'state/ui/oauth2-clients/selectors';
+import { isWooOAuth2Client } from 'lib/oauth2-clients';
 import { recordTracksEvent } from 'state/analytics/actions';
 import VerificationCodeForm from './two-factor-authentication/verification-code-form';
 import WaitingTwoFactorNotificationApproval from './two-factor-authentication/waiting-notification-approval';
@@ -145,7 +146,8 @@ class Login extends Component {
 				},
 				comment: "'clientTitle' is the name of the app that uses WordPress.com authentication (e.g. 'Akismet' or 'VaultPress')"
 			} );
-			if ( oauth2Client.name === 'woo' ) {
+
+			if ( isWooOAuth2Client( oauth2Client ) ) {
 				preHeader = (
 					<Gridicon icon="my-sites" size={ 72 } />
 				);

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -21,7 +21,7 @@ const LayoutLoggedOut = ( {
 	redirectUri,
 	useOAuth2Layout,
 } ) => {
-	const classNameObject = {
+	const classes = {
 		[ 'is-group-' + section.group ]: !! section,
 		[ 'is-section-' + section.name ]: !! section,
 		'focus-content': true,
@@ -32,17 +32,14 @@ const LayoutLoggedOut = ( {
 	let masterbar = null;
 
 	if ( useOAuth2Layout ) {
-		const hasValidOAuth2ClientData = !! oauth2Client;
-		const oauthClientName = hasValidOAuth2ClientData && oauth2Client.name;
-		classNameObject.dops = hasValidOAuth2ClientData;
-		classNameObject[ oauthClientName ] = hasValidOAuth2ClientData;
-
-		if ( oauthClientName ) {
-			masterbar = <OauthClientMasterbar oauth2Client={ oauth2Client } />;
+		// Uses custom styles for DOPS clients and WooCommerce - which are the only ones with a name property defined
+		if ( oauth2Client.name ) {
+			classes.dops = true;
+			classes[ oauth2Client.name ] = true;
 		}
-	}
 
-	if ( ! masterbar ) {
+		masterbar = <OauthClientMasterbar oauth2Client={ oauth2Client } />;
+	} else {
 		masterbar = <MasterbarLoggedOut
 			title={ section.title }
 			sectionName={ section.name }
@@ -51,12 +48,14 @@ const LayoutLoggedOut = ( {
 	}
 
 	return (
-		<div className={ classNames( 'layout', classNameObject ) }>
+		<div className={ classNames( 'layout', classes ) }>
 			{ masterbar }
+
 			<div id="content" className="layout__content">
 				<div id="primary" className="layout__primary">
 					{ primary }
 				</div>
+
 				<div id="secondary" className="layout__secondary">
 				</div>
 			</div>

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -31,12 +31,10 @@ const LayoutLoggedOut = ( {
 
 	let masterbar = null;
 
-	if ( useOAuth2Layout ) {
-		// Uses custom styles for DOPS clients and WooCommerce - which are the only ones with a name property defined
-		if ( oauth2Client.name ) {
-			classes.dops = true;
-			classes[ oauth2Client.name ] = true;
-		}
+	// Uses custom styles for DOPS clients and WooCommerce - which are the only ones with a name property defined
+	if ( useOAuth2Layout && oauth2Client && oauth2Client.name ) {
+		classes.dops = true;
+		classes[ oauth2Client.name ] = true;
 
 		masterbar = <OauthClientMasterbar oauth2Client={ oauth2Client } />;
 	} else {

--- a/client/layout/masterbar/oauth-client.jsx
+++ b/client/layout/masterbar/oauth-client.jsx
@@ -16,9 +16,9 @@ const OauthClientMasterbar = ( { oauth2Client } ) => (
 			<ul className="masterbar__oauth-client-main-nav">
 				<li className="masterbar__oauth-client-current">
 					{ oauth2Client.icon && (
-						<a className="masterbar__oauth-client-logo">
+						<div className="masterbar__oauth-client-logo">
 							<img src={ oauth2Client.icon } />
-						</a>
+						</div>
 					) }
 				</li>
 			</ul>

--- a/client/layout/masterbar/oauth-client.jsx
+++ b/client/layout/masterbar/oauth-client.jsx
@@ -10,19 +10,19 @@ import PropTypes from 'prop-types';
  */
 import { addLocaleToWpcomUrl, getLocaleSlug } from 'lib/i18n-utils';
 
-const OauthClientMasterbar = ( { oauth2Client } ) => (
+const OauthClientMasterbar = ( { oauth2Client } ) => (
 	<header className="masterbar masterbar__oauth-client">
 		<nav>
 			<ul className="masterbar__oauth-client-main-nav">
 				<li className="masterbar__oauth-client-current">
-					<a className="masterbar__oauth-client-logo">
-						<img
-							src={ oauth2Client.img_url }
-							width={ oauth2Client.img_width }
-							height={ oauth2Client.img_height } />
-					</a>
+					{ oauth2Client.icon && (
+						<a className="masterbar__oauth-client-logo">
+							<img src={ oauth2Client.icon } />
+						</a>
+					) }
 				</li>
 			</ul>
+
 			{ oauth2Client.name === 'woo' ? (
 				<li className="masterbar__oauth-client-close">
 					<a href="https://woocommerce.com">Cancel <span>X</span></a>

--- a/client/layout/masterbar/oauth-client.jsx
+++ b/client/layout/masterbar/oauth-client.jsx
@@ -9,6 +9,7 @@ import PropTypes from 'prop-types';
  * Internal dependencies
  */
 import { addLocaleToWpcomUrl, getLocaleSlug } from 'lib/i18n-utils';
+import { isWooOAuth2Client } from 'lib/oauth2-clients';
 
 const OauthClientMasterbar = ( { oauth2Client } ) => (
 	<header className="masterbar masterbar__oauth-client">
@@ -23,7 +24,7 @@ const OauthClientMasterbar = ( { oauth2Client } ) => (
 				</li>
 			</ul>
 
-			{ oauth2Client.name === 'woo' ? (
+			{ isWooOAuth2Client( oauth2Client ) ? (
 				<li className="masterbar__oauth-client-close">
 					<a href="https://woocommerce.com">Cancel <span>X</span></a>
 				</li>

--- a/client/layout/masterbar/oauth-client.jsx
+++ b/client/layout/masterbar/oauth-client.jsx
@@ -22,14 +22,12 @@ const OauthClientMasterbar = ( { oauth2Client } ) => (
 						</div>
 					) }
 				</li>
-			</ul>
 
-			{ isWooOAuth2Client( oauth2Client ) ? (
-				<li className="masterbar__oauth-client-close">
-					<a href="https://woocommerce.com">Cancel <span>X</span></a>
-				</li>
-			) : (
-				<ul className="masterbar__oauth-client-user-nav">
+				{ isWooOAuth2Client( oauth2Client ) ? (
+					<li className="masterbar__oauth-client-close">
+						<a href="https://woocommerce.com">Cancel <span>X</span></a>
+					</li>
+				) : (
 					<li className="masterbar__oauth-client-wpcc-sign-in">
 						<a
 							href={ addLocaleToWpcomUrl( 'https://wordpress.com/', getLocaleSlug() ) }
@@ -40,8 +38,8 @@ const OauthClientMasterbar = ( { oauth2Client } ) => (
 							WordPress.com
 						</a>
 					</li>
-				</ul>
-			) }
+				) }
+			</ul>
 		</nav>
 	</header>
 );

--- a/client/layout/masterbar/oauth-client.scss
+++ b/client/layout/masterbar/oauth-client.scss
@@ -1,6 +1,5 @@
 .masterbar__oauth-client {
 	background-color: $blue-wordpress;
-	height: 50px;
 
 	nav {
 		display: flex;
@@ -26,15 +25,19 @@
 	}
 }
 
+.masterbar__oauth-client-logo img {
+	max-height: 46px;
+}
+
 .masterbar__oauth-client-wpcc-sign-in {
 	background-color: rgba(255, 255, 255, 0.15);
 	border-radius: 3px;
 	color: #fff;
 	display: block;
 	line-height: 100%;
-	margin-right: 5px;
+	margin-right: 4px;
 	position: relative;
-	top: 6px;
+	top: 4px;
 
 	&:hover {
 		background: rgba(255, 255, 255, 0.2);
@@ -104,9 +107,8 @@
 	}
 
 	.masterbar__oauth-client-logo img {
-		max-width: none;
+		max-height: 41px;
 		margin-top: 22px;
-		vertical-align: middle;
 	}
 
 	.masterbar__oauth-client-main-nav {

--- a/client/layout/masterbar/oauth-client.scss
+++ b/client/layout/masterbar/oauth-client.scss
@@ -26,7 +26,7 @@
 }
 
 .masterbar__oauth-client-logo img {
-	max-height: 46px;
+	max-height: 47px;
 }
 
 .masterbar__oauth-client-wpcc-sign-in {

--- a/client/layout/masterbar/oauth-client.scss
+++ b/client/layout/masterbar/oauth-client.scss
@@ -9,7 +9,6 @@
 
 	ul {
 		margin: 0;
-		padding-left: 0;
 
 		li {
 			list-style-type: none;
@@ -25,6 +24,14 @@
 	}
 }
 
+.masterbar__oauth-client-main-nav {
+	width: 100%;
+}
+
+.masterbar__oauth-client-current {
+	float: left;
+}
+
 .masterbar__oauth-client-logo img {
 	max-height: 47px;
 }
@@ -34,6 +41,7 @@
 	border-radius: 3px;
 	color: #fff;
 	display: block;
+	float: right;
 	line-height: 100%;
 	margin-right: 4px;
 	position: relative;
@@ -91,42 +99,40 @@
 		background-color: #fff;
 		border: 1px solid #d3d3d3;
 		box-sizing: border-box;
-		height: 83px;
+		height: 85px;
 		line-height: 83px;
 		margin: 0 auto;
-		padding: 0 10px;
 		z-index: 100;
 
-		a {
-			color: #fff;
-			float: left;
-			line-height: 55px;
-			padding: 0 10px;
-			transition: 0.05 all ease-in-out;
+		nav {
+			box-sizing: border-box;
+			max-width: 1500px;
+			margin-left: auto;
+			margin-right: auto;
+			padding-left: 55px;
+			padding-right: 13px;
 		}
 	}
 
-	.masterbar__oauth-client-logo img {
-		max-height: 41px;
-		margin-top: 22px;
-	}
+	.masterbar__oauth-client-logo {
+		padding-top: 23px;
+		transition: 0.05 all ease-in-out;
 
-	.masterbar__oauth-client-main-nav {
-		margin: 0;
+		img {
+			max-height: 37px;
+		}
 	}
 
 	.masterbar__oauth-client-close {
 		float: right;
-		padding-top: 13px;
 
 		a {
 			color: #999;
-			cursor: pointer;
-			float: right;
 			font-size: 0.9em;
+			font-weight: bold;
+			padding: 32px;
 			text-decoration: none;
 			text-transform: uppercase;
-			font-weight: bold;
 		}
 	}
 

--- a/client/lib/oauth2-clients.js
+++ b/client/lib/oauth2-clients.js
@@ -1,0 +1,8 @@
+/**
+ * External dependencies
+ */
+import { includes } from 'lodash';
+
+export const isWooOAuth2Client = ( oauth2Client ) => {
+	return includes( [ 50019, 50915, 50916 ], oauth2Client.id );
+};

--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -48,22 +48,26 @@ export default {
 
 			if ( client_id !== redirectQueryString.client_id ) {
 				recordTracksEvent( 'calypso_login_phishing_attempt', context.query );
+
 				return next( new Error( 'The `redirect_to` query parameter is invalid with the given `client_id`.' ) );
 			}
 
 			context.store.dispatch( fetchOAuth2ClientData( Number( client_id ) ) )
 				.then( () => {
 					enhanceContextWithLogin( context );
+
 					next();
-				} );
+				} ).catch( error => next( error ) );
 		} else {
 			enhanceContextWithLogin( context );
+
 			next();
 		}
 	},
 
 	magicLogin( context, next ) {
 		context.primary = <MagicLogin />;
+
 		next();
 	},
 

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -10,6 +10,7 @@ import { identity, omit } from 'lodash';
 /**
  * Internal dependencies
  */
+import { isWooOAuth2Client } from 'lib/oauth2-clients';
 import StepWrapper from 'signup/step-wrapper';
 import SignupForm from 'components/signup-form';
 import signupUtils from 'signup/utils';
@@ -59,7 +60,7 @@ export class UserStep extends Component {
 		let subHeaderText = props.subHeaderText;
 
 		if ( flowName === 'wpcc' && oauth2Client ) {
-			if ( oauth2Client.name === 'woo' ) {
+			if ( isWooOAuth2Client( oauth2Client ) ) {
 				subHeaderText = translate( '{{a}}Learn more about the benefits{{/a}}', {
 					components: {
 						a: <a href="https://woocommerce.com/2017/01/woocommerce-requires-wordpress-account/"

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -59,7 +59,7 @@ export class UserStep extends Component {
 		let subHeaderText = props.subHeaderText;
 
 		if ( flowName === 'wpcc' && oauth2Client ) {
-			if ( oauth2Client.id === 50916 ) {
+			if ( oauth2Client.name === 'woo' ) {
 				subHeaderText = translate( '{{a}}Learn more about the benefits{{/a}}', {
 					components: {
 						a: <a href="https://woocommerce.com/2017/01/woocommerce-requires-wordpress-account/"

--- a/client/state/oauth2-clients/reducer.js
+++ b/client/state/oauth2-clients/reducer.js
@@ -18,57 +18,43 @@ export const initialClientsData = {
 		id: 930,
 		name: 'vaultpress',
 		title: 'Vaultpress',
-		img_url: 'https://vaultpress.com/images/vaultpress-wpcc-nav-2x.png',
-		img_height: 50,
-		img_width: 70,
+		icon: 'https://vaultpress.com/images/vaultpress-wpcc-nav-2x.png',
 	},
 	973: {
 		id: 973,
 		name: 'akismet',
 		title: 'Akismet',
-		img_url: 'https://akismet.com/img/akismet-wpcc-logo-2x.png',
-		img_height: 50,
-		img_width: 70,
+		icon: 'https://akismet.com/img/akismet-wpcc-logo-2x.png',
 	},
 	978: {
 		id: 978,
 		name: 'polldaddy',
 		title: 'Polldaddy',
-		img_url: 'https://polldaddy.com/images/polldaddy-wpcc-logo-2x.png',
-		img_height: 50,
-		img_width: 70,
+		icon: 'https://polldaddy.com/images/polldaddy-wpcc-logo-2x.png',
 	},
 	1854: {
 		id: 1854,
 		name: 'gravatar',
 		title: 'Gravatar',
-		img_url: 'https://gravatar.com/images/grav-logo-2x.png',
-		img_height: 50,
-		img_width: 70,
+		icon: 'https://gravatar.com/images/grav-logo-2x.png',
 	},
 	50019: {
 		id: 50019,
 		name: 'woo',
 		title: 'WooCommerce',
-		img_url: 'https://woocommerce.com/wp-content/themes/woomattic/images/logo-woocommerce@2x.png',
-		img_height: 41,
-		img_width: 200,
+		icon: 'https://woocommerce.com/wp-content/themes/woomattic/images/logo-woocommerce@2x.png',
 	},
 	50915: {
 		id: 50915,
 		name: 'woo',
 		title: 'WooCommerce',
-		img_url: 'https://woocommerce.com/wp-content/themes/woomattic/images/logo-woocommerce@2x.png',
-		img_height: 41,
-		img_width: 200,
+		icon: 'https://woocommerce.com/wp-content/themes/woomattic/images/logo-woocommerce@2x.png',
 	},
 	50916: {
 		id: 50916,
 		name: 'woo',
 		title: 'WooCommerce.com',
-		img_url: 'https://woocommerce.com/wp-content/themes/woomattic/images/logo-woocommerce@2x.png',
-		img_height: 41,
-		img_width: 200,
+		icon: 'https://woocommerce.com/wp-content/themes/woomattic/images/logo-woocommerce@2x.png',
 	},
 };
 
@@ -94,22 +80,9 @@ const getClientIdFromSignupUrl = signupUrl => {
 	return oauth2RedirectParams.client_id;
 };
 
-/**
- * Parses and normalizes data returned by the API.
- *
- * @param {Object} data - raw data
- * @return {Object} the normalized data
- */
-const fromApi = ( { icon, id, title, url } ) => ( {
-	id: Number( id ),
-	title,
-	url,
-	icon
-} );
-
 export default createReducer( initialClientsData, {
 	[ OAUTH2_CLIENT_DATA_REQUEST_SUCCESS ]: ( state, { data } ) => {
-		const newData = Object.assign( {}, state[ data.id ], fromApi( data ) );
+		const newData = Object.assign( {}, state[ data.id ], data );
 
 		return Object.assign( {}, state, { [ data.id ]: newData } );
 	},


### PR DESCRIPTION
This pull request fixes a wrong master bar displayed for OAuth clients that are not one of our DOPS services (Akismet, Polldaddy, VaultPress ...), e.g.:

#### Before

<img width="624" alt="before" src="https://user-images.githubusercontent.com/594356/29974856-9153bc48-8f34-11e7-8d2e-5758f6a6b19e.png">

#### After

<img width="625" alt="after" src="https://user-images.githubusercontent.com/594356/29974865-9505b7a6-8f34-11e7-8381-31c91d9bf2fe.png">

Moreover, this pull request:

* Fixes a wrong master bar height for DOPS services
* Handles the new data structure returned by the API
* Enforces the logo size only from CSS
* Simplifies the code a bit, and adds a few more unit tests

It also fixes an unhandled promise rejection when the OAuth client data could not be retrieved from the API in order to display the appropriate error page. Finally, it makes sure we display the right subheader on the `Signup` page for all WooCommerce apps.

#### Testing instructions
 
1. Run `git checkout fix/oauth-master-bar` and start your server
2. Enable your proxy
3. Apply D7136-code patch to your sandbox
4. Point `public-api.wordpress.com` to your sandbox

##### Non DOPS service

5. Open the IntenseDebate [`Home` page](http://www.intensedebate.com/) in an incognito window
6. Click the `Sign In Here` link located in the upper right corner
7. Click the `Sign in with WordPress.com` button
8. Assert that you are redirected to the new [`Login` page](https://wordpress.com/log-in)
9. Duplicate your browser's current tab to ease comparison
10. Replace `https://wordpress.com` with `http://calypso.localhost:3000` in this new tab's url
11. Hit <kbd>Enter</kbd> to reload the page
12. Compare both pages and assert that the right master bar is now displayed

##### DOPS service with default look-and-feel

5. Open the Gravatar [`Home` page](https://fr.gravatar.com/) in French in an incognito window
6. Click the `Connexion` button in the upper right corner
7. Assert that you are redirected to the new [`Login` page](https://wordpress.com/log-in)
8. Duplicate your browser's current tab to ease comparison
9. Replace `https://wordpress.com` with `http://calypso.localhost:3000` in this new tab's url
10. Hit <kbd>Enter</kbd> to reload the page
11. Compare both pages and assert that the master bar now has the right height

##### DOPS service with custom look-and-feel

5. Open the WooCommerce [`Home` page](https://woocommerce.com/)
6. Click the `SIGN IN WITH WORDPRESS.COM` link
7. Assert that you are redirected to the new [`Login` page](https://wordpress.com/log-in)
8. Duplicate your browser's current tab to ease comparison
9. Replace `https://wordpress.com` with `http://calypso.localhost:3000` in this new tab's url
10. Hit <kbd>Enter</kbd> to reload the page
11. Compare both pages and assert that they look the same

#### Reviews
 
- [x] Code
- [x] Product
- [ ] Tests