### PR TITLE
Add codemod for PropType import

### DIFF
--- a/bin/codemods/proptypes-extra-line
+++ b/bin/codemods/proptypes-extra-line
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Initialize from the provided arguments
+TARGET="${1:?No target supplied. Please provide a target directory or file.}"
+
+FILES=$(find $TARGET -type f -name '*.jsx' -o -name '*.js')
+
+for filename in $FILES; do
+    echo "Processing $filename"
+    node bin/codemods/src/proptypes-extra-line.js $filename
+done

--- a/bin/codemods/src/proptypes-extra-line.js
+++ b/bin/codemods/src/proptypes-extra-line.js
@@ -1,0 +1,20 @@
+/** @format */
+var fs = require( 'fs' );
+
+function replaceLine( file ) {
+	fs.readFile( file, 'utf8', function( err, data ) {
+		if ( err ) {
+			return console.log( err );
+		}
+		var result = data.replace(
+			/import PropTypes from 'prop-types';\n\n(?=import)/g,
+			"import PropTypes from 'prop-types';\n"
+		);
+
+		fs.writeFile( file, result, 'utf8', function( err ) {
+			if ( err ) return console.log( err );
+		} );
+	} );
+}
+
+replaceLine( process.argv[ 2 ] );


### PR DESCRIPTION
The PropTypes codemod produces a space between prop-types imports and the following imports.

```js
import PropTypes from 'prop-types';

import React, { Component } from 'react';
```

### Script
Find all instances where `import PropTypes from 'prop-types';` is followed by a blank line before more imports are listed.

Regex validation here, https://regex101.com/r/Ak1ux6/2/

### Usage
```
./bin/codemods/proptypes-extra-line path/to/folder
```

### Result
```js
import PropTypes from 'prop-types';
import React, { Component } from 'react';
```
cc @sirreal @dmsnell 