### PR TITLE
Stats: Fix Trends Arrows Overlapping Sidebar

### DIFF
--- a/assets/stylesheets/shared/functions/_z-index.scss
+++ b/assets/stylesheets/shared/functions/_z-index.scss
@@ -57,6 +57,7 @@ $z-layers: (
 		'.following-manage__url-follow': 1,
 		'.following__intro-close-icon': 1,
 		'.post-trends__title': 1,
+		'.post-trends__scroll': 1,
 		'.plugin-item__label': 1,
 		'.wp-editor-tools': 1,
 		'.plan .gridicons-checkmark-circle': 1,

--- a/client/my-sites/stats/post-trends/style.scss
+++ b/client/my-sites/stats/post-trends/style.scss
@@ -50,7 +50,13 @@
 	height: 130px;
 	background: linear-gradient(to right, $white , rgba( $white, .92 ), $transparent );
 	text-align: left;
-	z-index: 100;
+	z-index: z-index( 'root', '.post-trends__scroll' );
+
+	@include breakpoint( "<960px" ) {
+		.focus-sidebar & {
+			z-index: 0;
+		}
+	}
 
 	.left-arrow,
 	.right-arrow {


### PR DESCRIPTION
A left over branch from trash pickup day, this branch fixes #5778 - which affects only Firefox on smaller viewports:

__Current Issue__
- Open a Stats Insights Page in Firefox
- Adjust the viewport until the sidebar collapses, then view the sidebar

![stats_ _timmyonesite_ _wordpress_com](https://user-images.githubusercontent.com/22080/30221303-9ce29cd0-9477-11e7-93bd-b30d6a875ca3.png)

__After Fix__
![stats_ _timmyonesite_ _wordpress_com](https://user-images.githubusercontent.com/22080/30221436-16f20272-9478-11e7-8ec3-0cdadddd6a00.png)
