### PR TITLE
Comments: Rework getPostCommentsTree to be faster

### DIFF
--- a/client/state/comments/test/__snapshots__/selectors.js.snap
+++ b/client/state/comments/test/__snapshots__/selectors.js.snap
@@ -1,0 +1,127 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`selectors #getPostCommentsTree should return the tree structure 1`] = `
+Object {
+  "1": Object {
+    "children": Array [
+      3,
+    ],
+    "data": Object {
+      "ID": 1,
+      "date": "2016-01-31T10:07:18-08:00",
+      "i_like": true,
+      "like_count": 5,
+      "parent": false,
+    },
+  },
+  "2": Object {
+    "children": Array [
+      4,
+    ],
+    "data": Object {
+      "ID": 2,
+      "date": "2016-01-29T10:07:18-08:00",
+      "i_like": false,
+      "like_count": 456,
+      "parent": false,
+    },
+  },
+  "3": Object {
+    "children": Array [],
+    "data": Object {
+      "ID": 3,
+      "date": "2017-01-31T10:07:18-08:00",
+      "i_like": false,
+      "like_count": 0,
+      "parent": Object {
+        "ID": 1,
+      },
+    },
+  },
+  "4": Object {
+    "children": Array [],
+    "data": Object {
+      "ID": 4,
+      "date": "2015-01-29T10:07:18-08:00",
+      "i_like": false,
+      "like_count": 0,
+      "parent": Object {
+        "ID": 2,
+      },
+    },
+  },
+  "children": Array [
+    2,
+    1,
+  ],
+}
+`;
+
+exports[`selectors #getPostCommentsTree should reverse children 1`] = `
+Object {
+  "1": Object {
+    "children": Array [
+      2,
+      3,
+      4,
+    ],
+    "data": Object {
+      "ID": 1,
+      "date": "2017-01-31T00:00:01Z",
+      "i_like": false,
+      "like_count": 0,
+      "parent": false,
+    },
+  },
+  "2": Object {
+    "children": Array [],
+    "data": Object {
+      "ID": 2,
+      "date": "2017-01-31T00:00:02Z",
+      "i_like": false,
+      "like_count": 0,
+      "parent": Object {
+        "ID": 1,
+      },
+    },
+  },
+  "3": Object {
+    "children": Array [],
+    "data": Object {
+      "ID": 3,
+      "date": "2017-01-31T00:00:03Z",
+      "i_like": false,
+      "like_count": 0,
+      "parent": Object {
+        "ID": 1,
+      },
+    },
+  },
+  "4": Object {
+    "children": Array [],
+    "data": Object {
+      "ID": 4,
+      "date": "2017-01-31T00:00:04Z",
+      "i_like": false,
+      "like_count": 0,
+      "parent": Object {
+        "ID": 1,
+      },
+    },
+  },
+  "50": Object {
+    "children": Array [],
+    "data": Object {
+      "ID": 50,
+      "date": "2017-01-30T00:00:00Z",
+      "i_like": false,
+      "like_count": 0,
+      "parent": false,
+    },
+  },
+  "children": Array [
+    50,
+    1,
+  ],
+}
+`;

--- a/client/state/comments/test/selectors.js
+++ b/client/state/comments/test/selectors.js
@@ -2,11 +2,6 @@
 /**
  * External dependencies
  */
