### PR TITLE
Add the new Atomic Store signup flow feature flag and initial files

### DIFF
--- a/assets/stylesheets/sections/signup.scss
+++ b/assets/stylesheets/sections/signup.scss
@@ -8,6 +8,7 @@
 @import 'signup/step-wrapper/style';
 @import 'signup/steps/design-type-with-store/pressable-store/style';
 @import 'signup/steps/design-type-with-store/style';
+@import 'signup/steps/design-type-with-atomic-store/style';
 @import 'signup/steps/design-type/style';
 @import 'signup/steps/domains/style';
 @import 'signup/steps/site-or-domain/style';

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -237,6 +237,16 @@ const flows = {
 	},
 };
 
+if ( config.isEnabled( 'signup/atomic-store-flow' ) ) {
+	flows[ 'atomic-store' ] = {
+		// TODO: add new plan step with just Business plan
+		steps: [ 'design-type-with-atomic-store', 'domains', 'plans', 'user' ],
+		destination: getSiteDestination,
+		description: 'Signup flow for creating an online store with an Atomic site',
+		lastModified: '2017-09-27'
+	};
+}
+
 if ( config.isEnabled( 'signup/wpcc' ) ) {
 	flows.wpcc = {
 		steps: [ 'oauth2-user' ],

--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -4,6 +4,7 @@
 import config from 'config';
 import DesignTypeComponent from 'signup/steps/design-type';
 import DesignTypeWithStoreComponent from 'signup/steps/design-type-with-store';
+import DesignTypeWithAtomicStoreComponent from 'signup/steps/design-type-with-atomic-store';
 import DomainsStepComponent from 'signup/steps/domains';
 import GetDotBlogPlansStepComponent from 'signup/steps/get-dot-blog-plans';
 import PlansStepComponent from 'signup/steps/plans';
@@ -20,6 +21,7 @@ import PlansStepWithoutFreePlan from 'signup/steps/plans-without-free';
 export default {
 	'design-type': DesignTypeComponent,
 	'design-type-with-store': DesignTypeWithStoreComponent,
+	'design-type-with-atomic-store': DesignTypeWithAtomicStoreComponent,
 	domains: DomainsStepComponent,
 	'domain-only': DomainsStepComponent,
 	'domains-theme-preselected': DomainsStepComponent,

--- a/client/signup/config/steps.js
+++ b/client/signup/config/steps.js
@@ -82,6 +82,11 @@ export default {
 		providesDependencies: [ 'designType', 'themeSlugWithRepo' ]
 	},
 
+	'design-type-with-atomic-store': {
+		stepName: 'design-type-with-atomic-store',
+		providesDependencies: [ 'designType', 'themeSlugWithRepo' ]
+	},
+
 	site: {
 		stepName: 'site',
 		apiRequestFunction: stepActions.createSite,

--- a/client/signup/steps/design-type-with-atomic-store/domain-image.jsx
+++ b/client/signup/steps/design-type-with-atomic-store/domain-image.jsx
@@ -1,0 +1,44 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+const DomainImage = () => (
+	<svg width="443px" height="71px" viewBox="0 0 443 71" xmlns="http://www.w3.org/2000/svg">
+		<g id="Page-1" stroke="none" strokeWidth="1" fill="none" fillRule="evenodd">
+			<g id="Artboard" transform="translate(-1660.000000, -488.000000)">
+				<g id="domain-only" transform="translate(1660.000000, 488.000000)">
+					<g id="Rectangle-2">
+						<path d="M0,5.99222967 C0,2.68281261 2.68574448,0 5.99992833,0
+							L437.000072,0 C440.313741,0 443,2.6858357 443,5.99222967 L443,71 L0,71 L0,5.99222967 Z"
+							fill="#FFFFFF">
+						</path>
+						<path stroke="#D9E8F0" strokeWidth="2" d="M442,70 L1,70 L1,5.99222967 C1,3.23519406
+							3.23793311,1 5.99992833,1 L437.000072,1 C439.76062,1 442,3.23728589 442,5.99222967 L442,70 Z">
+						</path>
+					</g>
+					<polyline id="Shape" fill="#CFDEE7" fillRule="nonzero"
+						points="21 54 13 46 21 38 22.414 39.414 15.828 46 22.414 52.586"></polyline>
+					<polyline id="Shape" fill="#CFDEE7" fillRule="nonzero"
+						points="37 54 45 46 37 38 35.586 39.414 42.172 46 35.586 52.586"></polyline>
+					<path d="M68.91,48 C68.432,50.833 65.967,53 63,53 C59.692,53 57,50.308 57,47
+						C57,43.692 59.692,41 63,41 L65.172,41 L63.086,43.086 L64.5,44.5 L69,40
+						L64.5,35.5 L63.086,36.914 L65.172,39 L63,39 C58.582,39 55,42.582 55,47 C55,51.418
+						58.582,55 63,55 C67.08,55 70.438,51.945 70.93,48 L68.91,48 Z"
+						id="Shape" fill="#CFDEE7" fillRule="nonzero"></path>
+					<path d="M0,6.00009649 C0,2.6863347 2.68574448,0 5.99992833,0 L437.000072,0 C440.313741,0
+						443,2.68315617 443,6.00009649 L443,21.1854839 L0,21.1854839 L0,6.00009649 Z"
+						id="Rectangle-2" fill="#CFDEE7"></path>
+					<g id="Rectangle-7">
+						<rect fill="#FFFFFF" x="83.6597671" y="30.9193548" width="347.019989" height="29.7741935" rx="4"></rect>
+						<rect stroke="#CFDEE7" strokeWidth="2" x="84.6597671" y="31.9193548"
+							width="345.019989" height="27.7741935" rx="4"></rect>
+					</g>
+					<rect id="Rectangle-9" fill="#E4EEF4" x="92" y="39" width="150" height="13"></rect>
+				</g>
+			</g>
+		</g>
+	</svg>
+);
+
+export default DomainImage;

--- a/client/signup/steps/design-type-with-atomic-store/existing-site.jsx
+++ b/client/signup/steps/design-type-with-atomic-store/existing-site.jsx
@@ -1,0 +1,63 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+const ExistingSite = () => (
+	<svg width="173px" height="114px" viewBox="0 0 173 114" version="1.1" xmlns="http://www.w3.org/2000/svg">
+		<defs>
+			<rect id="path-3" x="0" y="0" width="149" height="97"></rect>
+			<mask
+				id="mask-4" maskContentUnits="userSpaceOnUse" maskUnits="objectBoundingBox"
+				x="0" y="0" width="149" height="97" fill="white">
+				<use xlinkHref="#path-3"></use>
+			</mask>
+		</defs>
+		<g id="Page-1" stroke="none" strokeWidth="1" fill="none" fillRule="evenodd">
+			<g id="Group-4">
+				<rect
+					id="Rectangle-1" stroke="#CFDEE7" strokeWidth="1.6" strokeDasharray="6.5"
+					x="1" y="1" width="171" height="112"></rect>
+				<g id="Group-3" transform="translate(11.000000, 8.000000)">
+					<g id="Group-2">
+						<g id="domain-illustration">
+							<g id="Imported-Layers">
+								<path
+									d="M0.0890083632,13.5587189 L0.0890083632,2.36561066 C0.0890083632,1.12952261
+									1.09159857,0.12755831 2.32845878,0.12755831 L146.596418,0.12755831
+									C147.833456,0.12755831 148.836225,1.12987842 148.836225,2.36614438
+									L148.836225,13.5587189 L0.0890083632,13.5587189" id="Fill-1" fill="#CFDEE7"></path>
+								<polygon id="Fill-6" fill="#FFFFFF"
+									points="0 13.6744186 148.747216 13.6744186 148.747216 96.9761648 0 96.9761648"></polygon>
+							</g>
+						</g>
+						<rect
+							id="Rectangle-4" fill="#CFDEE7" x="9.09923664" y="28.4883721"
+							width="96.6793893" height="5.69767442"></rect>
+						<rect
+							id="Rectangle-4-Copy" fill="#CFDEE7" x="9.09923664" y="39.8837209"
+							width="48.9083969" height="5.69767442"></rect>
+						<rect
+							id="Rectangle-4-Copy-2" fill="#B8F28A" x="9.09923664" y="52.4186047"
+							width="29.5725191" height="5.69767442"></rect>
+					</g>
+					<use
+						id="Rectangle-5" stroke="#E6F0F6" mask="url(#mask-4)" strokeWidth="2" fill="#FFFFFF"
+						opacity="0.800000012" xlinkHref="#path-3"></use>
+					<g id="gridicons-add" transform="translate(56.000000, 30.000000)">
+						<rect id="Rectangle-path" x="0" y="0" width="37.7968291" height="37.8676208"></rect>
+						<path d="M18.9975297,7 C12.371294,7 7,12.3813542 7,19.0200005 C7,25.6586467
+						12.371294,31.0400009 18.9975297,31.0400009 C25.6237653,31.0400009 30.9950593,25.6586467
+						30.9950593,19.0200005 C30.9950593,12.3813542 25.6237653,7 18.9975297,7 L18.9975297,7
+						Z M24.9962945,20.2220005 L20.1972826,20.2220005 L20.1972826,25.0300007 L17.7977767,25.0300007
+						L17.7977767,20.2220005 L12.9987648,20.2220005 L12.9987648,17.8180004 L17.7977767,17.8180004
+						L17.7977767,13.0100002 L20.1972826,13.0100002 L20.1972826,17.8180004 L24.9962945,17.8180004
+						L24.9962945,20.2220005 L24.9962945,20.2220005 Z" id="Shape" fill="#284455"></path>
+					</g>
+				</g>
+			</g>
+		</g>
+	</svg>
+);
+
+export default ExistingSite;

--- a/client/signup/steps/design-type-with-atomic-store/index.jsx
+++ b/client/signup/steps/design-type-with-atomic-store/index.jsx
@@ -1,0 +1,149 @@
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import classNames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import StepWrapper from 'signup/step-wrapper';
+import Card from 'components/card';
+import { localize } from 'i18n-calypso';
+import { recordTracksEvent } from 'state/analytics/actions';
+import { BlogImage, PageImage, GridImage, StoreImage } from '../design-type-with-atomic-store/type-images';
+import { abtest } from 'lib/abtest';
+
+import { setDesignType } from 'state/signup/steps/design-type/actions';
+
+class DesignTypeWithAtomicStoreStep extends Component {
+	constructor( props ) {
+		super( props );
+
+		this.state = {
+			showStore: false
+		};
+	}
+
+	getChoices() {
+		const { translate } = this.props;
+		const blogText = translate(
+			'To share your ideas, stories, and photographs with your followers.'
+		);
+		const siteText = translate(
+			'To promote your business, organization, or brand and connect with your audience.'
+		);
+		const gridText = translate( 'To present your creative projects in a visual showcase.' );
+		const storeText = translate( 'To sell your products or services and accept payments.' );
+
+		return [
+			{ type: 'blog',
+				label: translate( 'Start with a blog' ),
+				description: blogText,
+				image: <BlogImage /> },
+			{ type: 'page',
+				label: translate( 'Start with a website' ),
+				description: siteText,
+				image: <PageImage /> },
+			{ type: 'grid',
+				label: translate( 'Start with a portfolio' ),
+				description: gridText,
+				image: <GridImage /> },
+			{ type: 'store',
+				label: translate( 'Start with an online store' ),
+				description: storeText,
+				image: <StoreImage /> },
+		];
+	}
+
+	renderChoice = ( choice ) => {
+		return (
+			<Card className="design-type-with-atomic-store__choice" key={ choice.type }>
+				<a className="design-type-with-atomic-store__choice-link"
+					href="#">
+					<div className="design-type-with-atomic-store__image">
+						{ choice.image }
+					</div>
+					<div className="design-type-with-atomic-store__choice-copy">
+						<span className="button is-compact design-type-with-atomic-store__cta">
+							{choice.label}
+						</span>
+						<p className="design-type-with-atomic-store__choice-description">
+							{ choice.description }
+						</p>
+					</div>
+				</a>
+			</Card>
+		);
+	};
+
+	renderChoices() {
+		const { translate } = this.props;
+		const disclaimerText = translate( 'Not sure? Pick the closest option. You can always change your settings later.' ); // eslint-disable-line max-len
+
+		const designTypeListClassName = classNames(
+			'design-type-with-atomic-store__list',
+			{ 'is-hidden': this.state.showStore }
+		);
+
+		return (
+			<div className="design-type-with-atomic-store__substep-wrapper">
+				<div className={ designTypeListClassName }>
+					{ this.getChoices().map( this.renderChoice ) }
+
+					<p className="design-type-with-atomic-store__disclaimer">
+						{ disclaimerText }
+					</p>
+				</div>
+			</div>
+		);
+	}
+
+	getHeaderText() {
+		const { translate } = this.props;
+
+		if ( this.state.showStore ) {
+			return translate( 'Create your WordPress Store' );
+		}
+
+		if ( abtest( 'signupSurveyStep' ) === 'showSurveyStep' ) {
+			return 'We\'re excited to hear more about your project.';
+		}
+
+		return translate( 'Hello! Let’s create your new site.' );
+	}
+
+	getSubHeaderText() {
+		const { translate } = this.props;
+
+		return translate( 'What kind of site do you need? Choose an option below:' );
+	}
+
+	render() {
+		const headerText = this.getHeaderText();
+		const subHeaderText = this.getSubHeaderText();
+
+		return (
+			<StepWrapper
+				flowName={ this.props.flowName }
+				stepName={ this.props.stepName }
+				positionInFlow={ this.props.positionInFlow }
+				fallbackHeaderText={ headerText }
+				fallbackSubHeaderText={ subHeaderText }
+				headerText={ headerText }
+				subHeaderText={ subHeaderText }
+				signupProgress={ this.props.signupProgress }
+				stepContent={ this.renderChoices() }
+				shouldHideNavButtons={ this.state.showStore } />
+		);
+	}
+}
+
+export default connect(
+	null,
+	{
+		recordTracksEvent,
+		setDesignType,
+	}
+)( localize( DesignTypeWithAtomicStoreStep ) );

--- a/client/signup/steps/design-type-with-atomic-store/new-site-image.jsx
+++ b/client/signup/steps/design-type-with-atomic-store/new-site-image.jsx
@@ -1,0 +1,40 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+const NewSiteImage = () => (
+	<svg width="172px" height="112px" viewBox="0 0 172 112" version="1.1" xmlns="http://www.w3.org/2000/svg">
+		<defs>
+			<polygon id="path-1" points="0 15.7603469 171.708196 15.7603469 171.708196 111.769139 0 111.769139"></polygon>
+			<mask
+				id="mask-2" maskContentUnits="userSpaceOnUse"
+				maskUnits="objectBoundingBox" x="0" y="0" width="171.708196" height="96.0087922" fill="white">
+				<use xlinkHref="#path-1"></use>
+			</mask>
+		</defs>
+		<g id="Page-1" stroke="none" strokeWidth="1" fill="none" fillRule="evenodd">
+			<g id="Group-3-Copy">
+				<g id="Group-2">
+					<g id="domain-illustration">
+						<g id="Imported-Layers">
+							<path d="M0.102747909,15.6269981 L0.102747909,2.72646653 C0.102747909,1.30182267
+								1.26010036,0.147016357 2.6878853,0.147016357 L169.225395,0.147016357
+								C170.653386,0.147016357 171.810944,1.30223275 171.810944,2.72708166
+								L171.810944,15.6269981 L0.102747909,15.6269981"
+								id="Fill-1"
+								fill="#CFDEE7">
+							</path>
+							<use id="Fill-6" stroke="#D9E8F0" mask="url(#mask-2)" strokeWidth="2" fill="#FFFFFF" xlinkHref="#path-1"></use>
+						</g>
+					</g>
+					<rect id="Rectangle-4" fill="#CFDEE7" x="10.5038168" y="32.834056" width="111.603053" height="6.56681119"></rect>
+					<rect id="Rectangle-4-Copy" fill="#CFDEE7" x="10.5038168" y="45.9676784" width="56.4580153" height="6.56681119"></rect>
+					<rect id="Rectangle-4-Copy-2" fill="#B8F28A" x="10.5038168" y="60.414663" width="34.1374046" height="6.56681119"></rect>
+				</g>
+			</g>
+		</g>
+	</svg>
+);
+
+export default NewSiteImage;

--- a/client/signup/steps/design-type-with-atomic-store/style.scss
+++ b/client/signup/steps/design-type-with-atomic-store/style.scss
@@ -1,0 +1,193 @@
+.design-type-with-atomic-store {
+	position: relative;
+	text-align: center;
+}
+
+.design-type-with-atomic-store__substep-wrapper {
+	position: relative;
+}
+
+.design-type-with-atomic-store__list {
+	margin: 0 auto;
+	display: flex;
+	flex-flow: row wrap;
+	max-width: 640px;
+
+	opacity: 1;
+	filter: blur( 0 );
+	transform: translateZ( 0 ) translateX( 0 );
+	transition: 0.5s ease-in-out opacity, 0.5s ease-in-out filter, 0.5s ease-in-out transform;
+
+	&.is-hidden {
+		pointer-events: none;
+		transform: translateZ( 0 ) translateX( -25% );
+		opacity: 0;
+	}
+}
+
+.design-type-with-atomic-store__store-wrapper {
+	position: absolute;
+	width: 100%;
+	opacity: 1;
+	filter: blur( 0 );
+	transform: translateZ( 0 ) translateX( 0 );
+	transition: 0.5s ease-in-out opacity, 0.5s ease-in-out filter, 0.5s ease-in-out transform;
+
+	&.is-hidden {
+		pointer-events: none;
+		transform: translateZ( 0 ) translateX( 25% );
+		opacity: 0;
+	}
+}
+
+.design-type-with-atomic-store__choice {
+	transition: all 100ms ease-in-out;
+	position: relative;
+	border: 1px solid lighten( $gray, 20% );
+	border-bottom: 0;
+	margin: 0 10px;
+
+	@include breakpoint( "<480px" ) {
+		box-shadow: none; //inherited from .card, remove for mobile only
+	}
+
+	@include breakpoint( ">480px" ) {
+		padding: 0;
+		margin-bottom: 20px;
+		width: 230px;
+		text-align: center;
+		flex-grow: 1;
+		border: 0;
+
+		&:hover {
+			box-shadow: 0 0 0 1px $gray, 0 2px 4px lighten( $gray, 20 );
+		}
+	}
+
+	&:active {
+		.design-type-with-atomic-store__cta {
+			color: $blue-dark;
+		}
+
+		.design-type-with-atomic-store__choice-link:after {
+			border-top-color: $blue-dark;
+			border-right-color: $blue-dark;
+		}
+	}
+
+	&:first-child {
+		border-top-right-radius: 6px;
+		border-top-left-radius: 6px;
+
+		@include breakpoint( ">480px" ) {
+			border-radius: 0;
+		}
+	}
+
+	&:last-of-type {
+		margin-bottom: 20px;
+		border: 1px solid lighten( $gray, 20% );
+		border-bottom-right-radius: 6px;
+		border-bottom-left-radius: 6px;
+
+		@include breakpoint( ">480px" ) {
+			border-radius: 0;
+			border: 0;
+		}
+	}
+
+	a, svg {
+		display: block;
+		width: 100%; // Safari fix
+	}
+}
+
+.design-type-with-atomic-store__choice-link {
+	padding-right: 40px;
+	display: block;
+	box-sizing: border-box;
+
+	&:after {
+		content: '';
+		display: block;
+		width: 8px; //Match the size of the cta copy
+		height: 8px; //Match the size of the cta copy
+		position: absolute;
+		top: 20px;
+		right: 15px;
+		border-top: 2px solid lighten( $gray, 20% );
+		border-right: 2px solid lighten( $gray, 20% );
+		transform: rotate(45deg);
+	}
+
+	@include breakpoint( ">480px" ) {
+		padding-right: 0;
+		&:after {
+			display: none;
+		}
+	}
+}
+
+.design-type-with-atomic-store__image {
+	display: none;
+
+	@include breakpoint( ">480px" ) {
+		display: block;
+	}
+
+	img {
+		display: block;
+		margin: 10% auto 4%;
+		width: 85%;
+	}
+}
+
+@include breakpoint( ">480px" ) {
+	.design-type-with-atomic-store__choice-copy {
+		padding: 15px;
+		border-top: 1px solid transparentize( lighten( $gray, 20% ), .5 );
+	}
+}
+
+.design-type-with-atomic-store__choice-label {
+	color: $blue-wordpress;
+	padding: 0;
+	position: relative;
+}
+
+.design-type-with-atomic-store__choice-description {
+	margin: 0;
+	color: $gray;
+	font-size: 0.875em;
+
+	@include breakpoint( ">480px" ) {
+		margin-top: 10px;
+	}
+}
+
+.button.design-type-with-atomic-store__cta {
+	color: $blue-wordpress;
+
+	@include breakpoint( "<480px" ) {
+		background: none;
+		font-size: 1.1em;
+		border: 0;
+		padding: 0;
+		text-transform: none;
+		margin: 0;
+		line-height: 1.1em;
+	}
+}
+
+.design-type-with-atomic-store__disclaimer {
+	text-align: center;
+	padding: 0 15px;
+	color: darken( $gray, 20 );
+	font-size: 0.875em;
+	width: 100%;
+	box-sizing: border-box;
+
+	@include breakpoint( "<480px" ) {
+		padding: 0 20px;
+	}
+}

--- a/client/signup/steps/design-type-with-atomic-store/type-images.jsx
+++ b/client/signup/steps/design-type-with-atomic-store/type-images.jsx
@@ -1,0 +1,20 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+export function BlogImage() {
+	return <img src="/calypso/images/illustrations/type-blog.svg" />;
+}
+
+export function PageImage() {
+	return <img src="/calypso/images/illustrations/type-website.svg" />;
+}
+
+export function GridImage() {
+	return <img src="/calypso/images/illustrations/type-portfolio.svg" />;
+}
+
+export function StoreImage() {
+	return <img src="/calypso/images/illustrations/type-e-commerce.svg" />;
+}

--- a/config/development.json
+++ b/config/development.json
@@ -152,6 +152,7 @@
 		"signup/domain-first-flow": true,
 		"signup/social": true,
 		"signup/social-management": true,
+		"signup/store-flow": true,
 		"signup/wpcc": true,
 		"simple-payments": true,
 		"standalone-site-preview": true,

--- a/config/development.json
+++ b/config/development.json
@@ -152,7 +152,7 @@
 		"signup/domain-first-flow": true,
 		"signup/social": true,
 		"signup/social-management": true,
-		"signup/store-flow": true,
+		"signup/atomic-store-flow": true,
 		"signup/wpcc": true,
 		"simple-payments": true,
 		"standalone-site-preview": true,


### PR DESCRIPTION
@Automattic/stark will be working on the new Atomic Store signup flow. In this PR, we are adding a feature flag for it so we don't have to commit to a feature branch and instead can commit to `master`. What is more, we are reusing some of the code from the original `design-type-with-store` signup flow so we don't have to start from scratch -- big props to its authors!

## Testing

Make sure the original `store` flow works as before. Navigate to http://calypso.localhost:3000/start/store and verify that.

Verify that you can access the new flow at http://calypso.localhost:3000/start/atomic-store. It's not functional at the moment, should just render the screen with site selection:

![selection_047](https://user-images.githubusercontent.com/4988512/30935294-82e6d0fe-a3d0-11e7-8255-9d696a840e82.png)

Open `config/development.json` and put the `signup/atomic-store-flow` feature flag to `false`. Restart Calypso and verify that you can't access the new flow.