### PR TITLE
Localize: Apply to media-modal/gallery/remove-button

### DIFF
--- a/client/post-editor/media-modal/gallery/remove-button.jsx
+++ b/client/post-editor/media-modal/gallery/remove-button.jsx
@@ -1,10 +1,12 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import React from 'react';
 import PureRenderMixin from 'react-pure-render/mixin';
 import { reject } from 'lodash';
 import Gridicon from 'gridicons';
+import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies
@@ -12,7 +14,7 @@ import Gridicon from 'gridicons';
 import MediaActions from 'lib/media/actions';
 import MediaLibrarySelectedStore from 'lib/media/library-selected-store';
 
-export default React.createClass( {
+const RemoveButton = React.createClass( {
 	displayName: 'EditorMediaModalGalleryRemoveButton',
 
 	mixins: [ PureRenderMixin ],
@@ -35,14 +37,18 @@ export default React.createClass( {
 	},
 
 	render() {
+		const { translate } = this.props;
+		
 		return (
 			<button
 				onClick={ this.remove }
 				onMouseDown={ ( event ) => event.stopPropagation() }
 				className="editor-media-modal-gallery__remove">
-				<span className="screen-reader-text">{ this.translate( 'Remove' ) }</span>
+				<span className="screen-reader-text">{ translate( 'Remove' ) }</span>
 				<Gridicon icon="cross" />
 			</button>
 		);
 	}
 } );
+
+export default localize( RemoveButton );

--- a/client/post-editor/media-modal/gallery/remove-button.jsx
+++ b/client/post-editor/media-modal/gallery/remove-button.jsx
@@ -1,8 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
-import PureRenderMixin from 'react-pure-render/mixin';
+import React, { PureComponent } from 'react';
 import { reject } from 'lodash';
 import Gridicon from 'gridicons';
 import { localize } from 'i18n-calypso';
@@ -14,17 +13,16 @@ import PropTypes from 'prop-types';
 import MediaActions from 'lib/media/actions';
 import MediaLibrarySelectedStore from 'lib/media/library-selected-store';
 
-const RemoveButton = React.createClass( {
-	displayName: 'EditorMediaModalGalleryRemoveButton',
+/* eslint-disable wpcalypso/jsx-classname-namespace */
 
-	mixins: [ PureRenderMixin ],
+class RemoveButton extends PureComponent {
 
-	propTypes: {
+	static propTypes = {
 		siteId: PropTypes.number,
 		itemId: PropTypes.number
-	},
+	};
 
-	remove() {
+	remove = () => {
 		const { siteId, itemId } = this.props;
 		if ( ! siteId || ! itemId ) {
 			return;
@@ -34,21 +32,24 @@ const RemoveButton = React.createClass( {
 		const items = reject( selected, ( item ) => item.ID === itemId );
 
 		MediaActions.setLibrarySelectedItems( siteId, items );
-	},
+	};
 
 	render() {
 		const { translate } = this.props;
-		
+
 		return (
 			<button
 				onClick={ this.remove }
 				onMouseDown={ ( event ) => event.stopPropagation() }
-				className="editor-media-modal-gallery__remove">
+				className="editor-media-modal-gallery__remove"
+			>
 				<span className="screen-reader-text">{ translate( 'Remove' ) }</span>
 				<Gridicon icon="cross" />
 			</button>
 		);
 	}
-} );
+}
+
+RemoveButton.displayName = 'RemoveButton';
 
 export default localize( RemoveButton );


### PR DESCRIPTION
Part of a batch of refactors with the ultimate goal of getting rid of `this.translate`.

To pass the linter I've had to do some fairly heavy refactoring, so please be vigilant when reviewing

### Testing
- Go to a new or existing blog post
- [Create a gallery](https://en.support.wordpress.com/gallery/) by selecting 2 or more images and hitting continue
- Go to the 'edit' view of the gallery
- Look for the 'remove' buttons, they appear as <kbd>X</kbd> in the corner of each image like so:
  
<img width="303" alt="screen shot 2017-09-24 at 02 47 23" src="https://user-images.githubusercontent.com/4335450/30781400-2361bfa4-a0d3-11e7-92eb-8f0789594c3e.png">

- Click one, this should remove the image as expected.