### PR TITLE
Components: Add missing displayNames

### DIFF
--- a/client/components/feature-example/index.jsx
+++ b/client/components/feature-example/index.jsx
@@ -4,6 +4,8 @@
 import React from 'react';
 
 export default React.createClass( {
+	displayName: 'FeatureExample',
+
 	render() {
 		return (
 			<div className="feature-example">

--- a/client/components/olark-chatbox/index.jsx
+++ b/client/components/olark-chatbox/index.jsx
@@ -11,6 +11,9 @@ var ReactDom = require( 'react-dom' ),
 var OlarkEvents = require( 'lib/olark-events' );
 
 module.exports = React.createClass( {
+
+	displayName: 'OlarkChatBox',
+
 	/**
 	 * Initialize our component by binding to all of the necessary olark events.
 	 */

--- a/client/components/phone-input/country-flag.jsx
+++ b/client/components/phone-input/country-flag.jsx
@@ -6,6 +6,8 @@ import Gridicon from 'gridicons';
 import Spinner from 'components/spinner';
 
 export default React.createClass( {
+	displayName: 'PhoneInputCountryFlag',
+
 	propTypes: {
 		countryCode: React.PropTypes.string.isRequired
 	},

--- a/client/components/post-schedule/header-controls.jsx
+++ b/client/components/post-schedule/header-controls.jsx
@@ -10,6 +10,8 @@ import Gridicon from 'gridicons';
 var noop = () => {};
 
 export default React.createClass( {
+	displayName: 'PostScheduleHeaderControls',
+
 	propTypes: {
 		onYearChange: React.PropTypes.func
 	},

--- a/client/components/post-schedule/header.jsx
+++ b/client/components/post-schedule/header.jsx
@@ -15,6 +15,8 @@ import classNames from 'classnames';
 var noop = () => {};
 
 export default React.createClass( {
+	displayName: 'PostScheduleHeader',
+
 	propTypes: {
 		date: React.PropTypes.object,
 		inputChronoDisplayed: React.PropTypes.bool,

--- a/client/components/tinymce/plugins/wpcom-view/views/contact-form/index.jsx
+++ b/client/components/tinymce/plugins/wpcom-view/views/contact-form/index.jsx
@@ -11,6 +11,8 @@ import shortcodeUtils from 'lib/shortcode';
 import renderField from './preview-fields';
 
 export default React.createClass( {
+	displayName: 'ContactForm',
+
 	statics: {
 		match( content ) {
 			const match = shortcodeUtils.next( 'contact-form', content );

--- a/client/components/tinymce/plugins/wpcom-view/views/contact-form/preview-legend.jsx
+++ b/client/components/tinymce/plugins/wpcom-view/views/contact-form/preview-legend.jsx
@@ -9,6 +9,8 @@ import React from 'react';
 import PreviewRequired from './preview-required';
 
 export default React.createClass( {
+	displayName: 'PreviewLegend',
+
 	render() {
 		return ( <legend>{ this.props.label }<PreviewRequired { ...this.props } /></legend> );
 	}

--- a/client/lib/abtest/test-helper/Test.jsx
+++ b/client/lib/abtest/test-helper/Test.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import classNames from 'classnames';
 
 export default React.createClass( {
+	displayName: 'Test',
 
 	changeVariant( variation ) {
 		this.props.onChangeVariant( this.props.test, variation );

--- a/client/me/help/help-contact-confirmation/index.jsx
+++ b/client/me/help/help-contact-confirmation/index.jsx
@@ -11,6 +11,8 @@ import Gridicon from 'gridicons';
 import FormSectionHeading from 'components/forms/form-section-heading';
 
 module.exports = React.createClass( {
+	displayName: 'HelpContactConfirmation',
+
 	mixins: [ PureRenderMixin ],
 
 	propTypes: {

--- a/client/me/next-steps/index.jsx
+++ b/client/me/next-steps/index.jsx
@@ -16,6 +16,7 @@ var NextStepsBox = require( './next-steps-box' ),
 	sites = require( 'lib/sites-list' )();
 
 module.exports = React.createClass( {
+	displayName: 'NextSteps',
 
 	mixins: [ observe( 'trophiesData', 'sites' ) ],
 

--- a/client/me/next-steps/next-steps-box.jsx
+++ b/client/me/next-steps/next-steps-box.jsx
@@ -10,6 +10,8 @@ var React = require( 'react' );
 var analytics = require( 'lib/analytics' );
 
 module.exports = React.createClass( {
+	displayName: 'NextStepsBox',
+
 	recordEvent: function() {
 		analytics.ga.recordEvent( 'Me > Next > Box', this.props.stepName );
 		analytics.tracks.recordEvent( 'calypso_me_next_click', {

--- a/client/me/security-section-nav/index.jsx
+++ b/client/me/security-section-nav/index.jsx
@@ -14,6 +14,8 @@ import NavTabs from 'components/section-nav/tabs';
 import SectionNav from 'components/section-nav';
 
 module.exports = React.createClass( {
+	displayName: 'SecuritySectionNav',
+
 	propTypes: {
 		path: React.PropTypes.string.isRequired
 	},

--- a/client/my-sites/guided-transfer/host-select.jsx
+++ b/client/my-sites/guided-transfer/host-select.jsx
@@ -11,6 +11,8 @@ import SectionHeader from 'components/section-header';
 import Button from 'components/button';
 
 export default React.createClass( {
+	displayName: 'HostSelect',
+
 	propTypes: {
 		hosts: PropTypes.arrayOf(
 			PropTypes.shape( {

--- a/client/my-sites/plugins/plugin-activate-toggle/test/mocks/plugin-action.jsx
+++ b/client/my-sites/plugins/plugin-activate-toggle/test/mocks/plugin-action.jsx
@@ -4,6 +4,8 @@
 import React from 'react';
 
 export default React.createClass( {
+	displayName: 'MockPluginAction',
+
 	render() {
 		return <div className="plugin-action" onClick={ this.props.action }></div>;
 	}

--- a/client/my-sites/plugins/plugin-autoupdate-toggle/test/mocks/plugin-action.jsx
+++ b/client/my-sites/plugins/plugin-autoupdate-toggle/test/mocks/plugin-action.jsx
@@ -4,6 +4,8 @@
 var React = require( 'react' );
 
 module.exports = React.createClass( {
+	displayName: 'MockPluginAction',
+
 	render: function() {
 		return <div className="plugin-action" onClick={ this.props.action }></div>;
 	}

--- a/client/my-sites/stats/stats-first-view/index.jsx
+++ b/client/my-sites/stats/stats-first-view/index.jsx
@@ -10,6 +10,8 @@ import PureRenderMixin from 'react-pure-render/mixin';
 import FirstView from 'components/first-view';
 
 export default React.createClass( {
+	displayName: 'StatsFirstView',
+
 	mixins: [ PureRenderMixin ],
 
 	render() {


### PR DESCRIPTION
### Summary

This PR just adds a `displayName` property to any `React.createClass` components that did not already have one.

I found these while running a codemod that I have up for review @ #18390 - It relies on the component to have a display name in order to name the variable that the component will be assigned to. Adding these missing properties now will make that codemod more reliable.

### Testing
Testing not necessary, instead just check that the display names make sense per component :)
