### PR TITLE
Editor: Prevent error when clicking "Back" while scheduler is open

### DIFF
--- a/client/post-editor/editor-publish-date/index.jsx
+++ b/client/post-editor/editor-publish-date/index.jsx
@@ -44,9 +44,21 @@ export class EditorPublishDate extends React.Component {
 	}
 
 	handleOutsideClick = event => {
-		const targetClasses = event.target.className.split( /\s/ );
-		const hasDatePickerDayClass = intersection( targetClasses, [ 'DayPicker-Day', 'date-picker__day' ] ).length > 0;
-		const isChildOfPublishDate = ReactDom.findDOMNode( this.refs.editorPublishDateWrapper ).contains( event.target );
+		// The `className` of a `svg` element is a `SVGAnimatedString`, which
+		// does not have a `split` method.  Since an `svg` element will not
+		// have any of the classes we're interested in, don't bother trying to
+		// handle this situation.
+		const targetClasses = typeof event.target.className === 'string'
+			? event.target.className.split( /\s/ )
+			: [];
+
+		const hasDatePickerDayClass = intersection( targetClasses, [
+			'DayPicker-Day', 'date-picker__day'
+		] ).length > 0;
+
+		const isChildOfPublishDate =
+			ReactDom.findDOMNode( this.refs.editorPublishDateWrapper )
+				.contains( event.target );
 
 		if ( ! hasDatePickerDayClass && ! isChildOfPublishDate ) {
 			this.setState( { isOpen: false } );


### PR DESCRIPTION
While working on https://github.com/Automattic/wp-calypso/pull/17892 I noticed the following bug:

- Edit a post
- Expand the post scheduler under Status
- Click the Back arrow at the top left

The following error appears in the console:

```
Uncaught TypeError: event.target.className.split is not a function
    at EditorPublishDate._this.handleOutsideClick (index.jsx:83)
```

The reason for the bug is explained in the code comments in this PR; the fix seems straightforward.