### PR TITLE
State Selectors: Add missing function documentation.

### DIFF
--- a/client/state/ui/editor/selectors.js
+++ b/client/state/ui/editor/selectors.js
@@ -33,10 +33,11 @@ export function isEditorNewPost( state ) {
 /**
  * Returns the editor URL for duplicating a given site ID, post ID pair.
  *
- * @param  {Object}  state Global state tree
+ * @param  {Object}  state      Global state tree
  * @param  {Number} siteId      Site ID
  * @param  {Number} postId      Post ID
  * @param  {String} type        Post type
+ * @return {String}             Editor URL path
  */
 export function getEditorDuplicatePostPath( state, siteId, postId, type = 'post' ) {
 	const editorNewPostPath = getEditorNewPostPath( state, siteId, type );

--- a/client/state/ui/editor/selectors.js
+++ b/client/state/ui/editor/selectors.js
@@ -13,8 +13,8 @@ import { getPreference } from 'state/preferences/selectors';
 /**
  * Returns the current editor post ID, or `null` if a new post.
  *
- * @param  {Object}  state Global state tree
- * @return {?Number}       Current editor post ID
+ * @param  {Object} state Global state tree
+ * @return {?Number}      Current editor post ID
  */
 export function getEditorPostId( state ) {
 	return state.ui.editor.postId;
@@ -33,7 +33,7 @@ export function isEditorNewPost( state ) {
 /**
  * Returns the editor URL for duplicating a given site ID, post ID pair.
  *
- * @param  {Object}  state      Global state tree
+ * @param  {Object} state       Global state tree
  * @param  {Number} siteId      Site ID
  * @param  {Number} postId      Post ID
  * @param  {String} type        Post type
@@ -93,9 +93,9 @@ export function getEditorPath( state, siteId, postId, defaultType = 'post' ) {
 /**
  * Returns whether the confirmation sidebar is enabled for the given siteId
  *
- * @param  {Object}  state Global state tree
- * @param  {Number}  siteId      Site ID
- * @return {Boolean}             Whether or not the sidebar is enabled
+ * @param  {Object}  state     Global state tree
+ * @param  {Number}  siteId    Site ID
+ * @return {Boolean}           Whether or not the sidebar is enabled
  */
 export function isConfirmationSidebarEnabled( state, siteId ) {
 	return getPreference( state, 'editorConfirmationDisabledSites' ).indexOf( siteId ) === -1;


### PR DESCRIPTION
> Fixes lint error reporting missing function return statement documentation. And fixes function documentation indentation.

This is a copy of https://github.com/Automattic/wp-calypso/pull/18100 into the wp-calypso repo