### PR TITLE
Editor/Sharing: Show "scheduled" status and dates in orange

### DIFF
--- a/client/components/post-schedule/index.jsx
+++ b/client/components/post-schedule/index.jsx
@@ -3,6 +3,7 @@
  */
 import React, { PropTypes, Component } from 'react';
 import { moment } from 'i18n-calypso';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies
@@ -55,11 +56,16 @@ class PostSchedule extends Component {
 
 	componentWillMount() {
 		if ( ! this.props.selectedDay ) {
-			return this.setState( { localizedDate: null } );
+			return this.setState( {
+				localizedDate: null,
+				isFutureDate: false,
+			} );
 		}
 
+		const localizedDate = this.getDateToUserLocation( this.props.selectedDay );
 		this.setState( {
-			localizedDate: this.getDateToUserLocation( this.props.selectedDay )
+			localizedDate,
+			isFutureDate: localizedDate.isAfter(),
 		} );
 	}
 
@@ -126,13 +132,18 @@ class PostSchedule extends Component {
 	}
 
 	updateDate = ( date ) => {
-		this.setState( { calendarViewDate: date } );
-
-		this.props.onDateChange( utils.convertDateToGivenOffset(
+		const convertedDate = utils.convertDateToGivenOffset(
 			date,
 			this.props.timezone,
 			this.props.gmtOffset
-		) );
+		);
+
+		this.setState( {
+			calendarViewDate: date,
+			isFutureDate: convertedDate.isAfter(),
+		} );
+
+		this.props.onDateChange( convertedDate );
 	};
 
 	handleOnDayMouseEnter = ( date, modifiers, event, eventsByDay ) => {
@@ -216,8 +227,12 @@ class PostSchedule extends Component {
 	render() {
 		const handleEventsTooltip = ! this.props.events || ! this.props.events.length;
 
+		const className = classNames( 'post-schedule', {
+			'is-future-date': this.state.isFutureDate,
+		} );
+
 		return (
-			<div className="post-schedule">
+			<div className={ className }>
 				{
 					// Used by Clock for now, likely others in the future.
 					this.props.site && <QuerySiteSettings siteId={ this.props.site.ID } />

--- a/client/components/post-schedule/style.scss
+++ b/client/components/post-schedule/style.scss
@@ -1,5 +1,11 @@
 .post-schedule {
 	position: relative;
+
+	&.is-future-date {
+		.DayPicker-Day.DayPicker-Day--is-selected > .date-picker__day {
+			background-color: $orange-jazzy;
+		}
+	}
 }
 
 .post-schedule__header {

--- a/client/post-editor/editor-publish-date/index.jsx
+++ b/client/post-editor/editor-publish-date/index.jsx
@@ -127,7 +127,11 @@ export class EditorPublishDate extends React.Component {
 
 		return (
 			<div className={ className } onClick={ this.toggleOpenState }>
-				<Gridicon icon="calendar" size={ 18 } />
+				<Gridicon
+					className="editor-publish-date__header-icon"
+					icon="calendar"
+					size={ 18 }
+				/>
 				<div className="editor-publish-date__header-wrapper">
 					<div className="editor-publish-date__header-description">
 						{ this.getHeaderDescription() }
@@ -147,8 +151,14 @@ export class EditorPublishDate extends React.Component {
 			? this.props.post.date
 			: null;
 
+		const isScheduled = utils.isFutureDated( this.props.post );
+		const className = classNames( 'editor-publish-date__schedule', {
+			'is-scheduled': isScheduled,
+		} );
+
+
 		return (
-			<div className="editor-publish-date__schedule">
+			<div className={ className }>
 				{ this.renderCalendarHeader() }
 				<PostScheduler
 					post={ this.props.post }

--- a/client/post-editor/editor-publish-date/index.jsx
+++ b/client/post-editor/editor-publish-date/index.jsx
@@ -156,7 +156,6 @@ export class EditorPublishDate extends React.Component {
 			'is-scheduled': isScheduled,
 		} );
 
-
 		return (
 			<div className={ className }>
 				{ this.renderCalendarHeader() }

--- a/client/post-editor/editor-publish-date/style.scss
+++ b/client/post-editor/editor-publish-date/style.scss
@@ -65,6 +65,13 @@
 	.editor-publish-date.is-open &::after {
 		transform: rotate( 180deg );
 	}
+
+	&.is-scheduled {
+		.editor-publish-date__header-icon,
+		.editor-publish-date__header-description {
+			color: $orange-jazzy;
+		}
+	}
 }
 
 .editor-publish-date__header-wrapper {
@@ -123,4 +130,10 @@
 	position: static;
 	border-top: 1px solid lighten( $gray, 20% );
 	padding: 0 10px;
+
+	&.is-scheduled {
+		.DayPicker-Day.DayPicker-Day--is-selected > .date-picker__day {
+			background-color: $orange-jazzy;
+		}
+	}
 }


### PR DESCRIPTION
This PR updates the date pickers in the editor and in the posts list (when sharing a post) to show scheduled dates (and the status of a scheduled post) in orange, using the pre-existing `$orange-jazzy` Calypso color value.

The editor changes are pretty straightforward; we just use an existing property to determine whether the post is future dated (scheduled).

The post sharing changes are slightly more complicated, and it looks like there are also some timezone inconsistencies with this flow.  Apart from these issues (more detail at https://github.com/Automattic/wp-calypso/issues/18304), whenever the sharing action button says "Schedule post", the selected date should show up in orange (and vice versa).

## Editor screenshots

<img src="https://user-images.githubusercontent.com/227022/30893684-26d2f516-a305-11e7-97d6-8ca0f18c2880.png" width="210"> <img src="https://user-images.githubusercontent.com/227022/30893683-26d2ee2c-a305-11e7-9b27-00b5f06ca078.png" width="210"> <img src="https://user-images.githubusercontent.com/227022/30893682-26d2d6b2-a305-11e7-8abc-61a80bc83b9d.png" width="210">

## Post sharing screenshots

![2017-09-26t21 45 11-0500](https://user-images.githubusercontent.com/227022/30893551-61974c48-a304-11e7-84f4-71f41541a3a0.png)

![2017-09-26t21 45 34-0500](https://user-images.githubusercontent.com/227022/30893558-6b8b83c2-a304-11e7-8aba-f5359941035b.png)
