### PR TITLE
Framework: Remove obsolete QuerySites allSites instances

### DIFF
--- a/client/jetpack-connect/main.jsx
+++ b/client/jetpack-connect/main.jsx
@@ -24,7 +24,6 @@ import {
 	getJetpackSiteByUrl,
 } from 'state/jetpack-connect/selectors';
 import { isRequestingSites } from 'state/sites/selectors';
-import QuerySites from 'components/data/query-sites';
 import JetpackInstallStep from './install-step';
 import versionCompare from 'lib/version-compare';
 import LocaleSuggestions from 'components/locale-suggestions';
@@ -404,7 +403,6 @@ class JetpackConnectMain extends Component {
 			<MainWrapper>
 				{ this.renderLocaleSuggestions() }
 				<div className="jetpack-connect__site-url-entry-container">
-					<QuerySites allSites />
 					<FormattedHeader
 						headerText={ this.getTexts().headerTitle }
 						subHeaderText={ this.getTexts().headerSubtitle }

--- a/client/my-sites/plugins/plugin.jsx
+++ b/client/my-sites/plugins/plugin.jsx
@@ -29,7 +29,6 @@ import PluginSectionsCustom from 'my-sites/plugins/plugin-sections/custom';
 import DocumentHead from 'components/data/document-head';
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 import { recordGoogleEvent } from 'state/analytics/actions';
-import QuerySites from 'components/data/query-sites';
 import { canJetpackSiteManage, isJetpackSite, isRequestingSites } from 'state/sites/selectors';
 import {
 	canCurrentUser,
@@ -371,7 +370,6 @@ const SinglePlugin = React.createClass( {
 		return (
 			<MainComponent>
 				<NonSupportedJetpackVersionNotice />
-				<QuerySites allSites />
 				{ this.renderDocumentHead() }
 				<SidebarNavigation />
 				<div className="plugin__page">

--- a/client/my-sites/stats/overview.jsx
+++ b/client/my-sites/stats/overview.jsx
@@ -20,7 +20,6 @@ import DatePicker from './stats-date-picker';
 import StatsNavigation from 'blocks/stats-navigation';
 import Main from 'components/main';
 import StatsFirstView from './stats-first-view';
-import QuerySites from 'components/data/query-sites';
 import JetpackColophon from 'components/jetpack-colophon';
 import { getCurrentUser } from 'state/current-user/selectors';
 import { getVisibleSites } from 'state/selectors';
@@ -97,7 +96,6 @@ class StatsOverview extends Component {
 
 		return (
 			<Main wideLayout>
-				<QuerySites allSites />
 				<StatsFirstView />
 				<SidebarNavigation />
 				<StatsNavigation selectedItem={ 'traffic' } interval={ period } />


### PR DESCRIPTION
For quite some time we've been calling `<QuerySites allSites />` in `<Layout />`, which basically makes unnecessary any similar subsequent instances of this query component. 

So, this PR removes all unnecessary `<QuerySites allSites />` instances.

To test:

* Checkout this branch
* Clear your Redux state and test any of the below steps with a clean store:
  * http://calypso.localhost:3000/jetpack/connect
  * http://calypso.localhost:3000/stats/month and all other periods
  * http://calypso.localhost:3000/plugins/akismet
  * http://calypso.localhost:3000/plugins/akismet/:site
* Verify sites are being queried and loaded in all of the cases.