### PR TITLE
Codemods: sort imports

### DIFF
--- a/bin/codemods/sort-imports
+++ b/bin/codemods/sort-imports
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+
+/*
+	How to use:
+	./bin/codemods/sort-imports path-to-transform/
+*/
+
+/**
+ * External dependencies
+ */
+const path = require( 'path' );
+const child_process = require( 'child_process' );
+
+/**
+ * Internal dependencies
+ */
+const config = require( './src/config' );
+const helpers = require( './src/helpers' );
+
+const args = process.argv.slice( 2 );
+if ( args.length === 0 ) {
+	process.stdout.write( 'No files to transform\n' );
+	process.exit( 0 );
+}
+
+const binArgs = [
+	// jscodeshift options
+	'--transform=bin/codemods/src/sort-imports.js',
+	...config.jscodeshiftArgs,
+
+	// Transform target
+	...args,
+];
+const binPath = path.join( '.', 'node_modules', '.bin', 'jscodeshift' );
+const jscodeshift = child_process.spawn( binPath, binArgs );
+helpers.bindEvents( jscodeshift );

--- a/bin/codemods/sort-imports
+++ b/bin/codemods/sort-imports
@@ -1,8 +1,11 @@
 #!/usr/bin/env node
 
 /*
-	How to use:
+	How to use: run this command twice
 	./bin/codemods/sort-imports path-to-transform/
+
+	Note: it only needs to be run twice because of a bug where in certain cases an extra newline is added
+	on the first run.  The second run removes the extra newline.
 */
 
 /**

--- a/bin/codemods/src/sort-imports.js
+++ b/bin/codemods/src/sort-imports.js
@@ -1,0 +1,103 @@
+
+/**
+ * This codeshift takes all of the imports for a file, and organizes them into two sections:
+ * External dependencies and Internal Dependencies.
+ *
+ * It is smart enough to retain whether or not a docblock should keep a prettier/formatter pragma
+ */
+const fs = require( 'fs' );
+const _ = require( 'lodash' );
+
+/**
+ * Gather all of the external deps and throw them in a set
+ */
+const packageJson = JSON.parse( fs.readFileSync( './package.json', 'utf8' ) );
+const packageJsonDeps = []
+	.concat( Object.keys( packageJson.dependencies ) )
+	.concat( Object.keys( packageJson.devDependencies ) );
+
+const externalDependenciesSet = new Set( packageJsonDeps );
+
+const externalBlock = { type: "Block", value: "*\n * External dependencies\n " };
+const internalBlock = { type: "Block", value: "*\n * Internal dependencies\n " };
+
+
+/**
+ * Returns true if the given text contains @format.
+ * within its first docblock. False otherwise.
+ *
+ * @param {String} text text to scan for the format keyword within the first docblock
+ */
+const shouldFormat = text => {
+	const firstDocBlockStartIndex = text.indexOf( '/**' );
+
+	if ( -1 === firstDocBlockStartIndex ) {
+		return false;
+	}
+
+	const firstDocBlockEndIndex = text.indexOf( '*/', firstDocBlockStartIndex + 1 );
+
+	if ( -1 === firstDocBlockEndIndex ) {
+		return false;
+	}
+
+	const firstDocBlockText = text.substring( firstDocBlockStartIndex, firstDocBlockEndIndex + 1 );
+	return firstDocBlockText.indexOf( '@format' ) >= 0;
+};
+
+
+/**
+ * Removes the extra newlines between two import statements
+ */
+const removeExtraNewlines = str => str.replace(/(import.*\n)\n+(import)/g, '$1$2');
+
+/**
+ * Adds a newline in between the last import of external deps + the internal deps docblock
+ */
+const addNewlineBeforeDocBlock = str => str.replace( /(import.*\n)(\/\*\*)/, '$1\n$2' );
+const isExternal = importNode => externalDependenciesSet.has( importNode.source.value );
+
+/**
+ *
+ * @param {Array} importNodes the import nodes to sort
+ * @returns {Array} the sorted set of import nodes
+ */
+const sortImports = importNodes => _.sortBy( importNodes, node => node.source.value );
+
+module.exports = function ( file, api ) {
+	const j = api.jscodeshift;
+	const src = j(file.source);
+	const includeFormatBlock = shouldFormat( src.toSource().toString() );
+	const declarations = src.find(j.ImportDeclaration);
+
+	const withoutComments = declarations
+	  .nodes()
+	  .map( node => { node.comments = ''; return node } );
+
+	const externalDeps = sortImports( withoutComments.filter( node => isExternal( node ) ) );
+	const internalDeps = sortImports( withoutComments.filter( node => ! isExternal( node ) ) );
+
+
+	if ( externalDeps[0]) {
+		externalDeps[0].comments = [ externalBlock ];
+	}
+	if ( internalDeps[0] ) {
+		internalDeps[0].comments = [ internalBlock ]
+	}
+
+	const newDeclarations = []
+		.concat( includeFormatBlock && '/** @format */')
+		.concat( externalDeps )
+		.concat( internalDeps );
+
+	declarations.remove();
+
+	return  addNewlineBeforeDocBlock(
+		removeExtraNewlines(
+			src
+				.find(j.Statement)
+				.at(0)
+				.insertBefore(newDeclarations)
+				.toSource( { quote: 'single' } ) )
+		);
+};

