### PR TITLE
Activity log: State cleanup

### DIFF
--- a/client/lib/query-manager/activity/test/index.js
+++ b/client/lib/query-manager/activity/test/index.js
@@ -15,8 +15,6 @@ import ActivityQueryManager from '..';
  */
 const DEFAULT_ACTIVITY_DATE = '2014-09-14T00:30:00+02:00';
 const DEFAULT_ACTIVITY_TS = Date.parse( DEFAULT_ACTIVITY_DATE );
-
-// TODO: Update with wpcom/v2 style activity stream data
 const DEFAULT_ACTIVITY = deepFreeze( {
 	activityDate: DEFAULT_ACTIVITY_DATE,
 	activityGroup: 'plugin',

--- a/client/state/activity-log/log/reducer.js
+++ b/client/state/activity-log/log/reducer.js
@@ -9,11 +9,9 @@ import { mapValues } from 'lodash';
  */
 import ActivityQueryManager from 'lib/query-manager/activity';
 import { ACTIVITY_LOG_UPDATE, DESERIALIZE, SERIALIZE } from 'state/action-types';
-import { createReducer, keyedReducer, isValidStateWithSchema } from 'state/utils';
+import { createReducer, isValidStateWithSchema } from 'state/utils';
 
 import { logItemsSchema } from './schema';
-
-export const logError = keyedReducer( 'siteId', state => state );
 
 export const logItems = createReducer(
 	{},

--- a/client/state/activity-log/reducer.js
+++ b/client/state/activity-log/reducer.js
@@ -3,13 +3,12 @@
  */
 import { combineReducers } from 'state/utils';
 import { activationRequesting } from './activation/reducer';
-import { logItems, logError } from './log/reducer';
+import { logItems } from './log/reducer';
 import { restoreProgress } from './restore/reducer';
 import { rewindStatus, rewindStatusError } from './rewind-status/reducer';
 
 export default combineReducers( {
 	activationRequesting,
-	logError,
 	logItems,
 	restoreProgress,
 	rewindStatus,

--- a/client/state/activity-log/rewind-status/reducer.js
+++ b/client/state/activity-log/rewind-status/reducer.js
@@ -12,10 +12,8 @@ import {
 	keyedReducer,
 } from 'state/utils';
 
-const stubNull = () => null;
-
-export const rewindStatus = keyedReducer( 'siteId', createReducer( {}, {
-	[ REWIND_STATUS_ERROR ]: stubNull,
+export const rewindStatus = keyedReducer( 'siteId', createReducer( undefined, {
+	[ REWIND_STATUS_ERROR ]: () => undefined,
 	[ REWIND_STATUS_UPDATE ]: ( state, { status } ) => status,
 	[ REWIND_ACTIVATE_SUCCESS ]: ( state ) => ( {
 		...state,
@@ -24,7 +22,7 @@ export const rewindStatus = keyedReducer( 'siteId', createReducer( {}, {
 } ) );
 rewindStatus.schema = rewindStatusSchema;
 
-export const rewindStatusError = keyedReducer( 'siteId', createReducer( {}, {
+export const rewindStatusError = keyedReducer( 'siteId', createReducer( undefined, {
 	[ REWIND_STATUS_ERROR ]: ( state, { error } ) => error,
-	[ REWIND_STATUS_UPDATE ]: stubNull,
+	[ REWIND_STATUS_UPDATE ]: () => undefined,
 } ) );

--- a/client/state/activity-log/rewind-status/test/reducer.js
+++ b/client/state/activity-log/rewind-status/test/reducer.js
@@ -73,12 +73,12 @@ describe( '#rewindStatus()', () => {
 		expect( state[ otherSiteId ] ).to.deep.equal( prevState[ otherSiteId ] );
 	} );
 
-	it( 'should null status on error', () => {
+	it( 'should clear status on error', () => {
 		const prevState = deepFreeze( {
 			[ SITE_ID ]: STATUS_ACTION.status,
 		} );
 		const state = rewindStatus( prevState, ERROR_ACTION );
-		expect( state[ SITE_ID ] ).to.be.null;
+		expect( state ).to.not.have.property( SITE_ID );
 	} );
 
 	it( 'should preserve other site\'s status on error', () => {
@@ -116,12 +116,12 @@ describe( '#rewindStatusError()', () => {
 		expect( state[ otherSiteId ] ).to.deep.equal( prevState[ otherSiteId ] );
 	} );
 
-	it( 'should null an error on status', () => {
+	it( 'should clear an error on status', () => {
 		const prevState = deepFreeze( {
 			[ SITE_ID ]: ERROR_ACTION.error,
 		} );
 		const state = rewindStatusError( prevState, STATUS_ACTION );
-		expect( state[ SITE_ID ] ).to.be.null;
+		expect( state ).to.not.have.property( SITE_ID );
 	} );
 
 	it( 'should preserve other site\'s error on status', () => {

--- a/client/state/data-layer/wpcom/sites/activity/test/from-api.js
+++ b/client/state/data-layer/wpcom/sites/activity/test/from-api.js
@@ -8,7 +8,7 @@ import { expect } from 'chai';
 /**
  * Internal dependencies
  */
-import fromApi, { itemsReducer, processItem } from '../from-api';
+import { itemsReducer, processItem } from '../from-api';
 
 const SITE_ID = 123456;
 
@@ -46,95 +46,44 @@ const VALID_API_ITEM = deepFreeze( {
 	status: 'warning',
 } );
 
-const API_RESPONSE_BODY = deepFreeze( {
-	'@context': 'https://www.w3.org/ns/activitystreams',
-	id: `https://public-api.wordpress.com/wpcom/v2/sites/${ SITE_ID }/activity`,
-	itemsPerPage: 1000,
-	page: 1,
-	summary: 'Activity log',
-	totalItems: 1,
-	totalPages: 1,
-	type: 'OrderedCollection',
+describe( 'itemsReducer', () => {
+	it( 'should return a new array', () => {
+		const accumulator = [];
+		expect( itemsReducer( accumulator, VALID_API_ITEM ) ).to.not.equal( accumulator );
+	} );
 
-	current: {
-		totalItems: 1,
-		orderedItems: [ VALID_API_ITEM ],
-		type: 'OrderedCollectionPage',
-		id: `https://public-api.wordpress.com/wpcom/v2/sites/${ SITE_ID }/activity?number=1000`,
-	},
+	it( 'should add items to array', () => {
+		expect( itemsReducer( [], VALID_API_ITEM ) ).to.be.an( 'array' ).that.is.not.empty;
+	} );
+
+	it( 'should append valid items to array', () => {
+		const existingItem = Object.create( null );
+		const result = itemsReducer( [ existingItem ], VALID_API_ITEM );
+		expect( result ).to.be.an( 'array' );
+		expect( result.length ).to.equal( 2 );
+		expect( result[ 0 ] ).to.equal( existingItem );
+	} );
 } );
 
-describe( 'fromApi', () => {
-	context( '#schema', () => {
-		it( 'should process a valid API response', () => {
-			expect( fromApi( API_RESPONSE_BODY ) ).to.be.an( 'array' ).that.is.not.empty;
-		} );
-
-		it( 'should process an empty response', () => {
-			const noCurrent = { ...API_RESPONSE_BODY };
-			delete noCurrent.current;
-			expect( fromApi( noCurrent ) ).to.be.an( 'array' ).that.is.empty;
-		} );
-
-		it( 'should throw with invalid data', () => {
-			expect( () =>
-				fromApi( {
-					...API_RESPONSE_BODY,
-					totalItems: 1,
-					current: {
-						...API_RESPONSE_BODY.current,
-						totalItems: 1,
-						orderedItems: [
-							{
-								...VALID_API_ITEM,
-								activity_id: null,
-							},
-						],
-					},
-				} )
-			).to.throw();
-		} );
-	} );
-
-	context( 'itemsReducer', () => {
-		it( 'should return a new array', () => {
-			const accumulator = [];
-			expect( itemsReducer( accumulator, VALID_API_ITEM ) ).to.not.equal( accumulator );
-		} );
-
-		it( 'should add valid items to array', () => {
-			expect( itemsReducer( [], VALID_API_ITEM ) ).to.be.an( 'array' ).that.is.not.empty;
-		} );
-
-		it( 'should append valid items to array', () => {
-			const existingItem = Object.create( null );
-			const result = itemsReducer( [ existingItem ], VALID_API_ITEM );
-			expect( result ).to.be.an( 'array' );
-			expect( result.length ).to.equal( 2 );
-			expect( result[ 0 ] ).to.equal( existingItem );
-		} );
-	} );
-
-	context( 'processItem', () => {
-		it( 'should process an item', () => {
-			expect( processItem( VALID_API_ITEM ) )
-				.to.be.an( 'object' )
-				.that.has.keys( [
-					'activityDate',
-					'activityGroup',
-					'activityIcon',
-					'activityId',
-					'activityName',
-					'activityStatus',
-					'activityTitle',
-					'activityTs',
-					'actorAvatarUrl',
-					'actorName',
-					'actorRemoteId',
-					'actorRole',
-					'actorType',
-					'actorWpcomId',
-				] );
-		} );
+describe( 'processItem', () => {
+	it( 'should process an item', () => {
+		expect( processItem( VALID_API_ITEM ) )
+			.to.be.an( 'object' )
+			.that.has.keys( [
+				'activityDate',
+				'activityGroup',
+				'activityIcon',
+				'activityId',
+				'activityName',
+				'activityStatus',
+				'activityTitle',
+				'activityTs',
+				'actorAvatarUrl',
+				'actorName',
+				'actorRemoteId',
+				'actorRole',
+				'actorType',
+				'actorWpcomId',
+			] );
 	} );
 } );


### PR DESCRIPTION
This PR removes an unused piece of the state tree that we originally expected to need (`logError`).

It removes testing for Activity `fromApi` that is essentially redundant testing of the `fromApi` implementation in the data-layer.

It uses `undefined` as the default state for `RewindStatus` and `RewindStatusError`, which also allows these states to be cleared rather than set to `null`. This is an enhancement that was made after this part of the state was implemented.

## Testing
1. Do tests pass?
1. Does it build?
1. Visit https://calypso.live/stats/activity?branch=update/activity-log/clean-state.
1. Does everything continue to work correctly?