### PR TITLE
Allow resend verification email

### DIFF
--- a/client/blocks/login/error-notice.jsx
+++ b/client/blocks/login/error-notice.jsx
@@ -14,6 +14,7 @@ import {
 	getRequestSocialAccountError,
 } from 'state/login/selectors';
 import Notice from 'components/notice';
+import HelpUnverifiedWarning from 'me/help/help-unverified-warning';
 
 class ErrorNotice extends Component {
 	static propTypes = {
@@ -69,11 +70,20 @@ class ErrorNotice extends Component {
 			return null;
 		}
 
-		return (
-			<Notice status={ 'is-error' } showDismiss={ false }>
-				{ error.message }
-			</Notice>
-		);
+		let errorElement = <Notice status={ 'is-error' } showDismiss={ false }>
+			{ error.message }
+		</Notice>;
+
+		if ( error.code === 'account_unactivated' ) {
+			const { user_id: userId, nonce } = error.data;
+
+			errorElement = <div>
+				{ errorElement }
+				<HelpUnverifiedWarning userId={ userId } nonce={ nonce } />
+			</div>;
+		}
+
+		return errorElement;
 	}
 }
 

--- a/client/lib/user/user.js
+++ b/client/lib/user/user.js
@@ -240,8 +240,12 @@ User.prototype.clear = function( onClear ) {
  * Sends the user an email with a link to verify their account if they
  * are unverified.
  */
-User.prototype.sendVerificationEmail = function( fn ) {
-	return wpcom.undocumented().me().sendVerificationEmail( fn );
+User.prototype.sendVerificationEmail = function( userId, nonce, fn ) {
+	if ( typeof userId === 'function' ) {
+		return wpcom.undocumented().me().sendVerificationEmail( userId );
+	}
+
+	return wpcom.undocumented().me().sendVerificationEmail( userId, nonce, fn );
 };
 
 User.prototype.set = function( attributes ) {

--- a/client/lib/wpcom-undocumented/lib/me.js
+++ b/client/lib/wpcom-undocumented/lib/me.js
@@ -252,10 +252,14 @@ UndocumentedMe.prototype.devices = function( callback ) {
 	return this.wpcom.req.get( args, callback );
 };
 
-UndocumentedMe.prototype.sendVerificationEmail = function( callback ) {
+UndocumentedMe.prototype.sendVerificationEmail = function( userId, nonce, callback ) {
 	debug( '/me/send-verification-email' );
 
-	return this.wpcom.req.post( { path: '/me/send-verification-email' }, callback );
+	if ( typeof userId === 'function' ) {
+		return this.wpcom.req.post( { path: '/me/send-verification-email' }, userId );
+	}
+
+	return this.wpcom.req.post( { path: '/me/send-verification-email', body: { user_id: userId, nonce } }, callback );
 };
 
 UndocumentedMe.prototype.getNotificationSettings = function( callback ) {

--- a/client/me/help/help-unverified-warning/index.jsx
+++ b/client/me/help/help-unverified-warning/index.jsx
@@ -52,7 +52,7 @@ class HelpUnverifiedWarning extends Component {
 				resendState: RESEND_IN_PROGRESS,
 			} );
 
-			user.sendVerificationEmail()
+			user.sendVerificationEmail( this.props.userId, this.props.nonce )
 				.then( () => {
 					const nextResendState = RESEND_SUCCESS;
 

--- a/client/me/help/help-unverified-warning/index.jsx
+++ b/client/me/help/help-unverified-warning/index.jsx
@@ -59,11 +59,11 @@ class HelpUnverifiedWarning extends Component {
 					this.setState( { resendState: nextResendState } );
 					notices.success( resendStateToMessage( nextResendState ) );
 				} )
-				.catch( () => {
+				.catch( ( error ) => {
 					const nextResendState = RESEND_ERROR;
 
 					this.setState( { resendState: nextResendState } );
-					notices.error( resendStateToMessage( nextResendState ) );
+					notices.error( error.message );
 				} );
 		};
 

--- a/client/state/login/actions.js
+++ b/client/state/login/actions.js
@@ -98,7 +98,9 @@ function getErrorFromHTTPError( httpError ) {
 		message = get( httpError, 'response.body.data', httpError.message );
 	}
 
-	return { code, message, field };
+	const data = get( httpError, 'response.body.data.errors[0].data' );
+
+	return data ? { code, message, field, data } : { code, message, field };
 }
 
 /**


### PR DESCRIPTION
Allow a user with non verified email to request another verification email.
Test together with D7216

<p align="center">
<img src="https://user-images.githubusercontent.com/326402/30167488-400929a8-93ef-11e7-83e7-fad674e23361.png" />
</p>
  
#### Testing instructions
  
1. Run `git checkout add/resend-activation` and start your server, or open a [live branch](https://calypso.live/?branch=add/resend-activation)
2. Open the [`Login` page](http://calypso.localhost:3000/log-in)
3. When logging in with a user with non verified email, assert you are able to request additional verification email.
  
  
#### Reviews
  
- [ ] Code
- [ ] Product
