### PR TITLE
Devdocs: Add JetpackLogo and JetpackColophon

### DIFF
--- a/client/components/jetpack-colophon/docs/example.js
+++ b/client/components/jetpack-colophon/docs/example.js
@@ -10,6 +10,10 @@ import React from 'react';
 import JetpackColophon from 'components/jetpack-colophon';
 
 export default function JetpackColophonExample() {
-	return <JetpackColophon />;
+	return (
+		<div style={ { fontSize: '15px' } }>
+			<JetpackColophon />
+		</div>
+	);
 }
 JetpackColophonExample.displayName = 'JetpackColophonExample';

--- a/client/components/jetpack-colophon/docs/example.js
+++ b/client/components/jetpack-colophon/docs/example.js
@@ -1,0 +1,15 @@
+/** @format */
+/**
+* External dependencies
+*/
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import JetpackColophon from 'components/jetpack-colophon';
+
+export default function JetpackColophonExample() {
+	return <JetpackColophon />;
+}
+JetpackColophonExample.displayName = 'JetpackColophonExample';

--- a/client/components/jetpack-logo/docs/example.js
+++ b/client/components/jetpack-logo/docs/example.js
@@ -13,15 +13,9 @@ export default function JetpackLogoExample() {
 	return (
 		<div>
 			<div>
-				<p>
-					<code>{ '<JetpackLogo full size={ 24 } />' }</code>
-				</p>
 				<JetpackLogo full size={ 24 } />
 			</div>
 			<div>
-				<p>
-					<code>{ '<JetpackLogo size={ 40 } />' }</code>
-				</p>
 				<JetpackLogo size={ 40 } />
 			</div>
 		</div>

--- a/client/components/jetpack-logo/docs/example.js
+++ b/client/components/jetpack-logo/docs/example.js
@@ -14,19 +14,15 @@ export default function JetpackLogoExample() {
 		<div>
 			<div>
 				<p>
-					<code>
-						{ '<JetpackLogo full />' }
-					</code>
+					<code>{ '<JetpackLogo full size={ 24 } />' }</code>
 				</p>
-				<JetpackLogo full />
+				<JetpackLogo full size={ 24 } />
 			</div>
 			<div>
 				<p>
-					<code>
-						{ '<JetpackLogo />' }
-					</code>
+					<code>{ '<JetpackLogo size={ 40 } />' }</code>
 				</p>
-				<JetpackLogo />
+				<JetpackLogo size={ 40 } />
 			</div>
 		</div>
 	);

--- a/client/components/jetpack-logo/docs/example.js
+++ b/client/components/jetpack-logo/docs/example.js
@@ -1,0 +1,34 @@
+/** @format */
+/**
+* External dependencies
+*/
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import JetpackLogo from 'components/jetpack-logo';
+
+export default function JetpackLogoExample() {
+	return (
+		<div>
+			<div>
+				<p>
+					<code>
+						{ '<JetpackLogo full />' }
+					</code>
+				</p>
+				<JetpackLogo full />
+			</div>
+			<div>
+				<p>
+					<code>
+						{ '<JetpackLogo />' }
+					</code>
+				</p>
+				<JetpackLogo />
+			</div>
+		</div>
+	);
+}
+JetpackLogoExample.displayName = 'JetpackLogoExample';

--- a/client/devdocs/design/index.jsx
+++ b/client/devdocs/design/index.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */

--- a/client/devdocs/design/index.jsx
+++ b/client/devdocs/design/index.jsx
@@ -80,6 +80,7 @@ import ListEnd from 'components/list-end/docs/example';
 import Wizard from 'components/wizard/docs/example';
 import Suggestions from 'components/suggestions/docs/example';
 import HeaderButton from 'components/header-button/docs/example';
+import JetpackLogoExample from 'components/jetpack-logo/docs/example';
 
 class DesignAssets extends React.Component {
 	static displayName = 'DesignAssets';
@@ -150,6 +151,7 @@ class DesignAssets extends React.Component {
 					<InfoPopover />
 					<Tooltip />
 					<InputChrono />
+					<JetpackLogoExample />
 					<LanguagePicker />
 					<ListEnd />
 					<Notices />

--- a/client/devdocs/design/index.jsx
+++ b/client/devdocs/design/index.jsx
@@ -81,6 +81,7 @@ import Wizard from 'components/wizard/docs/example';
 import Suggestions from 'components/suggestions/docs/example';
 import HeaderButton from 'components/header-button/docs/example';
 import JetpackLogoExample from 'components/jetpack-logo/docs/example';
+import JetpackColophonExample from 'components/jetpack-colophon/docs/example';
 
 class DesignAssets extends React.Component {
 	static displayName = 'DesignAssets';
@@ -151,6 +152,7 @@ class DesignAssets extends React.Component {
 					<InfoPopover />
 					<Tooltip />
 					<InputChrono />
+					<JetpackColophonExample />
 					<JetpackLogoExample />
 					<LanguagePicker />
 					<ListEnd />

--- a/client/devdocs/design/index.jsx
+++ b/client/devdocs/design/index.jsx
@@ -2,11 +2,11 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
 import React from 'react';
-import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
+import PropTypes from 'prop-types';
 import page from 'page';
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
 import { slugToCamelCase } from 'devdocs/docs-example/util';
 import { trim } from 'lodash';
 
@@ -22,67 +22,67 @@ import SearchCard from 'components/search-card';
 /**
  * Docs examples
  */
-import SearchDemo from 'components/search/docs/example';
-import Notices from 'components/notice/docs/example';
+import Accordions from 'components/accordion/docs/example';
+import Banner from 'components/banner/docs/example';
+import BulkSelect from 'components/bulk-select/docs/example';
+import ButtonGroups from 'components/button-group/docs/example';
+import Buttons from 'components/button/docs/example';
+import Cards from 'components/card/docs/example';
+import ClipboardButtonInput from 'components/clipboard-button-input/docs/example';
+import ClipboardButtons from 'components/forms/clipboard-button/docs/example';
+import Collection from 'devdocs/design/search-collection';
+import Count from 'components/count/docs/example';
+import CountedTextareas from 'components/forms/counted-textarea/docs/example';
+import DatePicker from 'components/date-picker/docs/example';
+import DropZones from 'components/drop-zone/docs/example';
+import EllipsisMenu from 'components/ellipsis-menu/docs/example';
+import EmojifyExample from 'components/emojify/docs/example';
+import EmptyContent from 'components/empty-content/docs/example';
+import ExternalLink from 'components/external-link/docs/example';
+import FAQ from 'components/faq/docs/example';
+import FeatureGate from 'components/feature-example/docs/example';
+import FilePickers from 'components/file-picker/docs/example';
+import FoldableCard from 'components/foldable-card/docs/example';
+import FormattedHeader from 'components/formatted-header/docs/example';
+import FormFields from 'components/forms/docs/example';
+import Gauge from 'components/gauge/docs/example';
 import GlobalNotices from 'components/global-notices/docs/example';
 import Gravatar from 'components/gravatar/docs/example';
-import Buttons from 'components/button/docs/example';
-import ButtonGroups from 'components/button-group/docs/example';
 import Gridicons from 'gridicons/build/example';
-import Accordions from 'components/accordion/docs/example';
-import SocialLogos from 'social-logos/example';
-import SelectDropdown from 'components/select-dropdown/docs/example';
-import SegmentedControl from 'components/segmented-control/docs/example';
-import Cards from 'components/card/docs/example';
-import TokenFields from 'components/token-field/docs/example';
-import CountedTextareas from 'components/forms/counted-textarea/docs/example';
-import ProgressBar from 'components/progress-bar/docs/example';
-import Popovers from 'components/popover/docs/example';
-import EllipsisMenu from 'components/ellipsis-menu/docs/example';
-import Ranges from 'components/forms/range/docs/example';
-import Gauge from 'components/gauge/docs/example';
+import HeaderButton from 'components/header-button/docs/example';
 import Headers from 'components/header-cake/docs/example';
-import DropZones from 'components/drop-zone/docs/example';
-import FormFields from 'components/forms/docs/example';
+import ImagePreloader from 'components/image-preloader/docs/example';
+import InfoPopover from 'components/info-popover/docs/example';
+import InputChrono from 'components/input-chrono/docs/example';
+import JetpackColophonExample from 'components/jetpack-colophon/docs/example';
+import JetpackLogoExample from 'components/jetpack-logo/docs/example';
+import LanguagePicker from 'components/language-picker/docs/example';
+import ListEnd from 'components/list-end/docs/example';
+import Notices from 'components/notice/docs/example';
+import PaginationExample from 'components/pagination/docs/example';
+import PaymentLogo from 'components/payment-logo/docs/example';
+import Popovers from 'components/popover/docs/example';
+import ProgressBar from 'components/progress-bar/docs/example';
+import Ranges from 'components/forms/range/docs/example';
+import Rating from 'components/rating/docs/example';
+import Ribbon from 'components/ribbon/docs/example';
+import ScreenReaderTextExample from 'components/screen-reader-text/docs/example';
+import SearchDemo from 'components/search/docs/example';
+import SectionHeader from 'components/section-header/docs/example';
 import SectionNav from 'components/section-nav/docs/example';
+import SegmentedControl from 'components/segmented-control/docs/example';
+import SelectDropdown from 'components/select-dropdown/docs/example';
+import SocialLogos from 'social-logos/example';
 import Spinner from 'components/spinner/docs/example';
 import SpinnerButton from 'components/spinner-button/docs/example';
 import SpinnerLine from 'components/spinner-line/docs/example';
-import Rating from 'components/rating/docs/example';
-import DatePicker from 'components/date-picker/docs/example';
-import InputChrono from 'components/input-chrono/docs/example';
-import ImagePreloader from 'components/image-preloader/docs/example';
-import Ribbon from 'components/ribbon/docs/example';
-import Timezone from 'components/timezone/docs/example';
-import ClipboardButtons from 'components/forms/clipboard-button/docs/example';
-import ClipboardButtonInput from 'components/clipboard-button-input/docs/example';
-import InfoPopover from 'components/info-popover/docs/example';
-import Tooltip from 'components/tooltip/docs/example';
-import FoldableCard from 'components/foldable-card/docs/example';
-import SectionHeader from 'components/section-header/docs/example';
-import PaymentLogo from 'components/payment-logo/docs/example';
-import Count from 'components/count/docs/example';
-import Version from 'components/version/docs/example';
-import BulkSelect from 'components/bulk-select/docs/example';
-import ExternalLink from 'components/external-link/docs/example';
-import FeatureGate from 'components/feature-example/docs/example';
-import FilePickers from 'components/file-picker/docs/example';
-import Collection from 'devdocs/design/search-collection';
-import FAQ from 'components/faq/docs/example';
-import VerticalMenu from 'components/vertical-menu/docs/example';
-import Banner from 'components/banner/docs/example';
-import EmojifyExample from 'components/emojify/docs/example';
-import LanguagePicker from 'components/language-picker/docs/example';
-import FormattedHeader from 'components/formatted-header/docs/example';
-import EmptyContent from 'components/empty-content/docs/example';
-import ScreenReaderTextExample from 'components/screen-reader-text/docs/example';
-import PaginationExample from 'components/pagination/docs/example';
-import ListEnd from 'components/list-end/docs/example';
-import Wizard from 'components/wizard/docs/example';
 import Suggestions from 'components/suggestions/docs/example';
-import HeaderButton from 'components/header-button/docs/example';
-import JetpackLogoExample from 'components/jetpack-logo/docs/example';
-import JetpackColophonExample from 'components/jetpack-colophon/docs/example';
+import Timezone from 'components/timezone/docs/example';
+import TokenFields from 'components/token-field/docs/example';
+import Tooltip from 'components/tooltip/docs/example';
+import Version from 'components/version/docs/example';
+import VerticalMenu from 'components/vertical-menu/docs/example';
+import Wizard from 'components/wizard/docs/example';
 
 class DesignAssets extends React.Component {
 	static displayName = 'DesignAssets';
@@ -109,16 +109,18 @@ class DesignAssets extends React.Component {
 
 		return (
 			<Main className="design">
-				{ component
-					? <HeaderCake onClick={ this.backToComponents } backText="All Components">
-							{ slugToCamelCase( component ) }
-						</HeaderCake>
-					: <SearchCard
-							onSearch={ this.onSearch }
-							initialValue={ filter }
-							placeholder="Search components…"
-							analyticsGroup="Docs"
-						/> }
+				{ component ? (
+					<HeaderCake onClick={ this.backToComponents } backText="All Components">
+						{ slugToCamelCase( component ) }
+					</HeaderCake>
+				) : (
+					<SearchCard
+						onSearch={ this.onSearch }
+						initialValue={ filter }
+						placeholder="Search components…"
+						analyticsGroup="Docs"
+					/>
+				) }
 
 				<Collection component={ component } filter={ filter }>
 					<Accordions componentUsageStats={ componentsUsageStats.accordion } />
@@ -147,11 +149,10 @@ class DesignAssets extends React.Component {
 					<GlobalNotices />
 					<Gravatar />
 					<Gridicons />
-					<Headers />
 					<HeaderButton />
+					<Headers />
 					<ImagePreloader />
 					<InfoPopover />
-					<Tooltip />
 					<InputChrono />
 					<JetpackColophonExample />
 					<JetpackLogoExample />
@@ -178,8 +179,9 @@ class DesignAssets extends React.Component {
 					<Suggestions />
 					<Timezone />
 					<TokenFields />
-					<VerticalMenu />
+					<Tooltip />
 					<Version />
+					<VerticalMenu />
 					<Wizard />
 				</Collection>
 			</Main>


### PR DESCRIPTION
These components were missing from devdocs. This PR adds them.

It also takes the opportunity to correctly alphabetize the components devdocs and add the prettier flag.

## Testing
1. Visit https://calypso.live/devdocs/design/?branch=add/devdocs-jetpack-colophon
1. Check the `JetpackColophon` and `JetpackLogo` components.

## Screens

![devdocs](https://user-images.githubusercontent.com/841763/30159957-b0550ba2-93ca-11e7-950d-254b744db8d9.png)

Follow-up to #17513 
