### PR TITLE
Launch social management

### DIFF
--- a/client/me/social-login/index.jsx
+++ b/client/me/social-login/index.jsx
@@ -13,7 +13,6 @@ const debug = debugFactory( 'calypso:me:security:social-login' );
  */
 import config from 'config';
 import CompactCard from 'components/card/compact';
-import SectionHeader from 'components/section-header';
 import DocumentHead from 'components/data/document-head';
 import FormButton from 'components/forms/form-button';
 import Main from 'components/main';
@@ -82,7 +81,6 @@ class SocialLogin extends Component {
 
 		return (
 			<div>
-				<SectionHeader label={ translate( 'Manage Social Login Connections' ) } />
 				<CompactCard>
 					{ translate( 'You’ll be able to log in faster by linking your WordPress.com account with your ' +
 						'social networks. We’ll never post without your permission.' ) }

--- a/client/me/social-login/index.jsx
+++ b/client/me/social-login/index.jsx
@@ -77,10 +77,16 @@ class SocialLogin extends Component {
 	};
 
 	renderContent() {
-		const { translate } = this.props;
+		const { translate, errorUpdatingSocialConnection } = this.props;
 
 		return (
 			<div>
+				{
+					errorUpdatingSocialConnection &&
+						<Notice status={ 'is-error' } showDismiss={ false }>
+							{ errorUpdatingSocialConnection.message }
+						</Notice>
+				}
 				<CompactCard>
 					{ translate( 'You’ll be able to log in faster by linking your WordPress.com account with your ' +
 						'social networks. We’ll never post without your permission.' ) }
@@ -108,16 +114,10 @@ class SocialLogin extends Component {
 	}
 
 	renderGoogleConnection() {
-		const { errorUpdatingSocialConnection, isUserConnectedToGoogle } = this.props;
+		const { isUserConnectedToGoogle } = this.props;
 
 		return (
 			<CompactCard>
-				{
-					errorUpdatingSocialConnection &&
-						<Notice status={ 'is-error' } showDismiss={ false }>
-							{ errorUpdatingSocialConnection.message }
-						</Notice>
-				}
 				<div className="social-login__header">
 					<div className="social-login__header-info">
 						<div className="social-login__header-icon">

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -81,6 +81,7 @@
 		"settings/theme-setup": false,
 		"signup/domain-first-flow": true,
 		"signup/social": false,
+		"signup/social-management": true,
 		"ui/first-view": false,
 		"upgrades/checkout": true,
 		"upgrades/credit-cards": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -94,6 +94,7 @@
 		"settings/theme-setup": false,
 		"signup/domain-first-flow": true,
 		"signup/social": true,
+		"signup/social-management": true,
 		"simple-payments": true,
 		"support-user": true,
 		"sync-handler": true,

--- a/config/production.json
+++ b/config/production.json
@@ -94,6 +94,7 @@
 		"settings/theme-setup": false,
 		"signup/domain-first-flow": true,
 		"signup/social": true,
+		"signup/social-management": true,
 		"simple-payments": true,
 		"support-user": true,
 		"sync-handler": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -101,6 +101,7 @@
 		"settings/theme-setup": false,
 		"signup/domain-first-flow": true,
 		"signup/social": true,
+		"signup/social-management": true,
 		"simple-payments": true,
 		"standalone-site-preview": true,
 		"support-user": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -113,6 +113,7 @@
 		"settings/theme-setup": true,
 		"signup/domain-first-flow": true,
 		"signup/social": true,
+		"signup/social-management": true,
 		"signup/wpcc": true,
 		"simple-payments": true,
 		"standalone-site-preview": true,


### PR DESCRIPTION
This pull request launches social account management to all users.
  
#### Testing instructions
  
1. Run `git checkout update/launch-social-management` and start your server with NODE_ENV=production
2. Open the [`social management` page](http://calypso.localhost:3000/me/security/social-login)
3. Check that you can see the page

#### Reviews
  
- [x] Code
- [x] Product
- [x] Design

cc @danhauk for a final design review