### PR TITLE
Prettier: Reformat Files

### DIFF
--- a/client/blocks/comments/comment-actions.jsx
+++ b/client/blocks/comments/comment-actions.jsx
@@ -50,7 +50,7 @@ const CommentActions = ( {
 
 	return (
 		<div className="comments__comment-actions">
-			{ showReadMore &&
+			{ showReadMore && (
 				<button className="comments__comment-actions-read-more" onClick={ onReadMore }>
 					<Gridicon
 						icon="chevron-down"
@@ -58,22 +58,24 @@ const CommentActions = ( {
 						className="comments__comment-actions-read-more-icon"
 					/>
 					{ translate( 'Read More' ) }
-				</button> }
-			{ showReplyButton &&
+				</button>
+			) }
+			{ showReplyButton && (
 				<button className="comments__comment-actions-reply" onClick={ handleReply }>
 					<Gridicon icon="reply" size={ 18 } />
-					<span className="comments__comment-actions-reply-label">
-						{ translate( 'Reply' ) }
-					</span>
-				</button> }
-			{ showCancelReplyButton &&
+					<span className="comments__comment-actions-reply-label">{ translate( 'Reply' ) }</span>
+				</button>
+			) }
+			{ showCancelReplyButton && (
 				<button className="comments__comment-actions-cancel-reply" onClick={ onReplyCancel }>
 					{ translate( 'Cancel reply' ) }
-				</button> }
-			{ showCancelEditButton &&
+				</button>
+			) }
+			{ showCancelEditButton && (
 				<button className="comments__comment-actions-cancel-reply" onClick={ editCommentCancel }>
 					{ translate( 'Cancel' ) }
-				</button> }
+				</button>
+			) }
 			<CommentLikeButtonContainer
 				className="comments__comment-actions-like"
 				tagName="button"
@@ -81,26 +83,20 @@ const CommentActions = ( {
 				postId={ post.ID }
 				commentId={ commentId }
 			/>
-			{ showModerationTools &&
+			{ showModerationTools && (
 				<div className="comments__comment-actions-moderation-tools">
 					<CommentApproveAction { ...{ status, approveComment, unapproveComment } } />
 					<button className="comments__comment-actions-trash" onClick={ trashComment }>
 						<Gridicon icon="trash" size={ 18 } />
-						<span className="comments__comment-actions-like-label">
-							{ translate( 'Trash' ) }
-						</span>
+						<span className="comments__comment-actions-like-label">{ translate( 'Trash' ) }</span>
 					</button>
 					<button className="comments__comment-actions-spam" onClick={ spamComment }>
 						<Gridicon icon="spam" size={ 18 } />
-						<span className="comments__comment-actions-like-label">
-							{ translate( 'Spam' ) }
-						</span>
+						<span className="comments__comment-actions-like-label">{ translate( 'Spam' ) }</span>
 					</button>
 					<button className="comments__comment-actions-edit" onClick={ editComment }>
 						<Gridicon icon="pencil" size={ 18 } />
-						<span className="comments__comment-actions-like-label">
-							{ translate( 'Edit' ) }
-						</span>
+						<span className="comments__comment-actions-like-label">{ translate( 'Edit' ) }</span>
 					</button>
 					<EllipsisMenu toggleTitle={ translate( 'More' ) }>
 						<PopoverMenuItem
@@ -123,7 +119,8 @@ const CommentActions = ( {
 							{ translate( 'Edit' ) }
 						</PopoverMenuItem>
 					</EllipsisMenu>
-				</div> }
+				</div>
+			) }
 		</div>
 	);
 };

--- a/client/blocks/comments/post-comment.jsx
+++ b/client/blocks/comments/post-comment.jsx
@@ -197,13 +197,14 @@ class PostComment extends React.PureComponent {
 
 		return (
 			<div>
-				{ !! replyVisibilityText &&
+				{ !! replyVisibilityText && (
 					<button className="comments__view-replies-btn" onClick={ this.handleToggleRepliesClick }>
 						<Gridicon icon="reply" size={ 18 } /> { replyVisibilityText }
-					</button> }
-				{ showReplies &&
+					</button>
+				) }
+				{ showReplies && (
 					<ol className="comments__list">
-						{ commentChildrenIds.map( childId =>
+						{ commentChildrenIds.map( childId => (
 							<ConnectedPostComment
 								showNestingReplyArrow={ this.props.showNestingReplyArrow }
 								showReadMoreInActions={ this.props.showReadMoreInActions }
@@ -223,8 +224,9 @@ class PostComment extends React.PureComponent {
 								onUpdateCommentText={ this.props.onUpdateCommentText }
 								onCommentSubmit={ this.props.resetActiveReplyComment }
 							/>
-						) }
-					</ol> }
+						) ) }
+					</ol>
+				) }
 			</div>
 		);
 	}
@@ -257,22 +259,20 @@ class PostComment extends React.PureComponent {
 	};
 
 	renderAuthorTag = ( { authorName, authorUrl, commentId, className } ) => {
-		return !! authorUrl
-			? <a
-					href={ authorUrl }
-					className={ className }
-					onClick={ this.handleAuthorClick }
-					id={ `comment-${ commentId }` }
-				>
-					<Emojify>
-						{ authorName }
-					</Emojify>
-				</a>
-			: <strong className={ className } id={ `comment-${ commentId }` }>
-					<Emojify>
-						{ authorName }
-					</Emojify>
-				</strong>;
+		return !! authorUrl ? (
+			<a
+				href={ authorUrl }
+				className={ className }
+				onClick={ this.handleAuthorClick }
+				id={ `comment-${ commentId }` }
+			>
+				<Emojify>{ authorName }</Emojify>
+			</a>
+		) : (
+			<strong className={ className } id={ `comment-${ commentId }` }>
+				<Emojify>{ authorName }</Emojify>
+			</strong>
+		);
 	};
 
 	onReadMore = () => {
@@ -306,12 +306,7 @@ class PostComment extends React.PureComponent {
 			return null;
 		} else if ( commentsToShow && ! commentsToShow[ commentId ] ) {
 			// this comment should be hidden so just render children
-			return (
-				this.shouldRenderReplies() &&
-				<div>
-					{ this.renderRepliesList() }
-				</div>
-			);
+			return this.shouldRenderReplies() && <div>{ this.renderRepliesList() }</div>;
 		}
 
 		const displayType =
@@ -360,11 +355,13 @@ class PostComment extends React.PureComponent {
 		return (
 			<li className={ postCommentClassnames }>
 				<div className="comments__comment-author">
-					{ commentAuthorUrl
-						? <a href={ commentAuthorUrl } onClick={ this.handleAuthorClick }>
-								<Gravatar user={ comment.author } />
-							</a>
-						: <Gravatar user={ comment.author } /> }
+					{ commentAuthorUrl ? (
+						<a href={ commentAuthorUrl } onClick={ this.handleAuthorClick }>
+							<Gravatar user={ comment.author } />
+						</a>
+					) : (
+						<Gravatar user={ comment.author } />
+					) }
 
 					{ this.renderAuthorTag( {
 						authorUrl: commentAuthorUrl,
@@ -373,7 +370,7 @@ class PostComment extends React.PureComponent {
 						className: 'comments__comment-username',
 					} ) }
 					{ this.props.showNestingReplyArrow &&
-						parentAuthorName &&
+					parentAuthorName && (
 						<span className="comments__comment-respondee">
 							<Gridicon icon="chevron-right" size={ 16 } />
 							{ this.renderAuthorTag( {
@@ -382,7 +379,8 @@ class PostComment extends React.PureComponent {
 								authorUrl: parentAuthorUrl,
 								commentId: parentCommentId,
 							} ) }
-						</span> }
+						</span>
+					) }
 					<div className="comments__comment-timestamp">
 						<a href={ comment.URL }>
 							<PostTime date={ comment.date } />
@@ -390,28 +388,30 @@ class PostComment extends React.PureComponent {
 					</div>
 				</div>
 
-				{ comment.status && comment.status === 'unapproved'
-					? <p className="comments__comment-moderation">
-							{ translate( 'Your comment is awaiting moderation.' ) }
-						</p>
-					: null }
+				{ comment.status && comment.status === 'unapproved' ? (
+					<p className="comments__comment-moderation">
+						{ translate( 'Your comment is awaiting moderation.' ) }
+					</p>
+				) : null }
 
-				{ this.props.activeEditCommentId !== this.props.commentId &&
+				{ this.props.activeEditCommentId !== this.props.commentId && (
 					<PostCommentContent
 						content={ comment.content }
 						setWithDimensionsRef={ this.props.setWithDimensionsRef }
 						isPlaceholder={ comment.isPlaceholder }
 						className={ displayType }
-					/> }
+					/>
+				) }
 
 				{ isEnabled( 'comments/moderation-tools-in-posts' ) &&
-					this.props.activeEditCommentId === this.props.commentId &&
+				this.props.activeEditCommentId === this.props.commentId && (
 					<CommentEditForm
 						post={ this.props.post }
 						commentId={ this.props.commentId }
 						commentText={ comment.content }
 						onCommentSubmit={ this.props.onEditCommentCancel }
-					/> }
+					/>
+				) }
 
 				<CommentActions
 					post={ this.props.post || {} }
@@ -429,12 +429,13 @@ class PostComment extends React.PureComponent {
 				/>
 
 				{ haveReplyWithError ? null : this.renderCommentForm() }
-				{ this.shouldRenderCaterpillar() &&
+				{ this.shouldRenderCaterpillar() && (
 					<ConversationCaterpillar
 						blogId={ post.site_ID }
 						postId={ post.ID }
 						parentCommentId={ commentId }
-					/> }
+					/>
+				) }
 				{ this.renderRepliesList() }
 			</li>
 		);

--- a/client/blocks/conversation-caterpillar/index.jsx
+++ b/client/blocks/conversation-caterpillar/index.jsx
@@ -124,32 +124,36 @@ class ConversationCaterpillarComponent extends React.Component {
 				<button
 					className="conversation-caterpillar__count"
 					title={
-						commentCount > 1
-							? translate( 'View comments from %(commenterName)s and %(count)d more', {
-									args: {
-										commenterName: lastAuthorName,
-										count: commentCount - 1,
-									},
-								} )
-							: translate( 'View comment from %(commenterName)s', {
-									args: {
-										commenterName: lastAuthorName,
-									},
-								} )
-					}
-				>
-					{ commentCount > 1
-						? translate( '%(commenterName)s and %(count)d more', {
+						commentCount > 1 ? (
+							translate( 'View comments from %(commenterName)s and %(count)d more', {
 								args: {
 									commenterName: lastAuthorName,
 									count: commentCount - 1,
 								},
 							} )
-						: translate( '%(commenterName)s commented', {
+						) : (
+							translate( 'View comment from %(commenterName)s', {
 								args: {
 									commenterName: lastAuthorName,
 								},
-							} ) }
+							} )
+						)
+					}
+				>
+					{ commentCount > 1 ? (
+						translate( '%(commenterName)s and %(count)d more', {
+							args: {
+								commenterName: lastAuthorName,
+								count: commentCount - 1,
+							},
+						} )
+					) : (
+						translate( '%(commenterName)s commented', {
+							args: {
+								commenterName: lastAuthorName,
+							},
+						} )
+					) }
 				</button>
 				<button onClick={ this.handleShowAll } className="conversation-caterpillar__show-all">
 					<Gridicon

--- a/client/blocks/conversations/list.jsx
+++ b/client/blocks/conversations/list.jsx
@@ -120,8 +120,9 @@ export class ConversationCommentList extends React.Component {
 		return (
 			<div className="conversations__comment-list">
 				<ul className="conversations__comment-list-ul">
-					{ showCaterpillar &&
-						<ConversationCaterpillar blogId={ post.site_ID } postId={ post.ID } /> }
+					{ showCaterpillar && (
+						<ConversationCaterpillar blogId={ post.site_ID } postId={ post.ID } />
+					) }
 					{ map( commentsTree.children, commentId => {
 						return (
 							<PostComment
@@ -147,14 +148,15 @@ export class ConversationCommentList extends React.Component {
 							/>
 						);
 					} ) }
-					{ ! this.state.activeReplyCommentId &&
+					{ ! this.state.activeReplyCommentId && (
 						<PostCommentForm
 							ref="postCommentForm"
 							post={ post }
 							parentCommentId={ null }
 							commentText={ this.state.commentText }
 							onUpdateCommentText={ this.onUpdateCommentText }
-						/> }
+						/>
+					) }
 				</ul>
 			</div>
 		);

--- a/client/blocks/daily-post-button/index.jsx
+++ b/client/blocks/daily-post-button/index.jsx
@@ -130,12 +130,7 @@ export class DailyPostButton extends React.Component {
 		return (
 			<SitesPopover
 				key="menu"
-				header={
-					<div>
-						{' '}
-						{ translate( 'Post on' ) }{' '}
-					</div>
-				}
+				header={ <div> { translate( 'Post on' ) } </div> }
 				context={ this.refs && this.refs.dailyPostButton }
 				visible={ this.state.showingMenu }
 				groups={ true }
@@ -170,9 +165,7 @@ export class DailyPostButton extends React.Component {
 			[
 				<Button ref="dailyPostButton" key="button" compact primary className={ buttonClasses }>
 					<Gridicon icon="create" />
-					<span>
-						{ translate( 'Post about %(title)s', { args: { title } } ) }{' '}
-					</span>
+					<span>{ translate( 'Post about %(title)s', { args: { title } } ) } </span>
 				</Button>,
 				this.state.showingMenu ? this.renderSitesPopover() : null,
 			]

--- a/client/blocks/reader-author-link/index.jsx
+++ b/client/blocks/reader-author-link/index.jsx
@@ -41,18 +41,14 @@ const ReaderAuthorLink = ( { author, post, siteUrl, children, className, onClick
 	if ( ! siteUrl ) {
 		return (
 			<span className={ classes }>
-				<Emojify>
-					{ children }
-				</Emojify>
+				<Emojify>{ children }</Emojify>
 			</span>
 		);
 	}
 
 	return (
 		<a className={ classes } href={ siteUrl } onClick={ recordAuthorClick }>
-			<Emojify>
-				{ children }
-			</Emojify>
+			<Emojify>{ children }</Emojify>
 		</a>
 	);
 };

--- a/client/blocks/reader-author-link/test/index.jsx
+++ b/client/blocks/reader-author-link/test/index.jsx
@@ -66,12 +66,16 @@ describe( 'ReaderAuthorLink', () => {
 				xyz
 			</ReaderAuthorLink>
 		);
-		expect( wrapper.find( '.reader-author-link' ) ).to.have.prop( 'href' ).equal( siteUrl );
+		expect( wrapper.find( '.reader-author-link' ) )
+			.to.have.prop( 'href' )
+			.equal( siteUrl );
 	} );
 
 	it( 'should use author.URL if site URL is not provided', () => {
 		const wrapper = shallow( <ReaderAuthorLink author={ author }>xyz</ReaderAuthorLink> );
-		expect( wrapper.find( '.reader-author-link' ) ).to.have.prop( 'href' ).equal( author.URL );
+		expect( wrapper.find( '.reader-author-link' ) )
+			.to.have.prop( 'href' )
+			.equal( author.URL );
 	} );
 
 	it( 'should not return a link if siteUrl and author.URL are both missing', () => {

--- a/client/blocks/reader-avatar/index.jsx
+++ b/client/blocks/reader-avatar/index.jsx
@@ -87,20 +87,17 @@ const ReaderAvatar = ( {
 		'has-gravatar': hasAvatar || showPlaceholder,
 	} );
 
-	const siteIconElement =
-		hasSiteIcon && <SiteIcon key="site-icon" size={ siteIconSize } site={ fakeSite } />;
-	const avatarElement =
-		( hasAvatar || showPlaceholder ) &&
-		<Gravatar key="author-avatar" user={ author } size={ gravatarSize } />;
+	const siteIconElement = hasSiteIcon && (
+		<SiteIcon key="site-icon" size={ siteIconSize } site={ fakeSite } />
+	);
+	const avatarElement = ( hasAvatar || showPlaceholder ) && (
+		<Gravatar key="author-avatar" user={ author } size={ gravatarSize } />
+	);
 	const iconElements = [ siteIconElement, avatarElement ];
 
 	return (
 		<div className={ classes } onClick={ onClick } aria-hidden="true">
-			{ siteUrl
-				? <a href={ siteUrl }>
-						{ iconElements }
-					</a>
-				: iconElements }
+			{ siteUrl ? <a href={ siteUrl }>{ iconElements }</a> : iconElements }
 		</div>
 	);
 };

--- a/client/blocks/reader-combined-card/index.jsx
+++ b/client/blocks/reader-combined-card/index.jsx
@@ -113,11 +113,12 @@ class ReaderCombinedCard extends React.Component {
 						</p>
 					</div>
 					{ this.props.showFollowButton &&
-						followUrl &&
-						<FollowButton siteUrl={ followUrl } followSource={ this.props.followSource } /> }
+					followUrl && (
+						<FollowButton siteUrl={ followUrl } followSource={ this.props.followSource } />
+					) }
 				</header>
 				<ul className="reader-combined-card__post-list">
-					{ posts.map( post =>
+					{ posts.map( post => (
 						<ReaderCombinedCardPost
 							key={ `post-${ post.ID }` }
 							post={ post }
@@ -127,7 +128,7 @@ class ReaderCombinedCard extends React.Component {
 							isSelected={ isSelectedPost( post ) }
 							showFeaturedAsset={ mediaCount > 0 }
 						/>
-					) }
+					) ) }
 				</ul>
 				{ feedId && <QueryReaderFeed feedId={ +feedId } includeMeta={ false } /> }
 				{ siteId && <QueryReaderSite siteId={ +siteId } includeMeta={ false } /> }

--- a/client/blocks/reader-combined-card/post.jsx
+++ b/client/blocks/reader-combined-card/post.jsx
@@ -117,17 +117,14 @@ class ReaderCombinedCardPost extends React.Component {
 
 		return (
 			<li className={ classes } onClick={ this.handleCardClick }>
-				{ this.props.showFeaturedAsset &&
-					<div className="reader-combined-card__featured-asset-wrapper">
-						{ featuredAsset }
-					</div> }
+				{ this.props.showFeaturedAsset && (
+					<div className="reader-combined-card__featured-asset-wrapper">{ featuredAsset }</div>
+				) }
 				<div className="reader-combined-card__post-details">
 					<AutoDirection>
 						<h1 className="reader-combined-card__post-title">
 							<a className="reader-combined-card__post-title-link" href={ post.URL }>
-								<Emojify>
-									{ post.title }
-								</Emojify>
+								<Emojify>{ post.title }</Emojify>
 							</a>
 						</h1>
 					</AutoDirection>
@@ -136,7 +133,7 @@ class ReaderCombinedCardPost extends React.Component {
 						<ReaderVisitLink href={ post.URL } iconSize={ 14 }>
 							{ this.props.translate( 'Visit' ) }
 						</ReaderVisitLink>
-						{ hasAuthorName &&
+						{ hasAuthorName && (
 							<ReaderAuthorLink
 								className="reader-combined-card__author-link"
 								author={ post.author }
@@ -144,9 +141,10 @@ class ReaderCombinedCardPost extends React.Component {
 								post={ post }
 							>
 								{ post.author.name }
-							</ReaderAuthorLink> }
+							</ReaderAuthorLink>
+						) }
 						{ post.date &&
-							post.URL &&
+						post.URL && (
 							<span className="reader-combined-card__timestamp">
 								{ hasAuthorName && <span>, </span> }
 								<a
@@ -158,7 +156,8 @@ class ReaderCombinedCardPost extends React.Component {
 								>
 									<PostTime date={ post.date } />
 								</a>
-							</span> }
+							</span>
+						) }
 					</div>
 				</div>
 			</li>

--- a/client/blocks/reader-email-settings/index.jsx
+++ b/client/blocks/reader-email-settings/index.jsx
@@ -112,7 +112,7 @@ class ReaderEmailSettings extends Component {
 						{ translate( 'New posts' ) }
 						<FormToggle onChange={ this.toggleNewPostEmail } checked={ notifyOnNewPosts } />
 					</div>
-					{ notifyOnNewPosts &&
+					{ notifyOnNewPosts && (
 						<SegmentedControl>
 							<ControlItem
 								selected={ this.state.selected === 'instantly' }
@@ -132,7 +132,8 @@ class ReaderEmailSettings extends Component {
 							>
 								{ translate( 'Weekly' ) }
 							</ControlItem>
-						</SegmentedControl> }
+						</SegmentedControl>
+					) }
 					<div className="reader-email-settings__popout-toggle">
 						{ translate( 'New comments' ) }
 						<FormToggle onChange={ this.toggleNewCommentEmail } checked={ notifyOnNewComments } />

--- a/client/blocks/reader-export-button/index.jsx
+++ b/client/blocks/reader-export-button/index.jsx
@@ -59,9 +59,7 @@ class ReaderExportButton extends React.Component {
 		return (
 			<div className="reader-export-button" onClick={ this.onClick }>
 				<Gridicon icon="cloud-download" className="reader-export-button__icon" />
-				<span className="reader-export-button__label">
-					{ this.props.translate( 'Export' ) }
-				</span>
+				<span className="reader-export-button__label">{ this.props.translate( 'Export' ) }</span>
 			</div>
 		);
 	}

--- a/client/blocks/reader-featured-video/index.jsx
+++ b/client/blocks/reader-featured-video/index.jsx
@@ -108,12 +108,13 @@ class ReaderFeaturedVideo extends React.Component {
 					className={ className }
 					href={ href }
 				>
-					{ allowPlaying &&
+					{ allowPlaying && (
 						<img
 							className="reader-featured-video__play-icon"
 							src="/calypso/images/reader/play-icon.png"
 							title={ translate( 'Play Video' ) }
-						/> }
+						/>
+					) }
 				</ReaderFeaturedImage>
 			);
 		}
@@ -127,12 +128,13 @@ class ReaderFeaturedVideo extends React.Component {
 		return (
 			<div className={ classNames }>
 				<QueryReaderThumbnail embedUrl={ this.props.videoEmbed.src } />
-				{ showEmbed &&
+				{ showEmbed && (
 					<div
 						ref={ this.setVideoEmbedRef }
 						className="reader-featured-video__video"
 						dangerouslySetInnerHTML={ { __html: thumbnailUrl ? autoplayIframe : iframe } }
-					/> }
+					/>
+				) }
 			</div>
 		);
 		/* eslint-enable-line react/no-danger */

--- a/client/blocks/reader-feed-header/index.jsx
+++ b/client/blocks/reader-feed-header/index.jsx
@@ -60,25 +60,28 @@ class FeedHeader extends Component {
 				<div className="reader-feed-header__back-and-follow">
 					{ showBack && <HeaderBack /> }
 					<div className="reader-feed-header__follow">
-						{ followerCount &&
+						{ followerCount && (
 							<span className="reader-feed-header__follow-count">
 								{' '}
 								{ translate( '%s follower', '%s followers', {
 									count: followerCount,
 									args: [ this.props.numberFormat( followerCount ) ],
 								} ) }
-							</span> }
+							</span>
+						) }
 						{ feed &&
-							! feed.is_error &&
+						! feed.is_error && (
 							<div className="reader-feed-header__follow-button">
 								<ReaderFollowButton siteUrl={ feed.feed_URL } iconSize={ 24 } />
-							</div> }
+							</div>
+						) }
 						{ site &&
-							following &&
-							! isEmailBlocked &&
+						following &&
+						! isEmailBlocked && (
 							<div className="reader-feed-header__email-settings">
 								<ReaderEmailSettings siteId={ site.ID } />
-							</div> }
+							</div>
+						) }
 					</div>
 				</div>
 				<Card className="reader-feed-header__site">
@@ -86,28 +89,28 @@ class FeedHeader extends Component {
 						<SiteIcon site={ site } size={ 96 } />
 					</a>
 					<div className="reader-feed-header__site-title">
-						{ site &&
+						{ site && (
 							<span className="reader-feed-header__site-badge">
 								<ReaderFeedHeaderSiteBadge site={ site } />
 								<BlogStickers blogId={ site.ID } />
-							</span> }
+							</span>
+						) }
 						<a className="reader-feed-header__site-title-link" href={ siteUrl }>
 							{ siteTitle }
 						</a>
 					</div>
 					<div className="reader-feed-header__details">
-						<span className="reader-feed-header__description">
-							{ description }
-						</span>
+						<span className="reader-feed-header__description">{ description }</span>
 						{ ownerDisplayName &&
-							! isAuthorNameBlacklisted( ownerDisplayName ) &&
+						! isAuthorNameBlacklisted( ownerDisplayName ) && (
 							<span className="reader-feed-header__byline">
 								{ translate( 'by %(author)s', {
 									args: {
 										author: ownerDisplayName,
 									},
 								} ) }
-							</span> }
+							</span>
+						) }
 					</div>
 				</Card>
 			</div>

--- a/client/blocks/reader-full-post/back.jsx
+++ b/client/blocks/reader-full-post/back.jsx
@@ -17,9 +17,7 @@ const ReaderFullPostBack = ( { onBackClick, translate } ) => {
 		<div className="reader-full-post__back-container">
 			<Button className="reader-full-post__back" borderless compact onClick={ onBackClick }>
 				<Gridicon icon="arrow-left" />
-				<span className="reader-full-post__back-label">
-					{ translate( 'Back' ) }
-				</span>
+				<span className="reader-full-post__back-label">{ translate( 'Back' ) }</span>
 			</Button>
 		</div>
 	);

--- a/client/blocks/reader-full-post/header-tags.jsx
+++ b/client/blocks/reader-full-post/header-tags.jsx
@@ -19,11 +19,7 @@ const ReaderFullPostHeaderTags = ( { tags } ) => {
 		);
 	} );
 
-	return (
-		<ul className="reader-full-post__header-tag-list">
-			{ listItems }
-		</ul>
-	);
+	return <ul className="reader-full-post__header-tag-list">{ listItems }</ul>;
 };
 
 ReaderFullPostHeaderTags.propTypes = {

--- a/client/blocks/reader-full-post/header.jsx
+++ b/client/blocks/reader-full-post/header.jsx
@@ -42,41 +42,41 @@ const ReaderFullPostHeader = ( { post, referralPost } ) => {
 	/* eslint-disable react/jsx-no-target-blank */
 	return (
 		<div className={ classNames( classes ) }>
-			{ post.title
-				? <AutoDirection>
-						<h1 className="reader-full-post__header-title" onClick={ handlePermalinkClick }>
-							<ExternalLink
-								className="reader-full-post__header-title-link"
-								href={ externalHref }
-								target="_blank"
-								icon={ false }
-							>
-								{ post.title }
-							</ExternalLink>
-						</h1>
-					</AutoDirection>
-				: null }
+			{ post.title ? (
+				<AutoDirection>
+					<h1 className="reader-full-post__header-title" onClick={ handlePermalinkClick }>
+						<ExternalLink
+							className="reader-full-post__header-title-link"
+							href={ externalHref }
+							target="_blank"
+							icon={ false }
+						>
+							{ post.title }
+						</ExternalLink>
+					</h1>
+				</AutoDirection>
+			) : null }
 			<div className="reader-full-post__header-meta">
-				{ post.date
-					? <span className="reader-full-post__header-date">
-							<a
-								className="reader-full-post__header-date-link"
-								onClick={ recordDateClick }
-								href={ externalHref }
-								target="_blank"
-								rel="noopener noreferrer"
-							>
-								<PostTime date={ post.date } />
-							</a>
-						</span>
-					: null }
+				{ post.date ? (
+					<span className="reader-full-post__header-date">
+						<a
+							className="reader-full-post__header-date-link"
+							onClick={ recordDateClick }
+							href={ externalHref }
+							target="_blank"
+							rel="noopener noreferrer"
+						>
+							<PostTime date={ post.date } />
+						</a>
+					</span>
+				) : null }
 
-				{ post.tags && keys( post.tags ).length > 0
-					? <div className="reader-full-post__header-tags">
-							<Gridicon icon="tag" size={ 18 } />
-							<ReaderFullPostHeaderTags tags={ post.tags } />
-						</div>
-					: null }
+				{ post.tags && keys( post.tags ).length > 0 ? (
+					<div className="reader-full-post__header-tags">
+						<Gridicon icon="tag" size={ 18 } />
+						<ReaderFullPostHeaderTags tags={ post.tags } />
+					</div>
+				) : null }
 			</div>
 		</div>
 	);

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -306,14 +306,15 @@ export class FullPostView extends React.Component {
 		/*eslint-disable react/jsx-no-target-blank */
 		return (
 			<ReaderMain className={ classNames( classes ) }>
-				{ ! post || post._state === 'pending'
-					? <DocumentHead title={ translate( 'Loading' ) } />
-					: <DocumentHead title={ `${ post.title } ‹ ${ siteName } ‹ Reader` } /> }
+				{ ! post || post._state === 'pending' ? (
+					<DocumentHead title={ translate( 'Loading' ) } />
+				) : (
+					<DocumentHead title={ `${ post.title } ‹ ${ siteName } ‹ Reader` } />
+				) }
 				{ post && post.feed_ID && <QueryReaderFeed feedId={ +post.feed_ID } /> }
 				{ post &&
-					! post.is_external &&
-					post.site_ID &&
-					<QueryReaderSite siteId={ +post.site_ID } /> }
+				! post.is_external &&
+				post.site_ID && <QueryReaderSite siteId={ +post.site_ID } /> }
 				<ReaderFullPostBack onBackClick={ this.handleBack } />
 				<div className="reader-full-post__visit-site-container">
 					<ExternalLink
@@ -331,7 +332,7 @@ export class FullPostView extends React.Component {
 					<div className="reader-full-post__sidebar">
 						{ isLoading && <AuthorCompactProfile author={ null } /> }
 						{ ! isLoading &&
-							post.author &&
+						post.author && (
 							<AuthorCompactProfile
 								author={ post.author }
 								siteIcon={ get( site, 'icon.img' ) }
@@ -343,54 +344,59 @@ export class FullPostView extends React.Component {
 								feedId={ +post.feed_ID }
 								siteId={ +post.site_ID }
 								post={ post }
-							/> }
-						{ shouldShowComments( post ) &&
+							/>
+						) }
+						{ shouldShowComments( post ) && (
 							<CommentButton
 								key="comment-button"
 								commentCount={ commentCount }
 								onClick={ this.handleCommentClick }
 								tagName="div"
-							/> }
-						{ shouldShowLikes( post ) &&
+							/>
+						) }
+						{ shouldShowLikes( post ) && (
 							<LikeButton
 								siteId={ +post.site_ID }
 								postId={ +post.ID }
 								fullPost={ true }
 								tagName="div"
-							/> }
+							/>
+						) }
 					</div>
 					<Emojify>
 						<article className="reader-full-post__story" ref="article">
 							<ReaderFullPostHeader post={ post } referralPost={ referralPost } />
 
 							{ post.featured_image &&
-								! isFeaturedImageInContent( post ) &&
-								<FeaturedImage src={ post.featured_image } /> }
+							! isFeaturedImageInContent( post ) && <FeaturedImage src={ post.featured_image } /> }
 							{ isLoading && <ReaderFullPostContentPlaceholder /> }
-							{ post.use_excerpt
-								? <PostExcerpt
-										content={ post.better_excerpt ? post.better_excerpt : post.excerpt }
-									/>
-								: <EmbedContainer>
-										<AutoDirection>
-											<div
-												className="reader-full-post__story-content"
-												dangerouslySetInnerHTML={ { __html: post.content } }
-											/>
-										</AutoDirection>
-									</EmbedContainer> }
+							{ post.use_excerpt ? (
+								<PostExcerpt content={ post.better_excerpt ? post.better_excerpt : post.excerpt } />
+							) : (
+								<EmbedContainer>
+									<AutoDirection>
+										<div
+											className="reader-full-post__story-content"
+											dangerouslySetInnerHTML={ { __html: post.content } }
+										/>
+									</AutoDirection>
+								</EmbedContainer>
+							) }
 
 							{ post.use_excerpt &&
-								! isDiscoverPost( post ) &&
-								<PostExcerptLink siteName={ siteName } postUrl={ post.URL } /> }
-							{ isDiscoverSitePick( post ) &&
+							! isDiscoverPost( post ) && (
+								<PostExcerptLink siteName={ siteName } postUrl={ post.URL } />
+							) }
+							{ isDiscoverSitePick( post ) && (
 								<DiscoverSiteAttribution
 									attribution={ post.discover_metadata.attribution }
 									siteUrl={ getSiteUrl( post ) }
 									followUrl={ getSourceFollowUrl( post ) }
-								/> }
-							{ isDailyPostChallengeOrPrompt( post ) &&
-								<DailyPostButton post={ post } site={ site } /> }
+								/>
+							) }
+							{ isDailyPostChallengeOrPrompt( post ) && (
+								<DailyPostButton post={ post } site={ site } />
+							) }
 
 							<ReaderPostActions
 								post={ post }
@@ -399,7 +405,7 @@ export class FullPostView extends React.Component {
 								fullPost={ true }
 							/>
 
-							{ showRelatedPosts &&
+							{ showRelatedPosts && (
 								<RelatedPostsFromSameSite
 									siteId={ +post.site_ID }
 									postId={ +post.ID }
@@ -421,24 +427,25 @@ export class FullPostView extends React.Component {
 									className="is-same-site"
 									/* eslint-enable wpcalypso/jsx-classname-namespace */
 									onPostClick={ this.handleRelatedPostFromSameSiteClicked }
-								/> }
+								/>
+							) }
 
 							<div className="reader-full-post__comments-wrapper" ref="commentsWrapper">
-								{ shouldShowComments( post )
-									? <Comments
-											showNestingReplyArrow={ config.isEnabled( 'reader/nesting-arrow' ) }
-											ref="commentsList"
-											post={ post }
-											initialSize={ startingCommentId ? commentCount : 10 }
-											pageSize={ 25 }
-											startingCommentId={ startingCommentId }
-											commentCount={ commentCount }
-											maxDepth={ 1 }
-										/>
-									: null }
+								{ shouldShowComments( post ) ? (
+									<Comments
+										showNestingReplyArrow={ config.isEnabled( 'reader/nesting-arrow' ) }
+										ref="commentsList"
+										post={ post }
+										initialSize={ startingCommentId ? commentCount : 10 }
+										pageSize={ 25 }
+										startingCommentId={ startingCommentId }
+										commentCount={ commentCount }
+										maxDepth={ 1 }
+									/>
+								) : null }
 							</div>
 
-							{ showRelatedPosts &&
+							{ showRelatedPosts && (
 								<RelatedPostsFromOtherSites
 									siteId={ +post.site_ID }
 									postId={ +post.ID }
@@ -447,7 +454,8 @@ export class FullPostView extends React.Component {
 									className="is-other-site"
 									/* eslint-enable wpcalypso/jsx-classname-namespace */
 									onPostClick={ this.handleRelatedPostFromOtherSiteClicked }
-								/> }
+								/>
+							) }
 						</article>
 					</Emojify>
 				</div>
@@ -535,12 +543,12 @@ export default class FullPostFluxContainer extends React.Component {
 	}
 
 	render() {
-		return this.state.post
-			? <ConnectedFullPostView
-					onClose={ this.props.onClose }
-					post={ this.state.post }
-					referralPost={ this.state.referralPost }
-				/>
-			: null;
+		return this.state.post ? (
+			<ConnectedFullPostView
+				onClose={ this.props.onClose }
+				post={ this.state.post }
+				referralPost={ this.state.referralPost }
+			/>
+		) : null;
 	}
 }

--- a/client/blocks/reader-full-post/unavailable.jsx
+++ b/client/blocks/reader-full-post/unavailable.jsx
@@ -22,17 +22,13 @@ const ReaderFullPostUnavailable = ( { post, onBackClick, translate } ) => {
 			<DocumentHead title={ translate( 'Post unavailable' ) } />
 			<div className="reader-full-post__content">
 				<div className="reader-full-post__story">
-					<h1 className="reader-full-post__header-title">
-						{ translate( 'Post unavailable' ) }
-					</h1>
+					<h1 className="reader-full-post__header-title">{ translate( 'Post unavailable' ) }</h1>
 					<p className="reader-full-post__unavailable-message">
 						{ translate( "Sorry, we can't display that post right now." ) }
 					</p>
-					{ config.isEnabled( 'reader/full-errors' )
-						? <pre>
-								{ JSON.stringify( post, null, '  ' ) }
-							</pre>
-						: null }
+					{ config.isEnabled( 'reader/full-errors' ) ? (
+						<pre>{ JSON.stringify( post, null, '  ' ) }</pre>
+					) : null }
 				</div>
 			</div>
 		</ReaderMain>

--- a/client/blocks/reader-import-button/index.jsx
+++ b/client/blocks/reader-import-button/index.jsx
@@ -98,9 +98,7 @@ class ReaderImportButton extends React.Component {
 			<div className="reader-import-button">
 				<FilePicker accept=".xml,.opml" onClick={ this.onClick } onPick={ this.onPick }>
 					<Gridicon icon="cloud-upload" className="reader-import-button__icon" />
-					<span className="reader-import-button__label">
-						{ this.props.translate( 'Import' ) }
-					</span>
+					<span className="reader-import-button__label">{ this.props.translate( 'Import' ) }</span>
 				</FilePicker>
 			</div>
 		);

--- a/client/blocks/reader-post-actions/index.jsx
+++ b/client/blocks/reader-post-actions/index.jsx
@@ -53,7 +53,7 @@ const ReaderPostActions = props => {
 	/* eslint-disable react/jsx-no-target-blank */
 	return (
 		<ul className={ listClassnames }>
-			{ showVisit &&
+			{ showVisit && (
 				<li className="reader-post-actions__item reader-post-actions__visit">
 					<ReaderVisitLink
 						href={ visitUrl || post.URL }
@@ -62,10 +62,11 @@ const ReaderPostActions = props => {
 					>
 						{ translate( 'Visit' ) }
 					</ReaderVisitLink>
-				</li> }
+				</li>
+			) }
 			{ showEdit &&
-				site &&
-				userCan( 'edit_post', post ) &&
+			site &&
+			userCan( 'edit_post', post ) && (
 				<li className="reader-post-actions__item">
 					<PostEditButton
 						post={ post }
@@ -73,12 +74,14 @@ const ReaderPostActions = props => {
 						onClick={ onEditClick }
 						iconSize={ iconSize }
 					/>
-				</li> }
-			{ shouldShowShare( post ) &&
+				</li>
+			) }
+			{ shouldShowShare( post ) && (
 				<li className="reader-post-actions__item">
 					<ShareButton post={ post } position="bottom" tagName="div" iconSize={ iconSize } />
-				</li> }
-			{ shouldShowComments( post ) &&
+				</li>
+			) }
+			{ shouldShowComments( post ) && (
 				<li className="reader-post-actions__item">
 					<CommentButton
 						key="comment-button"
@@ -87,8 +90,9 @@ const ReaderPostActions = props => {
 						tagName="div"
 						size={ iconSize }
 					/>
-				</li> }
-			{ shouldShowLikes( post ) &&
+				</li>
+			) }
+			{ shouldShowLikes( post ) && (
 				<li className="reader-post-actions__item">
 					<LikeButton
 						key="like-button"
@@ -102,15 +106,17 @@ const ReaderPostActions = props => {
 						iconSize={ iconSize }
 						showZeroCount={ false }
 					/>
-				</li> }
-			{ showMenu &&
+				</li>
+			) }
+			{ showMenu && (
 				<li className="reader-post-actions__item">
 					<ReaderPostOptionsMenu
 						className="ignore-click"
 						showFollow={ showMenuFollow }
 						post={ post }
 					/>
-				</li> }
+				</li>
+			) }
 		</ul>
 	);
 	/* eslint-enable react/jsx-no-target-blank */

--- a/client/blocks/reader-post-card/byline.jsx
+++ b/client/blocks/reader-post-card/byline.jsx
@@ -96,7 +96,7 @@ class PostByline extends React.Component {
 		/* eslint-disable wpcalypso/jsx-gridicon-size */
 		return (
 			<div className="reader-post-card__byline ignore-click">
-				{ showAvatar &&
+				{ showAvatar && (
 					<ReaderAvatar
 						siteIcon={ siteIcon }
 						feedIcon={ feedIcon }
@@ -104,11 +104,12 @@ class PostByline extends React.Component {
 						preferGravatar={ true }
 						siteUrl={ streamUrl }
 						isCompact={ true }
-					/> }
+					/>
+				) }
 				<div className="reader-post-card__byline-details">
-					{ ( shouldDisplayAuthor || showSiteName ) &&
+					{ ( shouldDisplayAuthor || showSiteName ) && (
 						<div className="reader-post-card__byline-author-site">
-							{ shouldDisplayAuthor &&
+							{ shouldDisplayAuthor && (
 								<ReaderAuthorLink
 									className="reader-post-card__link"
 									author={ post.author }
@@ -116,9 +117,10 @@ class PostByline extends React.Component {
 									post={ post }
 								>
 									{ post.author.name }
-								</ReaderAuthorLink> }
+								</ReaderAuthorLink>
+							) }
 							{ shouldDisplayAuthor && showSiteName ? ', ' : '' }
-							{ showSiteName &&
+							{ showSiteName && (
 								<ReaderSiteStreamLink
 									className="reader-post-card__site reader-post-card__link"
 									feedId={ feedId }
@@ -126,11 +128,13 @@ class PostByline extends React.Component {
 									post={ post }
 								>
 									{ siteName }
-								</ReaderSiteStreamLink> }
-						</div> }
+								</ReaderSiteStreamLink>
+							) }
+						</div>
+					) }
 					<div className="reader-post-card__timestamp-and-tag">
 						{ post.date &&
-							post.URL &&
+						post.URL && (
 							<span className="reader-post-card__timestamp">
 								<a
 									className="reader-post-card__timestamp-link"
@@ -141,12 +145,14 @@ class PostByline extends React.Component {
 								>
 									<PostTime date={ post.date } />
 								</a>
-							</span> }
-						{ tags.length > 0 &&
+							</span>
+						) }
+						{ tags.length > 0 && (
 							<span className="reader-post-card__tags">
 								<Gridicon icon="tag" />
 								{ tags }
-							</span> }
+							</span>
+						) }
 					</div>
 				</div>
 			</div>

--- a/client/blocks/reader-post-card/compact.jsx
+++ b/client/blocks/reader-post-card/compact.jsx
@@ -34,9 +34,7 @@ const CompactPost = ( { post, postByline, children, isDiscover, onClick } ) => {
 				<AutoDirection>
 					<h1 className="reader-post-card__title">
 						<a className="reader-post-card__title-link" href={ post.URL }>
-							<Emojify>
-								{ post.title }
-							</Emojify>
+							<Emojify>{ post.title }</Emojify>
 						</a>
 					</h1>
 				</AutoDirection>

--- a/client/blocks/reader-post-card/gallery.jsx
+++ b/client/blocks/reader-post-card/gallery.jsx
@@ -51,16 +51,12 @@ const PostGallery = ( { post, children, isDiscover } ) => {
 	} );
 	return (
 		<div className="reader-post-card__post">
-			<ul className="reader-post-card__gallery">
-				{ listItems }
-			</ul>
+			<ul className="reader-post-card__gallery">{ listItems }</ul>
 			<div className="reader-post-card__post-details">
 				<AutoDirection>
 					<h1 className="reader-post-card__title">
 						<a className="reader-post-card__title-link" href={ post.URL }>
-							<Emojify>
-								{ post.title }
-							</Emojify>
+							<Emojify>{ post.title }</Emojify>
 						</a>
 					</h1>
 				</AutoDirection>

--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -147,12 +147,12 @@ class ReaderPostCard extends React.Component {
 
 		if ( isDiscover && ! compact ) {
 			const discoverBlogName = getDiscoverBlogName( post ) || null;
-			discoverFollowButton =
-				discoverBlogName &&
+			discoverFollowButton = discoverBlogName && (
 				<DiscoverFollowButton
 					siteName={ discoverBlogName }
 					followUrl={ getDiscoverFollowUrl( post ) }
-				/>;
+				/>
+			);
 		}
 
 		const readerPostActions = (
@@ -242,8 +242,7 @@ class ReaderPostCard extends React.Component {
 					postKey={ postKey }
 				>
 					{ isDailyPostChallengeOrPrompt( post ) &&
-						site &&
-						<DailyPostButton post={ post } site={ site } /> }
+					site && <DailyPostButton post={ post } site={ site } /> }
 					{ discoverFollowButton }
 					{ readerPostActions }
 				</StandardPost>
@@ -256,12 +255,13 @@ class ReaderPostCard extends React.Component {
 			<Card className={ classes } onClick={ ! isPhotoPost && ! compact && this.handleCardClick }>
 				{ ! compact && postByline }
 				{ showPrimaryFollowButton &&
-					followUrl &&
+				followUrl && (
 					<FollowButton
 						siteUrl={ followUrl }
 						followSource={ followSource }
 						railcar={ post.railcar }
-					/> }
+					/>
+				) }
 				{ readerPostCard }
 				{ this.props.children }
 			</Card>

--- a/client/blocks/reader-post-card/photo.jsx
+++ b/client/blocks/reader-post-card/photo.jsx
@@ -118,9 +118,7 @@ class PostPhoto extends React.Component {
 							href={ post.URL }
 							onClick={ this.props.onClick }
 						>
-							<Emojify>
-								{ linkTitle }
-							</Emojify>
+							<Emojify>{ linkTitle }</Emojify>
 						</a>
 					</h1>
 				</AutoDirection>
@@ -135,9 +133,7 @@ class PostPhoto extends React.Component {
 		return (
 			<div className="reader-post-card__post">
 				{ featuredImage }
-				<div className="reader-post-card__post-details">
-					{ children }
-				</div>
+				<div className="reader-post-card__post-details">{ children }</div>
 			</div>
 		);
 	}

--- a/client/blocks/reader-post-card/standard.jsx
+++ b/client/blocks/reader-post-card/standard.jsx
@@ -31,9 +31,7 @@ const StandardPost = ( { post, children, isDiscover, expandCard, postKey, isExpa
 				<AutoDirection>
 					<h1 className="reader-post-card__title">
 						<a className="reader-post-card__title-link" href={ post.URL }>
-							<Emojify>
-								{ post.title }
-							</Emojify>
+							<Emojify>{ post.title }</Emojify>
 						</a>
 					</h1>
 				</AutoDirection>

--- a/client/blocks/reader-post-options-menu/blog-stickers.jsx
+++ b/client/blocks/reader-post-options-menu/blog-stickers.jsx
@@ -25,7 +25,7 @@ class ReaderPostOptionsMenuBlogStickers extends React.Component {
 
 		return (
 			<div className="reader-post-options-menu__blog-stickers">
-				{ map( blogStickersOffered, blogStickerName =>
+				{ map( blogStickersOffered, blogStickerName => (
 					<ReaderPostOptionsMenuBlogStickerMenuItem
 						key={ blogStickerName }
 						blogId={ blogId }
@@ -34,7 +34,7 @@ class ReaderPostOptionsMenuBlogStickers extends React.Component {
 					>
 						{ blogStickerName }
 					</ReaderPostOptionsMenuBlogStickerMenuItem>
-				) }
+				) ) }
 				{ ! stickers && <QueryBlogStickers blogId={ blogId } /> }
 			</div>
 		);

--- a/client/blocks/reader-post-options-menu/index.jsx
+++ b/client/blocks/reader-post-options-menu/index.jsx
@@ -144,10 +144,9 @@ class ReaderPostOptionsMenu extends React.Component {
 			<span className={ classes }>
 				{ ! feed && post && post.feed_ID && <QueryReaderFeed feedId={ +post.feed_ID } /> }
 				{ ! site &&
-					post &&
-					! post.is_external &&
-					post.site_ID &&
-					<QueryReaderSite siteId={ +post.site_ID } /> }
+				post &&
+				! post.is_external &&
+				post.site_ID && <QueryReaderSite siteId={ +post.site_ID } /> }
 				{ ! teams && <QueryReaderTeams /> }
 				<EllipsisMenu
 					className="reader-post-options-menu__ellipsis-menu"
@@ -157,32 +156,36 @@ class ReaderPostOptionsMenu extends React.Component {
 				>
 					{ isTeamMember && site && <ReaderPostOptionsMenuBlogStickers blogId={ +site.ID } /> }
 
-					{ this.props.showFollow &&
-						<FollowButton tagName={ PopoverMenuItem } siteUrl={ followUrl } /> }
+					{ this.props.showFollow && (
+						<FollowButton tagName={ PopoverMenuItem } siteUrl={ followUrl } />
+					) }
 
-					{ post.URL &&
+					{ post.URL && (
 						<PopoverMenuItem onClick={ this.visitPost } icon="external">
 							{ translate( 'Visit Post' ) }
-						</PopoverMenuItem> }
+						</PopoverMenuItem>
+					) }
 
-					{ isEditPossible &&
+					{ isEditPossible && (
 						<PopoverMenuItem onClick={ this.editPost } icon="pencil">
 							{ translate( 'Edit Post' ) }
-						</PopoverMenuItem> }
+						</PopoverMenuItem>
+					) }
 
 					{ ( this.props.showFollow || isEditPossible || post.URL ) &&
-						( isBlockPossible || isDiscoverPost ) &&
-						<hr className="reader-post-options-menu__hr" /> }
+					( isBlockPossible || isDiscoverPost ) && <hr className="reader-post-options-menu__hr" /> }
 
-					{ isBlockPossible &&
+					{ isBlockPossible && (
 						<PopoverMenuItem onClick={ this.blockSite }>
 							{ translate( 'Block Site' ) }
-						</PopoverMenuItem> }
+						</PopoverMenuItem>
+					) }
 
-					{ ( isBlockPossible || isDiscoverPost ) &&
+					{ ( isBlockPossible || isDiscoverPost ) && (
 						<PopoverMenuItem onClick={ this.reportPost }>
 							{ translate( 'Report this Post' ) }
-						</PopoverMenuItem> }
+						</PopoverMenuItem>
+					) }
 				</EllipsisMenu>
 			</span>
 		);

--- a/client/blocks/reader-related-card-v2/index.jsx
+++ b/client/blocks/reader-related-card-v2/index.jsx
@@ -38,7 +38,7 @@ function AuthorAndSiteFollow( { post, site, onSiteClick, followSource } ) {
 			</a>
 			<div className="reader-related-card-v2__byline">
 				{ authorName &&
-					authorAndSiteAreDifferent &&
+				authorAndSiteAreDifferent && (
 					<span className="reader-related-card-v2__byline-author">
 						<ReaderAuthorLink
 							author={ post.author }
@@ -49,7 +49,8 @@ function AuthorAndSiteFollow( { post, site, onSiteClick, followSource } ) {
 						>
 							{ authorName }
 						</ReaderAuthorLink>
-					</span> }
+					</span>
+				) }
 				<span className="reader-related-card-v2__byline-site">
 					<a href={ siteUrl } onClick={ onSiteClick } className="reader-related-card-v2__link">
 						{ siteName }
@@ -155,9 +156,7 @@ export function RelatedPostCard( {
 				onClick={ postClickTracker }
 			>
 				<div className="reader-related-card-v2__site-info">
-					<h1 className="reader-related-card-v2__title">
-						{ post.title }
-					</h1>
+					<h1 className="reader-related-card-v2__title">{ post.title }</h1>
 					<div className="reader-related-card-v2__excerpt post-excerpt">
 						{ !! post.canonical_media ? post.short_excerpt : post.better_excerpt_no_html }
 					</div>

--- a/client/blocks/reader-share/index.jsx
+++ b/client/blocks/reader-share/index.jsx
@@ -191,7 +191,7 @@ class ReaderShare extends React.Component {
 						{ translate( 'Share', { comment: 'Share the post' } ) }
 					</span>
 				</span>,
-				this.state.showingMenu &&
+				this.state.showingMenu && (
 					<ReaderPopoverMenu
 						key="menu"
 						context={ this.refs && this.refs.shareButton }
@@ -219,7 +219,7 @@ class ReaderShare extends React.Component {
 							<SocialLogo icon="twitter" />
 							<span>Twitter</span>
 						</PopoverMenuItem>
-						{ this.props.hasSites &&
+						{ this.props.hasSites && (
 							<SiteSelector
 								className="reader-share__site-selector"
 								siteBasePath="/post"
@@ -228,8 +228,10 @@ class ReaderShare extends React.Component {
 								indicator={ false }
 								autoFocus={ false }
 								groups={ true }
-							/> }
-					</ReaderPopoverMenu>,
+							/>
+						) }
+					</ReaderPopoverMenu>
+				),
 			]
 		);
 	}

--- a/client/blocks/reader-site-stream-link/index.jsx
+++ b/client/blocks/reader-site-stream-link/index.jsx
@@ -33,9 +33,7 @@ class ReaderSiteStreamLink extends React.Component {
 		if ( ! this.props.feedId && ! this.props.siteId ) {
 			return (
 				<span>
-					<Emojify>
-						{ this.props.children }
-					</Emojify>
+					<Emojify>{ this.props.children }</Emojify>
 				</span>
 			);
 		}
@@ -45,9 +43,7 @@ class ReaderSiteStreamLink extends React.Component {
 
 		return (
 			<a { ...omit( this.props, omitProps ) } href={ link } onClick={ this.recordClick }>
-				<Emojify>
-					{ this.props.children }
-				</Emojify>
+				<Emojify>{ this.props.children }</Emojify>
 			</a>
 		);
 	}

--- a/client/blocks/reader-subscription-list-item/index.jsx
+++ b/client/blocks/reader-subscription-list-item/index.jsx
@@ -113,11 +113,9 @@ function ReaderSubscriptionListItem( {
 						</a>
 					}
 				</span>
-				<div className="reader-subscription-list-item__site-excerpt">
-					{ siteExcerpt }
-				</div>
+				<div className="reader-subscription-list-item__site-excerpt">{ siteExcerpt }</div>
 				{ ! isMultiAuthor &&
-					! isEmpty( authorName ) &&
+				! isEmpty( authorName ) && (
 					<span className="reader-subscription-list-item__by-text">
 						{ translate( 'by {{author/}}', {
 							components: {
@@ -132,8 +130,9 @@ function ReaderSubscriptionListItem( {
 								),
 							},
 						} ) }
-					</span> }
-				{ siteUrl &&
+					</span>
+				) }
+				{ siteUrl && (
 					<div className="reader-subscription-list-item__site-url-timestamp">
 						<a
 							href={ siteUrl }
@@ -144,11 +143,13 @@ function ReaderSubscriptionListItem( {
 						>
 							{ formatUrlForDisplay( siteUrl ) }
 						</a>
-						{ showLastUpdatedDate &&
+						{ showLastUpdatedDate && (
 							<span className="reader-subscription-list-item__timestamp">
 								{ feed && feed.last_update && translate( 'updated %s', { args: lastUpdatedDate } ) }
-							</span> }
-					</div> }
+							</span>
+						) }
+					</div>
+				) }
 			</div>
 			<div className="reader-subscription-list-item__options">
 				<FollowButton

--- a/client/blocks/reader-visit-link/index.jsx
+++ b/client/blocks/reader-visit-link/index.jsx
@@ -35,9 +35,7 @@ class ReaderVisitLink extends React.Component {
 				iconClassName="reader-visit-link__icon"
 				onClick={ this.props.onClick }
 			>
-				<span className="reader-visit-link__label">
-					{ this.props.children }
-				</span>
+				<span className="reader-visit-link__label">{ this.props.children }</span>
 			</ExternalLink>
 		);
 	}

--- a/client/blocks/site/index.jsx
+++ b/client/blocks/site/index.jsx
@@ -97,57 +97,63 @@ const Site = React.createClass( {
 					data-tip-target={ this.props.tipTarget }
 					target={ this.props.externalLink && '_blank' }
 					title={
-						this.props.homeLink
-							? translate( 'View site %(domain)s', {
-									args: { domain: site.domain },
-								} )
-							: translate( 'Select site %(domain)s', {
-									args: { domain: site.domain },
-								} )
+						this.props.homeLink ? (
+							translate( 'View site %(domain)s', {
+								args: { domain: site.domain },
+							} )
+						) : (
+							translate( 'Select site %(domain)s', {
+								args: { domain: site.domain },
+							} )
+						)
 					}
 					onClick={ this.onSelect }
 					onMouseEnter={ this.onMouseEnter }
 					onMouseLeave={ this.onMouseLeave }
 					aria-label={
-						this.props.homeLink
-							? translate( 'View site %(domain)s', {
-									args: { domain: site.domain },
-								} )
-							: translate( 'Select site %(domain)s', {
-									args: { domain: site.domain },
-								} )
+						this.props.homeLink ? (
+							translate( 'View site %(domain)s', {
+								args: { domain: site.domain },
+							} )
+						) : (
+							translate( 'Select site %(domain)s', {
+								args: { domain: site.domain },
+							} )
+						)
 					}
 				>
 					<SiteIcon site={ site } size={ this.props.compact ? 24 : 32 } />
 					<div className="site__info">
 						<div className="site__title">
 							{ /* eslint-disable wpcalypso/jsx-gridicon-size */ }
-							{ this.props.site.is_private &&
+							{ this.props.site.is_private && (
 								<span className="site__badge">
 									<Gridicon icon="lock" size={ 14 } />
-								</span> }
+								</span>
+							) }
 							{ site.options &&
-								site.options.is_redirect &&
+							site.options.is_redirect && (
 								<span className="site__badge">
 									<Gridicon icon="block" size={ 14 } />
-								</span> }
+								</span>
+							) }
 							{ site.options &&
-								site.options.is_domain_only &&
+							site.options.is_domain_only && (
 								<span className="site__badge">
 									<Gridicon icon="domains" size={ 14 } />
-								</span> }
+								</span>
+							) }
 							{ /* eslint-enable wpcalypso/jsx-gridicon-size */ }
 							{ site.title }
 						</div>
-						<div className="site__domain">
-							{ site.domain }
-						</div>
+						<div className="site__domain">{ site.domain }</div>
 					</div>
 					{ this.props.homeLink &&
-						this.props.showHomeIcon &&
+					this.props.showHomeIcon && (
 						<span className="site__home">
 							<Gridicon icon="house" size={ 18 } />
-						</span> }
+						</span>
+					) }
 				</a>
 				{ this.props.indicator ? <SiteIndicator site={ site } /> : null }
 			</div>

--- a/client/components/forms/form-currency-input/index.jsx
+++ b/client/components/forms/form-currency-input/index.jsx
@@ -43,11 +43,11 @@ function renderAffix( currencyValue, onCurrencyChange, currencyList ) {
 				value={ currencyValue }
 				onChange={ onCurrencyChange }
 			>
-				{ currencyList.map( ( { code, label = code } ) =>
+				{ currencyList.map( ( { code, label = code } ) => (
 					<option key={ code } value={ code }>
 						{ label }
 					</option>
-				) }
+				) ) }
 			</select>
 		</span>
 	);

--- a/client/components/forms/form-radio-with-thumbnail/index.jsx
+++ b/client/components/forms/form-radio-with-thumbnail/index.jsx
@@ -25,9 +25,7 @@ const FormRadioWithThumbnail = ( { label, thumbnail, ...otherProps } ) => {
 					{ imageUrl && <img src={ imageUrl } alt={ label } /> }
 				</div>
 				<FormRadio { ...otherProps } />
-				<span>
-					{ label }
-				</span>
+				<span>{ label }</span>
 			</FormLabel>
 		</div>
 	);

--- a/client/components/forms/form-radios-bar/index.jsx
+++ b/client/components/forms/form-radios-bar/index.jsx
@@ -18,19 +18,19 @@ const FormRadiosBar = ( { isThumbnail, checked, onChange, items } ) => {
 		<div className={ classnames( 'form-radios-bar', { 'is-thumbnail': isThumbnail } ) }>
 			{ items.map(
 				( item, i ) =>
-					isThumbnail
-						? <FormRadioWithThumbnail
-								key={ item.value + i }
-								checked={ checked === item.value }
-								onChange={ onChange }
-								{ ...item }
-							/>
-						: <FormLabel key={ item.value + i }>
-								<FormRadio checked={ checked === item.value } onChange={ onChange } { ...item } />
-								<span>
-									{ item.label }
-								</span>
-							</FormLabel>
+					isThumbnail ? (
+						<FormRadioWithThumbnail
+							key={ item.value + i }
+							checked={ checked === item.value }
+							onChange={ onChange }
+							{ ...item }
+						/>
+					) : (
+						<FormLabel key={ item.value + i }>
+							<FormRadio checked={ checked === item.value } onChange={ onChange } { ...item } />
+							<span>{ item.label }</span>
+						</FormLabel>
+					)
 			) }
 		</div>
 	);

--- a/client/components/forms/form-text-input-with-affixes/index.jsx
+++ b/client/components/forms/form-text-input-with-affixes/index.jsx
@@ -25,17 +25,11 @@ export default class extends React.Component {
 
 		return (
 			<div className={ classNames( 'form-text-input-with-affixes', { 'no-wrap': noWrap } ) }>
-				{ prefix &&
-					<span className="form-text-input-with-affixes__prefix">
-						{ prefix }
-					</span> }
+				{ prefix && <span className="form-text-input-with-affixes__prefix">{ prefix }</span> }
 
 				<FormTextInput { ...rest } />
 
-				{ suffix &&
-					<span className="form-text-input-with-affixes__suffix">
-						{ suffix }
-					</span> }
+				{ suffix && <span className="form-text-input-with-affixes__suffix">{ suffix }</span> }
 			</div>
 		);
 	}

--- a/client/components/forms/form-textarea/index.jsx
+++ b/client/components/forms/form-textarea/index.jsx
@@ -5,7 +5,7 @@
 import React from 'react';
 import classnames from 'classnames';
 
-const FormTextarea = ( { className, isError, isValid, children, ...otherProps } ) =>
+const FormTextarea = ( { className, isError, isValid, children, ...otherProps } ) => (
 	<textarea
 		{ ...otherProps }
 		className={ classnames( className, 'form-textarea', {
@@ -14,6 +14,7 @@ const FormTextarea = ( { className, isError, isValid, children, ...otherProps } 
 		} ) }
 	>
 		{ children }
-	</textarea>;
+	</textarea>
+);
 
 export default FormTextarea;

--- a/client/components/header-button/index.jsx
+++ b/client/components/header-button/index.jsx
@@ -11,13 +11,12 @@ import Gridicon from 'gridicons';
  */
 import Button from 'components/button';
 
-const HeaderButton = ( { icon, label, ...rest } ) =>
+const HeaderButton = ( { icon, label, ...rest } ) => (
 	<Button className="header-button" { ...rest }>
 		{ icon && <Gridicon icon={ icon } size={ 18 } /> }
-		<span className="header-button__text">
-			{ label }
-		</span>
-	</Button>;
+		<span className="header-button__text">{ label }</span>
+	</Button>
+);
 
 HeaderButton.propTypes = {
 	icon: PropTypes.string,

--- a/client/components/reader-popover/index.jsx
+++ b/client/components/reader-popover/index.jsx
@@ -17,10 +17,7 @@ const ReaderPopover = props => {
 	return (
 		<Popover className={ classes } { ...popoverProps }>
 			<div className="reader-popover__wrapper">
-				{ props.popoverTitle &&
-					<h3 className="reader-popover__header">
-						{ props.popoverTitle }
-					</h3> }
+				{ props.popoverTitle && <h3 className="reader-popover__header">{ props.popoverTitle }</h3> }
 				{ props.children }
 			</div>
 		</Popover>

--- a/client/components/redux-forms/redux-form-fieldset/index.jsx
+++ b/client/components/redux-forms/redux-form-fieldset/index.jsx
@@ -31,16 +31,10 @@ export const FieldsetRenderer = ( {
 
 	return (
 		<FormFieldset>
-			{ label &&
-				<FormLabel htmlFor={ input.name }>
-					{ label }
-				</FormLabel> }
+			{ label && <FormLabel htmlFor={ input.name }>{ label }</FormLabel> }
 			<InputComponent id={ input.name } isError={ isError } { ...input } { ...props } />
 			{ isError && <FormInputValidation isError text={ meta.error } /> }
-			{ explanation &&
-				<FormSettingExplanation>
-					{ explanation }
-				</FormSettingExplanation> }
+			{ explanation && <FormSettingExplanation>{ explanation }</FormSettingExplanation> }
 		</FormFieldset>
 	);
 };
@@ -49,8 +43,9 @@ export const FieldsetRenderer = ( {
  * Convenience wrapper around Redux Form `Field` to render a `FormFieldset`. Usage:
  *   <ReduxFormFieldset name="firstName" label="First Name" component={ FormTextInput } />
  */
-const ReduxFormFieldset = ( { component, ...props } ) =>
-	<Field component={ FieldsetRenderer } inputComponent={ component } { ...props } />;
+const ReduxFormFieldset = ( { component, ...props } ) => (
+	<Field component={ FieldsetRenderer } inputComponent={ component } { ...props } />
+);
 
 ReduxFormFieldset.propTypes = {
 	name: PropTypes.string.isRequired, // name of the Redux Form field to connect to

--- a/client/components/redux-forms/redux-form-radio/index.jsx
+++ b/client/components/redux-forms/redux-form-radio/index.jsx
@@ -12,8 +12,9 @@ import { Field } from 'redux-form';
 import FormRadio from 'components/forms/form-radio';
 
 // eslint-disable-next-line no-unused-vars
-const RadioRenderer = ( { input, meta, type, ...props } ) =>
-	<FormRadio { ...input } { ...props } />;
+const RadioRenderer = ( { input, meta, type, ...props } ) => (
+	<FormRadio { ...input } { ...props } />
+);
 
 const ReduxFormRadio = props => <Field component={ RadioRenderer } type="radio" { ...props } />;
 

--- a/client/components/redux-forms/redux-form-text-input/index.jsx
+++ b/client/components/redux-forms/redux-form-text-input/index.jsx
@@ -12,8 +12,9 @@ import { Field } from 'redux-form';
 import FormTextInput from 'components/forms/form-text-input';
 
 // eslint-disable-next-line no-unused-vars
-const TextInputRenderer = ( { input, meta, ...props } ) =>
-	<FormTextInput { ...input } { ...props } />;
+const TextInputRenderer = ( { input, meta, ...props } ) => (
+	<FormTextInput { ...input } { ...props } />
+);
 
 const ReduxFormTextInput = props => <Field component={ TextInputRenderer } { ...props } />;
 

--- a/client/components/redux-forms/redux-form-textarea/index.jsx
+++ b/client/components/redux-forms/redux-form-textarea/index.jsx
@@ -12,8 +12,9 @@ import { Field } from 'redux-form';
 import FormTextarea from 'components/forms/form-textarea';
 
 // eslint-disable-next-line no-unused-vars
-const TextareaRenderer = ( { input, meta, ...props } ) =>
-	<FormTextarea { ...input } { ...props } />;
+const TextareaRenderer = ( { input, meta, ...props } ) => (
+	<FormTextarea { ...input } { ...props } />
+);
 
 const ReduxFormTextarea = props => <Field component={ TextareaRenderer } { ...props } />;
 

--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -362,11 +362,7 @@ class SiteSelector extends Component {
 			return null;
 		}
 
-		return (
-			<div className="site-selector__recent">
-				{ recentSites }
-			</div>
-		);
+		return <div className="site-selector__recent">{ recentSites }</div>;
 	}
 
 	render() {
@@ -400,7 +396,7 @@ class SiteSelector extends Component {
 					{ this.renderRecentSites() }
 					{ this.renderSites() }
 					{ hiddenSitesCount > 0 &&
-						! this.props.sitesFound &&
+					! this.props.sitesFound && (
 						<span className="site-selector__hidden-sites-message">
 							{ this.props.translate(
 								'%(hiddenSitesCount)d more hidden site. {{a}}Change{{/a}}.{{br/}}Use search to access it.',
@@ -423,7 +419,8 @@ class SiteSelector extends Component {
 									},
 								}
 							) }
-						</span> }
+						</span>
+					) }
 				</div>
 				{ this.props.showAddNewSite && <SiteSelectorAddSite /> }
 			</div>

--- a/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
@@ -55,22 +55,29 @@ const productFormToCustomPost = state => productToCustomPost( getProductFormValu
 const createPaymentButton = siteId => ( dispatch, getState ) => {
 	const productCustomPost = productFormToCustomPost( getState() );
 
-	return wpcom.site( siteId ).addPost( productCustomPost ).then( newPost => {
-		const newProduct = customPostToProduct( newPost );
-		dispatch( receiveUpdateProduct( siteId, newProduct ) );
-		return newProduct;
-	} );
+	return wpcom
+		.site( siteId )
+		.addPost( productCustomPost )
+		.then( newPost => {
+			const newProduct = customPostToProduct( newPost );
+			dispatch( receiveUpdateProduct( siteId, newProduct ) );
+			return newProduct;
+		} );
 };
 
 // Thunk action creator to update an existing button
 const updatePaymentButton = ( siteId, paymentId ) => ( dispatch, getState ) => {
 	const productCustomPost = productFormToCustomPost( getState() );
 
-	return wpcom.site( siteId ).post( paymentId ).update( productCustomPost ).then( updatedPost => {
-		const updatedProduct = customPostToProduct( updatedPost );
-		dispatch( receiveUpdateProduct( siteId, updatedProduct ) );
-		return updatedProduct;
-	} );
+	return wpcom
+		.site( siteId )
+		.post( paymentId )
+		.update( productCustomPost )
+		.then( updatedPost => {
+			const updatedProduct = customPostToProduct( updatedPost );
+			dispatch( receiveUpdateProduct( siteId, updatedProduct ) );
+			return updatedProduct;
+		} );
 };
 
 // Thunk action creator to delete a button
@@ -366,16 +373,13 @@ class SimplePaymentsDialog extends Component {
 			<Dialog
 				isVisible={ showDialog }
 				onClose={ onClose }
-				buttons={ [
-					<Button onClick={ onClose }>
-						{ translate( 'Close' ) }
-					</Button>,
-				] }
+				buttons={ [ <Button onClick={ onClose }>{ translate( 'Close' ) }</Button> ] }
 				additionalClassNames="editor-simple-payments-modal"
 			>
 				<TrackComponentView eventName="calypso_simple_payments_dialog_view" />
-				{ ! disableNavigation &&
-					<Navigation activeTab={ 'list' } paymentButtons={ [] } onChangeTabs={ noop } /> }
+				{ ! disableNavigation && (
+					<Navigation activeTab={ 'list' } paymentButtons={ [] } onChangeTabs={ noop } />
+				) }
 				{ content }
 			</Dialog>
 		);
@@ -462,24 +466,28 @@ class SimplePaymentsDialog extends Component {
 
 				{ ( ! currencyCode || shouldQuerySitePlans ) && <QuerySitePlans siteId={ siteId } /> }
 
-				{ showNavigation &&
+				{ showNavigation && (
 					<Navigation
 						activeTab={ activeTab }
 						paymentButtons={ paymentButtons }
 						onChangeTabs={ this.handleChangeTabs }
-					/> }
-				{ errorMessage &&
-					<Notice status="is-error" text={ errorMessage } onDismissClick={ this.dismissError } /> }
-				{ activeTab === 'form'
-					? <ProductForm initialValues={ initialFormValues } showError={ this.showError } />
-					: <ProductList
-							siteId={ siteId }
-							paymentButtons={ paymentButtons }
-							selectedPaymentId={ this.state.selectedPaymentId }
-							onSelectedChange={ this.handleSelectedChange }
-							onTrashClick={ this.handleTrash }
-							onEditClick={ this.showButtonForm }
-						/> }
+					/>
+				) }
+				{ errorMessage && (
+					<Notice status="is-error" text={ errorMessage } onDismissClick={ this.dismissError } />
+				) }
+				{ activeTab === 'form' ? (
+					<ProductForm initialValues={ initialFormValues } showError={ this.showError } />
+				) : (
+					<ProductList
+						siteId={ siteId }
+						paymentButtons={ paymentButtons }
+						selectedPaymentId={ this.state.selectedPaymentId }
+						onSelectedChange={ this.handleSelectedChange }
+						onTrashClick={ this.handleTrash }
+						onEditClick={ this.showButtonForm }
+					/>
+				) }
 			</Dialog>
 		);
 	}

--- a/client/components/webpack-build-monitor/index.jsx
+++ b/client/components/webpack-build-monitor/index.jsx
@@ -143,8 +143,9 @@ class WebpackBuildMonitor extends React.PureComponent {
 
 		return (
 			<div className={ classnames }>
-				{ includes( [ BUILDING_BOTH, BUILDING_CSS, BUILDING_JS ], buildStatus ) &&
-					<Spinner size={ 11 } className="webpack-build-monitor__spinner" /> }
+				{ includes( [ BUILDING_BOTH, BUILDING_CSS, BUILDING_JS ], buildStatus ) && (
+					<Spinner size={ 11 } className="webpack-build-monitor__spinner" />
+				) }
 				{ text }
 			</div>
 		);

--- a/client/devdocs/design/blocks.jsx
+++ b/client/devdocs/design/blocks.jsx
@@ -96,16 +96,18 @@ export default class AppComponents extends React.Component {
 	render() {
 		return (
 			<Main className="design design__blocks">
-				{ this.props.component
-					? <HeaderCake onClick={ this.backToComponents } backText="All Blocks">
-							{ slugToCamelCase( this.props.component ) }
-						</HeaderCake>
-					: <SearchCard
-							onSearch={ this.onSearch }
-							initialValue={ this.state.filter }
-							placeholder="Search blocks…"
-							analyticsGroup="Docs"
-						/> }
+				{ this.props.component ? (
+					<HeaderCake onClick={ this.backToComponents } backText="All Blocks">
+						{ slugToCamelCase( this.props.component ) }
+					</HeaderCake>
+				) : (
+					<SearchCard
+						onSearch={ this.onSearch }
+						initialValue={ this.state.filter }
+						placeholder="Search blocks…"
+						analyticsGroup="Docs"
+					/>
+				) }
 				<Collection
 					component={ this.props.component }
 					filter={ this.state.filter }

--- a/client/extensions/woocommerce/app/store-stats/controller.js
+++ b/client/extensions/woocommerce/app/store-stats/controller.js
@@ -76,20 +76,22 @@ export default function StatsController( context ) {
 	}
 
 	const asyncComponent =
-		props.type === 'orders'
-			? <AsyncLoad
-					/* eslint-disable wpcalypso/jsx-classname-namespace */
-					placeholder={ <StatsPagePlaceholder className="woocommerce" /> }
-					/* eslint-enable wpcalypso/jsx-classname-namespace */
-					require="extensions/woocommerce/app/store-stats"
-					{ ...props }
-				/>
-			: <AsyncLoad
-					/* eslint-disable wpcalypso/jsx-classname-namespace */
-					placeholder={ <StatsPagePlaceholder className="woocommerce" /> }
-					/* eslint-enable wpcalypso/jsx-classname-namespace */
-					require="extensions/woocommerce/app/store-stats/listview"
-					{ ...props }
-				/>;
+		props.type === 'orders' ? (
+			<AsyncLoad
+				/* eslint-disable wpcalypso/jsx-classname-namespace */
+				placeholder={ <StatsPagePlaceholder className="woocommerce" /> }
+				/* eslint-enable wpcalypso/jsx-classname-namespace */
+				require="extensions/woocommerce/app/store-stats"
+				{ ...props }
+			/>
+		) : (
+			<AsyncLoad
+				/* eslint-disable wpcalypso/jsx-classname-namespace */
+				placeholder={ <StatsPagePlaceholder className="woocommerce" /> }
+				/* eslint-enable wpcalypso/jsx-classname-namespace */
+				require="extensions/woocommerce/app/store-stats/listview"
+				{ ...props }
+			/>
+		);
 	renderWithReduxStore( asyncComponent, document.getElementById( 'primary' ), context.store );
 }

--- a/client/my-sites/stats/activity-log-banner/error-banner.jsx
+++ b/client/my-sites/stats/activity-log-banner/error-banner.jsx
@@ -57,9 +57,7 @@ class ErrorBanner extends PureComponent {
 						restore_to: timestamp,
 					} }
 				/>
-				<p>
-					{ translate( 'We came across a problem while trying to restore your site.' ) }
-				</p>
+				<p>{ translate( 'We came across a problem while trying to restore your site.' ) }</p>
 				<Button primary onClick={ this.handleClickRestore }>
 					{ translate( 'Try again' ) }
 				</Button>

--- a/client/my-sites/stats/activity-log-banner/progress-banner.jsx
+++ b/client/my-sites/stats/activity-log-banner/progress-banner.jsx
@@ -47,9 +47,7 @@ function ProgressBanner( {
 			</p>
 
 			<div>
-				<em>
-					{ restoreStatusDescription }
-				</em>
+				<em>{ restoreStatusDescription }</em>
 				<ProgressBar
 					className={ status === 'queued' ? 'activity-log-banner__progress-bar--queued' : null }
 					isPulsing

--- a/client/my-sites/stats/activity-log-banner/success-banner.jsx
+++ b/client/my-sites/stats/activity-log-banner/success-banner.jsx
@@ -58,9 +58,7 @@ class SuccessBanner extends PureComponent {
 					{ translate( 'View site' ) }
 				</Button>
 				{ '  ' }
-				<Button onClick={ this.handleDismiss }>
-					{ translate( 'Thanks, got it!' ) }
-				</Button>
+				<Button onClick={ this.handleDismiss }>{ translate( 'Thanks, got it!' ) }</Button>
 			</ActivityLogBanner>
 		);
 	}

--- a/client/my-sites/stats/activity-log-item/activity-actor.jsx
+++ b/client/my-sites/stats/activity-log-item/activity-actor.jsx
@@ -44,13 +44,8 @@ export default class ActivityActor extends PureComponent {
 			<div className="activity-log-item__actor">
 				<Gravatar user={ { avatar_URL: actorAvatarUrl } } size={ 40 } />
 				<div className="activity-log-item__actor-info">
-					<div className="activity-log-item__actor-name">
-						{ actorName }
-					</div>
-					{ actorRole &&
-						<div className="activity-log-item__actor-role">
-							{ actorRole }
-						</div> }
+					<div className="activity-log-item__actor-name">{ actorName }</div>
+					{ actorRole && <div className="activity-log-item__actor-role">{ actorRole }</div> }
 				</div>
 			</div>
 		);

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -113,7 +113,10 @@ class ActivityLog extends Component {
 		}
 
 		if ( null !== gmtOffset ) {
-			return moment.utc( startDate ).subtract( gmtOffset, 'hours' ).utcOffset( gmtOffset );
+			return moment
+				.utc( startDate )
+				.subtract( gmtOffset, 'hours' )
+				.utcOffset( gmtOffset );
 		}
 
 		return moment.utc( startDate );
@@ -206,20 +209,22 @@ class ActivityLog extends Component {
 			return (
 				<div>
 					<QueryActivityLog siteId={ siteId } />
-					{ errorCode
-						? <ErrorBanner
-								errorCode={ errorCode }
-								failureReason={ failureReason }
-								requestRestore={ this.handleRequestRestore }
-								siteId={ siteId }
-								siteTitle={ siteTitle }
-								timestamp={ timestamp }
-							/>
-						: <SuccessBanner
-								applySiteOffset={ this.applySiteOffset }
-								siteId={ siteId }
-								timestamp={ timestamp }
-							/> }
+					{ errorCode ? (
+						<ErrorBanner
+							errorCode={ errorCode }
+							failureReason={ failureReason }
+							requestRestore={ this.handleRequestRestore }
+							siteId={ siteId }
+							siteTitle={ siteTitle }
+							timestamp={ timestamp }
+						/>
+					) : (
+						<SuccessBanner
+							applySiteOffset={ this.applySiteOffset }
+							siteId={ siteId }
+							timestamp={ timestamp }
+						/>
+					) }
 				</div>
 			);
 		}
@@ -290,17 +295,25 @@ class ActivityLog extends Component {
 
 		const disableRestore = this.isRestoreInProgress();
 		const logsGroupedByDay = groupBy( logs, log =>
-			this.applySiteOffset( moment.utc( log.activityTs ) ).endOf( 'day' ).valueOf()
+			this.applySiteOffset( moment.utc( log.activityTs ) )
+				.endOf( 'day' )
+				.valueOf()
 		);
 		const activityDays = [];
 
 		// loop backwards through each day in the month
 		for (
 			const m = moment.min(
-					startMoment.clone().endOf( 'month' ).startOf( 'day' ),
+					startMoment
+						.clone()
+						.endOf( 'month' )
+						.startOf( 'day' ),
 					this.applySiteOffset( moment.utc() ).startOf( 'day' )
 				),
-				startOfMonth = startMoment.clone().startOf( 'month' ).valueOf();
+				startOfMonth = startMoment
+					.clone()
+					.startOf( 'month' )
+					.valueOf();
 			startOfMonth <= m.valueOf();
 			m.subtract( 1, 'day' )
 		) {
@@ -320,11 +333,7 @@ class ActivityLog extends Component {
 			);
 		}
 
-		return (
-			<section className="activity-log__wrapper">
-				{ activityDays }
-			</section>
-		);
+		return <section className="activity-log__wrapper">{ activityDays }</section>;
 	}
 
 	renderMonthNavigation( position ) {

--- a/client/my-sites/stats/stats-navigation/index.jsx
+++ b/client/my-sites/stats/stats-navigation/index.jsx
@@ -58,11 +58,11 @@ const StatsNavigation = props => {
 	}
 
 	const ActivityTab =
-		config.isEnabled( 'jetpack/activity-log' ) && isJetpack && hasPaidPlan
-			? <NavItem path={ '/stats/activity' + siteFragment } selected={ section === 'activity' }>
-					{ sectionTitles.activity }
-				</NavItem>
-			: null;
+		config.isEnabled( 'jetpack/activity-log' ) && isJetpack && hasPaidPlan ? (
+			<NavItem path={ '/stats/activity' + siteFragment } selected={ section === 'activity' }>
+				{ sectionTitles.activity }
+			</NavItem>
+		) : null;
 
 	return (
 		<SectionNav selectedText={ sectionTitles[ section ] }>

--- a/client/reader/discover/site-attribution.jsx
+++ b/client/reader/discover/site-attribution.jsx
@@ -38,15 +38,17 @@ class DiscoverSiteAttribution extends React.Component {
 
 		return (
 			<div className={ classes }>
-				{ attribution.avatar_url
-					? <img
-							className="gravatar"
-							src={ encodeURI( attribution.avatar_url ) }
-							alt="Avatar"
-							width="20"
-							height="20"
-						/>
-					: <span className="noticon noticon-website" /> }
+				{ attribution.avatar_url ? (
+					<img
+						className="gravatar"
+						src={ encodeURI( attribution.avatar_url ) }
+						alt="Avatar"
+						width="20"
+						height="20"
+					/>
+				) : (
+					<span className="noticon noticon-website" />
+				) }
 				<span>
 					<a
 						{ ...siteLinkProps }
@@ -57,13 +59,13 @@ class DiscoverSiteAttribution extends React.Component {
 						{ translate( 'visit' ) } <em>{ attribution.blog_name }</em>
 					</a>
 				</span>
-				{ !! this.props.followUrl
-					? <FollowButton
-							siteUrl={ this.props.followUrl }
-							iconSize={ 20 }
-							onFollowToggle={ this.onFollowToggle }
-						/>
-					: null }
+				{ !! this.props.followUrl ? (
+					<FollowButton
+						siteUrl={ this.props.followUrl }
+						iconSize={ 20 }
+						onFollowToggle={ this.onFollowToggle }
+					/>
+				) : null }
 			</div>
 		);
 	}

--- a/client/reader/feed-error/index.jsx
+++ b/client/reader/feed-error/index.jsx
@@ -53,9 +53,7 @@ class FeedError extends React.Component {
 		return (
 			<ReaderMain>
 				<MobileBackToSidebar>
-					<h1>
-						{ this.props.sidebarTitle }
-					</h1>
+					<h1>{ this.props.sidebarTitle }</h1>
 				</MobileBackToSidebar>
 
 				<EmptyContent

--- a/client/reader/following-manage/feed-search-results.jsx
+++ b/client/reader/following-manage/feed-search-results.jsx
@@ -62,9 +62,9 @@ class FollowingManageSearchFeedsResults extends React.Component {
 		if ( ! searchResults ) {
 			return (
 				<div className={ classNames }>
-					{ times( 10, i =>
+					{ times( 10, i => (
 						<ReaderSubscriptionListItemPlaceholder key={ `placeholder-${ i }` } />
-					) }
+					) ) }
 				</div>
 			);
 		} else if ( isEmpty ) {
@@ -92,7 +92,7 @@ class FollowingManageSearchFeedsResults extends React.Component {
 					rowRenderer={ siteRowRenderer }
 				/>
 				{ ! showMoreResults &&
-					searchResultsCount > 10 &&
+				searchResultsCount > 10 && (
 					<div className="following-manage__show-more">
 						<Button
 							compact
@@ -103,7 +103,8 @@ class FollowingManageSearchFeedsResults extends React.Component {
 							<Gridicon icon="chevron-down" />
 							{ translate( 'Show more' ) }
 						</Button>
-					</div> }
+					</div>
+				) }
 			</div>
 		);
 	}

--- a/client/reader/following-manage/index.jsx
+++ b/client/reader/following-manage/index.jsx
@@ -196,20 +196,18 @@ class FollowingManage extends Component {
 			<ReaderMain className="following-manage">
 				<DocumentHead title={ 'Manage Following' } />
 				<MobileBackToSidebar>
-					<h1>
-						{ translate( 'Streams' ) }
-					</h1>
+					<h1>{ translate( 'Streams' ) }</h1>
 				</MobileBackToSidebar>
-				{ ! searchResults &&
-					<QueryReaderFeedsSearch query={ sitesQuery } excludeFollowed={ true } /> }
-				{ this.shouldRequestMoreRecs() &&
+				{ ! searchResults && (
+					<QueryReaderFeedsSearch query={ sitesQuery } excludeFollowed={ true } />
+				) }
+				{ this.shouldRequestMoreRecs() && (
 					<QueryReaderRecommendedSites
 						seed={ recommendationsSeed }
 						offset={ recommendedSitesPagingOffset + PAGE_SIZE || 0 }
-					/> }
-				<h2 className="following-manage__header">
-					{ translate( 'Follow Something New' ) }
-				</h2>
+					/>
+				) }
+				<h2 className="following-manage__header">{ translate( 'Follow Something New' ) }</h2>
 				<div ref={ this.handleStreamMounted } />
 				<div className="following-manage__fixed-area" ref={ this.handleSearchBoxMounted }>
 					<CompactCard className="following-manage__input-card">
@@ -228,7 +226,7 @@ class FollowingManage extends Component {
 						/>
 					</CompactCard>
 
-					{ showFollowByUrl &&
+					{ showFollowByUrl && (
 						<div className="following-manage__url-follow">
 							<FollowButton
 								followLabel={ translate( 'Follow %s', { args: sitesQueryWithoutProtocol } ) }
@@ -236,16 +234,18 @@ class FollowingManage extends Component {
 								siteUrl={ addSchemeIfMissing( readerAliasedFollowFeedUrl, 'http' ) }
 								followSource={ READER_FOLLOWING_MANAGE_URL_INPUT }
 							/>
-						</div> }
+						</div>
+					) }
 				</div>
 				{ hasFollows &&
-					! sitesQuery &&
+				! sitesQuery && (
 					<RecommendedSites
 						sites={ take( filteredRecommendedSites, 2 ) }
 						followSource={ READER_FOLLOWING_MANAGE_RECOMMENDATION }
-					/> }
+					/>
+				) }
 				{ !! sitesQuery &&
-					! isFollowByUrlWithNoSearchResults &&
+				! isFollowByUrlWithNoSearchResults && (
 					<FollowingManageSearchFeedsResults
 						searchResults={ searchResults }
 						showMoreResults={ showMoreResults }
@@ -253,14 +253,16 @@ class FollowingManage extends Component {
 						width={ this.state.width }
 						searchResultsCount={ searchResultsCount }
 						query={ sitesQuery }
-					/> }
-				{ showExistingSubscriptions &&
+					/>
+				) }
+				{ showExistingSubscriptions && (
 					<FollowingManageSubscriptions
 						width={ this.state.width }
 						query={ subsQuery }
 						sortOrder={ subsSortOrder }
 						windowScrollerRef={ this.handleWindowScrollerMounted }
-					/> }
+					/>
+				) }
 				{ ! hasFollows && <FollowingManageEmptyContent /> }
 			</ReaderMain>
 		);

--- a/client/reader/following-manage/sort-controls.jsx
+++ b/client/reader/following-manage/sort-controls.jsx
@@ -35,12 +35,8 @@ class FollowingManageSortControls extends React.Component {
 				onChange={ this.handleSelectChange }
 				value={ sortOrder }
 			>
-				<option value="date-followed">
-					{ this.props.translate( 'Sort by date followed' ) }
-				</option>
-				<option value="alpha">
-					{ this.props.translate( 'Sort by site name' ) }
-				</option>
+				<option value="date-followed">{ this.props.translate( 'Sort by date followed' ) }</option>
+				<option value="alpha">{ this.props.translate( 'Sort by site name' ) }</option>
 			</FormSelect>
 		);
 	}

--- a/client/reader/following-manage/subscriptions.jsx
+++ b/client/reader/following-manage/subscriptions.jsx
@@ -122,7 +122,7 @@ class FollowingManageSubscriptions extends Component {
 					</div>
 				</div>
 				<div className={ subsListClassNames }>
-					{ ! noSitesMatchQuery &&
+					{ ! noSitesMatchQuery && (
 						<InfiniteStream
 							items={ sortedFollows }
 							extraRenderItemProps={ {
@@ -133,14 +133,16 @@ class FollowingManageSubscriptions extends Component {
 							totalCount={ sortedFollows.length }
 							windowScrollerRef={ this.props.windowScrollerRef }
 							rowRenderer={ siteRowRenderer }
-						/> }
-					{ noSitesMatchQuery &&
+						/>
+					) }
+					{ noSitesMatchQuery && (
 						<span>
 							{ translate( 'Sorry, no followed sites match {{italic}}%s.{{/italic}}', {
 								components: { italic: <i /> },
 								args: query,
 							} ) }
-						</span> }
+						</span>
+					) }
 				</div>
 			</div>
 		);

--- a/client/reader/liked-stream/empty.jsx
+++ b/client/reader/liked-stream/empty.jsx
@@ -39,15 +39,15 @@ class TagEmptyContent extends React.Component {
 					{ this.props.translate( 'Back to Following' ) }
 				</a>
 			),
-			secondaryAction = isDiscoverEnabled()
-				? <a
-						className="empty-content__action button"
-						onClick={ this.recordSecondaryAction }
-						href="/discover"
-					>
-						{ this.props.translate( 'Explore Discover' ) }
-					</a>
-				: null;
+			secondaryAction = isDiscoverEnabled() ? (
+				<a
+					className="empty-content__action button"
+					onClick={ this.recordSecondaryAction }
+					href="/discover"
+				>
+					{ this.props.translate( 'Explore Discover' ) }
+				</a>
+			) : null;
 
 		return (
 			<EmptyContent

--- a/client/reader/list-item/actions.jsx
+++ b/client/reader/list-item/actions.jsx
@@ -6,11 +6,7 @@ import React from 'react';
 
 class ListItemActions extends React.PureComponent {
 	render() {
-		return (
-			<div className="reader-list-item__actions">
-				{ this.props.children }
-			</div>
-		);
+		return <div className="reader-list-item__actions">{ this.props.children }</div>;
 	}
 }
 

--- a/client/reader/list-item/description.jsx
+++ b/client/reader/list-item/description.jsx
@@ -7,11 +7,7 @@ import React from 'react';
 class ListItemDescription extends React.PureComponent {
 	render() {
 		// should this be a div instead of a p? p's have odd nesting rules that we can't enforce in code.
-		return (
-			<p className="reader-list-item__description">
-				{ this.props.children }
-			</p>
-		);
+		return <p className="reader-list-item__description">{ this.props.children }</p>;
 	}
 }
 

--- a/client/reader/list-item/index.jsx
+++ b/client/reader/list-item/index.jsx
@@ -13,11 +13,7 @@ import Card from 'components/card/compact';
 class ListItem extends React.PureComponent {
 	render() {
 		const classes = classnames( 'reader-list-item__card', this.props.className );
-		return (
-			<Card className={ classes }>
-				{ this.props.children }
-			</Card>
-		);
+		return <Card className={ classes }>{ this.props.children }</Card>;
 	}
 }
 

--- a/client/reader/list-stream/empty.jsx
+++ b/client/reader/list-stream/empty.jsx
@@ -39,15 +39,15 @@ class ListEmptyContent extends React.Component {
 					{ this.props.translate( 'Back to Following' ) }
 				</a>
 			),
-			secondaryAction = isDiscoverEnabled()
-				? <a
-						className="empty-content__action button"
-						onClick={ this.recordSecondaryAction }
-						href="/discover"
-					>
-						{ this.props.translate( 'Explore Discover' ) }
-					</a>
-				: null;
+			secondaryAction = isDiscoverEnabled() ? (
+				<a
+					className="empty-content__action button"
+					onClick={ this.recordSecondaryAction }
+					href="/discover"
+				>
+					{ this.props.translate( 'Explore Discover' ) }
+				</a>
+			) : null;
 
 		return (
 			<EmptyContent

--- a/client/reader/list-stream/header.jsx
+++ b/client/reader/list-stream/header.jsx
@@ -38,32 +38,27 @@ const ListStreamHeader = ( {
 			</span>
 
 			<div className="list-stream__header-details">
-				<h1 className="list-stream__header-title">
-					{ title }
-				</h1>
-				{ description &&
-					<p className="list-stream__header-description">
-						{ description }
-					</p> }
+				<h1 className="list-stream__header-title">{ title }</h1>
+				{ description && <p className="list-stream__header-description">{ description }</p> }
 			</div>
 
-			{ showFollow &&
+			{ showFollow && (
 				<div className="list-stream__header-follow">
 					<FollowButton iconSize={ 24 } following={ following } onFollowToggle={ onFollowToggle } />
-				</div> }
+				</div>
+			) }
 
 			{ showEdit &&
-				editUrl &&
+			editUrl && (
 				<div className="list-stream__header-edit">
 					<a href={ editUrl } rel={ isExternal( editUrl ) ? 'external' : '' }>
 						<span className="list-stream__header-action-icon">
 							<Gridicon icon="cog" size={ 24 } />
 						</span>
-						<span className="list-stream__header-action-label">
-							{ translate( 'Edit' ) }
-						</span>
+						<span className="list-stream__header-action-label">{ translate( 'Edit' ) }</span>
 					</a>
-				</div> }
+				</div>
+			) }
 		</Card>
 	);
 };

--- a/client/reader/list-stream/missing.jsx
+++ b/client/reader/list-stream/missing.jsx
@@ -42,15 +42,15 @@ class ListMissing extends React.Component {
 					{ this.props.translate( 'Back to Followed Sites' ) }
 				</a>
 			),
-			secondaryAction = isDiscoverEnabled()
-				? <a
-						className="empty-content__action button"
-						onClick={ this.recordSecondaryAction }
-						href="/discover"
-					>
-						{ this.props.translate( 'Explore Discover' ) }
-					</a>
-				: null;
+			secondaryAction = isDiscoverEnabled() ? (
+				<a
+					className="empty-content__action button"
+					onClick={ this.recordSecondaryAction }
+					href="/discover"
+				>
+					{ this.props.translate( 'Explore Discover' ) }
+				</a>
+			) : null;
 
 		return (
 			<div>

--- a/client/reader/post-excerpt-link/index.jsx
+++ b/client/reader/post-excerpt-link/index.jsx
@@ -44,9 +44,7 @@ class PostExcerptLink extends React.Component {
 				target="_blank"
 				rel="external noopener noreferrer"
 			>
-				<span className="post-excerpt-only-site-name">
-					{ this.props.siteName || '(untitled)' }
-				</span>
+				<span className="post-excerpt-only-site-name">{ this.props.siteName || '(untitled)' }</span>
 			</a>
 		);
 		const classes = classNames( {

--- a/client/reader/reading-time/index.jsx
+++ b/client/reader/reading-time/index.jsx
@@ -30,11 +30,7 @@ class ReadingTime extends React.PureComponent {
 			components: { Time: approxTime },
 		} );
 
-		return (
-			<span className="byline__reading-time reading-time">
-				{ readingTime }
-			</span>
-		);
+		return <span className="byline__reading-time reading-time">{ readingTime }</span>;
 	}
 }
 

--- a/client/reader/recommendations/posts/empty.jsx
+++ b/client/reader/recommendations/posts/empty.jsx
@@ -39,15 +39,15 @@ class RecommendedPostsEmptyContent extends React.Component {
 					{ this.props.translate( 'Back to Following' ) }
 				</a>
 			),
-			secondaryAction = isDiscoverEnabled()
-				? <a
-						className="empty-content__action button"
-						onClick={ this.recordSecondaryAction }
-						href="/discover"
-					>
-						{ this.props.translate( 'Explore Discover' ) }
-					</a>
-				: null;
+			secondaryAction = isDiscoverEnabled() ? (
+				<a
+					className="empty-content__action button"
+					onClick={ this.recordSecondaryAction }
+					href="/discover"
+				>
+					{ this.props.translate( 'Explore Discover' ) }
+				</a>
+			) : null;
 
 		return (
 			<EmptyContent

--- a/client/reader/search-stream/empty.jsx
+++ b/client/reader/search-stream/empty.jsx
@@ -40,23 +40,19 @@ class SearchEmptyContent extends React.Component {
 			</a>
 		);
 
-		const secondaryAction = isDiscoverEnabled()
-			? <a
-					className="empty-content__action button"
-					onClick={ this.recordSecondaryAction }
-					href="/discover"
-				>
-					{ this.props.translate( 'Explore Discover' ) }
-				</a>
-			: null;
+		const secondaryAction = isDiscoverEnabled() ? (
+			<a
+				className="empty-content__action button"
+				onClick={ this.recordSecondaryAction }
+				href="/discover"
+			>
+				{ this.props.translate( 'Explore Discover' ) }
+			</a>
+		) : null;
 
 		const message = this.props.translate( 'No posts found for {{query /}} for your language.', {
 			components: {
-				query: (
-					<em>
-						{ this.props.query }
-					</em>
-				),
+				query: <em>{ this.props.query }</em>,
 			},
 		} );
 

--- a/client/reader/search-stream/index.jsx
+++ b/client/reader/search-stream/index.jsx
@@ -39,14 +39,14 @@ const updateQueryArg = params =>
 
 const pickSort = sort => ( sort === 'date' ? SORT_BY_LAST_UPDATED : SORT_BY_RELEVANCE );
 
-const SpacerDiv = withDimensions( ( { width, height } ) =>
+const SpacerDiv = withDimensions( ( { width, height } ) => (
 	<div
 		style={ {
 			width: `${ width }px`,
 			height: `${ height }px`,
 		} }
 	/>
-);
+) );
 
 class SearchStream extends React.Component {
 	static propTypes = {
@@ -178,7 +178,7 @@ class SearchStream extends React.Component {
 							initialValue={ query || '' }
 							value={ query || '' }
 						/>
-						{ query &&
+						{ query && (
 							<SegmentedControl compact className="search-stream__sort-picker">
 								<ControlItem selected={ sortOrder !== 'date' } onClick={ this.useRelevanceSort }>
 									{ TEXT_RELEVANCE_SORT }
@@ -186,9 +186,10 @@ class SearchStream extends React.Component {
 								<ControlItem selected={ sortOrder === 'date' } onClick={ this.useDateSort }>
 									{ TEXT_DATE_SORT }
 								</ControlItem>
-							</SegmentedControl> }
+							</SegmentedControl>
+						) }
 					</CompactCard>
-					{ showFollowByUrl &&
+					{ showFollowByUrl && (
 						<div className="search-stream__url-follow">
 							<FollowButton
 								followLabel={ translate( 'Follow %s', { args: queryWithoutProtocol } ) }
@@ -196,14 +197,16 @@ class SearchStream extends React.Component {
 								siteUrl={ addSchemeIfMissing( readerAliasedFollowFeedUrl, 'http' ) }
 								followSource={ SEARCH_RESULTS_URL_INPUT }
 							/>
-						</div> }
-					{ query &&
+						</div>
+					) }
+					{ query && (
 						<SearchStreamHeader
 							selected={ searchType }
 							onSelection={ this.handleSearchTypeSelection }
 							wideDisplay={ wideDisplay }
-						/> }
-					{ ! query &&
+						/>
+					) }
+					{ ! query && (
 						<div className="search-stream__blank-suggestions">
 							{ suggestions &&
 								this.props.translate( 'Suggestions: {{suggestions /}}.', {
@@ -211,33 +214,39 @@ class SearchStream extends React.Component {
 										suggestions: suggestionList,
 									},
 								} ) }
-						</div> }
+						</div>
+					) }
 				</div>
 				<SpacerDiv domTarget={ this.fixedAreaRef } />
-				{ wideDisplay &&
+				{ wideDisplay && (
 					<div className={ searchStreamResultsClasses }>
 						<div className="search-stream__post-results">
 							<PostResults { ...this.props } />
 						</div>
-						{ query &&
+						{ query && (
 							<div className="search-stream__site-results">
 								<SiteResults
 									query={ query }
 									sort={ pickSort( sortOrder ) }
 									showLastUpdatedDate={ false }
 								/>
-							</div> }
-					</div> }
-				{ ! wideDisplay &&
+							</div>
+						) }
+					</div>
+				) }
+				{ ! wideDisplay && (
 					<div className={ singleColumnResultsClasses }>
-						{ ( ( searchType === SEARCH_TYPES.POSTS || ! query ) &&
-							<PostResults { ...this.props } /> ) ||
+						{ ( ( searchType === SEARCH_TYPES.POSTS || ! query ) && (
+							<PostResults { ...this.props } />
+						) ) || (
 							<SiteResults
 								query={ query }
 								sort={ pickSort( sortOrder ) }
 								showLastUpdatedDate={ true }
-							/> }
-					</div> }
+							/>
+						) }
+					</div>
+				) }
 			</div>
 		);
 	}
@@ -245,10 +254,11 @@ class SearchStream extends React.Component {
 
 /* eslint-disable */
 // wrapping with Main so that we can use withWidth helper to pass down whole width of Main
-const wrapWithMain = Component => props =>
+const wrapWithMain = Component => props => (
 	<ReaderMain className="search-stream search-stream__with-sites" wideLayout>
 		<Component { ...props } />
-	</ReaderMain>;
+	</ReaderMain>
+);
 /* eslint-enable */
 
 export default connect( ( state, ownProps ) => ( {

--- a/client/reader/search-stream/search-stream-header.jsx
+++ b/client/reader/search-stream/search-stream-header.jsx
@@ -36,12 +36,8 @@ class SearchStreamHeader extends Component {
 		if ( wideDisplay ) {
 			return (
 				<ul className="search-stream__headers">
-					<li className="search-stream__post-header">
-						{ translate( 'Posts' ) }
-					</li>
-					<li className="search-stream__site-header">
-						{ translate( 'Sites' ) }
-					</li>
+					<li className="search-stream__post-header">{ translate( 'Posts' ) }</li>
+					<li className="search-stream__site-header">{ translate( 'Sites' ) }</li>
 				</ul>
 			);
 		}

--- a/client/reader/sidebar/expandable-add-form.jsx
+++ b/client/reader/sidebar/expandable-add-form.jsx
@@ -58,11 +58,11 @@ export class ExpandableSidebarAddForm extends Component {
 		} );
 		return (
 			<div className={ classes }>
-				{ this.props.hideAddButton
-					? null
-					: <Button compact className="sidebar__menu-add-button" onClick={ this.toggleAdd }>
-							{ translate( 'Add' ) }
-						</Button> }
+				{ this.props.hideAddButton ? null : (
+					<Button compact className="sidebar__menu-add-button" onClick={ this.toggleAdd }>
+						{ translate( 'Add' ) }
+					</Button>
+				) }
 				<div className="sidebar__menu-add">
 					<input
 						aria-label={ addLabel }

--- a/client/reader/sidebar/expandable-heading.jsx
+++ b/client/reader/sidebar/expandable-heading.jsx
@@ -12,14 +12,13 @@ import Gridicon from 'gridicons';
 import SidebarHeading from 'layout/sidebar/heading';
 import Count from 'components/count';
 
-const ExpandableSidebarHeading = ( { title, count, onClick } ) =>
+const ExpandableSidebarHeading = ( { title, count, onClick } ) => (
 	<SidebarHeading onClick={ onClick }>
 		<Gridicon icon="chevron-down" />
-		<span>
-			{ title }
-		</span>
+		<span>{ title }</span>
 		<Count count={ count } />
-	</SidebarHeading>;
+	</SidebarHeading>
+);
 
 ExpandableSidebarHeading.propTypes = {
 	title: React.PropTypes.string.isRequired,

--- a/client/reader/sidebar/expandable.jsx
+++ b/client/reader/sidebar/expandable.jsx
@@ -39,9 +39,7 @@ export const ExpandableSidebarMenu = props => {
 				onAddClick={ onAddClick }
 				onAddSubmit={ onAddSubmit }
 			/>
-			<ul className="sidebar__menu-list">
-				{ props.children }
-			</ul>
+			<ul className="sidebar__menu-list">{ props.children }</ul>
 		</SidebarMenu>
 	);
 };

--- a/client/reader/sidebar/helper.js
+++ b/client/reader/sidebar/helper.js
@@ -11,7 +11,9 @@ const exported = {
 				.split( '?' )[ 0 ]
 				.replace( /\/manage$/, '' )
 				.toLowerCase(),
-			pathLowerCase = decodeURIComponent( path ).replace( /\/manage$/, '' ).toLowerCase();
+			pathLowerCase = decodeURIComponent( path )
+				.replace( /\/manage$/, '' )
+				.toLowerCase();
 
 		let selected = basePathLowerCase === pathLowerCase,
 			isActionButtonSelected = false;

--- a/client/reader/sidebar/index.jsx
+++ b/client/reader/sidebar/index.jsx
@@ -154,9 +154,7 @@ export const ReaderSidebar = createReactClass( {
 			<Sidebar onClick={ this.handleClick }>
 				<SidebarRegion>
 					<SidebarMenu>
-						<SidebarHeading>
-							{ this.props.translate( 'Streams' ) }
-						</SidebarHeading>
+						<SidebarHeading>{ this.props.translate( 'Streams' ) }</SidebarHeading>
 						<ul>
 							<li
 								className={ ReaderSidebarHelper.itemLinkClass( '/', this.props.path, {
@@ -177,7 +175,7 @@ export const ReaderSidebar = createReactClass( {
 									{ this.props.translate( 'Manage' ) }
 								</a>
 							</li>
-							{ config.isEnabled( 'reader/conversations' ) &&
+							{ config.isEnabled( 'reader/conversations' ) && (
 								<li
 									className={ ReaderSidebarHelper.itemLinkClass(
 										'/read/conversations',
@@ -196,10 +194,11 @@ export const ReaderSidebar = createReactClass( {
 											{ this.props.translate( 'Conversations' ) }
 										</span>
 									</a>
-								</li> }
+								</li>
+							) }
 							<ReaderSidebarTeams teams={ this.props.teams } path={ this.props.path } />
 							{ config.isEnabled( 'reader/conversations' ) &&
-								isAutomatticTeamMember( this.props.teams ) &&
+							isAutomatticTeamMember( this.props.teams ) && (
 								<li
 									className={ ReaderSidebarHelper.itemLinkClass(
 										'/read/conversations/a8c',
@@ -225,24 +224,23 @@ export const ReaderSidebar = createReactClass( {
 										</svg>
 										<span className="menu-link-text">A8C Conversations</span>
 									</a>
-								</li> }
+								</li>
+							) }
 
-							{ isDiscoverEnabled()
-								? <li
-										className={ ReaderSidebarHelper.itemLinkClass( '/discover', this.props.path, {
-											'sidebar-streams__discover': true,
-										} ) }
-									>
-										<a href="/discover" onClick={ this.handleReaderSidebarDiscoverClicked }>
-											<Gridicon icon="my-sites" />
-											<span className="menu-link-text">
-												{ this.props.translate( 'Discover' ) }
-											</span>
-										</a>
-									</li>
-								: null }
+							{ isDiscoverEnabled() ? (
+								<li
+									className={ ReaderSidebarHelper.itemLinkClass( '/discover', this.props.path, {
+										'sidebar-streams__discover': true,
+									} ) }
+								>
+									<a href="/discover" onClick={ this.handleReaderSidebarDiscoverClicked }>
+										<Gridicon icon="my-sites" />
+										<span className="menu-link-text">{ this.props.translate( 'Discover' ) }</span>
+									</a>
+								</li>
+							) : null }
 
-							{ config.isEnabled( 'reader/search' ) &&
+							{ config.isEnabled( 'reader/search' ) && (
 								<li
 									className={ ReaderSidebarHelper.itemLinkClass( '/read/search', this.props.path, {
 										'sidebar-streams__search': true,
@@ -250,11 +248,10 @@ export const ReaderSidebar = createReactClass( {
 								>
 									<a href="/read/search" onClick={ this.handleReaderSidebarSearchClicked }>
 										<Gridicon icon="search" size={ 24 } />
-										<span className="menu-link-text">
-											{ this.props.translate( 'Search' ) }
-										</span>
+										<span className="menu-link-text">{ this.props.translate( 'Search' ) }</span>
 									</a>
-								</li> }
+								</li>
+							) }
 
 							<li
 								className={ ReaderSidebarHelper.itemLinkClass(
@@ -265,9 +262,7 @@ export const ReaderSidebar = createReactClass( {
 							>
 								<a href="/activities/likes" onClick={ this.handleReaderSidebarLikeActivityClicked }>
 									<Gridicon icon="star" size={ 24 } />
-									<span className="menu-link-text">
-										{ this.props.translate( 'My Likes' ) }
-									</span>
+									<span className="menu-link-text">{ this.props.translate( 'My Likes' ) }</span>
 								</a>
 							</li>
 						</ul>
@@ -275,16 +270,16 @@ export const ReaderSidebar = createReactClass( {
 
 					<QueryReaderLists />
 					<QueryReaderTeams />
-					{ this.props.subscribedLists && this.props.subscribedLists.length
-						? <ReaderSidebarLists
-								lists={ this.props.subscribedLists }
-								path={ this.props.path }
-								isOpen={ this.props.isListsOpen }
-								onClick={ this.props.toggleListsVisibility }
-								currentListOwner={ this.state.currentListOwner }
-								currentListSlug={ this.state.currentListSlug }
-							/>
-						: null }
+					{ this.props.subscribedLists && this.props.subscribedLists.length ? (
+						<ReaderSidebarLists
+							lists={ this.props.subscribedLists }
+							path={ this.props.path }
+							isOpen={ this.props.isListsOpen }
+							onClick={ this.props.toggleListsVisibility }
+							currentListOwner={ this.state.currentListOwner }
+							currentListSlug={ this.state.currentListSlug }
+						/>
+					) : null }
 					<ReaderSidebarTags
 						tags={ this.props.followedTags }
 						path={ this.props.path }
@@ -295,10 +290,11 @@ export const ReaderSidebar = createReactClass( {
 					/>
 				</SidebarRegion>
 
-				{ this.props.shouldRenderAppPromo &&
+				{ this.props.shouldRenderAppPromo && (
 					<div className="sidebar__app-promo">
 						<AppPromo location="reader" locale={ userUtils.getLocaleSlug() } />
-					</div> }
+					</div>
+				) }
 
 				<SidebarFooter />
 			</Sidebar>

--- a/client/reader/sidebar/reader-sidebar-lists/list-item.jsx
+++ b/client/reader/sidebar/reader-sidebar-lists/list-item.jsx
@@ -77,9 +77,7 @@ export class ReaderSidebarListsListItem extends Component {
 						},
 					} ) }
 				>
-					<div className="sidebar__menu-item-listname">
-						{ list.title }
-					</div>
+					<div className="sidebar__menu-item-listname">{ list.title }</div>
 				</a>
 			</li>
 		);

--- a/client/reader/sidebar/reader-sidebar-lists/list.jsx
+++ b/client/reader/sidebar/reader-sidebar-lists/list.jsx
@@ -49,11 +49,7 @@ export class ReaderSidebarListsList extends React.Component {
 			);
 		}
 
-		return (
-			<div>
-				{ this.renderItems() }
-			</div>
-		);
+		return <div>{ this.renderItems() }</div>;
 	}
 }
 

--- a/client/reader/sidebar/reader-sidebar-tags/list-item.jsx
+++ b/client/reader/sidebar/reader-sidebar-tags/list-item.jsx
@@ -65,11 +65,9 @@ export class ReaderSidebarTagsListItem extends Component {
 						},
 					} ) }
 				>
-					<div className="sidebar__menu-item-tagname">
-						{ tagName }
-					</div>
+					<div className="sidebar__menu-item-tagname">{ tagName }</div>
 				</a>
-				{ tag.id !== 'pending' &&
+				{ tag.id !== 'pending' && (
 					<button
 						className="sidebar__menu-action"
 						data-tag-slug={ tag.slug }
@@ -81,10 +79,9 @@ export class ReaderSidebarTagsListItem extends Component {
 						} ) }
 					>
 						<Gridicon icon="cross-small" />
-						<span className="sidebar__menu-action-label">
-							{ translate( 'Unfollow' ) }
-						</span>
-					</button> }
+						<span className="sidebar__menu-action-label">{ translate( 'Unfollow' ) }</span>
+					</button>
+				) }
 			</li>
 		);
 		/* eslint-enable wpcalypso/jsx-classname-namespace */

--- a/client/reader/sidebar/reader-sidebar-tags/list.jsx
+++ b/client/reader/sidebar/reader-sidebar-tags/list.jsx
@@ -49,11 +49,7 @@ export class ReaderSidebarTagsList extends Component {
 			);
 		}
 
-		return (
-			<div>
-				{ this.renderItems() }
-			</div>
-		);
+		return <div>{ this.renderItems() }</div>;
 	}
 }
 

--- a/client/reader/sidebar/reader-sidebar-teams/index.jsx
+++ b/client/reader/sidebar/reader-sidebar-teams/index.jsx
@@ -11,9 +11,9 @@ import { map } from 'lodash';
 import ReaderSidebarTeamsListItem from './list-item';
 
 const renderItems = ( teams, path ) =>
-	map( teams, team =>
+	map( teams, team => (
 		<ReaderSidebarTeamsListItem key={ team.slug } team={ team } path={ path } />
-	);
+	) );
 
 export class ReaderSidebarTeams extends Component {
 	static propTypes = {
@@ -26,11 +26,7 @@ export class ReaderSidebarTeams extends Component {
 			return null;
 		}
 
-		return (
-			<div>
-				{ renderItems( this.props.teams, this.props.path ) }
-			</div>
-		);
+		return <div>{ renderItems( this.props.teams, this.props.path ) }</div>;
 	}
 }
 

--- a/client/reader/sidebar/reader-sidebar-teams/list-item.jsx
+++ b/client/reader/sidebar/reader-sidebar-teams/list-item.jsx
@@ -49,9 +49,7 @@ export const ReaderSidebarTeamsListItem = ( { path, team, translate } ) => {
 						8.9zm6.9-9.5c0-3.3-2.4-6.3-6.8-6.3s-6.8 3-6.8 6.3v.4c0 3.3 2.4 6.4 6.8 6.4s6.8-3 6.8-6.4V12z" />
 					<path d="M14.1 8.5c.6.4.7 1.2.4 1.7l-2.9 4.6c-.4.6-1.2.8-1.7.4-.7-.4-.9-1.2-.5-1.8l2.9-4.6c.4-.5 1.2-.7 1.8-.3z" />
 				</svg>
-				<span className="menu-link-text">
-					{ team.title }
-				</span>
+				<span className="menu-link-text">{ team.title }</span>
 			</a>
 		</li>
 	);

--- a/client/reader/site-stream/featured.jsx
+++ b/client/reader/site-stream/featured.jsx
@@ -116,9 +116,7 @@ export default localize(
 								onClick={ this.handleClick.bind( this, postData ) }
 							>
 								<div className="reader__featured-post-image" style={ style } />
-								<h2 className="reader__featured-post-title">
-									{ post.title }
-								</h2>
+								<h2 className="reader__featured-post-title">{ post.title }</h2>
 							</div>
 						);
 				}
@@ -135,17 +133,13 @@ export default localize(
 			return (
 				<Card className="reader__featured-card">
 					<div className="reader__featured-header">
-						<div className="reader__featured-title">
-							{ this.props.translate( 'Highlights' ) }
-						</div>
+						<div className="reader__featured-title">{ this.props.translate( 'Highlights' ) }</div>
 						<div className="reader__featured-description">
 							{ this.props.translate( 'What we’re reading this week.' ) }
 						</div>
 					</div>
 
-					<div className="reader__featured-posts">
-						{ this.renderPosts() }
-					</div>
+					<div className="reader__featured-posts">{ this.renderPosts() }</div>
 				</Card>
 			);
 		}

--- a/client/reader/stream/empty.jsx
+++ b/client/reader/stream/empty.jsx
@@ -24,15 +24,15 @@ class FollowingEmptyContent extends React.Component {
 	};
 
 	render() {
-		const action = isDiscoverEnabled()
-				? <a
-						className="empty-content__action button is-primary"
-						onClick={ this.recordAction }
-						href="/read/search"
-					>
-						{ this.props.translate( 'Find Sites to Follow' ) }
-					</a>
-				: null,
+		const action = isDiscoverEnabled() ? (
+				<a
+					className="empty-content__action button is-primary"
+					onClick={ this.recordAction }
+					href="/read/search"
+				>
+					{ this.props.translate( 'Find Sites to Follow' ) }
+				</a>
+			) : null,
 			secondaryAction = null;
 
 		/* eslint-disable wpcalypso/jsx-classname-namespace */

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -475,12 +475,11 @@ class ReaderStream extends React.Component {
 		return (
 			<TopLevel className={ classnames( 'following', this.props.className ) }>
 				{ this.props.isMain &&
-					this.props.showMobileBackToSidebar &&
+				this.props.showMobileBackToSidebar && (
 					<MobileBackToSidebar>
-						<h1>
-							{ this.props.translate( 'Streams' ) }
-						</h1>
-					</MobileBackToSidebar> }
+						<h1>{ this.props.translate( 'Streams' ) }</h1>
+					</MobileBackToSidebar>
+				) }
 
 				<UpdateNotice count={ this.state.updateCount } onClick={ this.showUpdates } />
 				{ this.props.children }

--- a/client/reader/stream/post-unavailable.jsx
+++ b/client/reader/stream/post-unavailable.jsx
@@ -42,14 +42,10 @@ class PostUnavailable extends React.PureComponent {
 				</div>
 
 				<div className="reader__post-excerpt">
-					<p>
-						{ errorMessage }
-					</p>
-					{ config.isEnabled( 'reader/full-errors' )
-						? <pre>
-								{ JSON.stringify( this.props.post, null, '  ' ) }
-							</pre>
-						: null }
+					<p>{ errorMessage }</p>
+					{ config.isEnabled( 'reader/full-errors' ) ? (
+						<pre>{ JSON.stringify( this.props.post, null, '  ' ) }</pre>
+					) : null }
 				</div>
 			</Card>
 		);

--- a/client/reader/stream/post.jsx
+++ b/client/reader/stream/post.jsx
@@ -93,8 +93,9 @@ class ReaderPostCardAdapter extends React.Component {
 			>
 				{ feedId && <QueryReaderFeed feedId={ feedId } includeMeta={ false } /> }
 				{ ! isExternal && siteId && <QueryReaderSite siteId={ +siteId } includeMeta={ false } /> }
-				{ discoverPickSiteId &&
-					<QueryReaderSite siteId={ discoverPickSiteId } includeMeta={ false } /> }
+				{ discoverPickSiteId && (
+					<QueryReaderSite siteId={ discoverPickSiteId } includeMeta={ false } />
+				) }
 			</ReaderPostCard>
 		);
 	}

--- a/client/reader/stream/test/utils.js
+++ b/client/reader/stream/test/utils.js
@@ -46,9 +46,21 @@ describe( 'reader stream', () => {
 		const datePostKey = date => ( { date } );
 		const todayPostKey = datePostKey( today );
 		const todayPostKey2 = datePostKey( new Date() );
-		const oneYearAgoPostKey = datePostKey( moment( today ).subtract( 1, 'year' ).toDate() );
-		const oneYearInTheFuturePostKey = datePostKey( moment( today ).add( 1, 'year' ).toDate() );
-		const oneMonthAgoPostKey = datePostKey( moment( today ).subtract( 1, 'month' ).toDate() );
+		const oneYearAgoPostKey = datePostKey(
+			moment( today )
+				.subtract( 1, 'year' )
+				.toDate()
+		);
+		const oneYearInTheFuturePostKey = datePostKey(
+			moment( today )
+				.add( 1, 'year' )
+				.toDate()
+		);
+		const oneMonthAgoPostKey = datePostKey(
+			moment( today )
+				.subtract( 1, 'month' )
+				.toDate()
+		);
 
 		it( 'should return true when two days are the same day', () => {
 			assert( sameDay( todayPostKey, todayPostKey2 ) );
@@ -186,7 +198,9 @@ describe( 'reader stream', () => {
 		} );
 
 		it( 'should not combine cards that are greater than a day apart', () => {
-			const theDistantPast = moment().year( -1 ).toDate();
+			const theDistantPast = moment()
+				.year( -1 )
+				.toDate();
 			const postKeys = [ site1Key1, { ...site1Key2, date: theDistantPast } ];
 			const combinedItems = combineCards( postKeys );
 			expect( combinedItems ).eql( postKeys );

--- a/client/reader/stream/x-post.jsx
+++ b/client/reader/stream/x-post.jsx
@@ -134,14 +134,15 @@ class CrossPost extends PureComponent {
 				<span className="reader__x-post-site" key={ xPostedTo.siteURL + '-' + index }>
 					{ xPostedTo.siteName }
 					{ index + 2 < array.length && <span>, </span> }
-					{ index + 2 === array.length &&
+					{ index + 2 === array.length && (
 						<span>
 							{' '}
 							{ this.props.translate( 'and', {
 								comment:
 									'last conjunction in a list of blognames: (blog1, blog2,) blog3 _and_ blog4',
 							} ) }{' '}
-						</span> }
+						</span>
+					) }
 				</span>
 			);
 		} );
@@ -174,7 +175,7 @@ class CrossPost extends PureComponent {
 					isCompact={ true }
 				/>
 				<div className="reader__x-post">
-					{ post.title &&
+					{ post.title && (
 						<h1 className="reader__post-title">
 							<a
 								className="reader__post-title-link"
@@ -185,7 +186,8 @@ class CrossPost extends PureComponent {
 							>
 								{ xpostTitle }
 							</a>
-						</h1> }
+						</h1>
+					) }
 					{ this.getDescription( post.author.first_name ) }
 				</div>
 				{ feedId && <QueryReaderFeed feedId={ +feedId } includeMeta={ false } /> }

--- a/client/reader/tag-stream/empty.jsx
+++ b/client/reader/tag-stream/empty.jsx
@@ -40,25 +40,21 @@ class TagEmptyContent extends React.Component {
 			</a>
 		);
 
-		const secondaryAction = isDiscoverEnabled()
-			? <a
-					className="empty-content__action button"
-					onClick={ this.recordSecondaryAction }
-					href="/discover"
-				>
-					{ this.props.translate( 'Explore Discover' ) }
-				</a>
-			: null;
+		const secondaryAction = isDiscoverEnabled() ? (
+			<a
+				className="empty-content__action button"
+				onClick={ this.recordSecondaryAction }
+				href="/discover"
+			>
+				{ this.props.translate( 'Explore Discover' ) }
+			</a>
+		) : null;
 
 		const message = this.props.translate(
 			'No posts have recently been tagged with {{tagName /}} for your language.',
 			{
 				components: {
-					tagName: (
-						<em>
-							{ this.props.decodedTagSlug }
-						</em>
-					),
+					tagName: <em>{ this.props.decodedTagSlug }</em>,
 				},
 			}
 		);

--- a/client/reader/tag-stream/header.jsx
+++ b/client/reader/tag-stream/header.jsx
@@ -94,7 +94,7 @@ class TagStreamHeader extends React.Component {
 		return (
 			<div className={ classes }>
 				<QueryReaderTagImages tag={ imageSearchString } />
-				{ showFollow &&
+				{ showFollow && (
 					<div className="tag-stream__header-follow">
 						<FollowButton
 							followLabel={ translate( 'Follow Tag' ) }
@@ -103,14 +103,15 @@ class TagStreamHeader extends React.Component {
 							following={ following }
 							onFollowToggle={ onFollowToggle }
 						/>
-					</div> }
+					</div>
+				) }
 
 				<div className="tag-stream__header-image" style={ imageStyle }>
 					<h1 className="tag-stream__header-image-title">
 						<Gridicon icon="tag" size={ 24 } />
 						{ title }
 					</h1>
-					{ tagImage &&
+					{ tagImage && (
 						<div className="tag-stream__header-image-byline">
 							{ translate( '{{photoByWrapper}}Photo by{{/photoByWrapper}} {{authorLink/}}', {
 								components: {
@@ -118,7 +119,8 @@ class TagStreamHeader extends React.Component {
 									authorLink,
 								},
 							} ) }
-						</div> }
+						</div>
+					) }
 				</div>
 			</div>
 		);

--- a/client/state/comments/test/actions.js
+++ b/client/state/comments/test/actions.js
@@ -33,7 +33,10 @@ const POST_ID = 287;
 describe( 'actions', () => {
 	describe( '#requestPostComments()', () => {
 		useSandbox( sandbox => {
-			sandbox.stub( config, 'isEnabled' ).withArgs( 'comments/filters-in-posts' ).returns( true );
+			sandbox
+				.stub( config, 'isEnabled' )
+				.withArgs( 'comments/filters-in-posts' )
+				.returns( true );
 		} );
 
 		it( 'should return a comment request action', function() {

--- a/client/state/comments/test/reducer.js
+++ b/client/state/comments/test/reducer.js
@@ -47,7 +47,7 @@ describe( 'reducer', () => {
 				type: COMMENTS_RECEIVE,
 				siteId: 1,
 				postId: 1,
-				comments: [ ...commentsNestedTree ].sort( () => ( Math.random() * 2 % 2 ? -1 : 1 ) ),
+				comments: [ ...commentsNestedTree ].sort( () => ( ( Math.random() * 2 ) % 2 ? -1 : 1 ) ),
 			} );
 			const ids = map( response[ '1-1' ], 'ID' );
 

--- a/client/state/data-layer/wpcom/sites/activity/test/from-api.js
+++ b/client/state/data-layer/wpcom/sites/activity/test/from-api.js
@@ -109,8 +109,8 @@ describe( 'fromApi', () => {
 
 	context( 'processItem', () => {
 		it( 'should process an item', () => {
-			expect( processItem( VALID_API_ITEM ) ).to.be
-				.an( 'object' )
+			expect( processItem( VALID_API_ITEM ) )
+				.to.be.an( 'object' )
 				.that.has.keys( [
 					'activityDate',
 					'activityGroup',

--- a/client/state/data-layer/wpcom/sites/activity/test/index.js
+++ b/client/state/data-layer/wpcom/sites/activity/test/index.js
@@ -67,8 +67,8 @@ describe( 'receiveActivityLog', () => {
 		const dispatch = sinon.spy();
 		receiveActivityLog( { dispatch }, { siteId: SITE_ID }, SUCCESS_RESPONSE );
 		expect( dispatch ).to.have.been.called.once;
-		expect( dispatch.args[ 0 ][ 0 ] ).to.be
-			.an( 'object' )
+		expect( dispatch.args[ 0 ][ 0 ] )
+			.to.be.an( 'object' )
 			.that.has.keys( [ 'type', 'siteId', 'data' ] )
 			.that.has.property( 'type', ACTIVITY_LOG_UPDATE );
 	} );

--- a/client/state/reader/feeds/actions.js
+++ b/client/state/reader/feeds/actions.js
@@ -24,25 +24,28 @@ export function requestFeed( feedId ) {
 				feed_ID: feedId,
 			},
 		} );
-		return wpcom.undocumented().readFeed( { ID: feedId } ).then(
-			function success( data ) {
-				dispatch( {
-					type: READER_FEED_REQUEST_SUCCESS,
-					payload: data,
-				} );
-				return data;
-			},
-			function failure( err ) {
-				dispatch( {
-					type: READER_FEED_REQUEST_FAILURE,
-					payload: {
-						feed_ID: feedId,
-					},
-					error: err,
-				} );
-				throw err;
-			}
-		);
+		return wpcom
+			.undocumented()
+			.readFeed( { ID: feedId } )
+			.then(
+				function success( data ) {
+					dispatch( {
+						type: READER_FEED_REQUEST_SUCCESS,
+						payload: data,
+					} );
+					return data;
+				},
+				function failure( err ) {
+					dispatch( {
+						type: READER_FEED_REQUEST_FAILURE,
+						payload: {
+							feed_ID: feedId,
+						},
+						error: err,
+					} );
+					throw err;
+				}
+			);
 	};
 }
 

--- a/client/state/reader/feeds/test/actions.js
+++ b/client/state/reader/feeds/test/actions.js
@@ -22,10 +22,12 @@ describe( 'actions', () => {
 		let request;
 
 		useNock( nock => {
-			nock( 'https://public-api.wordpress.com:443' ).get( '/rest/v1.1/read/feed/1' ).reply( 200, {
-				feed_ID: 1,
-				name: 'My test feed',
-			} );
+			nock( 'https://public-api.wordpress.com:443' )
+				.get( '/rest/v1.1/read/feed/1' )
+				.reply( 200, {
+					feed_ID: 1,
+					name: 'My test feed',
+				} );
 			request = requestFeed( 1 )( spy );
 		} );
 
@@ -62,7 +64,9 @@ describe( 'actions', () => {
 		let request;
 
 		useNock( nock => {
-			nock( 'https://public-api.wordpress.com:443' ).get( '/rest/v1.1/read/feed/1' ).reply( 404 );
+			nock( 'https://public-api.wordpress.com:443' )
+				.get( '/rest/v1.1/read/feed/1' )
+				.reply( 404 );
 			request = requestFeed( 1 )( spy );
 		} );
 

--- a/client/state/reader/feeds/test/reducer.js
+++ b/client/state/reader/feeds/test/reducer.js
@@ -261,7 +261,9 @@ describe( 'reducer', () => {
 				type: READER_FEED_REQUEST_SUCCESS,
 				payload: { feed_ID: 1 },
 			};
-			expect( lastFetched( original, action ) ).to.have.a.property( 1 ).that.is.a( 'number' );
+			expect( lastFetched( original, action ) )
+				.to.have.a.property( 1 )
+				.that.is.a( 'number' );
 		} );
 
 		it( 'should update the last fetched time on feed update', () => {
@@ -270,7 +272,9 @@ describe( 'reducer', () => {
 				type: READER_FEED_UPDATE,
 				payload: [ { feed_ID: 1 } ],
 			};
-			expect( lastFetched( original, action ) ).to.have.a.property( 1 ).that.is.a( 'number' );
+			expect( lastFetched( original, action ) )
+				.to.have.a.property( 1 )
+				.that.is.a( 'number' );
 		} );
 	} );
 } );

--- a/client/state/reader/related-posts/actions.js
+++ b/client/state/reader/related-posts/actions.js
@@ -43,49 +43,52 @@ export function requestRelatedPosts( siteId, postId, scope = SCOPE_ALL ) {
 			query.size_global = 2;
 		}
 
-		return wpcom.undocumented().readSitePostRelated( query ).then(
-			response => {
-				dispatch( {
-					type: READER_RELATED_POSTS_REQUEST_SUCCESS,
-					payload: { siteId, postId, scope },
-				} );
-				const sites = filter( map( response && response.posts, 'meta.data.site' ), Boolean );
-				if ( sites && sites.length !== 0 ) {
+		return wpcom
+			.undocumented()
+			.readSitePostRelated( query )
+			.then(
+				response => {
 					dispatch( {
-						type: READER_SITE_UPDATE,
-						payload: sites,
+						type: READER_RELATED_POSTS_REQUEST_SUCCESS,
+						payload: { siteId, postId, scope },
 					} );
-				}
-				// collect posts and dispatch
-				dispatch( receivePosts( response && response.posts ) ).then( () => {
+					const sites = filter( map( response && response.posts, 'meta.data.site' ), Boolean );
+					if ( sites && sites.length !== 0 ) {
+						dispatch( {
+							type: READER_SITE_UPDATE,
+							payload: sites,
+						} );
+					}
+					// collect posts and dispatch
+					dispatch( receivePosts( response && response.posts ) ).then( () => {
+						dispatch( {
+							type: READER_RELATED_POSTS_RECEIVE,
+							payload: {
+								siteId,
+								postId,
+								scope,
+								posts: ( response && response.posts ) || [],
+							},
+						} );
+					} );
+				},
+				err => {
+					dispatch( {
+						type: READER_RELATED_POSTS_REQUEST_FAILURE,
+						payload: { siteId, postId, scope, error: err },
+						error: true,
+					} );
+
 					dispatch( {
 						type: READER_RELATED_POSTS_RECEIVE,
 						payload: {
 							siteId,
 							postId,
 							scope,
-							posts: ( response && response.posts ) || [],
+							posts: [],
 						},
 					} );
-				} );
-			},
-			err => {
-				dispatch( {
-					type: READER_RELATED_POSTS_REQUEST_FAILURE,
-					payload: { siteId, postId, scope, error: err },
-					error: true,
-				} );
-
-				dispatch( {
-					type: READER_RELATED_POSTS_RECEIVE,
-					payload: {
-						siteId,
-						postId,
-						scope,
-						posts: [],
-					},
-				} );
-			}
-		);
+				}
+			);
 	};
 }

--- a/client/state/reader/sites/test/actions.js
+++ b/client/state/reader/sites/test/actions.js
@@ -82,7 +82,9 @@ describe( 'actions', () => {
 		let request;
 
 		useNock( nock => {
-			nock( 'https://public-api.wordpress.com:443' ).get( '/rest/v1.1/read/sites/1' ).reply( 404 );
+			nock( 'https://public-api.wordpress.com:443' )
+				.get( '/rest/v1.1/read/sites/1' )
+				.reply( 404 );
 			request = requestSite( 1 )( spy );
 		} );
 

--- a/client/state/reader/sites/test/reducer.js
+++ b/client/state/reader/sites/test/reducer.js
@@ -132,8 +132,8 @@ describe( 'reducer', () => {
 						},
 					}
 				)[ 1 ]
-			).to.have.a
-				.property( 'description' )
+			)
+				.to.have.a.property( 'description' )
 				.that.equals( 'Apples&Pears' );
 		} );
 
@@ -264,7 +264,9 @@ describe( 'reducer', () => {
 				type: READER_SITE_REQUEST_SUCCESS,
 				payload: { ID: 1 },
 			};
-			expect( lastFetched( original, action ) ).to.have.a.property( 1 ).that.is.a( 'number' );
+			expect( lastFetched( original, action ) )
+				.to.have.a.property( 1 )
+				.that.is.a( 'number' );
 		} );
 
 		it( 'should update the last fetched time on site update', () => {
@@ -273,7 +275,9 @@ describe( 'reducer', () => {
 				type: READER_SITE_UPDATE,
 				payload: [ { ID: 1 } ],
 			};
-			expect( lastFetched( original, action ) ).to.have.a.property( 1 ).that.is.a( 'number' );
+			expect( lastFetched( original, action ) )
+				.to.have.a.property( 1 )
+				.that.is.a( 'number' );
 		} );
 	} );
 } );

--- a/client/state/reader/tags/images/actions.js
+++ b/client/state/reader/tags/images/actions.js
@@ -56,26 +56,29 @@ export function requestTagImages( tag, limit = 5 ) {
 
 		debug( `Requesting tag images for tag ${ tag }` );
 
-		return wpcom.undocumented().readTagImages( query ).then(
-			data => {
-				dispatch( receiveTagImages( tag, ( data && data.images ) || [] ) );
+		return wpcom
+			.undocumented()
+			.readTagImages( query )
+			.then(
+				data => {
+					dispatch( receiveTagImages( tag, ( data && data.images ) || [] ) );
 
-				dispatch( {
-					type: READER_TAG_IMAGES_REQUEST_SUCCESS,
-					tag,
-					data,
-				} );
-			},
-			error => {
-				// dispatch an empty array so we stop requesting it
-				dispatch( receiveTagImages( tag, [] ) );
+					dispatch( {
+						type: READER_TAG_IMAGES_REQUEST_SUCCESS,
+						tag,
+						data,
+					} );
+				},
+				error => {
+					// dispatch an empty array so we stop requesting it
+					dispatch( receiveTagImages( tag, [] ) );
 
-				dispatch( {
-					type: READER_TAG_IMAGES_REQUEST_FAILURE,
-					tag,
-					error,
-				} );
-			}
-		);
+					dispatch( {
+						type: READER_TAG_IMAGES_REQUEST_FAILURE,
+						tag,
+						error,
+					} );
+				}
+			);
 	};
 }

--- a/client/state/reader/tags/items/actions.js
+++ b/client/state/reader/tags/items/actions.js
@@ -22,7 +22,12 @@ import {
  * @return {String}      Tag slug
  */
 export const slugify = tag =>
-	encodeURIComponent( trim( tag ).toLowerCase().replace( /\s+/g, '-' ).replace( /-{2,}/g, '-' ) );
+	encodeURIComponent(
+		trim( tag )
+			.toLowerCase()
+			.replace( /\s+/g, '-' )
+			.replace( /-{2,}/g, '-' )
+	);
 
 export const requestTags = tag => {
 	const type = READER_TAGS_REQUEST;

--- a/client/state/reader/thumbnails/test/actions.js
+++ b/client/state/reader/thumbnails/test/actions.js
@@ -51,8 +51,12 @@ describe( 'actions', () => {
 		const youtubeThumbnailUrl = 'https://img.youtube.com/vi/UoOCrbV3ZQ/mqdefault.jpg';
 
 		useNock( nock => {
-			nock( vimeoSuccessApiUrl ).get( '' ).reply( 200, deepFreeze( sampleVimeoResponse ) );
-			nock( vimeoFailureApiUrl ).get( '' ).reply( 500, deepFreeze( {} ) );
+			nock( vimeoSuccessApiUrl )
+				.get( '' )
+				.reply( 200, deepFreeze( sampleVimeoResponse ) );
+			nock( vimeoFailureApiUrl )
+				.get( '' )
+				.reply( 500, deepFreeze( {} ) );
 		} );
 
 		it( 'vimeo: should dispatch properly when receiving a valid response', () => {


### PR DESCRIPTION
Since the [1.6 upgrade](https://github.com/Automattic/wp-calypso/pull/17999) we haven't reran prettier on all our `@format`ed files.
This PR is the result of `npm run reformat-files`.  Also its very cool to see prettier being used for at least `109` files :)

cc @jsnajdr 