### PR TITLE
Store: Add selectors for getting data related to editing/adding review replies

### DIFF
--- a/client/extensions/woocommerce/state/ui/reducer.js
+++ b/client/extensions/woocommerce/state/ui/reducer.js
@@ -6,6 +6,7 @@ import payments from './payments/reducer';
 import products from './products/reducer';
 import productCategories from './product-categories/reducer';
 import reviews from './reviews/reducer';
+import reviewReplies from './review-replies/reducer';
 import shipping from './shipping/reducer';
 import { combineReducers } from 'state/utils';
 
@@ -15,5 +16,6 @@ export default combineReducers( {
 	products,
 	productCategories,
 	reviews,
+	reviewReplies,
 	shipping,
 } );

--- a/client/extensions/woocommerce/state/ui/review-replies/README.md
+++ b/client/extensions/woocommerce/state/ui/review-replies/README.md
@@ -32,3 +32,24 @@ This is saved on a per-site basis.
 	}
 }
 ```
+## Selectors
+
+### `getCurrentlyEditingReviewReplyId( state, [siteId] )`
+
+Gets the ID of the review reply, or object placeholder (if a new reply). Defaults to null, if no reply is being edited.
+
+### `getCurrentlyEditingReviewId( state, [siteId] )`
+
+Gets The ID of the review that a reply edit is associated with.
+
+### `getReviewReplyEdits( state, [siteId] )`
+
+Gets the local edits made to the reply. Defaults to {} if no reply is being edited.
+
+### `getReviewReplyWithEdits( state, [siteId] )`
+
+Merges the existing reply with the local changes, or just the "changes" if a new reply.
+
+### `isCurrentlyEditingReviewReply( state, [siteId] )`
+
+Whether the given site (or current site) has changes pending.

--- a/client/extensions/woocommerce/state/ui/review-replies/selectors.js
+++ b/client/extensions/woocommerce/state/ui/review-replies/selectors.js
@@ -1,0 +1,68 @@
+/**
+ * External dependencies
+ */
+import { get, isObject, merge } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { getReviewReply } from 'woocommerce/state/sites/review-replies/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
+
+/**
+ * @param {Object} state Whole Redux state tree
+ * @param {Number} [siteId] Site ID to check. If not provided, the Site ID selected in the UI will be used
+ * @return {Number|Object} The ID of the review reply (or object placeholder, if a new reply)
+ */
+export const getCurrentlyEditingReviewReplyId = ( state, siteId = getSelectedSiteId( state ) ) => {
+	return get( state, [ 'extensions', 'woocommerce', 'ui', 'reviewReplies', siteId, 'edits', 'currentlyEditingId' ], null );
+};
+
+/**
+ * @param {Object} state Whole Redux state tree
+ * @param {Number} [siteId] Site ID to check. If not provided, the Site ID selected in the UI will be used
+ * @return {Number|Object} The ID of the review that a reply edit is associated with.
+ */
+export const getCurrentlyEditingReviewId = ( state, siteId = getSelectedSiteId( state ) ) => {
+	return get( state, [ 'extensions', 'woocommerce', 'ui', 'reviewReplies', siteId, 'edits', 'reviewId' ], null );
+};
+
+/**
+ * @param {Object} state Whole Redux state tree
+ * @param {Number} [siteId] Site ID to check. If not provided, the Site ID selected in the UI will be used
+ * @return {Object} The local edits made to the reply.
+ */
+export const getReviewReplyEdits = ( state, siteId = getSelectedSiteId( state ) ) => {
+	return get( state, [ 'extensions', 'woocommerce', 'ui', 'reviewReplies', siteId, 'edits', 'changes' ], {} );
+};
+
+/**
+ * @param {Object} state Whole Redux state tree
+ * @param {Number} [siteId] Site ID to check. If not provided, the Site ID selected in the UI will be used
+ * @return {Object} The reply merged with changes, or just the changes if a new reply
+ */
+export const getReviewReplyWithEdits = ( state, siteId = getSelectedSiteId( state ) ) => {
+	const reviewId = getCurrentlyEditingReviewId( state, siteId );
+	const replyId = getCurrentlyEditingReviewReplyId( state, siteId );
+	const reviewEdits = getReviewReplyEdits( state, siteId );
+
+	if ( isObject( replyId ) ) {
+		return { ...reviewEdits, id: replyId, parent: reviewId };
+	}
+
+	const review = getReviewReply( state, reviewId, replyId, siteId );
+	if ( ! review ) {
+		return reviewEdits;
+	}
+
+	return merge( {}, review, reviewEdits );
+};
+
+/**
+ * @param {Object} state Whole Redux state tree
+ * @param {Number} [siteId] Site ID to check. If not provided, the Site ID selected in the UI will be used
+ * @return {Boolean} True if there is a reply ID tracked as "editing"
+ */
+export const isCurrentlyEditingReviewReply = ( state, siteId = getSelectedSiteId( state ) ) => {
+	return !! getCurrentlyEditingReviewReplyId( state, siteId );
+};

--- a/client/extensions/woocommerce/state/ui/review-replies/test/selectors.js
+++ b/client/extensions/woocommerce/state/ui/review-replies/test/selectors.js
@@ -1,0 +1,173 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import {
+	getCurrentlyEditingReviewReplyId,
+	getCurrentlyEditingReviewId,
+	getReviewReplyEdits,
+	getReviewReplyWithEdits,
+	isCurrentlyEditingReviewReply,
+} from '../selectors';
+
+import reviewReplies from 'woocommerce/state/sites/review-replies/test/fixtures/review-replies';
+
+const preInitializedState = {
+	extensions: {
+		woocommerce: {},
+	},
+};
+
+const state = {
+	ui: { selectedSiteId: 123 },
+	extensions: {
+		woocommerce: {
+			sites: {
+				123: {
+					reviewReplies: {
+						555: reviewReplies,
+					}
+				},
+			},
+			ui: {
+				reviewReplies: {
+					123: {
+						edits: {
+							currentlyEditingId: 556,
+							reviewId: 555,
+							changes: {
+								content: 'Hello world.'
+							},
+						},
+					},
+					321: {
+						edits: {
+							currentlyEditingId: { placeholder: 'review_reply_1' },
+							reviewId: 402,
+							changes: {
+								content: 'Testing'
+							},
+						},
+					},
+					111: {
+						edits: {},
+					},
+				}
+			}
+		},
+	},
+};
+
+describe( 'selectors', () => {
+	describe( '#getCurrentlyEditingReviewReplyId', () => {
+		it( 'should be null (default) when woocommerce state is not available', () => {
+			expect( getCurrentlyEditingReviewReplyId( preInitializedState, 123 ) ).to.be.null;
+		} );
+
+		it( 'should get the correct ID when a reply is being edited', () => {
+			expect( getCurrentlyEditingReviewReplyId( state, 123 ) ).to.eql( 556 );
+		} );
+
+		it( 'should get the correct ID when a new reply is being created', () => {
+			expect( getCurrentlyEditingReviewReplyId( state, 321 ) ).to.eql( { placeholder: 'review_reply_1' } );
+		} );
+
+		it( 'should be null when no replies are being edited', () => {
+			expect( getCurrentlyEditingReviewReplyId( state, 111 ) ).to.be.null;
+		} );
+
+		it( 'should get the siteId from the UI tree if not provided', () => {
+			expect( getCurrentlyEditingReviewReplyId( state ) ).to.eql( 556 );
+		} );
+	} );
+
+	describe( '#getCurrentlyEditingReviewId', () => {
+		it( 'should be null (default) when woocommerce state is not available', () => {
+			expect( getCurrentlyEditingReviewId( preInitializedState, 123 ) ).to.be.null;
+		} );
+
+		it( 'should get the correct ID when a reply is being edited', () => {
+			expect( getCurrentlyEditingReviewId( state, 123 ) ).to.eql( 555 );
+		} );
+
+		it( 'should get the correct ID when a new reply is being created', () => {
+			expect( getCurrentlyEditingReviewId( state, 321 ) ).to.eql( 402 );
+		} );
+
+		it( 'should be null when no replies are being edited', () => {
+			expect( getCurrentlyEditingReviewId( state, 111 ) ).to.be.null;
+		} );
+
+		it( 'should get the siteId from the UI tree if not provided', () => {
+			expect( getCurrentlyEditingReviewId( state ) ).to.eql( 555 );
+		} );
+	} );
+
+	describe( '#getReviewReplyEdits', () => {
+		it( 'should be an empty object (default) when woocommerce state is not available', () => {
+			expect( getReviewReplyEdits( preInitializedState, 123 ) ).to.eql( {} );
+		} );
+
+		it( 'should get the changes when a reply is being edited', () => {
+			expect( getReviewReplyEdits( state, 123 ) ).to.eql( { content: 'Hello world.' } );
+		} );
+
+		it( 'should get the new content when a new reply is being created', () => {
+			expect( getReviewReplyEdits( state, 321 ) ).to.eql( { content: 'Testing' } );
+		} );
+
+		it( 'should be empty object when no replies are being edited', () => {
+			expect( getReviewReplyEdits( state, 111 ) ).to.eql( {} );
+		} );
+
+		it( 'should get the siteId from the UI tree if not provided', () => {
+			expect( getReviewReplyEdits( state ) ).to.eql( { content: 'Hello world.' } );
+		} );
+	} );
+
+	describe( '#getReviewReplyWithEdits', () => {
+		it( 'should be an empy object when woocommerce state is not available', () => {
+			expect( getReviewReplyWithEdits( preInitializedState, 123 ) ).to.eql( {} );
+		} );
+
+		it( 'should merge the edited changes into the existing reply', () => {
+			const review = reviewReplies[ 0 ];
+			const mergedReview = { ...review, content: 'Hello world.' };
+			expect( getReviewReplyWithEdits( state, 123 ) ).to.eql( mergedReview );
+		} );
+
+		it( 'should return just the changes for a new reply', () => {
+			expect( getReviewReplyWithEdits( state, 321 ) ).to.eql( {
+				content: 'Testing',
+				id: { placeholder: 'review_reply_1' },
+				parent: 402
+			} );
+		} );
+	} );
+
+	describe( '#isCurrentlyEditingReviewReply', () => {
+		it( 'should be false (default) when woocommerce state is not available', () => {
+			expect( isCurrentlyEditingReviewReply( preInitializedState, 123 ) ).to.be.false;
+		} );
+
+		it( 'should be true when a reply is being edited', () => {
+			expect( isCurrentlyEditingReviewReply( state, 123 ) ).to.be.true;
+		} );
+
+		it( 'should be true when a new reply is being created', () => {
+			expect( isCurrentlyEditingReviewReply( state, 321 ) ).to.be.true;
+		} );
+
+		it( 'should be false when no replies are being edited', () => {
+			expect( isCurrentlyEditingReviewReply( state, 111 ) ).to.be.false;
+		} );
+
+		it( 'should get the siteId from the UI tree if not provided', () => {
+			expect( isCurrentlyEditingReviewReply( state ) ).to.be.true;
+		} );
+	} );
+} );


### PR DESCRIPTION
Depends on #18189.

This PR adds selectors for getting information about review reply edits stored in UI state.

To Test:
* Run `npm run test-client client/extensions/woocommerce/state` and make sure all tests pass.