### PR TITLE
Localize: Apply to media-modal/detail/detail-file-info

### DIFF
--- a/client/post-editor/media-modal/detail/detail-file-info.jsx
+++ b/client/post-editor/media-modal/detail/detail-file-info.jsx
@@ -1,27 +1,29 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	createFragment = require( 'react-addons-create-fragment' ),
-	classNames = require( 'classnames' );
+import React, { Component } from 'react';
+import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+import createFragment from 'react-addons-create-fragment';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies
  */
-var MediaUtils = require( 'lib/media/utils' );
+import MediaUtils from 'lib/media/utils';
 
-module.exports = React.createClass( {
-	displayName: 'EditorMediaModalDetailFileInfo',
+class EditorMediaModalDetailFileInfo extends Component {
 
-	propTypes: {
-		item: React.PropTypes.object
-	},
+	static propTypes = {
+		item: PropTypes.object
+	};
 
 	getItemValue( attribute ) {
+		const { moment, translate } = this.props;
 		let value;
 
 		if ( ! this.props.item ) {
-			return this.translate( 'Loading…' );
+			return translate( 'Loading…' );
 		}
 
 		switch ( attribute ) {
@@ -31,14 +33,14 @@ module.exports = React.createClass( {
 
 			case 'dimensions':
 				value = createFragment( {
-					width: <abbr title={ this.translate( 'Width in pixels' ) }>{ this.props.item.width }</abbr>,
+					width: <abbr title={ translate( 'Width in pixels' ) }>{ this.props.item.width }</abbr>,
 					separator: ' ✕ ',
-					height: <abbr title={ this.translate( 'Height in pixels' ) }>{ this.props.item.height }</abbr>
+					height: <abbr title={ translate( 'Height in pixels' ) }>{ this.props.item.height }</abbr>
 				} );
 				break;
 
 			case 'date':
-				value = this.moment( this.props.item[ attribute ] ).format( 'D MMMM YYYY' );
+				value = moment( this.props.item[ attribute ] ).format( 'D MMMM YYYY' );
 				break;
 
 			case 'length':
@@ -50,35 +52,41 @@ module.exports = React.createClass( {
 		}
 
 		return value;
-	},
+	}
 
 	renderDimensions() {
+		const { translate } = this.props;
+
 		if ( ! this.props.item || ( ! this.props.item.width && ! this.props.item.height ) ) {
 			return;
 		}
 
 		return (
 			<tr>
-				<th>{ this.translate( 'Dimensions' ) }</th>
+				<th>{ translate( 'Dimensions' ) }</th>
 				<td>{ this.getItemValue( 'dimensions' ) }</td>
 			</tr>
 		);
-	},
+	}
 
 	renderDuration() {
+		const { translate } = this.props;
+
 		if ( ! this.props.item || ! this.props.item.length ) {
 			return;
 		}
 
 		return (
 			<tr>
-				<th>{ this.translate( 'Duration' ) }</th>
+				<th>{ translate( 'Duration' ) }</th>
 				<td>{ this.getItemValue( 'length' ) }</td>
 			</tr>
 		);
-	},
+	}
 
 	render() {
+		const { translate } = this.props;
+
 		let classes = classNames( 'editor-media-modal-detail__file-info', {
 			'is-loading': ! this.props.item
 		} );
@@ -87,23 +95,27 @@ module.exports = React.createClass( {
 			<table className={ classes }>
 				<tbody>
 					<tr>
-						<th>{ this.translate( 'File Name' ) }</th>
+						<th>{ translate( 'File Name' ) }</th>
 						<td title={ this.getItemValue( 'file' ) }>
 							<span>{ this.getItemValue( 'file' ) }</span>
 						</td>
 					</tr>
 					<tr>
-						<th>{ this.translate( 'File Type' ) }</th>
+						<th>{ translate( 'File Type' ) }</th>
 						<td>{ this.getItemValue( 'extension' ) }</td>
 					</tr>
 					{ this.renderDimensions() }
 					{ this.renderDuration() }
 					<tr>
-						<th>{ this.translate( 'Upload Date' ) }</th>
+						<th>{ translate( 'Upload Date' ) }</th>
 						<td>{ this.getItemValue( 'date' ) }</td>
 					</tr>
 				</tbody>
 			</table>
 		);
 	}
-} );
+}
+
+EditorMediaModalDetailFileInfo.displayName = 'EditorMediaModalDetailFileInfo';
+
+export default localize( EditorMediaModalDetailFileInfo );


### PR DESCRIPTION
Part of a batch of refactors with the ultimate goal of getting rid of `this.translate`.

To pass the linter I've had to do some fairly heavy refactoring, so please be vigilant when reviewing

### Testing
- Go to a new or existing blog post
- Open the media modal
- Select an image
- Click 'edit'
- Make sure that the detail file info (highlighted below) appears as it did prior to applying the changes

<img width="350" alt="screen shot 2017-09-24 at 03 45 02" src="https://user-images.githubusercontent.com/4335450/30781821-fd25b27a-a0da-11e7-9f72-bbd5f1bd33fa.png">

