### PR TITLE
Localize: Apply to media-modal/gallery-help

### DIFF
--- a/client/post-editor/media-modal/gallery-help.jsx
+++ b/client/post-editor/media-modal/gallery-help.jsx
@@ -1,11 +1,13 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
-import PureRenderMixin from 'react-pure-render/mixin';
+import React, { PureComponent } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import Gridicon from 'gridicons';
+import { defer, flow, noop } from 'lodash';
+import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies
@@ -20,65 +22,60 @@ import { getPreference } from 'state/preferences/selectors';
 import { getSectionName } from 'state/ui/selectors';
 import QueryPreferences from 'components/data/query-preferences';
 
-const EditorMediaModalGalleryHelp =  React.createClass( {
-	displayName: 'EditorMediaModalGalleryHelp',
+class EditorMediaModalGalleryHelp extends PureComponent {
 
-	mixins: [ PureRenderMixin ],
-
-	propTypes: {
+	static propTypes = {
 		onDismiss: PropTypes.func,
 		sectionName: PropTypes.string,
-	},
+	};
 
-	getInitialState() {
-		return {
-			isDismissed: false,
-			rememberDismiss: true
-		};
-	},
+	static defaultProps = {
+		onDismiss: noop,
+	};
 
-	getDefaultProps() {
-		return {
-			onDismiss: () => {}
-		};
-	},
+	state = {
+		isDismissed: false,
+		rememberDismiss: true,
+	};
 
-	setRenderContext( renderContext ) {
+	setRenderContext = ( renderContext ) => {
 		if ( ! renderContext ) {
 			return;
 		}
 
 		this.setState( { renderContext } );
-	},
+	}
 
-	toggleRememberDismiss() {
+	toggleRememberDismiss = () => {
 		// This is a bit of ugly interoperability between the way React treats
 		// checkbox events and the media modal handler for preventing the modal
 		// from closing when clicking a popover.
 		//
 		// See: https://facebook.github.io/react/docs/forms.html#potential-issues-with-checkboxes-and-radio-buttons
 		// See: EditorMediaModal.preventPopoverClose()
-		setTimeout( () => {
+		defer( () =>
 			this.setState( {
 				rememberDismiss: ! this.state.rememberDismiss
-			} );
-		}, 0 );
-	},
+			} )
+		);
+	}
 
-	dismiss( { remember } = {} ) {
+	dismiss = ( { remember } = {} ) => {
 		this.setState( { isDismissed: true } );
 		this.props.onDismiss( { remember } );
-	},
+	}
 
 	renderPopover() {
+		const { translate } = this.props;
 		const { renderContext, isDismissed } = this.state;
+
 		if ( ! renderContext || isDismissed ) {
 			return;
 		}
 
 		return (
 			<Popover
-				onClose={ () => this.dismiss() }
+				onClose={ this.dismiss }
 				context={ renderContext }
 				position="bottom"
 				isVisible={ ! isMobile() }
@@ -89,24 +86,29 @@ const EditorMediaModalGalleryHelp =  React.createClass( {
 							<Gridicon icon="image-multiple" size={ 20 } />
 						</span>
 						<span className="editor-media-modal__gallery-help-text">
-							{ this.translate( 'Select more than one image to create a gallery.' ) }
+							{ translate( 'Select more than one image to create a gallery.' ) }
 						</span>
 					</div>
 					<div className="editor-media-modal__gallery-help-actions">
 						<label className="editor-media-modal__gallery-help-remember-dismiss">
 							<FormCheckbox checked={ this.state.rememberDismiss } onChange={ this.toggleRememberDismiss } />
 							<span>
-								{ this.translate( 'Don\'t show again' ) }
+								{ translate( 'Don\'t show again' ) }
 							</span>
 						</label>
 						<Button onClick={ () => this.dismiss( { remember: this.state.rememberDismiss } ) } compact>
-							{ this.translate( 'Got it', { context: 'Button label', comment: 'User clicks this to confirm that he has understood the text' } ) }
+							{
+								translate(
+									'Got it',
+									{ context: 'Button label', comment: 'User clicks this to confirm that he has understood the text' }
+								)
+							}
 						</Button>
 					</div>
 				</div>
 			</Popover>
 		);
-	},
+	}
 
 	render() {
 		// note that the post editor section is used for posts and pages
@@ -124,24 +126,30 @@ const EditorMediaModalGalleryHelp =  React.createClass( {
 			</div>
 		);
 	}
-} );
+}
 
-export default connect(
-	state => ( {
-		sectionName: getSectionName( state ),
-		isMediaModalGalleryInstructionsDismissed: (
-			getPreference( state, 'mediaModalGalleryInstructionsDismissed' ) ||
-			getPreference( state, 'mediaModalGalleryInstructionsDismissedForSession' )
+EditorMediaModalGalleryHelp.displayName = 'EditorMediaModalGalleryHelp';
+
+const enhance = flow(
+	localize,
+	connect(
+		state => ( {
+			sectionName: getSectionName( state ),
+			isMediaModalGalleryInstructionsDismissed: (
+				getPreference( state, 'mediaModalGalleryInstructionsDismissed' ) ||
+				getPreference( state, 'mediaModalGalleryInstructionsDismissedForSession' )
+			)
+		} ),
+		dispatch => bindActionCreators(
+			{
+				onDismiss: options =>
+					options.remember
+						? savePreference( 'mediaModalGalleryInstructionsDismissed', true )
+						: setPreference( 'mediaModalGalleryInstructionsDismissedForSession', true )
+			},
+			dispatch
 		)
-	} ),
-	dispatch => bindActionCreators( {
-		onDismiss: options => {
-			if ( options.remember ) {
-				return savePreference( 'mediaModalGalleryInstructionsDismissed', true );
-			} else {
-				return setPreference( 'mediaModalGalleryInstructionsDismissedForSession', true );
-			}
-		}
-	}, dispatch )
-)( EditorMediaModalGalleryHelp );
+	)
+);
 
+export default enhance( EditorMediaModalGalleryHelp );


### PR DESCRIPTION
Part of a batch of refactors with the ultimate goal of getting rid of `this.translate`.

To pass the linter I've had to do some fairly heavy refactoring, so please be vigilant when reviewing (I also snuck in a couple of minor things - couldn't help myself!).

### Testing
This was a tricky one, while developing I just forced different props by hardcoding them in `mapStateToProps`.
Following the test plan in #12094 seems a reasonable way to test this change-set though:

- Either create a new user, or unset the `mediaModalGalleryInstructionsDismissed` user preference
- Navigate to http://calypso.localhost:3000/post
- Select a site
- Click on "Insert Content" to open the media modal
- Click on one item
- We should see the gallery help modal
- Dismissing it should behave normally
