### PR TITLE
Config: Introduce a Jetpack Happychat feature flag

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -61,6 +61,7 @@
 		"jetpack/activity-log": true,
 		"jetpack/activity-log/rewind": true,
 		"jetpack/api-cache": true,
+		"jetpack/happychat": true,
 		"jetpack_core_inline_update": true,
 		"keyboard-shortcuts": true,
 		"login/magic-login": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -31,6 +31,7 @@
 		"help/courses": true,
 		"jetpack/activity-log": true,
 		"jetpack/api-cache": true,
+		"jetpack/happychat": true,
 		"jetpack_core_inline_update": true,
 		"keyboard-shortcuts": true,
 		"login/native-login-links": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -33,6 +33,7 @@
 		"jetpack/activity-log": true,
 		"jetpack/activity-log/rewind": true,
 		"jetpack/api-cache": true,
+		"jetpack/happychat": true,
 		"jetpack_core_inline_update": true,
 		"login/magic-login": true,
 		"login/native-login-links": true,

--- a/config/test.json
+++ b/config/test.json
@@ -40,6 +40,7 @@
 		"devdocs/redirect-loggedout-homepage": true,
 		"devdocs/components-usage-stats": false,
 		"help": true,
+		"jetpack/happychat": true,
 		"jetpack_core_inline_update": true,
 		"login/wp-login": true,
 		"keyboard-shortcuts": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -37,6 +37,7 @@
 		"help/courses": true,
 		"jetpack/activity-log": true,
 		"jetpack/api-cache": true,
+		"jetpack/happychat": true,
 		"jetpack_core_inline_update": true,
 		"login/magic-login": true,
 		"login/native-login-links": true,


### PR DESCRIPTION
This PR introduces a feature flag that we'll use for implementing Happychat with Jetpack in the following environments:

* development
* test
* horizon
* wpcalypso
* stage

Reason: we'll want to be able to test these features in all environments, but we won't be exposing them to the public before we're sure they work as expected.