### PR TITLE
Plugin uploads: Remove 'disabled' drop-zone state

### DIFF
--- a/client/my-sites/plugins/plugin-upload/index.jsx
+++ b/client/my-sites/plugins/plugin-upload/index.jsx
@@ -74,15 +74,13 @@ class PluginUpload extends React.Component {
 	}
 
 	renderUploadCard() {
-		const { inProgress, complete, isEligible, isJetpack } = this.props;
+		const { inProgress, complete, isJetpack } = this.props;
 
 		const uploadAction = isJetpack ? this.props.uploadPlugin : this.props.initiateAutomatedTransferWithPluginZip;
 
 		return (
 			<Card>
-				{ ! inProgress && ! complete && <UploadDropZone
-					doUpload={ uploadAction }
-					disabled={ ! isEligible } /> }
+				{ ! inProgress && ! complete && <UploadDropZone doUpload={ uploadAction } /> }
 				{ inProgress && this.renderProgressBar() }
 			</Card>
 		);
@@ -181,7 +179,6 @@ export default connect(
 			isJetpackMultisite,
 			siteAdminUrl: getSiteAdminUrl( state, siteId ),
 			showEligibility: ! isJetpack && ( hasEligibilityMessages || ! isEligible ),
-			isEligible,
 		};
 	},
 	{ uploadPlugin, clearPluginUpload, initiateAutomatedTransferWithPluginZip }


### PR DESCRIPTION
There is no state where the plugin upload dropzone should be disabled:
* non-multisite Jetpack: enabled dropzone
* multisite Jetpack: 'visit wp-admin' message
* eligible .com site: enabled dropzone
* ineligible .com site: eligibility component

We can remove the `disabled` prop passed to the dropzone component.

**To Test**
* Check out this branch or use the calypso.live link
* Check that /plugins/upload/{site} is in the correct site according to the rules above
