### PR TITLE
HeaderButton: adjust padding and borders

### DIFF
--- a/client/components/header-button/style.scss
+++ b/client/components/header-button/style.scss
@@ -1,6 +1,6 @@
 .header-button {
 	align-items: center;
-	border: 1px solid transparentize( lighten( $gray, 20% ), .5 );
+	border: 1px solid transparentize( lighten( $gray, 20% ), 0.5 );
 	border-width: 0 1px 0 0;
 	border-radius: 0;
 	display: flex;
@@ -9,22 +9,21 @@
 	justify-content: center;
 	min-height: 46px;
 	width: 50%;
-	padding: 0;
+	padding: 0 16px;
 
-	@include breakpoint( ">480px" ) {
-		min-height: 51px;
-	}
-
-	@include breakpoint( ">660px" ) {
-		width: 10em;
+	@include breakpoint( '>480px' ) {
+		border: 0;
+		flex: 0 0 auto;
+		min-width: 140px;
+		width: auto;
 	}
 
 	&:hover {
-		border-color: transparentize( lighten( $gray, 20% ), .5 );
+		border-color: transparentize( lighten( $gray, 20% ), 0.5 );
 	}
 
-	.gridicon {
-		margin-top: -5px;
+	&:active {
+		border-width: 0 1px 0 0;
 	}
 }
 


### PR DESCRIPTION
Originally this was supposed to be part of https://github.com/Automattic/wp-calypso/pull/17702

Before: 

<img width="202" alt="screen shot 2017-09-04 at 3 42 26 pm" src="https://user-images.githubusercontent.com/2036909/30037321-ca696a8c-9187-11e7-808b-a4c5508362c6.png">

<img width="103" alt="screen shot 2017-09-04 at 3 48 58 pm" src="https://user-images.githubusercontent.com/2036909/30037429-a9b2f604-9188-11e7-8532-56574d58fa9c.png">

<img width="274" alt="screen shot 2017-09-04 at 3 43 10 pm" src="https://user-images.githubusercontent.com/2036909/30037323-ccfb5a08-9187-11e7-8fb2-69c90df47fdc.png">

After:

<img width="224" alt="screen shot 2017-09-04 at 3 44 57 pm" src="https://user-images.githubusercontent.com/2036909/30037359-0e0790de-9188-11e7-912a-b82a79559468.png">

<img width="108" alt="screen shot 2017-09-04 at 3 49 46 pm" src="https://user-images.githubusercontent.com/2036909/30037435-b21ed1e6-9188-11e7-8e4d-cde38397ffe3.png">

<img width="201" alt="screen shot 2017-09-04 at 3 45 06 pm" src="https://user-images.githubusercontent.com/2036909/30037360-10788bde-9188-11e7-9e37-3a0a11b3be34.png">

props @iamtakashi

## Testing

Visit http://calypso.localhost:3000/plugins/ and adjust the width of the window. Verify that the button padding does not shrink too much at around 730px (see smaller, second screenshots above).