### PR TITLE
Sidebar: Load domain warnings asynchronously

### DIFF
--- a/client/lib/domains/assembler.js
+++ b/client/lib/domains/assembler.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { camelCase, find, mapKeys, without } from 'lodash';
-
 import i18n from 'i18n-calypso';
 
 /**
@@ -70,5 +69,6 @@ function ensurePrimaryDomainIsFirst( domains ) {
 }
 
 module.exports = {
+	assembleGoogleAppsSubscription,
 	createDomainObjects
 };

--- a/client/my-sites/current-site/domain-warnings.jsx
+++ b/client/my-sites/current-site/domain-warnings.jsx
@@ -1,0 +1,60 @@
+/**
+ * External dependencies
+ */
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import DomainWarnings from 'my-sites/domains/components/domain-warnings';
+import { getDecoratedSiteDomains } from 'state/sites/domains/selectors';
+import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
+import { isJetpackSite } from 'state/sites/selectors';
+import QuerySiteDomains from 'components/data/query-site-domains';
+
+const CurrentSiteDomainWarnings = ( { domains, isJetpack, selectedSite } ) => {
+	if ( ! selectedSite || isJetpack ) {
+		return null;
+	}
+
+	return (
+		<div>
+			<QuerySiteDomains siteId={ selectedSite.ID } />
+
+			<DomainWarnings
+				isCompact
+				selectedSite={ selectedSite }
+				domains={ domains }
+				ruleWhiteList={ [
+					'unverifiedDomainsCanManage',
+					'unverifiedDomainsCannotManage',
+					'expiredDomainsCanManage',
+					'expiringDomainsCanManage',
+					'expiredDomainsCannotManage',
+					'expiringDomainsCannotManage',
+					'wrongNSMappedDomains',
+					'pendingGappsTosAcceptanceDomains',
+				] } />
+		</div>
+	);
+};
+
+CurrentSiteDomainWarnings.propTypes = {
+	domains: PropTypes.array,
+	isJetpack: PropTypes.bool,
+	selectedSite: PropTypes.object
+};
+
+export default connect(
+	state => {
+		const selectedSiteId = getSelectedSiteId( state );
+
+		return {
+			domains: getDecoratedSiteDomains( state, selectedSiteId ),
+			isJetpack: isJetpackSite( state, selectedSiteId ),
+			selectedSite: getSelectedSite( state )
+		};
+	}
+)( CurrentSiteDomainWarnings );

--- a/client/my-sites/current-site/domain-warnings.jsx
+++ b/client/my-sites/current-site/domain-warnings.jsx
@@ -14,6 +14,17 @@ import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
 import QuerySiteDomains from 'components/data/query-site-domains';
 
