### PR TITLE
Components: Fix HeaderButton DevDocs example component name

### DIFF
--- a/client/components/header-button/docs/example.jsx
+++ b/client/components/header-button/docs/example.jsx
@@ -8,7 +8,7 @@ import React from 'react';
  */
 import HeaderButton from 'components/header-button';
 
-export default function HeaderButtonExample() {
+const HeaderButtonExample = () => {
 	const onClick = () => alert( 'clicked me!' );
 	return (
 		<div>
@@ -18,6 +18,9 @@ export default function HeaderButtonExample() {
 				onClick={ onClick }
 			/>
 		</div>
-		);
-}
+	);
+};
 
+HeaderButtonExample.displayName = 'HeaderButton';
+
+export default HeaderButtonExample;


### PR DESCRIPTION
In #17702 we added a `HeaderButton` component with a DevDocs example, but we forgot to add a `displayName` there. The specific `displayName` is necessary, because we mangle component names for production builds. You can check the issue here:

https://wpcalypso.wordpress.com/devdocs/design/s

Before:
![](https://cldup.com/VNu75HKONq.png)

After:
![](https://cldup.com/_iP9TMyVha.png)

If you test locally on dev environment, there should be no difference, but to verify the issue has been resolved, run this branch on wpcalypso.