### PR TITLE
Plugin Uploads: More useful error for transfer with non-zip

### DIFF
--- a/client/state/data-layer/wpcom/sites/automated-transfer/initiate/index.js
+++ b/client/state/data-layer/wpcom/sites/automated-transfer/initiate/index.js
@@ -34,15 +34,22 @@ export const receiveResponse = ( { dispatch }, { siteId } ) => {
 	dispatch( getAutomatedTransferStatus( siteId ) );
 };
 
-export const receiveError = ( { dispatch }, { siteId }, error ) => {
+const showErrorNotice = ( dispatch, error ) => {
+	if ( error.error === 'invalid_input' ) {
+		dispatch( errorNotice( translate( 'Not a valid zip file.' ) ) );
+		return;
+	}
 	if ( error.error ) {
 		dispatch( errorNotice( translate( 'Upload problem: %(error)s.', {
 			args: { error: error.error }
 		} ) ) );
-	} else {
-		dispatch( errorNotice( translate( 'Problem uploading the plugin.' ) ) );
+		return;
 	}
+	dispatch( errorNotice( translate( 'Problem uploading the plugin.' ) ) );
+};
 
+export const receiveError = ( { dispatch }, { siteId }, error ) => {
+	showErrorNotice( dispatch, error );
 	dispatch( pluginUploadError( siteId, error ) );
 };
 

--- a/client/state/data-layer/wpcom/sites/automated-transfer/initiate/test/index.js
+++ b/client/state/data-layer/wpcom/sites/automated-transfer/initiate/test/index.js
@@ -63,7 +63,7 @@ describe( 'receiveError', () => {
 		receiveError( { dispatch }, { siteId }, ERROR_RESPONSE );
 		expect( dispatch ).to.have.been.calledTwice;
 		expect( dispatch ).to.have.been.calledWithMatch( {
-			notice: { text: 'Upload problem: invalid_input.' }
+			notice: { text: 'Not a valid zip file.' }
 		} );
 	} );
 } );


### PR DESCRIPTION
**Before**
<img width="978" alt="screen shot 2017-09-26 at 17 12 47" src="https://user-images.githubusercontent.com/7767559/30871257-1e8500d8-a2de-11e7-8690-e5912ab05811.png">

**After**
<img width="977" alt="screen shot 2017-09-26 at 17 12 33" src="https://user-images.githubusercontent.com/7767559/30871271-28c68620-a2de-11e7-91a0-789e4f0c7556.png">

## Testing
* Run the unit tests

or

* Go to /plugins/upload/{site} where site is a simple business site with a mapped domain
* Drag a non zip file into the dropzone, for example a .png file
* Take care, because doing this with a .zip will initiate a real transfer
