### PR TITLE
Post-Editor: Return to site after following an edit link from site.

### DIFF
--- a/client/state/ui/editor/selectors.js
+++ b/client/state/ui/editor/selectors.js
@@ -9,6 +9,7 @@ import { get } from 'lodash';
 import { getSiteSlug } from 'state/sites/selectors';
 import { getEditedPost } from 'state/posts/selectors';
 import { getPreference } from 'state/preferences/selectors';
+import { getActionLog } from 'state/ui/action-log/selectors';
 
 /**
  * Returns the current editor post ID, or `null` if a new post.
@@ -99,4 +100,16 @@ export function getEditorPath( state, siteId, postId, defaultType = 'post' ) {
  */
 export function isConfirmationSidebarEnabled( state, siteId ) {
 	return getPreference( state, 'editorConfirmationDisabledSites' ).indexOf( siteId ) === -1;
+}
+
+/**
+ * Returns whether the Editor is the only route that exists in the history.
+ *
+ * @param  {Object}  state     Global state tree
+ * @return {Boolean}           Whether or not Editor is the only route in the history
+ */
+export function isEditorOnlyRouteInHistory( state ) {
+	const routeSets = getActionLog( state ).filter( entry => 'ROUTE_SET' === entry.type );
+
+	return 1 === routeSets.length && !! ( get( routeSets[ 0 ], 'path', '' ).match( /^\/(post|page|edit)\// ) );
 }

--- a/client/state/ui/editor/test/selectors.js
+++ b/client/state/ui/editor/test/selectors.js
@@ -11,7 +11,8 @@ import {
 	getEditorPostId,
 	isEditorNewPost,
 	getEditorNewPostPath,
-	getEditorPath
+	getEditorPath,
+	isEditorOnlyRouteInHistory,
 } from '../selectors';
 
 describe( 'selectors', () => {
@@ -263,6 +264,42 @@ describe( 'selectors', () => {
 			}, 2916284, null, 'jetpack-portfolio' );
 
 			expect( path ).to.equal( '/edit/jetpack-portfolio/example.wordpress.com' );
+		} );
+	} );
+
+	describe( 'isEditorOnlyRouteInHistory()', () => {
+		it( 'should return true when Editor is the only route in history', () => {
+			const isOnlyRoute = isEditorOnlyRouteInHistory( {
+				ui: {
+					actionLog: [
+						{
+							type: 'ROUTE_SET',
+							path: '/post/example.com/123',
+						}
+					]
+				}
+			} );
+
+			expect( isOnlyRoute ).to.be.true;
+		} );
+
+		it( 'should return false when Editor is not the only route in history', () => {
+			const isOnlyRoute = isEditorOnlyRouteInHistory( {
+				ui: {
+					actionLog: [
+						{
+							type: 'ROUTE_SET',
+							path: '/',
+						},
+						{
+							type: 'ROUTE_SET',
+							path: '/post/example.com/123',
+						}
+					]
+				}
+			} );
+
+			expect( isOnlyRoute ).to.be.false;
 		} );
 	} );
 } );


### PR DESCRIPTION
Fixes #16040

This PR returns you to the site front-end after updating a post when you have arrived at the Editor from an edit link on the site. Previously you'd be shown the preview instead.

To test:
* Checkout branch.
* `npm start`.
* Get to the editor via normal means within Calypso.
* Verify that a preview is still shown after updating an existing post.
* Copy the editor URL, and in a new tab visit that URL directly.
* Verify that a preview is still shown after updating the existing post.
* Visit your site directly (example.wordpress.com).
* Use your browser's inspector to modify the edit link to point to `calypso.localhost:3000`. For example, if it was previously `https://wordpress.com/post/example.wordpress.com/123`, update it so that it is `http://calypso.localhost:3000/post/example.wordpress.com/123`.
* Using the inspector, also add the following attribute to the link: `referrerpolicy="unsafe-url"`. Without that attribute the referrer will not properly propagate to the insecure host `calypso.localhost:3000`.
* Click on your modified edit link. Verify that after updating your post, instead of being shown a preview, your are returned to your site.