### PR TITLE
Fix editor publish confirmation ground control style

### DIFF
--- a/client/post-editor/editor-confirmation-sidebar/style.scss
+++ b/client/post-editor/editor-confirmation-sidebar/style.scss
@@ -70,7 +70,6 @@
 }
 
 .editor-confirmation-sidebar__ground-control {
-	@extend .card;
 	display: flex;
 	flex-direction: row;
 	flex-wrap: wrap;
@@ -79,7 +78,12 @@
 		top: 0;
 		left: 0;
 		right: 0;
+	margin-bottom: 16px;
 	padding: 0 24px;
+	box-sizing: border-box;
+	background: $white;
+	box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ),
+		0 1px 2px lighten( $gray, 30% );
 }
 
 .editor-confirmation-sidebar__close {


### PR DESCRIPTION
This PR fixes the editor publish confirmation style breakage introduced with #18477.

The ground control is not really a `.card` in any sense, so I have removed the `extends` and set styles directly on the ground control. This will make the style more robust.

To test:

1. Create a new post
2. Click Publish... to bring up the confirmation sidebar. Make sure it looks like this:

<img width="299" alt="screencapture at tue oct 3 14 18 32 edt 2017" src="https://user-images.githubusercontent.com/2098816/31141569-c52cdfc0-a845-11e7-9147-6ea54fd50286.png">

Fixes #18504