### PR TITLE
Plugin upload: Fix post-upload screen

### DIFF
--- a/client/lib/plugins/notices.jsx
+++ b/client/lib/plugins/notices.jsx
@@ -269,6 +269,10 @@ module.exports = {
 						} );
 				}
 				break;
+			case 'PLUGIN_UPLOAD':
+				return i18n.translate( 'You\'ve successfully uploaded the %(plugin)s plugin.', {
+					args: translateArg
+				} );
 		}
 	},
 

--- a/client/state/data-layer/wpcom/sites/plugins/new/index.js
+++ b/client/state/data-layer/wpcom/sites/plugins/new/index.js
@@ -17,6 +17,7 @@ import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { errorNotice } from 'state/notices/actions';
 import { recordTracksEvent } from 'state/analytics/actions';
+import { getSite } from 'state/sites/selectors';
 import Dispatcher from 'dispatcher';
 
 export const uploadPlugin = ( { dispatch }, action ) => {
@@ -55,8 +56,10 @@ const showErrorNotice = ( dispatch, error ) => {
 	dispatch( errorNotice( translate( 'Problem installing the plugin.' ) ) );
 };
 
-export const uploadComplete = ( { dispatch }, { siteId }, data ) => {
+export const uploadComplete = ( { dispatch, getState }, { siteId }, data ) => {
 	const { slug: pluginId } = data;
+	const state = getState();
+	const site = getSite( state, siteId );
 
 	dispatch( recordTracksEvent( 'calypso_plugin_upload_complete', {
 		plugin_id: pluginId
@@ -71,7 +74,7 @@ export const uploadComplete = ( { dispatch }, { siteId }, data ) => {
 	Dispatcher.handleServerAction( {
 		type: 'RECEIVE_INSTALLED_PLUGIN',
 		action: 'PLUGIN_UPLOAD',
-		site: { ID: siteId },
+		site,
 		plugin: data,
 		data,
 	} );

--- a/client/state/data-layer/wpcom/sites/plugins/new/index.js
+++ b/client/state/data-layer/wpcom/sites/plugins/new/index.js
@@ -69,8 +69,8 @@ export const uploadComplete = ( { dispatch, getState }, { siteId }, data ) => {
 
 	/*
 	 * Adding plugin to legacy flux store provides data for plugin page
-     * and displays a success message.
-     */
+	 * and displays a success message.
+	 */
 	Dispatcher.handleServerAction( {
 		type: 'RECEIVE_INSTALLED_PLUGIN',
 		action: 'PLUGIN_UPLOAD',

--- a/client/state/data-layer/wpcom/sites/plugins/new/index.js
+++ b/client/state/data-layer/wpcom/sites/plugins/new/index.js
@@ -7,7 +7,7 @@ import { find, includes, toLower } from 'lodash';
 /**
  * Internal dependencies
  */
-import { PLUGIN_UPLOAD, PLUGIN_INSTALL_REQUEST_SUCCESS } from 'state/action-types';
+import { PLUGIN_UPLOAD } from 'state/action-types';
 import {
 	completePluginUpload,
 	pluginUploadError,
@@ -15,8 +15,9 @@ import {
 } from 'state/plugins/upload/actions';
 import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { successNotice, errorNotice } from 'state/notices/actions';
+import { errorNotice } from 'state/notices/actions';
 import { recordTracksEvent } from 'state/analytics/actions';
+import Dispatcher from 'dispatcher';
 
 export const uploadPlugin = ( { dispatch }, action ) => {
 	const { siteId, file } = action;
@@ -29,15 +30,6 @@ export const uploadPlugin = ( { dispatch }, action ) => {
 		apiVersion: '1',
 		formData: [ [ 'zip[]', file ] ],
 	}, action ) );
-};
-
-const showSuccessNotice = ( dispatch, { name } ) => {
-	dispatch( successNotice(
-		translate( "You've successfully uploaded the %(name)s plugin.", {
-			args: { name }
-		} ),
-		{ duration: 5000 }
-	) );
 };
 
 const showErrorNotice = ( dispatch, error ) => {
@@ -71,14 +63,18 @@ export const uploadComplete = ( { dispatch }, { siteId }, data ) => {
 	} ) );
 
 	dispatch( completePluginUpload( siteId, pluginId ) );
-	dispatch( {
-		type: PLUGIN_INSTALL_REQUEST_SUCCESS,
-		siteId,
-		pluginId,
-		data
-	} );
 
-	showSuccessNotice( dispatch, data );
+	/*
+	 * Adding plugin to legacy flux store provides data for plugin page
+     * and displays a success message.
+     */
+	Dispatcher.handleServerAction( {
+		type: 'RECEIVE_INSTALLED_PLUGIN',
+		action: 'PLUGIN_UPLOAD',
+		site: { ID: siteId },
+		plugin: data,
+		data,
+	} );
 };
 
 export const receiveError = ( { dispatch }, { siteId }, error ) => {

--- a/client/state/data-layer/wpcom/sites/plugins/new/test/index.js
+++ b/client/state/data-layer/wpcom/sites/plugins/new/test/index.js
@@ -19,7 +19,7 @@ import {
 	pluginUploadError,
 	updatePluginUploadProgress,
 } from 'state/plugins/upload/actions';
-import { PLUGIN_INSTALL_REQUEST_SUCCESS } from 'state/action-types';
+import Dispatcher from 'dispatcher';
 
 const siteId = 77203074;
 const pluginId = 'hello-dolly';
@@ -56,6 +56,17 @@ describe( 'uploadPlugin', () => {
 } );
 
 describe( 'uploadComplete', () => {
+	let sandbox;
+
+	beforeEach( () => {
+		sandbox = sinon.sandbox.create();
+		sandbox.stub( Dispatcher, 'handleServerAction' );
+	} );
+
+	afterEach( () => {
+		sandbox.restore();
+	} );
+
 	it( 'should dispatch plugin upload complete action', () => {
 		const dispatch = sinon.spy();
 		uploadComplete( { dispatch }, { siteId }, SUCCESS_RESPONSE );
@@ -64,13 +75,16 @@ describe( 'uploadComplete', () => {
 		);
 	} );
 
-	it( 'should dispatch plugin install request success', () => {
+	it( 'should dispatch a receive installed plugin action', () => {
 		const dispatch = sinon.spy();
+
 		uploadComplete( { dispatch }, { siteId }, SUCCESS_RESPONSE );
-		expect( dispatch ).to.have.been.calledWith( {
-			type: PLUGIN_INSTALL_REQUEST_SUCCESS,
-			siteId,
-			pluginId,
+
+		expect( Dispatcher.handleServerAction ).to.have.been.calledWith( {
+			type: 'RECEIVE_INSTALLED_PLUGIN',
+			action: 'PLUGIN_UPLOAD',
+			site: { ID: siteId },
+			plugin: SUCCESS_RESPONSE,
 			data: SUCCESS_RESPONSE,
 		} );
 	} );

--- a/client/state/data-layer/wpcom/sites/plugins/new/test/index.js
+++ b/client/state/data-layer/wpcom/sites/plugins/new/test/index.js
@@ -57,6 +57,17 @@ describe( 'uploadPlugin', () => {
 
 describe( 'uploadComplete', () => {
 	let sandbox;
+	const site = {
+		ID: siteId,
+		URL: 'https://wordpress.com',
+	};
+	const getState = () => ( {
+		sites: {
+			items: {
+				[ siteId ]: site,
+			}
+		}
+	} );
 
 	beforeEach( () => {
 		sandbox = sinon.sandbox.create();
@@ -69,7 +80,7 @@ describe( 'uploadComplete', () => {
 
 	it( 'should dispatch plugin upload complete action', () => {
 		const dispatch = sinon.spy();
-		uploadComplete( { dispatch }, { siteId }, SUCCESS_RESPONSE );
+		uploadComplete( { dispatch, getState }, { siteId }, SUCCESS_RESPONSE );
 		expect( dispatch ).to.have.been.calledWith(
 			completePluginUpload( siteId, pluginId )
 		);
@@ -78,12 +89,12 @@ describe( 'uploadComplete', () => {
 	it( 'should dispatch a receive installed plugin action', () => {
 		const dispatch = sinon.spy();
 
-		uploadComplete( { dispatch }, { siteId }, SUCCESS_RESPONSE );
+		uploadComplete( { dispatch, getState }, { siteId }, SUCCESS_RESPONSE );
 
-		expect( Dispatcher.handleServerAction ).to.have.been.calledWith( {
+		expect( Dispatcher.handleServerAction ).to.have.been.calledWithMatch( {
 			type: 'RECEIVE_INSTALLED_PLUGIN',
 			action: 'PLUGIN_UPLOAD',
-			site: { ID: siteId },
+			site,
 			plugin: SUCCESS_RESPONSE,
 			data: SUCCESS_RESPONSE,
 		} );


### PR DESCRIPTION
The plugin details screen shown after uploading a plugin to a Jetpack site uses plugin data from a flux store. This PR fires the appropriate flux action on successful plugin upload, ensuring the plugin details page has data available.

The flux action also causes a success notice to be shown, so this change adds the appropriate notice.

**Before**
<img width="972" alt="screen shot 2017-09-07 at 12 56 35" src="https://user-images.githubusercontent.com/7767559/30162263-0c832dfe-93cc-11e7-9bf2-3505a63cd1a5.png">

**After**
<img width="979" alt="screen shot 2017-09-07 at 12 52 35" src="https://user-images.githubusercontent.com/7767559/30162145-7a93b68e-93cb-11e7-96b7-bbe3fa43887b.png">

**To Test**
1) Check out this branch or use the calypso.live link
2) Go to plugins/manage/{jetpackSite} to ensure the flux plugin store is initially populated
3) Click the _Upload Plugin_ button
4) Upload a custom plugin that is not in the .org repo (see attachment)
5) Check that the plugin details screen is shown as in the screenshot above

[mellow-brolly.zip](https://github.com/Automattic/wp-calypso/files/1284554/mellow-brolly.zip)
