### PR TITLE
Plugin uploads: enable on staging

### DIFF
--- a/config/stage.json
+++ b/config/stage.json
@@ -50,7 +50,7 @@
 		"manage/plugins": true,
 		"manage/plugins/cache": false,
 		"manage/plugins/setup": true,
-		"manage/plugins/upload": false,
+		"manage/plugins/upload": true,
 		"manage/posts": true,
 		"manage/security": true,
 		"manage/site-settings/analytics": true,


### PR DESCRIPTION
Enable plugin uploads for both jetpack and simple sites (transfers to atomic) on staging.

Plugin upload master thread: p6TEKc-1nA-p2

**To Test**
* Go to the live branch: https://calypso.live/plugins?branch=update/plugin-upload-enable-staging
* The /plugins page should show an 'Upload Plugin' button:
<img width="1251" alt="screen shot 2017-09-21 at 14 58 15" src="https://user-images.githubusercontent.com/7767559/30699736-73aa0bb2-9edd-11e7-9c88-1592755f8929.png">