+const ruleWhiteList = [
+	'unverifiedDomainsCanManage',
+	'unverifiedDomainsCannotManage',
+	'expiredDomainsCanManage',
+	'expiringDomainsCanManage',
+	'expiredDomainsCannotManage',
+	'expiringDomainsCannotManage',
+	'wrongNSMappedDomains',
+	'pendingGappsTosAcceptanceDomains',
+];
+
 const CurrentSiteDomainWarnings = ( { domains, isJetpack, selectedSite } ) => {
 	if ( ! selectedSite || isJetpack ) {
 		return null;
@@ -27,16 +38,7 @@ const CurrentSiteDomainWarnings = ( { domains, isJetpack, selectedSite } ) => {
 				isCompact
 				selectedSite={ selectedSite }
 				domains={ domains }
-				ruleWhiteList={ [
-					'unverifiedDomainsCanManage',
-					'unverifiedDomainsCannotManage',
-					'expiredDomainsCanManage',
-					'expiringDomainsCanManage',
-					'expiredDomainsCannotManage',
-					'expiringDomainsCannotManage',
-					'wrongNSMappedDomains',
-					'pendingGappsTosAcceptanceDomains',
-				] } />
+				ruleWhiteList={ ruleWhiteList } />
 		</div>
 	);
 };

--- a/client/my-sites/current-site/index.jsx
+++ b/client/my-sites/current-site/index.jsx
@@ -11,21 +11,18 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import AllSites from 'my-sites/all-sites';
+import AsyncLoad from 'components/async-load';
 import analytics from 'lib/analytics';
 import Button from 'components/button';
 import Card from 'components/card';
 import Site from 'blocks/site';
 import Gridicon from 'gridicons';
-import UpgradesActions from 'lib/upgrades/actions';
-import DomainsStore from 'lib/domains/store';
-import DomainWarnings from 'my-sites/domains/components/domain-warnings';
 import config from 'config';
 import SiteNotice from './notice';
 import CartStore from 'lib/cart/store';
 import { setLayoutFocus } from 'state/ui/layout-focus/actions';
-import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
+import { getSelectedSite } from 'state/ui/selectors';
 import { getCurrentUser } from 'state/current-user/selectors';
-import { isJetpackSite } from 'state/sites/selectors';
 import { getSelectedOrAllSites } from 'state/selectors';
 import { infoNotice, removeNotice } from 'state/notices/actions';
 import { getNoticeLastTimeShown } from 'state/notices/selectors';
@@ -34,44 +31,20 @@ import { recordTracksEvent } from 'state/analytics/actions';
 
 class CurrentSite extends Component {
 	static propTypes = {
-		isJetpack: React.PropTypes.bool,
 		isPreviewShowing: React.PropTypes.bool,
 		siteCount: React.PropTypes.number.isRequired,
 		setLayoutFocus: React.PropTypes.func.isRequired,
-		selectedSiteId: React.PropTypes.number,
 		selectedSite: React.PropTypes.object,
 		translate: React.PropTypes.func.isRequired,
 		anySiteSelected: React.PropTypes.array
 	};
 
-	state = {
-		domainsStore: DomainsStore
-	};
-
 	componentWillMount() {
-		const { selectedSiteId, isJetpack } = this.props;
-		if ( selectedSiteId && ! isJetpack ) {
-			UpgradesActions.fetchDomains( selectedSiteId );
-		}
-
-		DomainsStore.on( 'change', this.handleStoreChange );
 		CartStore.on( 'change', this.showStaleCartItemsNotice );
 	}
 
 	componentWillUnmount() {
-		DomainsStore.off( 'change', this.handleStoreChange );
 		CartStore.off( 'change', this.showStaleCartItemsNotice );
-	}
-
-	componentDidUpdate( prevProps ) {
-		const { selectedSiteId, isJetpack } = this.props;
-		if ( selectedSiteId && ! isJetpack && selectedSiteId !== prevProps.selectedSiteId ) {
-			UpgradesActions.fetchDomains( selectedSiteId );
-		}
-	}
-
-	handleStoreChange = () => {
-		this.setState( { domainsStore: DomainsStore } );
 	}
 
 	showStaleCartItemsNotice = () => {
@@ -101,11 +74,11 @@ class CurrentSite extends Component {
 				}
 			);
 		}
-	}
+	};
 
 	clickStaleCartItemsNotice = () => {
 		this.props.recordTracksEvent( 'calypso_cart_abandonment_notice_click' );
-	}
+	};
 
 	switchSites = ( event ) => {
 		event.preventDefault();
@@ -113,37 +86,7 @@ class CurrentSite extends Component {
 		this.props.setLayoutFocus( 'sites' );
 
 		analytics.ga.recordEvent( 'Sidebar', 'Clicked Switch Site' );
-	}
-
-	getDomainWarnings() {
-		const { selectedSiteId, selectedSite: site } = this.props;
-
-		if ( ! selectedSiteId ) {
-			return null;
-		}
-
-		const domainStore = this.state.domainsStore.getBySite( selectedSiteId );
-		const domains = domainStore && domainStore.list || [];
-
-		return (
-			<DomainWarnings
-				isCompact
-				selectedSite={ site }
-				domains={ domains }
-				position="site-sidebar"
-				ruleWhiteList={ [
-					'unverifiedDomainsCanManage',
-					'unverifiedDomainsCannotManage',
-					'expiredDomainsCanManage',
-					'expiringDomainsCanManage',
-					'expiredDomainsCannotManage',
-					'expiringDomainsCannotManage',
-					'wrongNSMappedDomains',
-					'pendingGappsTosAcceptanceDomains'
-				] }
-			/>
-		);
-	}
+	};
 
 	previewSite = ( event ) => this.props.onClick && this.props.onClick( event );
 
