### PR TITLE
Site Settings: separate reconnection and disconnection components in the JP Disconnect Flow.

### DIFF
--- a/client/my-sites/site-settings/disconnect-site/disconnect-survey.jsx
+++ b/client/my-sites/site-settings/disconnect-site/disconnect-survey.jsx
@@ -44,6 +44,11 @@ class DisconnectSurvey extends Component {
 		if ( ! isFreeJetpackPlan( site.plan ) ) {
 			options.push( { value: 'onlyNeedFree', label: translate( 'This plan is too expensive' ) } );
 		}
+		options.push( {
+			value: 'troubleshoot',
+			label: translate( "This is temporary -- I'm troubleshooting a problem." ),
+		} );
+
 		return options;
 	}
 
@@ -62,13 +67,10 @@ class DisconnectSurvey extends Component {
 	renderEntryQuestion() {
 		const { translate, siteSlug } = this.props;
 
-		const textShareWhy = translate(
-			'Would you mind sharing why you want to disconnect %(siteName)s from WordPress.com ',
-			{
-				textOnly: true,
-				args: { siteName: siteSlug },
-			}
-		);
+		const textShareWhy = translate( "I'm disconnecting my site %(siteName)s because:", {
+			textOnly: true,
+			args: { siteName: siteSlug },
+		} );
 		const options = this.getOptions();
 		const surveyQuestionsOne = this.getSurveyQuestions( options );
 		return (
@@ -82,7 +84,7 @@ class DisconnectSurvey extends Component {
 	render() {
 		const { reasonSelected, renderInitial } = this.state;
 		return (
-			<div className="disconnect-site__survey main">
+			<div className="disconnect-site__card">
 				{ renderInitial ? this.renderEntryQuestion() : this.renderFollowUp( reasonSelected ) }
 			</div>
 		);

--- a/client/my-sites/site-settings/disconnect-site/index.jsx
+++ b/client/my-sites/site-settings/disconnect-site/index.jsx
@@ -18,6 +18,7 @@ import Placeholder from 'my-sites/site-settings/placeholder';
 import redirectNonJetpack from 'my-sites/site-settings/redirect-non-jetpack';
 import NavigationBackButton from 'my-sites/site-settings/navigation-back-button';
 import SkipSurvey from './skip-survey';
+import Reconnect from './reconnect';
 
 class DisconnectSite extends Component {
 	getRoute() {
@@ -49,6 +50,7 @@ class DisconnectSite extends Component {
 					/>
 					<DisconnectSurvey />
 					<SkipSurvey />
+					<Reconnect />
 				</Main>
 			</div>
 		);

--- a/client/my-sites/site-settings/disconnect-site/reconnect.jsx
+++ b/client/my-sites/site-settings/disconnect-site/reconnect.jsx
@@ -1,0 +1,29 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+
+class Reconnect extends Component {
+	renderCardContent() {
+		const { translate } = this.props;
+		const help = translate( 'Click here to reconnect' );
+		return (
+			<div>
+				<h3> { translate( 'Are you having problems with your connection?' ) } </h3>
+				{ help }
+			</div>
+		);
+	}
+
+	render() {
+		return <div>{ this.renderCardContent() }</div>;
+	}
+}
+
+export default localize( Reconnect );


### PR DESCRIPTION
Add *Troubleshooting* survey option to the Jetpack Disconnect UX.

**Depends on**:  https://github.com/Automattic/wp-calypso/pull/17696

**View:**
`/settings/disconnect-site/:site`, where `:site` is a Jetpack or non-Atomic site.
For other sites the Flow redirects automatically to `/settings/general:site`.

**To test**:

- Checkout this branch, or use calypso.live:
https://calypso.live/?branch=update/site-settings-site-survey-separate-reconnection

Verify that the options are visible as shown below and, upon selection, redirect to an empty  placeholder follow-up Card.

**Visuals:**
![screen shot 2017-09-30 at 10 46 06](https://user-images.githubusercontent.com/13561163/31044874-e6d2dcba-a5cf-11e7-8259-c445313b1a75.png)
