### PR TITLE
PostList: Reduxify

### DIFF
--- a/client/my-sites/posts/main.jsx
+++ b/client/my-sites/posts/main.jsx
@@ -116,6 +116,7 @@ const PostsMain = React.createClass( {
 			author,
 			category,
 			search,
+			site_visibility: ! siteId ? 'visible' : undefined,
 			status: mapStatus( statusSlug ),
 			tag,
 			type: 'post'

--- a/client/my-sites/posts/post-list.jsx
+++ b/client/my-sites/posts/post-list.jsx
@@ -87,7 +87,8 @@ class PostList extends PureComponent {
 					incrementPage={ this.incrementPage }
 					pathname={ context.pathname }
 					query={ query }
-					siteId={ siteId } />
+					siteId={ siteId }
+					statusSlug={ statusSlug } />
 			</div>
 		);
 	}
@@ -95,13 +96,20 @@ class PostList extends PureComponent {
 
 const Posts = localize( class extends Component {
 	static propTypes = {
-		author: PropTypes.number,
 		lastPage: PropTypes.bool.isRequired,
 		loading: PropTypes.bool.isRequired,
-		page: PropTypes.number.isRequired,
 		pathname: PropTypes.string.isRequired,
 		posts: PropTypes.array.isRequired,
-		search: PropTypes.string,
+		query: PropTypes.shape( {
+			page: PropTypes.number,
+			number: PropTypes.number,
+			author: PropTypes.number,
+			category: PropTypes.string,
+			search: PropTypes.string,
+			status: PropTypes.oneOf( [ 'draft,pending', 'future', 'trash', 'publish,private' ] ),
+			tag: PropTypes.string,
+			type: PropTypes.oneOf( [ 'post' ] ),
+		} ),
 		siteId: PropTypes.number,
 		hasSites: PropTypes.bool.isRequired,
 		statusSlug: PropTypes.string,
@@ -111,7 +119,6 @@ const Posts = localize( class extends Component {
 	static defaultProps = {
 		loading: false,
 		lastPage: false,
-		page: 0,
 		posts: [],
 		trackScrollPage: function() {}
 	};
@@ -161,13 +168,13 @@ const Posts = localize( class extends Component {
 			return;
 		}
 		if ( options.triggeredByScroll ) {
-			this.props.trackScrollPage( this.props.page + 1 );
+			this.props.trackScrollPage( this.props.query.page + 1 );
 		}
 		this.props.incrementPage();
 	};
 
 	getNoContentMessage = () => {
-		const { hasRecentError, siteId, search, statusSlug, translate } = this.props;
+		const { hasRecentError, query: { search }, siteId, statusSlug, translate } = this.props;
 		let attributes;
 
 		if ( search ) {
@@ -244,7 +251,7 @@ const Posts = localize( class extends Component {
 
 	renderLoadingPlaceholders = () => {
 		return (
-			<PostPlaceholder key={ 'placeholder-scroll-' + this.props.page } />
+			<PostPlaceholder key={ 'placeholder-scroll-' + this.props.query.page } />
 		);
 	};
 

--- a/client/my-sites/posts/post-list.jsx
+++ b/client/my-sites/posts/post-list.jsx
@@ -100,7 +100,6 @@ const Posts = localize( class extends Component {
 		loading: PropTypes.bool.isRequired,
 		page: PropTypes.number.isRequired,
 		pathname: PropTypes.string.isRequired,
-		postImages: PropTypes.object.isRequired,
 		posts: PropTypes.array.isRequired,
 		search: PropTypes.string,
 		siteId: PropTypes.number,
@@ -113,7 +112,6 @@ const Posts = localize( class extends Component {
 		loading: false,
 		lastPage: false,
 		page: 0,
-		postImages: {},
 		posts: [],
 		trackScrollPage: function() {}
 	};
@@ -251,7 +249,8 @@ const Posts = localize( class extends Component {
 	};
 
 	renderPost = ( post, index ) => {
-		const postImages = this.props.postImages[ post.global_ID ];
+		const { canonical_image, featured_image } = post;
+		const postImages = { canonical_image, featured_image };
 		const renderedPost = (
 			<Post
 				ref={ post.global_ID }

--- a/client/my-sites/posts/post-list.jsx
+++ b/client/my-sites/posts/post-list.jsx
@@ -72,6 +72,7 @@ class PostList extends PureComponent {
 			category,
 			order_by: statusSlug === 'drafts' ? 'modified' : undefined,
 			search,
+			site_visibility: ! siteId ? 'visible' : undefined,
 			status: mapStatus( statusSlug ),
 			tag,
 			type: 'post'

--- a/client/my-sites/posts/post-list.jsx
+++ b/client/my-sites/posts/post-list.jsx
@@ -4,7 +4,7 @@
 import React, { Component, PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { debounce, isEqual } from 'lodash';
+import { debounce, isEqual, isUndefined, omitBy } from 'lodash';
 import { localize } from 'i18n-calypso';
 import debugFactory from 'debug';
 
@@ -65,7 +65,7 @@ class PostList extends PureComponent {
 
 	render() {
 		const { author, category, context, search, siteId, statusSlug, tag } = this.props;
-		const query = {
+		const query = omitBy( {
 			page: this.state.page,
 			number: 20, // all-sites mode, i.e the /me/posts endpoint, only supports up to 20 results at a time
 			author,
@@ -76,7 +76,7 @@ class PostList extends PureComponent {
 			status: mapStatus( statusSlug ),
 			tag,
 			type: 'post'
-		};
+		}, isUndefined );
 
 		return (
 			<div>

--- a/client/my-sites/posts/post-list.jsx
+++ b/client/my-sites/posts/post-list.jsx
@@ -70,6 +70,7 @@ class PostList extends PureComponent {
 			number: 20, // all-sites mode, i.e the /me/posts endpoint, only supports up to 20 results at a time
 			author,
 			category,
+			order_by: statusSlug === 'drafts' ? 'modified' : undefined,
 			search,
 			status: mapStatus( statusSlug ),
 			tag,

--- a/client/state/posts/utils.js
+++ b/client/state/posts/utils.js
@@ -26,6 +26,8 @@ import {
 import { DEFAULT_POST_QUERY } from './constants';
 import pickCanonicalImage from 'lib/post-normalizer/rule-pick-canonical-image';
 import decodeEntities from 'lib/post-normalizer/rule-decode-entities';
+import detectMedia from 'lib/post-normalizer/rule-content-detect-media';
+import withContentDom from 'lib/post-normalizer/rule-with-content-dom';
 import stripHtml from 'lib/post-normalizer/rule-strip-html';
 
 /**
@@ -47,9 +49,10 @@ const normalizeApiFlow = flow( [
 ] );
 
 const normalizeDisplayFlow = flow( [
-	pickCanonicalImage,
 	decodeEntities,
-	stripHtml
+	stripHtml,
+	withContentDom( [ detectMedia ] ),
+	pickCanonicalImage,
 ] );
 
 /**


### PR DESCRIPTION
Pretty straightforward, with one caveat: Previously, `PostListFetcher` would provide us with a `postImages` prop fetched from `PostContentImagesStore`, while  `QueryPosts` doesn't. Fortunately, individual `post` objects have `canonical_image` and `featured_image` attrs which we can use to synthesize that `postImages` object.

To test: Verify `/posts` still works as before (single-page and multi-page mode, queries, etc).

(Rebased after merging #18113 as this was also plagued by https://github.com/Automattic/wp-calypso/pull/18034#issuecomment-329375959)