### PR TITLE
Store-Promotions: Use gift icon for sidebar

### DIFF
--- a/client/extensions/woocommerce/store-sidebar/index.js
+++ b/client/extensions/woocommerce/store-sidebar/index.js
@@ -195,7 +195,7 @@ class StoreSidebar extends Component {
 		return (
 			<SidebarItem
 				className={ classes }
-				icon="star-outline"
+				icon="gift"
 				label={ translate( 'Promotions' ) }
 				link={ link }
 			>


### PR DESCRIPTION
This sets the "gift" gridicon for the promotions sidebar item.

To Test:

1. `npm start`
2. Visit http://calypso.localhost:3000/store/<your site url>
3. Observe "gift" icon for the promotions sidebar item.

(See: https://github.com/Automattic/wp-calypso/pull/18138)

Before:
<img width="277" alt="products_ _coderkevin_ _wordpress_com" src="https://user-images.githubusercontent.com/945228/30894701-cf11d1f2-a30a-11e7-8ee8-b7bcf43a8d19.png">

After:
<img width="283" alt="products_ _coderkevin_ _wordpress_com" src="https://user-images.githubusercontent.com/945228/30894714-ede2aa7a-a30a-11e7-8552-8993ec41f51f.png">
