### PR TITLE
Plugins: shorten the auto-manage message

### DIFF
--- a/client/my-sites/plugins/plugin-item/plugin-item.jsx
+++ b/client/my-sites/plugins/plugin-item/plugin-item.jsx
@@ -188,7 +188,7 @@ class PluginItem extends Component {
 		if ( this.props.isAutoManaged ) {
 			return (
 				<div className="plugin-item__last-updated">
-					{ translate( '%(pluginName)s is automatically managed on this site', { args: { pluginName: pluginData.name } } ) }
+					{ translate( 'Auto-managed on this site' ) }
 				</div>
 			);
 		}

--- a/client/my-sites/plugins/plugin-site-jetpack/index.jsx
+++ b/client/my-sites/plugins/plugin-site-jetpack/index.jsx
@@ -94,14 +94,11 @@ const PluginSiteJetpack = React.createClass( {
 						plugin={ this.props.site.plugin }
 						site={ this.props.site }
 						notices={ this.props.notices } /> }
-
-					{ showAutoManagedMessage &&
+					{ showAutoManagedMessage && (
 						<div className="plugin-site-jetpack__automanage-notice">
-						{ this.props.translate( '%(pluginName)s is automatically managed on this site',
-							{ args: { pluginName: this.props.plugin.name } } )
-						}
+							{ this.props.translate( 'Auto-managed on this site' ) }
 						</div>
-					}
+					) }
 
 				</div>
 			</FoldableCard>


### PR DESCRIPTION
Shortened the auto-manage message on manage page for a single site, and also on an individual plugin page in "all sites" mode.

Single site:
<img width="817" alt="auto-manage-site" src="https://user-images.githubusercontent.com/664258/30863642-dc4bd8ba-a2d1-11e7-96aa-85c212fb8eba.png">

All-sites:
<img width="537" alt="auto-manage-all-sites" src="https://user-images.githubusercontent.com/664258/30863684-f124fcb2-a2d1-11e7-9819-4177b546aa34.png">

If the single site view is 1041px wide (exactly at the 1-column vs. 3-columns breakpoint), the labels still don't fit very well and are truncated with ellipsis:
<img width="710" alt="auto-manage-site-1040" src="https://user-images.githubusercontent.com/664258/30863863-66ad8706-a2d2-11e7-94fc-f9d67d0c304a.png">

