### PR TITLE
Comments management: close navigation bar automatically

### DIFF
--- a/client/components/section-nav/index.jsx
+++ b/client/components/section-nav/index.jsx
@@ -1,16 +1,20 @@
 /**
  * External dependencies
  */
-import { isEqual } from 'lodash';
-var React = require( 'react' ),
-	classNames = require( 'classnames' );
+import React from 'react';
+import classNames from 'classnames';
+import {
+	isEqual,
+	includes,
+} from 'lodash';
 
 /**
  * Internal Dependencies
  */
-var NavTabs = require( './tabs' ),
-	NavItem = require( './item' ),
-	Search = require( 'components/search' );
+import CommentNavigationTab from 'my-sites/comments/comment-navigation/comment-navigation-tab';
+import NavTabs from 'components/section-nav/tabs';
+import NavItem from 'components/section-nav/item';
+import Search from 'components/search';
 
 /**
  * Main
@@ -176,9 +180,11 @@ var SectionNav = React.createClass( {
 	checkForSiblingControls: function( children ) {
 		this.hasSiblingControls = false;
 
+		const ignoreSiblings = [ Search, CommentNavigationTab ];
+
 		React.Children.forEach( children, function( child, index ) {
-			// Checking for at least 2 controls groups that are not search or null
-			if ( index && child && child.type !== Search ) {
+			// Checking for at least 2 controls groups that are not null or ignored siblings
+			if ( index && child && ! includes( ignoreSiblings, child.type ) ) {
 				this.hasSiblingControls = true;
 			}
 		}.bind( this ) );


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/17422

The comments navigation bar was not closing automatically because we
added a Bulk Edit sibling to NavTabs, which prevents auto close behavior
if it has any siblings other than Search. This was resolved by adding our
Bulk Edit component to the list of sibling controls that should be ignored
when checking whether auto close should be performed.

#### Testing instructions

1. Test on screen size that is lower than `480px`.
2. Navigate to `comments/pending/{siteUrl}`
3. Click on navigation item to expand the section (e.g. Pending, Approved, Spam, Trash).
4. Click on any navigation item again and verify that the section has been closed.

<img src="https://user-images.githubusercontent.com/1182160/29531030-029c08d8-86a7-11e7-946a-728a3d3ac696.png" alt="comments-navigation" width="400px">