### PR TITLE
Store: Fix http-request to correctly pass the path and body for non-GET requests

### DIFF
--- a/client/extensions/woocommerce/state/sites/http-request.js
+++ b/client/extensions/woocommerce/state/sites/http-request.js
@@ -19,15 +19,47 @@ const _request = ( method, path, siteId, body, action, namespace ) => {
 	// WPCOM API breaks if query parameters are passed after "?" instead of "&". Hide this hack from the calling code
 	path = path.replace( '?', '&' );
 	path = `${ namespace }/${ path }&_method=${ method }`;
+
+	let requestMethod;
+	let requestQuery;
+	let requestBody;
+
+	// DELETE, PUT, and POST all get passed to the Jetpack API as a POST request
+	switch ( method ) {
+		case 'GET':
+			requestMethod = 'GET';
+			requestQuery = {
+				path,
+				json: true,
+			};
+			requestBody = null;
+			break;
+		case 'DELETE':
+			requestMethod = 'POST';
+			requestQuery = {
+				json: true,
+			};
+			requestBody = {
+				path,
+			};
+			break;
+		default:
+			requestMethod = 'POST';
+			requestQuery = {
+				json: true,
+			};
+			requestBody = {
+				path,
+				body: body && JSON.stringify( body ),
+			};
+	}
+
 	return http( {
 		apiVersion: '1.1',
-		method: 'GET' === method ? 'GET' : 'POST',
+		method: requestMethod,
 		path: `/jetpack-blogs/${ siteId }/rest-api/`,
-		query: {
-			path,
-			json: true,
-		},
-		body: body && JSON.stringify( body ),
+		query: requestQuery,
+		body: requestBody,
 	}, action );
 };
 

--- a/client/extensions/woocommerce/state/sites/settings/stripe-connect-account/test/handlers.js
+++ b/client/extensions/woocommerce/state/sites/settings/stripe-connect-account/test/handlers.js
@@ -31,11 +31,13 @@ describe( 'handlers', () => {
 			handleAccountCreate( { dispatch }, action );
 			expect( dispatch ).to.have.been.calledWithMatch( {
 				type: WPCOM_HTTP_REQUEST,
-				body: JSON.stringify( { email, country } ),
+				body: {
+					path: '/wc/v1/connect/stripe/account/&_method=POST',
+					body: JSON.stringify( { email, country } ),
+				},
 				method: 'POST',
 				path: `/jetpack-blogs/${ siteId }/rest-api/`,
 				query: {
-					path: '/wc/v1/connect/stripe/account/&_method=POST',
 					json: true,
 					apiVersion: '1.1',
 				}

--- a/client/extensions/woocommerce/state/sites/test/http-request.js
+++ b/client/extensions/woocommerce/state/sites/test/http-request.js
@@ -15,7 +15,7 @@ const originalAction = {
 	siteId,
 };
 
-describe( 'request', () => {
+describe( 'http-request', () => {
 	describe( '#get', () => {
 		it( 'should return a request action', () => {
 			const action = request( siteId, originalAction ).get( 'placeholder_endpoint' );
@@ -49,11 +49,11 @@ describe( 'request', () => {
 				method: 'POST',
 				path: `/jetpack-blogs/${ siteId }/rest-api/`,
 			} );
-			expect( action.body ).to.eql( JSON.stringify( body ) );
-			expect( action.query ).to.exist;
-			expect( action.query ).to.include( {
+			expect( action.body ).to.exist;
+			expect( action.body ).to.include( {
 				path: '/wc/v3/placeholder_endpoint&_method=POST',
 			} );
+			expect( action.body.body ).to.eql( JSON.stringify( body ) );
 		} );
 	} );
 	describe( '#put', () => {
@@ -66,11 +66,11 @@ describe( 'request', () => {
 				method: 'POST', // Note that this stays POST
 				path: `/jetpack-blogs/${ siteId }/rest-api/`,
 			} );
-			expect( action.body ).to.eql( JSON.stringify( body ) );
-			expect( action.query ).to.exist;
-			expect( action.query ).to.include( {
+			expect( action.body ).to.exist;
+			expect( action.body ).to.include( {
 				path: '/wc/v3/placeholder_endpoint&_method=PUT',
 			} );
+			expect( action.body.body ).to.eql( JSON.stringify( body ) );
 		} );
 	} );
 
@@ -82,9 +82,8 @@ describe( 'request', () => {
 				method: 'POST', // Note that this stays POST
 				path: `/jetpack-blogs/${ siteId }/rest-api/`,
 			} );
-			expect( action.body ).to.be.null,
-			expect( action.query ).to.exist;
-			expect( action.query ).to.include( {
+			expect( action.body ).to.exist;
+			expect( action.body ).to.eql( {
 				path: '/wc/v3/placeholder_endpoint&_method=DELETE',
 			} );
 		} );


### PR DESCRIPTION
Previously the request handlers in `client/extensions/woocommerce/state/sites/http-request.js` would always pass the path in the query string.

However the jetpack-blogs API endpoint (that our calls proxy through) expect the path to be present in the body for non GET requests. See `class.wpcom-json-api-jetpack-blog-endpoint.php#569`.

This hasn't been an issue so far since only `GET` has been used from this library in production. I noticed the issue while working on reviews because I would get back `The required path parameter is missing`.

This PR adjusts the requests to make sure we are passing the correct objects, and updates some tests.

To Test:
* Run `npm run test-client client/extensions/woocommerce/state` and make sure all tests pass.
* Boot up the branch and click around the interface just for a sanity check. Settings is a good page to test (`http://calypso.localhost:3000/store/settings/:site`) because general settings makes a request using this code.