### PR TITLE
Site Settings: Fix margin and padding in Date & Time FoldableCard

### DIFF
--- a/client/my-sites/site-settings/date-time-format/index.jsx
+++ b/client/my-sites/site-settings/date-time-format/index.jsx
@@ -146,7 +146,7 @@ export class DateTimeFormat extends Component {
 
 		return (
 			<FoldableCard
-				className="date-time-format"
+				className="date-time-format site-settings__foldable-card"
 				clickableHeader
 				header={ this.getCardHeader() }
 			>

--- a/client/my-sites/site-settings/date-time-format/style.scss
+++ b/client/my-sites/site-settings/date-time-format/style.scss
@@ -3,16 +3,6 @@
 	margin-top: -10px;
 	@include breakpoint( ">480px" ) {
 		margin-top: -16px;
-
-		.foldable-card__header,
-		.foldable-card__content {
-			padding-left: 24px;
-			padding-right: 24px;
-		}
-
-		.foldable-card__action {
-			padding-right: 16px;
-		}
 	}
 
 	.date-time-format__title {

--- a/client/my-sites/site-settings/date-time-format/style.scss
+++ b/client/my-sites/site-settings/date-time-format/style.scss
@@ -3,6 +3,10 @@
 	margin-top: -10px;
 	@include breakpoint( ">480px" ) {
 		margin-top: -16px;
+
+		.foldable-card__content {
+			padding: 24px;
+		}
 	}
 
 	.date-time-format__title {


### PR DESCRIPTION
### Background

Today while playing with the settings of one of my sites I noticed that when the Date & Time `FoldableCard` is expanded, the margin below it is not consistent with the rest of the margins below cards in site settings. A further look also showed me that the spacing within the header/content of this `FoldableCard` is not consistent with the rest of the foldable cards throughout site settings. Seems like this has been introduced in #12900, when Date & Time Formats were moved to the Writing settings section.

### Purpose

This PR improves all of these issues by using what we use for the rest of the `FoldableCard`s within Site Settings, here is a detailed list:

* Fix margin below the expanded Date & Time `FoldableCard` to be consistent with the rest of site settings.
* Update padding within the header of the Date & Time `FoldableCard` to be consistent with the rest of the foldable cards throughout site settings.
* Update padding within the content of the Date & Time `FoldableCard` to be consistent with the rest of the foldable cards throughout site settings.
* Make the top border of the expanded `FoldableCard` content box consistent with the rest of the card and foldable card borders.
* Clean up the unnecessary `FoldableCard` CSS within the Date & Time format card.

### Preview

**Before**
![](https://cldup.com/PoVfF1bA1P.png)

**After**
![](https://cldup.com/4L2o5BqEYh.png)

### To test
* Checkout this branch, or get it going on calypso.live.
* Go to `/settings/writing/:site`, where `:site` is one of your sites.
* Expand the Date & Time card.
* Verify spacing is accurate and looks as shown on the After preview.