### PR TITLE
Modernize lib/analytics (ES modules, React.Component, etc.)

### DIFF
--- a/client/lib/analytics/ad-tracking.js
+++ b/client/lib/analytics/ad-tracking.js
@@ -273,7 +273,7 @@ function loadTrackingScripts( callback ) {
  * 2. `Do Not Track` is enabled
  * 3. `document.location.href` may contain personally identifiable information
  *
- * @returns {Boolean}
+ * @returns {Boolean} Is ad tracking is allowed?
  */
 function isAdTrackingAllowed() {
 	return config.isEnabled( 'ad-tracking' ) && ! doNotTrack() && ! isPiiUrl();

--- a/client/lib/analytics/ad-tracking.js
+++ b/client/lib/analytics/ad-tracking.js
@@ -1059,7 +1059,7 @@ function recordSignupCompletion() {
 	recordSignupCompletionInFloodlight();
 }
 
-module.exports = {
+export default {
 	retarget: function( context, next ) {
 		const nextFunction = typeof next === 'function' ? next : noop;
 

--- a/client/lib/analytics/ad-tracking.js
+++ b/client/lib/analytics/ad-tracking.js
@@ -2,17 +2,16 @@
  * External dependencies
  */
 import async from 'async';
-import { assign, clone, cloneDeep, noop, some } from 'lodash';
-import debugFactory from 'debug';
-const debug = debugFactory( 'calypso:analytics:ad-tracking' );
 import cookie from 'cookie';
+import debugFactory from 'debug';
+import { assign, clone, cloneDeep, noop, some } from 'lodash';
 import { v4 as uuid } from 'uuid';
 
 /**
  * Internal dependencies
  */
-import loadScript from 'lib/load-script';
 import config from 'config';
+import loadScript from 'lib/load-script';
 import productsValues from 'lib/products-values';
 import userModule from 'lib/user';
 import { doNotTrack, isPiiUrl } from 'lib/analytics/utils';
@@ -20,6 +19,7 @@ import { doNotTrack, isPiiUrl } from 'lib/analytics/utils';
 /**
  * Module variables
  */
+const debug = debugFactory( 'calypso:analytics:ad-tracking' );
 const user = userModule();
 let hasStartedFetchingScripts = false,
 	hasFinishedFetchingScripts = false;

--- a/client/lib/analytics/index.js
+++ b/client/lib/analytics/index.js
@@ -493,4 +493,4 @@ const analytics = {
 	}
 };
 emitter( analytics );
-module.exports = analytics;
+export default analytics;

--- a/client/lib/analytics/index.js
+++ b/client/lib/analytics/index.js
@@ -1,17 +1,29 @@
 /**
  * External dependencies
  */
-import { assign, isObjectLike, isUndefined, omit, pickBy, startsWith, times } from 'lodash';
 import cookie from 'cookie';
-const debug = require( 'debug' ),
-	url = require( 'url' ),
-	qs = require( 'qs' );
+import debug from 'debug';
+import qs from 'qs';
+import url from 'url';
+import { assign, isObjectLike, isUndefined, omit, pickBy, startsWith, times } from 'lodash';
 
 /**
  * Internal dependencies
  */
-const config = require( 'config' ),
-	loadScript = require( 'lib/load-script' ).loadScript;
+import config from 'config';
+import emitter from 'lib/mixins/emitter';
+import { ANALYTICS_SUPER_PROPS_UPDATE } from 'state/action-types';
+import { doNotTrack, isPiiUrl } from 'lib/analytics/utils';
+import { loadScript } from 'lib/load-script';
+import { retarget, recordAliasInFloodlight, recordPageViewInFloodlight } from 'lib/analytics/ad-tracking';
+import { statsdTimingUrl } from 'lib/analytics/statsd';
+
+/**
+ * Module variables
+ */
+const mcDebug = debug( 'calypso:analytics:mc' );
+const gaDebug = debug( 'calypso:analytics:ga' );
+const tracksDebug = debug( 'calypso:analytics:tracks' );
 
 let _superProps,
 	_user,
@@ -19,17 +31,6 @@ let _superProps,
 	_siteCount,
 	_dispatch,
 	_loadTracksError;
-
-import { retarget, recordAliasInFloodlight, recordPageViewInFloodlight } from 'lib/analytics/ad-tracking';
-import { doNotTrack, isPiiUrl } from 'lib/analytics/utils';
-import { ANALYTICS_SUPER_PROPS_UPDATE } from 'state/action-types';
-const mcDebug = debug( 'calypso:analytics:mc' );
-const gaDebug = debug( 'calypso:analytics:ga' );
-const tracksDebug = debug( 'calypso:analytics:tracks' );
-
-import emitter from 'lib/mixins/emitter';
-
-import { statsdTimingUrl } from 'lib/analytics/statsd';
 
 // Load tracking scripts
 window._tkq = window._tkq || [];

--- a/client/lib/analytics/page-view-tracker/index.jsx
+++ b/client/lib/analytics/page-view-tracker/index.jsx
@@ -10,20 +10,29 @@ import { connect } from 'react-redux';
  */
 import { recordPageView } from 'state/analytics/actions';
 
-export const PageViewTracker = React.createClass( {
-	getInitialState: () => ( {
+export class PageViewTracker extends React.Component {
+	static displayName = 'PageViewTracker';
+
+	static propTypes = {
+		delay: PropTypes.number,
+		path: PropTypes.string.isRequired,
+		recorder: PropTypes.func,
+		title: PropTypes.string.isRequired
+	};
+
+	state = {
 		timer: null
-	} ),
+	};
 
 	componentDidMount() {
 		this.queuePageView();
-	},
+	}
 
 	componentWillUnmount() {
 		clearTimeout( this.state.timer );
-	},
+	}
 
-	queuePageView() {
+	queuePageView = () => {
 		const {
 			delay = 0,
 			path,
@@ -42,17 +51,12 @@ export const PageViewTracker = React.createClass( {
 		this.setState( {
 			timer: setTimeout( () => recorder( path, title ), delay )
 		} );
-	},
+	};
 
-	render: () => null
-} );
-
-PageViewTracker.propTypes = {
-	delay: PropTypes.number,
-	path: PropTypes.string.isRequired,
-	recorder: PropTypes.func,
-	title: PropTypes.string.isRequired
-};
+	render() {
+		return null;
+	}
+}
 
 const mapDispatchToProps = dispatch => ( {
 	recorder: flowRight( dispatch, recordPageView )

--- a/client/lib/analytics/page-view-tracker/index.jsx
+++ b/client/lib/analytics/page-view-tracker/index.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import debugFactory from 'debug';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { flowRight, noop } from 'lodash';
@@ -10,6 +11,11 @@ import { connect } from 'react-redux';
  * Internal dependencies
  */
 import { recordPageView } from 'state/analytics/actions';
+
+/**
+ * Module variables
+ */
+const debug = debugFactory( 'calypso:analytics:PageViewTracker' );
 
 export class PageViewTracker extends React.Component {
 	static displayName = 'PageViewTracker';
@@ -26,10 +32,12 @@ export class PageViewTracker extends React.Component {
 	};
 
 	componentDidMount() {
+		debug( 'Component has mounted.' );
 		this.queuePageView();
 	}
 
 	componentWillUnmount() {
+		debug( 'Component has unmounted.' );
 		clearTimeout( this.state.timer );
 	}
 
@@ -40,6 +48,8 @@ export class PageViewTracker extends React.Component {
 			recorder = noop,
 			title
 		} = this.props;
+
+		debug( `Queuing Page View: "${ title }" at "${ path }" with ${ delay }ms delay` );
 
 		if ( this.state.timer ) {
 			return;

--- a/client/lib/analytics/page-view-tracker/index.jsx
+++ b/client/lib/analytics/page-view-tracker/index.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { flowRight, noop } from 'lodash';
 import { connect } from 'react-redux';
 

--- a/client/lib/analytics/page-view-tracker/test/index.jsx
+++ b/client/lib/analytics/page-view-tracker/test/index.jsx
@@ -1,11 +1,16 @@
+/**
+ * External dependencies
+ */
 import React from 'react';
 import { expect } from 'chai';
 import { mount } from 'enzyme';
 import { spy } from 'sinon';
 
+/**
+ * Internal dependencies
+ */
 import useFakeDom from 'test/helpers/use-fake-dom';
 import { useFakeTimers } from 'test/helpers/use-sinon';
-
 import { PageViewTracker } from '../';
 
 describe( 'PageViewTracker', () => {
@@ -13,7 +18,7 @@ describe( 'PageViewTracker', () => {
 
 	useFakeDom();
 	useFakeTimers( fakeClock => {
-		clock = fakeClock
+		clock = fakeClock;
 	} );
 
 	it( 'should immediately fire off event when given no delay', () => {
@@ -33,7 +38,7 @@ describe( 'PageViewTracker', () => {
 
 		clock.tick( 500 );
 
-		expect( recorder ).to.have.been.calledOnce
+		expect( recorder ).to.have.been.calledOnce;
 	} );
 
 	it( 'should pass the appropriate event information', () => {

--- a/client/lib/analytics/super-props.js
+++ b/client/lib/analytics/super-props.js
@@ -3,9 +3,6 @@
  */
 import config from 'config';
 import { assign } from 'lodash';
-/**
- * Internal dependencies
- */
 
 module.exports = {
 	getAll: function( selectedSite, siteCount ) {

--- a/client/lib/analytics/super-props.js
+++ b/client/lib/analytics/super-props.js
@@ -4,7 +4,7 @@
 import config from 'config';
 import { assign } from 'lodash';
 
-module.exports = {
+export default {
 	getAll: function( selectedSite, siteCount ) {
 		let siteProps = {};
 		const defaultProps = {

--- a/client/lib/analytics/test/config/index.js
+++ b/client/lib/analytics/test/config/index.js
@@ -1,4 +1,4 @@
-module.exports = function( key ) {
+export default function( key ) {
 	if ( key === 'mc_analytics_enabled' ) {
 		return true;
 	}
@@ -8,4 +8,4 @@ module.exports = function( key ) {
 	}
 
 	throw new Error( 'key ' + key + ' not expected to be needed' );
-};
+}

--- a/client/lib/analytics/test/index.js
+++ b/client/lib/analytics/test/index.js
@@ -1,12 +1,18 @@
-const expect = require( 'chai' ).expect,
-	url = require( 'url' );
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+import url from 'url';
 
-const useFakeDom = require( 'test/helpers/use-fake-dom' ),
-	useFilesystemMocks = require( 'test/helpers/use-filesystem-mocks' );
+/**
+ * Internal dependencies
+ */
+import useFakeDom from 'test/helpers/use-fake-dom';
+import useFilesystemMocks from 'test/helpers/use-filesystem-mocks';
 
 function logImageLoads() {
-	var imagesLoaded = [],
-		originalImage;
+	const imagesLoaded = [];
+	let originalImage;
 
 	before( function spyOnImage() {
 		imagesLoaded.length = 0;

--- a/client/lib/analytics/test/lib/load-script/index.js
+++ b/client/lib/analytics/test/lib/load-script/index.js
@@ -12,4 +12,4 @@ function fakeLoader( url, callback ) {
 
 fakeLoader.urlsLoaded = [];
 
-module.exports = { loadScript: fakeLoader };
+export default { loadScript: fakeLoader };

--- a/client/lib/analytics/track-component-view/index.jsx
+++ b/client/lib/analytics/track-component-view/index.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import debugFactory from 'debug';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -9,6 +10,11 @@ import { connect } from 'react-redux';
  * Internal dependencies
  */
 import { bumpStat, recordTracksEvent } from 'state/analytics/actions';
+
+/**
+ * Module variables
+ */
+const debug = debugFactory( 'calypso:analytics:TrackComponentView' );
 
 class TrackComponentView extends Component {
 	static propTypes = {
@@ -24,13 +30,16 @@ class TrackComponentView extends Component {
 	};
 
 	componentWillMount() {
+		debug( 'Component will mount.' );
 		const { eventName, eventProperties } = this.props;
 		if ( eventName ) {
+			debug( `Recording Tracks event "${ eventName }".` );
 			this.props.recordTracksEvent( eventName, eventProperties );
 		}
 
 		const { statGroup, statName } = this.props;
 		if ( statGroup ) {
+			debug( `Bumping stat "${ statName }".` );
 			this.props.bumpStat( statGroup, statName );
 		}
 	}

--- a/client/lib/analytics/track-component-view/index.jsx
+++ b/client/lib/analytics/track-component-view/index.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import { PropTypes, Component } from 'react';
+import PropTypes from 'prop-types';
+import { Component } from 'react';
 import { connect } from 'react-redux';
 
 /**

--- a/client/lib/analytics/utils.js
+++ b/client/lib/analytics/utils.js
@@ -3,7 +3,7 @@
  *
  * @returns {Boolean} true if Do Not Track is enabled in the user's browser.
  */
-function doNotTrack() {
+export function doNotTrack() {
 	return '1' === navigator.doNotTrack;
 }
 
@@ -36,17 +36,12 @@ const forbiddenPiiPatternsEnc = forbiddenPiiPatterns.map( pattern => {
  *
  * @returns {Boolean} true if the current URL can potentially contain personally identifiable info.
  */
-function isPiiUrl() {
+export function isPiiUrl() {
 	const href = document.location.href;
 
 	const match = pattern => {
 		return href.indexOf( pattern ) !== -1;
-	}
+	};
 
 	return forbiddenPiiPatterns.some( match ) || forbiddenPiiPatternsEnc.some( match );
 }
-
-module.exports = {
-	doNotTrack: doNotTrack,
-	isPiiUrl: isPiiUrl
-};


### PR DESCRIPTION
This change runs several codemods to achieve the following:

Before | After
------------ | -------------
`require( ... )` nested in blocks | All `require( ... )` moved to top block
`var ... = require( ... )` | `import ... from '...'`
`module.exports = ...` | `export default ...`
`this.translate` | `this.props.translate` via HOC
`React.createClass( ... )` | `class ThisComponentName extends React.Component`
`React.createClass( ... )` | `createReactClass( ... )` if unconvertible to `React.Component` subclass
`import { PropTypes } from 'react'` | `import PropTypes from 'prop-types'`

#### Testing instructions

##### Setup

1. Check out locally (`git checkout modernize/lib-analytics`) and start your server. You can also use a [live branch](https://calypso.live/?branch=modernize/lib-analytics)
2. Enable the debug flag in the console:`localStorage.debug = 'calypso:analytics:*'`

#### Testing the analytics library
1. Navigate around [site](http://calypso.localhost:3000/) with the console open.
2. Verify analytics actions are firing as expected.

#### Testing the PageViewTracker Component
1. Open the [billing history page](http://calypso.localhost:3000/me/purchases/billing)
2. Verify that all expected debug statements are being logged.

#### Testing the TrackComponentView Component
1. Open the [plan management page](http://calypso.localhost:3000/plans/)
2. Verify that all expected debug statements are being logged.
