### PR TITLE
Account recovery: update account-recovery request reset to use wpcom-http

### DIFF
--- a/client/state/account-recovery/reset/actions.js
+++ b/client/state/account-recovery/reset/actions.js
@@ -6,8 +6,6 @@ import {
 	ACCOUNT_RECOVERY_RESET_OPTIONS_RECEIVE,
 	ACCOUNT_RECOVERY_RESET_OPTIONS_ERROR,
 	ACCOUNT_RECOVERY_RESET_REQUEST,
-	ACCOUNT_RECOVERY_RESET_REQUEST_SUCCESS,
-	ACCOUNT_RECOVERY_RESET_REQUEST_ERROR,
 	ACCOUNT_RECOVERY_RESET_UPDATE_USER_DATA,
 	ACCOUNT_RECOVERY_RESET_VALIDATE_REQUEST,
 	ACCOUNT_RECOVERY_RESET_VALIDATE_REQUEST_SUCCESS,
@@ -41,15 +39,6 @@ export const fetchResetOptionsByNameAndUrl = ( firstname, lastname, url ) => fet
 export const updatePasswordResetUserData = ( userData ) => ( {
 	type: ACCOUNT_RECOVERY_RESET_UPDATE_USER_DATA,
 	userData,
-} );
-
-export const requestResetSuccess = () => ( {
-	type: ACCOUNT_RECOVERY_RESET_REQUEST_SUCCESS,
-} );
-
-export const requestResetError = ( error ) => ( {
-	type: ACCOUNT_RECOVERY_RESET_REQUEST_ERROR,
-	error,
 } );
 
 export const requestReset = ( userData, method ) => ( {

--- a/client/state/account-recovery/reset/test/actions.js
+++ b/client/state/account-recovery/reset/test/actions.js
@@ -8,8 +8,6 @@ import { assert } from 'chai';
  */
 import {
 	requestReset,
-	requestResetSuccess,
-	requestResetError,
 	updatePasswordResetUserData,
 	setResetMethod,
 } from '../actions';
@@ -17,8 +15,6 @@ import {
 import {
 	ACCOUNT_RECOVERY_RESET_SET_METHOD,
 	ACCOUNT_RECOVERY_RESET_REQUEST,
-	ACCOUNT_RECOVERY_RESET_REQUEST_SUCCESS,
-	ACCOUNT_RECOVERY_RESET_REQUEST_ERROR,
 	ACCOUNT_RECOVERY_RESET_UPDATE_USER_DATA,
 } from 'state/action-types';
 
@@ -35,32 +31,6 @@ describe( '#updatePasswordResetUserData', () => {
 		assert.deepEqual( action, {
 			type: ACCOUNT_RECOVERY_RESET_UPDATE_USER_DATA,
 			userData,
-		} );
-	} );
-} );
-
-describe( '#requestResetSuccess', () => {
-	it( 'should return action ACCOUNT_RECOVERY_RESET_REQUEST_SUCCESS', () => {
-		const action = requestResetSuccess();
-
-		assert.deepEqual( action, {
-			type: ACCOUNT_RECOVERY_RESET_REQUEST_SUCCESS,
-		} );
-	} );
-} );
-
-describe( '#requestResetError', () => {
-	it( 'should return action ACCOUNT_RECOVERY_RESET_REQUEST_ERROR with error field', () => {
-		const error = {
-			status: 404,
-			message: 'Error!',
-		};
-
-		const action = requestResetError( error );
-
-		assert.deepEqual( action, {
-			type: ACCOUNT_RECOVERY_RESET_REQUEST_ERROR,
-			error,
 		} );
 	} );
 } );

--- a/client/state/data-layer/wpcom/account-recovery/request-reset/index.js
+++ b/client/state/data-layer/wpcom/account-recovery/request-reset/index.js
@@ -1,34 +1,51 @@
 /**
  * Internal dependencies
  */
-import wpcom from 'lib/wp';
-import { ACCOUNT_RECOVERY_RESET_REQUEST } from 'state/action-types';
 import {
-	requestResetSuccess,
-	requestResetError,
-	setResetMethod,
-} from 'state/account-recovery/reset/actions';
+	ACCOUNT_RECOVERY_RESET_REQUEST,
+	ACCOUNT_RECOVERY_RESET_REQUEST_SUCCESS,
+	ACCOUNT_RECOVERY_RESET_REQUEST_ERROR,
+} from 'state/action-types';
+import { setResetMethod } from 'state/account-recovery/reset/actions';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
+import { http } from 'state/data-layer/wpcom-http/actions';
 
-export const handleRequestReset = ( { dispatch }, action ) => {
+export const requestReset = ( { dispatch }, action ) => {
 	const {
 		userData,
 		method,
 	} = action;
 
-	wpcom.req.post( {
+	dispatch( http( {
+		method: 'POST',
+		apiNamespace: 'wpcom/v2',
+		path: '/account-recovery/request-reset',
 		body: {
 			...userData,
 			method,
 		},
-		apiNamespace: 'wpcom/v2',
-		path: '/account-recovery/request-reset',
-	} ).then( () => {
-		dispatch( requestResetSuccess() );
-		dispatch( setResetMethod( method ) );
-	} )
-	.catch( ( error ) => dispatch( requestResetError( error ) ) );
+	}, action ) );
+};
+
+export const handleError = ( { dispatch }, action, rawError ) => {
+	dispatch( {
+		type: ACCOUNT_RECOVERY_RESET_REQUEST_ERROR,
+		error: rawError.message,
+	} );
+};
+
+export const handleSuccess = ( { dispatch }, action ) => {
+	const { method } = action;
+	dispatch( setResetMethod( method ) );
+	dispatch( {
+		type: ACCOUNT_RECOVERY_RESET_REQUEST_SUCCESS,
+	} );
 };
 
 export default {
-	[ ACCOUNT_RECOVERY_RESET_REQUEST ]: [ handleRequestReset ],
+	[ ACCOUNT_RECOVERY_RESET_REQUEST ]: [ dispatchRequest(
+		requestReset,
+		handleSuccess,
+		handleError
+	) ],
 };

--- a/client/state/data-layer/wpcom/account-recovery/request-reset/test/index.js
+++ b/client/state/data-layer/wpcom/account-recovery/request-reset/test/index.js
@@ -1,88 +1,88 @@
 /**
  * External dependencies
  */
-import { assert } from 'chai';
-import sinon from 'sinon';
+import { expect } from 'chai';
+import { spy } from 'sinon';
 
 /**
  * Internal dependencies
  */
-
-import { handleRequestReset } from '../';
-import useNock from 'test/helpers/use-nock';
-
+import {
+	requestReset,
+	handleError,
+	handleSuccess,
+ } from '../';
 import {
 	ACCOUNT_RECOVERY_RESET_REQUEST_SUCCESS,
 	ACCOUNT_RECOVERY_RESET_REQUEST_ERROR,
-	ACCOUNT_RECOVERY_RESET_SET_METHOD,
 } from 'state/action-types';
+import { http } from 'state/data-layer/wpcom-http/actions';
+import { setResetMethod } from 'state/account-recovery/reset/actions';
 
-describe( 'handleRequestReset()', () => {
-	const apiBaseUrl = 'https://public-api.wordpress.com:443';
-	const endpoint = '/wpcom/v2/account-recovery/request-reset';
+describe( 'account-recovery/request-reset', () => {
+	describe( '#requestReset', () => {
+		it( 'should dispatch HTTP request to account recovery request reset endpoint', () => {
+			const dispatchSpy = spy();
+			const dummyAction = {
+				userData: {
+					user: 'foo',
+				},
+				method: 'primary_email',
+			};
 
-	const userData = { user: 'foo' };
-	const method = 'primary-email';
+			requestReset( { dispatch: dispatchSpy }, dummyAction );
 
-	describe( 'success', () => {
-		useNock( nock => (
-			nock( apiBaseUrl )
-				.persist()
-				.post( endpoint )
-				.reply( 200, { success: true } )
-		) );
-
-		it( 'should dispatch SUCCESS action on success', ( done ) => {
-			const dispatch = sinon.spy( ( action ) => {
-				if ( action.type === ACCOUNT_RECOVERY_RESET_REQUEST_SUCCESS ) {
-					assert.isTrue( dispatch.calledWith( {
-						type: ACCOUNT_RECOVERY_RESET_REQUEST_SUCCESS,
-					} ) );
-
-					done();
-				}
-			} );
-
-			handleRequestReset( { dispatch }, { userData, method } );
-		} );
-
-		it( 'should dispatch SET_METHOD action on success', ( done ) => {
-			const dispatch = sinon.spy( ( action ) => {
-				if ( action.type === ACCOUNT_RECOVERY_RESET_SET_METHOD ) {
-					assert.isTrue( dispatch.calledWith( {
-						type: ACCOUNT_RECOVERY_RESET_SET_METHOD,
-						method,
-					} ) );
-
-					done();
-				}
-			} );
-
-			handleRequestReset( { dispatch }, { userData, method } );
+			const {
+				userData,
+				method,
+			} = dummyAction;
+			expect( dispatchSpy ).to.have.been.calledOnce;
+			expect( dispatchSpy ).to.have.been.calledWith( http( {
+				method: 'POST',
+				apiNamespace: 'wpcom/v2',
+				path: '/account-recovery/request-reset',
+				body: {
+					...userData,
+					method,
+				},
+			}, dummyAction ) );
 		} );
 	} );
 
-	describe( 'failure', () => {
-		const errorResponse = {
-			status: 400,
-			message: 'Something wrong!',
-		};
+	describe( '#handleError', () => {
+		it( 'should dispatch failure action with error message', () => {
+			const dispatchSpy = spy();
+			const message = 'This is an error message.';
+			const rawError = Error( message );
 
-		useNock( nock => (
-			nock( apiBaseUrl )
-				.post( endpoint )
-				.reply( errorResponse.status, errorResponse )
-		) );
+			handleError( { dispatch: dispatchSpy }, null, rawError );
 
-		it( 'should dispatch ERROR action on failure', () => {
-			const dispatch = sinon.spy( () => {
-				assert.isTrue( dispatch.calledWithMatch( {
-					type: ACCOUNT_RECOVERY_RESET_REQUEST_ERROR,
-					error: errorResponse,
-				} ) )
+			expect( dispatchSpy ).to.have.been.calledOnce;
+			expect( dispatchSpy ).to.have.been.calledWith( {
+				type: ACCOUNT_RECOVERY_RESET_REQUEST_ERROR,
+				error: message,
 			} );
+		} );
+	} );
 
-			handleRequestReset( { dispatch }, { userData, method } );
+	describe( '#handleSuccess', () => {
+		it( 'should dispatch success action and set reset method action', () => {
+			const dispatchSpy = spy();
+			const dummyAction = {
+				userData: {
+					user: 'foo',
+				},
+				method: 'primary_email',
+			};
+			const { method } = dummyAction;
+
+			handleSuccess( { dispatch: dispatchSpy }, dummyAction );
+
+			expect( dispatchSpy ).to.have.been.calledTwice;
+			expect( dispatchSpy ).to.have.been.calledWith( {
+				type: ACCOUNT_RECOVERY_RESET_REQUEST_SUCCESS,
+			} );
+			expect( dispatchSpy ).to.have.been.calledWith( setResetMethod( method ) );
 		} );
 	} );
 } );


### PR DESCRIPTION
Fixes #17828

**Testing Instructions:**
1) Open an incognito window and make sure you are logged out.
1) Visit http://calypso.localhost:3000/account-recovery
1) Use a test account info to proceed with instructions, but make sure to choose "reset by the primary SMS number" or "reset by the recovery SMS number".
1) Verify code is received and SMS code entry UI is displayed.