### PR TITLE
Site picker: Disable the icon and dropdown when only 1 site available

### DIFF
--- a/client/components/sites-dropdown/index.jsx
+++ b/client/components/sites-dropdown/index.jsx
@@ -80,24 +80,21 @@ export class SitesDropdown extends PureComponent {
 
 	render() {
 		return (
-			<div className={ classNames(
-				'sites-dropdown',
-				{ 'is-open': this.state.open },
-				{ 'has-multiple-sites': this.props.hasMultipleSites }
-				) }>
+			<div
+				className={ classNames(
+					'sites-dropdown',
+					{ 'is-open': this.state.open },
+					{ 'has-multiple-sites': this.props.hasMultipleSites }
+				) }
+			>
 				<div className="sites-dropdown__wrapper">
-					<div
-						className="sites-dropdown__selected"
-						onClick={ this.toggleOpen } >
-						{
-							this.props.isPlaceholder
-							? <SitePlaceholder />
-							: <Site siteId={ this.state.selectedSiteId } indicator={ false } />
-						}
-						{
-							this.props.hasMultipleSites &&
-							<Gridicon icon="chevron-down" />
-						}
+					<div className="sites-dropdown__selected" onClick={ this.toggleOpen }>
+						{ this.props.isPlaceholder ? (
+							<SitePlaceholder />
+						) : (
+							<Site siteId={ this.state.selectedSiteId } indicator={ false } />
+						) }
+						{ this.props.hasMultipleSites && <Gridicon icon="chevron-down" /> }
 					</div>
 					{ this.props.hasMultipleSites && this.state.open &&
 						<SiteSelector
@@ -115,9 +112,7 @@ export class SitesDropdown extends PureComponent {
 	}
 }
 
-export default connect(
-	( state ) => ( {
-		primarySiteId: getPrimarySiteId( state ),
-		hasMultipleSites: get( getCurrentUser( state ), 'site_count', 1 ) > 1,
-	} )
-)( SitesDropdown );
+export default connect( state => ( {
+	primarySiteId: getPrimarySiteId( state ),
+	hasMultipleSites: get( getCurrentUser( state ), 'site_count', 1 ) > 1,
+} ) )( SitesDropdown );

--- a/client/components/sites-dropdown/index.jsx
+++ b/client/components/sites-dropdown/index.jsx
@@ -28,7 +28,7 @@ export class SitesDropdown extends PureComponent {
 		onSiteSelect: PropTypes.func,
 		filter: PropTypes.func,
 		isPlaceholder: PropTypes.bool,
-		siteCount: PropTypes.number,
+		hasMultipleSites: PropTypes.bool,
 
 		// connected props
 		selectedSite: PropTypes.object,
@@ -39,7 +39,7 @@ export class SitesDropdown extends PureComponent {
 		onClose: noop,
 		onSiteSelect: noop,
 		isPlaceholder: false,
-		siteCount: 1,
+		hasMultipleSites: false,
 	};
 
 	constructor( props ) {
@@ -70,7 +70,7 @@ export class SitesDropdown extends PureComponent {
 	}
 
 	toggleOpen() {
-		this.props.siteCount > 1 && this.setState( { open: ! this.state.open } );
+		this.props.hasMultipleSites && this.setState( { open: ! this.state.open } );
 	}
 
 	onClose( e ) {
@@ -83,7 +83,7 @@ export class SitesDropdown extends PureComponent {
 			<div className={ classNames(
 				'sites-dropdown',
 				{ 'is-open': this.state.open },
-				{ 'has-multiple-sites': this.props.siteCount > 1 }
+				{ 'has-multiple-sites': this.props.hasMultipleSites }
 				) }>
 				<div className="sites-dropdown__wrapper">
 					<div
@@ -95,11 +95,11 @@ export class SitesDropdown extends PureComponent {
 							: <Site siteId={ this.state.selectedSiteId } indicator={ false } />
 						}
 						{
-							this.props.siteCount > 1 &&
+							this.props.hasMultipleSites &&
 							<Gridicon icon="chevron-down" />
 						}
 					</div>
-					{ this.props.siteCount > 1 && this.state.open &&
+					{ this.props.hasMultipleSites && this.state.open &&
 						<SiteSelector
 							autoFocus={ true }
 							onClose={ this.onClose }
@@ -118,6 +118,6 @@ export class SitesDropdown extends PureComponent {
 export default connect(
 	( state ) => ( {
 		primarySiteId: getPrimarySiteId( state ),
-		siteCount: get( getCurrentUser( state ), 'site_count', 0 )
+		hasMultipleSites: get( getCurrentUser( state ), 'site_count', 1 ) > 1
 	} )
 )( SitesDropdown );

--- a/client/components/sites-dropdown/index.jsx
+++ b/client/components/sites-dropdown/index.jsx
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
-import { noop, get } from 'lodash';
+import { noop, get } from 'lodash';
 import Gridicon from 'gridicons';
 
 /**
@@ -80,24 +80,21 @@ export class SitesDropdown extends PureComponent {
 
 	render() {
 		return (
-			<div className={ classNames(
-				'sites-dropdown',
-				{ 'is-open': this.state.open },
-				{ 'has-multiple-sites': this.props.hasMultipleSites }
-				) }>
+			<div
+				className={ classNames(
+					'sites-dropdown',
+					{ 'is-open': this.state.open },
+					{ 'has-multiple-sites': this.props.hasMultipleSites }
+				) }
+			>
 				<div className="sites-dropdown__wrapper">
-					<div
-						className="sites-dropdown__selected"
-						onClick={ this.toggleOpen } >
-						{
-							this.props.isPlaceholder
-							? <SitePlaceholder />
-							: <Site siteId={ this.state.selectedSiteId } indicator={ false } />
-						}
-						{
-							this.props.hasMultipleSites &&
-							<Gridicon icon="chevron-down" />
-						}
+					<div className="sites-dropdown__selected" onClick={ this.toggleOpen }>
+						{ this.props.isPlaceholder ? (
+							<SitePlaceholder />
+						) : (
+							<Site siteId={ this.state.selectedSiteId } indicator={ false } />
+						) }
+						{ this.props.hasMultipleSites && <Gridicon icon="chevron-down" /> }
 					</div>
 					{ this.props.hasMultipleSites && this.state.open &&
 						<SiteSelector

--- a/client/components/sites-dropdown/index.jsx
+++ b/client/components/sites-dropdown/index.jsx
@@ -80,21 +80,24 @@ export class SitesDropdown extends PureComponent {
 
 	render() {
 		return (
-			<div
-				className={ classNames(
-					'sites-dropdown',
-					{ 'is-open': this.state.open },
-					{ 'has-multiple-sites': this.props.hasMultipleSites }
-				) }
-			>
+			<div className={ classNames(
+				'sites-dropdown',
+				{ 'is-open': this.state.open },
+				{ 'has-multiple-sites': this.props.hasMultipleSites }
+				) }>
 				<div className="sites-dropdown__wrapper">
-					<div className="sites-dropdown__selected" onClick={ this.toggleOpen }>
-						{ this.props.isPlaceholder ? (
-							<SitePlaceholder />
-						) : (
-							<Site siteId={ this.state.selectedSiteId } indicator={ false } />
-						) }
-						{ this.props.hasMultipleSites && <Gridicon icon="chevron-down" /> }
+					<div
+						className="sites-dropdown__selected"
+						onClick={ this.toggleOpen } >
+						{
+							this.props.isPlaceholder
+							? <SitePlaceholder />
+							: <Site siteId={ this.state.selectedSiteId } indicator={ false } />
+						}
+						{
+							this.props.hasMultipleSites &&
+							<Gridicon icon="chevron-down" />
+						}
 					</div>
 					{ this.props.hasMultipleSites && this.state.open &&
 						<SiteSelector
@@ -115,6 +118,6 @@ export class SitesDropdown extends PureComponent {
 export default connect(
 	( state ) => ( {
 		primarySiteId: getPrimarySiteId( state ),
-		hasMultipleSites: get( getCurrentUser( state ), 'site_count', 1 ) > 1
+		hasMultipleSites: get( getCurrentUser( state ), 'site_count', 1 ) > 1,
 	} )
 )( SitesDropdown );

--- a/client/components/sites-dropdown/index.jsx
+++ b/client/components/sites-dropdown/index.jsx
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
-import { noop } from 'lodash';
+import { noop, get } from 'lodash';
 import Gridicon from 'gridicons';
 
 /**
@@ -18,6 +18,7 @@ import Site from 'blocks/site';
 import SitePlaceholder from 'blocks/site/placeholder';
 import SiteSelector from 'components/site-selector';
 import { getPrimarySiteId } from 'state/selectors';
+import { getCurrentUser } from 'state/current-user/selectors';
 
 export class SitesDropdown extends PureComponent {
 	static propTypes = {
@@ -27,6 +28,7 @@ export class SitesDropdown extends PureComponent {
 		onSiteSelect: PropTypes.func,
 		filter: PropTypes.func,
 		isPlaceholder: PropTypes.bool,
+		siteCount: PropTypes.number,
 
 		// connected props
 		selectedSite: PropTypes.object,
@@ -37,6 +39,7 @@ export class SitesDropdown extends PureComponent {
 		onClose: noop,
 		onSiteSelect: noop,
 		isPlaceholder: false,
+		siteCount: 1,
 	};
 
 	constructor( props ) {
@@ -67,7 +70,7 @@ export class SitesDropdown extends PureComponent {
 	}
 
 	toggleOpen() {
-		this.setState( { open: ! this.state.open } );
+		this.props.siteCount > 1 && this.setState( { open: ! this.state.open } );
 	}
 
 	onClose( e ) {
@@ -77,17 +80,26 @@ export class SitesDropdown extends PureComponent {
 
 	render() {
 		return (
-			<div className={ classNames( 'sites-dropdown', { 'is-open': this.state.open } ) }>
+			<div className={ classNames(
+				'sites-dropdown',
+				{ 'is-open': this.state.open },
+				{ 'has-multiple-sites': this.props.siteCount > 1 }
+				) }>
 				<div className="sites-dropdown__wrapper">
-					<div className="sites-dropdown__selected" onClick={ this.toggleOpen }>
-						{ this.props.isPlaceholder ? (
-							<SitePlaceholder />
-						) : (
-							<Site siteId={ this.state.selectedSiteId } indicator={ false } />
-						) }
-						<Gridicon icon="chevron-down" />
+					<div
+						className="sites-dropdown__selected"
+						onClick={ this.toggleOpen } >
+						{
+							this.props.isPlaceholder
+							? <SitePlaceholder />
+							: <Site siteId={ this.state.selectedSiteId } indicator={ false } />
+						}
+						{
+							this.props.siteCount > 1 &&
+							<Gridicon icon="chevron-down" />
+						}
 					</div>
-					{ this.state.open && (
+					{ this.props.siteCount > 1 && this.state.open &&
 						<SiteSelector
 							autoFocus={ true }
 							onClose={ this.onClose }
@@ -96,13 +108,16 @@ export class SitesDropdown extends PureComponent {
 							hideSelected={ true }
 							filter={ this.props.filter && this.siteFilter }
 						/>
-					) }
+					}
 				</div>
 			</div>
 		);
 	}
 }
 
-export default connect( state => ( {
-	primarySiteId: getPrimarySiteId( state ),
-} ) )( SitesDropdown );
+export default connect(
+	( state ) => ( {
+		primarySiteId: getPrimarySiteId( state ),
+		siteCount: get( getCurrentUser( state ), 'site_count', 0 )
+	} )
+)( SitesDropdown );

--- a/client/components/sites-dropdown/style.scss
+++ b/client/components/sites-dropdown/style.scss
@@ -30,8 +30,13 @@
 		width: 100%;
 	}
 
+<<<<<<< HEAD
 	&:hover {
 		border-color: $gray-lighten-10;
+=======
+	.has-multiple-sites &:hover {
+		border-color: lighten( $gray, 10% );
+>>>>>>> Site picker: Disable the icon and dropdown when only 1 site available
 	}
 }
 
@@ -42,8 +47,11 @@
 }
 
 .sites-dropdown__selected {
-	cursor: pointer;
 	display: flex;
+
+	.has-multiple-sites & {
+		cursor: pointer;
+	}
 
 	.is-open & {
 		border-bottom: 1px solid $gray-lighten-30;

--- a/client/components/sites-dropdown/style.scss
+++ b/client/components/sites-dropdown/style.scss
@@ -19,24 +19,22 @@
 .sites-dropdown__wrapper {
 	background: $white;
 	border: 1px solid $gray-lighten-20;
-	border-width: 1px 1px 2px;
+	border-width: 1px;
 	border-radius: 4px;
 	margin: 0;
+	overflow: hidden;
 	position: relative;
 	width: 300px;
 	transition: all .15s ease-in-out;
+	z-index: 1;
 
 	@include breakpoint( "<660px" ) {
 		width: 100%;
 	}
 
-<<<<<<< HEAD
-	&:hover {
-		border-color: $gray-lighten-10;
-=======
 	.has-multiple-sites &:hover {
-		border-color: lighten( $gray, 10% );
->>>>>>> Site picker: Disable the icon and dropdown when only 1 site available
+		border-color: $gray-lighten-10;
+		border-bottom-width: 2px;
 	}
 }
 

--- a/client/components/sites-dropdown/test/index.js
+++ b/client/components/sites-dropdown/test/index.js
@@ -29,7 +29,7 @@ describe( 'index', () => {
 
 		test( 'with multiple sites, should toggle the dropdown when it is clicked', () => {
 			const toggleOpenSpy = sinon.spy( SitesDropdown.prototype, 'toggleOpen' );
-			const sitesDropdown = shallow( <SitesDropdown siteCount={ 2 } /> );
+			const sitesDropdown = shallow( <SitesDropdown hasMultipleSites={ true } /> );
 
 			sitesDropdown.find( '.sites-dropdown__selected' ).simulate( 'click' );
 			sinon.assert.calledOnce( toggleOpenSpy );
@@ -41,7 +41,7 @@ describe( 'index', () => {
 
 		test( 'with only one site, nothing should happen when it is clicked', () => {
 			const toggleOpenSpy = sinon.spy( SitesDropdown.prototype, 'toggleOpen' );
-			const sitesDropdown = shallow( <SitesDropdown siteCount={ 1 } /> );
+			const sitesDropdown = shallow( <SitesDropdown hasMultipleSites={ false } /> );
 
 			sitesDropdown.find( '.sites-dropdown__selected' ).simulate( 'click' );
 			sinon.assert.calledOnce( toggleOpenSpy );

--- a/client/components/sites-dropdown/test/index.js
+++ b/client/components/sites-dropdown/test/index.js
@@ -23,18 +23,30 @@ describe( 'index', () => {
 	describe( 'component rendering', () => {
 		test( 'should render a dropdown component initially closed', () => {
 			const sitesDropdown = shallow( <SitesDropdown /> );
-			expect( sitesDropdown.hasClass( 'sites-dropdown' ) ).to.be.true;
-			expect( sitesDropdown.hasClass( 'is-open' ) ).to.be.false;
+			expect( sitesDropdown.hasClass( 'sites-dropdown' ) ).to.equal( true );
+			expect( sitesDropdown.hasClass( 'is-open' ) ).to.equal( false );
 		} );
 
-		test( 'should toggle the dropdown, when it is clicked', () => {
+		test( 'with multiple sites, should toggle the dropdown when it is clicked', () => {
 			const toggleOpenSpy = sinon.spy( SitesDropdown.prototype, 'toggleOpen' );
-			const sitesDropdown = shallow( <SitesDropdown /> );
+			const sitesDropdown = shallow( <SitesDropdown siteCount={ 2 } /> );
 
 			sitesDropdown.find( '.sites-dropdown__selected' ).simulate( 'click' );
-
 			sinon.assert.calledOnce( toggleOpenSpy );
-			expect( sitesDropdown.hasClass( 'is-open' ) ).to.be.true;
+			expect( sitesDropdown.hasClass( 'has-multiple-sites' ) ).to.equal( true );
+			expect( sitesDropdown.hasClass( 'is-open' ) ).to.equal( true );
+
+			toggleOpenSpy.restore();
+		} );
+
+		test( 'with only one site, nothing should happen when it is clicked', () => {
+			const toggleOpenSpy = sinon.spy( SitesDropdown.prototype, 'toggleOpen' );
+			const sitesDropdown = shallow( <SitesDropdown siteCount={ 1 } /> );
+
+			sitesDropdown.find( '.sites-dropdown__selected' ).simulate( 'click' );
+			sinon.assert.calledOnce( toggleOpenSpy );
+			expect( sitesDropdown.hasClass( 'has-multiple-sites' ) ).to.equal( false );
+			expect( sitesDropdown.hasClass( 'is-open' ) ).to.equal( false );
 
 			toggleOpenSpy.restore();
 		} );


### PR DESCRIPTION
Adds a `siteCount` property to SiteDropdown and only enables the
dropdown site list functionality when multiple sites are available.

Adds tests for cases with only one available site and with multiple
sites.

Refs #9895

**Screenshots**

Before

![before1](https://user-images.githubusercontent.com/916023/30506948-e6440004-9a34-11e7-915f-341b464db13d.jpg)

![before2](https://user-images.githubusercontent.com/916023/30506950-eace346e-9a34-11e7-9575-ccc1dc1438bc.jpg)

After

![after1](https://user-images.githubusercontent.com/916023/30506955-ef81fe78-9a34-11e7-9493-fdac1d6a3a51.jpg)

**To test:**

* Log in with an account that only has one associated site.
* Navigate to `me/account`
* Try hovering on and clicking on the Primary Site control.
* Expected: Nothing should happen. There should not be a chevron icon on the right side of the control.

* Log in with an account with multiple associated sites.
* Navigate to `me/account`
* Try hovering on and clicking on the Primary Site control.
* Expected: The sites dropdown should expand as usual. The chevron icon should be present on the right side of the control.