### PR TITLE
Add Geolocation checks for the Masterbar pride styling

### DIFF
--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -46,6 +46,12 @@ const prideLanguages = [
 	'en-au',
 ];
 
+// List of geolocated locations to show pride styling for.
+// Geolocation may not be 100% accurate.
+const prideLocations = [
+	'au',
+];
+
 const sections = sectionsModule.get();
 
 // TODO: Re-use (a modified version of) client/state/initial-state#getInitialServerState here
@@ -161,8 +167,13 @@ function getDefaultContext( request ) {
 		initialServerState = getInitialServerState( serializeCachedServerState );
 	}
 
+	// Note: The x-geoip-country-code header should *not* be considered 100% accurate.
+	// It should only be used for guestimating the visitor's location.
 	const acceptedLanguages = getAcceptedLanguagesFromHeader( request.headers[ 'accept-language' ] );
-	if ( prideLanguages.indexOf( '*' ) > -1 || intersection( prideLanguages, acceptedLanguages ).length > 0 ) {
+	if ( prideLanguages.indexOf( '*' ) > -1 ||
+		intersection( prideLanguages, acceptedLanguages ).length > 0 ||
+		prideLocations.indexOf( '*' ) > -1 ||
+		prideLocations.indexOf( request.headers[ 'x-geoip-country-code' ].toLowerCase() ) > -1 ) {
 		bodyClasses.push( 'pride' );
 	}
 

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -161,6 +161,7 @@ function getDefaultContext( request ) {
 	let initialServerState = {};
 	const bodyClasses = [];
 	const cacheKey = getCacheKey( request );
+	const geoLocation = ( request.headers[ 'x-geoip-country-code' ] || '' ).toLowerCase();
 
 	if ( cacheKey ) {
 		const serializeCachedServerState = stateCache.get( cacheKey ) || {};
@@ -173,7 +174,7 @@ function getDefaultContext( request ) {
 	if ( prideLanguages.indexOf( '*' ) > -1 ||
 		intersection( prideLanguages, acceptedLanguages ).length > 0 ||
 		prideLocations.indexOf( '*' ) > -1 ||
-		prideLocations.indexOf( request.headers[ 'x-geoip-country-code' ].toLowerCase() ) > -1 ) {
+		prideLocations.indexOf( geoLocation ) > -1 ) {
 		bodyClasses.push( 'pride' );
 	}
 


### PR DESCRIPTION
This pull request makes the pride styling check look at the new `X-GeoIP-Country-Code` header, which may contain accurate information.

#### Testing instructions

1. Run `git checkout add/pride-masterbar-geolocation`, and start your server
2. Grep with no header sent: `curl http://calypso.localhost:3000/ | grep pride`
3. Grep with the wrong header sent: `curl http://calypso.localhost:3000/ -H "X-GeoIP-Country-Code: US" | grep '"pride"'`
3. Grep with the right header sent: `curl http://calypso.localhost:3000/ -H "X-GeoIP-Country-Code: AU" | grep '"pride"'`

Note: The header isn't set automatically on calypso.live, but you can fake it. ie:

`curl https://calypso.live/?branch=add/pride-masterbar-geolocation -H "X-GeoIP-Country-Code: AU" | ack '"pride"'`

Only the correct header should show any grep results.

#### Reviews

- [ ] Code
