### PR TITLE
Atomic store: put back Pressable flow behind an abtest

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -17,6 +17,14 @@ module.exports = {
 		},
 		defaultVariation: 'hideSurveyStep',
 	},
+	signupPressableStoreFlow: {
+		datestamp: '20171018',
+		variations: {
+			atomic: 99,
+			pressable: 1,
+		},
+		defaultVariation: 'atomic',
+	},
 	businessPlanDescriptionAT: {
 		datestamp: '20170605',
 		variations: {

--- a/client/signup/steps/design-type-with-atomic-store/index.jsx
+++ b/client/signup/steps/design-type-with-atomic-store/index.jsx
@@ -30,15 +30,8 @@ import { DESIGN_TYPE_STORE } from 'signup/constants';
 import PressableStoreStep from '../design-type-with-store/pressable-store';
 
 class DesignTypeWithAtomicStoreStep extends Component {
-	constructor( props ) {
-		super( props );
-
-		this.state = {
-			showStore: false,
-		};
-
-		this.setPressableStore = this.setPressableStore.bind( this );
-	}
+	state = { showStore: false };
+	setPressableStore = ref => ( this.pressableStore = ref );
 
 	getChoices() {
 		const { translate } = this.props;
@@ -175,10 +168,6 @@ class DesignTypeWithAtomicStoreStep extends Component {
 				</div>
 			</div>
 		);
-	}
-
-	setPressableStore( ref ) {
-		this.pressableStore = ref;
 	}
 
 	getHeaderText() {

--- a/client/signup/steps/design-type-with-atomic-store/index.jsx
+++ b/client/signup/steps/design-type-with-atomic-store/index.jsx
@@ -101,7 +101,10 @@ class DesignTypeWithAtomicStoreStep extends Component {
 
 		this.props.recordTracksEvent( 'calypso_triforce_select_design', { category: designType } );
 
-		if ( designType === DESIGN_TYPE_STORE ) {
+		if (
+			abtest( 'signupPressableStoreFlow' ) === 'pressable' &&
+			designType === DESIGN_TYPE_STORE
+		) {
 			this.scrollUp();
 
 			this.setState( {


### PR DESCRIPTION
@apeatling asked us if we can add back the Pressable 'store' signup flow (so that you are redirected to Pressable signup flow when selecting the 'store' design type) and put it behind a 1% abtest. This PR implements that.

## Testing

Start with the `/start/atomic-store` signup flow. Select the 'pressable' option from the ABTESTS menu and click on the 'store' design type. Verify that it shows the Pressable + WOO screen with email address input and that if you input your email and click on 'Get started on Pressable', it works properly.

Then, select the 'atomic' option from the ABTESTS menu and click on the 'store' design type. It should take you through the 'domain', 'business-only' etc signup flow.

## Notes

I put the start date of the `signupPressableStoreFlow` to be 10/18/17. It means that if we deploy before that date, it should always default to the 'atomic' option. After that date, it should assign 1% customers to the 'pressable' option and the rest to the 'atomic' option.

/cc @jhnstn to confirm if my logic is okay. Also, this is still in the `/start/atomic-store` signup flow so we are not modifying the original flow which is running on prod right now.