### PR TITLE
Extensions: WPJM - Add UI for the confirmation step of the wizard

### DIFF
--- a/client/extensions/wp-job-manager/components/setup/confirmation/index.jsx
+++ b/client/extensions/wp-job-manager/components/setup/confirmation/index.jsx
@@ -1,0 +1,157 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import PropTypes from 'prop-types';
+import Gridicon from 'gridicons';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Card from 'components/card';
+import ExternalLink from 'components/external-link';
+import SectionHeader from 'components/section-header';
+import { getSelectedSiteSlug } from 'state/ui/selectors';
+
+const Confirmation = ( { slug, translate } ) => {
+	return (
+		<div>
+			<SectionHeader label={ translate( 'All Done!' ) } />
+			<Card>
+				<p>
+					{ translate( 'Looks like you\'re all set to start using the plugin. In case you\'re wondering where to go next:' ) }
+				</p>
+
+				{ translate(
+					'{{ul}}' +
+						'{{li}} {{settings}}Tweak the plugin settings{{/settings}} {{/li}}' +
+						'{{li}} {{addJob}}Add a job via the back-end{{/addJob}} {{/li}}' +
+						'{{li}} {{submission}}Find out more about the front-end job submission form{{/submission}} {{/li}}' +
+						'{{li}} {{jobs}}Add the [jobs] shortcode to a page to list jobs{{/jobs}} {{/li}}' +
+						'{{li}} {{dashboard}}Find out more about the front-end job dashboard{{/dashboard}} {{/li}}' +
+					'{{/ul}}',
+					{
+						components: {
+							ul: <ul />,
+							li: <li />,
+							settings: <a href={ `/extensions/wp-job-manager/${ slug }` } />,
+							addJob: <a href="#" />,
+							submission: (
+								<ExternalLink
+									icon={ true }
+									target="_blank"
+									href="https://wpjobmanager.com/document/the-job-submission-form/"
+								/>
+							),
+							jobs: (
+								<ExternalLink
+									icon={ true }
+									target="_blank"
+									href="https://wpjobmanager.com/document/shortcode-reference/#section-1"
+								/>
+							),
+							dashboard: (
+								<ExternalLink
+									icon={ true }
+									target="_blank"
+									href="https://wpjobmanager.com/document/the-job-dashboard/"
+								/>
+							),
+						}
+					}
+				) }
+
+				<p>
+					{ translate( 'And don\'t forget, if you need any more help using WP Job Manager you can ' +
+						'consult the {{docs}}documentation{{/docs}} or {{forums}}post on the forums!{{/forums}}',
+						{
+							components: {
+								docs: (
+									<ExternalLink
+										icon={ true }
+										target="_blank"
+										href="https://wpjobmanager.com/documentation/"
+									/>
+								),
+								forums: (
+									<ExternalLink
+										icon={ true }
+										target="_blank"
+										href="https://wordpress.org/support/plugin/wp-job-manager"
+									/>
+								),
+							}
+						}
+					) }
+				</p>
+			</Card>
+
+			<SectionHeader label={ translate( 'Support the Ongoing Development of this Plugin' ) } />
+			<Card>
+				<p>
+					{ translate( 'There are many ways to support open-source projects such as WP Job Manager, ' +
+						'for example code contribution, translation, or even telling your friends how awesome ' +
+						'the plugin (hopefully) is. Thanks in advance for your support - it is much appreciated!' ) }
+				</p>
+
+				{ translate(
+					'{{ul}}' +
+						'{{li}} {{star}}{{/star}} {{review}}Leave a positive review{{/review}} {{/li}}' +
+						'{{li}} {{globe}}{{/globe}} {{localize}}Contribute a localization{{/localize}} {{/li}}' +
+						'{{li}} {{cog}}{{/cog}} {{contribute}}Contribute code or report a bug{{/contribute}} {{/li}}' +
+						'{{li}} {{help}}{{/help}} {{forums}}Help other users on the forums{{/forums}} {{/li}}' +
+					'{{/ul}}',
+					{
+						components: {
+							ul: <ul className="confirmation__support" />,
+							li: <li />,
+							star: <Gridicon icon="star" size="18" />,
+							globe: <Gridicon icon="globe" size="18" />,
+							cog: <Gridicon icon="cog" size="18" />,
+							help: <Gridicon icon="help" size="18" />,
+							review: (
+								<ExternalLink
+									icon={ true }
+									target="_blank"
+									href="https://wordpress.org/support/view/plugin-reviews/wp-job-manager#postform"
+								/>
+							),
+							localize: (
+								<ExternalLink
+									icon={ true }
+									target="_blank"
+									href="https://translate.wordpress.org/projects/wp-plugins/wp-job-manager"
+								/>
+							),
+							contribute: (
+								<ExternalLink
+									icon={ true }
+									target="_blank"
+									href="https://github.com/mikejolley/WP-Job-Manager"
+								/>
+							),
+							forums: (
+								<ExternalLink
+									icon={ true }
+									target="_blank"
+									href="https://wordpress.org/support/plugin/wp-job-manager"
+								/>
+							),
+						}
+					}
+				) }
+			</Card>
+		</div>
+	);
+};
+
+Confirmation.propTypes = {
+	slug: PropTypes.string,
+	translate: PropTypes.func,
+};
+
+const mapStateToProps = state => ( { slug: getSelectedSiteSlug( state ) || '' } );
+
+export default connect( mapStateToProps )( localize( Confirmation ) );

