### PR TITLE
Comments: Correct comments path for PageViewTracker.

### DIFF
--- a/client/my-sites/comments/controller.js
+++ b/client/my-sites/comments/controller.js
@@ -51,7 +51,6 @@ export const comments = function( context ) {
 	const siteFragment = route.getSiteFragment( context.path );
 	renderWithReduxStore(
 		<CommentsManagement
-			basePath={ context.path }
 			siteFragment={ siteFragment }
 			status={ 'pending' === status ? 'unapproved' : status }
 		/>,

--- a/client/my-sites/comments/main.jsx
+++ b/client/my-sites/comments/main.jsx
@@ -20,7 +20,6 @@ import EmptyContent from 'components/empty-content';
 
 export class CommentsManagement extends Component {
 	static propTypes = {
-		basePath: PropTypes.string,
 		comments: PropTypes.array,
 		showPermissionError: PropTypes.bool,
 		siteId: PropTypes.number,
@@ -35,7 +34,6 @@ export class CommentsManagement extends Component {
 	render() {
 		const {
 			showPermissionError,
-			basePath,
 			siteId,
 			siteFragment,
 			status,
@@ -44,7 +42,7 @@ export class CommentsManagement extends Component {
 
 		return (
 			<Main className="comments" wideLayout>
-				<PageViewTracker path={ basePath } title="Comments" />
+				<PageViewTracker path="/comments/:status/:site" title="Comments" />
 				<DocumentHead title={ translate( 'Comments' ) } />
 				<SidebarNavigation />
 				{ showPermissionError && <EmptyContent


### PR DESCRIPTION
Comment page views are currently being collected with their site segment and status intact, rather than as variables, eg. as `/comments/pending/mysite.wordpress.com`. See #16902 .

**Testing**
- Add `localStorage.debug = 'calypso:analytics:PageViewTracker'` in the console.
- Go to any valid comments management route (eg. `http://calypso.localhost:3000/comments/approved/mysite.wordpress.com`) and verify that the PageViewTracker string appears as `/comments/:status/:site`.