### PR TITLE
Store: Add a “New Order” page behind a separate feature flag

### DIFF
--- a/client/extensions/woocommerce/app/order/order-create/index.js
+++ b/client/extensions/woocommerce/app/order/order-create/index.js
@@ -1,0 +1,47 @@
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import ActionHeader from 'woocommerce/components/action-header';
+import Button from 'components/button';
+import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
+import { getLink } from 'woocommerce/lib/nav-utils';
+import Main from 'components/main';
+
+class OrderCreate extends Component {
+
+	render() {
+		const { className, site, translate } = this.props;
+		const breadcrumbs = [
+			( <a href={ getLink( '/store/orders/:site/', site ) }>{ translate( 'Orders' ) }</a> ),
+			( <span>{ translate( 'New Order' ) }</span> ),
+		];
+		return (
+			<Main className={ className }>
+				<ActionHeader breadcrumbs={ breadcrumbs }>
+					<Button primary>{ translate( 'Save Order' ) }</Button>
+				</ActionHeader>
+
+				<div className="order-create__container"></div>
+			</Main>
+		);
+	}
+}
+
+export default connect(
+	state => {
+		const site = getSelectedSiteWithFallback( state );
+		const siteId = site ? site.ID : false;
+
+		return {
+			site,
+			siteId,
+		};
+	}
+)( localize( OrderCreate ) );

--- a/client/extensions/woocommerce/app/order/style.scss
+++ b/client/extensions/woocommerce/app/order/style.scss
@@ -1,4 +1,5 @@
-.order__container {
+.order__container,
+.order-create__container {
 	padding-bottom: 0;
 
 	@include breakpoint( ">660px" ) {

--- a/client/extensions/woocommerce/app/orders/index.js
+++ b/client/extensions/woocommerce/app/orders/index.js
@@ -1,23 +1,44 @@
 /**
  * External dependencies
  */
-import { localize } from 'i18n-calypso';
 import React from 'react';
+import config from 'config';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
 import ActionHeader from 'woocommerce/components/action-header';
+import Button from 'components/button';
+import { getLink } from 'woocommerce/lib/nav-utils';
+import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
 import Main from 'components/main';
 import OrdersList from './orders-list';
 
-function Orders( { className, params, translate } ) {
+function Orders( { className, params, site, translate } ) {
+	let addButton = null;
+
+	if ( config.isEnabled( 'woocommerce/extension-orders-create' ) ) {
+		addButton = (
+			<Button primary href={ getLink( '/store/order/:site/', site ) }>
+				{ translate( 'New Order' ) }
+			</Button>
+		);
+	}
+
 	return (
 		<Main className={ className }>
-			<ActionHeader breadcrumbs={ ( <span>{ translate( 'Orders' ) }</span> ) } />
+			<ActionHeader breadcrumbs={ ( <span>{ translate( 'Orders' ) }</span> ) }>
+				{ addButton }
+			</ActionHeader>
 			<OrdersList currentStatus={ params && params.filter } />
 		</Main>
 	);
 }
 
-export default localize( Orders );
+export default connect(
+	state => ( {
+		site: getSelectedSiteWithFallback( state ),
+	} )
+)( localize( Orders ) );

--- a/client/extensions/woocommerce/index.js
+++ b/client/extensions/woocommerce/index.js
@@ -18,6 +18,7 @@ import { navigation, siteSelection } from 'my-sites/controller';
 import { renderWithReduxStore } from 'lib/react-helpers';
 import installActionHandlers from './state/data-layer';
 import Order from './app/order';
+import OrderCreate from './app/order/order-create';
 import Orders from './app/orders';
 import Products from './app/products';
 import ProductCreate from './app/products/product-create';
@@ -79,6 +80,12 @@ const getStorePages = () => {
 			configKey: 'woocommerce/extension-orders',
 			documentTitle: translate( 'Order Details' ),
 			path: '/store/order/:site/:order',
+		},
+		{
+			container: OrderCreate,
+			configKey: 'woocommerce/extension-orders-create',
+			documentTitle: translate( 'New Order' ),
+			path: '/store/order/:site/',
 		},
 		{
 			container: Promotions,

--- a/config/development.json
+++ b/config/development.json
@@ -167,6 +167,7 @@
 		"webpack/persistent-caching": false,
 		"woocommerce/extension-dashboard": true,
 		"woocommerce/extension-orders": true,
+		"woocommerce/extension-orders-create": true,
 		"woocommerce/extension-products": true,
 		"woocommerce/extension-promotions": true,
 		"woocommerce/extension-reviews": true,

--- a/config/production.json
+++ b/config/production.json
@@ -109,6 +109,7 @@
 		"upgrades/presale-chat": true,
 		"woocommerce/extension-dashboard": true,
 		"woocommerce/extension-orders": true,
+		"woocommerce/extension-orders-create": false,
 		"woocommerce/extension-products": true,
 		"woocommerce/extension-promotions": false,
 		"woocommerce/extension-reviews": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -117,6 +117,7 @@
 		"upgrades/presale-chat": true,
 		"woocommerce/extension-dashboard": true,
 		"woocommerce/extension-orders": true,
+		"woocommerce/extension-orders-create": false,
 		"woocommerce/extension-products": true,
 		"woocommerce/extension-promotions": false,
 		"woocommerce/extension-reviews": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -130,6 +130,7 @@
 		"upgrades/presale-chat": true,
 		"woocommerce/extension-dashboard": true,
 		"woocommerce/extension-orders": true,
+		"woocommerce/extension-orders-create": true,
 		"woocommerce/extension-products": true,
 		"woocommerce/extension-promotions": false,
 		"woocommerce/extension-reviews": false,


### PR DESCRIPTION
Getting started on creating a new order 🙂 This PR just adds a blank page at the "create order" path, hidden behind a new feature flag.

**To test**

- View `/store/orders/:site`
- There should be a "New Order" button in the top bar opposite the breadcrumbs
- Clicking this takes you to `/store/order/:site` which is currently empty
- Additionally you can verify that you can visit `/store/order/:site` directly

This does enable the flag for wpcalypso - I find it useful for testing in general, but since nothing's really here yet I can disable it before merge if there's a strong opinion.