### PR TITLE
Plugin uploads: Enable in production and desktop

### DIFF
--- a/config/desktop.json
+++ b/config/desktop.json
@@ -44,6 +44,7 @@
 		"manage/plan-features": false,
 		"manage/plugins": true,
 		"manage/plugins/setup": false,
+		"manage/plugins/upload": true,
 		"manage/posts": true,
 		"manage/security": true,
 		"manage/site-settings/analytics": true,

--- a/config/production.json
+++ b/config/production.json
@@ -47,6 +47,7 @@
 		"manage/plugins": true,
 		"manage/plugins/browser": true,
 		"manage/plugins/setup": true,
+		"manage/plugins/upload": true,
 		"manage/posts": true,
 		"manage/security": true,
 		"manage/site-settings/analytics": true,


### PR DESCRIPTION
Adds ability to initiate a transfer to atomic with a custom plugin, and upload custom plugins to jetpack/atomic sites.

Further details: p6TEKc-1nA-p2