### PR TITLE
Move stats block detection to public route and simplify error message

### DIFF
--- a/client/lib/analytics/index.js
+++ b/client/lib/analytics/index.js
@@ -87,7 +87,7 @@ function checkForBlockedTracks() {
 		}
 	}
 
-	loadScript( '/nostats.js?_ut=' + encodeURIComponent( _ut ) + '&_ui=' + encodeURIComponent( _ui ) );
+	loadScript( '/public/nostats.js?_ut=' + encodeURIComponent( _ut ) + '&_ui=' + encodeURIComponent( _ui ) );
 }
 
 loadScript( '//stats.wp.com/w.js?56', function( error ) {

--- a/server/boot/index.js
+++ b/server/boot/index.js
@@ -53,11 +53,11 @@ function setup() {
 		express.static( path.resolve( __dirname, '..', '..', 'client', 'lib', 'service-worker', 'service-worker.js' ) ) );
 
 	// loaded when we detect stats blockers - see lib/analytics/index.js
-	app.get( '/nostats.js', function( request, response ) {
+	app.get( '/public/nostats.js', function( request, response ) {
 		const analytics = require( '../lib/analytics' );
 		analytics.tracks.recordEvent( 'calypso_nostats', {}, request );
 		response.setHeader( 'content-type', 'application/javascript' );
-		response.end( "console.log('Your browser appears to be blocking our stats');" );
+		response.end( "console.log('Stats are disabled');" );
 	} );
 
 	// serve files when not in production so that the source maps work correctly


### PR DESCRIPTION
Stats disabled detection was 404'ing on the root; move to a public route so it works.