### PR TITLE
View Site: use theme_preview query argument

### DIFF
--- a/client/my-sites/preview/main.jsx
+++ b/client/my-sites/preview/main.jsx
@@ -73,7 +73,7 @@ class PreviewMain extends React.Component {
 
 		const baseUrl = this.getBasePreviewUrl();
 		const newUrl = addQueryArgs( {
-			preview: true,
+			theme_preview: true,
 			iframe: true,
 			'frame-nonce': this.props.site.options.frame_nonce
 		}, baseUrl );


### PR DESCRIPTION
We used `preview=true` as a query argument of the embedded iframe but it turns out it has some unwanted consequences, like preventing us to visit blog page if it was reassigned from `/`. I haven't figured out what exactly is wrong with `preview` but for now, I think we can just switch to `theme_preview`. That's also what "Preview Site" modal uses.

Test:
- have a blog with a static homepage
- assign the blog page to some subpage like `/blog/` and make a menu link to it
- open View Site, click the link that leads to your blog
- compare a result:
    - in production: you will see your static homepage on `/blog/` (wrong behavior)
    - with this PR: you should be able to see your blog posts on `/blog/` (correct behavior)