### PR TITLE
View Site: Enable modifier keys to behave expectedly on click

### DIFF
--- a/client/layout/sidebar/item.jsx
+++ b/client/layout/sidebar/item.jsx
@@ -23,7 +23,7 @@ export default React.createClass( {
 		icon: PropTypes.string,
 		selected: PropTypes.bool,
 		preloadSectionName: PropTypes.string,
-		preventExternalIcon: PropTypes.bool,
+		forceInternalLink: PropTypes.bool,
 		testTarget: PropTypes.string,
 		tipTarget: PropTypes.string
 	},
@@ -38,9 +38,8 @@ export default React.createClass( {
 	},
 
 	render() {
-		const isExternalLink = isExternal( this.props.link );
+		const showAsExternal = isExternal( this.props.link ) && ! this.props.forceInternalLink;
 		const classes = classnames( this.props.className, { selected: this.props.selected } );
-		const showExternalIcon = isExternalLink && ! this.props.preventExternalIcon;
 
 		return (
 			<li
@@ -51,13 +50,13 @@ export default React.createClass( {
 				<a
 					onClick={ this.props.onNavigate }
 					href={ this.props.link }
-					target={ isExternalLink ? '_blank' : null }
-					rel={ isExternalLink ? 'noopener noreferrer' : null }
+					target={ showAsExternal ? '_blank' : null }
+					rel={ showAsExternal ? 'noopener noreferrer' : null }
 					onMouseEnter={ this.preload }
 				>
 					<Gridicon icon={ this.props.icon } size={ 24 } />
 					<span className="menu-link-text">{ this.props.label }</span>
-					{ showExternalIcon && <Gridicon icon="external" size={ 24 } /> }
+					{ showAsExternal && <Gridicon icon="external" size={ 24 } /> }
 				</a>
 				{ this.props.children }
 			</li>

--- a/client/layout/sidebar/item.jsx
+++ b/client/layout/sidebar/item.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import Gridicon from 'gridicons';
 
@@ -15,15 +16,16 @@ export default React.createClass( {
 	displayName: 'SidebarItem',
 
 	propTypes: {
-		label: React.PropTypes.string.isRequired,
-		className: React.PropTypes.string,
-		link: React.PropTypes.string.isRequired,
-		onNavigate: React.PropTypes.func,
-		icon: React.PropTypes.string,
-		selected: React.PropTypes.bool,
-		preloadSectionName: React.PropTypes.string,
-		testTarget: React.PropTypes.string,
-		tipTarget: React.PropTypes.string
+		label: PropTypes.string.isRequired,
+		className: PropTypes.string,
+		link: PropTypes.string.isRequired,
+		onNavigate: PropTypes.func,
+		icon: PropTypes.string,
+		selected: PropTypes.bool,
+		preloadSectionName: PropTypes.string,
+		preventExternalIcon: PropTypes.bool,
+		testTarget: PropTypes.string,
+		tipTarget: PropTypes.string
 	},
 
 	_preloaded: false,
@@ -38,6 +40,7 @@ export default React.createClass( {
 	render() {
 		const isExternalLink = isExternal( this.props.link );
 		const classes = classnames( this.props.className, { selected: this.props.selected } );
+		const showExternalIcon = isExternalLink && ! this.props.preventExternalIcon;
 
 		return (
 			<li
@@ -54,7 +57,7 @@ export default React.createClass( {
 				>
 					<Gridicon icon={ this.props.icon } size={ 24 } />
 					<span className="menu-link-text">{ this.props.label }</span>
-					{ isExternalLink ? <Gridicon icon="external" size={ 24 } /> : null }
+					{ showExternalIcon && <Gridicon icon="external" size={ 24 } /> }
 				</a>
 				{ this.props.children }
 			</li>

--- a/client/layout/sidebar/item.jsx
+++ b/client/layout/sidebar/item.jsx
@@ -38,7 +38,8 @@ export default React.createClass( {
 	},
 
 	render() {
-		const showAsExternal = isExternal( this.props.link ) && ! this.props.forceInternalLink;
+		const isExternalLink = isExternal( this.props.link );
+		const showAsExternal = isExternalLink && ! this.props.forceInternalLink;
 		const classes = classnames( this.props.className, { selected: this.props.selected } );
 
 		return (
@@ -51,7 +52,7 @@ export default React.createClass( {
 					onClick={ this.props.onNavigate }
 					href={ this.props.link }
 					target={ showAsExternal ? '_blank' : null }
-					rel={ showAsExternal ? 'noopener noreferrer' : null }
+					rel={ isExternalLink ? 'noopener noreferrer' : null }
 					onMouseEnter={ this.preload }
 				>
 					<Gridicon icon={ this.props.icon } size={ 24 } />

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -173,6 +173,7 @@ export class MySitesSidebar extends Component {
 
 	preview() {
 		const {
+			isPreviewable,
 			site,
 			siteId,
 			translate,
@@ -193,7 +194,7 @@ export class MySitesSidebar extends Component {
 				onNavigate={ this.onViewSiteClick }
 				icon="computer"
 				preloadSectionName="preview"
-				preventExternalIcon
+				preventExternalIcon={ isPreviewable }
 			/>
 		);
 	}

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -194,7 +194,7 @@ export class MySitesSidebar extends Component {
 				onNavigate={ this.onViewSiteClick }
 				icon="computer"
 				preloadSectionName="preview"
-				preventExternalIcon={ isPreviewable }
+				forceInternalLink={ isPreviewable }
 			/>
 		);
 	}

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -8,6 +8,7 @@ import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import Gridicon from 'gridicons';
 import { includes } from 'lodash';
+import page from 'page';
 
 /**
  * Internal dependencies
@@ -86,6 +87,27 @@ export class MySitesSidebar extends Component {
 		}
 	};
 
+	onViewSiteClick = ( event ) => {
+		const {
+			isPreviewable,
+			siteSuffix,
+		} = this.props;
+
+		if ( ! isPreviewable ) {
+			analytics.ga.recordEvent( 'Sidebar', 'Clicked View Site | Unpreviewable' );
+			return;
+		}
+
+		if ( event.altKey || event.ctrlKey || event.metaKey || event.shiftKey ) {
+			analytics.ga.recordEvent( 'Sidebar', 'Clicked View Site | Modifier Key' );
+			return;
+		}
+
+		event.preventDefault();
+		analytics.ga.recordEvent( 'Sidebar', 'Clicked View Site | Calypso' );
+		page( '/view' + siteSuffix );
+	};
+
 	itemLinkClass = ( paths, existingClasses ) => {
 		var classSet = {};
 
@@ -150,22 +172,28 @@ export class MySitesSidebar extends Component {
 	}
 
 	preview() {
-		if ( ! this.props.siteId ) {
+		const {
+			site,
+			siteId,
+			translate,
+		} = this.props;
+
+		if ( ! siteId ) {
 			return null;
 		}
 
-		const { site, isPreviewable } = this.props;
 		const siteUrl = site && site.URL || '';
 
 		return (
 			<SidebarItem
 				tipTarget="sitePreview"
-				label={ this.props.translate( 'View Site' ) }
+				label={ translate( 'View Site' ) }
 				className={ this.itemLinkClass( [ '/view' ], 'preview' ) }
-				link={ isPreviewable ? '/view' + this.props.siteSuffix : siteUrl }
-				onNavigate={ this.onNavigate }
+				link={ siteUrl }
+				onNavigate={ this.onViewSiteClick }
 				icon="computer"
 				preloadSectionName="preview"
+				preventExternalIcon
 			/>
 		);
 	}


### PR DESCRIPTION
Also, triggers GA `Sidebar` events for the various combinations of clicks on this menu item for tracking purposes:

* `Clicked View Site | Unpreviewable`
* `Clicked View Site | Modifier Key`
* `Clicked View Site | Calypso`

Fixes #17212

## To Test

* Hover over `View Site` -- it should show your site's URL
* Click on `View Site` in various situations for various types of sites (wpcom, jetpack, ssl, not) -- all previewable sites should open the section within calypso. Non-previewable sites should open in a new tab.
* Repeat the above with the cmd (or ctrl on non mac keyboards) key pressed. It should always open the site in a new tab. Other modifier keys behind pressed during clicking should behave as default / configured for your browser.
* Keyboard-based navigation (tab until `View Site` is "selected" & hit enter (with & without modifier keys being pressed) should all work according to browser defaults / preferences
* On mobile: long-press, open new tab should open the front end of the site in a new tab