### PR TITLE
Webpack: use minified versions of files in production

### DIFF
--- a/server/bundler/webpack-plugins/use-minified-files.js
+++ b/server/bundler/webpack-plugins/use-minified-files.js
@@ -1,0 +1,17 @@
+/** @format */
+
+/*
+ * modifies the require.ensure calls in production to point to .min.js instead of .js extension
+ */
+function UseMinifiedFiles() {}
+
+UseMinifiedFiles.prototype.apply = function( compiler ) {
+	compiler.plugin( 'compilation', function( compilation ) {
+		compilation.mainTemplate.plugin( 'require-ensure', function( source ) {
+			const newSrc = source.toString().replace( '.js"', '.min.js"' );
+			return this.asString( [ newSrc ] );
+		} );
+	} );
+};
+
+module.exports = UseMinifiedFiles;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -19,6 +19,7 @@ const NameAllModulesPlugin = require( 'name-all-modules-plugin' );
  */
 const cacheIdentifier = require( './server/bundler/babel/babel-loader-cache-identifier' );
 const config = require( './server/config' );
+const UseMinifiedFiles = require( './server/bundler/webpack-plugins/use-minified-files' );
 
 /**
  * Internal variables
@@ -234,6 +235,7 @@ if ( calypsoEnv === 'development' ) {
 		} );
 	}
 } else {
+	webpackConfig.plugins.push( new UseMinifiedFiles() );
 	webpackConfig.entry.build = path.join( __dirname, 'client', 'boot', 'app' );
 	webpackConfig.devtool = false;
 }


### PR DESCRIPTION
I introduced a regression in [this commit](https://github.com/Automattic/wp-calypso/pull/15623/files#diff-af0ff8f84f0c14d14267bd8ccd37db5fL36) where we no longer use minified versions of files for when files are loaded dynamically by the client.

This is because I replaced the custom require.ensure implementation with the default webpack one.  This left out the file extension transformation from `.js` --> `.min.js`.

This PR attempts to bring back minification without replacing the entire require.ensure function.
it does this via a naive `string.replace`

fixes https://github.com/Automattic/wp-calypso/issues/17797

To test:
- [x] local devserver build should work w/ no difference
- [x] docker builds should replace all .js with .min.js files