### PR TITLE
Build Monitor: Remove code, remove race condition, remove infinite loop

### DIFF
--- a/client/components/webpack-build-monitor/index.jsx
+++ b/client/components/webpack-build-monitor/index.jsx
@@ -5,148 +5,114 @@
  * External dependencies
  */
 import React from 'react';
-import { createStore } from 'redux';
 import classNames from 'classnames';
-import { find, includes, startsWith, identity } from 'lodash';
+import { find, startsWith } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import Spinner from 'components/spinner';
-import { combineReducers } from 'state/utils';
-
-// Action dispatched by wrapped console
-const CONSOLE_MESSAGE = 'CONSOLE_MESSAGE';
-
-const CONNECTED = 'CONNECTED';
-const DISCONNECTED = 'DISCONNECTED';
-const BUILDING_CSS = 'BUILDING_CSS';
-const BUILDING_JS = 'BUILDING_JS';
-const BUILDING_BOTH = 'BUILDING_BOTH';
-const ERROR = 'ERROR';
-const IDLE = 'IDLE';
-
-const doneBuilding = typeDone => state => {
-	if ( state === ERROR ) {
-		return state;
-	} else if ( state === BUILDING_BOTH ) {
-		return typeDone === BUILDING_JS ? BUILDING_CSS : BUILDING_JS;
-	}
-	return IDLE;
-};
-
-const buildJs = state => ( state === BUILDING_CSS ? BUILDING_BOTH : BUILDING_JS );
-const buildCss = state => ( state === BUILDING_JS ? BUILDING_BOTH : BUILDING_CSS );
 
 const MESSAGE_STATUS_MAP = {
-	'[HMR] connected': () => CONNECTED,
-	'[WDS] Disconnected!': () => DISCONNECTED,
-	'[HMR] bundle rebuilding': state => buildJs( state ),
-	'Building CSS…': state => buildCss( state ),
-	'CSS build failed': () => ERROR,
-	'[WDS] Nothing changed.': doneBuilding( BUILDING_JS ),
-	'Reloading CSS: ': doneBuilding( BUILDING_CSS ),
-	'[HMR] bundle rebuilt in': doneBuilding( BUILDING_JS ),
+	'[HMR] connected': { isConnected: true },
+	'[WDS] Disconnected!': { isConnected: false },
+	'[HMR] bundle rebuilding': { isBuildingJs: true },
+	"[HMR] The following modules couldn't be hot updated": { needsReload: true },
+	'Building CSS…': { isBuildingCss: true },
+	'CSS build failed': { hasError: true },
+	'[WDS] Nothing changed.': { isBuildingJs: false },
+	'Reloading CSS: ': { isBuildingCss: false },
+	'[HMR] bundle rebuilt in': { isBuildingJs: false },
 };
 
