### PR TITLE
Activity log: Show "not authorized" to users without manage_options

### DIFF
--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -357,7 +357,7 @@ class ActivityLog extends Component {
 
 		if ( false === canViewActivityLog ) {
 			return (
-				<Main wideLayout>
+				<Main>
 					<SidebarNavigation />
 					<EmptyContent
 						title={ translate( 'You are not authorized to view this page' ) }

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -22,6 +22,7 @@ import ActivityLogRewindToggle from './activity-log-rewind-toggle';
 import DatePicker from 'my-sites/stats/stats-date-picker';
 import EmptyContent from 'components/empty-content';
 import ErrorBanner from '../activity-log-banner/error-banner';
+import JetpackColophon from 'components/jetpack-colophon';
 import Main from 'components/main';
 import ProgressBanner from '../activity-log-banner/progress-banner';
 import QueryActivityLog from 'components/data/query-activity-log';
@@ -32,8 +33,8 @@ import StatsFirstView from '../stats-first-view';
 import StatsNavigation from '../stats-navigation';
 import StatsPeriodNavigation from 'my-sites/stats/stats-period-navigation';
 import SuccessBanner from '../activity-log-banner/success-banner';
-import JetpackColophon from 'components/jetpack-colophon';
 import { adjustMoment } from './utils';
+import { canCurrentUser } from 'state/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSiteSlug, getSiteTitle } from 'state/sites/selectors';
 import { recordTracksEvent as recordTracksEventAction } from 'state/analytics/actions';
@@ -344,7 +345,28 @@ class ActivityLog extends Component {
 	}
 
 	render() {
-		const { isPressable, isRewindActive, siteId, siteTitle, slug } = this.props;
+		const {
+			canViewActivityLog,
+			isPressable,
+			isRewindActive,
+			siteId,
+			siteTitle,
+			slug,
+			translate,
+		} = this.props;
+
+		if ( false === canViewActivityLog ) {
+			return (
+				<Main wideLayout>
+					<SidebarNavigation />
+					<EmptyContent
+						title={ translate( 'You are not authorized to view this page' ) }
+						illustration={ '/calypso/images/illustrations/illustration-empty-results.svg' }
+					/>
+				</Main>
+			);
+		}
+
 		const startMoment = this.getStartMoment();
 		const { requestedRestoreTimestamp, showRestoreConfirmDialog } = this.state;
 
@@ -390,6 +412,7 @@ export default connect(
 		const siteId = getSelectedSiteId( state );
 
 		return {
+			canViewActivityLog: canCurrentUser( state, siteId, 'manage_options' ),
 			gmtOffset: getSiteGmtOffset( state, siteId ),
 			isRewindActive: isRewindActiveSelector( state, siteId ),
 			logs: getActivityLogs( state, siteId ),


### PR DESCRIPTION
Add a "Not authorized" view to the Activity Log for users who don't have `manage_options` capability.
As the entire "Stats" section appears to be hidden, I have made no changes to the navigation elements.

## Testing
1. Visit https://calypso.live/stats/activity?branch=add/activity-log/check-caps
1. There should be no change for users with `manage_options` (admins).
1. Users without the cap should see the "Not authorized" view.

## Screens

![no-auth](https://user-images.githubusercontent.com/841763/30071798-6cc361ee-9268-11e7-95c9-3a95d40f9386.png)
