### PR TITLE
Jetpack Connect: Always auto-authorize SSO

### DIFF
--- a/client/jetpack-connect/auth-logged-in-form.jsx
+++ b/client/jetpack-connect/auth-logged-in-form.jsx
@@ -79,14 +79,17 @@ class LoggedInForm extends Component {
 	componentWillMount() {
 		const { queryObject, autoAuthorize } = this.props.jetpackConnectAuthorize;
 		this.props.recordTracksEvent( 'calypso_jpc_auth_view' );
-		if (
+
+		const doAutoAuthorize =
 			! this.props.isAlreadyOnSitesList &&
 			! queryObject.already_authorized &&
 			( this.props.calypsoStartedConnection ||
-				this.props.isSSO ||
 				queryObject.new_user_started_connection ||
-				autoAuthorize )
-		) {
+				autoAuthorize );
+
+		// isSSO is a separate case from the rest since we have already validated
+		// it in authorize-form.jsx. Therefore, if it's set, just authorize and redirect.
+		if ( this.props.isSSO || doAutoAuthorize ) {
 			debug( 'Authorizing automatically on component mount' );
 			this.setState( { haveAuthorized: true } );
 			return this.props.authorize( queryObject );


### PR DESCRIPTION
When testing Jetpack Start and the connect flow today, I noticed a minor issue with auto-authorize for JPO.

The flow should be:

- User goes to wp-admin and clicks "Log in with WordPress.com" button
- User is taken to WordPress.com where they approve SSO
- User is redirected to their Jetpack site, logged in, and redirected back to WordPress.com
- When back on WP.com, the user is auto-authorized/connected 
- User is then redirect back to wp-admin

When I disconnected a user from my Jetpack site, then went through the flow, this almost went off perfectly. Except, I was shown the JPC approve button to approve the connection after I had already approved SSO.

I narrowed it down to the `! this.props.isAlreadyOnSitesList` condition, since the site was in my sites list from when before I severed the connection.

I don't imagine this will impact too many users, but it could be pretty annoying to approve things twice.

This logic is starting to get a bit funky, so I welcome any suggestions for simplifying it.