### PR TITLE
Components: Sortable List - Fix buggy drag & drop behaviour

### DIFF
--- a/client/components/forms/sortable-list/index.jsx
+++ b/client/components/forms/sortable-list/index.jsx
@@ -40,10 +40,12 @@ class SortableList extends React.Component {
 
 	componentDidMount() {
 		document.addEventListener( 'mousemove', this.onMouseMove );
+		document.addEventListener( 'mouseup', this.onMouseUp );
 	}
 
 	componentWillUnmount() {
 		document.removeEventListener( 'mousemove', this.onMouseMove );
+		document.removeEventListener( 'mouseup', this.onMouseUp );
 	}
 
 	getPositionForCursorElement = ( element, event ) => {

--- a/client/components/forms/sortable-list/index.scss
+++ b/client/components/forms/sortable-list/index.scss
@@ -18,6 +18,7 @@
 
 	&.is-active > * {
 		box-shadow: 0 0 0 2px white, 0 0 0 4px $blue-medium;
+		z-index: 10;
 	}
 
 	&.is-draggable.is-active {

--- a/client/components/forms/sortable-list/index.scss
+++ b/client/components/forms/sortable-list/index.scss
@@ -18,12 +18,11 @@
 
 	&.is-active > * {
 		box-shadow: 0 0 0 2px white, 0 0 0 4px $blue-medium;
-		z-index: 10;
+		z-index: z-index( 'root', '.sortable-list__item.is-draggable.is-active' );
 	}
 
 	&.is-draggable.is-active {
 		position: fixed;
-		z-index: z-index( 'root', '.sortable-list__item.is-draggable.is-active' );
 	}
 
 	&.is-shadow {


### PR DESCRIPTION
This PR attempts to fix two issues with `SortableList` component:

- `onMouseUp` event was not always firing on screen sizes below 660px wide and was causing the active items to 'hang' like described [here](https://github.com/Automattic/wp-calypso/pull/18405#issuecomment-333495004).
- The active item border on touch devices could get covered up by neighbouring items like so:
![screen shot 2017-10-03 at 14 58 13](https://user-images.githubusercontent.com/8056203/31126231-53e4f356-a84b-11e7-824f-709a77677de8.png)

# Testing:

The component is used in two places which need verification:

- **Zoninator**: Go to `/extensions/zoninator`, add/select a zone and try adding and reordering posts.
- **Edit media modal**: Create a new post and open the add media modal. Try adding multiple images and reordering them in the process to verify the component works.
