### PR TITLE
Codemods: Preemptively run commonjs-imports on known troublemakers, fix

### DIFF
--- a/client/boot/project/wordpress-com.js
+++ b/client/boot/project/wordpress-com.js
@@ -2,32 +2,39 @@
  * External dependencies
  */
 import { includes, startsWith } from 'lodash';
-const React = require( 'react' ),
-	ReactDom = require( 'react-dom' ),
-	store = require( 'store' ),
-	debug = require( 'debug' )( 'calypso' ),
-	page = require( 'page' );
+import React from 'react';
+import ReactDom from 'react-dom';
+import store from 'store';
+import debugFactory from 'debug';
+const debug = debugFactory('calypso');
+import page from 'page';
 
 /**
  * Internal dependencies
  */
-const config = require( 'config' ),
-	abtestModule = require( 'lib/abtest' ), // used by error logger
-	getSavedVariations = abtestModule.getSavedVariations, // used by logger
-	initializeHappychat = require( 'state/happychat/actions' ).initialize,
-	analytics = require( 'lib/analytics' ),
-	reduxBridge = require( 'lib/redux-bridge' ),
-	route = require( 'lib/route' ),
-	normalize = require( 'lib/route/normalize' ),
-	{ isLegacyRoute } = require( 'lib/route/legacy-routes' ),
-	superProps = require( 'lib/analytics/super-props' ),
-	translatorJumpstart = require( 'lib/translator-jumpstart' ),
-	nuxWelcome = require( 'layout/nux-welcome' ),
-	emailVerification = require( 'components/email-verification' ),
-	viewport = require( 'lib/viewport' ),
-	pushNotificationsInit = require( 'state/push-notifications/actions' ).init,
-	syncHandler = require( 'lib/wp/sync-handler' ),
-	supportUser = require( 'lib/user/support-user-interop' );
+import config from 'config';
+
+import abtestModule from 'lib/abtest'; // used by error logger
+import { initialize as initializeHappychat } from 'state/happychat/actions';
+import analytics from 'lib/analytics';
+import reduxBridge from 'lib/redux-bridge';
+import route from 'lib/route';
+import normalize from 'lib/route/normalize';
+import { isLegacyRoute } from 'lib/route/legacy-routes';
+import superProps from 'lib/analytics/super-props';
+import translatorJumpstart from 'lib/translator-jumpstart';
+import nuxWelcome from 'layout/nux-welcome';
+import emailVerification from 'components/email-verification';
+import viewport from 'lib/viewport';
+import { init as pushNotificationsInit } from 'state/push-notifications/actions';
+import syncHandler from 'lib/wp/sync-handler';
+import supportUser from 'lib/user/support-user-interop';
+
+/**
+ * Internal dependencies
+ */
+const // used by logger
+getSavedVariations = abtestModule.getSavedVariations;
 
 import { getSelectedSiteId, getSectionName } from 'state/ui/selectors';
 import { setNextLayoutFocus, activateNextLayoutFocus } from 'state/ui/layout-focus/actions';

--- a/client/boot/project/wordpress-com.js
+++ b/client/boot/project/wordpress-com.js
@@ -5,19 +5,17 @@ import { includes, startsWith } from 'lodash';
 import React from 'react';
 import ReactDom from 'react-dom';
 import store from 'store';
-import debugFactory from 'debug';
-const debug = debugFactory('calypso');
 import page from 'page';
+import debugFactory from 'debug';
 
 /**
  * Internal dependencies
  */
 import config from 'config';
-
-import abtestModule from 'lib/abtest'; // used by error logger
+import { getSavedVariations } from 'lib/abtest'; // used by error logger
 import { initialize as initializeHappychat } from 'state/happychat/actions';
 import analytics from 'lib/analytics';
-import reduxBridge from 'lib/redux-bridge';
+import { setReduxStore as setReduxBridgeReduxStore } from 'lib/redux-bridge';
 import route from 'lib/route';
 import normalize from 'lib/route/normalize';
 import { isLegacyRoute } from 'lib/route/legacy-routes';
@@ -27,17 +25,12 @@ import nuxWelcome from 'layout/nux-welcome';
 import emailVerification from 'components/email-verification';
 import viewport from 'lib/viewport';
 import { init as pushNotificationsInit } from 'state/push-notifications/actions';
-import syncHandler from 'lib/wp/sync-handler';
-import supportUser from 'lib/user/support-user-interop';
-
-/**
- * Internal dependencies
- */
-const // used by logger
-getSavedVariations = abtestModule.getSavedVariations;
-
+import { pruneStaleRecords } from 'lib/wp/sync-handler';
+import { setReduxStore as setSupportUserReduxStore } from 'lib/user/support-user-interop';
 import { getSelectedSiteId, getSectionName } from 'state/ui/selectors';
 import { setNextLayoutFocus, activateNextLayoutFocus } from 'state/ui/layout-focus/actions';
