### PR TITLE
Store Orders: Run prettier

### DIFF
--- a/client/extensions/woocommerce/app/order/order-created/index.js
+++ b/client/extensions/woocommerce/app/order/order-created/index.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -11,7 +12,7 @@ class OrderCreated extends Component {
 		order: PropTypes.shape( {
 			date_created_gmt: PropTypes.string.isRequired,
 		} ),
-	}
+	};
 
 	render() {
 		const { moment, order, translate } = this.props;
@@ -20,15 +21,12 @@ class OrderCreated extends Component {
 		}
 
 		const createdMoment = moment( order.date_created_gmt + 'Z' );
-		const createdLabel = translate(
-			'Order created on %(createdDate)s at %(createdTime)s',
-			{
-				args: {
-					createdDate: createdMoment.format( 'll' ),
-					createdTime: createdMoment.format( 'LT' ),
-				}
-			}
-		);
+		const createdLabel = translate( 'Order created on %(createdDate)s at %(createdTime)s', {
+			args: {
+				createdDate: createdMoment.format( 'll' ),
+				createdTime: createdMoment.format( 'LT' ),
+			},
+		} );
 
 		return (
 			<div className="order-created">

--- a/client/extensions/woocommerce/app/order/order-details/index.js
+++ b/client/extensions/woocommerce/app/order/order-details/index.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -26,7 +27,7 @@ class OrderDetails extends Component {
 			ID: PropTypes.number.isRequired,
 			slug: PropTypes.string.isRequired,
 		} ),
-	}
+	};
 
 	constructor( props ) {
 		super( props );
@@ -35,19 +36,21 @@ class OrderDetails extends Component {
 		};
 	}
 
-	updateStatus = ( event ) => {
+	updateStatus = event => {
 		this.setState( { status: event.target.value } );
 		// Send the order back to the parent component
 		this.props.onUpdate( { status: event.target.value } );
-	}
+	};
 
 	renderStatus = () => {
 		const { order } = this.props;
 
-		return isOrderWaitingPayment( order.status )
-			? <OrderStatusSelect value={ this.state.status } onChange={ this.updateStatus } />
-			: <OrderStatus status={ order.status } showShipping={ false } />;
-	}
+		return isOrderWaitingPayment( order.status ) ? (
+			<OrderStatusSelect value={ this.state.status } onChange={ this.updateStatus } />
+		) : (
+			<OrderStatus status={ order.status } showShipping={ false } />
+		);
+	};
 
 	render() {
 		const { order, site, translate } = this.props;
@@ -57,7 +60,11 @@ class OrderDetails extends Component {
 
 		return (
 			<div className="order-details">
-				<SectionHeader label={ translate( 'Order %(orderId)s Details', { args: { orderId: `#${ order.id }` } } ) }>
+				<SectionHeader
+					label={ translate( 'Order %(orderId)s Details', {
+						args: { orderId: `#${ order.id }` },
+					} ) }
+				>
 					<span>{ this.renderStatus() }</span>
 				</SectionHeader>
 				<Card className="order-details__card">

--- a/client/extensions/woocommerce/app/order/order-details/row-discount.js
+++ b/client/extensions/woocommerce/app/order/order-details/row-discount.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -18,7 +19,7 @@ class OrderDiscountRow extends Component {
 			discount_total: PropTypes.string.isRequired,
 		} ),
 		showTax: PropTypes.bool,
-	}
+	};
 
 	render() {
 		const { order, showTax, translate } = this.props;

--- a/client/extensions/woocommerce/app/order/order-details/row-refund.js
+++ b/client/extensions/woocommerce/app/order/order-details/row-refund.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -17,11 +18,11 @@ class OrderRefundRow extends Component {
 			refunds: PropTypes.array.isRequired,
 		} ),
 		showTax: PropTypes.bool,
-	}
+	};
 
-	getRefundedTotal = ( order ) => {
-		return order.refunds.reduce( ( total, i ) => total + ( i.total * 1 ), 0 );
-	}
+	getRefundedTotal = order => {
+		return order.refunds.reduce( ( total, i ) => total + i.total * 1, 0 );
+	};
 
 	render() {
 		const { order, showTax, translate } = this.props;
@@ -33,7 +34,7 @@ class OrderRefundRow extends Component {
 		return (
 			<div className="order-details__total-refund">
 				<div className="order-details__totals-label">{ translate( 'Refunded' ) }</div>
-				{ showTax && <div className="order-details__totals-tax"></div> }
+				{ showTax && <div className="order-details__totals-tax" /> }
 				<div className="order-details__totals-value">
 					{ formatCurrency( refundValue, order.currency ) }
 				</div>

--- a/client/extensions/woocommerce/app/order/order-details/row-refund.js
+++ b/client/extensions/woocommerce/app/order/order-details/row-refund.js
@@ -21,7 +21,7 @@ class OrderRefundRow extends Component {
 	};
 
 	getRefundedTotal = order => {
-		return order.refunds.reduce( ( total, i ) => total + i.total * 1, 0 );
+		return order.refunds.reduce( ( total, i ) => total + parseFloat( i.total ), 0 );
 	};
 
 	render() {

--- a/client/extensions/woocommerce/app/order/order-details/row-shipping-refund.js
+++ b/client/extensions/woocommerce/app/order/order-details/row-shipping-refund.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -15,20 +16,11 @@ class OrderShippingRefundRow extends Component {
 	static propTypes = {
 		currency: PropTypes.string.isRequired,
 		onChange: PropTypes.func.isRequired,
-		shippingTotal: PropTypes.oneOfType( [
-			PropTypes.string,
-			PropTypes.number,
-		] ).isRequired,
-	}
+		shippingTotal: PropTypes.oneOfType( [ PropTypes.string, PropTypes.number ] ).isRequired,
+	};
 
 	render() {
-		const {
-			currency,
-			numberFormat,
-			onChange,
-			shippingTotal,
-			translate
-		} = this.props;
+		const { currency, numberFormat, onChange, shippingTotal, translate } = this.props;
 		const { decimal, grouping, precision } = getCurrencyDefaults( currency );
 		const total = numberFormat( Math.abs( shippingTotal ), {
 			decimals: precision,
@@ -44,7 +36,8 @@ class OrderShippingRefundRow extends Component {
 						name="shipping_total"
 						onChange={ onChange }
 						currency={ currency }
-						value={ total } />
+						value={ total }
+					/>
 				</div>
 			</div>
 		);

--- a/client/extensions/woocommerce/app/order/order-details/row-shipping.js
+++ b/client/extensions/woocommerce/app/order/order-details/row-shipping.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -18,7 +19,7 @@ class OrderShippingRow extends Component {
 			shipping_total: PropTypes.string.isRequired,
 		} ),
 		showTax: PropTypes.bool,
-	}
+	};
 
 	render() {
 		const { order, showTax, translate } = this.props;

--- a/client/extensions/woocommerce/app/order/order-details/row-total.js
+++ b/client/extensions/woocommerce/app/order/order-details/row-total.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -18,7 +19,7 @@ class OrderTotalRow extends Component {
 			total: PropTypes.string.isRequired,
 		} ),
 		showTax: PropTypes.bool,
-	}
+	};
 
 	render() {
 		const { order, showTax, translate } = this.props;

--- a/client/extensions/woocommerce/app/order/order-details/table.js
+++ b/client/extensions/woocommerce/app/order/order-details/table.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -39,7 +40,7 @@ class OrderDetailsTable extends Component {
 			ID: PropTypes.number.isRequired,
 			slug: PropTypes.string.isRequired,
 		} ),
-	}
+	};
 
 	constructor( props ) {
 		super( props );
@@ -57,31 +58,33 @@ class OrderDetailsTable extends Component {
 		}
 		// If there are any items in `tax_lines`, we have taxes on this order.
 		return !! order.tax_lines.length;
-	}
+	};
 
 	recalculateRefund = () => {
 		const { order } = this.props;
 		if ( ! order ) {
 			return 0;
 		}
-		const subtotal = sum( this.state.quantities.map( ( q, i ) => {
-			if ( ! order.line_items[ i ] ) {
-				return 0;
-			}
+		const subtotal = sum(
+			this.state.quantities.map( ( q, i ) => {
+				if ( ! order.line_items[ i ] ) {
+					return 0;
+				}
 
-			const price = parseFloat( order.line_items[ i ].price );
-			if ( order.prices_include_tax ) {
-				return price * q;
-			}
+				const price = parseFloat( order.line_items[ i ].price );
+				if ( order.prices_include_tax ) {
+					return price * q;
+				}
 
-			const tax = getOrderLineItemTax( order, i ) / order.line_items[ i ].quantity;
-			return ( price + tax ) * q;
-		} ) );
+				const tax = getOrderLineItemTax( order, i ) / order.line_items[ i ].quantity;
+				return ( price + tax ) * q;
+			} )
+		);
 		const total = subtotal + ( parseFloat( this.state.shippingTotal ) || 0 );
 		this.props.onChange( total );
-	}
+	};
 
