### PR TITLE
Store: Run codemods for PropTypes

### DIFF
--- a/client/extensions/woocommerce/components/form-dimensions-input/index.jsx
+++ b/client/extensions/woocommerce/components/form-dimensions-input/index.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import classNames from 'classnames';


### PR DESCRIPTION
Ran codemods over the store extension, and only one component needed to be updated 😄  (see p4TIVU-7YG-p2)

This transforms `import { PropTypes } from 'react'` to `import PropTypes from 'prop-types'`, as getting PropTypes from react is deprecated as of 15.5.0.