### PR TITLE
Comments: Enable "All" list in all environments

### DIFF
--- a/client/components/data/query-site-comments-tree/index.jsx
+++ b/client/components/data/query-site-comments-tree/index.jsx
@@ -1,7 +1,9 @@
+/** @format */
 /**
  * External dependencies
  */
-import { Component, PropTypes } from 'react';
+import { Component } from 'react';
+import { PropTypes } from 'prop-types';
 import { connect } from 'react-redux';
 
 /**
@@ -16,7 +18,7 @@ export class QuerySiteCommentsTree extends Component {
 	};
 
 	static defaultProps = {
-		status: 'unapproved',
+		status: 'all',
 	};
 
 	componentDidMount() {
@@ -32,7 +34,11 @@ export class QuerySiteCommentsTree extends Component {
 	request() {
 		const { siteId, status } = this.props;
 		if ( siteId ) {
-			this.props.requestCommentsTreeForSite( { siteId, status } );
+			if ( 'all' !== status ) {
+				return this.props.requestCommentsTreeForSite( { siteId, status } );
+			}
+			this.props.requestCommentsTreeForSite( { siteId, status: 'approved' } );
+			this.props.requestCommentsTreeForSite( { siteId, status: 'unapproved' } );
 		}
 	}
 

--- a/client/my-sites/comments/comment-navigation/index.jsx
+++ b/client/my-sites/comments/comment-navigation/index.jsx
@@ -66,6 +66,9 @@ export class CommentNavigation extends Component {
 	getNavItems = () => {
 		const { translate } = this.props;
 		const navItems = {
+			all: {
+				label: translate( 'All' ),
+			},
 			unapproved: {
 				label: translate( 'Pending' ),
 			},
@@ -79,12 +82,6 @@ export class CommentNavigation extends Component {
 				label: translate( 'Trash' ),
 			},
 		};
-
-		if ( isEnabled( 'comments/management/all-list' ) ) {
-			navItems.all = {
-				label: translate( 'All' ),
-			};
-		}
 
 		return navItems;
 	};

--- a/client/my-sites/comments/controller.js
+++ b/client/my-sites/comments/controller.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -10,28 +11,24 @@ import { each, includes, startsWith } from 'lodash';
  * Internal dependencies
  */
 import CommentsManagement from './main';
-import config from 'config';
 import route from 'lib/route';
 import { removeNotice } from 'state/notices/actions';
 import { getNotices } from 'state/notices/selectors';
 
