### PR TITLE
Stats Chart: Fix Sidebar Z-Index Issues.

### DIFF
--- a/client/components/chart/style.scss
+++ b/client/components/chart/style.scss
@@ -38,6 +38,12 @@
 	width: 100%;
 	height: 1px;
 	border-top: 1px solid rgba( lighten( $gray, 30% ), .1 );
+
+	@include breakpoint( "<480px" ) {
+		.focus-sidebar & {
+			z-index: 0;
+		}
+	}
 }
 
 .chart__bar-marker,
@@ -170,6 +176,12 @@
 		left: 16%; // 1
 	z-index: z-index( 'root', '.chart__bar-section' );
 
+	@include breakpoint( "<480px" ) {
+		.focus-sidebar & {
+			z-index: 0;
+		}
+	}
+
 	.chart__bar:hover &.is-bar {
 		background-color: $blue-medium;
 	}
@@ -181,6 +193,12 @@
 	&.is-spacer {
 		z-index: z-index( 'root', '.chart__bar-section.is-spacer' );
 		background-color: $transparent;
+
+		@include breakpoint( "<480px" ) {
+			.focus-sidebar & {
+				z-index: 0;
+			}
+		}
 	}
 
 	&.is-ghost::after {
@@ -191,6 +209,11 @@
 			bottom: 0;
 			left: 0;
 		z-index: z-index( 'root', '.chart__bar-section.is-ghost::after' );
+		@include breakpoint( "<480px" ) {
+			.focus-sidebar & {
+				z-index: 0;
+			}
+		}
 		width: 100%;
 		height: 40px;
 		background-image: linear-gradient(to bottom, $transparent, rgba( lighten( $gray, 30% ), .5 ) ); // TODO: needs to use default color for gradient
@@ -318,6 +341,12 @@
 	line-height: 24px;
 	clear: both;
 	z-index: z-index( 'root', '.chart__empty' );
+
+	@include breakpoint( "<480px" ) {
+		.focus-sidebar & {
+			z-index: 0;
+		}
+	}
 }
 
 .chart__empty-notice {


### PR DESCRIPTION
Trash Day! This branch fixes #12448 and fixes #7002 - both issues are related to z-index problems in *Firefox only* on small viewports and the stats chart.

__Before__
<img width="411" alt="stats_ _trout_bummin_ _wordpress_com" src="https://user-images.githubusercontent.com/22080/30075111-ae9ec3c8-9228-11e7-995a-62a68a5170f1.png">

<img width="411" alt="stats_ _timmyonesite_ _wordpress_com" src="https://user-images.githubusercontent.com/22080/30075130-bdc411aa-9228-11e7-840e-58e0b688e4f2.png">

__After__
<img width="411" alt="stats_ _trout_bummin_ _wordpress_com" src="https://user-images.githubusercontent.com/22080/30075142-c985b732-9228-11e7-9649-0cabdfb87297.png">

<img width="411" alt="stats_ _timmyonesite_ _wordpress_com" src="https://user-images.githubusercontent.com/22080/30075162-d8e42d80-9228-11e7-9f94-d8d700e64df3.png">

__To Test__
Open up a site stats page in Firefox for a site that has no stats data. Verify the empty chart messaging is not shown when viewing the sidebar on a small viewport. Open a stats page for a site that has stats, verify the chart bars are not shown when viewing the sidebar in a small viewport.
