### PR TITLE
PluginsBrowser: prevent infinite request loop when searching from a category page

### DIFF
--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -89,21 +89,26 @@ const PluginsBrowser = React.createClass( {
 	},
 
 	fetchNextPagePlugins() {
-		let doSearch = true;
+		const category = this.props.search ? 'search' : this.props.category;
 
-		if ( this.state.fullLists.search && this.state.fullLists.search.fetching ) {
-			doSearch = false;
+		if ( ! category ) {
+			return;
 		}
 
-		if ( this.state.fullLists.search && this.state.fullLists.search.list && this.state.fullLists.search.list.length < 10 ) {
-			doSearch = false;
+		const fullList = this.state.fullLists[ category ];
+
+		// If a request for this category is in progress, don't issue a new one
+		if ( fullList && fullList.fetching ) {
+			return;
 		}
 
-		if ( this.props.search && doSearch ) {
-			PluginsActions.fetchNextCategoryPage( 'search', this.props.search );
-		} else if ( this.props.category ) {
-			PluginsActions.fetchNextCategoryPage( this.props.category );
+		// If the first search request returned just a few results that fill less than one full page,
+		// don't try to fetch the next page. We already have all the results.
+		if ( category === 'search' && fullList && fullList.list && fullList.list.length < 24 ) {
+			return;
 		}
+
+		PluginsActions.fetchNextCategoryPage( category, this.props.search );
 	},
 
 	getPluginsLists( search ) {


### PR DESCRIPTION
Fixes a bug with the following STR:

1. Open plugins browser for the "popular" category: `/plugins/browse/popular`
2. Open Network panel in devtools and filter for `api.wordpress.org`. We'll be watching search requests for plugins. 
3. Click on the search icon in the nav bar and type some search term, i.e., "jetpack"

**Expected result:**
There are requests to `api.wordpress.org` to fill the whole viewport with results, and additional requests to fetch more results after you scroll near the end (infinite scroll)

**Actual result:**
Infinite loop of `api.wordpress.org` requests is triggered that never ends, even after 100+ pages.

**Why it happens and how it's fixed:**
When a search is active in the plugin browser, the "category" that you are on (all, featured, popular, new) doesn't matter -- the search is always the same.

However, the logic in `fetchNextPagePlugins` is wrong. When both `this.props.search` and `this.props.category` have a non-null value, and a `search` request is already in progress, it will start requesting more pages for the `category`. But the `category` list is not displayed (`search` is), so adding more results to it doesn't change the content of the viewport (and its scroll position). The infinite scroll logic is tricked to request more and more results in a futile effort to fill the viewport: infinite loop!

**How to test:**
1. Test that the above steps to reproduce no longer happen.
2. Test that infinite scrolling works in all plugin browser views -- search, popular, new...
