### PR TITLE
Store-Promotions: Add list page

### DIFF
--- a/client/extensions/woocommerce/app/promotions/index.js
+++ b/client/extensions/woocommerce/app/promotions/index.js
@@ -7,23 +7,29 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
+import { noop } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import { fetchPromotions } from 'woocommerce/state/sites/promotions/actions';
+import { getPromotions } from 'woocommerce/state/selectors/promotions';
 import ActionHeader from 'woocommerce/components/action-header';
 import Button from 'components/button';
 import { getLink } from 'woocommerce/lib/nav-utils';
 import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
 import Main from 'components/main';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
+import PromotionsList from './promotions-list';
+import SearchCard from 'components/search-card';
 
 class Promotions extends Component {
 	static propTypes = {
 		site: PropTypes.shape( {
 			ID: PropTypes.number,
 		} ),
+		promotions: PropTypes.array,
+		fetchPromotions: PropTypes.func.isRequired,
 	};
 
 	componentDidMount() {
@@ -43,6 +49,25 @@ class Promotions extends Component {
 		}
 	}
 
+	renderSearchCard() {
+		const { site, promotions, translate } = this.props;
+
+		if ( ! promotions || promotions.length === 0 ) {
+			return null;
+		}
+
+		// TODO: Implement onSearch
+		return (
+			<SearchCard
+				onSearch={ noop }
+				delaySearch
+				delayTimeout={ 400 }
+				disabled={ ! site }
+				placeholder={ translate( 'Search promotions…' ) }
+			/>
+		);
+	}
+
 	render() {
 		const { site, className, translate } = this.props;
 		const classes = classNames( 'promotions__list', className );
@@ -55,6 +80,8 @@ class Promotions extends Component {
 						{ translate( 'Add promotion' ) }
 					</Button>
 				</ActionHeader>
+				{ this.renderSearchCard() }
+				<PromotionsList />
 			</Main>
 		);
 	}
@@ -62,9 +89,11 @@ class Promotions extends Component {
 
 function mapStateToProps( state ) {
 	const site = getSelectedSiteWithFallback( state );
+	const promotions = getPromotions( state, site.ID );
 
 	return {
 		site,
+		promotions,
 	};
 }
 

--- a/client/extensions/woocommerce/app/promotions/index.js
+++ b/client/extensions/woocommerce/app/promotions/index.js
@@ -52,17 +52,13 @@ class Promotions extends Component {
 	renderSearchCard() {
 		const { site, promotions, translate } = this.props;
 
-		if ( ! promotions || promotions.length === 0 ) {
-			return null;
-		}
-
 		// TODO: Implement onSearch
 		return (
 			<SearchCard
 				onSearch={ noop }
 				delaySearch
 				delayTimeout={ 400 }
-				disabled={ ! site }
+				disabled={ ! site || ! promotions }
 				placeholder={ translate( 'Search promotions…' ) }
 			/>
 		);

--- a/client/extensions/woocommerce/app/promotions/promotions-list-pagination.js
+++ b/client/extensions/woocommerce/app/promotions/promotions-list-pagination.js
@@ -1,0 +1,48 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import PropTypes from 'prop-types';
+
+/**
+ * Internal dependencies
+ */
+import Pagination from 'components/pagination';
+
+const PromotionsListPagination = ( {
+	site,
+	promotionsLoaded,
+	totalPromotions,
+	currentPage,
+	perPage,
+	onSwitchPage,
+} ) => {
+	if ( ! totalPromotions || totalPromotions <= perPage ) {
+		return null;
+	}
+
+	if ( ! site || ! promotionsLoaded ) {
+		return ( <div className="promotions__list-placeholder pagination"></div> );
+	}
+
+	return (
+		<Pagination
+			page={ currentPage }
+			perPage={ perPage }
+			total={ totalPromotions }
+			pageClick={ onSwitchPage }
+		/>
+	);
+};
+
+PromotionsListPagination.propTypes = {
+	site: PropTypes.object,
+	promotionsLoaded: PropTypes.bool,
+	totalPromotions: PropTypes.number,
+	currentPage: PropTypes.number,
+	perPage: PropTypes.number,
+	onSwitchPage: PropTypes.func.isRequired,
+};
+
+export default PromotionsListPagination;
+

--- a/client/extensions/woocommerce/app/promotions/promotions-list-pagination.js
+++ b/client/extensions/woocommerce/app/promotions/promotions-list-pagination.js
@@ -38,7 +38,7 @@ const PromotionsListPagination = ( {
 PromotionsListPagination.propTypes = {
 	site: PropTypes.object,
 	promotionsLoaded: PropTypes.bool,
-	totalPromotions: PropTypes.number,
+	totalPromotions: PropTypes.oneOfType( [ PropTypes.number, PropTypes.bool ] ),
 	currentPage: PropTypes.number,
 	perPage: PropTypes.number,
 	onSwitchPage: PropTypes.func.isRequired,

--- a/client/extensions/woocommerce/app/promotions/promotions-list-row.js
+++ b/client/extensions/woocommerce/app/promotions/promotions-list-row.js
@@ -1,0 +1,68 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import PropTypes from 'prop-types';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import { getLink } from 'woocommerce/lib/nav-utils';
+import TableRow from 'woocommerce/components/table/table-row';
+import TableItem from 'woocommerce/components/table/table-item';
+
+function getPromotionTypeText( promotionType, translate ) {
+	switch ( promotionType ) {
+		case 'product_sale':
+			return translate( 'Product Sale' );
+		case 'coupon':
+			return translate( 'Coupon' );
+	}
+}
+
+function getTimeframeText( promotion, moment ) {
+	const startText = ( promotion.startDate ? moment( promotion.startDate ).format( 'L' ) : '' );
+	const endText = ( promotion.endDate ? moment( promotion.endDate ).format( 'L' ) : '' );
+
+	if ( promotion.startDate && promotion.endDate ) {
+		return `${ startText } - ${ endText }`;
+	}
+	if ( promotion.endDate ) {
+		return `ends on ${ endText }`;
+	}
+	if ( promotion.startDate ) {
+		return `${ startText } - ongoing`;
+	}
+	return 'ongoing';
+}
+
+const PromotionsListRow = ( { site, promotion, translate, moment } ) => {
+	return (
+		// TODO: Replace with individual update link for promotion.
+		<TableRow href={ getLink( '/store/promotions/:site', site ) }>
+			<TableItem isTitle className="promotions__list-promotion">
+				<span className="promotions__list-name">{ promotion.name }</span>
+			</TableItem>
+
+			<TableItem>
+				<span>{ getPromotionTypeText( promotion.type, translate ) }</span>
+			</TableItem>
+
+			<TableItem>
+				<span>{ getTimeframeText( promotion, moment ) }</span>
+			</TableItem>
+		</TableRow>
+	);
+};
+
+PromotionsListRow.propTypes = {
+	site: PropTypes.shape( {
+		slug: PropTypes.string,
+	} ),
+	promotion: PropTypes.shape( {
+	} ),
+};
+
+export default localize( PromotionsListRow );
+

--- a/client/extensions/woocommerce/app/promotions/promotions-list-row.js
+++ b/client/extensions/woocommerce/app/promotions/promotions-list-row.js
@@ -21,20 +21,32 @@ function getPromotionTypeText( promotionType, translate ) {
 	}
 }
 
-function getTimeframeText( promotion, moment ) {
-	const startText = ( promotion.startDate ? moment( promotion.startDate ).format( 'L' ) : '' );
-	const endText = ( promotion.endDate ? moment( promotion.endDate ).format( 'L' ) : '' );
+function getTimeframeText( promotion, translate, moment ) {
+	// TODO: Use humanDate when it supports future dates.
 
 	if ( promotion.startDate && promotion.endDate ) {
-		return `${ startText } - ${ endText }`;
+		return translate( '%(startDate)s - %(endDate)s', {
+			args: {
+				startDate: moment( promotion.startDate + 'Z' ).format( 'll' ),
+				endDate: moment( promotion.endDate + 'Z' ).format( 'll' ),
+			}
+		} );
 	}
 	if ( promotion.endDate ) {
-		return `ends on ${ endText }`;
+		return translate( 'Ends on %(endDate)s', {
+			args: {
+				endDate: moment( promotion.endDate + 'Z' ).format( 'll' ),
+			}
+		} );
 	}
 	if ( promotion.startDate ) {
-		return `${ startText } - ongoing`;
+		return translate( '%(startDate)s - No expiration date', {
+			args: {
+				startDate: moment( promotion.startDate + 'Z' ).format( 'll' ),
+			}
+		} );
 	}
-	return 'ongoing';
+	return translate( 'No expiration date' );
 }
 
 const PromotionsListRow = ( { site, promotion, translate, moment } ) => {
@@ -46,11 +58,11 @@ const PromotionsListRow = ( { site, promotion, translate, moment } ) => {
 			</TableItem>
 
 			<TableItem>
-				<span>{ getPromotionTypeText( promotion.type, translate ) }</span>
+				{ getPromotionTypeText( promotion.type, translate ) }
 			</TableItem>
 
 			<TableItem>
-				<span>{ getTimeframeText( promotion, moment ) }</span>
+				{ getTimeframeText( promotion, translate, moment ) }
 			</TableItem>
 		</TableRow>
 	);

--- a/client/extensions/woocommerce/app/promotions/promotions-list-table.js
+++ b/client/extensions/woocommerce/app/promotions/promotions-list-table.js
@@ -1,0 +1,58 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import PromotionsListRow from './promotions-list-row';
+import Table from 'woocommerce/components/table';
+import TableRow from 'woocommerce/components/table/table-row';
+import TableItem from 'woocommerce/components/table/table-item';
+
+const PromotionsListTable = ( {
+	site,
+	promotions,
+	translate,
+} ) => {
+	const headings = [
+		translate( 'Promotion' ),
+		translate( 'Type' ),
+		translate( 'Timeframe' ),
+	];
+
+	const tableHeader = (
+		<TableRow isHeader className={ classNames( { 'promotions__list-placeholder': ! promotions } ) }>
+			{ headings.map( ( item, i ) => <TableItem isHeader key={ i } isTitle={ 0 === i }>{ item }</TableItem> ) }
+		</TableRow>
+	);
+
+	return (
+		<div>
+			<Table header={ tableHeader } className={ classNames( { 'is-requesting': ! promotions } ) } horizontalScroll>
+				{ promotions && promotions.map( ( promotion, i ) => (
+					<PromotionsListRow
+						key={ i }
+						site={ site }
+						promotion={ promotion }
+					/>
+				) ) }
+			</Table>
+			{ ! promotions && ( <div className="promotions__list-placeholder"></div> ) }
+		</div>
+	);
+};
+
+PromotionsListTable.propTypes = {
+	site: PropTypes.shape( {
+		slug: PropTypes.string,
+	} ),
+	promotions: PropTypes.array,
+};
+
+export default localize( PromotionsListTable );
+

--- a/client/extensions/woocommerce/app/promotions/promotions-list-table.js
+++ b/client/extensions/woocommerce/app/promotions/promotions-list-table.js
@@ -21,7 +21,7 @@ const PromotionsListTable = ( {
 } ) => {
 	const headings = [
 		translate( 'Promotion' ),
-		translate( 'Type' ),
+		translate( 'Type', { context: 'noun' } ),
 		translate( 'Timeframe' ),
 	];
 

--- a/client/extensions/woocommerce/app/promotions/promotions-list.js
+++ b/client/extensions/woocommerce/app/promotions/promotions-list.js
@@ -1,0 +1,105 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { bindActionCreators } from 'redux';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Button from 'components/button';
+import EmptyContent from 'components/empty-content';
+import { getLink } from 'woocommerce/lib/nav-utils';
+import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
+import {
+	getPromotions,
+	getPromotionsPage,
+	getPromotionsCurrentPage,
+	getPromotionsPerPage
+} from 'woocommerce/state/selectors/promotions';
+import PromotionsListTable from './promotions-list-table';
+import PromotionsListPagination from './promotions-list-pagination';
+import { setPromotionsPage } from 'woocommerce/state/ui/promotions/actions';
+
+const PromotionsList = ( props ) => {
+	const { site, translate, promotions, promotionsPage, currentPage, perPage } = props;
+
+	const renderEmptyContent = () => {
+		const emptyContentAction = (
+			<Button href={ getLink( '/store/promotions/:site/', site ) }>
+				{ translate( 'Start a promotion!' ) }
+			</Button>
+		);
+		return (
+			<EmptyContent
+				title={ translate( 'You don\'t have any promotions.' ) }
+				action={ emptyContentAction }
+			/>
+		);
+	};
+
+	const switchPage = ( index ) => {
+		if ( site ) {
+			props.setPromotionsPage( site.ID, index, perPage );
+		}
+	};
+
+	if ( promotions && promotions.length === 0 ) {
+		return renderEmptyContent();
+	}
+
+	return (
+		<div className="promotions__list-wrapper">
+			<PromotionsListTable
+				site={ site }
+				promotions={ promotionsPage }
+			/>
+			<PromotionsListPagination
+				site={ site }
+				promotionsLoaded={ promotions && promotions.length > 0 }
+				totalPromotions={ promotions && promotions.length }
+				currentPage={ currentPage }
+				perPage={ perPage }
+				onSwitchPage={ switchPage }
+			/>
+		</div>
+	);
+};
+
+PromotionsList.propTypes = {
+	site: PropTypes.object,
+	promotions: PropTypes.array,
+	currentPage: PropTypes.number,
+	perPage: PropTypes.number,
+};
+
+function mapStateToProps( state ) {
+	const site = getSelectedSiteWithFallback( state );
+	const currentPage = site && getPromotionsCurrentPage( state );
+	const perPage = site && getPromotionsPerPage( state );
+	const promotions = site && getPromotions( state, site.ID );
+	const promotionsPage = site && getPromotionsPage( state, site.ID, currentPage, perPage );
+
+	return {
+		site,
+		promotions,
+		promotionsPage,
+		currentPage,
+		perPage,
+	};
+}
+
+function mapDispatchToProps( dispatch ) {
+	return bindActionCreators(
+		{
+			setPromotionsPage,
+		},
+		dispatch
+	);
+}
+
+export default connect( mapStateToProps, mapDispatchToProps )( localize( PromotionsList ) );
+

--- a/client/extensions/woocommerce/app/promotions/promotions-list.js
+++ b/client/extensions/woocommerce/app/promotions/promotions-list.js
@@ -59,7 +59,7 @@ const PromotionsList = ( props ) => {
 			/>
 			<PromotionsListPagination
 				site={ site }
-				promotionsLoaded={ promotions && promotions.length > 0 }
+				promotionsLoaded={ promotions && promotions.length >= 0 }
 				totalPromotions={ promotions && promotions.length }
 				currentPage={ currentPage }
 				perPage={ perPage }
@@ -74,6 +74,7 @@ PromotionsList.propTypes = {
 	promotions: PropTypes.array,
 	currentPage: PropTypes.number,
 	perPage: PropTypes.number,
+	promotionsPage: PropTypes.array,
 };
 
 function mapStateToProps( state ) {

--- a/client/extensions/woocommerce/app/promotions/promotions-list.scss
+++ b/client/extensions/woocommerce/app/promotions/promotions-list.scss
@@ -1,0 +1,108 @@
+.promotions__list {
+
+	.empty-content.has-title-only {
+		margin-top: 42px;
+	}
+
+	.empty-content.has-title-only .empty-content__title {
+		margin-bottom: 24px;
+	}
+
+	.table {
+		margin-bottom: 16px;
+		margin-top: 16px;
+	}
+
+	.search {
+		@include breakpoint( ">660px" ) {
+			margin-top: 58px;
+		}
+	}
+
+	.promotions__list-placeholder {
+		@include placeholder();
+		background: $white;
+		height: 525px;
+		margin-bottom: 16px;
+		margin-top: -15px;
+
+		&.is-header {
+			height: 50px;
+			width: 100%;
+		}
+
+		.table-heading {
+			border-bottom: 0;
+		}
+
+		&.pagination {
+			height: 44px;
+			margin-top: 16px;
+		}
+
+	}
+
+	.is-requesting td div {
+		@include placeholder();
+		background: transparent;
+	}
+
+	.promotions__list-product .table-item__cell-title {
+		display: flex;
+		align-items: center;
+	}
+
+	.promotions__list-image {
+		height: 40px;
+		width: 40px;
+		overflow: hidden;
+		position: relative;
+		margin-right: 16px;
+
+		&.is-thumb-placeholder {
+			background: $gray-light;
+		}
+
+		img {
+			position: absolute;
+			left: 50%;
+			top: 50%;
+			height: 100%;
+			width: auto;
+			-webkit-transform: translate( -50%, -50% );
+			transform: translate( -50%, -50% );
+		}
+	}
+
+	.is-header th {
+		&:first-child {
+			width: 50%;
+		}
+
+		&:nth-child( 2 ) {
+			width: 20%;
+		}
+
+		&:last-child {
+			width: 30%;
+		}
+	}
+
+	.table-row:not(.is-header) {
+		cursor: pointer;
+	}
+
+	.table-row:hover {
+		background: lighten( $gray, 35% );
+	}
+
+	.promotions__list-name {
+		color: $blue-wordpress;
+	}
+
+	.search, .search .search__open-icon {
+		z-index: initial;
+	}
+
+}
+

--- a/client/extensions/woocommerce/state/selectors/promotions.js
+++ b/client/extensions/woocommerce/state/selectors/promotions.js
@@ -8,6 +8,12 @@ export function getPromotions( rootState, siteId = getSelectedSiteWithFallback( 
 	return promotions.promotions;
 }
 
+export function getPromotionsPage( rootState, siteId = getSelectedSiteWithFallback( rootState ), page, perPage ) {
+	const offset = ( page - 1 ) * perPage;
+	const promotions = getPromotions( rootState, siteId );
+	return ( promotions ? promotions.slice( offset, ( offset + perPage ) ) : null );
+}
+
 export function getPromotionsCurrentPage( rootState ) {
 	const { promotions } = rootState.extensions.woocommerce.ui;
 	return promotions.currentPage;

--- a/client/extensions/woocommerce/state/selectors/test/promotions.js
+++ b/client/extensions/woocommerce/state/selectors/test/promotions.js
@@ -8,6 +8,7 @@ import { expect } from 'chai';
  */
 import {
 	getPromotions,
+	getPromotionsPage,
 	getPromotionsCurrentPage,
 	getPromotionsPerPage,
 } from '../promotions';
@@ -45,6 +46,25 @@ describe( 'promotions', () => {
 			expect( promotions[ 0 ].type ).to.equal( 'empty1' );
 			expect( promotions[ 1 ].type ).to.equal( 'empty2' );
 			expect( promotions[ 2 ].type ).to.equal( 'empty3' );
+		} );
+	} );
+
+	describe( '#getPromotionsPage', () => {
+		it( 'should return only promotions for a given page.', () => {
+			const page = getPromotionsPage( rootState, 123, 1, 2 );
+
+			expect( page ).to.exist;
+			expect( page.length ).to.equal( 2 );
+			expect( page[ 0 ].type ).to.equal( 'empty1' );
+			expect( page[ 1 ].type ).to.equal( 'empty2' );
+		} );
+
+		it( 'should advance the offset for pages > 1.', () => {
+			const page = getPromotionsPage( rootState, 123, 2, 2 );
+
+			expect( page ).to.exist;
+			expect( page.length ).to.equal( 1 );
+			expect( page[ 0 ].type ).to.equal( 'empty3' );
 		} );
 	} );
 

--- a/client/extensions/woocommerce/state/sites/promotions/reducer.js
+++ b/client/extensions/woocommerce/state/sites/promotions/reducer.js
@@ -99,6 +99,7 @@ function calculatePromotions( coupons, products ) {
 function createPromotionFromProduct( product ) {
 	return {
 		type: 'product_sale',
+		name: product.name,
 		startDate: product.date_on_sale_from_gmt,
 		endDate: product.date_on_sale_to_gmt,
 		product,
@@ -108,6 +109,7 @@ function createPromotionFromProduct( product ) {
 function createPromotionFromCoupon( coupon ) {
 	return {
 		type: 'coupon',
+		name: coupon.code,
 		startDate: coupon.date_created_gmt,
 		endDate: coupon.date_expires_gmt,
 		coupon,

--- a/client/extensions/woocommerce/style.scss
+++ b/client/extensions/woocommerce/style.scss
@@ -15,6 +15,7 @@
 	@import 'app/settings/payments/stripe/style';
 	@import 'app/products/product-form';
 	@import 'app/products/products-list';
+	@import 'app/promotions/promotions-list';
 	@import 'app/reviews/style';
 	@import 'app/settings/shipping/style';
 	@import 'app/settings/taxes/style';


### PR DESCRIPTION
This adds the necessary code to display promotions in a paginated list.

To Test:
1. `npm test`
2. `npm start`
3. Visit `http://calypso.localhost:3000/store/promotions/<site url>`
4. Ensure promotions show up in order of expiration (product sales and coupons)
5. Open dev console and enter `dispatch( { type: 'WOOCOMMERCE_PROMOTIONS_PAGE_SET', currentPage: 1, perPage: 2 } );`
6. Try out pagination to ensure it behaves as expected.

Extra testing:
Try it out with a store that has no promotions running to see the empty page.