### PR TITLE
Extensions: Zoninator - Link edit zone view to state

### DIFF
--- a/client/extensions/zoninator/app/controller.js
+++ b/client/extensions/zoninator/app/controller.js
@@ -13,7 +13,7 @@ import Settings from '../components/settings';
 
 export const renderTab = ( component ) => ( context ) => {
 	const siteId = getSiteFragment( context.path );
-	const zoneId = parseInt( context.params.zone );
+	const zoneId = parseInt( context.params.zone, 10 ) || 0;
 
 	let baseAnalyticsPath = sectionify( context.path );
 

--- a/client/extensions/zoninator/app/controller.js
+++ b/client/extensions/zoninator/app/controller.js
@@ -13,7 +13,7 @@ import Settings from '../components/settings';
 
 export const renderTab = ( component ) => ( context ) => {
 	const siteId = getSiteFragment( context.path );
-	const zoneId = context.params.zone;
+	const zoneId = parseInt( context.params.zone );
 
 	let baseAnalyticsPath = sectionify( context.path );
 

--- a/client/extensions/zoninator/components/data/query-feed/index.jsx
+++ b/client/extensions/zoninator/components/data/query-feed/index.jsx
@@ -22,18 +22,14 @@ class QueryFeed extends PureComponent {
 	}
 
 	componentWillReceiveProps( nextProps ) {
-		if (
-			! nextProps.siteId ||
-			! nextProps.zoneId ||
-			( this.props.siteId === nextProps.siteId && this.props.zoneId === nextProps.zoneId )
-		) {
+		if ( this.props.siteId === nextProps.siteId && this.props.zoneId === nextProps.zoneId ) {
 			return;
 		}
 
 		this.requestFeed( nextProps );
 	}
 
-	requestFeed = props => props.requestFeed( props.siteId, props.zoneId );
+	requestFeed = props => props.siteId && props.zoneId && props.requestFeed( props.siteId, props.zoneId );
 
 	render() {
 		return null;

--- a/client/extensions/zoninator/components/data/query-feed/index.jsx
+++ b/client/extensions/zoninator/components/data/query-feed/index.jsx
@@ -13,8 +13,8 @@ import { requestFeed } from '../../../state/feeds/actions';
 class QueryFeed extends PureComponent {
 
 	static propTypes = {
-		siteId: PropTypes.number,
-		zoneId: PropTypes.number,
+		siteId: PropTypes.number.isRequired,
+		zoneId: PropTypes.number.isRequired,
 	};
 
 	componentWillMount() {
@@ -29,7 +29,7 @@ class QueryFeed extends PureComponent {
 		this.requestFeed( nextProps );
 	}
 
-	requestFeed = props => props.siteId && props.zoneId && props.requestFeed( props.siteId, props.zoneId );
+	requestFeed = props => props.requestFeed( props.siteId, props.zoneId );
 
 	render() {
 		return null;

--- a/client/extensions/zoninator/components/forms/zone-content-form/index.jsx
+++ b/client/extensions/zoninator/components/forms/zone-content-form/index.jsx
@@ -22,12 +22,11 @@ class ZoneContentForm extends PureComponent {
 		handleSubmit: PropTypes.func.isRequired,
 		label: PropTypes.string.isRequired,
 		onSubmit: PropTypes.func.isRequired,
-		siteId: PropTypes.number,
 		submitting: PropTypes.bool.isRequired,
 		translate: PropTypes.func.isRequired,
 	}
 
-	save = data => this.props.onSubmit( this.props.siteId, form, data );
+	save = data => this.props.onSubmit( form, data );
 
 	render() {
 		const {
@@ -57,7 +56,10 @@ class ZoneContentForm extends PureComponent {
 	}
 }
 
-const createReduxForm = reduxForm( { form } );
+const createReduxForm = reduxForm( {
+	enableReinitialize: true,
+	form,
+} );
 
 export default flowRight(
 	localize,

--- a/client/extensions/zoninator/components/forms/zone-content-form/post-card.jsx
+++ b/client/extensions/zoninator/components/forms/zone-content-form/post-card.jsx
@@ -20,7 +20,7 @@ class PostCard extends Component {
 		editorPath: PropTypes.string.isRequired,
 		post: PropTypes.shape( {
 			title: PropTypes.string.isRequired,
-			URL: PropTypes.string.isRequired,
+			url: PropTypes.string.isRequired,
 		} ).isRequired,
 		remove: PropTypes.func.isRequired,
 	};
@@ -33,7 +33,7 @@ class PostCard extends Component {
 	render() {
 		const {
 			editorPath,
-			post: { URL, title },
+			post: { url, title },
 			remove,
 			translate,
 		} = this.props;
@@ -45,7 +45,7 @@ class PostCard extends Component {
 				<Button
 					compact
 					onMouseDown={ this.handleMouseDown }
-					href={ URL }
+					href={ url }
 					target="_blank">
 					{ translate( 'View' ) }
 				</Button>
@@ -68,7 +68,7 @@ class PostCard extends Component {
 }
 
 const connectComponent = connect( ( state, { post } ) => ( {
-	editorPath: getEditorPath( state, post.site_ID, post.ID ),
+	editorPath: getEditorPath( state, post.siteId, post.id ),
 } ) );
 
 export default flowRight(

--- a/client/extensions/zoninator/components/forms/zone-content-form/posts-list.jsx
+++ b/client/extensions/zoninator/components/forms/zone-content-form/posts-list.jsx
@@ -22,7 +22,12 @@ class PostsList extends Component {
 		translate: PropTypes.func.isRequired,
 	};
 
-	addPost = ( { push } ) => post => push( post );
+	addPost = ( { push } ) => post => push( {
+		id: post.ID,
+		siteId: post.site_ID,
+		title: post.title,
+		url: post.URL,
+	} );
 
 	removePost = ( { remove }, index ) => () => remove( index );
 
@@ -56,8 +61,8 @@ class PostsList extends Component {
 							'Add content to the zone by using search or by selecting it from the recent posts list below.'
 						) }
 					</p>
-					<SearchAutocomplete onSelect={ this.addPost( fields ) } exclude={ map( posts, post => post.ID ) }>
-						<RecentPostsDropdown onSelect={ this.addPost( fields ) } exclude={ map( posts, post => post.ID ) } />
+					<SearchAutocomplete onSelect={ this.addPost( fields ) } exclude={ map( posts, post => post.id ) }>
+						<RecentPostsDropdown onSelect={ this.addPost( fields ) } exclude={ map( posts, post => post.id ) } />
 					</SearchAutocomplete>
 				</FormFieldset>
 

--- a/client/extensions/zoninator/components/forms/zone-details-form/index.jsx
+++ b/client/extensions/zoninator/components/forms/zone-details-form/index.jsx
@@ -69,6 +69,10 @@ const createReduxForm = reduxForm( {
 	validate: ( data, { translate } ) => {
 		const errors = {};
 
+		if ( ! /[a-z0-9]/i.test( data.name ) ) {
+			errors.name = translate( 'Zone name must contain at least one alphanumeric character.' );
+		}
+
 		if ( ! data.name ) {
 			errors.name = translate( 'Zone name cannot be empty.' );
 		}

--- a/client/extensions/zoninator/components/forms/zone-details-form/index.jsx
+++ b/client/extensions/zoninator/components/forms/zone-details-form/index.jsx
@@ -5,7 +5,7 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { reduxForm } from 'redux-form';
 import { localize } from 'i18n-calypso';
-import { flowRight } from 'lodash';
+import { flowRight, mapValues, trim } from 'lodash';
 
 /**
  * Internal dependencies
@@ -28,7 +28,7 @@ class ZoneDetailsForm extends PureComponent {
 		translate: PropTypes.func.isRequired,
 	}
 
-	save = data => this.props.onSubmit( form, data );
+	save = data => this.props.onSubmit( form, mapValues( data, trim ) );
 
 	render() {
 		const {

--- a/client/extensions/zoninator/components/forms/zone-details-form/index.jsx
+++ b/client/extensions/zoninator/components/forms/zone-details-form/index.jsx
@@ -24,12 +24,11 @@ class ZoneDetailsForm extends PureComponent {
 		handleSubmit: PropTypes.func.isRequired,
 		label: PropTypes.string.isRequired,
 		onSubmit: PropTypes.func.isRequired,
-		siteId: PropTypes.number,
 		submitting: PropTypes.bool.isRequired,
 		translate: PropTypes.func.isRequired,
 	}
 
-	save = data => this.props.onSubmit( this.props.siteId, form, data );
+	save = data => this.props.onSubmit( form, data );
 
 	render() {
 		const {
@@ -65,6 +64,7 @@ class ZoneDetailsForm extends PureComponent {
 }
 
 const createReduxForm = reduxForm( {
+	enableReinitialize: true,
 	form,
 	validate: ( data, { translate } ) => {
 		const errors = {};

--- a/client/extensions/zoninator/components/settings/zone-creator/index.jsx
+++ b/client/extensions/zoninator/components/settings/zone-creator/index.jsx
@@ -28,7 +28,7 @@ class ZoneCreator extends PureComponent {
 	save = ( form, data ) => this.props.addZone( this.props.siteId, form, data );
 
 	render() {
-		const { siteId, siteSlug, translate } = this.props;
+		const { siteSlug, translate } = this.props;
 
 		return (
 			<div>
@@ -36,7 +36,7 @@ class ZoneCreator extends PureComponent {
 					{ translate( 'Add a zone' ) }
 				</HeaderCake>
 
-				<ZoneDetailsForm label={ translate( 'New zone' ) } siteId={ siteId } onSubmit={ this.save } />
+				<ZoneDetailsForm label={ translate( 'New zone' ) } onSubmit={ this.save } />
 			</div>
 		);
 	}

--- a/client/extensions/zoninator/components/settings/zone-creator/index.jsx
+++ b/client/extensions/zoninator/components/settings/zone-creator/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
@@ -16,34 +16,38 @@ import ZoneDetailsForm from '../../forms/zone-details-form';
 import { addZone } from '../../../state/zones/actions';
 import { settingsPath } from '../../../app/util';
 
-const ZoneCreator = ( {
-	saveZone,
-	siteId,
-	siteSlug,
-	translate,
-} ) => (
-	<div>
-		<HeaderCake backHref={ `${ settingsPath }/${ siteSlug }` }>
-			{ translate( 'Add a zone' ) }
-		</HeaderCake>
+class ZoneCreator extends PureComponent {
 
-		<ZoneDetailsForm label={ translate( 'New zone' ) } siteId={ siteId } onSubmit={ saveZone } />
-	</div>
-);
+	static propTypes = {
+		addZone: PropTypes.func.isRequired,
+		siteId: PropTypes.number,
+		siteSlug: PropTypes.string,
+		translate: PropTypes.func.isRequired,
+	}
 
-ZoneCreator.propTypes = {
-	siteId: PropTypes.number,
-	siteSlug: PropTypes.string,
-	saveZone: PropTypes.func.isRequired,
-	translate: PropTypes.func.isRequired,
-};
+	save = ( form, data ) => this.props.addZone( this.props.siteId, form, data );
+
+	render() {
+		const { siteId, siteSlug, translate } = this.props;
+
+		return (
+			<div>
+				<HeaderCake backHref={ `${ settingsPath }/${ siteSlug }` }>
+					{ translate( 'Add a zone' ) }
+				</HeaderCake>
+
+				<ZoneDetailsForm label={ translate( 'New zone' ) } siteId={ siteId } onSubmit={ this.save } />
+			</div>
+		);
+	}
+}
 
 const connectComponent = connect(
 	state => ( {
 		siteId: getSelectedSiteId( state ),
 		siteSlug: getSelectedSiteSlug( state ),
 	} ),
-	{ saveZone: addZone },
+	{ addZone },
 );
 
 export default flowRight(

--- a/client/extensions/zoninator/components/settings/zone/index.jsx
+++ b/client/extensions/zoninator/components/settings/zone/index.jsx
@@ -26,6 +26,8 @@ import { settingsPath } from '../../../app/util';
 class Zone extends Component {
 
 	static propTypes = {
+		deleteZone: PropTypes.func.isRequired,
+		feed: PropTypes.array,
 		saveFeed: PropTypes.func.isRequired,
 		saveZone: PropTypes.func.isRequired,
 		siteId: PropTypes.number,

--- a/client/extensions/zoninator/components/settings/zone/index.jsx
+++ b/client/extensions/zoninator/components/settings/zone/index.jsx
@@ -55,7 +55,7 @@ class Zone extends Component {
 
 		return (
 			<div>
-				<QueryFeed siteId={ siteId } zoneId={ zoneId } />
+				{ siteId && zoneId && <QueryFeed siteId={ siteId } zoneId={ zoneId } /> }
 
 				<HeaderCake
 					backHref={ `${ settingsPath }/${ siteSlug }` }

--- a/client/extensions/zoninator/state/data-layer/feeds/util.js
+++ b/client/extensions/zoninator/state/data-layer/feeds/util.js
@@ -6,5 +6,5 @@ export const fromApi = ( posts, siteId ) => posts.map( post => ( {
 } ) );
 
 export const toApi = posts => ( {
-	post_ids: posts.map( post => post.ID ),
+	post_ids: posts.map( post => post.id ),
 } );

--- a/client/extensions/zoninator/state/data-layer/zones/index.js
+++ b/client/extensions/zoninator/state/data-layer/zones/index.js
@@ -86,9 +86,7 @@ export const saveZone = ( { dispatch }, action ) => {
 	}, action ) );
 };
 
-export const announceZoneSaved = ( dispatch, { form, siteId }, data ) => {
-	const zone = fromApi( data );
-
+export const announceZoneSaved = ( dispatch, { form, siteId }, zone ) => {
 	dispatch( stopSubmit( form ) );
 	dispatch( updateZone( siteId, zone.id, zone ) );
 	dispatch( successNotice(
@@ -101,7 +99,7 @@ export const handleZoneCreated = ( { dispatch, getState }, action, response ) =>
 	const { siteId } = action;
 
 	page( `/extensions/zoninator/${ getSiteSlug( getState(), siteId ) }` );
-	announceZoneSaved( dispatch, action, response.data );
+	announceZoneSaved( dispatch, action, fromApi( response.data ) );
 };
 
 export const handleZoneSaved = ( { dispatch, getState }, action ) => {

--- a/client/extensions/zoninator/state/data-layer/zones/test/index.js
+++ b/client/extensions/zoninator/state/data-layer/zones/test/index.js
@@ -44,7 +44,8 @@ const apiResponse = {
 
 const zone = {
 	term_id: 43,
-	none: 'New zone',
+	name: 'New zone',
+	slug: 'new-zone',
 	description: 'A new zone',
 };
 
@@ -225,9 +226,13 @@ describe( '#announceZoneSaved()', () => {
 			form: 'form',
 		};
 
-		announceZoneSaved( dispatch, action, zone );
+		announceZoneSaved( dispatch, action, fromApi( zone ) );
 
-		expect( dispatch ).to.have.been.calledWith( updateZone( 123456, zone.term_id, fromApi( zone ) ) );
+		expect( dispatch ).to.have.been.calledWith(	updateZone(
+			123456,
+			zone.term_id,
+			fromApi( zone ),
+		) );
 	} );
 
 	it( 'should dispatch `successNotice`', () => {


### PR DESCRIPTION
This PR makes the edit zone view of the zoninator extension fully functional.  
Depends on #17786.

![screen shot 2017-09-05 at 14 46 52](https://user-images.githubusercontent.com/8056203/30062173-7c355c68-924a-11e7-956a-cc4c2fd4bd7b.png)

# Testing

Requires latest Zoninator changes from `add/rest-api` branch.

Open the extension at `/extensions/zoninator` and create some test zones if necessary.

- Select a zone and open its settings ( edit zone view ) - zone details should be immediately available and zone posts ( if any ) should follow.
- Click `Delete` and `Delete` on the confirmation dialog again. You should be redirected to zones dashboard, a success notification should appear and the zone should be removed from the list.
- Select another zone and make sure its data is loaded correctly.
- Change the zone name and description and click save. A success notification should appear. The changes should be reflected on zones dashboard if you click `back`.
- Add some posts to the zone and click save. A success notification should appear. The same posts should appear after reopening/reloading the page.
- Rearrange the posts for the zone and click save. A success notification should appear. Make sure the order is properly persisted.
- Try removing a post from the zone and click save. Expect a success notification and the remaining posts to be persisted.
- Feel free to try any combinations of the three last steps that come to mind - the result should be the same.