### PR TITLE
Plugin uploads: Fix test failure reading capabilities of undefined

### DIFF
--- a/client/state/data-layer/wpcom/sites/plugins/new/test/index.js
+++ b/client/state/data-layer/wpcom/sites/plugins/new/test/index.js
@@ -66,7 +66,12 @@ describe( 'uploadComplete', () => {
 			items: {
 				[ siteId ]: site,
 			}
-		}
+		},
+		currentUser: {
+			capabilities: {
+				edit_theme_options: true,
+			},
+		},
 	} );
 
 	beforeEach( () => {


### PR DESCRIPTION
Selectors indirectly invoked by tests need more mocked state. This PR adds necessary state to the mocked `getState`.