### PR TITLE
Update unauthorized illustrations

### DIFF
--- a/client/my-sites/people/main.jsx
+++ b/client/my-sites/people/main.jsx
@@ -91,7 +91,7 @@ export const People = React.createClass( { // eslint-disable-line react/prefer-e
 					<SidebarNavigation />
 					<EmptyContent
 						title={ this.translate( 'You are not authorized to view this page' ) }
-						illustration={ '/calypso/images/illustrations/illustration-empty-results.svg' }
+						illustration={ '/calypso/images/illustrations/illustration-404.svg' }
 					/>
 				</Main>
 			);

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -379,7 +379,7 @@ class ActivityLog extends Component {
 					<SidebarNavigation />
 					<EmptyContent
 						title={ translate( 'You are not authorized to view this page' ) }
-						illustration={ '/calypso/images/illustrations/illustration-empty-results.svg' }
+						illustration={ '/calypso/images/illustrations/illustration-404.svg' }
 					/>
 				</Main>
 			);


### PR DESCRIPTION
Update unauthorized illustrations as suggested by @folletto in https://github.com/Automattic/wp-calypso/pull/17804#issuecomment-331145400

The illustrations are updated in two places:
* Activity log `/stats/activity/{site}`
* People `/people/team/{site}`

The AL view was based on the people view originally.

## Testing

The updated views can be found by visiting `/stats/activity/{site}` and `/people/team/{site}` without admin privileges.

## Screens

### Before

![before](https://user-images.githubusercontent.com/841763/30734927-7b14921e-9f7d-11e7-83af-26f88a0c6c68.png)

### After

![after](https://user-images.githubusercontent.com/841763/30734932-7f7f5406-9f7d-11e7-9a23-d5bf72a27bcc.png)
