### PR TITLE
Segmented control: Clean up styles

### DIFF
--- a/client/components/segmented-control/style.scss
+++ b/client/components/segmented-control/style.scss
@@ -86,59 +86,20 @@
 }
 
 //Primary variation
-.segmented-control.is-primary {
+.segmented-control.is-primary { 
 
 	.segmented-control__item {
 
 		&.is-selected {
 
 			.segmented-control__link {
-		  	border-color: $blue-medium;
+		  		border-color: $blue-medium;
 		 		background-color: $blue-medium;
 		 		color: $white;
 		  }
 
 			+ .segmented-control__item .segmented-control__link {
 				border-left-color: $blue-medium;
-			}
-		}
-	}
-}
-
-//For WooCommerce Extension
-.is-store {
-
-	&.segmented-control {
-		@include breakpoint( "<480px" ) {
-			padding: 0 16px 16px;
-		}
-
-		.segmented-control__item {
-
-			.segmented-control__link {
-				background: #f3f6f8;
-				border-color: #e9eff3;
-
-				.segmented-control__text {
-					color: #a8bece;
-				}
-			}
-
-			&.is-selected {
-				.segmented-control__link {
-					background: #00aadc;
-					border-color: #008ab3;
-
-					.segmented-control__text {
-						color: #ffffff;
-					}
-				}
-			}
-
-			&.is-selected + .segmented-control__item {
-				.segmented-control__link {
-					border-left-color: #008ab3;
-				}
 			}
 		}
 	}

--- a/client/extensions/woocommerce/app/store-stats/store-stats-navigation/index.js
+++ b/client/extensions/woocommerce/app/store-stats/store-stats-navigation/index.js
@@ -34,6 +34,7 @@ const StoreStatsNavigation = props => {
 						{ value: 'site', label: translate( 'Site' ), path: `/stats/${ unit }/${ slug }` },
 						{ value: 'store', label: translate( 'Store' ) },
 					] }
+					primary
 				/>
 				<FollowersCount />
 			</SectionNav>

--- a/client/extensions/woocommerce/app/store-stats/store-stats-navigation/style.scss
+++ b/client/extensions/woocommerce/app/store-stats/store-stats-navigation/style.scss
@@ -7,6 +7,7 @@
 		}
 	}
 }
+
 @include breakpoint( ">660px" ) {
  	&.store-stats {
 		.store-stats-navigation {
@@ -17,39 +18,8 @@
 	}
 }
 
-
 .segmented-control {
 	@include breakpoint( "<480px" ) {
 		padding: 0 16px 16px;
-	}
-
-	.segmented-control__item {
-
-		.segmented-control__link {
-			background: #f3f6f8;
-			border-color: #e9eff3;
-
-			.segmented-control__text {
-				color: #a8bece;
-			}
-		}
-
-		&.is-selected {
-			.segmented-control__link {
-				background: #00aadc;
-				border-color: #008ab3;
-
-				.segmented-control__text {
-					color: #ffffff;
-				}
-			}
-		}
-
-		&.is-selected + .segmented-control__item {
-			.segmented-control__link {
-				border-left-color: #008ab3;
-			}
-		}
-
 	}
 }

--- a/client/my-sites/stats/stats-navigation/index.jsx
+++ b/client/my-sites/stats/stats-navigation/index.jsx
@@ -39,6 +39,7 @@ const StatsNavigation = props => {
 		const validSection = includes( [ 'day', 'week', 'month', 'year' ], section ) ? section : 'day';
 		statsControl = (
 			<SegmentedControl
+				primary
 				className="stats-navigation__control is-store"
 				initialSelected="site"
 				options={ [


### PR DESCRIPTION
Segmented controls were showing up funky in all store sections so I cleaned them up for hack/trash day.

Before

Store > Settings > Payments:
<img width="577" alt="screen shot 2017-09-05 at 10 52 40 am" src="https://user-images.githubusercontent.com/5835847/30075228-3ed397ac-9242-11e7-9d80-00481be2715f.png">

Stats toggle on sites with stores:
<img width="134" alt="screen shot 2017-09-05 at 1 56 57 pm" src="https://user-images.githubusercontent.com/5835847/30075214-2ea48a12-9242-11e7-8f70-b65d20943a92.png">

This is really hard to read and definitely won't pass any accessibility tests. They are also not aligned with our component style guide. 

They are supposed to show up as seen in [devdocs](https://wpcalypso.wordpress.com/devdocs/design/segmented-control):

<img width="447" alt="screen shot 2017-09-05 at 1 59 27 pm" src="https://user-images.githubusercontent.com/5835847/30075290-886732c0-9242-11e7-9a1b-0edccdb3168f.png">

It turns out there was a bunch of duplicated styles that were added. I removed those and cleaned up the others. 

After:

<img width="620" alt="screen shot 2017-09-05 at 1 39 20 pm" src="https://user-images.githubusercontent.com/5835847/30075550-039177ca-9244-11e7-849b-a43e5a59e388.png">

<img width="964" alt="screen shot 2017-09-05 at 2 11 01 pm" src="https://user-images.githubusercontent.com/5835847/30076141-0068727c-9246-11e7-8fb6-15de68656bfe.png">

@greenafrican: There's a small bug with the store stats toggle that I can't figure out. The `is-primary stats-navigation__control is-store` classes are getting removed from the main `segmented-control` class when you select Store, which makes it not turning blue. I can add a css hack in, but I think we should fix the root problem instead, since this isn't happening elsewhere that I can see.