### PR TITLE
Comments: add chronological sorting for comments list

### DIFF
--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -251,7 +251,10 @@ export class CommentList extends Component {
 	};
 
 	setSortOrder = order => () => {
-		this.setState( { sortOrder: order } );
+		this.setState( {
+			sortOrder: order,
+			page: 1
+		} );
 	};
 
 	showEditNotice = ( commentId, postId, undoCommentData ) => {

--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -5,7 +5,17 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { each, find, get, map, noop, size, slice, uniq } from 'lodash';
+import {
+	each,
+	find,
+	get,
+	map,
+	noop,
+	orderBy,
+	size,
+	slice,
+	uniq
+} from 'lodash';
 import ReactCSSTransitionGroup from 'react-addons-css-transition-group';
 
 /**
@@ -38,7 +48,6 @@ import { isJetpackSite } from 'state/sites/selectors';
 import {
 	COMMENTS_PER_PAGE,
 	NEWEST_FIRST,
-	OLDEST_FIRST,
 } from '../constants';
 
 export class CommentList extends Component {
@@ -106,16 +115,7 @@ export class CommentList extends Component {
 	getComments = () => {
 		const comments = uniq( [ ...this.state.persistedComments, ...this.props.comments ] );
 
-		// While sorting we are relying on the fact that newer comments will have larger ID values.
-		switch ( this.state.sortOrder ) {
-			case NEWEST_FIRST:
-				return comments.sort( ( a, b ) => b - a );
-			case OLDEST_FIRST:
-				return comments.sort( ( a, b ) => a - b );
-			default:
-				// Default to showing newest comments first.
-				return comments.sort( ( a, b ) => b - a );
-		}
+		return orderBy( comments, null, this.state.sortOrder );
 	};
 
 	getCommentsPage = ( comments, page ) => {

--- a/client/my-sites/comments/comment-navigation/index.jsx
+++ b/client/my-sites/comments/comment-navigation/index.jsx
@@ -16,6 +16,10 @@ import ControlItem from 'components/segmented-control/item';
 import Count from 'components/count';
 import CommentNavigationTab from './comment-navigation-tab';
 import FormCheckbox from 'components/forms/form-checkbox';
+import {
+	isJetpackMinimumVersion,
+	isJetpackSite
+} from 'state/sites/selectors';
 import NavItem from 'components/section-nav/item';
 import NavTabs from 'components/section-nav/tabs';
 import Search from 'components/search';
@@ -104,6 +108,7 @@ export class CommentNavigation extends Component {
 			doSearch,
 			hasSearch,
 			isBulkEdit,
+			isCommentsTreeSupported,
 			isSelectedAll,
 			query,
 			selectedCount,
@@ -205,8 +210,8 @@ export class CommentNavigation extends Component {
 					) }
 				</NavTabs>
 
-				{ isEnabled( 'manage/comments/bulk-actions' ) &&
-					<CommentNavigationTab className="comment-navigation__actions comment-navigation__open-bulk">
+				<CommentNavigationTab className="comment-navigation__actions comment-navigation__open-bulk">
+					{ isEnabled( 'comments/management/sorting' ) && isCommentsTreeSupported &&
 						<SegmentedControl compact className="comment-navigation__sort-buttons">
 							<ControlItem
 								onClick={ setSortOrder( NEWEST_FIRST ) }
@@ -227,11 +232,14 @@ export class CommentNavigation extends Component {
 								) }
 							</ControlItem>
 						</SegmentedControl>
+					}
+
+					{ isEnabled( 'manage/comments/bulk-actions' ) &&
 						<Button compact onClick={ toggleBulkEdit }>
 							{ translate( 'Bulk Edit' ) }
 						</Button>
-					</CommentNavigationTab>
-				}
+					}
+				</CommentNavigationTab>
 
 				{ hasSearch &&
 					<Search
@@ -259,7 +267,11 @@ const mapStateToProps = ( state, { commentsPage, siteId } ) => {
 			};
 		}
 	} );
-	return { visibleComments };
+
+	return {
+		visibleComments,
+		isCommentsTreeSupported: ! isJetpackSite( state, siteId ) || isJetpackMinimumVersion( state, siteId, '5.3' ),
+	};
 };
 
 const mapDispatchToProps = {

--- a/client/my-sites/comments/comment-navigation/index.jsx
+++ b/client/my-sites/comments/comment-navigation/index.jsx
@@ -3,6 +3,7 @@
  */
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
+import classNames from 'classnames';
 import Gridicon from 'gridicons';
 import { localize } from 'i18n-calypso';
 import { get, includes, isUndefined, map } from 'lodash';
@@ -27,6 +28,10 @@ import {
 	recordTracksEvent,
 } from 'state/analytics/actions';
 import { getSiteComment } from 'state/selectors';
+import {
+	NEWEST_FIRST,
+	OLDEST_FIRST,
+} from '../constants';
 
 const bulkActions = {
 	unapproved: [ 'approve', 'spam', 'trash' ],
@@ -41,6 +46,7 @@ export class CommentNavigation extends Component {
 		isSelectedAll: false,
 		selectedCount: 0,
 		status: 'unapproved',
+		sortOrder: NEWEST_FIRST,
 	};
 
 	bulkDeletePermanently = () => {
@@ -48,7 +54,7 @@ export class CommentNavigation extends Component {
 		if ( isUndefined( window ) || window.confirm( translate( 'Delete these comments permanently?' ) ) ) {
 			setBulkStatus( 'delete' )();
 		}
-	}
+	};
 
 	changeFilter = status => () => this.props.recordChangeFilter( status );
 
@@ -76,7 +82,7 @@ export class CommentNavigation extends Component {
 		}
 
 		return navItems;
-	}
+	};
 
 	getStatusPath = status => 'unapproved' !== status
 		? `/comments/${ status }/${ this.props.siteFragment }`
