### PR TITLE
Webpack: use minified versions of async-loaded files in production, take 2

### DIFF
--- a/server/bundler/webpack-plugins/use-minified-files.js
+++ b/server/bundler/webpack-plugins/use-minified-files.js
@@ -1,0 +1,17 @@
+/** @format */
+
+/*
+ * modifies the require.ensure calls in production to point to .min.js instead of .js extension
+ */
+function UseMinifiedFiles() {}
+
+UseMinifiedFiles.prototype.apply = function( compiler ) {
+	compiler.plugin( 'compilation', function( compilation ) {
+		compilation.mainTemplate.plugin( 'require-ensure', function( source ) {
+			const newSrc = source.toString().replace( '.js"', '.min.js"' );
+			return this.asString( [ newSrc ] );
+		} );
+	} );
+};
+
+module.exports = UseMinifiedFiles;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -184,32 +184,14 @@ if ( calypsoEnv === 'desktop' ) {
 		'wpcom',
 	];
 
-	webpackConfig.plugins.push(
-		new webpack.optimize.CommonsChunkPlugin( {
-			name: 'vendor',
-			filename: 'vendor.[chunkhash].js',
-			minChunks: Infinity,
-		} )
-	);
-
-	// slight black magic here. 'manifest' is a secret webpack module that includes the webpack loader and
-	// the mapping from module id to path.
-	//
-	// We extract it to prevent build-$env chunk from changing when the contents of a child chunk change.
-	//
-	// See https://github.com/webpack/webpack/issues/1315 for some backgroud. Guidance here taken from
-	// https://github.com/webpack/webpack/issues/1315#issuecomment-158530525.
-	//
-	// Our hashes will still change when modules are added or removed, but many of our deploys don't
-	// involve module structure changes, so this should at least help in many cases.
-	webpackConfig.plugins.push(
-		new webpack.optimize.CommonsChunkPlugin( {
-			name: 'manifest',
-			// have to use [hash] here instead of [chunkhash] because this is an entry chunk
-			// TODO rename to manifest.js.  was changed to cachebust in: https://github.com/Automattic/wp-calypso/pull/17981
-			filename: 'manifest1.[hash].js'
-		} )
-	);
+	// for details on what the manifest is, see: https://webpack.js.org/guides/caching/
+	// tldr: webpack maintains a mapping from chunk ids --> filenames.  whenever a filename changes
+	// then the mapping changes.  By providing a non-existing chunkname to CommonsChunkPlugin,
+	// it extracts the "runtime" so that the frequently changing mapping doesn't break caching of the entry chunks
+	webpackConfig.plugins = webpackConfig.plugins.concat( [
+		new webpack.optimize.CommonsChunkPlugin( { name: 'vendor', minChunks: Infinity } ),
+		new webpack.optimize.CommonsChunkPlugin( { name: 'manifest' } )
+	] );
 
 	// jquery is only needed in the build for the desktop app
 	// see electron bug: https://github.com/atom/electron/issues/254

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -206,7 +206,8 @@ if ( calypsoEnv === 'desktop' ) {
 		new webpack.optimize.CommonsChunkPlugin( {
 			name: 'manifest',
 			// have to use [hash] here instead of [chunkhash] because this is an entry chunk
-			filename: 'manifest.[hash].js'
+			// TODO rename to manifest.js.  was changed to cachebust in: https://github.com/Automattic/wp-calypso/pull/17981
+			filename: 'manifest1.[hash].js'
 		} )
 	);
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -200,6 +200,10 @@ if ( calypsoEnv === 'desktop' ) {
 }
 
 if ( calypsoEnv === 'development' ) {
+	// we should not use chunkhash in development: https://github.com/webpack/webpack-dev-server/issues/377#issuecomment-241258405
+	webpackConfig.output.filename = '[name].js';
+	webpackConfig.output.chunkFilename = '[name].js';
+
 	webpackConfig.plugins = webpackConfig.plugins.concat( [
 		new webpack.HotModuleReplacementPlugin(),
 		new webpack.LoaderOptionsPlugin( { debug: true } ),

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -188,6 +188,7 @@ if ( calypsoEnv === 'desktop' ) {
 	// tldr: webpack maintains a mapping from chunk ids --> filenames.  whenever a filename changes
 	// then the mapping changes.  By providing a non-existing chunkname to CommonsChunkPlugin,
 	// it extracts the "runtime" so that the frequently changing mapping doesn't break caching of the entry chunks
+	// NOTE: order matters. vendor must be before manifest.
 	webpackConfig.plugins = webpackConfig.plugins.concat( [
 		new webpack.optimize.CommonsChunkPlugin( { name: 'vendor', minChunks: Infinity } ),
 		new webpack.optimize.CommonsChunkPlugin( { name: 'manifest' } )

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -19,6 +19,7 @@ const NameAllModulesPlugin = require( 'name-all-modules-plugin' );
  */
 const cacheIdentifier = require( './server/bundler/babel/babel-loader-cache-identifier' );
 const config = require( './server/config' );
+const UseMinifiedFiles = require( './server/bundler/webpack-plugins/use-minified-files' );
 
 /**
  * Internal variables
@@ -234,6 +235,7 @@ if ( calypsoEnv === 'development' ) {
 		} );
 	}
 } else {
+	webpackConfig.plugins.push( new UseMinifiedFiles() );
 	webpackConfig.entry.build = path.join( __dirname, 'client', 'boot', 'app' );
 	webpackConfig.devtool = false;
 }


### PR DESCRIPTION
This pr is a second attempt at re-enabling minification in prod for client loaded chunks.
Original: https://github.com/Automattic/wp-calypso/pull/17803

>introduced a regression in this commit where we no longer use minified versions of files for when files are loaded dynamically by the client.
This is because I replaced the custom require.ensure implementation with the default webpack one. This left out the file extension transformation from .js --> .min.js.
This PR attempts to bring back minification without replacing the entire require.ensure function.
it does this via a naive string.replace

While testing in staging it became apparent that the pr didn't solve the issue. My current theory is that the hash on the `manifest.[hash].js` file did not change which would mean that cachebusting would fail and the old unminified files would be served.  For those that don't know what `manifest.js` is, it is a file that the webpack runtime uses to help load code on demand.  One of its jobs is to match chunk Ids ('reader', 'async-module-X') with the filename of the chunk.  If our caches weren't recognizing manifest.js as new, then it would continue to serve the old one with the old values lacking the `.min.js`.  In order to be safe, I reverted instead of leaving the untested code out as a potential time bomb.

This PR just ~adds a single character to the manifest file which should work as a cachebust~.
After some research, it seemed like there was a better way to solve the issue. Namely, that the manifest _can_ and _should_ be based off of a chunkhash instead of a build hash.  Doing that happens to change the manifest name anyway without having to resort to a silly character addition.  I also made a change so that simple filenames are used during development. So in summary:

1. During development we use now will use `[name].js` instead of `[name].[chunkhash].js`
2. the manifest file will be named `[manifest].[chunkhash].js` (default) instead of `[manifest].[hash].js`.


TODO:
- [x] confirm theory re. cachebusting.
- [x] make sure new strategy manifest naming actually modifies the hash of the manifest.
- [x] test local devbuild
- [x] test that docker build dynamically loads minified files