### PR TITLE
Site Settings: abstract a site-centered no-sidebar scenario Card into a separate component

### DIFF
--- a/client/my-sites/site-settings/centered-card/README.md
+++ b/client/my-sites/site-settings/centered-card/README.md
@@ -1,0 +1,35 @@
+#Centered Card
+
+This is a card component, which is to be used as a centered element
+of the page without the navigation sidebar. An example of its use is the Jetpack
+Disconnect Flow, e.g. see `settings/disconnect-site/:site`, where site
+is a Jetpack site.
+
+#### How to use:
+
+```js
+import CenteredCard from 'my-sites/site-settings/centered-card';
+
+render() {
+  return (
+      <DisconnectCard>
+        { 'Card content' }
+      </DisconnectCard>
+  );
+}
+```
+
+## Props
+
+### `header`
+
+### `subheader`
+
+The above supported props are used by the CenteredCard within a `FormattedHeader`
+component:
+```js
+<FormattedHeader
+  headerText={ header }
+  subHeaderText={ subheader }
+/>
+```

--- a/client/my-sites/site-settings/centered-card/index.jsx
+++ b/client/my-sites/site-settings/centered-card/index.jsx
@@ -1,0 +1,28 @@
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+/**
+ * Internal dependencies
+ */
+import Card from 'components/card';
+import FormattedHeader from 'components/formatted-header';
+
+class CenteredCard extends Component {
+	render() {
+		const { header, subheader } = this.props;
+
+		return (
+			<div>
+				<FormattedHeader
+					headerText={ header }
+					subHeaderText={ subheader }
+				/>
+				<Card className="centered-card__content">
+						{ this.props.children }
+				</Card>
+			</div>
+			);
+	}
+}
+export default CenteredCard;

--- a/client/my-sites/site-settings/centered-card/style.scss
+++ b/client/my-sites/site-settings/centered-card/style.scss
@@ -1,0 +1,18 @@
+.centered-card__content {
+		position: relative;
+		padding: 24px;
+
+		@include breakpoint( "<480px" ) {
+			max-width: 300px;
+		}
+
+		@include breakpoint( "<660px" ) {
+			margin-top: 2em;
+			max-width: 500px;
+		}
+
+		@include breakpoint( ">660px" ) {
+			margin-top: 17px;
+			max-width: 800px;
+		}
+	}

--- a/client/my-sites/site-settings/disconnect-site/index.jsx
+++ b/client/my-sites/site-settings/disconnect-site/index.jsx
@@ -9,9 +9,8 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import Card from 'components/card';
+import CenteredCard from 'my-sites/site-settings/centered-card';
 import DocumentHead from 'components/data/document-head';
-import FormattedHeader from 'components/formatted-header';
 import { getSelectedSite } from 'state/ui/selectors';
 import Main from 'components/main';
 import Placeholder from 'my-sites/site-settings/placeholder';
@@ -25,16 +24,17 @@ class DisconnectSite extends Component {
 		if ( ! site ) {
 			return <Placeholder />;
 		}
+
+		const header = translate( 'Disconnect Site' );
+		const subheader = translate(
+			'Tell us why you want to disconnect your site from WordPress.com.'
+		);
 		return (
 			<Main className="disconnect-site site-settings">
 				<DocumentHead title={ translate( 'Site Settings' ) } />
-				<FormattedHeader
-					headerText={ translate( 'Disconnect Site' ) }
-					subHeaderText={ translate(
-						'Tell us why you want to disconnect your site from WordPress.com.'
-					) }
-				/>
-				<Card className="disconnect-site__card"> </Card>
+				<CenteredCard header={ header } subheader={ subheader }>
+					{' '}
+				</CenteredCard>
 				<SkipSurvey />
 			</Main>
 		);

--- a/client/my-sites/site-settings/disconnect-site/style.scss
+++ b/client/my-sites/site-settings/disconnect-site/style.scss
@@ -7,25 +7,6 @@
 	}
 }
 
-.disconnect-site__card {
-		position: relative;
-		padding: 24px;
-
-		@include breakpoint( "<480px" ) {
-			max-width: 300px;
-		}
-
-		@include breakpoint( "<660px" ) {
-			margin-top: 2em;
-			max-width: 500px;
-		}
-
-		@include breakpoint( ">660px" ) {
-			margin-top: 17px;
-			max-width: 800px;
-		}
-	}
-
 .disconnect-site__skip-survey {
 		&.main {
 			margin: 16px 0 24px 0;


### PR DESCRIPTION
**Purpose:**
Create a Card component, which is centered on sites without a navigation sidebar. 

**Context:**
Throughout the Jetpack Disconnect Flow we use a site-centered Card component with varying headers and subheaders, but repeated styling. Aside from cleaning code repeats for the Disconnect Flow, IMO this set-up could be reused in the other contexts (great for UX flows).

**To test:**
- Checkout this branch, or use calypso.live:
https://calypso.live/?branch=update/site-settings-extract-card

*Refactor* of https://github.com/Automattic/wp-calypso/pull/18119.

**To test:**
- Checkout this branch, or use calypso.live:
https://calypso.live/?branch=update/update/site-settings-extract-card

For Jetpack and non-Atomic sites:
  -  the Card should show ```/settings/disconnect-site/:site```, where :site is the Jetpack site.

Remaining sites have no access and should be redirected to `/settings/general/`.

**Visuals:**
![30777449-b5d262ce-a0b2-11e7-99c7-994531670b2c](https://user-images.githubusercontent.com/13561163/30865993-fc845d02-a2cf-11e7-9119-6770bfc63be4.png)



