### PR TITLE
Plugins: Fix styling for rating component

### DIFF
--- a/client/components/rating/index.jsx
+++ b/client/components/rating/index.jsx
@@ -84,7 +84,7 @@ export default class Rating extends React.PureComponent {
 		};
 
 		return (
-			<div className="rating" style={ { width: totalWidth + 'px' } }>
+			<div className="rating" style={ { width: totalWidth + 'px', height: size + 'px' } }>
 				<div className="rating__overlay" style={ overlayStyles }>
 					{ this.overlayStars() }
 				</div>

--- a/client/my-sites/plugins/plugin-ratings/style.scss
+++ b/client/my-sites/plugins/plugin-ratings/style.scss
@@ -21,6 +21,7 @@
 	font-size: 12px;
 	color: $gray;
 	margin-bottom: 16px;
+	margin-top: 30px;
 
 	@include breakpoint( '<480px' ) {
 		display: inline;

--- a/client/my-sites/plugins/plugin-ratings/style.scss
+++ b/client/my-sites/plugins/plugin-ratings/style.scss
@@ -21,7 +21,6 @@
 	font-size: 12px;
 	color: $gray;
 	margin-bottom: 16px;
-	margin-top: 30px;
 
 	@include breakpoint( '<480px' ) {
 		display: inline;


### PR DESCRIPTION
Align rating component properly.

Test:
1. Use a jetpack site
2. Plugins
3. Click on a plugin
4. Make sure rating is aligned

before:
![misaligned-rating](https://user-images.githubusercontent.com/1103398/31015736-f1cf8af4-a521-11e7-9ab2-542b57947af8.jpg)
after:
<img width="209" alt="screen shot 2017-09-29 at 14 23 42" src="https://user-images.githubusercontent.com/1103398/31015745-f9454cce-a521-11e7-9061-b1f5744efe1d.png">