-	onChange = ( event ) => {
+	onChange = event => {
 		if ( 'shipping_total' === event.target.name ) {
 			const shippingTotal = event.target.value.replace( /[^0-9,.]/g, '' );
 			this.setState( { shippingTotal }, this.recalculateRefund );
@@ -92,20 +95,30 @@ class OrderDetailsTable extends Component {
 			newQuants[ i ] = event.target.value;
 			this.setState( { quantities: newQuants }, this.recalculateRefund );
 		}
-	}
+	};
 
 	renderTableHeader = () => {
 		const { translate } = this.props;
 		return (
 			<TableRow className="order-details__header">
-				<TableItem isHeader className="order-details__item-product">{ translate( 'Product' ) }</TableItem>
-				<TableItem isHeader className="order-details__item-cost">{ translate( 'Cost' ) }</TableItem>
-				<TableItem isHeader className="order-details__item-quantity">{ translate( 'Quantity' ) }</TableItem>
-				<TableItem isHeader className="order-details__item-tax">{ translate( 'Tax' ) }</TableItem>
-				<TableItem isHeader className="order-details__item-total">{ translate( 'Total' ) }</TableItem>
+				<TableItem isHeader className="order-details__item-product">
+					{ translate( 'Product' ) }
+				</TableItem>
+				<TableItem isHeader className="order-details__item-cost">
+					{ translate( 'Cost' ) }
+				</TableItem>
+				<TableItem isHeader className="order-details__item-quantity">
+					{ translate( 'Quantity' ) }
+				</TableItem>
+				<TableItem isHeader className="order-details__item-tax">
+					{ translate( 'Tax' ) }
+				</TableItem>
+				<TableItem isHeader className="order-details__item-total">
+					{ translate( 'Total' ) }
+				</TableItem>
 			</TableRow>
 		);
-	}
+	};
 
 	renderOrderItems = ( item, i ) => {
 		const { isEditable, order, site } = this.props;
@@ -113,31 +126,40 @@ class OrderDetailsTable extends Component {
 		return (
 			<TableRow key={ i } className="order-details__items">
 				<TableItem isRowHeader className="order-details__item-product">
-					<a href={ getLink( `/store/product/:site/${ item.product_id }`, site ) } className="order-details__item-link">
+					<a
+						href={ getLink( `/store/product/:site/${ item.product_id }`, site ) }
+						className="order-details__item-link"
+					>
 						{ item.name }
 					</a>
 					<span className="order-details__item-sku">{ item.sku }</span>
 				</TableItem>
-				<TableItem className="order-details__item-cost">{ formatCurrency( item.price, order.currency ) }</TableItem>
+				<TableItem className="order-details__item-cost">
+					{ formatCurrency( item.price, order.currency ) }
+				</TableItem>
 				<TableItem className="order-details__item-quantity">
-					{ isEditable
-						? <FormTextInput
+					{ isEditable ? (
+						<FormTextInput
 							type="number"
 							name={ `quantity-${ i }` }
 							onChange={ this.onChange }
 							min="0"
 							max={ item.quantity }
-							value={ this.state.quantities[ i ] || 0 } />
-						: item.quantity
-					}
+							value={ this.state.quantities[ i ] || 0 }
+						/>
+					) : (
+						item.quantity
+					) }
 				</TableItem>
 				<TableItem className="order-details__item-tax">
 					{ formatCurrency( tax, order.currency ) }
 				</TableItem>
-				<TableItem className="order-details__item-total">{ formatCurrency( item.total, order.currency ) }</TableItem>
+				<TableItem className="order-details__item-total">
+					{ formatCurrency( item.total, order.currency ) }
+				</TableItem>
 			</TableRow>
 		);
-	}
+	};
 
 	render() {
 		const { isEditable, order } = this.props;
@@ -160,13 +182,15 @@ class OrderDetailsTable extends Component {
 
 				<div className={ totalsClasses }>
 					<OrderDiscountRow order={ order } showTax={ showTax } />
-					{ isEditable
-						? <OrderShippingRefundRow
+					{ isEditable ? (
+						<OrderShippingRefundRow
 							currency={ order.currency }
 							onChange={ this.onChange }
-							shippingTotal={ this.state.shippingTotal } />
-						: <OrderShippingRow order={ order } showTax={ showTax } />
-					}
+							shippingTotal={ this.state.shippingTotal }
+						/>
+					) : (
+						<OrderShippingRow order={ order } showTax={ showTax } />
+					) }
 					<OrderTotalRow order={ order } showTax={ showTax } />
 					<OrderRefundRow order={ order } showTax={ showTax } />
 				</div>

--- a/client/extensions/woocommerce/app/order/order-fulfillment/index.js
+++ b/client/extensions/woocommerce/app/order/order-fulfillment/index.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -31,38 +32,38 @@ class OrderFulfillment extends Component {
 			ID: PropTypes.number.isRequired,
 			slug: PropTypes.string.isRequired,
 		} ),
-	}
+	};
 
 	state = {
 		errorMessage: false,
 		shouldEmail: false,
 		showDialog: false,
 		trackingNumber: '',
-	}
+	};
 
