### PR TITLE
Store Promotions: Add create coupon form

### DIFF
--- a/client/extensions/woocommerce/app/promotions/promotion-create.js
+++ b/client/extensions/woocommerce/app/promotions/promotion-create.js
@@ -37,7 +37,7 @@ class PromotionCreate extends React.Component {
 		} ),
 		editPromotion: PropTypes.func.isRequired,
 		clearPromotionEdits: PropTypes.func.isRequired,
-	}
+	};
 
 	componentDidMount() {
 		const { site } = this.props;
@@ -49,10 +49,10 @@ class PromotionCreate extends React.Component {
 
 	componentWillReceiveProps( newProps ) {
 		const { site } = this.props;
-		const newSiteId = newProps.site && newProps.site.ID || null;
-		const oldSiteId = site && site.ID || null;
+		const newSiteId = ( newProps.site && newProps.site.ID ) || null;
+		const oldSiteId = ( site && site.ID ) || null;
 		if ( oldSiteId !== newSiteId ) {
-			this.props.fetchSettingsGeneral( site.ID );
+			this.props.fetchSettingsGeneral( newSiteId );
 		}
 	}
 
@@ -65,7 +65,7 @@ class PromotionCreate extends React.Component {
 
 	onSave = () => {
 		// TODO: Add action to save promotion.
-	}
+	};
 
 	isPromotionValid() {
 		const { promotion } = this.props;
@@ -104,9 +104,9 @@ class PromotionCreate extends React.Component {
 function mapStateToProps( state ) {
 	const site = getSelectedSiteWithFallback( state );
 	const currencySettings = getPaymentCurrencySettings( state );
-	const currency = ( currencySettings ? currencySettings.value : null );
+	const currency = currencySettings ? currencySettings.value : null;
 	const promotionId = getCurrentlyEditingPromotionId( state, site.ID );
-	const promotion = ( promotionId ? getPromotionWithLocalEdits( state, promotionId, site.ID ) : null );
+	const promotion = promotionId ? getPromotionWithLocalEdits( state, promotionId, site.ID ) : null;
 
 	return {
 		site,

--- a/client/extensions/woocommerce/app/promotions/promotion-create.js
+++ b/client/extensions/woocommerce/app/promotions/promotion-create.js
@@ -6,6 +6,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
@@ -13,29 +14,116 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import Main from 'components/main';
+import { editPromotion, clearPromotionEdits } from 'woocommerce/state/ui/promotions/actions';
 import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
+import { fetchSettingsGeneral } from 'woocommerce/state/sites/settings/general/actions';
+import { getPaymentCurrencySettings } from 'woocommerce/state/sites/settings/general/selectors';
+import {
+	getCurrentlyEditingPromotionId,
+	getPromotionWithLocalEdits,
+} from 'woocommerce/state/selectors/promotions';
+import PromotionHeader from './promotion-header';
+import PromotionForm from './promotion-form';
 
 class PromotionCreate extends React.Component {
 	static propTypes = {
+		className: PropTypes.string,
 		site: PropTypes.shape( {
 			ID: PropTypes.number,
+			slug: PropTypes.string,
 		} ),
-		className: PropTypes.string,
-	};
+		promotion: PropTypes.shape( {
+			id: PropTypes.isRequired,
+		} ),
+		editPromotion: PropTypes.func.isRequired,
+		clearPromotionEdits: PropTypes.func.isRequired,
+	}
+
+	componentDidMount() {
+		const { site } = this.props;
+
+		if ( site && site.ID ) {
+			this.props.fetchSettingsGeneral( site.ID );
+		}
+	}
+
+	componentWillReceiveProps( newProps ) {
+		const { site } = this.props;
+		const newSiteId = newProps.site && newProps.site.ID || null;
+		const oldSiteId = site && site.ID || null;
+		if ( oldSiteId !== newSiteId ) {
+			this.props.fetchSettingsGeneral( site.ID );
+		}
+	}
+
+	componentWillUnmount() {
+		const { site } = this.props;
+		if ( site ) {
+			this.props.clearPromotionEdits( site.ID );
+		}
+	}
+
+	onSave = () => {
+		// TODO: Add action to save promotion.
+	}
+
+	isPromotionValid() {
+		const { promotion } = this.props;
+
+		// TODO: Update with real info.
+		return promotion && promotion.id;
+	}
 
 	render() {
-		const { className } = this.props;
+		const { site, currency, className, promotion } = this.props;
 
-		return <Main className={ className } />;
+		// TODO: Update with real info.
+		const isValid = 'undefined' !== typeof site && this.isPromotionValid();
+		const isBusy = false;
+		const saveEnabled = isValid && ! isBusy;
+
+		return (
+			<Main className={ className }>
+				<PromotionHeader
+					site={ site }
+					promotion={ promotion }
+					onSave={ saveEnabled ? this.onSave : false }
+					isBusy={ isBusy }
+				/>
+				<PromotionForm
+					siteId={ site && site.ID }
+					currency={ currency }
+					promotion={ promotion }
+					editPromotion={ this.props.editPromotion }
+				/>
+			</Main>
+		);
 	}
 }
 
 function mapStateToProps( state ) {
 	const site = getSelectedSiteWithFallback( state );
+	const currencySettings = getPaymentCurrencySettings( state );
+	const currency = ( currencySettings ? currencySettings.value : null );
+	const promotionId = getCurrentlyEditingPromotionId( state, site.ID );
+	const promotion = ( promotionId ? getPromotionWithLocalEdits( state, promotionId, site.ID ) : null );
 
 	return {
 		site,
+		promotion,
+		currency,
 	};
 }
 
-export default connect( mapStateToProps )( localize( PromotionCreate ) );
+function mapDispatchToProps( dispatch ) {
+	return bindActionCreators(
+		{
+			editPromotion,
+			clearPromotionEdits,
+			fetchSettingsGeneral,
+		},
+		dispatch
+	);
+}
+
+export default connect( mapStateToProps, mapDispatchToProps )( localize( PromotionCreate ) );

--- a/client/extensions/woocommerce/app/promotions/promotion-form-coupon-card.js
+++ b/client/extensions/woocommerce/app/promotions/promotion-form-coupon-card.js
@@ -1,0 +1,181 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import PropTypes from 'prop-types';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Card from 'components/card';
+import DatePicker from 'components/date-picker';
+import FormFieldset from 'components/forms/form-fieldset';
+import FormLabel from 'components/forms/form-label';
+import FormSelect from 'components/forms/form-select';
+import FormInputCheckbox from 'components/forms/form-checkbox';
+import FormTextInput from 'components/forms/form-text-input';
+import FormTextInputWithAffixes from 'components/forms/form-text-input-with-affixes';
+import PriceInput from 'woocommerce/components/price-input';
+
+function renderDiscountTypeSelect( coupon, translate, onDiscountTypeSelect ) {
+	return (
+		<FormSelect value={ coupon.discountType } onChange={ onDiscountTypeSelect } >
+			<option value="percent">{ translate( 'Percentage discount' ) }</option>
+			<option value="fixed_cart">{ translate( 'Cart discount' ) }</option>
+			<option value="fixed_product">{ translate( 'Product discount' ) }</option>
+		</FormSelect>
+	);
+}
+
+function renderAmountInput( coupon, currency, onAmountChange ) {
+	if ( 'percent' === coupon.discount_type ) {
+		// TODO: Consider making a FormPercentInput general-purpose component?
+		return (
+			<FormTextInputWithAffixes
+				type="number"
+				min="0"
+				max="100"
+				suffix="%"
+				value={ coupon.amount }
+				onChange={ onAmountChange }
+			/>
+		);
+	}
+
+	return (
+		<PriceInput
+			currency={ currency }
+			value={ coupon.amount }
+			onChange={ onAmountChange }
+		/>
+	);
+}
+
+function renderAppliesTo( coupon, translate, onAppliesToChange ) {
+	// TODO: Add support for including/excluding products and product categories
+	const appliesTo = 'all_products';
+
+	return (
+		<FormSelect value={ appliesTo } onChange={ onAppliesToChange } >
+			<option value="all_products">{ translate( 'All Products' ) }</option>
+		</FormSelect>
+	);
+}
+
+function renderExpiration( coupon, translate, onEnable, onChange ) {
+	const hasExpirationDate = Boolean( coupon.date_expires_gmt );
+
+	const datePicker = hasExpirationDate && renderDatePicker( new Date( coupon.date_expires_gmt ), onChange );
+
+	return (
+		<FormFieldset className="promotions__promotion-form-coupon-expires">
+			<FormInputCheckbox checked={ hasExpirationDate } onChange={ onEnable } />
+			<FormLabel>{ translate( 'Expiration date' ) }</FormLabel>
+			{ datePicker }
+		</FormFieldset>
+	);
+}
+
+function renderDatePicker( date, onChange ) {
+	return (
+		<DatePicker
+			initialMonth={ date }
+			selectedDay={ date }
+			onSelectDay={ onChange }
+		/>
+	);
+}
+
+function editCoupon( siteId, promotion, coupon, data, editPromotion ) {
+	const newCoupon = { ...coupon, ...data };
+	editPromotion( siteId, promotion, { ...promotion, coupon: newCoupon } );
+}
+
+const PromotionFormCouponCard = ( {
+	siteId,
+	currency,
+	promotion,
+	editPromotion,
+	translate,
+} ) => {
+	const coupon = ( promotion && promotion.coupon ) || { code: '', discount_type: 'percent', amount: '0' };
+
+	const onCodeChange = ( e ) => {
+		editCoupon( siteId, promotion, coupon, { code: e.target.value }, editPromotion );
+	};
+
+	const onDiscountTypeSelect = ( e ) => {
+		// Clear out the amount whenever the type is changed.
+		// This ensures a valid value when switching between currency and percent
+		editCoupon( siteId, promotion, coupon, { discount_type: e.target.value, amount: 0 }, editPromotion );
+	};
+
+	const onAmountChange = ( e ) => {
+		const value = Number( e.target.value );
+		if ( 'percent' === coupon.discount_type ) {
+			if ( value < 0 || value > 100 ) {
+				// Don't make a change that would invalidate the field.
+				return;
+			}
+		}
+
+		editCoupon( siteId, promotion, coupon, { amount: value }, editPromotion );
+	};
+
+	const onAppliesToChange = () => {
+		// TODO: Add support for other "Applies to" selections.
+	};
+
+	const onExpirationEnable = () => {
+		const checked = Boolean( coupon.date_expires_gmt );
+		const expirationDate = ( ! checked ? coupon.date_expires_gmt || new Date().toISOString() : undefined );
+		editCoupon( siteId, promotion, coupon, { date_expires_gmt: expirationDate }, editPromotion );
+	};
+
+	const onExpirationChange = ( date ) => {
+		editCoupon( siteId, promotion, coupon, { date_expires_gmt: date.toISOString() }, editPromotion );
+	};
+
+	return (
+		<Card className="promotions__promotion-form-coupon">
+			<FormFieldset className="promotions__promotion-form-coupon-code">
+				<FormLabel>{ translate( 'Coupon code' ) }</FormLabel>
+				<FormTextInput
+					value={ coupon.code }
+					onChange={ onCodeChange }
+					placeholder={ translate( 'Enter coupon code' ) }
+				/>
+			</FormFieldset>
+			<div className="promotions__promotion-form-coupon-discount-type-amount">
+				<FormFieldset className="promotions__promotion-form-coupon-discount-type">
+					<FormLabel>{ translate( 'Discount type' ) }</FormLabel>
+					{ renderDiscountTypeSelect( coupon, translate, onDiscountTypeSelect ) }
+				</FormFieldset>
+				<FormFieldset className="promotions__promotion-form-coupon-amount">
+					<FormLabel>{ translate( 'Amount' ) }</FormLabel>
+					{ renderAmountInput( coupon, currency, onAmountChange ) }
+				</FormFieldset>
+			</div>
+			<FormFieldset className="promotions__promotion-form-coupon-applies-to">
+				<FormLabel>{ translate( 'Applies to' ) }</FormLabel>
+				{ renderAppliesTo( coupon, translate, onAppliesToChange ) }
+			</FormFieldset>
+			{ renderExpiration( coupon, translate, onExpirationEnable, onExpirationChange ) }
+		</Card>
+	);
+};
+
+PromotionFormCouponCard.PropTypes = {
+	siteId: PropTypes.number,
+	promotion: PropTypes.shape( {
+		id: PropTypes.isRequired,
+		code: PropTypes.string,
+		discount_type: PropTypes.string,
+		amount: PropTypes.number,
+	} ),
+	editPromotion: PropTypes.func.isRequired,
+};
+
+export default localize( PromotionFormCouponCard );
+

--- a/client/extensions/woocommerce/app/promotions/promotion-form-discount-type-and-amount.js
+++ b/client/extensions/woocommerce/app/promotions/promotion-form-discount-type-and-amount.js
@@ -1,0 +1,108 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import PropTypes from 'prop-types';
+import { localize } from 'i18n-calypso';
+import { find, noop } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import FormFieldset from 'components/forms/form-fieldset';
+import FormLabel from 'components/forms/form-label';
+import FormSelect from 'components/forms/form-select';
+import FormTextInputWithAffixes from 'components/forms/form-text-input-with-affixes';
+import PriceInput from 'woocommerce/components/price-input';
+
+function renderPercentInput( amount, onAmountChange ) {
+	// TODO: Consider making a FormPercentInput general-purpose component?
+	return (
+		<FormTextInputWithAffixes
+			type="number"
+			min="0"
+			max="100"
+			suffix="%"
+			placeholder="0"
+			value={ amount }
+			onChange={ onAmountChange }
+		/>
+	);
+}
+
+function renderPriceInput( amount, onAmountChange, currency ) {
+	return (
+		<PriceInput
+			currency={ currency }
+			value={ amount }
+			onChange={ onAmountChange }
+		/>
+	);
+}
+
+const inputRenderers = {
+	percent: renderPercentInput,
+	price: renderPriceInput,
+};
+
+const inputValidators = {
+	percent: ( amount ) => ( amount >= 0 && amount <= 100 ),
+	price: ( amount ) => ( amount >= 0 ),
+};
+
+function renderDiscountTypeOption( { value, text } ) {
+	return ( <option key={ value } value={ value }>{ text }</option> );
+}
+
+const PromotionFormDiscountTypeAndAmount = ( {
+	discountTypesAvailable,
+	discountTypeValue,
+	amount,
+	currency,
+	onDiscountTypeSelect,
+	onAmountChange,
+	translate,
+} ) => {
+	const discountType = find( discountTypesAvailable, ( d ) => ( discountTypeValue === d.value ) );
+	const type = discountType && discountType.type;
+	const isAmountValid = inputValidators[ type ] || noop;
+	const renderAmount = inputRenderers[ type ] || noop;
+
+	const discountTypeSelect = ( e ) => {
+		onDiscountTypeSelect( e.target.value );
+	};
+
+	const amountChange = ( e ) => {
+		const value = e.target.value;
+		if ( isAmountValid( value ) ) {
+			onAmountChange( value );
+		}
+	};
+
+	return (
+		<div className="promotions__promotion-form-discount-type-and-amount">
+			<FormFieldset className="promotions__promotion-form-discount-type">
+				<FormLabel>{ translate( 'Discount type' ) }</FormLabel>
+				<FormSelect value={ discountTypeValue } onChange={ discountTypeSelect } >
+					{ discountTypesAvailable.map( renderDiscountTypeOption ) }
+				</FormSelect>
+			</FormFieldset>
+			<FormFieldset className="promotions__promotion-form-amount">
+				<FormLabel>{ translate( 'Amount' ) }</FormLabel>
+				{ renderAmount && renderAmount( amount, amountChange, currency ) }
+			</FormFieldset>
+		</div>
+	);
+};
+
+PromotionFormDiscountTypeAndAmount.PropTypes = {
+	discountTypesAvailable: PropTypes.object,
+	discountTypeValue: PropTypes.string,
+	amount: PropTypes.number,
+	currency: PropTypes.string,
+	onDiscountTypeSelect: PropTypes.func,
+	onAmountChange: PropTypes.func,
+};
+
+export default localize( PromotionFormDiscountTypeAndAmount );
+

--- a/client/extensions/woocommerce/app/promotions/promotion-form-type-card.js
+++ b/client/extensions/woocommerce/app/promotions/promotion-form-type-card.js
@@ -1,0 +1,51 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import PropTypes from 'prop-types';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Card from 'components/card';
+import FormFieldset from 'components/forms/form-fieldset';
+import FormLabel from 'components/forms/form-label';
+import FormSelect from 'components/forms/form-select';
+
+const PromotionFormTypeCard = ( {
+	siteId,
+	promotion,
+	editPromotion,
+	translate,
+} ) => {
+	const promotionType = ( promotion && promotion.type ? promotion.type : '' );
+
+	const onTypeSelect = ( e ) => {
+		editPromotion( siteId, promotion, { type: e.target.value } );
+	};
+
+	return (
+		<Card className="promotions__promotion-form-type">
+			<FormFieldset className="promotions__promotion-form-type-select">
+				<FormLabel>{ translate( 'Promotion type' ) }</FormLabel>
+				<FormSelect value={ promotionType } onChange={ onTypeSelect }>
+					<option value="" disabled>{ translate( 'Select promotion type…' ) }</option>
+					<option value="coupon">{ translate( 'Coupon' ) }</option>
+					<option value="product_sale">{ translate( 'Product Sale' ) }</option>
+				</FormSelect>
+			</FormFieldset>
+		</Card>
+	);
+};
+
+PromotionFormTypeCard.PropTypes = {
+	siteId: PropTypes.number,
+	promotion: PropTypes.shape( {
+		id: PropTypes.isRequired,
+	} ),
+	editPromotion: PropTypes.func.isRequired,
+};
+
+export default localize( PromotionFormTypeCard );
+

--- a/client/extensions/woocommerce/app/promotions/promotion-form-type-card.js
+++ b/client/extensions/woocommerce/app/promotions/promotion-form-type-card.js
@@ -43,6 +43,7 @@ PromotionFormTypeCard.PropTypes = {
 	siteId: PropTypes.number,
 	promotion: PropTypes.shape( {
 		id: PropTypes.isRequired,
+		type: PropTypes.string.isRequired,
 	} ),
 	editPromotion: PropTypes.func.isRequired,
 };

--- a/client/extensions/woocommerce/app/promotions/promotion-form.js
+++ b/client/extensions/woocommerce/app/promotions/promotion-form.js
@@ -1,0 +1,77 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import PromotionFormTypeCard from './promotion-form-type-card';
+import PromotionFormCouponCard from './promotion-form-coupon-card';
+
+function renderPlaceholder() {
+	const { className } = this.props;
+	return (
+		<div className={ classNames( 'promotions__form', 'is-placeholder', className ) }>
+			<div></div>
+			<div></div>
+			<div></div>
+		</div>
+	);
+}
+
+function renderEditCard( siteId, currency, promotion, editPromotion ) {
+	if ( ! promotion ) {
+		return null;
+	}
+
+	switch ( promotion.type ) {
+		case 'coupon':
+			return (
+				<PromotionFormCouponCard
+					siteId={ siteId }
+					promotion={ promotion }
+					editPromotion={ editPromotion }
+				/>
+			);
+		case 'product_sale':
+			return null;
+		default:
+			return null;
+	}
+}
+
+export default class PromotionForm extends React.PureComponent {
+	static propTypes = {
+		className: PropTypes.string,
+		siteId: PropTypes.number,
+		currency: PropTypes.string,
+		promotion: PropTypes.shape( {
+			id: PropTypes.isRequired,
+		} ),
+		editPromotion: PropTypes.func.isRequired,
+	};
+
+	render() {
+		const { siteId, currency, promotion, editPromotion } = this.props;
+
+		if ( ! siteId ) {
+			return renderPlaceholder();
+		}
+
+		return (
+			<div className={ classNames( 'promotions__form', this.props.className ) }>
+				<PromotionFormTypeCard
+					siteId={ siteId }
+					promotion={ promotion }
+					editPromotion={ editPromotion }
+				/>
+
+				{ renderEditCard( siteId, currency, promotion, editPromotion ) }
+			</div>
+		);
+	}
+}
+

--- a/client/extensions/woocommerce/app/promotions/promotion-form.js
+++ b/client/extensions/woocommerce/app/promotions/promotion-form.js
@@ -37,6 +37,7 @@ function renderEditCard( siteId, currency, promotion, editPromotion ) {
 				/>
 			);
 		case 'product_sale':
+			// TODO: implement product sale UI.
 			return null;
 		default:
 			return null;

--- a/client/extensions/woocommerce/app/promotions/promotion-form.scss
+++ b/client/extensions/woocommerce/app/promotions/promotion-form.scss
@@ -36,7 +36,7 @@
 	margin-bottom: 5px;
 }
 
-.promotions__promotion-form-coupon-discount-type-amount {
+.promotions__promotion-form-discount-type-and-amount {
 	display: flex;
 
 	@include breakpoint( ">960px" ) {

--- a/client/extensions/woocommerce/app/promotions/promotion-form.scss
+++ b/client/extensions/woocommerce/app/promotions/promotion-form.scss
@@ -1,0 +1,74 @@
+
+.promotions__form {
+	@include breakpoint( ">660px" ) {
+		margin-top: 58px;
+	}
+
+	&.is-placeholder div {
+		@include placeholder();
+		background: $white;
+		width: 720px;
+		margin-bottom: 8px;
+
+		@include breakpoint( "<480px" ) {
+			width: 100%;
+		}
+
+		@include breakpoint( "660px-960px" ) {
+			width: 620px;
+		}
+
+		&:first-child {
+			height: 575px;
+		}
+
+		&:nth-child( 2 ) {
+			height: 200px;
+		}
+
+		&:last-child {
+			height: 400px;
+		}
+	}
+}
+
+.form-label {
+	margin-bottom: 5px;
+}
+
+.promotions__promotion-form-coupon-discount-type-amount {
+	display: flex;
+
+	@include breakpoint( ">960px" ) {
+		align-items: flex-end;
+	}
+
+	.form-fieldset {
+		flex: 1;
+		margin-right: 16px;
+
+		&:last-child {
+			margin-right: 0;
+		}
+	}
+
+	@include breakpoint( "<960px" ) {
+		flex-direction: column;
+
+		label + select {
+			width: 100%;
+		}
+
+		.form-fieldset {
+			margin-right: 0;
+			width: 100%;
+		}
+	}
+
+	.form-select {
+		@include breakpoint( ">960px" ) {
+			max-width: 200px;
+		}
+	}
+}
+

--- a/client/extensions/woocommerce/app/promotions/promotion-header.js
+++ b/client/extensions/woocommerce/app/promotions/promotion-header.js
@@ -1,0 +1,83 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import PropTypes from 'prop-types';
+import { localize } from 'i18n-calypso';
+import Gridicon from 'gridicons';
+import { isObject } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import ActionHeader from 'woocommerce/components/action-header';
+import Button from 'components/button';
+import { getLink } from 'woocommerce/lib/nav-utils';
+
+function renderTrashButton( onTrash, promotion, isBusy, translate ) {
+	return onTrash && (
+		<Button borderless scary onClick={ onTrash }>
+			<Gridicon icon="trash" />
+			<span>{ translate( 'Delete' ) }</span>
+		</Button>
+	);
+}
+
+function renderSaveButton( onSave, promotion, isBusy, translate ) {
+	const saveExists = 'undefined' !== typeof onSave;
+	const saveDisabled = false === onSave;
+
+	const saveLabel = ( promotion && ! isObject( promotion.id )
+		? translate( 'Update' )
+		: translate( 'Save & Publish' )
+	);
+
+	return saveExists && (
+		<Button primary onClick={ onSave } disabled={ saveDisabled } busy={ isBusy }>
+			{ saveLabel }
+		</Button>
+	);
+}
+
+const PromotionHeader = ( { promotion, onSave, onTrash, isBusy, translate, site } ) => {
+	const existing = promotion && ! isObject( promotion.id );
+
+	const trashButton = renderTrashButton( onTrash, promotion, isBusy, translate );
+	const saveButton = renderSaveButton( onSave, promotion, isBusy, translate );
+
+	const currentCrumb = promotion && existing
+		? ( <span>{ translate( 'Edit Promotion' ) }</span> )
+		: ( <span>{ translate( 'Add Promotion' ) }</span> );
+
+	const breadcrumbs = [
+		( <a href={ getLink( '/store/promotions/:site/', site ) }>{ translate( 'Promotions' ) }</a> ),
+		currentCrumb,
+	];
+
+	return (
+		<ActionHeader breadcrumbs={ breadcrumbs }>
+			{ trashButton }
+			{ saveButton }
+		</ActionHeader>
+	);
+};
+
+PromotionHeader.propTypes = {
+	site: PropTypes.shape( {
+		slug: PropTypes.string,
+	} ),
+	promotion: PropTypes.shape( {
+		id: PropTypes.oneOfType( [
+			PropTypes.string,
+			PropTypes.object,
+		] ),
+	} ),
+	onTrash: PropTypes.func,
+	onSave: PropTypes.oneOfType( [
+		PropTypes.func,
+		PropTypes.bool,
+	] ),
+};
+
+export default localize( PromotionHeader );
+

--- a/client/extensions/woocommerce/app/promotions/promotion-header.js
+++ b/client/extensions/woocommerce/app/promotions/promotion-header.js
@@ -24,7 +24,11 @@ function renderTrashButton( onTrash, promotion, isBusy, translate ) {
 }
 
 function renderSaveButton( onSave, promotion, isBusy, translate ) {
-	const saveExists = 'undefined' !== typeof onSave;
+	if ( 'undefined' !== typeof onSave ) {
+		// 'Save' not allowed here.
+		return null;
+	}
+
 	const saveDisabled = false === onSave;
 
 	const saveLabel = ( promotion && ! isObject( promotion.id )
@@ -32,7 +36,7 @@ function renderSaveButton( onSave, promotion, isBusy, translate ) {
 		: translate( 'Save & Publish' )
 	);
 
-	return saveExists && (
+	return (
 		<Button primary onClick={ onSave } disabled={ saveDisabled } busy={ isBusy }>
 			{ saveLabel }
 		</Button>
@@ -40,12 +44,10 @@ function renderSaveButton( onSave, promotion, isBusy, translate ) {
 }
 
 const PromotionHeader = ( { promotion, onSave, onTrash, isBusy, translate, site } ) => {
-	const existing = promotion && ! isObject( promotion.id );
-
 	const trashButton = renderTrashButton( onTrash, promotion, isBusy, translate );
 	const saveButton = renderSaveButton( onSave, promotion, isBusy, translate );
 
-	const currentCrumb = promotion && existing
+	const currentCrumb = promotion && ! isObject( promotion.id )
 		? ( <span>{ translate( 'Edit Promotion' ) }</span> )
 		: ( <span>{ translate( 'Add Promotion' ) }</span> );
 

--- a/client/extensions/woocommerce/state/selectors/promotions.js
+++ b/client/extensions/woocommerce/state/selectors/promotions.js
@@ -62,9 +62,9 @@ export function getPromotionEdits(
 	const edits = get( rootState, [ 'extensions', 'woocommerce', 'ui', 'promotions', 'edits', siteId ], {} );
 
 	if ( isObject( promotionId ) ) {
-		return ( edits.creates && find( edits.creates, ( p ) => promotionId === p.id ) || null );
+		return find( edits.creates, ( p ) => promotionId === p.id ) || null;
 	}
-	return ( edits.updates && find( edits.updates, ( p ) => promotionId === p.id ) || null );
+	return find( edits.updates, ( p ) => promotionId === p.id ) || null;
 }
 
 export function getPromotionWithLocalEdits(

--- a/client/extensions/woocommerce/state/selectors/test/promotions.js
+++ b/client/extensions/woocommerce/state/selectors/test/promotions.js
@@ -207,4 +207,86 @@ describe( 'promotions', () => {
 			expect( editedPromotion.type ).to.equal( 'empty33' );
 		} );
 	} );
+
+	describe( '#getCurrentlyEditingPromotionId', () => {
+		it( 'should return null if nothing is being edited', () => {
+			const id = getCurrentlyEditingPromotionId( rootState, 123 );
+			expect( id ).to.be.null;
+		} );
+
+		it( 'should return the id of the last edited promotion', () => {
+			const editedState = cloneDeep( rootState );
+			editedState.extensions.woocommerce.ui.promotions.edits = {
+				[ 123 ]: {
+					creates: [
+						{ id: 'id4', type: 'empty4' },
+					],
+					currentlyEditingId: 'id4',
+				}
+			};
+
+			const id = getCurrentlyEditingPromotionId( editedState, 123 );
+			expect( id ).to.equal( 'id4' );
+		} );
+	} );
+
+	describe( '#getPromotionWithLocalEdits', () => {
+		it( 'should return null if no edits are found for a given id', () => {
+			const edits = getPromotionEdits( rootState, 'notthere', 123 );
+
+			expect( edits ).to.be.null;
+		} );
+
+		it( 'should return edits for a given id', () => {
+			const editedState = cloneDeep( rootState );
+			editedState.extensions.woocommerce.ui.promotions.edits = {
+				[ 123 ]: {
+					updates: [
+						{ id: 'id3', type: 'empty33' },
+					],
+					currentlyEditingId: 'id3',
+				}
+			};
+
+			const edits = getPromotionEdits( editedState, 'id3', 123 );
+
+			expect( edits ).to.exist;
+			expect( edits.id ).to.equal( 'id3' );
+			expect( edits.type ).to.equal( 'empty33' );
+		} );
+	} );
+
+	describe( '#getPromotionWithLocalEdits', () => {
+		it( 'should return null if a promotion is not found by the id provided', () => {
+			const editedPromotion = getPromotionWithLocalEdits( rootState, 'notthere', 123 );
+
+			expect( editedPromotion ).to.be.null;
+		} );
+
+		it( 'should return an unedited promotion as-is', () => {
+			const editedPromotion = getPromotionWithLocalEdits( rootState, 'id3', 123 );
+
+			expect( editedPromotion ).to.exist;
+			expect( editedPromotion.id ).to.equal( 'id3' );
+			expect( editedPromotion.type ).to.equal( 'empty3' );
+		} );
+
+		it( 'should return a promotion with edits overlaid on it', () => {
+			const editedState = cloneDeep( rootState );
+			editedState.extensions.woocommerce.ui.promotions.edits = {
+				[ 123 ]: {
+					updates: [
+						{ id: 'id3', type: 'empty33' },
+					],
+					currentlyEditingId: 'id3',
+				}
+			};
+
+			const editedPromotion = getPromotionWithLocalEdits( editedState, 'id3', 123 );
+
+			expect( editedPromotion ).to.exist;
+			expect( editedPromotion.id ).to.equal( 'id3' );
+			expect( editedPromotion.type ).to.equal( 'empty33' );
+		} );
+	} );
 } );

--- a/client/extensions/woocommerce/state/selectors/test/promotions.js
+++ b/client/extensions/woocommerce/state/selectors/test/promotions.js
@@ -242,16 +242,16 @@ describe( 'promotions', () => {
 			editedState.extensions.woocommerce.ui.promotions.edits = {
 				[ 123 ]: {
 					updates: [
-						{ id: 'id3', type: 'empty33' },
+						{ id: 'coupon:3', type: 'empty33' },
 					],
-					currentlyEditingId: 'id3',
+					currentlyEditingId: 'coupon:3',
 				}
 			};
 
-			const edits = getPromotionEdits( editedState, 'id3', 123 );
+			const edits = getPromotionEdits( editedState, 'coupon:3', 123 );
 
 			expect( edits ).to.exist;
-			expect( edits.id ).to.equal( 'id3' );
+			expect( edits.id ).to.equal( 'coupon:3' );
 			expect( edits.type ).to.equal( 'empty33' );
 		} );
 	} );
@@ -264,10 +264,10 @@ describe( 'promotions', () => {
 		} );
 
 		it( 'should return an unedited promotion as-is', () => {
-			const editedPromotion = getPromotionWithLocalEdits( rootState, 'id3', 123 );
+			const editedPromotion = getPromotionWithLocalEdits( rootState, 'coupon:3', 123 );
 
 			expect( editedPromotion ).to.exist;
-			expect( editedPromotion.id ).to.equal( 'id3' );
+			expect( editedPromotion.id ).to.equal( 'coupon:3' );
 			expect( editedPromotion.type ).to.equal( 'empty3' );
 		} );
 
@@ -276,16 +276,16 @@ describe( 'promotions', () => {
 			editedState.extensions.woocommerce.ui.promotions.edits = {
 				[ 123 ]: {
 					updates: [
-						{ id: 'id3', type: 'empty33' },
+						{ id: 'coupon:3', type: 'empty33' },
 					],
-					currentlyEditingId: 'id3',
+					currentlyEditingId: 'coupon:3',
 				}
 			};
 
-			const editedPromotion = getPromotionWithLocalEdits( editedState, 'id3', 123 );
+			const editedPromotion = getPromotionWithLocalEdits( editedState, 'coupon:3', 123 );
 
 			expect( editedPromotion ).to.exist;
-			expect( editedPromotion.id ).to.equal( 'id3' );
+			expect( editedPromotion.id ).to.equal( 'coupon:3' );
 			expect( editedPromotion.type ).to.equal( 'empty33' );
 		} );
 	} );

--- a/client/extensions/woocommerce/state/selectors/test/promotions.js
+++ b/client/extensions/woocommerce/state/selectors/test/promotions.js
@@ -118,14 +118,14 @@ describe( 'promotions', () => {
 			editedState.extensions.woocommerce.ui.promotions.edits = {
 				[ 123 ]: {
 					creates: [
-						{ id: 'id4', type: 'empty4' },
+						{ id: 'coupon:4', type: 'empty4' },
 					],
-					currentlyEditingId: 'id4',
+					currentlyEditingId: 'coupon:4',
 				}
 			};
 
 			const id = getCurrentlyEditingPromotionId( editedState, 123 );
-			expect( id ).to.equal( 'id4' );
+			expect( id ).to.equal( 'coupon:4' );
 		} );
 	} );
 
@@ -170,88 +170,6 @@ describe( 'promotions', () => {
 
 			expect( edits ).to.exist;
 			expect( edits.id ).to.equal( placeholderId );
-			expect( edits.type ).to.equal( 'empty33' );
-		} );
-	} );
-
-	describe( '#getPromotionWithLocalEdits', () => {
-		it( 'should return null if a promotion is not found by the id provided', () => {
-			const editedPromotion = getPromotionWithLocalEdits( rootState, 'notthere', 123 );
-
-			expect( editedPromotion ).to.be.null;
-		} );
-
-		it( 'should return an unedited promotion as-is', () => {
-			const editedPromotion = getPromotionWithLocalEdits( rootState, 'coupon:3', 123 );
-
-			expect( editedPromotion ).to.exist;
-			expect( editedPromotion.id ).to.equal( 'coupon:3' );
-			expect( editedPromotion.type ).to.equal( 'empty3' );
-		} );
-
-		it( 'should return a promotion with edits overlaid on it', () => {
-			const editedState = cloneDeep( rootState );
-			editedState.extensions.woocommerce.ui.promotions.edits = {
-				[ 123 ]: {
-					updates: [
-						{ id: 'coupon:3', type: 'empty33' },
-					],
-					currentlyEditingId: 'coupon:3',
-				}
-			};
-
-			const editedPromotion = getPromotionWithLocalEdits( editedState, 'coupon:3', 123 );
-
-			expect( editedPromotion ).to.exist;
-			expect( editedPromotion.id ).to.equal( 'coupon:3' );
-			expect( editedPromotion.type ).to.equal( 'empty33' );
-		} );
-	} );
-
-	describe( '#getCurrentlyEditingPromotionId', () => {
-		it( 'should return null if nothing is being edited', () => {
-			const id = getCurrentlyEditingPromotionId( rootState, 123 );
-			expect( id ).to.be.null;
-		} );
-
-		it( 'should return the id of the last edited promotion', () => {
-			const editedState = cloneDeep( rootState );
-			editedState.extensions.woocommerce.ui.promotions.edits = {
-				[ 123 ]: {
-					creates: [
-						{ id: 'id4', type: 'empty4' },
-					],
-					currentlyEditingId: 'id4',
-				}
-			};
-
-			const id = getCurrentlyEditingPromotionId( editedState, 123 );
-			expect( id ).to.equal( 'id4' );
-		} );
-	} );
-
-	describe( '#getPromotionWithLocalEdits', () => {
-		it( 'should return null if no edits are found for a given id', () => {
-			const edits = getPromotionEdits( rootState, 'notthere', 123 );
-
-			expect( edits ).to.be.null;
-		} );
-
-		it( 'should return edits for a given id', () => {
-			const editedState = cloneDeep( rootState );
-			editedState.extensions.woocommerce.ui.promotions.edits = {
-				[ 123 ]: {
-					updates: [
-						{ id: 'coupon:3', type: 'empty33' },
-					],
-					currentlyEditingId: 'coupon:3',
-				}
-			};
-
-			const edits = getPromotionEdits( editedState, 'coupon:3', 123 );
-
-			expect( edits ).to.exist;
-			expect( edits.id ).to.equal( 'coupon:3' );
 			expect( edits.type ).to.equal( 'empty33' );
 		} );
 	} );

--- a/client/extensions/woocommerce/style.scss
+++ b/client/extensions/woocommerce/style.scss
@@ -17,6 +17,7 @@
 	@import 'app/settings/email/mailchimp/style';
 	@import 'app/products/product-form';
 	@import 'app/products/products-list';
+	@import 'app/promotions/promotion-form';
 	@import 'app/promotions/promotions-list';
 	@import 'app/reviews/style';
 	@import 'app/settings/shipping/style';


### PR DESCRIPTION
This adds the base form code to create a coupon and modify the edit
state for it.

To Test:
1. `npm start`
2. Visit `http://calypso.localhost:3000/store/promotion/<site url>`
3. Select "Coupon" from the drop-down
4. Edit other fields and observe results.

(Note: only All products is supported in this PR.)

For UI Design Review, please just ensure that the elements are here and operational. The greater layout is adjusted in #18520 

![new_promotion_ _coderkevin_ _wordpress_com](https://user-images.githubusercontent.com/945228/31412365-67a4eac4-adda-11e7-8018-046e308bfb1a.png)
