### PR TITLE
Simple Payments: Remove "product name" placeholder

### DIFF
--- a/client/components/tinymce/plugins/simple-payments/dialog/form.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/form.jsx
@@ -82,7 +82,7 @@ const validate = ( values, props ) => {
 	const errors = {};
 
 	if ( ! values.title ) {
-		errors.title = translate( 'Product name can not be empty.' );
+		errors.title = translate( 'This can not be empty.' );
 	}
 
 	if ( ! values.price ) {
@@ -183,7 +183,6 @@ class ProductForm extends Component {
 					<ReduxFormFieldset
 						name="title"
 						label={ translate( 'What are you selling?' ) }
-						placeholder={ translate( 'Product name' ) }
 						component={ FormTextInput }
 					/>
 					<ReduxFormFieldset


### PR DESCRIPTION
The UI around Simple Payments have been designed for selling product. But we've learned many of our customers have used the button to sell services, courses, and asking donations etc. So how about removing the placeholder "Product name" to be inclusive of those non-product use cases?  I assume the label "What are you selling?" is clear enough without the placeholder.

Before:
<img width="918" alt="screen shot 2017-09-28 at 21 55 17" src="https://user-images.githubusercontent.com/908665/30990431-1f76705a-a499-11e7-9a6e-888d9371b1d3.png">

After:
<img width="915" alt="screen shot 2017-09-28 at 21 54 04" src="https://user-images.githubusercontent.com/908665/30990435-25491712-a499-11e7-8723-1a4591f6c7dd.png">

