### PR TITLE
Button component: Update PropTypes import for React 15.5

### DIFF
--- a/client/components/button/index.jsx
+++ b/client/components/button/index.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import { PropTypes, createElement, PureComponent } from 'react';
+import { createElement, PureComponent } from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { omit, uniq, compact } from 'lodash';
 


### PR DESCRIPTION
Move `PropTypes` to a separate import for upcoming change in React.