### PR TITLE
Store Orders: Add selectors for getting data related to editing/creating orders

### DIFF
--- a/client/extensions/woocommerce/state/ui/orders/README.md
+++ b/client/extensions/woocommerce/state/ui/orders/README.md
@@ -42,6 +42,10 @@ This is saved on a per-site basis.
 
 ## Selectors
 
+### `getCurrentlyEditingOrderId = ( state, [siteId] )`
+
+Gets the ID of the current order, or object placeholder, if a new order. Defaults to null, if no order is being edited.
+
 ### `getOrdersCurrentPage( state, [siteId] )`
 
 Gets the current page being shown to the user. Defaults to 1.
@@ -49,3 +53,15 @@ Gets the current page being shown to the user. Defaults to 1.
 ### `getOrdersCurrentSearch( state, [siteId] )`
 
 Gets the current search term being shown to the user. Defaults to "".
+
+### `getOrderEdits( state, [siteId] )`
+
+Gets the local edits made to the current order. Defaults to {} if no order is being edited.
+
+### `getOrderWithEdits( state, [siteId] )`
+
+Merges the existing order with the local changes, or just the "changes" if a newly created order. Defaults to {} if no order is being edited.
+
+### `isCurrentlyEditingOrder( state, [siteId] )`
+
+Whether the given site (or current site) has changes pending for an order (or new order).

--- a/client/extensions/woocommerce/state/ui/orders/selectors.js
+++ b/client/extensions/woocommerce/state/ui/orders/selectors.js
@@ -1,12 +1,22 @@
 /**
  * External dependencies
  */
-import { get } from 'lodash';
+import { get, isObject, merge } from 'lodash';
 
 /**
  * Internal dependencies
  */
+import { getOrder } from 'woocommerce/state/sites/orders/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
+
+/**
+ * @param {Object} state Whole Redux state tree
+ * @param {Number} [siteId] Site ID to check. If not provided, the Site ID selected in the UI will be used
+ * @return {Number|Object} The ID of the current order (or object placeholder, if a new order)
+ */
+export const getCurrentlyEditingOrderId = ( state, siteId = getSelectedSiteId( state ) ) => {
+	return get( state, [ 'extensions', 'woocommerce', 'ui', 'orders', siteId, 'edits', 'currentlyEditingId' ], null );
+};
 
 /**
  * @param {Object} state Whole Redux state tree
@@ -24,4 +34,45 @@ export const getOrdersCurrentPage = ( state, siteId = getSelectedSiteId( state )
  */
 export const getOrdersCurrentSearch = ( state, siteId = getSelectedSiteId( state ) ) => {
 	return get( state, [ 'extensions', 'woocommerce', 'ui', 'orders', siteId, 'list', 'currentSearch' ], '' );
+};
+
+/**
+ * @param {Object} state Whole Redux state tree
+ * @param {Number} [siteId] Site ID to check. If not provided, the Site ID selected in the UI will be used
+ * @return {Object} The local edits made to the current order
+ */
+export const getOrderEdits = ( state, siteId = getSelectedSiteId( state ) ) => {
+	return get( state, [ 'extensions', 'woocommerce', 'ui', 'orders', siteId, 'edits', 'changes' ], {} );
+};
+
+/**
+ * @param {Object} state Whole Redux state tree
+ * @param {Number} [siteId] Site ID to check. If not provided, the Site ID selected in the UI will be used
+ * @return {Object} The order merged with changes, or just the changes if a newly created order
+ */
+export const getOrderWithEdits = ( state, siteId = getSelectedSiteId( state ) ) => {
+	const orderId = getCurrentlyEditingOrderId( state, siteId );
+	const orderEdits = getOrderEdits( state, siteId );
+
+	// If there is no existing order, the edits are returned as the entire order.
+	if ( isObject( orderId ) ) {
+		return orderEdits;
+	}
+
+	const order = getOrder( state, orderId, siteId );
+	// We haven't synced the order yet, so return with just the changes.
+	if ( ! order ) {
+		return orderEdits;
+	}
+
+	return merge( {}, order, orderEdits );
+};
+
+/**
+ * @param {Object} state Whole Redux state tree
+ * @param {Number} [siteId] Site ID to check. If not provided, the Site ID selected in the UI will be used
+ * @return {Boolean} True if there is an order ID tracked as "editing"
+ */
+export const isCurrentlyEditingOrder = ( state, siteId = getSelectedSiteId( state ) ) => {
+	return !! getCurrentlyEditingOrderId( state, siteId );
 };

--- a/client/extensions/woocommerce/state/ui/orders/selectors.js
+++ b/client/extensions/woocommerce/state/ui/orders/selectors.js
@@ -56,7 +56,7 @@ export const getOrderWithEdits = ( state, siteId = getSelectedSiteId( state ) ) 
 
 	// If there is no existing order, the edits are returned as the entire order.
 	if ( isObject( orderId ) ) {
-		return orderEdits;
+		return { ...orderEdits, id: orderId };
 	}
 
 	const order = getOrder( state, orderId, siteId );

