### PR TITLE
People: Update the username/email field to focus on label click

### DIFF
--- a/client/components/token-field/README.md
+++ b/client/components/token-field/README.md
@@ -50,6 +50,7 @@ The `value` property is handled in a manner similar to controlled form component
 - `maxLength` - If passed, `TokenField` will disable ability to add new tokens once number of tokens is greater than or equal to `maxLength`.
 - `disabled` - When true, tokens are not able to be added or removed.
 - `placeholder` - If passed, the `TokenField` input will show a placeholder string if no value tokens are present.
+- `id` - the ID of the token input, should be unique.
 
 ### Example
 

--- a/client/components/token-field/index.jsx
+++ b/client/components/token-field/index.jsx
@@ -6,6 +6,7 @@ const React = require( 'react' ),
 	PureRenderMixin = require( 'react-pure-render/mixin' ),
 	classNames = require( 'classnames' ),
 	debug = require( 'debug' )( 'calypso:token-field' );
+import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies
@@ -16,17 +17,18 @@ var SuggestionsList = require( './suggestions-list' ),
 
 var TokenField = React.createClass( {
 	propTypes: {
-		suggestions: React.PropTypes.array,
-		maxSuggestions: React.PropTypes.number,
-		displayTransform: React.PropTypes.func,
-		saveTransform: React.PropTypes.func,
-		onChange: React.PropTypes.func,
-		isBorderless: React.PropTypes.bool,
-		maxLength: React.PropTypes.number,
-		onFocus: React.PropTypes.func,
-		disabled: React.PropTypes.bool,
-		tokenizeOnSpace: React.PropTypes.bool,
-		placeholder: React.PropTypes.string,
+		suggestions: PropTypes.array,
+		maxSuggestions: PropTypes.number,
+		displayTransform: PropTypes.func,
+		saveTransform: PropTypes.func,
+		onChange: PropTypes.func,
+		isBorderless: PropTypes.bool,
+		maxLength: PropTypes.number,
+		onFocus: PropTypes.func,
+		disabled: PropTypes.bool,
+		tokenizeOnSpace: PropTypes.bool,
+		placeholder: PropTypes.string,
+		id: PropTypes.string,
 		value: function( props ) {
 			const value = props.value;
 			if ( ! Array.isArray( value ) ) {
@@ -162,7 +164,7 @@ var TokenField = React.createClass( {
 	},
 
 	_renderInput: function() {
-		const { autoCapitalize, autoComplete, maxLength, value, placeholder } = this.props;
+		const { autoCapitalize, autoComplete, id, maxLength, value, placeholder } = this.props;
 
 		let props = {
 			autoCapitalize,
@@ -172,6 +174,7 @@ var TokenField = React.createClass( {
 			disabled: this.props.disabled,
 			value: this.state.incompleteTokenValue,
 			onBlur: this._onBlur,
+			id,
 		};
 
 		if ( value.length === 0 && placeholder ) {

--- a/client/my-sites/people/invite-people/index.jsx
+++ b/client/my-sites/people/invite-people/index.jsx
@@ -320,8 +320,9 @@ const InvitePeople = React.createClass( {
 				<EmailVerificationGate>
 					<form onSubmit={ this.submitForm } >
 						<div role="group" className="invite-people__token-field-wrapper">
-							<FormLabel>{ translate( 'Usernames or Emails' ) }</FormLabel>
+							<FormLabel htmlFor="usernamesOrEmails">{ translate( 'Usernames or Emails' ) }</FormLabel>
 							<TokenField
+								id="usernamesOrEmails"
 								isBorderless
 								tokenizeOnSpace
 								autoCapitalize="none"


### PR DESCRIPTION
This PR updates the People invitation form to focus the Usernames or Emails field when clicking on the corresponding label. To achieve this, this PR is also introducing ID prop support to the `TokenField` component, and updates the `PropTypes` usage to please the linter 😉 

To test:
* Checkout this branch
* Go to http://calypso.localhost:3000/people/new/:site, where `:site` is a .com site.
* Click on the **Usernames or Emails** label.
* Verify the corresponding field gets focused.
* Verify the PR introduces no regressions.