### PR TITLE
Editor: Reset raw content when switching modes

### DIFF
--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -1298,6 +1298,7 @@ export const PostEditor = createReactClass( {
 			function() {
 				// TODO: REDUX - remove flux actions when whole post-editor is reduxified
 				actions.edit( { content: content } );
+				actions.resetRawContent();
 
 				if ( mode === 'html' ) {
 					// Set raw content directly to avoid race conditions


### PR DESCRIPTION
See: https://github.com/Automattic/wp-calypso/issues/6869#issuecomment-327259455
Related: #9833, #6869, #5438, 10420-gh-calypso-pre-oss

This pull request seeks to restore a call to `actions.resetRawContent` when switching editor modes which was accidentally removed in #5438.

https://github.com/Automattic/wp-calypso/pull/5438/files#diff-914bdeefa512de6f78c9b7988546d6e3L903

For simple posts, this can help avoid the post from being considered as having unsaved changes when merely switching between Text and HTML modes. This does not fix all instances of #6869 however, and needs improved handling of content encoding when switching between editor modes. See https://github.com/Automattic/wp-calypso/issues/6869#issuecomment-327259455 for a detailed explanation.

__Testing instructions:__

1. Navigate to the [post editor](http://calypso.localhost:3000/post)
2. Select a site, if prompted
3. Enter some simple content ("1234")
4. Save the post
5. Switch between Visual and HTML modes
6. Navigate away from the editor
7. Note that you are not prompted about unsaved changes