### PR TITLE
Switch from deprecated PropTypes to prop-types package

### DIFF
--- a/client/components/count/index.jsx
+++ b/client/components/count/index.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
 import { omit } from 'lodash';


### PR DESCRIPTION
PropTypes was deprecated in React v15.5.0. This switches it out to the new package.