### PR TITLE
DevDocs: Preserve sidebar active menu items in subpages

### DIFF
--- a/client/devdocs/design/typography.jsx
+++ b/client/devdocs/design/typography.jsx
@@ -69,7 +69,7 @@ export default class Typography extends React.PureComponent {
 			<Main className="design">
 				<div className="docs__design-group">
 					<h2>
-						<a href="/devdocs/design/typography">Typography</a>
+						<a href="/devdocs/typography">Typography</a>
 					</h2>
 					<h3>Interface Typography</h3>
 					<Card>

--- a/client/devdocs/index.js
+++ b/client/devdocs/index.js
@@ -13,7 +13,6 @@ export default function() {
 	if ( config.isEnabled( 'devdocs' ) ) {
 		page( '/devdocs', controller.sidebar, controller.devdocs );
 		page( '/devdocs/form-state-examples/:component?', controller.sidebar, controller.formStateExamples );
-		page( '/devdocs/design/typography', controller.sidebar, controller.typography );
 		page( '/devdocs/design/wizard/:stepName?', controller.sidebar, controller.wizard );
 		page( '/devdocs/design/:component?', controller.sidebar, controller.design );
 		page( '/devdocs/app-components/:component?',
@@ -21,6 +20,7 @@ export default function() {
 		page( '/devdocs/app-components', '/devdocs/blocks' );
 		page( '/devdocs/blocks/:component?', controller.sidebar, controller.blocks );
 		page( '/devdocs/selectors/:selector?', controller.sidebar, controller.selectors );
+		page( '/devdocs/typography', controller.sidebar, controller.typography );
 		page( '/devdocs/start', controller.pleaseLogIn );
 		page( '/devdocs/welcome', controller.sidebar, controller.welcome );
 		page( '/devdocs/:path*', controller.sidebar, controller.singleDoc );

--- a/client/devdocs/sidebar.jsx
+++ b/client/devdocs/sidebar.jsx
@@ -44,7 +44,7 @@ export default class DevdocsSidebar extends React.PureComponent {
 							icon="location"
 							label="The Calypso Guide"
 							link="/devdocs/docs/guide/index.md"
-							selected={ this.isItemSelected( '/devdocs/docs/guide/index.md' ) }
+							selected={ this.isItemSelected( '/devdocs/docs/guide', false ) }
 						/>
 						<SidebarItem
 							className="devdocs__navigation-item"

--- a/client/devdocs/sidebar.jsx
+++ b/client/devdocs/sidebar.jsx
@@ -14,6 +14,16 @@ import SidebarItem from 'layout/sidebar/item';
 export default class DevdocsSidebar extends React.PureComponent {
 	static displayName = 'DevdocsSidebar';
 
+	isItemSelected( itemPath, isStrict = true ) {
+		const { path } = this.props;
+
+		if ( isStrict ) {
+			return path === itemPath;
+		}
+
+		return path.indexOf( itemPath ) >= 0;
+	},
+
 	render() {
 		return (
 			<Sidebar>
@@ -27,21 +37,21 @@ export default class DevdocsSidebar extends React.PureComponent {
 							icon="search"
 							label="Search"
 							link="/devdocs"
-							selected={ '/devdocs' === this.props.path }
+							selected={ this.isItemSelected( '/devdocs' ) }
 						/>
 						<SidebarItem
 							className="devdocs__navigation-item"
 							icon="location"
 							label="The Calypso Guide"
 							link="/devdocs/docs/guide/index.md"
-							selected={ '/devdocs/docs/guide/index.md' === this.props.path }
+							selected={ this.isItemSelected( '/devdocs/docs/guide/index.md' ) }
 						/>
 						<SidebarItem
 							className="devdocs__navigation-item"
 							icon="pencil"
 							label="Contributing"
 							link="/devdocs/.github/CONTRIBUTING.md"
-							selected={ '/devdocs/.github/CONTRIBUTING.md' === this.props.path }
+							selected={ this.isItemSelected( '/devdocs/.github/CONTRIBUTING.md' ) }
 						/>
 					</ul>
 				</SidebarMenu>
@@ -53,35 +63,35 @@ export default class DevdocsSidebar extends React.PureComponent {
 							icon="layout-blocks"
 							label="UI Components"
 							link="/devdocs/design"
-							selected={ '/devdocs/design' === this.props.path }
+							selected={ this.isItemSelected( '/devdocs/design', false ) }
 						/>
 						<SidebarItem
 							className="devdocs__navigation-item"
 							icon="custom-post-type"
 							label="Blocks"
 							link="/devdocs/blocks"
-							selected={ '/devdocs/blocks' === this.props.path }
+							selected={ this.isItemSelected( '/devdocs/blocks', false ) }
 						/>
 						<SidebarItem
 							className="devdocs__navigation-item"
 							icon="plugins"
 							label="State Selectors"
 							link="/devdocs/selectors"
-							selected={ 0 === this.props.path.indexOf( '/devdocs/selectors' ) }
+							selected={ this.isItemSelected( '/devdocs/selectors', false ) }
 						/>
 						<SidebarItem
 							className="devdocs__navigation-item"
 							icon="heading"
 							label="Typography"
-							link="/devdocs/design/typography"
-							selected={ '/devdocs/design/typography' === this.props.path }
+							link="/devdocs/typography"
+							selected={ this.isItemSelected( '/devdocs/typography' ) }
 						/>
 						<SidebarItem
 							className="devdocs__navigation-item"
 							icon="types"
 							label="Icons"
 							link="/devdocs/docs/icons.md"
-							selected={ '/devdocs/docs/icons.md' === this.props.path }
+							selected={ this.isItemSelected( '/devdocs/docs/icons.md' ) }
 						/>
 					</ul>
 				</SidebarMenu>

--- a/client/devdocs/sidebar.jsx
+++ b/client/devdocs/sidebar.jsx
@@ -21,7 +21,7 @@ export default class DevdocsSidebar extends React.PureComponent {
 			return path === itemPath;
 		}
 
-		return path.indexOf( itemPath ) >= 0;
+		return path.indexOf( itemPath ) === 0;
 	}
 
 	render() {

--- a/client/devdocs/sidebar.jsx
+++ b/client/devdocs/sidebar.jsx
@@ -22,7 +22,7 @@ export default class DevdocsSidebar extends React.PureComponent {
 		}
 
 		return path.indexOf( itemPath ) >= 0;
-	},
+	}
 
 	render() {
 		return (


### PR DESCRIPTION
This PR updates DevDocs to preserve the current sidebar nav menu items when visiting any of the sub pages, including:

* Keep **UI Components** nav menu item active when viewing a particular component.
* Keep **Blocks** nav menu item active when viewing a particular block.
* Keep **The Calypso Guide** nav menu item active when viewing any of the guide articles.

The PR uses the chance to introduce a couple of small improvements:
* Change `/devdocs/design/typography` to just `/devdocs/typography`, because `/devdocs/design/:component` is used for all UI components, and **Typography** itself is not a component.
* Instead of repeating logic, use a common method to determine whether a sidebar nav menu item is selected.

Fixes #17920.

To test:
* Checkout this branch.
* Go to http://calypso.localhost:3000/devdocs
* Visit a component page and verify the **UI Components** sidebar nav menu item is active.
* Visit a block page and verify the **Blocks** sidebar nav menu item is active.
* Visit a selector page and verify the **State selectors** sidebar nav menu item is still active.
* Go through all of **The Calypso Guide** pages and verify the corresponding nav menu item stays active while there.
* Visit the rest of the sidebar nav menu items and verify sidebar nav menu items work consistently and stay active as expected.