### PR TITLE
Update/codemod auth code button

### DIFF
--- a/client/auth/auth-code-button.jsx
+++ b/client/auth/auth-code-button.jsx
@@ -12,30 +12,27 @@ import { requestCode, resetCode } from 'lib/auth-code-request-store/actions';
 import { default as Store, requestState } from 'lib/auth-code-request-store';
 import Notice from 'components/notice';
 
-export default localize( React.createClass( {
+export default localize( class extends React.Component {
+	state = Store.get();
 
-	componentDidMount: function() {
+	componentDidMount() {
 		Store.on( 'change', this.refreshData );
-	},
+	}
 
-	componentWillUnmount: function() {
+	componentWillUnmount() {
 		Store.off( 'change', this.refreshData );
-	},
+	}
 
-	refreshData: function() {
+	refreshData = () => {
 		this.setState( Store.get() );
-	},
+	};
 
-	getInitialState: function() {
-		return Store.get();
-	},
-
-	requestSMSCode: function( e ) {
+	requestSMSCode = e => {
 		e.preventDefault();
 		requestCode( this.props.username, this.props.password );
-	},
+	};
 
-	render: function() {
+	render() {
 		const { status, errorLevel, errorMessage } = this.state;
 
 		let noticeStatus = 'is-info';
@@ -65,5 +62,4 @@ export default localize( React.createClass( {
 			</Notice>
 		);
 	}
-
-} ) );
+} );

--- a/client/auth/auth-code-button.jsx
+++ b/client/auth/auth-code-button.jsx
@@ -62,6 +62,6 @@ class AuthCodeButton extends React.Component {
 			</Notice>
 		);
 	}
-};
+}
 
 export default localize( AuthCodeButton );

--- a/client/auth/auth-code-button.jsx
+++ b/client/auth/auth-code-button.jsx
@@ -12,7 +12,7 @@ import { requestCode, resetCode } from 'lib/auth-code-request-store/actions';
 import { default as Store, requestState } from 'lib/auth-code-request-store';
 import Notice from 'components/notice';
 
-export default localize( class extends React.Component {
+class AuthCodeButton extends React.Component {
 	state = Store.get();
 
 	componentDidMount() {
@@ -62,4 +62,6 @@ export default localize( class extends React.Component {
 			</Notice>
 		);
 	}
-} );
+};
+
+export default localize( AuthCodeButton );

--- a/client/auth/auth-code-button.jsx
+++ b/client/auth/auth-code-button.jsx
@@ -3,6 +3,8 @@
  */
 import React from 'react';
 
+import { localize } from 'i18n-calypso';
+
 /**
  * Internal Dependencies
  */
@@ -10,7 +12,7 @@ import { requestCode, resetCode } from 'lib/auth-code-request-store/actions';
 import { default as Store, requestState } from 'lib/auth-code-request-store';
 import Notice from 'components/notice';
 
-export default React.createClass( {
+export default localize( React.createClass( {
 
 	componentDidMount: function() {
 		Store.on( 'change', this.refreshData );
@@ -36,19 +38,19 @@ export default React.createClass( {
 	render: function() {
 		const { status, errorLevel, errorMessage } = this.state;
 
-		var noticeStatus = 'is-info';
-		var showDismiss = false;
-		var message = (
-			<a href="#" onClick={ this.requestSMSCode }>{ this.translate( 'Send code via text message.' ) }</a>
+		let noticeStatus = 'is-info';
+		let showDismiss = false;
+		let message = (
+			<a href="#" onClick={ this.requestSMSCode }>{ this.props.translate( 'Send code via text message.' ) }</a>
 		);
 
 		if ( status === requestState.REQUESTING ) {
-			message = this.translate( 'Requesting code.' );
+			message = this.props.translate( 'Requesting code.' );
 		}
 
 		if ( status === requestState.COMPLETE ) {
 			noticeStatus = 'is-success';
-			message = this.translate( 'Code sent.' );
+			message = this.props.translate( 'Code sent.' );
 		}
 
 		if ( errorLevel !== false ) {
@@ -64,4 +66,4 @@ export default React.createClass( {
 		);
 	}
 
-} )
+} ) );


### PR DESCRIPTION
Runs `bin/runmods.sh` on `client/auth/auth-code-button.jsx`. This made the following changes:

- Use `localize` HOC instead of `this.translate`
- Use `React.Component` instead of `createClass`
- Some other small changes

*To test:*

- Build and run the Desktop app using this branch of Calypso (internal instructions: PCYsg-6rI-p2 ).
- Log into an account with 2-factor authentication enabled.
- Click on the button "Send code via text message." to make sure it works.

cc @gwwar @astralbodies 