### PR TITLE
Restore post setting sidebar state when returning to the editor from the preview screen

### DIFF
--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -50,7 +50,7 @@ import EditorWordCount from 'post-editor/editor-word-count';
 import { savePreference } from 'state/preferences/actions';
 import { getPreference } from 'state/preferences/selectors';
 import QueryPreferences from 'components/data/query-preferences';
-import { setLayoutFocus } from 'state/ui/layout-focus/actions';
+import { setLayoutFocus, setNextLayoutFocus } from 'state/ui/layout-focus/actions';
 import { getCurrentLayoutFocus } from 'state/ui/layout-focus/selectors';
 import { protectForm } from 'lib/protect-form';
 import EditorSidebar from 'post-editor/editor-sidebar';
@@ -71,6 +71,7 @@ export const PostEditor = React.createClass( {
 		setEditorModePreference: PropTypes.func,
 		setEditorSidebar: PropTypes.func,
 		setLayoutFocus: PropTypes.func.isRequired,
+		setNextLayoutFocus: PropTypes.func.isRequired,
 		editorModePreference: PropTypes.string,
 		editorSidebarPreference: PropTypes.string,
 		user: PropTypes.object,
@@ -821,6 +822,10 @@ export const PostEditor = React.createClass( {
 	},
 
 	onPreviewEdit: function() {
+		if ( this.props.editorSidebarPreference === 'open' ) {
+			this.props.setNextLayoutFocus( 'sidebar' );
+		}
+
 		this.setState( {
 			showPreview: false,
 			isPostPublishPreview: false,
@@ -1353,6 +1358,7 @@ export default connect(
 			setEditorModePreference: savePreference.bind( null, 'editor-mode' ),
 			setEditorSidebar: savePreference.bind( null, 'editor-sidebar' ),
 			setLayoutFocus,
+			setNextLayoutFocus,
 			saveConfirmationSidebarPreference,
 		}, dispatch );
 	},

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -823,6 +823,11 @@ export const PostEditor = React.createClass( {
 
 	onPreviewEdit: function() {
 		if ( this.props.editorSidebarPreference === 'open' ) {
+			// When returning to the editor from the preview, set the "next
+			// layout focus" to the sidebar if the editor sidebar should be
+			// visible.  Otherwise, according to its default behavior, the
+			// LAYOUT_NEXT_FOCUS_ACTIVATE action will cause the 'content'
+			// layout area to be activated, which hides the editor sidebar.
 			this.props.setNextLayoutFocus( 'sidebar' );
 		}
 


### PR DESCRIPTION
Closes #16039

This PR restores the post setting sidebar state when a user clicks Edit in the the preview screen.

When returning to the editor by pressing Edit on the preview screen the sidebar state is correctly restored but focus is set on 'content' by default so we have to make sure that an open sidebar gets the focus.

To test:

- Checkout this branch
- Draft a post and leave the post setting sidebar open
- Publish the post
- Click Edit
- Verify that the post settings sidebar is open
- Leave the post settings sidebar open, and update the post
- Click Edit
- Verify that the post settings sidebar is open