### PR TITLE
Comments: fall back to site post link until deep reader links for jetpack are supported

### DIFF
--- a/client/blocks/comment-detail/comment-detail-post.jsx
+++ b/client/blocks/comment-detail/comment-detail-post.jsx
@@ -2,8 +2,8 @@
  * External dependencies
  */
 import React from 'react';
-import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
+import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -11,11 +11,6 @@ import { localize } from 'i18n-calypso';
 import Emojify from 'components/emojify';
 import Gravatar from 'components/gravatar';
 import SiteIcon from 'blocks/site-icon';
-import {
-	bumpStat,
-	composeAnalytics,
-	recordTracksEvent,
-} from 'state/analytics/actions';
 
 export const CommentDetailPost = ( {
 	commentId,
@@ -25,8 +20,7 @@ export const CommentDetailPost = ( {
 	postAuthorDisplayName,
 	postTitle,
 	postUrl,
-	recordReaderArticleOpened,
-	recordReaderCommentOpened,
+	onClick = noop,
 	siteId,
 	translate,
 } ) => {
@@ -50,7 +44,7 @@ export const CommentDetailPost = ( {
 							</Emojify>
 						</span>
 					}
-					<a href={ `${ postUrl }#comment-${ commentId }` } onClick={ recordReaderCommentOpened }>
+					<a href={ `${ postUrl }#comment-${ commentId }` } onClick={ onClick }>
 						<Emojify>
 							{ parentCommentContent }
 						</Emojify>
@@ -71,7 +65,7 @@ export const CommentDetailPost = ( {
 						</Emojify>
 					</span>
 				}
-				<a href={ postUrl } onClick={ recordReaderArticleOpened }>
+				<a href={ postUrl } onClick={ onClick }>
 					<Emojify>
 						{ postTitle || translate( 'Untitled' ) }
 					</Emojify>
@@ -81,15 +75,4 @@ export const CommentDetailPost = ( {
 	);
 };
 
-const mapDispatchToProps = dispatch => ( {
-	recordReaderArticleOpened: () => dispatch( composeAnalytics(
-		recordTracksEvent( 'calypso_comment_management_article_opened' ),
-		bumpStat( 'calypso_comment_management', 'article_opened' )
-	) ),
-	recordReaderCommentOpened: () => dispatch( composeAnalytics(
-		recordTracksEvent( 'calypso_comment_management_comment_opened' ),
-		bumpStat( 'calypso_comment_management', 'comment_opened' )
-	) ),
-} );
-
-export default connect( null, mapDispatchToProps )( localize( CommentDetailPost ) );
+export default localize( CommentDetailPost );


### PR DESCRIPTION
This PR fixes #18319 by updating the post/comment link to point at the site post or site comment instead of the deep reader link. At the moment it doesn't appear that the reader is opening deep links from Jetpack sites correctly.

<img width="806" alt="screen shot 2017-09-28 at 5 13 23 pm" src="https://user-images.githubusercontent.com/1270189/30995618-64a92498-a470-11e7-9ca1-c372f3732f5b.png">

### Testing Instructions
- `localStorage.debug= 'calypso:analytics*'` to enable analytics debugging
- Navigate to calypso.localhost:3000/comments
- Select a simple site with comments
- Expand a comment 
- Click on the post/comment link
- `calypso_comment_management_article_opened` or `calypso_comment_management_comment_opened` analytics event fires as expected
- Verify that we navigate to the Calypso reader with the post or comment open
- Navigate to calypso.localhost:3000/comments
- Select a Jetpack site with comments
- Expand a comment 
- Click on the post/comment link
- `calypso_comment_management_article_opened` or `calypso_comment_management_comment_opened` does NOT fire
- Verify that we navigate to the site post or site comment

