### PR TITLE
Reader: fix position of visit link icon

### DIFF
--- a/client/blocks/reader-combined-card/style.scss
+++ b/client/blocks/reader-combined-card/style.scss
@@ -116,10 +116,10 @@
 		&::before {
 			content: '';
 			position: absolute;
-			top: -2px;
-			bottom: 2px;
-			left: -8px;
-			width: 2px;
+				top: -2px;
+				bottom: 2px;
+				left: -8px;
+				width: 2px;
 			background: $blue-wordpress;
 
 			@include breakpoint( '>660px' ) {
@@ -223,7 +223,7 @@
 	margin-top: 4px;
 	white-space: nowrap;
 
-	&:not(.is-placeholder)::after {
+	&:not( .is-placeholder )::after {
 		@include long-content-fade( $size: 10% );
 	}
 }
@@ -243,7 +243,7 @@
 
 // Override standard .card styles in stream
 .reader-combined-card.card {
-	border-bottom: 1px solid lighten($gray, 20%);
+	border-bottom: 1px solid lighten( $gray, 20% );
 	box-shadow: none;
 	margin: 0 15px;
 	padding: 18px 0 0;
@@ -262,8 +262,8 @@
 	float: right;
 	padding: 0;
 	position: absolute;
-	right: 0;
-	top: 13px;
+		right: 0;
+		top: 13px;
 
 	.gridicon {
 		fill: $blue-medium;

--- a/client/blocks/reader-combined-card/style.scss
+++ b/client/blocks/reader-combined-card/style.scss
@@ -1,4 +1,3 @@
-/** @format */
 /* Header */
 .reader-combined-card__header {
 	font-size: 13px;

--- a/client/blocks/reader-combined-card/style.scss
+++ b/client/blocks/reader-combined-card/style.scss
@@ -180,7 +180,7 @@
 	position: relative;
 	margin-top: 3px;
 
-	&:not(.is-placeholder)::after {
+	&:not( .is-placeholder )::after {
 		@include long-content-fade( $size: 20% );
 	}
 }

--- a/client/blocks/reader-combined-card/style.scss
+++ b/client/blocks/reader-combined-card/style.scss
@@ -1,3 +1,4 @@
+/** @format */
 /* Header */
 .reader-combined-card__header {
 	font-size: 13px;
@@ -115,13 +116,13 @@
 		&::before {
 			content: '';
 			position: absolute;
-				top: -2px;
-				bottom: 2px;
-				left: -8px;
-				width: 2px;
+			top: -2px;
+			bottom: 2px;
+			left: -8px;
+			width: 2px;
 			background: $blue-wordpress;
 
-			@include breakpoint( ">660px" ) {
+			@include breakpoint( '>660px' ) {
 				left: -16px;
 			}
 		}
@@ -180,17 +181,17 @@
 	position: relative;
 	margin-top: 3px;
 
-	&:not( .is-placeholder )::after {
+	&:not(.is-placeholder)::after {
 		@include long-content-fade( $size: 20% );
 	}
 }
 
 .reader-combined-card .reader-visit-link {
-	margin-left: -9px; // override gridicon margin
+	margin-left: 0;
 	margin-right: 26px;
 
 	.reader-visit-link__label {
-		margin-left: 4px;
+		margin-left: -4px;
 	}
 }
 
@@ -222,7 +223,7 @@
 	margin-top: 4px;
 	white-space: nowrap;
 
-	&:not( .is-placeholder )::after {
+	&:not(.is-placeholder)::after {
 		@include long-content-fade( $size: 10% );
 	}
 }
@@ -242,27 +243,27 @@
 
 // Override standard .card styles in stream
 .reader-combined-card.card {
-	border-bottom: 1px solid lighten( $gray, 20% );
+	border-bottom: 1px solid lighten($gray, 20%);
 	box-shadow: none;
 	margin: 0 15px;
 	padding: 18px 0 0;
 	position: relative;
 
-	@include breakpoint( ">660px" ) {
+	@include breakpoint( '>660px' ) {
 		margin: 0;
 	}
 }
 
 // Follow button for stream cards - copied and pasted from reader-post-card.
-// TODO: consolidate somewhere. preferabley reader/follow-button
+// TODO: consolidate somewhere. preferably reader/follow-button
 .reader-combined-card__header .follow-button {
 	border: 0;
 	border-radius: 0;
 	float: right;
 	padding: 0;
 	position: absolute;
-		right: 0;
-		top: 13px;
+	right: 0;
+	top: 13px;
 
 	.gridicon {
 		fill: $blue-medium;
@@ -273,7 +274,6 @@
 	}
 
 	&.is-following {
-
 		.gridicon {
 			fill: $alert-green;
 		}
@@ -291,7 +291,7 @@
 		margin-bottom: 3px;
 
 		.follow-button__label {
-			@include breakpoint( "<660px" ) {
+			@include breakpoint( '<660px' ) {
 				display: inline;
 			}
 		}

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -1,36 +1,34 @@
+/** @format */
 // Custom breakpoints needed to match original design
 
-$reader-post-card-breakpoint-xxlarge: "( min-width: 1100px )";
-$reader-post-card-breakpoint-xlarge: "( min-width: 1040px )";
-$reader-post-card-breakpoint-large: "( min-width: 961px ) and ( max-width: 1040px )";
-$reader-post-card-breakpoint-medium: "( min-width: 661px ) and ( max-width: 940px )";
-$reader-post-card-breakpoint-small: "( max-width: 550px )";
+$reader-post-card-breakpoint-xxlarge: '( min-width: 1100px )';
+$reader-post-card-breakpoint-xlarge: '( min-width: 1040px )';
+$reader-post-card-breakpoint-large: '( min-width: 961px ) and ( max-width: 1040px )';
+$reader-post-card-breakpoint-medium: '( min-width: 661px ) and ( max-width: 940px )';
+$reader-post-card-breakpoint-small: '( max-width: 550px )';
 
 // Adds a top border to first card in the Site Stream
 .is-reader-page .is-site-stream .reader-post-card.card {
-
 	&:nth-child(2) {
-		border-top: 1px solid lighten( $gray, 20% );
+		border-top: 1px solid lighten($gray, 20%);
 	}
 }
 
 // Removes top border from first card in Discover Stream
 .is-reader-page .is-discover-stream.is-site-stream .reader-post-card.card {
-
 	&:nth-child(2) {
 		border-top: 0;
 	}
 }
 
 .reader-post-card.card {
-
-	border-bottom: 1px solid lighten( $gray, 20% );
+	border-bottom: 1px solid lighten($gray, 20%);
 	box-shadow: none;
 	margin: 0 15px;
 	padding: 18px 0 20px;
 	position: relative;
 
-	@include breakpoint( ">660px" ) {
+	@include breakpoint( '>660px' ) {
 		margin: 0;
 	}
 
@@ -38,20 +36,19 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 		&::before {
 			content: '';
 			position: absolute;
-				top: 0;
-				bottom: 0;
-				left: -8px;
-				width: 2px;
+			top: 0;
+			bottom: 0;
+			left: -8px;
+			width: 2px;
 			background: $blue-wordpress;
 
-			@include breakpoint( ">660px" ) {
+			@include breakpoint( '>660px' ) {
 				left: -16px;
 			}
 		}
 	}
 
 	&.has-thumbnail {
-
 		.reader-featured-image {
 			flex-basis: auto;
 			flex-grow: 1;
@@ -59,7 +56,7 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 			max-width: 190px;
 			box-sizing: border-box;
 
-			@include breakpoint( ">960px" ) {
+			@include breakpoint( '>960px' ) {
 				max-width: 250px;
 			}
 
@@ -79,7 +76,6 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 		}
 
 		&.is-photo {
-
 			.reader-post-card__post {
 				flex-direction: column;
 			}
@@ -99,13 +95,13 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 				color: $white;
 				font-family: $sans;
 				position: relative;
-					bottom: 30px;
-					left: 20px;
+				bottom: 30px;
+				left: 20px;
 				text-shadow: 0 1px rgba(0, 0, 0, 0.3);
-				width: calc( 100% - 44px );
+				width: calc(100% - 44px);
 				text-overflow: ellipsis;
 				overflow: hidden;
-				z-index: z-index( 'root', '.reader-post-card__title' );
+				z-index: z-index('root', '.reader-post-card__title');
 				margin-bottom: -15px; // relative elements need a negative margin so they don't create bottom padding
 				height: 19px;
 				white-space: nowrap;
@@ -130,7 +126,6 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 
 	&.has-thumbnail,
 	&.is-gallery {
-
 		.reader-post-card__post {
 			margin-top: 18px;
 		}
@@ -158,7 +153,6 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 
 	&.is-gallery,
 	&.is-photo {
-
 		.reader-post-card__post {
 			margin-top: 16px;
 		}
@@ -169,12 +163,11 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 	}
 
 	&.is-compact {
-
 		.reader-post-card__byline-details {
 			display: flex;
 			flex-direction: row;
 			max-height: 16px * 1.4;
-			max-width: calc( 100% - 40px );
+			max-width: calc(100% - 40px);
 			overflow: hidden;
 			position: relative;
 
@@ -192,14 +185,13 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 			margin-top: 0;
 			margin-left: 0;
 
-			@include breakpoint( ">480px" ) {
+			@include breakpoint( '>480px' ) {
 				margin-left: 5px;
 			}
 		}
 
 		.reader-post-card__byline-author-site,
 		.reader-post-card__timestamp-and-tag {
-
 			&::after {
 				display: none;
 			}
@@ -211,8 +203,8 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 
 		.reader-post-options-menu {
 			position: absolute;
-				right: 14px;
-				top: 0;
+			right: 14px;
+			top: 0;
 		}
 
 		.reader-featured-image {
@@ -226,7 +218,7 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 		.reader-post-card__post {
 			margin-top: 0;
 
-			@include breakpoint( "<960px" ) {
+			@include breakpoint( '<960px' ) {
 				flex-direction: row;
 			}
 		}
@@ -248,7 +240,7 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 }
 
 .reader-post-card__photo {
-	border: 1px solid lighten( $gray, 20% );
+	border: 1px solid lighten($gray, 20%);
 	display: flex;
 	align-items: center;
 	justify-content: center;
@@ -257,7 +249,7 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 	margin-right: 20px;
 	cursor: pointer;
 	position: relative;
-		top: 0;
+	top: 0;
 	height: 225px;
 	margin-right: 0;
 	margin-bottom: 0;
@@ -280,12 +272,17 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 
 	&::before {
 		content: '';
-		background: linear-gradient( to bottom, rgba( 0, 0, 0, 0 ) 0%, rgba( 0, 0, 0, 0.37 ) 65%, rgba( 0, 0, 0, 1 ) 110% );
+		background: linear-gradient(
+			to bottom,
+			rgba(0, 0, 0, 0) 0%,
+			rgba(0, 0, 0, 0.37) 65%,
+			rgba(0, 0, 0, 1) 110%
+		);
 		height: 80px;
-		opacity: .4;
+		opacity: 0.4;
 		position: absolute;
-			bottom: 0;
-			left: 0;
+		bottom: 0;
+		left: 0;
 		width: 100%;
 	}
 }
@@ -301,8 +298,7 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 
 // Need .reader__content to override .reader__content a
 .reader__content .reader-post-card__timestamp-link,
-.reader__content .reader-post-card__tag-link
-{
+.reader__content .reader-post-card__tag-link {
 	color: $gray;
 	margin-top: 2px;
 	cursor: pointer;
@@ -328,14 +324,14 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 	overflow: hidden;
 	position: relative;
 	height: 20px;
-	width: calc( 100% - 25px );
+	width: calc(100% - 25px);
 
 	&::after {
 		@include long-content-fade( $size: 10% );
 	}
 
-	@include breakpoint( ">660px" ) {
-		width: calc( 100% - 90px );
+	@include breakpoint( '>660px' ) {
+		width: calc(100% - 90px);
 	}
 }
 
@@ -359,9 +355,9 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 	margin-left: 10px;
 	overflow: hidden;
 	position: relative;
-	width: calc( 100% - 140px );
+	width: calc(100% - 140px);
 
-	@include breakpoint( "<480px" ) {
+	@include breakpoint( '<480px' ) {
 		max-width: 500px;
 	}
 
@@ -375,7 +371,7 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 	margin-right: 3px;
 
 	&::after {
-		content: ', '
+		content: ', ';
 	}
 
 	&:last-child:after {
@@ -391,7 +387,6 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 }
 
 .reader-post-card__byline .reader-avatar {
-
 	flex-shrink: 0;
 
 	&.has-gravatar {
@@ -486,7 +481,7 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 		color: $gray-dark;
 	}
 
-	@include breakpoint( ">480px" ) {
+	@include breakpoint( '>480px' ) {
 		font-size: 19px;
 	}
 }
@@ -506,14 +501,12 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 
 // If it's not a discover card, clamp lines
 .reader-post-card.card:not(.is-discover) {
-
 	.reader-excerpt {
 		overflow: hidden;
 		max-height: 15px * 1.6 * 3.2;
 
-
 		// Clamp to 2 lines on wider viewports
-		@include breakpoint( ">960px" ) {
+		@include breakpoint( '>960px' ) {
 			max-height: 15px * 1.6 * 2;
 		}
 
@@ -524,7 +517,7 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 		}
 	}
 
-	.reader-excerpt[direction=rtl] {
+	.reader-excerpt[direction='rtl'] {
 		&::before {
 			@include long-content-fade( $direction: left, $size: 15px * 1.6 * 5 );
 			top: inherit;
@@ -532,7 +525,7 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 		}
 	}
 
-	.reader-excerpt[direction=ltr] {
+	.reader-excerpt[direction='ltr'] {
 		&::before {
 			@include long-content-fade( $direction: right, $size: 15px * 1.6 * 5 );
 			top: inherit;
@@ -543,7 +536,6 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 
 // 3 line excerpt for thumbnail cards
 .reader-post-card.card.has-thumbnail:not(.is-gallery):not(.is-discover):not(.is-compact) {
-
 	.reader-excerpt {
 		max-height: 15px * 1.6 * 3.2;
 		overflow: hidden;
@@ -556,16 +548,15 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 	height: 22px;
 
 	&.reader-post-actions__visit {
-
 		.gridicon {
 			position: relative;
-				left: -8px;
-				top: -1px;
+			left: -2px;
+			top: -1px;
 		}
 	}
 
 	.gridicons-external {
-		margin-right: -2px;
+		margin-right: 2px;
 	}
 
 	.reader-share__button .gridicon {
@@ -593,7 +584,7 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 	.reader-share_button .gridicon {
 		position: relative;
 
-		@include breakpoint( ">960px" ) {
+		@include breakpoint( '>960px' ) {
 			top: 1px;
 		}
 
@@ -605,7 +596,7 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 			top: 1px;
 		}
 
-		@include breakpoint( "<660px" ) {
+		@include breakpoint( '<660px' ) {
 			top: 1px;
 		}
 	}
@@ -613,8 +604,7 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 	.reader-share__button-label,
 	.comment-button__label-status,
 	.like-button__label-status {
-
-		@include breakpoint( ">960px" ) {
+		@include breakpoint( '>960px' ) {
 			display: none;
 		}
 
@@ -622,7 +612,7 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 			display: inline;
 		}
 
-		@include breakpoint( "<660px" ) {
+		@include breakpoint( '<660px' ) {
 			display: none;
 		}
 	}
@@ -640,8 +630,8 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 	float: right;
 	padding: 0;
 	position: absolute;
-		right: 0;
-		top: 16px;
+	right: 0;
+	top: 16px;
 
 	.gridicon {
 		fill: $blue-medium;
@@ -652,7 +642,6 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 	}
 
 	&.is-following {
-
 		.gridicon {
 			fill: $alert-green;
 		}
@@ -670,7 +659,7 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 		margin-bottom: 3px;
 
 		.follow-button__label {
-			@include breakpoint( "<660px" ) {
+			@include breakpoint( '<660px' ) {
 				display: inline;
 			}
 		}
@@ -679,9 +668,7 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 
 // If chat window is open
 .is-group-reader.has-chat {
-
 	@media #{$reader-post-card-breakpoint-xlarge} {
-
 		.reader-post-card__post {
 			flex-direction: column;
 		}
@@ -706,17 +693,17 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 	margin: 0 0 17px;
 	padding: 0;
 
-	@media #{$reader-post-card-breakpoint-medium}  {
+	@media #{$reader-post-card-breakpoint-medium} {
 		margin: 0 0 10px;
 	}
 
-	@media #{$reader-post-card-breakpoint-small}  {
+	@media #{$reader-post-card-breakpoint-small} {
 		margin: 0 0 10px;
 	}
 }
 
 .reader-post-card__gallery-item {
-	border: 1px solid lighten( $gray, 30% );
+	border: 1px solid lighten($gray, 30%);
 	cursor: pointer;
 	flex: 1;
 	list-style-type: none;
@@ -727,15 +714,13 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 	}
 
 	&:last-child {
-
 		@media #{$reader-post-card-breakpoint-medium} {
 			display: none;
 		}
 	}
 
-	&:nth-last-of-type(-n+2) {
-
-		@include breakpoint( "<480px" ) {
+	&:nth-last-of-type(-n + 2) {
+		@include breakpoint( '<480px' ) {
 			display: none;
 		}
 	}
@@ -756,7 +741,7 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 .reader-post-card__gallery-image {
 	height: 100px;
 
-	@include breakpoint( ">960px" ) {
+	@include breakpoint( '>960px' ) {
 		height: 130px;
 	}
 }

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -1,4 +1,3 @@
-/** @format */
 // Custom breakpoints needed to match original design
 
 $reader-post-card-breakpoint-xxlarge: '( min-width: 1100px )';

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -9,7 +9,7 @@ $reader-post-card-breakpoint-small: '( max-width: 550px )';
 // Adds a top border to first card in the Site Stream
 .is-reader-page .is-site-stream .reader-post-card.card {
 	&:nth-child(2) {
-		border-top: 1px solid lighten($gray, 20%);
+		border-top: 1px solid lighten( $gray, 20% );
 	}
 }
 
@@ -21,7 +21,7 @@ $reader-post-card-breakpoint-small: '( max-width: 550px )';
 }
 
 .reader-post-card.card {
-	border-bottom: 1px solid lighten($gray, 20%);
+	border-bottom: 1px solid lighten( $gray, 20% );
 	box-shadow: none;
 	margin: 0 15px;
 	padding: 18px 0 20px;
@@ -202,8 +202,8 @@ $reader-post-card-breakpoint-small: '( max-width: 550px )';
 
 		.reader-post-options-menu {
 			position: absolute;
-			right: 14px;
-			top: 0;
+				right: 14px;
+				top: 0;
 		}
 
 		.reader-featured-image {
@@ -239,7 +239,7 @@ $reader-post-card-breakpoint-small: '( max-width: 550px )';
 }
 
 .reader-post-card__photo {
-	border: 1px solid lighten($gray, 20%);
+	border: 1px solid lighten( $gray, 20% );
 	display: flex;
 	align-items: center;
 	justify-content: center;
@@ -629,8 +629,8 @@ $reader-post-card-breakpoint-small: '( max-width: 550px )';
 	float: right;
 	padding: 0;
 	position: absolute;
-	right: 0;
-	top: 16px;
+		right: 0;
+		top: 16px;
 
 	.gridicon {
 		fill: $blue-medium;
@@ -702,7 +702,7 @@ $reader-post-card-breakpoint-small: '( max-width: 550px )';
 }
 
 .reader-post-card__gallery-item {
-	border: 1px solid lighten($gray, 30%);
+	border: 1px solid lighten( $gray, 30% );
 	cursor: pointer;
 	flex: 1;
 	list-style-type: none;

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -36,10 +36,10 @@ $reader-post-card-breakpoint-small: '( max-width: 550px )';
 		&::before {
 			content: '';
 			position: absolute;
-			top: 0;
-			bottom: 0;
-			left: -8px;
-			width: 2px;
+				top: 0;
+				bottom: 0;
+				left: -8px;
+				width: 2px;
 			background: $blue-wordpress;
 
 			@include breakpoint( '>660px' ) {
@@ -95,13 +95,13 @@ $reader-post-card-breakpoint-small: '( max-width: 550px )';
 				color: $white;
 				font-family: $sans;
 				position: relative;
-				bottom: 30px;
-				left: 20px;
+					bottom: 30px;
+					left: 20px;
 				text-shadow: 0 1px rgba(0, 0, 0, 0.3);
-				width: calc(100% - 44px);
+				width: calc( 100% - 44px );
 				text-overflow: ellipsis;
 				overflow: hidden;
-				z-index: z-index('root', '.reader-post-card__title');
+				z-index: z-index( 'root', '.reader-post-card__title' );
 				margin-bottom: -15px; // relative elements need a negative margin so they don't create bottom padding
 				height: 19px;
 				white-space: nowrap;
@@ -167,7 +167,7 @@ $reader-post-card-breakpoint-small: '( max-width: 550px )';
 			display: flex;
 			flex-direction: row;
 			max-height: 16px * 1.4;
-			max-width: calc(100% - 40px);
+			max-width: calc( 100% - 40px );
 			overflow: hidden;
 			position: relative;
 
@@ -249,7 +249,7 @@ $reader-post-card-breakpoint-small: '( max-width: 550px )';
 	margin-right: 20px;
 	cursor: pointer;
 	position: relative;
-	top: 0;
+		top: 0;
 	height: 225px;
 	margin-right: 0;
 	margin-bottom: 0;
@@ -281,8 +281,8 @@ $reader-post-card-breakpoint-small: '( max-width: 550px )';
 		height: 80px;
 		opacity: 0.4;
 		position: absolute;
-		bottom: 0;
-		left: 0;
+			bottom: 0;
+			left: 0;
 		width: 100%;
 	}
 }
@@ -324,14 +324,14 @@ $reader-post-card-breakpoint-small: '( max-width: 550px )';
 	overflow: hidden;
 	position: relative;
 	height: 20px;
-	width: calc(100% - 25px);
+	width: calc( 100% - 25px );
 
 	&::after {
 		@include long-content-fade( $size: 10% );
 	}
 
 	@include breakpoint( '>660px' ) {
-		width: calc(100% - 90px);
+		width: calc( 100% - 90px );
 	}
 }
 
@@ -355,7 +355,7 @@ $reader-post-card-breakpoint-small: '( max-width: 550px )';
 	margin-left: 10px;
 	overflow: hidden;
 	position: relative;
-	width: calc(100% - 140px);
+	width: calc( 100% - 140px );
 
 	@include breakpoint( '<480px' ) {
 		max-width: 500px;
@@ -517,7 +517,7 @@ $reader-post-card-breakpoint-small: '( max-width: 550px )';
 		}
 	}
 
-	.reader-excerpt[direction='rtl'] {
+	.reader-excerpt[direction=rtl] {
 		&::before {
 			@include long-content-fade( $direction: left, $size: 15px * 1.6 * 5 );
 			top: inherit;
@@ -525,7 +525,7 @@ $reader-post-card-breakpoint-small: '( max-width: 550px )';
 		}
 	}
 
-	.reader-excerpt[direction='ltr'] {
+	.reader-excerpt[direction=ltr] {
 		&::before {
 			@include long-content-fade( $direction: right, $size: 15px * 1.6 * 5 );
 			top: inherit;
@@ -550,8 +550,8 @@ $reader-post-card-breakpoint-small: '( max-width: 550px )';
 	&.reader-post-actions__visit {
 		.gridicon {
 			position: relative;
-			left: -2px;
-			top: -1px;
+				left: -2px;
+				top: -1px;
 		}
 	}
 


### PR DESCRIPTION
We have a regression on Reader posts cards (both combined cards and regular post cards) meaning that the visit link icon displays in the wrong position (see https://github.com/Automattic/wp-calypso/issues/18143).

Before:

<img width="320" alt="30658904-17208b42-9df1-11e7-9db5-952fc0253c6a" src="https://user-images.githubusercontent.com/17325/30756435-9e6ba366-9fc2-11e7-8c7c-d6f66c17d763.png">

After:

<img width="348" alt="screen shot 2017-09-22 at 18 47 53" src="https://user-images.githubusercontent.com/17325/30757441-ab914876-9fc6-11e7-93cc-80130f944f66.png">
<img width="420" alt="screen shot 2017-09-22 at 18 47 57" src="https://user-images.githubusercontent.com/17325/30757440-ab8fa160-9fc6-11e7-9e16-167174647a15.png">
