### PR TITLE
Updates automated-transfer eligibility to use wpcom-http

### DIFF
--- a/client/state/data-layer/wpcom/sites/automated-transfer/eligibility/index.js
+++ b/client/state/data-layer/wpcom/sites/automated-transfer/eligibility/index.js
@@ -115,7 +115,7 @@ const trackEligibility = data => {
  * @param {Function} store.dispatch action dispatcher
  * @param {action} action Action object
  */
-export const requestEligibility = ( { dispatch }, action ) => {
+export const requestAutomatedTransferEligibility = ( { dispatch }, action ) => {
 	const { siteId } = action;
 
 	dispatch( http( {
@@ -125,21 +125,21 @@ export const requestEligibility = ( { dispatch }, action ) => {
 	}, action ) );
 };
 
-export const receiveResponse = ( { dispatch }, { siteId }, data ) => {
+export const updateAutomatedTransferEligibility = ( { dispatch }, { siteId }, data ) => {
 	dispatch( withAnalytics(
 		trackEligibility( data ),
 		updateEligibility( siteId, fromApi( data ) )
 	) );
 };
 
-export const receiveError = ( store, action, error ) => {
+export const throwRequestError = ( store, action, error ) => {
 	throw new Error( error );
 };
 
 export default {
 	[ AUTOMATED_TRANSFER_ELIGIBILITY_REQUEST ]: [ dispatchRequest(
-		requestEligibility,
-		receiveResponse,
-		receiveError
+		requestAutomatedTransferEligibility,
+		updateAutomatedTransferEligibility,
+		throwRequestError
 	) ],
 };

--- a/client/state/data-layer/wpcom/sites/automated-transfer/eligibility/index.js
+++ b/client/state/data-layer/wpcom/sites/automated-transfer/eligibility/index.js
@@ -125,14 +125,14 @@ export const requestEligibility = ( { dispatch }, action ) => {
 	}, action ) );
 };
 
-const receiveResponse = ( { dispatch }, { siteId }, data ) => {
+export const receiveResponse = ( { dispatch }, { siteId }, data ) => {
 	dispatch( withAnalytics(
 		trackEligibility( data ),
 		updateEligibility( siteId, fromApi( data ) )
 	) );
 };
 
-const receiveError = ( store, action, error ) => {
+export const receiveError = ( store, action, error ) => {
 	throw new Error( error );
 };
 

--- a/client/state/data-layer/wpcom/sites/automated-transfer/eligibility/test/index.js
+++ b/client/state/data-layer/wpcom/sites/automated-transfer/eligibility/test/index.js
@@ -1,0 +1,47 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+/**
+ * Internal dependencies
+ */
+import {
+	requestEligibility,
+	receiveResponse,
+	receiveError,
+} from 'state/data-layer/wpcom/sites/automated-transfer/eligibility';
+
+describe( 'requestEligibility', () => {
+	it( 'should dispatch an http request', () => {
+		const dispatch = sinon.spy();
+		const siteId = 2916284;
+		requestEligibility( { dispatch }, { siteId } );
+		expect( dispatch ).to.have.been.calledWithMatch( {
+			method: 'GET',
+			path: `/sites/${ siteId }/automated-transfers/eligibility`,
+		} );
+	} );
+} );
+
+describe( 'receiveResponse', () => {
+	it( 'should dispatch an update eligibility action ', () => {
+		const dispatch = sinon.spy();
+		const action = { type: 'AUTOMATED_TRANSFER_ELIGIBILITY_REQUEST', siteId: 2916284 };
+		receiveResponse( { dispatch }, action, { warnings: {}, errors: [] } );
+		expect( dispatch ).to.have.been.calledWith(
+			sinon.match( { type: 'AUTOMATED_TRANSFER_ELIGIBILITY_UPDATE', siteId: 2916284 } )
+		);
+	} );
+} );
+
+// TODO: Find out why we're throwing
+describe( 'receiveError', () => {
+	it( 'should throw an error', () => {
+		const testError = () => {
+			receiveError( {}, {}, {} );
+		};
+		expect( testError ).to.throw();
+	} );
+} );

--- a/client/state/data-layer/wpcom/sites/automated-transfer/eligibility/test/index.js
+++ b/client/state/data-layer/wpcom/sites/automated-transfer/eligibility/test/index.js
@@ -8,16 +8,16 @@ import sinon from 'sinon';
  * Internal dependencies
  */
 import {
-	requestEligibility,
-	receiveResponse,
-	receiveError,
+	requestAutomatedTransferEligibility,
+	updateAutomatedTransferEligibility,
+	throwRequestError,
 } from 'state/data-layer/wpcom/sites/automated-transfer/eligibility';
 
-describe( 'requestEligibility', () => {
+describe( 'requestAutomatedTransferEligibility', () => {
 	it( 'should dispatch an http request', () => {
 		const dispatch = sinon.spy();
 		const siteId = 2916284;
-		requestEligibility( { dispatch }, { siteId } );
+		requestAutomatedTransferEligibility( { dispatch }, { siteId } );
 		expect( dispatch ).to.have.been.calledWithMatch( {
 			method: 'GET',
 			path: `/sites/${ siteId }/automated-transfers/eligibility`,
@@ -25,11 +25,11 @@ describe( 'requestEligibility', () => {
 	} );
 } );
 
-describe( 'receiveResponse', () => {
+describe( 'updateAutomatedTransferEligibility', () => {
 	it( 'should dispatch an update eligibility action ', () => {
 		const dispatch = sinon.spy();
 		const action = { type: 'AUTOMATED_TRANSFER_ELIGIBILITY_REQUEST', siteId: 2916284 };
-		receiveResponse( { dispatch }, action, { warnings: {}, errors: [] } );
+		updateAutomatedTransferEligibility( { dispatch }, action, { warnings: {}, errors: [] } );
 		expect( dispatch ).to.have.been.calledWith(
 			sinon.match( { type: 'AUTOMATED_TRANSFER_ELIGIBILITY_UPDATE', siteId: 2916284 } )
 		);
@@ -37,10 +37,10 @@ describe( 'receiveResponse', () => {
 } );
 
 // TODO: Find out why we're throwing
-describe( 'receiveError', () => {
+describe( 'throwRequestError', () => {
 	it( 'should throw an error', () => {
 		const testError = () => {
-			receiveError( {}, {}, {} );
+			throwRequestError( {}, {}, {} );
 		};
 		expect( testError ).to.throw();
 	} );


### PR DESCRIPTION
**Summary**
Rewrites `fetchEligibility` in `client/state/data-layer/wpcom/sites/automated-transfer/elegibility/index.js` to use `dispatchRequest` and `http`.

Renamed `fetchEligibility` to `requestEligibility`.

Fixes #17835.

**Test Plan**
- Apply this patch and then
- Run `npm run test-client client/state/data-layer/wpcom/sites/automated-transfer/eligibility/test/`
- Should pass following three tests:
```
requestAutomatedTransferEligibility
✓ should dispatch an http request

updateAutomatedTransferEligibility
✓ should dispatch an update eligibility action

throwRequestError
✓ should throw an error
```
- Visit plugin uploads section from a site in the Calypso admin of your local environment that does **not** have the Business plan upgrade. For example `http://calypso.localhost:3000/plugins/upload/YOURTESTSITE.wordpress.com`
- Verify that you are prompted to upgrade to Business Plan _and_ set up a Custom Domain before uploading a plugin.
- Verify that you can still transfer site / upload a plugin, once aforementioned requirements are met.