### PR TITLE
Simplify design of PostShare component

### DIFF
--- a/client/blocks/post-share/connection.jsx
+++ b/client/blocks/post-share/connection.jsx
@@ -32,13 +32,17 @@ const PostShareConnection = ( {
 		'is-broken': status === 'broken'
 	} );
 
-	const backgroundImage = `url(${ cssSafeUrl( external_profile_picture ) })`;
+	const accountImageStyle = {};
+	if ( external_profile_picture ) {
+		accountImageStyle.backgroundImage =
+			'url( ' + cssSafeUrl( external_profile_picture ) + ' )';
+	}
 
 	return (
 		<div onClick={ toggle } className={ classes }>
 			<div
-				style={ { backgroundImage } }
 				className="post-share__service-account-image"
+				style={ accountImageStyle }
 			>
 				&nbsp;
 			</div>

--- a/client/blocks/post-share/connection.jsx
+++ b/client/blocks/post-share/connection.jsx
@@ -36,6 +36,9 @@ const PostShareConnection = ( {
 	if ( external_profile_picture ) {
 		accountImageStyle.backgroundImage =
 			'url( ' + cssSafeUrl( external_profile_picture ) + ' )';
+	} else {
+		// Display a solid color circle: lighten( $gray, 10% )
+		accountImageStyle.backgroundColor = 'rgb( 168, 190, 206 )';
 	}
 
 	return (

--- a/client/blocks/post-share/index.jsx
+++ b/client/blocks/post-share/index.jsx
@@ -555,7 +555,7 @@ class PostShare extends Component {
 		}
 
 		const classes = classNames( 'post-share__wrapper', {
-			'is-placeholder': ! this.hasFetchedConnections,
+			'is-placeholder': ! hasFetchedConnections,
 			'has-connections': this.hasConnections(),
 			'has-republicize-scheduling-feature': hasRepublicizeFeature,
 		} );

--- a/client/blocks/post-share/style.scss
+++ b/client/blocks/post-share/style.scss
@@ -11,14 +11,9 @@ $section-border: solid 1px transparentize( lighten( $gray, 20% ), .5 );
 	margin: 0;
 	position: relative;
 	background-color: $white;
-}
 
-.post-share__wrapper .notice {
-	margin-top: 4px;
-	margin-bottom: 0px;
-
-	&:first-of-type {
-		margin-top: 0px;
+	& .notice {
+		margin: 0;
 	}
 }
 

--- a/client/blocks/post-share/style.scss
+++ b/client/blocks/post-share/style.scss
@@ -42,7 +42,7 @@ $section-border: solid 1px transparentize( lighten( $gray, 20% ), .5 );
 
 .post-share__wrapper.is-placeholder {
 	padding-bottom: 24px;
-	border-bottom: 1px solid lighten( $gray, 25% );
+	border-bottom: 1px solid transparentize( lighten( $gray, 20% ), .5 );
 }
 
 .post-share__placeholder {
@@ -53,8 +53,12 @@ $section-border: solid 1px transparentize( lighten( $gray, 20% ), .5 );
 }
 
 .post-share__head {
-	padding: 0 16px 16px;
+	border-bottom: 1px solid transparentize( lighten( $gray, 20% ), .5 );
+	.post-share__wrapper.is-placeholder & {
+		border-bottom-width: 0;
+	}
 
+	padding: 0 16px 16px;
 	@include breakpoint( ">480px" ) {
 		padding: 0 24px 16px;
 	}

--- a/client/blocks/post-share/style.scss
+++ b/client/blocks/post-share/style.scss
@@ -40,18 +40,16 @@ $section-border: solid 1px transparentize( lighten( $gray, 20% ), .5 );
 	}
 }
 
-.post-share__placeholder {
-	@include placeholder;
-	margin: 0 0 24px 24px;
-	width: 300px;
-	height: 80px;
+.post-share__wrapper.is-placeholder {
+	padding-bottom: 24px;
+	border-bottom: 1px solid lighten( $gray, 25% );
 }
 
-.post-share__form.is-placeholder,
-.post-share__services.is-placeholder {
+.post-share__placeholder {
 	@include placeholder;
-	margin-top: 16px;
-	height: 48px;
+	margin: 0 0 0 24px;
+	width: 300px;
+	height: 80px;
 }
 
 .post-share__head {

--- a/client/blocks/post-share/style.scss
+++ b/client/blocks/post-share/style.scss
@@ -10,6 +10,7 @@ $section-border: solid 1px transparentize( lighten( $gray, 20% ), .5 );
 	border-top: $section-border;
 	margin: 0;
 	position: relative;
+	background-color: $white;
 }
 
 .post-share__wrapper .notice {

--- a/client/blocks/post-share/style.scss
+++ b/client/blocks/post-share/style.scss
@@ -206,8 +206,6 @@ $section-border: solid 1px transparentize( lighten( $gray, 20% ), .5 );
 	position: relative;
 	flex: 0 0 32px;
 	opacity: 0.3;
-	// Specify a color for accounts with no valid image
-	background-color: lighten( $gray, 10% );
 }
 
 .post-share__service.is-active .post-share__service-account-image {

--- a/client/blocks/post-share/style.scss
+++ b/client/blocks/post-share/style.scss
@@ -208,6 +208,8 @@ $section-border: solid 1px transparentize( lighten( $gray, 20% ), .5 );
 	position: relative;
 	flex: 0 0 32px;
 	opacity: 0.3;
+	// Specify a color for accounts with no valid image
+	background-color: lighten( $gray, 10% );
 }
 
 .post-share__service.is-active .post-share__service-account-image {

--- a/client/blocks/post-share/style.scss
+++ b/client/blocks/post-share/style.scss
@@ -72,7 +72,10 @@ $section-border: solid 1px transparentize( lighten( $gray, 20% ), .5 );
 
 .post-share__form {
 	flex: 3 0 0;
-	padding-bottom: 16px;
+	margin: 0 16px 16px;
+	@include breakpoint( ">480px" ) {
+		margin: 0 24px 16px;
+	}
 
 	.post-share__share-button {
 		margin-left: 8px;
@@ -83,39 +86,21 @@ $section-border: solid 1px transparentize( lighten( $gray, 20% ), .5 );
 		padding-left: 8px;
 	}
 
-	@include breakpoint( ">480px" ) {
-		padding-bottom: 24px;
-	}
-
 	.editor-sharing__publicize-message {
-			margin-top: 0;
+		margin-top: 0;
 
 		.editor-sharing__message-heading {
-			box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ), 0 1px 0 0 transparentize( lighten( $gray, 20% ), .5 );
 			line-height: 28px;
 			margin-bottom: 0;
-			padding: 11.5px 16px;
-
-			@include breakpoint( ">480px" ) {
-				padding-right: 24px;
-				padding-left: 24px;
-			}
+			padding: 11.5px 0;
 		}
 
 		.editor-sharing__message-input {
-			margin: 16px 16px 8px;
-
-			@include breakpoint( ">480px" ) {
-				margin: 24px 24px 8px;
-			}
+			margin: 0;
 
 			&.form-textarea {
 				padding: 8px;
-				width: calc(100% - 32px);
-
-				@include breakpoint( ">480px" ) {
-					width: calc(100% - 48px);
-				}
+				width: 100%;
 			}
 		}
 	}
@@ -123,26 +108,24 @@ $section-border: solid 1px transparentize( lighten( $gray, 20% ), .5 );
 
 .post-share__services {
 	flex: 2 1 0;
-
+	margin: 0 16px 16px;
+	@include breakpoint( ">480px" ) {
+		margin: 0 24px 16px;
+	}
 	@include breakpoint( ">960px" ) {
-		border-left: $section-border;
+		margin: 0 24px 16px 0;
 	}
 }
 
-.post-share .post-share__services-header {
-	box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ), 0 1px 0 0 transparentize( lighten( $gray, 20% ), .5 );
+.post-share .card.post-share__services-header {
+	// Override some Card styles
+	box-shadow: none;
+	padding: 11.5px 0;
+	line-height: 28px;
 }
 
 .post-share__services .section-header__actions {
 	flex: 0 0 auto;
-}
-
-.post-share__connections {
-	padding: 16px;
-
-	@include breakpoint( ">480px" ) {
-		padding: 24px;
-	}
 }
 
 .post-share__service {
@@ -288,11 +271,6 @@ $section-border: solid 1px transparentize( lighten( $gray, 20% ), .5 );
 .post-share__button-actions {
 	display: flex;
 	justify-content: flex-end;
-	margin: 0 16px;
-
-	@include breakpoint( ">480px" ) {
-		margin: 0 24px;
-	}
 }
 
 .post-share__share-combo {


### PR DESCRIPTION
This PR is part of a larger epic.  See p8F9tW-hL-p2.

It simplifies the design of the `PostShare` component used to share a post from the posts list, and also fixes a display bug with accounts that don't have a valid profile image.

This account with a broken/disabled Facebook connection has proved useful for finding edge cases, but this PR should also be tested on an account with various Publicize connections from different services.
*[edit: [done](https://github.com/Automattic/wp-calypso/pull/17768#issuecomment-327023084)]*

### Screenshots: Normal usage

| Before | After |
|--|--|
| ![postshare-tweaks-before](https://user-images.githubusercontent.com/227022/30036551-1b47c330-917a-11e7-9daf-f417f0a40312.png) | ![postshare-tweaks-after](https://user-images.githubusercontent.com/227022/30036553-1e77e594-917a-11e7-87da-e86dd4b13059.png) |

### Screenshots: Loading placeholder

| Before | After |
|--|--|
| ![postshare-tweaks-before-placeholder](https://user-images.githubusercontent.com/227022/30036560-2678bdfe-917a-11e7-9b3b-10da4f306ba7.png) | ![postshare-tweaks-after-placeholder](https://user-images.githubusercontent.com/227022/30036564-2ba1878e-917a-11e7-922c-6985e26acf55.png) |

### To test

Load Calypso using both the current posts list and the `PostTypeList` posts list:

- https://calypso.live/?branch=update/post-type-list-sharing-tweaks&flags=-posts/post-type-list
- https://calypso.live/?branch=update/post-type-list-sharing-tweaks&flags=+posts/post-type-list

Test sharing a post by clicking the `Share` item (either a button or an ellipsis menu item, depending on the posts list configuration).

Make sure the component looks good at all screen widths.

Make sure sharing a post still works as before.