### PR TITLE
Store Orders: Move order UI state to a subtree of `orders`

### DIFF
--- a/client/extensions/woocommerce/state/ui/orders/README.md
+++ b/client/extensions/woocommerce/state/ui/orders/README.md
@@ -1,0 +1,37 @@
+UI Orders
+=========
+
+This module is used to manage state for the UI of the orders sections. This includes which filters are in effect for the list view.
+
+## Actions
+
+### `updateCurrentOrdersQuery( siteId: number, query: object )`
+
+Update the query used to display the orders list - ex: set the search term, or change which page is being viewed.
+
+## Reducer
+
+This is saved on a per-site basis. 
+
+```js
+{
+	"orders": {
+		[ siteId ] : {
+			list: {
+				currentPage: 1,
+				currentSearch: "Smith",
+			},
+		}
+	}
+}
+```
+
+## Selectors
+
+### `getOrdersCurrentPage( state, [siteId] )`
+
+Gets the current page being shown to the user. Defaults to 1.
+
+### `getOrdersCurrentSearch( state, [siteId] )`
+
+Gets the current search term being shown to the user. Defaults to "".

--- a/client/extensions/woocommerce/state/ui/orders/list/reducer.js
+++ b/client/extensions/woocommerce/state/ui/orders/list/reducer.js
@@ -22,7 +22,7 @@ export function currentPage( state = 1, action ) {
 }
 
 /**
- * Tracks the current page of orders displayed for the current site.
+ * Tracks the current search term used for the current site.
  *
  * @param  {Object} state  Current state
  * @param  {Object} action Action payload

--- a/client/extensions/woocommerce/state/ui/orders/list/reducer.js
+++ b/client/extensions/woocommerce/state/ui/orders/list/reducer.js
@@ -1,0 +1,44 @@
+/**
+ * External dependencies
+ */
+import { combineReducers } from 'state/utils';
+import { WOOCOMMERCE_UI_ORDERS_SET_QUERY } from 'woocommerce/state/action-types';
+
+/**
+ * Tracks the current page of orders displayed for the current site.
+ *
+ * @param  {Object} state  Current state
+ * @param  {Object} action Action payload
+ * @return {Object}        Updated state
+ */
+export function currentPage( state = 1, action ) {
+	const { type, query } = action;
+	switch ( type ) {
+		case WOOCOMMERCE_UI_ORDERS_SET_QUERY:
+			return query && query.page ? query.page : state;
+		default:
+			return state;
+	}
+}
+
+/**
+ * Tracks the current page of orders displayed for the current site.
+ *
+ * @param  {Object} state  Current state
+ * @param  {Object} action Action payload
+ * @return {Object}        Updated state
+ */
+export function currentSearch( state = '', action ) {
+	const { type, query } = action;
+	switch ( type ) {
+		case WOOCOMMERCE_UI_ORDERS_SET_QUERY:
+			return query && ( 'undefined' !== typeof query.search ) ? query.search : state;
+		default:
+			return state;
+	}
+}
+
+export default combineReducers( {
+	currentPage,
+	currentSearch
+} );

--- a/client/extensions/woocommerce/state/ui/orders/list/test/reducer.js
+++ b/client/extensions/woocommerce/state/ui/orders/list/test/reducer.js
@@ -1,0 +1,51 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+import deepFreeze from 'deep-freeze';
+
+/**
+ * Internal dependencies
+ */
+import reducer from '../reducer';
+import { WOOCOMMERCE_UI_ORDERS_SET_QUERY } from 'woocommerce/state/action-types';
+
+describe( 'reducer', () => {
+	it( 'should store the current query', () => {
+		const action = {
+			type: WOOCOMMERCE_UI_ORDERS_SET_QUERY,
+			siteId: 123,
+			query: {
+				page: 2,
+			},
+		};
+		const newState = reducer( undefined, action );
+		expect( newState ).to.eql( { currentPage: 2, currentSearch: '' } );
+	} );
+
+	it( 'should update the current page when changed', () => {
+		const action = {
+			type: WOOCOMMERCE_UI_ORDERS_SET_QUERY,
+			siteId: 123,
+			query: {
+				page: 2,
+			},
+		};
+		const originalState = deepFreeze( { currentPage: 3, currentSearch: '' } );
+		const newState = reducer( originalState, action );
+		expect( newState ).to.eql( { currentPage: 2, currentSearch: '' } );
+	} );
+
+	it( 'should update the current search when changed', () => {
+		const action = {
+			type: WOOCOMMERCE_UI_ORDERS_SET_QUERY,
+			siteId: 123,
+			query: {
+				search: 'example'
+			},
+		};
+		const originalState = deepFreeze( { currentPage: 3, currentSearch: '' } );
+		const newState = reducer( originalState, action );
+		expect( newState ).to.eql( { currentPage: 3, currentSearch: 'example' } );
+	} );
+} );