--- a/client/extensions/woocommerce/state/ui/orders/test/fixtures/detailed-state.js
+++ b/client/extensions/woocommerce/state/ui/orders/test/fixtures/detailed-state.js
@@ -1,0 +1,112 @@
+export const order = {
+	id: 40,
+	status: 'completed',
+	currency: 'USD',
+	total: '50.87',
+	total_tax: '0.00',
+	prices_include_tax: false,
+	billing: {
+		first_name: 'Eleanor',
+		last_name: 'Smith',
+		company: '',
+		address_1: '839 Riverside Dr',
+		address_2: '',
+		city: 'New York',
+		state: 'NY',
+		postcode: '10032',
+		country: 'US',
+		email: 'fantastic.fall@gmail.com',
+		phone: '444222424',
+	},
+	shipping: {
+		first_name: 'Eleanor',
+		last_name: 'Smith',
+		company: '',
+		address_1: '839 Riverside Dr',
+		address_2: '',
+		city: 'New York',
+		state: 'NY',
+		postcode: '10032',
+		country: 'US',
+	},
+	payment_method: 'stripe',
+	payment_method_title: 'Credit Card (Stripe)',
+	meta_data: [],
+	line_items: [
+		{
+			id: 12,
+			name: 'Coffee',
+			price: 15.29,
+		},
+	],
+	tax_lines: [],
+	shipping_lines: [
+		{
+			id: 13,
+			method_title: 'Flat rate',
+			method_id: 'flat_rate:2',
+			total: '5.00',
+			total_tax: '0.00',
+			taxes: [],
+		},
+	],
+};
+
+export const state = {
+	ui: { selectedSiteId: 123 },
+	extensions: {
+		woocommerce: {
+			sites: {
+				123: {
+					orders: {
+						isLoading: {
+							40: false,
+						},
+						items: {
+							40: order,
+						}
+					}
+				}
+			},
+			ui: {
+				orders: {
+					123: {
+						edits: {
+							currentlyEditingId: 40,
+							changes: {
+								billing: {
+									first_name: 'Joan',
+								}
+							},
+						},
+						list: {
+							currentPage: 2,
+							currentSearch: 'example',
+						}
+					},
+					234: {
+						edits: {},
+						list: {
+							currentPage: 5,
+							currentSearch: 'test',
+						}
+					},
+					345: {
+						edits: {
+							currentlyEditingId: { placeholder: 'order_1' },
+							changes: {
+								billing: {
+									email: 'test@example.com',
+								}
+							},
+						},
+						list: {
+							currentPage: 2,
+							currentSearch: 'example',
+						}
+					},
+				},
+			},
+		},
+	},
+};

--- a/client/extensions/woocommerce/state/ui/orders/test/selectors.js
+++ b/client/extensions/woocommerce/state/ui/orders/test/selectors.js
@@ -114,7 +114,10 @@ describe( 'selectors', () => {
 		} );
 
 		it( 'should return just the changes for new orders', () => {
-			expect( getOrderWithEdits( state, 345 ) ).to.eql( { billing: { email: 'test@example.com' } } );
+			expect( getOrderWithEdits( state, 345 ) ).to.eql( {
+				billing: { email: 'test@example.com' },
+				id: { placeholder: 'order_1' },
+			} );
 		} );
 	} );
 

--- a/client/extensions/woocommerce/state/ui/orders/test/selectors.js
+++ b/client/extensions/woocommerce/state/ui/orders/test/selectors.js
@@ -7,9 +7,14 @@ import { expect } from 'chai';
  * Internal dependencies
  */
 import {
+	getCurrentlyEditingOrderId,
 	getOrdersCurrentPage,
-	getOrdersCurrentSearch
+	getOrdersCurrentSearch,
+	getOrderEdits,
+	getOrderWithEdits,
+	isCurrentlyEditingOrder,
 } from '../selectors';
