### PR TITLE
Extensions: Zoninator - Add a "Zones" entry to the sidebar when Zoninator is installed

### DIFF
--- a/client/my-sites/sidebar/manage-menu.jsx
+++ b/client/my-sites/sidebar/manage-menu.jsx
@@ -3,7 +3,7 @@
  */
 import React, { PureComponent, PropTypes } from 'react';
 import { connect } from 'react-redux';
-import { compact, includes, omit, reduce, get, mapValues } from 'lodash';
+import { compact, findIndex, includes, omit, reduce, get, mapValues } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -15,11 +15,13 @@ import config from 'config';
 import { getEditorPath } from 'state/ui/editor/selectors';
 import { getPostTypes } from 'state/post-types/selectors';
 import QueryPostTypes from 'components/data/query-post-types';
+import QueryJetpackPlugins from 'components/data/query-jetpack-plugins';
 import analytics from 'lib/analytics';
 import { decodeEntities } from 'lib/formatting';
 import MediaLibraryUploadButton from 'my-sites/media-library/upload-button';
 import { getSite, getSiteAdminUrl, getSiteSlug, isJetpackSite, isSingleUserSite } from 'state/sites/selectors';
 import { areAllSitesSingleUser, canCurrentUser } from 'state/selectors';
+import { getPlugins } from 'state/plugins/installed/selectors';
 
 class ManageMenu extends PureComponent {
 	static propTypes = {
@@ -31,6 +33,7 @@ class ManageMenu extends PureComponent {
 		canUser: PropTypes.func,
 		isJetpack: PropTypes.bool,
 		isSingleUser: PropTypes.bool,
+		plugins: PropTypes.array,
 		postTypes: PropTypes.object,
 		postTypeLinks: PropTypes.object,
 		siteAdminUrl: PropTypes.string,
@@ -102,6 +105,19 @@ class ManageMenu extends PureComponent {
 			} );
 		}
 
+		if ( this.isPluginActive( 'zoninator' ) ) {
+			items.push( {
+				name: 'zones',
+				label: this.props.translate( 'Zones' ),
+				config: 'zoninator/extension-settings',
+				queryable: true,
+				link: '/extensions/zoninator',
+				buttonLink: `/extensions/zoninator/new/${ siteSlug }`,
+				wpAdminLink: 'admin.php?page=zoninator',
+				showOnAllMySites: false,
+			} );
+		}
+
 		if ( config.isEnabled( 'comments/management' ) ) {
 			items.push( {
 				name: 'comments',
@@ -118,6 +134,10 @@ class ManageMenu extends PureComponent {
 		return items;
 	}
 
+	isPluginActive( slug ) {
+		return 0 <= findIndex( this.props.plugins, { slug } );
+	}
+
 	onNavigate = ( postType ) => () => {
 		if ( ! includes( [ 'post', 'page' ], postType ) ) {
 			analytics.mc.bumpStat( 'calypso_publish_menu_click', postType );
@@ -129,7 +149,7 @@ class ManageMenu extends PureComponent {
 	renderMenuItem( menuItem ) {
 		const { canUser, site, siteId, siteAdminUrl } = this.props;
 
-		if ( siteId && ! canUser( menuItem.capability ) ) {
+		if ( siteId && menuItem.capability && ! canUser( menuItem.capability ) ) {
 			return null;
 		}
 
@@ -159,16 +179,15 @@ class ManageMenu extends PureComponent {
 			preload = 'posts-custom';
 		}
 
-		let icon;
-		switch ( menuItem.name ) {
-			case 'post': icon = 'posts'; break;
-			case 'page': icon = 'pages'; break;
-			case 'jetpack-portfolio': icon = 'folder'; break;
-			case 'jetpack-testimonial': icon = 'quote'; break;
-			case 'media': icon = 'image'; break;
-			case 'comments': icon = 'chat'; break;
-			default: icon = 'custom-post-type';
-		}
+		const icon = {
+			post: 'posts',
+			page: 'pages',
+			'jetpack-portfolio': 'folder',
+			'jetpack-testimonial': 'quote',
+			media: 'image',
+			zones: 'layout',
+			comments: 'chat',
+		}[ menuItem.name ] || 'custom-post-type';
 
 		const className = this.props.itemLinkClass(
 			menuItem.paths ? menuItem.paths : menuItem.link
@@ -241,9 +260,8 @@ class ManageMenu extends PureComponent {
 
 		return (
 			<ul>
-				{ this.props.siteId && (
-					<QueryPostTypes siteId={ this.props.siteId } />
-				) }
+				{ this.props.siteId && <QueryPostTypes siteId={ this.props.siteId } /> }
+				{ this.props.siteId && <QueryJetpackPlugins siteIds={ [ this.props.siteId ] } /> }
 				{ menuItems.map( this.renderMenuItem, this ) }
 			</ul>
 		);
@@ -260,6 +278,7 @@ export default connect( ( state, { siteId } ) => {
 		canUser: ( cap ) => canCurrentUser( state, siteId, cap ),
 		isJetpack: isJetpackSite( state, siteId ),
 		isSingleUser: isSingleUserSite( state, siteId ),
+		plugins: getPlugins( state, [ siteId ], 'active' ),
 		postTypes,
 		postTypeLinks: mapValues( postTypes, ( postType, postTypeSlug ) => {
 			return getEditorPath( state, siteId, null, postTypeSlug );

--- a/config/development.json
+++ b/config/development.json
@@ -181,6 +181,7 @@
 		"woocommerce/extension-settings-tax": true,
 		"woocommerce/extension-wcservices": true,
 		"woocommerce/store-on-non-atomic-sites": false,
-		"wpcom-user-bootstrap": false
+		"wpcom-user-bootstrap": false,
+		"zoninator/extension-settings": true
 	}
 }

--- a/config/stage.json
+++ b/config/stage.json
@@ -130,7 +130,8 @@
 		"woocommerce/extension-settings-shipping": true,
 		"woocommerce/extension-settings-stripe-connect-flows": false,
 		"woocommerce/extension-settings-tax": true,
-		"wpcom-user-bootstrap": true
+		"wpcom-user-bootstrap": true,
+		"zoninator/extension-settings": true
 	},
 	"siftscience_key": "e00e878351",
 	"wpcom_signup_id": "39911",

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -143,7 +143,8 @@
 		"woocommerce/extension-settings-stripe-connect-flows": false,
 		"woocommerce/extension-settings-tax": true,
 		"woocommerce/extension-wcservices": true,
-		"wpcom-user-bootstrap": true
+		"wpcom-user-bootstrap": true,
+		"zoninator/extension-settings": true
 	},
 	"siftscience_key": "e00e878351",
 	"wpcom_signup_id": "39911",


### PR DESCRIPTION
This PR adds a **Zones** entry to the sidebar in the *Manage* section when Zoninator is installed and active on the site, similarly to how it works in WP Admin.

<img width="275" alt="screen shot 2017-10-02 at 12 38 51" src="https://user-images.githubusercontent.com/8056203/31074046-0a4e7adc-a76f-11e7-9e71-693e68c1d745.png">

# Testing

- Open a site with Zoninator **not** installed and make sure the link doesn't show up.
- Switch to a site with Zoninator installed and ensure it shows up correctly.
- Ensure the link redirects to *Zones dashboard*
- Ensure the *Add* button redirects to the *Add a zone* view of the extension.