--- a/client/extensions/woocommerce/state/ui/orders/reducer.js
+++ b/client/extensions/woocommerce/state/ui/orders/reducer.js
@@ -2,45 +2,12 @@
  * External dependencies
  */
 import { combineReducers, keyedReducer } from 'state/utils';
-import { WOOCOMMERCE_UI_ORDERS_SET_QUERY } from 'woocommerce/state/action-types';
 
 /**
- * Tracks the current page of orders displayed for the current site.
- *
- * @param  {Object} state  Current state
- * @param  {Object} action Action payload
- * @return {Object}        Updated state
+ * Internal dependencies
  */
-export function currentPage( state = 1, action ) {
-	const { type, query } = action;
-	switch ( type ) {
-		case WOOCOMMERCE_UI_ORDERS_SET_QUERY:
-			return query && query.page ? query.page : state;
-		default:
-			return state;
-	}
-}
+import list from './list/reducer';
 
-/**
- * Tracks the current page of orders displayed for the current site.
- *
- * @param  {Object} state  Current state
- * @param  {Object} action Action payload
- * @return {Object}        Updated state
- */
-export function currentSearch( state = '', action ) {
-	const { type, query } = action;
-	switch ( type ) {
-		case WOOCOMMERCE_UI_ORDERS_SET_QUERY:
-			return query && ( 'undefined' !== typeof query.search ) ? query.search : state;
-		default:
-			return state;
-	}
-}
-
-const ordersReducer = combineReducers( {
-	currentPage,
-	currentSearch
-} );
-
-export default keyedReducer( 'siteId', ordersReducer );
+export default keyedReducer( 'siteId', combineReducers( {
+	list,
+} ) );

--- a/client/extensions/woocommerce/state/ui/orders/selectors.js
+++ b/client/extensions/woocommerce/state/ui/orders/selectors.js
@@ -14,7 +14,7 @@ import { getSelectedSiteId } from 'state/ui/selectors';
  * @return {Number} The current page being shown to the user. Defaults to 1.
  */
 export const getOrdersCurrentPage = ( state, siteId = getSelectedSiteId( state ) ) => {
-	return get( state, [ 'extensions', 'woocommerce', 'ui', 'orders', siteId, 'currentPage' ], 1 );
+	return get( state, [ 'extensions', 'woocommerce', 'ui', 'orders', siteId, 'list', 'currentPage' ], 1 );
 };
 
 /**
@@ -23,5 +23,5 @@ export const getOrdersCurrentPage = ( state, siteId = getSelectedSiteId( state )
  * @return {String} The current search term being shown to the user. Defaults to "".
  */
 export const getOrdersCurrentSearch = ( state, siteId = getSelectedSiteId( state ) ) => {
-	return get( state, [ 'extensions', 'woocommerce', 'ui', 'orders', siteId, 'currentSearch' ], '' );
+	return get( state, [ 'extensions', 'woocommerce', 'ui', 'orders', siteId, 'list', 'currentSearch' ], '' );
 };

