### PR TITLE
try splitting out devdocs css

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ env-config.sh
 /public/style*.css.map
 /public/editor*.css
 /public/directly*.css
+/public/devdocs*.css
 /public/images/flags/*.svg
 /public/images/flags/*.png
 /server/devdocs/search-index.js

--- a/assets/stylesheets/style.scss
+++ b/assets/stylesheets/style.scss
@@ -31,7 +31,3 @@
 @import 'extensions/wp-job-manager/style';
 @import 'extensions/wp-super-cache/style';
 @import 'extensions/zoninator/style';
-
-// Devdocs
-@import 'devdocs/design/style';
-@import 'devdocs/design/syntax';

--- a/client/devdocs/design/index.jsx
+++ b/client/devdocs/design/index.jsx
@@ -12,6 +12,7 @@ import { trim } from 'lodash';
  * Internal dependencies
  */
 import config from 'config';
+import DocumentHead from 'components/data/document-head';
 import fetchComponentsUsageStats from 'state/components-usage-stats/actions';
 import HeaderCake from 'components/header-cake';
 import Main from 'components/main';
@@ -105,9 +106,11 @@ let DesignAssets = React.createClass( {
 	render() {
 		const { componentsUsageStats = {}, component } = this.props;
 		const { filter } = this.state;
+		const links = [ { href: '/calypso/devdocs.css', rel: 'stylesheet' } ];
 
 		return (
 			<Main className="design">
+				<DocumentHead link={ links } title="test" />
 				{ component
 					? <HeaderCake onClick={ this.backToComponents } backText="All Components">
 							{ slugToCamelCase( component ) }

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -90,6 +90,7 @@ export class Login extends React.Component {
 					'wp-login__footer--jetpack': ! isOauthLogin,
 				} ) }
 			>
+				<a href="/devdocs">devdocs</a>
 				{ isOauthLogin ? (
 					<div className="wp-login__footer-links">
 						<a

--- a/package.json
+++ b/package.json
@@ -179,6 +179,7 @@
     "postbuild": "npm run -s bundle",
     "build-css": "run-p -s build-css:*",
     "build-css:debug": "node-sass --include-path client --source-map \"public/style-debug.css.map\" assets/stylesheets/style.scss public/style-debug.css && npm run -s autoprefixer -- public/style-debug.css",
+    "build-css:devdocs": "node-sass --include-path client assets/stylesheets/devdocs.scss public/devdocs.css && npm run -s autoprefixer -- public/devdocs.css && rtlcss public/devdocs.css public/devdocs-rtl.css",
     "build-css:directly": "node-sass --include-path client assets/stylesheets/directly.scss public/directly.css && npm run -s autoprefixer -- public/directly.css",
     "build-css:editor": "node-sass --include-path client assets/stylesheets/editor.scss public/editor.css && npm run -s autoprefixer -- public/editor.css",
     "build-css:style": "node-sass --include-path client assets/stylesheets/style.scss public/style.css && npm run -s autoprefixer -- public/style.css && rtlcss public/style.css public/style-rtl.css",

--- a/server/pages/index.jade
+++ b/server/pages/index.jade
@@ -55,6 +55,9 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class=isFluidWidth ? 'is-fluid-width'
 			else
 				link(rel='stylesheet', href=urls['style.css'])
 
+		if 'devdocs' === chunk
+			link(rel='stylesheet', href=urls['devdocs.css'])
+
 	body( class=bodyClasses )
 		if renderedLayout
 			#wpcom.wpcom-site!= renderedLayout

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -35,6 +35,7 @@ const calypsoEnv = config( 'env_id' );
 const staticFiles = [
 	{ path: 'style.css' },
 	{ path: 'editor.css' },
+	{ path: 'devdocs.css' },
 	{ path: 'tinymce/skins/wordpress/wp-content.css' },
 	{ path: 'style-debug.css' },
 	{ path: 'style-rtl.css' }


### PR DESCRIPTION
This PR starts looking into how we could split CSS into sections by trying to extract the CSS for devdocs.

Loading CSS based on the chunk, serverside is quite trivial, but doing the same thing on the client is more involved. Looking for ideas how to proceed. (I really don't want to add a DocumentHead in every parent compenent inside a section).