### PR TITLE
Site Settings: Run codemods on amp

### DIFF
--- a/client/my-sites/site-settings/amp/wpcom.jsx
+++ b/client/my-sites/site-settings/amp/wpcom.jsx
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
 import page from 'page';

--- a/client/my-sites/site-settings/amp/wpcom.jsx
+++ b/client/my-sites/site-settings/amp/wpcom.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
-
 import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';


### PR DESCRIPTION
This PR contains updates from the following codemods I've ran on `site-settings/amp`:

* commonjs-imports-hoist
* commonjs-imports
* commonjs-exports
* i18n-mixin
* react-create-class
* react-prop-types

Seems like the code was up to date there, the only update necessary was the prop-types package in  one of the components.

To test:
* Checkout this branch
* Go to http://calypso.localhost:3000/settings/traffic/:site, where :site is one of your .com sites.
* Verify the AMP card appears OK and there are no warnings.