### PR TITLE
Account recovery: update account-recovery reset to use wpcom-http.

### DIFF
--- a/client/state/account-recovery/reset/actions.js
+++ b/client/state/account-recovery/reset/actions.js
@@ -13,8 +13,6 @@ import {
 	ACCOUNT_RECOVERY_RESET_VALIDATE_REQUEST_SUCCESS,
 	ACCOUNT_RECOVERY_RESET_VALIDATE_REQUEST_ERROR,
 	ACCOUNT_RECOVERY_RESET_PASSWORD_REQUEST,
-	ACCOUNT_RECOVERY_RESET_PASSWORD_REQUEST_SUCCESS,
-	ACCOUNT_RECOVERY_RESET_PASSWORD_REQUEST_ERROR,
 	ACCOUNT_RECOVERY_RESET_SET_METHOD,
 	ACCOUNT_RECOVERY_RESET_SET_VALIDATION_KEY,
 } from 'state/action-types';
@@ -71,15 +69,6 @@ export const validateRequestSuccess = () => ( {
 
 export const validateRequestError = ( error ) => ( {
 	type: ACCOUNT_RECOVERY_RESET_VALIDATE_REQUEST_ERROR,
-	error,
-} );
-
-export const requestResetPasswordSuccess = () => ( {
-	type: ACCOUNT_RECOVERY_RESET_PASSWORD_REQUEST_SUCCESS,
-} );
-
-export const requestResetPasswordError = ( error ) => ( {
-	type: ACCOUNT_RECOVERY_RESET_PASSWORD_REQUEST_ERROR,
 	error,
 } );
 

--- a/client/state/data-layer/wpcom/account-recovery/reset/test/index.js
+++ b/client/state/data-layer/wpcom/account-recovery/reset/test/index.js
@@ -22,19 +22,19 @@ import {
 
 describe( 'account-recovery/reset', () => {
 	describe( '#handleResetPasswordRequest', () => {
-		const dispatchSpy = spy();
-		const dummyAction = {
-			userData: {
-				user: 'foo',
-			},
-			method: 'primary_email',
-			key: 'a-super-secret-key',
-			password: 'my-new-password-which-I-cannot-remember',
-		};
-
-		resetPassword( { dispatch: dispatchSpy }, dummyAction );
-
 		it( 'should dispatch HTTP request to account recovery reset endpoint', () => {
+			const dispatchSpy = spy();
+			const dummyAction = {
+				userData: {
+					user: 'foo',
+				},
+				method: 'primary_email',
+				key: 'a-super-secret-key',
+				password: 'my-new-password-which-I-cannot-remember',
+			};
+
+			resetPassword( { dispatch: dispatchSpy }, dummyAction );
+
 			const {
 				userData,
 				method,
@@ -57,13 +57,13 @@ describe( 'account-recovery/reset', () => {
 	} );
 
 	describe( '#requestResetPasswordError', () => {
-		const dispatchSpy = spy();
-		const message = 'This is an error message.';
-		const rawError = Error( message );
-
-		handleError( { dispatch: dispatchSpy }, null, rawError );
-
 		it( 'should dispatch failure action with error message', () => {
+			const dispatchSpy = spy();
+			const message = 'This is an error message.';
+			const rawError = Error( message );
+
+			handleError( { dispatch: dispatchSpy }, null, rawError );
+
 			expect( dispatchSpy ).to.have.been.calledWith( {
 				type: ACCOUNT_RECOVERY_RESET_PASSWORD_REQUEST_ERROR,
 				error: message,
@@ -72,11 +72,11 @@ describe( 'account-recovery/reset', () => {
 	} );
 
 	describe( '#requestResetPasswordSuccess', () => {
-		const dispatchSpy = spy();
-
-		handleSuccess( { dispatch: dispatchSpy } );
-
 		it( 'should dispatch success action', () => {
+			const dispatchSpy = spy();
+
+			handleSuccess( { dispatch: dispatchSpy } );
+
 			expect( dispatchSpy ).to.have.been.calledWith( {
 				type: ACCOUNT_RECOVERY_RESET_PASSWORD_REQUEST_SUCCESS,
 			} );

--- a/client/state/data-layer/wpcom/account-recovery/reset/test/index.js
+++ b/client/state/data-layer/wpcom/account-recovery/reset/test/index.js
@@ -1,78 +1,85 @@
 /**
  * External dependencies
  */
-import { assert } from 'chai';
-import sinon from 'sinon';
+import { expect } from 'chai';
+import { spy } from 'sinon';
 
 /**
  * Internal dependencies
  */
 
-import { handleResetPasswordRequest } from '../';
-import useNock from 'test/helpers/use-nock';
+import {
+	resetPassword,
+	handleError,
+	handleSuccess,
+} from '../';
+import { http } from 'state/data-layer/wpcom-http/actions';
 
 import {
 	ACCOUNT_RECOVERY_RESET_PASSWORD_REQUEST_SUCCESS,
 	ACCOUNT_RECOVERY_RESET_PASSWORD_REQUEST_ERROR,
 } from 'state/action-types';
 
-describe( 'handleResetPasswordRequest()', () => {
-	const apiBaseUrl = 'https://public-api.wordpress.com:443';
-	const endpoint = '/wpcom/v2/account-recovery/reset';
+describe( 'account-recovery/reset', () => {
+	describe( '#handleResetPasswordRequest', () => {
+		const dispatchSpy = spy();
+		const dummyAction = {
+			userData: {
+				user: 'foo',
+			},
+			method: 'primary_email',
+			key: 'a-super-secret-key',
+			password: 'my-new-password-which-I-cannot-remember',
+		};
 
-	const params = {
-		userData: {
-			user: 'foo',
-		},
-		method: 'primary_email',
-		key: 'a-super-secret-key',
-		password: 'my-new-password-which-I-cannot-remember',
-	};
+		resetPassword( { dispatch: dispatchSpy }, dummyAction );
 
-	describe( 'success', () => {
-		useNock( nock => (
-			nock( apiBaseUrl )
-				.post( endpoint )
-				.reply( 200, { success: true } )
-		) );
-
-		it( 'should dispatch SUCCESS action on success', ( done ) => {
-			const dispatch = sinon.spy( () => {
-				assert.isTrue( dispatch.calledWith( {
-					type: ACCOUNT_RECOVERY_RESET_PASSWORD_REQUEST_SUCCESS,
-				} ) );
-
-				done();
-			} );
-
-			handleResetPasswordRequest( { dispatch }, params );
+		it( 'should dispatch HTTP request to account recovery reset endpoint', () => {
+			const {
+				userData,
+				method,
+				key,
+				password
+			} = dummyAction;
+			expect( dispatchSpy ).to.have.been.calledOnce;
+			expect( dispatchSpy ).to.have.been.calledWith( http( {
+				method: 'POST',
+				apiNamespace: 'wpcom/v2',
+				path: '/account-recovery/reset',
+				body: {
+					...userData,
+					method,
+					key,
+					password,
+				},
+			}, dummyAction ) );
 		} );
 	} );
 
-	describe( 'failure', () => {
-		const errorResponse = {
-			status: 400,
-			message: 'Something wrong!',
-		};
+	describe( '#requestResetPasswordError', () => {
+		const dispatchSpy = spy();
+		const message = 'This is an error message.';
+		const rawError = Error( message );
 
-		useNock( nock => (
-			nock( apiBaseUrl )
-				.post( endpoint )
-				.reply( errorResponse.status, errorResponse )
-		) );
+		handleError( { dispatch: dispatchSpy }, null, rawError );
 
-		it( 'should dispatch ERROR action on failure', ( done ) => {
-			const dispatch = sinon.spy( () => {
-				assert.isTrue( dispatch.calledWithMatch( {
-					type: ACCOUNT_RECOVERY_RESET_PASSWORD_REQUEST_ERROR,
-					error: errorResponse,
-				} ) )
-
-				done();
+		it( 'should dispatch failure action with error message', () => {
+			expect( dispatchSpy ).to.have.been.calledWith( {
+				type: ACCOUNT_RECOVERY_RESET_PASSWORD_REQUEST_ERROR,
+				error: message,
 			} );
+		} );
+	} );
 
-			handleResetPasswordRequest( { dispatch }, params );
+	describe( '#requestResetPasswordSuccess', () => {
+		const dispatchSpy = spy();
+
+		handleSuccess( { dispatch: dispatchSpy } );
+
+		it( 'should dispatch success action', () => {
+			expect( dispatchSpy ).to.have.been.calledWith( {
+				type: ACCOUNT_RECOVERY_RESET_PASSWORD_REQUEST_SUCCESS,
+			} );
 		} );
 	} );
 } );
-


### PR DESCRIPTION
**Testing Instructions:**

1. Open an incognito window and make sure you are logged out.
1. Visit http://calypso.localhost:3000/account-recovery
1. Use a test account info to proceed with instructions, but make sure to choose "reset by the 1. primary sms number" or "reset by the recovery sms number".
1. Enter the received code, and you should arrive the final "New password" form.
1. Enter a new password and click reset.
1. Verify that you can login with the new password.

Fixes #17830.

