### PR TITLE
Components: remove valueLink usage from FormPhoneInput

### DIFF
--- a/client/components/forms/form-phone-input/index.jsx
+++ b/client/components/forms/form-phone-input/index.jsx
@@ -44,23 +44,14 @@ export class FormPhoneInput extends React.Component {
 	};
 
 	componentWillMount() {
-		this._maybeSetCountryStateFromList();
+		this.maybeSetCountryStateFromList();
 	}
 
 	componentDidUpdate() {
-		this._maybeSetCountryStateFromList();
+		this.maybeSetCountryStateFromList();
 	}
 
 	render() {
-		var countryValueLink = {
-				value: this.state.countryCode,
-				requestChange: this._handleCountryChange,
-			},
-			phoneValueLink = {
-				value: this.state.phoneNumber,
-				requestChange: this._handlePhoneChange,
-			};
-
 		return (
 			<div className={ classnames( this.props.className, 'form-phone-input' ) }>
 				<FormFieldset className="form-fieldset__country">
@@ -75,7 +66,8 @@ export class FormPhoneInput extends React.Component {
 						disabled={ this.props.isDisabled }
 						name="country_code"
 						ref="countryCode"
-						valueLink={ countryValueLink }
+						value={ this.state.countryCode }
+						onChange={ this.handleCountryChange }
 					/>
 				</FormFieldset>
 
@@ -87,45 +79,44 @@ export class FormPhoneInput extends React.Component {
 						{ ...this.props.phoneInputProps }
 						disabled={ this.props.isDisabled }
 						name="phone_number"
-						valueLink={ phoneValueLink }
+						value={ this.state.phoneNumber }
+						onChange={ this.handlePhoneChange }
 					/>
 				</FormFieldset>
 			</div>
 		);
 	}
 
-	_getCountryData = () => {
+	getCountryData() {
 		// TODO: move this to country-list or CountrySelect
 		return find( this.props.countriesList.get(), {
 			code: this.state.countryCode,
 		} );
+	}
+
+	handleCountryChange = event => {
+		this.setState( { countryCode: event.target.value }, this.triggerOnChange );
 	};
 
-	_handleCountryChange = newValue => {
-		this.setState( { countryCode: newValue }, this._triggerOnChange );
+	handlePhoneChange = event => {
+		this.setState( { phoneNumber: event.target.value }, this.triggerOnChange );
 	};
 
-	_handlePhoneChange = newValue => {
-		this.setState( { phoneNumber: newValue }, this._triggerOnChange );
-	};
-
-	_triggerOnChange = () => {
+	triggerOnChange = () => {
 		this.props.onChange( this.getValue() );
 	};
 
-	_cleanNumber = number => {
+	cleanNumber( number ) {
 		return number.replace( CLEAN_REGEX, '' );
-	};
+	}
 
 	// Set the default state of the country code selector, if not already set
-	_maybeSetCountryStateFromList = () => {
-		var countries;
-
+	maybeSetCountryStateFromList() {
 		if ( this.state.countryCode ) {
 			return;
 		}
 
-		countries = this.props.countriesList.get();
+		const countries = this.props.countriesList.get();
 		if ( ! countries.length ) {
 			return;
 		}
@@ -133,18 +124,18 @@ export class FormPhoneInput extends React.Component {
 		this.setState( {
 			countryCode: countries[ 0 ].code,
 		} );
-	};
+	}
 
-	_validate = number => {
+	validate( number ) {
 		return phoneValidation( number );
-	};
+	}
 
-	getValue = () => {
-		var countryData = this._getCountryData(),
-			numberClean = this._cleanNumber( this.state.phoneNumber ),
+	getValue() {
+		const countryData = this.getCountryData(),
+			numberClean = this.cleanNumber( this.state.phoneNumber ),
 			countryNumericCode = countryData ? countryData.numeric_code : '',
 			numberFull = countryNumericCode + numberClean,
-			isValid = this._validate( numberFull );
+			isValid = this.validate( numberFull );
 
 		return {
 			isValid: ! isValid.error,
@@ -153,7 +144,7 @@ export class FormPhoneInput extends React.Component {
 			phoneNumber: numberClean,
 			phoneNumberFull: numberFull,
 		};
-	};
+	}
 }
 
 export default localize( FormPhoneInput );


### PR DESCRIPTION
Remove `valueLink` usage from `FormPhoneInput` component and replaces them by the usual `value` and `onChange`.

This component is too specific to be codemodded.

The PR also does some janitorial changes:
- fix eslint errors about usage of `var`: replaced by `const`
- some methods don't really need to be autobound. Use classic ES6 methods for them. Saves some CPU cycles and a few memory bytes when instantiating such a component
- don't use the `_prefix` for methods: we usually don't do that in Calypso

**How to test:**
Go to `/devdocs/design/form-fields` and test the "Form Phone Input" component there. It's the one that looks like this:
<img width="550" alt="form-phone-input" src="https://user-images.githubusercontent.com/664258/31126961-b0220760-a84d-11e7-82db-ba4b63005b74.png">
Do both values update correctly? When inspecting with React devtools, is the component state as expected?

Another place to test is the form for SMS messages in `/me/security/account-recovery`
