### PR TITLE
Extensions: WPJM - Create pages in wizard

### DIFF
--- a/client/extensions/wp-job-manager/components/setup/page-setup/index.jsx
+++ b/client/extensions/wp-job-manager/components/setup/page-setup/index.jsx
@@ -5,7 +5,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import page from 'page';
 import { connect } from 'react-redux';
-import { formValueSelector, reduxForm } from 'redux-form';
+import { Field, formValueSelector, reduxForm } from 'redux-form';
 import { localize } from 'i18n-calypso';
 import { flowRight as compose } from 'lodash';
 
@@ -17,8 +17,9 @@ import Button from 'components/button';
 import CompactCard from 'components/card/compact';
 import ExternalLink from 'components/external-link';
 import FormFieldset from 'components/forms/form-fieldset';
+import FormInputValidation from 'components/forms/form-input-validation';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
-import ReduxFormTextInput from 'components/redux-forms/redux-form-text-input';
+import FormTextInput from 'components/forms/form-text-input';
 import ReduxFormToggle from 'components/redux-forms/redux-form-toggle';
 import SectionHeader from 'components/section-header';
 import { createPages } from '../../../state/setup/actions';
@@ -45,6 +46,22 @@ const validate = ( values, props ) => {
 	}
 
 	return errors;
