### PR TITLE
Guided Tours: introduce a way to reset the tours history

### DIFF
--- a/client/layout/guided-tours/docs/API.md
+++ b/client/layout/guided-tours/docs/API.md
@@ -11,7 +11,7 @@ Tour is a React component that declares the top-level of a tour. It consists of 
 * `name`: (string) Unique name of tour in camelCase.
 * `version` (string): Version identifier. We use date string like "20161224".
 * `path` (string or array, optional): Use this prop to limit tour only to some path prefix (or more prefixes if array). Example: `path={ [ '/stats', '/settings' ] }`
-* `when` (function, optional): This is a Redux selector function. Use this to define conditions for the tour to start. Can be overridden by adding a `tour` query argument to the URL like so: `?tour=tourName`, in which case the tour will be triggered even if `when` would evaluate to `false`. This is useful for sending along a tour via email or chat. On the other hand, the framework will try to not trigger a tour multiple times (see `toursSeen` in [ARCHITECTURE.md](./ARCHITECTURE.md)).
+* `when` (function, optional): This is a Redux selector function. Use this to define conditions for the tour to start. Can be overridden by adding a `tour` query argument to the URL like so: `?tour=tourName`, in which case the tour will be triggered even if `when` would evaluate to `false`. This is useful for sending along a tour via email or chat. On the other hand, the framework will try to not trigger a tour multiple times (see `toursSeen` in [ARCHITECTURE.md](./ARCHITECTURE.md)). *Note:* you can reset the tours history by adding `?tour=reset` to the URL. 
 * `children` (nodes): only supported type is `<Step>`
 
 ### Example

--- a/client/layout/guided-tours/index.js
+++ b/client/layout/guided-tours/index.js
@@ -15,12 +15,18 @@ import QueryPreferences from 'components/data/query-preferences';
 import RootChild from 'components/root-child';
 import { getGuidedTourState } from 'state/ui/guided-tours/selectors';
 import { getLastAction } from 'state/ui/action-log/selectors';
-import { getSectionName, isSectionLoading } from 'state/ui/selectors';
-import { nextGuidedTourStep, quitGuidedTour } from 'state/ui/guided-tours/actions';
+import { getInitialQueryArguments, getSectionName, isSectionLoading } from 'state/ui/selectors';
+import { nextGuidedTourStep, quitGuidedTour, resetGuidedToursHistory } from 'state/ui/guided-tours/actions';
 
 class GuidedTours extends Component {
 	shouldComponentUpdate( nextProps ) {
 		return this.props.tourState !== nextProps.tourState;
+	}
+
+	componentWillReceiveProps( nextProps ) {
+		if ( nextProps.requestedTour === 'reset' && this.props.requestedTour !== 'reset' ) {
+			this.props.resetGuidedToursHistory();
+		}
 	}
 
 	start = ( { step, tour, tourVersion: tour_version } ) => {
@@ -109,7 +115,9 @@ export default connect( ( state ) => ( {
 	tourState: getGuidedTourState( state ),
 	isValid: ( when ) => !! when( state ),
 	lastAction: getLastAction( state ),
+	requestedTour: getInitialQueryArguments( state ).tour,
 } ), {
 	nextGuidedTourStep,
 	quitGuidedTour,
+	resetGuidedToursHistory,
 } )( localize( GuidedTours ) );

--- a/client/state/ui/guided-tours/actions.js
+++ b/client/state/ui/guided-tours/actions.js
@@ -49,3 +49,7 @@ function addSeenGuidedTour( getState, tourName, finished = false ) {
 		}
 	] );
 }
+
+export function resetGuidedToursHistory() {
+	return savePreference( 'guided-tours-history', [] );
+}


### PR DESCRIPTION
Testing the triggers for guided tours has often been a bit cumbersome because every tour is shown only once AND there was no easy way to reset the tours history. 

This PR introduces an easy way to do the latter — by invoking a URL with the query string `tour=reset`.

To see the reset work, enter `localStorage.setItem( 'debug', 'calypso:guided-tours' )` into your console and reload. You should then see debug messages from the Guided Tours framework. If you then enter a URL with `?tour=reset` you should see the "tours seen" array become empty. 