-import { expect as chaiExpect } from 'chai';
-
-/***
- * Internal dependencies
- */
 import {
 	getPostOldestCommentDate,
 	getPostMostRecentCommentDate,
@@ -88,7 +83,7 @@ describe( 'selectors', () => {
 		it( 'should get most recent date', () => {
 			const res = getPostMostRecentCommentDate( state, 1, 1 );
 
-			chaiExpect( res ).to.be.eql( new Date( '2017-01-31T10:07:18-08:00' ) );
+			expect( res ).toEqual( new Date( '2017-01-31T10:07:18-08:00' ) );
 		} );
 
 		it( 'should return undefined if no comment items', () => {
@@ -100,7 +95,7 @@ describe( 'selectors', () => {
 				1
 			);
 
-			chaiExpect( res ).to.be.eql( undefined );
+			expect( res ).toEqual( undefined );
 		} );
 	} ); // end of getPostMostRecentCommentDate
 
@@ -108,7 +103,7 @@ describe( 'selectors', () => {
 		it( 'should get earliest date', () => {
 			const res = getPostOldestCommentDate( state, 1, 1 );
 
-			chaiExpect( res ).to.be.eql( new Date( '2015-01-29T10:07:18-08:00' ) );
+			expect( res ).toEqual( new Date( '2015-01-29T10:07:18-08:00' ) );
 		} );
 
 		it( 'should return undefined if no comment items', () => {
@@ -120,7 +115,7 @@ describe( 'selectors', () => {
 				1
 			);
 
-			chaiExpect( res ).to.be.eql( undefined );
+			expect( res ).toEqual( undefined );
 		} );
 	} ); // end of getPostOldestCommentDate
 
@@ -128,8 +123,8 @@ describe( 'selectors', () => {
 		it( 'should provide only like statistics', () => {
 			const res = getCommentLike( state, 1, 1, 2 );
 
-			chaiExpect( res.i_like ).to.eql( false );
-			chaiExpect( res.like_count ).to.eql( 456 );
+			expect( res.i_like ).toEqual( false );
+			expect( res.like_count ).toEqual( 456 );
 		} );
 	} );
 

--- a/client/state/comments/test/selectors.js
+++ b/client/state/comments/test/selectors.js
@@ -11,6 +11,7 @@ import {
 	getPostOldestCommentDate,
 	getPostMostRecentCommentDate,
 	getCommentLike,
+	getPostCommentsTree,
 } from '../selectors';
 
 const state = {
@@ -85,6 +86,59 @@ describe( 'selectors', () => {
 
 			expect( res.i_like ).to.eql( false );
 			expect( res.like_count ).to.eql( 456 );
+		} );
+	} );
+
+	describe( '#getPostCommentsTree', () => {
+		it( 'should return the tree structure', () => {
+			const tree = getPostCommentsTree( state, 1, 1, 'all' );
+			expect( tree ).to.eql( {
+				1: {
+					children: [ 3 ],
+					data: {
+						ID: 1,
+						date: '2016-01-31T10:07:18-08:00',
+						i_like: true,
+						like_count: 5,
+						parent: false,
+					},
+				},
+				2: {
+					children: [ 4 ],
+					data: {
+						ID: 2,
+						date: '2016-01-29T10:07:18-08:00',
+						i_like: false,
+						like_count: 456,
+						parent: false,
+					},
+				},
+				3: {
+					children: [],
+					data: {
+						ID: 3,
+						date: '2017-01-31T10:07:18-08:00',
+						i_like: false,
+						like_count: 0,
+						parent: {
+							ID: 1,
+						},
+					},
+				},
+				4: {
+					children: [],
+					data: {
+						ID: 4,
+						date: '2015-01-29T10:07:18-08:00',
+						i_like: false,
+						like_count: 0,
+						parent: {
+							ID: 2,
+						},
+					},
+				},
+				children: [ 2, 1 ],
+			} );
 		} );
 	} );
 } );

