### PR TITLE
Style fixes

### DIFF
--- a/client/blocks/product-purchase-features/product-purchase-features-list/style.scss
+++ b/client/blocks/product-purchase-features/product-purchase-features-list/style.scss
@@ -7,7 +7,6 @@
 
 .product-purchase-features-list__item {
 	page-break-inside: avoid; // For Firefox
-	overflow: hidden; // For Firefox and IE
 	break-inside: avoid-column; // For IE
 	-webkit-column-break-inside: avoid; // For others
 

--- a/client/components/purchase-detail/style.scss
+++ b/client/components/purchase-detail/style.scss
@@ -1,7 +1,8 @@
 .purchase-detail {
-	border-top: 1px solid lighten( $gray, 30% );
+	box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ),
+		0 1px 2px lighten( $gray, 30% );
 	box-sizing: border-box;
-	color: $gray;
+	color: $gray-text-min;
 	position: relative;
 
 	&:last-child {
@@ -9,15 +10,10 @@
 	}
 
 	@include breakpoint( ">660px" ) {
-		border: 1px solid lighten( $gray, 30% );
 		border-radius: 3px;
 		max-width: 700px;
 		margin: 16px auto;
 		text-align: left;
-
-		&:last-child {
-			border: 1px solid lighten( $gray, 30% );
-		}
 
 		.button:not(.clipboard-button) {
 			width: auto;

--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -366,6 +366,7 @@ form.sidebar__button {
 
 	&.sidebar__footer-help {
 		margin-left: auto;
+		border-radius: 0;
 	}
 
 	&.sidebar__footer-chat.has-unread {

--- a/client/my-sites/plans/current-plan/style.scss
+++ b/client/my-sites/plans/current-plan/style.scss
@@ -21,11 +21,11 @@
 
 .current-plan__header-item-content {
 	background-color: $white;
-	border-top: 1px solid lighten( $gray, 30% );
 	padding: 32px;
+	box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ),
+		0 1px 2px lighten( $gray, 30% );
 
 	@include breakpoint( ">660px" ) {
-		border: 1px solid lighten( $gray, 30% );
 		text-align: left;
 	}
 

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -274,8 +274,6 @@
 }
 
 .site-settings__site-options {
-	padding-bottom: 24px;
-
 	@include breakpoint( ">660px" ) {
 		display: flex;
 	}

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -166,11 +166,14 @@
 	}
 
 	fieldset.site-icon-setting {
+		padding-bottom: 16px;
+
 		@include breakpoint( ">660px" ) {
 			flex: 0 0 122px;
 			order: 1;
 			margin-bottom: 0;
 			padding-right: 24px;
+			padding-bottom: 24px;
 		}
 	}
 
@@ -276,6 +279,12 @@
 .site-settings__site-options {
 	@include breakpoint( ">660px" ) {
 		display: flex;
+	}
+
+	&:last-child {
+		.site-icon-setting {
+			padding-bottom: 0;
+		}
 	}
 }
 

--- a/client/post-editor/editor-action-bar/style.scss
+++ b/client/post-editor/editor-action-bar/style.scss
@@ -95,7 +95,7 @@
 	}
 
 	.gridicon {
-		top: 2px;
+		top: 4px;
 	}
 }
 

--- a/client/post-editor/editor-action-bar/style.scss
+++ b/client/post-editor/editor-action-bar/style.scss
@@ -93,6 +93,10 @@
 	@include breakpoint( ">660px" ) {
 		color: lighten( $gray, 20% );
 	}
+
+	.gridicon {
+		top: 2px;
+	}
 }
 
 .editor-action-bar__view-post-tooltip .popover__inner {

--- a/client/post-editor/editor-action-bar/style.scss
+++ b/client/post-editor/editor-action-bar/style.scss
@@ -5,7 +5,7 @@
 	flex-shrink: 0;	// Safari fix for min-height
 	align-items: center;
 	margin-bottom: 24px;
-	padding: 12px 16px 8px;
+	padding: 12px 16px;
 
 	@include breakpoint( "<660px" ) {
 		margin-bottom: 8px;

--- a/client/post-editor/editor-ground-control/style.scss
+++ b/client/post-editor/editor-ground-control/style.scss
@@ -236,6 +236,7 @@
 	border-right: 1px solid lighten( $gray, 25% );
 	padding: 6px 10px;
 	height: 46px;
+	border-radius: 0;
 
 	.gridicon {
 		top: 4px;


### PR DESCRIPTION
This PR addresses a few minor design quirks in Calypso. The following has been updated;

### Rounded corners on buttons that shouldn't have them;

![rounded](https://cldup.com/c-pg5LhcO8-3000x3000.png)
![rounded2](https://cldup.com/Zmkt28SS5y-3000x3000.png)

### Alignment of editor action buttons
Before:
![editor-action-button](https://cldup.com/buZPQtmeJl.png)

After:
![editor-buttons](https://cldup.com/lcAbl63wsV-3000x3000.png)

### Site settings padding
Before:
![site-settings-padding](https://cldup.com/4QXmmr1kGg.png)

After: 
![settings](https://cldup.com/Kk5IDpuXLq-3000x3000.png)

### Plans page cards
The cards on this page had borders which didn't match the rest of the cards in Calypso. They were also using the old `$grey` color for text. I've updated them to be consistent with other cards;

![plan](https://cldup.com/7DG8HOWLG3.png)

