### PR TITLE
PostEditor: Compose component enhancements with flow

### DIFF
--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -9,7 +9,7 @@ import createReactClass from 'create-react-class';
 import ReactDom from 'react-dom';
 import page from 'page';
 import PropTypes from 'prop-types';
-import { debounce, throttle, get } from 'lodash';
+import { debounce, flow, get, throttle } from 'lodash';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { localize } from 'i18n-calypso';
@@ -1382,50 +1382,56 @@ export const PostEditor = createReactClass( {
 	},
 } );
 
-export default connect(
-	state => {
-		const siteId = getSelectedSiteId( state );
-		const postId = getEditorPostId( state );
-		const userId = getCurrentUserId( state );
-		const type = getEditedPostValue( state, siteId, postId, 'type' );
+const enhance = flow(
+	localize,
+	protectForm,
+	connect(
+		state => {
+			const siteId = getSelectedSiteId( state );
+			const postId = getEditorPostId( state );
+			const userId = getCurrentUserId( state );
+			const type = getEditedPostValue( state, siteId, postId, 'type' );
 
-		return {
-			siteId,
-			postId,
-			type,
-			selectedSite: getSelectedSite( state ),
-			selectedSiteDomain: getSiteDomain( state, siteId ),
-			editorModePreference: getPreference( state, 'editor-mode' ),
-			editorSidebarPreference: getPreference( state, 'editor-sidebar' ) || 'open',
-			editPath: getEditorPath( state, siteId, postId ),
-			edits: getPostEdits( state, siteId, postId ),
-			dirty: isEditedPostDirty( state, siteId, postId ),
-			hasContent: editedPostHasContent( state, siteId, postId ),
-			layoutFocus: getCurrentLayoutFocus( state ),
-			hasBrokenPublicizeConnection: hasBrokenSiteUserConnection( state, siteId, userId ),
-			isSitePreviewable: isSitePreviewable( state, siteId ),
-			isEditorOnlyRouteInHistory: isEditorOnlyRouteInHistory( state ),
-			isConfirmationSidebarEnabled: isConfirmationSidebarEnabled( state, siteId ),
-		};
-	},
-	dispatch => {
-		return bindActionCreators(
-			{
-				setEditorLastDraft,
-				resetEditorLastDraft,
-				receivePost,
-				editPost,
-				savePostSuccess,
-				setEditorModePreference: savePreference.bind( null, 'editor-mode' ),
-				setEditorSidebar: savePreference.bind( null, 'editor-sidebar' ),
-				setLayoutFocus,
-				setNextLayoutFocus,
-				saveConfirmationSidebarPreference,
-				recordTracksEvent,
-			},
-			dispatch
-		);
-	},
-	null,
-	{ pure: false }
-)( protectForm( localize( PostEditor ) ) );
+			return {
+				siteId,
+				postId,
+				type,
+				selectedSite: getSelectedSite( state ),
+				selectedSiteDomain: getSiteDomain( state, siteId ),
+				editorModePreference: getPreference( state, 'editor-mode' ),
+				editorSidebarPreference: getPreference( state, 'editor-sidebar' ) || 'open',
+				editPath: getEditorPath( state, siteId, postId ),
+				edits: getPostEdits( state, siteId, postId ),
+				dirty: isEditedPostDirty( state, siteId, postId ),
+				hasContent: editedPostHasContent( state, siteId, postId ),
+				layoutFocus: getCurrentLayoutFocus( state ),
+				hasBrokenPublicizeConnection: hasBrokenSiteUserConnection( state, siteId, userId ),
+				isSitePreviewable: isSitePreviewable( state, siteId ),
+				isEditorOnlyRouteInHistory: isEditorOnlyRouteInHistory( state ),
+				isConfirmationSidebarEnabled: isConfirmationSidebarEnabled( state, siteId ),
+			};
+		},
+		dispatch => {
+			return bindActionCreators(
+				{
+					setEditorLastDraft,
+					resetEditorLastDraft,
+					receivePost,
+					editPost,
+					savePostSuccess,
+					setEditorModePreference: savePreference.bind( null, 'editor-mode' ),
+					setEditorSidebar: savePreference.bind( null, 'editor-sidebar' ),
+					setLayoutFocus,
+					setNextLayoutFocus,
+					saveConfirmationSidebarPreference,
+					recordTracksEvent,
+				},
+				dispatch
+			);
+		},
+		null,
+		{ pure: false }
+	)
+);
+
+export default enhance( PostEditor );


### PR DESCRIPTION
I noticed that there were 3 HoCs being applied to this component in the form of 
```js
c( b( a ( Component ) ) )
``` 
so quickly refactored this using `flow`.

This should make any further enhancements easier and the code more readable.

### Testing
- Go to one of your blog posts and edit it
- Make sure that the editor works 
- Make sure translations are working (the 'Visual' tab in the editor for instance).

### Notes

The diff for this PR has a lot of whitespace only changes. It'll be easier to review using the `?w=1` url param: https://github.com/Automattic/wp-calypso/pull/18216/files?w=1