### PR TITLE
Localize: apply to editor-sharing/publicize-connection

### DIFF
--- a/client/post-editor/editor-sharing/publicize-connection.jsx
+++ b/client/post-editor/editor-sharing/publicize-connection.jsx
@@ -1,8 +1,10 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
-import { includes } from 'lodash';
+import React, { Component } from 'react';
+import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+import { get, includes, noop } from 'lodash';
 import Gridicon from 'gridicons';
 
 /**
@@ -11,42 +13,39 @@ import Gridicon from 'gridicons';
 import FormCheckbox from 'components/forms/form-checkbox';
 import PostMetadata from 'lib/post-metadata';
 import PostActions from 'lib/posts/actions';
-import * as PostStats from 'lib/posts/stats';
+import { recordStat, recordEvent } from 'lib/posts/stats';
 import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
 
-export default React.createClass( {
-	displayName: 'EditorSharingPublicizeConnection',
+class EditorSharingPublicizeConnection extends Component {
 
-	propTypes: {
+	static propTypes = {
 		post: PropTypes.object,
 		connection: PropTypes.object,
 		onRefresh: PropTypes.func,
-		label: PropTypes.string
-	},
+		label: PropTypes.string,
+	};
 
-	getDefaultProps() {
-		return {
-			onRefresh: () => {}
-		};
-	},
+	static defaultProps = {
+		onRefresh: noop,
+	};
 
 	isConnectionSkipped() {
 		const { post, connection } = this.props;
 		return post && connection && includes( PostMetadata.publicizeSkipped( post ), connection.keyring_connection_ID );
-	},
+	}
 
 	isConnectionDone() {
 		const { post, connection } = this.props;
 		return post && connection && includes( PostMetadata.publicizeDone( post ), connection.keyring_connection_ID );
-	},
+	}
 
 	isDisabled() {
 		const { connection } = this.props;
 		return ! connection || connection.read_only;
-	},
+	}
 
-	onChange( event ) {
+	onChange = ( event ) => {
 		const { connection } = this.props;
 		if ( ! connection ) {
 			return;
@@ -55,29 +54,29 @@ export default React.createClass( {
 		if ( event.target.checked ) {
 			// TODO: REDUX - remove flux actions when whole post-editor is reduxified
 			PostActions.deleteMetadata( '_wpas_skip_' + connection.keyring_connection_ID );
-			PostStats.recordStat( 'sharing_enabled_' + connection.service );
-			PostStats.recordEvent( 'Publicize Service', connection.service, 'enabled' );
+			recordStat( 'sharing_enabled_' + connection.service );
+			recordEvent( 'Publicize Service', connection.service, 'enabled' );
 		} else {
 			// TODO: REDUX - remove flux actions when whole post-editor is reduxified
 			PostActions.updateMetadata( '_wpas_skip_' + connection.keyring_connection_ID, 1 );
-			PostStats.recordStat( 'sharing_disabled_' + connection.service );
-			PostStats.recordEvent( 'Publicize Service', connection.service, 'disabled' );
+			recordStat( 'sharing_disabled_' + connection.service );
+			recordEvent( 'Publicize Service', connection.service, 'disabled' );
 		}
-	},
+	}
 
 	renderBrokenConnection() {
-		const { connection } = this.props;
+		const { connection, translate } = this.props;
 		if ( ! connection || connection.status !== 'broken' ) {
 			return;
 		}
 
 		return (
 			<Notice isCompact className="editor-sharing__broken-publicize-connection" status="is-warning" showDismiss={ false }>
-				{ this.translate( 'There is an issue connecting to %s.', { args: connection.label } ) }
+				{ translate( 'There is an issue connecting to %s.', { args: connection.label } ) }
 				<NoticeAction onClick={ this.props.onRefresh }>Reconnect <Gridicon icon="external" size={ 18 } /></NoticeAction>
 			</Notice>
 		);
-	},
+	}
 
 	render() {
 		const { connection, label } = this.props;
@@ -88,11 +87,16 @@ export default React.createClass( {
 					<FormCheckbox
 						checked={ ! this.isConnectionSkipped() }
 						disabled={ this.isDisabled() }
-						onChange={ this.onChange } />
-					<span data-e2e-service={ label }>{ connection && connection.external_display }</span>
+						onChange={ this.onChange }
+					/>
+					<span data-e2e-service={ label }>{ get( connection, 'external_display' ) }</span>
 				</label>
 				{ this.renderBrokenConnection() }
 			</div>
 		);
 	}
-} );
+}
+
+EditorSharingPublicizeConnection.displayName = 'EditorSharingPublicizeConnection';
+
+export default localize( EditorSharingPublicizeConnection );

--- a/client/post-editor/editor-sharing/publicize-connection.jsx
+++ b/client/post-editor/editor-sharing/publicize-connection.jsx
@@ -73,7 +73,10 @@ class EditorSharingPublicizeConnection extends Component {
 		return (
 			<Notice isCompact className="editor-sharing__broken-publicize-connection" status="is-warning" showDismiss={ false }>
 				{ translate( 'There is an issue connecting to %s.', { args: connection.label } ) }
-				<NoticeAction onClick={ this.props.onRefresh }>Reconnect <Gridicon icon="external" size={ 18 } /></NoticeAction>
+				<NoticeAction onClick={ this.props.onRefresh }>
+					{ translate( 'Reconnect' ) }
+					<Gridicon icon="external" size={ 18 } />
+				</NoticeAction>
 			</Notice>
 		);
 	}


### PR DESCRIPTION
Part of a batch of refactors with the ultimate goal of getting rid of `this.translate`.

To pass the linter I've had to do some fairly heavy refactoring, so please be vigilant when reviewing
This was an especially big refactor. It could be my tired eyes but I think I spotted major flaws, in terms of code-style, in the `renderMessage` method - There were a number of ternary operators that looked at the same condition, `this.hasConnections()` which was then used for an early return immediately afterwards, so I did away with those.

### Testing
- Go to a new or existing blog post
- Open the Post Settings menu if it's not already open
- Make sure the 'sharing' sub menu is open and look for 'Sharing Buttons & Likes'
- Make sure that this section (highlighted below) appears and works as it did prior to applying the changes. 
<img width="351" alt="screen shot 2017-09-24 at 09 27 31" src="https://user-images.githubusercontent.com/4335450/30784514-41906484-a10b-11e7-86b6-bee3d809d515.png">

- Try checking and unchecking the checkbox, there should be no issue in doing so.


