### PR TITLE
Store: Remove unused CSS now that we don’t have child items in the sidebar

### DIFF
--- a/client/extensions/woocommerce/style.scss
+++ b/client/extensions/woocommerce/style.scss
@@ -191,30 +191,4 @@
 			}
 		}
 	}
-
-	li {
-
-		&.has-selected-child a {
-			font-weight: bold;
-		}
-
-		&.has-selected-child svg {
-			fill: $gray-text-min;
-		}
-
-		&.is-child-item {
-			a {
-				font-size: 12px;
-				padding: 8px 16px 8px 55px;
-			}
-
-			svg {
-				display: none;
-			}
-		}
-	}
-}
-
-.settings-tax.is-child-item {
-	border-bottom: 1px solid lighten( $gray, 20% );
 }


### PR DESCRIPTION
I noticed we still have CSS related to child items in the sidebar, but we no longer use that UI pattern.  This PR removes that CSS, just to clean up the main `style.scss` file.

To test:

- Visit any store page
- Make sure the sidebar still looks OK