### PR TITLE
Happychat: Force JPOP group within Jetpack Connect

### DIFF
--- a/client/state/happychat/selectors.js
+++ b/client/state/happychat/selectors.js
@@ -19,6 +19,7 @@ import {
 } from './constants';
 import { isJetpackSite, getSite } from 'state/sites/selectors';
 import { isATEnabled } from 'lib/automated-transfer';
+import { getSectionName } from 'state/ui/selectors';
 
 // How much time needs to pass before we consider the session inactive:
 const HAPPYCHAT_INACTIVE_TIMEOUT_MS = 1000 * 60 * 10;
@@ -41,6 +42,12 @@ export const HAPPYCHAT_CHAT_STATUS_PENDING = 'pending';
  */
 export const getGroups = ( state, siteId ) => {
 	const groups = [];
+
+	if ( getSectionName( state ) === 'jetpackConnect' ) {
+		groups.push( HAPPYCHAT_GROUP_JPOP );
+		return groups;
+	}
+
 	const siteDetails = getSite( state, siteId );
 
 	if ( isATEnabled( siteDetails ) ) {

--- a/client/state/happychat/selectors.js
+++ b/client/state/happychat/selectors.js
@@ -17,6 +17,7 @@ import {
 	HAPPYCHAT_GROUP_JPOP,
 	HAPPYCHAT_CONNECTION_ERROR_PING_TIMEOUT
 } from './constants';
+import { isEnabled } from 'config';
 import { isJetpackSite, getSite } from 'state/sites/selectors';
 import { isATEnabled } from 'lib/automated-transfer';
 import { getSectionName } from 'state/ui/selectors';
@@ -43,7 +44,7 @@ export const HAPPYCHAT_CHAT_STATUS_PENDING = 'pending';
 export const getGroups = ( state, siteId ) => {
 	const groups = [];
 
-	if ( getSectionName( state ) === 'jetpackConnect' ) {
+	if ( isEnabled( 'jetpack/happychat' ) && getSectionName( state ) === 'jetpackConnect' ) {
 		groups.push( HAPPYCHAT_GROUP_JPOP );
 		return groups;
 	}

--- a/client/state/happychat/selectors.js
+++ b/client/state/happychat/selectors.js
@@ -44,6 +44,8 @@ export const HAPPYCHAT_CHAT_STATUS_PENDING = 'pending';
 export const getGroups = ( state, siteId ) => {
 	const groups = [];
 
+	// For Jetpack Connect we need to direct chat users to the JPOP group, to account for cases
+	// when the user does not have a site yet, or their primary site is not a Jetpack site.
 	if ( isEnabled( 'jetpack/happychat' ) && getSectionName( state ) === 'jetpackConnect' ) {
 		groups.push( HAPPYCHAT_GROUP_JPOP );
 		return groups;

--- a/client/state/happychat/test/middleware.js
+++ b/client/state/happychat/test/middleware.js
@@ -62,6 +62,11 @@ describe( 'middleware', () => {
 						name: 'Manual Automattic Updates',
 					}
 				}
+			},
+			ui: {
+				section: {
+					name: 'reader',
+				}
 			}
 		} );
 
@@ -225,6 +230,11 @@ describe( 'middleware', () => {
 						name: 'Manual Automattic Updates',
 					}
 				}
+			},
+			ui: {
+				section: {
+					name: 'reader',
+				}
 			}
 		} );
 		let connection, store;