-const VALID_STATUSES = [ 'pending', 'approved', 'spam', 'trash' ];
-if ( config.isEnabled( 'comments/management/all-list' ) ) {
-	VALID_STATUSES.push( 'all' );
-}
+const VALID_STATUSES = [ 'all', 'pending', 'approved', 'spam', 'trash' ];
 
 export const isValidStatus = status => includes( VALID_STATUSES, status );
 
 export const getRedirectUrl = ( status, siteFragment ) => {
 	const statusValidity = isValidStatus( status );
 	if ( status === siteFragment ) {
-		return `/comments/pending/${ siteFragment }`;
+		return `/comments/all/${ siteFragment }`;
 	}
 	if ( ! statusValidity && ! siteFragment ) {
-		return '/comments/pending';
+		return '/comments/all';
 	}
 	if ( ! statusValidity && siteFragment ) {
-		return `/comments/pending/${ siteFragment }`;
+		return `/comments/all/${ siteFragment }`;
 	}
 	if ( statusValidity && ! siteFragment ) {
 		return `/comments/${ status }`;

--- a/client/state/selectors/get-site-comments-tree.js
+++ b/client/state/selectors/get-site-comments-tree.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -19,9 +20,16 @@ import createSelector from 'lib/create-selector';
 export const getSiteCommentsTree = createSelector(
 	( state, siteId, status ) => {
 		const siteTree = get( state, [ 'comments', 'trees', siteId ] );
-		return status
-			? filter( siteTree, { status } )
-			: siteTree;
+		if ( ! status ) {
+			return siteTree;
+		}
+
+		return 'all' === status
+			? filter(
+					siteTree,
+					comment => 'approved' === comment.status || 'unapproved' === comment.status
+				)
+			: filter( siteTree, { status } );
 	},
 	( state, siteId ) => [ get( state, [ 'comments', 'trees', siteId ] ) ]
 );

--- a/client/state/selectors/is-comments-tree-initialized.js
+++ b/client/state/selectors/is-comments-tree-initialized.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -12,5 +13,10 @@ import { get } from 'lodash';
  * @return {Boolean} True if the comment tree has been initialized
  */
 export default function isCommentsTreeInitialized( state, siteId, status ) {
+	if ( 'all' === status ) {
+		const tree = get( state, [ 'comments', 'treesInitialized', siteId ] );
+		return tree && ( tree.approved || tree.unapproved );
+	}
+
 	return get( state, [ 'comments', 'treesInitialized', siteId, status ], false );
 }

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -17,7 +17,6 @@
 		"catch-js-errors": false,
 		"code-splitting": false,
 		"comments/management": true,
-		"comments/management/all-list": false,
 		"comments/management/sorting": false,
 		"manage/comments/bulk-actions": false,
 		"desktop": true,

--- a/config/development.json
+++ b/config/development.json
@@ -41,7 +41,6 @@
 		"comments/filters-in-posts": true,
 		"comments/moderation-tools-in-posts": true,
 		"comments/management": true,
-		"comments/management/all-list": false,
 		"comments/management/edit": true,
 		"comments/management/sorting": true,
 		"manage/comments/bulk-actions": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -19,7 +19,6 @@
 		"catch-js-errors": true,
 		"code-splitting": true,
 		"comments/management": true,
-		"comments/management/all-list": false,
 		"comments/management/edit": true,
 		"comments/management/sorting": true,
 		"manage/comments/bulk-actions": true,

--- a/config/production.json
+++ b/config/production.json
@@ -18,7 +18,6 @@
 		"catch-js-errors": true,
 		"code-splitting": true,
 		"comments/management": true,
-		"comments/management/all-list": false,
 		"comments/management/sorting": false,
 		"manage/comments/bulk-actions": false,
 		"desktop-promo": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -20,7 +20,6 @@
 		"catch-js-errors": true,
 		"code-splitting": true,
 		"comments/management": true,
-		"comments/management/all-list": false,
 		"comments/management/sorting": false,
 		"manage/comments/bulk-actions": false,
 		"desktop-promo": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -18,7 +18,6 @@
 		"automated-transfer": true,
 		"apple-pay": true,
 		"comments/management": true,
-		"comments/management/all-list": false,
 		"comments/management/edit": true,
 		"comments/management/sorting": true,
 		"manage/comments/bulk-actions": true,


### PR DESCRIPTION
Closes #18316

Enables the **All Comments list in all environments** and makes it the default Comment Management list.

This is what I did to adapt the current comments tree logic:

- Dispatched 2 different Redux actions, one for `status: 'approved'` and one for `status: 'unapproved'` in the `QuerySiteCommentsTree` query component. The data layer takes care of the rest as usual.

- Added an additional check in the `getSiteCommentsTree` and `isCommentsTreeInitialized` selectors.

Please notice that the current behaviour for Jetpack sites is **unchanged**.
The `comment-list` endpoint already accepts the `all` status and returns `approved` and `unapproved` comments as expected.

### Test instructions

- Navigate to the Comments section.
- Make sure that:
  - The default list is All.
  - The All list contains both approved and unapproved comments (the latter are yellow).
  - If there are no (approved and unapproved) comments, the All list shows an empty comment message, and it isn't stuck in a loading state (which is: an empty placeholder pulsating forever).
- Try opening the Comments section directly by typing the URL.
  - `/comments` should open the site selector, which then redirects to the All list.
  - `/comments/{ siteSlug }` and `/comments/all/{ siteSlug }` should directly open the All list.
  - `/comments/pending` should open the site selector, which then redirects to the Pending list.
  - `/comments/pending/{ siteSlug }` should directly open the All list.