### PR TITLE
A/B Test: Recommend shortest domain name.

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -479,7 +479,6 @@ class RegisterDomainStep extends React.Component {
 
 				let recommendedSuggestion = null;
 
-				// localStorage.setItem( 'ABTests', '{"recommendShortestDomain":"shortest"}' );
 				if ( abtest( 'recommendShortestDomain' ) === 'shortest' ) {
 					const shortestDomainBase = availableSuggestions.map( suggestion => {
 						const dotPos = suggestion.domain_name.indexOf( '.' );

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -27,6 +27,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import { abtest } from 'lib/abtest';
 import wpcom from 'lib/wp';
 import Notice from 'components/notice';
 import { checkDomainAvailability, getFixedDomainSearch } from 'lib/domains';
@@ -476,7 +477,24 @@ class RegisterDomainStep extends React.Component {
 					! exactMatchBeforeTld( suggestion ) && suggestion.isRecommended !== true;
 				const availableSuggestions = reject( suggestions, isFreeOrUnknown );
 
-				const recommendedSuggestion = find( availableSuggestions, exactMatchBeforeTld );
+				let recommendedSuggestion = null;
+
+				// localStorage.setItem( 'ABTests', '{"recommendShortestDomain":"shortest"}' );
+				if ( abtest( 'recommendShortestDomain' ) === 'shortest' ) {
+					const shortestDomainBase = availableSuggestions.map( suggestion => {
+						const dotPos = suggestion.domain_name.indexOf( '.' );
+						return suggestion.domain_name.slice( 0, -1 === dotPos ? suggestion.domain_name.length : dotPos );
+					} ).reduce( ( left, right ) => left.length <= right.length ? left : right );
+
+					const shortestDomainBeforeTld = ( suggestion ) =>
+						( startsWith( suggestion.domain_name, `${ shortestDomainBase }.` )
+					);
+
+					recommendedSuggestion = find( availableSuggestions, shortestDomainBeforeTld );
+				} else {
+					recommendedSuggestion = find( availableSuggestions, exactMatchBeforeTld );
+				}
+
 				if ( recommendedSuggestion ) {
 					recommendedSuggestion.isRecommended = true;
 				} else if ( availableSuggestions.length > 0 ) {

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -87,4 +87,14 @@ module.exports = {
 		allowExistingUsers: true,
 		localeTargets: 'any',
 	},
+	recommendShortestDomain: {
+		datestamp: '20170908', // placeholder
+		variations: {
+			shortest: 50,
+			original: 50,
+		},
+		defaultVariation: 'original',
+		allowExistingUsers: true,
+		localeTargets: 'any',
+	}
 };

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -88,7 +88,7 @@ module.exports = {
 		localeTargets: 'any',
 	},
 	recommendShortestDomain: {
-		datestamp: '20170908', // placeholder
+		datestamp: '20171010',
 		variations: {
 			shortest: 50,
 			original: 50,
@@ -96,5 +96,5 @@ module.exports = {
 		defaultVariation: 'original',
 		allowExistingUsers: true,
 		localeTargets: 'any',
-	}
+	},
 };


### PR DESCRIPTION
This is for an A/B test where we will recommend the shortest domain name instead of the highest ranking domain name.

More info available in: p8kIbR-ag-p2

To test, build locally and run several searches with each variation of the test. When the `shortest` variation is selected, the domain name with the shortest string before the TLD is the one that should have the recommended flag next to it.