### PR TITLE
Store: Add `isOrderEditable` helper function

### DIFF
--- a/client/extensions/woocommerce/lib/order-status/index.js
+++ b/client/extensions/woocommerce/lib/order-status/index.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -17,19 +18,10 @@ export const ORDER_COMPLETED = 'finished';
  * Lists of statuses in each group, waiting for payment, waiting for
  * fulfillment, and finished orders.
  */
-export const statusWaitingPayment = [
-	'on-hold',
-	'pending',
-];
-export const statusWaitingFulfillment = [
-	'processing',
-];
-export const statusFinished = [
-	'cancelled',
-	'completed',
-	'failed',
-	'refunded',
-];
+export const statusEditable = [ 'on-hold', 'pending' ];
+export const statusWaitingPayment = [ 'on-hold', 'pending' ];
+export const statusWaitingFulfillment = [ 'processing' ];
+export const statusFinished = [ 'cancelled', 'completed', 'failed', 'refunded' ];
 
 /**
  * Get a list of order statuses for display (including a translated label)
@@ -37,28 +29,36 @@ export const statusFinished = [
  * @return {Array} List of objects {name,value} for each status
  */
 export function getOrderStatusList() {
-	return [ {
-		value: 'pending',
-		name: translate( 'Pending payment' ),
-	}, {
-		value: 'processing',
-		name: translate( 'Processing' ),
-	}, {
-		value: 'on-hold',
-		name: translate( 'On hold' ),
-	}, {
-		value: 'completed',
-		name: translate( 'Completed' ),
-	}, {
-		value: 'cancelled',
-		name: translate( 'Cancelled' ),
-	}, {
-		value: 'refunded',
-		name: translate( 'Refunded' ),
-	}, {
-		value: 'failed',
-		name: translate( 'Payment failed' ),
-	} ];
+	return [
+		{
+			value: 'pending',
+			name: translate( 'Pending payment' ),
+		},
+		{
+			value: 'processing',
+			name: translate( 'Processing' ),
+		},
+		{
+			value: 'on-hold',
+			name: translate( 'On hold' ),
+		},
+		{
+			value: 'completed',
+			name: translate( 'Completed' ),
+		},
+		{
+			value: 'cancelled',
+			name: translate( 'Cancelled' ),
+		},
+		{
+			value: 'refunded',
+			name: translate( 'Refunded' ),
+		},
+		{
+			value: 'failed',
+			name: translate( 'Payment failed' ),
+		},
+	];
 }
 
 /**
@@ -68,7 +68,17 @@ export function getOrderStatusList() {
  * @return {Boolean} true if the status is awaiting payment
  */
 export function isOrderWaitingPayment( status ) {
-	return ( -1 !== statusWaitingPayment.indexOf( status ) );
+	return -1 !== statusWaitingPayment.indexOf( status );
+}
+
+/**
+ * Checks if this status (from an order) is editable
+ *
+ * @param {String} status Order status
+ * @return {Boolean} true if the status is editable
+ */
+export function isOrderEditable( status ) {
+	return -1 !== statusEditable.indexOf( status );
 }
 
 /**
@@ -78,7 +88,7 @@ export function isOrderWaitingPayment( status ) {
  * @return {Boolean} true if the status is awaiting fulfillment
  */
 export function isOrderWaitingFulfillment( status ) {
-	return ( -1 !== statusWaitingFulfillment.indexOf( status ) );
+	return -1 !== statusWaitingFulfillment.indexOf( status );
 }
 
 /**
@@ -88,5 +98,5 @@ export function isOrderWaitingFulfillment( status ) {
  * @return {Boolean} true if the status is completed, cancelled, or otherwise has no further action
  */
 export function isOrderFinished( status ) {
-	return ( -1 !== statusFinished.indexOf( status ) );
+	return -1 !== statusFinished.indexOf( status );
 }

--- a/client/extensions/woocommerce/lib/order-status/test/index.js
+++ b/client/extensions/woocommerce/lib/order-status/test/index.js
@@ -15,11 +15,11 @@ import {
 } from '../index';
 
 describe( 'isOrderEditable', () => {
-	it( 'should be false for a pending order', () => {
+	it( 'should be true for a pending order', () => {
 		expect( isOrderEditable( 'pending' ) ).to.be.true;
 	} );
 
-	it( 'should be false for an on-hold order', () => {
+	it( 'should be true for an on-hold order', () => {
 		expect( isOrderEditable( 'on-hold' ) ).to.be.true;
 	} );
 
@@ -27,11 +27,11 @@ describe( 'isOrderEditable', () => {
 		expect( isOrderEditable( 'processing' ) ).to.be.false;
 	} );
 
-	it( 'should be true for a completed order', () => {
+	it( 'should be false for a completed order', () => {
 		expect( isOrderEditable( 'completed' ) ).to.be.false;
 	} );
 
-	it( 'should be true for a failed order', () => {
+	it( 'should be false for a failed order', () => {
 		expect( isOrderEditable( 'failed' ) ).to.be.false;
 	} );
 

--- a/client/extensions/woocommerce/lib/order-status/test/index.js
+++ b/client/extensions/woocommerce/lib/order-status/test/index.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -7,10 +8,37 @@ import { expect } from 'chai';
  * Internal dependencies
  */
 import {
+	isOrderEditable,
 	isOrderWaitingPayment,
 	isOrderWaitingFulfillment,
 	isOrderFinished,
 } from '../index';
+
+describe( 'isOrderEditable', () => {
+	it( 'should be false for a pending order', () => {
+		expect( isOrderEditable( 'pending' ) ).to.be.true;
+	} );
+
+	it( 'should be false for an on-hold order', () => {
+		expect( isOrderEditable( 'on-hold' ) ).to.be.true;
+	} );
+
+	it( 'should be false for a processing order', () => {
+		expect( isOrderEditable( 'processing' ) ).to.be.false;
+	} );
+
+	it( 'should be true for a completed order', () => {
+		expect( isOrderEditable( 'completed' ) ).to.be.false;
+	} );
+
+	it( 'should be true for a failed order', () => {
+		expect( isOrderEditable( 'failed' ) ).to.be.false;
+	} );
+
+	it( 'should be false for a fake order status', () => {
+		expect( isOrderEditable( 'fake' ) ).to.be.false;
+	} );
+} );
 
 describe( 'isOrderWaitingPayment', () => {
 	it( 'should be true for a pending order', () => {


### PR DESCRIPTION
Orders can only be editable if their status is `pending` or `on-hold` (no payment has been accepted yet). I decided to create a function separate from `isOrderWaitingPayment` because we might need it later – as we include more extensions that might have custom statuses, these might be different cases.

This also runs prettier on both files, which I thought was a small enough change so I've left it in.

To test:

- Run the tests `npm run test-client client/extensions/woocommerce/lib/order-status/`

This isn't used anywhere in Calypso yet.