### PR TITLE
Store: add query param to launch NUX Customizer Tour

### DIFF
--- a/client/extensions/woocommerce/app/dashboard/setup-tasks.js
+++ b/client/extensions/woocommerce/app/dashboard/setup-tasks.js
@@ -108,6 +108,8 @@ class SetupTasks extends Component {
 			taxesAreSetUp,
 			translate
 		} = this.props;
+		const siteSlug = encodeURIComponent( '//' + site.slug );
+		const customizerUrl = getLink( 'https://:site/wp-admin/customize.php?store-wpcom-nux=true&return=' + siteSlug, site );
 
 		return [
 			{
@@ -184,7 +186,7 @@ class SetupTasks extends Component {
 				actions: [
 					{
 						label: translate( 'View and customize' ),
-						path: getLink( 'https://:site/wp-admin/customize.php?return=' + encodeURIComponent( '//' + site.slug ), site ),
+						path: customizerUrl,
 						onClick: this.onClickOpenCustomizer,
 						analyticsProp: 'view-and-customize',
 					}


### PR DESCRIPTION
This is for #17101 - and simply adds in a new query arg to the Customizer link that is used in the Dashboard setup checklist so the Customizer NUX Tour will be launched. As-is, this change won't do anything special outside of adding the query arg - in order to see/test the tour, you will need to install https://github.com/woocommerce/wc-api-dev/pull/54 on a test site - which isn't required here to test, but would be nice if you did check that out sometime too ;)

__To Test__
- Launch the store dashboard on a new site, or manipulate state accordingly to force the dashboard NUX steps to be displayed
- Verify the customizer link has the `wc-api-dev-tutorial=true` query arg included

The pre-commit linter complained about the line being too long, thus this one-liner PR ended up introducing 2 new `const`s