### PR TITLE
Extensions: WPJM - Make suggested design changes to wizard confirmation step

### DIFF
--- a/client/extensions/wp-job-manager/components/setup/confirmation/confirmation-link.jsx
+++ b/client/extensions/wp-job-manager/components/setup/confirmation/confirmation-link.jsx
@@ -1,0 +1,24 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import PropTypes from 'prop-types';
+
+/**
+ * Internal dependencies
+ */
+import CompactCard from 'components/card/compact';
+
+const ConfirmationLink = ( { text, ...props } ) => (
+	<CompactCard { ...props }>
+		<p className="confirmation__link">{ text }</p>
+	</CompactCard>
+);
+
+ConfirmationLink.propTypes = {
+	href: PropTypes.string,
+	target: PropTypes.string,
+	text: PropTypes.string,
+};
+
+export default ConfirmationLink;

--- a/client/extensions/wp-job-manager/components/setup/confirmation/index.jsx
+++ b/client/extensions/wp-job-manager/components/setup/confirmation/index.jsx
@@ -11,58 +11,43 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import Card from 'components/card';
+import ConfirmationLink from './confirmation-link';
 import ExternalLink from 'components/external-link';
+import FormattedHeader from 'components/formatted-header';
 import SectionHeader from 'components/section-header';
 import { getSelectedSiteSlug } from 'state/ui/selectors';
 
 const Confirmation = ( { slug, translate } ) => (
 	<div>
-		<SectionHeader label={ translate( 'You\'re ready to start using WP Job Manager!' ) } />
+		<FormattedHeader
+			headerText={ translate( 'You\'re ready to start using WP Job Manager!' ) }
+			subHeaderText={ translate( 'Wondering what to do now? Here are some of the most common next steps:' ) } />
+
+		<ConfirmationLink
+			href={ `/extensions/wp-job-manager/${ slug }` }
+			text={ translate( 'Tweak your settings' ) } />
+
+		<ConfirmationLink
+			href="#"
+			text={ translate( 'Add a job using the admin dashboard' ) } />
+
+		<ConfirmationLink
+			href="https://wpjobmanager.com/document/shortcode-reference/#section-1"
+			target="_blank"
+			text={ translate( 'Add job listings to a page using the [jobs] shortcode' ) } />
+
+		<ConfirmationLink
+			href="https://wpjobmanager.com/document/the-job-submission-form/"
+			target="_blank"
+			text={ translate( 'Learn to use the front-end job submission board' ) } />
+
+		<ConfirmationLink
+			href="https://wpjobmanager.com/document/the-job-dashboard/"
+			target="_blank"
+			text={ translate( 'Learn to use the front-end job dashboard' ) } />
+
 		<Card>
-			<p>
-				{ translate( 'Wondering what to do now? Here are some of the most common next steps:' ) }
-			</p>
-
-			{ translate(
-				'{{ul}}' +
-					'{{li}} {{settings}}Tweak your settings{{/settings}} {{/li}}' +
-					'{{li}} {{addJob}}Add a job using the admin dashboard{{/addJob}} {{/li}}' +
-					'{{li}} {{jobs}}Add job listings to a page using the [jobs] shortcode{{/jobs}} {{/li}}' +
-					'{{li}} {{submission}}Learn to use the front-end job submission board{{/submission}} {{/li}}' +
-					'{{li}} {{dashboard}}Learn to use the front-end job dashboard{{/dashboard}} {{/li}}' +
-				'{{/ul}}',
-				{
-					components: {
-						ul: <ul />,
-						li: <li />,
-						settings: <a href={ `/extensions/wp-job-manager/${ slug }` } />,
-						addJob: <a href="#" />,
-						jobs: (
-							<ExternalLink
-								icon={ true }
-								target="_blank"
-								href="https://wpjobmanager.com/document/shortcode-reference/#section-1"
-							/>
-						),
-						submission: (
-							<ExternalLink
-								icon={ true }
-								target="_blank"
-								href="https://wpjobmanager.com/document/the-job-submission-form/"
-							/>
-						),
-						dashboard: (
-							<ExternalLink
-								icon={ true }
-								target="_blank"
-								href="https://wpjobmanager.com/document/the-job-dashboard/"
-							/>
-						),
-					}
-				}
-			) }
-
-			<p>
+			<p className="confirmation__help">
 				{ translate( 'If you need help, you can find more detail in our {{docs}}support documentation{{/docs}}' +
 					'or post your question on the {{forums}}WP Job Manager support forums{{/forums}}. Happy hiring!',
 					{

--- a/client/extensions/wp-job-manager/components/setup/style.scss
+++ b/client/extensions/wp-job-manager/components/setup/style.scss
@@ -43,9 +43,24 @@
 	margin-right: 8px;
 }
 
+.wp-job-manager__setup .confirmation__link {
+	margin-bottom: 0;
+	font-size: 14px;
+	line-height: 18px;
+	color: $gray-text-min;
+}
+
+.wp-job-manager__setup .confirmation__help {
+	margin: 0;
+}
+
 .wp-job-manager__setup .confirmation__support {
 	list-style: none;
 	margin: 0;
+}
+
+.wp-job-manager__setup .confirmation__support li {
+	margin-bottom: 5px;
 }
 
 .wp-job-manager__setup .confirmation__support .gridicon {


### PR DESCRIPTION
This PR makes the [recommended design changes](https://github.com/Automattic/wp-calypso/pull/17916#issuecomment-328119912) to the wizard confirmation step.

## Before
![wizard-final](https://user-images.githubusercontent.com/1190420/30207900-33ca6164-945f-11e7-988f-99073720fd9a.jpg)

## After
![wpjm-confirmation](https://user-images.githubusercontent.com/1190420/30965412-5daa3b20-a423-11e7-8655-346101c9438a.jpg)

## Testing

Ensure the WP Job Manager plugin is installed and configured by following the steps in p6r3EZ-ra-p2. Checkout and run the `update/wpjm-redesign-wizard-confirmation` Calypso branch. Browse to `/extensions/wp-job-manager/setup/<siteId>/confirmation`. 