### PR TITLE
Jetpack Thank You Card: Fix Jetpack version check comparison and error detection

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/jetpack-thank-you-card.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/jetpack-thank-you-card.jsx
@@ -642,7 +642,7 @@ class JetpackThankYouCard extends Component {
 					<a
 						className={ classNames( 'button', 'thank-you-card__button', { 'is-placeholder': ! buttonUrl } ) }
 						href={ buttonUrl }>
-						{ translate( 'Visit Your Site' ) }
+						{ translate( 'Visit your site' ) }
 					</a>
 					{ this.renderLiveChatButton() }
 				</div>

--- a/client/my-sites/checkout/checkout-thank-you/jetpack-thank-you-card.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/jetpack-thank-you-card.jsx
@@ -353,7 +353,7 @@ class JetpackThankYouCard extends Component {
 		if ( reasons && reasons.length > 0 ) {
 			reason = translate( 'We can\'t modify files on your site.' );
 			this.trackConfigFinished( 'calypso_plans_autoconfig_error_filemod', { error: reason } );
-		} else if ( ! selectedSite.hasMinimumJetpackVersion ) {
+		} else if ( selectedSite.hasMinimumJetpackVersion === false ) {
 			reason = translate(
 				'We are unable to set up your plan because your site has an older version of Jetpack. ' +
 				'Please upgrade Jetpack.'

--- a/client/my-sites/checkout/checkout-thank-you/jetpack-thank-you-card.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/jetpack-thank-you-card.jsx
@@ -291,7 +291,9 @@ class JetpackThankYouCard extends Component {
 	isErrored() {
 		const { selectedSite, plugins } = this.props;
 		return ( selectedSite && ! selectedSite.canUpdateFiles ) ||
-			some( plugins, ( plugin ) => plugin.hasOwnProperty( 'error' ) && plugin.error );
+			some( plugins, ( plugin ) =>
+				plugin.hasOwnProperty( 'error' ) && plugin.error && plugin.satus !== 'done'
+		);
 	}
 
 	renderFeatures() {


### PR DESCRIPTION
#### Changes introduced in this PR

* Verifies that we have a version before comparing it to the minimum Jetpack version required
* FIxes case in "Visit your site" button.
* Makes the `isErrored()` method return true for plugins that falied only when their status is not `'done'`.

#### Testing instructions

1. Go to the staging environment for Calypso
1. Disconnect your site
1. Reconnect
1. Acquire a paid plan.
1. Expect to see the new Thank You Page card