### PR TITLE
Store: Add coupons API data reducer.

### DIFF
--- a/client/extensions/woocommerce/state/sites/coupons/reducer.js
+++ b/client/extensions/woocommerce/state/sites/coupons/reducer.js
@@ -1,0 +1,27 @@
+/**
+ * Internal dependencies
+ */
+import { createReducer } from 'state/utils';
+import {
+	WOOCOMMERCE_COUPONS_PAGE_UPDATED,
+} from 'woocommerce/state/action-types';
+
+export default createReducer( {}, {
+	[ WOOCOMMERCE_COUPONS_PAGE_UPDATED ]: pageUpdated,
+} );
+
+function pageUpdated( state, action ) {
+	const { pageIndex, coupons, totalPages, totalCoupons } = action;
+
+	if ( coupons ) {
+		return {
+			coupons,
+			pageIndex,
+			totalPages,
+			totalCoupons,
+		};
+	}
+
+	return null;
+}
+

--- a/client/extensions/woocommerce/state/sites/coupons/test/reducer.js
+++ b/client/extensions/woocommerce/state/sites/coupons/test/reducer.js
@@ -1,0 +1,67 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import reducer from '../reducer';
+
+import {
+	WOOCOMMERCE_COUPONS_PAGE_UPDATED,
+} from 'woocommerce/state/action-types';
+
+describe( 'reducer', () => {
+	const siteId = 123;
+
+	const couponsPage1 = [
+		{
+			id: 1,
+			code: 'one',
+			amount: '1',
+			discount_type: 'percent',
+		},
+		{
+			id: 2,
+			code: 'two',
+			amount: '2',
+			discount_type: 'fixed_product',
+		},
+		{
+			id: 3,
+			code: 'three',
+			amount: '3',
+			discount_type: 'fixed_cart',
+		},
+	];
+
+	it( 'should save page data to store', () => {
+		const action = {
+			type: WOOCOMMERCE_COUPONS_PAGE_UPDATED,
+			siteId,
+			coupons: couponsPage1,
+			pageIndex: 1,
+			totalPages: 1,
+			totalCoupons: 3,
+		};
+
+		const newState = reducer( undefined, action );
+
+		expect( newState ).to.exist;
+		expect( newState.coupons ).to.equal( couponsPage1 );
+		expect( newState.pageIndex ).to.equal( 1 );
+		expect( newState.totalPages ).to.equal( 1 );
+		expect( newState.totalCoupons ).to.equal( 3 );
+	} );
+
+	it( 'should clear page data from store', () => {
+		const action = {
+			type: WOOCOMMERCE_COUPONS_PAGE_UPDATED,
+			siteId,
+		};
+
+		const newState = reducer( undefined, action );
+		expect( newState ).to.be.null;
+	} );
+} );

--- a/client/extensions/woocommerce/state/sites/reducer.js
+++ b/client/extensions/woocommerce/state/sites/reducer.js
@@ -2,6 +2,7 @@
  * Internal dependencies
  */
 import { combineReducers, keyedReducer } from 'state/utils';
+import coupons from './coupons/reducer';
 import currencies from './currencies/reducer';
 import locations from './locations/reducer';
 import meta from './meta/reducer';
@@ -21,6 +22,7 @@ import settings from './settings/reducer';
 import status from './status/reducer';
 
 const reducer = combineReducers( {
+	coupons,
 	currencies,
 	locations,
 	meta,


### PR DESCRIPTION
This adds a reducer to store couponn API data from WooCommerce into the
redux state in the appropriate place under the desired site id.

To Test: Run `npm test`