### PR TITLE
Data Layer: Rename `local()` to `bypassDataLayer()`

### DIFF
--- a/client/state/data-layer/README.md
+++ b/client/state/data-layer/README.md
@@ -86,7 +86,7 @@ const myHandler = ( store, action ) => { … }
 Note that the Redux store incorporates four methods, two of which are likely to be used here.
 When dispatching through the store's `dispatch` function the action will start at the beginning of the entire middleware chain.
 Sometimes we need to bypass the data layer so that we don't create endless loops of action dispatches.
-In these cases we can import the `local()` function which will cause the action to do just that: bypass the data layer.
+In these cases we can import the `bypassDataLayer()` function which will cause the action to do just that: bypass the data layer.
 
 
 ```js

--- a/client/state/data-layer/test/extensions-middleware.js
+++ b/client/state/data-layer/test/extensions-middleware.js
@@ -8,7 +8,7 @@ import { spy, stub } from 'sinon';
  * Internal dependencies
  */
 import { addHandlers, removeHandlers, configureMiddleware } from '../extensions-middleware';
-import { local } from '../utils';
+import { bypassDataLayer } from '../utils';
 
 describe( 'Calypso Extensions Data Layer Middleware', () => {
 	let next;
@@ -47,7 +47,7 @@ describe( 'Calypso Extensions Data Layer Middleware', () => {
 
 		const config = configureMiddleware( Object.create( null ), Object.create( null ) );
 		addHandlers( 'my-extension', handlers, config );
-		const action = local( { type: 'ADD' } );
+		const action = bypassDataLayer( { type: 'ADD' } );
 
 		config.middleware( store )( next )( action );
 
@@ -118,7 +118,7 @@ describe( 'Calypso Extensions Data Layer Middleware', () => {
 		config.middleware( store )( next )( action );
 
 		expect( next ).to.have.been.calledOnce;
-		expect( next ).to.have.been.calledWith( local( action ) );
+		expect( next ).to.have.been.calledWith( bypassDataLayer( action ) );
 		expect( adder ).to.have.been.calledWith( store, action );
 	} );
 

--- a/client/state/data-layer/test/utils.js
+++ b/client/state/data-layer/test/utils.js
@@ -6,13 +6,13 @@ import { expect } from 'chai';
 /**
  * Internal dependencies
  */
-import { local } from '../utils';
+import { bypassDataLayer } from '../utils';
 
 describe( 'Data Layer', () => {
 	describe( '#local', () => {
 		it( 'should wrap an action with the bypass flag', () => {
 			const action = { type: 'ADD_SPLINE', id: 42 };
-			const localAction = local( action );
+			const localAction = bypassDataLayer( action );
 
 			expect( localAction ).to.have.deep.property( 'meta.dataLayer.doBypass', true );
 		} );
@@ -27,7 +27,7 @@ describe( 'Data Layer', () => {
 					}
 				}
 			};
-			const localAction = local( action );
+			const localAction = bypassDataLayer( action );
 
 			expect( localAction ).to.have.deep.property( 'meta.oceanName', 'ARCTIC' );
 			expect( localAction ).to.have.deep.property( 'meta.dataLayer.forceRefresh', true );

--- a/client/state/data-layer/test/wpcom-api-middleware.js
+++ b/client/state/data-layer/test/wpcom-api-middleware.js
@@ -8,7 +8,7 @@ import { spy, stub } from 'sinon';
  * Internal dependencies
  */
 import { middleware } from '../wpcom-api-middleware';
-import { local } from '../utils';
+import { bypassDataLayer } from '../utils';
 import { mergeHandlers } from 'state/action-watchers/utils';
 
 describe( 'WordPress.com API Middleware', () => {
@@ -43,7 +43,7 @@ describe( 'WordPress.com API Middleware', () => {
 		const handlers = mergeHandlers( {
 			[ 'ADD' ]: [ adder ],
 		} );
-		const action = local( { type: 'ADD' } );
+		const action = bypassDataLayer( { type: 'ADD' } );
 
 		middleware( handlers )( store )( next )( action );
 
@@ -100,7 +100,7 @@ describe( 'WordPress.com API Middleware', () => {
 		middleware( handlers )( store )( next )( action );
 
 		expect( next ).to.have.been.calledOnce;
-		expect( next ).to.have.been.calledWith( local( action ) );
+		expect( next ).to.have.been.calledWith( bypassDataLayer( action ) );
 		expect( adder ).to.have.been.calledWith( store, action );
 	} );
 

--- a/client/state/data-layer/utils.js
+++ b/client/state/data-layer/utils.js
@@ -11,4 +11,4 @@ const doBypassDataLayer = {
 	},
 };
 
-export const local = action => extendAction( action, doBypassDataLayer );
+export const bypassDataLayer = action => extendAction( action, doBypassDataLayer );

--- a/client/state/data-layer/wpcom-api-middleware.js
+++ b/client/state/data-layer/wpcom-api-middleware.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { local } from './utils';
+import { bypassDataLayer } from './utils';
 import { mergeHandlers } from 'state/action-watchers/utils';
 
 import wpcomHttpHandlers from './wpcom-http';
@@ -91,7 +91,7 @@ export const middleware = handlers => store => next => {
 		handlerChain.forEach( handler => handler( store, action ) );
 
 		if ( shouldNext( action ) ) {
-			next( local( action ) );
+			next( bypassDataLayer( action ) );
 		}
 	};
 };

--- a/client/state/data-layer/wpcom-http/README.md
+++ b/client/state/data-layer/wpcom-http/README.md
@@ -237,7 +237,7 @@ const likePost = ( { dispatch }, action ) => {
 const verifyLike = ( { dispatch }, { siteId, postId } data ) => {
 	// this is a response to data coming in from the data layer,
 	// so skip further data-layer middleware with local
-	dispatch( local( {
+	dispatch( bypassDataLayer( {
 		type: data.i_like ? LIKE_POST : UNLIKE_POST,
 		siteId,
 		postId,
@@ -250,7 +250,7 @@ const verifyLike = ( { dispatch }, { siteId, postId } data ) => {
  */
 const undoLike = ( { dispatch }, { siteId, postId }, error ) => {
 	// skip data-layer middleware
-	dispatch( local( {
+	dispatch( bypassDataLayer( {
 		type: UNLIKE_POST,
 		siteId,
 		postId,

--- a/client/state/data-layer/wpcom/login-2fa/index.js
+++ b/client/state/data-layer/wpcom/login-2fa/index.js
@@ -22,7 +22,7 @@ import {
 } from 'state/login/selectors';
 import { http } from 'state/http/actions';
 import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
-import { local } from 'state/data-layer/utils';
+import { bypassDataLayer } from 'state/data-layer/utils';
 import { addLocaleToWpcomUrl, getLocaleSlug } from 'lib/i18n-utils';
 
 /**
@@ -99,7 +99,7 @@ const makePushNotificationRequest = dispatchRequest(
 export default {
 	[ TWO_FACTOR_AUTHENTICATION_PUSH_POLL_START ]: [ ( store, action ) => {
 		// We need to store to update for `getTwoFactorPushPollInProgress` selector
-		store.dispatch( local( action ) );
+		store.dispatch( bypassDataLayer( action ) );
 		return makePushNotificationRequest( store, action );
 	} ],
 };

--- a/client/state/data-layer/wpcom/read/following/mine/delete/index.js
+++ b/client/state/data-layer/wpcom/read/following/mine/delete/index.js
@@ -16,7 +16,7 @@ import { follow } from 'state/reader/follows/actions';
 import { getFeedByFeedUrl } from 'state/reader/feeds/selectors';
 import { getSiteByFeedUrl } from 'state/reader/sites/selectors';
 import { getSiteName } from 'reader/get-helpers';
-import { local } from 'state/data-layer/utils';
+import { bypassDataLayer } from 'state/data-layer/utils';
 
 export function requestUnfollow( { dispatch, getState }, action ) {
 	const { payload: { feedUrl } } = action;
@@ -51,7 +51,7 @@ export function requestUnfollow( { dispatch, getState }, action ) {
 
 export function receiveUnfollow( store, action, response ) {
 	if ( response && ! response.subscribed ) {
-		store.dispatch( local( action ) );
+		store.dispatch( bypassDataLayer( action ) );
 	} else {
 		unfollowError( store, action );
 	}
@@ -71,7 +71,7 @@ export function unfollowError( { dispatch, getState }, action ) {
 			} )
 		)
 	);
-	dispatch( local( follow( action.payload.feedUrl ) ) );
+	dispatch( bypassDataLayer( follow( action.payload.feedUrl ) ) );
 }
 
 export default {

--- a/client/state/data-layer/wpcom/read/following/mine/delete/test/index.js
+++ b/client/state/data-layer/wpcom/read/following/mine/delete/test/index.js
@@ -12,7 +12,7 @@ import { NOTICE_CREATE } from 'state/action-types';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { follow, unfollow } from 'state/reader/follows/actions';
 import { requestUnfollow, receiveUnfollow, unfollowError } from '../';
-import { local } from 'state/data-layer/utils';
+import { bypassDataLayer } from 'state/data-layer/utils';
 
 describe( 'following/mine/delete', () => {
 	describe( 'requestUnfollow', () => {
@@ -68,7 +68,7 @@ describe( 'following/mine/delete', () => {
 
 			receiveUnfollow( { dispatch, getState }, action, response );
 			expect( dispatch ).to.be.calledWithMatch( { type: NOTICE_CREATE } );
-			expect( dispatch ).to.be.calledWith( local( follow( 'http://example.com' ) ) );
+			expect( dispatch ).to.be.calledWith( bypassDataLayer( follow( 'http://example.com' ) ) );
 		} );
 	} );
 
@@ -89,7 +89,7 @@ describe( 'following/mine/delete', () => {
 
 			unfollowError( { dispatch, getState }, action );
 			expect( dispatch ).to.be.calledWithMatch( { type: NOTICE_CREATE } );
-			expect( dispatch ).to.be.calledWith( local( follow( 'http://example.com' ) ) );
+			expect( dispatch ).to.be.calledWith( bypassDataLayer( follow( 'http://example.com' ) ) );
 		} );
 	} );
 } );

--- a/client/state/data-layer/wpcom/read/following/mine/new/index.js
+++ b/client/state/data-layer/wpcom/read/following/mine/new/index.js
@@ -17,7 +17,7 @@ import { subscriptionFromApi } from 'state/data-layer/wpcom/read/following/mine/
 import { getFeedByFeedUrl } from 'state/reader/feeds/selectors';
 import { getSiteByFeedUrl } from 'state/reader/sites/selectors';
 import { getSiteName } from 'reader/get-helpers';
-import { local } from 'state/data-layer/utils';
+import { bypassDataLayer } from 'state/data-layer/utils';
 
 export function requestFollow( { dispatch, getState }, action ) {
 	const { payload: { feedUrl } } = action;
@@ -50,7 +50,7 @@ export function requestFollow( { dispatch, getState }, action ) {
 export function receiveFollow( store, action, response ) {
 	if ( response && response.subscribed ) {
 		const subscription = subscriptionFromApi( response.subscription );
-		store.dispatch( local( follow( action.payload.feedUrl, subscription ) ) );
+		store.dispatch( bypassDataLayer( follow( action.payload.feedUrl, subscription ) ) );
 	} else {
 		followError( store, action, response );
 	}
@@ -70,7 +70,7 @@ export function followError( { dispatch }, action, response ) {
 		dispatch( recordFollowError( action.payload.feedUrl, response.info ) );
 	}
 
-	dispatch( local( unfollow( action.payload.feedUrl ) ) );
+	dispatch( bypassDataLayer( unfollow( action.payload.feedUrl ) ) );
 }
 
 export default {

--- a/client/state/data-layer/wpcom/read/following/mine/new/test/index.js
+++ b/client/state/data-layer/wpcom/read/following/mine/new/test/index.js
@@ -12,7 +12,7 @@ import { NOTICE_CREATE } from 'state/action-types';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { follow, unfollow } from 'state/reader/follows/actions';
 import { requestFollow, receiveFollow, followError } from '../';
-import { local } from 'state/data-layer/utils';
+import { bypassDataLayer } from 'state/data-layer/utils';
 
 describe( 'requestFollow', () => {
 	it( 'should dispatch a http request', () => {
@@ -69,7 +69,7 @@ describe( 'receiveFollow', () => {
 		};
 		receiveFollow( { dispatch }, action, response );
 		expect( dispatch ).to.be.calledWith(
-			local(
+			bypassDataLayer(
 				follow( 'http://example.com', {
 					ID: 1,
 					URL: 'http://example.com',
@@ -96,7 +96,7 @@ describe( 'receiveFollow', () => {
 			type: NOTICE_CREATE,
 			notice: { status: 'is-error' },
 		} );
-		expect( dispatch ).to.be.calledWith( local( unfollow( 'http://example.com' ) ) );
+		expect( dispatch ).to.be.calledWith( bypassDataLayer( unfollow( 'http://example.com' ) ) );
 	} );
 } );
 
@@ -107,6 +107,6 @@ describe( 'followError', () => {
 
 		followError( { dispatch }, action );
 		expect( dispatch ).to.be.calledWithMatch( { type: NOTICE_CREATE } );
-		expect( dispatch ).to.be.calledWith( local( unfollow( 'http://example.com' ) ) );
+		expect( dispatch ).to.be.calledWith( bypassDataLayer( unfollow( 'http://example.com' ) ) );
 	} );
 } );

--- a/client/state/data-layer/wpcom/read/site/comment-email-subscriptions/delete/index.js
+++ b/client/state/data-layer/wpcom/read/site/comment-email-subscriptions/delete/index.js
@@ -12,7 +12,7 @@ import { http } from 'state/data-layer/wpcom-http/actions';
 import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { subscribeToNewCommentEmail } from 'state/reader/follows/actions';
 import { errorNotice } from 'state/notices/actions';
-import { local } from 'state/data-layer/utils';
+import { bypassDataLayer } from 'state/data-layer/utils';
 
 export function requestCommentEmailUnsubscription( { dispatch }, action ) {
 	dispatch(
@@ -42,7 +42,7 @@ export function receiveCommentEmailUnsubscriptionError( { dispatch }, action ) {
 	dispatch(
 		errorNotice( translate( 'Sorry, we had a problem unsubscribing. Please try again.' ) )
 	);
-	dispatch( local( subscribeToNewCommentEmail( action.payload.blogId ) ) );
+	dispatch( bypassDataLayer( subscribeToNewCommentEmail( action.payload.blogId ) ) );
 }
 
 export default {

--- a/client/state/data-layer/wpcom/read/site/comment-email-subscriptions/delete/test/index.js
+++ b/client/state/data-layer/wpcom/read/site/comment-email-subscriptions/delete/test/index.js
@@ -18,7 +18,7 @@ import {
 	unsubscribeToNewCommentEmail,
 } from 'state/reader/follows/actions';
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { local } from 'state/data-layer/utils';
+import { bypassDataLayer } from 'state/data-layer/utils';
 
 describe( 'comment-email-subscriptions', () => {
 	describe( 'requestCommentEmailUnsubscription', () => {
@@ -61,7 +61,9 @@ describe( 'comment-email-subscriptions', () => {
 					text: 'Sorry, we had a problem unsubscribing. Please try again.',
 				},
 			} );
-			expect( dispatch ).to.have.been.calledWith( local( subscribeToNewCommentEmail( 1234 ) ) );
+			expect( dispatch ).to.have.been.calledWith(
+				bypassDataLayer( subscribeToNewCommentEmail( 1234 ) )
+			);
 		} );
 	} );
 
@@ -74,7 +76,9 @@ describe( 'comment-email-subscriptions', () => {
 					text: 'Sorry, we had a problem unsubscribing. Please try again.',
 				},
 			} );
-			expect( dispatch ).to.have.been.calledWith( local( subscribeToNewCommentEmail( 1234 ) ) );
+			expect( dispatch ).to.have.been.calledWith(
+				bypassDataLayer( subscribeToNewCommentEmail( 1234 ) )
+			);
 		} );
 	} );
 } );

--- a/client/state/data-layer/wpcom/read/site/comment-email-subscriptions/new/index.js
+++ b/client/state/data-layer/wpcom/read/site/comment-email-subscriptions/new/index.js
@@ -12,7 +12,7 @@ import { http } from 'state/data-layer/wpcom-http/actions';
 import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { unsubscribeToNewCommentEmail } from 'state/reader/follows/actions';
 import { errorNotice } from 'state/notices/actions';
-import { local } from 'state/data-layer/utils';
+import { bypassDataLayer } from 'state/data-layer/utils';
 
 export function requestCommentEmailSubscription( { dispatch }, action ) {
 	dispatch(
@@ -38,7 +38,7 @@ export function receiveCommentEmailSubscription( store, action, response ) {
 
 export function receiveCommentEmailSubscriptionError( { dispatch }, action ) {
 	dispatch( errorNotice( translate( 'Sorry, we had a problem subscribing. Please try again.' ) ) );
-	dispatch( local( unsubscribeToNewCommentEmail( action.payload.blogId ) ) );
+	dispatch( bypassDataLayer( unsubscribeToNewCommentEmail( action.payload.blogId ) ) );
 }
 
 export default {

--- a/client/state/data-layer/wpcom/read/site/comment-email-subscriptions/new/test/index.js
+++ b/client/state/data-layer/wpcom/read/site/comment-email-subscriptions/new/test/index.js
@@ -18,7 +18,7 @@ import {
 	unsubscribeToNewCommentEmail,
 } from 'state/reader/follows/actions';
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { local } from 'state/data-layer/utils';
+import { bypassDataLayer } from 'state/data-layer/utils';
 
 describe( 'comment-email-subscriptions', () => {
 	describe( 'requestCommentEmailSubscription', () => {
@@ -55,7 +55,9 @@ describe( 'comment-email-subscriptions', () => {
 					subscribed: false,
 				}
 			);
-			expect( dispatch ).to.have.been.calledWith( local( unsubscribeToNewCommentEmail( 1234 ) ) );
+			expect( dispatch ).to.have.been.calledWith(
+				bypassDataLayer( unsubscribeToNewCommentEmail( 1234 ) )
+			);
 			expect( dispatch ).to.have.been.calledWithMatch( {
 				notice: {
 					text: 'Sorry, we had a problem subscribing. Please try again.',
@@ -73,7 +75,9 @@ describe( 'comment-email-subscriptions', () => {
 					text: 'Sorry, we had a problem subscribing. Please try again.',
 				},
 			} );
-			expect( dispatch ).to.have.been.calledWith( local( unsubscribeToNewCommentEmail( 1234 ) ) );
+			expect( dispatch ).to.have.been.calledWith(
+				bypassDataLayer( unsubscribeToNewCommentEmail( 1234 ) )
+			);
 		} );
 	} );
 } );

--- a/client/state/data-layer/wpcom/read/site/post-email-subscriptions/delete/index.js
+++ b/client/state/data-layer/wpcom/read/site/post-email-subscriptions/delete/index.js
@@ -12,7 +12,7 @@ import { http } from 'state/data-layer/wpcom-http/actions';
 import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { subscribeToNewPostEmail } from 'state/reader/follows/actions';
 import { errorNotice } from 'state/notices/actions';
-import { local } from 'state/data-layer/utils';
+import { bypassDataLayer } from 'state/data-layer/utils';
 
 export function requestPostEmailUnsubscription( { dispatch }, action ) {
 	dispatch(
@@ -42,7 +42,7 @@ export function receivePostEmailUnsubscriptionError( { dispatch }, action ) {
 	dispatch(
 		errorNotice( translate( 'Sorry, we had a problem unsubscribing. Please try again.' ) )
 	);
-	dispatch( local( subscribeToNewPostEmail( action.payload.blogId ) ) );
+	dispatch( bypassDataLayer( subscribeToNewPostEmail( action.payload.blogId ) ) );
 }
 
 export default {

--- a/client/state/data-layer/wpcom/read/site/post-email-subscriptions/delete/test/index.js
+++ b/client/state/data-layer/wpcom/read/site/post-email-subscriptions/delete/test/index.js
@@ -15,7 +15,7 @@ import {
 } from '../';
 import { subscribeToNewPostEmail, unsubscribeToNewPostEmail } from 'state/reader/follows/actions';
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { local } from 'state/data-layer/utils';
+import { bypassDataLayer } from 'state/data-layer/utils';
 
 describe( 'comment-email-subscriptions', () => {
 	describe( 'requestPostEmailUnsubscription', () => {
@@ -58,7 +58,9 @@ describe( 'comment-email-subscriptions', () => {
 					text: 'Sorry, we had a problem unsubscribing. Please try again.',
 				},
 			} );
-			expect( dispatch ).to.have.been.calledWith( local( subscribeToNewPostEmail( 1234 ) ) );
+			expect( dispatch ).to.have.been.calledWith(
+				bypassDataLayer( subscribeToNewPostEmail( 1234 ) )
+			);
 		} );
 	} );
 
@@ -71,7 +73,9 @@ describe( 'comment-email-subscriptions', () => {
 					text: 'Sorry, we had a problem unsubscribing. Please try again.',
 				},
 			} );
-			expect( dispatch ).to.have.been.calledWith( local( subscribeToNewPostEmail( 1234 ) ) );
+			expect( dispatch ).to.have.been.calledWith(
+				bypassDataLayer( subscribeToNewPostEmail( 1234 ) )
+			);
 		} );
 	} );
 } );

--- a/client/state/data-layer/wpcom/read/site/post-email-subscriptions/new/index.js
+++ b/client/state/data-layer/wpcom/read/site/post-email-subscriptions/new/index.js
@@ -17,7 +17,7 @@ import {
 } from 'state/reader/follows/actions';
 import { errorNotice } from 'state/notices/actions';
 import { buildBody } from '../utils';
-import { local } from 'state/data-layer/utils';
+import { bypassDataLayer } from 'state/data-layer/utils';
 
 export function requestPostEmailSubscription( { dispatch }, action ) {
 	dispatch(
@@ -42,7 +42,7 @@ export function receivePostEmailSubscription( store, action, response ) {
 	}
 	// pass this on, but tack in the delivery_frequency that we got back from the API
 	store.dispatch(
-		local(
+		bypassDataLayer(
 			updateNewPostEmailSubscription(
 				action.payload.blogId,
 				get( response, [ 'subscription', 'delivery_frequency' ] )
@@ -53,7 +53,7 @@ export function receivePostEmailSubscription( store, action, response ) {
 
 export function receivePostEmailSubscriptionError( { dispatch }, action ) {
 	dispatch( errorNotice( translate( 'Sorry, we had a problem subscribing. Please try again.' ) ) );
-	dispatch( local( unsubscribeToNewPostEmail( action.payload.blogId ) ) );
+	dispatch( bypassDataLayer( unsubscribeToNewPostEmail( action.payload.blogId ) ) );
 }
 
 export default {

--- a/client/state/data-layer/wpcom/read/site/post-email-subscriptions/new/test/index.js
+++ b/client/state/data-layer/wpcom/read/site/post-email-subscriptions/new/test/index.js
@@ -19,7 +19,7 @@ import {
 	updateNewPostEmailSubscription,
 } from 'state/reader/follows/actions';
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { local } from 'state/data-layer/utils';
+import { bypassDataLayer } from 'state/data-layer/utils';
 
 describe( 'comment-email-subscriptions', () => {
 	describe( 'requestPostEmailSubscription', () => {
@@ -50,7 +50,7 @@ describe( 'comment-email-subscriptions', () => {
 				},
 			} );
 			expect( dispatch ).to.have.been.calledWith(
-				local( updateNewPostEmailSubscription( 1234, 'daily' ) )
+				bypassDataLayer( updateNewPostEmailSubscription( 1234, 'daily' ) )
 			);
 		} );
 
@@ -68,7 +68,9 @@ describe( 'comment-email-subscriptions', () => {
 					text: 'Sorry, we had a problem subscribing. Please try again.',
 				},
 			} );
-			expect( dispatch ).to.have.been.calledWith( local( unsubscribeToNewPostEmail( 1234 ) ) );
+			expect( dispatch ).to.have.been.calledWith(
+				bypassDataLayer( unsubscribeToNewPostEmail( 1234 ) )
+			);
 		} );
 	} );
 
@@ -81,7 +83,9 @@ describe( 'comment-email-subscriptions', () => {
 					text: 'Sorry, we had a problem subscribing. Please try again.',
 				},
 			} );
-			expect( dispatch ).to.have.been.calledWith( local( unsubscribeToNewPostEmail( 1234 ) ) );
+			expect( dispatch ).to.have.been.calledWith(
+				bypassDataLayer( unsubscribeToNewPostEmail( 1234 ) )
+			);
 		} );
 	} );
 } );

--- a/client/state/data-layer/wpcom/read/site/post-email-subscriptions/update/index.js
+++ b/client/state/data-layer/wpcom/read/site/post-email-subscriptions/update/index.js
@@ -15,7 +15,7 @@ import { updateNewPostEmailSubscription } from 'state/reader/follows/actions';
 import { errorNotice } from 'state/notices/actions';
 import { getReaderFollowForBlog } from 'state/selectors';
 import { buildBody } from '../utils';
-import { local } from 'state/data-layer/utils';
+import { bypassDataLayer } from 'state/data-layer/utils';
 
 export function requestUpdatePostEmailSubscription( { dispatch, getState }, action ) {
 	const actionWithRevert = merge( {}, action, {
@@ -55,7 +55,7 @@ export function receiveUpdatePostEmailSubscriptionError(
 			translate( 'Sorry, we had a problem updating that subscription. Please try again.' )
 		)
 	);
-	dispatch( local( updateNewPostEmailSubscription( blogId, previousState ) ) );
+	dispatch( bypassDataLayer( updateNewPostEmailSubscription( blogId, previousState ) ) );
 }
 
 export default {

--- a/client/state/data-layer/wpcom/read/site/post-email-subscriptions/update/test/index.js
+++ b/client/state/data-layer/wpcom/read/site/post-email-subscriptions/update/test/index.js
@@ -16,7 +16,7 @@ import {
 } from '../';
 import { updateNewPostEmailSubscription } from 'state/reader/follows/actions';
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { local } from 'state/data-layer/utils';
+import { bypassDataLayer } from 'state/data-layer/utils';
 
 describe( 'comment-email-subscriptions', () => {
 	describe( 'requestUpdatePostEmailSubscription', () => {
@@ -76,7 +76,7 @@ describe( 'comment-email-subscriptions', () => {
 				null
 			);
 			expect( dispatch ).to.have.been.calledWith(
-				local( updateNewPostEmailSubscription( 1234, previousState ) )
+				bypassDataLayer( updateNewPostEmailSubscription( 1234, previousState ) )
 			);
 		} );
 
@@ -92,7 +92,7 @@ describe( 'comment-email-subscriptions', () => {
 				{ success: false }
 			);
 			expect( dispatch ).to.have.been.calledWith(
-				local( updateNewPostEmailSubscription( 1234, previousState ) )
+				bypassDataLayer( updateNewPostEmailSubscription( 1234, previousState ) )
 			);
 		} );
 	} );
@@ -109,7 +109,7 @@ describe( 'comment-email-subscriptions', () => {
 				}
 			);
 			expect( dispatch ).to.have.been.calledWith(
-				local( updateNewPostEmailSubscription( 1234, previousState ) )
+				bypassDataLayer( updateNewPostEmailSubscription( 1234, previousState ) )
 			);
 			expect( dispatch ).to.have.been.calledWithMatch( {
 				notice: { text: 'Sorry, we had a problem updating that subscription. Please try again.' },

--- a/client/state/data-layer/wpcom/sites/blog-stickers/add/index.js
+++ b/client/state/data-layer/wpcom/sites/blog-stickers/add/index.js
@@ -12,7 +12,7 @@ import { http } from 'state/data-layer/wpcom-http/actions';
 import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { removeBlogSticker } from 'state/sites/blog-stickers/actions';
 import { errorNotice, successNotice } from 'state/notices/actions';
-import { local } from 'state/data-layer/utils';
+import { bypassDataLayer } from 'state/data-layer/utils';
 
 export function requestBlogStickerAdd( { dispatch }, action ) {
 	dispatch(
@@ -54,7 +54,7 @@ export function receiveBlogStickerAddError( { dispatch }, action ) {
 	dispatch(
 		errorNotice( translate( 'Sorry, we had a problem adding that sticker. Please try again.' ) ),
 	);
-	dispatch( local( removeBlogSticker( action.payload.blogId, action.payload.stickerName ) ) );
+	dispatch( bypassDataLayer( removeBlogSticker( action.payload.blogId, action.payload.stickerName ) ) );
 }
 
 export default {

--- a/client/state/data-layer/wpcom/sites/blog-stickers/add/test/index.js
+++ b/client/state/data-layer/wpcom/sites/blog-stickers/add/test/index.js
@@ -10,7 +10,7 @@ import { spy } from 'sinon';
 import { requestBlogStickerAdd, receiveBlogStickerAdd, receiveBlogStickerAddError } from '../';
 import { addBlogSticker, removeBlogSticker } from 'state/sites/blog-stickers/actions';
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { local } from 'state/data-layer/utils';
+import { bypassDataLayer } from 'state/data-layer/utils';
 
 describe( 'blog-sticker-add', () => {
 	describe( 'requestBlogStickerAdd', () => {
@@ -55,7 +55,7 @@ describe( 'blog-sticker-add', () => {
 					success: false,
 				},
 			);
-			expect( dispatch ).to.have.been.calledWith( local( removeBlogSticker( 123, 'broken-in-reader' ) ) );
+			expect( dispatch ).to.have.been.calledWith( bypassDataLayer( removeBlogSticker( 123, 'broken-in-reader' ) ) );
 			expect( dispatch ).to.have.been.calledWithMatch( {
 				notice: {
 					status: 'is-error',
@@ -76,7 +76,7 @@ describe( 'blog-sticker-add', () => {
 					status: 'is-error',
 				},
 			} );
-			expect( dispatch ).to.have.been.calledWith( local( removeBlogSticker( 123, 'broken-in-reader' ) ) );
+			expect( dispatch ).to.have.been.calledWith( bypassDataLayer( removeBlogSticker( 123, 'broken-in-reader' ) ) );
 		} );
 	} );
 } );

--- a/client/state/data-layer/wpcom/sites/blog-stickers/remove/index.js
+++ b/client/state/data-layer/wpcom/sites/blog-stickers/remove/index.js
@@ -12,7 +12,7 @@ import { http } from 'state/data-layer/wpcom-http/actions';
 import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { addBlogSticker } from 'state/sites/blog-stickers/actions';
 import { errorNotice, plainNotice } from 'state/notices/actions';
-import { local } from 'state/data-layer/utils';
+import { bypassDataLayer } from 'state/data-layer/utils';
 
 export function requestBlogStickerRemove( { dispatch }, action ) {
 	dispatch(
@@ -55,7 +55,7 @@ export function receiveBlogStickerRemoveError( { dispatch }, action ) {
 		errorNotice( translate( 'Sorry, we had a problem removing that sticker. Please try again.' ) ),
 	);
 	// Revert the removal
-	dispatch( local( addBlogSticker( action.payload.blogId, action.payload.stickerName ) ) );
+	dispatch( bypassDataLayer( addBlogSticker( action.payload.blogId, action.payload.stickerName ) ) );
 }
 
 export default {

--- a/client/state/data-layer/wpcom/sites/blog-stickers/remove/test/index.js
+++ b/client/state/data-layer/wpcom/sites/blog-stickers/remove/test/index.js
@@ -14,7 +14,7 @@ import {
 } from '../';
 import { addBlogSticker, removeBlogSticker } from 'state/sites/blog-stickers/actions';
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { local } from 'state/data-layer/utils';
+import { bypassDataLayer } from 'state/data-layer/utils';
 
 describe( 'blog-sticker-remove', () => {
 	describe( 'requestBlogStickerRemove', () => {
@@ -80,7 +80,7 @@ describe( 'blog-sticker-remove', () => {
 				},
 			} );
 			expect( dispatch ).to.have.been.calledWith(
-				local( addBlogSticker( 123, 'broken-in-reader' ) ),
+				bypassDataLayer( addBlogSticker( 123, 'broken-in-reader' ) ),
 			);
 		} );
 	} );

--- a/client/state/data-layer/wpcom/sites/comments/index.js
+++ b/client/state/data-layer/wpcom/sites/comments/index.js
@@ -17,7 +17,7 @@ import {
 	COMMENTS_TREE_SITE_ADD,
 	COMMENTS_EDIT,
 } from 'state/action-types';
-import { local } from 'state/data-layer/utils';
+import { bypassDataLayer } from 'state/data-layer/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import replies from './replies';
@@ -59,7 +59,7 @@ const announceStatusChangeFailure = ( { dispatch, getState }, action ) => {
 	dispatch( removeNotice( `comment-notice-${ commentId }` ) );
 
 	dispatch(
-		local( {
+		bypassDataLayer( {
 			...omit( action, [ 'meta' ] ),
 			status: previousStatus,
 		} )
@@ -229,7 +229,7 @@ export const editComment = ( { dispatch, getState }, action ) => {
 
 export const announceEditFailure = ( { dispatch }, action ) => {
 	dispatch(
-		local( {
+		bypassDataLayer( {
 			...omit( action, [ 'originalComment' ] ),
 			comment: action.originalComment,
 		} )

--- a/client/state/data-layer/wpcom/sites/comments/likes/mine/delete/index.js
+++ b/client/state/data-layer/wpcom/sites/comments/likes/mine/delete/index.js
@@ -8,7 +8,7 @@ import { translate } from 'i18n-calypso';
  */
 import { COMMENTS_LIKE, COMMENTS_UNLIKE } from 'state/action-types';
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { local } from 'state/data-layer/utils';
+import { bypassDataLayer } from 'state/data-layer/utils';
 import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { errorNotice } from 'state/notices/actions';
 
@@ -31,7 +31,7 @@ export const updateCommentLikes = (
 	{ like_count },
 ) =>
 	dispatch(
-		local( {
+		bypassDataLayer( {
 			type: COMMENTS_UNLIKE,
 			siteId,
 			postId,
@@ -47,7 +47,7 @@ export const updateCommentLikes = (
  */
 export const handleUnlikeFailure = ( { dispatch }, { siteId, postId, commentId } ) => {
 	// revert optimistic update on error
-	dispatch( local( { type: COMMENTS_LIKE, siteId, postId, commentId } ) );
+	dispatch( bypassDataLayer( { type: COMMENTS_LIKE, siteId, postId, commentId } ) );
 	// dispatch a error notice
 	dispatch( errorNotice( translate( 'Could not unlike this comment' ) ) );
 };

--- a/client/state/data-layer/wpcom/sites/comments/likes/mine/delete/test/index.js
+++ b/client/state/data-layer/wpcom/sites/comments/likes/mine/delete/test/index.js
@@ -9,7 +9,7 @@ import { spy } from 'sinon';
  */
 import { COMMENTS_UNLIKE, COMMENTS_LIKE, NOTICE_CREATE } from 'state/action-types';
 import { unlikeComment, updateCommentLikes, handleUnlikeFailure } from '../';
-import { local } from 'state/data-layer/utils';
+import { bypassDataLayer } from 'state/data-layer/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
 
 const SITE_ID = 77203074;
@@ -51,7 +51,7 @@ describe( '#updateCommentLikes()', () => {
 
 		expect( dispatch ).to.have.been.calledOnce;
 		expect( dispatch ).to.have.been.calledWith(
-			local( {
+			bypassDataLayer( {
 				type: COMMENTS_UNLIKE,
 				siteId: SITE_ID,
 				postId: POST_ID,
@@ -70,7 +70,7 @@ describe( '#handleUnlikeFailure()', () => {
 
 		expect( dispatch ).to.have.been.calledTwice;
 		expect( dispatch ).to.have.been.calledWith(
-			local( {
+			bypassDataLayer( {
 				type: COMMENTS_LIKE,
 				siteId: SITE_ID,
 				postId: POST_ID,

--- a/client/state/data-layer/wpcom/sites/comments/likes/new/index.js
+++ b/client/state/data-layer/wpcom/sites/comments/likes/new/index.js
@@ -8,7 +8,7 @@ import { translate } from 'i18n-calypso';
  */
 import { COMMENTS_LIKE, COMMENTS_UNLIKE } from 'state/action-types';
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { local } from 'state/data-layer/utils';
+import { bypassDataLayer } from 'state/data-layer/utils';
 import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { errorNotice } from 'state/notices/actions';
 
@@ -31,7 +31,7 @@ export const updateCommentLikes = (
 	{ like_count },
 ) =>
 	dispatch(
-		local( {
+		bypassDataLayer( {
 			type: COMMENTS_LIKE,
 			siteId,
 			postId,
@@ -47,7 +47,7 @@ export const updateCommentLikes = (
  */
 export const handleLikeFailure = ( { dispatch }, { siteId, postId, commentId } ) => {
 	// revert optimistic updated on error
-	dispatch( local( { type: COMMENTS_UNLIKE, siteId, postId, commentId } ) );
+	dispatch( bypassDataLayer( { type: COMMENTS_UNLIKE, siteId, postId, commentId } ) );
 	// dispatch a error notice
 	dispatch( errorNotice( translate( 'Could not like this comment' ) ) );
 };

--- a/client/state/data-layer/wpcom/sites/comments/likes/new/test/index.js
+++ b/client/state/data-layer/wpcom/sites/comments/likes/new/test/index.js
@@ -9,7 +9,7 @@ import { spy } from 'sinon';
  */
 import { COMMENTS_LIKE, COMMENTS_UNLIKE, NOTICE_CREATE } from 'state/action-types';
 import { likeComment, updateCommentLikes, handleLikeFailure } from '../';
-import { local } from 'state/data-layer/utils';
+import { bypassDataLayer } from 'state/data-layer/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
 
 const SITE_ID = 91750058;
@@ -51,7 +51,7 @@ describe( '#updateCommentLikes()', () => {
 
 		expect( dispatch ).to.have.been.calledOnce;
 		expect( dispatch ).to.have.been.calledWith(
-			local( {
+			bypassDataLayer( {
 				type: COMMENTS_LIKE,
 				siteId: SITE_ID,
 				postId: POST_ID,
@@ -70,7 +70,7 @@ describe( '#handleLikeFailure()', () => {
 
 		expect( dispatch ).to.have.been.calledTwice;
 		expect( dispatch ).to.have.been.calledWith(
-			local( {
+			bypassDataLayer( {
 				type: COMMENTS_UNLIKE,
 				siteId: SITE_ID,
 				postId: POST_ID,

--- a/client/state/data-layer/wpcom/sites/comments/test/index.js
+++ b/client/state/data-layer/wpcom/sites/comments/test/index.js
@@ -8,7 +8,7 @@ import { spy } from 'sinon';
  * Internal dependencies
  */
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { local } from 'state/data-layer/utils';
+import { bypassDataLayer } from 'state/data-layer/utils';
 import {
 	addComments,
 	announceEditFailure,
@@ -256,7 +256,7 @@ describe( '#announceEditFailure', () => {
 	it( 'should dispatch a local comment edit action', () => {
 		announceEditFailure( { dispatch }, { ...action, originalComment } );
 
-		expect( dispatch ).to.have.been.calledWith( local( {
+		expect( dispatch ).to.have.been.calledWith( bypassDataLayer( {
 			type: COMMENTS_EDIT,
 			siteId: 1,
 			postId: 1,

--- a/client/state/data-layer/wpcom/sites/utils.js
+++ b/client/state/data-layer/wpcom/sites/utils.js
@@ -11,7 +11,7 @@ import {
 	COMMENTS_RECEIVE,
 	COMMENTS_COUNT_INCREMENT,
 } from 'state/action-types';
-import { local } from 'state/data-layer/utils';
+import { bypassDataLayer } from 'state/data-layer/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { getSitePost } from 'state/posts/selectors';
 import { errorNotice } from 'state/notices/actions';
@@ -84,7 +84,7 @@ export const dispatchNewCommentRequest = ( dispatch, action, path ) => {
  */
 export const updatePlaceholderComment = ( { dispatch }, { siteId, postId, parentCommentId, placeholderId }, comment ) => {
 	// remove placeholder from state
-	dispatch( local( { type: COMMENTS_DELETE, siteId, postId, commentId: placeholderId } ) );
+	dispatch( bypassDataLayer( { type: COMMENTS_DELETE, siteId, postId, commentId: placeholderId } ) );
 	// add new comment to state with updated values from server
 	dispatch( { type: COMMENTS_RECEIVE, siteId, postId, comments: [ comment ], skipSort: !! parentCommentId } );
 	// increment comments count


### PR DESCRIPTION
Some people found `local()` to be confusing. `bypassDataLayer()` is
extremely explicit so it has been renamed here.