### PR TITLE
Build: move prop-types and create-react-class to vendor chunk

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -176,6 +176,8 @@ if ( calypsoEnv === 'desktop' ) {
 		'moment',
 		'page',
 		'react',
+		'create-react-class',
+		'prop-types',
 		'react-dom',
 		'react-redux',
 		'redux',


### PR DESCRIPTION
The `vendor` chunk already contains the `react` module, and `prop-types` and `create-react-class` are nothing but spinoffs from the `react` module. Having them in `vendor` makes all the other chunks smaller.

With React 15, `vendor` will contain duplicate definitions of these modules: one in `react` the other
one in the spinoff module. After upgrade to React 16, the `react` module will no longer contain this
code -- it's solely in the spinoffs.

Here are the deltas for gzipped size that iscalypsofastyet.com reports for this PR (`-1234` means that the chunk's gzipped size decreates by 1234 bytes):
```
accept-invite: -1699
async-load-layout-masterbar-drafts: -1641
async-load-my-sites-stats-activity-log: -1571
async-load-my-sites-stats-comment-follows: -1609
async-load-my-sites-stats-overview: -1590
async-load-my-sites-stats-site: -1546
async-load-my-sites-stats-stats-insights: -1576
async-load-my-sites-stats-summary: -1574
build: -312
checkout: -1784
devdocs: -1907
domain-connect-authorize: -1689
domains: -1578
happychat: -1673
hello-dolly: -1713
help: -1684
jetpack-connect: -1708
manifest: -1
me: -1676
notification-settings: -1695
people: -1683
plans: -1666
plugins: -1688
post-editor: -1575
posts-custom: -1638
posts-pages: -1624
purchases: -1734
reader: -1680
security: -1700
sensei: -1730
settings: -1737
settings-discussion: -1699
settings-security: -1702
settings-traffic: -1671
settings-writing: -1693
sharing: -1708
signup: -1626
theme: -1684
themes: -1677
vendor: 1926
woocommerce: -1509
wp-job-manager: -1687
wp-super-cache: -1728
zoninator: -1736
account: -1550
```