### PR TITLE
Localize: Apply to editor-sharing/sharing-like-options

### DIFF
--- a/client/post-editor/editor-sharing/sharing-like-options.jsx
+++ b/client/post-editor/editor-sharing/sharing-like-options.jsx
@@ -1,8 +1,11 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
+import { flow } from 'lodash';
+import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies
@@ -15,16 +18,17 @@ import { isEditorNewPost } from 'state/ui/editor/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { isJetpackModuleActive } from 'state/sites/selectors';
 
-const SharingLikeOptions = React.createClass( {
-	propTypes: {
-		site: React.PropTypes.object,
-		post: React.PropTypes.object,
-		isSharingButtonsEnabled: React.PropTypes.bool,
-		isLikesEnabled: React.PropTypes.bool,
-		isNew: React.PropTypes.bool
-	},
+class SharingLikeOptions extends Component {
 
-	isShowingSharingButtons: function() {
+	static propTypes = {
+		site: PropTypes.object,
+		post: PropTypes.object,
+		isSharingButtonsEnabled: PropTypes.bool,
+		isLikesEnabled: PropTypes.bool,
+		isNew: PropTypes.bool,
+	};
+
+	isShowingSharingButtons() {
 		if ( this.props.post && 'sharing_enabled' in this.props.post ) {
 			return this.props.post.sharing_enabled;
 		}
@@ -34,9 +38,9 @@ const SharingLikeOptions = React.createClass( {
 		}
 
 		return true;
-	},
+	}
 
-	isShowingLikeButton: function() {
+	isShowingLikeButton() {
 		if ( this.props.post && 'likes_enabled' in this.props.post ) {
 			return this.props.post.likes_enabled;
 		}
@@ -46,7 +50,7 @@ const SharingLikeOptions = React.createClass( {
 		}
 
 		return true;
-	},
+	}
 
 	renderSharingButtonField() {
 		if ( ! this.props.isSharingButtonsEnabled ) {
@@ -58,11 +62,12 @@ const SharingLikeOptions = React.createClass( {
 				<FormCheckbox
 					name='sharing_enabled'
 					checked={ this.isShowingSharingButtons() }
-					onChange={ this.onChange } />
-				<span>{ this.translate( 'Show Sharing Buttons', { context: 'Post Editor' } ) }</span>
+					onChange={ this.onChange }
+				/>
+				<span>{ this.props.translate( 'Show Sharing Buttons', { context: 'Post Editor' } ) }</span>
 			</label>
 		);
-	},
+	}
 
 	renderLikesButtonField() {
 		if ( ! this.props.isLikesEnabled ) {
@@ -70,37 +75,38 @@ const SharingLikeOptions = React.createClass( {
 		}
 
 		return (
-				<label>
-					<FormCheckbox
-						name='likes_enabled'
-						checked={ this.isShowingLikeButton() }
-						onChange={ this.onChange } />
-					<span>{ this.translate( 'Show Like Button', { context: 'Post Editor' } ) }</span>
-				</label>
+			<label>
+				<FormCheckbox
+					name="likes_enabled"
+					checked={ this.isShowingLikeButton() }
+					onChange={ this.onChange }
+				/>
+				<span>{ this.props.translate( 'Show Like Button', { context: 'Post Editor' } ) }</span>
+			</label>
 		);
-	},
+	}
 
-	onChange: function( event ) {
+	onChange = ( event ) => {
 		// TODO: REDUX - remove flux actions when whole post-editor is reduxified
 		PostActions.edit( {
 			[ event.target.name ]: event.target.checked
 		} );
 
 		this.recordStats( event );
-	},
+	}
 
-	recordStats: function( event ) {
-		let mcStat = event.target.name,
-			eventStat = 'sharing_enabled' === event.target.name ? 'Sharing Buttons' : 'Like Button';
+	recordStats = ( event ) => {
+		let mcStat = event.target.name;
+		let eventStat = 'sharing_enabled' === event.target.name ? 'Sharing Buttons' : 'Like Button';
 
 		mcStat += event.target.checked ? '_enabled' : '_disabled';
 		eventStat += event.target.checked ? ' Enabled' : ' Disabled';
 
 		recordStat( mcStat );
 		recordEvent( eventStat );
-	},
+	}
 
-	render: function() {
+	render() {
 		if ( ! this.props.isSharingButtonsEnabled && ! this.props.isLikesEnabled ) {
 			return null;
 		}
@@ -108,21 +114,30 @@ const SharingLikeOptions = React.createClass( {
 		return (
 			<EditorFieldset
 				className="editor-sharing__sharing-like-options"
-				legend={ this.translate( 'Sharing Buttons & Likes' ) }
+				legend={ this.props.translate( 'Sharing Buttons & Likes' ) }
 			>
 				{ this.renderSharingButtonField() }
 				{ this.renderLikesButtonField() }
 			</EditorFieldset>
 		);
 	}
-} );
+}
 
-export default connect( ( state ) => {
-	const siteId = getSelectedSiteId( state );
+SharingLikeOptions.displayName = 'SharingLikeOptions';
 
-	return {
-		isSharingButtonsEnabled: false !== isJetpackModuleActive( state, siteId, 'sharedaddy' ),
-		isLikesEnabled: false !== isJetpackModuleActive( state, siteId, 'likes' ),
-		isNew: isEditorNewPost( state )
-	};
-} )( SharingLikeOptions );
+const enhance = flow(
+	localize,
+	connect(
+		( state ) => {
+			const siteId = getSelectedSiteId( state );
+
+			return {
+				isSharingButtonsEnabled: false !== isJetpackModuleActive( state, siteId, 'sharedaddy' ),
+				isLikesEnabled: false !== isJetpackModuleActive( state, siteId, 'likes' ),
+				isNew: isEditorNewPost( state ),
+			};
+		}
+	)
+);
+
+export default enhance( SharingLikeOptions );


### PR DESCRIPTION
Part of a batch of refactors with the ultimate goal of getting rid of `this.translate`.

To pass the linter I've had to do some fairly heavy refactoring, so please be vigilant when reviewing

### Testing
- Go to a new or existing blog post
- Open the Post Settings menu if it's not already open
- Make sure the 'sharing' sub menu is open and look for 'Sharing Buttons & Likes'
- Make sure that this section (highlighted below) appears and works as it did prior to applying the changes.
<img width="276" alt="screen shot 2017-09-24 at 06 22 43" src="https://user-images.githubusercontent.com/4335450/30783043-d78da650-a0f1-11e7-9630-90014014427c.png">
