### PR TITLE
Comments: Add author Gravatar in reply field

### DIFF
--- a/client/blocks/comment-detail/comment-detail-reply.jsx
+++ b/client/blocks/comment-detail/comment-detail-reply.jsx
@@ -10,6 +10,7 @@ import classNames from 'classnames';
  * Internal dependencies
  */
 import AutoDirection from 'components/auto-direction';
+import Gravatar from 'components/gravatar';
 import { getCurrentUser } from 'state/current-user/selectors';
 
 const TEXTAREA_HEIGHT_COLLAPSED = 47; // 1 line
@@ -101,7 +102,10 @@ export class CommentDetailReply extends Component {
 	} );
 
 	render() {
-		const { translate } = this.props;
+		const {
+			currentUser,
+			translate,
+		} = this.props;
 		const {
 			commentText,
 			hasFocus,
@@ -116,9 +120,13 @@ export class CommentDetailReply extends Component {
 		const buttonClasses = classNames( 'comment-detail__reply-submit', {
 			'has-scrollbar': hasScrollbar,
 			'is-active': hasCommentText,
+			'is-visible': hasFocus || hasCommentText,
 		} );
 
+		const gravatarClasses = classNames( { 'is-visible': ! hasFocus } );
+
 		const textareaClasses = classNames( {
+			'has-content': hasCommentText,
 			'has-focus': hasFocus,
 			'has-scrollbar': hasScrollbar,
 		} );
@@ -143,15 +151,20 @@ export class CommentDetailReply extends Component {
 						value={ commentText }
 					/>
 				</AutoDirection>
-				{ ( hasFocus || hasCommentText ) &&
-					<button
-						className={ buttonClasses }
-						disabled={ ! hasCommentText }
-						onClick={ this.submitComment }
-					>
-						{ translate( 'Send' ) }
-					</button>
-				}
+
+				<Gravatar
+					className={ gravatarClasses }
+					size={ 24 }
+					user={ currentUser }
+				/>
+
+				<button
+					className={ buttonClasses }
+					disabled={ ! hasCommentText }
+					onClick={ this.submitComment }
+				>
+					{ translate( 'Send' ) }
+				</button>
 			</form>
 		);
 	}

--- a/client/blocks/comment-detail/index.jsx
+++ b/client/blocks/comment-detail/index.jsx
@@ -333,6 +333,7 @@ export class CommentDetail extends Component {
 									siteId={ siteId }
 								/>
 								<CommentDetailReply
+									authorAvatarUrl={ authorAvatarUrl }
 									authorDisplayName={ authorDisplayName }
 									comment={ getCommentStatusAction( this.props ) }
 									postTitle={ postTitle }

--- a/client/blocks/comment-detail/style.scss
+++ b/client/blocks/comment-detail/style.scss
@@ -505,6 +505,8 @@ a.comment-detail__author-more-element {
 
 .comment-detail__reply {
 	line-height: 0;
+	overflow: hidden;
+	padding: 2px;
 	position: relative;
 
 	textarea {
@@ -516,14 +518,19 @@ a.comment-detail__author-more-element {
 		padding: 12px 70px 12px 16px;
 		position: relative;
 		resize: vertical;
-		transition: min-height .15s linear;
+		transition: min-height .15s linear, padding-left 0.2s ease-in-out;
 		white-space: pre-wrap;
 		word-wrap: break-word;
 
 		&:not( :focus ) {
 			border-color: $white;
+			padding-left: 48px;
 			padding-right: 16px;
 			resize: none;
+
+			&.has-content {
+				padding-right: 70px;
+			}
 		}
 
 		&:focus,
@@ -543,24 +550,38 @@ a.comment-detail__author-more-element {
 		}
 	}
 
+	.gravatar {
+		position: absolute;
+			left: 16px;
+			top: 12px;
+		transition: transform 0.2s ease-in-out;
+
+		&:not( .is-visible ) {
+			transform: translateX( -40px );
+		}
+	}
+
 	.comment-detail__reply-submit {
 		color: $gray;
 		font-size: 12px;
 		font-weight: 600;
 		padding: 4px;
 		position: absolute;
-			right: 18px;
+			right: -70px;
 			top: 11px;
 		text-transform: uppercase;
-		transition: opacity 0.2s ease-in-out;
-
-		&.has-scrollbar {
-			right: 24px;
-		}
+		transition: transform 0.2s ease-in-out;
 
 		&.is-active {
 			color: $blue-medium;
 			cursor: pointer;
+		}
+
+		&.is-visible {
+			transform: translateX( -88px );
+		}
+		&.is-visible.has-scrollbar {
+			transform: translateX( -94px );
 		}
 	}
 }

--- a/client/blocks/comment-detail/style.scss
+++ b/client/blocks/comment-detail/style.scss
@@ -557,7 +557,7 @@ a.comment-detail__author-more-element {
 		transition: transform 0.2s ease-in-out;
 
 		&:not( .is-visible ) {
-			transform: translateX( -40px );
+			transform: translate3d( -40px, 0, 0 );
 		}
 	}
 
@@ -578,10 +578,10 @@ a.comment-detail__author-more-element {
 		}
 
 		&.is-visible {
-			transform: translateX( -88px );
+			transform: translate3d( -88px, 0, 0 );
 		}
 		&.is-visible.has-scrollbar {
-			transform: translateX( -94px );
+			transform: translate3d( -94px, 0, 0 );
 		}
 	}
 }


### PR DESCRIPTION
Closes #15806 

Add the author Gravatar in the reply field.

![sep-20-2017 19-25-46](https://user-images.githubusercontent.com/2070010/30660680-9185f532-9e39-11e7-92e1-97090d7e5cf2.gif)

The idea is that both elements "extraneous" to the textarea slide in and out.
The Gravatar slides out when the textarea gets focus, to leave as much room as possible to the actual content.
The Send button slides in when the textarea gets focus, and stays in as long as the textarea contains some content.

The textarea padding slides accordingly so that there's a sort of "everything slides left on focus" / "everything slides right on blur" movement.

### Testing

- Open the Comments section in Calypso (`comments/approved/{ siteSlug }`).
- Expand a comment.
- Play around the Reply field, focusing, blurring, adding and removing content.
- Check that the behaviour is smooth on both desktop and mobile.