### PR TITLE
Extensions: Zoninator - Add validation for zone description

### DIFF
--- a/client/extensions/zoninator/components/forms/zone-details-form/index.jsx
+++ b/client/extensions/zoninator/components/forms/zone-details-form/index.jsx
@@ -77,6 +77,10 @@ const createReduxForm = reduxForm( {
 			errors.name = translate( 'Zone name cannot be empty.' );
 		}
 
+		if ( /[<>&]/.test( data.description ) ) {
+			errors.description = translate( 'Description cannot contain the following characters: <, > or &.' );
+		}
+
 		return errors;
 	},
 } );


### PR DESCRIPTION
This PR adds validation for zone description on both *Add a zone* and *Edit zone* views.

The current plugin behaviour is to discard a description containing one of: `<`, `>` or `&`. This wasn't reflected on the client side which would store the description with these characters until the next page load.  
Rather than clearing the descriptions containing one of the characters, I thought it would be more informative for the user to add an appropriate validation message before saving the changes.

![screen shot 2017-10-05 at 13 32 40](https://user-images.githubusercontent.com/8056203/31225579-06d7af84-a9d3-11e7-97eb-828936e3265b.png)

# Testing

- Go to `/extensions/zoninator`, select a site and click `Add a zone`.
- Enter a zone name and a description with one of the characters mentioned above. Ensure a validation message appears.
- Repeat the above step on `Edit zone` view.