### PR TITLE
Disable restore last location in development and wpcalypso

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -141,7 +141,7 @@
 		"reader/tags-with-elasticsearch": false,
 		"resume-editing": true,
 		"republicize": true,
-		"restore-last-location": true,
+		"restore-last-location": false,
 		"rubberband-scroll-disable": false,
 		"server-side-rendering": true,
 		"settings/security/monitor": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -105,7 +105,7 @@
 		"reader/tags-with-elasticsearch": false,
 		"resume-editing": true,
 		"republicize": true,
-		"restore-last-location": true,
+		"restore-last-location": false,
 		"rubberband-scroll-disable": false,
 		"server-side-rendering": true,
 		"settings/security/monitor": true,


### PR DESCRIPTION
This was disabled in stage but not for these environments

@jblz: is it okay if we disable this in these two environments? It's still gets me confused on calypso.localhost and we have different behaviour locally to stage/production.

**Testing Instructions**

1. Open `calypso.localhost:3000` and visit a page in calypso
2. Open a new tab and open `calypso.localhost:3000` and make sure the other page doesn't load