### PR TITLE
Update woocommerce logo urls

### DIFF
--- a/client/state/oauth2-clients/reducer.js
+++ b/client/state/oauth2-clients/reducer.js
@@ -42,19 +42,19 @@ export const initialClientsData = {
 		id: 50019,
 		name: 'woo',
 		title: 'WooCommerce',
-		icon: 'https://woocommerce.com/wp-content/themes/woomattic/images/logo-woocommerce@2x.png',
+		icon: 'https://woocommerce.com/wp-content/themes/woo/images/logo-woocommerce@2x.png',
 	},
 	50915: {
 		id: 50915,
 		name: 'woo',
 		title: 'WooCommerce',
-		icon: 'https://woocommerce.com/wp-content/themes/woomattic/images/logo-woocommerce@2x.png',
+		icon: 'https://woocommerce.com/wp-content/themes/woo/images/logo-woocommerce@2x.png',
 	},
 	50916: {
 		id: 50916,
 		name: 'woo',
 		title: 'WooCommerce.com',
-		icon: 'https://woocommerce.com/wp-content/themes/woomattic/images/logo-woocommerce@2x.png',
+		icon: 'https://woocommerce.com/wp-content/themes/woo/images/logo-woocommerce@2x.png',
 	},
 };
 


### PR DESCRIPTION
The `woomattic` theme was removed [recently](https://github.com/Automattic/woocommerce.com/pull/2317). It caused the woo logo at https://woocommerce.com/wp-content/themes/woomattic/images/logo-woocommerce@2x.png to 404 in the WooCommerce login page. 

### Testing Instructions
- Go to https://calypso.live/log-in?client_id=50916&redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fresponse_type%3Dcode%26client_id%3D50916%26state%3D0b4af2ea33259a885e1e984174406288%26redirect_uri%3Dhttps%253A%252F%252Fwoocommerce.com%252Fwc-api%252Fwpcom-signin%253Fnext%253Dmyaccount%26blog_id%3D0%26wpcom_connect%3D1&branch=update/woo-logo while logged out
- Assert that the woocommerce logo is visible in the masterbar

### Reviews
- [x] Product
- [x] Code