### PR TITLE
Jetpack Connect: Codemod propTypes and Prettier

### DIFF
--- a/client/jetpack-connect/auth-logged-in-form.jsx
+++ b/client/jetpack-connect/auth-logged-in-form.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import Gridicon from 'gridicons';
 import addQueryArgs from 'lib/route/add-query-args';
 import debugModule from 'debug';

--- a/client/jetpack-connect/auth-logged-in-form.jsx
+++ b/client/jetpack-connect/auth-logged-in-form.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -52,10 +53,7 @@ class LoggedInForm extends Component {
 		isSSO: PropTypes.bool,
 		isWCS: PropTypes.bool,
 		jetpackConnectAuthorize: PropTypes.shape( {
-			authorizeError: PropTypes.oneOfType( [
-				PropTypes.object,
-				PropTypes.bool,
-			] ),
+			authorizeError: PropTypes.oneOfType( [ PropTypes.object, PropTypes.bool ] ),
 			authorizeSuccess: PropTypes.bool,
 			isRedirectingToWpAdmin: PropTypes.bool,
 			queryObject: PropTypes.shape( {
@@ -81,14 +79,13 @@ class LoggedInForm extends Component {
 	componentWillMount() {
 		const { queryObject, autoAuthorize } = this.props.jetpackConnectAuthorize;
 		this.props.recordTracksEvent( 'calypso_jpc_auth_view' );
-		if ( ! this.props.isAlreadyOnSitesList &&
+		if (
+			! this.props.isAlreadyOnSitesList &&
 			! queryObject.already_authorized &&
-			(
-				this.props.calypsoStartedConnection ||
+			( this.props.calypsoStartedConnection ||
 				this.props.isSSO ||
 				queryObject.new_user_started_connection ||
-				autoAuthorize
-			)
+				autoAuthorize )
 		) {
 			debug( 'Authorizing automatically on component mount' );
 			this.setState( { haveAuthorized: true } );
@@ -102,7 +99,7 @@ class LoggedInForm extends Component {
 			queryObject,
 			isRedirectingToWpAdmin,
 			authorizeSuccess,
-			authorizeError
+			authorizeError,
 		} = props.jetpackConnectAuthorize;
 
 		// For SSO, WooCommerce Services, and JPO users, do not display plans page
@@ -136,21 +133,19 @@ class LoggedInForm extends Component {
 	renderFormHeader( isConnected ) {
 		const { translate, isAlreadyOnSitesList } = this.props;
 		const { queryObject } = this.props.jetpackConnectAuthorize;
-		const headerText = ( isConnected )
+		const headerText = isConnected
 			? translate( 'You are connected!' )
 			: translate( 'Completing connection' );
-		const subHeaderText = ( isConnected )
+		const subHeaderText = isConnected
 			? translate( 'Thank you for flying with Jetpack' )
 			: translate( 'Jetpack is finishing up the connection process' );
-		const siteCard = versionCompare( queryObject.jp_version, '4.0.3', '>' )
-			? <SiteCard queryObject={ queryObject } isAlreadyOnSitesList={ isAlreadyOnSitesList } />
-			: null;
+		const siteCard = versionCompare( queryObject.jp_version, '4.0.3', '>' ) ? (
+			<SiteCard queryObject={ queryObject } isAlreadyOnSitesList={ isAlreadyOnSitesList } />
+		) : null;
 
 		return (
 			<div>
-				<FormattedHeader
-					headerText={ headerText }
-					subHeaderText={ subHeaderText } />
+				<FormattedHeader headerText={ headerText } subHeaderText={ subHeaderText } />
 				{ siteCard }
 			</div>
 		);
@@ -160,7 +155,13 @@ class LoggedInForm extends Component {
 		const { queryObject } = this.props.jetpackConnectAuthorize;
 
 		if ( 'jpo' === queryObject.from || this.props.isSSO || this.props.isWCS ) {
-			debug( 'Going back to WP Admin.', 'Connection initiated via: ', queryObject.from, 'SSO found:', this.props.isSSO );
+			debug(
+				'Going back to WP Admin.',
+				'Connection initiated via: ',
+				queryObject.from,
+				'SSO found:',
+				this.props.isSSO
+			);
 			this.props.goBackToWpAdmin( queryObject.redirect_after_auth );
 		} else {
 			page.redirect( this.getRedirectionTarget() );
@@ -201,21 +202,17 @@ class LoggedInForm extends Component {
 	};
 
 	handleSubmit = () => {
-		const {
-			queryObject,
-			authorizeError,
-			authorizeSuccess
-		} = this.props.jetpackConnectAuthorize;
+		const { queryObject, authorizeError, authorizeSuccess } = this.props.jetpackConnectAuthorize;
 
-		if ( ! this.props.isAlreadyOnSitesList &&
-			! this.props.isFetchingSites,
-			queryObject.already_authorized ) {
+		if (
+			( ! this.props.isAlreadyOnSitesList && ! this.props.isFetchingSites,
+			queryObject.already_authorized )
+		) {
 			this.props.recordTracksEvent( 'calypso_jpc_back_wpadmin_click' );
 			return this.props.goBackToWpAdmin( queryObject.redirect_after_auth );
 		}
 
-		if ( this.props.isAlreadyOnSitesList &&
-			queryObject.already_authorized ) {
+		if ( this.props.isAlreadyOnSitesList && queryObject.already_authorized ) {
 			this.props.recordTracksEvent( 'calypso_jpc_already_authorized_click' );
 			return this.redirect();
 		}
@@ -239,7 +236,7 @@ class LoggedInForm extends Component {
 
 	isAuthorizing() {
 		const { isAuthorizing } = this.props.jetpackConnectAuthorize;
-		return ( ! this.props.isAlreadyOnSitesList && isAuthorizing );
+		return ! this.props.isAlreadyOnSitesList && isAuthorizing;
 	}
 
 	renderErrorDetails() {
@@ -247,9 +244,7 @@ class LoggedInForm extends Component {
 		return (
 			<div className="jetpack-connect__error-details">
 				<FormLabel>{ this.props.translate( 'Error Details' ) }</FormLabel>
-				<FormSettingExplanation>
-					{ authorizeError.message }
-				</FormSettingExplanation>
+				<FormSettingExplanation>{ authorizeError.message }</FormSettingExplanation>
 			</div>
 		);
 	}
@@ -265,19 +260,24 @@ class LoggedInForm extends Component {
 						text={ translate( 'We had trouble connecting.' ) }
 						showDismiss={ false }
 					>
-						<NoticeAction onClick={ this.handleResolve }>
-							{ translate( 'Try again' ) }
-						</NoticeAction>
+						<NoticeAction onClick={ this.handleResolve }>{ translate( 'Try again' ) }</NoticeAction>
 					</Notice>
 				</div>
 				<p>
 					{ translate(
 						'WordPress.com was unable to reach your site and approve the connection. ' +
-						'Try again by clicking the button above; ' +
-						'if that doesn\'t work you may need to {{link}}contact support{{/link}}.', {
+							'Try again by clicking the button above; ' +
+							"if that doesn't work you may need to {{link}}contact support{{/link}}.",
+						{
 							components: {
-								link: <a href="https://jetpack.com/contact-support" target="_blank" rel="noopener noreferrer" />
-							}
+								link: (
+									<a
+										href="https://jetpack.com/contact-support"
+										target="_blank"
+										rel="noopener noreferrer"
+									/>
+								),
+							},
 						}
 					) }
 				</p>
@@ -287,8 +287,18 @@ class LoggedInForm extends Component {
 	}
 
 	renderNotices() {
-		const { authorizeError, queryObject, isAuthorizing, authorizeSuccess, userAlreadyConnected } = this.props.jetpackConnectAuthorize;
-		if ( queryObject.already_authorized && ! this.props.isFetchingSites && ! this.props.isAlreadyOnSitesList ) {
+		const {
+			authorizeError,
+			queryObject,
+			isAuthorizing,
+			authorizeSuccess,
+			userAlreadyConnected,
+		} = this.props.jetpackConnectAuthorize;
+		if (
+			queryObject.already_authorized &&
+			! this.props.isFetchingSites &&
+			! this.props.isAlreadyOnSitesList
+		) {
 			// For users who start their journey at `wordpress.com/jetpack/connect` or similar flows, we will discourage
 			// additional users from linking. Although it is possible to link multiple users with Jetpack, the `jetpack/connect`
 			// flows will be reserved for brand new connections.
@@ -306,7 +316,12 @@ class LoggedInForm extends Component {
 			return <JetpackConnectNotices noticeType="retryingAuth" />;
 		}
 
-		if ( this.props.authAttempts < MAX_AUTH_ATTEMPTS && this.props.authAttempts > 0 && ! isAuthorizing && ! authorizeSuccess ) {
+		if (
+			this.props.authAttempts < MAX_AUTH_ATTEMPTS &&
+			this.props.authAttempts > 0 &&
+			! isAuthorizing &&
+			! authorizeSuccess
+		) {
 			return <JetpackConnectNotices noticeType="retryAuth" />;
 		}
 
@@ -338,12 +353,14 @@ class LoggedInForm extends Component {
 			isAuthorizing,
 			authorizeSuccess,
 			isRedirectingToWpAdmin,
-			authorizeError
+			authorizeError,
 		} = this.props.jetpackConnectAuthorize;
 
-		if ( ! this.props.isAlreadyOnSitesList &&
+		if (
+			! this.props.isAlreadyOnSitesList &&
 			! this.props.isFetchingSites &&
-			queryObject.already_authorized ) {
+			queryObject.already_authorized
+		) {
 			return translate( 'Go back to your site' );
 		}
 
@@ -361,7 +378,8 @@ class LoggedInForm extends Component {
 
 		if ( authorizeSuccess ) {
 			return translate( 'Finishing up!', {
-				context: 'Shown during a jetpack authorization process, while we retrieve the info we need to show the last page'
+				context:
+					'Shown during a jetpack authorization process, while we retrieve the info we need to show the last page',
 			} );
 		}
 
@@ -388,26 +406,23 @@ class LoggedInForm extends Component {
 				rel="noopener noreferrer"
 				onClick={ this.handleClickDisclaimer }
 				href="https://jetpack.com/support/what-data-does-jetpack-sync/"
-				className="jetpack-connect__sso-actions-modal-link" />
+				className="jetpack-connect__sso-actions-modal-link"
+			/>
 		);
 
 		const text = this.props.translate(
 			'By connecting your site, you agree to {{detailsLink}}share details{{/detailsLink}} between WordPress.com and %(siteName)s.',
 			{
 				components: {
-					detailsLink
+					detailsLink,
 				},
 				args: {
-					siteName: decodeEntities( blogname )
-				}
+					siteName: decodeEntities( blogname ),
+				},
 			}
 		);
 
-		return (
-			<p className="jetpack-connect__tos-link">
-				{ text }
-			</p>
-		);
+		return <p className="jetpack-connect__tos-link">{ text }</p>;
 	}
 
 	getUserText() {
@@ -415,13 +430,13 @@ class LoggedInForm extends Component {
 		const { authorizeSuccess } = this.props.jetpackConnectAuthorize;
 		let text = translate( 'Connecting as {{strong}}%(user)s{{/strong}}', {
 			args: { user: this.props.user.display_name },
-			components: { strong: <strong /> }
+			components: { strong: <strong /> },
 		} );
 
 		if ( authorizeSuccess || this.props.isAlreadyOnSitesList ) {
 			text = translate( 'Connected as {{strong}}%(user)s{{/strong}}', {
 				args: { user: this.props.user.display_name },
-				components: { strong: <strong /> }
+				components: { strong: <strong /> },
 			} );
 		}
 
@@ -443,7 +458,7 @@ class LoggedInForm extends Component {
 			queryObject,
 			authorizeSuccess,
 			isAuthorizing,
-			isRedirectingToWpAdmin
+			isRedirectingToWpAdmin,
 		} = this.props.jetpackConnectAuthorize;
 		const { blogname, redirect_after_auth } = queryObject;
 		const redirectTo = addQueryArgs( queryObject, window.location.href );
@@ -451,7 +466,7 @@ class LoggedInForm extends Component {
 			<LoggedOutFormLinkItem icon={ true } href={ redirect_after_auth }>
 				<Gridicon size={ 18 } icon="arrow-left" />
 				{ translate( 'Return to %(sitename)s', {
-					args: { sitename: decodeEntities( blogname ) }
+					args: { sitename: decodeEntities( blogname ) },
 				} ) }
 			</LoggedOutFormLinkItem>
 		);
@@ -465,7 +480,7 @@ class LoggedInForm extends Component {
 				<LoggedOutFormLinks>
 					{ this.isWaitingForConfirmation() ? backToWpAdminLink : null }
 					<LoggedOutFormLinkItem href={ this.getRedirectionTarget() }>
-						{ translate( 'I\'m not interested in upgrades' ) }
+						{ translate( "I'm not interested in upgrades" ) }
 					</LoggedOutFormLinkItem>
 				</LoggedOutFormLinks>
 			);
@@ -510,7 +525,6 @@ class LoggedInForm extends Component {
 					{ this.getButtonText() }
 				</Button>
 			</LoggedOutFormFooter>
-
 		);
 	}
 

--- a/client/jetpack-connect/auth-logged-out-form.jsx
+++ b/client/jetpack-connect/auth-logged-out-form.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import debugModule from 'debug';
 import { get } from 'lodash';
 import { localize } from 'i18n-calypso';

--- a/client/jetpack-connect/auth-logged-out-form.jsx
+++ b/client/jetpack-connect/auth-logged-out-form.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -55,7 +56,7 @@ class LoggedOutForm extends Component {
 
 	handleClickHelp = () => {
 		this.props.recordTracksEvent( 'calypso_jpc_help_link_click' );
-	}
+	};
 
 	renderLoginUser() {
 		const { userData, bearerToken, queryObject } = this.props.jetpackConnectAuthorize;
@@ -65,7 +66,8 @@ class LoggedOutForm extends Component {
 				log={ userData.username }
 				authorization={ 'Bearer ' + bearerToken }
 				emailAddress={ queryObject.user_email }
-				redirectTo={ this.getRedirectAfterLoginUrl() } />
+				redirectTo={ this.getRedirectAfterLoginUrl() }
+			/>
 		);
 	}
 
@@ -74,24 +76,22 @@ class LoggedOutForm extends Component {
 		const headerText = translate( 'Create your account' );
 		const subHeaderText = translate( 'You are moments away from connecting your site.' );
 		const { queryObject } = this.props.jetpackConnectAuthorize;
-		const siteCard = versionCompare( queryObject.jp_version, '4.0.3', '>' )
-			? <SiteCard queryObject={ queryObject } isAlreadyOnSitesList={ isAlreadyOnSitesList } />
-			: null;
+		const siteCard = versionCompare( queryObject.jp_version, '4.0.3', '>' ) ? (
+			<SiteCard queryObject={ queryObject } isAlreadyOnSitesList={ isAlreadyOnSitesList } />
+		) : null;
 
 		return (
 			<div>
-				<FormattedHeader
-					headerText={ headerText }
-					subHeaderText={ subHeaderText } />
+				<FormattedHeader headerText={ headerText } subHeaderText={ subHeaderText } />
 				{ siteCard }
 			</div>
 		);
 	}
 
 	renderLocaleSuggestions() {
-		return this.props.locale
-			? <LocaleSuggestions path={ this.props.path } locale={ this.props.locale } />
-			: null;
+		return this.props.locale ? (
+			<LocaleSuggestions path={ this.props.path } locale={ this.props.locale } />
+		) : null;
 	}
 
 	renderFooterLink() {
@@ -101,7 +101,12 @@ class LoggedOutForm extends Component {
 		return (
 			<LoggedOutFormLinks>
 				<LoggedOutFormLinkItem
-					href={ login( { isNative: config.isEnabled( 'login/native-login-links' ), redirectTo, emailAddress } ) }>
+					href={ login( {
+						isNative: config.isEnabled( 'login/native-login-links' ),
+						redirectTo,
+						emailAddress,
+					} ) }
+				>
 					{ this.props.translate( 'Already have an account? Sign in' ) }
 				</LoggedOutFormLinkItem>
 				<HelpButton onClick={ this.handleClickHelp } />
@@ -110,11 +115,7 @@ class LoggedOutForm extends Component {
 	}
 
 	render() {
-		const {
-			isAuthorizing,
-			userData,
-			queryObject,
-		} = this.props.jetpackConnectAuthorize;
+		const { isAuthorizing, userData, queryObject } = this.props.jetpackConnectAuthorize;
 
 		return (
 			<div>

--- a/client/jetpack-connect/authorize-form.jsx
+++ b/client/jetpack-connect/authorize-form.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -17,7 +18,7 @@ import {
 	authorize,
 	goBackToWpAdmin,
 	retryAuth,
-	goToXmlrpcErrorFallbackUrl
+	goToXmlrpcErrorFallbackUrl,
 } from 'state/jetpack-connect/actions';
 import {
 	getAuthorizationData,
@@ -28,7 +29,7 @@ import {
 	isRemoteSiteOnSitesList,
 	getAuthAttempts,
 	getSiteIdFromQueryObject,
-	getUserAlreadyConnected
+	getUserAlreadyConnected,
 } from 'state/jetpack-connect/selectors';
 import { getCurrentUser } from 'state/current-user/selectors';
 import { recordTracksEvent, setTracksAnonymousUserId } from 'state/analytics/actions';
@@ -95,16 +96,14 @@ class JetpackConnectAuthorizeForm extends Component {
 
 	handleClickHelp = () => {
 		this.props.recordTracksEvent( 'calypso_jpc_help_link_click' );
-	}
+	};
 
 	renderNoQueryArgsError() {
 		return (
 			<Main className="jetpack-connect__main-error">
 				<EmptyContent
 					illustration="/calypso/images/illustrations/whoops.svg"
-					title={ this.props.translate(
-						'Oops, this URL should not be accessed directly'
-					) }
+					title={ this.props.translate( 'Oops, this URL should not be accessed directly' ) }
 					action={ this.props.translate( 'Get back to Jetpack Connect screen' ) }
 					actionURL="/jetpack/connect"
 				/>
@@ -116,18 +115,10 @@ class JetpackConnectAuthorizeForm extends Component {
 	}
 
 	renderForm() {
-		return (
-			( this.props.user )
-				? <LoggedInForm
-					{ ...this.props }
-					isSSO={ this.isSSO() }
-					isWCS={ this.isWCS() }
-				/>
-				: <LoggedOutForm
-					{ ...this.props }
-					isSSO={ this.isSSO() }
-					isWCS={ this.isWCS() }
-				/>
+		return this.props.user ? (
+			<LoggedInForm { ...this.props } isSSO={ this.isSSO() } isWCS={ this.isWCS() } />
+		) : (
+			<LoggedOutForm { ...this.props } isSSO={ this.isSSO() } isWCS={ this.isWCS() } />
 		);
 	}
 
@@ -144,9 +135,7 @@ class JetpackConnectAuthorizeForm extends Component {
 
 		return (
 			<MainWrapper>
-				<div className="jetpack-connect__authorize-form">
-					{ this.renderForm() }
-				</div>
+				<div className="jetpack-connect__authorize-form">{ this.renderForm() }</div>
 			</MainWrapper>
 		);
 	}
@@ -171,7 +160,7 @@ export default connect(
 			requestHasXmlrpcError,
 			siteSlug,
 			user: getCurrentUser( state ),
-			userAlreadyConnected: getUserAlreadyConnected( state )
+			userAlreadyConnected: getUserAlreadyConnected( state ),
 		};
 	},
 	{

--- a/client/jetpack-connect/authorize-form.jsx
+++ b/client/jetpack-connect/authorize-form.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import cookie from 'cookie';

--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External Dependencies
  */
@@ -6,10 +7,7 @@ import React from 'react';
 import page from 'page';
 import Debug from 'debug';
 import { translate } from 'i18n-calypso';
-import {
-	get,
-	isEmpty,
-} from 'lodash';
+import { get, isEmpty } from 'lodash';
 
 /**
  * Internal Dependencies
@@ -42,21 +40,26 @@ const analyticsPageTitleByType = {
 	pro: 'Jetpack Install Pro',
 };
 
-const removeSidebar = ( context ) => {
+const removeSidebar = context => {
 	ReactDom.unmountComponentAtNode( document.getElementById( 'secondary' ) );
 
-	context.store.dispatch( setSection( { name: 'jetpackConnect' }, {
-		hasSidebar: false
-	} ) );
+	context.store.dispatch(
+		setSection(
+			{ name: 'jetpackConnect' },
+			{
+				hasSidebar: false,
+			}
+		)
+	);
 };
 
-const jetpackNewSiteSelector = ( context ) => {
+const jetpackNewSiteSelector = context => {
 	removeSidebar( context );
 	renderWithReduxStore(
 		React.createElement( JetpackNewSite, {
 			path: context.path,
 			context: context,
-			locale: context.params.locale
+			locale: context.params.locale,
 		} ),
 		document.getElementById( 'primary' ),
 		context.store
@@ -79,7 +82,7 @@ export default {
 			debug( 'set initial query object', context.query );
 			context.store.dispatch( {
 				type: JETPACK_CONNECT_QUERY_SET,
-				queryObject: context.query
+				queryObject: context.query,
 			} );
 			page.redirect( context.pathname );
 		}
@@ -93,11 +96,7 @@ export default {
 	},
 
 	connect( context ) {
-		const {
-			path,
-			pathname,
-			params
-		} = context;
+		const { path, pathname, params } = context;
 		const { type = false } = params;
 		const analyticsPageTitle = get( type, analyticsPageTitleByType, 'Jetpack Connect' );
 
@@ -141,11 +140,7 @@ export default {
 
 		analytics.pageView.record( analyticsBasePath, analyticsPageTitle );
 		renderWithReduxStore(
-			<JetpackConnectAuthorizeForm
-				path={ context.path }
-				interval={ interval }
-				locale={ locale }
-			/>,
+			<JetpackConnectAuthorizeForm path={ context.path } interval={ interval } locale={ locale } />,
 			document.getElementById( 'primary' ),
 			context.store
 		);
@@ -167,7 +162,7 @@ export default {
 				locale: context.params.locale,
 				userModule: userModule,
 				siteId: context.params.siteId,
-				ssoNonce: context.params.ssoNonce
+				ssoNonce: context.params.ssoNonce,
 			} ),
 			document.getElementById( 'primary' ),
 			context.store
@@ -227,7 +222,8 @@ export default {
 					context={ context }
 					destinationType={ context.params.destinationType }
 					basePlansPath={ '/jetpack/connect/plans' }
-					interval={ context.params.interval } />
+					interval={ context.params.interval }
+				/>
 			</CheckoutData>,
 			document.getElementById( 'primary' ),
 			context.store
@@ -247,7 +243,8 @@ export default {
 			<Plans
 				context={ context }
 				showFirst={ true }
-				destinationType={ context.params.destinationType } />,
+				destinationType={ context.params.destinationType }
+			/>,
 			document.getElementById( 'primary' ),
 			context.store
 		);

--- a/client/jetpack-connect/example-components/jetpack-activate.jsx
+++ b/client/jetpack-connect/example-components/jetpack-activate.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react';
+import PropTypes from 'prop-types';
 import Gridicon from 'gridicons';
 
 /**
@@ -71,7 +72,7 @@ const JetpackConnectExampleActivate = ( { isInstall, url, translate, onClick } )
 };
 
 JetpackConnectExampleActivate.propTypes = {
-	onClick: React.PropTypes.func
+	onClick: PropTypes.func
 };
 
 JetpackConnectExampleActivate.defaultProps = {

--- a/client/jetpack-connect/example-components/jetpack-activate.jsx
+++ b/client/jetpack-connect/example-components/jetpack-activate.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -16,55 +17,51 @@ const JetpackConnectExampleActivate = ( { isInstall, url, translate, onClick } )
 		<div className="example-components__main" onClick={ onClick }>
 			<div className="example-components__browser-chrome example-components__site-url-input-container">
 				<div className="example-components__browser-chrome-dots">
-					<div className="example-components__browser-chrome-dot"></div>
-					<div className="example-components__browser-chrome-dot"></div>
-					<div className="example-components__browser-chrome-dot"></div>
+					<div className="example-components__browser-chrome-dot" />
+					<div className="example-components__browser-chrome-dot" />
+					<div className="example-components__browser-chrome-dot" />
 				</div>
 				<div className="example-components__site-address-container">
-					<Gridicon
-						size={ 24 }
-						icon="globe" />
+					<Gridicon size={ 24 } icon="globe" />
 					<FormTextInput
 						className="example-components__browser-chrome-url"
 						disabled="true"
-						placeholder={ url } />
+						placeholder={ url }
+					/>
 				</div>
 			</div>
 			<div className="example-components__content example-components__activate-jetpack">
-				<div className="example-components__content-wp-admin-masterbar"></div>
-				<div className="example-components__content-wp-admin-sidebar"></div>
+				<div className="example-components__content-wp-admin-masterbar" />
+				<div className="example-components__content-wp-admin-sidebar" />
 				<div className="example-components__content-wp-admin-main">
-					{ isInstall
-						? (
-							<div className="example-components__content-wp-admin-activate-view">
-								<div className="example-components__content-wp-admin-activate-link" aria-hidden="true">
-									{ translate( 'Activate Plugin',
-										{
-											context: 'Jetpack Connect activate plugin instructions, activate link'
-										}
-									) }
-								</div>
+					{ isInstall ? (
+						<div className="example-components__content-wp-admin-activate-view">
+							<div
+								className="example-components__content-wp-admin-activate-link"
+								aria-hidden="true"
+							>
+								{ translate( 'Activate Plugin', {
+									context: 'Jetpack Connect activate plugin instructions, activate link',
+								} ) }
 							</div>
-						)
-						: (
-							<div className="example-components__content-wp-admin-plugin-card">
-								<div className="example-components__content-wp-admin-plugin-name" aria-hidden="true">
-									{ translate( 'Jetpack by WordPress.com',
-										{
-											context: 'Jetpack Connect activate plugin instructions, plugin title'
-										}
-									) }
-								</div>
-								<div className="example-components__content-wp-admin-plugin-activate-link" aria-hidden="true">
-									{ translate( 'Activate',
-										{
-											context: 'Jetpack Connect activate plugin instructions, activate link'
-										}
-									) }
-								</div>
+						</div>
+					) : (
+						<div className="example-components__content-wp-admin-plugin-card">
+							<div className="example-components__content-wp-admin-plugin-name" aria-hidden="true">
+								{ translate( 'Jetpack by WordPress.com', {
+									context: 'Jetpack Connect activate plugin instructions, plugin title',
+								} ) }
 							</div>
-						)
-					}
+							<div
+								className="example-components__content-wp-admin-plugin-activate-link"
+								aria-hidden="true"
+							>
+								{ translate( 'Activate', {
+									context: 'Jetpack Connect activate plugin instructions, activate link',
+								} ) }
+							</div>
+						</div>
+					) }
 				</div>
 			</div>
 		</div>
@@ -72,11 +69,11 @@ const JetpackConnectExampleActivate = ( { isInstall, url, translate, onClick } )
 };
 
 JetpackConnectExampleActivate.propTypes = {
-	onClick: PropTypes.func
+	onClick: PropTypes.func,
 };
 
 JetpackConnectExampleActivate.defaultProps = {
-	onClick: () => {}
+	onClick: () => {},
 };
 
 export default localize( JetpackConnectExampleActivate );

--- a/client/jetpack-connect/example-components/jetpack-connect.jsx
+++ b/client/jetpack-connect/example-components/jetpack-connect.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -13,50 +14,48 @@ import FormTextInput from 'components/forms/form-text-input';
 import { localize } from 'i18n-calypso';
 
 const JetpackConnectExampleConnect = ( { isLegacy, url, translate, onClick } ) => {
-	const contentClassName = classNames( 'example-components__content', 'example-components__connect-jetpack', {
-		'is-legacy': isLegacy
-	} );
+	const contentClassName = classNames(
+		'example-components__content',
+		'example-components__connect-jetpack',
+		{
+			'is-legacy': isLegacy,
+		}
+	);
 	return (
 		<div className="example-components__main" onClick={ onClick }>
 			<div className="example-components__browser-chrome example-components__site-url-input-container">
 				<div className="example-components__browser-chrome-dots">
-					<div className="example-components__browser-chrome-dot"></div>
-					<div className="example-components__browser-chrome-dot"></div>
-					<div className="example-components__browser-chrome-dot"></div>
+					<div className="example-components__browser-chrome-dot" />
+					<div className="example-components__browser-chrome-dot" />
+					<div className="example-components__browser-chrome-dot" />
 				</div>
 				<div className="example-components__site-address-container">
-					<Gridicon
-						size={ 24 }
-						icon="globe" />
+					<Gridicon size={ 24 } icon="globe" />
 					<FormTextInput
 						className="example-components__browser-chrome-url"
 						disabled="true"
-						placeholder={ url } />
+						placeholder={ url }
+					/>
 				</div>
 			</div>
 			<div className={ contentClassName }>
-				<div className="example-components__content-wp-admin-masterbar"></div>
-				<div className="example-components__content-wp-admin-sidebar"></div>
+				<div className="example-components__content-wp-admin-masterbar" />
+				<div className="example-components__content-wp-admin-sidebar" />
 				<div className="example-components__content-wp-admin-main">
 					<div className="example-components__content-wp-admin-connect-banner">
-						{ ! isLegacy
-							? (
-								<div className="example-components__content-wp-admin-plugin-name" aria-hidden="true">
-									{ translate( 'Your Jetpack is almost ready!',
-										{
-											context: 'Jetpack Connect activate plugin instructions, connection banner headline'
-										}
-									) }
-								</div>
-							)
-							: null
-						}
+						{ ! isLegacy ? (
+							<div className="example-components__content-wp-admin-plugin-name" aria-hidden="true">
+								{ translate( 'Your Jetpack is almost ready!', {
+									context:
+										'Jetpack Connect activate plugin instructions, connection banner headline',
+								} ) }
+							</div>
+						) : null }
 						<div className="example-components__content-wp-admin-connect-button" aria-hidden="true">
-							{ translate( 'Connect to WordPress.com',
-								{
-									context: 'Jetpack Connect post-plugin-activation step, Connect to WordPress.com button'
-								}
-							) }
+							{ translate( 'Connect to WordPress.com', {
+								context:
+									'Jetpack Connect post-plugin-activation step, Connect to WordPress.com button',
+							} ) }
 						</div>
 					</div>
 				</div>

--- a/client/jetpack-connect/example-components/jetpack-connect.jsx
+++ b/client/jetpack-connect/example-components/jetpack-connect.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import Gridicon from 'gridicons';
 
@@ -65,15 +66,15 @@ const JetpackConnectExampleConnect = ( { isLegacy, url, translate, onClick } ) =
 };
 
 JetpackConnectExampleConnect.propTypes = {
-	isLegacy: React.PropTypes.bool,
-	url: React.PropTypes.string,
-	onClick: React.PropTypes.func
+	isLegacy: PropTypes.bool,
+	onClick: PropTypes.func,
+	url: PropTypes.string,
 };
 
 JetpackConnectExampleConnect.defaultProps = {
 	isLegacy: false,
+	onClick: () => {},
 	url: '',
-	onClick: () => {}
 };
 
 export default localize( JetpackConnectExampleConnect );

--- a/client/jetpack-connect/example-components/jetpack-install.jsx
+++ b/client/jetpack-connect/example-components/jetpack-install.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react';
+import PropTypes from 'prop-types';
 import Gridicon from 'gridicons';
 
 /**
@@ -47,7 +48,7 @@ const JetpackConnectExampleInstall = ( { url, translate, onClick } ) => {
 };
 
 JetpackConnectExampleInstall.propTypes = {
-	onClick: React.PropTypes.func
+	onClick: PropTypes.func
 };
 
 JetpackConnectExampleInstall.defaultProps = {

--- a/client/jetpack-connect/example-components/jetpack-install.jsx
+++ b/client/jetpack-connect/example-components/jetpack-install.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -16,30 +17,27 @@ const JetpackConnectExampleInstall = ( { url, translate, onClick } ) => {
 		<div className="example-components__main" onClick={ onClick }>
 			<div className="example-components__browser-chrome example-components__site-url-input-container">
 				<div className="example-components__browser-chrome-dots">
-					<div className="example-components__browser-chrome-dot"></div>
-					<div className="example-components__browser-chrome-dot"></div>
-					<div className="example-components__browser-chrome-dot"></div>
+					<div className="example-components__browser-chrome-dot" />
+					<div className="example-components__browser-chrome-dot" />
+					<div className="example-components__browser-chrome-dot" />
 				</div>
 				<div className="example-components__site-address-container">
-					<Gridicon
-						size={ 24 }
-						icon="globe" />
+					<Gridicon size={ 24 } icon="globe" />
 					<FormTextInput
 						className="example-components__browser-chrome-url"
 						disabled="true"
-						placeholder={ url } />
+						placeholder={ url }
+					/>
 				</div>
 			</div>
 			<div className="example-components__content example-components__install-jetpack">
-				<div className="example-components__install-plugin-header"></div>
-				<div className="example-components__install-plugin-body"></div>
+				<div className="example-components__install-plugin-header" />
+				<div className="example-components__install-plugin-body" />
 				<div className="example-components__install-plugin-footer">
 					<div className="example-components__install-plugin-footer-button" aria-hidden="true">
-						{ translate( 'Install Now',
-							{
-								context: 'Jetpack Connect install plugin instructions, install button'
-							}
-						) }
+						{ translate( 'Install Now', {
+							context: 'Jetpack Connect install plugin instructions, install button',
+						} ) }
 					</div>
 				</div>
 			</div>
@@ -48,11 +46,11 @@ const JetpackConnectExampleInstall = ( { url, translate, onClick } ) => {
 };
 
 JetpackConnectExampleInstall.propTypes = {
-	onClick: PropTypes.func
+	onClick: PropTypes.func,
 };
 
 JetpackConnectExampleInstall.defaultProps = {
-	onClick: () => {}
+	onClick: () => {},
 };
 
 export default localize( JetpackConnectExampleInstall );

--- a/client/jetpack-connect/help-button.jsx
+++ b/client/jetpack-connect/help-button.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import Gridicon from 'gridicons';
 
 /**

--- a/client/jetpack-connect/help-button.jsx
+++ b/client/jetpack-connect/help-button.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -16,7 +17,8 @@ const JetpackConnectHelpButton = ( { translate, onClick } ) => {
 		<LoggedOutFormLinkItem
 			className="jetpack-connect__help-button"
 			href="https://jetpack.com/contact-support"
-			target="_blank" rel="noopener noreferrer"
+			target="_blank"
+			rel="noopener noreferrer"
 			onClick={ onClick }
 		>
 			<Gridicon icon="help-outline" /> { translate( 'Get help connecting your site' ) }
@@ -25,7 +27,7 @@ const JetpackConnectHelpButton = ( { translate, onClick } ) => {
 };
 
 JetpackConnectHelpButton.propTypes = {
-	onClick: PropTypes.func
+	onClick: PropTypes.func,
 };
 
 export default localize( JetpackConnectHelpButton );

--- a/client/jetpack-connect/index.js
+++ b/client/jetpack-connect/index.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -10,16 +11,19 @@ import controller from './controller';
 import sitesController from 'my-sites/controller';
 
 const redirectToStoreWithInterval = context => {
-	const interval = context && context.params && context.params.interval
-		? context.params.interval
-		: '';
+	const interval =
+		context && context.params && context.params.interval ? context.params.interval : '';
 	page.redirect( `/jetpack/connect/store/${ interval }` );
 };
 
 export default function() {
-	page( '/jetpack/connect/:type(personal|premium|pro)/:interval(yearly|monthly)?', controller.connect );
+	page(
+		'/jetpack/connect/:type(personal|premium|pro)/:interval(yearly|monthly)?',
+		controller.connect
+	);
 
-	page( '/jetpack/connect/:type(install)/:locale?',
+	page(
+		'/jetpack/connect/:type(install)/:locale?',
 		controller.redirectWithoutLocaleifLoggedIn,
 		controller.connect
 	);
@@ -57,11 +61,7 @@ export default function() {
 		controller.connect
 	);
 
-	page(
-		'/jetpack/connect/plans/:site',
-		sitesController.siteSelection,
-		controller.plansSelection
-	);
+	page( '/jetpack/connect/plans/:site', sitesController.siteSelection, controller.plansSelection );
 
 	page(
 		'/jetpack/connect/plans/:interval/:site',

--- a/client/jetpack-connect/install-step.jsx
+++ b/client/jetpack-connect/install-step.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -23,10 +24,7 @@ class JetpackInstallStep extends Component {
 		confirmJetpackInstallStatus: PropTypes.func.isRequired,
 		currentUrl: PropTypes.string,
 		isInstall: PropTypes.bool.isRequired,
-		jetpackVersion: PropTypes.oneOfType( [
-			PropTypes.string,
-			PropTypes.bool,
-		] ),
+		jetpackVersion: PropTypes.oneOfType( [ PropTypes.string, PropTypes.bool ] ),
 		onClick: PropTypes.func,
 	};
 
@@ -35,19 +33,23 @@ class JetpackInstallStep extends Component {
 		onClick: noop,
 	};
 
-	confirmJetpackInstalled = ( event ) => {
+	confirmJetpackInstalled = event => {
 		event.preventDefault();
 		this.props.confirmJetpackInstallStatus( true );
 	};
 
-	confirmJetpackNotInstalled = ( event ) => {
+	confirmJetpackNotInstalled = event => {
 		event.preventDefault();
 		this.props.confirmJetpackInstallStatus( false );
 	};
 
 	renderAlreadyHaveJetpackButton() {
 		return (
-			<a className="jetpack-connect__already-installed-jetpack-button" href="#" onClick={ this.confirmJetpackInstalled }>
+			<a
+				className="jetpack-connect__already-installed-jetpack-button"
+				href="#"
+				onClick={ this.confirmJetpackInstalled }
+			>
 				{ preventWidows( this.props.translate( 'Already have Jetpack installed?' ) ) }
 			</a>
 		);
@@ -55,67 +57,76 @@ class JetpackInstallStep extends Component {
 
 	renderNotJetpackButton() {
 		return (
-			<a className="jetpack-connect__no-jetpack-button" href="#" onClick={ this.confirmJetpackNotInstalled }>
-				{ preventWidows( this.props.translate( 'Don\'t have Jetpack installed?' ) ) }
+			<a
+				className="jetpack-connect__no-jetpack-button"
+				href="#"
+				onClick={ this.confirmJetpackNotInstalled }
+			>
+				{ preventWidows( this.props.translate( "Don't have Jetpack installed?" ) ) }
 			</a>
 		);
 	}
 
 	getStep( stepName ) {
-		const {
-			currentUrl,
-			isInstall,
-			jetpackVersion,
-			onClick,
-			translate,
-		} = this.props;
+		const { currentUrl, isInstall, jetpackVersion, onClick, translate } = this.props;
 
-		const isLegacyVersion = (
-			jetpackVersion &&
-			versionCompare( jetpackVersion, NEW_INSTRUCTIONS_JETPACK_VERSION, '<' )
+		const isLegacyVersion =
+			jetpackVersion && versionCompare( jetpackVersion, NEW_INSTRUCTIONS_JETPACK_VERSION, '<' );
+
+		const jetpackConnectExample = (
+			<JetpackExampleConnect url={ currentUrl } isLegacy={ isLegacyVersion } onClick={ onClick } />
 		);
-
-		const jetpackConnectExample = <JetpackExampleConnect
-			url={ currentUrl }
-			isLegacy={ isLegacyVersion }
-			onClick={ onClick } />;
 
 		const steps = {
 			installJetpack: {
 				title: translate( '1. Install Jetpack' ),
 				text: isInstall
-					? translate( 'You will be redirected to your site\'s dashboard to install ' +
-					'Jetpack. Click the blue "Install Now" button.' )
-					: translate( 'You will be redirected to the Jetpack plugin page on your site\'s ' +
-					'dashboard to install Jetpack. Click the blue install button.' ),
+					? translate(
+							"You will be redirected to your site's dashboard to install " +
+								'Jetpack. Click the blue "Install Now" button.'
+						)
+					: translate(
+							"You will be redirected to the Jetpack plugin page on your site's " +
+								'dashboard to install Jetpack. Click the blue install button.'
+						),
 				action: this.renderAlreadyHaveJetpackButton(),
-				example: <JetpackExampleInstall url={ currentUrl } onClick={ onClick } />
+				example: <JetpackExampleInstall url={ currentUrl } onClick={ onClick } />,
 			},
 			activateJetpackAfterInstall: {
 				title: translate( '2. Activate Jetpack' ),
 				text: translate( 'Then you\'ll click the blue "Activate" link to activate Jetpack.' ),
 				action: null,
-				example: <JetpackExampleActivate url={ currentUrl } isInstall={ true } onClick={ onClick } />
+				example: (
+					<JetpackExampleActivate url={ currentUrl } isInstall={ true } onClick={ onClick } />
+				),
 			},
 			connectJetpackAfterInstall: {
 				title: translate( '3. Connect Jetpack' ),
-				text: translate( 'Finally, click the "Connect to WordPress.com" button to finish the process.' ),
+				text: translate(
+					'Finally, click the "Connect to WordPress.com" button to finish the process.'
+				),
 				action: null,
-				example: jetpackConnectExample
+				example: jetpackConnectExample,
 			},
 			activateJetpack: {
 				title: translate( '1. Activate Jetpack' ),
-				text: translate( 'You will be redirected to your site\'s dashboard to activate Jetpack. ' +
-					'Click the blue "Activate" link. ' ),
+				text: translate(
+					"You will be redirected to your site's dashboard to activate Jetpack. " +
+						'Click the blue "Activate" link. '
+				),
 				action: this.renderNotJetpackButton(),
-				example: <JetpackExampleActivate url={ currentUrl } isInstall={ false } onClick={ onClick } />
+				example: (
+					<JetpackExampleActivate url={ currentUrl } isInstall={ false } onClick={ onClick } />
+				),
 			},
 			connectJetpack: {
 				title: translate( '2. Connect Jetpack' ),
-				text: translate( 'Then click the "Connect to WordPress.com" button to finish the process.' ),
+				text: translate(
+					'Then click the "Connect to WordPress.com" button to finish the process.'
+				),
 				action: null,
-				example: jetpackConnectExample
-			}
+				example: jetpackConnectExample,
+			},
 		};
 		return steps[ stepName ];
 	}
@@ -124,9 +135,7 @@ class JetpackInstallStep extends Component {
 		const step = this.getStep( this.props.stepName );
 		return (
 			<Card className="jetpack-connect__install-step">
-				<div className="jetpack-connect__install-step-title">
-					{ step.title }
-				</div>
+				<div className="jetpack-connect__install-step-title">{ step.title }</div>
 				<div className="jetpack-connect__install-step-text">
 					<span>
 						{ preventWidows( step.text ) }&nbsp;

--- a/client/jetpack-connect/install-step.jsx
+++ b/client/jetpack-connect/install-step.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { noop } from 'lodash';
 import { localize } from 'i18n-calypso';
 

--- a/client/jetpack-connect/jetpack-connect-notices.jsx
+++ b/client/jetpack-connect/jetpack-connect-notices.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 
 /**

--- a/client/jetpack-connect/jetpack-connect-notices.jsx
+++ b/client/jetpack-connect/jetpack-connect-notices.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -37,17 +38,13 @@ class JetpackConnectNotices extends Component {
 	};
 
 	getNoticeValues() {
-		const {
-			noticeType,
-			onDismissClick,
-			translate,
-		} = this.props;
+		const { noticeType, onDismissClick, translate } = this.props;
 
 		const noticeValues = {
 			icon: 'notice',
 			status: 'is-error',
-			text: translate( 'That\'s not a valid url.' ),
-			showDismiss: false
+			text: translate( "That's not a valid url." ),
+			showDismiss: false,
 		};
 
 		if ( onDismissClick ) {
@@ -61,12 +58,14 @@ class JetpackConnectNotices extends Component {
 
 			case 'isDotCom':
 				noticeValues.icon = 'block';
-				noticeValues.text = translate( 'That\'s a WordPress.com site, so you don\'t need to connect it.' );
+				noticeValues.text = translate(
+					"That's a WordPress.com site, so you don't need to connect it."
+				);
 				return noticeValues;
 
 			case 'notWordPress':
 				noticeValues.icon = 'block';
-				noticeValues.text = translate( 'That\'s not a WordPress site.' );
+				noticeValues.text = translate( "That's not a WordPress site." );
 				return noticeValues;
 
 			case 'notActiveJetpack':
@@ -93,37 +92,52 @@ class JetpackConnectNotices extends Component {
 			case 'notJetpack':
 				noticeValues.status = 'is-notice';
 				noticeValues.icon = 'status';
-				noticeValues.text = translate( 'Jetpack couldn\'t be found.' );
+				noticeValues.text = translate( "Jetpack couldn't be found." );
 				return noticeValues;
 
 			case 'wordpress.com':
-				noticeValues.text = translate( 'Oops, that\'s us.' );
+				noticeValues.text = translate( "Oops, that's us." );
 				noticeValues.status = 'is-warning';
 				noticeValues.icon = 'status';
 				return noticeValues;
 
 			case 'retryingAuth':
-				noticeValues.text = translate( 'Error authorizing. Page is refreshing for another attempt.' );
+				noticeValues.text = translate(
+					'Error authorizing. Page is refreshing for another attempt.'
+				);
 				noticeValues.status = 'is-warning';
 				noticeValues.icon = 'notice';
 				return noticeValues;
 
 			case 'retryAuth':
-				noticeValues.text = translate( 'In some cases, authorization can take a few attempts. Please try again.' );
+				noticeValues.text = translate(
+					'In some cases, authorization can take a few attempts. Please try again.'
+				);
 				noticeValues.status = 'is-warning';
 				noticeValues.icon = 'notice';
 				return noticeValues;
 
 			case 'secretExpired':
-				noticeValues.text = translate( 'Oops, that took a while. You\'ll have to try again.' );
+				noticeValues.text = translate( "Oops, that took a while. You'll have to try again." );
 				noticeValues.status = 'is-error';
 				noticeValues.icon = 'notice';
 				return noticeValues;
 
 			case 'defaultAuthorizeError':
-				noticeValues.text = translate( 'Error authorizing your site. Please {{link}}contact support{{/link}}.', {
-					components: { link: <a href="https://jetpack.com/contact-support" target="_blank" rel="noopener noreferrer" /> }
-				} );
+				noticeValues.text = translate(
+					'Error authorizing your site. Please {{link}}contact support{{/link}}.',
+					{
+						components: {
+							link: (
+								<a
+									href="https://jetpack.com/contact-support"
+									target="_blank"
+									rel="noopener noreferrer"
+								/>
+							),
+						},
+					}
+				);
 				noticeValues.status = 'is-error';
 				noticeValues.icon = 'notice';
 				return noticeValues;
@@ -131,7 +145,7 @@ class JetpackConnectNotices extends Component {
 			case 'alreadyConnectedByOtherUser':
 				noticeValues.text = translate(
 					'This site is already connected to a different WordPress.com user, ' +
-					'you need to disconnect that user before you can connect another.'
+						'you need to disconnect that user before you can connect another.'
 				);
 				noticeValues.status = 'is-warning';
 				noticeValues.icon = 'notice';
@@ -139,7 +153,7 @@ class JetpackConnectNotices extends Component {
 			case 'userIsAlreadyConnectedToSite':
 				noticeValues.text = translate(
 					'This WordPress.com account is already connected to an other user on this site. ' +
-					'Please login to an other WordPress.com account to complete the connection.'
+						'Please login to an other WordPress.com account to complete the connection.'
 				);
 				noticeValues.status = 'is-warning';
 				noticeValues.icon = 'notice';

--- a/client/jetpack-connect/jetpack-new-site/index.jsx
+++ b/client/jetpack-connect/jetpack-new-site/index.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -33,7 +34,7 @@ class JetpackNewSite extends Component {
 		this.props.recordTracksEvent( 'calypso_jetpack_new_site_view' );
 	}
 
-	handleJetpackUrlChange = ( event ) => this.setState( { jetpackUrl: event.target.value } );
+	handleJetpackUrlChange = event => this.setState( { jetpackUrl: event.target.value } );
 
 	getNewWpcomSiteUrl() {
 		return config( 'signup_url' ) + '?ref=calypso-selector';
@@ -60,10 +61,14 @@ class JetpackNewSite extends Component {
 				<ReaderBack onBackClick={ this.handleBack } />
 				<div className="jetpack-new-site__main jetpack-new-site">
 					<div className="jetpack-new-site__header">
-						<h2 className="jetpack-new-site__header-title">{ this.props.translate( 'Add a New Site' ) }</h2>
-						<div className="jetpack-new-site__header-text">{ this.props.translate(
-							'Create a new site on WordPress.com or add your existing self-hosted WordPress site with Jetpack.'
-						) } </div>
+						<h2 className="jetpack-new-site__header-title">
+							{ this.props.translate( 'Add a New Site' ) }
+						</h2>
+						<div className="jetpack-new-site__header-text">
+							{ this.props.translate(
+								'Create a new site on WordPress.com or add your existing self-hosted WordPress site with Jetpack.'
+							) }{' '}
+						</div>
 					</div>
 					<div className="jetpack-new-site__content">
 						<Card className="jetpack-new-site__wpcom-site">
@@ -72,18 +77,19 @@ class JetpackNewSite extends Component {
 								{ this.props.translate( 'Create a new shiny WordPress.com site' ) }
 							</h3>
 							<div className="jetpack-new-site__card-description">
-							<p>
-								{ this.props.translate(
-									'Start telling your story in just 2 minutes. Pick a visual theme and a domain — ' +
-									'we’ll take care of the entire setup. If you need help we’ve got you covered with 24/7 support.' ) }
-							</p>
+								<p>
+									{ this.props.translate(
+										'Start telling your story in just 2 minutes. Pick a visual theme and a domain — ' +
+											'we’ll take care of the entire setup. If you need help we’ve got you covered with 24/7 support.'
+									) }
+								</p>
 							</div>
 							<div className="jetpack-new-site__button-holder">
 								<Button
 									className="jetpack-new-site__button button is-primary"
 									href={ this.getNewWpcomSiteUrl() }
 								>
-								{ this.props.translate( 'Start Now' ) }
+									{ this.props.translate( 'Start Now' ) }
 								</Button>
 							</div>
 						</Card>
@@ -93,7 +99,9 @@ class JetpackNewSite extends Component {
 								{ this.props.translate( 'Add an existing WordPress site with Jetpack' ) }
 							</h3>
 							<div className="jetpack-new-site__card-description">
-								{ this.props.translate( 'We’ll be using the Jetpack plugin to connect your site to WordPress.com.' ) }
+								{ this.props.translate(
+									'We’ll be using the Jetpack plugin to connect your site to WordPress.com.'
+								) }
 							</div>
 							<SiteUrlInput
 								onChange={ this.handleJetpackUrlChange }
@@ -105,8 +113,8 @@ class JetpackNewSite extends Component {
 						<Card className="jetpack-new-site__mobile">
 							<div className="jetpack-new-site__mobile-wpcom-site">
 								<p>{ this.props.translate( 'Create a new shiny WordPress.com site:' ) }</p>
-								<Button primary	href={ this.getNewWpcomSiteUrl() }>
-								{ this.props.translate( 'Start Now' ) }
+								<Button primary href={ this.getNewWpcomSiteUrl() }>
+									{ this.props.translate( 'Start Now' ) }
 								</Button>
 							</div>
 							<div className="jetpack-new-site__divider">
@@ -129,9 +137,11 @@ class JetpackNewSite extends Component {
 	}
 }
 
-export default connect(
-	null,
-	dispatch => bindActionCreators( {
-		recordTracksEvent
-	}, dispatch )
+export default connect( null, dispatch =>
+	bindActionCreators(
+		{
+			recordTracksEvent,
+		},
+		dispatch
+	)
 )( localize( JetpackNewSite ) );

--- a/client/jetpack-connect/main-wrapper.jsx
+++ b/client/jetpack-connect/main-wrapper.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -12,21 +13,17 @@ import Main from 'components/main';
 
 const JetpackConnectMainWrapper = ( { isWide, className, children } ) => {
 	const wrapperClassName = classNames( 'jetpack-connect__main', {
-		'is-wide': isWide
+		'is-wide': isWide,
 	} );
-	return (
-		<Main className={ classNames( className, wrapperClassName ) }>
-			{ children }
-		</Main>
-	);
+	return <Main className={ classNames( className, wrapperClassName ) }>{ children }</Main>;
 };
 
 JetpackConnectMainWrapper.propTypes = {
-	isWide: PropTypes.bool
+	isWide: PropTypes.bool,
 };
 
 JetpackConnectMainWrapper.defaultProps = {
-	isWide: false
+	isWide: false,
 };
 
 export default JetpackConnectMainWrapper;

--- a/client/jetpack-connect/main-wrapper.jsx
+++ b/client/jetpack-connect/main-wrapper.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 /**
@@ -21,7 +22,7 @@ const JetpackConnectMainWrapper = ( { isWide, className, children } ) => {
 };
 
 JetpackConnectMainWrapper.propTypes = {
-	isWide: React.PropTypes.bool
+	isWide: PropTypes.bool
 };
 
 JetpackConnectMainWrapper.defaultProps = {

--- a/client/jetpack-connect/main.jsx
+++ b/client/jetpack-connect/main.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -20,7 +21,7 @@ import SiteUrlInput from './site-url-input';
 import {
 	getGlobalSelectedPlan,
 	getConnectingSite,
-	getJetpackSiteByUrl
+	getJetpackSiteByUrl,
 } from 'state/jetpack-connect/selectors';
 import { isRequestingSites } from 'state/sites/selectors';
 import QuerySites from 'components/data/query-sites';
@@ -39,7 +40,7 @@ import {
 	goToPluginInstall,
 	goToPlans,
 	goToPluginActivation,
-	checkUrl
+	checkUrl,
 } from 'state/jetpack-connect/actions';
 
 /**
@@ -51,26 +52,21 @@ class JetpackConnectMain extends Component {
 	static propTypes = {
 		locale: PropTypes.string,
 		path: PropTypes.string,
-		type: PropTypes.oneOf( [
-			'install',
-			'pro',
-			'premium',
-			'personal',
-			false,
-		] ),
+		type: PropTypes.oneOf( [ 'install', 'pro', 'premium', 'personal', false ] ),
 		url: PropTypes.string,
 	};
 
 	state = this.props.url
 		? {
-			currentUrl: this.cleanUrl( this.props.url ),
-			shownUrl: this.props.url,
-			waitingForSites: false
-		} : {
-			currentUrl: '',
-			shownUrl: '',
-			waitingForSites: false
-		};
+				currentUrl: this.cleanUrl( this.props.url ),
+				shownUrl: this.props.url,
+				waitingForSites: false,
+			}
+		: {
+				currentUrl: '',
+				shownUrl: '',
+				waitingForSites: false,
+			};
 
 	componentWillMount() {
 		if ( this.props.url ) {
@@ -93,19 +89,19 @@ class JetpackConnectMain extends Component {
 			from = 'ad';
 		}
 		this.props.recordTracksEvent( 'calypso_jpc_url_view', {
-			jpc_from: from
+			jpc_from: from,
 		} );
 	}
 
 	componentDidUpdate() {
-		if ( this.getStatus() === 'notConnectedJetpack' &&
+		if (
+			this.getStatus() === 'notConnectedJetpack' &&
 			this.isCurrentUrlFetched() &&
 			! this.props.jetpackConnectSite.isRedirecting
 		) {
 			return this.props.goToRemoteAuth( this.state.currentUrl );
 		}
-		if ( this.getStatus() === 'alreadyOwned' &&
-			! this.props.jetpackConnectSite.isRedirecting ) {
+		if ( this.getStatus() === 'alreadyOwned' && ! this.props.jetpackConnectSite.isRedirecting ) {
 			return this.props.goToPlans( this.state.currentUrl );
 		}
 
@@ -119,19 +115,23 @@ class JetpackConnectMain extends Component {
 	dismissUrl = () => this.props.dismissUrl( this.state.currentUrl );
 
 	isCurrentUrlFetched() {
-		return this.props.jetpackConnectSite &&
+		return (
+			this.props.jetpackConnectSite &&
 			this.state.currentUrl === this.props.jetpackConnectSite.url &&
-			this.props.jetpackConnectSite.isFetched;
+			this.props.jetpackConnectSite.isFetched
+		);
 	}
 
 	isCurrentUrlFetching() {
-		return this.state.currentUrl !== '' &&
+		return (
+			this.state.currentUrl !== '' &&
 			this.props.jetpackConnectSite &&
 			this.state.currentUrl === this.props.jetpackConnectSite.url &&
-			this.props.jetpackConnectSite.isFetching;
+			this.props.jetpackConnectSite.isFetching
+		);
 	}
 
-	handleUrlChange = ( event ) => {
+	handleUrlChange = event => {
 		const url = event.target.value;
 		this.setState( {
 			currentUrl: this.cleanUrl( url ),
@@ -148,16 +148,12 @@ class JetpackConnectMain extends Component {
 	}
 
 	checkUrl( url ) {
-		return this.props.checkUrl(
-			url,
-			!! this.props.getJetpackSiteByUrl( url ),
-			this.props.type
-		);
+		return this.props.checkUrl( url, !! this.props.getJetpackSiteByUrl( url ), this.props.type );
 	}
 
 	handleUrlSubmit = () => {
 		this.props.recordTracksEvent( 'calypso_jpc_url_submit', {
-			jetpack_url: this.state.currentUrl
+			jetpack_url: this.state.currentUrl,
 		} );
 		if ( this.props.isRequestingSites ) {
 			this.setState( { waitingForSites: true } );
@@ -169,7 +165,7 @@ class JetpackConnectMain extends Component {
 	installJetpack = () => {
 		this.props.recordTracksEvent( 'calypso_jpc_instructions_click', {
 			jetpack_funnel: this.state.currentUrl,
-			type: 'install_jetpack'
+			type: 'install_jetpack',
 		} );
 
 		this.props.goToPluginInstall( this.state.currentUrl );
@@ -178,23 +174,27 @@ class JetpackConnectMain extends Component {
 	activateJetpack = () => {
 		this.props.recordTracksEvent( 'calypso_jpc_instructions_click', {
 			jetpack_funnel: this.state.currentUrl,
-			type: 'activate_jetpack'
+			type: 'activate_jetpack',
 		} );
 		this.props.goToPluginActivation( this.state.currentUrl );
 	};
 
 	checkProperty( propName ) {
-		return this.state.currentUrl &&
+		return (
+			this.state.currentUrl &&
 			this.props.jetpackConnectSite &&
 			this.props.jetpackConnectSite.data &&
 			this.isCurrentUrlFetched() &&
-			this.props.jetpackConnectSite.data[ propName ];
+			this.props.jetpackConnectSite.data[ propName ]
+		);
 	}
 
 	isRedirecting() {
-		return this.props.jetpackConnectSite &&
+		return (
+			this.props.jetpackConnectSite &&
 			this.props.jetpackConnectSite.isRedirecting &&
-			this.isCurrentUrlFetched();
+			this.isCurrentUrlFetched()
+		);
 	}
 
 	getStatus() {
@@ -214,8 +214,10 @@ class JetpackConnectMain extends Component {
 			return 'notActiveJetpack';
 		}
 
-		if ( this.state.currentUrl.toLowerCase() === 'http://wordpress.com' ||
-			this.state.currentUrl.toLowerCase() === 'https://wordpress.com' ) {
+		if (
+			this.state.currentUrl.toLowerCase() === 'http://wordpress.com' ||
+			this.state.currentUrl.toLowerCase() === 'https://wordpress.com'
+		) {
 			return 'wordpress.com';
 		}
 		if ( this.checkProperty( 'isWordPressDotCom' ) ) {
@@ -243,10 +245,7 @@ class JetpackConnectMain extends Component {
 		) {
 			return 'notConnectedJetpack';
 		}
-		if (
-			this.checkProperty( 'isJetpackConnected' ) &&
-			this.checkProperty( 'userOwnsSite' )
-		) {
+		if ( this.checkProperty( 'isJetpackConnected' ) && this.checkProperty( 'userOwnsSite' ) ) {
 			return 'alreadyConnected';
 		}
 
@@ -256,36 +255,44 @@ class JetpackConnectMain extends Component {
 	handleOnClickTos = () => this.props.recordTracksEvent( 'calypso_jpc_tos_link_click' );
 
 	getTexts() {
-		const {
-			type,
-			selectedPlan,
-			translate,
-		} = this.props;
+		const { type, selectedPlan, translate } = this.props;
 
-		if ( type === 'pro' || selectedPlan === 'jetpack_business' || selectedPlan === 'jetpack_business_monthly' ) {
+		if (
+			type === 'pro' ||
+			selectedPlan === 'jetpack_business' ||
+			selectedPlan === 'jetpack_business_monthly'
+		) {
 			return {
 				headerTitle: translate( 'Get Jetpack Professional' ),
 				headerSubtitle: translate(
 					'WordPress sites from start to finish: unlimited premium themes, ' +
-					'business class security, and marketing automation.'
+						'business class security, and marketing automation.'
 				),
 			};
 		}
-		if ( type === 'premium' || selectedPlan === 'jetpack_premium' || selectedPlan === 'jetpack_premium_monthly' ) {
+		if (
+			type === 'premium' ||
+			selectedPlan === 'jetpack_premium' ||
+			selectedPlan === 'jetpack_premium_monthly'
+		) {
 			return {
 				headerTitle: translate( 'Get Jetpack Premium' ),
 				headerSubtitle: translate(
 					'Automated backups and malware scanning, expert priority support, ' +
-					'marketing automation, and more.'
+						'marketing automation, and more.'
 				),
 			};
 		}
-		if ( type === 'personal' || selectedPlan === 'jetpack_personal' || selectedPlan === 'jetpack_personal_monthly' ) {
+		if (
+			type === 'personal' ||
+			selectedPlan === 'jetpack_personal' ||
+			selectedPlan === 'jetpack_personal_monthly'
+		) {
 			return {
 				headerTitle: translate( 'Get Jetpack Personal' ),
 				headerSubtitle: translate(
 					'Security essentials for every WordPress site ' +
-					'including automated backups and priority support.'
+						'including automated backups and priority support.'
 				),
 			};
 		}
@@ -293,14 +300,18 @@ class JetpackConnectMain extends Component {
 		if ( type === 'install' ) {
 			return {
 				headerTitle: translate( 'Install Jetpack' ),
-				headerSubtitle: translate( 'Jetpack brings free themes, security services, and essential marketing tools ' +
-					'to your self-hosted WordPress site.' ),
+				headerSubtitle: translate(
+					'Jetpack brings free themes, security services, and essential marketing tools ' +
+						'to your self-hosted WordPress site.'
+				),
 			};
 		}
 		return {
 			headerTitle: translate( 'Connect a self-hosted WordPress' ),
-			headerSubtitle: translate( 'We\'ll be installing the Jetpack plugin so WordPress.com can connect to ' +
-				'your self-hosted WordPress site.' ),
+			headerSubtitle: translate(
+				"We'll be installing the Jetpack plugin so WordPress.com can connect to " +
+					'your self-hosted WordPress site.'
+			),
 		};
 	}
 
@@ -310,30 +321,26 @@ class JetpackConnectMain extends Component {
 		 * I'm avoiding significantly changing this implementation
 		 * until propTypes have been around for a while.
 		 */
-		return includes( [
-			'install',
-			'pro',
-			'premium',
-			'personal',
-		], this.props.type );
+		return includes( [ 'install', 'pro', 'premium', 'personal' ], this.props.type );
 	}
 
 	getInstructionsData( status ) {
 		const { translate } = this.props;
 		return {
-			headerTitle: ( 'notJetpack' === status )
-				? translate( 'Ready for installation' )
-				: translate( 'Ready for activation' ),
-			headerSubtitle: translate( 'We\'ll need to send you to your site dashboard for a few manual steps.' ),
-			steps: ( 'notJetpack' === status )
-				? [ 'installJetpack', 'activateJetpackAfterInstall', 'connectJetpackAfterInstall' ]
-				: [ 'activateJetpack', 'connectJetpack' ],
-			buttonOnClick: ( 'notJetpack' === status )
-				? this.installJetpack
-				: this.activateJetpack,
-			buttonText: ( 'notJetpack' === status )
-				? translate( 'Install Jetpack' )
-				: translate( 'Activate Jetpack' )
+			headerTitle:
+				'notJetpack' === status
+					? translate( 'Ready for installation' )
+					: translate( 'Ready for activation' ),
+			headerSubtitle: translate(
+				"We'll need to send you to your site dashboard for a few manual steps."
+			),
+			steps:
+				'notJetpack' === status
+					? [ 'installJetpack', 'activateJetpackAfterInstall', 'connectJetpackAfterInstall' ]
+					: [ 'activateJetpack', 'connectJetpack' ],
+			buttonOnClick: 'notJetpack' === status ? this.installJetpack : this.activateJetpack,
+			buttonText:
+				'notJetpack' === status ? translate( 'Install Jetpack' ) : translate( 'Activate Jetpack' ),
 		};
 	}
 
@@ -344,10 +351,11 @@ class JetpackConnectMain extends Component {
 				<LoggedOutFormLinkItem href="https://jetpack.com/support/installing-jetpack/">
 					{ translate( 'Install Jetpack manually' ) }
 				</LoggedOutFormLinkItem>
-				{ this.isInstall()
-					? null
-					: <LoggedOutFormLinkItem href="/start">{ translate( 'Start a new site on WordPress.com' ) }</LoggedOutFormLinkItem>
-				}
+				{ this.isInstall() ? null : (
+					<LoggedOutFormLinkItem href="/start">
+						{ translate( 'Start a new site on WordPress.com' ) }
+					</LoggedOutFormLinkItem>
+				) }
 				<HelpButton />
 			</LoggedOutFormLinks>
 		);
@@ -356,10 +364,16 @@ class JetpackConnectMain extends Component {
 	renderSiteInput( status ) {
 		return (
 			<Card className="jetpack-connect__site-url-input-container">
-				{ ! this.isCurrentUrlFetching() && this.isCurrentUrlFetched() && ! this.props.jetpackConnectSite.isDismissed && status
-					? <JetpackConnectNotices noticeType={ status } onDismissClick={ this.dismissUrl } url={ this.state.currentUrl } />
-					: null
-				}
+				{ ! this.isCurrentUrlFetching() &&
+				this.isCurrentUrlFetched() &&
+				! this.props.jetpackConnectSite.isDismissed &&
+				status ? (
+					<JetpackConnectNotices
+						noticeType={ status }
+						onDismissClick={ this.dismissUrl }
+						url={ this.state.currentUrl }
+					/>
+				) : null }
 
 				<SiteUrlInput
 					url={ this.state.shownUrl }
@@ -367,8 +381,11 @@ class JetpackConnectMain extends Component {
 					onChange={ this.handleUrlChange }
 					onSubmit={ this.handleUrlSubmit }
 					isError={ this.getStatus() }
-					isFetching={ this.isCurrentUrlFetching() || this.isRedirecting() || this.state.waitingForSites }
-					isInstall={ this.isInstall() } />
+					isFetching={
+						this.isCurrentUrlFetching() || this.isRedirecting() || this.state.waitingForSites
+					}
+					isInstall={ this.isInstall() }
+				/>
 			</Card>
 		);
 	}
@@ -378,9 +395,7 @@ class JetpackConnectMain extends Component {
 			return;
 		}
 
-		return (
-			<LocaleSuggestions path={ this.props.path } locale={ this.props.locale } />
-		);
+		return <LocaleSuggestions path={ this.props.path } locale={ this.props.locale } />;
 	}
 
 	renderSiteEntry() {
@@ -405,8 +420,12 @@ class JetpackConnectMain extends Component {
 	renderNotJetpackButton() {
 		const { translate } = this.props;
 		return (
-			<a className="jetpack-connect__no-jetpack-button" href="#" onClick={ this.confirmJetpackNotInstalled }>
-				{ translate( 'Don\'t have jetpack installed?' ) }
+			<a
+				className="jetpack-connect__no-jetpack-button"
+				href="#"
+				onClick={ this.confirmJetpackNotInstalled }
+			>
+				{ translate( "Don't have jetpack installed?" ) }
 			</a>
 		);
 	}
@@ -414,7 +433,12 @@ class JetpackConnectMain extends Component {
 	renderBackButton() {
 		const { translate } = this.props;
 		return (
-			<Button compact borderless className="jetpack-connect__back-button" onClick={ this.dismissUrl }>
+			<Button
+				compact
+				borderless
+				className="jetpack-connect__back-button"
+				onClick={ this.dismissUrl }
+			>
 				<Gridicon icon="arrow-left" size={ 18 } />
 				{ translate( 'Back' ) }
 			</Button>
@@ -434,26 +458,24 @@ class JetpackConnectMain extends Component {
 						subHeaderText={ instructionsData.headerSubtitle }
 					/>
 					<div className="jetpack-connect__install-steps">
-						{
-							instructionsData.steps.map( ( stepName, key ) => {
-								return (
-									<JetpackInstallStep
-										key={ 'instructions-step-' + key }
-										stepName={ stepName }
-										jetpackVersion={ jetpackVersion }
-										isInstall={ isInstall }
-										currentUrl={ currentUrl }
-										confirmJetpackInstallStatus={ this.props.confirmJetpackInstallStatus }
-										onClick={ instructionsData.buttonOnClick }
-									/>
-								);
-							} )
-						}
+						{ instructionsData.steps.map( ( stepName, key ) => {
+							return (
+								<JetpackInstallStep
+									key={ 'instructions-step-' + key }
+									stepName={ stepName }
+									jetpackVersion={ jetpackVersion }
+									isInstall={ isInstall }
+									currentUrl={ currentUrl }
+									confirmJetpackInstallStatus={ this.props.confirmJetpackInstallStatus }
+									onClick={ instructionsData.buttonOnClick }
+								/>
+							);
+						} ) }
 					</div>
-					<Button onClick={ instructionsData.buttonOnClick } primary>{ instructionsData.buttonText }</Button>
-					<div className="jetpack-connect__navigation">
-						{ this.renderBackButton() }
-					</div>
+					<Button onClick={ instructionsData.buttonOnClick } primary>
+						{ instructionsData.buttonText }
+					</Button>
+					<div className="jetpack-connect__navigation">{ this.renderBackButton() }</div>
 				</div>
 				<LoggedOutFormLinks>
 					<HelpButton />
@@ -477,9 +499,9 @@ class JetpackConnectMain extends Component {
 const connectComponent = connect(
 	state => ( {
 		jetpackConnectSite: getConnectingSite( state ),
-		getJetpackSiteByUrl: ( url ) => getJetpackSiteByUrl( state, url ),
+		getJetpackSiteByUrl: url => getJetpackSiteByUrl( state, url ),
 		isRequestingSites: isRequestingSites( state ),
-		selectedPlan: getGlobalSelectedPlan( state )
+		selectedPlan: getGlobalSelectedPlan( state ),
 	} ),
 	{
 		confirmJetpackInstallStatus,
@@ -489,11 +511,8 @@ const connectComponent = connect(
 		goToRemoteAuth,
 		goToPlans,
 		goToPluginInstall,
-		goToPluginActivation
+		goToPluginActivation,
 	}
 );
 
-export default flowRight(
-	connectComponent,
-	localize
-)( JetpackConnectMain );
+export default flowRight( connectComponent, localize )( JetpackConnectMain );

--- a/client/jetpack-connect/main.jsx
+++ b/client/jetpack-connect/main.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import Gridicon from 'gridicons';
 import { flowRight, includes } from 'lodash';

--- a/client/jetpack-connect/plans-grid.jsx
+++ b/client/jetpack-connect/plans-grid.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 
 /**

--- a/client/jetpack-connect/plans-grid.jsx
+++ b/client/jetpack-connect/plans-grid.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -29,28 +30,19 @@ class JetpackPlansGrid extends Component {
 	};
 
 	renderConnectHeader() {
-		const {
-			isLanding,
-			showFirst,
-			translate,
-		} = this.props;
+		const { isLanding, showFirst, translate } = this.props;
 
 		let headerText = translate( 'Your site is now connected!' );
-		let subheaderText = translate( 'Now pick a plan that\'s right for you.' );
+		let subheaderText = translate( "Now pick a plan that's right for you." );
 
 		if ( showFirst ) {
 			headerText = translate( 'You are moments away from connecting your site' );
 		}
 		if ( isLanding ) {
-			headerText = translate( 'Pick a plan that\'s right for you.' );
+			headerText = translate( "Pick a plan that's right for you." );
 			subheaderText = '';
 		}
-		return (
-			<FormattedHeader
-				headerText={ headerText }
-				subHeaderText={ subheaderText }
-			/>
-		);
+		return <FormattedHeader headerText={ headerText } subHeaderText={ subheaderText } />;
 	}
 
 	render() {

--- a/client/jetpack-connect/plans-landing.jsx
+++ b/client/jetpack-connect/plans-landing.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -52,7 +53,7 @@ class PlansLanding extends Component {
 		}
 	}
 
-	storeSelectedPlan = ( cartItem ) => {
+	storeSelectedPlan = cartItem => {
 		const { url } = this.props;
 		let redirectUrl = CALYPSO_JETPACK_CONNECT;
 
@@ -61,7 +62,7 @@ class PlansLanding extends Component {
 		}
 
 		this.props.recordTracksEvent( 'calypso_jpc_plans_store_plan', {
-			plan: cartItem ? cartItem.product_slug : 'free'
+			plan: cartItem ? cartItem.product_slug : 'free',
 		} );
 		this.props.selectPlanInAdvance( cartItem ? cartItem.product_slug : 'free', '*' );
 
@@ -77,10 +78,7 @@ class PlansLanding extends Component {
 	};
 
 	render() {
-		const {
-			basePlansPath,
-			interval,
-		} = this.props;
+		const { basePlansPath, interval } = this.props;
 		const hideFreePlanTest = abtest( 'jetpackConnectHideFreePlan' ) === 'hide';
 
 		return (
@@ -95,10 +93,7 @@ class PlansLanding extends Component {
 					isLanding={ true }
 					onSelect={ this.storeSelectedPlan }
 				>
-					{
-						hideFreePlanTest &&
-						<PlansSkipButton onClick={ this.handleSkipButtonClick } />
-					}
+					{ hideFreePlanTest && <PlansSkipButton onClick={ this.handleSkipButtonClick } /> }
 				</PlansGrid>
 			</div>
 		);

--- a/client/jetpack-connect/plans-landing.jsx
+++ b/client/jetpack-connect/plans-landing.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import page from 'page';
 

--- a/client/jetpack-connect/plans-skip-button.jsx
+++ b/client/jetpack-connect/plans-skip-button.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -9,16 +10,9 @@ import { localize } from 'i18n-calypso';
  */
 import Button from 'components/button';
 
-const PlansSkipButton = ( {
-	onClick,
-	translate
-} ) => (
+const PlansSkipButton = ( { onClick, translate } ) => (
 	<div className="jetpack-connect__plans-nav-buttons">
-		<Button
-			onClick={ onClick }
-			compact
-			borderless
-		>
+		<Button onClick={ onClick } compact borderless>
 			{ translate( 'Skip' ) }
 		</Button>
 	</div>

--- a/client/jetpack-connect/plans.jsx
+++ b/client/jetpack-connect/plans.jsx
@@ -1,11 +1,12 @@
 /**
  * External dependencies
  */
-import { connect } from 'react-redux';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import page from 'page';
-import React, { Component, PropTypes } from 'react';
-import { localize } from 'i18n-calypso';
+import { connect } from 'react-redux';
 import { get } from 'lodash';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies

--- a/client/jetpack-connect/plans.jsx
+++ b/client/jetpack-connect/plans.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -13,13 +14,15 @@ import { localize } from 'i18n-calypso';
  */
 import PlansGrid from './plans-grid';
 import PlansSkipButton from './plans-skip-button';
-import { PLAN_JETPACK_FREE,
+import {
+	PLAN_JETPACK_FREE,
 	PLAN_JETPACK_PREMIUM,
 	PLAN_JETPACK_PREMIUM_MONTHLY,
 	PLAN_JETPACK_PERSONAL,
 	PLAN_JETPACK_PERSONAL_MONTHLY,
 	PLAN_JETPACK_BUSINESS,
-	PLAN_JETPACK_BUSINESS_MONTHLY } from 'lib/plans/constants';
+	PLAN_JETPACK_BUSINESS_MONTHLY,
+} from 'lib/plans/constants';
 import { getPlansBySite } from 'state/sites/plans/selectors';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { getCurrentUser } from 'state/current-user/selectors';
@@ -36,7 +39,7 @@ import {
 	getSiteSelectedPlan,
 	getGlobalSelectedPlan,
 	getAuthorizationData,
-	isCalypsoStartedConnection
+	isCalypsoStartedConnection,
 } from 'state/jetpack-connect/selectors';
 import { mc } from 'lib/analytics';
 import { isSiteAutomatedTransfer } from 'state/selectors';
@@ -60,7 +63,7 @@ class Plans extends Component {
 	};
 
 	static defaultProps = {
-		siteSlug: '*'
+		siteSlug: '*',
 	};
 
 	componentDidMount() {
@@ -71,7 +74,7 @@ class Plans extends Component {
 			this.autoselectPlan();
 		} else {
 			this.props.recordTracksEvent( 'calypso_jpc_plans_view', {
-				user: this.props.userId
+				user: this.props.userId,
 			} );
 		}
 	}
@@ -93,9 +96,7 @@ class Plans extends Component {
 			}
 		}
 
-		if ( ! this.props.isRequestingPlans &&
-				this.isFlowTypePaid() &&
-				! this.redirecting ) {
+		if ( ! this.props.isRequestingPlans && this.isFlowTypePaid() && ! this.redirecting ) {
 			return this.autoselectPlan();
 		}
 	}
@@ -104,10 +105,14 @@ class Plans extends Component {
 		this.props.recordTracksEvent( 'calypso_jpc_plans_skip_button_click' );
 
 		this.selectFreeJetpackPlan();
-	}
+	};
 
 	isFlowTypePaid() {
-		return this.props.flowType === 'pro' || this.props.flowType === 'premium' || this.props.flowType === 'personal';
+		return (
+			this.props.flowType === 'pro' ||
+			this.props.flowType === 'premium' ||
+			this.props.flowType === 'personal'
+		);
 	}
 
 	redirectToWpAdmin() {
@@ -139,19 +144,24 @@ class Plans extends Component {
 	}
 
 	hasPlan( site ) {
-		return site &&
+		return (
+			site &&
 			site.plan &&
 			( site.plan.product_slug === PLAN_JETPACK_BUSINESS ||
 				site.plan.product_slug === PLAN_JETPACK_BUSINESS_MONTHLY ||
 				site.plan.product_slug === PLAN_JETPACK_PREMIUM ||
 				site.plan.product_slug === PLAN_JETPACK_PREMIUM_MONTHLY ||
 				site.plan.product_slug === PLAN_JETPACK_PERSONAL ||
-				site.plan.product_slug === PLAN_JETPACK_PERSONAL_MONTHLY );
+				site.plan.product_slug === PLAN_JETPACK_PERSONAL_MONTHLY )
+		);
 	}
 
 	autoselectPlan() {
 		if ( ! this.props.showFirst ) {
-			if ( this.props.flowType === 'personal' || this.props.selectedPlan === PLAN_JETPACK_PERSONAL ) {
+			if (
+				this.props.flowType === 'personal' ||
+				this.props.selectedPlan === PLAN_JETPACK_PERSONAL
+			) {
 				const plan = this.props.getPlanBySlug( PLAN_JETPACK_PERSONAL );
 				if ( plan ) {
 					this.selectPlan( plan );
@@ -186,15 +196,17 @@ class Plans extends Component {
 					return;
 				}
 			}
-			if ( this.props.flowType === 'premium' || this.props.selectedPlan === PLAN_JETPACK_PREMIUM_MONTHLY ) {
+			if (
+				this.props.flowType === 'premium' ||
+				this.props.selectedPlan === PLAN_JETPACK_PREMIUM_MONTHLY
+			) {
 				const plan = this.props.getPlanBySlug( PLAN_JETPACK_PREMIUM_MONTHLY );
 				if ( plan ) {
 					this.selectPlan( plan );
 					return;
 				}
 			}
-			if ( this.props.selectedPlan === 'free' ||
-				this.props.selectedPlan === PLAN_JETPACK_FREE ) {
+			if ( this.props.selectedPlan === 'free' || this.props.selectedPlan === PLAN_JETPACK_FREE ) {
 				this.selectFreeJetpackPlan();
 			}
 		}
@@ -204,7 +216,7 @@ class Plans extends Component {
 		// clears whatever we had stored in local cache
 		this.props.selectPlanInAdvance( null, this.props.selectedSiteSlug );
 		this.props.recordTracksEvent( 'calypso_jpc_plans_submit_free', {
-			user: this.props.userId
+			user: this.props.userId,
 		} );
 		mc.bumpStat( 'calypso_jpc_plan_selection', 'jetpack_free' );
 
@@ -230,37 +242,37 @@ class Plans extends Component {
 
 		if ( cartItem.product_slug === PLAN_JETPACK_PERSONAL ) {
 			this.props.recordTracksEvent( 'calypso_jpc_plans_submit_personal', {
-				user: this.props.userId
+				user: this.props.userId,
 			} );
 			mc.bumpStat( 'calypso_jpc_plan_selection', 'jetpack_personal' );
 		}
 		if ( cartItem.product_slug === PLAN_JETPACK_PERSONAL_MONTHLY ) {
 			this.props.recordTracksEvent( 'calypso_jpc_plans_submit_personal_monthly', {
-				user: this.props.userId
+				user: this.props.userId,
 			} );
 			mc.bumpStat( 'calypso_jpc_plan_selection', 'jetpack_personal_monthly' );
 		}
 		if ( cartItem.product_slug === PLAN_JETPACK_PREMIUM ) {
 			this.props.recordTracksEvent( 'calypso_jpc_plans_submit_premium', {
-				user: this.props.userId
+				user: this.props.userId,
 			} );
 			mc.bumpStat( 'calypso_jpc_plan_selection', 'jetpack_premium' );
 		}
 		if ( cartItem.product_slug === PLAN_JETPACK_PREMIUM_MONTHLY ) {
 			this.props.recordTracksEvent( 'calypso_jpc_plans_submit_premium_monthly', {
-				user: this.props.userId
+				user: this.props.userId,
 			} );
 			mc.bumpStat( 'calypso_jpc_plan_selection', 'jetpack_premium_monthly' );
 		}
 		if ( cartItem.product_slug === PLAN_JETPACK_BUSINESS ) {
 			this.props.recordTracksEvent( 'calypso_jpc_plans_submit_business', {
-				user: this.props.userId
+				user: this.props.userId,
 			} );
 			mc.bumpStat( 'calypso_jpc_plan_selection', 'jetpack_business' );
 		}
 		if ( cartItem.product_slug === PLAN_JETPACK_BUSINESS_MONTHLY ) {
 			this.props.recordTracksEvent( 'calypso_jpc_plans_submit_business_monthly', {
-				user: this.props.userId
+				user: this.props.userId,
 			} );
 			mc.bumpStat( 'calypso_jpc_plan_selection', 'jetpack_business_monthly' );
 		}
@@ -273,16 +285,17 @@ class Plans extends Component {
 	storeSelectedPlan( cartItem ) {
 		this.props.recordTracksEvent( 'calypso_jpc_plans_store_plan', {
 			user: this.props.userId,
-			plan: cartItem ? cartItem.product_slug : 'free'
+			plan: cartItem ? cartItem.product_slug : 'free',
 		} );
 		this.props.selectPlanInAdvance(
 			cartItem ? cartItem.product_slug : 'free',
-			this.props.siteSlug,
+			this.props.siteSlug
 		);
 	}
 
 	render() {
-		if ( this.redirecting ||
+		if (
+			this.redirecting ||
 			this.hasPreSelectedPlan() ||
 			( ! this.props.showFirst && ! this.props.canPurchasePlans ) ||
 			( ! this.props.showFirst && this.hasPlan( this.props.selectedSite ) )
@@ -295,20 +308,20 @@ class Plans extends Component {
 		return (
 			<div>
 				<QueryPlans />
-				{ this.props.selectedSite
-					? <QuerySitePlans siteId={ this.props.selectedSite.ID } />
-					: null
-				}
+				{ this.props.selectedSite ? (
+					<QuerySitePlans siteId={ this.props.selectedSite.ID } />
+				) : null }
 				<PlansGrid
 					{ ...this.props }
-					basePlansPath={ this.props.showFirst ? '/jetpack/connect/authorize' : '/jetpack/connect/plans' }
-					onSelect={ this.props.showFirst || this.props.isLanding ? this.storeSelectedPlan : this.selectPlan }
+					basePlansPath={
+						this.props.showFirst ? '/jetpack/connect/authorize' : '/jetpack/connect/plans'
+					}
+					onSelect={
+						this.props.showFirst || this.props.isLanding ? this.storeSelectedPlan : this.selectPlan
+					}
 					hideFreePlan={ hideFreePlanTest }
 				>
-					{
-						hideFreePlanTest &&
-						<PlansSkipButton onClick={ this.handleSkipButtonClick } />
-					}
+					{ hideFreePlanTest && <PlansSkipButton onClick={ this.handleSkipButtonClick } /> }
 				</PlansGrid>
 			</div>
 		);
@@ -321,8 +334,9 @@ export default connect(
 		const selectedSite = getSelectedSite( state );
 		const selectedSiteSlug = selectedSite ? selectedSite.slug : '*';
 
-		const selectedPlan = getSiteSelectedPlan( state, selectedSiteSlug ) || getGlobalSelectedPlan( state );
-		const searchPlanBySlug = ( planSlug ) => {
+		const selectedPlan =
+			getSiteSelectedPlan( state, selectedSiteSlug ) || getGlobalSelectedPlan( state );
+		const searchPlanBySlug = planSlug => {
 			return getPlanBySlug( state, planSlug );
 		};
 
@@ -334,7 +348,9 @@ export default connect(
 			sitePlans: getPlansBySite( state, selectedSite ),
 			jetpackConnectAuthorize: getAuthorizationData( state ),
 			userId: user ? user.ID : null,
-			canPurchasePlans: selectedSite ? canCurrentUser( state, selectedSite.ID, 'manage_options' ) : true,
+			canPurchasePlans: selectedSite
+				? canCurrentUser( state, selectedSite.ID, 'manage_options' )
+				: true,
 			flowType: getFlowType( state, selectedSiteSlug ),
 			isRequestingPlans: isRequestingPlans( state ),
 			getPlanBySlug: searchPlanBySlug,
@@ -346,6 +362,6 @@ export default connect(
 		goBackToWpAdmin,
 		completeFlow,
 		selectPlanInAdvance,
-		recordTracksEvent
+		recordTracksEvent,
 	}
 )( localize( Plans ) );

--- a/client/jetpack-connect/site-card.jsx
+++ b/client/jetpack-connect/site-card.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import urlModule from 'url';
 
 /**

--- a/client/jetpack-connect/site-card.jsx
+++ b/client/jetpack-connect/site-card.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -23,22 +24,16 @@ class SiteCard extends Component {
 			site_url: PropTypes.string.isRequired,
 			client_id: PropTypes.string.isRequired,
 		} ).isRequired,
-		isAlreadyOnSitesList: PropTypes.bool
+		isAlreadyOnSitesList: PropTypes.bool,
 	};
 
 	render() {
-		const {
-			site_icon,
-			blogname,
-			home_url,
-			site_url,
-			client_id
-		} = this.props.queryObject;
+		const { site_icon, blogname, home_url, site_url, client_id } = this.props.queryObject;
 		const safeIconUrl = site_icon ? safeImageUrl( site_icon ) : false;
 		const siteIcon = safeIconUrl ? { img: safeIconUrl } : false;
 		const url = decodeEntities( home_url );
 		const parsedUrl = urlModule.parse( url );
-		const path = ( parsedUrl.path === '/' ) ? '' : parsedUrl.path;
+		const path = parsedUrl.path === '/' ? '' : parsedUrl.path;
 		const site = {
 			ID: null,
 			url: url,
@@ -46,7 +41,7 @@ class SiteCard extends Component {
 			domain: parsedUrl.host + path,
 			icon: siteIcon,
 			is_vip: false,
-			title: decodeEntities( blogname )
+			title: decodeEntities( blogname ),
 		};
 
 		return (

--- a/client/jetpack-connect/site-url-input.jsx
+++ b/client/jetpack-connect/site-url-input.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -19,10 +20,7 @@ import Spinner from 'components/spinner';
 class JetpackConnectSiteUrlInput extends Component {
 	static propTypes = {
 		handleOnClickTos: PropTypes.func,
-		isError: PropTypes.oneOfType( [
-			PropTypes.string,
-			PropTypes.bool,
-		] ),
+		isError: PropTypes.oneOfType( [ PropTypes.string, PropTypes.bool ] ),
 		isFetching: PropTypes.bool,
 		isInstall: PropTypes.bool,
 		onChange: PropTypes.func,
@@ -38,7 +36,7 @@ class JetpackConnectSiteUrlInput extends Component {
 
 	focusInput = noop;
 
-	refInput = ( formInputComponent ) => {
+	refInput = formInputComponent => {
 		this.focusInput = () => formInputComponent.focus();
 	};
 
@@ -50,7 +48,7 @@ class JetpackConnectSiteUrlInput extends Component {
 		this.focusInput();
 	}
 
-	handleKeyPress = ( event ) => {
+	handleKeyPress = event => {
 		if ( 13 === event.keyCode ) {
 			this.props.onSubmit();
 		}
@@ -73,42 +71,36 @@ class JetpackConnectSiteUrlInput extends Component {
 
 	renderTermsOfServiceLink() {
 		return (
-			<p className="jetpack-connect__tos-link">{
-				this.props.translate(
+			<p className="jetpack-connect__tos-link">
+				{ this.props.translate(
 					'By connecting your site you agree to our fascinating {{a}}Terms of Service{{/a}}.',
 					{
 						components: {
-							a: <a
-								className="jetpack-connect__tos-link-text"
-								href={ this.getTermsOfServiceUrl() }
-								onClick={ this.props.handleOnClickTos }
-								target="_blank"
-								rel="noopener noreferrer" />
-						}
+							a: (
+								<a
+									className="jetpack-connect__tos-link-text"
+									href={ this.getTermsOfServiceUrl() }
+									onClick={ this.props.handleOnClickTos }
+									target="_blank"
+									rel="noopener noreferrer"
+								/>
+							),
+						},
 					}
-				)
-			}</p>
+				) }
+			</p>
 		);
 	}
 
 	render() {
-		const {
-			isError,
-			isFetching,
-			onChange,
-			onSubmit,
-			translate,
-			url,
-		} = this.props;
-		const hasError = isError && ( 'notExists' !== isError );
+		const { isError, isFetching, onChange, onSubmit, translate, url } = this.props;
+		const hasError = isError && 'notExists' !== isError;
 
 		return (
 			<div>
 				<FormLabel htmlFor="siteUrl">{ translate( 'Site Address' ) }</FormLabel>
 				<div className="jetpack-connect__site-address-container">
-					<Gridicon
-						size={ 24 }
-						icon="globe" />
+					<Gridicon size={ 24 } icon="globe" />
 					<FormTextInput
 						ref={ this.refInput }
 						id="siteUrl"
@@ -120,18 +112,11 @@ class JetpackConnectSiteUrlInput extends Component {
 						onKeyUp={ this.handleKeyPress }
 						value={ url }
 					/>
-					{ isFetching
-						? <Spinner duration={ 30 } />
-						: null
-					}
+					{ isFetching ? <Spinner duration={ 30 } /> : null }
 				</div>
 				<Card className="jetpack-connect__connect-button-card">
 					{ this.renderTermsOfServiceLink() }
-					<Button
-						primary
-						disabled={ ( ! url || isFetching || hasError ) }
-						onClick={ onSubmit }
-					>
+					<Button primary disabled={ ! url || isFetching || hasError } onClick={ onSubmit }>
 						{ this.renderButtonLabel() }
 					</Button>
 				</Card>

--- a/client/jetpack-connect/site-url-input.jsx
+++ b/client/jetpack-connect/site-url-input.jsx
@@ -1,9 +1,10 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
-import { localize, getLocaleSlug } from 'i18n-calypso';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import Gridicon from 'gridicons';
+import { localize, getLocaleSlug } from 'i18n-calypso';
 import { noop } from 'lodash';
 
 /**

--- a/client/jetpack-connect/sso.jsx
+++ b/client/jetpack-connect/sso.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -46,7 +47,7 @@ const debug = debugModule( 'calypso:jetpack-connect:sso' );
 
 class JetpackSsoForm extends Component {
 	state = {
-		showTermsDialog: false
+		showTermsDialog: false,
 	};
 
 	componentWillMount() {
@@ -69,7 +70,7 @@ class JetpackSsoForm extends Component {
 		}
 	}
 
-	onApproveSSO = ( event ) => {
+	onApproveSSO = event => {
 		event.preventDefault();
 		analytics.tracks.recordEvent( 'calypso_jetpack_sso_log_in_button_click' );
 
@@ -85,13 +86,13 @@ class JetpackSsoForm extends Component {
 		this.props.authorizeSSO( siteId, ssoNonce, siteUrl );
 	};
 
-	onCancelClick = ( event ) => {
+	onCancelClick = event => {
 		debug( 'Clicked return to site link' );
 		analytics.tracks.recordEvent( 'calypso_jetpack_sso_return_to_site_link_click' );
 		this.returnToSiteFallback( event );
 	};
 
-	onTryAgainClick = ( event ) => {
+	onTryAgainClick = event => {
 		debug( 'Clicked try again link' );
 		analytics.tracks.recordEvent( 'calypso_jetpack_sso_try_again_link_click' );
 		this.returnToSiteFallback( event );
@@ -101,21 +102,21 @@ class JetpackSsoForm extends Component {
 		analytics.tracks.recordEvent( 'calypso_jetpack_sso_sign_in_different_user_link_click' );
 	};
 
-	onClickSharedDetailsModal = ( event ) => {
+	onClickSharedDetailsModal = event => {
 		event.preventDefault();
 		analytics.tracks.recordEvent( 'calypso_jetpack_sso_shared_details_link_click' );
 		this.setState( {
-			showTermsDialog: true
+			showTermsDialog: true,
 		} );
 	};
 
 	closeTermsDialog = () => {
 		this.setState( {
-			showTermsDialog: false
+			showTermsDialog: false,
 		} );
 	};
 
-	returnToSiteFallback = ( event ) => {
+	returnToSiteFallback = event => {
 		// If, for some reason, the API request failed and we do not have the admin URL,
 		// then fallback to the user's last location.
 		if ( ! get( this.props, 'blogDetails.admin_url' ) ) {
@@ -128,7 +129,14 @@ class JetpackSsoForm extends Component {
 	isButtonDisabled() {
 		const user = this.props.userModule.get();
 		const { nonceValid, isAuthorizing, isValidating, ssoUrl, authorizationError } = this.props;
-		return !! ( ! nonceValid || isAuthorizing || isValidating || ssoUrl || authorizationError || ! user.email_verified );
+		return !! (
+			! nonceValid ||
+			isAuthorizing ||
+			isValidating ||
+			ssoUrl ||
+			authorizationError ||
+			! user.email_verified
+		);
 	}
 
 	getSignInLink() {
@@ -138,17 +146,19 @@ class JetpackSsoForm extends Component {
 	maybeValidateSSO( props = this.props ) {
 		const { ssoNonce, siteId, nonceValid, isAuthorizing, isValidating } = props;
 
-		if ( ssoNonce && siteId && 'undefined' === typeof nonceValid && ! isAuthorizing && ! isValidating ) {
+		if (
+			ssoNonce &&
+			siteId &&
+			'undefined' === typeof nonceValid &&
+			! isAuthorizing &&
+			! isValidating
+		) {
 			this.props.validateSSONonce( siteId, ssoNonce );
 		}
 	}
 
 	maybeRenderErrorNotice() {
-		const {
-			authorizationError,
-			nonceValid,
-			translate,
-		} = this.props;
+		const { authorizationError, nonceValid, translate } = this.props;
 
 		if ( ! authorizationError && false !== nonceValid ) {
 			return null;
@@ -158,10 +168,12 @@ class JetpackSsoForm extends Component {
 			<Notice
 				status="is-error"
 				text={ translate( 'Oops, something went wrong.' ) }
-				showDismiss={ false }>
+				showDismiss={ false }
+			>
 				<NoticeAction
 					href={ get( this.props, 'blogDetails.admin_url', '#' ) }
-					onClick={ this.onTryAgainClick }>
+					onClick={ this.onTryAgainClick }
+				>
 					{ translate( 'Try again' ) }
 				</NoticeAction>
 			</Notice>
@@ -180,16 +192,12 @@ class JetpackSsoForm extends Component {
 				domain: get( this.props, 'blogDetails.domain', '' ),
 				icon: get( this.props, 'blogDetails.icon', { img: '', ico: '' } ),
 				is_vip: false,
-				title: decodeEntities( get( this.props, 'blogDetails.title', '' ) )
+				title: decodeEntities( get( this.props, 'blogDetails.title', '' ) ),
 			};
 			site = <Site site={ siteObject } />;
 		}
 
-		return (
-			<CompactCard className="jetpack-connect__site">
-				{ site }
-			</CompactCard>
-		);
+		return <CompactCard className="jetpack-connect__site">{ site }</CompactCard>;
 	}
 
 	getSharedDetailLabel( key ) {
@@ -233,9 +241,7 @@ class JetpackSsoForm extends Component {
 	getSharedDetailValue( key, value ) {
 		const { translate } = this.props;
 		if ( 'two_step_enabled' === key && value !== '' ) {
-			value = ( true === value )
-				? translate( 'Enabled' )
-				: translate( 'Disabled' );
+			value = true === value ? translate( 'Enabled' ) : translate( 'Disabled' );
 		}
 
 		return decodeEntities( value );
@@ -246,13 +252,11 @@ class JetpackSsoForm extends Component {
 		const text = (
 			<span className="jetpack-connect__sso-return-to-site">
 				<Gridicon icon="arrow-left" size={ 18 } />
-				{
-					translate( 'Return to %(siteName)s', {
-						args: {
-							siteName: get( this.props, 'blogDetails.title' )
-						}
-					} )
-				}
+				{ translate( 'Return to %(siteName)s', {
+					args: {
+						siteName: get( this.props, 'blogDetails.title' ),
+					},
+				} ) }
 			</span>
 		);
 
@@ -271,11 +275,11 @@ class JetpackSsoForm extends Component {
 							onClick={ this.onClickSharedDetailsModal }
 							className="jetpack-connect__sso-actions-modal-link"
 						/>
-					)
+					),
 				},
 				args: {
-					siteName: get( this.props, 'blogDetails.title' )
-				}
+					siteName: get( this.props, 'blogDetails.title' ),
+				},
 			}
 		);
 
@@ -285,10 +289,11 @@ class JetpackSsoForm extends Component {
 	getSubHeaderText() {
 		const { translate } = this.props;
 		const text = translate(
-			'To use Single Sign-On, WordPress.com needs to be able to connect to your account on %(siteName)s.', {
+			'To use Single Sign-On, WordPress.com needs to be able to connect to your account on %(siteName)s.',
+			{
 				args: {
-					siteName: get( this.props, 'blogDetails.title' )
-				}
+					siteName: get( this.props, 'blogDetails.title' ),
+				},
 			}
 		);
 		return this.maybeWrapWithPlaceholder( text );
@@ -300,11 +305,7 @@ class JetpackSsoForm extends Component {
 			return input;
 		}
 
-		return (
-			<span className="jetpack-connect__sso-placeholder">
-				{ input }
-			</span>
-		);
+		return <span className="jetpack-connect__sso-placeholder">{ input }</span>;
 	}
 
 	renderSharedDetailsList() {
@@ -347,8 +348,10 @@ class JetpackSsoForm extends Component {
 		const buttons = [
 			{
 				action: 'close',
-				label: translate( 'Got it', { context: 'Used in a button. Similar phrase would be, "I understand".' } )
-			}
+				label: translate( 'Got it', {
+					context: 'Used in a button. Similar phrase would be, "I understand".',
+				} ),
+			},
 		];
 
 		return (
@@ -356,14 +359,13 @@ class JetpackSsoForm extends Component {
 				buttons={ buttons }
 				onClose={ this.closeTermsDialog }
 				isVisible={ this.state.showTermsDialog }
-				className="jetpack-connect__sso-terms-dialog">
+				className="jetpack-connect__sso-terms-dialog"
+			>
 				<div className="jetpack-connect__sso-terms-dialog-content">
 					<p className="jetpack-connect__sso-shared-details-intro">
-						{
-							translate(
-								'When you approve logging in with WordPress.com, we will send the following details to your site.'
-							)
-						}
+						{ translate(
+							'When you approve logging in with WordPress.com, we will send the following details to your site.'
+						) }
 					</p>
 
 					{ this.renderSharedDetailsList() }
@@ -378,15 +380,13 @@ class JetpackSsoForm extends Component {
 			<Main>
 				<EmptyContent
 					illustration="/calypso/images/illustrations/whoops.svg"
-					title={ translate(
-						'Oops, this URL should not be accessed directly'
-					) }
+					title={ translate( 'Oops, this URL should not be accessed directly' ) }
 					line={ translate(
 						'Please click the {{em}}Log in with WordPress.com button{{/em}} on your Jetpack site.',
 						{
 							components: {
-								em: <em />
-							}
+								em: <em />,
+							},
 						}
 					) }
 					action={ translate( 'Read Single Sign-On Documentation' ) }
@@ -398,12 +398,7 @@ class JetpackSsoForm extends Component {
 
 	render() {
 		const user = this.props.userModule.get();
-		const {
-			ssoNonce,
-			siteId,
-			validationError,
-			translate,
-		} = this.props;
+		const { ssoNonce, siteId, validationError, translate } = this.props;
 
 		if ( ! ssoNonce || ! siteId || validationError ) {
 			return this.renderBadPathArgsError();
@@ -421,50 +416,45 @@ class JetpackSsoForm extends Component {
 
 					<EmailVerificationGate
 						noticeText={ translate( 'You must verify your email to sign in with WordPress.com.' ) }
-						noticeStatus="is-info">
+						noticeStatus="is-info"
+					>
 						<Card>
 							{ user.email_verified && this.maybeRenderErrorNotice() }
-								<div className="jetpack-connect__sso-user-profile">
-									<Gravatar user={ user } size={ 120 } imgSize={ 400 } />
-									<h3 className="jetpack-connect__sso-log-in-as">
-										{ translate(
-											'Log in as {{strong}}%s{{/strong}}',
-											{
-												args: user.display_name,
-												components: {
-													strong: <strong className="jetpack-connect__sso-display-name" />
-												}
-											}
-										) }
-									</h3>
-									<div className="jetpack-connect__sso-user-email">
-										{ user.email }
-									</div>
-								</div>
+							<div className="jetpack-connect__sso-user-profile">
+								<Gravatar user={ user } size={ 120 } imgSize={ 400 } />
+								<h3 className="jetpack-connect__sso-log-in-as">
+									{ translate( 'Log in as {{strong}}%s{{/strong}}', {
+										args: user.display_name,
+										components: {
+											strong: <strong className="jetpack-connect__sso-display-name" />,
+										},
+									} ) }
+								</h3>
+								<div className="jetpack-connect__sso-user-email">{ user.email }</div>
+							</div>
 
-								<LoggedOutFormFooter className="jetpack-connect__sso-actions">
-									<p className="jetpack-connect__tos-link">
-										{ this.getTOSText() }
-									</p>
+							<LoggedOutFormFooter className="jetpack-connect__sso-actions">
+								<p className="jetpack-connect__tos-link">{ this.getTOSText() }</p>
 
-									<Button
-										primary
-										onClick={ this.onApproveSSO }
-										disabled={ this.isButtonDisabled() }>
-										{ translate( 'Log in' ) }
-									</Button>
-								</LoggedOutFormFooter>
+								<Button primary onClick={ this.onApproveSSO } disabled={ this.isButtonDisabled() }>
+									{ translate( 'Log in' ) }
+								</Button>
+							</LoggedOutFormFooter>
 						</Card>
 					</EmailVerificationGate>
 
 					<LoggedOutFormLinks>
-						<LoggedOutFormLinkItem href={ this.getSignInLink() } onClick={ this.onClickSignInDifferentUser }>
+						<LoggedOutFormLinkItem
+							href={ this.getSignInLink() }
+							onClick={ this.onClickSignInDifferentUser }
+						>
 							{ translate( 'Sign in as a different user' ) }
 						</LoggedOutFormLinkItem>
 						<LoggedOutFormLinkItem
 							rel="external"
 							href={ get( this.props, 'blogDetails.admin_url', '#' ) }
-							onClick={ this.onCancelClick }>
+							onClick={ this.onCancelClick }
+						>
 							{ this.getReturnToSiteText() }
 						</LoggedOutFormLinkItem>
 						<HelpButton />
@@ -488,11 +478,15 @@ export default connect(
 			authorizationError: get( jetpackSSO, 'authorizationError' ),
 			validationError: get( jetpackSSO, 'validationError' ),
 			blogDetails: get( jetpackSSO, 'blogDetails' ),
-			sharedDetails: get( jetpackSSO, 'sharedDetails' )
+			sharedDetails: get( jetpackSSO, 'sharedDetails' ),
 		};
 	},
-	dispatch => bindActionCreators( {
-		authorizeSSO,
-		validateSSONonce
-	}, dispatch )
+	dispatch =>
+		bindActionCreators(
+			{
+				authorizeSSO,
+				validateSSONonce,
+			},
+			dispatch
+		)
 )( localize( JetpackSsoForm ) );

--- a/client/jetpack-connect/test/main-wrapper.jsx
+++ b/client/jetpack-connect/test/main-wrapper.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -13,9 +14,7 @@ import Main from 'components/main';
 
 describe( 'JetpackConnectMainWrapper', () => {
 	it( 'should render a <Main> instance', () => {
-		const wrapper = shallow(
-			<JetpackConnectMainWrapper />
-		);
+		const wrapper = shallow( <JetpackConnectMainWrapper /> );
 
 		expect( wrapper.find( Main ) ).to.have.length( 1 );
 	} );
@@ -23,7 +22,7 @@ describe( 'JetpackConnectMainWrapper', () => {
 	it( 'should render the passed children as children of the component', () => {
 		const wrapper = shallow(
 			<JetpackConnectMainWrapper>
-				<span className="test__child"></span>
+				<span className="test__child" />
 			</JetpackConnectMainWrapper>
 		).render();
 
@@ -31,34 +30,26 @@ describe( 'JetpackConnectMainWrapper', () => {
 	} );
 
 	it( 'should always specify the jetpack-connect__main class', () => {
-		const wrapper = shallow(
-			<JetpackConnectMainWrapper />
-		);
+		const wrapper = shallow( <JetpackConnectMainWrapper /> );
 
 		expect( wrapper.hasClass( 'jetpack-connect__main' ) ).to.be.true;
 	} );
 
 	it( 'should allow more classes to be added', () => {
-		const wrapper = shallow(
-			<JetpackConnectMainWrapper className="test__class" />
-		);
+		const wrapper = shallow( <JetpackConnectMainWrapper className="test__class" /> );
 
 		expect( wrapper.hasClass( 'jetpack-connect__main' ) ).to.be.true;
 		expect( wrapper.hasClass( 'test__class' ) ).to.be.true;
 	} );
 
 	it( 'should not contain the is-wide modifier class by default', () => {
-		const wrapper = shallow(
-			<JetpackConnectMainWrapper />
-		);
+		const wrapper = shallow( <JetpackConnectMainWrapper /> );
 
 		expect( wrapper.hasClass( 'is-wide' ) ).to.be.false;
 	} );
 
 	it( 'should contain the is-wide modifier class if prop is specified', () => {
-		const wrapper = shallow(
-			<JetpackConnectMainWrapper isWide />
-		);
+		const wrapper = shallow( <JetpackConnectMainWrapper isWide /> );
 
 		expect( wrapper.hasClass( 'is-wide' ) ).to.be.true;
 	} );


### PR DESCRIPTION
This PR does two things on the `client/jetpack-connect` directory:
* Replace `React.PropTypes` with the `prop-types` module. This was required when running prettier.
* Run prettier (re-format code).

There should be no behavioral changes.

This is contained in #18172. Prettier has been separated from that PR because it makes for noisy PRs.