@@ -327,6 +337,11 @@ describe( 'middleware', () => {
 				sites: {
 					items: {
 						1: { ID: 1 }
+					}
+				},
+				ui: {
+					section: {
+						name: 'reader',
 					}
 				}
 			};

--- a/client/state/happychat/test/selectors.js
+++ b/client/state/happychat/test/selectors.js
@@ -8,6 +8,7 @@ import deepFreeze from 'deep-freeze';
  * Internal dependencies
  */
 import { useSandbox } from 'test/helpers/use-sinon';
+import { isEnabled } from 'config';
 import {
 	HAPPYCHAT_CHAT_STATUS_ABANDONED,
 	HAPPYCHAT_CHAT_STATUS_ASSIGNED,
@@ -378,22 +379,26 @@ describe( 'selectors', () => {
 			expect( getGroups( state, siteId ) ).to.eql( [ HAPPYCHAT_GROUP_WPCOM ] );
 		} );
 
-		it( 'should return JPOP group if within the jetpackConnect section', () => {
-			const state = {
-				...userState,
-				sites: {
-					items: {
-						1: {}
+		if ( isEnabled( 'jetpack/happychat' ) ) {
+			it( 'should return JPOP group if within the jetpackConnect section', () => {
+				const state = {
+					...userState,
+					sites: {
+						items: {
+							1: {}
+						}
+					},
+					ui: {
+						section: {
+							name: 'jetpackConnect',
+						}
 					}
-				},
-				ui: {
-					section: {
-						name: 'jetpackConnect',
-					}
-				}
-			};
+				};
 
-			expect( getGroups( state ) ).to.eql( [ HAPPYCHAT_GROUP_JPOP ] );
-		} );
+				expect( getGroups( state ) ).to.eql( [ HAPPYCHAT_GROUP_JPOP ] );
+			} );
+		} else {
+			it.skip( 'should not return JPOP group if within the jetpackConnect section' );
+		}
 	} );
 } );

--- a/client/state/happychat/test/selectors.js
+++ b/client/state/happychat/test/selectors.js
@@ -277,6 +277,13 @@ describe( 'selectors', () => {
 
 	describe( '#getGroups()', () => {
 		let _window; // Keep a copy of the original window if any
+		const uiState = {
+			ui: {
+				section: {
+					name: 'reader',
+				}
+			}
+		};
 
 		beforeEach( () => {
 			_window = global.window;
@@ -290,6 +297,7 @@ describe( 'selectors', () => {
 		it( 'should return default group for no sites', () => {
 			const siteId = 1;
 			const state = {
+				...uiState,
 				...userState,
 				sites: {
 					items: {}
@@ -302,6 +310,7 @@ describe( 'selectors', () => {
 		it( 'should return default group for no siteId', () => {
 			const siteId = undefined;
 			const state = {
+				...uiState,
 				...userState,
 				sites: {
 					items: {
@@ -316,6 +325,7 @@ describe( 'selectors', () => {
 		it( 'should return JPOP group for jetpack paid sites', () => {
 			const siteId = 1;
 			const state = {
+				...uiState,
 				...userState,
 				currentUser: {
 					id: 1,
@@ -344,6 +354,7 @@ describe( 'selectors', () => {
 		it( 'should return WPCOM for AT sites group for jetpack site', () => {
 			const siteId = 1;
 			const state = {
+				...uiState,
 				...userState,
 				currentUser: {
 					id: 1,
@@ -365,6 +376,24 @@ describe( 'selectors', () => {
 			};
 
 			expect( getGroups( state, siteId ) ).to.eql( [ HAPPYCHAT_GROUP_WPCOM ] );
+		} );
+
+		it( 'should return JPOP group if within the jetpackConnect section', () => {
+			const state = {
+				...userState,
+				sites: {
+					items: {
+						1: {}
+					}
+				},
+				ui: {
+					section: {
+						name: 'jetpackConnect',
+					}
+				}
+			};
+
+			expect( getGroups( state ) ).to.eql( [ HAPPYCHAT_GROUP_JPOP ] );
 		} );
 	} );
 } );


### PR DESCRIPTION
This PR forces Happychat to defer users to the JPOP group when using Happychat within Jetpack Connect. Contains #18517 that introduces a feature flag.

Fixes #18468.

To test:
* Checkout this branch.
* Verify all happychat state tests pass:

```
npm run test-client client/state/happychat/
```