### PR TITLE
Editor: Update notice messages to display correct labels for CPTs

### DIFF
--- a/client/post-editor/editor-notice/index.jsx
+++ b/client/post-editor/editor-notice/index.jsx
@@ -52,14 +52,26 @@ export class EditorNotice extends Component {
 	}
 
 	getText( key ) {
+		/* eslint-disable max-len */
 		const { translate, type, typeObject, site } = this.props;
+		const typeLabel = typeObject && typeObject.labels.singular_name;
 
 		switch ( key ) {
 			case 'warnPublishDateChange':
+				// This message can only appear for type === 'post'.  See
+				// PostEditor#checkForDateChange().
 				return translate( 'Are you sure about that? If you change the date, existing links to your post will stop working.' );
+
 			case 'publishFailure':
 				if ( 'page' === type ) {
 					return translate( 'Publishing of page failed.' );
+				}
+
+				if ( 'post' !== type && typeLabel ) {
+					return translate(
+						'Publishing of %(typeLabel)s failed.',
+						{ args: { typeLabel } }
+					);
 				}
 
 				return translate( 'Publishing of post failed.' );
@@ -72,12 +84,26 @@ export class EditorNotice extends Component {
 					return translate( 'Trashing of page failed.' );
 				}
 
+				if ( 'post' !== type && typeLabel ) {
+					return translate(
+						'Trashing of %(typeLabel)s failed.',
+						{ args: { typeLabel } }
+					);
+				}
+
 				return translate( 'Trashing of post failed.' );
 
 			case 'published':
 				if ( ! site ) {
 					if ( 'page' === type ) {
 						return translate( 'Page published!' );
+					}
+
+					if ( 'post' !== type && typeLabel ) {
+						return translate(
+							'%(typeLabel)s published!',
+							{ args: { typeLabel } }
+						);
 					}
 
 					return translate( 'Post published!' );
@@ -90,6 +116,16 @@ export class EditorNotice extends Component {
 							a: <a href={ `/page/${ site.slug }` } />,
 						},
 						comment: 'Editor: Message displayed when a page is published, with a link to the site it was published on.'
+					} );
+				}
+
+				if ( 'post' !== type && typeLabel ) {
+					return translate( '%(typeLabel)s published on {{siteLink/}}!', {
+						args: { typeLabel },
+						components: {
+							siteLink: <a href={ site.URL } target="_blank" rel="noopener noreferrer">{ site.title }</a>
+						},
+						comment: 'Editor: Message displayed when a post of a custom type is published, with a link to the site it was published on.'
 					} );
 				}
 
@@ -106,6 +142,13 @@ export class EditorNotice extends Component {
 						return translate( 'Page scheduled!' );
 					}
 
+					if ( 'post' !== type && typeLabel ) {
+						return translate(
+							'%(typeLabel)s scheduled!',
+							{ args: { typeLabel } }
+						);
+					}
+
 					return translate( 'Post scheduled!' );
 				}
 
@@ -116,6 +159,16 @@ export class EditorNotice extends Component {
 							a: <a href={ `/page/${ site.slug }` } />,
 						},
 						comment: 'Editor: Message displayed when a page is scheduled, with a link to the site it was scheduled on.'
+					} );
+				}
+
+				if ( 'post' !== type && typeLabel ) {
+					return translate( '%(typeLabel)s scheduled on {{siteLink/}}!', {
+						args: { typeLabel },
+						components: {
+							siteLink: <a href={ site.URL } target="_blank" rel="noopener noreferrer">{ site.title }</a>
+						},
+						comment: 'Editor: Message displayed when a post of a custom type is scheduled, with a link to the site it was scheduled on.'
 					} );
 				}
 
@@ -137,7 +190,9 @@ export class EditorNotice extends Component {
 			case 'view':
 				if ( 'page' === type ) {
 					return translate( 'View Page' );
-				} else if ( 'post' !== type && typeObject ) {
+				}
+
+				if ( 'post' !== type && typeObject ) {
 					return typeObject.labels.view_item;
 				}
 
@@ -150,6 +205,13 @@ export class EditorNotice extends Component {
 				if ( ! site ) {
 					if ( 'page' === type ) {
 						return translate( 'Page updated!' );
+					}
+
+					if ( 'post' !== type && typeLabel ) {
+						return translate(
+							'%(typeLabel)s updated!',
+							{ args: { typeLabel } }
+						);
 					}
 
 					return translate( 'Post updated!' );
@@ -165,6 +227,16 @@ export class EditorNotice extends Component {
 					} );
 				}
 
+				if ( 'post' !== type && typeLabel ) {
+					return translate( '%(typeLabel)s updated on {{siteLink/}}!', {
+						args: { typeLabel },
+						components: {
+							siteLink: <a href={ site.URL } target="_blank" rel="noopener noreferrer">{ site.title }</a>
+						},
+						comment: 'Editor: Message displayed when a post of a custom type is updated, with a link to the site it was updated on.'
+					} );
+				}
+
 				return translate( 'Post updated on {{siteLink/}}!', {
 					components: {
 						siteLink: <a href={ site.URL } target="_blank" rel="noopener noreferrer">{ site.title }</a>
@@ -172,6 +244,7 @@ export class EditorNotice extends Component {
 					comment: 'Editor: Message displayed when a post is updated, with a link to the site it was updated on.'
 				} );
 		}
+		/* eslint-enable max-len */
 	}
 
 	render() {


### PR DESCRIPTION
Fixes #16041 by adding a separately translated string for the notice that a post of a custom type has been published (as long as its [post type label](https://codex.wordpress.org/Function_Reference/register_post_type#Arguments) is known).  This PR uses the same approach as #17511.

The same issue also applies to other editor notice messages such as updating and errors.  For consistency and to encourage a common pattern in this code, this PR updates all editor notice messages that mention a post type in the same way.

It would be difficult to test all of these flows in normal usage of the editor, especially the error messages.  To test this PR, edit a post of a custom type and use the [`debug/fix/editor-notice-cpt-labels` branch](https://github.com/Automattic/wp-calypso/compare/fix/editor-notice-cpt-labels...debug/fix/editor-notice-cpt-labels) which shows all of the possible notice messages at once:

![2017-09-26t12 21 50-0500](https://user-images.githubusercontent.com/227022/30874226-50377a94-a2b5-11e7-808d-4c44046f9e55.png)
