### PR TITLE
Olark: Prevent Olark from loading if the user is not logged in

### DIFF
--- a/client/boot/project/wordpress-com.js
+++ b/client/boot/project/wordpress-com.js
@@ -203,7 +203,7 @@ export function setupMiddlewares( currentUser, reduxStore ) {
 
 	require( 'my-sites' )();
 
-	if ( config.isEnabled( 'olark' ) ) {
+	if ( currentUser.get() && config.isEnabled( 'olark' ) ) {
 		asyncRequire( 'lib/olark', olark => olark.initialize( reduxStore.dispatch ) );
 	}
 


### PR DESCRIPTION
This pull request disables Olark if the user is not logged in. This saves an unnecessary request to the `help/olark/mine` API endpoint that would otherwise return:
 
```
{
  "code": 403,
  "headers": [{
    "name": "Content-Type",
    "value": "application\/json"
  }],
  "body": {
    "error": "authorization_required",
    "message": "An active access token must be used to query information about the current user."
  }
}
```
  
#### Testing instructions
 
1. Run `git checkout fix/olark` and start your server, or open a [live branch](https://calypso.live/?branch=fix/olark)
2. Open the [`Home` page](http://calypso.localhost:3000/log-in)
3. Open the network panel in your browser's devtools
4. Assert that no request to the `help/olark/mine` endpoint was sent
 
#### Reviews
 
- [x] Code
- [ ] Product