### PR TITLE
Data Layer: Fix when an api response is empty

### DIFF
--- a/client/state/data-layer/wpcom-http/test/utils.js
+++ b/client/state/data-layer/wpcom-http/test/utils.js
@@ -12,42 +12,62 @@ import { spy } from 'sinon';
 import { getData, getError, getProgress, dispatchRequest, makeParser } from '../utils.js';
 
 describe( 'WPCOM HTTP Data Layer', () => {
+	const withData = data => ( { type: 'SLUGGER', meta: { dataLayer: { data } } } );
+	const withError = error => ( { type: 'SLUGGER', meta: { dataLayer: { error } } } );
+	const withProgress = progress => ( { type: 'UPLOAD_PROGRESS', meta: { dataLayer: { progress } } } );
+
 	describe( '#getData', () => {
 		test( 'should return successful response data if available', () => {
 			const data = { utterance: 'Bork bork' };
-			const action = { type: 'SLUGGER', meta: { dataLayer: { data } } };
 
-			expect( getData( action ) ).to.equal( data );
+			expect( getData( withData( data ) ) ).to.equal( data );
 		} );
 
-		test( 'should return null if no response data available', () => {
+		test( 'should return undefined if no response data available', () => {
 			const action = { type: 'SLUGGER' };
 
-			expect( getData( action ) ).to.be.null;
+			expect( getData( action ) ).to.be.undefined;
+		} );
+		test( 'should return valid-but-falsey data', () => {
+			expect( getData( withData( '' ) ) ).to.equal( '' );
+			expect( getData( withData( null ) ) ).to.equal( null );
+			expect( getData( withData( 0 ) ) ).to.equal( 0 );
+			expect( getData( withData( false ) ) ).to.equal( false );
 		} );
 	} );
 
 	describe( '#getError', () => {
 		test( 'should return failing error data if available', () => {
 			const error = { utterance: 'Bork bork' };
-			const action = { type: 'SLUGGER', meta: { dataLayer: { error } } };
 
-			expect( getError( action ) ).to.equal( error );
+			expect( getError( withError( error ) ) ).to.equal( error );
 		} );
 
-		test( 'should return null if no error data available', () => {
+		test( 'should return undefined if no error data available', () => {
 			const action = { type: 'SLUGGER' };
 
-			expect( getError( action ) ).to.be.null;
+			expect( getError( action ) ).to.be.undefined;
+		} );
+
+		test( 'should return valid-but-falsey data', () => {
+			expect( getError( withError( '' ) ) ).to.equal( '' );
+			expect( getError( withError( null ) ) ).to.equal( null );
+			expect( getError( withError( 0 ) ) ).to.equal( 0 );
+			expect( getError( withError( false ) ) ).to.equal( false );
 		} );
 	} );
 
 	describe( '#getProgress', () => {
 		test( 'should return progress data if available', () => {
 			const progress = { total: 1234, loaded: 123 };
-			const action = { type: 'UPLOAD_PROGRESS', meta: { dataLayer: { progress } } };
 
-			expect( getProgress( action ) ).to.equal( progress );
+			expect( getProgress( withProgress( progress ) ) ).to.equal( progress );
+		} );
+		test( 'should return valid-but-falsey data', () => {
+			expect( getProgress( withProgress( '' ) ) ).to.equal( '' );
+			expect( getProgress( withProgress( null ) ) ).to.equal( null );
+			expect( getProgress( withProgress( 0 ) ) ).to.equal( 0 );
+			expect( getProgress( withProgress( false ) ) ).to.equal( false );
 		} );
 	} );
 

--- a/client/state/data-layer/wpcom-http/utils.js
+++ b/client/state/data-layer/wpcom-http/utils.js
@@ -13,7 +13,7 @@ import { get, identity, noop } from 'lodash';
  * @param {Object} action may contain HTTP response data
  * @returns {?*} response data if available
  */
-export const getData = action => get( action, 'meta.dataLayer.data', null );
+export const getData = action => get( action, 'meta.dataLayer.data', undefined );
 
 /**
  * Returns error data from an HTTP request failure action if available
@@ -21,7 +21,7 @@ export const getData = action => get( action, 'meta.dataLayer.data', null );
  * @param {Object} action may contain HTTP response error data
  * @returns {?*} error data if available
  */
-export const getError = action => get( action, 'meta.dataLayer.error', null );
+export const getError = action => get( action, 'meta.dataLayer.error', undefined );
 
 /**
  * Returns (response) headers data from an HTTP request action if available
@@ -29,7 +29,7 @@ export const getError = action => get( action, 'meta.dataLayer.error', null );
  * @param {Object} action may contain HTTP response headers data
  * @returns {?*} headers data if available
  */
-export const getHeaders = action => get( action, 'meta.dataLayer.headers', null );
+export const getHeaders = action => get( action, 'meta.dataLayer.headers', undefined );
 
 /**
  * @typedef {Object} ProgressData
@@ -44,7 +44,7 @@ export const getHeaders = action => get( action, 'meta.dataLayer.headers', null 
  * @returns {Object|null} progress data if available
  * @returns {ProgressData}
  */
-export const getProgress = action => get( action, 'meta.dataLayer.progress', null );
+export const getProgress = action => get( action, 'meta.dataLayer.progress', undefined );
 
 class SchemaError extends Error {
 	constructor( errors ) {
@@ -138,12 +138,12 @@ export const dispatchRequest = ( initiator, onSuccess, onError, options ) => ( s
 	const { fromApi, onProgress } = { ...defaultOptions, ...options };
 
 	const error = getError( action );
-	if ( error ) {
+	if ( undefined !== error ) {
 		return onError( store, action, error );
 	}
 
 	const data = getData( action );
-	if ( data ) {
+	if ( undefined !== data ) {
 		try {
 			return onSuccess( store, action, fromApi( data ) );
 		} catch ( err ) {
@@ -152,7 +152,7 @@ export const dispatchRequest = ( initiator, onSuccess, onError, options ) => ( s
 	}
 
 	const progress = getProgress( action );
-	if ( progress ) {
+	if ( undefined !== progress ) {
 		return onProgress( store, action, progress );
 	}
 


### PR DESCRIPTION
It's possible for an api response to be empty (will be passed to the data layer as an empty string). This PR makes it so that falsey api responses will be handled correctly, by checking for the raw `null` value.