### PR TITLE
Update banner component to meet linter requirements

### DIFF
--- a/client/components/banner/index.jsx
+++ b/client/components/banner/index.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
 import {


### PR DESCRIPTION
There was a deprecated method to import PropTypes from 'react'. Changed it to import PropTypes from 'prop-types'. 