### PR TITLE
Framework: bump react-virtualized from 9.4.0 to 9.10.1

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -661,7 +661,7 @@
       "version": "6.26.0",
       "dependencies": {
         "debug": {
-          "version": "2.6.8"
+          "version": "2.6.9"
         },
         "lodash": {
           "version": "4.17.4"
@@ -723,9 +723,6 @@
     },
     "binary-extensions": {
       "version": "1.10.0"
-    },
-    "binary-search-bounds": {
-      "version": "1.0.0"
     },
     "bindings": {
       "version": "1.2.1"
@@ -879,10 +876,10 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000733"
+      "version": "1.0.30000738"
     },
     "caniuse-lite": {
-      "version": "1.0.30000733"
+      "version": "1.0.30000738"
     },
     "cardinal": {
       "version": "1.0.0",
@@ -1577,7 +1574,7 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.21"
+      "version": "1.3.22"
     },
     "element-class": {
       "version": "0.2.2"
@@ -3116,9 +3113,6 @@
     "interpret": {
       "version": "1.0.4"
     },
-    "interval-tree-1d": {
-      "version": "1.0.3"
-    },
     "invariant": {
       "version": "2.2.2"
     },
@@ -3375,7 +3369,7 @@
       "dev": true,
       "dependencies": {
         "debug": {
-          "version": "2.6.8",
+          "version": "2.6.9",
           "dev": true
         },
         "ms": {
@@ -4623,7 +4617,7 @@
       "version": "2.0.4"
     },
     "nwmatcher": {
-      "version": "1.4.1",
+      "version": "1.4.2",
       "dev": true
     },
     "oauth-sign": {
@@ -4927,7 +4921,7 @@
           "dev": true
         },
         "postcss": {
-          "version": "6.0.11",
+          "version": "6.0.12",
           "dev": true
         },
         "source-map": {
@@ -5031,7 +5025,7 @@
           "dev": true
         },
         "postcss": {
-          "version": "6.0.11",
+          "version": "6.0.12",
           "dev": true,
           "dependencies": {
             "ansi-styles": {
@@ -5332,7 +5326,7 @@
       }
     },
     "react-virtualized": {
-      "version": "9.4.0",
+      "version": "9.10.1",
       "dependencies": {
         "classnames": {
           "version": "2.2.5"
@@ -6338,7 +6332,7 @@
       "version": "0.0.1"
     },
     "tough-cookie": {
-      "version": "2.3.2"
+      "version": "2.3.3"
     },
     "tr46": {
       "version": "0.0.3",
@@ -6719,7 +6713,7 @@
           "dev": true
         },
         "debug": {
-          "version": "2.6.8",
+          "version": "2.6.9",
           "dev": true
         },
         "destroy": {
@@ -6735,7 +6729,7 @@
           "dev": true
         },
         "express": {
-          "version": "4.15.4",
+          "version": "4.15.5",
           "dev": true
         },
         "filesize": {
@@ -6743,11 +6737,11 @@
           "dev": true
         },
         "finalhandler": {
-          "version": "1.0.5",
+          "version": "1.0.6",
           "dev": true
         },
         "fresh": {
-          "version": "0.5.0",
+          "version": "0.5.2",
           "dev": true
         },
         "ipaddr.js": {
@@ -6787,11 +6781,11 @@
           "dev": true
         },
         "send": {
-          "version": "0.15.4",
+          "version": "0.15.6",
           "dev": true
         },
         "serve-static": {
-          "version": "1.12.4",
+          "version": "1.12.6",
           "dev": true
         },
         "supports-color": {
@@ -6803,7 +6797,7 @@
           "dev": true
         },
         "vary": {
-          "version": "1.1.1",
+          "version": "1.1.2",
           "dev": true
         },
         "ws": {

--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
     "react-modal": "1.6.5",
     "react-pure-render": "1.0.2",
     "react-redux": "5.0.3",
-    "react-virtualized": "9.4.0",
+    "react-virtualized": "9.10.1",
     "redux": "3.0.4",
     "redux-form": "7.0.2",
     "redux-thunk": "1.0.0",


### PR DESCRIPTION
This PR updates the version of `react-virtualized` to 9.10.1.

The 9.10 release includes improvements to the accessibility of the `Grid` component, which should help us sort out #16585 (see https://github.com/Automattic/wp-calypso/issues/16585#issuecomment-318462471).

Changelog: https://github.com/bvaughn/react-virtualized/blob/master/CHANGELOG.md

### To test 

Ensure that parts of Calypso dependent on `react-virtualized` still function as expected. These include:

Reader Manage Following
http://calypso.localhost:3000/following/manage

Reader streams, e.g. Following Stream
http://calypso.localhost:3000/

These components and blocks also use `react-virtualized` but do not have a Devdocs example:
* `blocks/taxonomy-manager`
* `blocks/term-tree-selector`
* `components/virtual-list`
* `my-sites/post-selector`
* `my-sites/post-type-list`