### PR TITLE
Move stats check back to root

### DIFF
--- a/client/lib/analytics/index.js
+++ b/client/lib/analytics/index.js
@@ -87,7 +87,7 @@ function checkForBlockedTracks() {
 		}
 	}
 
-	loadScript( '/public/nostats.js?_ut=' + encodeURIComponent( _ut ) + '&_ui=' + encodeURIComponent( _ui ) );
+	loadScript( '/nostats.js?_ut=' + encodeURIComponent( _ut ) + '&_ui=' + encodeURIComponent( _ui ) );
 }
 
 loadScript( '//stats.wp.com/w.js?56', function( error ) {

--- a/server/boot/index.js
+++ b/server/boot/index.js
@@ -53,7 +53,7 @@ function setup() {
 		express.static( path.resolve( __dirname, '..', '..', 'client', 'lib', 'service-worker', 'service-worker.js' ) ) );
 
 	// loaded when we detect stats blockers - see lib/analytics/index.js
-	app.get( '/public/nostats.js', function( request, response ) {
+	app.get( '/nostats.js', function( request, response ) {
 		const analytics = require( '../lib/analytics' );
 		analytics.tracks.recordEvent( 'calypso_nostats', {}, request );
 		response.setHeader( 'content-type', 'application/javascript' );


### PR DESCRIPTION
/public is just for static files. Better to add a specific route for this to the web server configuration.