### PR TITLE
WebpackBuildMonitor: fix this reference by using fat arrow

### DIFF
--- a/client/components/webpack-build-monitor/index.jsx
+++ b/client/components/webpack-build-monitor/index.jsx
@@ -110,7 +110,7 @@ class WebpackBuildMonitor extends React.PureComponent {
 
 	componentDidMount() {
 		this.unsubscribe = store.subscribe(
-			( function() {
+			( () => {
 				let prevState = undefined;
 				return () => {
 					const nextState = store.getState();


### PR DESCRIPTION
> @samouri when we have a debug flag set like localStorage.debug = 'calypso:analytics*', we now see the following errors in development. We traced this odd behavior back to this PR. If we can't find a quick solution, would it be possible to revert this change for now?

![](https://user-images.githubusercontent.com/1270189/30090584-4d8993e2-9269-11e7-940f-c8ab290581ed.png)


fixes: https://github.com/Automattic/wp-calypso/pull/17545#issuecomment-327349530