### PR TITLE
Checkout: add support for Ebanx CC processing

### DIFF
--- a/client/blocks/credit-card-form/index.jsx
+++ b/client/blocks/credit-card-form/index.jsx
@@ -48,7 +48,22 @@ const CreditCardForm = createReactClass( {
 	},
 
 	_mounted: false,
-	fieldNames: [ 'name', 'number', 'cvv', 'expirationDate', 'country', 'postalCode' ],
+	fieldNames: [
+		'name',
+		'number',
+		'cvv',
+		'expirationDate',
+		'country',
+		'postalCode',
+		'streetNumber',
+		'address1',
+		'address2',
+		'phoneNumber',
+		'streetNumber',
+		'city',
+		'state',
+		'document',
+	],
 
 	componentWillMount() {
 		this._mounted = true;
@@ -217,6 +232,13 @@ const CreditCardForm = createReactClass( {
 			month: cardDetails[ 'expiration-date' ].split( '/' )[ 0 ],
 			year: cardDetails[ 'expiration-date' ].split( '/' )[ 1 ],
 			name: cardDetails.name,
+			document: cardDetails.document,
+			street_number: cardDetails[ 'street-number' ],
+			address_1: cardDetails[ 'address-1' ],
+			address_2: cardDetails[ 'address-2' ],
+			city: cardDetails.city,
+			state: cardDetails.state,
+			phone_number: cardDetails[ 'phone-number' ],
 			cardToken,
 		};
 	},

--- a/client/blocks/credit-card-form/test/index.js
+++ b/client/blocks/credit-card-form/test/index.js
@@ -1,0 +1,73 @@
+/**
+ * @format
+ * @jest-environment jsdom
+ */
+
+/**
+ * External dependencies
+ */
+import { shallow } from 'enzyme';
+import { identity, noop } from 'lodash';
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import CreditCardForm from '../';
+
+jest.mock( 'i18n-calypso', () => ( {
+	localize: x => x,
+} ) );
+
+describe( 'Credit Card Form', () => {
+	const defaultProps = {
+		translate: identity,
+		createCardToken: noop,
+		recordFormSubmitEvent: noop,
+		successCallback: noop,
+	};
+
+	test( 'does not blow up with default props', () => {
+		const wrapper = shallow( <CreditCardForm { ...defaultProps } /> );
+		expect( wrapper ).toHaveLength( 1 );
+	} );
+
+	describe( 'getParamsForApi()', () => {
+		test( 'should return expected api params from form credit card values', () => {
+			const wrapper = shallow( <CreditCardForm { ...defaultProps } /> );
+
+			expect(
+				wrapper.instance().getParamsForApi(
+					{
+						country: 'AU',
+						'postal-code': '33333',
+						'expiration-date': '02/2222',
+						year: '2222',
+						name: 'bob',
+						document: '1111',
+						'street-number': '12',
+						'address-1': '12 Pleasant Crescent',
+						city: 'city',
+						state: 'state',
+						'phone-number': '+31222222',
+					},
+					{}
+				)
+			).toEqual( {
+				country: 'AU',
+				zip: '33333',
+				month: '02',
+				year: '2222',
+				name: 'bob',
+				document: '1111',
+				street_number: '12',
+				address_1: '12 Pleasant Crescent',
+				address_2: undefined,
+				city: 'city',
+				state: 'state',
+				phone_number: '+31222222',
+				cardToken: {},
+			} );
+		} );
+	} );
+} );

--- a/client/components/credit-card-form-fields/README.md
+++ b/client/components/credit-card-form-fields/README.md
@@ -13,6 +13,12 @@ CreditCardFormFields
 
 Some of these fields use [masking](https://en.wikipedia.org/wiki/Input_mask), i.e. rules that govern what a user is allowed to enter in a text box.
 
+Brazil requires that users provide additional details when making payments. When a user selects Brazil from the country select menu, extra fields will appear:
+
+* Tax identification code, also known as [CPF](https://en.wikipedia.org/wiki/Cadastro_de_Pessoas_F%C3%ADsicas)
+* Phone number
+* Address, city and state details
+
 ## Usage
 
 ```jsx

--- a/client/components/credit-card-form-fields/index.jsx
+++ b/client/components/credit-card-form-fields/index.jsx
@@ -6,18 +6,20 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import { assign } from 'lodash';
 import { localize } from 'i18n-calypso';
+import classNames from 'classnames';
+import isEqual from 'lodash/isEqual';
 
 /**
  * Internal dependencies
  */
-import CountrySelect from 'my-sites/domains/components/form/country-select';
 import CreditCardNumberInput from 'components/upgrades/credit-card-number-input';
-import Input from 'my-sites/domains/components/form/input';
+import { CountrySelect, StateSelect, Input, HiddenInput } from 'my-sites/domains/components/form';
+import FormPhoneMediaInput from 'components/forms/form-phone-media-input';
 import { maskField, unmaskField } from 'lib/credit-card-details';
+import { isEbanx } from 'lib/credit-card-details/ebanx';
 
-class CreditCardFormFields extends React.Component {
+export class CreditCardFormFields extends React.Component {
 	static propTypes = {
 		card: PropTypes.object.isRequired,
 		countriesList: PropTypes.object.isRequired,
@@ -26,28 +28,46 @@ class CreditCardFormFields extends React.Component {
 		onFieldChange: PropTypes.func.isRequired,
 	};
 
-	field = ( fieldName, componentClass, props ) => {
+	constructor( props ) {
+		super( props );
+		this.state = {
+			countryCode: '',
+			phoneCountryCode: '',
+		};
+	}
+
+	shouldComponentUpdate( nextProps ) {
+		if ( ! isEqual( nextProps.card, this.props.card ) ) {
+			return true;
+		}
+		return false;
+	}
+
+	createField = ( fieldName, componentClass, props ) => {
 		return React.createElement(
 			componentClass,
-			assign( {}, props, {
-				additionalClasses: 'credit-card-form-fields__field',
-				eventFormName: this.props.eventFormName,
-				isError: this.props.isFieldInvalid( fieldName ),
-				name: fieldName,
-				onBlur: this.handleFieldChange,
-				onChange: this.handleFieldChange,
-				value: this.getFieldValue( fieldName ),
-				autoComplete: 'off',
-			} )
+			Object.assign(
+				{},
+				{
+					additionalClasses: 'credit-card-form-fields__field',
+					eventFormName: this.props.eventFormName,
+					isError: this.props.isFieldInvalid( fieldName ),
+					name: fieldName,
+					onChange: this.handleFieldChange,
+					value: this.getFieldValue( fieldName ) || '',
+					autoComplete: 'off',
+				},
+				props
+			)
 		);
 	};
 
 	getFieldValue = fieldName => {
-		return this.props.card[ fieldName ];
+		return this.props.card[ fieldName ] || '';
 	};
 
-	handleFieldChange = event => {
-		const { name: fieldName, value: nextValue } = event.target;
+	updateFieldValues( fieldName, nextValue ) {
+		const { onFieldChange } = this.props;
 
 		const previousValue = this.getFieldValue( fieldName );
 
@@ -59,54 +79,156 @@ class CreditCardFormFields extends React.Component {
 			[ fieldName ]: maskField( fieldName, previousValue, nextValue ),
 		};
 
-		this.props.onFieldChange( rawDetails, maskedDetails );
+		onFieldChange( rawDetails, maskedDetails );
+	}
+
+	handlePhoneFieldChange = ( { value, countryCode } ) => {
+		this.setState(
+			{
+				phoneCountryCode: countryCode,
+			},
+			() => {
+				this.updateFieldValues( 'phone-number', value );
+			}
+		);
 	};
 
+	handleFieldChange = event => {
+		const { name: fieldName, value: nextValue, options, selectedIndex } = event.target;
+
+		const newState = {};
+
+		if ( fieldName === 'country' ) {
+			newState.countryCode = nextValue;
+			newState.countryName = options[ selectedIndex ].text;
+			if ( ! this.state.phoneCountryCode ) {
+				newState.phoneCountryCode = nextValue;
+			}
+		}
+
+		this.setState( newState, () => this.updateFieldValues( fieldName, nextValue ) );
+	};
+
+	shouldRenderEbanx() {
+		const { countryCode } = this.state;
+		return isEbanx( countryCode );
+	}
+
+	renderEbanxFields() {
+		const { translate, countriesList } = this.props;
+		const { countryCode, phoneCountryCode, countryName } = this.state;
+
+		return [
+			<span key="ebanx-required-fields" className="credit-card-form-fields__info-text">
+				{ translate( 'The following fields are also required for payments in %(countryName)s', {
+					args: {
+						countryName,
+					},
+				} ) }
+			</span>,
+
+			this.createField( 'document', Input, {
+				label: translate( 'Taxpayer Identification Number', {
+					comment:
+						'Individual taxpayer registry identification required ' +
+						'for Brazilian payment methods on credit card form',
+				} ),
+				key: 'document',
+			} ),
+
+			this.createField( 'phone-number', FormPhoneMediaInput, {
+				onChange: this.handlePhoneFieldChange,
+				countriesList: countriesList,
+				countryCode: phoneCountryCode,
+				label: translate( 'Phone' ),
+				key: 'phone-number',
+			} ),
+
+			this.createField( 'address-1', Input, {
+				maxLength: 40,
+				labelClass: 'credit-card-form-fields__label',
+				label: translate( 'Address' ),
+				key: 'address-1',
+			} ),
+
+			this.createField( 'street-number', Input, {
+				inputMode: 'numeric',
+				label: translate( 'Street Number', {
+					comment: 'Street number associated with address on credit card form',
+				} ),
+				key: 'street-number',
+			} ),
+
+			this.createField( 'address-2', HiddenInput, {
+				maxLength: 40,
+				labelClass: 'credit-card-form-fields__label',
+				label: translate( 'Address Line 2' ),
+				text: translate( '+ Add Address Line 2' ),
+				key: 'address-2',
+			} ),
+
+			this.createField( 'city', Input, {
+				labelClass: 'credit-card-form-fields__label',
+				label: translate( 'City' ),
+				key: 'city',
+			} ),
+
+			<div className="credit-card-form-fields__state-field" key="state">
+				{ this.createField( 'state', StateSelect, {
+					countryCode: countryCode,
+					label: translate( 'State' ),
+				} ) }
+			</div>,
+		];
+	}
+
 	render() {
-		const translate = this.props.translate;
+		const { translate, countriesList } = this.props;
+		const ebanxDetailsRequired = this.shouldRenderEbanx();
+		const creditCardFormFieldsExtrasClassNames = classNames( {
+			'credit-card-form-fields__extras': true,
+			'ebanx-details-required': ebanxDetailsRequired,
+		} );
 
 		return (
 			<div className="credit-card-form-fields">
-				{ this.field( 'name', Input, {
-					labelClass: 'credit-card-form-fields__label',
+				{ this.createField( 'name', Input, {
 					autoFocus: true,
 					label: translate( 'Name on Card', {
 						context: 'Card holder name label on credit card form',
 					} ),
 				} ) }
 
-				{ this.field( 'number', CreditCardNumberInput, {
+				{ this.createField( 'number', CreditCardNumberInput, {
 					inputMode: 'numeric',
-					labelClass: 'credit-card-form-fields__label',
 					label: translate( 'Card Number', {
 						context: 'Card number label on credit card form',
 					} ),
 				} ) }
 
-				<div className="credit-card-form-fields__extras">
-					{ this.field( 'expiration-date', Input, {
+				<div className={ creditCardFormFieldsExtrasClassNames }>
+					{ this.createField( 'expiration-date', Input, {
 						inputMode: 'numeric',
-						labelClass: 'credit-card-form-fields__label',
 						label: translate( 'MM/YY', {
 							context: 'Expiry label on credit card form',
 						} ),
 					} ) }
 
-					{ this.field( 'cvv', Input, {
+					{ this.createField( 'cvv', Input, {
 						inputMode: 'numeric',
-						labelClass: 'credit-card-form-fields__label',
 						label: translate( 'CVV', {
 							context: '3 digit security number on credit card form',
 						} ),
 					} ) }
 
-					{ this.field( 'country', CountrySelect, {
+					{ this.createField( 'country', CountrySelect, {
 						label: translate( 'Country' ),
-						countriesList: this.props.countriesList,
+						countriesList: countriesList,
 					} ) }
 
-					{ this.field( 'postal-code', Input, {
-						labelClass: 'credit-card-form-fields__label',
+					{ ebanxDetailsRequired && this.renderEbanxFields() }
+
+					{ this.createField( 'postal-code', Input, {
 						label: translate( 'Postal Code', {
 							context: 'Postal code on credit card form',
 						} ),

--- a/client/components/credit-card-form-fields/index.jsx
+++ b/client/components/credit-card-form-fields/index.jsx
@@ -17,7 +17,7 @@ import CreditCardNumberInput from 'components/upgrades/credit-card-number-input'
 import { CountrySelect, StateSelect, Input, HiddenInput } from 'my-sites/domains/components/form';
 import FormPhoneMediaInput from 'components/forms/form-phone-media-input';
 import { maskField, unmaskField } from 'lib/credit-card-details';
-import { isEbanx } from 'lib/credit-card-details/ebanx';
+import { isEbanxEnabledForCountry } from 'lib/credit-card-details/ebanx';
 
 export class CreditCardFormFields extends React.Component {
 	static propTypes = {
@@ -110,8 +110,7 @@ export class CreditCardFormFields extends React.Component {
 	};
 
 	shouldRenderEbanx() {
-		const { countryCode } = this.state;
-		return isEbanx( countryCode );
+		return isEbanxEnabledForCountry( this.state.countryCode );
 	}
 
 	renderEbanxFields() {

--- a/client/components/credit-card-form-fields/style.scss
+++ b/client/components/credit-card-form-fields/style.scss
@@ -11,13 +11,19 @@
 		margin-left: 15px;
 	}
 
-	.country {
-		label {
-			display: none;
-		}
+	.credit-card-form-fields__state-field {
+		flex-basis: calc( 100% );
 	}
 
-	@include breakpoint( ">480px" ) {
+	.form__hidden-input a {
+		display: block;
+		font-size:  12px;
+		margin-top: -10px;
+		margin-left: 15px;
+		margin-bottom: 15px;
+	}
+
+	@include breakpoint( '>480px' ) {
 		.cvv,
 		.expiration-date {
 			flex-basis: calc( 50% - 15px );
@@ -29,6 +35,30 @@
 
 		.postal-code {
 			flex-basis: 8em;
+		}
+
+		&.ebanx-details-required {
+
+			.address-2,
+			.country,
+			.city {
+				flex-basis: calc( 100% - 15px );
+			}
+
+			.street-number {
+				flex-basis: calc( 33% - 15px);
+			}
+
+			.address-1 {
+				flex-basis: calc( 66% - 15px);
+			}
+
+			.document,
+			.phone,
+			.credit-card-form-fields__state-field,
+			.postal-code {
+				flex-basis: calc( 50% - 15px );
+			}
 		}
 	}
 }
@@ -42,19 +72,25 @@
 		width: 100%;
 	}
 
-	input[ disabled ] {
+	input[disabled] {
 		cursor: not-allowed;
 	}
-}
 
-.credit-card-form-fields__label {
 	label {
 		color: darken( $gray, 10% );
-		display: none;
 		font-size: 11px;
 		font-weight: bold;
 		position: absolute;
-		left: 13px;
-		top: 12px;
+		left: -1000px;
+		top: -1000px;
+		margin: 0;
 	}
+}
+
+.credit-card-form-fields__info-text {
+	margin-left: 15px;
+	color: lighten( $gray, 10% );
+	display: block;
+	font-size: 12px;
+	font-style: italic;
 }

--- a/client/components/credit-card-form-fields/test/index.js
+++ b/client/components/credit-card-form-fields/test/index.js
@@ -1,0 +1,61 @@
+/**
+ * @format
+ * @jest-environment jsdom
+ */
+
+/**
+ * External dependencies
+ */
+import { shallow } from 'enzyme';
+import React from 'react';
+import noop from 'lodash/noop';
+import identity from 'lodash/identity';
+/**
+ * Internal dependencies
+ */
+import { CreditCardFormFields } from '../';
+import { isEbanx } from 'lib/credit-card-details/ebanx';
+
+jest.mock( 'i18n-calypso', () => ( {
+	localize: x => x,
+} ) );
+
+jest.mock( 'lib/credit-card-details/ebanx', () => {
+	return {
+		isEbanx: jest.fn( false ),
+	};
+} );
+
+const defaultProps = {
+	card: {},
+	countriesList: {},
+	eventFormName: 'A fine form',
+	translate: identity,
+	isFieldInvalid: identity,
+	onFieldChange: noop,
+};
+
+describe( 'CreditCardFormFields', () => {
+	test( 'should have `CreditCardFormFields` class', () => {
+		const wrapper = shallow( <CreditCardFormFields { ...defaultProps } /> );
+		expect( wrapper.find( '.credit-card-form-fields' ) ).toHaveLength( 1 );
+	} );
+
+	describe( 'with ebanx activated', () => {
+		beforeAll( () => {
+			isEbanx.mockReturnValue( true );
+		} );
+		afterAll( () => {
+			isEbanx.mockReturnValue( false );
+		} );
+
+		test( 'should display Ebanx fields when an Ebanx payment country is selected', () => {
+			const wrapper = shallow( <CreditCardFormFields { ...defaultProps } /> );
+			wrapper.setState( { countryCode: 'BR' } );
+			// shouldComponentUpdate prevents setState from triggering a rerender in <CreditCardFormFields />
+			wrapper.setProps( { card: { country: 'BR' } } );
+			expect( wrapper.find( '.ebanx-details-required' ) ).toHaveLength( 1 );
+			expect( wrapper.find( '.credit-card-form-fields__info-text' ) ).toHaveLength( 1 );
+		} );
+	} );
+} );

--- a/client/components/credit-card-form-fields/test/index.js
+++ b/client/components/credit-card-form-fields/test/index.js
@@ -14,7 +14,7 @@ import identity from 'lodash/identity';
  * Internal dependencies
  */
 import { CreditCardFormFields } from '../';
-import { isEbanx } from 'lib/credit-card-details/ebanx';
+import { isEbanxEnabledForCountry } from 'lib/credit-card-details/ebanx';
 
 jest.mock( 'i18n-calypso', () => ( {
 	localize: x => x,
@@ -22,7 +22,7 @@ jest.mock( 'i18n-calypso', () => ( {
 
 jest.mock( 'lib/credit-card-details/ebanx', () => {
 	return {
-		isEbanx: jest.fn( false ),
+		isEbanxEnabledForCountry: jest.fn( false ),
 	};
 } );
 
@@ -43,10 +43,10 @@ describe( 'CreditCardFormFields', () => {
 
 	describe( 'with ebanx activated', () => {
 		beforeAll( () => {
-			isEbanx.mockReturnValue( true );
+			isEbanxEnabledForCountry.mockReturnValue( true );
 		} );
 		afterAll( () => {
-			isEbanx.mockReturnValue( false );
+			isEbanxEnabledForCountry.mockReturnValue( false );
 		} );
 
 		test( 'should display Ebanx fields when an Ebanx payment country is selected', () => {

--- a/client/lib/cart-values/index.js
+++ b/client/lib/cart-values/index.js
@@ -190,6 +190,13 @@ function isBelgiumBancontactEnabled( cart ) {
 	);
 }
 
+function isEbanxEnabled( cart ) {
+	return (
+		config.isEnabled( 'upgrades/ebanx' ) &&
+		cart.allowed_payment_methods.indexOf( 'WPCOM_Billing_Ebanx' ) >= 0
+	);
+}
+
 export {
 	applyCoupon,
 	canRemoveFromCart,
@@ -205,6 +212,7 @@ export {
 	isPayPalExpressEnabled,
 	isNetherlandsIdealEnabled,
 	isCreditCardPaymentsEnabled,
+	isEbanxEnabled,
 };
 
 export default {
@@ -222,4 +230,5 @@ export default {
 	isPayPalExpressEnabled,
 	isNetherlandsIdealEnabled,
 	isCreditCardPaymentsEnabled,
+	isEbanxEnabled,
 };

--- a/client/lib/credit-card-details/constants.js
+++ b/client/lib/credit-card-details/constants.js
@@ -1,0 +1,11 @@
+/**
+ * External dependencies
+ *
+ * @format
+ */
+
+export const PAYMENT_PROCESSOR_EBANX_COUNTRIES = {
+	BR: {
+		requiredFields: [ 'document', 'street-number', 'address-1', 'state', 'city', 'phone-number' ],
+	},
+};

--- a/client/lib/credit-card-details/ebanx.js
+++ b/client/lib/credit-card-details/ebanx.js
@@ -1,0 +1,39 @@
+/**
+ * External dependencies
+ *
+ * @format
+ */
+import isUndefined from 'lodash/isUndefined';
+import isString from 'lodash/isString';
+
+/**
+ * Internal dependencies
+ */
+import config from 'config';
+import { PAYMENT_PROCESSOR_EBANX_COUNTRIES } from './constants';
+
+/**
+ *
+ * @param {string} countryCode - a two-letter country code, e.g., 'DE', 'BR'
+ * @returns {bool} Whether the country code requires ebanx payement processing
+ */
+export function isEbanx( countryCode = '' ) {
+	return (
+		! isUndefined( PAYMENT_PROCESSOR_EBANX_COUNTRIES[ countryCode ] ) &&
+		config.isEnabled( 'upgrades/ebanx' )
+	);
+}
+
+/**
+ * CPF number (Cadastrado de Pessoas Físicas) is the Brazilian tax identification number.
+ * Total of 11 digits: 9 numbers followed by 2 verification numbers . E.g., 188.247.019-22
+ * The following test is a weak test only. Full algorithm here: http://www.geradorcpf.com/algoritmo_do_cpf.htm
+ *
+ * See: http://www.geradorcpf.com/algoritmo_do_cpf.htm
+ * @param {string} cpf - a Brazilian tax identification number
+ * @returns {bool} Whether the cpf is valid or not
+ */
+
+export function isValidCPF( cpf = '' ) {
+	return isString( cpf ) && /^[0-9]{3}\.[0-9]{3}\.[0-9]{3}-[0-9]{2}$/.test( cpf );
+}

--- a/client/lib/credit-card-details/ebanx.js
+++ b/client/lib/credit-card-details/ebanx.js
@@ -15,7 +15,7 @@ import { PAYMENT_PROCESSOR_EBANX_COUNTRIES } from './constants';
 /**
  *
  * @param {string} countryCode - a two-letter country code, e.g., 'DE', 'BR'
- * @returns {bool} Whether the country code requires ebanx payement processing
+ * @returns {bool} Whether the country code requires ebanx payment processing
  */
 export function isEbanx( countryCode = '' ) {
 	return (

--- a/client/lib/credit-card-details/ebanx.js
+++ b/client/lib/credit-card-details/ebanx.js
@@ -9,18 +9,19 @@ import isString from 'lodash/isString';
 /**
  * Internal dependencies
  */
-import config from 'config';
 import { PAYMENT_PROCESSOR_EBANX_COUNTRIES } from './constants';
+import { isEbanxEnabled } from 'lib/cart-values';
+import CartStore from 'lib/cart/store';
 
 /**
  *
- * @param {string} countryCode - a two-letter country code, e.g., 'DE', 'BR'
- * @returns {bool} Whether the country code requires ebanx payment processing
+ * @param {String} countryCode - a two-letter country code, e.g., 'DE', 'BR'
+ * @returns {Boolean} Whether the country code requires ebanx payment processing
  */
-export function isEbanx( countryCode = '' ) {
+export function isEbanxEnabledForCountry( countryCode = '' ) {
 	return (
 		! isUndefined( PAYMENT_PROCESSOR_EBANX_COUNTRIES[ countryCode ] ) &&
-		config.isEnabled( 'upgrades/ebanx' )
+		isEbanxEnabled( CartStore.get() )
 	);
 }
 
@@ -30,8 +31,8 @@ export function isEbanx( countryCode = '' ) {
  * The following test is a weak test only. Full algorithm here: http://www.geradorcpf.com/algoritmo_do_cpf.htm
  *
  * See: http://www.geradorcpf.com/algoritmo_do_cpf.htm
- * @param {string} cpf - a Brazilian tax identification number
- * @returns {bool} Whether the cpf is valid or not
+ * @param {String} cpf - a Brazilian tax identification number
+ * @returns {Boolean} Whether the cpf is valid or not
  */
 
 export function isValidCPF( cpf = '' ) {

--- a/client/lib/credit-card-details/test/ebanx.js
+++ b/client/lib/credit-card-details/test/ebanx.js
@@ -1,0 +1,49 @@
+/**
+ * @format
+ */
+
+/**
+ * External dependencies
+ */
+
+/**
+ * Internal dependencies
+ */
+import { isEbanx, isValidCPF } from '../ebanx';
+import { isEnabled } from 'config';
+
+jest.mock( 'config', () => {
+	const config = () => 'development';
+
+	config.isEnabled = jest.fn( false );
+
+	return config;
+} );
+
+describe( 'Ebanx payment processing methods', () => {
+	describe( 'isEbanx', () => {
+		beforeAll( () => {
+			isEnabled.mockReturnValue( true );
+		} );
+		afterAll( () => {
+			isEnabled.mockReturnValue( false );
+		} );
+
+		test( 'should return false for non-ebanx country', () => {
+			expect( isEbanx( 'AU' ) ).toEqual( false );
+		} );
+		test( 'should return true for ebanx country', () => {
+			expect( isEbanx( 'BR' ) ).toEqual( true );
+		} );
+	} );
+
+	describe( 'isValidCPF', () => {
+		test( 'should return true for valid CPF (Brazilian tax identification number)', () => {
+			expect( isValidCPF( '853.513.468-93' ) ).toEqual( true );
+		} );
+		test( 'should return false for invalid CPF', () => {
+			expect( isValidCPF( '85384484632' ) ).toEqual( false );
+			expect( isValidCPF( '853.844.846.32' ) ).toEqual( false );
+		} );
+	} );
+} );

--- a/client/lib/credit-card-details/test/ebanx.js
+++ b/client/lib/credit-card-details/test/ebanx.js
@@ -12,6 +12,9 @@
 import { isEbanx, isValidCPF } from '../ebanx';
 import { isEnabled } from 'config';
 
+jest.mock( 'lib/abtest', () => ( {
+	abtest: () => 'ebanx',
+} ) );
 jest.mock( 'config', () => {
 	const config = () => 'development';
 

--- a/client/lib/credit-card-details/test/ebanx.js
+++ b/client/lib/credit-card-details/test/ebanx.js
@@ -1,5 +1,6 @@
 /**
  * @format
+ * @jest-environment jsdom
  */
 
 /**
@@ -9,34 +10,31 @@
 /**
  * Internal dependencies
  */
-import { isEbanx, isValidCPF } from '../ebanx';
-import { isEnabled } from 'config';
+import { isEbanxEnabledForCountry, isValidCPF } from '../ebanx';
+import { isEbanxEnabled } from 'lib/cart-values';
 
-jest.mock( 'lib/abtest', () => ( {
-	abtest: () => 'ebanx',
-} ) );
-jest.mock( 'config', () => {
-	const config = () => 'development';
+jest.mock( 'lib/cart-values', () => {
+	const cartValues = {};
 
-	config.isEnabled = jest.fn( false );
+	cartValues.isEbanxEnabled = jest.fn( false );
 
-	return config;
+	return cartValues;
 } );
 
 describe( 'Ebanx payment processing methods', () => {
-	describe( 'isEbanx', () => {
+	describe( 'isEbanxEnabledForCountry', () => {
 		beforeAll( () => {
-			isEnabled.mockReturnValue( true );
+			isEbanxEnabled.mockReturnValue( true );
 		} );
 		afterAll( () => {
-			isEnabled.mockReturnValue( false );
+			isEbanxEnabled.mockReturnValue( false );
 		} );
 
 		test( 'should return false for non-ebanx country', () => {
-			expect( isEbanx( 'AU' ) ).toEqual( false );
+			expect( isEbanxEnabledForCountry( 'AU' ) ).toEqual( false );
 		} );
 		test( 'should return true for ebanx country', () => {
-			expect( isEbanx( 'BR' ) ).toEqual( true );
+			expect( isEbanxEnabledForCountry( 'BR' ) ).toEqual( true );
 		} );
 	} );
 

--- a/client/lib/credit-card-details/test/index.js
+++ b/client/lib/credit-card-details/test/index.js
@@ -1,4 +1,8 @@
-/** @format */
+/**
+ * @format
+ * @jest-environment jsdom
+ */
+
 /**
  * External dependencies
  */

--- a/client/lib/credit-card-details/test/index.js
+++ b/client/lib/credit-card-details/test/index.js
@@ -9,6 +9,10 @@ import assert from 'assert';
  */
 import { getCreditCardType } from '../';
 
+jest.mock( 'lib/abtest', () => ( {
+	abtest: () => '',
+} ) );
+
 function getRandomInt( min, max ) {
 	return Math.floor( Math.random() * ( max - min + 1 ) ) + min;
 }

--- a/client/lib/credit-card-details/test/validation.js
+++ b/client/lib/credit-card-details/test/validation.js
@@ -10,6 +10,14 @@ import moment from 'moment';
  * Internal dependencies
  */
 import { validateCardDetails } from '../validation';
+import { isEbanx, isValidCPF } from 'lib/credit-card-details/ebanx';
+
+jest.mock( 'lib/credit-card-details/ebanx', () => {
+	return {
+		isEbanx: jest.fn( false ),
+		isValidCPF: jest.fn( false ),
+	};
+} );
 
 describe( 'validation', () => {
 	const validCard = {
@@ -25,34 +33,168 @@ describe( 'validation', () => {
 		'postal-code': '90210',
 	};
 
+	const validBrazilianEbanxCard = {
+		name: 'Ana Santos Araujo',
+		number: '4111111111111111',
+		'expiration-date':
+			'01/' +
+			moment()
+				.add( 1, 'years' )
+				.format( 'YY' ),
+		cvv: '111',
+		country: 'BR',
+		'postal-code': '90210',
+		city: 'Maracanaú',
+		state: 'CE',
+		document: '853.513.468-93',
+		'phone-number': '+85 2284-7035',
+		'address-1': 'Rua E',
+		'street-number': '1040',
+	};
+
 	describe( '#validateCardDetails', () => {
 		test( 'should return no errors when card is valid', () => {
 			const result = validateCardDetails( validCard );
-
 			expect( result ).to.be.eql( { errors: {} } );
 		} );
 
-		test( 'should return error when card has expiration date in the past', () => {
-			const expiredCard = { ...validCard, 'expiration-date': '01/01' };
+		describe( 'validate credit card', () => {
+			test( 'should return error when card has expiration date in the past', () => {
+				const expiredCard = { ...validCard, 'expiration-date': '01/01' };
+				const result = validateCardDetails( expiredCard );
 
-			const result = validateCardDetails( expiredCard );
+				expect( result ).to.be.eql( {
+					errors: {
+						'expiration-date': [ 'Credit card expiration date is invalid' ],
+					},
+				} );
+			} );
 
-			expect( result ).to.be.eql( {
-				errors: {
-					'expiration-date': [ 'Credit card expiration date is invalid' ],
-				},
+			test( 'should return error when cvv is the wrong length', () => {
+				const invalidCVVCard = { ...validCard, cvv: '12345' };
+				const result = validateCardDetails( invalidCVVCard );
+
+				expect( result ).to.be.eql( {
+					errors: {
+						cvv: [ 'Credit card cvv code is invalid' ],
+					},
+				} );
 			} );
 		} );
 
-		test( 'should return error when cvv is the wrong length', () => {
-			const invalidCVVCard = { ...validCard, cvv: '12345' };
+		describe( 'validate basic non-credit card details', () => {
+			test( 'should return error when card holder name is missing', () => {
+				const invalidCardHolderName = { ...validCard, name: '' };
+				const result = validateCardDetails( invalidCardHolderName );
 
-			const result = validateCardDetails( invalidCVVCard );
+				expect( result ).to.be.eql( {
+					errors: {
+						name: [ 'Missing required Name on Card field' ],
+					},
+				} );
+			} );
 
-			expect( result ).to.be.eql( {
-				errors: {
-					cvv: [ 'Credit card cvv code is invalid' ],
-				},
+			test( 'should return error when Name on Card is missing', () => {
+				const invalidCardHolderName = { ...validCard, name: '' };
+				const result = validateCardDetails( invalidCardHolderName );
+
+				expect( result ).to.be.eql( {
+					errors: {
+						name: [ 'Missing required Name on Card field' ],
+					},
+				} );
+			} );
+
+			test( 'should return error when Postal Code is missing', () => {
+				const invalidCardPostCode = { ...validCard, 'postal-code': '' };
+				const result = validateCardDetails( invalidCardPostCode );
+
+				expect( result ).to.be.eql( {
+					errors: {
+						'postal-code': [ 'Missing required Postal Code field' ],
+					},
+				} );
+			} );
+		} );
+
+		describe( 'validate ebanx non-credit card details', () => {
+			beforeAll( () => {
+				isEbanx.mockReturnValue( true );
+				isValidCPF.mockReturnValue( true );
+			} );
+
+			test( 'should return no errors when details are valid', () => {
+				const result = validateCardDetails( validBrazilianEbanxCard );
+
+				expect( result ).to.be.eql( { errors: {} } );
+			} );
+
+			test( 'should return error when city is missing', () => {
+				const invalidCity = { ...validBrazilianEbanxCard, city: '' };
+				const result = validateCardDetails( invalidCity );
+
+				expect( result ).to.be.eql( {
+					errors: {
+						city: [ 'Missing required City field' ],
+					},
+				} );
+			} );
+
+			test( 'should return error when state is missing', () => {
+				const invalidState = { ...validBrazilianEbanxCard, state: '' };
+				const result = validateCardDetails( invalidState );
+
+				expect( result ).to.be.eql( {
+					errors: {
+						state: [ 'Missing required State field' ],
+					},
+				} );
+			} );
+
+			test( 'should return error when address-1 is missing', () => {
+				const invalidAddress = { ...validBrazilianEbanxCard, 'address-1': '' };
+				const result = validateCardDetails( invalidAddress );
+
+				expect( result ).to.be.eql( {
+					errors: {
+						'address-1': [ 'Missing required Address field' ],
+					},
+				} );
+			} );
+
+			test( 'should return error when street-number is missing', () => {
+				const invalidStNo = { ...validBrazilianEbanxCard, 'street-number': '' };
+				const result = validateCardDetails( invalidStNo );
+
+				expect( result ).to.be.eql( {
+					errors: {
+						'street-number': [ 'Missing required Street Number field' ],
+					},
+				} );
+			} );
+
+			test( 'should return error when phone number is missing', () => {
+				const invalidStPhNo = { ...validBrazilianEbanxCard, 'phone-number': '' };
+				const result = validateCardDetails( invalidStPhNo );
+
+				expect( result ).to.be.eql( {
+					errors: {
+						'phone-number': [ 'Missing required Phone Number field' ],
+					},
+				} );
+			} );
+
+			test( 'should return error when CPF is invalid', () => {
+				isValidCPF.mockReturnValue( false );
+				const invalidCPF = { ...validBrazilianEbanxCard, document: 'blah' };
+				const result = validateCardDetails( invalidCPF );
+				expect( result ).to.be.eql( {
+					errors: {
+						document: [
+							'Taxpayer Identification Number is invalid. Must be in format: 111.444.777-XX',
+						],
+					},
+				} );
 			} );
 		} );
 	} );

--- a/client/lib/credit-card-details/test/validation.js
+++ b/client/lib/credit-card-details/test/validation.js
@@ -10,11 +10,11 @@ import moment from 'moment';
  * Internal dependencies
  */
 import { validateCardDetails } from '../validation';
-import { isEbanx, isValidCPF } from 'lib/credit-card-details/ebanx';
+import { isEbanxEnabledForCountry, isValidCPF } from 'lib/credit-card-details/ebanx';
 
 jest.mock( 'lib/credit-card-details/ebanx', () => {
 	return {
-		isEbanx: jest.fn( false ),
+		isEbanxEnabledForCountry: jest.fn( false ),
 		isValidCPF: jest.fn( false ),
 	};
 } );
@@ -119,7 +119,7 @@ describe( 'validation', () => {
 
 		describe( 'validate ebanx non-credit card details', () => {
 			beforeAll( () => {
-				isEbanx.mockReturnValue( true );
+				isEbanxEnabledForCountry.mockReturnValue( true );
 				isValidCPF.mockReturnValue( true );
 			} );
 

--- a/client/lib/credit-card-details/validation.js
+++ b/client/lib/credit-card-details/validation.js
@@ -3,50 +3,100 @@
  * External dependencies
  */
 import creditcards from 'creditcards';
-import { capitalize, compact, inRange, isArray, isEmpty } from 'lodash';
+import capitalize from 'lodash/capitalize';
+import compact from 'lodash/compact';
+import inRange from 'lodash/inRange';
+import isArray from 'lodash/isArray';
+import isEmpty from 'lodash/isEmpty';
+import pick from 'lodash/pick';
 import i18n from 'i18n-calypso';
 
-function creditCardFieldRules() {
-	return {
-		name: {
-			description: i18n.translate( 'Name on Card', {
-				context: 'Upgrades: Card holder name label on credit card form',
-				textOnly: true,
-			} ),
-			rules: [ 'required' ],
-		},
+/**
+ * Internal dependencies
+ */
+import { isEbanx, isValidCPF } from 'lib/credit-card-details/ebanx';
+import { PAYMENT_PROCESSOR_EBANX_COUNTRIES } from './constants';
 
-		number: {
-			description: i18n.translate( 'Card Number', {
-				context: 'Upgrades: Card number label on credit card form',
-				textOnly: true,
-			} ),
-			rules: [ 'required', 'validCreditCardNumber' ],
-		},
+function ebanxFieldRules( country ) {
+	const requiredFields = PAYMENT_PROCESSOR_EBANX_COUNTRIES[ country ].requiredFields || [];
 
-		'expiration-date': {
-			description: i18n.translate( 'Credit Card Expiration Date' ),
-			rules: [ 'required', 'validExpirationDate' ],
-		},
+	return pick(
+		{
+			document: {
+				description: i18n.translate( 'Taxpayer Identification Number' ),
+				rules: [ 'validCPF' ],
+			},
 
-		cvv: {
-			description: i18n.translate( 'Credit Card CVV Code' ),
-			rules: [ 'required', 'validCvvNumber' ],
-		},
+			'street-number': {
+				description: i18n.translate( 'Street Number' ),
+				rules: [ 'required' ],
+			},
 
-		country: {
-			description: i18n.translate( 'Country' ),
-			rules: [ 'required' ],
-		},
+			'address-1': {
+				description: i18n.translate( 'Address' ),
+				rules: [ 'required' ],
+			},
 
-		'postal-code': {
-			description: i18n.translate( 'Postal Code', {
-				context: 'Upgrades: Postal code on credit card form',
-				textOnly: true,
-			} ),
-			rules: [ 'required' ],
+			state: {
+				description: i18n.translate( 'State' ),
+				rules: [ 'required' ],
+			},
+
+			city: {
+				description: i18n.translate( 'City' ),
+				rules: [ 'required' ],
+			},
+
+			'phone-number': {
+				description: i18n.translate( 'Phone Number' ),
+				rules: [ 'required' ],
+			},
 		},
-	};
+		requiredFields
+	);
+}
+
+function creditCardFieldRules( additionalFieldRules = {} ) {
+	return Object.assign(
+		{
+			name: {
+				description: i18n.translate( 'Name on Card', {
+					context: 'Upgrades: Card holder name label on credit card form',
+				} ),
+				rules: [ 'required' ],
+			},
+
+			number: {
+				description: i18n.translate( 'Card Number', {
+					context: 'Upgrades: Card number label on credit card form',
+				} ),
+				rules: [ 'validCreditCardNumber' ],
+			},
+
+			'expiration-date': {
+				description: i18n.translate( 'Credit Card Expiration Date' ),
+				rules: [ 'validExpirationDate' ],
+			},
+
+			cvv: {
+				description: i18n.translate( 'Credit Card CVV Code' ),
+				rules: [ 'validCvvNumber' ],
+			},
+
+			country: {
+				description: i18n.translate( 'Country' ),
+				rules: [ 'required' ],
+			},
+
+			'postal-code': {
+				description: i18n.translate( 'Postal Code', {
+					context: 'Upgrades: Postal code on credit card form',
+				} ),
+				rules: [ 'required' ],
+			},
+		},
+		additionalFieldRules
+	);
 }
 
 function parseExpiration( value ) {
@@ -113,8 +163,22 @@ validators.validExpirationDate = {
 	error: validationError,
 };
 
+validators.validCPF = {
+	isValid( value ) {
+		if ( ! value ) {
+			return false;
+		}
+		return isValidCPF( value );
+	},
+	error: function( description ) {
+		return i18n.translate( '%(description)s is invalid. Must be in format: 111.444.777-XX', {
+			args: { description: description },
+		} );
+	},
+};
+
 export function validateCardDetails( cardDetails ) {
-	const rules = creditCardFieldRules(),
+	const rules = creditCardFieldRules( getAdditionalFieldRules( cardDetails ) ),
 		errors = Object.keys( rules ).reduce( function( allErrors, fieldName ) {
 			const field = rules[ fieldName ],
 				newErrors = getErrors( field, cardDetails[ fieldName ], cardDetails );
@@ -173,6 +237,20 @@ function getErrors( field, value, cardDetails ) {
 			}
 		} )
 	);
+}
+
+/**
+ *
+ * @param {object} cardDetails - a map of credit card field key value pairs
+ * @returns {object|null} If match is found,
+ * an object containing rule sets for specific credit card processing providers,
+ * otherwise `null`
+ */
+function getAdditionalFieldRules( { country } ) {
+	if ( isEbanx( country ) ) {
+		return ebanxFieldRules( country );
+	}
+	return null;
 }
 
 function getValidator( rule ) {

--- a/client/lib/credit-card-details/validation.js
+++ b/client/lib/credit-card-details/validation.js
@@ -14,7 +14,7 @@ import i18n from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import { isEbanx, isValidCPF } from 'lib/credit-card-details/ebanx';
+import { isEbanxEnabledForCountry, isValidCPF } from 'lib/credit-card-details/ebanx';
 import { PAYMENT_PROCESSOR_EBANX_COUNTRIES } from './constants';
 
 function ebanxFieldRules( country ) {
@@ -247,7 +247,7 @@ function getErrors( field, value, cardDetails ) {
  * otherwise `null`
  */
 function getAdditionalFieldRules( { country } ) {
-	if ( isEbanx( country ) ) {
+	if ( isEbanxEnabledForCountry( country ) ) {
 		return ebanxFieldRules( country );
 	}
 	return null;

--- a/client/lib/store-transactions/index.js
+++ b/client/lib/store-transactions/index.js
@@ -290,7 +290,7 @@ function createEbanxToken( requestType, cardDetails, callback ) {
 
 	function createTokenCallback( ebanxResponse ) {
 		if ( ebanxResponse.data.hasOwnProperty( 'status' ) ) {
-			ebanxResponse.data.payment_method = 'WPCOM_Billing_Ebanx';
+			ebanxResponse.data.paymentMethod = 'WPCOM_Billing_Ebanx';
 			callback( null, ebanxResponse.data );
 		} else {
 			const errorMessage =

--- a/client/lib/store-transactions/index.js
+++ b/client/lib/store-transactions/index.js
@@ -278,7 +278,7 @@ function createEbanxToken( requestType, cardDetails, callback ) {
 		} else {
 			const errorMessage =
 				ebanxResponse.error.err.status_message || ebanxResponse.error.err.message;
-			callback( new Error( 'Ebanx Request Error: ' + errorMessage ) );
+			callback( new Error( 'Credit card Error: ' + errorMessage ) );
 		}
 	}
 }

--- a/client/lib/store-transactions/index.js
+++ b/client/lib/store-transactions/index.js
@@ -9,7 +9,6 @@ import debugFactory from 'debug';
 const debug = debugFactory( 'calypso:store-transactions' );
 import { Readable } from 'stream';
 import inherits from 'inherits';
-import config from 'config';
 
 /**
  * Internal dependencies
@@ -24,6 +23,7 @@ import {
 	SUBMITTING_WPCOM_REQUEST,
 } from './step-types';
 import wp from 'lib/wp';
+import { isEbanx } from 'lib/credit-card-details/ebanx';
 
 const wpcom = wp.undocumented();
 
@@ -245,6 +245,7 @@ function createPaygateToken( requestType, cardDetails, callback ) {
 }
 
 function createEbanxToken( requestType, cardDetails, callback ) {
+	debug( 'creating token with ebanx' );
 	wpcom.ebanxConfiguration(
 		{
 			request_type: requestType,

--- a/client/lib/store-transactions/index.js
+++ b/client/lib/store-transactions/index.js
@@ -23,7 +23,7 @@ import {
 	SUBMITTING_WPCOM_REQUEST,
 } from './step-types';
 import wp from 'lib/wp';
-import { isEbanx } from 'lib/credit-card-details/ebanx';
+import { isEbanxEnabledForCountry } from 'lib/credit-card-details/ebanx';
 
 const wpcom = wp.undocumented();
 
@@ -127,7 +127,7 @@ TransactionFlow.prototype._paymentHandlers = {
 
 		this._createCardToken(
 			function( gatewayData ) {
-				const { name, country, 'postal-code': zip, document, city, state } = newCardDetails;
+				const { name, country, 'postal-code': zip } = newCardDetails;
 
 				let paymentData = {
 					payment_method: gatewayData.paymentMethod,
@@ -137,15 +137,15 @@ TransactionFlow.prototype._paymentHandlers = {
 					country,
 				};
 
-				if ( isEbanx( country ) ) {
+				if ( isEbanxEnabledForCountry( country ) ) {
 					const ebanxPaymentData = {
-						state,
-						city,
+						state: newCardDetails.state,
+						city: newCardDetails.city,
 						address_1: newCardDetails[ 'address-1' ],
 						address_2: newCardDetails[ 'address-2' ],
 						street_number: newCardDetails[ 'street-number' ],
 						phone_number: newCardDetails[ 'phone-number' ],
-						document,
+						document: newCardDetails.document,
 					};
 
 					paymentData = { ...paymentData, ...ebanxPaymentData };
@@ -300,6 +300,7 @@ function createEbanxToken( requestType, cardDetails, callback ) {
 	}
 }
 
+
 function getPaygateParameters( cardDetails ) {
 	return {
 		name: cardDetails.name,
@@ -326,9 +327,9 @@ function getEbanxParameters( cardDetails ) {
 
 
 export function createCardToken( requestType, cardDetails, callback ) {
-	if ( isEbanx( cardDetails.country ) ) {
-		return createEbanxToken( requestType, cardDetails, callback );
-	}
+	if ( isEbanxEnabledForCountry( cardDetails.country ) ) {
+	return createEbanxToken( requestType, cardDetails, callback );
+}
 
 	return createPaygateToken( requestType, cardDetails, callback );
 }

--- a/client/lib/store-transactions/index.js
+++ b/client/lib/store-transactions/index.js
@@ -300,7 +300,6 @@ function createEbanxToken( requestType, cardDetails, callback ) {
 	}
 }
 
-
 function getPaygateParameters( cardDetails ) {
 	return {
 		name: cardDetails.name,
@@ -319,17 +318,16 @@ function getEbanxParameters( cardDetails ) {
 		card_number: cardDetails.number,
 		card_cvv: cardDetails.cvv,
 		card_due_date:
-		cardDetails[ 'expiration-date' ].substring( 0, 2 ) +
-		'/20' +
-		cardDetails[ 'expiration-date' ].substring( 3, 5 ),
+			cardDetails[ 'expiration-date' ].substring( 0, 2 ) +
+			'/20' +
+			cardDetails[ 'expiration-date' ].substring( 3, 5 ),
 	};
 }
 
-
 export function createCardToken( requestType, cardDetails, callback ) {
 	if ( isEbanxEnabledForCountry( cardDetails.country ) ) {
-	return createEbanxToken( requestType, cardDetails, callback );
-}
+		return createEbanxToken( requestType, cardDetails, callback );
+	}
 
 	return createPaygateToken( requestType, cardDetails, callback );
 }

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1226,11 +1226,28 @@ Undocumented.prototype.paygateConfiguration = function( query, fn ) {
 };
 
 /**
+ * GET ebanx js configuration
+ *
+ * @param {Object} query - query parameters
+ * @param {Function} fn The callback function
+ * @api public
+ *
+ * @returns {Promise} promise
+ */
+Undocumented.prototype.ebanxConfiguration = function( query, fn ) {
+	debug( '/me/ebanx-configuration query' );
+
+	return this.wpcom.req.get( '/me/ebanx-configuration', query, fn );
+};
+
+/**
  * GET paypal_express_url
  *
  * @param {object} [data] The GET data
  * @param {Function} fn The callback function
  * @api public
+ *
+ * @returns {string} Url
  *
  * The data format is: {
  *		country: {string} The billing country,

--- a/client/my-sites/checkout/checkout/credit-card-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/credit-card-payment-box.jsx
@@ -99,8 +99,13 @@ export class CreditCardPaymentBox extends React.Component {
 				}
 				return true;
 
-			case SUBMITTING_PAYMENT_KEY_REQUEST:
 			case RECEIVED_PAYMENT_KEY_RESPONSE:
+				if ( this.props.transactionStep.error ) {
+					return false;
+				}
+				return true;
+
+			case SUBMITTING_PAYMENT_KEY_REQUEST:
 			case SUBMITTING_WPCOM_REQUEST:
 				return true;
 

--- a/client/my-sites/checkout/checkout/pay-button.jsx
+++ b/client/my-sites/checkout/checkout/pay-button.jsx
@@ -40,8 +40,15 @@ class PayButton extends React.Component {
 				break;
 
 			case SUBMITTING_PAYMENT_KEY_REQUEST:
-			case RECEIVED_PAYMENT_KEY_RESPONSE:
 				state = this.sending();
+				break;
+
+			case RECEIVED_PAYMENT_KEY_RESPONSE:
+				if ( this.props.transactionStep.error ) {
+					state = this.beforeSubmit();
+				} else {
+					state = this.sending();
+				}
 				break;
 
 			case SUBMITTING_WPCOM_REQUEST:

--- a/client/my-sites/checkout/checkout/payment-box.jsx
+++ b/client/my-sites/checkout/checkout/payment-box.jsx
@@ -125,7 +125,6 @@ export class PaymentBox extends PureComponent {
 		if ( ! this.props.paymentMethods ) {
 			return null;
 		}
-
 		return this.props.paymentMethods.map( method => {
 			return this.paymentMethod( method );
 		} );

--- a/client/my-sites/checkout/checkout/style.scss
+++ b/client/my-sites/checkout/checkout/style.scss
@@ -350,7 +350,7 @@
 		}
 
 		.payment-box-section.selected .new-card-fields {
-			max-height: 500px;
+			max-height: 100%;
 			margin-bottom: 0;
 			padding-top: 15px;
 		}

--- a/config/development.json
+++ b/config/development.json
@@ -172,6 +172,7 @@
 		"ui/first-view/reset-route": true,
 		"upgrades/checkout": true,
 		"upgrades/credit-cards": true,
+		"upgrades/ebanx": true,
 		"upgrades/domain-search": true,
 		"upgrades/in-app-purchase": false,
 		"upgrades/netherlands-ideal": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -139,6 +139,7 @@
 		"upgrades/checkout": true,
 		"upgrades/credit-cards": true,
 		"upgrades/domain-search": true,
+		"upgrades/ebanx": true,
 		"upgrades/in-app-purchase": false,
 		"upgrades/paypal": true,
 		"upgrades/netherlands-ideal": true,


### PR DESCRIPTION
Processing CCs with Ebanx

## What's included
- During checkout, the CC token will be created directly using EBANX if the country is Brazil, and the payment method is enabled in the backend. Paygate (as usual) will be used in all other cases.

When EBANX is enabled, the customer will be asked for additional data in the CC form:
<img width="687" alt="screen shot 2018-01-08 at 10 45 53" src="https://user-images.githubusercontent.com/844866/34663788-3678b93a-f461-11e7-98a3-93d92a556af6.png">


## Not taken care of yet
- Adding a card in `me/purchases/add-credit-card`. All cards added there will use Paygate (low usage overall, I'm not very concerned)
- Updating a card for a purchase, after that purchase was done with ebanx (disabled via #20893)
- New credit card types supported by Ebanx

## Testing
- Use Brazil as the CC country during checkout. CC will be saved with Ebanx. 
- Visit the following likes for test details: [cc numbers](https://developers.ebanx.com/integrations/testing/credit-card-test-numbers/), [personal data](https://developers.ebanx.com/integrations/testing/fake-customer-data/fake-brazilian-customer-data/).




  