### PR TITLE
Theme showcase: Show 'Beginner' ribbon on some themes

### DIFF
--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -7,7 +7,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { find, get, isEmpty, isEqual, noop } from 'lodash';
+import { get, isEmpty, isEqual, noop, some } from 'lodash';
 import Gridicon from 'gridicons';
 import { localize } from 'i18n-calypso';
 
@@ -98,8 +98,8 @@ export class Theme extends Component {
 
 	isBeginnerTheme = () => {
 		const { theme } = this.props;
-		const skillLevels = get( theme, [ 'taxonomies', 'theme_skill-level' ], null );
-		return !! find( skillLevels, { slug: 'beginner' } );
+		const skillLevels = get( theme, [ 'taxonomies', 'theme_skill-level' ] );
+		return some( skillLevels, { slug: 'beginner' } );
 	};
 
 	renderPlaceholder = () => {
@@ -155,7 +155,11 @@ export class Theme extends Component {
 
 		return (
 			<Card className={ themeClass }>
-				{ this.isBeginnerTheme() && <Ribbon color="green">{ translate( 'BEGINNER' ) }</Ribbon> }
+				{ this.isBeginnerTheme() && <Ribbon
+					className="theme__ribbon"
+					color="green">
+					{ translate( 'Beginner' ) }
+				</Ribbon> }
 				<div className="theme__content">
 					{ this.renderHover() }
 

--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -7,7 +7,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { isEmpty, isEqual, noop } from 'lodash';
+import { find, get, isEmpty, isEqual, noop } from 'lodash';
 import Gridicon from 'gridicons';
 import { localize } from 'i18n-calypso';
 
@@ -17,6 +17,7 @@ import { localize } from 'i18n-calypso';
 import Card from 'components/card';
 import ThemeMoreButton from './more-button';
 import PulsingDot from 'components/pulsing-dot';
+import Ribbon from 'components/ribbon';
 
 /**
  * Component
@@ -34,6 +35,7 @@ export class Theme extends Component {
 			author_uri: PropTypes.string,
 			demo_uri: PropTypes.string,
 			stylesheet: PropTypes.string,
+			taxonomies: PropTypes.object,
 		} ),
 		// If true, highlight this theme as active
 		active: PropTypes.bool,
@@ -94,6 +96,12 @@ export class Theme extends Component {
 		this.props.onScreenshotClick( this.props.theme.id, this.props.index );
 	};
 
+	isBeginnerTheme = () => {
+		const { theme } = this.props;
+		const skillLevels = get( theme, [ 'taxonomies', 'theme_skill-level' ], null );
+		return !! find( skillLevels, { slug: 'beginner' } );
+	};
+
 	renderPlaceholder = () => {
 		return (
 			<Card className="theme is-placeholder">
@@ -147,6 +155,7 @@ export class Theme extends Component {
 
 		return (
 			<Card className={ themeClass }>
+				{ this.isBeginnerTheme() && <Ribbon color="green">{ translate( 'BEGINNER' ) }</Ribbon> }
 				<div className="theme__content">
 					{ this.renderHover() }
 

--- a/client/components/theme/style.scss
+++ b/client/components/theme/style.scss
@@ -5,7 +5,6 @@ $theme-info-height: 54px;
 	margin: 0 10px 20px 10px;
 	width: 230px; // Fixed width gives desired wrapping...
 	flex-grow: 1; // ...grow allows expansion to fill space after wrap.
-	overflow: hidden;
 	transition: all 100ms ease-in-out;
 
 	&.is-active {
@@ -155,7 +154,8 @@ $theme-info-height: 54px;
 .theme__content {
 	padding-top: 75%; // 4:3 screenshot ratio
 	padding-bottom: $theme-info-height;
-
+	position: relative;
+	overflow: hidden;
 }
 
 .theme__img {

--- a/client/components/theme/style.scss
+++ b/client/components/theme/style.scss
@@ -262,3 +262,7 @@ $theme-info-height: 54px;
 		color: white;
 	}
 }
+
+.theme__ribbon {
+	text-transfrom: capitalize;
+}


### PR DESCRIPTION
<img width="976" alt="screen shot 2017-09-29 at 15 19 13" src="https://user-images.githubusercontent.com/7767559/31020025-9e5c5408-a529-11e7-90fb-d5c9e1679ff2.png">

Show a ribbon on themes that are suitable for beginners to help guide theme choice.

pNEWy-9OC-p2

## Testing
* go to /themes
* You should see the new _Beginner_ ribbon on a couple of the themes


/cc @davidakennedy 