### PR TITLE
Comments: Remove local from edit comment data layer

### DIFF
--- a/client/state/data-layer/wpcom/sites/comments/index.js
+++ b/client/state/data-layer/wpcom/sites/comments/index.js
@@ -238,7 +238,7 @@ export const editComment = ( { dispatch, getState }, action ) => {
 export const updateComment = ( store, action, data ) => {
 	removeCommentStatusErrorNotice( store, action );
 	store.dispatch(
-		local( {
+		bypassDataLayer( {
 			...omit( action, [ 'originalComment' ] ),
 			comment: data,
 		} )


### PR DESCRIPTION
I didn't rebase before merging #17248 and I missed the fact that `local` has been deprecated in favour of `bypassDataLayer` in #17816.

This PR simply renames a `local` into `bypassDataLayer`.

#### Testing instructions

- Navigate to the Comment Management section.
- Edit a comment and save the changes.
- Notice that the console doesn't report any `Uncaught ReferenceError: local is not defined` error.