### PR TITLE
Sharing: Fix facebook reconnect

### DIFF
--- a/client/my-sites/sharing/connections/connection.jsx
+++ b/client/my-sites/sharing/connections/connection.jsx
@@ -55,7 +55,7 @@ class SharingConnection extends Component {
 
 	refresh = () => {
 		if ( ! this.props.isRefreshing ) {
-			this.props.onRefresh( this.props.connection );
+			this.props.onRefresh( [ this.props.connection ] );
 		}
 	};
 


### PR DESCRIPTION
Requires server patch D7265.

### Testing Instructions
- Boot the branch
- Connect your facebook account to a wordpress.com site
- Go to https://www.facebook.com/settings?tab=applications and disable the WordPress app
- Go back to wordpress.com, wait a bit (or bust cache using instructions from the server patch) and refresh http://calypso.localhost:3000/sharing/:site_slug until it shows an error with the facebook connection
- You should see an option to reconnect
- Click on reconnect
- Assert that you are reconnected successfully

### Reviews
- [ ]  Code
- [ ] Product