--- a/client/extensions/woocommerce/state/ui/orders/test/reducer.js
+++ b/client/extensions/woocommerce/state/ui/orders/test/reducer.js
@@ -11,49 +11,6 @@ import reducer from '../reducer';
 import { WOOCOMMERCE_UI_ORDERS_SET_QUERY } from 'woocommerce/state/action-types';
 
 describe( 'reducer', () => {
-	it( 'should have no change by default', () => {
-		const newState = reducer( undefined, {} );
-		expect( newState ).to.eql( {} );
-	} );
-
-	it( 'should store the current query', () => {
-		const action = {
-			type: WOOCOMMERCE_UI_ORDERS_SET_QUERY,
-			siteId: 123,
-			query: {
-				page: 2,
-			},
-		};
-		const newState = reducer( undefined, action );
-		expect( newState ).to.eql( { 123: { currentPage: 2, currentSearch: '' } } );
-	} );
-
-	it( 'should update the current page when changed', () => {
-		const action = {
-			type: WOOCOMMERCE_UI_ORDERS_SET_QUERY,
-			siteId: 123,
-			query: {
-				page: 2,
-			},
-		};
-		const originalState = deepFreeze( { 123: { currentPage: 3, currentSearch: '' } } );
-		const newState = reducer( originalState, action );
-		expect( newState ).to.eql( { 123: { currentPage: 2, currentSearch: '' } } );
-	} );
-
-	it( 'should update the current search when changed', () => {
-		const action = {
-			type: WOOCOMMERCE_UI_ORDERS_SET_QUERY,
-			siteId: 123,
-			query: {
-				search: 'example'
-			},
-		};
-		const originalState = deepFreeze( { 123: { currentPage: 3, currentSearch: '' } } );
-		const newState = reducer( originalState, action );
-		expect( newState ).to.eql( { 123: { currentPage: 3, currentSearch: 'example' } } );
-	} );
-
 	it( 'should store the current query for more than one site', () => {
 		const action = {
 			type: WOOCOMMERCE_UI_ORDERS_SET_QUERY,
@@ -62,37 +19,11 @@ describe( 'reducer', () => {
 				search: 'test'
 			},
 		};
-		const originalState = deepFreeze( { 123: { currentPage: 3, currentSearch: '' } } );
+		const originalState = deepFreeze( { 123: { list: { currentPage: 3, currentSearch: '' } } } );
 		const newState = reducer( originalState, action );
 		expect( newState ).to.eql( {
-			123: { currentPage: 3, currentSearch: '' },
-			234: { currentPage: 1, currentSearch: 'test' }
+			123: { list: { currentPage: 3, currentSearch: '' } },
+			234: { list: { currentPage: 1, currentSearch: 'test' } },
 		} );
-	} );
-
-	it( 'should remove the key when page is re-set to initial state', () => {
-		const action = {
-			type: WOOCOMMERCE_UI_ORDERS_SET_QUERY,
-			siteId: 123,
-			query: {
-				page: 1,
-			}
-		};
-		const originalState = deepFreeze( { 123: { currentPage: 3, currentSearch: '' } } );
-		const newState = reducer( originalState, action );
-		expect( newState ).to.eql( {} );
-	} );
-
-	it( 'should remove the key when search is re-set to initial state', () => {
-		const action = {
-			type: WOOCOMMERCE_UI_ORDERS_SET_QUERY,
-			siteId: 123,
-			query: {
-				search: '',
-			}
-		};
-		const originalState = deepFreeze( { 123: { currentPage: 1, currentSearch: 'test' } } );
-		const newState = reducer( originalState, action );
-		expect( newState ).to.eql( {} );
 	} );
 } );

--- a/client/extensions/woocommerce/state/ui/orders/test/selectors.js
+++ b/client/extensions/woocommerce/state/ui/orders/test/selectors.js
@@ -24,12 +24,16 @@ const state = {
 			ui: {
 				orders: {
 					123: {
-						currentPage: 2,
-						currentSearch: 'example',
+						list: {
+							currentPage: 2,
+							currentSearch: 'example',
+						}
 					},
 					234: {
-						currentPage: 5,
-						currentSearch: 'test',
+						list: {
+							currentPage: 5,
+							currentSearch: 'test',
+						}
 					},
 				},
 			},


### PR DESCRIPTION
This starts out some groundwork for bringing in state to track order creation and edits (like products). All that's happening here is the "list" reducer, which tracks the current filters on the list page, is being moved from the `state/ui/orders/` folder to a new `list/` folder inside orders. This also moves the reducer's test, and creates a README.

I've left the selectors and actions in the "top level" orders directory for now, I _think_ these should remain simpler, so I plan on leaving them combined.

I'll be adding a new folder `orders/edits/` with the create- and edit-related reducers next.

To test:

- Run the tests: `npm run test-client client/extensions/woocommerce/state/ui/orders/`
- Load up the branch and visit `/store/orders/:site` to make sure you can still filter through the list by searching & changing page view.
- There should be no functionality changes here.