### PR TITLE
Components: make compact notices dismissable

### DIFF
--- a/client/components/notice/docs/example.jsx
+++ b/client/components/notice/docs/example.jsx
@@ -104,6 +104,15 @@ var Notices = React.createClass( {
 						</NoticeAction>
 					</Notice>
 				</div>
+				<div>
+					<Notice
+						status="is-error"
+						showDismiss={ true }
+						text="I'm an always dismissable error notice."
+						isCompact={ this.state.compactNotices ? true : null }>
+						<NoticeAction href="#">More</NoticeAction>
+					</Notice>
+				</div>
 			</div>
 		);
 	},

--- a/client/components/notice/index.jsx
+++ b/client/components/notice/index.jsx
@@ -14,7 +14,6 @@ export class Notice extends Component {
 		icon: null,
 		isCompact: false,
 		onDismissClick: noop,
-		showDismiss: true,
 		status: null,
 		text: null,
 	};
@@ -85,7 +84,7 @@ export class Notice extends Component {
 			icon,
 			isCompact,
 			onDismissClick,
-			showDismiss,
+			showDismiss = ! isCompact, // by default, show on normal notices, don't show on compact ones
 			status,
 			text,
 			translate,

--- a/client/components/notice/style.scss
+++ b/client/components/notice/style.scss
@@ -252,7 +252,16 @@ a.notice__action {
 	}
 
 	.notice__dismiss {
-		display: none;
+		position: relative;
+		align-self: center;
+		flex: none;
+		margin: 0 8px 0 0;
+		padding: 0;
+
+		.gridicon {
+			width: 18px;
+			height: 18px;
+		}
 	}
 
 	a.notice__action {

--- a/client/components/notice/test/index.js
+++ b/client/components/notice/test/index.js
@@ -22,9 +22,24 @@ describe( 'Notice', function() {
 		assert.isOk( wrapper.find( '.is-dismissable' ).length );
 	} );
 
+	it( 'should have dismiss button by default if isCompact is false', function() {
+		const wrapper = shallow( <Notice isCompact={ false } translate={ identity } /> );
+		assert.isOk( wrapper.find( '.is-dismissable' ).length );
+	} );
+
 	it( 'should have compact look when isCompact passed as true', function() {
 		const wrapper = shallow( <Notice isCompact={ true } translate={ identity } /> );
 		assert.isOk( wrapper.find( '.is-compact' ).length );
+	} );
+
+	it( 'should not have dismiss button by default if isCompact is true', function() {
+		const wrapper = shallow( <Notice isCompact={ true } translate={ identity } /> );
+		assert.isOk( wrapper.find( '.is-dismissable' ).length === 0 );
+	} );
+
+	it( 'should have dismiss button when showDismiss is true and isCompact is true', function() {
+		const wrapper = shallow( <Notice isCompact={ true } showDismiss={ true } translate={ identity } /> );
+		assert.isOk( wrapper.find( '.is-dismissable' ).length );
 	} );
 
 	it( 'should have proper class for is-info status parameter', function() {


### PR DESCRIPTION
Fixes a bug where the `<Notice isCompact>` component doesn't display a dismiss icon even when `showDismiss` is set explicitly to `true`.

**Steps to reproduce:**
Create a dismissable compact notice: `<Notice isCompact showDismiss>`

**Actual result:**
The dismiss icon is never displayed on a compact notice. The CSS style for the `notice__dismiss` class is set to `display: none`.

**Expected result:**
- if the notice is not compact, show the dismiss icon by default. If the `showDismiss` prop is not specified, its default value is `true`.
- if the notice is compact, don't show the dismiss icon by default. `showDismiss` defaults to `false`.
- if `showDismiss` is set explicitly to `true`, always display the dismiss icon.

**Testing instructions:**
Go to `/devdocs/design/notices` and check the various scenarios there: compact vs not compact, `showDismiss` specified vs unspecified. Check the correct layout in various situations: desktop, mobile, compact, not compact.

The CSS styling of `.notice__dismiss` is very directly inspired by `.notice__icon`.

The changes in this PR will be very useful for plugin error notices work in #17537.