### PR TITLE
Activity Log: fix long description alignment

### DIFF
--- a/client/my-sites/stats/activity-log-item/style.scss
+++ b/client/my-sites/stats/activity-log-item/style.scss
@@ -165,6 +165,7 @@
 .activity-log-item__title {
 	flex: 4 1;
 	font-size: 14px;
+	word-break: break-word;
 
 	@include breakpoint( "<960px" ) {
 		margin-bottom: 16px;


### PR DESCRIPTION
Fixes items with long descriptions, where they would cause vertical misalignment.

### How to test

- Open https://calypso.live/?branch=fix/activity-log-long-descriptions
- Visit `Stats > Activity`

### Before

![image](https://user-images.githubusercontent.com/390760/31011453-336cc01a-a506-11e7-8d3a-839e4d226168.png)


### After

![image](https://user-images.githubusercontent.com/390760/31011459-3c6dc3b2-a506-11e7-8b7c-b96eff03162a.png)
