### PR TITLE
Site Settings: Run codemods on publishing tools and "press this"

### DIFF
--- a/client/my-sites/site-settings/press-this/index.jsx
+++ b/client/my-sites/site-settings/press-this/index.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
-
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';

--- a/client/my-sites/site-settings/press-this/index.jsx
+++ b/client/my-sites/site-settings/press-this/index.jsx
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 

--- a/client/my-sites/site-settings/press-this/link.jsx
+++ b/client/my-sites/site-settings/press-this/link.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
-
 import React from 'react';
 import { omit } from 'lodash';
 

--- a/client/my-sites/site-settings/press-this/link.jsx
+++ b/client/my-sites/site-settings/press-this/link.jsx
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import { omit } from 'lodash';
 
 /**
@@ -24,16 +26,16 @@ const pressThis = function( postURL ) {
 	let sel;
 
 	if ( winGetSel ) {
-		sel = winGetSel()
+		sel = winGetSel();
 	} else if ( docGetSel ) {
-		sel = docGetSel()
+		sel = docGetSel();
 	} else {
-		sel = docSel ? docSel.createRange().text : 0
+		sel = docSel ? docSel.createRange().text : 0;
 	}
 
-	let url = postURL + '?url=' + encodeURIComponent( loc.href ) + '&title=' + encodeURIComponent( doc.title ) + '&text=' + encodeURIComponent( sel ) + '&v=5';
+	const url = postURL + '?url=' + encodeURIComponent( loc.href ) + '&title=' + encodeURIComponent( doc.title ) + '&text=' + encodeURIComponent( sel ) + '&v=5';
 
-	let redirect = function() {
+	const redirect = function() {
 		if ( ! win.open( url, 't', 'toolbar=0,resizable=1,scrollbars=1,status=1,width=660,height=570' ) ) {
 			loc.href = url;
 		}
@@ -59,8 +61,8 @@ class PressThisLink extends React.Component {
 	 * @return {string} javascript pseudo-protocol link
 	 */
 	pressThisWPAdmin() {
-		let site = this.props.site;
-		let adminURL = site && site.options && site.options.admin_url;
+		const site = this.props.site;
+		const adminURL = site && site.options && site.options.admin_url;
 		return [
 			"javascript:var d=document,w=window,e=w.getSelection,k=d.getSelection,x=d.selection,s=(e?e():(k)?k():(x?x.createRange().text:0)),f='", // eslint-disable-line no-script-url
 			adminURL,
@@ -76,12 +78,12 @@ class PressThisLink extends React.Component {
 	buildPressThisLink() {
 		const functionText = pressThis.toString();
 		// IE does not reliably support window.location.origin
-		let postDomain = ( typeof window !== 'undefined' && window.location ) ? `${window.location.protocol}//${window.location.hostname}` : 'https://wordpress.com';
+		let postDomain = ( typeof window !== 'undefined' && window.location ) ? `${ window.location.protocol }//${ window.location.hostname }` : 'https://wordpress.com';
 		if ( window.location.port ) {
 			postDomain += `:${ window.location.port }`;
 		}
 		const postURL = postDomain + paths.newPost( this.props.site );
-		return `javascript:( ${functionText} )( '${postURL}' )`;
+		return `javascript:( ${ functionText } )( '${ postURL }' )`;
 	}
 
 	render() {
@@ -92,6 +94,6 @@ class PressThisLink extends React.Component {
 			</a>
 		);
 	}
-};
+}
 
 export default PressThisLink;

--- a/client/my-sites/site-settings/press-this/link.jsx
+++ b/client/my-sites/site-settings/press-this/link.jsx
@@ -32,7 +32,9 @@ const pressThis = function( postURL ) {
 		sel = docSel ? docSel.createRange().text : 0;
 	}
 
-	const url = postURL + '?url=' + encodeURIComponent( loc.href ) + '&title=' + encodeURIComponent( doc.title ) + '&text=' + encodeURIComponent( sel ) + '&v=5';
+	const url = postURL + '?url=' + encodeURIComponent( loc.href ) +
+		'&title=' + encodeURIComponent( doc.title ) +
+		'&text=' + encodeURIComponent( sel ) + '&v=5';
 
 	const redirect = function() {
 		if ( ! win.open( url, 't', 'toolbar=0,resizable=1,scrollbars=1,status=1,width=660,height=570' ) ) {
@@ -63,10 +65,12 @@ class PressThisLink extends React.Component {
 		const site = this.props.site;
 		const adminURL = site && site.options && site.options.admin_url;
 		return [
+			/* eslint-disable max-len */
 			"javascript:var d=document,w=window,e=w.getSelection,k=d.getSelection,x=d.selection,s=(e?e():(k)?k():(x?x.createRange().text:0)),f='", // eslint-disable-line no-script-url
 			adminURL,
 			"press-this.php',l=d.location,e=encodeURIComponent,u=f+'?u='+e(l.href)+'&t='+e(d.title)+'&s='+e(s)+'&v=4';a=function(){",
 			"if(!w.open(u,'t','toolbar=0,resizable=1,scrollbars=1,status=1,width=720,height=570'))l.href=u;};if (/Firefox/.test(navigator.userAgent)) setTimeout(a, 0); else a();void(0)"
+			/* eslint-enable max-len */
 		].join( '' );
 	}
 
@@ -77,7 +81,9 @@ class PressThisLink extends React.Component {
 	buildPressThisLink() {
 		const functionText = pressThis.toString();
 		// IE does not reliably support window.location.origin
-		let postDomain = ( typeof window !== 'undefined' && window.location ) ? `${ window.location.protocol }//${ window.location.hostname }` : 'https://wordpress.com';
+		let postDomain = ( typeof window !== 'undefined' && window.location )
+			? `${ window.location.protocol }//${ window.location.hostname }`
+			: 'https://wordpress.com';
 		if ( window.location.port ) {
 			postDomain += `:${ window.location.port }`;
 		}

--- a/client/my-sites/site-settings/publishing-tools/index.jsx
+++ b/client/my-sites/site-settings/publishing-tools/index.jsx
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
 

--- a/client/my-sites/site-settings/publishing-tools/index.jsx
+++ b/client/my-sites/site-settings/publishing-tools/index.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
-
 import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';


### PR DESCRIPTION
This PR contains updates from the following codemods I've ran on `site-settings/publishing-tools` and `site-settings/press-this`:

* commonjs-imports-hoist
* commonjs-imports
* commonjs-exports
* i18n-mixin
* react-create-class
* react-prop-types

To test:
* Checkout this branch
* Go to http://calypso.localhost:3000/settings/writing/:site, where :site is one of your Jetpack sites.
* Verify the Publishing Tools card appears OK and there are no warnings.
* Verify the Press This card looks and works fine and there are no warnings.