### PR TITLE
Update notice colors to pass WCAG AA guidelines

### DIFF
--- a/assets/stylesheets/shared/_colors.scss
+++ b/assets/stylesheets/shared/_colors.scss
@@ -32,9 +32,9 @@ $orange-jazzy:           #f0821e;
 $orange-fire:            #d54e21;
 
 // Alerts
-$alert-yellow:           #f0b849;
-$alert-red:              #d94f4f;
-$alert-green:            #4ab866;
+$alert-yellow:           #9D6400;
+$alert-red:              #A4302E;
+$alert-green:            #338449;
 $alert-purple:           #855DA6;
 
 // Link hovers

--- a/assets/stylesheets/shared/_colors.scss
+++ b/assets/stylesheets/shared/_colors.scss
@@ -32,9 +32,9 @@ $orange-jazzy:           #f0821e;
 $orange-fire:            #d54e21;
 
 // Alerts
-$alert-yellow:           #9D6400;
-$alert-red:              #A4302E;
-$alert-green:            #338449;
+$alert-yellow:           #f0b849;
+$alert-red:              #d94f4f;
+$alert-green:            #4ab866;
 $alert-purple:           #855DA6;
 
 // Link hovers

--- a/client/components/global-notices/style.scss
+++ b/client/components/global-notices/style.scss
@@ -35,17 +35,11 @@
 	text-align: left;
 	pointer-events: auto;
 	border-radius: 0;
-	align-items: baseline;
 	box-shadow: 0 2px 5px rgba( 0, 0, 0, 0.2 ),
 		0 0 56px rgba( 0, 0, 0, 0.15 );
 
 	.notice__icon-wrapper {
 		border-radius: 0;
-		align-items: baseline;
-
-		.gridicon {
-			margin-top: 10px;
-		}
 	}
 
 	@include breakpoint( ">660px" ) {
@@ -53,15 +47,9 @@
 		overflow: hidden;
 		margin-bottom: 24px;
 		border-radius: 3px;
-		align-items: center;
 
 		.notice__icon-wrapper {
 			border-radius: 3px 0 0 3px;
-			align-items: center;
-
-			.gridicon {
-				margin-top: 0;
-			}
 		}
 	}
 }
@@ -78,6 +66,6 @@
 	flex-shrink: 0;
 
 	@include breakpoint( ">660px" ) {
-		padding: 13px 16px;
+		padding: 13px 16px 0;
 	}
 }

--- a/client/components/global-notices/style.scss
+++ b/client/components/global-notices/style.scss
@@ -35,11 +35,17 @@
 	text-align: left;
 	pointer-events: auto;
 	border-radius: 0;
+	align-items: baseline;
 	box-shadow: 0 2px 5px rgba( 0, 0, 0, 0.2 ),
 		0 0 56px rgba( 0, 0, 0, 0.15 );
 
 	.notice__icon-wrapper {
 		border-radius: 0;
+		align-items: baseline;
+
+		.gridicon {
+			margin-top: 10px;
+		}
 	}
 
 	@include breakpoint( ">660px" ) {
@@ -47,20 +53,17 @@
 		overflow: hidden;
 		margin-bottom: 24px;
 		border-radius: 3px;
+		align-items: center;
 
 		.notice__icon-wrapper {
 			border-radius: 3px 0 0 3px;
+			align-items: center;
+
+			.gridicon {
+				margin-top: 0;
+			}
 		}
 	}
