### PR TITLE
Update Gridicons to 2.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "fuse.js": "2.6.1",
     "get-video-id": "2.1.4",
     "globby": "6.1.0",
-    "gridicons": "2.0.3",
+    "gridicons": "2.0.4",
     "happypack": "4.0.0-beta.1",
     "hard-source-webpack-plugin": "0.3.12",
     "hash.js": "1.1.3",


### PR DESCRIPTION
We need the "Gift" icon added in 2.0.4 for Promotions in Store on WP.

You can view the icon here; https://github.com/Automattic/gridicons/pull/248.