### PR TITLE
Reader: add ARIA roles to Manage Following grid

### DIFF
--- a/client/components/reader-infinite-stream/index.js
+++ b/client/components/reader-infinite-stream/index.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External Dependencies
  */
@@ -51,10 +52,12 @@ class ReaderInfiniteStream extends Component {
 		const railcar = get( this.props.items[ rowRendererProps.index ], 'railcar', undefined );
 		if ( railcar && ! this.recordedRender.has( rowRendererProps.index ) ) {
 			this.recordedRender.add( rowRendererProps.index );
-			this.recordTraintrackForRowRender( pickBy( {
-				index: rowRendererProps.index,
-				railcar,
-			} ) );
+			this.recordTraintrackForRowRender(
+				pickBy( {
+					index: rowRendererProps.index,
+					railcar,
+				} )
+			);
 		}
 
 		return this.props.rowRenderer( {
@@ -74,7 +77,7 @@ class ReaderInfiniteStream extends Component {
 			parent={ parent }
 		>
 			{ ( { measure } ) => (
-				<div key={ key } style={ style } className="reader-infinite-stream__row-wrapper">
+				<div key={ key } style={ style } className="reader-infinite-stream__row-wrapper" role="row">
 					<ComponentToMeasure { ...props } onShouldMeasure={ measure } />
 				</div>
 			) }


### PR DESCRIPTION
Combined with some changes in the latest version of `react-virtualized`(see https://github.com/bvaughn/react-virtualized/pull/744), this should make it possible to navigate through your subscriptions on Following Manage using a screen reader.

Fixes https://github.com/Automattic/wp-calypso/issues/16585.

### To test

Open VoiceOver on OS X (or your favourite screenreader) and visit:

http://calypso.localhost:3000/following/manage

Make sure the screenreader is able to read all of your subscriptions (previously, the subscriptions table reported "0 rows, 0 columns" when you tabbed to it).