### PR TITLE
Only load the Google Analytics ecommerce plugin when necessary

### DIFF
--- a/client/lib/analytics/ad-tracking.js
+++ b/client/lib/analytics/ad-tracking.js
@@ -560,6 +560,9 @@ function recordOrder( cart, orderId ) {
 		return;
 	}
 
+	// load the ecommerce plugin
+	window.ga( 'require', 'ecommerce' );
+
 	// Purchase tracking happens in one of three ways:
 
 	// 1. Fire one tracking event that includes details about the entire order

--- a/client/lib/analytics/index.js
+++ b/client/lib/analytics/index.js
@@ -399,9 +399,6 @@ const analytics = {
 
 				window.ga( 'create', config( 'google_analytics_key' ), 'auto', parameters );
 
-				// Load the Ecommerce Plugin
-				window.ga( 'require', 'ecommerce' );
-
 				analytics.ga.initialized = true;
 			}
 		},


### PR DESCRIPTION
While exploring how we setup Google Analytics in Calypso, I found that we were always requiring the `ecommerce` plugin for all users / usage, even though it's only used after an order to record it to GA.

Couple of things to note:

- GA is disabled in dev and staging but [enabled in prod](https://github.com/Automattic/wp-calypso/blob/8c37d513667a2177ea90c0f53ccfe285818605ae/config/production.json#L136), make sure you're hitting the right endpoint during testing.

- there is no risk of loading multiple times the same plugin, `analytics.js` handles this:
![screen shot 2017-10-03 at 15 11 15](https://user-images.githubusercontent.com/1145270/31126825-3193866c-a84d-11e7-8dfd-443009ab4b61.png)

- there is no ordering issue between the `require` command and the various `send` commands using that e-commerce plugin because [GA blocks the command queue while loading asynchronously a plugin](https://developers.google.com/analytics/devguides/collection/analyticsjs/using-plugins#waiting_for_plugins_to_load).

