### PR TITLE
Fix Webpack Bundle Analyzer not accessible when running in a virtual machine

### DIFF
--- a/package.json
+++ b/package.json
@@ -171,7 +171,7 @@
   },
   "scripts": {
     "preanalyze-bundles": "cross-env WEBPACK_OUTPUT_JSON=1 CALYPSO_ENV=production NODE_ARGS=\"--max_old_space_size=8192\" npm run -s build",
-    "analyze-bundles": "webpack-bundle-analyzer stats.json public -p 9898",
+    "analyze-bundles": "webpack-bundle-analyzer stats.json public -h 0.0.0.0 -p 9898",
     "autoprefixer": "postcss -r --use autoprefixer",
     "prebuild": "npm run -s install-if-deps-outdated",
     "build": "run-p -s build-devdocs:* build-server build-css",


### PR DESCRIPTION
This pull request updates the [Webpack Bundle Analyzer](https://github.com/webpack-contrib/webpack-bundle-analyzer) server to bind all hosts. This will allow instances running from a virtual machine (e.g. with [Calypso Bootstrap](https://github.com/Automattic/wp-calypso-bootstrap)) to be accessible from the host system.

#### Before

```
> webpack-bundle-analyzer stats.json public -p 9898

Webpack Bundle Analyzer is started at http://127.0.0.1:9898
Use Ctrl+C to close it
```

#### After

```
> webpack-bundle-analyzer stats.json public -h 0.0.0.0 -p 9898

Webpack Bundle Analyzer is started at http://0.0.0.0:9898
Use Ctrl+C to close it
```

#### Testing instructions

1. Run `git checkout update/bundle-analyzer`
2. Execute `npm run analyze-bundles`
3. Check that you can still access the treemap