### PR TITLE
Deploy social signup to all signup flows for logged out users

### DIFF
--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -258,15 +258,6 @@ if ( config.isEnabled( 'signup/domain-first-flow' ) ) {
 	};
 }
 
-if ( config.isEnabled( 'signup/social' ) ) {
-	flows.social = {
-		steps: [ 'user-social' ],
-		destination: '/',
-		description: 'Create an account without a blog with social signup enabled.',
-		lastModified: '2017-03-16'
-	};
-}
-
 if ( config( 'env' ) === 'development' ) {
 	flows[ 'test-plans' ] = {
 		steps: [ 'site', 'plans', 'user' ],

--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -40,6 +40,5 @@ export default {
 	'portfolio-themes': ThemeSelectionComponent,
 	'themes-site-selected': ThemeSelectionComponent,
 	user: UserSignupComponent,
-	'user-social': UserSignupComponent,
 	'oauth2-user': UserSignupComponent
 };

--- a/client/signup/config/steps.js
+++ b/client/signup/config/steps.js
@@ -7,6 +7,7 @@ import i18n from 'i18n-calypso';
 /**
 * Internal dependencies
 */
+import config from 'config';
 import stepActions from 'lib/signup/step-actions';
 
 export default {
@@ -85,17 +86,8 @@ export default {
 		providesToken: true,
 		providesDependencies: [ 'bearer_token', 'username' ],
 		unstorableDependencies: [ 'bearer_token' ],
-	},
-
-	'user-social': {
-		stepName: 'user-social',
-		apiRequestFunction: stepActions.createAccount,
-		providesToken: true,
-		providesDependencies: [ 'bearer_token', 'username' ],
-		unstorableDependencies: [ 'bearer_token' ],
 		props: {
-			headerText: i18n.translate( 'Create your account.' ),
-			isSocialSignupEnabled: true
+			isSocialSignupEnabled: config.isEnabled( 'signup/social' )
 		},
 	},
 

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -58,10 +58,7 @@ export class UserStep extends Component {
 
 		let subHeaderText = props.subHeaderText;
 
-		if ( flowName === 'social' ) {
-			// Hides sub header for this particular flow
-			subHeaderText = '';
-		} else if ( flowName === 'wpcc' && oauth2Client ) {
+		if ( flowName === 'wpcc' && oauth2Client ) {
 			if ( oauth2Client.id === 50916 ) {
 				subHeaderText = translate( '{{a}}Learn more about the benefits{{/a}}', {
 					components: {


### PR DESCRIPTION
This pull request adds a "Connect with Google" button to the user step in signup. This should allow users to skip entering these details in signup and create an account using their Google account.
  
#### Testing instructions
There are a lot of different combinations to test. Here are a few. When connecting with Google...
- [x] Does the theme selection get saved?
- [x] Does the plan selection get saved?
- [x] Does the domain selection get saved?
- [x] Do preselected domains and plans get saved?
- [x] Is the user taken to checkout if they selected a paid product?
- [x] If the user logs in to an existing account does the new site get attached to their account
- [x] Logged in signup should be unaffected
- [x] What happens in the desktop app?

#### Reviews
  
- [x] Code
- [x] Product