### PR TITLE
Site Settings: Run codemods on action-panel

### DIFF
--- a/client/my-sites/site-settings/action-panel/figure.jsx
+++ b/client/my-sites/site-settings/action-panel/figure.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
-
 import React from 'react';
 import classNames from 'classnames';
 

--- a/client/my-sites/site-settings/action-panel/figure.jsx
+++ b/client/my-sites/site-settings/action-panel/figure.jsx
@@ -1,6 +1,8 @@
 /**
  * External dependencies
  */
+import PropTypes from 'prop-types';
+
 import React from 'react';
 import classNames from 'classnames';
 
@@ -18,7 +20,7 @@ const ActionPanelFigure = ( { inlineBodyText, children } ) => {
 };
 
 ActionPanelFigure.propTypes = {
-	inlineBodyText: React.PropTypes.bool // above `480px` does figure align with body text (below title)
+	inlineBodyText: PropTypes.bool // above `480px` does figure align with body text (below title)
 };
 
 ActionPanelFigure.defaultProps = {


### PR DESCRIPTION
This PR contains updates from the following codemods I've ran on `site-settings/action-panel`:

* commonjs-imports-hoist
* commonjs-imports
* commonjs-exports
* i18n-mixin
* react-create-class
* react-prop-types

Seems like the code was up to date there, the only update necessary was the prop-types package in  one of the components.

To test:
* Checkout this branch
* Go to http://calypso.localhost:3000/settings/theme-setup/:site, where :site is one of your .com sites.
* Verify the figure appears OK and there are no warnings.