### PR TITLE
Codemods: Add sort-imports and remove pauses from runmods script

### DIFF
--- a/bin/runmods.sh
+++ b/bin/runmods.sh
@@ -17,6 +17,7 @@ MODS=(
   'i18n-mixin'
   'react-create-class'
   'react-prop-types'
+  'sort-imports'
   # 'combine-reducer-with-persistence'
   # 'combine-state-utils-imports'
   # 'merge-lodash-imports'

--- a/bin/runmods.sh
+++ b/bin/runmods.sh
@@ -33,6 +33,12 @@ for MOD in "${MODS[@]}"; do
 
 	"./bin/codemods/$MOD" $TARGET
 
+	# sort-imports needs to be run twice sometimes
+	# see https://github.com/Automattic/wp-calypso/pull/18070
+	if [[ $MOD == 'sort-imports' ]]; then
+		"./bin/codemods/$MOD" $TARGET
+	fi
+
 	# Check for changes
 	if [[ -n "$( git diff --name-only )" ]]; then
 		# Try to fix lint issues (but don't fail on lint errors)

--- a/bin/runmods.sh
+++ b/bin/runmods.sh
@@ -27,9 +27,9 @@ MODS=(
 )
 
 for MOD in "${MODS[@]}"; do
+	echo
 	echo "Running $MOD on $TARGET"
 	echo
-	read -p "Press any key to continue."
 
 	"./bin/codemods/$MOD" $TARGET
 


### PR DESCRIPTION
Adds the sort-imports script which will improve experience. The `prop-types` codemod in particular does strange things to `imports`.

Remove pauses and the need to hit a key several times during the process.