### PR TITLE
Add view site button on thank you page

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/header.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/header.jsx
@@ -4,6 +4,7 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
@@ -17,6 +18,7 @@ import {
 	isPlan,
 	isSiteRedirect
 } from 'lib/products-values';
+import { recordTracksEvent } from 'state/analytics/actions';
 import { localize } from 'i18n-calypso';
 
 class CheckoutThankYouHeader extends PureComponent {
@@ -138,6 +140,32 @@ class CheckoutThankYouHeader extends PureComponent {
 		);
 	}
 
+	visitSite = ( event ) => {
+		event.preventDefault();
+
+		const { primaryPurchase, selectedSite } = this.props;
+
+		this.props.recordTracksEvent( 'calypso_thank_you_view_site', { product: primaryPurchase.productName } );
+		window.location.href = selectedSite.URL;
+	}
+
+	getButton() {
+		const { translate, primaryPurchase } = this.props;
+		const headerButtonClassName = 'button is-primary';
+
+		if ( isPlan( primaryPurchase ) ) {
+			return (
+				<div className="checkout-thank-you__header-button" >
+					<button className={ headerButtonClassName } onClick={ this.visitSite }>
+						{ translate( 'View your site' ) }
+					</button>
+				</div>
+			);
+		}
+
+		return null;
+	}
+
 	render() {
 		const { isDataLoaded, hasFailedPurchases } = this.props;
 		const classes = { 'is-placeholder': ! isDataLoaded };
@@ -156,6 +184,8 @@ class CheckoutThankYouHeader extends PureComponent {
 						<h2 className="checkout-thank-you__header-text">
 							{ this.getText() }
 						</h2>
+
+						{ this.getButton() }
 					</div>
 				</div>
 			</div>
@@ -163,4 +193,9 @@ class CheckoutThankYouHeader extends PureComponent {
 	}
 }
 
-export default localize( CheckoutThankYouHeader );
+export default connect(
+	null,
+	{
+		recordTracksEvent,
+	}
+)( localize( CheckoutThankYouHeader ) );

--- a/client/my-sites/checkout/checkout-thank-you/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/style.scss
@@ -132,6 +132,10 @@
 	clear: none;
 }
 
+.checkout-thank-you__header-button {
+	margin: 2em 0;
+}
+
 .checkout-thank-you__header-heading {
 	font-size: 24px;
 	font-weight: 400;


### PR DESCRIPTION
When you purchase a plan for a new site on an existing account, you are shown a different thank you page than if you purchase a plan when you create your account. The former is missing a view your site link/button. This PR adds a "view your site" button to the thank you page after a plan is purchased.

**Test purchasing a plan: See button**
- Visit /start with an existing account
- Purchase a plan
- Press View your site. You should see your site

**Test purchasing another product: Don't see button**
- Buy a domain for an existing site
- You shouldn't see a view your site button on the thank you page

**Before**
![screen shot 2017-10-03 at 8 06 45 am](https://user-images.githubusercontent.com/6981253/31124286-d2de8cd8-a811-11e7-8d44-122d6a8dcfed.png)



**After**
![screen shot 2017-10-02 at 10 57 29 pm](https://user-images.githubusercontent.com/6981253/31108252-03ceac52-a7c6-11e7-82cc-6d0c55689dda.png)

cc @markryall @taggon @dzver 

