### PR TITLE
Comments: Enable comments trees on Jetpack>5.5 sites

### DIFF
--- a/client/blocks/comment-detail/index.jsx
+++ b/client/blocks/comment-detail/index.jsx
@@ -298,7 +298,9 @@ export class CommentDetail extends Component {
 				className={ classes }
 				tabIndex="0"
 			>
-				{ refreshCommentData && <QueryComment commentId={ commentId } siteId={ siteId } /> }
+				{ refreshCommentData && (
+					<QueryComment commentId={ commentId } siteId={ siteId } forceWpcom />
+				) }
 
 				{ ! isPostTitleLoaded && <QueryPosts siteId={ siteId } postId={ postId } /> }
 

--- a/client/components/data/query-comment/README.md
+++ b/client/components/data/query-comment/README.md
@@ -22,3 +22,4 @@ const CommentDetail = ( { comment, commentId, siteId } ) =>
 | --- | --- | --- |
 | `commentId` | Number | The comment to request. |
 | `siteId` | Number | The site ID for which the comment should be queried. |
+| `forceWpcom` | Bool | (default: false) Forces the request to wpcom. |

--- a/client/components/data/query-comment/index.jsx
+++ b/client/components/data/query-comment/index.jsx
@@ -16,7 +16,12 @@ import { requestComment } from 'state/comments/actions';
 export class QueryComment extends Component {
 	static propTypes = {
 		commentId: PropTypes.number,
+		forceWpcom: PropTypes.bool,
 		siteId: PropTypes.number,
+	};
+
+	static defaultProps = {
+		forceWpcom: false,
 	};
 
 	componentDidMount() {
@@ -30,9 +35,11 @@ export class QueryComment extends Component {
 	}
 
 	request() {
-		const { siteId, commentId } = this.props;
+		const { siteId, commentId, forceWpcom } = this.props;
 		if ( siteId && commentId ) {
-			this.props.requestComment( { siteId, commentId } );
+			const query = forceWpcom ? { force: 'wpcom' } : {};
+
+			this.props.requestComment( { siteId, commentId, query } );
 		}
 	}
 

--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -403,7 +403,7 @@ export class CommentList extends Component {
 
 	render() {
 		const {
-			areCommentsTreeSupported,
+			isCommentsTreeSupported,
 			isLoading,
 			page,
 			siteBlacklist,
@@ -428,7 +428,7 @@ export class CommentList extends Component {
 			<div className="comment-list">
 				<QuerySiteSettings siteId={ siteId } />
 
-				{ ! areCommentsTreeSupported && (
+				{ ! isCommentsTreeSupported && (
 					<QuerySiteCommentsList
 						number={ 100 }
 						offset={ ( validPage - 1 ) * COMMENTS_PER_PAGE }
@@ -436,9 +436,7 @@ export class CommentList extends Component {
 						status={ status }
 					/>
 				) }
-				{ areCommentsTreeSupported && (
-					<QuerySiteCommentsTree siteId={ siteId } status={ status } />
-				) }
+				{ isCommentsTreeSupported && <QuerySiteCommentsTree siteId={ siteId } status={ status } /> }
 
 				<CommentNavigation
 					commentsPage={ commentsPage }
@@ -469,7 +467,7 @@ export class CommentList extends Component {
 							isBulkEdit={ isBulkEdit }
 							key={ `comment-${ siteId }-${ commentId }` }
 							refreshCommentData={
-								areCommentsTreeSupported &&
+								isCommentsTreeSupported &&
 								! this.hasCommentJustMovedBackToCurrentStatus( commentId )
 							}
 							replyComment={ this.replyComment }
@@ -513,9 +511,9 @@ const mapStateToProps = ( state, { siteId, status } ) => {
 	const comments = map( getSiteCommentsTree( state, siteId, status ), 'commentId' );
 	const isLoading = ! isCommentsTreeInitialized( state, siteId, status );
 	return {
-		areCommentsTreeSupported:
-			! isJetpackSite( state, siteId ) || isJetpackMinimumVersion( state, siteId, '5.3' ),
 		comments,
+		isCommentsTreeSupported:
+			! isJetpackSite( state, siteId ) || isJetpackMinimumVersion( state, siteId, '5.3' ),
 		isLoading,
 		siteBlacklist: getSiteSetting( state, siteId, 'blacklist_keys' ),
 		siteId,

--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -513,7 +513,7 @@ const mapStateToProps = ( state, { siteId, status } ) => {
 	return {
 		comments,
 		isCommentsTreeSupported:
-			! isJetpackSite( state, siteId ) || isJetpackMinimumVersion( state, siteId, '5.3' ),
+			! isJetpackSite( state, siteId ) || isJetpackMinimumVersion( state, siteId, '5.5' ),
 		isLoading,
 		siteBlacklist: getSiteSetting( state, siteId, 'blacklist_keys' ),
 		siteId,

--- a/client/state/comments/actions.js
+++ b/client/state/comments/actions.js
@@ -20,10 +20,18 @@ import {
 } from '../action-types';
 import { NUMBER_OF_COMMENTS_PER_FETCH } from './constants';
 
-export const requestComment = ( { siteId, commentId } ) => ( {
+/**
+ * Creates an action that requests a single comment for a given site.
+ * @param {Number} siteId Site identifier
+ * @param {Number} commentId Comment identifier
+ * @param {Object} query API call parameters
+ * @returns {Object} Action that requests a single comment
+ */
+export const requestComment = ( { siteId, commentId, query = {} } ) => ( {
 	type: COMMENT_REQUEST,
 	siteId,
 	commentId,
+	query,
 } );
 
 /***

--- a/client/state/data-layer/wpcom/sites/comments/index.js
+++ b/client/state/data-layer/wpcom/sites/comments/index.js
@@ -87,12 +87,13 @@ const announceStatusChangeFailure = ( { dispatch }, action ) => {
 };
 
 export const requestComment = ( store, action ) => {
-	const { siteId, commentId } = action;
+	const { siteId, commentId, query } = action;
 	store.dispatch(
 		http( {
 			method: 'GET',
 			path: `/sites/${ siteId }/comments/${ commentId }`,
 			apiVersion: '1.1',
+			query,
 			onSuccess: action,
 			onFailure: action,
 		} )


### PR DESCRIPTION
Closes #19153

Enable comments trees to Jetpack >5.5 sites.

Differences with the comments list approach:

**Comments List**

- Opening a Comment Management list (e.g. "Approved") calls the `GET comments` (plural) endpoint requesting up to 100 comments. Each page in the list contains 20 comments; the additional comments are needed to build the following pages.
- Changing page fires a new `GET comments`, again requesting up to 100 comments, but offset to the new page.

**Comments Tree**

- Opening the same Approved list calls the `GET comments-tree` endpoint, requesting all the comments identifiers of a site. Then, each of the (up to) 20 `CommentDetail` components will be responsible of calling their own `GET comment` (singular).

---

I've noticed an unusual weirdness while testing on one of my own Jetpack sites, where I managed to exceed the limits of RAM, I/O, and CPU by just doing some light use of the Comment Management section.
My site is hosted on a really, really cheap shared hosting, which _might_ be the issue.
Though, we can't be sure, and there might be some worse issues going on.

This is a comparison of how the two approaches perform on both .com and my cheap JP site (values rounded / averaged; different sites, so different comments count and sizes):

| Environment | Request | Results | Size | Time |
| --- | --- | --- | --- | --- |
| **JP** | `comments-tree` | 3500 | 15K | 3s |
| **.com** | `comments-tree` | 7000 | 35K | 0.5s |
| **JP** | `comment` (each) | 1 | 1.5K | 17s |
| **.com** | `comment` (each) | 1 | 1.5K | 0.5s |
| | | | | |
| **JP** | `comments` | 100 | 25K | 2.5s |
| **.com** | `comments` | 100 | 40K | 2s |
| | | | | |
| **JP** | `comment` (batch endpoint) | 3 | nd | 3s |
| **JP** | `comment` (batch endpoint) | 20 | nd | 20s |
| **.com** | `comments` (batch endpoint) | nd | | |

Notice the astounding difference of time between JP and .com single `comment` requests.

**UPDATE**
I've added a new test case with the batch endpoint.
Firing a single request for all comments in a page takes roughly 1s per comment, which is definitely an improvement over the 17s registered while firing one request for each comment.

---

I'm opening this PR to ask for testing on our own self-hosted sites.
Is this only a problem with my hosting? Is this something that we can safely ignore?

### Testing instructions

To test the Tree approach on JP >5.5 sites: just pull this branch.

To test the List approach on .com sites: pull this branch and replace:
`isCommentsTreeSupported: ! isJetpackSite( state, siteId ) || isJetpackMinimumVersion( state, siteId, '5.5' ),`
with `isCommentsTreeSupported: false,`.

Then just check the Network tab in the browser dev tools (filtered on `comment`) and see if some of the API calls have crazy values like in my case.