### PR TITLE
Query Manager: Use static methods

### DIFF
--- a/client/lib/query-manager/activity/index.js
+++ b/client/lib/query-manager/activity/index.js
@@ -29,7 +29,7 @@ export default class ActivityQueryManager extends QueryManager {
 	 * @return {Number}       0 if equal, less than 0 if itemA is first,
 	 *                        greater than 0 if itemB is first.
 	 */
-	compare( query, { activityTs: tsA }, { activityTs: tsB } ) {
+	static compare( query, { activityTs: tsA }, { activityTs: tsB } ) {
 		return Date.parse( tsB ) - Date.parse( tsA );
 	}
 

--- a/client/lib/query-manager/activity/test/index.js
+++ b/client/lib/query-manager/activity/test/index.js
@@ -15,6 +15,9 @@ import ActivityQueryManager from '..';
  */
 const DEFAULT_ACTIVITY_DATE = '2014-09-14T00:30:00+02:00';
 const DEFAULT_ACTIVITY_TS = Date.parse( DEFAULT_ACTIVITY_DATE );
+
+const makeComparator = query => ( a, b ) => ActivityQueryManager.compare( query, a, b );
+
 const DEFAULT_ACTIVITY = deepFreeze( {
 	activityDate: DEFAULT_ACTIVITY_DATE,
 	activityGroup: 'plugin',
@@ -31,11 +34,6 @@ const DEFAULT_ACTIVITY = deepFreeze( {
 } );
 
 describe( 'ActivityQueryManager', () => {
-	let manager;
-	beforeEach( () => {
-		manager = new ActivityQueryManager();
-	} );
-
 	describe( '#matches()', () => {
 		describe( 'query.dateStart', () => {
 			test( 'should return true if activity is at the specified time', () => {
@@ -160,7 +158,7 @@ describe( 'ActivityQueryManager', () => {
 
 	describe( '#compare()', () => {
 		test( 'should sort by timestamp descending', () => {
-			const sortFunc = manager.compare.bind( manager, {} );
+			const sortFunc = makeComparator( {} );
 			const activityA = { activityId: 'a', activityTs: 100000 };
 			const activityB = { activityId: 'b', activityTs: 200000 };
 
@@ -168,7 +166,7 @@ describe( 'ActivityQueryManager', () => {
 		} );
 
 		test( 'should include simultaneous events (in any order, sort is unstable)', () => {
-			const sortFunc = manager.compare.bind( manager, {} );
+			const sortFunc = makeComparator( {} );
 			const activityA = { activityId: 'a', activityTs: 100000 };
 			const activityB = { activityId: 'b', activityTs: 100000 };
 

--- a/client/lib/query-manager/index.js
+++ b/client/lib/query-manager/index.js
@@ -97,7 +97,7 @@ export default class QueryManager {
 	 * @return {Number}       0 if equal, less than 0 if itemA is first,
 	 *                        greater than 0 if itemB is first.
 	 */
-	compare( query, itemA, itemB ) {
+	static compare( query, itemA, itemB ) {
 		if ( itemA === itemB ) {
 			return 0;
 		}
@@ -125,7 +125,7 @@ export default class QueryManager {
 				// method aren't required to implement this check.
 				return 0;
 			}
-			return this.compare( query, items[ keyA ], items[ keyB ] );
+			return this.constructor.compare( query, items[ keyA ], items[ keyB ] );
 		} );
 	}
 

--- a/client/lib/query-manager/index.js
+++ b/client/lib/query-manager/index.js
@@ -27,6 +27,8 @@ export const DELETE_PATCH_KEY = '__DELETE';
  * responsible for implementing its matching, merging, and sorting behaviors.
  */
 export default class QueryManager {
+	static QueryKey = QueryKey;
+
 	/**
 	 * Constructs a new instance of QueryManager
 	 *
@@ -411,5 +413,3 @@ export default class QueryManager {
 		);
 	}
 }
-
-QueryManager.QueryKey = QueryKey;

--- a/client/lib/query-manager/index.js
+++ b/client/lib/query-manager/index.js
@@ -64,7 +64,7 @@ export default class QueryManager {
 	 * @param  {Boolean} patch       Use patching application
 	 * @return {?Object}             Item to track, or undefined to omit
 	 */
-	mergeItem( item, revisedItem, patch = false ) {
+	static mergeItem( item, revisedItem, patch = false ) {
 		if ( patch ) {
 			if ( revisedItem[ DELETE_PATCH_KEY ] ) {
 				return undefined;
@@ -235,7 +235,7 @@ export default class QueryManager {
 			( memo, receivedItem ) => {
 				const receivedItemKey = receivedItem[ this.options.itemKey ];
 				const item = this.getItem( receivedItemKey );
-				const mergedItem = this.mergeItem( item, receivedItem, options.patch );
+				const mergedItem = this.constructor.mergeItem( item, receivedItem, options.patch );
 
 				if ( undefined === mergedItem ) {
 					if ( item ) {

--- a/client/lib/query-manager/index.js
+++ b/client/lib/query-manager/index.js
@@ -115,7 +115,7 @@ export default class QueryManager {
 	 * @param  {Array}  items Items by which to sort
 	 * @param  {Object} query Query object
 	 */
-	sort( keys, items, query ) {
+	static sort( keys, items, query ) {
 		keys.sort( ( keyA, keyB ) => {
 			if ( ! items[ keyA ] || ! items[ keyB ] ) {
 				// One of the items has yet to be removed from the
@@ -125,7 +125,7 @@ export default class QueryManager {
 				// method aren't required to implement this check.
 				return 0;
 			}
-			return this.constructor.compare( query, items[ keyA ], items[ keyB ] );
+			return this.compare( query, items[ keyA ], items[ keyB ] );
 		} );
 	}
 
@@ -390,7 +390,7 @@ export default class QueryManager {
 						);
 
 						// Re-sort the set
-						this.sort( memo[ queryKey ].itemKeys, nextItems, query );
+						this.constructor.sort( memo[ queryKey ].itemKeys, nextItems, query );
 					}
 				} );
 

--- a/client/lib/query-manager/media/index.js
+++ b/client/lib/query-manager/media/index.js
@@ -16,6 +16,9 @@ import { DEFAULT_MEDIA_QUERY } from './constants';
  * MediaQueryManager manages media which can be queried and change over time
  */
 export default class MediaQueryManager extends PaginatedQueryManager {
+	static QueryKey = MediaQueryKey;
+	static DEFAULT_QUERY = DEFAULT_MEDIA_QUERY;
+
 	/**
 	 * Returns true if the media item matches the given query, or false
 	 * otherwise.
@@ -25,7 +28,7 @@ export default class MediaQueryManager extends PaginatedQueryManager {
 	 * @return {Boolean}       Whether media item matches query
 	 */
 	static matches( query, media ) {
-		return every( { ...DEFAULT_MEDIA_QUERY, ...query }, ( value, key ) => {
+		return every( { ...this.constructor.DEFAULT_QUERY, ...query }, ( value, key ) => {
 			switch ( key ) {
 				case 'search':
 					if ( ! value ) {
@@ -110,7 +113,3 @@ export default class MediaQueryManager extends PaginatedQueryManager {
 		return order || 0;
 	}
 }
-
-MediaQueryManager.QueryKey = MediaQueryKey;
-
-MediaQueryManager.DEFAULT_QUERY = DEFAULT_MEDIA_QUERY;

--- a/client/lib/query-manager/media/index.js
+++ b/client/lib/query-manager/media/index.js
@@ -17,7 +17,7 @@ import { DEFAULT_MEDIA_QUERY } from './constants';
  */
 export default class MediaQueryManager extends PaginatedQueryManager {
 	static QueryKey = MediaQueryKey;
-	static DEFAULT_QUERY = DEFAULT_MEDIA_QUERY;
+	static DefaultQuery = DEFAULT_MEDIA_QUERY;
 
 	/**
 	 * Returns true if the media item matches the given query, or false
@@ -28,7 +28,7 @@ export default class MediaQueryManager extends PaginatedQueryManager {
 	 * @return {Boolean}       Whether media item matches query
 	 */
 	static matches( query, media ) {
-		return every( { ...this.constructor.DEFAULT_QUERY, ...query }, ( value, key ) => {
+		return every( { ...this.constructor.DefaultQuery, ...query }, ( value, key ) => {
 			switch ( key ) {
 				case 'search':
 					if ( ! value ) {

--- a/client/lib/query-manager/media/index.js
+++ b/client/lib/query-manager/media/index.js
@@ -88,7 +88,7 @@ export default class MediaQueryManager extends PaginatedQueryManager {
 	 * @return {Number}        0 if equal, less than 0 if mediaA is first,
 	 *                         greater than 0 if mediaB is first.
 	 */
-	compare( query, mediaA, mediaB ) {
+	static compare( query, mediaA, mediaB ) {
 		let order;
 
 		switch ( query.order_by ) {

--- a/client/lib/query-manager/media/index.js
+++ b/client/lib/query-manager/media/index.js
@@ -28,7 +28,7 @@ export default class MediaQueryManager extends PaginatedQueryManager {
 	 * @return {Boolean}       Whether media item matches query
 	 */
 	static matches( query, media ) {
-		return every( { ...this.constructor.DefaultQuery, ...query }, ( value, key ) => {
+		return every( { ...this.DefaultQuery, ...query }, ( value, key ) => {
 			switch ( key ) {
 				case 'search':
 					if ( ! value ) {

--- a/client/lib/query-manager/media/test/index.js
+++ b/client/lib/query-manager/media/test/index.js
@@ -33,12 +33,9 @@ const DEFAULT_MEDIA = {
 	exif: {},
 };
 
-describe( 'MediaQueryManager', () => {
-	let manager;
-	beforeEach( () => {
-		manager = new MediaQueryManager();
-	} );
+const makeComparator = query => ( a, b ) => MediaQueryManager.compare( query, a, b );
 
+describe( 'MediaQueryManager', () => {
 	describe( '#matches()', () => {
 		describe( 'query.search', () => {
 			test( 'should return false for a non-matching search', () => {
@@ -308,7 +305,7 @@ describe( 'MediaQueryManager', () => {
 		describe( 'query.order', () => {
 			test( 'should sort descending by default', () => {
 				const sorted = [ { ID: 200 }, { ID: 400 } ].sort(
-					manager.compare.bind( manager, {
+					makeComparator( {
 						order_by: 'ID',
 					} )
 				);
@@ -318,7 +315,7 @@ describe( 'MediaQueryManager', () => {
 
 			test( 'should reverse order when specified as ascending', () => {
 				const sorted = [ { ID: 400 }, { ID: 200 } ].sort(
-					manager.compare.bind( manager, {
+					makeComparator( {
 						order_by: 'ID',
 						order: 'ASC',
 					} )
@@ -342,7 +339,7 @@ describe( 'MediaQueryManager', () => {
 				};
 
 				test( 'should order by date', () => {
-					const sorted = [ olderMedia, newerMedia ].sort( manager.compare.bind( manager, {} ) );
+					const sorted = [ olderMedia, newerMedia ].sort( makeComparator( {} ) );
 
 					expect( sorted ).to.eql( [ newerMedia, olderMedia ] );
 				} );
@@ -362,7 +359,7 @@ describe( 'MediaQueryManager', () => {
 
 				test( 'should sort by title', () => {
 					const sorted = [ aaMedia, abMedia ].sort(
-						manager.compare.bind( manager, {
+						makeComparator( {
 							order_by: 'title',
 						} )
 					);
@@ -374,7 +371,7 @@ describe( 'MediaQueryManager', () => {
 			describe( 'ID', () => {
 				test( 'should sort by ID', () => {
 					const sorted = [ { ID: 200 }, { ID: 400 } ].sort(
-						manager.compare.bind( manager, {
+						makeComparator( {
 							order_by: 'ID',
 						} )
 					);

--- a/client/lib/query-manager/paginated/constants.js
+++ b/client/lib/query-manager/paginated/constants.js
@@ -1,5 +1,5 @@
 /** @format */
-export const DEFAULT_QUERY = {
+export const DEFAULT_PAGINATED_QUERY = {
 	number: 20,
 	page: 1,
 };

--- a/client/lib/query-manager/paginated/index.js
+++ b/client/lib/query-manager/paginated/index.js
@@ -16,6 +16,9 @@ import { DEFAULT_QUERY, PAGINATION_QUERY_KEYS } from './constants';
  * change over time
  */
 export default class PaginatedQueryManager extends QueryManager {
+	static QueryKey = PaginatedQueryKey;
+	static DEFAULT_QUERY = DEFAULT_QUERY;
+
 	/**
 	 * Returns true if the specified query is an object containing one or more
 	 * query pagination keys.
@@ -219,7 +222,3 @@ export default class PaginatedQueryManager extends QueryManager {
 		);
 	}
 }
-
-PaginatedQueryManager.QueryKey = PaginatedQueryKey;
-
-PaginatedQueryManager.DEFAULT_QUERY = DEFAULT_QUERY;

--- a/client/lib/query-manager/paginated/index.js
+++ b/client/lib/query-manager/paginated/index.js
@@ -9,7 +9,7 @@ import { cloneDeep, includes, omit, range } from 'lodash';
  */
 import QueryManager from '../';
 import PaginatedQueryKey from './key';
-import { DEFAULT_QUERY, PAGINATION_QUERY_KEYS } from './constants';
+import { DEFAULT_PAGINATED_QUERY, PAGINATION_QUERY_KEYS } from './constants';
 
 /**
  * PaginatedQueryManager manages paginated data which can be queried and
@@ -17,7 +17,7 @@ import { DEFAULT_QUERY, PAGINATION_QUERY_KEYS } from './constants';
  */
 export default class PaginatedQueryManager extends QueryManager {
 	static QueryKey = PaginatedQueryKey;
-	static DEFAULT_QUERY = DEFAULT_QUERY;
+	static DefaultQuery = DEFAULT_PAGINATED_QUERY;
 
 	/**
 	 * Returns true if the specified query is an object containing one or more
@@ -56,8 +56,8 @@ export default class PaginatedQueryManager extends QueryManager {
 		}
 
 		// Slice the unpaginated set of data
-		const page = query.page || this.constructor.DEFAULT_QUERY.page;
-		const perPage = query.number || this.constructor.DEFAULT_QUERY.number;
+		const page = query.page || this.constructor.DefaultQuery.page;
+		const perPage = query.number || this.constructor.DefaultQuery.number;
 		const startOffset = ( page - 1 ) * perPage;
 
 		return dataIgnoringPage.slice( startOffset, startOffset + perPage );
@@ -99,7 +99,7 @@ export default class PaginatedQueryManager extends QueryManager {
 			return found;
 		}
 
-		const perPage = query.number || this.constructor.DEFAULT_QUERY.number;
+		const perPage = query.number || this.constructor.DefaultQuery.number;
 		return Math.ceil( found / perPage );
 	}
 
@@ -151,8 +151,8 @@ export default class PaginatedQueryManager extends QueryManager {
 		}
 
 		const queryKey = this.constructor.QueryKey.stringify( options.query );
-		const page = options.query.page || this.constructor.DEFAULT_QUERY.page;
-		const perPage = options.query.number || this.constructor.DEFAULT_QUERY.number;
+		const page = options.query.page || this.constructor.DefaultQuery.page;
+		const perPage = options.query.number || this.constructor.DefaultQuery.number;
 		const startOffset = ( page - 1 ) * perPage;
 		const nextQuery = nextManager.data.queries[ queryKey ];
 

--- a/client/lib/query-manager/paginated/test/index.js
+++ b/client/lib/query-manager/paginated/test/index.js
@@ -13,9 +13,8 @@ import { useSandbox } from 'test/helpers/use-sinon';
 /**
  * Module constants
  */
-const TestCustomQueryManager = class TermQueryManager extends PaginatedQueryManager {};
-TestCustomQueryManager.DEFAULT_QUERY = {
-	number: 25,
+const TestCustomQueryManager = class TermQueryManager extends PaginatedQueryManager {
+	static DEFAULT_QUERY = { number: 25 };
 };
 
 describe( 'PaginatedQueryManager', () => {

--- a/client/lib/query-manager/paginated/test/index.js
+++ b/client/lib/query-manager/paginated/test/index.js
@@ -11,10 +11,12 @@ import PaginatedQueryManager from '../';
 import { useSandbox } from 'test/helpers/use-sinon';
 
 /**
- * Module constants
+ * Provide subclass with compare method implementation for testing
  */
 class TestCustomQueryManager extends PaginatedQueryManager {
-	static DefaultQuery = { number: 25 };
+	static compare( query, a, b ) {
+		return a.ID - b.ID;
+	}
 }
 
 describe( 'PaginatedQueryManager', () => {
@@ -23,8 +25,7 @@ describe( 'PaginatedQueryManager', () => {
 	useSandbox( _sandbox => ( sandbox = _sandbox ) );
 
 	beforeEach( () => {
-		manager = new PaginatedQueryManager();
-		sandbox.stub( PaginatedQueryManager.prototype, 'compare', ( query, a, b ) => a.ID - b.ID );
+		manager = new TestCustomQueryManager();
 	} );
 
 	afterEach( () => {
@@ -307,8 +308,9 @@ describe( 'PaginatedQueryManager', () => {
 		} );
 
 		test( 'should use the constructors DefaultQuery.number if query object does not specify it', () => {
-			let customizedManager = new TestCustomQueryManager();
-			customizedManager = customizedManager.receive(
+			const customizedManager = new class extends TestCustomQueryManager {
+				static DefaultQuery = { number: 25 };
+			}().receive(
 				[
 					{ ID: 144 },
 					{ ID: 152 },

--- a/client/lib/query-manager/paginated/test/index.js
+++ b/client/lib/query-manager/paginated/test/index.js
@@ -13,9 +13,9 @@ import { useSandbox } from 'test/helpers/use-sinon';
 /**
  * Module constants
  */
-const TestCustomQueryManager = class TermQueryManager extends PaginatedQueryManager {
+class TestCustomQueryManager extends PaginatedQueryManager {
 	static DEFAULT_QUERY = { number: 25 };
-};
+}
 
 describe( 'PaginatedQueryManager', () => {
 	let sandbox, manager;

--- a/client/lib/query-manager/paginated/test/index.js
+++ b/client/lib/query-manager/paginated/test/index.js
@@ -14,7 +14,7 @@ import { useSandbox } from 'test/helpers/use-sinon';
  * Module constants
  */
 class TestCustomQueryManager extends PaginatedQueryManager {
-	static DEFAULT_QUERY = { number: 25 };
+	static DefaultQuery = { number: 25 };
 }
 
 describe( 'PaginatedQueryManager', () => {
@@ -306,7 +306,7 @@ describe( 'PaginatedQueryManager', () => {
 			] );
 		} );
 
-		test( 'should use the constructors DEFAULT_QUERY.number if query object does not specify it', () => {
+		test( 'should use the constructors DefaultQuery.number if query object does not specify it', () => {
 			let customizedManager = new TestCustomQueryManager();
 			customizedManager = customizedManager.receive(
 				[

--- a/client/lib/query-manager/post/index.js
+++ b/client/lib/query-manager/post/index.js
@@ -16,6 +16,9 @@ import { DEFAULT_POST_QUERY } from './constants';
  * PostQueryManager manages posts which can be queried and change over time
  */
 export default class PostQueryManager extends PaginatedQueryManager {
+	static QueryKey = PostQueryKey;
+	static DEFAULT_QUERY = DEFAULT_POST_QUERY;
+
 	/**
 	 * Returns true if the post matches the given query, or false otherwise.
 	 *
@@ -24,7 +27,7 @@ export default class PostQueryManager extends PaginatedQueryManager {
 	 * @return {Boolean}       Whether post matches query
 	 */
 	static matches( query, post ) {
-		const queryWithDefaults = Object.assign( {}, DEFAULT_POST_QUERY, query );
+		const queryWithDefaults = Object.assign( {}, this.constructor.DEFAULT_QUERY, query );
 		return every( queryWithDefaults, ( value, key ) => {
 			switch ( key ) {
 				case 'search':
@@ -154,7 +157,3 @@ export default class PostQueryManager extends PaginatedQueryManager {
 		return order || 0;
 	}
 }
-
-PostQueryManager.QueryKey = PostQueryKey;
-
-PostQueryManager.DEFAULT_QUERY = DEFAULT_POST_QUERY;

--- a/client/lib/query-manager/post/index.js
+++ b/client/lib/query-manager/post/index.js
@@ -17,7 +17,7 @@ import { DEFAULT_POST_QUERY } from './constants';
  */
 export default class PostQueryManager extends PaginatedQueryManager {
 	static QueryKey = PostQueryKey;
-	static DEFAULT_QUERY = DEFAULT_POST_QUERY;
+	static DefaultQuery = DEFAULT_POST_QUERY;
 
 	/**
 	 * Returns true if the post matches the given query, or false otherwise.
@@ -27,7 +27,7 @@ export default class PostQueryManager extends PaginatedQueryManager {
 	 * @return {Boolean}       Whether post matches query
 	 */
 	static matches( query, post ) {
-		const queryWithDefaults = Object.assign( {}, this.constructor.DEFAULT_QUERY, query );
+		const queryWithDefaults = Object.assign( {}, this.constructor.DefaultQuery, query );
 		return every( queryWithDefaults, ( value, key ) => {
 			switch ( key ) {
 				case 'search':

--- a/client/lib/query-manager/post/index.js
+++ b/client/lib/query-manager/post/index.js
@@ -123,7 +123,7 @@ export default class PostQueryManager extends PaginatedQueryManager {
 	 * @return {Number}       0 if equal, less than 0 if postA is first,
 	 *                        greater than 0 if postB is first.
 	 */
-	compare( query, postA, postB ) {
+	static compare( query, postA, postB ) {
 		let order;
 
 		switch ( query.order_by ) {

--- a/client/lib/query-manager/post/index.js
+++ b/client/lib/query-manager/post/index.js
@@ -27,7 +27,7 @@ export default class PostQueryManager extends PaginatedQueryManager {
 	 * @return {Boolean}       Whether post matches query
 	 */
 	static matches( query, post ) {
-		const queryWithDefaults = Object.assign( {}, this.constructor.DefaultQuery, query );
+		const queryWithDefaults = Object.assign( {}, this.DefaultQuery, query );
 		return every( queryWithDefaults, ( value, key ) => {
 			switch ( key ) {
 				case 'search':

--- a/client/lib/query-manager/post/test/index.js
+++ b/client/lib/query-manager/post/test/index.js
@@ -85,12 +85,9 @@ const DEFAULT_POST = {
 	],
 };
 
-describe( 'PostQueryManager', () => {
-	let manager;
-	beforeEach( () => {
-		manager = new PostQueryManager();
-	} );
+const makeComparator = query => ( a, b ) => PostQueryManager.compare( query, a, b );
 
+describe( 'PostQueryManager', () => {
 	describe( '#matches()', () => {
 		describe( 'query.search', () => {
 			test( 'should return false for a non-matching search', () => {
@@ -804,7 +801,7 @@ describe( 'PostQueryManager', () => {
 		describe( 'query.order', () => {
 			test( 'should sort descending by default', () => {
 				const sorted = [ { ID: 200 }, { ID: 400 } ].sort(
-					manager.compare.bind( manager, {
+					makeComparator( {
 						order_by: 'ID',
 					} )
 				);
@@ -814,7 +811,7 @@ describe( 'PostQueryManager', () => {
 
 			test( 'should reverse order when specified as ascending', () => {
 				const sorted = [ { ID: 200 }, { ID: 400 } ].sort(
-					manager.compare.bind( manager, {
+					makeComparator( {
 						order_by: 'ID',
 						order: 'ASC',
 					} )
@@ -836,7 +833,7 @@ describe( 'PostQueryManager', () => {
 				} );
 
 				test( 'should order by date', () => {
-					const sorted = [ olderPost, newerPost ].sort( manager.compare.bind( manager, {} ) );
+					const sorted = [ olderPost, newerPost ].sort( makeComparator( {} ) );
 
 					expect( sorted ).to.eql( [ newerPost, olderPost ] );
 				} );
@@ -854,7 +851,7 @@ describe( 'PostQueryManager', () => {
 
 				test( 'should order by modified', () => {
 					const sorted = [ olderPost, newerPost ].sort(
-						manager.compare.bind( manager, {
+						makeComparator( {
 							order_by: 'modified',
 						} )
 					);
@@ -875,7 +872,7 @@ describe( 'PostQueryManager', () => {
 
 				test( 'should sort by title', () => {
 					const sorted = [ aPost, zPost ].sort(
-						manager.compare.bind( manager, {
+						makeComparator( {
 							order_by: 'title',
 						} )
 					);
@@ -900,7 +897,7 @@ describe( 'PostQueryManager', () => {
 
 				test( 'should sort by comment count', () => {
 					const sorted = [ unpopularPost, popularPost ].sort(
-						manager.compare.bind( manager, {
+						makeComparator( {
 							order_by: 'comment_count',
 						} )
 					);
@@ -912,7 +909,7 @@ describe( 'PostQueryManager', () => {
 			describe( 'ID', () => {
 				test( 'should sort by ID', () => {
 					const sorted = [ { ID: 200 }, { ID: 400 } ].sort(
-						manager.compare.bind( manager, {
+						makeComparator( {
 							order_by: 'ID',
 						} )
 					);

--- a/client/lib/query-manager/term/index.js
+++ b/client/lib/query-manager/term/index.js
@@ -16,7 +16,7 @@ import { DEFAULT_TERM_QUERY } from './constants';
  */
 export default class TermQueryManager extends PaginatedQueryManager {
 	static QueryKey = TermQueryKey;
-	static DEFAULT_QUERY = DEFAULT_TERM_QUERY;
+	static DefaultQuery = DEFAULT_TERM_QUERY;
 
 	/**
 	 * Returns true if the term matches the given query, or false otherwise.

--- a/client/lib/query-manager/term/index.js
+++ b/client/lib/query-manager/term/index.js
@@ -15,6 +15,9 @@ import { DEFAULT_TERM_QUERY } from './constants';
  * TermQueryManager manages terms which can be queried and change over time
  */
 export default class TermQueryManager extends PaginatedQueryManager {
+	static QueryKey = TermQueryKey;
+	static DEFAULT_QUERY = DEFAULT_TERM_QUERY;
+
 	/**
 	 * Returns true if the term matches the given query, or false otherwise.
 	 *
@@ -65,7 +68,3 @@ export default class TermQueryManager extends PaginatedQueryManager {
 		return order || 0;
 	}
 }
-
-TermQueryManager.QueryKey = TermQueryKey;
-
-TermQueryManager.DEFAULT_QUERY = DEFAULT_TERM_QUERY;

--- a/client/lib/query-manager/term/index.js
+++ b/client/lib/query-manager/term/index.js
@@ -47,7 +47,7 @@ export default class TermQueryManager extends PaginatedQueryManager {
 	 * @return {Number}       0 if equal, less than 0 if termA is first,
 	 *                        greater than 0 if termB is first.
 	 */
-	compare( query, termA, termB ) {
+	static compare( query, termA, termB ) {
 		let order;
 
 		switch ( query.order_by ) {

--- a/client/lib/query-manager/term/test/index.js
+++ b/client/lib/query-manager/term/test/index.js
@@ -20,12 +20,9 @@ const DEFAULT_TERM = {
 	post_count: 5,
 };
 
-describe( 'TermQueryManager', () => {
-	let manager;
-	beforeEach( () => {
-		manager = new TermQueryManager();
-	} );
+const makeComparator = query => ( a, b ) => TermQueryManager.compare( query, a, b );
 
+describe( 'TermQueryManager', () => {
 	describe( '#matches()', () => {
 		describe( 'query.search', () => {
 			test( 'should return false for a non-matching search', () => {
@@ -89,7 +86,7 @@ describe( 'TermQueryManager', () => {
 		describe( 'query.order', () => {
 			test( 'should sort ascending by default', () => {
 				const sorted = [ { name: 'Food' }, { name: 'Cars' } ].sort(
-					manager.compare.bind( manager, {
+					makeComparator( {
 						order_by: 'name',
 					} )
 				);
@@ -99,7 +96,7 @@ describe( 'TermQueryManager', () => {
 
 			test( 'should reverse order when specified as descending', () => {
 				const sorted = [ { name: 'Food' }, { name: 'Cars' } ].sort(
-					manager.compare.bind( manager, {
+					makeComparator( {
 						order_by: 'name',
 						order: 'DESC',
 					} )
@@ -113,7 +110,7 @@ describe( 'TermQueryManager', () => {
 			describe( 'name', () => {
 				test( 'should sort by name', () => {
 					const sorted = [ { name: 'Food' }, { name: 'Cars' } ].sort(
-						manager.compare.bind( manager, {
+						makeComparator( {
 							order_by: 'name',
 						} )
 					);
@@ -130,7 +127,7 @@ describe( 'TermQueryManager', () => {
 
 				test( 'should sort by post count', () => {
 					const sorted = [ DEFAULT_TERM, unusedTerm ].sort(
-						manager.compare.bind( manager, {
+						makeComparator( {
 							order_by: 'count',
 						} )
 					);

--- a/client/lib/query-manager/test/index.js
+++ b/client/lib/query-manager/test/index.js
@@ -89,15 +89,15 @@ describe( 'QueryManager', () => {
 
 	describe( '#compare()', () => {
 		test( 'should return 0 for equal items', () => {
-			expect( manager.compare( {}, 40, 40 ) ).to.equal( 0 );
+			expect( QueryManager.compare( {}, 40, 40 ) ).to.equal( 0 );
 		} );
 
 		test( 'should return a number less than zero if the first argument is larger', () => {
-			expect( manager.compare( {}, 50, 40 ) ).to.be.lt( 0 );
+			expect( QueryManager.compare( {}, 50, 40 ) ).to.be.lt( 0 );
 		} );
 
 		test( 'should return a number greater than zero if the first argument is smaller', () => {
-			expect( manager.compare( {}, 30, 40 ) ).to.be.gt( 0 );
+			expect( QueryManager.compare( {}, 30, 40 ) ).to.be.gt( 0 );
 		} );
 	} );
 
@@ -367,7 +367,7 @@ describe( 'QueryManager', () => {
 
 		test( 'should compare items appended to query set', () => {
 			manager = manager.receive( [ { ID: 140 }, { ID: 160 } ], { query: {} } );
-			sandbox.stub( manager, 'compare', ( query, a, b ) => a.ID - b.ID );
+			sandbox.stub( QueryManager, 'compare', ( query, a, b ) => a.ID - b.ID );
 			manager = manager.receive( { ID: 150 } );
 
 			expect( manager.getItems( {} ) ).to.eql( [ { ID: 140 }, { ID: 150 }, { ID: 160 } ] );

--- a/client/lib/query-manager/test/index.js
+++ b/client/lib/query-manager/test/index.js
@@ -52,26 +52,26 @@ describe( 'QueryManager', () => {
 
 	describe( '#mergeItem()', () => {
 		test( 'should return the revised item by default', () => {
-			const merged = manager.mergeItem( { ID: 144 }, { ID: 152 } );
+			const merged = QueryManager.mergeItem( { ID: 144 }, { ID: 152 } );
 
 			expect( merged ).to.eql( { ID: 152 } );
 		} );
 
 		test( 'should return a merged item when patching', () => {
-			const merged = manager.mergeItem( { ID: 144 }, { changed: true }, true );
+			const merged = QueryManager.mergeItem( { ID: 144 }, { changed: true }, true );
 
 			expect( merged ).to.eql( { ID: 144, changed: true } );
 		} );
 
 		test( 'should not mutate the original copy', () => {
 			const original = Object.freeze( { ID: 144 } );
-			const merged = manager.mergeItem( original, { changed: true }, true );
+			const merged = QueryManager.mergeItem( original, { changed: true }, true );
 
 			expect( merged ).to.not.equal( original );
 		} );
 
 		test( 'should return undefined if revised item includes delete key and patching', () => {
-			const merged = manager.mergeItem( { ID: 144 }, { [ DELETE_PATCH_KEY ]: true }, true );
+			const merged = QueryManager.mergeItem( { ID: 144 }, { [ DELETE_PATCH_KEY ]: true }, true );
 
 			expect( merged ).to.be.undefined;
 		} );
@@ -272,7 +272,7 @@ describe( 'QueryManager', () => {
 
 		test( 'should omit an item that returns undefined from #mergeItem()', () => {
 			manager = manager.receive( { ID: 144 } );
-			sandbox.stub( manager, 'mergeItem' ).returns( undefined );
+			sandbox.stub( QueryManager, 'mergeItem' ).returns( undefined );
 			const newManager = manager.receive( { ID: 144 } );
 
 			expect( manager.getItems() ).to.eql( [ { ID: 144 } ] );
@@ -281,7 +281,7 @@ describe( 'QueryManager', () => {
 
 		test( "should do nothing if #mergeItem() returns undefined but the item didn't exist", () => {
 			manager = manager.receive();
-			sandbox.stub( manager, 'mergeItem' ).returns( undefined );
+			sandbox.stub( QueryManager, 'mergeItem' ).returns( undefined );
 			const newManager = manager.receive( { ID: 144 } );
 
 			expect( manager ).to.equal( newManager );
@@ -348,7 +348,7 @@ describe( 'QueryManager', () => {
 
 		test( 'should remove a tracked query item when it is omitted from items', () => {
 			manager = manager.receive( { ID: 144 }, { query: {} } );
-			sandbox.stub( manager, 'mergeItem' ).returns( undefined );
+			sandbox.stub( QueryManager, 'mergeItem' ).returns( undefined );
 			const newManager = manager.receive( { ID: 144 } );
 
 			expect( manager.getItems() ).to.eql( [ { ID: 144 } ] );

--- a/client/lib/query-manager/test/index.js
+++ b/client/lib/query-manager/test/index.js
@@ -433,6 +433,36 @@ describe( 'QueryManager', () => {
 			expect( newManager.getFound( {} ) ).to.equal( 2 );
 			expect( newManager.getItems( {} ) ).to.eql( [ { ID: 144 }, { ID: 152 } ] );
 		} );
+
+		it( 'should sort items when merging queries', () => {
+			sandbox.stub( QueryManager, 'compare', ( query, a, b ) => a.ID - b.ID );
+			[ { ID: 4 }, { ID: 2 }, { ID: 3 } ].forEach(
+				item =>
+					( manager = manager.receive( item, {
+						mergeQuery: true,
+						query: {},
+					} ) )
+			);
+			// console.log( manager.data.queries );
+			expect( manager.getItems( {} ) ).to.eql( [ { ID: 2 }, { ID: 3 }, { ID: 4 } ] );
+		} );
+
+		it( 'should sort when extended using subclassed static compare', () => {
+			let sortingManager = new class extends QueryManager {
+				static compare( query, a, b ) {
+					return a.ID - b.ID;
+				}
+			}();
+			[ { ID: 4 }, { ID: 2 }, { ID: 3 } ].forEach(
+				item =>
+					( sortingManager = sortingManager.receive( item, {
+						mergeQuery: true,
+						query: {},
+					} ) )
+			);
+			// console.log( sortingManager.data.queries );
+			expect( sortingManager.getItems( {} ) ).to.eql( [ { ID: 2 }, { ID: 3 }, { ID: 4 } ] );
+		} );
 	} );
 
 	describe( '.QueryKey', () => {

--- a/client/lib/query-manager/theme/index.js
+++ b/client/lib/query-manager/theme/index.js
@@ -11,7 +11,7 @@ import { DEFAULT_THEME_QUERY } from './constants';
  */
 export default class ThemeQueryManager extends PaginatedQueryManager {
 	static QueryKey = ThemeQueryKey;
-	static DEFAULT_QUERY = DEFAULT_THEME_QUERY;
+	static DefaultQuery = DEFAULT_THEME_QUERY;
 
 	/**
 	 * A sorting function that defines the sort order of items under

--- a/client/lib/query-manager/theme/index.js
+++ b/client/lib/query-manager/theme/index.js
@@ -10,6 +10,9 @@ import { DEFAULT_THEME_QUERY } from './constants';
  * ThemeQueryManager manages themes which can be queried
  */
 export default class ThemeQueryManager extends PaginatedQueryManager {
+	static QueryKey = ThemeQueryKey;
+	static DEFAULT_QUERY = DEFAULT_THEME_QUERY;
+
 	/**
 	 * A sorting function that defines the sort order of items under
 	 * consideration of the specified query.
@@ -23,7 +26,3 @@ export default class ThemeQueryManager extends PaginatedQueryManager {
 		return; // Leave the keys argument unchanged.
 	}
 }
-
-ThemeQueryManager.QueryKey = ThemeQueryKey;
-
-ThemeQueryManager.DEFAULT_QUERY = DEFAULT_THEME_QUERY;

--- a/client/lib/query-manager/theme/index.js
+++ b/client/lib/query-manager/theme/index.js
@@ -22,7 +22,7 @@ export default class ThemeQueryManager extends PaginatedQueryManager {
 	 * The themes query REST API endpoint uses ElasticSearch to sort results by
 	 * relevancy, which we cannot easily mimick on the client side.
 	 */
-	sort() {
+	static sort() {
 		return; // Leave the keys argument unchanged.
 	}
 }

--- a/client/lib/query-manager/theme/test/index.js
+++ b/client/lib/query-manager/theme/test/index.js
@@ -26,9 +26,8 @@ describe( 'ThemeQueryManager', () => {
 				'pachyderm',
 			] );
 			const keys = [ ...originalKeys ];
-			const manager = new ThemeQueryManager();
 
-			manager.sort( keys );
+			ThemeQueryManager.sort( keys );
 			expect( keys ).to.deep.equal( originalKeys );
 		} );
 	} );


### PR DESCRIPTION
This PR does some cleanup and improvements around `QueryManager`. The following should not change behavior:

- ~247d31626 Prettier query-manager (isolated in #18004)~
- 1a349f96d Make QueryKey, DEFAULT_QUERY es2015 static class properties
- 10eb1847c Remove redundant in-line class declaration
- e5c6580ac Rename QueryManager.DEFAULT_QUERY to DefaultQuery

These changes are significant. 

- 6d4b3c9e2 **Make `compare` a static method**
- ae93ad49c **Make `mergeItem` a static method**
- 60d1101 **Make `sort` a static method**

## Testing
1. Do the tests pass? They've been updated accordingly. Do the changes make sense?
1. Smoke test parts of Calypso that use the different `QueryManagers`:
   * Media
   * Paginated
   * Post
   * Term
   * Theme

## ~Blockers~
- [x] I'd like to land #18004 first to reduce the size and noisiness of this PR.