### PR TITLE
Site Settings: hook and add the Jetpack Disconnect Site

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -392,6 +392,7 @@
 @import 'my-sites/site-settings/comment-display-settings/style';
 @import 'my-sites/site-settings/date-time-format/style';
 @import 'my-sites/site-settings/delete-site/style';
+@import 'my-sites/site-settings/disconnect-site/style';
 @import 'my-sites/site-settings/site-tools/style';
 @import 'my-sites/site-settings/delete-site-warning-dialog/style';
 @import 'my-sites/site-settings/jetpack-sync-panel/style';

--- a/client/my-sites/site-settings/controller.js
+++ b/client/my-sites/site-settings/controller.js
@@ -3,6 +3,7 @@
  */
 import page from 'page';
 import React from 'react';
+import ReactDom from 'react-dom';
 
 /**
  * Internal Dependencies
@@ -124,6 +125,7 @@ const controller = {
 	},
 
 	disconnectSite( context ) {
+		ReactDom.unmountComponentAtNode( document.getElementById( 'secondary' ) );
 		renderPage(
 			context,
 			<DisconnectSite />

--- a/client/my-sites/site-settings/controller.js
+++ b/client/my-sites/site-settings/controller.js
@@ -10,6 +10,7 @@ import React from 'react';
 import AsyncLoad from 'components/async-load';
 import config from 'config';
 import DeleteSite from './delete-site';
+import DisconnectSite from './disconnect-site';
 import purchasesPaths from 'me/purchases/paths';
 import { renderWithReduxStore } from 'lib/react-helpers';
 import SiteSettingsMain from 'my-sites/site-settings/main';
@@ -119,6 +120,13 @@ const controller = {
 		renderPage(
 			context,
 			<DeleteSite path={ context.path } />
+		);
+	},
+
+	disconnectSite( context ) {
+		renderPage(
+			context,
+			<DisconnectSite />
 		);
 	},
 

--- a/client/my-sites/site-settings/disconnect-site/index.jsx
+++ b/client/my-sites/site-settings/disconnect-site/index.jsx
@@ -1,0 +1,48 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { flowRight } from 'lodash';
+import { localize } from 'i18n-calypso';
+/**
+ * Internal dependencies
+ */
+import Card from 'components/card';
+import DocumentHead from 'components/data/document-head';
+import FormattedHeader from 'components/formatted-header';
+import { getSelectedSite } from 'state/ui/selectors';
+import Main from 'components/main';
+import Placeholder from 'my-sites/site-settings/placeholder';
+import redirectNonJetpack from 'my-sites/site-settings/redirect-non-jetpack';
+
+class DisconnectSite extends Component {
+	render() {
+		const { site, translate } = this.props;
+
+		if ( ! site ) {
+			return <Placeholder />;
+		}
+		return (
+			<Main className="disconnect-site site-settings">
+				<DocumentHead title={ translate( 'Site Settings' ) } />
+				<FormattedHeader
+					headerText={ translate( 'Disconnect Site' ) }
+					subHeaderText={ translate(
+						'Tell us why you want to disconnect your site from WordPress.com.'
+					) }
+				/>
+				<Card className="disconnect-site__card"> </Card>
+			</Main>
+		);
+	}
+}
+
+const connectComponent = connect( state => {
+	return {
+		site: getSelectedSite( state ),
+	};
+} );
+
+export default flowRight( connectComponent, localize, redirectNonJetpack() )( DisconnectSite );

--- a/client/my-sites/site-settings/disconnect-site/index.jsx
+++ b/client/my-sites/site-settings/disconnect-site/index.jsx
@@ -16,6 +16,7 @@ import { getSelectedSite } from 'state/ui/selectors';
 import Main from 'components/main';
 import Placeholder from 'my-sites/site-settings/placeholder';
 import redirectNonJetpack from 'my-sites/site-settings/redirect-non-jetpack';
