### PR TITLE
Fix wrong property name

### DIFF
--- a/client/lib/i18n-utils/switch-locale.js
+++ b/client/lib/i18n-utils/switch-locale.js
@@ -45,7 +45,7 @@ export default function switchLocale( localeSlug ) {
 		if ( typeof document !== 'undefined' ) {
 			document.documentElement.lang = localeSlug;
 			document.documentElement.dir = language.rtl ? 'rtl' : 'ltr';
-			const cssUrl = language.rtl ? window.app.urls[ 'style-rtl.css' ] : window.app.urls[ 'style.css' ];
+			const cssUrl = language.rtl ? window.app.staticUrls[ 'style-rtl.css' ] : window.app.staticUrls[ 'style.css' ];
 			switchCSS( 'main-css', cssUrl );
 		}
 	} );


### PR DESCRIPTION
It should be `staticUrls` instead of `urls`.

That fixes:
![screen shot 2017-10-01 at 13 43 15](https://user-images.githubusercontent.com/326402/31053832-8274b2c2-a6ae-11e7-8505-d6bd708b9768.png)

#### Testing instructions
  
1. Run `git checkout fix/wrong-property-name` and start your server, or open a [live branch](https://calypso.live/?branch=fix/wrong-property-name)
2. Open the [`Home` page](http://calypso.localhost:3000/)
3. Assert you don't see the error above
   
#### Reviews
  
- [x] Code
- [x] Product
