### PR TITLE
UserSettings: Fix getOriginalSetting to return falsy values

### DIFF
--- a/client/lib/user-settings/index.js
+++ b/client/lib/user-settings/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { assign, isEmpty, keys, merge } from 'lodash';
+import { assign, get, isEmpty, keys, merge } from 'lodash';
 var debug = require( 'debug' )( 'calypso:user:settings' ),
 	decodeEntities = require( 'lib/formatting' ).decodeEntities;
 
@@ -152,12 +152,7 @@ UserSettings.prototype.cancelPendingEmailChange = function( callback ) {
  * @return {*} setting key value
  */
 UserSettings.prototype.getOriginalSetting = function( settingName ) {
-	var setting = null;
-	if ( this.settings && this.settings[ settingName ] ) {
-		setting = this.settings[ settingName ];
-	}
-
-	return setting;
+	return get( this.settings, settingName, null );
 };
 
 /**

--- a/client/lib/user-settings/test/index.js
+++ b/client/lib/user-settings/test/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { assert } from 'chai';
+import { assert, expect } from 'chai';
 
 /**
  * Internal dependencies
@@ -40,5 +40,43 @@ describe( 'User Settings', () => {
 			assert.isTrue( userSettings.unsavedSettings.lang_id );
 			done();
 		}
+	} );
+
+	describe( '#getOriginalSetting', () => {
+		context( 'when a setting has a truthy value', () => {
+			beforeEach( () => {
+				userSettings.settings.someSetting = 'someValue';
+			} );
+
+			it( 'returns the value of that setting', () => {
+				const actual = userSettings.getOriginalSetting( 'someSetting' );
+				const expected = 'someValue';
+				expect( actual ).to.equal( expected );
+			} );
+		} );
+
+		context( 'when a setting has a falsy value', () => {
+			beforeEach( () => {
+				userSettings.settings.someSetting = 0;
+			} );
+
+			it( 'returns the value of that setting', () => {
+				const actual = userSettings.getOriginalSetting( 'someSetting' );
+				const expected = 0;
+				expect( actual ).to.equal( expected );
+			} );
+		} );
+
+		context( 'when a setting is not found', () => {
+			beforeEach( () => {
+				delete userSettings.settings.someSetting;
+			} );
+
+			it( 'returns null', () => {
+				const actual = userSettings.getOriginalSetting( 'someSetting' );
+				const expected = null;
+				expect( actual ).to.equal( expected );
+			} );
+		} );
 	} );
 } );


### PR DESCRIPTION
I noticed some potential for bugs when looking through `lib/user-settings/index.js` as part of another PR.
The original function returns null for any setting retrieved with a falsy value (`0`, `''`, `false`, etc.).

Using Lodash's `get` fixes this issue safely.

I've added tests first to prove the issue with the original logic (checkout that commit) and then passed them with the refactored code.