### PR TITLE
Site Settings: add a Placeholder for the JP Disconnect Flow

### DIFF
--- a/client/my-sites/site-settings/placeholder-disconnect.jsx
+++ b/client/my-sites/site-settings/placeholder-disconnect.jsx
@@ -1,0 +1,29 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Card from 'components/card';
+import FormattedHeader from 'components/formatted-header';
+import Main from 'components/main';
+
+const Placeholder = ( { translate } ) => {
+	return (
+		<Main className="site-settings__placeholder">
+			<FormattedHeader
+				headerText={ translate( 'Disconnect' ) }
+			/>
+		<Card className="site-settings__disconnect-card">
+			<div className="site-settings__placeholder-item disconnect">
+				{ 'An example of a Disconnect question' }
+			</div>
+		</Card>
+		</Main>
+	);
+};
+
+export default localize( Placeholder );

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -440,6 +440,49 @@
 	& + & {
 		margin-top: 24px;
 	}
+
+	&.disconnect {
+		width: 70%;
+		margin: auto;
+		height: 100px;
+
+		@include breakpoint( "<480px" ) {
+			padding: 12px;
+			max-width: 200px;
+		}
+
+		@include breakpoint( "<660px" ) {
+			margin-top: 1em;
+			max-width: 400px;
+		}
+
+		@include breakpoint( ">660px" ) {
+			margin-top: 10px;
+			max-width: 600px;
+		}
+	}
+}
+
+.site-settings__disconnect-card {
+		width: 70%;
+		margin: auto;
+		height: 400px;
+
+		@include breakpoint( "<480px" ) {
+			padding: 24px;
+			width: 300px;
+		}
+
+		@include breakpoint( "<660px" ) {
+			margin-top: 2em;
+			max-width: 500px;
+		}
+
+		@include breakpoint( ">660px" ) {
+			margin-top: 17px;
+			max-width: 800px;
+			max-height: 600px;
+		}
 }
 
 .site-settings__jetpack-dev-mode-notice .notice {


### PR DESCRIPTION
Introduce JP Disconnect UX specific Placeholder component. 

Placeholder currently used in Site Settings does not resemble the layout used in the Disconnect Flow. This PR adds one for the JP Disconnect UX based on the "base" Card that is used across the Disconnect screens (`Disconnect Site`, `Confirm Disconnection`) with a single
placeholder div and a generic title `Disconnect`.

**Visuals:**
![screen shot 2017-09-19 at 16 27 35](https://user-images.githubusercontent.com/13561163/30601249-643666ec-9d59-11e7-845a-c7c479725ad0.png)
