### PR TITLE
Plugins: fix document title of the Single Plugin page

### DIFF
--- a/client/my-sites/plugins/plugin.jsx
+++ b/client/my-sites/plugins/plugin.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react';
+import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
 import { includes, uniq, upperFirst } from 'lodash';
 
@@ -101,7 +102,7 @@ const SinglePlugin = React.createClass( {
 	},
 
 	buildPageTitle( pluginName ) {
-		return this.translate( '%(pluginName)s Plugin', '%(pluginName)s Plugins', {
+		return this.props.translate( '%(pluginName)s Plugin', '%(pluginName)s Plugins', {
 			count: pluginName.toLowerCase() !== 'standard' | 0,
 			args: { pluginName: upperFirst( this._currentPageTitle ) },
 			textOnly: true,
@@ -202,14 +203,15 @@ const SinglePlugin = React.createClass( {
 	},
 
 	getPluginDoesNotExistView( selectedSite ) {
-		const actionUrl = '/plugins' + ( selectedSite ? '/' + selectedSite.slug : '' ),
-			action = this.translate( 'Browse all plugins' );
+		const { translate } = this.props;
+		const actionUrl = '/plugins' + ( selectedSite ? '/' + selectedSite.slug : '' );
+		const action = translate( 'Browse all plugins' );
 
 		return (
 			<MainComponent>
 				<JetpackManageErrorPage
-					title={ this.translate( 'Oops! We can\'t find this plugin!' ) }
-					line={ this.translate( 'The plugin you are looking for doesn\'t exist.' ) }
+					title={ translate( 'Oops! We can\'t find this plugin!' ) }
+					line={ translate( 'The plugin you are looking for doesn\'t exist.' ) }
 					actionURL={ actionUrl }
 					action={ action }
 					illustration="/calypso/images/illustrations/illustration-404.svg" />
@@ -241,17 +243,24 @@ const SinglePlugin = React.createClass( {
 			return;
 		}
 
+		const { translate } = this.props;
+
 		return (
 			<div>
 				<PluginSiteList
 					className="plugin__installed-on"
-					title={ this.translate( 'Installed on', { comment: 'header for list of sites a plugin is installed on' } ) }
+					title={ translate( 'Installed on', {
+						comment: 'header for list of sites a plugin is installed on'
+					} ) }
 					sites={ this.state.sites }
 					plugin={ plugin }
-					notices={ this.state.notices } />
+					notices={ this.state.notices }
+				/>
 				{ plugin.wporg && <PluginSiteList
 					className="plugin__not-installed-on"
-					title={ this.translate( 'Available sites', { comment: 'header for list of sites a plugin can be installed on' } ) }
+					title={ translate( 'Available sites', {
+						comment: 'header for list of sites a plugin can be installed on'
+					} ) }
 					sites={ this.state.notInstalledSites }
 					plugin={ plugin }
 					notices={ this.state.notices } /> }
@@ -344,7 +353,7 @@ const SinglePlugin = React.createClass( {
 					<SidebarNavigation />
 					<JetpackManageErrorPage
 						template="optInManage"
-						title={ this.translate( 'Looking to manage this site\'s plugins?' ) }
+						title={ this.props.translate( 'Looking to manage this site\'s plugins?' ) }
 						siteId={ selectedSite.ID }
 						section="plugins"
 						featureExample={ this.getMockPlugin() } />
@@ -418,4 +427,4 @@ export default connect(
 		recordGoogleEvent,
 		wporgFetchPluginData
 	}
-)( SinglePlugin );
+)( localize( SinglePlugin ) );

--- a/client/my-sites/plugins/plugin.jsx
+++ b/client/my-sites/plugins/plugin.jsx
@@ -4,7 +4,7 @@
 import React from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
-import { includes, uniq, upperFirst } from 'lodash';
+import { includes, uniq } from 'lodash';
 
 /**
  * Internal dependencies
@@ -44,8 +44,6 @@ import NoPermissionsError from './no-permissions-error';
 const SinglePlugin = React.createClass( {
 	_DEFAULT_PLUGINS_BASE_PATH: 'http://wordpress.org/plugins/',
 
-	_currentPageTitle: null,
-
 	mixins: [ PluginNotices ],
 
 	componentWillMount() {
@@ -57,7 +55,6 @@ const SinglePlugin = React.createClass( {
 	componentDidMount() {
 		PluginsStore.on( 'change', this.refreshSitesAndPlugins );
 		PluginsLog.on( 'change', this.refreshSitesAndPlugins );
-		this.updatePageTitle();
 	},
 
 	getInitialState() {
@@ -90,36 +87,20 @@ const SinglePlugin = React.createClass( {
 		return {
 			sites: PluginsStore.getSites( sites, props.pluginSlug ) || [],
 			notInstalledSites: PluginsStore.getNotInstalledSites( sites, props.pluginSlug ) || [],
-			plugin: plugin,
-			pageTitle: this.buildPageTitle( plugin.name ),
+			plugin,
 		};
 	},
 
 	refreshSitesAndPlugins( nextProps ) {
 		this.setState( this.getSitesPlugin( nextProps ) );
-		// setTimeout to avoid React dispatch conflicts.
-		this.updatePageTitle();
 	},
 
-	buildPageTitle( pluginName ) {
-		return this.props.translate( '%(pluginName)s Plugin', '%(pluginName)s Plugins', {
-			count: pluginName.toLowerCase() !== 'standard' | 0,
-			args: { pluginName: upperFirst( this._currentPageTitle ) },
+	getPageTitle() {
+		const plugin = this.getPlugin();
+		return this.props.translate( '%(pluginName)s Plugin', {
+			args: { pluginName: plugin.name },
 			textOnly: true,
 			context: 'Page title: Plugin detail'
-		} );
-	},
-
-	updatePageTitle() {
-		const pageTitle = this.state.plugin ? this.state.plugin.name : this.props.pluginSlug;
-		if ( this._currentPageTitle === pageTitle ) {
-			return;
-		}
-
-		this._currentPageTitle = pageTitle;
-
-		this.setState( {
-			pageTitle: this.buildPageTitle( pageTitle )
 		} );
 	},
 
@@ -235,7 +216,7 @@ const SinglePlugin = React.createClass( {
 	},
 
 	renderDocumentHead() {
-		return <DocumentHead title={ this.state.pageTitle } />;
+		return <DocumentHead title={ this.getPageTitle() } />;
 	},
 
 	renderSitesList( plugin ) {
@@ -331,7 +312,7 @@ const SinglePlugin = React.createClass( {
 		const { selectedSite } = this.props;
 
 		if ( ! this.props.isRequestingSites && ! this.props.userCanManagePlugins ) {
-			return <NoPermissionsError title={ this.state.pageTitle } />;
+			return <NoPermissionsError title={ this.getPageTitle() } />;
 		}
 
 		const plugin = this.getPlugin();


### PR DESCRIPTION
Fixes a bug where the document title of a Single Plugin page contains the capitalized plugin slug (i.e., "Wordpress-seo Plugin") instead of the real name ("Yoast SEO Plugin").

The plugin information is loaded from two sources:
- the first part is basic info from WP.com API that contains just the plugin slug and list of sites where it's installed
- the second part is the detailed info from WP.org API that contains the real name and detailed description

Both these pieces of data need to be loaded and the page needs to be updated when async loading if these data is finished.

The bug has two main causes:
- wrong usage of `this.setState` that doesn't account for the fact that `this.setState` is asynchronous. Something like:
```js
this.setState( { plugin: newPluginData } );
// at this moment, state update is merely scheduled to be performed asynchonously at
// a later time that React finds convenient. `this.state` still has old data.
this.updatePageTitle( this.state.plugin );
```
- when WP.org data arrive, `this.state.pageTitle` is not updated and still has the old value

I fixed this bug by simplifying the code. Instead of updating `this.state.pageTitle`, just create a selector function `this.getPageTitle()` that rebuilds the title on each rerender.

I also removed legacy code that rendered title "Standard Plugins" in some cases that no longer exist in the code.

**How to review:**
There are two commits: the first one is a codemod change that upgrades `this.translate` calls to the `localize` HOC. The second commit contains the actual bugfix.

**How to test:**
1. Go to `/plugins/wordpress-seo`
2. Check that the document title is "Yoast SEO Plugin -- WordPress.com"
