### PR TITLE
Domains: Showing address fields only when country is selected

### DIFF
--- a/client/my-sites/checkout/checkout/domain-details-form.jsx
+++ b/client/my-sites/checkout/checkout/domain-details-form.jsx
@@ -38,7 +38,6 @@ import analytics from 'lib/analytics';
 import formState from 'lib/form-state';
 import { addPrivacyToAllDomains, removePrivacyFromAllDomains, setDomainDetails, addGoogleAppsRegistrationData } from 'lib/upgrades/actions';
 import FormButton from 'components/forms/form-button';
-import FormFieldset from 'components/forms/form-fieldset';
 import { countries } from 'components/phone-input/data';
 import { toIcannFormat } from 'components/phone-input/phone-number';
 import FormPhoneMediaInput from 'components/forms/form-phone-media-input';
@@ -390,12 +389,12 @@ export class DomainDetailsForm extends PureComponent {
 
 	renderCountryDependentAddressFields( needsOnlyGoogleAppsDetails ) {
 		return (
-			<FormFieldset className="checkout__domain-details-fieldset">
+			<div className="checkout__domain-details-country-dependent-address-fields">
                 { ! needsOnlyGoogleAppsDetails && this.renderAddressFields() }
                 { ! needsOnlyGoogleAppsDetails && this.renderCityField() }
                 { ! needsOnlyGoogleAppsDetails && this.renderStateField() }
                 { this.renderPostalCodeField() }
-			</FormFieldset>
+			</div>
 		);
 	}
 

--- a/client/my-sites/checkout/checkout/domain-details-form.jsx
+++ b/client/my-sites/checkout/checkout/domain-details-form.jsx
@@ -10,7 +10,6 @@ import {
 	camelCase,
 	deburr,
 	first,
-    get,
 	head,
 	includes,
 	indexOf,
@@ -261,12 +260,10 @@ export class DomainDetailsForm extends PureComponent {
 		return cartItems.getDomainRegistrationsWithoutPrivacy( this.props.cart ).length === 0;
 	}
 
-	canDisplayAddressFieldset() {
-		const countryCodeFieldState = get( this.state, 'form.countryCode' );
-			// To avoid a lag effect when displaying the AddressFieldset
-			// we show it when there are no errors AND the value is not empty
-		return countryCodeFieldState && countryCodeFieldState.errors
-				? !! countryCodeFieldState.value && countryCodeFieldState.errors.length === 0 : true;
+	shouldDisplayAddressFieldset() {
+		const { countryCode } = this.props.contactDetails;
+
+		return !! countryCode;
 	}
 
 	renderSubmitButton() {
@@ -413,7 +410,8 @@ export class DomainDetailsForm extends PureComponent {
 				{ ! needsOnlyGoogleAppsDetails && this.renderPhoneField() }
 				{ this.renderCountryField() }
 				{ ! needsOnlyGoogleAppsDetails && this.needsFax() && this.renderFaxField() }
-				{ this.canDisplayAddressFieldset() && this.renderAddressFieldset( needsOnlyGoogleAppsDetails ) }
+				{ this.shouldDisplayAddressFieldset() &&
+					this.renderAddressFieldset( needsOnlyGoogleAppsDetails ) }
 				{ this.renderSubmitButton() }
 			</form>
 		);

--- a/client/my-sites/checkout/checkout/domain-details-form.jsx
+++ b/client/my-sites/checkout/checkout/domain-details-form.jsx
@@ -260,9 +260,8 @@ export class DomainDetailsForm extends PureComponent {
 	}
 
 	shouldDisplayAddressFieldset() {
-		const { countryCode } = this.props.contactDetails;
-
-		return !! countryCode;
+		const { contactDetails } = this.props;
+		return !! ( contactDetails || {} ).countryCode;
 	}
 
 	renderSubmitButton() {

--- a/client/my-sites/checkout/checkout/domain-details-form.jsx
+++ b/client/my-sites/checkout/checkout/domain-details-form.jsx
@@ -388,7 +388,7 @@ export class DomainDetailsForm extends PureComponent {
 		);
 	}
 
-	renderAddressFieldset( needsOnlyGoogleAppsDetails ) {
+	renderCountryDependentAddressFields( needsOnlyGoogleAppsDetails ) {
 		return (
 			<FormFieldset className="checkout__domain-details-fieldset">
                 { ! needsOnlyGoogleAppsDetails && this.renderAddressFields() }
@@ -411,7 +411,7 @@ export class DomainDetailsForm extends PureComponent {
 				{ this.renderCountryField() }
 				{ ! needsOnlyGoogleAppsDetails && this.needsFax() && this.renderFaxField() }
 				{ this.shouldDisplayAddressFieldset() &&
-					this.renderAddressFieldset( needsOnlyGoogleAppsDetails ) }
+					this.renderCountryDependentAddressFields( needsOnlyGoogleAppsDetails ) }
 				{ this.renderSubmitButton() }
 			</form>
 		);

--- a/client/my-sites/checkout/checkout/domain-details-form.jsx
+++ b/client/my-sites/checkout/checkout/domain-details-form.jsx
@@ -10,6 +10,7 @@ import {
 	camelCase,
 	deburr,
 	first,
+    get,
 	head,
 	includes,
 	indexOf,
@@ -38,6 +39,7 @@ import analytics from 'lib/analytics';
 import formState from 'lib/form-state';
 import { addPrivacyToAllDomains, removePrivacyFromAllDomains, setDomainDetails, addGoogleAppsRegistrationData } from 'lib/upgrades/actions';
 import FormButton from 'components/forms/form-button';
+import FormFieldset from 'components/forms/form-fieldset';
 import { countries } from 'components/phone-input/data';
 import { toIcannFormat } from 'components/phone-input/phone-number';
 import FormPhoneMediaInput from 'components/forms/form-phone-media-input';
@@ -259,6 +261,14 @@ export class DomainDetailsForm extends PureComponent {
 		return cartItems.getDomainRegistrationsWithoutPrivacy( this.props.cart ).length === 0;
 	}
 
+	canDisplayAddressFieldset() {
+		const countryCodeFieldState = get( this.state, 'form.countryCode' );
+			// To avoid a lag effect when displaying the AddressFieldset
+			// we show it when there are no errors AND the value is not empty
+		return countryCodeFieldState && countryCodeFieldState.errors
+				? !! countryCodeFieldState.value && countryCodeFieldState.errors.length === 0 : true;
+	}
+
 	renderSubmitButton() {
 		const continueText = this.hasAnotherStep()
 			? this.props.translate( 'Continue' )
@@ -381,6 +391,17 @@ export class DomainDetailsForm extends PureComponent {
 		);
 	}
 
+	renderAddressFieldset( needsOnlyGoogleAppsDetails ) {
+		return (
+			<FormFieldset className="checkout__domain-details-fieldset">
+                { ! needsOnlyGoogleAppsDetails && this.renderAddressFields() }
+                { ! needsOnlyGoogleAppsDetails && this.renderCityField() }
+                { ! needsOnlyGoogleAppsDetails && this.renderStateField() }
+                { this.renderPostalCodeField() }
+			</FormFieldset>
+		);
+	}
+
 	renderDetailsForm() {
 		const needsOnlyGoogleAppsDetails = this.needsOnlyGoogleAppsDetails();
 
@@ -392,11 +413,7 @@ export class DomainDetailsForm extends PureComponent {
 				{ ! needsOnlyGoogleAppsDetails && this.renderPhoneField() }
 				{ this.renderCountryField() }
 				{ ! needsOnlyGoogleAppsDetails && this.needsFax() && this.renderFaxField() }
-				{ ! needsOnlyGoogleAppsDetails && this.renderAddressFields() }
-				{ ! needsOnlyGoogleAppsDetails && this.renderCityField() }
-				{ ! needsOnlyGoogleAppsDetails && this.renderStateField() }
-				{ this.renderPostalCodeField() }
-
+				{ this.canDisplayAddressFieldset() && this.renderAddressFieldset( needsOnlyGoogleAppsDetails ) }
 				{ this.renderSubmitButton() }
 			</form>
 		);

--- a/client/my-sites/checkout/checkout/test/domain-details-form.js
+++ b/client/my-sites/checkout/checkout/test/domain-details-form.js
@@ -35,6 +35,7 @@ import {
 	DomainDetailsForm,
 	DomainDetailsFormContainer
 } from '../domain-details-form';
+import { useSandbox } from 'test/helpers/use-sinon';
 
 describe( 'Domain Details Form', () => {
 	const defaultProps = {
@@ -45,6 +46,7 @@ describe( 'Domain Details Form', () => {
 		contactDetails: {
 		},
 		translate: identity,
+		updateContactDetailsCache: identity
 	};
 
 	const domainProduct = domainRegistration( {
@@ -147,5 +149,79 @@ describe( 'Domain Details Form', () => {
 		const wrapper = shallow( <DomainDetailsForm { ...mixedSupportProps } /> );
 
 		expect( wrapper.find( 'PrivacyProtection' ) ).to.have.length( 1 );
+	} );
+
+	describe( 'Country selection', () => {
+		let needsOnlyGoogleAppsDetailsStub;
+
+		useSandbox( ( sandbox ) => {
+			needsOnlyGoogleAppsDetailsStub = sandbox.stub( DomainDetailsForm.prototype, 'needsOnlyGoogleAppsDetails' );
+		} );
+
+		it( 'should not render address fieldset when no country selected', () => {
+			const wrapper = shallow( <DomainDetailsForm { ...defaultProps } /> );
+			wrapper.find( 'CountrySelect' ).simulate( 'change', { target: {
+				value: '',
+				name: 'countryCode'
+			} } );
+			expect( wrapper.find( '.checkout__domain-details-fieldset' ) ).to.have.length( 0 );
+		} );
+
+		it( 'should render address fieldset when a valid countryCode is selected', () => {
+			const wrapper = shallow( <DomainDetailsForm { ...defaultProps } /> );
+
+			wrapper.find( 'CountrySelect' ).simulate( 'change', { target: {
+				value: 'AU',
+				name: 'countryCode'
+			} } );
+
+			expect( wrapper.find( '.checkout__domain-details-fieldset' ) ).to.have.length( 1 );
+		} );
+
+		it( 'should not render address fieldset when the country field is showing an error', () => {
+			const wrapper = shallow( <DomainDetailsForm { ...defaultProps } /> );
+			const newCountyCodeState = {
+				value: 'BR',
+				name: 'countryCode'
+			};
+
+			wrapper.find( 'CountrySelect' ).simulate( 'change', { target: newCountyCodeState } );
+			wrapper.setState( {
+				form: Object.assign( {}, wrapper.state().form, {
+					countryCode: {
+						value: 'BR',
+						name: 'countryCode',
+						errors: [ 1, 2, 3 ]
+					}
+				} )
+			} );
+
+			wrapper.update();
+			expect( wrapper.find( '.checkout__domain-details-fieldset' ) ).to.have.length( 0 );
+		} );
+
+		it( 'should render address, city, and postal code fields when the cart does not contain a Google App ', () => {
+			needsOnlyGoogleAppsDetailsStub.returns( false );
+			const wrapper = shallow( <DomainDetailsForm { ...defaultProps } /> );
+			wrapper.find( 'CountrySelect' ).simulate( 'change', { target: {
+				value: 'AU',
+				name: 'countryCode'
+			} } );
+
+			expect( wrapper.find( '.checkout__domain-details-fieldset Input' ) ).to.have.length( 3 );
+		} );
+
+		it( 'should render postal code field when the cart contains only a Google App ', () => {
+			needsOnlyGoogleAppsDetailsStub.returns( true );
+			const wrapper = shallow( <DomainDetailsForm { ...defaultProps } /> );
+			wrapper.find( 'CountrySelect' ).simulate( 'change', { target: {
+				value: 'AU',
+				name: 'countryCode'
+			} } );
+
+			const inputs = wrapper.find( '.checkout__domain-details-fieldset Input' );
+			expect( inputs ).to.have.length( 1 );
+			expect( inputs.get( 0 ).props.name ).to.equal( 'postal-code' );
+		} );
 	} );
 } );

--- a/client/my-sites/checkout/checkout/test/domain-details-form.js
+++ b/client/my-sites/checkout/checkout/test/domain-details-form.js
@@ -49,6 +49,13 @@ describe( 'Domain Details Form', () => {
 		updateContactDetailsCache: identity
 	};
 
+	const propsWithCountry = {
+		...defaultProps,
+		contactDetails: {
+			countryCode: 'AU',
+		},
+	};
+
 	const domainProduct = domainRegistration( {
 		productSlug: 'normal_domain',
 		domain: 'test.test',
@@ -160,31 +167,20 @@ describe( 'Domain Details Form', () => {
 
 		it( 'should not render address fieldset when no country selected', () => {
 			const wrapper = shallow( <DomainDetailsForm { ...defaultProps } /> );
-			wrapper.find( 'CountrySelect' ).simulate( 'change', { target: {
-				value: '',
-				name: 'countryCode'
-			} } );
+
 			expect( wrapper.find( '.checkout__domain-details-country-dependent-address-fields' ) ).to.have.length( 0 );
 		} );
 
 		it( 'should render address fieldset when a valid countryCode is selected', () => {
-			const wrapper = shallow( <DomainDetailsForm { ...defaultProps } /> );
-
-			wrapper.find( 'CountrySelect' ).simulate( 'change', { target: {
-				value: 'AU',
-				name: 'countryCode'
-			} } );
+			const wrapper = shallow( <DomainDetailsForm { ...propsWithCountry } /> );
 
 			expect( wrapper.find( '.checkout__domain-details-country-dependent-address-fields' ) ).to.have.length( 1 );
 		} );
 
 		it( 'should render address, city, and postal code fields when the cart does not contain a Google App ', () => {
 			needsOnlyGoogleAppsDetailsStub.returns( false );
-			const wrapper = shallow( <DomainDetailsForm { ...defaultProps } /> );
-			wrapper.find( 'CountrySelect' ).simulate( 'change', { target: {
-				value: 'AU',
-				name: 'countryCode'
-			} } );
+			const wrapper = shallow(
+				<DomainDetailsForm { ...propsWithCountry } /> );
 
 			expect( wrapper.find( '.checkout__domain-details-country-dependent-address-fields Input' ) ).to.have.length( 3 );
 		} );
@@ -193,9 +189,7 @@ describe( 'Domain Details Form', () => {
 			needsOnlyGoogleAppsDetailsStub.returns( true );
 
 			const wrapper = shallow(
-				<DomainDetailsForm
-					{ ...defaultProps }
-					contactDetails={ { countryCode: 'AU' } } /> );
+				<DomainDetailsForm { ...propsWithCountry } /> );
 
 			const inputs = wrapper.find( '.checkout__domain-details-country-dependent-address-fields Input' );
 			expect( inputs ).to.have.length( 1 );

--- a/client/my-sites/checkout/checkout/test/domain-details-form.js
+++ b/client/my-sites/checkout/checkout/test/domain-details-form.js
@@ -45,8 +45,7 @@ describe( 'Domain Details Form', () => {
 		},
 		contactDetails: {
 		},
-		translate: identity,
-		updateContactDetailsCache: identity
+		translate: identity
 	};
 
 	const propsWithCountry = {

--- a/client/my-sites/checkout/checkout/test/domain-details-form.js
+++ b/client/my-sites/checkout/checkout/test/domain-details-form.js
@@ -165,8 +165,14 @@ describe( 'Domain Details Form', () => {
 			needsOnlyGoogleAppsDetailsStub = sandbox.stub( DomainDetailsForm.prototype, 'needsOnlyGoogleAppsDetails' );
 		} );
 
-		it( 'should not render address fieldset when no country selected', () => {
+		it( 'should not render address fieldset with no country data', () => {
 			const wrapper = shallow( <DomainDetailsForm { ...defaultProps } /> );
+
+			expect( wrapper.find( '.checkout__domain-details-country-dependent-address-fields' ) ).to.have.length( 0 );
+		} );
+
+		it( 'should not render address fieldset when no country selected', () => {
+			const wrapper = shallow( <DomainDetailsForm { ...defaultProps } contactDetails={ { countryCode: '' } } /> );
 
 			expect( wrapper.find( '.checkout__domain-details-country-dependent-address-fields' ) ).to.have.length( 0 );
 		} );

--- a/client/my-sites/checkout/checkout/test/domain-details-form.js
+++ b/client/my-sites/checkout/checkout/test/domain-details-form.js
@@ -164,7 +164,7 @@ describe( 'Domain Details Form', () => {
 				value: '',
 				name: 'countryCode'
 			} } );
-			expect( wrapper.find( '.checkout__domain-details-fieldset' ) ).to.have.length( 0 );
+			expect( wrapper.find( '.checkout__domain-details-country-dependent-address-fields' ) ).to.have.length( 0 );
 		} );
 
 		it( 'should render address fieldset when a valid countryCode is selected', () => {
@@ -175,29 +175,7 @@ describe( 'Domain Details Form', () => {
 				name: 'countryCode'
 			} } );
 
-			expect( wrapper.find( '.checkout__domain-details-fieldset' ) ).to.have.length( 1 );
-		} );
-
-		it( 'should not render address fieldset when the country field is showing an error', () => {
-			const wrapper = shallow( <DomainDetailsForm { ...defaultProps } /> );
-			const newCountyCodeState = {
-				value: 'BR',
-				name: 'countryCode'
-			};
-
-			wrapper.find( 'CountrySelect' ).simulate( 'change', { target: newCountyCodeState } );
-			wrapper.setState( {
-				form: Object.assign( {}, wrapper.state().form, {
-					countryCode: {
-						value: 'BR',
-						name: 'countryCode',
-						errors: [ 1, 2, 3 ]
-					}
-				} )
-			} );
-
-			wrapper.update();
-			expect( wrapper.find( '.checkout__domain-details-fieldset' ) ).to.have.length( 0 );
+			expect( wrapper.find( '.checkout__domain-details-country-dependent-address-fields' ) ).to.have.length( 1 );
 		} );
 
 		it( 'should render address, city, and postal code fields when the cart does not contain a Google App ', () => {
@@ -208,18 +186,18 @@ describe( 'Domain Details Form', () => {
 				name: 'countryCode'
 			} } );
 
-			expect( wrapper.find( '.checkout__domain-details-fieldset Input' ) ).to.have.length( 3 );
+			expect( wrapper.find( '.checkout__domain-details-country-dependent-address-fields Input' ) ).to.have.length( 3 );
 		} );
 
 		it( 'should render postal code field when the cart contains only a Google App ', () => {
 			needsOnlyGoogleAppsDetailsStub.returns( true );
-			const wrapper = shallow( <DomainDetailsForm { ...defaultProps } /> );
-			wrapper.find( 'CountrySelect' ).simulate( 'change', { target: {
-				value: 'AU',
-				name: 'countryCode'
-			} } );
 
-			const inputs = wrapper.find( '.checkout__domain-details-fieldset Input' );
+			const wrapper = shallow(
+				<DomainDetailsForm
+					{ ...defaultProps }
+					contactDetails={ { countryCode: 'AU' } } /> );
+
+			const inputs = wrapper.find( '.checkout__domain-details-country-dependent-address-fields Input' );
 			expect( inputs ).to.have.length( 1 );
 			expect( inputs.get( 0 ).props.name ).to.equal( 'postal-code' );
 		} );


### PR DESCRIPTION
Related issue: #16956

## Show/hide
I've taken a naïve stab at showing and hiding the address fieldset, since this was the least invasive task, and a smaller PR. :)

Checking for a valid value in the country select field worked of course, yet it raised a strange UI-based race condition whereby the validation error message hangs around for a second after we make the address fieldset active:

![show-hide-address-field](https://user-images.githubusercontent.com/6458278/30952922-257e1db2-a46d-11e7-9672-872acdc028a5.gif)

The validation of this field takes time because it waits for the results of an HTTP request.

So in `renderDetailsForm()` I'm checking [both the value and the existence of errors](https://github.com/Automattic/wp-calypso/blob/update/domain-entry-of-international-addresses/client/my-sites/checkout/checkout/domain-details-form.jsx#L396), which displays the address fieldset when the error is gone.

![show-hide-address-field-on-error](https://user-images.githubusercontent.com/6458278/30953126-eb0395c6-a46d-11e7-906d-5f076840fd43.gif)

Am I opening up an inherent risk here? If, for whatever reason, the select field state contains an error we'll hide the address fields regardless of whether a value is set. 

It _should_ be fine given that it's a select field with defined values — either a country is selected or it's not  — but I want to make sure :)

**Alternatives to waiting for the results of the HTTP request**
We can show the form immediately when the countryCode value is not falsey, but the error will still show. Instead of hiding it however, we could fill the lag and communicate to the user that something is happening, by displaying an opaque, disabled form ( or alternatively, the pulsating blocks ) for those few milliseconds.


