### PR TITLE
Sidebar: Show sidebar item as selected when query term present

### DIFF
--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -136,7 +136,7 @@ export class MySitesSidebar extends Component {
 		}
 
 		return paths.some( function( path ) {
-			return path === this.props.path || 0 === this.props.path.indexOf( path + '/' );
+			return path === this.props.path || 0 === this.props.path.indexOf( path + '/' ) || 0 === this.props.path.indexOf( path + '?' );
 		}, this );
 	}
 

--- a/client/my-sites/sidebar/test/sidebar.jsx
+++ b/client/my-sites/sidebar/test/sidebar.jsx
@@ -71,5 +71,16 @@ describe( 'MySitesSidebar', () => {
 
 			expect( isSelected ).to.be.true;
 		} );
+
+		it( 'should return true if one of the paths is a prefix of the current path and separated by search query', () => {
+			const instance = new MySitesSidebar();
+			const isSelected = instance.isItemLinkSelected.call( {
+				props: {
+					path: '/posts?s=search'
+				}
+			}, [ '/posts' ] );
+
+			expect( isSelected ).to.be.true;
+		} );
 	} );
 } );


### PR DESCRIPTION
Currently, if you're on a route like https://wordpress.com/pages and you use the search feature to search through all of your site pages, the Pages sidebar item no longer appears selected despite still being on a pages route.

This is happening because we're checking two things:
1. `path === this.props.path`
2. `0 === this.props.path.indexOf( path + '/' )`

Neither return `true` if the current path is `/posts?s=something` and the item path is `/posts`. 

This updates the logic used to determine whether a sidebar item should appear selected. It now returns truthy if the path of the item is a prefix of the current path plus a search query. I essentially added this check:

`0 === this.props.path.indexOf( path + '?' );`

Added a test case as well.

## To test
1. Load up this branch and visit http://calypso.localhost:3000/pages.
2. Use the search function in the nav to enter a search term. The "Site Pages" sidebar navigation should stay selected the entire time.
3. You can repeat this for Blog Posts, Plugins, and Themes as all items should be corrected now.
4. You can run the tests with `npm run test-client client/my-sites/sidebar/test`. Tests fail without this change and pass with it.

## Screenshot

<img width="1217" alt="zxrh8a" src="https://user-images.githubusercontent.com/7240478/30862148-50aad3f2-a28a-11e7-9e20-6a81277cdf77.png">

Fixes: #18153