### PR TITLE
Add banner dismissal tracking

### DIFF
--- a/client/components/banner/index.jsx
+++ b/client/components/banner/index.jsx
@@ -109,10 +109,9 @@ class Banner extends Component {
 
 		if ( event ) {
 			this.props.recordTracksEvent(
-				'calypso_banner_cta_dismiss', {
+				'calypso_banner_dismiss', {
 					cta_name: event,
 					cta_feature: feature,
-					cta_size: 'regular',
 				}
 			);
 		}

--- a/client/components/banner/index.jsx
+++ b/client/components/banner/index.jsx
@@ -51,6 +51,7 @@ class Banner extends Component {
 		icon: PropTypes.string,
 		list: PropTypes.arrayOf( PropTypes.string ),
 		onClick: PropTypes.func,
+		onDismiss: PropTypes.func,
 		plan: PropTypes.string,
 		price: PropTypes.oneOfType( [ PropTypes.number, PropTypes.arrayOf( PropTypes.number ) ] ),
 		siteSlug: PropTypes.string,
@@ -61,6 +62,7 @@ class Banner extends Component {
 		disableHref: false,
 		dismissTemporary: false,
 		onClick: noop,
+		onDismiss: noop,
 	};
 
 	getHref() {
@@ -96,7 +98,27 @@ class Banner extends Component {
 		}
 
 		onClick( e );
-	}
+	};
+
+	handleDismiss = ( e ) => {
+		const {
+			event,
+			feature,
+			onDismiss,
+		} = this.props;
+
+		if ( event ) {
+			this.props.recordTracksEvent(
+				'calypso_banner_cta_dismiss', {
+					cta_name: event,
+					cta_feature: feature,
+					cta_size: 'regular',
+				}
+			);
+		}
+
+		onDismiss( e );
+	};
 
 	getIcon() {
 		const {
@@ -241,6 +263,7 @@ class Banner extends Component {
 					className={ classes }
 					preferenceName={ dismissPreferenceName }
 					temporary={ dismissTemporary }
+					onClick={ this.handleDismiss }
 				>
 					{ this.getIcon() }
 					{ this.getContent() }


### PR DESCRIPTION
This adds dismissal tracking to all banner components and allows hooking into the dismissal itself.