@@ -90,7 +96,7 @@ export class CommentNavigation extends Component {
 		}
 
 		return this.props.toggleSelectAll( this.props.visibleComments );
-	}
+	};
 
 	render() {
 		const {
@@ -101,6 +107,8 @@ export class CommentNavigation extends Component {
 			query,
 			selectedCount,
 			setBulkStatus,
+			setSortOrder,
+			sortOrder,
 			status: queryStatus,
 			toggleBulkEdit,
 			translate,
@@ -198,6 +206,34 @@ export class CommentNavigation extends Component {
 
 				{ isEnabled( 'manage/comments/bulk-actions' ) &&
 					<CommentNavigationTab className="comment-navigation__actions comment-navigation__open-bulk">
+						<span className="comment-navigation__sort-buttons">
+							<Button
+								compact
+								onClick={ setSortOrder( NEWEST_FIRST ) }
+								className={ classNames( {
+									'comment-navigation__button-selected': sortOrder === NEWEST_FIRST,
+									first: true
+								} ) }
+							>
+								{ translate(
+									'Newest',
+									{ comment: 'Chronological order for sorting the comments list.' }
+								) }
+							</Button>
+							<Button
+								compact
+								onClick={ setSortOrder( OLDEST_FIRST ) }
+								className={ classNames( {
+									'comment-navigation__button-selected': sortOrder === OLDEST_FIRST,
+									last: true
+								} ) }
+							>
+								{ translate(
+									'Oldest',
+									{ comment: 'Chronological order for sorting the comments list.' }
+								) }
+							</Button>
+						</span>
 						<Button compact onClick={ toggleBulkEdit }>
 							{ translate( 'Bulk Edit' ) }
 						</Button>

--- a/client/my-sites/comments/comment-navigation/index.jsx
+++ b/client/my-sites/comments/comment-navigation/index.jsx
@@ -207,11 +207,7 @@ export class CommentNavigation extends Component {
 
 				{ isEnabled( 'manage/comments/bulk-actions' ) &&
 					<CommentNavigationTab className="comment-navigation__actions comment-navigation__open-bulk">
-						<SegmentedControl
-							primary
-							compact
-							className="comment-navigation__sort-buttons"
-						>
+						<SegmentedControl compact className="comment-navigation__sort-buttons">
 							<ControlItem
 								onClick={ setSortOrder( NEWEST_FIRST ) }
 								selected={ sortOrder === NEWEST_FIRST }

--- a/client/my-sites/comments/comment-navigation/index.jsx
+++ b/client/my-sites/comments/comment-navigation/index.jsx
@@ -3,7 +3,6 @@
  */
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import classNames from 'classnames';
 import Gridicon from 'gridicons';
 import { localize } from 'i18n-calypso';
 import { get, includes, isUndefined, map } from 'lodash';
@@ -13,6 +12,7 @@ import { get, includes, isUndefined, map } from 'lodash';
  */
 import Button from 'components/button';
 import ButtonGroup from 'components/button-group';
+import ControlItem from 'components/segmented-control/item';
 import Count from 'components/count';
 import CommentNavigationTab from './comment-navigation-tab';
 import FormCheckbox from 'components/forms/form-checkbox';
@@ -20,6 +20,7 @@ import NavItem from 'components/section-nav/item';
 import NavTabs from 'components/section-nav/tabs';
 import Search from 'components/search';
 import SectionNav from 'components/section-nav';
+import SegmentedControl from 'components/segmented-control';
 import UrlSearch from 'lib/url-search';
 import { isEnabled } from 'config';
 import {
@@ -206,34 +207,30 @@ export class CommentNavigation extends Component {
 
 				{ isEnabled( 'manage/comments/bulk-actions' ) &&
 					<CommentNavigationTab className="comment-navigation__actions comment-navigation__open-bulk">
-						<span className="comment-navigation__sort-buttons">
-							<Button
-								compact
+						<SegmentedControl
+							primary
+							compact
+							className="comment-navigation__sort-buttons"
+						>
+							<ControlItem
 								onClick={ setSortOrder( NEWEST_FIRST ) }
-								className={ classNames( {
-									'comment-navigation__button-selected': sortOrder === NEWEST_FIRST,
-									first: true
-								} ) }
+								selected={ sortOrder === NEWEST_FIRST }
 							>
 								{ translate(
 									'Newest',
 									{ comment: 'Chronological order for sorting the comments list.' }
 								) }
-							</Button>
-							<Button
-								compact
+							</ControlItem>
+							<ControlItem
 								onClick={ setSortOrder( OLDEST_FIRST ) }
-								className={ classNames( {
-									'comment-navigation__button-selected': sortOrder === OLDEST_FIRST,
-									last: true
-								} ) }
+								selected={ sortOrder === OLDEST_FIRST }
 							>
 								{ translate(
 									'Oldest',
 									{ comment: 'Chronological order for sorting the comments list.' }
 								) }
-							</Button>
-						</span>
+							</ControlItem>
+						</SegmentedControl>
 						<Button compact onClick={ toggleBulkEdit }>
 							{ translate( 'Bulk Edit' ) }
 						</Button>

--- a/client/my-sites/comments/constants.js
+++ b/client/my-sites/comments/constants.js
@@ -2,7 +2,7 @@
 export const COMMENTS_PER_PAGE = 20;
 
 // Allowed values for comments list sort order.
-// Currently these sorting is done by comparing the values of comment IDs,
+// Currently the sorting is done by comparing the values of comment IDs,
 // and relying on the fact that more recent comments have higher ID values.
 export const NEWEST_FIRST = 'desc';
 export const OLDEST_FIRST = 'asc';

--- a/client/my-sites/comments/constants.js
+++ b/client/my-sites/comments/constants.js
@@ -1,0 +1,8 @@
+// Maximum number of comments that will be shown per page.
+export const COMMENTS_PER_PAGE = 20;
+
+// Allowed values for comments list sort order.
+// Currently these sorting is done by comparing the values of comment IDs,
+// and relying on the fact that more recent comments have higher ID values.
+export const NEWEST_FIRST = 'desc';
+export const OLDEST_FIRST = 'asc';

--- a/client/my-sites/comments/style.scss
+++ b/client/my-sites/comments/style.scss
@@ -68,6 +68,25 @@
 	}
 }
 
+.comment-navigation__sort-buttons {
+	margin-right: 32px;
+}
+
+.comment-navigation__sort-buttons .first {
+	border-top-right-radius: 0;
+	border-bottom-right-radius: 0;
+	border-right: 0;
+}
+
+.comment-navigation__sort-buttons .last {
+	border-top-left-radius: 0;
+	border-bottom-left-radius: 0;
+}
+
+.comment-navigation__button-selected {
+	background-color: $gray-light;
+}
+
 .comment-list .pagination {
 	margin-top: 16px;
 }

--- a/client/my-sites/comments/style.scss
+++ b/client/my-sites/comments/style.scss
@@ -69,22 +69,8 @@
 }
 
 .comment-navigation__sort-buttons {
-	margin-right: 32px;
-}
-
-.comment-navigation__sort-buttons .first {
-	border-top-right-radius: 0;
-	border-bottom-right-radius: 0;
-	border-right: 0;
-}
-
-.comment-navigation__sort-buttons .last {
-	border-top-left-radius: 0;
-	border-bottom-left-radius: 0;
-}
-
-.comment-navigation__button-selected {
-	background-color: $gray-light;
+	margin-right: 16px;
+	float: left;
 }
 
 .comment-list .pagination {

--- a/client/my-sites/comments/style.scss
+++ b/client/my-sites/comments/style.scss
@@ -51,11 +51,16 @@
 }
 
 .comment-navigation__actions {
+	display: flex;
 	padding: 11px 16px;
 
 	.button-group {
 		margin-right: 16px;
 	}
+}
+
+.comment-navigation__open-bulk .button {
+	margin-left: 16px;
 }
 
 .comment-navigation__close-bulk {
@@ -66,11 +71,6 @@
 		display: inline-block;
 		padding: 10px 16px;
 	}
-}
-
-.comment-navigation__sort-buttons {
-	margin-right: 16px;
-	float: left;
 }
 
 .comment-list .pagination {

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -18,6 +18,7 @@
 		"code-splitting": false,
 		"comments/management": true,
 		"comments/management/all-list": false,
+		"comments/management/sorting": false,
 		"manage/comments/bulk-actions": false,
 		"desktop": true,
 		"desktop-promo": false,

--- a/config/development.json
+++ b/config/development.json
@@ -43,6 +43,7 @@
 		"comments/management": true,
 		"comments/management/all-list": false,
 		"comments/management/edit": true,
+		"comments/management/sorting": true,
 		"manage/comments/bulk-actions": true,
 		"css-hot-reload": true,
 		"desktop-promo": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -21,6 +21,7 @@
 		"comments/management": true,
 		"comments/management/all-list": false,
 		"comments/management/edit": true,
+		"comments/management/sorting": true,
 		"manage/comments/bulk-actions": true,
 		"devdocs": false,
 		"domains/cctlds": true,

--- a/config/production.json
+++ b/config/production.json
@@ -19,6 +19,7 @@
 		"code-splitting": true,
 		"comments/management": true,
 		"comments/management/all-list": false,
+		"comments/management/sorting": false,
 		"manage/comments/bulk-actions": false,
 		"desktop-promo": true,
 		"domains/cctlds": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -21,6 +21,7 @@
 		"code-splitting": true,
 		"comments/management": true,
 		"comments/management/all-list": false,
+		"comments/management/sorting": false,
 		"manage/comments/bulk-actions": false,
 		"desktop-promo": true,
 		"domains/cctlds": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -20,6 +20,7 @@
 		"comments/management": true,
 		"comments/management/all-list": false,
 		"comments/management/edit": true,
+		"comments/management/sorting": true,
 		"manage/comments/bulk-actions": true,
 		"catch-js-errors": true,
 		"code-splitting": true,


### PR DESCRIPTION
Resolves https://github.com/Automattic/wp-calypso/issues/14118

Adds the ability to chronologically sort the list of comments by selecting
either the 'Newest first' or 'Oldest first' option. The 'Newest first' will be
used as default.

#### Visual changes

![peek 2017-09-22 13-02](https://user-images.githubusercontent.com/1182160/30741802-a37cce88-9f96-11e7-9cd1-2bc1be938c30.gif)

#### Testing instructions

1. Navigate to `comments/approved/{siteUrl}`.
2. Verify that chronological order of comments is respecting the selected setting.
3. Test on sites with a larger number of comments and verify that ordering persists after pagination.
4. After switching sort order the page should reset to first one.
5. Test with Jetpack sites.