### PR TITLE
Activity log: Update rewind dialog

### DIFF
--- a/client/my-sites/stats/activity-log-confirm-dialog/index.jsx
+++ b/client/my-sites/stats/activity-log-confirm-dialog/index.jsx
@@ -48,8 +48,8 @@ class ActivityLogConfirmDialog extends Component {
 					} ) }
 				</HappychatButton>
 				<Button onClick={ onClose }>{ translate( 'Cancel' ) }</Button>
-				<Button primary scary onClick={ onConfirm }>
-					{ translate( 'Restore' ) }
+				<Button primary onClick={ onConfirm }>
+					{ translate( 'Confirm Rewind' ) }
 				</Button>
 			</div>
 		);

--- a/client/my-sites/stats/activity-log-confirm-dialog/index.jsx
+++ b/client/my-sites/stats/activity-log-confirm-dialog/index.jsx
@@ -13,6 +13,7 @@ import ActivityIcon from '../activity-log-item/activity-icon';
 import Button from 'components/button';
 import Card from 'components/card';
 import Gridicon from 'gridicons';
+import HappychatButton from 'components/happychat/button';
 
 class ActivityLogConfirmDialog extends Component {
 	static propTypes = {
@@ -38,14 +39,14 @@ class ActivityLogConfirmDialog extends Component {
 						components: { icon: <Gridicon icon={ 'notice' } /> },
 					} ) }
 				</a>
-				<a
+				<HappychatButton
 					className="activity-log-confirm-dialog__more-info-link"
 					href="https://help.vaultpress.com/one-click-restore/"
 				>
 					{ translate( '{{icon /}} Any Questions?', {
 						components: { icon: <Gridicon icon={ 'chat' } /> },
 					} ) }
-				</a>
+				</HappychatButton>
 				<Button onClick={ onClose }>{ translate( 'Cancel' ) }</Button>
 				<Button primary scary onClick={ onConfirm }>
 					{ translate( 'Restore' ) }

