### PR TITLE
Fix handling errors on the server

### DIFF
--- a/server/isomorphic-routing/index.js
+++ b/server/isomorphic-routing/index.js
@@ -7,7 +7,7 @@ import qs from 'qs';
 /**
  * Internal dependencies
  */
-import { serverRender, serverRenderError } from 'render';
+import { serverRender } from 'render';
 import { setSection as setSectionMiddlewareFactory } from '../../client/controller';
 import { setRoute as setRouteAction } from 'state/ui/actions';
 
@@ -23,7 +23,11 @@ export function serverRouter( expressApp, setUpRoute, section ) {
 				( err, req, res, next ) => {
 					route( err, req.context, next );
 				},
-				serverRenderError
+				( err, req, res, next ) => {
+					req.error = err;
+					res.status( err.status || 404 );
+					serverRender( req, res, next );
+				}
 			);
 		} else {
 			expressApp.get(
@@ -34,8 +38,7 @@ export function serverRouter( expressApp, setUpRoute, section ) {
 					setRouteMiddleware,
 					...middlewares
 				),
-				serverRender,
-				serverRenderError
+				serverRender
 			);
 		}
 	};

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -16,7 +16,7 @@ import sanitize from 'sanitize';
 import utils from 'bundler/utils';
 import sectionsModule from '../../client/sections';
 import { serverRouter, getCacheKey } from 'isomorphic-routing';
-import { serverRender } from 'render';
+import { serverRender, serverRenderError } from 'render';
 import stateCache from 'state-cache';
 import { createReduxStore, reducer } from 'state';
 import { DESERIALIZE } from 'state/action-types';
@@ -270,7 +270,7 @@ function setUpLoggedInRoute( req, res, next ) {
 
 					console.log( 'API Error: ' + errorMessage );
 
-					res.status( 500 ).render( '500.jade', context );
+					next( error );
 				}
 
 				return;
@@ -452,7 +452,10 @@ module.exports = function() {
 	} );
 
 	// catchall to render 404 for all routes not whitelisted in client/sections
-	app.get( '*', render404 );
+	app.use( render404 );
+
+	// Error handling middleware for displaying the server error 500 page must be the very last middleware defined
+	app.use( serverRenderError );
 
 	return app;
 };


### PR DESCRIPTION
This PR aims to fix rendering error pages on calypso.
Bug was reported [here](https://github.com/Automattic/wp-calypso/pull/17483/files/faf2acdd020f2c1d1d96f32a0416ffc13d03de6d#r140668149) by @ockham 

### Testing Instructions
- Checkout this branch and boot the server locally
- Load http://calypso.localhost:3000/log-in?client_id=930 you should see the default error 500 page and the actual error printed in your terminal
- Load http://calypso.localhost:3000/gsfadgn you should see the default 404 page
- Load http://calypso.localhost:3000/theme/gsfadgn you should see the server side rendered 404 page for theme "Looking for great WordPress designs?"
- Load http://calypso.localhost:3000/themes, edit the link of one of the themes and click on it, you should see the same page

### Reviews
- [x] Code
- [x] Product
