### PR TITLE
Login: Enable native login links in all environments

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -34,6 +34,7 @@
 		"jetpack/api-cache": true,
 		"jetpack_core_inline_update": true,
 		"keyboard-shortcuts": true,
+		"login/native-login-links": true,
 		"login/wp-login": true,
 		"manage/custom-post-types": true,
 		"manage/customize": true,

--- a/config/production.json
+++ b/config/production.json
@@ -30,6 +30,7 @@
 		"help/courses": true,
 		"jetpack/activity-log": true,
 		"jetpack/api-cache": false,
+		"login/native-login-links": true,
 		"login/wp-login": true,
 		"manage/custom-post-types": true,
 		"manage/customize": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -34,6 +34,7 @@
 		"jetpack/activity-log/rewind": true,
 		"jetpack/api-cache": true,
 		"jetpack_core_inline_update": true,
+		"login/native-login-links": true,
 		"login/wp-login": true,
 		"manage/custom-post-types": true,
 		"manage/customize": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -40,6 +40,7 @@
 		"jetpack/api-cache": true,
 		"jetpack_core_inline_update": true,
 		"login/magic-login": true,
+		"login/native-login-links": true,
 		"login/wp-login": true,
 		"keyboard-shortcuts": true,
 		"manage/customize": true,


### PR DESCRIPTION
This pull request enables native login links in all environments, meaning all links will point to the new [`Login` page](https://wordpress.com/log-in) instead of the [legacy one](https://wordpress.com/wp-login.php).
  
#### Testing instructions
  
1. Run `git checkout update/enable-native-login-links`
2. Set `calypsoEnv` to `development` [here](https://github.com/Automattic/wp-calypso/blob/d1613fab3933f45eb4a7f6d8b537ef9e316b9a9f/client/state/jetpack-connect/actions.js#L55)
3. Start your server with `NODE_ENV=production npm start`, and wait :)
4. Open the [`Me` page](http://calypso.localhost:3000/me) in an incognito window
5. Assert that you are presented with the new `Login` page
6. Open the [`Themes` page](http://calypso.localhost:3000/themes) 
7. Assert that the `Log In` link in the top right corner now points to the new `Login` page
8. Open the default [`Signup` page](http://calypso.localhost:3000/start) 
9. Proceed to the `User` step, further away in the signup flow
10. Enter the username of an existing WordPress.com account and submit the form
11. Check that a `Choose a different email address. [...]` error is displayed
12. Assert that the `log in` link in this error message points to the new `Login` page
13. Open the [`Account Signup` page](http://calypso.localhost:3000/start/account)
14. Assert that the `Already have a WordPress.com account? [...]` link points to the new `Login` page
15. Create a new Jetpack site with this [generator](http://poopy.life/create?src=inquisitive-macaw&key=g57uqr8kfjjn0Pwi)
16. Open a [`Jetpack Connect` page](http://calypso.localhost:3000/jetpack/connect/premium/yearly)
17. Submit the url of your new Jetpack site
18. Assert that the `Already have an account? Sign in` link points to the new `Login` page

You should now follow those instructions again, but log in from the new `Login` page (with a 2FA enabled account) to test each flow and make sure that you are then redirected back to the page you just left.

#### Reviews
  
- [ ] Code
- [ ] Product