### PR TITLE
Change Card to a functional component

### DIFF
--- a/client/components/card/index.jsx
+++ b/client/components/card/index.jsx
@@ -5,66 +5,56 @@ import React from 'react';
 import { assign, omit } from 'lodash';
 import classnames from 'classnames';
 import Gridicon from 'gridicons';
-import createClass from 'create-react-class';
 import PropTypes from 'prop-types';
 
-export default createClass( {
-	displayName: 'Card',
+const Card = ( props ) => {
+	const { href, tagName, target, compact, children, highlight } = props;
 
-	propTypes: {
-		className: PropTypes.string,
-		href: PropTypes.string,
-		tagName: PropTypes.string,
-		target: PropTypes.string,
-		compact: PropTypes.bool,
-		children: PropTypes.node,
-		highlight: PropTypes.oneOf( [
-			false,
-			'error',
-			'info',
-			'success',
-			'warning',
-		] ),
-	},
+	const highlightClass = highlight ? 'is-' + highlight : false;
 
-	getDefaultProps() {
-		return {
-			tagName: 'div',
-			highlight: false,
-		};
-	},
+	const className = classnames( 'card', props.className, {
+		'is-card-link': !! href,
+		'is-compact': compact,
+	}, highlightClass );
 
-	getHighlightClass() {
-		const { highlight } = this.props;
-		if ( ! highlight ) {
-			return false;
-		}
+	const omitProps = [ 'compact', 'highlight', 'tagName' ];
 
-		return 'is-' + highlight;
-	},
-
-	render: function() {
-		const className = classnames( 'card', this.props.className, {
-			'is-card-link': !! this.props.href,
-			'is-compact': this.props.compact,
-		}, this.getHighlightClass() );
-
-		const omitProps = [ 'compact', 'highlight', 'tagName' ];
-
-		let linkIndicator;
-		if ( this.props.href ) {
-			linkIndicator = <Gridicon
-				className="card__link-indicator"
-				icon={ this.props.target ? 'external' : 'chevron-right' } />;
-		} else {
-			omitProps.push( 'href', 'target' );
-		}
-
-		return React.createElement(
-			this.props.href ? 'a' : this.props.tagName,
-			assign( omit( this.props, omitProps ), { className } ),
-			linkIndicator,
-			this.props.children
-		);
+	let linkIndicator;
+	if ( href ) {
+		linkIndicator = <Gridicon
+			className="card__link-indicator"
+			icon={ target ? 'external' : 'chevron-right' } />;
+	} else {
+		omitProps.push( 'href', 'target' );
 	}
-} );
+
+	return React.createElement(
+		href ? 'a' : tagName,
+		assign( omit( props, omitProps ), { className } ),
+		linkIndicator,
+		children
+	);
+};
+
+Card.propTypes = {
+	className: PropTypes.string,
+	href: PropTypes.string,
+	tagName: PropTypes.string,
+	target: PropTypes.string,
+	compact: PropTypes.bool,
+	children: PropTypes.node,
+	highlight: PropTypes.oneOf( [
+		false,
+		'error',
+		'info',
+		'success',
+		'warning',
+	] ),
+};
+
+Card.defaultProps = {
+	tagName: 'div',
+	highlight: false,
+};
+
+export default Card;


### PR DESCRIPTION
eslint test fails with the following error:

```
25:4  error  className should follow CSS namespace guidelines (expected card)  wpcalypso/jsx-classname-namespace
```

Line 25 is for adding the class to the GridIcon which is used within the Card. This can't have the class card as this would apply incorrect styles.

Cards can be found in /devdocs/design/

![image](https://user-images.githubusercontent.com/11388669/30506956-eff042e8-9a34-11e7-9fad-20a873e9f6d0.png)
