### PR TITLE
Media library - header content fixes

### DIFF
--- a/client/components/data/media-list-data/index.jsx
+++ b/client/components/data/media-list-data/index.jsx
@@ -63,7 +63,7 @@ module.exports = React.createClass( {
 			query.search = props.search;
 		}
 
-		if ( props.filter ) {
+		if ( props.filter && ! props.source ) {
 			if ( props.filter === 'this-post' ) {
 				if ( props.postId ) {
 					query.post_ID = props.postId;

--- a/client/my-sites/media-library/filter-bar.jsx
+++ b/client/my-sites/media-library/filter-bar.jsx
@@ -148,6 +148,11 @@ export class MediaLibraryFilterBar extends Component {
 	}
 
 	renderPlanStorage() {
+		//hide the plan storage when viewing external sources
+		if ( this.props.source ) {
+			return null;
+		}
+
 		const eventName = 'calypso_upgrade_nudge_impression';
 		const eventProperties = { cta_name: 'plan-media-storage' };
 		return (

--- a/client/my-sites/media-library/filter-bar.jsx
+++ b/client/my-sites/media-library/filter-bar.jsx
@@ -51,7 +51,11 @@ export class MediaLibraryFilterBar extends Component {
 	};
 
 	getSearchPlaceholderText() {
-		const { filter, translate } = this.props;
+		const { filter, source, translate } = this.props;
+		if ( 'google_photos' === source ) {
+			return translate( 'Search your Google library…' );
+		}
+
 		switch ( filter ) {
 			case 'this-post':
 				return translate( 'Search media uploaded to this post…' );

--- a/client/my-sites/media-library/index.jsx
+++ b/client/my-sites/media-library/index.jsx
@@ -107,7 +107,11 @@ class MediaLibrary extends Component {
 	}
 
 	filterRequiresUpgrade() {
-		const { filter, site } = this.props;
+		const { filter, site, source } = this.props;
+		if ( source ) {
+			return false;
+		}
+
 		switch ( filter ) {
 			case 'audio':
 				return ! ( site && site.options.upgraded_filetypes_enabled || site.jetpack );

--- a/client/my-sites/media-library/list-no-content.jsx
+++ b/client/my-sites/media-library/list-no-content.jsx
@@ -21,8 +21,16 @@ class MediaLibraryListNoContent extends Component {
 	getLabel() {
 		const {
 			filter,
+			source,
 			translate,
 		} = this.props;
+
+		//TODO: handle each service with individual messages
+		if ( 'google_photos' === source ) {
+			return translate( 'You don\'t have any photos in your Google library.', {
+				comment: 'Media no results'
+			} );
+		}
 
 		switch ( filter ) {
 			case 'this-post':


### PR DESCRIPTION
For the GM project.

Fixes the following:
* an issue where selecting a non-image media type (documents, videos, audio etc) and then opening the Google Photos importer would always result in an empty page.
  * also handling the case of empty google photos library and free sites and plan upgrade nudges
* for free sites, removed the storage plan when viewing external sources (since it only relates to the WP.com-stored media)