### PR TITLE
Try ux_mode redirect for google login

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -75,18 +75,25 @@ class Login extends Component {
 
 	handleValidLogin = redirectTo => {
 		if ( this.props.twoFactorEnabled ) {
-			page( login( {
-				isNative: true,
-				// If no notification is sent, the user is using the authenticator for 2FA by default
-				twoFactorAuthType: this.props.twoFactorNotificationSent.replace( 'none', 'authenticator' ),
-				redirectTo,
-			} ) );
+			page(
+				login( {
+					isNative: true,
+					// If no notification is sent, the user is using the authenticator for 2FA by default
+					twoFactorAuthType: this.props.twoFactorNotificationSent.replace(
+						'none',
+						'authenticator'
+					),
+					redirectTo,
+				} )
+			);
 		} else if ( this.props.isLinking ) {
-			page( login( {
-				isNative: true,
-				socialConnect: true,
-				redirectTo,
-			} ) );
+			page(
+				login( {
+					isNative: true,
+					socialConnect: true,
+					redirectTo,
+				} )
+			);
 		} else {
 			this.rebootAfterLogin( redirectTo );
 		}
@@ -250,7 +257,8 @@ class Login extends Component {
 				onSuccess={ this.handleValidLogin }
 				privateSite={ privateSite }
 				socialService={ socialService }
-				socialServiceResponse={ socialServiceResponse } />
+				socialServiceResponse={ socialServiceResponse }
+			/>
 		);
 	}
 

--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -73,27 +73,22 @@ class Login extends Component {
 		}
 	};
 
-	handleValidLogin = () => {
+	handleValidLogin = redirectTo => {
 		if ( this.props.twoFactorEnabled ) {
-			page(
-				login( {
-					isNative: true,
-					// If no notification is sent, the user is using the authenticator for 2FA by default
-					twoFactorAuthType: this.props.twoFactorNotificationSent.replace(
-						'none',
-						'authenticator'
-					),
-				} )
-			);
+			page( login( {
+				isNative: true,
+				// If no notification is sent, the user is using the authenticator for 2FA by default
+				twoFactorAuthType: this.props.twoFactorNotificationSent.replace( 'none', 'authenticator' ),
+				redirectTo,
+			} ) );
 		} else if ( this.props.isLinking ) {
-			page(
-				login( {
-					isNative: true,
-					socialConnect: true,
-				} )
-			);
+			page( login( {
+				isNative: true,
+				socialConnect: true,
+				redirectTo,
+			} ) );
 		} else {
-			this.rebootAfterLogin();
+			this.rebootAfterLogin( redirectTo );
 		}
 	};
 
@@ -110,8 +105,8 @@ class Login extends Component {
 		}
 	};
 
