### PR TITLE
Jetpack Connect: Bypass plans page for JPO

### DIFF
--- a/client/jetpack-connect/auth-logged-in-form.jsx
+++ b/client/jetpack-connect/auth-logged-in-form.jsx
@@ -104,9 +104,9 @@ class LoggedInForm extends Component {
 			authorizeError
 		} = props.jetpackConnectAuthorize;
 
-		// For SSO or WooCommerce Services users, do not display plans page
+		// For SSO, WooCommerce Services, and JPO users, do not display plans page
 		// Instead, redirect back to admin as soon as we're connected
-		if ( props.isSSO || props.isWCS ) {
+		if ( props.isSSO || props.isWCS || ( 'undefined' !== typeof queryObject && 'jpo' === queryObject.from ) ) {
 			if ( ! isRedirectingToWpAdmin && authorizeSuccess ) {
 				return this.props.goBackToWpAdmin( queryObject.redirect_after_auth );
 			}

--- a/client/jetpack-connect/auth-logged-in-form.jsx
+++ b/client/jetpack-connect/auth-logged-in-form.jsx
@@ -106,7 +106,7 @@ class LoggedInForm extends Component {
 
 		// For SSO, WooCommerce Services, and JPO users, do not display plans page
 		// Instead, redirect back to admin as soon as we're connected
-		if ( props.isSSO || props.isWCS || ( 'undefined' !== typeof queryObject && 'jpo' === queryObject.from ) ) {
+		if ( props.isSSO || props.isWCS || ( queryObject && 'jpo' === queryObject.from ) ) {
 			if ( ! isRedirectingToWpAdmin && authorizeSuccess ) {
 				return this.props.goBackToWpAdmin( queryObject.redirect_after_auth );
 			}


### PR DESCRIPTION
Currently, when a user connects their site from JPO, they see an error before being redirected back to their site. Also, we show the "finishing up" text for a while before redirecting.

![jpo_jpc](https://user-images.githubusercontent.com/1126811/30134538-0fd47594-931d-11e7-9909-25ac19750091.gif)

Notice how the red error notice appears briefly before I am redirected.

Since we don't want to show JPO users the plans page and want to redirect them back to WP admin to complete the JPO flow, I was able to fix this by treating it the same as SSO.

![jpo_jpc_working](https://user-images.githubusercontent.com/1126811/30134642-70e3d7c6-931d-11e7-8961-b058553f974b.gif)

To test:

- Add `from=jpo` to the connection URL when you land on WP.com
- Test before patch. You should see the error.
- Test locally after patch. You should not see an error and should be redirected back to wp-admin