### PR TITLE
Site Settings: Run codemods on remaining settings dirs

### DIFF
--- a/client/my-sites/site-settings/site-icon-setting/index.jsx
+++ b/client/my-sites/site-settings/site-icon-setting/index.jsx
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { head, partial, partialRight, isEqual, flow, compact, includes, uniqueId } from 'lodash';

--- a/client/my-sites/site-settings/site-icon-setting/index.jsx
+++ b/client/my-sites/site-settings/site-icon-setting/index.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
-
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';

--- a/client/my-sites/site-settings/site-tools/link.jsx
+++ b/client/my-sites/site-settings/site-tools/link.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
-
 import React from 'react';
 import classNames from 'classnames';
 import { noop } from 'lodash';

--- a/client/my-sites/site-settings/site-tools/link.jsx
+++ b/client/my-sites/site-settings/site-tools/link.jsx
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import classNames from 'classnames';
 import { noop } from 'lodash';
 


### PR DESCRIPTION
This PR contains updates from the following codemods:

* commonjs-imports-hoist
* commonjs-imports
* commonjs-exports
* i18n-mixin
* react-create-class
* react-prop-types

that I've ran on the following files:

* `site-settings/site-icon-setting`
* `site-settings/site-tools`
* `site-settings/taxonomies`
* `site-settings/theme-setup`
* `site-settings/theme-setup-dialog`

Seems like the code was up to date there mostly, we only needed to update the following:
* Migrate `React.PropTypes` usages to use the `prop-types` package in two of the components.

To test:
* Checkout this branch
* Go to http://calypso.localhost:3000/settings/general/:site, where :site is one of your WordPress.com sites.
* Verify the Site Icon setting appears and works fine and there are no warnings.
* Verify the Site Tools card appears and works fine and there are no warnings.