### PR TITLE
Increase the 'back to nav' arrow to match the height of the container

### DIFF
--- a/client/extensions/woocommerce/style.scss
+++ b/client/extensions/woocommerce/style.scss
@@ -185,9 +185,11 @@
 			a {
 				position: fixed;
 				z-index: 1;
-				margin-top: 4px;
+				margin-top: 0;
 				background: transparent;
 				border: none;
+				padding-top: 11px;
+				padding-bottom: 11px;
 			}
 		}
 	}

--- a/client/extensions/woocommerce/style.scss
+++ b/client/extensions/woocommerce/style.scss
@@ -191,6 +191,11 @@
 				padding-top: 11px;
 				padding-bottom: 11px;
 			}
+
+			.gridicons-chevron-left {
+				margin-left: 11px;
+				margin-right: 11px;
+			}
 		}
 	}
 }


### PR DESCRIPTION
This increases the touch-target size of the 'back to nav' icon/link in our screen header from 40x40px to 46x46px (matching the full height of the container).

![46](https://cldup.com/51SWYSKiVk.png)