### PR TITLE
Typography Design: Added some details for the typography section of the design handbook.

### DIFF
--- a/client/devdocs/design/style.scss
+++ b/client/devdocs/design/style.scss
@@ -158,3 +158,17 @@
 		box-shadow: 0 0 0 1px $blue-wordpress, 0 0 0 4px $blue-light;
 	}
 }
+
+.docs__design-group {
+	pre {
+		padding: (12 / 15) * 1em;
+		background: $white;
+		background-color: $white;
+	}
+	code {
+		font-size: 0.86667em;
+	    background-color: white;
+	    padding: 0.2em;
+	    border-radius: 3px;
+	}
+}

--- a/client/devdocs/design/typography.jsx
+++ b/client/devdocs/design/typography.jsx
@@ -75,6 +75,7 @@ export default React.createClass( {
 						<a href="/devdocs/design/typography">Typography</a>
 					</h2>
 					<h3>Interface Typography</h3>
+					<p>We use system fonts (<code>-apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen-Sans", "Ubuntu", "Cantarell", "Helvetica Neue", sans-serif</code>) which improve the page rendering speed.</p>
 					<Card>
 						<p style={ interfaceTitle }>Quick foxes jump nightly above wizards.</p>
 						<p style={ interfaceSubtitle }>Pack my box with five dozen liquor jugs</p>
@@ -83,6 +84,7 @@ export default React.createClass( {
 						<p style={ interfaceCaption }>Views per page</p>
 					</Card>
 					<h3>Content Typography</h3>
+					<p>We use <code>Noto Serif</code> which helps to make the web more beautiful across platforms for all languages.</p>
 					<Card>
 						<p style={ contentTitle }>Quick foxes jump nightly above wizards.</p>
 						<p style={ contentSubtitle }>Pack my box with five dozen liquor jugs</p>

--- a/client/devdocs/design/typography.jsx
+++ b/client/devdocs/design/typography.jsx
@@ -75,7 +75,9 @@ export default React.createClass( {
 						<a href="/devdocs/design/typography">Typography</a>
 					</h2>
 					<h3>Interface Typography</h3>
-					<p>We use system fonts (<code>-apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen-Sans", "Ubuntu", "Cantarell", "Helvetica Neue", sans-serif</code>) which improve the page rendering speed.</p>
+					<p>We use system fonts which improve the page rendering speed.<br />
+					<code>-apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen-Sans",
+						"Ubuntu", "Cantarell", "Helvetica Neue", sans-serif</code></p>
 					<Card>
 						<p style={ interfaceTitle }>Quick foxes jump nightly above wizards.</p>
 						<p style={ interfaceSubtitle }>Pack my box with five dozen liquor jugs</p>


### PR DESCRIPTION
Our typography page wasn't clear which fonts we are using, so I added some details around that to help clarify for contributors.

It now looks like this:
![screen shot 2017-09-01 at 4 07 36 pm](https://user-images.githubusercontent.com/617986/29990535-75f6e58c-8f30-11e7-9b54-821637879722.png)
