### PR TITLE
Plugins Browser: pass site slug in getFullListView instead of full site object

### DIFF
--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -168,7 +168,7 @@ const PluginsBrowser = React.createClass( {
 					plugins={ list }
 					listName={ category }
 					title={ this.translateCategory( category ) }
-					site={ this.props.selectedSite }
+					site={ this.props.siteSlug }
 					showPlaceholders={ isFetching }
 					currentSites={ this.props.sites }
 				/>


### PR DESCRIPTION
**Steps to reproduce:**
1. Go to `/plugins/browse/popular/my.jetpack.site`
2. List of WP.org plugins is displayed. Hover over any of them and look at the URL where it links.

**Expected:**
`https://wordpress.com/plugins/contact-form-7/my.jetpack.site`

**Actual:**
`https://wordpress.com/plugins/contact-form-7/[object Object]`

The `site` prop passed to `PluginsBrowserList` should be a string site slug, not a full site object. This bug was introduced in #15765 when removing sites-list from plugins browser.
