### PR TITLE
Reader: handle x-posts with a missing title

### DIFF
--- a/client/reader/stream/x-post.jsx
+++ b/client/reader/stream/x-post.jsx
@@ -149,7 +149,7 @@ class CrossPost extends PureComponent {
 	};
 
 	render() {
-		const { post, postKey, site, feed } = this.props;
+		const { post, postKey, site, feed, translate } = this.props;
 		const { blogId: siteId, feedId } = postKey;
 		const siteIcon = get( site, 'icon.img' );
 		const feedIcon = get( feed, 'image' );
@@ -164,6 +164,10 @@ class CrossPost extends PureComponent {
 		// TODO: maybe add xpost metadata, so we can remove this regex
 		let xpostTitle = post.title;
 		xpostTitle = xpostTitle.replace( /x-post:/i, '' );
+
+		if ( ! xpostTitle ) {
+			xpostTitle = `(${ translate( 'no title' ) })`;
+		}
 
 		return (
 			<Card tagName="article" onClick={ this.handleCardClick } className={ articleClasses }>


### PR DESCRIPTION
When a post without a title is x-posted, we show it in Reader like this:

<img width="816" alt="screen shot 2017-09-22 at 16 14 14" src="https://user-images.githubusercontent.com/17325/30752210-80485398-9fb3-11e7-9048-3a5b708bd995.png">

This PR adds a "(no title)" fallback so there's still a title link available to click in that situation:

<img width="802" alt="screen shot 2017-09-22 at 16 13 56" src="https://user-images.githubusercontent.com/17325/30752235-95717eac-9fb3-11e7-9355-71a28635dba9.png">

### To test

Automattic users can see an example of an x-post with no title in the Automattic stream by adding the query string `?at=2017-09-15T00:00:00`.