### PR TITLE
Components: Run codemods on search components

### DIFF
--- a/client/components/search-card/index.jsx
+++ b/client/components/search-card/index.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
 /**
@@ -12,19 +13,19 @@ import Search from 'components/search';
 
 class SearchCard extends React.Component {
 	static propTypes = {
-		additionalClasses: React.PropTypes.string,
-		initialValue: React.PropTypes.string,
-		placeholder: React.PropTypes.string,
-		delaySearch: React.PropTypes.bool,
-		onSearch: React.PropTypes.func.isRequired,
-		onSearchChange: React.PropTypes.func,
-		analyticsGroup: React.PropTypes.string,
-		autoFocus: React.PropTypes.bool,
-		disabled: React.PropTypes.bool,
-		dir: React.PropTypes.string,
-		maxLength: React.PropTypes.number,
-		hideOpenIcon: React.PropTypes.bool,
-		disableAutocorrect: React.PropTypes.bool,
+		additionalClasses: PropTypes.string,
+		initialValue: PropTypes.string,
+		placeholder: PropTypes.string,
+		delaySearch: PropTypes.bool,
+		onSearch: PropTypes.func.isRequired,
+		onSearchChange: PropTypes.func,
+		analyticsGroup: PropTypes.string,
+		autoFocus: PropTypes.bool,
+		disabled: PropTypes.bool,
+		dir: PropTypes.string,
+		maxLength: PropTypes.number,
+		hideOpenIcon: PropTypes.bool,
+		disableAutocorrect: PropTypes.bool,
 	};
 
 	render() {

--- a/client/components/search/docs/example.jsx
+++ b/client/components/search/docs/example.jsx
@@ -1,8 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
-import PureRenderMixin from 'react-pure-render/mixin';
+import React, { PureComponent } from 'react';
 
 /**
  * Internal dependencies
@@ -15,12 +14,10 @@ import SearchCard from 'components/search-card';
  */
 var noop = () => {};
 
