### PR TITLE
Allow user bootstraping via config cookie

### DIFF
--- a/server/boot/index.js
+++ b/server/boot/index.js
@@ -4,6 +4,7 @@
 const path = require( 'path' ),
 	build = require( 'build' ),
 	config = require( 'config' ),
+	chalk = require( 'chalk' ),
 	express = require( 'express' ),
 	cookieParser = require( 'cookie-parser' ),
 	userAgent = require( 'express-useragent' ),
@@ -38,6 +39,23 @@ function setup() {
 
 		// setup logger
 		app.use( morgan( 'dev' ) );
+
+		if ( config.isEnabled( 'wpcom-user-bootstrap' ) ) {
+			if ( config( 'wordpress_logged_in_cookie' ) ) {
+				const username = config( 'wordpress_logged_in_cookie' ).split( '%7C' )[ 0 ];
+				console.info( chalk.cyan( '\nYour logged in cookie set to user: ' + username ) );
+
+				app.use( function( req, res, next ) {
+					if ( ! req.cookies.wordpress_logged_in ) {
+						req.cookies.wordpress_logged_in = config( 'wordpress_logged_in_cookie' );
+					}
+					next();
+				} );
+			} else {
+				console.info( chalk.red( '\nYou need to set `wordpress_logged_in_cookie` in secrets.json' +
+					' for wpcom-user-bootstrap to work in development.' ) );
+			}
+		}
 	} else {
 		require( 'bundler/assets' )( app );
 

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -278,7 +278,7 @@ function setUpLoggedInRoute( req, res, next ) {
 		start = new Date().getTime();
 
 		debug( 'Issuing API call to fetch user object' );
-		user( req.get( 'Cookie' ), function( error, data ) {
+		user( req.cookies.wordpress_logged_in, function( error, data ) {
 			let searchParam, errorMessage;
 
 			if ( error ) {


### PR DESCRIPTION
We can enable user bootstrapping in `development.json` and set `"wordpress_logged_in_cookie": "username%7your_cookie_here"` in `secrets.json`

This is useful for testing PRs such as #17988 that require user boostrapping on the server.
  
#### Testing instructions
  
1. Run `git checkout add/dev-user-bootstrapping`
2. `"wordpress_logged_in_cookie": "username%7your_cookie_here"` in `secrets.json` and make sure you have `wpcom_calypso_rest_api_key` private key as well.
3. set `wpcom-user-bootstrap` to `true` in `development.json`
4. Start your server with `npm start`
4. Open the [`Home` page](http://calypso.localhost:3000/)
5. Check that you are indeed logged in and user data is available in the source from server.

#### Reviews
  
- [x] Code
- [x] Product
