### PR TITLE
Store: Make sure dashicons is loaded for our TinyMCE component.

### DIFF
--- a/client/extensions/woocommerce/components/compact-tinymce/index.js
+++ b/client/extensions/woocommerce/components/compact-tinymce/index.js
@@ -113,6 +113,7 @@ class CompactTinyMCE extends Component {
 		// To avoid making changes that affect the post editor at this time, we can load a small set of CSS.
 		// This mainly affects the text format drop down which renders outside of any elements that we can target.
 		tinymce.DOM.loadCSS( '/calypso/tinymce/skins/woocommerce/editor.css' );
+		tinymce.DOM.loadCSS( '//s1.wp.com/wp-includes/css/dashicons.css?v=20150727' );
 	}
 
 	componentWillUnmount() {


### PR DESCRIPTION
This loads the dashicons CSS when our `CompactTinyMCE` component is mounted to fix our editor buttons from not showing up correctly:

<img width="686" alt="screen shot 2017-10-03 at 10 28 37 am" src="https://user-images.githubusercontent.com/689165/31139212-a3fdefda-a825-11e7-8143-be916449dafc.png">

See #18194.
