### PR TITLE
Build: Update prettier to 1.6 fork

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -5257,8 +5257,8 @@
     },
     "prettier": {
       "version": "1.6.1",
-      "from": "git://github.com/automattic/calypso-prettier.git#70f962b044204cc7dca95a58446fbe0a2fdba231",
-      "resolved": "git://github.com/automattic/calypso-prettier.git#70f962b044204cc7dca95a58446fbe0a2fdba231",
+      "from": "git://github.com/automattic/calypso-prettier.git#14307ba5cc6bcfc00243f5e2d1b25c72d52c28c8",
+      "resolved": "git://github.com/automattic/calypso-prettier.git#14307ba5cc6bcfc00243f5e2d1b25c72d52c28c8",
       "dev": true,
       "dependencies": {
         "babel-code-frame": {
@@ -5303,10 +5303,6 @@
         },
         "has-flag": {
           "version": "2.0.0",
-          "dev": true
-        },
-        "jest-docblock": {
-          "version": "20.0.3",
           "dev": true
         },
         "jest-matcher-utils": {

--- a/package.json
+++ b/package.json
@@ -273,7 +273,7 @@
     "mixedindentlint": "1.2.0",
     "nock": "8.0.0",
     "nodemon": "1.4.1",
-    "prettier": "github:automattic/calypso-prettier#70f962b0",
+    "prettier": "github:automattic/calypso-prettier#14307ba5cc6bcfc00243f5e2d1b25c72d52c28c8",
     "react-addons-test-utils": "15.4.0",
     "react-codemod": "reactjs/react-codemod",
     "react-test-env": "0.2.0",


### PR DESCRIPTION
This updates us to the latest fork of prettier which doesn't break jest doc-comment directives.

See https://github.com/Automattic/calypso-prettier/commits/calypso-1.6

To test, install this patch and run our bundled prettier against a test file that includes 
```
/**
  *  @jest-environment jsdom
  */
```

It should end up as 
```
/**
  * @format
  * @jest-envionment jsdom
  */
```

