### PR TITLE
Hide view site for jetpack plans

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/header.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/header.jsx
@@ -150,10 +150,10 @@ class CheckoutThankYouHeader extends PureComponent {
 	}
 
 	getButton() {
-		const { translate, primaryPurchase } = this.props;
+		const { translate, primaryPurchase, selectedSite } = this.props;
 		const headerButtonClassName = 'button is-primary';
 
-		if ( isPlan( primaryPurchase ) ) {
+		if ( isPlan( primaryPurchase ) && ! selectedSite.jetpack ) {
 			return (
 				<div className="checkout-thank-you__header-button" >
 					<button className={ headerButtonClassName } onClick={ this.visitSite }>


### PR DESCRIPTION
We [recently introduced a "View your site" button](https://github.com/Automattic/wp-calypso/pull/18466) on the thank you page. The button was intended to be only shown to WordPress.com users. This PR hides the button from Jetpack customers. 

![image](https://user-images.githubusercontent.com/6981253/31202746-da3ace62-a931-11e7-9ca3-c168eff3dbb6.png)

I unfortunately can't get to the Jetpack thank you screen to test this because I get stuck here:
![image](https://user-images.githubusercontent.com/6981253/31202698-a140a23a-a931-11e7-8d9e-deeadabb39d0.png)

Can someone confirm this fix hides the button for Jetpack plans?

cc @rickybanister 