### PR TITLE
Jetpack Connect: Fix authorize step with no query args

### DIFF
--- a/client/jetpack-connect/authorize-form.jsx
+++ b/client/jetpack-connect/authorize-form.jsx
@@ -57,7 +57,7 @@ class JetpackConnectAuthorizeForm extends Component {
 			queryObject: PropTypes.shape( {
 				client_id: PropTypes.string,
 				from: PropTypes.string,
-			} ).isRequired,
+			} ),
 		} ).isRequired,
 		recordTracksEvent: PropTypes.func,
 		setTracksAnonymousUserId: PropTypes.func,
@@ -72,7 +72,7 @@ class JetpackConnectAuthorizeForm extends Component {
 	componentWillMount() {
 		// set anonymous ID for cross-system analytics
 		const queryObject = this.props.jetpackConnectAuthorize.queryObject;
-		if ( queryObject._ui && 'anon' === queryObject._ut ) {
+		if ( queryObject && queryObject._ui && 'anon' === queryObject._ut ) {
 			this.props.setTracksAnonymousUserId( queryObject._ui );
 		}
 		this.props.recordTracksEvent( 'calypso_jpc_authorize_form_view' );


### PR DESCRIPTION
While working on #17604 I noticed we've broken the case when someone tries to access https://wordpress.com/jetpack/connect/authorize directly, without going through the connection flow. The working version used to display a **Oops, this URL should not be accessed directly** error message in that case.

Seems to have been introduced in #17591.

To test:
* Checkout this branch.
* Go to http://calypso.localhost:3000/jetpack/connect/authorize
* Verify you can see the **Oops, this URL should not be accessed directly** screen.
* Verify there are no errors/warnings displayed in the console.