### PR TITLE
Plugins: show "Manage" button in multisite if any sites are Jetpack

### DIFF
--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -23,7 +23,7 @@ import URLSearch from 'lib/mixins/url-search';
 import infiniteScroll from 'lib/mixins/infinite-scroll';
 import JetpackManageErrorPage from 'my-sites/jetpack-manage-error-page';
 import { recordTracksEvent } from 'state/analytics/actions';
-import { canCurrentUser } from 'state/selectors';
+import { canCurrentUser, hasJetpackSites } from 'state/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import {
 	canJetpackSiteManage,
@@ -298,13 +298,20 @@ const PluginsBrowser = React.createClass( {
 		);
 	},
 
+	shouldShowManageButton() {
+		if ( this.props.isJetpackSite ) {
+			return true;
+		}
+		return ( ! this.props.selectedSiteId && this.props.hasJetpackSites );
+	},
+
 	getPageHeaderView() {
 		if ( this.props.hideSearchForm ) {
 			return null;
 		}
 
 		const navigation = this.props.category ? this.getNavigationBar() : this.getSearchBar();
-		const manageButton = this.props.isJetpackSite && this.getManageButton();
+		const manageButton = this.shouldShowManageButton() && this.getManageButton();
 
 		return (
 			<div className="plugins-browser__main-header">
@@ -392,6 +399,7 @@ export default connect(
 		return {
 			sitePlan: getSitePlan( state, selectedSiteId ),
 			isJetpackSite: isJetpackSite( state, selectedSiteId ),
+			hasJetpackSites: hasJetpackSites( state ),
 			jetpackManageError: !! isJetpackSite( state, selectedSiteId ) && ! canJetpackSiteManage( state, selectedSiteId ),
 			isRequestingSites: isRequestingSites( state ),
 			noPermissionsError: !! selectedSiteId && ! canCurrentUser( state, selectedSiteId, 'manage_options' ),

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -238,7 +238,7 @@ export class MySitesSidebar extends Component {
 			return null;
 		}
 
-		const manageButton = this.props.isJetpack
+		const manageButton = this.props.isJetpack || ( ! this.props.siteId && this.props.hasJetpackSites )
 			? <SidebarButton href={ managePluginsLink }>
 					{ this.props.translate( 'Manage' ) }
 				</SidebarButton>


### PR DESCRIPTION
Previously, the Plugins "Manage" buttons were only visible if viewing a single site and that site was Jetpack. This changes the behavior such that the buttons also appear in multi-site if _any_ site owned by the user is Jetpack.

![screen shot 2017-09-05 at 1 42 23 pm](https://user-images.githubusercontent.com/2036909/30074685-66bbbaee-9240-11e7-81a9-5897030cb729.png)

## Testing 

1. Visit http://calypso.localhost:3000/plugins/ (the multi-site view) for a user account which has at least one Jetpack site. Verify that you see both the buttons in the screenshot above.
2. Visit http://calypso.localhost:3000/plugins/ (the multi-site view) for a user account with _no_ Jetpack site. Verify that you see _neither_ of the buttons.
3. Visit http://calypso.localhost:3000/plugins/[siteId] (single site view) for a Jetpack site. Verify that you see both of the icons.
4. Visit http://calypso.localhost:3000/plugins/[siteId] (single site view) for a Simple site on a user account that _also has a Jetpack site_. Verify that you see _neither_ of the icons.