### PR TITLE
Extensions: Zoninator - Redirect to plugin details page if the plugin is not active

### DIFF
--- a/client/extensions/zoninator/components/settings/index.jsx
+++ b/client/extensions/zoninator/components/settings/index.jsx
@@ -9,6 +9,7 @@ import { flowRight } from 'lodash';
 /**
  * Internal dependencies
  */
+import ExtensionRedirect from 'blocks/extension-redirect';
 import DocumentHead from 'components/data/document-head';
 import Main from 'components/main';
 import { getSelectedSiteId } from 'state/ui/selectors';
@@ -23,6 +24,7 @@ const Settings = ( {
 
 	return (
 		<Main className={ mainClassName }>
+			<ExtensionRedirect pluginId="zoninator" siteId={ siteId } />
 			<QueryZones siteId={ siteId } />
 			<DocumentHead title={ translate( 'WP Zone Manager' ) } />
 			{ children }


### PR DESCRIPTION
This PR adds `ExtensionRedirect` component to Zoninator in order to prevent accessing the extension settings whenever the plugin is not installed.  
Minimum version is not required yet as the API required by the extension isn't merged yet.

Depends on #18407.

# Testing

Head over to `/extensions/zoninator` and verify that:

- Zones dashboard is shown when the plugin is installed and active.
- You are redirected to the plugin details page in every other case.