### PR TITLE
Localize: apply to media-modal/gallery/caption

### DIFF
--- a/client/post-editor/media-modal/gallery/caption.jsx
+++ b/client/post-editor/media-modal/gallery/caption.jsx
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import React, { Component } from 'react';
+import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies
@@ -9,19 +11,18 @@ import React, { PropTypes } from 'react';
 import MediaActions from 'lib/media/actions';
 import FormTextInput from 'components/forms/form-text-input';
 
-export default React.createClass( {
-	displayName: 'EditorMediaModalGalleryCaption',
+/* eslint-disable wpcalypso/jsx-classname-namespace */
 
-	propTypes: {
+class EditorMediaModalGalleryCaption extends Component {
+
+	static propTypes = {
 		siteId: PropTypes.number,
-		item: PropTypes.object
-	},
+		item: PropTypes.object,
+	};
 
-	getInitialState() {
-		return {
-			caption: null
-		};
-	},
+	state = {
+		caption: null,
+	};
 
 	getValue() {
 		if ( null !== this.state.caption ) {
@@ -31,15 +32,14 @@ export default React.createClass( {
 		if ( this.props.item ) {
 			return this.props.item.caption;
 		}
-	},
+	}
 
-	setCaption( event ) {
+	setCaption = ( event ) =>
 		this.setState( {
 			caption: event.target.value
 		} );
-	},
 
-	saveCaption() {
+	saveCaption = () => {
 		const { siteId, item } = this.props;
 		if ( ! siteId || ! item ) {
 			return;
@@ -52,17 +52,24 @@ export default React.createClass( {
 		}
 
 		MediaActions.update( siteId, Object.assign( {}, item, { caption } ) );
-	},
+	}
 
 	render() {
+		const { translate } = this.props;
+
 		return (
 			<FormTextInput
 				value={ this.getValue() }
-				placeholder={ this.translate( 'Caption this image…' ) }
+				placeholder={ translate( 'Caption this image…' ) }
 				onChange={ this.setCaption }
 				onBlur={ this.saveCaption }
 				onMouseDown={ ( event ) => event.stopPropagation() }
-				className="editor-media-modal-gallery__caption" />
+				className="editor-media-modal-gallery__caption"
+			/>
 		);
 	}
-} );
+}
+
+EditorMediaModalGalleryCaption.displayName = 'EditorMediaModalGalleryCaption';
+
+export default localize( EditorMediaModalGalleryCaption );


### PR DESCRIPTION
Part of a batch of refactors with the ultimate goal of getting rid of `this.translate`.

To pass the linter I've had to do some fairly heavy refactoring, so please be vigilant when reviewing

### Testing
- Go to a new or existing blog post
- [Create a gallery](https://en.support.wordpress.com/gallery/) by selecting 2 or more images and hitting continue
- Go to the 'edit' view of the gallery
- Below each image you should see an input.
  
<img width="303" alt="screen shot 2017-09-24 at 02 47 23" src="https://user-images.githubusercontent.com/4335450/30781400-2361bfa4-a0d3-11e7-92eb-8f0789594c3e.png">

- Try using it, click on it, type, blur off, does it work as it did before? Are changes persisted as before?