### PR TITLE
Pages: Update schedule indicator to use relative time status component

### DIFF
--- a/client/my-sites/pages/page-card-info/index.jsx
+++ b/client/my-sites/pages/page-card-info/index.jsx
@@ -49,6 +49,7 @@ function PageCardInfo( {
 					post={ page }
 					link={ contentLink.contentLinkURL }
 					target={ contentLink.contentLinkTarget }
+					gridiconSize={ iconSize }
 				/>
 			);
 		}

--- a/client/my-sites/pages/page-card-info/index.jsx
+++ b/client/my-sites/pages/page-card-info/index.jsx
@@ -31,34 +31,45 @@ const getContentLink = ( state, siteId, page ) => {
 	return { contentLinkURL, contentLinkTarget };
 };
 
-function PageCardInfo( { translate, moment, page, showTimestamp, isFront, isPosts, siteUrl, contentLink } ) {
+function PageCardInfo( {
+	translate,
+	moment,
+	page,
+	showTimestamp,
+	isFront,
+	isPosts,
+	siteUrl,
+	contentLink,
+} ) {
 	const iconSize = 12;
-	const renderPageTimestamp = function() {
+	const renderFutureTimestamp = function() {
 		if ( page.status === 'future' ) {
 			return (
 				<PostRelativeTimeStatus
 					post={ page }
 					link={ contentLink.contentLinkURL }
-					target={ contentLink.contentLinkTarget } />
+					target={ contentLink.contentLinkTarget }
+				/>
 			);
 		}
 
-		return (
-			<span className="page-card-info__item">
-				<Gridicon icon="time" size={ iconSize } className="page-card-info__item-icon" />
-				<span className="page-card-info__item-text">
-					{ moment( page.modified ).fromNow() }
-				</span>
-			</span>
-		);
+		return null;
 	};
 
 	return (
 		<div className="page-card-info">
 			{ siteUrl && <div className="page-card-info__site-url">{ siteUrl }</div> }
 			<div>
-				{ showTimestamp && renderPageTimestamp() }
-				{ isFront &&
+				{ showTimestamp &&
+					( renderFutureTimestamp() || (
+						<span className="page-card-info__item">
+							<Gridicon icon="time" size={ iconSize } className="page-card-info__item-icon" />
+							<span className="page-card-info__item-text">
+								{ moment( page.modified ).fromNow() }
+							</span>
+						</span>
+					) ) }
+				{ isFront && (
 					<span className="page-card-info__item">
 						<Gridicon icon="house" size={ iconSize } className="page-card-info__item-icon" />
 						<span className="page-card-info__item-text">{ translate( 'Front page' ) }</span>

--- a/client/my-sites/pages/page-card-info/style.scss
+++ b/client/my-sites/pages/page-card-info/style.scss
@@ -2,6 +2,15 @@
 	color: $gray-text-min;
 	font-size: 12px;
 	vertical-align: middle;
+
+	a,
+	&.post-actions__relative-time {
+		color: $gray-text-min;
+
+		&:hover {
+			color: $blue-medium;
+		}
+	}
 }
 
 .page-card-info__item {
@@ -28,4 +37,8 @@
 
 .page-card-info__site-url {
 	font-style: italic;
+}
+
+p.post-relative-time-status {
+	margin-bottom: 0px;
 }

--- a/client/my-sites/pages/page-card-info/style.scss
+++ b/client/my-sites/pages/page-card-info/style.scss
@@ -41,4 +41,13 @@
 
 p.post-relative-time-status {
 	margin-bottom: 0px;
+
+	& .post-relative-time-status__time-text,
+	.post-relative-time-status__status-text {
+		vertical-align: middle;
+	}
+
+	& .gridicon {
+		margin: 0px 4px 0 0;
+	}
 }

--- a/client/my-sites/post-relative-time-status/index.jsx
+++ b/client/my-sites/post-relative-time-status/index.jsx
@@ -24,6 +24,7 @@ const PostRelativeTime = React.createClass( {
 		includeNonDraftStatuses: PropTypes.bool,
 		link: PropTypes.string,
 		target: PropTypes.string,
+		gridiconSize: PropTypes.number,
 	},
 
 	getDefaultProps: function() {
@@ -55,7 +56,7 @@ const PostRelativeTime = React.createClass( {
 
 		return (
 			<span className="post-relative-time-status__time">
-				<Gridicon icon="time" size={ 18 } />
+				<Gridicon icon="time" size={ this.props.gridiconSize || 18 } />
 				<time className="post-relative-time-status__time-text" dateTime={ time }>
 					{ this.props.moment( time ).fromNow() }
 				</time>
@@ -97,7 +98,7 @@ const PostRelativeTime = React.createClass( {
 		if ( statusText ) {
 			return (
 				<span className={ statusClassName }>
-					<Gridicon icon={ statusIcon } size={ 18 } />
+					<Gridicon icon={ statusIcon } size={ this.props.gridiconSize || 18 } />
 					<span className="post-relative-time-status__status-text">{ statusText }</span>
 				</span>
 			);

--- a/client/my-sites/post-relative-time-status/style.scss
+++ b/client/my-sites/post-relative-time-status/style.scss
@@ -6,6 +6,7 @@
 	}
 
 	// Apply colors on /posts/* cards
+	.pages__page-list &,
 	.posts__list & {
 		.is-sticky {
 			color: $orange-jazzy;


### PR DESCRIPTION
We have a [relative time status component](https://github.com/Automattic/wp-calypso/blob/master/client/my-sites/post-relative-time-status/index.jsx) that is used on [scheduled post lists](https://github.com/Automattic/wp-calypso/blob/master/client/blocks/post-actions/index.jsx#L57) to show when the post will be published (from the current time). This commit updates the pages list to use the same component. When viewing `/pages/scheduled/`, users should now see the indicator letting them know when the page will be scheduled. When clicked the link will either take them to the page editor or page preview when appropriate. 

These changes should only affect the scheduling tab for pages (not the published or draft tabs).

## To test
1. Load this branch.
2. Schedule a page or two to be published in the future.
3. Visit http://calypso.localhost:3000/pages/scheduled/. Underneath the post, you should see the scheduled indicator with a timestamp indicating when the page will be published.
4. Visit wordpress.com/pages/scheduled for the same site. You'll notice this indicator won't be present.

The link attribute on `PostRelativeTimeStatus` should change depending on the user role. I tested the following:

1. Loading http://calypso.localhost:3000/pages/scheduled/ for both an admin and editor user role. Both user roles worked as expected with the link pointing to the editor.
2. Loading the same URL as an author or contributor. Received error because I couldn't access that post type.

## Screenshots

Current

<img width="896" alt="screen shot 2017-10-03 at 7 12 23 am" src="https://user-images.githubusercontent.com/7240478/31126866-53333594-a80a-11e7-80e0-60a969483e32.png">


Updated

<img width="824" alt="screen shot 2017-10-03 at 7 12 29 am" src="https://user-images.githubusercontent.com/7240478/31126859-4f43d2e0-a80a-11e7-97d2-d45f5303504c.png">

Fixes: #18418