### PR TITLE
Extensions: Zoninator - State & data layer tweaks

### DIFF
--- a/client/extensions/zoninator/state/data-layer/feeds/index.js
+++ b/client/extensions/zoninator/state/data-layer/feeds/index.js
@@ -32,7 +32,7 @@ export const requestZoneFeed = ( { dispatch }, action ) => {
 };
 
 export const updateZoneFeed = ( { dispatch }, { siteId, zoneId }, { data } ) =>
-	dispatch( updateFeed( siteId, zoneId, fromApi( data ) ) );
+	dispatch( updateFeed( siteId, zoneId, fromApi( data, siteId ) ) );
 
 export const requestZoneFeedError = ( { dispatch, getState }, { siteId, zoneId } ) => {
 	const { name } = getZone( getState(), siteId, zoneId );

--- a/client/extensions/zoninator/state/data-layer/feeds/index.js
+++ b/client/extensions/zoninator/state/data-layer/feeds/index.js
@@ -26,7 +26,7 @@ export const requestZoneFeed = ( { dispatch }, action ) => {
 		method: 'GET',
 		path: `/jetpack-blogs/${ siteId }/rest-api/`,
 		query: {
-			path: `/zoninator/v1/zones/${ zoneId }`,
+			path: `/zoninator/v1/zones/${ zoneId }/posts`,
 		},
 	}, action ) );
 };
@@ -47,25 +47,25 @@ export const requestZoneFeedError = ( { dispatch, getState }, { siteId, zoneId }
 };
 
 export const saveZoneFeed = ( { dispatch }, action ) => {
-	const { form, postIds, siteId, zoneId } = action;
+	const { form, posts, siteId, zoneId } = action;
 
 	dispatch( startSubmit( form ) );
 	dispatch( removeNotice( saveFeedNotice ) );
 	dispatch( http( {
-		method: 'PUT',
+		method: 'POST',
 		path: `/jetpack-blogs/${ siteId }/rest-api/`,
 		query: {
-			body: JSON.stringify( toApi( postIds ) ),
+			body: JSON.stringify( toApi( posts ) ),
 			json: true,
-			path: `/zoninator/v1/zones/${ zoneId }/posts`,
+			path: `/zoninator/v1/zones/${ zoneId }/posts&_method=PUT`,
 		},
 	}, action ) );
 };
 
-export const announceSuccess = ( { dispatch }, { form, postIds, siteId, zoneId } ) => {
+export const announceSuccess = ( { dispatch }, { form, posts, siteId, zoneId } ) => {
 	dispatch( stopSubmit( form ) );
-	dispatch( initialize( form, postIds ) );
-	dispatch( updateFeed( siteId, zoneId, postIds ) );
+	dispatch( initialize( form, { posts } ) );
+	dispatch( updateFeed( siteId, zoneId, posts ) );
 	dispatch( successNotice(
 		translate( 'Zone feed saved!' ),
 		{ id: saveFeedNotice },

--- a/client/extensions/zoninator/state/data-layer/feeds/test/index.js
+++ b/client/extensions/zoninator/state/data-layer/feeds/test/index.js
@@ -96,7 +96,7 @@ describe( '#updateZoneFeed()', () => {
 		updateZoneFeed( { dispatch }, dummyAction, { data: apiResponse } );
 
 		expect( dispatch ).to.have.been.calledOnce;
-		expect( dispatch ).to.have.been.calledWith( updateFeed( 123, 456, fromApi( apiResponse ) ) );
+		expect( dispatch ).to.have.been.calledWith( updateFeed( 123, 456, fromApi( apiResponse, dummyAction.siteId ) ) );
 	} );
 } );
 

--- a/client/extensions/zoninator/state/data-layer/feeds/test/index.js
+++ b/client/extensions/zoninator/state/data-layer/feeds/test/index.js
@@ -27,13 +27,15 @@ const dummyAction = {
 	form: 'test-form',
 	siteId: 123,
 	zoneId: 456,
-	postIds: [ 7, 8, 9 ],
+	posts: [
+		{ ID: 1, title: 'A test post' },
+		{ ID: 2, title: 'Another test post' },
+	],
 };
 
 const apiResponse = [
-	{ ID: 1 },
-	{ ID: 2 },
-	{ ID: 3 },
+	{ ID: 1, title: 'Test one', guid: 'http://my.blog/test-one' },
+	{ ID: 2, title: 'Test two', guid: 'http://my.blog/test-two' },
 ];
 
 const getState = () => ( {
@@ -56,7 +58,7 @@ describe( '#requestZoneFeed()', () => {
 			method: 'GET',
 			path: '/jetpack-blogs/123/rest-api/',
 			query: {
-				path: '/zoninator/v1/zones/456'
+				path: '/zoninator/v1/zones/456/posts'
 			},
 		}, dummyAction ) );
 	} );
@@ -105,12 +107,12 @@ describe( '#saveZoneFeed()', () => {
 		saveZoneFeed( { dispatch }, dummyAction );
 
 		expect( dispatch ).to.have.been.calledWith( http( {
-			method: 'PUT',
+			method: 'POST',
 			path: '/jetpack-blogs/123/rest-api/',
 			query: {
-				body: JSON.stringify( toApi( dummyAction.postIds ) ),
+				body: JSON.stringify( toApi( dummyAction.posts ) ),
 				json: true,
-				path: '/zoninator/v1/zones/456/posts',
+				path: '/zoninator/v1/zones/456/posts&_method=PUT',
 			},
 		}, dummyAction ) );
 	} );
@@ -148,7 +150,7 @@ describe( '#announceSuccess()', () => {
 
 		expect( dispatch ).to.have.been.calledWith( initialize(
 			dummyAction.form,
-			dummyAction.postIds,
+			{ posts: dummyAction.posts },
 		) );
 	} );
 
@@ -168,7 +170,7 @@ describe( '#announceSuccess()', () => {
 
 		announceSuccess( { dispatch }, dummyAction );
 
-		expect( dispatch ).to.have.been.calledWith( updateFeed( 123, 456, dummyAction.postIds ) );
+		expect( dispatch ).to.have.been.calledWith( updateFeed( 123, 456, dummyAction.posts ) );
 	} );
 } );
 

