### PR TITLE
Store: Add reducers for reviews list

### DIFF
--- a/client/extensions/woocommerce/state/sites/reducer.js
+++ b/client/extensions/woocommerce/state/sites/reducer.js
@@ -10,6 +10,7 @@ import paymentMethods from './payment-methods/reducer';
 import productCategories from './product-categories/reducer';
 import products from './products/reducer';
 import productVariations from './product-variations/reducer';
+import reviews from './reviews/reducer';
 import setupChoices from './setup-choices/reducer';
 import shippingMethods from './shipping-methods/reducer';
 import shippingZoneLocations from './shipping-zone-locations/reducer';
@@ -27,6 +28,7 @@ const reducer = combineReducers( {
 	productCategories,
 	products,
 	productVariations,
+	reviews,
 	setupChoices,
 	settings,
 	shippingMethods,

--- a/client/extensions/woocommerce/state/sites/reviews/README.md
+++ b/client/extensions/woocommerce/state/sites/reviews/README.md
@@ -33,7 +33,7 @@ This is saved on a per-site basis. All reviews are collected in `items`, and the
 				"rating": 5,
 				...
 			},
-			2: { … }
+			2: { ... }
 		},
 		// Keyed by serialized query (a list of review IDs)
 		"queries": {

--- a/client/extensions/woocommerce/state/sites/reviews/README.md
+++ b/client/extensions/woocommerce/state/sites/reviews/README.md
@@ -8,3 +8,43 @@ This module is used to manage reviews for a site.
 ### `fetchReviews( siteId: number, query: object )`
 
 Pull a set of reviews from the remote site, based on a query. See https://github.com/woocommerce/wc-api-dev/pull/48.
+
+## Reducer
+
+This is saved on a per-site basis. All reviews are collected in `items`, and there is a query => ID mapping in `queries`. `isQueryLoading` indicates which queries are being requested. `total` tracks the number of reviews, mapped by queries (not including page). `isQueryError` tracks whether a specific query returned an error while being fetched. The review items example below is not a complete list. See the [API documentation for reviews](https://woocommerce.github.io/woocommerce-rest-api-docs/#product-review-properties).
+
+```js
+{
+	"reviews": {
+		// Keyed by serialized query
+		"isQueryLoading": {
+			'{}': false,
+			'{"page":2}': true
+		},
+		"isQueryError": {
+			'{"page":3}': true
+		},
+		// Keyed by review ID
+		"items": {
+			1: {
+				"id": 1,
+				"product_id": 549,
+				"review": "Test",
+				"rating": 5,
+				...
+			},
+			2: { … }
+		},
+		// Keyed by serialized query (a list of review IDs)
+		"queries": {
+			'{}': [ 1, 2, 3, 4, 5 ],
+			'{"page":2}': [ 6, 7, 8, 9, 10 ]
+		},
+		// Keyed by serialized query, without page.
+		"total": {
+			'{"status":"any"}': 50,
+			'{"status":"processing"}': 8,
+		}
+	}
+}
+```

--- a/client/extensions/woocommerce/state/sites/reviews/reducer.js
+++ b/client/extensions/woocommerce/state/sites/reviews/reducer.js
@@ -1,0 +1,108 @@
+/**
+ * External dependencies
+ */
+import { keyBy, omit } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { combineReducers } from 'state/utils';
+import { getSerializedReviewsQuery } from './utils';
+import {
+	WOOCOMMERCE_REVIEWS_RECEIVE,
+	WOOCOMMERCE_REVIEWS_REQUEST,
+} from 'woocommerce/state/action-types';
+
+/**
+ * Returns if a reviews request for a specific query is in progress or not.
+ *
+ * @param  {Object} state  Current state
+ * @param  {Object} action Action payload
+ * @return {Object}        Updated state
+ */
+export function isQueryLoading( state = {}, action ) {
+	switch ( action.type ) {
+		case WOOCOMMERCE_REVIEWS_REQUEST:
+		case WOOCOMMERCE_REVIEWS_RECEIVE:
+			const query = getSerializedReviewsQuery( action.query );
+			return Object.assign( {}, state, { [ query ]: WOOCOMMERCE_REVIEWS_REQUEST === action.type } );
+		default:
+			return state;
+	}
+}
+
+/**
+ * Tracks all known reviews objects, indexed by ID.
+ *
+ * @param  {Object} state  Current state
+ * @param  {Object} action Action payload
+ * @return {Object}        Updated state
+ */
+export function items( state = {}, action ) {
+	if ( action.error ) {
+		return state;
+	}
+
+	if ( WOOCOMMERCE_REVIEWS_RECEIVE === action.type && action.reviews ) {
+		const reviews = keyBy( action.reviews, 'id' );
+		return Object.assign( {}, state, reviews );
+	}
+
+	return state;
+}
+
+/**
+ * Returns if a reviews request for a specific query has returned an error.
+ *
+ * @param  {Object} state  Current state
+ * @param  {Object} action Action payload
+ * @return {Object}        Updated state
+ */
+export function isQueryError( state = {}, action ) {
+	if ( WOOCOMMERCE_REVIEWS_RECEIVE === action.type && action.error ) {
+		const query = getSerializedReviewsQuery( action.query );
+		return Object.assign( {}, state, { [ query ]: true } );
+	}
+
+	return state;
+}
+
+/**
+ * Tracks the reviews which belong to a query, as a list of IDs
+ * referencing items in `reviews.items`.
+ *
+ * @param  {Object} state  Current state
+ * @param  {Object} action Action payload
+ * @return {Object}        Updated state
+ */
+export function queries( state = {}, action ) {
+	if ( WOOCOMMERCE_REVIEWS_RECEIVE === action.type && action.reviews ) {
+		const idList = action.reviews.map( review => review.id );
+		const query = getSerializedReviewsQuery( action.query );
+		return Object.assign( {}, state, { [ query ]: idList } );
+	}
+	return state;
+}
+
+/**
+ * Tracks the total number of reviews for the current query.
+ *
+ * @param  {Object} state  Current state
+ * @param  {Object} action Action payload
+ * @return {Object}        Updated state
+ */
+export function total( state = 0, action ) {
+	if ( WOOCOMMERCE_REVIEWS_RECEIVE === action.type && action.reviews ) {
+		const query = getSerializedReviewsQuery( omit( action.query, 'page' ) );
+		return Object.assign( {}, state, { [ query ]: action.total } );
+	}
+	return state;
+}
+
+export default combineReducers( {
+	isQueryLoading,
+	isQueryError,
+	items,
+	queries,
+	total,
+} );

--- a/client/extensions/woocommerce/state/sites/reviews/test/reducer.js
+++ b/client/extensions/woocommerce/state/sites/reviews/test/reducer.js
@@ -1,0 +1,252 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+import deepFreeze from 'deep-freeze';
+import { keyBy } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import {
+	isQueryLoading,
+	isQueryError,
+	items,
+	queries,
+	total,
+} from '../reducer';
+import {
+	WOOCOMMERCE_REVIEWS_REQUEST,
+	WOOCOMMERCE_REVIEWS_RECEIVE,
+} from 'woocommerce/state/action-types';
+import reviews from './fixtures/reviews';
+import review from './fixtures/review';
+
+describe( 'reducer', () => {
+	describe( 'isQueryLoading', () => {
+		it( 'should have no change by default', () => {
+			const newState = isQueryLoading( undefined, {} );
+			expect( newState ).to.eql( {} );
+		} );
+
+		it( 'should store the currently loading page', () => {
+			const action = {
+				type: WOOCOMMERCE_REVIEWS_REQUEST,
+				siteId: 123,
+				query: {
+					page: 1,
+				},
+			};
+			const newState = isQueryLoading( undefined, action );
+			expect( newState ).to.eql( { '{}': true } );
+		} );
+
+		it( 'should show that request has loaded on success', () => {
+			const action = {
+				type: WOOCOMMERCE_REVIEWS_RECEIVE,
+				siteId: 123,
+				query: {
+					page: 1,
+				},
+				total: 2,
+				reviews,
+			};
+			const newState = isQueryLoading( { '{}': true }, action );
+			expect( newState ).to.eql( { '{}': false } );
+		} );
+
+		it( 'should show that request has loaded on failure', () => {
+			const action = {
+				type: WOOCOMMERCE_REVIEWS_RECEIVE,
+				siteId: 123,
+				query: {
+					page: 1,
+				},
+				error: {},
+			};
+			const newState = isQueryLoading( { '{}': true }, action );
+			expect( newState ).to.eql( { '{}': false } );
+		} );
+	} );
+	describe( 'isQueryError', () => {
+		it( 'should have no change by default', () => {
+			const newState = isQueryError( undefined, {} );
+			expect( newState ).to.eql( {} );
+		} );
+
+		it( 'should do nothing on success', () => {
+			const action = {
+				type: WOOCOMMERCE_REVIEWS_RECEIVE,
+				siteId: 123,
+				query: {
+					page: 1,
+				},
+				total: 2,
+				reviews,
+			};
+			const newState = isQueryError( undefined, action );
+			expect( newState ).to.eql( {} );
+		} );
+
+		it( 'should show that request has errored on failure', () => {
+			const action = {
+				type: WOOCOMMERCE_REVIEWS_RECEIVE,
+				siteId: 123,
+				query: {
+					page: 1,
+				},
+				error: {},
+			};
+			const newState = isQueryError( undefined, action );
+			expect( newState ).to.eql( { '{}': true } );
+		} );
+	} );
+	describe( 'items', () => {
+		it( 'should have no change by default', () => {
+			const newState = items( undefined, {} );
+			expect( newState ).to.eql( {} );
+		} );
+
+		it( 'should store the reviews in state', () => {
+			const action = {
+				type: WOOCOMMERCE_REVIEWS_RECEIVE,
+				siteId: 123,
+				query: {
+					page: 1,
+				},
+				total: 3,
+				reviews,
+			};
+			const newState = items( undefined, action );
+			const reviewsById = keyBy( reviews, 'id' );
+			expect( newState ).to.eql( reviewsById );
+		} );
+
+		it( 'should add new reviews onto the existing review list', () => {
+			const action = {
+				type: WOOCOMMERCE_REVIEWS_RECEIVE,
+				siteId: 123,
+				query: {
+					page: 2,
+				},
+				total: 3,
+				reviews: [ review ],
+			};
+			const originalState = deepFreeze( keyBy( reviews, 'id' ) );
+			const newState = items( originalState, action );
+			expect( newState ).to.eql( { ...originalState, 222: review } );
+		} );
+		it( 'should do nothing on a failure', () => {
+			const action = {
+				type: WOOCOMMERCE_REVIEWS_RECEIVE,
+				siteId: 123,
+				query: {
+					page: 1,
+				},
+				error: {},
+			};
+			const originalState = deepFreeze( keyBy( reviews, 'id' ) );
+			const newState = items( originalState, action );
+			expect( newState ).to.eql( originalState );
+		} );
+	} );
+
+	describe( 'queries', () => {
+		it( 'should have no change by default', () => {
+			const newState = queries( undefined, {} );
+			expect( newState ).to.eql( {} );
+		} );
+
+		it( 'should store the review IDs for the requested query', () => {
+			const action = {
+				type: WOOCOMMERCE_REVIEWS_RECEIVE,
+				siteId: 123,
+				query: {
+					page: 1,
+				},
+				total: 3,
+				reviews,
+			};
+			const newState = queries( undefined, action );
+			expect( newState ).to.eql( { '{}': [ 100, 105 ] } );
+		} );
+
+		it( 'should add the next page of reviews as a second list', () => {
+			const action = {
+				type: WOOCOMMERCE_REVIEWS_RECEIVE,
+				siteId: 123,
+				query: {
+					page: 2,
+				},
+				total: 3,
+				reviews: [ review ],
+			};
+			const originalState = deepFreeze( { '{}': [ 100, 105 ] } );
+			const newState = queries( originalState, action );
+			expect( newState ).to.eql( { ...originalState, '{"page":2}': [ 222 ] } );
+		} );
+
+		it( 'should do nothing on a failure', () => {
+			const action = {
+				type: WOOCOMMERCE_REVIEWS_RECEIVE,
+				siteId: 123,
+				query: {
+					page: 1,
+				},
+				error: {},
+			};
+			const originalState = deepFreeze( { '{}': [ 100, 105 ] } );
+			const newState = queries( originalState, action );
+			expect( newState ).to.eql( originalState );
+		} );
+	} );
+	describe( 'total', () => {
+		it( 'should have no change by default', () => {
+			const newState = total( undefined, {} );
+			expect( newState ).to.eql( 0 );
+		} );
+
+		it( 'should store the total number of reviews when a request loads', () => {
+			const action = {
+				type: WOOCOMMERCE_REVIEWS_RECEIVE,
+				siteId: 123,
+				query: {
+					page: 1,
+				},
+				total: 3,
+				reviews,
+			};
+			const newState = total( undefined, action );
+			expect( newState ).to.eql( { '{}': 3 } );
+		} );
+
+		it( 'should store the total number of reviews on a subsequent request load', () => {
+			const action = {
+				type: WOOCOMMERCE_REVIEWS_RECEIVE,
+				siteId: 123,
+				query: {
+					page: 2,
+				},
+				total: 3,
+				reviews: [ review ],
+			};
+			const originalState = deepFreeze( { '{}': 3 } );
+			const newState = total( originalState, action );
+			expect( newState ).to.eql( { '{}': 3 } );
+		} );
+
+		it( 'should do nothing on a failure', () => {
+			const action = {
+				type: WOOCOMMERCE_REVIEWS_RECEIVE,
+				siteId: 123,
+				query: {
+					page: 1,
+				},
+				error: {},
+			};
+			const originalState = deepFreeze( { '{}': 3 } );
+			const newState = total( originalState, action );
+			expect( newState ).to.eql( originalState );
+		} );
+	} );
+} );

--- a/client/extensions/woocommerce/state/sites/reviews/test/reducer.js
+++ b/client/extensions/woocommerce/state/sites/reviews/test/reducer.js
@@ -15,6 +15,7 @@ import {
 	queries,
 	total,
 } from '../reducer';
+import reducer from 'woocommerce/state/sites/reducer';
 import {
 	WOOCOMMERCE_REVIEWS_REQUEST,
 	WOOCOMMERCE_REVIEWS_RECEIVE,
@@ -66,6 +67,37 @@ describe( 'reducer', () => {
 			};
 			const newState = isQueryLoading( { '{}': true }, action );
 			expect( newState ).to.eql( { '{}': false } );
+		} );
+
+		it( 'should not update state for another site ID', () => {
+			const action = {
+				type: WOOCOMMERCE_REVIEWS_RECEIVE,
+				siteId: 546,
+				query: {
+					page: 1,
+				},
+				total: 2,
+				reviews,
+			};
+
+			const newState = reducer( {
+				546: {
+					reviews: {
+						isQueryLoading: {
+							'{}': true,
+						}
+					}
+				},
+				123: {
+					reviews: {
+						isQueryLoading: {
+							'{}': true,
+						}
+					}
+				}
+			}, action );
+			expect( newState[ 546 ].reviews.isQueryLoading ).to.eql( { '{}': false } );
+			expect( newState[ 123 ].reviews.isQueryLoading ).to.eql( { '{}': true } );
 		} );
 	} );
 	describe( 'isQueryError', () => {

--- a/client/extensions/woocommerce/state/sites/reviews/utils.js
+++ b/client/extensions/woocommerce/state/sites/reviews/utils.js
@@ -20,3 +20,16 @@ export const DEFAULT_QUERY = {
 export function getNormalizedReviewsQuery( query ) {
 	return omitBy( query, ( value, key ) => DEFAULT_QUERY[ key ] === value );
 }
+
+/**
+ * Returns a serialized reviews query
+ *
+ * @param  {Object} query  Reviews query
+ * @return {String}        Serialized reviews query
+ */
+export function getSerializedReviewsQuery( query = {} ) {
+	const normalizedQuery = getNormalizedReviewsQuery( query );
+	const serializedQuery = JSON.stringify( normalizedQuery );
+
+	return serializedQuery;
+}


### PR DESCRIPTION
This depends on #17775. Also see #17041.

This PR adds reducers for the responses returned by `fetchReviews`. It handles queries so that we will be able to filter by status, search string, etc. It is patterned off of the orders list code.

To Test:
* Load up this branch.
* Run `npm run test-client client/extensions/woocommerce` and make sure all tests pass.