### PR TITLE
Build monitor: Remove bad ") }" from rebuilding text

### DIFF
--- a/client/components/webpack-build-monitor/index.jsx
+++ b/client/components/webpack-build-monitor/index.jsx
@@ -85,8 +85,8 @@ class WebpackBuildMonitor extends React.PureComponent {
 			return console.error(
 				'There should only be a single build monitor loaded. ' +
 					"Please make sure we're not trying to load more than one at a time."
-		);
-	}
+			);
+		}
 		alreadyExists = true;
 
 		interceptConsole( console, state => this.setState( state ) );
@@ -115,7 +115,6 @@ class WebpackBuildMonitor extends React.PureComponent {
 				} ) }
 			>
 				{ isBusy && <Spinner size={ 11 } className="webpack-build-monitor__spinner" /> }
-				) }
 				{ getMessage( this.state ) }
 			</div>
 		);


### PR DESCRIPTION
Some bad JSX syntax was included as text in the build monitor building texts. This PR removes it.

## Testing
1. Spin up this branch with `npm start`
1. Make changes to JS or CSS to provoke rebuilds
1. Ensure that the rebuilding texts in the build monitor are correct

## Screens

### Before

> ) }REBUILDING JAVASCRIPT

![before](https://user-images.githubusercontent.com/841763/30686400-73d78738-9eb8-11e7-980c-6b755bc9567d.png)

### After

> REBUILDING JAVASCRIPT

![after](https://user-images.githubusercontent.com/841763/30686417-7f521c0e-9eb8-11e7-99ea-9f5ab359830e.png)
