### PR TITLE
Fix finding module version for `babel-loader-cache-identifier`

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1942,7 +1942,7 @@
       "version": "1.0.3"
     },
     "exec-sh": {
-      "version": "0.2.0",
+      "version": "0.2.1",
       "dev": true
     },
     "execa": {
@@ -2059,7 +2059,7 @@
       "version": "2.1.1"
     },
     "fbjs": {
-      "version": "0.8.14",
+      "version": "0.8.15",
       "dependencies": {
         "core-js": {
           "version": "1.2.7"
@@ -2127,6 +2127,9 @@
       "version": "0.4.0"
     },
     "find-cache-dir": {
+      "version": "1.0.0"
+    },
+    "find-package-json": {
       "version": "1.0.0"
     },
     "find-parent-dir": {
@@ -4450,7 +4453,7 @@
       "dev": true
     },
     "node-fetch": {
-      "version": "1.7.2"
+      "version": "1.7.3"
     },
     "node-gyp": {
       "version": "3.6.2",

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "express": "4.13.3",
     "express-useragent": "1.0.7",
     "filesize": "3.2.1",
+    "find-package-json": "1.0.0",
     "flag-icon-css": "2.3.0",
     "flux": "2.1.1",
     "fuse.js": "2.6.1",

--- a/server/bundler/babel/babel-loader-cache-identifier/index.js
+++ b/server/bundler/babel/babel-loader-cache-identifier/index.js
@@ -3,6 +3,7 @@
  */
 const fs = require( 'fs' );
 const path = require( 'path' );
+const packageJsonFinder = require( 'find-package-json' );
 
 /**
  * Given a module name, returns the package version
@@ -11,7 +12,8 @@ const path = require( 'path' );
  * @return {String}    Module version
  */
 function getModuleVersion( id ) {
-	return require( path.dirname( require.resolve( id ) ).replace( /[\/\\]lib/, '' ) + '/package' ).version;
+	const packageJsonSearch = packageJsonFinder( path.dirname( require.resolve( id ) ) );
+	return packageJsonSearch.next().value.version;
 }
 
 /**


### PR DESCRIPTION
I was hit with a strange bug while working on `calypso-live-branches`. It seems `npm install` will fail if your path to `wp-calypso` contains the string `/lib`.

This is the error I encountered (note that the branch is named `update/lib-user` and not `update-user`:

```
Error: Cannot find module '/private/tmp/data/gh-wp-calypso/branches/update-user/node_modules/babel-loader/lib/package'
    at Function.Module._resolveFilename (module.js:469:15)
    at Function.Module._load (module.js:417:25)
    at Module.require (module.js:497:17)
    at require (internal/module.js:20:19)
    at getModuleVersion (/private/tmp/data/gh-wp-calypso/branches/update/lib-user/server/bundler/babel/babel-loader-cache-identifier/index.js:14:9)
    at Object.<anonymous> (/private/tmp/data/gh-wp-calypso/branches/update/lib-user/server/bundler/babel/babel-loader-cache-identifier/index.js:26:18)
    at Module._compile (module.js:570:32)
    at Object.Module._extensions..js (module.js:579:10)
    at Module.load (module.js:487:32)
    at tryModuleLoad (module.js:446:12)
    at Function.Module._load (module.js:438:3)
    at Module.require (module.js:497:17)
    at require (internal/module.js:20:19)
    at Object.<anonymous> (/private/tmp/data/gh-wp-calypso/branches/update/lib-user/webpack.config.node.js:17:25)
    at Module._compile (module.js:570:32)
    at Object.Module._extensions..js (module.js:579:10)
```

This patch fixes the problem.

### Testing Instructions
- Try `npm run distclean && npm install && npm start` from a path containing `/lib`, it should work fine.
