### PR TITLE
Update/improved getSitesItems selector

### DIFF
--- a/client/state/selectors/get-sites-items.js
+++ b/client/state/selectors/get-sites-items.js
@@ -1,4 +1,11 @@
 /**
+ * Frozen empty object
+ *
+ * @type {Object}
+ */
+const EMPTY_SITES = Object.freeze( {} );
+
+/**
  * Returns site items object or empty object.
  * 
  *
@@ -8,5 +15,5 @@
  */
 
 export default function getSitesItems( state ) {
-	return state.sites.items || {};
+	return state.sites.items || EMPTY_SITES;
 }

--- a/client/state/selectors/test/get-sites-items.js
+++ b/client/state/selectors/test/get-sites-items.js
@@ -14,10 +14,10 @@ describe( 'getSitesItems()', () => {
 	it( 'should return site items if sites exist', () => {
 		const state = {
 			sites: {
-				items: { 1: { ID: 1 } },
+				items: { 13434: { ID: 13434 } },
 			},
 		};
-		expect( getSitesItems( state ) ).to.eql( { 1: { ID: 1 } } );
+		expect( getSitesItems( state ) ).to.eql( { 13434: { ID: 13434 } } );
 	} );
 
 	it( 'should return empty object if site items are empty', () => {


### PR DESCRIPTION
This PR makes 2 improvements to getSitesItems selector proposed in PR's https://github.com/Automattic/wp-calypso/pull/17364 and https://github.com/Automattic/wp-calypso/pull/17694.

1. Updates the automated tests to use an Id different from 1 because using 0 or 1 as test value may lead to false positives as they are the default numbers for many algorithms.

2. Change selector to use a static shared frozen empty object because it avoids creating objects frequently, and may improve caching on dependent memoized selectors.

Thank you @dmsnell and @aduth for the inputs that orgined this PR.

Use cases:
This selector is going used in PR #17364.

To test:
This PR just updates a selector that is not used yet so executing automatic tests that include this selector should be enough.
npm run test-client client/state/selectors/test

