### PR TITLE
Sort Imports: account for nodejs libs

### DIFF
--- a/bin/codemods/src/sort-imports.js
+++ b/bin/codemods/src/sort-imports.js
@@ -13,7 +13,8 @@ const _ = require( 'lodash' );
  */
 const nodeJsDeps = require( 'repl' )._builtinLibs;
 const packageJson = JSON.parse( fs.readFileSync( './package.json', 'utf8' ) );
-const packageJsonDeps = nodeJsDeps
+const packageJsonDeps = []
+	.concat( nodeJsDeps )
 	.concat( Object.keys( packageJson.dependencies ) )
 	.concat( Object.keys( packageJson.devDependencies ) );
 

--- a/bin/codemods/src/sort-imports.js
+++ b/bin/codemods/src/sort-imports.js
@@ -11,8 +11,9 @@ const _ = require( 'lodash' );
 /**
  * Gather all of the external deps and throw them in a set
  */
+const nodeJsDeps = require( 'repl' )._builtinLibs;
 const packageJson = JSON.parse( fs.readFileSync( './package.json', 'utf8' ) );
-const packageJsonDeps = []
+const packageJsonDeps = nodeJsDeps
 	.concat( Object.keys( packageJson.dependencies ) )
 	.concat( Object.keys( packageJson.devDependencies ) );
 


### PR DESCRIPTION
Currently the `sort-imports` codemod does not account for internal nodejs libs. It marks them as internal deps even though they should be external deps.

To Test
-----

Compare the output of files with nodejs dependencies.  A common one would be `url` like in: `client/reader/discover/helper.js`