### PR TITLE
Refactor image-editor/utils, fix tiny oversight & add test coverage.

### DIFF
--- a/client/blocks/image-editor/test/utils.js
+++ b/client/blocks/image-editor/test/utils.js
@@ -1,0 +1,94 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { AspectRatios } from 'state/ui/editor/image-editor/constants';
+import { getDefaultAspectRatio } from '../utils';
+
+describe( 'getDefaultAspectRatio', () => {
+	context( 'when only aspectRatio is given', () => {
+		context( 'when aspectRatio is valid', () => {
+			it( 'returns the aspectRatio', () => {
+				const expected = 'ASPECT_1X1';
+				const actual = getDefaultAspectRatio( 'ASPECT_1X1' );
+
+				expect( actual ).to.equal( expected );
+			} );
+		} );
+
+		context( 'when aspectRatio is invalid', () => {
+			it( 'returns the value of AspectRatios.FREE', () => {
+				const expected = AspectRatios.FREE;
+				const actual = getDefaultAspectRatio( 'INVALID_ASPECT' );
+
+				expect( actual ).to.equal( expected );
+			} );
+		} );
+	} );
+
+	context( 'when only aspectRatios is given', () => {
+		context( 'when aspectRatios is valid', () => {
+			it( 'returns the first given aspectRatio', () => {
+				const expected = 'ASPECT_1X1';
+				const actual = getDefaultAspectRatio( null, [ 'ASPECT_1X1' ] );
+
+				expect( actual ).to.equal( expected );
+			} );
+		} );
+
+		context( 'when aspectRatios is invalid', () => {
+			it( 'returns the value of AspectRatios.FREE', () => {
+				const expected = AspectRatios.FREE;
+				const actual = getDefaultAspectRatio( null, [ 'INVALID_ASPECT' ] );
+
+				expect( actual ).to.equal( expected );
+			} );
+		} );
+	} );
+
+	context( 'when both aspectRatio & aspectRatios are given', () => {
+		context( 'when aspectRatios includes the given aspectRatio', () => {
+			context( 'when the given aspectRatio is valid', () => {
+				it( 'returns the given aspectRatio', () => {
+					const expected = 'ASPECT_1X1';
+					const actual = getDefaultAspectRatio( 'ASPECT_1X1', [ 'INVALID_ASPECT', 'ASPECT_1X1' ] );
+
+					expect( actual ).to.equal( expected );
+				} );
+			} );
+
+			context( 'when the given aspectRatio is invalid', () => {
+				it( 'returns the value of AspectRatios.FREE', () => {
+					const expected = AspectRatios.FREE;
+					const actual = getDefaultAspectRatio( 'INVALID_ASPECT', [ 'INVALID_ASPECT', 'ASPECT_1X1' ] );
+
+					expect( actual ).to.equal( expected );
+				} );
+			} );
+		} );
+
+		context( 'when aspectRatios does not include the given aspectRatio', () => {
+			context( 'when the given aspectRatios starts with a valid aspectRatio', () => {
+				it( 'returns that valid aspectRatio', () => {
+					const expected = 'ASPECT_1X1';
+					const actual = getDefaultAspectRatio( 'INVALID_ASPECT', [ 'ASPECT_1X1' ] );
+
+					expect( actual ).to.equal( expected );
+				} );
+			} );
+
+			context( 'when the given aspectRatios does not start with a valid aspectRatio', () => {
+				it( 'returns the value of AspectRatios.FREE', () => {
+					const expected = AspectRatios.FREE;
+					const actual = getDefaultAspectRatio( 'OTHER_INVALID_ASPECT', [ 'INVALID_ASPECT' ] );
+
+					expect( actual ).to.equal( expected );
+				} );
+			} );
+		} );
+	} );
+} );

