### PR TITLE
Update help article about custom themes and plugins

### DIFF
--- a/client/me/help/main.jsx
+++ b/client/me/help/main.jsx
@@ -46,11 +46,8 @@ const Help = React.createClass( {
 		const helpfulResults = [
 			{
 				link: 'https://en.support.wordpress.com/com-vs-org/',
-				title: this.translate( 'Can\'t add your theme or plugin?' ),
-				description: this.translate(
-					'Learn about the differences between a fully hosted WordPress.com site and a ' +
-					'self-hosted WordPress.org site. Themes and plugins can be uploaded to self-hosted sites only.'
-				)
+				title: this.translate( 'Uploading custom plugins and themes' ),
+				description: this.translate( 'Learn more about installing a custom theme or plugin using the Business plan.' )
 			},
 			{
 				link: 'https://en.support.wordpress.com/all-about-domains/',

--- a/client/me/help/main.jsx
+++ b/client/me/help/main.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { find } from 'lodash';
+import { localize } from 'i18n-calypso';
 import React from 'react';
 import PureRenderMixin from 'react-pure-render/mixin';
 import debugModule from 'debug';
@@ -46,31 +47,31 @@ const Help = React.createClass( {
 		const helpfulResults = [
 			{
 				link: 'https://en.support.wordpress.com/com-vs-org/',
-				title: this.translate( 'Uploading custom plugins and themes' ),
-				description: this.translate( 'Learn more about installing a custom theme or plugin using the Business plan.' )
+				title: this.props.translate( 'Uploading custom plugins and themes' ),
+				description: this.props.translate( 'Learn more about installing a custom theme or plugin using the Business plan.' )
 			},
 			{
 				link: 'https://en.support.wordpress.com/all-about-domains/',
-				title: this.translate( 'All About Domains' ),
-				description: this.translate( 'Set up your domain whether it’s registered with WordPress.com or elsewhere.' )
+				title: this.props.translate( 'All About Domains' ),
+				description: this.props.translate( 'Set up your domain whether it’s registered with WordPress.com or elsewhere.' )
 			},
 			{
 				link: 'https://en.support.wordpress.com/start/',
-				title: this.translate( 'Get Started' ),
-				description: this.translate(
+				title: this.props.translate( 'Get Started' ),
+				description: this.props.translate(
 					'No matter what kind of site you want to build, our five-step checklists will get you set up and ready to publish.'
 				)
 			},
 			{
 				link: 'https://en.support.wordpress.com/settings/privacy-settings/',
-				title: this.translate( 'Privacy Settings' ),
-				description: this.translate( 'Limit your site’s visibility or make it completely private.' )
+				title: this.props.translate( 'Privacy Settings' ),
+				description: this.props.translate( 'Limit your site’s visibility or make it completely private.' )
 			}
 		];
 
 		return (
 			<div className="help-results">
-				<SectionHeader label={ this.translate( 'Most Helpful Articles' ) } />
+				<SectionHeader label={ this.props.translate( 'Most Helpful Articles' ) } />
 				{ helpfulResults.map( ( result, index ) => {
 					const trackClick = () => {
 						debug( 'Suggested result click: ', result.link );
@@ -91,46 +92,46 @@ const Help = React.createClass( {
 			<div className="help__support-links">
 				<CompactCard className="help__support-link" href="https://support.wordpress.com/" target="__blank">
 					<div className="help__support-link-section">
-						<h2 className="help__support-link-title">{ this.translate( 'All support articles' ) }</h2>
+						<h2 className="help__support-link-title">{ this.props.translate( 'All support articles' ) }</h2>
 						<p className="help__support-link-content">
-							{ this.translate( 'Looking to learn more about a feature? Our docs have all the details.' ) }
+							{ this.props.translate( 'Looking to learn more about a feature? Our docs have all the details.' ) }
 						</p>
 					</div>
 				</CompactCard>
 				<CompactCard className="help__support-link" href="https://en.support.wordpress.com/video-tutorials/" target="__blank">
 					<div className="help__support-link-section">
-						<h2 className="help__support-link-title">{ this.translate( 'Quick help video tutorials' ) }</h2>
+						<h2 className="help__support-link-title">{ this.props.translate( 'Quick help video tutorials' ) }</h2>
 						<p className="help__support-link-content">
-							{ this.translate( 'These short videos will demonstrate some of our most popular features.' ) }
+							{ this.props.translate( 'These short videos will demonstrate some of our most popular features.' ) }
 						</p>
 					</div>
 				</CompactCard>
 				<CompactCard className="help__support-link" href="https://dailypost.wordpress.com/blogging-university/" target="__blank">
 					<div className="help__support-link-section">
 						<h2 className="help__support-link-title">
-							{ this.translate( 'Self-guided email courses for site owners and bloggers' ) }
+							{ this.props.translate( 'Self-guided email courses for site owners and bloggers' ) }
 						</h2>
 						<p className="help__support-link-content">
-							{ this.translate( 'Pick from our ever-growing list of free email courses to improve your knowledge.' ) }
+							{ this.props.translate( 'Pick from our ever-growing list of free email courses to improve your knowledge.' ) }
 						</p>
 					</div>
 				</CompactCard>
 				<CompactCard className="help__support-link" href="https://learn.wordpress.com" target="__blank">
 					<div className="help__support-link-section">
-						<h2 className="help__support-link-title">{ this.translate( 'Self-guided online tutorial' ) }</h2>
+						<h2 className="help__support-link-title">{ this.props.translate( 'Self-guided online tutorial' ) }</h2>
 						<p className="help__support-link-content">
-							{ this.translate( 'A step-by-step guide to getting familiar with the platform.' ) }
+							{ this.props.translate( 'A step-by-step guide to getting familiar with the platform.' ) }
 						</p>
 					</div>
 				</CompactCard>
 				<CompactCard className="help__support-link help__support-link-contact" href="/help/contact/">
 					<div className="help__support-link-section">
-						<h2 className="help__support-link-title">{ this.translate( 'Get in touch' ) }</h2>
+						<h2 className="help__support-link-title">{ this.props.translate( 'Get in touch' ) }</h2>
 						<p className="help__support-link-content">
-							{ this.translate( 'Can\'t find the answer? Drop us a line and we\'ll lend a hand.' ) }
+							{ this.props.translate( 'Can\'t find the answer? Drop us a line and we\'ll lend a hand.' ) }
 						</p>
 					</div>
-					<Button className="help__support-link-button" primary>{ this.translate( 'Contact Us' ) }</Button>
+					<Button className="help__support-link-button" primary>{ this.props.translate( 'Contact Us' ) }</Button>
 				</CompactCard>
 		</div>
 		);
@@ -145,8 +146,8 @@ const Help = React.createClass( {
 			<HelpTeaserButton
 				onClick={ this.trackCoursesButtonClick }
 				href="/help/courses"
-				title={ this.translate( 'Courses' ) }
-				description={ this.translate( 'Learn how to make the most of your site with these courses and webinars' ) } />
+				title={ this.props.translate( 'Courses' ) }
+				description={ this.props.translate( 'Learn how to make the most of your site with these courses and webinars' ) } />
 		);
 	},
 
@@ -212,4 +213,4 @@ export default connect(
 			isEmailVerified,
 		};
 	}
-)( Help );
+)( localize( Help ) );


### PR DESCRIPTION
Fixes #17777 by updating the language around installing custom themes and plugins.

Before:
<img width="948" alt="screen shot 2017-09-04 at 17 17 29" src="https://user-images.githubusercontent.com/66797/30040586-12a65108-9196-11e7-99a9-7c83a339f3ab.png">

After:
<img width="906" alt="screen shot 2017-09-04 at 17 21 20" src="https://user-images.githubusercontent.com/66797/30040587-156098cc-9196-11e7-8850-6f75765286e8.png">
