### PR TITLE
Components: Suggestions - Fix suggestions concatenating suggestion parts in case of leading spaces

### DIFF
--- a/client/components/suggestions/style.scss
+++ b/client/components/suggestions/style.scss
@@ -12,6 +12,7 @@
   border: 1px solid darken( $gray-light, 10% );
   border-top: 0px;
   font-size: 15px;
+  white-space: pre-wrap;
   cursor: pointer;
 
   &.has-highlight {


### PR DESCRIPTION
Fixes an issue where parts of the suggestion would be concatenated in case one of them starts with a space. An example of this:

**Before**:

![screen shot 2017-09-29 at 16 13 39](https://user-images.githubusercontent.com/8056203/31019844-6056b380-a531-11e7-9bb7-27707f3ef0f0.png)

**After**:

![screen shot 2017-09-29 at 16 13 28](https://user-images.githubusercontent.com/8056203/31019857-66a56f74-a531-11e7-9866-291a527b2eae.png)

# Testing

- Go `/extensions/zoninator` and select a zone.
- Type a whole word from one of your posts' titles into the search field - make sure the word is emboldened in the suggestion and is preceded/followed by a space.
- Enter just the space character into the search field - ensure the suggestions that appear aren't missing any spaces.
