### PR TITLE
Add UI for viewing review replies

### DIFF
--- a/client/extensions/woocommerce/app/reviews/gravatar.js
+++ b/client/extensions/woocommerce/app/reviews/gravatar.js
@@ -1,0 +1,43 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import PropTypes from 'prop-types';
+
+/**
+ * Internal dependencies
+ */
+import Gravatar from 'components/gravatar';
+
+// The WP comments endpoint and reviews endpoints return different but similar responses.
+// This helper component displays a gravatar for either a review or admin reply to a review.
+// Just pass in the review or reply object, and what type it is.
+const ReviewGravatar = ( { object, forType = 'review' } ) => {
+	let avatarURL;
+	let displayName;
+
+	// The API returns avatar URLs for various sizes. 24, 48, and 96.
+	const AVATAR_SIZE = 48;
+
+	if ( 'reply' === forType ) {
+		avatarURL = object.author_avatar_urls[ AVATAR_SIZE ];
+		displayName = object.author_name;
+	} else {
+		avatarURL = object.avatar_urls[ AVATAR_SIZE ];
+		displayName = object.name;
+	}
+
+	const author = {
+		avatar_URL: avatarURL,
+		display_name: displayName,
+	};
+
+	return <Gravatar user={ author } />;
+};
+
+ReviewGravatar.propTypes = {
+	object: PropTypes.object.isRequired,
+	forType: PropTypes.string.isRequired,
+};
+
+export default ReviewGravatar;

--- a/client/extensions/woocommerce/app/reviews/review-card.js
+++ b/client/extensions/woocommerce/app/reviews/review-card.js
@@ -15,10 +15,11 @@ import AutoDirection from 'components/auto-direction';
 import Button from 'components/button';
 import Card from 'components/card';
 import Emojify from 'components/emojify';
-import Gravatar from 'components/gravatar';
+import Gravatar from './gravatar';
 import humanDate from 'lib/human-date';
 import Rating from 'components/rating';
 import ReviewActionsBar from './review-actions-bar';
+import ReviewReplies from './review-replies';
 import { stripHTML, decodeEntities } from 'lib/formatting';
 
 class ReviewCard extends Component {
@@ -58,17 +59,6 @@ class ReviewCard extends Component {
 		);
 	}
 
