### PR TITLE
Update reader teams to use WPCOM-http

### DIFF
--- a/client/state/data-layer/wpcom/read/teams/index.js
+++ b/client/state/data-layer/wpcom/read/teams/index.js
@@ -3,26 +3,39 @@
  * Internal dependencies
  */
 import { READER_TEAMS_REQUEST, READER_TEAMS_RECEIVE } from 'state/action-types';
-import wpcom from 'lib/wp';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
+import { http } from 'state/data-layer/wpcom-http/actions';
 
-export function handleTeamsRequest( store ) {
-	wpcom.req.get( '/read/teams', { apiVersion: '1.2' } ).then(
-		payload => {
-			store.dispatch( {
-				type: READER_TEAMS_RECEIVE,
-				payload,
-			} );
-		},
-		error => {
-			store.dispatch( {
-				type: READER_TEAMS_RECEIVE,
-				payload: error,
-				error: true,
-			} );
-		}
+export const handleTeamsRequest = ( { dispatch }, action ) => {
+	dispatch(
+		http(
+			{
+				method: 'GET',
+				path: '/read/teams',
+				apiVersion: '1.2',
+			},
+			action
+		)
 	);
-}
+};
+
+export const teamRequestReceived = ( { dispatch }, payload ) => {
+	dispatch( {
+		type: READER_TEAMS_RECEIVE,
+		payload,
+	} );
+};
+
+export const teamRequestFailure = ( { dispatch }, error ) => {
+	dispatch( {
+		type: READER_TEAMS_RECEIVE,
+		payload: error,
+		error: true,
+	} );
+};
 
 export default {
-	[ READER_TEAMS_REQUEST ]: [ handleTeamsRequest ],
+	[ READER_TEAMS_REQUEST ]: [
+		dispatchRequest( handleTeamsRequest, teamRequestReceived, teamRequestFailure ),
+	],
 };

--- a/client/state/data-layer/wpcom/read/teams/test/index.js
+++ b/client/state/data-layer/wpcom/read/teams/test/index.js
@@ -3,64 +3,58 @@
  * External dependencies
  */
 import { expect } from 'chai';
-import sinon from 'sinon';
+import { spy } from 'sinon';
 
 /**
  * Internal dependencies
  */
-import useNock from 'test/helpers/use-nock';
+import { handleTeamsRequest, teamRequestFailure, teamRequestReceived } from '../';
+import { http } from 'state/data-layer/wpcom-http/actions';
 
-import { handleTeamsRequest } from '../';
-import { requestTeams } from 'state/reader/teams/actions';
+// import { requestTeams } from 'state/reader/teams/actions';
 import { READER_TEAMS_RECEIVE } from 'state/action-types';
-
-export const successfulResponse = {
-	teams: [
-		{
-			title: 'Automattic',
-			slug: 'a8c',
-		},
-	],
-	number: 1,
-};
 
 describe( 'wpcom-api', () => {
 	describe( 'teams request', () => {
-		useNock( nock =>
-			nock( 'https://public-api.wordpress.com:443' )
-				.get( '/rest/v1.2/read/teams' )
-				.reply( 200, successfulResponse )
-				.get( '/rest/v1.2/read/teams' )
-				.reply( 500, new Error() )
-		);
+		const action = { type: 'DUMMY_ACTION' };
 
-		it( 'should dispatch RECEIVE action when request completes', done => {
-			const dispatch = sinon.spy( action => {
-				if ( action.type === READER_TEAMS_RECEIVE ) {
-					expect( dispatch ).to.have.been.calledWith( {
-						type: READER_TEAMS_RECEIVE,
-						payload: successfulResponse,
-					} );
-					done();
-				}
-			} );
-
-			handleTeamsRequest( { dispatch }, requestTeams() );
+		it( 'should dispatch HTTP request to teams endpoint', () => {
+			const dispatch = spy();
+			handleTeamsRequest( { dispatch }, action );
+			expect( dispatch ).to.have.been.calledOnce;
+			expect( dispatch ).to.have.been.calledWith(
+				http(
+					{
+						method: 'GET',
+						path: '/read/teams',
+						apiVersion: '1.2',
+					},
+					action
+				)
+			);
 		} );
 
-		it( 'should dispatch RECEIVE action with error when request errors', done => {
-			const dispatch = sinon.spy( action => {
-				if ( action.type === READER_TEAMS_RECEIVE ) {
-					expect( dispatch ).to.have.been.calledWith( {
-						type: READER_TEAMS_RECEIVE,
-						payload: sinon.match.any,
-						error: true,
-					} );
-					done();
-				}
-			} );
+		it( 'should dispatch READER_TEAMS_RECEIVE action with error when request errors', () => {
+			const dispatch = spy();
+			teamRequestFailure( { dispatch }, action );
 
-			handleTeamsRequest( { dispatch }, requestTeams() );
+			expect( dispatch ).to.have.been.calledOnce;
+			expect( dispatch ).to.have.been.calledWith( {
+				type: READER_TEAMS_RECEIVE,
+				payload: action,
+				error: true,
+			} );
+		} );
+
+		it( 'should dispatch READER_TEAMS_RECEIVE action without error when request succeeds', () => {
+			const dispatch = spy();
+			teamRequestReceived( { dispatch }, action );
+
+			expect( dispatch ).to.have.been.calledOnce;
+			expect( dispatch ).to.have.been.calledWith( {
+				type: READER_TEAMS_RECEIVE,
+				payload: action,
+			} );
 		} );
 	} );
 } );


### PR DESCRIPTION
We updated the reader teams to use the new data layer wpcom-http instead of calling the wpcom js library. We're doing this in order to make it easier to test and get rid of the wpcom.js API.

This action is dispatched when the sidebar is loaded from the `QueryReaderTeams` component.

To test:
run `npm run test-client client/state/data-layer/wpcom/read/teams/`

and

in console run `dispatch( { type: 'READER_TEAMS_REQUEST' } );` and check if a request is made and that the `state.reader.teams.items` is updated

Closes #17834