### PR TITLE
Store Orders: Enable "Edit Order" button

### DIFF
--- a/client/extensions/woocommerce/app/order/index.js
+++ b/client/extensions/woocommerce/app/order/index.js
@@ -63,6 +63,12 @@ class Order extends Component {
 		}
 	};
 
+	// Clear this order's edits, takes it out of edit state
+	cancelEditing = () => {
+		const { siteId } = this.props;
+		this.props.clearOrderEdits( siteId );
+	};
+
 	// Saves changes to the remote site via API
 	saveOrder = () => {
 		const { siteId, order } = this.props;
@@ -92,11 +98,20 @@ class Order extends Component {
 			</span>,
 		];
 
-		let button = (
-			<Button primary onClick={ this.saveOrder } busy={ isSaving } disabled={ ! hasOrderEdits }>
+		let button = [
+			<Button key="cancel" onClick={ this.cancelEditing }>
+				{ translate( 'Cancel' ) }
+			</Button>,
+			<Button
+				key="save"
+				primary
+				onClick={ this.saveOrder }
+				busy={ isSaving }
+				disabled={ ! hasOrderEdits }
+			>
 				{ translate( 'Save Order' ) }
-			</Button>
-		);
+			</Button>,
+		];
 		if ( ! isEditing ) {
 			button = (
 				<Button primary onClick={ this.toggleEditing }>

--- a/client/extensions/woocommerce/app/order/index.js
+++ b/client/extensions/woocommerce/app/order/index.js
@@ -97,8 +97,8 @@ class Order extends Component {
 				<ActionHeader breadcrumbs={ breadcrumbs }>{ button }</ActionHeader>
 
 				<div className="order__container">
-					<OrderDetails order={ order } site={ site } />
-					<OrderNotes orderId={ order.id } siteId={ site.ID } />
+					<OrderDetails orderId={ orderId } />
+					<OrderNotes orderId={ orderId } siteId={ site.ID } />
 					<OrderCustomer order={ order } />
 				</div>
 			</Main>

--- a/client/extensions/woocommerce/app/order/index.js
+++ b/client/extensions/woocommerce/app/order/index.js
@@ -1,8 +1,11 @@
+/** @format */
 /**
  * External dependencies
  */
 import { bindActionCreators } from 'redux';
+import config from 'config';
 import { connect } from 'react-redux';
+import { isEmpty } from 'lodash';
 import { localize } from 'i18n-calypso';
 import React, { Component } from 'react';
 
@@ -11,10 +14,12 @@ import React, { Component } from 'react';
  */
 import ActionHeader from 'woocommerce/components/action-header';
 import Button from 'components/button';
+import { clearOrderEdits, editOrder } from 'woocommerce/state/ui/orders/actions';
 import { fetchNotes } from 'woocommerce/state/sites/orders/notes/actions';
 import { fetchOrder } from 'woocommerce/state/sites/orders/actions';
 import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
 import { getLink } from 'woocommerce/lib/nav-utils';
+import { isCurrentlyEditingOrder, getOrderWithEdits } from 'woocommerce/state/ui/orders/selectors';
 import { isOrderUpdating, getOrder } from 'woocommerce/state/sites/orders/selectors';
 import Main from 'components/main';
 import OrderCustomer from './order-customer';
@@ -23,12 +28,6 @@ import OrderNotes from './order-notes';
 import { updateOrder } from 'woocommerce/state/sites/orders/actions';
 
 class Order extends Component {
-	state = {
-		order: {
-			id: this.props.orderId,
-		}
-	}
-
 	componentDidMount() {
 		const { siteId, orderId } = this.props;
 
@@ -42,42 +41,63 @@ class Order extends Component {
 		if ( newProps.orderId !== this.props.orderId || newProps.siteId !== this.props.siteId ) {
 			this.props.fetchOrder( newProps.siteId, newProps.orderId );
 			this.props.fetchNotes( newProps.siteId, newProps.orderId );
-		} else if ( newProps.order && this.props.order && newProps.order.status !== this.props.order.status ) {
+		} else if (
+			newProps.order &&
+			this.props.order &&
+			newProps.order.status !== this.props.order.status
+		) {
 			// A status change should force a notes refresh
 			this.props.fetchNotes( newProps.siteId, newProps.orderId, true );
 		}
 	}
 
-	onUpdate = ( order ) => {
-		// Merge the new order updates into the existing order updates
-		this.setState( ( prevState ) => {
-			const updatedOrder = { ...prevState.order, ...order };
-			return { order: updatedOrder };
-		} );
-	}
+	// Put this order into the editing state
+	toggleEditing = () => {
+		const { siteId, orderId } = this.props;
+		if ( siteId ) {
+			this.props.editOrder( siteId, { id: orderId } );
+		}
+	};
 
+	// Saves changes to the remote site via API
 	saveOrder = () => {
-		this.props.updateOrder( this.props.siteId, this.state.order );
-	}
+		const { siteId } = this.props;
+		// this.props.updateOrder( siteId, order );
+		this.props.clearOrderEdits( siteId );
+	};
 
 	render() {
-		const { className, isSaving, order, orderId, site, translate } = this.props;
-		if ( ! order ) {
+		const { className, isEditing, isSaving, order, orderId, site, translate } = this.props;
+		if ( isEmpty( order ) ) {
 			return null;
 		}
 
 		const breadcrumbs = [
-			( <a href={ getLink( '/store/orders/:site/', site ) }>{ translate( 'Orders' ) }</a> ),
-			( <span>{ translate( 'Order %(orderId)s Details', { args: { orderId: `#${ orderId }` } } ) }</span> ),
+			<a href={ getLink( '/store/orders/:site/', site ) }>{ translate( 'Orders' ) }</a>,
+			<span>
+				{ translate( 'Order %(orderId)s Details', { args: { orderId: `#${ orderId }` } } ) }
+			</span>,
 		];
+
+		let button = (
+			<Button primary onClick={ this.saveOrder } busy={ isSaving }>
+				{ translate( 'Save Order' ) }
+			</Button>
+		);
+		if ( ! isEditing && config.isEnabled( 'woocommerce/extension-orders-create' ) ) {
+			button = (
+				<Button primary onClick={ this.toggleEditing }>
+					{ translate( 'Edit Order' ) }
+				</Button>
+			);
+		}
+
 		return (
 			<Main className={ className }>
-				<ActionHeader breadcrumbs={ breadcrumbs }>
-					<Button primary onClick={ this.saveOrder } busy={ isSaving }>{ translate( 'Save Order' ) }</Button>
-				</ActionHeader>
+				<ActionHeader breadcrumbs={ breadcrumbs }>{ button }</ActionHeader>
 
 				<div className="order__container">
-					<OrderDetails order={ order } onUpdate={ this.onUpdate } site={ site } />
+					<OrderDetails order={ order } site={ site } />
 					<OrderNotes orderId={ order.id } siteId={ site.ID } />
 					<OrderCustomer order={ order } />
 				</div>
@@ -90,11 +110,13 @@ export default connect(
 	( state, props ) => {
 		const site = getSelectedSiteWithFallback( state );
 		const siteId = site ? site.ID : false;
-		const orderId = props.params.order;
-		const order = getOrder( state, orderId );
+		const orderId = parseInt( props.params.order );
 		const isSaving = isOrderUpdating( state, orderId );
+		const isEditing = isCurrentlyEditingOrder( state );
+		const order = isEditing ? getOrderWithEdits( state ) : getOrder( state, orderId );
 
 		return {
+			isEditing,
 			isSaving,
 			order,
 			orderId,
@@ -102,5 +124,9 @@ export default connect(
 			siteId,
 		};
 	},
-	dispatch => bindActionCreators( { fetchNotes, fetchOrder, updateOrder }, dispatch )
+	dispatch =>
+		bindActionCreators(
+			{ clearOrderEdits, editOrder, fetchNotes, fetchOrder, updateOrder },
+			dispatch
+		)
 )( localize( Order ) );

--- a/client/extensions/woocommerce/app/order/index.js
+++ b/client/extensions/woocommerce/app/order/index.js
@@ -81,7 +81,6 @@ class Order extends Component {
 	saveOrder = () => {
 		const { siteId, order } = this.props;
 		this.props.updateOrder( siteId, order );
-		this.props.clearOrderEdits( siteId );
 	};
 
 	render() {

--- a/client/extensions/woocommerce/app/order/index.js
+++ b/client/extensions/woocommerce/app/order/index.js
@@ -97,7 +97,7 @@ class Order extends Component {
 				{ translate( 'Save Order' ) }
 			</Button>
 		);
-		if ( ! isEditing && config.isEnabled( 'woocommerce/extension-orders-create' ) ) {
+		if ( ! isEditing ) {
 			button = (
 				<Button primary onClick={ this.toggleEditing }>
 					{ translate( 'Edit Order' ) }
@@ -107,7 +107,9 @@ class Order extends Component {
 
 		return (
 			<Main className={ className }>
-				<ActionHeader breadcrumbs={ breadcrumbs }>{ button }</ActionHeader>
+				<ActionHeader breadcrumbs={ breadcrumbs }>
+					{ config.isEnabled( 'woocommerce/extension-orders-create' ) && button }
+				</ActionHeader>
 
 				<div className="order__container">
 					<OrderDetails orderId={ orderId } />

--- a/client/extensions/woocommerce/app/order/index.js
+++ b/client/extensions/woocommerce/app/order/index.js
@@ -61,8 +61,8 @@ class Order extends Component {
 
 	// Saves changes to the remote site via API
 	saveOrder = () => {
-		const { siteId } = this.props;
-		// this.props.updateOrder( siteId, order );
+		const { siteId, order } = this.props;
+		this.props.updateOrder( siteId, order );
 		this.props.clearOrderEdits( siteId );
 	};
 

--- a/client/extensions/woocommerce/app/order/index.js
+++ b/client/extensions/woocommerce/app/order/index.js
@@ -19,7 +19,11 @@ import { fetchNotes } from 'woocommerce/state/sites/orders/notes/actions';
 import { fetchOrder } from 'woocommerce/state/sites/orders/actions';
 import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
 import { getLink } from 'woocommerce/lib/nav-utils';
-import { isCurrentlyEditingOrder, getOrderWithEdits } from 'woocommerce/state/ui/orders/selectors';
+import {
+	isCurrentlyEditingOrder,
+	getOrderEdits,
+	getOrderWithEdits,
+} from 'woocommerce/state/ui/orders/selectors';
 import { isOrderUpdating, getOrder } from 'woocommerce/state/sites/orders/selectors';
 import Main from 'components/main';
 import OrderCustomer from './order-customer';
@@ -67,7 +71,16 @@ class Order extends Component {
 	};
 
 	render() {
-		const { className, isEditing, isSaving, order, orderId, site, translate } = this.props;
+		const {
+			className,
+			hasOrderEdits,
+			isEditing,
+			isSaving,
+			order,
+			orderId,
+			site,
+			translate,
+		} = this.props;
 		if ( isEmpty( order ) ) {
 			return null;
 		}
@@ -80,7 +93,7 @@ class Order extends Component {
 		];
 
 		let button = (
-			<Button primary onClick={ this.saveOrder } busy={ isSaving }>
+			<Button primary onClick={ this.saveOrder } busy={ isSaving } disabled={ ! hasOrderEdits }>
 				{ translate( 'Save Order' ) }
 			</Button>
 		);
@@ -113,9 +126,11 @@ export default connect(
 		const orderId = parseInt( props.params.order );
 		const isSaving = isOrderUpdating( state, orderId );
 		const isEditing = isCurrentlyEditingOrder( state );
+		const hasOrderEdits = ! isEmpty( getOrderEdits( state ) );
 		const order = isEditing ? getOrderWithEdits( state ) : getOrder( state, orderId );
 
 		return {
+			hasOrderEdits,
 			isEditing,
 			isSaving,
 			order,

--- a/client/extensions/woocommerce/app/order/index.js
+++ b/client/extensions/woocommerce/app/order/index.js
@@ -43,6 +43,9 @@ class Order extends Component {
 
 	componentWillReceiveProps( newProps ) {
 		if ( newProps.orderId !== this.props.orderId || newProps.siteId !== this.props.siteId ) {
+			// New order or site should clear any pending edits
+			this.props.clearOrderEdits( this.props.siteId );
+			// And fetch the new order's info
 			this.props.fetchOrder( newProps.siteId, newProps.orderId );
 			this.props.fetchNotes( newProps.siteId, newProps.orderId );
 		} else if (
@@ -53,6 +56,11 @@ class Order extends Component {
 			// A status change should force a notes refresh
 			this.props.fetchNotes( newProps.siteId, newProps.orderId, true );
 		}
+	}
+
+	componentWillUnmount() {
+		// Removing this component should clear any pending edits
+		this.props.clearOrderEdits( this.props.siteId );
 	}
 
 	// Put this order into the editing state

--- a/client/extensions/woocommerce/app/order/order-details/index.js
+++ b/client/extensions/woocommerce/app/order/order-details/index.js
@@ -4,6 +4,7 @@
  */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
@@ -11,6 +12,7 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import Card from 'components/card';
+import { editOrder } from 'woocommerce/state/ui/orders/actions';
 import { isCurrentlyEditingOrder, getOrderWithEdits } from 'woocommerce/state/ui/orders/selectors';
 import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
 import { getOrder } from 'woocommerce/state/sites/orders/selectors';
@@ -35,9 +37,9 @@ class OrderDetails extends Component {
 	}
 
 	updateStatus = event => {
-		const { siteId } = this.props;
+		const { siteId, order } = this.props;
 		if ( siteId ) {
-			this.props.editOrder( siteId, { status: event.target.value } );
+			this.props.editOrder( siteId, { id: order.id, status: event.target.value } );
 		}
 	};
 
@@ -45,7 +47,7 @@ class OrderDetails extends Component {
 		const { isEditing, order } = this.props;
 
 		return isEditing ? (
-			<OrderStatusSelect value={ this.state.status } onChange={ this.updateStatus } />
+			<OrderStatusSelect value={ order.status } onChange={ this.updateStatus } />
 		) : (
 			<OrderStatus status={ order.status } showShipping={ false } />
 		);
@@ -86,16 +88,19 @@ class OrderDetails extends Component {
 	}
 }
 
-export default connect( ( state, props ) => {
-	const site = getSelectedSiteWithFallback( state );
-	const siteId = site ? site.ID : false;
-	const isEditing = isCurrentlyEditingOrder( state );
-	const order = isEditing ? getOrderWithEdits( state ) : getOrder( state, props.orderId );
+export default connect(
+	( state, props ) => {
+		const site = getSelectedSiteWithFallback( state );
+		const siteId = site ? site.ID : false;
+		const isEditing = isCurrentlyEditingOrder( state );
+		const order = isEditing ? getOrderWithEdits( state ) : getOrder( state, props.orderId );
 
-	return {
-		isEditing,
-		order,
-		site,
-		siteId,
-	};
-} )( localize( OrderDetails ) );
+		return {
+			isEditing,
+			order,
+			site,
+			siteId,
+		};
+	},
+	dispatch => bindActionCreators( { editOrder }, dispatch )
+)( localize( OrderDetails ) );

--- a/client/extensions/woocommerce/app/order/order-details/index.js
+++ b/client/extensions/woocommerce/app/order/order-details/index.js
@@ -4,7 +4,6 @@
  */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-// import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
@@ -52,8 +51,22 @@ class OrderDetails extends Component {
 		);
 	};
 
+	renderDetails = () => {
+		const { isEditing, order, site } = this.props;
+		if ( isEditing ) {
+			return <OrderDetailsTable order={ order } site={ site } />;
+		}
+
+		return [
+			<OrderCreated key="order-date" order={ order } site={ site } />,
+			<OrderDetailsTable key="order-details" order={ order } site={ site } />,
+			<OrderPaymentCard key="order-payment" order={ order } site={ site } />,
+			<OrderFulfillment key="order-fulfillment" order={ order } site={ site } />,
+		];
+	};
+
 	render() {
-		const { isEditing, order, site, translate } = this.props;
+		const { order, translate } = this.props;
 		if ( ! order ) {
 			return null;
 		}
@@ -67,12 +80,7 @@ class OrderDetails extends Component {
 				>
 					<span>{ this.renderStatus() }</span>
 				</SectionHeader>
-				<Card className="order-details__card">
-					{ ! isEditing && <OrderCreated order={ order } site={ site } /> }
-					<OrderDetailsTable order={ order } site={ site } />
-					{ ! isEditing && <OrderPaymentCard order={ order } site={ site } /> }
-					{ ! isEditing && <OrderFulfillment order={ order } site={ site } /> }
-				</Card>
+				<Card className="order-details__card">{ this.renderDetails() }</Card>
 			</div>
 		);
 	}

--- a/client/extensions/woocommerce/state/ui/orders/edits/reducer.js
+++ b/client/extensions/woocommerce/state/ui/orders/edits/reducer.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -8,6 +9,7 @@ import { combineReducers } from 'state/utils';
  * Internal dependencies
  */
 import {
+	WOOCOMMERCE_ORDER_UPDATE_SUCCESS,
 	WOOCOMMERCE_UI_ORDERS_CLEAR_EDIT,
 	WOOCOMMERCE_UI_ORDERS_EDIT,
 } from 'woocommerce/state/action-types';
@@ -30,6 +32,8 @@ export function currentlyEditingId( state = null, action ) {
 			return { placeholder: uniqueId( 'order_' ) };
 		case WOOCOMMERCE_UI_ORDERS_CLEAR_EDIT:
 			return null;
+		case WOOCOMMERCE_ORDER_UPDATE_SUCCESS:
+			return null;
 		default:
 			return state;
 	}
@@ -50,6 +54,8 @@ export function changes( state = {}, action ) {
 			const order = omit( action.order, 'id' );
 			return merge( {}, state, order );
 		case WOOCOMMERCE_UI_ORDERS_CLEAR_EDIT:
+			return {};
+		case WOOCOMMERCE_ORDER_UPDATE_SUCCESS:
 			return {};
 		default:
 			return state;

--- a/client/extensions/woocommerce/state/ui/orders/edits/test/reducer.js
+++ b/client/extensions/woocommerce/state/ui/orders/edits/test/reducer.js
@@ -11,6 +11,7 @@ import deepFreeze from 'deep-freeze';
  */
 import reducer from '../reducer';
 import {
+	WOOCOMMERCE_ORDER_UPDATE_SUCCESS,
 	WOOCOMMERCE_UI_ORDERS_CLEAR_EDIT,
 	WOOCOMMERCE_UI_ORDERS_EDIT,
 } from 'woocommerce/state/action-types';
@@ -155,6 +156,28 @@ describe( 'reducer', () => {
 		const action = {
 			type: WOOCOMMERCE_UI_ORDERS_CLEAR_EDIT,
 			siteId: 123,
+		};
+		const originalState = deepFreeze( {
+			currentlyEditingId: 40,
+			changes: {
+				billing: {
+					first_name: 'Joan',
+				},
+			},
+		} );
+		const newState = reducer( originalState, action );
+		expect( newState ).to.eql( {
+			currentlyEditingId: null,
+			changes: {},
+		} );
+	} );
+
+	it( 'should clear order changes if this order is successfully updated', () => {
+		const action = {
+			type: WOOCOMMERCE_ORDER_UPDATE_SUCCESS,
+			siteId: 123,
+			orderId: 40,
+			order: {},
 		};
 		const originalState = deepFreeze( {
 			currentlyEditingId: 40,


### PR DESCRIPTION
This PR adds a button to toggle on the "edit state" of a given order. Right now the only thing that can be changed in the edit state is the order status. Since this page will also be the create screen, I've re-used the feature flag `woocommerce/extension-orders-create`, which is enabled only in `development` & `wp-calypso`.

<img width="855" alt="flag-enabled" src="https://user-images.githubusercontent.com/541093/31148313-5eb31998-a85a-11e7-9aa8-e8be0b9e1a47.png">

One you're in the edit state, you can change the order status. The save button is disabled until changes are made.

<img width="837" alt="screen shot 2017-10-03 at 5 07 28 pm" src="https://user-images.githubusercontent.com/541093/31149282-5dd238bc-a85d-11e7-95ff-0ca6a0f045af.png">
<img width="845" alt="screen shot 2017-10-03 at 5 05 37 pm" src="https://user-images.githubusercontent.com/541093/31149253-4c48d5e2-a85d-11e7-84e5-426d585eff5b.png">

The "Order created…", payment card, and fulfillment card are not shown in the "edit state" to reduce the complexity of the screen.

For staging & production, where the feature flag is not enabled, users will not be able to edit the order, including changing the order status using the dropdown. Users can mark as paid, refund, or fulfill orders using the actions in those sections, so there should be no issue while editing is being developed. Screenshot:

<img width="855" alt="flag-disabled" src="https://user-images.githubusercontent.com/541093/31148315-5ec06440-a85a-11e7-9c46-66900e5e5b72.png">

**To test**

- View an order by going to `/store/orders/:site` and clicking into one
- You should see an "Edit Order" button in the top right corner
- Click it to enable edit state, a disabled "Save Order" button appears in its place
- Change the order status, the save button should switch to enabled
- Click save, it should switch you out of edit mode, and show a green "Order saved" notice.
- Repeat, cancelling out of an edit without making changes, or with changes pending (that will be cleared without saving)

Test with the flag disabled by running `DISABLE_FEATURES=woocommerce/extension-orders-create npm start` to make sure nothing is broken without the flag.