### PR TITLE
When the media view changes, clear current selection.

### DIFF
--- a/client/my-sites/media/main.jsx
+++ b/client/my-sites/media/main.jsx
@@ -55,6 +55,10 @@ class Media extends Component {
 			redirect += '/' + this.props.selectedSite.slug;
 		}
 
+		if ( this.props.selectedSite ) {
+			MediaActions.setLibrarySelectedItems( this.props.selectedSite.ID, [] );
+		}
+
 		page( redirect );
 	};
 


### PR DESCRIPTION
Fixes #17551

To test, go to Media, select some items, then switch the view from
‘all’ to ‘documents’.

The edit/trash icon should disappear and switching back to all or
images should reveal no selections.

@belcherj Please let me know if a different approach is needed.