### PR TITLE
Activity log: Use isSiteOnPaidPlan selector

### DIFF
--- a/client/my-sites/stats/stats-navigation/index.jsx
+++ b/client/my-sites/stats/stats-navigation/index.jsx
@@ -17,10 +17,8 @@ import NavItem from 'components/section-nav/item';
 import FollowersCount from 'blocks/followers-count';
 import SegmentedControl from 'components/segmented-control';
 import QueryJetpackPlugins from 'components/data/query-jetpack-plugins';
-import { getSitePlanSlug } from 'state/sites/plans/selectors';
-import { isFreePlan } from 'lib/plans';
 import { isJetpackSite } from 'state/sites/selectors';
-import { isPluginActive } from 'state/selectors';
+import { isPluginActive, isSiteOnPaidPlan } from 'state/selectors';
 import config from 'config';
 
 const StatsNavigation = props => {
@@ -106,7 +104,7 @@ const localized = localize( StatsNavigation );
 export default connect( ( state, { siteId } ) => {
 	const isJetpack = isJetpackSite( state, siteId );
 	return {
-		hasPaidPlan: ! isFreePlan( getSitePlanSlug( state, siteId ) ),
+		hasPaidPlan: isSiteOnPaidPlan( state, siteId ),
 		isJetpack,
 		isStore: isJetpack && isPluginActive( state, siteId, 'woocommerce' ),
 		siteId,


### PR DESCRIPTION
There should be no functional changes, we update to use the appropriate selector to detect paid plans.

#17598 was blocking this implementation, but has now landed.

## Testing
1. Visit https://calypso.live/stats?branch=update/activity-log/use-is-paid-selector
1. Do you see the Activity navigation item for Jetpack paid sites?
1. Is it hidden for all other sites?