### PR TITLE
Atomic Store: add ability to move through the flow

### DIFF
--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -240,7 +240,7 @@ const flows = {
 if ( config.isEnabled( 'signup/atomic-store-flow' ) ) {
 	flows[ 'atomic-store' ] = {
 		// TODO: add new plan step with just Business plan
-		steps: [ 'design-type-with-atomic-store', 'domains', 'plans', 'user' ],
+		steps: [ 'design-type-with-atomic-store', 'themes', 'domains', 'plans', 'user' ],
 		destination: getSiteDestination,
 		description: 'Signup flow for creating an online store with an Atomic site',
 		lastModified: '2017-09-27'

--- a/client/signup/steps/design-type-with-atomic-store/index.jsx
+++ b/client/signup/steps/design-type-with-atomic-store/index.jsx
@@ -14,6 +14,7 @@ import { localize } from 'i18n-calypso';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { BlogImage, PageImage, GridImage, StoreImage } from '../design-type-with-atomic-store/type-images';
 import { abtest } from 'lib/abtest';
+import SignupActions from 'lib/signup/actions';
 
 import { setDesignType } from 'state/signup/steps/design-type/actions';
 
@@ -57,11 +58,29 @@ class DesignTypeWithAtomicStoreStep extends Component {
 		];
 	}
 
+	handleChoiceClick = type => event => {
+		event.preventDefault();
+		event.stopPropagation();
+		this.handleNextStep( type );
+	};
+
+	handleNextStep = ( designType ) => {
+		this.props.setDesignType( designType );
+
+		this.props.recordTracksEvent( 'calypso_triforce_select_design', { category: designType } );
+
+		SignupActions.submitSignupStep( { stepName: this.props.stepName }, [], { designType } );
+
+		this.props.goToNextStep();
+	};
+
 	renderChoice = ( choice ) => {
 		return (
 			<Card className="design-type-with-atomic-store__choice" key={ choice.type }>
 				<a className="design-type-with-atomic-store__choice-link"
-					href="#">
+					href="#"
+					onClick={ this.handleChoiceClick( choice.type ) }
+				>
 					<div className="design-type-with-atomic-store__image">
 						{ choice.image }
 					</div>

--- a/client/signup/steps/design-type-with-atomic-store/index.jsx
+++ b/client/signup/steps/design-type-with-atomic-store/index.jsx
@@ -24,6 +24,10 @@ import SignupActions from 'lib/signup/actions';
 
 import { setDesignType } from 'state/signup/steps/design-type/actions';
 
+import SignupDependencyStore from 'lib/signup/dependency-store';
+import SignupProgressStore from 'lib/signup/progress-store';
+import { getSignupDependencyStore } from 'state/signup/dependency-store/selectors';
+
 class DesignTypeWithAtomicStoreStep extends Component {
 	constructor( props ) {
 		super( props );
@@ -151,6 +155,16 @@ class DesignTypeWithAtomicStoreStep extends Component {
 		return translate( 'What kind of site do you need? Choose an option below:' );
 	}
 
+	componentWillMount() {
+		if ( this.props.signupDependencyStore.themeSlugWithRepo ) {
+			SignupDependencyStore.reset();
+		}
+
+		if ( this.props.signupProgress ) {
+			SignupProgressStore.reset();
+		}
+	}
+
 	render() {
 		const headerText = this.getHeaderText();
 		const subHeaderText = this.getSubHeaderText();
@@ -172,7 +186,14 @@ class DesignTypeWithAtomicStoreStep extends Component {
 	}
 }
 
-export default connect( null, {
-	recordTracksEvent,
-	setDesignType,
-} )( localize( DesignTypeWithAtomicStoreStep ) );
+export default connect(
+	state => {
+		return {
+			signupDependencyStore: getSignupDependencyStore( state ),
+		};
+	},
+	{
+		recordTracksEvent,
+		setDesignType,
+	}
+)( localize( DesignTypeWithAtomicStoreStep ) );

--- a/client/signup/steps/design-type-with-atomic-store/index.jsx
+++ b/client/signup/steps/design-type-with-atomic-store/index.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -12,7 +13,12 @@ import StepWrapper from 'signup/step-wrapper';
 import Card from 'components/card';
 import { localize } from 'i18n-calypso';
 import { recordTracksEvent } from 'state/analytics/actions';
-import { BlogImage, PageImage, GridImage, StoreImage } from '../design-type-with-atomic-store/type-images';
+import {
+	BlogImage,
+	PageImage,
+	GridImage,
+	StoreImage,
+} from '../design-type-with-atomic-store/type-images';
 import { abtest } from 'lib/abtest';
 import SignupActions from 'lib/signup/actions';
 
@@ -23,7 +29,7 @@ class DesignTypeWithAtomicStoreStep extends Component {
 		super( props );
 
 		this.state = {
-			showStore: false
+			showStore: false,
 		};
 	}
 
@@ -39,22 +45,30 @@ class DesignTypeWithAtomicStoreStep extends Component {
 		const storeText = translate( 'To sell your products or services and accept payments.' );
 
 		return [
-			{ type: 'blog',
+			{
+				type: 'blog',
 				label: translate( 'Start with a blog' ),
 				description: blogText,
-				image: <BlogImage /> },
-			{ type: 'page',
+				image: <BlogImage />,
+			},
+			{
+				type: 'page',
 				label: translate( 'Start with a website' ),
 				description: siteText,
-				image: <PageImage /> },
-			{ type: 'grid',
+				image: <PageImage />,
+			},
+			{
+				type: 'grid',
 				label: translate( 'Start with a portfolio' ),
 				description: gridText,
-				image: <GridImage /> },
-			{ type: 'store',
+				image: <GridImage />,
+			},
+			{
+				type: 'store',
 				label: translate( 'Start with an online store' ),
 				description: storeText,
-				image: <StoreImage /> },
+				image: <StoreImage />,
+			},
 		];
 	}
 
@@ -64,7 +78,7 @@ class DesignTypeWithAtomicStoreStep extends Component {
 		this.handleNextStep( type );
 	};
 
-	handleNextStep = ( designType ) => {
+	handleNextStep = designType => {
 		this.props.setDesignType( designType );
 
 		this.props.recordTracksEvent( 'calypso_triforce_select_design', { category: designType } );
@@ -74,19 +88,18 @@ class DesignTypeWithAtomicStoreStep extends Component {
 		this.props.goToNextStep();
 	};
 
-	renderChoice = ( choice ) => {
+	renderChoice = choice => {
 		return (
 			<Card className="design-type-with-atomic-store__choice" key={ choice.type }>
-				<a className="design-type-with-atomic-store__choice-link"
+				<a
+					className="design-type-with-atomic-store__choice-link"
 					href="#"
 					onClick={ this.handleChoiceClick( choice.type ) }
 				>
-					<div className="design-type-with-atomic-store__image">
-						{ choice.image }
-					</div>
+					<div className="design-type-with-atomic-store__image">{ choice.image }</div>
 					<div className="design-type-with-atomic-store__choice-copy">
 						<span className="button is-compact design-type-with-atomic-store__cta">
-							{choice.label}
+							{ choice.label }
 						</span>
 						<p className="design-type-with-atomic-store__choice-description">
 							{ choice.description }
@@ -99,21 +112,20 @@ class DesignTypeWithAtomicStoreStep extends Component {
 
 	renderChoices() {
 		const { translate } = this.props;
-		const disclaimerText = translate( 'Not sure? Pick the closest option. You can always change your settings later.' ); // eslint-disable-line max-len
+		const disclaimerText = translate(
+			'Not sure? Pick the closest option. You can always change your settings later.'
+		); // eslint-disable-line max-len
 
-		const designTypeListClassName = classNames(
-			'design-type-with-atomic-store__list',
-			{ 'is-hidden': this.state.showStore }
-		);
+		const designTypeListClassName = classNames( 'design-type-with-atomic-store__list', {
+			'is-hidden': this.state.showStore,
+		} );
 
 		return (
 			<div className="design-type-with-atomic-store__substep-wrapper">
 				<div className={ designTypeListClassName }>
 					{ this.getChoices().map( this.renderChoice ) }
 
-					<p className="design-type-with-atomic-store__disclaimer">
-						{ disclaimerText }
-					</p>
+					<p className="design-type-with-atomic-store__disclaimer">{ disclaimerText }</p>
 				</div>
 			</div>
 		);
@@ -127,7 +139,7 @@ class DesignTypeWithAtomicStoreStep extends Component {
 		}
 
 		if ( abtest( 'signupSurveyStep' ) === 'showSurveyStep' ) {
-			return 'We\'re excited to hear more about your project.';
+			return "We're excited to hear more about your project.";
 		}
 
 		return translate( 'Hello! Let’s create your new site.' );
@@ -154,15 +166,13 @@ class DesignTypeWithAtomicStoreStep extends Component {
 				subHeaderText={ subHeaderText }
 				signupProgress={ this.props.signupProgress }
 				stepContent={ this.renderChoices() }
-				shouldHideNavButtons={ this.state.showStore } />
+				shouldHideNavButtons={ this.state.showStore }
+			/>
 		);
 	}
 }
 
-export default connect(
-	null,
-	{
-		recordTracksEvent,
-		setDesignType,
-	}
-)( localize( DesignTypeWithAtomicStoreStep ) );
+export default connect( null, {
+	recordTracksEvent,
+	setDesignType,
+} )( localize( DesignTypeWithAtomicStoreStep ) );

--- a/client/signup/steps/design-type-with-atomic-store/index.jsx
+++ b/client/signup/steps/design-type-with-atomic-store/index.jsx
@@ -87,7 +87,9 @@ class DesignTypeWithAtomicStoreStep extends Component {
 
 		this.props.recordTracksEvent( 'calypso_triforce_select_design', { category: designType } );
 
-		SignupActions.submitSignupStep( { stepName: this.props.stepName }, [], { designType } );
+		SignupActions.submitSignupStep( { stepName: this.props.stepName }, [], {
+			designType,
+		} );
 
 		this.props.goToNextStep();
 	};

--- a/client/signup/steps/theme-selection/index.jsx
+++ b/client/signup/steps/theme-selection/index.jsx
@@ -74,10 +74,14 @@ class ThemeSelectionStep extends Component {
 		);
 	}
 
-	render = () => {
+	componentWillMount() {
 		if ( this.props.designType === 'store' ) {
 			this.props.goToNextStep();
+		}
+	}
 
+	render = () => {
+		if ( this.props.designType === 'store' ) {
 			return null;
 		}
 

--- a/client/signup/steps/theme-selection/index.jsx
+++ b/client/signup/steps/theme-selection/index.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -16,7 +17,7 @@ import SignupActions from 'lib/signup/actions';
 import SignupThemesList from './signup-themes-list';
 import StepWrapper from 'signup/step-wrapper';
 import Button from 'components/button';
-import { themes } from 'lib/signup/themes-data';
+import { themes } from 'lib/signup/themes-data';
 import { getCurrentUser } from 'state/current-user/selectors';
 import { getSurveyVertical } from 'state/signup/steps/survey/selectors';
 import { getDesignType } from 'state/signup/steps/design-type/selectors';
@@ -36,22 +37,26 @@ class ThemeSelectionStep extends Component {
 		translate: identity,
 	};
 
-	pickTheme = ( themeId ) => {
-		const theme = find( themes, { slug: themeId } );
+	pickTheme = themeId => {
+		const theme = find( themes, { slug: themeId } );
 		const repoSlug = `${ theme.repo }/${ theme.slug }`;
 
 		analytics.tracks.recordEvent( 'calypso_signup_theme_select', {
 			theme: repoSlug,
-			headstart: true
+			headstart: true,
 		} );
 
-		SignupActions.submitSignupStep( {
-			stepName: this.props.stepName,
-			processingMessage: this.props.translate( 'Adding your theme' ),
-			repoSlug
-		}, null, {
-			themeSlugWithRepo: repoSlug
-		} );
+		SignupActions.submitSignupStep(
+			{
+				stepName: this.props.stepName,
+				processingMessage: this.props.translate( 'Adding your theme' ),
+				repoSlug,
+			},
+			null,
+			{
+				themeSlugWithRepo: repoSlug,
+			}
+		);
 
 		this.props.goToNextStep();
 	};
@@ -85,7 +90,9 @@ class ThemeSelectionStep extends Component {
 			return null;
 		}
 
-		const defaultDependencies = this.props.useHeadstart ? { themeSlugWithRepo: 'pub/twentysixteen' } : undefined;
+		const defaultDependencies = this.props.useHeadstart
+			? { themeSlugWithRepo: 'pub/twentysixteen' }
+			: undefined;
 		const { translate } = this.props;
 		const headerText = translate( 'Choose a theme.' );
 		const subHeaderText = translate(
@@ -104,13 +111,11 @@ class ThemeSelectionStep extends Component {
 				{ ...this.props }
 			/>
 		);
-	}
+	};
 }
 
-export default connect(
-	( state ) => ( {
-		chosenSurveyVertical: getSurveyVertical( state ),
-		currentUser: getCurrentUser( state ),
-		designType: getDesignType( state ),
-	} )
-)( localize( ThemeSelectionStep ) );
+export default connect( state => ( {
+	chosenSurveyVertical: getSurveyVertical( state ),
+	currentUser: getCurrentUser( state ),
+	designType: getDesignType( state ),
+} ) )( localize( ThemeSelectionStep ) );

--- a/client/signup/steps/theme-selection/index.jsx
+++ b/client/signup/steps/theme-selection/index.jsx
@@ -21,6 +21,7 @@ import { themes } from 'lib/signup/themes-data';
 import { getCurrentUser } from 'state/current-user/selectors';
 import { getSurveyVertical } from 'state/signup/steps/survey/selectors';
 import { getDesignType } from 'state/signup/steps/design-type/selectors';
+import { isEnabled } from 'config';
 
 class ThemeSelectionStep extends Component {
 	static propTypes = {
@@ -80,7 +81,7 @@ class ThemeSelectionStep extends Component {
 	}
 
 	componentWillMount() {
-		if ( this.props.designType === 'store' ) {
+		if ( isEnabled( 'signup/atomic-store-flow' ) && this.props.designType === 'store' ) {
 			SignupActions.submitSignupStep(
 				{
 					stepName: this.props.stepName,
@@ -98,7 +99,7 @@ class ThemeSelectionStep extends Component {
 	}
 
 	render = () => {
-		if ( this.props.designType === 'store' ) {
+		if ( isEnabled( 'signup/atomic-store-flow' ) && this.props.designType === 'store' ) {
 			return null;
 		}
 

--- a/client/signup/steps/theme-selection/index.jsx
+++ b/client/signup/steps/theme-selection/index.jsx
@@ -19,6 +19,7 @@ import Button from 'components/button';
 import { themes } from 'lib/signup/themes-data';
 import { getCurrentUser } from 'state/current-user/selectors';
 import { getSurveyVertical } from 'state/signup/steps/survey/selectors';
+import { getDesignType } from 'state/signup/steps/design-type/selectors';
 
 class ThemeSelectionStep extends Component {
 	static propTypes = {
@@ -74,6 +75,12 @@ class ThemeSelectionStep extends Component {
 	}
 
 	render = () => {
+		if ( this.props.designType === 'store' ) {
+			this.props.goToNextStep();
+
+			return null;
+		}
+
 		const defaultDependencies = this.props.useHeadstart ? { themeSlugWithRepo: 'pub/twentysixteen' } : undefined;
 		const { translate } = this.props;
 		const headerText = translate( 'Choose a theme.' );
@@ -99,6 +106,7 @@ class ThemeSelectionStep extends Component {
 export default connect(
 	( state ) => ( {
 		chosenSurveyVertical: getSurveyVertical( state ),
-		currentUser: getCurrentUser( state )
+		currentUser: getCurrentUser( state ),
+		designType: getDesignType( state ),
 	} )
 )( localize( ThemeSelectionStep ) );

--- a/client/signup/steps/theme-selection/index.jsx
+++ b/client/signup/steps/theme-selection/index.jsx
@@ -81,6 +81,18 @@ class ThemeSelectionStep extends Component {
 
 	componentWillMount() {
 		if ( this.props.designType === 'store' ) {
+			SignupActions.submitSignupStep(
+				{
+					stepName: this.props.stepName,
+					processingMessage: this.props.translate( 'Adding your theme' ),
+					repoSlug: 'pub/storefront',
+				},
+				null,
+				{
+					themeSlugWithRepo: 'pub/storefront',
+				}
+			);
+
 			this.props.goToNextStep();
 		}
 	}


### PR DESCRIPTION
In this PR, we are adding all the required functionality for the whole Atomic Store flow so we can move through it.

## Testing

Start by navigating to `/start/atomic-store/` -- you should see the initial step with selection of four design types.

We need to test the 'store' design type and some other one. In the 'store' design type, we are skipping the theme selection step and assigning the theme 'pub/storefront' manually. In all the other design types, we are not skipping the theme selection step.

Test if you can get through all the steps. Also test going back in a flow -- it should properly take you to the previous step or the starting point (the design type selection).

What is more, test the `/start/main` flow as well, whether it's still working as before.