### PR TITLE
Pages: Fix display of no search results and no pages

### DIFF
--- a/client/my-sites/pages/page-list.jsx
+++ b/client/my-sites/pages/page-list.jsx
@@ -98,6 +98,7 @@ const Pages = createReactClass( {
 		siteId: PropTypes.any,
 		hasSites: PropTypes.bool.isRequired,
 		trackScrollPage: PropTypes.func.isRequired,
+		query: PropTypes.object,
 	},
 
 	getDefaultProps() {
@@ -156,8 +157,8 @@ const Pages = createReactClass( {
 	},
 
 	getNoContentMessage() {
-		const { translate } = this.props;
-		const { search, status = 'published' } = this.props.query;
+		const { query = {}, translate, site, siteId } = this.props;
+		const { search, status = 'published' } = query;
 
 		if ( search ) {
 			return (
@@ -172,9 +173,8 @@ const Pages = createReactClass( {
 			);
 		}
 
-		const { site, siteId } = this.props;
 		const sitePart = ( site && site.slug ) || siteId;
-		const newPageLink = this.props.siteId ? '/page/' + sitePart : '/page';
+		const newPageLink = siteId ? '/page/' + sitePart : '/page';
 		let attributes;
 
 		switch ( status ) {

--- a/client/my-sites/pages/page-list.jsx
+++ b/client/my-sites/pages/page-list.jsx
@@ -156,7 +156,8 @@ const Pages = createReactClass( {
 	},
 
 	getNoContentMessage() {
-		const { search, translate } = this.props;
+		const { translate } = this.props;
+		const { search, status = 'published' } = this.props.query;
 
 		if ( search ) {
 			return (
@@ -171,13 +172,13 @@ const Pages = createReactClass( {
 			);
 		}
 
-		const { site, siteId, status = 'published' } = this.props;
+		const { site, siteId } = this.props;
 		const sitePart = ( site && site.slug ) || siteId;
 		const newPageLink = this.props.siteId ? '/page/' + sitePart : '/page';
 		let attributes;
 
 		switch ( status ) {
-			case 'drafts':
+			case 'draft,pending':
 				attributes = {
 					title: translate( "You don't have any drafts." ),
 					line: translate( 'Would you like to create one?' ),
@@ -185,7 +186,7 @@ const Pages = createReactClass( {
 					actionURL: newPageLink,
 				};
 				break;
-			case 'scheduled':
+			case 'future':
 				attributes = {
 					title: translate( "You don't have any scheduled pages yet." ),
 					line: translate( 'Would you like to create one?' ),
@@ -193,7 +194,7 @@ const Pages = createReactClass( {
 					actionURL: newPageLink,
 				};
 				break;
-			case 'trashed':
+			case 'trash':
 				attributes = {
 					title: translate( "You don't have any pages in your trash folder." ),
 					line: translate( 'Everything you write is solid gold.' ),


### PR DESCRIPTION
This fixes #18306. I also noticed while testing this that all of the `<EmptyContent/>` messages were the same default case. This PR fixes that issue too.

Before | After
------------ | -------------
![image](https://user-images.githubusercontent.com/448298/30949187-ebc9be12-a3e2-11e7-8e2e-6aa363ef9448.png) | ![image](https://user-images.githubusercontent.com/448298/30949196-f886ce60-a3e2-11e7-90a7-5019189bbefe.png)
![image](https://user-images.githubusercontent.com/448298/30949205-0bb29e88-a3e3-11e7-8ae8-1d1c3edc4960.png) | ![image](https://user-images.githubusercontent.com/448298/30949211-14f90c2a-a3e3-11e7-8b69-8ed19beef6d6.png)

#### Testing

1. Run `git checkout fix/pages-empty-content` or open a [live branch](https://calypso.live/?branch=fix/pages-empty-content)
2. Visit your pages at http://calypso.localhost:3000/pages
3. Enter a search with no matches
4. Assert that you see the proper `No pages match your search ...` message
5. Close the search and switch between Published, Drafts, Scheduled, and Trashed
6. Assert that the messaging changes with each route change