### PR TITLE
Plugins: migrate usage of this.translate to this.props.translate

### DIFF
--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -119,26 +119,27 @@ const PluginsMain = React.createClass( {
 	},
 
 	getFilters() {
+		const { translate } = this.props;
 		const siteFilter = this.props.selectedSiteSlug ? '/' + this.props.selectedSiteSlug : '';
 
 		return [
 			{
-				title: this.translate( 'All', { context: 'Filter label for plugins list' } ),
+				title: translate( 'All', { context: 'Filter label for plugins list' } ),
 				path: '/plugins' + siteFilter,
 				id: 'all'
 			},
 			{
-				title: this.translate( 'Active', { context: 'Filter label for plugins list' } ),
+				title: translate( 'Active', { context: 'Filter label for plugins list' } ),
 				path: '/plugins/active' + siteFilter,
 				id: 'active'
 			},
 			{
-				title: this.translate( 'Inactive', { context: 'Filter label for plugins list' } ),
+				title: translate( 'Inactive', { context: 'Filter label for plugins list' } ),
 				path: '/plugins/inactive' + siteFilter,
 				id: 'inactive'
 			},
 			{
-				title: this.translate( 'Updates', { context: 'Filter label for plugins list' } ),
+				title: translate( 'Updates', { context: 'Filter label for plugins list' } ),
 				path: '/plugins/updates' + siteFilter,
 				id: 'updates'
 			}
@@ -159,59 +160,62 @@ const PluginsMain = React.createClass( {
 	},
 
 	getSearchPlaceholder() {
+		const { translate } = this.props;
+
 		switch ( this.props.filter ) {
 			case 'active':
-				return this.translate( 'Search All…', { textOnly: true } );
+				return translate( 'Search All…', { textOnly: true } );
 
 			case 'inactive':
-				return this.translate( 'Search Inactive…', { textOnly: true } );
+				return translate( 'Search Inactive…', { textOnly: true } );
 
 			case 'updates':
-				return this.translate( 'Search Updates…', { textOnly: true } );
+				return translate( 'Search Updates…', { textOnly: true } );
 
 			case 'all':
-				return this.translate( 'Search All…', { textOnly: true } );
+				return translate( 'Search All…', { textOnly: true } );
 		}
 	},
 
 	getEmptyContentUpdateData() {
+		const { translate } = this.props;
 		const emptyContentData = { illustration: '/calypso/images/illustrations/illustration-ok.svg' },
 			{ selectedSite } = this.props;
 
 		if ( selectedSite ) {
-			emptyContentData.title = this.translate( 'All plugins on %(siteName)s are {{span}}up to date.{{/span}}', {
+			emptyContentData.title = translate( 'All plugins on %(siteName)s are {{span}}up to date.{{/span}}', {
 				textOnly: true,
 				args: { siteName: selectedSite.title },
 				components: { span: <span className="plugins__plugin-list-state" /> },
 				comment: 'The span tags prevents single words from showing on a single line.'
 			} );
 		} else {
-			emptyContentData.title = this.translate( 'All plugins are up to date.', { textOnly: true } );
+			emptyContentData.title = translate( 'All plugins are up to date.', { textOnly: true } );
 		}
 
 		if ( this.getUpdatesTabVisibility() ) {
 			return emptyContentData;
 		}
 
-		emptyContentData.action = this.translate( 'All Plugins', { textOnly: true } );
+		emptyContentData.action = translate( 'All Plugins', { textOnly: true } );
 
 		if ( selectedSite ) {
 			emptyContentData.actionURL = '/plugins/' + selectedSite.slug;
 			if ( this.props.selectedSiteIsJetpack ) {
 				emptyContentData.illustration = '/calypso/images/illustrations/illustration-jetpack.svg';
-				emptyContentData.title = this.translate( 'Plugins can\'t be updated on %(siteName)s.', {
+				emptyContentData.title = translate( 'Plugins can\'t be updated on %(siteName)s.', {
 					textOnly: true,
 					args: { siteName: selectedSite.title }
 				} );
 			} else {
 				// buisness plan sites
-				emptyContentData.title = this.translate( 'Plugins are updated automatically on %(siteName)s.', {
+				emptyContentData.title = translate( 'Plugins are updated automatically on %(siteName)s.', {
 					textOnly: true,
 					args: { siteName: selectedSite.title }
 				} );
 			}
 		} else {
-			emptyContentData.title = this.translate( 'No updates are available.', { textOnly: true } );
+			emptyContentData.title = translate( 'No updates are available.', { textOnly: true } );
 			emptyContentData.illustration = '/calypso/images/illustrations/illustration-empty-results.svg';
 			emptyContentData.actionURL = '/plugins';
 		}
@@ -220,14 +224,15 @@ const PluginsMain = React.createClass( {
 	},
 
 	getEmptyContentData() {
+		const { translate } = this.props;
 		let emptyContentData = { illustration: '/calypso/images/illustrations/illustration-empty-results.svg', };
 
 		switch ( this.props.filter ) {
 			case 'active':
-				emptyContentData.title = this.translate( 'No plugins are active.', { textOnly: true } );
+				emptyContentData.title = translate( 'No plugins are active.', { textOnly: true } );
 				break;
 			case 'inactive':
-				emptyContentData.title = this.translate( 'No plugins are inactive.', { textOnly: true } );
+				emptyContentData.title = translate( 'No plugins are inactive.', { textOnly: true } );
 				break;
 			case 'updates':
 				emptyContentData = this.getEmptyContentUpdateData();
@@ -258,7 +263,7 @@ const PluginsMain = React.createClass( {
 	},
 
 	renderDocumentHead() {
-		return <DocumentHead title={ this.translate( 'Plugins', { textOnly: true } ) } />;
+		return <DocumentHead title={ this.props.translate( 'Plugins', { textOnly: true } ) } />;
 	},
 
 	renderPluginsContent() {
@@ -267,7 +272,7 @@ const PluginsMain = React.createClass( {
 
 		if ( isEmpty( plugins ) && ! this.isFetchingPlugins() ) {
 			if ( this.props.search ) {
-				const searchTitle = this.translate( 'Suggested plugins for: %(searchQuery)s', {
+				const searchTitle = this.props.translate( 'Suggested plugins for: %(searchQuery)s', {
 					textOnly: true,
 					args: {
 						searchQuery: this.props.search
@@ -297,7 +302,7 @@ const PluginsMain = React.createClass( {
 		return (
 			<div className="plugins__lists">
 				<PluginsList
-					header={ this.translate( 'Plugins' ) }
+					header={ this.props.translate( 'Plugins' ) }
 					plugins={ plugins }
 					sites={ this.props.sites }
 					pluginUpdateCount={ this.state.pluginUpdateCount }
@@ -373,7 +378,7 @@ const PluginsMain = React.createClass( {
 					<JetpackManageErrorPage
 						template="optInManage"
 						siteId={ selectedSiteId }
-						title={ this.translate( 'Looking to manage this site\'s plugins?' ) }
+						title={ this.props.translate( 'Looking to manage this site\'s plugins?' ) }
 						section="plugins"
 						featureExample={ this.getMockPluginItems() } />
 				</Main>

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -123,11 +123,11 @@ const PluginsBrowser = React.createClass( {
 	translateCategory( category ) {
 		switch ( category ) {
 			case 'new':
-				return this.translate( 'New', { context: 'Category description for the plugin browser.' } );
+				return this.props.translate( 'New', { context: 'Category description for the plugin browser.' } );
 			case 'popular':
-				return this.translate( 'Popular', { context: 'Category description for the plugin browser.' } );
+				return this.props.translate( 'Popular', { context: 'Category description for the plugin browser.' } );
 			case 'featured':
-				return this.translate( 'Featured', { context: 'Category description for the plugin browser.' } );
+				return this.props.translate( 'Featured', { context: 'Category description for the plugin browser.' } );
 		}
 	},
 
@@ -147,7 +147,7 @@ const PluginsBrowser = React.createClass( {
 	getSearchListView( searchTerm ) {
 		const isFetching = this.state.fullLists.search ? !! this.state.fullLists.search.fetching : true;
 		if ( this.getPluginsFullList( 'search' ).length > 0 || isFetching ) {
-			const searchTitle = this.props.searchTitle || this.translate( 'Results for: %(searchTerm)s', {
+			const searchTitle = this.props.searchTitle || this.props.translate( 'Results for: %(searchTerm)s', {
 				textOnly: true,
 				args: {
 					searchTerm
@@ -164,7 +164,7 @@ const PluginsBrowser = React.createClass( {
 		return (
 			<NoResults
 				text={
-					this.translate( 'No plugins match your search for {{searchTerm/}}.', {
+					this.props.translate( 'No plugins match your search for {{searchTerm/}}.', {
 						textOnly: true,
 						components: { searchTerm: <em>{ searchTerm }</em> }
 					} )
@@ -222,31 +222,31 @@ const PluginsBrowser = React.createClass( {
 
 	getNavigationBar() {
 		const site = this.props.site ? '/' + this.props.site : '';
-		return <SectionNav selectedText={ this.translate( 'Category', { context: 'Category of plugins to be filtered by' } ) }>
+		return <SectionNav selectedText={ this.props.translate( 'Category', { context: 'Category of plugins to be filtered by' } ) }>
 			<NavTabs label="Category">
 				<NavItem
 					path={ '/plugins/browse' + site }
 					selected={ false }
 				>
-					{ this.translate( 'All', { context: 'Filter all plugins' } ) }
+					{ this.props.translate( 'All', { context: 'Filter all plugins' } ) }
 				</NavItem>
 				<NavItem
 					path={ '/plugins/browse/featured' + site }
 					selected={ this.props.path === ( '/plugins/browse/featured' + site ) }
 				>
-					{ this.translate( 'Featured', { context: 'Filter featured plugins' } ) }
+					{ this.props.translate( 'Featured', { context: 'Filter featured plugins' } ) }
 				</NavItem>
 				<NavItem
 					path={ '/plugins/browse/popular' + site }
 					selected={ this.props.path === ( '/plugins/browse/popular' + site ) }
 				>
-					{ this.translate( 'Popular', { context: 'Filter popular plugins' } ) }
+					{ this.props.translate( 'Popular', { context: 'Filter popular plugins' } ) }
 				</NavItem>
 				<NavItem
 					path={ '/plugins/browse/new' + site }
 					selected={ this.props.path === ( '/plugins/browse/new' + site ) }
 				>
-					{ this.translate( 'New', { context: 'Filter new plugins' } ) }
+					{ this.props.translate( 'New', { context: 'Filter new plugins' } ) }
 				</NavItem>
 			</NavTabs>
 			{ this.getSearchBox( true ) }
@@ -273,12 +273,12 @@ const PluginsBrowser = React.createClass( {
 		return <PluginsBrowserList
 			plugins={ this.getPluginsShortList( 'popular' ) }
 			listName={ 'Plugins' }
-			title={ this.translate( 'Popular Plugins' ) }
+			title={ this.props.translate( 'Popular Plugins' ) }
 			size={ 12 } />;
 	},
 
 	renderDocumentHead() {
-		return <DocumentHead title={ this.translate( 'Plugin Browser', { textOnly: true } ) } />;
+		return <DocumentHead title={ this.props.translate( 'Plugin Browser', { textOnly: true } ) } />;
 	},
 
 	renderJetpackManageError() {
@@ -290,7 +290,7 @@ const PluginsBrowser = React.createClass( {
 				<SidebarNavigation />
 				<JetpackManageErrorPage
 					template="optInManage"
-					title={ this.translate( 'Looking to manage this site\'s plugins?' ) }
+					title={ this.props.translate( 'Looking to manage this site\'s plugins?' ) }
 					siteId={ selectedSiteId }
 					section="plugins"
 					illustration="/calypso/images/jetpack/jetpack-manage.svg"


### PR DESCRIPTION
First spinoff PR from #17537, arguably the most boring one: migrate usages of `this.translate` (coming from the mixin) to `this.props.translate` (coming from the `localize` HOC).
