### PR TITLE
Magic Login: Enable feature flag in production env

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -30,6 +30,7 @@
 		"help/courses": true,
 		"jetpack/activity-log": true,
 		"jetpack/api-cache": false,
+		"login/magic-login": true,
 		"login/native-login-links": true,
 		"login/wp-login": true,
 		"manage/custom-post-types": true,


### PR DESCRIPTION
Magic Login has been in testing a long while. This PR enables in production 🎉!

## To Test

* Open the staging environment in an incognito / logged out window (production should act identically after this PR is merged)
* Click `Log In`
* Click the `Email me a login link` link
* Request an email
* Click through the CTA in the email in the incognito window (you should land on domain: `wordpress.com`)
* Complete the flow
* Report any blockers