### PR TITLE
Plugins: move "Upload Plugin" button to the navigation bar

### DIFF
--- a/client/components/header-button/style.scss
+++ b/client/components/header-button/style.scss
@@ -1,30 +1,14 @@
 .header-button {
 	align-items: center;
-	border: 1px solid transparentize( lighten( $gray, 20% ), 0.5 );
-	border-width: 0 1px 0 0;
+	border: none;
 	border-radius: 0;
 	display: flex;
 	flex-direction: column;
 	font-weight: normal;
 	justify-content: center;
+	min-width: 140px;
 	min-height: 46px;
-	width: 50%;
 	padding: 0 16px;
-
-	@include breakpoint( '>480px' ) {
-		border: 0;
-		flex: 0 0 auto;
-		min-width: 140px;
-		width: auto;
-	}
-
-	&:hover {
-		border-color: transparentize( lighten( $gray, 20% ), 0.5 );
-	}
-
-	&:active {
-		border-width: 0 1px 0 0;
-	}
 }
 
 .header-button__text {

--- a/client/components/header-button/style.scss
+++ b/client/components/header-button/style.scss
@@ -11,6 +11,10 @@
 	padding: 0 16px;
 }
 
+.header-button .gridicon.gridicons-cloud-upload {
+	top: 6px;
+}
+
 .header-button__text {
 	margin-top: 3px;
 	white-space: nowrap;

--- a/client/components/header-button/style.scss
+++ b/client/components/header-button/style.scss
@@ -9,6 +9,10 @@
 	min-width: 140px;
 	min-height: 46px;
 	padding: 0 16px;
+
+	&:hover {
+		background-color: $gray-light;
+	}
 }
 
 .header-button .gridicon.gridicons-cloud-upload {

--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -45,6 +45,7 @@ import {
 	getSelectedSiteSlug
 } from 'state/ui/selectors';
 import HeaderButton from 'components/header-button';
+import { isEnabled } from 'config';
 
 const PluginsMain = React.createClass( {
 	mixins: [ URLSearch ],
@@ -368,15 +369,40 @@ const PluginsMain = React.createClass( {
 		this.props.recordGoogleEvent( 'Plugins', 'Clicked Add New Plugins' );
 	},
 
-	getAddPluginButton() {
-		const browserUrl = '/plugins/browse' + ( this.props.selectedSiteSlug ? '/' + this.props.selectedSiteSlug : '' );
+	renderAddPluginButton() {
+		const { selectedSiteSlug, translate } = this.props;
+		const browserUrl = '/plugins/browse' + ( selectedSiteSlug ? '/' + selectedSiteSlug : '' );
+
 		return (
 			<HeaderButton
 				icon="plus"
-				label={ this.props.translate( 'Add Plugin' ) }
-				aria-label={ this.props.translate( 'Browse all plugins', { context: 'button label' } ) }
+				label={ translate( 'Add Plugin' ) }
+				aria-label={ translate( 'Browse all plugins', { context: 'button label' } ) }
 				href={ browserUrl }
 				onClick={ this.handleAddPluginButtonClick }
+			/>
+		);
+	},
+
+	handleUploadPluginButtonClick() {
+		this.props.recordGoogleEvent( 'Plugins', 'Clicked Plugin Upload Link' );
+	},
+
+	renderUploadPluginButton() {
+		if ( ! isEnabled( 'manage/plugins/upload' ) ) {
+			return null;
+		}
+
+		const { selectedSiteSlug, translate } = this.props;
+		const uploadUrl = '/plugins/upload' + ( selectedSiteSlug ? '/' + selectedSiteSlug : '' );
+
+		return (
+			<HeaderButton
+				icon="cloud-upload"
+				label={ translate( 'Upload Plugin' ) }
+				aria-label={ translate( 'Upload Plugin' ) }
+				href={ uploadUrl }
+				onClick={ this.handleUploadPluginButtonClick }
 			/>
 		);
 	},
@@ -421,7 +447,6 @@ const PluginsMain = React.createClass( {
 			);
 		}
 
-		const addPluginButton = this.getAddPluginButton();
 		const navItems = this.getFilters().map( filterItem => {
 			if ( 'updates' === filterItem.id && ! this.getUpdatesTabVisibility() ) {
 				return null;
@@ -462,7 +487,10 @@ const PluginsMain = React.createClass( {
 							analyticsGroup="Plugins"
 							placeholder={ this.getSearchPlaceholder() } />
 					</SectionNav>
-					{ addPluginButton }
+					<div className="plugins__header-buttons">
+						{ this.renderAddPluginButton() }
+						{ this.renderUploadPluginButton() }
+					</div>
 				</div>
 				{ this.renderPluginsContent() }
 			</Main>

--- a/client/my-sites/plugins/plugin-list-header/index.jsx
+++ b/client/my-sites/plugins/plugin-list-header/index.jsx
@@ -19,7 +19,6 @@ import DropdownItem from 'components/select-dropdown/item';
 import DropdownSeparator from 'components/select-dropdown/separator';
 import BulkSelect from 'components/bulk-select';
 import analytics from 'lib/analytics';
-import { isEnabled } from 'config';
 
 // Constants help determine if the action bar should be a dropdown
 const MAX_ACTIONBAR_HEIGHT = 57;
@@ -91,10 +90,6 @@ export class PluginsListHeader extends PureComponent {
 		}
 	}
 
-	onUploadLinkClick = () => {
-		analytics.ga.recordEvent( 'Plugins', 'Clicked Plugin Upload Link' );
-	}
-
 	unselectOrSelectAll = () => {
 		const { plugins, selected } = this.props;
 		const someSelected = selected.length > 0;
@@ -153,24 +148,6 @@ export class PluginsListHeader extends PureComponent {
 					</Button>
 				</ButtonGroup>
 			);
-
-			if ( isEnabled( 'manage/plugins/upload' ) ) {
-				const uploadUrl = '/plugins/upload' + ( this.props.selectedSiteSlug ? '/' + this.props.selectedSiteSlug : '' );
-
-				rightSideButtons.push(
-					<ButtonGroup key="plugin-list-header__buttons-upload">
-						<Button
-							compact
-							href={ uploadUrl }
-							onClick={ this.onUploadLinkClick }
-							aria-label={ translate( 'Upload Plugin' ) }
-						>
-							<Gridicon icon="cloud-upload" size={ 18 } />
-							{ translate( 'Upload Plugin' ) }
-						</Button>
-					</ButtonGroup>
-				);
-			}
 		} else {
 			const updateButton = (
 				<Button

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -37,6 +37,19 @@
 
 .plugins__header-buttons {
 	display: flex;
+
+	.header-button {
+		flex: auto;
+		flex-basis: 0;
+
+		&:not( :last-child ) {
+			border-right: 1px solid transparentize( lighten( $gray, 20% ), 0.5 );
+		}
+
+		@include breakpoint( '>480px' ) {
+			flex: none;
+		}
+	}
 }
 
 .plugins__more-header {

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -35,6 +35,10 @@
 	}
 }
 
+.plugins__header-buttons {
+	display: flex;
+}
+
 .plugins__more-header {
 	font-size: 14px;
 	line-height: 2;


### PR DESCRIPTION
Use the `HeaderButton` component for the "Upload Plugin" button and move the button from the list header to the navigation bar.

The "Manage", "Add Plugin" and "Upload Plugin" now share the same location and style.

I also cleaned up the `HeaderButton` styling in the second commit. See the commit message for details. Cc @iamtakashi 

There's one more improvement I'd like to do in this PR before it's ready to merge: fine-tune the horizontal layout of the navigation bar. Using a `@media` breakpoint doesn't look like a good solution any more:

At width of 680px, the `SectionNav` is far too narrow and the bar should break into two lines:
<img width="682" alt="section-nav-at-680-px" src="https://user-images.githubusercontent.com/664258/30062357-2be4345e-924b-11e7-95b5-6fa9ab3bf026.png">

But at a **smaller** width of 650px, the `SectionNav` fits into available space just fine:
<img width="653" alt="section-nav-at-650-px" src="https://user-images.githubusercontent.com/664258/30062384-3f420ab2-924b-11e7-9267-e6b110d016b3.png">

I'd like to try out another approach: use `flex-wrap: wrap` to optionally wrap the bar into two lines, and specify the point where this happens by setting `min-width` on the `SectionNav`.

This PR continues the Plugins improvements work that was started in #17537.