### PR TITLE
WooCommerce - Copied the *updated* Shipping Label components from WCS

### DIFF
--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-item.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-item.js
@@ -1,0 +1,158 @@
+/**
+ * External dependencies
+ */
+import React, { Component, PropTypes } from 'react';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+import Gridicon from 'gridicons';
+import { translate as __ } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import RefundDialog from '../label-refund-modal';
+import ReprintDialog from '../label-reprint-modal';
+import TrackingLink from '../tracking-link';
+import InfoTooltip from 'components/info-tooltip';
+import formatDate from 'lib/utils/format-date';
+import timeAgo from 'lib/utils/time-ago';
+import { openRefundDialog, openReprintDialog } from '../../state/actions';
+
+class LabelItem extends Component {
+	renderRefundLink = ( label ) => {
+		const today = new Date();
+		const thirtyDaysAgo = new Date().setDate( today.getDate() - 30 );
+		if ( ( label.used_date && label.used_date < today.getTime() ) || ( label.created_date && label.created_date < thirtyDaysAgo ) ) {
+			return null;
+		}
+
+		const openDialog = ( e ) => {
+			e.preventDefault();
+			this.props.openRefundDialog( label.label_id );
+		};
+
+		return (
+			<span>
+				<RefundDialog { ...label } />
+				<a href="#" onClick={ openDialog } >
+					<Gridicon icon="refund" size={ 12 } />{ __( 'Request refund' ) }
+				</a>
+			</span>
+		);
+	};
+
+	renderRefund = ( label ) => {
+		if ( ! label.refund ) {
+			return this.renderRefundLink( label );
+		}
+
+		let text = '';
+		let className = '';
+		switch ( label.refund.status ) {
+			case 'pending':
+				if ( label.statusUpdated ) {
+					className = 'is-refund-pending';
+					text = __( 'Refund pending' );
+				} else {
+					className = 'is-refund-checking';
+					text = __( 'Checking refund status' );
+				}
+				break;
+			case 'complete':
+				className = 'is-refund-complete';
+				text = __( 'Refunded on %(date)s', { args: { date: formatDate( label.refund.refund_date ) } } );
+				break;
+			case 'rejected':
+				className = 'is-refund-rejected';
+				text = __( 'Refund rejected' );
+				break;
+			default:
+				return this.renderRefundLink( label );
+		}
+
+		return (
+			<span className={ className } ><Gridicon icon="time" size={ 12 } />{ text }</span>
+		);
+	};
+
+	renderReprint = ( label ) => {
+		const todayTime = new Date().getTime();
+		if ( label.refund ||
+			( label.used_date && label.used_date < todayTime ) ||
+			( label.expiry_date && label.expiry_date < todayTime ) ) {
+			return null;
+		}
+
+		const openDialog = ( e ) => {
+			e.preventDefault();
+			this.props.openReprintDialog( label.label_id );
+		};
+
+		return (
+			<span>
+				<ReprintDialog { ...label } />
+				<a href="#" onClick={ openDialog } >
+					<Gridicon icon="print" size={ 12 } />{ __( 'Reprint' ) }
+				</a>
+			</span>
+		);
+	};
+
+	renderLabelDetails = ( label ) => {
+		if ( ! label.package_name || ! label.product_names ) {
+			return null;
+		}
+
+		const tooltipAnchor = (
+			<span className="label-item__detail">
+				{ __( 'Label #%(labelNum)s', { args: { labelNum: this.props.labelNum } } ) }
+			</span>
+		);
+		return (
+			<InfoTooltip anchor={ tooltipAnchor }>
+				<h3>{ label.package_name }</h3>
+				<p>{ label.service_name }</p>
+				<ul>
+					{ label.product_names.map( ( productName, productIdx ) => <li key={ productIdx }>{ productName }</li> ) }
+				</ul>
+			</InfoTooltip>
+		);
+	};
+
+	render() {
+		const { label } = this.props;
+		const purchased = timeAgo( label.created );
+
+		return (
+			<div key={ label.label_id } className="label-item" >
+				<p className="label-item__created">
+					{ __( '{{labelDetails/}} purchased {{purchasedAt/}}', {
+						components: {
+							labelDetails: this.renderLabelDetails( label ),
+							purchasedAt: <span title={ formatDate( label.created ) }>{ purchased }</span>
+						}
+					} ) }
+				</p>
+				<p className="label-item__tracking">
+					{ __( 'Tracking #: {{trackingLink/}}', { components: { trackingLink: <TrackingLink { ...label } /> } } ) }
+				</p>
+				<p className="label-item__actions" >
+					{ this.renderRefund( label ) }
+					{ this.renderReprint( label ) }
+				</p>
+			</div>
+		);
+	}
+}
+
+LabelItem.propTypes = {
+	label: PropTypes.object.isRequired,
+	openRefundDialog: PropTypes.func.isRequired,
+	openReprintDialog: PropTypes.func.isRequired,
+};
+
+const mapDispatchToProps = ( dispatch ) => {
+	return bindActionCreators( { openRefundDialog, openReprintDialog }, dispatch );
+};
+
+export default connect( null, mapDispatchToProps )( LabelItem );

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/address-step/fields.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/address-step/fields.js
@@ -2,6 +2,8 @@
  * External dependencies
  */
 import React, { PropTypes } from 'react';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
 import { translate as __ } from 'i18n-calypso';
 import _ from 'lodash';
 
