### PR TITLE
Use error code 401 for invalid query parameters in login

### DIFF
--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -40,7 +40,9 @@ export default {
 
 		if ( client_id ) {
 			if ( ! redirect_to ) {
-				return next( new Error( 'The `redirect_to` query parameter is missing.' ) );
+				const error = new Error( 'The `redirect_to` query parameter is missing.' );
+				error.status = 401;
+				return next( error );
 			}
 
 			const parsedRedirectUrl = parseUrl( redirect_to );
@@ -49,7 +51,9 @@ export default {
 			if ( client_id !== redirectQueryString.client_id ) {
 				recordTracksEvent( 'calypso_login_phishing_attempt', context.query );
 
-				return next( new Error( 'The `redirect_to` query parameter is invalid with the given `client_id`.' ) );
+				const error = new Error( 'The `redirect_to` query parameter is invalid with the given `client_id`.' );
+				error.status = 401;
+				return next( error );
 			}
 
 			context.store.dispatch( fetchOAuth2ClientData( Number( client_id ) ) )


### PR DESCRIPTION
This update the HTTP error returned when accessing the oauth2 login page with wrong parameters. For instance https://wordpress.com/log-in?client_id=1111

### Testing Instructions
- `curl -s -o /dev/null -w "%{http_code}" "https://calypso.live/log-in?client_id=1111&branch=update/login-error-code"`
- Assert that the code is 401

### Reviews
- [x] Code
- [x] Product