### PR TITLE
WooCommerce - fixed shipping labels unit tests

### DIFF
--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/test/actions.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/test/actions.js
@@ -3,6 +3,7 @@
  */
 import { expect } from 'chai';
 import sinon from 'sinon';
+import nock from 'nock';
 
 /**
  * Internal dependencies
@@ -84,6 +85,19 @@ function createGetFormErrorsFn( opts = {} ) {
 
 describe( 'Shipping label Actions', () => {
 	describe( '#openPrintingFlow', () => {
+		nock( 'https://public-api.wordpress.com:443' )
+			.persist()
+			.post( `/rest/v1.1/jetpack-blogs/${ siteId }/rest-api/` )
+			.reply( 200, {
+				data: {
+					status: 200,
+					body: {
+						normalized: true,
+						is_trivial_normalization: true,
+					},
+				},
+			} );
+
 		describe( 'origin validation ignored', () => {
 			const dispatchSpy = sinon.spy();
 
@@ -200,5 +214,7 @@ describe( 'Shipping label Actions', () => {
 				} ) ).to.equal( true );
 			} );
 		} );
+
+		nock.cleanAll();
 	} );
 } );

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/test/actions.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/test/actions.js
@@ -8,14 +8,13 @@ import sinon from 'sinon';
  * Internal dependencies
  */
 import { openPrintingFlow } from '../actions';
+import {
+	WOOCOMMERCE_SERVICES_SHIPPING_LABEL_TOGGLE_STEP,
+	WOOCOMMERCE_SERVICES_SHIPPING_LABEL_OPEN_PRINTING_FLOW,
+ } from '../../action-types';
 
