### PR TITLE
Plugin list: align disabled autoupdate message with other messages

### DIFF
--- a/client/my-sites/plugins/plugin-action/style.scss
+++ b/client/my-sites/plugins/plugin-action/style.scss
@@ -22,6 +22,7 @@
 	}
 
 	.plugin-action__label {
+		margin-left: 12px;
 		@include breakpoint( '<480px' ) {
 			color: $gray-dark;
 		}
@@ -64,7 +65,6 @@
 .plugin-action__disabled-info.info-popover {
 	float: right;
 	height: 16px;
-	width: 24px;
 }
 
 .plugin-action__disabled-info.info-popover .gridicons-info-outline {

--- a/client/my-sites/plugins/plugin-action/style.scss
+++ b/client/my-sites/plugins/plugin-action/style.scss
@@ -22,7 +22,6 @@
 	}
 
 	.plugin-action__label {
-		margin-left: 12px;
 		@include breakpoint( '<480px' ) {
 			color: $gray-dark;
 		}
@@ -47,6 +46,7 @@
 
 	.has-disabled-info & {
 		cursor: default;
+		margin-left: 12px;
 	}
 }
 
@@ -65,6 +65,7 @@
 .plugin-action__disabled-info.info-popover {
 	float: right;
 	height: 16px;
+	width: 24px;
 }
 
 .plugin-action__disabled-info.info-popover .gridicons-info-outline {

--- a/client/my-sites/plugins/plugin-remove-button/style.scss
+++ b/client/my-sites/plugins/plugin-remove-button/style.scss
@@ -8,14 +8,11 @@
 	display: block;
 }
 
-.plugin-meta__actions .plugin-remove-button__remove-link {
-	margin-left: 0;
-}
-
 .plugin-site__actions .plugin-remove-button__remove {
 	margin-top: 0;
 	padding: 16px;
 }
+
 .plugin-remove-button__remove-icon {
 	display: block;
 	margin: -2px 3px 0;

--- a/client/my-sites/plugins/plugin-remove-button/style.scss
+++ b/client/my-sites/plugins/plugin-remove-button/style.scss
@@ -8,9 +8,6 @@
 	display: block;
 }
 
-.plugin-remove-button__remove-link {
-	margin-left:12px;
-}
 .plugin-meta__actions .plugin-remove-button__remove-link {
 	margin-left: 0;
 }

--- a/client/my-sites/plugins/plugin-site-jetpack/style.scss
+++ b/client/my-sites/plugins/plugin-site-jetpack/style.scss
@@ -50,6 +50,10 @@
 	}
 }
 
+.plugin-site-jetpack .plugin-action__disabled-info.info-popover .gridicons-info-outline {
+	    transform: translate(2px, -2px);
+}
+
 .plugin-site-jetpack__embed-action {
 	height: 32px;
 	position: absolute;


### PR DESCRIPTION
Fixes #17260

**Before:**

<img width="771" alt="screenshot 2017-09-15 at 16 27 40" src="https://user-images.githubusercontent.com/426388/30506834-de78b60e-9a33-11e7-8903-cd4b03f699e8.png">

**After:**

<img width="788" alt="screenshot 2017-09-15 at 16 27 30" src="https://user-images.githubusercontent.com/426388/30506824-d954d5e0-9a33-11e7-88fc-191c600138bd.png">

**To test:**

Follow the instructions in the original bug report:
https://github.com/Automattic/wp-calypso/issues/17260#issue-250784771