### PR TITLE
Extensions: Zoninator - Enable the extension on staging

### DIFF
--- a/client/extensions/zoninator/package.json
+++ b/client/extensions/zoninator/package.json
@@ -3,7 +3,7 @@
 	"author": "Automattic",
 	"description": "Zone Manager (Zoninator)",
 	"version": "0.0.1",
-	"env_id": [ "development", "wpcalypso" ],
+	"env_id": [ "development", "wpcalypso", "stage" ],
 	"section": {
 		"name": "zoninator",
 		"paths": [ "/extensions/zoninator" ],


### PR DESCRIPTION
Enables the extension on staging.

Depends on:
- [x] #17786 
- [x] #17793.

Currently requires `add/update-zone` to be checked out on the server.