### PR TITLE
Reader: Fix comment box alignment

### DIFF
--- a/client/blocks/comments/style.scss
+++ b/client/blocks/comments/style.scss
@@ -20,13 +20,13 @@
 // Add a New Comment Form
 .comments__form {
 	position: relative;
-	padding: 0 0 0 48px;
+	padding: 0 0 0 42px;
 	margin-top: 24px;
 
 	.gravatar {
 		position: absolute;
 			top: 0;
-			left: 8px;
+			left: 0;
 		border-radius: 48px;
 	}
 


### PR DESCRIPTION
This fixes: https://github.com/Automattic/wp-calypso/issues/17825

This fixes it in fullpost Comments as well.

**Before:**
![screenshot 2017-09-06 00 11 32](https://user-images.githubusercontent.com/4924246/30098843-7d24336c-9298-11e7-87a0-7c9e856891d2.png)

**After:**
![screenshot 2017-09-06 00 12 52](https://user-images.githubusercontent.com/4924246/30098833-733c574e-9298-11e7-9d60-2856c3b7436c.png)
