### PR TITLE
Auth: Run codemods; use enzyme, remove mixin injection from tests

### DIFF
--- a/client/auth/login.jsx
+++ b/client/auth/login.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -26,7 +27,10 @@ import { addLocaleToWpcomUrl, getLocaleSlug } from 'lib/i18n-utils';
 
 const LostPassword = React.createClass( {
 	render: function() {
-		const url = addLocaleToWpcomUrl( 'https://wordpress.com/wp-login.php?action=lostpassword', getLocaleSlug() );
+		const url = addLocaleToWpcomUrl(
+			'https://wordpress.com/wp-login.php?action=lostpassword',
+			getLocaleSlug()
+		);
 		return (
 			<p className="auth__lost-password">
 				<a href={ url } target="_blank" rel="noopener noreferrer">
@@ -34,28 +38,51 @@ const LostPassword = React.createClass( {
 				</a>
 			</p>
 		);
-	}
+	},
 } );
 
 const SelfHostedInstructions = React.createClass( {
-
 	render: function() {
 		return (
 			<div className="auth__self-hosted-instructions">
-				<a href="#" onClick={ this.props.onClickClose } className="auth__self-hosted-instructions-close"><Gridicon icon="cross" size={ 24 } /></a>
+				<a
+					href="#"
+					onClick={ this.props.onClickClose }
+					className="auth__self-hosted-instructions-close"
+				>
+					<Gridicon icon="cross" size={ 24 } />
+				</a>
 
 				<h2>{ this.translate( 'Add self-hosted site' ) }</h2>
-				<p>{ this.translate( 'By default when you sign into the WordPress.com app, you can edit blogs and sites hosted at WordPress.com' ) }</p>
-				<p>{ this.translate( 'If you\'d like to edit your self-hosted WordPress blog or site, you can do that by following these instructions:' ) }</p>
+				<p>
+					{ this.translate(
+						'By default when you sign into the WordPress.com app, you can edit blogs and sites hosted at WordPress.com'
+					) }
+				</p>
+				<p>
+					{ this.translate(
+						"If you'd like to edit your self-hosted WordPress blog or site, you can do that by following these instructions:"
+					) }
+				</p>
 
 				<ol>
-					<li><strong>{ this.translate( 'Install the Jetpack plugin.' ) }</strong><br /><a href="http://jetpack.me/install/">{ this.translate( 'Please follow these instructions to install Jetpack' ) }</a>.</li>
+					<li>
+						<strong>{ this.translate( 'Install the Jetpack plugin.' ) }</strong>
+						<br />
+						<a href="http://jetpack.me/install/">
+							{ this.translate( 'Please follow these instructions to install Jetpack' ) }
+						</a>.
+					</li>
 					<li>{ this.translate( 'Connect Jetpack to WordPress.com.' ) }</li>
-					<li>{ this.translate( 'Now you can sign in to the app using the WordPress.com account Jetpack is connected to, and you can find your self-hosted site under the "My Sites" section.' ) }</li>
+					<li>
+						{ this.translate(
+							'Now you can sign in to the app using the WordPress.com account Jetpack is connected to, and you can find your self-hosted site under the "My Sites" section.'
+						) }
+					</li>
 				</ol>
 			</div>
 		);
-	}
+	},
 } );
 
 module.exports = React.createClass( {
@@ -82,11 +109,14 @@ module.exports = React.createClass( {
 	},
 
 	getInitialState: function() {
-		return Object.assign( {
-			login: '',
-			password: '',
-			auth_code: ''
-		}, AuthStore.get() );
+		return Object.assign(
+			{
+				login: '',
+				password: '',
+				auth_code: '',
+			},
+			AuthStore.get()
+		);
 	},
 
 	submitForm: function( event ) {
@@ -119,8 +149,8 @@ module.exports = React.createClass( {
 		return this.hasLoginDetails();
 	},
 
-	toggleSelfHostedInstructions: function () {
-		var isShowing = !this.state.showInstructions;
+	toggleSelfHostedInstructions: function() {
+		var isShowing = ! this.state.showInstructions;
 		this.setState( { showInstructions: isShowing } );
 	},
 
@@ -134,14 +164,15 @@ module.exports = React.createClass( {
 					<form className="auth__form" onSubmit={ this.submitForm }>
 						<FormFieldset>
 							<div className="auth__input-wrapper">
-								<Gridicon icon="user"/>
+								<Gridicon icon="user" />
 								<FormTextInput
 									name="login"
 									ref="login"
 									disabled={ requires2fa || inProgress }
 									placeholder={ this.translate( 'Username or email address' ) }
 									onFocus={ this.recordFocusEvent( 'Username or email address' ) }
-									valueLink={ this.linkState( 'login' ) } />
+									valueLink={ this.linkState( 'login' ) }
+								/>
 							</div>
 							<div className="auth__input-wrapper">
 								<Gridicon icon="lock" />
@@ -153,9 +184,10 @@ module.exports = React.createClass( {
 									onFocus={ this.recordFocusEvent( 'Password' ) }
 									hideToggle={ requires2fa }
 									submitting={ inProgress }
-									valueLink={ this.linkState( 'password' ) } />
+									valueLink={ this.linkState( 'password' ) }
+								/>
 							</div>
-							{ requires2fa &&
+							{ requires2fa && (
 								<FormFieldset>
 									<FormTextInput
 										name="auth_code"
@@ -164,29 +196,47 @@ module.exports = React.createClass( {
 										disabled={ inProgress }
 										placeholder={ this.translate( 'Verification code' ) }
 										onFocus={ this.recordFocusEvent( 'Verification code' ) }
-										valueLink={ this.linkState( 'auth_code' ) } />
+										valueLink={ this.linkState( 'auth_code' ) }
+									/>
 								</FormFieldset>
-							}
+							) }
 						</FormFieldset>
 						<FormButtonsBar>
-							<FormButton disabled={ ! this.canSubmitForm() } onClick={ this.recordClickEvent( 'Sign in' ) } >
+							<FormButton
+								disabled={ ! this.canSubmitForm() }
+								onClick={ this.recordClickEvent( 'Sign in' ) }
+							>
 								{ requires2fa ? this.translate( 'Verify' ) : this.translate( 'Sign in' ) }
 							</FormButton>
 						</FormButtonsBar>
 						{ ! requires2fa && <LostPassword /> }
-						{ errorMessage && <Notice text={ errorMessage } status={ errorLevel } showDismiss={ false } /> }
-						{ requires2fa && <AuthCodeButton username={ this.state.login } password={ this.state.password } /> }
+						{ errorMessage && (
+							<Notice text={ errorMessage } status={ errorLevel } showDismiss={ false } />
+						) }
+						{ requires2fa && (
+							<AuthCodeButton username={ this.state.login } password={ this.state.password } />
+						) }
 					</form>
-					<a className="auth__help" target="_blank" rel="noopener noreferrer" title={ this.translate( 'Visit the WordPress.com support site for help' ) } href="https://en.support.wordpress.com/">
+					<a
+						className="auth__help"
+						target="_blank"
+						rel="noopener noreferrer"
+						title={ this.translate( 'Visit the WordPress.com support site for help' ) }
+						href="https://en.support.wordpress.com/"
+					>
 						<Gridicon icon="help" />
 					</a>
 					<div className="auth__links">
-						<a href="#" onClick={ this.toggleSelfHostedInstructions }>{ this.translate( 'Add self-hosted site' ) }</a>
+						<a href="#" onClick={ this.toggleSelfHostedInstructions }>
+							{ this.translate( 'Add self-hosted site' ) }
+						</a>
 						<a href={ config( 'signup_url' ) }>{ this.translate( 'Create account' ) }</a>
 					</div>
-					{ showInstructions && <SelfHostedInstructions onClickClose={ this.toggleSelfHostedInstructions } /> }
+					{ showInstructions && (
+						<SelfHostedInstructions onClickClose={ this.toggleSelfHostedInstructions } />
+					) }
 				</div>
 			</Main>
 		);
-	}
+	},
 } );

--- a/client/auth/login.jsx
+++ b/client/auth/login.jsx
@@ -24,58 +24,8 @@ import * as AuthActions from 'lib/oauth-store/actions';
 import eventRecorder from 'me/event-recorder';
 import WordPressLogo from 'components/wordpress-logo';
 import AuthCodeButton from './auth-code-button';
-import { addLocaleToWpcomUrl, getLocaleSlug } from 'lib/i18n-utils';
-
-const LostPassword = localize( ( { translate } ) => {
-	const url = addLocaleToWpcomUrl(
-		'https://wordpress.com/wp-login.php?action=lostpassword',
-		getLocaleSlug()
-	);
-	return (
-		<p className="auth__lost-password">
-			<a href={ url } target="_blank" rel="noopener noreferrer">
-				{ translate( 'Lost your password?' ) }
-			</a>
-		</p>
-	);
-} );
-
-const SelfHostedInstructions = localize( ( { onClickClose, translate } ) => (
-	<div className="auth__self-hosted-instructions">
-		<a href="#" onClick={ onClickClose } className="auth__self-hosted-instructions-close">
-			<Gridicon icon="cross" size={ 24 } />
-		</a>
-
-		<h2>{ translate( 'Add self-hosted site' ) }</h2>
-		<p>
-			{ translate(
-				'By default when you sign into the WordPress.com app, you can edit blogs and sites hosted at WordPress.com'
-			) }
-		</p>
-		<p>
-			{ translate(
-				"If you'd like to edit your self-hosted WordPress blog or site, you can do that by following these instructions:"
-			) }
-		</p>
-
-		<ol>
-			<li>
-				<strong>{ translate( 'Install the Jetpack plugin.' ) }</strong>
-				<br />
-				<a href="http://jetpack.me/install/">
-					{ translate( 'Please follow these instructions to install Jetpack' ) }
-				</a>.
-			</li>
-			<li>{ translate( 'Connect Jetpack to WordPress.com.' ) }</li>
-			<li>
-				{ translate(
-					'Now you can sign in to the app using the WordPress.com account Jetpack is connected to, ' +
-						'and you can find your self-hosted site under the "My Sites" section.'
-				) }
-			</li>
-		</ol>
-	</div>
-) );
+import SelfHostedInstructions from './self-hosted-instructions';
+import LostPassword from './lost-password';
 
 export const Login = createReactClass( {
 	displayName: 'Auth',

--- a/client/auth/login.jsx
+++ b/client/auth/login.jsx
@@ -4,7 +4,6 @@
  */
 import React from 'react';
 import createReactClass from 'create-react-class';
-import ReactDom from 'react-dom';
 import { localize } from 'i18n-calypso';
 import LinkedStateMixin from 'react-addons-linked-state-mixin';
 import Gridicon from 'gridicons';
@@ -95,9 +94,9 @@ export const Login = createReactClass( {
 		this.setState( AuthStore.get() );
 	},
 
-	componentDidUpdate() {
+	focusInput( input ) {
 		if ( this.state.requires2fa && this.state.inProgress === false ) {
-			ReactDom.findDOMNode( this.refs.auth_code ).focus();
+			input.focus();
 		}
 	},
 
@@ -186,7 +185,7 @@ export const Login = createReactClass( {
 									<FormTextInput
 										name="auth_code"
 										type="number"
-										ref="auth_code"
+										ref={ this.focusInput }
 										disabled={ inProgress }
 										placeholder={ translate( 'Verification code' ) }
 										onFocus={ this.recordFocusEvent( 'Verification code' ) }

--- a/client/auth/login.jsx
+++ b/client/auth/login.jsx
@@ -27,218 +27,228 @@ import WordPressLogo from 'components/wordpress-logo';
 import AuthCodeButton from './auth-code-button';
 import { addLocaleToWpcomUrl, getLocaleSlug } from 'lib/i18n-utils';
 
-const LostPassword = localize(class extends React.Component {
-    render() {
-		const url = addLocaleToWpcomUrl(
-			'https://wordpress.com/wp-login.php?action=lostpassword',
-			getLocaleSlug()
-		);
-		return (
-            <p className="auth__lost-password">
-				<a href={ url } target="_blank" rel="noopener noreferrer">
-					{ this.props.translate( 'Lost your password?' ) }
-				</a>
-			</p>
-        );
-	}
-});
-
-const SelfHostedInstructions = localize(class extends React.Component {
-    render() {
-		return (
-            <div className="auth__self-hosted-instructions">
-				<a
-					href="#"
-					onClick={ this.props.onClickClose }
-					className="auth__self-hosted-instructions-close"
-				>
-					<Gridicon icon="cross" size={ 24 } />
-				</a>
-
-				<h2>{ this.props.translate( 'Add self-hosted site' ) }</h2>
-				<p>
-					{ this.props.translate(
-						'By default when you sign into the WordPress.com app, you can edit blogs and sites hosted at WordPress.com'
-					) }
-				</p>
-				<p>
-					{ this.props.translate(
-						"If you'd like to edit your self-hosted WordPress blog or site, you can do that by following these instructions:"
-					) }
-				</p>
-
-				<ol>
-					<li>
-						<strong>{ this.props.translate( 'Install the Jetpack plugin.' ) }</strong>
-						<br />
-						<a href="http://jetpack.me/install/">
-							{ this.props.translate( 'Please follow these instructions to install Jetpack' ) }
-						</a>.
-					</li>
-					<li>{ this.props.translate( 'Connect Jetpack to WordPress.com.' ) }</li>
-					<li>
-						{ this.props.translate(
-							'Now you can sign in to the app using the WordPress.com account Jetpack is connected to, and you can find your self-hosted site under the "My Sites" section.'
-						) }
-					</li>
-				</ol>
-			</div>
-        );
-	}
-});
-
-module.exports = localize(createReactClass({
-	displayName: 'Auth',
-
-	mixins: [ LinkedStateMixin, eventRecorder ],
-
-	componentDidMount: function() {
-		AuthStore.on( 'change', this.refreshData );
-	},
-
-	componentWillUnmount: function() {
-		AuthStore.off( 'change', this.refreshData );
-	},
-
-	refreshData: function() {
-		this.setState( AuthStore.get() );
-	},
-
-	componentDidUpdate() {
-		if ( this.state.requires2fa && this.state.inProgress === false ) {
-			ReactDom.findDOMNode( this.refs.auth_code ).focus();
-		}
-	},
-
-	getInitialState: function() {
-		return Object.assign(
-			{
-				login: '',
-				password: '',
-				auth_code: '',
-			},
-			AuthStore.get()
-		);
-	},
-
-	submitForm: function( event ) {
-		event.preventDefault();
-		event.stopPropagation();
-
-		AuthActions.login( this.state.login, this.state.password, this.state.auth_code );
-	},
-
-	hasLoginDetails: function() {
-		if ( this.state.login === '' || this.state.password === '' ) {
-			return false;
-		}
-
-		return true;
-	},
-
-	canSubmitForm: function() {
-		// No submission until the ajax has finished
-		if ( this.state.inProgress ) {
-			return false;
-		}
-
-		// If we have 2fa set then don't allow submission until a code is entered
-		if ( this.state.requires2fa ) {
-			return parseInt( this.state.auth_code, 10 ) > 0;
-		}
-
-		// Don't allow submission until username+password is entered
-		return this.hasLoginDetails();
-	},
-
-	toggleSelfHostedInstructions: function() {
-		var isShowing = ! this.state.showInstructions;
-		this.setState( { showInstructions: isShowing } );
-	},
-
-	render: function() {
-		const { requires2fa, inProgress, errorMessage, errorLevel, showInstructions } = this.state;
-
-		return (
-            <Main className="auth">
-				<div className="auth__content">
-					<WordPressLogo />
-					<form className="auth__form" onSubmit={ this.submitForm }>
-						<FormFieldset>
-							<div className="auth__input-wrapper">
-								<Gridicon icon="user" />
-								<FormTextInput
-									name="login"
-									ref="login"
-									disabled={ requires2fa || inProgress }
-									placeholder={ this.props.translate( 'Username or email address' ) }
-									onFocus={ this.recordFocusEvent( 'Username or email address' ) }
-									valueLink={ this.linkState( 'login' ) }
-								/>
-							</div>
-							<div className="auth__input-wrapper">
-								<Gridicon icon="lock" />
-								<FormPasswordInput
-									name="password"
-									ref="password"
-									disabled={ requires2fa || inProgress }
-									placeholder={ this.props.translate( 'Password' ) }
-									onFocus={ this.recordFocusEvent( 'Password' ) }
-									hideToggle={ requires2fa }
-									submitting={ inProgress }
-									valueLink={ this.linkState( 'password' ) }
-								/>
-							</div>
-							{ requires2fa && (
-								<FormFieldset>
-									<FormTextInput
-										name="auth_code"
-										type="number"
-										ref="auth_code"
-										disabled={ inProgress }
-										placeholder={ this.props.translate( 'Verification code' ) }
-										onFocus={ this.recordFocusEvent( 'Verification code' ) }
-										valueLink={ this.linkState( 'auth_code' ) }
-									/>
-								</FormFieldset>
-							) }
-						</FormFieldset>
-						<FormButtonsBar>
-							<FormButton
-								disabled={ ! this.canSubmitForm() }
-								onClick={ this.recordClickEvent( 'Sign in' ) }
-							>
-								{ requires2fa ? this.props.translate( 'Verify' ) : this.props.translate( 'Sign in' ) }
-							</FormButton>
-						</FormButtonsBar>
-						{ ! requires2fa && <LostPassword /> }
-						{ errorMessage && (
-							<Notice text={ errorMessage } status={ errorLevel } showDismiss={ false } />
-						) }
-						{ requires2fa && (
-							<AuthCodeButton username={ this.state.login } password={ this.state.password } />
-						) }
-					</form>
-					<a
-						className="auth__help"
-						target="_blank"
-						rel="noopener noreferrer"
-						title={ this.props.translate( 'Visit the WordPress.com support site for help' ) }
-						href="https://en.support.wordpress.com/"
-					>
-						<Gridicon icon="help" />
+const LostPassword = localize(
+	class extends React.Component {
+		render() {
+			const url = addLocaleToWpcomUrl(
+				'https://wordpress.com/wp-login.php?action=lostpassword',
+				getLocaleSlug()
+			);
+			return (
+				<p className="auth__lost-password">
+					<a href={ url } target="_blank" rel="noopener noreferrer">
+						{ this.props.translate( 'Lost your password?' ) }
 					</a>
-					<div className="auth__links">
-						<a href="#" onClick={ this.toggleSelfHostedInstructions }>
-							{ this.props.translate( 'Add self-hosted site' ) }
-						</a>
-						<a href={ config( 'signup_url' ) }>{ this.props.translate( 'Create account' ) }</a>
-					</div>
-					{ showInstructions && (
-						<SelfHostedInstructions onClickClose={ this.toggleSelfHostedInstructions } />
-					) }
+				</p>
+			);
+		}
+	}
+);
+
+const SelfHostedInstructions = localize(
+	class extends React.Component {
+		render() {
+			return (
+				<div className="auth__self-hosted-instructions">
+					<a
+						href="#"
+						onClick={ this.props.onClickClose }
+						className="auth__self-hosted-instructions-close"
+					>
+						<Gridicon icon="cross" size={ 24 } />
+					</a>
+
+					<h2>{ this.props.translate( 'Add self-hosted site' ) }</h2>
+					<p>
+						{ this.props.translate(
+							'By default when you sign into the WordPress.com app, you can edit blogs and sites hosted at WordPress.com'
+						) }
+					</p>
+					<p>
+						{ this.props.translate(
+							"If you'd like to edit your self-hosted WordPress blog or site, you can do that by following these instructions:"
+						) }
+					</p>
+
+					<ol>
+						<li>
+							<strong>{ this.props.translate( 'Install the Jetpack plugin.' ) }</strong>
+							<br />
+							<a href="http://jetpack.me/install/">
+								{ this.props.translate( 'Please follow these instructions to install Jetpack' ) }
+							</a>.
+						</li>
+						<li>{ this.props.translate( 'Connect Jetpack to WordPress.com.' ) }</li>
+						<li>
+							{ this.props.translate(
+								'Now you can sign in to the app using the WordPress.com account Jetpack is connected to, and you can find your self-hosted site under the "My Sites" section.'
+							) }
+						</li>
+					</ol>
 				</div>
-			</Main>
-        );
-	},
-}));
+			);
+		}
+	}
+);
+
+module.exports = localize(
+	createReactClass( {
+		displayName: 'Auth',
+
+		mixins: [ LinkedStateMixin, eventRecorder ],
+
+		componentDidMount: function() {
+			AuthStore.on( 'change', this.refreshData );
+		},
+
+		componentWillUnmount: function() {
+			AuthStore.off( 'change', this.refreshData );
+		},
+
+		refreshData: function() {
+			this.setState( AuthStore.get() );
+		},
+
+		componentDidUpdate() {
+			if ( this.state.requires2fa && this.state.inProgress === false ) {
+				ReactDom.findDOMNode( this.refs.auth_code ).focus();
+			}
+		},
+
+		getInitialState: function() {
+			return Object.assign(
+				{
+					login: '',
+					password: '',
+					auth_code: '',
+				},
+				AuthStore.get()
+			);
+		},
+
+		submitForm: function( event ) {
+			event.preventDefault();
+			event.stopPropagation();
+
+			AuthActions.login( this.state.login, this.state.password, this.state.auth_code );
+		},
+
+		hasLoginDetails: function() {
+			if ( this.state.login === '' || this.state.password === '' ) {
+				return false;
+			}
+
+			return true;
+		},
+
+		canSubmitForm: function() {
+			// No submission until the ajax has finished
+			if ( this.state.inProgress ) {
+				return false;
+			}
+
+			// If we have 2fa set then don't allow submission until a code is entered
+			if ( this.state.requires2fa ) {
+				return parseInt( this.state.auth_code, 10 ) > 0;
+			}
+
+			// Don't allow submission until username+password is entered
+			return this.hasLoginDetails();
+		},
+
+		toggleSelfHostedInstructions: function() {
+			var isShowing = ! this.state.showInstructions;
+			this.setState( { showInstructions: isShowing } );
+		},
+
+		render: function() {
+			const { requires2fa, inProgress, errorMessage, errorLevel, showInstructions } = this.state;
+
+			return (
+				<Main className="auth">
+					<div className="auth__content">
+						<WordPressLogo />
+						<form className="auth__form" onSubmit={ this.submitForm }>
+							<FormFieldset>
+								<div className="auth__input-wrapper">
+									<Gridicon icon="user" />
+									<FormTextInput
+										name="login"
+										ref="login"
+										disabled={ requires2fa || inProgress }
+										placeholder={ this.props.translate( 'Username or email address' ) }
+										onFocus={ this.recordFocusEvent( 'Username or email address' ) }
+										valueLink={ this.linkState( 'login' ) }
+									/>
+								</div>
+								<div className="auth__input-wrapper">
+									<Gridicon icon="lock" />
+									<FormPasswordInput
+										name="password"
+										ref="password"
+										disabled={ requires2fa || inProgress }
+										placeholder={ this.props.translate( 'Password' ) }
+										onFocus={ this.recordFocusEvent( 'Password' ) }
+										hideToggle={ requires2fa }
+										submitting={ inProgress }
+										valueLink={ this.linkState( 'password' ) }
+									/>
+								</div>
+								{ requires2fa && (
+									<FormFieldset>
+										<FormTextInput
+											name="auth_code"
+											type="number"
+											ref="auth_code"
+											disabled={ inProgress }
+											placeholder={ this.props.translate( 'Verification code' ) }
+											onFocus={ this.recordFocusEvent( 'Verification code' ) }
+											valueLink={ this.linkState( 'auth_code' ) }
+										/>
+									</FormFieldset>
+								) }
+							</FormFieldset>
+							<FormButtonsBar>
+								<FormButton
+									disabled={ ! this.canSubmitForm() }
+									onClick={ this.recordClickEvent( 'Sign in' ) }
+								>
+									{ requires2fa ? (
+										this.props.translate( 'Verify' )
+									) : (
+										this.props.translate( 'Sign in' )
+									) }
+								</FormButton>
+							</FormButtonsBar>
+							{ ! requires2fa && <LostPassword /> }
+							{ errorMessage && (
+								<Notice text={ errorMessage } status={ errorLevel } showDismiss={ false } />
+							) }
+							{ requires2fa && (
+								<AuthCodeButton username={ this.state.login } password={ this.state.password } />
+							) }
+						</form>
+						<a
+							className="auth__help"
+							target="_blank"
+							rel="noopener noreferrer"
+							title={ this.props.translate( 'Visit the WordPress.com support site for help' ) }
+							href="https://en.support.wordpress.com/"
+						>
+							<Gridicon icon="help" />
+						</a>
+						<div className="auth__links">
+							<a href="#" onClick={ this.toggleSelfHostedInstructions }>
+								{ this.props.translate( 'Add self-hosted site' ) }
+							</a>
+							<a href={ config( 'signup_url' ) }>{ this.props.translate( 'Create account' ) }</a>
+						</div>
+						{ showInstructions && (
+							<SelfHostedInstructions onClickClose={ this.toggleSelfHostedInstructions } />
+						) }
+					</div>
+				</Main>
+			);
+		},
+	} )
+);

--- a/client/auth/login.jsx
+++ b/client/auth/login.jsx
@@ -3,6 +3,7 @@
  * External dependencies
  */
 import ReactDom from 'react-dom';
+import { localize } from 'i18n-calypso';
 import React from 'react';
 import LinkedStateMixin from 'react-addons-linked-state-mixin';
 import Gridicon from 'gridicons';
@@ -25,26 +26,26 @@ import WordPressLogo from 'components/wordpress-logo';
 import AuthCodeButton from './auth-code-button';
 import { addLocaleToWpcomUrl, getLocaleSlug } from 'lib/i18n-utils';
 
-const LostPassword = React.createClass( {
+const LostPassword = localize(React.createClass( {
 	render: function() {
 		const url = addLocaleToWpcomUrl(
 			'https://wordpress.com/wp-login.php?action=lostpassword',
 			getLocaleSlug()
 		);
 		return (
-			<p className="auth__lost-password">
+            <p className="auth__lost-password">
 				<a href={ url } target="_blank" rel="noopener noreferrer">
-					{ this.translate( 'Lost your password?' ) }
+					{ this.props.translate( 'Lost your password?' ) }
 				</a>
 			</p>
-		);
+        );
 	},
-} );
+} ));
 
-const SelfHostedInstructions = React.createClass( {
+const SelfHostedInstructions = localize(React.createClass( {
 	render: function() {
 		return (
-			<div className="auth__self-hosted-instructions">
+            <div className="auth__self-hosted-instructions">
 				<a
 					href="#"
 					onClick={ this.props.onClickClose }
@@ -53,39 +54,39 @@ const SelfHostedInstructions = React.createClass( {
 					<Gridicon icon="cross" size={ 24 } />
 				</a>
 
-				<h2>{ this.translate( 'Add self-hosted site' ) }</h2>
+				<h2>{ this.props.translate( 'Add self-hosted site' ) }</h2>
 				<p>
-					{ this.translate(
+					{ this.props.translate(
 						'By default when you sign into the WordPress.com app, you can edit blogs and sites hosted at WordPress.com'
 					) }
 				</p>
 				<p>
-					{ this.translate(
+					{ this.props.translate(
 						"If you'd like to edit your self-hosted WordPress blog or site, you can do that by following these instructions:"
 					) }
 				</p>
 
 				<ol>
 					<li>
-						<strong>{ this.translate( 'Install the Jetpack plugin.' ) }</strong>
+						<strong>{ this.props.translate( 'Install the Jetpack plugin.' ) }</strong>
 						<br />
 						<a href="http://jetpack.me/install/">
-							{ this.translate( 'Please follow these instructions to install Jetpack' ) }
+							{ this.props.translate( 'Please follow these instructions to install Jetpack' ) }
 						</a>.
 					</li>
-					<li>{ this.translate( 'Connect Jetpack to WordPress.com.' ) }</li>
+					<li>{ this.props.translate( 'Connect Jetpack to WordPress.com.' ) }</li>
 					<li>
-						{ this.translate(
+						{ this.props.translate(
 							'Now you can sign in to the app using the WordPress.com account Jetpack is connected to, and you can find your self-hosted site under the "My Sites" section.'
 						) }
 					</li>
 				</ol>
 			</div>
-		);
+        );
 	},
-} );
+} ));
 
-module.exports = React.createClass( {
+module.exports = localize(React.createClass( {
 	displayName: 'Auth',
 
 	mixins: [ LinkedStateMixin, eventRecorder ],
@@ -158,7 +159,7 @@ module.exports = React.createClass( {
 		const { requires2fa, inProgress, errorMessage, errorLevel, showInstructions } = this.state;
 
 		return (
-			<Main className="auth">
+            <Main className="auth">
 				<div className="auth__content">
 					<WordPressLogo />
 					<form className="auth__form" onSubmit={ this.submitForm }>
@@ -169,7 +170,7 @@ module.exports = React.createClass( {
 									name="login"
 									ref="login"
 									disabled={ requires2fa || inProgress }
-									placeholder={ this.translate( 'Username or email address' ) }
+									placeholder={ this.props.translate( 'Username or email address' ) }
 									onFocus={ this.recordFocusEvent( 'Username or email address' ) }
 									valueLink={ this.linkState( 'login' ) }
 								/>
@@ -180,7 +181,7 @@ module.exports = React.createClass( {
 									name="password"
 									ref="password"
 									disabled={ requires2fa || inProgress }
-									placeholder={ this.translate( 'Password' ) }
+									placeholder={ this.props.translate( 'Password' ) }
 									onFocus={ this.recordFocusEvent( 'Password' ) }
 									hideToggle={ requires2fa }
 									submitting={ inProgress }
@@ -194,7 +195,7 @@ module.exports = React.createClass( {
 										type="number"
 										ref="auth_code"
 										disabled={ inProgress }
-										placeholder={ this.translate( 'Verification code' ) }
+										placeholder={ this.props.translate( 'Verification code' ) }
 										onFocus={ this.recordFocusEvent( 'Verification code' ) }
 										valueLink={ this.linkState( 'auth_code' ) }
 									/>
@@ -206,7 +207,7 @@ module.exports = React.createClass( {
 								disabled={ ! this.canSubmitForm() }
 								onClick={ this.recordClickEvent( 'Sign in' ) }
 							>
-								{ requires2fa ? this.translate( 'Verify' ) : this.translate( 'Sign in' ) }
+								{ requires2fa ? this.props.translate( 'Verify' ) : this.props.translate( 'Sign in' ) }
 							</FormButton>
 						</FormButtonsBar>
 						{ ! requires2fa && <LostPassword /> }
@@ -221,22 +222,22 @@ module.exports = React.createClass( {
 						className="auth__help"
 						target="_blank"
 						rel="noopener noreferrer"
-						title={ this.translate( 'Visit the WordPress.com support site for help' ) }
+						title={ this.props.translate( 'Visit the WordPress.com support site for help' ) }
 						href="https://en.support.wordpress.com/"
 					>
 						<Gridicon icon="help" />
 					</a>
 					<div className="auth__links">
 						<a href="#" onClick={ this.toggleSelfHostedInstructions }>
-							{ this.translate( 'Add self-hosted site' ) }
+							{ this.props.translate( 'Add self-hosted site' ) }
 						</a>
-						<a href={ config( 'signup_url' ) }>{ this.translate( 'Create account' ) }</a>
+						<a href={ config( 'signup_url' ) }>{ this.props.translate( 'Create account' ) }</a>
 					</div>
 					{ showInstructions && (
 						<SelfHostedInstructions onClickClose={ this.toggleSelfHostedInstructions } />
 					) }
 				</div>
 			</Main>
-		);
+        );
 	},
-} );
+} ));

--- a/client/auth/login.jsx
+++ b/client/auth/login.jsx
@@ -78,161 +78,161 @@ const SelfHostedInstructions = localize( ( { onClickClose, translate } ) => (
 	</div>
 ) );
 
-module.exports = localize(
-	createReactClass( {
-		displayName: 'Auth',
+export const Login = createReactClass( {
+	displayName: 'Auth',
 
-		mixins: [ LinkedStateMixin, eventRecorder ],
+	mixins: [ LinkedStateMixin, eventRecorder ],
 
-		componentDidMount: function() {
-			AuthStore.on( 'change', this.refreshData );
-		},
+	componentDidMount: function() {
+		AuthStore.on( 'change', this.refreshData );
+	},
 
-		componentWillUnmount: function() {
-			AuthStore.off( 'change', this.refreshData );
-		},
+	componentWillUnmount: function() {
+		AuthStore.off( 'change', this.refreshData );
+	},
 
-		refreshData: function() {
-			this.setState( AuthStore.get() );
-		},
+	refreshData: function() {
+		this.setState( AuthStore.get() );
+	},
 
-		componentDidUpdate() {
-			if ( this.state.requires2fa && this.state.inProgress === false ) {
-				ReactDom.findDOMNode( this.refs.auth_code ).focus();
-			}
-		},
+	componentDidUpdate() {
+		if ( this.state.requires2fa && this.state.inProgress === false ) {
+			ReactDom.findDOMNode( this.refs.auth_code ).focus();
+		}
+	},
 
-		getInitialState: function() {
-			return Object.assign(
-				{
-					login: '',
-					password: '',
-					auth_code: '',
-				},
-				AuthStore.get()
-			);
-		},
+	getInitialState: function() {
+		return Object.assign(
+			{
+				login: '',
+				password: '',
+				auth_code: '',
+			},
+			AuthStore.get()
+		);
+	},
 
-		submitForm: function( event ) {
-			event.preventDefault();
-			event.stopPropagation();
+	submitForm: function( event ) {
+		event.preventDefault();
+		event.stopPropagation();
 
-			AuthActions.login( this.state.login, this.state.password, this.state.auth_code );
-		},
+		AuthActions.login( this.state.login, this.state.password, this.state.auth_code );
+	},
 
-		hasLoginDetails: function() {
-			if ( this.state.login === '' || this.state.password === '' ) {
-				return false;
-			}
+	hasLoginDetails: function() {
+		if ( this.state.login === '' || this.state.password === '' ) {
+			return false;
+		}
 
-			return true;
-		},
+		return true;
+	},
 
-		canSubmitForm: function() {
-			// No submission until the ajax has finished
-			if ( this.state.inProgress ) {
-				return false;
-			}
+	canSubmitForm: function() {
+		// No submission until the ajax has finished
+		if ( this.state.inProgress ) {
+			return false;
+		}
 
-			// If we have 2fa set then don't allow submission until a code is entered
-			if ( this.state.requires2fa ) {
-				return parseInt( this.state.auth_code, 10 ) > 0;
-			}
+		// If we have 2fa set then don't allow submission until a code is entered
+		if ( this.state.requires2fa ) {
+			return parseInt( this.state.auth_code, 10 ) > 0;
+		}
 
-			// Don't allow submission until username+password is entered
-			return this.hasLoginDetails();
-		},
+		// Don't allow submission until username+password is entered
+		return this.hasLoginDetails();
+	},
 
-		toggleSelfHostedInstructions: function() {
-			const isShowing = ! this.state.showInstructions;
-			this.setState( { showInstructions: isShowing } );
-		},
+	toggleSelfHostedInstructions: function() {
+		const isShowing = ! this.state.showInstructions;
+		this.setState( { showInstructions: isShowing } );
+	},
 
-		render: function() {
-			const { translate } = this.props;
-			const { requires2fa, inProgress, errorMessage, errorLevel, showInstructions } = this.state;
+	render: function() {
+		const { translate } = this.props;
+		const { requires2fa, inProgress, errorMessage, errorLevel, showInstructions } = this.state;
 
-			return (
-				<Main className="auth">
-					<div className="auth__content">
-						<WordPressLogo />
-						<form className="auth__form" onSubmit={ this.submitForm }>
-							<FormFieldset>
-								<div className="auth__input-wrapper">
-									<Gridicon icon="user" />
-									<FormTextInput
-										name="login"
-										ref="login"
-										disabled={ requires2fa || inProgress }
-										placeholder={ translate( 'Username or email address' ) }
-										onFocus={ this.recordFocusEvent( 'Username or email address' ) }
-										valueLink={ this.linkState( 'login' ) }
-									/>
-								</div>
-								<div className="auth__input-wrapper">
-									<Gridicon icon="lock" />
-									<FormPasswordInput
-										name="password"
-										ref="password"
-										disabled={ requires2fa || inProgress }
-										placeholder={ translate( 'Password' ) }
-										onFocus={ this.recordFocusEvent( 'Password' ) }
-										hideToggle={ requires2fa }
-										submitting={ inProgress }
-										valueLink={ this.linkState( 'password' ) }
-									/>
-								</div>
-								{ requires2fa && (
-									<FormFieldset>
-										<FormTextInput
-											name="auth_code"
-											type="number"
-											ref="auth_code"
-											disabled={ inProgress }
-											placeholder={ translate( 'Verification code' ) }
-											onFocus={ this.recordFocusEvent( 'Verification code' ) }
-											valueLink={ this.linkState( 'auth_code' ) }
-										/>
-									</FormFieldset>
-								) }
-							</FormFieldset>
-							<FormButtonsBar>
-								<FormButton
-									disabled={ ! this.canSubmitForm() }
-									onClick={ this.recordClickEvent( 'Sign in' ) }
-								>
-									{ requires2fa ? translate( 'Verify' ) : translate( 'Sign in' ) }
-								</FormButton>
-							</FormButtonsBar>
-							{ ! requires2fa && <LostPassword /> }
-							{ errorMessage && (
-								<Notice text={ errorMessage } status={ errorLevel } showDismiss={ false } />
-							) }
+		return (
+			<Main className="auth">
+				<div className="auth__content">
+					<WordPressLogo />
+					<form className="auth__form" onSubmit={ this.submitForm }>
+						<FormFieldset>
+							<div className="auth__input-wrapper">
+								<Gridicon icon="user" />
+								<FormTextInput
+									name="login"
+									ref="login"
+									disabled={ requires2fa || inProgress }
+									placeholder={ translate( 'Username or email address' ) }
+									onFocus={ this.recordFocusEvent( 'Username or email address' ) }
+									valueLink={ this.linkState( 'login' ) }
+								/>
+							</div>
+							<div className="auth__input-wrapper">
+								<Gridicon icon="lock" />
+								<FormPasswordInput
+									name="password"
+									ref="password"
+									disabled={ requires2fa || inProgress }
+									placeholder={ translate( 'Password' ) }
+									onFocus={ this.recordFocusEvent( 'Password' ) }
+									hideToggle={ requires2fa }
+									submitting={ inProgress }
+									valueLink={ this.linkState( 'password' ) }
+								/>
+							</div>
 							{ requires2fa && (
-								<AuthCodeButton username={ this.state.login } password={ this.state.password } />
+								<FormFieldset>
+									<FormTextInput
+										name="auth_code"
+										type="number"
+										ref="auth_code"
+										disabled={ inProgress }
+										placeholder={ translate( 'Verification code' ) }
+										onFocus={ this.recordFocusEvent( 'Verification code' ) }
+										valueLink={ this.linkState( 'auth_code' ) }
+									/>
+								</FormFieldset>
 							) }
-						</form>
-						<a
-							className="auth__help"
-							target="_blank"
-							rel="noopener noreferrer"
-							title={ translate( 'Visit the WordPress.com support site for help' ) }
-							href="https://en.support.wordpress.com/"
-						>
-							<Gridicon icon="help" />
-						</a>
-						<div className="auth__links">
-							<a href="#" onClick={ this.toggleSelfHostedInstructions }>
-								{ translate( 'Add self-hosted site' ) }
-							</a>
-							<a href={ config( 'signup_url' ) }>{ translate( 'Create account' ) }</a>
-						</div>
-						{ showInstructions && (
-							<SelfHostedInstructions onClickClose={ this.toggleSelfHostedInstructions } />
+						</FormFieldset>
+						<FormButtonsBar>
+							<FormButton
+								disabled={ ! this.canSubmitForm() }
+								onClick={ this.recordClickEvent( 'Sign in' ) }
+							>
+								{ requires2fa ? translate( 'Verify' ) : translate( 'Sign in' ) }
+							</FormButton>
+						</FormButtonsBar>
+						{ ! requires2fa && <LostPassword /> }
+						{ errorMessage && (
+							<Notice text={ errorMessage } status={ errorLevel } showDismiss={ false } />
 						) }
+						{ requires2fa && (
+							<AuthCodeButton username={ this.state.login } password={ this.state.password } />
+						) }
+					</form>
+					<a
+						className="auth__help"
+						target="_blank"
+						rel="noopener noreferrer"
+						title={ translate( 'Visit the WordPress.com support site for help' ) }
+						href="https://en.support.wordpress.com/"
+					>
+						<Gridicon icon="help" />
+					</a>
+					<div className="auth__links">
+						<a href="#" onClick={ this.toggleSelfHostedInstructions }>
+							{ translate( 'Add self-hosted site' ) }
+						</a>
+						<a href={ config( 'signup_url' ) }>{ translate( 'Create account' ) }</a>
 					</div>
-				</Main>
-			);
-		},
-	} )
-);
+					{ showInstructions && (
+						<SelfHostedInstructions onClickClose={ this.toggleSelfHostedInstructions } />
+					) }
+				</div>
+			</Main>
+		);
+	},
+} );
+
+export default localize( Login );

--- a/client/auth/login.jsx
+++ b/client/auth/login.jsx
@@ -5,6 +5,7 @@
 import ReactDom from 'react-dom';
 import { localize } from 'i18n-calypso';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import LinkedStateMixin from 'react-addons-linked-state-mixin';
 import Gridicon from 'gridicons';
 
@@ -26,8 +27,8 @@ import WordPressLogo from 'components/wordpress-logo';
 import AuthCodeButton from './auth-code-button';
 import { addLocaleToWpcomUrl, getLocaleSlug } from 'lib/i18n-utils';
 
-const LostPassword = localize(React.createClass( {
-	render: function() {
+const LostPassword = localize(class extends React.Component {
+    render() {
 		const url = addLocaleToWpcomUrl(
 			'https://wordpress.com/wp-login.php?action=lostpassword',
 			getLocaleSlug()
@@ -39,11 +40,11 @@ const LostPassword = localize(React.createClass( {
 				</a>
 			</p>
         );
-	},
-} ));
+	}
+});
 
-const SelfHostedInstructions = localize(React.createClass( {
-	render: function() {
+const SelfHostedInstructions = localize(class extends React.Component {
+    render() {
 		return (
             <div className="auth__self-hosted-instructions">
 				<a
@@ -83,10 +84,10 @@ const SelfHostedInstructions = localize(React.createClass( {
 				</ol>
 			</div>
         );
-	},
-} ));
+	}
+});
 
-module.exports = localize(React.createClass( {
+module.exports = localize(createReactClass({
 	displayName: 'Auth',
 
 	mixins: [ LinkedStateMixin, eventRecorder ],
@@ -240,4 +241,4 @@ module.exports = localize(React.createClass( {
 			</Main>
         );
 	},
-} ));
+}));

--- a/client/auth/login.jsx
+++ b/client/auth/login.jsx
@@ -160,7 +160,6 @@ export const Login = createReactClass( {
 								<Gridicon icon="user" />
 								<FormTextInput
 									name="login"
-									ref="login"
 									disabled={ requires2fa || inProgress }
 									placeholder={ translate( 'Username or email address' ) }
 									onFocus={ this.recordFocusEvent( 'Username or email address' ) }
@@ -171,7 +170,6 @@ export const Login = createReactClass( {
 								<Gridicon icon="lock" />
 								<FormPasswordInput
 									name="password"
-									ref="password"
 									disabled={ requires2fa || inProgress }
 									placeholder={ translate( 'Password' ) }
 									onFocus={ this.recordFocusEvent( 'Password' ) }

--- a/client/auth/login.jsx
+++ b/client/auth/login.jsx
@@ -2,10 +2,10 @@
 /**
  * External dependencies
  */
-import ReactDom from 'react-dom';
-import { localize } from 'i18n-calypso';
 import React from 'react';
 import createReactClass from 'create-react-class';
+import ReactDom from 'react-dom';
+import { localize } from 'i18n-calypso';
 import LinkedStateMixin from 'react-addons-linked-state-mixin';
 import Gridicon from 'gridicons';
 
@@ -27,69 +27,56 @@ import WordPressLogo from 'components/wordpress-logo';
 import AuthCodeButton from './auth-code-button';
 import { addLocaleToWpcomUrl, getLocaleSlug } from 'lib/i18n-utils';
 
-const LostPassword = localize(
-	class extends React.Component {
-		render() {
-			const url = addLocaleToWpcomUrl(
-				'https://wordpress.com/wp-login.php?action=lostpassword',
-				getLocaleSlug()
-			);
-			return (
-				<p className="auth__lost-password">
-					<a href={ url } target="_blank" rel="noopener noreferrer">
-						{ this.props.translate( 'Lost your password?' ) }
-					</a>
-				</p>
-			);
-		}
-	}
-);
+const LostPassword = localize( ( { translate } ) => {
+	const url = addLocaleToWpcomUrl(
+		'https://wordpress.com/wp-login.php?action=lostpassword',
+		getLocaleSlug()
+	);
+	return (
+		<p className="auth__lost-password">
+			<a href={ url } target="_blank" rel="noopener noreferrer">
+				{ translate( 'Lost your password?' ) }
+			</a>
+		</p>
+	);
+} );
 
-const SelfHostedInstructions = localize(
-	class extends React.Component {
-		render() {
-			return (
-				<div className="auth__self-hosted-instructions">
-					<a
-						href="#"
-						onClick={ this.props.onClickClose }
-						className="auth__self-hosted-instructions-close"
-					>
-						<Gridicon icon="cross" size={ 24 } />
-					</a>
+const SelfHostedInstructions = localize( ( { onClickClose, translate } ) => (
+	<div className="auth__self-hosted-instructions">
+		<a href="#" onClick={ onClickClose } className="auth__self-hosted-instructions-close">
+			<Gridicon icon="cross" size={ 24 } />
+		</a>
 
-					<h2>{ this.props.translate( 'Add self-hosted site' ) }</h2>
-					<p>
-						{ this.props.translate(
-							'By default when you sign into the WordPress.com app, you can edit blogs and sites hosted at WordPress.com'
-						) }
-					</p>
-					<p>
-						{ this.props.translate(
-							"If you'd like to edit your self-hosted WordPress blog or site, you can do that by following these instructions:"
-						) }
-					</p>
+		<h2>{ translate( 'Add self-hosted site' ) }</h2>
+		<p>
+			{ translate(
+				'By default when you sign into the WordPress.com app, you can edit blogs and sites hosted at WordPress.com'
+			) }
+		</p>
+		<p>
+			{ translate(
+				"If you'd like to edit your self-hosted WordPress blog or site, you can do that by following these instructions:"
+			) }
+		</p>
 
-					<ol>
-						<li>
-							<strong>{ this.props.translate( 'Install the Jetpack plugin.' ) }</strong>
-							<br />
-							<a href="http://jetpack.me/install/">
-								{ this.props.translate( 'Please follow these instructions to install Jetpack' ) }
-							</a>.
-						</li>
-						<li>{ this.props.translate( 'Connect Jetpack to WordPress.com.' ) }</li>
-						<li>
-							{ this.props.translate(
-								'Now you can sign in to the app using the WordPress.com account Jetpack is connected to, and you can find your self-hosted site under the "My Sites" section.'
-							) }
-						</li>
-					</ol>
-				</div>
-			);
-		}
-	}
-);
+		<ol>
+			<li>
+				<strong>{ translate( 'Install the Jetpack plugin.' ) }</strong>
+				<br />
+				<a href="http://jetpack.me/install/">
+					{ translate( 'Please follow these instructions to install Jetpack' ) }
+				</a>.
+			</li>
+			<li>{ translate( 'Connect Jetpack to WordPress.com.' ) }</li>
+			<li>
+				{ translate(
+					'Now you can sign in to the app using the WordPress.com account Jetpack is connected to, ' +
+						'and you can find your self-hosted site under the "My Sites" section.'
+				) }
+			</li>
+		</ol>
+	</div>
+) );
 
 module.exports = localize(
 	createReactClass( {
@@ -157,11 +144,12 @@ module.exports = localize(
 		},
 
 		toggleSelfHostedInstructions: function() {
-			var isShowing = ! this.state.showInstructions;
+			const isShowing = ! this.state.showInstructions;
 			this.setState( { showInstructions: isShowing } );
 		},
 
 		render: function() {
+			const { translate } = this.props;
 			const { requires2fa, inProgress, errorMessage, errorLevel, showInstructions } = this.state;
 
 			return (
@@ -176,7 +164,7 @@ module.exports = localize(
 										name="login"
 										ref="login"
 										disabled={ requires2fa || inProgress }
-										placeholder={ this.props.translate( 'Username or email address' ) }
+										placeholder={ translate( 'Username or email address' ) }
 										onFocus={ this.recordFocusEvent( 'Username or email address' ) }
 										valueLink={ this.linkState( 'login' ) }
 									/>
@@ -187,7 +175,7 @@ module.exports = localize(
 										name="password"
 										ref="password"
 										disabled={ requires2fa || inProgress }
-										placeholder={ this.props.translate( 'Password' ) }
+										placeholder={ translate( 'Password' ) }
 										onFocus={ this.recordFocusEvent( 'Password' ) }
 										hideToggle={ requires2fa }
 										submitting={ inProgress }
@@ -201,7 +189,7 @@ module.exports = localize(
 											type="number"
 											ref="auth_code"
 											disabled={ inProgress }
-											placeholder={ this.props.translate( 'Verification code' ) }
+											placeholder={ translate( 'Verification code' ) }
 											onFocus={ this.recordFocusEvent( 'Verification code' ) }
 											valueLink={ this.linkState( 'auth_code' ) }
 										/>
@@ -213,11 +201,7 @@ module.exports = localize(
 									disabled={ ! this.canSubmitForm() }
 									onClick={ this.recordClickEvent( 'Sign in' ) }
 								>
-									{ requires2fa ? (
-										this.props.translate( 'Verify' )
-									) : (
-										this.props.translate( 'Sign in' )
-									) }
+									{ requires2fa ? translate( 'Verify' ) : translate( 'Sign in' ) }
 								</FormButton>
 							</FormButtonsBar>
 							{ ! requires2fa && <LostPassword /> }
@@ -232,16 +216,16 @@ module.exports = localize(
 							className="auth__help"
 							target="_blank"
 							rel="noopener noreferrer"
-							title={ this.props.translate( 'Visit the WordPress.com support site for help' ) }
+							title={ translate( 'Visit the WordPress.com support site for help' ) }
 							href="https://en.support.wordpress.com/"
 						>
 							<Gridicon icon="help" />
 						</a>
 						<div className="auth__links">
 							<a href="#" onClick={ this.toggleSelfHostedInstructions }>
-								{ this.props.translate( 'Add self-hosted site' ) }
+								{ translate( 'Add self-hosted site' ) }
 							</a>
-							<a href={ config( 'signup_url' ) }>{ this.props.translate( 'Create account' ) }</a>
+							<a href={ config( 'signup_url' ) }>{ translate( 'Create account' ) }</a>
 						</div>
 						{ showInstructions && (
 							<SelfHostedInstructions onClickClose={ this.toggleSelfHostedInstructions } />

--- a/client/auth/lost-password.jsx
+++ b/client/auth/lost-password.jsx
@@ -1,0 +1,26 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import { addLocaleToWpcomUrl, getLocaleSlug } from 'lib/i18n-utils';
+
+const LostPassword = ( { translate } ) => {
+	const url = addLocaleToWpcomUrl(
+		'https://wordpress.com/wp-login.php?action=lostpassword',
+		getLocaleSlug()
+	);
+	return (
+		<p className="auth__lost-password">
+			<a href={ url } target="_blank" rel="noopener noreferrer">
+				{ translate( 'Lost your password?' ) }
+			</a>
+		</p>
+	);
+};
+
+export default localize( LostPassword );

--- a/client/auth/self-hosted-instructions.jsx
+++ b/client/auth/self-hosted-instructions.jsx
@@ -1,0 +1,45 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { localize } from 'i18n-calypso';
+import Gridicon from 'gridicons';
+
+const SelfHostedInstructions = ( { onClickClose, translate } ) => (
+	<div className="auth__self-hosted-instructions">
+		<a href="#" onClick={ onClickClose } className="auth__self-hosted-instructions-close">
+			<Gridicon icon="cross" size={ 24 } />
+		</a>
+
+		<h2>{ translate( 'Add self-hosted site' ) }</h2>
+		<p>
+			{ translate(
+				'By default when you sign into the WordPress.com app, you can edit blogs and sites hosted at WordPress.com'
+			) }
+		</p>
+		<p>
+			{ translate(
+				"If you'd like to edit your self-hosted WordPress blog or site, you can do that by following these instructions:"
+			) }
+		</p>
+
+		<ol>
+			<li>
+				<strong>{ translate( 'Install the Jetpack plugin.' ) }</strong>
+				<br />
+				<a href="http://jetpack.me/install/">
+					{ translate( 'Please follow these instructions to install Jetpack' ) }
+				</a>.
+			</li>
+			<li>{ translate( 'Connect Jetpack to WordPress.com.' ) }</li>
+			<li>
+				{ translate(
+					'Now you can sign in to the app using the WordPress.com account Jetpack is connected to, ' +
+						'and you can find your self-hosted site under the "My Sites" section.'
+				) }
+			</li>
+		</ol>
+	</div>
+);
+
+export default localize( SelfHostedInstructions );

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -855,10 +855,10 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000743"
+      "version": "1.0.30000744"
     },
     "caniuse-lite": {
-      "version": "1.0.30000743"
+      "version": "1.0.30000744"
     },
     "cardinal": {
       "version": "1.0.0",
@@ -920,11 +920,29 @@
       }
     },
     "cheerio": {
-      "version": "0.20.0",
+      "version": "0.22.0",
       "dev": true,
       "dependencies": {
         "entities": {
           "version": "1.1.1",
+          "dev": true
+        },
+        "htmlparser2": {
+          "version": "3.9.2",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.3.3",
+          "dev": true,
+          "dependencies": {
+            "inherits": {
+              "version": "2.0.3",
+              "dev": true
+            }
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.3",
           "dev": true
         }
       }
@@ -1627,8 +1645,18 @@
       "version": "1.0.0"
     },
     "enzyme": {
-      "version": "2.4.1",
-      "dev": true
+      "version": "2.9.1",
+      "dev": true,
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.4",
+          "dev": true
+        },
+        "uuid": {
+          "version": "3.1.0",
+          "dev": true
+        }
+      }
     },
     "errno": {
       "version": "0.1.4",
@@ -1795,20 +1823,8 @@
       "version": "1.1.0",
       "dev": true,
       "dependencies": {
-        "fast-levenshtein": {
-          "version": "1.1.4",
-          "dev": true
-        },
         "jest-docblock": {
           "version": "20.0.3",
-          "dev": true
-        },
-        "optionator": {
-          "version": "0.8.1",
-          "dev": true
-        },
-        "wordwrap": {
-          "version": "1.0.0",
           "dev": true
         }
       }
@@ -1829,8 +1845,16 @@
           "version": "1.5.0",
           "dev": true
         },
+        "fast-levenshtein": {
+          "version": "2.0.6",
+          "dev": true
+        },
         "inquirer": {
           "version": "0.12.0",
+          "dev": true
+        },
+        "optionator": {
+          "version": "0.8.2",
           "dev": true
         },
         "strip-bom": {
@@ -1847,6 +1871,10 @@
         },
         "user-home": {
           "version": "2.0.0",
+          "dev": true
+        },
+        "wordwrap": {
+          "version": "1.0.0",
           "dev": true
         }
       }
@@ -2025,7 +2053,7 @@
       "version": "1.0.2"
     },
     "fast-levenshtein": {
-      "version": "2.0.6",
+      "version": "1.1.4",
       "dev": true
     },
     "fast-luhn": {
@@ -2667,6 +2695,10 @@
     },
     "function-bind": {
       "version": "1.1.1"
+    },
+    "function.prototype.name": {
+      "version": "1.0.3",
+      "dev": true
     },
     "fuse.js": {
       "version": "2.6.1"
@@ -3640,21 +3672,7 @@
     },
     "jest-environment-jsdom": {
       "version": "21.2.1",
-      "dev": true,
-      "dependencies": {
-        "acorn": {
-          "version": "4.0.13",
-          "dev": true
-        },
-        "jsdom": {
-          "version": "9.12.0",
-          "dev": true
-        },
-        "webidl-conversions": {
-          "version": "4.0.2",
-          "dev": true
-        }
-      }
+      "dev": true
     },
     "jest-environment-node": {
       "version": "21.2.1",
@@ -4147,18 +4165,12 @@
       }
     },
     "jsdom": {
-      "version": "7.2.2",
+      "version": "9.12.0",
       "dev": true,
-      "optional": true,
       "dependencies": {
         "acorn": {
-          "version": "2.7.0",
+          "version": "4.0.13",
           "dev": true
-        },
-        "acorn-globals": {
-          "version": "1.0.9",
-          "dev": true,
-          "optional": true
         }
       }
     },
@@ -4393,6 +4405,14 @@
     "lodash.assign": {
       "version": "4.2.0"
     },
+    "lodash.assignin": {
+      "version": "4.2.0",
+      "dev": true
+    },
+    "lodash.bind": {
+      "version": "4.2.1",
+      "dev": true
+    },
     "lodash.camelcase": {
       "version": "4.3.0"
     },
@@ -4400,12 +4420,24 @@
       "version": "3.0.2",
       "dev": true
     },
+    "lodash.defaults": {
+      "version": "4.2.0",
+      "dev": true
+    },
     "lodash.escape": {
       "version": "3.2.0",
       "dev": true
     },
+    "lodash.filter": {
+      "version": "4.6.0",
+      "dev": true
+    },
     "lodash.flatten": {
       "version": "4.4.0"
+    },
+    "lodash.foreach": {
+      "version": "4.5.0",
+      "dev": true
     },
     "lodash.isarguments": {
       "version": "3.1.0",
@@ -4422,7 +4454,27 @@
       "version": "3.1.2",
       "dev": true
     },
+    "lodash.map": {
+      "version": "4.6.0",
+      "dev": true
+    },
+    "lodash.merge": {
+      "version": "4.6.0",
+      "dev": true
+    },
+    "lodash.pick": {
+      "version": "4.4.0",
+      "dev": true
+    },
     "lodash.pickby": {
+      "version": "4.6.0",
+      "dev": true
+    },
+    "lodash.reduce": {
+      "version": "4.6.0",
+      "dev": true
+    },
+    "lodash.reject": {
       "version": "4.6.0",
       "dev": true
     },
@@ -4432,6 +4484,10 @@
     },
     "lodash.snakecase": {
       "version": "4.1.1"
+    },
+    "lodash.some": {
+      "version": "4.6.0",
+      "dev": true
     },
     "lodash.template": {
       "version": "3.6.2",
@@ -4641,7 +4697,7 @@
       }
     },
     "mout": {
-      "version": "1.0.0",
+      "version": "1.1.0",
       "dev": true
     },
     "ms": {
@@ -4927,6 +4983,10 @@
     "object.assign": {
       "version": "4.0.4"
     },
+    "object.entries": {
+      "version": "1.0.4",
+      "dev": true
+    },
     "object.omit": {
       "version": "2.0.1"
     },
@@ -4957,7 +5017,7 @@
       "dev": true
     },
     "optionator": {
-      "version": "0.8.2",
+      "version": "0.8.1",
       "dev": true,
       "dependencies": {
         "wordwrap": {
@@ -5540,10 +5600,6 @@
       "resolved": "git://github.com/reactjs/react-codemod.git#0e6aabb233453b17c23d68bb181a3d70ad03f9c9",
       "dev": true,
       "dependencies": {
-        "acorn": {
-          "version": "4.0.13",
-          "dev": true
-        },
         "babel-jest": {
           "version": "15.0.0",
           "dev": true
@@ -5692,10 +5748,6 @@
           "version": "17.0.2",
           "dev": true
         },
-        "jsdom": {
-          "version": "9.12.0",
-          "dev": true
-        },
         "minimist": {
           "version": "1.2.0",
           "dev": true
@@ -5738,10 +5790,6 @@
         },
         "watch": {
           "version": "0.10.0",
-          "dev": true
-        },
-        "webidl-conversions": {
-          "version": "4.0.2",
           "dev": true
         },
         "yargs": {
@@ -7126,9 +7174,8 @@
       }
     },
     "webidl-conversions": {
-      "version": "2.0.1",
-      "dev": true,
-      "optional": true
+      "version": "4.0.2",
+      "dev": true
     },
     "webpack": {
       "version": "3.4.1",
@@ -7510,11 +7557,6 @@
           "dev": true
         }
       }
-    },
-    "whatwg-url-compat": {
-      "version": "0.6.5",
-      "dev": true,
-      "optional": true
     },
     "which": {
       "version": "1.3.0"

--- a/package.json
+++ b/package.json
@@ -247,7 +247,7 @@
     "chai": "3.5.0",
     "chai-enzyme": "0.5.2",
     "deep-freeze": "0.0.1",
-    "enzyme": "2.4.1",
+    "enzyme": "2.9.1",
     "esformatter": "0.7.3",
     "esformatter-braces": "1.2.1",
     "esformatter-collapse-objects-a8c": "0.1.0",


### PR DESCRIPTION
Rationale: We're trying to get rid of mixin auto-injection for the React 16 upgrade, since this relies on methods (`react/lib`) that aren't part of the public interface.

This was tricky. These tests were a bit dubious in the first place, since they were arguably diluting the concept of a _unit_ test. My fix was to use `enzyme` to shallow-render the component, which brings us closer to actual unit testing.

I also ran the `i18n` and `createClass` codemods on `login.jsx`, and modified it to `export` the un-`localize()`d `Login` component so we could test it (without having to inject the `i18n` mixin, which was the whole point of this PR). That's pretty standard stuff tho.

Other than that, I tried to change tests as little as possible. To continue to pass a callback to `setState` in tests, I had to upgrade `enzyme` (0dc78297f30fd613f550a09c660c18d41507f577):

> 2.5.0 supports passing callbacks to `setState`, which we require for `client/auth/test/login`.
Furthermore, there's a fix in 2.6.0 that's required for this to actually work
(airbnb/enzyme#490)
Not updating to >=3.0.0 yet since chai-expect isn't compatible (yet).
Changelog: https://github.com/airbnb/enzyme/blob/master/CHANGELOG.md#252-november-9-2016

To test:
* Verify that tests pass.
* Verify that login still works.