### PR TITLE
Site Settings: Run codemods on composing

### DIFF
--- a/client/my-sites/site-settings/composing/after-the-deadline.jsx
+++ b/client/my-sites/site-settings/composing/after-the-deadline.jsx
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
 

--- a/client/my-sites/site-settings/composing/after-the-deadline.jsx
+++ b/client/my-sites/site-settings/composing/after-the-deadline.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
-
 import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';

--- a/client/my-sites/site-settings/composing/default-post-format.jsx
+++ b/client/my-sites/site-settings/composing/default-post-format.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
-
 import React from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';

--- a/client/my-sites/site-settings/composing/default-post-format.jsx
+++ b/client/my-sites/site-settings/composing/default-post-format.jsx
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
 import { map } from 'lodash';

--- a/client/my-sites/site-settings/composing/index.jsx
+++ b/client/my-sites/site-settings/composing/index.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
-
 import React from 'react';
 import { connect } from 'react-redux';
 

--- a/client/my-sites/site-settings/composing/index.jsx
+++ b/client/my-sites/site-settings/composing/index.jsx
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import { connect } from 'react-redux';
 
 /**

--- a/client/my-sites/site-settings/composing/publish-confirmation.jsx
+++ b/client/my-sites/site-settings/composing/publish-confirmation.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
-
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';

--- a/client/my-sites/site-settings/composing/publish-confirmation.jsx
+++ b/client/my-sites/site-settings/composing/publish-confirmation.jsx
@@ -1,6 +1,8 @@
 /**
  * External dependencies
  */
+import PropTypes from 'prop-types';
+
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
@@ -69,11 +71,11 @@ PublishConfirmation.defaultProps = {
 };
 
 PublishConfirmation.propTypes = {
-	siteId: React.PropTypes.number,
-	fetchingPreferences: React.PropTypes.bool,
-	publishConfirmationEnabled: React.PropTypes.bool,
-	savePublishConfirmationPreference: React.PropTypes.func,
-	translate: React.PropTypes.func,
+	siteId: PropTypes.number,
+	fetchingPreferences: PropTypes.bool,
+	publishConfirmationEnabled: PropTypes.bool,
+	savePublishConfirmationPreference: PropTypes.func,
+	translate: PropTypes.func,
 };
 
 export default connect(


### PR DESCRIPTION
This PR contains updates from the following codemods I've ran on `site-settings/composing`:

* commonjs-imports-hoist
* commonjs-imports
* commonjs-exports
* i18n-mixin
* react-create-class
* react-prop-types

Seems like the code was up to date there, the only update necessary was the prop-types package in  several of the components.

To test:
* Checkout this branch
* Go to http://calypso.localhost:3000/settings/writing/:site, where :site is one of your .com sites.
* Verify the Composing card looks well and there are no warnings.
* Go to http://calypso.localhost:3000/settings/writing/:site, where :site is one of your Jetpack sites.
* Verify the Composing card looks well and there are no warnings.