+import SkipSurvey from './skip-survey';
 
 class DisconnectSite extends Component {
 	render() {
@@ -34,6 +35,7 @@ class DisconnectSite extends Component {
 					) }
 				/>
 				<Card className="disconnect-site__card"> </Card>
+				<SkipSurvey />
 			</Main>
 		);
 	}

--- a/client/my-sites/site-settings/disconnect-site/skip-survey.jsx
+++ b/client/my-sites/site-settings/disconnect-site/skip-survey.jsx
@@ -1,0 +1,42 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+import page from 'page';
+/**
+ * Internal dependencies
+ */
+import Button from 'components/button';
+import Gridicon from 'gridicons';
+import Main from 'components/main';
+import { getSelectedSiteSlug } from 'state/ui/selectors';
+
+class SkipSurvey extends Component {
+	handleClick = () => {
+		const { siteSlug } = this.props;
+
+		//placeholder for redirection to the Confirm Disconnection page
+		if ( siteSlug ) {
+			page( '/settings/general/' + siteSlug );
+		}
+	};
+
+	render() {
+		const { translate } = this.props;
+		return (
+			<Main className="disconnect-site__skip-survey">
+				<Button compact borderless onClick={ this.handleClick }>
+					<Gridicon icon="arrow-right" size={ 18 } />
+					{ translate( 'Skip Survey' ) }
+				</Button>
+			</Main>
+		);
+	}
+}
+
+export default connect( state => ( {
+	siteSlug: getSelectedSiteSlug( state ),
+} ) )( localize( SkipSurvey ) );

--- a/client/my-sites/site-settings/disconnect-site/skip-survey.jsx
+++ b/client/my-sites/site-settings/disconnect-site/skip-survey.jsx
@@ -20,7 +20,7 @@ class SkipSurvey extends Component {
 
 		//placeholder for redirection to the Confirm Disconnection page
 		if ( siteSlug ) {
-			page( '/settings/general/' + siteSlug );
+			page( '/settings/manage-connection/' + siteSlug );
 		}
 	};
 

--- a/client/my-sites/site-settings/disconnect-site/style.scss
+++ b/client/my-sites/site-settings/disconnect-site/style.scss
@@ -1,8 +1,23 @@
 .disconnect-site__card {
 		width: 70%;
 		margin: auto;
+
+		@include breakpoint( "<480px" ) {
+			padding: 24px;
+			width: 300px;
+		}
+
+		@include breakpoint( "<660px" ) {
+			margin-top: 2em;
+			max-width: 500px;
+		}
+
+		@include breakpoint( ">660px" ) {
+			margin-top: 17px;
+			max-width: 800px;
+		}
 	}