-var SearchDemo = React.createClass( {
-	displayName: 'Search',
+class SearchDemo extends PureComponent {
+    static displayName = 'Search';
 
-	mixins: [ PureRenderMixin ],
-
-	render: function() {
+	render() {
 		return (
 			<div>
 				<Search
@@ -37,6 +34,6 @@ var SearchDemo = React.createClass( {
 			</div>
 		);
 	}
-} );
+}
 
 export default SearchDemo;

--- a/client/components/search/docs/example.jsx
+++ b/client/components/search/docs/example.jsx
@@ -39,4 +39,4 @@ var SearchDemo = React.createClass( {
 	}
 } );
 
-module.exports = SearchDemo;
+export default SearchDemo;

--- a/client/components/search/docs/example.jsx
+++ b/client/components/search/docs/example.jsx
@@ -1,14 +1,14 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	PureRenderMixin = require( 'react-pure-render/mixin' );
+import React from 'react';
+import PureRenderMixin from 'react-pure-render/mixin';
 
 /**
  * Internal dependencies
  */
-var Search = require( 'components/search' ),
-	SearchCard = require( 'components/search-card' );
+import Search from 'components/search';
+import SearchCard from 'components/search-card';
 
 /**
  * Globals

--- a/client/components/search/index.jsx
+++ b/client/components/search/index.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import ReactDom from 'react-dom';
-import React, { PropTypes } from 'react';
+import React, { Component, PropTypes } from 'react';
 import classNames from 'classnames';
 import { debounce, noop } from 'lodash';
 import i18n from 'i18n-calypso';
@@ -29,14 +29,11 @@ function keyListener( methodToCall, event ) {
 	}
 }
 
-const Search = React.createClass( {
-	displayName: 'Search',
+class Search extends Component {
+	static displayName = 'Search';
+	static instances = 0;
 
-	statics: {
-		instances: 0,
-	},
-
-	propTypes: {
+	static propTypes = {
 		additionalClasses: PropTypes.string,
 		initialValue: PropTypes.string,
 		value: PropTypes.string,
@@ -65,52 +62,48 @@ const Search = React.createClass( {
 		compact: PropTypes.bool,
 		hideOpenIcon: PropTypes.bool,
 		inputLabel: PropTypes.string,
-	},
+	};
 
-	getInitialState: function() {
-		return {
-			keyword: this.props.initialValue || '',
-			isOpen: !! this.props.isOpen,
-			hasFocus: false,
-		};
-	},
+	static defaultProps = {
+		pinned: false,
+		delaySearch: false,
+		delayTimeout: SEARCH_DEBOUNCE_MS,
+		autoFocus: false,
+		disabled: false,
+		onSearchChange: noop,
+		onSearchOpen: noop,
+		onSearchClose: noop,
+		onKeyDown: noop,
+		onClick: noop,
+		//undefined value for overlayStyling is an optimization that will
+		//disable overlay scrolling calculation when no overlay is provided.
+		overlayStyling: undefined,
+		disableAutocorrect: false,
+		searching: false,
+		isOpen: false,
+		dir: undefined,
+		fitsContainer: false,
+		hideClose: false,
+		compact: false,
+		hideOpenIcon: false,
+	};
 
-	getDefaultProps: function() {
-		return {
-			pinned: false,
-			delaySearch: false,
-			delayTimeout: SEARCH_DEBOUNCE_MS,
-			autoFocus: false,
-			disabled: false,
-			onSearchChange: noop,
-			onSearchOpen: noop,
-			onSearchClose: noop,
-			onKeyDown: noop,
-			onClick: noop,
-			//undefined value for overlayStyling is an optimization that will
-			//disable overlay scrolling calculation when no overlay is provided.
-			overlayStyling: undefined,
-			disableAutocorrect: false,
-			searching: false,
-			isOpen: false,
-			dir: undefined,
-			fitsContainer: false,
-			hideClose: false,
-			compact: false,
-			hideOpenIcon: false,
-		};
-	},
+	state = {
+		keyword: this.props.initialValue || '',
+		isOpen: !! this.props.isOpen,
+		hasFocus: false,
+	};
 
-	componentWillMount: function() {
+	componentWillMount() {
 		this.setState( {
 			instanceId: ++Search.instances,
 		} );
 
 		this.closeListener = keyListener.bind( this, 'closeSearch' );
 		this.openListener = keyListener.bind( this, 'openSearch' );
-	},
+	}
 
-	componentWillReceiveProps: function( nextProps ) {
+	componentWillReceiveProps( nextProps ) {
 		if (
 			nextProps.onSearch !== this.props.onSearch ||
 			nextProps.delaySearch !== this.props.delaySearch
@@ -131,9 +124,9 @@ const Search = React.createClass( {
 		) {
 			this.setState( { keyword: nextProps.value } );
 		}
-	},
+	}
 
-	componentDidUpdate: function( prevProps, prevState ) {
+	componentDidUpdate( prevProps, prevState ) {
 		this.scrollOverlay();
 		// Focus if the search box was opened or the autoFocus prop has changed
 		if (
@@ -161,9 +154,9 @@ const Search = React.createClass( {
 			this.props.onSearch( this.state.keyword );
 		}
 		this.props.onSearchChange( this.state.keyword );
-	},
+	}
 
-	componentDidMount: function() {
+	componentDidMount() {
 		this.onSearch = this.props.delaySearch
 			? debounce( this.props.onSearch, this.props.delayTimeout )
 			: this.props.onSearch;
@@ -172,21 +165,21 @@ const Search = React.createClass( {
 			// this hack makes autoFocus work correctly in Dropdown
 			setTimeout( () => this.focus(), 0 );
 		}
-	},
+	}
 
-	scrollOverlay: function() {
+	scrollOverlay = () => {
 		this.refs.overlay &&
 			window.requestAnimationFrame( () => {
 				if ( this.refs.overlay && this.refs.searchInput ) {
 					this.refs.overlay.scrollLeft = this.getScrollLeft( this.refs.searchInput );
 				}
 			} );
-	},
+	};
 
 	//This is fix for IE11. Does not work on Edge.
 	//On IE11 scrollLeft value for input is always 0.
 	//We are calculating it manually using TextRange object.
-	getScrollLeft: function( inputElement ) {
+	getScrollLeft = inputElement => {
 		//TextRange is IE11 specific so this checks if we are not on IE11.
 		if ( ! inputElement.createTextRange ) {
 			return inputElement.scrollLeft;
@@ -202,44 +195,44 @@ const Search = React.createClass( {
 			paddingLeft -
 			rangeRect.left;
 		return scrollLeft;
-	},
+	};
 
-	focus: function() {
+	focus = () => {
 		// if we call focus before the element has been entirely synced up with the DOM, we stand a decent chance of
 		// causing the browser to scroll somewhere odd. Instead, defer the focus until a future turn of the event loop.
 		setTimeout(
 			() => this.refs.searchInput && ReactDom.findDOMNode( this.refs.searchInput ).focus(),
 			0
 		);
-	},
+	};
 
-	blur: function() {
+	blur = () => {
 		ReactDom.findDOMNode( this.refs.searchInput ).blur();
-	},
+	};
 
-	getCurrentSearchValue: function() {
+	getCurrentSearchValue = () => {
 		return ReactDom.findDOMNode( this.refs.searchInput ).value;
-	},
+	};
 
-	clear: function() {
+	clear = () => {
 		this.setState( { keyword: '' } );
-	},
+	};
 
-	onBlur: function( event ) {
+	onBlur = event => {
 		if ( this.props.onBlur ) {
 			this.props.onBlur( event );
 		}
 
 		this.setState( { hasFocus: false } );
-	},
+	};
 
-	onChange: function() {
+	onChange = () => {
 		this.setState( {
 			keyword: this.getCurrentSearchValue(),
 		} );
-	},
+	};
 
-	openSearch: function( event ) {
+	openSearch = event => {
 		event.preventDefault();
 		this.setState( {
 			keyword: '',
@@ -247,9 +240,9 @@ const Search = React.createClass( {
 		} );
 
 		analytics.ga.recordEvent( this.props.analyticsGroup, 'Clicked Open Search' );
-	},
+	};
 
-	closeSearch: function( event ) {
+	closeSearch = event => {
 		event.preventDefault();
 
 		if ( this.props.disabled ) {
@@ -273,9 +266,9 @@ const Search = React.createClass( {
 		this.props.onSearchClose( event );
 
 		analytics.ga.recordEvent( this.props.analyticsGroup, 'Clicked Close Search' );
-	},
+	};
 
-	keyUp: function( event ) {
+	keyUp = event => {
 		if ( event.key === 'Enter' && isMobile() ) {
 			//dismiss soft keyboards
 			this.blur();
@@ -289,19 +282,19 @@ const Search = React.createClass( {
 			this.closeSearch( event );
 		}
 		this.scrollOverlay();
-	},
+	};
 
-	keyDown: function( event ) {
+	keyDown = event => {
 		this.scrollOverlay();
 		if ( event.key === 'Escape' && event.target.value === '' ) {
 			this.closeSearch( event );
 		}
 		this.props.onKeyDown( event );
-	},
+	};
 
 	// Puts the cursor at end of the text when starting
 	// with `initialValue` set.
-	onFocus: function() {
+	onFocus = () => {
 		const input = ReactDom.findDOMNode( this.refs.searchInput ),
 			setValue = input.value;
 
@@ -313,9 +306,9 @@ const Search = React.createClass( {
 
 		this.setState( { hasFocus: true } );
 		this.props.onSearchOpen();
-	},
+	};
 
-	render: function() {
+	render() {
 		const searchValue = this.state.keyword;
 		const placeholder = this.props.placeholder || i18n.translate( 'Search…', { textOnly: true } );
 		const inputLabel = this.props.inputLabel;
@@ -387,17 +380,17 @@ const Search = React.createClass( {
 				{ this.closeButton() }
 			</div>
 		);
-	},
+	}
 
-	renderStylingDiv: function() {
+	renderStylingDiv = () => {
 		return (
 			<div className="search__text-overlay" ref="overlay">
 				{ this.props.overlayStyling( this.state.keyword ) }
 			</div>
 		);
-	},
+	};
 
-	closeButton: function() {
+	closeButton = () => {
 		if ( ! this.props.hideClose && ( this.state.keyword || this.state.isOpen ) ) {
 			return (
 				<div
@@ -414,7 +407,7 @@ const Search = React.createClass( {
 		}
 
 		return null;
-	},
-} );
+	};
+}
 
 export default Search;

--- a/client/components/search/index.jsx
+++ b/client/components/search/index.jsx
@@ -1,8 +1,9 @@
 /**
  * External dependencies
  */
+import React, { Component } from 'react';
 import ReactDom from 'react-dom';
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { debounce, noop } from 'lodash';
 import i18n from 'i18n-calypso';

--- a/client/components/search/index.jsx
+++ b/client/components/search/index.jsx
@@ -417,4 +417,4 @@ const Search = React.createClass( {
 	},
 } );
 
-module.exports = Search;
+export default Search;

--- a/client/components/search/test/index.jsx
+++ b/client/components/search/test/index.jsx
@@ -7,7 +7,7 @@ import useMockery from 'test/helpers/use-mockery';
 import useFakeDom from 'test/helpers/use-fake-dom';
 
 describe( 'Search', function() {
-	var React, TestUtils, EMPTY_COMPONENT;
+	let React, TestUtils, EMPTY_COMPONENT;
 
 	useFakeDom();
 	useMockery( mockery => {


### PR DESCRIPTION
This change runs several codemods on the `Search` and `SearchCard` components to achieve the following:

Before | After
------------ | -------------
`require( ... )` nested in blocks | All `require( ... )` moved to top block
`var ... = require( ... )` | `import ... from '...'`
`module.exports = ...` | `export default ...`
`this.translate` | `this.props.translate` via HOC
`React.createClass( ... )` | `class ThisComponentName extends React.Component`
`React.createClass( ... )` | `createReactClass( ... )` if unconvertible to `React.Component` subclass
`import { PropTypes } from 'react'` | `import PropTypes from 'prop-types'`

**To test**

- Run the search component test: `npm run test-client client/components/search`
- Check that search displays correctly in calypso
- and/or check the display in devdocs `/devdocs/design/search`