+
+const debug = debugFactory( 'calypso' );
 
 function renderLayout( reduxStore ) {
 	const Layout = require( 'controller' ).ReduxWrappedLayout;
@@ -58,7 +51,7 @@ export function utils() {
 	debug( 'Executing WordPress.com utils.' );
 
 	// prune sync-handler records more than two days old
-	syncHandler.pruneStaleRecords( '2 days' );
+	pruneStaleRecords( '2 days' );
 
 	translatorJumpstart.init();
 }
@@ -66,8 +59,8 @@ export function utils() {
 export const configureReduxStore = ( currentUser, reduxStore ) => {
 	debug( 'Executing WordPress.com configure Redux store.' );
 
-	supportUser.setReduxStore( reduxStore );
-	reduxBridge.setReduxStore( reduxStore );
+	setSupportUserReduxStore( reduxStore );
+	setReduxBridgeReduxStore( reduxStore );
 
 	if ( currentUser.get() ) {
 		if ( config.isEnabled( 'push-notifications' ) ) {

--- a/client/lib/invites/reducers/test/invites-create-validation.js
+++ b/client/lib/invites/reducers/test/invites-create-validation.js
@@ -1,13 +1,14 @@
 /**
  * External dependencies
  */
-const assert = require( 'chai' ).assert;
+import { assert } from 'chai';
 
 /**
  * Internal dependencies
  */
-const Dispatcher = require( 'dispatcher' ),
-	constants = require( 'lib/invites/constants' );
+import Dispatcher from 'dispatcher';
+
+import constants from 'lib/invites/constants';
 
 describe( 'Invites Create Validation Store', () => {
 	let InvitesCreateValidationStore;

--- a/client/lib/invites/reducers/test/invites-create-validation.js
+++ b/client/lib/invites/reducers/test/invites-create-validation.js
@@ -7,8 +7,7 @@ import { assert } from 'chai';
  * Internal dependencies
  */
 import Dispatcher from 'dispatcher';
-
-import constants from 'lib/invites/constants';
+import { action as ActionTypes } from 'lib/invites/constants';
 
 describe( 'Invites Create Validation Store', () => {
 	let InvitesCreateValidationStore;
@@ -28,7 +27,7 @@ describe( 'Invites Create Validation Store', () => {
 
 	const actions = {
 		receiveValidaton: {
-			type: constants.action.RECEIVE_CREATE_INVITE_VALIDATION_SUCCESS,
+			type: ActionTypes.RECEIVE_CREATE_INVITE_VALIDATION_SUCCESS,
 			siteId: siteId,
 			data: validationData
 		},

--- a/client/lib/invites/stores/test/invites-list.js
+++ b/client/lib/invites/stores/test/invites-list.js
@@ -7,15 +7,14 @@ import { assert } from 'chai';
  * Internal dependencies
  */
 import Dispatcher from 'dispatcher';
-
-import constants from 'lib/invites/constants';
+import { action as ActionTypes } from 'lib/invites/constants';
 
 describe( 'List Invites Store', function() {
-	var ListInvitesStore;
+	let ListInvitesStore;
 	const siteId = 123;
 	const actions = {
 		receiveInvites: {
-			type: constants.action.RECEIVE_INVITES,
+			type: ActionTypes.RECEIVE_INVITES,
 			siteId: siteId,
 			offset: 0,
 			data: {
@@ -33,7 +32,7 @@ describe( 'List Invites Store', function() {
 			}
 		},
 		receiveMoreInvites: {
-			type: constants.action.RECEIVE_INVITES,
+			type: ActionTypes.RECEIVE_INVITES,
 			siteId: siteId,
 			offset: 0,
 			data: {

--- a/client/lib/invites/stores/test/invites-list.js
+++ b/client/lib/invites/stores/test/invites-list.js
@@ -1,13 +1,14 @@
 /**
  * External dependencies
  */
-const assert = require( 'chai' ).assert;
+import { assert } from 'chai';
 
 /**
  * Internal dependencies
  */
-const Dispatcher = require( 'dispatcher' ),
-	constants = require( 'lib/invites/constants' );
+import Dispatcher from 'dispatcher';
+
+import constants from 'lib/invites/constants';
 
 describe( 'List Invites Store', function() {
 	var ListInvitesStore;

--- a/client/lib/posts/actions.js
+++ b/client/lib/posts/actions.js
@@ -1,23 +1,27 @@
 /**
  * External dependencies
  */
-var debug = require( 'debug' )( 'calypso:posts' ),
-	store = require( 'store' );
+import debugFactory from 'debug';
+
+const debug = debugFactory('calypso:posts');
+import store from 'store';
 import { assign, clone, defer, fromPairs } from 'lodash';
 
 /**
  * Internal dependencies
  */
-var wpcom = require( 'lib/wp' ),
-	PostsStore = require( './posts-store' ),
-	PostEditStore = require( './post-edit-store' ),
-	postListStoreFactory = require( './post-list-store-factory' ),
-	PreferencesStore = require( 'lib/preferences/store' ),
-	sites = require( 'lib/sites-list' )(),
-	utils = require( './utils' ),
-	versionCompare = require( 'lib/version-compare' ),
-	Dispatcher = require( 'dispatcher' ),
-	stats = require( './stats' );
+import wpcom from 'lib/wp';
+
+import PostsStore from './posts-store';
+import PostEditStore from './post-edit-store';
+import postListStoreFactory from './post-list-store-factory';
+import PreferencesStore from 'lib/preferences/store';
+import sitesFactory from 'lib/sites-list';
+const sites = sitesFactory();
+import utils from './utils';
+import versionCompare from 'lib/version-compare';
+import Dispatcher from 'dispatcher';
+import stats from './stats';
 import { normalizeTermsForApi } from 'state/posts/utils';
 
 var PostActions;

--- a/client/lib/posts/actions.js
+++ b/client/lib/posts/actions.js
@@ -1,28 +1,27 @@
 /**
  * External dependencies
  */
-import debugFactory from 'debug';
-
-const debug = debugFactory('calypso:posts');
 import store from 'store';
 import { assign, clone, defer, fromPairs } from 'lodash';
+import debugFactory from 'debug';
 
 /**
  * Internal dependencies
  */
 import wpcom from 'lib/wp';
-
 import PostsStore from './posts-store';
 import PostEditStore from './post-edit-store';
 import postListStoreFactory from './post-list-store-factory';
 import PreferencesStore from 'lib/preferences/store';
 import sitesFactory from 'lib/sites-list';
-const sites = sitesFactory();
 import utils from './utils';
 import versionCompare from 'lib/version-compare';
 import Dispatcher from 'dispatcher';
-import stats from './stats';
+import { recordSaveEvent } from './stats';
 import { normalizeTermsForApi } from 'state/posts/utils';
+
+const sites = sitesFactory();
+const debug = debugFactory( 'calypso:posts' );
 
 var PostActions;
 
@@ -339,7 +338,7 @@ PostActions = {
 		};
 
 		if ( ! options || options.recordSaveEvent !== false ) {
-			stats.recordSaveEvent( context ); // do this before changing status from 'future'
+			recordSaveEvent( context ); // do this before changing status from 'future'
 		}
 
 		if ( ( changedAttributes && changedAttributes.status === 'future' && utils.isFutureDated( post ) ) ||

--- a/client/lib/transaction/store.js
+++ b/client/lib/transaction/store.js
@@ -13,7 +13,7 @@ import { cartItems } from 'lib/cart-values';
 import CartStore from 'lib/cart/store';
 import Emitter from 'lib/mixins/emitter';
 import Dispatcher from 'dispatcher';
-import transactionStepTypes from 'lib/store-transactions/step-types';
+import { BEFORE_SUBMIT } from 'lib/store-transactions/step-types';
 import { hasDomainDetails } from 'lib/store-transactions';
 
 var _transaction = createInitialTransaction();
@@ -35,7 +35,7 @@ function createInitialTransaction() {
 	return {
 		errors: {},
 		newCardFormFields: {},
-		step: { name: transactionStepTypes.BEFORE_SUBMIT },
+		step: { name: BEFORE_SUBMIT },
 		domainDetails: null
 	};
 }

--- a/client/lib/transaction/store.js
+++ b/client/lib/transaction/store.js
@@ -2,18 +2,19 @@
  * External dependencies
  */
 import { assign, cloneDeep, merge } from 'lodash';
-const update = require( 'react-addons-update' );
+import update from 'react-addons-update';
 
 /**
  * Internal dependencies
  */
-var UpgradesActionTypes = require( 'lib/upgrades/constants' ).action,
-	cartItems = require( 'lib/cart-values' ).cartItems,
-	CartStore = require( 'lib/cart/store' ),
-	Emitter = require( 'lib/mixins/emitter' ),
-	Dispatcher = require( 'dispatcher' ),
-	transactionStepTypes = require( 'lib/store-transactions/step-types' ),
-	hasDomainDetails = require( 'lib/store-transactions' ).hasDomainDetails;
+import { action as UpgradesActionTypes } from 'lib/upgrades/constants';
+
+import { cartItems } from 'lib/cart-values';
+import CartStore from 'lib/cart/store';
+import Emitter from 'lib/mixins/emitter';
+import Dispatcher from 'dispatcher';
+import transactionStepTypes from 'lib/store-transactions/step-types';
+import { hasDomainDetails } from 'lib/store-transactions';
 
 var _transaction = createInitialTransaction();
 


### PR DESCRIPTION
Spun off from #18359, as per [discussion](https://github.com/Automattic/wp-calypso/pull/18359#discussion_r141728728) with @samouri.

The idea (as discussed also via DM) is to

> 1. apply one codemod to the whole codebase.
> 2. see which files break.  fix those cases
> 3. repeat steps 1 and 2 for all of our codemods
> 
> [...]
> then the codebase should be in a place where we could run all of the codemods at once w/ no hand-edits

To test:
* Verify that the app still works (restart to be sure!), with special focus on the areas affected by the changes in this PR.
* Verify that tests pass