-	rebootAfterLogin = () => {
-		const { redirectTo } = this.props;
+	rebootAfterLogin = redirectTo => {
+		redirectTo = redirectTo || this.props.redirectTo;
 
 		this.props.recordTracksEvent( 'calypso_login_success', {
 			two_factor_enabled: this.props.twoFactorEnabled,

--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -51,6 +51,8 @@ class Login extends Component {
 		socialConnect: PropTypes.bool,
 		isLinking: PropTypes.bool,
 		linkingSocialService: PropTypes.string,
+		socialService: PropTypes.string,
+		socialServiceResponse: PropTypes.object,
 	};
 
 	componentDidMount = () => {
@@ -214,6 +216,8 @@ class Login extends Component {
 			twoFactorEnabled,
 			twoFactorNotificationSent,
 			socialConnect,
+			socialService,
+			socialServiceResponse,
 		} = this.props;
 
 		let poller;
@@ -246,7 +250,13 @@ class Login extends Component {
 			return <SocialConnectPrompt onSuccess={ this.handleValidLogin } />;
 		}
 
-		return <LoginForm onSuccess={ this.handleValidLogin } privateSite={ privateSite } />;
+		return (
+			<LoginForm
+				onSuccess={ this.handleValidLogin }
+				privateSite={ privateSite }
+				socialService={ socialService }
+				socialServiceResponse={ socialServiceResponse } />
+		);
 	}
 
 	render() {

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -124,16 +124,19 @@ export class LoginForm extends Component {
 
 		this.props.recordTracksEvent( 'calypso_login_block_login_form_submit' );
 
-		this.props.loginUser( usernameOrEmail, password, rememberMe, redirectTo ).then( () => {
-			this.props.recordTracksEvent( 'calypso_login_block_login_form_success' );
+		this.props
+			.loginUser( usernameOrEmail, password, rememberMe, redirectTo )
+			.then( () => {
+				this.props.recordTracksEvent( 'calypso_login_block_login_form_success' );
 
-			onSuccess( redirectTo );
-		} ).catch( error => {
-			this.props.recordTracksEvent( 'calypso_login_block_login_form_failure', {
-				error_code: error.code,
-				error_message: error.message
+				onSuccess( redirectTo );
+			} )
+			.catch( error => {
+				this.props.recordTracksEvent( 'calypso_login_block_login_form_failure', {
+					error_code: error.code,
+					error_message: error.message,
+				} );
 			} );
-		} );
 	};
 
 	savePasswordRef = input => {
@@ -307,7 +310,8 @@ export class LoginForm extends Component {
 							socialServiceResponse={ this.props.socialServiceResponse }
 							linkingSocialService={
 								this.props.socialAccountIsLinking ? this.props.socialAccountLinkService : null
-							} />
+							}
+						/>
 					</Card>
 				) }
 			</form>

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -124,19 +124,16 @@ export class LoginForm extends Component {
 
 		this.props.recordTracksEvent( 'calypso_login_block_login_form_submit' );
 
-		this.props
-			.loginUser( usernameOrEmail, password, rememberMe, redirectTo )
-			.then( () => {
-				this.props.recordTracksEvent( 'calypso_login_block_login_form_success' );
+		this.props.loginUser( usernameOrEmail, password, rememberMe, redirectTo ).then( () => {
+			this.props.recordTracksEvent( 'calypso_login_block_login_form_success' );
 
-				onSuccess();
-			} )
-			.catch( error => {
-				this.props.recordTracksEvent( 'calypso_login_block_login_form_failure', {
-					error_code: error.code,
-					error_message: error.message,
-				} );
+			onSuccess( redirectTo );
+		} ).catch( error => {
+			this.props.recordTracksEvent( 'calypso_login_block_login_form_failure', {
+				error_code: error.code,
+				error_message: error.message
 			} );
+		} );
 	};
 
 	savePasswordRef = input => {

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -54,6 +54,8 @@ export class LoginForm extends Component {
 		translate: PropTypes.func.isRequired,
 		isFormDisabled: PropTypes.bool,
 		oauth2Client: PropTypes.object,
+		socialService: PropTypes.string,
+		socialServiceResponse: PropTypes.object,
 	};
 
 	state = {
@@ -304,10 +306,11 @@ export class LoginForm extends Component {
 					<Card className="login__form-social">
 						<SocialLoginForm
 							onSuccess={ this.props.onSuccess }
+							socialService={ this.props.socialService }
+							socialServiceResponse={ this.props.socialServiceResponse }
 							linkingSocialService={
 								this.props.socialAccountIsLinking ? this.props.socialAccountLinkService : null
-							}
-						/>
+							} />
 					</Card>
 				) }
 			</form>

--- a/client/blocks/login/social.jsx
+++ b/client/blocks/login/social.jsx
@@ -71,32 +71,33 @@ class SocialLoginForm extends Component {
 			id_token: response.Zi.id_token,
 		};
 
-		this.props.loginSocialUser( socialInfo, redirectTo ).then(
-			() => {
-				this.recordEvent( 'calypso_login_social_login_success' );
+		this.props.loginSocialUser( socialInfo, redirectTo )
+			.then(
+				() => {
+					this.recordEvent( 'calypso_login_social_login_success' );
 
-				onSuccess();
-			},
-			error => {
-				if ( error.code === 'unknown_user' ) {
-					return this.props.createSocialUser( socialInfo, 'login' ).then(
-						() => this.recordEvent( 'calypso_login_social_signup_success' ),
-						createAccountError =>
-							this.recordEvent( 'calypso_login_social_signup_failure', {
-								error_code: createAccountError.code,
-								error_message: createAccountError.message,
-							} )
-					);
-				} else if ( error.code === 'user_exists' ) {
-					this.props.createSocialUserFailed( 'google', response.Zi.id_token, error );
+					onSuccess( redirectTo );
+				},
+				error => {
+					if ( error.code === 'unknown_user' ) {
+						return this.props.createSocialUser( socialInfo, 'login' )
+							.then(
+								() => this.recordEvent( 'calypso_login_social_signup_success' ),
+								createAccountError => this.recordEvent( 'calypso_login_social_signup_failure', {
+									error_code: createAccountError.code,
+									error_message: createAccountError.message
+								} )
+							);
+					} else if ( error.code === 'user_exists' ) {
+						this.props.createSocialUserFailed( 'google', response.Zi.id_token, error );
+					}
+
+					this.recordEvent( 'calypso_login_social_login_failure', {
+						error_code: error.code,
+						error_message: error.message
+					} );
 				}
-
-				this.recordEvent( 'calypso_login_social_login_failure', {
-					error_code: error.code,
-					error_message: error.message,
-				} );
-			}
-		);
+			);
 	};
 
 	recordEvent = ( eventName, params ) =>

--- a/client/blocks/login/social.jsx
+++ b/client/blocks/login/social.jsx
@@ -27,23 +27,17 @@ import WpcomLoginForm from 'signup/wpcom-login-form';
 import { InfoNotice } from 'blocks/global-notice';
 import { login } from 'lib/paths';
 
-function isLocalStorageFunctional() {
-	try {
-		window.localStorage.setItem( '__test_localStorage', 1 );
-		window.localStorage.removeItem( '__test_localStorage' );
-		return true;
-	} catch ( error ) {
-		return false;
-	}
+function isSafari() {
+	return typeof window !== 'undefined' && window.navigator.userAgent.match( /safari/i );
 }
 
 function shouldUseRedirectFlow() {
 	// If calypso is loaded in a popup, we don't want to open a second popup for social login
 	// let's use the redirect flow instead in that case
 	const isPopup = typeof window !== 'undefined' && window.opener && window.opener !== window;
-	// also disable the popup flow for old versions of safari private browsing (<v11)
+	// also disable the popup flow for all safari versions
 	// See https://github.com/google/google-api-javascript-client/issues/297#issuecomment-333869742
-	return isPopup || ! isLocalStorageFunctional();
+	return isPopup || isSafari();
 }
 
 class SocialLoginForm extends Component {

--- a/client/blocks/login/social.jsx
+++ b/client/blocks/login/social.jsx
@@ -122,8 +122,10 @@ class SocialLoginForm extends Component {
 	}
 
 	render() {
-		const isPopup = window.opener && window.opener !== window;
-		const redirectUri = isPopup ? login( { isNative: true, socialService: 'google' } ) : null;
+		const { redirectTo } = this.props;
+		const isPopup = typeof window !== 'undefined' && window.opener && window.opener !== window;
+		const loginCallbackRoute = login( { isNative: true, socialService: 'google' } );
+		const redirectUri = isPopup ? `https://${ config( 'hostname' ) + loginCallbackRoute }` : null;
 
 		return (
 			<div className="login__social">
@@ -146,7 +148,7 @@ class SocialLoginForm extends Component {
 					<WpcomLoginForm
 						log={ this.props.username }
 						authorization={ 'Bearer ' + this.props.bearerToken }
-						redirectTo={ this.props.redirectTo || '/start' }
+						redirectTo={ redirectTo || '/start' }
 					/>
 				) }
 			</div>

--- a/client/blocks/login/social.jsx
+++ b/client/blocks/login/social.jsx
@@ -134,6 +134,8 @@ class SocialLoginForm extends Component {
 
 	render() {
 		const { redirectTo } = this.props;
+		// If calypso is loaded in a popup, we don't want to open a second popup for social login
+		// let's use the redirect flow instead in that case.
 		const isPopup = typeof window !== 'undefined' && window.opener && window.opener !== window;
 		const loginCallbackRoute = login( { isNative: true, socialService: 'google' } );
 		const redirectUri = isPopup ? `https://${ config( 'hostname' ) + loginCallbackRoute }` : null;

--- a/client/blocks/login/social.jsx
+++ b/client/blocks/login/social.jsx
@@ -108,7 +108,9 @@ class SocialLoginForm extends Component {
 	trackGoogleLogin = () => {
 		this.recordEvent( 'calypso_login_social_button_click' );
 
-		window.sessionStorage.setItem( 'login_redirect_to', this.props.redirectTo );
+		if ( this.props.redirectTo ) {
+			window.sessionStorage.setItem( 'login_redirect_to', this.props.redirectTo );
+		}
 	};
 
 	renderText() {

--- a/client/blocks/login/social.jsx
+++ b/client/blocks/login/social.jsx
@@ -35,16 +35,24 @@ class SocialLoginForm extends Component {
 		translate: PropTypes.func.isRequired,
 		loginSocialUser: PropTypes.func.isRequired,
 		linkingSocialService: PropTypes.string,
+		socialService: PropTypes.string,
+		socialServiceResponse: PropTypes.object,
 	};
 
 	static defaultProps = {
 		linkingSocialService: '',
 	};
 
-	handleGoogleResponse = response => {
-		const { onSuccess, redirectTo } = this.props;
+	handleGoogleResponse = ( response, triggeredByUser = true ) => {
+		const { onSuccess, redirectTo, socialService } = this.props;
 
 		if ( ! response.Zi || ! response.Zi.access_token || ! response.Zi.id_token ) {
+			return;
+		}
+
+		// ignore response if the user did not click on the google button
+		// and did not follow the redirect flow
+		if ( ! triggeredByUser && socialService !== 'google' ) {
 			return;
 		}
 

--- a/client/blocks/login/social.jsx
+++ b/client/blocks/login/social.jsx
@@ -25,6 +25,7 @@ import {
 import { recordTracksEvent } from 'state/analytics/actions';
 import WpcomLoginForm from 'signup/wpcom-login-form';
 import { InfoNotice } from 'blocks/global-notice';
+import { login } from 'lib/paths';
 
 class SocialLoginForm extends Component {
 	static propTypes = {
@@ -121,6 +122,9 @@ class SocialLoginForm extends Component {
 	}
 
 	render() {
+		const isPopup = window.opener && window.opener !== window;
+		const redirectUri = isPopup ? login( { isNative: true, socialService: 'google' } ) : null;
+
 		return (
 			<div className="login__social">
 				{ this.renderText() }
@@ -129,6 +133,7 @@ class SocialLoginForm extends Component {
 					<GoogleLoginButton
 						clientId={ config( 'google_oauth_client_id' ) }
 						responseHandler={ this.handleGoogleResponse }
+						redirectUri={ redirectUri }
 						onClick={ this.trackGoogleLogin }
 					/>
 				</div>

--- a/client/blocks/login/social.jsx
+++ b/client/blocks/login/social.jsx
@@ -45,7 +45,8 @@ class SocialLoginForm extends Component {
 	};
 
 	handleGoogleResponse = ( response, triggeredByUser = true ) => {
-		const { onSuccess, redirectTo, socialService } = this.props;
+		const { onSuccess, socialService } = this.props;
+		let redirectTo = this.props.redirectTo;
 
 		if ( ! response.Zi || ! response.Zi.access_token || ! response.Zi.id_token ) {
 			return;
@@ -56,6 +57,13 @@ class SocialLoginForm extends Component {
 		if ( ! triggeredByUser && socialService !== 'google' ) {
 			return;
 		}
+
+		// load persisted redirect_to url from session storage, needed for redirect_to to work with google redirect flow
+		if ( ! triggeredByUser && ! redirectTo ) {
+			redirectTo = window.sessionStorage.getItem( 'login_redirect_to' );
+		}
+
+		window.sessionStorage.removeItem( 'login_redirect_to' );
 
 		const socialInfo = {
 			service: 'google',
@@ -99,6 +107,8 @@ class SocialLoginForm extends Component {
 
 	trackGoogleLogin = () => {
 		this.recordEvent( 'calypso_login_social_button_click' );
+
+		window.sessionStorage.setItem( 'login_redirect_to', this.props.redirectTo );
 	};
 
 	renderText() {

--- a/client/components/signup-form/social.jsx
+++ b/client/components/signup-form/social.jsx
@@ -22,8 +22,13 @@ class SocialSignupForm extends Component {
 		translate: PropTypes.func.isRequired,
 	};
 
-	handleGoogleResponse = response => {
+	handleGoogleResponse = ( response, triggeredByUser = true ) => {
 		if ( ! response.Zi || ! response.Zi.access_token || ! response.Zi.id_token ) {
+			return;
+		}
+
+		if ( ! triggeredByUser ) {
+			// TODO: handle social signup for the redirect flow
 			return;
 		}
 

--- a/client/components/social-buttons/google.js
+++ b/client/components/social-buttons/google.js
@@ -80,29 +80,33 @@ class GoogleLoginButton extends Component {
 		const { translate } = this.props;
 
 		this.initialized = this.loadDependency()
-			.then( gapi => new Promise( resolve => gapi.load( 'client:auth2', resolve ) ).then( () => gapi ) )
 			.then( gapi =>
-				gapi.client.init( {
-					client_id: this.props.clientId,
-					scope: this.props.scope,
-					fetch_basic_profile: this.props.fetchBasicProfile,
-					ux_mode: this.props.redirectUri ? 'redirect' : 'popup',
-					redirect_uri: this.props.redirectUri,
-				} )
-				.then( () => {
-					this.setState( { isDisabled: false } );
+				new Promise( resolve => gapi.load( 'client:auth2', resolve ) ).then( () => gapi )
+			)
+			.then( gapi =>
+				gapi.client
+					.init( {
+						client_id: this.props.clientId,
+						scope: this.props.scope,
+						fetch_basic_profile: this.props.fetchBasicProfile,
+						ux_mode: this.props.redirectUri ? 'redirect' : 'popup',
+						redirect_uri: this.props.redirectUri,
+					} )
+					.then( () => {
+						this.setState( { isDisabled: false } );
 
-					const googleAuth = gapi.auth2.getAuthInstance();
-					const currentUser = googleAuth.currentUser.get();
+						const googleAuth = gapi.auth2.getAuthInstance();
+						const currentUser = googleAuth.currentUser.get();
 
-					// handle social authentication response from a redirect-based oauth2 flow
-					if ( currentUser ) {
-						this.props.responseHandler( currentUser, false );
-					}
+						// handle social authentication response from a redirect-based oauth2 flow
+						if ( currentUser ) {
+							this.props.responseHandler( currentUser, false );
+						}
 
-					return gapi; // don't try to return googleAuth here, it's a thenable but not a valid promise
-				} )
-			).catch( error => {
+						return gapi; // don't try to return googleAuth here, it's a thenable but not a valid promise
+					} )
+			)
+			.catch( error => {
 				this.initialized = null;
 
 				if ( 'idpiframe_initialization_failed' === error.error ) {

--- a/client/components/social-buttons/google.js
+++ b/client/components/social-buttons/google.js
@@ -86,8 +86,8 @@ class GoogleLoginButton extends Component {
 					client_id: this.props.clientId,
 					scope: this.props.scope,
 					fetch_basic_profile: this.props.fetchBasicProfile,
-					ux_mode: 'redirect',
-					redirect_uri: 'https://wordpress.com/log-in/google/callback'
+					ux_mode: this.props.redirectUri ? 'redirect' : 'popup',
+					redirect_uri: this.props.redirectUri,
 				} )
 				.then( () => {
 					this.setState( { isDisabled: false } );

--- a/client/lib/paths/login/index.js
+++ b/client/lib/paths/login/index.js
@@ -8,13 +8,23 @@ import { addQueryArgs } from 'lib/url';
 import { addLocaleToPath, addLocaleToWpcomUrl } from 'lib/i18n-utils';
 import config, { isEnabled } from 'config';
 
-export function login(
-	{ isNative, locale, redirectTo, twoFactorAuthType, socialConnect, emailAddress } = {}
-) {
+export function login( {
+	isNative,
+	locale,
+	redirectTo,
+	twoFactorAuthType,
+	socialConnect,
+	emailAddress,
+	socialService,
+} = {} ) {
 	let url = config( 'login_url' );
 
 	if ( isNative && isEnabled( 'login/wp-login' ) ) {
 		url = '/log-in';
+
+		if ( socialService ) {
+			url += '/' + socialService + '/callback';
+		}
 
 		if ( twoFactorAuthType ) {
 			url += '/' + twoFactorAuthType;

--- a/client/lib/paths/login/index.js
+++ b/client/lib/paths/login/index.js
@@ -8,15 +8,17 @@ import { addQueryArgs } from 'lib/url';
 import { addLocaleToPath, addLocaleToWpcomUrl } from 'lib/i18n-utils';
 import config, { isEnabled } from 'config';
 
-export function login( {
-	isNative,
-	locale,
-	redirectTo,
-	twoFactorAuthType,
-	socialConnect,
-	emailAddress,
-	socialService,
-} = {} ) {
+export function login(
+	{
+		isNative,
+		locale,
+		redirectTo,
+		twoFactorAuthType,
+		socialConnect,
+		emailAddress,
+		socialService,
+	} = {}
+) {
 	let url = config( 'login_url' );
 
 	if ( isNative && isEnabled( 'login/wp-login' ) ) {

--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -19,7 +19,7 @@ import { fetchOAuth2ClientData } from 'state/oauth2-clients/actions';
 import { recordTracksEvent } from 'state/analytics/actions';
 
 const enhanceContextWithLogin = context => {
-	const { lang, path, params: { flow, twoFactorAuthType } } = context;
+	const { lang, path, params: { flow, twoFactorAuthType, socialService } } = context;
 
 	context.cacheQueryKeys = [ 'client_id' ];
 
@@ -28,6 +28,8 @@ const enhanceContextWithLogin = context => {
 			locale={ lang }
 			path={ path }
 			twoFactorAuthType={ twoFactorAuthType }
+			socialService={ socialService }
+			socialServiceResponse={ context.hash }
 			socialConnect={ flow === 'social-connect' }
 			privateSite={ flow === 'private-site' }
 		/>

--- a/client/login/index.web.js
+++ b/client/login/index.web.js
@@ -21,6 +21,7 @@ export default router => {
 			[
 				'/log-in/:twoFactorAuthType(authenticator|backup|sms|push)/:lang?',
 				'/log-in/:flow(social-connect|private-site)/:lang?',
+				'/log-in/:socialService(google)/callback/:lang?',
 				'/log-in/:lang?',
 			],
 			setUpLocale,

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -38,6 +38,8 @@ export class Login extends React.Component {
 		translate: PropTypes.func.isRequired,
 		twoFactorAuthType: PropTypes.string,
 		socialConnect: PropTypes.bool,
+		socialService: PropTypes.string,
+		socialServiceResponse: PropTypes.object,
 	};
 
 	componentDidMount() {
@@ -135,6 +137,8 @@ export class Login extends React.Component {
 			privateSite,
 			socialConnect,
 			twoFactorAuthType,
+			socialService,
+			socialServiceResponse,
 		} = this.props;
 
 		if ( privateSite && isLoggedIn ) {
@@ -148,6 +152,8 @@ export class Login extends React.Component {
 				privateSite={ privateSite }
 				clientId={ clientId }
 				oauth2Client={ oauth2Client }
+				socialService={ socialService }
+				socialServiceResponse={ socialServiceResponse }
 			/>
 		);
 	}


### PR DESCRIPTION
This PR adds the possibility of using the redirect oauth2 flow (instead of the popup flow) for google login/signup.

### Testing Instructions
- Navigate to https://calypso.live/log-in?branch=add/social-login-redirect
- Click on the `Connect with Google` button and assert that you are redirected to google oauth page for wordpress
- Give your consent and assert that you are brought back to https://calypso.live/log-in/google/callback
- Now it should act exactly as if you just completed the popup flow
- Try the same flow with a `redirect_to` parameter. For instance: https://calypso.live/log-in?redirect_to=%2Fthemes and assert that you are redirected to `/themes` after signing in.

### Reviews
- [x] Code
- [x] Product