### PR TITLE
Try preconnecting/preloading various assets 

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -158,6 +158,8 @@
 		"standalone-site-preview": true,
 		"support-user": true,
 		"sync-handler": true,
+		"try/preconnect": true,
+		"try/preload": true,
 		"ui/first-view": true,
 		"ui/first-view/reset-route": true,
 		"upgrades/checkout": true,

--- a/config/development.json
+++ b/config/development.json
@@ -160,6 +160,7 @@
 		"sync-handler": true,
 		"try/preconnect": true,
 		"try/preload": true,
+		"try/single-cdn": true,
 		"ui/first-view": true,
 		"ui/first-view/reset-route": true,
 		"upgrades/checkout": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -122,6 +122,8 @@
 		"standalone-site-preview": true,
 		"support-user": true,
 		"sync-handler": true,
+		"try/preconnect": true,
+		"try/preload": true,
 		"ui/first-view": true,
 		"ui/first-view/reset-route": true,
 		"upgrades/checkout": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -124,6 +124,7 @@
 		"sync-handler": true,
 		"try/preconnect": true,
 		"try/preload": true,
+		"try/single-cdn": true,
 		"ui/first-view": true,
 		"ui/first-view/reset-route": true,
 		"upgrades/checkout": true,

--- a/server/pages/index.jade
+++ b/server/pages/index.jade
@@ -59,6 +59,7 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class=isFluidWidth ? 'is-fluid-width'
 			if sectionCss
 				link(rel='stylesheet', id='section-css', href=sectionCss)
 
+		//- Preload our scripts
 		if i18nLocaleScript
 			link(rel='preload' as='script' href=i18nLocaleScript)
 		if 'development' === env || isDebug

--- a/server/pages/index.jade
+++ b/server/pages/index.jade
@@ -30,23 +30,40 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class=isFluidWidth ? 'is-fluid-width'
 		link(rel='shortcut icon', type='image/vnd.microsoft.icon', href=faviconURL, sizes='16x16 32x32')
 		link(rel='shortcut icon', type='image/x-icon', href=faviconURL, sizes='16x16 32x32')
 		link(rel='icon', type='image/x-icon', href=faviconURL, sizes='16x16 32x32')
