### PR TITLE
Jetpack Connect: Check if siteReceived is different from the new prop version before redirecting

### DIFF
--- a/client/jetpack-connect/auth-logged-in-form.jsx
+++ b/client/jetpack-connect/auth-logged-in-form.jsx
@@ -141,7 +141,7 @@ class LoggedInForm extends Component {
 			if ( ! isRedirectingToWpAdmin && authorizeSuccess ) {
 				return goBackToWpAdmin( redirectAfterAuth );
 			}
-		} else if ( siteReceived ) {
+		} else if ( ! this.props.jetpackConnectAuthorize.siteReceived && siteReceived ) {
 			return this.redirect();
 		} else if ( nextProps.isAlreadyOnSitesList && queryObject.already_authorized ) {
 			return this.redirect();


### PR DESCRIPTION
... before redirecting after sites fetch in Jetpack Connect Authorization step

This PR compares previous props to new ones before deciding if we should redirect the user to the plans page after everything went ok. 

#### Testing instructions.

1. Checkout this branch.
1. Add a `console.log( 'siteReceievd' )` between lines 113-114 of `client/jetpack-connect/auth-logged-in-form.jsx`.
1. Get to `/jetpack/connect` in your calypso dev env.
1. Connect a site and check the console.
1. You should see only one `'siteReceived'` logged when being redirected to the plans page.

#### Why

We're perceiving some errors logged related to `Maximum call stack size exceeded` when finishing Jetpack connections. I haven't been able to reproduce, but this fix here is a possible one as we should not be doing more than one redirect from `componentWillReceiveProps`. 