### PR TITLE
Framework: update SitesList selected state on Redux setAllSitesSelected action

### DIFF
--- a/client/state/lib/middleware.js
+++ b/client/state/lib/middleware.js
@@ -99,7 +99,11 @@ let sitesListeners = [];
  * @param {number} siteId     - the selected site id
  */
 const updateSelectedSiteIdForSitesList = ( dispatch, { siteId } ) => {
-	sites.select( siteId );
+	if ( siteId ) {
+		sites.select( siteId );
+	} else {
+		sites.selectAll();
+	}
 };
 
 /**


### PR DESCRIPTION
The `updateSelectedSiteIdForSitesList` middleware can intercept the `SELECTED_SITE_SET` action and keep the selection in SitesList in sync with the Redux state.

But it does nothing when the `siteId` to select is `null`, i.e., when selecting all sites. In that case, `sites.select( null )` is a noop and SitesList will think that a site is still selected.

This patch calls `sites.selectAll()` in that case.

Fixes #17815.

**Testing instructions:**
Try to reproduce the bug reported by @sirbrillig in #17815 -- there are very precise and simple steps to reproduce in the very first comment. Does the bug still happen?
