### PR TITLE
Fix form toggle on post sharing

### DIFF
--- a/client/components/forms/form-toggle/index.jsx
+++ b/client/components/forms/form-toggle/index.jsx
@@ -46,7 +46,10 @@ export default class FormToggle extends PureComponent {
 	};
 
 	onClick = event => {
-		event.stopPropagation();
+		if ( event ) {
+			event.stopPropagation && event.stopPropagation();
+		}
+
 		if ( ! this.props.disabled ) {
 			this.props.onChange( ! this.props.checked );
 		}

--- a/client/components/forms/form-toggle/index.jsx
+++ b/client/components/forms/form-toggle/index.jsx
@@ -45,7 +45,8 @@ export default class FormToggle extends PureComponent {
 		this.props.onKeyDown( event );
 	};
 
-	onClick = () => {
+	onClick = event => {
+		event.stopPropagation();
 		if ( ! this.props.disabled ) {
 			this.props.onChange( ! this.props.checked );
 		}

--- a/client/components/forms/form-toggle/test/index.jsx
+++ b/client/components/forms/form-toggle/test/index.jsx
@@ -40,7 +40,7 @@ describe( 'FormToggle', function() {
 				const toggle = shallow(
 					<FormToggle checked={ bool }
 						onChange={ noop } />
-        );
+				);
 				const toggleInput = toggle.find( '.form-toggle' );
 
 				assert( 0 < toggleInput.length, 'a form toggle was rendered' );
@@ -59,7 +59,7 @@ describe( 'FormToggle', function() {
 				/>,
 			);
 
-			toggle.find( '.form-toggle__switch' ).simulate( 'click' );
+			toggle.find( '.form-toggle__switch' ).simulate( 'click', { preventDefault() {} } );
 		} );
 
 		it( 'should not be disabled when disabled is false', function() {

--- a/client/components/forms/form-toggle/test/index.jsx
+++ b/client/components/forms/form-toggle/test/index.jsx
@@ -59,7 +59,7 @@ describe( 'FormToggle', function() {
 				/>,
 			);
 
-			toggle.find( '.form-toggle__switch' ).simulate( 'click', { preventDefault() {} } );
+			toggle.find( '.form-toggle__switch' ).simulate( 'click' );
 		} );
 
 		it( 'should not be disabled when disabled is false', function() {


### PR DESCRIPTION
Try to toggle social connection when sharing a post, clicking on the toggle button should now work (clicking on the label already works).

Try switching on and off toggle buttons at other places to ensure that nothing broke