### PR TITLE
Media: Group media library items by date

### DIFF
--- a/client/components/sorted-grid/label.jsx
+++ b/client/components/sorted-grid/label.jsx
@@ -17,7 +17,7 @@ const Label = ( {
 	scale,
 	text,
 } ) => {
-	const margin = ( 1 % scale ) / ( itemsPerRow - 1 ) * 100;
+	const margin = ( ( 1 % scale ) / ( itemsPerRow - 1 ) * 100 ) || 0;
 	const style = {
 		marginRight: `${ lastInRow ? 0 : margin }%`,
 		width: `${ scale * itemsCount * 100 + margin * ( itemsCount - 1 ) }%`,

--- a/client/my-sites/media-library/list.jsx
+++ b/client/my-sites/media-library/list.jsx
@@ -15,13 +15,28 @@ var MediaActions = require( 'lib/media/actions' ),
 	ListItem = require( './list-item' ),
 	ListNoResults = require( './list-no-results' ),
 	ListNoContent = require( './list-no-content' ),
-	InfiniteList = require( 'components/infinite-list' ),
 	user = require( 'lib/user' )();
 
+import SortedGrid from 'components/sorted-grid';
 import ListPlanUpgradeNudge from './list-plan-upgrade-nudge';
 import { getPreference } from 'state/preferences/selectors';
 
 const GOOGLE_MAX_RESULTS = 1000;
+
+const months = [
+	translate( 'January' ),
+	translate( 'February' ),
+	translate( 'March' ),
+	translate( 'April' ),
+	translate( 'May' ),
+	translate( 'June' ),
+	translate( 'July' ),
+	translate( 'August' ),
+	translate( 'September' ),
+	translate( 'October' ),
+	translate( 'November' ),
+	translate( 'December' ),
+];
 
 export const MediaLibraryList = React.createClass( {
 	displayName: 'MediaLibraryList',
@@ -152,6 +167,15 @@ export const MediaLibraryList = React.createClass( {
 		return 'item-' + item.ID;
 	},
 
+	getGroupLabel: function( dateString ) {
+		const date = new Date( dateString );
+		return `${ months[ date.getMonth() ].slice( 0, 3 ) } ${ date.getDate() }`;
+	},
+
+	getItemGroup: function( item ) {
+		return item.date.slice( 0, 10 );
+	},
+
 	renderItem: function( item ) {
 		var index = findIndex( this.props.media, { ID: item.ID } ),
 			selectedItems = this.props.mediaLibrarySelectedItems,
@@ -233,8 +257,10 @@ export const MediaLibraryList = React.createClass( {
 		}.bind( this );
 
 		return (
-			<InfiniteList
+			<SortedGrid
 				ref={ this.setListContext }
+				getItemGroup={ this.getItemGroup }
+				getGroupLabel={ this.getGroupLabel }
 				context={ this.props.scrollable ? this.state.listContext : false }
 				items={ this.props.media || [] }
 				itemsPerRow={ this.getItemsPerRow() }

--- a/client/my-sites/media-library/list.jsx
+++ b/client/my-sites/media-library/list.jsx
@@ -153,7 +153,14 @@ export const MediaLibraryList = React.createClass( {
 	},
 
 	getGroupLabel: function( date ) {
-		return moment( date ).format( 'MMM DD' );
+		const itemDate = new Date( date );
+		const currentDate = new Date();
+
+		if ( itemDate.getYear() === currentDate.getYear() ) {
+			return moment( date ).format( 'MMM DD' );
+		}
+
+		return moment( date ).format( 'MMM DD, YYYY' );
 	},
 
 	getItemGroup: function( item ) {

--- a/client/my-sites/media-library/list.jsx
+++ b/client/my-sites/media-library/list.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { connect } from 'react-redux';
-import { translate } from 'i18n-calypso';
+import { moment, translate } from 'i18n-calypso';
 import { clone, filter, findIndex, noop } from 'lodash';
 const ReactDom = require( 'react-dom' ),
 	React = require( 'react' );
@@ -22,21 +22,6 @@ import ListPlanUpgradeNudge from './list-plan-upgrade-nudge';
 import { getPreference } from 'state/preferences/selectors';
 
 const GOOGLE_MAX_RESULTS = 1000;
-
-const months = [
-	translate( 'January' ),
-	translate( 'February' ),
-	translate( 'March' ),
-	translate( 'April' ),
-	translate( 'May' ),
-	translate( 'June' ),
-	translate( 'July' ),
-	translate( 'August' ),
-	translate( 'September' ),
-	translate( 'October' ),
-	translate( 'November' ),
-	translate( 'December' ),
-];
 
 export const MediaLibraryList = React.createClass( {
 	displayName: 'MediaLibraryList',
@@ -167,9 +152,8 @@ export const MediaLibraryList = React.createClass( {
 		return 'item-' + item.ID;
 	},
 
-	getGroupLabel: function( dateString ) {
-		const date = new Date( dateString );
-		return `${ months[ date.getMonth() ].slice( 0, 3 ) } ${ date.getDate() }`;
+	getGroupLabel: function( date ) {
+		return moment( date ).format( 'MMM DD' );
 	},
 
 	getItemGroup: function( item ) {

--- a/client/my-sites/media-library/test/fixtures/index.js
+++ b/client/my-sites/media-library/test/fixtures/index.js
@@ -43,41 +43,51 @@ module.exports = {
 		{
 			ID: 1009,
 			guid: 'http://example.files.wordpress.com/2015/05/g1009.gif',
+			date: '2017-09-15',
 			URL: 'http://example.files.wordpress.com/2015/05/g1009.gif',
 			thumbnails: {
-				medium: 'http://example.files.wordpress.com/2015/05/g1009-medium.gif'
-			}
+				medium: 'http://example.files.wordpress.com/2015/05/g1009-medium.gif',
+			},
 		}, {
 			ID: 1008,
 			guid: 'http://example.files.wordpress.com/2015/05/g1008.gif',
+			date: '2017-09-15',
 			URL: 'http://example.files.wordpress.com/2015/05/g1009.gif',
 			thumbnails: {
-				fmt_hd: 'http://example.files.wordpress.com/2015/05/g1009-hd.gif'
-			}
+				fmt_hd: 'http://example.files.wordpress.com/2015/05/g1009-hd.gif',
+			},
 		}, {
 			ID: 1007,
-			guid: 'http://example.files.wordpress.com/2015/05/g1007.gif'
+			guid: 'http://example.files.wordpress.com/2015/05/g1007.gif',
+			date: '2017-09-15',
 		}, {
 			ID: 1006,
-			guid: 'http://example.files.wordpress.com/2015/05/g1006.gif'
+			guid: 'http://example.files.wordpress.com/2015/05/g1006.gif',
+			date: '2017-09-08',
 		}, {
 			ID: 1005,
-			guid: 'http://example.files.wordpress.com/2015/05/g1005.gif'
+			guid: 'http://example.files.wordpress.com/2015/05/g1005.gif',
+			date: '2017-09-07',
 		}, {
 			ID: 1004,
-			guid: 'http://example.files.wordpress.com/2015/05/g1004.gif'
+			guid: 'http://example.files.wordpress.com/2015/05/g1004.gif',
+			date: '2017-09-06',
 		}, {
 			ID: 1003,
-			guid: 'http://example.files.wordpress.com/2015/05/g1003.gif'
+			guid: 'http://example.files.wordpress.com/2015/05/g1003.gif',
+			date: '2017-09-05',
 		}, {
 			ID: 1002,
-			guid: 'http://example.files.wordpress.com/2015/05/g1002.gif'
+			guid: 'http://example.files.wordpress.com/2015/05/g1002.gif',
+			date: '2017-09-04',
 		}, {
 			ID: 1001,
-			guid: 'http://example.files.wordpress.com/2015/05/g1001.gif'
+			guid: 'http://example.files.wordpress.com/2015/05/g1001.gif',
+			date: '2017-09-03',
 		}, {
 			ID: 1000,
-			guid: 'http://example.files.wordpress.com/2015/05/g1000.gif'
+			guid: 'http://example.files.wordpress.com/2015/05/g1000.gif',
+			date: '2017-09-02',
 		}
 	]
 };

--- a/client/my-sites/media/style.scss
+++ b/client/my-sites/media/style.scss
@@ -2,7 +2,9 @@
 	max-width: 100%;
 
 	.media-library__list {
-		padding: 0;
+		@include breakpoint( ">660px" ) {
+			padding: 0;
+		}
 	}
 }
 


### PR DESCRIPTION
This PR implements media items organization by date.

Depends on #18052.

<img width="879" alt="screen shot 2017-09-14 at 15 57 44" src="https://user-images.githubusercontent.com/8056203/30460893-d92b0dde-996e-11e7-91c0-04203c276a1c.png">

# Testing

- Go to `/media`
- All items should be organized by date added. Each row should have its own labels.
- Ensure selecting/editing/removing items works as expected.
- Ensure labels are adjusted properly after resizing the images.
- Ensure the labels are shown on both the `WordPress` and `Google Photos` views.