### PR TITLE
Use wpcom-http instead of wpcom directly

### DIFF
--- a/client/state/data-layer/wpcom/account-recovery/validate/index.js
+++ b/client/state/data-layer/wpcom/account-recovery/validate/index.js
@@ -1,31 +1,43 @@
 /**
  * Internal dependencies
  */
-import wpcom from 'lib/wp';
 import { ACCOUNT_RECOVERY_RESET_VALIDATE_REQUEST } from 'state/action-types';
 import {
 	validateRequestSuccess,
 	validateRequestError,
 	setValidationKey,
 } from 'state/account-recovery/reset/actions';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
+import { http } from 'state/data-layer/wpcom-http/actions';
 
 export const handleValidateRequest = ( { dispatch }, action ) => {
 	const { userData, method, key } = action;
-	wpcom.req.post( {
-		body: {
-			...userData,
-			method,
-			key,
-		},
-		apiNamespace: 'wpcom/v2',
-		path: '/account-recovery/validate',
-	} ).then( () => {
-		dispatch( validateRequestSuccess() );
-		dispatch( setValidationKey( key ) );
-	} )
-	.catch( ( error ) => dispatch( validateRequestError( error ) ) );
+	dispatch(
+		http(
+			{
+				method: 'POST',
+				apiNamespace: 'wpcom/v2',
+				path: '/account-recovery/validate',
+				body: {
+					...userData,
+					method,
+					key
+				}
+			},
+			action
+		)
+	);
+};
+
+export const handleValidateRequestSuccess = ( { dispatch }, { key } ) => {
+	dispatch( validateRequestSuccess() );
+	dispatch( setValidationKey( key ) );
+};
+
+export const handleValidateRequestFailure = ( { dispatch }, action, response ) => {
+	dispatch( validateRequestError( response ) );
 };
 
 export default {
-	[ ACCOUNT_RECOVERY_RESET_VALIDATE_REQUEST ]: [ handleValidateRequest ],
+	[ ACCOUNT_RECOVERY_RESET_VALIDATE_REQUEST ]: [ dispatchRequest( handleValidateRequest, handleValidateRequestSuccess, handleValidateRequestFailure ) ], // eslint-disable-line max-len
 };

--- a/client/state/data-layer/wpcom/account-recovery/validate/index.js
+++ b/client/state/data-layer/wpcom/account-recovery/validate/index.js
@@ -39,5 +39,9 @@ export const handleValidateRequestFailure = ( { dispatch }, action, response ) =
 };
 
 export default {
-	[ ACCOUNT_RECOVERY_RESET_VALIDATE_REQUEST ]: [ dispatchRequest( handleValidateRequest, handleValidateRequestSuccess, handleValidateRequestFailure ) ], // eslint-disable-line max-len
+	[ ACCOUNT_RECOVERY_RESET_VALIDATE_REQUEST ]: [ dispatchRequest(
+		handleValidateRequest,
+		handleValidateRequestSuccess,
+		handleValidateRequestFailure
+	) ],
 };

--- a/client/state/data-layer/wpcom/account-recovery/validate/test/index.js
+++ b/client/state/data-layer/wpcom/account-recovery/validate/test/index.js
@@ -1,92 +1,79 @@
 /**
  * External dependencies
  */
-import { assert } from 'chai';
-import sinon from 'sinon';
+import { expect } from 'chai';
+import { spy } from 'sinon';
 
 /**
  * Internal dependencies
  */
 
-import { handleValidateRequest } from '../';
-import useNock from 'test/helpers/use-nock';
-
 import {
-	ACCOUNT_RECOVERY_RESET_VALIDATE_REQUEST_SUCCESS,
-	ACCOUNT_RECOVERY_RESET_VALIDATE_REQUEST_ERROR,
-	ACCOUNT_RECOVERY_RESET_SET_VALIDATION_KEY,
-} from 'state/action-types';
+	handleValidateRequest,
+	handleValidateRequestSuccess,
+	handleValidateRequestFailure
+} from '../';
+import { http } from 'state/data-layer/wpcom-http/actions';
+import {
+	validateRequestSuccess,
+	validateRequestError,
+	setValidationKey,
+} from 'state/account-recovery/reset/actions';
 
