### PR TITLE
Modernize blocks (ES modules, React.Component, etc.) 

### DIFF
--- a/client/blocks/app-banner/index.jsx
+++ b/client/blocks/app-banner/index.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import ReactDom from 'react-dom';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
@@ -54,9 +55,9 @@ class AppBanner extends Component {
 		recordAppBannerOpen: PropTypes.func,
 		userAgent: PropTypes.string,
 		// connected
-		currentSection: React.PropTypes.string,
-		dismissedUntil: React.PropTypes.object,
-		fetchingPreferences: React.PropTypes.bool,
+		currentSection: PropTypes.string,
+		dismissedUntil: PropTypes.object,
+		fetchingPreferences: PropTypes.bool,
 	};
 
 	static defaultProps = {

--- a/client/blocks/app-promo/test/index.jsx
+++ b/client/blocks/app-promo/test/index.jsx
@@ -65,20 +65,20 @@ describe( 'AppPromo', ( ) => {
 			promoCode: 'a0006',
 			message: 'WordPress.com in the palm of your hands — download app for mobile.',
 			type: 'mobile',
-		}
+		};
 
 		const desktopPromo = {
 			promoCode: 'a0005',
 			message: 'WordPress.com at your fingertips — download app for desktop.',
 			type: 'desktop'
-		}
+		};
 
-		it('should render a mobile link when the mobile promo code is passed in', ( ) => {
+		it( 'should render a mobile link when the mobile promo code is passed in', ( ) => {
 			expect( getPromoLink( 'reader', mobilePromo ) ).to.include( 'mobile' );
-		});
+		} );
 
-		it('should render a desktop link when the desktop promo code is passed in', ( ) => {
+		it( 'should render a desktop link when the desktop promo code is passed in', ( ) => {
 			expect( getPromoLink( 'reader', desktopPromo ) ).to.include( 'desktop' );
-		});
-	});
+		} );
+	} );
 } );

