### PR TITLE
WPSC: Fix Plugins tab copy

### DIFF
--- a/client/extensions/wp-super-cache/components/plugins/index.jsx
+++ b/client/extensions/wp-super-cache/components/plugins/index.jsx
@@ -51,19 +51,19 @@ class PluginsTab extends Component {
 
 				<Card>
 					<p>{ translate(
-						'Cache plugins are PHP scripts that live in a plugins folder inside the wp-super-cache folder. ' +
-						'They are loaded when Supercache loads, much sooner than regular WordPress plugins.'
+						'Cache plugins are PHP scripts you\'ll find in a dedicated folder inside the WP Super Cache folder ' +
+						'(wp-super-cache/plugins/). They load at the same time as WP Super Cache, and before regular WordPress plugins.'
 					) }</p>
 					<p>{ translate(
-						'This is strictly an advanced feature only and knowledge of both PHP and WordPress actions ' +
-						'is required to create them.'
+						'Keep in mind that cache plugins are for advanced users only. To create and manage them, you\'ll need extensive ' +
+						'knowledge of both PHP and WordPress actions.'
 					) }</p>
 					<p>{ translate(
-						'{{strong}}Warning!{{/strong}} Due to the way WordPress upgrades plugins, the plugins you upload to ' +
-						'wp-super-cache/plugins/ will be deleted when you upgrade WP Super Cache. ' +
-						'You can avoid this by loading the plugins from elsewhere. ' +
-						'Set {{strong}}$wp_cache_plugins_dir{{/strong}} to the new location in wp-config.php and WP Super Cache ' +
-						'will look there instead. More info available in the {{a}}developer documentation.{{/a}}',
+						'{{strong}}Warning!{{/strong}} Due to the way WordPress upgrades plugins, the ones you upload to the ' +
+						'WP Super Cache folder (wp-super-cache/plugins/) will be deleted when you upgrade WP Super Cache. ' +
+						'To avoid this loss, load your cache plugins from a different location. When you set ' +
+						'{{strong}}$wp_cache_plugins_dir{{/strong}} to the new location in wp-config.php, WP Super Cache will ' +
+						'look there instead. You can find additional details in the {{a}}developer documentation.{{/a}}',
 						{ components: {
 							a: <ExternalLink href="https://odd.blog/wp-super-cache-developers/" target="_blank" />,
 							strong: <strong />,


### PR DESCRIPTION
Thanks @benhuberman for these suggestions!
https://github.com/Automattic/wp-calypso/pull/18002#issuecomment-333630924

Before:

![image](https://user-images.githubusercontent.com/96308/31094829-c50c39e4-a7b6-11e7-9c3c-5938bb2362f4.png)

After:

![image](https://user-images.githubusercontent.com/96308/31094739-793bbbd4-a7b6-11e7-8305-2cbb5d24261a.png)

To test: see testing instructions in #18002's PR description.
