### PR TITLE
Simple Payments: Add a "learn more" button to the upgrade modal

### DIFF
--- a/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
@@ -449,6 +449,14 @@ class SimplePaymentsDialog extends Component {
 							shouldDisplay={ this.returnTrue }
 						/>
 					}
+					secondaryAction={
+						<a
+							className="empty-content__action button"
+							href="https://support.wordpress.com/simple-payments/"
+						>
+							{ this.props.translate( 'Learn more about Simple Payments' ) }
+						</a>
+					}
 				/>,
 				true
 			);

--- a/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
@@ -454,7 +454,7 @@ class SimplePaymentsDialog extends Component {
 							className="empty-content__action button"
 							href="https://support.wordpress.com/simple-payments/"
 						>
-							{ this.props.translate( 'Learn more about Simple Payments' ) }
+							{ translate( 'Learn more about Simple Payments' ) }
 						</a>
 					}
 				/>,

--- a/client/components/tinymce/plugins/simple-payments/style.scss
+++ b/client/components/tinymce/plugins/simple-payments/style.scss
@@ -69,14 +69,17 @@
 		min-height: 0;
 	}
 
+	.empty-content.has-title-only .empty-content__title {
+		margin-bottom: 16px;
+	}
+
 	.upgrade-nudge.card.editor-simple-payments-modal__nudge-nudge {
 		flex-shrink: 0;
-		margin: 0;
 		text-align: left;
+	}
 
-		@include breakpoint( ">480px" ) {
-			width: 70%;
-		}
+	.empty-content__action {
+		margin-top: 16px;
 	}
 
 	.upgrade-jetpack {


### PR DESCRIPTION
This PR intends to add a "learn more" secondary button that takes you to the support doc for the free and the personal plan sites.

<img width="978" alt="screen shot 2017-09-23 at 17 03 05" src="https://user-images.githubusercontent.com/908665/30774871-5d56aa78-a081-11e7-8523-518e46d79140.png">


