### PR TITLE
extend `sectionify` to support `page.Route` array

### DIFF
--- a/client/lib/analytics/index.js
+++ b/client/lib/analytics/index.js
@@ -219,12 +219,12 @@ const analytics = {
 
 	// pageView is a wrapper for pageview events across Tracks and GA
 	pageView: {
-		record: function( urlPath, pageTitle ) {
+		record: function( urlPath, pageTitle, params ) {
 			// add delay to avoid stale `_dl` in recorded calypso_page_view event details
 			// `_dl` (browserdocumentlocation) is read from the current URL by external JavaScript
 			setTimeout( () => {
 				mostRecentUrlPath = urlPath;
-				analytics.tracks.recordPageView( urlPath );
+				analytics.tracks.recordPageView( urlPath, params );
 				analytics.ga.recordPageView( urlPath, pageTitle );
 				analytics.emit( 'page-view', urlPath, pageTitle );
 			}, 0 );
@@ -282,11 +282,16 @@ const analytics = {
 			analytics.emit( 'record-event', eventName, eventProperties );
 		},
 
-		recordPageView: function( urlPath ) {
+		recordPageView: function( urlPath, params ) {
 			let eventProperties = {
 				path: urlPath,
 				do_not_track: doNotTrack() ? 1 : 0
 			};
+
+			// add optional path params
+			if ( params ) {
+				eventProperties = assign( eventProperties, params );
+			}
 
 			// Record all `utm` marketing parameters as event properties on the page view event
 			// so we can analyze their performance with our analytics tools

--- a/client/lib/route/path.js
+++ b/client/lib/route/path.js
@@ -63,6 +63,17 @@ function addSiteFragment( path, site ) {
 	return pieces.join( '/' );
 }
 
+function sectionifyUsingRoutes( path, routes ) {
+	const params = {};
+	for ( let i = 0; i < routes.length; i++ ) {
+		const route = routes[ i ];
+		if ( route.match( path, params ) ) {
+			return route.path;
+		}
+	}
+	return path;
+}
+
 function sectionify( path, siteFragment ) {
 	let basePath = path.split( '?' )[ 0 ];
 
@@ -75,7 +86,12 @@ function sectionify( path, siteFragment ) {
 	}
 
 	if ( siteFragment ) {
-		basePath = trailingslashit( basePath ).replace( '/' + siteFragment + '/', '/' );
+		if ( siteFragment.constructor === Array ) {
+			// siteFragment is an array of page routes (from 'page' node.js module)
+			basePath = sectionifyUsingRoutes( basePath, siteFragment );
+		} else {
+			basePath = trailingslashit( basePath ).replace( '/' + siteFragment + '/', '/' );
+		}
 	}
 	return untrailingslashit( basePath );
 }

--- a/client/lib/route/path.js
+++ b/client/lib/route/path.js
@@ -63,15 +63,27 @@ function addSiteFragment( path, site ) {
 	return pieces.join( '/' );
 }
 
-function sectionifyUsingRoutes( path, routes ) {
-	const params = {};
-	for ( let i = 0; i < routes.length; i++ ) {
-		const route = routes[ i ];
-		if ( route.match( path, params ) ) {
-			return route.path;
+function sectionifyWithRoutes( path, routes ) {
+	const routeParams = {};
+	if ( ! routes || ! Array.isArray( routes ) ) {
+		return {
+			routePath: sectionify( path, routes ),
+			routeParams
+		};
+	}
+
+	let routePath = path.split( '?' )[ 0 ];
+	for ( const route of routes ) {
+		if ( route.match( routePath, routeParams ) ) {
+			routePath = route.path;
+			break;
 		}
 	}
-	return path;
+
+	return {
+		routePath: untrailingslashit( routePath ),
+		routeParams
+	};
 }
 
 function sectionify( path, siteFragment ) {
@@ -86,12 +98,7 @@ function sectionify( path, siteFragment ) {
 	}
 
 	if ( siteFragment ) {
-		if ( siteFragment.constructor === Array ) {
-			// siteFragment is an array of page routes (from 'page' node.js module)
-			basePath = sectionifyUsingRoutes( basePath, siteFragment );
-		} else {
-			basePath = trailingslashit( basePath ).replace( '/' + siteFragment + '/', '/' );
-		}
+		basePath = trailingslashit( basePath ).replace( '/' + siteFragment + '/', '/' );
 	}
 	return untrailingslashit( basePath );
 }
@@ -160,6 +167,7 @@ module.exports = {
 	getStatsDefaultSitePage: getStatsDefaultSitePage,
 	getStatsPathForTab: getStatsPathForTab,
 	sectionify: sectionify,
+	sectionifyWithRoutes: sectionifyWithRoutes,
 	mapPostStatus: mapPostStatus,
 	externalRedirect: externalRedirect
 };

--- a/client/lib/route/test/index.js
+++ b/client/lib/route/test/index.js
@@ -32,7 +32,7 @@ describe( 'route', function() {
 
 	describe( '#addQueryArgs()', () => {
 		it( 'should error when args is not an object', () => {
-			var types = [
+			const types = [
 				undefined,
 				1,
 				true,
@@ -49,7 +49,7 @@ describe( 'route', function() {
 		} );
 
 		it( 'should error when url is not a string', () => {
-			var types = [
+			const types = [
 				{},
 				undefined,
 				1,
@@ -508,53 +508,6 @@ describe( 'route', function() {
 					route.sectionify( '/edit/jetpack-portfolio/2916284/new' )
 				).to.equal( '/edit/jetpack-portfolio/new' );
 			} );
-			it( 'should parameterize checkout thank you paths', function() {
-				expect(
-					route.sectionify( '/checkout/thank-you', checkoutRoutes )
-				).to.equal( '/checkout/thank-you' );
-				expect(
-					route.sectionify( '/checkout/thank-you/25222194', checkoutRoutes )
-				).to.equal( '/checkout/thank-you/:receipt' );
-			} );
-			it( 'should parameterize checkout paths', function() {
-				expect(
-					route.sectionify( '/checkout/gapps', checkoutRoutes )
-				).to.equal( '/checkout/:product' );
-				expect(
-					route.sectionify( '/checkout/theme:elemin', checkoutRoutes )
-				).to.equal( '/checkout/:product' );
-				expect(
-					route.sectionify( '/checkout/domain_map:69thclergycouncil.com', checkoutRoutes )
-				).to.equal( '/checkout/:product' );
-			} );
-			it( 'should parameterize checkout renew paths', function() {
-				expect(
-					route.sectionify( '/checkout/gapps/renew/6527469', checkoutRoutes )
-				).to.equal( '/checkout/:product/renew/:receipt' );
-				expect(
-					route.sectionify( '/checkout/jetpack_premium_monthly/renew/7980613', checkoutRoutes )
-				).to.equal( '/checkout/:product/renew/:receipt' );
-				expect(
-					route.sectionify( '/checkout/personal-bundle/renew/6611954', checkoutRoutes )
-				).to.equal( '/checkout/:product/renew/:receipt' );
-				expect(
-					route.sectionify( '/checkout/domain_map:69thclergycouncil.com/renew/5164008', checkoutRoutes )
-				).to.equal( '/checkout/:product/renew/:receipt' );
-			} );
-			it( 'should parameterize comment paths', function() {
-				expect(
-					route.sectionify( '/comments/approved', commentsRoutes )
-				).to.equal( '/comments/approved' );
-				expect(
-					route.sectionify( '/comments/pending', commentsRoutes )
-				).to.equal( '/comments/pending' );
-				expect(
-					route.sectionify( '/comments/approved/elmundodelaliteraturasite.wordpress.com', commentsRoutes )
-				).to.equal( '/comments/approved/:domain' );
-				expect(
-					route.sectionify( '/comments/pending/17evasetyowatimm2.wordpress.com', commentsRoutes )
-				).to.equal( '/comments/pending/:domain' );
-			} );
 		} );
 		describe( 'for listing paths', function() {
 			it( 'should return the same path when there is no site yet', function() {
@@ -627,6 +580,120 @@ describe( 'route', function() {
 				expect(
 					route.sectionify( '/domains/manage/not-a-site', 'not-a-site' )
 				).to.equal( '/domains/manage' );
+			} );
+		} );
+	} );
+	describe( 'sectionifyWithRoutes', function() {
+		describe( 'for checkout paths', function() {
+			it( 'should parameterize checkout thank you paths', function() {
+				expect(
+					route.sectionifyWithRoutes( '/checkout/thank-you', checkoutRoutes )
+				).to.deep.equal( {
+					routePath: '/checkout/thank-you',
+					routeParams: {}
+				} );
+				expect(
+					route.sectionifyWithRoutes( '/checkout/thank-you/25222194', checkoutRoutes )
+				).to.deep.equal( {
+					routePath: '/checkout/thank-you/:receipt',
+					routeParams: {
+						receipt: '25222194'
+					}
+				} );
+			} );
+			it( 'should parameterize checkout paths', function() {
+				expect(
+					route.sectionifyWithRoutes( '/checkout/gapps', checkoutRoutes )
+				).to.deep.equal( {
+					routePath: '/checkout/:product',
+					routeParams: {
+						product: 'gapps'
+					}
+				} );
+				expect(
+					route.sectionifyWithRoutes( '/checkout/theme:elemin', checkoutRoutes )
+				).to.deep.equal( {
+					routePath: '/checkout/:product',
+					routeParams: {
+						product: 'theme:elemin'
+					}
+				} );
+				expect(
+					route.sectionifyWithRoutes( '/checkout/domain_map:69thclergycouncil.com', checkoutRoutes )
+				).to.deep.equal( {
+					routePath: '/checkout/:product',
+					routeParams: {
+						product: 'domain_map:69thclergycouncil.com'
+					}
+				} );
+			} );
+			it( 'should parameterize checkout renew paths', function() {
+				expect(
+					route.sectionifyWithRoutes( '/checkout/gapps/renew/6527469', checkoutRoutes )
+				).to.deep.equal( {
+					routePath: '/checkout/:product/renew/:receipt',
+					routeParams: {
+						product: 'gapps',
+						receipt: '6527469'
+					}
+				} );
+				expect(
+					route.sectionifyWithRoutes( '/checkout/jetpack_premium_monthly/renew/7980613', checkoutRoutes )
+				).to.deep.equal( {
+					routePath: '/checkout/:product/renew/:receipt',
+					routeParams: {
+						product: 'jetpack_premium_monthly',
+						receipt: '7980613'
+					}
+				} );
+				expect(
+					route.sectionifyWithRoutes( '/checkout/personal-bundle/renew/6611954', checkoutRoutes )
+				).to.deep.equal( {
+					routePath: '/checkout/:product/renew/:receipt',
+					routeParams: {
+						product: 'personal-bundle',
+						receipt: '6611954'
+					}
+				} );
+				expect(
+					route.sectionifyWithRoutes( '/checkout/domain_map:69thclergycouncil.com/renew/5164008', checkoutRoutes )
+				).to.deep.equal( {
+					routePath: '/checkout/:product/renew/:receipt',
+					routeParams: {
+						product: 'domain_map:69thclergycouncil.com',
+						receipt: '5164008'
+					}
+				} );
+			} );
+			it( 'should parameterize comment paths', function() {
+				expect(
+					route.sectionifyWithRoutes( '/comments/approved', commentsRoutes )
+				).to.deep.equal( {
+					routePath: '/comments/approved',
+					routeParams: {}
+				} );
+				expect(
+					route.sectionifyWithRoutes( '/comments/pending', commentsRoutes )
+				).to.deep.equal( {
+					routePath: '/comments/pending',
+					routeParams: {}
+				} );
+				expect(
+					route.sectionifyWithRoutes( '/comments/approved/elmundodelaliteraturasite.wordpress.com', commentsRoutes )
+				).to.deep.equal( {
+					routePath: '/comments/approved/:domain',
+					routeParams: {
+						domain: 'elmundodelaliteraturasite.wordpress.com'
+					}
+				} );
+				expect(
+					route.sectionifyWithRoutes( '/comments/pending/17evasetyowatimm2.wordpress.com', commentsRoutes )
+				).to.deep.equal( {
+					routePath: '/comments/pending/:domain',
+					routeParams: {
+						domain: '17evasetyowatimm2.wordpress.com'
+					}
+				} );
 			} );
 		} );
 	} );

--- a/client/lib/route/test/index.js
+++ b/client/lib/route/test/index.js
@@ -2,11 +2,24 @@
  * External dependencies
  */
 import { expect } from 'chai';
+import { Route } from 'page';
 
 /**
  * Internal dependencies
  */
 import useFakeDom from 'test/helpers/use-fake-dom';
+
+const checkoutRoutes = [
+	new Route( '/checkout/thank-you' ),
+	new Route( '/checkout/thank-you/:receipt' ),
+	new Route( '/checkout/:product' ),
+	new Route( '/checkout/:product/renew/:receipt' ),
+];
+
+const commentsRoutes = [
+	new Route( '/comments/approved/:domain' ),
+	new Route( '/comments/pending/:domain' ),
+];
 
 describe( 'route', function() {
 	let route;
@@ -494,6 +507,53 @@ describe( 'route', function() {
 				expect(
 					route.sectionify( '/edit/jetpack-portfolio/2916284/new' )
 				).to.equal( '/edit/jetpack-portfolio/new' );
+			} );
+			it( 'should parameterize checkout thank you paths', function() {
+				expect(
+					route.sectionify( '/checkout/thank-you', checkoutRoutes )
+				).to.equal( '/checkout/thank-you' );
+				expect(
+					route.sectionify( '/checkout/thank-you/25222194', checkoutRoutes )
+				).to.equal( '/checkout/thank-you/:receipt' );
+			} );
+			it( 'should parameterize checkout paths', function() {
+				expect(
+					route.sectionify( '/checkout/gapps', checkoutRoutes )
+				).to.equal( '/checkout/:product' );
+				expect(
+					route.sectionify( '/checkout/theme:elemin', checkoutRoutes )
+				).to.equal( '/checkout/:product' );
+				expect(
+					route.sectionify( '/checkout/domain_map:69thclergycouncil.com', checkoutRoutes )
+				).to.equal( '/checkout/:product' );
+			} );
+			it( 'should parameterize checkout renew paths', function() {
+				expect(
+					route.sectionify( '/checkout/gapps/renew/6527469', checkoutRoutes )
+				).to.equal( '/checkout/:product/renew/:receipt' );
+				expect(
+					route.sectionify( '/checkout/jetpack_premium_monthly/renew/7980613', checkoutRoutes )
+				).to.equal( '/checkout/:product/renew/:receipt' );
+				expect(
+					route.sectionify( '/checkout/personal-bundle/renew/6611954', checkoutRoutes )
+				).to.equal( '/checkout/:product/renew/:receipt' );
+				expect(
+					route.sectionify( '/checkout/domain_map:69thclergycouncil.com/renew/5164008', checkoutRoutes )
+				).to.equal( '/checkout/:product/renew/:receipt' );
+			} );
+			it( 'should parameterize comment paths', function() {
+				expect(
+					route.sectionify( '/comments/approved', commentsRoutes )
+				).to.equal( '/comments/approved' );
+				expect(
+					route.sectionify( '/comments/pending', commentsRoutes )
+				).to.equal( '/comments/pending' );
+				expect(
+					route.sectionify( '/comments/approved/elmundodelaliteraturasite.wordpress.com', commentsRoutes )
+				).to.equal( '/comments/approved/:domain' );
+				expect(
+					route.sectionify( '/comments/pending/17evasetyowatimm2.wordpress.com', commentsRoutes )
+				).to.equal( '/comments/pending/:domain' );
 			} );
 		} );
 		describe( 'for listing paths', function() {

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -5,6 +5,7 @@ import i18n from 'i18n-calypso';
 import ReactDom from 'react-dom';
 import React from 'react';
 import { isEmpty } from 'lodash';
+import { Route } from 'page';
 
 /**
  * Internal Dependencies
@@ -22,13 +23,20 @@ import { getSelectedSite } from 'state/ui/selectors';
  */
 const productsList = productsFactory();
 
+const checkoutRoutes = [
+	new Route( '/checkout/thank-you' ),
+	new Route( '/checkout/thank-you/:receipt' ),
+	new Route( '/checkout/:product' ),
+	new Route( '/checkout/:product/renew/:receipt' ),
+];
+
 module.exports = {
 	checkout: function( context ) {
-		var Checkout = require( './checkout' ),
+		const Checkout = require( './checkout' ),
 			CheckoutData = require( 'components/data/checkout' ),
 			CartData = require( 'components/data/cart' ),
 			SecondaryCart = require( './cart/secondary-cart' ),
-			basePath = route.sectionify( context.path ),
+			basePath = route.sectionify( context.path, checkoutRoutes ),
 			product = context.params.product,
 			selectedFeature = context.params.feature;
 
@@ -108,14 +116,15 @@ module.exports = {
 
 	checkoutThankYou: function( context ) {
 		const CheckoutThankYouComponent = require( './checkout-thank-you' ),
-			basePath = route.sectionify( context.path ),
+			basePath = route.sectionify( context.path, checkoutRoutes ),
 			receiptId = Number( context.params.receiptId );
 
 		analytics.pageView.record( basePath, 'Checkout Thank You' );
 
 		context.store.dispatch( setSection( { name: 'checkout-thank-you' }, { hasSidebar: false } ) );
 
-		context.store.dispatch( setTitle( i18n.translate( 'Thank You' ) ) ); // FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
+		// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
+		context.store.dispatch( setTitle( i18n.translate( 'Thank You' ) ) );
 
 		const state = context.store.getState();
 		const selectedSite = getSelectedSite( state );

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -36,7 +36,7 @@ module.exports = {
 			CheckoutData = require( 'components/data/checkout' ),
 			CartData = require( 'components/data/cart' ),
 			SecondaryCart = require( './cart/secondary-cart' ),
-			basePath = route.sectionify( context.path, checkoutRoutes ),
+			{ routePath, routeParams } = route.sectionifyWithRoutes( context.path, checkoutRoutes ),
 			product = context.params.product,
 			selectedFeature = context.params.feature;
 
@@ -47,7 +47,7 @@ module.exports = {
 			return;
 		}
 
-		analytics.pageView.record( basePath, 'Checkout' );
+		analytics.pageView.record( routePath, 'Checkout', routeParams );
 
 		// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
 		context.store.dispatch( setTitle( i18n.translate( 'Checkout' ) ) );
@@ -116,10 +116,10 @@ module.exports = {
 
 	checkoutThankYou: function( context ) {
 		const CheckoutThankYouComponent = require( './checkout-thank-you' ),
-			basePath = route.sectionify( context.path, checkoutRoutes ),
+			{ routePath, routeParams } = route.sectionifyWithRoutes( context.path, checkoutRoutes ),
 			receiptId = Number( context.params.receiptId );
 
-		analytics.pageView.record( basePath, 'Checkout Thank You' );
+		analytics.pageView.record( routePath, 'Checkout Thank You', routeParams );
 
 		context.store.dispatch( setSection( { name: 'checkout-thank-you' }, { hasSidebar: false } ) );
 


### PR DESCRIPTION
`sectionify` function in `lib/route` module currently supports only simple paths with **at most one parameter**, which is matched by value then **discarded**. This results in shortcomings reported in issue #16902 which are Tracks `calypso_page_view` events recorded with:

1. parameter values in `path` property.
2. `path` property without parameter names.

This PR extends `sectionify` function in `lib/route` module to use optional array of `page` modules' `Route` instances so correct parameterized paths can be determined for any known path.

`calypso_page_view` event property `path` being reported **before** this PR:

    /checkout/domain_map:69thclergycouncil.com/renew/5164008
    /checkout/theme:elemin
    /checkout/thank-you/25222194

event property `path` expected to be reported **after** this PR:

    /checkout/:product/renew/:receipt
    /checkout/:product
    /checkout/thank-you/:receipt

Test Plan:

    npm run test-client client/lib/route

Note: Despite `[Size] L` labeling, this PR is actually very small in impact area, specifically limited to checkout controller.