### PR TITLE
Comments: Add a notice that registered user info cannot be edited.

### DIFF
--- a/client/blocks/comment-detail/comment-detail-edit.jsx
+++ b/client/blocks/comment-detail/comment-detail-edit.jsx
@@ -16,6 +16,7 @@ import FormLabel from 'components/forms/form-label';
 import FormTextarea from 'components/forms/form-textarea';
 import FormTextInput from 'components/forms/form-text-input';
 import { getSiteSlug } from 'state/sites/selectors';
+import InfoPopover from 'components/info-popover';
 
 export class CommentDetailEdit extends Component {
 	static propTypes = {
@@ -75,6 +76,9 @@ export class CommentDetailEdit extends Component {
 					<FormLabel htmlFor="author">
 						{ translate( 'Name' ) }
 					</FormLabel>
+					<InfoPopover>
+						{ translate( 'This user is registered, the name can\'t be edited.' ) }
+					</InfoPopover>
 					<FormTextInput
 						disabled={ ! isEditCommentSupported || isAuthorRegistered }
 						onChange={ this.setAuthorDisplayNameValue }
@@ -86,6 +90,9 @@ export class CommentDetailEdit extends Component {
 					<FormLabel htmlFor="author_url">
 						{ translate( 'URL' ) }
 					</FormLabel>
+					<InfoPopover>
+						{ translate( 'This user is registered, the URL can\'t be edited.' ) }
+					</InfoPopover>
 					<FormTextInput
 						disabled={ ! isEditCommentSupported || isAuthorRegistered }
 						onChange={ this.setAuthorUrlValue }

--- a/client/blocks/comment-detail/comment-detail-edit.jsx
+++ b/client/blocks/comment-detail/comment-detail-edit.jsx
@@ -76,9 +76,11 @@ export class CommentDetailEdit extends Component {
 					<FormLabel htmlFor="author">
 						{ translate( 'Name' ) }
 					</FormLabel>
-					<InfoPopover>
-						{ translate( 'This user is registered, the name can\'t be edited.' ) }
-					</InfoPopover>
+					{ isAuthorRegistered &&
+						<InfoPopover>
+							{ translate( 'This user is registered, the name can\'t be edited.' ) }
+						</InfoPopover>
+					}
 					<FormTextInput
 						disabled={ ! isEditCommentSupported || isAuthorRegistered }
 						onChange={ this.setAuthorDisplayNameValue }
@@ -90,9 +92,11 @@ export class CommentDetailEdit extends Component {
 					<FormLabel htmlFor="author_url">
 						{ translate( 'URL' ) }
 					</FormLabel>
-					<InfoPopover>
-						{ translate( 'This user is registered, the URL can\'t be edited.' ) }
-					</InfoPopover>
+					{ isAuthorRegistered &&
+						<InfoPopover>
+							{ translate( 'This user is registered, the URL can\'t be edited.' ) }
+						</InfoPopover>
+					}
 					<FormTextInput
 						disabled={ ! isEditCommentSupported || isAuthorRegistered }
 						onChange={ this.setAuthorUrlValue }

--- a/client/blocks/comment-detail/style.scss
+++ b/client/blocks/comment-detail/style.scss
@@ -586,6 +586,10 @@ a.comment-detail__author-more-element {
 		font-size: 14px;
 	}
 
+	label {
+		display: inline-block;
+	}
+
 	.comment-detail__edit-jetpack-update-notice {
 		color: $alert-red;
 		margin-left: 8px;
@@ -600,6 +604,12 @@ a.comment-detail__author-more-element {
 	.comment-detail__edit-buttons {
 		padding: 0 8px;
 		width: 100%;
+	}
+
+	.info-popover {
+		margin-left: 4px;
+		position: relative;
+		top: -2px;
 	}
 }
 


### PR DESCRIPTION
Registered users cannot have their name or URL edited in a comment; this notice will alert users when they are in Edit mode for a comment made by a registered author. Note that regardless of the comment author being registered or not, if the site has an older version of Jetpack, only the notice from #17856 ("Comment editing requires a newer version of Jetpack") should appear.

This should wait for #17856 to land first, and will need a rebase afterwards.

<img width="435" alt="screen shot 2017-09-06 at 10 56 43 am" src="https://user-images.githubusercontent.com/349751/30126889-4cf533f8-92f2-11e7-8b6f-5be6397662d7.png">

**Testing**
Load this PR, and verify that the correct message (if any) appears for each of the situations below.

| Site | User | Notice |
|---|---|---|
| dotcom | registered | "A registered user..." |
| JP = 5.3 | unregistered | none |
| JP = 5.3 | registered | "A registered user..." |
| JP < 5.3 | unregistered | "Comment editing..." |
| JP < 5.3 | registered | "Comment editing..." |
