### PR TITLE
Components: Refactor PurchaseDetail component

### DIFF
--- a/client/components/purchase-detail/index.jsx
+++ b/client/components/purchase-detail/index.jsx
@@ -1,9 +1,11 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import Gridicon from 'gridicons';
+import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -11,94 +13,103 @@ import Gridicon from 'gridicons';
 import PurchaseButton from './purchase-button';
 import TipInfo from './tip-info';
 
-const PurchaseDetail = ( {
-	body,
-	buttonText,
-	description,
-	href,
-	icon,
-	id,
-	info,
-	isPlaceholder,
-	isRequired,
-	isSubmitting,
-	onClick,
-	requiredText,
-	target,
-	rel,
-	title
-} ) => {
-	const classes = classNames( 'purchase-detail', {
-		'is-placeholder': isPlaceholder
-	} );
+export default class PurchaseDetail extends PureComponent {
+	static propTypes = {
+		buttonText: PropTypes.string,
+		description: PropTypes.oneOfType( [
+			PropTypes.array,
+			PropTypes.string,
+			PropTypes.object
+		] ),
+		href: PropTypes.string,
+		icon: PropTypes.string,
+		isPlaceholder: PropTypes.bool,
+		isRequired: PropTypes.bool,
+		isSubmitting: PropTypes.bool,
+		onClick: PropTypes.func,
+		requiredText: PropTypes.string,
+		target: PropTypes.string,
+		rel: PropTypes.string,
+		title: PropTypes.string,
+	};
 
-	let buttonElement;
+	static defaultProps = {
+		onClick: noop,
+	};
 
-	if ( buttonText || isPlaceholder ) {
-		buttonElement = (
+	renderPurchaseButton() {
+		const { buttonText, isPlaceholder, isSubmitting, href, onClick, target, rel } = this.props;
+
+		if ( ! buttonText && ! isPlaceholder ) {
+			return null;
+		}
+
+		return (
 			<PurchaseButton
 				disabled={ isSubmitting }
 				href={ href }
 				onClick={ onClick }
 				target={ target }
 				rel={ rel }
-				text={ buttonText } />
+				text={ buttonText }
+			/>
 		);
 	}
 
-	return (
-		<div className={ classes } id={ id || null }>
-			{ requiredText && (
-				<div className="purchase-detail__required-notice">
-					<em>{ requiredText }</em>
-				</div>
-			) }
-			<div className="purchase-detail__content">
-				{ icon && (
-					<div className="purchase-detail__icon">
-						<Gridicon icon={ icon } />
-						{ isRequired && <Gridicon className="purchase-detail__notice-icon" icon="notice" /> }
+	renderBody() {
+		if ( this.props.body ) {
+			return (
+				<div className="purchase-detail__body">{ this.props.body }</div>
+			);
+		}
+
+		return (
+			<div className="purchase-detail__body">
+				{ this.renderPurchaseButton() }
+				{ this.props.info && <TipInfo info={ this.props.info } /> }
+			</div>
+		);
+	}
+
+	renderIcon() {
+		const { icon, isRequired } = this.props;
+
+		if ( ! icon ) {
+			return null;
+		}
+
+		return (
+			<div className="purchase-detail__icon">
+				<Gridicon icon={ icon } />
+				{ isRequired && <Gridicon className="purchase-detail__notice-icon" icon="notice" /> }
+			</div>
+		);
+	}
+
+	render() {
+		const { id, requiredText, title, description } = this.props;
+		const classes = classNames( 'purchase-detail', {
+			'is-placeholder': this.props.isPlaceholder,
+		} );
+
+		return (
+			<div className={ classes } id={ id }>
+				{ requiredText && (
+					<div className="purchase-detail__required-notice">
+						<em>{ requiredText }</em>
 					</div>
 				) }
+				<div className="purchase-detail__content">
+					{ this.renderIcon() }
 
-				<div className="purchase-detail__text">
-					<h3 className="purchase-detail__title">{ title }</h3>
-					<div className="purchase-detail__description">{ description }</div>
-				</div>
-
-				{ body
-					? <div className="purchase-detail__body">{ body }</div>
-					: <div className="purchase-detail__body">
-						{ buttonElement }
-						{ info && <TipInfo info={ info } /> }
+					<div className="purchase-detail__text">
+						<h3 className="purchase-detail__title">{ title }</h3>
+						<div className="purchase-detail__description">{ description }</div>
 					</div>
-				}
+
+					{ this.renderBody() }
+				</div>
 			</div>
-		</div>
-	);
-};
-
-PurchaseDetail.propTypes = {
-	buttonText: PropTypes.string,
-	description: PropTypes.oneOfType( [
-		PropTypes.array,
-		PropTypes.string,
-		PropTypes.object
-	] ),
-	href: PropTypes.string,
-	icon: PropTypes.string,
-	isPlaceholder: PropTypes.bool,
-	isRequired: PropTypes.bool,
-	isSubmitting: PropTypes.bool,
-	onClick: PropTypes.func,
-	requiredText: PropTypes.string,
-	target: PropTypes.string,
-	rel: PropTypes.string,
-	title: PropTypes.string
-};
-
-PurchaseDetail.defaultProps = {
-	onClick: () => {},
-};
-
-export default PurchaseDetail;
+		);
+	}
+}

--- a/client/components/purchase-detail/test/index.jsx
+++ b/client/components/purchase-detail/test/index.jsx
@@ -1,0 +1,84 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+import { noop } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import PurchaseDetail from '..';
+import PurchaseButton from '../purchase-button';
+import TipInfo from '../tip-info';
+
+describe( 'PurchaseDetail', function() {
+	let wrapper;
+
+	it( 'should be a placeholder if in need', function() {
+		wrapper = shallow( <PurchaseDetail /> );
+		expect( wrapper.hasClass( 'is-placeholder' ) ).to.be.false;
+
+		wrapper = shallow( <PurchaseDetail isPlaceholder={ true } /> );
+		expect( wrapper.hasClass( 'is-placeholder' ) ).to.be.true;
+	} );
+
+	it( 'should render given title and description', function() {
+		wrapper = shallow( <PurchaseDetail title="test:title" description="test:description" /> );
+		expect( wrapper.find( '.purchase-detail__title' ).props().children ).to.equal( 'test:title' );
+		expect( wrapper.find( '.purchase-detail__description' ).props().children ).to.equal( 'test:description' );
+	} );
+
+	it( 'should render given notice text', function() {
+		wrapper = shallow( <PurchaseDetail requiredText="test:notice" /> );
+
+		const notice = wrapper.find( '.purchase-detail__required-notice > em' );
+		expect( notice ).to.have.length( 1 );
+		expect( notice.props().children ).to.equal( 'test:notice' );
+	} );
+
+	it( 'should render given body text', function() {
+		wrapper = shallow( <PurchaseDetail body="test:body" /> );
+
+		const body = wrapper.find( '.purchase-detail__body' );
+		expect( body ).to.have.length( 1 );
+		expect( body.props().children ).to.equal( 'test:body' );
+	} );
+
+	it( 'should render a <TipInfo /> with given tip info unless the body text is passed', function() {
+		wrapper = shallow( <PurchaseDetail info="test:tip-info" /> );
+
+		const tipInfo = wrapper.find( TipInfo );
+		expect( tipInfo ).to.have.length( 1 );
+		expect( tipInfo.prop( 'info' ) ).to.equal( 'test:tip-info' );
+
+		wrapper = shallow( <PurchaseDetail info="test:tip-info" body="test:body" /> );
+		expect( wrapper.find( TipInfo ) ).to.have.length( 0 );
+	} );
+
+	it( 'should render a <PurchaseButton> with given info unless the body text is passed', function() {
+		const buttonProps = {
+			isSubmitting: false,
+			href: 'https://wordpress.com/test/url',
+			onClick: noop,
+			target: 'test:target',
+			rel: 'test:rel',
+			buttonText: 'test:button-text',
+		};
+
+		wrapper = shallow( <PurchaseDetail { ...buttonProps } /> );
+
+		const purchaseButton = wrapper.find( PurchaseButton );
+		expect( purchaseButton ).to.have.length( 1 );
+		expect( purchaseButton.prop( 'disabled' ) ).to.be.false;
+		expect( purchaseButton.prop( 'href' ) ).to.equal( 'https://wordpress.com/test/url' );
+		expect( purchaseButton.prop( 'onClick' ) ).to.equal( noop );
+		expect( purchaseButton.prop( 'target' ) ).to.equal( 'test:target' );
+		expect( purchaseButton.prop( 'rel' ) ).to.equal( 'test:rel' );
+		expect( purchaseButton.prop( 'text' ) ).to.equal( buttonProps.buttonText );
+
+		wrapper = shallow( <PurchaseDetail { ...buttonProps } body="test:body" /> );
+		expect( wrapper.find( PurchaseButton ) ).to.have.length( 0 );
+	} );
+} );


### PR DESCRIPTION
- Improve the code readability of the component.
- Add test cases.

## How to test

1. Purchase a paid plan subscription on the master branch.
2. When you accomplish the payment flow and reach out the thank you screen, there will be some PurchaseDetail elements as the below screenshot shows:
![thank_you_ _wordpress_com_and___projects_wp-testbed_wp-calypso_ _-zsh_ _-zsh_ _ 1](https://user-images.githubusercontent.com/212034/30053021-59d5118c-9262-11e7-9d94-76e318f4ca42.png)
3. Remember the location of the current page.
4. Switch branch to `refactor/purchase-detail` and open the Thank you screen again.
5. The PurchaseDetail elements should look the same as before.