### PR TITLE
Post-publish Preview: Never return to site when publishing a new post

### DIFF
--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -1063,7 +1063,9 @@ export const PostEditor = React.createClass( {
 			const referrer = get( window, 'document.referrer', '' );
 			const referrerDomain = parseUrl( referrer ).hostname;
 			const shouldReturnToSite =
-				this.props.isEditorOnlyRouteInHistory && referrerDomain === this.props.selectedSiteDomain;
+				'updated' === message &&
+				this.props.isEditorOnlyRouteInHistory &&
+				referrerDomain === this.props.selectedSiteDomain;
 
 			if ( shouldReturnToSite ) {
 				window.location.href = this.getExternalUrl();


### PR DESCRIPTION
The change in #18326 was intended to only affect the edit link.

If, from the front-page of your site (example.wordpress.com), you selected "Write" in the master bar, you would be returned to your site after publishing a new post. This behavior isn't desired.

This PR updates the change in #18326 such that the edit link from your site returns you to your site and that the "Write" button in the master bar of your site keeps you in Calypso, displaying the preview as usual.

To test (new instructions that were not part of #18326 in **bold**):
* Checkout branch.
* `npm start`.
* Get to the editor via normal means within Calypso.
* Verify that a preview is still shown after updating an existing post.
* Copy the editor URL, and in a new tab visit that URL directly.
* Verify that a preview is still shown after updating the existing post.
* **Verify that a preview is still shown after publishing a new post using "Write" in the master bar from within Calypso.**
* Visit your site directly (example.wordpress.com).
* Use your browser's inspector to modify the edit link to point to `calypso.localhost:3000`. For example, if it was previously `https://wordpress.com/post/example.wordpress.com/123`, update it so that it is `http://calypso.localhost:3000/post/example.wordpress.com/123`.
* Using the inspector, also add the following attribute to the link: `referrerpolicy="unsafe-url"`. Without that attribute the referrer will not properly propagate to the insecure host `calypso.localhost:3000`.
* Click on your modified edit link. Verify that after updating your post, instead of being shown a preview, your are returned to your site.
* **Again, visit your site directly (example.wordpress.com).**
* **Use your browser's inspector to modify the "Write" link in the master bar to point to `calypso.localhost:3000`. For example, if it was previously `https://wordpress.com/post/example.wordpress.com`, update it so that it is `http://calypso.localhost:3000/post/example.wordpress.com`.**
* **Using the inspector, also add the following attribute to the link: `referrerpolicy="unsafe-url"`. Without that attribute the referrer will not properly propagate to the insecure host `calypso.localhost:3000`.**
* **Click on your modified "Write" link. Verify that after publishing your post, you are shown a preview.**
