### PR TITLE
Extensions: WPJM - Refactor to use keyedReducer

### DIFF
--- a/client/extensions/wp-job-manager/state/settings/reducer.js
+++ b/client/extensions/wp-job-manager/state/settings/reducer.js
@@ -1,7 +1,12 @@
 /**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
  * Internal dependencies
  */
-import { combineReducers, createReducer } from 'state/utils';
+import { combineReducers, keyedReducer } from 'state/utils';
 import { itemsSchema } from './schema';
 import {
 	WP_JOB_MANAGER_FETCH_ERROR,
@@ -17,11 +22,11 @@ import {
  * @param  {Object} action Action object
  * @return {Object} Updated fetching state
  */
-export const fetching = createReducer( {}, {
-	[ WP_JOB_MANAGER_FETCH_SETTINGS ]: ( state, { siteId } ) => ( { ...state, [ siteId ]: true } ),
-	[ WP_JOB_MANAGER_UPDATE_SETTINGS ]: ( state, { siteId } ) => ( { ...state, [ siteId ]: false } ),
-	[ WP_JOB_MANAGER_FETCH_ERROR ]: ( state, { siteId } ) => ( { ...state, [ siteId ]: false } ),
-} );
+export const fetching = ( state = false, { type } ) => get( {
+	[ WP_JOB_MANAGER_FETCH_SETTINGS ]: true,
+	[ WP_JOB_MANAGER_FETCH_ERROR ]: false,
+	[ WP_JOB_MANAGER_UPDATE_SETTINGS ]: false,
+}, type, state );
 
 /**
  * Tracks the settings for a particular site.
@@ -30,11 +35,14 @@ export const fetching = createReducer( {}, {
  * @param  {Object} action Action object
  * @return {Object} Updated settings
  */
-export const items = createReducer( {}, {
-	[ WP_JOB_MANAGER_UPDATE_SETTINGS ]: ( state, { siteId, data } ) => ( { ...state, [ siteId ]: data } ),
-}, itemsSchema );
+export const items = ( state = {}, { data, type } ) =>
+	WP_JOB_MANAGER_UPDATE_SETTINGS === type
+		? data
+		: state;
 
-export default combineReducers( {
+items.schema = itemsSchema;
+
+export default keyedReducer( 'siteId', combineReducers( {
 	fetching,
 	items,
-} );
+} ) );

--- a/client/extensions/wp-job-manager/state/settings/selectors.js
+++ b/client/extensions/wp-job-manager/state/settings/selectors.js
@@ -3,7 +3,7 @@
  */
 import { get } from 'lodash';
 
-function getSettingsState( state ) {
+export function getSettingsState( state ) {
 	return get( state, 'extensions.wpJobManager.settings', {} );
 }
 

--- a/client/extensions/wp-job-manager/state/settings/selectors.js
+++ b/client/extensions/wp-job-manager/state/settings/selectors.js
@@ -4,7 +4,7 @@
 import { get } from 'lodash';
 
 function getSettingsState( state ) {
-	return state.extensions.wpJobManager.settings;
+	return get( state, 'extensions.wpJobManager.settings', {} );
 }
 
 /**
@@ -15,7 +15,7 @@ function getSettingsState( state ) {
  * @return {Boolean} Whether settings are being fetched
  */
 export function isFetchingSettings( state, siteId ) {
-	return get( getSettingsState( state ), [ 'fetching', siteId ], false );
+	return get( getSettingsState( state ), [ siteId, 'fetching' ], false );
 }
 
 /**
@@ -26,5 +26,5 @@ export function isFetchingSettings( state, siteId ) {
  * @return {Object} Settings
  */
 export function getSettings( state, siteId ) {
-	return get( getSettingsState( state ), [ 'items', siteId ], {} );
+	return get( getSettingsState( state ), [ siteId, 'items' ], {} );
 }

--- a/client/extensions/wp-job-manager/state/settings/test/reducer.js
+++ b/client/extensions/wp-job-manager/state/settings/test/reducer.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { expect } from 'chai';
-import deepFreeze from 'deep-freeze';
 
 /**
  * Internal dependencies
@@ -12,186 +11,56 @@ import {
 	WP_JOB_MANAGER_FETCH_SETTINGS,
 	WP_JOB_MANAGER_UPDATE_SETTINGS,
 } from '../../action-types';
-import { DESERIALIZE, SERIALIZE } from 'state/action-types';
 import reducer, { fetching, items } from '../reducer';
 
 describe( 'reducer', () => {
-	const primarySiteId = 123456;
-	const secondarySiteId = 456789;
-
-	it( 'should export expected reducer keys', () => {
-		expect( reducer( undefined, {} ) ).to.have.keys( [
-			'fetching',
-			'items',
-		] );
+	it( 'should initialize to an empty object', () => {
+		expect( reducer( undefined, { type: '@@UNKNOWN_ACTION' } ) ).to.eql( {} );
 	} );
 
 	describe( 'fetching()', () => {
-		const previousState = deepFreeze( {
-			[ primarySiteId ]: true,
-		} );
+		it( 'should default to false', () => {
+			const state = fetching( undefined, { type: '@@UNKNOWN_ACTION' } );
 
-		it( 'should default to an empty object', () => {
-			const state = fetching( undefined, {} );
-
-			expect( state ).to.deep.equal( {} );
+			expect( state ).to.eql( false );
 		} );
 
 		it( 'should set state to true if settings are being fetched', () => {
-			const state = fetching( undefined, {
-				type: WP_JOB_MANAGER_FETCH_SETTINGS,
-				siteId: primarySiteId,
-			} );
+			const state = fetching( undefined, { type: WP_JOB_MANAGER_FETCH_SETTINGS } );
 
-			expect( state ).to.deep.equal( {
-				[ primarySiteId ]: true,
-			} );
-		} );
-
-		it( 'should accumulate fetching values', () => {
-			const state = fetching( previousState, {
-				type: WP_JOB_MANAGER_FETCH_SETTINGS,
-				siteId: secondarySiteId,
-			} );
-
-			expect( state ).to.deep.equal( {
-				[ primarySiteId ]: true,
-				[ secondarySiteId ]: true,
-			} );
+			expect( state ).to.eql( true );
 		} );
 
 		it( 'should set state to false if updating settings', () => {
-			const state = fetching( previousState, {
-				type: WP_JOB_MANAGER_UPDATE_SETTINGS,
-				siteId: primarySiteId,
-			} );
+			const state = fetching( undefined, { type: WP_JOB_MANAGER_UPDATE_SETTINGS } );
 
-			expect( state ).to.deep.equal( {
-				[ primarySiteId ]: false,
-			} );
+			expect( state ).to.eql( false );
 		} );
 
 		it( 'should set state to false if settings could not be fetched', () => {
-			const state = fetching( previousState, {
-				type: WP_JOB_MANAGER_FETCH_ERROR,
-				siteId: primarySiteId,
-			} );
+			const state = fetching( undefined, { type: WP_JOB_MANAGER_FETCH_ERROR } );
 
-			expect( state ).to.deep.equal( {
-				[ primarySiteId ]: false,
-			} );
-		} );
-
-		it( 'should not persist state', () => {
-			const state = fetching( previousState, {
-				type: SERIALIZE,
-			} );
-
-			expect( state ).to.deep.equal( {} );
-		} );
-
-		it( 'should not load persisted state', () => {
-			const state = fetching( previousState, {
-				type: DESERIALIZE,
-			} );
-
-			expect( state ).to.deep.equal( {} );
+			expect( state ).to.eql( false );
 		} );
 	} );
 
 	describe( 'items()', () => {
-		const primarySettings = { job_manager_hide_filled_positions: true };
-		const secondarySettings = { job_manager_hide_filled_positions: false };
-		const previousState = deepFreeze( {
-			[ primarySiteId ]: primarySettings,
-		} );
+		const data = { listings: { hideFilledPositions: true } };
 
 		it( 'should default to an empty object', () => {
-			const state = items( undefined, {} );
+			const state = items( undefined, { type: '@@UNKNOWN_ACTION' } );
 
 			expect( state ).to.deep.equal( {} );
 		} );
 
-		it( 'should index settings by site ID', () => {
-			const state = items( undefined, {
-				type: WP_JOB_MANAGER_UPDATE_SETTINGS,
-				siteId: primarySiteId,
-				data: primarySettings,
-			} );
+		it( 'should return settings if settings are being updated', () => {
+			const state = items( undefined, { type: WP_JOB_MANAGER_UPDATE_SETTINGS, data } );
 
-			expect( state ).to.deep.equal( {
-				[ primarySiteId ]: primarySettings,
-			} );
+			expect( state ).to.deep.equal( data );
 		} );
 
-		it( 'should accumulate settings', () => {
-			const state = items( previousState, {
-				type: WP_JOB_MANAGER_UPDATE_SETTINGS,
-				siteId: secondarySiteId,
-				data: secondarySettings,
-			} );
-
-			expect( state ).to.deep.equal( {
-				[ primarySiteId ]: primarySettings,
-				[ secondarySiteId ]: secondarySettings,
-			} );
-		} );
-
-		it( 'should override previous settings of same site ID', () => {
-			const state = items( previousState, {
-				type: WP_JOB_MANAGER_UPDATE_SETTINGS,
-				siteId: primarySiteId,
-				data: secondarySettings,
-			} );
-
-			expect( state ).to.deep.equal( {
-				[ primarySiteId ]: secondarySettings,
-			} );
-		} );
-
-		it( 'should accumulate new settings and overwrite existing ones for the same site ID', () => {
-			const newSettings = {
-				job_manager_hide_expired: false,
-				job_manager_hide_filled_positions: true,
-			};
-			const state = items( previousState, {
-				type: WP_JOB_MANAGER_UPDATE_SETTINGS,
-				siteId: primarySiteId,
-				data: newSettings,
-			} );
-
-			expect( state ).to.deep.equal( {
-				[ primarySiteId ]: newSettings,
-			} );
-		} );
-
-		it( 'should persist state', () => {
-			const state = items( previousState, {
-				type: SERIALIZE,
-			} );
-
-			expect( state ).to.deep.equal( {
-				[ primarySiteId ]: primarySettings,
-			} );
-		} );
-
-		it( 'should load valid persisted state', () => {
-			const state = items( previousState, {
-				type: DESERIALIZE,
-			} );
-
-			expect( state ).to.deep.equal( {
-				[ primarySiteId ]: primarySettings,
-			} );
-		} );
-
-		it( 'should not load invalid persisted state', () => {
-			const previousInvalidState = deepFreeze( {
-				[ primarySiteId ]: 2,
-			} );
-			const state = items( previousInvalidState, {
-				type: DESERIALIZE,
-			} );
+		it( 'should return an empty object if settings are not being updated', () => {
+			const state = items( undefined, { type: '@@UNKNOWN_ACTION', data } );
 
 			expect( state ).to.deep.equal( {} );
 		} );

--- a/client/extensions/wp-job-manager/state/settings/test/selectors.js
+++ b/client/extensions/wp-job-manager/state/settings/test/selectors.js
@@ -8,15 +8,17 @@ import { expect } from 'chai';
  */
 import {
 	getSettings,
+	getSettingsState,
 	isFetchingSettings,
 } from '../selectors';
 
 describe( 'selectors', () => {
 	const primarySiteId = 123456;
 	const secondarySiteId = 456789;
+	const primarySettings = { job_manager_hide_expired: true };
 
-	describe( 'isFetchingSettings()', () => {
-		it( 'should return false if no state exists', () => {
+	describe( 'getSettingsState()', () => {
+		it( 'should return an empty object if no state exists', () => {
 			const state = {
 				extensions: {
 					wpJobManager: {
@@ -24,18 +26,37 @@ describe( 'selectors', () => {
 					}
 				}
 			};
-			const isFetching = isFetchingSettings( state, primarySiteId );
+			const settingsState = getSettingsState( state );
 
-			expect( isFetching ).to.be.false;
+			expect( settingsState ).to.deep.equal( {} );
 		} );
 
+		it( 'should return the settings state', () => {
+			const state = {
+				extensions: {
+					wpJobManager: {
+						settings: {
+							[ primarySiteId ]: {
+								items: primarySettings,
+							}
+						}
+					}
+				}
+			};
+			const settings = getSettingsState( state );
+
+			expect( settings ).to.deep.equal( { [ primarySiteId ]: { items: primarySettings } } );
+		} );
+	} );
+
+	describe( 'isFetchingSettings()', () => {
 		it( 'should return false if the site is not attached', () => {
 			const state = {
 				extensions: {
 					wpJobManager: {
 						settings: {
-							fetching: {
-								[ primarySiteId ]: true,
+							[ primarySiteId ]: {
+								fetching: true,
 							}
 						}
 					}
@@ -51,8 +72,8 @@ describe( 'selectors', () => {
 				extensions: {
 					wpJobManager: {
 						settings: {
-							fetching: {
-								[ primarySiteId ]: false,
+							[ primarySiteId ]: {
+								fetching: false,
 							}
 						}
 					}
@@ -68,8 +89,8 @@ describe( 'selectors', () => {
 				extensions: {
 					wpJobManager: {
 						settings: {
-							fetching: {
-								[ primarySiteId ]: true,
+							[ primarySiteId ]: {
+								fetching: true,
 							}
 						}
 					}
@@ -82,28 +103,13 @@ describe( 'selectors', () => {
 	} );
 
 	describe( 'getSettings()', () => {
-		const primarySettings = { job_manager_hide_expired: true };
-
-		it( 'should return an empty object if no state exists', () => {
-			const state = {
-				extensions: {
-					wpJobManager: {
-						settings: undefined,
-					}
-				}
-			};
-			const settings = getSettings( state, primarySiteId );
-
-			expect( settings ).to.deep.equal( {} );
-		} );
-
 		it( 'should return an empty object if the site is not attached', () => {
 			const state = {
 				extensions: {
 					wpJobManager: {
 						settings: {
-							items: {
-								[ primarySiteId ]: primarySettings,
+							[ primarySiteId ]: {
+								items: primarySettings,
 							}
 						}
 					}
@@ -119,8 +125,8 @@ describe( 'selectors', () => {
 				extensions: {
 					wpJobManager: {
 						settings: {
-							items: {
-								[ primarySiteId ]: primarySettings,
+							[ primarySiteId ]: {
+								items: primarySettings,
 							}
 						}
 					}

--- a/client/extensions/wp-job-manager/state/setup/reducer.js
+++ b/client/extensions/wp-job-manager/state/setup/reducer.js
@@ -1,7 +1,12 @@
 /**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
  * Internal dependencies
  */
-import { combineReducers, createReducer } from 'state/utils';
+import { combineReducers, keyedReducer } from 'state/utils';
 import {
 	WP_JOB_MANAGER_CREATE_PAGES,
 	WP_JOB_MANAGER_CREATE_PAGES_ERROR,
@@ -16,11 +21,11 @@ import {
  * @param  {Object} action Action object
  * @return {Object} Updated creating state
  */
-export const creating = createReducer( {}, {
-	[ WP_JOB_MANAGER_CREATE_PAGES ]: ( state, { siteId } ) => ( { ...state, [ siteId ]: true } ),
-	[ WP_JOB_MANAGER_CREATE_PAGES_ERROR ]: ( state, { siteId } ) => ( { ...state, [ siteId ]: false } ),
-	[ WP_JOB_MANAGER_WIZARD_NEXT_STEP ]: ( state, { siteId } ) => ( { ...state, [ siteId ]: false } ),
-} );
+export const creating = ( state = false, { type } ) => get( {
+	[ WP_JOB_MANAGER_CREATE_PAGES ]: true,
+	[ WP_JOB_MANAGER_CREATE_PAGES_ERROR ]: false,
+	[ WP_JOB_MANAGER_WIZARD_NEXT_STEP ]: false,
+}, type, state );
 
 /**
  * Tracks whether or not to move to the next step in the wizard.
@@ -29,11 +34,12 @@ export const creating = createReducer( {}, {
  * @param  {Object} action Action object
  * @return {Object} Updated state
  */
-export const nextStep = createReducer( {}, {
-	[ WP_JOB_MANAGER_WIZARD_NEXT_STEP ]: ( state, { siteId } ) => ( { ...state, [ siteId ]: true } ),
-} );
+export const nextStep = ( state = false, { type } ) =>
+	WP_JOB_MANAGER_WIZARD_NEXT_STEP === type
+		? true
+		: state;
 
-export default combineReducers( {
+export default keyedReducer( 'siteId', combineReducers( {
 	creating,
 	nextStep,
-} );
+} ) );

--- a/client/extensions/wp-job-manager/state/setup/selectors.js
+++ b/client/extensions/wp-job-manager/state/setup/selectors.js
@@ -4,7 +4,7 @@
 import { get } from 'lodash';
 
 function getSetupState( state ) {
-	return state.extensions.wpJobManager.setup;
+	return get( state, 'extensions.wpJobManager.setup', {} );
 }
 
 /**
@@ -15,7 +15,7 @@ function getSetupState( state ) {
  * @return {Boolean} Whether pages are being created
  */
 export function isCreatingPages( state, siteId ) {
-	return get( getSetupState( state ), [ 'creating', siteId ], false );
+	return get( getSetupState( state ), [ siteId, 'creating' ], false );
 }
 
 /**
@@ -26,5 +26,5 @@ export function isCreatingPages( state, siteId ) {
  * @return {Boolean} Whether to advance to the next step of the wizard
  */
 export function shouldGoToNextStep( state, siteId ) {
-	return get( getSetupState( state ), [ 'nextStep', siteId ], false );
+	return get( getSetupState( state ), [ siteId, 'nextStep' ], false );
 }

--- a/client/extensions/wp-job-manager/state/setup/selectors.js
+++ b/client/extensions/wp-job-manager/state/setup/selectors.js
@@ -3,7 +3,7 @@
  */
 import { get } from 'lodash';
 
-function getSetupState( state ) {
+export function getSetupState( state ) {
 	return get( state, 'extensions.wpJobManager.setup', {} );
 }
 

--- a/client/extensions/wp-job-manager/state/setup/test/reducer.js
+++ b/client/extensions/wp-job-manager/state/setup/test/reducer.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { expect } from 'chai';
-import deepFreeze from 'deep-freeze';
 
 /**
  * Internal dependencies
@@ -15,93 +14,47 @@ import {
 import reducer, { creating, nextStep } from '../reducer';
 
 describe( 'reducer', () => {
-	const primarySiteId = 123456;
-	const secondarySiteId = 456789;
-
-	it( 'should export expected reducer keys', () => {
-		expect( reducer( undefined, {} ) ).to.have.keys( [
-			'creating',
-			'nextStep',
-		] );
+	it( 'should initialize to an empty object', () => {
+		expect( reducer( undefined, { type: '@@UNKNOWN_ACTION' } ) ).to.eql( {} );
 	} );
 
 	describe( 'creating()', () => {
-		const previousState = deepFreeze( {
-			[ primarySiteId ]: true,
-		} );
+		it( 'should default to false', () => {
+			const state = creating( undefined, { type: '@@UNKNOWN_ACTION' } );
 
-		it( 'should default to an empty object', () => {
-			const state = creating( undefined, {} );
-
-			expect( state ).to.deep.equal( {} );
+			expect( state ).to.eql( false );
 		} );
 
 		it( 'should set state to true if pages are being created', () => {
-			const state = creating( undefined, {
-				type: WP_JOB_MANAGER_CREATE_PAGES,
-				siteId: primarySiteId,
-			} );
+			const state = creating( undefined, { type: WP_JOB_MANAGER_CREATE_PAGES } );
 
-			expect( state ).to.deep.equal( {
-				[ primarySiteId ]: true,
-			} );
-		} );
-
-		it( 'should accumulate creating values', () => {
-			const state = creating( previousState, {
-				type: WP_JOB_MANAGER_CREATE_PAGES,
-				siteId: secondarySiteId,
-			} );
-
-			expect( state ).to.deep.equal( {
-				[ primarySiteId ]: true,
-				[ secondarySiteId ]: true,
-			} );
+			expect( state ).to.eql( true );
 		} );
 
 		it( 'should set state to false if not all pages were created', () => {
-			const state = creating( previousState, {
-				type: WP_JOB_MANAGER_CREATE_PAGES_ERROR,
-				siteId: primarySiteId,
-			} );
+			const state = creating( undefined, { type: WP_JOB_MANAGER_CREATE_PAGES_ERROR } );
 
-			expect( state ).to.deep.equal( {
-				[ primarySiteId ]: false,
-			} );
+			expect( state ).to.eql( false );
 		} );
 
 		it( 'should set state to false if moving to the next step of the wizard', () => {
-			const state = creating( previousState, {
-				type: WP_JOB_MANAGER_WIZARD_NEXT_STEP,
-				siteId: primarySiteId,
-			} );
+			const state = creating( undefined, { type: WP_JOB_MANAGER_WIZARD_NEXT_STEP } );
 
-			expect( state ).to.deep.equal( {
-				[ primarySiteId ]: false,
-			} );
+			expect( state ).to.eql( false );
 		} );
 	} );
 
 	describe( 'nextStep()', () => {
-		const previousState = deepFreeze( {
-			[ primarySiteId ]: true,
-		} );
+		it( 'should default to false', () => {
+			const state = nextStep( undefined, { type: '@@UNKNOWN_ACTION' } );
 
-		it( 'should default to an empty object', () => {
-			const state = nextStep( undefined, {} );
-
-			expect( state ).to.deep.equal( {} );
+			expect( state ).to.eql( false );
 		} );
 
 		it( 'should set state to true if moving to the next step of the wizard', () => {
-			const state = nextStep( previousState, {
-				type: WP_JOB_MANAGER_WIZARD_NEXT_STEP,
-				siteId: primarySiteId,
-			} );
+			const state = nextStep( undefined, { type: WP_JOB_MANAGER_WIZARD_NEXT_STEP } );
 
-			expect( state ).to.deep.equal( {
-				[ primarySiteId ]: true,
-			} );
+			expect( state ).to.eql( true );
 		} );
 	} );
 } );

--- a/client/extensions/wp-job-manager/state/setup/test/selectors.js
+++ b/client/extensions/wp-job-manager/state/setup/test/selectors.js
@@ -6,14 +6,18 @@ import { expect } from 'chai';
 /**
  * Internal dependencies
  */
-import { isCreatingPages, shouldGoToNextStep } from '../selectors';
+import {
+	getSetupState,
+	isCreatingPages,
+	shouldGoToNextStep,
+} from '../selectors';
 
 describe( 'selectors', () => {
 	const primarySiteId = 123456;
 	const secondarySiteId = 456789;
 
-	describe( 'isCreatingPages()', () => {
-		it( 'should return false if no state exists', () => {
+	describe( 'getSettingsState()', () => {
+		it( 'should return an empty object if no state exists', () => {
 			const state = {
 				extensions: {
 					wpJobManager: {
@@ -21,18 +25,38 @@ describe( 'selectors', () => {
 					}
 				}
 			};
-			const isCreating = isCreatingPages( state, primarySiteId );
+			const settingsState = getSetupState( state );
 
-			expect( isCreating ).to.be.false;
+			expect( settingsState ).to.deep.equal( {} );
 		} );
 
+		it( 'should return the setup state', () => {
+			const state = {
+				extensions: {
+					wpJobManager: {
+						setup: {
+							[ primarySiteId ]: {
+								creating: false,
+								nextStep: true
+							}
+						}
+					}
+				}
+			};
+			const settings = getSetupState( state );
+
+			expect( settings ).to.deep.equal( { [ primarySiteId ]: { creating: false, nextStep: true } } );
+		} );
+	} );
+
+	describe( 'isCreatingPages()', () => {
 		it( 'should return false if the site is not attached', () => {
 			const state = {
 				extensions: {
 					wpJobManager: {
 						setup: {
-							creating: {
-								[ primarySiteId ]: true,
+							[ primarySiteId ]: {
+								creating: true,
 							}
 						}
 					}
@@ -48,8 +72,8 @@ describe( 'selectors', () => {
 				extensions: {
 					wpJobManager: {
 						setup: {
-							creating: {
-								[ primarySiteId ]: false,
+							[ primarySiteId ]: {
+								creating: false,
 							}
 						}
 					}
@@ -65,8 +89,8 @@ describe( 'selectors', () => {
 				extensions: {
 					wpJobManager: {
 						setup: {
-							creating: {
-								[ primarySiteId ]: true,
+							[ primarySiteId ]: {
+								creating: true,
 							}
 						}
 					}
@@ -79,26 +103,13 @@ describe( 'selectors', () => {
 	} );
 
 	describe( 'shouldGoToNextStep()', () => {
-		it( 'should return false if no state exists', () => {
-			const state = {
-				extensions: {
-					wpJobManager: {
-						setup: undefined,
-					}
-				}
-			};
-			const goToNextStep = shouldGoToNextStep( state, primarySiteId );
-
-			expect( goToNextStep ).to.be.false;
-		} );
-
 		it( 'should return false if the site is not attached', () => {
 			const state = {
 				extensions: {
 					wpJobManager: {
 						setup: {
-							nextStep: {
-								[ primarySiteId ]: true,
+							[ primarySiteId ]: {
+								nextStep: true,
 							}
 						}
 					}
@@ -114,8 +125,8 @@ describe( 'selectors', () => {
 				extensions: {
 					wpJobManager: {
 						setup: {
-							nextStep: {
-								[ primarySiteId ]: false,
+							[ primarySiteId ]: {
+								nextStep: false,
 							}
 						}
 					}
@@ -131,8 +142,8 @@ describe( 'selectors', () => {
 				extensions: {
 					wpJobManager: {
 						setup: {
-							nextStep: {
-								[ primarySiteId ]: true,
+							[ primarySiteId ]: {
+								nextStep: true,
 							}
 						}
 					}


### PR DESCRIPTION
This PR refactors the WPJM `setup` and `settings` reducers to use the [`keyedReducer()` utility method](https://github.com/Automattic/wp-calypso/tree/master/client/state#keyedreducer-keyname-reducer-). Consequently, the state subtree is simplified by removing a level of nesting. That is, the `siteId` key has been moved up a level and no longer needs to be repeated for each property.

**State - Before**

![state-subtree-before](https://user-images.githubusercontent.com/1190420/30881999-ab4d7378-a2d5-11e7-82b5-a24911665329.jpg)

**State - After**

![settings-after](https://user-images.githubusercontent.com/1190420/30882209-470434dc-a2d6-11e7-91b1-307e51cc500d.jpg)
![setup-after](https://user-images.githubusercontent.com/1190420/30882401-cbdb75ee-a2d6-11e7-8fb9-d38d87462fef.jpg)