### PR TITLE
Domain Only: Fix when conflicting Jetpack sites exist

### DIFF
--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -183,9 +183,12 @@ function isPathAllowedForDomainOnlySite( path, slug, primaryDomain ) {
 		domainManagementTransferToOtherSite
 	];
 
-	const domainManagementPaths = allPaths.map( pathFactory => pathFactory( slug, slug ) );
+	let domainManagementPaths = allPaths.map( pathFactory => pathFactory( slug, slug ) );
+
 	if ( primaryDomain && slug !== primaryDomain.name ) {
-		domainManagementPaths.concat( allPaths.map( pathFactory => pathFactory( slug, primaryDomain.name ) ) );
+		domainManagementPaths = domainManagementPaths.concat(
+			allPaths.map( pathFactory => pathFactory( slug, primaryDomain.name ) )
+		);
 	}
 
 	const otherPaths = [
@@ -217,6 +220,7 @@ function onSelectedSiteAvailable( context ) {
 	context.store.dispatch( setSelectedSiteId( selectedSite.ID ) );
 
 	const primaryDomain = getPrimaryDomainBySiteId( getState(), selectedSite.ID );
+
 	if ( isDomainOnlySite( getState(), selectedSite.ID ) &&
 		! isPathAllowedForDomainOnlySite( context.pathname, selectedSite.slug, primaryDomain ) ) {
 		renderSelectedSiteIsDomainOnly( context, selectedSite );

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -5,7 +5,7 @@ import page from 'page';
 import ReactDom from 'react-dom';
 import React from 'react';
 import i18n from 'i18n-calypso';
-import { union, uniq, some, startsWith } from 'lodash';
+import { uniq, some, startsWith } from 'lodash';
 
 /**
  * Internal Dependencies
@@ -183,13 +183,9 @@ function isPathAllowedForDomainOnlySite( path, slug, primaryDomain ) {
 		domainManagementTransferToOtherSite
 	];
 
-	let domainManagementPaths = allPaths.map( pathFactory => pathFactory( slug, slug ) );
-
+	const domainManagementPaths = allPaths.map( pathFactory => pathFactory( slug, slug ) );
 	if ( primaryDomain && slug !== primaryDomain.name ) {
-		domainManagementPaths = union(
-			domainManagementPaths,
-			allPaths.map( pathFactory => pathFactory( slug, primaryDomain.name ) )
-		);
+		domainManagementPaths.concat( allPaths.map( pathFactory => pathFactory( slug, primaryDomain.name ) ) );
 	}
 
 	const otherPaths = [

--- a/client/my-sites/current-site/domain-to-paid-plan-notice.jsx
+++ b/client/my-sites/current-site/domain-to-paid-plan-notice.jsx
@@ -18,6 +18,7 @@ import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
 import TrackComponentView from 'lib/analytics/track-component-view';
 import { recordTracksEvent } from 'state/analytics/actions';
+import { isDomainOnlySite } from 'state/selectors';
 
 const impressionEventName = 'calypso_upgrade_nudge_impression';
 const clickEventName = 'calypso_upgrade_nudge_cta_click';
@@ -37,11 +38,15 @@ export class DomainToPaidPlanNotice extends Component {
 	};
 
 	render() {
-		const { eligible, site, translate } = this.props;
+		const { eligible, isDomainOnly, site, translate } = this.props;
 
 		if ( ! site || ! eligible ) {
 			return null;
 		}
+
+		const actionLink = isDomainOnly
+			? `/start/site-selected/?siteSlug=${ encodeURIComponent( site.slug ) }&siteId=${ encodeURIComponent( site.ID ) }`
+			: `/plans/my-plan/${ site.slug }`;
 
 		return (
 			<Notice
@@ -51,7 +56,7 @@ export class DomainToPaidPlanNotice extends Component {
 				showDismiss={ false }
 				text={ translate( 'Upgrade your site and save.' ) }
 			>
-				<NoticeAction onClick={ this.onClick } href={ `/plans/my-plan/${ site.slug }` }>
+				<NoticeAction onClick={ this.onClick } href={ actionLink }>
 					{ translate( 'Go' ) }
 					<TrackComponentView
 						eventName={ impressionEventName }
@@ -64,9 +69,12 @@ export class DomainToPaidPlanNotice extends Component {
 }
 
 const mapStateToProps = ( state ) => {
+	const siteId = getSelectedSiteId( state );
+
 	return {
+		eligible: isEligibleForDomainToPaidPlanUpsell( state, siteId ),
+		isDomainOnly: isDomainOnlySite( state, siteId ),
 		site: getSelectedSite( state ),
-		eligible: isEligibleForDomainToPaidPlanUpsell( state, getSelectedSiteId( state ) ),
 	};
 };
 const mapDispatchToProps = { recordTracksEvent };

--- a/client/my-sites/current-site/domain-to-paid-plan-notice.jsx
+++ b/client/my-sites/current-site/domain-to-paid-plan-notice.jsx
@@ -6,14 +6,14 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import {
+	endsWith,
 	noop,
 } from 'lodash';
 
 /**
  * Internal dependencies
  */
-import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
-import { isSiteConflicting } from 'state/sites/selectors';
+import { getSelectedSite } from 'state/ui/selectors';
 import { isEligibleForDomainToPaidPlanUpsell } from 'state/selectors';
 import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
@@ -70,13 +70,14 @@ export class DomainToPaidPlanNotice extends Component {
 }
 
 const mapStateToProps = ( state ) => {
-	const siteId = getSelectedSiteId( state );
+	const site = getSelectedSite( state );
+	const isDomainOnly = isDomainOnlySite( state, site.ID );
 
 	return {
-		eligible: isEligibleForDomainToPaidPlanUpsell( state, siteId ),
-		isConflicting: isSiteConflicting( state, siteId ),
-		isDomainOnly: isDomainOnlySite( state, siteId ),
-		site: getSelectedSite( state ),
+		eligible: isEligibleForDomainToPaidPlanUpsell( state, site.ID ),
+		isConflicting: isDomainOnly && endsWith( site.domain, '.wordpress.com' ),
+		isDomainOnly,
+		site,
 	};
 };
 const mapDispatchToProps = { recordTracksEvent };

--- a/client/my-sites/current-site/domain-to-paid-plan-notice.jsx
+++ b/client/my-sites/current-site/domain-to-paid-plan-notice.jsx
@@ -13,6 +13,7 @@ import {
  * Internal dependencies
  */
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
+import { isSiteConflicting } from 'state/sites/selectors';
 import { isEligibleForDomainToPaidPlanUpsell } from 'state/selectors';
 import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
@@ -38,9 +39,9 @@ export class DomainToPaidPlanNotice extends Component {
 	};
 
 	render() {
-		const { eligible, isDomainOnly, site, translate } = this.props;
+		const { eligible, isConflicting, isDomainOnly, site, translate } = this.props;
 
-		if ( ! site || ! eligible ) {
+		if ( ! site || ! eligible || isConflicting ) {
 			return null;
 		}
 
@@ -73,6 +74,7 @@ const mapStateToProps = ( state ) => {
 
 	return {
 		eligible: isEligibleForDomainToPaidPlanUpsell( state, siteId ),
+		isConflicting: isSiteConflicting( state, siteId ),
 		isDomainOnly: isDomainOnlySite( state, siteId ),
 		site: getSelectedSite( state ),
 	};

--- a/client/my-sites/current-site/notice.jsx
+++ b/client/my-sites/current-site/notice.jsx
@@ -26,6 +26,7 @@ import {
 } from 'state/plugins/premium/selectors';
 import TrackComponentView from 'lib/analytics/track-component-view';
 import DomainToPaidPlanNotice from './domain-to-paid-plan-notice';
+import { isDomainOnlySite } from 'state/selectors';
 
 class SiteNotice extends React.Component {
 	static propTypes = {
@@ -35,7 +36,7 @@ class SiteNotice extends React.Component {
 	static defaultProps = {};
 
 	getSiteRedirectNotice( site ) {
-		if ( ! site ) {
+		if ( ! site || this.props.isDomainOnly ) {
 			return null;
 		}
 		if ( ! ( site.options && site.options.is_redirect ) ) {
@@ -150,6 +151,7 @@ class SiteNotice extends React.Component {
 export default connect( ( state, ownProps ) => {
 	const siteId = ownProps.site && ownProps.site.ID ? ownProps.site.ID : null;
 	return {
+		isDomainOnly: isDomainOnlySite( state, siteId ),
 		isEligibleForFreeToPaidUpsell: isEligibleForFreeToPaidUpsell( state, siteId, moment() ),
 		hasDomainCredit: hasDomainCredit( state, siteId ),
 		canManageOptions: canCurrentUser( state, siteId, 'manage_options' ),

--- a/client/my-sites/domains/domain-management/list/domain-only.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-only.jsx
@@ -29,7 +29,7 @@ const DomainOnly = ( { primaryDomain, hasNotice, siteId, slug, translate } ) => 
 				line={ translate( 'Start a site now to unlock everything WordPress.com can offer.' ) }
 				action={ translate( 'Create Site' ) }
 				actionURL={
-					`/start/site-selected/?siteSlug=${ encodeURIComponent( domainName ) }&siteId=${ encodeURIComponent( siteId ) }`
+					`/start/site-selected/?siteSlug=${ encodeURIComponent( slug ) }&siteId=${ encodeURIComponent( siteId ) }`
 				}
 				secondaryAction={ translate( 'Manage Domain' ) }
 				secondaryActionURL={ domainManagementEdit( slug, domainName ) }

--- a/client/my-sites/domains/domain-management/list/domain-only.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-only.jsx
@@ -17,7 +17,15 @@ import { getSiteSlug } from 'state/sites/selectors';
 
 const DomainOnly = ( { primaryDomain, hasNotice, siteId, slug, translate } ) => {
 	if ( ! primaryDomain ) {
-		return <QuerySiteDomains siteId={ siteId } />;
+		return (
+			<div>
+				<QuerySiteDomains siteId={ siteId } />
+				<EmptyContent
+					className={ 'domain-only-site__placeholder' }
+					illustration={ '/calypso/images/drake/drake-browser.svg' }
+				/>
+			</div>
+		);
 	}
 
 	const domainName = primaryDomain.name;
@@ -33,7 +41,8 @@ const DomainOnly = ( { primaryDomain, hasNotice, siteId, slug, translate } ) => 
 				}
 				secondaryAction={ translate( 'Manage Domain' ) }
 				secondaryActionURL={ domainManagementEdit( slug, domainName ) }
-				illustration={ '/calypso/images/drake/drake-browser.svg' } />
+				illustration={ '/calypso/images/drake/drake-browser.svg' }
+			/>
 			{ hasNotice && (
 				<div className="domain-only-site__settings-notice">
 					{ translate( 'Your domain should start working immediately, but may be unreliable during the first 72 hours.' ) }

--- a/client/my-sites/domains/domain-management/list/domain-only.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-only.jsx
@@ -1,38 +1,60 @@
 /**
  * External dependencies
  */
+import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 /**
  * Internal dependencies
  */
 import EmptyContent from 'components/empty-content';
+import QuerySiteDomains from 'components/data/query-site-domains';
 import { domainManagementEdit } from 'my-sites/domains/paths';
+import { getPrimaryDomainBySiteId } from 'state/sites/domains/selectors';
+import { getSiteSlug } from 'state/sites/selectors';
 
-const DomainOnly = ( { domainName, hasNotice, siteId, translate } ) => (
-	<div>
-		<EmptyContent
-			title={ translate( '%(domainName)s is ready when you are.', { args: { domainName } } ) }
-			line={ translate( 'Start a site now to unlock everything WordPress.com can offer.' ) }
-			action={ translate( 'Create Site' ) }
-			actionURL={ `/start/site-selected/?siteSlug=${ encodeURIComponent( domainName ) }&siteId=${ encodeURIComponent( siteId ) }` }
-			secondaryAction={ translate( 'Manage Domain' ) }
-			secondaryActionURL={ domainManagementEdit( domainName, domainName ) }
-			illustration={ '/calypso/images/drake/drake-browser.svg' } />
-		{ hasNotice && (
-			<div className="domain-only-site__settings-notice">
-				{ translate( 'Your domain should start working immediately, but may be unreliable during the first 72 hours.' ) }
-			</div>
-		) }
-	</div>
-);
+const DomainOnly = ( { primaryDomain, hasNotice, siteId, slug, translate } ) => {
+	if ( ! primaryDomain ) {
+		return <QuerySiteDomains siteId={ siteId } />;
+	}
+
+	const domainName = primaryDomain.name;
+
+	return (
+		<div>
+			<EmptyContent
+				title={ translate( '%(domainName)s is ready when you are.', { args: { domainName } } ) }
+				line={ translate( 'Start a site now to unlock everything WordPress.com can offer.' ) }
+				action={ translate( 'Create Site' ) }
+				actionURL={
+					`/start/site-selected/?siteSlug=${ encodeURIComponent( domainName ) }&siteId=${ encodeURIComponent( siteId ) }`
+				}
+				secondaryAction={ translate( 'Manage Domain' ) }
+				secondaryActionURL={ domainManagementEdit( slug, domainName ) }
+				illustration={ '/calypso/images/drake/drake-browser.svg' } />
+			{ hasNotice && (
+				<div className="domain-only-site__settings-notice">
+					{ translate( 'Your domain should start working immediately, but may be unreliable during the first 72 hours.' ) }
+				</div>
+			) }
+		</div>
+	);
+};
 
 DomainOnly.propTypes = {
-	domainName: PropTypes.string.isRequired,
+	primaryDomain: PropTypes.object,
 	hasNotice: PropTypes.bool.isRequired,
 	translate: PropTypes.func.isRequired,
 	siteId: PropTypes.number.isRequired,
 };
 
-export default localize( DomainOnly );
+export default connect(
+	( state, ownProps ) => {
+		return {
+			slug: getSiteSlug( state, ownProps.siteId ),
+			primaryDomain: getPrimaryDomainBySiteId( state, ownProps.siteId )
+		};
+	}
+)( localize( DomainOnly ) );

--- a/client/my-sites/domains/domain-management/list/domain-only.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-only.jsx
@@ -12,7 +12,7 @@ import React from 'react';
 import EmptyContent from 'components/empty-content';
 import QuerySiteDomains from 'components/data/query-site-domains';
 import { domainManagementEdit } from 'my-sites/domains/paths';
-import { getPrimaryDomainBySiteId } from 'state/sites/domains/selectors';
+import { getPrimaryDomainBySiteId } from 'state/selectors';
 import { getSiteSlug } from 'state/sites/selectors';
 
 const DomainOnly = ( { primaryDomain, hasNotice, siteId, slug, translate } ) => {

--- a/client/my-sites/domains/domain-management/list/index.jsx
+++ b/client/my-sites/domains/domain-management/list/index.jsx
@@ -110,7 +110,6 @@ export class List extends React.Component {
 				<Main>
 					<SidebarNavigation />
 					<DomainOnly
-						domainName={ this.props.selectedSite.domain }
 						hasNotice={ this.isFreshDomainOnlyRegistration() }
 						siteId={ this.props.selectedSite.ID }
 					/>

--- a/client/my-sites/domains/domain-management/style.scss
+++ b/client/my-sites/domains/domain-management/style.scss
@@ -889,3 +889,9 @@ ul.domain-connect__dns-list
 		width: 60px;
 	}
 }
+
+.domain-only-site__placeholder {
+	h2 {
+		@include placeholder();
+	}
+}

--- a/client/state/selectors/get-primary-domain-by-site-id.js
+++ b/client/state/selectors/get-primary-domain-by-site-id.js
@@ -1,0 +1,21 @@
+/**
+ * Internal Dependencies
+ */
+import { getDomainsBySiteId } from 'state/sites/domains/selectors';
+
+/**
+ * Return primary domain from state object and
+ * the given site ID
+ *
+ * @param {Object} state - current state object
+ * @param {Object} siteId - site object
+ * @return {Object} primary domain
+ */
+export const getPrimaryDomainBySiteId = ( state, siteId ) => {
+	const domains = getDomainsBySiteId( state, siteId );
+	if ( domains.length === 0 ) {
+		return null;
+	}
+
+	return domains.filter( domain => domain.isPrimary )[ 0 ];
+};

--- a/client/state/selectors/get-primary-domain-by-site-id.js
+++ b/client/state/selectors/get-primary-domain-by-site-id.js
@@ -11,11 +11,11 @@ import { getDomainsBySiteId } from 'state/sites/domains/selectors';
  * @param {Object} siteId - site object
  * @return {Object} primary domain
  */
-export const getPrimaryDomainBySiteId = ( state, siteId ) => {
+export default function getPrimaryDomainBySiteId( state, siteId ) {
 	const domains = getDomainsBySiteId( state, siteId );
 	if ( domains.length === 0 ) {
 		return null;
 	}
 
 	return domains.filter( domain => domain.isPrimary )[ 0 ];
-};
+}

--- a/client/state/selectors/index.js
+++ b/client/state/selectors/index.js
@@ -76,6 +76,7 @@ export getPostRevisionsAuthorsId from './get-post-revisions-authors-id';
 export getPostSharePublishedActions from './get-post-share-published-actions';
 export getPostShareScheduledActions from './get-post-share-scheduled-actions';
 export getPrimarySiteId from './get-primary-site-id';
+export getPrimaryDomainBySiteId from './get-primary-domain-by-site-id';
 export getPublicizeConnection from './get-publicize-connection';
 export getPublicSites from './get-public-sites';
 export getRawOffsets from './get-raw-offsets';


### PR DESCRIPTION
If a conflicting (registered on WPCOM then linked to a Jetpack site) sites exist, users are unable to manage their domains. This fixes the bug, and hides the redirect notice, and provides proper upgrade link for upsells.

Test:
1. Register a domain using `/domains`.
2. Link the domain to an externally hosted Jetpack site
2.1. Create a self-hosted WordPress site
2.2. Install Jetpack plugin
2.3. Link to your WP.com account
2.4. Setup Jetpack to use the the domain registered in 1.
3. Try to manage the domain
4. Make sure upsell links work
5. Make sure Jetpack site works in Calypso