### PR TITLE
Plugins: create redirect from /plugins/browse to just /plugins

### DIFF
--- a/client/lib/analytics/index.js
+++ b/client/lib/analytics/index.js
@@ -351,8 +351,6 @@ const analytics = {
 					featureSlug = 'tag__id';
 				} else if ( startsWith( featureSlug, 'domains_add_suggestion_' ) ) {
 					featureSlug = 'domains_add_suggestion__suggestion__domain';
-				} else if ( startsWith( document.location.pathname, '/plugins/browse/' ) ) {
-					featureSlug = 'plugins_browse__site';
 				} else if ( featureSlug.match( /^plugins_[^_].*__/ ) ) {
 					featureSlug = 'plugins__site__plugin';
 				} else if ( featureSlug.match( /^plugins_[^_]/ ) ) {

--- a/client/my-sites/plugins-wpcom/jetpack-plugins-panel.jsx
+++ b/client/my-sites/plugins-wpcom/jetpack-plugins-panel.jsx
@@ -151,7 +151,7 @@ class JetpackPluginsPanel extends Component {
 			} ) )
 			.filter( group => group.plugins.length > 0 );
 
-		const browserUrl = [ '/plugins/browse', this.props.siteSlug ].join( '/' );
+		const browserUrl = '/plugins' + ( this.props.siteSlug ? '/' + this.props.siteSlug : '' );
 		const uploadUrl = '/plugins/upload' + ( this.props.siteSlug ? '/' + this.props.siteSlug : '' );
 
 		return (

--- a/client/my-sites/plugins/index.js
+++ b/client/my-sites/plugins/index.js
@@ -38,25 +38,28 @@ module.exports = function() {
 	if ( config.isEnabled( 'manage/plugins' ) ) {
 		page( '/plugins/wpcom-masterbar-redirect/:site', context => {
 			context.store.dispatch( recordTracksEvent( 'calypso_wpcom_masterbar_plugins_view_click' ) );
-			page.redirect( '/plugins/' + context.params.site );
+			page.redirect( `/plugins/${ context.params.site }` );
 		} );
 
 		page( '/plugins/browse/wpcom-masterbar-redirect/:site', context => {
 			context.store.dispatch( recordTracksEvent( 'calypso_wpcom_masterbar_plugins_add_click' ) );
-			page.redirect( '/plugins/browse/' + context.params.site );
+			page.redirect( `/plugins/browse/${ context.params.site }` );
 		} );
 
-		page( '/plugins/browse/:category/:site',
-			controller.siteSelection,
-			controller.navigation,
-			pluginsController.browsePlugins
-		);
+		page( '/plugins/manage/wpcom-masterbar-redirect/:site', context => {
+			context.store.dispatch( recordTracksEvent( 'calypso_wpcom_masterbar_plugins_manage_click' ) );
+			page.redirect( `/plugins/manage/${ context.params.site }` );
+		} );
 
-		page( '/plugins/browse/:siteOrCategory?',
-			controller.siteSelection,
-			controller.navigation,
-			pluginsController.browsePlugins
-		);
+		page( '/plugins/browse/:category/:site', context => {
+			const { category, site } = context.params;
+			page.redirect( `/plugins/${ category }/${ site }` );
+		} );
+
+		page( '/plugins/browse/:siteOrCategory?', context => {
+			const { siteOrCategory } = context.params;
+			page.redirect( '/plugins' + ( siteOrCategory ? '/' + siteOrCategory : '' ) );
+		} );
 
 		page( '/plugins/category/:category/:site_id',
 			controller.siteSelection,
@@ -100,6 +103,7 @@ module.exports = function() {
 		page( '/plugins/:plugin/:site_id?',
 			controller.siteSelection,
 			controller.navigation,
+			pluginsController.maybeBrowsePlugins,
 			pluginsController.plugin
 		);
 

--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -365,7 +365,7 @@ const PluginsMain = React.createClass( {
 
 	renderAddPluginButton() {
 		const { selectedSiteSlug, translate } = this.props;
-		const browserUrl = '/plugins/browse' + ( selectedSiteSlug ? '/' + selectedSiteSlug : '' );
+		const browserUrl = '/plugins' + ( selectedSiteSlug ? '/' + selectedSiteSlug : '' );
 
 		return (
 			<HeaderButton

--- a/client/my-sites/plugins/plugin.jsx
+++ b/client/my-sites/plugins/plugin.jsx
@@ -202,7 +202,7 @@ const SinglePlugin = React.createClass( {
 	},
 
 	getPluginDoesNotExistView( selectedSite ) {
-		const actionUrl = '/plugins/browse' + ( selectedSite ? '/' + selectedSite.slug : '' ),
+		const actionUrl = '/plugins' + ( selectedSite ? '/' + selectedSite.slug : '' ),
 			action = this.translate( 'Browse all plugins' );
 
 		return (

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -213,7 +213,7 @@ const PluginsBrowser = React.createClass( {
 	},
 
 	getPluginSingleListView( category ) {
-		const listLink = '/plugins/browse/' + category + '/';
+		const listLink = '/plugins/' + category + '/';
 		return (
 			<PluginsBrowserList
 				plugins={ this.getPluginsShortList( category ) }
@@ -319,24 +319,24 @@ const PluginsBrowser = React.createClass( {
 				} ) }
 			>
 				<NavTabs label="Category">
-					<NavItem path={ '/plugins/browse' + site } selected={ false }>
+					<NavItem path={ '/plugins' + site } selected={ false }>
 						{ this.props.translate( 'All', { context: 'Filter all plugins' } ) }
 					</NavItem>
 					<NavItem
-						path={ '/plugins/browse/featured' + site }
-						selected={ this.props.path === '/plugins/browse/featured' + site }
+						path={ '/plugins/featured' + site }
+						selected={ this.props.path === '/plugins/featured' + site }
 					>
 						{ this.props.translate( 'Featured', { context: 'Filter featured plugins' } ) }
 					</NavItem>
 					<NavItem
-						path={ '/plugins/browse/popular' + site }
-						selected={ this.props.path === '/plugins/browse/popular' + site }
+						path={ '/plugins/popular' + site }
+						selected={ this.props.path === '/plugins/popular' + site }
 					>
 						{ this.props.translate( 'Popular', { context: 'Filter popular plugins' } ) }
 					</NavItem>
 					<NavItem
-						path={ '/plugins/browse/new' + site }
-						selected={ this.props.path === '/plugins/browse/new' + site }
+						path={ '/plugins/new' + site }
+						selected={ this.props.path === '/plugins/new' + site }
 					>
 						{ this.props.translate( 'New', { context: 'Filter new plugins' } ) }
 					</NavItem>


### PR DESCRIPTION
Three commits that do different parts:

**1. redirect the `/plugins/browse` routes to the canonical ones**
    
The `/plugins/browse/*` routes are now just redirects to the canonical routes that are directly under the `/plugins` path: `/plugins/:site`, `/plugins/:category/:site?` etc.
    
This commit also cleans up the logic that handles the route:
```
/plugins/:plugin/:site?
```
and decides whether to show a page for individual plugins, or a plugin browser. That depends on whether the `:plugin` parameter looks like a site slug, a category name, or a plugin name.

**2. change all `/plugins/browse` links to just `/plugins`**

All links that used to lead to `/plugins/browse` now lead just to `/plugins`. See testing instructions below for the list of places to test.

**3. remove the statsd analytics special case for `/plugins/browse`**

There's an analytics feature that sends data to `statsd` on how long it takes to load various pages. There was a special case for `/plugins/browse` that determined to which dashboard to send the data. This case is now removed.

**How to test:**
First, test the redirects. Routes like `/plugins/browse`, `/plugins/browse/:site`, `/plugins/browse/popular/:site` or `/plugins/browse/featured` should redirect to the equivalent URL without the `browse` part and display the right list.

At the same time, routes like `/plugins/jetpack` or `plugins/akismet/:site` that use the same URL format and share one `page()` route should still display info about an individual plugin.

Second, test the links:
- Do the links in the WPCOM masterbar open the right page in Calypso?
- When looking at the sections in `/plugins`, do the "See all" links point to the URL without the `browse` part?
<img width="661" alt="browse-popular" src="https://user-images.githubusercontent.com/664258/31076239-8c32dc82-a779-11e7-88e0-631b0fe9b6a7.png">
- When looking at one of the `featured`, `new`, `popular` lists, do the links in the navbar point to the right URL without the `browse` part?
<img width="663" alt="browse-navbar" src="https://user-images.githubusercontent.com/664258/31076243-9242c98e-a779-11e7-8253-51ba2d3d6e65.png">
- When displaying a page about unknown plugin (`/plugins/unknown`), does the "Browse all plugins" link point to the right URL?
<img width="457" alt="browse-notfound" src="https://user-images.githubusercontent.com/664258/31076246-95d61402-a779-11e7-8c8d-c194f6a17104.png">
 