### PR TITLE
Checkout: Fix hasFreeTrial import in pay-button.jsx

### DIFF
--- a/client/my-sites/checkout/checkout/pay-button.jsx
+++ b/client/my-sites/checkout/checkout/pay-button.jsx
@@ -8,7 +8,6 @@ import React from 'react';
  */
 import {
 	cartItems,
-	hasFreeTrial,
 	isPaidForFullyInCredits,
 } from 'lib/cart-values';
 import SubscriptionText from './subscription-text';
@@ -123,7 +122,7 @@ var PayButton = React.createClass( {
 
 	completing: function() {
 		var text;
-		if ( hasFreeTrial( this.props.cart ) ) {
+		if ( cartItems.hasFreeTrial( this.props.cart ) ) {
 			text = this.translate( 'Starting your free trial…', { context: 'Loading state on /checkout' } )
 		} else {
 			text = this.translate( 'Completing your purchase', { context: 'Loading state on /checkout' } )


### PR DESCRIPTION
Broken by #18359 (https://github.com/Automattic/wp-calypso/pull/18359/files#diff-5dca9d3f8f0e140509c204503492fbbbL11), reported by @lamosty in Slack.