### PR TITLE
Extensions: WPJM - Redirect to plugin details page if plugin is not active or is an old version

### DIFF
--- a/client/extensions/wp-job-manager/components/settings/index.jsx
+++ b/client/extensions/wp-job-manager/components/settings/index.jsx
@@ -14,6 +14,7 @@ import { flowRight } from 'lodash';
  * Internal dependencies
  */
 import DocumentHead from 'components/data/document-head';
+import ExtensionRedirect from 'blocks/extension-redirect';
 import Main from 'components/main';
 import Navigation from '../navigation';
 import QuerySettings from '../data/query-settings';
@@ -40,6 +41,10 @@ class Settings extends Component {
 
 		return (
 			<Main className={ mainClassName }>
+				<ExtensionRedirect
+					minimumVersion="1.28.0"
+					pluginId="wp-job-manager"
+					siteId={ siteId } />
 				<SetupRedirect siteId={ siteId } />
 				<QuerySettings siteId={ siteId } />
 				<DocumentHead title={ translate( 'WP Job Manager' ) } />

--- a/client/extensions/wp-job-manager/components/settings/index.jsx
+++ b/client/extensions/wp-job-manager/components/settings/index.jsx
@@ -13,6 +13,7 @@ import { flowRight } from 'lodash';
 /**
  * Internal dependencies
  */
+import { MinPluginVersion } from '../../constants';
 import DocumentHead from 'components/data/document-head';
 import ExtensionRedirect from 'blocks/extension-redirect';
 import Main from 'components/main';
@@ -42,9 +43,10 @@ class Settings extends Component {
 		return (
 			<Main className={ mainClassName }>
 				<ExtensionRedirect
-					minimumVersion="1.28.0"
+					minimumVersion={ MinPluginVersion }
 					pluginId="wp-job-manager"
-					siteId={ siteId } />
+					siteId={ siteId }
+				/>
 				<SetupRedirect siteId={ siteId } />
 				<QuerySettings siteId={ siteId } />
 				<DocumentHead title={ translate( 'WP Job Manager' ) } />

--- a/client/extensions/wp-job-manager/components/setup/constants.js
+++ b/client/extensions/wp-job-manager/components/setup/constants.js
@@ -1,8 +1,0 @@
-/** @format */
-export const Steps = {
-	CONFIRMATION: 'confirmation',
-	INTRO: 'intro',
-	PAGE_SETUP: 'page-setup',
-};
-
-export const SetupPath = '/extensions/wp-job-manager/setup';

--- a/client/extensions/wp-job-manager/components/setup/index.jsx
+++ b/client/extensions/wp-job-manager/components/setup/index.jsx
@@ -15,6 +15,7 @@ import { localize } from 'i18n-calypso';
 import { SetupPath, Steps } from './constants';
 import Confirmation from './confirmation';
 import DocumentHead from 'components/data/document-head';
+import ExtensionRedirect from 'blocks/extension-redirect';
 import Intro from './intro';
 import Main from 'components/main';
 import PageSetup from './page-setup';
@@ -56,7 +57,7 @@ class SetupWizard extends Component {
 	}
 
 	render() {
-		const { slug, stepName, translate } = this.props;
+		const { siteId, slug, stepName, translate } = this.props;
 		const steps = [ Steps.INTRO, Steps.PAGE_SETUP, Steps.CONFIRMATION ];
 		const components = {
 			[ Steps.INTRO ]: <Intro />,
@@ -67,6 +68,10 @@ class SetupWizard extends Component {
 
 		return (
 			<Main className={ mainClassName }>
+				<ExtensionRedirect
+					minimumVersion="1.28.0"
+					pluginId="wp-job-manager"
+					siteId={ siteId } />
 				<DocumentHead title={ translate( 'Setup' ) } />
 				<Wizard
 					basePath={ `${ SetupPath }/${ slug }` }

--- a/client/extensions/wp-job-manager/components/setup/index.jsx
+++ b/client/extensions/wp-job-manager/components/setup/index.jsx
@@ -12,7 +12,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import { SetupPath, Steps } from '../../constants';
+import { MinPluginVersion, SetupPath, Steps } from '../../constants';
 import Confirmation from './confirmation';
 import DocumentHead from 'components/data/document-head';
 import ExtensionRedirect from 'blocks/extension-redirect';
@@ -68,7 +68,11 @@ class SetupWizard extends Component {
 
 		return (
 			<Main className={ mainClassName }>
-				<ExtensionRedirect minimumVersion="1.28.0" pluginId="wp-job-manager" siteId={ siteId } />
+				<ExtensionRedirect
+					minimumVersion={ MinPluginVersion }
+					pluginId="wp-job-manager"
+					siteId={ siteId }
+				/>
 				<DocumentHead title={ translate( 'Setup' ) } />
 				<Wizard
 					basePath={ `${ SetupPath }/${ slug }` }

--- a/client/extensions/wp-job-manager/components/setup/index.jsx
+++ b/client/extensions/wp-job-manager/components/setup/index.jsx
@@ -12,7 +12,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import { SetupPath, Steps } from './constants';
+import { SetupPath, Steps } from '../../constants';
 import Confirmation from './confirmation';
 import DocumentHead from 'components/data/document-head';
 import ExtensionRedirect from 'blocks/extension-redirect';
@@ -68,10 +68,7 @@ class SetupWizard extends Component {
 
 		return (
 			<Main className={ mainClassName }>
-				<ExtensionRedirect
-					minimumVersion="1.28.0"
-					pluginId="wp-job-manager"
-					siteId={ siteId } />
+				<ExtensionRedirect minimumVersion="1.28.0" pluginId="wp-job-manager" siteId={ siteId } />
 				<DocumentHead title={ translate( 'Setup' ) } />
 				<Wizard
 					basePath={ `${ SetupPath }/${ slug }` }

--- a/client/extensions/wp-job-manager/components/setup/intro/index.jsx
+++ b/client/extensions/wp-job-manager/components/setup/intro/index.jsx
@@ -12,7 +12,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import { SetupPath, Steps } from '../constants';
+import { SetupPath, Steps } from '../../../constants';
 import Button from 'components/button';
 import CompactCard from 'components/card/compact';
 import ExternalLink from 'components/external-link';

--- a/client/extensions/wp-job-manager/components/setup/page-setup/index.jsx
+++ b/client/extensions/wp-job-manager/components/setup/page-setup/index.jsx
@@ -15,7 +15,7 @@ import { flowRight as compose } from 'lodash';
 /**
  * Internal dependencies
  */
-import { SetupPath, Steps } from '../constants';
+import { SetupPath, Steps } from '../../../constants';
 import Button from 'components/button';
 import CompactCard from 'components/card/compact';
 import ExternalLink from 'components/external-link';

--- a/client/extensions/wp-job-manager/components/setup/setup-redirect/index.jsx
+++ b/client/extensions/wp-job-manager/components/setup/setup-redirect/index.jsx
@@ -12,7 +12,7 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import { SetupPath } from '../constants';
+import { SetupPath } from '../../../constants';
 import { getSiteSlug } from 'state/sites/selectors';
 import { isFetchingSetupStatus, shouldShowSetupWizard } from '../../../state/setup/selectors';
 import QuerySetupStatus from '../../data/query-setup-status';

--- a/client/extensions/wp-job-manager/constants.js
+++ b/client/extensions/wp-job-manager/constants.js
@@ -20,3 +20,11 @@ export const Tabs = {
 		slug: 'pages',
 	},
 };
+
+export const Steps = {
+	CONFIRMATION: 'confirmation',
+	INTRO: 'intro',
+	PAGE_SETUP: 'page-setup',
+};
+
+export const SetupPath = '/extensions/wp-job-manager/setup';

--- a/client/extensions/wp-job-manager/constants.js
+++ b/client/extensions/wp-job-manager/constants.js
@@ -28,3 +28,5 @@ export const Steps = {
 };
 
 export const SetupPath = '/extensions/wp-job-manager/setup';
+
+export const MinPluginVersion = '1.28.0';


### PR DESCRIPTION
This PR adds the `ExtensionRedirect` component to the settings and setup wizard pages. If the plugin is inactive, or the installed version of WPJM is before 1.28.0, the user will be redirected to the WPJM plugin details page when trying to access the setup wizard or settings.

## Testing

1. Deactivate the WPJM plugin on the "Manage Plugins" page.
2. Navigate to `http://calypso.localhost:3000/extensions/wp-job-manager/setup/<siteId>`. You should be redirected to the plugin details page.
3. Navigate to `http://calypso.localhost:3000/extensions/wp-job-manager/<siteId>`. You should be redirected to the plugin details page.
4. Activate the WPJM plugin on the "Manage Plugins" page.
5. Navigate to `http://calypso.localhost:3000/extensions/wp-job-manager/setup/<siteId>`. You should *not* be redirected to the plugin details page.
3. Navigate to `http://calypso.localhost:3000/extensions/wp-job-manager/<siteId>`. You should *not* be redirected to the plugin details page.