### PR TITLE
Site Settings: Run codemods on JetpackSyncPanel

### DIFF
--- a/client/my-sites/site-settings/jetpack-sync-panel/index.jsx
+++ b/client/my-sites/site-settings/jetpack-sync-panel/index.jsx
@@ -31,8 +31,6 @@ const debug = debugModule( 'calypso:site-settings:jetpack-sync-panel' );
 const SYNC_STATUS_ERROR_NOTICE_THRESHOLD = 3; // Only show sync status error notice if >= this number
 
 class JetpackSyncPanel extends React.Component {
-	static displayName = 'JetpackSyncPanel';
-
 	componentWillMount() {
 		this.fetchSyncStatus();
 	}

--- a/client/my-sites/site-settings/jetpack-sync-panel/index.jsx
+++ b/client/my-sites/site-settings/jetpack-sync-panel/index.jsx
@@ -30,35 +30,35 @@ import analytics from 'lib/analytics';
 const debug = debugModule( 'calypso:site-settings:jetpack-sync-panel' );
 const SYNC_STATUS_ERROR_NOTICE_THRESHOLD = 3; // Only show sync status error notice if >= this number
 
-const JetpackSyncPanel = React.createClass( {
-	displayName: 'JetpackSyncPanel',
+class JetpackSyncPanel extends React.Component {
+	static displayName = 'JetpackSyncPanel';
 
 	componentWillMount() {
 		this.fetchSyncStatus();
-	},
+	}
 
-	fetchSyncStatus() {
+	fetchSyncStatus = () => {
 		this.props.getSyncStatus( this.props.siteId );
-	},
+	};
 
-	isErrored() {
+	isErrored = () => {
 		const syncRequestError = get( this.props, 'fullSyncRequest.error' );
 		const syncStatusErrorCount = get( this.props, 'syncStatus.errorCounter', 0 );
 		return !! ( syncRequestError || ( syncStatusErrorCount >= SYNC_STATUS_ERROR_NOTICE_THRESHOLD ) );
-	},
+	};
 
-	shouldDisableSync() {
+	shouldDisableSync = () => {
 		return !! ( this.props.isFullSyncing || this.props.isPendingSyncStart );
-	},
+	};
 
-	onSyncRequestButtonClick( event ) {
+	onSyncRequestButtonClick = event => {
 		event.preventDefault();
 		debug( 'Perform full sync button clicked' );
 		analytics.tracks.recordEvent( 'calypso_jetpack_sync_panel_request_button_clicked' );
 		this.props.scheduleJetpackFullysync( this.props.siteId );
-	},
+	};
 
-	onTryAgainClick( event ) {
+	onTryAgainClick = event => {
 		event.preventDefault();
 		debug( 'Try again button clicked' );
 		analytics.tracks.recordEvent( 'calypso_jetpack_sync_panel_try_again_button_clicked', {
@@ -66,17 +66,17 @@ const JetpackSyncPanel = React.createClass( {
 			errorMsg: get( this.props, 'fullSyncRequest.error.message', '' )
 		} );
 		this.props.scheduleJetpackFullysync( this.props.siteId );
-	},
+	};
 
-	onClickDebug() {
+	onClickDebug = () => {
 		debug( 'Clicked check connection button' );
 		analytics.tracks.recordEvent( 'calypso_jetpack_sync_panel_check_connection_button_clicked', {
 			errorCode: get( this.props, 'syncStatus.error.error', '' ),
 			errorMsg: get( this.props, 'syncStatus.error.message', '' )
 		} );
-	},
+	};
 
-	renderErrorNotice() {
+	renderErrorNotice = () => {
 		const syncRequestError = get( this.props, 'fullSyncRequest.error' );
 		const syncStatusErrorCount = get( this.props, 'syncStatus.errorCounter', 0 );
 		const { translate } = this.props;
@@ -123,9 +123,9 @@ const JetpackSyncPanel = React.createClass( {
 		}
 
 		return errorNotice;
-	},
+	};
 
-	renderStatusNotice() {
+	renderStatusNotice = () => {
 		if ( this.isErrored() ) {
 			return null;
 		}
@@ -156,9 +156,9 @@ const JetpackSyncPanel = React.createClass( {
 				{ text }
 			</Notice>
 		);
-	},
+	};
 
-	renderProgressBar() {
+	renderProgressBar = () => {
 		if ( ! this.shouldDisableSync() || this.isErrored() ) {
 			return null;
 		}
@@ -166,7 +166,7 @@ const JetpackSyncPanel = React.createClass( {
 		return (
 			<ProgressBar isPulsing value={ this.props.syncProgress || 0 } />
 		);
-	},
+	};
 
 	render() {
 		const { translate } = this.props;
@@ -200,7 +200,7 @@ const JetpackSyncPanel = React.createClass( {
 			</CompactCard>
 		);
 	}
-} );
+}
 
 export default connect(
 	state => {

--- a/client/my-sites/site-settings/jetpack-sync-panel/index.jsx
+++ b/client/my-sites/site-settings/jetpack-sync-panel/index.jsx
@@ -131,8 +131,8 @@ class JetpackSyncPanel extends React.Component {
 		}
 
 		const finished = get( this.props, 'syncStatus.finished' );
-		const finishedTimestamp = this.moment( parseInt( finished, 10 ) * 1000 );
-		const { isPendingSyncStart, isFullSyncing, translate } = this.props;
+		const { isPendingSyncStart, isFullSyncing, moment, translate } = this.props;
+		const finishedTimestamp = moment( parseInt( finished, 10 ) * 1000 );
 
 		let text = '';
 		if ( isPendingSyncStart ) {


### PR DESCRIPTION
This PR contains updates from the following codemods I've ran on `site-settings/jetpack-sync-panel`:

* commonjs-imports-hoist
* commonjs-imports
* commonjs-exports
* i18n-mixin
* react-create-class
* react-prop-types

Seems like the code was up to date there, the only update necessary was to migrate `JetpackSyncPanel` to `React.Component`, which also included a manual update of `this.moment` to `this.props.moment`.

To test:
* Checkout this branch
* Go to http://calypso.localhost:3000/settings/manage-connection/:site, where :site is one of your Jetpack sites.
* Verify the Data Connection card appears and works fine and there are no warnings.