### PR TITLE
Theme search: Allow '-' chars in theme taxonomies

### DIFF
--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -86,7 +86,7 @@ const ThemeShowcase = React.createClass( {
 	},
 
 	doSearch( searchBoxContent ) {
-		const filterRegex = /(\w+)\:([\w-]*)/g;
+		const filterRegex = /([\w-]*)\:([\w-]*)/g;
 		const { filterToTermTable } = this.props;
 
 		const filters = searchBoxContent.match( filterRegex ) || [];


### PR DESCRIPTION
Allow theme magic search to cope with the new skill-level taxonomy.

Use with D7407-code for working filtering
