### PR TITLE
Comments: Prompt to update Jetpack to edit comments on JP<5.3 sites

### DIFF
--- a/client/blocks/comment-detail/comment-detail-edit.jsx
+++ b/client/blocks/comment-detail/comment-detail-edit.jsx
@@ -75,7 +75,7 @@ export class CommentDetailEdit extends Component {
 						{ translate( 'Name' ) }
 					</FormLabel>
 					<FormTextInput
-						disabled={ isAuthorRegistered }
+						disabled={ ! isEditCommentSupported || isAuthorRegistered }
 						onChange={ this.setAuthorDisplayNameValue }
 						value={ authorDisplayName }
 					/>
@@ -86,7 +86,7 @@ export class CommentDetailEdit extends Component {
 						{ translate( 'URL' ) }
 					</FormLabel>
 					<FormTextInput
-						disabled={ isAuthorRegistered }
+						disabled={ ! isEditCommentSupported || isAuthorRegistered }
 						onChange={ this.setAuthorUrlValue }
 						value={ authorUrl }
 					/>

--- a/client/blocks/comment-detail/comment-detail-edit.jsx
+++ b/client/blocks/comment-detail/comment-detail-edit.jsx
@@ -4,6 +4,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
@@ -13,6 +14,9 @@ import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
 import FormTextarea from 'components/forms/form-textarea';
 import FormTextInput from 'components/forms/form-text-input';
+import Notice from 'components/notice';
+import NoticeAction from 'components/notice/notice-action';
+import { getSiteSlug } from 'state/sites/selectors';
 
 export class CommentDetailEdit extends Component {
 	static propTypes = {
@@ -23,7 +27,10 @@ export class CommentDetailEdit extends Component {
 		commentId: PropTypes.number,
 		editComment: PropTypes.func,
 		isAuthorRegistered: PropTypes.bool,
+		isEditCommentSupported: PropTypes.bool,
 		postId: PropTypes.number,
+		siteId: PropTypes.number,
+		siteSlug: PropTypes.string,
 	};
 
 	state = {
@@ -52,6 +59,8 @@ export class CommentDetailEdit extends Component {
 		const {
 			closeEditMode,
 			isAuthorRegistered,
+			isEditCommentSupported,
+			siteSlug,
 			translate,
 		} = this.props;
 		const {
@@ -85,13 +94,29 @@ export class CommentDetailEdit extends Component {
 				</FormFieldset>
 
 				<FormTextarea
+					disabled={ ! isEditCommentSupported }
 					onChange={ this.setCommentContentValue }
 					value={ commentContent }
 				/>
 
+				{ ! isEditCommentSupported &&
+					<Notice
+						status="is-warning"
+						showDismiss={ false }
+						text={ translate(
+							'Comment editing requires a newer version of Jetpack.'
+						) }
+					>
+						<NoticeAction href={ `/plugins/jetpack/${ siteSlug }` }>
+							{ translate( 'Update Now' ) }
+						</NoticeAction>
+					</Notice>
+				}
+
 				<div className="comment-detail__edit-buttons">
 					<FormButton
 						compact
+						disabled={ ! isEditCommentSupported }
 						onClick={ this.editCommentAndCloseEditMode }
 					>
 						{ translate( 'Save' ) }
@@ -110,4 +135,8 @@ export class CommentDetailEdit extends Component {
 	}
 }
 
-export default localize( CommentDetailEdit );
+const mapStateToProps = ( state, { siteId } ) => ( {
+	siteSlug: getSiteSlug( state, siteId ),
+} );
+
+export default connect( mapStateToProps )( localize( CommentDetailEdit ) );

--- a/client/blocks/comment-detail/comment-detail-edit.jsx
+++ b/client/blocks/comment-detail/comment-detail-edit.jsx
@@ -102,7 +102,10 @@ export class CommentDetailEdit extends Component {
 					<p className="comment-detail__edit-jetpack-update-notice">
 						<Gridicon icon="notice-outline" />
 						{ translate( 'Comment editing requires a newer version of Jetpack.' ) }
-						<a href={ `/plugins/jetpack/${ siteSlug }` }>
+						<a
+							className="comment-detail__edit-jetpack-update-notice-link"
+							href={ `/plugins/jetpack/${ siteSlug }` }
+						>
 							{ translate( 'Update Now' ) }
 						</a>
 					</p>

--- a/client/blocks/comment-detail/comment-detail-edit.jsx
+++ b/client/blocks/comment-detail/comment-detail-edit.jsx
@@ -3,6 +3,7 @@
  */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import Gridicon from 'gridicons';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
 
@@ -14,8 +15,6 @@ import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
 import FormTextarea from 'components/forms/form-textarea';
 import FormTextInput from 'components/forms/form-text-input';
-import Notice from 'components/notice';
-import NoticeAction from 'components/notice/notice-action';
 import { getSiteSlug } from 'state/sites/selectors';
 
 export class CommentDetailEdit extends Component {
@@ -100,17 +99,13 @@ export class CommentDetailEdit extends Component {
 				/>
 
 				{ ! isEditCommentSupported &&
-					<Notice
-						status="is-warning"
-						showDismiss={ false }
-						text={ translate(
-							'Comment editing requires a newer version of Jetpack.'
-						) }
-					>
-						<NoticeAction href={ `/plugins/jetpack/${ siteSlug }` }>
+					<p className="comment-detail__edit-jetpack-update-notice">
+						<Gridicon icon="notice-outline" />
+						{ translate( 'Comment editing requires a newer version of Jetpack.' ) }
+						<a href={ `/plugins/jetpack/${ siteSlug }` }>
 							{ translate( 'Update Now' ) }
-						</NoticeAction>
-					</Notice>
+						</a>
+					</p>
 				}
 
 				<div className="comment-detail__edit-buttons">

--- a/client/blocks/comment-detail/index.jsx
+++ b/client/blocks/comment-detail/index.jsx
@@ -215,8 +215,8 @@ export class CommentDetail extends Component {
 			commentUrl,
 			editComment,
 			isBulkEdit,
+			isEditCommentSupported,
 			isLoading,
-			isRawContentSupported,
 			parentCommentAuthorAvatarUrl,
 			parentCommentAuthorDisplayName,
 			parentCommentContent,
@@ -304,11 +304,13 @@ export class CommentDetail extends Component {
 								authorDisplayName={ authorDisplayName }
 								authorUrl={ authorUrl }
 								closeEditMode={ this.toggleEditMode }
-								commentContent={ isRawContentSupported ? commentRawContent : commentContent }
+								commentContent={ isEditCommentSupported ? commentRawContent : commentContent }
 								commentId={ commentId }
 								editComment={ editComment }
 								isAuthorRegistered={ authorId !== 0 }
+								isEditCommentSupported={ isEditCommentSupported }
 								postId={ postId }
+								siteId={ siteId }
 							/>
 						}
 
@@ -379,8 +381,8 @@ const mapStateToProps = ( state, ownProps ) => {
 		commentRawContent: get( comment, 'raw_content' ),
 		commentStatus: get( comment, 'status' ),
 		commentUrl: get( comment, 'URL' ),
+		isEditCommentSupported: ! isJetpackSite( state, siteId ) || isJetpackMinimumVersion( state, siteId, '5.3' ),
 		isLoading,
-		isRawContentSupported: ! isJetpackSite( state, siteId ) || isJetpackMinimumVersion( state, siteId, '5.3' ),
 		parentCommentAuthorAvatarUrl: get( parentComment, 'author.avatar_URL' ),
 		parentCommentAuthorDisplayName: get( parentComment, 'author.name' ),
 		parentCommentContent,

--- a/client/blocks/comment-detail/style.scss
+++ b/client/blocks/comment-detail/style.scss
@@ -586,6 +586,11 @@ a.comment-detail__author-more-element {
 		font-size: 14px;
 	}
 
+	.notice {
+		margin-left: 8px;
+		margin-right: 8px;
+	}
+
 	.comment-detail__edit-buttons {
 		padding: 0 8px;
 		width: 100%;

--- a/client/blocks/comment-detail/style.scss
+++ b/client/blocks/comment-detail/style.scss
@@ -590,12 +590,11 @@ a.comment-detail__author-more-element {
 		color: $alert-red;
 		margin-left: 8px;
 		margin-right: 8px;
-
-		a {
-			color: $alert-red;
-			margin-left: 4px;
-			text-decoration: underline;
-		}
+	}
+	.comment-detail__edit-jetpack-update-notice-link {
+		color: $alert-red;
+		margin-left: 4px;
+		text-decoration: underline;
 	}
 
 	.comment-detail__edit-buttons {

--- a/client/blocks/comment-detail/style.scss
+++ b/client/blocks/comment-detail/style.scss
@@ -586,9 +586,16 @@ a.comment-detail__author-more-element {
 		font-size: 14px;
 	}
 
-	.notice {
+	.comment-detail__edit-jetpack-update-notice {
+		color: $alert-red;
 		margin-left: 8px;
 		margin-right: 8px;
+
+		a {
+			color: $alert-red;
+			margin-left: 4px;
+			text-decoration: underline;
+		}
 	}
 
 	.comment-detail__edit-buttons {


### PR DESCRIPTION
On Jetpack <5.3 sites we can't easily retrieve the comment's `raw_content`.
Instead of flooding the `CommentDetail` component with conditionals and introducing a new Query component for old Jetpack versions, we simply display an update nudge.

See: p1HpG7-4aq-p2

<img width="670" alt="screen shot 2017-09-06 at 18 34 36" src="https://user-images.githubusercontent.com/2070010/30125962-320dc222-9332-11e7-9e03-ab717caaea55.png">

cc @Automattic/lannister 
