### PR TITLE
Comments: Remove unused `notices` prop in CommentList.

### DIFF
--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -19,7 +19,6 @@ import {
 	unlikeComment,
 } from 'state/comments/actions';
 import { removeNotice, successNotice } from 'state/notices/actions';
-import { getNotices } from 'state/notices/selectors';
 import CommentDetail from 'blocks/comment-detail';
 import CommentDetailPlaceholder from 'blocks/comment-detail/comment-detail-placeholder';
 import CommentNavigation from '../comment-navigation';
@@ -451,7 +450,6 @@ const mapStateToProps = ( state, { siteId, status } ) => {
 		comments,
 		isJetpack: isJetpackSite( state, siteId ),
 		isLoading,
-		notices: getNotices( state ),
 		siteId,
 	};
 };


### PR DESCRIPTION
Remove unused `notices` prop in CommentList. It looks like all notice handling is now done through the `removeNotice` and `successNotice` actions.

**Testing**
 - Apply this PR.
 - Go to https://calypso.localhost:3000/comments/ and select a site.
 - Perform an action that produces a notice (eg. trash or spam a comment).
 - Check that it worked, with no errors.