### PR TITLE
Store: Add getWithHeaders to http-request

### DIFF
--- a/client/extensions/woocommerce/state/sites/http-request.js
+++ b/client/extensions/woocommerce/state/sites/http-request.js
@@ -6,6 +6,7 @@ import { http } from 'state/data-layer/wpcom-http/actions';
 /**
  * Returns a proper WPCOM_HTTP_REQUEST action (http data layer) for dispatching requests
  * in data-layer handlers.
+ * The resulting data will be in the form of `{ data: { API data } }`
  * @param {String} method HTTP Request Method
  * @param {String} path The WC API path to make a request to (after /wc/v#)
  * @param {Number} siteId Site ID to make the request to
@@ -30,6 +31,20 @@ const _request = ( method, path, siteId, body, action ) => {
 };
 
 /**
+ * Prepares a request action that will return the body and headers.
+ * The resulting data will be in the form of `{ data: { body: { API data }, headers: { API response headers } } }`
+ * @param {String} method HTTP Request Method
+ * @param {String} path The WC API path to make a request to (after /wc/v#)
+ * @param {Number} siteId Site ID to make the request to
+ * @param {Object} body HTTP Body for POST and PUT Requests
+ * @param {Object} action The original requesting action
+ * @return {Object} WPCOM_HTTP_REQUEST Action
+ */
+const _requestWithHeaders = ( method, path, siteId, body, action ) => {
+	return _request( method, path + '&_envelope', siteId, body, action );
+};
+
+/**
  * Provides a wrapper over the http data-layer, made specifically for making requests to
  * WooCommerce endpoints without repeating things like /wc/v3.
  * @param {Number} siteId Site ID to make the request to
@@ -42,9 +57,16 @@ export default ( siteId, action ) => ( {
 	/**
 	 * Sends a GET request to the API
 	 * @param {String} path REST path to hit, omitting the "blog.url/wp-json/wc/v#/" prefix
-	 * @return {Object} WPCOM_HTTP_REQUEST Action
+	 * @return {Object} WPCOM_HTTP_REQUEST Action with `data = { API data }`
 	 */
 	get: ( path ) => _request( 'GET', path, siteId, null, action ),
+
+	/**
+	 * Sends a GET request to the API that will return with headers
+	 * @param {String} path REST path to hit, omitting the "blog.url/wp-json-/wc/v#/" prefix
+	 * @return {Object} WPCOM_HTTP_REQUEST Action with `data = { body: { API data }, headers: { API response headers } }`
+	 */
+	getWithHeaders: ( path ) => _requestWithHeaders( 'GET', path, siteId, null, action ),
 
 	/**
 	 * Sends a POST request to the API

--- a/client/extensions/woocommerce/state/sites/test/http-request.js
+++ b/client/extensions/woocommerce/state/sites/test/http-request.js
@@ -30,6 +30,15 @@ describe( 'request', () => {
 			} );
 		} );
 	} );
+	describe( '#getWithHeaders', () => {
+		it( 'should return a modified path', () => {
+			const action = request( siteId, originalAction ).getWithHeaders( 'placeholder_endpoint' );
+
+			expect( action.query ).to.exist;
+			expect( action.query.path ).to.exist;
+			expect( action.query.path.indexOf( '&_envelope' ) ).to.not.equal( -1 );
+		} );
+	} );
 	describe( '#post', () => {
 		const body = { name: 'placeholder post request', placeholder: true };
 


### PR DESCRIPTION
This adds functionality to get headers like X-WP-Total and
W-WP-TotalPages from the API via the data layer HTTP module.

To Test: `npm test`