-		link(rel='icon', type='image/png', href='//s1.wp.com/i/favicons/favicon-64x64.png', sizes='64x64')
-		link(rel='icon', type='image/png', href='//s1.wp.com/i/favicons/favicon-96x96.png', sizes='96x96')
-		link(rel='icon', type='image/png', href='//s1.wp.com/i/favicons/android-chrome-192x192.png', sizes='192x192')
-		link(rel='apple-touch-icon', sizes='57x57', href='//s1.wp.com/i/favicons/apple-touch-icon-57x57.png')
-		link(rel='apple-touch-icon', sizes='60x60', href='//s1.wp.com/i/favicons/apple-touch-icon-60x60.png')
-		link(rel='apple-touch-icon', sizes='72x72', href='//s1.wp.com/i/favicons/apple-touch-icon-72x72.png')
-		link(rel='apple-touch-icon', sizes='76x76', href='//s1.wp.com/i/favicons/apple-touch-icon-76x76.png')
-		link(rel='apple-touch-icon', sizes='114x114', href='//s1.wp.com/i/favicons/apple-touch-icon-114x114.png')
-		link(rel='apple-touch-icon', sizes='120x120', href='//s1.wp.com/i/favicons/apple-touch-icon-120x120.png')
-		link(rel='apple-touch-icon', sizes='144x144', href='//s1.wp.com/i/favicons/apple-touch-icon-144x144.png')
-		link(rel='apple-touch-icon', sizes='152x152', href='//s1.wp.com/i/favicons/apple-touch-icon-152x152.png')
-		link(rel='apple-touch-icon', sizes='180x180', href='//s1.wp.com/i/favicons/apple-touch-icon-180x180.png')
+		if shouldUseSingleCDN
+			link(rel='icon', type='image/png', href='//s0.wp.com/i/favicons/favicon-64x64.png', sizes='64x64')
+			link(rel='icon', type='image/png', href='//s0.wp.com/i/favicons/favicon-96x96.png', sizes='96x96')
+			link(rel='icon', type='image/png', href='//s0.wp.com/i/favicons/android-chrome-192x192.png', sizes='192x192')
+			link(rel='apple-touch-icon', sizes='57x57', href='//s0.wp.com/i/favicons/apple-touch-icon-57x57.png')
+			link(rel='apple-touch-icon', sizes='60x60', href='//s0.wp.com/i/favicons/apple-touch-icon-60x60.png')
+			link(rel='apple-touch-icon', sizes='72x72', href='//s0.wp.com/i/favicons/apple-touch-icon-72x72.png')
+			link(rel='apple-touch-icon', sizes='76x76', href='//s0.wp.com/i/favicons/apple-touch-icon-76x76.png')
+			link(rel='apple-touch-icon', sizes='114x114', href='//s0.wp.com/i/favicons/apple-touch-icon-114x114.png')
+			link(rel='apple-touch-icon', sizes='120x120', href='//s0.wp.com/i/favicons/apple-touch-icon-120x120.png')
+			link(rel='apple-touch-icon', sizes='144x144', href='//s0.wp.com/i/favicons/apple-touch-icon-144x144.png')
+			link(rel='apple-touch-icon', sizes='152x152', href='//s0.wp.com/i/favicons/apple-touch-icon-152x152.png')
+			link(rel='apple-touch-icon', sizes='180x180', href='//s0.wp.com/i/favicons/apple-touch-icon-180x180.png')
+		else 
+			link(rel='icon', type='image/png', href='//s1.wp.com/i/favicons/favicon-64x64.png', sizes='64x64')
+			link(rel='icon', type='image/png', href='//s1.wp.com/i/favicons/favicon-96x96.png', sizes='96x96')
+			link(rel='icon', type='image/png', href='//s1.wp.com/i/favicons/android-chrome-192x192.png', sizes='192x192')
+			link(rel='apple-touch-icon', sizes='57x57', href='//s1.wp.com/i/favicons/apple-touch-icon-57x57.png')
+			link(rel='apple-touch-icon', sizes='60x60', href='//s1.wp.com/i/favicons/apple-touch-icon-60x60.png')
+			link(rel='apple-touch-icon', sizes='72x72', href='//s1.wp.com/i/favicons/apple-touch-icon-72x72.png')
+			link(rel='apple-touch-icon', sizes='76x76', href='//s1.wp.com/i/favicons/apple-touch-icon-76x76.png')
+			link(rel='apple-touch-icon', sizes='114x114', href='//s1.wp.com/i/favicons/apple-touch-icon-114x114.png')
+			link(rel='apple-touch-icon', sizes='120x120', href='//s1.wp.com/i/favicons/apple-touch-icon-120x120.png')
+			link(rel='apple-touch-icon', sizes='144x144', href='//s1.wp.com/i/favicons/apple-touch-icon-144x144.png')
+			link(rel='apple-touch-icon', sizes='152x152', href='//s1.wp.com/i/favicons/apple-touch-icon-152x152.png')
+			link(rel='apple-touch-icon', sizes='180x180', href='//s1.wp.com/i/favicons/apple-touch-icon-180x180.png')
 		link(rel='profile', href='http://gmpg.org/xfn/11')
 		link(rel='manifest', href='/calypso/manifest.json')
 		
 		link(rel='stylesheet', href='https://fonts.googleapis.com/css?family=Noto+Serif:400,400i,700,700i&subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext,vietnamese')
-		link(rel='stylesheet', href='//s1.wp.com/i/noticons/noticons.css?v=20150727')
+		if shouldUseSingleCDN
+			link(rel='stylesheet', href='//s0.wp.com/i/noticons/noticons.css?v=20150727')
+		else 
+			link(rel='stylesheet', href='//s1.wp.com/i/noticons/noticons.css?v=20150727')
 		if isRTL
 			link(rel='stylesheet', id='main-css', href=urls['style-rtl.css'])
 			if sectionCssRtl
