### PR TITLE
Rating: Change from noticon to gridicon

### DIFF
--- a/client/components/rating/README.md
+++ b/client/components/rating/README.md
@@ -13,7 +13,7 @@ render: function() {
 	return (
 		<Rating
 			rating={ 65 }
-			size={ 50 }
+			size={ 48 }
 		/>
 	);
 }
@@ -23,5 +23,5 @@ render: function() {
 
 * `rating`: Number - A number with the 0-100 rating to render
 
-* `size`: **optional** Number - `font-size` value in pixels. If it isn't
-  defined font-size will be set to `inherit`
+* `size`: **optional** Number - icon height in pixels. If it isn't
+  defined size will be set to 24px.

--- a/client/components/rating/docs/example.jsx
+++ b/client/components/rating/docs/example.jsx
@@ -16,7 +16,7 @@ module.exports = React.createClass( {
 
 	render: function() {
 		return (
-			<Rating rating={ 65 } size={ 50 } />
+			<Rating rating={ 70 } size={ 48 } />
 		);
 	}
 } );

--- a/client/components/rating/docs/example.jsx
+++ b/client/components/rating/docs/example.jsx
@@ -1,22 +1,17 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	PureRenderMixin = require( 'react-pure-render/mixin' );
+import React from 'react';
 
 /**
  * Internal dependencies
  */
-var Rating = require( 'components/rating' );
+import Rating from 'components/rating';
 
-module.exports = React.createClass( {
-	displayName: 'Rating',
-
-	mixins: [ PureRenderMixin ],
-
-	render: function() {
+export default class RatingExample extends React.PureComponent {
+	render() {
 		return (
 			<Rating rating={ 70 } size={ 48 } />
 		);
 	}
-} );
+}

--- a/client/components/rating/index.jsx
+++ b/client/components/rating/index.jsx
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-var React = require( 'react' );
+import React from 'react';
+import PropTypes from 'prop-types';
+import Gridicon from 'gridicons';
 
 module.exports = React.createClass( {
 
@@ -12,48 +14,66 @@ module.exports = React.createClass( {
 	},
 
 	propTypes: {
-		rating: React.PropTypes.number,
-		size: React.PropTypes.number
+		rating: PropTypes.number,
+		size: PropTypes.number
 	},
 
-	getStars: function() {
-		var i,
-			stars = [],
-			ratingOverTen = Math.ceil( this.props.rating / 10 ),
-			numberOfStars = Math.floor( ratingOverTen / 2 ),
-			hasHalfStar = ( ( ratingOverTen / 2 ) % 1 >= 0.5 ),
-			starStyles = {
-				fontSize: this.props.size
-					? this.props.size + 'px'
-					: 'inherit'
-			};
+	overlayStars: function() {
+		let i;
+		const stars = [];
+		const starStyles = {
+			width: this.props.size
+				? this.props.size + 'px'
+				: '24px',
+			height: this.props.size
+				? this.props.size + 'px'
+				: '24px'
+		};
 
-		for ( i = 0; i < numberOfStars; i++ ) {
+		for ( i = 1; i < 6; i++ ) {
 			stars.push(
-				<span
-					key={ 'star_' + i }
-					className="noticon noticon-rating-full"
+				<Gridicon
+					key={ 'star-' + i }
+					icon="star"
 					style={ starStyles }
 				/>
 			);
 		}
+		return stars;
+	},
 
-		if ( hasHalfStar ) {
-			stars.push(
-				<span
-					key="halfstar"
-					className="noticon noticon-rating-half"
-					style={ starStyles }
-				/>
-			);
-		}
+	outlineStars: function() {
+		const stars = [];
+		let i;
+		const roundRating = Math.round( this.props.rating / 10 ) * 10;
+		const inverseRating = 100 - roundRating;
+		const outlineCount = Math.floor( inverseRating / 20 );
+		const starStyles = {
+			width: this.props.size
+				? this.props.size + 'px'
+				: '24px',
+			height: this.props.size
+				? this.props.size + 'px'
+				: '24px'
+		};
 
-		while ( stars.length < 5 ) {
+		for ( i = 1; i < 6; i++ ) {
+			let outlineStyles = { fill: '#00aadc' };
+			if ( inverseRating / 20 >= 1 ) {
+				if ( i > ( 5 - outlineCount ) ) {
+					outlineStyles = {
+						fill: '#c8d7e1',
+					};
+				}
+			}
+			const allStyles = Object.assign( {}, starStyles, outlineStyles );
+
 			stars.push(
-				<span
-					key={ 'empty_' + stars.length }
-					className="noticon noticon-rating-empty"
-					style={ starStyles }
+				<Gridicon
+					key={ 'outline-' + i }
+					icon="star-outline"
+					className={ 'outline-' + i }
+					style={ allStyles }
 				/>
 			);
 		}
@@ -62,15 +82,27 @@ module.exports = React.createClass( {
 	},
 
 	render: function() {
-		var ratingStyles = {
-			width: this.props.size
-				? ( this.props.size * 5 ) + 'px'
-				: '100%'
+		const ratingStyles = {
+			width: ( this.props.size * 5 ) + 'px'
+		};
+
+		const roundRating = Math.round( this.props.rating / 10 ) * 10;
+		const ratingWidth = ( this.props.size * 5 );
+		const maskPosition = ( ( roundRating / 100 ) * ratingWidth ) + 'px';
+		const overlayHeightPx = ( this.props.size ) + 'px';
+		const overlayStyles = {
+			clip: 'rect(0,' + maskPosition + ',' + overlayHeightPx + ', 0)',
+			width: ( this.props.size * 5 ) + 'px'
 		};
 
 		return (
-			<div className="rating" style={ ratingStyles }>
-				{ this.getStars() }
+			<div className="rating" style={ ratingStyles } data-rating={ this.props.rating } data-size={ this.props.size }>
+				<div className="rating__overlay" style={ overlayStyles }>
+					{ this.overlayStars() }
+				</div>
+				<div className="rating__star-outline">
+					{ this.outlineStars() }
+				</div>
 			</div>
 		);
 	}

--- a/client/components/rating/index.jsx
+++ b/client/components/rating/index.jsx
@@ -5,32 +5,27 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Gridicon from 'gridicons';
 
-module.exports = React.createClass( {
+export default class Rating extends React.PureComponent {
+	static defaultProps = {
+		rating: 0,
+		size: 24,
+	};
 
-	displayName: 'Rating',
-
-	getDefaultProps: function() {
-		return { rating: 0, size: 24 };
-	},
-
-	propTypes: {
+	static propTypes = {
 		rating: PropTypes.number,
-		size: PropTypes.number
-	},
+		size: PropTypes.number,
+	};
 
-	overlayStars: function() {
-		let i;
-		const stars = [];
+	overlayStars() {
+		const { size } = this.props;
+
 		const starStyles = {
-			width: this.props.size
-				? this.props.size + 'px'
-				: '24px',
-			height: this.props.size
-				? this.props.size + 'px'
-				: '24px'
+			width: size + 'px',
+			height: size + 'px',
 		};
 
-		for ( i = 1; i < 6; i++ ) {
+		const stars = [];
+		for ( let i = 0; i < 5; i++ ) {
 			stars.push(
 				<Gridicon
 					key={ 'star-' + i }
@@ -40,66 +35,56 @@ module.exports = React.createClass( {
 			);
 		}
 		return stars;
-	},
+	}
 
-	outlineStars: function() {
-		const stars = [];
-		let i;
-		const roundRating = Math.round( this.props.rating / 10 ) * 10;
-		const inverseRating = 100 - roundRating;
-		const outlineCount = Math.floor( inverseRating / 20 );
+	outlineStars() {
+		const { rating, size } = this.props;
+
+		const inverseRating = 100 - Math.round( rating / 10 ) * 10;
+		const noFillOutlineCount = Math.floor( inverseRating / 20 );
+
 		const starStyles = {
-			width: this.props.size
-				? this.props.size + 'px'
-				: '24px',
-			height: this.props.size
-				? this.props.size + 'px'
-				: '24px'
+			width: size + 'px',
+			height: size + 'px',
+			fill: '#00aadc',
 		};
 
-		for ( i = 1; i < 6; i++ ) {
-			let outlineStyles = { fill: '#00aadc' };
-			if ( inverseRating / 20 >= 1 ) {
-				if ( i > ( 5 - outlineCount ) ) {
-					outlineStyles = {
-						fill: '#c8d7e1',
-					};
-				}
+		const stars = [];
+		for ( let i = 0; i < 5; i++ ) {
+			let allStyles = starStyles;
+			if ( i >= ( 5 - noFillOutlineCount ) ) {
+				allStyles = Object.assign( {}, starStyles, { fill: '#c8d7e1' } );
 			}
-			const allStyles = Object.assign( {}, starStyles, outlineStyles );
 
 			stars.push(
 				<Gridicon
-					key={ 'outline-' + i }
+					key={ 'star-outline-' + i }
 					icon="star-outline"
-					className={ 'outline-' + i }
 					style={ allStyles }
 				/>
 			);
 		}
 
 		return stars;
-	},
+	}
 
-	render: function() {
-		const ratingStyles = {
-			width: ( this.props.size * 5 ) + 'px'
-		};
+	render() {
+		const { rating, size } = this.props;
 
-		const roundRating = Math.round( this.props.rating / 10 ) * 10;
-		const ratingWidth = ( this.props.size * 5 );
-		const maskPosition = ( ( roundRating / 100 ) * ratingWidth ) + 'px';
-		const clipPathMaskPosition = ( ratingWidth - ( ( roundRating / 100 ) * ratingWidth ) ) + 'px';
-		const overlayHeightPx = ( this.props.size ) + 'px';
+		const totalWidth = size * 5;
+		const roundRating = Math.round( rating / 10 ) * 10;
+		const maskPosition = ( ( roundRating / 100 ) * totalWidth );
+		const clipPathMaskPosition = ( totalWidth - maskPosition ) + 'px';
+		const overlayHeightPx = size + 'px';
 		const overlayStyles = {
 			WebkitClipPath: 'inset(0 ' + clipPathMaskPosition + ' 0 0 )',
 			clipPath: 'inset(0 ' + clipPathMaskPosition + ' 0 0 )',
-			clip: 'rect(0, ' + maskPosition + ', ' + overlayHeightPx + ', 0)',
-			width: ( this.props.size * 5 ) + 'px'
+			clip: 'rect(0, ' + ( maskPosition + 'px' ) + ', ' + overlayHeightPx + ', 0)',
+			width: totalWidth + 'px'
 		};
 
 		return (
-			<div className="rating" style={ ratingStyles }>
+			<div className="rating" style={ { width: totalWidth + 'px' } }>
 				<div className="rating__overlay" style={ overlayStyles }>
 					{ this.overlayStars() }
 				</div>
@@ -109,4 +94,4 @@ module.exports = React.createClass( {
 			</div>
 		);
 	}
-} );
+}

--- a/client/components/rating/index.jsx
+++ b/client/components/rating/index.jsx
@@ -89,14 +89,17 @@ module.exports = React.createClass( {
 		const roundRating = Math.round( this.props.rating / 10 ) * 10;
 		const ratingWidth = ( this.props.size * 5 );
 		const maskPosition = ( ( roundRating / 100 ) * ratingWidth ) + 'px';
+		const clipPathMaskPosition = ( ratingWidth - ( ( roundRating / 100 ) * ratingWidth ) ) + 'px';
 		const overlayHeightPx = ( this.props.size ) + 'px';
 		const overlayStyles = {
-			clip: 'rect(0,' + maskPosition + ',' + overlayHeightPx + ', 0)',
+			WebkitClipPath: 'inset(0 ' + clipPathMaskPosition + ' 0 0 )',
+			clipPath: 'inset(0 ' + clipPathMaskPosition + ' 0 0 )',
+			clip: 'rect(0, ' + maskPosition + ', ' + overlayHeightPx + ', 0)',
 			width: ( this.props.size * 5 ) + 'px'
 		};
 
 		return (
-			<div className="rating" style={ ratingStyles } data-rating={ this.props.rating } data-size={ this.props.size }>
+			<div className="rating" style={ ratingStyles }>
 				<div className="rating__overlay" style={ overlayStyles }>
 					{ this.overlayStars() }
 				</div>

--- a/client/components/rating/index.jsx
+++ b/client/components/rating/index.jsx
@@ -10,7 +10,7 @@ module.exports = React.createClass( {
 	displayName: 'Rating',
 
 	getDefaultProps: function() {
-		return { rating: 0 };
+		return { rating: 0, size: 24 };
 	},
 
 	propTypes: {

--- a/client/components/rating/style.scss
+++ b/client/components/rating/style.scss
@@ -1,9 +1,15 @@
 .rating {
-	width: 80px;
-	color: $blue-medium;
-	line-height: 1;
+	position: relative;
 
-	.noticon-rating-empty {
-		color: lighten( $gray, 20% );
+	.rating__overlay,
+	.rating__star-outline {
+		display: flex;
+		left: 0;
+		position: absolute;
+		top: 0;
+
+		.gridicon {
+			fill: $blue-medium;
+		}
 	}
 }

--- a/client/components/rating/test/index.js
+++ b/client/components/rating/test/index.js
@@ -4,6 +4,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import { expect } from 'chai';
+require( 'it-each' )( { testPerIteration: true } );
 
 /**
  * Internal dependencies
@@ -65,8 +66,9 @@ describe( '<Rating />', function() {
 			expect( component.props().style.clip ).to.equal( 'rect(0, 0px, ' + size + 'px, 0)' );
 		} );
 
-		it( 'should render half width mask for rating 50', function() {
-			const rating = 50,
+		const ratingList = [ 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 ];
+		it.each( ratingList, 'should render rating %s as %s', [ 'element', 'element' ], function( element ) {
+			const rating = element,
 				size = 24, // use default size
 				wrapper = shallow(
 					<Rating
@@ -75,24 +77,13 @@ describe( '<Rating />', function() {
 					/>
 				);
 
+			const roundRating = Math.round( rating / 10 ) * 10;
+			const ratingWidth = ( size * 5 );
+			const maskPosition = ( ( roundRating / 100 ) * ratingWidth );
+			const clipPathMaskPosition = ( ratingWidth - ( ( roundRating / 100 ) * ratingWidth ) );
 			const component = wrapper.find( 'div.rating__overlay' );
-			expect( component.props().style.clipPath ).to.equal( 'inset(0 ' + ( ( size * 5 ) / 2 ) + 'px 0 0 )' );
-			expect( component.props().style.clip ).to.equal( 'rect(0, ' + ( ( size * 5 ) / 2 ) + 'px, ' + size + 'px, 0)' );
-		} );
-
-		it( 'should render no mask for full rating', function() {
-			const rating = 100,
-				size = 24, // use default size
-				wrapper = shallow(
-					<Rating
-						rating={ rating }
-						size={ size }
-					/>
-				);
-
-			const component = wrapper.find( 'div.rating__overlay' );
-			expect( component.props().style.clipPath ).to.equal( 'inset(0 0px 0 0 )' );
-			expect( component.props().style.clip ).to.equal( 'rect(0, ' + ( size * 5 ) + 'px, ' + size + 'px, 0)' );
+			expect( component.props().style.clipPath ).to.equal( 'inset(0 ' + clipPathMaskPosition + 'px 0 0 )' );
+			expect( component.props().style.clip ).to.equal( 'rect(0, ' + maskPosition + 'px, ' + size + 'px, 0)' );
 		} );
 	} );
 } );

--- a/client/components/rating/test/index.js
+++ b/client/components/rating/test/index.js
@@ -4,7 +4,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import { expect } from 'chai';
-require( 'it-each' )( { testPerIteration: true } );
+import { each } from 'lodash';
 
 /**
  * Internal dependencies
@@ -66,24 +66,24 @@ describe( '<Rating />', function() {
 			expect( component.props().style.clip ).to.equal( 'rect(0, 0px, ' + size + 'px, 0)' );
 		} );
 
-		const ratingList = [ 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 ];
-		it.each( ratingList, 'should render rating %s as %s', [ 'element', 'element' ], function( element ) {
-			const rating = element,
-				size = 24, // use default size
-				wrapper = shallow(
+		it( 'should render rating clipping mask properly', function() {
+			each( [ 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 ], function( ratingValue ) {
+				const size = 24; // use default size
+				const wrapper = shallow(
 					<Rating
-						rating={ rating }
+						rating={ ratingValue }
 						size={ size }
 					/>
 				);
 
-			const roundRating = Math.round( rating / 10 ) * 10;
-			const ratingWidth = ( size * 5 );
-			const maskPosition = ( ( roundRating / 100 ) * ratingWidth );
-			const clipPathMaskPosition = ( ratingWidth - ( ( roundRating / 100 ) * ratingWidth ) );
-			const component = wrapper.find( 'div.rating__overlay' );
-			expect( component.props().style.clipPath ).to.equal( 'inset(0 ' + clipPathMaskPosition + 'px 0 0 )' );
-			expect( component.props().style.clip ).to.equal( 'rect(0, ' + maskPosition + 'px, ' + size + 'px, 0)' );
+				const roundRating = Math.round( ratingValue / 10 ) * 10;
+				const ratingWidth = ( size * 5 );
+				const maskPosition = ( ( roundRating / 100 ) * ratingWidth );
+				const clipPathMaskPosition = ( ratingWidth - ( ( roundRating / 100 ) * ratingWidth ) );
+				const component = wrapper.find( 'div.rating__overlay' );
+				expect( component.props().style.clipPath ).to.equal( 'inset(0 ' + clipPathMaskPosition + 'px 0 0 )' );
+				expect( component.props().style.clip ).to.equal( 'rect(0, ' + maskPosition + 'px, ' + size + 'px, 0)' );
+			} );
 		} );
 	} );
 } );

--- a/client/components/rating/test/index.js
+++ b/client/components/rating/test/index.js
@@ -12,57 +12,30 @@ import Rating from 'components/rating';
 
 describe( '<Rating />', function() {
 	describe( 'check props size', function() {
-		it( 'should fill in the parent component if no size', function() {
+		it( 'should be set to 24px if no size', function() {
 			const wrapper = shallow(
 				<Rating />
 			);
 
-			const component = wrapper.find( 'div' );
-			expect( component.props().style.width ).to.equal( '100%' );
+			const component = wrapper.find( 'div.rating' );
+			expect( component.props().style.width ).to.equal( '120px' ); // 24 * 5 = 120;
 		} );
 
 		it( 'should use size if passed', function() {
-			const size = 50,
+			const size = 48,
 				wrapper = shallow(
 					<Rating
 						size={ size }
 					/>
 				);
 
-			const component = wrapper.find( 'div' );
+			const component = wrapper.find( 'div.rating' );
 			expect( component.props().style.width ).to.equal( ( size * 5 ) + 'px' );
-		} );
-	} );
-
-	describe( 'check props rating', function() {
-		it( 'should render 5 spans without rating', function() {
-			const wrapper = shallow(
-					<Rating />
-				);
-
-			const component = wrapper.find( 'span' );
-			expect( component.nodes.length ).to.equal( 5 );
-			expect( component ).to.have.exactly( 5 ).descendants( '.noticon-rating-empty' );
-		} );
-
-		it( 'should render 1.5 stars with rating 30', function() {
-			const rating = 30,
-				wrapper = shallow(
-					<Rating
-						rating={ rating }
-					/>
-				);
-
-			const component = wrapper.find( 'span' );
-			expect( component.nodes.length ).to.equal( 5 );
-			expect( component ).to.have.exactly( 1 ).descendants( '.noticon-rating-full' );
-			expect( component ).to.have.exactly( 1 ).descendants( '.noticon-rating-half' );
-			expect( component ).to.have.exactly( 3 ).descendants( '.noticon-rating-empty' );
 		} );
 
 		it( 'should use size in each star', function() {
 			const rating = 30,
-				size = 10,
+				size = 48,
 				wrapper = shallow(
 					<Rating
 						rating={ rating }
@@ -70,27 +43,56 @@ describe( '<Rating />', function() {
 					/>
 				);
 
-			wrapper.find( 'span' ).forEach(
+			wrapper.find( 'svg' ).forEach(
 				( node ) => {
-					expect( node.props().style.fontSize ).to.equal( size + 'px' );
+					expect( node.props().style.width ).to.equal( size + 'px' );
 				}
 			);
 		} );
+	} );
 
-		it( 'if no size it should inherit', function() {
-			const rating = 30,
+	describe( 'check props rating', function() {
+		it( 'should render full width mask for no rating', function() {
+			const size = 24, // use default size
 				wrapper = shallow(
 					<Rating
-						rating={ rating
-						}
+						size={ size }
 					/>
 				);
 
-			wrapper.find( 'span' ).forEach(
-				( node ) => {
-					expect( node.props().style.fontSize ).to.equal( 'inherit' );
-				}
-			);
+			const component = wrapper.find( 'div.rating__overlay' );
+			expect( component.props().style.clipPath ).to.equal( 'inset(0 ' + ( size * 5 ) + 'px 0 0 )' );
+			expect( component.props().style.clip ).to.equal( 'rect(0, 0px, ' + size + 'px, 0)' );
+		} );
+
+		it( 'should render half width mask for rating 50', function() {
+			const rating = 50,
+				size = 24, // use default size
+				wrapper = shallow(
+					<Rating
+						rating={ rating }
+						size={ size }
+					/>
+				);
+
+			const component = wrapper.find( 'div.rating__overlay' );
+			expect( component.props().style.clipPath ).to.equal( 'inset(0 ' + ( ( size * 5 ) / 2 ) + 'px 0 0 )' );
+			expect( component.props().style.clip ).to.equal( 'rect(0, ' + ( ( size * 5 ) / 2 ) + 'px, ' + size + 'px, 0)' );
+		} );
+
+		it( 'should render no mask for full rating', function() {
+			const rating = 100,
+				size = 24, // use default size
+				wrapper = shallow(
+					<Rating
+						rating={ rating }
+						size={ size }
+					/>
+				);
+
+			const component = wrapper.find( 'div.rating__overlay' );
+			expect( component.props().style.clipPath ).to.equal( 'inset(0 0px 0 0 )' );
+			expect( component.props().style.clip ).to.equal( 'rect(0, ' + ( size * 5 ) + 'px, ' + size + 'px, 0)' );
 		} );
 	} );
 } );

--- a/client/my-sites/plugins/plugins-browser-item/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-item/index.jsx
@@ -78,7 +78,7 @@ const PluginsBrowserListElement = React.createClass( {
 						<div className="plugins-browser-item__title">…</div>
 						<div className="plugins-browser-item__author">…</div>
 					</div>
-					<Rating rating={ 0 } />
+					<Rating rating={ 0 } size="12" />
 				</span>
 			</li>
 		);
@@ -97,7 +97,7 @@ const PluginsBrowserListElement = React.createClass( {
 						<div className="plugins-browser-item__author">{ this.props.plugin.author_name }</div>
 						{ this.renderInstalledIn() }
 					</div>
-					<Rating rating={ this.props.plugin.rating } />
+					<Rating rating={ this.props.plugin.rating } size="12" />
 				</a>
 			</li>
 		);

--- a/client/my-sites/plugins/plugins-browser-item/style.scss
+++ b/client/my-sites/plugins/plugins-browser-item/style.scss
@@ -86,7 +86,7 @@
 
 .plugins-browser-item .plugin-icon.is-placeholder,
 .plugins-browser-item .plugin-icon[style*='undefined'] {
-	&:before {
+	&::before {
 		width: 40px;
 		height: 40px;
 		font: normal 40px/40px Noticons;
@@ -97,11 +97,9 @@
 	margin-right: 0;
 }
 
-.plugins-browser-item  .rating {
-	padding-top: 10px;
+.plugins-browser-item .rating {
+	margin-top: 12px;
 	position: absolute;
-		bottom: 16px;
-		left: 16px;
 }
 
 .plugins-browser-item__installed {

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "imports-loader": "0.6.5",
     "inherits": "2.0.1",
     "is-my-json-valid": "2.13.1",
+    "it-each": "0.3.1",
     "jade": "pugjs/jade#29784fd",
     "jquery": "1.11.3",
     "json-loader": "0.5.4",

--- a/package.json
+++ b/package.json
@@ -90,7 +90,6 @@
     "imports-loader": "0.6.5",
     "inherits": "2.0.1",
     "is-my-json-valid": "2.13.1",
-    "it-each": "0.3.1",
     "jade": "pugjs/jade#29784fd",
     "jquery": "1.11.3",
     "json-loader": "0.5.4",


### PR DESCRIPTION
This replaces Noticons with Gridicons, by overlaying solid stars on outline stars, with a mask, to create half stars. See initial discussion here: https://github.com/Automattic/gridicons/pull/249 and CSS proptotype here: https://codepen.io/raoulwegat/pen/yzBqEm

**Before**
<img width="271" alt="screen shot 2017-09-17 at 4 47 17 pm" src="https://user-images.githubusercontent.com/2627210/30518672-0265c5a8-9bc8-11e7-8070-b1a21a29a8ad.png">

**After**
<img width="259" alt="screen shot 2017-09-17 at 4 47 29 pm" src="https://user-images.githubusercontent.com/2627210/30518675-05c699b6-9bc8-11e7-9de4-5ab0157a50cd.png">

Note: Size difference is due to Gridicons requiring multiples of 24px (After is 48px), whereas original Rating was set to 50px.

**Testing Instructions**

1. Open http://calypso.localhost:3000/devdocs/design/rating
2. Edit `docs/example.jsx` to test any rating from 10 to 100 with intervals of 10 (eg. 10, 20, 30...). Save & reload.

**Notes**

[Masking](https://github.com/Automattic/wp-calypso/pull/18103/files#diff-2a7f489faff42c576293644df618e498R94) is using done [`clip-path`](https://developer.mozilla.org/en-US/docs/Web/CSS/clip-path) for [supporting browsers](http://caniuse.com/#feat=css-clip-path), except IE and Edge who don't support the property. Fallback (for IE/Edge) is provided by the [`clip`](https://developer.mozilla.org/en-US/docs/Web/CSS/clip) property that is still present in all browsers even though it has been deprecated.

Tested in Windows 10 IE11/Edge/Chrome/Firefox, macOS Sierra Safari/Chrome/Firefox, iOS 9 & 10 Safari, Android 5, 6 & 8 Chrome.
