### PR TITLE
Fix publish date component time field widths

### DIFF
--- a/client/components/post-schedule/style.scss
+++ b/client/components/post-schedule/style.scss
@@ -98,7 +98,7 @@ hr.post-schedule__hr {
 	margin: 0 -16px;
 }
 
-input.post-schedule__clock-time {
+input[type="text"].post-schedule__clock-time {
 	height: 28px;
 	display: inline-block;
 	border: 1px solid lighten( $gray, 30% );


### PR DESCRIPTION
This PR fixes the width of the publish date component time fields to be correct.

To test:

1. Create a new post
2. Open the publish date component
3. Verify that the time fields look like this:

<img width="252" alt="screencapture at tue oct 3 09 47 16 edt 2017" src="https://user-images.githubusercontent.com/2098816/31128521-10c7042c-a820-11e7-90d6-4c252252f03f.png">

NOT

<img width="251" alt="screencapture at tue oct 3 09 18 20 edt 2017" src="https://user-images.githubusercontent.com/2098816/31128514-0cb83950-a820-11e7-9d29-34a9866c5c74.png">

Fixes #18485 