-	renderGravatar() {
-		const { review } = this.props;
-
-		// The API returns avatar URLs for various sizes. 24, 48, and 96. This uses the middle size.
-		const author = {
-			avatar_URL: review.avatar_urls[ 48 ],
-			display_name: review.name,
-		};
-		return <Gravatar user={ author } />;
-	}
-
 	renderProductImage() {
 		const { review } = this.props;
 		const productImageClasses = classNames( 'reviews__product', { 'is-placeholder': ! review.product.image } );
@@ -97,7 +87,10 @@ class ReviewCard extends Component {
 				onClick={ this.toggleExpanded }
 			>
 				<div className="reviews__author-gravatar">
-					{ this.renderGravatar() }
+					<Gravatar
+						object={ review }
+						forType="review"
+					/>
 				</div>
 				<div className="reviews__info">
 					<div className="reviews__author-name">
@@ -126,7 +119,10 @@ class ReviewCard extends Component {
 			<div className="reviews__expanded-card">
 				<div className="reviews__expanded-card-details">
 					<div className="reviews__author-gravatar">
-						{ this.renderGravatar() }
+						<Gravatar
+							object={ review }
+							forType="review"
+						/>
 					</div>
 
 					<div className="reviews__info">
@@ -155,6 +151,10 @@ class ReviewCard extends Component {
 						/>
 					</Emojify>
 				</AutoDirection>
+
+				<ReviewReplies
+					review={ review }
+				/>
 			</div>
 		);
 	}

--- a/client/extensions/woocommerce/app/reviews/review-replies.js
+++ b/client/extensions/woocommerce/app/reviews/review-replies.js
@@ -1,0 +1,92 @@
+/**
+ * External depedencies
+ */
+import React, { Component } from 'react';
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+
+/**
+ * Internal dependencies
+ */
+import Button from 'components/button';
+import { fetchReviewReplies } from 'woocommerce/state/sites/review-replies/actions';
+import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
+import { getReviewReplies } from 'woocommerce/state/sites/review-replies/selectors';
+import ReviewReply from './review-reply';
+
+class ReviewReplies extends Component {
+	static propTypes = {
+		siteId: PropTypes.number,
+		review: PropTypes.shape( {
+			status: PropTypes.string,
+			name: PropTypes.string,
+			id: PropTypes.number,
+		} ).isRequired,
+	};
+
+	componentDidMount() {
+		const { siteId, review } = this.props;
+		if ( siteId ) {
+			this.props.fetchReviewReplies( siteId, review.id );
+		}
+	}
+
+	componentWillReceiveProps( newProps ) {
+		const { siteId, review } = this.props;
+		const newSiteId = newProps.siteId || null;
+		const oldSiteId = siteId || null;
+		if ( oldSiteId !== newSiteId ) {
+			this.props.fetchReviewReplies( newSiteId, review.id );
+		}
+	}
+
+	renderReply = ( replyId, i ) => {
+		const { review } = this.props;
+		return <ReviewReply
+			key={ i }
+			reviewId={ review.id }
+			replyId={ replyId }
+		/>;
+	}
+
+	render() {
+		const { replyIds, review, translate } = this.props;
+		const repliesOutput = replyIds.length && replyIds.map( this.renderReply ) || null;
+
+		const textAreaPlaceholder = translate( 'Reply to %(reviewAuthor)s…', {
+			args: { reviewAuthor: review.name }
+		} );
+		const submitButton = 'approved' === review.status ? translate( 'Send reply' ) : translate( 'Approve and send reply' );
+
+		return (
+			<div className="reviews__replies">
+				{ repliesOutput }
+
+				<textarea
+					className="reviews__reply-textarea"
+					placeholder={ textAreaPlaceholder }
+				/>
+
+				<div className="reviews__reply-submit">
+					<Button>{ submitButton }</Button>
+				</div>
+			</div>
+		);
+	}
+}
+
+export default connect(
+	( state, props ) => {
+		const site = getSelectedSiteWithFallback( state );
+		const siteId = site ? site.ID : false;
+		const replies = getReviewReplies( state, props.review.id );
+		const replyIds = replies && replies.map( reply => reply.id ) || [];
+		return {
+			siteId,
+			replyIds,
+		};
+	},
+	dispatch => bindActionCreators( { fetchReviewReplies }, dispatch )
+)( localize( ReviewReplies ) );

--- a/client/extensions/woocommerce/app/reviews/review-replies.js
+++ b/client/extensions/woocommerce/app/reviews/review-replies.js
@@ -10,7 +10,6 @@ import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
-import Button from 'components/button';
 import { fetchReviewReplies } from 'woocommerce/state/sites/review-replies/actions';
 import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
 import { getReviewReplies } from 'woocommerce/state/sites/review-replies/selectors';
@@ -55,23 +54,20 @@ class ReviewReplies extends Component {
 		const { replyIds, review, translate } = this.props;
 		const repliesOutput = replyIds.length && replyIds.map( this.renderReply ) || null;
 
-		const textAreaPlaceholder = translate( 'Reply to %(reviewAuthor)s…', {
-			args: { reviewAuthor: review.name }
-		} );
-		const submitButton = 'approved' === review.status ? translate( 'Send reply' ) : translate( 'Approve and send reply' );
+		const textAreaPlaceholder = 'approved' === review.status
+			? translate( 'Reply to %(reviewAuthor)s…', { args: { reviewAuthor: review.name } } )
+			: translate( 'Approve and reply to %(reviewAuthor)s…', { args: { reviewAuthor: review.name } } );
 
 		return (
 			<div className="reviews__replies">
 				{ repliesOutput }
 
-				<textarea
-					className="reviews__reply-textarea"
-					placeholder={ textAreaPlaceholder }
-				/>
-
-				<div className="reviews__reply-submit">
-					<Button>{ submitButton }</Button>
-				</div>
+				<form className="reviews__reply-textarea">
+					<textarea placeholder={ textAreaPlaceholder } />
+					<button className="reviews__reply-submit">
+						{ translate( 'Send' ) }
+					</button>
+				</form>
 			</div>
 		);
 	}

--- a/client/extensions/woocommerce/app/reviews/review-reply.js
+++ b/client/extensions/woocommerce/app/reviews/review-reply.js
@@ -1,0 +1,80 @@
+/**
+ * External depedencies
+ */
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import Gridicon from 'gridicons';
+import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+
+/**
+ * Internal dependencies
+ */
+import Button from 'components/button';
+import { getReviewReply } from 'woocommerce/state/sites/review-replies/selectors';
+import Gravatar from './gravatar';
+import humanDate from 'lib/human-date';
+
+class ReviewReply extends Component {
+	static propTypes = {
+		siteId: PropTypes.number,
+		reviewId: PropTypes.number.isRequired,
+		replyId: PropTypes.number.isRequired,
+	};
+
+	renderReplyActions = () => {
+		const { translate } = this.props;
+		return (
+			<div className="reviews__reply-actions">
+				<Button borderless className="reviews__reply-action-edit">
+					<Gridicon icon="pencil" />
+					<span>{ translate( 'Edit reply' ) }</span>
+				</Button>
+				<Button borderless className="reviews__reply-action-delete">
+					<Gridicon icon="trash" />
+					<span>{ translate( 'Delete reply' ) }</span>
+				</Button>
+			</div>
+		);
+	}
+
+	render() {
+		const { reply } = this.props;
+		const content = reply.content && reply.content.rendered || '';
+		return (
+			<div className="reviews__reply">
+				<div className="reviews__reply-bar">
+					<div className="reviews__author-gravatar">
+						<Gravatar
+							object={ reply }
+							forType="reply"
+						/>
+					</div>
+
+					<div className="reviews__info">
+						<div className="reviews__author-name">{ reply.author_name }</div>
+						<div className="reviews__date">{ humanDate( reply.date_gmt + 'Z' ) }</div>
+					</div>
+
+					{ this.renderReplyActions() }
+				</div>
+
+				<div className="reviews__reply-content"
+					dangerouslySetInnerHTML={ { __html: content } } //eslint-disable-line react/no-danger
+					// Sets the rendered comment HTML correctly for display.
+					// Also used for comments in `comment-detail/comment-detail-comment.jsx`
+				/>
+			</div>
+		);
+	}
+
+}
+
+export default connect(
+	( state, props ) => {
+		const reply = getReviewReply( state, props.reviewId, props.replyId );
+		return {
+			reply,
+		};
+	}
+)( localize( ReviewReply ) );

--- a/client/extensions/woocommerce/app/reviews/reviews-list.js
+++ b/client/extensions/woocommerce/app/reviews/reviews-list.js
@@ -124,8 +124,14 @@ class ReviewsList extends Component {
 	}
 
 	renderReview = ( review, i ) => {
+		const { siteId } = this.props;
 		return (
-			<ReviewCard key={ i } review={ review } currentStatus={ this.props.currentStatus } />
+			<ReviewCard
+				key={ i }
+				siteId={ siteId }
+				review={ review }
+				currentStatus={ this.props.currentStatus }
+			/>
 		);
 	}
 

--- a/client/extensions/woocommerce/app/reviews/style.scss
+++ b/client/extensions/woocommerce/app/reviews/style.scss
@@ -227,15 +227,45 @@
 }
 
 .reviews__reply-textarea {
-	border-right: 0;
-	border-left: 0;
-}
+	line-height: 0;
+	position: relative;
 
-.reviews__reply-submit {
-	padding: 16px;
-	text-align: right;
-}
+	textarea {
+		font-size: 14px;
+		height: 47px;
+		line-height: 21px;
+		min-height: 47px;
+		overflow: hidden;
+		padding: 12px 70px 12px 16px;
+		position: relative;
+		resize: vertical;
+		transition: min-height .15s linear;
+		white-space: pre-wrap;
+		word-wrap: break-word;
+		border-left: 0;
+		border-right: 0;
+		border-bottom: 0;
 
+		&::placeholder {
+			color: $gray-text-min;
+			overflow: hidden;
+			text-overflow: ellipsis;
+			white-space: nowrap;
+		}
+	}
+
+	.reviews__reply-submit {
+		color: $gray;
+		font-size: 12px;
+		font-weight: 600;
+		padding: 4px;
+		position: absolute;
+		right: 18px;
+		top: 11px;
+		text-transform: uppercase;
+		transition: opacity 0.2s ease-in-out;
+	}
+}
 .reviews__reply-bar {
 	display: flex;
 	flex-flow: row nowrap;

--- a/client/extensions/woocommerce/app/reviews/style.scss
+++ b/client/extensions/woocommerce/app/reviews/style.scss
@@ -25,7 +25,7 @@
 
 		.reviews__header {
 			justify-content: space-between;
-			border-bottom: 1px solid #e9eff3;
+			border-bottom: 1px solid lighten( $gray, 30% );
 		}
 	}
 
