### PR TITLE
Editor: Prevent unsaved changes from appearing on feature image change

### DIFF
--- a/client/lib/posts/post-edit-store.js
+++ b/client/lib/posts/post-edit-store.js
@@ -3,8 +3,7 @@
  *
  * @format
  */
-
-import { assign, filter, isEqual, pickBy, without } from 'lodash';
+import { assign, filter, isEqual, pickBy, without, omit } from 'lodash';
 import debugFactory from 'debug';
 const debug = debugFactory( 'calypso:posts:post-edit-store' );
 import emitter from 'lib/mixins/emitter';
@@ -135,6 +134,17 @@ function set( attributes ) {
 	}
 
 	updatedPost = assign( {}, _post, attributes );
+
+	// This prevents an unsaved changes dialogue from appearing
+	// on a new post when only the featured image is added then removed.
+	// See #17701 for context.
+	if ( updatedPost.featured_image === '' &&
+		! _savedPost.featured_image &&
+		_post.featured_image
+	) {
+		updatedPost = omit( updatedPost, 'featured_image' );
+	}
+
 	updatedPost = normalize( updatedPost );
 
 	if ( ! isEqual( updatedPost, _post ) ) {


### PR DESCRIPTION
As mentioned in #17701, currently if you start a new post and add/remove a featured image,
you get an unsaved changes dialogue popup if you try to leave the page. This is only happening with new posts. Here's the overall process. 

1. When we initialize a new post, we create two identical copies - `_post` and `_savedPost` [here](https://github.com/Automattic/wp-calypso/blob/master/client/lib/posts/post-edit-store.js#L78). Neither have [the `featured_image` property](https://github.com/Automattic/wp-calypso/blob/master/client/lib/posts/post-edit-store.js#L99) to start.
2. When you add a featured image to a brand new post, we create the `featured_image` property on `_post` to hold the value.
3. If you then remove the featured image, we keep the `featured_image` property on `_post`, but we just empty out the value.

This results in the unsaved change message because we're comparing `_post !== _savedPost` to determine if the post is dirty [here](https://github.com/Automattic/wp-calypso/blob/master/client/lib/posts/post-edit-store.js#L352). The issue is that `_post.featured_image` still exists with an empty value and `_savedPost.featured_image` does not.

This is immediately fixed when a new post is saved for the first time because we flesh out the remaining attributes. At that point, both `_post` and `_savedPost` are given a `featured_image` property [here](https://github.com/Automattic/wp-calypso/blob/master/client/lib/posts/actions.js#L288).

As a result, this PR omits the `featured_image` property from the `_post` object when:
1. `updatedPost` comes back with an empty featured image.
2. `_savedPost` doesn't have a featured image property yet.
3. `_post` has a previous featured image.

## To test
1. Load this branch.
2. Open the editor for a new post.
3. Add a featured image. Then, remove it.
4. Try to leave the page. You shouldn't encounter an unsaved changes error.

The remaining functionality (adding/removing featured images for saved posts, etc) should remain the same.