### PR TITLE
Codemods: Remove repetition in i18n-mixin codemod

### DIFF
--- a/bin/codemods/src/i18n-mixin-to-localize.js
+++ b/bin/codemods/src/i18n-mixin-to-localize.js
@@ -88,52 +88,30 @@ export default function transformer( file, api ) {
 	}
 
 	createClassesInstances.forEach( createClassInstance => {
-		const thisTranslateInstances = j( createClassInstance ).find( j.MemberExpression, {
-			object: { type: 'ThisExpression' },
-			property: {
-				type: 'Identifier',
-				name: 'translate',
-			},
-		} );
-		thisTranslateInstances.replaceWith( () =>
-			j.memberExpression(
-				j.memberExpression( j.thisExpression(), j.identifier( 'props' ) ),
-				j.identifier( 'translate' )
-			)
-		);
-		const thisMomentInstances = j( createClassInstance ).find( j.MemberExpression, {
-			object: { type: 'ThisExpression' },
-			property: {
-				type: 'Identifier',
-				name: 'moment',
-			},
-		} );
-		thisMomentInstances.replaceWith( () =>
-			j.memberExpression(
-				j.memberExpression( j.thisExpression(), j.identifier( 'props' ) ),
-				j.identifier( 'moment' )
-			)
-		);
-		const thisNumberFormatInstances = j( createClassInstance ).find( j.MemberExpression, {
-			object: { type: 'ThisExpression' },
-			property: {
-				type: 'Identifier',
-				name: 'numberFormat',
-			},
-		} );
-		thisNumberFormatInstances.replaceWith( () =>
-			j.memberExpression(
-				j.memberExpression( j.thisExpression(), j.identifier( 'props' ) ),
-				j.identifier( 'numberFormat' )
-			)
-		);
-		if (
-			thisTranslateInstances.size() ||
-			thisMomentInstances.size() ||
-			thisNumberFormatInstances.size()
-		) {
-			foundMixinUsage = true;
+		const propertiesToModify = [ 'translate', 'moment', 'numberFormat' ];
 
+		propertiesToModify.forEach( property => {
+			const propertyInstances = j( createClassInstance ).find( j.MemberExpression, {
+				object: { type: 'ThisExpression' },
+				property: {
+					type: 'Identifier',
+					name: property,
+				},
+			} );
+
+			propertyInstances.replaceWith( () =>
+				j.memberExpression(
+					j.memberExpression( j.thisExpression(), j.identifier( 'props' ) ),
+					j.identifier( property )
+				)
+			);
+
+			if ( propertyInstances.size() ) {
+				foundMixinUsage = true;
+			}
+		} );
+
+		if ( foundMixinUsage ) {
 			const declarationsToWrap = findDeclarationsToWrap( createClassInstance );
 			declarationsToWrap.replaceWith( decl => {
 				return j.callExpression( j.identifier( 'localize' ), [ decl.value ] );


### PR DESCRIPTION
In #18097 we introduced a quick fix to the i18n codemod to also convert `moment` and `numberFormat` instances. While it was working just fine, it was unnecessarily repeating some code.

This PR updates the codemod to reuse the same code for handling all of the i18n methods. This PR is not supposed to be introducing any functional or behavioral changes.

To test:
* Checkout this branch
* Run the codemod on files that have one or more instances of:
  * `i18n.translate`
  * `i18n.moment`
  * `i18n.numberFormat`
* Verify all of the instances are still converted properly.
* Verify the codemod still works as before when skipping files.