### PR TITLE
Fix the regression that causes the Publicize error message to not show.

### DIFF
--- a/client/blocks/post-share/index.jsx
+++ b/client/blocks/post-share/index.jsx
@@ -438,7 +438,7 @@ class PostShare extends Component {
 		if ( failure ) {
 			return (
 				<Notice status="is-error" onDismissClick={ this.dismiss }>
-					{ translate( 'Something went wrong. Please try again later.' ) }
+					{ translate( 'Something went wrong. Please try again.' ) }
 				</Notice>
 			);
 		}

--- a/client/blocks/post-share/index.jsx
+++ b/client/blocks/post-share/index.jsx
@@ -85,7 +85,7 @@ class PostShare extends Component {
 
 		// connect prps
 		connections: PropTypes.array,
-		failed: PropTypes.bool,
+		failure: PropTypes.bool,
 		hasFetchedConnections: PropTypes.bool,
 		hasRepublicizeFeature: PropTypes.bool,
 		isPublicizeEnabled: PropTypes.bool,
@@ -438,7 +438,7 @@ class PostShare extends Component {
 		if ( failure ) {
 			return (
 				<Notice status="is-error" onDismissClick={ this.dismiss }>
-					{ translate( 'Something went wrong. Please don\'t be mad.' ) }
+					{ translate( 'Something went wrong. Please try again later.' ) }
 				</Notice>
 			);
 		}
@@ -640,7 +640,7 @@ export default connect(
 			connections: getSiteUserConnections( state, siteId, userId ),
 			requesting: isRequestingSharePost( state, siteId, postId ),
 			schedulingFailed: isSchedulingPublicizeShareActionError( state, siteId, postId ),
-			failed: sharePostFailure( state, siteId, postId ),
+			failure: sharePostFailure( state, siteId, postId ),
 			success: sharePostSuccessMessage( state, siteId, postId ),
 			scheduledAt: getScheduledPublicizeShareActionTime( state, siteId, postId ),
 			premiumPrice: getDiscountedOrRegularPrice( state, siteId, PLAN_PREMIUM ),

--- a/client/state/sharing/publicize/selectors.js
+++ b/client/state/sharing/publicize/selectors.js
@@ -131,5 +131,6 @@ export function sharePostSuccessMessage( state, siteId, postId ) {
 }
 
 export function sharePostFailure( state, siteId, postId ) {
-	return ( get( state.sharing.publicize.sharePostStatus, [ siteId, postId, 'error' ], false ) === true );
+	return get( state.sharing.publicize.sharePostStatus, [ siteId, postId, 'success' ] ) === false &&
+		!! get( state.sharing.publicize.sharePostStatus, [ siteId, postId, 'error' ] );
 }


### PR DESCRIPTION
## Summary
There is regression causing the Publicize error message to not show, due to:

1. The component is checking for `failure` property to show the error message, but the corresponding redux state is connected as `failed`.
1. The selector `sharePostFailure` is not correct.

Besides fixing the above, this PR also updates the error message from 
```
Something went wrong. Please don't be mad.
```
to a more neutral
```
Something went wrong. Please try again.
```

### Test Plan
1. Choose a post as the test subject. Record its post ID and the site ID, say 45 and 1234567. 
1. Click the "Share" button of it from the post list:
![image](https://user-images.githubusercontent.com/1842898/30457591-bbb065e0-995c-11e7-9c67-f33924283d31.png)
1. Open the developer console and dispatch `PUBLICIZE_SHARE_FAILURE` action along with the side ID and the post ID. e.g.
```
dispatch( { type: actionTypes.PUBLICIZE_SHARE_FAILURE, siteId: 1234567, postId: 45, errro: {} } );
```
4. You should see the error message shown:
![image](https://user-images.githubusercontent.com/1842898/30460364-68ff17d8-996b-11e7-848c-c335dba7a165.png)


