### PR TITLE
Extensions: WPJM - Connect the wizard steps

### DIFF
--- a/client/extensions/wp-job-manager/components/setup/constants.js
+++ b/client/extensions/wp-job-manager/components/setup/constants.js
@@ -3,3 +3,5 @@ export const Steps = {
 	INTRO: 'intro',
 	PAGE_SETUP: 'page-setup',
 };
+
+export const SetupPath = '/extensions/wp-job-manager/setup';

--- a/client/extensions/wp-job-manager/components/setup/index.jsx
+++ b/client/extensions/wp-job-manager/components/setup/index.jsx
@@ -3,7 +3,6 @@
  */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import page from 'page';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
@@ -26,16 +25,11 @@ class SetupWizard extends Component {
 		translate: PropTypes.func.isRequired,
 	};
 
-	goToStep = ( event, step ) => {
-		event.preventDefault();
-		page( `/extensions/wp-job-manager/setup/${ this.props.slug }/${ step }` );
-	}
-
 	render() {
 		const steps = [ Steps.INTRO, Steps.PAGE_SETUP, Steps.CONFIRMATION ];
 		const components = {
-			[ Steps.INTRO ]: <Intro goToStep={ this.goToStep } />,
-			[ Steps.PAGE_SETUP ]: <PageSetup goToStep={ this.goToStep } />,
+			[ Steps.INTRO ]: <Intro />,
+			[ Steps.PAGE_SETUP ]: <PageSetup />,
 			[ Steps.CONFIRMATION ]: <Confirmation />,
 		};
 		const {

--- a/client/extensions/wp-job-manager/components/setup/index.jsx
+++ b/client/extensions/wp-job-manager/components/setup/index.jsx
@@ -35,7 +35,7 @@ class SetupWizard extends Component {
 		const steps = [ Steps.INTRO, Steps.PAGE_SETUP, Steps.CONFIRMATION ];
 		const components = {
 			[ Steps.INTRO ]: <Intro goToStep={ this.goToStep } />,
-			[ Steps.PAGE_SETUP ]: <PageSetup />,
+			[ Steps.PAGE_SETUP ]: <PageSetup goToStep={ this.goToStep } />,
 			[ Steps.CONFIRMATION ]: <Confirmation />,
 		};
 		const {

--- a/client/extensions/wp-job-manager/components/setup/index.jsx
+++ b/client/extensions/wp-job-manager/components/setup/index.jsx
@@ -3,6 +3,7 @@
  */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import page from 'page';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
@@ -25,10 +26,15 @@ class SetupWizard extends Component {
 		translate: PropTypes.func.isRequired,
 	};
 
+	goToStep = ( event, step ) => {
+		event.preventDefault();
+		page( `/extensions/wp-job-manager/setup/${ this.props.slug }/${ step }` );
+	}
+
 	render() {
 		const steps = [ Steps.INTRO, Steps.PAGE_SETUP, Steps.CONFIRMATION ];
 		const components = {
-			[ Steps.INTRO ]: <Intro />,
+			[ Steps.INTRO ]: <Intro goToStep={ this.goToStep } />,
 			[ Steps.PAGE_SETUP ]: <PageSetup />,
 			[ Steps.CONFIRMATION ]: <Confirmation />,
 		};

--- a/client/extensions/wp-job-manager/components/setup/index.jsx
+++ b/client/extensions/wp-job-manager/components/setup/index.jsx
@@ -9,7 +9,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import { Steps } from './constants';
+import { SetupPath, Steps } from './constants';
 import Confirmation from './confirmation';
 import DocumentHead from 'components/data/document-head';
 import Intro from './intro';
@@ -35,7 +35,7 @@ const SetupWizard = ( {
 		<Main className={ mainClassName }>
 			<DocumentHead title={ translate( 'Setup' ) } />
 			<Wizard
-				basePath={ `/extensions/wp-job-manager/setup/${ slug }` }
+				basePath={ `${ SetupPath }/${ slug }` }
 				components={ components }
 				forwardText={ translate( 'Continue' ) }
 				hideNavigation={ true }
@@ -45,9 +45,7 @@ const SetupWizard = ( {
 	);
 };
 
-const mapStateToProps = state => ( {
-	slug: getSelectedSiteSlug( state ),
-} );
+const mapStateToProps = state => ( { slug: getSelectedSiteSlug( state ) } );
 
 SetupWizard.propTypes = {
 	slug: PropTypes.string,

--- a/client/extensions/wp-job-manager/components/setup/index.jsx
+++ b/client/extensions/wp-job-manager/components/setup/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
@@ -18,41 +18,44 @@ import PageSetup from './page-setup';
 import Wizard from 'components/wizard';
 import { getSelectedSiteSlug } from 'state/ui/selectors';
 
-const SetupWizard = ( {
-	slug,
-	stepName = Steps.INTRO,
-	translate,
-} ) => {
-	const steps = [ Steps.INTRO, Steps.PAGE_SETUP, Steps.CONFIRMATION ];
-	const components = {
-		[ Steps.INTRO ]: <Intro />,
-		[ Steps.PAGE_SETUP ]: <PageSetup />,
-		[ Steps.CONFIRMATION ]: <Confirmation />,
+class SetupWizard extends Component {
+	static propTypes = {
+		slug: PropTypes.string,
+		stepName: PropTypes.string,
+		translate: PropTypes.func.isRequired,
 	};
-	const mainClassName = 'wp-job-manager__setup';
 
-	return (
-		<Main className={ mainClassName }>
-			<DocumentHead title={ translate( 'Setup' ) } />
-			<Wizard
-				basePath={ `/extensions/wp-job-manager/setup/${ slug }` }
-				components={ components }
-				forwardText={ translate( 'Continue' ) }
-				hideNavigation={ true }
-				steps={ steps }
-				stepName={ stepName } />
-		</Main>
-	);
-};
+	render() {
+		const steps = [ Steps.INTRO, Steps.PAGE_SETUP, Steps.CONFIRMATION ];
+		const components = {
+			[ Steps.INTRO ]: <Intro />,
+			[ Steps.PAGE_SETUP ]: <PageSetup />,
+			[ Steps.CONFIRMATION ]: <Confirmation />,
+		};
+		const {
+			slug,
+			stepName = Steps.INTRO,
+			translate,
+		} = this.props;
+		const mainClassName = 'wp-job-manager__setup';
+
+		return (
+			<Main className={ mainClassName }>
+				<DocumentHead title={ translate( 'Setup' ) } />
+				<Wizard
+					basePath={ `/extensions/wp-job-manager/setup/${ slug }` }
+					components={ components }
+					forwardText={ translate( 'Continue' ) }
+					hideNavigation={ true }
+					steps={ steps }
+					stepName={ stepName } />
+			</Main>
+		);
+	}
+}
 
 const mapStateToProps = state => ( {
 	slug: getSelectedSiteSlug( state ),
 } );
-
-SetupWizard.propTypes = {
-	slug: PropTypes.string,
-	stepName: PropTypes.string,
-	translate: PropTypes.func.isRequired,
-};
 
 export default connect( mapStateToProps )( localize( SetupWizard ) );

--- a/client/extensions/wp-job-manager/components/setup/index.jsx
+++ b/client/extensions/wp-job-manager/components/setup/index.jsx
@@ -38,6 +38,7 @@ const SetupWizard = ( {
 				basePath={ `/extensions/wp-job-manager/setup/${ slug }` }
 				components={ components }
 				forwardText={ translate( 'Continue' ) }
+				hideNavigation={ true }
 				steps={ steps }
 				stepName={ stepName } />
 		</Main>

--- a/client/extensions/wp-job-manager/components/setup/index.jsx
+++ b/client/extensions/wp-job-manager/components/setup/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { Component } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
@@ -18,44 +18,41 @@ import PageSetup from './page-setup';
 import Wizard from 'components/wizard';
 import { getSelectedSiteSlug } from 'state/ui/selectors';
 
-class SetupWizard extends Component {
-	static propTypes = {
-		slug: PropTypes.string,
-		stepName: PropTypes.string,
-		translate: PropTypes.func.isRequired,
+const SetupWizard = ( {
+	slug,
+	stepName = Steps.INTRO,
+	translate,
+} ) => {
+	const steps = [ Steps.INTRO, Steps.PAGE_SETUP, Steps.CONFIRMATION ];
+	const components = {
+		[ Steps.INTRO ]: <Intro />,
+		[ Steps.PAGE_SETUP ]: <PageSetup />,
+		[ Steps.CONFIRMATION ]: <Confirmation />,
 	};
+	const mainClassName = 'wp-job-manager__setup';
 
-	render() {
-		const steps = [ Steps.INTRO, Steps.PAGE_SETUP, Steps.CONFIRMATION ];
-		const components = {
-			[ Steps.INTRO ]: <Intro />,
-			[ Steps.PAGE_SETUP ]: <PageSetup />,
-			[ Steps.CONFIRMATION ]: <Confirmation />,
-		};
-		const {
-			slug,
-			stepName = Steps.INTRO,
-			translate,
-		} = this.props;
-		const mainClassName = 'wp-job-manager__setup';
-
-		return (
-			<Main className={ mainClassName }>
-				<DocumentHead title={ translate( 'Setup' ) } />
-				<Wizard
-					basePath={ `/extensions/wp-job-manager/setup/${ slug }` }
-					components={ components }
-					forwardText={ translate( 'Continue' ) }
-					hideNavigation={ true }
-					steps={ steps }
-					stepName={ stepName } />
-			</Main>
-		);
-	}
-}
+	return (
+		<Main className={ mainClassName }>
+			<DocumentHead title={ translate( 'Setup' ) } />
+			<Wizard
+				basePath={ `/extensions/wp-job-manager/setup/${ slug }` }
+				components={ components }
+				forwardText={ translate( 'Continue' ) }
+				hideNavigation={ true }
+				steps={ steps }
+				stepName={ stepName } />
+		</Main>
+	);
+};
 
 const mapStateToProps = state => ( {
 	slug: getSelectedSiteSlug( state ),
 } );
+
+SetupWizard.propTypes = {
+	slug: PropTypes.string,
+	stepName: PropTypes.string,
+	translate: PropTypes.func.isRequired,
+};
 
 export default connect( mapStateToProps )( localize( SetupWizard ) );

--- a/client/extensions/wp-job-manager/components/setup/intro/index.jsx
+++ b/client/extensions/wp-job-manager/components/setup/intro/index.jsx
@@ -74,7 +74,7 @@ class Intro extends Component {
 					<Button primary
 						className="intro__start-setup"
 						onClick={ this.startSetup }>
-						{ translate( 'Start Setup' ) }
+						{ translate( 'Start setup' ) }
 					</Button>
 				</CompactCard>
 			</div>

--- a/client/extensions/wp-job-manager/components/setup/intro/index.jsx
+++ b/client/extensions/wp-job-manager/components/setup/intro/index.jsx
@@ -3,29 +3,27 @@
  */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
-import { Steps } from '../constants';
+import { SetupPath, Steps } from '../constants';
 import Button from 'components/button';
 import CompactCard from 'components/card/compact';
 import ExternalLink from 'components/external-link';
 import SectionHeader from 'components/section-header';
+import { getSelectedSiteSlug } from 'state/ui/selectors';
 
 class Intro extends Component {
 	static propTypes = {
-		goToStep: PropTypes.func.isRequired,
+		slug: PropTypes.string,
 		translate: PropTypes.func.isRequired,
 	};
 
-	skipSetup = event => this.props.goToStep( event, Steps.CONFIRMATION );
-
-	startSetup = event => this.props.goToStep( event, Steps.PAGE_SETUP );
-
 	render() {
-		const { translate } = this.props;
+		const { slug, translate } = this.props;
 
 		return (
 			<div>
@@ -67,13 +65,12 @@ class Intro extends Component {
 				<CompactCard>
 					<a
 						className="intro__skip-setup"
-						href="#"
-						onClick={ this.skipSetup }>
+						href={ slug && `${ SetupPath }/${ slug }/${ Steps.CONFIRMATION }` }>
 						{ translate( 'Skip setup. I will set up the plugin manually.' ) }
 					</a>
 					<Button primary
 						className="intro__start-setup"
-						onClick={ this.startSetup }>
+						href={ slug && `${ SetupPath }/${ slug }/${ Steps.PAGE_SETUP }` }>
 						{ translate( 'Start setup' ) }
 					</Button>
 				</CompactCard>
@@ -82,4 +79,6 @@ class Intro extends Component {
 	}
 }
 
-export default localize( Intro );
+const mapStateToProps = state => ( { slug: getSelectedSiteSlug( state ) } );
+
+export default connect( mapStateToProps )( localize( Intro ) );

--- a/client/extensions/wp-job-manager/components/setup/intro/index.jsx
+++ b/client/extensions/wp-job-manager/components/setup/intro/index.jsx
@@ -8,6 +8,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import { Steps } from '../constants';
 import Button from 'components/button';
 import CompactCard from 'components/card/compact';
 import ExternalLink from 'components/external-link';
@@ -15,8 +16,13 @@ import SectionHeader from 'components/section-header';
 
 class Intro extends Component {
 	static propTypes = {
+		goToStep: PropTypes.func.isRequired,
 		translate: PropTypes.func.isRequired,
 	};
+
+	skipSetup = event => this.props.goToStep( event, Steps.CONFIRMATION );
+
+	startSetup = event => this.props.goToStep( event, Steps.PAGE_SETUP );
 
 	render() {
 		const { translate } = this.props;
@@ -61,11 +67,13 @@ class Intro extends Component {
 				<CompactCard>
 					<a
 						className="intro__skip-setup"
-						href="#">
+						href="#"
+						onClick={ this.skipSetup }>
 						{ translate( 'Skip setup. I will set up the plugin manually.' ) }
 					</a>
 					<Button primary
-						className="intro__start-setup">
+						className="intro__start-setup"
+						onClick={ this.startSetup }>
 						{ translate( 'Start Setup' ) }
 					</Button>
 				</CompactCard>

--- a/client/extensions/wp-job-manager/components/setup/page-setup/index.jsx
+++ b/client/extensions/wp-job-manager/components/setup/page-setup/index.jsx
@@ -70,6 +70,7 @@ class PageSetup extends Component {
 		createPages: PropTypes.func.isRequired,
 		createPostJob: PropTypes.bool,
 		goToNextStep: PropTypes.bool,
+		goToStep: PropTypes.func.isRequired,
 		handleSubmit: PropTypes.func,
 		isCreating: PropTypes.bool,
 		siteId: PropTypes.number,
@@ -111,6 +112,8 @@ class PageSetup extends Component {
 
 		this.props.createPages( siteId, titles );
 	}
+
+	skip = event => this.props.goToStep( event, Steps.CONFIRMATION );
 
 	render() {
 		const {
@@ -205,7 +208,8 @@ class PageSetup extends Component {
 				<CompactCard>
 					<a
 						className="page-setup__skip"
-						href="#">
+						href="#"
+						onClick={ this.skip }>
 						{ translate( 'Skip this step' ) }
 					</a>
 					<Button primary

--- a/client/extensions/wp-job-manager/components/setup/page-setup/index.jsx
+++ b/client/extensions/wp-job-manager/components/setup/page-setup/index.jsx
@@ -12,7 +12,7 @@ import { flowRight as compose } from 'lodash';
 /**
  * Internal dependencies
  */
-import { Steps } from '../constants';
+import { SetupPath, Steps } from '../constants';
 import Button from 'components/button';
 import CompactCard from 'components/card/compact';
 import ExternalLink from 'components/external-link';
@@ -70,7 +70,6 @@ class PageSetup extends Component {
 		createPages: PropTypes.func.isRequired,
 		createPostJob: PropTypes.bool,
 		goToNextStep: PropTypes.bool,
-		goToStep: PropTypes.func.isRequired,
 		handleSubmit: PropTypes.func,
 		isCreating: PropTypes.bool,
 		siteId: PropTypes.number,
@@ -113,8 +112,6 @@ class PageSetup extends Component {
 		this.props.createPages( siteId, titles );
 	}
 
-	skip = event => this.props.goToStep( event, Steps.CONFIRMATION );
-
 	render() {
 		const {
 			createDashboard,
@@ -122,6 +119,7 @@ class PageSetup extends Component {
 			createPostJob,
 			handleSubmit,
 			isCreating,
+			slug,
 			translate,
 		} = this.props;
 
@@ -208,8 +206,7 @@ class PageSetup extends Component {
 				<CompactCard>
 					<a
 						className="page-setup__skip"
-						href="#"
-						onClick={ this.skip }>
+						href={ slug && `${ SetupPath }/${ slug }/${ Steps.CONFIRMATION }` }>
 						{ translate( 'Skip this step' ) }
 					</a>
 					<Button primary


### PR DESCRIPTION
This PR hooks up the navigation in the WP Job Manager setup wizard.

## Testing

Ensure the WP Job Manager plugin is installed and configured by following the steps in p6r3EZ-ra-p2. Browse to `/extensions/wp-job-manager/setup/<siteId>`.

1. Ensure there is no "Continue" link beneath the card.
2. Click on the "Skip setup. I will set up the plugin manually." link. You should be taken to step 3 of the wizard.
3. Click the Back button in your browser to return to the first step.
4. Click the "Start setup" button. You should be taken to step 2 of the wizard.
5. Ensure there are no "Continue" or "Back" links beneath the card.
6. Click the "Skip this step" link. You should be taken to step 3 of the wizard.
7. Ensure there is no "Back" link beneath the card.