### PR TITLE
Editor: Migrate deprecated React.PropTypes to npm prop-types module.

### DIFF
--- a/client/components/tinymce/index.jsx
+++ b/client/components/tinymce/index.jsx
@@ -4,6 +4,7 @@
 import { assign, forEach } from 'lodash';
 const ReactDom = require( 'react-dom' ),
 	React = require( 'react' ),
+	PropTypes = require( 'prop-types' ),
 	classnames = require( 'classnames' ),
 	autosize = require( 'autosize' ),
 	tinymce = require( 'tinymce/tinymce' );
@@ -161,29 +162,31 @@ module.exports = React.createClass( {
 	displayName: 'TinyMCE',
 
 	propTypes: {
-		mode: React.PropTypes.string,
-		onActivate: React.PropTypes.func,
-		onBlur: React.PropTypes.func,
-		onChange: React.PropTypes.func,
-		onDeactivate: React.PropTypes.func,
-		onFocus: React.PropTypes.func,
-		onHide: React.PropTypes.func,
-		onInit: React.PropTypes.func,
-		onRedo: React.PropTypes.func,
-		onRemove: React.PropTypes.func,
-		onReset: React.PropTypes.func,
-		onShow: React.PropTypes.func,
-		onSubmit: React.PropTypes.func,
-		onUndo: React.PropTypes.func,
-		onSetContent: React.PropTypes.func,
-		tabIndex: React.PropTypes.number,
-		isNew: React.PropTypes.bool,
-		onTextEditorChange: React.PropTypes.func,
-		onKeyUp: React.PropTypes.func
+		isNew: PropTypes.bool,
+		mode: PropTypes.string,
+		tabIndex: PropTypes.number,
+		onActivate: PropTypes.func,
+		onBlur: PropTypes.func,
+		onChange: PropTypes.func,
+		onDeactivate: PropTypes.func,
+		onFocus: PropTypes.func,
+		onHide: PropTypes.func,
+		onInit: PropTypes.func,
+		onInput: PropTypes.func,
+		onKeyUp: PropTypes.func,
+		onMouseUp: PropTypes.func,
+		onRedo: PropTypes.func,
+		onRemove: PropTypes.func,
+		onReset: PropTypes.func,
+		onShow: PropTypes.func,
+		onSubmit: PropTypes.func,
+		onSetContent: PropTypes.func,
+		onUndo: PropTypes.func,
+		onTextEditorChange: PropTypes.func,
 	},
 
 	contextTypes: {
-		store: React.PropTypes.object
+		store: PropTypes.object,
 	},
 
 	getDefaultProps: function() {

--- a/client/post-editor/editor-drawer-well/index.jsx
+++ b/client/post-editor/editor-drawer-well/index.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { noop, identity } from 'lodash';
 import Gridicon from 'gridicons';

--- a/client/post-editor/editor-drawer/featured-image.jsx
+++ b/client/post-editor/editor-drawer/featured-image.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 

--- a/client/post-editor/editor-featured-image/index.jsx
+++ b/client/post-editor/editor-featured-image/index.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import Gridicon from 'gridicons';
 import { connect } from 'react-redux';
@@ -26,12 +27,14 @@ import { recordTracksEvent } from 'state/analytics/actions';
 
 class EditorFeaturedImage extends Component {
 	static propTypes = {
-		maxWidth: React.PropTypes.number,
-		site: React.PropTypes.object,
-		post: React.PropTypes.object,
-		selecting: React.PropTypes.bool,
-		onImageSelected: React.PropTypes.func,
-		featuredImage: React.PropTypes.object,
+		featuredImage: PropTypes.object,
+		maxWidth: PropTypes.number,
+		site: PropTypes.object,
+		post: PropTypes.object,
+		recordTracksEvent: PropTypes.func,
+		selecting: PropTypes.bool,
+		translate: PropTypes.func,
+		onImageSelected: PropTypes.func,
 	};
 
 	static defaultProps = {

--- a/client/post-editor/editor-html-toolbar/index.jsx
+++ b/client/post-editor/editor-html-toolbar/index.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import {
 	get,
@@ -58,6 +59,7 @@ export class EditorHtmlToolbar extends Component {
 		moment: PropTypes.func,
 		onToolbarChangeContent: PropTypes.func,
 		settingsUpdate: PropTypes.func,
+		site: PropTypes.object,
 		translate: PropTypes.func,
 	};
 


### PR DESCRIPTION
This was originally part of #16819, but that PR was getting too big, so I'm breaking it into multiple ones.