### PR TITLE
Posts: Update sorting order for scheduled posts to return in ASC order

### DIFF
--- a/client/lib/posts/post-list-store.js
+++ b/client/lib/posts/post-list-store.js
@@ -135,6 +135,7 @@ export default function( id ) {
 	 */
 	function sort() {
 		const key = _activeList.query.orderBy;
+		const order = _activeList.query.order || null;
 
 		_activeList.postIds.sort( function( a, b ) {
 			var postA = PostsStore.get( a ),
@@ -149,6 +150,11 @@ export default function( id ) {
 
 				return postA.title > postB.title ? 1 : -1;
 			}
+
+			if ( order === 'ASC' ) {
+				return timeA < timeB ? -1 : 1;
+			}
+
 			// reverse-chronological
 			return timeA > timeB ? -1 : 1;
 		} );

--- a/client/lib/posts/test/post-list-store.js
+++ b/client/lib/posts/test/post-list-store.js
@@ -249,6 +249,24 @@ describe( 'post-list-store', () => {
 		} );
 	} );
 
+	describe( '#sort', () => {
+		it( 'should sort posts in ascending order if specified', () => {
+			dispatchQueryPosts( DEFAULT_POST_LIST_ID, { order: 'ASC', orderBy: 'global_ID' } );
+			dispatchReceivePostsPage( defaultPostListStore.getID(), defaultPostListStore.id, TWO_POST_PAYLOAD );
+			const results = defaultPostListStore.getAll();
+			const expectedResults = [ { global_ID: 778 }, { global_ID: 779 } ];
+			assert.deepEqual( expectedResults, results );
+		} );
+
+		it( 'should sort posts in descending order if specified', () => {
+			dispatchQueryPosts( DEFAULT_POST_LIST_ID, { order: 'DESC', orderBy: 'global_ID' } );
+			dispatchReceivePostsPage( defaultPostListStore.getID(), defaultPostListStore.id, TWO_POST_PAYLOAD );
+			const results = defaultPostListStore.getAll();
+			const expectedResults = [ { global_ID: 779 }, { global_ID: 778 } ];
+			assert.deepEqual( expectedResults, results );
+		} );
+	} );
+
 	describe( 'RECEIVE_POSTS_PAGE', () => {
 		it( 'should add post ids for matching postListStore', () => {
 			dispatchReceivePostsPage( defaultPostListStore.getID(), defaultPostListStore.id );

--- a/client/my-sites/posts/post-list.jsx
+++ b/client/my-sites/posts/post-list.jsx
@@ -51,6 +51,7 @@ class PostList extends PureComponent {
 				search={ this.props.search }
 				category={ this.props.category }
 				tag={ this.props.tag }
+				order={ this.props.statusSlug === 'scheduled' ? 'ASC' : 'DESC' }
 			>
 				<Posts
 					{ ...omit( this.props, 'children' ) }


### PR DESCRIPTION
Currently, scheduled posts return in descending order with the post scheduled farthest out at the top. This updates the logic to return the list in ascending order so the next post to publish gets returned first in the list.

In order to fix this, I updated the logic used to sort the posts. We now check for the order. If the order is ASC, we update our comparison checks. I _think_ that the order has been ignored for awhile. In `post-list-store.js`, you can see that [we're currently returning reverse chronological order by default](https://github.com/Automattic/wp-calypso/blob/master/client/lib/posts/post-list-store.js#L153). Before adding the check for the order and updating the logic, I couldn't get anything to return in chronological order. I updated the tests for `PostListStore` to reflect and test for these changes moving forward. Of note, this works for all `orderBy` parameters, but it's mainly applicable to `date` in the context of this issue.

While working on this, I also found #18417 and #18418.

## To test
1. Load this branch and schedule a group of posts all at various dates.
2. Visit http://calypso.localhost:3000/posts/scheduled/. The posts should be in chronological order with the post set to publish soonest at the top. Compare to wordpress.com/posts/scheduled. You'll see the post set to publish soonest at the bottom.
3. Compare http://calypso.localhost:3000/posts/ and wordpress.com/posts (other posts views). You shouldn't notice any changes except for the Scheduled tab.
4. You can run the tests with `npm run test-client client/lib/posts/test/post-list-store.js`

## Screenshot

**Current**
<img width="806" alt="screen shot 2017-09-30 at 6 44 25 am" src="https://user-images.githubusercontent.com/7240478/31045938-290990a2-a5ac-11e7-8dde-ef401739850e.png">

**Updated**
<img width="757" alt="screen shot 2017-09-30 at 6 44 00 am" src="https://user-images.githubusercontent.com/7240478/31045939-308a0c9e-a5ac-11e7-9caf-34929af165f2.png">

Fixes: #17953