### PR TITLE
Reader: Remove AB test banner code in activetests

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -1,3 +1,4 @@
+/** @format */
 module.exports = {
 	multiDomainRegistrationV1: {
 		datestamp: '20200721',
@@ -67,16 +68,6 @@ module.exports = {
 		},
 		defaultVariation: 'hide',
 		allowExistingUsers: true,
-	},
-	readerIntroIllustration: {
-		datestamp: '20170718',
-		variations: {
-			blue: 33,
-			lightBlue: 33,
-			white: 34,
-		},
-		defaultVariation: 'white',
-		assignmentMethod: 'userId',
 	},
 	skipThemesSelectionModal: {
 		datestamp: '20170904',


### PR DESCRIPTION
In https://github.com/Automattic/wp-calypso/pull/18261, we stopped the AB test and cleaned up the code associated with it. However, there's some leftover code in `activetests.js` that we missed.

There are no functional changes in this PR.