### PR TITLE
Extensions: Zoninator - Show preview for zone posts whenever available

### DIFF
--- a/client/extensions/zoninator/components/forms/zone-content-form/posts-list.jsx
+++ b/client/extensions/zoninator/components/forms/zone-content-form/posts-list.jsx
@@ -89,7 +89,7 @@ class PostsList extends Component {
 						<SortableList direction="vertical" onChange={ this.changePostOrder( fields ) }>
 							{ posts.map( ( post, index ) => (
 								<PostCard
-									key={ index }
+									key={ post.id }
 									postId={ post.id }
 									postTitle={ post.title }
 									siteId={ post.siteId }

--- a/client/extensions/zoninator/components/forms/zone-content-form/posts-list.jsx
+++ b/client/extensions/zoninator/components/forms/zone-content-form/posts-list.jsx
@@ -79,25 +79,26 @@ class PostsList extends Component {
 					</SearchAutocomplete>
 				</FormFieldset>
 
-				{ !! posts.length &&
-					! requesting && (
-						<FormFieldset>
-							<p className={ explanationTextClass }>
-								{ translate(
-									"You can reorder the zone's content by dragging it to a different location on the list."
-								) }
-							</p>
-							<SortableList direction="vertical" onChange={ this.changePostOrder( fields ) }>
-								{ posts.map( ( post, index ) => (
-									<PostCard
-										key={ index }
-										post={ post }
-										remove={ this.removePost( fields, index ) }
-									/>
-								) ) }
-							</SortableList>
-						</FormFieldset>
-					) }
+				{ !! posts.length && ! requesting && (
+					<FormFieldset>
+						<p className={ explanationTextClass }>
+							{ translate(
+								"You can reorder the zone's content by dragging it to a different location on the list."
+							) }
+						</p>
+						<SortableList direction="vertical" onChange={ this.changePostOrder( fields ) }>
+							{ posts.map( ( post, index ) => (
+								<PostCard
+									key={ index }
+									postId={ post.id }
+									postTitle={ post.title }
+									siteId={ post.siteId }
+									remove={ this.removePost( fields, index ) }
+								/>
+							) ) }
+						</SortableList>
+					</FormFieldset>
+				) }
 
 				{ requesting && times( 3, index => <PostPlaceholder key={ index } /> ) }
 			</div>


### PR DESCRIPTION
This PR adds the capability to display a post preview rather than opening the page in a new tab when clicking *View* on a post on Zoninator's *Edit zone* view.

# Testing

- Open `/extensions/zoninator` and a zone to open *Edit zone* view and make sure there are some posts in the zone.
- Validate that clicking **View** button brings up a preview or opens a new tab depending on if the preview is available.