### PR TITLE
Plugins: add suggested searches to header

### DIFF
--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -40,6 +40,14 @@ const PluginsBrowser = React.createClass( {
 
 	mixins: [ infiniteScroll( 'fetchNextPagePlugins' ), URLSearch ],
 
+	reinitializeSearch() {
+		this.WrappedSearch = props => <Search { ...props } />;
+	},
+
+	componentWillMount() {
+		this.reinitializeSearch();
+	},
+
 	componentDidMount() {
 		PluginsListStore.on( 'change', this.refreshLists );
 		this.props.sites.on( 'change', this.refreshLists );
@@ -194,8 +202,10 @@ const PluginsBrowser = React.createClass( {
 	},
 
 	getSearchBox() {
+		const { WrappedSearch } = this;
+
 		return (
-			<Search
+			<WrappedSearch
 				pinned
 				fitsContainer
 				onSearch={ this.doSearch }
@@ -239,6 +249,13 @@ const PluginsBrowser = React.createClass( {
 		</SectionNav>;
 	},
 
+	handleSuggestedSearch( term ) {
+		return () => {
+			this.reinitializeSearch();
+			this.doSearch( term );
+		};
+	},
+
 	getPageHeaderView() {
 		if ( this.props.category ) {
 			return this.getNavigationBar();
@@ -248,15 +265,13 @@ const PluginsBrowser = React.createClass( {
 			return;
 		}
 
-		const site = this.props.site ? '/' + this.props.site : '';
 		const suggestedSearches = [
 			this.props.translate( 'Engagement', { context: 'Plugins suggested search term' } ),
 			this.props.translate( 'Security', { context: 'Plugins suggested search term' } ),
 			this.props.translate( 'Appearance', { context: 'Plugins suggested search term' } ),
 			this.props.translate( 'Writing', { context: 'Plugins suggested search term' } ),
 		];
-		// TODO: The Search does not get the search text when a suggested term is clicked
-		// TODO: do we still need any of the CSS in plugins-browser__main-header? It breaks the layout when the search field is open.
+
 		return (
 			<SectionNav selectedText={ this.props.translate( 'Suggested Searches', { context: 'Suggested searches for plugins' } ) }>
 				<NavTabs label="Suggested Searches">

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -11,7 +11,6 @@ import { localize } from 'i18n-calypso';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import DocumentHead from 'components/data/document-head';
 import Search from 'components/search';
-import SearchCard from 'components/search-card';
 import SectionNav from 'components/section-nav';
 import MainComponent from 'components/main';
 import NavTabs from 'components/section-nav/tabs';
@@ -23,7 +22,6 @@ import PluginsActions from 'lib/plugins/wporg-data/actions';
 import URLSearch from 'lib/mixins/url-search';
 import infiniteScroll from 'lib/mixins/infinite-scroll';
 import JetpackManageErrorPage from 'my-sites/jetpack-manage-error-page';
-import { hasTouch } from 'lib/touch-detect';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { canCurrentUser } from 'state/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
@@ -195,29 +193,17 @@ const PluginsBrowser = React.createClass( {
 		);
 	},
 
-	getSearchBox( pinned ) {
-		if ( pinned ) {
-			return (
-				<Search
-					pinned
-					fitsContainer
-					onSearch={ this.doSearch }
-					initialValue={ this.props.search }
-					placeholder={ this.translate( 'Search Plugins' ) }
-					delaySearch={ true }
-					analyticsGroup="PluginsBrowser" />
-			);
-		}
-
+	getSearchBox() {
 		return (
-			<SearchCard
-				autoFocus={ ! hasTouch() }
+			<Search
+				pinned
+				fitsContainer
 				onSearch={ this.doSearch }
 				initialValue={ this.props.search }
-				placeholder={ this.translate( 'Search Plugins' ) }
+				placeholder={ this.props.translate( 'Search Plugins' ) }
 				delaySearch={ true }
 				analyticsGroup="PluginsBrowser" />
-		);
+			);
 	},
 
 	getNavigationBar() {
@@ -249,7 +235,7 @@ const PluginsBrowser = React.createClass( {
 					{ this.props.translate( 'New', { context: 'Filter new plugins' } ) }
 				</NavItem>
 			</NavTabs>
-			{ this.getSearchBox( true ) }
+			{ this.getSearchBox() }
 		</SectionNav>;
 	},
 
@@ -262,10 +248,26 @@ const PluginsBrowser = React.createClass( {
 			return;
 		}
 
+		const site = this.props.site ? '/' + this.props.site : '';
+		const suggestedSearches = [
+			this.props.translate( 'Engagement', { context: 'Plugins suggested search term' } ),
+			this.props.translate( 'Security', { context: 'Plugins suggested search term' } ),
+			this.props.translate( 'Appearance', { context: 'Plugins suggested search term' } ),
+			this.props.translate( 'Writing', { context: 'Plugins suggested search term' } ),
+		];
+		// TODO: The Search does not get the search text when a suggested term is clicked
+		// TODO: do we still need any of the CSS in plugins-browser__main-header? It breaks the layout when the search field is open.
 		return (
-			<div className="plugins-browser__main-header">
-				{ this.getSearchBox( false ) }
-			</div>
+			<SectionNav selectedText={ this.props.translate( 'Suggested Searches', { context: 'Suggested searches for plugins' } ) }>
+				<NavTabs label="Suggested Searches">
+					{ suggestedSearches.map( term =>
+						<NavItem key={ term } onClick={ this.handleSuggestedSearch( term ) }>
+							{ term }
+						</NavItem>
+					) }
+				</NavTabs>
+				{ this.getSearchBox() }
+			</SectionNav>
 		);
 	},
 


### PR DESCRIPTION
This adds suggested searches to the search field on the Plugins browsing page.

<img width="757" alt="screen shot 2017-09-01 at 1 10 34 pm" src="https://user-images.githubusercontent.com/2036909/29980287-22c33032-8f17-11e7-8081-19e8e043c062.png">

Clicking on a suggested search will fill the search field with that search term.

<img width="774" alt="screen shot 2017-09-01 at 1 10 50 pm" src="https://user-images.githubusercontent.com/2036909/29980299-3c6f7892-8f17-11e7-89a1-b92ad37bb063.png">

Extracted from the feature branch #17537

**Note: because the `Search` component is used in `PluginsBrowser` as an uncontrolled component with a search mixin, pre-filling the search field is actually rather complicated. We determined that properly updating the field is outside the scope of this PR, so we came up with a hack to reload the `Search` element multiple times to cause its `initialValue` prop to change its value. Ideally this should be refactored later, probably to make the `Search` component have a controlled value.**

## Testing

Visit http://calypso.localhost:3000/plugins/browse/ and click the suggested searches. Verify that they pre-fill the search field and that the search results are shown. Also verify that typing in the search field works as expected.

