### PR TITLE
Plugin Uploads: Add AT tracks events

### DIFF
--- a/client/state/data-layer/wpcom/sites/automated-transfer/initiate/index.js
+++ b/client/state/data-layer/wpcom/sites/automated-transfer/initiate/index.js
@@ -7,6 +7,7 @@ import { translate } from 'i18n-calypso';
  * Internal dependencies
  */
 import { AUTOMATED_TRANSFER_INITIATE_WITH_PLUGIN_ZIP } from 'state/action-types';
+import { recordTracksEvent } from 'state/analytics/actions';
 import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { errorNotice } from 'state/notices/actions';
 import { http } from 'state/data-layer/wpcom-http/actions';
@@ -22,6 +23,11 @@ import { getAutomatedTransferStatus } from 'state/automated-transfer/actions';
 export const initiateTransferWithPluginZip = ( { dispatch }, action ) => {
 	const { siteId, pluginZip } = action;
 
+	dispatch( recordTracksEvent(
+		'calypso_automated_transfer_inititate_transfer',
+		{ context: 'plugin_upload' }
+	) );
+
 	dispatch( http( {
 		method: 'POST',
 		path: `/sites/${ siteId }/automated-transfers/initiate`,
@@ -31,6 +37,10 @@ export const initiateTransferWithPluginZip = ( { dispatch }, action ) => {
 };
 
 export const receiveResponse = ( { dispatch }, { siteId } ) => {
+	dispatch( recordTracksEvent(
+		'calypso_automated_transfer_inititate_success',
+		{ context: 'plugin_upload' }
+	) );
 	dispatch( getAutomatedTransferStatus( siteId ) );
 };
 
@@ -49,6 +59,10 @@ const showErrorNotice = ( dispatch, error ) => {
 };
 
 export const receiveError = ( { dispatch }, { siteId }, error ) => {
+	dispatch( recordTracksEvent( 'calypso_automated_transfer_inititate_failure', {
+		context: 'plugin_upload',
+		error: error.error,
+	} ) );
 	showErrorNotice( dispatch, error );
 	dispatch( pluginUploadError( siteId, error ) );
 };

--- a/client/state/data-layer/wpcom/sites/automated-transfer/initiate/test/index.js
+++ b/client/state/data-layer/wpcom/sites/automated-transfer/initiate/test/index.js
@@ -52,7 +52,7 @@ describe( 'receiveError', () => {
 	it( 'should dispatch a plugin upload error', () => {
 		const dispatch = sinon.spy();
 		receiveError( { dispatch }, { siteId }, ERROR_RESPONSE );
-		expect( dispatch ).to.have.been.calledTwice;
+		expect( dispatch ).to.have.been.calledThrice;
 		expect( dispatch ).to.have.been.calledWith(
 			pluginUploadError( siteId, ERROR_RESPONSE )
 		);
@@ -61,7 +61,7 @@ describe( 'receiveError', () => {
 	it( 'should dispatch an error notice', () => {
 		const dispatch = sinon.spy();
 		receiveError( { dispatch }, { siteId }, ERROR_RESPONSE );
-		expect( dispatch ).to.have.been.calledTwice;
+		expect( dispatch ).to.have.been.calledThrice;
 		expect( dispatch ).to.have.been.calledWithMatch( {
 			notice: { text: 'Not a valid zip file.' }
 		} );

--- a/client/state/data-layer/wpcom/sites/automated-transfer/initiate/test/index.js
+++ b/client/state/data-layer/wpcom/sites/automated-transfer/initiate/test/index.js
@@ -13,6 +13,7 @@ import {
 	receiveError,
 	updateUploadProgress,
 } from '../';
+import { recordTracksEvent } from 'state/analytics/actions';
 import { getAutomatedTransferStatus } from 'state/automated-transfer/actions';
 import {
 	pluginUploadError,
@@ -36,6 +37,16 @@ describe( 'initiateTransferWithPluginZip', () => {
 			formData: [ [ 'plugin_zip', 'foo' ] ],
 		} );
 	} );
+
+	it( 'should dispatch a tracks call', () => {
+		const dispatch = sinon.spy();
+		initiateTransferWithPluginZip( { dispatch }, { siteId, pluginZip: 'foo' } );
+		expect( dispatch ).to.have.been.calledWith(
+			recordTracksEvent( 'calypso_automated_transfer_inititate_transfer', {
+				context: 'plugin_upload',
+			} )
+		);
+	} );
 } );
 
 describe( 'receiveResponse', () => {
@@ -46,13 +57,22 @@ describe( 'receiveResponse', () => {
 			getAutomatedTransferStatus( siteId )
 		);
 	} );
+
+	it( 'should dispatch a tracks call', () => {
+		const dispatch = sinon.spy();
+		receiveResponse( { dispatch }, { siteId } );
+		expect( dispatch ).to.have.been.calledWith(
+			recordTracksEvent( 'calypso_automated_transfer_inititate_success', {
+				context: 'plugin_upload',
+			} )
+		);
+	} );
 } );
 
 describe( 'receiveError', () => {
 	it( 'should dispatch a plugin upload error', () => {
 		const dispatch = sinon.spy();
 		receiveError( { dispatch }, { siteId }, ERROR_RESPONSE );
-		expect( dispatch ).to.have.been.calledThrice;
 		expect( dispatch ).to.have.been.calledWith(
 			pluginUploadError( siteId, ERROR_RESPONSE )
 		);
@@ -61,10 +81,20 @@ describe( 'receiveError', () => {
 	it( 'should dispatch an error notice', () => {
 		const dispatch = sinon.spy();
 		receiveError( { dispatch }, { siteId }, ERROR_RESPONSE );
-		expect( dispatch ).to.have.been.calledThrice;
 		expect( dispatch ).to.have.been.calledWithMatch( {
 			notice: { text: 'Not a valid zip file.' }
 		} );
+	} );
+
+	it( 'should dispatch a tracks call', () => {
+		const dispatch = sinon.spy();
+		receiveError( { dispatch }, { siteId }, ERROR_RESPONSE );
+		expect( dispatch ).to.have.been.calledWith(
+			recordTracksEvent( 'calypso_automated_transfer_inititate_failure', {
+				context: 'plugin_upload',
+				error: 'invalid_input',
+			} )
+		);
 	} );
 } );
 

--- a/client/state/data-layer/wpcom/sites/automated-transfer/status/index.js
+++ b/client/state/data-layer/wpcom/sites/automated-transfer/status/index.js
@@ -8,6 +8,7 @@ import { delay, noop } from 'lodash';
  * Internal dependencies
  */
 import { AUTOMATED_TRANSFER_STATUS_REQUEST } from 'state/action-types';
+import { recordTracksEvent } from 'state/analytics/actions';
 import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { requestSite } from 'state/sites/actions';
 import { http } from 'state/data-layer/wpcom-http/actions';
@@ -27,7 +28,7 @@ export const requestStatus = ( { dispatch }, action ) => {
 	}, action ) );
 };
 
-export const receiveStatus = ( { dispatch, getState }, { siteId }, { status, uploaded_plugin_slug } ) => {
+export const receiveStatus = ( { dispatch, getState }, { siteId }, { status, uploaded_plugin_slug, transfer_id } ) => {
 	const pluginId = uploaded_plugin_slug;
 
 	dispatch( setAutomatedTransferStatus( siteId, status, pluginId ) );
@@ -36,6 +37,12 @@ export const receiveStatus = ( { dispatch, getState }, { siteId }, { status, upl
 	}
 
 	if ( status === 'complete' ) {
+		dispatch( recordTracksEvent( 'calypso_automated_transfer_complete', {
+			context: 'plugin_upload',
+			transfer_id,
+			uploaded_plugin_slug,
+		} ) );
+
 		// Update the now-atomic site to ensure plugin page displays correctly.
 		dispatch( requestSite( siteId ) );
 		dispatch( successNotice(

--- a/client/state/data-layer/wpcom/sites/automated-transfer/status/test/index.js
+++ b/client/state/data-layer/wpcom/sites/automated-transfer/status/test/index.js
@@ -49,7 +49,7 @@ describe( 'receiveStatus', () => {
 	it( 'should dispatch set status action', () => {
 		const dispatch = sinon.spy();
 		receiveStatus( { dispatch }, { siteId }, COMPLETE_RESPONSE );
-		expect( dispatch ).to.have.been.calledThrice;
+		expect( dispatch ).to.have.callCount( 4 );
 		expect( dispatch ).to.have.been.calledWith(
 			setAutomatedTransferStatus( siteId, 'complete', 'hello-dolly' )
 		);
@@ -58,7 +58,7 @@ describe( 'receiveStatus', () => {
 	it( 'should dispatch success notice if complete', () => {
 		const dispatch = sinon.spy();
 		receiveStatus( { dispatch }, { siteId }, COMPLETE_RESPONSE );
-		expect( dispatch ).to.have.been.calledThrice;
+		expect( dispatch ).to.have.callCount( 4 );
 		expect( dispatch ).to.have.been.calledWithMatch( {
 			notice: { text: "You've successfully uploaded the hello-dolly plugin." }
 		} );

--- a/client/state/data-layer/wpcom/sites/automated-transfer/status/test/index.js
+++ b/client/state/data-layer/wpcom/sites/automated-transfer/status/test/index.js
@@ -7,6 +7,7 @@ import sinon from 'sinon';
 /**
  * Internal dependencies
  */
+import { recordTracksEvent } from 'state/analytics/actions';
 import { useFakeTimers } from 'test/helpers/use-sinon';
 import {
 	requestStatus,
@@ -23,6 +24,7 @@ const COMPLETE_RESPONSE = {
 	blog_id: 1916284,
 	status: 'complete',
 	uploaded_plugin_slug: 'hello-dolly',
+	transfer_id: 1,
 };
 
 const IN_PROGRESS_RESPONSE = {
@@ -60,8 +62,21 @@ describe( 'receiveStatus', () => {
 		receiveStatus( { dispatch }, { siteId }, COMPLETE_RESPONSE );
 		expect( dispatch ).to.have.callCount( 4 );
 		expect( dispatch ).to.have.been.calledWithMatch( {
-			notice: { text: "You've successfully uploaded the hello-dolly plugin." }
+			notice: { text: "You've successfully uploaded the hello-dolly plugin." },
 		} );
+	} );
+
+	it( 'should dispatch tracks event if complete', () => {
+		const dispatch = sinon.spy();
+		receiveStatus( { dispatch }, { siteId }, COMPLETE_RESPONSE );
+		expect( dispatch ).to.have.callCount( 4 );
+		expect( dispatch ).to.have.been.calledWith(
+			recordTracksEvent( 'calypso_automated_transfer_complete', {
+				context: 'plugin_upload',
+				transfer_id: 1,
+				uploaded_plugin_slug: 'hello-dolly',
+			} )
+		);
 	} );
 
 	it( 'should request status again if not complete', () => {


### PR DESCRIPTION
Add tracks events for automated transfer via plugin upload. For details of existing events: PCYsg-c3L-p2

Added events:
```
calypso_automated_transfer_inititate_transfer
calypso_automated_transfer_initiate_success
calypso_automated_transfer_initiate_failure
calypso_automated_transfer_complete
```


## Testing
* Enter `localStorage.setItem('debug', 'calypso:analytics:tracks');` in browser console
* go to /plugins/upload/{site} where {site} is a simple business site with a mapped domain
* drag a file that is not a zip into the drop zone
* Expected: relevant tracks events in the console, in this case `calypso_automated_transfer_inititate_transfer` and `calypso_automated_transfer_inititate_failure` with appropriate args.