--- a/client/extensions/wp-job-manager/components/setup/confirmation/index.jsx
+++ b/client/extensions/wp-job-manager/components/setup/confirmation/index.jsx
@@ -15,121 +15,63 @@ import ExternalLink from 'components/external-link';
 import SectionHeader from 'components/section-header';
 import { getSelectedSiteSlug } from 'state/ui/selectors';
 
-const Confirmation = ( { slug, translate } ) => {
-	return (
-		<div>
-			<SectionHeader label={ translate( 'You\'re ready to start using WP Job Manager!' ) } />
-			<Card>
-				<p>
-					{ translate( 'Wondering what to do now? Here are some of the most common next steps:' ) }
-				</p>
+const Confirmation = ( { slug, translate } ) => (
+	<div>
+		<SectionHeader label={ translate( 'You\'re ready to start using WP Job Manager!' ) } />
+		<Card>
+			<p>
+				{ translate( 'Wondering what to do now? Here are some of the most common next steps:' ) }
+			</p>
 
-				{ translate(
-					'{{ul}}' +
-						'{{li}} {{settings}}Tweak your settings{{/settings}} {{/li}}' +
-						'{{li}} {{addJob}}Add a job using the admin dashboard{{/addJob}} {{/li}}' +
-						'{{li}} {{jobs}}Add job listings to a page using the [jobs] shortcode{{/jobs}} {{/li}}' +
-						'{{li}} {{submission}}Learn to use the front-end job submission board{{/submission}} {{/li}}' +
-						'{{li}} {{dashboard}}Learn to use the front-end job dashboard{{/dashboard}} {{/li}}' +
-					'{{/ul}}',
-					{
-						components: {
-							ul: <ul />,
-							li: <li />,
-							settings: <a href={ `/extensions/wp-job-manager/${ slug }` } />,
-							addJob: <a href="#" />,
-							jobs: (
-								<ExternalLink
-									icon={ true }
-									target="_blank"
-									href="https://wpjobmanager.com/document/shortcode-reference/#section-1"
-								/>
-							),
-							submission: (
-								<ExternalLink
-									icon={ true }
-									target="_blank"
-									href="https://wpjobmanager.com/document/the-job-submission-form/"
-								/>
-							),
-							dashboard: (
-								<ExternalLink
-									icon={ true }
-									target="_blank"
-									href="https://wpjobmanager.com/document/the-job-dashboard/"
-								/>
-							),
-						}
+			{ translate(
+				'{{ul}}' +
+					'{{li}} {{settings}}Tweak your settings{{/settings}} {{/li}}' +
+					'{{li}} {{addJob}}Add a job using the admin dashboard{{/addJob}} {{/li}}' +
+					'{{li}} {{jobs}}Add job listings to a page using the [jobs] shortcode{{/jobs}} {{/li}}' +
+					'{{li}} {{submission}}Learn to use the front-end job submission board{{/submission}} {{/li}}' +
+					'{{li}} {{dashboard}}Learn to use the front-end job dashboard{{/dashboard}} {{/li}}' +
+				'{{/ul}}',
+				{
+					components: {
+						ul: <ul />,
+						li: <li />,
+						settings: <a href={ `/extensions/wp-job-manager/${ slug }` } />,
+						addJob: <a href="#" />,
+						jobs: (
+							<ExternalLink
+								icon={ true }
+								target="_blank"
+								href="https://wpjobmanager.com/document/shortcode-reference/#section-1"
+							/>
+						),
+						submission: (
+							<ExternalLink
+								icon={ true }
+								target="_blank"
+								href="https://wpjobmanager.com/document/the-job-submission-form/"
+							/>
+						),
+						dashboard: (
+							<ExternalLink
+								icon={ true }
+								target="_blank"
+								href="https://wpjobmanager.com/document/the-job-dashboard/"
+							/>
+						),
 					}
-				) }
+				}
+			) }
 
-				<p>
-					{ translate( 'If you need help, you can find more detail in our {{docs}}support documentation{{/docs}}' +
-						'or post your question on the {{forums}}WP Job Manager support forums{{/forums}}. Happy hiring!',
-						{
-							components: {
-								docs: (
-									<ExternalLink
-										icon={ true }
-										target="_blank"
-										href="https://wpjobmanager.com/documentation/"
-									/>
-								),
-								forums: (
-									<ExternalLink
-										icon={ true }
-										target="_blank"
-										href="https://wordpress.org/support/plugin/wp-job-manager"
-									/>
-								),
-							}
-						}
-					) }
-				</p>
-			</Card>
-
-			<SectionHeader label={ translate( 'Support WP Job Manager\'s Ongoing Development' ) } />
-			<Card>
-				<p>
-					{ translate( 'There are lots of ways you can support open source software projects like this one: ' +
-						'contributing code, fixing a bug, assisting with non-English translation, or just telling your ' +
-						'friends about WP Job Manager to help spread the word. We appreciate your support!' ) }
-				</p>
-
-				{ translate(
-					'{{ul}}' +
-						'{{li}} {{star}}{{/star}} {{review}}Leave a positive review{{/review}} {{/li}}' +
-						'{{li}} {{globe}}{{/globe}} {{localize}}Contribute a localization{{/localize}} {{/li}}' +
-						'{{li}} {{cog}}{{/cog}} {{contribute}}Contribute code or report a bug{{/contribute}} {{/li}}' +
-						'{{li}} {{help}}{{/help}} {{forums}}Help other users on the forums{{/forums}} {{/li}}' +
-					'{{/ul}}',
+			<p>
+				{ translate( 'If you need help, you can find more detail in our {{docs}}support documentation{{/docs}}' +
+					'or post your question on the {{forums}}WP Job Manager support forums{{/forums}}. Happy hiring!',
 					{
 						components: {
-							ul: <ul className="confirmation__support" />,
-							li: <li />,
-							star: <Gridicon icon="star" size="18" />,
-							globe: <Gridicon icon="globe" size="18" />,
-							cog: <Gridicon icon="cog" size="18" />,
-							help: <Gridicon icon="help" size="18" />,
-							review: (
+							docs: (
 								<ExternalLink
 									icon={ true }
 									target="_blank"
-									href="https://wordpress.org/support/view/plugin-reviews/wp-job-manager#postform"
-								/>
-							),
-							localize: (
-								<ExternalLink
-									icon={ true }
-									target="_blank"
-									href="https://translate.wordpress.org/projects/wp-plugins/wp-job-manager"
-								/>
-							),
-							contribute: (
-								<ExternalLink
-									icon={ true }
-									target="_blank"
-									href="https://github.com/mikejolley/WP-Job-Manager"
+									href="https://wpjobmanager.com/documentation/"
 								/>
 							),
 							forums: (
@@ -142,10 +84,66 @@ const Confirmation = ( { slug, translate } ) => {
 						}
 					}
 				) }
-			</Card>
-		</div>
-	);
-};
+			</p>
+		</Card>
+
+		<SectionHeader label={ translate( 'Support WP Job Manager\'s Ongoing Development' ) } />
+		<Card>
+			<p>
+				{ translate( 'There are lots of ways you can support open source software projects like this one: ' +
+					'contributing code, fixing a bug, assisting with non-English translation, or just telling your ' +
+					'friends about WP Job Manager to help spread the word. We appreciate your support!' ) }
+			</p>
+
+			{ translate(
+				'{{ul}}' +
+					'{{li}} {{star}}{{/star}} {{review}}Leave a positive review{{/review}} {{/li}}' +
+					'{{li}} {{globe}}{{/globe}} {{localize}}Contribute a localization{{/localize}} {{/li}}' +
+					'{{li}} {{cog}}{{/cog}} {{contribute}}Contribute code or report a bug{{/contribute}} {{/li}}' +
+					'{{li}} {{help}}{{/help}} {{forums}}Help other users on the forums{{/forums}} {{/li}}' +
+				'{{/ul}}',
+				{
+					components: {
+						ul: <ul className="confirmation__support" />,
+						li: <li />,
+						star: <Gridicon icon="star" size="18" />,
+						globe: <Gridicon icon="globe" size="18" />,
+						cog: <Gridicon icon="cog" size="18" />,
+						help: <Gridicon icon="help" size="18" />,
+						review: (
+							<ExternalLink
+								icon={ true }
+								target="_blank"
+								href="https://wordpress.org/support/view/plugin-reviews/wp-job-manager#postform"
+							/>
+						),
+						localize: (
+							<ExternalLink
+								icon={ true }
+								target="_blank"
+								href="https://translate.wordpress.org/projects/wp-plugins/wp-job-manager"
+							/>
+						),
+						contribute: (
+							<ExternalLink
+								icon={ true }
+								target="_blank"
+								href="https://github.com/mikejolley/WP-Job-Manager"
+							/>
+						),
+						forums: (
+							<ExternalLink
+								icon={ true }
+								target="_blank"
+								href="https://wordpress.org/support/plugin/wp-job-manager"
+							/>
+						),
+					}
+				}
+			) }
+		</Card>
+	</div>
+);
 
 Confirmation.propTypes = {
 	slug: PropTypes.string,

--- a/client/extensions/wp-job-manager/components/setup/confirmation/index.jsx
+++ b/client/extensions/wp-job-manager/components/setup/confirmation/index.jsx
@@ -106,10 +106,10 @@ const Confirmation = ( { slug, translate } ) => (
 					components: {
 						ul: <ul className="confirmation__support" />,
 						li: <li />,
-						star: <Gridicon icon="star" size="18" />,
-						globe: <Gridicon icon="globe" size="18" />,
-						cog: <Gridicon icon="cog" size="18" />,
-						help: <Gridicon icon="help" size="18" />,
+						star: <Gridicon icon="star" size={ 18 } />,
+						globe: <Gridicon icon="globe" size={ 18 } />,
+						cog: <Gridicon icon="cog" size={ 18 } />,
+						help: <Gridicon icon="help" size={ 18 } />,
 						review: (
 							<ExternalLink
 								icon={ true }

--- a/client/extensions/wp-job-manager/components/setup/confirmation/index.jsx
+++ b/client/extensions/wp-job-manager/components/setup/confirmation/index.jsx
@@ -18,19 +18,19 @@ import { getSelectedSiteSlug } from 'state/ui/selectors';
 const Confirmation = ( { slug, translate } ) => {
 	return (
 		<div>
-			<SectionHeader label={ translate( 'All Done!' ) } />
+			<SectionHeader label={ translate( 'You\'re ready to start using WP Job Manager!' ) } />
 			<Card>
 				<p>
-					{ translate( 'Looks like you\'re all set to start using the plugin. In case you\'re wondering where to go next:' ) }
+					{ translate( 'Wondering what to do now? Here are some of the most common next steps:' ) }
 				</p>
 
 				{ translate(
 					'{{ul}}' +
-						'{{li}} {{settings}}Tweak the plugin settings{{/settings}} {{/li}}' +
-						'{{li}} {{addJob}}Add a job via the back-end{{/addJob}} {{/li}}' +
-						'{{li}} {{submission}}Find out more about the front-end job submission form{{/submission}} {{/li}}' +
-						'{{li}} {{jobs}}Add the [jobs] shortcode to a page to list jobs{{/jobs}} {{/li}}' +
-						'{{li}} {{dashboard}}Find out more about the front-end job dashboard{{/dashboard}} {{/li}}' +
+						'{{li}} {{settings}}Tweak your settings{{/settings}} {{/li}}' +
+						'{{li}} {{addJob}}Add a job using the admin dashboard{{/addJob}} {{/li}}' +
+						'{{li}} {{jobs}}Add job listings to a page using the [jobs] shortcode{{/jobs}} {{/li}}' +
+						'{{li}} {{submission}}Learn to use the front-end job submission board{{/submission}} {{/li}}' +
+						'{{li}} {{dashboard}}Learn to use the front-end job dashboard{{/dashboard}} {{/li}}' +
 					'{{/ul}}',
 					{
 						components: {
@@ -38,18 +38,18 @@ const Confirmation = ( { slug, translate } ) => {
 							li: <li />,
 							settings: <a href={ `/extensions/wp-job-manager/${ slug }` } />,
 							addJob: <a href="#" />,
-							submission: (
-								<ExternalLink
-									icon={ true }
-									target="_blank"
-									href="https://wpjobmanager.com/document/the-job-submission-form/"
-								/>
-							),
 							jobs: (
 								<ExternalLink
 									icon={ true }
 									target="_blank"
 									href="https://wpjobmanager.com/document/shortcode-reference/#section-1"
+								/>
+							),
+							submission: (
+								<ExternalLink
+									icon={ true }
+									target="_blank"
+									href="https://wpjobmanager.com/document/the-job-submission-form/"
 								/>
 							),
 							dashboard: (
@@ -64,8 +64,8 @@ const Confirmation = ( { slug, translate } ) => {
 				) }
 
 				<p>
-					{ translate( 'And don\'t forget, if you need any more help using WP Job Manager you can ' +
-						'consult the {{docs}}documentation{{/docs}} or {{forums}}post on the forums!{{/forums}}',
+					{ translate( 'If you need help, you can find more detail in our {{docs}}support documentation{{/docs}}' +
+						'or post your question on the {{forums}}WP Job Manager support forums{{/forums}}. Happy hiring!',
 						{
 							components: {
 								docs: (
@@ -88,12 +88,12 @@ const Confirmation = ( { slug, translate } ) => {
 				</p>
 			</Card>
 
-			<SectionHeader label={ translate( 'Support the Ongoing Development of this Plugin' ) } />
+			<SectionHeader label={ translate( 'Support WP Job Manager\'s Ongoing Development' ) } />
 			<Card>
 				<p>
-					{ translate( 'There are many ways to support open-source projects such as WP Job Manager, ' +
-						'for example code contribution, translation, or even telling your friends how awesome ' +
-						'the plugin (hopefully) is. Thanks in advance for your support - it is much appreciated!' ) }
+					{ translate( 'There are lots of ways you can support open source software projects like this one: ' +
+						'contributing code, fixing a bug, assisting with non-English translation, or just telling your ' +
+						'friends about WP Job Manager to help spread the word. We appreciate your support!' ) }
 				</p>
 
 				{ translate(

--- a/client/extensions/wp-job-manager/components/setup/constants.js
+++ b/client/extensions/wp-job-manager/components/setup/constants.js
@@ -1,5 +1,5 @@
 export const Steps = {
-	FINAL: 'final',
+	CONFIRMATION: 'confirmation',
 	INTRO: 'intro',
 	PAGE_SETUP: 'page-setup',
 };

--- a/client/extensions/wp-job-manager/components/setup/index.jsx
+++ b/client/extensions/wp-job-manager/components/setup/index.jsx
@@ -10,6 +10,7 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import { Steps } from './constants';
+import Confirmation from './confirmation';
 import DocumentHead from 'components/data/document-head';
 import Intro from './intro';
 import Main from 'components/main';
@@ -22,10 +23,11 @@ const SetupWizard = ( {
 	stepName = Steps.INTRO,
 	translate,
 } ) => {
-	const steps = [ Steps.INTRO, Steps.PAGE_SETUP ];
+	const steps = [ Steps.INTRO, Steps.PAGE_SETUP, Steps.CONFIRMATION ];
 	const components = {
 		[ Steps.INTRO ]: <Intro />,
-		[ Steps.PAGE_SETUP ]: <PageSetup />
+		[ Steps.PAGE_SETUP ]: <PageSetup />,
+		[ Steps.CONFIRMATION ]: <Confirmation />,
 	};
 	const mainClassName = 'wp-job-manager__setup';
 

--- a/client/extensions/wp-job-manager/components/setup/style.scss
+++ b/client/extensions/wp-job-manager/components/setup/style.scss
@@ -37,3 +37,14 @@
 .wp-job-manager__setup .page-setup__pages .button {
 	margin-right: 8px;
 }
+
+.wp-job-manager__setup .confirmation__support {
+	list-style: none;
+	margin: 0;
+}
+
+.wp-job-manager__setup .gridicon {
+	color: $blue-wordpress;
+	top: 2px;
+	position: relative;
+}


### PR DESCRIPTION
This PR adds the UI for the confirmation step of the WPJM setup wizard. The wizard will be triggered when the plugin is first activated. This is the last and final step of the wizard. All links are functional except for _Add a job using the admin dashboard_, which will eventually point to a not-yet-created custom post type.

_Updated screenshot after copy review_

![wizard-final](https://user-images.githubusercontent.com/1190420/30207900-33ca6164-945f-11e7-988f-99073720fd9a.jpg)

For comparison's sake, here is what the confirmation step looks like in the plugin itself:

![plugin-wizard-confirmation](https://user-images.githubusercontent.com/1190420/30178354-9ddf869e-93d6-11e7-940c-811ee73dd8a4.jpg)

## Testing

Ensure the WP Job Manager plugin is installed and configured by following the steps in p6r3EZ-ra-p2. Checkout and run the `add/wpjm-wizard-final-step` Calypso branch. Browse to `/extensions/wp-job-manager/setup/<siteId>/confirmation`. 