### PR TITLE
Comments: Emojify all the things

### DIFF
--- a/client/blocks/comment-detail/comment-detail-author.jsx
+++ b/client/blocks/comment-detail/comment-detail-author.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import Gridicon from 'gridicons';
 import { localize } from 'i18n-calypso';
@@ -10,6 +11,7 @@ import classNames from 'classnames';
 /**
  * Internal dependencies
  */
+import Emojify from 'components/emojify';
 import ExternalLink from 'components/external-link';
 import Gravatar from 'components/gravatar';
 import { urlToDomainAndPath } from 'lib/url';
@@ -80,7 +82,9 @@ export class CommentDetailAuthor extends Component {
 						<div className="comment-detail__author-info">
 							<div className="comment-detail__author-name">
 								<strong>
-									{ authorDisplayName }
+									<Emojify>
+										{ authorDisplayName }
+									</Emojify>
 								</strong>
 							</div>
 							<div className="comment-detail__author-username">
@@ -148,7 +152,9 @@ export class CommentDetailAuthor extends Component {
 					<div className="comment-detail__author-info">
 						<div className="comment-detail__author-info-element comment-detail__author-name">
 							<strong>
-								{ authorDisplayName }
+								<Emojify>
+									{ authorDisplayName }
+								</Emojify>
 							</strong>
 							<ExternalLink href={ authorUrl }>
 								{ urlToDomainAndPath( authorUrl ) }

--- a/client/blocks/comment-detail/comment-detail-author.jsx
+++ b/client/blocks/comment-detail/comment-detail-author.jsx
@@ -153,14 +153,16 @@ export class CommentDetailAuthor extends Component {
 					<Gravatar user={ this.getAuthorObject() } />
 					<div className="comment-detail__author-info">
 						<div className="comment-detail__author-info-element comment-detail__author-name">
-							<Emojify>
-								<strong>
-										{ authorDisplayName }
-								</strong>
-								<ExternalLink href={ authorUrl }>
+							<strong>
+								<Emojify>
+									{ authorDisplayName }
+								</Emojify>
+							</strong>
+							<ExternalLink href={ authorUrl }>
+								<Emojify>
 									{ urlToDomainAndPath( authorUrl ) }
-								</ExternalLink>
-							</Emojify>
+								</Emojify>
+							</ExternalLink>
 						</div>
 						<ExternalLink
 							className="comment-detail__author-info-element comment-detail__comment-date"

--- a/client/blocks/comment-detail/comment-detail-author.jsx
+++ b/client/blocks/comment-detail/comment-detail-author.jsx
@@ -101,7 +101,9 @@ export class CommentDetailAuthor extends Component {
 					<div className="comment-detail__author-more-element">
 						<Gridicon icon="link" />
 						<ExternalLink href={ authorUrl }>
-							{ urlToDomainAndPath( authorUrl ) }
+							<Emojify>
+								{ urlToDomainAndPath( authorUrl ) }
+							</Emojify>
 						</ExternalLink>
 					</div>
 					<div className="comment-detail__author-more-element">
@@ -151,14 +153,14 @@ export class CommentDetailAuthor extends Component {
 					<Gravatar user={ this.getAuthorObject() } />
 					<div className="comment-detail__author-info">
 						<div className="comment-detail__author-info-element comment-detail__author-name">
-							<strong>
-								<Emojify>
-									{ authorDisplayName }
-								</Emojify>
-							</strong>
-							<ExternalLink href={ authorUrl }>
-								{ urlToDomainAndPath( authorUrl ) }
-							</ExternalLink>
+							<Emojify>
+								<strong>
+										{ authorDisplayName }
+								</strong>
+								<ExternalLink href={ authorUrl }>
+									{ urlToDomainAndPath( authorUrl ) }
+								</ExternalLink>
+							</Emojify>
 						</div>
 						<ExternalLink
 							className="comment-detail__author-info-element comment-detail__comment-date"

--- a/client/blocks/comment-detail/comment-detail-comment.jsx
+++ b/client/blocks/comment-detail/comment-detail-comment.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import Gridicon from 'gridicons';
 import { localize } from 'i18n-calypso';
 
@@ -10,6 +11,7 @@ import { localize } from 'i18n-calypso';
  */
 import CommentDetailAuthor from './comment-detail-author';
 import AutoDirection from 'components/auto-direction';
+import Emojify from 'components/emojify';
 
 export class CommentDetailComment extends Component {
 	static propTypes = {
@@ -66,9 +68,11 @@ export class CommentDetailComment extends Component {
 						siteId={ siteId }
 					/>
 					<AutoDirection>
-						<div className="comment-detail__comment-body"
-							dangerouslySetInnerHTML={ { __html: commentContent } } //eslint-disable-line react/no-danger
-						/>
+						<Emojify>
+							<div className="comment-detail__comment-body"
+								dangerouslySetInnerHTML={ { __html: commentContent } } //eslint-disable-line react/no-danger
+							/>
+						</Emojify>
 					</AutoDirection>
 
 					{ repliedToComment &&

--- a/client/blocks/comment-detail/comment-detail-header.jsx
+++ b/client/blocks/comment-detail/comment-detail-header.jsx
@@ -97,23 +97,21 @@ export const CommentDetailHeader = ( {
 						}
 						<Gravatar user={ author } />
 						<div className="comment-detail__author-info">
-							<div className="comment-detail__author-info-element">
-								<Emojify>
+							<Emojify>
+								<div className="comment-detail__author-info-element">
 									<strong>
 										{ authorDisplayName }
 									</strong>
-								</Emojify>
-								<span>
-									{ urlToDomainAndPath( authorUrl ) }
-								</span>
-							</div>
-							<div className="comment-detail__author-info-element">
-								<Emojify>
+									<span>
+										{ urlToDomainAndPath( authorUrl ) }
+									</span>
+								</div>
+								<div className="comment-detail__author-info-element">
 									{ translate( 'on %(postTitle)s', { args: {
 										postTitle: postTitle ? decodeEntities( postTitle ) : translate( 'Untitled' ),
 									} } ) }
-								</Emojify>
-							</div>
+								</div>
+							</Emojify>
 						</div>
 					</div>
 					<AutoDirection>

--- a/client/blocks/comment-detail/comment-detail-header.jsx
+++ b/client/blocks/comment-detail/comment-detail-header.jsx
@@ -13,6 +13,7 @@ import { noop } from 'lodash';
 import AutoDirection from 'components/auto-direction';
 import Button from 'components/button';
 import CommentDetailActions from './comment-detail-actions';
+import Emojify from 'components/emojify';
 import Gravatar from 'components/gravatar';
 import FormCheckbox from 'components/forms/form-checkbox';
 import { stripHTML, decodeEntities } from 'lib/formatting';
@@ -113,7 +114,9 @@ export const CommentDetailHeader = ( {
 					</div>
 					<AutoDirection>
 						<div className="comment-detail__comment-preview">
-							{ decodeEntities( stripHTML( commentContent ) ) }
+							<Emojify>
+								{ decodeEntities( stripHTML( commentContent ) ) }
+							</Emojify>
 						</div>
 					</AutoDirection>
 				</div>

--- a/client/blocks/comment-detail/comment-detail-header.jsx
+++ b/client/blocks/comment-detail/comment-detail-header.jsx
@@ -98,9 +98,11 @@ export const CommentDetailHeader = ( {
 						<Gravatar user={ author } />
 						<div className="comment-detail__author-info">
 							<div className="comment-detail__author-info-element">
-								<strong>
-									{ authorDisplayName }
-								</strong>
+								<Emojify>
+									<strong>
+										{ authorDisplayName }
+									</strong>
+								</Emojify>
 								<span>
 									{ urlToDomainAndPath( authorUrl ) }
 								</span>

--- a/client/blocks/comment-detail/comment-detail-header.jsx
+++ b/client/blocks/comment-detail/comment-detail-header.jsx
@@ -97,21 +97,25 @@ export const CommentDetailHeader = ( {
 						}
 						<Gravatar user={ author } />
 						<div className="comment-detail__author-info">
-							<Emojify>
-								<div className="comment-detail__author-info-element">
-									<strong>
+							<div className="comment-detail__author-info-element">
+								<strong>
+									<Emojify>
 										{ authorDisplayName }
-									</strong>
-									<span>
+									</Emojify>
+								</strong>
+								<span>
+									<Emojify>
 										{ urlToDomainAndPath( authorUrl ) }
-									</span>
-								</div>
-								<div className="comment-detail__author-info-element">
+									</Emojify>
+								</span>
+							</div>
+							<div className="comment-detail__author-info-element">
+								<Emojify>
 									{ translate( 'on %(postTitle)s', { args: {
 										postTitle: postTitle ? decodeEntities( postTitle ) : translate( 'Untitled' ),
 									} } ) }
-								</div>
-							</Emojify>
+								</Emojify>
+							</div>
 						</div>
 					</div>
 					<AutoDirection>

--- a/client/blocks/comment-detail/comment-detail-header.jsx
+++ b/client/blocks/comment-detail/comment-detail-header.jsx
@@ -108,9 +108,11 @@ export const CommentDetailHeader = ( {
 								</span>
 							</div>
 							<div className="comment-detail__author-info-element">
-								{ translate( 'on %(postTitle)s', { args: {
-									postTitle: postTitle ? decodeEntities( postTitle ) : translate( 'Untitled' ),
-								} } ) }
+								<Emojify>
+									{ translate( 'on %(postTitle)s', { args: {
+										postTitle: postTitle ? decodeEntities( postTitle ) : translate( 'Untitled' ),
+									} } ) }
+								</Emojify>
 							</div>
 						</div>
 					</div>

--- a/client/blocks/comment-detail/comment-detail-post.jsx
+++ b/client/blocks/comment-detail/comment-detail-post.jsx
@@ -8,6 +8,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import Emojify from 'components/emojify';
 import Gravatar from 'components/gravatar';
 import SiteIcon from 'blocks/site-icon';
 import {
@@ -43,9 +44,11 @@ export const CommentDetailPost = ( {
 				</div>
 				<div className="comment-detail__post-info">
 					{ parentCommentAuthorDisplayName &&
-						<span>
-							{ translate( '%(authorName)s:', { args: { authorName: parentCommentAuthorDisplayName } } ) }
-						</span>
+						<Emojify>
+							<span>
+								{ translate( '%(authorName)s:', { args: { authorName: parentCommentAuthorDisplayName } } ) }
+							</span>
+						</Emojify>
 					}
 					<a href={ `${ postUrl }#comment-${ commentId }` } onClick={ recordReaderCommentOpened }>
 						{ parentCommentContent }
@@ -60,9 +63,11 @@ export const CommentDetailPost = ( {
 			<SiteIcon siteId={ siteId } size={ 24 } />
 			<div className="comment-detail__post-info">
 				{ postAuthorDisplayName &&
-					<span>
-						{ translate( '%(authorName)s:', { args: { authorName: postAuthorDisplayName } } ) }
-					</span>
+					<Emojify>
+						<span>
+							{ translate( '%(authorName)s:', { args: { authorName: postAuthorDisplayName } } ) }
+						</span>
+					</Emojify>
 				}
 				<a href={ postUrl } onClick={ recordReaderArticleOpened }>
 					{ postTitle || translate( 'Untitled' ) }

--- a/client/blocks/comment-detail/comment-detail-post.jsx
+++ b/client/blocks/comment-detail/comment-detail-post.jsx
@@ -43,16 +43,16 @@ export const CommentDetailPost = ( {
 					<Gravatar user={ author } />
 				</div>
 				<div className="comment-detail__post-info">
-					{ parentCommentAuthorDisplayName &&
-						<Emojify>
+					<Emojify>
+						{ parentCommentAuthorDisplayName &&
 							<span>
 								{ translate( '%(authorName)s:', { args: { authorName: parentCommentAuthorDisplayName } } ) }
 							</span>
-						</Emojify>
-					}
-					<a href={ `${ postUrl }#comment-${ commentId }` } onClick={ recordReaderCommentOpened }>
-						{ parentCommentContent }
-					</a>
+						}
+						<a href={ `${ postUrl }#comment-${ commentId }` } onClick={ recordReaderCommentOpened }>
+							{ parentCommentContent }
+						</a>
+					</Emojify>
 				</div>
 			</div>
 		);
@@ -62,16 +62,16 @@ export const CommentDetailPost = ( {
 		<div className="comment-detail__post">
 			<SiteIcon siteId={ siteId } size={ 24 } />
 			<div className="comment-detail__post-info">
-				{ postAuthorDisplayName &&
-					<Emojify>
+				<Emojify>
+					{ postAuthorDisplayName &&
 						<span>
 							{ translate( '%(authorName)s:', { args: { authorName: postAuthorDisplayName } } ) }
 						</span>
-					</Emojify>
-				}
-				<a href={ postUrl } onClick={ recordReaderArticleOpened }>
-					{ postTitle || translate( 'Untitled' ) }
-				</a>
+					}
+					<a href={ postUrl } onClick={ recordReaderArticleOpened }>
+						{ postTitle || translate( 'Untitled' ) }
+					</a>
+				</Emojify>
 			</div>
 		</div>
 	);

--- a/client/blocks/comment-detail/comment-detail-post.jsx
+++ b/client/blocks/comment-detail/comment-detail-post.jsx
@@ -43,16 +43,18 @@ export const CommentDetailPost = ( {
 					<Gravatar user={ author } />
 				</div>
 				<div className="comment-detail__post-info">
-					<Emojify>
-						{ parentCommentAuthorDisplayName &&
-							<span>
+					{ parentCommentAuthorDisplayName &&
+						<span>
+							<Emojify>
 								{ translate( '%(authorName)s:', { args: { authorName: parentCommentAuthorDisplayName } } ) }
-							</span>
-						}
-						<a href={ `${ postUrl }#comment-${ commentId }` } onClick={ recordReaderCommentOpened }>
+							</Emojify>
+						</span>
+					}
+					<a href={ `${ postUrl }#comment-${ commentId }` } onClick={ recordReaderCommentOpened }>
+						<Emojify>
 							{ parentCommentContent }
-						</a>
-					</Emojify>
+						</Emojify>
+					</a>
 				</div>
 			</div>
 		);
@@ -62,16 +64,18 @@ export const CommentDetailPost = ( {
 		<div className="comment-detail__post">
 			<SiteIcon siteId={ siteId } size={ 24 } />
 			<div className="comment-detail__post-info">
-				<Emojify>
-					{ postAuthorDisplayName &&
-						<span>
+				{ postAuthorDisplayName &&
+					<span>
+						<Emojify>
 							{ translate( '%(authorName)s:', { args: { authorName: postAuthorDisplayName } } ) }
-						</span>
-					}
-					<a href={ postUrl } onClick={ recordReaderArticleOpened }>
+						</Emojify>
+					</span>
+				}
+				<a href={ postUrl } onClick={ recordReaderArticleOpened }>
+					<Emojify>
 						{ postTitle || translate( 'Untitled' ) }
-					</a>
-				</Emojify>
+					</Emojify>
+				</a>
 			</div>
 		</div>
 	);


### PR DESCRIPTION
Close #17636

Adds the `Emojify` component to all places where we might need to convert emojis.

| Non-`Emojify`-ed | `Emojify`-ed |
| --- | --- |
| <img width="255" alt="screen shot 2017-08-30 at 16 20 38" src="https://user-images.githubusercontent.com/2070010/29880324-654341fa-8d9f-11e7-84a7-9436bc8f9e91.png"> | <img width="224" alt="screen shot 2017-08-30 at 16 20 43" src="https://user-images.githubusercontent.com/2070010/29880342-6daa174c-8d9f-11e7-8c31-ae5330321845.png"> |

There is one notable place missing: the reply textarea placeholder.
The `Emojify` component doesn't work on that because it replaces the emojis with `<img>`s, and I'm unsure on how to proceed.

cc @Automattic/lannister 
(Please notice that unlike most of the m2 PRs, this goes straight to prod)

---

Author name, site URL, and post title in the comment header:
<img width="763" alt="screen shot 2017-09-06 at 16 28 05" src="https://user-images.githubusercontent.com/2070010/30120319-65226e4a-9320-11e7-8c2a-52ee92912183.png">


Comment excerpt in the comment header:
<img width="812" alt="screen shot 2017-09-06 at 16 18 14" src="https://user-images.githubusercontent.com/2070010/30119899-32515d38-931f-11e7-8f50-f6c45ab67924.png">

Parent comment author name and comment content in the expanded view:
<img width="816" alt="screen shot 2017-09-06 at 16 18 22" src="https://user-images.githubusercontent.com/2070010/30119913-428eecd8-931f-11e7-9127-13fc44b66639.png">

Parent comment excerpt in the expanded view:
<img width="816" alt="screen shot 2017-09-06 at 16 18 39" src="https://user-images.githubusercontent.com/2070010/30119931-53179c76-931f-11e7-8838-5818a260125b.png">

Parent post title in the expanded view:
<img width="813" alt="screen shot 2017-09-06 at 16 18 46" src="https://user-images.githubusercontent.com/2070010/30119932-531d6926-931f-11e7-9d63-870f6c514ef4.png">

Site URL in the expanded view:
<img width="568" alt="screen shot 2017-09-06 at 16 28 47" src="https://user-images.githubusercontent.com/2070010/30120348-7f7245d6-9320-11e7-919c-46d89ea4abf4.png">