### PR TITLE
Moving masterbar to general settings tab

### DIFF
--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -10,7 +10,6 @@ import { flowRight } from 'lodash';
 /**
  * Internal dependencies
  */
-import Masterbar from './masterbar';
 import wrapSettingsForm from './wrap-settings-form';
 import Card from 'components/card';
 import CompactCard from 'components/card/compact';
@@ -32,11 +31,19 @@ import Banner from 'components/banner';
 import { isBusiness } from 'lib/products-values';
 import { FEATURE_NO_BRANDING, PLAN_BUSINESS } from 'lib/plans/constants';
 import QuerySiteSettings from 'components/data/query-site-settings';
-import { isJetpackMinimumVersion, isJetpackSite, siteSupportsJetpackSettingsUi } from 'state/sites/selectors';
+import {
+	isJetpackSite,
+	isJetpackMinimumVersion,
+	siteSupportsJetpackSettingsUi
+} from 'state/sites/selectors';
+
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import { preventWidows } from 'lib/formatting';
+import Masterbar from './masterbar';
+import QueryJetpackModules from 'components/data/query-jetpack-modules';
 
 class SiteSettingsFormGeneral extends Component {
+
 	componentWillMount() {
 		this._showWarning( this.props.site );
 	}
@@ -297,9 +304,6 @@ class SiteSettingsFormGeneral extends Component {
 			isSavingSettings,
 			site,
 			siteIsJetpack,
-			isJetpackSite,
-			jetpackMasterbarSupported,
-			siteSlug,
 			translate
 		} = this.props;
 		if ( siteIsJetpack && ! site.hasMinimumJetpackVersion ) {
@@ -312,7 +316,7 @@ class SiteSettingsFormGeneral extends Component {
 
 		return (
 			<div className={ classNames( classes ) }>
-				{ site && <QuerySiteSettings siteId={ site.ID } /> }
+				{ site && <QuerySiteSettings siteId={ this.props.siteId } /> }
 
 				<SectionHeader label={ translate( 'Site Profile' ) }>
 					<Button
@@ -338,6 +342,13 @@ class SiteSettingsFormGeneral extends Component {
 					</form>
 				</Card>
 
+				<QueryJetpackModules siteId={ this.props.siteId } />
+
+				<Masterbar
+					isSavingSettings={ isSavingSettings }
+					isRequestingSettings={ isRequestingSettings }
+				/>
+
 				<SectionHeader label={ translate( 'Privacy' ) }>
 					<Button
 						compact={ true }
@@ -352,22 +363,16 @@ class SiteSettingsFormGeneral extends Component {
 							}
 					</Button>
 				</SectionHeader>
+
 				<Card>
 					<form>
 						{ this.visibilityOptions() }
 					</form>
 				</Card>
-				
-				<Masterbar
-					isSavingSettings={ isSavingSettings }
-					isRequestingSettings={ isRequestingSettings }
-				/>
-				
-
-
 
 				{
-					! siteIsJetpack && <div className="site-settings__footer-credit-container">
+					! siteIsJetpack &&
+					<div className="site-settings__footer-credit-container">
 						<SectionHeader label={ translate( 'Footer Credit' ) } />
 						<CompactCard className="site-settings__footer-credit-explanation">
 							<p>
@@ -394,6 +399,7 @@ class SiteSettingsFormGeneral extends Component {
 					</div>
 				}
 			</div>
+
 		);
 	}
 
@@ -425,8 +431,8 @@ const connectComponent = connect(
 			siteIsJetpack,
 			siteSlug: getSelectedSiteSlug( state ),
 			supportsHolidaySnowOption: siteIsJetpack && isJetpackMinimumVersion( state, siteId, '4.0' ),
-			jetpackMasterbarSupported: isJetpackMinimumVersion( state, siteId, '4.8' ),
 			jetpackSettingsUISupported: siteSupportsJetpackSettingsUi( state, siteId ),
+			siteId
 		};
 	},
 	null,

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -10,6 +10,7 @@ import { flowRight } from 'lodash';
 /**
  * Internal dependencies
  */
+import Masterbar from './masterbar';
 import wrapSettingsForm from './wrap-settings-form';
 import Card from 'components/card';
 import CompactCard from 'components/card/compact';
@@ -31,7 +32,7 @@ import Banner from 'components/banner';
 import { isBusiness } from 'lib/products-values';
 import { FEATURE_NO_BRANDING, PLAN_BUSINESS } from 'lib/plans/constants';
 import QuerySiteSettings from 'components/data/query-site-settings';
-import { isJetpackMinimumVersion, isJetpackSite } from 'state/sites/selectors';
+import { isJetpackMinimumVersion, isJetpackSite, siteSupportsJetpackSettingsUi } from 'state/sites/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import { preventWidows } from 'lib/formatting';
 
@@ -296,6 +297,8 @@ class SiteSettingsFormGeneral extends Component {
 			isSavingSettings,
 			site,
 			siteIsJetpack,
+			isJetpackSite,
+			jetpackMasterbarSupported,
 			siteSlug,
 			translate
 		} = this.props;
@@ -354,6 +357,14 @@ class SiteSettingsFormGeneral extends Component {
 						{ this.visibilityOptions() }
 					</form>
 				</Card>
+				
+				<Masterbar
+					isSavingSettings={ isSavingSettings }
+					isRequestingSettings={ isRequestingSettings }
+				/>
+				
+
+
 
 				{
 					! siteIsJetpack && <div className="site-settings__footer-credit-container">
@@ -414,6 +425,8 @@ const connectComponent = connect(
 			siteIsJetpack,
 			siteSlug: getSelectedSiteSlug( state ),
 			supportsHolidaySnowOption: siteIsJetpack && isJetpackMinimumVersion( state, siteId, '4.0' ),
+			jetpackMasterbarSupported: isJetpackMinimumVersion( state, siteId, '4.8' ),
+			jetpackSettingsUISupported: siteSupportsJetpackSettingsUi( state, siteId ),
 		};
 	},
 	null,

--- a/client/my-sites/site-settings/form-writing.jsx
+++ b/client/my-sites/site-settings/form-writing.jsx
@@ -83,7 +83,7 @@ class SiteSettingsFormWriting extends Component {
 								isSavingSettings={ isSavingSettings }
 								isRequestingSettings={ isRequestingSettings }
 							/>
-						</div>
+						</div> 
 					)
 				}
 

--- a/client/my-sites/site-settings/form-writing.jsx
+++ b/client/my-sites/site-settings/form-writing.jsx
@@ -24,7 +24,6 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 import { requestPostTypes } from 'state/post-types/actions';
 import Composing from './composing';
 import CustomContentTypes from './custom-content-types';
-import Masterbar from './masterbar';
 import MediaSettings from './media-settings';
 import ThemeEnhancements from './theme-enhancements';
 import PublishingTools from './publishing-tools';
@@ -72,20 +71,6 @@ class SiteSettingsFormWriting extends Component {
 				onSubmit={ this.props.handleSubmitForm }
 				className="site-settings__general-settings"
 			>
-
-				{
-					this.props.isJetpackSite && this.props.jetpackMasterbarSupported && (
-						<div>
-							{
-								this.renderSectionHeader( translate( 'WordPress.com toolbar' ), false )
-							}
-							<Masterbar
-								isSavingSettings={ isSavingSettings }
-								isRequestingSettings={ isRequestingSettings }
-							/>
-						</div> 
-					)
-				}
 
 				{ config.isEnabled( 'manage/site-settings/categories' ) &&
 					<div className="site-settings__taxonomies">

--- a/client/my-sites/site-settings/masterbar.jsx
+++ b/client/my-sites/site-settings/masterbar.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
 
@@ -37,7 +38,6 @@ const Masterbar = ( {
 							</ExternalLink>
 						</InfoPopover>
 					</div>
-
 					<JetpackModuleToggle
 						siteId={ selectedSiteId }
 						moduleSlug="masterbar"


### PR DESCRIPTION
Fixes #16631 , <strike>Work in progress</strike>. Moves the Jetpack Masterbar to general settings tab. Masterbar info here: https://jetpack.com/support/masterbar/

![toolbar settings](http://cld.wthms.co/uBxV1m+)