### PR TITLE
PostEditor/MediaModal: refactor confusing switch cases

### DIFF
--- a/client/post-editor/media-modal/index.jsx
+++ b/client/post-editor/media-modal/index.jsx
@@ -7,17 +7,18 @@ import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
 import {
 	findIndex,
-	head,
-	noop,
-	map,
 	flow,
-	partial,
-	some,
-	values,
+	get,
+	head,
 	isEmpty,
 	identity,
 	includes,
+	map,
+	noop,
+	partial,
+	some,
 	uniqueId,
+	values,
 } from 'lodash';
 
 /**
@@ -514,38 +515,43 @@ export class EditorMediaModal extends Component {
 				);
 				break;
 
-			case ModalViews.IMAGE_EDITOR:
-			case ModalViews.VIDEO_EDITOR:
+			case ModalViews.IMAGE_EDITOR: {
 				const {
 					site,
 					imageEditorProps,
 					mediaLibrarySelectedItems: items
 				} = this.props;
-
 				const selectedIndex = this.getDetailSelectedIndex();
-				const media = items ? items[ selectedIndex ] : null;
+				const media = get( items, selectedIndex, null );
 
-				if ( ModalViews.IMAGE_EDITOR === this.props.view ) {
-					content = (
-						<ImageEditor
-							siteId={ site && site.ID }
-							media={ media }
-							onDone={ this.onImageEditorDone }
-							onCancel={ this.onImageEditorCancel }
-							{ ...imageEditorProps }
-						/>
-					);
-				} else {
-					content = (
-						<VideoEditor
-							media={ media }
-							onCancel={ this.handleCancel }
-							onUpdatePoster={ this.handleUpdatePoster }
-						/>
-					);
-				}
+				content = (
+					<ImageEditor
+						siteId={ get( site, 'ID' ) }
+						media={ media }
+						onDone={ this.onImageEditorDone }
+						onCancel={ this.onImageEditorCancel }
+						{ ...imageEditorProps }
+					/>
+				);
 
 				break;
+			}
+
+			case ModalViews.VIDEO_EDITOR: {
+				const { mediaLibrarySelectedItems: items } = this.props;
+				const selectedIndex = this.getDetailSelectedIndex();
+				const media = get( items, selectedIndex, null );
+
+				content = (
+					<VideoEditor
+						media={ media }
+						onCancel={ this.handleCancel }
+						onUpdatePoster={ this.handleUpdatePoster }
+					/>
+				);
+
+				break;
+			}
 
 			default:
 				content = (


### PR DESCRIPTION
I came across this switch statement while trying to build up some context around a 🐞 that I'm trying to 👞 and found it a little bit confusing.

My main issue is that we have a conditional within the case that should already be answered, and so should be redundant - this, at least to me, breaks the normal flow of reading...

My changes add a little bit of duplicated boilerplate in that some of the same variables are repeated in each of the separated cases but I would argue that this repetition is a welcome trade-off for being more straight-forward to read.

I get the feeling that this fall-through was written to avoid the issue seen below:
<img width="777" alt="screen shot 2017-09-26 at 23 35 44" src="https://user-images.githubusercontent.com/4335450/30887915-89278bf4-a315-11e7-990d-c55c367fcde3.png">
Where declarations with the same names will clash. This is due to switch/case statements sharing lexical scope by default and is easily fixed by wrapping the case bodies in `{}`s and creating new lexical scopes.
(As an aside, I'd argue that all switch cases that declare anything for 'local' use should be wrapped anyway)

### Testing
- Go to a new or existing blog post
- Open the media modal
- Select an image
- Click 'edit'
- Click 'edit image'
- Make sure that this view loads without issue and behaves as before
- Repeat the process for a video