@@ -61,13 +78,13 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class=isFluidWidth ? 'is-fluid-width'
 				link(rel='stylesheet', id='section-css', href=sectionCss)
 		
 		if shouldUsePreconnect
-			//- Preconnect to our CDN.
-			link(rel='preconnect' href='//s1.wp.com')
+			//- Preconnect to our CDN hosts
+			link(rel='preconnect' href='//s0.wp.com')
+			if ! shouldUseSingleCDN
+				link(rel='preconnect' href='//s1.wp.com')
+
 			//- Preconnect to Google's font CDN. Note the mandatory crossorigin attr for fonts.
 			link(rel='preconnect' crossorigin href='https://fonts.gstatic.com')
-			
-			//- Preconnect to our CDN.
-			link(rel='preconnect' href='//s0.wp.com')
 			
 			//- Preconnect to our API.
 			link(rel='preconnect' href='https://public-api.wordpress.com')
@@ -87,9 +104,11 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class=isFluidWidth ? 'is-fluid-width'
 		if shouldUsePreload
 			if i18nLocaleScript
 				link(rel='preload' as='script' href=i18nLocaleScript)
+
 			link(rel='preload' as='script' href=urls[ 'manifest' ])
 			link(rel='preload' as='script' href=urls[ 'vendor' ])
 			link(rel='preload' as='script' href=urls[ jsFile ])
+
 			if chunk
 				link(rel='preload' as='script' href=urls[ chunk ])
 

--- a/server/pages/index.jade
+++ b/server/pages/index.jade
@@ -30,6 +30,8 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class=isFluidWidth ? 'is-fluid-width'
 		link(rel='shortcut icon', type='image/vnd.microsoft.icon', href=faviconURL, sizes='16x16 32x32')
 		link(rel='shortcut icon', type='image/x-icon', href=faviconURL, sizes='16x16 32x32')
 		link(rel='icon', type='image/x-icon', href=faviconURL, sizes='16x16 32x32')
+		//- Preconnect to our CDN.
+		link(rel='preconnect' href='//s1.wp.com')
 		link(rel='icon', type='image/png', href='//s1.wp.com/i/favicons/favicon-64x64.png', sizes='64x64')
 		link(rel='icon', type='image/png', href='//s1.wp.com/i/favicons/favicon-96x96.png', sizes='96x96')
 		link(rel='icon', type='image/png', href='//s1.wp.com/i/favicons/android-chrome-192x192.png', sizes='192x192')
@@ -44,6 +46,9 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class=isFluidWidth ? 'is-fluid-width'
 		link(rel='apple-touch-icon', sizes='180x180', href='//s1.wp.com/i/favicons/apple-touch-icon-180x180.png')
 		link(rel='profile', href='http://gmpg.org/xfn/11')
 		link(rel='manifest', href='/calypso/manifest.json')
+		
+		//- Preconnect to Google's font CDN. Note the mandatory crossorigin attr for fonts.
+		link(rel='preconnect' crossorigin href='https://fonts.gstatic.com')
 		link(rel='stylesheet', href='https://fonts.googleapis.com/css?family=Noto+Serif:400,400i,700,700i&subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext,vietnamese')
 		link(rel='stylesheet', href='//s1.wp.com/i/noticons/noticons.css?v=20150727')
 		if isRTL
@@ -58,6 +63,23 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class=isFluidWidth ? 'is-fluid-width'
 
 			if sectionCss
 				link(rel='stylesheet', id='section-css', href=sectionCss)
+		
+		//- Preconnect to our CDN.
+		link(rel='preconnect' href='//s0.wp.com')
+		
+		//- Preconnect to our API.
+		link(rel='preconnect' href='https://public-api.wordpress.com')
+		
+		//- Preconnect for analytics scripts.
+		link(rel='preconnect' href='//stats.wp.com')
+		link(rel='preconnect' href='https://www.google-analytics.com')
+		
+		//- Preconnect for Google domains - especially useful for SSO.
+		link(rel='preconnect' href='https://google.com')
+		link(rel='preconnect' href='https://ssl.gstatic.com')
+		link(rel='preconnect' href='https://apis.google.com')
+		link(rel='preconnect' href='https://accounts.google.com')
+		link(rel='preconnect' href='https://stats.g.doubleclick.net')
 
 		//- Preload our scripts
 		if i18nLocaleScript

