### PR TITLE
Notifications: Update notifications panel version to 1.2.4

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1576,7 +1576,7 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.20"
+      "version": "1.3.21"
     },
     "element-class": {
       "version": "0.2.2"
@@ -4573,7 +4573,7 @@
       "dev": true
     },
     "notifications-panel": {
-      "version": "1.2.3"
+      "version": "1.2.4"
     },
     "npm-path": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "ms": "0.7.1",
     "name-all-modules-plugin": "1.0.1",
     "node-sass": "3.7.0",
-    "notifications-panel": "1.2.3",
+    "notifications-panel": "1.2.4",
     "npm-run-all": "4.0.2",
     "numeral": "2.0.4",
     "page": "1.6.4",


### PR DESCRIPTION
This is a janitorial PR to update the notifications panel version to `1.2.4`.

There are no visible changes, so, calypso should work as normal.