### PR TITLE
Store: Add a count of pending reviews to the store sidebar.

### DIFF
--- a/client/extensions/woocommerce/app/reviews/review-actions-bar.js
+++ b/client/extensions/woocommerce/app/reviews/review-actions-bar.js
@@ -92,21 +92,21 @@ ReviewActionsBar.propTypes = {
 };
 
 const mapDispatchToProps = ( dispatch, ownProps ) => {
-	const { review, siteId, currentStatus, toggleExpanded } = ownProps;
+	const { review, siteId, toggleExpanded } = ownProps;
 	const { product } = review;
 	const postId = product.id;
 	const commentId = review.id;
 	return {
 		approveReview: () => {
-			dispatch( changeReviewStatus( siteId, postId, commentId, currentStatus, 'approved' ) );
+			dispatch( changeReviewStatus( siteId, postId, commentId, review.status, 'approved' ) );
 			toggleExpanded();
 		},
 		unapproveReview: () => {
-			dispatch( changeReviewStatus( siteId, postId, commentId, currentStatus, 'pending' ) );
+			dispatch( changeReviewStatus( siteId, postId, commentId, review.status, 'pending' ) );
 			toggleExpanded();
 		},
 		trashReview: () => {
-			dispatch( changeReviewStatus( siteId, postId, commentId, currentStatus, 'trash' ) );
+			dispatch( changeReviewStatus( siteId, postId, commentId, review.status, 'trash' ) );
 			toggleExpanded();
 		},
 		deleteTheReview: () => {
@@ -114,7 +114,7 @@ const mapDispatchToProps = ( dispatch, ownProps ) => {
 			toggleExpanded();
 		},
 		spamReview: () => {
-			dispatch( changeReviewStatus( siteId, postId, commentId, currentStatus, 'spam' ) );
+			dispatch( changeReviewStatus( siteId, postId, commentId, review.status, 'spam' ) );
 			toggleExpanded();
 		}
 	};

--- a/client/extensions/woocommerce/state/sites/reviews/reducer.js
+++ b/client/extensions/woocommerce/state/sites/reviews/reducer.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { keyBy, omit } from 'lodash';
+import { keyBy, omit, isNumber } from 'lodash';
 
 /**
  * Internal dependencies
@@ -108,6 +108,24 @@ export function total( state = 0, action ) {
 		const query = getSerializedReviewsQuery( omit( action.query, 'page' ) );
 		return Object.assign( {}, state, { [ query ]: action.total } );
 	}
+
+	// Updates total numbers of reviews for statuses without requiring another API query/fetch
+	// Only updates totals which we have previously fetched.
+	if ( WOOCOMMERCE_REVIEW_STATUS_CHANGE === action.type ) {
+		const updatedState = {};
+		const newStatusQuery = getSerializedReviewsQuery( { status: action.newStatus } );
+		if ( isNumber( state[ newStatusQuery ] ) ) {
+			updatedState[ newStatusQuery ] = state[ newStatusQuery ] + 1;
+		}
+
+		const currentStatusQuery = getSerializedReviewsQuery( { status: action.currentStatus } );
+		if ( isNumber( state[ currentStatusQuery ] ) ) {
+			updatedState[ currentStatusQuery ] = state[ currentStatusQuery ] - 1;
+		}
+
+		return Object.assign( {}, state, updatedState );
+	}
+
 	return state;
 }
 

--- a/client/extensions/woocommerce/state/sites/reviews/test/reducer.js
+++ b/client/extensions/woocommerce/state/sites/reviews/test/reducer.js
@@ -284,6 +284,34 @@ describe( 'reducer', () => {
 			expect( newState ).to.eql( { '{}': 3 } );
 		} );
 
+		it( 'should update the number of reviews for a status query when a status changes', () => {
+			const action = {
+				type: WOOCOMMERCE_REVIEW_STATUS_CHANGE,
+				siteId: 123,
+				productId: 5,
+				reviewId: 6,
+				currentStatus: 'pending',
+				newStatus: 'approved',
+			};
+			const originalState = deepFreeze( { '{}': 3, '{"status":"approved"}': 1 } );
+			const newState = total( originalState, action );
+			expect( newState ).to.eql( { '{}': 2, '{"status":"approved"}': 2 } );
+		} );
+
+		it( 'should not update the number of reviews for a status query when a previous total is absent', () => {
+			const action = {
+				type: WOOCOMMERCE_REVIEW_STATUS_CHANGE,
+				siteId: 123,
+				productId: 5,
+				reviewId: 6,
+				currentStatus: 'approved',
+				newStatus: 'trash',
+			};
+			const originalState = deepFreeze( { '{"status":"approved"}': 1 } );
+			const newState = total( originalState, action );
+			expect( newState ).to.eql( { '{"status":"approved"}': 0 } );
+		} );
+
 		it( 'should do nothing on a failure', () => {
 			const action = {
 				type: WOOCOMMERCE_REVIEWS_RECEIVE,


### PR DESCRIPTION
This PR adds a pending count to the sidebar for Reviews.

Closes #17044.

<img width="306" alt="screen shot 2017-09-27 at 11 47 25 am" src="https://user-images.githubusercontent.com/689165/30937341-5226290a-a38b-11e7-95b5-39374d4a3525.png">

To Test:
* Run `npm run test-client client/extensions/woocommerce/state` and make sure all tests pass.
* Go to `http://calypso.localhost:3000/store/:site`
* If you have pending reviews, you should see a bubble with the count. If not, no bubble will be displayed.
* Click `Reviews`. Mark a pending review approved and the count should update. Unapprove the review again, and the count should update again.