--- a/server/pages/index.jade
+++ b/server/pages/index.jade
@@ -94,11 +94,12 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class=isFluidWidth ? 'is-fluid-width'
 			link(rel='preconnect' href='https://www.google-analytics.com')
 			
 			//- Preconnect for Google domains - especially useful for SSO.
-			link(rel='preconnect' href='https://google.com')
-			link(rel='preconnect' href='https://ssl.gstatic.com')
-			link(rel='preconnect' href='https://apis.google.com')
-			link(rel='preconnect' href='https://accounts.google.com')
-			link(rel='preconnect' href='https://stats.g.doubleclick.net')
+			if shouldUsePreconnectGoogle
+				link(rel='preconnect' href='https://google.com')
+				link(rel='preconnect' href='https://ssl.gstatic.com')
+				link(rel='preconnect' href='https://apis.google.com')
+				link(rel='preconnect' href='https://accounts.google.com')
+				link(rel='preconnect' href='https://stats.g.doubleclick.net')
 
 		//- Preload our scripts
 		if shouldUsePreload

--- a/server/pages/index.jade
+++ b/server/pages/index.jade
@@ -30,8 +30,6 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class=isFluidWidth ? 'is-fluid-width'
 		link(rel='shortcut icon', type='image/vnd.microsoft.icon', href=faviconURL, sizes='16x16 32x32')
 		link(rel='shortcut icon', type='image/x-icon', href=faviconURL, sizes='16x16 32x32')
 		link(rel='icon', type='image/x-icon', href=faviconURL, sizes='16x16 32x32')
-		//- Preconnect to our CDN.
-		link(rel='preconnect' href='//s1.wp.com')
 		link(rel='icon', type='image/png', href='//s1.wp.com/i/favicons/favicon-64x64.png', sizes='64x64')
 		link(rel='icon', type='image/png', href='//s1.wp.com/i/favicons/favicon-96x96.png', sizes='96x96')
 		link(rel='icon', type='image/png', href='//s1.wp.com/i/favicons/android-chrome-192x192.png', sizes='192x192')
@@ -47,8 +45,6 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class=isFluidWidth ? 'is-fluid-width'
 		link(rel='profile', href='http://gmpg.org/xfn/11')
 		link(rel='manifest', href='/calypso/manifest.json')
 		
-		//- Preconnect to Google's font CDN. Note the mandatory crossorigin attr for fonts.
-		link(rel='preconnect' crossorigin href='https://fonts.gstatic.com')
 		link(rel='stylesheet', href='https://fonts.googleapis.com/css?family=Noto+Serif:400,400i,700,700i&subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext,vietnamese')
 		link(rel='stylesheet', href='//s1.wp.com/i/noticons/noticons.css?v=20150727')
 		if isRTL
@@ -64,31 +60,38 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class=isFluidWidth ? 'is-fluid-width'
 			if sectionCss
 				link(rel='stylesheet', id='section-css', href=sectionCss)
 		
-		//- Preconnect to our CDN.
-		link(rel='preconnect' href='//s0.wp.com')
-		
-		//- Preconnect to our API.
-		link(rel='preconnect' href='https://public-api.wordpress.com')
-		
-		//- Preconnect for analytics scripts.
-		link(rel='preconnect' href='//stats.wp.com')
-		link(rel='preconnect' href='https://www.google-analytics.com')
-		
-		//- Preconnect for Google domains - especially useful for SSO.
-		link(rel='preconnect' href='https://google.com')
-		link(rel='preconnect' href='https://ssl.gstatic.com')
-		link(rel='preconnect' href='https://apis.google.com')
-		link(rel='preconnect' href='https://accounts.google.com')
-		link(rel='preconnect' href='https://stats.g.doubleclick.net')
+		if shouldUsePreconnect
+			//- Preconnect to our CDN.
+			link(rel='preconnect' href='//s1.wp.com')
+			//- Preconnect to Google's font CDN. Note the mandatory crossorigin attr for fonts.
+			link(rel='preconnect' crossorigin href='https://fonts.gstatic.com')
+			
+			//- Preconnect to our CDN.
+			link(rel='preconnect' href='//s0.wp.com')
+			
+			//- Preconnect to our API.
+			link(rel='preconnect' href='https://public-api.wordpress.com')
+			
+			//- Preconnect for analytics scripts.
+			link(rel='preconnect' href='//stats.wp.com')
+			link(rel='preconnect' href='https://www.google-analytics.com')
+			
+			//- Preconnect for Google domains - especially useful for SSO.
+			link(rel='preconnect' href='https://google.com')
+			link(rel='preconnect' href='https://ssl.gstatic.com')
+			link(rel='preconnect' href='https://apis.google.com')
+			link(rel='preconnect' href='https://accounts.google.com')
+			link(rel='preconnect' href='https://stats.g.doubleclick.net')
 
 		//- Preload our scripts
