### PR TITLE
Accordion: update component to fix eslint warnings

### DIFF
--- a/client/components/accordion/index.jsx
+++ b/client/components/accordion/index.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { noop } from 'lodash';
 import classNames from 'classnames';
 import Gridicon from 'gridicons';

--- a/client/components/accordion/section.jsx
+++ b/client/components/accordion/section.jsx
@@ -1,15 +1,15 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Component } from 'react';
 import classNames from 'classnames';
 
-export default React.createClass( {
+export default class AccordionSection extends Component {
 	render() {
 		return (
 			<section className={ classNames( 'accordion__section', this.props.className ) } >
 				{ this.props.children }
 			</section>
 		);
-	},
-} );
+	}
+}

--- a/client/components/accordion/status.jsx
+++ b/client/components/accordion/status.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { PureComponent, PropTypes } from 'react';
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import Gridicon from 'gridicons';
 


### PR DESCRIPTION
- Use prop-types instead of React PropTypes
- Do not use `React.createClass` anymore.

**To test:**

You can test whether accordions are working all around Calypso. A good place to test is the post editor:
http://calypso.localhost:3000/post/