### PR TITLE
Store orders: make them stand out

### DIFF
--- a/client/extensions/woocommerce/app/orders/orders-list.js
+++ b/client/extensions/woocommerce/app/orders/orders-list.js
@@ -124,7 +124,8 @@ class Orders extends Component {
 	renderOrderItem = ( order, i ) => {
 		const { site } = this.props;
 		return (
-			<TableRow key={ i } href={ getLink( `/store/order/:site/${ order.number }`, site ) }>
+			<TableRow className={ 'orders__status-' + order.status } key={ i }
+				href={ getLink( `/store/order/:site/${ order.number }`, site ) }>
 				<TableItem className="orders__table-name" isRowHeader>
 					<span className="orders__item-link">#{ order.number }</span>
 					<span className="orders__item-name">

--- a/client/extensions/woocommerce/app/orders/style.scss
+++ b/client/extensions/woocommerce/app/orders/style.scss
@@ -15,6 +15,14 @@
 		&:hover {
 			background: lighten( $gray, 35% );
 		}
+
+		&.orders__status-processing {
+			background: lighten( $blue-light, 25% );
+
+			&:hover {
+				background: lighten( $blue-light, 24% );
+			}
+		}
 	}
 
 	.orders__row-placeholder span {

--- a/client/extensions/woocommerce/components/order-status/style.scss
+++ b/client/extensions/woocommerce/components/order-status/style.scss
@@ -5,6 +5,15 @@
 	background: lighten( $gray, 20% );
 	border-radius: 4px;
 
+	&.is-processing {
+		background: lighten( $alert-green, 20% );
+		color: darken( $alert-green, 30% );
+
+		span + span {
+			border-color: $alert-green;
+		}
+	}
+
 	&.is-failed {
 		background: lighten( $alert-red, 20% );
 		color: darken( $alert-red, 30% );


### PR DESCRIPTION
New orders should stand out! This was originally supposed to happen in the PR: https://github.com/Automattic/wp-calypso/pull/16608 but it never got in. 

Before
<img width="750" alt="screen shot 2017-09-06 at 6 51 52 pm" src="https://user-images.githubusercontent.com/5835847/30138098-7e55693a-9334-11e7-8cde-3bcf4d3e2658.png">

After
<img width="755" alt="screen shot 2017-09-06 at 6 25 50 pm" src="https://user-images.githubusercontent.com/5835847/30138095-7c69c3d2-9334-11e7-907c-fec3c255c61c.png">
