### PR TITLE
Jetpack Connect: Fix return to site for JPO

### DIFF
--- a/client/jetpack-connect/auth-logged-in-form.jsx
+++ b/client/jetpack-connect/auth-logged-in-form.jsx
@@ -104,7 +104,7 @@ class LoggedInForm extends Component {
 
 		// For SSO, WooCommerce Services, and JPO users, do not display plans page
 		// Instead, redirect back to admin as soon as we're connected
-		if ( props.isSSO || props.isWoo || ( queryObject && 'jpo' === queryObject.from ) ) {
+		if ( props.isSSO || props.isWoo || this.isFromJPO() ) {
 			if ( ! isRedirectingToWpAdmin && authorizeSuccess ) {
 				return this.props.goBackToWpAdmin( queryObject.redirect_after_auth );
 			}
@@ -154,7 +154,7 @@ class LoggedInForm extends Component {
 	redirect() {
 		const { queryObject } = this.props.jetpackConnectAuthorize;
 
-		if ( 'jpo' === queryObject.from || this.props.isSSO || this.props.isWoo ) {
+		if ( this.isFromJPO() || this.props.isSSO || this.props.isWoo ) {
 			debug(
 				'Going back to WP Admin.',
 				'Connection initiated via: ',
@@ -166,6 +166,16 @@ class LoggedInForm extends Component {
 		} else {
 			page.redirect( this.getRedirectionTarget() );
 		}
+	}
+
+	isFromJPO() {
+		const { queryObject } = this.props.jetpackConnectAuthorize;
+
+		if ( ! queryObject || ! queryObject.from || 'string' !== typeof queryObject.from ) {
+			return false;
+		}
+
+		return 0 === queryObject.from.indexOf( 'jpo' );
 	}
 
 	handleClickDisclaimer = () => {

--- a/client/jetpack-connect/auth-logged-in-form.jsx
+++ b/client/jetpack-connect/auth-logged-in-form.jsx
@@ -9,6 +9,7 @@ import addQueryArgs from 'lib/route/add-query-args';
 import debugModule from 'debug';
 import page from 'page';
 import { localize } from 'i18n-calypso';
+import { get, startsWith } from 'lodash';
 
 /**
  * Internal dependencies
@@ -169,13 +170,10 @@ class LoggedInForm extends Component {
 	}
 
 	isFromJpo() {
-		const { queryObject } = this.props.jetpackConnectAuthorize;
-
-		if ( ! queryObject || ! queryObject.from || 'string' !== typeof queryObject.from ) {
-			return false;
-		}
-
-		return 0 === queryObject.from.indexOf( 'jpo' );
+		return startsWith(
+			get( this.props, [ 'jetpackConnectAuthorize', 'queryObject', 'from' ] ),
+			'jpo'
+		);
 	}
 
 	handleClickDisclaimer = () => {

--- a/client/jetpack-connect/auth-logged-in-form.jsx
+++ b/client/jetpack-connect/auth-logged-in-form.jsx
@@ -154,7 +154,7 @@ class LoggedInForm extends Component {
 	redirect() {
 		const { queryObject } = this.props.jetpackConnectAuthorize;
 
-		if ( this.isFromJpo() || this.props.isSSO || this.props.isWoo ) {
+		if ( this.props.isSSO || this.props.isWoo || this.isFromJpo() ) {
 			debug(
 				'Going back to WP Admin.',
 				'Connection initiated via: ',

--- a/client/jetpack-connect/auth-logged-in-form.jsx
+++ b/client/jetpack-connect/auth-logged-in-form.jsx
@@ -104,7 +104,7 @@ class LoggedInForm extends Component {
 
 		// For SSO, WooCommerce Services, and JPO users, do not display plans page
 		// Instead, redirect back to admin as soon as we're connected
-		if ( props.isSSO || props.isWoo || this.isFromJPO() ) {
+		if ( props.isSSO || props.isWoo || this.isFromJpo() ) {
 			if ( ! isRedirectingToWpAdmin && authorizeSuccess ) {
 				return this.props.goBackToWpAdmin( queryObject.redirect_after_auth );
 			}
@@ -154,7 +154,7 @@ class LoggedInForm extends Component {
 	redirect() {
 		const { queryObject } = this.props.jetpackConnectAuthorize;
 
-		if ( this.isFromJPO() || this.props.isSSO || this.props.isWoo ) {
+		if ( this.isFromJpo() || this.props.isSSO || this.props.isWoo ) {
 			debug(
 				'Going back to WP Admin.',
 				'Connection initiated via: ',
@@ -168,7 +168,7 @@ class LoggedInForm extends Component {
 		}
 	}
 
-	isFromJPO() {
+	isFromJpo() {
 		const { queryObject } = this.props.jetpackConnectAuthorize;
 
 		if ( ! queryObject || ! queryObject.from || 'string' !== typeof queryObject.from ) {

--- a/client/jetpack-connect/auth-logged-in-form.jsx
+++ b/client/jetpack-connect/auth-logged-in-form.jsx
@@ -105,7 +105,7 @@ class LoggedInForm extends Component {
 
 		// For SSO, WooCommerce Services, and JPO users, do not display plans page
 		// Instead, redirect back to admin as soon as we're connected
-		if ( props.isSSO || props.isWoo || this.isFromJpo() ) {
+		if ( props.isSSO || props.isWoo || this.isFromJpo( props ) ) {
 			if ( ! isRedirectingToWpAdmin && authorizeSuccess ) {
 				return this.props.goBackToWpAdmin( queryObject.redirect_after_auth );
 			}
@@ -155,7 +155,7 @@ class LoggedInForm extends Component {
 	redirect() {
 		const { queryObject } = this.props.jetpackConnectAuthorize;
 
-		if ( this.props.isSSO || this.props.isWoo || this.isFromJpo() ) {
+		if ( this.props.isSSO || this.props.isWoo || this.isFromJpo( this.props ) ) {
 			debug(
 				'Going back to WP Admin.',
 				'Connection initiated via: ',
@@ -169,11 +169,8 @@ class LoggedInForm extends Component {
 		}
 	}
 
-	isFromJpo() {
-		return startsWith(
-			get( this.props, [ 'jetpackConnectAuthorize', 'queryObject', 'from' ] ),
-			'jpo'
-		);
+	isFromJpo( props ) {
+		return startsWith( get( props, [ 'jetpackConnectAuthorize', 'queryObject', 'from' ] ), 'jpo' );
 	}
 
 	handleClickDisclaimer = () => {


### PR DESCRIPTION
In Automattic/jetpack-onboard#https://github.com/Automattic/jetpack-onboarding/commit/86cf1fd77e2145841d1b4f6bc77b3166478cabb5 I inadvertently broke the logic that bypassed the JPC plans page the the connection came from JPO.

In that commit, I began appending the JPO version to the from value so we can get an idea of how many connections were coming from which JPO versions. But, I didn't consider that Calypso was looking at that value.

This PR fixes the issue by checking if the `from` value begins with `jpo`.

To test,

- Checkout PR
- Disconnect Jetpack site
- Click "Connect" button in Jetpack site
- Grab the URL, and swap out `wordpress.com` for `calypso.localhost:3000` as well as modify the `from` value to be something like `jpo-1.7.3`
- Ensure that you are redirected to the `wp-admin` of the remote site directly after authorizing, bypassing the plans page