### PR TITLE
Better validation handling on signup form

### DIFF
--- a/client/components/signup-form/index.jsx
+++ b/client/components/signup-form/index.jsx
@@ -270,6 +270,8 @@ class SignupForm extends Component {
 
 	handleBlur = () => {
 		const data = this.getUserData();
+		// When a user moves away from the signup form without having entered
+		// anything do not show error messages, think going to click log in.
 		if ( data.username.length === 0 && data.password.length === 0 && data.email.length === 0 ) {
 			return;
 		}

--- a/client/components/signup-form/index.jsx
+++ b/client/components/signup-form/index.jsx
@@ -269,6 +269,10 @@ class SignupForm extends Component {
 	};
 
 	handleBlur = () => {
+		const data = this.getUserData();
+		if ( data.username.length === 0 && data.password.length === 0 && data.email.length === 0 ) {
+			return;
+		}
 		this.formStateController.sanitize();
 		this.formStateController.validate();
 		this.props.save && this.props.save( this.state.form );


### PR DESCRIPTION
This adds a check to the signup form validation which makes sure not to give any error messages when you leave an input and no values have been entered. Eg realising you have an account and heading to click the log in link underneath the form.

Closes #16684

Test at https://wordpress.com/start/account/user, click in any of the input boxes and then click outside of the input without entering any values. Or click in any of the inputs and then click the log in link underneath the form without entering any values in any of the input boxes.

Validation should only happen if you click the Continue button or enter values in the inputs.