### PR TITLE
Check post type before showing strings in the individual page stats

### DIFF
--- a/client/blocks/post-likes/index.jsx
+++ b/client/blocks/post-likes/index.jsx
@@ -15,11 +15,19 @@ import { isRequestingPostLikes, getPostLikes, countPostLikes } from 'state/selec
 import { recordGoogleEvent } from 'state/analytics/actions';
 
 export const PostLikes = props => {
-	const { countLikes, isRequesting, likes, postId, siteId, translate } = props;
+	const { countLikes, isRequesting, likes, postId, postType, siteId, translate } = props;
 	const trackLikeClick = () => props.recordGoogleEvent( 'Post Likes', 'Clicked on Gravatar' );
 	const getLikeUrl = like => {
 		return like.URL ? like.URL : `https://gravatar.com/${ like.login }`;
 	};
+
+	let noLikesLabel;
+
+	if ( postType === 'page' ) {
+		noLikesLabel = translate( 'There are no likes on this page yet.' );
+	} else {
+		noLikesLabel = translate( 'There are no likes on this post yet.' );
+	}
 
 	return (
 		<div className="post-likes">
@@ -42,9 +50,13 @@ export const PostLikes = props => {
 					</span>
 				)
 			}
-			{ countLikes === 0 && ! isRequesting && translate( 'There are no likes on this post yet.' ) }
+			{ countLikes === 0 && ! isRequesting && noLikesLabel }
 		</div>
 	);
+};
+
+PostLikes.defaultProps = {
+	postType: 'post'
 };
 
 const connectComponent = connect(

--- a/client/my-sites/stats/stats-post-detail/index.jsx
+++ b/client/my-sites/stats/stats-post-detail/index.jsx
@@ -99,6 +99,17 @@ class StatsPostDetail extends Component {
 			title = translate( 'We don\'t have that post on record yet.' );
 		}
 
+		const postType = post && post.type !== null ? post.type : 'post';
+		let actionLabel, noViewsLabel;
+
+		if ( postType === 'page' ) {
+			actionLabel = translate( 'View Page' );
+			noViewsLabel = translate( 'Your page has not received any views yet!' );
+		} else {
+			actionLabel = translate( 'View Post' );
+			noViewsLabel = translate( 'Your post has not received any views yet!' );
+		}
+
 		return (
 			<Main wideLayout>
 				{ siteId && <QueryPosts siteId={ siteId } postId={ postId } /> }
@@ -109,7 +120,7 @@ class StatsPostDetail extends Component {
 				<HeaderCake
 					onClick={ this.goBack }
 					actionIcon={ showViewLink ? 'visible' : null }
-					actionText={ showViewLink ? translate( 'View Post' ) : null }
+					actionText={ showViewLink ? actionLabel : null }
 					actionOnClick={ showViewLink ? this.openPreview : null }
 					>
 					{ title }
@@ -119,7 +130,7 @@ class StatsPostDetail extends Component {
 
 				{ ! isLoading && countViews === 0 &&
 					<EmptyContent
-						title={ translate( 'Your post has not received any views yet!' ) }
+						title={ noViewsLabel }
 						line={ translate( 'Learn some tips to attract more visitors' ) }
 						action={ translate( 'Get more traffic!' ) }
 						actionURL="https://en.support.wordpress.com/getting-more-views-and-traffic/"
@@ -133,7 +144,7 @@ class StatsPostDetail extends Component {
 					<div>
 						<PostSummary siteId={ siteId } postId={ postId } />
 
-						{ !! postId && <PostLikes siteId={ siteId } postId={ postId } /> }
+						{ !! postId && <PostLikes siteId={ siteId } postId={ postId } postType={ postType } /> }
 
 						<PostMonths
 							dataKey="years"

--- a/client/my-sites/stats/stats-post-likes/index.jsx
+++ b/client/my-sites/stats/stats-post-likes/index.jsx
@@ -21,7 +21,7 @@ import { isRequestingPostLikes, countPostLikes } from 'state/selectors';
 import PostLikes from 'blocks/post-likes';
 
 export const StatsPostLikes = props => {
-	const { countLikes, isRequesting, opened, postId, siteId, toggle, translate } = props;
+	const { countLikes, isRequesting, opened, postId, postType, siteId, toggle, translate } = props;
 	const infoIcon = opened ? 'info' : 'info-outline';
 	const isLoading = isRequesting && ! countLikes;
 	const classes = {
@@ -29,12 +29,22 @@ export const StatsPostLikes = props => {
 		'is-loading': isLoading,
 	};
 
+	let likesListLabel, likesTitleLabel;
+
+	if ( postType === 'page' ) {
+		likesTitleLabel = translate( 'Page Likes' );
+		likesListLabel = translate( 'This panel shows the list of people who like your page.' );
+	} else {
+		likesTitleLabel = translate( 'Post Likes' );
+		likesListLabel = translate( 'This panel shows the list of people who like your post.' );
+	}
+
 	return (
 		<Card className={ classNames( 'stats-module', 'stats-post-likes', 'is-expanded', classes ) }>
 			<QueryPostLikes siteId={ siteId } postId={ postId } />
 			<div className="module-header">
 				<h4 className="module-header-title">
-					{ translate( 'Post Likes' ) }
+					{ likesTitleLabel }
 					{ countLikes !== null && <Count count={ countLikes } /> }
 				</h4>
 				<ul className="module-header-actions">
@@ -52,14 +62,18 @@ export const StatsPostLikes = props => {
 				</ul>
 			</div>
 			<StatsModuleContent className="module-content-text-info">
-				{ translate( 'This panel shows the list of people who like your post.' ) }
+				{ likesListLabel }
 			</StatsModuleContent>
 			<StatsModulePlaceholder isLoading={ isLoading } />
 			<div className="stats-post-likes__content">
-				<PostLikes siteId={ siteId } postId={ postId } />
+				<PostLikes siteId={ siteId } postId={ postId } postType={ postType } />
 			</div>
 		</Card>
 	);
+};
+
+StatsPostLikes.defaultProps = {
+	postType: 'post'
 };
 
 const connectComponent = connect(


### PR DESCRIPTION
This PR adds a few ifs to use "page" instead of "post" in some strings in the individual page stats when data for a page is being displayed.

Done pairing with @mikkamp

Fixes #17497 

#### Steps to reproduce
1. Starting at URL: https://wpcalypso.wordpress.com/pages/example.com
2. Click the ... menu, it says View Page as expected.
3. Click on Stats in the ... menu, arriving at https://wpcalypso.wordpress.com/stats/post/1234/example.com
4. You'll see "Your post has not received any views yet!" and "View post" labels