### PR TITLE
ReaderSiteStreamLink: Bind recordClick for context

### DIFF
--- a/client/blocks/reader-site-stream-link/index.jsx
+++ b/client/blocks/reader-site-stream-link/index.jsx
@@ -20,13 +20,13 @@ class ReaderSiteStreamLink extends React.Component {
 		post: PropTypes.object, // for stats only
 	};
 
-	recordClick() {
+	recordClick = () => {
 		recordAction( 'visit_blog_feed' );
 		recordGaEvent( 'Clicked Feed Link' );
 		if ( this.props.post ) {
 			recordTrackForPost( 'calypso_reader_feed_link_clicked', this.props.post );
 		}
-	}
+	};
 
 	render() {
 		// If we can't make a link, just return children


### PR DESCRIPTION
### Summary

I noticed an error while using the reader and found that it was due to `recordClick` not having the right context when it was being called.

![readersitestreamlink](https://user-images.githubusercontent.com/4335450/30783320-d17d0644-a0f5-11e7-85ee-b28f993967c7.gif)

### Testing
- Go to Reader
- Click on the reader-site-stream-link (darker in colour to the author link, not always available)
<img width="260" alt="screen shot 2017-09-24 at 07 00 46" src="https://user-images.githubusercontent.com/4335450/30783340-4a013540-a0f6-11e7-8168-892d2c718317.png">
- There should no longer be any errors in the console