--- a/client/my-sites/stats/activity-log-confirm-dialog/index.jsx
+++ b/client/my-sites/stats/activity-log-confirm-dialog/index.jsx
@@ -29,30 +29,34 @@ class ActivityLogConfirmDialog extends Component {
 
 	renderButtons() {
 		const { onClose, onConfirm, translate } = this.props;
-		return (
-			<div>
+		return [
+			<div className="activity-log-confirm-dialog__primary-actions">
+				<Button onClick={ onClose }>{ translate( 'Cancel' ) }</Button>
+				<Button primary onClick={ onConfirm }>
+					{ translate( 'Confirm Rewind' ) }
+				</Button>
+			</div>,
+			<div className="activity-log-confirm-dialog__secondary-actions">
 				<a
 					className="activity-log-confirm-dialog__more-info-link"
 					href="https://help.vaultpress.com/one-click-restore/"
 				>
-					{ translate( '{{icon /}} More info', {
-						components: { icon: <Gridicon icon={ 'notice' } /> },
-					} ) }
+					<Gridicon icon="notice" />
+					<span className="activity-log-confirm-dialog__more-info-link-text">
+						{ translate( 'More info' ) }
+					</span>
 				</a>
 				<HappychatButton
 					className="activity-log-confirm-dialog__more-info-link"
 					href="https://help.vaultpress.com/one-click-restore/"
 				>
-					{ translate( '{{icon /}} Any Questions?', {
-						components: { icon: <Gridicon icon={ 'chat' } /> },
-					} ) }
+					<Gridicon icon="chat" />
+					<span className="activity-log-confirm-dialog__more-info-link-text">
+						{ translate( 'Any Questions?' ) }
+					</span>
 				</HappychatButton>
-				<Button onClick={ onClose }>{ translate( 'Cancel' ) }</Button>
-				<Button primary onClick={ onConfirm }>
-					{ translate( 'Confirm Rewind' ) }
-				</Button>
-			</div>
-		);
+			</div>,
+		];
 	}
 
 	render() {
@@ -65,13 +69,12 @@ class ActivityLogConfirmDialog extends Component {
 					<ActivityIcon activityIcon={ 'history' } />
 				</div>
 				<Card className="activity-log-item__card">
-					<h1>{ translate( 'Rewind Site' ) }</h1>
+					<h5 className="activity-log-confirm-dialog__title">{ translate( 'Rewind Site' ) }</h5>
 
 					<p className="activity-log-confirm-dialog__highlight">
 						{ translate(
-							'This is the selected point for your site Rewind.' +
-								'Are you sure you want to rewind your site back to ' +
-								'{{b}}%(time)s{{/b}}?',
+							'This is the selected point for your site Rewind. ' +
+								'Are you sure you want to rewind your site back to {{b}}%(time)s{{/b}}?',
 							{
 								args: {
 									time: applySiteOffset( moment.utc( timestamp ) ).format( 'LLL' ),

--- a/client/my-sites/stats/activity-log-confirm-dialog/index.jsx
+++ b/client/my-sites/stats/activity-log-confirm-dialog/index.jsx
@@ -1,9 +1,7 @@
+/** @format */
 /**
  * External dependencies
- *
- * @format
  */
-
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
@@ -11,17 +9,16 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import Dialog from 'components/dialog';
+import ActivityIcon from '../activity-log-item/activity-icon';
 import Button from 'components/button';
+import Card from 'components/card';
 import Gridicon from 'gridicons';
 
 class ActivityLogConfirmDialog extends Component {
 	static propTypes = {
 		applySiteOffset: PropTypes.func.isRequired,
-		isVisible: PropTypes.bool.isRequired,
 		onClose: PropTypes.func.isRequired,
 		onConfirm: PropTypes.func.isRequired,
-		siteTitle: PropTypes.string,
 		timestamp: PropTypes.number,
 
 		// Localize
@@ -29,14 +26,26 @@ class ActivityLogConfirmDialog extends Component {
 		moment: PropTypes.func.isRequired,
 	};
 
-	static defaultProps = {
-		isVisible: false,
-	};
-
 	renderButtons() {
 		const { onClose, onConfirm, translate } = this.props;
 		return (
 			<div>
+				<a
+					className="activity-log-confirm-dialog__more-info-link"
+					href="https://help.vaultpress.com/one-click-restore/"
+				>
+					{ translate( '{{icon /}} More info', {
+						components: { icon: <Gridicon icon={ 'notice' } /> },
+					} ) }
+				</a>
+				<a
+					className="activity-log-confirm-dialog__more-info-link"
+					href="https://help.vaultpress.com/one-click-restore/"
+				>
+					{ translate( '{{icon /}} Any Questions?', {
+						components: { icon: <Gridicon icon={ 'chat' } /> },
+					} ) }
+				</a>
 				<Button onClick={ onClose }>{ translate( 'Cancel' ) }</Button>
 				<Button primary scary onClick={ onConfirm }>
 					{ translate( 'Restore' ) }
@@ -46,45 +55,43 @@ class ActivityLogConfirmDialog extends Component {
 	}
 
 	render() {
-		const { applySiteOffset, isVisible, moment, siteTitle, timestamp, translate } = this.props;
+		const { applySiteOffset, moment, timestamp, translate } = this.props;
 
+		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		return (
-			<Dialog additionalClassNames="activity-log-confirm-dialog" isVisible={ isVisible }>
-				<h1>{ translate( 'Restore Site' ) }</h1>
-				<p className="activity-log-confirm-dialog__highlight">
-					{ translate( 'To proceed please confirm this restore on your site %(siteTitle)s', {
-						args: { siteTitle },
-					} ) }
-				</p>
-
-				<div className="activity-log-confirm-dialog__line">
-					<Gridicon icon={ 'history' } />
-					{ timestamp ? (
-						translate( 'Restoring to {{b}}%(time)s{{/b}}', {
-							args: {
-								time: applySiteOffset( moment.utc( timestamp ) ).format( 'LLL' ),
-							},
-							components: { b: <b /> },
-						} )
-					) : (
-						' '
-					) }
+			<div className="activity-log-item activity-log-item__restore-confirm">
+				<div className="activity-log-item__type">
+					<ActivityIcon activityIcon={ 'history' } />
 				</div>
-				<div className="activity-log-confirm-dialog__line">
-					<Gridicon icon={ 'notice' } />
-					{ translate( 'This will remove all content and options created or changed since then.' ) }
-				</div>
+				<Card className="activity-log-item__card">
+					<h1>{ translate( 'Rewind Site' ) }</h1>
 
-				<div className="activity-log-confirm-dialog__button-wrap">{ this.renderButtons() }</div>
+					<p className="activity-log-confirm-dialog__highlight">
+						{ translate(
+							'This is the selected point for your site Rewind.' +
+								'Are you sure you want to rewind your site back to ' +
+								'{{b}}%(time)s{{/b}}?',
+							{
+								args: {
+									time: applySiteOffset( moment.utc( timestamp ) ).format( 'LLL' ),
+								},
+								components: { b: <b /> },
+							}
+						) }
+					</p>
 
-				<a
-					className="activity-log-confirm-dialog__more-info-link"
-					href="https://help.vaultpress.com/one-click-restore/"
-				>
-					{ translate( 'Read more about site restores' ) }
-				</a>
-			</Dialog>
+					<p>
+						<Gridicon icon={ 'notice' } />
+						{ translate(
+							'This will remove all content and options created or changed since then.'
+						) }
+					</p>
+
+					<div className="activity-log-confirm-dialog__button-wrap">{ this.renderButtons() }</div>
+				</Card>
+			</div>
 		);
+		/* eslint-enable wpcalypso/jsx-classname-namespace */
 	}
 }
 

--- a/client/my-sites/stats/activity-log-confirm-dialog/index.jsx
+++ b/client/my-sites/stats/activity-log-confirm-dialog/index.jsx
@@ -81,12 +81,14 @@ class ActivityLogConfirmDialog extends Component {
 						) }
 					</p>
 
-					<p>
+					<div className="activity-log-confirm-dialog__notice">
 						<Gridicon icon={ 'notice' } />
-						{ translate(
-							'This will remove all content and options created or changed since then.'
-						) }
-					</p>
+						<span className="activity-log-confirm-dialog__notice-content">
+							{ translate(
+								'This will remove all content and options created or changed since then.'
+							) }
+						</span>
+					</div>
 
 					<div className="activity-log-confirm-dialog__button-wrap">{ this.renderButtons() }</div>
 				</Card>

--- a/client/my-sites/stats/activity-log-confirm-dialog/style.scss
+++ b/client/my-sites/stats/activity-log-confirm-dialog/style.scss
@@ -1,4 +1,3 @@
-
 .activity-log-confirm-dialog.dialog.card {
 	text-align: center;
 	max-width: 400px;
@@ -6,7 +5,10 @@
 
 .activity-log-item__restore-confirm {
 	.activity-log-item__card {
-		padding-bottom: 16px;
+		padding-bottom: 8px;
+		border-radius: 4px;
+		box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ),
+		0 2px 5px lighten( $gray, 20% );
 	}
 }
 
@@ -112,7 +114,7 @@
 	}
 
 	.button {
-		margin: 0 4px;
+		margin: 0 4px 8px;
 
 		@include breakpoint("<480px") {
 			margin: 0 8px 0 0;
@@ -121,8 +123,10 @@
 }
 
 .activity-log-confirm-dialog__primary-actions {
+	text-align: right;
 	@include breakpoint("<480px") {
 		margin-bottom: 8px;
+		text-align: left;
 	}
 }
 
@@ -136,8 +140,7 @@
 
 .activity-log-confirm-dialog__more-info-link {
 	color: $gray;
-	padding: 7px 0 0;
-	line-height: 1;
+	padding: 7px 8px 0 0;
 	display: inline-block;
 
 	.gridicon {
@@ -148,12 +151,8 @@
 			width: 24px;
 			height: 24px;
 		}
-		vertical-align: middle;
-	}
-
-	.activity-log-confirm-dialog__more-info-link-text {
-		padding-left: 8px;
-		vertical-align: middle;
+		float: left;
+		margin-right: 8px;
 	}
 }
 

--- a/client/my-sites/stats/activity-log-confirm-dialog/style.scss
+++ b/client/my-sites/stats/activity-log-confirm-dialog/style.scss
@@ -24,6 +24,53 @@
 	font-size: 16px;
 }
 
+.activity-log-confirm-dialog__notice {
+	display: flex;
+	flex-direction: column;
+	position: relative;
+	width: 100%;
+	margin-bottom: 24px;
+	box-sizing: border-box;
+	animation: appear .3s ease-in-out;
+
+	@include breakpoint(">480px") {
+		flex-direction: row;
+	}
+
+	.gridicons-notice {
+		fill: $alert-red;
+		position: absolute;
+		top: 0;
+		left: 0;
+		display: flex;
+		-ms-flex-negative: 0;
+		flex-shrink: 0;
+		width: 18px;
+		height: 18px;
+
+		@include breakpoint(">480px") {
+			position: relative;
+			width: 24px;
+			height: 24px;
+		}
+	}
+}
+
+.activity-log-confirm-dialog__notice-content {
+	color: $alert-red;
+	display: flex;
+	-webkit-box-flex: 1;
+	-ms-flex-positive: 1;
+	flex-grow: 1;
+	padding-left: 24px;
+	font-size: 12px;
+
+	@include breakpoint(">480px") {
+		padding-left: 8px;
+		font-size: 14px;
+	}
+}
+
 .activity-log-confirm-dialog__line {
 	padding: 14px 24px 14px 44px;
 	text-align: left;

--- a/client/my-sites/stats/activity-log-confirm-dialog/style.scss
+++ b/client/my-sites/stats/activity-log-confirm-dialog/style.scss
@@ -4,6 +4,12 @@
 	max-width: 400px;
 }
 
+.activity-log-item__restore-confirm {
+	.activity-log-item__card {
+		padding-bottom: 16px;
+	}
+}
+
 .activity-log-confirm-dialog .dialog__content {
 	color: darken( $gray, 20% );
 
@@ -18,10 +24,14 @@
 	}
 }
 
+.activity-log-confirm-dialog__title {
+	font-size: 21px;
+	margin-bottom: 12px;
+	line-height: 1;
+}
+
 .activity-log-confirm-dialog__highlight {
-	color: darken( $gray, 10% );
-	margin-bottom: 1.5em;
-	font-size: 16px;
+	margin-bottom: 24px;
 }
 
 .activity-log-confirm-dialog__notice {
@@ -90,16 +100,61 @@
 }
 
 .activity-log-confirm-dialog__button-wrap {
-	margin-top: 32px;
-	margin-bottom:16px;
+	margin: 0 -24px;
+	padding: 16px 24px 0;
+	border-top: #eee 1px solid;
+	display: block;
+
+	@include breakpoint(">480px") {
+		display: flex;
+		justify-content: space-between;
+		flex-direction: row-reverse;
+	}
 
 	.button {
 		margin: 0 4px;
+
+		@include breakpoint("<480px") {
+			margin: 0 8px 0 0;
+		}
+	}
+}
+
+.activity-log-confirm-dialog__primary-actions {
+	@include breakpoint("<480px") {
+		margin-bottom: 8px;
+	}
+}
+
+.activity-log-confirm-dialog__secondary-actions {
+	font-size: 14px;
+
+	@include breakpoint("<480px") {
+		font-size: 12px;
 	}
 }
 
 .activity-log-confirm-dialog__more-info-link {
-	font-size: 13px;
+	color: $gray;
+	padding: 7px 0 0;
+	line-height: 1;
+	display: inline-block;
+
+	.gridicon {
+		width: 18px;
+		height: 18px;
+
+		@include breakpoint(">480px") {
+			width: 24px;
+			height: 24px;
+		}
+		vertical-align: middle;
+	}
+
+	.activity-log-confirm-dialog__more-info-link-text {
+		padding-left: 8px;
+		vertical-align: middle;
+	}
 }
 
 .activity-log-confirm-dialog__dialog__action-buttons {

--- a/client/my-sites/stats/activity-log-day/index.jsx
+++ b/client/my-sites/stats/activity-log-day/index.jsx
@@ -10,7 +10,7 @@ import classnames from 'classnames';
 import Gridicon from 'gridicons';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { get, isEmpty, map } from 'lodash';
+import { flatMap, get, isEmpty } from 'lodash';
 
 /**
  * Internal dependencies
@@ -34,6 +34,7 @@ class ActivityLogDay extends Component {
 		logs: PropTypes.array.isRequired,
 		requestedRestoreActivityId: PropTypes.string,
 		requestRestore: PropTypes.func.isRequired,
+		rewindConfirmDialog: PropTypes.element,
 		siteId: PropTypes.number,
 		tsEndOfSiteDay: PropTypes.number.isRequired,
 
@@ -139,7 +140,9 @@ class ActivityLogDay extends Component {
 			hideRestore,
 			isToday,
 			logs,
+			requestedRestoreActivityId,
 			requestRestore,
+			rewindConfirmDialog,
 			siteId,
 		} = this.props;
 
@@ -155,17 +158,19 @@ class ActivityLogDay extends Component {
 					onOpen={ this.trackOpenDay }
 					summary={ hasLogs ? this.renderRewindButton( 'primary' ) : null }
 				>
-					{ hasLogs && map( logs, log => (
-						<ActivityLogItem
-							applySiteOffset={ applySiteOffset }
-							disableRestore={ disableRestore }
-							hideRestore={ hideRestore }
-							key={ log.activityId }
-							log={ log }
-							requestRestore={ requestRestore }
-							siteId={ siteId }
-						/>
-					) ) }
+					{ hasLogs &&
+						flatMap( logs, log => [
+							log.activityId === requestedRestoreActivityId && rewindConfirmDialog,
+							<ActivityLogItem
+								applySiteOffset={ applySiteOffset }
+								disableRestore={ disableRestore }
+								hideRestore={ hideRestore }
+								key={ log.activityId }
+								log={ log }
+								requestRestore={ requestRestore }
+								siteId={ siteId }
+							/>,
+						] ) }
 				</FoldableCard>
 			</div>
 		);

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -34,7 +34,6 @@ import StatsNavigation from 'blocks/stats-navigation';
 import StatsPeriodNavigation from 'my-sites/stats/stats-period-navigation';
 import SuccessBanner from '../activity-log-banner/success-banner';
 import { adjustMoment, getActivityLogQuery, getStartMoment } from './utils';
-import { canCurrentUser } from 'state/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSiteSlug, getSiteTitle } from 'state/sites/selectors';
 import { recordTracksEvent as recordTracksEventAction } from 'state/analytics/actions';
@@ -44,6 +43,7 @@ import {
 	rewindRestore as rewindRestoreAction,
 } from 'state/activity-log/actions';
 import {
+	canCurrentUser,
 	getActivityLog,
 	getActivityLogs,
 	getRequestedRewind,

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -257,9 +257,11 @@ class ActivityLog extends Component {
 			logs,
 			moment,
 			requestedRestoreActivityId,
+			requestedRestoreActivity,
 			siteId,
 			translate,
 		} = this.props;
+
 		const startMoment = this.getStartMoment();
 
 		if ( isNull( logs ) ) {
@@ -323,7 +325,19 @@ class ActivityLog extends Component {
 			);
 		}
 
-		return <section className="activity-log__wrapper">{ activityDays }</section>;
+		return (
+			<section className="activity-log__wrapper">
+				{ activityDays }
+				{ requestedRestoreActivity && (
+					<ActivityLogConfirmDialog
+						applySiteOffset={ this.applySiteOffset }
+						timestamp={ requestedRestoreActivity.activityTs }
+						onClose={ this.handleRestoreDialogClose }
+						onConfirm={ this.handleRestoreDialogConfirm }
+					/>
+				) }
+			</section>
+		);
 	}
 
 	renderMonthNavigation( position ) {
@@ -358,9 +372,7 @@ class ActivityLog extends Component {
 			gmtOffset,
 			isPressable,
 			isRewindActive,
-			requestedRestoreActivity,
 			siteId,
-			siteTitle,
 			slug,
 			startDate,
 			timezone,
@@ -396,15 +408,6 @@ class ActivityLog extends Component {
 				{ ! isRewindActive && !! isPressable && <ActivityLogRewindToggle siteId={ siteId } /> }
 				{ this.renderLogs() }
 				{ this.renderMonthNavigation( 'bottom' ) }
-
-				<ActivityLogConfirmDialog
-					applySiteOffset={ this.applySiteOffset }
-					isVisible={ !! requestedRestoreActivity }
-					siteTitle={ siteTitle }
-					timestamp={ requestedRestoreActivity && requestedRestoreActivity.activityTs }
-					onClose={ this.handleRestoreDialogClose }
-					onConfirm={ this.handleRestoreDialogConfirm }
-				/>
 				<JetpackColophon />
 			</Main>
 		);

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -256,12 +256,11 @@ class ActivityLog extends Component {
 			isRewindActive,
 			logs,
 			moment,
-			requestedRestoreActivityId,
 			requestedRestoreActivity,
+			requestedRestoreActivityId,
 			siteId,
 			translate,
 		} = this.props;
-
 		const startMoment = this.getStartMoment();
 
 		if ( isNull( logs ) ) {
@@ -290,6 +289,15 @@ class ActivityLog extends Component {
 				.endOf( 'day' )
 				.valueOf()
 		);
+		const rewindConfirmDialog = requestedRestoreActivity && (
+			<ActivityLogConfirmDialog
+				applySiteOffset={ this.applySiteOffset }
+				key="activity-rewind-dialog"
+				onClose={ this.handleRestoreDialogClose }
+				onConfirm={ this.handleRestoreDialogConfirm }
+				timestamp={ requestedRestoreActivity.activityTs }
+			/>
+		);
 
 		const activityDays = [];
 		// loop backwards through each day in the month
@@ -313,6 +321,7 @@ class ActivityLog extends Component {
 				<ActivityLogDay
 					applySiteOffset={ this.applySiteOffset }
 					requestedRestoreActivityId={ requestedRestoreActivityId }
+					rewindConfirmDialog={ rewindConfirmDialog }
 					disableRestore={ disableRestore }
 					hideRestore={ ! rewindEnabledByConfig || ! isPressable }
 					isRewindActive={ isRewindActive }
@@ -325,19 +334,7 @@ class ActivityLog extends Component {
 			);
 		}
 
-		return (
-			<section className="activity-log__wrapper">
-				{ activityDays }
-				{ requestedRestoreActivity && (
-					<ActivityLogConfirmDialog
-						applySiteOffset={ this.applySiteOffset }
-						timestamp={ requestedRestoreActivity.activityTs }
-						onClose={ this.handleRestoreDialogClose }
-						onConfirm={ this.handleRestoreDialogConfirm }
-					/>
-				) }
-			</section>
-		);
+		return <section className="activity-log__wrapper">{ activityDays }</section>;
 	}
 
 	renderMonthNavigation( position ) {

--- a/client/state/selectors/get-requested-rewind.js
+++ b/client/state/selectors/get-requested-rewind.js
@@ -7,9 +7,9 @@ import { get } from 'lodash';
 /**
  * Returns the requested rewind Activity ID.
  *
- * @param  {Object}        state      Global state tree
- * @param  {number|string} siteId     the site ID
- * @return {?Object}                  Activity log item if found, otherwise null
+ * @param  {Object}        state  Global state tree
+ * @param  {number|string} siteId Site ID
+ * @return {?Object}              Activity log item if found, otherwise null
  */
 export default function getRequestedRewind( state, siteId ) {
 	return get( state, [ 'activityLog', 'restoreRequest', siteId ], null );


### PR DESCRIPTION
This PR changes the way that rewind confirmation dialogs are displayed.
This is an initial implementation that moves the dialog from a modal into the list of activity items just before the "rewound" item.

see p6TEKc-1C7-p2



Includes #18493 



Todo:
- ~When restore is requested, find next backup point in the future and show the dialog there.~