### PR TITLE
Modernize devdocs (ES modules, React.Component, etc.)

### DIFF
--- a/client/devdocs/controller.js
+++ b/client/devdocs/controller.js
@@ -183,4 +183,4 @@ const devdocs = {
 	}
 };
 
-module.exports = devdocs;
+export default devdocs;

--- a/client/devdocs/design/blocks.jsx
+++ b/client/devdocs/design/blocks.jsx
@@ -81,24 +81,21 @@ import SimplePaymentsDialog from 'components/tinymce/plugins/simple-payments/dia
 import ConversationCaterpillar from 'blocks/conversation-caterpillar/docs/example';
 import ColorSchemePicker from 'blocks/color-scheme-picker/docs/example';
 
-export default React.createClass( {
-	displayName: 'AppComponents',
+export default class AppComponents extends React.Component {
+	static displayName = 'AppComponents';
+	state = { filter: '' };
 
-	getInitialState() {
-		return { filter: '' };
-	},
-
-	onSearch( term ) {
+	onSearch = term => {
 		this.setState( { filter: trim( term || '' ).toLowerCase() } );
-	},
+	};
 
-	backToComponents() {
+	backToComponents = () => {
 		page( '/devdocs/blocks/' );
-	},
+	};
 
 	render() {
 		return (
-			<Main className="design">
+			<Main className="design design__blocks">
 				{ this.props.component
 					? <HeaderCake onClick={ this.backToComponents } backText="All Blocks">
 							{ slugToCamelCase( this.props.component ) }
@@ -178,5 +175,5 @@ export default React.createClass( {
 				</Collection>
 			</Main>
 		);
-	},
-} );
+	}
+}

--- a/client/devdocs/design/index.jsx
+++ b/client/devdocs/design/index.jsx
@@ -80,27 +80,24 @@ import Wizard from 'components/wizard/docs/example';
 import Suggestions from 'components/suggestions/docs/example';
 import HeaderButton from 'components/header-button/docs/example';
 
-let DesignAssets = React.createClass( {
-	displayName: 'DesignAssets',
-
-	getInitialState() {
-		return { filter: '' };
-	},
+class DesignAssets extends React.Component {
+	static displayName = 'DesignAssets';
+	state = { filter: '' };
 
 	componentWillMount() {
 		if ( config.isEnabled( 'devdocs/components-usage-stats' ) ) {
 			const { dispatchFetchComponentsUsageStats } = this.props;
 			dispatchFetchComponentsUsageStats();
 		}
-	},
+	}
 
-	onSearch( term ) {
+	onSearch = term => {
 		this.setState( { filter: trim( term || '' ).toLowerCase() } );
-	},
+	};
 
-	backToComponents() {
+	backToComponents = () => {
 		page( '/devdocs/design/' );
-	},
+	};
 
 	render() {
 		const { componentsUsageStats = {}, component } = this.props;
@@ -181,8 +178,8 @@ let DesignAssets = React.createClass( {
 				</Collection>
 			</Main>
 		);
-	},
-} );
+	}
+}
 
 if ( config.isEnabled( 'devdocs/components-usage-stats' ) ) {
 	const mapStateToProps = state => {

--- a/client/devdocs/design/index.jsx
+++ b/client/devdocs/design/index.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import page from 'page';

--- a/client/devdocs/design/typography.jsx
+++ b/client/devdocs/design/typography.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import React from 'react';
-import PureRenderMixin from 'react-pure-render/mixin';
 
 /**
  * Internal dependencies
@@ -10,10 +9,8 @@ import PureRenderMixin from 'react-pure-render/mixin';
 import Card from 'components/card';
 import Main from 'components/main';
 
-export default React.createClass( {
-	displayName: 'Typography',
-
-	mixins: [ PureRenderMixin ],
+export default class Typography extends React.PureComponent {
+	static displayName = 'Typography';
 
 	render() {
 		const interfaceTitle = {
@@ -92,4 +89,4 @@ export default React.createClass( {
 			</Main>
 		);
 	}
-} );
+}

--- a/client/devdocs/doc.jsx
+++ b/client/devdocs/doc.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import PropTypes from 'prop-types';
 import React from 'react';
 import createReactClass from 'create-react-class';
 
@@ -14,9 +15,9 @@ import highlight from 'lib/highlight';
 export default createReactClass( {
 	displayName: 'SingleDocument',
 	propTypes: {
-		path: React.PropTypes.string.isRequired,
-		term: React.PropTypes.string,
-		sectionId: React.PropTypes.string
+		path: PropTypes.string.isRequired,
+		term: PropTypes.string,
+		sectionId: PropTypes.string
 	},
 	timeoutID: null,
 

--- a/client/devdocs/doc.jsx
+++ b/client/devdocs/doc.jsx
@@ -10,7 +10,7 @@ import DocService from './service';
 import CompactCard from 'components/card/compact';
 import highlight from 'lib/highlight';
 
-module.exports = React.createClass( {
+export default React.createClass( {
 	displayName: 'SingleDocument',
 	propTypes: {
 		path: React.PropTypes.string.isRequired,

--- a/client/devdocs/doc.jsx
+++ b/client/devdocs/doc.jsx
@@ -1,14 +1,14 @@
 /**
  * External dependencies
  */
-var React = require( 'react' );
+import React from 'react';
 
 /**
  * Internal dependencies
  */
-var DocService = require( './service' ),
-	CompactCard = require( 'components/card/compact' ),
-	highlight = require( 'lib/highlight' );
+import DocService from './service';
+import CompactCard from 'components/card/compact';
+import highlight from 'lib/highlight';
 
 module.exports = React.createClass( {
 	displayName: 'SingleDocument',
@@ -58,7 +58,7 @@ module.exports = React.createClass( {
 
 	setBodyScrollPosition: function() {
 		if ( this.props.sectionId ) {
-			var sectionNode = document.getElementById( this.props.sectionId );
+			const sectionNode = document.getElementById( this.props.sectionId );
 
 			if ( sectionNode ) {
 				sectionNode.scrollIntoView();
@@ -85,8 +85,7 @@ module.exports = React.createClass( {
 	},
 
 	render: function() {
-
-		var editURL = encodeURI( 'https://github.com/Automattic/wp-calypso/edit/master/' + this.props.path ) +
+		const editURL = encodeURI( 'https://github.com/Automattic/wp-calypso/edit/master/' + this.props.path ) +
 			'?message=Documentation: <title>&description=What did you change and why&target_branch=update/docs-your-title';
 
 		return (
@@ -98,7 +97,7 @@ module.exports = React.createClass( {
 				<div
 					className="devdocs__doc-content"
 					ref="body"
-					dangerouslySetInnerHTML={{ __html: highlight( this.props.term, this.state.body ) }} //eslint-disable-line react/no-danger
+					dangerouslySetInnerHTML={ { __html: highlight( this.props.term, this.state.body ) } } //eslint-disable-line react/no-danger
 				/>
 			</div>
 		);

--- a/client/devdocs/doc.jsx
+++ b/client/devdocs/doc.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react';
+import createReactClass from 'create-react-class';
 
 /**
  * Internal dependencies
@@ -10,7 +11,7 @@ import DocService from './service';
 import CompactCard from 'components/card/compact';
 import highlight from 'lib/highlight';
 
-export default React.createClass( {
+export default createReactClass( {
 	displayName: 'SingleDocument',
 	propTypes: {
 		path: React.PropTypes.string.isRequired,

--- a/client/devdocs/doc.jsx
+++ b/client/devdocs/doc.jsx
@@ -3,7 +3,6 @@
  */
 import PropTypes from 'prop-types';
 import React from 'react';
-import createReactClass from 'create-react-class';
 
 /**
  * Internal dependencies
@@ -12,53 +11,51 @@ import DocService from './service';
 import CompactCard from 'components/card/compact';
 import highlight from 'lib/highlight';
 
-export default createReactClass( {
-	displayName: 'SingleDocument',
-	propTypes: {
+export default class extends React.Component {
+	static displayName = 'SingleDocument';
+
+	static propTypes = {
 		path: PropTypes.string.isRequired,
 		term: PropTypes.string,
 		sectionId: PropTypes.string
-	},
-	timeoutID: null,
+	};
 
-	getInitialState: function() {
-		return {
-			body: ''
-		};
-	},
+	state = {
+		body: ''
+	};
 
-	componentDidMount: function() {
+	timeoutID = null;
+
+	componentDidMount() {
 		this.fetch();
-	},
+	}
 
-	componentDidUpdate: function( prevProps ) {
+	componentDidUpdate( prevProps ) {
 		if ( this.props.path !== prevProps.path ) {
 			this.fetch();
 		}
 		if ( this.state.body ) {
 			this.setBodyScrollPosition();
 		}
-	},
+	}
 
-	componentWillUnmount: function() {
+	componentWillUnmount() {
 		this.clearLoadingMessage();
-	},
+	}
 
-	fetch: function() {
+	fetch = () => {
 		this.setState( {
 			body: ''
 		} );
 		this.delayLoadingMessage();
 		DocService.fetch( this.props.path, function( err, body ) {
-			if ( this.isMounted() ) {
-				this.setState( {
-					body: ( err || body )
-				} );
-			}
+			this.setState( {
+				body: ( err || body )
+			} );
 		}.bind( this ) );
-	},
+	};
 
-	setBodyScrollPosition: function() {
+	setBodyScrollPosition = () => {
 		if ( this.props.sectionId ) {
 			const sectionNode = document.getElementById( this.props.sectionId );
 
@@ -66,9 +63,9 @@ export default createReactClass( {
 				sectionNode.scrollIntoView();
 			}
 		}
-	},
+	};
 
-	delayLoadingMessage: function() {
+	delayLoadingMessage = () => {
 		this.clearLoadingMessage();
 		this.timeoutID = setTimeout( function() {
 			if ( ! this.state.body ) {
@@ -77,16 +74,16 @@ export default createReactClass( {
 				} );
 			}
 		}.bind( this ), 1000 );
-	},
+	};
 
-	clearLoadingMessage: function() {
+	clearLoadingMessage = () => {
 		if ( 'number' === typeof this.timeoutID ) {
 			window.clearTimeout( this.timeoutID );
 			this.timeoutID = null;
 		}
-	},
+	};
 
-	render: function() {
+	render() {
 		const editURL = encodeURI( 'https://github.com/Automattic/wp-calypso/edit/master/' + this.props.path ) +
 			'?message=Documentation: <title>&description=What did you change and why&target_branch=update/docs-your-title';
 
@@ -99,9 +96,11 @@ export default createReactClass( {
 				<div
 					className="devdocs__doc-content"
 					ref="body"
-					dangerouslySetInnerHTML={ { __html: highlight( this.props.term, this.state.body ) } } //eslint-disable-line react/no-danger
+					dangerouslySetInnerHTML={ //eslint-disable-line react/no-danger
+						{ __html: highlight( this.props.term, this.state.body ) }
+					}
 				/>
 			</div>
 		);
 	}
-} );
+}

--- a/client/devdocs/docs-example/index.jsx
+++ b/client/devdocs/docs-example/index.jsx
@@ -2,7 +2,8 @@
  * External dependencies
  */
 
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 /**
  * Internal dependencies
@@ -73,7 +74,7 @@ const DocsExample = ( {
 };
 
 DocsExample.propTypes = {
-	children: React.PropTypes.element.isRequired,
+	children: PropTypes.element.isRequired,
 	componentUsageStats: PropTypes.shape( {
 		count: PropTypes.number
 	} ),

--- a/client/devdocs/docs-example/wrapper.jsx
+++ b/client/devdocs/docs-example/wrapper.jsx
@@ -3,7 +3,8 @@
  * External dependencies
  */
 
-import React, { PropTypes, Component } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import classNames from 'classnames';
 
 const renderTitle = ( unique, name, url ) => unique

--- a/client/devdocs/docs-selectors/index.jsx
+++ b/client/devdocs/docs-selectors/index.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { PureComponent, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { PureComponent } from 'react';
 
 /**
  * Internal dependencies

--- a/client/devdocs/docs-selectors/param-type.jsx
+++ b/client/devdocs/docs-selectors/param-type.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { get } from 'lodash';
 
 /**

--- a/client/devdocs/docs-selectors/result.jsx
+++ b/client/devdocs/docs-selectors/result.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { filter, findLast } from 'lodash';
 import classnames from 'classnames';
 

--- a/client/devdocs/docs-selectors/search.jsx
+++ b/client/devdocs/docs-selectors/search.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import request from 'superagent';
 import page from 'page';
 import { map } from 'lodash';

--- a/client/devdocs/docs-selectors/single.jsx
+++ b/client/devdocs/docs-selectors/single.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import page from 'page';
 import request from 'superagent';
 import { find } from 'lodash';

--- a/client/devdocs/main.jsx
+++ b/client/devdocs/main.jsx
@@ -3,21 +3,21 @@
  */
 import debug from 'debug';
 import { isFunction } from 'lodash';
-const React = require( 'react' );
+import React from 'react';
 
 /**
  * Internal dependencies
  */
-var DocService = require( './service' ),
-	Card = require( 'components/card' ),
-	Main = require( 'components/main' ),
-	SearchCard = require( 'components/search-card' );
+import DocService from './service';
+import Card from 'components/card';
+import Main from 'components/main';
+import SearchCard from 'components/search-card';
 
 /**
  * Constants
  */
 
-var DEFAULT_FILES = [
+const DEFAULT_FILES = [
 	'docs/guide/index.md',
 	'README.md',
 	'.github/CONTRIBUTING.md',
@@ -62,7 +62,7 @@ module.exports = React.createClass( {
 		}
 
 		DocService.list( DEFAULT_FILES, function( err, results ) {
-			if ( !err && this.isMounted() ) {
+			if ( ! err && this.isMounted() ) {
 				this.setState( {
 					defaultResults: results
 				} );
@@ -71,7 +71,7 @@ module.exports = React.createClass( {
 	},
 
 	componentDidMount: function() {
-		var term = this.state.term;
+		const { term } = this.state;
 		this.loadDefaultFiles();
 		if ( ! term ) {
 			return;
@@ -115,7 +115,7 @@ module.exports = React.createClass( {
 	},
 
 	results: function() {
-		var searchResults;
+		let searchResults;
 
 		if ( this.notFound() ) {
 			return <p>Not Found</p>;
@@ -145,12 +145,12 @@ module.exports = React.createClass( {
 
 	snippet: function( result ) {
 		// split around <mark> tags to avoid setting unescaped inner HTML
-		var parts = result.snippet.split(/(<mark>.*?<\/mark>)/);
+		const parts = result.snippet.split( /(<mark>.*?<\/mark>)/ );
 
 		return (
 			<div className="devdocs__result-snippet" key={ 'snippet' + result.path }>
 				{ parts.map( function( part, i ) {
-					var markMatch = part.match( /<mark>(.*?)<\/mark>/ );
+					const markMatch = part.match( /<mark>(.*?)<\/mark>/ );
 					if ( markMatch ) {
 						return <mark key={ 'mark' + i }>{ markMatch[ 1 ] }</mark>;
 					} else {

--- a/client/devdocs/main.jsx
+++ b/client/devdocs/main.jsx
@@ -33,7 +33,7 @@ const DEFAULT_FILES = [
 
 const log = debug( 'calypso:devdocs' );
 
-module.exports = React.createClass( {
+export default React.createClass( {
 	displayName: 'Devdocs',
 	propTypes: {
 		term: React.PropTypes.string

--- a/client/devdocs/main.jsx
+++ b/client/devdocs/main.jsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import createReactClass from 'create-react-class';
 import debug from 'debug';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -35,44 +34,41 @@ const DEFAULT_FILES = [
 
 const log = debug( 'calypso:devdocs' );
 
-export default createReactClass( {
-	displayName: 'Devdocs',
-	propTypes: {
+export default class Devdocs extends React.Component {
+	static displayName = 'Devdocs';
+
+	static propTypes = {
 		term: PropTypes.string
-	},
+	};
 
-	getDefaultProps: function() {
-		return {
-			term: ''
-		};
-	},
+	static defaultProps = {
+		term: ''
+	};
 
-	getInitialState: function() {
-		return {
-			term: this.props.term,
-			results: [],
-			defaultResults: [],
-			inputValue: '',
-			searching: false
-		};
-	},
+	state = {
+		term: this.props.term,
+		results: [],
+		defaultResults: [],
+		inputValue: '',
+		searching: false
+	};
 
 	// load default files if not already cached
-	loadDefaultFiles: function() {
+	loadDefaultFiles = () => {
 		if ( this.state.defaultResults.length ) {
 			return;
 		}
 
 		DocService.list( DEFAULT_FILES, function( err, results ) {
-			if ( ! err && this.isMounted() ) {
+			if ( ! err ) {
 				this.setState( {
 					defaultResults: results
 				} );
 			}
 		}.bind( this ) );
-	},
+	};
 
-	componentDidMount: function() {
+	componentDidMount() {
 		const { term } = this.state;
 		this.loadDefaultFiles();
 		if ( ! term ) {
@@ -80,27 +76,27 @@ export default createReactClass( {
 		}
 		this.onSearchChange( this.state.term );
 		this.onSearch( this.state.term );
-	},
+	}
 
-	componentDidUpdate: function() {
+	componentDidUpdate() {
 		if ( isFunction( this.props.onSearchChange ) ) {
 			this.props.onSearchChange( this.state.term );
 		}
-	},
+	}
 
-	notFound: function() {
+	notFound = () => {
 		return this.state.inputValue && this.state.term && ! this.state.results.length && ! this.state.searching;
-	},
+	};
 
-	onSearchChange: function( term ) {
+	onSearchChange = term => {
 		this.setState( {
 			inputValue: term,
 			term: term,
 			searching: !! term
 		} );
-	},
+	};
 
-	onSearch: function( term ) {
+	onSearch = term => {
 		if ( ! term ) {
 			return;
 		}
@@ -114,16 +110,14 @@ export default createReactClass( {
 				searching: false
 			} );
 		}.bind( this ) );
-	},
+	};
 
-	results: function() {
-		let searchResults;
-
+	results = () => {
 		if ( this.notFound() ) {
 			return <p>Not Found</p>;
 		}
 
-		searchResults = this.state.inputValue ? this.state.results : this.state.defaultResults;
+		const searchResults = this.state.inputValue ? this.state.results : this.state.defaultResults;
 		return searchResults.map( function( result ) {
 			let url = '/devdocs/' + result.path;
 
@@ -143,9 +137,9 @@ export default createReactClass( {
 				</Card>
 			);
 		}, this );
-	},
+	};
 
-	snippet: function( result ) {
+	snippet = result => {
 		// split around <mark> tags to avoid setting unescaped inner HTML
 		const parts = result.snippet.split( /(<mark>.*?<\/mark>)/ );
 
@@ -155,15 +149,14 @@ export default createReactClass( {
 					const markMatch = part.match( /<mark>(.*?)<\/mark>/ );
 					if ( markMatch ) {
 						return <mark key={ 'mark' + i }>{ markMatch[ 1 ] }</mark>;
-					} else {
-						return part;
 					}
+					return part;
 				} ) }
 			</div>
 		);
-	},
+	};
 
-	render: function() {
+	render() {
 		return (
 			<Main className="devdocs">
 				<SearchCard
@@ -181,4 +174,4 @@ export default createReactClass( {
 			</Main>
 		);
 	}
-} );
+}

--- a/client/devdocs/main.jsx
+++ b/client/devdocs/main.jsx
@@ -3,6 +3,7 @@
  */
 import createReactClass from 'create-react-class';
 import debug from 'debug';
+import PropTypes from 'prop-types';
 import React from 'react';
 import { isFunction } from 'lodash';
 
@@ -37,7 +38,7 @@ const log = debug( 'calypso:devdocs' );
 export default createReactClass( {
 	displayName: 'Devdocs',
 	propTypes: {
-		term: React.PropTypes.string
+		term: PropTypes.string
 	},
 
 	getDefaultProps: function() {

--- a/client/devdocs/main.jsx
+++ b/client/devdocs/main.jsx
@@ -1,9 +1,10 @@
 /**
  * External dependencies
  */
+import createReactClass from 'create-react-class';
 import debug from 'debug';
-import { isFunction } from 'lodash';
 import React from 'react';
+import { isFunction } from 'lodash';
 
 /**
  * Internal dependencies
@@ -33,7 +34,7 @@ const DEFAULT_FILES = [
 
 const log = debug( 'calypso:devdocs' );
 
-export default React.createClass( {
+export default createReactClass( {
 	displayName: 'Devdocs',
 	propTypes: {
 		term: React.PropTypes.string

--- a/client/devdocs/service.js
+++ b/client/devdocs/service.js
@@ -20,7 +20,7 @@ function fetchDocsEndpoint( endpoint, params, callback ) {
  * This service allows you to retrieve a document list (with title, snippets and path) based on
  * query term or filename(s), and also to separately retrieve the document body by path.
  */
-module.exports = {
+export default {
 	search: function( term, callback ) {
 		fetchDocsEndpoint( 'search', { q: term }, callback );
 	},

--- a/client/devdocs/service.js
+++ b/client/devdocs/service.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var request = require( 'superagent' );
+import request from 'superagent';
 
 function fetchDocsEndpoint( endpoint, params, callback ) {
 	request.
@@ -13,7 +13,7 @@ function fetchDocsEndpoint( endpoint, params, callback ) {
 			} else {
 				callback( 'Error invoking /devdocs/' + endpoint + ': ' + res.text, null );
 			}
-		});
+		} );
 }
 
 /**
@@ -26,7 +26,7 @@ module.exports = {
 	},
 
 	list: function( filenames, callback ) {
-		fetchDocsEndpoint( 'list', { files: filenames.join(',') }, callback );
+		fetchDocsEndpoint( 'list', { files: filenames.join( ',' ) }, callback );
 	},
 
 	fetch: function( path, callback ) {

--- a/client/devdocs/sidebar.jsx
+++ b/client/devdocs/sidebar.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import React from 'react';
-import PureRenderMixin from 'react-pure-render/mixin';
 
 /**
  * Internal dependencies
@@ -12,11 +11,8 @@ import SidebarHeading from 'layout/sidebar/heading';
 import SidebarMenu from 'layout/sidebar/menu';
 import SidebarItem from 'layout/sidebar/item';
 
-export default React.createClass( {
-
-	displayName: 'DevdocsSidebar',
-
-	mixins: [ PureRenderMixin ],
+export default class DevdocsSidebar extends React.PureComponent {
+	static displayName = 'DevdocsSidebar';
 
 	render() {
 		return (
@@ -92,4 +88,4 @@ export default React.createClass( {
 			</Sidebar>
 		);
 	}
-} );
+}

--- a/client/devdocs/test/doc.jsx
+++ b/client/devdocs/test/doc.jsx
@@ -44,7 +44,7 @@ describe( 'SingleDoc', () => {
 
 			it( 'should render html with marked text', () => {
 				renderedSingleDoc.setState( { body: fetchResponse } );
-				let html = ReactDom.findDOMNode( renderedSingleDoc.refs.body ).innerHTML;
+				const html = ReactDom.findDOMNode( renderedSingleDoc.refs.body ).innerHTML;
 				expect( html ).to.equal( '<div><p>something <mark>hello</mark></p></div>' );
 			} );
 		} );

--- a/client/devdocs/welcome.jsx
+++ b/client/devdocs/welcome.jsx
@@ -2,18 +2,14 @@
  * External dependencies
  */
 import React from 'react';
-import PureRenderMixin from 'react-pure-render/mixin';
 
 /**
  * Internal dependencies
  */
 import Card from 'components/card';
 
-export default React.createClass( {
-
-	displayName: 'DevWelcome',
-
-	mixins: [ PureRenderMixin ],
+export default class extends React.PureComponent {
+	static displayName = 'DevWelcome';
 
 	render() {
 		return (
@@ -24,4 +20,4 @@ export default React.createClass( {
 			</Card>
 		);
 	}
-} );
+}


### PR DESCRIPTION
This change runs several codemods to achieve the following:

Before | After
------------ | -------------
`require( ... )` nested in blocks | All `require( ... )` moved to top block
`var ... = require( ... )` | `import ... from '...'`
`module.exports = ...` | `export default ...`
`this.translate` | `this.props.translate` via HOC
`React.createClass( ... )` | `class ThisComponentName extends React.Component`
`React.createClass( ... )` | `createReactClass( ... )` if unconvertible to `React.Component` subclass
`import { PropTypes } from 'react'` | `import PropTypes from 'prop-types'`

#### Testing instructions

1. Check out locally (`git checkout modernize/devdocs`) and start your server. You can also use a [live branch](https://calypso.live/?branch=modernize/devdocs)
2. Open the [DevDocs Page](http://calypso.localhost:3000/devdocs)
3. Verify that all components work identically to before.
