### PR TITLE
Domains: Mark .IN as "Testing"

### DIFF
--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -319,11 +319,7 @@ class DomainRegistrationSuggestion extends React.Component {
 		let buttonClasses, buttonContent;
 
 		if ( domain ) {
-			const testTLDs = [
-				'.de',
-				// .in and third level domains
-				'.in', '.co.in', '.firm.in', '.gen.in', '.ind.in', '.net.in', '.org.in',
-			];
+			const testTLDs = [ '.de', '.in', ];
 
 			// Grab everything from the first dot, so 'example.co.uk' will
 			// match '.co.uk' but not '.uk'

--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -319,8 +319,13 @@ class DomainRegistrationSuggestion extends React.Component {
 		let buttonClasses, buttonContent;
 
 		if ( domain ) {
-			const testTLDs = [ '.de' ];
-			// Grab everything after the first dot, so 'example.co.uk' will
+			const testTLDs = [
+				'.de',
+				// .in and third level domains
+				'.in', '.co.in', '.firm.in', '.gen.in', '.ind.in', '.net.in', '.org.in',
+			];
+
+			// Grab everything from the first dot, so 'example.co.uk' will
 			// match '.co.uk' but not '.uk'
 			// This won't work if we add subdomains.
 			const tld = domain.substring( domain.indexOf( '.' ) );


### PR DESCRIPTION
This PR adds the "Testing" tag for '.in':

![domain_search_ _julesauspremiumtest_ _wordpress_com](https://user-images.githubusercontent.com/5952255/30214370-8a266950-94ef-11e7-92bd-fceb0376e255.jpg)

Somewhat aspirationally, I'm also adding the third level domains that we're looking at, even though they won't be visible until we fix https://github.com/Automattic/wp-calypso/issues/17946