+};
+
+const PageRenderer = ( { disabled, explanation, input, meta } ) => {
+	const isError = !! ( meta.touched && meta.error );
+
+	return (
+		<div className="page-setup__page">
+			<FormTextInput { ...input } disabled={ disabled } />
+			{ isError && <FormInputValidation isError text={ meta.error } /> }
+			{ explanation &&
+				<FormSettingExplanation>
+					{ explanation }
+				</FormSettingExplanation>
+			}
+		</div>
+	);
 };
 
 class PageSetup extends Component {
@@ -144,50 +161,43 @@ class PageSetup extends Component {
 								<ReduxFormToggle
 									disabled={ isCreating }
 									name="createPostJob" />
-								<ReduxFormTextInput
+								<Field
+									component={ PageRenderer }
 									disabled={ ! createPostJob || isCreating }
-									name="postJobTitle" />
-
-								<FormSettingExplanation>
-									{ translate(
+									explanation={ translate(
 										'Creates a page that allows employers to post new jobs directly from a page on your website, ' +
 										'instead of requiring them to log in to an admin area. If you\'d rather not allow this -- ' +
 										'for example, if you want employers to use the admin dashboard only -- you can uncheck ' +
 										'this setting.'
 									) }
-								</FormSettingExplanation>
+									name="postJobTitle" />
 							</FormFieldset>
 
 							<FormFieldset>
 								<ReduxFormToggle
 									disabled={ isCreating }
 									name="createDashboard" />
-								<ReduxFormTextInput
+								<Field
+									component={ PageRenderer }
 									disabled={ ! createDashboard || isCreating }
-									name="dashboardTitle" />
-
-								<FormSettingExplanation>
-									{ translate(
+									explanation={ translate(
 										'Creates a page that allows employers to manage their job listings directly from a page on your ' +
 										'website, instead of requiring them to log in to an admin area. If you want to manage all ' +
 										'job listings from the admin dashboard only, you can uncheck this setting.'
 									) }
-								</FormSettingExplanation>
+									name="dashboardTitle" />
 							</FormFieldset>
 
 							<FormFieldset>
 								<ReduxFormToggle
 									disabled={ isCreating }
 									name="createJobs" />
-								<ReduxFormTextInput
+								<Field
+									component={ PageRenderer }
 									disabled={ ! createJobs || isCreating }
+									explanation={ translate( 'Creates a page where visitors can browse, search, and filter ' +
+										'job listings.' ) }
 									name="jobsTitle" />
-
-								<FormSettingExplanation>
-									{ translate(
-										'Creates a page where visitors can browse, search, and filter job listings.'
-									) }
-								</FormSettingExplanation>
 							</FormFieldset>
 						</form>
 					</div>

--- a/client/extensions/wp-job-manager/components/setup/page-setup/index.jsx
+++ b/client/extensions/wp-job-manager/components/setup/page-setup/index.jsx
@@ -23,7 +23,7 @@ import ReduxFormToggle from 'components/redux-forms/redux-form-toggle';
 import SectionHeader from 'components/section-header';
 import { createPages } from '../../../state/setup/actions';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
-import { shouldGoToNextStep } from '../../../state/setup/selectors';
+import { isCreatingPages, shouldGoToNextStep } from '../../../state/setup/selectors';
 
 const form = 'extensions.wpJobManager.pageSetup';
 
@@ -35,6 +35,7 @@ class PageSetup extends Component {
 		createPostJob: PropTypes.bool,
 		dashboardTitle: PropTypes.string,
 		goToNextStep: PropTypes.bool,
+		isCreating: PropTypes.bool,
 		jobsTitle: PropTypes.string,
 		postJobTitle: PropTypes.string,
 		siteId: PropTypes.number,
@@ -82,6 +83,7 @@ class PageSetup extends Component {
 			createDashboard,
 			createJobs,
 			createPostJob,
+			isCreating,
 			translate,
 		} = this.props;
 
@@ -121,9 +123,10 @@ class PageSetup extends Component {
 						<form>
 							<FormFieldset>
 								<ReduxFormToggle
+									disabled={ isCreating }
 									name="createPostJob" />
 								<ReduxFormTextInput
-									disabled={ ! createPostJob }
+									disabled={ ! createPostJob || isCreating }
 									name="postJobTitle" />
 
 								<FormSettingExplanation>
@@ -138,9 +141,10 @@ class PageSetup extends Component {
 
 							<FormFieldset>
 								<ReduxFormToggle
+									disabled={ isCreating }
 									name="createDashboard" />
 								<ReduxFormTextInput
-									disabled={ ! createDashboard }
+									disabled={ ! createDashboard || isCreating }
 									name="dashboardTitle" />
 
 								<FormSettingExplanation>
@@ -154,9 +158,10 @@ class PageSetup extends Component {
 
 							<FormFieldset>
 								<ReduxFormToggle
+									disabled={ isCreating }
 									name="createJobs" />
 								<ReduxFormTextInput
-									disabled={ ! createJobs }
+									disabled={ ! createJobs || isCreating }
 									name="jobsTitle" />
 
 								<FormSettingExplanation>
@@ -177,7 +182,7 @@ class PageSetup extends Component {
 					</a>
 					<Button primary
 						className="page-setup__create-pages"
-						disabled={ ( ! createPostJob && ! createDashboard && ! createJobs ) }
+						disabled={ ( ! createPostJob && ! createDashboard && ! createJobs ) || isCreating }
 						onClick={ this.createSelectedPages }>
 						{ translate( 'Create selected pages' ) }
 					</Button>
@@ -195,6 +200,7 @@ const mapStateToProps = state => {
 	return {
 		...selector( state, 'createDashboard', 'createJobs', 'createPostJob', 'dashboardTitle', 'jobsTitle', 'postJobTitle' ),
 		goToNextStep: shouldGoToNextStep( state, siteId ),
+		isCreating: isCreatingPages( state, siteId ),
 		siteId,
 		slug: getSelectedSiteSlug( state ) || '',
 	};

--- a/client/extensions/wp-job-manager/components/setup/page-setup/index.jsx
+++ b/client/extensions/wp-job-manager/components/setup/page-setup/index.jsx
@@ -28,8 +28,7 @@ import { isCreatingPages, shouldGoToNextStep } from '../../../state/setup/select
 
 const form = 'extensions.wpJobManager.pageSetup';
 
-const validate = ( values, props ) => {
-	const { translate } = props;
+const validate = ( values, { translate } ) => {
 	const errors = {};
 	const message = translate( 'Page name cannot be empty.' );
 

--- a/client/extensions/wp-job-manager/components/setup/style.scss
+++ b/client/extensions/wp-job-manager/components/setup/style.scss
@@ -30,6 +30,7 @@
 	width: 250px;
 }
 
+.wp-job-manager__setup .page-setup__pages .form-input-validation.is-error,
 .wp-job-manager__setup .page-setup__pages .form-setting-explanation {
 	margin-left: 36px;
 }
@@ -43,7 +44,7 @@
 	margin: 0;
 }
 
-.wp-job-manager__setup .gridicon {
+.wp-job-manager__setup .confirmation__support .gridicon {
 	color: $blue-wordpress;
 	top: 2px;
 	position: relative;

--- a/client/extensions/wp-job-manager/components/setup/style.scss
+++ b/client/extensions/wp-job-manager/components/setup/style.scss
@@ -26,6 +26,10 @@
 	}
 }
 
+.wp-job-manager__setup .page-setup__page {
+	display: inline;
+}
+
 .wp-job-manager__setup .page-setup__pages .form-text-input {
 	width: 250px;
 }


### PR DESCRIPTION
This PR implements the _Create selected pages_ button in the second step of the WP Job Manager wizard. It adds validation to check that the textboxes are not empty if their corresponding toggle is on:

![page-setup-validation](https://user-images.githubusercontent.com/1190420/30227758-d66abe02-94a8-11e7-8840-6ba2aaced3aa.jpg)

Once all pages are created, the wizard automatically moves to the final confirmation step.

## Testing

Ensure the WP Job Manager plugin is installed and configured by following the steps in p6r3EZ-ra-p2. Browse to `/extensions/wp-job-manager/setup/<siteId>/page-setup`.

Clear the text fields. Error messages should appear once the field loses focus to indicate that "Page name cannot be empty." Toggle the switches off. The error messages should disppear. Toggle them back on. The error messages should re-appear. If all toggles are off, the _Create selected pages_ button is disabled.

Add page names in the text fields. Turn one or more fields off to skip creating a particular page. Click the _Create selected pages_ button. You should be taken to the _You're ready to start using WP Job Manager!_ step of the wizard. Check to ensure that the pages were created as expected in the admin.