### PR TITLE
DevDocs: Set page title in all of the sections

### DIFF
--- a/client/devdocs/controller.js
+++ b/client/devdocs/controller.js
@@ -70,14 +70,15 @@ const devdocs = {
 				false );
 		}
 
-		ReactDom.render(
+		renderWithReduxStore(
 			React.createElement( DocsComponent, {
 				term: context.query.term,
 				// we debounce with wait time of 0, so that the search doesn’t happen
 				// in the same tick as the keyUp event and possibly cause typing lag
 				onSearchChange: debounce( onSearchChange, 0 )
 			} ),
-			document.getElementById( 'primary' )
+			'primary',
+			context.store
 		);
 	},
 
@@ -85,13 +86,14 @@ const devdocs = {
 	 * Controller for single developer document
 	 */
 	singleDoc: function( context ) {
-		ReactDom.render(
+		renderWithReduxStore(
 			React.createElement( SingleDocComponent, {
 				path: context.params.path,
 				term: context.query.term,
 				sectionId: Object.keys( context.hash )[ 0 ]
 			} ),
-			document.getElementById( 'primary' )
+			'primary',
+			context.store
 		);
 	},
 
@@ -137,11 +139,12 @@ const devdocs = {
 	},
 
 	typography: function( context ) {
-		ReactDom.render(
+		renderWithReduxStore(
 			React.createElement( Typography, {
 				component: context.params.component
 			} ),
-			document.getElementById( 'primary' )
+			'primary',
+			context.store
 		);
 	},
 

--- a/client/devdocs/design/blocks.jsx
+++ b/client/devdocs/design/blocks.jsx
@@ -11,6 +11,7 @@ import { slugToCamelCase } from 'devdocs/docs-example/util';
  * Internal dependencies
  */
 import Collection from 'devdocs/design/search-collection';
+import DocumentHead from 'components/data/document-head';
 import HeaderCake from 'components/header-cake';
 import Main from 'components/main';
 import SearchCard from 'components/search-card';
@@ -96,6 +97,7 @@ export default class AppComponents extends React.Component {
 	render() {
 		return (
 			<Main className="design design__blocks">
+				<DocumentHead title="Blocks" />
 				{ this.props.component ? (
 					<HeaderCake onClick={ this.backToComponents } backText="All Blocks">
 						{ slugToCamelCase( this.props.component ) }

--- a/client/devdocs/design/index.jsx
+++ b/client/devdocs/design/index.jsx
@@ -14,6 +14,7 @@ import { trim } from 'lodash';
  * Internal dependencies
  */
 import config from 'config';
+import DocumentHead from 'components/data/document-head';
 import fetchComponentsUsageStats from 'state/components-usage-stats/actions';
 import HeaderCake from 'components/header-cake';
 import Main from 'components/main';
@@ -109,6 +110,8 @@ class DesignAssets extends React.Component {
 
 		return (
 			<Main className="design">
+				<DocumentHead title="UI Components" />
+
 				{ component ? (
 					<HeaderCake onClick={ this.backToComponents } backText="All Components">
 						{ slugToCamelCase( component ) }

--- a/client/devdocs/design/typography.jsx
+++ b/client/devdocs/design/typography.jsx
@@ -7,6 +7,7 @@ import React from 'react';
  * Internal dependencies
  */
 import Card from 'components/card';
+import DocumentHead from 'components/data/document-head';
 import Main from 'components/main';
 
 export default class Typography extends React.PureComponent {
@@ -67,6 +68,8 @@ export default class Typography extends React.PureComponent {
 
 		return (
 			<Main className="design">
+				<DocumentHead title="Typography" />
+
 				<div className="docs__design-group">
 					<h2>
 						<a href="/devdocs/design/typography">Typography</a>

--- a/client/devdocs/doc.jsx
+++ b/client/devdocs/doc.jsx
@@ -8,6 +8,7 @@ import React from 'react';
  * Internal dependencies
  */
 import DocService from './service';
+import DocumentHead from 'components/data/document-head';
 import CompactCard from 'components/card/compact';
 import highlight from 'lib/highlight';
 
@@ -86,9 +87,17 @@ export default class extends React.Component {
 	render() {
 		const editURL = encodeURI( 'https://github.com/Automattic/wp-calypso/edit/master/' + this.props.path ) +
 			'?message=Documentation: <title>&description=What did you change and why&target_branch=update/docs-your-title';
+		const titleMatches = this.state.body.length && this.state.body.match( /<h1[^>]+>(.+)<\/h1>/ );
+		const title = titleMatches && titleMatches[ 1 ];
 
 		return (
 			<div className="devdocs devdocs__doc">
+				{
+					title
+						? <DocumentHead title={ title } />
+						: null
+
+				}
 				<CompactCard className="devdocs__doc-header">
 					Path: <code>{ this.props.path }</code>
 					<a href={ editURL } target="_blank" rel="noopener noreferrer">Improve this document on GitHub &rarr;</a>

--- a/client/devdocs/docs-selectors/index.jsx
+++ b/client/devdocs/docs-selectors/index.jsx
@@ -8,9 +8,9 @@ import React, { PureComponent } from 'react';
  * Internal dependencies
  */
 import Main from 'components/main';
-import DocumentHead from 'components/data/document-head';
 import DocsSelectorsSingle from './single';
 import DocsSelectorsSearch from './search';
+import DocumentHead from 'components/data/document-head';
 
 export default class DocsSelectors extends PureComponent {
 	static propTypes = {

--- a/client/devdocs/main.jsx
+++ b/client/devdocs/main.jsx
@@ -10,6 +10,7 @@ import { isFunction } from 'lodash';
  * Internal dependencies
  */
 import DocService from './service';
+import DocumentHead from 'components/data/document-head';
 import Card from 'components/card';
 import Main from 'components/main';
 import SearchCard from 'components/search-card';
@@ -159,6 +160,8 @@ export default class Devdocs extends React.Component {
 	render() {
 		return (
 			<Main className="devdocs">
+				<DocumentHead title="Calypso Docs" />
+
 				<SearchCard
 					autoFocus
 					placeholder="Search documentation…"


### PR DESCRIPTION
This PR suggests that we set page title to each of the DevDocs sections. This way, navigating to each of the docs sections will properly have the right page title set. Currently, page title is only set for the selectors directory. 

Fixes #17919.

To test:
* Checkout this branch
* Go to http://calypso.localhost:3000/devdocs/
* Verify you now have a "Calypso Docs" page title set.
* Search for something, click on several results and verify title is set properly when you navigate to each of them.
* Navigate to each of the sections in the left sidebar menu and verify they set the proper page title.
* Navigate to a sub-section of Blocks, UI Components, State Selectors and verify each of them sets the parent section page title.
