### PR TITLE
Simple Payments: Fix a couple of React warnings in SimplePaymentsDialog

### DIFF
--- a/client/components/tinymce/plugins/simple-payments/dialog/docs/example.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/docs/example.jsx
@@ -3,7 +3,7 @@
  */
 import React, { PureComponent } from 'react';
 import { connect } from 'react-redux';
-import { get } from 'lodash';
+import { get, noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -27,6 +27,7 @@ class SimplePaymentsDialogExample extends PureComponent {
 					siteId={ this.props.siteId }
 					showDialog={ this.state.showDialog }
 					onClose={ this.handleClose }
+					onInsert={ noop }
 				/>
 			</Card>
 		);

--- a/client/components/tinymce/plugins/simple-payments/dialog/form.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/form.jsx
@@ -8,7 +8,7 @@ import React, { Component } from 'react';
 import { reduxForm, Field, Fields, getFormValues, isValid, isDirty } from 'redux-form';
 import { localize } from 'i18n-calypso';
 import emailValidator from 'email-validator';
-import { flowRight as compose, padEnd, trimEnd } from 'lodash';
+import { flowRight as compose, omit, padEnd, trimEnd } from 'lodash';
 
 /**
  * Internal dependencies
@@ -138,7 +138,7 @@ const renderPriceField = ( { price, currency, ...props } ) => {
 		<FieldsetRenderer
 			inputComponent={ FormCurrencyInput }
 			{ ...price }
-			{ ...props }
+			{ ...omit( props, [ 'names' ] ) }
 			currencySymbolPrefix={ currency.input.value }
 			onCurrencyChange={ currency.input.onChange }
 			currencyList={ VISUAL_CURRENCY_LIST }


### PR DESCRIPTION
This PR fixes a couple of React warnings with the Simple Payments Dialog.

To reproduce them:
* Open http://calypso.localhost:3000/devdocs/blocks/simple-payments-dialog
* You'll see the first warning: `Warning: Failed prop type: The prop onInsert is marked...`
* Click the button to open the dialog.
* You'll see the second warning: `Warning: Unknown prop names on <input> tag...`

To test:
* Checkout this branch
* Go to http://calypso.localhost:3000/devdocs/blocks/simple-payments-dialog
* Verify you no longer see the first warning.
* Click the button to open the dialog.
* Verify you no longer see the second warning.
* Verify these changes introduce no regressions.