### PR TITLE
Uses ES6 PropTypes on AsyncLoad component

### DIFF
--- a/client/components/async-load/index.jsx
+++ b/client/components/async-load/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { omit } from 'lodash';
 

--- a/client/components/async-load/index.jsx
+++ b/client/components/async-load/index.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import React from 'react';
 import PropTypes from 'prop-types';
 import { omit } from 'lodash';
 

--- a/client/components/async-load/index.jsx
+++ b/client/components/async-load/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
 import { omit } from 'lodash';
 
 export default class AsyncLoad extends Component {


### PR DESCRIPTION
Imports PropTypes following ES6, as has been separated into a different library, more on https://www.npmjs.com/package/prop-types