### PR TITLE
QueryManager: Run prettier

### DIFF
--- a/client/lib/query-manager/index.js
+++ b/client/lib/query-manager/index.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -34,14 +35,20 @@ export default class QueryManager {
 	 * @param {String} options.itemKey Field to key items by
 	 */
 	constructor( data, options ) {
-		this.data = Object.assign( {
-			items: {},
-			queries: {}
-		}, data );
+		this.data = Object.assign(
+			{
+				items: {},
+				queries: {},
+			},
+			data
+		);
 
-		this.options = Object.assign( {
-			itemKey: 'ID'
-		}, options );
+		this.options = Object.assign(
+			{
+				itemKey: 'ID',
+			},
+			options
+		);
 	}
 
 	/**
@@ -149,7 +156,7 @@ export default class QueryManager {
 			return null;
 		}
 
-		return itemKeys.map( ( itemKey ) => this.getItem( itemKey ) );
+		return itemKeys.map( itemKey => this.getItem( itemKey ) );
 	}
 
 	/**
@@ -188,12 +195,15 @@ export default class QueryManager {
 	 *                                 instance otherwise
 	 */
 	removeItems( itemKeys = [] ) {
-		return this.receive( itemKeys.map( ( itemKey ) => {
-			return {
-				[ this.options.itemKey ]: itemKey,
-				[ DELETE_PATCH_KEY ]: true
-			};
-		} ), { patch: true } );
+		return this.receive(
+			itemKeys.map( itemKey => {
+				return {
+					[ this.options.itemKey ]: itemKey,
+					[ DELETE_PATCH_KEY ]: true,
+				};
+			} ),
+			{ patch: true }
+		);
 	}
 
 	/**
@@ -218,35 +228,39 @@ export default class QueryManager {
 			items = [ items ];
 		}
 
-		const nextItems = reduce( items, ( memo, receivedItem ) => {
-			const receivedItemKey = receivedItem[ this.options.itemKey ];
-			const item = this.getItem( receivedItemKey );
-			const mergedItem = this.mergeItem( item, receivedItem, options.patch );
+		const nextItems = reduce(
+			items,
+			( memo, receivedItem ) => {
+				const receivedItemKey = receivedItem[ this.options.itemKey ];
+				const item = this.getItem( receivedItemKey );
+				const mergedItem = this.mergeItem( item, receivedItem, options.patch );
 
-			if ( undefined === mergedItem ) {
-				if ( item ) {
-					// `undefined` item is an intended omission from set
-					return omit( memo, receivedItemKey );
+				if ( undefined === mergedItem ) {
+					if ( item ) {
+						// `undefined` item is an intended omission from set
+						return omit( memo, receivedItemKey );
+					}
+
+					// Item never existed in set in the first place, skip and
+					// return same memo
+					return memo;
 				}
 
-				// Item never existed in set in the first place, skip and
-				// return same memo
+				if ( ! item || ! isEqual( mergedItem, item ) ) {
+					// Did not exist previously or has changed
+					if ( memo === this.data.items ) {
+						// Create a copy of memo, as we don't want to mutate the
+						// original items set
+						memo = cloneDeep( memo );
+					}
+
+					memo[ receivedItemKey ] = mergedItem;
+				}
+
 				return memo;
-			}
-
-			if ( ! item || ! isEqual( mergedItem, item ) ) {
-				// Did not exist previously or has changed
-				if ( memo === this.data.items ) {
-					// Create a copy of memo, as we don't want to mutate the
-					// original items set
-					memo = cloneDeep( memo );
-				}
-
-				memo[ receivedItemKey ] = mergedItem;
-			}
-
-			return memo;
-		}, this.data.items );
+			},
+			this.data.items
+		);
 
 		let isModified = nextItems !== this.data.items,
 			nextQueries = this.data.queries,
@@ -265,12 +279,18 @@ export default class QueryManager {
 			isNewlyReceivedQueryKey = ! this.data.queries[ receivedQueryKey ];
 
 			let nextQueryReceivedItemKeys;
-			if ( isNewlyReceivedQueryKey || ! isEqual( this.data.queries[ receivedQueryKey ].itemKeys, receivedItemKeys ) ) {
+			if (
+				isNewlyReceivedQueryKey ||
+				! isEqual( this.data.queries[ receivedQueryKey ].itemKeys, receivedItemKeys )
+			) {
 				if ( options.mergeQuery && ! isNewlyReceivedQueryKey ) {
 					// When merging into a query where items already exist,
 					// omit incoming keys from existing set. These keys will
 					// be restored below during match testing.
-					nextQueryReceivedItemKeys = difference( this.data.queries[ receivedQueryKey ].itemKeys, receivedItemKeys );
+					nextQueryReceivedItemKeys = difference(
+						this.data.queries[ receivedQueryKey ].itemKeys,
+						receivedItemKeys
+					);
 				} else {
 					// If not merging, assign incoming keys as next items
 					nextQueryReceivedItemKeys = receivedItemKeys;
@@ -278,7 +298,10 @@ export default class QueryManager {
 			}
 
 			let nextQueryFound;
-			if ( options.found >= 0 && options.found !== get( nextQueries, [ receivedQueryKey, 'found' ] ) ) {
+			if (
+				options.found >= 0 &&
+				options.found !== get( nextQueries, [ receivedQueryKey, 'found' ] )
+			) {
 				nextQueryFound = options.found;
 			}
 
@@ -297,77 +320,83 @@ export default class QueryManager {
 				}
 
 				nextQueries = Object.assign( {}, nextQueries, {
-					[ receivedQueryKey ]: nextReceivedQuery
+					[ receivedQueryKey ]: nextReceivedQuery,
 				} );
 			}
 		}
 
-		nextQueries = reduce( nextQueries, ( memo, queryDetails, queryKey ) => {
-			memo[ queryKey ] = queryDetails;
+		nextQueries = reduce(
+			nextQueries,
+			( memo, queryDetails, queryKey ) => {
+				memo[ queryKey ] = queryDetails;
 
-			const isReceivedQueryKey = receivedQueryKey && receivedQueryKey === queryKey;
-			if ( isReceivedQueryKey && ( isNewlyReceivedQueryKey || ! options.mergeQuery ) ) {
-				// We can save the effort testing against received items in
-				// the current query, since we know they'll match
-				return memo;
-			}
+				const isReceivedQueryKey = receivedQueryKey && receivedQueryKey === queryKey;
+				if ( isReceivedQueryKey && ( isNewlyReceivedQueryKey || ! options.mergeQuery ) ) {
+					// We can save the effort testing against received items in
+					// the current query, since we know they'll match
+					return memo;
+				}
 
-			// Found counts should not be adjusted for the received query if
-			// merging into existing items
-			const shouldAdjustFoundCount = ! isReceivedQueryKey;
+				// Found counts should not be adjusted for the received query if
+				// merging into existing items
+				const shouldAdjustFoundCount = ! isReceivedQueryKey;
 
-			const query = this.constructor.QueryKey.parse( queryKey );
-			items.forEach( ( receivedItem ) => {
-				// Find item in known data for query
-				const receivedItemKey = receivedItem[ this.options.itemKey ];
-				const updatedItem = nextItems[ receivedItemKey ];
-				const index = memo[ queryKey ].itemKeys.indexOf( receivedItemKey );
+				const query = this.constructor.QueryKey.parse( queryKey );
+				items.forEach( receivedItem => {
+					// Find item in known data for query
+					const receivedItemKey = receivedItem[ this.options.itemKey ];
+					const updatedItem = nextItems[ receivedItemKey ];
+					const index = memo[ queryKey ].itemKeys.indexOf( receivedItemKey );
 
-				if ( -1 !== index ) {
-					// Item already exists in query, check to see whether the
-					// updated item is being removed or no longer matches
-					if ( ! updatedItem || ! this.constructor.matches( query, updatedItem ) ) {
+					if ( -1 !== index ) {
+						// Item already exists in query, check to see whether the
+						// updated item is being removed or no longer matches
+						if ( ! updatedItem || ! this.constructor.matches( query, updatedItem ) ) {
+							// Create a copy of the original details to avoid mutating
+							if ( memo[ queryKey ] === queryDetails ) {
+								memo[ queryKey ] = cloneDeep( queryDetails );
+							}
+
+							// Omit item by slicing previous and next
+							memo[ queryKey ].itemKeys = [
+								...memo[ queryKey ].itemKeys.slice( 0, index ),
+								...memo[ queryKey ].itemKeys.slice( index + 1 ),
+							];
+
+							// Decrement found count for query
+							if ( shouldAdjustFoundCount && Number.isFinite( memo[ queryKey ].found ) ) {
+								memo[ queryKey ].found--;
+							}
+						}
+					} else if ( updatedItem && this.constructor.matches( query, updatedItem ) ) {
+						// Item doesn't currently exist in query but is a match, so
+						// insert item into set
+
 						// Create a copy of the original details to avoid mutating
 						if ( memo[ queryKey ] === queryDetails ) {
 							memo[ queryKey ] = cloneDeep( queryDetails );
 						}
 
-						// Omit item by slicing previous and next
-						memo[ queryKey ].itemKeys = [
-							...memo[ queryKey ].itemKeys.slice( 0, index ),
-							...memo[ queryKey ].itemKeys.slice( index + 1 )
-						];
-
-						// Decrement found count for query
+						// Increment found count for query
 						if ( shouldAdjustFoundCount && Number.isFinite( memo[ queryKey ].found ) ) {
-							memo[ queryKey ].found--;
+							memo[ queryKey ].found++;
 						}
+
+						// A matching item should be inserted into the query set
+						memo[ queryKey ].itemKeys = get( memo, [ queryKey, 'itemKeys' ], [] ).concat(
+							receivedItemKey
+						);
+
+						// Re-sort the set
+						this.sort( memo[ queryKey ].itemKeys, nextItems, query );
 					}
-				} else if ( updatedItem && this.constructor.matches( query, updatedItem ) ) {
-					// Item doesn't currently exist in query but is a match, so
-					// insert item into set
+				} );
 
-					// Create a copy of the original details to avoid mutating
-					if ( memo[ queryKey ] === queryDetails ) {
-						memo[ queryKey ] = cloneDeep( queryDetails );
-					}
-
-					// Increment found count for query
-					if ( shouldAdjustFoundCount && Number.isFinite( memo[ queryKey ].found ) ) {
-						memo[ queryKey ].found++;
-					}
-
-					// A matching item should be inserted into the query set
-					memo[ queryKey ].itemKeys = get( memo, [ queryKey, 'itemKeys' ], [] ).concat( receivedItemKey );
-
-					// Re-sort the set
-					this.sort( memo[ queryKey ].itemKeys, nextItems, query );
-				}
-			} );
-
-			isModified = isModified || memo[ queryKey ] !== queryDetails;
-			return memo;
-		}, {} );
+				isModified = isModified || memo[ queryKey ] !== queryDetails;
+				return memo;
+			},
+			{}
+		);
 
 		if ( ! isModified ) {
 			return this;
@@ -376,7 +405,7 @@ export default class QueryManager {
 		return new this.constructor(
 			Object.assign( {}, this.data, {
 				items: nextItems,
-				queries: nextQueries
+				queries: nextQueries,
 			} ),
 			this.options
 		);

--- a/client/lib/query-manager/key.js
+++ b/client/lib/query-manager/key.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -65,7 +66,7 @@ export default class QueryKey {
 		// key ordering in the original object, to ensure that:
 		//
 		// QueryKey.stringify( { a: 1, b: 2 } ) === QueryKey.stringify( { b: 2, a: 1 } )
-		const stableQuery = sortBy( toPairs( prunedQuery ), ( pair ) => pair[ 0 ] );
+		const stableQuery = sortBy( toPairs( prunedQuery ), pair => pair[ 0 ] );
 
 		return JSON.stringify( stableQuery );
 	}

--- a/client/lib/query-manager/media/constants.js
+++ b/client/lib/query-manager/media/constants.js
@@ -1,3 +1,4 @@
+/** @format */
 export const DEFAULT_MEDIA_QUERY = {
 	context: 'display',
 	http_envelope: false,
@@ -8,5 +9,5 @@ export const DEFAULT_MEDIA_QUERY = {
 	order: 'DESC',
 	order_by: 'date',
 	mime_type: '',
-	search: ''
+	search: '',
 };

--- a/client/lib/query-manager/media/index.js
+++ b/client/lib/query-manager/media/index.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -39,22 +40,22 @@ export default class MediaQueryManager extends PaginatedQueryManager {
 					}
 
 					// See: https://developer.wordpress.org/reference/functions/wp_post_mime_type_where/
-					return new RegExp( `^${
-						value
+					return new RegExp(
+						`^${ value
 							// Replace wildcard-only, wildcard group, and empty
 							// group with wildcard pattern matching
 							.replace( /(^%|(\/)%?)$/, '$2.+' )
 							// Split subgroup and group to filter
 							.split( '/' )
 							// Remove invalid characters
-							.map( ( group ) => group.replace( /[^-*.+a-zA-Z0-9]/g, '' ) )
+							.map( group => group.replace( /[^-*.+a-zA-Z0-9]/g, '' ) )
 							// If no group, append wildcard match
 							.concat( '.+' )
 							// Take only subgroup and group
 							.slice( 0, 2 )
 							// Finally, merge back into string
-							.join( '/' )
-					}$` ).test( media.mime_type );
+							.join( '/' ) }$`
+					).test( media.mime_type );
 
 				case 'post_ID':
 					// Note that documentation specifies that query value of 0

--- a/client/lib/query-manager/media/key.js
+++ b/client/lib/query-manager/media/key.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * Internal dependencies
  */

--- a/client/lib/query-manager/media/test/index.js
+++ b/client/lib/query-manager/media/test/index.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -29,7 +30,7 @@ const DEFAULT_MEDIA = {
 	thumbnails: {},
 	height: 405,
 	width: 600,
-	exif: {}
+	exif: {},
 };
 
 describe( 'MediaQueryManager', () => {
@@ -41,33 +42,45 @@ describe( 'MediaQueryManager', () => {
 	describe( '#matches()', () => {
 		context( 'query.search', () => {
 			it( 'should return false for a non-matching search', () => {
-				const isMatch = MediaQueryManager.matches( {
-					search: 'Cars'
-				}, DEFAULT_MEDIA );
+				const isMatch = MediaQueryManager.matches(
+					{
+						search: 'Cars',
+					},
+					DEFAULT_MEDIA
+				);
 
 				expect( isMatch ).to.be.false;
 			} );
 
 			it( 'should return true for an empty search', () => {
-				const isMatch = MediaQueryManager.matches( {
-					search: ''
-				}, DEFAULT_MEDIA );
+				const isMatch = MediaQueryManager.matches(
+					{
+						search: '',
+					},
+					DEFAULT_MEDIA
+				);
 
 				expect( isMatch ).to.be.true;
 			} );
 
 			it( 'should return true for a matching title search', () => {
-				const isMatch = MediaQueryManager.matches( {
-					search: 'lower'
-				}, DEFAULT_MEDIA );
+				const isMatch = MediaQueryManager.matches(
+					{
+						search: 'lower',
+					},
+					DEFAULT_MEDIA
+				);
 
 				expect( isMatch ).to.be.true;
 			} );
 
 			it( 'should search case-insensitive', () => {
-				const isMatch = MediaQueryManager.matches( {
-					search: 'fLoWeR'
-				}, DEFAULT_MEDIA );
+				const isMatch = MediaQueryManager.matches(
+					{
+						search: 'fLoWeR',
+					},
+					DEFAULT_MEDIA
+				);
 
 				expect( isMatch ).to.be.true;
 			} );
@@ -75,89 +88,122 @@ describe( 'MediaQueryManager', () => {
 
 		context( 'query.mime_type', () => {
 			it( 'should return true for an empty mime type', () => {
-				const isMatch = MediaQueryManager.matches( {
-					mime_type: ''
-				}, DEFAULT_MEDIA );
+				const isMatch = MediaQueryManager.matches(
+					{
+						mime_type: '',
+					},
+					DEFAULT_MEDIA
+				);
 
 				expect( isMatch ).to.be.true;
 			} );
 
 			it( 'should return true an exact match', () => {
-				const isMatch = MediaQueryManager.matches( {
-					mime_type: 'image/gif'
-				}, DEFAULT_MEDIA );
+				const isMatch = MediaQueryManager.matches(
+					{
+						mime_type: 'image/gif',
+					},
+					DEFAULT_MEDIA
+				);
 
 				expect( isMatch ).to.be.true;
 			} );
 
 			it( 'should return true for mime subgroup exact match', () => {
-				const isMatch = MediaQueryManager.matches( {
-					mime_type: 'image'
-				}, DEFAULT_MEDIA );
+				const isMatch = MediaQueryManager.matches(
+					{
+						mime_type: 'image',
+					},
+					DEFAULT_MEDIA
+				);
 
 				expect( isMatch ).to.be.true;
 			} );
 
 			it( 'should return true for mime subgroup exact match with trailing slash', () => {
-				const isMatch = MediaQueryManager.matches( {
-					mime_type: 'image/'
-				}, DEFAULT_MEDIA );
+				const isMatch = MediaQueryManager.matches(
+					{
+						mime_type: 'image/',
+					},
+					DEFAULT_MEDIA
+				);
 
 				expect( isMatch ).to.be.true;
 			} );
 
 			it( 'should return false for mime subgroup partial match', () => {
-				const isMatch = MediaQueryManager.matches( {
-					mime_type: 'imag'
-				}, DEFAULT_MEDIA );
+				const isMatch = MediaQueryManager.matches(
+					{
+						mime_type: 'imag',
+					},
+					DEFAULT_MEDIA
+				);
 
 				expect( isMatch ).to.be.false;
 			} );
 
 			it( 'should return false for mime group partial match', () => {
-				const isMatch = MediaQueryManager.matches( {
-					mime_type: 'image/gi'
-				}, DEFAULT_MEDIA );
+				const isMatch = MediaQueryManager.matches(
+					{
+						mime_type: 'image/gi',
+					},
+					DEFAULT_MEDIA
+				);
 
 				expect( isMatch ).to.be.false;
 			} );
 
 			it( 'should return true for wildcard match', () => {
-				const isMatch = MediaQueryManager.matches( {
-					mime_type: '%'
-				}, DEFAULT_MEDIA );
+				const isMatch = MediaQueryManager.matches(
+					{
+						mime_type: '%',
+					},
+					DEFAULT_MEDIA
+				);
 
 				expect( isMatch ).to.be.true;
 			} );
 
 			it( 'should return false for mime subgroup wildcard match', () => {
-				const isMatch = MediaQueryManager.matches( {
-					mime_type: '%/gif'
-				}, DEFAULT_MEDIA );
+				const isMatch = MediaQueryManager.matches(
+					{
+						mime_type: '%/gif',
+					},
+					DEFAULT_MEDIA
+				);
 
 				expect( isMatch ).to.be.false;
 			} );
 
 			it( 'should return true for mime group wildcard match', () => {
-				const isMatch = MediaQueryManager.matches( {
-					mime_type: 'image/%'
-				}, DEFAULT_MEDIA );
+				const isMatch = MediaQueryManager.matches(
+					{
+						mime_type: 'image/%',
+					},
+					DEFAULT_MEDIA
+				);
 
 				expect( isMatch ).to.be.true;
 			} );
 
 			it( 'should return false for mime subgroup partial wildcard match', () => {
-				const isMatch = MediaQueryManager.matches( {
-					mime_type: 'ima%/%'
-				}, DEFAULT_MEDIA );
+				const isMatch = MediaQueryManager.matches(
+					{
+						mime_type: 'ima%/%',
+					},
+					DEFAULT_MEDIA
+				);
 
 				expect( isMatch ).to.be.false;
 			} );
 
 			it( 'should return false for mime group partial wildcard match', () => {
-				const isMatch = MediaQueryManager.matches( {
-					mime_type: 'image/gi%'
-				}, DEFAULT_MEDIA );
+				const isMatch = MediaQueryManager.matches(
+					{
+						mime_type: 'image/gi%',
+					},
+					DEFAULT_MEDIA
+				);
 
 				expect( isMatch ).to.be.false;
 			} );
@@ -165,17 +211,23 @@ describe( 'MediaQueryManager', () => {
 
 		context( 'query.post_ID', () => {
 			it( 'should return false if post ID does not match', () => {
-				const isMatch = MediaQueryManager.matches( {
-					post_ID: 0
-				}, DEFAULT_MEDIA );
+				const isMatch = MediaQueryManager.matches(
+					{
+						post_ID: 0,
+					},
+					DEFAULT_MEDIA
+				);
 
 				expect( isMatch ).to.be.false;
 			} );
 
 			it( 'should return true if post ID matches', () => {
-				const isMatch = MediaQueryManager.matches( {
-					post_ID: 41
-				}, DEFAULT_MEDIA );
+				const isMatch = MediaQueryManager.matches(
+					{
+						post_ID: 41,
+					},
+					DEFAULT_MEDIA
+				);
 
 				expect( isMatch ).to.be.true;
 			} );
@@ -183,25 +235,34 @@ describe( 'MediaQueryManager', () => {
 
 		context( 'query.before', () => {
 			it( 'should return false if query is not ISO 8601', () => {
-				const isMatch = MediaQueryManager.matches( {
-					before: '2018'
-				}, DEFAULT_MEDIA );
+				const isMatch = MediaQueryManager.matches(
+					{
+						before: '2018',
+					},
+					DEFAULT_MEDIA
+				);
 
 				expect( isMatch ).to.be.false;
 			} );
 
 			it( 'should return false if media is not before date', () => {
-				const isMatch = MediaQueryManager.matches( {
-					before: '2010-04-25T15:47:33-04:00'
-				}, DEFAULT_MEDIA );
+				const isMatch = MediaQueryManager.matches(
+					{
+						before: '2010-04-25T15:47:33-04:00',
+					},
+					DEFAULT_MEDIA
+				);
 
 				expect( isMatch ).to.be.false;
 			} );
 
 			it( 'should return true if media is before date', () => {
-				const isMatch = MediaQueryManager.matches( {
-					before: '2018-04-25T15:47:33-04:00'
-				}, DEFAULT_MEDIA );
+				const isMatch = MediaQueryManager.matches(
+					{
+						before: '2018-04-25T15:47:33-04:00',
+					},
+					DEFAULT_MEDIA
+				);
 
 				expect( isMatch ).to.be.true;
 			} );
@@ -209,25 +270,34 @@ describe( 'MediaQueryManager', () => {
 
 		context( 'query.after', () => {
 			it( 'should return false if query is not ISO 8601', () => {
-				const isMatch = MediaQueryManager.matches( {
-					after: '2010'
-				}, DEFAULT_MEDIA );
+				const isMatch = MediaQueryManager.matches(
+					{
+						after: '2010',
+					},
+					DEFAULT_MEDIA
+				);
 
 				expect( isMatch ).to.be.false;
 			} );
 
 			it( 'should return false if media is not after date', () => {
-				const isMatch = MediaQueryManager.matches( {
-					after: '2018-04-25T15:47:33-04:00'
-				}, DEFAULT_MEDIA );
+				const isMatch = MediaQueryManager.matches(
+					{
+						after: '2018-04-25T15:47:33-04:00',
+					},
+					DEFAULT_MEDIA
+				);
 
 				expect( isMatch ).to.be.false;
 			} );
 
 			it( 'should return true if media is after date', () => {
-				const isMatch = MediaQueryManager.matches( {
-					after: '2010-04-25T15:47:33-04:00'
-				}, DEFAULT_MEDIA );
+				const isMatch = MediaQueryManager.matches(
+					{
+						after: '2010-04-25T15:47:33-04:00',
+					},
+					DEFAULT_MEDIA
+				);
 
 				expect( isMatch ).to.be.true;
 			} );
@@ -237,32 +307,24 @@ describe( 'MediaQueryManager', () => {
 	describe( '#compare()', () => {
 		context( 'query.order', () => {
 			it( 'should sort descending by default', () => {
-				const sorted = [
-					{ ID: 200 },
-					{ ID: 400 }
-				].sort( manager.compare.bind( manager, {
-					order_by: 'ID'
-				} ) );
+				const sorted = [ { ID: 200 }, { ID: 400 } ].sort(
+					manager.compare.bind( manager, {
+						order_by: 'ID',
+					} )
+				);
 
-				expect( sorted ).to.eql( [
-					{ ID: 400 },
-					{ ID: 200 }
-				] );
+				expect( sorted ).to.eql( [ { ID: 400 }, { ID: 200 } ] );
 			} );
 
 			it( 'should reverse order when specified as ascending', () => {
-				const sorted = [
-					{ ID: 400 },
-					{ ID: 200 }
-				].sort( manager.compare.bind( manager, {
-					order_by: 'ID',
-					order: 'ASC'
-				} ) );
+				const sorted = [ { ID: 400 }, { ID: 200 } ].sort(
+					manager.compare.bind( manager, {
+						order_by: 'ID',
+						order: 'ASC',
+					} )
+				);
 
-				expect( sorted ).to.eql( [
-					{ ID: 200 },
-					{ ID: 400 }
-				] );
+				expect( sorted ).to.eql( [ { ID: 200 }, { ID: 400 } ] );
 			} );
 		} );
 
@@ -270,68 +332,54 @@ describe( 'MediaQueryManager', () => {
 			context( 'date', () => {
 				const olderMedia = {
 					...DEFAULT_MEDIA,
-					date: '2016-04-25T11:40:52-04:00'
+					date: '2016-04-25T11:40:52-04:00',
 				};
 
 				const newerMedia = {
 					...DEFAULT_MEDIA,
 					ID: 152,
-					date: '2016-04-25T15:47:33-04:00'
+					date: '2016-04-25T15:47:33-04:00',
 				};
 
 				it( 'should order by date', () => {
-					const sorted = [
-						olderMedia,
-						newerMedia
-					].sort( manager.compare.bind( manager, {} ) );
+					const sorted = [ olderMedia, newerMedia ].sort( manager.compare.bind( manager, {} ) );
 
-					expect( sorted ).to.eql( [
-						newerMedia,
-						olderMedia
-					] );
+					expect( sorted ).to.eql( [ newerMedia, olderMedia ] );
 				} );
 			} );
 
 			context( 'title', () => {
 				const abMedia = {
 					...DEFAULT_MEDIA,
-					title: 'AB'
+					title: 'AB',
 				};
 
 				const aaMedia = {
 					...DEFAULT_MEDIA,
 					ID: 152,
-					title: 'Aa'
+					title: 'Aa',
 				};
 
 				it( 'should sort by title', () => {
-					const sorted = [
-						aaMedia,
-						abMedia
-					].sort( manager.compare.bind( manager, {
-						order_by: 'title'
-					} ) );
+					const sorted = [ aaMedia, abMedia ].sort(
+						manager.compare.bind( manager, {
+							order_by: 'title',
+						} )
+					);
 
-					expect( sorted ).to.eql( [
-						abMedia,
-						aaMedia
-					] );
+					expect( sorted ).to.eql( [ abMedia, aaMedia ] );
 				} );
 			} );
 
 			context( 'ID', () => {
 				it( 'should sort by ID', () => {
-					const sorted = [
-						{ ID: 200 },
-						{ ID: 400 }
-					].sort( manager.compare.bind( manager, {
-						order_by: 'ID'
-					} ) );
+					const sorted = [ { ID: 200 }, { ID: 400 } ].sort(
+						manager.compare.bind( manager, {
+							order_by: 'ID',
+						} )
+					);
 
-					expect( sorted ).to.eql( [
-						{ ID: 400 },
-						{ ID: 200 }
-					] );
+					expect( sorted ).to.eql( [ { ID: 400 }, { ID: 200 } ] );
 				} );
 			} );
 		} );

--- a/client/lib/query-manager/paginated/constants.js
+++ b/client/lib/query-manager/paginated/constants.js
@@ -1,10 +1,7 @@
+/** @format */
 export const DEFAULT_QUERY = {
 	number: 20,
-	page: 1
+	page: 1,
 };
 
-export const PAGINATION_QUERY_KEYS = [
-	'number',
-	'offset',
-	'page'
-];
+export const PAGINATION_QUERY_KEYS = [ 'number', 'offset', 'page' ];

--- a/client/lib/query-manager/paginated/index.js
+++ b/client/lib/query-manager/paginated/index.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -27,7 +28,7 @@ export default class PaginatedQueryManager extends QueryManager {
 			return false;
 		}
 
-		return PAGINATION_QUERY_KEYS.some( ( key ) => {
+		return PAGINATION_QUERY_KEYS.some( key => {
 			return query.hasOwnProperty( key );
 		} );
 	}
@@ -79,7 +80,7 @@ export default class PaginatedQueryManager extends QueryManager {
 			return items;
 		}
 
-		return items.filter( ( item ) => undefined !== item );
+		return items.filter( item => undefined !== item );
 	}
 
 	/**
@@ -120,11 +121,15 @@ export default class PaginatedQueryManager extends QueryManager {
 		// simulated in `PaginatedQueryManager.prototype.getItems`.
 		let modifiedOptions = options;
 		if ( options.query ) {
-			modifiedOptions = Object.assign( {
-				mergeQuery: true
-			}, options, {
-				query: omit( options.query, PAGINATION_QUERY_KEYS )
-			} );
+			modifiedOptions = Object.assign(
+				{
+					mergeQuery: true,
+				},
+				options,
+				{
+					query: omit( options.query, PAGINATION_QUERY_KEYS ),
+				}
+			);
 		}
 
 		// Receive the updated manager, passing a modified set of options to
@@ -155,7 +160,7 @@ export default class PaginatedQueryManager extends QueryManager {
 
 		// If the item set for the queried page is identical, there are no
 		// updates to be made
-		const pageItemKeys = items.map( ( item ) => item[ this.options.itemKey ] );
+		const pageItemKeys = items.map( item => item[ this.options.itemKey ] );
 
 		// If we've reached this point, we know that we've received a paged
 		// set of data where our assumed item set is incorrect.
@@ -171,12 +176,12 @@ export default class PaginatedQueryManager extends QueryManager {
 			// of items received added to the summed per page total. Note that
 			// we can reach this point if receiving the last page of items, but
 			// the updated value should still be correct given this logic.
-			modifiedNextQuery.found = ( ( page - 1 ) * perPage ) + items.length;
+			modifiedNextQuery.found = ( page - 1 ) * perPage + items.length;
 		}
 
 		// Replace the assumed set with the received items.
 		modifiedNextQuery.itemKeys = [
-			...range( 0, startOffset ).map( ( index ) => {
+			...range( 0, startOffset ).map( index => {
 				// Ensure that item set is comprised of all indices leading up
 				// to received page, even if those items are not known.
 				const itemKey = nextQuery.itemKeys[ index ];
@@ -184,22 +189,22 @@ export default class PaginatedQueryManager extends QueryManager {
 					return itemKey;
 				}
 			} ),
-			...range( 0, perPage ).map( ( index ) => {
+			...range( 0, perPage ).map( index => {
 				// Fill page with items from the received set, or undefined to
 				// at least ensure page matches expected range
 				return pageItemKeys[ index ];
 			} ),
-			...nextQuery.itemKeys.slice( startOffset + perPage ).filter( ( itemKey ) => {
+			...nextQuery.itemKeys.slice( startOffset + perPage ).filter( itemKey => {
 				// Filter out any item keys which exist in the page set, as
 				// this indicates that they've trickled down from later page
 				return itemKey && ! includes( pageItemKeys, itemKey );
-			} )
+			} ),
 		];
 
 		// If found is known from options, ensure that we fill the end of the
 		// array with undefined entries until found count
 		if ( modifiedNextQuery.hasOwnProperty( 'found' ) ) {
-			modifiedNextQuery.itemKeys = range( 0, modifiedNextQuery.found ).map( ( index ) => {
+			modifiedNextQuery.itemKeys = range( 0, modifiedNextQuery.found ).map( index => {
 				return modifiedNextQuery.itemKeys[ index ];
 			} );
 		}
@@ -207,8 +212,8 @@ export default class PaginatedQueryManager extends QueryManager {
 		return new this.constructor(
 			Object.assign( {}, nextManager.data, {
 				queries: Object.assign( {}, nextManager.data.queries, {
-					[ queryKey ]: modifiedNextQuery
-				} )
+					[ queryKey ]: modifiedNextQuery,
+				} ),
 			} ),
 			nextManager.options
 		);

--- a/client/lib/query-manager/paginated/key.js
+++ b/client/lib/query-manager/paginated/key.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */

--- a/client/lib/query-manager/paginated/test/index.js
+++ b/client/lib/query-manager/paginated/test/index.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -14,15 +15,13 @@ import PaginatedQueryManager from '../';
  */
 const TestCustomQueryManager = class TermQueryManager extends PaginatedQueryManager {};
 TestCustomQueryManager.DEFAULT_QUERY = {
-	number: 25
+	number: 25,
 };
 
 describe( 'PaginatedQueryManager', () => {
 	let sandbox, manager;
 
-	useSandbox( ( _sandbox ) => {
-		sandbox = _sandbox;
-	} );
+	useSandbox( _sandbox => ( sandbox = _sandbox ) );
 
 	beforeEach( () => {
 		manager = new PaginatedQueryManager();
@@ -47,7 +46,10 @@ describe( 'PaginatedQueryManager', () => {
 		} );
 
 		it( 'should return true if query has pagination keys', () => {
-			const hasKeys = PaginatedQueryManager.hasQueryPaginationKeys( { search: 'title', number: 2 } );
+			const hasKeys = PaginatedQueryManager.hasQueryPaginationKeys( {
+				search: 'title',
+				number: 2,
+			} );
 
 			expect( hasKeys ).to.be.true;
 		} );
@@ -154,9 +156,14 @@ describe( 'PaginatedQueryManager', () => {
 
 		it( 'should update a single changed item', () => {
 			manager = manager.receive( { ID: 144 }, { query: { search: 'title', number: 1 } } );
-			manager = manager.receive( { ID: 144, changed: true }, { query: { search: 'title', number: 1 } } );
+			manager = manager.receive(
+				{ ID: 144, changed: true },
+				{ query: { search: 'title', number: 1 } }
+			);
 
-			expect( manager.getItems( { search: 'title', number: 1 } ) ).to.eql( [ { ID: 144, changed: true } ] );
+			expect( manager.getItems( { search: 'title', number: 1 } ) ).to.eql( [
+				{ ID: 144, changed: true },
+			] );
 		} );
 
 		it( 'should append paginated items, tracked as query sans pagination keys', () => {
@@ -164,14 +171,20 @@ describe( 'PaginatedQueryManager', () => {
 			manager = manager.receive( { ID: 152 }, { query: { search: 'title', number: 1, page: 2 } } );
 
 			expect( manager.getItems( { search: 'title', number: 1 } ) ).to.eql( [ { ID: 144 } ] );
-			expect( manager.getItemsIgnoringPage( { search: 'title', number: 1 } ) ).to.eql( [ { ID: 144 }, { ID: 152 } ] );
+			expect( manager.getItemsIgnoringPage( { search: 'title', number: 1 } ) ).to.eql( [
+				{ ID: 144 },
+				{ ID: 152 },
+			] );
 		} );
 
 		it( 'should preserve existing pages when receiving items queried with different number', () => {
 			manager = manager.receive( [ { ID: 144 }, { ID: 152 } ], { query: { number: 2 } } );
 			manager = manager.receive( { ID: 144, changed: true }, { query: { number: 1 } } );
 
-			expect( manager.getItemsIgnoringPage( {} ) ).to.eql( [ { ID: 144, changed: true }, { ID: 152 } ] );
+			expect( manager.getItemsIgnoringPage( {} ) ).to.eql( [
+				{ ID: 144, changed: true },
+				{ ID: 152 },
+			] );
 			expect( manager.getItems( { number: 1, page: 1 } ) ).to.eql( [ { ID: 144, changed: true } ] );
 			expect( manager.getItems( { number: 1, page: 2 } ) ).to.eql( [ { ID: 152 } ] );
 		} );
@@ -179,11 +192,19 @@ describe( 'PaginatedQueryManager', () => {
 		it( 'should include filler undefined entries for yet-to-be-received items', () => {
 			manager = manager.receive( [ { ID: 144 } ], { query: { number: 1, page: 2 }, found: 4 } );
 
-			expect( manager.getItemsIgnoringPage( { number: 1 }, true ) ).to.eql( [ undefined, { ID: 144 }, undefined, undefined ] );
+			expect( manager.getItemsIgnoringPage( { number: 1 }, true ) ).to.eql( [
+				undefined,
+				{ ID: 144 },
+				undefined,
+				undefined,
+			] );
 		} );
 
 		it( 'should strip excess undefined entries beyond found count', () => {
-			manager = manager.receive( [ { ID: 144 }, { ID: 152 } ], { query: { number: 20 }, found: 2 } );
+			manager = manager.receive( [ { ID: 144 }, { ID: 152 } ], {
+				query: { number: 20 },
+				found: 2,
+			} );
 
 			expect( manager.getItems( { number: 20 } ) ).to.eql( [ { ID: 144 }, { ID: 152 } ] );
 		} );
@@ -196,7 +217,11 @@ describe( 'PaginatedQueryManager', () => {
 			manager = manager.receive( { ID: 160 }, { query: { search: 'title', number: 1, page: 3 } } );
 			manager = manager.receive( { ID: 154 }, { query: { search: 'title', number: 1, page: 2 } } );
 
-			expect( manager.getItemsIgnoringPage( { search: 'title' } ) ).to.eql( [ { ID: 144 }, { ID: 154 }, { ID: 160 } ] );
+			expect( manager.getItemsIgnoringPage( { search: 'title' } ) ).to.eql( [
+				{ ID: 144 },
+				{ ID: 154 },
+				{ ID: 160 },
+			] );
 			expect( manager.getFound( { search: 'title' } ) ).to.equal( 3 );
 		} );
 
@@ -205,8 +230,14 @@ describe( 'PaginatedQueryManager', () => {
 			// ID:152, then deleted ID:144 and received updated first page
 			// including only ID:152 (net found change: -1)
 			manager = manager.receive( { ID: 144 }, { query: { search: 'title', number: 1 }, found: 2 } );
-			manager = manager.receive( { ID: 152 }, { query: { search: 'title', number: 1, page: 2 }, found: 2 } );
-			manager = manager.receive( { ID: 152 }, { query: { search: 'title', number: 1, page: 1 }, found: 1 } );
+			manager = manager.receive(
+				{ ID: 152 },
+				{ query: { search: 'title', number: 1, page: 2 }, found: 2 }
+			);
+			manager = manager.receive(
+				{ ID: 152 },
+				{ query: { search: 'title', number: 1, page: 1 }, found: 1 }
+			);
 
 			expect( manager.getItems( { search: 'title', number: 1 } ) ).to.eql( [ { ID: 152 } ] );
 			expect( manager.getItems( { search: 'title', number: 1, page: 2 } ) ).to.eql( [] );
@@ -218,52 +249,123 @@ describe( 'PaginatedQueryManager', () => {
 			// Scenario: Received 3 pages of data, then deleted an item in the
 			// middle of the set (net found change: -1). Ensure also that pages
 			// redistribute accordingly
-			manager = manager.receive( [ { ID: 144 }, { ID: 152 } ], { query: { search: 'title', number: 2 }, found: 6 } );
-			manager = manager.receive( [ { ID: 160 }, { ID: 168 } ], { query: { search: 'title', number: 2, page: 2 } } );
-			manager = manager.receive( [ { ID: 176 }, { ID: 184 } ], { query: { search: 'title', number: 2, page: 3 } } );
+			manager = manager.receive( [ { ID: 144 }, { ID: 152 } ], {
+				query: { search: 'title', number: 2 },
+				found: 6,
+			} );
+			manager = manager.receive( [ { ID: 160 }, { ID: 168 } ], {
+				query: { search: 'title', number: 2, page: 2 },
+			} );
+			manager = manager.receive( [ { ID: 176 }, { ID: 184 } ], {
+				query: { search: 'title', number: 2, page: 3 },
+			} );
 			sandbox.stub( PaginatedQueryManager, 'matches' ).returns( false );
 			manager = manager.receive( { ID: 160, changed: true } );
 
 			expect( manager.getFound( { search: 'title' } ) ).to.equal( 5 );
-			expect( manager.getItems( { search: 'title', number: 2, page: 2 } ) ).to.eql( [ { ID: 168 }, { ID: 176 } ] );
-			expect( manager.getItems( { search: 'title', number: 2, page: 3 } ) ).to.eql( [ { ID: 184 } ] );
+			expect( manager.getItems( { search: 'title', number: 2, page: 2 } ) ).to.eql( [
+				{ ID: 168 },
+				{ ID: 176 },
+			] );
+			expect( manager.getItems( { search: 'title', number: 2, page: 3 } ) ).to.eql( [
+				{ ID: 184 },
+			] );
 		} );
 
 		it( 'should adjust for the difference in found after an item is added', () => {
 			// Scenario: Received 3 pages of data, then inserted an item in the
 			// middle of the set (net found change: +1). Ensure also that pages
 			// redistribute accordingly
-			manager = manager.receive( [ { ID: 144 }, { ID: 152 } ], { query: { search: 'title', number: 2 }, found: 6 } );
-			manager = manager.receive( [ { ID: 160 }, { ID: 168 } ], { query: { search: 'title', number: 2, page: 2 } } );
-			manager = manager.receive( [ { ID: 176 }, { ID: 184 } ], { query: { search: 'title', number: 2, page: 3 } } );
+			manager = manager.receive( [ { ID: 144 }, { ID: 152 } ], {
+				query: { search: 'title', number: 2 },
+				found: 6,
+			} );
+			manager = manager.receive( [ { ID: 160 }, { ID: 168 } ], {
+				query: { search: 'title', number: 2, page: 2 },
+			} );
+			manager = manager.receive( [ { ID: 176 }, { ID: 184 } ], {
+				query: { search: 'title', number: 2, page: 3 },
+			} );
 			manager = manager.receive( { ID: 154 } );
 
 			expect( manager.getFound( { search: 'title' } ) ).to.equal( 7 );
 			expect( manager.getNumberOfPages( { search: 'title', number: 2 } ) ).to.equal( 4 );
-			expect( manager.getItems( { search: 'title', number: 2, page: 1 } ) ).to.eql( [ { ID: 144 }, { ID: 152 } ] );
-			expect( manager.getItems( { search: 'title', number: 2, page: 2 } ) ).to.eql( [ { ID: 154 }, { ID: 160 } ] );
-			expect( manager.getItems( { search: 'title', number: 2, page: 3 } ) ).to.eql( [ { ID: 168 }, { ID: 176 } ] );
-			expect( manager.getItems( { search: 'title', number: 2, page: 4 } ) ).to.eql( [ { ID: 184 } ] );
+			expect( manager.getItems( { search: 'title', number: 2, page: 1 } ) ).to.eql( [
+				{ ID: 144 },
+				{ ID: 152 },
+			] );
+			expect( manager.getItems( { search: 'title', number: 2, page: 2 } ) ).to.eql( [
+				{ ID: 154 },
+				{ ID: 160 },
+			] );
+			expect( manager.getItems( { search: 'title', number: 2, page: 3 } ) ).to.eql( [
+				{ ID: 168 },
+				{ ID: 176 },
+			] );
+			expect( manager.getItems( { search: 'title', number: 2, page: 4 } ) ).to.eql( [
+				{ ID: 184 },
+			] );
 		} );
 
 		it( 'should use the constructors DEFAULT_QUERY.number if query object does not specify it', () => {
 			let customizedManager = new TestCustomQueryManager();
 			customizedManager = customizedManager.receive(
 				[
-					{ ID: 144 }, { ID: 152 }, { ID: 162 }, { ID: 164 }, { ID: 165 },
-					{ ID: 244 }, { ID: 252 }, { ID: 262 }, { ID: 264 }, { ID: 265 },
-					{ ID: 344 }, { ID: 352 }, { ID: 362 }, { ID: 364 }, { ID: 365 },
-					{ ID: 444 }, { ID: 452 }, { ID: 462 }, { ID: 464 }, { ID: 465 },
-					{ ID: 544 }, { ID: 552 }, { ID: 562 }, { ID: 564 }, { ID: 565 }
-				], { query: { page: 1 }, found: 28 }
+					{ ID: 144 },
+					{ ID: 152 },
+					{ ID: 162 },
+					{ ID: 164 },
+					{ ID: 165 },
+					{ ID: 244 },
+					{ ID: 252 },
+					{ ID: 262 },
+					{ ID: 264 },
+					{ ID: 265 },
+					{ ID: 344 },
+					{ ID: 352 },
+					{ ID: 362 },
+					{ ID: 364 },
+					{ ID: 365 },
+					{ ID: 444 },
+					{ ID: 452 },
+					{ ID: 462 },
+					{ ID: 464 },
+					{ ID: 465 },
+					{ ID: 544 },
+					{ ID: 552 },
+					{ ID: 562 },
+					{ ID: 564 },
+					{ ID: 565 },
+				],
+				{ query: { page: 1 }, found: 28 }
 			);
 			expect( customizedManager.getNumberOfPages( {} ) ).to.equal( 2 );
 			expect( customizedManager.getItems( { page: 1 } ) ).eql( [
-				{ ID: 144 }, { ID: 152 }, { ID: 162 }, { ID: 164 }, { ID: 165 },
-				{ ID: 244 }, { ID: 252 }, { ID: 262 }, { ID: 264 }, { ID: 265 },
-				{ ID: 344 }, { ID: 352 }, { ID: 362 }, { ID: 364 }, { ID: 365 },
-				{ ID: 444 }, { ID: 452 }, { ID: 462 }, { ID: 464 }, { ID: 465 },
-				{ ID: 544 }, { ID: 552 }, { ID: 562 }, { ID: 564 }, { ID: 565 }
+				{ ID: 144 },
+				{ ID: 152 },
+				{ ID: 162 },
+				{ ID: 164 },
+				{ ID: 165 },
+				{ ID: 244 },
+				{ ID: 252 },
+				{ ID: 262 },
+				{ ID: 264 },
+				{ ID: 265 },
+				{ ID: 344 },
+				{ ID: 352 },
+				{ ID: 362 },
+				{ ID: 364 },
+				{ ID: 365 },
+				{ ID: 444 },
+				{ ID: 452 },
+				{ ID: 462 },
+				{ ID: 464 },
+				{ ID: 465 },
+				{ ID: 544 },
+				{ ID: 552 },
+				{ ID: 562 },
+				{ ID: 564 },
+				{ ID: 565 },
 			] );
 		} );
 
@@ -272,8 +374,13 @@ describe( 'PaginatedQueryManager', () => {
 			// found. Upon receiving second page, only one entry is provided,
 			// presumably because they don't have access to the fourth. Thus,
 			// found should be updated to reflect this discrepency.
-			manager = manager.receive( [ { ID: 144 }, { ID: 152 } ], { query: { search: 'title', number: 2 }, found: 4 } );
-			manager = manager.receive( [ { ID: 160 } ], { query: { search: 'title', number: 2, page: 2 } } );
+			manager = manager.receive( [ { ID: 144 }, { ID: 152 } ], {
+				query: { search: 'title', number: 2 },
+				found: 4,
+			} );
+			manager = manager.receive( [ { ID: 160 } ], {
+				query: { search: 'title', number: 2, page: 2 },
+			} );
 
 			expect( manager.getFound( { search: 'title' } ) ).to.equal( 3 );
 		} );

--- a/client/lib/query-manager/paginated/test/key.js
+++ b/client/lib/query-manager/paginated/test/key.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */

--- a/client/lib/query-manager/post/constants.js
+++ b/client/lib/query-manager/post/constants.js
@@ -1,3 +1,4 @@
+/** @format */
 export const DEFAULT_POST_QUERY = {
 	context: 'display',
 	http_envelope: false,
@@ -10,5 +11,5 @@ export const DEFAULT_POST_QUERY = {
 	type: 'post',
 	status: 'publish',
 	sticky: 'include',
-	search: ''
+	search: '',
 };

--- a/client/lib/query-manager/post/index.js
+++ b/client/lib/query-manager/post/index.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -95,9 +96,14 @@ export default class PostQueryManager extends PaginatedQueryManager {
 					return get( post, 'author.ID', post.author ) === value;
 
 				case 'status':
-					return 'any' === value || String( value ).split( ',' ).some( ( status ) => {
-						return status === post[ key ];
-					} );
+					return (
+						'any' === value ||
+						String( value )
+							.split( ',' )
+							.some( status => {
+								return status === post[ key ];
+							} )
+					);
 			}
 
 			return true;
@@ -123,7 +129,8 @@ export default class PostQueryManager extends PaginatedQueryManager {
 				break;
 
 			case 'comment_count':
-				order = get( postA.discussion, 'comment_count', 0 ) - get( postB.discussion, 'comment_count', 0 );
+				order =
+					get( postA.discussion, 'comment_count', 0 ) - get( postB.discussion, 'comment_count', 0 );
 				break;
 
 			case 'title':

--- a/client/lib/query-manager/post/key.js
+++ b/client/lib/query-manager/post/key.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -19,8 +20,7 @@ import { DEFAULT_POST_QUERY } from './constants';
  */
 function isDefaultOrNullQueryValue( value, key ) {
 	return (
-		null == value || // Double-equals null checks undefined, null
-		DEFAULT_POST_QUERY[ key ] === value
+		null == value || DEFAULT_POST_QUERY[ key ] === value // Double-equals null checks undefined, null
 	);
 }
 

--- a/client/lib/query-manager/post/test/index.js
+++ b/client/lib/query-manager/post/test/index.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -16,7 +17,7 @@ const DEFAULT_POST = {
 	site_ID: 77203074,
 	author: {
 		ID: 73705554,
-		login: 'testonesite2014'
+		login: 'testonesite2014',
 	},
 	date: '2016-04-25T15:47:33-04:00',
 	modified: '2016-04-29T11:53:53-04:00',
@@ -31,57 +32,57 @@ const DEFAULT_POST = {
 		comment_status: 'open',
 		pings_open: true,
 		ping_status: 'open',
-		comment_count: 0
+		comment_count: 0,
 	},
 	tags: {
 		Tagged: {
 			ID: 17695,
 			name: 'Tagged!',
-			slug: 'tagged'
-		}
+			slug: 'tagged',
+		},
 	},
 	categories: {
 		'Categorized!': {
 			ID: 5519,
 			name: 'Categorized!',
-			slug: 'categorized'
-		}
+			slug: 'categorized',
+		},
 	},
 	terms: {
 		post_tag: {
 			Tagged: {
 				ID: 17695,
 				name: 'Tagged!',
-				slug: 'tagged'
-			}
+				slug: 'tagged',
+			},
 		},
 		category: {
 			'Categorized!': {
 				ID: 5519,
 				name: 'Categorized!',
-				slug: 'categorized'
-			}
+				slug: 'categorized',
+			},
 		},
 		genre: {
 			Fiction: {
 				ID: 5102,
 				name: 'Fiction',
-				slug: 'fiction'
+				slug: 'fiction',
 			},
 			'Sci-Fi': {
 				ID: 5102,
 				name: 'Sci-Fi',
-				slug: 'sci-fi'
-			}
-		}
+				slug: 'sci-fi',
+			},
+		},
 	},
 	metadata: [
 		{
 			id: '22573',
 			key: '_rest_api_published',
-			value: '1'
-		}
-	]
+			value: '1',
+		},
+	],
 };
 
 describe( 'PostQueryManager', () => {
@@ -93,49 +94,67 @@ describe( 'PostQueryManager', () => {
 	describe( '#matches()', () => {
 		context( 'query.search', () => {
 			it( 'should return false for a non-matching search', () => {
-				const isMatch = PostQueryManager.matches( {
-					search: 'disgusting'
-				}, DEFAULT_POST );
+				const isMatch = PostQueryManager.matches(
+					{
+						search: 'disgusting',
+					},
+					DEFAULT_POST
+				);
 
 				expect( isMatch ).to.be.false;
 			} );
 
 			it( 'should return true for a matching title search', () => {
-				const isMatch = PostQueryManager.matches( {
-					search: 'Ribs'
-				}, DEFAULT_POST );
+				const isMatch = PostQueryManager.matches(
+					{
+						search: 'Ribs',
+					},
+					DEFAULT_POST
+				);
 
 				expect( isMatch ).to.be.true;
 			} );
 
 			it( 'should return true for a falsey title search', () => {
-				const isMatch = PostQueryManager.matches( {
-					search: null
-				}, DEFAULT_POST );
+				const isMatch = PostQueryManager.matches(
+					{
+						search: null,
+					},
+					DEFAULT_POST
+				);
 
 				expect( isMatch ).to.be.true;
 			} );
 
 			it( 'should return true for a matching content search', () => {
-				const isMatch = PostQueryManager.matches( {
-					search: 'delicious'
-				}, DEFAULT_POST );
+				const isMatch = PostQueryManager.matches(
+					{
+						search: 'delicious',
+					},
+					DEFAULT_POST
+				);
 
 				expect( isMatch ).to.be.true;
 			} );
 
 			it( 'should search case-insensitive', () => {
-				const isMatch = PostQueryManager.matches( {
-					search: 'ribs'
-				}, DEFAULT_POST );
+				const isMatch = PostQueryManager.matches(
+					{
+						search: 'ribs',
+					},
+					DEFAULT_POST
+				);
 
 				expect( isMatch ).to.be.true;
 			} );
 
 			it( 'should separately test title and content fields', () => {
-				const isMatch = PostQueryManager.matches( {
-					search: 'ChickenAre'
-				}, DEFAULT_POST );
+				const isMatch = PostQueryManager.matches(
+					{
+						search: 'ChickenAre',
+					},
+					DEFAULT_POST
+				);
 
 				expect( isMatch ).to.be.false;
 			} );
@@ -143,25 +162,34 @@ describe( 'PostQueryManager', () => {
 
 		context( 'query.after', () => {
 			it( 'should return false if query is not ISO 8601', () => {
-				const isMatch = PostQueryManager.matches( {
-					after: '2014'
-				}, DEFAULT_POST );
+				const isMatch = PostQueryManager.matches(
+					{
+						after: '2014',
+					},
+					DEFAULT_POST
+				);
 
 				expect( isMatch ).to.be.false;
 			} );
 
 			it( 'should return false if post is not after date', () => {
-				const isMatch = PostQueryManager.matches( {
-					after: '2018-04-25T15:47:33-04:00'
-				}, DEFAULT_POST );
+				const isMatch = PostQueryManager.matches(
+					{
+						after: '2018-04-25T15:47:33-04:00',
+					},
+					DEFAULT_POST
+				);
 
 				expect( isMatch ).to.be.false;
 			} );
 
 			it( 'should return true if post is after date', () => {
-				const isMatch = PostQueryManager.matches( {
-					after: '2014-04-25T15:47:33-04:00'
-				}, DEFAULT_POST );
+				const isMatch = PostQueryManager.matches(
+					{
+						after: '2014-04-25T15:47:33-04:00',
+					},
+					DEFAULT_POST
+				);
 
 				expect( isMatch ).to.be.true;
 			} );
@@ -169,25 +197,34 @@ describe( 'PostQueryManager', () => {
 
 		context( 'query.before', () => {
 			it( 'should return false if query is not ISO 8601', () => {
-				const isMatch = PostQueryManager.matches( {
-					before: '2018'
-				}, DEFAULT_POST );
+				const isMatch = PostQueryManager.matches(
+					{
+						before: '2018',
+					},
+					DEFAULT_POST
+				);
 
 				expect( isMatch ).to.be.false;
 			} );
 
 			it( 'should return false if post is not before date', () => {
-				const isMatch = PostQueryManager.matches( {
-					before: '2014-04-25T15:47:33-04:00'
-				}, DEFAULT_POST );
+				const isMatch = PostQueryManager.matches(
+					{
+						before: '2014-04-25T15:47:33-04:00',
+					},
+					DEFAULT_POST
+				);
 
 				expect( isMatch ).to.be.false;
 			} );
 
 			it( 'should return true if post is before date', () => {
-				const isMatch = PostQueryManager.matches( {
-					before: '2018-04-25T15:47:33-04:00'
-				}, DEFAULT_POST );
+				const isMatch = PostQueryManager.matches(
+					{
+						before: '2018-04-25T15:47:33-04:00',
+					},
+					DEFAULT_POST
+				);
 
 				expect( isMatch ).to.be.true;
 			} );
@@ -195,25 +232,34 @@ describe( 'PostQueryManager', () => {
 
 		context( 'query.modified_after', () => {
 			it( 'should return false if query is not ISO 8601', () => {
-				const isMatch = PostQueryManager.matches( {
-					modified_after: '2014'
-				}, DEFAULT_POST );
+				const isMatch = PostQueryManager.matches(
+					{
+						modified_after: '2014',
+					},
+					DEFAULT_POST
+				);
 
 				expect( isMatch ).to.be.false;
 			} );
 
 			it( 'should return false if post is not modified after date', () => {
-				const isMatch = PostQueryManager.matches( {
-					modified_after: '2018-04-25T15:47:33-04:00'
-				}, DEFAULT_POST );
+				const isMatch = PostQueryManager.matches(
+					{
+						modified_after: '2018-04-25T15:47:33-04:00',
+					},
+					DEFAULT_POST
+				);
 
 				expect( isMatch ).to.be.false;
 			} );
 
 			it( 'should return true if post is modified after date', () => {
-				const isMatch = PostQueryManager.matches( {
-					modified_after: '2014-04-25T15:47:33-04:00'
-				}, DEFAULT_POST );
+				const isMatch = PostQueryManager.matches(
+					{
+						modified_after: '2014-04-25T15:47:33-04:00',
+					},
+					DEFAULT_POST
+				);
 
 				expect( isMatch ).to.be.true;
 			} );
@@ -221,25 +267,34 @@ describe( 'PostQueryManager', () => {
 
 		context( 'query.modified_before', () => {
 			it( 'should return false if query is not ISO 8601', () => {
-				const isMatch = PostQueryManager.matches( {
-					modified_before: '2018'
-				}, DEFAULT_POST );
+				const isMatch = PostQueryManager.matches(
+					{
+						modified_before: '2018',
+					},
+					DEFAULT_POST
+				);
 
 				expect( isMatch ).to.be.false;
 			} );
 
 			it( 'should return false if post is not modified before date', () => {
-				const isMatch = PostQueryManager.matches( {
-					modified_before: '2014-04-25T15:47:33-04:00'
-				}, DEFAULT_POST );
+				const isMatch = PostQueryManager.matches(
+					{
+						modified_before: '2014-04-25T15:47:33-04:00',
+					},
+					DEFAULT_POST
+				);
 
 				expect( isMatch ).to.be.false;
 			} );
 
 			it( 'should return true if post is modified before date', () => {
-				const isMatch = PostQueryManager.matches( {
-					modified_before: '2018-04-25T15:47:33-04:00'
-				}, DEFAULT_POST );
+				const isMatch = PostQueryManager.matches(
+					{
+						modified_before: '2018-04-25T15:47:33-04:00',
+					},
+					DEFAULT_POST
+				);
 
 				expect( isMatch ).to.be.true;
 			} );
@@ -247,41 +302,56 @@ describe( 'PostQueryManager', () => {
 
 		context( 'query.tag', () => {
 			it( 'should return false if post does not include tag', () => {
-				const isMatch = PostQueryManager.matches( {
-					tag: 'Nottag'
-				}, DEFAULT_POST );
+				const isMatch = PostQueryManager.matches(
+					{
+						tag: 'Nottag',
+					},
+					DEFAULT_POST
+				);
 
 				expect( isMatch ).to.be.false;
 			} );
 
 			it( 'should return false on a partial match', () => {
-				const isMatch = PostQueryManager.matches( {
-					tag: 'agg'
-				}, DEFAULT_POST );
+				const isMatch = PostQueryManager.matches(
+					{
+						tag: 'agg',
+					},
+					DEFAULT_POST
+				);
 
 				expect( isMatch ).to.be.false;
 			} );
 
 			it( 'should return true if post includes tag by name', () => {
-				const isMatch = PostQueryManager.matches( {
-					tag: 'Tagged!'
-				}, DEFAULT_POST );
+				const isMatch = PostQueryManager.matches(
+					{
+						tag: 'Tagged!',
+					},
+					DEFAULT_POST
+				);
 
 				expect( isMatch ).to.be.true;
 			} );
 
 			it( 'should return true if post includes tag by slug', () => {
-				const isMatch = PostQueryManager.matches( {
-					tag: 'tagged'
-				}, DEFAULT_POST );
+				const isMatch = PostQueryManager.matches(
+					{
+						tag: 'tagged',
+					},
+					DEFAULT_POST
+				);
 
 				expect( isMatch ).to.be.true;
 			} );
 
 			it( 'should search case-insensitive', () => {
-				const isMatch = PostQueryManager.matches( {
-					tag: 'taGgEd'
-				}, DEFAULT_POST );
+				const isMatch = PostQueryManager.matches(
+					{
+						tag: 'taGgEd',
+					},
+					DEFAULT_POST
+				);
 
 				expect( isMatch ).to.be.true;
 			} );
@@ -289,41 +359,56 @@ describe( 'PostQueryManager', () => {
 
 		context( 'query.category', () => {
 			it( 'should return false if post does not include category', () => {
-				const isMatch = PostQueryManager.matches( {
-					category: 'Notcategory'
-				}, DEFAULT_POST );
+				const isMatch = PostQueryManager.matches(
+					{
+						category: 'Notcategory',
+					},
+					DEFAULT_POST
+				);
 
 				expect( isMatch ).to.be.false;
 			} );
 
 			it( 'should return false on a partial match', () => {
-				const isMatch = PostQueryManager.matches( {
-					category: 'egori'
-				}, DEFAULT_POST );
+				const isMatch = PostQueryManager.matches(
+					{
+						category: 'egori',
+					},
+					DEFAULT_POST
+				);
 
 				expect( isMatch ).to.be.false;
 			} );
 
 			it( 'should return true if post includes category by name', () => {
-				const isMatch = PostQueryManager.matches( {
-					category: 'Categorized!'
-				}, DEFAULT_POST );
+				const isMatch = PostQueryManager.matches(
+					{
+						category: 'Categorized!',
+					},
+					DEFAULT_POST
+				);
 
 				expect( isMatch ).to.be.true;
 			} );
 
 			it( 'should return true if post includes category by slug', () => {
-				const isMatch = PostQueryManager.matches( {
-					category: 'categorized'
-				}, DEFAULT_POST );
+				const isMatch = PostQueryManager.matches(
+					{
+						category: 'categorized',
+					},
+					DEFAULT_POST
+				);
 
 				expect( isMatch ).to.be.true;
 			} );
 
 			it( 'should search case-insensitive', () => {
-				const isMatch = PostQueryManager.matches( {
-					category: 'caTegoriZed'
-				}, DEFAULT_POST );
+				const isMatch = PostQueryManager.matches(
+					{
+						category: 'caTegoriZed',
+					},
+					DEFAULT_POST
+				);
 
 				expect( isMatch ).to.be.true;
 			} );
@@ -331,52 +416,67 @@ describe( 'PostQueryManager', () => {
 
 		context( 'query.term', () => {
 			it( 'should return false if post does not include term', () => {
-				const isMatch = PostQueryManager.matches( {
-					term: {
-						genre: 'non-fiction'
-					}
-				}, DEFAULT_POST );
+				const isMatch = PostQueryManager.matches(
+					{
+						term: {
+							genre: 'non-fiction',
+						},
+					},
+					DEFAULT_POST
+				);
 
 				expect( isMatch ).to.be.false;
 			} );
 
 			it( 'should return false if one but not both term slug queries match', () => {
-				const isMatch = PostQueryManager.matches( {
-					term: {
-						genre: 'fiction',
-						category: 'notcategory'
-					}
-				}, DEFAULT_POST );
+				const isMatch = PostQueryManager.matches(
+					{
+						term: {
+							genre: 'fiction',
+							category: 'notcategory',
+						},
+					},
+					DEFAULT_POST
+				);
 
 				expect( isMatch ).to.be.false;
 			} );
 
 			it( 'should return true if post includes term by slug', () => {
-				const isMatch = PostQueryManager.matches( {
-					term: {
-						genre: 'fiction'
-					}
-				}, DEFAULT_POST );
+				const isMatch = PostQueryManager.matches(
+					{
+						term: {
+							genre: 'fiction',
+						},
+					},
+					DEFAULT_POST
+				);
 
 				expect( isMatch ).to.be.true;
 			} );
 
 			it( 'should return true if post includes one of comma-separated term slugs', () => {
-				const isMatch = PostQueryManager.matches( {
-					term: {
-						genre: 'fiction,non-fiction'
-					}
-				}, DEFAULT_POST );
+				const isMatch = PostQueryManager.matches(
+					{
+						term: {
+							genre: 'fiction,non-fiction',
+						},
+					},
+					DEFAULT_POST
+				);
 
 				expect( isMatch ).to.be.true;
 			} );
 
 			it( 'should return true if post includes both of comma-separated term slugs', () => {
-				const isMatch = PostQueryManager.matches( {
-					term: {
-						genre: 'fiction,sci-fi'
-					}
-				}, DEFAULT_POST );
+				const isMatch = PostQueryManager.matches(
+					{
+						term: {
+							genre: 'fiction,sci-fi',
+						},
+					},
+					DEFAULT_POST
+				);
 
 				expect( isMatch ).to.be.true;
 			} );
@@ -385,27 +485,36 @@ describe( 'PostQueryManager', () => {
 		context( 'query.type', () => {
 			it( 'should return true if type is any', () => {
 				const post = Object.assign( {}, DEFAULT_POST, {
-					type: 'cpt-book'
+					type: 'cpt-book',
 				} );
-				const isMatch = PostQueryManager.matches( {
-					type: 'any'
-				}, post );
+				const isMatch = PostQueryManager.matches(
+					{
+						type: 'any',
+					},
+					post
+				);
 
 				expect( isMatch ).to.be.true;
 			} );
 
 			it( 'should return false if type does not match', () => {
-				const isMatch = PostQueryManager.matches( {
-					type: 'page'
-				}, DEFAULT_POST );
+				const isMatch = PostQueryManager.matches(
+					{
+						type: 'page',
+					},
+					DEFAULT_POST
+				);
 
 				expect( isMatch ).to.be.false;
 			} );
 
 			it( 'should return true if type matches', () => {
-				const isMatch = PostQueryManager.matches( {
-					type: 'post'
-				}, DEFAULT_POST );
+				const isMatch = PostQueryManager.matches(
+					{
+						type: 'post',
+					},
+					DEFAULT_POST
+				);
 
 				expect( isMatch ).to.be.true;
 			} );
@@ -413,20 +522,26 @@ describe( 'PostQueryManager', () => {
 
 		context( 'query.parent_id', () => {
 			it( 'should return false if parent does not match', () => {
-				const isMatch = PostQueryManager.matches( {
-					parent_id: 10
-				}, DEFAULT_POST );
+				const isMatch = PostQueryManager.matches(
+					{
+						parent_id: 10,
+					},
+					DEFAULT_POST
+				);
 
 				expect( isMatch ).to.be.false;
 			} );
 
 			it( 'should return true if numeric parent matches', () => {
 				const post = Object.assign( {}, DEFAULT_POST, {
-					parent: 10
+					parent: 10,
 				} );
-				const isMatch = PostQueryManager.matches( {
-					parent_id: 10
-				}, post );
+				const isMatch = PostQueryManager.matches(
+					{
+						parent_id: 10,
+					},
+					post
+				);
 
 				expect( isMatch ).to.be.true;
 			} );
@@ -434,12 +549,15 @@ describe( 'PostQueryManager', () => {
 			it( 'should return true if object parent matches', () => {
 				const post = Object.assign( {}, DEFAULT_POST, {
 					parent: {
-						ID: 10
-					}
+						ID: 10,
+					},
 				} );
-				const isMatch = PostQueryManager.matches( {
-					parent_id: 10
-				}, post );
+				const isMatch = PostQueryManager.matches(
+					{
+						parent_id: 10,
+					},
+					post
+				);
 
 				expect( isMatch ).to.be.true;
 			} );
@@ -447,33 +565,45 @@ describe( 'PostQueryManager', () => {
 
 		context( 'query.exclude', () => {
 			it( 'should return false if ID matches single exclude', () => {
-				const isMatch = PostQueryManager.matches( {
-					exclude: 144
-				}, DEFAULT_POST );
+				const isMatch = PostQueryManager.matches(
+					{
+						exclude: 144,
+					},
+					DEFAULT_POST
+				);
 
 				expect( isMatch ).to.be.false;
 			} );
 
 			it( 'should return false if ID matches array of excludes', () => {
-				const isMatch = PostQueryManager.matches( {
-					exclude: [ 144, 152 ]
-				}, DEFAULT_POST );
+				const isMatch = PostQueryManager.matches(
+					{
+						exclude: [ 144, 152 ],
+					},
+					DEFAULT_POST
+				);
 
 				expect( isMatch ).to.be.false;
 			} );
 
 			it( 'should return true if ID does not match single exclude', () => {
-				const isMatch = PostQueryManager.matches( {
-					exclude: 152
-				}, DEFAULT_POST );
+				const isMatch = PostQueryManager.matches(
+					{
+						exclude: 152,
+					},
+					DEFAULT_POST
+				);
 
 				expect( isMatch ).to.be.true;
 			} );
 
 			it( 'should return true if ID does not match array of excludes', () => {
-				const isMatch = PostQueryManager.matches( {
-					exclude: [ 152, 160 ]
-				}, DEFAULT_POST );
+				const isMatch = PostQueryManager.matches(
+					{
+						exclude: [ 152, 160 ],
+					},
+					DEFAULT_POST
+				);
 
 				expect( isMatch ).to.be.true;
 			} );
@@ -481,53 +611,71 @@ describe( 'PostQueryManager', () => {
 
 		context( 'query.sticky', () => {
 			const stickyPost = Object.assign( {}, DEFAULT_POST, {
-				sticky: true
+				sticky: true,
 			} );
 
 			it( 'should return true if "include" and sticky', () => {
-				const isMatch = PostQueryManager.matches( {
-					sticky: 'include'
-				}, stickyPost );
+				const isMatch = PostQueryManager.matches(
+					{
+						sticky: 'include',
+					},
+					stickyPost
+				);
 
 				expect( isMatch ).to.be.true;
 			} );
 
 			it( 'should return true if "include" and not sticky', () => {
-				const isMatch = PostQueryManager.matches( {
-					sticky: 'include'
-				}, DEFAULT_POST );
+				const isMatch = PostQueryManager.matches(
+					{
+						sticky: 'include',
+					},
+					DEFAULT_POST
+				);
 
 				expect( isMatch ).to.be.true;
 			} );
 
 			it( 'should return true if "require" and sticky', () => {
-				const isMatch = PostQueryManager.matches( {
-					sticky: 'require'
-				}, stickyPost );
+				const isMatch = PostQueryManager.matches(
+					{
+						sticky: 'require',
+					},
+					stickyPost
+				);
 
 				expect( isMatch ).to.be.true;
 			} );
 
 			it( 'should return false if "require" and not sticky', () => {
-				const isMatch = PostQueryManager.matches( {
-					sticky: 'require'
-				}, DEFAULT_POST );
+				const isMatch = PostQueryManager.matches(
+					{
+						sticky: 'require',
+					},
+					DEFAULT_POST
+				);
 
 				expect( isMatch ).to.be.false;
 			} );
 
 			it( 'should return false if "exclude" and sticky', () => {
-				const isMatch = PostQueryManager.matches( {
-					sticky: 'exclude'
-				}, stickyPost );
+				const isMatch = PostQueryManager.matches(
+					{
+						sticky: 'exclude',
+					},
+					stickyPost
+				);
 
 				expect( isMatch ).to.be.false;
 			} );
 
 			it( 'should return true if "exclude" and not sticky', () => {
-				const isMatch = PostQueryManager.matches( {
-					sticky: 'exclude'
-				}, DEFAULT_POST );
+				const isMatch = PostQueryManager.matches(
+					{
+						sticky: 'exclude',
+					},
+					DEFAULT_POST
+				);
 
 				expect( isMatch ).to.be.true;
 			} );
@@ -535,37 +683,49 @@ describe( 'PostQueryManager', () => {
 
 		context( 'query.author', () => {
 			const postWithScalarAuthor = Object.assign( {}, DEFAULT_POST, {
-				author: 73705554
+				author: 73705554,
 			} );
 
 			it( 'should return false if author does not match by nested object', () => {
-				const isMatch = PostQueryManager.matches( {
-					author: 73705672
-				}, DEFAULT_POST );
+				const isMatch = PostQueryManager.matches(
+					{
+						author: 73705672,
+					},
+					DEFAULT_POST
+				);
 
 				expect( isMatch ).to.be.false;
 			} );
 
 			it( 'should return true if author matches by nested object', () => {
-				const isMatch = PostQueryManager.matches( {
-					author: 73705554
-				}, DEFAULT_POST );
+				const isMatch = PostQueryManager.matches(
+					{
+						author: 73705554,
+					},
+					DEFAULT_POST
+				);
 
 				expect( isMatch ).to.be.true;
 			} );
 
 			it( 'should return false if author does not match by scalar value', () => {
-				const isMatch = PostQueryManager.matches( {
-					author: 73705672
-				}, postWithScalarAuthor );
+				const isMatch = PostQueryManager.matches(
+					{
+						author: 73705672,
+					},
+					postWithScalarAuthor
+				);
 
 				expect( isMatch ).to.be.false;
 			} );
 
 			it( 'should return true if author matches by scalar value', () => {
-				const isMatch = PostQueryManager.matches( {
-					author: 73705554
-				}, postWithScalarAuthor );
+				const isMatch = PostQueryManager.matches(
+					{
+						author: 73705554,
+					},
+					postWithScalarAuthor
+				);
 
 				expect( isMatch ).to.be.true;
 			} );
@@ -573,49 +733,67 @@ describe( 'PostQueryManager', () => {
 
 		context( 'query.status', () => {
 			it( 'should return false if status is "any"', () => {
-				const isMatch = PostQueryManager.matches( {
-					status: 'any'
-				}, DEFAULT_POST );
+				const isMatch = PostQueryManager.matches(
+					{
+						status: 'any',
+					},
+					DEFAULT_POST
+				);
 
 				expect( isMatch ).to.be.true;
 			} );
 
 			it( 'should return false if status does not match', () => {
-				const isMatch = PostQueryManager.matches( {
-					status: 'draft'
-				}, DEFAULT_POST );
+				const isMatch = PostQueryManager.matches(
+					{
+						status: 'draft',
+					},
+					DEFAULT_POST
+				);
 
 				expect( isMatch ).to.be.false;
 			} );
 
 			it( 'should return true if status matches', () => {
-				const isMatch = PostQueryManager.matches( {
-					status: 'publish'
-				}, DEFAULT_POST );
+				const isMatch = PostQueryManager.matches(
+					{
+						status: 'publish',
+					},
+					DEFAULT_POST
+				);
 
 				expect( isMatch ).to.be.true;
 			} );
 
 			it( 'should return false if none of comma-separated values match', () => {
-				const isMatch = PostQueryManager.matches( {
-					status: 'draft,trash'
-				}, DEFAULT_POST );
+				const isMatch = PostQueryManager.matches(
+					{
+						status: 'draft,trash',
+					},
+					DEFAULT_POST
+				);
 
 				expect( isMatch ).to.be.false;
 			} );
 
 			it( 'should return true if one of comma-separated values match', () => {
-				const isMatch = PostQueryManager.matches( {
-					status: 'draft,publish'
-				}, DEFAULT_POST );
+				const isMatch = PostQueryManager.matches(
+					{
+						status: 'draft,publish',
+					},
+					DEFAULT_POST
+				);
 
 				expect( isMatch ).to.be.true;
 			} );
 
 			it( 'should gracefully handle non-string search values', () => {
-				const isMatch = PostQueryManager.matches( {
-					status: undefined
-				}, DEFAULT_POST );
+				const isMatch = PostQueryManager.matches(
+					{
+						status: undefined,
+					},
+					DEFAULT_POST
+				);
 
 				expect( isMatch ).to.be.false;
 			} );
@@ -625,151 +803,121 @@ describe( 'PostQueryManager', () => {
 	describe( '#compare()', () => {
 		context( 'query.order', () => {
 			it( 'should sort descending by default', () => {
-				const sorted = [
-					{ ID: 200 },
-					{ ID: 400 }
-				].sort( manager.compare.bind( manager, {
-					order_by: 'ID'
-				} ) );
+				const sorted = [ { ID: 200 }, { ID: 400 } ].sort(
+					manager.compare.bind( manager, {
+						order_by: 'ID',
+					} )
+				);
 
-				expect( sorted ).to.eql( [
-					{ ID: 400 },
-					{ ID: 200 }
-				] );
+				expect( sorted ).to.eql( [ { ID: 400 }, { ID: 200 } ] );
 			} );
 
 			it( 'should reverse order when specified as ascending', () => {
-				const sorted = [
-					{ ID: 200 },
-					{ ID: 400 }
-				].sort( manager.compare.bind( manager, {
-					order_by: 'ID',
-					order: 'ASC'
-				} ) );
+				const sorted = [ { ID: 200 }, { ID: 400 } ].sort(
+					manager.compare.bind( manager, {
+						order_by: 'ID',
+						order: 'ASC',
+					} )
+				);
 
-				expect( sorted ).to.eql( [
-					{ ID: 200 },
-					{ ID: 400 }
-				] );
+				expect( sorted ).to.eql( [ { ID: 200 }, { ID: 400 } ] );
 			} );
 		} );
 
 		context( 'query.order_by', () => {
 			context( 'date', () => {
 				const olderPost = Object.assign( {}, DEFAULT_POST, {
-					date: '2016-04-25T11:40:52-04:00'
+					date: '2016-04-25T11:40:52-04:00',
 				} );
 
 				const newerPost = Object.assign( {}, DEFAULT_POST, {
 					ID: 152,
-					date: '2016-04-25T15:47:33-04:00'
+					date: '2016-04-25T15:47:33-04:00',
 				} );
 
 				it( 'should order by date', () => {
-					const sorted = [
-						olderPost,
-						newerPost
-					].sort( manager.compare.bind( manager, {} ) );
+					const sorted = [ olderPost, newerPost ].sort( manager.compare.bind( manager, {} ) );
 
-					expect( sorted ).to.eql( [
-						newerPost,
-						olderPost
-					] );
+					expect( sorted ).to.eql( [ newerPost, olderPost ] );
 				} );
 			} );
 
 			context( 'modified', () => {
 				const olderPost = Object.assign( {}, DEFAULT_POST, {
-					modified: '2016-04-25T11:40:52-04:00'
+					modified: '2016-04-25T11:40:52-04:00',
 				} );
 
 				const newerPost = Object.assign( {}, DEFAULT_POST, {
 					ID: 152,
-					modified: '2016-04-25T15:47:33-04:00'
+					modified: '2016-04-25T15:47:33-04:00',
 				} );
 
 				it( 'should order by modified', () => {
-					const sorted = [
-						olderPost,
-						newerPost
-					].sort( manager.compare.bind( manager, {
-						order_by: 'modified'
-					} ) );
+					const sorted = [ olderPost, newerPost ].sort(
+						manager.compare.bind( manager, {
+							order_by: 'modified',
+						} )
+					);
 
-					expect( sorted ).to.eql( [
-						newerPost,
-						olderPost
-					] );
+					expect( sorted ).to.eql( [ newerPost, olderPost ] );
 				} );
 			} );
 
 			context( 'title', () => {
 				const aPost = Object.assign( {}, DEFAULT_POST, {
-					title: 'a'
+					title: 'a',
 				} );
 
 				const zPost = Object.assign( {}, DEFAULT_POST, {
 					ID: 152,
-					title: 'z'
+					title: 'z',
 				} );
 
 				it( 'should sort by title', () => {
-					const sorted = [
-						aPost,
-						zPost
-					].sort( manager.compare.bind( manager, {
-						order_by: 'title'
-					} ) );
+					const sorted = [ aPost, zPost ].sort(
+						manager.compare.bind( manager, {
+							order_by: 'title',
+						} )
+					);
 
-					expect( sorted ).to.eql( [
-						zPost,
-						aPost
-					] );
+					expect( sorted ).to.eql( [ zPost, aPost ] );
 				} );
 			} );
 
 			context( 'comment_count', () => {
 				const unpopularPost = Object.assign( {}, DEFAULT_POST, {
 					discussion: {
-						comment_count: 2
-					}
+						comment_count: 2,
+					},
 				} );
 
 				const popularPost = Object.assign( {}, DEFAULT_POST, {
 					ID: 152,
 					discussion: {
-						comment_count: 97
-					}
+						comment_count: 97,
+					},
 				} );
 
 				it( 'should sort by comment count', () => {
-					const sorted = [
-						unpopularPost,
-						popularPost
-					].sort( manager.compare.bind( manager, {
-						order_by: 'comment_count'
-					} ) );
+					const sorted = [ unpopularPost, popularPost ].sort(
+						manager.compare.bind( manager, {
+							order_by: 'comment_count',
+						} )
+					);
 
-					expect( sorted ).to.eql( [
-						popularPost,
-						unpopularPost
-					] );
+					expect( sorted ).to.eql( [ popularPost, unpopularPost ] );
 				} );
 			} );
 
 			context( 'ID', () => {
 				it( 'should sort by ID', () => {
-					const sorted = [
-						{ ID: 200 },
-						{ ID: 400 }
-					].sort( manager.compare.bind( manager, {
-						order_by: 'ID'
-					} ) );
+					const sorted = [ { ID: 200 }, { ID: 400 } ].sort(
+						manager.compare.bind( manager, {
+							order_by: 'ID',
+						} )
+					);
 
-					expect( sorted ).to.eql( [
-						{ ID: 400 },
-						{ ID: 200 }
-					] );
+					expect( sorted ).to.eql( [ { ID: 400 }, { ID: 200 } ] );
 				} );
 			} );
 		} );

--- a/client/lib/query-manager/post/test/key.js
+++ b/client/lib/query-manager/post/test/key.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */

--- a/client/lib/query-manager/term/constants.js
+++ b/client/lib/query-manager/term/constants.js
@@ -1,3 +1,4 @@
+/** @format */
 export const DEFAULT_TERM_QUERY = {
 	context: 'display',
 	http_envelope: false,
@@ -7,5 +8,5 @@ export const DEFAULT_TERM_QUERY = {
 	page: 1,
 	search: '',
 	order: 'ASC',
-	order_by: 'name'
+	order_by: 'name',
 };

--- a/client/lib/query-manager/term/index.js
+++ b/client/lib/query-manager/term/index.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */

--- a/client/lib/query-manager/term/key.js
+++ b/client/lib/query-manager/term/key.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -19,8 +20,7 @@ import { DEFAULT_TERM_QUERY } from './constants';
  */
 function isDefaultOrNullQueryValue( value, key ) {
 	return (
-		null == value || // Double-equals null checks undefined, null
-		DEFAULT_TERM_QUERY[ key ] === value
+		null == value || DEFAULT_TERM_QUERY[ key ] === value // Double-equals null checks undefined, null
 	);
 }
 

--- a/client/lib/query-manager/term/test/index.js
+++ b/client/lib/query-manager/term/test/index.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -16,7 +17,7 @@ const DEFAULT_TERM = {
 	name: 'Food',
 	slug: 'my-slug',
 	description: '',
-	post_count: 5
+	post_count: 5,
 };
 
 describe( 'TermQueryManager', () => {
@@ -28,41 +29,56 @@ describe( 'TermQueryManager', () => {
 	describe( '#matches()', () => {
 		context( 'query.search', () => {
 			it( 'should return false for a non-matching search', () => {
-				const isMatch = TermQueryManager.matches( {
-					search: 'Cars'
-				}, DEFAULT_TERM );
+				const isMatch = TermQueryManager.matches(
+					{
+						search: 'Cars',
+					},
+					DEFAULT_TERM
+				);
 
 				expect( isMatch ).to.be.false;
 			} );
 
 			it( 'should return true for an empty search', () => {
-				const isMatch = TermQueryManager.matches( {
-					search: ''
-				}, DEFAULT_TERM );
+				const isMatch = TermQueryManager.matches(
+					{
+						search: '',
+					},
+					DEFAULT_TERM
+				);
 
 				expect( isMatch ).to.be.true;
 			} );
 
 			it( 'should return true for a matching name search', () => {
-				const isMatch = TermQueryManager.matches( {
-					search: 'ood'
-				}, DEFAULT_TERM );
+				const isMatch = TermQueryManager.matches(
+					{
+						search: 'ood',
+					},
+					DEFAULT_TERM
+				);
 
 				expect( isMatch ).to.be.true;
 			} );
 
 			it( 'should return true for a matching slug search', () => {
-				const isMatch = TermQueryManager.matches( {
-					search: 'y-sl'
-				}, DEFAULT_TERM );
+				const isMatch = TermQueryManager.matches(
+					{
+						search: 'y-sl',
+					},
+					DEFAULT_TERM
+				);
 
 				expect( isMatch ).to.be.true;
 			} );
 
 			it( 'should search case-insensitive', () => {
-				const isMatch = TermQueryManager.matches( {
-					search: 'fOoD'
-				}, DEFAULT_TERM );
+				const isMatch = TermQueryManager.matches(
+					{
+						search: 'fOoD',
+					},
+					DEFAULT_TERM
+				);
 
 				expect( isMatch ).to.be.true;
 			} );
@@ -72,70 +88,54 @@ describe( 'TermQueryManager', () => {
 	describe( '#compare()', () => {
 		context( 'query.order', () => {
 			it( 'should sort ascending by default', () => {
-				const sorted = [
-					{ name: 'Food' },
-					{ name: 'Cars' }
-				].sort( manager.compare.bind( manager, {
-					order_by: 'name'
-				} ) );
+				const sorted = [ { name: 'Food' }, { name: 'Cars' } ].sort(
+					manager.compare.bind( manager, {
+						order_by: 'name',
+					} )
+				);
 
-				expect( sorted ).to.eql( [
-					{ name: 'Cars' },
-					{ name: 'Food' }
-				] );
+				expect( sorted ).to.eql( [ { name: 'Cars' }, { name: 'Food' } ] );
 			} );
 
 			it( 'should reverse order when specified as descending', () => {
-				const sorted = [
-					{ name: 'Food' },
-					{ name: 'Cars' }
-				].sort( manager.compare.bind( manager, {
-					order_by: 'name',
-					order: 'DESC'
-				} ) );
+				const sorted = [ { name: 'Food' }, { name: 'Cars' } ].sort(
+					manager.compare.bind( manager, {
+						order_by: 'name',
+						order: 'DESC',
+					} )
+				);
 
-				expect( sorted ).to.eql( [
-					{ name: 'Food' },
-					{ name: 'Cars' }
-				] );
+				expect( sorted ).to.eql( [ { name: 'Food' }, { name: 'Cars' } ] );
 			} );
 		} );
 
 		context( 'query.order_by', () => {
 			context( 'name', () => {
 				it( 'should sort by name', () => {
-					const sorted = [
-						{ name: 'Food' },
-						{ name: 'Cars' }
-					].sort( manager.compare.bind( manager, {
-						order_by: 'name'
-					} ) );
+					const sorted = [ { name: 'Food' }, { name: 'Cars' } ].sort(
+						manager.compare.bind( manager, {
+							order_by: 'name',
+						} )
+					);
 
-					expect( sorted ).to.eql( [
-						{ name: 'Cars' },
-						{ name: 'Food' }
-					] );
+					expect( sorted ).to.eql( [ { name: 'Cars' }, { name: 'Food' } ] );
 				} );
 			} );
 
 			context( 'count', () => {
 				const unusedTerm = Object.assign( {}, DEFAULT_TERM, {
 					ID: 152,
-					post_count: 0
+					post_count: 0,
 				} );
 
 				it( 'should sort by post count', () => {
-					const sorted = [
-						DEFAULT_TERM,
-						unusedTerm
-					].sort( manager.compare.bind( manager, {
-						order_by: 'count'
-					} ) );
+					const sorted = [ DEFAULT_TERM, unusedTerm ].sort(
+						manager.compare.bind( manager, {
+							order_by: 'count',
+						} )
+					);
 
-					expect( sorted ).to.eql( [
-						unusedTerm,
-						DEFAULT_TERM
-					] );
+					expect( sorted ).to.eql( [ unusedTerm, DEFAULT_TERM ] );
 				} );
 			} );
 		} );

--- a/client/lib/query-manager/term/test/key.js
+++ b/client/lib/query-manager/term/test/key.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */

--- a/client/lib/query-manager/test/index.js
+++ b/client/lib/query-manager/test/index.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -12,7 +13,7 @@ import QueryManager, { DELETE_PATCH_KEY } from '../';
 describe( 'QueryManager', () => {
 	let sandbox, manager;
 
-	useSandbox( ( _sandbox ) => sandbox = _sandbox );
+	useSandbox( _sandbox => ( sandbox = _sandbox ) );
 
 	beforeEach( () => {
 		manager = new QueryManager();
@@ -27,14 +28,14 @@ describe( 'QueryManager', () => {
 			manager = new QueryManager( {
 				items: {
 					144: { ID: 144 },
-					152: { ID: 152 }
+					152: { ID: 152 },
 				},
 				queries: {
 					'[]': {
 						itemKeys: [ 152 ],
-						found: 1
-					}
-				}
+						found: 1,
+					},
+				},
 			} );
 
 			expect( manager.getItems() ).to.eql( [ { ID: 144 }, { ID: 152 } ] );
@@ -278,7 +279,7 @@ describe( 'QueryManager', () => {
 			expect( newManager.getItems() ).to.eql( [] );
 		} );
 
-		it( 'should do nothing if #mergeItem() returns undefined but the item didn\'t exist', () => {
+		it( "should do nothing if #mergeItem() returns undefined but the item didn't exist", () => {
 			manager = manager.receive();
 			sandbox.stub( manager, 'mergeItem' ).returns( undefined );
 			const newManager = manager.receive( { ID: 144 } );
@@ -317,20 +318,14 @@ describe( 'QueryManager', () => {
 			manager = manager.receive( { ID: 144 }, { query: {}, mergeQuery: true } );
 			manager = manager.receive( { ID: 152 }, { query: {}, mergeQuery: true } );
 
-			expect( manager.getItems( {} ) ).to.eql( [
-				{ ID: 144 },
-				{ ID: 152 }
-			] );
+			expect( manager.getItems( {} ) ).to.eql( [ { ID: 144 }, { ID: 152 } ] );
 		} );
 
 		it( 'should de-dupe received items into query set when merging', () => {
 			manager = manager.receive( { ID: 144 }, { query: {}, mergeQuery: true } );
 			manager = manager.receive( [ { ID: 144 }, { ID: 152 } ], { query: {}, mergeQuery: true } );
 
-			expect( manager.getItems( {} ) ).to.eql( [
-				{ ID: 144 },
-				{ ID: 152 }
-			] );
+			expect( manager.getItems( {} ) ).to.eql( [ { ID: 144 }, { ID: 152 } ] );
 		} );
 
 		it( 'should remove a tracked query item when it no longer matches', () => {

--- a/client/lib/query-manager/test/key.js
+++ b/client/lib/query-manager/test/key.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */

--- a/client/lib/query-manager/theme/constants.js
+++ b/client/lib/query-manager/theme/constants.js
@@ -1,8 +1,9 @@
+/** @format */
 export const DEFAULT_THEME_QUERY = {
 	search: '',
 	tier: '',
 	filter: '',
 	number: 20,
 	offset: 0,
-	page: 1
+	page: 1,
 };

--- a/client/lib/query-manager/theme/index.js
+++ b/client/lib/query-manager/theme/index.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * Internal dependencies
  */
@@ -9,7 +10,6 @@ import { DEFAULT_THEME_QUERY } from './constants';
  * ThemeQueryManager manages themes which can be queried
  */
 export default class ThemeQueryManager extends PaginatedQueryManager {
-
 	/**
 	 * A sorting function that defines the sort order of items under
 	 * consideration of the specified query.

--- a/client/lib/query-manager/theme/key.js
+++ b/client/lib/query-manager/theme/key.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -18,10 +19,7 @@ import { DEFAULT_THEME_QUERY } from './constants';
  * @return {Boolean}       Whether key value matches default query or is null
  */
 function isDefaultOrNullQueryValue( value, key ) {
-	return (
-		value === undefined || value === null ||
-		DEFAULT_THEME_QUERY[ key ] === value
-	);
+	return value === undefined || value === null || DEFAULT_THEME_QUERY[ key ] === value;
 }
 
 /**

--- a/client/lib/query-manager/theme/test/index.js
+++ b/client/lib/query-manager/theme/test/index.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -8,9 +9,9 @@ import { expect } from 'chai';
  */
 import ThemeQueryManager from '../';
 
-describe( 'ThemeQueryManager', ( ) => {
-	describe( '#sort()', ( ) => {
-		it( 'should leave key order unchanged', ( ) => {
+describe( 'ThemeQueryManager', () => {
+	describe( '#sort()', () => {
+		it( 'should leave key order unchanged', () => {
 			const originalKeys = Object.freeze( [
 				'adaline',
 				'fanwood-light',
@@ -22,7 +23,7 @@ describe( 'ThemeQueryManager', ( ) => {
 				'trvl',
 				'dyad',
 				'little-story',
-				'pachyderm'
+				'pachyderm',
 			] );
 			const keys = [ ...originalKeys ];
 			const manager = new ThemeQueryManager();

--- a/client/lib/query-manager/theme/test/key.js
+++ b/client/lib/query-manager/theme/test/key.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */


### PR DESCRIPTION
This is part of #17990, but all the prettier diffs make for a noisy PR. I've separated `prettier` from the more significant commits in that PR to reduce the noise.

This PR is only a formatting change, it should contain no behavioral changes.