### PR TITLE
Update account-recovery lookup to use wpcom-http

### DIFF
--- a/client/state/data-layer/wpcom/account-recovery/lookup/index.js
+++ b/client/state/data-layer/wpcom/account-recovery/lookup/index.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -6,7 +7,9 @@ import { isString, tap } from 'lodash';
 /**
  * Internal dependencies
  */
-import wpcom from 'lib/wp';
+import { http } from 'state/data-layer/wpcom-http/actions';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
+import { noRetry } from 'state/data-layer/wpcom-http/pipeline/retry-on-failure/policies';
 import { ACCOUNT_RECOVERY_RESET_OPTIONS_REQUEST } from 'state/action-types';
 import {
 	fetchResetOptionsSuccess,
@@ -14,7 +17,7 @@ import {
 	updatePasswordResetUserData,
 } from 'state/account-recovery/reset/actions';
 
-export const fromApi = data => ( [
+export const fromApi = data => [
 	{
 		email: data.primary_email,
 		sms: data.primary_sms,
@@ -25,7 +28,7 @@ export const fromApi = data => ( [
 		sms: data.secondary_sms,
 		name: 'secondary',
 	},
-] );
+];
 
 export const validate = ( { primary_email, primary_sms, secondary_email, secondary_sms } ) => {
 	if ( ! [ primary_email, primary_sms, secondary_email, secondary_sms ].every( isString ) ) {
@@ -33,20 +36,41 @@ export const validate = ( { primary_email, primary_sms, secondary_email, seconda
 	}
 };
 
-export const handleRequestResetOptions = ( { dispatch }, action ) => {
+export const requestResetOptions = ( { dispatch }, action ) => {
 	const { userData } = action;
 
-	wpcom.req.get( {
-		body: userData,
-		apiNamespace: 'wpcom/v2',
-		path: '/account-recovery/lookup',
-	} ).then( data => {
+	dispatch(
+		http(
+			{
+				method: 'GET',
+				path: '/account-recovery/lookup',
+				apiNamespace: 'wpcom/v2',
+				query: userData,
+				retryPolicy: noRetry(),
+			},
+			action
+		)
+	);
+};
+
+export const requestResetOptionsError = ( { dispatch }, action, error ) => {
+	dispatch( fetchResetOptionsError( error ) );
+};
+
+export const requestResetOptionsSuccess = ( store, action, data ) => {
+	const { dispatch } = store;
+	const { userData } = action;
+
+	try {
 		dispatch( fetchResetOptionsSuccess( fromApi( tap( data, validate ) ) ) );
 		dispatch( updatePasswordResetUserData( userData ) );
-	} )
-	.catch( error => dispatch( fetchResetOptionsError( error ) ) );
+	} catch ( error ) {
+		requestResetOptionsError( store, action, error );
+	}
 };
 
 export default {
-	[ ACCOUNT_RECOVERY_RESET_OPTIONS_REQUEST ]: [ handleRequestResetOptions ],
+	[ ACCOUNT_RECOVERY_RESET_OPTIONS_REQUEST ]: [
+		dispatchRequest( requestResetOptions, requestResetOptionsSuccess, requestResetOptionsError ),
+	],
 };


### PR DESCRIPTION
Refactoring patch that doesn't change any behavior observable to the user. A GM class project we just did with @eoigal 

Some non-obvious things we did that could be an interesting feedback for @dmsnell:
- we use the `noRetry` policy, because the default policy retries the request even if the real HTTP status is 200, and there is 40x status code in the response JSON. It's a valid response of the `/account-recovery/lookup` endpoint in case the user has 2FA enabled.
- the module uses a custom validation function and we had to do some try/catch magic to correctly handle the errors. It would be nice if the future `makeParser` API supported a custom validator, too :)

**Testing instructions:**
1. Log out from Calypso and go to `/account-recovery`
2. Enter a username that can do the recovery, i.e., it doesn't have 2FA enabled. The `/account-recovery/lookup` request should be issued (check in Network tab in devtools) and successful response returned. The UI workflow proceeds.
3. Enter a username that has 2FA enabled. The recovery attempt should result in error. Network request returns a 40x response.

Fixes #17827