### PR TITLE
Comments: Add pingbacks and trackbacks to the comments tree

### DIFF
--- a/client/state/comments/trees/reducer.js
+++ b/client/state/comments/trees/reducer.js
@@ -21,6 +21,7 @@ const convertToTree = comments =>
 		commentParentId: get( comment, 'parent.ID', 0 ),
 		postId: get( comment, 'post.ID' ),
 		status: get( comment, 'status' ),
+		type: get( comment, 'type', 'comment' ),
 	} ) );
 
 const siteTree = ( state = [], action ) => {

--- a/client/state/data-layer/wpcom/sites/comments-tree/index.js
+++ b/client/state/data-layer/wpcom/sites/comments-tree/index.js
@@ -35,10 +35,10 @@ export const fetchCommentsTreeForSite = ( { dispatch }, action ) => {
 	);
 };
 
-const mapTree = ( tree, status, type ) => map( tree, comment => ( {
-	commentId: comment[ 0 ],
-	commentParentId: comment[ 2 ],
-	postId: comment[ 1 ],
+const mapTree = ( tree, status, type ) => map( tree, ( [ commentId, postId, commentParentId ] ) => ( {
+	commentId,
+	commentParentId,
+	postId,
 	status,
 	type,
 } ) );

--- a/client/state/data-layer/wpcom/sites/comments-tree/index.js
+++ b/client/state/data-layer/wpcom/sites/comments-tree/index.js
@@ -35,16 +35,22 @@ export const fetchCommentsTreeForSite = ( { dispatch }, action ) => {
 	);
 };
 
+const mapTree = ( tree, status, type ) => map( tree, comment => ( {
+	commentId: comment[ 0 ],
+	commentParentId: comment[ 2 ],
+	postId: comment[ 1 ],
+	status,
+	type,
+} ) );
+
 export const addCommentsTree = ( { dispatch }, { query }, data ) => {
 	const { siteId, status } = query;
-	const { comments_tree: commentsTree } = data;
 
-	const tree = map( commentsTree, comment => ( {
-		commentId: comment[ 0 ],
-		postId: comment[ 1 ],
-		commentParentId: comment[ 2 ],
-		status,
-	} ) );
+	const tree = [
+		...mapTree( data.comments_tree, status, 'comment' ),
+		...mapTree( data.pingbacks_tree, status, 'pingback' ),
+		...mapTree( data.trackbacks_tree, status, 'trackback' ),
+	];
 
 	dispatch( {
 		type: COMMENTS_TREE_SITE_ADD,

--- a/client/state/data-layer/wpcom/sites/comments-tree/test/index.js
+++ b/client/state/data-layer/wpcom/sites/comments-tree/test/index.js
@@ -38,18 +38,39 @@ describe( 'comments-tree', () => {
 	describe( 'addCommentsTree', () => {
 		it( 'should dispatch comment tree updates', () => {
 			const dispatch = spy();
-			addCommentsTree( { dispatch }, action, { comments_tree: [ [ 2, 1, 0 ] ] } );
+			addCommentsTree( { dispatch }, action, {
+				comments_tree: [ [ 2, 1, 0 ] ],
+				pingbacks_tree: [ [ 3, 1, 0 ] ],
+				trackbacks_tree: [ [ 4, 1, 0 ] ],
+			} );
 			expect( dispatch ).to.have.been.calledOnce;
 			expect( dispatch ).to.have.been.calledWith( {
 				type: COMMENTS_TREE_SITE_ADD,
 				siteId: 77203074,
 				status: 'approved',
-				tree: [ {
-					commentId: 2,
-					postId: 1,
-					commentParentId: 0,
-					status: 'approved',
-				} ],
+				tree: [
+					{
+						commentId: 2,
+						postId: 1,
+						commentParentId: 0,
+						status: 'approved',
+						type: 'comment',
+					},
+					{
+						commentId: 3,
+						postId: 1,
+						commentParentId: 0,
+						status: 'approved',
+						type: 'pingback',
+					},
+					{
+						commentId: 4,
+						postId: 1,
+						commentParentId: 0,
+						status: 'approved',
+						type: 'trackback',
+					},
+				],
 			} );
 		} );
 	} );


### PR DESCRIPTION
Add pingbacks and trackbacks to the `comments-tree` state.

New tree items will have the following properties:
```
{
  commentId,
  commentParentId,
  postId,
  status,
  type: "comment" | "pingback" | "trackback",
}
```