### PR TITLE
Comments: Add Undo functionality for comment editing.

### DIFF
--- a/client/blocks/comment-detail/comment-detail-edit.jsx
+++ b/client/blocks/comment-detail/comment-detail-edit.jsx
@@ -44,7 +44,8 @@ export class CommentDetailEdit extends Component {
 	setCommentContentValue = event => this.setState( { commentContent: event.target.value } );
 
 	editCommentAndCloseEditMode = () => {
-		this.props.editComment( this.props.commentId, this.props.postId, this.state );
+		const { authorDisplayName, authorUrl, commentContent } = this.props;
+		this.props.editComment( this.props.commentId, this.props.postId, this.state, { authorDisplayName, authorUrl, commentContent } );
 		this.props.closeEditMode();
 	};
 

--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -92,13 +92,11 @@ export class CommentList extends Component {
 		this.props.deleteComment( commentId, postId );
 	}
 
-	editComment = ( commentId, postId, commentData ) => {
+	editComment = ( commentId, postId, commentData, undoCommentData, showNotice = true ) => {
 		this.props.editComment( commentId, postId, commentData );
-		this.props.successNotice( this.props.translate( 'Comment updated.' ), {
-			duration: 5000,
-			id: `comment-notice-${ commentId }`,
-			isPersistent: true,
-		} );
+		if ( showNotice ) {
+			this.showEditNotice( commentId, postId, undoCommentData );
+		}
 	}
 
 	getComments = () => uniq( [ ...this.state.persistedComments, ...this.props.comments ] ).sort( ( a, b ) => b - a );
@@ -234,6 +232,25 @@ export class CommentList extends Component {
 			this.props.unlikeComment( commentId, postId );
 		}
 	}
+
+	showEditNotice = ( commentId, postId, undoCommentData ) => {
+		const { translate } = this.props;
+
+		const message = translate( 'Your comment has been updated.' );
+
+		const noticeOptions = {
+			button: translate( 'Undo' ),
+			duration: 5000,
+			id: `comment-notice-${ commentId }`,
+			isPersistent: true,
+			onClick: () => {
+				this.editComment( commentId, postId, undoCommentData, false );
+				this.props.removeNotice( `comment-notice-${ commentId }` );
+			},
+		};
+
+		this.props.successNotice( message, noticeOptions );
+	};
 
 	showBulkNotice = newStatus => {
 		const { translate } = this.props;


### PR DESCRIPTION
This PR adds an Undo button to the notice that appears on edit of a comment. Clicking it will restore the original data from before the edit occurred.

<img width="463" alt="screen shot 2017-09-06 at 3 50 03 pm" src="https://user-images.githubusercontent.com/349751/30138050-29f09a5e-931b-11e7-929e-a4e63f19824b.png">
