### PR TITLE
Disable social Connect/Disconnect buttons when user data is refreshing

### DIFF
--- a/client/components/button/style.scss
+++ b/client/components/button/style.scss
@@ -122,7 +122,8 @@ button {
 		color: $white;
 	}
 	&[disabled],
-	&:disabled {
+	&:disabled,
+	&.disabled {
 		color: lighten( $gray, 30% );
 		background: $white;
 		border-color: lighten( $gray, 30% );

--- a/client/components/social-buttons/google.js
+++ b/client/components/social-buttons/google.js
@@ -158,10 +158,10 @@ class GoogleLoginButton extends Component {
 
 		if ( children ) {
 			const childProps = {
+				className: classNames( { disabled: isDisabled } ),
 				onClick: this.handleClick,
 				onMouseOver: this.showError,
 				onMouseOut: this.hideError,
-				className: classNames( { disabled: isDisabled } ),
 			};
 
 			customButton = React.cloneElement( children, childProps );

--- a/client/components/social-buttons/google.js
+++ b/client/components/social-buttons/google.js
@@ -154,34 +154,40 @@ class GoogleLoginButton extends Component {
 		const isDisabled = Boolean( this.state.isDisabled || this.props.isFormDisabled || this.state.error );
 
 		const { children } = this.props;
+		let customButton = null;
+
 		if ( children ) {
 			const childProps = {
+				onClick: this.handleClick,
 				onMouseOver: this.showError,
 				onMouseOut: this.hideError,
-				onClick: this.handleClick,
+				className: classNames( { disabled: isDisabled } ),
 			};
 
-			return React.cloneElement( children, childProps );
+			customButton = React.cloneElement( children, childProps );
 		}
 
 		return (
 			<div className="social-buttons__button-container">
-				<button
-					className={ classNames( 'social-buttons__button button', { disabled: isDisabled } ) }
-					onMouseOver={ this.showError }
-					onMouseOut={ this.hideError }
-					onClick={ this.handleClick }
-				>
-					<GoogleIcon isDisabled={ isDisabled } />
+				{
+					customButton
+						? customButton
+						: <button
+							className={ classNames( 'social-buttons__button button', { disabled: isDisabled } ) }
+							onMouseOver={ this.showError }
+							onMouseOut={ this.hideError }
+							onClick={ this.handleClick }
+						>
+							<GoogleIcon isDisabled={ isDisabled } />
 
-					<span className="social-buttons__service-name">
-						{ this.props.translate( 'Continue with %(service)s', {
-							args: { service: 'Google' },
-							comment: '%(service)s is the name of a Social Network, e.g. "Google", "Facebook", "Twitter" ...'
-						} ) }
-					</span>
-				</button>
-
+							<span className="social-buttons__service-name">
+								{ this.props.translate( 'Continue with %(service)s', {
+									args: { service: 'Google' },
+									comment: '%(service)s is the name of a Social Network, e.g. "Google", "Facebook", "Twitter" ...'
+								} ) }
+							</span>
+						</button>
+				}
 				<Popover
 					id="social-buttons__error"
 					className="social-buttons__error"

--- a/client/me/social-login/index.jsx
+++ b/client/me/social-login/index.jsx
@@ -62,7 +62,7 @@ class SocialLogin extends Component {
 		this.props.disconnectSocialUser( 'google' ).then( () => this.refreshUser() );
 	};
 
-	handleGoogleResponse = ( response ) => {
+	handleGoogleLoginResponse = ( response ) => {
 		if ( ! response.Zi || ! response.Zi.access_token || ! response.Zi.id_token ) {
 			return;
 		}
@@ -91,10 +91,24 @@ class SocialLogin extends Component {
 		);
 	}
 
-	renderGoogleConnection() {
+	renderActionButton( onClickAction = null ) {
 		const { isUserConnectedToGoogle, isUpdatingSocialConnection, translate } = this.props;
 		const buttonLabel = isUserConnectedToGoogle ? translate( 'Disconnect' ) : translate( 'Connect' );
 		const disableButton = isUpdatingSocialConnection || this.state.fetchingUser;
+
+		return (
+			<FormButton
+				compact={ true }
+				disabled={ disableButton }
+				isPrimary={ true }
+				onClick={ onClickAction }>
+				{ buttonLabel }
+			</FormButton>
+		);
+	}
+
+	renderGoogleConnection() {
+		const { isUserConnectedToGoogle } = this.props;
 
 		return (
 			<CompactCard>
@@ -109,23 +123,11 @@ class SocialLogin extends Component {
 					<div className="social-login__header-action">
 						{
 							isUserConnectedToGoogle
-								? <FormButton
-									compact={ true }
-									disabled={ disableButton }
-									isPrimary={ false }
-									onClick={ this.disconnectFromGoogle }>
-									{ buttonLabel }
-								</FormButton>
+								? this.renderActionButton( this.disconnectFromGoogle )
 								: <GoogleLoginButton
 									clientId={ config( 'google_oauth_client_id' ) }
-									responseHandler={ this.handleGoogleResponse } >
-									<FormButton
-										compact={ true }
-										disabled={ disableButton }
-										isPrimary={ true }
-										onClick={ this.disconnectFromGoogle }>
-										{ buttonLabel }
-									</FormButton>
+									responseHandler={ this.handleGoogleLoginResponse } >
+									{ this.renderActionButton() }
 								</GoogleLoginButton>
 						}
 					</div>

--- a/client/me/social-login/index.jsx
+++ b/client/me/social-login/index.jsx
@@ -40,6 +40,10 @@ class SocialLogin extends Component {
 		userSettings: PropTypes.object,
 	};
 
+	state = {
+		fetchingUser: false
+	};
+
 	componentDidMount() {
 		debug( this.constructor.displayName + ' React component has mounted.' );
 	}
@@ -48,8 +52,14 @@ class SocialLogin extends Component {
 		debug( this.constructor.displayName + ' React component is unmounting.' );
 	}
 
+	refreshUser() {
+		user.fetch();
+		this.setState( { fetchingUser: true } );
+		user.once( 'change', () => this.setState( { fetchingUser: false } ) );
+	}
+
 	disconnectFromGoogle = () => {
-		this.props.disconnectSocialUser( 'google' ).then( () => user.fetch() );
+		this.props.disconnectSocialUser( 'google' ).then( () => this.refreshUser() );
 	};
 
 	handleGoogleResponse = ( response ) => {
@@ -63,7 +73,7 @@ class SocialLogin extends Component {
 			id_token: response.Zi.id_token,
 		};
 
-		return this.props.connectSocialUser( socialInfo ).then( () => user.fetch() );
+		return this.props.connectSocialUser( socialInfo ).then( () => this.refreshUser() );
 	};
 
 	renderContent() {
@@ -84,6 +94,7 @@ class SocialLogin extends Component {
 	renderGoogleConnection() {
 		const { isUserConnectedToGoogle, isUpdatingSocialConnection, translate } = this.props;
 		const buttonLabel = isUserConnectedToGoogle ? translate( 'Disconnect' ) : translate( 'Connect' );
+		const disableButton = isUpdatingSocialConnection || this.state.fetchingUser;
 
 		return (
 			<CompactCard>
@@ -100,7 +111,7 @@ class SocialLogin extends Component {
 							isUserConnectedToGoogle
 								? <FormButton
 									compact={ true }
-									disabled={ isUpdatingSocialConnection }
+									disabled={ disableButton }
 									isPrimary={ false }
 									onClick={ this.disconnectFromGoogle }>
 									{ buttonLabel }
@@ -110,7 +121,7 @@ class SocialLogin extends Component {
 									responseHandler={ this.handleGoogleResponse } >
 									<FormButton
 										compact={ true }
-										disabled={ isUpdatingSocialConnection }
+										disabled={ disableButton }
 										isPrimary={ true }
 										onClick={ this.disconnectFromGoogle }>
 										{ buttonLabel }

--- a/client/me/social-login/index.jsx
+++ b/client/me/social-login/index.jsx
@@ -117,7 +117,7 @@ class SocialLogin extends Component {
 				{
 					errorUpdatingSocialConnection &&
 						<Notice status={ 'is-error' } showDismiss={ false }>
-							{ errorUpdatingSocialConnection }
+							{ errorUpdatingSocialConnection.message }
 						</Notice>
 				}
 				<div className="social-login__header">

--- a/client/me/social-login/index.jsx
+++ b/client/me/social-login/index.jsx
@@ -27,6 +27,7 @@ import { isRequesting, getRequestError } from 'state/login/selectors';
 import GoogleIcon from 'components/social-icons/google';
 import GoogleLoginButton from 'components/social-buttons/google';
 import userFactory from 'lib/user';
+import Notice from 'components/notice';
 
 const user = userFactory();
 
@@ -41,7 +42,7 @@ class SocialLogin extends Component {
 	};
 
 	state = {
-		fetchingUser: false
+		fetchingUser: false,
 	};
 
 	componentDidMount() {
@@ -98,9 +99,10 @@ class SocialLogin extends Component {
 
 		return (
 			<FormButton
-				compact={ true }
+				className="social-login__button button"
 				disabled={ disableButton }
-				isPrimary={ true }
+				compact={ true }
+				isPrimary={ ! isUserConnectedToGoogle }
 				onClick={ onClickAction }>
 				{ buttonLabel }
 			</FormButton>
@@ -108,10 +110,16 @@ class SocialLogin extends Component {
 	}
 
 	renderGoogleConnection() {
-		const { isUserConnectedToGoogle } = this.props;
+		const { errorUpdatingSocialConnection, isUserConnectedToGoogle } = this.props;
 
 		return (
 			<CompactCard>
+				{
+					errorUpdatingSocialConnection &&
+						<Notice status={ 'is-error' } showDismiss={ false }>
+							{ errorUpdatingSocialConnection }
+						</Notice>
+				}
 				<div className="social-login__header">
 					<div className="social-login__header-info">
 						<div className="social-login__header-icon">
@@ -126,7 +134,7 @@ class SocialLogin extends Component {
 								? this.renderActionButton( this.disconnectFromGoogle )
 								: <GoogleLoginButton
 									clientId={ config( 'google_oauth_client_id' ) }
-									responseHandler={ this.handleGoogleLoginResponse } >
+									responseHandler={ this.handleGoogleLoginResponse }>
 									{ this.renderActionButton() }
 								</GoogleLoginButton>
 						}

--- a/client/me/social-login/style.scss
+++ b/client/me/social-login/style.scss
@@ -26,3 +26,9 @@
 	flex: 1 1;
 	justify-content: flex-end;
 }
+.social-login__header-action__error {
+	.popover__inner {
+		padding: 10px;
+		max-width: 200px;
+	}
+}

--- a/client/state/login/reducer.js
+++ b/client/state/login/reducer.js
@@ -63,7 +63,7 @@ export const redirectTo = createReducer( null, {
 	[ SOCIAL_LOGIN_REQUEST_SUCCESS ]: ( state, { data } ) => get( data, 'redirect_to', null ),
 	[ SOCIAL_LOGIN_REQUEST_FAILURE ]: () => null,
 	[ SOCIAL_CONNECT_ACCOUNT_REQUEST ]: () => null,
-	[ SOCIAL_CONNECT_ACCOUNT_REQUEST_FAILURE ]: null,
+	[ SOCIAL_CONNECT_ACCOUNT_REQUEST_FAILURE ]: () => null,
 	[ SOCIAL_CONNECT_ACCOUNT_REQUEST_SUCCESS ]: ( state, action ) => get( action, 'redirect_to', null ),
 	[ LOGOUT_REQUEST ]: () => null,
 	[ LOGOUT_REQUEST_SUCCESS ]: () => ( state, { data } ) => get( data, 'redirect_to', null ),

--- a/client/state/login/reducer.js
+++ b/client/state/login/reducer.js
@@ -100,7 +100,7 @@ export const requestError = createReducer( null, {
 	[ SOCIAL_CONNECT_ACCOUNT_REQUEST_SUCCESS ]: () => null,
 	[ SOCIAL_DISCONNECT_ACCOUNT_REQUEST ]: () => null,
 	[ SOCIAL_DISCONNECT_ACCOUNT_REQUEST_FAILURE ]: ( state, { error } ) => error,
-	[ SOCIAL_DISCONNECT_ACCOUNT_REQUEST_SUCCESS ]: () => true,
+	[ SOCIAL_DISCONNECT_ACCOUNT_REQUEST_SUCCESS ]: () => null,
 	[ ROUTE_SET ]: () => null,
 	[ LOGIN_FORM_UPDATE ]: () => null,
 } );


### PR DESCRIPTION
This PR update the social login settings page (at `/me/security/social-login`) to handle disabled button state and errors properly.

### Testing Instructions
- Boot this branch
- Disable 3rd party cookies on your browser ( `chrome://settings/content/cookies` )
- Go to /log-in and check that you see a popover element when you hover the disabled Google Connect button
- Login, go to `/me/security/social-login` and check that the same popover is displayed in this case
- Activate 3rd party cookies
- Sandbox and edit the `/me/social-login/connect` and `/me/social-login/disconnect` endpoints to return an error in all cases
- Check that the error is displayed properly

### Reviews
- [x] Code
- [x] Product
