### PR TITLE
Store: Add base reviews page, link, and feature flag.

### DIFF
--- a/client/extensions/woocommerce/app/reviews/index.js
+++ b/client/extensions/woocommerce/app/reviews/index.js
@@ -1,0 +1,30 @@
+/**
+ * External depedencies
+ */
+import React, { Component } from 'react';
+import classNames from 'classnames';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import ActionHeader from 'woocommerce/components/action-header';
+import Main from 'components/main';
+import SidebarNavigation from 'my-sites/sidebar-navigation';
+
+class Reviews extends Component {
+
+	render() {
+		const { className, translate } = this.props;
+		const classes = classNames( 'reviews__list', className );
+
+		return (
+			<Main className={ classes }>
+				<SidebarNavigation />
+				<ActionHeader breadcrumbs={ ( <span>{ translate( 'Reviews' ) }</span> ) } />
+			</Main>
+		);
+	}
+}
+
+export default localize( Reviews );

--- a/client/extensions/woocommerce/index.js
+++ b/client/extensions/woocommerce/index.js
@@ -12,6 +12,7 @@ import { translate } from 'i18n-calypso';
 import App from './app';
 
 import controller from 'my-sites/controller';
+import Dashboard from './app/dashboard';
 import EmptyContent from 'components/empty-content';
 import { navigation, siteSelection } from 'my-sites/controller';
 import { renderWithReduxStore } from 'lib/react-helpers';
@@ -24,7 +25,7 @@ import ProductUpdate from './app/products/product-update';
 import Promotions from './app/promotions';
 import PromotionCreate from './app/promotions/promotion-create';
 import PromotionUpdate from './app/promotions/promotion-update';
-import Dashboard from './app/dashboard';
+import Reviews from './app/reviews';
 import SettingsPayments from './app/settings/payments';
 import SettingsTaxes from './app/settings/taxes';
 import Shipping from './app/settings/shipping';
@@ -96,6 +97,12 @@ const getStorePages = () => {
 			configKey: 'woocommerce/extension-promotions',
 			documentTitle: translate( 'Edit Promotion' ),
 			path: '/store/promotion/:site/:promotion',
+		},
+		{
+			container: Reviews,
+			configKey: 'woocommerce/extension-reviews',
+			documentTitle: translate( 'Reviews' ),
+			path: '/store/reviews/:site',
 		},
 		{
 			container: SettingsPayments,

--- a/client/extensions/woocommerce/store-sidebar/index.js
+++ b/client/extensions/woocommerce/store-sidebar/index.js
@@ -117,6 +117,32 @@ class StoreSidebar extends Component {
 		);
 	}
 
+	reviews = () => {
+		if ( ! config.isEnabled( 'woocommerce/extension-reviews' ) ) {
+			return null;
+		}
+
+		const { site, siteSuffix, translate } = this.props;
+		const link = '/store/reviews' + siteSuffix;
+		const selected = this.isItemLinkSelected( [ link ] );
+		const classes = classNames( {
+			reviews: true,
+			'is-placeholder': ! site,
+			selected,
+		} );
+
+		// TODO Add bubble containing count of unapproved reviews.
+		return (
+			<SidebarItem
+				className={ classes }
+				icon="star-outline"
+				label={ translate( 'Reviews' ) }
+				link={ link }
+			>
+			</SidebarItem>
+		);
+	}
+
 	orders = () => {
 		const { orders, site, siteSuffix, translate } = this.props;
 		const link = '/store/orders' + siteSuffix;
@@ -216,6 +242,7 @@ class StoreSidebar extends Component {
 						{ showAllSidebarItems && this.products() }
 						{ showAllSidebarItems && this.orders() }
 						{ showAllSidebarItems && this.promotions() }
+						{ showAllSidebarItems && this.reviews() }
 						{ showAllSidebarItems && <SidebarSeparator /> }
 						{ showAllSidebarItems && this.settings() }
 					</ul>

--- a/config/development.json
+++ b/config/development.json
@@ -169,6 +169,7 @@
 		"woocommerce/extension-orders": true,
 		"woocommerce/extension-products": true,
 		"woocommerce/extension-promotions": true,
+		"woocommerce/extension-reviews": true,
 		"woocommerce/extension-settings": true,
 		"woocommerce/extension-settings-payments": true,
 		"woocommerce/extension-settings-shipping": true,

--- a/config/production.json
+++ b/config/production.json
@@ -110,6 +110,7 @@
 		"woocommerce/extension-orders": true,
 		"woocommerce/extension-products": true,
 		"woocommerce/extension-promotions": false,
+		"woocommerce/extension-reviews": false,
 		"woocommerce/extension-settings": true,
 		"woocommerce/extension-settings-payments": true,
 		"woocommerce/extension-settings-shipping": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -118,6 +118,7 @@
 		"woocommerce/extension-orders": true,
 		"woocommerce/extension-products": true,
 		"woocommerce/extension-promotions": false,
+		"woocommerce/extension-reviews": false,
 		"woocommerce/extension-settings": true,
 		"woocommerce/extension-settings-payments": true,
 		"woocommerce/extension-settings-shipping": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -132,6 +132,7 @@
 		"woocommerce/extension-orders": true,
 		"woocommerce/extension-products": true,
 		"woocommerce/extension-promotions": false,
+		"woocommerce/extension-reviews": false,
 		"woocommerce/extension-settings": true,
 		"woocommerce/extension-settings-payments": true,
 		"woocommerce/extension-settings-shipping": true,


### PR DESCRIPTION
This adds a base reviews page and sidebar link, behind a new reviews feature flag.

@kellychoffman & @jameskoster I am using the 'Star' right now for the menu Gridicon. That seems to make the most sense for reviews since they have ratings.

To Test:
* Run `npm start`.
* Go to `http://calypso.localhost:3000/store/:site`.
* Verify that you see a 'Reviews' item in the sidebar.
* Click the link.
* Verify that you see a blank 'Reviews' page.