### PR TITLE
Make social signup work in ux_mode redirect

### DIFF
--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -36,23 +36,14 @@ const switchUserLocale = ( currentUser, reduxStore ) => {
 
 const setupContextMiddleware = reduxStore => {
 	page( '*', ( context, next ) => {
-		const parsed = url.parse( location.href, true );
-
-		// Decode the pathname by default (now disabled in page.js)
-		context.pathname = decodeURIComponent( context.pathname );
-
-		context.store = reduxStore;
-
-		// Break routing and do full load for logout link in /me
-		if ( context.pathname === '/wp-login.php' ) {
-			window.location.href = context.path;
-			return;
-		}
-
-		context.query = parsed.query;
+		// page.js url parsing is broken so we had to disable it with `decodeURLComponents: false`
+		const parsed = url.parse( context.canonicalPath, true );
+		context.pathname = parsed.pathname;
 		context.prevPath = parsed.path === context.path ? false : parsed.path;
+		context.path = parsed.path;
+		context.query = parsed.query;
 
-		context.hashstring = parsed.hash && parsed.hash.substring( 1 ) || '';
+		context.hashstring = ( parsed.hash && parsed.hash.substring( 1 ) ) || '';
 		// set `context.hash` (we have to parse manually)
 		if ( context.hashstring ) {
 			try {
@@ -64,6 +55,15 @@ const setupContextMiddleware = reduxStore => {
 		} else {
 			context.hash = {};
 		}
+
+		context.store = reduxStore;
+
+		// Break routing and do full load for logout link in /me
+		if ( context.pathname === '/wp-login.php' ) {
+			window.location.href = context.path;
+			return;
+		}
+
 		next();
 	} );
 };

--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -52,10 +52,11 @@ const setupContextMiddleware = reduxStore => {
 		context.query = parsed.query;
 		context.prevPath = parsed.path === context.path ? false : parsed.path;
 
+		context.hashstring = parsed.hash && parsed.hash.substring( 1 ) || '';
 		// set `context.hash` (we have to parse manually)
-		if ( parsed.hash && parsed.hash.length > 1 ) {
+		if ( context.hashstring ) {
 			try {
-				context.hash = qs.parse( parsed.hash.substring( 1 ) );
+				context.hash = qs.parse( context.hashstring );
 			} catch ( e ) {
 				debug( 'failed to query-string parse `location.hash`', e );
 				context.hash = {};

--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -49,15 +49,7 @@ const setupContextMiddleware = reduxStore => {
 			return;
 		}
 
-		// set `context.query`
-		const querystringStart = context.canonicalPath.indexOf( '?' );
-
-		if ( querystringStart !== -1 ) {
-			context.query = qs.parse( context.canonicalPath.substring( querystringStart + 1 ) );
-		} else {
-			context.query = {};
-		}
-
+		context.query = parsed.query;
 		context.prevPath = parsed.path === context.path ? false : parsed.path;
 
 		// set `context.hash` (we have to parse manually)

--- a/client/components/signup-form/index.jsx
+++ b/client/components/signup-form/index.jsx
@@ -606,7 +606,10 @@ class SignupForm extends Component {
 				</LoggedOutForm>
 
 				{ this.props.isSocialSignupEnabled && (
-					<SocialSignupForm handleResponse={ this.props.handleSocialResponse } />
+					<SocialSignupForm
+						handleResponse={ this.props.handleSocialResponse }
+						socialService={ this.props.socialService }
+						socialServiceResponse={ this.props.socialServiceResponse } />
 				) }
 
 				{ this.props.footerLink || this.footerLink() }

--- a/client/components/signup-form/social.jsx
+++ b/client/components/signup-form/social.jsx
@@ -15,6 +15,7 @@ import { localize } from 'i18n-calypso';
 import Card from 'components/card';
 import config from 'config';
 import { preventWidows } from 'lib/formatting';
+import { shouldUseLoginRedirectFlow } from 'lib/user/utils';
 
 class SocialSignupForm extends Component {
 	static propTypes = {
@@ -37,11 +38,9 @@ class SocialSignupForm extends Component {
 	};
 
 	render() {
-		// If calypso is loaded in a popup, we don't want to open a second popup for social signup
-		// let's use the redirect flow instead in that case.
-		//const isPopup = typeof window !== 'undefined' && window.opener && window.opener !== window;
-		const isPopup = typeof window !== 'undefined';
-		const redirectUri = isPopup ? `https://${ ( typeof window !== 'undefined' && window.location.host ) }/start` : null;
+		const redirectUri = shouldUseLoginRedirectFlow()
+			? `https://${ window.location.host }/start`
+			: null;
 
 		return (
 			<Card className="signup-form__social">
@@ -55,6 +54,7 @@ class SocialSignupForm extends Component {
 					<GoogleLoginButton
 						clientId={ config( 'google_oauth_client_id' ) }
 						responseHandler={ this.handleGoogleResponse }
+						redirectUri={ redirectUri }
 					/>
 				</div>
 			</Card>

--- a/client/components/signup-form/social.jsx
+++ b/client/components/signup-form/social.jsx
@@ -20,6 +20,8 @@ class SocialSignupForm extends Component {
 	static propTypes = {
 		handleResponse: PropTypes.func.isRequired,
 		translate: PropTypes.func.isRequired,
+		socialService: PropTypes.string,
+		socialServiceResponse: PropTypes.object,
 	};
 
 	handleGoogleResponse = ( response, triggeredByUser = true ) => {
@@ -27,8 +29,7 @@ class SocialSignupForm extends Component {
 			return;
 		}
 
-		if ( ! triggeredByUser ) {
-			// TODO: handle social signup for the redirect flow
+		if ( ! triggeredByUser && this.props.socialService !== 'google' ) {
 			return;
 		}
 
@@ -36,6 +37,12 @@ class SocialSignupForm extends Component {
 	};
 
 	render() {
+		// If calypso is loaded in a popup, we don't want to open a second popup for social signup
+		// let's use the redirect flow instead in that case.
+		//const isPopup = typeof window !== 'undefined' && window.opener && window.opener !== window;
+		const isPopup = typeof window !== 'undefined';
+		const redirectUri = isPopup ? `https://${ ( typeof window !== 'undefined' && window.location.host ) }/start` : null;
+
 		return (
 			<Card className="signup-form__social">
 				<p>

--- a/client/components/social-buttons/google.js
+++ b/client/components/social-buttons/google.js
@@ -100,7 +100,7 @@ class GoogleLoginButton extends Component {
 						const currentUser = googleAuth.currentUser.get();
 
 						// handle social authentication response from a redirect-based oauth2 flow
-						if ( currentUser ) {
+						if ( currentUser && this.props.uxMode === 'redirect' ) {
 							this.props.responseHandler( currentUser, false );
 						}
 

--- a/client/lib/signup/progress-store.js
+++ b/client/lib/signup/progress-store.js
@@ -35,6 +35,10 @@ var SignupProgressStore = {
 		signupProgress = [];
 		store.remove( STORAGE_KEY );
 	},
+	getFromCache: function() {
+		loadProgressFromCache();
+		return this.get();
+	},
 };
 
 emitter( SignupProgressStore );

--- a/client/lib/user/utils.js
+++ b/client/lib/user/utils.js
@@ -71,3 +71,16 @@ const userUtils = {
 };
 
 export default userUtils;
+
+export function isSafari() {
+	return typeof window !== 'undefined' && window.navigator.userAgent.match( /safari/i );
+}
+
+export function shouldUseLoginRedirectFlow() {
+	// If calypso is loaded in a popup, we don't want to open a second popup for social login
+	// let's use the redirect flow instead in that case
+	const isPopup = typeof window !== 'undefined' && window.opener && window.opener !== window;
+	// also disable the popup flow for all safari versions
+	// See https://github.com/google/google-api-javascript-client/issues/297#issuecomment-333869742
+	return isPopup || isSafari();
+}

--- a/client/lib/user/utils.js
+++ b/client/lib/user/utils.js
@@ -71,16 +71,3 @@ const userUtils = {
 };
 
 export default userUtils;
-
-export function isSafari() {
-	return typeof window !== 'undefined' && window.navigator.userAgent.match( /safari/i );
-}
-
-export function shouldUseLoginRedirectFlow() {
-	// If calypso is loaded in a popup, we don't want to open a second popup for social login
-	// let's use the redirect flow instead in that case
-	const isPopup = typeof window !== 'undefined' && window.opener && window.opener !== window;
-	// also disable the popup flow for all safari versions
-	// See https://github.com/google/google-api-javascript-client/issues/297#issuecomment-333869742
-	return isPopup || isSafari();
-}

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -31,7 +31,7 @@ const basePageTitle = 'Signup'; // used for analytics, doesn't require translati
 /**
  * Module variables
  */
-let queryObject, hashstring;
+let initialContext;
 
 export default {
 	redirectWithoutLocaleIfLoggedIn( context, next ) {
@@ -60,14 +60,8 @@ export default {
 		next();
 	},
 
-	saveQueryObject( context, next ) {
-		if ( ! isEmpty( context.query ) ) {
-			queryObject = context.query;
-		}
-
-		if ( context.hashstring ) {
-			hashstring = context.hashstring;
-		}
+	saveInitialContext( context, next ) {
+		initialContext = Object.assign( {}, context );
 
 		next();
 	},
@@ -100,9 +94,7 @@ export default {
 		renderWithReduxStore(
 			React.createElement( SignupComponent, {
 				path: context.path,
-				refParameter: queryObject && queryObject.ref,
-				queryObject,
-				hashstring,
+				initialContext,
 				locale: utils.getLocale( context.params ),
 				flowName: flowName,
 				stepName: stepName,

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -61,7 +61,9 @@ export default {
 	},
 
 	saveInitialContext( context, next ) {
-		initialContext = Object.assign( {}, context );
+		if ( ! initialContext ) {
+			initialContext = Object.assign( {}, context );
+		}
 
 		next();
 	},

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -41,16 +41,16 @@ export default {
 				stepSectionName = utils.getStepSectionName( context.params );
 			let urlWithoutLocale = utils.getStepUrl( flowName, stepName, stepSectionName );
 
+			if ( config.isEnabled( 'wpcom-user-bootstrap' ) ) {
+				return page.redirect( urlWithoutLocale );
+			}
+
 			if ( ! isEmpty( context.query ) ) {
 				urlWithoutLocale += '?' + context.querystring;
 			}
 
 			if ( ! isEmpty( context.hash ) ) {
 				urlWithoutLocale += '#' + context.hashstring;
-			}
-
-			if ( config.isEnabled( 'wpcom-user-bootstrap' ) ) {
-				return page.redirect( urlWithoutLocale );
 			}
 
 			window.location = urlWithoutLocale;

--- a/client/signup/index.web.js
+++ b/client/signup/index.web.js
@@ -14,7 +14,6 @@ import controller from './controller';
 export default function() {
 	page(
 		'/start/:flowName?/:stepName?/:stepSectionName?/:lang?',
-		controller.saveRefParameter,
 		controller.saveQueryObject,
 		controller.redirectWithoutLocaleIfLoggedIn,
 		controller.redirectToFlow,

--- a/client/signup/index.web.js
+++ b/client/signup/index.web.js
@@ -14,7 +14,7 @@ import controller from './controller';
 export default function() {
 	page(
 		'/start/:flowName?/:stepName?/:stepSectionName?/:lang?',
-		controller.saveQueryObject,
+		controller.saveInitialContext,
 		controller.redirectWithoutLocaleIfLoggedIn,
 		controller.redirectToFlow,
 		controller.start

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -106,14 +106,15 @@ class Signup extends React.Component {
 	};
 
 	submitQueryDependencies = () => {
-		if ( ! this.props.queryObject ) {
+		if ( isEmpty( this.props.initialContext && this.props.initialContext.query ) ) {
 			return;
 		}
 
+		const queryObject = this.props.initialContext.query;
 		const flowSteps = flows.getFlow( this.props.flowName ).steps;
 
 		// `vertical` query parameter
-		const vertical = this.props.queryObject.vertical;
+		const vertical = queryObject.vertical;
 		if ( 'undefined' !== typeof vertical && -1 === flowSteps.indexOf( 'survey' ) ) {
 			debug( 'From query string: vertical = %s', vertical );
 			this.props.setSurvey( {
@@ -142,11 +143,12 @@ class Signup extends React.Component {
 		this.submitQueryDependencies();
 
 		const flow = flows.getFlow( this.props.flowName );
+		const queryObject = this.props.initialContext && this.props.initialContext.query || {};
 
 		let providedDependencies;
 
 		if ( flow.providesDependenciesInQuery ) {
-			providedDependencies = pick( this.props.queryObject, flow.providesDependenciesInQuery );
+			providedDependencies = pick( queryObject, flow.providesDependenciesInQuery );
 		}
 
 		this.signupFlowController = new SignupFlowController( {
@@ -476,6 +478,7 @@ class Signup extends React.Component {
 					<CurrentComponent
 						path={ this.props.path }
 						step={ currentStepProgress }
+						initialContext={ this.props.initialContext }
 						steps={ flow.steps }
 						stepName={ this.props.stepName }
 						meta={ flow.meta || {} }

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -17,6 +17,7 @@ import {
 	filter,
 	find,
 	indexOf,
+	isEmpty,
 	last,
 	matchesProperty,
 	pick,
@@ -143,7 +144,7 @@ class Signup extends React.Component {
 		this.submitQueryDependencies();
 
 		const flow = flows.getFlow( this.props.flowName );
-		const queryObject = this.props.initialContext && this.props.initialContext.query || {};
+		const queryObject = ( this.props.initialContext && this.props.initialContext.query ) || {};
 
 		let providedDependencies;
 

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -178,13 +178,7 @@ class Signup extends React.Component {
 
 		this.loadProgressFromStore();
 
-		const flowSteps = flow.steps;
-		const flowStepsInProgressStore = filter(
-			SignupProgressStore.get(),
-			step => -1 !== flowSteps.indexOf( step.stepName )
-		);
-
-		if ( flowStepsInProgressStore.length > 0 && ! flow.disallowResume ) {
+		if ( utils.canResumeFlow( this.props.flowName, SignupProgressStore.get() ) ) {
 			// we loaded progress from local storage, attempt to resume progress
 			return this.resumeProgress();
 		}

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -30,6 +30,7 @@ export class UserStep extends Component {
 		translate: PropTypes.func,
 		subHeaderText: PropTypes.string,
 		isSocialSignupEnabled: PropTypes.bool,
+		initialContext: PropTypes.object,
 	};
 
 	static defaultProps = {

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -240,9 +240,8 @@ export class UserStep extends Component {
 	}
 
 	renderSignupForm() {
-
 		let socialService, socialServiceResponse;
-		const hashObject = this.props.initialContext && this.props.initialContext.query.hash;
+		const hashObject = this.props.initialContext && this.props.initialContext.hash;
 		if ( this.props.isSocialSignupEnabled && ! isEmpty( hashObject ) ) {
 			const clientId = hashObject.client_id;
 			socialService = getSocialServiceFromClientId( clientId );

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -163,7 +163,7 @@ export class UserStep extends Component {
 		this.submit( {
 			userData,
 			form: formWithoutPassword,
-			queryArgs: this.props.queryObject || {},
+			queryArgs: ( this.props.initialContext && this.props.initialContext.query ) || {},
 		} );
 	};
 
@@ -206,8 +206,12 @@ export class UserStep extends Component {
 	}
 
 	getRedirectToAfterLoginUrl() {
-		if ( this.props.oauth2Signup && this.props.queryObject.oauth2_redirect ) {
-			return this.props.queryObject.oauth2_redirect;
+		if (
+			this.props.oauth2Signup &&
+			this.props.initialContext &&
+			this.props.initialContext.query.oauth2_redirect
+		) {
+			return this.props.initialContext.query.oauth2_redirect;
 		}
 
 		const stepAfterRedirect =

--- a/client/signup/utils.js
+++ b/client/signup/utils.js
@@ -4,7 +4,7 @@
  * @format
  */
 
-import { find, indexOf, isEmpty, merge, pick } from 'lodash';
+import { filter, find, indexOf, isEmpty, merge, pick } from 'lodash';
 
 /**
  * Internal dependencies
@@ -143,7 +143,18 @@ function getThemeForDesignType( designType ) {
 	}
 }
 
+function canResumeFlow( flowName, progress ) {
+	const flow = flows.getFlow( flowName );
+	const flowStepsInProgressStore = filter(
+		progress,
+		step => -1 !== flow.steps.indexOf( step.stepName )
+	);
+
+	return flowStepsInProgressStore.length > 0 && ! flow.disallowResume;
+}
+
 export default {
+	canResumeFlow: canResumeFlow,
 	getFlowName: getFlowName,
 	getFlowSteps: getFlowSteps,
 	getStepName: getStepName,


### PR DESCRIPTION
This PR allows users to use the social login redirect flow (with google) during signup.

### Testing Instructions
- Navigate to https://calypso.live/start?branch=add/social-signup-redirect
- Try signing up with an already connected google account
- Try signing up with a new google account
- Check that other flows that use query parameters aren't affected by the change:
    - jetpack connect
    - oauth2 signup (https://woocomerce.com), social connect should be disabled

### Reviews
- [ ] Code
- [x] Product