### PR TITLE
Apply codemod react-prop-types

### DIFF
--- a/client/login/magic-login/emailed-login-link-expired.jsx
+++ b/client/login/magic-login/emailed-login-link-expired.jsx
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import page from 'page';

--- a/client/login/magic-login/emailed-login-link-successfully.jsx
+++ b/client/login/magic-login/emailed-login-link-successfully.jsx
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import page from 'page';

--- a/client/login/magic-login/index.jsx
+++ b/client/login/magic-login/index.jsx
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';

--- a/client/login/magic-login/request-login-email-form.jsx
+++ b/client/login/magic-login/request-login-email-form.jsx
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import { connect } from 'react-redux';
 import { get } from 'lodash';
 

--- a/client/login/wp-login/private-site.jsx
+++ b/client/login/wp-login/private-site.jsx
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
 
 /**


### PR DESCRIPTION
This change runs several codemods to achieve the following:

Before | After
------------ | -------------
`require( ... )` nested in blocks | All `require( ... )` moved to top block
`var ... = require( ... )` | `import ... from '...'`
`module.exports = ...` | `export default ...`
`this.translate` | `this.props.translate` via HOC
`React.createClass( ... )` | `class ThisComponentName extends React.Component`
`React.createClass( ... )` | `createReactClass( ... )` if unconvertible to `React.Component` subclass
`import { PropTypes } from 'react'` | `import PropTypes from 'prop-types'`

#### Testing instructions

1. Check out locally (`git checkout update/codemod-client-login`) and start your server. You can also use a [live branch](https://calypso.live/?branch=update/codemod-client-login)
2. Open the [Login Page](http://calypso.localhost:3000/log-in)
3. Verify that all components work identically to before.