@@ -15,8 +17,17 @@ import StateDropdown from 'components/state-dropdown';
 import { hasNonEmptyLeaves } from 'lib/utils/tree';
 import AddressSuggestion from './suggestion';
 import { getPlainPhoneNumber, formatPhoneForDisplay } from 'lib/utils/phone-format';
+import getFormErrors from '../../../state/selectors/errors';
+import {
+	selectNormalizedAddress,
+	confirmAddressSuggestion,
+	editAddress,
+	updateAddressValue,
+	submitAddressForNormalization,
+} from '../../../state/actions';
 
-const AddressFields = ( {
+const AddressFields = ( props ) => {
+	const {
 		values,
 		isNormalized,
 		normalized,
@@ -24,22 +35,22 @@ const AddressFields = ( {
 		normalizationInProgress,
 		allowChangeCountry,
 		group,
-		labelActions,
 		storeOptions,
 		errors,
-	} ) => {
+	} = props;
+
 	if ( isNormalized && normalized && ! _.isEqual( normalized, values ) ) {
-		const selectNormalizedAddress = ( select ) => labelActions.selectNormalizedAddress( group, select );
-		const confirmAddressSuggestion = () => labelActions.confirmAddressSuggestion( group );
-		const editAddress = () => labelActions.editAddress( group );
+		const selectNormalizedAddressHandler = ( select ) => props.selectNormalizedAddress( group, select );
+		const confirmAddressSuggestionHandler = () => props.confirmAddressSuggestion( group );
+		const editAddressHandler = () => props.editAddress( group );
 		return (
 			<AddressSuggestion
 				values={ values }
 				normalized={ normalized }
 				selectNormalized={ selectNormalized }
-				selectNormalizedAddress={ selectNormalizedAddress }
-				confirmAddressSuggestion={ confirmAddressSuggestion }
-				editAddress={ editAddress }
+				selectNormalizedAddress={ selectNormalizedAddressHandler }
+				confirmAddressSuggestion={ confirmAddressSuggestionHandler }
+				editAddress={ editAddressHandler }
 				countriesData={ storeOptions.countriesData } />
 		);
 	}
@@ -47,10 +58,10 @@ const AddressFields = ( {
 	const fieldErrors = _.isObject( errors ) ? errors : {};
 	const getId = ( fieldName ) => group + '_' + fieldName;
 	const getValue = ( fieldName ) => values[ fieldName ] || '';
-	const updateValue = ( fieldName ) => ( newValue ) => labelActions.updateAddressValue( group, fieldName, newValue );
+	const updateValue = ( fieldName ) => ( newValue ) => props.updateAddressValue( group, fieldName, newValue );
 	const getPhoneNumber = ( value ) => getPlainPhoneNumber( value, getValue( 'country' ) );
-	const updatePhoneValue = ( value ) => labelActions.updateAddressValue( group, 'phone', getPhoneNumber( value ) );
-	const submitAddressForNormalization = () => labelActions.submitAddressForNormalization( group );
+	const updatePhoneValue = ( value ) => props.updateAddressValue( group, 'phone', getPhoneNumber( value ) );
+	const submitAddressForNormalizationHandler = () => props.submitAddressForNormalization( group );
 
 	return (
 		<div>
@@ -123,7 +134,7 @@ const AddressFields = ( {
 				error={ fieldErrors.country } />
 			<StepConfirmationButton
 				disabled={ hasNonEmptyLeaves( errors ) || normalizationInProgress }
-				onClick={ submitAddressForNormalization } >
+				onClick={ submitAddressForNormalizationHandler } >
 					{ __( 'Use this address' ) }
 			</StepConfirmationButton>
 		</div>
@@ -136,12 +147,32 @@ AddressFields.propTypes = {
 	normalized: PropTypes.object,
 	selectNormalized: PropTypes.bool.isRequired,
 	allowChangeCountry: PropTypes.bool.isRequired,
-	labelActions: PropTypes.object.isRequired,
 	storeOptions: PropTypes.object.isRequired,
 	errors: PropTypes.oneOfType( [
 		PropTypes.object,
 		PropTypes.bool,
 	] ).isRequired,
+	group: PropTypes.string.isRequired,
 };
 
-export default AddressFields;
+const mapStateToProps = ( state, ownProps ) => {
+	const loaded = state.shippingLabel.loaded;
+	const storeOptions = loaded ? state.shippingLabel.storeOptions : {};
+	return {
+		...state.shippingLabel.form[ ownProps.group ],
+		errors: loaded && getFormErrors( state, storeOptions )[ ownProps.group ],
+		storeOptions,
+	};
+};
+
+const mapDispatchToProps = ( dispatch ) => {
+	return bindActionCreators( {
+		selectNormalizedAddress,
+		confirmAddressSuggestion,
+		editAddress,
+		updateAddressValue,
+		submitAddressForNormalization,
+	}, dispatch );
+};
+
+export default connect( mapStateToProps, mapDispatchToProps )( AddressFields );

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/packages-step/add-item.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/packages-step/add-item.js
@@ -2,6 +2,8 @@
  * External dependencies
  */
 import React, { PropTypes } from 'react';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
 import { translate as __ } from 'i18n-calypso';
 import _ from 'lodash';
 
@@ -14,16 +16,17 @@ import FormLabel from 'components/forms/form-label';
 import ActionButtons from 'components/action-buttons';
 import getPackageDescriptions from './get-package-descriptions';
 import FormSectionHeading from 'components/forms/form-section-heading';
+import { closeAddItem, setAddedItem, addItems } from '../../../state/actions';
 
-const AddItemDialog = ( {
-	showAddItemDialog,
-	addedItems,
-	openedPackageId,
-	selected,
-	all,
-	closeAddItem,
-	setAddedItem,
-	addItems } ) => {
+const AddItemDialog = ( props ) => {
+	const {
+		showAddItemDialog,
+		addedItems,
+		openedPackageId,
+		selected,
+		all,
+	} = props;
+
 	if ( ! showAddItemDialog ) {
 		return null;
 	}
@@ -38,7 +41,7 @@ const AddItemDialog = ( {
 			? __( '%(item)s from {{pckg/}}', { args: { item: item.name }, components: { pckg: getPackageNameElement( pckgId ) } } )
 			: item;
 
-		const onChange = ( event ) => setAddedItem( pckgId, itemIdx, event.target.checked );
+		const onChange = ( event ) => props.setAddedItem( pckgId, itemIdx, event.target.checked );
 		return (
 			<FormLabel
 				key={ `${ pckgId }-${ itemIdx }` }
@@ -66,8 +69,8 @@ const AddItemDialog = ( {
 	return (
 		<Dialog isVisible={ showAddItemDialog }
 				isFullScreen={ false }
-				onClickOutside={ closeAddItem }
-				onClose={ closeAddItem }
+				onClickOutside={ props.closeAddItem }
+				onClose={ props.closeAddItem }
 				additionalClassNames="wcc-root packages-step__dialog" >
 			<FormSectionHeading>{ __( 'Add item' ) }</FormSectionHeading>
 			<div className="packages-step__dialog-body">
@@ -85,9 +88,9 @@ const AddItemDialog = ( {
 					label: __( 'Add' ),
 					isPrimary: true,
 					isDisabled: ! _.some( addedItems, _.size ),
-					onClick: () => addItems( openedPackageId ),
+					onClick: () => props.addItems( openedPackageId ),
 				},
-				{ label: __( 'Close' ), onClick: closeAddItem },
+				{ label: __( 'Close' ), onClick: props.closeAddItem },
 			] } />
 		</Dialog>
 	);
@@ -104,4 +107,18 @@ AddItemDialog.propTypes = {
 	addItems: PropTypes.func.isRequired,
 };
 
-export default AddItemDialog;
+const mapStateToProps = ( state ) => {
+	return {
+		showAddItemDialog: state.shippingLabel.showAddItemDialog || false,
+		addedItems: state.shippingLabel.addedItems,
+		openedPackageId: state.shippingLabel.openedPackageId,
+		selected: state.shippingLabel.form.packages.selected,
+		all: state.shippingLabel.form.packages.all,
+	};
+};
+
+const mapDispatchToProps = ( dispatch ) => {
+	return bindActionCreators( { closeAddItem, setAddedItem, addItems }, dispatch );
+};
+
+export default connect( mapStateToProps, mapDispatchToProps )( AddItemDialog );

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/packages-step/item-info.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/packages-step/item-info.js
@@ -2,15 +2,19 @@
  * External dependencies
  */
 import React, { PropTypes } from 'react';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
 import { translate as __ } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
 import Button from 'components/button';
+import { openItemMove, removeItem } from '../../../state/actions';
 
-const ItemInfo = ( { item, itemIndex, openItemMove } ) => {
-	const onMoveClick = () => openItemMove( itemIndex );
+const ItemInfo = ( props ) => {
+	const { item, itemIndex } = props;
+	const onMoveClick = () => props.openItemMove( itemIndex );
 
 	const renderMoveToPackage = () => {
 		return (
@@ -44,4 +48,11 @@ ItemInfo.propTypes = {
 	openItemMove: PropTypes.func.isRequired,
 };
 
-export default ItemInfo;
+const mapDispatchToProps = ( dispatch ) => {
+	return bindActionCreators( {
+		openItemMove,
+		removeItem,
+	}, dispatch );
+};
+
+export default connect( null, mapDispatchToProps )( ItemInfo );

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/packages-step/list.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/packages-step/list.js
@@ -2,6 +2,8 @@
  * External dependencies
  */
 import React, { PropTypes } from 'react';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
 import { translate as __ } from 'i18n-calypso';
 import Gridicon from 'gridicons';
 import classNames from 'classnames';
@@ -10,8 +12,12 @@ import classNames from 'classnames';
  * Internal dependencies
  */
 import getPackageDescriptions from './get-package-descriptions';
+import getFormErrors from '../../../state/selectors/errors';
+import { openPackage } from '../../../state/actions';
 
-const PackageList = ( { selected, all, errors, packageId, openPackage } ) => {
+const PackageList = ( props ) => {
+	const { selected, all, errors, packageId } = props;
+
 	const renderCountOrError = ( isError, count ) => {
 		if ( isError ) {
 			// eslint-disable-next-line wpcalypso/jsx-classname-namespace
@@ -27,7 +33,7 @@ const PackageList = ( { selected, all, errors, packageId, openPackage } ) => {
 
 	const renderPackageListItem = ( pckgId, name, count ) => {
 		const isError = 0 < Object.keys( errors[ pckgId ] || {} ).length;
-		const onOpenClick = () => openPackage( pckgId );
+		const onOpenClick = () => props.openPackage( pckgId );
 		return (
 			<div className="packages-step__list-item" key={ pckgId }>
 				<div
@@ -78,4 +84,20 @@ PackageList.propTypes = {
 	openPackage: PropTypes.func.isRequired,
 };
 
-export default PackageList;
+const mapStateToProps = ( state ) => {
+	const loaded = state.shippingLabel.loaded;
+	const storeOptions = loaded ? state.shippingLabel.storeOptions : {};
+	const errors = loaded && getFormErrors( state, storeOptions ).packages;
+	return {
+		errors,
+		packageId: state.shippingLabel.openedPackageId,
+		selected: state.shippingLabel.form.packages.selected,
+		all: state.shippingLabel.form.packages.all,
+	};
+};
+
+const mapDispatchToProps = ( dispatch ) => {
+	return bindActionCreators( { openPackage }, dispatch );
+};
+
+export default connect( mapStateToProps, mapDispatchToProps )( PackageList );

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/packages-step/move-item.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/packages-step/move-item.js
@@ -2,6 +2,8 @@
  * External dependencies
  */
 import React, { PropTypes } from 'react';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
 import { translate as __ } from 'i18n-calypso';
 
 /**
@@ -13,23 +15,24 @@ import FormLabel from 'components/forms/form-label';
 import ActionButtons from 'components/action-buttons';
 import getPackageDescriptions from './get-package-descriptions';
 import FormSectionHeading from 'components/forms/form-section-heading';
+import { closeItemMove, setTargetPackage, moveItem } from '../../../state/actions';
 
-const MoveItemDialog = ( {
-	showItemMoveDialog,
-	movedItemIndex,
-	targetPackageId,
-	openedPackageId,
-	selected,
-	all,
-	closeItemMove,
-	setTargetPackage,
-	moveItem } ) => {
+const MoveItemDialog = ( props ) => {
+	const {
+		showItemMoveDialog,
+		movedItemIndex,
+		targetPackageId,
+		openedPackageId,
+		selected,
+		all,
+	} = props;
+
 	if ( -1 === movedItemIndex || ! showItemMoveDialog ) {
 		return null;
 	}
 
 	const renderRadioButton = ( pckgId, label ) => {
-		const onChange = () => setTargetPackage( pckgId );
+		const onChange = () => props.setTargetPackage( pckgId );
 		return (
 			<FormLabel
 				key={ pckgId }
@@ -93,8 +96,8 @@ const MoveItemDialog = ( {
 	return (
 		<Dialog isVisible={ showItemMoveDialog }
 				isFullScreen={ false }
-				onClickOutside={ closeItemMove }
-				onClose={ closeItemMove }
+				onClickOutside={ props.closeItemMove }
+				onClose={ props.closeItemMove }
 				additionalClassNames="wcc-root packages-step__dialog" >
 			<FormSectionHeading>{ __( 'Move item' ) }</FormSectionHeading>
 			<div className="packages-step__dialog-body">
@@ -109,9 +112,9 @@ const MoveItemDialog = ( {
 					label: __( 'Move' ),
 					isPrimary: true,
 					isDisabled: targetPackageId === openedPackageId,  // Result of targetPackageId initialization
-					onClick: () => moveItem( openedPackageId, movedItemIndex, targetPackageId ),
+					onClick: () => props.moveItem( openedPackageId, movedItemIndex, targetPackageId ),
 				},
-				{ label: __( 'Cancel' ), onClick: closeItemMove },
+				{ label: __( 'Cancel' ), onClick: props.closeItemMove },
 			] } />
 		</Dialog>
 	);
@@ -127,4 +130,19 @@ MoveItemDialog.propTypes = {
 	moveItem: PropTypes.func.isRequired,
 };
 
-export default MoveItemDialog;
+const mapStateToProps = ( state ) => {
+	return {
+		showItemMoveDialog: state.shippingLabel.showItemMoveDialog || false,
+		movedItemIndex: isNaN( state.shippingLabel.movedItemIndex ) ? -1 : state.shippingLabel.movedItemIndex,
+		targetPackageId: state.shippingLabel.targetPackageId,
+		openedPackageId: state.shippingLabel.openedPackageId,
+		selected: state.shippingLabel.form.packages.selected,
+		all: state.shippingLabel.form.packages.all,
+	};
+};
+
+const mapDispatchToProps = ( dispatch ) => {
+	return bindActionCreators( { closeItemMove, setTargetPackage, moveItem }, dispatch );
+};
+
+export default connect( mapStateToProps, mapDispatchToProps )( MoveItemDialog );

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/packages-step/package-info.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/packages-step/package-info.js
@@ -2,6 +2,8 @@
  * External dependencies
  */
 import React, { PropTypes } from 'react';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
 import { translate as __ } from 'i18n-calypso';
 import _ from 'lodash';
 
@@ -14,6 +16,13 @@ import FormLegend from 'components/forms/form-legend';
 import FormSelect from 'components/forms/form-select';
 import Button from 'components/button';
 import getBoxDimensions from 'lib/utils/get-box-dimensions';
+import getFormErrors from '../../../state/selectors/errors';
+import {
+	updateWeight,
+	removePackage,
+	setPackageType,
+	openAddItem,
+} from '../../../state/actions';
 
 const renderPackageDimensions = ( dimensions, dimensionUnit ) => {
 	return `${ dimensions.length } ${ dimensionUnit } x 
@@ -21,7 +30,8 @@ const renderPackageDimensions = ( dimensions, dimensionUnit ) => {
 			${ dimensions.height } ${ dimensionUnit }`;
 };
 
-const PackageInfo = ( {
+const PackageInfo = ( props ) => {
+	const {
 		packageId,
 		selected,
 		all,
@@ -29,12 +39,8 @@ const PackageInfo = ( {
 		dimensionUnit,
 		weightUnit,
 		errors,
-		updateWeight,
-		openItemMove,
-		removeItem,
-		setPackageType,
-		openAddItem,
-	} ) => {
+	} = props;
+
 	const pckgErrors = errors[ packageId ] || {};
 	if ( ! packageId ) {
 		return null;
@@ -50,8 +56,6 @@ const PackageInfo = ( {
 					itemIndex={ itemIndex }
 					packageId={ packageId }
 					showRemove
-					openItemMove={ openItemMove }
-					removeItem={ removeItem }
 					isIndividualPackage={ isIndividualPackage } />
 		);
 	};
@@ -66,11 +70,11 @@ const PackageInfo = ( {
 			return null;
 		}
 
-		return ( <Button className="packages-step__add-item-btn" compact onClick={ openAddItem }>{ __( 'Add items' ) }</Button> );
+		return ( <Button className="packages-step__add-item-btn" compact onClick={ props.openAddItem }>{ __( 'Add items' ) }</Button> );
 	};
 
 	const packageOptionChange = ( e ) => {
-		setPackageType( packageId, e.target.value );
+		props.setPackageType( packageId, e.target.value );
 	};
 
 	const renderItems = () => {
@@ -141,7 +145,7 @@ const PackageInfo = ( {
 		);
 	};
 
-	const onWeightChange = ( value ) => updateWeight( packageId, value );
+	const onWeightChange = ( value ) => props.updateWeight( packageId, value );
 
 	return (
 		<div className="packages-step__package">
@@ -177,10 +181,32 @@ PackageInfo.propTypes = {
 	dimensionUnit: PropTypes.string.isRequired,
 	weightUnit: PropTypes.string.isRequired,
 	errors: PropTypes.object.isRequired,
-	openItemMove: PropTypes.func.isRequired,
-	removeItem: PropTypes.func.isRequired,
 	setPackageType: PropTypes.func.isRequired,
 	openAddItem: PropTypes.func.isRequired,
 };
 
-export default PackageInfo;
+const mapStateToProps = ( state ) => {
+	const loaded = state.shippingLabel.loaded;
+	const storeOptions = loaded ? state.shippingLabel.storeOptions : {};
+	const errors = loaded && getFormErrors( state, storeOptions ).packages;
+	return {
+		errors,
+		packageId: state.shippingLabel.openedPackageId,
+		selected: state.shippingLabel.form.packages.selected,
+		all: state.shippingLabel.form.packages.all,
+		flatRateGroups: state.shippingLabel.form.packages.flatRateGroups,
+		dimensionUnit: storeOptions.dimension_unit,
+		weightUnit: storeOptions.weight_unit,
+	};
+};
+
+const mapDispatchToProps = ( dispatch ) => {
+	return bindActionCreators( {
+		updateWeight,
+		removePackage,
+		setPackageType,
+		openAddItem,
+	}, dispatch );
+};
+
+export default connect( mapStateToProps, mapDispatchToProps )( PackageInfo );

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/packages-step/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/packages-step/style.scss
@@ -25,7 +25,7 @@
 	}
 }
 
-.packages-step {
+.packages-step__contents {
 	display: flex;
 	padding-bottom: 24px;
 }

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/sidebar.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/sidebar.js
@@ -2,6 +2,8 @@
  * External dependencies
  */
 import React, { PropTypes } from 'react';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
 import { translate as __ } from 'i18n-calypso';
 
 /**
@@ -9,8 +11,11 @@ import { translate as __ } from 'i18n-calypso';
  */
 import { getPaperSizes } from 'lib/pdf-label-utils';
 import Dropdown from 'components/dropdown';
+import getFormErrors from '../../state/selectors/errors';
+import { updatePaperSize } from '../../state/actions';
 
-const Sidebar = ( { form, errors, labelActions, paperSize } ) => {
+const Sidebar = ( props ) => {
+	const { form, errors, paperSize } = props;
 	return (
 		<div className="label-purchase-modal__sidebar">
 			<Dropdown
@@ -18,7 +23,7 @@ const Sidebar = ( { form, errors, labelActions, paperSize } ) => {
 				valuesMap={ getPaperSizes( form.origin.values.country ) }
 				title={ __( 'Paper size' ) }
 				value={ paperSize }
-				updateValue={ labelActions.updatePaperSize }
+				updateValue={ props.updatePaperSize }
 				error={ errors.paperSize } />
 		</div>
 	);
@@ -28,7 +33,21 @@ Sidebar.propTypes = {
 	paperSize: PropTypes.string.isRequired,
 	errors: PropTypes.object.isRequired,
 	form: PropTypes.object.isRequired,
-	labelActions: PropTypes.object.isRequired,
+	updatePaperSize: PropTypes.func.isRequired,
 };
 
-export default Sidebar;
+const mapStateToProps = ( state ) => {
+	const loaded = state.shippingLabel.loaded;
+	const storeOptions = loaded ? state.shippingLabel.storeOptions : {};
+	return {
+		paperSize: state.shippingLabel.paperSize,
+		form: state.shippingLabel.form,
+		errors: loaded && getFormErrors( state, storeOptions ).sidebar,
+	};
+};
+
+const mapDispatchToProps = ( dispatch ) => {
+	return bindActionCreators( { updatePaperSize }, dispatch );
+};
+
+export default connect( mapStateToProps, mapDispatchToProps )( Sidebar );

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-refund-modal.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-refund-modal.js
@@ -2,6 +2,8 @@
  * External dependencies
  */
 import React, { PropTypes } from 'react';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
 import { translate as __ } from 'i18n-calypso';
 
 /**
@@ -11,8 +13,11 @@ import Modal from 'components/modal';
 import ActionButtons from 'components/action-buttons';
 import formatDate from 'lib/utils/format-date';
 import FormSectionHeading from 'components/forms/form-section-heading';
+import { closeRefundDialog, confirmRefund } from '../../state/actions';
 
-const RefundDialog = ( { refundDialog, labelActions, storeOptions, created, refundable_amount, label_id } ) => {
+const RefundDialog = ( props ) => {
+	const { refundDialog, storeOptions, created, refundable_amount, label_id } = props;
+
 	const getRefundableAmount = () => {
 		return storeOptions.currency_symbol + Number( refundable_amount ).toFixed( 2 );
 	};
@@ -20,7 +25,7 @@ const RefundDialog = ( { refundDialog, labelActions, storeOptions, created, refu
 	return (
 		<Modal
 			isVisible={ Boolean( refundDialog && refundDialog.labelId === label_id ) }
-			onClose={ labelActions.closeRefundDialog }
+			onClose={ props.closeRefundDialog }
 			additionalClassNames="label-refund-modal">
 			<FormSectionHeading>
 				{ __( 'Request a refund' ) }
@@ -39,13 +44,13 @@ const RefundDialog = ( { refundDialog, labelActions, storeOptions, created, refu
 			</dl>
 			<ActionButtons buttons={ [
 				{
-					onClick: labelActions.confirmRefund,
+					onClick: props.confirmRefund,
 					isPrimary: true,
 					isDisabled: refundDialog && refundDialog.isSubmitting,
 					label: __( 'Refund label (-%(amount)s)', { args: { amount: getRefundableAmount() } } ),
 				},
 				{
-					onClick: labelActions.closeRefundDialog,
+					onClick: props.closeRefundDialog,
 					label: __( 'Cancel' ),
 				},
 			] } />
@@ -55,11 +60,25 @@ const RefundDialog = ( { refundDialog, labelActions, storeOptions, created, refu
 
 RefundDialog.propTypes = {
 	refundDialog: PropTypes.object,
-	labelActions: PropTypes.object.isRequired,
 	storeOptions: PropTypes.object.isRequired,
 	created: PropTypes.number,
 	refundable_amount: PropTypes.number,
 	label_id: PropTypes.number,
+	closeRefundDialog: PropTypes.func.isRequired,
+	confirmRefund: PropTypes.func.isRequired,
 };
 
-export default RefundDialog;
+const mapStateToProps = ( state ) => {
+	const shippingLabel = state.shippingLabel;
+	const loaded = shippingLabel.loaded;
+	return {
+		refundDialog: loaded ? shippingLabel.refundDialog : {},
+		storeOptions: loaded ? shippingLabel.storeOptions : {},
+	};
+};
+
+const mapDispatchToProps = ( dispatch ) => {
+	return bindActionCreators( { closeRefundDialog, confirmRefund }, dispatch );
+};
+
+export default connect( mapStateToProps, mapDispatchToProps )( RefundDialog );

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/style.scss
@@ -1,5 +1,4 @@
 @import './label-purchase-modal/style';
-
 .shipping-label__container {
 	margin-bottom: 0;
 	text-align: center;
@@ -9,11 +8,11 @@
 		margin-top: 8px;
 	}
 
-	.shipping-label__item {
+	.shipping-label__item, .label-item {
 		padding: 16px;
 		border-bottom: 1px solid #eee;
 
-		.shipping-label__item-created {
+		.label-item__created {
 			color: $gray;
 			font-size: 12px;
 		}
@@ -26,7 +25,7 @@
 			margin-bottom: 3px;
 			text-align: left;
 
-			&.shipping-label__item-tracking {
+			&.label-item__tracking {
 				margin-bottom: 16px;
 				font-size: 12px;
 
@@ -36,7 +35,7 @@
 				}
 			}
 
-			& .shipping-label__item-detail {
+			& .label-item__detail {
 				font-weight: bold;
 				font-size: 14px;
 				color: $gray-dark;
@@ -52,7 +51,7 @@
 			margin-top: 16px;
 		}
 
-		.shipping-label__item-actions {
+		.label-item__actions {
 			display: flex;
 			justify-content: space-between;
 			font-size: 12px;
@@ -89,6 +88,14 @@
 			.is-refund-rejected {
 				color: $alert-red;
 			}
+		}
+
+		.shipping-label__purchase-error {
+			color: $alert-red;
+			cursor: help;
+			text-decoration: underline;
+			text-decoration-color: $alert-red;
+			text-decoration-style: dotted;
 		}
 	}
 }


### PR DESCRIPTION
Copied changes from https://github.com/Automattic/woocommerce-services/pull/1144, that separates individual label list item into its own connected component, and connects other subcomponents in the shipping label code.