### PR TITLE
Comments: Add page query parameter to the URL

### DIFF
--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -97,15 +97,12 @@ export class CommentList extends Component {
 
 	changePage = pageNumber => {
 		const {
-			comments,
 			recordChangePage,
 			siteFragment,
 			status,
 		} = this.props;
-		const { persistedComments } = this.state;
 
-		const total = Math.ceil( ( comments.length + persistedComments.length ) / COMMENTS_PER_PAGE );
-		recordChangePage( page, total );
+		recordChangePage( page, this.getTotalPages() );
 
 		this.setState( { selectedComments: [] } );
 
@@ -154,11 +151,17 @@ export class CommentList extends Component {
 		}, status, [ '', '' ] );
 	};
 
+	getTotalPages = () => Math.ceil(
+		( this.props.comments.length + this.state.persistedComments.length ) / COMMENTS_PER_PAGE
+	);
+
 	hasCommentJustMovedBackToCurrentStatus = commentId => this.state.lastUndo === commentId;
 
 	isCommentPersisted = commentId => -1 !== this.state.persistedComments.indexOf( commentId );
 
 	isCommentSelected = commentId => !! find( this.state.selectedComments, { commentId } );
+
+	isRequestedPageValid = () => this.getTotalPages() >= this.props.page;
 
 	isSelectedAll = () => {
 		const { page: pageNumber } = this.props;
@@ -431,9 +434,11 @@ export class CommentList extends Component {
 			selectedComments,
 		} = this.state;
 
+		const validPage = this.isRequestedPageValid() ? pageNumber : 1;
+
 		const comments = this.getComments();
 		const commentsCount = comments.length;
-		const commentsPage = this.getCommentsPage( comments, pageNumber );
+		const commentsPage = this.getCommentsPage( comments, validPage );
 
 		const showPlaceholder = ( ! siteId || isLoading ) && ! commentsCount;
 		const showEmptyContent = ! commentsCount && ! showPlaceholder;
@@ -447,7 +452,7 @@ export class CommentList extends Component {
 				{ isJetpack &&
 					<QuerySiteCommentsList
 						number={ 100 }
-						offset={ ( pageNumber - 1 ) * COMMENTS_PER_PAGE }
+						offset={ ( validPage - 1 ) * COMMENTS_PER_PAGE }
 						siteId={ siteId }
 						status={ status }
 					/>
@@ -508,7 +513,7 @@ export class CommentList extends Component {
 				{ ! showPlaceholder && ! showEmptyContent &&
 					<Pagination
 						key="comment-list-pagination"
-						page={ pageNumber }
+						page={ validPage }
 						pageClick={ this.changePage }
 						perPage={ COMMENTS_PER_PAGE }
 						total={ commentsCount }

--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -102,7 +102,7 @@ export class CommentList extends Component {
 			status,
 		} = this.props;
 
-		recordChangePage( page, this.getTotalPages() );
+		recordChangePage( pageNumber, this.getTotalPages() );
 
 		this.setState( { selectedComments: [] } );
 

--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -94,17 +94,17 @@ export class CommentList extends Component {
 		}
 	}
 
-	changePage = pageNumber => {
+	changePage = page => {
 		const {
 			recordChangePage,
 			changePage,
 		} = this.props;
 
-		recordChangePage( pageNumber, this.getTotalPages() );
+		recordChangePage( page, this.getTotalPages() );
 
 		this.setState( { selectedComments: [] } );
 
-		changePage( pageNumber );
+		changePage( page );
 	};
 
 	deleteCommentPermanently = ( commentId, postId ) => {
@@ -126,8 +126,8 @@ export class CommentList extends Component {
 		return orderBy( comments, null, this.state.sortOrder );
 	};
 
-	getCommentsPage = ( comments, pageNumber ) => {
-		const startingIndex = ( pageNumber - 1 ) * COMMENTS_PER_PAGE;
+	getCommentsPage = ( comments, page ) => {
+		const startingIndex = ( page - 1 ) * COMMENTS_PER_PAGE;
 		return slice( comments, startingIndex, startingIndex + COMMENTS_PER_PAGE );
 	};
 
@@ -158,9 +158,9 @@ export class CommentList extends Component {
 	isRequestedPageValid = () => this.getTotalPages() >= this.props.page;
 
 	isSelectedAll = () => {
-		const { page: pageNumber } = this.props;
+		const { page } = this.props;
 		const { selectedComments } = this.state;
-		const visibleComments = this.getCommentsPage( this.getComments(), pageNumber );
+		const visibleComments = this.getCommentsPage( this.getComments(), page );
 		return selectedComments.length && ( selectedComments.length === visibleComments.length );
 	};
 
@@ -417,7 +417,7 @@ export class CommentList extends Component {
 		const {
 			isJetpack,
 			isLoading,
-			page: pageNumber,
+			page,
 			siteBlacklist,
 			siteId,
 			siteFragment,
@@ -428,7 +428,7 @@ export class CommentList extends Component {
 			selectedComments,
 		} = this.state;
 
-		const validPage = this.isRequestedPageValid() ? pageNumber : 1;
+		const validPage = this.isRequestedPageValid() ? page : 1;
 
 		const comments = this.getComments();
 		const commentsCount = comments.length;
@@ -572,8 +572,8 @@ const mapDispatchToProps = ( dispatch, { siteId } ) => ( {
 		likeComment( siteId, postId, commentId )
 	) ),
 
-	recordChangePage: ( pageNumber, total ) => dispatch( composeAnalytics(
-		recordTracksEvent( 'calypso_comment_management_change_page', { pageNumber, total } ),
+	recordChangePage: ( page, total ) => dispatch( composeAnalytics(
+		recordTracksEvent( 'calypso_comment_management_change_page', { page, total } ),
 		bumpStat( 'calypso_comment_management', 'change_page' )
 	) ),
 

--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -17,7 +17,6 @@ import {
 	uniq
 } from 'lodash';
 import ReactCSSTransitionGroup from 'react-addons-css-transition-group';
-import page from 'page';
 
 /**
  * Internal dependencies
@@ -51,7 +50,6 @@ import {
 	withAnalytics,
 } from 'state/analytics/actions';
 import { isJetpackSite } from 'state/sites/selectors';
-import { addQueryArgs } from 'lib/route';
 import {
 	COMMENTS_PER_PAGE,
 	NEWEST_FIRST,
@@ -64,6 +62,7 @@ export class CommentList extends Component {
 		deleteComment: PropTypes.func,
 		likeComment: PropTypes.func,
 		recordChangePage: PropTypes.func,
+		changePage: PropTypes.func,
 		replyComment: PropTypes.func,
 		setBulkStatus: PropTypes.func,
 		siteBlacklist: PropTypes.string,
@@ -98,19 +97,14 @@ export class CommentList extends Component {
 	changePage = pageNumber => {
 		const {
 			recordChangePage,
-			siteFragment,
-			status,
+			changePage,
 		} = this.props;
 
 		recordChangePage( pageNumber, this.getTotalPages() );
 
 		this.setState( { selectedComments: [] } );
 
-		if ( window ) {
-			window.scrollTo( 0, 0 );
-		}
-
-		page( addQueryArgs( { page: pageNumber }, `/comments/${ status }/${ siteFragment }` ) );
+		changePage( pageNumber );
 	};
 
 	deleteCommentPermanently = ( commentId, postId ) => {

--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -83,7 +83,12 @@ export class CommentList extends Component {
 	};
 
 	componentWillReceiveProps( nextProps ) {
-		const { siteId, status } = this.props;
+		const { siteId, status, changePage } = this.props;
+		const totalPages = this.getTotalPages();
+		if ( ! this.isRequestedPageValid() && totalPages > 1 ) {
+			return changePage( totalPages );
+		}
+
 		if ( siteId !== nextProps.siteId || status !== nextProps.status ) {
 			this.setState( {
 				isBulkEdit: false,

--- a/client/my-sites/comments/controller.js
+++ b/client/my-sites/comments/controller.js
@@ -19,7 +19,10 @@ const VALID_STATUSES = [ 'all', 'pending', 'approved', 'spam', 'trash' ];
 
 export const isValidStatus = status => includes( VALID_STATUSES, status );
 
-export const setValidPage = pageNumber => ( parseInt( pageNumber, 10 ) > 0 ? pageNumber : 1 );
+export const setValidPage = pageNumber => {
+	const parsedPageNumber = parseInt( pageNumber, 10 );
+	return parsedPageNumber > 0 ? parsedPageNumber : 1;
+};
 
 export const getRedirectUrl = ( status, siteFragment ) => {
 	const statusValidity = isValidStatus( status );

--- a/client/my-sites/comments/controller.js
+++ b/client/my-sites/comments/controller.js
@@ -19,6 +19,8 @@ const VALID_STATUSES = [ 'all', 'pending', 'approved', 'spam', 'trash' ];
 
 export const isValidStatus = status => includes( VALID_STATUSES, status );
 
+export const setValidPage = pageNumber => ( parseInt( pageNumber, 10 ) > 0 ? pageNumber : 1 );
+
 export const getRedirectUrl = ( status, siteFragment ) => {
 	const statusValidity = isValidStatus( status );
 	if ( status === siteFragment ) {
@@ -49,8 +51,12 @@ export const redirect = function( context, next ) {
 export const comments = function( context ) {
 	const { status } = context.params;
 	const siteFragment = route.getSiteFragment( context.path );
+	const validPage = setValidPage( context.query.page );
+
 	renderWithReduxStore(
 		<CommentsManagement
+			basePath={ context.path }
+			page={ validPage }
 			siteFragment={ siteFragment }
 			status={ 'pending' === status ? 'unapproved' : status }
 		/>,

--- a/client/my-sites/comments/controller.js
+++ b/client/my-sites/comments/controller.js
@@ -11,7 +11,7 @@ import { each, includes, startsWith } from 'lodash';
  * Internal dependencies
  */
 import CommentsManagement from './main';
-import route from 'lib/route';
+import route, { addQueryArgs } from 'lib/route';
 import { removeNotice } from 'state/notices/actions';
 import { getNotices } from 'state/notices/selectors';
 
@@ -51,8 +51,16 @@ export const redirect = function( context, next ) {
 	next();
 };
 
+const changePage = ( status, siteFragment ) => pageNumber => {
+	if ( window ) {
+		window.scrollTo( 0, 0 );
+	}
+
+	page( addQueryArgs( { page: pageNumber }, `/comments/${ status }/${ siteFragment }` ) );
+};
+
 export const comments = function( context ) {
-	const { status } = context.params;
+	const status = 'pending' === context.params.status ? 'unapproved' : context.params.status;
 	const siteFragment = route.getSiteFragment( context.path );
 	const validPage = setValidPage( context.query.page );
 
@@ -60,8 +68,9 @@ export const comments = function( context ) {
 		<CommentsManagement
 			basePath={ context.path }
 			page={ validPage }
+			changePage={ changePage( status, siteFragment ) }
 			siteFragment={ siteFragment }
-			status={ 'pending' === status ? 'unapproved' : status }
+			status={ status }
 		/>,
 		'primary',
 		context.store

--- a/client/my-sites/comments/controller.js
+++ b/client/my-sites/comments/controller.js
@@ -19,11 +19,6 @@ const VALID_STATUSES = [ 'all', 'pending', 'approved', 'spam', 'trash' ];
 
 export const isValidStatus = status => includes( VALID_STATUSES, status );
 
-export const setValidPage = pageNumber => {
-	const parsedPageNumber = parseInt( pageNumber, 10 );
-	return parsedPageNumber > 0 ? parsedPageNumber : 1;
-};
-
 export const getRedirectUrl = ( status, siteFragment ) => {
 	const statusValidity = isValidStatus( status );
 	if ( status === siteFragment ) {
@@ -56,18 +51,22 @@ const changePage = ( status, siteFragment ) => pageNumber => {
 		window.scrollTo( 0, 0 );
 	}
 
-	page( addQueryArgs( { page: pageNumber }, `/comments/${ status }/${ siteFragment }` ) );
+	return page( addQueryArgs( { page: pageNumber }, `/comments/${ status }/${ siteFragment }` ) );
 };
 
 export const comments = function( context ) {
 	const status = 'pending' === context.params.status ? 'unapproved' : context.params.status;
 	const siteFragment = route.getSiteFragment( context.path );
-	const validPage = setValidPage( context.query.page );
+
+	const pageNumber = parseInt( context.query.page, 10 );
+	if ( isNaN( pageNumber ) || pageNumber === 0 ) {
+		return changePage( status, siteFragment )( 1 );
+	}
 
 	renderWithReduxStore(
 		<CommentsManagement
 			basePath={ context.path }
-			page={ validPage }
+			page={ pageNumber }
 			changePage={ changePage( status, siteFragment ) }
 			siteFragment={ siteFragment }
 			status={ status }

--- a/client/my-sites/comments/controller.js
+++ b/client/my-sites/comments/controller.js
@@ -60,7 +60,7 @@ export const comments = function( context ) {
 
 	const pageNumber = parseInt( context.query.page, 10 );
 	if ( isNaN( pageNumber ) || pageNumber === 0 ) {
-		return changePage( status, siteFragment )( 1 );
+		return changePage( context.params.status, siteFragment )( 1 );
 	}
 
 	renderWithReduxStore(

--- a/client/my-sites/comments/index.js
+++ b/client/my-sites/comments/index.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -16,13 +17,10 @@ export default function() {
 	}
 
 	if ( config.isEnabled( 'comments/management' ) ) {
-		page( '/comments/:status?',
-			controller.siteSelection,
-			redirect,
-			controller.sites
-		);
+		page( '/comments/:status?', controller.siteSelection, redirect, controller.sites );
 
-		page( '/comments/:status/:site',
+		page(
+			'/comments/:status/:site',
 			controller.siteSelection,
 			redirect,
 			controller.navigation,

--- a/client/my-sites/comments/main.jsx
+++ b/client/my-sites/comments/main.jsx
@@ -41,6 +41,7 @@ export class CommentsManagement extends Component {
 			showPermissionError,
 			basePath,
 			page,
+			changePage,
 			siteId,
 			siteFragment,
 			status,
@@ -66,6 +67,7 @@ export class CommentsManagement extends Component {
 				{ ! showPermissionError && (
 					<CommentList
 						page={ page }
+						changePage={ changePage }
 						siteId={ siteId }
 						siteFragment={ siteFragment }
 						status={ status }

--- a/client/my-sites/comments/main.jsx
+++ b/client/my-sites/comments/main.jsx
@@ -39,7 +39,6 @@ export class CommentsManagement extends Component {
 	render() {
 		const {
 			showPermissionError,
-			basePath,
 			page,
 			changePage,
 			siteId,

--- a/client/my-sites/comments/main.jsx
+++ b/client/my-sites/comments/main.jsx
@@ -1,8 +1,9 @@
+/** @format */
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
@@ -22,19 +23,24 @@ import EmptyContent from 'components/empty-content';
 export class CommentsManagement extends Component {
 	static propTypes = {
 		comments: PropTypes.array,
+		page: PropTypes.number,
 		showPermissionError: PropTypes.bool,
 		siteId: PropTypes.number,
-		siteFragment: PropTypes.oneOfType( [
-			PropTypes.string,
-			PropTypes.number,
-		] ),
+		siteFragment: PropTypes.oneOfType( [ PropTypes.string, PropTypes.number ] ),
 		status: PropTypes.string,
 		translate: PropTypes.func,
+	};
+
+	static defaultProps = {
+		page: 1,
+		status: 'all',
 	};
 
 	render() {
 		const {
 			showPermissionError,
+			basePath,
+			page,
 			siteId,
 			siteFragment,
 			status,
@@ -46,17 +52,26 @@ export class CommentsManagement extends Component {
 				<PageViewTracker path="/comments/:status/:site" title="Comments" />
 				<DocumentHead title={ translate( 'Comments' ) } />
 				<SidebarNavigation />
-				{ showPermissionError && <EmptyContent
-					title={ preventWidows( translate( 'Oops! You don\'t have permission to manage comments.' ) ) }
-					line={ preventWidows( translate( 'If you think you should, contact this site\'s administrator.' ) ) }
-					illustration="/calypso/images/illustrations/illustration-500.svg" />
-				}
-				{ ! showPermissionError && <CommentList
-					siteId={ siteId }
-					siteFragment={ siteFragment }
-					status={ status }
-					order={ 'desc' }
-				/> }
+				{ showPermissionError && (
+					<EmptyContent
+						title={ preventWidows(
+							translate( "Oops! You don't have permission to manage comments." )
+						) }
+						line={ preventWidows(
+							translate( "If you think you should, contact this site's administrator." )
+						) }
+						illustration="/calypso/images/illustrations/illustration-500.svg"
+					/>
+				) }
+				{ ! showPermissionError && (
+					<CommentList
+						page={ page }
+						siteId={ siteId }
+						siteFragment={ siteFragment }
+						status={ status }
+						order={ 'desc' }
+					/>
+				) }
 			</Main>
 		);
 	}


### PR DESCRIPTION
Closes #17223

Adds a `?page` query parameter to the URL in the Comment Management, in order to be able to load directly into a chosen page.

Quirks

- If the page number is not valid (not a number or not included between `1` and the total number of pages) it defaults to `1`, but the query param **doesn't update accordingly**.
So, for example, opening `?page=abc` would keep the `?page=abc` in the URL and display the first page.
On wp-admin the `page` param is updated if it's greater than the total number of pages; but it's not updated if `page` it's not a number, not an integer, or not positive.

- The query param is `page`, which makes sense to me, but requires to be renamed as `pageNumber` pretty much anywhere, because of the `page` module import.
On wp-admin the param is called `paged`, which, well, doesn't look as good, imho.
Though, `paged` would remove the need of renaming it. What do you think?

I'd love to change it to `?page=1` or even better, to remove the param altogether, but I can't find a good way to do so in the section controller.

---

If reviewers find this approach good enough, we can add the sorting parameter in a follow up PR.