### PR TITLE
Store Sidebar: Only conditionally display the sidebar items when on the dashboard

### DIFF
--- a/client/extensions/woocommerce/store-sidebar/index.js
+++ b/client/extensions/woocommerce/store-sidebar/index.js
@@ -203,9 +203,17 @@ class StoreSidebar extends Component {
 	}
 
 	render = () => {
-		const { finishedAddressSetup, hasProducts, site } = this.props;
+		const {
+			finishedAddressSetup,
+			hasProducts,
+			path,
+			site,
+			siteSuffix,
+		} = this.props;
 
-		const showAllSidebarItems = finishedAddressSetup || hasProducts;
+		// Show all items if: we're not on the dashboard, we have finished setup, or we have products.
+		const notOnDashboard = 0 !== path.indexOf( '/store' + siteSuffix );
+		const showAllSidebarItems = notOnDashboard || finishedAddressSetup || hasProducts;
 
 		return (
 			<Sidebar className="store-sidebar__sidebar">


### PR DESCRIPTION
Fixes #16858 – The sidebar items are conditionally displayed based on whether you've entered an address (or have products), but this means they might be delayed in showing up while these API checks run. This PR changes the logic around showing the sidebar items so that it only affects the dashboard.

**To test:**

- Set the `set_store_address_during_initial_setup` to 0 in [the dev console](https://developer.wordpress.com/docs/api/console/)
- View your store dashboard `/store/:site` – it should show a loading indicator, then Dashboard, then (if this site has products) load the rest of the sidebar items. If you don't have products, no other items should load.
- Clear your cache, and load your orders page `/store/orders/:site` – it should show a loading indicator, then all the items should show up at once (regardless of whether you have products).

