### PR TITLE
Activity log: Request rewind dialog via redux state

### DIFF
--- a/client/my-sites/stats/activity-log-confirm-dialog/index.jsx
+++ b/client/my-sites/stats/activity-log-confirm-dialog/index.jsx
@@ -59,12 +59,16 @@ class ActivityLogConfirmDialog extends Component {
 
 				<div className="activity-log-confirm-dialog__line">
 					<Gridicon icon={ 'history' } />
-					{ translate( 'Restoring to {{b}}%(time)s{{/b}}', {
-						args: {
-							time: applySiteOffset( moment.utc( timestamp ) ).format( 'LLL' ),
-						},
-						components: { b: <b /> },
-					} ) }
+					{ timestamp ? (
+						translate( 'Restoring to {{b}}%(time)s{{/b}}', {
+							args: {
+								time: applySiteOffset( moment.utc( timestamp ) ).format( 'LLL' ),
+							},
+							components: { b: <b /> },
+						} )
+					) : (
+						' '
+					) }
 				</div>
 				<div className="activity-log-confirm-dialog__line">
 					<Gridicon icon={ 'notice' } />

--- a/client/my-sites/stats/activity-log-day/index.jsx
+++ b/client/my-sites/stats/activity-log-day/index.jsx
@@ -10,7 +10,7 @@ import classnames from 'classnames';
 import Gridicon from 'gridicons';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { isEmpty, map } from 'lodash';
+import { flatMap, get, isEmpty } from 'lodash';
 
 /**
  * Internal dependencies
@@ -32,7 +32,9 @@ class ActivityLogDay extends Component {
 		hideRestore: PropTypes.bool,
 		isRewindActive: PropTypes.bool,
 		logs: PropTypes.array.isRequired,
+		requestedRestoreActivityId: PropTypes.string,
 		requestRestore: PropTypes.func.isRequired,
+		rewindConfirmDialog: PropTypes.element,
 		siteId: PropTypes.number,
 		tsEndOfSiteDay: PropTypes.number.isRequired,
 
@@ -48,8 +50,11 @@ class ActivityLogDay extends Component {
 
 	handleClickRestore = event => {
 		event.stopPropagation();
-		const { tsEndOfSiteDay, requestRestore } = this.props;
-		requestRestore( tsEndOfSiteDay, 'day' );
+		const { logs, requestRestore } = this.props;
+		const lastLogId = get( logs, [ 0, 'activityId' ], null );
+		if ( lastLogId ) {
+			requestRestore( lastLogId, 'day' );
+		}
 	};
 
 	trackOpenDay = () => {
@@ -135,7 +140,9 @@ class ActivityLogDay extends Component {
 			hideRestore,
 			isToday,
 			logs,
+			requestedRestoreActivityId,
 			requestRestore,
+			rewindConfirmDialog,
 			siteId,
 		} = this.props;
 
@@ -152,7 +159,8 @@ class ActivityLogDay extends Component {
 					summary={ hasLogs ? this.renderRewindButton( 'primary' ) : null }
 				>
 					{ hasLogs &&
-						map( logs, log => (
+						flatMap( logs, log => [
+							log.activityId === requestedRestoreActivityId && rewindConfirmDialog,
 							<ActivityLogItem
 								applySiteOffset={ applySiteOffset }
 								disableRestore={ disableRestore }
@@ -161,8 +169,8 @@ class ActivityLogDay extends Component {
 								log={ log }
 								requestRestore={ requestRestore }
 								siteId={ siteId }
-							/>
-						) ) }
+							/>,
+						] ) }
 				</FoldableCard>
 			</div>
 		);

--- a/client/my-sites/stats/activity-log-day/index.jsx
+++ b/client/my-sites/stats/activity-log-day/index.jsx
@@ -10,7 +10,7 @@ import classnames from 'classnames';
 import Gridicon from 'gridicons';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { flatMap, get, isEmpty } from 'lodash';
+import { get, isEmpty, map } from 'lodash';
 
 /**
  * Internal dependencies
@@ -34,7 +34,6 @@ class ActivityLogDay extends Component {
 		logs: PropTypes.array.isRequired,
 		requestedRestoreActivityId: PropTypes.string,
 		requestRestore: PropTypes.func.isRequired,
-		rewindConfirmDialog: PropTypes.element,
 		siteId: PropTypes.number,
 		tsEndOfSiteDay: PropTypes.number.isRequired,
 
@@ -140,9 +139,7 @@ class ActivityLogDay extends Component {
 			hideRestore,
 			isToday,
 			logs,
-			requestedRestoreActivityId,
 			requestRestore,
-			rewindConfirmDialog,
 			siteId,
 		} = this.props;
 
@@ -158,19 +155,17 @@ class ActivityLogDay extends Component {
 					onOpen={ this.trackOpenDay }
 					summary={ hasLogs ? this.renderRewindButton( 'primary' ) : null }
 				>
-					{ hasLogs &&
-						flatMap( logs, log => [
-							log.activityId === requestedRestoreActivityId && rewindConfirmDialog,
-							<ActivityLogItem
-								applySiteOffset={ applySiteOffset }
-								disableRestore={ disableRestore }
-								hideRestore={ hideRestore }
-								key={ log.activityId }
-								log={ log }
-								requestRestore={ requestRestore }
-								siteId={ siteId }
-							/>,
-						] ) }
+					{ hasLogs && map( logs, log => (
+						<ActivityLogItem
+							applySiteOffset={ applySiteOffset }
+							disableRestore={ disableRestore }
+							hideRestore={ hideRestore }
+							key={ log.activityId }
+							log={ log }
+							requestRestore={ requestRestore }
+							siteId={ siteId }
+						/>
+					) ) }
 				</FoldableCard>
 			</div>
 		);

--- a/client/my-sites/stats/activity-log-item/index.jsx
+++ b/client/my-sites/stats/activity-log-item/index.jsx
@@ -66,7 +66,7 @@ class ActivityLogItem extends Component {
 
 	handleClickRestore = () => {
 		const { log, requestRestore } = this.props;
-		requestRestore( log.activityTs, 'item' );
+		requestRestore( log.activityId, 'item' );
 	};
 
 	handleOpen = () => {

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -311,15 +311,6 @@ class ActivityLog extends Component {
 				.endOf( 'day' )
 				.valueOf()
 		);
-		const rewindConfirmDialog = requestedRestoreActivityId && (
-			<ActivityLogConfirmDialog
-				applySiteOffset={ this.applySiteOffset }
-				activityId={ requestedRestoreActivityId }
-				key="activity-rewind-dialog"
-				onClose={ this.handleRestoreDialogClose }
-				onConfirm={ this.handleRestoreDialogConfirm }
-			/>
-		);
 
 		const activityDays = [];
 		// loop backwards through each day in the month
@@ -343,7 +334,6 @@ class ActivityLog extends Component {
 				<ActivityLogDay
 					applySiteOffset={ this.applySiteOffset }
 					requestedRestoreActivityId={ requestedRestoreActivityId }
-					rewindConfirmDialog={ rewindConfirmDialog }
 					disableRestore={ disableRestore }
 					hideRestore={ ! rewindEnabledByConfig || ! isPressable }
 					isRewindActive={ isRewindActive }

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -391,6 +391,7 @@ class ActivityLog extends Component {
 			gmtOffset,
 			isPressable,
 			isRewindActive,
+			requestedRestoreActivity,
 			siteId,
 			siteTitle,
 			slug,
@@ -410,8 +411,6 @@ class ActivityLog extends Component {
 				</Main>
 			);
 		}
-
-		const { requestedRestoreTimestamp, showRestoreConfirmDialog } = this.state;
 
 		return (
 			<Main wideLayout>
@@ -433,9 +432,9 @@ class ActivityLog extends Component {
 
 				<ActivityLogConfirmDialog
 					applySiteOffset={ this.applySiteOffset }
-					isVisible={ showRestoreConfirmDialog }
+					isVisible={ !! requestedRestoreActivity }
 					siteTitle={ siteTitle }
-					timestamp={ requestedRestoreTimestamp }
+					timestamp={ requestedRestoreActivity && requestedRestoreActivity.activityTs }
 					onClose={ this.handleRestoreDialogClose }
 					onConfirm={ this.handleRestoreDialogConfirm }
 				/>

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -134,46 +134,23 @@ class ActivityLog extends Component {
 	handleRequestRestore = ( activityId, from ) => {
 		const { recordTracksEvent, rewindRequestRestore, siteId } = this.props;
 
-		recordTracksEvent( 'calypso_activitylog_restore_request', {
-			from,
-			activityId,
-		} );
+		recordTracksEvent( 'calypso_activitylog_restore_request', { from } );
 		rewindRequestRestore( siteId, activityId );
 	};
 
 	handleRestoreDialogClose = () => {
-		const {
-			recordTracksEvent,
-			requestedRestoreActivityId,
-			rewindRequestDismiss,
-			siteId,
-		} = this.props;
-		recordTracksEvent( 'calypso_activitylog_restore_cancel', {
-			activityId: requestedRestoreActivityId,
-		} );
+		const { recordTracksEvent, rewindRequestDismiss, siteId } = this.props;
+		recordTracksEvent( 'calypso_activitylog_restore_cancel' );
 		rewindRequestDismiss( siteId );
 	};
 
 	handleRestoreDialogConfirm = () => {
-		const {
-			recordTracksEvent,
-			requestedRestoreActivity,
-			requestedRestoreActivityId,
-			rewindRestore,
-			siteId,
-		} = this.props;
-		const { activityTs } = requestedRestoreActivity;
+		const { recordTracksEvent, requestedRestoreActivity, rewindRestore, siteId } = this.props;
+		const { activityTs: timestamp } = requestedRestoreActivity;
 
-		recordTracksEvent( 'calypso_activitylog_restore_confirm', {
-			activityId: requestedRestoreActivityId,
-		} );
-		debug(
-			'Restore requested for site %d after activity %s, found activity %o',
-			this.props.siteId,
-			requestedRestoreActivityId,
-			requestedRestoreActivity
-		);
-		rewindRestore( siteId, activityTs );
+		debug( 'Restore requested for after activity %o', requestedRestoreActivity );
+		recordTracksEvent( 'calypso_activitylog_restore_confirm', { timestamp } );
+		rewindRestore( siteId, timestamp );
 	};
 
 	/**


### PR DESCRIPTION
This PR migrates the Activity Log Rewind modal dialog to use the new redux state added in #18493 and in preparation for #18241 

This PR includes two behavioral changes in the Dialog/Rewind:
* The rewind time in the modal dialog will disappear as it is closed. This will not be an issue in #18493. This could be mitigated, but the fix is messy it's likely a non-issue.
* The rewind time for a day is now _the same as the last activity for a day_. This is part of the solution in #18493 to passing an `activityId` as the basis for a restore point.

## Testing
* Visit https://calypso.live/stats/activity?branch=update/activity-log/restore-via-redux
* Test rewind
* Does the modal behave as expected?
* Do rewinds behave correctly?
* Any changes beyond those mentioned?