### PR TITLE
PostTypeList: Fix incorrect action menu positioning

### DIFF
--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/style.scss
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/style.scss
@@ -1,6 +1,5 @@
 .post-actions-ellipsis-menu {
 	flex-shrink: 0;
-	align-self: stretch;
 	margin-left: 8px;
 }
 


### PR DESCRIPTION
This PR is part of a larger epic and behind the `posts/post-type-list` feature flag.  See p8F9tW-hL-p2.

Currently, the `PostItem` action menu appears below the `PostItem` instead of immediately below the ellipsis menu as it should.

The ellipsis menu was set to `align-self: stretch` which was causing its height to take up the entire `PostItem`.  We can just remove this CSS rule and then the ellipsis menu will be centered like the rest of the `PostItem` content due to [this `align-items: center` rule](https://github.com/Automattic/wp-calypso/blob/741b3ec/client/blocks/post-item/style.scss#L16).

| Before | After |
|--|--|
| ![2017-09-28t15 23 55-0500](https://user-images.githubusercontent.com/227022/30988788-1161c38a-a461-11e7-9778-d26ba12a6f9b.png) | ![2017-09-28t15 21 10-0500](https://user-images.githubusercontent.com/227022/30988751-ec6b02da-a460-11e7-97ba-3423e398d47d.png) |