### PR TITLE
Extensions: Zoninator - Implement a 'zone not found' view

### DIFF
--- a/client/extensions/zoninator/components/settings/zone/index.jsx
+++ b/client/extensions/zoninator/components/settings/zone/index.jsx
@@ -15,12 +15,13 @@ import HeaderCake from 'components/header-cake';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import DeleteZoneDialog from './delete-zone-dialog';
 import QueryFeed from '../../data/query-feed';
-import ZoneDetailsForm from '../../forms/zone-details-form';
 import ZoneContentForm from '../../forms/zone-content-form';
+import ZoneDetailsForm from '../../forms/zone-details-form';
+import ZoneNotFound from './zone-not-found';
 import { saveFeed } from '../../../state/feeds/actions';
 import { deleteZone, saveZone } from '../../../state/zones/actions';
 import { getFeed } from '../../../state/feeds/selectors';
-import { getZone } from '../../../state/zones/selectors';
+import { getZone, isRequestingZones } from '../../../state/zones/selectors';
 import { settingsPath } from '../../../app/util';
 
 class Zone extends Component {
@@ -28,6 +29,7 @@ class Zone extends Component {
 	static propTypes = {
 		deleteZone: PropTypes.func.isRequired,
 		feed: PropTypes.array,
+		isRequesting: PropTypes.bool,
 		saveFeed: PropTypes.func.isRequired,
 		saveZone: PropTypes.func.isRequired,
 		siteId: PropTypes.number,
@@ -51,27 +53,23 @@ class Zone extends Component {
 
 	saveZoneFeed = ( form, data ) => this.props.saveFeed( this.props.siteId, this.props.zoneId, form, data.posts );
 
-	render() {
-		const { feed, siteId, siteSlug, translate, zone, zoneId } = this.props;
+	renderContent() {
+		const { feed, siteSlug, translate, zone } = this.props;
 		const { showDeleteDialog } = this.state;
+
+		if ( ! zone ) {
+			return <ZoneNotFound siteSlug={ siteSlug } />;
+		}
 
 		return (
 			<div>
-				{ siteId && zoneId && <QueryFeed siteId={ siteId } zoneId={ zoneId } /> }
-
-				<HeaderCake
-					backHref={ `${ settingsPath }/${ siteSlug }` }
-					actionButton={ <Button compact primary scary onClick={ this.showDeleteDialog }>{ translate( 'Delete' ) }</Button> } >
-					{ translate( 'Edit zone' ) }
-				</HeaderCake>
-
 				{
 					showDeleteDialog &&
 					<DeleteZoneDialog
 						zoneName={ zone.name }
 						onConfirm={ this.deleteZone }
 						onCancel={ this.hideDeleteDialog } />
-					}
+				}
 
 				<ZoneDetailsForm
 					label={ translate( 'Zone label' ) }
@@ -85,6 +83,24 @@ class Zone extends Component {
 			</div>
 		);
 	}
+
+	render() {
+		const { isRequesting, siteId, siteSlug, translate, zoneId } = this.props;
+
+		return (
+			<div>
+				{ siteId && zoneId && <QueryFeed siteId={ siteId } zoneId={ zoneId } /> }
+
+				<HeaderCake
+					backHref={ `${ settingsPath }/${ siteSlug }` }
+					actionButton={ <Button compact primary scary onClick={ this.showDeleteDialog }>{ translate( 'Delete' ) }</Button> } >
+					{ translate( 'Edit zone' ) }
+				</HeaderCake>
+
+				{ ! isRequesting && this.renderContent() }
+			</div>
+		);
+	}
 }
 
 const connectComponent = connect(
@@ -92,6 +108,7 @@ const connectComponent = connect(
 		const siteId = getSelectedSiteId( state );
 
 		return {
+			isRequesting: isRequestingZones( state, siteId ),
 			siteId,
 			siteSlug: getSelectedSiteSlug( state ),
 			zone: getZone( state, siteId, zoneId ),

--- a/client/extensions/zoninator/components/settings/zone/index.jsx
+++ b/client/extensions/zoninator/components/settings/zone/index.jsx
@@ -85,7 +85,13 @@ class Zone extends Component {
 	}
 
 	render() {
-		const { isRequesting, siteId, siteSlug, translate, zoneId } = this.props;
+		const { isRequesting, siteId, siteSlug, translate, zone, zoneId } = this.props;
+
+		const deleteButton = (
+			<Button compact primary scary onClick={ this.showDeleteDialog }>
+				{ translate( 'Delete' ) }
+			</Button>
+		);
 
 		return (
 			<div>
@@ -93,7 +99,7 @@ class Zone extends Component {
 
 				<HeaderCake
 					backHref={ `${ settingsPath }/${ siteSlug }` }
-					actionButton={ <Button compact primary scary onClick={ this.showDeleteDialog }>{ translate( 'Delete' ) }</Button> } >
+					actionButton={ zone && deleteButton } >
 					{ translate( 'Edit zone' ) }
 				</HeaderCake>
 

--- a/client/extensions/zoninator/components/settings/zone/zone-not-found.jsx
+++ b/client/extensions/zoninator/components/settings/zone/zone-not-found.jsx
@@ -9,14 +9,18 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import EmptyContent from 'components/empty-content';
+import { settingsPath } from '../../../app/util';
 
-const ZoneNotFound = ( { translate } ) => (
+const ZoneNotFound = ( { siteSlug, translate } ) => (
 	<EmptyContent
 		title={ translate( 'Zone not found' ) }
-		line={ translate( 'The zone you\'re trying to access doesn\'t exist.' ) } />
+		line={ translate( 'The zone you\'re trying to access doesn\'t exist.' ) }
+		action={ translate( 'Add new' ) }
+		actionURL={ `${ settingsPath }/new/${ siteSlug }` } />
 );
 
 ZoneNotFound.propTypes = {
+	siteSlug: PropTypes.string,
 	translate: PropTypes.func.isRequired,
 };
 

--- a/client/extensions/zoninator/components/settings/zone/zone-not-found.jsx
+++ b/client/extensions/zoninator/components/settings/zone/zone-not-found.jsx
@@ -1,0 +1,27 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { PropTypes } from 'prop-types';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import EmptyContent from 'components/empty-content';
+import { settingsPath } from '../../../app/util';
+
+const ZoneNotFound = ( { siteSlug, translate } ) => (
+	<EmptyContent
+		title={ translate( 'Zone not found' ) }
+		line={ translate( 'The zone you\'re trying to access doesn\'t exist.' ) }
+		action={ translate( 'Return to zones dashboard' ) }
+		actionURL={ `${ settingsPath }/${ siteSlug }` } />
+);
+
+ZoneNotFound.propTypes = {
+	siteSlug: PropTypes.string,
+	translate: PropTypes.func.isRequired,
+};
+
+export default localize( ZoneNotFound );

--- a/client/extensions/zoninator/components/settings/zone/zone-not-found.jsx
+++ b/client/extensions/zoninator/components/settings/zone/zone-not-found.jsx
@@ -9,18 +9,14 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import EmptyContent from 'components/empty-content';
-import { settingsPath } from '../../../app/util';
 
-const ZoneNotFound = ( { siteSlug, translate } ) => (
+const ZoneNotFound = ( { translate } ) => (
 	<EmptyContent
 		title={ translate( 'Zone not found' ) }
-		line={ translate( 'The zone you\'re trying to access doesn\'t exist.' ) }
-		action={ translate( 'Return to zones dashboard' ) }
-		actionURL={ `${ settingsPath }/${ siteSlug }` } />
+		line={ translate( 'The zone you\'re trying to access doesn\'t exist.' ) } />
 );
 
 ZoneNotFound.propTypes = {
-	siteSlug: PropTypes.string,
 	translate: PropTypes.func.isRequired,
 };
 


### PR DESCRIPTION
This PR implements a *zone not found* view for Zoninator calypso extension.

![screen shot 2017-09-20 at 11 48 02](https://user-images.githubusercontent.com/8056203/30637838-cf2b2b0e-9df9-11e7-8c84-02f12bb32b47.png)

# Testing

- Go to `/extensions/zoninator` and choose a zone.
- Change the zone ID ( last part of the url ) to a random high number and reload the page. *Zone not found* message should appear.
- The `Delete` button shouldn't be visible in the header if a zone doesn't exist.
- `Return to zones dashboard` button should redirect back to the zones dashboard.
