### PR TITLE
Build: Move lodash to the vendor chunk

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -14,7 +14,6 @@
 	],
 	"plugins": [
 		"add-module-exports",
-		"lodash",
 		"syntax-jsx",
 		"transform-export-extensions",
 		"transform-react-display-name",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -365,17 +365,6 @@
       "version": "1.0.4",
       "dev": true
     },
-    "babel-plugin-lodash": {
-      "version": "3.2.11",
-      "dependencies": {
-        "glob": {
-          "version": "7.1.2"
-        },
-        "lodash": {
-          "version": "4.17.4"
-        }
-      }
-    },
     "babel-plugin-member-expression-literals": {
       "version": "1.0.1",
       "dev": true
@@ -866,10 +855,10 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000739"
+      "version": "1.0.30000740"
     },
     "caniuse-lite": {
-      "version": "1.0.30000739"
+      "version": "1.0.30000740"
     },
     "cardinal": {
       "version": "1.0.0",
@@ -1556,7 +1545,7 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.23"
+      "version": "1.3.24"
     },
     "element-class": {
       "version": "0.2.2"
@@ -1649,7 +1638,7 @@
       "version": "1.3.1"
     },
     "es-abstract": {
-      "version": "1.8.2"
+      "version": "1.9.0"
     },
     "es-to-primitive": {
       "version": "1.1.1"
@@ -2714,7 +2703,8 @@
       "version": "0.0.0"
     },
     "glob": {
-      "version": "7.0.3"
+      "version": "7.0.3",
+      "dev": true
     },
     "glob-base": {
       "version": "0.3.0",
@@ -2742,7 +2732,12 @@
       "version": "9.18.0"
     },
     "globby": {
-      "version": "6.1.0"
+      "version": "6.1.0",
+      "dependencies": {
+        "glob": {
+          "version": "7.1.2"
+        }
+      }
     },
     "globjoin": {
       "version": "0.1.4",
@@ -4712,6 +4707,9 @@
     "node-gyp": {
       "version": "3.6.2",
       "dependencies": {
+        "glob": {
+          "version": "7.1.2"
+        },
         "semver": {
           "version": "5.3.0"
         }
@@ -4756,6 +4754,9 @@
       "dependencies": {
         "chalk": {
           "version": "1.1.3"
+        },
+        "glob": {
+          "version": "7.1.2"
         },
         "supports-color": {
           "version": "2.0.0"
@@ -5165,7 +5166,7 @@
       }
     },
     "postcss-less": {
-      "version": "1.1.0",
+      "version": "1.1.1",
       "dev": true
     },
     "postcss-media-query-parser": {
@@ -6173,6 +6174,9 @@
         },
         "cliui": {
           "version": "3.2.0"
+        },
+        "glob": {
+          "version": "7.1.2"
         },
         "yargs": {
           "version": "7.1.0"
@@ -7253,7 +7257,7 @@
           "dev": true
         },
         "express": {
-          "version": "4.16.0",
+          "version": "4.16.1",
           "dev": true
         },
         "filesize": {
@@ -7313,11 +7317,11 @@
           "dev": true
         },
         "send": {
-          "version": "0.16.0",
+          "version": "0.16.1",
           "dev": true
         },
         "serve-static": {
-          "version": "1.13.0",
+          "version": "1.13.1",
           "dev": true
         },
         "setprototypeof": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "babel-core": "6.25.0",
     "babel-loader": "7.1.1",
     "babel-plugin-add-module-exports": "0.2.1",
-    "babel-plugin-lodash": "3.2.11",
     "babel-plugin-syntax-jsx": "6.18.0",
     "babel-plugin-transform-class-properties": "6.24.1",
     "babel-plugin-transform-export-extensions": "6.22.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -173,6 +173,7 @@ if ( calypsoEnv === 'desktop' ) {
 	webpackConfig.entry.vendor = [
 		'classnames',
 		'i18n-calypso',
+		'lodash',
 		'moment',
 		'page',
 		'react',


### PR DESCRIPTION
1. Stop using the `babel-plugin-lodash` that transforms `import {x} from 'lodash'` into
`import x from 'lodash/x'`. That enforces using the big `lodash` module instead of the
individual submodues.

2. Move the `lodash` module to the `vendor` chunk. This moves a lot of code from the
frequently changed `build` chunk to the rarely updated `vendor` chunk. The result is
that bigger part of Calypso can be cached!

This moves forward the work @dmsnell started a few months ago and finally delivers some improvements in bundle sizes.

This is what my testing says about the size changes for various chunks:
```
# The two chunks that are most impacted:
build: -29143 bytes
vendor: +23740 bytes

# And almost everything else gets smaller, too:
accept-invite: -467
account-recovery: -98
ads: -77
async-load-blocks-calendar-popover: -75
async-load-blocks-reader-full-post: -324
async-load-components-happychat: -7
async-load-components-webpack-build-monitor: -16
async-load-extensions-woocommerce-app-store-stats: -73
async-load-extensions-woocommerce-app-store-stats-listview: -35
async-load-featured-image: -63
async-load-layout-masterbar-drafts: -329
async-load-my-sites-guided-transfer: 3
async-load-my-sites-site-settings-section-export: -29
async-load-my-sites-site-settings-section-import: -110
async-load-my-sites-stats-activity-log: -272
async-load-my-sites-stats-comment-follows: -54
async-load-my-sites-stats-overview: -201
async-load-my-sites-stats-site: -278
async-load-my-sites-stats-stats-insights: -432
async-load-my-sites-stats-stats-post-detail: -203
async-load-my-sites-stats-summary: -238
async-load-post-editor-editor-author: 27
async-load-post-editor-editor-discussion: -36
async-load-post-editor-editor-location: -3
async-load-post-editor-editor-post-formats-accordion: 16
async-load-post-editor-editor-seo-accordion: -14
async-load-post-editor-editor-sharing-accordion: -46
async-load-post-editor-media-modal: -1205
async-load-reader-following-manage: -273
async-load-reader-list-stream: -35
async-load-reader-search-stream: -115
async-load-reader-sidebar: -194
async-load-reader-site-stream: -5
async-load-reader-tag-stream-main: -133
checkout: -1705
comments: -439
customize: -170
devdocs: -3176
domain-connect-authorize: 18
domains: -1368
happychat: -400
hello-dolly: 14
help: -704
jetpack-connect: -739
login: -160
mailing-lists: 10
manifest: 12
me: -387
media: -980
notification-settings: -597
people: -263
plans: -305
plugins: -1222
post-editor: -3175
posts-custom: -691
posts-pages: -869
preview: -4
purchases: -1018
reader: -749
security: -564
sensei: 26
settings: -470
settings-discussion: -137
settings-security: -341
settings-traffic: -797
settings-writing: -623
sharing: -541
signup: -1668
stats: -13
theme: -304
themes: -686
woocommerce: -2101
wp-job-manager: -212
wp-super-cache: -411
zoninator: -305
account: -569
```

Further improvements are possible: either by using `lodash-es` together with the [babel-plugin-lodash](http://npmjs.com/package/babel-plugin-lodash) and [lodash-webpack-plugin](https://www.npmjs.com/package/lodash-webpack-plugin), or by externing `lodash` as @dmsnell originally suggested in p4TIVU-7g0-p2.

[Redux Form](https://github.com/erikras/redux-form/) is a nice example of how to optimize a build with `lodash-es` -- see their `.babelrc` file and the `babel-lodash-es.js` transform.