### PR TITLE
Reader: Add redirects for tags and searches when logged out

### DIFF
--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -377,6 +377,24 @@ module.exports = function() {
 			}
 		} );
 
+		// redirect tag pages to en.wordpress.com
+		app.get( '/tag/:tag_slug', function( req, res, next ) {
+			if ( ! req.cookies.wordpress_logged_in ) {
+				res.redirect( 'https://en.wordpress.com/tag/' + req.params.tag_slug );
+			} else {
+				next();
+			}
+		} );
+
+		// redirect tag pages to en.wordpress.com
+		app.get( '/read/search', function( req, res, next ) {
+			if ( ! req.cookies.wordpress_logged_in ) {
+				res.redirect( 'https://en.search.wordpress.com/?q=' + req.query.q );
+			} else {
+				next();
+			}
+		} );
+
 		app.get( '/plans', function( req, res, next ) {
 			if ( ! req.cookies.wordpress_logged_in ) {
 				const queryFor = req.query && req.query.for;

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -405,7 +405,7 @@ module.exports = function() {
 			}
 		} );
 
-		// redirect tag pages to en.wordpress.com
+		// redirect logged-out tag pages to en.wordpress.com
 		app.get( '/tag/:tag_slug', function( req, res, next ) {
 			if ( ! req.cookies.wordpress_logged_in ) {
 				res.redirect( 'https://en.wordpress.com/tag/' + encodeURIComponent( req.params.tag_slug ) );
@@ -414,7 +414,7 @@ module.exports = function() {
 			}
 		} );
 
-		// redirect tag pages to en.wordpress.com
+		// redirect logged-out searches to en.search.wordpress.com
 		app.get( '/read/search', function( req, res, next ) {
 			if ( ! req.cookies.wordpress_logged_in ) {
 				res.redirect( 'https://en.search.wordpress.com/?q=' + encodeURIComponent( req.query.q ) );

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -33,20 +34,16 @@ const staticFiles = [
 	{ path: 'editor.css' },
 	{ path: 'tinymce/skins/wordpress/wp-content.css' },
 	{ path: 'style-debug.css' },
-	{ path: 'style-rtl.css' }
+	{ path: 'style-rtl.css' },
 ];
 
 // List of browser languages to show pride styling for.
 // Add a '*' element to show the styling for all visitors.
-const prideLanguages = [
-	'en-au',
-];
+const prideLanguages = [ 'en-au' ];
 
 // List of geolocated locations to show pride styling for.
 // Geolocation may not be 100% accurate.
-const prideLocations = [
-	'au',
-];
+const prideLocations = [ 'au' ];
 
 const sections = sectionsModule.get();
 
@@ -88,7 +85,9 @@ function generateStaticUrls( request ) {
 
 function getCurrentBranchName() {
 	try {
-		return execSync( 'git rev-parse --abbrev-ref HEAD' ).toString().replace( /\s/gm, '' );
+		return execSync( 'git rev-parse --abbrev-ref HEAD' )
+			.toString()
+			.replace( /\s/gm, '' );
 	} catch ( err ) {
 		return undefined;
 	}
@@ -96,7 +95,9 @@ function getCurrentBranchName() {
 
 function getCurrentCommitShortChecksum() {
 	try {
-		return execSync( 'git rev-parse --short HEAD' ).toString().replace( /\s/gm, '' );
+		return execSync( 'git rev-parse --short HEAD' )
+			.toString()
+			.replace( /\s/gm, '' );
 	} catch ( err ) {
 		return undefined;
 	}
@@ -116,14 +117,17 @@ function getAcceptedLanguagesFromHeader( header ) {
 		return [];
 	}
 
-	return header.split( ',' ).map( lang => {
-		const match = lang.match( /^[A-Z]{2,3}(-[A-Z]{2,3})?/i );
-		if ( ! match ) {
-			return false;
-		}
+	return header
+		.split( ',' )
+		.map( lang => {
+			const match = lang.match( /^[A-Z]{2,3}(-[A-Z]{2,3})?/i );
+			if ( ! match ) {
+				return false;
+			}
 
-		return match[ 0 ].toLowerCase();
-	} ).filter( lang => lang );
+			return match[ 0 ].toLowerCase();
+		} )
+		.filter( lang => lang );
 }
 
 function getDefaultContext( request ) {
@@ -135,17 +139,19 @@ function getDefaultContext( request ) {
 	let sectionCss, sectionCssRtl;
 
 	if ( cacheKey ) {
-		const serializeCachedServerState = stateCache.get( cacheKey ) || {};
+		const serializeCachedServerState = stateCache.get( cacheKey ) || {};
 		initialServerState = getInitialServerState( serializeCachedServerState );
 	}
 
 	// Note: The x-geoip-country-code header should *not* be considered 100% accurate.
 	// It should only be used for guestimating the visitor's location.
 	const acceptedLanguages = getAcceptedLanguagesFromHeader( request.headers[ 'accept-language' ] );
-	if ( prideLanguages.indexOf( '*' ) > -1 ||
+	if (
+		prideLanguages.indexOf( '*' ) > -1 ||
 		intersection( prideLanguages, acceptedLanguages ).length > 0 ||
 		prideLocations.indexOf( '*' ) > -1 ||
-		prideLocations.indexOf( geoLocation ) > -1 ) {
+		prideLocations.indexOf( geoLocation ) > -1
+	) {
 		bodyClasses.push( 'pride' );
 	}
 
@@ -181,7 +187,7 @@ function getDefaultContext( request ) {
 		clientIp: request.ip ? request.ip.replace( '::ffff:', '' ) : request.ip,
 		isDebug: context.env === 'development' || context.isDebug,
 		tinymceWpSkin: context.urls[ 'tinymce/skins/wordpress/wp-content.css' ],
-		tinymceEditorCss: context.urls[ 'editor.css' ]
+		tinymceEditorCss: context.urls[ 'editor.css' ],
 	};
 
 	if ( calypsoEnv === 'wpcalypso' ) {
@@ -218,7 +224,7 @@ function getDefaultContext( request ) {
 function setUpLoggedOutRoute( req, res, next ) {
 	req.context = getDefaultContext( req );
 	res.set( {
-		'X-Frame-Options': 'SAMEORIGIN'
+		'X-Frame-Options': 'SAMEORIGIN',
 	} );
 
 	next();
@@ -228,7 +234,7 @@ function setUpLoggedInRoute( req, res, next ) {
 	let redirectUrl, protocol, start;
 
 	res.set( {
-		'X-Frame-Options': 'SAMEORIGIN'
+		'X-Frame-Options': 'SAMEORIGIN',
 	} );
 
 	const context = getDefaultContext( req );
@@ -240,7 +246,7 @@ function setUpLoggedInRoute( req, res, next ) {
 
 		redirectUrl = login( {
 			isNative: config.isEnabled( 'login/native-login-links' ),
-			redirectTo: protocol + '://' + config( 'hostname' ) + req.originalUrl
+			redirectTo: protocol + '://' + config( 'hostname' ) + req.originalUrl,
 		} );
 
 		// if we don't have a wordpress cookie, we know the user needs to
@@ -259,7 +265,11 @@ function setUpLoggedInRoute( req, res, next ) {
 			if ( error ) {
 				if ( error.error === 'authorization_required' ) {
 					debug( 'User public API authorization required. Redirecting to %s', redirectUrl );
-					res.clearCookie( 'wordpress_logged_in', { path: '/', httpOnly: true, domain: '.wordpress.com' } );
+					res.clearCookie( 'wordpress_logged_in', {
+						path: '/',
+						httpOnly: true,
+						domain: '.wordpress.com',
+					} );
 					res.redirect( redirectUrl );
 				} else {
 					if ( error.error ) {
@@ -276,7 +286,7 @@ function setUpLoggedInRoute( req, res, next ) {
 				return;
 			}
 
-			const end = ( new Date().getTime() ) - start;
+			const end = new Date().getTime() - start;
 
 			debug( 'Rendering with bootstrapped user object. Fetched in %d ms', end );
 			context.user = data;
@@ -293,7 +303,12 @@ function setUpLoggedInRoute( req, res, next ) {
 			if ( req.path === '/' && req.query ) {
 				searchParam = req.query.s || req.query.q;
 				if ( searchParam ) {
-					res.redirect( 'https://' + context.lang + '.search.wordpress.com/?q=' + encodeURIComponent( searchParam ) );
+					res.redirect(
+						'https://' +
+							context.lang +
+							'.search.wordpress.com/?q=' +
+							encodeURIComponent( searchParam )
+					);
 					return;
 				}
 
@@ -330,7 +345,7 @@ function setUpRoute( req, res, next ) {
 
 function render404( request, response ) {
 	response.status( 404 ).render( '404.jade', {
-		urls: generateStaticUrls( request )
+		urls: generateStaticUrls( request ),
 	} );
 }
 
@@ -353,7 +368,14 @@ module.exports = function() {
 
 	// redirects to handle old newdash formats
 	app.use( '/sites/:site/:section', function( req, res, next ) {
-		const redirectedSections = [ 'posts', 'pages', 'sharing', 'upgrade', 'checkout', 'change-theme' ];
+		const redirectedSections = [
+			'posts',
+			'pages',
+			'sharing',
+			'upgrade',
+			'checkout',
+			'change-theme',
+		];
 		let redirectUrl;
 
 		if ( -1 === redirectedSections.indexOf( req.params.section ) ) {
@@ -361,9 +383,15 @@ module.exports = function() {
 			return;
 		}
 		if ( 'change-theme' === req.params.section ) {
-			redirectUrl = req.originalUrl.replace( /^\/sites\/[0-9a-zA-Z\-\.]+\/change\-theme/, '/themes' );
+			redirectUrl = req.originalUrl.replace(
+				/^\/sites\/[0-9a-zA-Z\-\.]+\/change\-theme/,
+				'/themes'
+			);
 		} else {
-			redirectUrl = req.originalUrl.replace( /^\/sites\/[0-9a-zA-Z\-\.]+\/\w+/, '/' + req.params.section + '/' + req.params.site );
+			redirectUrl = req.originalUrl.replace(
+				/^\/sites\/[0-9a-zA-Z\-\.]+\/\w+/,
+				'/' + req.params.section + '/' + req.params.site
+			);
 		}
 		res.redirect( redirectUrl );
 	} );
@@ -380,7 +408,7 @@ module.exports = function() {
 		// redirect tag pages to en.wordpress.com
 		app.get( '/tag/:tag_slug', function( req, res, next ) {
 			if ( ! req.cookies.wordpress_logged_in ) {
-				res.redirect( 'https://en.wordpress.com/tag/' + req.params.tag_slug );
+				res.redirect( 'https://en.wordpress.com/tag/' + encodeURIComponent( req.params.tag_slug ) );
 			} else {
 				next();
 			}
@@ -389,7 +417,7 @@ module.exports = function() {
 		// redirect tag pages to en.wordpress.com
 		app.get( '/read/search', function( req, res, next ) {
 			if ( ! req.cookies.wordpress_logged_in ) {
-				res.redirect( 'https://en.search.wordpress.com/?q=' + req.query.q );
+				res.redirect( 'https://en.search.wordpress.com/?q=' + encodeURIComponent( req.query.q ) );
 			} else {
 				next();
 			}
@@ -399,7 +427,9 @@ module.exports = function() {
 			if ( ! req.cookies.wordpress_logged_in ) {
 				const queryFor = req.query && req.query.for;
 				if ( queryFor && 'jetpack' === queryFor ) {
-					res.redirect( 'https://wordpress.com/wp-login.php?redirect_to=https%3A%2F%2Fwordpress.com%2Fplans' );
+					res.redirect(
+						'https://wordpress.com/wp-login.php?redirect_to=https%3A%2F%2Fwordpress.com%2Fplans'
+					);
 				} else {
 					res.redirect( 'https://wordpress.com/pricing' );
 				}
@@ -411,7 +441,7 @@ module.exports = function() {
 
 	// Redirect legacy `/menus` routes to the corresponding Customizer panel
 	// TODO: Move to `my-sites/customize` route defs once that section is isomorphic
-	app.get( [ '/menus', '/menus/:site?' ], ( req, res ) => {
+	app.get( [ '/menus', '/menus/:site?' ], ( req, res ) => {
 		const siteSlug = get( req.params, 'site', '' );
 		const newRoute = '/customize/menus/' + siteSlug;
 		res.redirect( 301, newRoute );
@@ -446,7 +476,11 @@ module.exports = function() {
 				} );
 
 				if ( ! section.isomorphic ) {
-					app.get( pathRegex, section.enableLoggedOut ? setUpRoute : setUpLoggedInRoute, serverRender );
+					app.get(
+						pathRegex,
+						section.enableLoggedOut ? setUpRoute : setUpLoggedInRoute,
+						serverRender
+					);
 				}
 			} );
 


### PR DESCRIPTION
This adds a redirect to the en.wordpress.com variant of tag and search pages for logged out users. Instead of trying to force them to log in to see the content, we'll send them someplace that doesn't require a login. This helps folks who share searches or tag streams with others to have a successful experience.

Testing this is a bit of a bear as it only works in `!development` environments. The easiest thing to do is to do a docker build and spin up docker pretending to be wpcalypso.wordpress.com.

```
docker build -t wp-calypso .
docker run -it --name wp-calypso --rm -p 80:3000 -e NODE_ENV='production' -e CALYPSO_ENV='wpcalypso' wp-calypso
```

Once you have that spun up and have a `/etc/hosts` entry for wpcalypso, try:

```
# should redirect to https://en.wordpress.com/tag/a8cgm
curl -I http://wpcalypso.wordpress.com/tag/a8cgm

# should redirect to https://en.search.wordpress.com/?q=foo
curl -I http://wpcalypso.wordpress.com/read/search?q=foo
```