### PR TITLE
Plugins: show suggested plugins on the Plugins Manage page

### DIFF
--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -268,29 +268,13 @@ const PluginsMain = React.createClass( {
 	},
 
 	renderPluginsContent() {
-		const plugins = this.state.plugins || [];
-		const { selectedSite } = this.props;
+		const { plugins = [] } = this.state;
+		const { filter, search, selectedSite } = this.props;
 
-		if ( isEmpty( plugins ) && ! this.isFetchingPlugins() ) {
-			if ( this.props.search ) {
-				const searchTitle = this.props.translate( 'Suggested plugins for: %(searchQuery)s', {
-					textOnly: true,
-					args: {
-						searchQuery: this.props.search
-					}
-				} );
+		const showInstalledPluginList = ! isEmpty( plugins ) || this.isFetchingPlugins();
+		const showSuggestedPluginsList = filter === 'all' || ( ! showInstalledPluginList && search );
 
-				return <PluginsBrowser
-						hideSearchForm
-						site={ selectedSite ? selectedSite.slug : null }
-						path={ this.context.path }
-						sites={ this.props.sites }
-						search={ this.props.search }
-						store={ this.context.store }
-						searchTitle={ searchTitle }
-					/>;
-			}
-
+		if ( ! showInstalledPluginList && ! search ) {
 			const emptyContentData = this.getEmptyContentData();
 			if ( emptyContentData ) {
 				return <EmptyContent
@@ -300,14 +284,48 @@ const PluginsMain = React.createClass( {
 					action={ emptyContentData.action } />;
 			}
 		}
+
+		const installedPluginsList = showInstalledPluginList && (
+			<PluginsList
+				header={ this.props.translate( 'Installed Plugins' ) }
+				plugins={ plugins }
+				sites={ this.props.sites }
+				pluginUpdateCount={ this.state.pluginUpdateCount }
+				isPlaceholder={ this.shouldShowPluginListPlaceholders() }
+			/>
+		);
+
+		const morePluginsHeader = showInstalledPluginList && showSuggestedPluginsList && (
+			<h3 className="plugins__more-header">More Plugins</h3>
+		);
+
+		let searchTitle;
+		if ( search ) {
+			searchTitle = this.props.translate( 'Suggested plugins for: %(searchQuery)s', {
+				textOnly: true,
+				args: {
+					searchQuery: search,
+				},
+			} );
+		}
+
+		const suggestedPluginsList = showSuggestedPluginsList && (
+			<PluginsBrowser
+				hideSearchForm
+				site={ selectedSite ? selectedSite.slug : null }
+				path={ this.context.path }
+				sites={ this.props.sites }
+				search={ search }
+				store={ this.context.store }
+				searchTitle={ searchTitle }
+			/>
+		);
+
 		return (
-			<div className="plugins__lists">
-				<PluginsList
-					header={ this.props.translate( 'Plugins' ) }
-					plugins={ plugins }
-					sites={ this.props.sites }
-					pluginUpdateCount={ this.state.pluginUpdateCount }
-					isPlaceholder= { this.shouldShowPluginListPlaceholders() } />
+			<div>
+				{ installedPluginsList }
+				{ morePluginsHeader }
+				{ suggestedPluginsList }
 			</div>
 		);
 	},
@@ -377,7 +395,7 @@ const PluginsMain = React.createClass( {
 
 		if ( selectedSite && ! this.props.selectedSiteIsJetpack ) {
 			return (
-				<Main>
+				<Main wideLayout>
 					{ this.renderDocumentHead() }
 					<SidebarNavigation />
 					<WpcomPluginPanel { ...{
@@ -426,7 +444,7 @@ const PluginsMain = React.createClass( {
 		} );
 
 		return (
-			<Main>
+			<Main wideLayout>
 				<NonSupportedJetpackVersionNotice />
 				{ this.renderDocumentHead() }
 				<SidebarNavigation />

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -34,3 +34,14 @@
 		border-width: 0 1px 0 0;
 	}
 }
+
+.plugins__more-header {
+	font-size: 14px;
+	line-height: 2;
+	margin: 40px 0 20px;
+	padding: 0 15px;
+
+	@include breakpoint( ">660px" ) {
+		padding: 0;
+	}
+}


### PR DESCRIPTION
Always show list of suggested plugins from WP.org on the Manage page.

If no search is active, show the Featured/Popular/New sections.

If search is active, show search results for both installed and suggested plugins.

The above holds only for the "All" tab. If the selected tab is one of "Active", "Inactive" or "Updates", show suggested plugins only when search is active and when nothing is found in the list of installed plugins.

The Plugins Manage page also starts to use `<Main wideLayout>` in this PR.

Extracted from the #17537 feature branch.
Even after this PR, issue #17738 is still happening. Let's not forget to fix it soon!
