### PR TITLE
Localize: Apply to post-editor/editor-status-label

### DIFF
--- a/client/post-editor/editor-status-label/index.jsx
+++ b/client/post-editor/editor-status-label/index.jsx
@@ -1,8 +1,9 @@
 /**
  * External dependencies
  */
-import React from 'react';
-import PureRenderMixin from 'react-pure-render/mixin';
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
 import Gridicon from 'gridicons';
 
@@ -12,58 +13,52 @@ import Gridicon from 'gridicons';
 import postUtils from 'lib/posts/utils';
 import EditorStatusLabelPlaceholder from './placeholder';
 
-export default React.createClass( {
-	displayName: 'StatusLabel',
+class StatusLabel extends PureComponent {
 
-	propTypes: {
-		onClick: React.PropTypes.func,
-		post: React.PropTypes.object,
-		type: React.PropTypes.string,
-		advancedStatus: React.PropTypes.bool
-	},
+	static propTypes = {
+		onClick: PropTypes.func,
+		post: PropTypes.object,
+		type: PropTypes.string,
+		advancedStatus: PropTypes.bool,
+	};
 
-	mixins: [ PureRenderMixin ],
+	static defaultProps = {
+		onClick: null,
+		post: null,
+		advancedStatus: false,
+		type: 'post',
+	};
 
-	getDefaultProps: function() {
-		return {
-			onClick: null,
-			post: null,
-			advancedStatus: false,
-			type: 'post'
-		};
-	},
+	state = {
+		currentTime: Date.now(),
+	};
 
-	getInitialState: function() {
-		return {
-			currentTime: Date.now()
-		};
-	},
-
-	componentDidMount: function() {
+	componentDidMount() {
 		// update the `currentTime` every minute
 		this.currentTimeTimer = setInterval( this.updateCurrentTime, 60000 );
-	},
+	}
 
-	componentWillReceiveProps: function( nextProps ) {
+	componentWillReceiveProps( nextProps ) {
 		if ( nextProps.post !== this.props.post ) {
 			// the post has been updated, so update the current time so that
 			// it will be the most up-to-date when re-rendering
 			this.updateCurrentTime();
 		}
-	},
+	}
 
-	componentWillUnmount: function() {
+	componentWillUnmount() {
 		clearInterval( this.currentTimeTimer );
-	},
+	}
 
-	render: function() {
+	render() {
+		const { post, translate } = this.props;
 		let statusClass = 'editor-status-label';
 
-		if ( ! this.props.post ) {
+		if ( ! post ) {
 			return <EditorStatusLabelPlaceholder className={ statusClass } />;
 		}
 
-		statusClass = classNames( statusClass, 'is-' + this.props.post.status );
+		statusClass = classNames( statusClass, 'is-' + post.status );
 
 		if ( ! this.props.onClick ) {
 			return (
@@ -78,7 +73,7 @@ export default React.createClass( {
 				className={ statusClass }
 				onClick={ this.props.onClick }
 				ref="statusLabel"
-				aria-label={ this.translate( 'Show advanced status details' ) }
+				aria-label={ translate( 'Show advanced status details' ) }
 				aria-pressed={ !! this.props.advancedStatus }
 				role="alert"
 				aria-live="polite"
@@ -87,29 +82,29 @@ export default React.createClass( {
 				{ this.renderLabel() }
 			</button>
 		);
-	},
+	}
 
-	renderLabel: function() {
-		var post = this.props.post,
-			editedTime = this.moment( postUtils.getEditedTime( post ) ),
-			label;
+	renderLabel() {
+		const { moment, post, translate } = this.props;
+		let editedTime = moment( postUtils.getEditedTime( post ) );
+		let label;
 
 		if ( ! post.modified ) {
-			return this.translate( 'New Draft' );
+			return translate( 'New Draft' );
 		}
 
 		// prevent JP sites from showing a draft as saved in the future
 		if ( 'draft' === post.status &&
 				editedTime.isAfter( this.state.currentTime )
 		) {
-			editedTime = this.moment( this.state.currentTime );
+			editedTime = moment( this.state.currentTime );
 		}
 
 		const timeFromNow = editedTime.from( this.state.currentTime );
 
 		switch ( post.status ) {
 			case 'publish':
-				label = this.translate( '{{strong}}Published{{/strong}} %(relativeTimeFromNow)s', {
+				label = translate( '{{strong}}Published{{/strong}} %(relativeTimeFromNow)s', {
 					args: { relativeTimeFromNow: timeFromNow },
 					components: {
 						strong: <strong />
@@ -117,7 +112,7 @@ export default React.createClass( {
 				} );
 				break;
 			case 'private':
-				label = this.translate( '{{strong}}Published Privately{{/strong}} %(relativeTimeFromNow)s', {
+				label = translate( '{{strong}}Published Privately{{/strong}} %(relativeTimeFromNow)s', {
 					args: { relativeTimeFromNow: timeFromNow },
 					components: {
 						strong: <strong />
@@ -125,7 +120,7 @@ export default React.createClass( {
 				} );
 				break;
 			case 'draft':
-				label = this.translate( '{{strong}}Saved{{/strong}} %(relativeTimeFromNow)s', {
+				label = translate( '{{strong}}Saved{{/strong}} %(relativeTimeFromNow)s', {
 					args: { relativeTimeFromNow: timeFromNow },
 					components: {
 						strong: <strong />
@@ -133,7 +128,7 @@ export default React.createClass( {
 				} );
 				break;
 			case 'pending':
-				label = this.translate( '{{strong}}Pending Review{{/strong}} %(relativeTimeFromNow)s', {
+				label = translate( '{{strong}}Pending Review{{/strong}} %(relativeTimeFromNow)s', {
 					args: { relativeTimeFromNow: timeFromNow },
 					components: {
 						strong: <strong />
@@ -141,7 +136,7 @@ export default React.createClass( {
 				} );
 				break;
 			case 'future':
-				label = this.translate( '{{strong}}Scheduled{{/strong}} %(relativeTimeFromNow)s', {
+				label = translate( '{{strong}}Scheduled{{/strong}} %(relativeTimeFromNow)s', {
 					args: { relativeTimeFromNow: timeFromNow },
 					components: {
 						strong: <strong />
@@ -149,7 +144,7 @@ export default React.createClass( {
 				} );
 				break;
 			case 'trash':
-				label = this.translate( '{{strong}}Trashed{{/strong}}', {
+				label = translate( '{{strong}}Trashed{{/strong}}', {
 					components: {
 						strong: <strong />
 					}
@@ -161,11 +156,15 @@ export default React.createClass( {
 		}
 
 		return label;
-	},
+	}
 
-	updateCurrentTime: function() {
+	updateCurrentTime = () => {
 		this.setState( {
-			currentTime: Date.now()
+			currentTime: Date.now(),
 		} );
 	}
-} );
+}
+
+StatusLabel.displayName = 'StatusLabel';
+
+export default localize( StatusLabel );


### PR DESCRIPTION
Part of a batch of refactors with the ultimate goal of getting rid of `this.translate`.

To pass the linter I've had to do some fairly heavy refactoring, so please be vigilant when reviewing

### Testing
- Go to a new or existing blog post
- Look for the editor-status-label (highlighted below)
<img width="1336" alt="screen shot 2017-09-24 at 05 59 24" src="https://user-images.githubusercontent.com/4335450/30782792-9c32c076-a0ed-11e7-96a0-7d54a553d660.png">
- This should behave as it did prior to applying these changes.