### PR TITLE
Reader: mishandling of sites that were deleted

### DIFF
--- a/client/reader/feed-stream/index.jsx
+++ b/client/reader/feed-stream/index.jsx
@@ -41,7 +41,7 @@ class FeedStream extends React.Component {
 		const emptyContent = <EmptyContent />;
 		const title = getSiteName( { feed, site } ) || this.props.translate( 'Loading Feed' );
 
-		if ( ( feed && feed.is_error ) || ( site && site.is_error ) ) {
+		if ( ( feed && feed.is_error ) || ( site && site.is_error && site.error.code === 410 ) ) {
 			return <FeedError sidebarTitle={ title } />;
 		}
 

--- a/client/reader/feed-stream/index.jsx
+++ b/client/reader/feed-stream/index.jsx
@@ -41,7 +41,7 @@ class FeedStream extends React.Component {
 		const emptyContent = <EmptyContent />;
 		const title = getSiteName( { feed, site } ) || this.props.translate( 'Loading Feed' );
 
-		if ( feed && feed.is_error ) {
+		if ( ( feed && feed.is_error ) || ( site && site.is_error ) ) {
 			return <FeedError sidebarTitle={ title } />;
 		}
 

--- a/client/state/reader/sites/actions.js
+++ b/client/state/reader/sites/actions.js
@@ -52,15 +52,15 @@ export function requestSite( siteId ) {
 					} );
 					return data;
 				},
-				function failure( err ) {
+				function failure( error ) {
 					dispatch( {
 						type: READER_SITE_REQUEST_FAILURE,
 						payload: {
 							ID: siteId,
 						},
-						error: err,
+						error,
 					} );
-					throw err;
+					throw error;
 				}
 			);
 	};

--- a/client/state/reader/sites/reducer.js
+++ b/client/state/reader/sites/reducer.js
@@ -46,15 +46,12 @@ function handleDeserialize( state ) {
 
 function handleRequestFailure( state, action ) {
 	// new object proceeds current state to prevent new errors from overwriting existing values
-	return assign(
-		{
-			[ action.payload.ID ]: {
-				ID: action.payload.ID,
-				is_error: true,
-			},
+	return assign( {}, state, {
+		[ action.payload.ID ]: {
+			ID: action.payload.ID,
+			is_error: true,
 		},
-		state
-	);
+	} );
 }
 
 function adaptSite( attributes ) {

--- a/client/state/reader/sites/reducer.js
+++ b/client/state/reader/sites/reducer.js
@@ -45,6 +45,13 @@ function handleDeserialize( state ) {
 }
 
 function handleRequestFailure( state, action ) {
+	// marking a site as a failure to request also temporarily deletes it from
+	// following/manage.  we only want to do that in the case of 403 which can sometimes also be 404s
+	// in disguise signifying that the site was deleted.
+	if ( action.error && action.error.code !== 403 ) {
+		return state;
+	}
+
 	// new object proceeds current state to prevent new errors from overwriting existing values
 	return assign( {}, state, {
 		[ action.payload.ID ]: {

--- a/client/state/reader/sites/reducer.js
+++ b/client/state/reader/sites/reducer.js
@@ -45,10 +45,8 @@ function handleDeserialize( state ) {
 }
 
 function handleRequestFailure( state, action ) {
-	// marking a site as a failure to request also temporarily deletes it from
-	// following/manage.  we only want to do that in the case of 403 which can sometimes also be 404s
-	// in disguise signifying that the site was deleted.
-	if ( action.error && action.error.code !== 403 ) {
+	// 410 means site moved. site used to be wpcom but is no longer
+	if ( action.error && action.error.code !== 410 ) {
 		return state;
 	}
 
@@ -57,6 +55,7 @@ function handleRequestFailure( state, action ) {
 		[ action.payload.ID ]: {
 			ID: action.payload.ID,
 			is_error: true,
+			error: action.error,
 		},
 	} );
 }

--- a/client/state/reader/sites/test/reducer.js
+++ b/client/state/reader/sites/test/reducer.js
@@ -173,17 +173,17 @@ describe( 'reducer', () => {
 			expect( items( validState, { type: DESERIALIZE } ) ).to.deep.equal( validState );
 		} );
 
-		test( 'should stash an error object in the map if the request fails', () => {
+		test( 'should stash an error object in the map if the request fails with a 410', () => {
 			expect(
 				items(
 					{},
 					{
 						type: READER_SITE_REQUEST_FAILURE,
-						error: { code: 403 },
+						error: { code: 410 },
 						payload: { ID: 666 },
 					}
 				)
-			).to.deep.equal( { 666: { ID: 666, is_error: true } } );
+			).to.deep.equal( { 666: { ID: 666, is_error: true, error: { code: 410 } } } );
 		} );
 
 		test( 'should overwrite an existing entry on receiving a new feed', () => {

--- a/client/state/reader/sites/test/reducer.js
+++ b/client/state/reader/sites/test/reducer.js
@@ -179,7 +179,7 @@ describe( 'reducer', () => {
 					{},
 					{
 						type: READER_SITE_REQUEST_FAILURE,
-						error: new Error( 'request failed' ),
+						error: { code: 403 },
 						payload: { ID: 666 },
 					}
 				)
@@ -204,7 +204,7 @@ describe( 'reducer', () => {
 			expect(
 				items( startingState, {
 					type: READER_SITE_REQUEST_FAILURE,
-					error: new Error( 'request failed' ),
+					error: { code: 500 },
 					payload: { ID: 666 },
 				} )
 			).to.deep.equal( startingState );

--- a/client/state/selectors/get-reader-follows.js
+++ b/client/state/selectors/get-reader-follows.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  *
@@ -22,12 +23,19 @@ import { getFeed } from 'state/reader/feeds/selectors';
 const getReaderFollows = createSelector(
 	state => {
 		const items = reject( values( state.reader.follows.items ), 'error' );
+
 		// this is important. don't mutate the original items.
-		return items.map( item => ( {
+		const withSiteAndFeed = items.map( item => ( {
 			...item,
 			site: getSite( state, item.blog_ID ),
 			feed: getFeed( state, item.feed_ID ),
 		} ) );
+
+		const withoutErrors = reject(
+			withSiteAndFeed,
+			item => ( item.site && item.site.is_error ) || ( item.feed && item.feed.is_error )
+		);
+		return withoutErrors;
 	},
 	state => [
 		state.reader.follows.items,

--- a/client/state/selectors/get-reader-follows.js
+++ b/client/state/selectors/get-reader-follows.js
@@ -22,6 +22,7 @@ import { getFeed } from 'state/reader/feeds/selectors';
  */
 const getReaderFollows = createSelector(
 	state => {
+		// remove subs where the sub has an error
 		const items = reject( values( state.reader.follows.items ), 'error' );
 
 		// this is important. don't mutate the original items.
@@ -31,9 +32,12 @@ const getReaderFollows = createSelector(
 			feed: getFeed( state, item.feed_ID ),
 		} ) );
 
+		// remove subs where the feed or site has an error
 		const withoutErrors = reject(
 			withSiteAndFeed,
-			item => ( item.site && item.site.is_error ) || ( item.feed && item.feed.is_error )
+			item =>
+				( item.site && item.site.is_error && item.site.error.code === 410 ) ||
+				( item.feed && item.feed.is_error )
 		);
 		return withoutErrors;
 	},


### PR DESCRIPTION
1. feed-stream had a bad check for errors so was missing cases where site is deleted.
2. get-reader-follows wasn't filtering out follows that had errored.

fixes both:
https://github.com/Automattic/wp-calypso/issues/18139 and https://github.com/Automattic/wp-calypso/issues/18140