### PR TITLE
Update accordion example to use React.Component

### DIFF
--- a/client/components/accordion/docs/example.jsx
+++ b/client/components/accordion/docs/example.jsx
@@ -3,14 +3,16 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	PureRenderMixin = require( 'react-pure-render/mixin' );
+import React from 'react';
+
+import PureRenderMixin from 'react-pure-render/mixin';
 
 /**
  * Internal dependencies
  */
-var Accordion = require( 'components/accordion' ),
-	Gridicon = require( 'gridicons' );
+import Accordion from 'components/accordion';
+
+import Gridicon from 'gridicons';
 
 module.exports = React.createClass( {
 	displayName: 'AccordionExample',

--- a/client/components/accordion/docs/example.jsx
+++ b/client/components/accordion/docs/example.jsx
@@ -5,8 +5,6 @@
  */
 import React from 'react';
 
-import PureRenderMixin from 'react-pure-render/mixin';
-
 /**
  * Internal dependencies
  */
@@ -14,24 +12,20 @@ import Accordion from 'components/accordion';
 
 import Gridicon from 'gridicons';
 
-export default React.createClass( {
-	displayName: 'AccordionExample',
+export default class extends React.PureComponent {
+    static displayName = 'AccordionExample';
 
-	mixins: [ PureRenderMixin ],
+	state = {
+		showSubtitles: true
+	};
 
-	getInitialState: function() {
-		return {
-			showSubtitles: true
-		};
-	},
-
-	_toggleShowSubtitles: function() {
+	_toggleShowSubtitles = () => {
 		this.setState( {
 			showSubtitles: ! this.state.showSubtitles
 		} );
-	},
+	};
 
-	render: function() {
+	render() {
 		return (
 			<div>
 				<div style={ { paddingBottom: '10px' } }>
@@ -82,4 +76,4 @@ export default React.createClass( {
 			</div>
 		);
 	}
-} );
+}

--- a/client/components/accordion/docs/example.jsx
+++ b/client/components/accordion/docs/example.jsx
@@ -14,7 +14,7 @@ import Accordion from 'components/accordion';
 
 import Gridicon from 'gridicons';
 
-module.exports = React.createClass( {
+export default React.createClass( {
 	displayName: 'AccordionExample',
 
 	mixins: [ PureRenderMixin ],


### PR DESCRIPTION
This PR updates the accordion example to React.component over React.createClass using bin/runmods.sh

### Testing Instructions
- No functional changes
- Navigate to https://calypso.localhost:3000/devdocs/design/accordion
- Example works as it did in https://wpcalypso.wordpress.com/devdocs/design/accordion