### PR TITLE
Plugins: make 'browse' the default route

### DIFF
--- a/client/my-sites/plugins-wpcom/jetpack-plugins-panel.jsx
+++ b/client/my-sites/plugins-wpcom/jetpack-plugins-panel.jsx
@@ -98,7 +98,7 @@ class JetpackPluginsPanel extends Component {
 			{
 				key: 'all',
 				title: translate( 'All' ),
-				path: '/plugins' + siteFilter,
+				path: '/plugins/manage' + siteFilter,
 			},
 			{
 				key: 'engagement',

--- a/client/my-sites/plugins/controller.js
+++ b/client/my-sites/plugins/controller.js
@@ -110,7 +110,7 @@ function renderPluginList( context, basePath ) {
 			: ''
 		);
 
-	let baseAnalyticsPath = 'plugins';
+	let baseAnalyticsPath = 'plugins/manage';
 	if ( site ) {
 		baseAnalyticsPath += '/:site';
 	}

--- a/client/my-sites/plugins/controller.js
+++ b/client/my-sites/plugins/controller.js
@@ -212,12 +212,13 @@ const controller = {
 	plugin( context ) {
 		const siteUrl = route.getSiteFragment( context.path );
 
+		// If the "plugin" part of the route is actually a site, browse the plugins for that site instead.
 		if (
 			siteUrl &&
 			context.params.plugin &&
 			context.params.plugin === siteUrl.toString()
 		) {
-			controller.plugins( 'all', context );
+			controller.browsePlugins( context );
 			return;
 		}
 
@@ -244,10 +245,10 @@ const controller = {
 
 			if ( redirectToPlugins ) {
 				if ( context.params && context.params.site_id ) {
-					page.redirect( `/plugins/${ context.params.site_id }` );
+					page.redirect( `/plugins/manage/${ context.params.site_id }` );
 					return;
 				}
-				page.redirect( '/plugins' );
+				page.redirect( '/plugins/manage' );
 				return;
 			}
 		}

--- a/client/my-sites/plugins/index.js
+++ b/client/my-sites/plugins/index.js
@@ -61,7 +61,7 @@ module.exports = function() {
 		page( '/plugins/category/:category/:site_id',
 			controller.siteSelection,
 			controller.navigation,
-			nonJetpackRedirectTo( '/plugins' ),
+			nonJetpackRedirectTo( '/plugins/manage' ),
 			pluginsController.plugins.bind( null, 'all' ),
 		);
 
@@ -77,6 +77,12 @@ module.exports = function() {
 		page( '/plugins',
 			controller.siteSelection,
 			controller.navigation,
+			pluginsController.browsePlugins
+		);
+
+		page( '/plugins/manage/:site?',
+			controller.siteSelection,
+			controller.navigation,
 			pluginsController.plugins.bind( null, 'all' ),
 			controller.sites
 		);
@@ -86,7 +92,8 @@ module.exports = function() {
 				controller.siteSelection,
 				controller.navigation,
 				pluginsController.jetpackCanUpdate.bind( null, filter ),
-				pluginsController.plugins.bind( null, filter )
+				pluginsController.plugins.bind( null, filter ),
+				controller.sites
 			)
 		) );
 

--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -126,7 +126,7 @@ const PluginsMain = React.createClass( {
 		return [
 			{
 				title: translate( 'All', { context: 'Filter label for plugins list' } ),
-				path: '/plugins' + siteFilter,
+				path: '/plugins/manage' + siteFilter,
 				id: 'all'
 			},
 			{

--- a/client/my-sites/plugins/plugin.jsx
+++ b/client/my-sites/plugins/plugin.jsx
@@ -148,7 +148,7 @@ const SinglePlugin = React.createClass( {
 		if ( this.props.prevPath ) {
 			return this.getPreviousListUrl();
 		}
-		return '/plugins/' + ( this.props.siteUrl || '' );
+		return '/plugins/manage/' + ( this.props.siteUrl || '' );
 	},
 
 	displayHeader() {

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -289,7 +289,7 @@ const PluginsBrowser = React.createClass( {
 			<HeaderButton
 				icon="cog"
 				label={ this.props.translate( 'Manage Plugins' ) }
-				href={ '/plugins' + site }
+				href={ '/plugins/manage' + site }
 			/>
 		);
 	},

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -225,20 +225,8 @@ export class MySitesSidebar extends Component {
 	}
 
 	plugins() {
-		const { site } = this.props;
-		const addPluginsLink = '/plugins/browse' + this.props.siteSuffix;
-		let pluginsLink = '/plugins' + this.props.siteSuffix;
-
-		// TODO: we can probably rip this out
-		if ( ! config.isEnabled( 'manage/plugins' ) ) {
-			if ( ! site ) {
-				return null;
-			}
-
-			if ( site.options ) {
-				pluginsLink = site.options.admin_url + 'plugins.php';
-			}
-		}
+		const pluginsLink = '/plugins' + this.props.siteSuffix;
+		const managePluginsLink = '/plugins/manage' + this.props.siteSuffix;
 
 		// checks for manage plugins capability across all sites
 		if ( ! this.props.canManagePlugins ) {
@@ -250,6 +238,12 @@ export class MySitesSidebar extends Component {
 			return null;
 		}
 
+		const manageButton = this.props.isJetpack
+			? <SidebarButton href={ managePluginsLink }>
+					{ this.props.translate( 'Manage' ) }
+				</SidebarButton>
+			: null;
+
 		return (
 			<SidebarItem
 				label={ this.props.translate( 'Plugins' ) }
@@ -259,9 +253,7 @@ export class MySitesSidebar extends Component {
 				icon="plugins"
 				preloadSectionName="plugins"
 			>
-				<SidebarButton href={ addPluginsLink }>
-					{ this.props.translate( 'Add' ) }
-				</SidebarButton>
+				{ manageButton }
 			</SidebarItem>
 		);
 	}


### PR DESCRIPTION
This updates the Plugins page so that browsing plugins happens at `/plugins` (previously `/plugins/browse`, although that will still work) and managing plugins happens at `/plugins/manage` (previously `/plugins`).

Requires #17719 to be merged first!

Extracted from #17537

## Testing

1. Visit a site in Calypso. 
2. Click on the "Plugins" link in the sidebar. Verify that you see the "browse" page (aka "add a plugin").
3. Click the "manage" button adjacent to the "Plugins" link in the sidebar. Verify that you see the "manage" page (aka: "installed plugins").
4. Click the "Add plugin" button in the header of the "manage" page. Verify that you are directed to the "browse" page.
5. Click the "Manage Plugins" button in the header of the "browse" page. Verify that you are directed to the "manage" page.
6. Look around Calypso for other links to the plugins pages and verify that they work as expected (this might need further refinement!).