+import { state, order } from './fixtures/detailed-state';
 
 const preInitializedState = {
 	extensions: {
@@ -17,31 +22,29 @@ const preInitializedState = {
 	}
 };
 
-const state = {
-	ui: { selectedSiteId: 123 },
-	extensions: {
-		woocommerce: {
-			ui: {
-				orders: {
-					123: {
-						list: {
-							currentPage: 2,
-							currentSearch: 'example',
-						}
-					},
-					234: {
-						list: {
-							currentPage: 5,
-							currentSearch: 'test',
-						}
-					},
-				},
-			},
-		},
-	},
-};
-
 describe( 'selectors', () => {
+	describe( '#getCurrentlyEditingOrderId', () => {
+		it( 'should be null (default) when woocommerce state is not available', () => {
+			expect( getCurrentlyEditingOrderId( preInitializedState, 123 ) ).to.be.null;
+		} );
+
+		it( 'should get the correct ID when an order is being edited', () => {
+			expect( getCurrentlyEditingOrderId( state, 123 ) ).to.eql( 40 );
+		} );
+
+		it( 'should get the correct ID when a new order has been created', () => {
+			expect( getCurrentlyEditingOrderId( state, 345 ) ).to.eql( { placeholder: 'order_1' } );
+		} );
+
+		it( 'should be null when no orders are being edited', () => {
+			expect( getCurrentlyEditingOrderId( state, 234 ) ).to.be.null;
+		} );
+
+		it( 'should get the siteId from the UI tree if not provided', () => {
+			expect( getCurrentlyEditingOrderId( state ) ).to.eql( 40 );
+		} );
+	} );
+
 	describe( '#getOrdersCurrentPage', () => {
 		it( 'should be 1 (default) when woocommerce state is not available', () => {
 			expect( getOrdersCurrentPage( preInitializedState, 123 ) ).to.eql( 1 );
@@ -75,6 +78,65 @@ describe( 'selectors', () => {
 
 		it( 'should get the siteId from the UI tree if not provided', () => {
 			expect( getOrdersCurrentSearch( state ) ).to.eql( 'example' );
+		} );
+	} );
+
+	describe( '#getOrderEdits', () => {
+		it( 'should be an empty object (default) when woocommerce state is not available', () => {
+			expect( getOrderEdits( preInitializedState, 123 ) ).to.eql( {} );
+		} );
+
+		it( 'should get the changes when an order is being edited', () => {
+			expect( getOrderEdits( state, 123 ) ).to.eql( { billing: { first_name: 'Joan' } } );
+		} );
+
+		it( 'should get the new content when a new order has been created', () => {
+			expect( getOrderEdits( state, 345 ) ).to.eql( { billing: { email: 'test@example.com' } } );
+		} );
+
+		it( 'should be empty object when no orders are being edited', () => {
+			expect( getOrderEdits( state, 234 ) ).to.eql( {} );
+		} );
+
+		it( 'should get the siteId from the UI tree if not provided', () => {
+			expect( getOrderEdits( state ) ).to.eql( { billing: { first_name: 'Joan' } } );
+		} );
+	} );
+
+	describe( '#getOrderWithEdits', () => {
+		it( 'should be an empy object when woocommerce state is not available', () => {
+			expect( getOrderWithEdits( preInitializedState, 123 ) ).to.eql( {} );
+		} );
+
+		it( 'should merge the edited changes into the existing order', () => {
+			const mergedOrder = { ...order, billing: { ...order.billing, first_name: 'Joan' } };
+			expect( getOrderWithEdits( state, 123 ) ).to.eql( mergedOrder );
+		} );
+
+		it( 'should return just the changes for new orders', () => {
+			expect( getOrderWithEdits( state, 345 ) ).to.eql( { billing: { email: 'test@example.com' } } );
+		} );
+	} );
+
+	describe( '#isCurrentlyEditingOrder', () => {
+		it( 'should be false (default) when woocommerce state is not available', () => {
+			expect( isCurrentlyEditingOrder( preInitializedState, 123 ) ).to.be.false;
+		} );
+
+		it( 'should be true when an order is being edited', () => {
+			expect( isCurrentlyEditingOrder( state, 123 ) ).to.be.true;
+		} );
+
+		it( 'should be true when a new order is being created', () => {
+			expect( isCurrentlyEditingOrder( state, 345 ) ).to.be.true;
+		} );
+
+		it( 'should be false when no orders are being edited', () => {
+			expect( isCurrentlyEditingOrder( state, 234 ) ).to.be.false;
+		} );
+
+		it( 'should get the siteId from the UI tree if not provided', () => {
+			expect( isCurrentlyEditingOrder( state ) ).to.be.true;
 		} );
 	} );
 } );


### PR DESCRIPTION
This PR follows up on #17927, and adds the selectors to handle the reducer added there. Check out [the README](https://github.com/Automattic/wp-calypso/blob/cfdbebc471c26516a620704e62036c55a3b65dcc/client/extensions/woocommerce/state/ui/orders/README.md) for the new selectors:

- getCurrentlyEditingOrderId
- getOrderEdits
- getOrderWithEdits
- isCurrentlyEditingOrder

These will be used to display orders with local changes in the create/edit form, so the order object structure matches the [order structure in the WC API](http://woocommerce.github.io/woocommerce-rest-api-docs/#create-an-order).

There are no functional changes here, so to test, run the tests:

- `npm run test-client client/extensions/woocommerce/state/ui/orders`