### PR TITLE
Jetpack Connect: Make JetpackConnectSiteUrlInput pure

### DIFF
--- a/client/jetpack-connect/site-url-input.jsx
+++ b/client/jetpack-connect/site-url-input.jsx
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import React, { Component } from 'react';
+import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import Gridicon from 'gridicons';
 import { localize, getLocaleSlug } from 'i18n-calypso';
@@ -17,7 +17,7 @@ import FormLabel from 'components/forms/form-label';
 import FormTextInput from 'components/forms/form-text-input';
 import Spinner from 'components/spinner';
 
-class JetpackConnectSiteUrlInput extends Component {
+class JetpackConnectSiteUrlInput extends PureComponent {
 	static propTypes = {
 		handleOnClickTos: PropTypes.func,
 		isError: PropTypes.oneOfType( [ PropTypes.string, PropTypes.bool ] ),


### PR DESCRIPTION
### Purpose & background

This PR updates `JetpackConnectSiteUrlInput` to be a `PureComponent` instead of `Component` for performance reasons - less renders, and also to prevent some weird behavior when some other things are popping up on the page (Notifications, HappyChat, etc.).

To reproduce the current weird behavior I'm talking about:

* Go to https://wordpress.com/jetpack/connect?url=test
* Click anywhere on the screen to blur from the URL field
* Click the notifications button in the top right portion of your screen.
* The URL field will get focused, and it shouldn't. The same will be observed while the user types within the Happychat window, so we should avoid it.

We need to fix this in order to be able to implement Happychat in JPC.

### Testing
* Checkout this branch.
* Go to http://calypso.localhost:3000/jetpack/connect?url=test
* Click anywhere on the screen to blur from the URL field
* Click the notifications button in the top right portion of your screen.
* Verify the URL field does not get focused.
* Play some more with the `JetpackConnectSiteUrlInput` component in various situations and verify it behaves as expected.