### PR TITLE
Update/codemod client/signup

### DIFF
--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -75,7 +75,7 @@ export default {
 	},
 
 	start( context ) {
-		let basePath = route.sectionify( context.path ),
+		const basePath = route.sectionify( context.path ),
 			flowName = utils.getFlowName( context.params ),
 			stepName = utils.getStepName( context.params ),
 			stepSectionName = utils.getStepSectionName( context.params );

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -75,7 +75,7 @@ export default {
 	},
 
 	start( context ) {
-		var basePath = route.sectionify( context.path ),
+		let basePath = route.sectionify( context.path ),
 			flowName = utils.getFlowName( context.params ),
 			stepName = utils.getStepName( context.params ),
 			stepSectionName = utils.getStepSectionName( context.params );

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -55,7 +55,7 @@ class Signup extends React.Component {
 	};
 
 	constructor( props, context ) {
-	    super( props, context );
+		super( props, context );
 		SignupDependencyStore.setReduxStore( context.store );
 
 		this.state = {

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -44,29 +44,30 @@ import { loadTrackingTool } from 'state/analytics/actions';
  */
 const MINIMUM_TIME_LOADING_SCREEN_IS_DISPLAYED = 3000;
 
-const Signup = React.createClass( {
-	displayName: 'Signup',
+class Signup extends React.Component {
+	static displayName = 'Signup';
 
-	contextTypes: {
+	static contextTypes = {
 		store: React.PropTypes.object
-	},
+	};
 
-	getInitialState() {
-		SignupDependencyStore.setReduxStore( this.context.store );
+	constructor( props, context ) {
+	    super( props, context );
+		SignupDependencyStore.setReduxStore( context.store );
 
-		return {
+		this.state = {
 			login: false,
 			progress: SignupProgressStore.get(),
-			dependencies: this.props.signupDependencies,
+			dependencies: props.signupDependencies,
 			loadingScreenStartTime: undefined,
 			resumingStep: undefined,
 			user: user.get(),
 			loginHandler: null,
 			hasCartItems: false,
 		};
-	},
+	}
 
-	loadProgressFromStore() {
+	loadProgressFromStore = () => {
 		const newProgress = SignupProgressStore.get(),
 			invalidSteps = some( newProgress, matchesProperty( 'status', 'invalid' ) ),
 			waitingForServer = ! invalidSteps && this.isEveryStepSubmitted(),
@@ -85,9 +86,9 @@ const Signup = React.createClass( {
 		if ( invalidSteps ) {
 			this.setState( { loadingScreenStartTime: undefined } );
 		}
-	},
+	};
 
-	submitQueryDependencies() {
+	submitQueryDependencies = () => {
 		if ( ! this.props.queryObject ) {
 			return;
 		}
@@ -106,7 +107,7 @@ const Signup = React.createClass( {
 				{ stepName: 'survey' }, [], { surveySiteType: 'blog', surveyQuestion: vertical }
 			);
 		}
-	},
+	};
 
 	componentWillMount() {
 		analytics.tracks.recordEvent( 'calypso_signup_start', {
@@ -178,7 +179,7 @@ const Signup = React.createClass( {
 		this.checkForCartItems( this.props.signupDependencies );
 
 		this.recordStep();
-	},
+	}
 
 	componentWillReceiveProps( { signupDependencies, stepName } ) {
 		if ( this.props.stepName !== stepName ) {
@@ -190,9 +191,9 @@ const Signup = React.createClass( {
 		}
 
 		this.checkForCartItems( signupDependencies );
-	},
+	}
 
-	checkForCartItems( signupDependencies ) {
+	checkForCartItems = signupDependencies => {
 		const dependenciesContainCartItem = ( dependencies ) => {
 			return dependencies && ( dependencies.cartItem || dependencies.domainItem || dependencies.themeItem );
 		};
@@ -200,13 +201,13 @@ const Signup = React.createClass( {
 		if ( dependenciesContainCartItem( signupDependencies ) ) {
 			this.setState( { hasCartItems: true } );
 		}
-	},
+	};
 
-	recordStep( stepName = this.props.stepName ) {
+	recordStep = ( stepName = this.props.stepName ) => {
 		analytics.tracks.recordEvent( 'calypso_signup_step_start', { flow: this.props.flowName, step: stepName } );
-	},
+	};
 
-	handleFlowComplete( dependencies, destination ) {
+	handleFlowComplete = ( dependencies, destination ) => {
 		debug( 'The flow is completed. Logging you in...' );
 
 		analytics.tracks.recordEvent( 'calypso_signup_complete', { flow: this.props.flowName } );
@@ -220,9 +221,9 @@ const Signup = React.createClass( {
 				loginHandler: this.handleLogin.bind( this, dependencies, destination )
 			} );
 		}
-	},
+	};
 
-	handleLogin( dependencies, destination, event ) {
+	handleLogin = ( dependencies, destination, event ) => {
 		const userIsLoggedIn = Boolean( user.get() );
 
 		if ( event && event.redirectTo ) {
@@ -249,20 +250,20 @@ const Signup = React.createClass( {
 				redirectTo: this.loginRedirectTo( destination )
 			} );
 		}
-	},
+	};
 
 	componentDidMount() {
 		debug( 'Signup component mounted' );
 		SignupProgressStore.on( 'change', this.loadProgressFromStore );
 		this.props.loadTrackingTool( 'HotJar' );
-	},
+	}
 
 	componentWillUnmount() {
 		debug( 'Signup component unmounted' );
 		SignupProgressStore.off( 'change', this.loadProgressFromStore );
-	},
+	}
 
-	loginRedirectTo( path ) {
+	loginRedirectTo = path => {
 		let redirectTo;
 
 		if ( startsWith( path, 'https://' ) || startsWith( path, 'http://' ) ) {
@@ -275,9 +276,9 @@ const Signup = React.createClass( {
 			redirectTo += ':' + window.location.port;
 		}
 		return redirectTo + path;
-	},
+	};
 
-	firstUnsubmittedStepName() {
+	firstUnsubmittedStepName = () => {
 		const currentSteps = flows.getFlow( this.props.flowName ).steps,
 			signupProgress = filter(
 				SignupProgressStore.get(),
@@ -288,9 +289,9 @@ const Signup = React.createClass( {
 			firstInProgressStepName = firstInProgressStep.stepName;
 
 		return firstInProgressStepName || nextStepName || last( currentSteps );
-	},
+	};
 
-	resumeProgress() {
+	resumeProgress = () => {
 		// Update the Flows object to know that the signup flow is being resumed.
 		flows.resumingFlow = true;
 
@@ -306,9 +307,9 @@ const Signup = React.createClass( {
 			stepSectionName,
 			this.props.locale
 		) );
-	},
+	};
 
-	goToStep( stepName, stepSectionName ) {
+	goToStep = ( stepName, stepSectionName ) => {
 		if ( this.state.scrolling ) {
 			return;
 		}
@@ -335,9 +336,9 @@ const Signup = React.createClass( {
 				this.goToFirstInvalidStep();
 			}
 		} );
-	},
+	};
 
-	goToNextStep() {
+	goToNextStep = () => {
 		const flowSteps = flows.getFlow( this.props.flowName, this.props.stepName ).steps,
 			currentStepIndex = indexOf( flowSteps, this.props.stepName ),
 			nextStepName = flowSteps[ currentStepIndex + 1 ],
@@ -345,9 +346,9 @@ const Signup = React.createClass( {
 			nextStepSection = nextProgressItem && nextProgressItem.stepSectionName || '';
 
 		this.goToStep( nextStepName, nextStepSection );
-	},
+	};
 
-	goToFirstInvalidStep() {
+	goToFirstInvalidStep = () => {
 		const firstInvalidStep = find( SignupProgressStore.get(), { status: 'invalid' } );
 
 		if ( firstInvalidStep ) {
@@ -363,9 +364,9 @@ const Signup = React.createClass( {
 
 			page( utils.getStepUrl( this.props.flowName, firstInvalidStep.stepName, this.props.locale ) );
 		}
-	},
+	};
 
-	isEveryStepSubmitted() {
+	isEveryStepSubmitted = () => {
 		const flowSteps = flows.getFlow( this.props.flowName ).steps;
 		const signupProgress = filter(
 				SignupProgressStore.get(),
@@ -376,33 +377,33 @@ const Signup = React.createClass( {
 			);
 
 		return flowSteps.length === signupProgress.length;
-	},
+	};
 
-	positionInFlow() {
+	positionInFlow = () => {
 		return indexOf( flows.getFlow( this.props.flowName ).steps, this.props.stepName );
-	},
+	};
 
-	localeSuggestions() {
+	localeSuggestions = () => {
 		return 0 === this.positionInFlow() && ! user.get()
 			? <LocaleSuggestions path={ this.props.path } locale={ this.props.locale } />
 			: null;
-	},
+	};
 
-	loginForm() {
+	loginForm = () => {
 		return this.state.bearerToken
 			? <WpcomLoginForm
 				authorization={ 'Bearer ' + this.state.bearerToken }
 				log={ this.state.username }
 				redirectTo={ this.state.redirectTo } />
 			: null;
-	},
+	};
 
-	pageTitle() {
+	pageTitle = () => {
 		const accountFlowName = 'account';
 		return this.props.flowName === accountFlowName ? translate( 'Create an account' ) : translate( 'Create a site' );
-	},
+	};
 
-	currentStep() {
+	currentStep = () => {
 		const currentStepProgress = find( this.state.progress, { stepName: this.props.stepName } ),
 			CurrentComponent = stepComponents[ this.props.stepName ],
 			propsFromConfig = assign( {}, this.props, steps[ this.props.stepName ].props ),
@@ -446,7 +447,7 @@ const Signup = React.createClass( {
 				}
 			</div>
 		);
-	},
+	};
 
 	render() {
 		if ( ! this.props.stepName ||
@@ -478,7 +479,7 @@ const Signup = React.createClass( {
 			</span>
 		);
 	}
-} );
+}
 
 export default connect(
 	state => ( {

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -1,8 +1,11 @@
+import debugModule from 'debug';
+const debug = debugModule( 'calypso:signup' );
+
 /**
  * External dependencies
  */
-import debugModule from 'debug';
-const debug = debugModule( 'calypso:signup' );
+import PropTypes from 'prop-types';
+
 import React from 'react';
 import { connect } from 'react-redux';
 import ReactCSSTransitionGroup from 'react-addons-css-transition-group';
@@ -48,7 +51,7 @@ class Signup extends React.Component {
 	static displayName = 'Signup';
 
 	static contextTypes = {
-		store: React.PropTypes.object
+		store: PropTypes.object
 	};
 
 	constructor( props, context ) {

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -1,16 +1,14 @@
-import debugModule from 'debug';
-const debug = debugModule( 'calypso:signup' );
-
 /**
  * External dependencies
  */
 import PropTypes from 'prop-types';
 
-import React from 'react';
-import { connect } from 'react-redux';
-import ReactCSSTransitionGroup from 'react-addons-css-transition-group';
+import debugModule from 'debug';
 import page from 'page';
+import React from 'react';
+import ReactCSSTransitionGroup from 'react-addons-css-transition-group';
 import { assign, defer, delay, filter, find, indexOf, last, matchesProperty, pick, some, startsWith } from 'lodash';
+import { connect } from 'react-redux';
 import { setSurvey } from 'state/signup/steps/survey/actions';
 
 /**
@@ -28,7 +26,6 @@ import stepComponents from './config/step-components';
 import flows from './config/flows';
 import WpcomLoginForm from './wpcom-login-form';
 import userModule from 'lib/user';
-const user = userModule();
 import analytics from 'lib/analytics';
 import SignupProcessingScreen from 'signup/processing-screen';
 import utils from './utils';
@@ -45,8 +42,9 @@ import { loadTrackingTool } from 'state/analytics/actions';
 /**
  * Constants
  */
+const debug = debugModule( 'calypso:signup' );
 const MINIMUM_TIME_LOADING_SCREEN_IS_DISPLAYED = 3000;
-
+const user = userModule();
 class Signup extends React.Component {
 	static displayName = 'Signup';
 

--- a/client/signup/navigation-link/index.jsx
+++ b/client/signup/navigation-link/index.jsx
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import { localize, getLocaleSlug } from 'i18n-calypso';
 import { find, findIndex, get } from 'lodash';
 import Gridicon from 'gridicons';

--- a/client/signup/step-wrapper/index.jsx
+++ b/client/signup/step-wrapper/index.jsx
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
 

--- a/client/signup/steps/design-type-with-store/index.jsx
+++ b/client/signup/steps/design-type-with-store/index.jsx
@@ -212,7 +212,6 @@ class DesignTypeWithStoreStep extends Component {
 	}
 }
 
-
 export default connect(
 	null,
 	{

--- a/client/signup/steps/design-type-with-store/pressable-store/index.jsx
+++ b/client/signup/steps/design-type-with-store/pressable-store/index.jsx
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { PropTypes, Component } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import EmailValidator from 'email-validator';
 import { connect } from 'react-redux';
 import { invoke } from 'lodash';

--- a/client/signup/steps/design-type/index.jsx
+++ b/client/signup/steps/design-type/index.jsx
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { identity, memoize, transform } from 'lodash';

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -31,8 +31,8 @@ import {
 import { getCurrentUser, currentUserHasFlag } from 'state/current-user/selectors';
 import Notice from 'components/notice';
 
-const DomainsStep = React.createClass( {
-	propTypes: {
+class DomainsStep extends React.Component {
+	static propTypes = {
 		domainsWithPlansOnly: PropTypes.bool,
 		flowName: PropTypes.string.isRequired,
 		goToNextStep: PropTypes.func.isRequired,
@@ -45,37 +45,35 @@ const DomainsStep = React.createClass( {
 		step: PropTypes.object,
 		stepName: PropTypes.string.isRequired,
 		stepSectionName: PropTypes.string,
-	},
+	};
 
-	contextTypes: {
+	static contextTypes = {
 		store: PropTypes.object
-	},
+	};
 
-	showDomainSearch: function() {
+	state = { products: productsList.get() };
+
+	showDomainSearch = () => {
 		page( signupUtils.getStepUrl( this.props.flowName, this.props.stepName, this.props.locale ) );
-	},
+	};
 
-	getMapDomainUrl: function() {
+	getMapDomainUrl = () => {
 		return signupUtils.getStepUrl( this.props.flowName, this.props.stepName, 'mapping', this.props.locale );
-	},
+	};
 
-	getInitialState: function() {
-		return { products: productsList.get() };
-	},
-
-	componentDidMount: function() {
+	componentDidMount() {
 		productsList.on( 'change', this.refreshState );
-	},
+	}
 
-	componentWillUnmount: function() {
+	componentWillUnmount() {
 		productsList.off( 'change', this.refreshState );
-	},
+	}
 
-	refreshState: function() {
+	refreshState = () => {
 		this.setState( { products: productsList.get() } );
-	},
+	};
 
-	handleAddDomain: function( suggestion ) {
+	handleAddDomain = suggestion => {
 		const stepData = {
 			stepName: this.props.stepName,
 			suggestion,
@@ -88,17 +86,17 @@ const DomainsStep = React.createClass( {
 		defer( () => {
 			this.submitWithDomain();
 		} );
-	},
+	};
 
-	isPurchasingTheme: function() {
+	isPurchasingTheme = () => {
 		return this.props.queryObject && this.props.queryObject.premium;
-	},
+	};
 
-	getThemeSlug: function() {
+	getThemeSlug = () => {
 		return this.props.queryObject ? this.props.queryObject.theme : undefined;
-	},
+	};
 
-	getThemeArgs: function() {
+	getThemeArgs = () => {
 		const themeSlug = this.getThemeSlug(),
 			themeSlugWithRepo = this.getThemeSlugWithRepo( themeSlug ),
 			themeItem = this.isPurchasingTheme()
@@ -106,17 +104,17 @@ const DomainsStep = React.createClass( {
 			: undefined;
 
 		return { themeSlug, themeSlugWithRepo, themeItem };
-	},
+	};
 
-	getThemeSlugWithRepo: function( themeSlug ) {
+	getThemeSlugWithRepo = themeSlug => {
 		if ( ! themeSlug ) {
 			return undefined;
 		}
 		const repo = this.isPurchasingTheme() ? 'premium' : 'pub';
 		return `${ repo }/${ themeSlug }`;
-	},
+	};
 
-	submitWithDomain: function( googleAppsCartItem ) {
+	submitWithDomain = googleAppsCartItem => {
 		const suggestion = this.props.step.suggestion,
 			isPurchasingItem = Boolean( suggestion.product_slug ),
 			siteUrl = isPurchasingItem
@@ -145,9 +143,9 @@ const DomainsStep = React.createClass( {
 
 		// Start the username suggestion process.
 		getUsernameSuggestion( siteUrl.split( '.' )[ 0 ], this.context.store );
-	},
+	};
 
-	handleAddMapping: function( sectionName, domain, state ) {
+	handleAddMapping = ( sectionName, domain, state ) => {
 		const domainItem = cartItems.domainMapping( { domain } );
 		const isPurchasingItem = true;
 
@@ -164,17 +162,17 @@ const DomainsStep = React.createClass( {
 		}, this.getThemeArgs() ) );
 
 		this.props.goToNextStep();
-	},
+	};
 
-	handleSave: function( sectionName, state ) {
+	handleSave = ( sectionName, state ) => {
 		SignupActions.saveSignupStep( {
 			stepName: this.props.stepName,
 			stepSectionName: this.props.stepSectionName,
 			[ sectionName ]: state,
 		} );
-	},
+	};
 
-	domainForm: function() {
+	domainForm = () => {
 		const initialState = this.props.step ? this.props.step.domainForm : this.state.domainForm;
 		const includeDotBlogSubdomain = ( this.props.flowName === 'subdomain' );
 
@@ -200,9 +198,9 @@ const DomainsStep = React.createClass( {
 				designType={ this.props.signupDependencies && this.props.signupDependencies.designType }
 			/>
 		);
-	},
+	};
 
-	mappingForm: function() {
+	mappingForm = () => {
 		const initialState = this.props.step ? this.props.step.mappingForm : undefined,
 			initialQuery = this.props.step && this.props.step.domainForm && this.props.step.domainForm.lastQuery;
 
@@ -221,9 +219,9 @@ const DomainsStep = React.createClass( {
 				/>
 			</div>
 		);
-	},
+	};
 
-	render: function() {
+	render() {
 		let content;
 		const { translate } = this.props;
 		const backUrl = this.props.stepSectionName
@@ -265,7 +263,7 @@ const DomainsStep = React.createClass( {
 			/>
 		);
 	}
-} );
+}
 
 const submitDomainStepSelection = ( suggestion, section ) => {
 	let domainType = 'domain_reg';

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -12,7 +12,8 @@ import { localize, getLocaleSlug } from 'i18n-calypso';
  * Internal dependencies
  */
 import StepWrapper from 'signup/step-wrapper';
-const productsList = require( 'lib/products-list' )();
+import productsListFactory from 'lib/products-list';
+const productsList = productsListFactory();
 import { cartItems } from 'lib/cart-values';
 import SignupActions from 'lib/signup/actions';
 import MapDomainStep from 'components/domains/map-domain-step';

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -2,25 +2,24 @@
  * External dependencies
  */
 import React from 'react';
+import page from 'page';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { defer, endsWith } from 'lodash';
-import page from 'page';
 import { localize, getLocaleSlug } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
-import StepWrapper from 'signup/step-wrapper';
-import productsListFactory from 'lib/products-list';
-const productsList = productsListFactory();
-import { cartItems } from 'lib/cart-values';
-import SignupActions from 'lib/signup/actions';
 import MapDomainStep from 'components/domains/map-domain-step';
+import productsListFactory from 'lib/products-list';
 import RegisterDomainStep from 'components/domains/register-domain-step';
+import SignupActions from 'lib/signup/actions';
+import signupUtils from 'signup/utils';
+import StepWrapper from 'signup/step-wrapper';
+import { cartItems } from 'lib/cart-values';
 import { DOMAINS_WITH_PLANS_ONLY } from 'state/current-user/constants';
 import { getSurveyVertical } from 'state/signup/steps/survey/selectors.js';
-import signupUtils from 'signup/utils';
 import { getUsernameSuggestion } from 'lib/signup/step-actions';
 import { recordAddDomainButtonClick, recordAddDomainButtonClickInMapDomain } from 'state/domains/actions';
 import {
@@ -30,6 +29,8 @@ import {
 } from 'state/analytics/actions';
 import { getCurrentUser, currentUserHasFlag } from 'state/current-user/selectors';
 import Notice from 'components/notice';
+
+const productsList = productsListFactory();
 
 class DomainsStep extends React.Component {
 	static propTypes = {

--- a/client/signup/steps/get-dot-blog-plans/index.jsx
+++ b/client/signup/steps/get-dot-blog-plans/index.jsx
@@ -1,9 +1,13 @@
-// External dependencies
+/**
+ * External dependencies
+ */
 import PropTypes from 'prop-types';
 
 import React from 'react';
 
-// Internal dependencies
+/**
+ * Internal dependencies
+ */
 import { cartItems } from 'lib/cart-values';
 import PlansStep from 'signup/steps/plans';
 

--- a/client/signup/steps/get-dot-blog-plans/index.jsx
+++ b/client/signup/steps/get-dot-blog-plans/index.jsx
@@ -1,5 +1,7 @@
 // External dependencies
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 
 // Internal dependencies
 import { cartItems } from 'lib/cart-values';

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -1,8 +1,11 @@
+import { connect } from 'react-redux';
+
 /**
  * External dependencies
  */
-import { connect } from 'react-redux';
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import { isEmpty } from 'lodash';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';

--- a/client/signup/steps/site-title/index.jsx
+++ b/client/signup/steps/site-title/index.jsx
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import { connect } from 'react-redux';
 
 /**

--- a/client/signup/steps/site-title/index.jsx
+++ b/client/signup/steps/site-title/index.jsx
@@ -17,17 +17,17 @@ import { setSiteTitle } from 'state/signup/steps/site-title/actions';
 
 import { translate } from 'i18n-calypso';
 
-const SiteTitleStep = React.createClass( {
-	propTypes: {
+class SiteTitleStep extends React.Component {
+	static propTypes = {
 		flowName: PropTypes.string,
 		goToNextStep: PropTypes.func.isRequired,
 		positionInFlow: PropTypes.number,
 		setSiteTitle: PropTypes.func.isRequired,
 		signupProgress: PropTypes.array,
 		stepName: PropTypes.string,
-	},
+	};
 
-	submitSiteTitleStep( siteTitle ) {
+	submitSiteTitleStep = siteTitle => {
 		this.props.setSiteTitle( siteTitle );
 
 		SignupActions.submitSignupStep( {
@@ -37,13 +37,13 @@ const SiteTitleStep = React.createClass( {
 		}, [], { siteTitle } );
 
 		this.props.goToNextStep();
-	},
+	};
 
-	skipStep() {
+	skipStep = () => {
 		this.submitSiteTitleStep( '' );
-	},
+	};
 
-	renderSiteTitleStep() {
+	renderSiteTitleStep = () => {
 		return (
 			<div>
 				<SignupSiteTitle
@@ -52,7 +52,8 @@ const SiteTitleStep = React.createClass( {
 				<SiteTitleExample />
 			</div>
 		);
-	},
+	};
+
 	render() {
 		const headerText = translate( 'Give your new site a name.' );
 		const subHeaderText = translate( 'Enter a Site Title that will be displayed for visitors. You can always change this later.' );
@@ -74,7 +75,7 @@ const SiteTitleStep = React.createClass( {
 			</div>
 		);
 	}
-} );
+}
 
 export default connect(
 	null,

--- a/client/signup/steps/site/index.jsx
+++ b/client/signup/steps/site/index.jsx
@@ -5,7 +5,6 @@ import React from 'react';
 import { localize } from 'i18n-calypso';
 import { includes, isEmpty, map } from 'lodash';
 import debugFactory from 'debug';
-const debug = debugFactory( 'calypso:steps:site' ); // eslint-disable-line no-unused-vars
 
 /**
  * Internal dependencies
@@ -23,6 +22,8 @@ import FormTextInput from 'components/forms/form-text-input';
 import StepWrapper from 'signup/step-wrapper';
 import LoggedOutForm from 'components/logged-out-form';
 import LoggedOutFormFooter from 'components/logged-out-form/footer';
+
+const debug = debugFactory( 'calypso:steps:site' );
 
 /**
  * Constants

--- a/client/signup/steps/site/index.jsx
+++ b/client/signup/steps/site/index.jsx
@@ -33,7 +33,7 @@ const VALIDATION_DELAY_AFTER_FIELD_CHANGES = 1500;
 let siteUrlsSearched = [],
 	timesValidationFailed = 0;
 
-module.exports = React.createClass( {
+export default React.createClass( {
 	displayName: 'Site',
 
 	getInitialState: function() {

--- a/client/signup/steps/site/index.jsx
+++ b/client/signup/steps/site/index.jsx
@@ -34,17 +34,15 @@ const VALIDATION_DELAY_AFTER_FIELD_CHANGES = 1500;
 let siteUrlsSearched = [],
 	timesValidationFailed = 0;
 
-export default localize( React.createClass( {
-	displayName: 'Site',
+export default localize( class extends React.Component {
+	static displayName = 'Site';
 
-	getInitialState: function() {
-		return {
-			form: null,
-			submitting: false
-		};
-	},
+	state = {
+		form: null,
+		submitting: false
+	};
 
-	componentWillMount: function() {
+	componentWillMount() {
 		let initialState;
 
 		if ( this.props.step && this.props.step.form ) {
@@ -69,27 +67,27 @@ export default localize( React.createClass( {
 		} );
 
 		this.setState( { form: this.formStateController.getInitialState() } );
-	},
+	}
 
-	componentWillUnmount: function() {
+	componentWillUnmount() {
 		this.save();
-	},
+	}
 
-	sanitizeSubdomain: function( domain ) {
+	sanitizeSubdomain = domain => {
 		if ( ! domain ) {
 			return domain;
 		}
 		return domain.replace( /[^a-zA-Z0-9]/g, '' ).toLowerCase();
-	},
+	};
 
-	sanitize: function( fields, onComplete ) {
+	sanitize = ( fields, onComplete ) => {
 		const sanitizedSubdomain = this.sanitizeSubdomain( fields.site );
 		if ( fields.site !== sanitizedSubdomain ) {
 			onComplete( { site: sanitizedSubdomain } );
 		}
-	},
+	};
 
-	validate: function( fields, onComplete ) {
+	validate = ( fields, onComplete ) => {
 		wpcom.undocumented().sitesNew( {
 			blog_name: fields.site,
 			blog_title: fields.site,
@@ -117,18 +115,18 @@ export default localize( React.createClass( {
 			}
 			onComplete( null, messages );
 		} );
-	},
+	};
 
-	setFormState: function( state ) {
+	setFormState = state => {
 		this.setState( { form: state } );
-	},
+	};
 
-	resetAnalyticsData: function() {
+	resetAnalyticsData = () => {
 		siteUrlsSearched = [];
 		timesValidationFailed = 0;
-	},
+	};
 
-	handleSubmit: function( event ) {
+	handleSubmit = event => {
 		event.preventDefault();
 
 		this.setState( { submitting: true } );
@@ -158,35 +156,35 @@ export default localize( React.createClass( {
 
 			this.props.goToNextStep();
 		}.bind( this ) );
-	},
+	};
 
-	handleBlur: function() {
+	handleBlur = () => {
 		this.formStateController.sanitize();
 		this.formStateController.validate();
 		this.save();
-	},
+	};
 
-	save: function() {
+	save = () => {
 		SignupActions.saveSignupStep( {
 			stepName: 'site',
 			form: this.state.form
 		} );
-	},
+	};
 
-	handleChangeEvent: function( event ) {
+	handleChangeEvent = event => {
 		this.formStateController.handleFieldChange( {
 			name: event.target.name,
 			value: event.target.value
 		} );
-	},
+	};
 
-	handleFormControllerError: function( error ) {
+	handleFormControllerError = error => {
 		if ( error ) {
 			throw error;
 		}
-	},
+	};
 
-	getErrorMessagesWithLogin( fieldName ) {
+	getErrorMessagesWithLogin = fieldName => {
 		const link = login( { isNative: config.isEnabled( 'login/native-login-links' ), redirectTo: window.location.href } ),
 			messages = formState.getFieldErrorMessages( this.state.form, fieldName );
 
@@ -211,9 +209,9 @@ export default localize( React.createClass( {
 			}
 			return message;
 		}.bind( this ) );
-	},
+	};
 
-	formFields: function() {
+	formFields = () => {
 		const fieldDisabled = this.state.submitting;
 
 		return (
@@ -236,9 +234,9 @@ export default localize( React.createClass( {
 				<span className="site-signup-step__wordpress-domain-suffix">.wordpress.com</span>
 			</ValidationFieldset>
 		);
-	},
+	};
 
-	buttonText: function() {
+	buttonText = () => {
 		if ( this.props.step && 'completed' === this.props.step.status ) {
 			return this.props.translate( 'Site created - Go to next step' );
 		}
@@ -248,13 +246,13 @@ export default localize( React.createClass( {
 		}
 
 		return this.props.translate( 'Create My Site' );
-	},
+	};
 
-	formFooter: function() {
+	formFooter = () => {
 		return <FormButton>{ this.buttonText() }</FormButton>;
-	},
+	};
 
-	renderSiteForm: function() {
+	renderSiteForm = () => {
 		return (
 			<LoggedOutForm onSubmit={ this.handleSubmit } noValidate >
 				{ this.formFields() }
@@ -264,9 +262,9 @@ export default localize( React.createClass( {
 				</LoggedOutFormFooter>
 			</LoggedOutForm>
 		);
-	},
+	};
 
-	render: function() {
+	render() {
 		return (
 		    <StepWrapper
 				flowName={ this.props.flowName }
@@ -277,4 +275,4 @@ export default localize( React.createClass( {
 				stepContent={ this.renderSiteForm() } />
 		);
 	}
-} ) );
+} );

--- a/client/signup/steps/site/index.jsx
+++ b/client/signup/steps/site/index.jsx
@@ -3,7 +3,8 @@
  */
 import React from 'react';
 import { includes, isEmpty, map } from 'lodash';
-const debug = require( 'debug' )( 'calypso:steps:site' ); // eslint-disable-line no-unused-vars
+import debugFactory from 'debug';
+const debug = debugFactory( 'calypso:steps:site' ); // eslint-disable-line no-unused-vars
 /**
  * Internal dependencies
  */
@@ -24,12 +25,12 @@ import LoggedOutFormFooter from 'components/logged-out-form/footer';
 /**
  * Constants
  */
-var VALIDATION_DELAY_AFTER_FIELD_CHANGES = 1500;
+const VALIDATION_DELAY_AFTER_FIELD_CHANGES = 1500;
 
 /**
  * Module variables
  */
-var siteUrlsSearched = [],
+let siteUrlsSearched = [],
 	timesValidationFailed = 0;
 
 module.exports = React.createClass( {
@@ -43,7 +44,7 @@ module.exports = React.createClass( {
 	},
 
 	componentWillMount: function() {
-		var initialState;
+		let initialState;
 
 		if ( this.props.step && this.props.step.form ) {
 			initialState = this.props.step.form;
@@ -81,7 +82,7 @@ module.exports = React.createClass( {
 	},
 
 	sanitize: function( fields, onComplete ) {
-		var sanitizedSubdomain = this.sanitizeSubdomain( fields.site );
+		const sanitizedSubdomain = this.sanitizeSubdomain( fields.site );
 		if ( fields.site !== sanitizedSubdomain ) {
 			onComplete( { site: sanitizedSubdomain } );
 		}
@@ -93,7 +94,7 @@ module.exports = React.createClass( {
 			blog_title: fields.site,
 			validate: true
 		}, function( error, response ) {
-			var messages = {},
+			let messages = {},
 				errorObject = {};
 
 			debug( error, response );
@@ -132,7 +133,7 @@ module.exports = React.createClass( {
 		this.setState( { submitting: true } );
 
 		this.formStateController.handleSubmit( function( hasErrors ) {
-			var site = formState.getFieldValue( this.state.form, 'site' );
+			const site = formState.getFieldValue( this.state.form, 'site' );
 
 			this.setState( { submitting: false } );
 
@@ -212,7 +213,7 @@ module.exports = React.createClass( {
 	},
 
 	formFields: function() {
-		var fieldDisabled = this.state.submitting;
+		const fieldDisabled = this.state.submitting;
 
 		return <ValidationFieldset errorMessages={ this.getErrorMessagesWithLogin( 'site' ) }>
 			<FormLabel htmlFor="site">
@@ -221,16 +222,16 @@ module.exports = React.createClass( {
 			<FormTextInput
 				autoFocus={ true }
 				autoCapitalize={ 'off' }
-				className='site-signup-step__site-url'
+				className="site-signup-step__site-url"
 				disabled={ fieldDisabled }
-				type='text'
-				name='site'
+				type="text"
+				name="site"
 				value={ formState.getFieldValue( this.state.form, 'site' ) }
 				isError={ formState.isFieldInvalid( this.state.form, 'site' ) }
 				isValid={ formState.isFieldValid( this.state.form, 'site' ) }
 				onBlur={ this.handleBlur }
 				onChange={ this.handleChangeEvent } />
-			<span className='site-signup-step__wordpress-domain-suffix'>.wordpress.com</span>
+			<span className="site-signup-step__wordpress-domain-suffix">.wordpress.com</span>
 		</ValidationFieldset>;
 	},
 

--- a/client/signup/steps/site/index.jsx
+++ b/client/signup/steps/site/index.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react';
+import { localize } from 'i18n-calypso';
 import { includes, isEmpty, map } from 'lodash';
 import debugFactory from 'debug';
 const debug = debugFactory( 'calypso:steps:site' ); // eslint-disable-line no-unused-vars
@@ -33,7 +34,7 @@ const VALIDATION_DELAY_AFTER_FIELD_CHANGES = 1500;
 let siteUrlsSearched = [],
 	timesValidationFailed = 0;
 
-export default React.createClass( {
+export default localize( React.createClass( {
 	displayName: 'Site',
 
 	getInitialState: function() {
@@ -149,7 +150,7 @@ export default React.createClass( {
 			this.resetAnalyticsData();
 
 			SignupActions.submitSignupStep( {
-				processingMessage: this.translate( 'Setting up your site' ),
+				processingMessage: this.props.translate( 'Setting up your site' ),
 				stepName: this.props.stepName,
 				form: this.state.form,
 				site
@@ -196,10 +197,10 @@ export default React.createClass( {
 		return map( messages, function( message, error_code ) {
 			if ( error_code === 'blog_name_reserved' ) {
 				return (
-					<span>
+				    <span>
 						<p>
 							{ message }&nbsp;
-							{ this.translate( 'Is this your username? {{a}}Log in now to claim this site address{{/a}}.', {
+							{ this.props.translate( 'Is this your username? {{a}}Log in now to claim this site address{{/a}}.', {
 								components: {
 									a: <a href={ link } />
 								}
@@ -215,36 +216,38 @@ export default React.createClass( {
 	formFields: function() {
 		const fieldDisabled = this.state.submitting;
 
-		return <ValidationFieldset errorMessages={ this.getErrorMessagesWithLogin( 'site' ) }>
-			<FormLabel htmlFor="site">
-				{ this.translate( 'Choose a site address' ) }
-			</FormLabel>
-			<FormTextInput
-				autoFocus={ true }
-				autoCapitalize={ 'off' }
-				className="site-signup-step__site-url"
-				disabled={ fieldDisabled }
-				type="text"
-				name="site"
-				value={ formState.getFieldValue( this.state.form, 'site' ) }
-				isError={ formState.isFieldInvalid( this.state.form, 'site' ) }
-				isValid={ formState.isFieldValid( this.state.form, 'site' ) }
-				onBlur={ this.handleBlur }
-				onChange={ this.handleChangeEvent } />
-			<span className="site-signup-step__wordpress-domain-suffix">.wordpress.com</span>
-		</ValidationFieldset>;
+		return (
+		    <ValidationFieldset errorMessages={ this.getErrorMessagesWithLogin( 'site' ) }>
+				<FormLabel htmlFor="site">
+					{ this.props.translate( 'Choose a site address' ) }
+				</FormLabel>
+				<FormTextInput
+					autoFocus={ true }
+					autoCapitalize={ 'off' }
+					className="site-signup-step__site-url"
+					disabled={ fieldDisabled }
+					type="text"
+					name="site"
+					value={ formState.getFieldValue( this.state.form, 'site' ) }
+					isError={ formState.isFieldInvalid( this.state.form, 'site' ) }
+					isValid={ formState.isFieldValid( this.state.form, 'site' ) }
+					onBlur={ this.handleBlur }
+					onChange={ this.handleChangeEvent } />
+				<span className="site-signup-step__wordpress-domain-suffix">.wordpress.com</span>
+			</ValidationFieldset>
+		);
 	},
 
 	buttonText: function() {
 		if ( this.props.step && 'completed' === this.props.step.status ) {
-			return this.translate( 'Site created - Go to next step' );
+			return this.props.translate( 'Site created - Go to next step' );
 		}
 
 		if ( this.state.submitting ) {
-			return this.translate( 'Creating your site…' );
+			return this.props.translate( 'Creating your site…' );
 		}
 
-		return this.translate( 'Create My Site' );
+		return this.props.translate( 'Create My Site' );
 	},
 
 	formFooter: function() {
@@ -265,13 +268,13 @@ export default React.createClass( {
 
 	render: function() {
 		return (
-			<StepWrapper
+		    <StepWrapper
 				flowName={ this.props.flowName }
 				stepName={ this.props.stepName }
 				positionInFlow={ this.props.positionInFlow }
-				fallbackHeaderText={ this.translate( 'Create your site.' ) }
+				fallbackHeaderText={ this.props.translate( 'Create your site.' ) }
 				signupProgress={ this.props.signupProgress }
 				stepContent={ this.renderSiteForm() } />
 		);
 	}
-} );
+} ) );

--- a/client/signup/steps/site/index.jsx
+++ b/client/signup/steps/site/index.jsx
@@ -6,6 +6,7 @@ import { localize } from 'i18n-calypso';
 import { includes, isEmpty, map } from 'lodash';
 import debugFactory from 'debug';
 const debug = debugFactory( 'calypso:steps:site' ); // eslint-disable-line no-unused-vars
+
 /**
  * Internal dependencies
  */
@@ -195,7 +196,7 @@ export default localize( class extends React.Component {
 		return map( messages, function( message, error_code ) {
 			if ( error_code === 'blog_name_reserved' ) {
 				return (
-				    <span>
+					<span>
 						<p>
 							{ message }&nbsp;
 							{ this.props.translate( 'Is this your username? {{a}}Log in now to claim this site address{{/a}}.', {
@@ -215,14 +216,14 @@ export default localize( class extends React.Component {
 		const fieldDisabled = this.state.submitting;
 
 		return (
-		    <ValidationFieldset errorMessages={ this.getErrorMessagesWithLogin( 'site' ) }>
+			<ValidationFieldset errorMessages={ this.getErrorMessagesWithLogin( 'site' ) }>
 				<FormLabel htmlFor="site">
 					{ this.props.translate( 'Choose a site address' ) }
 				</FormLabel>
 				<FormTextInput
 					autoFocus={ true }
 					autoCapitalize={ 'off' }
-					className="site-signup-step__site-url"
+					className="site__site-url"
 					disabled={ fieldDisabled }
 					type="text"
 					name="site"
@@ -231,7 +232,7 @@ export default localize( class extends React.Component {
 					isValid={ formState.isFieldValid( this.state.form, 'site' ) }
 					onBlur={ this.handleBlur }
 					onChange={ this.handleChangeEvent } />
-				<span className="site-signup-step__wordpress-domain-suffix">.wordpress.com</span>
+				<span className="site__wordpress-domain-suffix">.wordpress.com</span>
 			</ValidationFieldset>
 		);
 	};
@@ -266,7 +267,7 @@ export default localize( class extends React.Component {
 
 	render() {
 		return (
-		    <StepWrapper
+			<StepWrapper
 				flowName={ this.props.flowName }
 				stepName={ this.props.stepName }
 				positionInFlow={ this.props.positionInFlow }

--- a/client/signup/steps/site/style.scss
+++ b/client/signup/steps/site/style.scss
@@ -1,8 +1,8 @@
-.site-signup-step__site-url.form-text-input {
+.site_site-url.form-text-input {
 	padding-right: 122px;
 }
 
-.site-signup-step__wordpress-domain-suffix {
+.site__wordpress-domain-suffix {
 	color: $gray;
 	line-height: 40px;
 	margin-left: -122px;

--- a/client/signup/steps/survey/index.jsx
+++ b/client/signup/steps/survey/index.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React, { PropTypes } from 'react';
+import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
 import page from 'page';
 import { find, get } from 'lodash';
@@ -68,25 +69,25 @@ const SurveyStep = React.createClass( {
 	renderOther() {
 		const otherWriteIn = this.getOtherWriteIn();
 		return (
-			<div className="survey__other">
+		    <div className="survey__other">
 				<FormTextInputWithAction
-					action={ this.translate( 'Continue' ) }
+					action={ this.props.translate( 'Continue' ) }
 					defaultValue={ otherWriteIn }
-					placeholder={ this.translate( 'Please describe what your site is about' ) }
+					placeholder={ this.props.translate( 'Please describe what your site is about' ) }
 					onAction={ this.handleVerticalOther }
 					onChange={ this.handleOtherWriteIn }
 				/>
-				<p className="survey__other-copy">{ this.translate( 'e.g. ’yoga’, ‘classic cars’' ) }</p>
+				<p className="survey__other-copy">{ this.props.translate( 'e.g. ’yoga’, ‘classic cars’' ) }</p>
 			</div>
 		);
 	},
 
 	renderOptionList() {
 		return (
-			<div className="survey__verticals-list">
+		    <div className="survey__verticals-list">
 				{ this.state.verticalList.map( this.renderVertical ) }
 				<Button className="survey__vertical" onClick={ this.handleOther }>
-					<span className="survey__vertical-label">{ this.translate( 'Other' ) }</span>
+					<span className="survey__vertical-label">{ this.props.translate( 'Other' ) }</span>
 					<Gridicon className="survey__vertical-chevron" icon="chevron-right" />
 				</Button>
 			</div>
@@ -94,10 +95,10 @@ const SurveyStep = React.createClass( {
 	},
 
 	render() {
-		const blogHeaderText = this.translate( 'Let\'s create your new WordPress.com blog!' );
-		const siteHeaderText = this.translate( 'Let\'s create your new WordPress.com site!' );
-		const blogSubHeaderText = this.translate( 'To get started, tell us what your blog is about.' );
-		const siteSubHeaderText = this.translate( 'To get started, tell us what your blog or website is about.' );
+		const blogHeaderText = this.props.translate( 'Let\'s create your new WordPress.com blog!' );
+		const siteHeaderText = this.props.translate( 'Let\'s create your new WordPress.com site!' );
+		const blogSubHeaderText = this.props.translate( 'To get started, tell us what your blog is about.' );
+		const siteSubHeaderText = this.props.translate( 'To get started, tell us what your blog or website is about.' );
 
 		const backUrl = this.props.stepSectionName
 			? signupUtils.getStepUrl( this.props.flowName, this.props.stepName, undefined, this.props.locale )
@@ -173,4 +174,4 @@ const SurveyStep = React.createClass( {
 export default connect(
 	null,
 	{ setSurvey }
-)( SurveyStep );
+)( localize( SurveyStep ) );

--- a/client/signup/steps/survey/index.jsx
+++ b/client/signup/steps/survey/index.jsx
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
 import page from 'page';

--- a/client/signup/steps/survey/index.jsx
+++ b/client/signup/steps/survey/index.jsx
@@ -21,31 +21,27 @@ import FormTextInputWithAction from 'components/forms/form-text-input-with-actio
 
 import { setSurvey } from 'state/signup/steps/survey/actions';
 
-const SurveyStep = React.createClass( {
-	propTypes: {
+class SurveyStep extends React.Component {
+	static propTypes = {
 		surveySiteType: PropTypes.string,
 		setSurvey: PropTypes.func.isRequired,
-	},
+	};
 
-	getDefaultProps() {
-		return {
-			surveySiteType: 'site'
-		};
-	},
+	static defaultProps = {
+		surveySiteType: 'site'
+	};
 
-	getInitialState() {
-		return {
-			otherWriteIn: '',
-			verticalList: verticals.get(),
-		};
-	},
+	state = {
+		otherWriteIn: '',
+		verticalList: verticals.get(),
+	};
 
-	getOtherWriteIn() {
+	getOtherWriteIn = () => {
 		return this.state.otherWriteIn ||
 			get( find( this.props.signupProgress, { stepName: this.props.stepName } ), 'otherWriteIn', '' );
-	},
+	};
 
-	renderVertical( vertical ) {
+	renderVertical = vertical => {
 		return (
 			<Button
 				className="survey__vertical"
@@ -64,9 +60,9 @@ const SurveyStep = React.createClass( {
 				<Gridicon className="survey__vertical-chevron" icon="chevron-right" />
 			</Button>
 		);
-	},
+	};
 
-	renderOther() {
+	renderOther = () => {
 		const otherWriteIn = this.getOtherWriteIn();
 		return (
 		    <div className="survey__other">
@@ -80,9 +76,9 @@ const SurveyStep = React.createClass( {
 				<p className="survey__other-copy">{ this.props.translate( 'e.g. ’yoga’, ‘classic cars’' ) }</p>
 			</div>
 		);
-	},
+	};
 
-	renderOptionList() {
+	renderOptionList = () => {
 		return (
 		    <div className="survey__verticals-list">
 				{ this.state.verticalList.map( this.renderVertical ) }
@@ -92,7 +88,7 @@ const SurveyStep = React.createClass( {
 				</Button>
 			</div>
 		);
-	},
+	};
 
 	render() {
 		const blogHeaderText = this.props.translate( 'Let\'s create your new WordPress.com blog!' );
@@ -116,33 +112,33 @@ const SurveyStep = React.createClass( {
 					signupProgress={ this.props.signupProgress }
 					stepContent={ this.props.stepSectionName === 'other' ? this.renderOther() : this.renderOptionList() } />
 		);
-	},
+	}
 
-	handleVerticalButton( e ) {
+	handleVerticalButton = e => {
 		const { value, label } = e.target.dataset;
 		this.submitStep( label, value );
-	},
+	};
 
-	handleOther() {
+	handleOther = () => {
 		page( signupUtils.getStepUrl( this.props.flowName, this.props.stepName, 'other', this.props.locale ) );
-	},
+	};
 
-	handleVerticalOther( otherTextValue ) {
+	handleVerticalOther = otherTextValue => {
 		const otherText = otherTextValue.replace( /^\W+|\W+$/g, '' );
 		const otherWriteIn = otherText.length !== 0
 			? otherText
 			: undefined;
 
 		this.submitStep( 'Uncategorized', 'a8c.24', otherWriteIn );
-	},
+	};
 
-	handleOtherWriteIn( value ) {
+	handleOtherWriteIn = value => {
 		this.setState( {
 			otherWriteIn: value.replace( /^\W+|\W+$/g, '' ),
 		} );
-	},
+	};
 
-	submitStep( label, value, otherWriteIn = '' ) {
+	submitStep = ( label, value, otherWriteIn = '' ) => {
 		analytics.tracks.recordEvent( 'calypso_survey_site_type', { type: this.props.surveySiteType } );
 		analytics.tracks.recordEvent( 'calypso_survey_category_chosen', {
 			category_id: value,
@@ -168,8 +164,8 @@ const SurveyStep = React.createClass( {
 		);
 
 		this.props.goToNextStep();
-	}
-} );
+	};
+}
 
 export default connect(
 	null,

--- a/client/signup/steps/survey/index.jsx
+++ b/client/signup/steps/survey/index.jsx
@@ -67,7 +67,7 @@ class SurveyStep extends React.Component {
 	renderOther = () => {
 		const otherWriteIn = this.getOtherWriteIn();
 		return (
-		    <div className="survey__other">
+			<div className="survey__other">
 				<FormTextInputWithAction
 					action={ this.props.translate( 'Continue' ) }
 					defaultValue={ otherWriteIn }
@@ -82,7 +82,7 @@ class SurveyStep extends React.Component {
 
 	renderOptionList = () => {
 		return (
-		    <div className="survey__verticals-list">
+			<div className="survey__verticals-list">
 				{ this.state.verticalList.map( this.renderVertical ) }
 				<Button className="survey__vertical" onClick={ this.handleOther }>
 					<span className="survey__vertical-label">{ this.props.translate( 'Other' ) }</span>

--- a/client/signup/steps/test-step/index.jsx
+++ b/client/signup/steps/test-step/index.jsx
@@ -2,7 +2,8 @@
  * External dependencies
  */
 import React from 'react';
-const debug = require( 'debug' )( 'calypso:steps:test' );
+import debugFactory from 'debug';
+const debug = debugFactory( 'calypso:steps:test' );
 
 /**
  * Internal dependencies

--- a/client/signup/steps/test-step/index.jsx
+++ b/client/signup/steps/test-step/index.jsx
@@ -11,10 +11,10 @@ const debug = debugFactory( 'calypso:steps:test' );
 import StepWrapper from 'signup/step-wrapper';
 import SubmitStepButton from 'signup/submit-step-button';
 
-export default React.createClass( {
-	displayName: 'TestStep',
+export default class extends React.Component {
+	static displayName = 'TestStep';
 
-	render: function() {
+	render() {
 		debug( this.props.stepSectionName );
 
 		return (
@@ -34,4 +34,4 @@ export default React.createClass( {
 			</span>
 		);
 	}
-} );
+}

--- a/client/signup/steps/test-step/index.jsx
+++ b/client/signup/steps/test-step/index.jsx
@@ -11,7 +11,7 @@ const debug = debugFactory( 'calypso:steps:test' );
 import StepWrapper from 'signup/step-wrapper';
 import SubmitStepButton from 'signup/submit-step-button';
 
-module.exports = React.createClass( {
+export default React.createClass( {
 	displayName: 'TestStep',
 
 	render: function() {

--- a/client/signup/steps/theme-selection/index.jsx
+++ b/client/signup/steps/theme-selection/index.jsx
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { find, identity } from 'lodash';

--- a/client/signup/steps/theme-selection/signup-themes-list.jsx
+++ b/client/signup/steps/theme-selection/signup-themes-list.jsx
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import { identity, noop } from 'lodash';
 import { localize } from 'i18n-calypso';
 

--- a/client/signup/submit-step-button/index.jsx
+++ b/client/signup/submit-step-button/index.jsx
@@ -18,7 +18,7 @@ export default class SubmitStepButton extends Component {
 
 	render() {
 		return (
-			<button onClick={ this.handleSubmit } className='button is-primary'>
+			<button onClick={ this.handleSubmit } className="button is-primary">
 				{ this.props.buttonText }
 			</button>
 		);

--- a/client/signup/submit-step-button/index.jsx
+++ b/client/signup/submit-step-button/index.jsx
@@ -18,7 +18,7 @@ export default class SubmitStepButton extends Component {
 
 	render() {
 		return (
-			<button onClick={ this.handleSubmit } className="button is-primary">
+			<button onClick={ this.handleSubmit } className="submit-step-button button is-primary">
 				{ this.props.buttonText }
 			</button>
 		);

--- a/client/signup/test/lib/user/index.js
+++ b/client/signup/test/lib/user/index.js
@@ -2,7 +2,7 @@
  * User stub
  */
 
-var isLoggedIn = false;
+let isLoggedIn = false;
 
 export default function() {
 	return {
@@ -14,4 +14,4 @@ export default function() {
 			isLoggedIn = newIsLoggedIn;
 		}
 	};
-};
+}

--- a/client/signup/utils.js
+++ b/client/signup/utils.js
@@ -75,7 +75,7 @@ function getStepUrl( flowName, stepName, stepSectionName, localeSlug ) {
 }
 
 function getValidPath( parameters ) {
-	let locale = getLocale( parameters ),
+	const locale = getLocale( parameters ),
 		flowName = getFlowName( parameters ),
 		currentFlowSteps = flows.getFlow( flowName ).steps,
 		stepName = getStepName( parameters ) || currentFlowSteps[ 0 ],

--- a/client/signup/utils.js
+++ b/client/signup/utils.js
@@ -11,7 +11,8 @@ import steps from 'signup/config/steps';
 import flows from 'signup/config/flows';
 import { defaultFlowName } from 'signup/config/flows';
 import formState from 'lib/form-state';
-const user = require( 'lib/user' )();
+import userFactory from 'lib/user';
+const user = userFactory();
 
 function getFlowName( parameters ) {
 	const flow = ( parameters.flowName && isFlowName( parameters.flowName ) ) ? parameters.flowName : defaultFlowName;
@@ -74,7 +75,7 @@ function getStepUrl( flowName, stepName, stepSectionName, localeSlug ) {
 }
 
 function getValidPath( parameters ) {
-	var locale = getLocale( parameters ),
+	let locale = getLocale( parameters ),
 		flowName = getFlowName( parameters ),
 		currentFlowSteps = flows.getFlow( flowName ).steps,
 		stepName = getStepName( parameters ) || currentFlowSteps[ 0 ],
@@ -110,7 +111,7 @@ function getValueFromProgressStore( { signupProgress, stepName, fieldName } ) {
 	return siteStepProgress ? siteStepProgress[ fieldName ] : null;
 }
 
-function mergeFormWithValue( { form, fieldName, fieldValue} ) {
+function mergeFormWithValue( { form, fieldName, fieldValue } ) {
 	if ( ! formState.getFieldValue( form, fieldName ) ) {
 		return merge( form, {
 			[ fieldName ]: { value: fieldValue }

--- a/client/signup/validation-fieldset/index.jsx
+++ b/client/signup/validation-fieldset/index.jsx
@@ -5,7 +5,7 @@ import React, { Component } from 'react';
 import classNames from 'classnames';
 import { head, values } from 'lodash';
 import debugFactory from 'debug';
-const debug = debugFactory( 'calypso:validate-fieldset' ); // eslint-disable-line no-unused-vars
+const debug = debugFactory( 'calypso:validate-fieldset' );
 
 /**
  * Internal dependencies

--- a/client/signup/validation-fieldset/index.jsx
+++ b/client/signup/validation-fieldset/index.jsx
@@ -4,7 +4,8 @@
 import React, { Component } from 'react';
 import classNames from 'classnames';
 import { head, values } from 'lodash';
-const debug = require( 'debug' )( 'calypso:validate-fieldset' ); // eslint-disable-line no-unused-vars
+import debugFactory from 'debug';
+const debug = debugFactory( 'calypso:validate-fieldset' ); // eslint-disable-line no-unused-vars
 
 /**
  * Internal dependencies

--- a/client/signup/wpcom-login-form/index.jsx
+++ b/client/signup/wpcom-login-form/index.jsx
@@ -2,7 +2,8 @@
  * External dependencies
  */
 import React, { Component } from 'react';
-const debug = require( 'debug' )( 'calypso:signup:wpcom-login' );
+import debugFactory from 'debug';
+const debug = debugFactory( 'calypso:signup:wpcom-login' );
 
 /**
  * Internal dependencies


### PR DESCRIPTION
This change runs several codemods to achieve the following:

Before | After
------------ | -------------
`require( ... )` nested in blocks | All `require( ... )` moved to top block
`var ... = require( ... )` | `import ... from '...'`
`module.exports = ...` | `export default ...`
`this.translate` | `this.props.translate` via HOC
`React.createClass( ... )` | `class ThisComponentName extends React.Component`
`React.createClass( ... )` | `createReactClass( ... )` if unconvertible to `React.Component` subclass
`import { PropTypes } from 'react'` | `import PropTypes from 'prop-types'`

#### Testing instructions

1. Check out locally (`git checkout update/codemod-client/signup`) and start your server. You can also use a [live branch](https://calypso.live/?branch=update/codemod-client/signup)
2. Open the [Signup Page](http://calypso.localhost:3000/start)
3. Verify that the signup works as before!
