### PR TITLE
Comments: Enable user info and block user

### DIFF
--- a/client/blocks/comment-detail/comment-detail-author.jsx
+++ b/client/blocks/comment-detail/comment-detail-author.jsx
@@ -152,21 +152,26 @@ export class CommentDetailAuthor extends Component {
 					<div className="comment-detail__author-more-element">
 						<Gridicon icon="mail" />
 						<span>
-							{ authorEmail }
+							{ authorEmail || <em>{ translate( 'No email address' ) }</em> }
 						</span>
 					</div>
 					<div className="comment-detail__author-more-element">
 						<Gridicon icon="link" />
-						<ExternalLink href={ authorUrl }>
-							<Emojify>
-								{ urlToDomainAndPath( authorUrl ) }
-							</Emojify>
-						</ExternalLink>
+						{ !! authorUrl &&
+							<ExternalLink href={ authorUrl }>
+								<Emojify>
+									{ urlToDomainAndPath( authorUrl ) }
+								</Emojify>
+							</ExternalLink>
+						}
+						{ ! authorUrl &&
+							<em>{ translate( 'No website' ) }</em>
+						}
 					</div>
 					<div className="comment-detail__author-more-element">
 						<Gridicon icon="globe" />
 						<span>
-							{ authorIp }
+							{ authorIp || <em>{ translate( 'No IP address' ) }</em> }
 						</span>
 					</div>
 					{ showBlockUser &&
@@ -185,7 +190,7 @@ export class CommentDetailAuthor extends Component {
 							<span>
 								{ translate(
 									// eslint-disable-next-line max-len
-									"Anonymous messages can't be blocked individually, but you can update your {{a}}settings{{/a}} to allow comments only from registered users.",
+									"Anonymous messages can't be blocked individually, but you can update your {{a}}settings{{/a}} to only allow comments from registered users.",
 									{ components: { a: <a href={ `/settings/discussion/${ site.slug }` } /> } }
 								) }
 							</span>

--- a/client/blocks/comment-detail/comment-detail-author.jsx
+++ b/client/blocks/comment-detail/comment-detail-author.jsx
@@ -129,7 +129,7 @@ export class CommentDetailAuthor extends Component {
 			translate,
 		} = this.props;
 
-		const showBlockUser = canUserBlacklist && !! authorEmail && ( authorEmail === currentUserEmail );
+		const showBlockUser = canUserBlacklist && !! authorEmail && ( authorEmail !== currentUserEmail );
 
 		return (
 			<div className="comment-detail__author-more-info">

--- a/client/blocks/comment-detail/comment-detail-author.jsx
+++ b/client/blocks/comment-detail/comment-detail-author.jsx
@@ -32,12 +32,7 @@ export class CommentDetailAuthor extends Component {
 		commentDate: PropTypes.string,
 		commentStatus: PropTypes.string,
 		commentUrl: PropTypes.string,
-		showAuthorInfo: PropTypes.bool,
 		siteId: PropTypes.number,
-	};
-
-	static defaultProps = {
-		showAuthorInfo: false,
 	};
 
 	state = {
@@ -60,10 +55,6 @@ export class CommentDetailAuthor extends Component {
 	).format( 'll LT' );
 
 	authorMoreInfo() {
-		if ( ! this.props.showAuthorInfo ) {
-			return null;
-		}
-
 		const {
 			authorDisplayName,
 			authorEmail,
@@ -138,7 +129,6 @@ export class CommentDetailAuthor extends Component {
 			authorUrl,
 			commentStatus,
 			commentUrl,
-			showAuthorInfo,
 			translate,
 		} = this.props;
 		const { isExpanded } = this.state;
@@ -176,12 +166,9 @@ export class CommentDetailAuthor extends Component {
 							{ translate( 'Pending' ) }
 						</div>
 					}
-					{
-						showAuthorInfo &&
-						<a className="comment-detail__author-more-info-toggle" onClick={ this.toggleExpanded }>
-							<Gridicon icon="info-outline" />
-						</a>
-					}
+					<a className="comment-detail__author-more-info-toggle" onClick={ this.toggleExpanded }>
+						<Gridicon icon="info-outline" />
+					</a>
 				</div>
 				{ this.authorMoreInfo() }
 			</div>

--- a/client/blocks/comment-detail/comment-detail-author.jsx
+++ b/client/blocks/comment-detail/comment-detail-author.jsx
@@ -7,6 +7,7 @@ import { connect } from 'react-redux';
 import Gridicon from 'gridicons';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
+import { some } from 'lodash';
 
 /**
  * Internal dependencies
@@ -70,7 +71,7 @@ export class CommentDetailAuthor extends Component {
 		gmtOffset( this.props.site )
 	).format( 'll LT' );
 
-	showMoreInfo = () => !! this.props.authorEmail || !! this.props.authorIp || !! this.props.authorUrl;
+	showMoreInfo = () => some( [ this.props.authorEmail, this.props.authorIp, this.props.authorUrl ] );
 
 	toggleBlockUser = () => {
 		const {

--- a/client/blocks/comment-detail/comment-detail-author.jsx
+++ b/client/blocks/comment-detail/comment-detail-author.jsx
@@ -70,15 +70,6 @@ export class CommentDetailAuthor extends Component {
 		gmtOffset( this.props.site )
 	).format( 'll LT' );
 
-	showBlockUser = () => {
-		const { authorEmail, canUserBlacklist, currentUserEmail } = this.props;
-
-		const isAuthorBlacklistable = !! authorEmail;
-		const isAuthorCurrentUser = !! authorEmail && authorEmail === currentUserEmail;
-
-		return isAuthorBlacklistable && canUserBlacklist && ! isAuthorCurrentUser;
-	};
-
 	showMoreInfo = () => !! this.props.authorEmail || !! this.props.authorIp || !! this.props.authorUrl;
 
 	toggleBlockUser = () => {
@@ -132,8 +123,13 @@ export class CommentDetailAuthor extends Component {
 			authorIsBlocked,
 			authorUrl,
 			authorUsername,
+			canUserBlacklist,
+			currentUserEmail,
+			site,
 			translate,
 		} = this.props;
+
+		const showBlockUser = canUserBlacklist && !! authorEmail && ( authorEmail === currentUserEmail );
 
 		return (
 			<div className="comment-detail__author-more-info">
@@ -173,7 +169,7 @@ export class CommentDetailAuthor extends Component {
 							{ authorIp }
 						</span>
 					</div>
-					{ this.showBlockUser() &&
+					{ showBlockUser &&
 						<div className="comment-detail__author-more-element comment-detail__author-more-element-block-user">
 							<Button onClick={ this.toggleBlockUser }>
 								<Gridicon icon="block" />
@@ -182,6 +178,17 @@ export class CommentDetailAuthor extends Component {
 									: translate( 'Block user' )
 								}</span>
 							</Button>
+						</div>
+					}
+					{ ! authorEmail &&
+						<div className="comment-detail__author-more-element comment-detail__author-more-element-block-anonymous-user">
+							<span>
+								{ translate(
+									// eslint-disable-next-line max-len
+									"Anonymous messages can't be blocked individually, but you can update your {{a}}settings{{/a}} to allow comments only from registered users.",
+									{ components: { a: <a href={ `/settings/discussion/${ site.slug }` } /> } }
+								) }
+							</span>
 						</div>
 					}
 				</div>

--- a/client/blocks/comment-detail/comment-detail-author.jsx
+++ b/client/blocks/comment-detail/comment-detail-author.jsx
@@ -60,11 +60,6 @@ export class CommentDetailAuthor extends Component {
 		this.setState( { isExpanded: ! this.state.isExpanded } );
 	};
 
-	getAuthorObject = () => ( {
-		avatar_URL: this.props.authorAvatarUrl,
-		display_name: this.props.authorDisplayName,
-	} );
-
 	getFormattedDate = () => convertDateToUserLocation(
 		( this.props.commentDate || new Date() ),
 		timezone( this.props.site ),
@@ -143,7 +138,7 @@ export class CommentDetailAuthor extends Component {
 			<div className="comment-detail__author-more-info">
 				<div className="comment-detail__author-more-actions">
 					<div className="comment-detail__author-more-element comment-detail__author-more-element-author">
-						<Gravatar user={ this.getAuthorObject() } />
+						<Gridicon icon="user-circle" />
 						<div className="comment-detail__author-info">
 							<div className="comment-detail__author-name">
 								<strong>
@@ -228,7 +223,10 @@ export class CommentDetailAuthor extends Component {
 		return (
 			<div className={ classes }>
 				<div className="comment-detail__author-preview">
-					<Gravatar user={ this.getAuthorObject() } />
+					<Gravatar user={ {
+						avatar_URL: this.props.authorAvatarUrl,
+						display_name: this.props.authorDisplayName,
+					} } />
 					<div className="comment-detail__author-info">
 						<div className="comment-detail__author-info-element comment-detail__author-name">
 							<strong>

--- a/client/blocks/comment-detail/comment-detail-author.jsx
+++ b/client/blocks/comment-detail/comment-detail-author.jsx
@@ -19,7 +19,7 @@ import { getSite } from 'state/sites/selectors';
 import { convertDateToUserLocation } from 'components/post-schedule/utils';
 import { gmtOffset, timezone } from 'lib/site/utils';
 import { saveSiteSettings } from 'state/site-settings/actions';
-import { removeNotice, successNotice } from 'state/notices/actions';
+import { successNotice } from 'state/notices/actions';
 import { canCurrentUser } from 'state/selectors';
 
 export class CommentDetailAuthor extends Component {
@@ -60,10 +60,6 @@ export class CommentDetailAuthor extends Component {
 		timezone( this.props.site ),
 		gmtOffset( this.props.site )
 	).format( 'll LT' );
-
-	isAuthorBlacklisted = () => ( !! this.props.authorEmail && !! this.props.siteBlacklist )
-		? -1 !== this.props.siteBlacklist.split( '\n' ).indexOf( this.props.authorEmail )
-		: false;
 
 	toggleBlockUser = () => {
 		const {
@@ -233,11 +229,8 @@ const mapStateToProps = ( state, { siteId } ) => ( {
 } );
 
 const mapDispatchToProps = ( dispatch, { siteId } ) => ( {
-	removeNotice: noticeId => dispatch( removeNotice( noticeId ) ),
 	successNotice: ( text, options ) => dispatch( successNotice( text, options ) ),
-	updateBlacklist: blacklist_keys => dispatch(
-		saveSiteSettings( siteId, { blacklist_keys } )
-	),
+	updateBlacklist: blacklist_keys => dispatch( saveSiteSettings( siteId, { blacklist_keys } ) ),
 } );
 
 export default connect( mapStateToProps, mapDispatchToProps )( localize( CommentDetailAuthor ) );

--- a/client/blocks/comment-detail/comment-detail-author.jsx
+++ b/client/blocks/comment-detail/comment-detail-author.jsx
@@ -20,6 +20,7 @@ import { convertDateToUserLocation } from 'components/post-schedule/utils';
 import { gmtOffset, timezone } from 'lib/site/utils';
 import { saveSiteSettings } from 'state/site-settings/actions';
 import { removeNotice, successNotice } from 'state/notices/actions';
+import { canCurrentUser } from 'state/selectors';
 
 export class CommentDetailAuthor extends Component {
 	static propTypes = {
@@ -35,6 +36,7 @@ export class CommentDetailAuthor extends Component {
 		commentId: PropTypes.number,
 		commentStatus: PropTypes.string,
 		commentUrl: PropTypes.string,
+		showBlockUser: PropTypes.bool,
 		siteBlacklist: PropTypes.string,
 		siteId: PropTypes.number,
 		updateBlacklist: PropTypes.func,
@@ -108,6 +110,7 @@ export class CommentDetailAuthor extends Component {
 			authorIsBlocked,
 			authorUrl,
 			authorUsername,
+			showBlockUser,
 			translate,
 		} = this.props;
 
@@ -150,21 +153,23 @@ export class CommentDetailAuthor extends Component {
 						</span>
 					</div>
 				</div>
-				<div className="comment-detail__author-more-actions">
-					<a
-						className={ classNames(
-							'comment-detail__author-more-element comment-detail__author-more-element-block-user',
-							{ 'is-blocked': authorIsBlocked }
-						) }
-						onClick={ this.toggleBlockUser }
-					>
-						<Gridicon icon="block" />
-						<span>{ authorIsBlocked
-							? translate( 'Unblock user' )
-							: translate( 'Block user' )
-						}</span>
-					</a>
-				</div>
+				{ showBlockUser &&
+					<div className="comment-detail__author-more-actions">
+						<a
+							className={ classNames(
+								'comment-detail__author-more-element comment-detail__author-more-element-block-user',
+								{ 'is-blocked': authorIsBlocked }
+							) }
+							onClick={ this.toggleBlockUser }
+						>
+							<Gridicon icon="block" />
+							<span>{ authorIsBlocked
+								? translate( 'Unblock user' )
+								: translate( 'Block user' )
+							}</span>
+						</a>
+					</div>
+				}
 			</div>
 		);
 	}
@@ -223,6 +228,7 @@ export class CommentDetailAuthor extends Component {
 }
 
 const mapStateToProps = ( state, { siteId } ) => ( {
+	showBlockUser: canCurrentUser( state, siteId, 'manage_options' ),
 	site: getSite( state, siteId ),
 } );
 

--- a/client/blocks/comment-detail/comment-detail-author.jsx
+++ b/client/blocks/comment-detail/comment-detail-author.jsx
@@ -91,15 +91,8 @@ export class CommentDetailAuthor extends Component {
 
 		const analytics = {
 			action: authorIsBlocked ? 'unblock_user' : 'block_user',
+			user_type: authorId ? 'wpcom' : 'email_only',
 		};
-		if ( authorId ) {
-			analytics.user_type = 'wpcom';
-		} else if ( !! authorEmail ) {
-			analytics.user_type = 'email_only';
-		} else {
-			// not currently supported
-			analytics.user_type = 'anonymous';
-		}
 
 		if ( authorIsBlocked ) {
 			this.props.successNotice(
@@ -139,6 +132,7 @@ export class CommentDetailAuthor extends Component {
 			canUserBlacklist,
 			currentUserEmail,
 			site,
+			trackAnonymousModeration,
 			translate,
 		} = this.props;
 
@@ -204,7 +198,9 @@ export class CommentDetailAuthor extends Component {
 								{ translate(
 									// eslint-disable-next-line max-len
 									"Anonymous messages can't be blocked individually, but you can update your {{a}}settings{{/a}} to only allow comments from registered users.",
-									{ components: { a: <a href={ `/settings/discussion/${ site.slug }` } /> } }
+									{ components: {
+										a: <a href={ `/settings/discussion/${ site.slug }` } onClick={ trackAnonymousModeration } />,
+									} }
 								) }
 							</span>
 						</div>
@@ -291,6 +287,13 @@ const mapDispatchToProps = ( dispatch, { siteId } ) => ( {
 		),
 		saveSiteSettings( siteId, { blacklist_keys } )
 	) ),
+	trackAnonymousModeration: () => dispatch( composeAnalytics(
+		recordTracksEvent( 'calypso_comment_management_moderate_user', {
+			action: 'open_discussion_settings',
+			user_type: 'anonymous',
+		} ),
+		bumpStat( 'calypso_comment_management', 'open_discussion_settings' )
+) ),
 } );
 
 export default connect( mapStateToProps, mapDispatchToProps )( localize( CommentDetailAuthor ) );

--- a/client/blocks/comment-detail/comment-detail-author.jsx
+++ b/client/blocks/comment-detail/comment-detail-author.jsx
@@ -11,6 +11,7 @@ import classNames from 'classnames';
 /**
  * Internal dependencies
  */
+import Button from 'components/button';
 import Emojify from 'components/emojify';
 import ExternalLink from 'components/external-link';
 import Gravatar from 'components/gravatar';
@@ -172,24 +173,18 @@ export class CommentDetailAuthor extends Component {
 							{ authorIp }
 						</span>
 					</div>
+					{ this.showBlockUser() &&
+						<div className="comment-detail__author-more-element comment-detail__author-more-element-block-user">
+							<Button onClick={ this.toggleBlockUser }>
+								<Gridicon icon="block" />
+								<span>{ authorIsBlocked
+									? translate( 'Unblock user' )
+									: translate( 'Block user' )
+								}</span>
+							</Button>
+						</div>
+					}
 				</div>
-				{ this.showBlockUser() &&
-					<div className="comment-detail__author-more-actions">
-						<a
-							className={ classNames(
-								'comment-detail__author-more-element comment-detail__author-more-element-block-user',
-								{ 'is-blocked': authorIsBlocked }
-							) }
-							onClick={ this.toggleBlockUser }
-						>
-							<Gridicon icon="block" />
-							<span>{ authorIsBlocked
-								? translate( 'Unblock user' )
-								: translate( 'Block user' )
-							}</span>
-						</a>
-					</div>
-				}
 			</div>
 		);
 	}

--- a/client/blocks/comment-detail/comment-detail-comment.jsx
+++ b/client/blocks/comment-detail/comment-detail-comment.jsx
@@ -26,8 +26,10 @@ export class CommentDetailComment extends Component {
 		blockUser: PropTypes.func,
 		commentContent: PropTypes.string,
 		commentDate: PropTypes.string,
+		commentId: PropTypes.number,
 		commentStatus: PropTypes.string,
 		commentUrl: PropTypes.string,
+		siteBlacklist: PropTypes.string,
 		siteId: PropTypes.number,
 	};
 
@@ -40,12 +42,13 @@ export class CommentDetailComment extends Component {
 			authorIsBlocked,
 			authorUrl,
 			authorUsername,
-			blockUser,
 			commentContent,
 			commentDate,
+			commentId,
 			commentStatus,
 			commentUrl,
 			repliedToComment,
+			siteBlacklist,
 			siteId,
 			translate,
 		} = this.props;
@@ -61,10 +64,11 @@ export class CommentDetailComment extends Component {
 						authorIsBlocked={ authorIsBlocked }
 						authorUrl={ authorUrl }
 						authorUsername={ authorUsername }
-						blockUser={ blockUser }
 						commentDate={ commentDate }
+						commentId={ commentId }
 						commentStatus={ commentStatus }
 						commentUrl={ commentUrl }
+						siteBlacklist={ siteBlacklist }
 						siteId={ siteId }
 					/>
 					<AutoDirection>

--- a/client/blocks/comment-detail/comment-detail-comment.jsx
+++ b/client/blocks/comment-detail/comment-detail-comment.jsx
@@ -38,6 +38,7 @@ export class CommentDetailComment extends Component {
 			authorAvatarUrl,
 			authorDisplayName,
 			authorEmail,
+			authorId,
 			authorIp,
 			authorIsBlocked,
 			authorUrl,
@@ -60,6 +61,7 @@ export class CommentDetailComment extends Component {
 						authorAvatarUrl={ authorAvatarUrl }
 						authorDisplayName={ authorDisplayName }
 						authorEmail={ authorEmail }
+						authorId={ authorId }
 						authorIp={ authorIp }
 						authorIsBlocked={ authorIsBlocked }
 						authorUrl={ authorUrl }

--- a/client/blocks/comment-detail/index.jsx
+++ b/client/blocks/comment-detail/index.jsx
@@ -315,6 +315,7 @@ export class CommentDetail extends Component {
 									authorAvatarUrl={ authorAvatarUrl }
 									authorDisplayName={ authorDisplayName }
 									authorEmail={ authorEmail }
+									authorId={ authorId }
 									authorIp={ authorIp }
 									authorIsBlocked={ authorIsBlocked }
 									authorUrl={ authorUrl }

--- a/client/blocks/comment-detail/index.jsx
+++ b/client/blocks/comment-detail/index.jsx
@@ -48,7 +48,6 @@ export class CommentDetail extends Component {
 		authorEmail: PropTypes.oneOfType( [ PropTypes.bool, PropTypes.string ] ),
 		authorId: PropTypes.number,
 		authorIp: PropTypes.string,
-		authorIsBlocked: PropTypes.bool,
 		authorName: PropTypes.string,
 		authorUrl: PropTypes.string,
 		authorUsername: PropTypes.string,
@@ -71,6 +70,7 @@ export class CommentDetail extends Component {
 		repliedToComment: PropTypes.bool,
 		replyComment: PropTypes.func,
 		setCommentStatus: PropTypes.func,
+		siteBlacklist: PropTypes.string,
 		siteId: PropTypes.number,
 		toggleCommentLike: PropTypes.func,
 		toggleCommentSelected: PropTypes.func,
@@ -84,23 +84,13 @@ export class CommentDetail extends Component {
 	};
 
 	state = {
-		authorIsBlocked: false,
 		isEditMode: false,
 	};
-
-	componentWillMount() {
-		const { authorIsBlocked } = this.props;
-		this.setState( { authorIsBlocked } );
-	}
 
 	componentWillReceiveProps( nextProps ) {
 		if ( nextProps.isBulkEdit && ! this.props.isBulkEdit ) {
 			this.setState( { isExpanded: false } );
 		}
-	}
-
-	blockUser = () => {
-		this.setState( { authorIsBlocked: ! this.state.authorIsBlocked } );
 	}
 
 	deleteCommentPermanently = () => {
@@ -113,6 +103,10 @@ export class CommentDetail extends Component {
 			deleteCommentPermanently( commentId, postId );
 		}
 	}
+
+	isAuthorBlacklisted = () => ( !! this.props.authorEmail && !! this.props.siteBlacklist )
+		? -1 !== this.props.siteBlacklist.split( '\n' ).indexOf( this.props.authorEmail )
+		: false;
 
 	toggleApprove = () => {
 		if ( this.state.isEditMode ) {
@@ -226,15 +220,16 @@ export class CommentDetail extends Component {
 			refreshCommentData,
 			repliedToComment,
 			replyComment,
+			siteBlacklist,
 			siteId,
 			translate,
 		} = this.props;
 
 		const postUrl = `/read/blogs/${ siteId }/posts/${ postId }`;
 		const authorDisplayName = authorName || translate( 'Anonymous' );
+		const authorIsBlocked = this.isAuthorBlacklisted();
 
 		const {
-			authorIsBlocked,
 			isEditMode,
 			isExpanded,
 		} = this.state;
@@ -324,12 +319,13 @@ export class CommentDetail extends Component {
 									authorIsBlocked={ authorIsBlocked }
 									authorUrl={ authorUrl }
 									authorUsername={ authorUsername }
-									blockUser={ this.blockUser }
 									commentContent={ commentContent }
 									commentDate={ commentDate }
+									commentId={ commentId }
 									commentStatus={ commentStatus }
 									commentUrl={ commentUrl }
 									repliedToComment={ repliedToComment }
+									siteBlacklist={ siteBlacklist }
 									siteId={ siteId }
 								/>
 								<CommentDetailReply
@@ -370,7 +366,6 @@ const mapStateToProps = ( state, ownProps ) => {
 		authorEmail: get( comment, 'author.email' ),
 		authorId: get( comment, 'author.ID' ),
 		authorIp: get( comment, 'author.ip_address' ),
-		authorIsBlocked: get( comment, 'author.isBlocked' ), // TODO: not available in the current data structure
 		authorName: get( comment, 'author.name' ),
 		authorUrl: get( comment, 'author.URL', '' ),
 		authorUsername: get( comment, 'author.nice_name' ),

--- a/client/blocks/comment-detail/index.jsx
+++ b/client/blocks/comment-detail/index.jsx
@@ -369,7 +369,7 @@ const mapStateToProps = ( state, ownProps ) => {
 		authorAvatarUrl: get( comment, 'author.avatar_URL' ),
 		authorEmail: get( comment, 'author.email' ),
 		authorId: get( comment, 'author.ID' ),
-		authorIp: get( comment, 'author.ip' ), // TODO: not available in the current data structure
+		authorIp: get( comment, 'author.ip_address' ),
 		authorIsBlocked: get( comment, 'author.isBlocked' ), // TODO: not available in the current data structure
 		authorName: get( comment, 'author.name' ),
 		authorUrl: get( comment, 'author.URL', '' ),

--- a/client/blocks/comment-detail/style.scss
+++ b/client/blocks/comment-detail/style.scss
@@ -377,6 +377,10 @@
 
 .comment-detail__author {
 	padding: 16px 0 0;
+
+	&.is-expanded {
+		padding: 16px 0;
+	}
 }
 
 .comment-detail__author-preview {

--- a/client/blocks/comment-detail/style.scss
+++ b/client/blocks/comment-detail/style.scss
@@ -505,6 +505,10 @@ a.comment-detail__author-more-element {
 		padding-left: 8px;
 		text-overflow: ellipsis;
 	}
+
+	strong {
+		float: none;
+	}
 }
 
 .comment-detail.card .comment-detail__author-more-element-block-user .gridicon {

--- a/client/blocks/comment-detail/style.scss
+++ b/client/blocks/comment-detail/style.scss
@@ -507,9 +507,8 @@ a.comment-detail__author-more-element {
 	}
 }
 
-.comment-detail__author-more-element-block-user.is-blocked .gridicon {
-	color: $alert-red;
-	fill: $alert-red;
+.comment-detail.card .comment-detail__author-more-element-block-user .gridicon {
+	vertical-align: baseline;
 }
 
 .comment-detail__reply {

--- a/client/blocks/comment-detail/style.scss
+++ b/client/blocks/comment-detail/style.scss
@@ -444,10 +444,15 @@
 
 .comment-detail__author-more-info {
 	border-bottom: 1px solid lighten( $gray, 30% );
-	color: $gray;
+	color: $gray-text-min;
 	display: none;
 	transform: scaleY( 0 );
 	transform-origin: top;
+
+	.gridicon {
+		color: $gray;
+		fill: $gray;
+	}
 }
 .comment-detail__author.is-expanded .comment-detail__author-more-info {
 	animation: comment-detail__author-more-info .15s linear;
@@ -476,17 +481,6 @@
 
 	@include breakpoint( ">660px" ) {
 		width: 50%;
-	}
-}
-
-a.comment-detail__author-more-element {
-	color: $gray;
-	cursor: pointer;
-	fill: $gray;
-	&:focus,
-	&:hover {
-		color: $blue-wordpress;
-		fill: $blue-wordpress;
 	}
 }
 

--- a/client/blocks/comment-detail/style.scss
+++ b/client/blocks/comment-detail/style.scss
@@ -407,11 +407,16 @@
 	padding-bottom: 16px;
 }
 
+.comment-detail__author-preview-actions {
+	align-items: center;
+	display: flex;
+	justify-content: space-between;
+	margin-left: auto;
+}
+
 .comment-detail__status-label {
-	align-self: flex-start;
 	border-radius: 9px;
 	font-size: 12px;
-	margin-left: auto;
 	padding: 0 10px;
 
 	&.is-unapproved {
@@ -429,7 +434,7 @@
 	display: block;
 	fill: $gray;
 	height: 24px;
-	margin-left: auto;
+	margin-left: 8px;
 	&:focus,
 	&:hover {
 		color: $blue-wordpress;

--- a/client/blocks/comment-detail/style.scss
+++ b/client/blocks/comment-detail/style.scss
@@ -511,6 +511,11 @@ a.comment-detail__author-more-element {
 	vertical-align: baseline;
 }
 
+.comment-detail__author-more-element-block-anonymous-user {
+	white-space: normal;
+	width: 100%;
+}
+
 .comment-detail__reply {
 	line-height: 0;
 	position: relative;

--- a/client/blocks/comment-detail/style.scss
+++ b/client/blocks/comment-detail/style.scss
@@ -496,7 +496,6 @@
 	.comment-detail__author-info {
 		line-height: 1.2;
 		overflow: hidden;
-		padding-left: 8px;
 		text-overflow: ellipsis;
 	}
 

--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -27,7 +27,12 @@ import EmptyContent from 'components/empty-content';
 import Pagination from 'components/pagination';
 import QuerySiteCommentsList from 'components/data/query-site-comments-list';
 import QuerySiteCommentsTree from 'components/data/query-site-comments-tree';
-import { getSiteCommentsTree, isCommentsTreeInitialized } from 'state/selectors';
+import QuerySiteSettings from 'components/data/query-site-settings';
+import {
+	getSiteCommentsTree,
+	getSiteSetting,
+	isCommentsTreeInitialized,
+} from 'state/selectors';
 import {
 	bumpStat,
 	composeAnalytics,
@@ -47,6 +52,7 @@ export class CommentList extends Component {
 		recordChangePage: PropTypes.func,
 		replyComment: PropTypes.func,
 		setBulkStatus: PropTypes.func,
+		siteBlacklist: PropTypes.string,
 		siteId: PropTypes.number,
 		status: PropTypes.string,
 		translate: PropTypes.func,
@@ -378,6 +384,7 @@ export class CommentList extends Component {
 		const {
 			isJetpack,
 			isLoading,
+			siteBlacklist,
 			siteId,
 			siteFragment,
 			status,
@@ -399,6 +406,8 @@ export class CommentList extends Component {
 
 		return (
 			<div className="comment-list">
+				<QuerySiteSettings siteId={ siteId } />
+
 				{ isJetpack &&
 					<QuerySiteCommentsList
 						number={ 100 }
@@ -440,6 +449,7 @@ export class CommentList extends Component {
 							refreshCommentData={ ! isJetpack && ! this.hasCommentJustMovedBackToCurrentStatus( commentId ) }
 							replyComment={ this.replyComment }
 							setCommentStatus={ this.setCommentStatus }
+							siteBlacklist={ siteBlacklist }
 							siteId={ siteId }
 							toggleCommentLike={ this.toggleCommentLike }
 							toggleCommentSelected={ this.toggleCommentSelected }
@@ -478,6 +488,7 @@ const mapStateToProps = ( state, { siteId, status } ) => {
 		comments,
 		isJetpack: isJetpackSite( state, siteId ),
 		isLoading,
+		siteBlacklist: getSiteSetting( state, siteId, 'blacklist_keys' ),
 		siteId,
 	};
 };


### PR DESCRIPTION
Close #13895

Enables the **User Info** panel and the **Block User** action.

The Block action simply adds (or removes) the comment author email address to the site's comment blacklist (as shown in _Settings → Discussion_).

### Screenshots

| Unblocked | Blocked |
| --- | --- |
| <img width="733" alt="screen shot 2017-09-25 at 12 21 47" src="https://user-images.githubusercontent.com/2070010/30806079-34327fca-a1ec-11e7-82ac-859f20001a2d.png"> | <img width="730" alt="screen shot 2017-09-25 at 12 22 04" src="https://user-images.githubusercontent.com/2070010/30806091-3cfc874a-a1ec-11e7-87d0-015ee045cf36.png"> |
| <img width="371" alt="screen shot 2017-09-20 at 17 50 01" src="https://user-images.githubusercontent.com/2070010/30656551-6ec69c52-9e2c-11e7-8fd2-85caec24b66d.png"> | <img width="394" alt="screen shot 2017-09-20 at 17 50 18" src="https://user-images.githubusercontent.com/2070010/30656561-73657774-9e2c-11e7-8292-b7b238a62007.png"> |

Bonus: anonymous user block message

<img width="729" alt="screen shot 2017-09-25 at 12 24 31" src="https://user-images.githubusercontent.com/2070010/30806169-8f655fde-a1ec-11e7-8b8a-5d5b0970cc12.png">
