### PR TITLE
Components Chart: autobind functions to fix 'this' property

### DIFF
--- a/client/components/chart/index.jsx
+++ b/client/components/chart/index.jsx
@@ -52,7 +52,7 @@ class ModuleChartExport extends React.Component {
 		}
 	}
 
-	resize() {
+	resize = () => {
 		const node = this.refs.chart;
 		let width = node.clientWidth - 82,
 			maxBars;
@@ -70,7 +70,7 @@ class ModuleChartExport extends React.Component {
 		} );
 	}
 
-	getYAxisMax( values ) {
+	getYAxisMax = ( values ) => {
 		const max = Math.max.apply( null, values ),
 			operand = Math.pow( 10, ( Math.floor( max ).toString().length - 1 ) );
 		let rounded = ( Math.ceil( ( max + 1 ) / operand ) * operand );
@@ -82,7 +82,7 @@ class ModuleChartExport extends React.Component {
 		return rounded;
 	}
 
-	getData() {
+	getData = () => {
 		let data = this.props.data;
 
 		data = data.slice( 0 - this.state.maxBars );
@@ -90,7 +90,7 @@ class ModuleChartExport extends React.Component {
 		return data;
 	}
 
-	getValues() {
+	getValues = () => {
 		let data = this.getData();
 
 		data = data.map( function( item ) {
@@ -100,7 +100,7 @@ class ModuleChartExport extends React.Component {
 		return data;
 	}
 
-	isEmptyChart( values ) {
+	isEmptyChart = ( values ) => {
 		return ! some( values, ( value ) => value > 0 );
 	}
 


### PR DESCRIPTION
It looks like `chart` is doesn't have the proper autobinding in its functions to use `this` when its functions are called in callbacks.  

I am seeing this error:
<img width="1440" alt="screen shot 2017-09-25 at 4 39 51 pm" src="https://user-images.githubusercontent.com/4656974/30829903-35e3113a-a210-11e7-8246-9271943f38a4.png">

This PR just transforms all of the functions `likeThis(){` to be `likeThis = () => {`
