### PR TITLE
Reader: Fix blockquote and Caterpillar link color

### DIFF
--- a/client/blocks/comments/style.scss
+++ b/client/blocks/comments/style.scss
@@ -314,7 +314,6 @@
 .comments__comment-content-wrapper {
 	display: inline-block;
 	position: relative;
-	width: 100%;
 
 	&.is-single-line,
 	&.is-single-line .comments__comment-content {

--- a/client/blocks/comments/style.scss
+++ b/client/blocks/comments/style.scss
@@ -314,6 +314,7 @@
 .comments__comment-content-wrapper {
 	display: inline-block;
 	position: relative;
+	width: 100%;
 
 	&.is-single-line,
 	&.is-single-line .comments__comment-content {
@@ -341,6 +342,10 @@
 
 .comments__comment-content-wrapper.is-excerpt .comments__comment-content p {
 	margin-bottom: 0;
+}
+
+.comments__comment-content-wrapper.is-excerpt .comments__comment-content blockquote {
+	margin: 10px 0 16px;
 }
 
 // Avoids long trackback links from wrapping

--- a/client/blocks/comments/style.scss
+++ b/client/blocks/comments/style.scss
@@ -406,11 +406,12 @@ a.comments__comment-username {
 	}
 
 	blockquote {
-		padding: 8px 16px;
-		margin: 8px 0 16px;
-		border-left: 2px solid $gray;
+		background: $gray-light;
+		border-left: 2px solid lighten( $gray, 30% );
+		border-radius: 0;
 		color: darken( $gray, 30% );
-		background: lighten( $gray, 30% );
+		margin: 8px 0 16px;
+		padding: 8px 16px;
 	}
 }
 

--- a/client/blocks/conversation-caterpillar/style.scss
+++ b/client/blocks/conversation-caterpillar/style.scss
@@ -20,9 +20,9 @@
 
 .conversation-caterpillar__show-all,
 .conversation-caterpillar__count {
-	display: flex;
-	color: #87a6bc;
+	color: $gray;
 	cursor: pointer;
+	display: flex;
 	font-size: 13px;
 	font-weight: 400;
 }
@@ -46,8 +46,12 @@
 		white-space: normal;
 	}
 
+	&:hover {
+		color: $blue-medium;
+	}
+
 	&::after {
-		@include long-content-fade( $size: 10% );
+		@include long-content-fade( $size: 35px );
 		height: 16px * 2;
 		width: 16px * 2;
 		z-index: 1;
@@ -79,4 +83,18 @@
 	font-weight: 400;
 	margin-left: 8px;
 	cursor: pointer;
+}
+
+.conversation-caterpillar__show-all {
+
+	&:hover {
+		color: $blue-medium;
+	}
+
+	.gridicon {
+
+		&:hover {
+			fill: $blue-medium;
+		}
+	}
 }

--- a/client/blocks/conversations/style.scss
+++ b/client/blocks/conversations/style.scss
@@ -21,6 +21,7 @@
 	}
 
 	.reader-post-card__byline-author-site {
+		font-weight: 500;
 		margin-right: 5px;
 	}
 

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -324,6 +324,7 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 
 .reader-post-card__byline-author-site {
 	font-family: $sans;
+	font-weight: 500;
 	overflow: hidden;
 	position: relative;
 	height: 20px;


### PR DESCRIPTION
Small fix to Conversations blockquote:

**Before:**
<img width="815" alt="screenshot 2017-09-06 14 34 49" src="https://user-images.githubusercontent.com/4924246/30135944-bc628456-9311-11e7-8eab-e1be939979ae.png">

**After:**
<img width="818" alt="screenshot 2017-09-06 14 34 54" src="https://user-images.githubusercontent.com/4924246/30135951-c1710436-9311-11e7-9222-a1dfe92ac302.png">

Also updated hover link colors for caterpillar and "show all" button.