### PR TITLE
Media Library: Add more specificity to make custom card style works

### DIFF
--- a/client/my-sites/media-library/style.scss
+++ b/client/my-sites/media-library/style.scss
@@ -5,7 +5,7 @@
 @import 'upload-button';
 @import 'upload-url';
 
-.media-library__header {
+.media-library__header.card {
 	padding-top: 12px;
 	padding-bottom: 12px;
 	display: flex;


### PR DESCRIPTION
Same as #18534, this PR intends to fix custom card style for media library header.

Before: 
<img width="969" alt="screen shot 2017-10-04 at 17 40 58" src="https://user-images.githubusercontent.com/908665/31188220-1683fc3c-a92c-11e7-84c3-c0af979709bf.png">

After:
<img width="964" alt="screen shot 2017-10-04 at 17 44 12" src="https://user-images.githubusercontent.com/908665/31188228-1ddb2b72-a92c-11e7-95e8-b0664ca08f02.png">