@@ -185,7 +128,7 @@ class CurrentSite extends Component {
 	}
 
 	render() {
-		const { isJetpack, selectedSite, translate, anySiteSelected } = this.props;
+		const { selectedSite, translate, anySiteSelected } = this.props;
 
 		if ( ! anySiteSelected.length ) {
 			return (
@@ -215,6 +158,7 @@ class CurrentSite extends Component {
 						</Button>
 					</span>
 				}
+
 				{ selectedSite
 					? <div>
 						<Site site={ selectedSite } />
@@ -222,7 +166,9 @@ class CurrentSite extends Component {
 					</div>
 					: <AllSites />
 				}
-				{ ! isJetpack && this.getDomainWarnings() }
+
+				<AsyncLoad require="my-sites/current-site/domain-warnings" noPlaceholder={ null } />
+
 				<SiteNotice site={ selectedSite } allSitesPath={ this.props.allSitesPath } />
 			</Card>
 		);
@@ -231,12 +177,9 @@ class CurrentSite extends Component {
 
 export default connect(
 	( state ) => {
-		const selectedSiteId = getSelectedSiteId( state );
 		const user = getCurrentUser( state );
 
 		return {
-			isJetpack: isJetpackSite( state, selectedSiteId ),
-			selectedSiteId,
 			selectedSite: getSelectedSite( state ),
 			anySiteSelected: getSelectedOrAllSites( state ),
 			siteCount: get( user, 'visible_site_count', 0 ),

--- a/client/my-sites/current-site/index.jsx
+++ b/client/my-sites/current-site/index.jsx
@@ -6,6 +6,7 @@ import classNames from 'classnames';
 import { connect } from 'react-redux';
 import { get } from 'lodash';
 import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies
@@ -31,12 +32,12 @@ import { recordTracksEvent } from 'state/analytics/actions';
 
 class CurrentSite extends Component {
 	static propTypes = {
-		isPreviewShowing: React.PropTypes.bool,
-		siteCount: React.PropTypes.number.isRequired,
-		setLayoutFocus: React.PropTypes.func.isRequired,
-		selectedSite: React.PropTypes.object,
-		translate: React.PropTypes.func.isRequired,
-		anySiteSelected: React.PropTypes.array
+		isPreviewShowing: PropTypes.bool,
+		siteCount: PropTypes.number.isRequired,
+		setLayoutFocus: PropTypes.func.isRequired,
+		selectedSite: PropTypes.object,
+		translate: PropTypes.func.isRequired,
+		anySiteSelected: PropTypes.array
 	};
 
 	componentWillMount() {
@@ -131,11 +132,13 @@ class CurrentSite extends Component {
 		const { selectedSite, translate, anySiteSelected } = this.props;
 
 		if ( ! anySiteSelected.length ) {
+			/* eslint-disable wpcalypso/jsx-classname-namespace */
 			return (
 				<Card className="current-site is-loading">
 					{ this.props.siteCount > 1 &&
 						<span className="current-site__switch-sites">&nbsp;</span>
 					}
+
 					<div className="site">
 						<a className="site__content">
 							<div className="site-icon" />
@@ -146,6 +149,7 @@ class CurrentSite extends Component {
 					</div>
 				</Card>
 			);
+			/* eslint-enable wpcalypso/jsx-classname-namespace */
 		}
 
 		return (

--- a/client/state/sites/domains/assembler.js
+++ b/client/state/sites/domains/assembler.js
@@ -2,6 +2,7 @@
  * Internal dependencies
  */
 import { getDomainType } from 'lib/domains/utils';
+import { assembleGoogleAppsSubscription } from 'lib/domains/assembler';
 
 export const createSiteDomainObject = domain => {
 	return {
@@ -15,7 +16,7 @@ export const createSiteDomainObject = domain => {
 		expired: Boolean( domain.expired ),
 		expiry: ! domain.expiry ? null : String( domain.expiry ),
 		expirySoon: Boolean( domain.expiry_soon ),
-		googleAppsSubscription: Object( domain.google_apps_subscription ),
+		googleAppsSubscription: assembleGoogleAppsSubscription( domain.google_apps_subscription ),
 		hasPrivacyProtection: Boolean( domain.has_private_registration ),
 		privacyAvailable: Boolean( domain.privacy_available ),
 		hasRegistration: Boolean( domain.has_registration ),


### PR DESCRIPTION
This pull request is a follow-up of #15341 that aims at loading the domain warnings displayed in the sidebar asynchronously. The goal is to reduce the size of the main Javascript bundle by creating a new chunk only for this component: before it would weight 5.96MB (633.5KB zipped). However after this change it weights 5.69MB (600.6KB zipped).

<img width="623" alt="screenshot" src="https://user-images.githubusercontent.com/594356/31056277-57f51a98-a6cf-11e7-8678-aee915143703.png">

#### Testing instructions
 
1. Run `git checkout update/domain-warnings` and start your server, or open a [live branch](https://calypso.live/?branch=update/domain-warnings)
2. Open any page from the `My Sites` section, assuming you have a site selected
3. Check that domain warnings display as before in the sidebar


#### Reviews
 
- [x] Code
- [ ] Product
- [ ] Tests