### PR TITLE
Simplify and improve conditions for force sympathy

### DIFF
--- a/client/state/initial-state.js
+++ b/client/state/initial-state.js
@@ -60,18 +60,22 @@ function deserialize( state ) {
  * @returns {bool} Whether to clear persistent state on page load
  */
 function shouldAddSympathy() {
+	// If `force-sympathy` flag is enabled, always clear persistent state.
 	if ( config.isEnabled( 'force-sympathy' ) ) {
 		return true;
 	}
 
+	// If `no-force-sympathy` flag is enabled, never clear persistent state.
 	if ( config.isEnabled( 'no-force-sympathy' ) ) {
 		return false;
 	}
 
+	// Otherwise, in development mode, clear persistent state 25% of the time.
 	if ( 'development' === process.env.NODE_ENV && Math.random() < 0.25 ) {
 		return true;
 	}
 
+	// Otherwise, do not clear persistent state.
 	return false;
 }
 


### PR DESCRIPTION
The [conditions for "force sympathy"](https://github.com/Automattic/wp-calypso/blob/5da1e109282ac25482b319b9ccc7dbef249644da/client/state/initial-state.js#L50) are a bit difficult to read, and there is a line in there indented with spaces :scream: 

Also, today I wanted to clear my local storage on the staging environment.  As of https://github.com/Automattic/wp-calypso/pull/17721 this should be easily possible with `?flags=force-sympathy`, but we also need to change the conditions to make this flag take precedence if it is set.

So this PR cleans that code up a bit and adds the ability to always override the sympathy handler via config flags.