### PR TITLE
Simple Payment: Add more specificities to make custom card styles work

### DIFF
--- a/client/components/tinymce/plugins/simple-payments/style.scss
+++ b/client/components/tinymce/plugins/simple-payments/style.scss
@@ -98,7 +98,7 @@
 	text-decoration: none;
 }
 
-.editor-simple-payments-modal__navigation {
+.editor-simple-payments-modal__navigation.card {
 	margin: 0;
 	flex: none;
 }
@@ -152,7 +152,7 @@
 	overflow-y: auto;
 }
 
-.editor-simple-payments-modal__list-item {
+.editor-simple-payments-modal__list-item.card {
 	display: flex;
 	align-items: center;
 


### PR DESCRIPTION
Not sure why, but now default `.card` style trumps, so custom card style now needs more specificity.

Before:
<img width="790" alt="screen shot 2017-10-04 at 17 10 10" src="https://user-images.githubusercontent.com/908665/31186939-1bd90a64-a928-11e7-89da-cd8371a63bd5.png">

After:
<img width="783" alt="screen shot 2017-10-04 at 17 14 02" src="https://user-images.githubusercontent.com/908665/31186957-2a969e36-a928-11e7-86e5-eae1efc34e87.png">

