### PR TITLE
Store Orders: Add Customer Details to order creation

### DIFF
--- a/client/extensions/woocommerce/app/order/order-create/customer-card.js
+++ b/client/extensions/woocommerce/app/order/order-create/customer-card.js
@@ -18,8 +18,11 @@ import FormCheckbox from 'components/forms/form-checkbox';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
 import FormLegend from 'components/forms/form-legend';
-import FormTelInput from 'components/forms/form-tel-input';
+import FormPhoneMediaInput from 'components/forms/form-phone-media-input';
 import FormTextInput from 'components/forms/form-text-input';
+// @todo Update this to use our store countries list
+import countriesListBuilder from 'lib/countries-list';
+const countriesList = countriesListBuilder.forPayments();
 
 class OrderCustomerCard extends Component {
 	static propTypes = {
@@ -29,6 +32,7 @@ class OrderCustomerCard extends Component {
 
 	state = {
 		showShipping: false,
+		phoneCountry: 'US',
 	};
 
 	getAddressViewFormat = address => {
@@ -40,6 +44,11 @@ class OrderCustomerCard extends Component {
 			country: address.country || '',
 			postcode: address.postcode || '',
 		};
+	};
+
+	onPhoneChange = phone => {
+		this.updateOrder( 'phoneNumber', phone.value );
+		this.setState( { phoneCountry: phone.countryCode } );
 	};
 
 	onAddressChange = ( type = 'billing' ) => {
@@ -201,12 +210,12 @@ class OrderCustomerCard extends Component {
 							/>
 						</div>
 						<div className="order-create__field">
-							<FormLabel htmlFor="phoneNumber">{ translate( 'Phone Number' ) }</FormLabel>
-							<FormTelInput
-								id="phoneNumber"
-								name="phoneNumber"
+							<FormPhoneMediaInput
+								label={ translate( 'Phone Number' ) }
+								onChange={ this.onPhoneChange }
+								countryCode={ this.state.phoneCountry }
+								countriesList={ countriesList }
 								value={ get( order, [ 'billing', 'phone' ], '' ) }
-								onChange={ this.onChange }
 							/>
 						</div>
 					</div>

--- a/client/extensions/woocommerce/app/order/order-create/customer-card.js
+++ b/client/extensions/woocommerce/app/order/order-create/customer-card.js
@@ -10,6 +10,7 @@ import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
+import AddressView from 'woocommerce/components/address-view';
 import Card from 'components/card';
 import { getOrderWithEdits } from 'woocommerce/state/ui/orders/selectors';
 import FormCheckbox from 'components/forms/form-checkbox';
@@ -18,8 +19,6 @@ import FormLabel from 'components/forms/form-label';
 import FormLegend from 'components/forms/form-legend';
 import FormTelInput from 'components/forms/form-tel-input';
 import FormTextInput from 'components/forms/form-text-input';
-
-const AddressSearch = () => null;
 
 class OrderCustomerCard extends Component {
 	static propTypes = {
@@ -31,26 +30,78 @@ class OrderCustomerCard extends Component {
 		showShipping: false
 	}
 
+	getAddressViewFormat = ( address ) => {
+		return {
+			street: address.address_1 || '',
+			street2: address.address_2 || '',
+			city: address.city || '',
+			state: address.state || '',
+			country: address.country || '',
+			postcode: address.postcode || '',
+		};
+	}
+
+	onAddressChange = ( type = 'billing' ) => {
+		return ( event ) => {
+			this.updateOrder( `${ type }_${ event.target.name }`, event.target.value );
+		};
+	}
+
 	onChange = ( event ) => {
+		this.updateOrder( event.target.name, event.target.value );
+	}
+
+	updateOrder = ( name, value ) => {
 		let updateOrder;
-		switch ( event.target.name ) {
+		switch ( name ) {
 			case 'customerEmail':
-				updateOrder = { billing: { email: event.target.value } };
+				updateOrder = { billing: { email: value } };
 				break;
 			case 'firstName':
-				updateOrder = { billing: { first_name: event.target.value } };
+				updateOrder = { billing: { first_name: value } };
 				break;
 			case 'lastName':
-				updateOrder = { billing: { last_name: event.target.value } };
+				updateOrder = { billing: { last_name: value } };
 				break;
 			case 'phoneNumber':
-				updateOrder = { billing: { phone: event.target.value } };
+				updateOrder = { billing: { phone: value } };
 				break;
+			case 'billing_street':
+				updateOrder = { billing: { address_1: value } };
+				break;
+			case 'billing_street2':
+				updateOrder = { billing: { address_2: value } };
+				break;
+			case 'billing_city':
+			case 'billing_state':
+			case 'billing_country':
+			case 'billing_postcode': {
+				const keyName = name.replace( 'billing_', '' );
+				updateOrder = { billing: { [ keyName ]: value } };
+				break;
+			}
 			case 'shippingFirstName':
-				updateOrder = { shipping: { first_name: event.target.value } };
+				updateOrder = { shipping: { first_name: value } };
 				break;
 			case 'shippingLastName':
-				updateOrder = { shipping: { last_name: event.target.value } };
+				updateOrder = { shipping: { last_name: value } };
+				break;
+			case 'shipping_street':
+				updateOrder = { shipping: { address_1: value } };
+				break;
+			case 'shipping_street2':
+				updateOrder = { shipping: { address_2: value } };
+				break;
+			case 'shipping_city':
+			case 'shipping_state':
+			case 'shipping_country':
+			case 'shipping_postcode': {
+				const keyName = name.replace( 'shipping_', '' );
+				updateOrder = { shipping: { [ keyName ]: value } };
+				break;
+			}
+			default:
+				updateOrder = {};
 				break;
 		}
 		if ( this.props.order && this.props.order.id ) {
@@ -91,7 +142,10 @@ class OrderCustomerCard extends Component {
 							onChange={ this.onChange } />
 					</div>
 				</div>
-				<AddressSearch />
+				<AddressView
+					isEditable
+					onChange={ this.onAddressChange( 'shipping' ) }
+					address={ this.getAddressViewFormat( get( order, [ 'shipping' ], {} ) ) } />
 			</FormFieldset>
 		);
 	}
@@ -137,7 +191,10 @@ class OrderCustomerCard extends Component {
 								onChange={ this.onChange } />
 						</div>
 					</div>
-					<AddressSearch />
+					<AddressView
+						isEditable
+						onChange={ this.onAddressChange( 'billing' ) }
+						address={ this.getAddressViewFormat( get( order, [ 'billing' ], {} ) ) } />
 				</FormFieldset>
 				<FormFieldset>
 					<FormLegend>{ translate( 'Shipping Details' ) }</FormLegend>

--- a/client/extensions/woocommerce/app/order/order-create/customer-card.js
+++ b/client/extensions/woocommerce/app/order/order-create/customer-card.js
@@ -142,7 +142,7 @@ class OrderCustomerCard extends Component {
 				<FormFieldset>
 					<FormLegend>{ translate( 'Shipping Details' ) }</FormLegend>
 					<FormLabel>
-						<FormCheckbox checked={ ! this.state.showShipping } onClick={ this.toggleShipping } />
+						<FormCheckbox checked={ ! this.state.showShipping } onChange={ this.toggleShipping } />
 						<span>{ translate( 'Same as billing details' ) }</span>
 					</FormLabel>
 				</FormFieldset>

--- a/client/extensions/woocommerce/app/order/order-create/customer-card.js
+++ b/client/extensions/woocommerce/app/order/order-create/customer-card.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -24,13 +25,13 @@ class OrderCustomerCard extends Component {
 	static propTypes = {
 		siteId: PropTypes.number,
 		editOrder: PropTypes.func.isRequired,
-	}
+	};
 
 	state = {
-		showShipping: false
-	}
+		showShipping: false,
+	};
 
-	getAddressViewFormat = ( address ) => {
+	getAddressViewFormat = address => {
 		return {
 			street: address.address_1 || '',
 			street2: address.address_2 || '',
@@ -39,17 +40,17 @@ class OrderCustomerCard extends Component {
 			country: address.country || '',
 			postcode: address.postcode || '',
 		};
-	}
+	};
 
 	onAddressChange = ( type = 'billing' ) => {
-		return ( event ) => {
+		return event => {
 			this.updateOrder( `${ type }_${ event.target.name }`, event.target.value );
 		};
-	}
+	};
 
-	onChange = ( event ) => {
+	onChange = event => {
 		this.updateOrder( event.target.name, event.target.value );
-	}
+	};
 
 	updateOrder = ( name, value ) => {
 		let updateOrder;
@@ -108,13 +109,13 @@ class OrderCustomerCard extends Component {
 			updateOrder.id = this.props.order.id;
 		}
 		this.props.editOrder( updateOrder );
-	}
+	};
 
 	toggleShipping = () => {
 		this.setState( state => ( {
-			showShipping: ! state.showShipping
+			showShipping: ! state.showShipping,
 		} ) );
-	}
+	};
 
 	renderShipping = () => {
 		const { order, translate } = this.props;
@@ -131,7 +132,8 @@ class OrderCustomerCard extends Component {
 							id="shippingFirstName"
 							name="shippingFirstName"
 							value={ get( order, [ 'shipping', 'first_name' ], '' ) }
-							onChange={ this.onChange } />
+							onChange={ this.onChange }
+						/>
 					</div>
 					<div className="order-create__field">
 						<FormLabel htmlFor="shippingLastName">{ translate( 'Last Name' ) }</FormLabel>
@@ -139,16 +141,18 @@ class OrderCustomerCard extends Component {
 							id="shippingLastName"
 							name="shippingLastName"
 							value={ get( order, [ 'shipping', 'last_name' ], '' ) }
-							onChange={ this.onChange } />
+							onChange={ this.onChange }
+						/>
 					</div>
 				</div>
 				<AddressView
 					isEditable
 					onChange={ this.onAddressChange( 'shipping' ) }
-					address={ this.getAddressViewFormat( get( order, [ 'shipping' ], {} ) ) } />
+					address={ this.getAddressViewFormat( get( order, [ 'shipping' ], {} ) ) }
+				/>
 			</FormFieldset>
 		);
-	}
+	};
 
 	render() {
 		const { order, translate } = this.props;
@@ -161,7 +165,8 @@ class OrderCustomerCard extends Component {
 						id="customerEmail"
 						name="customerEmail"
 						value={ get( order, [ 'billing', 'email' ], '' ) }
-						onChange={ this.onChange } />
+						onChange={ this.onChange }
+					/>
 				</FormFieldset>
 				<FormFieldset>
 					<FormLegend>{ translate( 'Billing Details' ) }</FormLegend>
@@ -172,7 +177,8 @@ class OrderCustomerCard extends Component {
 								id="firstName"
 								name="firstName"
 								value={ get( order, [ 'billing', 'first_name' ], '' ) }
-								onChange={ this.onChange } />
+								onChange={ this.onChange }
+							/>
 						</div>
 						<div className="order-create__field">
 							<FormLabel htmlFor="lastName">{ translate( 'Last Name' ) }</FormLabel>
@@ -180,7 +186,8 @@ class OrderCustomerCard extends Component {
 								id="lastName"
 								name="lastName"
 								value={ get( order, [ 'billing', 'last_name' ], '' ) }
-								onChange={ this.onChange } />
+								onChange={ this.onChange }
+							/>
 						</div>
 						<div className="order-create__field">
 							<FormLabel htmlFor="phoneNumber">{ translate( 'Phone Number' ) }</FormLabel>
@@ -188,13 +195,15 @@ class OrderCustomerCard extends Component {
 								id="phoneNumber"
 								name="phoneNumber"
 								value={ get( order, [ 'billing', 'phone' ], '' ) }
-								onChange={ this.onChange } />
+								onChange={ this.onChange }
+							/>
 						</div>
 					</div>
 					<AddressView
 						isEditable
 						onChange={ this.onAddressChange( 'billing' ) }
-						address={ this.getAddressViewFormat( get( order, [ 'billing' ], {} ) ) } />
+						address={ this.getAddressViewFormat( get( order, [ 'billing' ], {} ) ) }
+					/>
 				</FormFieldset>
 				<FormFieldset>
 					<FormLegend>{ translate( 'Shipping Details' ) }</FormLegend>
@@ -209,8 +218,6 @@ class OrderCustomerCard extends Component {
 	}
 }
 
-export default connect(
-	state => ( {
-		order: getOrderWithEdits( state ),
-	} )
-)( localize( OrderCustomerCard ) );
+export default connect( state => ( {
+	order: getOrderWithEdits( state ),
+} ) )( localize( OrderCustomerCard ) );

--- a/client/extensions/woocommerce/app/order/order-create/customer-card.js
+++ b/client/extensions/woocommerce/app/order/order-create/customer-card.js
@@ -1,14 +1,17 @@
 /**
  * External dependencies
  */
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { get } from 'lodash';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
-import React, { Component } from 'react';
 
 /**
  * Internal dependencies
  */
 import Card from 'components/card';
+import { getOrderWithEdits } from 'woocommerce/state/ui/orders/selectors';
 import FormCheckbox from 'components/forms/form-checkbox';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
@@ -24,28 +27,64 @@ class OrderCustomerCard extends Component {
 		editOrder: PropTypes.func.isRequired,
 	}
 
+	onChange = ( event ) => {
+		let updateOrder;
+		switch ( event.target.name ) {
+			case 'customerEmail':
+				updateOrder = { billing: { email: event.target.value } };
+				break;
+			case 'firstName':
+				updateOrder = { billing: { first_name: event.target.value } };
+				break;
+			case 'lastName':
+				updateOrder = { billing: { last_name: event.target.value } };
+				break;
+			case 'phoneNumber':
+				updateOrder = { billing: { phone: event.target.value } };
+				break;
+		}
+		this.props.editOrder( updateOrder );
+	}
+
 	render() {
-		const { translate } = this.props;
+		const { order, translate } = this.props;
+
 		return (
 			<Card className="order-create__card order-create__card-customer">
 				<FormFieldset>
 					<FormLabel htmlFor="customerEmail">{ translate( 'Email address' ) }</FormLabel>
-					<FormTextInput id="customerEmail" name="customerEmail" />
+					<FormTextInput
+						id="customerEmail"
+						name="customerEmail"
+						value={ get( order, [ 'billing', 'email' ], '' ) }
+						onChange={ this.onChange } />
 				</FormFieldset>
 				<FormFieldset>
 					<FormLegend>{ translate( 'Billing Details' ) }</FormLegend>
 					<div className="order-create__fieldset">
 						<div className="order-create__field">
 							<FormLabel htmlFor="firstName">{ translate( 'First Name' ) }</FormLabel>
-							<FormTextInput id="firstName" name="firstName" />
+							<FormTextInput
+								id="firstName"
+								name="firstName"
+								value={ get( order, [ 'billing', 'first_name' ], '' ) }
+								onChange={ this.onChange } />
 						</div>
 						<div className="order-create__field">
 							<FormLabel htmlFor="lastName">{ translate( 'Last Name' ) }</FormLabel>
-							<FormTextInput id="lastName" name="lastName" />
+							<FormTextInput
+								id="lastName"
+								name="lastName"
+								value={ get( order, [ 'billing', 'last_name' ], '' ) }
+								onChange={ this.onChange } />
 						</div>
 						<div className="order-create__field">
 							<FormLabel htmlFor="phoneNumber">{ translate( 'Phone Number' ) }</FormLabel>
-							<FormTelInput id="phoneNumber" name="phoneNumber" />
+							<FormTelInput
+								id="phoneNumber"
+								name="phoneNumber"
+								value={ get( order, [ 'billing', 'phone' ], '' ) }
+								onChange={ this.onChange } />
 						</div>
 					</div>
 					<AddressSearch />
@@ -62,4 +101,8 @@ class OrderCustomerCard extends Component {
 	}
 }
 
-export default localize( OrderCustomerCard );
+export default connect(
+	state => ( {
+		order: getOrderWithEdits( state ),
+	} )
+)( localize( OrderCustomerCard ) );

--- a/client/extensions/woocommerce/app/order/order-create/customer-card.js
+++ b/client/extensions/woocommerce/app/order/order-create/customer-card.js
@@ -1,0 +1,65 @@
+/**
+ * External dependencies
+ */
+import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import Card from 'components/card';
+import FormCheckbox from 'components/forms/form-checkbox';
+import FormFieldset from 'components/forms/form-fieldset';
+import FormLabel from 'components/forms/form-label';
+import FormLegend from 'components/forms/form-legend';
+import FormTelInput from 'components/forms/form-tel-input';
+import FormTextInput from 'components/forms/form-text-input';
+
+const AddressSearch = () => null;
+
+class OrderCustomerCard extends Component {
+	static propTypes = {
+		siteId: PropTypes.number,
+		editOrder: PropTypes.func.isRequired,
+	}
+
+	render() {
+		const { translate } = this.props;
+		return (
+			<Card className="order-create__card order-create__card-customer">
+				<FormFieldset>
+					<FormLabel htmlFor="customerEmail">{ translate( 'Email address' ) }</FormLabel>
+					<FormTextInput id="customerEmail" name="customerEmail" />
+				</FormFieldset>
+				<FormFieldset>
+					<FormLegend>{ translate( 'Billing Details' ) }</FormLegend>
+					<div className="order-create__fieldset">
+						<div className="order-create__field">
+							<FormLabel htmlFor="firstName">{ translate( 'First Name' ) }</FormLabel>
+							<FormTextInput id="firstName" name="firstName" />
+						</div>
+						<div className="order-create__field">
+							<FormLabel htmlFor="lastName">{ translate( 'Last Name' ) }</FormLabel>
+							<FormTextInput id="lastName" name="lastName" />
+						</div>
+						<div className="order-create__field">
+							<FormLabel htmlFor="phoneNumber">{ translate( 'Phone Number' ) }</FormLabel>
+							<FormTelInput id="phoneNumber" name="phoneNumber" />
+						</div>
+					</div>
+					<AddressSearch />
+				</FormFieldset>
+				<FormFieldset>
+					<FormLegend>{ translate( 'Billing Details' ) }</FormLegend>
+					<FormLabel>
+						<FormCheckbox />
+						<span>{ translate( 'Same as billing details' ) }</span>
+					</FormLabel>
+				</FormFieldset>
+			</Card>
+		);
+	}
+}
+
+export default localize( OrderCustomerCard );

--- a/client/extensions/woocommerce/app/order/order-create/customer-card.js
+++ b/client/extensions/woocommerce/app/order/order-create/customer-card.js
@@ -52,6 +52,15 @@ class OrderCustomerCard extends Component {
 		this.updateOrder( event.target.name, event.target.value );
 	};
 
+	/**
+	 * Create an object with structure matching the order properties, which contains
+	 * the updates to be pushed into the UI redux state (and eventually saved to
+	 * the remote site). The input name needs to be mapped to a tree structure,
+	 * see http://woocommerce.github.io/woocommerce-rest-api-docs/#order-properties
+	 *
+	 * @param  {string} name  The field being edited, from the input name
+	 * @param  {string} value The input value, which should be saved
+	 */
 	updateOrder = ( name, value ) => {
 		let updateOrder;
 		switch ( name ) {

--- a/client/extensions/woocommerce/app/order/order-create/customer-card.js
+++ b/client/extensions/woocommerce/app/order/order-create/customer-card.js
@@ -27,6 +27,10 @@ class OrderCustomerCard extends Component {
 		editOrder: PropTypes.func.isRequired,
 	}
 
+	state = {
+		showShipping: false
+	}
+
 	onChange = ( event ) => {
 		let updateOrder;
 		switch ( event.target.name ) {
@@ -42,8 +46,54 @@ class OrderCustomerCard extends Component {
 			case 'phoneNumber':
 				updateOrder = { billing: { phone: event.target.value } };
 				break;
+			case 'shippingFirstName':
+				updateOrder = { shipping: { first_name: event.target.value } };
+				break;
+			case 'shippingLastName':
+				updateOrder = { shipping: { last_name: event.target.value } };
+				break;
+		}
+		if ( this.props.order && this.props.order.id ) {
+			updateOrder.id = this.props.order.id;
 		}
 		this.props.editOrder( updateOrder );
+	}
+
+	toggleShipping = () => {
+		this.setState( state => ( {
+			showShipping: ! state.showShipping
+		} ) );
+	}
+
+	renderShipping = () => {
+		const { order, translate } = this.props;
+		if ( ! this.state.showShipping ) {
+			return null;
+		}
+
+		return (
+			<FormFieldset>
+				<div className="order-create__fieldset">
+					<div className="order-create__field">
+						<FormLabel htmlFor="shippingFirstName">{ translate( 'First Name' ) }</FormLabel>
+						<FormTextInput
+							id="shippingFirstName"
+							name="shippingFirstName"
+							value={ get( order, [ 'shipping', 'first_name' ], '' ) }
+							onChange={ this.onChange } />
+					</div>
+					<div className="order-create__field">
+						<FormLabel htmlFor="shippingLastName">{ translate( 'Last Name' ) }</FormLabel>
+						<FormTextInput
+							id="shippingLastName"
+							name="shippingLastName"
+							value={ get( order, [ 'shipping', 'last_name' ], '' ) }
+							onChange={ this.onChange } />
+					</div>
+				</div>
+				<AddressSearch />
+			</FormFieldset>
+		);
 	}
 
 	render() {
@@ -90,12 +140,13 @@ class OrderCustomerCard extends Component {
 					<AddressSearch />
 				</FormFieldset>
 				<FormFieldset>
-					<FormLegend>{ translate( 'Billing Details' ) }</FormLegend>
+					<FormLegend>{ translate( 'Shipping Details' ) }</FormLegend>
 					<FormLabel>
-						<FormCheckbox />
+						<FormCheckbox checked={ ! this.state.showShipping } onClick={ this.toggleShipping } />
 						<span>{ translate( 'Same as billing details' ) }</span>
 					</FormLabel>
 				</FormFieldset>
+				{ this.renderShipping() }
 			</Card>
 		);
 	}

--- a/client/extensions/woocommerce/app/order/order-create/customer-card.js
+++ b/client/extensions/woocommerce/app/order/order-create/customer-card.js
@@ -178,7 +178,9 @@ class OrderCustomerCard extends Component {
 					/>
 				</FormFieldset>
 				<FormFieldset>
-					<FormLegend>{ translate( 'Billing Details' ) }</FormLegend>
+					<FormLegend className="order-create__billing-details">
+						{ translate( 'Billing Details' ) }
+					</FormLegend>
 					<div className="order-create__fieldset">
 						<div className="order-create__field">
 							<FormLabel htmlFor="firstName">{ translate( 'First Name' ) }</FormLabel>
@@ -215,7 +217,9 @@ class OrderCustomerCard extends Component {
 					/>
 				</FormFieldset>
 				<FormFieldset>
-					<FormLegend>{ translate( 'Shipping Details' ) }</FormLegend>
+					<FormLegend className="order-create__shipping-details">
+						{ translate( 'Shipping Details' ) }
+					</FormLegend>
 					<FormLabel>
 						<FormCheckbox checked={ ! this.state.showShipping } onChange={ this.toggleShipping } />
 						<span>{ translate( 'Same as billing details' ) }</span>

--- a/client/extensions/woocommerce/app/order/order-create/index.js
+++ b/client/extensions/woocommerce/app/order/order-create/index.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -21,18 +22,18 @@ import { ProtectFormGuard } from 'lib/protect-form';
 import SectionHeader from 'components/section-header';
 
 class OrderCreate extends Component {
-	editOrder = ( order ) => {
+	editOrder = order => {
 		const { site } = this.props;
 		if ( site && site.ID ) {
 			this.props.editOrder( site.ID, order );
 		}
-	}
+	};
 
 	render() {
 		const { className, site, translate } = this.props;
 		const breadcrumbs = [
-			( <a href={ getLink( '/store/orders/:site/', site ) }>{ translate( 'Orders' ) }</a> ),
-			( <span>{ translate( 'New Order' ) }</span> ),
+			<a href={ getLink( '/store/orders/:site/', site ) }>{ translate( 'Orders' ) }</a>,
+			<span>{ translate( 'New Order' ) }</span>,
 		];
 		return (
 			<Main className={ className }>
@@ -66,7 +67,7 @@ export default connect(
 		const site = getSelectedSiteWithFallback( state );
 
 		return {
-			site
+			site,
 		};
 	},
 	dispatch => bindActionCreators( { editOrder }, dispatch )

--- a/client/extensions/woocommerce/app/order/order-create/index.js
+++ b/client/extensions/woocommerce/app/order/order-create/index.js
@@ -10,11 +10,17 @@ import { localize } from 'i18n-calypso';
  */
 import ActionHeader from 'woocommerce/components/action-header';
 import Button from 'components/button';
+import Card from 'components/card';
 import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
 import { getLink } from 'woocommerce/lib/nav-utils';
 import Main from 'components/main';
+import OrderCustomerCard from './customer-card';
+import { ProtectFormGuard } from 'lib/protect-form';
+import SectionHeader from 'components/section-header';
 
 class OrderCreate extends Component {
+	editOrder = () => {
+	}
 
 	render() {
 		const { className, site, translate } = this.props;
@@ -27,8 +33,23 @@ class OrderCreate extends Component {
 				<ActionHeader breadcrumbs={ breadcrumbs }>
 					<Button primary>{ translate( 'Save Order' ) }</Button>
 				</ActionHeader>
+				<ProtectFormGuard isChanged={ false } />
 
-				<div className="order-create__container"></div>
+				<div className="order-create__container">
+					<SectionHeader label={ translate( 'Customer Details' ) } />
+					<OrderCustomerCard siteId={ site && site.ID } editOrder={ this.editOrder } />
+
+					<SectionHeader label={ translate( 'Add products to the order' ) } />
+					<Card className="order-create__card" />
+
+					<SectionHeader label={ translate( 'How will these products be shipped?' ) } />
+					<Card className="order-create__card" />
+
+					<SectionHeader label={ translate( 'How will the customer pay for the order?' ) }>
+						<span>{ translate( 'Add coupon' ) }</span>
+					</SectionHeader>
+					<Card className="order-create__card" />
+				</div>
 			</Main>
 		);
 	}
@@ -37,11 +58,9 @@ class OrderCreate extends Component {
 export default connect(
 	state => {
 		const site = getSelectedSiteWithFallback( state );
-		const siteId = site ? site.ID : false;
 
 		return {
-			site,
-			siteId,
+			site
 		};
 	}
 )( localize( OrderCreate ) );

--- a/client/extensions/woocommerce/app/order/order-create/index.js
+++ b/client/extensions/woocommerce/app/order/order-create/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React, { Component } from 'react';
+import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
@@ -11,6 +12,7 @@ import { localize } from 'i18n-calypso';
 import ActionHeader from 'woocommerce/components/action-header';
 import Button from 'components/button';
 import Card from 'components/card';
+import { editOrder } from 'woocommerce/state/ui/orders/actions';
 import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
 import { getLink } from 'woocommerce/lib/nav-utils';
 import Main from 'components/main';
@@ -19,7 +21,11 @@ import { ProtectFormGuard } from 'lib/protect-form';
 import SectionHeader from 'components/section-header';
 
 class OrderCreate extends Component {
-	editOrder = () => {
+	editOrder = ( order ) => {
+		const { site } = this.props;
+		if ( site && site.ID ) {
+			this.props.editOrder( site.ID, order );
+		}
 	}
 
 	render() {
@@ -62,5 +68,6 @@ export default connect(
 		return {
 			site
 		};
-	}
+	},
+	dispatch => bindActionCreators( { editOrder }, dispatch )
 )( localize( OrderCreate ) );

--- a/client/extensions/woocommerce/app/order/order-create/style.scss
+++ b/client/extensions/woocommerce/app/order/order-create/style.scss
@@ -1,7 +1,8 @@
+/** @format */
 .order-create__container {
 	padding-bottom: 0;
 
-	@include breakpoint( ">660px" ) {
+	@include breakpoint( '>660px' ) {
 		margin-top: 58px;
 	}
 
@@ -19,8 +20,8 @@
 	}
 
 	.order-create__field {
-		flex: 0 1 calc( 50% - 10px );
-		max-width: calc( 50% - 10px );
+		flex: 0 1 calc(50% - 10px);
+		max-width: calc(50% - 10px);
 		margin-bottom: 20px;
 	}
 }

--- a/client/extensions/woocommerce/app/order/order-create/style.scss
+++ b/client/extensions/woocommerce/app/order/order-create/style.scss
@@ -1,0 +1,26 @@
+.order-create__container {
+	padding-bottom: 0;
+
+	@include breakpoint( ">660px" ) {
+		margin-top: 58px;
+	}
+
+	.section-header__label {
+		font-size: 16px;
+	}
+}
+
+.order-create__card-customer {
+	.order-create__fieldset {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: flex-start;
+		justify-content: space-between;
+	}
+
+	.order-create__field {
+		flex: 0 1 calc( 50% - 10px );
+		max-width: calc( 50% - 10px );
+		margin-bottom: 20px;
+	}
+}

--- a/client/extensions/woocommerce/app/order/order-create/style.scss
+++ b/client/extensions/woocommerce/app/order/order-create/style.scss
@@ -24,4 +24,21 @@
 		max-width: calc(50% - 10px);
 		margin-bottom: 20px;
 	}
+	
+	.address-view__country {
+		margin-bottom: 0;
+	}
+	
+	.order-create__billing-details {
+		padding-top: 16px;
+	}
+	
+	.order-create__shipping-details {
+		padding-top: 8px
+	}
+	
+	.address-view__editable-city-state-postcode .form-select {
+		max-width: none;
+		width: 100%;
+	}
 }

--- a/client/extensions/woocommerce/app/order/order-customer/style.scss
+++ b/client/extensions/woocommerce/app/order/order-customer/style.scss
@@ -1,11 +1,4 @@
 .order-customer {
-	.order-customer__billing-details,
-	.order-customer__shipping-details {
-		margin-bottom: 16px;
-		color: $gray-text-min;
-		font-size: 12px;
-		text-transform: uppercase;
-	}
 	
 	.order-customer__shipping-details {
 		margin-top: 32px;
@@ -29,4 +22,15 @@
 			margin-bottom: 0;
 		}
 	}
+}
+
+.order-customer__billing-details,
+.order-create__billing-details, 
+.order-customer__shipping-details,
+.order-create__shipping-details {
+	margin-bottom: 16px;
+	color: $gray-text-min;
+	font-size: 12px;
+	text-transform: uppercase;
+	font-weight: 500;
 }

--- a/client/extensions/woocommerce/app/order/style.scss
+++ b/client/extensions/woocommerce/app/order/style.scss
@@ -1,5 +1,4 @@
-.order__container,
-.order-create__container {
+.order__container {
 	padding-bottom: 0;
 
 	@include breakpoint( ">660px" ) {

--- a/client/extensions/woocommerce/style.scss
+++ b/client/extensions/woocommerce/style.scss
@@ -3,6 +3,7 @@
 
 	@import 'app/dashboard/style';
 	@import 'app/order/style';
+	@import 'app/order/order-create/style';
 	@import 'app/order/order-created/style';
 	@import 'app/order/order-customer/style';
 	@import 'app/order/order-details/style';


### PR DESCRIPTION
I'm going to be building out the order creation screen in steps based on each section. This PR adds all 4 sections to the new order screen, and fills out the Customer Details section (the other 3 are left empty for now). I wanted to get this PR up so I can iterate off of it, and so that I can get design input early 🙂 

![screen shot 2017-09-25 at 2 30 23 pm](https://user-images.githubusercontent.com/541093/30824618-1c39062a-a1fe-11e7-8402-99efaaebde21.png)

All the inputs are functional, and if you uncheck "Same as billing details", a shipping address form becomes visible. Nothing fancy is happening here yet with searching customers/addresses, you can see my roadmap/plan for this functionality at the parent issue #15679.

To test:

- Visit `/store/order/:site`
- Add customer info – see that each field works, and updates correctly
- If you want, open the Redux dev tools to see the `WOOCOMMERCE_UI_ORDERS_EDIT` action fire, and the state changing under `extensions.woocommerce.ui.orders[siteId]edits`.
- Save order is currently not hooked up, as there's no way to add products yet (and this is feature-flagged so no unsuspecting user should end up here)