### PR TITLE
Store: Fix review reply create issues.

### DIFF
--- a/client/extensions/woocommerce/state/sites/review-replies/test/handlers.js
+++ b/client/extensions/woocommerce/state/sites/review-replies/test/handlers.js
@@ -32,7 +32,7 @@ import reviewReplies from './fixtures/review-replies';
 import reviews from 'woocommerce/state/sites/reviews/test/fixtures/reviews';
 import {
 	WOOCOMMERCE_REVIEW_REPLIES_UPDATED,
-	WOOCOMMERCE_REVIEW_REPLY_CREATED,
+	WOOCOMMERCE_REVIEW_REPLIES_REQUEST,
 	WOOCOMMERCE_REVIEW_REPLY_DELETED,
 	WOOCOMMERCE_REVIEW_REPLY_UPDATED,
 	WOOCOMMERCE_REVIEW_STATUS_CHANGE,
@@ -206,14 +206,12 @@ describe( 'handlers', () => {
 			expect( dispatch ).to.have.been.calledWith( match( {
 				type: WPCOM_HTTP_REQUEST,
 				method: 'POST',
-				path: `/jetpack-blogs/${ siteId }/rest-api/`,
+				path: `/sites/${ siteId }/comments/${ reviewId }/replies/new`,
 				query: {
-					json: true,
 					apiVersion: '1.1',
 				},
 				body: {
-					path: '/wp/v2/comments&_method=POST',
-					body: JSON.stringify( { content: 'Hello world', parent: reviewId, post: productId } ),
+					content: 'Hello world',
 				}
 			} ) );
 		} );
@@ -247,7 +245,7 @@ describe( 'handlers', () => {
 			const action = createReviewReply( siteId, productId, reviewId, 'Hello world', false );
 			handleReviewReplyCreateSuccess( store, action, create );
 			expect( store.dispatch ).to.have.been.calledWith( match( {
-				type: WOOCOMMERCE_REVIEW_REPLY_CREATED,
+				type: WOOCOMMERCE_REVIEW_REPLIES_REQUEST,
 			} ) );
 			expect( store.dispatch ).to.not.have.been.calledWith( match( {
 				type: WOOCOMMERCE_REVIEW_STATUS_CHANGE,


### PR DESCRIPTION
This PR fixes two issues that @jameskoster noted:

* Create reply failing with a 5 second timeout. I was able to replicate this on one of my test sites as well: https://cloudup.com/cX8Qddf8NdA. It's inconsistent though, because it was working on another site. See #18540.
*  If you have two reply forms open, typing in one populated the other as well.

I'm marking both of these fixes with TODOs, because I want to consider these fixes temporary.

I would like to investigate the 5 second timeout, and why it's happening for this endpoint -- but I don't think we need to block reviews for it. We can use the .com endpoint like comments management does.

Unfortunately I limited my edits UI state to only hold one set of edits at a time, which works OK for updating replies, but not creating if you have multiple review boxes open at once. Since we are only holding the comment text for creates, I've switched this to use component state for now.

To Test:
* Run `npm run test-client client/extensions/woocommerce/state` and make sure all tests pass.
* Go to `http://calypso.localhost:3000/store/reviews/:site` and make sure to have more than two reviews.
* Expand two reviews, and type in their comment boxes separately.
* Submit a reply for one of the reviews. Make sure it posts and shows up in the list.
