### PR TITLE
Use prop-types package instead of grabbing it from react

### DIFF
--- a/client/components/animate/index.jsx
+++ b/client/components/animate/index.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 const Animate = ( { type, children } ) => (
 	<div className={ `animate__${ type }` }>


### PR DESCRIPTION
## Summary
This PR replaces the import for `PropTypes` to use the newer `prop-types` package instead of importing it from `react`.

## Testing steps
1. Go to `/me`
2. Your user avatar should be displayed (this PR affects the animation component used there)