-	
+
 .disconnect-site__skip-survey {
 		&.main {
 			margin: 16px 0 24px 0;

--- a/client/my-sites/site-settings/disconnect-site/style.scss
+++ b/client/my-sites/site-settings/disconnect-site/style.scss
@@ -2,3 +2,10 @@
 		width: 70%;
 		margin: auto;
 	}
+	
+.disconnect-site__skip-survey {
+		&.main {
+			margin: 16px 0 24px 0;
+			text-align: center;
+		}
+}

--- a/client/my-sites/site-settings/disconnect-site/style.scss
+++ b/client/my-sites/site-settings/disconnect-site/style.scss
@@ -1,10 +1,18 @@
+.disconnect-site {
+	&.site-settings {
+	position: fixed;
+  top: 40%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+	}
+}
+
 .disconnect-site__card {
-		width: 70%;
-		margin: auto;
+		position: relative;
+		padding: 24px;
 
 		@include breakpoint( "<480px" ) {
-			padding: 24px;
-			width: 300px;
+			max-width: 300px;
 		}
 
 		@include breakpoint( "<660px" ) {

--- a/client/my-sites/site-settings/disconnect-site/style.scss
+++ b/client/my-sites/site-settings/disconnect-site/style.scss
@@ -1,0 +1,4 @@
+.disconnect-site__card {
+		width: 70%;
+		margin: auto;
+	}

--- a/client/my-sites/site-settings/index.js
+++ b/client/my-sites/site-settings/index.js
@@ -1,4 +1,4 @@
-/**
+ /**
  * External dependencies
  */
 import page from 'page';
@@ -56,6 +56,15 @@ module.exports = function() {
 		settingsController.setScroll,
 		controller.deleteSite
 	);
+
+	page(
+		'/settings/disconnect-site/:site_id',
+		mySitesController.siteSelection,
+		mySitesController.navigation,
+		settingsController.setScroll,
+		controller.disconnectSite
+	);
+
 	page(
 		'/settings/start-over/:site_id',
 		mySitesController.siteSelection,

--- a/client/my-sites/site-settings/index.js
+++ b/client/my-sites/site-settings/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import page from 'page';
+
 /**
  * Internal dependencies
  */

--- a/client/my-sites/site-settings/index.js
+++ b/client/my-sites/site-settings/index.js
@@ -57,13 +57,15 @@ module.exports = function() {
 		controller.deleteSite
 	);
 
-	page(
-		'/settings/disconnect-site/:site_id',
-		mySitesController.siteSelection,
-		mySitesController.navigation,
-		settingsController.setScroll,
-		controller.disconnectSite
-	);
+	if ( config.isEnabled( 'manage/site-settings/disconnect-flow' ) ) {
+		page(
+			'/settings/disconnect-site/:site_id',
+			mySitesController.siteSelection,
+			mySitesController.navigation,
+			settingsController.setScroll,
+			controller.disconnectSite
+		);
+	}
 
 	page(
 		'/settings/start-over/:site_id',

--- a/client/my-sites/site-settings/index.js
+++ b/client/my-sites/site-settings/index.js
@@ -1,8 +1,7 @@
- /**
+/**
  * External dependencies
  */
 import page from 'page';
-
 /**
  * Internal dependencies
  */
@@ -61,7 +60,6 @@ module.exports = function() {
 		page(
 			'/settings/disconnect-site/:site_id',
 			mySitesController.siteSelection,
-			mySitesController.navigation,
 			settingsController.setScroll,
 			controller.disconnectSite
 		);

--- a/config/development.json
+++ b/config/development.json
@@ -90,6 +90,7 @@
 		"manage/security": true,
 		"manage/site-settings/analytics": true,
 		"manage/site-settings/categories": true,
+		"manage/site-settings/disconnect-flow": true,
 		"manage/stats": true,
 		"manage/stats/podcasts": true,
 		"manage/themes": true,


### PR DESCRIPTION
This is a landing PR for the new Jetpack Disconnect Flow. It introduces a basic layout of the first page of the flow and makes it visible from the /settings/disconnect-site page (in dev). 

Included:
- Introduce the `Disconnect Site`, hook it up and add route definitions
- add style and included it for loading
- add `Skip Survey` component, which will redirect to the end point of the flow (`Confirm Disconnection` https://github.com/Automattic/wp-calypso/pull/18039). For the time being, it redirects to `/settings/manage-connection`.
- add dev feature flag 
- add Placeholder for the Disconnect Site to be shown with an empty Redux state 
Placeholder will be corrected in a separate PR https://github.com/Automattic/wp-calypso/pull/18127 as an independent component or appropriate styling.

The PR uses `redirectNonJetpack` HoC  https://github.com/Automattic/wp-calypso/pull/17555 for access control.

**To test**:
- Checkout this branch, or use calypso.live
 https://calypso.live/?branch=add/site-settings-disconnect-site-layout

For Jetpack sites (incl. the dev mode):
 - verify that the start of the flow is visible at ```/settings/disconnect-site/:site```, where ```:site``` is the Jetpack site.

For non-Jetpack and Atomic sites, 
 - verify immediate redirection to `/settings/general/:site`

With empty Redux state we should see a placeholder prior to rendering.

**Visuals:**
After removing the sidebar:
![screen shot 2017-09-23 at 22 28 36](https://user-images.githubusercontent.com/13561163/30777449-b5d262ce-a0b2-11e7-99c7-994531670b2c.png)

