### PR TITLE
Localize: Apply to post-editor/editor-sticky

### DIFF
--- a/client/post-editor/editor-sticky/index.jsx
+++ b/client/post-editor/editor-sticky/index.jsx
@@ -1,9 +1,12 @@
 /**
  * External dependencies
  */
-import React from 'react';
-import classnames from 'classnames';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
+import { flow, get } from 'lodash';
+import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+import classnames from 'classnames';
 import Gridicon from 'gridicons';
 
 /**
@@ -17,32 +20,28 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 import { getEditorPostId } from 'state/ui/editor/selectors';
 import { getEditedPostValue } from 'state/posts/selectors';
 
-const EditorSticky = React.createClass( {
-	displayName: 'EditorSticky',
+class EditorSticky extends Component {
 
-	propTypes: {
-		postId: React.PropTypes.number,
-		siteId: React.PropTypes.number,
-		sticky: React.PropTypes.bool
-	},
+	static propTypes = {
+		postId: PropTypes.number,
+		siteId: PropTypes.number,
+		sticky: PropTypes.bool,
+	};
 
-	getInitialState: function() {
-		return {
-			tooltip: false
-		};
-	},
+	state = {
+		tooltip: false,
+	};
 
-	toggleStickyStatus: function() {
-		let stickyStat;
-		let stickyEventLabel;
-
-		if ( ! this.props.sticky ) {
-			stickyStat = 'advanced_sticky_enabled_toolbar';
-			stickyEventLabel = 'On';
-		} else {
-			stickyStat = 'advanced_sticky_disabled_toolbar';
-			stickyEventLabel = 'Off';
-		}
+	toggleStickyStatus = () => {
+		const { stickyStat, stickyEventLabel } = this.props.sticky
+			? {
+				stickyStat: 'advanced_sticky_disabled_toolbar',
+				stickyEventLabel: 'Off',
+			}
+			: {
+				stickyStat: 'advanced_sticky_enabled_toolbar',
+				stickyEventLabel: 'On',
+			};
 
 		recordStat( stickyStat );
 		recordEvent( 'Changed Sticky Setting', stickyEventLabel );
@@ -51,17 +50,18 @@ const EditorSticky = React.createClass( {
 			sticky: ! this.props.sticky
 		} );
 		this.setState( { tooltip: false } );
-	},
+	}
 
-	enableTooltip: function() {
+	enableTooltip = () => {
 		this.setState( { tooltip: true } );
-	},
+	}
 
-	disableTooltip: function() {
+	disableTooltip = () => {
 		this.setState( { tooltip: false } );
-	},
+	}
 
-	render: function() {
+	render() {
+		const { translate } = this.props;
 		const classes = classnames(
 			'editor-sticky',
 			{ 'is-sticky': this.props.sticky }
@@ -74,36 +74,43 @@ const EditorSticky = React.createClass( {
 				onClick={ this.toggleStickyStatus }
 				onMouseEnter={ this.enableTooltip }
 				onMouseLeave={ this.disableTooltip }
-				aria-label={ this.translate( 'Stick post to the front page' ) }
+				aria-label={ translate( 'Stick post to the front page' ) }
 				ref="stickyPostButton"
 			>
 				<Gridicon icon="bookmark" />
 				{ this.props.sticky &&
 					<Tooltip
 						className="editor-sticky__tooltip"
-						context={ this.refs && this.refs.stickyPostButton }
+						context={ get( this.refs, 'stickyPostButton' ) }
 						isVisible={ this.state.tooltip }
 						position="bottom left"
 					>
-						<span>{ this.translate( 'Marked as sticky' ) }</span>
+						<span>{ translate( 'Marked as sticky' ) }</span>
 					</Tooltip>
 				}
 			</Button>
 		);
 	}
-} );
+}
 
-export default connect(
-	( state ) => {
-		const postId = getEditorPostId( state );
-		const siteId = getSelectedSiteId( state );
-		const sticky = getEditedPostValue( state, siteId, postId, 'sticky' );
+EditorSticky.displayName = 'EditorSticky';
 
-		return {
-			postId,
-			siteId,
-			sticky
-		};
-	},
-	{ editPost }
-)( EditorSticky );
+const enhance = flow(
+	localize,
+	connect(
+		( state ) => {
+			const postId = getEditorPostId( state );
+			const siteId = getSelectedSiteId( state );
+			const sticky = getEditedPostValue( state, siteId, postId, 'sticky' );
+
+			return {
+				postId,
+				siteId,
+				sticky
+			};
+		},
+		{ editPost }
+	)
+);
+
+export default enhance( EditorSticky );


### PR DESCRIPTION
Part of a batch of refactors with the ultimate goal of getting rid of `this.translate`.

To pass the linter I've had to do some fairly heavy refactoring, so please be vigilant when reviewing.
I also tried something a little different with the destructuring & ternary combination - totally fine with reverting it if others disagree with it! :)

There is a related bug: #18217 to consider while testing. You won't see the icon but will instead have to click in the area it should be and hope for the best unfortunately.

<img width="1085" alt="screen shot 2017-09-24 at 05 05 16" src="https://user-images.githubusercontent.com/4335450/30782385-3f4bb324-a0e6-11e7-8eff-508b272058af.png">

### Testing
- Go to a new or existing blog post
- Inspect element or click around to find the sticky icon
- Click the icon so that it is now 'on'
- Hover on the orange icon, noting that there is a tooltip shown when you do.
- This should be the same behaviour as before the changes were applied.
