### PR TITLE
Plugins: Use lodash.map in normalizePluginsList

### DIFF
--- a/client/lib/plugins/utils.js
+++ b/client/lib/plugins/utils.js
@@ -218,9 +218,7 @@ PluginUtils = {
 		if ( ! pluginsList ) {
 			return [];
 		}
-		return pluginsList.map( function( pluginData ) {
-			return PluginUtils.normalizePluginData( pluginData );
-		} );
+		return map( pluginsList, pluginData => PluginUtils.normalizePluginData( pluginData ) );
 	},
 
 	/**

--- a/client/lib/plugins/utils.js
+++ b/client/lib/plugins/utils.js
@@ -2,14 +2,13 @@
  * External dependencies
  */
 import { assign, filter, map, pick, sortBy, transform } from 'lodash';
-const sanitizeHtml = require( 'sanitize-html' );
+import sanitizeHtml from 'sanitize-html';
 
 /**
  * Internal dependencies
  */
-var decodeEntities = require( 'lib/formatting' ).decodeEntities,
-	parseHtml = require( 'lib/formatting' ).parseHtml,
-	PluginUtils;
+import { decodeEntities } from 'lib/formatting';
+import { parseHtml } from 'lib/formatting';
 
 /**
  * @param  {Object} site       Site Object
@@ -51,7 +50,7 @@ function filterNoticesBy( site, pluginSlug, log ) {
 	return false;
 }
 
-PluginUtils = {
+const PluginUtils = {
 	whiteListPluginData: function( plugin ) {
 		return pick( plugin,
 			'action_links',
@@ -93,7 +92,7 @@ PluginUtils = {
 	},
 
 	extractAuthorUrl: function( authorElementSource ) {
-		var match = /<a\s+(?:[^>]*?\s+)?href="([^"]*)"/.exec( authorElementSource );
+		const match = /<a\s+(?:[^>]*?\s+)?href="([^"]*)"/.exec( authorElementSource );
 		return ( match && match[ 1 ] ? match[ 1 ] : '' );
 	},
 
@@ -123,7 +122,7 @@ PluginUtils = {
 
 	normalizeCompatibilityList: function( compatibilityList ) {
 		function splitInNumbers( version ) {
-			let splittedVersion = version.split( '.' ).map( function( versionComponent ) {
+			const splittedVersion = version.split( '.' ).map( function( versionComponent ) {
 				return Number.parseInt( versionComponent, 10 );
 			} );
 			while ( splittedVersion.length < 3 ) {
@@ -131,7 +130,7 @@ PluginUtils = {
 			}
 			return splittedVersion;
 		}
-		let sortedCompatibility = sortBy( Object.keys( compatibilityList ).map( splitInNumbers ), [ 0, 1, 2 ] );
+		const sortedCompatibility = sortBy( Object.keys( compatibilityList ).map( splitInNumbers ), [ 0, 1, 2 ] );
 		return sortedCompatibility.map( function( version ) {
 			if ( version.length && version[ version.length - 1 ] === 0 ) {
 				version.pop();
@@ -179,8 +178,8 @@ PluginUtils = {
 					returnData.author_url = plugin.author_url || PluginUtils.extractAuthorUrl( item );
 					break;
 				case 'sections':
-					let cleanItem = {};
-					for ( let sectionKey of Object.keys( item ) ) {
+					const cleanItem = {};
+					for ( const sectionKey of Object.keys( item ) ) {
 						cleanItem[ sectionKey ] = PluginUtils.sanitizeSectionContent( item[ sectionKey ] );
 					}
 					returnData.sections = cleanItem;
@@ -191,7 +190,7 @@ PluginUtils = {
 					returnData[ key ] = parseInt( item, 10 );
 					break;
 				case 'ratings':
-					for ( let prop in item ) {
+					for ( const prop in item ) {
 						item[ prop ] = parseInt( item[ prop ], 10 );
 					}
 					returnData[ key ] = item;


### PR DESCRIPTION
Fixes the following bug:

**Steps to reproduce:**
1. Go to `/plugins/browse/popular`
2. Scroll down to force loading the second page of search results from `api.wordpress.org`

**Expected:**
The second page is displayed, infinite scroll works.

**Actual:**
The second page never loads, there is placeholder at the bottom of the list that never disappears, and there is error in console:
<img width="441" alt="wporg-load-error" src="https://user-images.githubusercontent.com/664258/31020091-3d8a5fae-a532-11e7-8be7-5057473d88ab.png">

**Why it fails and how it's fixed:**
For some strange reason, when retrieving the second page of popular plugins list, the `api.wordpress.org` returns an object with numeric keys instead of array:
```js
plugins: { 0: ..., 1: ..., 2: ... }
```
<img width="783" alt="wporg-pseudo-array" src="https://user-images.githubusercontent.com/664258/31020141-66e19aca-a532-11e7-8c8a-303cbf3c13c1.png">

Trying to call `plugins.map` on such object throws a `TypeError`.

The fix: use `lodash.map` instead, as it can handle such pseudo-array just fine, and returns a real array.