### PR TITLE
Update styles of disabled plugin actions

### DIFF
--- a/client/my-sites/plugins/plugin-action/plugin-action.jsx
+++ b/client/my-sites/plugins/plugin-action/plugin-action.jsx
@@ -22,27 +22,26 @@ class PluginAction extends React.Component {
 		}
 	};
 
-	renderLabel = () => {
-		if ( this.props.label ) {
-			return (
-				<label
-					className="plugin-action__label"
-					ref="disabledInfoLabel"
-					onClick={ this.handleAction }
-					htmlFor={ this.props.htmlFor }
-					key="renderDisabledInfoLabel"
-				>
-					{ this.props.label }
-				</label>
-			);
+	renderLabel() {
+		if ( ! this.props.label ) {
+			return null;
 		}
-		return null;
-	};
 
-	renderDisabledInfo = () => {
-		return [
+		return (
+			<span className="plugin-action__label" ref="disabledInfoLabel" onClick={ this.handleAction }>
+				{ this.props.label }
+				{ this.renderDisabledInfo() }
+			</span>
+		);
+	}
+
+	renderDisabledInfo() {
+		if ( ! this.props.disabledInfo ) {
+			return null;
+		}
+
+		return (
 			<InfoPopover
-				key="renderDisabledInfoPopOver"
 				className="plugin-action__disabled-info"
 				position="bottom left"
 				popoverName={ 'Plugin Action Disabled' + this.props.label }
@@ -51,45 +50,40 @@ class PluginAction extends React.Component {
 				ignoreContext={ this.refs && this.refs.disabledInfoLabel }
 			>
 				{ this.props.disabledInfo }
-			</InfoPopover>,
-			this.renderLabel(),
-		];
-	};
+			</InfoPopover>
+		);
+	}
 
-	renderToggle = () => {
+	renderToggle() {
 		return (
 			<CompactToggle
 				onChange={ this.props.action }
 				checked={ this.props.status }
 				toggling={ this.props.inProgress }
-				disabled={ this.props.disabled }
+				disabled={ this.props.disabled || !! this.props.disabledInfo }
 				id={ this.props.htmlFor }
 			>
 				{ this.renderLabel() }
 			</CompactToggle>
 		);
-	};
+	}
 
-	renderChildren = () => {
+	renderChildren() {
 		return (
-			<div>
-				<span className="plugin-action__children">{ this.props.children }</span>
+			<span className="plugin-action__children">
+				{ this.props.children }
 				{ this.renderLabel() }
-			</div>
+			</span>
 		);
-	};
+	}
 
-	renderInner = () => {
-		if ( this.props.disabledInfo ) {
-			return this.renderDisabledInfo();
-		}
-
+	renderInner() {
 		if ( 0 < React.Children.count( this.props.children ) ) {
 			return this.renderChildren();
 		}
 
 		return this.renderToggle();
-	};
+	}
 
 	render() {
 		const additionalClasses = {

--- a/client/my-sites/plugins/plugin-action/plugin-action.jsx
+++ b/client/my-sites/plugins/plugin-action/plugin-action.jsx
@@ -18,7 +18,7 @@ class PluginAction extends React.Component {
 		if ( ! this.props.disabledInfo ) {
 			this.props.action();
 		} else {
-			this.infoPopover._onClick( event );
+			this.infoPopover.handleClick( event );
 		}
 	};
 

--- a/client/my-sites/plugins/plugin-action/plugin-action.jsx
+++ b/client/my-sites/plugins/plugin-action/plugin-action.jsx
@@ -18,8 +18,12 @@ class PluginAction extends React.Component {
 		if ( ! this.props.disabledInfo ) {
 			this.props.action();
 		} else {
-			this.refs.infoPopover._onClick( event );
+			this.infoPopover._onClick( event );
 		}
+	};
+
+	disabledInfoLabelRef = ref => {
+		this.disabledInfoLabel = ref;
 	};
 
 	renderLabel() {
@@ -28,12 +32,20 @@ class PluginAction extends React.Component {
 		}
 
 		return (
-			<span className="plugin-action__label" ref="disabledInfoLabel" onClick={ this.handleAction }>
+			<span
+				className="plugin-action__label"
+				ref={ this.disabledInfoLabelRef }
+				onClick={ this.handleAction }
+			>
 				{ this.props.label }
 				{ this.renderDisabledInfo() }
 			</span>
 		);
 	}
+
+	infoPopoverRef = ref => {
+		this.infoPopover = ref;
+	};
 
 	renderDisabledInfo() {
 		if ( ! this.props.disabledInfo ) {
@@ -46,8 +58,8 @@ class PluginAction extends React.Component {
 				position="bottom left"
 				popoverName={ 'Plugin Action Disabled' + this.props.label }
 				gaEventCategory="Plugins"
-				ref="infoPopover"
-				ignoreContext={ this.refs && this.refs.disabledInfoLabel }
+				ref={ this.infoPopoverRef }
+				ignoreContext={ this.disabledInfoLabel }
 			>
 				{ this.props.disabledInfo }
 			</InfoPopover>

--- a/client/my-sites/plugins/plugin-action/style.scss
+++ b/client/my-sites/plugins/plugin-action/style.scss
@@ -60,15 +60,10 @@
 
 	.has-disabled-info & {
 		cursor: default;
-		margin-left: 12px;
 	}
 }
 
 .plugin-action .form-toggle__label .form-toggle__switch {
-	float: right;
-}
-
-.plugin-action__children {
 	float: right;
 }
 

--- a/client/my-sites/plugins/plugin-action/style.scss
+++ b/client/my-sites/plugins/plugin-action/style.scss
@@ -4,7 +4,7 @@
 
 .plugin-action {
 	clear:both;
-	line-height: 1;
+	line-height: 0;
 	margin-top: 16px;
 
 	&:first-child {
@@ -28,19 +28,33 @@
 	}
 }
 
-.plugin-action .toggle__switch {
-	float: right;
+.plugin-action .form-toggle__label {
+	display: inline-flex;
+	flex-direction: row-reverse;
+	align-items: center;
+}
+
+.plugin-action .form-toggle__switch {
+	flex: none;
+	align-self: center;
+}
+
+.plugin-action .form-toggle__label-content {
+	flex: none;
+	margin-right: auto;
 }
 
 .plugin-action__label {
+	display: flex;
+	flex-direction: row-reverse;
+	align-items: center;
 	font-size: 12px;
 	line-height: 16px;
 	margin-right: 8px;
-	vertical-align: top;
 	cursor: pointer;
 
 	.is-disabled & {
-		color: lighten( $gray, 30% );
+		color: lighten( $gray, 10% );
 		cursor: default;
 	}
 
@@ -58,15 +72,22 @@
 	float: right;
 }
 
-
-.plugin-action__disabled-info.info-popover {
-	float: right;
-	height: 16px;
-	width: 24px;
+.plugin-action__children .noticon {
+	margin-left: 8px;
 }
 
-.plugin-action__disabled-info.info-popover .gridicons-info-outline {
-	transform: translate(-4px, -2px);
+.plugin-action__disabled-info.info-popover {
+	flex: none;
+	margin: -1px 4px;
+
+	.gridicon {
+		display: block;
+	}
+
+	.gridicons-info-outline g {
+		// revert the translate(1px,1px) done by needs-offset
+		transform: none;
+	}
 }
 
 .plugin-action__disabled-info-list {

--- a/client/my-sites/plugins/plugin-action/test/index.jsx
+++ b/client/my-sites/plugins/plugin-action/test/index.jsx
@@ -62,7 +62,7 @@ describe( 'PluginAction', () => {
 				children = wrapper.find( '.plugin-action__children' );
 
 			expect( children.length ).to.equal( 1 );
-			expect( children.props().children.type ).to.equal( 'span' );
+			expect( children.props().children[ 0 ].type ).to.equal( 'span' );
 		} );
 
 		test( 'should render a plugin action label', () => {

--- a/client/my-sites/plugins/plugin-activate-toggle/index.jsx
+++ b/client/my-sites/plugins/plugin-activate-toggle/index.jsx
@@ -61,11 +61,13 @@ export class PluginActivateToggle extends Component {
 		if ( disabled ) {
 			return (
 				<span className="plugin-activate-toggle__disabled">
-					{ translate( 'Manage Connection', {
-						comment: 'manage Jetpack connnection settings link',
-					} ) }
 					<span className="plugin-activate-toggle__icon">
 						<Gridicon icon="cog" size={ 18 } />
+					</span>
+					<span className="plugin-activate-toggle__label">
+						{ translate( 'Manage Connection', {
+							comment: 'manage Jetpack connnection settings link',
+						} ) }
 					</span>
 				</span>
 			);
@@ -74,19 +76,20 @@ export class PluginActivateToggle extends Component {
 		return (
 			<span className="plugin-activate-toggle__link">
 				<a
+					className="plugin-activate-toggle__icon"
+					onClick={ this.trackManageConnectionLink }
+					href={ '/settings/manage-connection/' + site.slug }
+				>
+					<Gridicon icon="cog" size={ 18 } />
+				</a>
+				<a
+					className="plugin-activate-toggle__label"
 					onClick={ this.trackManageConnectionLink }
 					href={ '/settings/manage-connection/' + site.slug }
 				>
 					{ translate( 'Manage Connection', {
 						comment: 'manage Jetpack connnection settings link',
 					} ) }
-				</a>
-				<a
-					className="plugin-activate-toggle__icon"
-					onClick={ this.trackManageConnectionLink }
-					href={ '/settings/manage-connection/' + site.slug }
-				>
-					<Gridicon icon="cog" size={ 18 } />
 				</a>
 			</span>
 		);

--- a/client/my-sites/plugins/plugin-activate-toggle/style.scss
+++ b/client/my-sites/plugins/plugin-activate-toggle/style.scss
@@ -1,13 +1,9 @@
-.plugin-activate-toggle .plugin-action__children {
-	float: none;
-}
-
 .plugin-activate-toggle__disabled,
 .plugin-activate-toggle__link {
+	display: inline-flex;
+	flex-direction: row-reverse;
 	font-size: 12px;
 	line-height: 16px;
-	margin-right: 8px;
-	vertical-align: top;
 }
 
 .plugin-activate-toggle__link:hover,
@@ -16,13 +12,25 @@
 }
 
 .plugin-activate-toggle__disabled {
+	color: lighten( $gray, 10% );
+}
+
+.plugin-activate-toggle__disabled .plugin-activate-toggle__icon {
 	color: lighten( $gray, 30% );
+}
+
+.plugin-activate-toggle__label {
+	margin-left: 0px;
+	margin-right: 8px;
+}
+
+.plugin-activate-toggle__link {
+	cursor: pointer;
 }
 
 .plugin-activate-toggle__link a {
 	color: currentcolor;
 	line-height: 16px;
-	vertical-align: top;
 }
 
 .plugin-activate-toggle__link .plugin-activate-toggle__icon {
@@ -30,13 +38,10 @@
 }
 
 .plugin-activate-toggle__icon {
-	display: inline-block;
-	vertical-align: inherit;
-	float: right;
-	height: 16px;
-	width: 24px;
-}
+	flex: none;
+	margin: -1px 3px;
 
-.plugin-activate-toggle__icon .gridicons-cog {
-	transform: translate(3px, -1px);
+	.gridicon {
+		display: block;
+	}
 }

--- a/client/my-sites/plugins/plugin-autoupdate-toggle/index.jsx
+++ b/client/my-sites/plugins/plugin-autoupdate-toggle/index.jsx
@@ -155,15 +155,10 @@ export class PluginAutoUpdateToggle extends Component {
 				'DISABLE_AUTOUPDATE_PLUGIN',
 			] ),
 			getDisabledInfo = this.getDisabledInfo(),
-			label = getDisabledInfo
-				? translate( 'Autoupdates disabled', {
-						context:
-							'this goes next to an icon that displays if the plugin has "autoupdates disabled" active',
-					} )
-				: translate( 'Autoupdates', {
-						context:
-							'this goes next to an icon that displays if the plugin has "autoupdates" active',
-					} );
+			label = translate( 'Autoupdates', {
+				context:
+					'this goes next to an icon that displays if the plugin has "autoupdates", both enabled and disabled',
+			} );
 
 		return (
 			<PluginAction

--- a/client/my-sites/plugins/plugin-item/style.scss
+++ b/client/my-sites/plugins/plugin-item/style.scss
@@ -173,21 +173,15 @@
 
 .plugin-item .plugin-action__label {
 	@include breakpoint( '>1040px' ) {
+		flex-direction: row;
 		margin-right: 0;
 		margin-left: 8px;
 	}
 }
 
-.plugin-item .has-disabled-info .plugin-action__label {
+.plugin-item .plugin-action .form-toggle__label {
 	@include breakpoint( '>1040px' ) {
-		margin-right: 8px;
-		margin-left: 0px;
-	}
-}
-
-.plugin-item .plugin-action .form-toggle__label .form-toggle__switch {
-	@include breakpoint( '>1040px' ) {
-		float: left;
+		flex-direction: row;
 	}
 }
 
@@ -198,32 +192,18 @@
 	}
 }
 
-.plugin-item .plugin-action__disabled-info.info-popover .gridicons-info-outline {
+.plugin-item .plugin-activate-toggle__link,
+.plugin-item .plugin-activate-toggle__disabled {
 	@include breakpoint( '>1040px' ) {
-		transform: translate(-2px, -2px);
-	}
-}
-
-.plugin-item .plugin-action .plugin-activate-toggle__link {
-	@include breakpoint( '>1040px' ) {
+		flex-direction: row;
 		margin-right: 12px;
+	}
+}
+
+.plugin-item .plugin-activate-toggle__label {
+	@include breakpoint( '>1040px' ) {
 		margin-left: 8px;
-	}
-}
-
-.plugin-item .plugin-activate-toggle__icon {
-	@include breakpoint( '>1040px' ) {
-		float: left;
-	}
-}
-
-.plugin-item .plugin-activate-toggle__icon .gridicons-cog {
-	@include breakpoint( '>480px' ) {
-		transform: translate(-3px, -1px);
-	}
-
-	@include breakpoint( '>1040px' ) {
-		transform: translate(3px, -1px);
+		margin-right: 0;
 	}
 }
 

--- a/client/my-sites/plugins/plugin-meta/style.scss
+++ b/client/my-sites/plugins/plugin-meta/style.scss
@@ -116,6 +116,15 @@
 		}
 	}
 
+	.form-toggle__label,
+	.plugin-activate-toggle__disabled,
+	.plugin-activate-toggle__link,
+	.plugin-remove-button__remove-link .plugin-action__children {
+		@include breakpoint( '<480px' ) {
+			width: 100%;
+		}
+	}
+
 	.form-toggle__label-content {
 		@include breakpoint( '<480px' ) {
 			margin-left: 0;
@@ -124,14 +133,10 @@
 
 	.plugin-action__label {
 		@include breakpoint( '<480px' ) {
-			flex-grow: 2;
+			flex-flow: row;
 			font-size: 11px;
 		}
 	}
-}
-
-.plugin-meta__actions .plugin-activate-toggle__icon .gridicons-cog {
-	transform: translate(-3px, -1px);
 }
 
 .plugin-meta__version-notice {

--- a/client/my-sites/plugins/plugin-meta/style.scss
+++ b/client/my-sites/plugins/plugin-meta/style.scss
@@ -135,6 +135,7 @@
 		@include breakpoint( '<480px' ) {
 			flex-flow: row;
 			font-size: 11px;
+			margin-right: auto;
 		}
 	}
 }

--- a/client/my-sites/plugins/plugin-meta/style.scss
+++ b/client/my-sites/plugins/plugin-meta/style.scss
@@ -125,6 +125,12 @@
 		}
 	}
 
+	.plugin-activate-toggle__link {
+		@include breakpoint( '<480px' ) {
+			justify-content: space-between;
+		}
+	}
+
 	.form-toggle__label-content {
 		@include breakpoint( '<480px' ) {
 			margin-left: 0;

--- a/client/my-sites/plugins/plugin-remove-button/index.jsx
+++ b/client/my-sites/plugins/plugin-remove-button/index.jsx
@@ -161,8 +161,9 @@ class PluginRemoveButton extends React.Component {
 		const inProgress = PluginsLog.isInProgressAction( this.props.site.ID, this.props.plugin.slug, [
 			'REMOVE_PLUGIN',
 		] );
-		const getDisabledInfo = this.getDisabledInfo();
-		const label = getDisabledInfo
+		const disabledInfo = this.getDisabledInfo();
+		const disabled = !! disabledInfo;
+		const label = disabled
 			? this.props.translate( 'Removal Disabled', {
 					context:
 						'this goes next to an icon that displays if site is in a state where it can\'t modify has "Removal Disabled" ',
@@ -177,15 +178,19 @@ class PluginRemoveButton extends React.Component {
 				</span>
 			);
 		}
+
+		const handleClick = disabled ? null : this.removeAction;
+
 		return (
 			<PluginAction
 				label={ label }
 				htmlFor={ 'remove-plugin-' + this.props.site.ID }
 				action={ this.removeAction }
-				disabledInfo={ getDisabledInfo }
+				disabled={ disabled }
+				disabledInfo={ disabledInfo }
 				className="plugin-remove-button__remove-link"
 			>
-				<a onClick={ this.removeAction } className="plugin-remove-button__remove-icon">
+				<a onClick={ handleClick } className="plugin-remove-button__remove-icon">
 					<Gridicon icon="trash" size={ 18 } />
 				</a>
 			</PluginAction>

--- a/client/my-sites/plugins/plugin-remove-button/index.jsx
+++ b/client/my-sites/plugins/plugin-remove-button/index.jsx
@@ -25,7 +25,9 @@ class PluginRemoveButton extends React.Component {
 	removeAction = () => {
 		accept(
 			this.props.translate(
-				'Are you sure you want to remove {{strong}}%(pluginName)s{{/strong}} from %(siteName)s? {{br /}} {{em}}This will deactivate the plugin and delete all associated files and data.{{/em}}',
+				'Are you sure you want to remove {{strong}}%(pluginName)s{{/strong}} from' +
+					' %(siteName)s? {{br /}} {{em}}This will deactivate the plugin and delete all' +
+					' associated files and data.{{/em}}',
 				{
 					components: {
 						em: <em />,
@@ -125,6 +127,7 @@ class PluginRemoveButton extends React.Component {
 					<li key={ 'reason-i' + i + '-' + this.props.site.ID }>{ reason }</li>
 				) );
 				html.push(
+					/* eslint-disable wpcalypso/jsx-classname-namespace */
 					<ul className="plugin-action__disabled-info-list" key="reason-shell-list">
 						{ list }
 					</ul>
@@ -141,11 +144,7 @@ class PluginRemoveButton extends React.Component {
 			html.push(
 				<ExternalLink
 					key="external-link"
-					onClick={ analytics.ga.recordEvent.bind(
-						this,
-						'Plugins',
-						'Clicked How do I fix diabled plugin removal.'
-					) }
+					onClick={ this.handleHowDoIFixThisButtonClick }
 					href="https://jetpack.me/support/site-management/#file-update-disabled"
 				>
 					{ this.props.translate( 'How do I fix this?' ) }
@@ -155,6 +154,10 @@ class PluginRemoveButton extends React.Component {
 			return html;
 		}
 		return null;
+	};
+
+	handleHowDoIFixThisButtonClick = () => {
+		analytics.ga.recordEvent( 'Plugins', 'Clicked How do I fix disabled plugin removal.' );
 	};
 
 	renderButton = () => {

--- a/client/my-sites/plugins/plugin-remove-button/style.scss
+++ b/client/my-sites/plugins/plugin-remove-button/style.scss
@@ -4,8 +4,20 @@
 	line-height: 16px;
 	margin-right: 10px;
 	vertical-align: top;
-	text-transform: uppercase;
 	display: block;
+}
+
+.plugin-remove-button__remove-link {
+	margin-left: 12px;
+}
+
+.plugin-meta__actions .plugin-remove-button__remove-link {
+	margin-left: 0;
+}
+
+.plugin-remove-button__remove-link .plugin-action__children {
+	display: inline-flex;
+	flex-direction: row-reverse;
 }
 
 .plugin-site__actions .plugin-remove-button__remove {
@@ -13,19 +25,21 @@
 	padding: 16px;
 }
 
-.plugin-remove-button__remove-link .plugin-action__label {
-	margin-left: 12px;
-}
-
 .plugin-remove-button__remove-icon {
 	display: block;
 	margin: -2px 3px 0;
 
 	.gridicons-trash {
+		display: block;
 		color: $gray;
 		cursor: pointer;
-		&:hover{
+		&:hover {
 			color: $alert-red;
 		}
 	}
+}
+
+.plugin-remove-button__remove-link.is-disabled .plugin-remove-button__remove-icon .gridicons-trash {
+	color: lighten( $gray, 30% );
+	cursor: default;
 }

--- a/client/my-sites/plugins/plugins-list/style.scss
+++ b/client/my-sites/plugins/plugins-list/style.scss
@@ -40,7 +40,7 @@
 		.plugin-item__count,
 		.plugin-item__actions {
 			align-self: flex-start;
-			flex-direction: row;
+			flex-direction: column;
 			margin-top: -6px;
 			padding-top: 0;
 			text-align: left;

--- a/client/my-sites/plugins/plugins-list/style.scss
+++ b/client/my-sites/plugins/plugins-list/style.scss
@@ -45,6 +45,10 @@
 			padding-top: 0;
 			text-align: left;
 		}
+
+		.plugin-item__count {
+			flex-direction: row;
+		}
 	}
 }
 


### PR DESCRIPTION
This attempts to fix #17941 and is still work in progress. The following cases are OK:

3-column plugins view:
<img width="798" alt="plugin-actions-3col" src="https://user-images.githubusercontent.com/664258/30857723-23346cd4-a2bd-11e7-96b9-fa44c9cf26de.png">

1-column plugins view:
<img width="679" alt="plugin-actions-1col" src="https://user-images.githubusercontent.com/664258/30857727-27430de4-a2bd-11e7-9d2b-79410b1761a5.png">

individual plugin's info:
<img width="616" alt="plugin-actions-meta" src="https://user-images.githubusercontent.com/664258/30857736-2ea8cb5a-a2bd-11e7-925f-20ab792981e0.png">

The following two cases are still not OK. The desired state in both of them is to have the label and info icon aligned on the left, and the toggle/icon aligned on the right.

individual plugin's info in narrow mobile (<480px) view: (first two actions are OK, the third is broken)
<img width="402" alt="plugin-actions-meta-narrow" src="https://user-images.githubusercontent.com/664258/30857741-31c39cb6-a2bd-11e7-8b86-d618b343e4b9.png">

individual plugin's info, "all sites" view:
<img width="571" alt="plugin-actions-meta-multi" src="https://user-images.githubusercontent.com/664258/30857747-35a9c38c-a2bd-11e7-8448-662f206a4a64.png">

You can see that the plugin action buttons need to work in 5 different cases, which makes any change very difficult.