-		if i18nLocaleScript
-			link(rel='preload' as='script' href=i18nLocaleScript)
-		link(rel='preload' as='script' href=urls[ 'manifest' ])
-		link(rel='preload' as='script' href=urls[ 'vendor' ])
-		link(rel='preload' as='script' href=urls[ jsFile ])
-		if chunk
-			link(rel='preload' as='script' href=urls[ chunk ])
+		if shouldUsePreload
+			if i18nLocaleScript
+				link(rel='preload' as='script' href=i18nLocaleScript)
+			link(rel='preload' as='script' href=urls[ 'manifest' ])
+			link(rel='preload' as='script' href=urls[ 'vendor' ])
+			link(rel='preload' as='script' href=urls[ jsFile ])
+			if chunk
+				link(rel='preload' as='script' href=urls[ chunk ])
 
 	body( class=bodyClasses )
 		if renderedLayout

--- a/server/pages/index.jade
+++ b/server/pages/index.jade
@@ -84,18 +84,11 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class=isFluidWidth ? 'is-fluid-width'
 		//- Preload our scripts
 		if i18nLocaleScript
 			link(rel='preload' as='script' href=i18nLocaleScript)
-		if 'development' === env || isDebug
-			link(rel='preload' as='script' href=urls[ 'manifest' ])
-			link(rel='preload' as='script' href=urls[ 'vendor' ])
-			link(rel='preload' as='script' href=urls[ jsFile ])
-			if chunk
-				link(rel='preload' as='script' href=urls[ chunk ])
-		else
-			link(rel='preload' as='script' href=urls[ 'manifest-min' ])
-			link(rel='preload' as='script' href=urls[ 'vendor-min' ])
-			link(rel='preload' as='script' href=urls[ jsFile + '-min' ])
-			if chunk
-				link(rel='preload' as='script' href=urls[ chunk + '-min' ])
+		link(rel='preload' as='script' href=urls[ 'manifest' ])
+		link(rel='preload' as='script' href=urls[ 'vendor' ])
+		link(rel='preload' as='script' href=urls[ jsFile ])
+		if chunk
+			link(rel='preload' as='script' href=urls[ chunk ])
 
 	body( class=bodyClasses )
 		if renderedLayout

--- a/server/pages/index.jade
+++ b/server/pages/index.jade
@@ -59,6 +59,21 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class=isFluidWidth ? 'is-fluid-width'
 			if sectionCss
 				link(rel='stylesheet', id='section-css', href=sectionCss)
 
