### PR TITLE
Site Settings: Run codemods on date-time-format

### DIFF
--- a/client/my-sites/site-settings/date-time-format/index.jsx
+++ b/client/my-sites/site-settings/date-time-format/index.jsx
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
 import { capitalize, includes } from 'lodash';
 

--- a/client/my-sites/site-settings/date-time-format/index.jsx
+++ b/client/my-sites/site-settings/date-time-format/index.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
-
 import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
 import { capitalize, includes } from 'lodash';


### PR DESCRIPTION
This PR contains updates from the following codemods I've ran on `site-settings/date-time-format`:

* commonjs-imports-hoist
* commonjs-imports
* commonjs-exports
* i18n-mixin
* react-create-class
* react-prop-types

Seems like the code was up to date there, the only update necessary was the prop-types package in  one of the components.

To test:
* Checkout this branch
* Go to http://calypso.localhost:3000/settings/writing/:site, where :site is:
  * One of your Jetpack sites.
  * One of your WordPress.com sites.
* Verify the Date & Time compact card appears OK and there are no warnings.
* Expand the card and verify it's fine and no warnings are displayed.