### PR TITLE
Signup: Add Radcliffe 2 to the signup

### DIFF
--- a/client/lib/signup/themes-data.js
+++ b/client/lib/signup/themes-data.js
@@ -126,6 +126,15 @@ export const themes = [
 		verticals: []
 	},
 	{
+		name: 'Radcliffe',
+		slug: 'radcliffe-2',
+		repo: 'pub',
+		fallback: false,
+		design: 'page',
+		demo_uri: 'https://radcliffe2demo.wordpress.com',
+		verticals: []
+	},
+	{
 		name: 'Twenty Seventeen',
 		slug: 'twentyseventeen',
 		repo: 'pub',


### PR DESCRIPTION
Instructions for local testing:
* Switch to this PR
* Go to calypso.local:3000(?)/start/
* Click "Start with a website"
* Make sure that Radcliffe 2 appears (it may take some back and forth to get it instead of the other themes)

Thanks!