### PR TITLE
Domains: Clarify domains credit doesn't apply to Premium Domains

### DIFF
--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -800,7 +800,7 @@ export const FEATURES_LIST = {
 
 			return i18n.translate(
 				'Get a free custom domain name (example.com) with this plan ' +
-				'to use for your website.'
+				'to use for your website. Does not apply to premium domains.'
 			);
 		}
 	},

--- a/client/my-sites/checkout/checkout-thank-you/custom-domain-purchase-detail.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/custom-domain-purchase-detail.jsx
@@ -18,7 +18,7 @@ const CustomDomainPurchaseDetail = ( { selectedSite, hasDomainCredit, translate 
 				description={
 					translate(
 						'Your plan includes a free custom domain. Replace {{em}}%(siteDomain)s{{/em}} ' +
-						'with a custom domain to personalize your site.',
+						'with a custom domain to personalize your site. Does not apply to premium domains.',
 						{
 							args: { siteDomain: selectedSite.domain },
 							components: { em: <em /> }

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -203,7 +203,7 @@ class PlansFeaturesMain extends Component {
 					answer={ translate(
 						'Yes! The Personal, Premium, and Business plans include a free custom domain. That includes new' +
 						' domains purchased through WordPress.com or your own existing domain that you can map' +
-						' to your WordPress.com site. {{a}}Find out more about domains.{{/a}}',
+						' to your WordPress.com site. Does not apply to premium domains. {{a}}Find out more about domains.{{/a}}',
 						{
 							components: {
 								a: <a


### PR DESCRIPTION
As mentioned in https://github.com/Automattic/wp-calypso/issues/16932#issuecomment-325310952, we should clarify in few places in Calypso that the Domain Credit does not entitle the user to a Premium Domain.

### Testing
Plans FAQ section:
<img width="314" alt="screen shot 2017-09-03 at 22 45 51" src="https://user-images.githubusercontent.com/3392497/30006498-13ae5858-90fa-11e7-981e-17e8d8684bb9.png">
<img width="321" alt="screen shot 2017-09-03 at 22 47 13" src="https://user-images.githubusercontent.com/3392497/30006499-13dcdfb6-90fa-11e7-9dfa-53cae768ffc0.png">

On the plans page, for the "Custom Domain Name" tooltip:
<img width="589" alt="screen shot 2017-09-03 at 22 46 07" src="https://user-images.githubusercontent.com/3392497/30006505-221265f6-90fa-11e7-8288-7b709020ebef.png">
<img width="617" alt="screen shot 2017-09-03 at 22 47 04" src="https://user-images.githubusercontent.com/3392497/30006506-22406032-90fa-11e7-992e-09a6d0e490d2.png">

And one more place I think needs addressing: on My Plan page, when the user has domain credit available, we show this nudge:
<img width="479" alt="screen shot 2017-09-03 at 22 50 47" src="https://user-images.githubusercontent.com/3392497/30006522-5a5f6382-90fa-11e7-87b4-69c8838f0cdc.png">
<img width="473" alt="screen shot 2017-09-03 at 22 47 43" src="https://user-images.githubusercontent.com/3392497/30006521-5a324ff0-90fa-11e7-9517-33a28a6de0c1.png">
