### PR TITLE
Checkout: wrap up PayPal logo vs text test, logo wins

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -95,16 +95,6 @@ module.exports = {
 		defaultVariation: 'white',
 		assignmentMethod: 'userId',
 	},
-	paymentShowPaypalLogo: {
-		datestamp: '20170719',
-		variations: {
-			hide: 50,
-			show: 50,
-		},
-		defaultVariation: 'hide',
-		allowExistingUsers: true,
-		localeTargets: 'any',
-	},
 	postSignupUpgradeScreen: {
 		datestamp: '20170810',
 		variations: {

--- a/client/my-sites/checkout/checkout/credit-card-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/credit-card-payment-box.jsx
@@ -100,13 +100,9 @@ var CreditCardPaymentBox = React.createClass( {
 			showPaymentChatButton = config.isEnabled( 'upgrades/presale-chat' ) &&
 				abtest( 'presaleChatButton' ) === 'showChatButton' &&
 				hasBusinessPlanInCart,
-			showPaypalLogo = abtest( 'paymentShowPaypalLogo' ) === 'show',
 			paypalButtonClasses = classnames( 'credit-card-payment-box__switch-link', {
 				'credit-card-payment-box__switch-link-left': showPaymentChatButton,
-			} ),
-			paypalLinkContent = showPaypalLogo
-				? <img src="/calypso/images/upgrades/paypal.svg" alt="PayPal" width="80" />
-				: <span>PayPal</span>;
+			} );
 
 		return (
 			<div className="payment-box__payment-buttons">
@@ -118,7 +114,7 @@ var CreditCardPaymentBox = React.createClass( {
 					? <a className={ paypalButtonClasses } href="" onClick={ this.handleToggle }>
 						{ this.props.translate( 'or use {{paypal/}}', {
 							components: {
-								paypal: paypalLinkContent
+								paypal: <img src="/calypso/images/upgrades/paypal.svg" alt="PayPal" width="80" />
 							}
 						} ) }</a>
 					: null


### PR DESCRIPTION
Test was launched with #16343
This wraps up the test and use the logo for everybody.

Testing: you should see the PayPal logo in the checkout screen, under the CC form:
<img width="742" alt="screen shot 2017-07-19 at 1 43 15" src="https://user-images.githubusercontent.com/844866/28342981-b006ac10-6c23-11e7-82fb-e41f2b224db2.png">

