### PR TITLE
Editor: Try scrolling to content on preview (simple approach)

### DIFF
--- a/client/components/web-preview/content.jsx
+++ b/client/components/web-preview/content.jsx
@@ -179,10 +179,16 @@ export class WebPreviewContent extends PureComponent {
 				? iframeUrl
 				: addQueryArgs( { calypso_token: this.previewId }, iframeUrl );
 			this.iframe.contentWindow.location.replace( newUrl );
-			this.setState( {
-				loaded: false,
-				iframeUrl: iframeUrl,
-			} );
+
+			this.setState( { iframeUrl } );
+
+			const isHashChangeOnly = (
+				iframeUrl.replace( /#.*$/, '' ) ===
+				this.state.iframeUrl.replace( /#.*$/, '' )
+			);
+			if ( ! isHashChangeOnly ) {
+				this.setState( { loaded: false } );
+			}
 		} catch ( e ) {}
 	}
 

--- a/client/post-editor/editor-preview/index.jsx
+++ b/client/post-editor/editor-preview/index.jsx
@@ -48,6 +48,13 @@ const EditorPreview = React.createClass( {
 		) ) {
 			this.setState( { iframeUrl: this.getIframePreviewUrl() } );
 		}
+
+		if (
+			this.state.iframeUrl !== 'about:blank' &&
+			prevProps.showPreview !== this.props.showPreview
+		) {
+			this.setState( { iframeUrl: this.getIframePreviewUrl() } );
+		}
 	},
 
 	componentWillUnmount() {
@@ -84,11 +91,21 @@ const EditorPreview = React.createClass( {
 		parsed.query.preview = 'true';
 		parsed.query.iframe = 'true';
 		parsed.query.revision = String( this.props.revision );
+		// Scroll to the main post content.
 		if (
 			this.props.postId &&
 			isEnabled( 'post-editor/preview-scroll-to-content' )
 		) {
-			parsed.hash = 'post-' + this.props.postId;
+			// Vary the URL hash based on whether the preview is shown.  When
+			// the preview is hidden then re-shown, we want to be sure to
+			// scroll to the content section again even if the preview has not
+			// reloaded in the meantime, which is most easily accomplished by
+			// changing the URL hash.  This does not cause a page reload.
+			if ( this.props.showPreview ) {
+				parsed.hash = 'post-' + this.props.postId;
+			} else {
+				parsed.hash = '__preview-hidden';
+			}
 		}
 		delete parsed.search;
 		return url.format( parsed );

--- a/client/post-editor/editor-preview/index.jsx
+++ b/client/post-editor/editor-preview/index.jsx
@@ -44,15 +44,9 @@ const EditorPreview = React.createClass( {
 		if ( this.props.previewUrl && (
 			this.didFinishSaving( prevProps ) ||
 			this.didLoad( prevProps ) ||
-			this.didShowSavedPreviewViaTouch( prevProps )
+			this.didShowSavedPreviewViaTouch( prevProps ) ||
+			this.didShowOrHideFullPreview( prevProps )
 		) ) {
-			this.setState( { iframeUrl: this.getIframePreviewUrl() } );
-		}
-
-		if (
-			this.state.iframeUrl !== 'about:blank' &&
-			prevProps.showPreview !== this.props.showPreview
-		) {
 			this.setState( { iframeUrl: this.getIframePreviewUrl() } );
 		}
 	},
@@ -84,6 +78,17 @@ const EditorPreview = React.createClass( {
 			this.props.showPreview &&
 			! this.props.isSaving &&
 			! this.props.isLoading;
+	},
+
+	didShowOrHideFullPreview( prevProps ) {
+		// Force a URL update (hash change) when the preview is shown or
+		// hidden, but only if we are currently showing the actual preview URL
+		// and not 'about:blank'.
+		return (
+			isEnabled( 'post-editor/preview-scroll-to-content' ) &&
+			this.state.iframeUrl !== 'about:blank' &&
+			prevProps.showPreview !== this.props.showPreview
+		);
 	},
 
 	getIframePreviewUrl() {

--- a/client/post-editor/editor-preview/index.jsx
+++ b/client/post-editor/editor-preview/index.jsx
@@ -12,6 +12,7 @@ import { localize } from 'i18n-calypso';
 import { omitUrlParams } from 'lib/url';
 import WebPreview from 'components/web-preview';
 import WebPreviewContent from 'components/web-preview/content';
+import { isEnabled } from 'config';
 
 const EditorPreview = React.createClass( {
 
@@ -83,6 +84,12 @@ const EditorPreview = React.createClass( {
 		parsed.query.preview = 'true';
 		parsed.query.iframe = 'true';
 		parsed.query.revision = String( this.props.revision );
+		if (
+			this.props.postId &&
+			isEnabled( 'post-editor/preview-scroll-to-content' )
+		) {
+			parsed.hash = 'post-' + this.props.postId;
+		}
 		delete parsed.search;
 		return url.format( parsed );
 	},

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -464,6 +464,7 @@ export const PostEditor = React.createClass( {
 							isLoading={ this.state.isLoading }
 							isFullScreen={ this.state.isPostPublishPreview }
 							previewUrl={ this.getPreviewUrl() }
+							postId={ this.props.postId }
 							externalUrl={ this.getExternalUrl() }
 							editUrl={ this.props.editPath }
 							defaultViewportDevice={ this.state.isPostPublishPreview ? 'computer' : 'tablet' }

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -90,6 +90,7 @@
 		"plans/jetpack-config-v2": true,
 		"post-editor/html-toolbar": true,
 		"post-editor/image-editor": true,
+		"post-editor/preview-scroll-to-content": true,
 		"post-editor/revisions": true,
 		"press-this": true,
 		"preview-layout": true,


### PR DESCRIPTION
This PR is an initial attempt at making the editor preview scroll to the content of the post being edited:

![2017-09-22t16 08 41-0500](https://user-images.githubusercontent.com/227022/30764756-45b287b0-9fa1-11e7-9fdb-dec87cc07573.png)

Unfortunately, WordPress does not really provide a clean way to do this.  The best we can do for a first attempt is to pick an element with an `id` attribute and scroll to it using a URL hash.  The `article` element containing the post content provides the most appropriate element ID.  (Example:  https://testpreviewscroll.wordpress.com/2017/09/22/test-scrolling-to-content-in-preview/#post-18)

Several complications are immediately apparent:

- Many themes provide page borders or other content near the top of the page, like Twenty Sixteen in use on the above test site or the custom theme in use on https://en.blog.wordpress.com/.  Simply scrolling to an element will cause part of that element to be hidden behind these borders.
- Themes vary widely in their handling of featured images.  Sometimes the featured image will be displayed immediately after the post title; sometimes (as on https://en.blog.wordpress.com/) it will be displayed as the header image on the page.  Scrolling to the page content will show the featured image in some cases and hide it in other cases.  If we attempt to scroll *past* the featured image, this will hide the post title, which also seems undesirable.
- As noted in the above image, a more sophisticated solution will require the same changes to be made to Jetpack sites, and we'll need to make sure that any communication with a Jetpack site's preview page works well under browsers' cross-domain security restrictions.

So, any further change will take some time to plan and implement, and needs to be tested against a wide variety of sites/themes with different handling of featured images and other characteristics.

### To test

In local development or on calypso.live, you'll need to append `?flags=post-editor/preview-scroll-to-content` to the URL.  Verify that when previewing a post in the editor, the preview attempts to scroll to the post content instead of showing the top of the page.

Note that if you scroll in the preview, close the preview, then reopen it again without making any changes, the preview does not scroll back to the content.  This is because the preview page is not reloaded.  This would probably be pretty easy to fix in this PR.

After this PR is merged, this feature will be enabled in the wpcalypso environment.  There it will be easier to test in a variety of situations.