### PR TITLE
Bump the minimum supported version of iOS/Safari to 10.

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -4,8 +4,8 @@
 			"targets": {
 				"browsers": [
 					"last 2 versions",
-					"Safari >= 9",
-					"iOS >= 9",
+					"Safari >= 10",
+					"iOS >= 10",
 					"not ie <= 10"
 				]
 			}

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
   "main": "index.js",
   "browserlist": [
     "last 2 versions",
-    "Safari >= 9",
-    "iOS >= 9",
+    "Safari >= 10",
+    "iOS >= 10",
     "not ie <= 10",
     "> 1%"
   ],


### PR DESCRIPTION
We support [the latest 2 versions of the major browsers](https://github.com/Automattic/wp-calypso#browser-support).

Since `Safari 11` and `iOS 11` were released a few weeks ago, we can drop support for Safari & iOS 9.

We need to still use the explicit `Safari >= 10` because the minor versions ('9.1', `10.1`, etc) count as a "version" in `browserslist`, so if we left just the `last 2 versions` rule it would drop support for `iOS 10` as soon as `iOS 11.1` is released.