### PR TITLE
Jetpack Plans: Start with some progress in Thank You page

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/jetpack-thank-you-card.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/jetpack-thank-you-card.jsx
@@ -613,7 +613,8 @@ class JetpackThankYouCard extends Component {
 				return total += 1;
 			}, 0 );
 
-		return Math.ceil( completed / features.length * 100 );
+		// We're intentionally showing at least 10% progress to indicate that setup has started.
+		return Math.max( 10, Math.ceil( completed / features.length * 100 ) );
 	}
 
 	renderAction( progress = 0 ) {


### PR DESCRIPTION
This PR updates the Jetpack Plans Thank You page to always start with at least 10% of progress. This way it will be more intuitive for users in case of a delay with the first step, because there will be the sense that the setup process is already in progress.

Before:
![](https://cldup.com/H3NWctPMG3.png)

After:
![](https://cldup.com/EmYKtdaUx5.png)

Fixes #13585.

To test:
* Checkout this branch, or get it going on calypso.live.
* Buy a plan for one of your Jetpack sites
* Reach the thank you page
* Verify you can see the progress bar and it's at 10% before it starts increasing.