### PR TITLE
Extensions: Zoninator - Redirect to zone details instead of zones dashboard after adding a zone

### DIFF
--- a/client/extensions/zoninator/components/settings/zone-creator/index.jsx
+++ b/client/extensions/zoninator/components/settings/zone-creator/index.jsx
@@ -27,7 +27,7 @@ class ZoneCreator extends PureComponent {
 		translate: PropTypes.func.isRequired,
 	};
 
-	save = ( form, data ) => this.props.addZone( this.props.siteId, form, data );
+	save = ( form, data ) => this.props.addZone( this.props.siteId, this.props.siteSlug, form, data );
 
 	render() {
 		const { siteSlug, translate } = this.props;

--- a/client/extensions/zoninator/components/settings/zone/index.jsx
+++ b/client/extensions/zoninator/components/settings/zone/index.jsx
@@ -50,7 +50,8 @@ class Zone extends Component {
 
 	hideDeleteDialog = () => this.setState( { showDeleteDialog: false } );
 
-	deleteZone = () => this.props.deleteZone( this.props.siteId, this.props.zoneId );
+	deleteZone = () =>
+		this.props.deleteZone( this.props.siteId, this.props.siteSlug, this.props.zoneId );
 
 	saveZoneDetails = ( form, data ) =>
 		this.props.saveZone( this.props.siteId, this.props.zoneId, form, data );

--- a/client/extensions/zoninator/state/data-layer/zones/index.js
+++ b/client/extensions/zoninator/state/data-layer/zones/index.js
@@ -116,9 +116,10 @@ export const announceZoneSaved = ( dispatch, { form, siteId }, zone ) => {
 
 export const handleZoneCreated = ( { dispatch, getState }, action, response ) => {
 	const { siteId } = action;
+	const zone = fromApi( response.data );
 
-	page( `/extensions/zoninator/${ getSiteSlug( getState(), siteId ) }` );
-	announceZoneSaved( dispatch, action, fromApi( response.data ) );
+	page( `/extensions/zoninator/zone/${ getSiteSlug( getState(), siteId ) }/${ zone.id }` );
+	announceZoneSaved( dispatch, action, zone );
 };
 
 export const handleZoneSaved = ( { dispatch, getState }, action ) => {

--- a/client/extensions/zoninator/state/data-layer/zones/index.js
+++ b/client/extensions/zoninator/state/data-layer/zones/index.js
@@ -4,7 +4,6 @@
  * External dependencies
  */
 
-import page from 'page';
 import { translate } from 'i18n-calypso';
 import { initialize, startSubmit, stopSubmit } from 'redux-form';
 import { merge, reduce } from 'lodash';
@@ -15,6 +14,7 @@ import { merge, reduce } from 'lodash';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { errorNotice, removeNotice, successNotice } from 'state/notices/actions';
+import { navigate } from 'state/ui/actions';
 import { getSiteSlug } from 'state/sites/selectors';
 import { getZone } from '../../zones/selectors';
 import { requestZones, requestError, updateZone, updateZones } from '../../zones/actions';
@@ -108,17 +108,17 @@ export const saveZone = ( { dispatch }, action ) => {
 	);
 };
 
-export const announceZoneSaved = ( dispatch, { form, siteId }, zone ) => {
+const announceZoneSaved = ( dispatch, { form, siteId }, zone ) => {
 	dispatch( stopSubmit( form ) );
 	dispatch( updateZone( siteId, zone.id, zone ) );
 	dispatch( successNotice( translate( 'Zone saved!' ), { id: saveZoneNotice } ) );
 };
 
 export const handleZoneCreated = ( { dispatch, getState }, action, response ) => {
-	const { siteId } = action;
+	const siteSlug = getSiteSlug( getState(), action.siteId );
 	const zone = fromApi( response.data );
 
-	page( `/extensions/zoninator/zone/${ getSiteSlug( getState(), siteId ) }/${ zone.id }` );
+	dispatch( navigate( `${ settingsPath }/zone/${ siteSlug }/${ zone.id }` ) );
 	announceZoneSaved( dispatch, action, zone );
 };
 
@@ -158,7 +158,7 @@ export const deleteZone = ( { dispatch }, action ) => {
 };
 
 export const announceZoneDeleted = ( { dispatch, getState }, { siteId } ) => {
-	page( `${ settingsPath }/${ getSiteSlug( getState(), siteId ) }` );
+	dispatch( navigate( `${ settingsPath }/${ getSiteSlug( getState(), siteId ) }` ) );
 	dispatch( requestZones( siteId ) );
 	dispatch( successNotice( translate( 'The zone has been deleted.' ), { id: deleteZoneNotice } ) );
 };

--- a/client/extensions/zoninator/state/data-layer/zones/index.js
+++ b/client/extensions/zoninator/state/data-layer/zones/index.js
@@ -6,7 +6,7 @@
 
 import { translate } from 'i18n-calypso';
 import { initialize, startSubmit, stopSubmit } from 'redux-form';
-import { merge, reduce } from 'lodash';
+import { reduce } from 'lodash';
 
 /**
  * Internal dependencies
@@ -15,8 +15,6 @@ import { http } from 'state/data-layer/wpcom-http/actions';
 import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { errorNotice, removeNotice, successNotice } from 'state/notices/actions';
 import { navigate } from 'state/ui/actions';
-import { getSiteSlug } from 'state/sites/selectors';
-import { getZone } from '../../zones/selectors';
 import { requestZones, requestError, updateZone, updateZones } from '../../zones/actions';
 import { fromApi } from './utils';
 import {
@@ -114,20 +112,18 @@ const announceZoneSaved = ( dispatch, { form, siteId }, zone ) => {
 	dispatch( successNotice( translate( 'Zone saved!' ), { id: saveZoneNotice } ) );
 };
 
-export const handleZoneCreated = ( { dispatch, getState }, action, response ) => {
-	const siteSlug = getSiteSlug( getState(), action.siteId );
+export const handleZoneCreated = ( { dispatch }, action, response ) => {
 	const zone = fromApi( response.data );
 
-	dispatch( navigate( `${ settingsPath }/zone/${ siteSlug }/${ zone.id }` ) );
+	dispatch( navigate( `${ settingsPath }/zone/${ action.siteSlug }/${ zone.id }` ) );
 	announceZoneSaved( dispatch, action, zone );
 };
 
-export const handleZoneSaved = ( { dispatch, getState }, action ) => {
-	const { data, form, siteId, zoneId } = action;
-	const newZone = merge( {}, getZone( getState(), siteId, zoneId ), data );
+export const handleZoneSaved = ( { dispatch }, action ) => {
+	const { data, form } = action;
 
-	dispatch( initialize( form, newZone ) );
-	announceZoneSaved( dispatch, action, newZone );
+	dispatch( initialize( form, data ) );
+	announceZoneSaved( dispatch, action, data );
 };
 
 export const announceSaveFailure = ( { dispatch }, { form } ) => {
@@ -157,8 +153,8 @@ export const deleteZone = ( { dispatch }, action ) => {
 	);
 };
 
-export const announceZoneDeleted = ( { dispatch, getState }, { siteId } ) => {
-	dispatch( navigate( `${ settingsPath }/${ getSiteSlug( getState(), siteId ) }` ) );
+export const announceZoneDeleted = ( { dispatch }, { siteId, siteSlug } ) => {
+	dispatch( navigate( `${ settingsPath }/${ siteSlug }` ) );
 	dispatch( requestZones( siteId ) );
 	dispatch( successNotice( translate( 'The zone has been deleted.' ), { id: deleteZoneNotice } ) );
 };

--- a/client/extensions/zoninator/state/data-layer/zones/test/index.js
+++ b/client/extensions/zoninator/state/data-layer/zones/test/index.js
@@ -224,24 +224,17 @@ describe( '#saveZone()', () => {
 } );
 
 describe( '#handleZoneCreated()', () => {
-	const getState = () => ( {
-		sites: {
-			items: {
-				[ 123 ]: { URL: 'test.dev' },
-			},
-		},
-	} );
-
 	test( 'should dispatch `navigate`', () => {
 		const dispatch = sinon.spy();
 		const action = {
 			type: 'DUMMY_ACTION',
 			siteId: 123,
+			siteSlug: 'test.dev',
 			form: 'form',
 			data: { name: 'Test Zone' },
 		};
 
-		handleZoneCreated( { dispatch, getState }, action, { data: zone } );
+		handleZoneCreated( { dispatch }, action, { data: zone } );
 
 		expect( dispatch ).to.have.been.calledWith(
 			navigate( '/extensions/zoninator/zone/test.dev/43' )
@@ -253,11 +246,12 @@ describe( '#handleZoneCreated()', () => {
 		const action = {
 			type: 'DUMMY_ACTION',
 			siteId: 123,
+			siteSlug: 'test.dev',
 			form: 'form',
 			data: { name: 'Test Zone' },
 		};
 
-		handleZoneCreated( { dispatch, getState }, action, { data: zone } );
+		handleZoneCreated( { dispatch }, action, { data: zone } );
 
 		expect( dispatch ).to.have.been.calledWith( stopSubmit( 'form' ) );
 	} );
@@ -267,11 +261,12 @@ describe( '#handleZoneCreated()', () => {
 		const action = {
 			type: 'DUMMY_ACTION',
 			siteId: 123,
+			siteSlug: 'test.dev',
 			form: 'form',
 			data: { name: 'Test Zone' },
 		};
 
-		handleZoneCreated( { dispatch, getState }, action, { data: zone } );
+		handleZoneCreated( { dispatch }, action, { data: zone } );
 
 		expect( dispatch ).to.have.been.calledWith( updateZone( 123, zone.term_id, fromApi( zone ) ) );
 	} );
@@ -285,7 +280,7 @@ describe( '#handleZoneCreated()', () => {
 			data: { name: 'Test Zone' },
 		};
 
-		handleZoneCreated( { dispatch, getState }, action, { data: zone } );
+		handleZoneCreated( { dispatch }, action, { data: zone } );
 
 		expect( dispatch ).to.have.been.calledWith(
 			successNotice( translate( 'Zone saved!' ), { id: 'zoninator-zone-create' } )
@@ -294,24 +289,6 @@ describe( '#handleZoneCreated()', () => {
 } );
 
 describe( '#handleZoneSaved()', () => {
-	const getState = () => ( {
-		extensions: {
-			zoninator: {
-				zones: {
-					items: {
-						123: {
-							456: {
-								id: 456,
-								name: 'Before',
-								description: 'Zone description',
-							},
-						},
-					},
-				},
-			},
-		},
-	} );
-
 	test( 'should dispatch `initialize`', () => {
 		const dispatch = sinon.spy();
 		const action = {
@@ -319,16 +296,16 @@ describe( '#handleZoneSaved()', () => {
 			siteId: 123,
 			zoneId: 456,
 			form: 'form',
-			data: { name: 'After' },
+			data: { id: 456, name: 'After', description: 'A description' },
 		};
 
-		handleZoneSaved( { dispatch, getState }, action );
+		handleZoneSaved( { dispatch }, action );
 
 		expect( dispatch ).to.have.been.calledWith(
 			initialize( 'form', {
 				id: 456,
 				name: 'After',
-				description: 'Zone description',
+				description: 'A description',
 			} )
 		);
 	} );
@@ -343,7 +320,7 @@ describe( '#handleZoneSaved()', () => {
 			data: { name: 'Test zone' },
 		};
 
-		handleZoneSaved( { dispatch, getState }, action );
+		handleZoneSaved( { dispatch }, action );
 
 		expect( dispatch ).to.have.been.calledWith( stopSubmit( 'form' ) );
 	} );
@@ -355,16 +332,16 @@ describe( '#handleZoneSaved()', () => {
 			siteId: 123,
 			zoneId: 456,
 			form: 'form',
-			data: { name: 'After' },
+			data: { id: 456, name: 'After', description: '' },
 		};
 
-		handleZoneSaved( { dispatch, getState }, action );
+		handleZoneSaved( { dispatch }, action );
 
 		expect( dispatch ).to.have.been.calledWith(
 			updateZone( 123, 456, {
 				id: 456,
 				name: 'After',
-				description: 'Zone description',
+				description: '',
 			} )
 		);
 	} );
@@ -379,7 +356,7 @@ describe( '#handleZoneSaved()', () => {
 			data: { name: 'Test zone' },
 		};
 
-		handleZoneSaved( { dispatch, getState }, action );
+		handleZoneSaved( { dispatch }, action );
 
 		expect( dispatch ).to.have.been.calledWith(
 			successNotice( translate( 'Zone saved!' ), { id: 'zoninator-zone-create' } )
@@ -460,23 +437,16 @@ describe( '#deleteZone()', () => {
 } );
 
 describe( '#announceZoneDeleted()', () => {
-	const getState = () => ( {
-		sites: {
-			items: {
-				[ 123 ]: { URL: 'test.dev' },
-			},
-		},
-	} );
-
 	test( 'should dispatch `navigate`', () => {
 		const dispatch = sinon.spy();
 		const action = {
 			type: 'DUMMY_ACTION',
 			siteId: 123,
+			siteSlug: 'test.dev',
 			zoneId: 456,
 		};
 
-		announceZoneDeleted( { dispatch, getState }, action );
+		announceZoneDeleted( { dispatch }, action );
 
 		expect( dispatch ).to.have.been.calledWith( navigate( '/extensions/zoninator/test.dev' ) );
 	} );
@@ -486,10 +456,11 @@ describe( '#announceZoneDeleted()', () => {
 		const action = {
 			type: 'DUMMY_ACTION',
 			siteId: 123,
+			siteSlug: 'test.dev',
 			zoneId: 456,
 		};
 
-		announceZoneDeleted( { dispatch, getState }, action );
+		announceZoneDeleted( { dispatch }, action );
 
 		expect( dispatch ).to.have.been.calledWith( requestZones( 123 ) );
 	} );
@@ -499,10 +470,11 @@ describe( '#announceZoneDeleted()', () => {
 		const action = {
 			type: 'DUMMY_ACTION',
 			siteId: 123,
+			siteSlug: 'test.dev',
 			zoneId: 456,
 		};
 
-		announceZoneDeleted( { dispatch, getState }, action );
+		announceZoneDeleted( { dispatch }, action );
 
 		expect( dispatch ).to.have.been.calledWith(
 			successNotice( translate( 'The zone has been deleted.' ), { id: 'zoninator-zone-delete' } )

--- a/client/extensions/zoninator/state/zones/actions.js
+++ b/client/extensions/zoninator/state/zones/actions.js
@@ -57,14 +57,16 @@ export const updateZone = ( siteId, zoneId, data ) => ( {
 /**
  * Returns an action object to indicate that a new zone should be created.
  *
- * @param  {Number} siteId Site ID
- * @param  {String} form   Form name
- * @param  {Object} data   Zone details
- * @return {Object}        Action object
+ * @param  {Number} siteId   Site ID
+ * @param  {String} siteSlug Site slug
+ * @param  {String} form     Form name
+ * @param  {Object} data     Zone details
+ * @return {Object}          Action object
  */
-export const addZone = ( siteId, form, data ) => ( {
+export const addZone = ( siteId, siteSlug, form, data ) => ( {
 	type: ZONINATOR_ADD_ZONE,
 	siteId,
+	siteSlug,
 	form,
 	data,
 } );
@@ -88,8 +90,14 @@ export const saveZone = ( siteId, zoneId, form, data ) => ( {
 
 /**
  * Returns an action object to indicate that a zone should be deleted.
- * @param  {Number} siteId Site ID
- * @param  {Number} zoneId Zone ID
- * @return {Object}        Action object
+ * @param  {Number} siteId   Site ID
+ * @param  {String} siteSlug Site slug
+ * @param  {Number} zoneId   Zone ID
+ * @return {Object}          Action object
  */
-export const deleteZone = ( siteId, zoneId ) => ( { type: ZONINATOR_DELETE_ZONE, siteId, zoneId } );
+export const deleteZone = ( siteId, siteSlug, zoneId ) => ( {
+	type: ZONINATOR_DELETE_ZONE,
+	siteId,
+	siteSlug,
+	zoneId,
+} );

--- a/client/extensions/zoninator/state/zones/test/actions.js
+++ b/client/extensions/zoninator/state/zones/test/actions.js
@@ -29,6 +29,7 @@ import {
 
 describe( 'actions', () => {
 	const siteId = 123456;
+	const siteSlug = 'test.dev';
 	const zones = {
 		1: {
 			id: 1,
@@ -91,13 +92,14 @@ describe( 'actions', () => {
 
 	describe( '#addZone()', () => {
 		test( 'should return an action object', () => {
-			const action = addZone( siteId, 'form', zones[ 1 ] );
+			const action = addZone( siteId, siteSlug, 'form', zones[ 1 ] );
 
 			expect( action ).to.deep.equal( {
 				type: ZONINATOR_ADD_ZONE,
 				data: zones[ 1 ],
 				form: 'form',
 				siteId,
+				siteSlug,
 			} );
 		} );
 	} );
@@ -118,12 +120,13 @@ describe( 'actions', () => {
 
 	describe( '#deleteZone', () => {
 		test( 'should return an action object', () => {
-			const action = deleteZone( siteId, zones[ 1 ].id );
+			const action = deleteZone( siteId, siteSlug, zones[ 1 ].id );
 
 			expect( action ).to.deep.equal( {
 				type: ZONINATOR_DELETE_ZONE,
 				zoneId: 1,
 				siteId,
+				siteSlug,
 			} );
 		} );
 	} );


### PR DESCRIPTION
Changes the behaviour after creating a new zone. The user will now be redirected to the details page of the zone he just created rather than zones dashboard as that seems more intuitive.  
See p7nzsm-nB-p2.

# Testing

- Go to `/extensions/zoninator` and click **Add a zone**.
- Proceed to fill out the form and click **save**.
- A success notification should appear and you should be redirected to **Edit zone** view for the zone you just created.