### PR TITLE
Plugins: Spacing fix around plugin remove button label

### DIFF
--- a/client/my-sites/plugins/plugin-remove-button/style.scss
+++ b/client/my-sites/plugins/plugin-remove-button/style.scss
@@ -13,6 +13,10 @@
 	padding: 16px;
 }
 
+.plugin-remove-button__remove-link .plugin-action__label {
+	margin-left: 12px;
+}
+
 .plugin-remove-button__remove-icon {
 	display: block;
 	margin: -2px 3px 0;


### PR DESCRIPTION
This PR intends to fix the bug introduced in #18092.

**Before:**
<img width="743" alt="screen shot 2017-09-27 at 00 48 25" src="https://user-images.githubusercontent.com/908665/30889532-e05e557a-a31e-11e7-96e4-98cace4218c1.png">

**After:**
<img width="758" alt="screen shot 2017-09-27 at 00 48 41" src="https://user-images.githubusercontent.com/908665/30889536-eaa9246a-a31e-11e7-9283-d40d087f933a.png">
