### PR TITLE
Site Settings: Run codemods on settings sections

### DIFF
--- a/client/my-sites/site-settings/settings-security/main.jsx
+++ b/client/my-sites/site-settings/settings-security/main.jsx
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
 

--- a/client/my-sites/site-settings/settings-security/main.jsx
+++ b/client/my-sites/site-settings/settings-security/main.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
-
 import React from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';


### PR DESCRIPTION
This PR contains updates from the following codemods:

* commonjs-imports-hoist
* commonjs-imports
* commonjs-exports
* i18n-mixin
* react-create-class
* react-prop-types

that I've ran on the following files:

* `site-settings/settings-discussion`
* `site-settings/settings-security`
* `site-settings/settings-traffic`
* `site-settings/settings-writing`

Seems like the code was up to date there mostly, we only needed to update the following:
* Migrate `React.PropTypes` usages to use the `prop-types` package in `settings-security/main`.

To test:
* Checkout this branch
* Go to http://calypso.localhost:3000/settings/security/:site, where :site is one of your Jetpack sites.
* Verify the settings cards appear and work fine and there are no warnings.