### PR TITLE
Plugin Uploads: Add error notice for invalid plugin transfer

### DIFF
--- a/client/state/data-layer/wpcom/sites/automated-transfer/initiate/index.js
+++ b/client/state/data-layer/wpcom/sites/automated-transfer/initiate/index.js
@@ -40,6 +40,10 @@ export const receiveResponse = ( { dispatch }, { siteId }, { success } ) => {
 	if ( success === false ) {
 		dispatch( errorNotice( translate( 'The uploaded file is not a valid plugin.' ) ) );
 		dispatch( pluginUploadError( siteId, 'Initiate failed' ) );
+		dispatch( recordTracksEvent( 'calypso_automated_transfer_inititate_failure', {
+			context: 'plugin_upload',
+			error: 'Initiate failed',
+		} ) );
 		return;
 	}
 
@@ -57,7 +61,7 @@ const showErrorNotice = ( dispatch, error ) => {
 	}
 	if ( error.error ) {
 		dispatch( errorNotice( translate( 'Upload problem: %(error)s.', {
-			args: { error: error.error }
+			args: { error: error.error },
 		} ) ) );
 		return;
 	}
@@ -84,5 +88,5 @@ export default {
 		receiveResponse,
 		receiveError,
 		{ onProgress: updateUploadProgress }
-	) ]
+	) ],
 };

--- a/client/state/data-layer/wpcom/sites/automated-transfer/initiate/index.js
+++ b/client/state/data-layer/wpcom/sites/automated-transfer/initiate/index.js
@@ -36,7 +36,13 @@ export const initiateTransferWithPluginZip = ( { dispatch }, action ) => {
 	}, action ) );
 };
 
