### PR TITLE
Allow empty message to be posted for publicized posts

### DIFF
--- a/client/blocks/post-share/index.jsx
+++ b/client/blocks/post-share/index.jsx
@@ -226,7 +226,7 @@ class PostShare extends Component {
 			<PublicizeMessage
 				disabled={ this.isDisabled() }
 				message={ this.state.message }
-				preview={ this.props.post.title }
+				preview={ this.props.translate( 'Write a message for your audience here.' ) }
 				requireCount={ requireCount }
 				onChange={ this.setMessage }
 				acceptableLength={ acceptableLength } />

--- a/client/blocks/post-share/index.jsx
+++ b/client/blocks/post-share/index.jsx
@@ -104,7 +104,7 @@ class PostShare extends Component {
 	};
 
 	state = {
-		message: PostMetadata.publicizeMessage( this.props.post ) || this.props.post.title,
+		message: PostMetadata.publicizeMessage( this.props.post ),
 		skipped: PostMetadata.publicizeSkipped( this.props.post ) || [],
 		showSharingPreview: false,
 		showAccountTooltip: false,

--- a/client/blocks/post-share/index.jsx
+++ b/client/blocks/post-share/index.jsx
@@ -226,7 +226,6 @@ class PostShare extends Component {
 			<PublicizeMessage
 				disabled={ this.isDisabled() }
 				message={ this.state.message }
-				preview={ this.props.translate( 'Write a message for your audience here.' ) }
 				requireCount={ requireCount }
 				onChange={ this.setMessage }
 				acceptableLength={ acceptableLength } />

--- a/client/blocks/post-share/index.jsx
+++ b/client/blocks/post-share/index.jsx
@@ -104,7 +104,7 @@ class PostShare extends Component {
 	};
 
 	state = {
-		message: PostMetadata.publicizeMessage( this.props.post ),
+		message: PostMetadata.publicizeMessage( this.props.post ) || '',
 		skipped: PostMetadata.publicizeSkipped( this.props.post ) || [],
 		showSharingPreview: false,
 		showAccountTooltip: false,

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -929,9 +929,7 @@ Undocumented.prototype.createConnection = function( keyringConnectionId, siteId,
 Undocumented.prototype.publicizePost = function( siteId, postId, message, skippedConnections, fn ) {
 	const body = { skipped_connections: [] };
 
-	if ( message ) {
-		body.message = message;
-	}
+	body.message = message;
 
 	if ( skippedConnections && skippedConnections.length > 0 ) {
 		body.skipped_connections = skippedConnections;

--- a/client/post-editor/editor-sharing/publicize-message.jsx
+++ b/client/post-editor/editor-sharing/publicize-message.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -13,7 +14,7 @@ import TrackInputChanges from 'components/track-input-changes';
 import PostActions from 'lib/posts/actions';
 import stats from 'lib/posts/stats';
 
-export default React.createClass( {
+const PublicizeMessage = React.createClass( {
 	displayName: 'PublicizeMessage',
 
 	propTypes: {
@@ -107,3 +108,5 @@ export default React.createClass( {
 		);
 	}
 } );
+
+export default localize( PublicizeMessage );

--- a/client/post-editor/editor-sharing/publicize-message.jsx
+++ b/client/post-editor/editor-sharing/publicize-message.jsx
@@ -13,7 +13,7 @@ import FormTextarea from 'components/forms/form-textarea';
 import InfoPopover from 'components/info-popover';
 import TrackInputChanges from 'components/track-input-changes';
 import PostActions from 'lib/posts/actions';
-import stats from 'lib/posts/stats';
+import * as stats from 'lib/posts/stats';
 
 class PublicizeMessage extends Component {
 	static propTypes = {

--- a/client/post-editor/editor-sharing/publicize-message.jsx
+++ b/client/post-editor/editor-sharing/publicize-message.jsx
@@ -1,8 +1,9 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies
@@ -14,42 +15,38 @@ import TrackInputChanges from 'components/track-input-changes';
 import PostActions from 'lib/posts/actions';
 import stats from 'lib/posts/stats';
 
-const PublicizeMessage = React.createClass( {
-	displayName: 'PublicizeMessage',
+class PublicizeMessage extends Component {
+	static propTypes = {
+		disabled: PropTypes.bool,
+		message: PropTypes.string,
+		preview: PropTypes.string,
+		acceptableLength: PropTypes.number,
+		requireCount: PropTypes.bool,
+		onChange: PropTypes.func
+	};
 
-	propTypes: {
-		disabled: React.PropTypes.bool,
-		message: React.PropTypes.string,
-		preview: React.PropTypes.string,
-		acceptableLength: React.PropTypes.number,
-		requireCount: React.PropTypes.bool,
-		onChange: React.PropTypes.func
-	},
+	static defaultProps = {
+		disabled: false,
+		message: '',
+		acceptableLength: 140,
+		requireCount: false,
+	};
 
-	getDefaultProps: function() {
-		return {
-			disabled: false,
-			message: '',
-			acceptableLength: 140,
-			requireCount: false,
-		};
-	},
-
-	onChange: function( event ) {
+	onChange = ( event ) => {
 		// TODO: REDUX - remove flux actions when whole post-editor is reduxified
 		if ( this.props.onChange ) {
 			this.props.onChange( event.target.value );
 		} else {
 			PostActions.updateMetadata( '_wpas_mess', event.target.value );
 		}
-	},
+	};
 
-	recordStats: function() {
+	recordStats = () => {
 		stats.recordStat( 'sharing_message_changed' );
 		stats.recordEvent( 'Publicize Sharing Message Changed' );
-	},
+	};
 
-	renderInfoPopover: function() {
+	renderInfoPopover() {
 		return (
 			<InfoPopover
 				className="publicize-message-counter-info"
@@ -57,15 +54,15 @@ const PublicizeMessage = React.createClass( {
 				gaEventCategory="Editor"
 				popoverName="SharingMessage"
 			>
-				{ this.translate(
+				{ this.props.translate(
 					'The length includes space for the link to your post and an attached image.',
 					{ context: 'Post editor sharing message counter explanation' }
 			) }
 			</InfoPopover>
 		);
-	},
+	}
 
-	renderTextarea: function() {
+	renderTextarea() {
 		const placeholder = this.props.preview || this.props.translate( 'Write a message for your audience here.' );
 
 		if ( this.props.requireCount ) {
@@ -93,13 +90,13 @@ const PublicizeMessage = React.createClass( {
 					className="editor-sharing__message-input" />
 			);
 		}
-	},
+	}
 
-	render: function() {
+	render() {
 		return (
 			<div className="editor-sharing__publicize-message">
 				<h5 className="editor-sharing__message-heading">
-					{ this.translate( 'Customize the message', { context: 'Post editor sharing message heading' } ) }
+					{ this.props.translate( 'Customize the message', { context: 'Post editor sharing message heading' } ) }
 				</h5>
 				<TrackInputChanges onNewValue={ this.recordStats }>
 					{ this.renderTextarea() }
@@ -107,6 +104,6 @@ const PublicizeMessage = React.createClass( {
 			</div>
 		);
 	}
-} );
+}
 
 export default localize( PublicizeMessage );

--- a/client/post-editor/editor-sharing/publicize-message.jsx
+++ b/client/post-editor/editor-sharing/publicize-message.jsx
@@ -65,12 +65,14 @@ export default React.createClass( {
 	},
 
 	renderTextarea: function() {
+		const placeholder = this.props.preview || this.props.translate( 'Write a message for your audience here.' );
+
 		if ( this.props.requireCount ) {
 			return (
 				<CountedTextarea
 					disabled={ this.props.disabled }
 					value={ this.props.message }
-					placeholder={ this.props.preview }
+					placeholder={ placeholder }
 					countPlaceholderLength={ true }
 					onChange={ this.onChange }
 					showRemainingCharacters={ true }
@@ -85,7 +87,7 @@ export default React.createClass( {
 				<FormTextarea
 					disabled={ this.props.disabled }
 					value={ this.props.message }
-					placeholder={ this.props.preview }
+					placeholder={ placeholder }
 					onChange={ this.onChange }
 					className="editor-sharing__message-input" />
 			);

--- a/client/post-editor/editor-sharing/publicize-options.jsx
+++ b/client/post-editor/editor-sharing/publicize-options.jsx
@@ -3,7 +3,7 @@
  */
 import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
-import { get, includes, map } from 'lodash';
+import { includes, map } from 'lodash';
 import classNames from 'classnames';
 import Gridicon from 'gridicons';
 
@@ -127,8 +127,7 @@ const EditorSharingPublicizeOptions = React.createClass( {
 	},
 
 	renderMessage: function() {
-		var preview = get( this.props.post, 'title' ),
-			skipped = this.hasConnections() ? PostMetadata.publicizeSkipped( this.props.post ) : [],
+		const skipped = this.hasConnections() ? PostMetadata.publicizeSkipped( this.props.post ) : [],
 			targeted = this.hasConnections() ? this.props.connections.filter( function( connection ) {
 				return skipped && -1 === skipped.indexOf( connection.keyring_connection_ID );
 			} ) : [],
@@ -141,8 +140,7 @@ const EditorSharingPublicizeOptions = React.createClass( {
 
 		return (
 			<PublicizeMessage
-				message={ PostMetadata.publicizeMessage( this.props.post ) }
-				preview={ preview }
+				message={ PostMetadata.publicizeMessage( this.props.post ) || '' }
 				requireCount={ requireCount }
 				acceptableLength={ acceptableLength } />
 		);


### PR DESCRIPTION
This patch updates the publicize UI to allow (and default to) an empty message for sharing a post.

### Testing Instructions
- Boot the branch
- Go to Posts and click on Share for a post you never shared before
- Ensure the message is empty
- Click "Share post" and check that your post was published to your social medias

### Reviews
- [ ] Code
- [ ] Product