### PR TITLE
Jetpack Connect: Place Happychat button under a feature flag

### DIFF
--- a/client/jetpack-connect/happychat-button.jsx
+++ b/client/jetpack-connect/happychat-button.jsx
@@ -14,6 +14,7 @@ import { localize } from 'i18n-calypso';
  */
 import HappychatButton from 'components/happychat/button';
 import HappychatConnection from 'components/happychat/connection';
+import { isEnabled } from 'config';
 import { hasActiveHappychatSession, isHappychatAvailable } from 'state/happychat/selectors';
 
 const JetpackConnectHappychatButton = ( {
@@ -22,6 +23,14 @@ const JetpackConnectHappychatButton = ( {
 	isChatAvailable,
 	translate,
 } ) => {
+	if ( ! isEnabled( 'jetpack/happychat' ) ) {
+		return (
+			<div>
+				{ children }
+			</div>
+		);
+	}
+
 	if ( ! isChatAvailable && ! isChatActive ) {
 		return (
 			<div>


### PR DESCRIPTION
This PR moves the Jetpack Connect Happychat button under the dedicated feature flag, so we can test it before we push it on production.

This PR is part of #18397, so to test it you can use that PR.