### PR TITLE
PostListWrapper: Remove PostListFetcher

### DIFF
--- a/client/my-sites/posts/post-list-wrapper.jsx
+++ b/client/my-sites/posts/post-list-wrapper.jsx
@@ -7,7 +7,6 @@ import React from 'react';
  * Internal dependencies
  */
 import PostList from './post-list';
-import PostListFetcher from 'components/post-list-fetcher';
 import PostTypeList from 'my-sites/post-type-list';
 import config from 'config';
 import { mapPostStatus } from 'lib/route/path';
@@ -38,24 +37,11 @@ class PostListWrapper extends React.Component {
 		}
 
 		return (
-			<div>
-				<PostListFetcher
-					siteId={ this.props.siteId }
-					status={ mapPostStatus( this.props.statusSlug ) }
-					author={ this.props.author }
-					withImages={ true }
-					withCounts={ true }
-					search={ this.props.search }
-					category={ this.props.category }
-					tag={ this.props.tag }
-				>
-					<PostTypeList
-						query={ query }
-						largeTitles={ true }
-						wrapTitles={ true }
-					/>
-				</PostListFetcher>
-			</div>
+			<PostTypeList
+				query={ query }
+				largeTitles={ true }
+				wrapTitles={ true }
+			/>
 		);
 	}
 


### PR DESCRIPTION
`PostListWrapper` uses `PostTypeList` to display its list of posts, which internally uses a Redux query component and selectors to fetch its data autonomously. This means that the wrapping `PostListFetcher` component is entirely obsolete and can be removed.

No visual changes (AFAICS):

![image](https://user-images.githubusercontent.com/96308/30412661-e0518558-98cd-11e7-80a1-78947802c5a3.png)

To test:

* Run `ENABLE_FEATURES=posts/post-type-list npm start`
* Navigate to Blog Posts (`/posts`) and verify that the page works as on `master`, both in All Sites mode and with a specific site.

`PostListWrapper` was introduced in https://github.com/Automattic/wp-calypso/pull/16890.