### PR TITLE
Settings: Fix media library popup too small when changing site icon

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -458,6 +458,7 @@
 @import 'my-sites/domains/domain-management/email/style';
 @import 'my-sites/domains/domain-management/components/icann-verification/style';
 @import 'notifications/style';
+@import 'post-editor/media-modal/style';
 @import 'reader/discover/style';
 @import 'reader/following/style';
 @import 'reader/following-manage/style';

--- a/assets/stylesheets/sections/post-editor.scss
+++ b/assets/stylesheets/sections/post-editor.scss
@@ -7,6 +7,7 @@
 @import '../main';
 @import '../shared/forms';
 @import 'components/accordion/style';
+@import 'components/card/style';
 @import 'components/global-notices/style';
 @import 'components/select-dropdown/style';
 @import 'layout/sidebar/style';
@@ -52,4 +53,3 @@
 @import 'post-editor/editor-title/style';
 @import 'post-editor/editor-visibility/style';
 @import 'post-editor/editor-word-count/style';
-@import 'post-editor/media-modal/style';


### PR DESCRIPTION
This pull request fixes #18460 by making sure the media modal stylesheet is loaded when the user accesses the `Settings` page. Previously, because of https://github.com/Automattic/wp-calypso/pull/18194, this particular stylesheet was only loaded when the post editor was displayed.

#### Before

<img width="960" alt="before" src="https://user-images.githubusercontent.com/594356/31125797-e8840bc0-a849-11e7-8a99-2aaab9dc4c41.png">

#### After

<img width="960" alt="after" src="https://user-images.githubusercontent.com/594356/31125804-ee160692-a849-11e7-8b2b-a9832f722df2.png">

#### Testing instructions

1. Run `git checkout fix/site-icon-popup` and start your server, or open a [live branch](https://calypso.live/?branch=fix/site-icon-popup)
2. Open the [`General Settings` page](http://calypso.localhost:3000/settings/general)
3. Click the `Change` button in the `Site Profile` section
4. Asserts that the media library displays normally

#### Reviews

- [x] Code
- [x] Product