### PR TITLE
Extensions: Zoninator - Unescape html entities in zone name

### DIFF
--- a/client/extensions/zoninator/state/data-layer/zones/utils.js
+++ b/client/extensions/zoninator/state/data-layer/zones/utils.js
@@ -1,7 +1,13 @@
-/** @format */
+/**
+ * External dependencies
+ *
+ * @format
+ */
+import { unescape } from 'lodash';
+
 export const fromApi = ( { description, name, slug, term_id } ) => ( {
 	description,
 	id: term_id,
-	name,
+	name: unescape( name ),
 	slug,
 } );

--- a/client/extensions/zoninator/state/data-layer/zones/utils.js
+++ b/client/extensions/zoninator/state/data-layer/zones/utils.js
@@ -1,12 +1,10 @@
 /**
  * External dependencies
- *
- * @format
  */
 import { unescape } from 'lodash';
 
 export const fromApi = ( { description, name, slug, term_id } ) => ( {
-	description,
+	description: unescape( description ),
 	id: term_id,
 	name: unescape( name ),
 	slug,


### PR DESCRIPTION
This PR ensures html entities in zone names are unescaped so React can render them correctly.

**Before:**

![screen shot 2017-10-05 at 13 50 17](https://user-images.githubusercontent.com/8056203/31225900-603a99c8-a9d4-11e7-9314-a1ae767f5f13.png)

**After:**

![screen shot 2017-10-05 at 13 49 48](https://user-images.githubusercontent.com/8056203/31225906-67437af0-a9d4-11e7-8068-6dc7ad1732b7.png)

# Testing

- Open `/extensions/zoninator`, select a site and click `Add a zone`.
- Add a zone and make sure to put `<`, `>` or `&` in the title.
- Click save and ensure the characters are displayed correctly.
- Reload the page and ensure the characters are still displayed instead of html entities.