### PR TITLE
Update error message on disconnected Jetpack Primary Site

### DIFF
--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -5,7 +5,7 @@ import page from 'page';
 import ReactDom from 'react-dom';
 import React from 'react';
 import i18n from 'i18n-calypso';
-import { uniq, some, startsWith } from 'lodash';
+import { uniq, some, startsWith, omit } from 'lodash';
 
 /**
  * Internal Dependencies
@@ -59,7 +59,7 @@ import {
 } from 'my-sites/domains/paths';
 import SitesComponent from 'my-sites/sites';
 import { isATEnabled } from 'lib/automated-transfer';
-import { errorNotice } from 'state/notices/actions';
+import { warningNotice } from 'state/notices/actions';
 import { getPrimaryDomainBySiteId } from 'state/selectors';
 
 /*
@@ -328,10 +328,12 @@ module.exports = {
 				} );
 			} else {
 				// If the primary site does not exist, skip redirect and display a useful error notification
-				dispatch( errorNotice( i18n.translate( 'Please set your Primary Site to valid site' ), {
-					button: 'Settings',
-					href: '/me/account',
+				dispatch( warningNotice( i18n.translate( 'Please check your Primary Site\'s Jetpack connection' ), {
+					button: 'wp-admin',
+					href: `${ currentUser.primary_blog_url }/wp-admin`,
 				} ) );
+
+				analytics.tracks.recordEvent( 'calypso_my-sites_single_site_jetpack_connection_error', omit( currentUser, 'meta' ) );
 			}
 		}
 


### PR DESCRIPTION
### Background
Users with just one site, which happens to be a Jetpack site, who have somehow disconnected Jetpack end up in an odd state where the primary blog is not retrieved on the `/sites` endpoint, causing my-sites to render without data.

Previously, https://github.com/Automattic/wp-calypso/pull/17731

![screen shot 2017-09-29 at 3 43 17 pm](https://user-images.githubusercontent.com/1922453/30998705-0161c166-a52d-11e7-8ffd-8ebd2c071229.png)

### Fix
Changes here attempt to bring a clearer error message to the user. The link is also changed from Settings to the offending site's wp-admin so the user can solve the problem themselves. Finally, add Tracks event to the error so we can know how often this error is shown, to whom, and the identity of problematic sites.

### Before
![screen shot 2017-09-29 at 3 44 54 pm](https://user-images.githubusercontent.com/1922453/30998736-2ea23eda-a52d-11e7-82b7-0679226e208e.png)

The error message was misleading because upon entry to Settings, the list of available sites (coming from `/sites`) didn't have anything. This was part of the cause in of the problem in the first place.

![screen shot 2017-09-29 at 3 45 58 pm](https://user-images.githubusercontent.com/1922453/30998790-83b859a4-a52d-11e7-831f-a29e5b2c735f.png)

### After
![screen shot 2017-09-29 at 3 43 04 pm](https://user-images.githubusercontent.com/1922453/30998744-3bb42854-a52d-11e7-918e-099c57e13e4d.png)

### Feedback Requested
First,
>Please check your Primary Site's Jetpack connection

Is this good?

Second, the link construction makes the assumption that the user's `primary_blog_url` + `/wp-admin` is always where wp-admin lies. Is this assumption valid?

cc @supernovia @jag24fps

Fixes https://github.com/Automattic/wp-calypso/issues/18258