### PR TITLE
Extensions: WPJM - Add UI for the page setup step of the wizard

### DIFF
--- a/client/extensions/wp-job-manager/components/setup/index.jsx
+++ b/client/extensions/wp-job-manager/components/setup/index.jsx
@@ -13,6 +13,7 @@ import { Steps } from './constants';
 import DocumentHead from 'components/data/document-head';
 import Intro from './intro';
 import Main from 'components/main';
+import PageSetup from './page-setup';
 import Wizard from 'components/wizard';
 import { getSelectedSiteSlug } from 'state/ui/selectors';
 
@@ -21,9 +22,10 @@ const SetupWizard = ( {
 	stepName = Steps.INTRO,
 	translate,
 } ) => {
-	const steps = [ Steps.INTRO ];
+	const steps = [ Steps.INTRO, Steps.PAGE_SETUP ];
 	const components = {
 		[ Steps.INTRO ]: <Intro />,
+		[ Steps.PAGE_SETUP ]: <PageSetup />
 	};
 	const mainClassName = 'wp-job-manager__setup';
 

--- a/client/extensions/wp-job-manager/components/setup/page-setup/index.jsx
+++ b/client/extensions/wp-job-manager/components/setup/page-setup/index.jsx
@@ -141,13 +141,7 @@ class PageSetup extends Component {
 
 const selector = formValueSelector( form );
 
-const mapStateToProps = state => {
-	return {
-		createDashboard: selector( state, 'createDashboard' ),
-		createJobs: selector( state, 'createJobs' ),
-		createPostJob: selector( state, 'createPostJob' ),
-	};
-};
+const mapStateToProps = state => selector( state, 'createDashboard', 'createJobs', 'createPostJob' );
 
 const createReduxForm = reduxForm( {
 	form,

--- a/client/extensions/wp-job-manager/components/setup/page-setup/index.jsx
+++ b/client/extensions/wp-job-manager/components/setup/page-setup/index.jsx
@@ -1,0 +1,174 @@
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { formValueSelector, reduxForm } from 'redux-form';
+import { localize } from 'i18n-calypso';
+import { flowRight as compose } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import Button from 'components/button';
+import CompactCard from 'components/card/compact';
+import ExternalLink from 'components/external-link';
+import FormFieldset from 'components/forms/form-fieldset';
+import FormSettingExplanation from 'components/forms/form-setting-explanation';
+import ReduxFormTextInput from 'components/redux-forms/redux-form-text-input';
+import ReduxFormToggle from 'components/redux-forms/redux-form-toggle';
+import SectionHeader from 'components/section-header';
+
+const form = 'extensions.wpJobManager.pageSetup';
+
+class PageSetup extends Component {
+	static propTypes = {
+		createDashboard: PropTypes.bool,
+		createJobs: PropTypes.bool,
+		createPostJob: PropTypes.bool,
+		translate: PropTypes.func.isRequired,
+	};
+
+	render() {
+		const {
+			createDashboard,
+			createJobs,
+			createPostJob,
+			translate,
+		} = this.props;
+
+		return (
+			<div>
+				<SectionHeader label={ translate( 'Page Setup' ) } />
+				<CompactCard>
+					<p>
+						{ translate(
+							'{{em}}WP Job Manager{{/em}} includes {{shortcodes}}shortcodes{{/shortcodes}} which can ' +
+							'be used within your {{pages}}pages{{/pages}} to output content. These can be created ' +
+							'for you below. For more information on the job shortcodes view the ' +
+							'{{shortcodeRef}}shortcode documentation{{/shortcodeRef}}.',
+							{ components: {
+								em: <em />,
+								pages: (
+									<ExternalLink
+										icon={ true }
+										target="_blank"
+										href="https://codex.wordpress.org/Pages"
+									/>
+								),
+								shortcodes: (
+									<ExternalLink
+										icon={ true }
+										target="_blank"
+										href="https://codex.wordpress.org/Shortcode"
+									/>
+								),
+								shortcodeRef: (
+									<ExternalLink
+										icon={ true }
+										target="_blank"
+										href="https://wpjobmanager.com/document/shortcode-reference/"
+									/>
+								)
+							} }
+						) }
+					</p>
+
+					<div className="page-setup__pages">
+						<form>
+							<FormFieldset>
+								<ReduxFormToggle
+									name="createPostJob" />
+								<ReduxFormTextInput
+									disabled={ ! createPostJob }
+									name="postJobTitle" />
+
+								<FormSettingExplanation>
+									{ translate(
+										'This page allows employers to post jobs to your website from the front-end. ' +
+										'If you do not want to accept submissions from users in this way (for example, you ' +
+										'just want to post jobs from the admin dashboard), you can skip creating this page. ' +
+										'Alternatively, you can add the [submit_job_form] shortcode to an existing page.'
+									) }
+								</FormSettingExplanation>
+							</FormFieldset>
+
+							<FormFieldset>
+								<ReduxFormToggle
+									name="createDashboard" />
+								<ReduxFormTextInput
+									disabled={ ! createDashboard }
+									name="dashboardTitle" />
+
+								<FormSettingExplanation>
+									{ translate(
+										'This page allows employers to manage and edit their own jobs from the front-end. ' +
+										'If you plan on managing all listings from the admin dashboard, you can skip creating ' +
+										'this page. Alternatively, you can add the [job_dashboard] shortcode to an existing page.'
+									) }
+								</FormSettingExplanation>
+							</FormFieldset>
+
+							<FormFieldset>
+								<ReduxFormToggle
+									name="createJobs" />
+								<ReduxFormTextInput
+									disabled={ ! createJobs }
+									name="jobsTitle" />
+
+								<FormSettingExplanation>
+									{ translate(
+										'This page allows users to browse, search, and filter job listings on the front-end ' +
+										'of your site. Alternatively, you can add the [jobs] shortcode to an existing page.'
+									) }
+								</FormSettingExplanation>
+							</FormFieldset>
+						</form>
+					</div>
+				</CompactCard>
+
+				<CompactCard>
+					<a
+						className="page-setup__skip"
+						href="#">
+						{ translate( 'Skip this step' ) }
+					</a>
+					<Button primary
+						className="page-setup__create-pages"
+						disabled={ ( ! createPostJob && ! createDashboard && ! createJobs ) }>
+						{ translate( 'Create selected pages' ) }
+					</Button>
+				</CompactCard>
+			</div>
+		);
+	}
+}
+
+const selector = formValueSelector( form );
+
+const mapStateToProps = state => {
+	return {
+		createDashboard: selector( state, 'createDashboard' ),
+		createJobs: selector( state, 'createJobs' ),
+		createPostJob: selector( state, 'createPostJob' ),
+	};
+};
+
+const createReduxForm = reduxForm( {
+	form,
+	initialValues: {
+		createDashboard: true,
+		createJobs: true,
+		createPostJob: true,
+		dashboardTitle: 'Job Dashboard',
+		jobsTitle: 'Jobs',
+		postJobTitle: 'Post a Job',
+	}
+} );
+
+export default compose(
+	connect( mapStateToProps ),
+	createReduxForm,
+	localize,
+)( PageSetup );

--- a/client/extensions/wp-job-manager/components/setup/page-setup/index.jsx
+++ b/client/extensions/wp-job-manager/components/setup/page-setup/index.jsx
@@ -42,38 +42,33 @@ class PageSetup extends Component {
 			<div>
 				<SectionHeader label={ translate( 'Page Setup' ) } />
 				<CompactCard>
-					<p>
-						{ translate(
-							'{{em}}WP Job Manager{{/em}} includes {{shortcodes}}shortcodes{{/shortcodes}} which can ' +
-							'be used within your {{pages}}pages{{/pages}} to output content. These can be created ' +
-							'for you below. For more information on the job shortcodes view the ' +
-							'{{shortcodeRef}}shortcode documentation{{/shortcodeRef}}.',
-							{ components: {
-								em: <em />,
-								pages: (
-									<ExternalLink
-										icon={ true }
-										target="_blank"
-										href="https://codex.wordpress.org/Pages"
-									/>
-								),
-								shortcodes: (
-									<ExternalLink
-										icon={ true }
-										target="_blank"
-										href="https://codex.wordpress.org/Shortcode"
-									/>
-								),
-								shortcodeRef: (
-									<ExternalLink
-										icon={ true }
-										target="_blank"
-										href="https://wpjobmanager.com/document/shortcode-reference/"
-									/>
-								)
-							} }
-						) }
-					</p>
+					{ translate(
+						'{{p}}With WP Job Manager, employers and applicants can post, manage, and browse job listings ' +
+						'right on your website. Tell us which of these common pages you\'d like your site to have ' +
+						'and we\'ll create and configure them for you.{{/p}}' +
+						'{{p}}(These pages are created using {{shortcodes}}shortcodes{{/shortcodes}}, which we take care of ' +
+						'in this step. If you\'d like to build these pages yourself or want to add one of these options to an ' +
+						'existing page on your site, you can skip this step and take a look at {{shortcodeRef}}shortcode ' +
+						'support documentation{{/shortcodeRef}} for detailed instructions.){{/p}}',
+						{ components: {
+							em: <em />,
+							p: <p />,
+							shortcodes: (
+								<ExternalLink
+									icon={ true }
+									target="_blank"
+									href="https://codex.wordpress.org/Shortcode"
+								/>
+							),
+							shortcodeRef: (
+								<ExternalLink
+									icon={ true }
+									target="_blank"
+									href="https://wpjobmanager.com/document/shortcode-reference/"
+								/>
+							)
+						} }
+					) }
 
 					<div className="page-setup__pages">
 						<form>
@@ -86,10 +81,10 @@ class PageSetup extends Component {
 
 								<FormSettingExplanation>
 									{ translate(
-										'This page allows employers to post jobs to your website from the front-end. ' +
-										'If you do not want to accept submissions from users in this way (for example, you ' +
-										'just want to post jobs from the admin dashboard), you can skip creating this page. ' +
-										'Alternatively, you can add the [submit_job_form] shortcode to an existing page.'
+										'Creates a page that allows employers to post new jobs directly from a page on your website, ' +
+										'instead of requiring them to log in to an admin area. If you\'d rather not allow this -- ' +
+										'for example, if you want employers to use the admin dashboard only -- you can uncheck ' +
+										'this setting.'
 									) }
 								</FormSettingExplanation>
 							</FormFieldset>
@@ -103,9 +98,9 @@ class PageSetup extends Component {
 
 								<FormSettingExplanation>
 									{ translate(
-										'This page allows employers to manage and edit their own jobs from the front-end. ' +
-										'If you plan on managing all listings from the admin dashboard, you can skip creating ' +
-										'this page. Alternatively, you can add the [job_dashboard] shortcode to an existing page.'
+										'Creates a page that allows employers to manage their job listings directly from a page on your ' +
+										'website, instead of requiring them to log in to an admin area. If you want to manage all ' +
+										'job listings from the admin dashboard only, you can uncheck this setting.'
 									) }
 								</FormSettingExplanation>
 							</FormFieldset>
@@ -119,8 +114,7 @@ class PageSetup extends Component {
 
 								<FormSettingExplanation>
 									{ translate(
-										'This page allows users to browse, search, and filter job listings on the front-end ' +
-										'of your site. Alternatively, you can add the [jobs] shortcode to an existing page.'
+										'Creates a page where visitors can browse, search, and filter job listings.'
 									) }
 								</FormSettingExplanation>
 							</FormFieldset>

--- a/client/extensions/wp-job-manager/components/setup/style.scss
+++ b/client/extensions/wp-job-manager/components/setup/style.scss
@@ -1,4 +1,5 @@
-.wp-job-manager__setup .intro__skip-setup {
+.wp-job-manager__setup .intro__skip-setup,
+.wp-job-manager__setup .page-setup__skip {
 	color: $blue-medium;
 	display: block;
 	font-size: 13px;
@@ -10,7 +11,8 @@
 	}
 }
 
-.wp-job-manager__setup .intro__start-setup {
+.wp-job-manager__setup .intro__start-setup,
+.wp-job-manager__setup .page-setup__create-pages {
 	margin-top: 10px;
 
 	@include breakpoint( "<660px" ) {
@@ -22,4 +24,16 @@
 		float: right;
 		margin: 0;
 	}
+}
+
+.wp-job-manager__setup .page-setup__pages .form-text-input {
+	width: 250px;
+}
+
+.wp-job-manager__setup .page-setup__pages .form-setting-explanation {
+	margin-left: 36px;
+}
+
+.wp-job-manager__setup .page-setup__pages .button {
+	margin-right: 8px;
 }


### PR DESCRIPTION
This PR adds the UI (no functionality) for the page setup step of the WPJM setup wizard. The wizard will be triggered when the plugin is first activated. Note that there will ultimately be 3 steps in the wizard. Here is what the page setup step looks like:

_Updated screenshot after copy review_

![page-setup](https://user-images.githubusercontent.com/1190420/30120255-4fbf518c-92f6-11e7-986c-d3f4317c4e26.jpg)

For comparison's sake, here is what the page setup step looks like in the plugin itself:

![plugin-page-setup-step](https://user-images.githubusercontent.com/1190420/30062053-cfec91ec-9217-11e7-9e4a-9c27e6dc1974.jpg)

## Testing

Ensure the WP Job Manager plugin is installed and configured by following the steps in p6r3EZ-ra-p2. Browse to `/extensions/wp-job-manager/setup/<siteId>/page-setup`.