### PR TITLE
Add e2e data attributes to all the editor accordions

### DIFF
--- a/client/post-editor/editor-categories-tags/accordion.jsx
+++ b/client/post-editor/editor-categories-tags/accordion.jsx
@@ -178,6 +178,7 @@ export class EditorCategoriesTagsAccordion extends Component {
 				title={ this.getTitle() }
 				subtitle={ this.getSubtitle() }
 				className={ classes }
+				e2eTitle="categories-tags"
 			>
 				{ this.renderCategories() }
 				{ this.renderTags() }

--- a/client/post-editor/editor-drawer/featured-image.jsx
+++ b/client/post-editor/editor-drawer/featured-image.jsx
@@ -49,7 +49,7 @@ class EditorDrawerFeaturedImage extends Component {
 		const { translate, site, post, isDrawerHidden } = this.props;
 
 		return (
-			<Accordion title={ translate( 'Featured Image' ) } forceExpand={ isDrawerHidden } e2eTitle={ 'featured-image' }>
+			<Accordion title={ translate( 'Featured Image' ) } forceExpand={ isDrawerHidden } e2eTitle="featured-image" >
 				<EditorDrawerWell
 					label={ translate( 'Set Featured Image' ) }
 					empty={ ! site || ! post || ! getFeaturedImageId( post ) }

--- a/client/post-editor/editor-drawer/index.jsx
+++ b/client/post-editor/editor-drawer/index.jsx
@@ -6,6 +6,7 @@ import PropTypes from 'prop-types';
 import createFragment from 'react-addons-create-fragment';
 import { connect } from 'react-redux';
 import { get } from 'lodash';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -178,6 +179,7 @@ const EditorDrawer = React.createClass( {
 
 	renderExcerpt: function() {
 		let excerpt;
+		const { translate } = this.props;
 
 		if ( ! this.currentPostTypeSupports( 'excerpt' ) ) {
 			return;
@@ -190,8 +192,8 @@ const EditorDrawer = React.createClass( {
 		return (
 			<AccordionSection>
 				<EditorDrawerLabel
-					labelText={ this.translate( 'Excerpt' ) }
-					helpText={ this.translate( 'Excerpts are optional hand-crafted summaries of your content.' ) }
+					labelText={ translate( 'Excerpt' ) }
+					helpText={ translate( 'Excerpts are optional hand-crafted summaries of your content.' ) }
 				>
 					<TrackInputChanges onNewValue={ this.recordExcerptChangeStats }>
 						<FormTextarea
@@ -199,8 +201,8 @@ const EditorDrawer = React.createClass( {
 							name="excerpt"
 							onChange={ this.onExcerptChange }
 							value={ excerpt }
-							placeholder={ this.translate( 'Write an excerpt…' ) }
-							aria-label={ this.translate( 'Write an excerpt…' ) }
+							placeholder={ translate( 'Write an excerpt…' ) }
+							aria-label={ translate( 'Write an excerpt…' ) }
 						/>
 					</TrackInputChanges>
 				</EditorDrawerLabel>
@@ -209,6 +211,7 @@ const EditorDrawer = React.createClass( {
 	},
 
 	renderLocation: function() {
+		const { translate } = this.props;
 		if ( ! this.props.site || this.props.isJetpack ) {
 			return;
 		}
@@ -219,7 +222,7 @@ const EditorDrawer = React.createClass( {
 
 		return (
 			<AccordionSection>
-				<EditorDrawerLabel labelText={ this.translate( 'Location' ) } />
+				<EditorDrawerLabel labelText={ translate( 'Location' ) } />
 				<AsyncLoad
 					require="post-editor/editor-location"
 					coordinates={ PostMetadata.geoCoordinates( this.props.post ) }
@@ -283,7 +286,7 @@ const EditorDrawer = React.createClass( {
 	},
 
 	renderMoreOptions: function() {
-		const { isPermalinkEditable } = this.props;
+		const { isPermalinkEditable, translate } = this.props;
 
 		if (
 			! this.currentPostTypeSupports( 'excerpt' ) &&
@@ -296,8 +299,9 @@ const EditorDrawer = React.createClass( {
 
 		return (
 			<Accordion
-				title={ this.translate( 'More Options' ) }
+				title={ translate( 'More Options' ) }
 				className="editor-drawer__more-options"
+				e2eTitle="more-options"
 			>
 				{ isPermalinkEditable && <EditorMoreOptionsSlug /> }
 				{ this.renderExcerpt() }
@@ -320,9 +324,10 @@ const EditorDrawer = React.createClass( {
 		// TODO: REDUX - remove this logic and prop for EditPostStatus when date is moved to redux
 		const postDate = get( this.props.post, 'date', null );
 		const postStatus = get( this.props.post, 'status', null );
+		const { translate } = this.props;
 
 		return (
-			<Accordion title={ this.translate( 'Status' ) }>
+			<Accordion title={ translate( 'Status' ) } e2eTitle="status" >
 				<EditPostStatus
 					savedPost={ this.props.savedPost }
 					postDate={ postDate }
@@ -383,4 +388,4 @@ export default connect(
 	null,
 	null,
 	{ pure: false }
-)( EditorDrawer );
+)( localize( EditorDrawer ) );

--- a/client/post-editor/editor-drawer/page-options.jsx
+++ b/client/post-editor/editor-drawer/page-options.jsx
@@ -27,7 +27,7 @@ function EditorDrawerPageOptions( { translate, postType, hierarchical } ) {
 	}
 
 	return (
-		<Accordion title={ title }>
+		<Accordion title={ title } e2etitle="page-options">
 			{ hierarchical && (
 				<PageParent />
 			) }

--- a/client/post-editor/editor-drawer/taxonomies.jsx
+++ b/client/post-editor/editor-drawer/taxonomies.jsx
@@ -70,6 +70,7 @@ function EditorDrawerTaxonomies( { translate, siteId, postType, isSupported, tax
 						key={ name }
 						title={ label }
 						subtitle={ subtitle }
+						e2eTitle="taxonomies"
 					>
 					{ hierarchical
 						? <TermSelector compact taxonomyName={ name } />

--- a/client/post-editor/editor-post-formats/accordion.jsx
+++ b/client/post-editor/editor-post-formats/accordion.jsx
@@ -68,7 +68,8 @@ const EditorPostFormatsAccordion = React.createClass( {
 					<Accordion
 						title={ this.translate( 'Post Format' ) }
 						subtitle={ this.getSubtitle() }
-						className={ classes }>
+						className={ classes }
+						e2eTitle="post-format">
 						<PostFormats value={ this.getFormatValue() } />
 					</Accordion>
 				) }

--- a/client/post-editor/editor-seo-accordion/index.jsx
+++ b/client/post-editor/editor-seo-accordion/index.jsx
@@ -55,6 +55,7 @@ class EditorSeoAccordion extends Component {
 			<Accordion
 				title={ translate( 'SEO Description' ) }
 				className="editor-seo-accordion"
+				e2eTitle="seo"
 			>
 				<AccordionSection>
 					<EditorDrawerLabel

--- a/client/post-editor/editor-sharing/accordion.jsx
+++ b/client/post-editor/editor-sharing/accordion.jsx
@@ -120,7 +120,8 @@ const EditorSharingAccordion = React.createClass( {
 				title={ this.translate( 'Sharing' ) }
 				subtitle={ this.getSubtitle() }
 				status={ status }
-				className={ classes }>
+				className={ classes }
+				e2eTitle="sharing">
 				{ this.props.site && (
 					<QueryPublicizeConnections siteId={ this.props.site.ID } />
 				) }


### PR DESCRIPTION
This is to make sure that our e2e tests are reliable and easy to maintain

This also uses localize for the `editor-drawer` as this was failing ES lint

**Testing Instructions**

* Open the editor sidebar and make sure all the accordions display as expected
* Open the browser DOM and check that each accordion has an `data-e2e-title` attribute for it

