### PR TITLE
Fix post scheduling calendar not indicating other scheduled posts 

### DIFF
--- a/client/post-editor/editor-ground-control/style.scss
+++ b/client/post-editor/editor-ground-control/style.scss
@@ -150,18 +150,6 @@
 	color: lighten( $gray, 20% );
 }
 
-.editor-ground-control__schedule-post {
-	box-sizing: border-box;
-	display: block;
-	padding: 0 16px;
-	width: 237px;
-
-	.async-load {
-		margin: 16px 0;
-		width: auto;
-	}
-}
-
 .editor-ground-control .edit-post-status {
 	border-top: 1px solid lighten( $gray, 30% );
 	border-bottom: 1px solid lighten( $gray, 30% );

--- a/client/post-editor/editor-publish-date/index.jsx
+++ b/client/post-editor/editor-publish-date/index.jsx
@@ -3,6 +3,7 @@
  */
 import React from 'react';
 import ReactDom from 'react-dom';
+import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
 import Gridicon from 'gridicons';
@@ -12,8 +13,9 @@ import { intersection } from 'lodash';
  * Internal dependencies
  */
 import Button from 'components/button';
-import PostSchedule from 'components/post-schedule';
+import PostScheduler from './post-scheduler';
 import utils from 'lib/posts/utils';
+import { getSelectedSite } from 'state/ui/selectors';
 
 export class EditorPublishDate extends React.Component {
 
@@ -148,11 +150,13 @@ export class EditorPublishDate extends React.Component {
 		return (
 			<div className="editor-publish-date__schedule">
 				{ this.renderCalendarHeader() }
-				<PostSchedule
-					displayInputChrono={ false }
-					onDateChange={ this.props.setPostDate }
+				<PostScheduler
+					post={ this.props.post }
+					site={ this.props.site }
+					initialDate={ this.props.moment() }
+					setPostDate={ this.props.setPostDate }
 					selectedDay={ selectedDay }
-					/>
+				/>
 			</div>
 		);
 	}
@@ -174,4 +178,10 @@ export class EditorPublishDate extends React.Component {
 
 }
 
-export default localize( EditorPublishDate );
+export default connect(
+	( state, props ) => {
+		return {
+			site: getSelectedSite( state ),
+		};
+	}
+)( localize( EditorPublishDate ) );

--- a/client/post-editor/editor-publish-date/index.jsx
+++ b/client/post-editor/editor-publish-date/index.jsx
@@ -179,7 +179,7 @@ export class EditorPublishDate extends React.Component {
 }
 
 export default connect(
-	( state, props ) => {
+	state => {
 		return {
 			site: getSelectedSite( state ),
 		};

--- a/client/post-editor/editor-publish-date/post-scheduler.jsx
+++ b/client/post-editor/editor-publish-date/post-scheduler.jsx
@@ -89,7 +89,7 @@ export default class PostScheduler extends PureComponent {
 		};
 
 		return (
-			<span className="editor-ground-control__schedule-post">
+			<span className="editor-publish-date__post-scheduler">
 				{ ! postUtils.isPage( post ) && <QueryPosts
 					siteId={ get( site, 'ID' ) }
 					query={ query } /> }

--- a/client/post-editor/editor-publish-date/post-scheduler.jsx
+++ b/client/post-editor/editor-publish-date/post-scheduler.jsx
@@ -9,29 +9,28 @@ import { get } from 'lodash';
 /**
  * Internal dependencies
  */
-import AsyncLoad from 'components/async-load';
+import PostSchedule from 'components/post-schedule';
 import QueryPosts from 'components/data/query-posts';
 import postUtils from 'lib/posts/utils';
 import siteUtils from 'lib/site/utils';
 import { getSitePostsForQueryIgnoringPage } from 'state/posts/selectors';
 
-const PostSchedule = ( { onDateChange, onMonthChange, posts, selectedDay, site } ) => {
-	const tz = siteUtils.timezone( site );
-	const gmtOffset = siteUtils.gmtOffset( site );
-
+const PostScheduleWithCurrentMonthPosts = connect(
+	( state, { site, query } ) => ( {
+		posts: getSitePostsForQueryIgnoringPage( state, get( site, 'ID' ), query ) || [],
+	} )
+) ( function( { onDateChange, onMonthChange, posts, selectedDay, site } ) {
 	return (
-		<AsyncLoad
-			require="components/post-schedule"
+		<PostSchedule
+			displayInputChrono={ false }
 			selectedDay={ selectedDay }
-			timezone={ tz }
-			gmtOffset={ gmtOffset }
 			onDateChange={ onDateChange }
 			onMonthChange={ onMonthChange }
 			posts={ posts }
 			site={ site }
 		/>
 	);
-};
+} );
 
 const ConnectedPostSchedule = connect(
 	( state, { site, query } ) => ( {
@@ -93,8 +92,7 @@ export default class PostScheduler extends PureComponent {
 				{ ! postUtils.isPage( post ) && <QueryPosts
 					siteId={ get( site, 'ID' ) }
 					query={ query } /> }
-				<ConnectedPostSchedule
-					require="components/post-schedule"
+				<PostScheduleWithCurrentMonthPosts
 					onDateChange={ setPostDate }
 					onMonthChange={ this.setCurrentMonth }
 					query={ query }

--- a/client/post-editor/editor-publish-date/post-scheduler.jsx
+++ b/client/post-editor/editor-publish-date/post-scheduler.jsx
@@ -82,10 +82,13 @@ export default class PostScheduler extends PureComponent {
 		};
 
 		return (
-			<span className="editor-publish-date__post-scheduler">
-				{ ! postUtils.isPage( post ) && <QueryPosts
-					siteId={ get( site, 'ID' ) }
-					query={ query } /> }
+			<div>
+				{ ! postUtils.isPage( post ) && (
+					<QueryPosts
+						siteId={ get( site, 'ID' ) }
+						query={ query }
+					/>
+				) }
 				<PostScheduleWithOtherPostsIndicated
 					onDateChange={ setPostDate }
 					onMonthChange={ this.setCurrentMonth }
@@ -93,7 +96,7 @@ export default class PostScheduler extends PureComponent {
 					selectedDay={ get( post, 'date' ) }
 					site={ site }
 				/>
-			</span>
+			</div>
 		);
 	}
 }

--- a/client/post-editor/editor-publish-date/post-scheduler.jsx
+++ b/client/post-editor/editor-publish-date/post-scheduler.jsx
@@ -19,7 +19,7 @@ const PostScheduleWithCurrentMonthPosts = connect(
 	( state, { site, query } ) => ( {
 		posts: getSitePostsForQueryIgnoringPage( state, get( site, 'ID' ), query ) || [],
 	} )
-) ( function( { onDateChange, onMonthChange, posts, selectedDay, site } ) {
+)( function( { onDateChange, onMonthChange, posts, selectedDay, site } ) {
 	return (
 		<PostSchedule
 			displayInputChrono={ false }
@@ -31,12 +31,6 @@ const PostScheduleWithCurrentMonthPosts = connect(
 		/>
 	);
 } );
-
-const ConnectedPostSchedule = connect(
-	( state, { site, query } ) => ( {
-		posts: getSitePostsForQueryIgnoringPage( state, get( site, 'ID' ), query ) || [],
-	} )
-)( PostSchedule );
 
 export default class PostScheduler extends PureComponent {
 	static propTypes = {

--- a/client/post-editor/editor-publish-date/post-scheduler.jsx
+++ b/client/post-editor/editor-publish-date/post-scheduler.jsx
@@ -15,7 +15,7 @@ import postUtils from 'lib/posts/utils';
 import siteUtils from 'lib/site/utils';
 import { getSitePostsForQueryIgnoringPage } from 'state/posts/selectors';
 
-const PostScheduleWithCurrentMonthPosts = connect(
+const PostScheduleWithOtherPostsIndicated = connect(
 	( state, { site, query } ) => ( {
 		posts: getSitePostsForQueryIgnoringPage( state, get( site, 'ID' ), query ) || [],
 	} )
@@ -86,7 +86,7 @@ export default class PostScheduler extends PureComponent {
 				{ ! postUtils.isPage( post ) && <QueryPosts
 					siteId={ get( site, 'ID' ) }
 					query={ query } /> }
-				<PostScheduleWithCurrentMonthPosts
+				<PostScheduleWithOtherPostsIndicated
 					onDateChange={ setPostDate }
 					onMonthChange={ this.setCurrentMonth }
 					query={ query }

--- a/client/post-editor/editor-publish-date/style.scss
+++ b/client/post-editor/editor-publish-date/style.scss
@@ -124,3 +124,17 @@
 	border-top: 1px solid lighten( $gray, 20% );
 	padding: 0 10px;
 }
+
+/*
+.editor-ground-control__schedule-post {
+	box-sizing: border-box;
+	display: block;
+	padding: 0 16px;
+	width: 237px;
+
+	.async-load {
+		margin: 16px 0;
+		width: auto;
+	}
+}
+*/

--- a/client/post-editor/editor-publish-date/style.scss
+++ b/client/post-editor/editor-publish-date/style.scss
@@ -124,17 +124,3 @@
 	border-top: 1px solid lighten( $gray, 20% );
 	padding: 0 10px;
 }
-
-/*
-.editor-ground-control__schedule-post {
-	box-sizing: border-box;
-	display: block;
-	padding: 0 16px;
-	width: 237px;
-
-	.async-load {
-		margin: 16px 0;
-		width: auto;
-	}
-}
-*/


### PR DESCRIPTION
Fixes #17888 - see that issue for testing instructions.

There is a component, `PostScheduler`, that renders `PostSchedule` along with a list of other posts from the site, so that they can be displayed with light blue outlines in the scheduling calendar.  In previous PRs related to the publish confirmation sidebars, this component was no longer used, and finally the reference to it was removed [here](https://github.com/Automattic/wp-calypso/pull/17655/files#diff-2b7e4118ffc960578bd452a0242ed25aL25).

This PR reinstates the `PostScheduler` component and modifies it to fit with the new code structure of the publish confirmation sidebar.

In the "After" screenshot below, note that the clock display changed to include AM/PM.  This can be removed if desired, but I believe it is also a fix from the current behavior.  In `master` we are not passing a `site` object to `post-schedule`, and this is used [here](https://github.com/Automattic/wp-calypso/blob/f17172466808e44e7b4354894c8e10ec5af1e64c/client/components/post-schedule/index.jsx#L204-L210) to render a `Clock` component with site-specific settings.

### Before

![2017-09-06t21 18 51-0500](https://user-images.githubusercontent.com/227022/30142966-04d6e560-9349-11e7-893b-4098e64cffca.png)

### After

![2017-09-06t21 20 26-0500](https://user-images.githubusercontent.com/227022/30143003-3a14780a-9349-11e7-927d-3af891b41dfa.png)