### PR TITLE
Framework: Remove component-uid dependency

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -35,7 +35,7 @@
       }
     },
     "abab": {
-      "version": "1.0.3",
+      "version": "1.0.4",
       "dev": true
     },
     "abbrev": {
@@ -114,7 +114,7 @@
       "dev": true
     },
     "aproba": {
-      "version": "1.1.2"
+      "version": "1.2.0"
     },
     "are-we-there-yet": {
       "version": "1.1.4",
@@ -191,7 +191,7 @@
       "version": "1.4.1"
     },
     "assert-plus": {
-      "version": "0.2.0"
+      "version": "1.0.0"
     },
     "assertion-error": {
       "version": "1.0.2",
@@ -223,7 +223,7 @@
       "version": "3.0.15"
     },
     "aws-sign2": {
-      "version": "0.6.0"
+      "version": "0.7.0"
     },
     "aws4": {
       "version": "1.6.0"
@@ -778,7 +778,7 @@
       "dev": true
     },
     "boom": {
-      "version": "2.10.1"
+      "version": "4.3.1"
     },
     "bounding-client-rect": {
       "version": "1.0.5"
@@ -879,10 +879,10 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000732"
+      "version": "1.0.30000733"
     },
     "caniuse-lite": {
-      "version": "1.0.30000732"
+      "version": "1.0.30000733"
     },
     "cardinal": {
       "version": "1.0.0",
@@ -1142,9 +1142,6 @@
     "component-query": {
       "version": "0.0.3"
     },
-    "component-uid": {
-      "version": "0.0.2"
-    },
     "concat-map": {
       "version": "0.0.1"
     },
@@ -1272,7 +1269,12 @@
       "dev": true
     },
     "cryptiles": {
-      "version": "2.0.5"
+      "version": "3.1.2",
+      "dependencies": {
+        "boom": {
+          "version": "5.2.0"
+        }
+      }
     },
     "crypto-browserify": {
       "version": "3.11.1"
@@ -1345,12 +1347,7 @@
       "version": "2.0.5"
     },
     "dashdash": {
-      "version": "1.14.1",
-      "dependencies": {
-        "assert-plus": {
-          "version": "1.0.0"
-        }
-      }
+      "version": "1.14.1"
     },
     "dashify": {
       "version": "0.2.2",
@@ -1360,7 +1357,7 @@
       "version": "0.1.4"
     },
     "dateformat": {
-      "version": "2.0.0",
+      "version": "2.2.0",
       "dev": true
     },
     "debug": {
@@ -2160,7 +2157,7 @@
       "dev": true
     },
     "flow-parser": {
-      "version": "0.54.1",
+      "version": "0.55.0",
       "dev": true
     },
     "flux": {
@@ -2193,7 +2190,7 @@
       "version": "0.6.1"
     },
     "form-data": {
-      "version": "2.1.4"
+      "version": "2.3.1"
     },
     "formatio": {
       "version": "1.1.1",
@@ -2220,6 +2217,460 @@
     },
     "fs.realpath": {
       "version": "1.0.0"
+    },
+    "fsevents": {
+      "version": "1.1.1",
+      "optional": true,
+      "dependencies": {
+        "abbrev": {
+          "version": "1.1.0",
+          "optional": true
+        },
+        "ansi-regex": {
+          "version": "2.1.1"
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "optional": true
+        },
+        "aproba": {
+          "version": "1.1.1",
+          "optional": true
+        },
+        "are-we-there-yet": {
+          "version": "1.1.2",
+          "optional": true
+        },
+        "asn1": {
+          "version": "0.2.3",
+          "optional": true
+        },
+        "assert-plus": {
+          "version": "0.2.0",
+          "optional": true
+        },
+        "asynckit": {
+          "version": "0.4.0",
+          "optional": true
+        },
+        "aws-sign2": {
+          "version": "0.6.0",
+          "optional": true
+        },
+        "aws4": {
+          "version": "1.6.0",
+          "optional": true
+        },
+        "balanced-match": {
+          "version": "0.4.2"
+        },
+        "bcrypt-pbkdf": {
+          "version": "1.0.1",
+          "optional": true
+        },
+        "block-stream": {
+          "version": "0.0.9"
+        },
+        "boom": {
+          "version": "2.10.1"
+        },
+        "brace-expansion": {
+          "version": "1.1.6"
+        },
+        "buffer-shims": {
+          "version": "1.0.0"
+        },
+        "caseless": {
+          "version": "0.11.0",
+          "optional": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "optional": true
+        },
+        "code-point-at": {
+          "version": "1.1.0"
+        },
+        "combined-stream": {
+          "version": "1.0.5"
+        },
+        "commander": {
+          "version": "2.9.0",
+          "optional": true
+        },
+        "concat-map": {
+          "version": "0.0.1"
+        },
+        "console-control-strings": {
+          "version": "1.1.0"
+        },
+        "core-util-is": {
+          "version": "1.0.2"
+        },
+        "cryptiles": {
+          "version": "2.0.5",
+          "optional": true
+        },
+        "dashdash": {
+          "version": "1.14.1",
+          "optional": true,
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "optional": true
+            }
+          }
+        },
+        "debug": {
+          "version": "2.2.0",
+          "optional": true
+        },
+        "deep-extend": {
+          "version": "0.4.1",
+          "optional": true
+        },
+        "delayed-stream": {
+          "version": "1.0.0"
+        },
+        "delegates": {
+          "version": "1.0.0",
+          "optional": true
+        },
+        "ecc-jsbn": {
+          "version": "0.1.1",
+          "optional": true
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "optional": true
+        },
+        "extend": {
+          "version": "3.0.0",
+          "optional": true
+        },
+        "extsprintf": {
+          "version": "1.0.2"
+        },
+        "forever-agent": {
+          "version": "0.6.1",
+          "optional": true
+        },
+        "form-data": {
+          "version": "2.1.2",
+          "optional": true
+        },
+        "fs.realpath": {
+          "version": "1.0.0"
+        },
+        "fstream": {
+          "version": "1.0.10"
+        },
+        "fstream-ignore": {
+          "version": "1.0.5",
+          "optional": true
+        },
+        "gauge": {
+          "version": "2.7.3",
+          "optional": true
+        },
+        "generate-function": {
+          "version": "2.0.0",
+          "optional": true
+        },
+        "generate-object-property": {
+          "version": "1.2.0",
+          "optional": true
+        },
+        "getpass": {
+          "version": "0.1.6",
+          "optional": true,
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "optional": true
+            }
+          }
+        },
+        "glob": {
+          "version": "7.1.1"
+        },
+        "graceful-fs": {
+          "version": "4.1.11"
+        },
+        "graceful-readlink": {
+          "version": "1.0.1",
+          "optional": true
+        },
+        "har-validator": {
+          "version": "2.0.6",
+          "optional": true
+        },
+        "has-ansi": {
+          "version": "2.0.0",
+          "optional": true
+        },
+        "has-unicode": {
+          "version": "2.0.1",
+          "optional": true
+        },
+        "hawk": {
+          "version": "3.1.3",
+          "optional": true
+        },
+        "hoek": {
+          "version": "2.16.3"
+        },
+        "http-signature": {
+          "version": "1.1.1",
+          "optional": true
+        },
+        "inflight": {
+          "version": "1.0.6"
+        },
+        "inherits": {
+          "version": "2.0.3"
+        },
+        "ini": {
+          "version": "1.3.4",
+          "optional": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0"
+        },
+        "is-my-json-valid": {
+          "version": "2.15.0",
+          "optional": true
+        },
+        "is-property": {
+          "version": "1.0.2",
+          "optional": true
+        },
+        "is-typedarray": {
+          "version": "1.0.0",
+          "optional": true
+        },
+        "isarray": {
+          "version": "1.0.0"
+        },
+        "isstream": {
+          "version": "0.1.2",
+          "optional": true
+        },
+        "jodid25519": {
+          "version": "1.0.2",
+          "optional": true
+        },
+        "jsbn": {
+          "version": "0.1.1",
+          "optional": true
+        },
+        "json-schema": {
+          "version": "0.2.3",
+          "optional": true
+        },
+        "json-stringify-safe": {
+          "version": "5.0.1",
+          "optional": true
+        },
+        "jsonpointer": {
+          "version": "4.0.1",
+          "optional": true
+        },
+        "jsprim": {
+          "version": "1.3.1",
+          "optional": true
+        },
+        "mime-db": {
+          "version": "1.26.0"
+        },
+        "mime-types": {
+          "version": "2.1.14"
+        },
+        "minimatch": {
+          "version": "3.0.3"
+        },
+        "minimist": {
+          "version": "0.0.8"
+        },
+        "mkdirp": {
+          "version": "0.5.1"
+        },
+        "ms": {
+          "version": "0.7.1",
+          "optional": true
+        },
+        "node-pre-gyp": {
+          "version": "0.6.33",
+          "optional": true
+        },
+        "nopt": {
+          "version": "3.0.6",
+          "optional": true
+        },
+        "npmlog": {
+          "version": "4.0.2",
+          "optional": true
+        },
+        "number-is-nan": {
+          "version": "1.0.1"
+        },
+        "oauth-sign": {
+          "version": "0.8.2",
+          "optional": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "optional": true
+        },
+        "once": {
+          "version": "1.4.0"
+        },
+        "path-is-absolute": {
+          "version": "1.0.1"
+        },
+        "pinkie": {
+          "version": "2.0.4",
+          "optional": true
+        },
+        "pinkie-promise": {
+          "version": "2.0.1",
+          "optional": true
+        },
+        "process-nextick-args": {
+          "version": "1.0.7"
+        },
+        "punycode": {
+          "version": "1.4.1",
+          "optional": true
+        },
+        "qs": {
+          "version": "6.3.1",
+          "optional": true
+        },
+        "rc": {
+          "version": "1.1.7",
+          "optional": true,
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "optional": true
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "2.2.2",
+          "optional": true
+        },
+        "request": {
+          "version": "2.79.0",
+          "optional": true
+        },
+        "rimraf": {
+          "version": "2.5.4"
+        },
+        "semver": {
+          "version": "5.3.0",
+          "optional": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "optional": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "optional": true
+        },
+        "sntp": {
+          "version": "1.0.9",
+          "optional": true
+        },
+        "sshpk": {
+          "version": "1.10.2",
+          "optional": true,
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "optional": true
+            }
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31"
+        },
+        "string-width": {
+          "version": "1.0.2"
+        },
+        "stringstream": {
+          "version": "0.0.5",
+          "optional": true
+        },
+        "strip-ansi": {
+          "version": "3.0.1"
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "optional": true
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "optional": true
+        },
+        "tar": {
+          "version": "2.2.1"
+        },
+        "tar-pack": {
+          "version": "3.3.0",
+          "optional": true,
+          "dependencies": {
+            "once": {
+              "version": "1.3.3",
+              "optional": true
+            },
+            "readable-stream": {
+              "version": "2.1.5",
+              "optional": true
+            }
+          }
+        },
+        "tough-cookie": {
+          "version": "2.3.2",
+          "optional": true
+        },
+        "tunnel-agent": {
+          "version": "0.4.3",
+          "optional": true
+        },
+        "tweetnacl": {
+          "version": "0.14.5",
+          "optional": true
+        },
+        "uid-number": {
+          "version": "0.0.6",
+          "optional": true
+        },
+        "util-deprecate": {
+          "version": "1.0.2"
+        },
+        "uuid": {
+          "version": "3.0.1",
+          "optional": true
+        },
+        "verror": {
+          "version": "1.3.6",
+          "optional": true
+        },
+        "wide-align": {
+          "version": "1.1.0",
+          "optional": true
+        },
+        "wrappy": {
+          "version": "1.0.2"
+        },
+        "xtend": {
+          "version": "4.0.1",
+          "optional": true
+        }
+      }
     },
     "fstream": {
       "version": "1.0.11"
@@ -2264,12 +2715,7 @@
       "version": "2.1.4"
     },
     "getpass": {
-      "version": "0.1.7",
-      "dependencies": {
-        "assert-plus": {
-          "version": "1.0.0"
-        }
-      }
+      "version": "0.1.7"
     },
     "github-from-package": {
       "version": "0.0.0"
@@ -2348,7 +2794,7 @@
       "dev": true
     },
     "gridicons": {
-      "version": "2.0.3"
+      "version": "2.0.4"
     },
     "growl": {
       "version": "1.9.2",
@@ -2426,15 +2872,10 @@
       }
     },
     "har-schema": {
-      "version": "1.0.5"
+      "version": "2.0.0"
     },
     "har-validator": {
-      "version": "4.2.1",
-      "dependencies": {
-        "ajv": {
-          "version": "4.11.8"
-        }
-      }
+      "version": "5.0.3"
     },
     "hard-source-webpack-plugin": {
       "version": "0.3.12",
@@ -2490,7 +2931,7 @@
       }
     },
     "hawk": {
-      "version": "3.1.3"
+      "version": "6.0.2"
     },
     "he": {
       "version": "0.5.0"
@@ -2499,7 +2940,7 @@
       "version": "1.0.1"
     },
     "hoek": {
-      "version": "2.16.3"
+      "version": "4.2.0"
     },
     "hoist-non-react-statics": {
       "version": "1.2.0"
@@ -2568,7 +3009,7 @@
       }
     },
     "http-signature": {
-      "version": "1.1.1"
+      "version": "1.2.0"
     },
     "https-browserify": {
       "version": "0.0.1"
@@ -3466,12 +3907,7 @@
       "dev": true
     },
     "jsprim": {
-      "version": "1.4.1",
-      "dependencies": {
-        "assert-plus": {
-          "version": "1.0.0"
-        }
-      }
+      "version": "1.4.1"
     },
     "jstimezonedetect": {
       "version": "1.0.5"
@@ -3536,7 +3972,12 @@
       "version": "1.2.1"
     },
     "leveldown": {
-      "version": "1.7.2"
+      "version": "1.7.2",
+      "dependencies": {
+        "nan": {
+          "version": "2.6.2"
+        }
+      }
     },
     "levelup": {
       "version": "1.3.9",
@@ -3953,7 +4394,7 @@
       "version": "1.0.1"
     },
     "nan": {
-      "version": "2.6.2"
+      "version": "2.7.0"
     },
     "natives": {
       "version": "1.1.0",
@@ -4382,7 +4823,7 @@
       "version": "3.0.0"
     },
     "performance-now": {
-      "version": "0.2.0"
+      "version": "2.1.0"
     },
     "phone": {
       "version": "1.0.8",
@@ -4774,8 +5215,8 @@
     },
     "react-codemod": {
       "version": "4.0.0",
-      "from": "git://github.com/reactjs/react-codemod.git#d8a1d474b6b208cfdbec339b672617270ef78ac5",
-      "resolved": "git://github.com/reactjs/react-codemod.git#d8a1d474b6b208cfdbec339b672617270ef78ac5",
+      "from": "git://github.com/reactjs/react-codemod.git#0e6aabb233453b17c23d68bb181a3d70ad03f9c9",
+      "resolved": "git://github.com/reactjs/react-codemod.git#0e6aabb233453b17c23d68bb181a3d70ad03f9c9",
       "dev": true,
       "dependencies": {
         "chalk": {
@@ -5005,7 +5446,7 @@
       "version": "1.0.0"
     },
     "regenerate": {
-      "version": "1.3.2"
+      "version": "1.3.3"
     },
     "regenerator": {
       "version": "0.8.40",
@@ -5107,10 +5548,10 @@
       "dev": true
     },
     "request": {
-      "version": "2.81.0",
+      "version": "2.82.0",
       "dependencies": {
         "qs": {
-          "version": "6.4.0"
+          "version": "6.5.1"
         },
         "uuid": {
           "version": "3.1.0"
@@ -5392,7 +5833,7 @@
       "version": "1.1.2"
     },
     "sntp": {
-      "version": "1.0.9"
+      "version": "2.0.2"
     },
     "social-logos": {
       "version": "1.0.1"
@@ -5498,12 +5939,7 @@
       "dev": true
     },
     "sshpk": {
-      "version": "1.13.1",
-      "dependencies": {
-        "assert-plus": {
-          "version": "1.0.0"
-        }
-      }
+      "version": "1.13.1"
     },
     "stable": {
       "version": "0.1.6",
@@ -6104,12 +6540,7 @@
       "version": "1.0.1"
     },
     "verror": {
-      "version": "1.10.0",
-      "dependencies": {
-        "assert-plus": {
-          "version": "1.0.0"
-        }
-      }
+      "version": "1.10.0"
     },
     "vinyl": {
       "version": "0.5.3",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "commander": "2.3.0",
     "component-closest": "0.1.4",
     "component-file-picker": "0.2.1",
-    "component-uid": "0.0.2",
     "cookie": "0.1.2",
     "cookie-parser": "1.3.2",
     "copy-webpack-plugin": "4.0.1",


### PR DESCRIPTION
Obsolete as of #17356.

Seems like this was missed by #17356.

To test: Make sure that Calypso still works, and verify that `component-uid` isn't used anywhere.