### PR TITLE
Console log message to prevent self xss

### DIFF
--- a/server/pages/index.jade
+++ b/server/pages/index.jade
@@ -243,10 +243,12 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class=isFluidWidth ? 'is-fluid-width'
 				if ( window.console ) {
 					console.log( "%cSTOP!", "color:#f00;font-size:xx-large" );
 					console.log(
-						"%cThis browser features is intended for developers. " +
-						"If you have been told to copy and paste something here to enable " +
-						"a feature, someone might be trying to compromise your account.",
-						"font-size:large;" );
+						"%cWait! This browser feature runs code that can alter your website or its security, " +
+						"and is intended for developers. If you've been told to copy and paste something here " +
+						"to enable a feature, someone may be trying to compromise your account. Please make " +
+						"sure you understand the code and trust the source before adding anything here.",
+						"font-size:large;"
+					);
 				}
 			})();
 

--- a/server/pages/index.jade
+++ b/server/pages/index.jade
@@ -238,5 +238,17 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class=isFluidWidth ? 'is-fluid-width'
 			script(src=urls[ chunk ])
 		script(type='text/javascript')!='window.AppBoot();'
 
+		script.
+			(function() {
+				if ( window.console ) {
+					console.log( "%cSTOP!", "color:#f00;font-size:xx-large" );
+					console.log(
+						"%cThis browser features is intended for developers. " +
+						"If you have been told to copy and paste something here to enable " +
+						"a feature, someone might be trying to compromise your account.",
+						"font-size:large;" );
+				}
+			})();
+
 		noscript.wpcom-site__global-noscript
 			|Please enable JavaScript in your browser to enjoy WordPress.com.


### PR DESCRIPTION
This adds a developer console message informing the user about the possibility of a self XSS attack if they were asked to enter a value in the console.

![Image of message](https://cdn-pro.dprcdn.net/files/acc_403010/RQMuhz)

This closes #15, it could do with additions like translating the string based on locale and checking if the console support colors and styles, the latter only possible via user agent checking, unfortunately.

Could also be useful to setup a page on wordpress.com explaining self XSS and then linking to that page.