### PR TITLE
Comments: Enable edit and bulk actions in all environments

### DIFF
--- a/client/blocks/comment-detail/comment-detail-actions.jsx
+++ b/client/blocks/comment-detail/comment-detail-actions.jsx
@@ -11,7 +11,6 @@ import { includes } from 'lodash';
  * Internal dependencies
  */
 import Button from 'components/button';
-import { isEnabled } from 'config';
 
 const commentActions = {
 	unapproved: [ 'like', 'approve', 'edit', 'spam', 'trash' ],
@@ -69,7 +68,7 @@ export const CommentDetailActions = ( {
 				</Button>
 			}
 
-			{ hasAction( commentStatus, 'edit' ) && isEnabled( 'comments/management/edit' ) &&
+			{ hasAction( commentStatus, 'edit' ) &&
 				<Button
 					borderless
 					className="comment-detail__action-edit"

--- a/client/my-sites/comments/comment-navigation/index.jsx
+++ b/client/my-sites/comments/comment-navigation/index.jsx
@@ -231,11 +231,9 @@ export class CommentNavigation extends Component {
 						</SegmentedControl>
 					}
 
-					{ isEnabled( 'manage/comments/bulk-actions' ) &&
-						<Button compact onClick={ toggleBulkEdit }>
-							{ translate( 'Bulk Edit' ) }
-						</Button>
-					}
+					<Button compact onClick={ toggleBulkEdit }>
+						{ translate( 'Bulk Edit' ) }
+					</Button>
 				</CommentNavigationTab>
 
 				{ hasSearch &&

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -18,7 +18,6 @@
 		"code-splitting": false,
 		"comments/management": true,
 		"comments/management/sorting": false,
-		"manage/comments/bulk-actions": false,
 		"desktop": true,
 		"desktop-promo": false,
 		"domains/cctlds": true,

--- a/config/development.json
+++ b/config/development.json
@@ -41,7 +41,6 @@
 		"comments/filters-in-posts": true,
 		"comments/moderation-tools-in-posts": true,
 		"comments/management": true,
-		"comments/management/edit": true,
 		"comments/management/sorting": true,
 		"manage/comments/bulk-actions": true,
 		"css-hot-reload": true,

--- a/config/development.json
+++ b/config/development.json
@@ -42,7 +42,6 @@
 		"comments/moderation-tools-in-posts": true,
 		"comments/management": true,
 		"comments/management/sorting": true,
-		"manage/comments/bulk-actions": true,
 		"css-hot-reload": true,
 		"desktop-promo": true,
 		"devdocs": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -19,7 +19,6 @@
 		"catch-js-errors": true,
 		"code-splitting": true,
 		"comments/management": true,
-		"comments/management/edit": true,
 		"comments/management/sorting": true,
 		"manage/comments/bulk-actions": true,
 		"devdocs": false,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -20,7 +20,6 @@
 		"code-splitting": true,
 		"comments/management": true,
 		"comments/management/sorting": true,
-		"manage/comments/bulk-actions": true,
 		"devdocs": false,
 		"domains/cctlds": true,
 		"domains/cctlds/ca": true,

--- a/config/production.json
+++ b/config/production.json
@@ -19,7 +19,6 @@
 		"code-splitting": true,
 		"comments/management": true,
 		"comments/management/sorting": false,
-		"manage/comments/bulk-actions": false,
 		"desktop-promo": true,
 		"domains/cctlds": true,
 		"domains/cctlds/ca": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -21,7 +21,6 @@
 		"code-splitting": true,
 		"comments/management": true,
 		"comments/management/sorting": false,
-		"manage/comments/bulk-actions": false,
 		"desktop-promo": true,
 		"domains/cctlds": true,
 		"domains/cctlds/ca": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -19,7 +19,6 @@
 		"apple-pay": true,
 		"comments/management": true,
 		"comments/management/sorting": true,
-		"manage/comments/bulk-actions": true,
 		"catch-js-errors": true,
 		"code-splitting": true,
 		"desktop-promo": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -18,7 +18,6 @@
 		"automated-transfer": true,
 		"apple-pay": true,
 		"comments/management": true,
-		"comments/management/edit": true,
 		"comments/management/sorting": true,
 		"manage/comments/bulk-actions": true,
 		"catch-js-errors": true,


### PR DESCRIPTION
Closes Comments Management m2!

Enables Edit Comment and Bulk Actions in all environments.

### Testing instructions

- Navigate to the Comments section.

- Click on the Bulk Edit button in the right corner of the navbar.

- Select a bunch of comments by clicking anywhere on their collapsed cards.

- Apply an action from the navbar and make sure all the comments selected change as expected.
  - If toggling between Approved and Unapproved while in the All, Pending, and Approved list, the comments should remain in the same list and eventually change color (white for approved, yellow for unapproved).
  - If setting to Spam or Trash while in any list, or to Approved while in the Spam and Trash lists, the comments should disappear from the list, and "reappear" in their new list.
  - If Deleting (available in the Spam and Trash lists), the comment should disappear for good.

- Expand any comment and click the Edit button in the comment's actions bar (not available on Spam and Trash lists).

- The comment card content should be replaced by an Edit form, containing three fields: the author name, the author email address, the comment content.
  - If the comment author is a wpcom registered user, the author name and email fields are disabled and there are info tooltips that explain the reason.
  - If the site runs a Jetpack version older than 5.3, the entire Edit form is disabled and there is a prompt to update.
  - Make sure that editing each of the three fields actually persists the changes when clicking Save (allow a little bit of time for the server to actually acknowledge it).
  - Try to Undo the changes (from the edit success notice): everything should revert as expected (there could be a flash of new-old content, if the Undo comes before the server response to the first Edit dispatch).