### PR TITLE
Fix bug which registered analytics error even if it loaded

### DIFF
--- a/client/lib/analytics/index.js
+++ b/client/lib/analytics/index.js
@@ -90,8 +90,10 @@ function checkForBlockedTracks() {
 	loadScript( '/nostats.js?_ut=' + encodeURIComponent( _ut ) + '&_ui=' + encodeURIComponent( _ui ) );
 }
 
-loadScript( '//stats.wp.com/w.js?56', function( /* error */ ) {
-	_loadTracksError = true;
+loadScript( '//stats.wp.com/w.js?56', function( error ) {
+	if ( error ) {
+		_loadTracksError = true;
+	}
 } ); // W_JS_VER
 
 // Google Analytics


### PR DESCRIPTION
We weren't checking for the error object - whoops.