### PR TITLE
Simple Payments: Note that the Premium and Business plan is required in the nudge.

### DIFF
--- a/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
@@ -440,7 +440,7 @@ class SimplePaymentsDialog extends Component {
 					action={
 						<UpgradeNudge
 							className="editor-simple-payments-modal__nudge-nudge"
-							title={ translate( 'Upgrade your plan!' ) }
+							title={ translate( 'Upgrade your plan to our Premium or Business plan!' ) }
 							message={ translate(
 								'Get simple payments, advanced social media tools, your own domain, and more.'
 							) }


### PR DESCRIPTION
I've heard a customer confused by thinking they can use Simple Payments with the Personal plan. Let's make it clear here.

Before:
<img width="710" alt="screen shot 2017-09-27 at 14 11 14" src="https://user-images.githubusercontent.com/908665/30916258-e5565056-a390-11e7-9696-cf59a248aee0.png">

After:
<img width="718" alt="screen shot 2017-09-27 at 14 30 52" src="https://user-images.githubusercontent.com/908665/30916276-eace1c94-a390-11e7-97b3-3ff3769bf264.png">
