### PR TITLE
Media: fix media basics tour trigger

### DIFF
--- a/client/layout/guided-tours/config-elements/step.js
+++ b/client/layout/guided-tours/config-elements/step.js
@@ -182,7 +182,7 @@ export default class Step extends Component {
 		this.setAnalyticsTimestamp( context );
 
 		if ( when && ! isValid( when ) ) {
-			const nextStepName = anyFrom( branching[ step ] );
+			const nextStepName = props.next || anyFrom( branching[ step ] );
 			const skipping = this.shouldSkipAnalytics();
 			next( { tour, tourVersion, step, nextStepName, skipping } );
 		}

--- a/client/layout/guided-tours/tours/media-basics-tour.js
+++ b/client/layout/guided-tours/tours/media-basics-tour.js
@@ -32,7 +32,6 @@ export const MediaBasicsTour = makeTour(
 		when={ and(
 			isDesktop,
 			isNewUser,
-			doesSelectedSiteHaveMediaFiles,
 		) }
 	>
 		<Step
@@ -87,6 +86,8 @@ export const MediaBasicsTour = makeTour(
 			arrow="top-left"
 			target=".media-library__list-item:not(.is-selected), .media-library__list-item"
 			style={ { marginTop: '-10px' } }
+			when={ doesSelectedSiteHaveMediaFiles }
+			next="done-no-media"
 		>
 			<p>
 				{ translate( 'Once you upload a file, you can edit its title, add a caption, and even do basic photo editing.' ) }
@@ -161,5 +162,21 @@ export const MediaBasicsTour = makeTour(
 				<Quit primary>{ translate( "Got it, I'm ready to explore!" ) }</Quit>
 			</ButtonRow>
 		</Step>
+
+		<Step name="done-no-media"
+			placement="center"
+		>
+			<p>
+				{
+					translate( 'Once you upload media files, you can edit them — change titles, do basic image editing, and more — ' +
+						"and they'll be ready and waiting for you to add to posts and pages."
+					)
+				}
+			</p>
+			<ButtonRow>
+				<Quit primary>{ translate( "Got it, I'm ready to explore!" ) }</Quit>
+			</ButtonRow>
+		</Step>
+
 	</Tour>
 );


### PR DESCRIPTION
Previously, the `mediaBasicsTour` would usually not trigger properly, as it required the current site's media library to have items in it — the store for that would not be ready (and also not block) when the tour was requesting this information. 

This PR fixes this behavior by moving the check for media into one of the steps. By then, it is far more likely for the store to be available. In addition, we add an alternative path for the tour to take for the no media case. 

Fixes #17632. 

Screen capture:

![media-basics-no-media](https://user-images.githubusercontent.com/23619/30113199-2d9122c0-9314-11e7-86f3-45635355a491.gif)

The new final step for the "no media" variation:

<img width="471" alt="screen shot 2017-09-07 at 10 42 00 am" src="https://user-images.githubusercontent.com/23619/30154127-3b677d90-93b9-11e7-852c-8c0ca2e14cdf.png">

To test:
- create a new user and site, choosing a theme that does result in images in the media library, then go to the site's media library
- make sure the tour loads and shows the "select an image", "edit an image", etc. steps
- create a new user and site, choosing a theme that does NOT result in images in the media library, then go to the site's media library
- make sure the tour loads and shows only three basic steps

Alternatively: 
- comment out the check for `isNewUser` in the tour's triggers
- use http://calypso.localhost:3000/?tour=reset to reset your tour history so that tours that you've already seen will be shown again
- visit the media library with a site that has files in its media library and one that doesn't, making sure the results from above