### PR TITLE
Reader: remove React.PropTypes references

### DIFF
--- a/client/reader/discover/follow-button.jsx
+++ b/client/reader/discover/follow-button.jsx
@@ -2,6 +2,8 @@
 /**
  * External dependencies
  */
+import PropTypes from 'prop-types';
+
 import React from 'react';
 import { localize } from 'i18n-calypso';
 
@@ -14,8 +16,8 @@ import { DISCOVER_POST } from 'reader/follow-button/follow-sources';
 
 class DiscoverFollowButton extends React.Component {
 	static propTypes = {
-		siteName: React.PropTypes.string.isRequired,
-		followUrl: React.PropTypes.string.isRequired,
+		siteName: PropTypes.string.isRequired,
+		followUrl: PropTypes.string.isRequired,
 	};
 
 	recordFollowToggle = isFollowing => {

--- a/client/reader/discover/follow-button.jsx
+++ b/client/reader/discover/follow-button.jsx
@@ -2,16 +2,15 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
-import React from 'react';
 import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 /**
  * Internal dependencies
  */
-import FollowButton from 'reader/follow-button';
 import { recordFollowToggle } from './stats';
+import FollowButton from 'reader/follow-button';
 import { DISCOVER_POST } from 'reader/follow-button/follow-sources';
 
 class DiscoverFollowButton extends React.Component {

--- a/client/reader/discover/site-attribution.jsx
+++ b/client/reader/discover/site-attribution.jsx
@@ -2,18 +2,17 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
-import React from 'react';
 import classNames from 'classnames';
+import { translate } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 /**
  * Internal dependencies
  */
-import { translate } from 'i18n-calypso';
-import FollowButton from 'reader/follow-button';
 import { getLinkProps } from './helper';
 import { recordFollowToggle, recordSiteClick } from './stats';
+import FollowButton from 'reader/follow-button';
 
 class DiscoverSiteAttribution extends React.Component {
 	static propTypes = {

--- a/client/reader/discover/site-attribution.jsx
+++ b/client/reader/discover/site-attribution.jsx
@@ -2,6 +2,8 @@
 /**
  * External dependencies
  */
+import PropTypes from 'prop-types';
+
 import React from 'react';
 import classNames from 'classnames';
 
@@ -15,13 +17,13 @@ import { recordFollowToggle, recordSiteClick } from './stats';
 
 class DiscoverSiteAttribution extends React.Component {
 	static propTypes = {
-		attribution: React.PropTypes.shape( {
-			blog_name: React.PropTypes.string.isRequired,
-			blog_url: React.PropTypes.string.isRequired,
-			avatar_url: React.PropTypes.string,
+		attribution: PropTypes.shape( {
+			blog_name: PropTypes.string.isRequired,
+			blog_url: PropTypes.string.isRequired,
+			avatar_url: PropTypes.string,
 		} ).isRequired,
-		siteUrl: React.PropTypes.string.isRequired,
-		followUrl: React.PropTypes.string.isRequired,
+		siteUrl: PropTypes.string.isRequired,
+		followUrl: PropTypes.string.isRequired,
 	};
 
 	onSiteClick = () => recordSiteClick( this.props.siteUrl );

--- a/client/reader/discover/site-attribution.jsx
+++ b/client/reader/discover/site-attribution.jsx
@@ -39,15 +39,17 @@ class DiscoverSiteAttribution extends React.Component {
 
 		return (
 			<div className={ classes }>
-				{ attribution.avatar_url
-					? <img
-							className="gravatar"
-							src={ encodeURI( attribution.avatar_url ) }
-							alt="Avatar"
-							width="20"
-							height="20"
-						/>
-					: <span className="noticon noticon-website" /> }
+				{ attribution.avatar_url ? (
+					<img
+						className="gravatar"
+						src={ encodeURI( attribution.avatar_url ) }
+						alt="Avatar"
+						width="20"
+						height="20"
+					/>
+				) : (
+					<span className="noticon noticon-website" />
+				) }
 				<span>
 					<a
 						{ ...siteLinkProps }
@@ -58,13 +60,13 @@ class DiscoverSiteAttribution extends React.Component {
 						{ translate( 'visit' ) } <em>{ attribution.blog_name }</em>
 					</a>
 				</span>
-				{ !! this.props.followUrl
-					? <FollowButton
-							siteUrl={ this.props.followUrl }
-							iconSize={ 20 }
-							onFollowToggle={ this.onFollowToggle }
-						/>
-					: null }
+				{ !! this.props.followUrl ? (
+					<FollowButton
+						siteUrl={ this.props.followUrl }
+						iconSize={ 20 }
+						onFollowToggle={ this.onFollowToggle }
+					/>
+				) : null }
 			</div>
 		);
 	}

--- a/client/reader/feed-error/index.jsx
+++ b/client/reader/feed-error/index.jsx
@@ -2,6 +2,8 @@
 /**
  * External dependencies
  */
+import PropTypes from 'prop-types';
+
 import React from 'react';
 import i18n, { localize } from 'i18n-calypso';
 
@@ -71,7 +73,7 @@ class FeedError extends React.Component {
 }
 
 FeedError.propTypes = {
-	sidebarTitle: React.PropTypes.string,
+	sidebarTitle: PropTypes.string,
 };
 
 export default localize( FeedError );

--- a/client/reader/feed-error/index.jsx
+++ b/client/reader/feed-error/index.jsx
@@ -2,17 +2,16 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
-import React from 'react';
 import i18n, { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 /**
  * Internal dependencies
  */
-import ReaderMain from 'components/reader-main';
-import MobileBackToSidebar from 'components/mobile-back-to-sidebar';
 import EmptyContent from 'components/empty-content';
+import MobileBackToSidebar from 'components/mobile-back-to-sidebar';
+import ReaderMain from 'components/reader-main';
 import { recordAction, recordGaEvent, recordTrack } from 'reader/stats';
 
 class FeedError extends React.Component {

--- a/client/reader/feed-error/index.jsx
+++ b/client/reader/feed-error/index.jsx
@@ -54,9 +54,7 @@ class FeedError extends React.Component {
 		return (
 			<ReaderMain>
 				<MobileBackToSidebar>
-					<h1>
-						{ this.props.sidebarTitle }
-					</h1>
+					<h1>{ this.props.sidebarTitle }</h1>
 				</MobileBackToSidebar>
 
 				<EmptyContent

--- a/client/reader/feed-stream/index.jsx
+++ b/client/reader/feed-stream/index.jsx
@@ -2,25 +2,24 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
-import React from 'react';
 import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
  */
 import EmptyContent from './empty';
-import DocumentHead from 'components/data/document-head';
-import Stream from 'reader/stream';
-import FeedError from 'reader/feed-error';
 import RefreshFeedHeader from 'blocks/reader-feed-header';
-import QueryReaderSite from 'components/data/query-reader-site';
+import DocumentHead from 'components/data/document-head';
 import QueryReaderFeed from 'components/data/query-reader-feed';
-import { getSite } from 'state/reader/sites/selectors';
-import { getFeed } from 'state/reader/feeds/selectors';
+import QueryReaderSite from 'components/data/query-reader-site';
+import FeedError from 'reader/feed-error';
 import { getSiteName } from 'reader/get-helpers';
+import Stream from 'reader/stream';
+import { getFeed } from 'state/reader/feeds/selectors';
+import { getSite } from 'state/reader/sites/selectors';
 
 // If the blog_ID of a reader feed is 0, that means no site exists for it.
 const getReaderSiteId = feed => ( feed && feed.blog_ID === 0 ? null : feed && feed.blog_ID );

--- a/client/reader/feed-stream/index.jsx
+++ b/client/reader/feed-stream/index.jsx
@@ -2,6 +2,8 @@
 /**
  * External dependencies
  */
+import PropTypes from 'prop-types';
+
 import React from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
@@ -25,9 +27,9 @@ const getReaderSiteId = feed => ( feed && feed.blog_ID === 0 ? null : feed && fe
 
 class FeedStream extends React.Component {
 	static propTypes = {
-		feedId: React.PropTypes.number.isRequired,
-		className: React.PropTypes.string,
-		showBack: React.PropTypes.bool,
+		feedId: PropTypes.number.isRequired,
+		className: PropTypes.string,
+		showBack: PropTypes.bool,
 	};
 
 	static defaultProps = {

--- a/client/reader/follow-button/index.jsx
+++ b/client/reader/follow-button/index.jsx
@@ -3,7 +3,6 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
-
 import React from 'react';
 
 /**
@@ -11,10 +10,7 @@ import React from 'react';
  */
 import FollowButtonContainer from 'blocks/follow-button';
 import FollowButton from 'blocks/follow-button/button';
-import {
-	recordFollow as recordFollowTracks,
-	recordUnfollow as recordUnfollowTracks,
-} from 'reader/stats';
+import { recordFollow as recordFollowTracks, recordUnfollow as recordUnfollowTracks } from 'reader/stats';
 
 function ReaderFollowButton( props ) {
 	const { onFollowToggle, railcar, followSource, isButtonOnly, siteUrl } = props;

--- a/client/reader/follow-button/index.jsx
+++ b/client/reader/follow-button/index.jsx
@@ -2,6 +2,8 @@
 /**
  * External dependencies
  */
+import PropTypes from 'prop-types';
+
 import React from 'react';
 
 /**
@@ -37,9 +39,9 @@ function ReaderFollowButton( props ) {
 }
 
 ReaderFollowButton.propTypes = {
-	onFollowToggle: React.PropTypes.func,
-	railcar: React.PropTypes.object,
-	followSource: React.PropTypes.string,
+	onFollowToggle: PropTypes.func,
+	railcar: PropTypes.object,
+	followSource: PropTypes.string,
 };
 
 export default ReaderFollowButton;

--- a/client/reader/follow-button/index.jsx
+++ b/client/reader/follow-button/index.jsx
@@ -10,7 +10,10 @@ import React from 'react';
  */
 import FollowButtonContainer from 'blocks/follow-button';
 import FollowButton from 'blocks/follow-button/button';
-import { recordFollow as recordFollowTracks, recordUnfollow as recordUnfollowTracks } from 'reader/stats';
+import {
+	recordFollow as recordFollowTracks,
+	recordUnfollow as recordUnfollowTracks,
+} from 'reader/stats';
 
 function ReaderFollowButton( props ) {
 	const { onFollowToggle, railcar, followSource, isButtonOnly, siteUrl } = props;

--- a/client/reader/following-manage/feed-search-results.jsx
+++ b/client/reader/following-manage/feed-search-results.jsx
@@ -2,7 +2,9 @@
 /**
  * External Dependencies
  */
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { take, times } from 'lodash';

--- a/client/reader/following-manage/feed-search-results.jsx
+++ b/client/reader/following-manage/feed-search-results.jsx
@@ -1,24 +1,23 @@
 /** @format */
 /**
- * External Dependencies
+ * External dependencies
  */
-import PropTypes from 'prop-types';
-
-import React from 'react';
-import { connect } from 'react-redux';
+import classnames from 'classnames';
+import Gridicon from 'gridicons';
 import { localize } from 'i18n-calypso';
 import { take, times } from 'lodash';
-import Gridicon from 'gridicons';
-import classnames from 'classnames';
+import PropTypes from 'prop-types';
+import React from 'react';
+import { connect } from 'react-redux';
 
 /**
- * Internal Dependencies
+ * Internal dependencies
  */
-import Button from 'components/button';
 import ReaderSubscriptionListItemPlaceholder from 'blocks/reader-subscription-list-item/placeholder';
-import { READER_FOLLOWING_MANAGE_SEARCH_RESULT } from 'reader/follow-button/follow-sources';
+import Button from 'components/button';
 import InfiniteStream from 'components/reader-infinite-stream';
 import { siteRowRenderer } from 'components/reader-infinite-stream/row-renderers';
+import { READER_FOLLOWING_MANAGE_SEARCH_RESULT } from 'reader/follow-button/follow-sources';
 import { requestFeedSearch } from 'state/reader/feed-searches/actions';
 
 class FollowingManageSearchFeedsResults extends React.Component {

--- a/client/reader/following-manage/feed-search-results.jsx
+++ b/client/reader/following-manage/feed-search-results.jsx
@@ -63,9 +63,9 @@ class FollowingManageSearchFeedsResults extends React.Component {
 		if ( ! searchResults ) {
 			return (
 				<div className={ classNames }>
-					{ times( 10, i =>
+					{ times( 10, i => (
 						<ReaderSubscriptionListItemPlaceholder key={ `placeholder-${ i }` } />
-					) }
+					) ) }
 				</div>
 			);
 		} else if ( isEmpty ) {
@@ -93,7 +93,7 @@ class FollowingManageSearchFeedsResults extends React.Component {
 					rowRenderer={ siteRowRenderer }
 				/>
 				{ ! showMoreResults &&
-					searchResultsCount > 10 &&
+				searchResultsCount > 10 && (
 					<div className="following-manage__show-more">
 						<Button
 							compact
@@ -104,7 +104,8 @@ class FollowingManageSearchFeedsResults extends React.Component {
 							<Gridicon icon="chevron-down" />
 							{ translate( 'Show more' ) }
 						</Button>
-					</div> }
+					</div>
+				) }
 			</div>
 		);
 	}

--- a/client/reader/following-manage/index.jsx
+++ b/client/reader/following-manage/index.jsx
@@ -1,49 +1,37 @@
-import React, { Component } from 'react';
-import { connect } from 'react-redux';
-import { trim, debounce, random, take, reject, includes } from 'lodash';
-import { localize } from 'i18n-calypso';
-import page from 'page';
-
 /** @format */
 /**
- * External Dependencies
+ * External dependencies
  */
+import { localize } from 'i18n-calypso';
+import { trim, debounce, random, take, reject, includes } from 'lodash';
+import page from 'page';
 import PropTypes from 'prop-types';
-
 import qs from 'qs';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
 
 /**
- * Internal Dependencies
+ * Internal dependencies
  */
+import FollowingManageEmptyContent from './empty';
+import FollowingManageSearchFeedsResults from './feed-search-results';
+import FollowingManageSubscriptions from './subscriptions';
+import RecommendedSites from 'blocks/reader-recommended-sites';
 import CompactCard from 'components/card/compact';
 import DocumentHead from 'components/data/document-head';
-import SearchInput from 'components/search';
-import ReaderMain from 'components/reader-main';
-import {
-	getReaderFeedsForQuery,
-	getReaderFeedsCountForQuery,
-	getReaderRecommendedSites,
-	getReaderRecommendedSitesPagingOffset,
-	getBlockedSites,
-	getReaderAliasedFollowFeedUrl,
-} from 'state/selectors';
 import QueryReaderFeedsSearch from 'components/data/query-reader-feeds-search';
 import QueryReaderRecommendedSites from 'components/data/query-reader-recommended-sites';
-import RecommendedSites from 'blocks/reader-recommended-sites';
-import FollowingManageSubscriptions from './subscriptions';
-import FollowingManageSearchFeedsResults from './feed-search-results';
-import FollowingManageEmptyContent from './empty';
 import MobileBackToSidebar from 'components/mobile-back-to-sidebar';
+import ReaderMain from 'components/reader-main';
+import SearchInput from 'components/search';
 import { addQueryArgs } from 'lib/url';
-import FollowButton from 'reader/follow-button';
-import {
-	READER_FOLLOWING_MANAGE_URL_INPUT,
-	READER_FOLLOWING_MANAGE_RECOMMENDATION,
-} from 'reader/follow-button/follow-sources';
 import { resemblesUrl, withoutHttp, addSchemeIfMissing } from 'lib/url';
-import { getReaderFollowsCount } from 'state/selectors';
+import FollowButton from 'reader/follow-button';
+import { READER_FOLLOWING_MANAGE_URL_INPUT, READER_FOLLOWING_MANAGE_RECOMMENDATION } from 'reader/follow-button/follow-sources';
 import { recordTrack, recordAction } from 'reader/stats';
 import { SORT_BY_RELEVANCE } from 'state/reader/feed-searches/actions';
+import { getReaderFeedsForQuery, getReaderFeedsCountForQuery, getReaderRecommendedSites, getReaderRecommendedSitesPagingOffset, getBlockedSites, getReaderAliasedFollowFeedUrl } from 'state/selectors';
+import { getReaderFollowsCount } from 'state/selectors';
 
 const PAGE_SIZE = 4;
 let recommendationsSeed = random( 0, 10000 );

--- a/client/reader/following-manage/index.jsx
+++ b/client/reader/following-manage/index.jsx
@@ -1,12 +1,15 @@
-/** @format */
-/**
- * External Dependencies
- */
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { trim, debounce, random, take, reject, includes } from 'lodash';
 import { localize } from 'i18n-calypso';
 import page from 'page';
+
+/** @format */
+/**
+ * External Dependencies
+ */
+import PropTypes from 'prop-types';
+
 import qs from 'qs';
 
 /**

--- a/client/reader/following-manage/index.jsx
+++ b/client/reader/following-manage/index.jsx
@@ -27,10 +27,20 @@ import SearchInput from 'components/search';
 import { addQueryArgs } from 'lib/url';
 import { resemblesUrl, withoutHttp, addSchemeIfMissing } from 'lib/url';
 import FollowButton from 'reader/follow-button';
-import { READER_FOLLOWING_MANAGE_URL_INPUT, READER_FOLLOWING_MANAGE_RECOMMENDATION } from 'reader/follow-button/follow-sources';
+import {
+	READER_FOLLOWING_MANAGE_URL_INPUT,
+	READER_FOLLOWING_MANAGE_RECOMMENDATION,
+} from 'reader/follow-button/follow-sources';
 import { recordTrack, recordAction } from 'reader/stats';
 import { SORT_BY_RELEVANCE } from 'state/reader/feed-searches/actions';
-import { getReaderFeedsForQuery, getReaderFeedsCountForQuery, getReaderRecommendedSites, getReaderRecommendedSitesPagingOffset, getBlockedSites, getReaderAliasedFollowFeedUrl } from 'state/selectors';
+import {
+	getReaderFeedsForQuery,
+	getReaderFeedsCountForQuery,
+	getReaderRecommendedSites,
+	getReaderRecommendedSitesPagingOffset,
+	getBlockedSites,
+	getReaderAliasedFollowFeedUrl,
+} from 'state/selectors';
 import { getReaderFollowsCount } from 'state/selectors';
 
 const PAGE_SIZE = 4;
@@ -187,20 +197,18 @@ class FollowingManage extends Component {
 			<ReaderMain className="following-manage">
 				<DocumentHead title={ 'Manage Following' } />
 				<MobileBackToSidebar>
-					<h1>
-						{ translate( 'Streams' ) }
-					</h1>
+					<h1>{ translate( 'Streams' ) }</h1>
 				</MobileBackToSidebar>
-				{ ! searchResults &&
-					<QueryReaderFeedsSearch query={ sitesQuery } excludeFollowed={ true } /> }
-				{ this.shouldRequestMoreRecs() &&
+				{ ! searchResults && (
+					<QueryReaderFeedsSearch query={ sitesQuery } excludeFollowed={ true } />
+				) }
+				{ this.shouldRequestMoreRecs() && (
 					<QueryReaderRecommendedSites
 						seed={ recommendationsSeed }
 						offset={ recommendedSitesPagingOffset + PAGE_SIZE || 0 }
-					/> }
-				<h2 className="following-manage__header">
-					{ translate( 'Follow Something New' ) }
-				</h2>
+					/>
+				) }
+				<h2 className="following-manage__header">{ translate( 'Follow Something New' ) }</h2>
 				<div ref={ this.handleStreamMounted } />
 				<div className="following-manage__fixed-area" ref={ this.handleSearchBoxMounted }>
 					<CompactCard className="following-manage__input-card">
@@ -219,7 +227,7 @@ class FollowingManage extends Component {
 						/>
 					</CompactCard>
 
-					{ showFollowByUrl &&
+					{ showFollowByUrl && (
 						<div className="following-manage__url-follow">
 							<FollowButton
 								followLabel={ translate( 'Follow %s', { args: sitesQueryWithoutProtocol } ) }
@@ -227,16 +235,18 @@ class FollowingManage extends Component {
 								siteUrl={ addSchemeIfMissing( readerAliasedFollowFeedUrl, 'http' ) }
 								followSource={ READER_FOLLOWING_MANAGE_URL_INPUT }
 							/>
-						</div> }
+						</div>
+					) }
 				</div>
 				{ hasFollows &&
-					! sitesQuery &&
+				! sitesQuery && (
 					<RecommendedSites
 						sites={ take( filteredRecommendedSites, 2 ) }
 						followSource={ READER_FOLLOWING_MANAGE_RECOMMENDATION }
-					/> }
+					/>
+				) }
 				{ !! sitesQuery &&
-					! isFollowByUrlWithNoSearchResults &&
+				! isFollowByUrlWithNoSearchResults && (
 					<FollowingManageSearchFeedsResults
 						searchResults={ searchResults }
 						showMoreResults={ showMoreResults }
@@ -244,14 +254,16 @@ class FollowingManage extends Component {
 						width={ this.state.width }
 						searchResultsCount={ searchResultsCount }
 						query={ sitesQuery }
-					/> }
-				{ showExistingSubscriptions &&
+					/>
+				) }
+				{ showExistingSubscriptions && (
 					<FollowingManageSubscriptions
 						width={ this.state.width }
 						query={ subsQuery }
 						sortOrder={ subsSortOrder }
 						windowScrollerRef={ this.handleWindowScrollerMounted }
-					/> }
+					/>
+				) }
 				{ ! hasFollows && <FollowingManageEmptyContent /> }
 			</ReaderMain>
 		);

--- a/client/reader/following-manage/search-followed.jsx
+++ b/client/reader/following-manage/search-followed.jsx
@@ -2,7 +2,9 @@
 /**
  * External Dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
 import { noop } from 'lodash';
 

--- a/client/reader/following-manage/search-followed.jsx
+++ b/client/reader/following-manage/search-followed.jsx
@@ -1,15 +1,14 @@
 /** @format */
 /**
- * External Dependencies
+ * External dependencies
  */
-import PropTypes from 'prop-types';
-
-import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
 import { noop } from 'lodash';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 
 /**
- * Internal Dependencies
+ * Internal dependencies
  */
 import SearchCard from 'components/search-card';
 

--- a/client/reader/following-manage/sort-controls.jsx
+++ b/client/reader/following-manage/sort-controls.jsx
@@ -2,11 +2,10 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
-import React from 'react';
-import { noop } from 'lodash';
 import { localize } from 'i18n-calypso';
+import { noop } from 'lodash';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 /**
  * Internal dependencies

--- a/client/reader/following-manage/sort-controls.jsx
+++ b/client/reader/following-manage/sort-controls.jsx
@@ -2,6 +2,8 @@
 /**
  * External dependencies
  */
+import PropTypes from 'prop-types';
+
 import React from 'react';
 import { noop } from 'lodash';
 import { localize } from 'i18n-calypso';
@@ -13,8 +15,8 @@ import FormSelect from 'components/forms/form-select';
 
 class FollowingManageSortControls extends React.Component {
 	static propTypes = {
-		onSortChange: React.PropTypes.func,
-		sortOrder: React.PropTypes.oneOf( [ 'date-followed', 'alpha' ] ),
+		onSortChange: PropTypes.func,
+		sortOrder: PropTypes.oneOf( [ 'date-followed', 'alpha' ] ),
 	};
 
 	static defaultProps = {

--- a/client/reader/following-manage/sort-controls.jsx
+++ b/client/reader/following-manage/sort-controls.jsx
@@ -36,12 +36,8 @@ class FollowingManageSortControls extends React.Component {
 				onChange={ this.handleSelectChange }
 				value={ sortOrder }
 			>
-				<option value="date-followed">
-					{ this.props.translate( 'Sort by date followed' ) }
-				</option>
-				<option value="alpha">
-					{ this.props.translate( 'Sort by site name' ) }
-				</option>
+				<option value="date-followed">{ this.props.translate( 'Sort by date followed' ) }</option>
+				<option value="alpha">{ this.props.translate( 'Sort by site name' ) }</option>
 			</FormSelect>
 		);
 	}

--- a/client/reader/following-manage/subscriptions.jsx
+++ b/client/reader/following-manage/subscriptions.jsx
@@ -2,7 +2,9 @@
 /**
  * External Dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import escapeRegexp from 'escape-string-regexp';

--- a/client/reader/following-manage/subscriptions.jsx
+++ b/client/reader/following-manage/subscriptions.jsx
@@ -1,35 +1,34 @@
 /** @format */
 /**
- * External Dependencies
+ * External dependencies
  */
-import PropTypes from 'prop-types';
-
-import React, { Component } from 'react';
-import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
+import classnames from 'classnames';
 import escapeRegexp from 'escape-string-regexp';
+import { localize } from 'i18n-calypso';
 import { reverse, sortBy, trimStart, isEmpty } from 'lodash';
 import page from 'page';
-import classnames from 'classnames';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
 
 /**
- * Internal Dependencies
+ * Internal dependencies
  */
-import ReaderImportButton from 'blocks/reader-import-button';
-import ReaderExportButton from 'blocks/reader-export-button';
-import InfiniteStream from 'components/reader-infinite-stream';
-import { siteRowRenderer } from 'components/reader-infinite-stream/row-renderers';
-import SyncReaderFollows from 'components/data/sync-reader-follows';
 import FollowingManageSearchFollowed from './search-followed';
 import FollowingManageSortControls from './sort-controls';
-import { getReaderFollows, getReaderFollowsCount } from 'state/selectors';
-import UrlSearch from 'lib/url-search';
-import { getSiteName, getSiteUrl, getSiteDescription, getSiteAuthorName } from 'reader/get-helpers';
+import ReaderExportButton from 'blocks/reader-export-button';
+import ReaderImportButton from 'blocks/reader-import-button';
+import SyncReaderFollows from 'components/data/sync-reader-follows';
 import EllipsisMenu from 'components/ellipsis-menu';
 import PopoverMenuItem from 'components/popover/menu-item';
-import { formatUrlForDisplay, getFeedTitle } from 'reader/lib/feed-display-helper';
+import InfiniteStream from 'components/reader-infinite-stream';
+import { siteRowRenderer } from 'components/reader-infinite-stream/row-renderers';
 import { addQueryArgs } from 'lib/url';
+import UrlSearch from 'lib/url-search';
 import { READER_SUBSCRIPTIONS } from 'reader/follow-button/follow-sources';
+import { getSiteName, getSiteUrl, getSiteDescription, getSiteAuthorName } from 'reader/get-helpers';
+import { formatUrlForDisplay, getFeedTitle } from 'reader/lib/feed-display-helper';
+import { getReaderFollows, getReaderFollowsCount } from 'state/selectors';
 
 class FollowingManageSubscriptions extends Component {
 	static propTypes = {

--- a/client/reader/following-manage/subscriptions.jsx
+++ b/client/reader/following-manage/subscriptions.jsx
@@ -123,7 +123,7 @@ class FollowingManageSubscriptions extends Component {
 					</div>
 				</div>
 				<div className={ subsListClassNames }>
-					{ ! noSitesMatchQuery &&
+					{ ! noSitesMatchQuery && (
 						<InfiniteStream
 							items={ sortedFollows }
 							extraRenderItemProps={ {
@@ -134,14 +134,16 @@ class FollowingManageSubscriptions extends Component {
 							totalCount={ sortedFollows.length }
 							windowScrollerRef={ this.props.windowScrollerRef }
 							rowRenderer={ siteRowRenderer }
-						/> }
-					{ noSitesMatchQuery &&
+						/>
+					) }
+					{ noSitesMatchQuery && (
 						<span>
 							{ translate( 'Sorry, no followed sites match {{italic}}%s.{{/italic}}', {
 								components: { italic: <i /> },
 								args: query,
 							} ) }
-						</span> }
+						</span>
+					) }
 				</div>
 			</div>
 		);

--- a/client/reader/liked-stream/empty.jsx
+++ b/client/reader/liked-stream/empty.jsx
@@ -39,15 +39,15 @@ class TagEmptyContent extends React.Component {
 					{ this.props.translate( 'Back to Following' ) }
 				</a>
 			),
-			secondaryAction = isDiscoverEnabled()
-				? <a
-						className="empty-content__action button"
-						onClick={ this.recordSecondaryAction }
-						href="/discover"
-					>
-						{ this.props.translate( 'Explore Discover' ) }
-					</a>
-				: null;
+			secondaryAction = isDiscoverEnabled() ? (
+				<a
+					className="empty-content__action button"
+					onClick={ this.recordSecondaryAction }
+					href="/discover"
+				>
+					{ this.props.translate( 'Explore Discover' ) }
+				</a>
+			) : null;
 
 		return (
 			<EmptyContent

--- a/client/reader/list-gap/index.jsx
+++ b/client/reader/list-gap/index.jsx
@@ -1,15 +1,14 @@
 /** @format */
 /**
- * External Dependencies
+ * External dependencies
  */
-import PropTypes from 'prop-types';
-
-import React from 'react';
 import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 /**
- * Internal Dependencies
+ * Internal dependencies
  */
 import { handleGapClicked } from 'reader/utils';
 

--- a/client/reader/list-gap/index.jsx
+++ b/client/reader/list-gap/index.jsx
@@ -2,6 +2,8 @@
 /**
  * External Dependencies
  */
+import PropTypes from 'prop-types';
+
 import React from 'react';
 import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
@@ -13,9 +15,9 @@ import { handleGapClicked } from 'reader/utils';
 
 class Gap extends React.Component {
 	static propTypes = {
-		gap: React.PropTypes.object.isRequired,
-		store: React.PropTypes.object.isRequired,
-		selected: React.PropTypes.bool,
+		gap: PropTypes.object.isRequired,
+		store: PropTypes.object.isRequired,
+		selected: PropTypes.bool,
 	};
 
 	state = { isFilling: false };

--- a/client/reader/list-item/actions.jsx
+++ b/client/reader/list-item/actions.jsx
@@ -6,11 +6,7 @@ import React from 'react';
 
 class ListItemActions extends React.PureComponent {
 	render() {
-		return (
-			<div className="reader-list-item__actions">
-				{ this.props.children }
-			</div>
-		);
+		return <div className="reader-list-item__actions">{ this.props.children }</div>;
 	}
 }
 

--- a/client/reader/list-item/description.jsx
+++ b/client/reader/list-item/description.jsx
@@ -7,11 +7,7 @@ import React from 'react';
 class ListItemDescription extends React.PureComponent {
 	render() {
 		// should this be a div instead of a p? p's have odd nesting rules that we can't enforce in code.
-		return (
-			<p className="reader-list-item__description">
-				{ this.props.children }
-			</p>
-		);
+		return <p className="reader-list-item__description">{ this.props.children }</p>;
 	}
 }
 

--- a/client/reader/list-item/index.jsx
+++ b/client/reader/list-item/index.jsx
@@ -13,11 +13,7 @@ import Card from 'components/card/compact';
 class ListItem extends React.PureComponent {
 	render() {
 		const classes = classnames( 'reader-list-item__card', this.props.className );
-		return (
-			<Card className={ classes }>
-				{ this.props.children }
-			</Card>
-		);
+		return <Card className={ classes }>{ this.props.children }</Card>;
 	}
 }
 

--- a/client/reader/list-stream/empty.jsx
+++ b/client/reader/list-stream/empty.jsx
@@ -39,15 +39,15 @@ class ListEmptyContent extends React.Component {
 					{ this.props.translate( 'Back to Following' ) }
 				</a>
 			),
-			secondaryAction = isDiscoverEnabled()
-				? <a
-						className="empty-content__action button"
-						onClick={ this.recordSecondaryAction }
-						href="/discover"
-					>
-						{ this.props.translate( 'Explore Discover' ) }
-					</a>
-				: null;
+			secondaryAction = isDiscoverEnabled() ? (
+				<a
+					className="empty-content__action button"
+					onClick={ this.recordSecondaryAction }
+					href="/discover"
+				>
+					{ this.props.translate( 'Explore Discover' ) }
+				</a>
+			) : null;
 
 		return (
 			<EmptyContent

--- a/client/reader/list-stream/header.jsx
+++ b/client/reader/list-stream/header.jsx
@@ -2,6 +2,8 @@
 /**
  * External dependencies
  */
+import PropTypes from 'prop-types';
+
 import React from 'react';
 import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
@@ -69,14 +71,14 @@ const ListStreamHeader = ( {
 };
 
 ListStreamHeader.propTypes = {
-	isPlaceholder: React.PropTypes.bool,
-	title: React.PropTypes.string,
-	description: React.PropTypes.string,
-	showEdit: React.PropTypes.bool,
-	editUrl: React.PropTypes.string,
-	showFollow: React.PropTypes.bool,
-	following: React.PropTypes.bool,
-	onFollowToggle: React.PropTypes.func,
+	isPlaceholder: PropTypes.bool,
+	title: PropTypes.string,
+	description: PropTypes.string,
+	showEdit: PropTypes.bool,
+	editUrl: PropTypes.string,
+	showFollow: PropTypes.bool,
+	following: PropTypes.bool,
+	onFollowToggle: PropTypes.func,
 };
 
 export default localize( ListStreamHeader );

--- a/client/reader/list-stream/header.jsx
+++ b/client/reader/list-stream/header.jsx
@@ -2,19 +2,18 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
-import React from 'react';
 import classnames from 'classnames';
-import { localize } from 'i18n-calypso';
 import Gridicon from 'gridicons';
+import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 /**
  * Internal dependencies
  */
+import FollowButton from 'blocks/follow-button/button';
 import Card from 'components/card';
 import { isExternal } from 'lib/url';
-import FollowButton from 'blocks/follow-button/button';
 
 const ListStreamHeader = ( {
 	isPlaceholder,

--- a/client/reader/list-stream/header.jsx
+++ b/client/reader/list-stream/header.jsx
@@ -39,32 +39,27 @@ const ListStreamHeader = ( {
 			</span>
 
 			<div className="list-stream__header-details">
-				<h1 className="list-stream__header-title">
-					{ title }
-				</h1>
-				{ description &&
-					<p className="list-stream__header-description">
-						{ description }
-					</p> }
+				<h1 className="list-stream__header-title">{ title }</h1>
+				{ description && <p className="list-stream__header-description">{ description }</p> }
 			</div>
 
-			{ showFollow &&
+			{ showFollow && (
 				<div className="list-stream__header-follow">
 					<FollowButton iconSize={ 24 } following={ following } onFollowToggle={ onFollowToggle } />
-				</div> }
+				</div>
+			) }
 
 			{ showEdit &&
-				editUrl &&
+			editUrl && (
 				<div className="list-stream__header-edit">
 					<a href={ editUrl } rel={ isExternal( editUrl ) ? 'external' : '' }>
 						<span className="list-stream__header-action-icon">
 							<Gridicon icon="cog" size={ 24 } />
 						</span>
-						<span className="list-stream__header-action-label">
-							{ translate( 'Edit' ) }
-						</span>
+						<span className="list-stream__header-action-label">{ translate( 'Edit' ) }</span>
 					</a>
-				</div> }
+				</div>
+			) }
 		</Card>
 	);
 };

--- a/client/reader/list-stream/missing.jsx
+++ b/client/reader/list-stream/missing.jsx
@@ -2,18 +2,16 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
-import React from 'react';
 import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 /**
  * Internal dependencies
  */
+import QueryReaderList from 'components/data/query-reader-list';
 import EmptyContent from 'components/empty-content';
 import { isDiscoverEnabled } from 'reader/discover/helper';
-import QueryReaderList from 'components/data/query-reader-list';
-
 import { recordAction, recordGaEvent, recordTrack } from 'reader/stats';
 
 class ListMissing extends React.Component {

--- a/client/reader/list-stream/missing.jsx
+++ b/client/reader/list-stream/missing.jsx
@@ -2,6 +2,8 @@
 /**
  * External dependencies
  */
+import PropTypes from 'prop-types';
+
 import React from 'react';
 import { localize } from 'i18n-calypso';
 
@@ -16,8 +18,8 @@ import { recordAction, recordGaEvent, recordTrack } from 'reader/stats';
 
 class ListMissing extends React.Component {
 	static propTypes = {
-		owner: React.PropTypes.string.isRequired,
-		slug: React.PropTypes.string.isRequired,
+		owner: PropTypes.string.isRequired,
+		slug: PropTypes.string.isRequired,
 	};
 
 	recordAction = () => {

--- a/client/reader/list-stream/missing.jsx
+++ b/client/reader/list-stream/missing.jsx
@@ -42,15 +42,15 @@ class ListMissing extends React.Component {
 					{ this.props.translate( 'Back to Followed Sites' ) }
 				</a>
 			),
-			secondaryAction = isDiscoverEnabled()
-				? <a
-						className="empty-content__action button"
-						onClick={ this.recordSecondaryAction }
-						href="/discover"
-					>
-						{ this.props.translate( 'Explore Discover' ) }
-					</a>
-				: null;
+			secondaryAction = isDiscoverEnabled() ? (
+				<a
+					className="empty-content__action button"
+					onClick={ this.recordSecondaryAction }
+					href="/discover"
+				>
+					{ this.props.translate( 'Explore Discover' ) }
+				</a>
+			) : null;
 
 		return (
 			<div>

--- a/client/reader/post-excerpt-link/index.jsx
+++ b/client/reader/post-excerpt-link/index.jsx
@@ -2,11 +2,10 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
-import React from 'react';
-import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
+import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 /**
  * Internal dependencies

--- a/client/reader/post-excerpt-link/index.jsx
+++ b/client/reader/post-excerpt-link/index.jsx
@@ -2,6 +2,8 @@
 /**
  * External dependencies
  */
+import PropTypes from 'prop-types';
+
 import React from 'react';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
@@ -13,8 +15,8 @@ import { recordPermalinkClick } from 'reader/stats';
 
 class PostExcerptLink extends React.Component {
 	static propTypes = {
-		siteName: React.PropTypes.string,
-		postUrl: React.PropTypes.string,
+		siteName: PropTypes.string,
+		postUrl: PropTypes.string,
 	};
 
 	state = {

--- a/client/reader/post-excerpt-link/index.jsx
+++ b/client/reader/post-excerpt-link/index.jsx
@@ -45,9 +45,7 @@ class PostExcerptLink extends React.Component {
 				target="_blank"
 				rel="external noopener noreferrer"
 			>
-				<span className="post-excerpt-only-site-name">
-					{ this.props.siteName || '(untitled)' }
-				</span>
+				<span className="post-excerpt-only-site-name">{ this.props.siteName || '(untitled)' }</span>
 			</a>
 		);
 		const classes = classNames( {

--- a/client/reader/reading-time/index.jsx
+++ b/client/reader/reading-time/index.jsx
@@ -30,11 +30,7 @@ class ReadingTime extends React.PureComponent {
 			components: { Time: approxTime },
 		} );
 
-		return (
-			<span className="byline__reading-time reading-time">
-				{ readingTime }
-			</span>
-		);
+		return <span className="byline__reading-time reading-time">{ readingTime }</span>;
 	}
 }
 

--- a/client/reader/recommendations/navigation/index.jsx
+++ b/client/reader/recommendations/navigation/index.jsx
@@ -1,11 +1,17 @@
 /** @format */
-import PropTypes from 'prop-types';
-
-import React from 'react';
+/**
+ * External dependencies
+ */
 import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
 import SectionNav from 'components/section-nav';
-import NavTabs from 'components/section-nav/tabs';
 import NavItem from 'components/section-nav/item';
+import NavTabs from 'components/section-nav/tabs';
 
 class RecommendedNavigation extends React.Component {
 	static propTypes = { selected: PropTypes.oneOf( [ 'for-you', 'sites', 'tags' ] ).isRequired };

--- a/client/reader/recommendations/navigation/index.jsx
+++ b/client/reader/recommendations/navigation/index.jsx
@@ -1,5 +1,7 @@
 /** @format */
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import { localize } from 'i18n-calypso';
 import SectionNav from 'components/section-nav';
 import NavTabs from 'components/section-nav/tabs';

--- a/client/reader/recommendations/posts/empty.jsx
+++ b/client/reader/recommendations/posts/empty.jsx
@@ -39,15 +39,15 @@ class RecommendedPostsEmptyContent extends React.Component {
 					{ this.props.translate( 'Back to Following' ) }
 				</a>
 			),
-			secondaryAction = isDiscoverEnabled()
-				? <a
-						className="empty-content__action button"
-						onClick={ this.recordSecondaryAction }
-						href="/discover"
-					>
-						{ this.props.translate( 'Explore Discover' ) }
-					</a>
-				: null;
+			secondaryAction = isDiscoverEnabled() ? (
+				<a
+					className="empty-content__action button"
+					onClick={ this.recordSecondaryAction }
+					href="/discover"
+				>
+					{ this.props.translate( 'Explore Discover' ) }
+				</a>
+			) : null;
 
 		return (
 			<EmptyContent

--- a/client/reader/search-stream/empty.jsx
+++ b/client/reader/search-stream/empty.jsx
@@ -2,6 +2,8 @@
 /**
  * External dependencies
  */
+import PropTypes from 'prop-types';
+
 import React from 'react';
 import { localize } from 'i18n-calypso';
 
@@ -14,7 +16,7 @@ import { isDiscoverEnabled } from 'reader/discover/helper';
 
 class SearchEmptyContent extends React.Component {
 	static propTypes = {
-		query: React.PropTypes.string,
+		query: PropTypes.string,
 	};
 
 	shouldComponentUpdate() {

--- a/client/reader/search-stream/empty.jsx
+++ b/client/reader/search-stream/empty.jsx
@@ -2,17 +2,16 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
-import React from 'react';
 import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 /**
  * Internal dependencies
  */
 import EmptyContent from 'components/empty-content';
-import { recordAction, recordGaEvent, recordTrack } from 'reader/stats';
 import { isDiscoverEnabled } from 'reader/discover/helper';
+import { recordAction, recordGaEvent, recordTrack } from 'reader/stats';
 
 class SearchEmptyContent extends React.Component {
 	static propTypes = {

--- a/client/reader/search-stream/empty.jsx
+++ b/client/reader/search-stream/empty.jsx
@@ -41,23 +41,19 @@ class SearchEmptyContent extends React.Component {
 			</a>
 		);
 
-		const secondaryAction = isDiscoverEnabled()
-			? <a
-					className="empty-content__action button"
-					onClick={ this.recordSecondaryAction }
-					href="/discover"
-				>
-					{ this.props.translate( 'Explore Discover' ) }
-				</a>
-			: null;
+		const secondaryAction = isDiscoverEnabled() ? (
+			<a
+				className="empty-content__action button"
+				onClick={ this.recordSecondaryAction }
+				href="/discover"
+			>
+				{ this.props.translate( 'Explore Discover' ) }
+			</a>
+		) : null;
 
 		const message = this.props.translate( 'No posts found for {{query /}} for your language.', {
 			components: {
-				query: (
-					<em>
-						{ this.props.query }
-					</em>
-				),
+				query: <em>{ this.props.query }</em>,
 			},
 		} );
 

--- a/client/reader/search-stream/index.jsx
+++ b/client/reader/search-stream/index.jsx
@@ -1,38 +1,37 @@
 /** @format */
 /**
- * External Dependencies
+ * External dependencies
  */
+import classnames from 'classnames';
+import { localize } from 'i18n-calypso';
+import { trim, initial, flatMap } from 'lodash';
+import page from 'page';
 import PropTypes from 'prop-types';
-
 import React from 'react';
 import { connect } from 'react-redux';
-import { trim, initial, flatMap } from 'lodash';
-import { localize } from 'i18n-calypso';
-import page from 'page';
-import classnames from 'classnames';
 
 /**
- * Internal Dependencies
+ * Internal dependencies
  */
-import ControlItem from 'components/segmented-control/item';
-import SegmentedControl from 'components/segmented-control';
+import PostResults from './post-results';
+import SearchStreamHeader, { SEARCH_TYPES } from './search-stream-header';
+import SiteResults from './site-results';
+import Suggestion from './suggestion';
+import SuggestionProvider from './suggestion-provider';
 import CompactCard from 'components/card/compact';
 import DocumentHead from 'components/data/document-head';
-import SearchInput from 'components/search';
-import { recordAction, recordTrack } from 'reader/stats';
-import SiteResults from './site-results';
-import PostResults from './post-results';
 import ReaderMain from 'components/reader-main';
+import SearchInput from 'components/search';
+import SegmentedControl from 'components/segmented-control';
+import ControlItem from 'components/segmented-control/item';
 import { addQueryArgs } from 'lib/url';
-import SearchStreamHeader, { SEARCH_TYPES } from './search-stream-header';
-import { SORT_BY_RELEVANCE, SORT_BY_LAST_UPDATED } from 'state/reader/feed-searches/actions';
-import withDimensions from 'lib/with-dimensions';
-import SuggestionProvider from './suggestion-provider';
-import Suggestion from './suggestion';
 import { resemblesUrl, withoutHttp, addSchemeIfMissing } from 'lib/url';
-import { getReaderAliasedFollowFeedUrl } from 'state/selectors';
-import { SEARCH_RESULTS_URL_INPUT } from 'reader/follow-button/follow-sources';
+import withDimensions from 'lib/with-dimensions';
 import FollowButton from 'reader/follow-button';
+import { SEARCH_RESULTS_URL_INPUT } from 'reader/follow-button/follow-sources';
+import { recordAction, recordTrack } from 'reader/stats';
+import { SORT_BY_RELEVANCE, SORT_BY_LAST_UPDATED } from 'state/reader/feed-searches/actions';
+import { getReaderAliasedFollowFeedUrl } from 'state/selectors';
 
 const WIDE_DISPLAY_CUTOFF = 660;
 

--- a/client/reader/search-stream/index.jsx
+++ b/client/reader/search-stream/index.jsx
@@ -2,7 +2,9 @@
 /**
  * External Dependencies
  */
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import { connect } from 'react-redux';
 import { trim, initial, flatMap } from 'lodash';
 import { localize } from 'i18n-calypso';

--- a/client/reader/search-stream/index.jsx
+++ b/client/reader/search-stream/index.jsx
@@ -40,14 +40,14 @@ const updateQueryArg = params =>
 
 const pickSort = sort => ( sort === 'date' ? SORT_BY_LAST_UPDATED : SORT_BY_RELEVANCE );
 
-const SpacerDiv = withDimensions( ( { width, height } ) =>
+const SpacerDiv = withDimensions( ( { width, height } ) => (
 	<div
 		style={ {
 			width: `${ width }px`,
 			height: `${ height }px`,
 		} }
 	/>
-);
+) );
 
 class SearchStream extends React.Component {
 	static propTypes = {
@@ -179,7 +179,7 @@ class SearchStream extends React.Component {
 							initialValue={ query || '' }
 							value={ query || '' }
 						/>
-						{ query &&
+						{ query && (
 							<SegmentedControl compact className="search-stream__sort-picker">
 								<ControlItem selected={ sortOrder !== 'date' } onClick={ this.useRelevanceSort }>
 									{ TEXT_RELEVANCE_SORT }
@@ -187,9 +187,10 @@ class SearchStream extends React.Component {
 								<ControlItem selected={ sortOrder === 'date' } onClick={ this.useDateSort }>
 									{ TEXT_DATE_SORT }
 								</ControlItem>
-							</SegmentedControl> }
+							</SegmentedControl>
+						) }
 					</CompactCard>
-					{ showFollowByUrl &&
+					{ showFollowByUrl && (
 						<div className="search-stream__url-follow">
 							<FollowButton
 								followLabel={ translate( 'Follow %s', { args: queryWithoutProtocol } ) }
@@ -197,14 +198,16 @@ class SearchStream extends React.Component {
 								siteUrl={ addSchemeIfMissing( readerAliasedFollowFeedUrl, 'http' ) }
 								followSource={ SEARCH_RESULTS_URL_INPUT }
 							/>
-						</div> }
-					{ query &&
+						</div>
+					) }
+					{ query && (
 						<SearchStreamHeader
 							selected={ searchType }
 							onSelection={ this.handleSearchTypeSelection }
 							wideDisplay={ wideDisplay }
-						/> }
-					{ ! query &&
+						/>
+					) }
+					{ ! query && (
 						<div className="search-stream__blank-suggestions">
 							{ suggestions &&
 								this.props.translate( 'Suggestions: {{suggestions /}}.', {
@@ -212,33 +215,39 @@ class SearchStream extends React.Component {
 										suggestions: suggestionList,
 									},
 								} ) }
-						</div> }
+						</div>
+					) }
 				</div>
 				<SpacerDiv domTarget={ this.fixedAreaRef } />
-				{ wideDisplay &&
+				{ wideDisplay && (
 					<div className={ searchStreamResultsClasses }>
 						<div className="search-stream__post-results">
 							<PostResults { ...this.props } />
 						</div>
-						{ query &&
+						{ query && (
 							<div className="search-stream__site-results">
 								<SiteResults
 									query={ query }
 									sort={ pickSort( sortOrder ) }
 									showLastUpdatedDate={ false }
 								/>
-							</div> }
-					</div> }
-				{ ! wideDisplay &&
+							</div>
+						) }
+					</div>
+				) }
+				{ ! wideDisplay && (
 					<div className={ singleColumnResultsClasses }>
-						{ ( ( searchType === SEARCH_TYPES.POSTS || ! query ) &&
-							<PostResults { ...this.props } /> ) ||
+						{ ( ( searchType === SEARCH_TYPES.POSTS || ! query ) && (
+							<PostResults { ...this.props } />
+						) ) || (
 							<SiteResults
 								query={ query }
 								sort={ pickSort( sortOrder ) }
 								showLastUpdatedDate={ true }
-							/> }
-					</div> }
+							/>
+						) }
+					</div>
+				) }
 			</div>
 		);
 	}
@@ -246,10 +255,11 @@ class SearchStream extends React.Component {
 
 /* eslint-disable */
 // wrapping with Main so that we can use withWidth helper to pass down whole width of Main
-const wrapWithMain = Component => props =>
+const wrapWithMain = Component => props => (
 	<ReaderMain className="search-stream search-stream__with-sites" wideLayout>
 		<Component { ...props } />
-	</ReaderMain>;
+	</ReaderMain>
+);
 /* eslint-enable */
 
 export default connect( ( state, ownProps ) => ( {

--- a/client/reader/search-stream/post-results.jsx
+++ b/client/reader/search-stream/post-results.jsx
@@ -1,21 +1,20 @@
 /** @format */
 /**
- * External Dependencies
+ * External dependencies
  */
-import PropTypes from 'prop-types';
-
-import React, { Component } from 'react';
-import { identity } from 'lodash';
 import { localize } from 'i18n-calypso';
+import { identity } from 'lodash';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 
 /**
- * Internal Dependencies
+ * Internal dependencies
  */
-import Stream from 'reader/stream';
 import EmptyContent from './empty';
-import HeaderBack from 'reader/header-back';
 import { RelatedPostCard } from 'blocks/reader-related-card-v2';
 import { SEARCH_RESULTS } from 'reader/follow-button/follow-sources';
+import HeaderBack from 'reader/header-back';
+import Stream from 'reader/stream';
 import PostPlaceholder from 'reader/stream/post-placeholder';
 
 class PostResults extends Component {

--- a/client/reader/search-stream/post-results.jsx
+++ b/client/reader/search-stream/post-results.jsx
@@ -2,6 +2,8 @@
 /**
  * External Dependencies
  */
+import PropTypes from 'prop-types';
+
 import React, { Component } from 'react';
 import { identity } from 'lodash';
 import { localize } from 'i18n-calypso';
@@ -18,7 +20,7 @@ import PostPlaceholder from 'reader/stream/post-placeholder';
 
 class PostResults extends Component {
 	static propTypes = {
-		query: React.PropTypes.string,
+		query: PropTypes.string,
 	};
 
 	placeholderFactory = ( { key, ...rest } ) => {

--- a/client/reader/search-stream/search-stream-header.jsx
+++ b/client/reader/search-stream/search-stream-header.jsx
@@ -1,19 +1,18 @@
 /** @format */
 /**
- * External Dependencies
+ * External dependencies
  */
-import PropTypes from 'prop-types';
-
-import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
 import { noop, values } from 'lodash';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 
 /**
- * Internal Dependencies
+ * Internal dependencies
  */
-import NavTabs from 'components/section-nav/tabs';
 import SectionNav from 'components/section-nav';
 import NavItem from 'components/section-nav/item';
+import NavTabs from 'components/section-nav/tabs';
 
 export const SEARCH_TYPES = { POSTS: 'posts', SITES: 'sites' };
 

--- a/client/reader/search-stream/search-stream-header.jsx
+++ b/client/reader/search-stream/search-stream-header.jsx
@@ -2,7 +2,9 @@
 /**
  * External Dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
 import { noop, values } from 'lodash';
 

--- a/client/reader/search-stream/search-stream-header.jsx
+++ b/client/reader/search-stream/search-stream-header.jsx
@@ -37,12 +37,8 @@ class SearchStreamHeader extends Component {
 		if ( wideDisplay ) {
 			return (
 				<ul className="search-stream__headers">
-					<li className="search-stream__post-header">
-						{ translate( 'Posts' ) }
-					</li>
-					<li className="search-stream__site-header">
-						{ translate( 'Sites' ) }
-					</li>
+					<li className="search-stream__post-header">{ translate( 'Posts' ) }</li>
+					<li className="search-stream__site-header">{ translate( 'Sites' ) }</li>
 				</ul>
 			);
 		}

--- a/client/reader/search-stream/site-results.jsx
+++ b/client/reader/search-stream/site-results.jsx
@@ -2,7 +2,9 @@
 /**
  * External Dependencies
  */
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import 'lodash';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';

--- a/client/reader/search-stream/site-results.jsx
+++ b/client/reader/search-stream/site-results.jsx
@@ -1,25 +1,24 @@
 /** @format */
 /**
- * External Dependencies
+ * External dependencies
  */
-import PropTypes from 'prop-types';
-
-import React from 'react';
-import 'lodash';
 import { localize } from 'i18n-calypso';
+import 'lodash';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { connect } from 'react-redux';
 
 /**
- * Internal Dependencies
+ * Internal dependencies
  */
-import { getReaderFeedsCountForQuery, getReaderFeedsForQuery } from 'state/selectors';
 import QueryReaderFeedsSearch from 'components/data/query-reader-feeds-search';
-import { requestFeedSearch } from 'state/reader/feed-searches/actions';
 import ReaderInfiniteStream from 'components/reader-infinite-stream';
-import { SORT_BY_RELEVANCE, SORT_BY_LAST_UPDATED } from 'state/reader/feed-searches/actions';
-import { SEARCH_RESULTS_SITES } from 'reader/follow-button/follow-sources';
 import { siteRowRenderer } from 'components/reader-infinite-stream/row-renderers';
 import withDimensions from 'lib/with-dimensions';
+import { SEARCH_RESULTS_SITES } from 'reader/follow-button/follow-sources';
+import { requestFeedSearch } from 'state/reader/feed-searches/actions';
+import { SORT_BY_RELEVANCE, SORT_BY_LAST_UPDATED } from 'state/reader/feed-searches/actions';
+import { getReaderFeedsCountForQuery, getReaderFeedsForQuery } from 'state/selectors';
 
 class SiteResults extends React.Component {
 	static propTypes = {

--- a/client/reader/search-stream/suggestion.jsx
+++ b/client/reader/search-stream/suggestion.jsx
@@ -1,8 +1,11 @@
+import React, { Component } from 'react';
+
 /** @format */
 /**
  * External Dependencies
  */
-import React, { PropTypes, Component } from 'react';
+import PropTypes from 'prop-types';
+
 import { stringify } from 'qs';
 
 /**

--- a/client/reader/search-stream/suggestion.jsx
+++ b/client/reader/search-stream/suggestion.jsx
@@ -1,18 +1,16 @@
-import React, { Component } from 'react';
-
 /** @format */
 /**
- * External Dependencies
+ * External dependencies
  */
 import PropTypes from 'prop-types';
-
 import { stringify } from 'qs';
+import React, { Component } from 'react';
 
 /**
- * Internal Dependencies
+ * Internal dependencies
  */
-import { recordTrack, recordTracksRailcarInteract } from 'reader/stats';
 import analytics from 'lib/analytics';
+import { recordTrack, recordTracksRailcarInteract } from 'reader/stats';
 
 export class Suggestion extends Component {
 	static propTypes = {

--- a/client/reader/sidebar/expandable-add-form.jsx
+++ b/client/reader/sidebar/expandable-add-form.jsx
@@ -2,7 +2,9 @@
 /**
  * External Dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import classNames from 'classnames';
 import { noop, identity } from 'lodash';
 import { localize } from 'i18n-calypso';

--- a/client/reader/sidebar/expandable-add-form.jsx
+++ b/client/reader/sidebar/expandable-add-form.jsx
@@ -1,17 +1,16 @@
 /** @format */
 /**
- * External Dependencies
+ * External dependencies
  */
-import PropTypes from 'prop-types';
-
-import React, { Component } from 'react';
 import classNames from 'classnames';
-import { noop, identity } from 'lodash';
-import { localize } from 'i18n-calypso';
 import Gridicon from 'gridicons';
+import { localize } from 'i18n-calypso';
+import { noop, identity } from 'lodash';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 
 /**
- * Internal Dependencies
+ * Internal dependencies
  */
 import Button from 'components/button';
 

--- a/client/reader/sidebar/expandable-add-form.jsx
+++ b/client/reader/sidebar/expandable-add-form.jsx
@@ -59,11 +59,11 @@ export class ExpandableSidebarAddForm extends Component {
 		} );
 		return (
 			<div className={ classes }>
-				{ this.props.hideAddButton
-					? null
-					: <Button compact className="sidebar__menu-add-button" onClick={ this.toggleAdd }>
-							{ translate( 'Add' ) }
-						</Button> }
+				{ this.props.hideAddButton ? null : (
+					<Button compact className="sidebar__menu-add-button" onClick={ this.toggleAdd }>
+						{ translate( 'Add' ) }
+					</Button>
+				) }
 				<div className="sidebar__menu-add">
 					<input
 						aria-label={ addLabel }

--- a/client/reader/sidebar/expandable-heading.jsx
+++ b/client/reader/sidebar/expandable-heading.jsx
@@ -2,6 +2,8 @@
 /**
  * External dependencies
  */
+import PropTypes from 'prop-types';
+
 import React from 'react';
 import { noop } from 'lodash';
 import Gridicon from 'gridicons';
@@ -22,9 +24,9 @@ const ExpandableSidebarHeading = ( { title, count, onClick } ) =>
 	</SidebarHeading>;
 
 ExpandableSidebarHeading.propTypes = {
-	title: React.PropTypes.string.isRequired,
-	count: React.PropTypes.number,
-	onClick: React.PropTypes.func,
+	title: PropTypes.string.isRequired,
+	count: PropTypes.number,
+	onClick: PropTypes.func,
 };
 
 ExpandableSidebarHeading.defaultProps = {

--- a/client/reader/sidebar/expandable-heading.jsx
+++ b/client/reader/sidebar/expandable-heading.jsx
@@ -13,14 +13,13 @@ import React from 'react';
 import Count from 'components/count';
 import SidebarHeading from 'layout/sidebar/heading';
 
-const ExpandableSidebarHeading = ( { title, count, onClick } ) =>
+const ExpandableSidebarHeading = ( { title, count, onClick } ) => (
 	<SidebarHeading onClick={ onClick }>
 		<Gridicon icon="chevron-down" />
-		<span>
-			{ title }
-		</span>
+		<span>{ title }</span>
 		<Count count={ count } />
-	</SidebarHeading>;
+	</SidebarHeading>
+);
 
 ExpandableSidebarHeading.propTypes = {
 	title: PropTypes.string.isRequired,

--- a/client/reader/sidebar/expandable-heading.jsx
+++ b/client/reader/sidebar/expandable-heading.jsx
@@ -2,17 +2,16 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
-import React from 'react';
-import { noop } from 'lodash';
 import Gridicon from 'gridicons';
+import { noop } from 'lodash';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 /**
  * Internal dependencies
  */
-import SidebarHeading from 'layout/sidebar/heading';
 import Count from 'components/count';
+import SidebarHeading from 'layout/sidebar/heading';
 
 const ExpandableSidebarHeading = ( { title, count, onClick } ) =>
 	<SidebarHeading onClick={ onClick }>

--- a/client/reader/sidebar/expandable.jsx
+++ b/client/reader/sidebar/expandable.jsx
@@ -1,18 +1,17 @@
 /** @format */
 /**
- * External Dependencies
+ * External dependencies
  */
-import PropTypes from 'prop-types';
-
-import React from 'react';
 import classNames from 'classnames';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 /**
- * Internal Dependencies
+ * Internal dependencies
  */
-import SidebarMenu from 'layout/sidebar/menu';
-import ExpandableSidebarHeading from './expandable-heading';
 import ExpandableSidebarAddForm from './expandable-add-form';
+import ExpandableSidebarHeading from './expandable-heading';
+import SidebarMenu from 'layout/sidebar/menu';
 
 export const ExpandableSidebarMenu = props => {
 	const {

--- a/client/reader/sidebar/expandable.jsx
+++ b/client/reader/sidebar/expandable.jsx
@@ -2,6 +2,8 @@
 /**
  * External Dependencies
  */
+import PropTypes from 'prop-types';
+
 import React from 'react';
 import classNames from 'classnames';
 
@@ -47,15 +49,15 @@ export const ExpandableSidebarMenu = props => {
 };
 
 ExpandableSidebarMenu.propTypes = {
-	title: React.PropTypes.oneOfType( [ React.PropTypes.string, React.PropTypes.element ] )
+	title: PropTypes.oneOfType( [ PropTypes.string, PropTypes.element ] )
 		.isRequired,
-	count: React.PropTypes.number,
-	addLabel: React.PropTypes.string,
-	addPlaceholder: React.PropTypes.string,
-	onAddSubmit: React.PropTypes.func,
-	onAddClick: React.PropTypes.func,
-	onClick: React.PropTypes.func,
-	hideAddButton: React.PropTypes.bool,
+	count: PropTypes.number,
+	addLabel: PropTypes.string,
+	addPlaceholder: PropTypes.string,
+	onAddSubmit: PropTypes.func,
+	onAddClick: PropTypes.func,
+	onClick: PropTypes.func,
+	hideAddButton: PropTypes.bool,
 };
 
 ExpandableSidebarMenu.defaultProps = {

--- a/client/reader/sidebar/expandable.jsx
+++ b/client/reader/sidebar/expandable.jsx
@@ -40,16 +40,13 @@ export const ExpandableSidebarMenu = props => {
 				onAddClick={ onAddClick }
 				onAddSubmit={ onAddSubmit }
 			/>
-			<ul className="sidebar__menu-list">
-				{ props.children }
-			</ul>
+			<ul className="sidebar__menu-list">{ props.children }</ul>
 		</SidebarMenu>
 	);
 };
 
 ExpandableSidebarMenu.propTypes = {
-	title: PropTypes.oneOfType( [ PropTypes.string, PropTypes.element ] )
-		.isRequired,
+	title: PropTypes.oneOfType( [ PropTypes.string, PropTypes.element ] ).isRequired,
 	count: PropTypes.number,
 	addLabel: PropTypes.string,
 	addPlaceholder: PropTypes.string,

--- a/client/reader/sidebar/index.jsx
+++ b/client/reader/sidebar/index.jsx
@@ -154,9 +154,7 @@ export const ReaderSidebar = createReactClass( {
 			<Sidebar onClick={ this.handleClick }>
 				<SidebarRegion>
 					<SidebarMenu>
-						<SidebarHeading>
-							{ this.props.translate( 'Streams' ) }
-						</SidebarHeading>
+						<SidebarHeading>{ this.props.translate( 'Streams' ) }</SidebarHeading>
 						<ul>
 							<li
 								className={ ReaderSidebarHelper.itemLinkClass( '/', this.props.path, {
@@ -177,7 +175,7 @@ export const ReaderSidebar = createReactClass( {
 									{ this.props.translate( 'Manage' ) }
 								</a>
 							</li>
-							{ config.isEnabled( 'reader/conversations' ) &&
+							{ config.isEnabled( 'reader/conversations' ) && (
 								<li
 									className={ ReaderSidebarHelper.itemLinkClass(
 										'/read/conversations',
@@ -196,10 +194,11 @@ export const ReaderSidebar = createReactClass( {
 											{ this.props.translate( 'Conversations' ) }
 										</span>
 									</a>
-								</li> }
+								</li>
+							) }
 							<ReaderSidebarTeams teams={ this.props.teams } path={ this.props.path } />
 							{ config.isEnabled( 'reader/conversations' ) &&
-								isAutomatticTeamMember( this.props.teams ) &&
+							isAutomatticTeamMember( this.props.teams ) && (
 								<li
 									className={ ReaderSidebarHelper.itemLinkClass(
 										'/read/conversations/a8c',
@@ -225,24 +224,23 @@ export const ReaderSidebar = createReactClass( {
 										</svg>
 										<span className="menu-link-text">A8C Conversations</span>
 									</a>
-								</li> }
+								</li>
+							) }
 
-							{ isDiscoverEnabled()
-								? <li
-										className={ ReaderSidebarHelper.itemLinkClass( '/discover', this.props.path, {
-											'sidebar-streams__discover': true,
-										} ) }
-									>
-										<a href="/discover" onClick={ this.handleReaderSidebarDiscoverClicked }>
-											<Gridicon icon="my-sites" />
-											<span className="menu-link-text">
-												{ this.props.translate( 'Discover' ) }
-											</span>
-										</a>
-									</li>
-								: null }
+							{ isDiscoverEnabled() ? (
+								<li
+									className={ ReaderSidebarHelper.itemLinkClass( '/discover', this.props.path, {
+										'sidebar-streams__discover': true,
+									} ) }
+								>
+									<a href="/discover" onClick={ this.handleReaderSidebarDiscoverClicked }>
+										<Gridicon icon="my-sites" />
+										<span className="menu-link-text">{ this.props.translate( 'Discover' ) }</span>
+									</a>
+								</li>
+							) : null }
 
-							{ config.isEnabled( 'reader/search' ) &&
+							{ config.isEnabled( 'reader/search' ) && (
 								<li
 									className={ ReaderSidebarHelper.itemLinkClass( '/read/search', this.props.path, {
 										'sidebar-streams__search': true,
@@ -250,11 +248,10 @@ export const ReaderSidebar = createReactClass( {
 								>
 									<a href="/read/search" onClick={ this.handleReaderSidebarSearchClicked }>
 										<Gridicon icon="search" size={ 24 } />
-										<span className="menu-link-text">
-											{ this.props.translate( 'Search' ) }
-										</span>
+										<span className="menu-link-text">{ this.props.translate( 'Search' ) }</span>
 									</a>
-								</li> }
+								</li>
+							) }
 
 							<li
 								className={ ReaderSidebarHelper.itemLinkClass(
@@ -265,9 +262,7 @@ export const ReaderSidebar = createReactClass( {
 							>
 								<a href="/activities/likes" onClick={ this.handleReaderSidebarLikeActivityClicked }>
 									<Gridicon icon="star" size={ 24 } />
-									<span className="menu-link-text">
-										{ this.props.translate( 'My Likes' ) }
-									</span>
+									<span className="menu-link-text">{ this.props.translate( 'My Likes' ) }</span>
 								</a>
 							</li>
 						</ul>
@@ -275,16 +270,16 @@ export const ReaderSidebar = createReactClass( {
 
 					<QueryReaderLists />
 					<QueryReaderTeams />
-					{ this.props.subscribedLists && this.props.subscribedLists.length
-						? <ReaderSidebarLists
-								lists={ this.props.subscribedLists }
-								path={ this.props.path }
-								isOpen={ this.props.isListsOpen }
-								onClick={ this.props.toggleListsVisibility }
-								currentListOwner={ this.state.currentListOwner }
-								currentListSlug={ this.state.currentListSlug }
-							/>
-						: null }
+					{ this.props.subscribedLists && this.props.subscribedLists.length ? (
+						<ReaderSidebarLists
+							lists={ this.props.subscribedLists }
+							path={ this.props.path }
+							isOpen={ this.props.isListsOpen }
+							onClick={ this.props.toggleListsVisibility }
+							currentListOwner={ this.state.currentListOwner }
+							currentListSlug={ this.state.currentListSlug }
+						/>
+					) : null }
 					<ReaderSidebarTags
 						tags={ this.props.followedTags }
 						path={ this.props.path }
@@ -295,10 +290,11 @@ export const ReaderSidebar = createReactClass( {
 					/>
 				</SidebarRegion>
 
-				{ this.props.shouldRenderAppPromo &&
+				{ this.props.shouldRenderAppPromo && (
 					<div className="sidebar__app-promo">
 						<AppPromo location="reader" locale={ userUtils.getLocaleSlug() } />
-					</div> }
+					</div>
+				) }
 
 				<SidebarFooter />
 			</Sidebar>

--- a/client/reader/sidebar/reader-sidebar-lists/index.jsx
+++ b/client/reader/sidebar/reader-sidebar-lists/index.jsx
@@ -2,7 +2,9 @@
 /**
  * External Dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import { identity } from 'lodash';
 import { localize } from 'i18n-calypso';
 /**

--- a/client/reader/sidebar/reader-sidebar-lists/index.jsx
+++ b/client/reader/sidebar/reader-sidebar-lists/index.jsx
@@ -1,19 +1,18 @@
 /** @format */
 /**
- * External Dependencies
+ * External dependencies
  */
-import PropTypes from 'prop-types';
-
-import React, { Component } from 'react';
-import { identity } from 'lodash';
 import { localize } from 'i18n-calypso';
+import { identity } from 'lodash';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+
 /**
- * Internal Dependencies
+ * Internal dependencies
  */
 import ExpandableSidebarMenu from '../expandable';
 import ReaderSidebarListsList from './list';
 import ReaderListsActions from 'lib/reader-lists/actions';
-
 import { recordAction, recordGaEvent, recordTrack } from 'reader/stats';
 
 export class ReaderSidebarLists extends Component {

--- a/client/reader/sidebar/reader-sidebar-lists/list-item.jsx
+++ b/client/reader/sidebar/reader-sidebar-lists/list-item.jsx
@@ -2,6 +2,8 @@
 /**
  * External Dependencies
  */
+import PropTypes from 'prop-types';
+
 import React, { Component } from 'react';
 import ReactDom from 'react-dom';
 import { last } from 'lodash';
@@ -16,10 +18,10 @@ import { recordAction, recordGaEvent, recordTrack } from 'reader/stats';
 
 export class ReaderSidebarListsListItem extends Component {
 	static propTypes = {
-		list: React.PropTypes.object.isRequired,
-		path: React.PropTypes.string.isRequired,
-		currentListOwner: React.PropTypes.string,
-		currentListSlug: React.PropTypes.string,
+		list: PropTypes.object.isRequired,
+		path: PropTypes.string.isRequired,
+		currentListOwner: PropTypes.string,
+		currentListSlug: PropTypes.string,
 	};
 
 	componentDidMount() {

--- a/client/reader/sidebar/reader-sidebar-lists/list-item.jsx
+++ b/client/reader/sidebar/reader-sidebar-lists/list-item.jsx
@@ -1,17 +1,16 @@
 /** @format */
 /**
- * External Dependencies
+ * External dependencies
  */
-import PropTypes from 'prop-types';
-
-import React, { Component } from 'react';
-import ReactDom from 'react-dom';
-import { last } from 'lodash';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
+import { last } from 'lodash';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import ReactDom from 'react-dom';
 
 /**
- * Internal Dependencies
+ * Internal dependencies
  */
 import ReaderSidebarHelper from '../helper';
 import { recordAction, recordGaEvent, recordTrack } from 'reader/stats';

--- a/client/reader/sidebar/reader-sidebar-lists/list-item.jsx
+++ b/client/reader/sidebar/reader-sidebar-lists/list-item.jsx
@@ -78,9 +78,7 @@ export class ReaderSidebarListsListItem extends Component {
 						},
 					} ) }
 				>
-					<div className="sidebar__menu-item-listname">
-						{ list.title }
-					</div>
+					<div className="sidebar__menu-item-listname">{ list.title }</div>
 				</a>
 			</li>
 		);

--- a/client/reader/sidebar/reader-sidebar-lists/list.jsx
+++ b/client/reader/sidebar/reader-sidebar-lists/list.jsx
@@ -1,15 +1,14 @@
 /** @format */
 /**
- * External Dependencies
+ * External dependencies
  */
-import PropTypes from 'prop-types';
-
-import React from 'react';
-import { identity, map } from 'lodash';
 import { localize } from 'i18n-calypso';
+import { identity, map } from 'lodash';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 /**
- * Internal Dependencies
+ * Internal dependencies
  */
 import ReaderSidebarListsListItem from './list-item';
 

--- a/client/reader/sidebar/reader-sidebar-lists/list.jsx
+++ b/client/reader/sidebar/reader-sidebar-lists/list.jsx
@@ -2,6 +2,8 @@
 /**
  * External Dependencies
  */
+import PropTypes from 'prop-types';
+
 import React from 'react';
 import { identity, map } from 'lodash';
 import { localize } from 'i18n-calypso';
@@ -13,11 +15,11 @@ import ReaderSidebarListsListItem from './list-item';
 
 export class ReaderSidebarListsList extends React.Component {
 	static propTypes = {
-		lists: React.PropTypes.array,
-		path: React.PropTypes.string.isRequired,
-		currentListOwner: React.PropTypes.string,
-		currentListSlug: React.PropTypes.string,
-		translate: React.PropTypes.func,
+		lists: PropTypes.array,
+		path: PropTypes.string.isRequired,
+		currentListOwner: PropTypes.string,
+		currentListSlug: PropTypes.string,
+		translate: PropTypes.func,
 	};
 
 	static defaultProps = {

--- a/client/reader/sidebar/reader-sidebar-lists/list.jsx
+++ b/client/reader/sidebar/reader-sidebar-lists/list.jsx
@@ -50,11 +50,7 @@ export class ReaderSidebarListsList extends React.Component {
 			);
 		}
 
-		return (
-			<div>
-				{ this.renderItems() }
-			</div>
-		);
+		return <div>{ this.renderItems() }</div>;
 	}
 }
 

--- a/client/reader/sidebar/reader-sidebar-tags/index.jsx
+++ b/client/reader/sidebar/reader-sidebar-tags/index.jsx
@@ -1,25 +1,23 @@
 /** @format */
 /**
- * External Dependencies
+ * External dependencies
  */
-import PropTypes from 'prop-types';
-
-import React, { Component } from 'react';
-import { connect } from 'react-redux';
 import closest from 'component-closest';
 import { localize } from 'i18n-calypso';
 import { identity } from 'lodash';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
 
 /**
- * Internal Dependencies
+ * Internal dependencies
  */
 import ExpandableSidebarMenu from '../expandable';
 import ReaderSidebarTagsList from './list';
 import QueryReaderFollowedTags from 'components/data/query-reader-followed-tags';
-import { getReaderFollowedTags } from 'state/selectors';
-import { requestFollowTag, requestUnfollowTag } from 'state/reader/tags/items/actions';
-
 import { recordAction, recordGaEvent, recordTrack } from 'reader/stats';
+import { requestFollowTag, requestUnfollowTag } from 'state/reader/tags/items/actions';
+import { getReaderFollowedTags } from 'state/selectors';
 
 export class ReaderSidebarTags extends Component {
 	static propTypes = {

--- a/client/reader/sidebar/reader-sidebar-tags/index.jsx
+++ b/client/reader/sidebar/reader-sidebar-tags/index.jsx
@@ -2,7 +2,9 @@
 /**
  * External Dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import closest from 'component-closest';
 import { localize } from 'i18n-calypso';

--- a/client/reader/sidebar/reader-sidebar-tags/list-item.jsx
+++ b/client/reader/sidebar/reader-sidebar-tags/list-item.jsx
@@ -1,17 +1,16 @@
 /** @format */
 /**
- * External Dependencies
+ * External dependencies
  */
-import PropTypes from 'prop-types';
-
-import React, { Component } from 'react';
-import ReactDom from 'react-dom';
+import Gridicon from 'gridicons';
 import { localize } from 'i18n-calypso';
 import { identity } from 'lodash';
-import Gridicon from 'gridicons';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import ReactDom from 'react-dom';
 
 /**
- * Internal Dependencies
+ * Internal dependencies
  */
 import ReaderSidebarHelper from '../helper';
 import { recordAction, recordGaEvent, recordTrack } from 'reader/stats';

--- a/client/reader/sidebar/reader-sidebar-tags/list-item.jsx
+++ b/client/reader/sidebar/reader-sidebar-tags/list-item.jsx
@@ -2,6 +2,8 @@
 /**
  * External Dependencies
  */
+import PropTypes from 'prop-types';
+
 import React, { Component } from 'react';
 import ReactDom from 'react-dom';
 import { localize } from 'i18n-calypso';
@@ -16,11 +18,11 @@ import { recordAction, recordGaEvent, recordTrack } from 'reader/stats';
 
 export class ReaderSidebarTagsListItem extends Component {
 	static propTypes = {
-		tag: React.PropTypes.object.isRequired,
-		onUnfollow: React.PropTypes.func.isRequired,
-		path: React.PropTypes.string.isRequired,
-		currentTag: React.PropTypes.string,
-		translate: React.PropTypes.func,
+		tag: PropTypes.object.isRequired,
+		onUnfollow: PropTypes.func.isRequired,
+		path: PropTypes.string.isRequired,
+		currentTag: PropTypes.string,
+		translate: PropTypes.func,
 	};
 
 	static defaultProps = {

--- a/client/reader/sidebar/reader-sidebar-tags/list-item.jsx
+++ b/client/reader/sidebar/reader-sidebar-tags/list-item.jsx
@@ -66,11 +66,9 @@ export class ReaderSidebarTagsListItem extends Component {
 						},
 					} ) }
 				>
-					<div className="sidebar__menu-item-tagname">
-						{ tagName }
-					</div>
+					<div className="sidebar__menu-item-tagname">{ tagName }</div>
 				</a>
-				{ tag.id !== 'pending' &&
+				{ tag.id !== 'pending' && (
 					<button
 						className="sidebar__menu-action"
 						data-tag-slug={ tag.slug }
@@ -82,10 +80,9 @@ export class ReaderSidebarTagsListItem extends Component {
 						} ) }
 					>
 						<Gridicon icon="cross-small" />
-						<span className="sidebar__menu-action-label">
-							{ translate( 'Unfollow' ) }
-						</span>
-					</button> }
+						<span className="sidebar__menu-action-label">{ translate( 'Unfollow' ) }</span>
+					</button>
+				) }
 			</li>
 		);
 		/* eslint-enable wpcalypso/jsx-classname-namespace */

--- a/client/reader/sidebar/reader-sidebar-tags/list.jsx
+++ b/client/reader/sidebar/reader-sidebar-tags/list.jsx
@@ -2,6 +2,8 @@
 /**
  * External Dependencies
  */
+import PropTypes from 'prop-types';
+
 import React, { Component } from 'react';
 import { identity, map } from 'lodash';
 import { localize } from 'i18n-calypso';
@@ -13,11 +15,11 @@ import ReaderSidebarTagsListItem from './list-item';
 
 export class ReaderSidebarTagsList extends Component {
 	static propTypes = {
-		tags: React.PropTypes.array,
-		onUnfollow: React.PropTypes.func.isRequired,
-		path: React.PropTypes.string.isRequired,
-		currentTag: React.PropTypes.string,
-		translate: React.PropTypes.func,
+		tags: PropTypes.array,
+		onUnfollow: PropTypes.func.isRequired,
+		path: PropTypes.string.isRequired,
+		currentTag: PropTypes.string,
+		translate: PropTypes.func,
 	};
 
 	static defaultProps = {

--- a/client/reader/sidebar/reader-sidebar-tags/list.jsx
+++ b/client/reader/sidebar/reader-sidebar-tags/list.jsx
@@ -1,15 +1,14 @@
 /** @format */
 /**
- * External Dependencies
+ * External dependencies
  */
-import PropTypes from 'prop-types';
-
-import React, { Component } from 'react';
-import { identity, map } from 'lodash';
 import { localize } from 'i18n-calypso';
+import { identity, map } from 'lodash';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 
 /**
- * Internal Dependencies
+ * Internal dependencies
  */
 import ReaderSidebarTagsListItem from './list-item';
 

--- a/client/reader/sidebar/reader-sidebar-tags/list.jsx
+++ b/client/reader/sidebar/reader-sidebar-tags/list.jsx
@@ -50,11 +50,7 @@ export class ReaderSidebarTagsList extends Component {
 			);
 		}
 
-		return (
-			<div>
-				{ this.renderItems() }
-			</div>
-		);
+		return <div>{ this.renderItems() }</div>;
 	}
 }
 

--- a/client/reader/sidebar/reader-sidebar-teams/index.jsx
+++ b/client/reader/sidebar/reader-sidebar-teams/index.jsx
@@ -2,6 +2,8 @@
 /**
  * External Dependencies
  */
+import PropTypes from 'prop-types';
+
 import React, { Component } from 'react';
 import { map } from 'lodash';
 
@@ -17,8 +19,8 @@ const renderItems = ( teams, path ) =>
 
 export class ReaderSidebarTeams extends Component {
 	static propTypes = {
-		teams: React.PropTypes.array,
-		path: React.PropTypes.string.isRequired,
+		teams: PropTypes.array,
+		path: PropTypes.string.isRequired,
 	};
 
 	render() {

--- a/client/reader/sidebar/reader-sidebar-teams/index.jsx
+++ b/client/reader/sidebar/reader-sidebar-teams/index.jsx
@@ -1,14 +1,13 @@
 /** @format */
 /**
- * External Dependencies
+ * External dependencies
  */
-import PropTypes from 'prop-types';
-
-import React, { Component } from 'react';
 import { map } from 'lodash';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 
 /**
- * Internal Dependencies
+ * Internal dependencies
  */
 import ReaderSidebarTeamsListItem from './list-item';
 

--- a/client/reader/sidebar/reader-sidebar-teams/index.jsx
+++ b/client/reader/sidebar/reader-sidebar-teams/index.jsx
@@ -12,9 +12,9 @@ import React, { Component } from 'react';
 import ReaderSidebarTeamsListItem from './list-item';
 
 const renderItems = ( teams, path ) =>
-	map( teams, team =>
+	map( teams, team => (
 		<ReaderSidebarTeamsListItem key={ team.slug } team={ team } path={ path } />
-	);
+	) );
 
 export class ReaderSidebarTeams extends Component {
 	static propTypes = {
@@ -27,11 +27,7 @@ export class ReaderSidebarTeams extends Component {
 			return null;
 		}
 
-		return (
-			<div>
-				{ renderItems( this.props.teams, this.props.path ) }
-			</div>
-		);
+		return <div>{ renderItems( this.props.teams, this.props.path ) }</div>;
 	}
 }
 

--- a/client/reader/sidebar/reader-sidebar-teams/list-item.jsx
+++ b/client/reader/sidebar/reader-sidebar-teams/list-item.jsx
@@ -2,6 +2,8 @@
 /**
  * External Dependencies
  */
+import PropTypes from 'prop-types';
+
 import React from 'react';
 import { localize } from 'i18n-calypso';
 
@@ -59,8 +61,8 @@ export const ReaderSidebarTeamsListItem = ( { path, team, translate } ) => {
 };
 
 ReaderSidebarTeamsListItem.propTypes = {
-	team: React.PropTypes.object.isRequired,
-	path: React.PropTypes.string.isRequired,
+	team: PropTypes.object.isRequired,
+	path: PropTypes.string.isRequired,
 };
 
 export default localize( ReaderSidebarTeamsListItem );

--- a/client/reader/sidebar/reader-sidebar-teams/list-item.jsx
+++ b/client/reader/sidebar/reader-sidebar-teams/list-item.jsx
@@ -1,14 +1,13 @@
 /** @format */
 /**
- * External Dependencies
+ * External dependencies
  */
-import PropTypes from 'prop-types';
-
-import React from 'react';
 import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 /**
- * Internal Dependencies
+ * Internal dependencies
  */
 import ReaderSidebarHelper from '../helper';
 import { recordAction, recordGaEvent, recordTrack } from 'reader/stats';

--- a/client/reader/sidebar/reader-sidebar-teams/list-item.jsx
+++ b/client/reader/sidebar/reader-sidebar-teams/list-item.jsx
@@ -50,9 +50,7 @@ export const ReaderSidebarTeamsListItem = ( { path, team, translate } ) => {
 						8.9zm6.9-9.5c0-3.3-2.4-6.3-6.8-6.3s-6.8 3-6.8 6.3v.4c0 3.3 2.4 6.4 6.8 6.4s6.8-3 6.8-6.4V12z" />
 					<path d="M14.1 8.5c.6.4.7 1.2.4 1.7l-2.9 4.6c-.4.6-1.2.8-1.7.4-.7-.4-.9-1.2-.5-1.8l2.9-4.6c.4-.5 1.2-.7 1.8-.3z" />
 				</svg>
-				<span className="menu-link-text">
-					{ team.title }
-				</span>
+				<span className="menu-link-text">{ team.title }</span>
 			</a>
 		</li>
 	);

--- a/client/reader/site-stream/featured.jsx
+++ b/client/reader/site-stream/featured.jsx
@@ -116,9 +116,7 @@ export default localize(
 								onClick={ this.handleClick.bind( this, postData ) }
 							>
 								<div className="reader__featured-post-image" style={ style } />
-								<h2 className="reader__featured-post-title">
-									{ post.title }
-								</h2>
+								<h2 className="reader__featured-post-title">{ post.title }</h2>
 							</div>
 						);
 				}
@@ -135,17 +133,13 @@ export default localize(
 			return (
 				<Card className="reader__featured-card">
 					<div className="reader__featured-header">
-						<div className="reader__featured-title">
-							{ this.props.translate( 'Highlights' ) }
-						</div>
+						<div className="reader__featured-title">{ this.props.translate( 'Highlights' ) }</div>
 						<div className="reader__featured-description">
 							{ this.props.translate( 'What we’re reading this week.' ) }
 						</div>
 					</div>
 
-					<div className="reader__featured-posts">
-						{ this.renderPosts() }
-					</div>
+					<div className="reader__featured-posts">{ this.renderPosts() }</div>
 				</Card>
 			);
 		}

--- a/client/reader/site-stream/index.jsx
+++ b/client/reader/site-stream/index.jsx
@@ -2,26 +2,25 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
-import React from 'react';
 import { localize } from 'i18n-calypso';
-import { connect } from 'react-redux';
 import page from 'page';
+import PropTypes from 'prop-types';
+import React from 'react';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
  */
-import DocumentHead from 'components/data/document-head';
-import RefreshFeedHeader from 'blocks/reader-feed-header';
 import EmptyContent from './empty';
-import Stream from 'reader/stream';
-import FeedError from 'reader/feed-error';
-import { getSite } from 'state/reader/sites/selectors';
-import { getFeed } from 'state/reader/feeds/selectors';
-import QueryReaderSite from 'components/data/query-reader-site';
-import QueryReaderFeed from 'components/data/query-reader-feed';
 import FeedFeatured from './featured';
+import RefreshFeedHeader from 'blocks/reader-feed-header';
+import DocumentHead from 'components/data/document-head';
+import QueryReaderFeed from 'components/data/query-reader-feed';
+import QueryReaderSite from 'components/data/query-reader-site';
+import FeedError from 'reader/feed-error';
+import Stream from 'reader/stream';
+import { getFeed } from 'state/reader/feeds/selectors';
+import { getSite } from 'state/reader/sites/selectors';
 
 class SiteStream extends React.Component {
 	static propTypes = {

--- a/client/reader/site-stream/index.jsx
+++ b/client/reader/site-stream/index.jsx
@@ -2,6 +2,8 @@
 /**
  * External dependencies
  */
+import PropTypes from 'prop-types';
+
 import React from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
@@ -23,11 +25,11 @@ import FeedFeatured from './featured';
 
 class SiteStream extends React.Component {
 	static propTypes = {
-		siteId: React.PropTypes.number.isRequired,
-		className: React.PropTypes.string,
-		showBack: React.PropTypes.bool,
-		isDiscoverStream: React.PropTypes.bool,
-		featuredStore: React.PropTypes.object,
+		siteId: PropTypes.number.isRequired,
+		className: PropTypes.string,
+		showBack: PropTypes.bool,
+		isDiscoverStream: PropTypes.bool,
+		featuredStore: PropTypes.object,
 	};
 
 	static defaultProps = {

--- a/client/reader/stream/empty.jsx
+++ b/client/reader/stream/empty.jsx
@@ -24,15 +24,15 @@ class FollowingEmptyContent extends React.Component {
 	};
 
 	render() {
-		const action = isDiscoverEnabled()
-				? <a
-						className="empty-content__action button is-primary"
-						onClick={ this.recordAction }
-						href="/read/search"
-					>
-						{ this.props.translate( 'Find Sites to Follow' ) }
-					</a>
-				: null,
+		const action = isDiscoverEnabled() ? (
+				<a
+					className="empty-content__action button is-primary"
+					onClick={ this.recordAction }
+					href="/read/search"
+				>
+					{ this.props.translate( 'Find Sites to Follow' ) }
+				</a>
+			) : null,
 			secondaryAction = null;
 
 		/* eslint-disable wpcalypso/jsx-classname-namespace */

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -1,51 +1,41 @@
-import ReactDom from 'react-dom';
-
 /** @format */
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
-import React from 'react';
 import classnames from 'classnames';
-import { defer, findLast, noop, times, clamp, identity, map } from 'lodash';
-import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
+import { defer, findLast, noop, times, clamp, identity, map } from 'lodash';
+import PropTypes from 'prop-types';
+import React from 'react';
+import ReactDom from 'react-dom';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
  */
-import ReaderMain from 'components/reader-main';
 import EmptyContent from './empty';
-import {
-	fetchNextPage,
-	selectFirstItem,
-	selectItem,
-	selectNextItem,
-	selectPrevItem,
-	showUpdates,
-	shufflePosts,
-} from 'lib/feed-stream-store/actions';
-import LikeStore from 'lib/like-store/like-store';
-import LikeStoreActions from 'lib/like-store/actions';
-import LikeHelper from 'reader/like-helper';
-import ListEnd from 'components/list-end';
-import InfiniteList from 'components/infinite-list';
-import MobileBackToSidebar from 'components/mobile-back-to-sidebar';
-import PostPlaceholder from './post-placeholder';
-import PostStore from 'lib/feed-post-store';
-import UpdateNotice from 'reader/update-notice';
-import KeyboardShortcuts from 'lib/keyboard-shortcuts';
-import scrollTo from 'lib/scroll-to';
-import XPostHelper from 'reader/xpost-helper';
 import PostLifecycle from './post-lifecycle';
-import { showSelectedPost } from 'reader/utils';
-import getBlockedSites from 'state/selectors/get-blocked-sites';
-import { getReaderFollows } from 'state/selectors';
-import { keysAreEqual } from 'lib/feed-stream-store/post-key';
-import { resetCardExpansions } from 'state/ui/reader/card-expansions/actions';
+import PostPlaceholder from './post-placeholder';
 import { combineCards, injectRecommendations, RECS_PER_BLOCK } from './utils';
+import InfiniteList from 'components/infinite-list';
+import ListEnd from 'components/list-end';
+import MobileBackToSidebar from 'components/mobile-back-to-sidebar';
+import ReaderMain from 'components/reader-main';
+import PostStore from 'lib/feed-post-store';
+import { fetchNextPage, selectFirstItem, selectItem, selectNextItem, selectPrevItem, showUpdates, shufflePosts } from 'lib/feed-stream-store/actions';
+import { keysAreEqual } from 'lib/feed-stream-store/post-key';
 import { keyToString, keyForPost } from 'lib/feed-stream-store/post-key';
+import KeyboardShortcuts from 'lib/keyboard-shortcuts';
+import LikeStoreActions from 'lib/like-store/actions';
+import LikeStore from 'lib/like-store/like-store';
+import scrollTo from 'lib/scroll-to';
+import LikeHelper from 'reader/like-helper';
+import UpdateNotice from 'reader/update-notice';
+import { showSelectedPost } from 'reader/utils';
+import XPostHelper from 'reader/xpost-helper';
+import { getReaderFollows } from 'state/selectors';
+import getBlockedSites from 'state/selectors/get-blocked-sites';
+import { resetCardExpansions } from 'state/ui/reader/card-expansions/actions';
 
 const GUESSED_POST_HEIGHT = 600;
 const HEADER_OFFSET_TOP = 46;

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -1,9 +1,12 @@
+import ReactDom from 'react-dom';
+
 /** @format */
 /**
  * External dependencies
  */
-import ReactDom from 'react-dom';
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import classnames from 'classnames';
 import { defer, findLast, noop, times, clamp, identity, map } from 'lodash';
 import { connect } from 'react-redux';

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -22,7 +22,15 @@ import ListEnd from 'components/list-end';
 import MobileBackToSidebar from 'components/mobile-back-to-sidebar';
 import ReaderMain from 'components/reader-main';
 import PostStore from 'lib/feed-post-store';
-import { fetchNextPage, selectFirstItem, selectItem, selectNextItem, selectPrevItem, showUpdates, shufflePosts } from 'lib/feed-stream-store/actions';
+import {
+	fetchNextPage,
+	selectFirstItem,
+	selectItem,
+	selectNextItem,
+	selectPrevItem,
+	showUpdates,
+	shufflePosts,
+} from 'lib/feed-stream-store/actions';
 import { keysAreEqual } from 'lib/feed-stream-store/post-key';
 import { keyToString, keyForPost } from 'lib/feed-stream-store/post-key';
 import KeyboardShortcuts from 'lib/keyboard-shortcuts';
@@ -468,12 +476,11 @@ class ReaderStream extends React.Component {
 		return (
 			<TopLevel className={ classnames( 'following', this.props.className ) }>
 				{ this.props.isMain &&
-					this.props.showMobileBackToSidebar &&
+				this.props.showMobileBackToSidebar && (
 					<MobileBackToSidebar>
-						<h1>
-							{ this.props.translate( 'Streams' ) }
-						</h1>
-					</MobileBackToSidebar> }
+						<h1>{ this.props.translate( 'Streams' ) }</h1>
+					</MobileBackToSidebar>
+				) }
 
 				<UpdateNotice count={ this.state.updateCount } onClick={ this.showUpdates } />
 				{ this.props.children }

--- a/client/reader/stream/post-lifecycle.jsx
+++ b/client/reader/stream/post-lifecycle.jsx
@@ -2,7 +2,9 @@
 /**
  * External Dependencies
  */
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import { defer, omit, includes } from 'lodash';
 
 /**

--- a/client/reader/stream/post-lifecycle.jsx
+++ b/client/reader/stream/post-lifecycle.jsx
@@ -1,30 +1,29 @@
 /** @format */
 /**
- * External Dependencies
+ * External dependencies
  */
-import PropTypes from 'prop-types';
-
-import React from 'react';
 import { defer, omit, includes } from 'lodash';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 /**
- * Internal Dependencies
+ * Internal dependencies
  */
-import PostStore from 'lib/feed-post-store';
-import PostStoreActions from 'lib/feed-post-store/actions';
+import EmptySearchRecommendedPost from './empty-search-recommended-post';
+import Post from './post';
 import PostPlaceholder from './post-placeholder';
 import PostUnavailable from './post-unavailable';
-import ListGap from 'reader/list-gap';
-import CrossPost from './x-post';
-import { shallowEquals } from 'reader/utils';
 import RecommendedPosts from './recommended-posts';
-import XPostHelper, { isXPost } from 'reader/xpost-helper';
-import PostBlocked from 'blocks/reader-post-card/blocked';
-import Post from './post';
-import { IN_STREAM_RECOMMENDATION } from 'reader/follow-button/follow-sources';
+import CrossPost from './x-post';
 import CombinedCard from 'blocks/reader-combined-card';
+import PostBlocked from 'blocks/reader-post-card/blocked';
+import PostStore from 'lib/feed-post-store';
+import PostStoreActions from 'lib/feed-post-store/actions';
 import fluxPostAdapter from 'lib/reader-post-flux-adapter';
-import EmptySearchRecommendedPost from './empty-search-recommended-post';
+import { IN_STREAM_RECOMMENDATION } from 'reader/follow-button/follow-sources';
+import ListGap from 'reader/list-gap';
+import { shallowEquals } from 'reader/utils';
+import XPostHelper, { isXPost } from 'reader/xpost-helper';
 
 const ConnectedCombinedCard = fluxPostAdapter( CombinedCard );
 

--- a/client/reader/stream/post-unavailable.jsx
+++ b/client/reader/stream/post-unavailable.jsx
@@ -42,14 +42,10 @@ class PostUnavailable extends React.PureComponent {
 				</div>
 
 				<div className="reader__post-excerpt">
-					<p>
-						{ errorMessage }
-					</p>
-					{ config.isEnabled( 'reader/full-errors' )
-						? <pre>
-								{ JSON.stringify( this.props.post, null, '  ' ) }
-							</pre>
-						: null }
+					<p>{ errorMessage }</p>
+					{ config.isEnabled( 'reader/full-errors' ) ? (
+						<pre>{ JSON.stringify( this.props.post, null, '  ' ) }</pre>
+					) : null }
 				</div>
 			</Card>
 		);

--- a/client/reader/stream/post.jsx
+++ b/client/reader/stream/post.jsx
@@ -93,8 +93,9 @@ class ReaderPostCardAdapter extends React.Component {
 			>
 				{ feedId && <QueryReaderFeed feedId={ feedId } includeMeta={ false } /> }
 				{ ! isExternal && siteId && <QueryReaderSite siteId={ +siteId } includeMeta={ false } /> }
-				{ discoverPickSiteId &&
-					<QueryReaderSite siteId={ discoverPickSiteId } includeMeta={ false } /> }
+				{ discoverPickSiteId && (
+					<QueryReaderSite siteId={ discoverPickSiteId } includeMeta={ false } />
+				) }
 			</ReaderPostCard>
 		);
 	}

--- a/client/reader/stream/recommended-posts.jsx
+++ b/client/reader/stream/recommended-posts.jsx
@@ -2,7 +2,9 @@
 /**
  * External Dependencies
  */
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import { map, partial, some } from 'lodash';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'gridicons';

--- a/client/reader/stream/recommended-posts.jsx
+++ b/client/reader/stream/recommended-posts.jsx
@@ -1,22 +1,21 @@
 /** @format */
 /**
- * External Dependencies
+ * External dependencies
  */
-import PropTypes from 'prop-types';
-
-import React from 'react';
-import { map, partial, some } from 'lodash';
-import { localize } from 'i18n-calypso';
 import Gridicon from 'gridicons';
+import { localize } from 'i18n-calypso';
+import { map, partial, some } from 'lodash';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 /**
- * Internal Dependencies
+ * Internal dependencies
  */
 import { RelatedPostCard } from 'blocks/reader-related-card-v2';
-import PostStore from 'lib/feed-post-store';
-import { recordAction, recordTrackForPost } from 'reader/stats';
 import Button from 'components/button';
+import PostStore from 'lib/feed-post-store';
 import { dismissPost } from 'lib/feed-stream-store/actions';
+import { recordAction, recordTrackForPost } from 'reader/stats';
 
 function dismissRecommendation( uiIndex, storeId, post ) {
 	recordTrackForPost( 'calypso_reader_recommended_post_dismissed', post, {

--- a/client/reader/stream/x-post.jsx
+++ b/client/reader/stream/x-post.jsx
@@ -1,27 +1,26 @@
 /** @format */
 /**
- * External Dependencies
+ * External dependencies
  */
+import classnames from 'classnames';
+import closest from 'component-closest';
+import { localize } from 'i18n-calypso';
+import { get } from 'lodash';
 import PropTypes from 'prop-types';
-
 import React, { PureComponent } from 'react';
 import ReactDom from 'react-dom';
-import classnames from 'classnames';
-import url from 'url';
-import { localize } from 'i18n-calypso';
-import closest from 'component-closest';
-import { get } from 'lodash';
 import { connect } from 'react-redux';
 
 /**
- * Internal Dependencies
+ * Internal dependencies
  */
-import Card from 'components/card';
 import ReaderAvatar from 'blocks/reader-avatar';
-import { getSite } from 'state/reader/sites/selectors';
-import { getFeed } from 'state/reader/feeds/selectors';
-import QueryReaderSite from 'components/data/query-reader-site';
+import Card from 'components/card';
 import QueryReaderFeed from 'components/data/query-reader-feed';
+import QueryReaderSite from 'components/data/query-reader-site';
+import { getFeed } from 'state/reader/feeds/selectors';
+import { getSite } from 'state/reader/sites/selectors';
+import url from 'url';
 
 class CrossPost extends PureComponent {
 	static propTypes = {

--- a/client/reader/stream/x-post.jsx
+++ b/client/reader/stream/x-post.jsx
@@ -2,6 +2,8 @@
 /**
  * External Dependencies
  */
+import PropTypes from 'prop-types';
+
 import React, { PureComponent } from 'react';
 import ReactDom from 'react-dom';
 import classnames from 'classnames';
@@ -23,15 +25,15 @@ import QueryReaderFeed from 'components/data/query-reader-feed';
 
 class CrossPost extends PureComponent {
 	static propTypes = {
-		post: React.PropTypes.object.isRequired,
-		isSelected: React.PropTypes.bool.isRequired,
-		xMetadata: React.PropTypes.object.isRequired,
-		xPostedTo: React.PropTypes.array,
-		handleClick: React.PropTypes.func.isRequired,
-		translate: React.PropTypes.func.isRequired,
-		postKey: React.PropTypes.object,
-		site: React.PropTypes.object,
-		feed: React.PropTypes.object,
+		post: PropTypes.object.isRequired,
+		isSelected: PropTypes.bool.isRequired,
+		xMetadata: PropTypes.object.isRequired,
+		xPostedTo: PropTypes.array,
+		handleClick: PropTypes.func.isRequired,
+		translate: PropTypes.func.isRequired,
+		postKey: PropTypes.object,
+		site: PropTypes.object,
+		feed: PropTypes.object,
 	};
 
 	handleTitleClick = event => {

--- a/client/reader/stream/x-post.jsx
+++ b/client/reader/stream/x-post.jsx
@@ -135,14 +135,15 @@ class CrossPost extends PureComponent {
 				<span className="reader__x-post-site" key={ xPostedTo.siteURL + '-' + index }>
 					{ xPostedTo.siteName }
 					{ index + 2 < array.length && <span>, </span> }
-					{ index + 2 === array.length &&
+					{ index + 2 === array.length && (
 						<span>
 							{' '}
 							{ this.props.translate( 'and', {
 								comment:
 									'last conjunction in a list of blognames: (blog1, blog2,) blog3 _and_ blog4',
 							} ) }{' '}
-						</span> }
+						</span>
+					) }
 				</span>
 			);
 		} );
@@ -175,7 +176,7 @@ class CrossPost extends PureComponent {
 					isCompact={ true }
 				/>
 				<div className="reader__x-post">
-					{ post.title &&
+					{ post.title && (
 						<h1 className="reader__post-title">
 							<a
 								className="reader__post-title-link"
@@ -186,7 +187,8 @@ class CrossPost extends PureComponent {
 							>
 								{ xpostTitle }
 							</a>
-						</h1> }
+						</h1>
+					) }
 					{ this.getDescription( post.author.first_name ) }
 				</div>
 				{ feedId && <QueryReaderFeed feedId={ +feedId } includeMeta={ false } /> }

--- a/client/reader/tag-stream/empty.jsx
+++ b/client/reader/tag-stream/empty.jsx
@@ -2,6 +2,8 @@
 /**
  * External dependencies
  */
+import PropTypes from 'prop-types';
+
 import React from 'react';
 import { localize } from 'i18n-calypso';
 
@@ -14,7 +16,7 @@ import { isDiscoverEnabled } from 'reader/discover/helper';
 
 class TagEmptyContent extends React.Component {
 	static propTypes = {
-		decodedTagSlug: React.PropTypes.string,
+		decodedTagSlug: PropTypes.string,
 	};
 
 	shouldComponentUpdate() {

--- a/client/reader/tag-stream/empty.jsx
+++ b/client/reader/tag-stream/empty.jsx
@@ -2,17 +2,16 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
-import React from 'react';
 import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 /**
  * Internal dependencies
  */
 import EmptyContent from 'components/empty-content';
-import { recordAction, recordGaEvent, recordTrack } from 'reader/stats';
 import { isDiscoverEnabled } from 'reader/discover/helper';
+import { recordAction, recordGaEvent, recordTrack } from 'reader/stats';
 
 class TagEmptyContent extends React.Component {
 	static propTypes = {

--- a/client/reader/tag-stream/empty.jsx
+++ b/client/reader/tag-stream/empty.jsx
@@ -41,25 +41,21 @@ class TagEmptyContent extends React.Component {
 			</a>
 		);
 
-		const secondaryAction = isDiscoverEnabled()
-			? <a
-					className="empty-content__action button"
-					onClick={ this.recordSecondaryAction }
-					href="/discover"
-				>
-					{ this.props.translate( 'Explore Discover' ) }
-				</a>
-			: null;
+		const secondaryAction = isDiscoverEnabled() ? (
+			<a
+				className="empty-content__action button"
+				onClick={ this.recordSecondaryAction }
+				href="/discover"
+			>
+				{ this.props.translate( 'Explore Discover' ) }
+			</a>
+		) : null;
 
 		const message = this.props.translate(
 			'No posts have recently been tagged with {{tagName /}} for your language.',
 			{
 				components: {
-					tagName: (
-						<em>
-							{ this.props.decodedTagSlug }
-						</em>
-					),
+					tagName: <em>{ this.props.decodedTagSlug }</em>,
 				},
 			}
 		);

--- a/client/reader/tag-stream/header.jsx
+++ b/client/reader/tag-stream/header.jsx
@@ -2,24 +2,23 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
-import React from 'react';
 import classnames from 'classnames';
-import { localize } from 'i18n-calypso';
-import { connect } from 'react-redux';
-import { sample } from 'lodash';
 import Gridicon from 'gridicons';
+import { localize } from 'i18n-calypso';
+import { sample } from 'lodash';
+import PropTypes from 'prop-types';
+import React from 'react';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
  */
 import FollowButton from 'blocks/follow-button/button';
 import QueryReaderTagImages from 'components/data/query-reader-tag-images';
-import { getTagImages } from 'state/reader/tags/images/selectors';
-import resizeImageUrl from 'lib/resize-image-url';
 import cssSafeUrl from 'lib/css-safe-url';
 import { decodeEntities } from 'lib/formatting';
+import resizeImageUrl from 'lib/resize-image-url';
+import { getTagImages } from 'state/reader/tags/images/selectors';
 
 const TAG_HEADER_WIDTH = 800;
 const TAG_HEADER_HEIGHT = 140;

--- a/client/reader/tag-stream/header.jsx
+++ b/client/reader/tag-stream/header.jsx
@@ -2,6 +2,8 @@
 /**
  * External dependencies
  */
+import PropTypes from 'prop-types';
+
 import React from 'react';
 import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
@@ -24,12 +26,12 @@ const TAG_HEADER_HEIGHT = 140;
 
 class TagStreamHeader extends React.Component {
 	static propTypes = {
-		isPlaceholder: React.PropTypes.bool,
-		showFollow: React.PropTypes.bool,
-		following: React.PropTypes.bool,
-		onFollowToggle: React.PropTypes.func,
-		tagImages: React.PropTypes.array,
-		showBack: React.PropTypes.bool,
+		isPlaceholder: PropTypes.bool,
+		showFollow: PropTypes.bool,
+		following: PropTypes.bool,
+		onFollowToggle: PropTypes.func,
+		tagImages: PropTypes.array,
+		showBack: PropTypes.bool,
 	};
 
 	static defaultProps = {

--- a/client/reader/tag-stream/header.jsx
+++ b/client/reader/tag-stream/header.jsx
@@ -95,7 +95,7 @@ class TagStreamHeader extends React.Component {
 		return (
 			<div className={ classes }>
 				<QueryReaderTagImages tag={ imageSearchString } />
-				{ showFollow &&
+				{ showFollow && (
 					<div className="tag-stream__header-follow">
 						<FollowButton
 							followLabel={ translate( 'Follow Tag' ) }
@@ -104,14 +104,15 @@ class TagStreamHeader extends React.Component {
 							following={ following }
 							onFollowToggle={ onFollowToggle }
 						/>
-					</div> }
+					</div>
+				) }
 
 				<div className="tag-stream__header-image" style={ imageStyle }>
 					<h1 className="tag-stream__header-image-title">
 						<Gridicon icon="tag" size={ 24 } />
 						{ title }
 					</h1>
-					{ tagImage &&
+					{ tagImage && (
 						<div className="tag-stream__header-image-byline">
 							{ translate( '{{photoByWrapper}}Photo by{{/photoByWrapper}} {{authorLink/}}', {
 								components: {
@@ -119,7 +120,8 @@ class TagStreamHeader extends React.Component {
 									authorLink,
 								},
 							} ) }
-						</div> }
+						</div>
+					) }
 				</div>
 			</div>
 		);

--- a/client/reader/tag-stream/main.jsx
+++ b/client/reader/tag-stream/main.jsx
@@ -2,6 +2,8 @@
 /**
  * External Dependencies
  */
+import PropTypes from 'prop-types';
+
 import React from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
@@ -23,9 +25,9 @@ import QueryReaderTag from 'components/data/query-reader-tag';
 
 class TagStream extends React.Component {
 	static propTypes = {
-		encodedTagSlug: React.PropTypes.string,
-		decodedTagSlug: React.PropTypes.string,
-		followSource: React.PropTypes.string.isRequired,
+		encodedTagSlug: PropTypes.string,
+		decodedTagSlug: PropTypes.string,
+		followSource: PropTypes.string.isRequired,
 	};
 
 	state = {

--- a/client/reader/tag-stream/main.jsx
+++ b/client/reader/tag-stream/main.jsx
@@ -1,27 +1,26 @@
 /** @format */
 /**
- * External Dependencies
+ * External dependencies
  */
-import PropTypes from 'prop-types';
-
-import React from 'react';
 import { localize } from 'i18n-calypso';
-import { connect } from 'react-redux';
 import { find } from 'lodash';
+import PropTypes from 'prop-types';
+import React from 'react';
+import { connect } from 'react-redux';
 
 /**
- * Internal Dependencies
+ * Internal dependencies
  */
-import Stream from 'reader/stream';
-import DocumentHead from 'components/data/document-head';
 import EmptyContent from './empty';
 import TagStreamHeader from './header';
-import { recordAction, recordGaEvent, recordTrack } from 'reader/stats';
-import HeaderBack from 'reader/header-back';
-import { getReaderFollowedTags, getReaderTags } from 'state/selectors';
-import { requestFollowTag, requestUnfollowTag } from 'state/reader/tags/items/actions';
+import DocumentHead from 'components/data/document-head';
 import QueryReaderFollowedTags from 'components/data/query-reader-followed-tags';
 import QueryReaderTag from 'components/data/query-reader-tag';
+import HeaderBack from 'reader/header-back';
+import { recordAction, recordGaEvent, recordTrack } from 'reader/stats';
+import Stream from 'reader/stream';
+import { requestFollowTag, requestUnfollowTag } from 'state/reader/tags/items/actions';
+import { getReaderFollowedTags, getReaderTags } from 'state/selectors';
 
 class TagStream extends React.Component {
 	static propTypes = {

--- a/client/reader/update-notice/index.jsx
+++ b/client/reader/update-notice/index.jsx
@@ -2,6 +2,8 @@
 /**
  * External Dependencies
  */
+import PropTypes from 'prop-types';
+
 import React from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
@@ -17,10 +19,10 @@ import { getDocumentHeadCappedUnreadCount } from 'state/document-head/selectors'
 
 class UpdateNotice extends React.PureComponent {
 	static propTypes = {
-		count: React.PropTypes.number.isRequired,
-		onClick: React.PropTypes.func,
+		count: PropTypes.number.isRequired,
+		onClick: PropTypes.func,
 		// connected props
-		cappedUnreadCount: React.PropTypes.string,
+		cappedUnreadCount: PropTypes.string,
 	};
 
 	static defaultProps = { onClick: noop };

--- a/client/reader/update-notice/index.jsx
+++ b/client/reader/update-notice/index.jsx
@@ -1,15 +1,14 @@
 /** @format */
 /**
- * External Dependencies
+ * External dependencies
  */
-import PropTypes from 'prop-types';
-
-import React from 'react';
-import { localize } from 'i18n-calypso';
-import { connect } from 'react-redux';
-import { noop } from 'lodash';
 import classnames from 'classnames';
 import Gridicon from 'gridicons';
+import { localize } from 'i18n-calypso';
+import { noop } from 'lodash';
+import PropTypes from 'prop-types';
+import React from 'react';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies


### PR DESCRIPTION
How I made this pr

1. codemod for removing React.PropTypes from `client/reader`
2. run sort imports twice on `client/reader`
3. ran prettier on `client/reader/**/*.jsx`.  Note I didn't realize we hadn't rerun prettier since the 1.6 upgrade so there are more changes than just in the imports