### PR TITLE
Components: Fix minimumVersion not actually being optional in ExtensionRedirect

### DIFF
--- a/client/blocks/extension-redirect/index.jsx
+++ b/client/blocks/extension-redirect/index.jsx
@@ -32,8 +32,8 @@ class ExtensionRedirect extends Component {
 		// Is the plugin active? (That implicitly also checks if the plugin is installed)
 		// Do we require a minimum version? Have we received the plugin's version? Is it sufficient?
 		if ( nextProps.pluginActive && (
-			nextProps.minimumVersion && nextProps.pluginVersion &&
-			versionCompare( nextProps.minimumVersion, nextProps.pluginVersion, '<=' )
+			! nextProps.minimumVersion ||
+			( nextProps.pluginVersion && versionCompare( nextProps.minimumVersion, nextProps.pluginVersion, '<=' ) )
 		) ) {
 			return;
 		}


### PR DESCRIPTION
This PR updates the logic within `ExtensionRedirect` to actually allow for not requiring the optional `minimumVersion` property.

# Testing

The component is currently live in WP Super Cache extension. To test head over to `/extensions/wp-super-cache` and verify that:

- The settings appear if the plugin is installed, active and matches the minimum version.
- You are redirected to the plugin details page in every other case.