### PR TITLE
Reader Teams: fix data layer dispatch

### DIFF
--- a/client/state/data-layer/wpcom/read/teams/index.js
+++ b/client/state/data-layer/wpcom/read/teams/index.js
@@ -19,10 +19,10 @@ export const handleTeamsRequest = ( { dispatch }, action ) => {
 	);
 };
 
-export const teamRequestReceived = ( { dispatch }, payload ) => {
+export const teamRequestReceived = ( { dispatch }, action, apiResponse ) => {
 	dispatch( {
 		type: READER_TEAMS_RECEIVE,
-		payload,
+		payload: apiResponse,
 	} );
 };
 

--- a/client/state/data-layer/wpcom/read/teams/test/index.js
+++ b/client/state/data-layer/wpcom/read/teams/test/index.js
@@ -14,6 +14,8 @@ import { http } from 'state/data-layer/wpcom-http/actions';
 // import { requestTeams } from 'state/reader/teams/actions';
 import { READER_TEAMS_RECEIVE } from 'state/action-types';
 
+const apiResponse = { teams: [ { slug: 'a8c', title: 'Automattic' } ] };
+
 describe( 'wpcom-api', () => {
 	describe( 'teams request', () => {
 		const action = { type: 'DUMMY_ACTION' };
@@ -48,12 +50,12 @@ describe( 'wpcom-api', () => {
 
 		it( 'should dispatch READER_TEAMS_RECEIVE action without error when request succeeds', () => {
 			const dispatch = spy();
-			teamRequestReceived( { dispatch }, action );
+			teamRequestReceived( { dispatch }, action, apiResponse );
 
 			expect( dispatch ).to.have.been.calledOnce;
 			expect( dispatch ).to.have.been.calledWith( {
 				type: READER_TEAMS_RECEIVE,
-				payload: action,
+				payload: apiResponse,
 			} );
 		} );
 	} );


### PR DESCRIPTION
Looks like there was a slight error in data-layer usage when updating the teams request to use the http layer in https://github.com/Automattic/wp-calypso/commit/a14628561426b8e3c035a17d978801e89340e202

cc @fraying @timmyc  @hambai 

Note: this wasn't immediately obvious because Teams are currently cached in redux and aren't being invalidated properly.

To Test:
- load the branch ensure that a8c stream loads