### PR TITLE
Jetpack plans: Make the free plan button clearer

### DIFF
--- a/client/jetpack-connect/plans-skip-button.jsx
+++ b/client/jetpack-connect/plans-skip-button.jsx
@@ -9,11 +9,13 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import Button from 'components/button';
+import Gridicon from 'gridicons';
 
 const PlansSkipButton = ( { onClick, translate } ) => (
 	<div className="jetpack-connect__plans-nav-buttons">
-		<Button onClick={ onClick } compact borderless>
-			{ translate( 'Skip' ) }
+		<Button onClick={ onClick }>
+			{ translate( 'Start with free' ) }
+			<Gridicon icon="arrow-right" />
 		</Button>
 	</div>
 );

--- a/client/jetpack-connect/plans-skip-button.jsx
+++ b/client/jetpack-connect/plans-skip-button.jsx
@@ -11,11 +11,11 @@ import { localize } from 'i18n-calypso';
 import Button from 'components/button';
 import Gridicon from 'gridicons';
 
-const PlansSkipButton = ( { onClick, translate } ) => (
+const PlansSkipButton = ( { onClick, isRtl, translate } ) => (
 	<div className="jetpack-connect__plans-nav-buttons">
 		<Button onClick={ onClick }>
 			{ translate( 'Start with free' ) }
-			<Gridicon icon="arrow-right" />
+			<Gridicon icon={ isRtl ? 'arrow-left' : 'arrow-right' } />
 		</Button>
 	</div>
 );

--- a/client/jetpack-connect/plans.jsx
+++ b/client/jetpack-connect/plans.jsx
@@ -32,7 +32,7 @@ import QueryPlans from 'components/data/query-plans';
 import QuerySitePlans from 'components/data/query-site-plans';
 import { isRequestingPlans, getPlanBySlug } from 'state/plans/selectors';
 import { getSelectedSite } from 'state/ui/selectors';
-import { canCurrentUser } from 'state/selectors';
+import { canCurrentUser, isRtl } from 'state/selectors';
 import {
 	getFlowType,
 	isRedirectingToWpAdmin,
@@ -263,6 +263,8 @@ class Plans extends Component {
 	}
 
 	render() {
+		const { isRtlLayout } = this.props;
+
 		if (
 			this.redirecting ||
 			this.hasPreSelectedPlan() ||
@@ -288,7 +290,7 @@ class Plans extends Component {
 					}
 					hideFreePlan={ true }
 				>
-					<PlansSkipButton onClick={ this.handleSkipButtonClick } />
+					<PlansSkipButton onClick={ this.handleSkipButtonClick } isRtl={ isRtlLayout } />
 				</PlansGrid>
 			</div>
 		);
@@ -323,6 +325,7 @@ export default connect(
 			getPlanBySlug: searchPlanBySlug,
 			calypsoStartedConnection: isCalypsoStartedConnection( state, selectedSiteSlug ),
 			redirectingToWpAdmin: isRedirectingToWpAdmin( state ),
+			isRtlLayout: isRtl( state ),
 		};
 	},
 	{

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -495,9 +495,9 @@
 .jetpack-connect__plans-nav-buttons {
 	text-align: center;
 
-	.button.is-compact {
-		font-size: 14px;
-		font-weight: 500;
+	.button .gridicon {
+		padding-left: 4px;
+		margin-right: -5px;
 	}
 }
 


### PR DESCRIPTION
Fixes #18357.

Make the free plan option more obvious with clearer wording and button instead of link styling.

**Before**
<img width="862" alt="screen shot 2017-10-03 at 16 41 12" src="https://user-images.githubusercontent.com/7767559/31134484-28329cf4-a85a-11e7-9add-259a772575b5.png">

**After**
<img width="923" alt="screen shot 2017-10-03 at 16 43 57" src="https://user-images.githubusercontent.com/7767559/31134494-2ea3bdd4-a85a-11e7-97e9-9c494228c7dc.png">

## Testing
* Create a temporary site with jetpack installed using http://poopy.life/
* Connect site in calypso (switch site -> add new)
* On the plans page, check the _Start with free_ button looks correct and still works
