### PR TITLE
Reader: Fix inconsistent line height Safari/Chrome

### DIFF
--- a/client/blocks/comments/style.scss
+++ b/client/blocks/comments/style.scss
@@ -330,10 +330,6 @@
 	}
 }
 
-.comments__comment-content-wrapper.is-excerpt ~ .comments__comment-actions {
-	margin-top: -6px;
-}
-
 .comments__comment-content-wrapper.is-excerpt .comments__comment-content p {
 	margin-bottom: 0;
 }
@@ -415,6 +411,7 @@ a.comments__comment-username {
 	color: $gray;
 	font-size: 14px;
 	list-style: none;
+	margin-top: -6px;
 
 	button {
 		display: inline-block;

--- a/client/blocks/comments/style.scss
+++ b/client/blocks/comments/style.scss
@@ -312,7 +312,6 @@
 
 // Post comments line-clamping
 .comments__comment-content-wrapper {
-	display: inline-block;
 	position: relative;
 
 	&.is-single-line,
@@ -332,11 +331,7 @@
 }
 
 .comments__comment-content-wrapper.is-excerpt ~ .comments__comment-actions {
-	margin-top: -10px;
-}
-
-.comments__comment-content-wrapper.is-full ~ .comments__comment-actions {
-	margin-top: -5px;
+	margin-top: -6px;
 }
 
 .comments__comment-content-wrapper.is-excerpt .comments__comment-content p {
@@ -417,15 +412,16 @@ a.comments__comment-username {
 
 // Actions for Individual Comments
 .comments__comment-actions {
-	list-style: none;
 	color: $gray;
 	font-size: 14px;
+	list-style: none;
 
 	button {
 		display: inline-block;
 		color: $gray;
 		padding: 4px;
 		margin-right: 8px;
+		margin-top: 0;
 		cursor: pointer;
 		font-size: 14px;
 


### PR DESCRIPTION
This PR fixes: https://github.com/Automattic/wp-calypso/issues/18144

Took me a while to figure it out, but apparently, Safari adds a top margin to `button` tags by default. Alignment now fixed:

Single line:
![screenshot 2017-09-26 14 19 41](https://user-images.githubusercontent.com/4924246/30885151-150eaae8-a2c7-11e7-8558-74b7e2e69157.png)

Multi-line:
![screenshot 2017-09-26 14 21 42](https://user-images.githubusercontent.com/4924246/30885158-1b57b3d6-a2c7-11e7-85a5-bf63866d9dae.png)

With "Read more":
![screenshot 2017-09-26 14 19 47](https://user-images.githubusercontent.com/4924246/30885139-0934cab8-a2c7-11e7-92d5-97be4abb7347.png)

Made sure the alignment fix has also been applied to My Sites > Blog Posts > Comments:
![screenshot 2017-09-26 14 34 05](https://user-images.githubusercontent.com/4924246/30885386-ea3ca454-a2c7-11e7-92a2-ff38f218a2eb.png)

And fullpost:
![screenshot 2017-09-26 14 36 14](https://user-images.githubusercontent.com/4924246/30885425-135b950c-a2c8-11e7-8de7-c834637682f6.png)