--- a/bin/codemods/src/sort-imports.js
+++ b/bin/codemods/src/sort-imports.js
@@ -70,6 +70,11 @@ module.exports = function ( file, api ) {
 	const includeFormatBlock = shouldFormat( src.toSource().toString() );
 	const declarations = src.find(j.ImportDeclaration);
 
+	// if there are no deps at all, then return early.
+	if ( isEmpty( declarations.nodes() ) ) {
+		return file.source;
+	}
+
 	const withoutComments = declarations
 	  .nodes()
 	  .map( node => { node.comments = ''; return node } );

--- a/bin/codemods/src/sort-imports.js
+++ b/bin/codemods/src/sort-imports.js
@@ -71,7 +71,7 @@ module.exports = function ( file, api ) {
 	const declarations = src.find(j.ImportDeclaration);
 
 	// if there are no deps at all, then return early.
-	if ( isEmpty( declarations.nodes() ) ) {
+	if ( _.isEmpty( declarations.nodes() ) ) {
 		return file.source;
 	}
 

--- a/bin/codemods/src/sort-imports.js
+++ b/bin/codemods/src/sort-imports.js
@@ -55,7 +55,7 @@ const removeExtraNewlines = str => str.replace(/(import.*\n)\n+(import)/g, '$1$2
  * Adds a newline in between the last import of external deps + the internal deps docblock
  */
 const addNewlineBeforeDocBlock = str => str.replace( /(import.*\n)(\/\*\*)/, '$1\n$2' );
-const isExternal = importNode => externalDependenciesSet.has( importNode.source.value );
+const isExternal = importNode => externalDependenciesSet.has( importNode.source.value.split('/')[ 0 ] );
 
 /**
  *


### PR DESCRIPTION
While [running a codemod](https://github.com/Automattic/wp-calypso/pull/18069) to convert all of our `React.PropTypes` to be from `prop-types` I noticed that our custom external/internal blocks are being mangled.


This PR introduces a new codemod that sorts the import declarations into internal/external groupings.  My hope is that this can make using codemods easier


It can turn something like:
```js
import React from 'react';
import classnames from 'classnames';
import page from 'page';
/** @format */
/**
 * External Dependencies */
import PropTypes from 'prop-types';
import qs from 'qs';
import { get, defer } from 'lodash';

/**
 * Internal dependencies
 */
import { getCurrentUser } from 'state/current-user/select'
import Gridicon from 'gridicons';
```

Into: 

```js
/** @format */
/**
 * External dependencies
 */
import React from 'react';
import classnames from 'classnames';
import page from 'page';
import PropTypes from 'prop-types';
import qs from 'qs';
import { get, defer } from 'lodash';
import Gridicon from 'gridicons';

/**
 * Internal dependencies
 */
import { getCurrentUser } from 'state/current-user/select';
```


cc @gziolo who was the first one i've heard to have this idea