### PR TITLE
Components: Run codemods on components t-u

### DIFF
--- a/client/components/textarea-autosize/index.jsx
+++ b/client/components/textarea-autosize/index.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import autosize from 'autosize';
 

--- a/client/components/thank-you-card/index.jsx
+++ b/client/components/thank-you-card/index.jsx
@@ -1,9 +1,10 @@
 /**
  * External dependencies
  */
+import React from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import Gridicon from 'gridicons';
-import React, { PropTypes } from 'react';
 
 // Non standard gridicon sizes are used here because we use them as background pattern with various sizes and rotation
 /* eslint-disable wpcalypso/jsx-gridicon-size */

--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { isEmpty, isEqual, noop } from 'lodash';
 import Gridicon from 'gridicons';
@@ -19,47 +20,47 @@ import PulsingDot from 'components/pulsing-dot';
  */
 export class Theme extends Component {
 	static propTypes = {
-		theme: React.PropTypes.shape( {
+		theme: PropTypes.shape( {
 			// Theme ID (theme-slug)
-			id: React.PropTypes.string.isRequired,
+			id: PropTypes.string.isRequired,
 			// Theme name
-			name: React.PropTypes.string.isRequired,
+			name: PropTypes.string.isRequired,
 			// Theme screenshot URL
-			screenshot: React.PropTypes.string,
-			author: React.PropTypes.string,
-			author_uri: React.PropTypes.string,
-			demo_uri: React.PropTypes.string,
-			stylesheet: React.PropTypes.string
+			screenshot: PropTypes.string,
+			author: PropTypes.string,
+			author_uri: PropTypes.string,
+			demo_uri: PropTypes.string,
+			stylesheet: PropTypes.string
 		} ),
 		// If true, highlight this theme as active
-		active: React.PropTypes.bool,
+		active: PropTypes.bool,
 		// Theme price (pre-formatted string) -- empty string indicates free theme
-		price: React.PropTypes.string,
+		price: PropTypes.string,
 		// If true, the theme is being installed
-		installing: React.PropTypes.bool,
+		installing: PropTypes.bool,
 		// If true, render a placeholder
-		isPlaceholder: React.PropTypes.bool,
+		isPlaceholder: PropTypes.bool,
 		// URL the screenshot link points to
-		screenshotClickUrl: React.PropTypes.string,
+		screenshotClickUrl: PropTypes.string,
 		// Called when theme screenshot is clicked
-		onScreenshotClick: React.PropTypes.func,
+		onScreenshotClick: PropTypes.func,
 		// Called when the more button is clicked
-		onMoreButtonClick: React.PropTypes.func,
+		onMoreButtonClick: PropTypes.func,
 		// Options to populate the 'More' button popover menu with
-		buttonContents: React.PropTypes.objectOf(
-			React.PropTypes.shape( {
-				label: React.PropTypes.string,
-				header: React.PropTypes.string,
-				action: React.PropTypes.func,
-				getUrl: React.PropTypes.func
+		buttonContents: PropTypes.objectOf(
+			PropTypes.shape( {
+				label: PropTypes.string,
+				header: PropTypes.string,
+				action: PropTypes.func,
+				getUrl: PropTypes.func
 			} )
 		),
 		// Index of theme in results list
-		index: React.PropTypes.number,
+		index: PropTypes.number,
 		// Label to show on screenshot hover.
-		actionLabel: React.PropTypes.string,
+		actionLabel: PropTypes.string,
 		// Translate function,
-		translate: React.PropTypes.func,
+		translate: PropTypes.func,
 	};
 
 	static defaultProps = {

--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Component } from 'react';
 import classNames from 'classnames';
 import { isEmpty, isEqual, noop } from 'lodash';
 import Gridicon from 'gridicons';
@@ -17,9 +17,8 @@ import PulsingDot from 'components/pulsing-dot';
 /**
  * Component
  */
-export const Theme = React.createClass( {
-
-	propTypes: {
+export class Theme extends Component {
+	static propTypes = {
 		theme: React.PropTypes.shape( {
 			// Theme ID (theme-slug)
 			id: React.PropTypes.string.isRequired,
@@ -61,7 +60,15 @@ export const Theme = React.createClass( {
 		actionLabel: React.PropTypes.string,
 		// Translate function,
 		translate: React.PropTypes.func,
-	},
+	};
+
+	static defaultProps = {
+		isPlaceholder: false,
+		buttonContents: {},
+		onMoreButtonClick: noop,
+		actionLabel: '',
+		active: false
+	};
 
 	shouldComponentUpdate( nextProps ) {
 		return nextProps.theme.id !== this.props.theme.id ||
@@ -72,31 +79,21 @@ export const Theme = React.createClass( {
 			( nextProps.screenshotClickUrl !== this.props.screenshotClickUrl ) ||
 			( nextProps.onScreenshotClick !== this.props.onScreenshotClick ) ||
 			( nextProps.onMoreButtonClick !== this.props.onMoreButtonClick );
-	},
+	}
 
-	getDefaultProps() {
-		return ( {
-			isPlaceholder: false,
-			buttonContents: {},
-			onMoreButtonClick: noop,
-			actionLabel: '',
-			active: false
-		} );
-	},
-
-	onScreenshotClick() {
+	onScreenshotClick = () => {
 		this.props.onScreenshotClick( this.props.theme.id, this.props.index );
-	},
+	};
 
-	renderPlaceholder() {
+	renderPlaceholder = () => {
 		return (
 			<Card className="theme is-placeholder">
 				<div className="theme__content" />
 			</Card>
 		);
-	},
+	};
 
-	renderHover() {
+	renderHover = () => {
 		if ( this.props.screenshotClickUrl || this.props.onScreenshotClick ) {
 			return (
 				<a className="theme__active-focus"
@@ -108,9 +105,9 @@ export const Theme = React.createClass( {
 				</a>
 			);
 		}
-	},
+	};
 
-	renderInstalling() {
+	renderInstalling = () => {
 		if ( this.props.installing ) {
 			return (
 				<div className="theme__installing" >
@@ -118,7 +115,7 @@ export const Theme = React.createClass( {
 				</div>
 			);
 		}
-	},
+	};
 
 	render() {
 		const {
@@ -192,6 +189,6 @@ export const Theme = React.createClass( {
 			</Card>
 		);
 	}
-} );
+}
 
 export default localize( Theme );

--- a/client/components/theme/more-button.jsx
+++ b/client/components/theme/more-button.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { isFunction, map } from 'lodash';
 
@@ -111,22 +112,22 @@ class ThemeMoreButton extends Component {
 
 ThemeMoreButton.propTypes = {
 	// See Theme component propTypes
-	theme: React.PropTypes.object,
+	theme: PropTypes.object,
 	// Index of theme in results list
-	index: React.PropTypes.number,
+	index: PropTypes.number,
 	// More elaborate onClick action, used for tracking.
 	// Made to not interfere with DOM onClick
-	onMoreButtonClick: React.PropTypes.func,
+	onMoreButtonClick: PropTypes.func,
 	// Options to populate the popover menu with
-	options: React.PropTypes.objectOf(
-		React.PropTypes.shape( {
-			label: React.PropTypes.string,
-			header: React.PropTypes.string,
-			action: React.PropTypes.func,
-			getUrl: React.PropTypes.func
+	options: PropTypes.objectOf(
+		PropTypes.shape( {
+			label: PropTypes.string,
+			header: PropTypes.string,
+			action: PropTypes.func,
+			getUrl: PropTypes.func
 		} )
 	).isRequired,
-	active: React.PropTypes.bool
+	active: PropTypes.bool
 };
 
 export default ThemeMoreButton;

--- a/client/components/theme/more-button.jsx
+++ b/client/components/theme/more-button.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Component } from 'react';
 import classNames from 'classnames';
 import { isFunction, map } from 'lodash';
 
@@ -15,7 +15,7 @@ import { isOutsideCalypso } from 'lib/url';
 /**
  * Component
  */
-class ThemeMoreButton extends React.Component {
+class ThemeMoreButton extends Component {
 
 	constructor( props ) {
 		super( props );

--- a/client/components/theme/test/index.jsx
+++ b/client/components/theme/test/index.jsx
@@ -11,19 +11,21 @@ import { identity } from 'lodash';
 import useFakeDom from 'test/helpers/use-fake-dom';
 import useMockery from 'test/helpers/use-mockery';
 
+import MockMoreButton from '../more-button';
+
 describe( 'Theme', function() {
 	let ReactDom, React, TestUtils, Theme, togglePopoverStub;
 
 	useFakeDom();
 
 	useMockery( mockery => {
-		ReactDom = require( 'react-dom' );
+	    ReactDom = require( 'react-dom' );
 		React = require( 'react' );
 		TestUtils = require( 'react-addons-test-utils' );
 
-		let EmptyComponent = React.createClass( {
+		const EmptyComponent = React.createClass( {
 			render: function() {
-				return <div/>;
+				return <div />;
 			}
 		} );
 
@@ -31,7 +33,6 @@ describe( 'Theme', function() {
 		mockery.registerMock( 'components/popover/menu-item', EmptyComponent );
 
 		togglePopoverStub = sinon.stub().returnsArg( 0 );
-		let MockMoreButton = require( '../more-button' );
 		MockMoreButton.prototype.togglePopover = togglePopoverStub;
 		mockery.registerMock( './more-button', MockMoreButton );
 
@@ -54,7 +55,7 @@ describe( 'Theme', function() {
 		context( 'with default display buttonContents', function() {
 			beforeEach( function() {
 				this.props.onScreenshotClick = sinon.spy();
-				let themeElement = TestUtils.renderIntoDocument( React.createElement( Theme, this.props ) );
+				const themeElement = TestUtils.renderIntoDocument( React.createElement( Theme, this.props ) );
 				this.themeNode = ReactDom.findDOMNode( themeElement );
 			} );
 
@@ -67,12 +68,12 @@ describe( 'Theme', function() {
 			} );
 
 			it( 'should render a screenshot', function() {
-				var imgNode = this.themeNode.getElementsByTagName( 'img' )[ 0 ];
+				const imgNode = this.themeNode.getElementsByTagName( 'img' )[ 0 ];
 				assert.include( imgNode.getAttribute( 'src' ), '/theme/screenshot.png' );
 			} );
 
 			it( 'should call onScreenshotClick() on click on screenshot', function() {
-				var imgNode = this.themeNode.getElementsByTagName( 'img' )[ 0 ];
+				const imgNode = this.themeNode.getElementsByTagName( 'img' )[ 0 ];
 				TestUtils.Simulate.click( imgNode );
 				assert( this.props.onScreenshotClick.calledOnce, 'onClick did not trigger onScreenshotClick' );
 			} );
@@ -82,7 +83,7 @@ describe( 'Theme', function() {
 			} );
 
 			it( 'should render a More button', function() {
-				var more = this.themeNode.getElementsByClassName( 'theme__more-button' );
+				const more = this.themeNode.getElementsByClassName( 'theme__more-button' );
 
 				assert( more.length === 1, 'More button container not found' );
 				assert( more[ 0 ].getElementsByTagName( 'button' ).length === 1, 'More button not found' );
@@ -94,12 +95,12 @@ describe( 'Theme', function() {
 		context( 'with empty buttonContents', function() {
 			beforeEach( function() {
 				this.props.buttonContents = {};
-				let themeElement = TestUtils.renderIntoDocument( React.createElement( Theme, this.props ) );
+				const themeElement = TestUtils.renderIntoDocument( React.createElement( Theme, this.props ) );
 				this.themeNode = ReactDom.findDOMNode( themeElement );
 			} );
 
 			it( 'should not render a More button', function() {
-				var more = this.themeNode.getElementsByClassName( 'theme__more-button' );
+				const more = this.themeNode.getElementsByClassName( 'theme__more-button' );
 
 				assert( more.length === 0, 'More button container found' );
 			} );
@@ -108,7 +109,7 @@ describe( 'Theme', function() {
 
 	context( 'when isPlaceholder is set to true', function() {
 		beforeEach( function() {
-			let themeElement = TestUtils.renderIntoDocument(
+			const themeElement = TestUtils.renderIntoDocument(
 				React.createElement( Theme, {
 					theme: { id: 'placeholder-1', name: 'Loading' },
 					isPlaceholder: true,
@@ -127,7 +128,7 @@ describe( 'Theme', function() {
 	context( 'when the theme has a price', function() {
 		beforeEach( function() {
 			this.props.price = '$50';
-			let themeElement = TestUtils.renderIntoDocument(
+			const themeElement = TestUtils.renderIntoDocument(
 				React.createElement( Theme, this.props )
 			);
 			this.themeNode = ReactDom.findDOMNode( themeElement );

--- a/client/components/theme/test/index.jsx
+++ b/client/components/theme/test/index.jsx
@@ -19,15 +19,11 @@ describe( 'Theme', function() {
 	useFakeDom();
 
 	useMockery( mockery => {
-	    ReactDom = require( 'react-dom' );
+		ReactDom = require( 'react-dom' );
 		React = require( 'react' );
 		TestUtils = require( 'react-addons-test-utils' );
 
-		const EmptyComponent = React.createClass( {
-			render: function() {
-				return <div />;
-			}
-		} );
+		const EmptyComponent = () => <div />;
 
 		mockery.registerMock( 'components/popover/menu', EmptyComponent );
 		mockery.registerMock( 'components/popover/menu-item', EmptyComponent );

--- a/client/components/theme/test/index.jsx
+++ b/client/components/theme/test/index.jsx
@@ -11,8 +11,6 @@ import { identity } from 'lodash';
 import useFakeDom from 'test/helpers/use-fake-dom';
 import useMockery from 'test/helpers/use-mockery';
 
-import MockMoreButton from '../more-button';
-
 describe( 'Theme', function() {
 	let ReactDom, React, TestUtils, Theme, togglePopoverStub;
 
@@ -29,6 +27,10 @@ describe( 'Theme', function() {
 		mockery.registerMock( 'components/popover/menu-item', EmptyComponent );
 
 		togglePopoverStub = sinon.stub().returnsArg( 0 );
+
+		// NOTE: This import should not be hoisted, since it relies on the FakeDOM
+		// being available during instantiation.
+		const MockMoreButton = require( '../more-button' );
 		MockMoreButton.prototype.togglePopover = togglePopoverStub;
 		mockery.registerMock( './more-button', MockMoreButton );
 

--- a/client/components/themes-list/docs/example.jsx
+++ b/client/components/themes-list/docs/example.jsx
@@ -25,14 +25,14 @@ const demoThemes = [ {
 	actionLabel: 'Click Action Theme 3',
 } ];
 
-export default React.createClass( {
-	displayName: 'ThemesListExample',
+export default class extends React.Component {
+    static displayName = 'ThemesListExample';
 
-	getActionLabel( theme ) {
+	getActionLabel = theme => {
 		return theme.actionLabel;
-	},
+	};
 
-	getButtonOptions( themeId ) {
+	getButtonOptions = themeId => {
 		return {
 			action1: {
 				label: 'Menu Item 1',
@@ -47,11 +47,11 @@ export default React.createClass( {
 				}
 			}
 		}
-	},
+	};
 
-	themeScreenshotClick( themeId, index ) {
+	themeScreenshotClick = (themeId, index) => {
 		console.log( `Theme ${ themeId } at ${ index } clicked` );
-	},
+	};
 
 	render() {
 		return (
@@ -63,4 +63,4 @@ export default React.createClass( {
 			/>
 		);
 	}
-} );
+}

--- a/client/components/themes-list/docs/example.jsx
+++ b/client/components/themes-list/docs/example.jsx
@@ -26,7 +26,7 @@ const demoThemes = [ {
 } ];
 
 export default class extends React.Component {
-    static displayName = 'ThemesListExample';
+	static displayName = 'ThemesListExample';
 
 	getActionLabel = theme => {
 		return theme.actionLabel;

--- a/client/components/themes-list/index.jsx
+++ b/client/components/themes-list/index.jsx
@@ -1,6 +1,8 @@
 /**
  * External dependencies
  */
+import PropTypes from 'prop-types';
+
 import React from 'react';
 import createReactClass from 'create-react-class';
 import { isEqual, noop, times } from 'lodash';
@@ -22,20 +24,20 @@ export const ThemesList = createReactClass( {
 	mixins: [ InfiniteScroll( 'fetchNextPage' ) ],
 
 	propTypes: {
-		themes: React.PropTypes.array.isRequired,
-		emptyContent: React.PropTypes.element,
-		loading: React.PropTypes.bool.isRequired,
-		fetchNextPage: React.PropTypes.func.isRequired,
-		getButtonOptions: React.PropTypes.func,
-		onScreenshotClick: React.PropTypes.func.isRequired,
-		onMoreButtonClick: React.PropTypes.func,
-		getActionLabel: React.PropTypes.func,
-		isActive: React.PropTypes.func,
-		getPrice: React.PropTypes.func,
-		isInstalling: React.PropTypes.func,
+		themes: PropTypes.array.isRequired,
+		emptyContent: PropTypes.element,
+		loading: PropTypes.bool.isRequired,
+		fetchNextPage: PropTypes.func.isRequired,
+		getButtonOptions: PropTypes.func,
+		onScreenshotClick: PropTypes.func.isRequired,
+		onMoreButtonClick: PropTypes.func,
+		getActionLabel: PropTypes.func,
+		isActive: PropTypes.func,
+		getPrice: PropTypes.func,
+		isInstalling: PropTypes.func,
 		// i18n function provided by localize()
-		translate: React.PropTypes.func,
-		placeholderCount: React.PropTypes.number
+		translate: PropTypes.func,
+		placeholderCount: PropTypes.number
 	},
 
 	fetchNextPage( options ) {

--- a/client/components/themes-list/index.jsx
+++ b/client/components/themes-list/index.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react';
+import createReactClass from 'create-react-class';
 import { isEqual, noop, times } from 'lodash';
 import { localize } from 'i18n-calypso';
 
@@ -16,8 +17,8 @@ import { DEFAULT_THEME_QUERY } from 'state/themes/constants';
 /**
  * Component
  */
-export const ThemesList = React.createClass( {
-
+export const ThemesList = createReactClass( {
+	displayName: 'ThemesList',
 	mixins: [ InfiniteScroll( 'fetchNextPage' ) ],
 
 	propTypes: {
@@ -85,7 +86,7 @@ export const ThemesList = React.createClass( {
 		} );
 	},
 
-	// Invisible trailing items keep all elements same width in flexbox grid.
+    // Invisible trailing items keep all elements same width in flexbox grid.
 	renderTrailingItems() {
 		const NUM_SPACERS = 11; // gives enough spacers for a theoretical 12 column layout
 		return times( NUM_SPACERS, function( i ) {

--- a/client/components/themes-list/index.jsx
+++ b/client/components/themes-list/index.jsx
@@ -88,7 +88,7 @@ export const ThemesList = createReactClass( {
 		} );
 	},
 
-    // Invisible trailing items keep all elements same width in flexbox grid.
+	// Invisible trailing items keep all elements same width in flexbox grid.
 	renderTrailingItems() {
 		const NUM_SPACERS = 11; // gives enough spacers for a theoretical 12 column layout
 		return times( NUM_SPACERS, function( i ) {

--- a/client/components/themes-list/index.jsx
+++ b/client/components/themes-list/index.jsx
@@ -19,6 +19,7 @@ import { DEFAULT_THEME_QUERY } from 'state/themes/constants';
 /**
  * Component
  */
+/* eslint-disable react/prefer-es6-class */
 export const ThemesList = createReactClass( {
 	displayName: 'ThemesList',
 	mixins: [ InfiniteScroll( 'fetchNextPage' ) ],

--- a/client/components/themes-list/test/index.jsx
+++ b/client/components/themes-list/test/index.jsx
@@ -17,8 +17,8 @@ describe( 'ThemesList', function() {
 	useMockery( mockery => {
 		React = require( 'react' );
 		TestUtils = require( 'react-addons-test-utils' );
-		mockery.registerMock( 'components/pulsing-dot', React.createClass( { render: () => <div/> } ) );
-		mockery.registerMock( './more-button', React.createClass( { render: () => <div/> } ) );
+		mockery.registerMock( 'components/pulsing-dot', React.createClass( { render: () => <div /> } ) );
+		mockery.registerMock( './more-button', React.createClass( { render: () => <div /> } ) );
 		ThemesList = require( '../' ).ThemesList;
 	} );
 
@@ -55,7 +55,7 @@ describe( 'ThemesList', function() {
 
 	describe( 'rendering', function() {
 		beforeEach( function() {
-			var shallowRenderer = TestUtils.createRenderer();
+			const shallowRenderer = TestUtils.createRenderer();
 
 			shallowRenderer.render( this.themesList );
 			this.themesListElement = shallowRenderer.getRenderOutput();
@@ -68,7 +68,7 @@ describe( 'ThemesList', function() {
 
 		context( 'when no themes are found', function() {
 			beforeEach( function() {
-				var shallowRenderer = TestUtils.createRenderer();
+				const shallowRenderer = TestUtils.createRenderer();
 				this.props.themes = [];
 				this.themesList = React.createElement( ThemesList, this.props );
 

--- a/client/components/themes-list/test/index.jsx
+++ b/client/components/themes-list/test/index.jsx
@@ -17,8 +17,8 @@ describe( 'ThemesList', function() {
 	useMockery( mockery => {
 		React = require( 'react' );
 		TestUtils = require( 'react-addons-test-utils' );
-		mockery.registerMock( 'components/pulsing-dot', React.createClass( { render: () => <div /> } ) );
-		mockery.registerMock( './more-button', React.createClass( { render: () => <div /> } ) );
+		mockery.registerMock( 'components/pulsing-dot', () => <div /> );
+		mockery.registerMock( './more-button', () => <div /> );
 		ThemesList = require( '../' ).ThemesList;
 	} );
 

--- a/client/components/timezone/docs/example.jsx
+++ b/client/components/timezone/docs/example.jsx
@@ -1,8 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
-import PureRenderMixin from 'react-pure-render/mixin';
+import React, { PureComponent } from 'react';
 
 /**
  * Internal dependencies
@@ -10,21 +9,16 @@ import PureRenderMixin from 'react-pure-render/mixin';
 import Timezone from 'components/timezone';
 import Card from 'components/card';
 
-export default React.createClass( {
+export default class extends PureComponent {
+    static displayName = 'Timezone';
 
-	mixins: [ PureRenderMixin ],
+	state = {
+		timezone: 'America/Argentina/La_Rioja'
+	};
 
-	displayName: 'Timezone',
-
-	getInitialState() {
-		return {
-			timezone: 'America/Argentina/La_Rioja'
-		};
-	},
-
-	onTimezoneSelect( timezone ) {
+	onTimezoneSelect = timezone => {
 		this.setState( { timezone } );
-	},
+	};
 
 	render() {
 		return (
@@ -36,4 +30,4 @@ export default React.createClass( {
 			</Card>
 		);
 	}
-} );
+}

--- a/client/components/timezone/docs/example.jsx
+++ b/client/components/timezone/docs/example.jsx
@@ -9,8 +9,8 @@ import React, { PureComponent } from 'react';
 import Timezone from 'components/timezone';
 import Card from 'components/card';
 
-export default class extends PureComponent {
-    static displayName = 'Timezone';
+export default class TimezoneExample extends PureComponent {
+	static displayName = 'TimezoneExample';
 
 	state = {
 		timezone: 'America/Argentina/La_Rioja'

--- a/client/components/title-format-editor/index.jsx
+++ b/client/components/title-format-editor/index.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
 import {

--- a/client/components/title-format-editor/index.jsx
+++ b/client/components/title-format-editor/index.jsx
@@ -94,21 +94,10 @@ if ( ! Array.prototype.fill ) {
 
 // The below is a `require()` statement becuase it needs to
 // be loaded in after the polyfills are created.
-const {
-	CompositeDecorator,
-	Editor,
-	EditorState,
-	Entity,
-	Modifier,
-	SelectionState,
-} = require( 'draft-js' );
+import { CompositeDecorator, Editor, EditorState, Entity, Modifier, SelectionState } from 'draft-js';
 
 // Parser also requires draft-js. Lets load it after the polyfills are created too.
-const {
-	fromEditor,
-	mapTokenTitleForEditor,
-	toEditor,
-} = require( './parser' );
+import { fromEditor, mapTokenTitleForEditor, toEditor } from './parser';
 
 import Token from './token';
 import { buildSeoTitle } from 'state/sites/selectors';

--- a/client/components/tooltip/index.jsx
+++ b/client/components/tooltip/index.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
 /**

--- a/client/components/track-input-changes/index.jsx
+++ b/client/components/track-input-changes/index.jsx
@@ -1,36 +1,34 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Component } from 'react';
 import { assign, noop } from 'lodash';
 
-export default React.createClass( {
-	displayName: 'TrackInputChanges',
+export default class TrackInputChanges extends Component {
+	static displayName = 'TrackInputChanges';
 
-	propTypes: {
+	static propTypes = {
 		onNewValue: React.PropTypes.func
-	},
+	};
 
-	getDefaultProps() {
-		return {
-			onNewValue: noop
-		};
-	},
+	static defaultProps = {
+		onNewValue: noop
+	};
 
 	componentWillMount() {
 		this.inputEdited = false;
-	},
+	}
 
-	onInputChange( /*event*/ ) {
+	onInputChange = () => {
 		this.inputEdited = true;
-	},
+	};
 
-	onInputBlur( event ) {
+	onInputBlur = event => {
 		if ( this.inputEdited ) {
 			this.props.onNewValue( event );
 			this.inputEdited = false;
 		}
-	},
+	};
 
 	render() {
 		// Multiple children not supported
@@ -53,4 +51,4 @@ export default React.createClass( {
 
 		return React.cloneElement( child, props );
 	}
-} );
+}

--- a/client/components/track-input-changes/index.jsx
+++ b/client/components/track-input-changes/index.jsx
@@ -2,13 +2,14 @@
  * External dependencies
  */
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { assign, noop } from 'lodash';
 
 export default class TrackInputChanges extends Component {
 	static displayName = 'TrackInputChanges';
 
 	static propTypes = {
-		onNewValue: React.PropTypes.func
+		onNewValue: PropTypes.func
 	};
 
 	static defaultProps = {

--- a/client/components/track-input-changes/test/index.jsx
+++ b/client/components/track-input-changes/test/index.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import ReactDom from 'react-dom';
-import React from 'react';
+import React, { Component } from 'react';
 import TestUtils from 'react-addons-test-utils';
 import { expect } from 'chai';
 import sinon from 'sinon';
@@ -22,19 +22,19 @@ const spies = {
 	onBlur: null
 };
 
-const DummyInput = React.createClass( {
-	triggerChange( value ) {
+class DummyInput extends Component {
+	triggerChange = value => {
 		this.props.onChange( { target: this, value } );
-	},
+	};
 
-	triggerBlur() {
+	triggerBlur = () => {
 		this.props.onBlur( { target: this } );
-	},
+	};
 
 	render() {
 		return <div />;
 	}
-} );
+}
 
 describe( 'TrackInputChanges#onNewValue', function() {
 	let tree, dummyInput, container;

--- a/client/components/track-input-changes/test/index.jsx
+++ b/client/components/track-input-changes/test/index.jsx
@@ -11,7 +11,7 @@ import useFakeDom from 'test/helpers/use-fake-dom';
 /**
  * Internal dependencies
  */
-var TrackInputChanges = require( '../' );
+import TrackInputChanges from '../';
 
 /**
  * Module variables
@@ -50,7 +50,7 @@ describe( 'TrackInputChanges#onNewValue', function() {
 	} );
 
 	beforeEach( function() {
-		for ( let spy in spies ) {
+		for ( const spy in spies ) {
 			spies[ spy ] = sinon.spy();
 		}
 		tree = ReactDom.render(

--- a/client/components/user/index.jsx
+++ b/client/components/user/index.jsx
@@ -8,13 +8,14 @@ import React from 'react';
  */
 import Gravatar from 'components/gravatar';
 
-export default React.createClass( {
-	displayName: 'UserItem',
-	propTypes: {
-		user: React.PropTypes.object
-	},
+export default class extends React.Component {
+	static displayName = 'UserItem';
 
-	render: function() {
+	static propTypes = {
+		user: React.PropTypes.object
+	};
+
+	render() {
 		let user = this.props.user || null,
 			name = user ? user.name : '';
 		return (
@@ -26,4 +27,4 @@ export default React.createClass( {
 			</div>
 		);
 	}
-} );
+}

--- a/client/components/user/index.jsx
+++ b/client/components/user/index.jsx
@@ -1,16 +1,15 @@
 /**
  * External dependencies
  */
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-
-import React from 'react';
 
 /**
  * Internal dependencies
  */
 import Gravatar from 'components/gravatar';
 
-export default class extends React.Component {
+export default class UserItem extends Component {
 	static displayName = 'UserItem';
 
 	static propTypes = {
@@ -18,8 +17,8 @@ export default class extends React.Component {
 	};
 
 	render() {
-		let user = this.props.user || null,
-			name = user ? user.name : '';
+		const user = this.props.user || null;
+		const name = user ? user.name : '';
 		return (
 			<div className="user" title={ name }>
 				<Gravatar size={ 26 } user={ user } />

--- a/client/components/user/index.jsx
+++ b/client/components/user/index.jsx
@@ -1,6 +1,8 @@
 /**
  * External dependencies
  */
+import PropTypes from 'prop-types';
+
 import React from 'react';
 
 /**
@@ -12,7 +14,7 @@ export default class extends React.Component {
 	static displayName = 'UserItem';
 
 	static propTypes = {
-		user: React.PropTypes.object
+		user: PropTypes.object
 	};
 
 	render() {

--- a/client/components/user/index.jsx
+++ b/client/components/user/index.jsx
@@ -8,15 +8,15 @@ import React from 'react';
  */
 import Gravatar from 'components/gravatar';
 
-module.exports = React.createClass( {
+export default React.createClass( {
 	displayName: 'UserItem',
 	propTypes: {
 		user: React.PropTypes.object
 	},
 
 	render: function() {
-		var user = this.props.user || null,
-		name = user ? user.name : '';
+		let user = this.props.user || null,
+			name = user ? user.name : '';
 		return (
 			<div className="user" title={ name }>
 				<Gravatar size={ 26 } user={ user } />


### PR DESCRIPTION
This PR runs codemods over components T-U alphabetically (some of the components had no changes).

- client/components/textarea-autosize/
- client/components/thank-you-card/
- client/components/theme/
- client/components/timezone/
- client/components/title-format-editor/
- client/components/tooltip/
- client/components/track-input-changes/
- client/components/update-post-status/
- client/components/user/

This also updates `client/components/themes-list/`, but does not apply the `react-create-class` codemod due to errors: "`ThemesList` was skipped because of inconvertible mixins" so I think @seear or @ockham will need to check this out? (names from file history, feel free to ping someone else if needed 🙂 )

~As for token-field, this had issues with getDefaultProps/getInitialState. Not sure how to fix this, as it seemed like it should be straightforward. Maybe this is what you were talking about last night, @jsnmoon?~

The following were skipped for complexity:

- client/components/tinymce
- client/components/token-field
- client/components/upgrades

Note, I've updated the PR to remove the changes to token-field.