### PR TITLE
Jetpack Connect: Add Happychat button to Plans pages

### DIFF
--- a/client/jetpack-connect/plans-landing.jsx
+++ b/client/jetpack-connect/plans-landing.jsx
@@ -10,6 +10,9 @@ import page from 'page';
 /**
  * Internal dependencies
  */
+import HelpButton from './help-button';
+import JetpackConnectHappychatButton from './happychat-button';
+import LoggedOutFormLinks from 'components/logged-out-form/links';
 import PlansGrid from './plans-grid';
 import PlansSkipButton from './plans-skip-button';
 import { recordTracksEvent } from 'state/analytics/actions';
@@ -76,6 +79,10 @@ class PlansLanding extends Component {
 		this.storeSelectedPlan( null );
 	};
 
+	handleHelpButtonClick = () => {
+		this.props.recordTracksEvent( 'calypso_jpc_help_link_click' );
+	};
+
 	render() {
 		const { basePlansPath, interval } = this.props;
 
@@ -92,6 +99,11 @@ class PlansLanding extends Component {
 					onSelect={ this.storeSelectedPlan }
 				>
 					<PlansSkipButton onClick={ this.handleSkipButtonClick } />
+					<LoggedOutFormLinks>
+						<JetpackConnectHappychatButton>
+							<HelpButton onClick={ this.handleHelpButtonClick } />
+						</JetpackConnectHappychatButton>
+					</LoggedOutFormLinks>
 				</PlansGrid>
 			</div>
 		);

--- a/client/jetpack-connect/plans.jsx
+++ b/client/jetpack-connect/plans.jsx
@@ -12,6 +12,9 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import HelpButton from './help-button';
+import JetpackConnectHappychatButton from './happychat-button';
+import LoggedOutFormLinks from 'components/logged-out-form/links';
 import PlansGrid from './plans-grid';
 import PlansSkipButton from './plans-skip-button';
 import {
@@ -104,6 +107,10 @@ class Plans extends Component {
 		this.props.recordTracksEvent( 'calypso_jpc_plans_skip_button_click' );
 
 		this.selectFreeJetpackPlan();
+	};
+
+	handleHelpButtonClick = () => {
+		this.props.recordTracksEvent( 'calypso_jpc_help_link_click' );
 	};
 
 	isFlowTypePaid() {
@@ -291,6 +298,11 @@ class Plans extends Component {
 					hideFreePlan={ true }
 				>
 					<PlansSkipButton onClick={ this.handleSkipButtonClick } isRtl={ isRtlLayout } />
+					<LoggedOutFormLinks>
+						<JetpackConnectHappychatButton>
+							<HelpButton onClick={ this.handleHelpButtonClick } />
+						</JetpackConnectHappychatButton>
+					</LoggedOutFormLinks>
 				</PlansGrid>
 			</div>
 		);

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -549,4 +549,16 @@
 	.formatted-header.is-without-subhead {
 		margin-bottom: 8px;
 	}
+
+	.logged-out-form__links,
+	.jetpack-connect__happychat-button {
+		text-align: center;
+	}
+
+	.logged-out-form__link-item {
+		.gridicon {
+			position: relative;
+			top: 4px;
+		}
+	}
 }


### PR DESCRIPTION
### Purpose

This PR adds a Happychat button to the Plans and Plans landing pages. If Happychat is not available at this time, the old Help link is displayed, so users can still get in touch with us and receive help.

Relies on #18567. 
Fixes #18151.

### Preview:

**Happychat unavailable**
![](https://cldup.com/MYQytmjRvd.png)

**Happychat available**
![](https://cldup.com/ZBIcU73RhX.png)

### Testing:

* Checkout this branch.
* Test all steps below with both of the following test steps:
  * Go to http://calypso.localhost:3000/jetpack/connect/store
  * Start at http://calypso.localhost:3000/jetpack/connect/, connect a site and reach the Plans page.
* While Happychat is available, verify the Happychat button is there and looks as on the preview. Use the button and verify it works as expected (opening the chat box).
* While Happychat is unavailable, verify the default Help button is there and looks as on the preview. Use the button and verify it works as expected (opening a new window with the Jetpack support form).