### PR TITLE
Fixing filename case that results in broken image

### DIFF
--- a/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
@@ -430,7 +430,7 @@ class SimplePaymentsDialog extends Component {
 		if ( ! shouldQuerySitePlans && ! planHasSimplePaymentsFeature ) {
 			return this.renderEmptyDialog(
 				<EmptyContent
-					illustration="/calypso/images/illustrations/type-e-Commerce.svg"
+					illustration="/calypso/images/illustrations/type-e-commerce.svg"
 					illustrationWidth={ 300 }
 					title={ translate( 'Want to add a payment button to your site?' ) }
 					action={


### PR DESCRIPTION
Quick/simple fix here - `/calypso/images/illustrations/type-e-commerce.svg` is the file that exists. The capital C in the filename here is causing the image to not load.

Fixes #18040