### PR TITLE
PostTypeList: only allow a single active Share panel

### DIFF
--- a/client/state/ui/post-type-list/reducer.js
+++ b/client/state/ui/post-type-list/reducer.js
@@ -23,7 +23,7 @@ export const postTypeList = ( state = initialState, action ) => {
 			if ( state.activeSharePanels.indexOf( action.postGlobalId ) > -1 ) {
 				return { ...state, activeSharePanels: without( state.activeSharePanels, action.postGlobalId ) };
 			}
-			return { ...state, activeSharePanels: [ ...state.activeSharePanels, action.postGlobalId ] };
+			return { ...state, activeSharePanels: [ action.postGlobalId ] };
 	}
 
 	return state;

--- a/client/state/ui/post-type-list/test/reducer.js
+++ b/client/state/ui/post-type-list/test/reducer.js
@@ -55,5 +55,16 @@ describe( 'reducer', () => {
 
 			expect( state.activeSharePanels ).to.eql( [ postGlobalId ] );
 		} );
+
+		it( 'should remove an existing active Share panel when toggling on a different Share panel', () => {
+			const existingPostGlobalId = 5;
+			const postGlobalId = 4;
+			const state = postTypeList( { activeSharePanels: [ existingPostGlobalId ] }, {
+				type: POST_TYPE_LIST_SHARE_PANEL_TOGGLE,
+				postGlobalId: postGlobalId,
+			} );
+
+			expect( state.activeSharePanels ).to.eql( [ postGlobalId ] );
+		} );
 	} );
 } );


### PR DESCRIPTION
This PR updates the reducer for `post-type-list` such that only a single active Share panel is allowed. When opening an additional Share panel, previous Share panels will be closed. A test has been added to cover the new behavior.

Note: This PR is part of a larger epic and behind the `posts/post-type-list` feature flag.
See p8F9tW-hL-p2.

![single-share](https://user-images.githubusercontent.com/363749/30704862-96c844de-9eb9-11e7-8c55-d8e44fc3ce41.gif)

To test:
* Checkout branch.
* `ENABLE_FEATURES=posts/post-type-list npm start`.
* Navigate to "Blog Posts" and toggle on a Share panel via the ellipsis menu.
* Toggle on a different Share panel. Verify that the previous Share panel is closed and that only one share panel remains active.