### PR TITLE
Plugins: add manage/browse buttons in header

### DIFF
--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -23,6 +23,7 @@ import PluginsStore from 'lib/plugins/store';
 import { fetchPluginData as wporgFetchPluginData } from 'state/plugins/wporg/actions';
 import WporgPluginsSelectors from 'state/plugins/wporg/selectors';
 import PluginsList from './plugins-list';
+import { recordGoogleEvent } from 'state/analytics/actions';
 import JetpackManageErrorPage from 'my-sites/jetpack-manage-error-page';
 import WpcomPluginPanel from 'my-sites/plugins-wpcom';
 import PluginsBrowser from './plugins-browser';
@@ -43,6 +44,7 @@ import {
 	getSelectedSiteId,
 	getSelectedSiteSlug
 } from 'state/ui/selectors';
+import HeaderButton from 'components/header-button';
 
 const PluginsMain = React.createClass( {
 	mixins: [ URLSearch ],
@@ -344,6 +346,23 @@ const PluginsMain = React.createClass( {
 		} );
 	},
 
+	handleAddPluginButtonClick() {
+		this.props.recordGoogleEvent( 'Plugins', 'Clicked Add New Plugins' );
+	},
+
+	getAddPluginButton() {
+		const browserUrl = '/plugins/browse' + ( this.props.selectedSiteSlug ? '/' + this.props.selectedSiteSlug : '' );
+		return (
+			<HeaderButton
+				icon="plus"
+				label={ this.props.translate( 'Add Plugin' ) }
+				aria-label={ this.props.translate( 'Browse all plugins', { context: 'button label' } ) }
+				href={ browserUrl }
+				onClick={ this.handleAddPluginButtonClick }
+			/>
+		);
+	},
+
 	render() {
 		const {
 			category,
@@ -384,6 +403,7 @@ const PluginsMain = React.createClass( {
 			);
 		}
 
+		const addPluginButton = this.getAddPluginButton();
 		const navItems = this.getFilters().map( filterItem => {
 			if ( 'updates' === filterItem.id && ! this.getUpdatesTabVisibility() ) {
 				return null;
@@ -410,20 +430,22 @@ const PluginsMain = React.createClass( {
 				<NonSupportedJetpackVersionNotice />
 				{ this.renderDocumentHead() }
 				<SidebarNavigation />
-				<SectionNav selectedText={ this.getSelectedText() }>
-					<NavTabs>
-						{ navItems }
-					</NavTabs>
-
-					<Search
-						pinned
-						fitsContainer
-						onSearch={ this.doSearch }
-						initialValue={ this.props.search }
-						ref="url-search"
-						analyticsGroup="Plugins"
-						placeholder={ this.getSearchPlaceholder() } />
-				</SectionNav>
+				<div className="plugins__header">
+					<SectionNav selectedText={ this.getSelectedText() }>
+						<NavTabs>
+							{ navItems }
+						</NavTabs>
+						<Search
+							pinned
+							fitsContainer
+							onSearch={ this.doSearch }
+							initialValue={ this.props.search }
+							ref="url-search"
+							analyticsGroup="Plugins"
+							placeholder={ this.getSearchPlaceholder() } />
+					</SectionNav>
+					{ addPluginButton }
+				</div>
 				{ this.renderPluginsContent() }
 			</Main>
 		);
@@ -450,5 +472,5 @@ export default connect(
 				: canCurrentUserManagePlugins( state ) )
 		};
 	},
-	{ wporgFetchPluginData }
+	{ wporgFetchPluginData, recordGoogleEvent }
 )( localize( PluginsMain ) );

--- a/client/my-sites/plugins/plugin-list-header/index.jsx
+++ b/client/my-sites/plugins/plugin-list-header/index.jsx
@@ -18,7 +18,6 @@ import SelectDropdown from 'components/select-dropdown';
 import DropdownItem from 'components/select-dropdown/item';
 import DropdownSeparator from 'components/select-dropdown/separator';
 import BulkSelect from 'components/bulk-select';
-import Tooltip from 'components/tooltip';
 import analytics from 'lib/analytics';
 import { isEnabled } from 'config';
 
@@ -30,7 +29,6 @@ export class PluginsListHeader extends PureComponent {
 
 	state = {
 		actionBarVisible: true,
-		addPluginTooltip: false
 	}
 
 	static defaultProps = {
@@ -81,14 +79,6 @@ export class PluginsListHeader extends PureComponent {
 		}, 1 );
 	}
 
-	showPluginTooltip = () => {
-		this.setState( { addPluginTooltip: true } );
-	}
-
-	hidePluginTooltip = () => {
-		this.setState( { addPluginTooltip: false } );
-	}
-
 	toggleBulkManagement = () => {
 		this.props.toggleBulkManagement();
 
@@ -99,10 +89,6 @@ export class PluginsListHeader extends PureComponent {
 		if ( this.props.isBulkManagementActive ) {
 			this.maybeMakeActionBarVisible();
 		}
-	}
-
-	onBrowserLinkClick = () => {
-		analytics.ga.recordEvent( 'Plugins', 'Clicked Add New Plugins' );
 	}
 
 	onUploadLinkClick = () => {
@@ -164,30 +150,6 @@ export class PluginsListHeader extends PureComponent {
 				<ButtonGroup key="plugin-list-header__buttons-bulk-management">
 					<Button compact onClick={ this.toggleBulkManagement }>
 						{ translate( 'Edit All', { context: 'button label' } ) }
-					</Button>
-				</ButtonGroup>
-			);
-
-			const browserUrl = '/plugins/browse' + ( this.props.selectedSiteSlug ? '/' + this.props.selectedSiteSlug : '' );
-
-			rightSideButtons.push(
-				<ButtonGroup key="plugin-list-header__buttons-browser">
-					<Button
-						compact
-						href={ browserUrl }
-						onClick={ this.onBrowserLinkClick }
-						className="plugin-list-header__browser-button"
-						onMouseEnter={ this.showPluginTooltip }
-						onMouseLeave={ this.hidePluginTooltip }
-						ref="addPluginButton"
-						aria-label={ translate( 'Browse all plugins', { context: 'button label' } ) }>
-						<Gridicon key="plus-icon" icon="plus-small" size={ 18 } /><Gridicon key="plugins-icon" icon="plugins" size={ 18 } />
-						<Tooltip
-							isVisible={ this.state.addPluginTooltip }
-							context={ this.refs && this.refs.addPluginButton }
-							position="bottom">
-							{ translate( 'Browse all plugins', { context: 'button tooltip' } ) }
-						</Tooltip>
 					</Button>
 				</ButtonGroup>
 			);

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -256,15 +256,7 @@ const PluginsBrowser = React.createClass( {
 		};
 	},
 
-	getPageHeaderView() {
-		if ( this.props.category ) {
-			return this.getNavigationBar();
-		}
-
-		if ( this.props.hideSearchForm ) {
-			return;
-		}
-
+	getSearchBar() {
 		const suggestedSearches = [
 			this.props.translate( 'Engagement', { context: 'Plugins suggested search term' } ),
 			this.props.translate( 'Security', { context: 'Plugins suggested search term' } ),
@@ -273,7 +265,11 @@ const PluginsBrowser = React.createClass( {
 		];
 
 		return (
-			<SectionNav selectedText={ this.props.translate( 'Suggested Searches', { context: 'Suggested searches for plugins' } ) }>
+			<SectionNav
+				selectedText={ this.props.translate( 'Suggested Searches', {
+					context: 'Suggested searches for plugins',
+				} ) }
+			>
 				<NavTabs label="Suggested Searches">
 					{ suggestedSearches.map( term =>
 						<NavItem key={ term } onClick={ this.handleSuggestedSearch( term ) }>
@@ -283,6 +279,20 @@ const PluginsBrowser = React.createClass( {
 				</NavTabs>
 				{ this.getSearchBox() }
 			</SectionNav>
+		);
+	},
+
+	getPageHeaderView() {
+		if ( this.props.hideSearchForm ) {
+			return null;
+		}
+
+		const navigation = this.props.category ? this.getNavigationBar() : this.getSearchBar();
+
+		return (
+			<div className="plugins-browser__main-header">
+				{ navigation }
+			</div>
 		);
 	},
 

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -32,6 +32,7 @@ import {
 } from 'state/sites/selectors';
 import NonSupportedJetpackVersionNotice from 'my-sites/plugins/not-supported-jetpack-version';
 import NoPermissionsError from 'my-sites/plugins/no-permissions-error';
+import HeaderButton from 'components/header-button';
 
 const PluginsBrowser = React.createClass( {
 	_SHORT_LIST_LENGTH: 6,
@@ -282,16 +283,29 @@ const PluginsBrowser = React.createClass( {
 		);
 	},
 
+	getManageButton() {
+		const site = this.props.site ? '/' + this.props.site : '';
+		return (
+			<HeaderButton
+				icon="cog"
+				label={ this.props.translate( 'Manage Plugins' ) }
+				href={ '/plugins' + site }
+			/>
+		);
+	},
+
 	getPageHeaderView() {
 		if ( this.props.hideSearchForm ) {
 			return null;
 		}
 
 		const navigation = this.props.category ? this.getNavigationBar() : this.getSearchBar();
+		const manageButton = this.props.isJetpackSite && this.getManageButton();
 
 		return (
 			<div className="plugins-browser__main-header">
 				{ navigation }
+				{ manageButton }
 			</div>
 		);
 	},
@@ -351,6 +365,7 @@ export default connect(
 	state => {
 		const selectedSiteId = getSelectedSiteId( state );
 		return {
+			isJetpackSite: isJetpackSite( state, selectedSiteId ),
 			jetpackManageError: !! isJetpackSite( state, selectedSiteId ) && ! canJetpackSiteManage( state, selectedSiteId ),
 			isRequestingSites: isRequestingSites( state ),
 			noPermissionsError: !! selectedSiteId && ! canCurrentUser( state, selectedSiteId, 'manage_options' ),

--- a/client/my-sites/plugins/plugins-browser/style.scss
+++ b/client/my-sites/plugins/plugins-browser/style.scss
@@ -1,8 +1,24 @@
 .plugins-browser__main-header {
+	background: $white;
+	box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), 0.5 ), 0 1px 2px lighten( $gray, 30% );
+	flex-direction: column;
 	display: flex;
+	margin-bottom: 9px;
 
-	.section-nav {
-		flex: auto;
-		margin: 0;
+	@include breakpoint( '>480px' ) {
+		flex-direction: row;
+		margin-bottom: 17px;
+	}
+}
+
+.plugins-browser__main-header .section-nav {
+	border: 1px solid transparentize( lighten( $gray, 20% ), 0.5 );
+	border-width: 0 0 1px;
+	box-shadow: none;
+	flex: auto;
+	margin: 0;
+
+	@include breakpoint( '>480px' ) {
+		border-width: 0 1px 0 0;
 	}
 }

--- a/client/my-sites/plugins/plugins-browser/style.scss
+++ b/client/my-sites/plugins/plugins-browser/style.scss
@@ -1,15 +1,8 @@
 .plugins-browser__main-header {
-	.search {
-		position: relative;
-	}
+	display: flex;
 
-	@include breakpoint( "<660px" ) {
-		margin-top: 2em;
-	}
-}
-
-.plugins-browser .section-nav {
-	@include breakpoint( "<660px" ) {
-		margin-top: 2em;
+	.section-nav {
+		flex: auto;
+		margin: 0;
 	}
 }

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -9,3 +9,28 @@
 .card.is-compact.section-header.after-compact {
 	margin-top: 16px;
 }
+
+.plugins__header {
+	background: $white;
+	box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), 0.5 ), 0 1px 2px lighten( $gray, 30% );
+	flex-direction: column;
+	display: flex;
+	margin-bottom: 9px;
+
+	@include breakpoint( '>480px' ) {
+		flex-direction: row;
+		margin-bottom: 17px;
+	}
+}
+
+.plugins__header .section-nav {
+	border: 1px solid transparentize( lighten( $gray, 20% ), 0.5 );
+	border-width: 0 0 1px;
+	box-shadow: none;
+	flex: auto;
+	margin: 0;
+
+	@include breakpoint( '>480px' ) {
+		border-width: 0 1px 0 0;
+	}
+}


### PR DESCRIPTION
This adds buttons to the header bars of the "browse" and "manage" Plugin pages which navigate between the two sections.

It adds a button labeled "Add Plugin" to the "manage" page that links to the "browse" page: http://calypso.localhost:3000/plugins/

<img width="733" alt="screen shot 2017-09-01 at 5 12 16 pm" src="https://user-images.githubusercontent.com/2036909/29988008-05878834-8f39-11e7-937a-6c5041006370.png">

It also adds a button labeled "Manage Plugins" to the "browse" page that links to the "manage" page: http://calypso.localhost:3000/plugins/browse/

<img width="749" alt="screen shot 2017-09-01 at 5 12 34 pm" src="https://user-images.githubusercontent.com/2036909/29988011-0a172990-8f39-11e7-9eaa-02f6f64c470c.png">

**Note: the "Manage Plugins" link only appears for Jetpack sites!**

Lastly, there already exists a smaller "Add Plugin" button inside `PluginsListHeader`. Since the larger button is more prominent, this PR removes the smaller button.

![screen shot 2017-09-01 at 5 15 24 pm](https://user-images.githubusercontent.com/2036909/29988102-856ab882-8f39-11e7-9587-c283be614e5e.png)

Extracted from #17537

## Testing

Visit both pages listed above and click the buttons. Verify that they switch back and forth between the two pages.