### PR TITLE
Extensions: Zoninator - Fix items' links causing buggy drag&drop behaviour

### DIFF
--- a/client/extensions/zoninator/components/forms/zone-content-form/post-card.jsx
+++ b/client/extensions/zoninator/components/forms/zone-content-form/post-card.jsx
@@ -46,13 +46,15 @@ class PostCard extends Component {
 					compact
 					onMouseDown={ this.handleMouseDown }
 					href={ url }
+					draggable="false"
 					target="_blank">
 					{ translate( 'View' ) }
 				</Button>
 				<Button
 					compact
 					onMouseDown={ this.handleMouseDown }
-					href={ editorPath }>
+					href={ editorPath }
+					draggable="false">
 					{ translate( 'Edit' ) }
 				</Button>
 				<Button


### PR DESCRIPTION
This PR addresses the buggy drag & drop behaviour with the zone post list on smaller screens. See p7nzsm-nB-p2.

# Testing

- Go `/extensions/zoninator` and select a zone.
- Add some posts to the zone and try re-ordering them making sure drag & drop works smoothly.
- Repeat the last step under different screen sizes/resolutions ( the bug was becoming apparent at 1040 pixels wide or less ).