-}
-
-.global-notices .notice__icon {
-
-}
-
-.global-notices .notice__content {
-	flex-basis: auto;
-	flex-grow: 1;
 }
 
 .global-notices .notice a.notice__action {

--- a/client/components/global-notices/style.scss
+++ b/client/components/global-notices/style.scss
@@ -1,5 +1,4 @@
 .global-notices {
-	overflow: hidden;
 	text-align: right;
 	pointer-events: none;
 
@@ -35,36 +34,40 @@
 	margin-bottom: 0;
 	text-align: left;
 	pointer-events: auto;
+	border-radius: 0;
+	box-shadow: 0 2px 5px rgba( 0, 0, 0, 0.2 ),
+		0 0 56px rgba( 0, 0, 0, 0.15 );
+
+	.notice__icon-wrapper {
+		border-radius: 0;
+	}
 
 	@include breakpoint( ">660px" ) {
 		display: flex;
-		border-radius: 20px;
 		overflow: hidden;
 		margin-bottom: 24px;
+		border-radius: 3px;
+
+		.notice__icon-wrapper {
+			border-radius: 3px 0 0 3px;
+		}
 	}
 }
 
 .global-notices .notice__icon {
 
-	@include breakpoint( ">660px" ) {
-		padding: 8px 0 8px 16px;
-	}
 }
 
 .global-notices .notice__content {
 	flex-basis: auto;
 	flex-grow: 1;
-
-	@include breakpoint( ">660px" ) {
-		padding: 9px 13px;
-	}
 }
 
 .global-notices .notice a.notice__action {
 
 	@include breakpoint( ">660px" ) {
 		font-size: 14px;
-		padding: 9px 16px;
+		padding: 13px 16px;
 	}
 }
 
@@ -72,6 +75,6 @@
 	flex-shrink: 0;
 
 	@include breakpoint( ">660px" ) {
-		padding: 8px 16px;
+		padding: 13px 16px;
 	}
 }

