### PR TITLE
Signup: Remove 'post signup landing page' test.

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -94,15 +94,6 @@ module.exports = {
 		defaultVariation: 'white',
 		assignmentMethod: 'userId',
 	},
-	postSignupUpgradeScreen: {
-		datestamp: '20170810',
-		variations: {
-			original: 50,
-			modified: 50,
-		},
-		defaultVariation: 'original',
-		allowExistingUsers: true,
-	},
 	privacyNoPopup: {
 		datestamp: '20170830',
 		variations: {

--- a/client/signup/processing-screen/index.jsx
+++ b/client/signup/processing-screen/index.jsx
@@ -15,7 +15,6 @@ import { connect } from 'react-redux';
 import Button from 'components/button';
 import Notice from 'components/notice';
 import analytics from 'lib/analytics';
-import { abtest } from 'lib/abtest';
 import { showOAuth2Layout } from 'state/ui/oauth2-clients/selectors';
 
 export class SignupProcessingScreen extends Component {
@@ -185,12 +184,12 @@ export class SignupProcessingScreen extends Component {
 	}
 
 	renderUpgradeNudge() {
-		/* Do NOT translate the strings in this function until the abtest is finished. */
+		const { translate } = this.props;
 
 		/* eslint-disable max-len, wpcalypso/jsx-classname-namespace */
 		return (
 			<div className="signup-pricessing__upgrade-nudge">
-				<p className="signup-pricessing__title-subdomain">Your subdomain</p>
+				<p className="signup-pricessing__title-subdomain">{ translate( 'Your subdomain' ) }</p>
 				<div className="signup-pricessing__address-bar">
 					<Gridicon icon="refresh" size={ 24 } />
 					<Gridicon icon="house" size={ 24 } />
@@ -198,22 +197,22 @@ export class SignupProcessingScreen extends Component {
 				</div>
 				<div className="signup-pricessing__bubble">
 					<svg className="signup-pricessing__bubble-tail" viewBox="0 0 47 31" xmlns="http://www.w3.org/2000/svg"><path d="M.261 30.428S14.931 6.646 46.066.528l-11.852 29.9H.26z" fillRule="evenodd" /></svg>
-					<p>Search engines like Google or Bing prefer websites with their own web address and place them higher in search results.</p>
+					<p>{ translate( 'Search engines like Google or Bing prefer websites with their own web address and place them higher in search results.' ) }</p>
 				</div>
 				<p className="signup-pricessing__nudge-message">
-					Looks like your new online home doesn't have its own domain name.
+					{ translate( 'Looks like your new online home doesn\'t have its own domain name.' ) }
 				</p>
-				<Button disabled={ ! this.props.loginHandler } className="signup-pricessing__upgrade-button" onClick={ this.handleClickUpgradeButton }>Upgrade Plan & Get A Domain</Button>
+				<Button disabled={ ! this.props.loginHandler } className="signup-pricessing__upgrade-button" onClick={ this.handleClickUpgradeButton }>{ translate( 'Upgrade Plan & Get A Domain' ) }</Button>
 			</div>
 		);
 		/* eslint-disable max-len, wpcalypso/jsx-classname-namespace */
 	}
 
 	renderUpgradeScreen() {
-		/* Do NOT translate the strings in this function until the abtest is finished. */
+		const { translate } = this.props;
 		const title = this.props.loginHandler
-			? 'Congratulations! Your site is live.'
-			: 'Congratulations! Your website is almost ready.';
+			? translate( 'Congratulations! Your site is live.' )
+			: translate( 'Congratulations! Your website is almost ready.' );
 
 		/* eslint-disable max-len, wpcalypso/jsx-classname-namespace */
 		return (
@@ -225,20 +224,20 @@ export class SignupProcessingScreen extends Component {
 					<p className="signup-process-screen__title signup-process-screen__title-test">{ title }</p>
 
 					{ this.props.loginHandler
-						?	<Button primary className="email-confirmation__button" onClick={ this.props.loginHandler }>View My Site</Button>
-						:	<Button primary disabled className="email-confirmation__button">{ this.props.translate( 'Please wait…' ) }</Button>
+						?	<Button primary className="email-confirmation__button" onClick={ this.props.loginHandler }>{ translate( 'View My Site' ) }</Button>
+						:	<Button primary disabled className="email-confirmation__button">{ translate( 'Please wait…' ) }</Button>
 					}
 
 					{ this.renderUpgradeNudge() }
 				</div>
-				<div className="signup-processing-screen__loader">{ this.props.translate( 'Loading…' ) }</div>
+				<div className="signup-processing-screen__loader">{ translate( 'Loading…' ) }</div>
 			</div>
 		);
 		/* eslint-enable max-len, wpcalypso/jsx-classname-namespace */
 	}
 
 	render() {
-		if ( abtest( 'postSignupUpgradeScreen' ) === 'modified' && ! this.state.hasPaidSubscription && this.currentFlowIncludesDomainStep() && ! this.props.useOAuth2Layout ) {
+		if ( ! this.state.hasPaidSubscription && this.currentFlowIncludesDomainStep() && ! this.props.useOAuth2Layout ) {
 			return this.renderUpgradeScreen();
 		}
 


### PR DESCRIPTION
This PR will remove [the 'post signup landing page' test](https://github.com/Automattic/wp-calypso/pull/17096) and roll out the screen to 100% of users.

## How to test

1. Create a new website and follow the steps with free plan.
2. You should be able to see the new post signup screen like the following.

![screen_shot_2017-08-10_at_23_05_45](https://user-images.githubusercontent.com/212034/29174295-d78e955e-7e20-11e7-9c7c-0c4c903ba3d0.png)
