### PR TITLE
Plugins: use 3-column layout only for installed plugins list

### DIFF
--- a/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
+++ b/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
@@ -243,26 +243,30 @@ const PlansSetup = React.createClass( {
 		return plugins.map( ( item, i ) => {
 			const plugin = Object.assign( {}, item, getPlugin( this.props.wporg, item.slug ) );
 
+			/* eslint-disable wpcalypso/jsx-classname-namespace */
 			return (
 				<CompactCard className="plugin-item" key={ i }>
 					<span className="plugin-item__link">
 						<PluginIcon image={ plugin.icon } />
-						<div className="plugin-item__title">
-							{ plugin.name }
+						<div className="plugin-item__info">
+							<div className="plugin-item__title">
+								{ plugin.name }
+							</div>
+							{ hidden
+								? <Notice
+									key={ 0 }
+									isCompact={ true }
+									showDismiss={ false }
+									icon="plugins"
+									text={ this.props.translate( 'Waiting to install' ) } />
+								: this.renderStatus( plugin )
+							}
 						</div>
-						{ hidden
-							? <Notice
-								key={ 0 }
-								isCompact={ true }
-								showDismiss={ false }
-								icon="plugins"
-								text={ this.props.translate( 'Waiting to install' ) } />
-							: this.renderStatus( plugin )
-						}
 					</span>
 					{ this.renderActions( plugin ) }
 				</CompactCard>
 			);
+			/* eslint-enable wpcalypso/jsx-classname-namespace */
 		} );
 	},
 

--- a/client/my-sites/plugins/jetpack-plugins-setup/style.scss
+++ b/client/my-sites/plugins/jetpack-plugins-setup/style.scss
@@ -17,14 +17,6 @@
 	.plugin-item__link {
 		cursor: default;
 	}
-
-	.plugin-item {
-		width: 100%;
-
-		&:nth-last-child( n + 2 ) {
-			border-bottom-width: 1px;
-		}
-	}
 }
 
 .jetpack-plugins-setup__header {
@@ -47,6 +39,14 @@
 
 	.button + .button {
 		margin-right: 16px;
+	}
+}
+
+.jetpack-plugins-setup .plugin-item {
+	width: 100%;
+
+	&:nth-last-child( n + 2 ) {
+		border-bottom-width: 1px;
 	}
 }
 

--- a/client/my-sites/plugins/jetpack-plugins-setup/style.scss
+++ b/client/my-sites/plugins/jetpack-plugins-setup/style.scss
@@ -17,6 +17,14 @@
 	.plugin-item__link {
 		cursor: default;
 	}
