### PR TITLE
Jetpack Connect: Implement hide free plan test

### DIFF
--- a/client/jetpack-connect/plans-grid.jsx
+++ b/client/jetpack-connect/plans-grid.jsx
@@ -66,7 +66,9 @@ class JetpackPlansGrid extends Component {
 							onUpgradeClick={ this.props.onSelect }
 							intervalType={ this.props.interval }
 							hideFreePlan={ this.props.hideFreePlan }
-							displayJetpackPlans={ true } />
+							displayJetpackPlans={ true }
+						/>
+						{ this.props.children }
 					</div>
 				</div>
 			</Main>

--- a/client/jetpack-connect/plans-landing.jsx
+++ b/client/jetpack-connect/plans-landing.jsx
@@ -9,6 +9,8 @@ import page from 'page';
  * Internal dependencies
  */
 import PlansGrid from './plans-grid';
+import PlansSkipButton from './plans-skip-button';
+import { abtest } from 'lib/abtest';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { selectPlanInAdvance } from 'state/jetpack-connect/actions';
 import { getJetpackSiteByUrl } from 'state/jetpack-connect/selectors';
@@ -67,11 +69,19 @@ class PlansLanding extends Component {
 		}, 25 );
 	};
 
+	handleSkipButtonClick = () => {
+		this.props.recordTracksEvent( 'calypso_jpc_plans_skip_button_click' );
+
+		this.storeSelectedPlan( null );
+	};
+
 	render() {
 		const {
 			basePlansPath,
 			interval,
 		} = this.props;
+		const hideFreePlanTest = abtest( 'jetpackConnectHideFreePlan' ) === 'hide';
+
 		return (
 			<div>
 				<QueryPlans />
@@ -79,11 +89,16 @@ class PlansLanding extends Component {
 				<PlansGrid
 					basePlansPath={ basePlansPath }
 					calypsoStartedConnection={ true }
-					hideFreePlan={ false }
+					hideFreePlan={ hideFreePlanTest }
 					interval={ interval }
 					isLanding={ true }
 					onSelect={ this.storeSelectedPlan }
-				/>
+				>
+					{
+						hideFreePlanTest &&
+						<PlansSkipButton onClick={ this.handleSkipButtonClick } />
+					}
+				</PlansGrid>
 			</div>
 		);
 	}

--- a/client/jetpack-connect/plans-skip-button.jsx
+++ b/client/jetpack-connect/plans-skip-button.jsx
@@ -1,0 +1,27 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Button from 'components/button';
+
+const PlansSkipButton = ( {
+	onClick,
+	translate
+} ) => (
+	<div className="jetpack-connect__plans-nav-buttons">
+		<Button
+			onClick={ onClick }
+			compact
+			borderless
+		>
+			{ translate( 'Skip' ) }
+		</Button>
+	</div>
+);
+
+export default localize( PlansSkipButton );

--- a/client/jetpack-connect/plans.jsx
+++ b/client/jetpack-connect/plans.jsx
@@ -10,8 +10,8 @@ import { get } from 'lodash';
 /**
  * Internal dependencies
  */
-import Button from 'components/button';
 import PlansGrid from './plans-grid';
+import PlansSkipButton from './plans-skip-button';
 import { PLAN_JETPACK_FREE,
 	PLAN_JETPACK_PREMIUM,
 	PLAN_JETPACK_PREMIUM_MONTHLY,
@@ -289,7 +289,6 @@ class Plans extends Component {
 			return <QueryPlans />;
 		}
 
-		const { translate } = this.props;
 		const hideFreePlanTest = abtest( 'jetpackConnectHideFreePlan' ) === 'hide';
 
 		return (
@@ -306,17 +305,8 @@ class Plans extends Component {
 					hideFreePlan={ hideFreePlanTest }
 				>
 					{
-						hideFreePlanTest && (
-							<div className="jetpack-connect__plans-nav-buttons">
-								<Button
-									onClick={ this.handleSkipButtonClick }
-									compact
-									borderless
-								>
-									{ translate( 'Skip' ) }
-								</Button>
-							</div>
-						)
+						hideFreePlanTest &&
+						<PlansSkipButton onClick={ this.handleSkipButtonClick } />
 					}
 				</PlansGrid>
 			</div>

--- a/client/jetpack-connect/plans.jsx
+++ b/client/jetpack-connect/plans.jsx
@@ -10,6 +10,7 @@ import { get } from 'lodash';
 /**
  * Internal dependencies
  */
+import Button from 'components/button';
 import PlansGrid from './plans-grid';
 import { PLAN_JETPACK_FREE,
 	PLAN_JETPACK_PREMIUM,
@@ -38,6 +39,7 @@ import {
 } from 'state/jetpack-connect/selectors';
 import { mc } from 'lib/analytics';
 import { isSiteAutomatedTransfer } from 'state/selectors';
+import { abtest } from 'lib/abtest';
 
 const CALYPSO_REDIRECTION_PAGE = '/posts/';
 const CALYPSO_PLANS_PAGE = '/plans/my-plan/';
@@ -95,6 +97,10 @@ class Plans extends Component {
 				! this.redirecting ) {
 			return this.autoselectPlan();
 		}
+	}
+
+	handleSkipButtonClick = () => {
+		this.selectFreeJetpackPlan();
 	}
 
 	isFlowTypePaid() {
@@ -281,6 +287,9 @@ class Plans extends Component {
 			return <QueryPlans />;
 		}
 
+		const { translate } = this.props;
+		const hideFreePlanTest = abtest( 'jetpackConnectHideFreePlan' ) === 'hide';
+
 		return (
 			<div>
 				<QueryPlans />
@@ -291,7 +300,23 @@ class Plans extends Component {
 				<PlansGrid
 					{ ...this.props }
 					basePlansPath={ this.props.showFirst ? '/jetpack/connect/authorize' : '/jetpack/connect/plans' }
-					onSelect={ this.props.showFirst || this.props.isLanding ? this.storeSelectedPlan : this.selectPlan } />
+					onSelect={ this.props.showFirst || this.props.isLanding ? this.storeSelectedPlan : this.selectPlan }
+					hideFreePlan={ hideFreePlanTest }
+				>
+					{
+						hideFreePlanTest && (
+							<div className="jetpack-connect__plans-nav-buttons">
+								<Button
+									onClick={ this.handleSkipButtonClick }
+									compact
+									borderless
+								>
+									{ translate( 'Skip' ) }
+								</Button>
+							</div>
+						)
+					}
+				</PlansGrid>
 			</div>
 		);
 	}

--- a/client/jetpack-connect/plans.jsx
+++ b/client/jetpack-connect/plans.jsx
@@ -100,6 +100,8 @@ class Plans extends Component {
 	}
 
 	handleSkipButtonClick = () => {
+		this.props.recordTracksEvent( 'calypso_jpc_plans_skip_button_click' );
+
 		this.selectFreeJetpackPlan();
 	}
 

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -487,6 +487,11 @@
 
 .jetpack-connect__plans-nav-buttons {
 	text-align: center;
+
+	.button.is-compact {
+		font-size: 14px;
+		font-weight: 500;
+	}
 }
 
 .jetpack-connect__plans {

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -485,6 +485,9 @@
 	margin-bottom: 16px;
 }
 
+.jetpack-connect__plans-nav-buttons {
+	text-align: center;
+}
 
 .jetpack-connect__plans {
 	.plan-features__header-figure {

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -33,6 +33,14 @@ module.exports = {
 		defaultVariation: 'original',
 		localeTargets: 'any',
 	},
+	jetpackConnectHideFreePlan: {
+		datestamp: '20170905',
+		variations: {
+			show: 50,
+			hide: 50,
+		},
+		defaultVariation: 'show',
+	},
 	newSiteWithJetpack: {
 		datestamp: '20170419',
 		variations: {


### PR DESCRIPTION
### Purpose & functionality

As @richardmuscat suggested in p7kMJG-3fL-p2, this PR implements a test where in our Jetpack signup flow we hide the Free plan, and display a Skip button at the bottom instead. 

The Skip button serves the purpose of selecting a free plan, which can do a couple of different things depending on the situation:

* If the JPC flow started in Calypso, user is redirected to `/posts/`
* If the JPC flow started in wp-admin, user is redirected to the wp-admin.

### Preview

**Before**
![](https://cldup.com/PTPx2DMkh8.png)

**After**
![](https://cldup.com/SKR0PTnRfd.png)

### To test

* Checkout this branch or get it going on calypso.live
* Enable the test by typing the following in your console: `localStorage.setItem( 'ABTests', '{"jetpackConnectHideFreePlan_20170905":"hide"}' );`
* Connect a new Jetpack site and get to the Plan selection page.
* Verify you no longer see the free plan.
* Verify you see the Skip link at the bottom.
* Click the Skip link at the bottom and verify it works just like the Free plan button does.
* Disable the test by typing the following in your console: `localStorage.setItem( 'ABTests', '{"jetpackConnectHideFreePlan_20170905":"show"}' );`
* Test various flows with this AB test enabled and verify it works as expected.
* Connect a new Jetpack site and get to the Plan selection page.
* Verify you see the Free plan and you don't see the Skip link.
* Test various flows with this AB test disabled and verify it works as expected.

### Questions

* Do we need to apply any additional styling to the Skip link? cc @rickybanister 
* Do we want to update the Skip button copy in any way? cc @Automattic/editorial 