### PR TITLE
My Sites: Fix for Tooltip showing not so useful information.

### DIFF
--- a/client/blocks/site/index.jsx
+++ b/client/blocks/site/index.jsx
@@ -99,7 +99,7 @@ class Site extends React.Component {
 							? translate( 'View site %(domain)s', {
 									args: { domain: site.domain },
 								} )
-							: translate( 'Select site %(domain)s', {
+							: translate( 'Site %(domain)s', {
 									args: { domain: site.domain },
 								} )
 					}
@@ -111,7 +111,7 @@ class Site extends React.Component {
 							? translate( 'View site %(domain)s', {
 									args: { domain: site.domain },
 								} )
-							: translate( 'Select site %(domain)s', {
+							: translate( 'Site %(domain)s', {
 									args: { domain: site.domain },
 								} )
 					}

--- a/client/blocks/site/index.jsx
+++ b/client/blocks/site/index.jsx
@@ -95,25 +95,25 @@ class Site extends React.Component {
 					data-tip-target={ this.props.tipTarget }
 					target={ this.props.externalLink && '_blank' }
 					title={
-						this.props.homeLink
-							? translate( 'View site %(domain)s', {
-									args: { domain: site.domain },
-								} )
-							: translate( 'Site %(domain)s', {
-									args: { domain: site.domain },
-								} )
+						this.props.homeLink ? (
+							translate( 'View site %(domain)s', {
+								args: { domain: site.domain },
+							} )
+						) : (
+							site.domain
+						)
 					}
 					onClick={ this.onSelect }
 					onMouseEnter={ this.onMouseEnter }
 					onMouseLeave={ this.onMouseLeave }
 					aria-label={
-						this.props.homeLink
-							? translate( 'View site %(domain)s', {
-									args: { domain: site.domain },
-								} )
-							: translate( 'Site %(domain)s', {
-									args: { domain: site.domain },
-								} )
+						this.props.homeLink ? (
+							translate( 'View site %(domain)s', {
+								args: { domain: site.domain },
+							} )
+						) : (
+							site.domain
+						)
 					}
 				>
 					<SiteIcon site={ site } size={ this.props.compact ? 24 : 32 } />


### PR DESCRIPTION
This PR is set to address a small style tweak for #16911. Currently, the tool tip on a selected site shows 
![](https://user-images.githubusercontent.com/373903/28972405-29be4fe4-78f5-11e7-9911-8aae68281509.png)

I have edited the tool tip to show Site instead of Select site so that it is less confusing. 

Screenshots 
![]()
<img width="312" alt="site-tooltip" src="https://user-images.githubusercontent.com/2734132/30124270-443c3f30-9352-11e7-8b57-1719973200bb.png">

cc @gziolo if you have a chance to take a look.