-const context = {
-	storeOptions: {
-		countriesData: {
-			US: '',
-		},
-	},
-};
+const orderId = 1;
+const siteId = 123456;
 
 function createGetStateFn( newProps = { origin: {}, destination: {} } ) {
 	const defaultProps = {
@@ -38,15 +37,25 @@ function createGetStateFn( newProps = { origin: {}, destination: {} } ) {
 
 	return function() {
 		return {
-			shippingLabel: {
-				form: {
-					origin,
-					destination,
-					packages: {
-						selected: {},
-					},
-					rates: {
-						values: {},
+			extensions: {
+				woocommerce: {
+					woocommerceServices: {
+						[ siteId ]: {
+							shippingLabel: {
+								[ orderId ]: {
+									form: {
+										origin,
+										destination,
+										packages: {
+											selected: {},
+										},
+										rates: {
+											values: {},
+										},
+									},
+								},
+							},
+						},
 					},
 				},
 			},
@@ -78,10 +87,9 @@ describe( 'Shipping label Actions', () => {
 		describe( 'origin validation ignored', () => {
 			const dispatchSpy = sinon.spy();
 
-			openPrintingFlow()(
+			openPrintingFlow( orderId, siteId )(
 				dispatchSpy,
 				createGetStateFn( { origin: { ignoreValidation: true } } ),
-				context,
 				createGetFormErrorsFn(
 					{ setOriginError: false, setDestinationError: false }
 				)
@@ -89,19 +97,19 @@ describe( 'Shipping label Actions', () => {
 
 			it( 'toggle origin', () => {
 				expect( dispatchSpy.calledWith( {
-					stepName: 'origin', type: 'TOGGLE_STEP',
+					stepName: 'origin', type: WOOCOMMERCE_SERVICES_SHIPPING_LABEL_TOGGLE_STEP, orderId, siteId,
 				} ) )
 					.to.equal( true );
 			} );
 			it( 'do not toggle destination', () => {
 				expect( dispatchSpy.calledWith( {
-					stepName: 'destination', type: 'TOGGLE_STEP',
+					stepName: 'destination', type: WOOCOMMERCE_SERVICES_SHIPPING_LABEL_TOGGLE_STEP, orderId, siteId,
 				} ) )
 					.to.equal( false );
 			} );
 			it( 'open printing flow', () => {
 				expect( dispatchSpy.calledWith( {
-					type: 'OPEN_PRINTING_FLOW',
+					type: WOOCOMMERCE_SERVICES_SHIPPING_LABEL_OPEN_PRINTING_FLOW, orderId, siteId,
 				} ) )
 					.to.equal( true );
 			} );
@@ -110,10 +118,9 @@ describe( 'Shipping label Actions', () => {
 		describe( 'origin errors exist', () => {
 			const dispatchSpy = sinon.spy();
 
-			openPrintingFlow()(
+			openPrintingFlow( orderId, siteId )(
 				dispatchSpy,
 				createGetStateFn(),
-				context,
 				createGetFormErrorsFn(
 					{ setOriginError: true, setDestinationError: false }
 				)
@@ -121,17 +128,17 @@ describe( 'Shipping label Actions', () => {
 
 			it( 'toggles origin', () => {
 				expect( dispatchSpy.calledWith( {
-					stepName: 'origin', type: 'TOGGLE_STEP',
+					stepName: 'origin', type: WOOCOMMERCE_SERVICES_SHIPPING_LABEL_TOGGLE_STEP, orderId, siteId,
 				} ) ).to.equal( true );
 			} );
 			it( 'do not toggle destination', () => {
 				expect( dispatchSpy.calledWith( {
-					stepName: 'destination', type: 'TOGGLE_STEP',
+					stepName: 'destination', type: WOOCOMMERCE_SERVICES_SHIPPING_LABEL_TOGGLE_STEP, orderId, siteId,
 				} ) ).to.equal( false );
 			} );
 			it( 'open printing flow', () => {
 				expect( dispatchSpy.calledWith( {
-					type: 'OPEN_PRINTING_FLOW',
+					type: WOOCOMMERCE_SERVICES_SHIPPING_LABEL_OPEN_PRINTING_FLOW, orderId, siteId,
 				} ) ).to.equal( true );
 			} );
 		} );
@@ -139,12 +146,11 @@ describe( 'Shipping label Actions', () => {
 		describe( 'destination validation ignored', () => {
 			const dispatchSpy = sinon.spy();
 
-			openPrintingFlow()(
+			openPrintingFlow( orderId, siteId )(
 				dispatchSpy,
 				createGetStateFn( {
 					destination: { ignoreValidation: true },
 				} ),
-				context,
 				createGetFormErrorsFn(
 					{ setOriginError: false, setDestinationError: false }
 				)
@@ -152,17 +158,17 @@ describe( 'Shipping label Actions', () => {
 
 			it( 'toggle destination', () => {
 				expect( dispatchSpy.calledWith( {
-					stepName: 'destination', type: 'TOGGLE_STEP',
+					stepName: 'destination', type: WOOCOMMERCE_SERVICES_SHIPPING_LABEL_TOGGLE_STEP, orderId, siteId,
 				} ) ).to.equal( true );
 			} );
 			it( 'do not toggle origin', () => {
 				expect( dispatchSpy.calledWith( {
-					stepName: 'origin', type: 'TOGGLE_STEP',
+					stepName: 'origin', type: WOOCOMMERCE_SERVICES_SHIPPING_LABEL_TOGGLE_STEP, orderId, siteId,
 				} ) ).to.equal( false );
 			} );
 			it( 'open printing flow', () => {
 				expect( dispatchSpy.calledWith( {
-					type: 'OPEN_PRINTING_FLOW',
+					type: WOOCOMMERCE_SERVICES_SHIPPING_LABEL_OPEN_PRINTING_FLOW, orderId, siteId,
 				} ) ).to.equal( true );
 			} );
 		} );
@@ -170,10 +176,9 @@ describe( 'Shipping label Actions', () => {
 		describe( 'destination errors exist', () => {
 			const dispatchSpy = sinon.spy();
 
-			openPrintingFlow()(
+			openPrintingFlow( orderId, siteId )(
 				dispatchSpy,
 				createGetStateFn(),
-				context,
 				createGetFormErrorsFn(
 					{ setOriginError: false, setDestinationError: true }
 				)
@@ -181,17 +186,17 @@ describe( 'Shipping label Actions', () => {
 
 			it( 'toggle destination', () => {
 				expect( dispatchSpy.calledWith( {
-					stepName: 'destination', type: 'TOGGLE_STEP',
+					stepName: 'destination', type: WOOCOMMERCE_SERVICES_SHIPPING_LABEL_TOGGLE_STEP, orderId, siteId,
 				} ) ).to.equal( true );
 			} );
 			it( 'do not toggle origin', () => {
 				expect( dispatchSpy.calledWith( {
-					stepName: 'origin', type: 'TOGGLE_STEP',
+					stepName: 'origin', type: WOOCOMMERCE_SERVICES_SHIPPING_LABEL_TOGGLE_STEP, orderId, siteId,
 				} ) ).to.equal( false );
 			} );
 			it( 'open printing flow', () => {
 				expect( dispatchSpy.calledWith( {
-					type: 'OPEN_PRINTING_FLOW',
+					type: WOOCOMMERCE_SERVICES_SHIPPING_LABEL_OPEN_PRINTING_FLOW, orderId, siteId,
 				} ) ).to.equal( true );
 			} );
 		} );

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/test/reducer.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/test/reducer.js
@@ -21,48 +21,55 @@ import {
 	removeIgnoreValidation,
 	updateAddressValue,
     clearAvailableRates,
-	PURCHASE_LABEL_RESPONSE,
 } from '../actions';
+import {
+	WOOCOMMERCE_SERVICES_SHIPPING_LABEL_PURCHASE_RESPONSE,
+ } from '../../action-types';
+
+const orderId = 1;
+const siteId = 123456;
 
 const initialState = {
-	form: {
-		origin: {
-			values: { address: 'Some street', postcode: '', state: 'CA', country: 'US' },
-			isNormalized: false,
-			normalized: null,
-			ignoreValidation: { address: true, postcode: true, state: true, country: true },
-		},
-		packages: {
-			all: {
-				customPackage1: {
-					inner_dimensions: '1 x 2 x 3',
-					box_weight: 3.5,
-				},
-				customPackage2: {},
+	[ orderId ]: {
+		form: {
+			origin: {
+				values: { address: 'Some street', postcode: '', state: 'CA', country: 'US' },
+				isNormalized: false,
+				normalized: null,
+				ignoreValidation: { address: true, postcode: true, state: true, country: true },
 			},
-			selected: {
-				weight_0_custom1: {
-					items: [
-						{
-							product_id: 123,
-							weight: 1.2,
-						},
-					],
+			packages: {
+				all: {
+					customPackage1: {
+						inner_dimensions: '1 x 2 x 3',
+						box_weight: 3.5,
+					},
+					customPackage2: {},
 				},
-				weight_1_custom1: {
-					items: [
-						{
-							product_id: 456,
-							weight: 2.3,
-						},
-					],
+				selected: {
+					weight_0_custom1: {
+						items: [
+							{
+								product_id: 123,
+								weight: 1.2,
+							},
+						],
+					},
+					weight_1_custom1: {
+						items: [
+							{
+								product_id: 456,
+								weight: 2.3,
+							},
+						],
+					},
 				},
+				isPacked: true,
 			},
-			isPacked: true,
 		},
+		openedPackageId: 'weight_0_custom1',
+		labels: [],
 	},
-	openedPackageId: 'weight_0_custom1',
-	labels: [],
 };
 
 describe( 'Label purchase form reducer', () => {
@@ -79,59 +86,59 @@ describe( 'Label purchase form reducer', () => {
 	} );
 
 	it( 'MOVE_ITEM moves items between selected packages', () => {
-		const action = moveItem( 'weight_0_custom1', 0, 'weight_1_custom1' );
+		const action = moveItem( orderId, siteId, 'weight_0_custom1', 0, 'weight_1_custom1' );
 		const state = reducer( initialState, action );
 
-		expect( state.form.packages.selected.weight_0_custom1 ).to.eql( undefined );
-		expect( state.form.packages.selected.weight_1_custom1.items.length ).to.eql( 2 );
-		expect( state.form.packages.selected.weight_1_custom1.items )
-			.to.include( initialState.form.packages.selected.weight_0_custom1.items[ 0 ] );
-		expect( state.form.packages.saved ).to.eql( false );
-		expect( state.form.rates.values ).to.include.all.keys( Object.keys( state.form.packages.selected ) );
-		expect( state.form.needsPrintConfirmation ).to.eql( false );
-		expect( state.form.rates.available ).to.eql( {} );
+		expect( state[ orderId ].form.packages.selected.weight_0_custom1 ).to.eql( undefined );
+		expect( state[ orderId ].form.packages.selected.weight_1_custom1.items.length ).to.eql( 2 );
+		expect( state[ orderId ].form.packages.selected.weight_1_custom1.items )
+			.to.include( initialState[ orderId ].form.packages.selected.weight_0_custom1.items[ 0 ] );
+		expect( state[ orderId ].form.packages.saved ).to.eql( false );
+		expect( state[ orderId ].form.rates.values ).to.include.all.keys( Object.keys( state[ orderId ].form.packages.selected ) );
+		expect( state[ orderId ].form.needsPrintConfirmation ).to.eql( false );
+		expect( state[ orderId ].form.rates.available ).to.eql( {} );
 	} );
 
 	it( 'MOVE_ITEM moves items from selected packages to original packaging', () => {
-		const action = moveItem( 'weight_0_custom1', 0, 'individual' );
+		const action = moveItem( orderId, siteId, 'weight_0_custom1', 0, 'individual' );
 		const state = reducer( initialState, action );
 
-		expect( state.form.packages.selected.weight_0_custom1 ).to.eql( undefined );
-		expect( state.form.packages.selected ).to.include.keys( 'client_individual_0' );
-		expect( state.form.packages.selected.client_individual_0.box_id ).to.eql( 'individual' );
-		expect( state.form.packages.selected.client_individual_0.items.length ).to.eql( 1 );
-		expect( state.form.packages.selected.client_individual_0.items )
-			.to.include( initialState.form.packages.selected.weight_0_custom1.items[ 0 ] );
-		expect( state.form.packages.saved ).to.eql( false );
-		expect( state.form.rates.values ).to.include.all.keys( Object.keys( state.form.packages.selected ) );
-		expect( state.form.needsPrintConfirmation ).to.eql( false );
-		expect( state.form.rates.available ).to.eql( {} );
+		expect( state[ orderId ].form.packages.selected.weight_0_custom1 ).to.eql( undefined );
+		expect( state[ orderId ].form.packages.selected ).to.include.keys( 'client_individual_0' );
+		expect( state[ orderId ].form.packages.selected.client_individual_0.box_id ).to.eql( 'individual' );
+		expect( state[ orderId ].form.packages.selected.client_individual_0.items.length ).to.eql( 1 );
+		expect( state[ orderId ].form.packages.selected.client_individual_0.items )
+			.to.include( initialState[ orderId ].form.packages.selected.weight_0_custom1.items[ 0 ] );
+		expect( state[ orderId ].form.packages.saved ).to.eql( false );
+		expect( state[ orderId ].form.rates.values ).to.include.all.keys( Object.keys( state[ orderId ].form.packages.selected ) );
+		expect( state[ orderId ].form.needsPrintConfirmation ).to.eql( false );
+		expect( state[ orderId ].form.rates.available ).to.eql( {} );
 	} );
 
 	it( 'MOVE_ITEM moves items from original packaging to selected packages and deletes original package', () => {
 		const existingState = hoek.clone( initialState );
-		existingState.form.packages.selected.client_individual_0 = {
+		existingState[ orderId ].form.packages.selected.client_individual_0 = {
 			items: [ {
 				product_id: 789,
 			} ],
 			box_id: 'individual',
 		};
-		existingState.openedPackageId = 'client_individual_0';
+		existingState[ orderId ].openedPackageId = 'client_individual_0';
 
-		const action = moveItem( 'client_individual_0', 0, 'weight_0_custom1' );
+		const action = moveItem( orderId, siteId, 'client_individual_0', 0, 'weight_0_custom1' );
 		const state = reducer( existingState, action );
 
-		expect( state.form.packages.selected.weight_0_custom1.items.length ).to.eql( 2 );
-		expect( state.form.packages.selected.weight_0_custom1.items )
-			.to.include( existingState.form.packages.selected.client_individual_0.items[ 0 ] );
-		expect( state.form.packages.saved ).to.eql( false );
-		expect( state.form.needsPrintConfirmation ).to.eql( false );
-		expect( state.form.rates.available ).to.eql( {} );
+		expect( state[ orderId ].form.packages.selected.weight_0_custom1.items.length ).to.eql( 2 );
+		expect( state[ orderId ].form.packages.selected.weight_0_custom1.items )
+			.to.include( existingState[ orderId ].form.packages.selected.client_individual_0.items[ 0 ] );
+		expect( state[ orderId ].form.packages.saved ).to.eql( false );
+		expect( state[ orderId ].form.needsPrintConfirmation ).to.eql( false );
+		expect( state[ orderId ].form.rates.available ).to.eql( {} );
 	} );
 
 	it( 'ADD_ITEMS moves a set of items from their original packaging to selected package', () => {
 		const existingState = hoek.clone( initialState );
-		existingState.form.packages.selected.weight_2_custom1 = {
+		existingState[ orderId ].form.packages.selected.weight_2_custom1 = {
 			items: [
 				{
 					product_id: 789,
@@ -139,174 +146,176 @@ describe( 'Label purchase form reducer', () => {
 				},
 			],
 		};
-		existingState.form.packages.selected.weight_1_custom1.items[ 1 ] = {
+		existingState[ orderId ].form.packages.selected.weight_1_custom1.items[ 1 ] = {
 			product_id: 457,
 			weight: 3.4,
 		};
 
-		let state = reducer( existingState, openAddItem() );
-		expect( state.addedItems ).to.eql( {} );
+		let state = reducer( existingState, openAddItem( orderId, siteId ) );
+		expect( state[ orderId ].addedItems ).to.eql( {} );
 
 		state = [
-			setAddedItem( 'weight_0_custom1', 0, true ),
-			setAddedItem( 'weight_1_custom1', 0, true ),
-			setAddedItem( 'weight_1_custom1', 1, true ),
+			setAddedItem( orderId, siteId, 'weight_0_custom1', 0, true ),
+			setAddedItem( orderId, siteId, 'weight_1_custom1', 0, true ),
+			setAddedItem( orderId, siteId, 'weight_1_custom1', 1, true ),
 		].reduce( reducer, state );
 
-		expect( state.addedItems.weight_0_custom1 ).to.eql( [ 0 ] );
-		expect( state.addedItems.weight_1_custom1 ).to.include( 0 );
-		expect( state.addedItems.weight_1_custom1 ).to.include( 1 );
+		expect( state[ orderId ].addedItems.weight_0_custom1 ).to.eql( [ 0 ] );
+		expect( state[ orderId ].addedItems.weight_1_custom1 ).to.include( 0 );
+		expect( state[ orderId ].addedItems.weight_1_custom1 ).to.include( 1 );
 
-		state = reducer( state, addItems( 'weight_2_custom1' ) );
+		state = reducer( state, addItems( orderId, siteId, 'weight_2_custom1' ) );
 
-		expect( state.form.packages.selected.weight_0_custom1 ).to.not.exist;
-		expect( state.form.packages.selected.weight_1_custom1 ).to.not.exist;
-		expect( state.form.packages.selected.weight_2_custom1.items.length ).to.eql( 4 );
-		expect( state.form.packages.selected.weight_2_custom1.items )
-			.to.include( existingState.form.packages.selected.weight_0_custom1.items[ 0 ] );
-		expect( state.form.packages.selected.weight_2_custom1.items )
-			.to.include( existingState.form.packages.selected.weight_1_custom1.items[ 0 ] );
-		expect( state.form.packages.selected.weight_2_custom1.items )
-			.to.include( existingState.form.packages.selected.weight_1_custom1.items[ 1 ] );
+		expect( state[ orderId ].form.packages.selected.weight_0_custom1 ).to.not.exist;
+		expect( state[ orderId ].form.packages.selected.weight_1_custom1 ).to.not.exist;
+		expect( state[ orderId ].form.packages.selected.weight_2_custom1.items.length ).to.eql( 4 );
+		expect( state[ orderId ].form.packages.selected.weight_2_custom1.items )
+			.to.include( existingState[ orderId ].form.packages.selected.weight_0_custom1.items[ 0 ] );
+		expect( state[ orderId ].form.packages.selected.weight_2_custom1.items )
+			.to.include( existingState[ orderId ].form.packages.selected.weight_1_custom1.items[ 0 ] );
+		expect( state[ orderId ].form.packages.selected.weight_2_custom1.items )
+			.to.include( existingState[ orderId ].form.packages.selected.weight_1_custom1.items[ 1 ] );
 	} );
 
 	it( 'ADD_PACKAGE adds a new package', () => {
-		const action = addPackage();
+		const action = addPackage( orderId, siteId );
 		const state = reducer( initialState, action );
 
-		expect( state.form.packages.selected ).to.include.keys( 'client_custom_0' );
-		expect( state.form.packages.selected.client_custom_0.items.length ).to.eql( 0 );
-		expect( state.form.packages.selected.client_custom_0.box_id ).to.eql( 'not_selected' );
-		expect( state.form.packages.selected.client_custom_0.length ).to.eql( 0 );
-		expect( state.form.packages.selected.client_custom_0.width ).to.eql( 0 );
-		expect( state.form.packages.selected.client_custom_0.height ).to.eql( 0 );
-		expect( state.form.packages.selected.client_custom_0.weight ).to.eql( 0 );
-		expect( state.form.packages.saved ).to.eql( false );
-		expect( state.openedPackageId ).to.eql( 'client_custom_0' );
-		expect( state.form.needsPrintConfirmation ).to.eql( false );
-		expect( state.form.rates.available ).to.eql( {} );
+		expect( state[ orderId ].form.packages.selected ).to.include.keys( 'client_custom_0' );
+		expect( state[ orderId ].form.packages.selected.client_custom_0.items.length ).to.eql( 0 );
+		expect( state[ orderId ].form.packages.selected.client_custom_0.box_id ).to.eql( 'not_selected' );
+		expect( state[ orderId ].form.packages.selected.client_custom_0.length ).to.eql( 0 );
+		expect( state[ orderId ].form.packages.selected.client_custom_0.width ).to.eql( 0 );
+		expect( state[ orderId ].form.packages.selected.client_custom_0.height ).to.eql( 0 );
+		expect( state[ orderId ].form.packages.selected.client_custom_0.weight ).to.eql( 0 );
+		expect( state[ orderId ].form.packages.saved ).to.eql( false );
+		expect( state[ orderId ].openedPackageId ).to.eql( 'client_custom_0' );
+		expect( state[ orderId ].form.needsPrintConfirmation ).to.eql( false );
+		expect( state[ orderId ].form.rates.available ).to.eql( {} );
 	} );
 
 	it( 'REMOVE_PACKAGE removes the package and moves all the items to first package', () => {
-		const action = removePackage( 'weight_0_custom1' );
+		const action = removePackage( orderId, siteId, 'weight_0_custom1' );
 		const state = reducer( initialState, action );
 
-		expect( state.form.packages.selected ).to.not.include.keys( 'weight_0_custom1' );
-		expect( state.form.packages.selected ).to.include.keys( 'weight_1_custom1' );
-		expect( state.form.packages.selected.weight_1_custom1 )
-			.to.include.all.keys( Object.keys( initialState.form.packages.selected.weight_0_custom1 ) );
-		expect( state.form.packages.selected.weight_1_custom1 )
-			.to.include.all.keys( Object.keys( initialState.form.packages.selected.weight_1_custom1 ) );
-		expect( state.form.rates.values ).to.include.all.keys( Object.keys( state.form.packages.selected ) );
-		expect( state.form.packages.saved ).to.eql( false );
-		expect( state.form.needsPrintConfirmation ).to.eql( false );
-		expect( state.form.rates.available ).to.eql( {} );
+		expect( state[ orderId ].form.packages.selected ).to.not.include.keys( 'weight_0_custom1' );
+		expect( state[ orderId ].form.packages.selected ).to.include.keys( 'weight_1_custom1' );
+		expect( state[ orderId ].form.packages.selected.weight_1_custom1 )
+			.to.include.all.keys( Object.keys( initialState[ orderId ].form.packages.selected.weight_0_custom1 ) );
+		expect( state[ orderId ].form.packages.selected.weight_1_custom1 )
+			.to.include.all.keys( Object.keys( initialState[ orderId ].form.packages.selected.weight_1_custom1 ) );
+		expect( state[ orderId ].form.rates.values ).to.include.all.keys( Object.keys( state[ orderId ].form.packages.selected ) );
+		expect( state[ orderId ].form.packages.saved ).to.eql( false );
+		expect( state[ orderId ].form.needsPrintConfirmation ).to.eql( false );
+		expect( state[ orderId ].form.rates.available ).to.eql( {} );
 	} );
 
 	it( 'SET_PACKAGE_TYPE changes an existing package', () => {
-		const action = setPackageType( 'weight_0_custom1', 'customPackage1' );
+		const action = setPackageType( orderId, siteId, 'weight_0_custom1', 'customPackage1' );
 		const state = reducer( initialState, action );
 
-		expect( state.form.packages.selected.weight_0_custom1.items.length ).to.eql( 1 );
-		expect( state.form.packages.selected.weight_0_custom1.box_id ).to.eql( 'customPackage1' );
-		expect( state.form.packages.selected.weight_0_custom1.length ).to.eql( 1 );
-		expect( state.form.packages.selected.weight_0_custom1.width ).to.eql( 2 );
-		expect( state.form.packages.selected.weight_0_custom1.height ).to.eql( 3 );
-		expect( state.form.packages.selected.weight_0_custom1.weight ).to.eql( 4.7 );
-		expect( state.form.packages.saved ).to.eql( false );
-		expect( state.form.rates.values ).to.include.all.keys( Object.keys( state.form.packages.selected ) );
-		expect( state.form.needsPrintConfirmation ).to.eql( false );
-		expect( state.form.rates.available ).to.eql( {} );
+		expect( state[ orderId ].form.packages.selected.weight_0_custom1.items.length ).to.eql( 1 );
+		expect( state[ orderId ].form.packages.selected.weight_0_custom1.box_id ).to.eql( 'customPackage1' );
+		expect( state[ orderId ].form.packages.selected.weight_0_custom1.length ).to.eql( 1 );
+		expect( state[ orderId ].form.packages.selected.weight_0_custom1.width ).to.eql( 2 );
+		expect( state[ orderId ].form.packages.selected.weight_0_custom1.height ).to.eql( 3 );
+		expect( state[ orderId ].form.packages.selected.weight_0_custom1.weight ).to.eql( 4.7 );
+		expect( state[ orderId ].form.packages.saved ).to.eql( false );
+		expect( state[ orderId ].form.rates.values ).to.include.all.keys( Object.keys( state[ orderId ].form.packages.selected ) );
+		expect( state[ orderId ].form.needsPrintConfirmation ).to.eql( false );
+		expect( state[ orderId ].form.rates.available ).to.eql( {} );
 	} );
 
 	it( 'SET_PACKAGE_TYPE maintains user-specified weight after changing an existing package', () => {
-		const priorAction = updatePackageWeight( 'weight_0_custom1', 5.8 );
+		const priorAction = updatePackageWeight( orderId, siteId, 'weight_0_custom1', 5.8 );
 		const existingState = reducer( initialState, priorAction );
 
-		const action = setPackageType( 'weight_0_custom1', 'customPackage1' );
+		const action = setPackageType( orderId, siteId, 'weight_0_custom1', 'customPackage1' );
 		const state = reducer( existingState, action );
 
-		expect( state.form.packages.selected.weight_0_custom1.box_id ).to.eql( 'customPackage1' );
-		expect( state.form.packages.selected.weight_0_custom1.weight ).to.eql( 5.8 );
+		expect( state[ orderId ].form.packages.selected.weight_0_custom1.box_id ).to.eql( 'customPackage1' );
+		expect( state[ orderId ].form.packages.selected.weight_0_custom1.weight ).to.eql( 5.8 );
 	} );
 
 	it( 'SAVE_PACKAGES changes the saved state', () => {
 		const existingState = hoek.clone( initialState );
-		existingState.form.packages.saved = false;
+		existingState[ orderId ].form.packages.saved = false;
 
-		const action = savePackages();
+		const action = savePackages( orderId, siteId );
 		const state = reducer( existingState, action );
 
-		expect( state.form.packages.saved ).to.eql( true );
+		expect( state[ orderId ].form.packages.saved ).to.eql( true );
 	} );
 
 	it( 'REMOVE_IGNORE_VALIDATION removes the ignore validation flags, does not change anything else', () => {
 		const existingState = hoek.clone( initialState );
 
-		const action = removeIgnoreValidation( 'origin' );
+		const action = removeIgnoreValidation( orderId, siteId, 'origin' );
 		const state = reducer( existingState, action );
 
-		expect( state.form.origin.ignoreValidation ).to.be.null;
-		state.form.origin.ignoreValidation = existingState.form.origin.ignoreValidation;
+		expect( state[ orderId ].form.origin.ignoreValidation ).to.be.null;
+		state[ orderId ].form.origin.ignoreValidation = existingState[ orderId ].form.origin.ignoreValidation;
 		expect( state ).to.deep.equal( existingState );
 	} );
 
 	it( 'UPDATE_ADDRESS_VALUE on any field marks the address as not validated', () => {
 		const existingState = hoek.clone( initialState );
-		existingState.form.origin.ignoreValidation = null;
-		existingState.form.origin.isNormalized = true;
-		existingState.form.origin.normalized = { address: 'MAIN ST', postcode: '12345' };
+		existingState[ orderId ].form.origin.ignoreValidation = null;
+		existingState[ orderId ].form.origin.isNormalized = true;
+		existingState[ orderId ].form.origin.normalized = { address: 'MAIN ST', postcode: '12345' };
 
-		const action = updateAddressValue( 'origin', 'address', 'Main Street' );
+		const action = updateAddressValue( orderId, siteId, 'origin', 'address', 'Main Street' );
 		const state = reducer( existingState, action );
 
-		expect( state.form.origin.values.address ).to.equal( 'Main Street' );
-		expect( state.form.origin.isNormalized ).to.be.false;
-		expect( state.form.origin.normalized ).to.be.null;
+		expect( state[ orderId ].form.origin.values.address ).to.equal( 'Main Street' );
+		expect( state[ orderId ].form.origin.isNormalized ).to.be.false;
+		expect( state[ orderId ].form.origin.normalized ).to.be.null;
 	} );
 
 	it( 'UPDATE_ADDRESS_VALUE changing the country restes the state field', () => {
 		const existingState = hoek.clone( initialState );
 
-		const action = updateAddressValue( 'origin', 'country', 'ES' );
+		const action = updateAddressValue( orderId, siteId, 'origin', 'country', 'ES' );
 		const state = reducer( existingState, action );
 
-		expect( state.form.origin.values.country ).to.equal( 'ES' );
-		expect( state.form.origin.values.state ).to.equal( '' );
+		expect( state[ orderId ].form.origin.values.country ).to.equal( 'ES' );
+		expect( state[ orderId ].form.origin.values.state ).to.equal( '' );
 	} );
 
 	it( 'UPDATE_ADDRESS_VALUE removed the "ignore validation" flag on that field', () => {
 		const existingState = hoek.clone( initialState );
 
-		const action = updateAddressValue( 'origin', 'address', 'Main Street' );
+		const action = updateAddressValue( orderId, siteId, 'origin', 'address', 'Main Street' );
 		const state = reducer( existingState, action );
 
-		expect( state.form.origin.ignoreValidation.address ).to.be.false;
-		expect( state.form.origin.ignoreValidation.postcode ).to.be.true;
+		expect( state[ orderId ].form.origin.ignoreValidation.address ).to.be.false;
+		expect( state[ orderId ].form.origin.ignoreValidation.postcode ).to.be.true;
 	} );
 
 	it( 'CLEAR_AVAILABLE_RATES clears the available rates and resets the print confirmation', () => {
 		const existingState = hoek.clone( initialState );
 
-		const action = clearAvailableRates();
+		const action = clearAvailableRates( orderId, siteId );
 		const state = reducer( existingState, action );
 
-		expect( state.form.rates.available ).to.eql( {} );
-		expect( state.form.needsPrintConfirmation ).to.eql( false );
+		expect( state[ orderId ].form.rates.available ).to.eql( {} );
+		expect( state[ orderId ].form.needsPrintConfirmation ).to.eql( false );
 	} );
 
 	it( 'PURCHASE_LABEL_RESPONSE handles errors', () => {
 		const action = {
-			type: PURCHASE_LABEL_RESPONSE,
+			type: WOOCOMMERCE_SERVICES_SHIPPING_LABEL_PURCHASE_RESPONSE,
 			response: null,
 			error: 'there was an error',
+			siteId,
+			orderId,
 		};
 		const state = reducer( initialState, action );
 
 		// In an error condition, the form is marked as "not submitting"
 		// and the label data should remain unchanged
-		expect( state.form.isSubmitting ).to.equal( false );
-		expect( initialState.labels ).to.deep.equal( state.labels );
+		expect( state[ orderId ].form.isSubmitting ).to.equal( false );
+		expect( initialState[ orderId ].labels ).to.deep.equal( state[ orderId ].labels );
 	} );
 
 	it( 'PURCHASE_LABEL_RESPONSE handles success', () => {
@@ -321,20 +330,22 @@ describe( 'Label purchase form reducer', () => {
 			product_names: [ 'Dark Matter' ],
 		};
 		const action = {
-			type: PURCHASE_LABEL_RESPONSE,
+			type: WOOCOMMERCE_SERVICES_SHIPPING_LABEL_PURCHASE_RESPONSE,
 			response: [ label ],
 			error: null,
+			siteId,
+			orderId,
 		};
 		const state = reducer( initialState, action );
 
 		// All labels in response should be in state, marked as "updated"
-		expect( state.labels ).to.deep.equal( [ { ...label, statusUpdated: true } ] );
+		expect( state[ orderId ].labels ).to.deep.equal( [ { ...label, statusUpdated: true } ] );
 	} );
 
 	it( 'Maintains fixed precision upon adjusting total weight', () => {
 		const existingState = hoek.clone( initialState );
-		existingState.form.packages.all.customPackage1.box_weight = 1.33;
-		existingState.form.packages.selected.weight_0_custom1 = {
+		existingState[ orderId ].form.packages.all.customPackage1.box_weight = 1.33;
+		existingState[ orderId ].form.packages.selected.weight_0_custom1 = {
 			items: [
 				{
 					product_id: 123,
@@ -347,7 +358,7 @@ describe( 'Label purchase form reducer', () => {
 			],
 			weight: 3.3,
 		};
-		existingState.form.packages.selected.weight_1_custom1 = {
+		existingState[ orderId ].form.packages.selected.weight_1_custom1 = {
 			items: [
 				{
 					product_id: 456,
@@ -357,15 +368,15 @@ describe( 'Label purchase form reducer', () => {
 			weight: 1.44,
 		};
 
-		const action = moveItem( 'weight_0_custom1', 0, 'weight_1_custom1' );
+		const action = moveItem( orderId, siteId, 'weight_0_custom1', 0, 'weight_1_custom1' );
 		let state = reducer( existingState, action );
 
-		expect( state.form.packages.selected.weight_0_custom1.weight ).to.eql( 0.3 );
-		expect( state.form.packages.selected.weight_1_custom1.weight ).to.eql( 4.44 );
+		expect( state[ orderId ].form.packages.selected.weight_0_custom1.weight ).to.eql( 0.3 );
+		expect( state[ orderId ].form.packages.selected.weight_1_custom1.weight ).to.eql( 4.44 );
 
-		const packageTypeAction = setPackageType( 'weight_0_custom1', 'customPackage1' );
+		const packageTypeAction = setPackageType( orderId, siteId, 'weight_0_custom1', 'customPackage1' );
 		state = reducer( state, packageTypeAction );
 
-		expect( state.form.packages.selected.weight_0_custom1.weight ).to.eql( 1.63 );
+		expect( state[ orderId ].form.packages.selected.weight_0_custom1.weight ).to.eql( 1.63 );
 	} );
 } );

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/test/list.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/test/list.js
@@ -10,8 +10,8 @@ import { noop } from 'lodash';
  * Internal dependencies
  */
 import ShippingRates from '../list';
-import Dropdown from 'components/dropdown';
-import FieldError from 'components/field-error';
+import Dropdown from 'woocommerce/woocommerce-services/components/dropdown';
+import FieldError from 'woocommerce/woocommerce-services/components/field-error';
 
 /*
  * Useful data for testing
@@ -200,7 +200,7 @@ describe( '<ShippingRates />', () => {
 				availableRates={ {} }
 			/>
 		);
-		expect( wrapper.exists() ).to.equal( true );
+		expect( wrapper ).to.have.length( 1 );
 	} );
 
 	describe( 'Individual package', () => {


### PR DESCRIPTION
Fixes the unit tests. No changes were required to the unit tests logic or the objects under test, so that's good news :)

Also fixed the `actions.js` tests to not send HTTP requests