### PR TITLE
Activity log: Fix banner dates

### DIFF
--- a/client/my-sites/stats/activity-log-banner/error-banner.jsx
+++ b/client/my-sites/stats/activity-log-banner/error-banner.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -39,12 +40,7 @@ class ErrorBanner extends PureComponent {
 	handleDismiss = () => this.props.dismissRewindRestoreProgress( this.props.siteId );
 
 	render() {
-		const {
-			errorCode,
-			failureReason,
-			timestamp,
-			translate,
-		} = this.props;
+		const { errorCode, failureReason, timestamp, translate } = this.props;
 
 		return (
 			<ActivityLogBanner
@@ -53,12 +49,17 @@ class ErrorBanner extends PureComponent {
 				status="error"
 				title={ translate( 'Problem restoring your site' ) }
 			>
-				<TrackComponentView eventName="calypso_activitylog_errorbanner_impression" eventProperties={ {
-					error_code: errorCode,
-					failure_reason: failureReason,
-					restore_to: timestamp,
-				} } />
-				<p>{ translate( 'We came across a problem while trying to restore your site.' ) }</p>
+				<TrackComponentView
+					eventName="calypso_activitylog_errorbanner_impression"
+					eventProperties={ {
+						error_code: errorCode,
+						failure_reason: failureReason,
+						restore_to: timestamp,
+					} }
+				/>
+				<p>
+					{ translate( 'We came across a problem while trying to restore your site.' ) }
+				</p>
 				<Button primary onClick={ this.handleClickRestore }>
 					{ translate( 'Try again' ) }
 				</Button>

--- a/client/my-sites/stats/activity-log-banner/error-banner.jsx
+++ b/client/my-sites/stats/activity-log-banner/error-banner.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { PropTypes, PureComponent } from 'react';
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 

--- a/client/my-sites/stats/activity-log-banner/progress-banner.jsx
+++ b/client/my-sites/stats/activity-log-banner/progress-banner.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 
 /**

--- a/client/my-sites/stats/activity-log-banner/progress-banner.jsx
+++ b/client/my-sites/stats/activity-log-banner/progress-banner.jsx
@@ -12,6 +12,7 @@ import ProgressBar from 'components/progress-bar';
 import QueryRewindRestoreStatus from 'components/data/query-rewind-restore-status';
 
 function ProgressBanner( {
+	applySiteOffset,
 	moment,
 	percent,
 	status,
@@ -37,11 +38,13 @@ function ProgressBanner( {
 				siteId={ siteId }
 				timestamp={ timestamp }
 			/>
-			<p>{ translate(
-				"We're in the process of restoring your site back to %s. " +
-				"You'll be notified once it's complete.",
-				{ args: moment( timestamp ).format( 'LLLL' ) }
-			) }</p>
+			<p>
+				{ translate(
+					"We're in the process of restoring your site back to %s. " +
+						"You'll be notified once it's complete.",
+					{ args: applySiteOffset( moment.utc( timestamp ) ).format( 'LLLL' ) }
+				) }
+			</p>
 
 			<div>
 				<em>{ restoreStatusDescription }</em>
@@ -60,6 +63,7 @@ function ProgressBanner( {
 }
 
 ProgressBanner.propTypes = {
+	applySiteOffset: PropTypes.func.isRequired,
 	percent: PropTypes.number.isRequired,
 	siteId: PropTypes.number,
 	status: PropTypes.oneOf( [

--- a/client/my-sites/stats/activity-log-banner/progress-banner.jsx
+++ b/client/my-sites/stats/activity-log-banner/progress-banner.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -23,15 +24,13 @@ function ProgressBanner( {
 	freshness,
 	restoreId,
 } ) {
-	const restoreStatusDescription = status === 'queued'
-		? translate( 'Your restore will start in a moment.' )
-		: translate( 'We\'re on it! Your site is being restored.' );
+	const restoreStatusDescription =
+		status === 'queued'
+			? translate( 'Your restore will start in a moment.' )
+			: translate( "We're on it! Your site is being restored." );
 
 	return (
-		<ActivityLogBanner
-			status="info"
-			title={ translate( 'Currently restoring your site' ) }
-		>
+		<ActivityLogBanner status="info" title={ translate( 'Currently restoring your site' ) }>
 			<QueryRewindRestoreStatus
 				freshness={ freshness }
 				queryDelay={ 1500 }
@@ -48,13 +47,11 @@ function ProgressBanner( {
 			</p>
 
 			<div>
-				<em>{ restoreStatusDescription }</em>
+				<em>
+					{ restoreStatusDescription }
+				</em>
 				<ProgressBar
-					className={
-						status === 'queued'
-							? 'activity-log-banner__progress-bar--queued'
-							: null
-					}
+					className={ status === 'queued' ? 'activity-log-banner__progress-bar--queued' : null }
 					isPulsing
 					value={ status === 'queued' ? 100 : percent }
 				/>
@@ -67,10 +64,7 @@ ProgressBanner.propTypes = {
 	applySiteOffset: PropTypes.func.isRequired,
 	percent: PropTypes.number.isRequired,
 	siteId: PropTypes.number,
-	status: PropTypes.oneOf( [
-		'queued',
-		'running',
-	] ).isRequired,
+	status: PropTypes.oneOf( [ 'queued', 'running' ] ).isRequired,
 	timestamp: PropTypes.number.isRequired,
 };
 

--- a/client/my-sites/stats/activity-log-banner/success-banner.jsx
+++ b/client/my-sites/stats/activity-log-banner/success-banner.jsx
@@ -16,6 +16,7 @@ import { dismissRewindRestoreProgress as dismissRewindRestoreProgressAction } fr
 
 class SuccessBanner extends PureComponent {
 	static propTypes = {
+		applySiteOffset: PropTypes.func.isRequired,
 		siteId: PropTypes.number.isRequired,
 		siteUrl: PropTypes.string.isRequired,
 		timestamp: PropTypes.number.isRequired,
@@ -32,6 +33,7 @@ class SuccessBanner extends PureComponent {
 
 	render() {
 		const {
+			applySiteOffset,
 			moment,
 			siteUrl,
 			timestamp,
@@ -50,7 +52,7 @@ class SuccessBanner extends PureComponent {
 				} } />
 				<p>{ translate(
 					'We successfully restored your site back to %s!',
-					{ args: moment( timestamp ).format( 'LLLL' ) }
+					{ args: applySiteOffset( moment.utc( timestamp ) ).format( 'LLLL' ) }
 				) }</p>
 				<Button
 					href={ siteUrl }

--- a/client/my-sites/stats/activity-log-banner/success-banner.jsx
+++ b/client/my-sites/stats/activity-log-banner/success-banner.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { PropTypes, PureComponent } from 'react';
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 

--- a/client/my-sites/stats/activity-log-banner/success-banner.jsx
+++ b/client/my-sites/stats/activity-log-banner/success-banner.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -33,13 +34,7 @@ class SuccessBanner extends PureComponent {
 	handleDismiss = () => this.props.dismissRewindRestoreProgress( this.props.siteId );
 
 	render() {
-		const {
-			applySiteOffset,
-			moment,
-			siteUrl,
-			timestamp,
-			translate,
-		} = this.props;
+		const { applySiteOffset, moment, siteUrl, timestamp, translate } = this.props;
 
 		return (
 			<ActivityLogBanner
@@ -48,17 +43,18 @@ class SuccessBanner extends PureComponent {
 				status="success"
 				title={ translate( 'Your site has been successfully restored' ) }
 			>
-				<TrackComponentView eventName="calypso_activitylog_successbanner_impression" eventProperties={ {
-					restore_to: timestamp,
-				} } />
-				<p>{ translate(
-					'We successfully restored your site back to %s!',
-					{ args: applySiteOffset( moment.utc( timestamp ) ).format( 'LLLL' ) }
-				) }</p>
-				<Button
-					href={ siteUrl }
-					primary
-				>
+				<TrackComponentView
+					eventName="calypso_activitylog_successbanner_impression"
+					eventProperties={ {
+						restore_to: timestamp,
+					} }
+				/>
+				<p>
+					{ translate( 'We successfully restored your site back to %s!', {
+						args: applySiteOffset( moment.utc( timestamp ) ).format( 'LLLL' ),
+					} ) }
+				</p>
+				<Button href={ siteUrl } primary>
 					{ translate( 'View site' ) }
 				</Button>
 				{ '  ' }

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -215,12 +215,17 @@ class ActivityLog extends Component {
 								siteTitle={ siteTitle }
 								timestamp={ timestamp }
 							/>
-						: <SuccessBanner siteId={ siteId } timestamp={ timestamp } /> }
+						: <SuccessBanner
+								applySiteOffset={ this.applySiteOffset }
+								siteId={ siteId }
+								timestamp={ timestamp }
+							/> }
 				</div>
 			);
 		}
 		return (
 			<ProgressBanner
+				applySiteOffset={ this.applySiteOffset }
 				freshness={ freshness }
 				percent={ percent }
 				restoreId={ restoreId }

--- a/client/my-sites/stats/activity-log/style.scss
+++ b/client/my-sites/stats/activity-log/style.scss
@@ -11,7 +11,7 @@
 		left: 33px;
 		width: 2px;
 		background-color: lighten( $gray, 20% );
-		
+
 		@include breakpoint( "<660px" ) {
 			left: 48px;
 		}


### PR DESCRIPTION
Site timezone and offset were not being applied in banners. This PR fixes that.

Problem:

<img width="1069" alt="bad-date" src="https://user-images.githubusercontent.com/841763/30202240-fb9ec8b0-947d-11e7-8b73-072cbe28b917.png">

It also does some banner cleanup:
* PropTypes from module
* Prettier 💅 ❤️ 

## Testing
1. Try using sites that are not UTC and don't match your browser timezone.
1. Visit https://calypso.live/stats/activity?branch=fix/activity-log/banner-dates
1. Note the _correct_ dates in the Activity Log items.
1. Do a rewind and note the correct dates.

## Context
This came out of p2JiWH-1Xb-p2.
Thanks to @davoraltman for the report and help tracking it down.