### PR TITLE
 Editor: Ground control - Add history button to header

### DIFF
--- a/client/post-editor/editor-ground-control/history-button.jsx
+++ b/client/post-editor/editor-ground-control/history-button.jsx
@@ -2,26 +2,56 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { PureComponent } from 'react';
 import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
-import { NESTED_SIDEBAR_REVISIONS } from 'post-editor/editor-sidebar/constants';
+import {
+	NESTED_SIDEBAR_NONE,
+	NESTED_SIDEBAR_REVISIONS,
+} from 'post-editor/editor-sidebar/constants';
 
-const HistoryButton = ( { selectRevision, setNestedSidebar, translate } ) => (
-	<div className="editor-ground-control__history">
-		<button
-			className="editor-ground-control__save button is-link"
-			onClick={ function() {
-				selectRevision( null );
-				setNestedSidebar( NESTED_SIDEBAR_REVISIONS );
-			} }
-		>
-			{ translate( 'History' ) }
-		</button>
-	</div>
-);
+class HistoryButton extends PureComponent {
+	state = {
+		showingHistory: false,
+	};
+
+	toggleShowing = () => {
+		this.setState( {
+			showingHistory: ! this.state.showingHistory,
+		} );
+	};
+
+	componentWillUpdate( nextProps, nextState ) {
+		if ( nextState.showingHistory === this.state.showingHistory ) {
+			return;
+		}
+
+		const { selectRevision, setNestedSidebar } = this.props;
+
+		selectRevision( null );
+
+		if ( nextState.showingHistory ) {
+			setNestedSidebar( NESTED_SIDEBAR_REVISIONS );
+			return;
+		}
+		setNestedSidebar( NESTED_SIDEBAR_NONE );
+	}
+
+	render() {
+		return (
+			<div className="editor-ground-control__history">
+				<button
+					className="editor-ground-control__save button is-link"
+					onClick={ this.toggleShowing }
+				>
+					{ this.props.translate( 'History' ) }
+				</button>
+			</div>
+		);
+	}
+}
 
 export default localize( HistoryButton );

--- a/client/post-editor/editor-ground-control/history-button.jsx
+++ b/client/post-editor/editor-ground-control/history-button.jsx
@@ -5,12 +5,19 @@
 import React from 'react';
 import { localize } from 'i18n-calypso';
 
-const HistoryButton = ( { translate, onClick } ) => (
+/**
+ * Internal dependencies
+ */
+import { NESTED_SIDEBAR_REVISIONS } from 'post-editor/editor-sidebar/constants';
+
+const HistoryButton = ( { selectRevision, setNestedSidebar, translate } ) => (
 	<div className="editor-ground-control__history">
 		<button
 			className="editor-ground-control__save button is-link"
-			onClick={ onClick }
-			tabIndex={ 3 }
+			onClick={ function() {
+				selectRevision( null );
+				setNestedSidebar( NESTED_SIDEBAR_REVISIONS );
+			} }
 		>
 			{ translate( 'History' ) }
 		</button>

--- a/client/post-editor/editor-ground-control/history-button.jsx
+++ b/client/post-editor/editor-ground-control/history-button.jsx
@@ -1,0 +1,20 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { localize } from 'i18n-calypso';
+
+const HistoryButton = ( { translate, onClick } ) => (
+	<div className="editor-ground-control__history">
+		<button
+			className="editor-ground-control__save button is-link"
+			onClick={ onClick }
+			tabIndex={ 3 }
+		>
+			{ translate( 'History' ) }
+		</button>
+	</div>
+);
+
+export default localize( HistoryButton );

--- a/client/post-editor/editor-ground-control/index.jsx
+++ b/client/post-editor/editor-ground-control/index.jsx
@@ -27,6 +27,7 @@ import {
 	NESTED_SIDEBAR_REVISIONS,
 	NestedSidebarPropType,
 } from 'post-editor/editor-sidebar/constants';
+import HistoryButton from 'post-editor/editor-ground-control/history-button';
 
 export class EditorGroundControl extends PureComponent {
 	static propTypes = {
@@ -318,6 +319,7 @@ export class EditorGroundControl extends PureComponent {
 						) }
 					</div>
 				) }
+				<HistoryButton onClick={ this.onSaveButtonClick } />
 				{ this.renderGroundControlActionButtons() }
 			</Card>
 		);

