### PR TITLE
Site Settings: Run codemods on Related Posts

### DIFF
--- a/client/my-sites/site-settings/related-posts/index.jsx
+++ b/client/my-sites/site-settings/related-posts/index.jsx
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import { localize } from 'i18n-calypso';
 
 /**

--- a/client/my-sites/site-settings/related-posts/index.jsx
+++ b/client/my-sites/site-settings/related-posts/index.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
-
 import React from 'react';
 import { localize } from 'i18n-calypso';
 


### PR DESCRIPTION
This PR contains updates from the following codemods I've ran on `site-settings/related-posts`:

* commonjs-imports-hoist
* commonjs-imports
* commonjs-exports
* i18n-mixin
* react-create-class
* react-prop-types

Seems like the code was up to date there, the only update necessary was to migrate `React.PropTypes` usages to use the `prop-types` package.

To test:
* Checkout this branch
* Go to http://calypso.localhost:3000/settings/traffic/:site, where :site is one of your Jetpack sites.
* Verify the Related Posts card appears and works fine and there are no warnings.