### PR TITLE
Stats: Fix moment.isValid check

### DIFF
--- a/client/my-sites/stats/controller.jsx
+++ b/client/my-sites/stats/controller.jsx
@@ -189,7 +189,7 @@ module.exports = {
 
 			const gmtOffset = getSiteOption( context.store.getState(), siteId, 'gmt_offset' );
 			const momentSiteZone = i18n.moment().utcOffset( Number.isFinite( gmtOffset ) ? gmtOffset : 0 );
-			if ( queryOptions.startDate && i18n.moment( queryOptions.startDate ).isValid ) {
+			if ( queryOptions.startDate && i18n.moment( queryOptions.startDate ).isValid() ) {
 				date = i18n.moment( queryOptions.startDate ).locale( 'en' );
 				numPeriodAgo = getNumPeriodAgo( momentSiteZone, date, activeFilter.period );
 			} else {
@@ -269,7 +269,7 @@ module.exports = {
 			if ( Number.isFinite( gmtOffset ) ) {
 				momentSiteZone = i18n.moment().utcOffset( gmtOffset );
 			}
-			if ( queryOptions.startDate && i18n.moment( queryOptions.startDate ).isValid ) {
+			if ( queryOptions.startDate && i18n.moment( queryOptions.startDate ).isValid() ) {
 				date = i18n.moment( queryOptions.startDate );
 			} else {
 				date = momentSiteZone.endOf( activeFilter.period );


### PR DESCRIPTION
The stats controller attempts to validate datestrings in a few places, but the validation is buggy as it checks the presence of the moment method `moment.isValid` rather than calling the method to test the validity `moment.isValid()`.

To see the failing test, visit this link to se `Stats for Invalid date`: `/stats/day/$SOME_SITE?startDate=this-isnt-a-valid-date`

## Testing
1. Visit `https://calypso.live/stats/day/$SOME_SITE?startDate=this-isnt-a-valid-date&branch=fix/stats/invalid-date`
1. Verify that the validation works and you just see the current period.

There's usage in the `summary` controller as well, which I've fixed here, but I'm not familiar with the stats route that uses summary. That would also be good to test.

## Context

Found this in code while working on #17319 