### PR TITLE
Activity Log: update styles for smaller devices

### DIFF
--- a/client/my-sites/stats/activity-log-day/index.jsx
+++ b/client/my-sites/stats/activity-log-day/index.jsx
@@ -94,7 +94,10 @@ class ActivityLogDay extends Component {
 			>
 				<Gridicon icon="history" size={ 18 } />
 				{ ' ' }
-				{ this.props.translate( 'Rewind to this day' ) }
+				{ this.props.translate(
+					'Rewind {{em}}to this day{{/em}}',
+					{ components: { em: <em /> } },
+				) }
 			</Button>
 		);
 	}

--- a/client/my-sites/stats/activity-log-day/style.scss
+++ b/client/my-sites/stats/activity-log-day/style.scss
@@ -53,6 +53,16 @@
 	font-weight: 600;
 }
 
+.activity-log-day__rewind-button {
+	em {
+		font-style: normal;
+
+		@include breakpoint( "<960px" ) {
+			display: none;
+		}
+	}
+}
+
 .activity-log-day__events {
 	font-size: 12px;
 	color: $gray;
@@ -75,3 +85,4 @@
 		margin-top: .2em;
 	}
 }
+

--- a/client/my-sites/stats/activity-log-day/style.scss
+++ b/client/my-sites/stats/activity-log-day/style.scss
@@ -33,6 +33,12 @@
 		}
 	}
 
+	.foldable-card__main {
+		@include breakpoint( "<480px" ) {
+			flex: 3 1;
+		}
+	}
+
 	.foldable-card.card.is-expanded {
 		box-shadow: none;
 

--- a/client/my-sites/stats/activity-log-item/style.scss
+++ b/client/my-sites/stats/activity-log-item/style.scss
@@ -114,17 +114,31 @@
 	margin-right: 32px;
 
 	@include breakpoint( "<960px" ) {
-		margin-bottom: 16px;
+		order: 2;
 	}
 
 	.gravatar,
 	.jetpack-logo {
 		float: left;
 		margin-right: 16px;
+
+		@include breakpoint( "<960px" ) {
+			width: 24px;
+			height: 24px;
+			margin-right: 8px;
+		}
 	}
 
 	.jetpack-logo path {
 		fill: $green-jetpack;
+	}
+}
+
+.activity-log-item__actor-name {
+	font-size: 14px;
+
+	@include breakpoint( "<960px" ) {
+		font-size: 13px;
 	}
 }
 
@@ -139,7 +153,7 @@
 	font-size: 14px;
 
 	@include breakpoint( "<960px" ) {
-		margin-left: 54px;
+		margin-bottom: 16px;
 	}
 }
 

--- a/client/my-sites/stats/activity-log-item/style.scss
+++ b/client/my-sites/stats/activity-log-item/style.scss
@@ -47,6 +47,12 @@
 		}
 	}
 
+	.foldable-card__header {
+		@include breakpoint( "<480px" ) {
+			padding: 12px;
+		}
+	}
+
 	.foldable-card__main {
 		flex: 5 1;
 	}

--- a/client/my-sites/stats/activity-log-item/style.scss
+++ b/client/my-sites/stats/activity-log-item/style.scss
@@ -60,7 +60,7 @@
 	padding: 4px 0 6px;
 
 	@include breakpoint( "<480px" ) {
-		margin: -2px 14px 0 4px;
+		margin: -2px 8px 0 0px;
 	}
 }
 
@@ -69,6 +69,10 @@
 	color: $gray;
 	text-transform: uppercase;
 	white-space: nowrap;
+
+	@include breakpoint( "<480px" ) {
+		letter-spacing: -1px;
+	}
 }
 
 .activity-log-item__activity-icon {

--- a/client/my-sites/stats/activity-log-item/style.scss
+++ b/client/my-sites/stats/activity-log-item/style.scss
@@ -7,6 +7,10 @@
 	align-items: center;
 	position: relative;
 
+	@include breakpoint( "<480px" ) {
+		margin-left: 8px;
+	}
+
 	// TODO: Remove when foldable cards become "expandable"
 	.foldable-card__header.is-clickable {
 		cursor: default;

--- a/client/my-sites/stats/activity-log/style.scss
+++ b/client/my-sites/stats/activity-log/style.scss
@@ -12,12 +12,8 @@
 		width: 2px;
 		background-color: lighten( $gray, 20% );
 
-		@include breakpoint( "<660px" ) {
-			left: 48px;
-		}
-
 		@include breakpoint( "<480px" ) {
-			left: 41px;
+			left: 29px;
 		}
 	}
 }

--- a/client/my-sites/stats/activity-log/style.scss
+++ b/client/my-sites/stats/activity-log/style.scss
@@ -20,10 +20,6 @@
 			left: 41px;
 		}
 	}
-
-	@include breakpoint( "<660px" ) {
-		padding: 0 16px;
-	}
 }
 
 .activity-log__rewind-toggle {


### PR DESCRIPTION
This PR introduces minor changes to how we handle the activity log UI in smaller screen devices.

List of changes:

- Compress the rewind button so we can have smaller day blocks, and dates in a single line.
- Truncate the text of the button so it's much shorter in smaller screens.
- Reorder and tweak styles of activity actor, to present a cleaner event block.
- Minor tweaks to bring all elements together in terms of margins and paddings.

### Before

![image](https://user-images.githubusercontent.com/390760/30381684-0372b540-9895-11e7-90bd-3d96a4c76727.png)

![image](https://user-images.githubusercontent.com/390760/30381731-2a3e9946-9895-11e7-85a2-daf52ba69e46.png)

### After

![image](https://user-images.githubusercontent.com/390760/30912446-730c6078-a384-11e7-8e07-89a75e08b23e.png)

### How to test

- Go to https://calypso.live/?branch=update/activity-log-mobile-tweaks
- Open Stats > Activity