### PR TITLE
Editor: Use title placeholder in tooltip when post title is empty

### DIFF
--- a/client/components/date-picker/events-tooltip.jsx
+++ b/client/components/date-picker/events-tooltip.jsx
@@ -77,7 +77,13 @@ class EventsTooltip extends Component {
 								icon={ event.icon }
 								socialIcon={ event.socialIcon }
 								socialIconColor={ event.socialIconColor }
-								title={ event.title } />
+								title={ event.title === ''
+									? this.props.translate( '{{em}}(No title){{/em}}',
+										{ components: { em: <em /> } }
+									)
+									: event.title
+								}
+							/>
 						</li>
 					) }
 


### PR DESCRIPTION
When a user opens the post scheduler, we show an indicator on dates with a currently scheduled post. When the user hovers over those dates, they see a tooltip with the post title. Currently, that tooltip is empty if the post has no title. This adds a `(No Title)` placeholder. This actually applies to old posts as well (already published).

## To test
1. Run this branch. Schedule a new post but leave the post title blank.
2. Start a new post.
3. Click "Status" and under "Publish Immediately," open up the calendar. You'll see a circle around the dates with a scheduled post already. Hover over that date. See "No title".

## Screenshots

**Current**
<img width="295" alt="screen shot 2017-09-17 at 12 57 07 pm" src="https://user-images.githubusercontent.com/7240478/30524492-be671528-9ba9-11e7-9e51-c0ee910348e6.png">

**Fixed**
<img width="313" alt="screen shot 2017-09-17 at 12 56 39 pm" src="https://user-images.githubusercontent.com/7240478/30524490-bc02cb60-9ba9-11e7-80e3-e8516acc7c67.png">

**With Title**
<img width="292" alt="screen shot 2017-09-17 at 12 56 46 pm" src="https://user-images.githubusercontent.com/7240478/30524487-b88d58a6-9ba9-11e7-98fc-f8bf98b0e2a3.png">

Fixes: #17665.