### PR TITLE
MySites: Show error on invalid primary

### DIFF
--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -59,6 +59,7 @@ import {
 } from 'my-sites/domains/paths';
 import SitesComponent from 'my-sites/sites';
 import { isATEnabled } from 'lib/automated-transfer';
+import { errorNotice } from 'state/notices/actions';
 
 /*
  * @FIXME Shorthand, but I might get rid of this.
@@ -304,15 +305,23 @@ module.exports = {
 		// If the user has only one site, redirect to the single site
 		// context instead of rendering the all-site views.
 		if ( hasOneSite && ! siteFragment ) {
-			const hasInitialized = getSites( getState() ).length;
-			if ( hasInitialized ) {
-				redirectToPrimary();
-				return;
+			if ( primary ) {
+				const hasInitialized = getSites( getState() ).length;
+				if ( hasInitialized ) {
+					redirectToPrimary();
+					return;
+				}
+				dispatch( {
+					type: SITES_ONCE_CHANGED,
+					listener: redirectToPrimary,
+				} );
+			} else {
+				// If the primary site does not exist, skip redirect and display a useful error notification
+				dispatch( errorNotice( i18n.translate( 'Please set your Primary Site to valid site' ), {
+					button: 'Settings',
+					href: '/me/account',
+				} ) );
 			}
-			dispatch( {
-				type: SITES_ONCE_CHANGED,
-				listener: redirectToPrimary,
-			} );
 		}
 
 		// If the path fragment does not resemble a site, set all sites to visible


### PR DESCRIPTION
Continuation of https://github.com/Automattic/wp-calypso/pull/17583 which is a continuation of https://github.com/Automattic/wp-calypso/pull/17512

> ### Cause

>For some reason, the primary site is not found and an attempt to access primary.slug results in the addition of /undefined string on a redirect.

### Previous Solutions
https://github.com/Automattic/wp-calypso/pull/17583 attempts to address the faulted logic with `visible_site_count` on the client. It turns out, referencing a count of visible sites does not work. The `visible_site_count` field is required before the return of the `/sites` request, causing [problems in other areas](https://github.com/Automattic/wp-calypso/pull/17583#issuecomment-325583358).

### This Solution
Due to the difficult nature of pinpointing the exact cause of primary sites not being found in a user's `state.sites.items` and the [odd origins](https://github.com/Automattic/wp-calypso/pull/17583#issuecomment-325715137) of this state, address the problem by showing "MySItes" without data and an `errorNotice` informing the user. This avoids the redirect problem, the interference with other flows, and invites the user to solve the problem.

![screen shot 2017-09-04 at 2 21 32 pm](https://user-images.githubusercontent.com/1922453/30009699-86914590-917e-11e7-896b-3d16f9eea76c.png)

cc @alisterscott @gwwar @jeremysawesome @westi 