### PR TITLE
Extensions: Zoninator - Prevent form submission on 'Enter' in SearchAutocomplete

### DIFF
--- a/client/extensions/zoninator/components/search-autocomplete/index.jsx
+++ b/client/extensions/zoninator/components/search-autocomplete/index.jsx
@@ -46,7 +46,13 @@ class SearchAutocomplete extends Component {
 
 	handleSearchOpen = () => this.setState( { searchIsOpen: true } );
 
-	handleKeyDown = event => this.suggestionsRef && this.suggestionsRef.handleKeyEvent( event );
+	handleKeyDown = event => {
+		if ( event.key === 'Enter' ) {
+			event.preventDefault();
+		}
+
+		this.suggestionsRef && this.suggestionsRef.handleKeyEvent( event );
+	}
 
 	handleSelect = ( item ) => {
 		this.searchRef.clear();


### PR DESCRIPTION
Fixes the issue where pressing `Enter` while the search field on *Edit Zone* page is focused would submit the form.  
See p7nzsm-nB-p2.

# Testing

- Go `/extensions/zoninator` and select a zone.
- Toggle the search field and press `Enter` - nothing should happen.
- Try typing and pressing `Enter` before any suggestions appear - nothing should happen.