### PR TITLE
Update Rebrand Cities signup

### DIFF
--- a/client/lib/rebrand-cities/index.js
+++ b/client/lib/rebrand-cities/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { v4 as uuid } from 'uuid';
+import config from 'config';
 
 const allHyphens = new RegExp( '-', 'g' );
 
@@ -13,7 +14,7 @@ function generateUniqueSiteUrl( prefix ) {
 	return `${ prefix }${ uuidWithoutHyphens() }`;
 }
 
-const rebrandCitiesPrefix = 'rebrandcitiessite';
+const rebrandCitiesPrefix = config( 'rebrand_cities_prefix' );
 
 function generateUniqueRebrandCitiesSiteUrl() {
 	return generateUniqueSiteUrl( rebrandCitiesPrefix );

--- a/client/signup/steps/rebrand-cities-welcome/index.jsx
+++ b/client/signup/steps/rebrand-cities-welcome/index.jsx
@@ -3,6 +3,7 @@
  */
 import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
@@ -11,9 +12,10 @@ import StepWrapper from 'signup/step-wrapper';
 import SignupActions from 'lib/signup/actions';
 import { generateUniqueRebrandCitiesSiteUrl } from 'lib/rebrand-cities';
 import FormTextInputWithAction from 'components/forms/form-text-input-with-action';
+import { setSiteTitle } from 'state/signup/steps/site-title/actions';
 
 class RebrandCitiesWelcomeStep extends Component {
-	handleSubmit = ( event ) => {
+	handleSubmit = siteTitle => {
 		event.preventDefault();
 
 		const {
@@ -22,6 +24,8 @@ class RebrandCitiesWelcomeStep extends Component {
 			stepSectionName,
 			translate,
 		} = this.props;
+
+		this.props.setSiteTitle( siteTitle );
 
 		SignupActions.submitSignupStep(
 			{
@@ -78,4 +82,7 @@ class RebrandCitiesWelcomeStep extends Component {
 	}
 }
 
-export default localize( RebrandCitiesWelcomeStep );
+export default connect(
+	null,
+	{ setSiteTitle }
+)( localize( RebrandCitiesWelcomeStep ) );

--- a/client/signup/steps/rebrand-cities-welcome/index.jsx
+++ b/client/signup/steps/rebrand-cities-welcome/index.jsx
@@ -10,6 +10,7 @@ import { localize } from 'i18n-calypso';
 import StepWrapper from 'signup/step-wrapper';
 import SignupActions from 'lib/signup/actions';
 import { generateUniqueRebrandCitiesSiteUrl } from 'lib/rebrand-cities';
+import FormTextInputWithAction from 'components/forms/form-text-input-with-action';
 
 class RebrandCitiesWelcomeStep extends Component {
 	handleSubmit = ( event ) => {
@@ -37,11 +38,14 @@ class RebrandCitiesWelcomeStep extends Component {
 
 	renderContent() {
 		const { translate } = this.props;
-		const buttonClass = 'button is-primary';
 		return (
-			<button className={ buttonClass } onClick={ this.handleSubmit }>
-				{ translate( 'Create your account' ) }
-			</button>
+			<div className="rebrand-cities-welcome__site-title-field">
+				<FormTextInputWithAction
+					action={ translate( 'Create account' ) }
+					placeholder={ translate( 'Enter your business name' ) }
+					onAction={ this.handleSubmit }
+				/>
+			</div>
 		);
 	}
 

--- a/client/signup/steps/rebrand-cities-welcome/index.jsx
+++ b/client/signup/steps/rebrand-cities-welcome/index.jsx
@@ -16,8 +16,6 @@ import { setSiteTitle } from 'state/signup/steps/site-title/actions';
 
 class RebrandCitiesWelcomeStep extends Component {
 	handleSubmit = siteTitle => {
-		event.preventDefault();
-
 		const {
 			goToNextStep,
 			stepName,

--- a/client/signup/steps/rebrand-cities-welcome/style.scss
+++ b/client/signup/steps/rebrand-cities-welcome/style.scss
@@ -20,6 +20,12 @@
 	}
 }
 
+.rebrand-cities-welcome__site-title-field {
+	max-width: 500px;
+	padding: 0 20px;
+	margin: 0 auto;
+}
+
 .rebrand-cities-welcome__illustration-wrapper {
 	max-width: 800px;
 	width: 100%;

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -34,6 +34,7 @@
 	"happychat_support_blog": "en.support.wordpress.com",
 	"google_oauth_client_id": "108380595987-j91sm1alavcdgd81i2655kp8q1lbtvrc.apps.googleusercontent.com",
 	"facebook_app_id": "611241942420191",
+	"rebrand_cities_prefix": "rebrandcitiestestsite",
 	"support_locales": [ "en", "es", "pt-br" ],
 	"languages": [
 		{ "value": 2, "langSlug": "af", "name": "Afrikaans", "wpLocale": "af" },

--- a/config/client.json
+++ b/config/client.json
@@ -31,6 +31,7 @@
   "olark",
   "project",
   "readerFollowingSource",
+  "rebrand_cities_prefix",
   "rtl",
   "siftscience_key",
   "signup_url",

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -9,6 +9,7 @@
 	"logout_url": "/logout",
 	"facebook_api_key": "249643311490",
 	"discover_logged_out_redirect_url": "/",
+	"rebrand_cities_prefix": "rebrandcitiessite",
 	"support_locales": [ "en", "es", "pt-br" ],
 	"features": {
 		"ad-tracking": true,

--- a/config/development.json
+++ b/config/development.json
@@ -31,6 +31,7 @@
 	"facebook_api_key": "249643311490",
 	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
 	"happychat_url": "https://happychat-io-staging.go-vip.co/customer",
+	"rebrand_cities_prefix": "rebrandcitiesdevelopmentsite",
 	"support_locales": [ "en", "es", "pt-br" ],
 	"features": {
 		"account-recovery": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -11,6 +11,7 @@
 	"logout_url": "https://wordpress.com/wp-login.php?action=logout&redirect_to=https%3A%2F%2F|subdomain|wordpress.com",
 	"facebook_api_key": "249643311490",
 	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
+	"rebrand_cities_prefix": "rebrandcitiestestsite",
 	"support_locales": [ "en", "es", "pt-br" ],
 	"features": {
 		"ad-tracking": false,

--- a/config/production.json
+++ b/config/production.json
@@ -10,6 +10,7 @@
 	"facebook_api_key": "249643311490",
 	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
 	"facebook_app_id": "2373049596",
+	"rebrand_cities_prefix": "rebrandcitiessite",
 	"support_locales": [ "en", "es", "pt-br" ],
 	"features": {
 		"ad-tracking": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -12,6 +12,7 @@
 	"logout_url": "https://wordpress.com/wp-login.php?action=logout&redirect_to=https%3A%2F%2F|subdomain|wordpress.com",
 	"facebook_api_key": "249643311490",
 	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
+	"rebrand_cities_prefix": "rebrandcitiestestsite",
 	"support_locales": [ "en", "es", "pt-br" ],
 	"features": {
 		"ad-tracking": false,

--- a/config/test.json
+++ b/config/test.json
@@ -28,6 +28,7 @@
 	"logout_url": "https://wordpress.com/wp-login.php?action=logout&redirect_to=https%3A%2F%2F|subdomain|wordpress.com",
 	"facebook_api_key": "249643311490",
 	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
+	"rebrand_cities_prefix": "rebrandcitiestestsite",
 	"support_locales": [ "en", "es", "pt-br" ],
 	"features": {
 		"ad-tracking": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -12,6 +12,7 @@
 	"logout_url": "https://wordpress.com/wp-login.php?action=logout&redirect_to=https%3A%2F%2F|subdomain|wordpress.com",
 	"facebook_api_key": "249643311490",
 	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
+	"rebrand_cities_prefix": "rebrandcitiestestsite",
 	"support_locales": [ "en", "es", "pt-br" ],
 	"features": {
 		"ad-tracking": false,


### PR DESCRIPTION
This PR adds a new site title field to the Rebrand Cities welcome screen. 

![image](https://user-images.githubusercontent.com/6981253/30915593-4a427c32-a365-11e7-8bfa-ef194eb60381.png)

@markryall I'll need your help integrating this into the flow so that we're actually setting the site title with the business name when someone creates their site.

**Testing**
- Run local dev environment and create a site from here `/start/rebrand-cities`
- Once a site is created, you should see the site title match the business name you entered on the first screen.