### PR TITLE
Apply codemods to `client/components/email-verification`

### DIFF
--- a/client/components/email-verification/email-unverified-notice.jsx
+++ b/client/components/email-verification/email-unverified-notice.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import * as React from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 /**
  * Internal dependencies
@@ -24,9 +25,9 @@ export default class EmailUnverifiedNotice extends React.Component {
 	};
 
 	static propTypes = {
-		userEmail: React.PropTypes.string,
-		noticeText: React.PropTypes.node,
-		noticeStatus: React.PropTypes.string
+		userEmail: PropTypes.string,
+		noticeText: PropTypes.node,
+		noticeStatus: PropTypes.string
 	};
 
 	static defaultProps = {

--- a/client/components/email-verification/email-verification-dialog/index.jsx
+++ b/client/components/email-verification/email-verification-dialog/index.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { get, includes, noop } from 'lodash';
 import { localize } from 'i18n-calypso';
@@ -97,11 +98,11 @@ class VerifyEmailDialog extends Component {
 }
 
 VerifyEmailDialog.propTypes = {
-	onClose: React.PropTypes.func,
-	translate: React.PropTypes.func,
+	onClose: PropTypes.func,
+	translate: PropTypes.func,
 	// connected props:
-	email: React.PropTypes.string,
-	emailVerificationStatus: React.PropTypes.string,
+	email: PropTypes.string,
+	emailVerificationStatus: PropTypes.string,
 };
 
 VerifyEmailDialog.defaultProps = {

--- a/client/components/email-verification/email-verification-gate.jsx
+++ b/client/components/email-verification/email-verification-gate.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import * as React from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { connect } from 'react-redux';
 
 /**
@@ -14,11 +15,11 @@ import { isCurrentUserEmailVerified } from 'state/current-user/selectors';
 
 export class EmailVerificationGate extends React.Component {
 	static propTypes = {
-		noticeText: React.PropTypes.node,
-		noticeStatus: React.PropTypes.string,
+		noticeText: PropTypes.node,
+		noticeStatus: PropTypes.string,
 		//connected
-		userEmail: React.PropTypes.string,
-		needsVerification: React.PropTypes.bool
+		userEmail: PropTypes.string,
+		needsVerification: PropTypes.bool
 	};
 
 	static defaultProps = {

--- a/client/components/email-verification/index.js
+++ b/client/components/email-verification/index.js
@@ -22,16 +22,16 @@ const user = userFactory();
  */
 
 export default function emailVerification( context, next ) {
-	let showVerifiedNotice = ( '1' === context.query.verified );
+	const showVerifiedNotice = ( '1' === context.query.verified );
 
 	if ( showVerifiedNotice ) {
 		user.signalVerification();
 		setTimeout( () => {
 			// TODO: unify these once translations catch up
-			let message = i18n.getLocaleSlug() === 'en'
+			const message = i18n.getLocaleSlug() === 'en'
 				? i18n.translate( 'Email confirmed!' )
 				: i18n.translate( "Email confirmed! Now that you've confirmed your email address you can publish posts on your blog." );
-			let notice = successNotice( message, { duration: 10000 } );
+			const notice = successNotice( message, { duration: 10000 } );
 			context.store.dispatch( notice );
 		}, 100 ); // A delay is needed here, because the notice state seems to be cleared upon page load
 	}


### PR DESCRIPTION
Ran `./bin/runmods.sh client/components/account-recovery`

**Testing instructions:**
1) Change your email address.
2) The `/verify-email` endpoint should redirect to `/me/account?verified=1` but it isn't appending the query string. Visit this endpoint on dev and verify the notice shows that the email has been verified.