@@ -215,5 +215,38 @@
 .reviews__expanded-card {
 	.reviews__content {
 		padding: 16px;
+	}
+}
+
+.reviews__reply {
+	border-top: 1px solid lighten( $gray, 30% );
+
+	.reviews__reply-content {
+		padding: 16px;
+	}
+}
+
+.reviews__reply-textarea {
+	border-right: 0;
+	border-left: 0;
+}
+
+.reviews__reply-submit {
+	padding: 16px;
+	text-align: right;
+}
+
+.reviews__reply-bar {
+	display: flex;
+	flex-flow: row nowrap;
+	padding: 16px;
+
+	.reviews__reply-actions {
+		align-self: flex-start;
+		margin-left: auto;
+
+		.button {
+			margin-left: 32px;
+		}
 	}
 }


### PR DESCRIPTION
This PR adds a read-only view of admin replies for reviews. Replies are pulled in and displayed, and a textarea for replying is displayed. The action links and submit button do not do anything yet. This will come in a future PR.

<img width="793" alt="screen shot 2017-09-13 at 4 23 42 pm" src="https://user-images.githubusercontent.com/689165/30405326-fd88c1aa-989f-11e7-8728-710989ca3aa3.png">

cc @kellychoffman @jameskoster since this has UI

See #17693.

To Test:
* Make sure you are using the latest version [of my review branch](https://github.com/woocommerce/wc-api-dev/tree/add/all-product-reviews-endpoint). If you reviewed my previous branches, I have made another adjustment to the API to correctly return formatted review content in the view context. _tl;dr Download the branch again and install this version on your test site._
* Make sure you have a review with a few replies on it. You can reply to a review in wp-admin under each individual product.
* Go to `http://calypso.localhost:3000/store/reviews/:site`.
* Select and expand a review without replies.
* You should see the textarea but nothing else.
* Select and expand a review with replies.
* Replies should load in above the textarea.