### PR TITLE
PageList: Use `this.props.moment` instead of `this.moment`

### DIFF
--- a/client/my-sites/pages/page-list.jsx
+++ b/client/my-sites/pages/page-list.jsx
@@ -128,11 +128,11 @@ const Pages = localize( React.createClass( {
 
 	_insertTimeMarkers( pages ) {
 		const markedPages = [],
-			now = this.moment();
+			now = this.props.moment();
 		let lastMarker;
 
 		const buildMarker = function( pageDate ) {
-			pageDate = this.moment( pageDate );
+			pageDate = this.props.moment( pageDate );
 			const days = now.diff( pageDate, 'days' );
 			if ( days <= 0 ) {
 				return this.props.translate( 'Today' );
@@ -144,7 +144,7 @@ const Pages = localize( React.createClass( {
 		}.bind( this );
 
 		pages.forEach( function( page ) {
-			const date = this.moment( page.date ),
+			const date = this.props.moment( page.date ),
 				marker = buildMarker( date );
 			if ( lastMarker !== marker ) {
 				markedPages.push(


### PR DESCRIPTION
This component is already wrapped in  `localize`, so we can use `this.props.moment()`.
Note that if we ran the `i18n-translate` codemod again, we'd end up with two `localize` wrappers.

I did a quick search, and AFAICS, this was the only instance that was using `this.props.translate` while still using `this.moment()`.

To test: Verify that `/pages` still work.