### PR TITLE
Store: Add a "product search" component

### DIFF
--- a/client/extensions/woocommerce/app/order/order-create/index.js
+++ b/client/extensions/woocommerce/app/order/order-create/index.js
@@ -18,6 +18,7 @@ import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
 import { getLink } from 'woocommerce/lib/nav-utils';
 import Main from 'components/main';
 import OrderCustomerCard from './customer-card';
+import ProductSearch from 'woocommerce/components/product-search';
 import { ProtectFormGuard } from 'lib/protect-form';
 import SectionHeader from 'components/section-header';
 
@@ -47,7 +48,9 @@ class OrderCreate extends Component {
 					<OrderCustomerCard siteId={ site && site.ID } editOrder={ this.editOrder } />
 
 					<SectionHeader label={ translate( 'Add products to the order' ) } />
-					<Card className="order-create__card" />
+					<Card className="order-create__card">
+						<ProductSearch />
+					</Card>
 
 					<SectionHeader label={ translate( 'How will these products be shipped?' ) } />
 					<Card className="order-create__card" />

--- a/client/extensions/woocommerce/app/order/order-create/index.js
+++ b/client/extensions/woocommerce/app/order/order-create/index.js
@@ -22,6 +22,8 @@ import ProductSearch from 'woocommerce/components/product-search';
 import { ProtectFormGuard } from 'lib/protect-form';
 import SectionHeader from 'components/section-header';
 
+const noop = () => {};
+
 class OrderCreate extends Component {
 	editOrder = order => {
 		const { site } = this.props;
@@ -49,7 +51,7 @@ class OrderCreate extends Component {
 
 					<SectionHeader label={ translate( 'Add products to the order' ) } />
 					<Card className="order-create__card">
-						<ProductSearch />
+						<ProductSearch onSelect={ noop } />
 					</Card>
 
 					<SectionHeader label={ translate( 'How will these products be shipped?' ) } />

--- a/client/extensions/woocommerce/components/product-search/README.md
+++ b/client/extensions/woocommerce/components/product-search/README.md
@@ -1,0 +1,27 @@
+ProductSearch
+=============
+
+This component is used to search through the products on a given site.
+
+#### How to use:
+
+```js
+import Card from 'components/card';
+import ProductSearch from 'woocommerce/components/product-search';
+
+render: function() {
+	const onSelect = product => {
+		// Do something with product object
+	};
+
+	return (
+		<Card>
+			<ProductSearch onSelect={ onSelect } />
+		</Card>
+	);
+}
+```
+
+#### Props
+
+* `onSelect`: Function called when a result is clicked, with product object as an argument.

--- a/client/extensions/woocommerce/components/product-search/README.md
+++ b/client/extensions/woocommerce/components/product-search/README.md
@@ -5,7 +5,7 @@ This component is used to search through the products on a given site.
 
 #### How to use:
 
-```js
+```jsx
 import Card from 'components/card';
 import ProductSearch from 'woocommerce/components/product-search';
 

--- a/client/extensions/woocommerce/components/product-search/index.js
+++ b/client/extensions/woocommerce/components/product-search/index.js
@@ -49,10 +49,7 @@ class ProductSearch extends Component {
 		this.refs.searchCard.clear();
 
 		// Pass products back to parent component
-		this.props.onSelect( {
-			product_id: product.id,
-			quantity: 1,
-		} );
+		this.props.onSelect( product );
 	};
 
 	render() {

--- a/client/extensions/woocommerce/components/product-search/index.js
+++ b/client/extensions/woocommerce/components/product-search/index.js
@@ -3,6 +3,7 @@
  * External dependencies
  */
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
@@ -19,6 +20,10 @@ import ProductSearchResults from './results';
 import SearchCard from 'components/search-card';
 
 class ProductSearch extends Component {
+	static propTypes = {
+		onSelect: PropTypes.func.isRequired,
+	};
+
 	state = {
 		query: '',
 	};
@@ -36,18 +41,33 @@ class ProductSearch extends Component {
 		this.props.fetchProductSearchResults( siteId, 1, query );
 	};
 
+	onSelect = product => {
+		const { siteId } = this.props;
+		// Clear the search field
+		this.setState( { query: '' } );
+		this.props.clearProductSearch( siteId );
+		this.refs.searchCard.clear();
+
+		// Pass products back to parent component
+		this.props.onSelect( {
+			product_id: product.id,
+			quantity: 1,
+		} );
+	};
+
 	render() {
 		const { translate } = this.props;
 
 		return (
 			<div className="product-search">
 				<SearchCard
+					ref="searchCard"
 					onSearch={ this.onSearch }
 					delaySearch
 					delayTimeout={ 400 }
 					placeholder={ translate( 'Search products…' ) }
 				/>
-				<ProductSearchResults search={ this.state.query } />
+				<ProductSearchResults search={ this.state.query } onSelect={ this.onSelect } />
 			</div>
 		);
 	}

--- a/client/extensions/woocommerce/components/product-search/index.js
+++ b/client/extensions/woocommerce/components/product-search/index.js
@@ -28,7 +28,7 @@ class ProductSearch extends Component {
 		query: '',
 	};
 
-	onSearch = query => {
+	handleSearch = query => {
 		const { siteId } = this.props;
 
 		if ( trim( query ) === '' ) {
@@ -41,7 +41,7 @@ class ProductSearch extends Component {
 		this.props.fetchProductSearchResults( siteId, 1, query );
 	};
 
-	onSelect = product => {
+	handleSelect = product => {
 		const { siteId } = this.props;
 		// Clear the search field
 		this.setState( { query: '' } );
@@ -59,12 +59,12 @@ class ProductSearch extends Component {
 			<div className="product-search">
 				<SearchCard
 					ref="searchCard"
-					onSearch={ this.onSearch }
+					onSearch={ this.handleSearch }
 					delaySearch
 					delayTimeout={ 400 }
 					placeholder={ translate( 'Search products…' ) }
 				/>
-				<ProductSearchResults search={ this.state.query } onSelect={ this.onSelect } />
+				<ProductSearchResults search={ this.state.query } onSelect={ this.handleSelect } />
 			</div>
 		);
 	}

--- a/client/extensions/woocommerce/components/product-search/index.js
+++ b/client/extensions/woocommerce/components/product-search/index.js
@@ -1,0 +1,64 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+import { trim } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import {
+	fetchProductSearchResults,
+	clearProductSearch,
+} from 'woocommerce/state/sites/products/actions';
+import ProductSearchResults from './results';
+import SearchCard from 'components/search-card';
+
+class ProductSearch extends Component {
+	state = {
+		query: '',
+	};
+
+	onSearch = query => {
+		const { siteId } = this.props;
+
+		if ( trim( query ) === '' ) {
+			this.setState( { query: '' } );
+			this.props.clearProductSearch( siteId );
+			return;
+		}
+
+		this.setState( { query } );
+		this.props.fetchProductSearchResults( siteId, 1, query );
+	};
+
+	render() {
+		const { translate } = this.props;
+
+		return (
+			<div className="product-search">
+				<SearchCard
+					onSearch={ this.onSearch }
+					delaySearch
+					delayTimeout={ 400 }
+					placeholder={ translate( 'Search products…' ) }
+				/>
+				<ProductSearchResults search={ this.state.query } />
+			</div>
+		);
+	}
+}
+
+export default connect( null, dispatch =>
+	bindActionCreators(
+		{
+			fetchProductSearchResults,
+			clearProductSearch,
+		},
+		dispatch
+	)
+)( localize( ProductSearch ) );

--- a/client/extensions/woocommerce/components/product-search/item.js
+++ b/client/extensions/woocommerce/components/product-search/item.js
@@ -74,7 +74,8 @@ class ProductItem extends Component {
 			productList = variations.map( v => {
 				const name = product.name + ' – ' + formattedVariationName( v );
 				const key = product.id + '-' + v.id;
-				return { ...product, name, key, sku: v.sku, variation: v.id };
+				const images = v.image ? [ v.image ] : product.images;
+				return { ...product, name, key, images, sku: v.sku, variation: v.id };
 			} );
 		}
 

--- a/client/extensions/woocommerce/components/product-search/item.js
+++ b/client/extensions/woocommerce/components/product-search/item.js
@@ -5,11 +5,26 @@
 import React from 'react';
 import CompactCard from 'components/card/compact';
 
-const ProductItem = ( { product } ) => {
+/**
+ * Internal dependencies
+ */
+import getKeyboardHandler from 'woocommerce/lib/get-keyboard-handler';
+
+const ProductItem = ( { product, onClick } ) => {
 	const featuredImage = product.images && product.images[ 0 ];
 
+	const onClickProduct = () => {
+		onClick( product );
+	};
+
 	return (
-		<CompactCard className="product-search__item">
+		<CompactCard
+			className="product-search__item"
+			role="button"
+			tabIndex="0"
+			onClick={ onClickProduct }
+			onKeyDown={ getKeyboardHandler( onClickProduct ) }
+		>
 			<div className="product-search__image">
 				{ featuredImage && <img src={ featuredImage.src } /> }
 			</div>

--- a/client/extensions/woocommerce/components/product-search/item.js
+++ b/client/extensions/woocommerce/components/product-search/item.js
@@ -2,38 +2,89 @@
 /**
  * External dependencies
  */
-import React from 'react';
-import CompactCard from 'components/card/compact';
+import React, { Component } from 'react';
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
  */
+import CompactCard from 'components/card/compact';
+import { fetchProductVariations } from 'woocommerce/state/sites/product-variations/actions';
+import formattedVariationName from 'woocommerce/lib/formatted-variation-name';
 import getKeyboardHandler from 'woocommerce/lib/get-keyboard-handler';
+import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
+import { getVariationsForProduct } from 'woocommerce/state/sites/product-variations/selectors';
 
-const ProductItem = ( { product, onClick } ) => {
-	const featuredImage = product.images && product.images[ 0 ];
+class ProductItem extends Component {
+	componentDidMount() {
+		const { siteId, productId } = this.props;
 
-	const onClickProduct = () => {
-		onClick( product );
+		if ( siteId ) {
+			this.props.fetchProductVariations( siteId, productId );
+		}
+	}
+
+	componentWillReceiveProps( newProps ) {
+		const { siteId, productId } = this.props;
+		if ( newProps.productId !== productId || newProps.siteId !== siteId ) {
+			this.props.fetchProductVariations( newProps.siteId, newProps.productId );
+		}
+	}
+
+	onClick = () => {
+		const { product } = this.props;
+		this.props.onClick( product );
 	};
 
-	return (
-		<CompactCard
-			className="product-search__item"
-			role="button"
-			tabIndex="0"
-			onClick={ onClickProduct }
-			onKeyDown={ getKeyboardHandler( onClickProduct ) }
-		>
-			<div className="product-search__image">
-				{ featuredImage && <img src={ featuredImage.src } /> }
-			</div>
-			<div className="product-search__label">
-				<div className="product-search__name">{ product.name }</div>
-				<div className="product-search__sku">{ product.sku }</div>
-			</div>
-		</CompactCard>
-	);
-};
+	renderItem = product => {
+		const featuredImage = product.images && product.images[ 0 ];
+		return (
+			<CompactCard
+				key={ product.key }
+				className="product-search__item"
+				role="button"
+				tabIndex="0"
+				onClick={ this.onClick }
+				onKeyDown={ getKeyboardHandler( this.onClick ) }
+			>
+				<div className="product-search__image">
+					{ featuredImage && <img src={ featuredImage.src } /> }
+				</div>
+				<div className="product-search__label">
+					<div className="product-search__name">{ product.name }</div>
+					<div className="product-search__sku">{ product.sku }</div>
+				</div>
+			</CompactCard>
+		);
+	};
 
-export default ProductItem;
+	render() {
+		const { product, variations } = this.props;
+		let productList = [ { ...product, key: product.id } ];
+
+		if ( variations.length ) {
+			productList = variations.map( v => {
+				const name = product.name + ' – ' + formattedVariationName( v );
+				const key = product.id + '-' + v.id;
+				return { ...product, name, key, sku: v.sku, variation: v.id };
+			} );
+		}
+
+		return <div>{ productList.map( this.renderItem ) }</div>;
+	}
+}
+
+export default connect(
+	( state, props ) => {
+		const productId = props.product.id;
+		const site = getSelectedSiteWithFallback( state );
+
+		return {
+			productId,
+			siteId: site && site.ID,
+			variations: getVariationsForProduct( state, productId ) || [],
+		};
+	},
+	dispatch => bindActionCreators( { fetchProductVariations }, dispatch )
+)( ProductItem );

--- a/client/extensions/woocommerce/components/product-search/item.js
+++ b/client/extensions/woocommerce/components/product-search/item.js
@@ -1,0 +1,24 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import React from 'react';
+import CompactCard from 'components/card/compact';
+
+const ProductItem = ( { product } ) => {
+	const featuredImage = product.images && product.images[ 0 ];
+
+	return (
+		<CompactCard className="product-search__item">
+			<div className="product-search__image">
+				{ featuredImage && <img src={ featuredImage.src } /> }
+			</div>
+			<div className="product-search__label">
+				<div className="product-search__name">{ product.name }</div>
+				<div className="product-search__sku">{ product.sku }</div>
+			</div>
+		</CompactCard>
+	);
+};
+
+export default ProductItem;

--- a/client/extensions/woocommerce/components/product-search/item.js
+++ b/client/extensions/woocommerce/components/product-search/item.js
@@ -3,8 +3,10 @@
  * External dependencies
  */
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -17,6 +19,11 @@ import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
 import { getVariationsForProduct } from 'woocommerce/state/sites/product-variations/selectors';
 
 class ProductItem extends Component {
+	static propTypes = {
+		onClick: PropTypes.func.isRequired,
+		product: PropTypes.object.isRequired,
+	};
+
 	componentDidMount() {
 		const { siteId, productId } = this.props;
 
@@ -32,21 +39,21 @@ class ProductItem extends Component {
 		}
 	}
 
-	onClick = () => {
+	handleClick = () => {
 		const { product } = this.props;
 		this.props.onClick( product );
 	};
 
 	renderItem = product => {
-		const featuredImage = product.images && product.images[ 0 ];
+		const featuredImage = get( product, 'images[0]', false );
 		return (
 			<CompactCard
 				key={ product.key }
 				className="product-search__item"
 				role="button"
 				tabIndex="0"
-				onClick={ this.onClick }
-				onKeyDown={ getKeyboardHandler( this.onClick ) }
+				onClick={ this.handleClick }
+				onKeyDown={ getKeyboardHandler( this.handleClick ) }
 			>
 				<div className="product-search__image">
 					{ featuredImage && <img src={ featuredImage.src } /> }
@@ -63,7 +70,7 @@ class ProductItem extends Component {
 		const { product, variations } = this.props;
 		let productList = [ { ...product, key: product.id } ];
 
-		if ( variations.length ) {
+		if ( variations ) {
 			productList = variations.map( v => {
 				const name = product.name + ' – ' + formattedVariationName( v );
 				const key = product.id + '-' + v.id;
@@ -82,8 +89,8 @@ export default connect(
 
 		return {
 			productId,
-			siteId: site && site.ID,
-			variations: getVariationsForProduct( state, productId ) || [],
+			siteId: get( site, 'ID' ),
+			variations: getVariationsForProduct( state, productId ),
 		};
 	},
 	dispatch => bindActionCreators( { fetchProductVariations }, dispatch )

--- a/client/extensions/woocommerce/components/product-search/item.js
+++ b/client/extensions/woocommerce/components/product-search/item.js
@@ -53,19 +53,19 @@ class ProductItem extends Component {
 			const lowercasePart = part.toLowerCase();
 			if ( lowercasePart === highlightedText ) {
 				return (
-					<span key={ key } className="product-search__value-emphasis">
+					<span aria-hidden key={ key } className="product-search__value-emphasis">
 						{ part }
 					</span>
 				);
 			}
 			return (
-				<span key={ key } className="product-search__value-normal">
+				<span aria-hidden key={ key } className="product-search__value-normal">
 					{ part }
 				</span>
 			);
 		} );
 
-		return token;
+		return <span aria-label={ text }>{ token }</span>;
 	};
 
 	renderItem = product => {

--- a/client/extensions/woocommerce/components/product-search/item.js
+++ b/client/extensions/woocommerce/components/product-search/item.js
@@ -44,7 +44,32 @@ class ProductItem extends Component {
 		this.props.onClick( product );
 	};
 
+	createTextWithHighlight = ( text, highlightedText ) => {
+		highlightedText = highlightedText.toLowerCase();
+		const re = new RegExp( '(' + highlightedText + ')', 'gi' );
+		const parts = text.split( re );
+		const token = parts.map( ( part, i ) => {
+			const key = text + i;
+			const lowercasePart = part.toLowerCase();
+			if ( lowercasePart === highlightedText ) {
+				return (
+					<span key={ key } className="product-search__value-emphasis">
+						{ part }
+					</span>
+				);
+			}
+			return (
+				<span key={ key } className="product-search__value-normal">
+					{ part }
+				</span>
+			);
+		} );
+
+		return token;
+	};
+
 	renderItem = product => {
+		const { search } = this.props;
 		const featuredImage = get( product, 'images[0]', false );
 		return (
 			<CompactCard
@@ -59,7 +84,9 @@ class ProductItem extends Component {
 					{ featuredImage && <img src={ featuredImage.src } /> }
 				</div>
 				<div className="product-search__label">
-					<div className="product-search__name">{ product.name }</div>
+					<div className="product-search__name">
+						{ this.createTextWithHighlight( product.name, search ) }
+					</div>
 					<div className="product-search__sku">{ product.sku }</div>
 				</div>
 			</CompactCard>

--- a/client/extensions/woocommerce/components/product-search/results.js
+++ b/client/extensions/woocommerce/components/product-search/results.js
@@ -20,6 +20,7 @@ import ProductItem from './item';
 
 class ProductSearchResults extends Component {
 	static propTypes = {
+		onSelect: PropTypes.func.isRequired,
 		search: PropTypes.string.isRequired,
 	};
 
@@ -40,6 +41,7 @@ class ProductSearchResults extends Component {
 		);
 	}
 }
+
 export default connect( ( state, props ) => {
 	const query = {
 		page: 1,

--- a/client/extensions/woocommerce/components/product-search/results.js
+++ b/client/extensions/woocommerce/components/product-search/results.js
@@ -24,7 +24,7 @@ class ProductSearchResults extends Component {
 	};
 
 	render() {
-		const { isLoaded, isLoading, products, search, translate } = this.props;
+		const { isLoaded, isLoading, onSelect, products, search, translate } = this.props;
 		if ( ( ! isLoaded && ! search ) || isLoading ) {
 			return null;
 		}
@@ -32,7 +32,7 @@ class ProductSearchResults extends Component {
 		return (
 			<div className="product-search__results">
 				{ products.length ? (
-					products.map( p => <ProductItem key={ p.id } product={ p } /> )
+					products.map( p => <ProductItem key={ p.id } product={ p } onClick={ onSelect } /> )
 				) : (
 					<Card>{ translate( 'No results for %(search)s', { args: { search } } ) }</Card>
 				) }

--- a/client/extensions/woocommerce/components/product-search/results.js
+++ b/client/extensions/woocommerce/components/product-search/results.js
@@ -16,6 +16,7 @@ import {
 	areProductSearchResultsLoading,
 } from 'woocommerce/state/sites/products/selectors';
 import { getProductSearchResults } from 'woocommerce/state/ui/products/selectors';
+import ProductItem from './item';
 
 class ProductSearchResults extends Component {
 	static propTypes = {
@@ -24,17 +25,19 @@ class ProductSearchResults extends Component {
 
 	render() {
 		const { isLoaded, isLoading, products, search, translate } = this.props;
-		let results;
-		if ( ! isLoaded && ! search ) {
-			results = <p>{ translate( 'Please enter a search term.' ) }</p>;
-		} else if ( isLoading ) {
-			results = <p>{ translate( 'Searching…' ) }</p>;
-		} else if ( ! products.length ) {
-			results = <p>{ translate( 'No results for %(search)s', { args: { search } } ) }</p>;
-		} else {
-			results = <ul>{ products.map( p => <li key={ p.id }>{ p.name }</li> ) }</ul>;
+		if ( ( ! isLoaded && ! search ) || isLoading ) {
+			return null;
 		}
-		return <Card>{ results }</Card>;
+
+		return (
+			<div className="product-search__results">
+				{ products.length ? (
+					products.map( p => <ProductItem key={ p.id } product={ p } /> )
+				) : (
+					<Card>{ translate( 'No results for %(search)s', { args: { search } } ) }</Card>
+				) }
+			</div>
+		);
 	}
 }
 export default connect( ( state, props ) => {

--- a/client/extensions/woocommerce/components/product-search/results.js
+++ b/client/extensions/woocommerce/components/product-search/results.js
@@ -4,13 +4,15 @@
  */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
+import Gridicon from 'gridicons';
 
 /**
  * Internal dependencies
  */
-import Card from 'components/card';
+import CompactCard from 'components/card/compact';
 import {
 	areProductSearchResultsLoaded,
 	areProductSearchResultsLoading,
@@ -24,18 +26,62 @@ class ProductSearchResults extends Component {
 		search: PropTypes.string.isRequired,
 	};
 
+	renderLoading = () => {
+		return (
+			<div className="product-search__results is-placeholder">
+				<CompactCard className="product-search__item">
+					<div className="product-search__image">
+						<span />
+					</div>
+					<div className="product-search__label">
+						<div className="product-search__name">
+							<span />
+						</div>
+						<div className="product-search__sku">
+							<span />
+						</div>
+					</div>
+				</CompactCard>
+			</div>
+		);
+	};
+
+	renderNotFound = () => {
+		const { translate } = this.props;
+		return (
+			<CompactCard className="product-search__item">
+				<div className="product-search__image">
+					<Gridicon icon="info-outline" />
+				</div>
+				<div className="product-search__label">
+					<div className="product-search__name">{ translate( 'No products found' ) }</div>
+					<div className="product-search__sku">{ translate( 'Please try another search' ) }</div>
+				</div>
+			</CompactCard>
+		);
+	};
+
 	render() {
-		const { isLoaded, isLoading, onSelect, products, search, translate } = this.props;
-		if ( ( ! isLoaded && ! search ) || isLoading ) {
+		const { isLoaded, isLoading, onSelect, products, search } = this.props;
+		if ( ! isLoaded && ! search ) {
 			return null;
 		}
 
+		if ( isLoading ) {
+			return this.renderLoading();
+		}
+
+		const classes = classNames( {
+			'product-search__results': true,
+			'is-not-found': ! products.length,
+		} );
+
 		return (
-			<div className="product-search__results">
+			<div className={ classes }>
 				{ products.length ? (
 					products.map( p => <ProductItem key={ p.id } product={ p } onClick={ onSelect } /> )
 				) : (
-					<Card>{ translate( 'No results for %(search)s', { args: { search } } ) }</Card>
+					this.renderNotFound()
 				) }
 			</div>
 		);

--- a/client/extensions/woocommerce/components/product-search/results.js
+++ b/client/extensions/woocommerce/components/product-search/results.js
@@ -1,0 +1,52 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Card from 'components/card';
+import {
+	areProductSearchResultsLoaded,
+	areProductSearchResultsLoading,
+} from 'woocommerce/state/sites/products/selectors';
+import { getProductSearchResults } from 'woocommerce/state/ui/products/selectors';
+
+class ProductSearchResults extends Component {
+	static propTypes = {
+		search: PropTypes.string.isRequired,
+	};
+
+	render() {
+		const { isLoaded, isLoading, products, search, translate } = this.props;
+		let results;
+		if ( ! isLoaded && ! search ) {
+			results = <p>{ translate( 'Please enter a search term.' ) }</p>;
+		} else if ( isLoading ) {
+			results = <p>{ translate( 'Searching…' ) }</p>;
+		} else if ( ! products.length ) {
+			results = <p>{ translate( 'No results for %(search)s', { args: { search } } ) }</p>;
+		} else {
+			results = <ul>{ products.map( p => <li key={ p.id }>{ p.name }</li> ) }</ul>;
+		}
+		return <Card>{ results }</Card>;
+	}
+}
+export default connect( ( state, props ) => {
+	const query = {
+		page: 1,
+		per_page: 10,
+		search: props.search,
+	};
+
+	return {
+		isLoaded: areProductSearchResultsLoaded( state, query ),
+		isLoading: areProductSearchResultsLoading( state, query ),
+		products: getProductSearchResults( state ) || [],
+	};
+} )( localize( ProductSearchResults ) );

--- a/client/extensions/woocommerce/components/product-search/results.js
+++ b/client/extensions/woocommerce/components/product-search/results.js
@@ -79,7 +79,9 @@ class ProductSearchResults extends Component {
 		return (
 			<div className={ classes }>
 				{ products.length ? (
-					products.map( p => <ProductItem key={ p.id } product={ p } onClick={ onSelect } /> )
+					products.map( p => (
+						<ProductItem key={ p.id } onClick={ onSelect } product={ p } search={ search } />
+					) )
 				) : (
 					this.renderNotFound()
 				) }

--- a/client/extensions/woocommerce/components/product-search/style.scss
+++ b/client/extensions/woocommerce/components/product-search/style.scss
@@ -1,0 +1,43 @@
+.product-search {
+	position: relative;
+}
+
+.product-search__results {
+	position: absolute;
+	top: 52px;
+	width: 100%;
+	z-index: 1;
+}
+
+.product-search__item {
+	display: flex;
+}
+
+.product-search__image {
+	flex: 0 0 40px;
+	height: 40px;
+	width: 40px;
+	overflow: hidden;
+	position: relative;
+	margin-right: 16px;
+
+	img {
+		position: absolute;
+		left: 50%;
+		top: 50%;
+		height: 100%;
+		width: auto;
+		-webkit-transform: translate(-50%, -50%);
+		transform: translate(-50%, -50%);
+	}
+}
+
+.product-search__label {
+	flex: 1;
+
+	.product-search__sku {
+		color: $gray-text-min;
+		font-size: 11px;
+		text-transform: uppercase;
+	}
+}

--- a/client/extensions/woocommerce/components/product-search/style.scss
+++ b/client/extensions/woocommerce/components/product-search/style.scss
@@ -1,16 +1,20 @@
 .product-search {
 	position: relative;
+
+	.search-card {
+		box-shadow: none;
+		border: 1px solid lighten( $gray, 30% );
+	}
 }
 
 .product-search__results {
 	position: absolute;
-	top: 52px;
+	top: 100%;
 	z-index: 1;
-	margin: 0 -5px;
-	padding: 0 5px 5px;
 	width: 100%;
 	max-height: 250px;
 	overflow-y: scroll;
+	border-bottom: 1px solid lighten( $gray, 30% );
 
 	&.is-placeholder {
 		overflow-y: visible;
@@ -52,11 +56,21 @@
 			text-transform: none;
 		}
 	}
+
+	> div:first-child {
+		.product-search__item {
+			border-top: 0;
+		}
+	}
 }
 
 .product-search__item {
 	display: flex;
 	cursor: pointer;
+	box-shadow: none;
+	border: 1px solid lighten( $gray, 30% );
+	border-bottom-width: 0;
+	margin: 0;
 
 	.accessible-focus &:focus {
 		box-shadow: 0 0 0 1px $blue-wordpress, 0 0 0 4px $blue-light;

--- a/client/extensions/woocommerce/components/product-search/style.scss
+++ b/client/extensions/woocommerce/components/product-search/style.scss
@@ -11,6 +11,12 @@
 
 .product-search__item {
 	display: flex;
+	cursor: pointer;
+
+	.accessible-focus &:focus {
+		box-shadow: 0 0 0 1px $blue-wordpress, 0 0 0 4px $blue-light;
+		z-index: 2;
+	}
 }
 
 .product-search__image {

--- a/client/extensions/woocommerce/components/product-search/style.scss
+++ b/client/extensions/woocommerce/components/product-search/style.scss
@@ -3,7 +3,7 @@
 
 	.search-card {
 		box-shadow: none;
-		border: 1px solid lighten( $gray, 30% );
+		border: 1px solid darken( $gray-light, 10% );
 	}
 }
 
@@ -12,9 +12,9 @@
 	top: 100%;
 	z-index: 1;
 	width: 100%;
-	max-height: 250px;
+	max-height: 275px;
 	overflow-y: scroll;
-	border-bottom: 1px solid lighten( $gray, 30% );
+	border-bottom: 1px solid darken( $gray-light, 10% );
 
 	&.is-placeholder {
 		overflow-y: visible;
@@ -68,13 +68,19 @@
 	display: flex;
 	cursor: pointer;
 	box-shadow: none;
-	border: 1px solid lighten( $gray, 30% );
+	border: 1px solid darken( $gray-light, 10% );
 	border-bottom-width: 0;
 	margin: 0;
+	padding: 10px;
 
-	.accessible-focus &:focus {
-		box-shadow: 0 0 0 1px $blue-wordpress, 0 0 0 4px $blue-light;
-		z-index: 2;
+	.accessible-focus &:focus,
+	&:hover {
+		background: $blue-medium;
+		color: $white;
+
+		.product-search__sku {
+			color: $white;
+		}
 	}
 }
 
@@ -84,7 +90,12 @@
 	width: 40px;
 	overflow: hidden;
 	position: relative;
-	margin-right: 16px;
+	margin-right: 10px;
+
+	&:empty {
+		border: 1px solid darken( $gray-light, 10% );
+		box-sizing: border-box;
+	}
 
 	img {
 		position: absolute;

--- a/client/extensions/woocommerce/components/product-search/style.scss
+++ b/client/extensions/woocommerce/components/product-search/style.scss
@@ -5,8 +5,12 @@
 .product-search__results {
 	position: absolute;
 	top: 52px;
-	width: 100%;
 	z-index: 1;
+	margin: 0 -5px;
+	padding: 0 5px 5px;
+	width: 100%;
+	max-height: 250px;
+	overflow: scroll;
 }
 
 .product-search__item {

--- a/client/extensions/woocommerce/components/product-search/style.scss
+++ b/client/extensions/woocommerce/components/product-search/style.scss
@@ -5,6 +5,10 @@
 		box-shadow: none;
 		border: 1px solid darken( $gray-light, 10% );
 	}
+
+	div.has-focus {
+		box-shadow: 0 0 0 1px $blue-wordpress, 0 0 0 4px $blue-light;
+	}
 }
 
 .product-search__results {

--- a/client/extensions/woocommerce/components/product-search/style.scss
+++ b/client/extensions/woocommerce/components/product-search/style.scss
@@ -10,7 +10,48 @@
 	padding: 0 5px 5px;
 	width: 100%;
 	max-height: 250px;
-	overflow: scroll;
+	overflow-y: scroll;
+
+	&.is-placeholder {
+		overflow-y: visible;
+
+		span {
+			display: inline-block;
+			width: 100%;
+			@include placeholder();
+		}
+
+		.product-search__image span {
+			height: 40px;
+			width: 40px;
+		}
+
+		.product-search__name span {
+			height: 20px;
+			width: 35%;
+		}
+
+		.product-search__sku span {
+			margin-top: 2px;
+			height: 12px;
+			width: 30%;
+		}
+	}
+
+	&.is-not-found {
+		overflow-y: visible;
+
+		.product-search__image {
+			padding: 8px;
+			flex: 0 0 24px;
+			height: 24px;
+			width: 24px;
+		}
+
+		.product-search__sku {
+			text-transform: none;
+		}
+	}
 }
 
 .product-search__item {

--- a/client/extensions/woocommerce/components/product-search/style.scss
+++ b/client/extensions/woocommerce/components/product-search/style.scss
@@ -86,6 +86,10 @@
 			color: $white;
 		}
 	}
+
+	.product-search__value-emphasis {
+		font-weight: bold;
+	}
 }
 
 .product-search__image {

--- a/client/extensions/woocommerce/components/product-search/style.scss
+++ b/client/extensions/woocommerce/components/product-search/style.scss
@@ -49,6 +49,19 @@
 	&.is-not-found {
 		overflow-y: visible;
 
+		.product-search__item {
+			cursor: default;
+
+			&:hover {
+				background: $white;
+				color: $gray-text;
+
+				.product-search__sku {
+					color: $gray-text-min;
+				}
+			}
+		}
+
 		.product-search__image {
 			padding: 8px;
 			flex: 0 0 24px;

--- a/client/extensions/woocommerce/style.scss
+++ b/client/extensions/woocommerce/style.scss
@@ -39,6 +39,7 @@
 	@import 'components/process-orders-widget/style';
 	@import 'components/product-image-uploader/style';
 	@import 'components/product-reviews-widget/style';
+	@import 'components/product-search/style';
 	@import 'components/reading-widget/style';
 	@import 'components/share-widget/style';
 	@import 'components/sparkline/style';


### PR DESCRIPTION
This PR creates a new component, `ProductSearch`, which displays a `SearchCard` and is used to search through a site's projects. This will eventually be used on the order edit & creation screens, and might be useful elsewhere.

![screen shot 2017-09-27 at 6 54 06 pm](https://user-images.githubusercontent.com/541093/30941784-4397d2a6-a3b5-11e7-9be4-0d0ad97f8f7e.png)

In addition to returning matching products, it auto-expands variations into selectable items:

![screen shot 2017-09-27 at 6 48 49 pm](https://user-images.githubusercontent.com/541093/30941656-91017e9e-a3b4-11e7-8a19-7069314aaf0e.png)

It's up to the parent component to pass a prop `onSelect`, which fires when a result is clicked.

Currently the only required prop is the `onSelect` function, but I could also see maybe wanting to control whether variations are included - let me know if that would be useful 🙂 

To test:

- This is currently used on the create order page, so you can visit there to test it: `/store/order/:site`
- Try searching a few different products, things that don't exist, products with and without variations, etc.
- Clicking a result selects it, but nothing is being done with the selected object yet, so it should just close the result set.
- Keyboard navigation (tabbing to items, using space or enter to select) should also work like clicking