-const buildStatusReducer = ( state = IDLE, { type, message } ) => {
-	if ( type !== CONSOLE_MESSAGE ) {
-		return state;
+let buildState = {
+	hasError: false,
+	isBuildingCss: false,
+	isBuildingJs: false,
+	isConnected: true,
+};
+
+const interceptConsole = ( consoleObject, updater ) => {
+	[ 'error', 'log', 'warn' ].forEach( method => {
+		const unwrapped = consoleObject[ method ];
+
+		consoleObject[ method ] = ( msg, ...args ) => {
+			const stateUpdates = find( MESSAGE_STATUS_MAP, ( v, prefix ) => startsWith( msg, prefix ) );
+
+			if ( stateUpdates ) {
+				buildState = { ...buildState, ...stateUpdates };
+
+				if ( buildState.needsReload ) {
+					window.location.reload( /* force refresh to load from server */ true );
 	}
 
-	const getNextState =
-		find( MESSAGE_STATUS_MAP, ( v, messagePrefix ) => startsWith( message, messagePrefix ) ) ||
-		identity;
+				updater( buildState );
+			}
 
-	return getNextState( state );
+			unwrapped( msg, ...args );
+		};
+	} );
 };
 
-const reloadReducer = ( state = false, { type, message } ) => {
-	if ( type !== CONSOLE_MESSAGE || state ) {
-		return state;
+const getMessage = ( { hasError, isBuildingCss, isBuildingJs, isConnected } ) => {
+	if ( ! isConnected ) {
+		return 'Dev Server disconnected';
 	}
 
-	if ( startsWith( message, "[HMR] The following modules couldn't be hot updated" ) ) {
-		return true;
+	if ( hasError ) {
+		return 'Build error';
 	}
 
-	return state;
+	if ( isBuildingCss && isBuildingJs ) {
+		return 'Rebuilding JS and CSS';
+	}
+
+	if ( isBuildingCss ) {
+		return 'Building CSS';
+	}
+
+	if ( isBuildingJs ) {
+		return 'Rebuilding JavaScript';
+	}
+
+	return '';
 };
 
-const store = createStore(
-	combineReducers( {
-		buildStatus: buildStatusReducer,
-		reloadRequired: reloadReducer,
-	} )
-);
-
-const wrapConsole = fn => ( message, ...args ) => {
-	Promise.resolve().then( () => store.dispatch( { type: CONSOLE_MESSAGE, message } ) );
-	fn.call( window, message, ...args );
-};
-
-console.error = wrapConsole( console.error );
-console.warn = wrapConsole( console.warn );
-console.log = wrapConsole( console.log );
-
-const STATUS_TEXTS = {
-	[ DISCONNECTED ]: 'Dev Server disconnected',
-	[ ERROR ]: 'Build error',
-	[ BUILDING_JS ]: 'Rebuilding Javascript',
-	[ BUILDING_CSS ]: 'Rebuilding CSS',
-	[ BUILDING_BOTH ]: 'Rebuilding JS and CSS',
-};
-
-const RELOAD_REQUIRED_ELEMENT = (
-	// eslint-disable-next-line wpcalypso/jsx-classname-namespace
-	<div className="webpack-build-monitor is-warning">Need to refresh</div>
-);
+let alreadyExists = false;
 
 class WebpackBuildMonitor extends React.PureComponent {
-	state = {
-		buildStatus: IDLE,
-		reloadRequired: false,
-	};
+	state = buildState;
 
 	componentDidMount() {
-		this.unsubscribe = store.subscribe(
-			( () => {
-				let prevState = undefined;
-				return () => {
-					const nextState = store.getState();
-					if ( nextState !== prevState ) {
-						this.setState( nextState );
-						prevState = nextState;
-					}
-				};
-			} )()
+		if ( alreadyExists ) {
+			console.error(
+				'There should only be a single build monitor loaded. ' +
+					"Please make sure we're not trying to load more than one at a time."
 		);
 	}
+		alreadyExists = true;
 
-	componentWillUnmount() {
-		this.unsubscribe();
+		interceptConsole( console, state => this.setState( state ) );
 	}
 
 	render() {
-		const { buildStatus, reloadRequired } = this.state;
+		const { hasError, isBuildingCss, isBuildingJs, isConnected } = this.state;
 
-		if ( buildStatus === IDLE ) {
-			return reloadRequired && RELOAD_REQUIRED_ELEMENT;
+		// build is idle
+		if ( ! isBuildingCss && ! isBuildingJs ) {
+			return null;
 		}
 
-		const text = STATUS_TEXTS[ buildStatus ] || '';
-
-		const classnames = classNames( 'webpack-build-monitor', {
-			'is-error': status === ERROR || status === DISCONNECTED,
-			'is-warning': reloadRequired,
-		} );
-
 		return (
-			<div className={ classnames }>
-				{ includes( [ BUILDING_BOTH, BUILDING_CSS, BUILDING_JS ], buildStatus ) && (
-					<Spinner size={ 11 } className="webpack-build-monitor__spinner" />
+			<div
+				className={ classNames( 'webpack-build-monitor', {
+					'is-error': hasError || ! isConnected,
+				} ) }
+			>
+				{ ( isBuildingCss || isBuildingJs ) &&
+					<Spinner size={ 11 } className="webpack-build-monitor__spinner" /> }
 				) }
-				{ text }
+				{ getMessage( this.state ) }
 			</div>
 		);
 	}

--- a/client/components/webpack-build-monitor/index.jsx
+++ b/client/components/webpack-build-monitor/index.jsx
@@ -17,6 +17,7 @@ const MESSAGE_STATUS_MAP = {
 	'[HMR] connected': { isConnected: true },
 	'[WDS] Disconnected!': { isConnected: false },
 	'[HMR] bundle rebuilding': { isBuildingJs: true },
+	'[HMR] Cannot find update (Full reload needed)': { needsReload: true },
 	"[HMR] The following modules couldn't be hot updated": { needsReload: true },
 	'Building CSS…': { isBuildingCss: true },
 	'CSS build failed': { hasError: true },


### PR DESCRIPTION
The build monitor currently grabs its information on build status by
intercepting the `console.` functions. In #17479 we tried to prevent an
infinite loop that could occur because we were calling out to the
console from within the same stack context that was intercepting the
messages. #17545 introduced a race condition to delay updating the
monitor to try and work around the circumstances that produced the
infinite loop.

This patch removes all the code which created the loop in the first
place and removes the abstractions around the monitoring. We could have
done more work to abstract or generalize this, but as a design rule
there should only be a single build monitor and it should only exist in
the browser in local development. Therefore I have coupled the console
interception to the React lifecycle and updates.

Additionally I have attempted to go ahead and automatically refresh the
browser when we infer that we have to because of changes which could not
be applied.

**Testing**

Load up the development version with `npm start` and make some changes. Make sure the build monitor displays appropriately.

I couldn't exactly figure out how to trigger the "Disconnected" message so it's not tested.

Also I wasn't sure how to trigger the `needsRefresh` scenario so it's also untested.