### PR TITLE
Enable modifying feature flags based on URL query parameters

### DIFF
--- a/client/config/README.md
+++ b/client/config/README.md
@@ -1,14 +1,21 @@
 client/config
 =============
 
-The `index.js` file is generated on startup by `regenerate-client.js`. Based on the environment, data is read from the appropriate .json file in the root config directory, for example, `/config/development.json`. The data is then compared against a whitelist in `/config/client.json`, and whitelisted items are added to the data object in `/client/config/index.js`. You can read more about how to use `config` in the [config documentation](../config).
+This module reads config data from `window.configData` (passed from the Node.js
+server via the Jade template file) and initializes a `config` object that is
+used to read these values.
+
+You can read more about how to use `config` in the [config documentation](../config).
 
 Feature Flags API
 -----------------
 
-The config files contain a features object that can be used to determine whether to enable a feature for certain environments. This allows us to merge in-progress features without launching them to production.
+The config files contain a features object that can be used to determine
+whether to enable a feature for certain environments. This allows us to merge
+in-progress features without launching them to production.
 
 ### config.isEnabled( key )
+
 Is a feature enabled?
 
 ``` js
@@ -19,4 +26,14 @@ if ( config.isEnabled( 'myFeature') ) {
 }
 ```
 
-The key should always be a literal string not a variable so that down the road we can process the compiled scripts and remove code for disabled features in production.
+The key should always be a literal string not a variable so that down the road
+we can process the compiled scripts and remove code for disabled features in
+production.
+
+When Calypso is running in development mode or in the `stage` environment, you
+can specify a `?flags=` query argument to modify feature flags for each full
+page load.  Examples:
+
+- `?flags=flag1`: Enable feature `flag1`.
+- `?flags=-flag2`: Disable feature `flag2`.
+- `?flags=+flag1,-flag2`: Enable feature `flag1` and disable feature `flag2`.

--- a/client/config/README.md
+++ b/client/config/README.md
@@ -5,7 +5,8 @@ This module reads config data from `window.configData` (passed from the Node.js
 server via the Jade template file) and initializes a `config` object that is
 used to read these values.
 
-You can read more about how to use `config` in the [config documentation](../config).
+You can read more about how to use `config` in the
+[config documentation](../../config).
 
 Feature Flags API
 -----------------
@@ -40,5 +41,5 @@ page load.  Examples:
 
 Note: the `?flags` argument won't work for feature flags used by the Node.js
 server.  For this case, you can use the
-[`ENABLE_FEATURES` and/or `DISABLE_FEATURES`](../config/README.md#feature-flags)
+[`ENABLE_FEATURES` and/or `DISABLE_FEATURES`](../../config/README.md#feature-flags)
 environment variables instead.

--- a/client/config/README.md
+++ b/client/config/README.md
@@ -37,3 +37,8 @@ page load.  Examples:
 - `?flags=flag1`: Enable feature `flag1`.
 - `?flags=-flag2`: Disable feature `flag2`.
 - `?flags=+flag1,-flag2`: Enable feature `flag1` and disable feature `flag2`.
+
+Note: the `?flags` argument won't work for feature flags used by the Node.js
+server.  For this case, you can use the
+[`ENABLE_FEATURES` and/or `DISABLE_FEATURES`](../config/README.md#feature-flags)
+environment variables instead.

--- a/client/config/index.js
+++ b/client/config/index.js
@@ -22,19 +22,13 @@ if ( process.env.NODE_ENV === 'development' ) {
 		const flags = match[ 1 ].split( ',' );
 		flags.forEach( flagRaw => {
 			const flag = flagRaw.replace( /^[-+]/, '' );
-			if ( /^-/.test( flagRaw ) ) {
-				console.log( // eslint-disable-line no-console
-					'Config flag disabled via URL:',
-					flag
-				);
-				configData.features[ flag ] = false;
-			} else {
-				console.log( // eslint-disable-line no-console
-					'Config flag enabled via URL:',
-					flag
-				);
-				configData.features[ flag ] = true;
-			}
+			const enabled = ! /^-/.test( flagRaw );
+			configData.features[ flag ] = enabled;
+			console.warn( // eslint-disable-line no-console
+				'Config flag %s via URL: %s',
+				( enabled ? 'enabled' : 'disabled' ),
+				flag
+			);
 		} );
 	}
 }

--- a/client/config/index.js
+++ b/client/config/index.js
@@ -11,5 +11,32 @@ if ( 'undefined' === typeof window || ! window.configData ) {
 	throw new ReferenceError( 'No configuration was found: please see client/config/README.md for more information' );
 }
 
-export default createConfig( window.configData );
+const configData = window.configData;
 
+if ( process.env.NODE_ENV === 'development' ) {
+	const match = (
+		document.location.search &&
+		document.location.search.match( /[?&]flags=([^&]+)(&|$)/ )
+	);
+	if ( match ) {
+		const flags = match[ 1 ].split( ',' );
+		flags.forEach( flagRaw => {
+			const flag = flagRaw.replace( /^[-+]/, '' );
+			if ( /^-/.test( flagRaw ) ) {
+				console.log( // eslint-disable-line no-console
+					'Config flag disabled via URL:',
+					flag
+				);
+				configData.features[ flag ] = false;
+			} else {
+				console.log( // eslint-disable-line no-console
+					'Config flag enabled via URL:',
+					flag
+				);
+				configData.features[ flag ] = true;
+			}
+		} );
+	}
+}
+
+export default createConfig( configData );

--- a/client/config/index.js
+++ b/client/config/index.js
@@ -24,8 +24,9 @@ if ( process.env.NODE_ENV === 'development' ) {
 			const flag = flagRaw.replace( /^[-+]/, '' );
 			const enabled = ! /^-/.test( flagRaw );
 			configData.features[ flag ] = enabled;
-			console.warn( // eslint-disable-line no-console
-				'Config flag %s via URL: %s',
+			console.log( // eslint-disable-line no-console
+				'%cConfig flag %s via URL: %s',
+				'font-weight: bold;',
 				( enabled ? 'enabled' : 'disabled' ),
 				flag
 			);

--- a/client/config/index.js
+++ b/client/config/index.js
@@ -13,7 +13,7 @@ if ( 'undefined' === typeof window || ! window.configData ) {
 
 const configData = window.configData;
 
-if ( process.env.NODE_ENV === 'development' ) {
+if ( process.env.NODE_ENV === 'development' || configData.env_id === 'stage' ) {
 	const match = (
 		document.location.search &&
 		document.location.search.match( /[?&]flags=([^&]+)(&|$)/ )


### PR DESCRIPTION
This will enable us to modify feature flags without restarting the Webpack build and without modifying any files locally.

Since calypso.live [runs Calypso in development mode](https://github.com/Automattic/calypso-live-branches/blob/09de597/calypso.json#L7) we can use it there too.

When loading a fresh Calypso page, you can specify a `?flags=` query argument.  Here are a couple of examples:

- `?flags=flag1`: Enable feature `flag1`.
- `?flags=-flag2`: Disable feature `flag2`.
- `?flags=+flag1,-flag2`: Enable feature `flag1` and disable feature `flag2`.