--- a/client/components/notice/index.jsx
+++ b/client/components/notice/index.jsx
@@ -97,7 +97,9 @@ export class Notice extends Component {
 
 		return (
 			<div className={ classes }>
-				<Gridicon className="notice__icon" icon={ icon || this.getIcon() } size={ 24 } />
+				<span class="notice__icon-wrapper">
+					<Gridicon className="notice__icon" icon={ icon || this.getIcon() } size={ 24 } />
+				</span>
 				<span className="notice__content">
 					<span className="notice__text">
 						{ text ? text : children }

--- a/client/components/notice/index.jsx
+++ b/client/components/notice/index.jsx
@@ -97,7 +97,7 @@ export class Notice extends Component {
 
 		return (
 			<div className={ classes }>
-				<span class="notice__icon-wrapper">
+				<span className="notice__icon-wrapper">
 					<Gridicon className="notice__icon" icon={ icon || this.getIcon() } size={ 24 } />
 				</span>
 				<span className="notice__content">

--- a/client/components/notice/style.scss
+++ b/client/components/notice/style.scss
@@ -15,28 +15,28 @@
 	// Success!
 	&.is-success {
 		background: $alert-green;
-		color: darken( $alert-green, 35 );
+		color: darken( $alert-green, 40 );
 
 		.notice__text a {
-			color: darken( $alert-green, 38 );
+			color: darken( $alert-green, 43 );
 		}
 
 		.notice__dismiss {
-			color: darken( $alert-green, 35 );
+			color: darken( $alert-green, 40 );
 		}
 	}
 
 	// Warning
 	&.is-warning {
 		background: $alert-yellow;
-		color: darken( $alert-yellow, 45 );
+		color: darken( $alert-yellow, 48 );
 
 		.notice__text a {
-			color: darken( $alert-yellow, 49 );
+			color: darken( $alert-yellow, 51 );
 		}
 
 		.notice__dismiss {
-			color: darken( $alert-yellow, 45 );
+			color: darken( $alert-yellow, 48 );
 		}
 	}
 
@@ -56,15 +56,15 @@
 
 	// General notice
 	&.is-info {
-		background: $blue-wordpress;
-		color: darken( $blue-wordpress, 32 );
+		background: $blue-medium;
+		color: darken( $blue-medium, 35 );
 
 		.notice__text a {
-			color: darken( $blue-wordpress, 35 );
+			color: darken( $blue-medium, 38 );
 		}
 
 		.notice__dismiss {
-			color: darken( $blue-wordpress, 32 );
+			color: darken( $blue-medium, 35 );
 		}
 	}
 

--- a/client/components/notice/style.scss
+++ b/client/components/notice/style.scss
@@ -14,62 +14,62 @@
 
 	// Success!
 	&.is-success {
-		background: lighten( $alert-green, 25 );
-		color: darken( $alert-green, 30 );
+		background: $alert-green;
+		color: darken( $alert-green, 35 );
 
 		.notice__text a {
-			color: darken( $alert-green, 30 );
+			color: darken( $alert-green, 38 );
 		}
 
 		.notice__dismiss {
-			color: darken( $alert-green, 30 );
-			overflow: hidden;
+			color: darken( $alert-green, 35 );
 		}
 	}
 
 	// Warning
 	&.is-warning {
-		background: lighten( $alert-yellow, 15 );
-		color: darken( $alert-yellow, 40 );
+		background: $alert-yellow;
+		color: darken( $alert-yellow, 45 );
 
 		.notice__text a {
-			color: darken( $alert-yellow, 40 );
+			color: darken( $alert-yellow, 49 );
 		}
 
 		.notice__dismiss {
-			color: darken( $alert-yellow, 40 );
-			overflow: hidden;
+			color: darken( $alert-yellow, 45 );
 		}
 	}
 
 	// Error! OHNO!
 	&.is-error {
-		background: lighten( $alert-red, 10 );
-		color: darken( $alert-red, 40 );
+		background: $alert-red;
+		color: darken( $alert-red, 48 );
 
 		.notice__text a {
-			color: darken( $alert-red, 40 );
+			color: darken( $alert-red, 51 );
 		}
 
 		.notice__dismiss {
-			color: darken( $alert-red, 40 );
-			overflow: hidden;
+			color: darken( $alert-red, 48 );
 		}
 	}
 
 	// General notice
 	&.is-info {
 		background: $blue-wordpress;
-		color: $white;
+		color: darken( $blue-wordpress, 32 );
 
 		.notice__text a {
-			color: $white;
+			color: darken( $blue-wordpress, 35 );
 		}
 
 		.notice__dismiss {
-			color: $white;
-			overflow: hidden;
+			color: darken( $blue-wordpress, 32 );
 		}
+	}
+
+	.notice__dismiss {
+		overflow: hidden;
 	}
 
 	&.is-success,

--- a/client/components/notice/style.scss
+++ b/client/components/notice/style.scss
@@ -14,28 +14,52 @@
 
 	// Success!
 	&.is-success {
-		background: $alert-green;
+		background: lighten( $alert-green, 25 );
+		color: darken( $alert-green, 30 );
+
+		.notice__text a {
+			color: darken( $alert-green, 30 );
+		}
+
+		.notice__dismiss {
+			color: darken( $alert-green, 30 );
+			overflow: hidden;
+		}
 	}
 
 	// Warning
 	&.is-warning {
-		background: $alert-yellow;
+		background: lighten( $alert-yellow, 15 );
+		color: darken( $alert-yellow, 40 );
+
+		.notice__text a {
+			color: darken( $alert-yellow, 40 );
+		}
+
+		.notice__dismiss {
+			color: darken( $alert-yellow, 40 );
+			overflow: hidden;
+		}
 	}
 
 	// Error! OHNO!
 	&.is-error {
-		background: $alert-red;
+		background: lighten( $alert-red, 10 );
+		color: darken( $alert-red, 40 );
+
+		.notice__text a {
+			color: darken( $alert-red, 40 );
+		}
+
+		.notice__dismiss {
+			color: darken( $alert-red, 40 );
+			overflow: hidden;
+		}
 	}
 
 	// General notice
 	&.is-info {
 		background: $blue-wordpress;
-	}
-
-	&.is-success,
-	&.is-error,
-	&.is-warning,
-	&.is-info {
 		color: $white;
 
 		.notice__text a {
@@ -44,6 +68,15 @@
 
 		.notice__dismiss {
 			color: $white;
+			overflow: hidden;
+		}
+	}
+
+	&.is-success,
+	&.is-error,
+	&.is-warning,
+	&.is-info {
+		.notice__dismiss {
 			overflow: hidden;
 		}
 	}
@@ -192,10 +225,24 @@ a.notice__action {
 		color: $white;
 	}
 
-	.is-success & { background: darken( $alert-green, 15 ); }
-	.is-error & { background: darken( $alert-red, 15 ); }
-	.is-warning & { background: darken( $alert-yellow, 15 ); }
-	.is-info & { background: darken( $blue-wordpress, 15 ); }
+	.is-success & {
+		background: lighten( $alert-green, 20 );
+		color: darken( $alert-green, 30 );
+	}
+
+	.is-error & {
+		background: lighten( $alert-red, 5 );
+		color: darken( $alert-red, 40 );
+	}
+
+	.is-warning & {
+		background: lighten( $alert-yellow, 10 );
+		color: darken( $alert-yellow, 40 );
+	}
+
+	.is-info & {
+		background: darken( $blue-wordpress, 15 );
+	}
 
 	.gridicon {
 		margin-left: 8px;

--- a/client/components/notice/style.scss
+++ b/client/components/notice/style.scss
@@ -9,6 +9,7 @@
 	background: $gray-dark;
 	color: $white;
 	border-radius: 3px;
+	align-items: center;
 
 	@include breakpoint( ">480px" ) {
 		flex-direction: row;
@@ -65,6 +66,7 @@
 	justify-content: center;
 	border-radius: 3px 0 0 3px;
 	flex-shrink: 0;
+	align-self: stretch;
 }
 
 .notice__content {

--- a/client/components/notice/style.scss
+++ b/client/components/notice/style.scss
@@ -1,12 +1,14 @@
 .notice {
 	display: flex;
-		flex-direction: column;
+	flex-direction: column;
 	position: relative;
 	width: 100%;
 	margin-bottom: 24px;
-	background: lighten( $gray, 30 );
 	box-sizing: border-box;
 	animation: appear .3s ease-in-out;
+	background: $gray-dark;
+	color: $white;
+	border-radius: 3px;
 
 	@include breakpoint( ">480px" ) {
 		flex-direction: row;
@@ -14,57 +16,29 @@
 
 	// Success!
 	&.is-success {
-		background: $alert-green;
-		color: darken( $alert-green, 40 );
-
-		.notice__text a {
-			color: darken( $alert-green, 43 );
-		}
-
-		.notice__dismiss {
-			color: darken( $alert-green, 40 );
+		.notice__icon-wrapper {
+			background: $alert-green;
 		}
 	}
 
 	// Warning
 	&.is-warning {
-		background: $alert-yellow;
-		color: darken( $alert-yellow, 48 );
-
-		.notice__text a {
-			color: darken( $alert-yellow, 51 );
-		}
-
-		.notice__dismiss {
-			color: darken( $alert-yellow, 48 );
+		.notice__icon-wrapper {
+			background: $alert-yellow;
 		}
 	}
 
 	// Error! OHNO!
 	&.is-error {
-		background: $alert-red;
-		color: darken( $alert-red, 48 );
-
-		.notice__text a {
-			color: darken( $alert-red, 51 );
-		}
-
-		.notice__dismiss {
-			color: darken( $alert-red, 48 );
+		.notice__icon-wrapper {
+			background: $alert-red;
 		}
 	}
 
 	// General notice
 	&.is-info {
-		background: $blue-medium;
-		color: darken( $blue-medium, 35 );
-
-		.notice__text a {
-			color: darken( $blue-medium, 38 );
-		}
-
-		.notice__dismiss {
-			color: darken( $blue-medium, 35 );
+		.notice__icon-wrapper {
+			background: $blue-medium;
 		}
 	}
 
@@ -82,22 +56,15 @@
 	}
 }
 
-.notice__icon {
-	position: absolute;
-		top: 0;
-		left: 0;
+.notice__icon-wrapper {
+	background: $gray-text-min;
+	color: $white;
 	display: flex;
-		flex-shrink: 0;
-	width: 18px;
-	height: 18px;
-	padding: 14px 16px;
-
-	@include breakpoint( ">480px" ) {
-		position: relative;
-		padding: 13px 0px 13px 16px;
-		width: 24px;
-		height: 24px;
-	}
+	align-items: center;
+	width: 47px;
+	justify-content: center;
+	border-radius: 3px 0 0 3px;
+	flex-shrink: 0;
 }
 
 .notice__content {
@@ -117,6 +84,7 @@
 
 	a {
 		text-decoration: underline;
+		color: $white;
 	}
 
 	ul {
@@ -153,7 +121,6 @@
 		flex-shrink: 0;
 	padding: 14px 16px;
 	cursor: pointer;
-	color: $gray;
 
 	.gridicon {
 		width: 18px;
@@ -170,18 +137,12 @@
 		}
 	}
 
-	&:hover,
-	&:focus {
-		color: $gray-dark;
-	}
-
 	.notice & {
-		color: $gray;
-		opacity: 0.85;
+		color: lighten( $gray, 10% );
 
 		&:hover,
 		&:focus {
-			opacity: 1;
+			color: $white;
 		}
 	}
 }
@@ -195,13 +156,12 @@ a.notice__action {
 	box-sizing: border-box;
 	margin: 0 8px 8px 8px;
 	padding: 8px;
-	border-radius: 3px;
 	cursor: pointer;
 	font-size: 12px;
 	font-weight: 400;
 	text-decoration: none;
 	white-space: nowrap;
-	background: lighten( $gray, 28 );
+	color: lighten( $gray, 10% );
 
 	@include breakpoint( ">480px" ) {
 			flex-shrink: 1;
@@ -218,30 +178,8 @@ a.notice__action {
 		}
 	}
 
-	.is-success &,
-	.is-error &,
-	.is-warning &,
-	.is-info & {
+	&:hover {
 		color: $white;
-	}
-
-	.is-success & {
-		background: lighten( $alert-green, 20 );
-		color: darken( $alert-green, 30 );
-	}
-
-	.is-error & {
-		background: lighten( $alert-red, 5 );
-		color: darken( $alert-red, 40 );
-	}
-
-	.is-warning & {
-		background: lighten( $alert-yellow, 10 );
-		color: darken( $alert-yellow, 40 );
-	}
-
-	.is-info & {
-		background: darken( $blue-wordpress, 15 );
 	}
 
 	.gridicon {
@@ -249,11 +187,6 @@ a.notice__action {
 		opacity: 0.7;
 		width: 18px;
 		height: 18px;
-	}
-
-	&:hover,
-	&:focus {
-		background: rgba( 255, 255, 255, 0.2 );
 	}
 }
 
@@ -263,20 +196,13 @@ a.notice__action {
 		flex-wrap: nowrap;
 		flex-direction: row;
 	width: auto;
-	border-radius: 2px;
+	border-radius: 3px;
 	min-height: 20px;
 	margin: 0;
 	padding: 0;
 	text-decoration: none;
 	text-transform: none;
 	vertical-align: middle;
-
-	&.is-success,
-	&.is-error,
-	&.is-warning,
-	&.is-info {
-		color: $white;
-	}
 
 	.notice__content {
 		font-size: 12px;
@@ -287,15 +213,13 @@ a.notice__action {
 		line-height: 1;
 	}
 
-	.notice__icon {
-		position: relative;
-		align-self: center;
-		flex-shrink: 0;
-		margin: 0 0 0 8px;
-		padding: 0;
-		width: 18px;
-		height: 18px;
-		vertical-align: middle;
+	.notice__icon-wrapper {
+		width: 24px;
+
+		.notice__icon {
+			width: 18px;
+			height: 18px;
+		}
 	}
 
 	.notice__dismiss {

--- a/client/components/notice/style.scss
+++ b/client/components/notice/style.scss
@@ -8,7 +8,6 @@
 	background: $gray-dark;
 	color: $white;
 	border-radius: 3px;
-	align-items: center;
 
 	// Success!
 	&.is-success {
@@ -56,12 +55,20 @@
 	background: $gray-text-min;
 	color: $white;
 	display: flex;
-	align-items: center;
+	align-items: baseline;
 	width: 47px;
 	justify-content: center;
 	border-radius: 3px 0 0 3px;
 	flex-shrink: 0;
 	align-self: stretch;
+
+	.gridicon {
+		margin-top: 10px;
+
+		@include breakpoint( ">480px" ) {
+			margin-top: 12px;
+		}
+	}
 }
 
 .notice__content {
@@ -109,13 +116,10 @@
 
 // "X" for dismissing a notice
 .notice__dismiss {
-	position: absolute;
-		top: 0;
-		right: 0;
-	display: flex;
-		flex-shrink: 0;
-	padding: 14px 16px;
+	flex-shrink: 0;
+	padding: 12px;
 	cursor: pointer;
+	padding-bottom: 0;
 
 	.gridicon {
 		width: 18px;
@@ -123,8 +127,8 @@
 	}
 
 	@include breakpoint( ">480px" ) {
-		position: relative;
-		padding: 13px 16px;
+		padding: 11px;
+		padding-bottom: 0;
 
 		.gridicon {
 			width: 24px;
@@ -151,7 +155,6 @@ a.notice__action {
 	white-space: nowrap;
 	color: lighten( $gray, 10% );
 	padding: 13px;
-	margin-right: 50px;
 
 	@include breakpoint( ">480px" ) {
 			flex-shrink: 1;

--- a/client/components/notice/style.scss
+++ b/client/components/notice/style.scss
@@ -1,6 +1,5 @@
 .notice {
 	display: flex;
-	flex-direction: column;
 	position: relative;
 	width: 100%;
 	margin-bottom: 24px;
@@ -10,10 +9,6 @@
 	color: $white;
 	border-radius: 3px;
 	align-items: center;
-
-	@include breakpoint( ">480px" ) {
-		flex-direction: row;
-	}
 
 	// Success!
 	&.is-success {
@@ -70,14 +65,12 @@
 }
 
 .notice__content {
-	display: flex;
-		flex-grow: 1;
-	padding: 14px 48px;
+	padding: 13px;
 	font-size: 12px;
+	flex-grow: 1;
 
 	@include breakpoint( ">480px" ) {
 		font-size: 14px;
-		padding: 13px;
 	}
 }
 
@@ -151,19 +144,14 @@
 
 // specificity for general `a` elements within notice is too great
 a.notice__action {
-	display: flex;
-		justify-content: center;
-		flex-shrink: 0;
-		flex-grow: 1;
-	box-sizing: border-box;
-	margin: 0 8px 8px 8px;
-	padding: 8px;
 	cursor: pointer;
 	font-size: 12px;
 	font-weight: 400;
 	text-decoration: none;
 	white-space: nowrap;
 	color: lighten( $gray, 10% );
+	padding: 13px;
+	margin-right: 50px;
 
 	@include breakpoint( ">480px" ) {
 			flex-shrink: 1;


### PR DESCRIPTION
The contrast between white text and the colors used for the backgrounds of our notices do not meet WCAG AA guidelines for contrast ratio. This PR addresses that for success, error and warning notices. The blue notices use a brand color which will need more input before we change it.

Before:

![oldnotices](https://cldup.com/Y7ggyhopzr.png)

After:

![newnotices](https://cldup.com/BDYAifvyfb-3000x3000.png)

Clearly these colors are quite a bit darker and this does change the overall tone somewhat. If we wanted to keep lighter colors the only option really would be to use much lighter backgrounds with darker text colors. 