### PR TITLE
Reader: Fix comment box inconnsistency

### DIFF
--- a/client/blocks/comments/style.scss
+++ b/client/blocks/comments/style.scss
@@ -127,10 +127,6 @@
 	&.is-root {
 		margin-top: 20px;
 	}
-
-	.comments__form {
-		margin-top: 10px;
-	}
 }
 
 // Add a New Comment Form
@@ -248,6 +244,10 @@
 		.notice {
 			margin-top: 10px;
 		}
+	}
+
+	.comments__form {
+		margin-top: 10px;
 	}
 }
 
@@ -459,6 +459,7 @@ a.comments__comment-username {
 			float: right;
 			margin-top: 4px;
 			margin-right: 0;
+			padding-right: 0;
 		}
 	}
 


### PR DESCRIPTION
This fixes: https://github.com/Automattic/wp-calypso/issues/18333

**Before:**
![screenshot 2017-09-28 12 59 11](https://user-images.githubusercontent.com/4924246/30988285-d487ab1c-a44e-11e7-8a49-33da97b8df69.png)

**After:**
![screenshot 2017-09-28 12 59 22](https://user-images.githubusercontent.com/4924246/30988287-d49b601c-a44e-11e7-838e-fe1dfaba366c.png)
