### PR TITLE
Reader: Whitelist embeds from gfycat

### DIFF
--- a/client/lib/post-normalizer/utils.js
+++ b/client/lib/post-normalizer/utils.js
@@ -163,6 +163,7 @@ export function iframeIsWhitelisted( iframe ) {
 		'www.audiomack.com',
 		'player.theplatform.com',
 		'embed.radiopublic.com',
+		'gfycat.com',
 	];
 	const hostName = iframe.src && url.parse( iframe.src ).hostname;
 	const iframeSrc = hostName && hostName.toLowerCase();


### PR DESCRIPTION
To test, try http://calypso.localhost:3000/read/feeds/9721900/posts/1586110779

Enables gfycat.com embeds in the Reader.