### PR TITLE
Plans: Add monthly/yearly billing button text test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -113,4 +113,12 @@ module.exports = {
 		allowExistingUsers: true,
 		localeTargets: 'any',
 	},
+	jetpackBillingButtonTextI1: {
+		datestamp: '20170925',
+		variations: {
+			original: 50,
+			modified: 50,
+		},
+		defaultVariation: 'original',
+	},
 };

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -32,6 +32,7 @@ import purchasesPaths from 'me/purchases/paths';
 import { plansLink } from 'lib/plans';
 import SegmentedControl from 'components/segmented-control';
 import SegmentedControlItem from 'components/segmented-control/item';
+import { abtest } from 'lib/abtest';
 
 class PlansFeaturesMain extends Component {
 	getPlanFeatures() {
@@ -336,20 +337,28 @@ class PlansFeaturesMain extends Component {
 			plansUrl = basePlansPath;
 		}
 
+		const isInBillingButtonTest = abtest( 'jetpackBillingButtonTextI1' ) === 'modified';
+
 		return (
 			<SegmentedControl compact className={ segmentClasses } primary={ true }>
 				<SegmentedControlItem
 					selected={ intervalType === 'monthly' }
 					path={ plansLink( plansUrl, site, 'monthly' ) }
 				>
-					{ translate( 'Monthly billing' ) }
+					{ isInBillingButtonTest
+						? translate( 'Monthly' )
+						: translate( 'Monthly billing' )
+					}
 				</SegmentedControlItem>
 
 				<SegmentedControlItem
 					selected={ intervalType === 'yearly' }
 					path={ plansLink( plansUrl, site, 'yearly' ) }
 				>
-					{ translate( 'Yearly billing' ) }
+					{ isInBillingButtonTest
+						? translate( 'Yearly (Cheaper)' )
+						: translate( 'Yearly billing' )
+					}
 				</SegmentedControlItem>
 			</SegmentedControl>
 		);


### PR DESCRIPTION
Add a test (`jetpackBillingButtonTextI1`) for modifying the monthly/yearly buttons on plans pages.

## Testing
1. Connect a new Jetpack site (append `&calypso_env=development` to the end of the connection URL to connect via calypso.localhost:3000).
1. Verify the original and modified versions are correct when you arrive at the plans page of the connection flow
1. After connecting a Jetpack site, visit `/plans` and verify the original and modified versions of the buttons are correct.


## Screens

### `/plans`

#### Original

![original](https://user-images.githubusercontent.com/841763/30802222-10ef5f7a-a1e6-11e7-8976-3340141d028e.png)

#### Modified

![modified](https://user-images.githubusercontent.com/841763/30802228-147c975c-a1e6-11e7-878f-fe51f1bc42f0.png)


### Jetpack connect (`/jetpack/connect/plans/{site}`

#### Original

![orig-connect](https://user-images.githubusercontent.com/841763/30802218-0cba26a6-a1e6-11e7-8f17-ef2fdd74a17c.png)

#### Modified

![mod-connect](https://user-images.githubusercontent.com/841763/30802212-092b6c70-a1e6-11e7-95bc-5632c1fb6a24.png)

cc/ @richardmuscat 

via p7kMJG-3kb-p2