### PR TITLE
Analytics: block HotJar on pages with PII

### DIFF
--- a/client/lib/analytics/ad-tracking.js
+++ b/client/lib/analytics/ad-tracking.js
@@ -11,9 +11,9 @@ import { v4 as uuid } from 'uuid';
  * Internal dependencies
  */
 import config from 'config';
-import loadScript from 'lib/load-script';
 import productsValues from 'lib/products-values';
 import userModule from 'lib/user';
+import { loadScript } from 'lib/load-script';
 import { shouldSkipAds } from 'lib/analytics/utils';
 
 /**
@@ -198,34 +198,34 @@ function loadTrackingScripts( callback ) {
 
 	async.parallel( [
 		function( onComplete ) {
-			loadScript.loadScript( FACEBOOK_TRACKING_SCRIPT_URL, onComplete );
+			loadScript( FACEBOOK_TRACKING_SCRIPT_URL, onComplete );
 		},
 		function( onComplete ) {
-			loadScript.loadScript( GOOGLE_TRACKING_SCRIPT_URL, onComplete );
+			loadScript( GOOGLE_TRACKING_SCRIPT_URL, onComplete );
 		},
 		function( onComplete ) {
-			loadScript.loadScript( BING_TRACKING_SCRIPT_URL, onComplete );
+			loadScript( BING_TRACKING_SCRIPT_URL, onComplete );
 		},
 		function( onComplete ) {
-			loadScript.loadScript( CRITEO_TRACKING_SCRIPT_URL, onComplete );
+			loadScript( CRITEO_TRACKING_SCRIPT_URL, onComplete );
 		},
 		function( onComplete ) {
-			loadScript.loadScript( quantcastAsynchronousTagURL(), onComplete );
+			loadScript( quantcastAsynchronousTagURL(), onComplete );
 		},
 		function( onComplete ) {
-			loadScript.loadScript( YAHOO_TRACKING_SCRIPT_URL, onComplete );
+			loadScript( YAHOO_TRACKING_SCRIPT_URL, onComplete );
 		},
 		function( onComplete ) {
-			loadScript.loadScript( TWITTER_TRACKING_SCRIPT_URL, onComplete );
+			loadScript( TWITTER_TRACKING_SCRIPT_URL, onComplete );
 		},
 		function( onComplete ) {
-			loadScript.loadScript( LINKED_IN_SCRIPT_URL, onComplete );
+			loadScript( LINKED_IN_SCRIPT_URL, onComplete );
 		},
 		function( onComplete ) {
-			loadScript.loadScript( MEDIA_WALLAH_URL, onComplete );
+			loadScript( MEDIA_WALLAH_URL, onComplete );
 		},
 		function( onComplete ) {
-			loadScript.loadScript( QUORA_URL, onComplete );
+			loadScript( QUORA_URL, onComplete );
 		}
 	], function( errors ) {
 		if ( ! some( errors ) ) {
@@ -616,7 +616,7 @@ function recordOrderInAtlas( cart, orderId ) {
 	const urlWithParams = ATLAS_TRACKING_SCRIPT_URL + ';m=' + TRACKING_IDS.atlasUniveralTagId +
 		';cache=' + Math.random() + '?' + urlParams;
 
-	loadScript.loadScript( urlWithParams );
+	loadScript( urlWithParams );
 }
 
 /**

--- a/client/lib/analytics/index.js
+++ b/client/lib/analytics/index.js
@@ -23,6 +23,7 @@ import { statsdTimingUrl } from 'lib/analytics/statsd';
  */
 const mcDebug = debug( 'calypso:analytics:mc' );
 const gaDebug = debug( 'calypso:analytics:ga' );
+const hotjarDebug = debug( 'calypso:analytics:hotjar' );
 const tracksDebug = debug( 'calypso:analytics:tracks' );
 
 let _superProps,
@@ -444,10 +445,12 @@ const analytics = {
 	hotjar: {
 		addHotJarScript: function() {
 			if ( ! config( 'hotjar_enabled' ) || doNotTrack() || isPiiUrl() ) {
+				hotjarDebug( 'Not loading HotJar script' );
 				return;
 			}
 
 			( function( h, o, t, j, a, r ) {
+				hotjarDebug( 'Loading HotJar script' );
 				h.hj = h.hj || function() {
 					( h.hj.q = h.hj.q || [] ).push( arguments );
 				};

--- a/client/lib/analytics/index.js
+++ b/client/lib/analytics/index.js
@@ -443,6 +443,10 @@ const analytics = {
 	// HotJar tracking
 	hotjar: {
 		addHotJarScript: function() {
+			if ( ! config( 'hotjar_enabled' ) || doNotTrack() || isPiiUrl() ) {
+				return;
+			}
+
 			( function( h, o, t, j, a, r ) {
 				h.hj = h.hj || function() {
 					( h.hj.q = h.hj.q || [] ).push( arguments );

--- a/client/state/analytics/middleware.js
+++ b/client/state/analytics/middleware.js
@@ -14,9 +14,6 @@ import {
 	trackCustomFacebookConversionEvent,
 } from 'lib/analytics/ad-tracking';
 import {
-	doNotTrack,
-} from 'lib/analytics/utils';
-import {
 	ANALYTICS_EVENT_RECORD,
 	ANALYTICS_PAGE_VIEW_RECORD,
 	ANALYTICS_STAT_BUMP,
@@ -24,7 +21,6 @@ import {
 	ANALYTICS_TRACKS_ANONID_SET,
 } from 'state/action-types';
 import isTracking from 'state/selectors/is-tracking';
-import config from 'config';
 
 const eventServices = {
 	ga: ( { category, action, label, value } ) => analytics.ga.recordEvent( category, action, label, value ),
@@ -39,10 +35,7 @@ const pageViewServices = {
 };
 
 const loadTrackingTool = ( trackingTool, state ) => {
-	const trackUser = ! doNotTrack();
-	const hotJarEnabled = config( 'hotjar_enabled' );
-
-	if ( trackingTool === 'HotJar' && ! isTracking( state, 'HotJar' ) && hotJarEnabled && trackUser ) {
+	if ( trackingTool === 'HotJar' && ! isTracking( state, 'HotJar' ) ) {
 		analytics.hotjar.addHotJarScript();
 	}
 };


### PR DESCRIPTION
Fixes #17971.

This uses `doNotTrack` and `isPiiUrl` functions to determine if we should load HotJar. 

(I also threw in a small refactor commit.)

#### Testing instructions

1. Check out locally (`git checkout fix/hotjar-loading-on-pii`) and start your server. ([Live branch here](https://calypso.live/?branch=fix/hotjar-loading-on-pii))
2. Disable "Do Not Track" on your browser.
3. Set your localStorage debug flag to 'calypso:analytics*' like so:  
```javascript
localStorage.debug = 'calypso:analytics*'
```
4. Open the [Premium Start Page](http://calypso.localhost:3000/start/premium/design-type-with-store)
5. Verify that HotJar script has loaded by checking for the debug logs, the presence of `window.hj` function, and the presence of `window._hjSettings` object.
6. Open the [Premium Start Page containing potential PII](http://calypso.localhost:3000/start/premium/design-type-with-store?first-name=automattic). In this case, it's `first-name=automattic`.
7. Verify that HotJar script has not loaded and `window.hj` and `window._hjSettings` are not defined.

#### Reviews

- [x] Code
- [x] Product