### PR TITLE
Login: Update error message displayed for admin username

### DIFF
--- a/client/state/login/actions.js
+++ b/client/state/login/actions.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import React from 'react';
 import request from 'superagent';
 import { get, omit } from 'lodash';
 import { translate } from 'i18n-calypso';
@@ -89,6 +90,45 @@ function getErrorFromHTTPError( httpError ) {
 	if ( code ) {
 		if ( code in errorFields ) {
 			field = errorFields[ code ];
+		} else if ( code === 'admin_login_attempt' ) {
+			const url = addLocaleToWpcomUrl( 'https://wordpress.com/wp-login.php?action=lostpassword', getLocaleSlug() );
+
+			return {
+				code,
+				message: (
+					<div>
+						<p>
+							{ translate( 'You attempted to login with the username {{em}}admin{{/em}} on WordPress.com.',
+								{ components: { em: <em /> } }
+							) }
+						</p>
+
+						<p>
+							{ translate( 'If you were trying to access your self hosted {{a}}WordPress.org{{/a}} site, ' +
+								'try {{strong}}yourdomain.com/wp-admin/{{/strong}} instead.',
+								{
+									components: {
+										a: <a href="http://wordpress.org" target="_blank" rel="noopener noreferrer" />,
+										strong: <strong />
+									}
+								}
+							) }
+						</p>
+
+						<p>
+							{ translate( 'If you can’t remember your WordPress.com username, you can {{a}}reset your password{{/a}} ' +
+								'by providing your email address.',
+								{
+									components: {
+										a: <a href={ url } rel="external" />
+									}
+								}
+							) }
+						</p>
+					</div>
+				),
+				field
+			};
 		}
 	}
 


### PR DESCRIPTION
This pull request fixes https://github.com/Automattic/wp-calypso/issues/17143 by overriding the error message returned by the API when a user tries to log in with the `admin` username. The following error message is now displayed:

<img width="624" alt="screenshot" src="https://user-images.githubusercontent.com/594356/30223463-3f93940e-94cb-11e7-9047-bde712bb8671.png">

#### Testing instructions
 
1. Run `git checkout fix/login-admin-error` and start your server, or open a [live branch](https://calypso.live/?branch=fix/login-admin-error)
2. Open the [`Login` page](http://calypso.localhost:3000/log-in)
4. Enter `admin` in the `Username or Email Address` field
5. Enter anything in the `Password` field, and submit the form
6. Assert that the error message mentioned above is displayed

#### Reviews
 
- [x] Code
- [x] Product

/cc @ranh 