--- a/client/blocks/author-compact-profile/docs/example.jsx
+++ b/client/blocks/author-compact-profile/docs/example.jsx
@@ -10,7 +10,7 @@ import AuthorCompactProfile from 'blocks/author-compact-profile';
 import Card from 'components/card';
 
 export default class extends React.Component {
-    static displayName = 'AuthorCompactProfile';
+	static displayName = 'AuthorCompactProfile';
 
 	render() {
 		const author = {

--- a/client/blocks/author-compact-profile/docs/example.jsx
+++ b/client/blocks/author-compact-profile/docs/example.jsx
@@ -9,8 +9,8 @@ import React from 'react';
 import AuthorCompactProfile from 'blocks/author-compact-profile';
 import Card from 'components/card';
 
-export default React.createClass( {
-	displayName: 'AuthorCompactProfile',
+export default class extends React.Component {
+    static displayName = 'AuthorCompactProfile';
 
 	render() {
 		const author = {
@@ -31,5 +31,5 @@ export default React.createClass( {
 				/>
 			</Card>
 		);
-	},
-} );
+	}
+}

--- a/client/blocks/author-compact-profile/docs/example.jsx
+++ b/client/blocks/author-compact-profile/docs/example.jsx
@@ -9,8 +9,8 @@ import React from 'react';
 import AuthorCompactProfile from 'blocks/author-compact-profile';
 import Card from 'components/card';
 
-export default class extends React.Component {
-	static displayName = 'AuthorCompactProfile';
+export default class AuthorCompactProfileExample extends React.Component {
+	static displayName = 'AuthorCompactProfileExample';
 
 	render() {
 		const author = {

--- a/client/blocks/author-compact-profile/index.jsx
+++ b/client/blocks/author-compact-profile/index.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import PropTypes from 'prop-types';
 import React from 'react';
 import { numberFormat, localize } from 'i18n-calypso';
 import { has } from 'lodash';
@@ -17,19 +18,19 @@ import { getStreamUrl } from 'reader/route';
 import { areEqualIgnoringWhitespaceAndCase } from 'lib/string';
 import AuthorCompactProfilePlaceholder from './placeholder';
 
-const AuthorCompactProfile = React.createClass( {
-	propTypes: {
-		author: React.PropTypes.object,
-		siteName: React.PropTypes.string,
-		siteUrl: React.PropTypes.string,
-		feedUrl: React.PropTypes.string,
-		followCount: React.PropTypes.number,
-		feedId: React.PropTypes.number,
-		siteId: React.PropTypes.number,
-		siteIcon: React.PropTypes.string,
-		feedIcon: React.PropTypes.string,
-		post: React.PropTypes.object,
-	},
+class AuthorCompactProfile extends React.Component {
+	static propTypes = {
+		author: PropTypes.object,
+		siteName: PropTypes.string,
+		siteUrl: PropTypes.string,
+		feedUrl: PropTypes.string,
+		followCount: PropTypes.number,
+		feedId: PropTypes.number,
+		siteId: PropTypes.number,
+		siteIcon: PropTypes.string,
+		feedIcon: PropTypes.string,
+		post: PropTypes.object,
+	};
 
 	render() {
 		const {
@@ -98,7 +99,7 @@ const AuthorCompactProfile = React.createClass( {
 				</div>
 			</div>
 		);
-	},
-} );
+	}
+}
 
 export default localize( AuthorCompactProfile );

--- a/client/blocks/blog-stickers/index.jsx
+++ b/client/blocks/blog-stickers/index.jsx
@@ -1,6 +1,7 @@
 /**
  * External Dependencies
  */
+import PropTypes from 'prop-types';
 import React from 'react';
 
 /**
@@ -35,7 +36,7 @@ const BlogStickers = ( { blogId, teams, stickers } ) => {
 };
 
 BlogStickers.propTypes = {
-	blogId: React.PropTypes.number.isRequired,
+	blogId: PropTypes.number.isRequired,
 };
 
 export default connect( ( state, ownProps ) => {

--- a/client/blocks/calendar-button/index.jsx
+++ b/client/blocks/calendar-button/index.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import Gridicon from 'gridicons';
 import classNames from 'classnames';
 import { noop, pick } from 'lodash';
@@ -23,7 +24,7 @@ class CalendarButton extends Component {
 		closeOnEsc: PropTypes.bool,
 		disabledDays: PropTypes.array,
 		events: PropTypes.array,
-		ignoreContext: PropTypes.shape( { getDOMNode: React.PropTypes.function } ),
+		ignoreContext: PropTypes.shape( { getDOMNode: PropTypes.function } ),
 		isVisible: PropTypes.bool,
 		rootClassName: PropTypes.string,
 		selectedDay: PropTypes.object,

--- a/client/blocks/calendar-popover/index.jsx
+++ b/client/blocks/calendar-popover/index.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { noop, pick } from 'lodash';
 
@@ -26,7 +27,7 @@ class CalendarPopover extends Component {
 		// popover props
 		autoPosition: PropTypes.bool,
 		closeOnEsc: PropTypes.bool,
-		ignoreContext: PropTypes.shape( { getDOMNode: React.PropTypes.function } ),
+		ignoreContext: PropTypes.shape( { getDOMNode: PropTypes.function } ),
 		isVisible: PropTypes.bool,
 		position: PropTypes.string,
 		rootClassName: PropTypes.string,

--- a/client/blocks/comment-button/docs/example.jsx
+++ b/client/blocks/comment-button/docs/example.jsx
@@ -9,7 +9,7 @@ import React from 'react';
 import CommentButton from 'blocks/comment-button';
 import Card from 'components/card';
 
-export default class extends React.Component {
+export default class CommentButtonExample extends React.Component {
 	static displayName = 'CommentButtonExample';
 
 	render() {

--- a/client/blocks/comment-button/docs/example.jsx
+++ b/client/blocks/comment-button/docs/example.jsx
@@ -9,8 +9,8 @@ import React from 'react';
 import CommentButton from 'blocks/comment-button';
 import Card from 'components/card';
 
-export default React.createClass( {
-	displayName: 'CommentButtonExample',
+export default class extends React.Component {
+    static displayName = 'CommentButtonExample';
 
 	render() {
 		return (
@@ -24,4 +24,4 @@ export default React.createClass( {
 			</div>
 		);
 	}
-} );
+}

--- a/client/blocks/comment-button/docs/example.jsx
+++ b/client/blocks/comment-button/docs/example.jsx
@@ -10,7 +10,7 @@ import CommentButton from 'blocks/comment-button';
 import Card from 'components/card';
 
 export default class extends React.Component {
-    static displayName = 'CommentButtonExample';
+	static displayName = 'CommentButtonExample';
 
 	render() {
 		return (

--- a/client/blocks/comment-button/index.jsx
+++ b/client/blocks/comment-button/index.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
@@ -15,10 +16,10 @@ import { getPostTotalCommentsCount } from 'state/comments/selectors';
 class CommentButton extends Component {
 
 	static propTypes = {
-		onClick: React.PropTypes.func,
-		tagName: React.PropTypes.string,
-		commentCount: React.PropTypes.number,
-		showLabel: React.PropTypes.bool
+		onClick: PropTypes.func,
+		tagName: PropTypes.string,
+		commentCount: PropTypes.number,
+		showLabel: PropTypes.bool
 	};
 
 	static defaultProps = {

--- a/client/blocks/comments/comment-approve-action.jsx
+++ b/client/blocks/comments/comment-approve-action.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import PropTypes from 'prop-types';
 import React from 'react';
 import { noop } from 'lodash';
 import { localize } from 'i18n-calypso';
@@ -24,10 +25,10 @@ const CommentApproveAction = ( { translate, status, approveComment, unapproveCom
 };
 
 CommentApproveAction.propTypes = {
-	translate: React.PropTypes.func.isRequired,
-	approveComment: React.PropTypes.func,
-	unapproveComment: React.PropTypes.func,
-	status: React.PropTypes.string.isRequired,
+	translate: PropTypes.func.isRequired,
+	approveComment: PropTypes.func,
+	unapproveComment: PropTypes.func,
+	status: PropTypes.string.isRequired,
 };
 
 CommentApproveAction.defaultProps = {

--- a/client/blocks/comments/comment-count.jsx
+++ b/client/blocks/comments/comment-count.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import PropTypes from 'prop-types';
 import React from 'react';
 
 /**
@@ -32,7 +33,7 @@ const CommentCount = ( { count, translate } ) => {
 };
 
 CommentCount.propTypes = {
-	count: React.PropTypes.number.isRequired,
+	count: PropTypes.number.isRequired,
 };
 
 export default localize( CommentCount );

--- a/client/blocks/comments/comment-edit-form.jsx
+++ b/client/blocks/comments/comment-edit-form.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
@@ -203,13 +204,13 @@ class PostCommentForm extends Component {
 }
 
 PostCommentForm.propTypes = {
-	post: React.PropTypes.object.isRequired,
-	commentId: React.PropTypes.number,
-	commentText: React.PropTypes.string,
-	onCommentSubmit: React.PropTypes.func,
+	post: PropTypes.object.isRequired,
+	commentId: PropTypes.number,
+	commentText: PropTypes.string,
+	onCommentSubmit: PropTypes.func,
 
 	// connect()ed props:
-	editComment: React.PropTypes.func.isRequired,
+	editComment: PropTypes.func.isRequired,
 };
 
 PostCommentForm.defaultProps = {

--- a/client/blocks/comments/comment-likes.jsx
+++ b/client/blocks/comments/comment-likes.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import PropTypes from 'prop-types';
 import React from 'react';
 import { get, pick } from 'lodash';
 import { connect } from 'react-redux';
@@ -56,16 +57,16 @@ class CommentLikeButtonContainer extends React.Component {
 }
 
 CommentLikeButtonContainer.propTypes = {
-	siteId: React.PropTypes.number.isRequired,
-	postId: React.PropTypes.number.isRequired,
-	commentId: React.PropTypes.number.isRequired,
-	showZeroCount: React.PropTypes.bool,
-	tagName: React.PropTypes.string,
+	siteId: PropTypes.number.isRequired,
+	postId: PropTypes.number.isRequired,
+	commentId: PropTypes.number.isRequired,
+	showZeroCount: PropTypes.bool,
+	tagName: PropTypes.string,
 
 	// connected props:
-	commentLike: React.PropTypes.object.isRequired,
-	likeComment: React.PropTypes.func.isRequired,
-	unlikeComment: React.PropTypes.func.isRequired,
+	commentLike: PropTypes.object.isRequired,
+	likeComment: PropTypes.func.isRequired,
+	unlikeComment: PropTypes.func.isRequired,
 };
 
 export default connect(

--- a/client/blocks/comments/post-comment-list.jsx
+++ b/client/blocks/comments/post-comment-list.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 import { translate } from 'i18n-calypso';
@@ -42,22 +43,22 @@ import SegmentedControlItem from 'components/segmented-control/item';
 
 class PostCommentList extends React.Component {
 	static propTypes = {
-		post: React.PropTypes.shape( {
-			ID: React.PropTypes.number.isRequired,
-			site_ID: React.PropTypes.number.isRequired,
+		post: PropTypes.shape( {
+			ID: PropTypes.number.isRequired,
+			site_ID: PropTypes.number.isRequired,
 		} ).isRequired,
-		pageSize: React.PropTypes.number,
-		initialSize: React.PropTypes.number,
-		showCommentCount: React.PropTypes.bool,
-		startingCommentId: React.PropTypes.number,
-		commentCount: React.PropTypes.number,
-		maxDepth: React.PropTypes.number,
-		showNestingReplyArrow: React.PropTypes.bool,
+		pageSize: PropTypes.number,
+		initialSize: PropTypes.number,
+		showCommentCount: PropTypes.bool,
+		startingCommentId: PropTypes.number,
+		commentCount: PropTypes.number,
+		maxDepth: PropTypes.number,
+		showNestingReplyArrow: PropTypes.bool,
 
 		// connect()ed props:
-		commentsTree: React.PropTypes.object,
-		requestPostComments: React.PropTypes.func.isRequired,
-		requestComment: React.PropTypes.func.isRequired,
+		commentsTree: PropTypes.object,
+		requestPostComments: PropTypes.func.isRequired,
+		requestComment: PropTypes.func.isRequired,
 	};
 
 	static defaultProps = {

--- a/client/blocks/comments/post-comment-with-error.jsx
+++ b/client/blocks/comments/post-comment-with-error.jsx
@@ -1,6 +1,7 @@
-/***
+/**
  * External dependencies
  */
+import PropTypes from 'prop-types';
 import React from 'react';
 
 /***
@@ -48,10 +49,10 @@ export default class PostCommentWithError extends React.Component {
 }
 
 PostCommentWithError.propTypes = {
-	post: React.PropTypes.object.isRequired,
-	repliesList: React.PropTypes.object.isRequired,
-	commentsTree: React.PropTypes.object.isRequired,
-	onUpdateCommentText: React.PropTypes.func.isRequired,
-	commentId: React.PropTypes.oneOfType( [ React.PropTypes.string, React.PropTypes.number ] )
+	post: PropTypes.object.isRequired,
+	repliesList: PropTypes.object.isRequired,
+	commentsTree: PropTypes.object.isRequired,
+	onUpdateCommentText: PropTypes.func.isRequired,
+	commentId: PropTypes.oneOfType( [ PropTypes.string, PropTypes.number ] )
 		.isRequired,
 };

--- a/client/blocks/comments/post-trackback.jsx
+++ b/client/blocks/comments/post-trackback.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import PropTypes from 'prop-types';
 import React from 'react';
 import Gridicon from 'gridicons';
 import { get } from 'lodash';
@@ -55,6 +56,6 @@ export default class PostTrackback extends React.Component {
 }
 
 PostTrackback.propTypes = {
-	commentId: React.PropTypes.number,
-	commentsTree: React.PropTypes.object,
+	commentId: PropTypes.number,
+	commentsTree: PropTypes.object,
 };

--- a/client/blocks/design-menu/design-menu-panel/index.jsx
+++ b/client/blocks/design-menu/design-menu-panel/index.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import PropTypes from 'prop-types';
 import React from 'react';
 
 /**
@@ -8,10 +9,10 @@ import React from 'react';
  */
 import Card from 'components/card';
 
-const DesignMenuPanel = React.createClass( {
-	propTypes: {
-		label: React.PropTypes.string.isRequired,
-	},
+class DesignMenuPanel extends React.Component {
+	static propTypes = {
+		label: PropTypes.string.isRequired,
+	};
 
 	render() {
 		return (
@@ -25,6 +26,6 @@ const DesignMenuPanel = React.createClass( {
 			</div>
 		);
 	}
-} );
+}
 
 export default DesignMenuPanel;

--- a/client/blocks/disconnect-jetpack-dialog/index.jsx
+++ b/client/blocks/disconnect-jetpack-dialog/index.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { PropTypes, PureComponent } from 'react';
+import PropTypes from 'prop-types';
+import React, { PureComponent } from 'react';
 import Gridicon from 'gridicons';
 import { connect } from 'react-redux';
 

--- a/client/blocks/dismissible-card/index.jsx
+++ b/client/blocks/dismissible-card/index.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { noop, flow } from 'lodash';

--- a/client/blocks/domain-to-plan-nudge/index.jsx
+++ b/client/blocks/domain-to-plan-nudge/index.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { PropTypes, Component } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
 

--- a/client/blocks/edit-gravatar/index.jsx
+++ b/client/blocks/edit-gravatar/index.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import classnames from 'classnames';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';

--- a/client/blocks/eligibility-warnings/index.jsx
+++ b/client/blocks/eligibility-warnings/index.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { get, includes, noop, partition } from 'lodash';

--- a/client/blocks/follow-button/docs/example.jsx
+++ b/client/blocks/follow-button/docs/example.jsx
@@ -10,7 +10,7 @@ import FollowButton from 'blocks/follow-button/button';
 import Card from 'components/card/compact';
 
 export default class extends React.PureComponent {
-    static displayName = 'FollowButton';
+	static displayName = 'FollowButton';
 
 	render() {
 		return (

--- a/client/blocks/follow-button/docs/example.jsx
+++ b/client/blocks/follow-button/docs/example.jsx
@@ -9,8 +9,8 @@ import React from 'react';
 import FollowButton from 'blocks/follow-button/button';
 import Card from 'components/card/compact';
 
-export default class extends React.PureComponent {
-	static displayName = 'FollowButton';
+export default class FollowButtonExample extends React.PureComponent {
+	static displayName = 'FollowButtonExample';
 
 	render() {
 		return (

--- a/client/blocks/follow-button/docs/example.jsx
+++ b/client/blocks/follow-button/docs/example.jsx
@@ -2,7 +2,6 @@
 * External dependencies
 */
 import React from 'react';
-import PureRenderMixin from 'react-pure-render/mixin';
 
 /**
  * Internal dependencies
@@ -10,10 +9,8 @@ import PureRenderMixin from 'react-pure-render/mixin';
 import FollowButton from 'blocks/follow-button/button';
 import Card from 'components/card/compact';
 
-export default React.createClass( {
-	displayName: 'FollowButton',
-
-	mixins: [ PureRenderMixin ],
+export default class extends React.PureComponent {
+    static displayName = 'FollowButton';
 
 	render() {
 		return (
@@ -33,5 +30,5 @@ export default React.createClass( {
 				</Card>
 			</div>
 		);
-	},
-} );
+	}
+}

--- a/client/blocks/follow-button/index.jsx
+++ b/client/blocks/follow-button/index.jsx
@@ -1,6 +1,7 @@
 /**
  * External Dependencies
  */
+import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { noop, omitBy, isUndefined } from 'lodash';
 import { connect } from 'react-redux';
@@ -14,13 +15,13 @@ import { follow, unfollow } from 'state/reader/follows/actions';
 
 class FollowButtonContainer extends Component {
 	static propTypes = {
-		siteUrl: React.PropTypes.string.isRequired,
-		iconSize: React.PropTypes.number,
-		onFollowToggle: React.PropTypes.func,
-		followLabel: React.PropTypes.string,
-		followingLabel: React.PropTypes.string,
-		feedId: React.PropTypes.number,
-		siteId: React.PropTypes.number,
+		siteUrl: PropTypes.string.isRequired,
+		iconSize: PropTypes.number,
+		onFollowToggle: PropTypes.func,
+		followLabel: PropTypes.string,
+		followingLabel: PropTypes.string,
+		feedId: PropTypes.number,
+		siteId: PropTypes.number,
 	};
 
 	static defaultProps = {

--- a/client/blocks/image-editor/image-editor-buttons.jsx
+++ b/client/blocks/image-editor/image-editor-buttons.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { noop } from 'lodash';
 import { localize } from 'i18n-calypso';

--- a/client/blocks/image-editor/image-editor-canvas.jsx
+++ b/client/blocks/image-editor/image-editor-canvas.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import ReactDom from 'react-dom';
 import { connect } from 'react-redux';
 import { noop, startsWith } from 'lodash';

--- a/client/blocks/image-editor/image-editor-crop.jsx
+++ b/client/blocks/image-editor/image-editor-crop.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { isEqual, noop } from 'lodash';
 import classNames from 'classnames';

--- a/client/blocks/image-editor/image-editor-toolbar.jsx
+++ b/client/blocks/image-editor/image-editor-toolbar.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import {
 	noop,

--- a/client/blocks/like-button/button.jsx
+++ b/client/blocks/like-button/button.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
 import classNames from 'classnames';
 import { omitBy, isNull } from 'lodash';
@@ -13,17 +14,17 @@ import LikeIcons from './icons';
 
 class LikeButton extends PureComponent {
 	static propTypes = {
-		liked: React.PropTypes.bool,
-		showZeroCount: React.PropTypes.bool,
-		likeCount: React.PropTypes.number,
-		showLabel: React.PropTypes.bool,
-		tagName: React.PropTypes.string,
-		onLikeToggle: React.PropTypes.func,
-		likedLabel: React.PropTypes.string,
-		iconSize: React.PropTypes.number,
-		animateLike: React.PropTypes.bool,
-		postId: React.PropTypes.number,
-		slug: React.PropTypes.string,
+		liked: PropTypes.bool,
+		showZeroCount: PropTypes.bool,
+		likeCount: PropTypes.number,
+		showLabel: PropTypes.bool,
+		tagName: PropTypes.string,
+		onLikeToggle: PropTypes.func,
+		likedLabel: PropTypes.string,
+		iconSize: PropTypes.number,
+		animateLike: PropTypes.bool,
+		postId: PropTypes.number,
+		slug: PropTypes.string,
 	};
 
 	static defaultProps = {

--- a/client/blocks/like-button/icons.jsx
+++ b/client/blocks/like-button/icons.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import PropTypes from 'prop-types';
 import React from 'react';
 import Gridicon from 'gridicons';
 
@@ -12,7 +13,7 @@ const LikeIcons = ( { size } ) => (
 );
 
 LikeIcons.propTypes = {
-	size: React.PropTypes.number,
+	size: PropTypes.number,
 };
 
 LikeIcons.defaultProps = {

--- a/client/blocks/like-button/index.jsx
+++ b/client/blocks/like-button/index.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
 import { omit, noop } from 'lodash';
 
@@ -14,11 +15,11 @@ import LikeStore from 'lib/like-store/like-store';
 
 class LikeButtonContainer extends PureComponent {
 	static propTypes = {
-		siteId: React.PropTypes.number.isRequired,
-		postId: React.PropTypes.number.isRequired,
-		showZeroCount: React.PropTypes.bool,
-		tagName: React.PropTypes.string,
-		onLikeToggle: React.PropTypes.func,
+		siteId: PropTypes.number.isRequired,
+		postId: PropTypes.number.isRequired,
+		showZeroCount: PropTypes.bool,
+		tagName: PropTypes.string,
+		onLikeToggle: PropTypes.func,
 	};
 
 	static defaultProps = {

--- a/client/blocks/login/error-notice.jsx
+++ b/client/blocks/login/error-notice.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 
 /**

--- a/client/blocks/login/social-connect-prompt.jsx
+++ b/client/blocks/login/social-connect-prompt.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { capitalize } from 'lodash';

--- a/client/blocks/login/social.jsx
+++ b/client/blocks/login/social.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import GoogleLoginButton from 'components/social-buttons/google';
 import { localize } from 'i18n-calypso';

--- a/client/blocks/login/two-factor-authentication/two-factor-actions.jsx
+++ b/client/blocks/login/two-factor-authentication/two-factor-actions.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import page from 'page';
 

--- a/client/blocks/nps-survey/index.jsx
+++ b/client/blocks/nps-survey/index.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';

--- a/client/blocks/nps-survey/recommendation-option.jsx
+++ b/client/blocks/nps-survey/recommendation-option.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import classNames from 'classnames';
 
 class RecommendationOption extends Component {

--- a/client/blocks/nps-survey/recommendation-select.jsx
+++ b/client/blocks/nps-survey/recommendation-select.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { PropTypes, PureComponent } from 'react';
+import PropTypes from 'prop-types';
+import React, { PureComponent } from 'react';
 import { range } from 'lodash';
 
 /**

--- a/client/blocks/plan-storage/bar.jsx
+++ b/client/blocks/plan-storage/bar.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
 import filesize from 'filesize';

--- a/client/blocks/plan-thank-you-card/index.jsx
+++ b/client/blocks/plan-thank-you-card/index.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { PropTypes, Component } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
 import classnames from 'classnames';

--- a/client/blocks/post-actions/index.jsx
+++ b/client/blocks/post-actions/index.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
@@ -91,12 +92,12 @@ const PostActions = ( {
 };
 
 PostActions.propTypes = {
-	className: React.PropTypes.string,
-	post: React.PropTypes.object.isRequired,
-	siteId: React.PropTypes.number.isRequired,
-	toggleComments: React.PropTypes.func.isRequired,
-	trackRelativeTimeStatusOnClick: React.PropTypes.func,
-	trackTotalViewsOnClick: React.PropTypes.func,
+	className: PropTypes.string,
+	post: PropTypes.object.isRequired,
+	siteId: PropTypes.number.isRequired,
+	toggleComments: PropTypes.func.isRequired,
+	trackRelativeTimeStatusOnClick: PropTypes.func,
+	trackTotalViewsOnClick: PropTypes.func,
 };
 
 const mapStateToProps = ( state, { siteId, post } ) => {

--- a/client/blocks/post-edit-button/docs/example.jsx
+++ b/client/blocks/post-edit-button/docs/example.jsx
@@ -9,8 +9,8 @@ import React from 'react';
 import Card from 'components/card';
 import PostEditButton from 'blocks/post-edit-button';
 
-export default class extends React.PureComponent {
-	static displayName = 'PostEditButton';
+export default class PostEditButtonExample extends React.PureComponent {
+	static displayName = 'PostEditButtonExample';
 
 	render() {
 		const post = { ID: 123, type: 'post' };

--- a/client/blocks/post-edit-button/docs/example.jsx
+++ b/client/blocks/post-edit-button/docs/example.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import React from 'react';
-import PureRenderMixin from 'react-pure-render/mixin';
 
 /**
  * Internal dependencies
@@ -10,10 +9,8 @@ import PureRenderMixin from 'react-pure-render/mixin';
 import Card from 'components/card';
 import PostEditButton from 'blocks/post-edit-button';
 
-export default React.createClass( {
-	displayName: 'PostEditButton',
-
-	mixins: [ PureRenderMixin ],
+export default class extends React.PureComponent {
+    static displayName = 'PostEditButton';
 
 	render() {
 		const post = { ID: 123, type: 'post' };
@@ -27,4 +24,4 @@ export default React.createClass( {
 			</div>
 		);
 	}
-} );
+}

--- a/client/blocks/post-edit-button/docs/example.jsx
+++ b/client/blocks/post-edit-button/docs/example.jsx
@@ -10,7 +10,7 @@ import Card from 'components/card';
 import PostEditButton from 'blocks/post-edit-button';
 
 export default class extends React.PureComponent {
-    static displayName = 'PostEditButton';
+	static displayName = 'PostEditButton';
 
 	render() {
 		const post = { ID: 123, type: 'post' };

--- a/client/blocks/post-edit-button/index.jsx
+++ b/client/blocks/post-edit-button/index.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import PropTypes from 'prop-types';
 import React from 'react';
 import Gridicon from 'gridicons';
 
@@ -21,10 +22,10 @@ const PostEditButton = ( { post, site, iconSize, onClick, translate } ) => {
 };
 
 PostEditButton.propTypes = {
-	post: React.PropTypes.object.isRequired,
-	site: React.PropTypes.object.isRequired,
-	iconSize: React.PropTypes.number,
-	onClick: React.PropTypes.func
+	post: PropTypes.object.isRequired,
+	site: PropTypes.object.isRequired,
+	iconSize: PropTypes.number,
+	onClick: PropTypes.func
 };
 
 PostEditButton.defaultProps = {

--- a/client/blocks/post-share/connections-list.jsx
+++ b/client/blocks/post-share/connections-list.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { PureComponent, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { PureComponent } from 'react';
 import { localize } from 'i18n-calypso';
 
 /**

--- a/client/blocks/post-share/index.jsx
+++ b/client/blocks/post-share/index.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
 import { get, includes, map, concat } from 'lodash';

--- a/client/blocks/post-share/publicize-actions-list.jsx
+++ b/client/blocks/post-share/publicize-actions-list.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { PureComponent, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { PureComponent } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'gridicons';

--- a/client/blocks/post-share/sharing-preview-modal.jsx
+++ b/client/blocks/post-share/sharing-preview-modal.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import Gridicon from 'gridicons';
 
 /**

--- a/client/blocks/post-status/index.jsx
+++ b/client/blocks/post-status/index.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';

--- a/client/blocks/product-purchase-features/product-purchase-features-list/index.jsx
+++ b/client/blocks/product-purchase-features/product-purchase-features-list/index.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { partial } from 'lodash';
 

--- a/client/blocks/reader-author-link/index.jsx
+++ b/client/blocks/reader-author-link/index.jsx
@@ -2,6 +2,7 @@
 /**
  * External dependencies
  */
+import PropTypes from 'prop-types';
 import React from 'react';
 import { get, noop } from 'lodash';
 import classnames from 'classnames';
@@ -57,9 +58,9 @@ const ReaderAuthorLink = ( { author, post, siteUrl, children, className, onClick
 };
 
 ReaderAuthorLink.propTypes = {
-	author: React.PropTypes.object.isRequired,
-	post: React.PropTypes.object, // for stats only,
-	siteUrl: React.PropTypes.string, // used instead of author.URL if present
+	author: PropTypes.object.isRequired,
+	post: PropTypes.object, // for stats only,
+	siteUrl: PropTypes.string, // used instead of author.URL if present
 };
 
 ReaderAuthorLink.defaultProps = {

--- a/client/blocks/reader-avatar/index.jsx
+++ b/client/blocks/reader-avatar/index.jsx
@@ -2,6 +2,7 @@
 /**
  * External dependencies
  */
+import PropTypes from 'prop-types';
 import React from 'react';
 import { startsWith, endsWith, noop, get } from 'lodash';
 
@@ -105,14 +106,14 @@ const ReaderAvatar = ( {
 };
 
 ReaderAvatar.propTypes = {
-	author: React.PropTypes.object,
-	siteIcon: React.PropTypes.string,
-	feedIcon: React.PropTypes.string,
-	siteUrl: React.PropTypes.string,
-	preferGravatar: React.PropTypes.bool,
-	showPlaceholder: React.PropTypes.bool,
-	isCompact: React.PropTypes.bool,
-	onClick: React.PropTypes.func,
+	author: PropTypes.object,
+	siteIcon: PropTypes.string,
+	feedIcon: PropTypes.string,
+	siteUrl: PropTypes.string,
+	preferGravatar: PropTypes.bool,
+	showPlaceholder: PropTypes.bool,
+	isCompact: PropTypes.bool,
+	onClick: PropTypes.func,
 };
 
 ReaderAvatar.defaultProps = {

--- a/client/blocks/reader-combined-card/index.jsx
+++ b/client/blocks/reader-combined-card/index.jsx
@@ -2,6 +2,7 @@
 /**
  * External Dependencies
  */
+import PropTypes from 'prop-types';
 import React from 'react';
 import { get, size, filter, isEmpty } from 'lodash';
 import { localize } from 'i18n-calypso';
@@ -23,15 +24,15 @@ import FollowButton from 'reader/follow-button';
 
 class ReaderCombinedCard extends React.Component {
 	static propTypes = {
-		posts: React.PropTypes.array.isRequired,
-		site: React.PropTypes.object,
-		feed: React.PropTypes.object,
-		onClick: React.PropTypes.func,
-		isDiscover: React.PropTypes.bool,
-		postKey: React.PropTypes.object.isRequired,
-		selectedPostKey: React.PropTypes.object,
-		showFollowButton: React.PropTypes.bool,
-		followSource: React.PropTypes.string,
+		posts: PropTypes.array.isRequired,
+		site: PropTypes.object,
+		feed: PropTypes.object,
+		onClick: PropTypes.func,
+		isDiscover: PropTypes.bool,
+		postKey: PropTypes.object.isRequired,
+		selectedPostKey: PropTypes.object,
+		showFollowButton: PropTypes.bool,
+		followSource: PropTypes.string,
 	};
 
 	static defaultProps = {

--- a/client/blocks/reader-combined-card/post.jsx
+++ b/client/blocks/reader-combined-card/post.jsx
@@ -2,6 +2,7 @@
 /**
  * External Dependencies
  */
+import PropTypes from 'prop-types';
 import React from 'react';
 import { has } from 'lodash';
 import ReactDom from 'react-dom';
@@ -27,10 +28,10 @@ import { isAuthorNameBlacklisted } from 'reader/lib/author-name-blacklist';
 
 class ReaderCombinedCardPost extends React.Component {
 	static propTypes = {
-		post: React.PropTypes.object.isRequired,
-		streamUrl: React.PropTypes.string,
-		onClick: React.PropTypes.func,
-		showFeaturedAsset: React.PropTypes.bool,
+		post: PropTypes.object.isRequired,
+		streamUrl: PropTypes.string,
+		onClick: PropTypes.func,
+		showFeaturedAsset: PropTypes.bool,
 	};
 
 	static defaultProps = {

--- a/client/blocks/reader-email-settings/index.jsx
+++ b/client/blocks/reader-email-settings/index.jsx
@@ -2,7 +2,8 @@
 /**
  * External dependencies
  */
-import React, { PropTypes, Component } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { find, get } from 'lodash';
 

--- a/client/blocks/reader-excerpt/index.jsx
+++ b/client/blocks/reader-excerpt/index.jsx
@@ -2,6 +2,7 @@
 /**
  * External Dependencies
  */
+import PropTypes from 'prop-types';
 import React from 'react';
 
 /**
@@ -31,8 +32,8 @@ const ReaderExcerpt = ( { post, isDiscover } ) => {
 };
 
 ReaderExcerpt.propTypes = {
-	post: React.PropTypes.object.isRequired,
-	isDiscover: React.PropTypes.bool,
+	post: PropTypes.object.isRequired,
+	isDiscover: PropTypes.bool,
 };
 
 export default ReaderExcerpt;

--- a/client/blocks/reader-export-button/index.jsx
+++ b/client/blocks/reader-export-button/index.jsx
@@ -2,6 +2,7 @@
 /**
  * External dependencies
  */
+import PropTypes from 'prop-types';
 import React from 'react';
 import Blob from 'blob';
 import { saveAs } from 'browser-filesaver';
@@ -17,7 +18,7 @@ import { errorNotice } from 'state/notices/actions';
 
 class ReaderExportButton extends React.Component {
 	static propTypes = {
-		saveAs: React.PropTypes.string,
+		saveAs: PropTypes.string,
 	};
 
 	static defaultProps = {

--- a/client/blocks/reader-featured-image/index.jsx
+++ b/client/blocks/reader-featured-image/index.jsx
@@ -2,6 +2,7 @@
 /**
  * External Dependencies
  */
+import PropTypes from 'prop-types';
 import React from 'react';
 import { noop } from 'lodash';
 import classnames from 'classnames';
@@ -34,9 +35,9 @@ const ReaderFeaturedImage = ( { imageUrl, imageWidth, href, children, onClick, c
 };
 
 ReaderFeaturedImage.propTypes = {
-	imageUrl: React.PropTypes.string,
-	href: React.PropTypes.string,
-	onClick: React.PropTypes.func,
+	imageUrl: PropTypes.string,
+	href: PropTypes.string,
+	onClick: PropTypes.func,
 };
 
 ReaderFeaturedImage.defaultProps = {

--- a/client/blocks/reader-featured-video/index.jsx
+++ b/client/blocks/reader-featured-video/index.jsx
@@ -2,6 +2,7 @@
 /**
  * External Dependencies
  */
+import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 import { throttle, constant, noop } from 'lodash';
@@ -19,16 +20,16 @@ import QueryReaderThumbnail from 'components/data/query-reader-thumbnails';
 
 class ReaderFeaturedVideo extends React.Component {
 	static propTypes = {
-		thumbnailUrl: React.PropTypes.string,
-		autoplayIframe: React.PropTypes.string,
-		iframe: React.PropTypes.string,
-		videoEmbed: React.PropTypes.object,
-		allowPlaying: React.PropTypes.bool,
-		onThumbnailClick: React.PropTypes.func,
-		className: React.PropTypes.string,
-		href: React.PropTypes.string,
-		isExpanded: React.PropTypes.bool,
-		expandCard: React.PropTypes.func,
+		thumbnailUrl: PropTypes.string,
+		autoplayIframe: PropTypes.string,
+		iframe: PropTypes.string,
+		videoEmbed: PropTypes.object,
+		allowPlaying: PropTypes.bool,
+		onThumbnailClick: PropTypes.func,
+		className: PropTypes.string,
+		href: PropTypes.string,
+		isExpanded: PropTypes.bool,
+		expandCard: PropTypes.func,
 	};
 
 	static defaultProps = {

--- a/client/blocks/reader-feed-header/badge.jsx
+++ b/client/blocks/reader-feed-header/badge.jsx
@@ -2,6 +2,7 @@
 /**
  * External Dependencies
  */
+import PropTypes from 'prop-types';
 import React from 'react';
 import Gridicon from 'gridicons';
 
@@ -20,7 +21,7 @@ const ReaderFeedHeaderSiteBadge = ( { site } ) => {
 };
 
 ReaderFeedHeaderSiteBadge.propTypes = {
-	site: React.PropTypes.object,
+	site: PropTypes.object,
 };
 
 export default ReaderFeedHeaderSiteBadge;

--- a/client/blocks/reader-full-post/back.jsx
+++ b/client/blocks/reader-full-post/back.jsx
@@ -2,6 +2,7 @@
 /**
  * External dependencies
  */
+import PropTypes from 'prop-types';
 import React from 'react';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'gridicons';
@@ -25,7 +26,7 @@ const ReaderFullPostBack = ( { onBackClick, translate } ) => {
 };
 
 ReaderFullPostBack.propTypes = {
-	onBackClick: React.PropTypes.func.isRequired,
+	onBackClick: PropTypes.func.isRequired,
 };
 
 export default localize( ReaderFullPostBack );

--- a/client/blocks/reader-full-post/docs/header-example.jsx
+++ b/client/blocks/reader-full-post/docs/header-example.jsx
@@ -10,7 +10,7 @@ import PureRenderMixin from 'react-pure-render/mixin';
 import ReaderFullPostHeader from 'blocks/reader-full-post/header';
 import Card from 'components/card';
 
-module.exports = React.createClass( {
+export default React.createClass( {
 	displayName: 'ReaderFullPostHeader',
 
 	mixins: [ PureRenderMixin ],

--- a/client/blocks/reader-full-post/docs/header-example.jsx
+++ b/client/blocks/reader-full-post/docs/header-example.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import React from 'react';
-import PureRenderMixin from 'react-pure-render/mixin';
 
 /**
  * Internal dependencies
@@ -10,10 +9,8 @@ import PureRenderMixin from 'react-pure-render/mixin';
 import ReaderFullPostHeader from 'blocks/reader-full-post/header';
 import Card from 'components/card';
 
-export default React.createClass( {
-	displayName: 'ReaderFullPostHeader',
-
-	mixins: [ PureRenderMixin ],
+export default class extends React.PureComponent {
+    static displayName = 'ReaderFullPostHeader';
 
 	render() {
 		const post = {
@@ -54,5 +51,5 @@ export default React.createClass( {
 				<ReaderFullPostHeader post={ post } />
 			</Card>
 		);
-	},
-} );
+	}
+}

--- a/client/blocks/reader-full-post/docs/header-example.jsx
+++ b/client/blocks/reader-full-post/docs/header-example.jsx
@@ -10,7 +10,7 @@ import ReaderFullPostHeader from 'blocks/reader-full-post/header';
 import Card from 'components/card';
 
 export default class extends React.PureComponent {
-    static displayName = 'ReaderFullPostHeader';
+	static displayName = 'ReaderFullPostHeader';
 
 	render() {
 		const post = {

--- a/client/blocks/reader-full-post/docs/header-example.jsx
+++ b/client/blocks/reader-full-post/docs/header-example.jsx
@@ -9,8 +9,8 @@ import React from 'react';
 import ReaderFullPostHeader from 'blocks/reader-full-post/header';
 import Card from 'components/card';
 
-export default class extends React.PureComponent {
-	static displayName = 'ReaderFullPostHeader';
+export default class ReaderFullPostHeaderExample extends React.PureComponent {
+	static displayName = 'ReaderFullPostHeaderExample';
 
 	render() {
 		const post = {

--- a/client/blocks/reader-full-post/header-tags.jsx
+++ b/client/blocks/reader-full-post/header-tags.jsx
@@ -2,6 +2,7 @@
 /**
  * External dependencies
  */
+import PropTypes from 'prop-types';
 import React from 'react';
 import { take, map, values } from 'lodash';
 
@@ -26,7 +27,7 @@ const ReaderFullPostHeaderTags = ( { tags } ) => {
 };
 
 ReaderFullPostHeaderTags.propTypes = {
-	tags: React.PropTypes.object.isRequired,
+	tags: PropTypes.object.isRequired,
 };
 
 export default ReaderFullPostHeaderTags;

--- a/client/blocks/reader-full-post/header.jsx
+++ b/client/blocks/reader-full-post/header.jsx
@@ -2,6 +2,7 @@
 /**
  * External dependencies
  */
+import PropTypes from 'prop-types';
 import React from 'react';
 import { keys, trim } from 'lodash';
 import classNames from 'classnames';
@@ -83,8 +84,8 @@ const ReaderFullPostHeader = ( { post, referralPost } ) => {
 };
 
 ReaderFullPostHeader.propTypes = {
-	post: React.PropTypes.object.isRequired,
-	referralPost: React.PropTypes.object,
+	post: PropTypes.object.isRequired,
+	referralPost: PropTypes.object,
 };
 
 export default ReaderFullPostHeader;

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -2,6 +2,7 @@
 /**
  * External Dependencies
  */
+import PropTypes from 'prop-types';
 import React from 'react';
 import ReactDom from 'react-dom';
 import { connect } from 'react-redux';
@@ -72,9 +73,9 @@ import config from 'config';
 
 export class FullPostView extends React.Component {
 	static propTypes = {
-		post: React.PropTypes.object.isRequired,
-		onClose: React.PropTypes.func.isRequired,
-		referralPost: React.PropTypes.object,
+		post: PropTypes.object.isRequired,
+		onClose: PropTypes.func.isRequired,
+		referralPost: PropTypes.object,
 	};
 
 	hasScrolledToCommentAnchor = false;
@@ -484,11 +485,11 @@ export default class FullPostFluxContainer extends React.Component {
 	}
 
 	static propTypes = {
-		blogId: React.PropTypes.string,
-		postId: React.PropTypes.string.isRequired,
-		onClose: React.PropTypes.func.isRequired,
-		onPostNotFound: React.PropTypes.func.isRequired,
-		referral: React.PropTypes.object,
+		blogId: PropTypes.string,
+		postId: PropTypes.string.isRequired,
+		onClose: PropTypes.func.isRequired,
+		onPostNotFound: PropTypes.func.isRequired,
+		referral: PropTypes.object,
 	};
 
 	getStateFromStores( props = this.props ) {

--- a/client/blocks/reader-full-post/unavailable.jsx
+++ b/client/blocks/reader-full-post/unavailable.jsx
@@ -2,6 +2,7 @@
 /**
  * External dependencies
  */
+import PropTypes from 'prop-types';
 import React from 'react';
 import config from 'config';
 import { localize } from 'i18n-calypso';
@@ -39,8 +40,8 @@ const ReaderFullPostUnavailable = ( { post, onBackClick, translate } ) => {
 };
 
 ReaderFullPostUnavailable.propTypes = {
-	post: React.PropTypes.object.isRequired,
-	onBackClick: React.PropTypes.func.isRequired,
+	post: PropTypes.object.isRequired,
+	onBackClick: PropTypes.func.isRequired,
 };
 
 ReaderFullPostUnavailable.defaultProps = {

--- a/client/blocks/reader-import-button/index.jsx
+++ b/client/blocks/reader-import-button/index.jsx
@@ -2,6 +2,7 @@
 /**
  * External dependencies
  */
+import PropTypes from 'prop-types';
 import React from 'react';
 import { noop } from 'lodash';
 import { localize } from 'i18n-calypso';
@@ -17,7 +18,7 @@ import { successNotice, errorNotice } from 'state/notices/actions';
 
 class ReaderImportButton extends React.Component {
 	static propTypes = {
-		onProgress: React.PropTypes.func,
+		onProgress: PropTypes.func,
 	};
 
 	static defaultProps = {

--- a/client/blocks/reader-post-actions/index.jsx
+++ b/client/blocks/reader-post-actions/index.jsx
@@ -2,6 +2,7 @@
 /**
  * External dependencies
  */
+import PropTypes from 'prop-types';
 import React from 'react';
 import classnames from 'classnames';
 
@@ -116,15 +117,15 @@ const ReaderPostActions = props => {
 };
 
 ReaderPostActions.propTypes = {
-	post: React.PropTypes.object.isRequired,
-	site: React.PropTypes.object,
-	onCommentClick: React.PropTypes.func,
-	showEdit: React.PropTypes.bool,
-	iconSize: React.PropTypes.number,
-	showMenu: React.PropTypes.bool,
-	showMenuFollow: React.PropTypes.bool,
-	visitUrl: React.PropTypes.string,
-	fullPost: React.PropTypes.bool,
+	post: PropTypes.object.isRequired,
+	site: PropTypes.object,
+	onCommentClick: PropTypes.func,
+	showEdit: PropTypes.bool,
+	iconSize: PropTypes.number,
+	showMenu: PropTypes.bool,
+	showMenuFollow: PropTypes.bool,
+	visitUrl: PropTypes.string,
+	fullPost: PropTypes.bool,
 };
 
 ReaderPostActions.defaultProps = {

--- a/client/blocks/reader-post-card/blocked.jsx
+++ b/client/blocks/reader-post-card/blocked.jsx
@@ -2,6 +2,7 @@
 /**
  * External dependencies
  */
+import PropTypes from 'prop-types';
 import React from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
@@ -16,7 +17,7 @@ import { bumpStat, recordGoogleEvent } from 'state/analytics/actions';
 
 class PostBlocked extends React.Component {
 	static propTypes = {
-		post: React.PropTypes.object,
+		post: PropTypes.object,
 	};
 
 	unblock = () => {

--- a/client/blocks/reader-post-card/byline.jsx
+++ b/client/blocks/reader-post-card/byline.jsx
@@ -2,6 +2,7 @@
 /**
  * External Dependencies
  */
+import PropTypes from 'prop-types';
 import React from 'react';
 import { get, has, map, take, values } from 'lodash';
 import Gridicon from 'gridicons';
@@ -54,12 +55,12 @@ class TagLink extends React.Component {
 
 class PostByline extends React.Component {
 	static propTypes = {
-		post: React.PropTypes.object.isRequired,
-		site: React.PropTypes.object,
-		feed: React.PropTypes.object,
-		isDiscoverPost: React.PropTypes.bool,
-		showSiteName: React.PropTypes.bool,
-		showAvatar: React.PropTypes.bool,
+		post: PropTypes.object.isRequired,
+		site: PropTypes.object,
+		feed: PropTypes.object,
+		isDiscoverPost: PropTypes.bool,
+		showSiteName: PropTypes.bool,
+		showAvatar: PropTypes.bool,
 	};
 
 	static defaultProps = {

--- a/client/blocks/reader-post-card/compact.jsx
+++ b/client/blocks/reader-post-card/compact.jsx
@@ -2,6 +2,7 @@
 /**
  * External Dependencies
  */
+import PropTypes from 'prop-types';
 import React from 'react';
 
 /**
@@ -48,9 +49,9 @@ const CompactPost = ( { post, postByline, children, isDiscover, onClick } ) => {
 };
 
 CompactPost.propTypes = {
-	post: React.PropTypes.object.isRequired,
-	postByline: React.PropTypes.object,
-	isDiscover: React.PropTypes.bool,
+	post: PropTypes.object.isRequired,
+	postByline: PropTypes.object,
+	isDiscover: PropTypes.bool,
 };
 
 export default CompactPost;

--- a/client/blocks/reader-post-card/featured-asset.jsx
+++ b/client/blocks/reader-post-card/featured-asset.jsx
@@ -2,6 +2,7 @@
 /**
  * External Dependencies
  */
+import PropTypes from 'prop-types';
 import React from 'react';
 
 /**
@@ -37,11 +38,11 @@ const FeaturedAsset = ( {
 };
 
 FeaturedAsset.propTypes = {
-	canonicalMedia: React.PropTypes.object,
-	postUrl: React.PropTypes.string,
-	allowVideoPlaying: React.PropTypes.bool,
-	onVideoThumbnailClick: React.PropTypes.func,
-	isVideoExpanded: React.PropTypes.bool,
+	canonicalMedia: PropTypes.object,
+	postUrl: PropTypes.string,
+	allowVideoPlaying: PropTypes.bool,
+	onVideoThumbnailClick: PropTypes.func,
+	isVideoExpanded: PropTypes.bool,
 };
 
 FeaturedAsset.defaultProps = {

--- a/client/blocks/reader-post-card/gallery.jsx
+++ b/client/blocks/reader-post-card/gallery.jsx
@@ -2,6 +2,7 @@
 /**
  * External Dependencies
  */
+import PropTypes from 'prop-types';
 import React from 'react';
 import { map, take, filter } from 'lodash';
 
@@ -71,8 +72,8 @@ const PostGallery = ( { post, children, isDiscover } ) => {
 };
 
 PostGallery.propTypes = {
-	post: React.PropTypes.object.isRequired,
-	isDiscover: React.PropTypes.bool,
+	post: PropTypes.object.isRequired,
+	isDiscover: PropTypes.bool,
 };
 
 export default PostGallery;

--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -2,7 +2,8 @@
 /**
  * External Dependencies
  */
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { connect } from 'react-redux';
 import { noop, truncate, get, isEmpty } from 'lodash';
 import classnames from 'classnames';

--- a/client/blocks/reader-post-card/photo.jsx
+++ b/client/blocks/reader-post-card/photo.jsx
@@ -2,6 +2,7 @@
 /**
  * External Dependencies
  */
+import PropTypes from 'prop-types';
 import React from 'react';
 import { noop, debounce } from 'lodash';
 import classnames from 'classnames';
@@ -143,10 +144,10 @@ class PostPhoto extends React.Component {
 }
 
 PostPhoto.propTypes = {
-	post: React.PropTypes.object,
-	site: React.PropTypes.object,
-	title: React.PropTypes.string,
-	onClick: React.PropTypes.func,
+	post: PropTypes.object,
+	site: PropTypes.object,
+	title: PropTypes.string,
+	onClick: PropTypes.func,
 };
 
 PostPhoto.defaultProps = {

--- a/client/blocks/reader-post-card/standard.jsx
+++ b/client/blocks/reader-post-card/standard.jsx
@@ -2,6 +2,7 @@
 /**
  * External Dependencies
  */
+import PropTypes from 'prop-types';
 import React from 'react';
 import { get, partial } from 'lodash';
 
@@ -44,8 +45,8 @@ const StandardPost = ( { post, children, isDiscover, expandCard, postKey, isExpa
 };
 
 StandardPost.propTypes = {
-	post: React.PropTypes.object.isRequired,
-	isDiscover: React.PropTypes.bool,
+	post: PropTypes.object.isRequired,
+	isDiscover: PropTypes.bool,
 };
 
 export default StandardPost;

--- a/client/blocks/reader-post-options-menu/blog-sticker-menu-item.jsx
+++ b/client/blocks/reader-post-options-menu/blog-sticker-menu-item.jsx
@@ -2,6 +2,7 @@
 /**
  * External Dependencies
  */
+import PropTypes from 'prop-types';
 import React from 'react';
 import classnames from 'classnames';
 import { connect } from 'react-redux';
@@ -14,9 +15,9 @@ import { addBlogSticker, removeBlogSticker } from 'state/sites/blog-stickers/act
 
 class ReaderPostOptionsMenuBlogStickerMenuItem extends React.Component {
 	static propTypes = {
-		blogId: React.PropTypes.number,
-		blogStickerName: React.PropTypes.string,
-		hasSticker: React.PropTypes.bool,
+		blogId: PropTypes.number,
+		blogStickerName: PropTypes.string,
+		hasSticker: PropTypes.bool,
 	};
 
 	toggleSticker = () => {

--- a/client/blocks/reader-post-options-menu/blog-stickers.jsx
+++ b/client/blocks/reader-post-options-menu/blog-stickers.jsx
@@ -2,6 +2,7 @@
 /**
  * External dependencies
  */
+import PropTypes from 'prop-types';
 import React from 'react';
 import { map, includes } from 'lodash';
 import { connect } from 'react-redux';
@@ -15,7 +16,7 @@ import ReaderPostOptionsMenuBlogStickerMenuItem from './blog-sticker-menu-item';
 
 class ReaderPostOptionsMenuBlogStickers extends React.Component {
 	static propTypes = {
-		blogId: React.PropTypes.number.isRequired,
+		blogId: PropTypes.number.isRequired,
 	};
 
 	render() {

--- a/client/blocks/reader-post-options-menu/docs/example.jsx
+++ b/client/blocks/reader-post-options-menu/docs/example.jsx
@@ -9,7 +9,7 @@ import React from 'react';
 import ReaderPostOptionsMenu from 'blocks/reader-post-options-menu';
 
 export default class extends React.Component {
-    static displayName = 'ReaderPostOptionsMenu';
+	static displayName = 'ReaderPostOptionsMenu';
 
 	render() {
 		const post = {

--- a/client/blocks/reader-post-options-menu/docs/example.jsx
+++ b/client/blocks/reader-post-options-menu/docs/example.jsx
@@ -8,8 +8,8 @@ import React from 'react';
  */
 import ReaderPostOptionsMenu from 'blocks/reader-post-options-menu';
 
-export default React.createClass( {
-	displayName: 'ReaderPostOptionsMenu',
+export default class extends React.Component {
+    static displayName = 'ReaderPostOptionsMenu';
 
 	render() {
 		const post = {
@@ -31,5 +31,5 @@ export default React.createClass( {
 				</div>
 			</div>
 		);
-	},
-} );
+	}
+}

--- a/client/blocks/reader-post-options-menu/docs/example.jsx
+++ b/client/blocks/reader-post-options-menu/docs/example.jsx
@@ -8,8 +8,8 @@ import React from 'react';
  */
 import ReaderPostOptionsMenu from 'blocks/reader-post-options-menu';
 
-export default class extends React.Component {
-	static displayName = 'ReaderPostOptionsMenu';
+export default class ReaderPostOptionsMenuExample extends React.Component {
+	static displayName = 'ReaderPostOptionsMenuExample';
 
 	render() {
 		const post = {

--- a/client/blocks/reader-post-options-menu/index.jsx
+++ b/client/blocks/reader-post-options-menu/index.jsx
@@ -2,6 +2,7 @@
 /**
  * External dependencies
  */
+import PropTypes from 'prop-types';
 import React from 'react';
 import { noop } from 'lodash';
 import page from 'page';
@@ -30,11 +31,11 @@ import ReaderPostOptionsMenuBlogStickers from './blog-stickers';
 
 class ReaderPostOptionsMenu extends React.Component {
 	static propTypes = {
-		post: React.PropTypes.object.isRequired,
-		feed: React.PropTypes.object,
-		onBlock: React.PropTypes.func,
-		showFollow: React.PropTypes.bool,
-		position: React.PropTypes.string,
+		post: PropTypes.object.isRequired,
+		feed: PropTypes.object,
+		onBlock: PropTypes.func,
+		showFollow: PropTypes.bool,
+		position: PropTypes.string,
 	};
 
 	static defaultProps = {

--- a/client/blocks/reader-recommended-sites/index.jsx
+++ b/client/blocks/reader-recommended-sites/index.jsx
@@ -2,7 +2,8 @@
 /**
  * External Dependencies
  */
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { map, partial, isEmpty } from 'lodash';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'gridicons';

--- a/client/blocks/reader-site-stream-link/docs/example.jsx
+++ b/client/blocks/reader-site-stream-link/docs/example.jsx
@@ -9,8 +9,8 @@ import React from 'react';
 import ReaderSiteStreamLink from 'blocks/reader-site-stream-link';
 import Card from 'components/card';
 
-export default React.createClass( {
-	displayName: 'ReaderSiteStreamLink',
+export default class extends React.Component {
+    static displayName = 'ReaderSiteStreamLink';
 
 	render() {
 		const feedId = 40474296;
@@ -20,5 +20,5 @@ export default React.createClass( {
 				<ReaderSiteStreamLink feedId={ feedId } siteId={ siteId }>futonbleu</ReaderSiteStreamLink>
 			</Card>
 		);
-	},
-} );
+	}
+}

--- a/client/blocks/reader-site-stream-link/docs/example.jsx
+++ b/client/blocks/reader-site-stream-link/docs/example.jsx
@@ -9,8 +9,8 @@ import React from 'react';
 import ReaderSiteStreamLink from 'blocks/reader-site-stream-link';
 import Card from 'components/card';
 
-export default class extends React.Component {
-	static displayName = 'ReaderSiteStreamLink';
+export default class ReaderSiteStreamLinkExample extends React.Component {
+	static displayName = 'ReaderSiteStreamLinkExample';
 
 	render() {
 		const feedId = 40474296;

--- a/client/blocks/reader-site-stream-link/docs/example.jsx
+++ b/client/blocks/reader-site-stream-link/docs/example.jsx
@@ -10,7 +10,7 @@ import ReaderSiteStreamLink from 'blocks/reader-site-stream-link';
 import Card from 'components/card';
 
 export default class extends React.Component {
-    static displayName = 'ReaderSiteStreamLink';
+	static displayName = 'ReaderSiteStreamLink';
 
 	render() {
 		const feedId = 40474296;

--- a/client/blocks/reader-subscription-list-item/connected.jsx
+++ b/client/blocks/reader-subscription-list-item/connected.jsx
@@ -2,7 +2,8 @@
 /**
  * External Dependencies
  */
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { localize } from 'i18n-calypso';
 import { noop } from 'lodash';
 import { connect } from 'react-redux';

--- a/client/blocks/reader-visit-link/index.jsx
+++ b/client/blocks/reader-visit-link/index.jsx
@@ -2,6 +2,7 @@
 /**
  * External dependencies
  */
+import PropTypes from 'prop-types';
 import React from 'react';
 import { noop } from 'lodash';
 
@@ -12,9 +13,9 @@ import ExternalLink from 'components/external-link';
 
 class ReaderVisitLink extends React.Component {
 	static propTypes = {
-		href: React.PropTypes.string,
-		iconSize: React.PropTypes.number,
-		onClick: React.PropTypes.func,
+		href: PropTypes.string,
+		iconSize: PropTypes.number,
+		onClick: PropTypes.func,
 	};
 
 	static defaultProps = {

--- a/client/blocks/sharing-preview-pane/index.jsx
+++ b/client/blocks/sharing-preview-pane/index.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { PureComponent, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { PureComponent } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { get, find } from 'lodash';

--- a/client/blocks/site-icon/index.jsx
+++ b/client/blocks/site-icon/index.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { connect } from 'react-redux';
 import { get } from 'lodash';
 import classNames from 'classnames';

--- a/client/blocks/site-preview/index.jsx
+++ b/client/blocks/site-preview/index.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { noop } from 'lodash';
 

--- a/client/blocks/stats-sparkline/index.jsx
+++ b/client/blocks/stats-sparkline/index.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { connect } from 'react-redux';
 import { get, mapValues, sortBy } from 'lodash';
 import { localize } from 'i18n-calypso';

--- a/client/blocks/taxonomy-manager/index.jsx
+++ b/client/blocks/taxonomy-manager/index.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { get } from 'lodash';
 

--- a/client/blocks/taxonomy-manager/list-item.jsx
+++ b/client/blocks/taxonomy-manager/list-item.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import page from 'page';
 import { connect } from 'react-redux';
 import classNames from 'classnames';

--- a/client/blocks/taxonomy-manager/list.jsx
+++ b/client/blocks/taxonomy-manager/list.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { PropTypes, Component } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';

--- a/client/blocks/term-form-dialog/index.jsx
+++ b/client/blocks/term-form-dialog/index.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { PropTypes, Component } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { get, find, noop, assign } from 'lodash';

--- a/client/blocks/upgrade-nudge-expanded/index.jsx
+++ b/client/blocks/upgrade-nudge-expanded/index.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { PropTypes, Component } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import page from 'page';

--- a/client/blocks/upload-drop-zone/index.jsx
+++ b/client/blocks/upload-drop-zone/index.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'gridicons';

--- a/client/blocks/upload-image/index.jsx
+++ b/client/blocks/upload-image/index.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import classnames from 'classnames';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';

--- a/client/blocks/url-preview/index.jsx
+++ b/client/blocks/url-preview/index.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { connect } from 'react-redux';
 import debugFactory from 'debug';
 

--- a/client/blocks/video-editor/index.jsx
+++ b/client/blocks/video-editor/index.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { get, noop } from 'lodash';
 import { localize } from 'i18n-calypso';

--- a/client/blocks/video-editor/video-editor-controls.jsx
+++ b/client/blocks/video-editor/video-editor-controls.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { noop } from 'lodash';
 import { localize } from 'i18n-calypso';
 


### PR DESCRIPTION
Retry of #17781. This takes files that @psealock has codemodded and @sirreal has 👍'd.

This change runs several codemods to achieve the following:

Before | After
------------ | -------------
`require( ... )` nested in blocks | All `require( ... )` moved to top block
`var ... = require( ... )` | `import ... from '...'`
`module.exports = ...` | `export default ...`
`this.translate` | `this.props.translate` via HOC
`React.createClass( ... )` | `class ThisComponentName extends React.Component`
`React.createClass( ... )` | `createReactClass( ... )` if unconvertible to `React.Component` subclass
`import { PropTypes } from 'react'` | `import PropTypes from 'prop-types'`