### PR TITLE
Sidebar: Improve accessibility of Double Buttons

### DIFF
--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -146,7 +146,7 @@
 
 		-webkit-tap-highlight-color: rgba( $gray-dark, .2 );
 
-		.menu-link-secondary-text {
+		.sidebar__menu-link-secondary-text {
 			padding: 3px 8px 4px 8px;
 			margin-right: 8px;
 			align-self: center;

--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -192,8 +192,7 @@ a.sidebar__button, form.sidebar__button {
 	position: relative;
 	align-self: center;
 	box-sizing: border-box;
-	white-space: nowrap;
-	overflow: hidden;
+	overflow: visible;
 	padding: 2px 8px 3px 8px;
 	height: 24px;
 	margin-right: 8px;
@@ -211,8 +210,16 @@ a.sidebar__button, form.sidebar__button {
 		line-height: 23px;
 	}
 }
-form.sidebar__button {
-	cursor: pointer;
+
+// Expanding clickable area of mini buttons
+a.sidebar__button:after,
+form.sidebar__button input {
+	content: '';
+	position: absolute;
+	top: -10px;
+	bottom: -10px;
+	right: -10px;
+	left: -10px;
 }
 
 // Selected Menu
@@ -234,6 +241,10 @@ form.sidebar__button {
 		.sidebar__button {
 			color: $gray-dark;
 			border: 1px solid darken( $sidebar-selected-color, 10% );
+
+			&:hover {
+				color: $blue-medium;
+			}
 		}
 
 		.gridicon,
@@ -260,8 +271,6 @@ form.sidebar__button {
 
 		a,
 		form {
-			color: $blue-medium;
-
 			&:first-child:after {
 				background: linear-gradient(
 					to right,
@@ -273,11 +282,6 @@ form.sidebar__button {
 				background-color: lighten( $sidebar-bg-color, 10% );
 				color: $sidebar-text-color;
 			}
-		}
-
-		.gridicon,
-		.jetpack-logo {
-			fill: $blue-medium;
 		}
 	}
 
@@ -317,6 +321,15 @@ form.sidebar__button {
 
 	form.sidebar__button:hover {
 		border-color: darken( $sidebar-bg-color, 10% );
+	}
+
+	a:hover, form:hover {
+		color: $blue-medium;
+
+		.gridicon,
+		.jetpack-logo {
+			fill: $blue-medium;
+		}
 	}
 }
 

--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -146,15 +146,17 @@
 
 		-webkit-tap-highlight-color: rgba( $gray-dark, .2 );
 
-	}
-
-	a.plan-name {
-		padding: 3px 8px 4px 8px;
-		margin-right: 8px;
-		align-self: center;
-		color: darken( $gray, 20% );
-		font-weight: 600;
-		font-size: 12px;
+		.menu-link-secondary-text {
+			padding: 3px 8px 4px 8px;
+			margin-right: 8px;
+			align-self: center;
+			font-weight: 600;
+			font-size: 12px;
+			position: absolute;
+			right: 0;
+			z-index: z-index( 'icon-parent', '.sidebar__menu .gridicon.gridicons-external' );
+			color: darken( $gray, 20% );
+		}
 	}
 
 	.gridicon,
@@ -325,6 +327,10 @@ form.sidebar__button input {
 
 	a:hover, form:hover {
 		color: $blue-medium;
+
+		.sidebar__menu-link-secondary-text {
+			color: inherit;
+		}
 
 		.gridicon,
 		.jetpack-logo {

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -357,8 +357,8 @@ export class MySitesSidebar extends Component {
 				<a onClick={ this.trackUpgradeClick } href={ planLink }>
 					<JetpackLogo size={ 24 } />
 					<span className="menu-link-text">{ this.props.translate( 'Plan', { context: 'noun' } ) }</span>
+					<span className="sidebar__menu-link-secondary-text">{ planName }</span>
 				</a>
-				<a href={ planLink } className="plan-name" onClick={ this.trackUpgradeClick }>{ planName }</a>
 			</li>
 		);
 	}


### PR DESCRIPTION
Double buttons are those sidebar items that provide two actions - usually "list existing" and "create new". Their current behavior is little weird.

# Current state

| marked areas | live action |
| - | - |
| ![double-buttons](https://user-images.githubusercontent.com/156676/30133740-d263c182-9309-11e7-9678-bfa4203cbad1.png) | ![double-button-current](https://user-images.githubusercontent.com/156676/30133905-40b8dec4-930a-11e7-9d50-c52cfe47a8d5.gif) |

- purple is the link for “site pages”
- green is “add”, but hovering it also triggers the hover for the purple link
- yellow is weird - it activates the hover state for the purple link but if you click it, nothing happens

# This PR

| marked areas | live action |
| - | - |
| ![double-buttons-new](https://user-images.githubusercontent.com/156676/30134025-9d9c4252-930a-11e7-9127-e9ffaa00ea7d.png) | ![double-button-hover](https://user-images.githubusercontent.com/156676/30134037-abda31a8-930a-11e7-9d2f-162eaaf04ced.gif) |

- we have only two clickable areas for two possible outcomes
    - the main link and the tiny button
- only one area is highlighted (blue font) at any single time
    - it is now more apparent what will happen when you click — the "blue" thing will happen 
- the tiny button is more forgiving and will also accept a click from the tiny edge around it that was previously noop when clicked
    - this is a common practice for buttons that leads to a better usability
    - helps people that might not be very precise with their cursor but also people that are used to fast-paced movements. Bigger area is always easier to aim for
    - this also adds more forgiveness when using touch

# Test

Make sure all sidebars work as expected (My Sites, Reader, /me) and they provide features listed above.

Calypso.live bot hasn't commented with a URL here, but it still can be accessed: https://calypso.live/?branch=fix/double-button-accessibility