-	isShippable = ( order ) => {
-		return ( -1 === [ 'completed', 'failed', 'cancelled', 'refunded' ].indexOf( order.status ) );
-	}
+	isShippable = order => {
+		return -1 === [ 'completed', 'failed', 'cancelled', 'refunded' ].indexOf( order.status );
+	};
 
 	toggleDialog = () => {
 		this.setState( {
 			showDialog: ! this.state.showDialog,
 		} );
-	}
+	};
 
-	updateTrackingNumber = ( event ) => {
+	updateTrackingNumber = event => {
 		this.setState( {
 			errorMessage: false,
 			trackingNumber: event.target.value,
 		} );
-	}
+	};
 
 	updateCustomerEmail = () => {
 		this.setState( {
 			errorMessage: false,
 			shouldEmail: ! this.state.shouldEmail,
 		} );
-	}
+	};
 
 	submit = () => {
 		const { order, site, translate } = this.props;
@@ -81,14 +82,14 @@ class OrderFulfillment extends Component {
 		this.toggleDialog();
 		const note = {
 			note: translate( 'Your order has been shipped. The tracking number is %(trackingNumber)s.', {
-				args: { trackingNumber }
+				args: { trackingNumber },
 			} ),
 			customer_note: shouldEmail,
 		};
 		if ( trackingNumber ) {
 			this.props.createNote( site.ID, order.id, note );
 		}
-	}
+	};
 
 	getFulfillmentStatus = () => {
 		const { order, translate } = this.props;
@@ -104,7 +105,7 @@ class OrderFulfillment extends Component {
 			default:
 				return translate( 'Order needs to be fulfilled' );
 		}
-	}
+	};
 
 	render() {
 		const { order, translate } = this.props;
@@ -116,7 +117,9 @@ class OrderFulfillment extends Component {
 
 		const dialogButtons = [
 			<Button onClick={ this.toggleDialog }>{ translate( 'Cancel' ) }</Button>,
-			<Button primary onClick={ this.submit }>{ translate( 'Fulfill' ) }</Button>,
+			<Button primary onClick={ this.submit }>
+				{ translate( 'Fulfill' ) }
+			</Button>,
 		];
 
 		const classes = classNames( {
@@ -131,13 +134,19 @@ class OrderFulfillment extends Component {
 					{ this.getFulfillmentStatus() }
 				</div>
 				<div className="order-fulfillment__action">
-					{ ( this.isShippable( order ) )
-						? <Button primary onClick={ this.toggleDialog }>{ translate( 'Fulfill' ) }</Button>
-						: null
-					}
+					{ this.isShippable( order ) ? (
+						<Button primary onClick={ this.toggleDialog }>
+							{ translate( 'Fulfill' ) }
+						</Button>
+					) : null }
 				</div>
 
-				<Dialog isVisible={ showDialog } onClose={ this.toggleDialog } className={ dialogClass } buttons={ dialogButtons }>
+				<Dialog
+					isVisible={ showDialog }
+					onClose={ this.toggleDialog }
+					className={ dialogClass }
+					buttons={ dialogButtons }
+				>
 					<h1>{ translate( 'Fulfill order' ) }</h1>
 					<form>
 						<FormFieldset className="order-fulfillment__tracking">
@@ -149,13 +158,21 @@ class OrderFulfillment extends Component {
 								className="order-fulfillment__value"
 								value={ trackingNumber }
 								onChange={ this.updateTrackingNumber }
-								placeholder={ translate( 'Tracking Number' ) } />
+								placeholder={ translate( 'Tracking Number' ) }
+							/>
 						</FormFieldset>
 						<FormLabel className="order-fulfillment__email">
-							<FormInputCheckbox checked={ this.state.shouldEmail } onChange={ this.updateCustomerEmail } />
+							<FormInputCheckbox
+								checked={ this.state.shouldEmail }
+								onChange={ this.updateCustomerEmail }
+							/>
 							<span>{ translate( 'Email tracking number to customer' ) }</span>
 						</FormLabel>
-						{ errorMessage && <Notice status="is-error" showDismiss={ false }>{ errorMessage }</Notice> }
+						{ errorMessage && (
+							<Notice status="is-error" showDismiss={ false }>
+								{ errorMessage }
+							</Notice>
+						) }
 					</form>
 				</Dialog>
 			</div>
@@ -163,7 +180,6 @@ class OrderFulfillment extends Component {
 	}
 }
 
-export default connect(
-	undefined,
-	dispatch => bindActionCreators( { createNote, updateOrder }, dispatch )
+export default connect( undefined, dispatch =>
+	bindActionCreators( { createNote, updateOrder }, dispatch )
 )( localize( OrderFulfillment ) );

--- a/client/extensions/woocommerce/app/order/order-notes/day.js
+++ b/client/extensions/woocommerce/app/order/order-notes/day.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -17,11 +18,11 @@ class OrderNotesByDay extends Component {
 		index: PropTypes.number.isRequired,
 		isOpen: PropTypes.bool.isRequired,
 		onClick: PropTypes.func.isRequired,
-	}
+	};
 
 	onClick = () => {
 		this.props.onClick( this.props.index );
-	}
+	};
 
 	render() {
 		const { count, date, isOpen, moment, translate } = this.props;
@@ -30,7 +31,9 @@ class OrderNotesByDay extends Component {
 		const header = (
 			<div>
 				<h3>{ displayDate }</h3>
-				<small>{ translate( '%(count)s event', '%(count)s events', { count, args: { count } } ) }</small>
+				<small>
+					{ translate( '%(count)s event', '%(count)s events', { count, args: { count } } ) }
+				</small>
 			</div>
 		);
 
@@ -41,7 +44,10 @@ class OrderNotesByDay extends Component {
 					className="order-notes__day-header"
 					expanded={ isOpen }
 					header={ header }
-					screenReaderText={ translate( 'Show notes from %(date)s', { args: { date: displayDate } } ) }>
+					screenReaderText={ translate( 'Show notes from %(date)s', {
+						args: { date: displayDate },
+					} ) }
+				>
 					{ this.props.children }
 				</FoldableCard>
 			</div>

--- a/client/extensions/woocommerce/app/order/order-notes/index.js
+++ b/client/extensions/woocommerce/app/order/order-notes/index.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -36,7 +37,7 @@ class OrderNotes extends Component {
 	static propTypes = {
 		orderId: PropTypes.number.isRequired,
 		siteId: PropTypes.number.isRequired,
-	}
+	};
 
 	constructor( props ) {
 		super( props );
@@ -45,16 +46,14 @@ class OrderNotes extends Component {
 		};
 	}
 
-	toggleOpenDay = ( index ) => {
+	toggleOpenDay = index => {
 		this.setState( () => ( { openIndex: index } ) );
-	}
+	};
 
 	renderNotes = () => {
 		const { days, notesByDay, translate } = this.props;
 		if ( ! days.length ) {
-			return (
-				<p>{ translate( 'No activity yet' ) }</p>
-			);
+			return <p>{ translate( 'No activity yet' ) }</p>;
 		}
 
 		return days.map( ( day, index ) => {
@@ -66,12 +65,13 @@ class OrderNotes extends Component {
 					date={ day }
 					index={ index }
 					isOpen={ index === this.state.openIndex }
-					onClick={ this.toggleOpenDay } >
+					onClick={ this.toggleOpenDay }
+				>
 					{ notes.map( note => <OrderNote { ...note } key={ note.id } /> ) }
 				</OrderNotesByDay>
 			);
 		} );
-	}
+	};
 
 	renderPlaceholder = () => {
 		const noop = () => {};
@@ -80,22 +80,19 @@ class OrderNotes extends Component {
 				<OrderNote note="" />
 			</OrderNotesByDay>
 		);
-	}
+	};
 
 	render() {
 		const { areNotesLoaded, orderId, siteId, translate } = this.props;
 		const classes = classNames( {
-			'is-placeholder': ! areNotesLoaded
+			'is-placeholder': ! areNotesLoaded,
 		} );
 
 		return (
 			<div className="order-notes">
 				<SectionHeader label={ translate( 'Activity Log' ) } />
 				<Card className={ classes }>
-					{ areNotesLoaded
-						? this.renderNotes()
-						: this.renderPlaceholder()
-					}
+					{ areNotesLoaded ? this.renderNotes() : this.renderPlaceholder() }
 					<CreateOrderNote orderId={ orderId } siteId={ siteId } />
 				</Card>
 			</div>
@@ -103,23 +100,21 @@ class OrderNotes extends Component {
 	}
 }
 
-export default connect(
-	( state, props ) => {
-		const orderId = props.orderId || false;
-		const siteId = props.siteId || false;
-		const areNotesLoaded = areOrderNotesLoaded( state, orderId );
-		const notes = getOrderNotes( state, orderId );
-		const notesByDay = notes.length ? getSortedNotes( notes ) : false;
-		const days = notesByDay ? keys( notesByDay ) : [];
-		days.sort().reverse();
+export default connect( ( state, props ) => {
+	const orderId = props.orderId || false;
+	const siteId = props.siteId || false;
+	const areNotesLoaded = areOrderNotesLoaded( state, orderId );
+	const notes = getOrderNotes( state, orderId );
+	const notesByDay = notes.length ? getSortedNotes( notes ) : false;
+	const days = notesByDay ? keys( notesByDay ) : [];
+	days.sort().reverse();
 
-		return {
-			areNotesLoaded,
-			days,
-			notes,
-			notesByDay,
-			orderId,
-			siteId,
-		};
-	}
-)( localize( OrderNotes ) );
+	return {
+		areNotesLoaded,
+		days,
+		notes,
+		notesByDay,
+		orderId,
+		siteId,
+	};
+} )( localize( OrderNotes ) );

--- a/client/extensions/woocommerce/app/order/order-notes/new-note.js
+++ b/client/extensions/woocommerce/app/order/order-notes/new-note.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -23,24 +24,24 @@ class CreateOrderNote extends Component {
 	static propTypes = {
 		orderId: PropTypes.number.isRequired,
 		siteId: PropTypes.number.isRequired,
-	}
+	};
 
 	state = {
 		note: '',
 		type: 'internal',
-	}
+	};
 
-	setNote = ( event ) => {
+	setNote = event => {
 		this.setState( {
 			note: event.target.value,
 		} );
-	}
+	};
 
-	setType = ( event ) => {
+	setType = event => {
 		this.setState( {
 			type: event.target.value,
 		} );
-	}
+	};
 
 	saveNote = () => {
 		const { orderId, siteId } = this.props;
@@ -53,7 +54,7 @@ class CreateOrderNote extends Component {
 		};
 		this.props.createNote( siteId, orderId, note );
 		this.setState( { note: '' } );
-	}
+	};
 
 	render() {
 		const { isNoteSaving, translate } = this.props;
@@ -61,7 +62,9 @@ class CreateOrderNote extends Component {
 		return (
 			<div className="order-notes__new-note">
 				<FormFieldSet className="order-notes__new-note-content">
-					<ScreenReaderText><FormLabel htmlFor="note">{ translate( 'Add a note' ) }</FormLabel></ScreenReaderText>
+					<ScreenReaderText>
+						<FormLabel htmlFor="note">{ translate( 'Add a note' ) }</FormLabel>
+					</ScreenReaderText>
 					<FormTextarea
 						id="note"
 						value={ this.state.note }
@@ -74,11 +77,7 @@ class CreateOrderNote extends Component {
 						<option value={ 'internal' }>{ translate( 'Private Note' ) }</option>
 						<option value={ 'email' }>{ translate( 'Send to Customer' ) }</option>
 					</FormSelect>
-					<Button
-						primary
-						onClick={ this.saveNote }
-						busy={ isNoteSaving }
-						disabled={ isNoteSaving }>
+					<Button primary onClick={ this.saveNote } busy={ isNoteSaving } disabled={ isNoteSaving }>
 						{ translate( 'Add Note' ) }
 					</Button>
 				</div>
@@ -89,7 +88,7 @@ class CreateOrderNote extends Component {
 
 export default connect(
 	( state, props ) => ( {
-		isNoteSaving: isOrderNoteSaving( state, props.orderId )
+		isNoteSaving: isOrderNoteSaving( state, props.orderId ),
 	} ),
 	dispatch => bindActionCreators( { createNote }, dispatch )
 )( localize( CreateOrderNote ) );

--- a/client/extensions/woocommerce/app/order/order-notes/note.js
+++ b/client/extensions/woocommerce/app/order/order-notes/note.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -16,16 +17,10 @@ class OrderNote extends Component {
 		customer_note: PropTypes.bool,
 		date_created_gmt: PropTypes.string,
 		note: PropTypes.string.isRequired,
-	}
+	};
 
 	render() {
-		const {
-			customer_note,
-			date_created_gmt,
-			note,
-			moment,
-			translate
-		} = this.props;
+		const { customer_note, date_created_gmt, note, moment, translate } = this.props;
 
 		const createdMoment = date_created_gmt ? moment( date_created_gmt + 'Z' ) : moment();
 
@@ -45,9 +40,7 @@ class OrderNote extends Component {
 				</div>
 				<div className="order-notes__note-body">
 					<div className="order-notes__note-type">{ note_type }</div>
-					<div className="order-notes__note-content">
-						{ decodeEntities( stripHTML( note ) ) }
-					</div>
+					<div className="order-notes__note-content">{ decodeEntities( stripHTML( note ) ) }</div>
 				</div>
 			</div>
 		);

--- a/client/extensions/woocommerce/app/order/order-payment/index.js
+++ b/client/extensions/woocommerce/app/order/order-payment/index.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -11,7 +12,10 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import { arePaymentMethodsLoaded, getPaymentMethod } from 'woocommerce/state/sites/payment-methods/selectors';
+import {
+	arePaymentMethodsLoaded,
+	getPaymentMethod,
+} from 'woocommerce/state/sites/payment-methods/selectors';
 import Button from 'components/button';
 import Dialog from 'components/dialog';
 import { fetchPaymentMethods } from 'woocommerce/state/sites/payment-methods/actions';
@@ -39,14 +43,14 @@ class OrderPaymentCard extends Component {
 			ID: PropTypes.number.isRequired,
 			slug: PropTypes.string.isRequired,
 		} ),
-	}
+	};
 
 	state = {
 		errorMessage: false,
 		refundTotal: 0,
 		refundNote: '',
 		showDialog: false,
-	}
+	};
 
 	componentDidMount = () => {
 		const { site } = this.props;
@@ -54,21 +58,21 @@ class OrderPaymentCard extends Component {
 		if ( site && site.ID ) {
 			this.props.fetchPaymentMethods( site.ID );
 		}
-	}
+	};
 
-	componentWillReceiveProps = ( newProps ) => {
+	componentWillReceiveProps = newProps => {
 		const { site } = this.props;
-		const newSiteId = newProps.site && newProps.site.ID || null;
-		const oldSiteId = site && site.ID || null;
+		const newSiteId = ( newProps.site && newProps.site.ID ) || null;
+		const oldSiteId = ( site && site.ID ) || null;
 
 		if ( oldSiteId !== newSiteId ) {
 			this.props.fetchPaymentMethods( newSiteId );
 		}
-	}
+	};
 
-	getRefundedTotal = ( order ) => {
+	getRefundedTotal = order => {
 		return order.refunds.reduce( ( sum, i ) => sum + parseFloat( i.total ), 0 );
-	}
+	};
 
 	getPaymentStatus = () => {
 		const { order, translate } = this.props;
@@ -78,14 +82,14 @@ class OrderPaymentCard extends Component {
 			paymentStatus = translate( 'Payment of %(total)s has been refunded', {
 				args: {
 					total: formatCurrency( order.total, order.currency ),
-				}
+				},
 			} );
 		} else if ( 'on-hold' === order.status || 'pending' === order.status ) {
 			paymentStatus = translate( 'Awaiting payment of %(total)s via %(method)s', {
 				args: {
 					total: formatCurrency( order.total, order.currency ),
 					method: order.payment_method_title,
-				}
+				},
 			} );
 		} else if ( order.refunds.length ) {
 			const refund = this.getRefundedTotal( order );
@@ -93,37 +97,33 @@ class OrderPaymentCard extends Component {
 				args: {
 					total: formatCurrency( order.total, order.currency ),
 					refund: formatCurrency( refund, order.currency ),
-				}
+				},
 			} );
 		} else {
 			paymentStatus = translate( 'Payment of %(total)s received via %(method)s', {
 				args: {
 					total: formatCurrency( order.total, order.currency ),
 					method: order.payment_method_title,
-				}
+				},
 			} );
 		}
 		return paymentStatus;
-	}
+	};
 
 	getPaymentAction = () => {
 		const { order, translate } = this.props;
 		if ( 'refunded' === order.status ) {
 			return null;
 		} else if ( 'on-hold' === order.status || 'pending' === order.status ) {
-			return (
-				<Button onClick={ this.markAsPaid }>{ translate( 'Mark as Paid' ) }</Button>
-			);
+			return <Button onClick={ this.markAsPaid }>{ translate( 'Mark as Paid' ) }</Button>;
 		}
-		return (
-			<Button onClick={ this.toggleDialog }>{ translate( 'Submit Refund' ) }</Button>
-		);
-	}
+		return <Button onClick={ this.toggleDialog }>{ translate( 'Submit Refund' ) }</Button>;
+	};
 
 	markAsPaid = () => {
 		const { order, siteId } = this.props;
 		this.props.updateOrder( siteId, { ...order, status: 'processing' } );
-	}
+	};
 
 	toggleDialog = () => {
 		this.setState( {
@@ -132,23 +132,25 @@ class OrderPaymentCard extends Component {
 			refundNote: '',
 			showDialog: ! this.state.showDialog,
 		} );
-	}
+	};
 
