### PR TITLE
State: Updated requestMedia to use wpcom-http

### DIFF
--- a/client/state/data-layer/wpcom/sites/media/index.js
+++ b/client/state/data-layer/wpcom/sites/media/index.js
@@ -51,12 +51,12 @@ export function requestMedia( { dispatch, getState }, action ) {
 	);
 }
 
-function requestMediaSuccess( { dispatch }, { siteId, query }, { media, found } ) {
+export function requestMediaSuccess( { dispatch }, { siteId, query }, { media, found } ) {
 	dispatch( receiveMedia( siteId, media, found, query ) );
 	dispatch( successMediaRequest( siteId, query ) );
 }
 
-function requestMediaError( { dispatch }, { siteId, query } ) {
+export function requestMediaError( { dispatch }, { siteId, query } ) {
 	dispatch( failMediaRequest( siteId, query ) );
 }
 

--- a/client/state/data-layer/wpcom/sites/media/index.js
+++ b/client/state/data-layer/wpcom/sites/media/index.js
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import { MEDIA_REQUEST, MEDIA_ITEM_REQUEST } from 'state/action-types';
-import { isRequestingMedia, isRequestingMediaItem } from 'state/selectors';
+import { isRequestingMediaItem } from 'state/selectors';
 import {
 	failMediaRequest,
 	failMediaItemRequest,
@@ -31,10 +31,6 @@ const log = debug( 'calypso:middleware-media' );
  * @return {Promise}        Promise
  */
 export function requestMedia( { dispatch, getState }, action ) {
-	if ( isRequestingMedia( getState(), action.siteId, action.query ) ) {
-		return;
-	}
-
 	dispatch( requestingMedia( action.siteId, action.query ) );
 
 	log( 'Request media for site %d using query %o', action.siteId, action.query );

--- a/client/state/data-layer/wpcom/sites/media/test/index.js
+++ b/client/state/data-layer/wpcom/sites/media/test/index.js
@@ -9,9 +9,20 @@ import { expect } from 'chai';
 import useNock from 'test/helpers/use-nock';
 import { useSandbox } from 'test/helpers/use-sinon';
 import {
-	requestingMedia, requestingMediaItem, successMediaRequest, successMediaItemRequest, failMediaRequest, failMediaItemRequest, receiveMedia
+	requestingMedia,
+	requestingMediaItem,
+	successMediaRequest,
+	successMediaItemRequest,
+	failMediaRequest,
+	failMediaItemRequest,
+	receiveMedia
 } from 'state/media/actions';
-import { requestMediaItem, requestMediaSuccess, requestMediaError, requestMedia } from '../';
+import {
+	requestMediaItem,
+	requestMediaSuccess,
+	requestMediaError,
+	requestMedia
+} from '../';
 import { http } from 'state/data-layer/wpcom-http/actions';
 
 describe( 'wpcom-api', () => {

--- a/client/state/data-layer/wpcom/sites/media/test/index.js
+++ b/client/state/data-layer/wpcom/sites/media/test/index.js
@@ -41,11 +41,6 @@ describe( 'wpcom-api', () => {
 			}
 		} );
 
-		it( 'should not dispatch anything if the request is in flight', () => {
-			requestMedia( { dispatch, getState }, { siteId: 2916284 } );
-			expect( dispatch ).to.not.have.been.called;
-		} );
-
 		it( 'should dispatch REQUESTING action when request triggers', () => {
 			requestMedia( { dispatch, getState }, { siteId: 2916284, query: 'a=b' } );
 			expect( dispatch ).to.have.been.calledWith( requestingMedia( 2916284, 'a=b' ) );

--- a/client/state/data-layer/wpcom/sites/media/test/index.js
+++ b/client/state/data-layer/wpcom/sites/media/test/index.js
@@ -9,14 +9,63 @@ import { expect } from 'chai';
 import useNock from 'test/helpers/use-nock';
 import { useSandbox } from 'test/helpers/use-sinon';
 import {
-	requestingMediaItem, successMediaItemRequest, failMediaItemRequest, receiveMedia
+	requestingMedia, requestingMediaItem, successMediaRequest, successMediaItemRequest, failMediaRequest, failMediaItemRequest, receiveMedia
 } from 'state/media/actions';
-import { requestMediaItem } from '../';
+import { requestMediaItem, requestMediaSuccess, requestMediaError, requestMedia } from '../';
+import { http } from 'state/data-layer/wpcom-http/actions';
 
 describe( 'wpcom-api', () => {
 	let dispatch;
 
 	useSandbox( sandbox => ( dispatch = sandbox.spy() ) );
+
+	describe( 'media request', () => {
+		const getState = () => ( {
+			media: {
+				queryRequests: {
+					2916284: {
+						'[]': true
+					}
+				}
+			}
+		} );
+
+		it( 'should not dispatch anything if the request is in flight', () => {
+			requestMedia( { dispatch, getState }, { siteId: 2916284 } );
+			expect( dispatch ).to.not.have.been.called;
+		} );
+
+		it( 'should dispatch REQUESTING action when request triggers', () => {
+			requestMedia( { dispatch, getState }, { siteId: 2916284, query: 'a=b' } );
+			expect( dispatch ).to.have.been.calledWith( requestingMedia( 2916284, 'a=b' ) );
+		} );
+
+		it( 'should dispatch SUCCESS action when request completes', () => {
+			requestMediaSuccess( { dispatch }, { siteId: 2916284, query: 'a=b' },
+				{ media: { ID: 10, title: 'media title' }, found: true } );
+			expect( dispatch ).to.have.been.calledWith( successMediaRequest( 2916284, 'a=b' ) );
+			expect( dispatch ).to.have.been.calledWith( receiveMedia( 2916284, { ID: 10, title: 'media title' }, true, 'a=b' ) );
+		} );
+
+		it( 'should dispatch FAILURE action when request fails', () => {
+			requestMediaError( { dispatch }, { siteId: 2916284, query: 'a=b' } );
+			expect( dispatch ).to.have.been.calledWith( failMediaRequest( 2916284, 'a=b' ) );
+		} );
+
+		it( 'should dispatch http request', () => {
+			requestMedia( { dispatch, getState }, { siteId: 2916284, query: 'a=b' } );
+			expect( dispatch ).to.have.been.calledWith(
+				http(
+					{
+						method: 'GET',
+						path: '/sites/2916284/media',
+						apiVersion: '1.1',
+					},
+					{ siteId: 2916284, query: 'a=b' }
+				)
+			);
+		} );
+	} );
 
 	describe( 'media item request', () => {
 		const getState = () => ( {


### PR DESCRIPTION
`requestMedia` used to use wpcom directly instead of using wpcom-http (data layer). It has been rewritten using `dispatchRequest` and http.

Fixes: #17836