### PR TITLE
Components: Add validation to `ReduxFormTextInput` component

### DIFF
--- a/client/components/redux-forms/redux-form-text-input/index.jsx
+++ b/client/components/redux-forms/redux-form-text-input/index.jsx
@@ -9,11 +9,20 @@ import { Field } from 'redux-form';
 /**
  * Internal dependencies
  */
+import FormInputValidation from 'components/forms/form-input-validation';
 import FormTextInput from 'components/forms/form-text-input';
 
 // eslint-disable-next-line no-unused-vars
-const TextInputRenderer = ( { input, meta, ...props } ) =>
-	<FormTextInput { ...input } { ...props } />;
+const TextInputRenderer = ( { input, meta: { error, touched }, ...props } ) => {
+	const isError = !! ( touched && error );
+
+	return (
+		<span>
+			<FormTextInput isError={ isError } { ...input } { ...props } />
+			{ isError && <FormInputValidation isError text={ error } /> }
+		</span>
+	);
+};
 
 const ReduxFormTextInput = props => <Field component={ TextInputRenderer } { ...props } />;
 


### PR DESCRIPTION
This PR adds validation to the `ReduxFormTextInput` component. I investigated using the existing `ReduxFormFieldset` component, but it doesn't suit my needs as I need to create the following UI:

![page-setup-validation](https://user-images.githubusercontent.com/1190420/30227018-1747dc82-94a6-11e7-9560-af81c193cd37.jpg)

That is, I need to render two Redux form components inside the same fieldset (a toggle and a textbox), which `ReduxFormFieldset` does not support. Rather than introduce complexity to `ReduxFormFieldset`, I opted to add validation directly to `ReduxFormTextInput`.