### PR TITLE
Jetpack Thank You Page: Fix typo in isErrored() check for the Jetpack Thank You Page

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/jetpack-thank-you-card.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/jetpack-thank-you-card.jsx
@@ -292,7 +292,7 @@ class JetpackThankYouCard extends Component {
 		const { selectedSite, plugins } = this.props;
 		return ( selectedSite && ! selectedSite.canUpdateFiles ) ||
 			some( plugins, ( plugin ) =>
-				plugin.hasOwnProperty( 'error' ) && plugin.error && plugin.satus !== 'done'
+				plugin.hasOwnProperty( 'error' ) && plugin.error && plugin.status !== 'done'
 		);
 	}
 


### PR DESCRIPTION
Fixes detection of blocking errors detected while auto installing plugin

Just a typo...

#### Testing instructions.

Note: On your WP installation you should have an empty directory for either `akismet` or `vaultpress`. This should trigger an error detection of `folder_exists` internally but the installation should go on and eventually be a successful operation.

1. Get a brand new Jetpack installation, connect and get a paid plan. OR upgrade to another Jetpack plan in a current installation. 
1. In the end, you should see the Thank You Page, with a success title, description and actions like 

![image](https://user-images.githubusercontent.com/746152/30928749-d0d2c4a0-a392-11e7-85eb-ac8405b530a6.png)
