### PR TITLE
Auto-populate email on login form

### DIFF
--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -49,6 +49,7 @@ export class LoginForm extends Component {
 		socialAccountIsLinking: PropTypes.bool,
 		socialAccountLinkEmail: PropTypes.string,
 		socialAccountLinkService: PropTypes.string,
+		userEmail: PropTypes.string,
 		translate: PropTypes.func.isRequired,
 		isFormDisabled: PropTypes.bool,
 		oauth2Client: PropTypes.object,
@@ -56,7 +57,7 @@ export class LoginForm extends Component {
 
 	state = {
 		isDisabledWhileLoading: true,
-		usernameOrEmail: this.props.socialAccountLinkEmail || '',
+		usernameOrEmail: this.props.socialAccountLinkEmail || this.props.userEmail || '',
 		password: '',
 		rememberMe: false,
 	};
@@ -310,6 +311,7 @@ export class LoginForm extends Component {
 export default connect(
 	( state ) => ( {
 		redirectTo: getCurrentQueryArguments( state ).redirect_to,
+		userEmail: getCurrentQueryArguments( state ).user_email,
 		requestError: getRequestError( state ),
 		isFormDisabled: isFormDisabled( state ),
 		socialAccountIsLinking: getSocialAccountIsLinking( state ),

--- a/client/components/signup-form/index.jsx
+++ b/client/components/signup-form/index.jsx
@@ -337,7 +337,7 @@ class SignupForm extends Component {
 
 		return map( messages, ( message, error_code ) => {
 			if ( error_code === 'taken' ) {
-				link += '&email_address=' + encodeURIComponent( formState.getFieldValue( this.state.form, fieldName ) );
+				link += '&user_email=' + encodeURIComponent( formState.getFieldValue( this.state.form, fieldName ) );
 				return (
 					<span>
 						<p>

--- a/client/jetpack-connect/auth-logged-out-form.jsx
+++ b/client/jetpack-connect/auth-logged-out-form.jsx
@@ -57,12 +57,13 @@ class LoggedOutForm extends Component {
 	}
 
 	renderLoginUser() {
-		const { userData, bearerToken } = this.props.jetpackConnectAuthorize;
+		const { userData, bearerToken, queryObject } = this.props.jetpackConnectAuthorize;
 
 		return (
 			<WpcomLoginForm
 				log={ userData.username }
 				authorization={ 'Bearer ' + bearerToken }
+				userEmail={ queryObject.user_email }
 				redirectTo={ this.getRedirectAfterLoginUrl() } />
 		);
 	}
@@ -94,10 +95,12 @@ class LoggedOutForm extends Component {
 
 	renderFooterLink() {
 		const redirectTo = this.getRedirectAfterLoginUrl();
+		const userEmail = this.props.jetpackConnectAuthorize.queryObject.user_email;
 
 		return (
 			<LoggedOutFormLinks>
-				<LoggedOutFormLinkItem href={ login( { isNative: config.isEnabled( 'login/native-login-links' ), redirectTo } ) }>
+				<LoggedOutFormLinkItem
+					href={ login( { isNative: config.isEnabled( 'login/native-login-links' ), redirectTo, userEmail } ) }>
 					{ this.props.translate( 'Already have an account? Sign in' ) }
 				</LoggedOutFormLinkItem>
 				<HelpButton onClick={ this.handleClickHelp } />

--- a/client/jetpack-connect/auth-logged-out-form.jsx
+++ b/client/jetpack-connect/auth-logged-out-form.jsx
@@ -109,6 +109,7 @@ class LoggedOutForm extends Component {
 		const {
 			isAuthorizing,
 			userData,
+			queryObject,
 		} = this.props.jetpackConnectAuthorize;
 
 		return (
@@ -122,6 +123,7 @@ class LoggedOutForm extends Component {
 					submitForm={ this.handleSubmitSignup }
 					submitButtonText={ this.props.translate( 'Sign Up and Connect Jetpack' ) }
 					footerLink={ this.renderFooterLink() }
+					email={ queryObject.user_email }
 					suggestedUsername={ get( userData, 'username', '' ) }
 				/>
 				{ userData && this.renderLoginUser() }

--- a/client/lib/paths/login/index.js
+++ b/client/lib/paths/login/index.js
@@ -5,7 +5,7 @@ import { addQueryArgs } from 'lib/url';
 import { addLocaleToPath, addLocaleToWpcomUrl } from 'lib/i18n-utils';
 import config, { isEnabled } from 'config';
 
-export function login( { isNative, locale, redirectTo, twoFactorAuthType, socialConnect } = {} ) {
+export function login( { isNative, locale, redirectTo, twoFactorAuthType, socialConnect, userEmail } = {} ) {
 	let url = config( 'login_url' );
 
 	if ( isNative && isEnabled( 'login/wp-login' ) ) {
@@ -30,6 +30,10 @@ export function login( { isNative, locale, redirectTo, twoFactorAuthType, social
 
 	if ( redirectTo ) {
 		url = addQueryArgs( { redirect_to: redirectTo }, url );
+	}
+
+	if ( userEmail ) {
+		url = addQueryArgs( { user_email: userEmail }, url );
 	}
 
 	return url;

--- a/client/lib/paths/login/test/index.js
+++ b/client/lib/paths/login/test/index.js
@@ -55,5 +55,13 @@ describe( 'index', () => {
 				'/log-in?redirect_to=https%3A%2F%2Fwordpress.com%2F%3Fsearch%3Dtest%26foo%3Dbar'
 			);
 		} );
+
+		it( 'should return the login url with encoded user_email param', () => {
+			const url = login( { isNative: true, userEmail: 'foo@bar.com' } );
+
+			expect( url ).to.equal(
+				'/log-in?user_email=foo%40bar.com'
+			);
+		} );
 	} );
 } );


### PR DESCRIPTION
Currently if a user tries to connect and we recognize their email, and they're not logged in to WordPress.com, we redirect them to /wp-login.php with the email field prepopulated.

In order to migrate this functionality to Calypso, I wanted to add email population to both the login and signup forms.

This also fixes an issue with the existing login link for users signing up with an existing email address - it was using the unrecognised `email_address` parameter, now migrated to the working `user_email` parameter.