### PR TITLE
Disable "wpcom-user-bootstrap" until it works correctly with GeoIP.

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -104,7 +104,7 @@
 		"upgrades/removal-survey": true,
 		"upgrades/precancellation-chat": true,
 		"upgrades/presale-chat": true,
-		"wpcom-user-bootstrap": true
+		"wpcom-user-bootstrap": false
 	},
 	"siftscience_key": "a4f69f6759",
 	"wpcom_signup_id": "39911",

--- a/config/production.json
+++ b/config/production.json
@@ -113,7 +113,7 @@
 		"woocommerce/extension-settings-payments": true,
 		"woocommerce/extension-settings-shipping": true,
 		"woocommerce/extension-settings-tax": true,
-		"wpcom-user-bootstrap": true
+		"wpcom-user-bootstrap": false
 	},
 	"rtl": false,
 	"jetpack_min_version": "3.3",

--- a/config/production.json
+++ b/config/production.json
@@ -113,7 +113,7 @@
 		"woocommerce/extension-settings-payments": true,
 		"woocommerce/extension-settings-shipping": true,
 		"woocommerce/extension-settings-tax": true,
-		"wpcom-user-bootstrap": false
+		"wpcom-user-bootstrap": true
 	},
 	"rtl": false,
 	"jetpack_min_version": "3.3",

--- a/config/stage.json
+++ b/config/stage.json
@@ -121,7 +121,7 @@
 		"woocommerce/extension-settings-payments": true,
 		"woocommerce/extension-settings-shipping": true,
 		"woocommerce/extension-settings-tax": true,
-		"wpcom-user-bootstrap": true
+		"wpcom-user-bootstrap": false
 	},
 	"siftscience_key": "e00e878351",
 	"wpcom_signup_id": "39911",

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -135,7 +135,7 @@
 		"woocommerce/extension-settings-shipping": true,
 		"woocommerce/extension-settings-tax": true,
 		"woocommerce/extension-wcservices": true,
-		"wpcom-user-bootstrap": true
+		"wpcom-user-bootstrap": false
 	},
 	"siftscience_key": "e00e878351",
 	"wpcom_signup_id": "39911",


### PR DESCRIPTION
For more backstory on this change, see https://github.com/Automattic/wp-calypso/pull/16910 and p4TIVU-7BK-p2.

**TL;DR:** To make the initial loading of Calypso faster, a server-side request is made to the `/me` endpoint. Since that request comes from the Calypso server itself (geolocated in US), that means that every user will be effectively geolocated to US. There aren't many places when the user's country is checked, but the 2 I could fine were:
* GApps check. Since Google is banned in some countries, we need to check the user's country before allowing them to purchase GApps. That's effectively useless because the user will be geolocated in the US no matter what.
* Store on wp.com. We are rolling out the `Store (BETA)` feature to US and Canada business users only. Since everyone is geolocated in the US, we've received complaints of European people that saw the section and then couldn't use it because we're only supporting US/CA for now.

After dropping a bomb on the Calypso P2 and immediately going AFK for 3 weeks, I came back to the shocking revelation that the problem hadn't fixed itself :)

There are several options too solve this (I brainstormed a bit in the P2 post) but the immediate action is to disable `wpcom-user-bootstrap` so the problem is fixed. In hindsight, I should have made this change as soon as we detected the problem.
