### PR TITLE
Add isFirst meta flag to first message

### DIFF
--- a/client/lib/happychat/connection.js
+++ b/client/lib/happychat/connection.js
@@ -79,9 +79,9 @@ class Connection {
 		);
 	}
 
-	send( message ) {
+	send( message, meta = {} ) {
 		this.openSocket.then(
-			socket => socket.emit( 'message', { text: message, id: uuid() } ),
+			socket => socket.emit( 'message', { text: message, id: uuid(), meta } ),
 			e => debug( 'failed to send message', e )
 		);
 	}

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -145,7 +145,7 @@ class HelpContact extends React.Component {
 		const { howCanWeHelp, howYouFeel, message, site } = contactForm;
 
 		this.props.sendUserInfo( howCanWeHelp, howYouFeel, site );
-		this.props.sendHappychatMessage( message );
+		this.props.sendHappychatMessage( message, { isFirst: true } );
 
 		analytics.tracks.recordEvent( 'calypso_help_live_chat_begin', {
 			site_plan_product_id: site ? site.plan.product_id : null,

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -145,7 +145,7 @@ class HelpContact extends React.Component {
 		const { howCanWeHelp, howYouFeel, message, site } = contactForm;
 
 		this.props.sendUserInfo( howCanWeHelp, howYouFeel, site );
-		this.props.sendHappychatMessage( message, { isFirst: true } );
+		this.props.sendHappychatMessage( message, { includeInSummary: true } );
 
 		analytics.tracks.recordEvent( 'calypso_help_live_chat_begin', {
 			site_plan_product_id: site ? site.plan.product_id : null,

--- a/client/state/happychat/connection/actions.js
+++ b/client/state/happychat/connection/actions.js
@@ -35,7 +35,11 @@ export const setHappychatAvailable = isAvailable => ( {
 	isAvailable,
 } );
 
-export const sendChatMessage = message => ( { type: HAPPYCHAT_SEND_MESSAGE, message } );
+export const sendChatMessage = ( message, meta ) => ( {
+	type: HAPPYCHAT_SEND_MESSAGE,
+	message,
+	meta,
+} );
 
 /**
  * Returns an action object that sends information about the customer to happychat

--- a/client/state/happychat/middleware.js
+++ b/client/state/happychat/middleware.js
@@ -146,9 +146,9 @@ const onMessageChange = ( connection, message ) => {
 	}
 };
 
-const sendMessage = ( connection, message ) => {
+const sendMessage = ( connection, { message, meta } ) => {
 	debug( 'sending message', message );
-	connection.send( message );
+	connection.send( message, meta );
 	connection.notTyping();
 };
 
@@ -335,7 +335,7 @@ export default function( connection = null ) {
 				break;
 
 			case HAPPYCHAT_SEND_MESSAGE:
-				sendMessage( connection, action.message );
+				sendMessage( connection, action );
 				break;
 
 			case HAPPYCHAT_SET_CURRENT_MESSAGE:


### PR DESCRIPTION
This PR allows messages to have metadata, and adds a `isFirst` flag for the first message send by the customer in a new session. This helps us identify and persist first messages in the summary, more info 819-gh-happychat

## Testing Steps
1. Start a chat
2. Using Network tab from developers tool, make sure that the first websocket message sent by the customer has a `meta` object with `includeInSummary` flag set to true. 
3. Send another message, it should not have any metadata.