### PR TITLE
Components: add HeaderButton

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -138,6 +138,7 @@
 @import 'components/global-notices/style';
 @import 'components/gravatar/style';
 @import 'components/happiness-support/style';
+@import 'components/header-button/style';
 @import 'components/header-cake/style';
 @import 'components/hr-with-text/style';
 @import 'components/image/style';

--- a/client/components/header-button/README.md
+++ b/client/components/header-button/README.md
@@ -1,0 +1,33 @@
+HeaderButton
+==================
+
+This component is used to display a large button in the header area, adjacent
+to elements like a `Search`. It takes an `icon` prop that is an ID of a
+`Gridicon`, and a `label` prop that is used as the label of the button.  All
+the other properties are passed to the `Button` component that is used to
+implement this one.
+
+#### How to use:
+
+```js
+import HeaderButton from 'components/header-button';
+
+function MyHeader() {
+	return (
+		<div>
+			<HeaderButton
+				icon="plus-small"
+				label="Add Plugin"
+				href="/plugins/manage"
+			/>
+	  </div>
+	);
+}
+```
+
+#### Props
+
+* `icon` : (string) ID of a `Gridicon` icon
+* `label` : The text label of the button
+
+All other props are passed to the underlying `Button`.

--- a/client/components/header-button/docs/example.jsx
+++ b/client/components/header-button/docs/example.jsx
@@ -1,0 +1,23 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import HeaderButton from 'components/header-button';
+
+export default function HeaderButtonExample() {
+	const onClick = () => alert( 'clicked me!' );
+	return (
+		<div>
+			<HeaderButton
+				icon="plus-small"
+				label="Add Plugin"
+				onClick={ onClick }
+			/>
+		</div>
+		);
+}
+

--- a/client/components/header-button/index.jsx
+++ b/client/components/header-button/index.jsx
@@ -1,0 +1,27 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import React from 'react';
+import PropTypes from 'prop-types';
+import Gridicon from 'gridicons';
+
+/**
+ * Internal dependencies
+ */
+import Button from 'components/button';
+
+const HeaderButton = ( { icon, label, ...rest } ) =>
+	<Button className="header-button" { ...rest }>
+		{ icon && <Gridicon icon={ icon } size={ 18 } /> }
+		<span className="header-button__text">
+			{ label }
+		</span>
+	</Button>;
+
+HeaderButton.propTypes = {
+	icon: PropTypes.string,
+	label: PropTypes.node,
+};
+
+export default HeaderButton;

--- a/client/components/header-button/style.scss
+++ b/client/components/header-button/style.scss
@@ -1,0 +1,34 @@
+.header-button {
+	align-items: center;
+	border: 1px solid transparentize( lighten( $gray, 20% ), .5 );
+	border-width: 0 1px 0 0;
+	border-radius: 0;
+	display: flex;
+	flex-direction: column;
+	font-weight: normal;
+	justify-content: center;
+	min-height: 46px;
+	width: 50%;
+	padding: 0;
+
+	@include breakpoint( ">480px" ) {
+		min-height: 51px;
+	}
+
+	@include breakpoint( ">660px" ) {
+		width: 10em;
+	}
+
+	&:hover {
+		border-color: transparentize( lighten( $gray, 20% ), .5 );
+	}
+
+	.gridicon {
+		margin-top: -5px;
+	}
+}
+
+.header-button__text {
+	margin-top: 3px;
+	white-space: nowrap;
+}

--- a/client/devdocs/design/index.jsx
+++ b/client/devdocs/design/index.jsx
@@ -78,6 +78,7 @@ import PaginationExample from 'components/pagination/docs/example';
 import ListEnd from 'components/list-end/docs/example';
 import Wizard from 'components/wizard/docs/example';
 import Suggestions from 'components/suggestions/docs/example';
+import HeaderButton from 'components/header-button/docs/example';
 
 let DesignAssets = React.createClass( {
 	displayName: 'DesignAssets',
@@ -146,6 +147,7 @@ let DesignAssets = React.createClass( {
 					<Gravatar />
 					<Gridicons />
 					<Headers />
+					<HeaderButton />
 					<ImagePreloader />
 					<InfoPopover />
 					<Tooltip />


### PR DESCRIPTION
This creates a new component called `HeaderButton` which will be used to add buttons to the header area (adjacent to the search bar) of the /plugins/browse and /plugins/manage (currently /plugins) pages.

Its design mirrors the buttons used in the /themes page.

You can see the plugin in devdocs here: http://calypso.localhost:3000/devdocs/design/header-button

You can read the README here: http://calypso.localhost:3000/devdocs/client/components/header-button/README.md

This was extracted from the feature branch in #17537

## Screenshots

The component, alone:

<img width="309" alt="screen shot 2017-09-01 at 12 18 51 pm" src="https://user-images.githubusercontent.com/2036909/29978604-e00e9c06-8f0f-11e7-8768-639335c87914.png">

The component used in a header:

<img width="653" alt="screen shot 2017-09-01 at 12 28 49 pm" src="https://user-images.githubusercontent.com/2036909/29978889-2aeeaaa8-8f11-11e7-87bd-c6b78fe0430c.png">

## Testing

It's not used anywhere yet, but verify that the version in devdocs looks as expected.