--- a/client/extensions/zoninator/state/data-layer/feeds/util.js
+++ b/client/extensions/zoninator/state/data-layer/feeds/util.js
@@ -1,7 +1,8 @@
-export const fromApi = posts => posts.map( post => ( {
-	ID: post.ID,
+export const fromApi = ( posts, siteId ) => posts.map( post => ( {
+	id: post.ID,
+	siteId,
 	title: post.post_title,
-	URL: post.guid,
+	url: post.guid,
 } ) );
 
 export const toApi = posts => ( {

--- a/client/extensions/zoninator/state/data-layer/feeds/util.js
+++ b/client/extensions/zoninator/state/data-layer/feeds/util.js
@@ -1,3 +1,9 @@
-export const fromApi = data => data.map( post => post.ID );
+export const fromApi = posts => posts.map( post => ( {
+	ID: post.ID,
+	title: post.post_title,
+	URL: post.guid,
+} ) );
 
-export const toApi = postIds => ( { post_ids: postIds } );
+export const toApi = posts => ( {
+	post_ids: posts.map( post => post.ID ),
+} );

--- a/client/extensions/zoninator/state/data-layer/zones/index.js
+++ b/client/extensions/zoninator/state/data-layer/zones/index.js
@@ -76,12 +76,12 @@ export const saveZone = ( { dispatch }, action ) => {
 	dispatch( startSubmit( form ) );
 	dispatch( removeNotice( saveZoneNotice ) );
 	dispatch( http( {
-		method: 'PUT',
+		method: 'POST',
 		path: `/jetpack-blogs/${ siteId }/rest-api/`,
 		query: {
 			body: JSON.stringify( data ),
 			json: true,
-			path: `/zoninator/v1/zones/${ zoneId }`,
+			path: `/zoninator/v1/zones/${ zoneId }&_method=PUT`,
 		},
 	}, action ) );
 };
@@ -129,10 +129,10 @@ export const deleteZone = ( { dispatch }, action ) => {
 
 	dispatch( removeNotice( deleteZoneNotice ) );
 	dispatch( http( {
-		method: 'DELETE',
+		method: 'POST',
 		path: `/jetpack-blogs/${ siteId }/rest-api/`,
 		query: {
-			path: `/zoninator/v1/zones/${ zoneId }`,
+			path: `/zoninator/v1/zones/${ zoneId }&_method=DELETE`,
 		},
 	}, action ) );
 };

--- a/client/extensions/zoninator/state/data-layer/zones/test/index.js
+++ b/client/extensions/zoninator/state/data-layer/zones/test/index.js
@@ -191,12 +191,12 @@ describe( '#saveZone()', () => {
 		saveZone( { dispatch }, action );
 
 		expect( dispatch ).to.have.been.calledWith( http( {
-			method: 'PUT',
+			method: 'POST',
 			path: '/jetpack-blogs/123/rest-api/',
 			query: {
 				body: JSON.stringify( zone ),
 				json: true,
-				path: '/zoninator/v1/zones/456',
+				path: '/zoninator/v1/zones/456&_method=PUT',
 			},
 		}, action ) );
 	} );
@@ -336,10 +336,10 @@ describe( '#deleteZone()', () => {
 		deleteZone( { dispatch }, action );
 
 		expect( dispatch ).to.have.been.calledWith( http( {
-			method: 'DELETE',
+			method: 'POST',
 			path: '/jetpack-blogs/123/rest-api/',
 			query: {
-				path: '/zoninator/v1/zones/456',
+				path: '/zoninator/v1/zones/456&_method=DELETE',
 			},
 		}, action ) );
 	} );

--- a/client/extensions/zoninator/state/feeds/actions.js
+++ b/client/extensions/zoninator/state/feeds/actions.js
@@ -26,15 +26,15 @@ export const requestFeed = ( siteId, zoneId ) => ( {
  * @param  {Number} siteId  Site ID
  * @param  {Number} zoneId  Zone ID
  * @param  {String} zoneId  Form name
- * @param  {Array}  postIds Feed post IDs
+ * @param  {Array}  posts   Feed posts
  * @return {Object}         Action object
  */
-export const saveFeed = ( siteId, zoneId, form, postIds ) => ( {
+export const saveFeed = ( siteId, zoneId, form, posts ) => ( {
 	type: ZONINATOR_SAVE_FEED,
 	siteId,
 	zoneId,
 	form,
-	postIds,
+	posts,
 } );
 
 /**
@@ -42,12 +42,12 @@ export const saveFeed = ( siteId, zoneId, form, postIds ) => ( {
  *
  * @param  {Number} siteId  Site ID
  * @param  {Number} zoneId  Zone ID
- * @param  {Array}  postIds Feed post IDs
+ * @param  {Array}  posts   Feed posts
  * @return {Object}         Action object
  */
-export const updateFeed = ( siteId, zoneId, postIds ) => ( {
+export const updateFeed = ( siteId, zoneId, posts ) => ( {
 	type: ZONINATOR_UPDATE_FEED,
 	siteId,
 	zoneId,
-	postIds,
+	posts,
 } );

--- a/client/extensions/zoninator/state/feeds/reducer.js
+++ b/client/extensions/zoninator/state/feeds/reducer.js
@@ -5,7 +5,7 @@ import { combineReducers, createReducer, keyedReducer } from 'state/utils';
 import { ZONINATOR_UPDATE_FEED } from '../action-types';
 
 const feed = createReducer( {}, {
-	[ ZONINATOR_UPDATE_FEED ]: ( state, { postIds } ) => postIds,
+	[ ZONINATOR_UPDATE_FEED ]: ( state, { posts } ) => posts,
 } );
 
 export const items = keyedReducer( 'siteId', keyedReducer( 'zoneId', feed ) );

--- a/client/extensions/zoninator/state/feeds/test/actions.js
+++ b/client/extensions/zoninator/state/feeds/test/actions.js
@@ -13,7 +13,10 @@ describe( 'actions', () => {
 	const siteId = 1234;
 	const zoneId = 5678;
 
-	const feed = [ 1, 2, 3, 4 ];
+	const posts = [
+		{ ID: 1, title: 'A test post' },
+		{ ID: 2, title: 'Another test post' },
+	];
 
 	describe( 'requestFeed()', () => {
 		it( 'should return an action object', () => {
@@ -29,12 +32,12 @@ describe( 'actions', () => {
 
 	describe( 'saveFeed()', () => {
 		it( 'should return an action object', () => {
-			const action = saveFeed( siteId, zoneId, 'test-form', feed );
+			const action = saveFeed( siteId, zoneId, 'test-form', posts );
 
 			expect( action ).to.deep.equal( {
 				type: ZONINATOR_SAVE_FEED,
 				form: 'test-form',
-				postIds: feed,
+				posts,
 				siteId,
 				zoneId,
 			} );
@@ -43,11 +46,11 @@ describe( 'actions', () => {
 
 	describe( 'updateFeed()', () => {
 		it( 'should return an action object', () => {
-			const action = updateFeed( siteId, zoneId, feed );
+			const action = updateFeed( siteId, zoneId, posts );
 
 			expect( action ).to.deep.equal( {
 				type: ZONINATOR_UPDATE_FEED,
-				postIds: feed,
+				posts,
 				siteId,
 				zoneId,
 			} );


### PR DESCRIPTION
This PR features the following tweaks to Zoninator's state & data-layer:

- **Feeds should keep actual post data instead of just the post IDs**  
It's necessary to retrieve the posts through the Zoninator's endpoint as we don't support fetching multiple posts by ID in the same request.

- **Replace PUT & DELETE uses with &_method= GET param**  
We only support `GET` and `POST` request in Calypso, but it's possible to still execute a `PUT` or `DELETE` route by appending `&_method=...` to the URL.

# Testing

Unit tests: `npm run test-client client/extensions/zoninator/state/`