### PR TITLE
Store: Add a pending reviews widget to the dashboard view.

### DIFF
--- a/client/extensions/woocommerce/app/dashboard/manage-orders-view.js
+++ b/client/extensions/woocommerce/app/dashboard/manage-orders-view.js
@@ -113,7 +113,8 @@ class ManageOrdersView extends Component {
 				</div>
 				<div>
 					<Button href={ getLink( '/store/reviews/:site', site ) }>
-						{ translate( 'Moderate' ) }
+						{ translate( 'Moderate',
+						{ context: 'Product reviews widget moderation button' } ) }
 					</Button>
 				</div>
 			</div>

--- a/client/extensions/woocommerce/app/dashboard/manage-orders-view.js
+++ b/client/extensions/woocommerce/app/dashboard/manage-orders-view.js
@@ -3,6 +3,8 @@
  */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import config from 'config';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
@@ -12,6 +14,7 @@ import { localize } from 'i18n-calypso';
  */
 import Button from 'components/button';
 import { fetchOrders } from 'woocommerce/state/sites/orders/actions';
+import { fetchReviews } from 'woocommerce/state/sites/reviews/actions';
 import {
 	areOrdersLoading,
 	areOrdersLoaded,
@@ -22,6 +25,7 @@ import { getCurrentUser } from 'state/current-user/selectors';
 import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
 import { getLink } from 'woocommerce/lib/nav-utils';
 import { getPaymentCurrencySettings } from 'woocommerce/state/sites/settings/general/selectors';
+import { getTotalReviews } from 'woocommerce/state/sites/reviews/selectors';
 import ProcessOrdersWidget from 'woocommerce/components/process-orders-widget';
 import ShareWidget from 'woocommerce/components/share-widget';
 import Card from 'components/card';
@@ -53,6 +57,10 @@ class ManageOrdersView extends Component {
 
 		if ( site && site.ID ) {
 			this.props.fetchOrders( site.ID );
+			// TODO This check can be removed when we launch reviews.
+			if ( config.isEnabled( 'woocommerce/extension-reviews' ) ) {
+				this.props.fetchReviews( site.ID, { status: 'pending' } );
+			}
 		}
 	}
 
@@ -63,6 +71,10 @@ class ManageOrdersView extends Component {
 
 		if ( oldSiteId !== newSiteId ) {
 			this.props.fetchOrders( newSiteId );
+			// TODO This check can be removed when we launch reviews.
+			if ( config.isEnabled( 'woocommerce/extension-reviews' ) ) {
+				this.props.fetchReviews( newSiteId, { status: 'pending' } );
+			}
 		}
 	}
 
@@ -79,6 +91,32 @@ class ManageOrdersView extends Component {
 				ordersRevenue={ ordersRevenue }
 				currency={ currency }
 			/>
+		);
+	}
+
+	possiblyRenderReviewsWidget = () => {
+		const { site, pendingReviews, translate } = this.props;
+		if ( ! pendingReviews ) {
+			return null;
+		}
+
+		const classes = classNames( 'card', 'dashboard__reviews-widget' );
+		const countText = translate( 'Pending review', 'Pending reviews', {
+			count: pendingReviews
+		} );
+
+		return (
+			<div className={ classes } >
+				<div>
+					<span>{ pendingReviews}</span>
+					<span>{ countText }</span>
+				</div>
+				<div>
+					<Button href={ getLink( '/store/reviews/:site', site ) }>
+						{ translate( 'Moderate' ) }
+					</Button>
+				</div>
+			</div>
 		);
 	}
 
@@ -111,7 +149,12 @@ class ManageOrdersView extends Component {
 						) || '' }
 					</h2>
 				</div>
-				{ this.possiblyRenderProcessOrdersWidget() }
+
+				<div className="dashboard__queue-widgets">
+					{ this.possiblyRenderProcessOrdersWidget() }
+					{ config.isEnabled( 'woocommerce/extension-reviews' ) && this.possiblyRenderReviewsWidget() }
+				</div>
+
 				<Card
 					className="dashboard__reports-widget"
 				>
@@ -146,6 +189,7 @@ function mapStateToProps( state ) {
 	const ordersRevenue = getNewOrdersRevenue( state );
 	const user = getCurrentUser( state );
 	const currency = getPaymentCurrencySettings( state );
+	const pendingReviews = getTotalReviews( state, { status: 'pending' } );
 	return {
 		site,
 		orders,
@@ -154,6 +198,7 @@ function mapStateToProps( state ) {
 		ordersLoaded,
 		user,
 		currency,
+		pendingReviews,
 	};
 }
 
@@ -161,6 +206,7 @@ function mapDispatchToProps( dispatch ) {
 	return bindActionCreators(
 		{
 			fetchOrders,
+			fetchReviews,
 		},
 		dispatch
 	);

--- a/client/extensions/woocommerce/app/dashboard/style.scss
+++ b/client/extensions/woocommerce/app/dashboard/style.scss
@@ -320,3 +320,39 @@
 		}
 	}
 }
+
+@include breakpoint( ">960px" ) {
+	.dashboard__queue-widgets {
+		display: flex;
+
+		div {
+			flex-grow: 1;
+		}
+
+		div:nth-child( 2 ) {
+			margin-left: 8px;
+		}
+	}
+}
+
+.dashboard__reviews-widget {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	min-width: 30%;
+
+
+	div {
+		min-width: 50%;
+		text-align: center;
+
+		span:first-child {
+			display: block;
+			font-size: 24px;
+		}
+
+		span:nth-child( 2 ) {
+			color: $gray-text-min;
+		}
+	}
+}

--- a/client/extensions/woocommerce/components/process-orders-widget/style.scss
+++ b/client/extensions/woocommerce/components/process-orders-widget/style.scss
@@ -2,6 +2,8 @@
 	display: flex;
 	justify-content: space-between;
 	align-items: center;
+	margin-left: 0px;
+	min-width: 65%;
 
 	div {
 		min-width: 33%;


### PR DESCRIPTION
This PR adds a pending reviews widget to the dashboard view when there are widgets to show.

I've put it on the same line as the orders widget, since it's a simple one -- but each widget will grow if the other one is not displayed (i.e. there are no reviews or orders).

<img width="975" alt="screen shot 2017-09-29 at 12 00 50 pm" src="https://user-images.githubusercontent.com/689165/31031588-df264000-a50d-11e7-891c-4c9a263aa607.png">

To Test:
* Visit `http://calypso.localhost:3000/store/:site` with and without pending reviews.
* Make sure the widget displays properly, or doesn't display if there are no pending reviews.