--- a/client/state/comments/test/selectors.js
+++ b/client/state/comments/test/selectors.js
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import { expect } from 'chai';
+import { expect as chaiExpect } from 'chai';
 
 /***
  * Internal dependencies
@@ -39,12 +39,56 @@ const state = {
 	},
 };
 
+const stateWithDeeperChildren = {
+	comments: {
+		items: {
+			'1-1': [
+				{
+					ID: 4,
+					parent: { ID: 1 },
+					date: '2017-01-31T00:00:04Z',
+					i_like: false,
+					like_count: 0,
+				},
+				{
+					ID: 3,
+					parent: { ID: 1 },
+					date: '2017-01-31T00:00:03Z',
+					i_like: false,
+					like_count: 0,
+				},
+				{
+					ID: 2,
+					parent: { ID: 1 },
+					date: '2017-01-31T00:00:02Z',
+					i_like: false,
+					like_count: 0,
+				},
+				{
+					ID: 1,
+					parent: false,
+					date: '2017-01-31T00:00:01Z',
+					i_like: false,
+					like_count: 0,
+				},
+				{
+					ID: 50,
+					parent: false,
+					date: '2017-01-30T00:00:00Z',
+					i_like: false,
+					like_count: 0,
+				},
+			],
+		},
+	},
+};
+
 describe( 'selectors', () => {
 	describe( '#getPostMostRecentCommentDate()', () => {
 		it( 'should get most recent date', () => {
 			const res = getPostMostRecentCommentDate( state, 1, 1 );
 
-			expect( res ).to.be.eql( new Date( '2017-01-31T10:07:18-08:00' ) );
+			chaiExpect( res ).to.be.eql( new Date( '2017-01-31T10:07:18-08:00' ) );
 		} );
 
 		it( 'should return undefined if no comment items', () => {
@@ -56,7 +100,7 @@ describe( 'selectors', () => {
 				1
 			);
 
-			expect( res ).to.be.eql( undefined );
+			chaiExpect( res ).to.be.eql( undefined );
 		} );
 	} ); // end of getPostMostRecentCommentDate
 
@@ -64,7 +108,7 @@ describe( 'selectors', () => {
 		it( 'should get earliest date', () => {
 			const res = getPostOldestCommentDate( state, 1, 1 );
 
-			expect( res ).to.be.eql( new Date( '2015-01-29T10:07:18-08:00' ) );
+			chaiExpect( res ).to.be.eql( new Date( '2015-01-29T10:07:18-08:00' ) );
 		} );
 
 		it( 'should return undefined if no comment items', () => {
@@ -76,7 +120,7 @@ describe( 'selectors', () => {
 				1
 			);
 
-			expect( res ).to.be.eql( undefined );
+			chaiExpect( res ).to.be.eql( undefined );
 		} );
 	} ); // end of getPostOldestCommentDate
 
@@ -84,61 +128,19 @@ describe( 'selectors', () => {
 		it( 'should provide only like statistics', () => {
 			const res = getCommentLike( state, 1, 1, 2 );
 
-			expect( res.i_like ).to.eql( false );
-			expect( res.like_count ).to.eql( 456 );
+			chaiExpect( res.i_like ).to.eql( false );
+			chaiExpect( res.like_count ).to.eql( 456 );
 		} );
 	} );
 
 	describe( '#getPostCommentsTree', () => {
 		it( 'should return the tree structure', () => {
 			const tree = getPostCommentsTree( state, 1, 1, 'all' );
-			expect( tree ).to.eql( {
-				1: {
-					children: [ 3 ],
-					data: {
-						ID: 1,
-						date: '2016-01-31T10:07:18-08:00',
-						i_like: true,
-						like_count: 5,
-						parent: false,
-					},
-				},
-				2: {
-					children: [ 4 ],
-					data: {
-						ID: 2,
-						date: '2016-01-29T10:07:18-08:00',
-						i_like: false,
-						like_count: 456,
-						parent: false,
-					},
-				},
-				3: {
-					children: [],
-					data: {
-						ID: 3,
-						date: '2017-01-31T10:07:18-08:00',
-						i_like: false,
-						like_count: 0,
-						parent: {
-							ID: 1,
-						},
-					},
-				},
-				4: {
-					children: [],
-					data: {
-						ID: 4,
-						date: '2015-01-29T10:07:18-08:00',
-						i_like: false,
-						like_count: 0,
-						parent: {
-							ID: 2,
-						},
-					},
-				},
-				children: [ 2, 1 ],
-			} );
+			expect( tree ).toMatchSnapshot();
+		} );
+
+		it( 'should reverse children', () => {
+			expect( getPostCommentsTree( stateWithDeeperChildren, 1, 1, 'all' ) ).toMatchSnapshot();
 		} );
 	} );
 } );

--- a/client/state/comments/test/selectors.js
+++ b/client/state/comments/test/selectors.js
@@ -80,13 +80,13 @@ const stateWithDeeperChildren = {
 
 describe( 'selectors', () => {
 	describe( '#getPostMostRecentCommentDate()', () => {
-		it( 'should get most recent date', () => {
+		test( 'should get most recent date', () => {
 			const res = getPostMostRecentCommentDate( state, 1, 1 );
 
 			expect( res ).toEqual( new Date( '2017-01-31T10:07:18-08:00' ) );
 		} );
 
-		it( 'should return undefined if no comment items', () => {
+		test( 'should return undefined if no comment items', () => {
 			const res = getPostMostRecentCommentDate(
 				{
 					comments: { items: { '1-1': [] } },
@@ -100,13 +100,13 @@ describe( 'selectors', () => {
 	} ); // end of getPostMostRecentCommentDate
 
 	describe( '#getPostOldestCommentDate()', () => {
-		it( 'should get earliest date', () => {
+		test( 'should get earliest date', () => {
 			const res = getPostOldestCommentDate( state, 1, 1 );
 
 			expect( res ).toEqual( new Date( '2015-01-29T10:07:18-08:00' ) );
 		} );
 
-		it( 'should return undefined if no comment items', () => {
+		test( 'should return undefined if no comment items', () => {
 			const res = getPostOldestCommentDate(
 				{
 					comments: { items: { '1-1': [] } },
@@ -120,7 +120,7 @@ describe( 'selectors', () => {
 	} ); // end of getPostOldestCommentDate
 
 	describe( '#getCommentLike()', () => {
-		it( 'should provide only like statistics', () => {
+		test( 'should provide only like statistics', () => {
 			const res = getCommentLike( state, 1, 1, 2 );
 
 			expect( res.i_like ).toEqual( false );
@@ -129,12 +129,12 @@ describe( 'selectors', () => {
 	} );
 
 	describe( '#getPostCommentsTree', () => {
-		it( 'should return the tree structure', () => {
+		test( 'should return the tree structure', () => {
 			const tree = getPostCommentsTree( state, 1, 1, 'all' );
 			expect( tree ).toMatchSnapshot();
 		} );
 
-		it( 'should reverse children', () => {
+		test( 'should reverse children', () => {
 			expect( getPostCommentsTree( stateWithDeeperChildren, 1, 1, 'all' ) ).toMatchSnapshot();
 		} );
 	} );


### PR DESCRIPTION
Make it run in O(n) time instead of O(n^2). Makes expanding comments on large trees much much faster.

A good test post: http://calypso.localhost:3000/read/blogs/489937/posts/254547

~This selector has no tests, though I'd like to add some before landing this.~