### PR TITLE
Jetpack Connect: Use Happychat button instead of help link

### DIFF
--- a/client/jetpack-connect/auth-logged-in-form.jsx
+++ b/client/jetpack-connect/auth-logged-in-form.jsx
@@ -20,6 +20,7 @@ import FormLabel from 'components/forms/form-label';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import Gravatar from 'components/gravatar';
 import HelpButton from './help-button';
+import JetpackConnectHappychatButton from './happychat-button';
 import JetpackConnectNotices from './jetpack-connect-notices';
 import LoggedOutFormFooter from 'components/logged-out-form/footer';
 import LoggedOutFormLinkItem from 'components/logged-out-form/link-item';
@@ -503,7 +504,9 @@ class LoggedInForm extends Component {
 				<LoggedOutFormLinkItem onClick={ this.handleSignOut }>
 					{ translate( 'Create a new account' ) }
 				</LoggedOutFormLinkItem>
-				<HelpButton onClick={ this.handleClickHelp } />
+				<JetpackConnectHappychatButton>
+					<HelpButton onClick={ this.handleClickHelp } />
+				</JetpackConnectHappychatButton>
 			</LoggedOutFormLinks>
 		);
 	}

--- a/client/jetpack-connect/authorize-form.jsx
+++ b/client/jetpack-connect/authorize-form.jsx
@@ -39,6 +39,7 @@ import { requestSites } from 'state/sites/actions';
 import { isRequestingSites, isRequestingSite } from 'state/sites/selectors';
 import MainWrapper from './main-wrapper';
 import HelpButton from './help-button';
+import JetpackConnectHappychatButton from './happychat-button';
 import { urlToSlug } from 'lib/url';
 import LoggedInForm from './auth-logged-in-form';
 import LoggedOutForm from './auth-logged-out-form';
@@ -112,7 +113,9 @@ class JetpackConnectAuthorizeForm extends Component {
 					actionURL="/jetpack/connect"
 				/>
 				<LoggedOutFormLinks>
-					<HelpButton onClick={ this.handleClickHelp } />
+					<JetpackConnectHappychatButton>
+						<HelpButton onClick={ this.handleClickHelp } />
+					</JetpackConnectHappychatButton>
 				</LoggedOutFormLinks>
 			</Main>
 		);

--- a/client/jetpack-connect/main.jsx
+++ b/client/jetpack-connect/main.jsx
@@ -32,6 +32,7 @@ import { recordTracksEvent } from 'state/analytics/actions';
 import MainWrapper from './main-wrapper';
 import FormattedHeader from 'components/formatted-header';
 import HelpButton from './help-button';
