### PR TITLE
Devdocs: prevent requesting of comments in ConversationCommentList example

### DIFF
--- a/client/blocks/conversations/docs/example.jsx
+++ b/client/blocks/conversations/docs/example.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */

--- a/client/blocks/conversations/docs/example.jsx
+++ b/client/blocks/conversations/docs/example.jsx
@@ -22,6 +22,7 @@ const ConversationCommentListExample = () => {
 				commentIds={ [ 1, 2, 3 ] }
 				post={ post }
 				enableCaterpillar={ false }
+				shouldRequestComments={ false }
 			/>
 		</div>
 	);

--- a/client/blocks/conversations/docs/fixtures.js
+++ b/client/blocks/conversations/docs/fixtures.js
@@ -1,3 +1,4 @@
+/** @format */
 export const commentsTree = {
 	1: {
 		data: {
@@ -33,4 +34,5 @@ export const commentsTree = {
 			date: '2016-04-18T14:59:22+00:00',
 		},
 	},
+	children: [ 1, 2, 3 ],
 };

--- a/client/blocks/conversations/list.jsx
+++ b/client/blocks/conversations/list.jsx
@@ -27,10 +27,12 @@ export class ConversationCommentList extends React.Component {
 	static propTypes = {
 		post: PropTypes.object.isRequired, // required by PostComment
 		commentIds: PropTypes.array.isRequired,
+		shouldRequestComments: PropTypes.bool,
 	};
 
 	static defaultProps = {
 		enableCaterpillar: true,
+		shouldRequestComments: true,
 	};
 
 	state = {
@@ -64,7 +66,11 @@ export class ConversationCommentList extends React.Component {
 	};
 
 	reqMoreComments = ( props = this.props ) => {
-		const { siteId, postId, enableCaterpillar } = props;
+		const { siteId, postId, enableCaterpillar, shouldRequestComments } = props;
+
+		if ( ! shouldRequestComments || ! props.commentsFetchingStatus ) {
+			return;
+		}
 
 		const { haveEarlierCommentsToFetch, haveLaterCommentsToFetch } = props.commentsFetchingStatus;
 

--- a/client/blocks/reader-post-card/docs/example.jsx
+++ b/client/blocks/reader-post-card/docs/example.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
 * External dependencies
 */
@@ -13,13 +14,8 @@ const ReaderPostCard = () =>
 	<div className="design-assets__group">
 		<div>
 			{ posts.map( item =>
-				<ReaderPostCardBlock key={ item.global_ID } post={ item } site={ site } />,
+				<ReaderPostCardBlock key={ item.global_ID } post={ item } site={ site } />
 			) }
-			<ReaderPostCardBlock compact key={ posts[ 0 ].global_ID } post={ posts[ 0 ] } site={ site } postKey={ {
-				feedId: posts[0].feed_ID,
-				postId: posts[0].feed_item_ID,
-				comments: []
-			} } />
 		</div>
 	</div>;
 


### PR DESCRIPTION
@rachelmcr reported in https://github.com/Automattic/wp-calypso/issues/17753 that a block example is causing errors in Devdocs > Blocks.

This PR ensures that a comment request is not made for the ConversationCommentList example, and that the commentsTree from fixtures is used instead.

Fixes https://github.com/Automattic/wp-calypso/issues/17753.

Todo:
- [x] stop ConversationCommentList from firing a comment request on mount in the example
- [x] identify block making API request to https://public-api.wordpress.com/rest/v1.1/sites/1/posts/1/replies on Blocks index
- [x] fix display of comment fixtures for ConversationCommentList