+
+	.plugin-item {
+		width: 100%;
+
+		&:nth-last-child( n + 2 ) {
+			border-bottom-width: 1px;
+		}
+	}
 }
 
 .jetpack-plugins-setup__header {

--- a/client/my-sites/plugins/plugin-item/style.scss
+++ b/client/my-sites/plugins/plugin-item/style.scss
@@ -35,10 +35,6 @@
 	display: flex;
 	overflow: hidden; // lazy clearfix
 
-	@include breakpoint( '>1040px' ) {
-		flex-direction: column;
-	}
-
 	&.disabled {
 		opacity: 0.5;
 		background: $gray-light;
@@ -150,14 +146,6 @@
 		flex-direction: column;
 		text-align: right;
 	}
-
-	@include breakpoint( '>1040px' ) {
-		align-self: flex-start;
-		flex-direction: row;
-		margin-top: -6px;
-		padding-top: 0;
-		text-align: left;
-	}
 }
 
 .plugin-item .plugin-item__count {
@@ -250,39 +238,4 @@
 .plugin-item {
 	box-sizing: border-box;
 	border: 0 solid lighten( $gray, 30% );
-
-	@include breakpoint( ">1040px" ) {
-		width: 33.33%;
-
-		border-right-width: 1px;
-
-		&:nth-child( 3n ) {
-			border-right-width: 0;
-		}
-
-		&:nth-last-child( n + 4 ) {
-			border-bottom-width: 1px;
-		}
-
-		// Provider proper bottom borders in the second-last row when the number
-		// of items is not multiple of 3.
-		&:nth-child( 3n ) {
-			&:nth-last-child( 3 ),
-			&:nth-last-child( 2 ) {
-				border-bottom-width: 1px;
-			}
-		}
-
-		&:nth-child( 3n - 1 ):nth-last-child( 3 ) {
-			border-bottom-width: 1px;
-		}
-	}
-
-	@include breakpoint( "<1040px" ) {
-		width: 100%;
-
-		&:nth-last-child( n + 2 ) {
-			border-bottom-width: 1px;
-		}
-	}
 }

--- a/client/my-sites/plugins/plugins-list/style.scss
+++ b/client/my-sites/plugins/plugins-list/style.scss
@@ -1,5 +1,53 @@
 .plugins-list {
 	margin-bottom: 16px;
+
+	.plugin-item {
+		@include breakpoint( "<1040px" ) {
+			width: 100%;
+
+			&:nth-last-child( n + 2 ) {
+				border-bottom-width: 1px;
+			}
+		}
+
+		@include breakpoint( ">1040px" ) {
+			flex-direction: column;
+			width: 33.33%;
+			border-right-width: 1px;
+
+			&:nth-child( 3n ) {
+				border-right-width: 0;
+			}
+
+			&:nth-last-child( n + 4 ) {
+				border-bottom-width: 1px;
+			}
+
+			// Provider proper bottom borders in the second-last row when the number
+			// of items is not multiple of 3.
+			&:nth-child( 3n ) {
+				&:nth-last-child( 3 ),
+				&:nth-last-child( 2 ) {
+					border-bottom-width: 1px;
+				}
+			}
+
+			&:nth-child( 3n - 1 ):nth-last-child( 3 ) {
+				border-bottom-width: 1px;
+			}
+
+			.plugin-item__count,
+			.plugin-item__actions {
+				@include breakpoint( '>1040px' ) {
+					align-self: flex-start;
+					flex-direction: row;
+					margin-top: -6px;
+					padding-top: 0;
+					text-align: left;
+				}
+			}
+		}
+	}
 }
 
 .plugins-list__elements {

--- a/client/my-sites/plugins/plugins-list/style.scss
+++ b/client/my-sites/plugins/plugins-list/style.scss
@@ -1,51 +1,49 @@
 .plugins-list {
 	margin-bottom: 16px;
+}
 
-	.plugin-item {
-		@include breakpoint( "<1040px" ) {
-			width: 100%;
+.plugins-list .plugin-item {
+	@include breakpoint( "<1040px" ) {
+		width: 100%;
 
-			&:nth-last-child( n + 2 ) {
+		&:nth-last-child( n + 2 ) {
+			border-bottom-width: 1px;
+		}
+	}
+
+	@include breakpoint( ">1040px" ) {
+		flex-direction: column;
+		width: 33.33%;
+		border-right-width: 1px;
+
+		&:nth-child( 3n ) {
+			border-right-width: 0;
+		}
+
+		&:nth-last-child( n + 4 ) {
+			border-bottom-width: 1px;
+		}
+
+		// Provider proper bottom borders in the second-last row when the number
+		// of items is not multiple of 3.
+		&:nth-child( 3n ) {
+			&:nth-last-child( 3 ),
+			&:nth-last-child( 2 ) {
 				border-bottom-width: 1px;
 			}
 		}
 
-		@include breakpoint( ">1040px" ) {
-			flex-direction: column;
-			width: 33.33%;
-			border-right-width: 1px;
+		&:nth-child( 3n - 1 ):nth-last-child( 3 ) {
+			border-bottom-width: 1px;
+		}
 
-			&:nth-child( 3n ) {
-				border-right-width: 0;
-			}
-
-			&:nth-last-child( n + 4 ) {
-				border-bottom-width: 1px;
-			}
-
-			// Provider proper bottom borders in the second-last row when the number
-			// of items is not multiple of 3.
-			&:nth-child( 3n ) {
-				&:nth-last-child( 3 ),
-				&:nth-last-child( 2 ) {
-					border-bottom-width: 1px;
-				}
-			}
-
-			&:nth-child( 3n - 1 ):nth-last-child( 3 ) {
-				border-bottom-width: 1px;
-			}
-
-			.plugin-item__count,
-			.plugin-item__actions {
-				@include breakpoint( '>1040px' ) {
-					align-self: flex-start;
-					flex-direction: row;
-					margin-top: -6px;
-					padding-top: 0;
-					text-align: left;
-				}
-			}
+		.plugin-item__count,
+		.plugin-item__actions {
+			align-self: flex-start;
+			flex-direction: row;
+			margin-top: -6px;
+			padding-top: 0;
+			text-align: left;
 		}
 	}
 }


### PR DESCRIPTION
Don't use it at other places like jetpack-plugins-setup.

Achieved by moving all styling that specifies the number of columns and performs layout tweaks from the generic `.plugin-item` class to a nested selectors like `.plugins-list .plugin-item` or `.jetpack-plugins-setup .plugin-item`.

Also, use the `.plugin-item__info` div to enclose the plugin name and notice: that fixes the plugin item layout in Jetpack Plugins Setup.

To test:
- go to `/plugins/setup/:jetpack_site_id` and verify that plugins are displayed correctly in one column and the layout isn't broken
- go to `/plugins/manage/:site_id` and verify that the installed plugins list has 3 columns (when the window is wide enough) and that the layout isn't broken.

Cc @Automattic/luna 