--- a/client/post-editor/editor-ground-control/index.jsx
+++ b/client/post-editor/editor-ground-control/index.jsx
@@ -10,12 +10,13 @@ import { get, identity, noop } from 'lodash';
 import moment from 'moment';
 import page from 'page';
 import i18n, { localize } from 'i18n-calypso';
+import Gridicon from 'gridicons';
 
 /**
  * Internal dependencies
  */
+import { isEnabled } from 'config';
 import Card from 'components/card';
-import Gridicon from 'gridicons';
 import Site from 'blocks/site';
 import postUtils from 'lib/posts/utils';
 import siteUtils from 'lib/site/utils';
@@ -262,7 +263,10 @@ export class EditorGroundControl extends PureComponent {
 		const { isSaving, translate } = this.props;
 		const isSaveEnabled = this.isSaveEnabled();
 		const shouldShowStatusLabel = this.shouldShowStatusLabel();
-		const hasRevisions = get( this.props.post, 'revisions.length' );
+		const hasRevisions = (
+			isEnabled( 'post-editor/revisions' ) &&
+			get( this.props.post, 'revisions.length' )
+		);
 
 		return (
 			<Card className="editor-ground-control">

--- a/client/post-editor/editor-ground-control/index.jsx
+++ b/client/post-editor/editor-ground-control/index.jsx
@@ -319,7 +319,10 @@ export class EditorGroundControl extends PureComponent {
 						) }
 					</div>
 				) }
-				<HistoryButton onClick={ this.onSaveButtonClick } />
+				<HistoryButton
+					selectRevision={ this.props.selectRevision }
+					setNestedSidebar={ this.props.setNestedSidebar }
+				/>
 				{ this.renderGroundControlActionButtons() }
 			</Card>
 		);

--- a/client/post-editor/editor-ground-control/index.jsx
+++ b/client/post-editor/editor-ground-control/index.jsx
@@ -1,9 +1,7 @@
+/** @format */
 /**
  * External dependencies
- *
- * @format
  */
-
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { get, identity, noop } from 'lodash';
@@ -263,10 +261,8 @@ export class EditorGroundControl extends PureComponent {
 		const { isSaving, translate } = this.props;
 		const isSaveEnabled = this.isSaveEnabled();
 		const shouldShowStatusLabel = this.shouldShowStatusLabel();
-		const hasRevisions = (
-			isEnabled( 'post-editor/revisions' ) &&
-			get( this.props.post, 'revisions.length' )
-		);
+		const hasRevisions =
+			isEnabled( 'post-editor/revisions' ) && get( this.props.post, 'revisions.length' );
 
 		return (
 			<Card className="editor-ground-control">
@@ -324,16 +320,12 @@ export class EditorGroundControl extends PureComponent {
 						) }
 					</div>
 				) }
-				<HistoryButton
-					selectRevision={ this.props.selectRevision }
-					setNestedSidebar={ this.props.setNestedSidebar }
-				/>
-				{ hasRevisions &&
+				{ hasRevisions && (
 					<HistoryButton
 						selectRevision={ this.props.selectRevision }
 						setNestedSidebar={ this.props.setNestedSidebar }
 					/>
-				}
+				) }
 				{ this.renderGroundControlActionButtons() }
 			</Card>
 		);

--- a/client/post-editor/editor-ground-control/index.jsx
+++ b/client/post-editor/editor-ground-control/index.jsx
@@ -6,7 +6,7 @@
 
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import { identity, noop } from 'lodash';
+import { get, identity, noop } from 'lodash';
 import moment from 'moment';
 import page from 'page';
 import i18n, { localize } from 'i18n-calypso';
