### PR TITLE
Media: Update request media item to data-layer

### DIFF
--- a/client/state/data-layer/wpcom/sites/media/index.js
+++ b/client/state/data-layer/wpcom/sites/media/index.js
@@ -55,25 +55,6 @@ export function requestMediaError( { dispatch }, { siteId, query } ) {
 	dispatch( failMediaRequest( siteId, query ) );
 }
 
-export function requestMediaItem( { dispatch, getState }, { siteId, mediaId } ) {
-	if ( isRequestingMediaItem( getState(), siteId, mediaId ) ) {
-		return;
-	}
-
-	dispatch( requestingMediaItem( siteId, mediaId ) );
-
-	log( 'Request media item %d for site %d', mediaId, siteId );
-
-	return wpcom
-		.site( siteId )
-		.media( mediaId )
-		.get()
-		.then( ( media ) => {
-			dispatch( receiveMedia( siteId, media ) );
-			dispatch( successMediaItemRequest( siteId, mediaId ) );
-		} )
-		.catch( () => dispatch( failMediaItemRequest( siteId, mediaId ) ) );
-}
 
 function handleMediaItemRequest( { dispatch, getState }, action ) {
 	const { mediaId, query, siteId } = action;
@@ -110,7 +91,6 @@ function receiveMediaItemError( { dispatch }, { mediaId, siteId } ) {
 export default {
 	[ MEDIA_REQUEST ]: [ dispatchRequest( requestMedia, requestMediaSuccess, requestMediaError ) ],
 	[ MEDIA_ITEM_REQUEST ]: [
-		requestMediaItem,
 		dispatchRequest( handleMediaItemRequest, receiveMediaItem, receiveMediaItemError ),
 	],
 };

--- a/client/state/data-layer/wpcom/sites/media/index.js
+++ b/client/state/data-layer/wpcom/sites/media/index.js
@@ -55,8 +55,7 @@ export function requestMediaError( { dispatch }, { siteId, query } ) {
 	dispatch( failMediaRequest( siteId, query ) );
 }
 
-
-function handleMediaItemRequest( { dispatch, getState }, action ) {
+export function handleMediaItemRequest( { dispatch, getState }, action ) {
 	const { mediaId, query, siteId } = action;
 	if ( isRequestingMediaItem( getState(), siteId, mediaId ) ) {
 		return;
@@ -79,12 +78,12 @@ function handleMediaItemRequest( { dispatch, getState }, action ) {
 	);
 }
 
-function receiveMediaItem( { dispatch }, { mediaId, siteId }, media ) {
+export function receiveMediaItem( { dispatch }, { mediaId, siteId }, media ) {
 	dispatch( receiveMedia( siteId, media ) );
 	dispatch( successMediaItemRequest( siteId, mediaId ) );
 }
 
-function receiveMediaItemError( { dispatch }, { mediaId, siteId } ) {
+export function receiveMediaItemError( { dispatch }, { mediaId, siteId } ) {
 	dispatch( failMediaItemRequest( siteId, mediaId ) );
 }
 

--- a/client/state/data-layer/wpcom/sites/media/index.js
+++ b/client/state/data-layer/wpcom/sites/media/index.js
@@ -97,15 +97,20 @@ function handleMediaItemRequest( { dispatch, getState }, action ) {
 		)
 	);
 }
+
 function receiveMediaItem( { dispatch }, { mediaId, siteId }, media ) {
 	dispatch( receiveMedia( siteId, media ) );
 	dispatch( successMediaItemRequest( siteId, mediaId ) );
+}
+
+function receiveMediaItemError( { dispatch }, { mediaId, siteId } ) {
+	dispatch( failMediaItemRequest( siteId, mediaId ) );
 }
 
 export default {
 	[ MEDIA_REQUEST ]: [ dispatchRequest( requestMedia, requestMediaSuccess, requestMediaError ) ],
 	[ MEDIA_ITEM_REQUEST ]: [
 		requestMediaItem,
-		dispatchRequest( handleMediaItemRequest, receiveMediaItem, () => {} ),
+		dispatchRequest( handleMediaItemRequest, receiveMediaItem, receiveMediaItemError ),
 	],
 };

--- a/client/state/data-layer/wpcom/sites/media/index.js
+++ b/client/state/data-layer/wpcom/sites/media/index.js
@@ -2,10 +2,8 @@
  * Internal dependencies
  */
 import debug from 'debug';
-import wpcom from 'lib/wp';
 import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { isRequestingMediaItem } from 'state/selectors';
 import { MEDIA_REQUEST, MEDIA_ITEM_REQUEST } from 'state/action-types';
 import {
 	failMediaRequest,
@@ -55,11 +53,8 @@ export function requestMediaError( { dispatch }, { siteId, query } ) {
 	dispatch( failMediaRequest( siteId, query ) );
 }
 
-export function handleMediaItemRequest( { dispatch, getState }, action ) {
+export function handleMediaItemRequest( { dispatch }, action ) {
 	const { mediaId, query, siteId } = action;
-	if ( isRequestingMediaItem( getState(), siteId, mediaId ) ) {
-		return;
-	}
 
 	dispatch( requestingMediaItem( siteId, query ) );
 

--- a/client/state/data-layer/wpcom/sites/media/index.js
+++ b/client/state/data-layer/wpcom/sites/media/index.js
@@ -97,11 +97,15 @@ function handleMediaItemRequest( { dispatch, getState }, action ) {
 		)
 	);
 }
+function receiveMediaItem( { dispatch }, { mediaId, siteId }, media ) {
+	dispatch( receiveMedia( siteId, media ) );
+	dispatch( successMediaItemRequest( siteId, mediaId ) );
+}
 
 export default {
 	[ MEDIA_REQUEST ]: [ dispatchRequest( requestMedia, requestMediaSuccess, requestMediaError ) ],
 	[ MEDIA_ITEM_REQUEST ]: [
 		requestMediaItem,
-		dispatchRequest( handleMediaItemRequest, ()=>{}, () => {} ),
+		dispatchRequest( handleMediaItemRequest, receiveMediaItem, () => {} ),
 	],
 };

--- a/client/state/data-layer/wpcom/sites/media/index.js
+++ b/client/state/data-layer/wpcom/sites/media/index.js
@@ -25,7 +25,6 @@ const log = debug( 'calypso:middleware-media' );
  *
  * @param  {Object}  store  Redux store
  * @param  {Object}  action Action object
- * @return {Promise}        Promise
  */
 export function requestMedia( { dispatch, getState }, action ) {
 	dispatch( requestingMedia( action.siteId, action.query ) );

--- a/client/state/data-layer/wpcom/sites/media/index.js
+++ b/client/state/data-layer/wpcom/sites/media/index.js
@@ -1,8 +1,12 @@
 /**
  * Internal dependencies
  */
-import { MEDIA_REQUEST, MEDIA_ITEM_REQUEST } from 'state/action-types';
+import debug from 'debug';
+import wpcom from 'lib/wp';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
+import { http } from 'state/data-layer/wpcom-http/actions';
 import { isRequestingMediaItem } from 'state/selectors';
+import { MEDIA_REQUEST, MEDIA_ITEM_REQUEST } from 'state/action-types';
 import {
 	failMediaRequest,
 	failMediaItemRequest,
@@ -12,11 +16,6 @@ import {
 	successMediaRequest,
 	successMediaItemRequest
 } from 'state/media/actions';
-import wpcom from 'lib/wp';
-import debug from 'debug';
-
-import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
-import { http } from 'state/data-layer/wpcom-http/actions';
 
 /**
  * Module variables
@@ -76,7 +75,33 @@ export function requestMediaItem( { dispatch, getState }, { siteId, mediaId } ) 
 		.catch( () => dispatch( failMediaItemRequest( siteId, mediaId ) ) );
 }
 
+function handleMediaItemRequest( { dispatch, getState }, action ) {
+	const { mediaId, query, siteId } = action;
+	if ( isRequestingMediaItem( getState(), siteId, mediaId ) ) {
+		return;
+	}
+
+	dispatch( requestingMediaItem( siteId, query ) );
+
+	log( 'Request media item %d for site %d', mediaId, siteId );
+
+	dispatch(
+		http(
+			{
+				apiVersion: '1.2',
+				method: 'GET',
+				path: `/sites/${ siteId }/media/${ mediaId }`,
+				query,
+			},
+			action
+		)
+	);
+}
+
 export default {
 	[ MEDIA_REQUEST ]: [ dispatchRequest( requestMedia, requestMediaSuccess, requestMediaError ) ],
-	[ MEDIA_ITEM_REQUEST ]: [ requestMediaItem ],
+	[ MEDIA_ITEM_REQUEST ]: [
+		requestMediaItem,
+		dispatchRequest( handleMediaItemRequest, ()=>{}, () => {} ),
+	],
 };

--- a/client/state/data-layer/wpcom/sites/media/test/index.js
+++ b/client/state/data-layer/wpcom/sites/media/test/index.js
@@ -6,119 +6,144 @@ import { expect } from 'chai';
 /**
  * Internal dependencies
  */
-import useNock from 'test/helpers/use-nock';
+import { handleMediaItemRequest, receiveMediaItem, receiveMediaItemError } from '../';
+import { http } from 'state/data-layer/wpcom-http/actions';
+import { MEDIA_ITEM_REQUEST } from 'state/action-types';
 import { useSandbox } from 'test/helpers/use-sinon';
 import {
+	failMediaItemRequest,
+	failMediaRequest,
+	receiveMedia,
 	requestingMedia,
 	requestingMediaItem,
-	successMediaRequest,
 	successMediaItemRequest,
-	failMediaRequest,
-	failMediaItemRequest,
-	receiveMedia
+	successMediaRequest,
 } from 'state/media/actions';
 import {
-	requestMediaItem,
 	requestMediaSuccess,
 	requestMediaError,
 	requestMedia
 } from '../';
-import { http } from 'state/data-layer/wpcom-http/actions';
 
-describe( 'wpcom-api', () => {
+describe( 'media request', () => {
 	let dispatch;
 
 	useSandbox( sandbox => ( dispatch = sandbox.spy() ) );
 
-	describe( 'media request', () => {
-		const getState = () => ( {
-			media: {
-				queryRequests: {
-					2916284: {
-						'[]': true
-					}
+	const getState = () => ( {
+		media: {
+			queryRequests: {
+				2916284: {
+					'[]': true
 				}
 			}
-		} );
-
-		it( 'should dispatch REQUESTING action when request triggers', () => {
-			requestMedia( { dispatch, getState }, { siteId: 2916284, query: 'a=b' } );
-			expect( dispatch ).to.have.been.calledWith( requestingMedia( 2916284, 'a=b' ) );
-		} );
-
-		it( 'should dispatch SUCCESS action when request completes', () => {
-			requestMediaSuccess( { dispatch }, { siteId: 2916284, query: 'a=b' },
-				{ media: { ID: 10, title: 'media title' }, found: true } );
-			expect( dispatch ).to.have.been.calledWith( successMediaRequest( 2916284, 'a=b' ) );
-			expect( dispatch ).to.have.been.calledWith( receiveMedia( 2916284, { ID: 10, title: 'media title' }, true, 'a=b' ) );
-		} );
-
-		it( 'should dispatch FAILURE action when request fails', () => {
-			requestMediaError( { dispatch }, { siteId: 2916284, query: 'a=b' } );
-			expect( dispatch ).to.have.been.calledWith( failMediaRequest( 2916284, 'a=b' ) );
-		} );
-
-		it( 'should dispatch http request', () => {
-			requestMedia( { dispatch, getState }, { siteId: 2916284, query: 'a=b' } );
-			expect( dispatch ).to.have.been.calledWith(
-				http(
-					{
-						method: 'GET',
-						path: '/sites/2916284/media',
-						apiVersion: '1.1',
-					},
-					{ siteId: 2916284, query: 'a=b' }
-				)
-			);
-		} );
+		}
 	} );
 
-	describe( 'media item request', () => {
-		const getState = () => ( {
-			media: {
-				mediaItemRequests: {
-					2916284: {
-						15: true
-					}
-				}
-			}
-		} );
+	it( 'should dispatch REQUESTING action when request triggers', () => {
+		requestMedia( { dispatch, getState }, { siteId: 2916284, query: 'a=b' } );
+		expect( dispatch ).to.have.been.calledWith( requestingMedia( 2916284, 'a=b' ) );
+	} );
 
-		useNock( nock => (
-			nock( 'https://public-api.wordpress.com:443' )
-				.persist()
-				.get( '/rest/v1.2/sites/2916284/media/10' )
-				.reply( 200, {
-					ID: 10,
-					title: 'media title'
-				} )
-				.get( '/rest/v1.2/sites/2916284/media/20' )
-				.reply( 400, {} )
-		) );
+	it( 'should dispatch SUCCESS action when request completes', () => {
+		requestMediaSuccess( { dispatch }, { siteId: 2916284, query: 'a=b' },
+			{ media: { ID: 10, title: 'media title' }, found: true } );
+		expect( dispatch ).to.have.been.calledWith( successMediaRequest( 2916284, 'a=b' ) );
+		expect( dispatch ).to.have.been.calledWith( receiveMedia( 2916284, { ID: 10, title: 'media title' }, true, 'a=b' ) );
+	} );
 
-		it( 'should not dispatch anything if the request is in flight', () => {
-			requestMediaItem( { dispatch, getState }, { siteId: 2916284, mediaId: 15 } );
-			expect( dispatch ).to.not.have.been.called;
-		} );
+	it( 'should dispatch FAILURE action when request fails', () => {
+		requestMediaError( { dispatch }, { siteId: 2916284, query: 'a=b' } );
+		expect( dispatch ).to.have.been.calledWith( failMediaRequest( 2916284, 'a=b' ) );
+	} );
 
-		it( 'should dispatch REQUESTING action when request triggers', () => {
-			requestMediaItem( { dispatch, getState }, { siteId: 2916284, mediaId: 10 } );
-			expect( dispatch ).to.have.been.calledWith( requestingMediaItem( 2916284, 10 ) );
-		} );
+	it( 'should dispatch http request', () => {
+		requestMedia( { dispatch, getState }, { siteId: 2916284, query: 'a=b' } );
+		expect( dispatch ).to.have.been.calledWith(
+			http(
+				{
+					method: 'GET',
+					path: '/sites/2916284/media',
+					apiVersion: '1.1',
+				},
+				{ siteId: 2916284, query: 'a=b' }
+			)
+		);
+	} );
+} );
 
-		it( 'should dispatch SUCCESS action when request completes', () => {
-			return requestMediaItem( { dispatch, getState }, { siteId: 2916284, mediaId: 10 } )
-				.then( () => {
-					expect( dispatch ).to.have.been.calledWith( successMediaItemRequest( 2916284, 10 ) );
-					expect( dispatch ).to.have.been.calledWith( receiveMedia( 2916284, { ID: 10, title: 'media title' } ) );
-				} );
-		} );
+describe( 'handleMediaItemRequest', () => {
+	let dispatch;
 
-		it( 'should dispatch FAILURE action when request fails', () => {
-			return requestMediaItem( { dispatch, getState }, { siteId: 2916284, mediaId: 20 } )
-				.catch( () => {
-					expect( dispatch ).to.have.been.calledWith( failMediaItemRequest( 2916284, 20 ) );
-				} );
-		} );
+	useSandbox( sandbox => ( dispatch = sandbox.spy() ) );
+
+	it( 'should dispatch an http action', () => {
+		const siteId = 12345;
+		const mediaId = 67890;
+		const action = {
+			type: MEDIA_ITEM_REQUEST,
+			mediaId,
+			siteId,
+		};
+		handleMediaItemRequest( { dispatch }, action );
+		expect( dispatch ).to.have.been.calledTwice;
+		expect( dispatch ).to.have.been.calledWith(
+			requestingMediaItem( siteId )
+		);
+		expect( dispatch ).to.have.been.calledWith(
+			http(
+				{
+					apiVersion: '1.2',
+					method: 'GET',
+					path: `/sites/${ siteId }/media/${ mediaId }`,
+				},
+				action
+			)
+		);
+	} );
+} );
+
+describe( 'receiveMediaItem', () => {
+	let dispatch;
+
+	useSandbox( sandbox => ( dispatch = sandbox.spy() ) );
+
+	it( 'should dispatch media recieve actions', () => {
+		const siteId = 12345;
+		const mediaId = 67890;
+		const action = {
+			type: MEDIA_ITEM_REQUEST,
+			mediaId,
+			siteId,
+		};
+		const media = { ID: 91827364 };
+		receiveMediaItem( { dispatch }, action, media );
+		expect( dispatch ).to.have.been.calledTwice,
+		expect( dispatch ).to.have.been.calledWith(
+			receiveMedia( siteId, media )
+		);
+		expect( dispatch ).to.have.been.calledWith(
+			successMediaItemRequest( siteId, mediaId )
+		);
+	} );
+} );
+
+describe( 'receiveMediaItemError', () => {
+	let dispatch;
+
+	useSandbox( sandbox => ( dispatch = sandbox.spy() ) );
+
+	it( 'should dispatch failure', () => {
+		const siteId = 12345;
+		const mediaId = 67890;
+		const action = {
+			type: MEDIA_ITEM_REQUEST,
+			mediaId,
+			siteId,
+		};
+		receiveMediaItemError( { dispatch }, action );
+		expect( dispatch ).to.have.been.calledWith(
+			failMediaItemRequest( siteId, mediaId )
+		);
 	} );
 } );


### PR DESCRIPTION
Update requestMediaItem to use data-layer `http`.

This is a simple translation from wpcom to data-layer

## Testing
1. Do the tests pass?
1. Visit https://calypso.live/?branch=update/data-layer/request-media-item
1. Run this from the console:
   ```js
   dispatch( { type: 'MEDIA_ITEM_REQUEST', siteId: 123, mediaId: 456 } )
   ```
1. You should see an appropriate network request fire (`https://public-api.wordpress.com/rest/v1.2/sites/123/media/456`)

Closes #17837