### PR TITLE
Stop calling `isMounted` in data-observe mixin

### DIFF
--- a/client/lib/mixins/data-observe/index.js
+++ b/client/lib/mixins/data-observe/index.js
@@ -1,9 +1,12 @@
-var debug = require( 'debug' )( 'calypso:data-observe' );
+/** @format */
+/**
+ * External dependencies
+ */
+import debugFactory from 'debug';
 
-module.exports = function() {
-	var propNames = Array.prototype.slice.call( arguments );
+const debug = debugFactory( 'calypso:data-observe' );
 
-
+export default function( ...propNames ) {
 	return {
 		componentDidMount: function() {
 			propNames.forEach( function( propName ) {
@@ -42,7 +45,6 @@ module.exports = function() {
 		update: function() {
 			debug( 'Re-rendering ' + this.constructor.displayName + ' component.' );
 			this.forceUpdate();
-		}
-
+		},
 	};
-};
+}

--- a/client/lib/mixins/data-observe/index.js
+++ b/client/lib/mixins/data-observe/index.js
@@ -37,14 +37,11 @@ module.exports = function() {
 					}
 				}
 			}, this );
-
 		},
 
 		update: function() {
-			if ( this.isMounted() ) {
-				debug( 'Re-rendering ' + this.constructor.displayName + ' component.' );
-				this.forceUpdate();
-			}
+			debug( 'Re-rendering ' + this.constructor.displayName + ' component.' );
+			this.forceUpdate();
 		}
 
 	};


### PR DESCRIPTION
The `isMounted` check is redundant: the `this.update` listener is installed after the component is mounted, and uninstalled before the component is unmounted. It's already guaranteed that the component is mounted when `this.update` is called.

Also, I verified (with some grepping) that no component that uses the mixin calls `this.update()` directly.

This should be a small step towards the React 16 migration.

To test:
- enable debug logging of the data observer in console: `localStorage.debug = 'calypso:data-observe'`
- click around places in Calypso where the `observe` mixin is used. For example, the `/me` section has a lot of them.

The second commit ES6-ifies the component a bit, mainly imports and exports.