### PR TITLE
Plugins Browser: include WP.com features as Jetpack pseudo-plugins

### DIFF
--- a/client/my-sites/plugins/plugins-browser-item/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-item/index.jsx
@@ -99,7 +99,7 @@ class PluginsBrowserListElement extends Component {
 						<div className="plugins-browser-item__title">…</div>
 						<div className="plugins-browser-item__author">…</div>
 					</div>
-					<Rating rating={ 0 } size="12" />
+					<Rating rating={ 0 } size={ 12 } />
 				</span>
 			</li>
 		);
@@ -126,7 +126,7 @@ class PluginsBrowserListElement extends Component {
 						<div className="plugins-browser-item__author">{ this.props.plugin.author_name }</div>
 						{ this.renderInstalledIn() }
 					</div>
-					<Rating rating={ this.props.plugin.rating } size="12" />
+					<Rating rating={ this.props.plugin.rating } size={ 12 } />
 				</a>
 				{ this.renderUpgradeButton() }
 			</li>

--- a/client/my-sites/plugins/plugins-browser-item/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-item/index.jsx
@@ -1,9 +1,11 @@
+/** @format */
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { includes } from 'lodash';
+import { localize } from 'i18n-calypso';
+import { flowRight as compose, includes } from 'lodash';
 
 /**
  * Internal dependencies
@@ -16,37 +18,34 @@ import Gridicon from 'gridicons';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
 
-const PluginsBrowserListElement = React.createClass( {
+class PluginsBrowserListElement extends Component {
+	static defaultProps = {
+		iconSize: 40,
+	};
 
-	getDefaultProps: function() {
-		return {
-			iconSize: 40
-		};
-	},
-
-	getPluginLink: function() {
-		var url = '/plugins/' + this.props.plugin.slug;
+	getPluginLink() {
+		let url = '/plugins/' + this.props.plugin.slug;
 		if ( this.props.site ) {
 			url += '/' + this.props.site;
 		}
 		return url;
-	},
+	}
 
-	getSites: function() {
+	getSites() {
 		if ( this.props.site && this.props.currentSites ) {
 			return PluginsStore.getSites( this.props.currentSites, this.props.plugin.slug );
 		}
 		return [];
-	},
+	}
 
-	trackPluginLinkClick: function() {
+	trackPluginLinkClick = () => {
 		analytics.tracks.recordEvent( 'calypso_plugin_browser_item_click', {
 			site: this.props.site,
-			plugin: this.props.plugin.slug
+			plugin: this.props.plugin.slug,
 		} );
-	},
+	};
 
-	isWpcomPreinstalled: function() {
+	isWpcomPreinstalled() {
 		const installedPlugins = [ 'Jetpack by WordPress.com', 'Akismet', 'VaultPress' ];
 
 		if ( ! this.props.site ) {
@@ -54,25 +53,25 @@ const PluginsBrowserListElement = React.createClass( {
 		}
 
 		return ! this.props.isJetpackSite && includes( installedPlugins, this.props.plugin.name );
-	},
+	}
 
-	renderInstalledIn: function() {
-		var sites = this.getSites();
-		if ( sites && sites.length > 0 || this.isWpcomPreinstalled() ) {
+	renderInstalledIn() {
+		const sites = this.getSites();
+		if ( ( sites && sites.length > 0 ) || this.isWpcomPreinstalled() ) {
 			return (
 				<div className="plugins-browser-item__installed">
-						<Gridicon icon='checkmark' size={ 18 } />
-						{ this.translate( 'Installed' ) }
+					<Gridicon icon="checkmark" size={ 18 } />
+					{ this.props.translate( 'Installed' ) }
 				</div>
 			);
 		}
 		return null;
-	},
+	}
 
-	renderPlaceholder: function() {
+	renderPlaceholder() {
 		return (
 			<li className="plugins-browser-item is-placeholder">
-				<span className="plugins-browser-item__link" >
+				<span className="plugins-browser-item__link">
 					<div className="plugins-browser-item__info">
 						<PluginIcon size={ this.props.iconSize } isPlaceholder={ true } />
 						<div className="plugins-browser-item__title">…</div>
@@ -82,17 +81,25 @@ const PluginsBrowserListElement = React.createClass( {
 				</span>
 			</li>
 		);
-	},
+	}
 
-	render: function() {
+	render() {
 		if ( this.props.isPlaceholder ) {
 			return this.renderPlaceholder();
 		}
 		return (
 			<li className="plugins-browser-item">
-				<a href={ this.getPluginLink() } className="plugins-browser-item__link" onClick={ this.trackPluginLinkClick }>
+				<a
+					href={ this.getPluginLink() }
+					className="plugins-browser-item__link"
+					onClick={ this.trackPluginLinkClick }
+				>
 					<div className="plugins-browser-item__info">
-						<PluginIcon size={ this.props.iconSize } image={ this.props.plugin.icon } isPlaceholder={ this.props.isPlaceholder } />
+						<PluginIcon
+							size={ this.props.iconSize }
+							image={ this.props.plugin.icon }
+							isPlaceholder={ this.props.isPlaceholder }
+						/>
 						<div className="plugins-browser-item__title">{ this.props.plugin.name }</div>
 						<div className="plugins-browser-item__author">{ this.props.plugin.author_name }</div>
 						{ this.renderInstalledIn() }
@@ -102,14 +109,15 @@ const PluginsBrowserListElement = React.createClass( {
 			</li>
 		);
 	}
-} );
+}
 
-export default connect(
-	( state ) => {
+export default compose(
+	connect( state => {
 		const selectedSiteId = getSelectedSiteId( state );
 
 		return {
 			isJetpackSite: isJetpackSite( state, selectedSiteId ),
 		};
-	}
+	} ),
+	localize
 )( PluginsBrowserListElement );

--- a/client/my-sites/plugins/plugins-browser-item/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-item/index.jsx
@@ -5,6 +5,7 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
+import Gridicon from 'gridicons';
 import { flowRight as compose, includes } from 'lodash';
 
 /**
@@ -12,9 +13,9 @@ import { flowRight as compose, includes } from 'lodash';
  */
 import PluginIcon from 'my-sites/plugins/plugin-icon/plugin-icon';
 import PluginsStore from 'lib/plugins/store';
-import Rating from 'components/rating/';
+import Button from 'components/button';
+import Rating from 'components/rating';
 import analytics from 'lib/analytics';
-import Gridicon from 'gridicons';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
 
@@ -76,6 +77,19 @@ class PluginsBrowserListElement extends Component {
 		return null;
 	}
 
+	renderUpgradeButton() {
+		const { isPreinstalled, upgradeLink } = this.props.plugin;
+		if ( isPreinstalled || ! upgradeLink ) {
+			return null;
+		}
+
+		return (
+			<Button className="plugins-browser-item__upgrade-button" compact primary href={ upgradeLink }>
+				{ this.props.translate( 'Upgrade' ) }
+			</Button>
+		);
+	}
+
 	renderPlaceholder() {
 		return (
 			<li className="plugins-browser-item is-placeholder">
@@ -114,6 +128,7 @@ class PluginsBrowserListElement extends Component {
 					</div>
 					<Rating rating={ this.props.plugin.rating } size="12" />
 				</a>
+				{ this.renderUpgradeButton() }
 			</li>
 		);
 	}

--- a/client/my-sites/plugins/plugins-browser-item/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-item/index.jsx
@@ -18,12 +18,18 @@ import Gridicon from 'gridicons';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
 
+const PREINSTALLED_PLUGINS = [ 'Jetpack by WordPress.com', 'Akismet', 'VaultPress' ];
+
 class PluginsBrowserListElement extends Component {
 	static defaultProps = {
 		iconSize: 40,
 	};
 
 	getPluginLink() {
+		if ( this.props.plugin.link ) {
+			return this.props.plugin.link;
+		}
+
 		let url = '/plugins/' + this.props.plugin.slug;
 		if ( this.props.site ) {
 			url += '/' + this.props.site;
@@ -46,13 +52,15 @@ class PluginsBrowserListElement extends Component {
 	};
 
 	isWpcomPreinstalled() {
-		const installedPlugins = [ 'Jetpack by WordPress.com', 'Akismet', 'VaultPress' ];
+		if ( this.props.plugin.isPreinstalled ) {
+			return true;
+		}
 
 		if ( ! this.props.site ) {
 			return false;
 		}
 
-		return ! this.props.isJetpackSite && includes( installedPlugins, this.props.plugin.name );
+		return ! this.props.isJetpackSite && includes( PREINSTALLED_PLUGINS, this.props.plugin.name );
 	}
 
 	renderInstalledIn() {

--- a/client/my-sites/plugins/plugins-browser-item/style.scss
+++ b/client/my-sites/plugins/plugins-browser-item/style.scss
@@ -109,12 +109,17 @@
 		bottom: 16px;
 		right: 16px;
 	color: $alert-green;
-	font-size: 11px;
-	font-weight: 600;
-	text-transform: uppercase;
+	font-size: 12px;
+	font-weight: 500;
 	animation: appear .15s ease-in;
 
 	.gridicon {
 		margin-right: 3px;
 	}
+}
+
+.button.plugins-browser-item__upgrade-button {
+	position: absolute;
+		bottom: 16px;
+		right: 16px;
 }

--- a/client/my-sites/plugins/plugins-browser-list/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-list/index.jsx
@@ -1,18 +1,18 @@
+/** @format */
 /**
  * External dependencies
  */
-import React from 'react'
+import React from 'react';
 
 /**
  * Internal dependencies
  */
-import PluginBrowserItem from 'my-sites/plugins/plugins-browser-item'
-import Card from 'components/card'
-import Gridicon from 'gridicons'
-import SectionHeader from 'components/section-header'
+import PluginBrowserItem from 'my-sites/plugins/plugins-browser-item';
+import Card from 'components/card';
+import Gridicon from 'gridicons';
+import SectionHeader from 'components/section-header';
 
 export default React.createClass( {
-
 	displayName: 'PluginsBrowserList',
 
 	_DEFAULT_PLACEHOLDER_NUMBER: 6,
@@ -21,7 +21,14 @@ export default React.createClass( {
 		let emptyCounter = 0;
 
 		let pluginsViewsList = this.props.plugins.map( ( plugin, n ) => {
-			return <PluginBrowserItem site={ this.props.site } key={ plugin.slug + n } plugin={ plugin } currentSites={ this.props.currentSites } />;
+			return (
+				<PluginBrowserItem
+					site={ this.props.site }
+					key={ plugin.slug + n }
+					plugin={ plugin }
+					currentSites={ this.props.currentSites }
+				/>
+			);
 		} );
 
 		if ( this.props.showPlaceholders ) {
@@ -30,7 +37,9 @@ export default React.createClass( {
 
 		// We need to complete the list with empty elements to keep the grid drawn.
 		while ( pluginsViewsList.length % 3 !== 0 || pluginsViewsList.length % 2 !== 0 ) {
-			pluginsViewsList.push( <div className="plugins-browser-item is-empty" key={ 'empty-item-' + emptyCounter++ }></div> );
+			pluginsViewsList.push(
+				<div className="plugins-browser-item is-empty" key={ 'empty-item-' + emptyCounter++ } />
+			);
 		}
 
 		if ( this.props.size ) {
@@ -41,7 +50,10 @@ export default React.createClass( {
 	},
 
 	renderPlaceholdersViews() {
-		return Array.apply( null, Array( this.props.size || this._DEFAULT_PLACEHOLDER_NUMBER ) ).map( ( item, i ) => {
+		return Array.apply(
+			null,
+			Array( this.props.size || this._DEFAULT_PLACEHOLDER_NUMBER )
+		).map( ( item, i ) => {
 			return <PluginBrowserItem isPlaceholder key={ 'placeholder-plugin-' + i } />;
 		} );
 	},
@@ -56,23 +68,24 @@ export default React.createClass( {
 
 	renderLink() {
 		if ( this.props.expandedListLink ) {
-			return <a className="button is-link plugins-browser-list__select-all" href={ this.props.expandedListLink + ( this.props.site || '' ) }>
-				{ this.translate( 'See All' ) }
-				<Gridicon icon="chevron-right" size={ 18 } />
-			</a>;
+			return (
+				<a
+					className="button is-link plugins-browser-list__select-all"
+					href={ this.props.expandedListLink + ( this.props.site || '' ) }
+				>
+					{ this.translate( 'See All' ) }
+					<Gridicon icon="chevron-right" size={ 18 } />
+				</a>
+			);
 		}
 	},
 
 	render() {
 		return (
 			<div className="plugins-browser-list">
-				<SectionHeader label={ this.props.title }>
-					{ this.renderLink() }
-				</SectionHeader>
-				<Card className="plugins-browser-list__elements">
-					{ this.renderViews() }
-				</Card>
+				<SectionHeader label={ this.props.title }>{ this.renderLink() }</SectionHeader>
+				<Card className="plugins-browser-list__elements">{ this.renderViews() }</Card>
 			</div>
 		);
-	}
+	},
 } );

--- a/client/my-sites/plugins/plugins-browser-list/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-list/index.jsx
@@ -2,7 +2,9 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Component } from 'react';
+import { localize } from 'i18n-calypso';
+import { times } from 'lodash';
 
 /**
  * Internal dependencies
@@ -12,10 +14,10 @@ import Card from 'components/card';
 import Gridicon from 'gridicons';
 import SectionHeader from 'components/section-header';
 
-export default React.createClass( {
-	displayName: 'PluginsBrowserList',
+const DEFAULT_PLACEHOLDER_NUMBER = 6;
 
-	_DEFAULT_PLACEHOLDER_NUMBER: 6,
+class PluginsBrowserList extends Component {
+	static displayName = 'PluginsBrowserList';
 
 	renderPluginsViewList() {
 		let emptyCounter = 0;
@@ -47,16 +49,13 @@ export default React.createClass( {
 		}
 
 		return pluginsViewsList;
-	},
+	}
 
 	renderPlaceholdersViews() {
-		return Array.apply(
-			null,
-			Array( this.props.size || this._DEFAULT_PLACEHOLDER_NUMBER )
-		).map( ( item, i ) => {
-			return <PluginBrowserItem isPlaceholder key={ 'placeholder-plugin-' + i } />;
-		} );
-	},
+		return times( this.props.size || DEFAULT_PLACEHOLDER_NUMBER, i => (
+			<PluginBrowserItem isPlaceholder key={ 'placeholder-plugin-' + i } />
+		) );
+	}
 
 	renderViews() {
 		if ( this.props.plugins.length ) {
@@ -64,7 +63,7 @@ export default React.createClass( {
 		} else if ( this.props.showPlaceholders ) {
 			return this.renderPlaceholdersViews();
 		}
-	},
+	}
 
 	renderLink() {
 		if ( this.props.expandedListLink ) {
@@ -73,12 +72,12 @@ export default React.createClass( {
 					className="button is-link plugins-browser-list__select-all"
 					href={ this.props.expandedListLink + ( this.props.site || '' ) }
 				>
-					{ this.translate( 'See All' ) }
+					{ this.props.translate( 'See All' ) }
 					<Gridicon icon="chevron-right" size={ 18 } />
 				</a>
 			);
 		}
-	},
+	}
 
 	render() {
 		return (
@@ -87,5 +86,7 @@ export default React.createClass( {
 				<Card className="plugins-browser-list__elements">{ this.renderViews() }</Card>
 			</div>
 		);
-	},
-} );
+	}
+}
+
+export default localize( PluginsBrowserList );

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -5,6 +5,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -92,16 +93,16 @@ const PluginsBrowser = React.createClass( {
 			return;
 		}
 
-		const fullList = this.state.fullLists[ category ];
+		const fullList = get( this.state.fullLists, category );
 
 		// If a request for this category is in progress, don't issue a new one
-		if ( fullList && fullList.fetching ) {
+		if ( get( fullList, 'fetching' ) ) {
 			return;
 		}
 
 		// If the first search request returned just a few results that fill less than one full page,
 		// don't try to fetch the next page. We already have all the results.
-		if ( category === 'search' && fullList && fullList.list && fullList.list.length < 24 ) {
+		if ( category === 'search' && get( fullList, 'list.length', Infinity ) < 24 ) {
 			return;
 		}
 
@@ -123,11 +124,11 @@ const PluginsBrowser = React.createClass( {
 	},
 
 	getPluginsShortList( listName ) {
-		return this.state.shortLists[ listName ] ? this.state.shortLists[ listName ].list : [];
+		return get( this.state.shortLists, [ listName, 'list' ], [] );
 	},
 
 	getPluginsFullList( listName ) {
-		return this.state.fullLists[ listName ] ? this.state.fullLists[ listName ].list : [];
+		return get( this.state.fullLists, [ listName, 'list' ], [] );
 	},
 
 	getPluginBrowserContent() {
@@ -158,13 +159,12 @@ const PluginsBrowser = React.createClass( {
 	},
 
 	getFullListView( category ) {
-		const isFetching = this.state.fullLists[ category ]
-			? !! this.state.fullLists[ category ].fetching
-			: true;
-		if ( this.getPluginsFullList( category ).length > 0 || isFetching ) {
+		const isFetching = get( this.state.fullLists, [ category, 'fetching' ], true );
+		const list = this.getPluginsFullList( category );
+		if ( list.length > 0 || isFetching ) {
 			return (
 				<PluginsBrowserList
-					plugins={ this.getPluginsFullList( category ) }
+					plugins={ list }
 					listName={ category }
 					title={ this.translateCategory( category ) }
 					site={ this.props.selectedSite }
@@ -176,8 +176,9 @@ const PluginsBrowser = React.createClass( {
 	},
 
 	getSearchListView( searchTerm ) {
-		const isFetching = this.state.fullLists.search ? !! this.state.fullLists.search.fetching : true;
-		if ( this.getPluginsFullList( 'search' ).length > 0 || isFetching ) {
+		const isFetching = get( this.state.fullLists, 'search.fetching', true );
+		const list = this.getPluginsFullList( 'search' );
+		if ( list.length > 0 || isFetching ) {
 			const searchTitle =
 				this.props.searchTitle ||
 				this.props.translate( 'Results for: %(searchTerm)s', {
@@ -188,7 +189,7 @@ const PluginsBrowser = React.createClass( {
 				} );
 			return (
 				<PluginsBrowserList
-					plugins={ this.getPluginsFullList( 'search' ) }
+					plugins={ list }
 					listName={ searchTerm }
 					title={ searchTitle }
 					site={ this.props.siteSlug }
@@ -219,7 +220,7 @@ const PluginsBrowser = React.createClass( {
 					this.getPluginsFullList( category ).length > this._SHORT_LIST_LENGTH ? listLink : false
 				}
 				size={ this._SHORT_LIST_LENGTH }
-				showPlaceholders={ this.state.fullLists[ category ].fetching !== false }
+				showPlaceholders={ get( this.state.fullLists, [ category, 'fetching' ] ) !== false }
 				currentSites={ this.props.sites }
 			/>
 		);

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -28,11 +29,7 @@ import {
 	getSelectedOrAllSitesJetpackCanManage,
 	hasJetpackSites,
 } from 'state/selectors';
-import {
-	getSelectedSite,
-	getSelectedSiteId,
-	getSelectedSiteSlug,
-} from 'state/ui/selectors';
+import { getSelectedSite, getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import {
 	getSitePlan,
 	isJetpackSite,
@@ -67,7 +64,7 @@ const PluginsBrowser = React.createClass( {
 
 		if ( this.props.search && this.props.searchTitle ) {
 			this.props.recordTracksEvent( 'calypso_plugins_search_noresults_recommendations_show', {
-				search_query: this.props.search
+				search_query: this.props.search,
 			} );
 		}
 	},
@@ -121,7 +118,7 @@ const PluginsBrowser = React.createClass( {
 		fullLists.search = PluginsListStore.getSearchList( search );
 		return {
 			shortLists: shortLists,
-			fullLists: fullLists
+			fullLists: fullLists,
 		};
 	},
 
@@ -146,66 +143,86 @@ const PluginsBrowser = React.createClass( {
 	translateCategory( category ) {
 		switch ( category ) {
 			case 'new':
-				return this.props.translate( 'New', { context: 'Category description for the plugin browser.' } );
+				return this.props.translate( 'New', {
+					context: 'Category description for the plugin browser.',
+				} );
 			case 'popular':
-				return this.props.translate( 'Popular', { context: 'Category description for the plugin browser.' } );
+				return this.props.translate( 'Popular', {
+					context: 'Category description for the plugin browser.',
+				} );
 			case 'featured':
-				return this.props.translate( 'Featured', { context: 'Category description for the plugin browser.' } );
+				return this.props.translate( 'Featured', {
+					context: 'Category description for the plugin browser.',
+				} );
 		}
 	},
 
 	getFullListView( category ) {
-		const isFetching = this.state.fullLists[ category ] ? !! this.state.fullLists[ category ].fetching : true;
+		const isFetching = this.state.fullLists[ category ]
+			? !! this.state.fullLists[ category ].fetching
+			: true;
 		if ( this.getPluginsFullList( category ).length > 0 || isFetching ) {
-			return <PluginsBrowserList
-				plugins={ this.getPluginsFullList( category ) }
-				listName={ category }
-				title={ this.translateCategory( category ) }
-				site={ this.props.selectedSite }
-				showPlaceholders={ isFetching }
-				currentSites={ this.props.sites } />;
+			return (
+				<PluginsBrowserList
+					plugins={ this.getPluginsFullList( category ) }
+					listName={ category }
+					title={ this.translateCategory( category ) }
+					site={ this.props.selectedSite }
+					showPlaceholders={ isFetching }
+					currentSites={ this.props.sites }
+				/>
+			);
 		}
 	},
 
 	getSearchListView( searchTerm ) {
 		const isFetching = this.state.fullLists.search ? !! this.state.fullLists.search.fetching : true;
 		if ( this.getPluginsFullList( 'search' ).length > 0 || isFetching ) {
-			const searchTitle = this.props.searchTitle || this.props.translate( 'Results for: %(searchTerm)s', {
-				textOnly: true,
-				args: {
-					searchTerm
-				}
-			} );
-			return <PluginsBrowserList
-				plugins={ this.getPluginsFullList( 'search' ) }
-				listName={ searchTerm }
-				title={ searchTitle }
-				site={ this.props.siteSlug }
-				showPlaceholders={ isFetching }
-				currentSites={ this.props.sites } />;
+			const searchTitle =
+				this.props.searchTitle ||
+				this.props.translate( 'Results for: %(searchTerm)s', {
+					textOnly: true,
+					args: {
+						searchTerm,
+					},
+				} );
+			return (
+				<PluginsBrowserList
+					plugins={ this.getPluginsFullList( 'search' ) }
+					listName={ searchTerm }
+					title={ searchTitle }
+					site={ this.props.siteSlug }
+					showPlaceholders={ isFetching }
+					currentSites={ this.props.sites }
+				/>
+			);
 		}
 		return (
 			<NoResults
-				text={
-					this.props.translate( 'No plugins match your search for {{searchTerm/}}.', {
-						textOnly: true,
-						components: { searchTerm: <em>{ searchTerm }</em> }
-					} )
-				} />
+				text={ this.props.translate( 'No plugins match your search for {{searchTerm/}}.', {
+					textOnly: true,
+					components: { searchTerm: <em>{ searchTerm }</em> },
+				} ) }
+			/>
 		);
 	},
 
 	getPluginSingleListView( category ) {
 		const listLink = '/plugins/browse/' + category + '/';
-		return <PluginsBrowserList
-			plugins={ this.getPluginsShortList( category ) }
-			listName={ category }
-			title={ this.translateCategory( category ) }
-			site={ this.props.siteSlug }
-			expandedListLink={ this.getPluginsFullList( category ).length > this._SHORT_LIST_LENGTH ? listLink : false }
-			size={ this._SHORT_LIST_LENGTH }
-			showPlaceholders={ this.state.fullLists[ category ].fetching !== false }
-			currentSites={ this.props.sites } />;
+		return (
+			<PluginsBrowserList
+				plugins={ this.getPluginsShortList( category ) }
+				listName={ category }
+				title={ this.translateCategory( category ) }
+				site={ this.props.siteSlug }
+				expandedListLink={
+					this.getPluginsFullList( category ).length > this._SHORT_LIST_LENGTH ? listLink : false
+				}
+				size={ this._SHORT_LIST_LENGTH }
+				showPlaceholders={ this.state.fullLists[ category ].fetching !== false }
+				currentSites={ this.props.sites }
+			/>
+		);
 	},
 
 	getShortListsView() {
@@ -229,41 +246,45 @@ const PluginsBrowser = React.createClass( {
 				initialValue={ this.props.search }
 				placeholder={ this.props.translate( 'Search Plugins' ) }
 				delaySearch={ true }
-				analyticsGroup="PluginsBrowser" />
-			);
+				analyticsGroup="PluginsBrowser"
+			/>
+		);
 	},
 
 	getNavigationBar() {
 		const site = this.props.siteSlug ? '/' + this.props.siteSlug : '';
-		return <SectionNav selectedText={ this.props.translate( 'Category', { context: 'Category of plugins to be filtered by' } ) }>
-			<NavTabs label="Category">
-				<NavItem
-					path={ '/plugins/browse' + site }
-					selected={ false }
-				>
-					{ this.props.translate( 'All', { context: 'Filter all plugins' } ) }
-				</NavItem>
-				<NavItem
-					path={ '/plugins/browse/featured' + site }
-					selected={ this.props.path === ( '/plugins/browse/featured' + site ) }
-				>
-					{ this.props.translate( 'Featured', { context: 'Filter featured plugins' } ) }
-				</NavItem>
-				<NavItem
-					path={ '/plugins/browse/popular' + site }
-					selected={ this.props.path === ( '/plugins/browse/popular' + site ) }
-				>
-					{ this.props.translate( 'Popular', { context: 'Filter popular plugins' } ) }
-				</NavItem>
-				<NavItem
-					path={ '/plugins/browse/new' + site }
-					selected={ this.props.path === ( '/plugins/browse/new' + site ) }
-				>
-					{ this.props.translate( 'New', { context: 'Filter new plugins' } ) }
-				</NavItem>
-			</NavTabs>
-			{ this.getSearchBox() }
-		</SectionNav>;
+		return (
+			<SectionNav
+				selectedText={ this.props.translate( 'Category', {
+					context: 'Category of plugins to be filtered by',
+				} ) }
+			>
+				<NavTabs label="Category">
+					<NavItem path={ '/plugins/browse' + site } selected={ false }>
+						{ this.props.translate( 'All', { context: 'Filter all plugins' } ) }
+					</NavItem>
+					<NavItem
+						path={ '/plugins/browse/featured' + site }
+						selected={ this.props.path === '/plugins/browse/featured' + site }
+					>
+						{ this.props.translate( 'Featured', { context: 'Filter featured plugins' } ) }
+					</NavItem>
+					<NavItem
+						path={ '/plugins/browse/popular' + site }
+						selected={ this.props.path === '/plugins/browse/popular' + site }
+					>
+						{ this.props.translate( 'Popular', { context: 'Filter popular plugins' } ) }
+					</NavItem>
+					<NavItem
+						path={ '/plugins/browse/new' + site }
+						selected={ this.props.path === '/plugins/browse/new' + site }
+					>
+						{ this.props.translate( 'New', { context: 'Filter new plugins' } ) }
+					</NavItem>
+				</NavTabs>
+				{ this.getSearchBox() }
+			</SectionNav>
+		);
 	},
 
 	handleSuggestedSearch( term ) {
@@ -288,11 +309,11 @@ const PluginsBrowser = React.createClass( {
 				} ) }
 			>
 				<NavTabs label="Suggested Searches">
-					{ suggestedSearches.map( term =>
+					{ suggestedSearches.map( term => (
 						<NavItem key={ term } onClick={ this.handleSuggestedSearch( term ) }>
 							{ term }
 						</NavItem>
-					) }
+					) ) }
 				</NavTabs>
 				{ this.getSearchBox() }
 			</SectionNav>
@@ -303,7 +324,7 @@ const PluginsBrowser = React.createClass( {
 		if ( this.props.isJetpackSite ) {
 			return true;
 		}
-		return ( ! this.props.selectedSiteId && this.props.hasJetpackSites );
+		return ! this.props.selectedSiteId && this.props.hasJetpackSites;
 	},
 
 	renderManageButton() {
@@ -365,11 +386,14 @@ const PluginsBrowser = React.createClass( {
 	},
 
 	getMockPluginItems() {
-		return <PluginsBrowserList
-			plugins={ this.getPluginsShortList( 'popular' ) }
-			listName={ 'Plugins' }
-			title={ this.props.translate( 'Popular Plugins' ) }
-			size={ 12 } />;
+		return (
+			<PluginsBrowserList
+				plugins={ this.getPluginsShortList( 'popular' ) }
+				listName={ 'Plugins' }
+				title={ this.props.translate( 'Popular Plugins' ) }
+				size={ 12 }
+			/>
+		);
 	},
 
 	renderDocumentHead() {
@@ -385,11 +409,12 @@ const PluginsBrowser = React.createClass( {
 				<SidebarNavigation />
 				<JetpackManageErrorPage
 					template="optInManage"
-					title={ this.props.translate( 'Looking to manage this site\'s plugins?' ) }
+					title={ this.props.translate( "Looking to manage this site's plugins?" ) }
 					siteId={ selectedSiteId }
 					section="plugins"
 					illustration="/calypso/images/jetpack/jetpack-manage.svg"
-					featureExample={ this.getMockPluginItems() } />
+					featureExample={ this.getMockPluginItems() }
+				/>
 			</MainComponent>
 		);
 	},
@@ -416,7 +441,11 @@ const PluginsBrowser = React.createClass( {
 
 	render() {
 		if ( ! this.props.isRequestingSites && this.props.noPermissionsError ) {
-			return <NoPermissionsError title={ this.props.translate( 'Plugin Browser', { textOnly: true } ) } />;
+			return (
+				<NoPermissionsError
+					title={ this.props.translate( 'Plugin Browser', { textOnly: true } ) }
+				/>
+			);
 		}
 
 		if ( this.props.jetpackManageError ) {
@@ -433,7 +462,7 @@ const PluginsBrowser = React.createClass( {
 				{ this.getPluginBrowserContent() }
 			</MainComponent>
 		);
-	}
+	},
 } );
 
 export default connect(
@@ -443,9 +472,12 @@ export default connect(
 			sitePlan: getSitePlan( state, selectedSiteId ),
 			isJetpackSite: isJetpackSite( state, selectedSiteId ),
 			hasJetpackSites: hasJetpackSites( state ),
-			jetpackManageError: !! isJetpackSite( state, selectedSiteId ) && ! canJetpackSiteManage( state, selectedSiteId ),
+			jetpackManageError:
+				!! isJetpackSite( state, selectedSiteId ) &&
+				! canJetpackSiteManage( state, selectedSiteId ),
 			isRequestingSites: isRequestingSites( state ),
-			noPermissionsError: !! selectedSiteId && ! canCurrentUser( state, selectedSiteId, 'manage_options' ),
+			noPermissionsError:
+				!! selectedSiteId && ! canCurrentUser( state, selectedSiteId, 'manage_options' ),
 			selectedSiteId,
 			selectedSite: getSelectedSite( state ),
 			siteSlug: getSelectedSiteSlug( state ),


### PR DESCRIPTION
When searching for something in Plugins Browser, include matching WP.com features as pseudo-plugins in the search results. The intent is to remind the user that WordPress.com already includes many features that would require either Jetpack or another plugin on a self-hosted site.

<img width="823" alt="wpcom-features-as-plugins" src="https://user-images.githubusercontent.com/664258/30925912-c1eab30a-a3b3-11e7-9199-c696e9ca0e9e.png">

**How to test:**
Select a Simple site and go to the Plugins Browser
1. Click on one of the predefined search terms (Engagement, Writing, ...)
2. Verify that all Jetpack features from that group are displayed as pseudo-plugins (compare with the legacy `/plugins/manage` page for Simple sites)
3. Verify that real WP.org search results are displayed after the Jetpack features and that the infinite scrolling still works (loads more results after scrolling far enough)
4. Enter some other search term, e.g., "SEO"
5. Verify that Jetpack features that have "SEO" in their name or description are displayed in the search results
6. Try to click on any of the pseudo-plugin. You should be navigated to the support page of that feature.

Select a Jetpack/Atomic site, or select "All Sites"
1. Verify that no Jetpack pseudo-plugins are not displayed in this case -- the feature should be limited to Simple sites only.

**How to review:**
There are several preliminary commits that Prettify, ES6-ify and lodash-ify the code. Only the last commit contains the "important" stuff, i.e., the feature itself.

**Open questions (mainly for @iamtakashi)**
The legacy `/plugins/manage` page shows either "Active" for active features, or "Upgrade" button for features that are only in plans I don't have (Premium, Business). Should we display the "Upgrade" button also on the search results page? Right now, I'm showing "Installed" for everything, which should be fixed.

The feature names like "Something Really Nice by Jetpack" don't fit very well into the 3-column view. See the screenshot above.

Should we show Jetpack's rating on every pseudo-plugin? It has "only" 4.5 stars :wink:

The feature's "description" is not displayed anywhere -- we only search in it.