-describe( 'handleValidateRequest()', () => {
-	const apiBaseUrl = 'https://public-api.wordpress.com:443';
-	const endpoint = '/wpcom/v2/account-recovery/validate';
-
-	const userData = { user: 'foo' };
-	const method = 'primary_email';
-	const key = 'a-super-secret-key';
-
+describe( 'handleValidateRequest()', () =>{
 	describe( 'success', () => {
-		useNock( nock => (
-			nock( apiBaseUrl )
-				.persist()
-				.post( endpoint )
-				.reply( 200, { success: true } )
-		) );
+		it( 'should dispatch SUCCESS action on success', ( ) => {
+			const dispatch = spy();
+			const action = {
+				type: 'DUMMY_ACTION',
+				userData: { user: 'foo' },
+				method: 'primary_email',
+				key: 'a-super-secret-key',
+			};
+			const { userData, method, key } = action;
 
-		it( 'should dispatch SUCCESS action on success', ( done ) => {
-			const dispatch = sinon.spy( ( action ) => {
-				if ( action.type === ACCOUNT_RECOVERY_RESET_VALIDATE_REQUEST_SUCCESS ) {
-					assert.isTrue( dispatch.calledWith( {
-						type: ACCOUNT_RECOVERY_RESET_VALIDATE_REQUEST_SUCCESS,
-					} ) );
+			handleValidateRequest( { dispatch }, action );
 
-					done();
-				}
-			} );
-
-			handleValidateRequest( { dispatch }, { userData, method, key } );
+			expect( dispatch ).to.have.been.calledOnce;
+			expect( dispatch ).to.have.been.calledWith(
+				http(
+					{
+						method: 'POST',
+						apiNamespace: 'wpcom/v2',
+						path: '/account-recovery/validate',
+						body: {
+							...userData,
+							method,
+							key
+						}
+					},
+					action
+				)
+			);
 		} );
 
-		it( 'should dispatch SET_VALIDATION_KEY action on success', ( done ) => {
-			const dispatch = sinon.spy( ( action ) => {
-				if ( action.type === ACCOUNT_RECOVERY_RESET_SET_VALIDATION_KEY ) {
-					assert.isTrue( dispatch.calledWith( {
-						type: ACCOUNT_RECOVERY_RESET_SET_VALIDATION_KEY,
-						key: key,
-					} ) );
+		it( 'should dispatch SET_VALIDATION_KEY action on success', ( ) => {
+			const dispatch = spy();
+			const action = {
+				type: 'DUMMY_ACTION',
+				userData: { user: 'foo' },
+				method: 'primary_email',
+				key: 'a-super-secret-key',
+			};
 
-					done();
-				}
-			} );
+			handleValidateRequestSuccess( { dispatch }, action );
 
-			handleValidateRequest( { dispatch }, { userData, method, key } );
+			expect( dispatch ).to.have.been.calledWith( validateRequestSuccess() );
+			expect( dispatch ).to.have.been.calledWith( setValidationKey( action.key ) );
 		} );
-	} );
 
-	describe( 'failure', () => {
-		const errorResponse = {
-			status: 400,
-			message: 'Something wrong!',
-		};
+		it( 'should dispatch ERROR action on failure', ( ) => {
+			const dispatch = spy();
+			const error = 'something bad happened';
+			handleValidateRequestFailure( { dispatch }, {}, error );
 
-		useNock( nock => (
-			nock( apiBaseUrl )
-				.post( endpoint )
-				.reply( errorResponse.status, errorResponse )
-		) );
-
-		it( 'should dispatch ERROR action on failure', ( done ) => {
-			const dispatch = sinon.spy( () => {
-				assert.isTrue( dispatch.calledWithMatch( {
-					type: ACCOUNT_RECOVERY_RESET_VALIDATE_REQUEST_ERROR,
-					error: errorResponse,
-				} ) )
-
-				done();
-			} );
-
-			handleValidateRequest( { dispatch }, { userData, method, key } );
+			expect( dispatch ).to.have.been.calledOnce;
+			expect( dispatch ).to.have.been.calledWith( validateRequestError( error ) );
 		} );
 	} );
 } );
-

--- a/client/state/data-layer/wpcom/account-recovery/validate/test/index.js
+++ b/client/state/data-layer/wpcom/account-recovery/validate/test/index.js
@@ -20,9 +20,9 @@ import {
 	setValidationKey,
 } from 'state/account-recovery/reset/actions';
 
-describe( 'handleValidateRequest()', () =>{
+describe( 'handleValidateRequest()', () => {
 	describe( 'success', () => {
-		it( 'should dispatch SUCCESS action on success', ( ) => {
+		it( 'should dispatch SUCCESS action on success', () => {
 			const dispatch = spy();
 			const action = {
 				type: 'DUMMY_ACTION',
@@ -52,7 +52,7 @@ describe( 'handleValidateRequest()', () =>{
 			);
 		} );
 
-		it( 'should dispatch SET_VALIDATION_KEY action on success', ( ) => {
+		it( 'should dispatch SET_VALIDATION_KEY action on success', () => {
 			const dispatch = spy();
 			const action = {
 				type: 'DUMMY_ACTION',
@@ -67,7 +67,7 @@ describe( 'handleValidateRequest()', () =>{
 			expect( dispatch ).to.have.been.calledWith( setValidationKey( action.key ) );
 		} );
 
-		it( 'should dispatch ERROR action on failure', ( ) => {
+		it( 'should dispatch ERROR action on failure', () => {
 			const dispatch = spy();
 			const error = 'something bad happened';
 			handleValidateRequestFailure( { dispatch }, {}, error );


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/17832

## Testing instructions

`npm run test-client client/state/data-layer/wpcom/account-recovery/validate/test/index.js`

Quick test: 

* Run this branch locally.
* Open the console and trigger `dispatch( { type: 'ACCOUNT_RECOVERY_RESET_VALIDATE_REQUEST' } );`
* Check that a new network request is done to the endpoint `https://public-api.wordpress.com/wpcom/v2/account-recovery/validate?_envelope=1` and its response is 

```
    {
    "body": 
        { "code": "rest_missing_callback_param",
          "message": "Missing parameter(s): key, method",
          "data": {
              "status": 400,
              "params": [ "key", "method" ] 
           } 
        },
       "status": 400,
       "headers": { "Allow": "POST, PUT, PATCH" }
    }
```

