### PR TITLE
Reader: Fix stats import in sidebar actions

### DIFF
--- a/client/state/ui/reader/sidebar/actions.js
+++ b/client/state/ui/reader/sidebar/actions.js
@@ -2,21 +2,21 @@
  * Internal dependencies
  */
 import { READER_SIDEBAR_LISTS_TOGGLE, READER_SIDEBAR_TAGS_TOGGLE } from 'state/action-types';
-import stats from 'reader/stats';
+import { recordAction, recordGaEvent, recordTrack } from 'reader/stats';
 
 export function toggleReaderSidebarLists() {
-	stats.recordAction( 'sidebar_toggle_lists_menu' );
-	stats.recordGaEvent( 'Toggle Lists Menu' );
-	stats.recordTrack( 'calypso_reader_sidebar_list_toggle' );
+	recordAction( 'sidebar_toggle_lists_menu' );
+	recordGaEvent( 'Toggle Lists Menu' );
+	recordTrack( 'calypso_reader_sidebar_list_toggle' );
 	return {
 		type: READER_SIDEBAR_LISTS_TOGGLE
 	};
 }
 
 export function toggleReaderSidebarTags() {
-	stats.recordAction( 'sidebar_toggle_tags_menu' );
-	stats.recordGaEvent( 'Toggle Tags Menu' );
-	stats.recordTrack( 'calypso_reader_sidebar_tags_toggle' );
+	recordAction( 'sidebar_toggle_tags_menu' );
+	recordGaEvent( 'Toggle Tags Menu' );
+	recordTrack( 'calypso_reader_sidebar_tags_toggle' );
 	return {
 		type: READER_SIDEBAR_TAGS_TOGGLE
 	};


### PR DESCRIPTION
Fixes `Uncaught TypeError: Cannot read property 'recordAction' of undefined` as reported by @rachelmcr in Slack. Introduced by #18359.

