### PR TITLE
Desktop App: Improve app preferences experience

### DIFF
--- a/client/lib/desktop/index.js
+++ b/client/lib/desktop/index.js
@@ -32,6 +32,7 @@ var Desktop = {
 		ipc.on( 'page-my-sites', this.onShowMySites.bind( this ) );
 		ipc.on( 'page-reader', this.onShowReader.bind( this ) );
 		ipc.on( 'page-profile', this.onShowProfile.bind( this ) );
+		ipc.on( 'app-preferences', this.onShowAppPreferences.bind( this ) );
 		ipc.on( 'new-post', this.onNewPost.bind( this ) );
 		ipc.on( 'signout', this.onSignout.bind( this ) );
 		ipc.on( 'toggle-notification-bar', this.onToggleNotifications.bind( this ) );
@@ -141,6 +142,12 @@ var Desktop = {
 
 		this.clearNotificationBar();
 		page( '/me' );
+	},
+
+	onShowAppPreferences: function() {
+		debug( 'Showing app preferences' );
+		// this.clearNotificationBar();
+		page( '/me/app-preferences' );
 	},
 
 	onNewPost: function() {

--- a/client/me/app-preferences/controller.js
+++ b/client/me/app-preferences/controller.js
@@ -1,0 +1,23 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { renderWithReduxStore } from 'lib/react-helpers';
+
+export default {
+	preferences( context ) {
+		const AppPreferencesComponent = require( 'me/app-preferences/main' );
+
+		renderWithReduxStore(
+			React.createElement(
+				AppPreferencesComponent
+			),
+			document.getElementById( 'primary' ),
+			context.store
+		);
+	}
+};

--- a/client/me/app-preferences/index.js
+++ b/client/me/app-preferences/index.js
@@ -1,0 +1,14 @@
+/**
+ * External dependencies
+ */
+import page from 'page';
+
+/**
+ * Internal dependencies
+ */
+import meController from 'me/controller';
+import controller from './controller';
+
+export default function() {
+	page( '/me/app-preferences', meController.sidebar, controller.preferences );
+}

--- a/client/me/app-preferences/main.jsx
+++ b/client/me/app-preferences/main.jsx
@@ -1,0 +1,41 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { localize } from 'i18n-calypso';
+import { identity } from 'lodash';
+import PropTypes from 'prop-types';
+
+/**
+ * Internal dependencies
+ */
+import Main from 'components/main';
+import DocumentHead from 'components/data/document-head';
+import MeSidebarNavigation from 'me/sidebar-navigation';
+import WritingPreferences from './writing-preferences';
+import NotificationPreferences from './notification-preferences';
+import ReleaseChannelPreferences from './release-channel-preferences';
+import ProxyPreferences from './proxy-preferences';
+
+/* eslint-disable wpcalypso/jsx-classname-namespace */
+const AppPreferences = ( { translate } ) => (
+	<Main className="account">
+		<DocumentHead title={ translate( 'App Preferences' ) } />
+
+		<MeSidebarNavigation />
+		<WritingPreferences />
+		<NotificationPreferences />
+		<ReleaseChannelPreferences />
+		<ProxyPreferences />
+	</Main>
+);
+
+AppPreferences.propTypes = {
+	translate: PropTypes.func,
+};
+
+AppPreferences.defaultProps = {
+	translate: identity,
+};
+
+export default localize( AppPreferences );

--- a/client/me/app-preferences/notification-preferences.jsx
+++ b/client/me/app-preferences/notification-preferences.jsx
@@ -1,0 +1,72 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { flow, identity, noop } from 'lodash';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Card from 'components/card';
+import Button from 'components/button';
+import SectionHeader from 'components/section-header';
+import FormCheckbox from 'components/forms/form-checkbox';
+
+const NotificationPreferences = ( { isSaving, isSpellCheckEnabled, translate } ) => (
+	<div>
+		<SectionHeader label={ translate( 'Notifications' ) }>
+			<Button
+				compact
+				primary
+				onClick={ noop }
+				type="submit"
+				disabled={ false }
+			>
+				{ isSaving ? translate( 'Saving…' ) : translate( 'Save Settings' ) }
+			</Button>
+		</SectionHeader>
+		<Card className="app-preferences__writing-preferences">
+			<label>
+				<FormCheckbox
+					name="enableSpellCheck"
+					checked={ isSpellCheckEnabled }
+					onChange={ noop }
+				/>
+				<span>{ translate( 'Show Notification Badge' ) }</span>
+			</label>
+			<label>
+				<FormCheckbox
+					name="enableSpellCheck"
+					checked={ isSpellCheckEnabled }
+					onChange={ noop }
+				/>
+				<span>{ translate( 'Bounce app icon in the dock when notification is received' ) }</span>
+			</label>
+		</Card>
+	</div>
+);
+
+NotificationPreferences.propTypes = {
+	isSaving: PropTypes.bool,
+	isSpellCheckEnabled: PropTypes.bool,
+	translate: PropTypes.func,
+};
+
+NotificationPreferences.defaultProps = {
+	isSaving: false,
+	isSpellCheckEnabled: false,
+	translate: identity,
+};
+
+export default flow(
+	localize,
+	connect(
+		() => ( {
+			isSaving: false,
+			isSpellCheckEnabled: true,
+		} )
+	)
+)( NotificationPreferences );

--- a/client/me/app-preferences/proxy-preferences.jsx
+++ b/client/me/app-preferences/proxy-preferences.jsx
@@ -1,0 +1,62 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { flow, identity, noop } from 'lodash';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Card from 'components/card';
+import Button from 'components/button';
+import SectionHeader from 'components/section-header';
+import FormSelect from 'components/forms/form-select';
+import FormFieldset from 'components/forms/form-fieldset';
+
+const ProxyPreferences = ( { isSaving, translate } ) => (
+	<div>
+		<SectionHeader label={ translate( 'Proxy' ) }>
+			<Button
+				compact
+				primary
+				onClick={ noop }
+				type="submit"
+				disabled={ false }
+			>
+				{ isSaving ? translate( 'Saving…' ) : translate( 'Save Settings' ) }
+			</Button>
+		</SectionHeader>
+		<Card className="app-preferences__proxy-preferences">
+			<label>
+				<FormFieldset>
+					<FormSelect id="select">
+						<option>{ translate( 'No Proxy' ) }</option>
+						<option>{ translate( 'Use System Proxy' ) }</option>
+					</FormSelect>
+				</FormFieldset>
+			</label>
+		</Card>
+	</div>
+);
+
+ProxyPreferences.propTypes = {
+	isSaving: PropTypes.bool,
+	translate: PropTypes.func,
+};
+
+ProxyPreferences.defaultProps = {
+	isSaving: false,
+	translate: identity,
+};
+
+export default flow(
+	localize,
+	connect(
+		() => ( {
+			isSaving: false,
+		} )
+	)
+)( ProxyPreferences );

--- a/client/me/app-preferences/release-channel-preferences.jsx
+++ b/client/me/app-preferences/release-channel-preferences.jsx
@@ -1,0 +1,64 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { flow, identity, noop } from 'lodash';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Card from 'components/card';
+import Button from 'components/button';
+import SectionHeader from 'components/section-header';
+import FormSelect from 'components/forms/form-select';
+import FormFieldset from 'components/forms/form-fieldset';
+
+const ReleaseChannelPreferences = ( { isSaving, translate } ) => (
+	<div>
+		<SectionHeader label={ translate( 'Release Channel' ) }>
+			<Button
+				compact
+				primary
+				onClick={ noop }
+				type="submit"
+				disabled={ false }
+			>
+				{ isSaving ? translate( 'Saving…' ) : translate( 'Save Settings' ) }
+			</Button>
+		</SectionHeader>
+		<Card className="app-preferences__writing-preferences">
+			<label>
+				<FormFieldset>
+					<FormSelect id="select">
+						<option>{ translate( 'Stable' ) }</option>
+						<option>{ translate( 'Beta' ) }</option>
+					</FormSelect>
+				</FormFieldset>
+				<p>{ translate( 'Select Stable channel for official, public releases of the app.' ) }</p>
+				<p>{ translate( 'Select Beta channel if you want to get and help test preview releases of the app.' ) }</p>
+			</label>
+		</Card>
+	</div>
+);
+
+ReleaseChannelPreferences.propTypes = {
+	isSaving: PropTypes.bool,
+	translate: PropTypes.func,
+};
+
+ReleaseChannelPreferences.defaultProps = {
+	isSaving: false,
+	translate: identity,
+};
+
+export default flow(
+	localize,
+	connect(
+		() => ( {
+			isSaving: false,
+		} )
+	)
+)( ReleaseChannelPreferences );

--- a/client/me/app-preferences/writing-preferences.jsx
+++ b/client/me/app-preferences/writing-preferences.jsx
@@ -1,0 +1,70 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { flow, identity, noop } from 'lodash';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Card from 'components/card';
+import Button from 'components/button';
+import SectionHeader from 'components/section-header';
+import FormCheckbox from 'components/forms/form-checkbox';
+
+// remove eslint-disable once new css is in place for app-preferences
+/* eslint-disable wpcalypso/jsx-classname-namespace */
+const WritingPreferences = ( { isSaving, isSpellCheckEnabled, translate } ) => (
+	<div>
+		<SectionHeader label={ translate( 'Writing' ) }>
+			<Button
+				compact
+				primary
+				onClick={ noop }
+				data-tip-target="settings-site-profile-save"
+				type="submit"
+				disabled={ false }
+			>
+				{ isSaving ? translate( 'Saving…' ) : translate( 'Save Settings' ) }
+			</Button>
+		</SectionHeader>
+		<Card className="app-writing-preferences">
+			<div className="login__form-remember-me">
+				<label>
+					<FormCheckbox
+						name="enableSpellCheck"
+						checked={ isSpellCheckEnabled }
+						onChange={ noop }
+					/>
+					<p>{ translate( 'Enable spell checking (experimental)' ) }</p>
+					<p>{ translate( 'May effect performance on large posts' ) }</p>
+				</label>
+			</div>
+		</Card>
+	</div>
+);
+
+WritingPreferences.propTypes = {
+	isSaving: PropTypes.bool,
+	isSpellCheckEnabled: PropTypes.bool,
+	translate: PropTypes.func,
+};
+
+WritingPreferences.defaultProps = {
+	isSaving: false,
+	isSpellCheckEnabled: false,
+	translate: identity,
+};
+
+export default flow(
+	localize,
+	connect(
+		() => ( {
+			isSaving: false,
+			isSpellCheckEnabled: false,
+		} )
+	)
+)( WritingPreferences );

--- a/client/me/sidebar/index.jsx
+++ b/client/me/sidebar/index.jsx
@@ -155,12 +155,18 @@ const MeSidebar = React.createClass( {
 							onNavigate={ this.onNavigate }
 							preloadSectionName="notification-settings"
 						/>
-
 					</ul>
 				</SidebarMenu>
 				<SidebarMenu>
 					<SidebarHeading>{ this.translate( 'Special' ) }</SidebarHeading>
 					<ul>
+						<SidebarItem
+							selected={ selected === 'app-preferences' }
+							link={ '/me/app-preferences' }
+							label={ this.translate( 'App Preferences' ) }
+							icon="cog"
+							onNavigate={ this.onNavigate }
+						/>
 						<SidebarItem
 							selected={ selected === 'get-apps' }
 							link={ '/me/get-apps' }

--- a/client/wordpress-com.js
+++ b/client/wordpress-com.js
@@ -393,4 +393,12 @@ sections.push( {
 	isomorphic: false
 } );
 
+sections.push( {
+	name: 'app-preferences',
+	paths: [ '/me/app-preferences' ],
+	module: 'me/app-preferences',
+	group: 'me',
+	secondary: true
+} );
+
 module.exports = sections;


### PR DESCRIPTION
#### _No need to review the code at this stage, high level reviews only please :)_

![app-preferences](https://user-images.githubusercontent.com/4335450/30615091-8bedcc3c-9d42-11e7-96ca-d1361e8a195f.gif)

### Motivation
I recently changed to using the Beta version of the desktop app, in doing so I had to go to the `WordPress.com > preferences` menu and noticed that the menu was sub-par for a number of reasons (design, experience, accessibility, etc.).
Compare this to other modern desktop apps (Spotify being an obvious choice) and it's plain to see that there is room for improvement.
More details can be found here: https://github.com/Automattic/wp-desktop/issues/333

As a bit of side project while AFK I decided to put together a 'prototype' of how this could look and how it could work, this PR is the starting point of the Calypso-side work needed to see a better experience when clicking the 'preferences' item in the desktop app menu.

### Testing

- Open the desktop app as it is and look at the prefences menu (`WordPress.com > preferences`)
- Go to: https://calypso.live/me/app-preferences?branch=try/desktop-improve-app-preferences-experience
- notice that nothing actually works yet!
- Take a look around, do you prefer seeing these options within Calypso's UI?
- Are there improvements to be made? (I'm sure there are!) Let me know.

### Notes

#### Confusing settings?

I think the current options could be a little confusing regardless of whether they appear in the app or a separate menu, but more so when bringing in this set of desktop specific options in to the app UI (versus the seemingly separate 'native' ui that we have currently). 
For instance, we have a menu titled 'notifications', but we also have a sub-section in the app preferences for 'notifications'.
Embarking on the set of changes that I'm proposing might be a good opportunity to solidify this, but how? Do we remove the 'notifications' sub-section in app-preferences and expect folk to navigate to the existing settings page intuitively? Perhaps adding any extra desktop-specific settings to that page conditionally?

#### This PR is far from a complete set of changes

The purpose of this PR is to gather high-level opinions and conversation - it is a long way from being mergeable.

Things that are missing:
- Attention to styling details - some elements might not be spaced properly etc.
- Checking that env is desktop - we wouldn't want to include this menu if it were not applicable, eventually we would be looking to see that the feature-flag is true and that we are building the desktop client.
- State & persistence - currently the options do nothing, once I know that this is something that we agree we should build out I'll hook up the form fields to act as the current menu does, persisting the preferences and putting them in to action.