### PR TITLE
Use the configuration port when running the app

### DIFF
--- a/client/auth/controller.js
+++ b/client/auth/controller.js
@@ -59,12 +59,13 @@ export default {
 		let authUrl;
 
 		if ( config( 'oauth_client_id' ) ) {
+			const port = process.env.PORT || config( 'port' );
 			const oauthSettings = {
 				response_type: 'token',
 				client_id: config( 'oauth_client_id' ),
 				client_secret: 'n/a',
 				url: {
-					redirect: 'http://calypso.localhost:3000/api/oauth/token'
+					redirect: `http://calypso.localhost:${ port }/api/oauth/token`
 				}
 			};
 

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -29,7 +29,7 @@
 	"mc_analytics_enabled": false,
 	"oauth_client_id": false,
 	"olark": {},
-	"port": false,
+	"port": 3000,
 	"happychat_url": "https://happychat.io/customer",
 	"happychat_support_blog": "en.support.wordpress.com",
 	"google_oauth_client_id": "108380595987-j91sm1alavcdgd81i2655kp8q1lbtvrc.apps.googleusercontent.com",

--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ var pkg = require( './package.json' ),
 	config = require( 'config' );
 
 var start = Date.now(),
-	port = process.env.PORT || 3000,
+	port = process.env.PORT || config( 'port' ) || 3000,
 	host = process.env.HOST || config( 'hostname' ),
 	app = boot(),
 	server,

--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ var pkg = require( './package.json' ),
 	config = require( 'config' );
 
 var start = Date.now(),
-	port = process.env.PORT || config( 'port' ) || 3000,
+	port = process.env.PORT || config( 'port' ),
 	host = process.env.HOST || config( 'hostname' ),
 	app = boot(),
 	server,

--- a/server/bundler/index.js
+++ b/server/bundler/index.js
@@ -9,6 +9,10 @@ const hotMiddleware = require( 'webpack-hot-middleware' );
 var utils = require( './utils' ),
 	webpackConfig = require( 'webpack.config' );
 
+const config = require( 'config' );
+
+const port = process.env.PORT || config( 'port' );
+
 function middleware( app ) {
 	var compiler = webpack( webpackConfig ),
 		callbacks = [],
@@ -42,7 +46,7 @@ function middleware( app ) {
 			process.nextTick( function() {
 				if ( beforeFirstCompile ) {
 					beforeFirstCompile = false;
-					console.info( chalk.cyan( '\nReady! You can load http://calypso.localhost:3000/ now. Have fun!' ) );
+					console.info( chalk.cyan( `\nReady! You can load http://calypso.localhost:${ port }/ now. Have fun!` ) );
 				} else {
 					console.info( chalk.cyan( '\nReady! All assets are re-compiled. Have fun!' ) );
 				}


### PR DESCRIPTION
Various config files set a `port`, or `false` in the case of the shared config:

https://github.com/Automattic/wp-calypso/blob/641207b6f599e9c4e4a11b89821248467b204f4c/config/development.json#L8
https://github.com/Automattic/wp-calypso/blob/641207b6f599e9c4e4a11b89821248467b204f4c/config/test.json#L6
https://github.com/Automattic/wp-calypso/blob/641207b6f599e9c4e4a11b89821248467b204f4c/config/_shared.json#L32

These properties do not seem to affect the port which is used. This PR adds the the config `port` so that it can be configured.

## Testing
* Try adding port via environment, i.e. `PORT=3001 npm start`. This should have precedence.
* Try modifying the port in config files, which should override the default `3000`. This is the behavior corrected by this PR.
* When a config file does not specify a port, the default `3000` should continue to be used.
* Test different environments like `wp-calypso` via the docker build.

**UPDATE**
* Try using oauth to ensure the correct port is used (9aed88f)
* Try removing the port from the environment config file, and ensure the default `3000` is used from `_shared`.