### PR TITLE
Plugin upload: Notices for uploading to simple business sites

### DIFF
--- a/client/state/data-layer/wpcom/sites/automated-transfer/initiate/index.js
+++ b/client/state/data-layer/wpcom/sites/automated-transfer/initiate/index.js
@@ -1,8 +1,14 @@
 /**
+ * External dependencies
+ */
+import { translate } from 'i18n-calypso';
+
+/**
  * Internal dependencies
  */
 import { AUTOMATED_TRANSFER_INITIATE_WITH_PLUGIN_ZIP } from 'state/action-types';
 import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
+import { errorNotice } from 'state/notices/actions';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { updatePluginUploadProgress, pluginUploadError } from 'state/plugins/upload/actions';
 import { getAutomatedTransferStatus } from 'state/automated-transfer/actions';
@@ -29,6 +35,14 @@ export const receiveResponse = ( { dispatch }, { siteId } ) => {
 };
 
 export const receiveError = ( { dispatch }, { siteId }, error ) => {
+	if ( error.error ) {
+		dispatch( errorNotice( translate( 'Upload problem: %(error)s.', {
+			args: { error: error.error }
+		} ) ) );
+	} else {
+		dispatch( errorNotice( translate( 'Problem uploading the plugin.' ) ) );
+	}
+
 	dispatch( pluginUploadError( siteId, error ) );
 };
 

--- a/client/state/data-layer/wpcom/sites/automated-transfer/initiate/test/index.js
+++ b/client/state/data-layer/wpcom/sites/automated-transfer/initiate/test/index.js
@@ -52,9 +52,19 @@ describe( 'receiveError', () => {
 	it( 'should dispatch a plugin upload error', () => {
 		const dispatch = sinon.spy();
 		receiveError( { dispatch }, { siteId }, ERROR_RESPONSE );
+		expect( dispatch ).to.have.been.calledTwice;
 		expect( dispatch ).to.have.been.calledWith(
 			pluginUploadError( siteId, ERROR_RESPONSE )
 		);
+	} );
+
+	it( 'should dispatch an error notice', () => {
+		const dispatch = sinon.spy();
+		receiveError( { dispatch }, { siteId }, ERROR_RESPONSE );
+		expect( dispatch ).to.have.been.calledTwice;
+		expect( dispatch ).to.have.been.calledWithMatch( {
+			notice: { text: 'Upload problem: invalid_input.' }
+		} );
 	} );
 } );
 

--- a/client/state/data-layer/wpcom/sites/automated-transfer/status/test/index.js
+++ b/client/state/data-layer/wpcom/sites/automated-transfer/status/test/index.js
@@ -49,9 +49,19 @@ describe( 'receiveStatus', () => {
 	it( 'should dispatch set status action', () => {
 		const dispatch = sinon.spy();
 		receiveStatus( { dispatch }, { siteId }, COMPLETE_RESPONSE );
+		expect( dispatch ).to.have.been.calledThrice;
 		expect( dispatch ).to.have.been.calledWith(
 			setAutomatedTransferStatus( siteId, 'complete', 'hello-dolly' )
 		);
+	} );
+
+	it( 'should dispatch success notice if complete', () => {
+		const dispatch = sinon.spy();
+		receiveStatus( { dispatch }, { siteId }, COMPLETE_RESPONSE );
+		expect( dispatch ).to.have.been.calledThrice;
+		expect( dispatch ).to.have.been.calledWithMatch( {
+			notice: { text: "You've successfully uploaded the hello-dolly plugin." }
+		} );
 	} );
 
 	it( 'should request status again if not complete', () => {


### PR DESCRIPTION
<img width="1247" alt="screen shot 2017-09-25 at 13 23 17" src="https://user-images.githubusercontent.com/7767559/30808170-e1eacaf2-a1f4-11e7-8f17-3491fa6ed671.png">

Add success and error notices for plugin uploads that initiate a transfer.

**To Test**
* Run unit tests

(To test fully in the UI, follow instructions at p58i-4Uy-p2, but upload a plugin to initiate a transfer at  /plugins/upload/{site}).
