### PR TITLE
Editor: Consolidate post visibility stats recording

### DIFF
--- a/client/post-editor/editor-visibility/index.jsx
+++ b/client/post-editor/editor-visibility/index.jsx
@@ -104,6 +104,14 @@ const EditorVisibility = React.createClass( {
 		postActions.edit( postEdits );
 	},
 
+	recordStats( newVisibility ) {
+		if ( this.getVisibility() !== newVisibility ) {
+			recordStat( 'visibility-set-' + newVisibility );
+			recordEvent( 'Changed visibility', newVisibility );
+			tracks.recordEvent( 'calypso_editor_visibility_set', { context: this.props.context, visibility: newVisibility } );
+		}
+	},
+
 	updateVisibility( newVisibility ) {
 		const { siteId, postId } = this.props;
 		let reduxPostEdits;
@@ -123,12 +131,7 @@ const EditorVisibility = React.createClass( {
 				break;
 		}
 
-		recordStat( 'visibility-set-' + newVisibility );
-		recordEvent( 'Changed visibility', newVisibility );
-		tracks.recordEvent( 'calypso_editor_visibility_set', {
-			context: this.props.context,
-			visibility: newVisibility,
-		} );
+		this.recordStats( newVisibility );
 
 		// This is necessary for cases when the post is changed from private to another visibility
 		// since private has its own post status.
@@ -152,12 +155,7 @@ const EditorVisibility = React.createClass( {
 			sticky: false,
 		} );
 
-		recordStat( 'visibility-set-private' );
-		recordEvent( 'Changed visibility', 'private' );
-		tracks.recordEvent( 'calypso_editor_visibility_set', {
-			context: this.props.context,
-			visibility: 'private',
-		} );
+		this.recordStats( 'private' );
 	},
 
 	onPrivatePublish() {


### PR DESCRIPTION
Currently, if you open the visibility toggle on a post and select the currently set availability, you bump a series of stats even though you haven't actually changed the visibility of the post. This commit refactors how we record stats for visibility changes to prevent unnecessary stats updates.

## To test
1. Load this branch and run `localStorage.setItem('debug', 'calypso:analytics*');` in your console so you can see Tracks events.
2. Open the editor.
3. Open the visibility setting under Status.
4. Change the dropdown to `Password Protected`. The Tracks event `calypso_editor_visibility_set` should fire correctly with recorded props of `context` and `visibility`.
5. Open the dropdown again and select the existing visibility (i.e. Reselect `Password Protected`).
6. You should not see the Tracks event fired. You can compare this to prod where the Tracks event would get fired again.

## GIF
![tracks](https://user-images.githubusercontent.com/7240478/31176657-d610bc9a-a8d0-11e7-9fba-7c6947440c55.gif)

Fixes: #18412