### PR TITLE
Jetpack Connect: skip plans for users coming from the WooCommerce setup wizard.

### DIFF
--- a/client/jetpack-connect/auth-logged-in-form.jsx
+++ b/client/jetpack-connect/auth-logged-in-form.jsx
@@ -51,7 +51,7 @@ class LoggedInForm extends Component {
 		isFetchingSites: PropTypes.bool,
 		isFetchingAuthorizationSite: PropTypes.bool,
 		isSSO: PropTypes.bool,
-		isWCS: PropTypes.bool,
+		isWoo: PropTypes.bool,
 		jetpackConnectAuthorize: PropTypes.shape( {
 			authorizeError: PropTypes.oneOfType( [ PropTypes.object, PropTypes.bool ] ),
 			authorizeSuccess: PropTypes.bool,
@@ -104,7 +104,7 @@ class LoggedInForm extends Component {
 
 		// For SSO, WooCommerce Services, and JPO users, do not display plans page
 		// Instead, redirect back to admin as soon as we're connected
-		if ( props.isSSO || props.isWCS || ( queryObject && 'jpo' === queryObject.from ) ) {
+		if ( props.isSSO || props.isWoo || ( queryObject && 'jpo' === queryObject.from ) ) {
 			if ( ! isRedirectingToWpAdmin && authorizeSuccess ) {
 				return this.props.goBackToWpAdmin( queryObject.redirect_after_auth );
 			}
@@ -154,7 +154,7 @@ class LoggedInForm extends Component {
 	redirect() {
 		const { queryObject } = this.props.jetpackConnectAuthorize;
 
-		if ( 'jpo' === queryObject.from || this.props.isSSO || this.props.isWCS ) {
+		if ( 'jpo' === queryObject.from || this.props.isSSO || this.props.isWoo ) {
 			debug(
 				'Going back to WP Admin.',
 				'Connection initiated via: ',

--- a/client/jetpack-connect/authorize-form.jsx
+++ b/client/jetpack-connect/authorize-form.jsx
@@ -7,6 +7,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import cookie from 'cookie';
+import { get, includes } from 'lodash';
 
 /**
  * Internal dependencies
@@ -90,8 +91,11 @@ class JetpackConnectAuthorizeForm extends Component {
 		);
 	}
 
-	isWCS() {
-		return 'woocommerce-services' === this.props.jetpackConnectAuthorize.queryObject.from;
+	isWoo() {
+		const wooSlugs = [ 'woocommerce-setup-wizard', 'woocommerce-services' ];
+		const jetpackConnectSource = get( this.props, 'jetpackConnectAuthorize.queryObject.from' );
+
+		return includes( wooSlugs, jetpackConnectSource );
 	}
 
 	handleClickHelp = () => {
@@ -116,9 +120,9 @@ class JetpackConnectAuthorizeForm extends Component {
 
 	renderForm() {
 		return this.props.user ? (
-			<LoggedInForm { ...this.props } isSSO={ this.isSSO() } isWCS={ this.isWCS() } />
+			<LoggedInForm { ...this.props } isSSO={ this.isSSO() } isWoo={ this.isWoo() } />
 		) : (
-			<LoggedOutForm { ...this.props } isSSO={ this.isSSO() } isWCS={ this.isWCS() } />
+			<LoggedOutForm { ...this.props } isSSO={ this.isSSO() } isWoo={ this.isWoo() } />
 		);
 	}
 


### PR DESCRIPTION
This PR is an expansion of https://github.com/Automattic/wp-calypso/pull/16238, it's a light refactor, but mostly adds a check for `woocommerce-setup-wizard` in addition to `woocommerce-services`.

_This is needed to support connecting Jetpack from the WooCommerce setup wizard. See: https://github.com/woocommerce/woocommerce/pull/16755_

# To test
1. Install WooCommerce on your test site -
 this branch: (https://github.com/woocommerce/woocommerce/tree/update/setup-wizard-smart-defaults-with-jetpack)
2. Deactivate Jetpack
3. Make sure Jetpack will use your local calypso install for the connection by following the instructions in P7rd6c-Me-p2
4. Go to the setup wizard Jetpack step: `/wp-admin/admin.php?page=wc-setup&step=activate`
5. Click connect to Jetpack
6. See that you are not taken through the plans page during the connection flow, and are auto-redirected
