### PR TITLE
Plans: End jetpackConnectHideFreePlan test, use challenger

### DIFF
--- a/client/jetpack-connect/plans-landing.jsx
+++ b/client/jetpack-connect/plans-landing.jsx
@@ -12,7 +12,6 @@ import page from 'page';
  */
 import PlansGrid from './plans-grid';
 import PlansSkipButton from './plans-skip-button';
-import { abtest } from 'lib/abtest';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { selectPlanInAdvance } from 'state/jetpack-connect/actions';
 import { getJetpackSiteByUrl } from 'state/jetpack-connect/selectors';
@@ -79,7 +78,6 @@ class PlansLanding extends Component {
 
 	render() {
 		const { basePlansPath, interval } = this.props;
-		const hideFreePlanTest = abtest( 'jetpackConnectHideFreePlan' ) === 'hide';
 
 		return (
 			<div>
@@ -88,12 +86,12 @@ class PlansLanding extends Component {
 				<PlansGrid
 					basePlansPath={ basePlansPath }
 					calypsoStartedConnection={ true }
-					hideFreePlan={ hideFreePlanTest }
+					hideFreePlan={ true }
 					interval={ interval }
 					isLanding={ true }
 					onSelect={ this.storeSelectedPlan }
 				>
-					{ hideFreePlanTest && <PlansSkipButton onClick={ this.handleSkipButtonClick } /> }
+					<PlansSkipButton onClick={ this.handleSkipButtonClick } />
 				</PlansGrid>
 			</div>
 		);

--- a/client/jetpack-connect/plans.jsx
+++ b/client/jetpack-connect/plans.jsx
@@ -43,7 +43,6 @@ import {
 } from 'state/jetpack-connect/selectors';
 import { mc } from 'lib/analytics';
 import { isSiteAutomatedTransfer } from 'state/selectors';
-import { abtest } from 'lib/abtest';
 
 const CALYPSO_REDIRECTION_PAGE = '/posts/';
 const CALYPSO_PLANS_PAGE = '/plans/my-plan/';
@@ -303,8 +302,6 @@ class Plans extends Component {
 			return <QueryPlans />;
 		}
 
-		const hideFreePlanTest = abtest( 'jetpackConnectHideFreePlan' ) === 'hide';
-
 		return (
 			<div>
 				<QueryPlans />
@@ -319,9 +316,9 @@ class Plans extends Component {
 					onSelect={
 						this.props.showFirst || this.props.isLanding ? this.storeSelectedPlan : this.selectPlan
 					}
-					hideFreePlan={ hideFreePlanTest }
+					hideFreePlan={ true }
 				>
-					{ hideFreePlanTest && <PlansSkipButton onClick={ this.handleSkipButtonClick } /> }
+					<PlansSkipButton onClick={ this.handleSkipButtonClick } />
 				</PlansGrid>
 			</div>
 		);

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -33,14 +33,6 @@ module.exports = {
 		defaultVariation: 'original',
 		localeTargets: 'any',
 	},
-	jetpackConnectHideFreePlan: {
-		datestamp: '20170905',
-		variations: {
-			show: 50,
-			hide: 50,
-		},
-		defaultVariation: 'show',
-	},
 	newSiteWithJetpack: {
 		datestamp: '20170419',
 		variations: {


### PR DESCRIPTION
Remove the `jetpackConnectHideFreePlan` test using the `hide` challenger.

## Testing
1. Connect a new Jetpack site (append `&calypso_env=development` to the end of the connection URL to connect via calypso.localhost:3000).
1. Verify that the abtest is removed (hover the the abtest bug and look for `jetpackConnectHideFreePlan`)
1. Verify you see the **Skip** button and no free offering on the plans page shown immediately after connection.

## Screens

### Before

![before](https://user-images.githubusercontent.com/841763/30798743-fc0e0170-a1da-11e7-8d98-458cb95a9aae.png)

### After

#### Plans

![after-plans](https://user-images.githubusercontent.com/841763/30798752-01a52e88-a1db-11e7-8ab2-972f0eb8bf9b.png)

#### AB Tests

![after-abtest](https://user-images.githubusercontent.com/841763/30798771-0ce0b448-a1db-11e7-9d4f-b30ef7b49cc9.png)

/cc @richardmuscat 

via p7kMJG-3k8-p2