### PR TITLE
Plugin Upload: show notice outside of data-layer AT status polling code

### DIFF
--- a/client/my-sites/plugins/plugin-upload/index.jsx
+++ b/client/my-sites/plugins/plugin-upload/index.jsx
@@ -39,6 +39,7 @@ import {
 	isJetpackSiteMultiSite,
 } from 'state/sites/selectors';
 import { getEligibility, isEligibleForAutomatedTransfer } from 'state/automated-transfer/selectors';
+import { successNotice } from 'state/notices/actions';
 
 class PluginUpload extends React.Component {
 	state = {
@@ -62,6 +63,13 @@ class PluginUpload extends React.Component {
 
 		if ( nextProps.complete ) {
 			page( `/plugins/${ nextProps.pluginId }/${ nextProps.siteSlug }` );
+
+			nextProps.successNotice(
+				nextProps.translate( "You've successfully uploaded the %(pluginId)s plugin.", {
+					args: { pluginId: nextProps.pluginId }
+				} ),
+				{ duration: 8000 }
+			);
 		}
 	}
 
@@ -183,5 +191,5 @@ export default connect(
 			showEligibility: ! isJetpack && ( hasEligibilityMessages || ! isEligible ),
 		};
 	},
-	{ uploadPlugin, clearPluginUpload, initiateAutomatedTransferWithPluginZip }
+	{ uploadPlugin, clearPluginUpload, initiateAutomatedTransferWithPluginZip, successNotice }
 )( localize( PluginUpload ) );

--- a/client/my-sites/plugins/plugin-upload/index.jsx
+++ b/client/my-sites/plugins/plugin-upload/index.jsx
@@ -38,8 +38,13 @@ import {
 	isJetpackSite,
 	isJetpackSiteMultiSite,
 } from 'state/sites/selectors';
-import { getEligibility, isEligibleForAutomatedTransfer } from 'state/automated-transfer/selectors';
+import {
+	getEligibility,
+	isEligibleForAutomatedTransfer,
+	getAutomatedTransferStatus,
+} from 'state/automated-transfer/selectors';
 import { successNotice } from 'state/notices/actions';
+import { transferStates } from 'state/automated-transfer/constants';
 
 class PluginUpload extends React.Component {
 	state = {
@@ -63,10 +68,17 @@ class PluginUpload extends React.Component {
 
 		if ( nextProps.complete ) {
 			page( `/plugins/${ nextProps.pluginId }/${ nextProps.siteSlug }` );
+		}
 
+		const { COMPLETE } = transferStates;
+
+		if (
+			this.props.automatedTransferStatus !== COMPLETE &&
+			nextProps.automatedTransferStatus === COMPLETE
+		) {
 			nextProps.successNotice(
 				nextProps.translate( "You've successfully uploaded the %(pluginId)s plugin.", {
-					args: { pluginId: nextProps.pluginId }
+					args: { pluginId: nextProps.pluginId },
 				} ),
 				{ duration: 8000 }
 			);
@@ -189,6 +201,7 @@ export default connect(
 			isJetpackMultisite,
 			siteAdminUrl: getSiteAdminUrl( state, siteId ),
 			showEligibility: ! isJetpack && ( hasEligibilityMessages || ! isEligible ),
+			automatedTransferStatus: getAutomatedTransferStatus( state, siteId ),
 		};
 	},
 	{ uploadPlugin, clearPluginUpload, initiateAutomatedTransferWithPluginZip, successNotice }

--- a/client/state/data-layer/wpcom/sites/automated-transfer/status/index.js
+++ b/client/state/data-layer/wpcom/sites/automated-transfer/status/index.js
@@ -3,8 +3,6 @@
  *
  * @format
  */
-
-import { translate } from 'i18n-calypso';
 import { delay, noop } from 'lodash';
 
 /**
@@ -15,7 +13,6 @@ import { recordTracksEvent } from 'state/analytics/actions';
 import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { requestSite } from 'state/sites/actions';
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { successNotice } from 'state/notices/actions';
 import {
 	getAutomatedTransferStatus,
 	setAutomatedTransferStatus,
@@ -59,14 +56,6 @@ export const receiveStatus = (
 
 		// Update the now-atomic site to ensure plugin page displays correctly.
 		dispatch( requestSite( siteId ) );
-		dispatch(
-			successNotice(
-				translate( "You've successfully uploaded the %(pluginId)s plugin.", {
-					args: { pluginId },
-				} ),
-				{ duration: 8000 }
-			)
-		);
 	}
 };
 

--- a/client/state/data-layer/wpcom/sites/automated-transfer/status/test/index.js
+++ b/client/state/data-layer/wpcom/sites/automated-transfer/status/test/index.js
@@ -50,25 +50,16 @@ describe( 'receiveStatus', () => {
 	it( 'should dispatch set status action', () => {
 		const dispatch = sinon.spy();
 		receiveStatus( { dispatch }, { siteId }, COMPLETE_RESPONSE );
-		expect( dispatch ).to.have.callCount( 4 );
+		expect( dispatch ).to.have.callCount( 3 );
 		expect( dispatch ).to.have.been.calledWith(
 			setAutomatedTransferStatus( siteId, 'complete', 'hello-dolly' )
 		);
 	} );
 
-	it( 'should dispatch success notice if complete', () => {
-		const dispatch = sinon.spy();
-		receiveStatus( { dispatch }, { siteId }, COMPLETE_RESPONSE );
-		expect( dispatch ).to.have.callCount( 4 );
-		expect( dispatch ).to.have.been.calledWithMatch( {
-			notice: { text: "You've successfully uploaded the hello-dolly plugin." },
-		} );
-	} );
-
 	it( 'should dispatch tracks event if complete', () => {
 		const dispatch = sinon.spy();
 		receiveStatus( { dispatch }, { siteId }, COMPLETE_RESPONSE );
-		expect( dispatch ).to.have.callCount( 4 );
+		expect( dispatch ).to.have.callCount( 3 );
 		expect( dispatch ).to.have.been.calledWith(
 			recordTracksEvent( 'calypso_automated_transfer_complete', {
 				context: 'plugin_upload',


### PR DESCRIPTION
Currently, we show a success notice "You've successfully uploaded the %(pluginId)s plugin." after polling transfer status and getting a `complete` status. However, the code which is used to poll for a transfer status can be used outside of just the Plugin Upload page (where this notice makes sense). 

In this PR, we are moving the notice away from the data-layer code and into the Plugin Upload component where it makes sense.

## Testing

Select a Business site and navigate to `/plugins/upload/<site>`. Upload a plugin zip. After the site transfers, you should be redirected to the plugin info view and the notice should show.