### PR TITLE
Build: move the Immutable.js library to the vendor chunk

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -173,6 +173,7 @@ if ( calypsoEnv === 'desktop' ) {
 	webpackConfig.entry.vendor = [
 		'classnames',
 		'i18n-calypso',
+		'immutable',
 		'lodash',
 		'moment',
 		'page',


### PR DESCRIPTION
Makes the frequently changed `build` chunk smaller, as it moves the rarely changed `immutable` library to the `vendor` chunk, which is more likely to be cached.

Deltas for `gzip_size`:
build: -15281 bytes
vendor: +16194 bytes
