### PR TITLE
Activity log: Hide nav to Activity Log for free plans

### DIFF
--- a/client/my-sites/stats/stats-navigation/index.jsx
+++ b/client/my-sites/stats/stats-navigation/index.jsx
@@ -17,12 +17,14 @@ import NavItem from 'components/section-nav/item';
 import FollowersCount from 'blocks/followers-count';
 import SegmentedControl from 'components/segmented-control';
 import QueryJetpackPlugins from 'components/data/query-jetpack-plugins';
-import { isPluginActive } from 'state/selectors';
+import { getSitePlanSlug } from 'state/sites/plans/selectors';
+import { isFreePlan } from 'lib/plans';
 import { isJetpackSite } from 'state/sites/selectors';
+import { isPluginActive } from 'state/selectors';
 import config from 'config';
 
 const StatsNavigation = props => {
-	const { translate, section, slug, siteId, isJetpack, isStore } = props;
+	const { translate, section, slug, siteId, isJetpack, isStore, hasPaidPlan } = props;
 	const siteFragment = slug ? '/' + slug : '';
 	const sectionTitles = {
 		insights: translate( 'Insights' ),
@@ -57,7 +59,7 @@ const StatsNavigation = props => {
 	}
 
 	const ActivityTab =
-		config.isEnabled( 'jetpack/activity-log' ) && isJetpack
+		config.isEnabled( 'jetpack/activity-log' ) && isJetpack && hasPaidPlan
 			? <NavItem path={ '/stats/activity' + siteFragment } selected={ section === 'activity' }>
 					{ sectionTitles.activity }
 				</NavItem>
@@ -103,6 +105,7 @@ const localized = localize( StatsNavigation );
 export default connect( ( state, { siteId } ) => {
 	const isJetpack = isJetpackSite( state, siteId );
 	return {
+		hasPaidPlan: ! isFreePlan( getSitePlanSlug( state, siteId ) ),
 		isJetpack,
 		isStore: isJetpack && isPluginActive( state, siteId, 'woocommerce' ),
 		siteId,


### PR DESCRIPTION
This PR hides the stats navigation tab to Activity Log for free plans.

## Testing
1. https://calypso.live/stats/activity?branch=update/activity-log/disable-for-non-paid
1. Is the activity tab hidden for free plan sites?
1. Is the activity tab visible for paid plan sites?
