### PR TITLE
Store: Re-word description for shipping label payment settings to emphasize purpose

### DIFF
--- a/client/extensions/woocommerce/woocommerce-services/views/label-settings/label-settings.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/label-settings/label-settings.js
@@ -88,10 +88,10 @@ class ShippingLabels extends Component {
 
 		let description, buttonLabel;
 		if ( paymentMethods.length ) {
-			description = translate( 'Use your credit card on file to pay for the labels you print or add a new one.' );
+			description = translate( 'To purchase shipping labels, use your credit card on file or add a new one.' );
 			buttonLabel = translate( 'Add another credit card' );
 		} else {
-			description = translate( 'To pay for the shipping labels you print, add a credit card.' );
+			description = translate( 'To purchase shipping labels, add a credit card.' );
 			buttonLabel = translate( 'Add a credit card' );
 		}
 

--- a/client/extensions/woocommerce/woocommerce-services/views/label-settings/label-settings.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/label-settings/label-settings.js
@@ -88,7 +88,7 @@ class ShippingLabels extends Component {
 
 		let description, buttonLabel;
 		if ( paymentMethods.length ) {
-			description = translate( 'To purchase shipping labels, use your credit card on file or add a new one.' );
+			description = translate( 'To purchase shipping labels, choose a credit card you have on file or add a new card.' );
 			buttonLabel = translate( 'Add another credit card' );
 		} else {
 			description = translate( 'To purchase shipping labels, add a credit card.' );


### PR DESCRIPTION
Brings label settings copy into line with https://github.com/Automattic/woocommerce-services/pull/1141. Can put the mention of printing back if it was valuable.

<img width="751" src="https://user-images.githubusercontent.com/1867547/30034186-a7f138e6-916d-11e7-8372-e0077c3d7bef.png">
