### PR TITLE
Store Order: Update customer info to use `AddressView` component

### DIFF
--- a/client/extensions/woocommerce/app/order/order-customer/index.js
+++ b/client/extensions/woocommerce/app/order/order-customer/index.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -8,6 +9,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import AddressView from 'woocommerce/components/address-view';
 import Card from 'components/card';
 import SectionHeader from 'components/section-header';
 
@@ -17,7 +19,18 @@ class OrderCustomerInfo extends Component {
 			billing: PropTypes.object.isRequired,
 			shipping: PropTypes.object.isRequired,
 		} ),
-	}
+	};
+
+	getAddressViewFormat = address => {
+		return {
+			street: address.address_1 || '',
+			street2: address.address_2 || '',
+			city: address.city || '',
+			state: address.state || '',
+			country: address.country || '',
+			postcode: address.postcode || '',
+		};
+	};
 
 	render() {
 		const { order, translate } = this.props;
@@ -31,37 +44,35 @@ class OrderCustomerInfo extends Component {
 			<div className="order-customer">
 				<SectionHeader label={ translate( 'Customer Information' ) } />
 				<Card>
-				<div className="order-customer__container">
-					<div className="order-customer__billing">
-					<h3 className="order-customer__billing-details">{ translate( 'Billing Details' ) }</h3>
-						<h4>{ translate( 'Address' ) }</h4>
-						<div className="order-customer__billing-address">
-							<p>{ `${ billing.first_name } ${ billing.last_name }` }</p>
-							<p>{ billing.address_1 }</p>
-							<p>{ billing.address_2 }</p>
-							<p>{ `${ billing.city }, ${ billing.state } ${ billing.postcode }` }</p>
-							<p>{ billing.country }</p>
+					<div className="order-customer__container">
+						<div className="order-customer__billing">
+							<h3 className="order-customer__billing-details">
+								{ translate( 'Billing Details' ) }
+							</h3>
+							<h4>{ translate( 'Address' ) }</h4>
+							<div className="order-customer__billing-address">
+								<p>{ `${ billing.first_name } ${ billing.last_name }` }</p>
+								<AddressView address={ this.getAddressViewFormat( billing ) } />
+							</div>
+
+							<h4>{ translate( 'Email' ) }</h4>
+							<p>{ billing.email }</p>
+
+							<h4>{ translate( 'Phone' ) }</h4>
+							<span>{ billing.phone }</span>
 						</div>
 
-						<h4>{ translate( 'Email' ) }</h4>
-						<p>{ billing.email }</p>
-
-						<h4>{ translate( 'Phone' ) }</h4>
-						<span>{ billing.phone }</span>
-					</div>
-
-					<div className="order-customer__shipping">
-						<h3 className="order-customer__shipping-details">{ translate( 'Shipping Details' ) }</h3>
-						<h4>{ translate( 'Address' ) }</h4>
-						<div className="order-customer__shipping-address">
-							<p>{ `${ shipping.first_name } ${ shipping.last_name }` }</p>
-							<p>{ shipping.address_1 }</p>
-							<p>{ shipping.address_2 }</p>
-							<p>{ `${ shipping.city }, ${ shipping.state } ${ shipping.postcode }` }</p>
-							<p>{ shipping.country }</p>
+						<div className="order-customer__shipping">
+							<h3 className="order-customer__shipping-details">
+								{ translate( 'Shipping Details' ) }
+							</h3>
+							<h4>{ translate( 'Address' ) }</h4>
+							<div className="order-customer__shipping-address">
+								<p>{ `${ shipping.first_name } ${ shipping.last_name }` }</p>
+								<AddressView address={ this.getAddressViewFormat( shipping ) } />
+							</div>
 						</div>
 					</div>
-				</div>
 				</Card>
 			</div>
 		);

--- a/client/extensions/woocommerce/app/order/order-customer/index.js
+++ b/client/extensions/woocommerce/app/order/order-customer/index.js
@@ -11,6 +11,7 @@ import { localize } from 'i18n-calypso';
  */
 import AddressView from 'woocommerce/components/address-view';
 import Card from 'components/card';
+import getAddressViewFormat from 'woocommerce/lib/get-address-view-format';
 import SectionHeader from 'components/section-header';
 
 class OrderCustomerInfo extends Component {
@@ -19,17 +20,6 @@ class OrderCustomerInfo extends Component {
 			billing: PropTypes.object.isRequired,
 			shipping: PropTypes.object.isRequired,
 		} ),
-	};
-
-	getAddressViewFormat = address => {
-		return {
-			street: address.address_1 || '',
-			street2: address.address_2 || '',
-			city: address.city || '',
-			state: address.state || '',
-			country: address.country || '',
-			postcode: address.postcode || '',
-		};
 	};
 
 	render() {
@@ -52,7 +42,7 @@ class OrderCustomerInfo extends Component {
 							<h4>{ translate( 'Address' ) }</h4>
 							<div className="order-customer__billing-address">
 								<p>{ `${ billing.first_name } ${ billing.last_name }` }</p>
-								<AddressView address={ this.getAddressViewFormat( billing ) } />
+								<AddressView address={ getAddressViewFormat( billing ) } />
 							</div>
 
 							<h4>{ translate( 'Email' ) }</h4>
@@ -69,7 +59,7 @@ class OrderCustomerInfo extends Component {
 							<h4>{ translate( 'Address' ) }</h4>
 							<div className="order-customer__shipping-address">
 								<p>{ `${ shipping.first_name } ${ shipping.last_name }` }</p>
-								<AddressView address={ this.getAddressViewFormat( shipping ) } />
+								<AddressView address={ getAddressViewFormat( shipping ) } />
 							</div>
 						</div>
 					</div>

--- a/client/extensions/woocommerce/lib/get-address-view-format/index.js
+++ b/client/extensions/woocommerce/lib/get-address-view-format/index.js
@@ -1,0 +1,23 @@
+/** @format */
+
+/**
+ * This function maps the API address to the view address format. The AddressView
+ * component expects the address in a slightly different format than the WC API
+ * responds with.
+ * See http://woocommerce.github.io/woocommerce-rest-api-docs/#order-billing-properties
+ *
+ * @param {Object} address The address as returned from the remote site API
+ * @return {Object} An object with keys matching the expected AddressView props
+ */
+const getAddressViewFormat = address => {
+	return {
+		street: address.address_1 || '',
+		street2: address.address_2 || '',
+		city: address.city || '',
+		state: address.state || '',
+		country: address.country || '',
+		postcode: address.postcode || '',
+	};
+};
+
+export default getAddressViewFormat;

--- a/client/extensions/woocommerce/lib/get-address-view-format/test/index.js
+++ b/client/extensions/woocommerce/lib/get-address-view-format/test/index.js
@@ -1,0 +1,43 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import getAddressViewFormat from '../index';
+
+describe( 'getAddressViewFormat', () => {
+	it( 'returns a "skeleton" object if no address is supplied', () => {
+		expect( getAddressViewFormat( {} ) ).to.eql( {
+			street: '',
+			street2: '',
+			city: '',
+			state: '',
+			country: '',
+			postcode: '',
+		} );
+	} );
+
+	it( 'returns correctly formatted address', () => {
+		const ApiAddress = {
+			address_1: '1 Main St',
+			address_2: '',
+			city: 'Somerville',
+			state: 'MA',
+			country: 'US',
+			postcode: '02111',
+		};
+
+		expect( getAddressViewFormat( ApiAddress ) ).to.eql( {
+			street: '1 Main St',
+			street2: '',
+			city: 'Somerville',
+			state: 'MA',
+			country: 'US',
+			postcode: '02111',
+		} );
+	} );
+} );


### PR DESCRIPTION
This PR switches from displaying the address "by hand", and instead passes the address object to `AddressView`. I also had to introduce `getAddressViewFormat` helper to convert the address from [the order API response](http://woocommerce.github.io/woocommerce-rest-api-docs/#order-billing-properties) to the object that AddressView expects.

There should be no major differences between this branch and master:

![comparison](https://user-images.githubusercontent.com/541093/31090299-2fd7b1be-a775-11e7-8b32-5d6831348f4e.png)

To test:

- Run the test `npm run test-client client/extensions/woocommerce/lib/get-address-view-format/test/index.js`
- View a single order to verify no change in displaying the address