### PR TITLE
Store: Enable product reviews for all environments

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -117,7 +117,7 @@
 		"woocommerce/extension-orders-create": false,
 		"woocommerce/extension-products": true,
 		"woocommerce/extension-promotions": false,
-		"woocommerce/extension-reviews": false,
+		"woocommerce/extension-reviews": true,
 		"woocommerce/extension-settings": true,
 		"woocommerce/extension-settings-payments": true,
 		"woocommerce/extension-settings-shipping": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -124,7 +124,7 @@
 		"woocommerce/extension-orders-create": false,
 		"woocommerce/extension-products": true,
 		"woocommerce/extension-promotions": false,
-		"woocommerce/extension-reviews": false,
+		"woocommerce/extension-reviews": true,
 		"woocommerce/extension-settings": true,
 		"woocommerce/extension-settings-payments": true,
 		"woocommerce/extension-settings-shipping": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -136,7 +136,7 @@
 		"woocommerce/extension-orders-create": true,
 		"woocommerce/extension-products": true,
 		"woocommerce/extension-promotions": false,
-		"woocommerce/extension-reviews": false,
+		"woocommerce/extension-reviews": true,
 		"woocommerce/extension-settings": true,
 		"woocommerce/extension-settings-payments": true,
 		"woocommerce/extension-settings-shipping": true,


### PR DESCRIPTION
This enables product reviews (`http://calypso.localhost:3000/store/reviews/:site` and related widgets) in `production`, `staging`, and `wpcalypso`.