### PR TITLE
Remove isRequesting props and requesting from state

### DIFF
--- a/client/components/data/query-reader-teams/index.jsx
+++ b/client/components/data/query-reader-teams/index.jsx
@@ -9,14 +9,9 @@ import { bindActionCreators } from 'redux';
  * Internal dependencies
  */
 import { requestTeams } from 'state/reader/teams/actions';
-import { isRequestingReaderTeams } from 'state/selectors';
 
 class QueryReaderTeams extends Component {
 	componentWillMount() {
-		if ( this.props.isRequesting ) {
-			return;
-		}
-
 		this.props.requestTeams();
 	}
 
@@ -26,18 +21,13 @@ class QueryReaderTeams extends Component {
 }
 
 QueryReaderTeams.propTypes = {
-	isRequesting: PropTypes.bool,
 	request: PropTypes.func
 };
-
-const mapStateToProps = state => ( {
-	requesting: isRequestingReaderTeams( state )
-} );
 
 const mapDispatchToProps = dispatch =>
 	bindActionCreators( { requestTeams }, dispatch );
 
 export default connect(
-	mapStateToProps,
+	null,
 	mapDispatchToProps,
 )( QueryReaderTeams );

--- a/client/components/data/query-reader-teams/index.jsx
+++ b/client/components/data/query-reader-teams/index.jsx
@@ -3,7 +3,6 @@
  */
 import { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
 
 /**
  * Internal dependencies
@@ -24,10 +23,7 @@ QueryReaderTeams.propTypes = {
 	request: PropTypes.func
 };
 
-const mapDispatchToProps = dispatch =>
-	bindActionCreators( { requestTeams }, dispatch );
-
 export default connect(
 	null,
-	mapDispatchToProps,
+	{ requestTeams },
 )( QueryReaderTeams );


### PR DESCRIPTION
Depends on #18020.

Once #18020 is merged, `handleTeamsRequest` will use http from the data layer. The data layer will handle the `isRequesting` state, so this is no longer needed inside the `QueryReaderTeams` component.

You can test this by checking the `READER_TEAMS_REQUEST` and `READER_TEAMS_RECEIVE` actions which are dispatched when the sidebar loads.