### PR TITLE
Localize: apply to media-modal/back-to-library

### DIFF
--- a/client/post-editor/media-modal/back-to-library.jsx
+++ b/client/post-editor/media-modal/back-to-library.jsx
@@ -2,16 +2,17 @@
  * External dependencies
  */
 import React from 'react';
+import { localize } from 'i18n-calypso';
 
-export default React.createClass( {
-	displayName: 'BackToLibrary',
+/* eslint-disable wpcalypso/jsx-classname-namespace */
 
-	render() {
-		return (
-			<span className="editor-media-modal__back-to-library">
-				<span className="is-mobile">{ this.translate( 'Library' ) }</span>
-				<span className="is-desktop">{ this.translate( 'Media Library' ) }</span>
-			</span>
-		);
-	}
-} );
+const BackToLibrary = ( { translate } ) => (
+	<span className="editor-media-modal__back-to-library">
+		<span className="is-mobile">{ translate( 'Library' ) }</span>
+		<span className="is-desktop">{ translate( 'Media Library' ) }</span>
+	</span>
+);
+
+BackToLibrary.displayName = 'BackToLibrary';
+
+export default localize( BackToLibrary );


### PR DESCRIPTION
Part of a batch of refactors with the ultimate goal of getting rid of `this.translate`.

To pass the linter I've had to do some fairly heavy refactoring, so please be vigilant when reviewing

It actually looks as though this component is no longer in use... I'll investigate and update this PR if it turns out to be best to delete the component altogether. 

### Testing
No testing since the component isn't referenced anywhere.