### PR TITLE
Reader: fix emoji display in x-post title and description

### DIFF
--- a/client/reader/stream/x-post.jsx
+++ b/client/reader/stream/x-post.jsx
@@ -20,6 +20,7 @@ import { getSite } from 'state/reader/sites/selectors';
 import { getFeed } from 'state/reader/feeds/selectors';
 import QueryReaderSite from 'components/data/query-reader-site';
 import QueryReaderFeed from 'components/data/query-reader-feed';
+import Emojify from 'components/emojify';
 
 class CrossPost extends PureComponent {
 	static propTypes = {
@@ -188,11 +189,11 @@ class CrossPost extends PureComponent {
 								target="_blank"
 								rel="noopener noreferrer"
 							>
-								{ xpostTitle }
+								<Emojify>{ xpostTitle }</Emojify>
 							</a>
 						</h1>
 					) }
-					{ this.getDescription( post.author.first_name ) }
+					<Emojify>{ this.getDescription( post.author.first_name ) }</Emojify>
 				</div>
 				{ feedId && <QueryReaderFeed feedId={ +feedId } includeMeta={ false } /> }
 				{ siteId && <QueryReaderSite siteId={ +siteId } includeMeta={ false } /> }


### PR DESCRIPTION
I spotted a recent x-post using the :man_dancing: emoji in its title, which was unfortunately displayed like this:

![screen shot 2017-09-27 at 18 04 55](https://user-images.githubusercontent.com/17325/30926928-a76e0270-a3ae-11e7-9348-6200d4ea0c03.png)

This PR emojifies the title and description for x-posts, which should now look more like this:

![screen shot 2017-09-27 at 18 04 10](https://user-images.githubusercontent.com/17325/30926947-b6c916e2-a3ae-11e7-9749-004fba19f8e6.png)

### To test

Automatticians: ping @bluefuton for details of the post shown above, if you can't find it.