### PR TITLE
Remove WPCOM UI for ES settings

### DIFF
--- a/client/my-sites/site-settings/search.jsx
+++ b/client/my-sites/site-settings/search.jsx
@@ -141,6 +141,11 @@ class Search extends Component {
 			return null;
 		}
 
+		// don't show for WPCOM, for now
+		if ( ! siteIsJetpack ) {
+			return null;
+		}
+
 		return (
 			<div>
 				{ siteId && <QueryJetpackConnection siteId={ siteId } /> }


### PR DESCRIPTION
This UI was confusing users and wasn't always true.