-	recalculateRefund = ( total ) => {
+	recalculateRefund = total => {
 		this.setState( { refundTotal: total } );
-	}
+	};
 
-	updateNote = ( event ) => {
+	updateNote = event => {
 		this.setState( {
 			refundNote: event.target.value,
 		} );
-	}
+	};
 
 	sendRefund = () => {
 		const { order, paymentMethod, site, translate } = this.props;
 		const maxRefund = parseFloat( order.total ) + this.getRefundedTotal( order );
 		if ( this.state.refundTotal > maxRefund ) {
-			this.setState( { errorMessage: translate( 'Refund must be less than or equal to the order total.' ) } );
+			this.setState( {
+				errorMessage: translate( 'Refund must be less than or equal to the order total.' ),
+			} );
 			return;
 		} else if ( this.state.refundTotal <= 0 ) {
 			this.setState( { errorMessage: translate( 'Refund must be greater than zero.' ) } );
@@ -158,10 +160,10 @@ class OrderPaymentCard extends Component {
 		const refundObj = {
 			amount: this.state.refundTotal + '', // API expects a string
 			reason: this.state.refundNote,
-			api_refund: ( paymentMethod && ( -1 !== paymentMethod.method_supports.indexOf( 'refunds' ) ) ),
+			api_refund: paymentMethod && -1 !== paymentMethod.method_supports.indexOf( 'refunds' ),
 		};
 		this.props.sendRefund( site.ID, order.id, refundObj );
-	}
+	};
 
 	renderCreditCard = () => {
 		const { isPaymentLoading, paymentMethod, translate } = this.props;
@@ -169,11 +171,15 @@ class OrderPaymentCard extends Component {
 			return null;
 		}
 
-		if ( paymentMethod && ( -1 === paymentMethod.method_supports.indexOf( 'refunds' ) ) ) {
+		if ( paymentMethod && -1 === paymentMethod.method_supports.indexOf( 'refunds' ) ) {
 			return (
 				<div className="order-payment__method">
 					<h3>{ translate( 'Manual Refund' ) }</h3>
-					<p>{ translate( 'This payment method doesn\'t support automated refunds and must be submitted manually.' ) }</p>
+					<p>
+						{ translate(
+							"This payment method doesn't support automated refunds and must be submitted manually."
+						) }
+					</p>
 				</div>
 			);
 		}
@@ -184,12 +190,12 @@ class OrderPaymentCard extends Component {
 					{ translate( 'Refunding payment via %(method)s', {
 						args: {
 							method: paymentMethod.title,
-						}
+						},
 					} ) }
 				</h3>
 			</div>
 		);
-	}
+	};
 
 	render() {
 		const { isPaymentLoading, order, site, translate } = this.props;
@@ -208,7 +214,9 @@ class OrderPaymentCard extends Component {
 
 		const dialogButtons = [
 			<Button onClick={ this.toggleDialog }>{ translate( 'Cancel' ) }</Button>,
-			<Button primary onClick={ this.sendRefund } disabled={ isPaymentLoading }>{ translate( 'Refund' ) }</Button>,
+			<Button primary onClick={ this.sendRefund } disabled={ isPaymentLoading }>
+				{ translate( 'Refund' ) }
+			</Button>,
 		];
 
 		return (
@@ -217,18 +225,22 @@ class OrderPaymentCard extends Component {
 					<Gridicon icon="checkmark" />
 					{ this.getPaymentStatus() }
 				</div>
-				<div className="order-payment__action">
-					{ this.getPaymentAction() }
-				</div>
+				<div className="order-payment__action">{ this.getPaymentAction() }</div>
 
 				<Dialog
 					isVisible={ showDialog }
 					onClose={ this.toggleDialog }
 					className={ dialogClass }
 					buttons={ dialogButtons }
-					additionalClassNames="order-payment__dialog woocommerce">
+					additionalClassNames="order-payment__dialog woocommerce"
+				>
 					<h1>{ translate( 'Refund order' ) }</h1>
-					<OrderDetailsTable order={ order } isEditable onChange={ this.recalculateRefund } site={ site } />
+					<OrderDetailsTable
+						order={ order }
+						isEditable
+						onChange={ this.recalculateRefund }
+						site={ site }
+					/>
 					<form className="order-payment__container">
 						<FormLabel className="order-payment__note">
 							{ translate( 'Refund note' ) }
@@ -237,20 +249,27 @@ class OrderPaymentCard extends Component {
 
 						<FormFieldset className="order-payment__details">
 							<FormLabel className="order-payment__amount">
-								<span className="order-payment__amount-label">{ translate( 'Total refund amount' ) }</span>
+								<span className="order-payment__amount-label">
+									{ translate( 'Total refund amount' ) }
+								</span>
 								<div className="order-payment__amount-value">
 									<PriceInput
 										name="refund_total"
 										readOnly
 										currency={ order.currency }
-										value={ refundTotal } />
+										value={ refundTotal }
+									/>
 								</div>
 							</FormLabel>
 
 							{ this.renderCreditCard() }
 						</FormFieldset>
 
-						{ errorMessage && <Notice status="is-error" showDismiss={ false }>{ errorMessage }</Notice> }
+						{ errorMessage && (
+							<Notice status="is-error" showDismiss={ false }>
+								{ errorMessage }
+							</Notice>
+						) }
 					</form>
 				</Dialog>
 			</div>

--- a/client/extensions/woocommerce/app/order/order-payment/index.js
+++ b/client/extensions/woocommerce/app/order/order-payment/index.js
@@ -215,7 +215,7 @@ class OrderPaymentCard extends Component {
 		const dialogButtons = [
 			<Button onClick={ this.toggleDialog }>{ translate( 'Cancel' ) }</Button>,
 			<Button primary onClick={ this.sendRefund } disabled={ isPaymentLoading }>
-				{ translate( 'Refund' ) }
+				{ translate( 'Refund', { context: 'Button to open refund dialog' } ) }
 			</Button>,
 		];
 

--- a/client/extensions/woocommerce/app/orders/index.js
+++ b/client/extensions/woocommerce/app/orders/index.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -29,7 +30,7 @@ function Orders( { className, params, site, translate } ) {
 
 	return (
 		<Main className={ className }>
-			<ActionHeader breadcrumbs={ ( <span>{ translate( 'Orders' ) }</span> ) }>
+			<ActionHeader breadcrumbs={ <span>{ translate( 'Orders' ) }</span> }>
 				{ addButton }
 			</ActionHeader>
 			<OrdersList currentStatus={ params && params.filter } />
@@ -37,8 +38,6 @@ function Orders( { className, params, site, translate } ) {
 	);
 }
 
-export default connect(
-	state => ( {
-		site: getSelectedSiteWithFallback( state ),
-	} )
-)( localize( Orders ) );
+export default connect( state => ( {
+	site: getSelectedSiteWithFallback( state ),
+} ) )( localize( Orders ) );

--- a/client/extensions/woocommerce/app/orders/orders-filter-nav.js
+++ b/client/extensions/woocommerce/app/orders/orders-filter-nav.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -14,23 +15,19 @@ import { getOrdersCurrentSearch } from 'woocommerce/state/ui/orders/selectors';
 import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
 import NavItem from 'components/section-nav/item';
 import NavTabs from 'components/section-nav/tabs';
-import {
-	ORDER_UNPAID,
-	ORDER_UNFULFILLED,
-	ORDER_COMPLETED,
-} from 'woocommerce/lib/order-status';
+import { ORDER_UNPAID, ORDER_UNFULFILLED, ORDER_COMPLETED } from 'woocommerce/lib/order-status';
 import Search from 'components/search';
 import SectionNav from 'components/section-nav';
 import { updateCurrentOrdersQuery } from 'woocommerce/state/ui/orders/actions';
 
 class OrdersFilterNav extends Component {
-	doSearch = ( search ) => {
+	doSearch = search => {
 		this.props.updateCurrentOrdersQuery( this.props.site.ID, { search } );
-	}
+	};
 
 	clearSearch = () => {
 		this.doSearch( '' );
-	}
+	};
 
 	render() {
 		const { translate, site, status } = this.props;
@@ -46,24 +43,25 @@ class OrdersFilterNav extends Component {
 		return (
 			<SectionNav selectedText={ currentSelection }>
 				<NavTabs label={ translate( 'Status' ) } selectedText={ currentSelection }>
-					<NavItem
-						path={ getLink( '/store/orders/:site', site ) }
-						selected={ 'any' === status }>
+					<NavItem path={ getLink( '/store/orders/:site', site ) } selected={ 'any' === status }>
 						{ translate( 'All Orders' ) }
 					</NavItem>
 					<NavItem
 						path={ getLink( `/store/orders/${ ORDER_UNPAID }/:site`, site ) }
-						selected={ ORDER_UNPAID === status }>
+						selected={ ORDER_UNPAID === status }
+					>
 						{ translate( 'Awaiting Payment' ) }
 					</NavItem>
 					<NavItem
 						path={ getLink( `/store/orders/${ ORDER_UNFULFILLED }/:site`, site ) }
-						selected={ ORDER_UNFULFILLED === status }>
+						selected={ ORDER_UNFULFILLED === status }
+					>
 						{ translate( 'Awaiting Fulfillment' ) }
 					</NavItem>
 					<NavItem
 						path={ getLink( `/store/orders/${ ORDER_COMPLETED }/:site`, site ) }
-						selected={ ORDER_COMPLETED === status }>
+						selected={ ORDER_COMPLETED === status }
+					>
 						{ translate( 'Completed' ) }
 					</NavItem>
 				</NavTabs>

--- a/client/extensions/woocommerce/app/orders/orders-list.js
+++ b/client/extensions/woocommerce/app/orders/orders-list.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -18,17 +19,16 @@ import {
 	areOrdersLoading,
 	areOrdersLoaded,
 	getOrders,
-	getTotalOrders
+	getTotalOrders,
 } from 'woocommerce/state/sites/orders/selectors';
 import { getLink } from 'woocommerce/lib/nav-utils';
-import { getOrdersCurrentPage, getOrdersCurrentSearch } from 'woocommerce/state/ui/orders/selectors';
+import {
+	getOrdersCurrentPage,
+	getOrdersCurrentSearch,
+} from 'woocommerce/state/ui/orders/selectors';
 import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
 import humanDate from 'lib/human-date';
-import {
-	ORDER_UNPAID,
-	ORDER_UNFULFILLED,
-	ORDER_COMPLETED,
-} from 'woocommerce/lib/order-status';
+import { ORDER_UNPAID, ORDER_UNFULFILLED, ORDER_COMPLETED } from 'woocommerce/lib/order-status';
 import OrdersFilterNav from './orders-filter-nav';
 import OrderStatus from 'woocommerce/components/order-status';
 import Pagination from 'components/pagination';
@@ -52,12 +52,11 @@ class Orders extends Component {
 	}
 
 	componentWillReceiveProps( newProps ) {
-		const hasAnythingChanged = (
+		const hasAnythingChanged =
 			newProps.currentPage !== this.props.currentPage ||
 			newProps.currentSearch !== this.props.currentSearch ||
 			newProps.currentStatus !== this.props.currentStatus ||
-			newProps.siteId !== this.props.siteId
-		);
+			newProps.siteId !== this.props.siteId;
 		if ( ! newProps.siteId || ! hasAnythingChanged ) {
 			return;
 		}
@@ -78,25 +77,33 @@ class Orders extends Component {
 		this.props.fetchOrders( newProps.siteId, query );
 	}
 
-	clearSearch = ( event ) => {
+	clearSearch = event => {
 		const { site, siteId } = this.props;
 		this.search.closeSearch( event );
 		this.props.updateCurrentOrdersQuery( siteId, { page: 1, search: '' } );
 		page( getLink( '/store/orders/:site', site ) );
-	}
+	};
 
 	renderPlaceholders = () => {
-		return range( 5 ).map( ( i ) => {
+		return range( 5 ).map( i => {
 			return (
 				<TableRow key={ i } className="orders__row-placeholder">
-					<TableItem className="orders__table-name" isRowHeader><span /></TableItem>
-					<TableItem className="orders__table-date"><span /></TableItem>
-					<TableItem className="orders__table-status"><span /></TableItem>
-					<TableItem className="orders__table-total"><span /></TableItem>
+					<TableItem className="orders__table-name" isRowHeader>
+						<span />
+					</TableItem>
+					<TableItem className="orders__table-date">
+						<span />
+					</TableItem>
+					<TableItem className="orders__table-status">
+						<span />
+					</TableItem>
+					<TableItem className="orders__table-total">
+						<span />
+					</TableItem>
 				</TableRow>
 			);
 		} );
-	}
+	};
 
 	renderNoContent = () => {
 		const { currentSearch, currentStatus, site, translate } = this.props;
@@ -104,11 +111,11 @@ class Orders extends Component {
 		if ( currentSearch ) {
 			emptyMessage = translate( 'There are no orders matching your search.' );
 		} else if ( ORDER_UNPAID === currentStatus ) {
-			emptyMessage = translate( 'You don\'t have any orders awaiting payment.' );
+			emptyMessage = translate( "You don't have any orders awaiting payment." );
 		} else if ( ORDER_UNFULFILLED === currentStatus ) {
-			emptyMessage = translate( 'You don\'t have any orders awaiting fulfillment.' );
+			emptyMessage = translate( "You don't have any orders awaiting fulfillment." );
 		} else if ( ORDER_COMPLETED === currentStatus ) {
-			emptyMessage = translate( 'You don\'t have any completed orders.' );
+			emptyMessage = translate( "You don't have any completed orders." );
 		}
 
 		return (
@@ -119,13 +126,16 @@ class Orders extends Component {
 				actionCallback={ this.clearSearch }
 			/>
 		);
-	}
+	};
 
 	renderOrderItem = ( order, i ) => {
 		const { site } = this.props;
 		return (
-			<TableRow className={ 'orders__status-' + order.status } key={ i }
-				href={ getLink( `/store/order/:site/${ order.number }`, site ) }>
+			<TableRow
+				className={ 'orders__status-' + order.status }
+				key={ i }
+				href={ getLink( `/store/order/:site/${ order.number }`, site ) }
+			>
 				<TableItem className="orders__table-name" isRowHeader>
 					<span className="orders__item-link">#{ order.number }</span>
 					<span className="orders__item-name">
@@ -143,36 +153,41 @@ class Orders extends Component {
 				</TableItem>
 			</TableRow>
 		);
-	}
+	};
 
 	renderOrderItems = () => {
 		const { orders, ordersLoading, translate } = this.props;
 
 		const headers = (
 			<TableRow isHeader>
-				<TableItem className="orders__table-name" isHeader>{ translate( 'Order' ) }</TableItem>
-				<TableItem className="orders__table-date" isHeader>{ translate( 'Date' ) }</TableItem>
-				<TableItem className="orders__table-status" isHeader>{ translate( 'Status' ) }</TableItem>
-				<TableItem className="orders__table-total" isHeader>{ translate( 'Total' ) }</TableItem>
+				<TableItem className="orders__table-name" isHeader>
+					{ translate( 'Order' ) }
+				</TableItem>
+				<TableItem className="orders__table-date" isHeader>
+					{ translate( 'Date' ) }
+				</TableItem>
+				<TableItem className="orders__table-status" isHeader>
+					{ translate( 'Status' ) }
+				</TableItem>
+				<TableItem className="orders__table-total" isHeader>
+					{ translate( 'Total' ) }
+				</TableItem>
 			</TableRow>
 		);
 
 		return (
 			<Table className="orders__table" header={ headers } horizontalScroll>
-				{ ordersLoading
-					? this.renderPlaceholders()
-					: orders.map( this.renderOrderItem )
-				}
+				{ ordersLoading ? this.renderPlaceholders() : orders.map( this.renderOrderItem ) }
 			</Table>
 		);
-	}
+	};
 
 	onPageClick = nextPage => {
 		this.props.updateCurrentOrdersQuery( this.props.siteId, {
 			page: nextPage,
 			status: this.props.currentStatus,
 		} );
-	}
+	};
 
 	render() {
 		const {
@@ -182,30 +197,29 @@ class Orders extends Component {
 			orders,
 			ordersLoaded,
 			total,
-			translate
+			translate,
 		} = this.props;
 
 		// Orders are done loading, and there are definitely no orders for this site
 		if ( ordersLoaded && ! total && isDefaultPage ) {
 			return (
 				<div className="orders__container">
-					<EmptyContent
-						title={ translate( 'Your orders will appear here as they come in.' ) }
-					/>
+					<EmptyContent title={ translate( 'Your orders will appear here as they come in.' ) } />
 				</div>
 			);
 		}
 
-		const setSearchRef = ref => this.search = ref;
+		const setSearchRef = ref => ( this.search = ref );
 
 		return (
 			<div className="orders__container">
 				<OrdersFilterNav searchRef={ setSearchRef } status={ currentStatus } />
 
-				{ ( ! ordersLoaded || ( orders && orders.length ) )
-					? this.renderOrderItems()
-					: this.renderNoContent()
-				}
+				{ ! ordersLoaded || ( orders && orders.length ) ? (
+					this.renderOrderItems()
+				) : (
+					this.renderNoContent()
+				) }
 
 				<Pagination
 					page={ currentPage }
@@ -226,7 +240,7 @@ export default connect(
 		const currentSearch = getOrdersCurrentSearch( state, siteId );
 		const currentStatus = props.currentStatus || 'any';
 
-		const isDefaultPage = ( '' === currentSearch && 'any' === currentStatus );
+		const isDefaultPage = '' === currentSearch && 'any' === currentStatus;
 
 		const query = {
 			page: currentPage,

--- a/client/extensions/woocommerce/app/orders/orders-list.js
+++ b/client/extensions/woocommerce/app/orders/orders-list.js
@@ -161,7 +161,7 @@ class Orders extends Component {
 		const headers = (
 			<TableRow isHeader>
 				<TableItem className="orders__table-name" isHeader>
-					{ translate( 'Order' ) }
+					{ translate( 'Order', { context: 'Order list table header' } ) }
 				</TableItem>
 				<TableItem className="orders__table-date" isHeader>
 					{ translate( 'Date' ) }


### PR DESCRIPTION
There are no functionality changes here, I just ran [prettier](https://github.com/Automattic/wp-calypso/issues/12260) across all the `woocommerce/app/orders` and `woocommerce/app/order` files. It seems like Calypso is moving to using prettier everywhere, and I have my editor set to auto-run prettier on save. Rather than continuing to bloat my PRs with changes _and_ prettier formatting, I've put together this PR. If this gets through fast, I'll rebase any other active orders PRs right away.

To generate this PR, I ran:

```
./node_modules/.bin/prettier client/extensions/woocommerce/app/order/**/*.js --write
./node_modules/.bin/prettier client/extensions/woocommerce/app/orders/**/*.js --write
```

To test:

- There are no tests updated by these changes, so you'll have to load up calypso and look at the orders list and single pages. There should be no visual/interaction changes.