### PR TITLE
Framework: Remove i18n mixin injections from tests

### DIFF
--- a/client/my-sites/domains/domain-management/edit/test/mapped-domain.js
+++ b/client/my-sites/domains/domain-management/edit/test/mapped-domain.js
@@ -3,15 +3,19 @@ jest.mock( 'lib/analytics', () => {} );
 /**
  * External dependencies
  */
+import React from 'react';
+import TestUtils from 'react-addons-test-utils';
 import assert from 'assert';
 import sinon from 'sinon';
 import { identity } from 'lodash';
 
+/**
+ * External dependencies
+ */
+import { MappedDomain } from '../mapped-domain.jsx';
+
 describe( 'mapped-domain', () => {
-	let React,
-		MappedDomain,
-		props,
-		TestUtils;
+	let props;
 
 	before( () => {
 		props = {
@@ -26,15 +30,6 @@ describe( 'mapped-domain', () => {
 			settingPrimaryDomain: false,
 			translate: identity
 		};
-	} );
-
-	before( () => {
-		React = require( 'react' );
-		TestUtils = require( 'react-addons-test-utils' );
-
-		const ReactClass = require( 'react/lib/ReactClass' );
-		ReactClass.injection.injectMixin( require( 'i18n-calypso' ).mixin );
-		MappedDomain = require( '../mapped-domain.jsx' ).MappedDomain;
 	} );
 
 	it( 'should render when props.domain.expirationMoment is null', () => {

--- a/client/my-sites/domains/domain-management/edit/test/mapped-domain.js
+++ b/client/my-sites/domains/domain-management/edit/test/mapped-domain.js
@@ -10,7 +10,7 @@ import sinon from 'sinon';
 import { identity } from 'lodash';
 
 /**
- * External dependencies
+ * Internal dependencies
  */
 import { MappedDomain } from '../mapped-domain.jsx';
 

--- a/client/my-sites/domains/domain-management/list/test/index.js
+++ b/client/my-sites/domains/domain-management/list/test/index.js
@@ -9,6 +9,9 @@ jest.mock( 'lib/wp', () => ( {
 /**
  * External dependencies
  */
+import React from 'react';
+import ReactDom from 'react-dom';
+import TestUtils from 'react-addons-test-utils';
 import deepFreeze from 'deep-freeze';
 import assert from 'assert';
 import { Provider as ReduxProvider } from 'react-redux';
@@ -19,30 +22,17 @@ import { Provider as ReduxProvider } from 'react-redux';
 import { createReduxStore } from 'state';
 import { useSandbox } from 'test/helpers/use-sinon';
 
+import {
+	PRIMARY_DOMAIN_CHANGE_SUCCESS,
+	PRIMARY_DOMAIN_CHANGE_FAIL,
+} from '../constants';
+import { List as DomainList } from '../';
+
 describe( 'index', function() {
-	let React,
-		ReactDom,
-		ReactClass,
-		DomainList,
-		TestUtils,
-		noticeTypes,
-		component,
+	let component,
 		sandbox;
 
 	useSandbox( newSandbox => sandbox = newSandbox );
-
-	before( () => {
-		React = require( 'react' );
-		ReactDom = require( 'react-dom' );
-		TestUtils = require( 'react-addons-test-utils' );
-
-		noticeTypes = require( '../constants' );
-
-		ReactClass = require( 'react/lib/ReactClass' );
-		ReactClass.injection.injectMixin( require( 'i18n-calypso' ).mixin );
-
-		DomainList = require( '../' ).List;
-	} );
 
 	const selectedSite = deepFreeze( {
 		slug: 'example.com',
@@ -164,7 +154,7 @@ describe( 'index', function() {
 					setTimeout( () => {
 						assert( ! component.state.settingPrimaryDomain, 'Setting Primary Domain should be false' );
 						assert( ! component.changePrimaryDomainModeEnabled );
-						assert.equal( component.state.notice.type, noticeTypes.PRIMARY_DOMAIN_CHANGE_SUCCESS );
+						assert.equal( component.state.notice.type, PRIMARY_DOMAIN_CHANGE_SUCCESS );
 						assert.equal( component.state.notice.previousDomainName, defaultProps.domains.list[ 1 ].name );
 						done();
 					}, 0 );
@@ -177,7 +167,7 @@ describe( 'index', function() {
 						assert( ! component.state.settingPrimaryDomain );
 						assert( component.state.changePrimaryDomainModeEnabled );
 						assert.equal( component.state.primaryDomainIndex, 1 );
-						assert.equal( component.state.notice.type, noticeTypes.PRIMARY_DOMAIN_CHANGE_FAIL );
+						assert.equal( component.state.notice.type, PRIMARY_DOMAIN_CHANGE_FAIL );
 						done();
 					}, 0 );
 				} );

--- a/client/my-sites/plugins/plugin-autoupdate-toggle/test/index.jsx
+++ b/client/my-sites/plugins/plugin-autoupdate-toggle/test/index.jsx
@@ -1,7 +1,6 @@
 /** @jest-environment jsdom */
 jest.mock( 'my-sites/plugins/plugin-action/plugin-action', () => require( './mocks/plugin-action' ) );
 jest.mock( 'lib/plugins/actions', () => require( './mocks/actions' ) );
-jest.mock( 'matches-selector', () => require( 'component-matches-selector' ), { virtual: true } );
 jest.mock( 'query', () => require( 'component-query' ), { virtual: true } );
 
 /**

--- a/client/my-sites/plugins/plugins-list/test/index.jsx
+++ b/client/my-sites/plugins/plugins-list/test/index.jsx
@@ -12,7 +12,6 @@ jest.mock( 'lib/wp', () => ( {
 } ) );
 jest.mock( 'my-sites/plugins/plugin-item/plugin-item', () => require( 'components/empty-component' ) );
 jest.mock( 'my-sites/plugins/plugin-list-header', () => require( 'components/empty-component' ) );
-jest.mock( 'matches-selector', () => require( 'component-matches-selector' ), { virtual: true } );
 jest.mock( 'query', () => require( 'component-query' ), { virtual: true } );
 
 /**

--- a/client/my-sites/plugins/plugins-list/test/index.jsx
+++ b/client/my-sites/plugins/plugins-list/test/index.jsx
@@ -34,12 +34,6 @@ import { PluginsList } from '../';
 import { sites } from './fixtures';
 
 describe( 'PluginsList', () => {
-	before( () => {
-		const ReactClass = require( 'react/lib/ReactClass' );
-
-		ReactClass.injection.injectMixin( require( 'i18n-calypso' ).mixin );
-	} );
-
 	describe( 'rendering bulk actions', function() {
 		let renderedPluginsList, plugins, props;
 

--- a/client/my-sites/theme/test/main.jsx
+++ b/client/my-sites/theme/test/main.jsx
@@ -7,7 +7,6 @@ jest.mock( 'lib/wp', () => ( {
 		getProducts: () => {}
 	} ),
 } ) );
-jest.mock( 'matches-selector', () => require( 'component-matches-selector' ), { virtual: true } );
 jest.mock( 'my-sites/themes/theme-preview', () => require( 'components/empty-component' ) );
 jest.mock( 'my-sites/themes/themes-site-selector-modal', () => require( 'components/empty-component' ) );
 

--- a/client/post-editor/test/post-editor.jsx
+++ b/client/post-editor/test/post-editor.jsx
@@ -13,7 +13,6 @@ jest.mock( 'lib/user', () => () => {} );
 jest.mock( 'lib/wp', () => ( {
 	undocumented: () => {}
 } ) );
-jest.mock( 'matches-selector', () => require( 'component-matches-selector' ), { virtual: true } );
 jest.mock( 'post-editor/editor-document-head', () => require( 'components/empty-component' ) );
 jest.mock( 'post-editor/editor-action-bar', () => require( 'components/empty-component' ) );
 jest.mock( 'post-editor/editor-drawer', () => require( 'components/empty-component' ) );


### PR DESCRIPTION
Remove i18n mixin injections from tests (and some obsolete `matches-selector` stubs I found while working on this). This PR really only touches test files -- the corresponding units have been using `localize` already, only the tests hadn't been updated accordingly yet.

Rationale: We're trying to get rid of mixin auto-injection for the React 16 upgrade, since this relies on methods (`react/lib`) that aren't part of the public interface.

To test: Verify that unit tests pass.

[Follow-up PR](https://github.com/Automattic/wp-calypso/pull/18472) that tackles `client/auth/test/login.jsx` which also requires changes to the tested unit.