### PR TITLE
Components: Run codemods on section-header & section-nav

### DIFF
--- a/client/components/section-header/docs/example.jsx
+++ b/client/components/section-header/docs/example.jsx
@@ -2,7 +2,6 @@
 * External dependencies
 */
 import React, { PureComponent } from 'react';
-import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -16,26 +15,22 @@ class SectionHeaderExample extends PureComponent {
 	render() {
 		return (
 			<div>
-				<SectionHeader label={ this.props.translate( 'Team' ) } count={ 10 }>
-					<Button compact primary>
-						{ this.props.translate( 'Primary Action' ) }
-					</Button>
-					<Button compact>
-						{ this.props.translate( 'Manage' ) }
-					</Button>
+				<SectionHeader label="Team" count={ 10 }>
+					<Button compact primary>Primary Action</Button>
+					<Button compact>Manage</Button>
 					<Button
 						compact
 						onClick={ function() {
 							alert( 'Clicked add button' );
 						} }
 					>
-						{ this.props.translate( 'Add' ) }
+						Add
 					</Button>
 				</SectionHeader>
 
 				<h3>Clickable SectionHeader</h3>
 
-				<SectionHeader label={ this.props.translate( 'Team' ) } count={ 10 } href="/devdocs/design/section-header">
+				<SectionHeader label="Team" count={ 10 } href="/devdocs/design/section-header">
 				</SectionHeader>
 
 				<h3>Empty SectionHeader</h3>
@@ -45,4 +40,4 @@ class SectionHeaderExample extends PureComponent {
 	}
 }
 
-export default localize( SectionHeader );
+export default SectionHeaderExample;

--- a/client/components/section-header/docs/example.jsx
+++ b/client/components/section-header/docs/example.jsx
@@ -47,4 +47,4 @@ var Cards = React.createClass( {
 	}
 } );
 
-module.exports = Cards;
+export default Cards;

--- a/client/components/section-header/docs/example.jsx
+++ b/client/components/section-header/docs/example.jsx
@@ -1,9 +1,8 @@
 /**
 * External dependencies
 */
-import React from 'react';
+import React, { PureComponent } from 'react';
 import { localize } from 'i18n-calypso';
-import PureRenderMixin from 'react-pure-render/mixin';
 
 /**
  * Internal dependencies
@@ -11,14 +10,12 @@ import PureRenderMixin from 'react-pure-render/mixin';
 import Button from 'components/button';
 import SectionHeader from 'components/section-header';
 
-var Cards = React.createClass( {
-	displayName: 'SectionHeader',
+class SectionHeader extends PureComponent {
+	static displayName = 'SectionHeader';
 
-	mixins: [ PureRenderMixin ],
-
-	render: function() {
+	render() {
 		return (
-		    <div>
+			<div>
 				<SectionHeader label={ this.props.translate( 'Team' ) } count={ 10 }>
 					<Button compact primary>
 						{ this.props.translate( 'Primary Action' ) }
@@ -46,6 +43,6 @@ var Cards = React.createClass( {
 			</div>
 		);
 	}
-} );
+}
 
-export default localize(Cards);
+export default localize( SectionHeader );

--- a/client/components/section-header/docs/example.jsx
+++ b/client/components/section-header/docs/example.jsx
@@ -1,14 +1,14 @@
 /**
 * External dependencies
 */
-var React = require( 'react' ),
-	PureRenderMixin = require( 'react-pure-render/mixin' );
+import React from 'react';
+import PureRenderMixin from 'react-pure-render/mixin';
 
 /**
  * Internal dependencies
  */
-var SectionHeader = require( 'components/section-header' ),
-	Button = require( 'components/button' );
+import Button from 'components/button';
+import SectionHeader from 'components/section-header';
 
 var Cards = React.createClass( {
 	displayName: 'SectionHeader',

--- a/client/components/section-header/docs/example.jsx
+++ b/client/components/section-header/docs/example.jsx
@@ -8,6 +8,7 @@ import React, { PureComponent } from 'react';
  */
 import Button from 'components/button';
 import SectionHeader from 'components/section-header';
+import { translate } from 'i18n-calypso';
 
 class SectionHeaderExample extends PureComponent {
 	static displayName = 'SectionHeader';
@@ -15,25 +16,25 @@ class SectionHeaderExample extends PureComponent {
 	render() {
 		return (
 			<div>
-				<SectionHeader label="Team" count={ 10 }>
-					<Button compact primary>Primary Action</Button>
-					<Button compact>Manage</Button>
+				<SectionHeader label={ translate( 'Team' ) } count={ 10 }>
+					<Button compact primary>{ translate( 'Primary Action' ) }</Button>
+					<Button compact>{ translate( 'Manage' ) }</Button>
 					<Button
 						compact
 						onClick={ function() {
-							alert( 'Clicked add button' );
+							alert( translate( 'Clicked add button' ) );
 						} }
 					>
-						Add
+						{ translate( 'Add' ) }
 					</Button>
 				</SectionHeader>
 
-				<h3>Clickable SectionHeader</h3>
+				<h3>{ translate( 'Clickable SectionHeader' ) }</h3>
 
-				<SectionHeader label="Team" count={ 10 } href="/devdocs/design/section-header">
+				<SectionHeader label={ translate( 'Team' ) } count={ 10 } href="/devdocs/design/section-header">
 				</SectionHeader>
 
-				<h3>Empty SectionHeader</h3>
+				<h3>{ translate( 'Empty SectionHeader' ) }</h3>
 				<SectionHeader />
 			</div>
 		);

--- a/client/components/section-header/docs/example.jsx
+++ b/client/components/section-header/docs/example.jsx
@@ -10,7 +10,7 @@ import { localize } from 'i18n-calypso';
 import Button from 'components/button';
 import SectionHeader from 'components/section-header';
 
-class SectionHeader extends PureComponent {
+class SectionHeaderExample extends PureComponent {
 	static displayName = 'SectionHeader';
 
 	render() {

--- a/client/components/section-header/docs/example.jsx
+++ b/client/components/section-header/docs/example.jsx
@@ -2,6 +2,7 @@
 * External dependencies
 */
 import React from 'react';
+import { localize } from 'i18n-calypso';
 import PureRenderMixin from 'react-pure-render/mixin';
 
 /**
@@ -17,13 +18,13 @@ var Cards = React.createClass( {
 
 	render: function() {
 		return (
-			<div>
-				<SectionHeader label={ this.translate( 'Team' ) } count={ 10 }>
+		    <div>
+				<SectionHeader label={ this.props.translate( 'Team' ) } count={ 10 }>
 					<Button compact primary>
-						{ this.translate( 'Primary Action' ) }
+						{ this.props.translate( 'Primary Action' ) }
 					</Button>
 					<Button compact>
-						{ this.translate( 'Manage' ) }
+						{ this.props.translate( 'Manage' ) }
 					</Button>
 					<Button
 						compact
@@ -31,13 +32,13 @@ var Cards = React.createClass( {
 							alert( 'Clicked add button' );
 						} }
 					>
-						{ this.translate( 'Add' ) }
+						{ this.props.translate( 'Add' ) }
 					</Button>
 				</SectionHeader>
 
 				<h3>Clickable SectionHeader</h3>
 
-				<SectionHeader label={ this.translate( 'Team' ) } count={ 10 } href="/devdocs/design/section-header">
+				<SectionHeader label={ this.props.translate( 'Team' ) } count={ 10 } href="/devdocs/design/section-header">
 				</SectionHeader>
 
 				<h3>Empty SectionHeader</h3>
@@ -47,4 +48,4 @@ var Cards = React.createClass( {
 	}
 } );
 
-export default Cards;
+export default localize(Cards);

--- a/client/components/section-nav/docs/example.jsx
+++ b/client/components/section-nav/docs/example.jsx
@@ -186,4 +186,4 @@ var SectionNavigation = React.createClass( {
 	}
 } );
 
-module.exports = SectionNavigation;
+export default SectionNavigation;

--- a/client/components/section-nav/docs/example.jsx
+++ b/client/components/section-nav/docs/example.jsx
@@ -2,8 +2,7 @@
  * External dependencies
  */
 import { forEach, omit } from 'lodash';
-import React from 'react';
-import PureRenderMixin from 'react-pure-render/mixin';
+import React, { PureComponent } from 'react';
 
 /**
  * Internal dependencies
@@ -17,70 +16,64 @@ import SectionNav from 'components/section-nav';
 /**
  * Main
  */
-var SectionNavigation = React.createClass( {
-	displayName: 'SectionNav',
+class SectionNavigation extends PureComponent {
+	static displayName = 'SectionNav';
 
-	mixins: [ PureRenderMixin ],
+	static defaultProps = {
+		basicTabs: [
+			'Days',
+			'Weeks',
+			{
+				name: 'Months',
+				count: 45
+			},
+			{
+				name: 'Years',
+				count: 11
+			}
+		],
+		manyTabs: [
+			'Staff Picks',
+			'Trending',
+			'Blog',
+			{
+				name: 'Business',
+				count: 8761
+			},
+			'Food',
+			'Music',
+			{
+				name: 'Travel',
+				count: 761
+			},
+			'Wedding',
+			'Minimal',
+			'Magazine',
+			'Photography'
+		],
+		siblingTabs: [
+			{
+				name: 'Published',
+				count: 8
+			},
+			'Scheduled',
+			'Drafts',
+			'Trashed'
+		],
+		siblingSegmented: [
+			'Only Me',
+			'Everyone'
+		]
+	};
 
-	getInitialState: function() {
-		return {
-			basicTabsSelectedIndex: 0,
-			manyTabsSelectedIndex: 0,
-			siblingTabsSelectedIndex: 0,
-			siblingSegmentedSelectedIndex: 0
-		};
-	},
+	state = {
+		basicTabsSelectedIndex: 0,
+		manyTabsSelectedIndex: 0,
+		siblingTabsSelectedIndex: 0,
+		siblingSegmentedSelectedIndex: 0
+	};
 
-	getDefaultProps: function() {
-		return {
-			basicTabs: [
-				'Days',
-				'Weeks',
-				{
-					name: 'Months',
-					count: 45
-				},
-				{
-					name: 'Years',
-					count: 11
-				}
-			],
-			manyTabs: [
-				'Staff Picks',
-				'Trending',
-				'Blog',
-				{
-					name: 'Business',
-					count: 8761
-				},
-				'Food',
-				'Music',
-				{
-					name: 'Travel',
-					count: 761
-				},
-				'Wedding',
-				'Minimal',
-				'Magazine',
-				'Photography'
-			],
-			siblingTabs: [
-				{
-					name: 'Published',
-					count: 8
-				},
-				'Scheduled',
-				'Drafts',
-				'Trashed'
-			],
-			siblingSegmented: [
-				'Only Me',
-				'Everyone'
-			]
-		};
-	},
-
-	render: function() {
+	render() {
 		var demoSections = {};
 
 		forEach( omit( this.props, 'isolated', 'uniqueInstance' ), function( prop, key ) {
@@ -145,45 +138,45 @@ var SectionNavigation = React.createClass( {
 				</SectionNav>
 			</div>
 		);
-	},
+	}
 
-	getSelectedText: function( section ) {
+	getSelectedText = section => {
 		var selected = this.state[ section + 'SelectedIndex' ],
 			text = this.props[ section ][ selected ];
 
 		return 'object' === typeof text ? text.name : text;
-	},
+	};
 
-	getSelectedCount: function( section ) {
+	getSelectedCount = section => {
 		var selected = this.state[ section + 'SelectedIndex' ],
 			selectedItem = this.props[ section ][ selected ];
 
 		return 'object' === typeof selectedItem
 			? selectedItem.count || null
 			: null;
-	},
+	};
 
-	getSiblingDemoSelectedText: function() {
+	getSiblingDemoSelectedText = () => {
 		return (
 			<span>
 				<span>{ this.getSelectedText( 'siblingTabs' ) }</span>
 				<small>{ this.getSelectedText( 'siblingSegmented' ) }</small>
 			</span>
 		);
-	},
+	};
 
-	handleNavItemClick: function( section, index ) {
+	handleNavItemClick = (section, index) => {
 		return function() {
 			var stateUpdate = {};
 
 			stateUpdate[ section + 'SelectedIndex' ] = index;
 			this.setState( stateUpdate );
 		}.bind( this );
-	},
+	};
 
-	demoSearch: function( keywords ) {
+	demoSearch = keywords => {
 		console.log( 'Section Nav Search (keywords):', keywords );
-	}
-} );
+	};
+}
 
 export default SectionNavigation;

--- a/client/components/section-nav/docs/example.jsx
+++ b/client/components/section-nav/docs/example.jsx
@@ -2,17 +2,17 @@
  * External dependencies
  */
 import { forEach, omit } from 'lodash';
-var React = require( 'react' ),
-	PureRenderMixin = require( 'react-pure-render/mixin' );
+import React from 'react';
+import PureRenderMixin from 'react-pure-render/mixin';
 
 /**
  * Internal dependencies
  */
-var SectionNav = require( 'components/section-nav' ),
-	NavTabs = require( 'components/section-nav/tabs' ),
-	NavSegmented = require( 'components/section-nav/segmented' ),
-	NavItem = require( 'components/section-nav/item' ),
-	Search = require( 'components/search' );
+import NavTabs from 'components/section-nav/tabs';
+import NavSegmented from 'components/section-nav/segmented';
+import NavItem from 'components/section-nav/item';
+import Search from 'components/search';
+import SectionNav from 'components/section-nav';
 
 /**
  * Main

--- a/client/components/section-nav/index.jsx
+++ b/client/components/section-nav/index.jsx
@@ -172,10 +172,10 @@ const SectionNav = React.createClass( {
 	},
 
 	generateOnSearch: function( existingOnSearch ) {
-		return function() {
-			existingOnSearch.apply( this, arguments );
+		return ( search ) => {
+			existingOnSearch( search );
 			this.closeMobilePanel();
-		}.bind( this );
+		};
 	},
 
 	checkForSiblingControls: function( children ) {

--- a/client/components/section-nav/index.jsx
+++ b/client/components/section-nav/index.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import {
 	isEqual,
@@ -22,13 +23,13 @@ import Search from 'components/search';
 const SectionNav = React.createClass( {
 
 	propTypes: {
-		children: React.PropTypes.node,
-		selectedText: React.PropTypes.node,
-		selectedCount: React.PropTypes.number,
-		hasPinnedItems: React.PropTypes.bool,
-		onMobileNavPanelOpen: React.PropTypes.func,
-		className: React.PropTypes.string,
-		allowDropdown: React.PropTypes.bool,
+		children: PropTypes.node,
+		selectedText: PropTypes.node,
+		selectedCount: PropTypes.number,
+		hasPinnedItems: PropTypes.bool,
+		onMobileNavPanelOpen: PropTypes.func,
+		className: PropTypes.string,
+		allowDropdown: PropTypes.bool,
 	},
 
 	getInitialState: function() {

--- a/client/components/section-nav/index.jsx
+++ b/client/components/section-nav/index.jsx
@@ -167,8 +167,8 @@ class SectionNav extends Component {
 	};
 
 	generateOnSearch = existingOnSearch => {
-		return ( search ) => {
-			existingOnSearch( search );
+		return ( ...args ) => {
+			existingOnSearch( ...args );
 			this.closeMobilePanel();
 		};
 	};

--- a/client/components/section-nav/index.jsx
+++ b/client/components/section-nav/index.jsx
@@ -19,7 +19,7 @@ import Search from 'components/search';
 /**
  * Main
  */
-var SectionNav = React.createClass( {
+const SectionNav = React.createClass( {
 
 	propTypes: {
 		children: React.PropTypes.node,
@@ -78,7 +78,7 @@ var SectionNav = React.createClass( {
 	},
 
 	render: function() {
-		var children = this.getChildren(),
+		let children = this.getChildren(),
 			className;
 
 		if ( ! children ) {
@@ -115,7 +115,7 @@ var SectionNav = React.createClass( {
 
 	getChildren: function() {
 		return React.Children.map( this.props.children, function( child ) {
-			var extraProps = {
+			const extraProps = {
 				hasSiblingControls: this.hasSiblingControls,
 				closeSectionNavMobilePanel: this.closeMobilePanel
 			};
@@ -159,7 +159,7 @@ var SectionNav = React.createClass( {
 	},
 
 	toggleMobileOpenState: function() {
-		var mobileOpen = ! this.state.mobileOpen;
+		const mobileOpen = ! this.state.mobileOpen;
 
 		this.setState( {
 			mobileOpen: mobileOpen

--- a/client/components/section-nav/index.jsx
+++ b/client/components/section-nav/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import {
@@ -20,9 +20,8 @@ import Search from 'components/search';
 /**
  * Main
  */
-const SectionNav = React.createClass( {
-
-	propTypes: {
+class SectionNav extends Component {
+	static propTypes = {
 		children: PropTypes.node,
 		selectedText: PropTypes.node,
 		selectedCount: PropTypes.number,
@@ -30,26 +29,22 @@ const SectionNav = React.createClass( {
 		onMobileNavPanelOpen: PropTypes.func,
 		className: PropTypes.string,
 		allowDropdown: PropTypes.bool,
-	},
+	};
 
-	getInitialState: function() {
-		return {
-			mobileOpen: false
-		};
-	},
+	static defaultProps = {
+		onMobileNavPanelOpen: () => {},
+		allowDropdown: true,
+	};
 
-	getDefaultProps: function() {
-		return {
-			onMobileNavPanelOpen: () => {},
-			allowDropdown: true,
-		};
-	},
+	state = {
+		mobileOpen: false
+	};
 
-	componentWillMount: function() {
+	componentWillMount() {
 		this.checkForSiblingControls( this.props.children );
-	},
+	}
 
-	componentWillReceiveProps: function( nextProps ) {
+	componentWillReceiveProps( nextProps ) {
 		if ( isEqual( this.props, nextProps ) ) {
 			return;
 		}
@@ -59,9 +54,9 @@ const SectionNav = React.createClass( {
 		if ( ! this.hasSiblingControls ) {
 			this.closeMobilePanel();
 		}
-	},
+	}
 
-	renderDropdown() {
+	renderDropdown = () => {
 		if ( ! this.props.allowDropdown ) {
 			return <div />;
 		}
@@ -76,11 +71,11 @@ const SectionNav = React.createClass( {
 				</span>
 			</div>
 		);
-	},
+	};
 
-	render: function() {
-		let children = this.getChildren(),
-			className;
+	render() {
+		const children = this.getChildren();
+		let className;
 
 		if ( ! children ) {
 			className = classNames( {
@@ -112,9 +107,9 @@ const SectionNav = React.createClass( {
 				</div>
 			</div>
 		);
-	},
+	}
 
-	getChildren: function() {
+	getChildren = () => {
 		return React.Children.map( this.props.children, function( child ) {
 			const extraProps = {
 				hasSiblingControls: this.hasSiblingControls,
@@ -149,17 +144,17 @@ const SectionNav = React.createClass( {
 
 			return React.cloneElement( child, extraProps );
 		}.bind( this ) );
-	},
+	};
 
-	closeMobilePanel: function() {
+	closeMobilePanel = () => {
 		if ( window.innerWidth < 480 && this.state.mobileOpen ) {
 			this.setState( {
 				mobileOpen: false
 			} );
 		}
-	},
+	};
 
-	toggleMobileOpenState: function() {
+	toggleMobileOpenState = () => {
 		const mobileOpen = ! this.state.mobileOpen;
 
 		this.setState( {
@@ -169,16 +164,16 @@ const SectionNav = React.createClass( {
 		if ( mobileOpen ) {
 			this.props.onMobileNavPanelOpen();
 		}
-	},
+	};
 
-	generateOnSearch: function( existingOnSearch ) {
+	generateOnSearch = existingOnSearch => {
 		return ( search ) => {
 			existingOnSearch( search );
 			this.closeMobilePanel();
 		};
-	},
+	};
 
-	checkForSiblingControls: function( children ) {
+	checkForSiblingControls = children => {
 		this.hasSiblingControls = false;
 
 		const ignoreSiblings = [ Search, CommentNavigationTab ];
@@ -189,7 +184,7 @@ const SectionNav = React.createClass( {
 				this.hasSiblingControls = true;
 			}
 		}.bind( this ) );
-	}
-} );
+	};
+}
 
 export default SectionNav;

--- a/client/components/section-nav/index.jsx
+++ b/client/components/section-nav/index.jsx
@@ -191,4 +191,4 @@ const SectionNav = React.createClass( {
 	}
 } );
 
-module.exports = SectionNav;
+export default SectionNav;

--- a/client/components/section-nav/item.jsx
+++ b/client/components/section-nav/item.jsx
@@ -1,9 +1,9 @@
 /**
  * External Dependencies
  */
-var React = require( 'react' ),
-	PureRenderMixin = require( 'react-pure-render/mixin' ),
-	classNames = require( 'classnames' );
+import React from 'react';
+import PureRenderMixin from 'react-pure-render/mixin';
+import classNames from 'classnames';
 
 /**
  * Internal Dependencies
@@ -14,7 +14,7 @@ import { preload } from 'sections-preload';
 /**
  * Main
  */
-var NavItem = React.createClass( {
+const NavItem = React.createClass( {
 
 	mixins: [ PureRenderMixin ],
 
@@ -44,7 +44,7 @@ var NavItem = React.createClass( {
 	},
 
 	render: function() {
-		var itemClassPrefix = this.props.itemType
+		let itemClassPrefix = this.props.itemType
 			? this.props.itemType
 			: 'tab',
 

--- a/client/components/section-nav/item.jsx
+++ b/client/components/section-nav/item.jsx
@@ -1,8 +1,7 @@
 /**
  * External Dependencies
  */
-import React from 'react';
-import PureRenderMixin from 'react-pure-render/mixin';
+import React, { PureComponent } from 'react';
 import classNames from 'classnames';
 
 /**
@@ -14,11 +13,8 @@ import { preload } from 'sections-preload';
 /**
  * Main
  */
-const NavItem = React.createClass( {
-
-	mixins: [ PureRenderMixin ],
-
-	propTypes: {
+class NavItem extends PureComponent {
+	static propTypes = {
 		itemType: React.PropTypes.string,
 		path: React.PropTypes.string,
 		selected: React.PropTypes.bool,
@@ -32,18 +28,18 @@ const NavItem = React.createClass( {
 		] ),
 		className: React.PropTypes.string,
 		preloadSectionName: React.PropTypes.string
-	},
+	};
 
-	_preloaded: false,
+	_preloaded = false;
 
-	preload() {
+	preload = () => {
 		if ( ! this._preloaded && this.props.preloadSectionName ) {
 			this._preloaded = true;
 			preload( this.props.preloadSectionName );
 		}
-	},
+	};
 
-	render: function() {
+	render() {
 		let itemClassPrefix = this.props.itemType
 			? this.props.itemType
 			: 'tab',
@@ -90,6 +86,6 @@ const NavItem = React.createClass( {
 			</li>
 		);
 	}
-} );
+}
 
 export default NavItem;

--- a/client/components/section-nav/item.jsx
+++ b/client/components/section-nav/item.jsx
@@ -41,19 +41,15 @@ class NavItem extends PureComponent {
 	};
 
 	render() {
-		let itemClassPrefix = this.props.itemType
-			? this.props.itemType
-			: 'tab',
-
-			itemClassName, target, onClick,
-
-			itemClasses = {
-				'is-selected': this.props.selected,
-				'is-external': this.props.isExternalLink
-			};
-
+		const itemClassPrefix = this.props.itemType ? this.props.itemType : 'tab';
+		const itemClasses = {
+			'is-selected': this.props.selected,
+			'is-external': this.props.isExternalLink
+		};
 		itemClasses[ 'section-nav-' + itemClassPrefix ] = true;
-		itemClassName = classNames( this.props.className, itemClasses );
+		const itemClassName = classNames( this.props.className, itemClasses );
+
+		let target, onClick;
 
 		if ( this.props.isExternalLink ) {
 			target = '_blank';

--- a/client/components/section-nav/item.jsx
+++ b/client/components/section-nav/item.jsx
@@ -92,4 +92,4 @@ const NavItem = React.createClass( {
 	}
 } );
 
-module.exports = NavItem;
+export default NavItem;

--- a/client/components/section-nav/item.jsx
+++ b/client/components/section-nav/item.jsx
@@ -2,6 +2,7 @@
  * External Dependencies
  */
 import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 /**
@@ -15,19 +16,19 @@ import { preload } from 'sections-preload';
  */
 class NavItem extends PureComponent {
 	static propTypes = {
-		itemType: React.PropTypes.string,
-		path: React.PropTypes.string,
-		selected: React.PropTypes.bool,
-		tabIndex: React.PropTypes.number,
-		onClick: React.PropTypes.func,
-		isExternalLink: React.PropTypes.bool,
-		disabled: React.PropTypes.bool,
-		count: React.PropTypes.oneOfType( [
-			React.PropTypes.number,
-			React.PropTypes.bool,
+		itemType: PropTypes.string,
+		path: PropTypes.string,
+		selected: PropTypes.bool,
+		tabIndex: PropTypes.number,
+		onClick: PropTypes.func,
+		isExternalLink: PropTypes.bool,
+		disabled: PropTypes.bool,
+		count: PropTypes.oneOfType( [
+			PropTypes.number,
+			PropTypes.bool,
 		] ),
-		className: React.PropTypes.string,
-		preloadSectionName: React.PropTypes.string
+		className: PropTypes.string,
+		preloadSectionName: PropTypes.string
 	};
 
 	_preloaded = false;

--- a/client/components/section-nav/segmented.jsx
+++ b/client/components/section-nav/segmented.jsx
@@ -2,6 +2,7 @@
  * External Dependencies
  */
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 /**
@@ -20,8 +21,8 @@ let _instance = 1;
  */
 class NavSegmented extends Component {
 	static propTypes = {
-		label: React.PropTypes.string,
-		hasSiblingControls: React.PropTypes.bool
+		label: PropTypes.string,
+		hasSiblingControls: PropTypes.bool
 	};
 
 	static defaultProps = {

--- a/client/components/section-nav/segmented.jsx
+++ b/client/components/section-nav/segmented.jsx
@@ -1,24 +1,24 @@
 /**
  * External Dependencies
  */
-var React = require( 'react' ),
-	classNames = require( 'classnames' );
+import React from 'react';
+import classNames from 'classnames';
 
 /**
  * Internal Dependencies
  */
-var SegmentedControl = require( 'components/segmented-control' ),
-	ControlItem = require( 'components/segmented-control/item' );
+import ControlItem from 'components/segmented-control/item';
+import SegmentedControl from 'components/segmented-control';
 
 /**
  * Internal variables
  */
-var _instance = 1;
+let _instance = 1;
 
 /**
  * Main
  */
-var NavSegmented = React.createClass( {
+const NavSegmented = React.createClass( {
 
 	propTypes: {
 		label: React.PropTypes.string,
@@ -37,7 +37,7 @@ var NavSegmented = React.createClass( {
 	},
 
 	render: function() {
-		var segmentedClassName = classNames( {
+		const segmentedClassName = classNames( {
 			'section-nav-group': true,
 			'section-nav__segmented': true,
 			'has-siblings': this.props.hasSiblingControls

--- a/client/components/section-nav/segmented.jsx
+++ b/client/components/section-nav/segmented.jsx
@@ -1,7 +1,7 @@
 /**
  * External Dependencies
  */
-import React from 'react';
+import React, { Component } from 'react';
 import classNames from 'classnames';
 
 /**
@@ -18,25 +18,22 @@ let _instance = 1;
 /**
  * Main
  */
-const NavSegmented = React.createClass( {
-
-	propTypes: {
+class NavSegmented extends Component {
+	static propTypes = {
 		label: React.PropTypes.string,
 		hasSiblingControls: React.PropTypes.bool
-	},
+	};
 
-	getDefaultProps: function() {
-		return {
-			hasSiblingControls: false
-		};
-	},
+	static defaultProps = {
+		hasSiblingControls: false
+	};
 
-	componentWillMount: function() {
+	componentWillMount() {
 		this.id = _instance;
 		_instance++;
-	},
+	}
 
-	render: function() {
+	render() {
 		const segmentedClassName = classNames( {
 			'section-nav-group': true,
 			'section-nav__segmented': true,
@@ -55,9 +52,9 @@ const NavSegmented = React.createClass( {
 				</SegmentedControl>
 			</div>
 		);
-	},
+	}
 
-	getControlItems: function() {
+	getControlItems = () => {
 		return React.Children.map( this.props.children, function( child, index ) {
 			return (
 				<ControlItem
@@ -68,7 +65,7 @@ const NavSegmented = React.createClass( {
 				</ControlItem>
 			);
 		}, this );
-	}
-} );
+	};
+}
 
 export default NavSegmented;

--- a/client/components/section-nav/segmented.jsx
+++ b/client/components/section-nav/segmented.jsx
@@ -71,4 +71,4 @@ const NavSegmented = React.createClass( {
 	}
 } );
 
-module.exports = NavSegmented;
+export default NavSegmented;

--- a/client/components/section-nav/tabs.jsx
+++ b/client/components/section-nav/tabs.jsx
@@ -3,7 +3,7 @@
  */
 import { debounce } from 'lodash';
 import ReactDom from 'react-dom';
-import React from 'react';
+import React, { Component } from 'react';
 import classNames from 'classnames';
 
 /**
@@ -21,43 +21,38 @@ const MOBILE_PANEL_THRESHOLD = 480;
 /**
  * Main
  */
-const NavTabs = React.createClass( {
-
-	propTypes: {
+class NavTabs extends Component {
+	static propTypes = {
 		selectedText: React.PropTypes.string,
 		selectedCount: React.PropTypes.number,
 		label: React.PropTypes.string,
 		hasSiblingControls: React.PropTypes.bool
-	},
+	};
 
-	getDefaultProps: function() {
-		return {
-			hasSiblingControls: false
-		};
-	},
+	static defaultProps = {
+		hasSiblingControls: false
+	};
 
-	getInitialState: function() {
-		return {
-			isDropdown: false
-		};
-	},
+	state = {
+		isDropdown: false
+	};
 
-	componentDidMount: function() {
+	componentDidMount() {
 		this.setDropdown();
 		this.debouncedAfterResize = debounce( this.setDropdown, 300 );
 
 		window.addEventListener( 'resize', this.debouncedAfterResize );
-	},
+	}
 
-	componentWillReceiveProps: function() {
+	componentWillReceiveProps() {
 		this.setDropdown();
-	},
+	}
 
-	componentWillUnmount: function() {
+	componentWillUnmount() {
 		window.removeEventListener( 'resize', this.debouncedAfterResize );
-	},
+	}
 
-	render: function() {
+	render() {
 		const tabs = React.Children.map( this.props.children, function( child, index ) {
 			return child && React.cloneElement( child, { ref: 'tab-' + index } );
 		} );
@@ -95,9 +90,9 @@ const NavTabs = React.createClass( {
 				</div>
 			</div>
 		);
-	},
+	}
 
-	getTabWidths: function() {
+	getTabWidths = () => {
 		let totalWidth = 0;
 
 		React.Children.forEach( this.props.children, function( child, index ) {
@@ -109,9 +104,9 @@ const NavTabs = React.createClass( {
 		}.bind( this ) );
 
 		this.tabsWidth = totalWidth;
-	},
+	};
 
-	getDropdown: function() {
+	getDropdown = () => {
 		const dropdownOptions = React.Children.map(
 		this.props.children, function( child, index ) {
 			if ( ! child ) {
@@ -133,9 +128,9 @@ const NavTabs = React.createClass( {
 				{ dropdownOptions }
 			</SelectDropdown>
 		);
-	},
+	};
 
-	setDropdown: function() {
+	setDropdown = () => {
 		let navGroupWidth;
 
 		if ( window.innerWidth > MOBILE_PANEL_THRESHOLD ) {
@@ -163,9 +158,9 @@ const NavTabs = React.createClass( {
 				isDropdown: false
 			} );
 		}
-	},
+	};
 
-	keyHandler: function( event ) {
+	keyHandler = event => {
 		switch ( event.keyCode ) {
 			case 32: // space
 			case 13: // enter
@@ -173,7 +168,7 @@ const NavTabs = React.createClass( {
 				document.activeElement.click();
 				break;
 		}
-	}
-} );
+	};
+}
 
 export default NavTabs;

--- a/client/components/section-nav/tabs.jsx
+++ b/client/components/section-nav/tabs.jsx
@@ -176,4 +176,4 @@ const NavTabs = React.createClass( {
 	}
 } );
 
-module.exports = NavTabs;
+export default NavTabs;

--- a/client/components/section-nav/tabs.jsx
+++ b/client/components/section-nav/tabs.jsx
@@ -2,26 +2,26 @@
  * External dependencies
  */
 import { debounce } from 'lodash';
-var ReactDom = require( 'react-dom' ),
-	React = require( 'react' ),
-	classNames = require( 'classnames' );
+import ReactDom from 'react-dom';
+import React from 'react';
+import classNames from 'classnames';
 
 /**
  * Internal Dependencies
  */
-var SelectDropdown = require( 'components/select-dropdown' ),
-	DropdownItem = require( 'components/select-dropdown/item' ),
-	viewport = require( 'lib/viewport' );
+import DropdownItem from 'components/select-dropdown/item';
+import SelectDropdown from 'components/select-dropdown';
+import viewport from 'lib/viewport';
 
 /**
  * Internal Variables
  */
-var MOBILE_PANEL_THRESHOLD = 480;
+const MOBILE_PANEL_THRESHOLD = 480;
 
 /**
  * Main
  */
-var NavTabs = React.createClass( {
+const NavTabs = React.createClass( {
 
 	propTypes: {
 		selectedText: React.PropTypes.string,
@@ -58,18 +58,18 @@ var NavTabs = React.createClass( {
 	},
 
 	render: function() {
-		var tabs = React.Children.map( this.props.children, function( child, index ) {
+		const tabs = React.Children.map( this.props.children, function( child, index ) {
 			return child && React.cloneElement( child, { ref: 'tab-' + index } );
 		} );
 
-		var tabsClassName = classNames( {
+		const tabsClassName = classNames( {
 			'section-nav-tabs': true,
 			'is-dropdown': this.state.isDropdown,
 			'is-open': this.state.isDropdownOpen,
 			'has-siblings': this.props.hasSiblingControls
 		} );
 
-		var innerWidth = viewport.getWindowInnerWidth();
+		const innerWidth = viewport.getWindowInnerWidth();
 
 		return (
 			<div className="section-nav-group" ref="navGroup">
@@ -98,13 +98,13 @@ var NavTabs = React.createClass( {
 	},
 
 	getTabWidths: function() {
-		var totalWidth = 0;
+		let totalWidth = 0;
 
 		React.Children.forEach( this.props.children, function( child, index ) {
 			if ( ! child ) {
 				return;
 			}
-			let tabWidth = ReactDom.findDOMNode( this.refs[ 'tab-' + index ] ).offsetWidth;
+			const tabWidth = ReactDom.findDOMNode( this.refs[ 'tab-' + index ] ).offsetWidth;
 			totalWidth += tabWidth;
 		}.bind( this ) );
 
@@ -112,13 +112,13 @@ var NavTabs = React.createClass( {
 	},
 
 	getDropdown: function() {
-		var dropdownOptions = React.Children.map(
+		const dropdownOptions = React.Children.map(
 		this.props.children, function( child, index ) {
 			if ( ! child ) {
 				return null;
 			}
 			return (
-				<DropdownItem {...child.props} key={ 'navTabsDropdown-' + index }>
+				<DropdownItem { ...child.props } key={ 'navTabsDropdown-' + index }>
 					{ child.props.children }
 				</DropdownItem>
 			);
@@ -136,7 +136,7 @@ var NavTabs = React.createClass( {
 	},
 
 	setDropdown: function() {
-		var navGroupWidth;
+		let navGroupWidth;
 
 		if ( window.innerWidth > MOBILE_PANEL_THRESHOLD ) {
 			if ( ! this.refs.navGroup ) {

--- a/client/components/section-nav/tabs.jsx
+++ b/client/components/section-nav/tabs.jsx
@@ -1,10 +1,11 @@
 /**
  * External dependencies
  */
-import { debounce } from 'lodash';
-import ReactDom from 'react-dom';
 import React, { Component } from 'react';
+import ReactDom from 'react-dom';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import { debounce } from 'lodash';
 
 /**
  * Internal Dependencies
@@ -23,10 +24,10 @@ const MOBILE_PANEL_THRESHOLD = 480;
  */
 class NavTabs extends Component {
 	static propTypes = {
-		selectedText: React.PropTypes.string,
-		selectedCount: React.PropTypes.number,
-		label: React.PropTypes.string,
-		hasSiblingControls: React.PropTypes.bool
+		selectedText: PropTypes.string,
+		selectedCount: PropTypes.number,
+		label: PropTypes.string,
+		hasSiblingControls: PropTypes.bool
 	};
 
 	static defaultProps = {

--- a/client/components/section-nav/test/index.jsx
+++ b/client/components/section-nav/test/index.jsx
@@ -28,7 +28,7 @@ describe( 'section-nav', function() {
 	useFakeDom( '<html><body><script></script><div id="container"></div></body></html>' );
 
 	useMockery( mockery => {
-	    ReactDom = require( 'react-dom' );
+		ReactDom = require( 'react-dom' );
 		React = require( 'react' );
 		TestUtils = require( 'react-addons-test-utils' );
 

--- a/client/components/section-nav/test/index.jsx
+++ b/client/components/section-nav/test/index.jsx
@@ -11,6 +11,8 @@ import sinon from 'sinon';
 import useMockery from 'test/helpers/use-mockery';
 import useFakeDom from 'test/helpers/use-fake-dom';
 
+import EMPTY_COMPONENT from 'test/helpers/react/empty-component';
+
 let ReactDom, React, TestUtils, SectionNav;
 
 function createComponent( component, props, children ) {
@@ -26,11 +28,9 @@ describe( 'section-nav', function() {
 	useFakeDom( '<html><body><script></script><div id="container"></div></body></html>' );
 
 	useMockery( mockery => {
-		ReactDom = require( 'react-dom' );
+	    ReactDom = require( 'react-dom' );
 		React = require( 'react' );
 		TestUtils = require( 'react-addons-test-utils' );
-
-		const EMPTY_COMPONENT = require( 'test/helpers/react/empty-component' );
 
 		mockery.registerMock( 'gridicons', EMPTY_COMPONENT );
 		mockery.registerMock( 'lib/analytics', { ga: { recordEvent: noop } } );


### PR DESCRIPTION
This change runs several codemods on the `SectionHeader` and `SectionNav` components to achieve the following:

Before | After
------------ | -------------
`require( ... )` nested in blocks | All `require( ... )` moved to top block
`var ... = require( ... )` | `import ... from '...'`
`module.exports = ...` | `export default ...`
`this.translate` | `this.props.translate` via HOC
`React.createClass( ... )` | `class ThisComponentName extends React.Component`
`React.createClass( ... )` | `createReactClass( ... )` if unconvertible to `React.Component` subclass
`import { PropTypes } from 'react'` | `import PropTypes from 'prop-types'`

**To test**

- Run the section-nav component test: `npm run test-client client/components/section-nav`
- Check that section headers & section nav displays correctly in calypso
- Check devdocs: `/devdocs/design/section-header` & `/devdocs/design/section-nav`
