### PR TITLE
Editor: Move HTML-mode media dropzone higher in DOM to cover editor body

### DIFF
--- a/client/components/drop-zone/index.jsx
+++ b/client/components/drop-zone/index.jsx
@@ -36,8 +36,11 @@ export const DropZone = React.createClass( {
 
 	getInitialState() {
 		return {
-			isDraggingOverDocument: false,
-			isDraggingOverElement: false,
+			//isDraggingOverDocument: false,
+			//isDraggingOverElement: false,
+			isDraggingOverDocument: true,
+			isDraggingOverElement: true,
+			// todo tmp set to false to make the dropzone easier to work with while debugging. revert before merging to master
 			lastVisibleState: false,
 		};
 	},
@@ -85,8 +88,11 @@ export const DropZone = React.createClass( {
 		}
 
 		this.setState( {
-			isDraggingOverDocument: false,
-			isDraggingOverElement: false,
+			//isDraggingOverDocument: false,
+			//isDraggingOverElement: false,
+			isDraggingOverDocument: true,
+			isDraggingOverElement: true
+			// todo tmp set to false to make the dropzone easier to work with while debugging. revert before merging to master
 		} );
 
 		this.toggleDropZoneReduxState( false );
@@ -194,6 +200,7 @@ export const DropZone = React.createClass( {
 	},
 
 	onDrop( event ) {
+		console.log('comp dropzone ondrop');
 		// This seemingly useless line has been shown to resolve a Safari issue
 		// where files dragged directly from the dock are not recognized
 		event.dataTransfer && event.dataTransfer.files.length;
@@ -208,6 +215,7 @@ export const DropZone = React.createClass( {
 		}
 
 		this.props.onDrop( event );
+		// this is still noop for the medialib zone? wtf
 
 		if ( ! this.props.onVerifyValidTransfer( event.dataTransfer ) ) {
 			return;
@@ -217,6 +225,7 @@ export const DropZone = React.createClass( {
 			this.props.onFilesDrop( Array.prototype.slice.call( event.dataTransfer.files ) );
 		}
 
+		// skipped past these? that wouldn't make sense though
 		event.stopPropagation();
 		event.preventDefault();
 	},

--- a/client/my-sites/media-library/drop-zone.jsx
+++ b/client/my-sites/media-library/drop-zone.jsx
@@ -41,6 +41,7 @@ module.exports = React.createClass( {
 
 		MediaActions.clearValidationErrors( this.props.site.ID );
 		MediaActions.add( this.props.site.ID, files );
+		console.log('medialibdropzone uploadfiles');
 		this.props.onAddMedia();
 
 		if ( this.props.trackStats ) {

--- a/client/post-editor/editor-featured-image/index.jsx
+++ b/client/post-editor/editor-featured-image/index.jsx
@@ -48,6 +48,9 @@ class EditorFeaturedImage extends Component {
 	static defaultProps = {
 		hasDropZone: false,
 		isDropZoneVisible: false,
+		//hasDropZone: true,
+		//isDropZoneVisible: true,
+			// ^^^ tmp, should go back to false when done testing
 		maxWidth: 450,
 		onImageSelected: () => {},
 	};

--- a/client/post-editor/editor-html-toolbar/index.jsx
+++ b/client/post-editor/editor-html-toolbar/index.jsx
@@ -18,14 +18,7 @@ import { Env } from 'tinymce/tinymce';
  */
 import { serialize as serializeContactForm } from 'components/tinymce/plugins/contact-form/shortcode-utils';
 import { serialize as serializeSimplePayment } from 'components/tinymce/plugins/simple-payments/shortcode-utils';
-import MediaActions from 'lib/media/actions';
-import MediaLibrarySelectedStore from 'lib/media/library-selected-store';
-import MediaUtils from 'lib/media/utils';
-import MediaValidationStore from 'lib/media/validation-store';
-import PostActions from 'lib/posts/actions';
 import { isWithinBreakpoint } from 'lib/viewport';
-import markup from 'post-editor/media-modal/markup';
-import { getSelectedSite } from 'state/ui/selectors';
 import {
 	fieldAdd,
 	fieldRemove,
@@ -37,7 +30,6 @@ import AddLinkDialog from './add-link-dialog';
 import Button from 'components/button';
 import ContactFormDialog from 'components/tinymce/plugins/contact-form/dialog';
 import EditorMediaModal from 'post-editor/editor-media-modal';
-import MediaLibraryDropZone from 'my-sites/media-library/drop-zone';
 import config from 'config';
 import SimplePaymentsDialog from 'components/tinymce/plugins/simple-payments/dialog';
 
@@ -56,7 +48,6 @@ export class EditorHtmlToolbar extends Component {
 		moment: PropTypes.func,
 		onToolbarChangeContent: PropTypes.func,
 		settingsUpdate: PropTypes.func,
-		site: PropTypes.object,
 		translate: PropTypes.func,
 	};
 
@@ -454,29 +445,6 @@ export class EditorHtmlToolbar extends Component {
 		this.closeSimplePaymentsDialog();
 	};
 
-	onFilesDrop = () => {
-		const { site } = this.props;
-		// Find selected images. Non-images will still be uploaded, but not
-		// inserted directly into the post contents.
-		const selectedItems = MediaLibrarySelectedStore.getAll( site.ID );
-		const isSingleImage =
-			1 === selectedItems.length && 'image' === MediaUtils.getMimePrefix( selectedItems[ 0 ] );
-
-		if ( isSingleImage && ! MediaValidationStore.hasErrors( site.ID ) ) {
-			// For single image upload, insert into post content, blocking save
-			// until the image has finished upload
-			if ( selectedItems[ 0 ].transient ) {
-				PostActions.blockSave( 'MEDIA_MODAL_TRANSIENT_INSERT' );
-			}
-
-			this.onInsertMedia( markup.get( site, selectedItems[ 0 ] ) );
-			MediaActions.setLibrarySelectedItems( site.ID, [] );
-		} else {
-			// In all other cases, show the media modal list view
-			this.openMediaModal();
-		}
-	};
-
 	isTagOpen = tag => -1 !== this.state.openTags.indexOf( tag );
 
 	renderExternal() {
@@ -516,7 +484,7 @@ export class EditorHtmlToolbar extends Component {
 	}
 
 	render() {
-		const { site, translate } = this.props;
+		const { translate } = this.props;
 
 		const classes = classNames( 'editor-html-toolbar', {
 			'is-pinned': this.state.isPinned,
@@ -676,8 +644,6 @@ export class EditorHtmlToolbar extends Component {
 					source={ this.state.source }
 				/>
 
-				<MediaLibraryDropZone onAddMedia={ this.onFilesDrop } site={ site } fullScreen={ false } />
-
 				<SimplePaymentsDialog
 					showDialog={ this.state.showSimplePaymentsDialog }
 					activeTab={ this.state.simplePaymentsDialogTab }
@@ -693,7 +659,6 @@ export class EditorHtmlToolbar extends Component {
 
 const mapStateToProps = state => ( {
 	contactForm: get( state, 'ui.editor.contactForm', {} ),
-	site: getSelectedSite( state ),
 } );
 
 const mapDispatchToProps = {

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -215,7 +215,25 @@ export const PostEditor = React.createClass( {
 	},
 
 	storeEditor( ref ) {
-		this.editor = ref;
+		// changing this to use .getWrappedInstance because TinyMCE is wrapped in connect() now
+		// so ref is now the wrapper, and we need to get the wrapped instance instead
+
+		// ref === null when unmounting old instance. if don't account for that, unit tests break now
+		// https://github.com/facebook/react/issues/4533#issuecomment-126807678
+		// seems like this is the correct approach, but maybe tests need to be updated instead? not 100% sure
+
+		// it's bad to have extra logic like this?
+		// https://github.com/facebook/react/pull/8333#issuecomment-263721571
+		// not sure how to deal w/ the wrapped component if that's true, though
+
+		// also, has to be inline? https://github.com/facebook/react/pull/8707#issuecomment-271117654
+			// didn't seem to work that way, though
+
+		if ( null === ref ) {
+			this.editor = ref;
+		} else {
+			this.editor = ref.getWrappedInstance();
+		}
 	},
 
 	useDefaultSidebarFocus( nextProps ) {

--- a/client/post-editor/style.scss
+++ b/client/post-editor/style.scss
@@ -145,7 +145,7 @@
 }
 
 .post-editor .tinymce-container .drop-zone.is-active {
-	top: 80px; /* Move it below the TinyMCE toolbar, because it looks bad when they overlap */
+	top: 35px; /* Move it below the TinyMCE toolbar, because it looks bad when they overlap */
 }
 
 .post-editor .tinymce {

--- a/client/state/selectors/is-drop-zone-visible.js
+++ b/client/state/selectors/is-drop-zone-visible.js
@@ -7,5 +7,7 @@
 import { get } from 'lodash';
 
 export default function isDropZoneVisible( state, dropZoneName = null ) {
+	return true;
+	// todo tmp set to false to make the dropzone easier to work with while debugging. revert before merging to master
 	return get( state, [ 'ui', 'dropZone', 'isVisible', dropZoneName ], false );
 }


### PR DESCRIPTION
When in HTML-mode, the Editor has a dropzone for uploading files and inserting them into the post body. Because of #18535, that dropzone is currently only `10px` tall, when it should take up the entire body of the editor.

The editor's HTML-mode media dropzone was introduced in #11680. At the time, there weren't any other dropzones on the screen -- the sidebar featured image zone was added a week later, in #11839 -- so the HTML-mode dropzone took up the entire screen.

Because it could take up the entire screen, its placement inside the `editor-html-toolbar` didn't pose any tangible problems*.

When a third dropzone was added in #16819, the HTML-mode dropzone has its `fullscreen` prop disabled, so that the new dropzone would be accessible. The changes in this PR should have been done at that time, but it was overlooked. Because they weren't done, the media dropzone is currently only `10px` tall, instead of covering the entire editor body. This makes it difficult for someone to drop a file in the correct location.

Because there are now multiple dropzones on the editor screen, the HTML-mode dropzone should only cover the editor body itself, not the entire screen. In order to achieve that, it needs to be moved above the `editor-html-toolbar` in the DOM, since the toolbar is restricted to be `40px` tall.

Fixes #18535

[*] - Despite not causing any tangible problems, the placement inside `editor-html-toolbar`,  seems like an odd choice, since it's not directly related to the toolbar. Perhaps it was just chosen for convenience, since the toolbar was already being output inside a conditional that checks if the editor is currently in HTML-mode. @Copons, do you remember? I just want to make sure I'm not missing something important.

### Test Plan

1. Create a new post, or open an existing one
1. Switch to HTML mode
1. Drag a file onto the editor
1. A large, blue dropzone should cover the editor body
1. Drop the file onto the blue editor
1. The file should upload, and insert into the editor
1. Repeat the steps above, but drop multiple images. A gallery should be inserted.
1. Drop files onto the two orange featured image dropzones, to make sure they still work fine.
1. Switch to visual mode and drop a file onto the blue editor dropzone, to make sure it still works fine.
1. **TBD** Add any other potential side-effects that need to be tested.