+		if i18nLocaleScript
+			link(rel='preload' as='script' href=i18nLocaleScript)
+		if 'development' === env || isDebug
+			link(rel='preload' as='script' href=urls[ 'manifest' ])
+			link(rel='preload' as='script' href=urls[ 'vendor' ])
+			link(rel='preload' as='script' href=urls[ jsFile ])
+			if chunk
+				link(rel='preload' as='script' href=urls[ chunk ])
+		else
+			link(rel='preload' as='script' href=urls[ 'manifest-min' ])
+			link(rel='preload' as='script' href=urls[ 'vendor-min' ])
+			link(rel='preload' as='script' href=urls[ jsFile + '-min' ])
+			if chunk
+				link(rel='preload' as='script' href=urls[ chunk + '-min' ])
+
 	body( class=bodyClasses )
 		if renderedLayout
 			#wpcom.wpcom-site!= renderedLayout

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -191,6 +191,8 @@ function getDefaultContext( request ) {
 		devDocsURL: '/devdocs',
 		store: createReduxStore( initialServerState ),
 		shouldUsePreconnect: config.isEnabled( 'try/preconnect' ) && !! request.query.enablePreconnect,
+		shouldUsePreconnectGoogle:
+			config.isEnabled( 'try/preconnect' ) && !! request.query.enablePreconnectGoogle,
 		shouldUsePreload: config.isEnabled( 'try/preload' ) && !! request.query.enablePreload,
 		shouldUseSingleCDN,
 		bodyClasses,

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -187,6 +187,8 @@ function getDefaultContext( request ) {
 		abTestHelper: !! config.isEnabled( 'dev/test-helper' ),
 		devDocsURL: '/devdocs',
 		store: createReduxStore( initialServerState ),
+		shouldUsePreconnect: config.isEnabled( 'try/preconnect' ),
+		shouldUsePreload: config.isEnabled( 'try/preload' ),
 		bodyClasses,
 		sectionCss,
 		sectionCssRtl,

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -171,6 +171,8 @@ function getDefaultContext( request ) {
 		sectionCssRtl = urls.rtl;
 	}
 
+	const shouldUseSingleCDN = config.isEnabled( 'try/preload' ) && !! request.query.singleCdn;
+
 	const context = Object.assign( {}, request.context, {
 		compileDebug: config( 'env' ) === 'development' ? true : false,
 		urls: generateStaticUrls(),
@@ -182,13 +184,14 @@ function getDefaultContext( request ) {
 		badge: false,
 		lang: config( 'i18n_default_locale_slug' ),
 		jsFile: 'build',
-		faviconURL: '//s1.wp.com/i/favicon.ico',
+		faviconURL: shouldUseSingleCDN ? '//s0.wp.com/i/favicon.ico' : '//s1.wp.com/i/favicon.ico',
 		isFluidWidth: !! config.isEnabled( 'fluid-width' ),
 		abTestHelper: !! config.isEnabled( 'dev/test-helper' ),
 		devDocsURL: '/devdocs',
 		store: createReduxStore( initialServerState ),
-		shouldUsePreconnect: config.isEnabled( 'try/preconnect' ),
-		shouldUsePreload: config.isEnabled( 'try/preload' ),
+		shouldUsePreconnect: config.isEnabled( 'try/preconnect' ) && !! request.query.enablePreconnect,
+		shouldUsePreload: config.isEnabled( 'try/preload' ) && !! request.query.enablePreload,
+		shouldUseSingleCDN,
 		bodyClasses,
 		sectionCss,
 		sectionCssRtl,

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -171,7 +171,8 @@ function getDefaultContext( request ) {
 		sectionCssRtl = urls.rtl;
 	}
 
-	const shouldUseSingleCDN = config.isEnabled( 'try/preload' ) && !! request.query.singleCdn;
+	const shouldUseSingleCDN =
+		config.isEnabled( 'try/single-cdn' ) && !! request.query.enableSingleCDN;
 
 	const context = Object.assign( {}, request.context, {
 		compileDebug: config( 'env' ) === 'development' ? true : false,


### PR DESCRIPTION
This experiment adds [`preconnect`](https://www.w3.org/TR/resource-hints/#preconnect) and [`preload`](https://w3c.github.io/preload/#early-fetch-of-critical-resources) resource hints in order to improve our page load times.

Note that `preload` is a bleeding edge browser feature. It's currently supported in Chrome with Firefox expecting to add support for cacheable assets in [version 56](https://bugzilla.mozilla.org/show_bug.cgi?id=1222633).

If the code looks good, I would like to ship this to wpcalypso for profiling.

See resources [here](https://www.igvita.com/2015/08/17/eliminating-roundtrips-with-preconnect/) and [here](https://www.smashingmagazine.com/2016/02/preload-what-is-it-good-for/).