-export const receiveResponse = ( { dispatch }, { siteId } ) => {
+export const receiveResponse = ( { dispatch }, { siteId }, { success } ) => {
+	if ( success === false ) {
+		dispatch( errorNotice( translate( 'The uploaded file is not a valid plugin.' ) ) );
+		dispatch( pluginUploadError( siteId, 'Initiate failed' ) );
+		return;
+	}
+
 	dispatch( recordTracksEvent(
 		'calypso_automated_transfer_inititate_success',
 		{ context: 'plugin_upload' }
@@ -46,7 +52,7 @@ export const receiveResponse = ( { dispatch }, { siteId } ) => {
 
 const showErrorNotice = ( dispatch, error ) => {
 	if ( error.error === 'invalid_input' ) {
-		dispatch( errorNotice( translate( 'Not a valid zip file.' ) ) );
+		dispatch( errorNotice( translate( 'The uploaded file is not a valid zip.' ) ) );
 		return;
 	}
 	if ( error.error ) {

--- a/client/state/data-layer/wpcom/sites/automated-transfer/initiate/index.js
+++ b/client/state/data-layer/wpcom/sites/automated-transfer/initiate/index.js
@@ -36,29 +36,17 @@ export const initiateTransferWithPluginZip = ( { dispatch }, action ) => {
 	}, action ) );
 };
 
-export const receiveResponse = ( { dispatch }, { siteId }, { success } ) => {
-	if ( success === false ) {
-		dispatch( errorNotice( translate( 'The uploaded file is not a valid plugin.' ) ) );
-		dispatch( pluginUploadError( siteId, 'Initiate failed' ) );
-		dispatch( recordTracksEvent( 'calypso_automated_transfer_inititate_failure', {
-			context: 'plugin_upload',
-			error: 'Initiate failed',
-		} ) );
-		return;
-	}
-
-	dispatch( recordTracksEvent(
-		'calypso_automated_transfer_inititate_success',
-		{ context: 'plugin_upload' }
-	) );
-	dispatch( getAutomatedTransferStatus( siteId ) );
-};
-
 const showErrorNotice = ( dispatch, error ) => {
 	if ( error.error === 'invalid_input' ) {
 		dispatch( errorNotice( translate( 'The uploaded file is not a valid zip.' ) ) );
 		return;
 	}
+
+	if ( error.error === 'api_success_false' ) {
+		dispatch( errorNotice( translate( 'The uploaded file is not a valid plugin.' ) ) );
+		return;
+	}
+
 	if ( error.error ) {
 		dispatch( errorNotice( translate( 'Upload problem: %(error)s.', {
 			args: { error: error.error },
@@ -75,6 +63,19 @@ export const receiveError = ( { dispatch }, { siteId }, error ) => {
 	} ) );
 	showErrorNotice( dispatch, error );
 	dispatch( pluginUploadError( siteId, error ) );
+};
+
+export const receiveResponse = ( { dispatch }, { siteId }, { success } ) => {
+	if ( success === false ) {
+		receiveError( { dispatch }, { siteId }, { error: 'api_success_false' } );
+		return;
+	}
+
+	dispatch( recordTracksEvent(
+		'calypso_automated_transfer_inititate_success',
+		{ context: 'plugin_upload' }
+	) );
+	dispatch( getAutomatedTransferStatus( siteId ) );
 };
 
 export const updateUploadProgress = ( { dispatch }, { siteId }, { loaded, total } ) => {

--- a/client/state/data-layer/wpcom/sites/automated-transfer/initiate/test/index.js
+++ b/client/state/data-layer/wpcom/sites/automated-transfer/initiate/test/index.js
@@ -83,10 +83,20 @@ describe( 'receiveResponse', () => {
 	it( 'should dispatch error notice on unsuccessful initiation', () => {
 		const dispatch = sinon.spy();
 		receiveResponse( { dispatch }, { siteId }, INITIATE_FAILURE_RESPONSE );
-		expect( dispatch ).to.have.been.calledTwice;
 		expect( dispatch ).to.have.been.calledWithMatch( {
 			notice: { text: 'The uploaded file is not a valid plugin.' },
 		} );
+	} );
+
+	it( 'should dispatch a tracks call on unsuccessful initiation', () => {
+		const dispatch = sinon.spy();
+		receiveResponse( { dispatch }, { siteId }, INITIATE_FAILURE_RESPONSE );
+		expect( dispatch ).to.have.been.calledWith(
+			recordTracksEvent( 'calypso_automated_transfer_inititate_failure', {
+				context: 'plugin_upload',
+				error: 'Initiate failed',
+			} )
+		);
 	} );
 } );
 

--- a/client/state/data-layer/wpcom/sites/automated-transfer/initiate/test/index.js
+++ b/client/state/data-layer/wpcom/sites/automated-transfer/initiate/test/index.js
@@ -27,6 +27,18 @@ const ERROR_RESPONSE = {
 	message: 'Invalid file type.',
 };
 
+const INITIATE_SUCCESS_RESPONSE = {
+	success: true,
+	status: 'uploading',
+	transfer_id: 1,
+};
+
+const INITIATE_FAILURE_RESPONSE = {
+	success: false,
+	status: '',
+	transfer_id: 0,
+};
+
 describe( 'initiateTransferWithPluginZip', () => {
 	it( 'should dispatch an http request', () => {
 		const dispatch = sinon.spy();
@@ -52,7 +64,7 @@ describe( 'initiateTransferWithPluginZip', () => {
 describe( 'receiveResponse', () => {
 	it( 'should dispatch a status request', () => {
 		const dispatch = sinon.spy();
-		receiveResponse( { dispatch }, { siteId } );
+		receiveResponse( { dispatch }, { siteId }, INITIATE_SUCCESS_RESPONSE );
 		expect( dispatch ).to.have.been.calledWith(
 			getAutomatedTransferStatus( siteId )
 		);
@@ -60,12 +72,21 @@ describe( 'receiveResponse', () => {
 
 	it( 'should dispatch a tracks call', () => {
 		const dispatch = sinon.spy();
-		receiveResponse( { dispatch }, { siteId } );
+		receiveResponse( { dispatch }, { siteId }, INITIATE_SUCCESS_RESPONSE );
 		expect( dispatch ).to.have.been.calledWith(
 			recordTracksEvent( 'calypso_automated_transfer_inititate_success', {
 				context: 'plugin_upload',
 			} )
 		);
+	} );
+
+	it( 'should dispatch error notice on unsuccessful initiation', () => {
+		const dispatch = sinon.spy();
+		receiveResponse( { dispatch }, { siteId }, INITIATE_FAILURE_RESPONSE );
+		expect( dispatch ).to.have.been.calledTwice;
+		expect( dispatch ).to.have.been.calledWithMatch( {
+			notice: { text: 'The uploaded file is not a valid plugin.' },
+		} );
 	} );
 } );
 
@@ -82,7 +103,7 @@ describe( 'receiveError', () => {
 		const dispatch = sinon.spy();
 		receiveError( { dispatch }, { siteId }, ERROR_RESPONSE );
 		expect( dispatch ).to.have.been.calledWithMatch( {
-			notice: { text: 'Not a valid zip file.' }
+			notice: { text: 'The uploaded file is not a valid zip.' },
 		} );
 	} );
 

--- a/client/state/data-layer/wpcom/sites/automated-transfer/initiate/test/index.js
+++ b/client/state/data-layer/wpcom/sites/automated-transfer/initiate/test/index.js
@@ -94,7 +94,7 @@ describe( 'receiveResponse', () => {
 		expect( dispatch ).to.have.been.calledWith(
 			recordTracksEvent( 'calypso_automated_transfer_inititate_failure', {
 				context: 'plugin_upload',
-				error: 'Initiate failed',
+				error: 'api_success_false',
 			} )
 		);
 	} );

--- a/client/state/data-layer/wpcom/sites/plugins/new/index.js
+++ b/client/state/data-layer/wpcom/sites/plugins/new/index.js
@@ -37,8 +37,8 @@ const showErrorNotice = ( dispatch, error ) => {
 	const knownErrors = {
 		exists: translate( 'This plugin is already installed on your site.' ),
 		'too large': translate( 'The plugin zip file must be smaller than 10MB.' ),
-		incompatible: translate( 'Not a compatible plugin.' ),
-		unsupported_mime_type: translate( 'Not a valid zip file.' ),
+		incompatible: translate( 'The uploaded file is not a compatible plugin.' ),
+		unsupported_mime_type: translate( 'The uploaded file is not a valid zip.' ),
 	};
 	const errorString = toLower( error.error + error.message );
 	const knownError = find( knownErrors, ( v, key ) => includes( errorString, key ) );
@@ -49,7 +49,7 @@ const showErrorNotice = ( dispatch, error ) => {
 	}
 	if ( error.error ) {
 		dispatch( errorNotice( translate( 'Upload problem: %(error)s.', {
-			args: { error: error.error }
+			args: { error: error.error },
 		} ) ) );
 		return;
 	}
@@ -62,7 +62,7 @@ export const uploadComplete = ( { dispatch, getState }, { siteId }, data ) => {
 	const site = getSite( state, siteId );
 
 	dispatch( recordTracksEvent( 'calypso_plugin_upload_complete', {
-		plugin_id: pluginId
+		plugin_id: pluginId,
 	} ) );
 
 	dispatch( completePluginUpload( siteId, pluginId ) );


### PR DESCRIPTION

<img width="979" alt="screen shot 2017-10-02 at 16 42 50" src="https://user-images.githubusercontent.com/7767559/31087258-44ee357c-a794-11e7-958e-7bf3a00291d4.png">


When a plugin uploaded to initiate a transfer is determined by the server to be invalid, a 200 response is sent, but with the `success` field set to `false`. Show an error notice in this case and reset the UI for another upload.

Also make related error notices more natural.