--- a/client/blocks/image-editor/test/utils.js
+++ b/client/blocks/image-editor/test/utils.js
@@ -10,8 +10,8 @@ import { AspectRatios } from 'state/ui/editor/image-editor/constants';
 import { getDefaultAspectRatio } from '../utils';
 
 describe( 'getDefaultAspectRatio', () => {
-	context( 'when only aspectRatio is given', () => {
-		context( 'when aspectRatio is valid', () => {
+	describe( 'when only aspectRatio is given', () => {
+		describe( 'when aspectRatio is valid', () => {
 			it( 'returns the aspectRatio', () => {
 				const expected = 'ASPECT_1X1';
 				const actual = getDefaultAspectRatio( 'ASPECT_1X1' );
@@ -20,7 +20,7 @@ describe( 'getDefaultAspectRatio', () => {
 			} );
 		} );
 
-		context( 'when aspectRatio is invalid', () => {
+		describe( 'when aspectRatio is invalid', () => {
 			it( 'returns the value of AspectRatios.FREE', () => {
 				const expected = AspectRatios.FREE;
 				const actual = getDefaultAspectRatio( 'INVALID_ASPECT' );
@@ -30,8 +30,8 @@ describe( 'getDefaultAspectRatio', () => {
 		} );
 	} );
 
-	context( 'when only aspectRatios is given', () => {
-		context( 'when aspectRatios is valid', () => {
+	describe( 'when only aspectRatios is given', () => {
+		describe( 'when aspectRatios is valid', () => {
 			it( 'returns the first given aspectRatio', () => {
 				const expected = 'ASPECT_1X1';
 				const actual = getDefaultAspectRatio( null, [ 'ASPECT_1X1' ] );
@@ -40,7 +40,7 @@ describe( 'getDefaultAspectRatio', () => {
 			} );
 		} );
 
-		context( 'when aspectRatios is invalid', () => {
+		describe( 'when aspectRatios is invalid', () => {
 			it( 'returns the value of AspectRatios.FREE', () => {
 				const expected = AspectRatios.FREE;
 				const actual = getDefaultAspectRatio( null, [ 'INVALID_ASPECT' ] );
@@ -50,9 +50,9 @@ describe( 'getDefaultAspectRatio', () => {
 		} );
 	} );
 
-	context( 'when both aspectRatio & aspectRatios are given', () => {
-		context( 'when aspectRatios includes the given aspectRatio', () => {
-			context( 'when the given aspectRatio is valid', () => {
+	describe( 'when both aspectRatio & aspectRatios are given', () => {
+		describe( 'when aspectRatios includes the given aspectRatio', () => {
+			describe( 'when the given aspectRatio is valid', () => {
 				it( 'returns the given aspectRatio', () => {
 					const expected = 'ASPECT_1X1';
 					const actual = getDefaultAspectRatio( 'ASPECT_1X1', [ 'INVALID_ASPECT', 'ASPECT_1X1' ] );
@@ -61,7 +61,7 @@ describe( 'getDefaultAspectRatio', () => {
 				} );
 			} );
 
-			context( 'when the given aspectRatio is invalid', () => {
+			describe( 'when the given aspectRatio is invalid', () => {
 				it( 'returns the value of AspectRatios.FREE', () => {
 					const expected = AspectRatios.FREE;
 					const actual = getDefaultAspectRatio( 'INVALID_ASPECT', [ 'INVALID_ASPECT', 'ASPECT_1X1' ] );
@@ -71,8 +71,8 @@ describe( 'getDefaultAspectRatio', () => {
 			} );
 		} );
 
-		context( 'when aspectRatios does not include the given aspectRatio', () => {
-			context( 'when the given aspectRatios starts with a valid aspectRatio', () => {
+		describe( 'when aspectRatios does not include the given aspectRatio', () => {
+			describe( 'when the given aspectRatios starts with a valid aspectRatio', () => {
 				it( 'returns that valid aspectRatio', () => {
 					const expected = 'ASPECT_1X1';
 					const actual = getDefaultAspectRatio( 'INVALID_ASPECT', [ 'ASPECT_1X1' ] );
@@ -81,7 +81,7 @@ describe( 'getDefaultAspectRatio', () => {
 				} );
 			} );
 
-			context( 'when the given aspectRatios does not start with a valid aspectRatio', () => {
+			describe( 'when the given aspectRatios does not start with a valid aspectRatio', () => {
 				it( 'returns the value of AspectRatios.FREE', () => {
 					const expected = AspectRatios.FREE;
 					const actual = getDefaultAspectRatio( 'OTHER_INVALID_ASPECT', [ 'INVALID_ASPECT' ] );

--- a/client/blocks/image-editor/utils.js
+++ b/client/blocks/image-editor/utils.js
@@ -9,10 +9,7 @@ import { includes, get } from 'lodash';
 /**
  * Internal dependencies
  */
-import {
-	AspectRatios,
-	AspectRatiosValues,
-} from 'state/ui/editor/image-editor/constants';
+import { AspectRatios, AspectRatiosValues } from 'state/ui/editor/image-editor/constants';
 
 /**
  * Returns the default aspect ratio image editor should use.
@@ -35,5 +32,5 @@ export function getDefaultAspectRatio( aspectRatio = null, aspectRatios = Aspect
 
 	return includes( AspectRatiosValues, aspectRatio )
 		? aspectRatio
- 		: getDefaultAspectRatio( aspectRatio );
+		: getDefaultAspectRatio( aspectRatio );
 }

--- a/client/blocks/image-editor/utils.js
+++ b/client/blocks/image-editor/utils.js
@@ -1,15 +1,18 @@
+/** @format */
+
 /**
  * External dependencies
  *
- * @format
  */
-
-import { indexOf, get } from 'lodash';
+import { includes, get } from 'lodash';
 
 /**
  * Internal dependencies
  */
-import { AspectRatiosValues } from 'state/ui/editor/image-editor/constants';
+import {
+	AspectRatios,
+	AspectRatiosValues,
+} from 'state/ui/editor/image-editor/constants';
 
 /**
  * Returns the default aspect ratio image editor should use.
@@ -19,18 +22,18 @@ import { AspectRatiosValues } from 'state/ui/editor/image-editor/constants';
  * 1. aspectRatio, if it is included in aspectRatios
  * 2. aspectRatios[ 0 ] if aspectRatio is not included in aspectRatios
  *
- * We return AllAspectRatios.FREE if no specified aspect ratio is valid.
+ * We return AspectRatios.FREE if no specified aspect ratio is valid.
  *
  * @param   {String} aspectRatio  an aspect ratio which should be validated and used as default one for image editor
  * @param   {Array}  aspectRatios list of aspect ratios to be validated and used in image editor
  * @returns {String}              the default valid aspect ratio image editor should use
  */
 export function getDefaultAspectRatio( aspectRatio = null, aspectRatios = AspectRatiosValues ) {
-	if ( indexOf( aspectRatios, aspectRatio ) === -1 ) {
-		aspectRatio = get( aspectRatios, '0', AspectRatiosValues.FREE );
+	if ( ! includes( aspectRatios, aspectRatio ) ) {
+		aspectRatio = get( aspectRatios, '0', AspectRatios.FREE );
 	}
 
-	return indexOf( AspectRatiosValues, aspectRatio ) === -1
-		? getDefaultAspectRatio( aspectRatio )
-		: aspectRatio;
+	return includes( AspectRatiosValues, aspectRatio )
+		? aspectRatio
+ 		: getDefaultAspectRatio( aspectRatio );
 }


### PR DESCRIPTION
### Summary
I was looking through files that could have their semantics improved a little by using Lodash utilities.
Before making changes in this file I wanted to back up the behaviour with some test coverage and while doing so noticed that `AspectRatiosValues.FREE` in `utils.js` is always undefined, since `AspectRatiosValues` is an array. The function still worked but not as planned - it would just have to recurse one extra time and only land on `FREE` because it's the first AR found in the list.

I couldn't figure out a clean way to prove this via tests but some debug logging should be easy if you'd like to confirm it yourself.

### Motivation
Having fun while on a 🛩 :)

### Test Plan
I'll update when I have something solid, but for now test coverage should prove that behaviour hasn't changed.