@@ -262,6 +262,7 @@ export class EditorGroundControl extends PureComponent {
 		const { isSaving, translate } = this.props;
 		const isSaveEnabled = this.isSaveEnabled();
 		const shouldShowStatusLabel = this.shouldShowStatusLabel();
+		const hasRevisions = get( this.props.post, 'revisions.length' );
 
 		return (
 			<Card className="editor-ground-control">
@@ -323,6 +324,12 @@ export class EditorGroundControl extends PureComponent {
 					selectRevision={ this.props.selectRevision }
 					setNestedSidebar={ this.props.setNestedSidebar }
 				/>
+				{ hasRevisions &&
+					<HistoryButton
+						selectRevision={ this.props.selectRevision }
+						setNestedSidebar={ this.props.setNestedSidebar }
+					/>
+				}
 				{ this.renderGroundControlActionButtons() }
 			</Card>
 		);

--- a/client/post-editor/editor-ground-control/style.scss
+++ b/client/post-editor/editor-ground-control/style.scss
@@ -17,6 +17,7 @@
 
 .editor-ground-control .site,
 .editor-ground-control .editor-ground-control__status,
+.editor-ground-control .editor-ground-control__history,
 .editor-ground-control .editor-ground-control__action-buttons {
 	height: 46px;
 	line-height: 46px;
@@ -55,6 +56,18 @@
 
 	@include breakpoint( "<660px" ) {
 		border-left: none;
+	}
+}
+
+.editor-ground-control__history {
+	display: flex;
+	min-height: 20px;
+	justify-content: space-between;
+	position: relative;
+	padding-left: 16px;
+
+	@include breakpoint( "<660px" ) {
+		display: none;
 	}
 }
 

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -363,6 +363,8 @@ export const PostEditor = React.createClass( {
 						onMoreInfoAboutEmailVerify={ this.onMoreInfoAboutEmailVerify }
 						allPostsUrl={ this.getAllPostsUrl() }
 						nestedSidebar={ this.state.nestedSidebar }
+						setNestedSidebar={ this.setNestedSidebar }
+						selectRevision={ this.selectRevision }
 					/>
 					<div className="post-editor__content">
 						<div className="post-editor__content-editor">


### PR DESCRIPTION
### Summary
Currently, to see the post revisions list, one would have to navigate through the editor sidebar > status and click the 'X Revisions' link.
To give post revisions a little more visibility we wanted to try adding a similar link to the post editor header.

Note that I've not removed the original link - I think this still gives some value in that it shows the number of revisions made and will remain the primary method for seeing these revisions on smaller screens - I'm open to change this, either in this PR or a future PR.

Also, I've taken the quickest route though I think I would prefer to see these actions and state handled in redux to avoid having to pass down two actions through various components as props - another change that I'd be happy to make in a future PR.

### Testing
- Create a new post - stay in the editor for this post
- Note that the header bar for the editor appears as normal and you can't see a history button yet
- Add some cat pictures, memes or other such great content.
- Save your post using the save the button in the top left:
  - <img width="238" alt="savebutton" src="https://user-images.githubusercontent.com/4335450/31127429-d53544c4-a846-11e7-8530-62eb5c164865.png">
- Repeat the process of making edits and save a couple of times.
- You should now see a new 'History' button.
  - <img width="318" alt="screen shot 2017-10-03 at 14 31 25" src="https://user-images.githubusercontent.com/4335450/31127832-e24e44fc-a847-11e7-8403-832dd06d4f19.png">

- Click the history button - this should open the post revisions view inside the editor sidebar and show the most recent revision in place of the editor.
  - <img width="740" alt="screen shot 2017-10-03 at 14 32 42" src="https://user-images.githubusercontent.com/4335450/31127802-ca644616-a847-11e7-9faa-ec72e15c18d4.png">


### Side Thoughts
I don't think that it's obvious enough that the main view is showing the selected revision (in place of the editor - I wonder if this could confuse some folk. Would a heading or note of some type showing 'Showing revision 2 of 5' or something be worth adding?
