### PR TITLE
Jetpack Connect: Introduce a Happychat button component

### DIFF
--- a/client/jetpack-connect/happychat-button.jsx
+++ b/client/jetpack-connect/happychat-button.jsx
@@ -1,0 +1,52 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import Gridicon from 'gridicons';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import HappychatButton from 'components/happychat/button';
+import HappychatConnection from 'components/happychat/connection';
+import {
+	hasActiveHappychatSession,
+	isHappychatAvailable,
+} from 'state/happychat/selectors';
+
+const JetpackConnectHappychatButton = ( {
+	children,
+	isChatActive,
+	isChatAvailable,
+	translate,
+} ) => {
+	if ( ! isChatAvailable && ! isChatActive ) {
+		return (
+			<div>
+				<HappychatConnection />
+				{ children }
+			</div>
+		);
+	}
+
+	return (
+		<HappychatButton
+			className="logged-out-form__link-item jetpack-connect__happychat-button"
+			borderless={ false }
+		>
+			<HappychatConnection />
+			<Gridicon icon="chat" />
+			{ ' ' }
+			{ translate( 'Get help connecting your site' ) }
+		</HappychatButton>
+	);
+};
+
+export default connect(
+	state => ( {
+		isChatAvailable: isHappychatAvailable( state ),
+		isChatActive: hasActiveHappychatSession( state ),
+	} ),
+)( localize( JetpackConnectHappychatButton ) );

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -42,6 +42,10 @@
 				top: 4px;
 			}
 		}
+
+		.jetpack-connect__happychat-button {
+			text-align: center;
+		}
 	}
 }
 

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -11,6 +11,9 @@
 			}
 		}
 
+		.jetpack-connect__happychat-button {
+			text-align: center;
+		}
 	}
 
 	.formatted-header{
@@ -491,6 +494,23 @@
 	.button.is-compact {
 		font-size: 14px;
 		font-weight: 500;
+	}
+}
+
+.jetpack-connect__happychat-button {
+	background: none;
+	border: none;
+	color: darken( $gray, 20% );
+	padding: 16px 24px;
+	text-align: left;
+	width: 100%;
+
+	&:visited {
+		color: $gray;
+	}
+
+	&:hover {
+		color: $blue-medium;
 	}
 }
 

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -10,10 +10,6 @@
 				top: 4px;
 			}
 		}
-
-		.jetpack-connect__happychat-button {
-			text-align: center;
-		}
 	}
 
 	.formatted-header{
@@ -28,6 +24,10 @@
 
 	.button.is-primary {
 		width: 320px;
+	}
+
+	.jetpack-connect__happychat-button {
+		text-align: center;
 	}
 }
 

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -501,6 +501,7 @@
 	background: none;
 	border: none;
 	color: darken( $gray, 20% );
+	font-weight: normal;
 	padding: 16px 24px;
 	text-align: left;
 	width: 100%;


### PR DESCRIPTION
### Purpose

This PR introduces a Happychat button component for use in Jetpack Connect. It will be used in the footer links on most of the Jetpack Connect pages. Part of #17604 and #18149.

### How it works
It consists of a simple component that decides whether to display the Happychat button (if it's available), or whatever else we pass it as component children otherwise.

### Preview:

![](https://cldup.com/x7FpFiy66c.png)

### Testing instructions

* Checkout the branch from #18397 (`update/jetpack-connect-use-happychat`), which contains this one.
* Go through some Jetpack Connect flows (see #18397 for detailed testing instructions) and verify the button looks and works properly.