### PR TITLE
Fix redirects from site selector for `site` and `settings`

### DIFF
--- a/client/my-sites/sites/sites.jsx
+++ b/client/my-sites/sites/sites.jsx
@@ -15,6 +15,7 @@ import Main from 'components/main';
 import observe from 'lib/mixins/data-observe';
 import SiteSelector from 'components/site-selector';
 import { addSiteFragment } from 'lib/route';
+import { getSiteFragment } from 'lib/route/path';
 import { getSites } from 'state/selectors';
 import { getSiteSlug } from 'state/sites/selectors';
 import { getSelectedSite } from 'state/ui/selectors';
@@ -26,6 +27,25 @@ export const Sites = React.createClass( {
 
 	propTypes: {
 		path: React.PropTypes.string.isRequired
+	},
+
+	componentWillMount() {
+		// If we have a selected site already, and an un-registered
+		// path we want to handle, do a redirect rather than show
+		// the site site selector.
+		if ( this.props.selectedSite ) {
+			const siteFragment = getSiteFragment( page.current );
+			const path = this.props.path.toLowerCase().split( '?' )[ 0 ].split( '/' )[ 1 ];
+
+			switch ( path ) {
+				case 'sites':
+					page.redirect( `/stats/insights/${ siteFragment }` );
+					break;
+				case 'settings':
+					page.redirect( `/settings/general/${ siteFragment }` );
+					break;
+			}
+		}
 	},
 
 	filterSites( site ) {
@@ -126,13 +146,13 @@ export const Sites = React.createClass( {
 } );
 
 const selectSite = ( siteId, rawPath ) => ( dispatch, getState ) => {
-	let path = rawPath;
+	let path = rawPath.toLowerCase();
 
-	if ( startsWith( rawPath, '/sites' ) ) {
+	if ( startsWith( path, '/sites' ) ) {
 		path = '/stats/insights';
 	}
 
-	if ( startsWith( rawPath, '/settings' ) ) {
+	if ( startsWith( path, '/settings' ) ) {
 		path = '/settings/general';
 	}
 

--- a/client/my-sites/sites/sites.jsx
+++ b/client/my-sites/sites/sites.jsx
@@ -5,6 +5,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import page from 'page';
 import i18n from 'i18n-calypso';
+import { startsWith } from 'lodash';
 
 /**
  * Internal dependencies
@@ -125,9 +126,16 @@ export const Sites = React.createClass( {
 } );
 
 const selectSite = ( siteId, rawPath ) => ( dispatch, getState ) => {
-	const path = ( rawPath === '/sites' )
-		? '/stats/insights'
-		: rawPath;
+	let path = rawPath;
+
+	if ( startsWith( rawPath, '/sites' ) ) {
+		path = '/stats/insights';
+	}
+
+	if ( startsWith( rawPath, '/settings' ) ) {
+		path = '/settings/general';
+	}
+
 	page( addSiteFragment( path, getSiteSlug( getState(), siteId ) ) );
 };
 


### PR DESCRIPTION
The site selector does nothing if you go to `/sites/` or `/settings/` as reported in #11543. This PR fixes this up and does some redirecting if we already have a site selected.

To test, go to `http://calypso.localhost:3000/sites/YOURDOMAINHERE` and `http://calypso.localhost:3000/settings/YOURDOMAINHERE`. It should redirect to the stats page and settings page respectively.

You should also test  `http://calypso.localhost:3000/sites/someoneelsesdomain` and `http://calypso.localhost:3000/settings/someoneelsesdomain`. This should show the site selector, and redirect to the correct place when you select a site.

Fixes #11543