### PR TITLE
Editor: Fix Publish button positioning

### DIFF
--- a/client/post-editor/editor-confirmation-sidebar/style.scss
+++ b/client/post-editor/editor-confirmation-sidebar/style.scss
@@ -80,7 +80,6 @@
 		left: 0;
 		right: 0;
 	padding: 0 24px;
-	width: 100%;
 }
 
 .editor-confirmation-sidebar__close {


### PR DESCRIPTION
I'm not positive how this broke (I didn't see any recent related change, but suspect that perhaps it might have been inadvertently caused by the refactoring around #18194), but the Publish button in the editor is positioned off the screen:

<img width="254" alt="screen_shot_2017-10-02_at_2 07 18_pm_720" src="https://user-images.githubusercontent.com/2098816/31094594-bd5afc7c-a783-11e7-8fab-f9df318e63c6.png">

This PR fixes that, by removing the unnecessary `width: 100%` style to the editor ground control.

Test in multiple browsers and verify that the Publish button is positioned as it should be.