+import JetpackConnectHappychatButton from './happychat-button';
 import untrailingslashit from 'lib/route/untrailingslashit';
 import {
 	confirmJetpackInstallStatus,
@@ -348,15 +349,17 @@ class JetpackConnectMain extends Component {
 		const { translate } = this.props;
 		return (
 			<LoggedOutFormLinks>
-				<LoggedOutFormLinkItem href="https://jetpack.com/support/installing-jetpack/">
-					{ translate( 'Install Jetpack manually' ) }
-				</LoggedOutFormLinkItem>
-				{ this.isInstall() ? null : (
-					<LoggedOutFormLinkItem href="/start">
-						{ translate( 'Start a new site on WordPress.com' ) }
+				<JetpackConnectHappychatButton>
+					<LoggedOutFormLinkItem href="https://jetpack.com/support/installing-jetpack/">
+						{ translate( 'Install Jetpack manually' ) }
 					</LoggedOutFormLinkItem>
-				) }
-				<HelpButton />
+					{ this.isInstall() ? null : (
+						<LoggedOutFormLinkItem href="/start">
+							{ translate( 'Start a new site on WordPress.com' ) }
+						</LoggedOutFormLinkItem>
+					) }
+					<HelpButton />
+				</JetpackConnectHappychatButton>
 			</LoggedOutFormLinks>
 		);
 	}
@@ -478,7 +481,9 @@ class JetpackConnectMain extends Component {
 					<div className="jetpack-connect__navigation">{ this.renderBackButton() }</div>
 				</div>
 				<LoggedOutFormLinks>
-					<HelpButton />
+					<JetpackConnectHappychatButton>
+						<HelpButton />
+					</JetpackConnectHappychatButton>
 				</LoggedOutFormLinks>
 			</MainWrapper>
 		);

--- a/client/jetpack-connect/sso.jsx
+++ b/client/jetpack-connect/sso.jsx
@@ -38,6 +38,7 @@ import Dialog from 'components/dialog';
 import analytics from 'lib/analytics';
 import MainWrapper from './main-wrapper';
 import HelpButton from './help-button';
+import JetpackConnectHappychatButton from './happychat-button';
 import EmailVerificationGate from 'components/email-verification/email-verification-gate';
 
 /*
@@ -457,7 +458,9 @@ class JetpackSsoForm extends Component {
 						>
 							{ this.getReturnToSiteText() }
 						</LoggedOutFormLinkItem>
-						<HelpButton />
+						<JetpackConnectHappychatButton>
+							<HelpButton />
+						</JetpackConnectHappychatButton>
 					</LoggedOutFormLinks>
 				</div>
 


### PR DESCRIPTION
### Purpose

This PR updates the Jetpack Connect components to use the Happychat button that was introduced in #18396. Depends on #18396 and was rebased against it. Also contains #18393, as it fixes an error in the authorization page when we access it directly. It also places the JPC Happychat button under a feature flag (done separately in #18567).

Fixes #17604.
Fixes #18149.

### How it works

The Happychat button will be displayed only if Happychat is available. Otherwise, we're falling back to what we had before. In most cases, that is the old help button.

Currently, we've enabled this functionality only for development, stage, test, horizon and wpcalypso environments, so for production we're using what we had before.

### Previews

Concentrate on the **Get help connecting your site** button at the bottom, which looks like this by itself:
![](https://cldup.com/x7FpFiy66c.png)

Updates can be seen in the following locations

**1. Jetpack Connect - Home**
We're removing the "Install Jetpack manually", "Start a new site on WordPress.com" and the old help button in favor of the Happychat button. In case Happychat is not available, they'll still be displayed there.
![](https://cldup.com/KuNteKJf_p.png)

**2. Jetpack Connect - Instructions**
We're removing the old help button in favor of the Happychat button. In case Happychat is not available, the old help button will still be displayed there.
![](https://cldup.com/Z0p8ytm12Q.png)

**3. Jetpack Connect - Authorization Approval**
We're removing the old help button in favor of the Happychat button. In case Happychat is not available, the old help button will still be displayed there. We're keeping the rest of the buttons, which might be of help in the current context.
![](https://cldup.com/dOVkAECxil.png)

**4. Jetpack Connect - Authorization Error**
We're removing the old help button in favor of the Happychat button. In case Happychat is not available, the old help button will still be displayed there. We're keeping the rest of the buttons, which might be of help in the current context.
![](https://cldup.com/LkxzZSnjvg.png)

**5. Jetpack Connect - Authorization Page (without query args)**
We're removing the old help button in favor of the Happychat button. In case Happychat is not available, the old help button will still be displayed there. We're keeping the rest of the buttons, which might be of help in the current context.
![](https://cldup.com/uPA7dtwh5c.png)

**6. Jetpack Connect - SSO flow**
We're removing the old help button in favor of the Happychat button. In case Happychat is not available, the old help button will still be displayed there. We're keeping the rest of the buttons, which might be of help in the current context.
![](https://cldup.com/c0Q-F058dy.png)

### Testing

* Checkout this branch
* Make sure live chat is available (see below for information)
* Go through some free and paid Jetpack Connect flows and verify you can see the new button.
* Go through the SSO flow and verify you can see the new button.
* Load http://calypso.localhost:3000/jetpack/connect/authorize and verify you can see the new button at the bottom.
* Verify the button works in all of the instances, opening the happychat window in the sidebar.
* Test all of the above cases with live chat disabled and verify everything behaves as it did before.

If live chat is currently unavailable, you can login to Happychat staging and make yourself available. Another option to test is to force-enable Happychat by running the following commands in your browser console:

```
dispatch( { type: 'HAPPYCHAT_CONNECTED' } );
dispatch( { type: 'HAPPYCHAT_SET_AVAILABLE', isAvailable: true } );
```