### PR TITLE
Move Domain Connect Sync Flow from React PropTypes to prop-types

### DIFF
--- a/client/my-sites/domains/domain-management/domain-connect/domain-connect-authorize-description.jsx
+++ b/client/my-sites/domains/domain-management/domain-connect/domain-connect-authorize-description.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
 
 class DomainConnectAuthorizeDescription extends Component {

--- a/client/my-sites/domains/domain-management/domain-connect/domain-connect-authorize-footer.jsx
+++ b/client/my-sites/domains/domain-management/domain-connect/domain-connect-authorize-footer.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'gridicons';
 

--- a/client/my-sites/domains/domain-management/domain-connect/domain-connect-authorize-records.jsx
+++ b/client/my-sites/domains/domain-management/domain-connect/domain-connect-authorize-records.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
 
 /**

--- a/client/my-sites/domains/domain-management/domain-connect/domain-connect-authorize.jsx
+++ b/client/my-sites/domains/domain-management/domain-connect/domain-connect-authorize.jsx
@@ -1,6 +1,6 @@
 /**
  * External dependencies
-*/
+ */
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';

--- a/client/my-sites/domains/domain-management/domain-connect/domain-connect-authorize.jsx
+++ b/client/my-sites/domains/domain-management/domain-connect/domain-connect-authorize.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
- */
-import React, { Component, PropTypes } from 'react';
+*/
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
 
 /**


### PR DESCRIPTION
This PR is just migrating the PropTypes from the React PropTypes to PropTypes from prop-types.

 D5862-code (which is now merged), includes instructions on how to test the Domain Connect Sync Flow.