### PR TITLE
Plugins: refactor /plugins page navigation, remove legacy CSS classes

### DIFF
--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -3,7 +3,6 @@
  */
 import React from 'react';
 import { connect } from 'react-redux';
-import classNames from 'classnames';
 import { find, isEmpty, some } from 'lodash';
 import { localize } from 'i18n-calypso';
 
@@ -385,39 +384,35 @@ const PluginsMain = React.createClass( {
 			);
 		}
 
-		const containerClass = classNames( {
-			'main-column': true,
-			plugins: true,
-			'search-open': this.getSearchOpen()
+		const navItems = this.getFilters().map( filterItem => {
+			if ( 'updates' === filterItem.id && ! this.getUpdatesTabVisibility() ) {
+				return null;
+			}
+
+			const attr = {
+				key: filterItem.id,
+				path: filterItem.path,
+				selected: filterItem.id === this.props.filter,
+			};
+
+			if ( 'updates' === filterItem.id ) {
+				attr.count = this.state.pluginUpdateCount;
+			}
+			return (
+				<NavItem { ...attr } >
+					{ filterItem.title }
+				</NavItem>
+			);
 		} );
 
 		return (
-			<Main className={ containerClass }>
+			<Main>
 				<NonSupportedJetpackVersionNotice />
 				{ this.renderDocumentHead() }
 				<SidebarNavigation />
 				<SectionNav selectedText={ this.getSelectedText() }>
 					<NavTabs>
-						{ this.getFilters().map( filterItem => {
-							if ( 'updates' === filterItem.id && ! this.getUpdatesTabVisibility() ) {
-								return null;
-							}
-
-							const attr = {
-								key: filterItem.id,
-								path: filterItem.path,
-								selected: filterItem.id === this.props.filter,
-							};
-
-							if ( 'updates' === filterItem.id ) {
-								attr.count = this.state.pluginUpdateCount;
-							}
-							return (
-								<NavItem { ...attr } >
-									{ filterItem.title }
-								</NavItem>
-							);
-						} ) }
+						{ navItems }
 					</NavTabs>
 
 					<Search


### PR DESCRIPTION
Refactor rendering of the plugin list by extracting part of the JSX to a separate variable.
Removed legacy CSS classes for the `Main` component -- no CSS styling is associated with them.

Another easy-to-review spinoff from the #17537 feature branch.