### PR TITLE
Activity log: Fix loading and empty states

### DIFF
--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -263,8 +263,6 @@ class ActivityLog extends Component {
 			);
 		}
 
-		const disableRestore = this.isRestoreInProgress();
-
 		if ( isEmpty( logs ) ) {
 			return (
 				<EmptyContent
@@ -275,6 +273,7 @@ class ActivityLog extends Component {
 			);
 		}
 
+		const disableRestore = this.isRestoreInProgress();
 		const logsGroupedByDay = groupBy( logs, log =>
 			this.applySiteOffset( moment.utc( log.activityTs ) ).endOf( 'day' ).valueOf()
 		);

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -313,12 +313,17 @@ class ActivityLog extends Component {
 	}
 
 	renderMonthNavigation( position ) {
-		const { slug } = this.props;
+		const { logs, slug } = this.props;
 		const startOfMonth = this.getStartMoment().startOf( 'month' );
 		const query = {
 			period: 'month',
 			date: startOfMonth.format( 'YYYY-MM-DD' ),
 		};
+
+		if ( position === 'bottom' && ( ! isNull( logs ) && isEmpty( logs ) ) ) {
+			return null;
+		}
+
 		return (
 			<StatsPeriodNavigation
 				date={ startOfMonth }

--- a/client/state/activity-log/log/reducer.js
+++ b/client/state/activity-log/log/reducer.js
@@ -11,7 +11,7 @@ export const logError = keyedReducer( 'siteId', state => state );
 
 export const logItems = keyedReducer(
 	'siteId',
-	createReducer( [], {
+	createReducer( undefined, {
 		[ ACTIVITY_LOG_UPDATE ]: ( state, { data } ) => data,
 	} )
 );

--- a/client/state/data-layer/wpcom/sites/activity/index.js
+++ b/client/state/data-layer/wpcom/sites/activity/index.js
@@ -46,6 +46,9 @@ export const handleActivityLogRequest = ( { dispatch }, action ) => {
 
 	debug( 'Handling activity request', query );
 
+	// Clear current logs, this will allow loading placeholders to appear
+	dispatch( activityLogUpdate( siteId, undefined ) );
+
 	dispatch(
 		http(
 			{

--- a/client/state/data-layer/wpcom/sites/activity/test/index.js
+++ b/client/state/data-layer/wpcom/sites/activity/test/index.js
@@ -94,7 +94,7 @@ describe( 'handleActivityLogRequest', () => {
 
 		handleActivityLogRequest( { dispatch }, action );
 
-		expect( dispatch ).to.have.been.calledOnce;
+		expect( dispatch ).to.have.been.calledTwice;
 		expect( dispatch ).to.have.been.calledWith(
 			http(
 				{
@@ -120,7 +120,7 @@ describe( 'handleActivityLogRequest', () => {
 
 		handleActivityLogRequest( { dispatch }, action );
 
-		expect( dispatch ).to.have.been.calledOnce;
+		expect( dispatch ).to.have.been.calledTwice;
 		expect( dispatch ).to.have.been.calledWith(
 			http(
 				{
@@ -149,7 +149,7 @@ describe( 'handleActivityLogRequest', () => {
 
 		handleActivityLogRequest( { dispatch }, action );
 
-		expect( dispatch ).to.have.been.calledOnce;
+		expect( dispatch ).to.have.been.calledTwice;
 		expect( dispatch ).to.have.been.calledWith(
 			http(
 				{


### PR DESCRIPTION
Loading and empty states were conflicting. This PR fixes that with a few changes:

* Flush activity data when requesting new data
* Change initial Activity state from `[]` (conflicts with empty state) to `undefined` (not loaded).

**Update**
Remove bottom nav when empty (fixes #17801)

## Testing
1. Visit https://calypso.live/stats/activity?branch=fix/activity-log/loading-state
1. Navigate with month picker.
1. Note that loading placeholders are displayed
1. Go back to an empty month, verify the empty view is correctly displayed
