### PR TITLE
Posts: Expose upcoming shares on Posts list

### DIFF
--- a/client/my-sites/posts/post-controls.jsx
+++ b/client/my-sites/posts/post-controls.jsx
@@ -206,10 +206,12 @@ class PostControls extends Component {
 
 		return (
 			<div className={ classes }>
-				<QuerySharePostActions
-					siteId={ siteId }
-					postId={ post.ID }
-					status={ SCHEDULED } />
+				{ isEnabled( 'republicize' ) && this.props.isPublicizeEnabled &&
+					<QuerySharePostActions
+						siteId={ siteId }
+						postId={ post.ID }
+						status={ SCHEDULED } />
+				}
 				{ more.length > 0 &&
 					<ul className="posts__post-controls post-controls__pane post-controls__more-options">
 						{ this.getControlElements( more ) }

--- a/client/my-sites/posts/post-controls.jsx
+++ b/client/my-sites/posts/post-controls.jsx
@@ -11,10 +11,16 @@ import Gridicon from 'gridicons';
 /**
  * Internal dependencies
  */
+import Count from 'components/count';
 import { isEnabled } from 'config';
 import { ga } from 'lib/analytics';
+import QuerySharePostActions from 'components/data/query-share-post-actions';
+import { SCHEDULED } from 'blocks/post-share/constants';
 import { userCan } from 'lib/posts/utils';
-import { isPublicizeEnabled } from 'state/selectors';
+import {
+	getPostShareScheduledActions,
+	isPublicizeEnabled
+} from 'state/selectors';
 import { getSiteSlug, isSitePreviewable } from 'state/sites/selectors';
 
 const edit = () => ga.recordEvent( 'Posts', 'Clicked Edit Post' );
@@ -74,6 +80,7 @@ const getAvailableControls = props => {
 		if ( isEnabled( 'republicize' ) ) {
 			controls.main.push( {
 				className: 'share' + ( current === 'share' ? ' is-active' : '' ),
+				count: props.scheduledActionsCount,
 				disabled: ! props.isPublicizeEnabled,
 				icon: 'share',
 				onClick: onToggleShare,
@@ -174,8 +181,9 @@ const getControlElements = controls => controls.map( ( control, index ) =>
 			target={ control.target ? control.target : null }
 		>
 			<Gridicon icon={ control.icon } size={ 18 } />
-			<span>
+			<span className="posts__post-controls-text">
 				{ control.text }
+				{ control.count > 0 && <Count count={ control.count } /> }
 			</span>
 		</a>
 	</li>
@@ -190,6 +198,10 @@ export const PostControls = props => {
 
 	return (
 		<div className={ classes }>
+			<QuerySharePostActions
+				siteId={ props.siteId }
+				postId={ props.post.ID }
+				status={ SCHEDULED } />
 			{ more.length > 0 &&
 				<ul className="posts__post-controls post-controls__pane post-controls__more-options">
 					{ getControlElements( more ) }
@@ -224,5 +236,6 @@ PostControls.propTypes = {
 export default connect( ( state, { siteId, post } ) => ( {
 	isPreviewable: false !== isSitePreviewable( state, siteId ),
 	isPublicizeEnabled: isPublicizeEnabled( state, siteId, post.type ),
+	scheduledActionsCount: getPostShareScheduledActions( state, siteId, post.ID ).length,
 	siteSlug: getSiteSlug( state, siteId ),
 } ) )( localize( PostControls ) );

--- a/client/my-sites/posts/post-controls.jsx
+++ b/client/my-sites/posts/post-controls.jsx
@@ -1,12 +1,13 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
 import { includes, noop } from 'lodash';
 import Gridicon from 'gridicons';
+import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies
@@ -23,196 +24,204 @@ import {
 } from 'state/selectors';
 import { getSiteSlug, isSitePreviewable } from 'state/sites/selectors';
 
-const edit = () => ga.recordEvent( 'Posts', 'Clicked Edit Post' );
-const copy = () => ga.recordEvent( 'Posts', 'Clicked Copy Post' );
-const viewStats = () => ga.recordEvent( 'Posts', 'Clicked View Post Stats' );
-
-const getAvailableControls = props => {
-	const {
-		current,
-		editURL,
-		fullWidth,
-		onDelete,
-		onHideMore,
-		onPublish,
-		onRestore,
-		onShowMore,
-		onToggleShare,
-		onTrash,
-		post,
-		siteSlug,
-		translate,
-		onViewPost,
-	} = props;
-	const controls = { main: [], more: [] };
-
-	// NOTE: Currently Jetpack site posts are not returning `post.capabilities`
-	// and those posts will not have access to post management type controls
-
-	// Main Controls (not behind ... more link)
-	if ( userCan( 'edit_post', post ) ) {
-		controls.main.push( {
-			className: 'edit' + ( current === 'edit' ? ' is-active' : '' ),
-			href: editURL,
-			icon: 'pencil',
-			onClick: edit,
-			text: translate( 'Edit' ),
+class PostControls extends Component {
+	getControlElements = ( controls ) => {
+		const elements = controls.map( ( control, index ) => {
+			return (
+				<li
+					className={ classNames( { 'post-controls__disabled': control.disabled } ) }
+					key={ index }
+				>
+					<a
+						className={ `post-controls__${ control.className }` }
+						href={ control.href }
+						onClick={ control.disabled ? noop : control.onClick }
+						target={ control.target ? control.target : null }
+					>
+						<Gridicon icon={ control.icon } size={ 18 } />
+						<span className="posts__post-controls-text">
+							{ control.text }
+							{ control.count > 0 && <Count count={ control.count } /> }
+						</span>
+					</a>
+				</li>
+			);
 		} );
+
+		return elements;
 	}
 
-	if ( 'publish' === post.status ) {
-		controls.main.push( {
-			className: 'view' + ( current === 'view' ? ' is-active' : '' ),
-			href: post.URL,
-			icon: props.isPreviewable ? 'visible' : 'external',
-			onClick: onViewPost,
-			text: translate( 'View' ),
-		} );
+	getAvailableControls = () => {
+		const {
+			current,
+			editURL,
+			fullWidth,
+			onDelete,
+			onHideMore,
+			onPublish,
+			onRestore,
+			onShowMore,
+			onToggleShare,
+			onTrash,
+			post,
+			siteSlug,
+			translate,
+			onViewPost,
+		} = this.props;
+		const controls = { main: [], more: [] };
+		const edit = () => ga.recordEvent( 'Posts', 'Clicked Edit Post' );
+		const copy = () => ga.recordEvent( 'Posts', 'Clicked Copy Post' );
+		const viewStats = () => ga.recordEvent( 'Posts', 'Clicked View Post Stats' );
 
-		controls.main.push( {
-			className: 'stats' + ( current === 'stats' ? ' is-active' : '' ),
-			href: `/stats/post/${ post.ID }/${ siteSlug }`,
-			icon: 'stats-alt',
-			onClick: viewStats,
-			text: translate( 'Stats' ),
-		} );
+		// NOTE: Currently Jetpack site posts are not returning `post.capabilities`
+		// and those posts will not have access to post management type controls
 
-		if ( isEnabled( 'republicize' ) ) {
+		// Main Controls (not behind ... more link)
+		if ( userCan( 'edit_post', post ) ) {
 			controls.main.push( {
-				className: 'share' + ( current === 'share' ? ' is-active' : '' ),
-				count: props.scheduledActionsCount,
-				disabled: ! props.isPublicizeEnabled,
-				icon: 'share',
-				onClick: onToggleShare,
-				text: translate( 'Share' ),
+				className: 'edit' + ( current === 'edit' ? ' is-active' : '' ),
+				href: editURL,
+				icon: 'pencil',
+				onClick: edit,
+				text: translate( 'Edit' ),
 			} );
 		}
-	} else if ( 'trash' !== post.status ) {
-		controls.main.push( {
-			className: 'view' + ( current === 'preview' ? ' is-active' : '' ),
-			icon: props.isPreviewable ? 'visible' : 'external',
-			onClick: onViewPost,
-			text: translate( 'Preview' ),
-		} );
 
-		if ( userCan( 'publish_post', post ) ) {
+		if ( 'publish' === post.status ) {
 			controls.main.push( {
-				className: 'publish' + ( current === 'publish' ? ' is-active' : '' ),
-				icon: 'reader',
-				onClick: onPublish,
-				text: translate( 'Publish' ),
+				className: 'view' + ( current === 'view' ? ' is-active' : '' ),
+				href: post.URL,
+				icon: this.props.isPreviewable ? 'visible' : 'external',
+				onClick: onViewPost,
+				text: translate( 'View' ),
 			} );
-		}
-	} else if ( userCan( 'delete_post', post ) ) {
-		controls.main.push( {
-			className: 'restore' + ( current === 'restore' ? ' is-active' : '' ),
-			icon: 'undo',
-			onClick: onRestore,
-			text: translate( 'Restore' ),
-		} );
-	}
 
-	if ( userCan( 'delete_post', post ) ) {
-		if ( 'trash' === post.status ) {
 			controls.main.push( {
-				className: 'trash is-scary' + ( current === 'delete-permanently' ? ' is-active' : '' ),
-				icon: 'trash',
-				onClick: onDelete,
-				text: translate( 'Delete Permanently' ),
+				className: 'stats' + ( current === 'stats' ? ' is-active' : '' ),
+				href: `/stats/post/${ post.ID }/${ siteSlug }`,
+				icon: 'stats-alt',
+				onClick: viewStats,
+				text: translate( 'Stats' ),
 			} );
-		} else {
-			controls.main.push( {
-				className: 'trash' + ( current === 'trash' ? ' is-active' : '' ),
-				icon: 'trash',
-				onClick: onTrash,
-				text: translate( 'Trash' ),
-			} );
-		}
-	}
 
-	if (
-		includes( [ 'draft', 'future', 'pending', 'private', 'publish' ], post.status ) &&
-		userCan( 'edit_post', post )
-	) {
-		controls.main.push( {
-			className: 'copy' + ( current === 'copy' ? ' is-active' : '' ),
-			href: `/post/${ siteSlug }?copy=${ post.ID }`,
-			icon: 'clipboard',
-			onClick: copy,
-			text: translate( 'Copy' ),
-		} );
-	}
-
-	// More Controls (behind ... more link)
-	if ( controls.main.length > 4 && fullWidth ) {
-		controls.more = controls.main.splice( 4 );
-	} else if ( controls.main.length > 2 && ! fullWidth ) {
-		controls.more = controls.main.splice( 2 );
-	}
-
-	if ( controls.more.length ) {
-		controls.main.push( {
-			className: 'more' + ( current === 'more' ? ' is-active' : '' ),
-			icon: 'ellipsis',
-			onClick: onShowMore,
-			text: translate( 'More' ),
-		} );
-
-		controls.more.push( {
-			className: 'back' + ( current === 'back' ? ' is-active' : '' ),
-			icon: 'chevron-left',
-			onClick: onHideMore,
-			text: translate( 'Back' ),
-		} );
-	}
-
-	return controls;
-};
-
-const getControlElements = controls => controls.map( ( control, index ) =>
-	<li
-		className={ classNames( { 'post-controls__disabled': control.disabled } ) }
-		key={ index }
-	>
-		<a
-			className={ `post-controls__${ control.className }` }
-			href={ control.href }
-			onClick={ control.disabled ? noop : control.onClick }
-			target={ control.target ? control.target : null }
-		>
-			<Gridicon icon={ control.icon } size={ 18 } />
-			<span className="posts__post-controls-text">
-				{ control.text }
-				{ control.count > 0 && <Count count={ control.count } /> }
-			</span>
-		</a>
-	</li>
-);
-
-export const PostControls = props => {
-	const { main, more } = getAvailableControls( props );
-	const classes = classNames(
-		'post-controls',
-		{ 'post-controls--desk-nomore': more <= 2 }
-	);
-
-	return (
-		<div className={ classes }>
-			<QuerySharePostActions
-				siteId={ props.siteId }
-				postId={ props.post.ID }
-				status={ SCHEDULED } />
-			{ more.length > 0 &&
-				<ul className="posts__post-controls post-controls__pane post-controls__more-options">
-					{ getControlElements( more ) }
-				</ul>
+			if ( isEnabled( 'republicize' ) ) {
+				controls.main.push( {
+					className: 'share' + ( current === 'share' ? ' is-active' : '' ),
+					count: this.props.scheduledActionsCount,
+					disabled: ! this.props.isPublicizeEnabled,
+					icon: 'share',
+					onClick: onToggleShare,
+					text: translate( 'Share' ),
+				} );
 			}
-			<ul className="posts__post-controls post-controls__pane post-controls__main-options">
-				{ getControlElements( main ) }
-			</ul>
-		</div>
-	);
-};
+		} else if ( 'trash' !== post.status ) {
+			controls.main.push( {
+				className: 'view' + ( current === 'preview' ? ' is-active' : '' ),
+				icon: this.props.isPreviewable ? 'visible' : 'external',
+				onClick: onViewPost,
+				text: translate( 'Preview' ),
+			} );
+
+			if ( userCan( 'publish_post', post ) ) {
+				controls.main.push( {
+					className: 'publish' + ( current === 'publish' ? ' is-active' : '' ),
+					icon: 'reader',
+					onClick: onPublish,
+					text: translate( 'Publish' ),
+				} );
+			}
+		} else if ( userCan( 'delete_post', post ) ) {
+			controls.main.push( {
+				className: 'restore' + ( current === 'restore' ? ' is-active' : '' ),
+				icon: 'undo',
+				onClick: onRestore,
+				text: translate( 'Restore' ),
+			} );
+		}
+
+		if ( userCan( 'delete_post', post ) ) {
+			if ( 'trash' === post.status ) {
+				controls.main.push( {
+					className: 'trash is-scary' + ( current === 'delete-permanently' ? ' is-active' : '' ),
+					icon: 'trash',
+					onClick: onDelete,
+					text: translate( 'Delete Permanently' ),
+				} );
+			} else {
+				controls.main.push( {
+					className: 'trash' + ( current === 'trash' ? ' is-active' : '' ),
+					icon: 'trash',
+					onClick: onTrash,
+					text: translate( 'Trash' ),
+				} );
+			}
+		}
+
+		if (
+			includes( [ 'draft', 'future', 'pending', 'private', 'publish' ], post.status ) &&
+			userCan( 'edit_post', post )
+		) {
+			controls.main.push( {
+				className: 'copy' + ( current === 'copy' ? ' is-active' : '' ),
+				href: `/post/${ siteSlug }?copy=${ post.ID }`,
+				icon: 'clipboard',
+				onClick: copy,
+				text: translate( 'Copy' ),
+			} );
+		}
+
+		// More Controls (behind ... more link)
+		if ( controls.main.length > 4 && fullWidth ) {
+			controls.more = controls.main.splice( 4 );
+		} else if ( controls.main.length > 2 && ! fullWidth ) {
+			controls.more = controls.main.splice( 2 );
+		}
+
+		if ( controls.more.length ) {
+			controls.main.push( {
+				className: 'more' + ( current === 'more' ? ' is-active' : '' ),
+				icon: 'ellipsis',
+				onClick: onShowMore,
+				text: translate( 'More' ),
+			} );
+
+			controls.more.push( {
+				className: 'back' + ( current === 'back' ? ' is-active' : '' ),
+				icon: 'chevron-left',
+				onClick: onHideMore,
+				text: translate( 'Back' ),
+			} );
+		}
+
+		return controls;
+	}
+
+	render() {
+		const { main, more } = this.getAvailableControls();
+		const classes = classNames(
+			'post-controls',
+			{ 'post-controls--desk-nomore': more <= 2 }
+		);
+		const { siteId, post } = this.props;
+
+		return (
+			<div className={ classes }>
+				<QuerySharePostActions
+					siteId={ siteId }
+					postId={ post.ID }
+					status={ SCHEDULED } />
+				{ more.length > 0 &&
+					<ul className="posts__post-controls post-controls__pane post-controls__more-options">
+						{ this.getControlElements( more ) }
+					</ul>
+				}
+				<ul className="posts__post-controls post-controls__pane post-controls__main-options">
+					{ this.getControlElements( main ) }
+				</ul>
+			</div>
+		);
+	}
+}
 
 PostControls.propTypes = {
 	current: PropTypes.string,

--- a/client/my-sites/posts/style.scss
+++ b/client/my-sites/posts/style.scss
@@ -411,6 +411,10 @@
 	}
 }
 
+.posts__post-controls-text .count {
+	margin-left: 8px;
+}
+
 .post-controls__pane {
 	// Flex
 	display: flex;


### PR DESCRIPTION
Implements #16672.

From @aheckler:

> As it stands now, there's no single place where I can see all of my scheduled shares. I have to open up the Share section under each blog post to see if I have any.

> Barring that, perhaps we can add a `.count` span to the post card if the post in question has shares scheduled to go out in the future?

It doesn't address the following part though:

> We should consider adding some sort of "master" list or calendar view where I can see all my upcoming shares in one place.

### Before

<img width="733" alt="screen shot 2017-09-14 at 15 01 33" src="https://user-images.githubusercontent.com/699132/30457792-a771136c-995d-11e7-8d32-d4dd7d657634.png">

### After

<img width="729" alt="screen shot 2017-09-14 at 15 28 42" src="https://user-images.githubusercontent.com/699132/30458673-71fcc83a-9961-11e7-981e-b8dc0659b098.png">

## Testing

1. Open https://calypso.live/posts?branch=fix/16672-expose-upcoming-shares or https://calypso.localhost:3000/posts.
2. You should see list of posts, if not add a post. You can also narrow down selection to one site.
3. Click on Share tab on one of the posts and schedule share to one of social medias (connect to social media if you didn't do it before).
4. You should see count number next to Share tab text and below the sharing box.

## To fix
1. [x] Don't trigger network requests for sites that have publicize disabled (private sites, free sites, Jetpack sites with option set to disabled).

