### PR TITLE
Localize: Apply to post-editor/invalid-url-dialog

### DIFF
--- a/client/post-editor/invalid-url-dialog.jsx
+++ b/client/post-editor/invalid-url-dialog.jsx
@@ -1,9 +1,11 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { noop, startsWith } from 'lodash';
 import page from 'page';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -12,79 +14,74 @@ import Dialog from 'components/dialog';
 import FormButton from 'components/forms/form-button';
 import { getSiteFragment } from 'lib/route/path';
 
-export default React.createClass( {
+class EditorTrashedDialog extends Component {
 
-	displayName: 'EditorTrashedDialog',
+	static propTypes = {
+		onClose: PropTypes.func,
+		onSave: PropTypes.func,
+	};
 
-	getInitialState() {
-		return {
-			isPage: this.isPage()
-		};
-	},
+	static defaultProps = {
+		onClose: noop,
+		onSave: noop,
+	};
 
-	isPage() {
-		return startsWith( page.current, '/page/' );
-	},
-
-	getDefaultProps() {
-		return {
-			onClose: noop,
-			onSave: noop
-		};
-	},
-
-	propTypes: {
-		onClose: React.PropTypes.func,
-		onSave: React.PropTypes.func
-	},
+	state = {
+		isPage: startsWith( page.current, '/page/' ),
+	};
 
 	getDialogButtons() {
-		const newText = this.state.isPage ? this.translate( 'New Page' ) : this.translate( 'New Post' );
+		const { translate } = this.props;
+		const { isPage } = this.state;
+
 		return [
 			<FormButton
 				key="startNewPage"
-				isPrimary={ true }
-				onClick={ this.startNewPage }>
-					{ newText }
+				isPrimary
+				onClick={ this.startNewPage }
+			>
+				{ isPage ? translate( 'New Page' ) : translate( 'New Post' ) }
 			</FormButton>,
 			<FormButton
 				key="back"
 				isPrimary={ false }
-				onClick={ this.props.onClose }>
-					{ this.translate( 'Close' ) }
+				onClick={ this.props.onClose }
+			>
+				{ translate( 'Close' ) }
 			</FormButton>
 		];
-	},
+	}
 
-	startNewPage() {
+	startNewPage = () => {
 		const siteFragment = getSiteFragment( page.current );
 		const postSegment = this.state.isPage ? '/page/' : '/post/';
 		page( postSegment + siteFragment );
-	},
-
-	getStrings( isPage ) {
-		if ( isPage ) {
-			return {
-				dialogTitle: this.translate( 'Invalid Page Address' ),
-				dialogContent: this.translate( 'This page cannot be found. Check the web address or start a new page.' ),
-			};
-		}
-		return {
-			dialogTitle: this.translate( 'Invalid Post Address' ),
-			dialogContent: this.translate( 'This post cannot be found. Check the web address or start a new post.' ),
-		};
-	},
+	}
 
 	render() {
-		const strings = this.getStrings( this.state.isPage );
+		const { translate } = this.props;
+		const { isPage } = this.state;
+
 		return (
 			<Dialog
-				isVisible={ true }
+				isVisible
 				buttons={ this.getDialogButtons() }
 			>
-				<h1>{ strings.dialogTitle }</h1>
-				<p>{ strings.dialogContent }</p>
+				<h1>{
+					isPage
+						? translate( 'Invalid Page Address' )
+						: translate( 'Invalid Post Address' )
+				}</h1>
+				<p>{
+					isPage
+						? translate( 'This page cannot be found. Check the web address or start a new page.' )
+						: translate( 'This post cannot be found. Check the web address or start a new post.' )
+				}</p>
 			</Dialog>
 		);
 	}
-} );
+}
+
+EditorTrashedDialog.displayName = 'EditorTrashedDialog';
+
+export default localize( EditorTrashedDialog );


### PR DESCRIPTION
Part of a batch of refactors with the ultimate goal of getting rid of `this.translate`.

To pass the linter I've had to do some fairly heavy refactoring, so please be vigilant when reviewing

### Testing
- Go to a post on your site that doesn't exist: http://calypso.localhost:3000/post/you.wordpress.com/999999
- You should see the 'Invalid Url' dialog as you would have before applying the changes.
- Click the <kbd>new post</kbd> button and make sure it takes you to a new post without error.