### PR TITLE
Store Orders: Edit customer info on an order

### DIFF
--- a/client/extensions/woocommerce/app/order/index.js
+++ b/client/extensions/woocommerce/app/order/index.js
@@ -136,7 +136,7 @@ class Order extends Component {
 				<div className="order__container">
 					<OrderDetails orderId={ orderId } />
 					<OrderNotes orderId={ orderId } siteId={ site.ID } />
-					<OrderCustomer order={ order } />
+					<OrderCustomer orderId={ orderId } />
 				</div>
 			</Main>
 		);

--- a/client/extensions/woocommerce/app/order/order-customer/dialog.js
+++ b/client/extensions/woocommerce/app/order/order-customer/dialog.js
@@ -13,7 +13,7 @@ import { localize } from 'i18n-calypso';
 import AddressView from 'woocommerce/components/address-view';
 import Button from 'components/button';
 import Dialog from 'components/dialog';
-// import FormCheckbox from 'components/forms/form-checkbox';
+import FormCheckbox from 'components/forms/form-checkbox';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
 import FormLegend from 'components/forms/form-legend';
@@ -39,9 +39,9 @@ class CustomerAddressDialog extends Component {
 			last_name: PropTypes.string.isRequired,
 			phone: PropTypes.string,
 		} ),
-		isVisible: PropTypes.bool,
 		closeDialog: PropTypes.func,
-		showPhoneEmail: PropTypes.bool,
+		isBilling: PropTypes.bool,
+		isVisible: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -58,8 +58,8 @@ class CustomerAddressDialog extends Component {
 			phone: '',
 		},
 		closeDialog: noop,
+		isBilling: false,
 		isVisible: false,
-		showPhoneEmail: false,
 	};
 
 	constructor( props ) {
@@ -102,10 +102,18 @@ class CustomerAddressDialog extends Component {
 		} );
 	};
 
-	renderPhoneEmail = () => {
-		const { showPhoneEmail, translate } = this.props;
+	toggleShipping = () => {
+		this.setState( prevState => {
+			const { address } = prevState;
+			const newState = { ...address, copyToShipping: ! prevState.address.copyToShipping };
+			return { address: newState };
+		} );
+	};
+
+	renderBillingFields = () => {
+		const { isBilling, translate } = this.props;
 		const { address } = this.state;
-		if ( ! showPhoneEmail ) {
+		if ( ! isBilling ) {
 			return null;
 		}
 		return (
@@ -127,6 +135,15 @@ class CustomerAddressDialog extends Component {
 						value={ get( address, 'email', '' ) }
 						onChange={ this.onChange }
 					/>
+				</FormFieldset>
+				<FormFieldset>
+					<FormLabel>
+						<FormCheckbox
+							checked={ get( address, 'copyToShipping', false ) }
+							onChange={ this.toggleShipping }
+						/>
+						<span>{ translate( 'Copy changes to shipping' ) }</span>
+					</FormLabel>
 				</FormFieldset>
 			</div>
 		);
@@ -178,7 +195,7 @@ class CustomerAddressDialog extends Component {
 						onChange={ this.onChange }
 						address={ getAddressViewFormat( address ) }
 					/>
-					{ this.renderPhoneEmail() }
+					{ this.renderBillingFields() }
 				</FormFieldset>
 			</Dialog>
 		);

--- a/client/extensions/woocommerce/app/order/order-customer/dialog.js
+++ b/client/extensions/woocommerce/app/order/order-customer/dialog.js
@@ -42,6 +42,7 @@ class CustomerAddressDialog extends Component {
 		closeDialog: PropTypes.func,
 		isBilling: PropTypes.bool,
 		isVisible: PropTypes.bool,
+		updateAddress: PropTypes.func.isRequired,
 	};
 
 	static defaultProps = {
@@ -60,6 +61,7 @@ class CustomerAddressDialog extends Component {
 		closeDialog: noop,
 		isBilling: false,
 		isVisible: false,
+		updateAddress: noop,
 	};
 
 	constructor( props ) {

--- a/client/extensions/woocommerce/app/order/order-customer/dialog.js
+++ b/client/extensions/woocommerce/app/order/order-customer/dialog.js
@@ -150,7 +150,7 @@ class CustomerAddressDialog extends Component {
 	};
 
 	render() {
-		const { isVisible, translate } = this.props;
+		const { isBilling, isVisible, translate } = this.props;
 		const { address } = this.state;
 		const dialogButtons = [
 			<Button onClick={ this.closeDialog }>{ translate( 'Close' ) }</Button>,
@@ -168,7 +168,7 @@ class CustomerAddressDialog extends Component {
 			>
 				<FormFieldset>
 					<FormLegend className="order-customer__billing-details">
-						{ translate( 'Billing Details' ) }
+						{ isBilling ? translate( 'Billing Details' ) : translate( 'Shipping Details' ) }
 					</FormLegend>
 					<div className="order-customer__fieldset">
 						<div className="order-customer__field">

--- a/client/extensions/woocommerce/app/order/order-customer/dialog.js
+++ b/client/extensions/woocommerce/app/order/order-customer/dialog.js
@@ -1,0 +1,188 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { get, noop } from 'lodash';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import AddressView from 'woocommerce/components/address-view';
+import Button from 'components/button';
+import Dialog from 'components/dialog';
+// import FormCheckbox from 'components/forms/form-checkbox';
+import FormFieldset from 'components/forms/form-fieldset';
+import FormLabel from 'components/forms/form-label';
+import FormLegend from 'components/forms/form-legend';
+import FormPhoneMediaInput from 'components/forms/form-phone-media-input';
+import FormTextInput from 'components/forms/form-text-input';
+import getAddressViewFormat from 'woocommerce/lib/get-address-view-format';
+
+// @todo Update this to use our store countries list
+import countriesListBuilder from 'lib/countries-list';
+const countriesList = countriesListBuilder.forPayments();
+
+class CustomerAddressDialog extends Component {
+	static propTypes = {
+		address: PropTypes.shape( {
+			address_1: PropTypes.string.isRequired,
+			address_2: PropTypes.string,
+			city: PropTypes.string.isRequired,
+			state: PropTypes.string,
+			country: PropTypes.string.isRequired,
+			postcode: PropTypes.string,
+			email: PropTypes.string,
+			first_name: PropTypes.string.isRequired,
+			last_name: PropTypes.string.isRequired,
+			phone: PropTypes.string,
+		} ),
+		isVisible: PropTypes.bool,
+		closeDialog: PropTypes.func,
+		showPhoneEmail: PropTypes.bool,
+	};
+
+	static defaultProps = {
+		address: {
+			street: '',
+			street2: '',
+			city: '',
+			state: 'AL',
+			country: 'US',
+			postcode: '',
+			email: '',
+			first_name: '',
+			last_name: '',
+			phone: '',
+		},
+		closeDialog: noop,
+		isVisible: false,
+		showPhoneEmail: false,
+	};
+
+	constructor( props ) {
+		super( props );
+		this.state = {
+			address: props.address,
+			phoneCountry: 'US',
+		};
+	}
+
+	updateAddress = () => {
+		this.props.updateAddress( this.state.address );
+		this.props.closeDialog();
+	};
+
+	closeDialog = () => {
+		this.props.closeDialog();
+	};
+
+	onPhoneChange = phone => {
+		this.setState( prevState => {
+			const { address } = prevState;
+			const newState = { ...address, phone: phone.value };
+			return { address: newState, phoneCountry: phone.countryCode };
+		} );
+	};
+
+	onChange = event => {
+		let name = event.target.name;
+		if ( 'street' === event.target.name ) {
+			name = 'address_1';
+		} else if ( 'street2' === event.target.name ) {
+			name = 'address_2';
+		}
+		const value = event.target.value;
+		this.setState( prevState => {
+			const { address } = prevState;
+			const newState = { ...address, [ name ]: value };
+			return { address: newState };
+		} );
+	};
+
+	renderPhoneEmail = () => {
+		const { showPhoneEmail, translate } = this.props;
+		const { address } = this.state;
+		if ( ! showPhoneEmail ) {
+			return null;
+		}
+		return (
+			<div>
+				<FormFieldset>
+					<FormPhoneMediaInput
+						label={ translate( 'Phone Number' ) }
+						onChange={ this.onPhoneChange }
+						countryCode={ this.state.phoneCountry }
+						countriesList={ countriesList }
+						value={ get( address, 'phone', '' ) }
+					/>
+				</FormFieldset>
+				<FormFieldset>
+					<FormLabel htmlFor="email">{ translate( 'Email address' ) }</FormLabel>
+					<FormTextInput
+						id="email"
+						name="email"
+						value={ get( address, 'email', '' ) }
+						onChange={ this.onChange }
+					/>
+				</FormFieldset>
+			</div>
+		);
+	};
+
+	render() {
+		const { isVisible, translate } = this.props;
+		const { address } = this.state;
+		const dialogButtons = [
+			<Button onClick={ this.closeDialog }>{ translate( 'Close' ) }</Button>,
+			<Button primary onClick={ this.updateAddress }>
+				{ translate( 'Save' ) }
+			</Button>,
+		];
+
+		return (
+			<Dialog
+				isVisible={ isVisible }
+				onClose={ this.closeDialog }
+				className="order-customer__dialog woocommerce"
+				buttons={ dialogButtons }
+			>
+				<FormFieldset>
+					<FormLegend className="order-customer__billing-details">
+						{ translate( 'Billing Details' ) }
+					</FormLegend>
+					<div className="order-customer__fieldset">
+						<div className="order-customer__field">
+							<FormLabel htmlFor="first_name">{ translate( 'First Name' ) }</FormLabel>
+							<FormTextInput
+								id="first_name"
+								name="first_name"
+								value={ get( address, 'first_name', '' ) }
+								onChange={ this.onChange }
+							/>
+						</div>
+						<div className="order-customer__field">
+							<FormLabel htmlFor="last_name">{ translate( 'Last Name' ) }</FormLabel>
+							<FormTextInput
+								id="last_name"
+								name="last_name"
+								value={ get( address, 'last_name', '' ) }
+								onChange={ this.onChange }
+							/>
+						</div>
+					</div>
+					<AddressView
+						isEditable
+						onChange={ this.onChange }
+						address={ getAddressViewFormat( address ) }
+					/>
+					{ this.renderPhoneEmail() }
+				</FormFieldset>
+			</Dialog>
+		);
+	}
+}
+
+export default localize( CustomerAddressDialog );

--- a/client/extensions/woocommerce/app/order/order-customer/index.js
+++ b/client/extensions/woocommerce/app/order/order-customer/index.js
@@ -19,7 +19,7 @@ import { editOrder } from 'woocommerce/state/ui/orders/actions';
 import { isCurrentlyEditingOrder, getOrderWithEdits } from 'woocommerce/state/ui/orders/selectors';
 import getAddressViewFormat from 'woocommerce/lib/get-address-view-format';
 import { getOrder } from 'woocommerce/state/sites/orders/selectors';
-import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
 import SectionHeader from 'components/section-header';
 
 class OrderCustomerInfo extends Component {
@@ -148,15 +148,13 @@ class OrderCustomerInfo extends Component {
 
 export default connect(
 	( state, props ) => {
-		const site = getSelectedSiteWithFallback( state );
-		const siteId = site ? site.ID : false;
+		const siteId = getSelectedSiteId( state );
 		const isEditing = isCurrentlyEditingOrder( state );
 		const order = isEditing ? getOrderWithEdits( state ) : getOrder( state, props.orderId );
 
 		return {
 			isEditing,
 			order,
-			site,
 			siteId,
 		};
 	},

--- a/client/extensions/woocommerce/app/order/order-customer/index.js
+++ b/client/extensions/woocommerce/app/order/order-customer/index.js
@@ -38,8 +38,12 @@ class OrderCustomerInfo extends Component {
 	updateAddress = ( type = 'billing' ) => {
 		const { siteId, order } = this.props;
 		return address => {
+			const { copyToShipping = false, ...newAddress } = address;
 			if ( siteId ) {
-				this.props.editOrder( siteId, { id: order.id, [ type ]: address } );
+				this.props.editOrder( siteId, { id: order.id, [ type ]: newAddress } );
+				if ( copyToShipping && 'billing' === type ) {
+					this.props.editOrder( siteId, { id: order.id, shipping: newAddress } );
+				}
 			}
 		};
 	};
@@ -57,9 +61,9 @@ class OrderCustomerInfo extends Component {
 				key="dialog-billing"
 				address={ billing }
 				closeDialog={ this.toggleDialog( false ) }
+				isBilling
 				isVisible={ 'billing' === this.state.showDialog }
 				updateAddress={ this.updateAddress( 'billing' ) }
-				showPhoneEmail
 			/>,
 			<CustomerAddressDialog
 				key="dialog-shipping"

--- a/client/extensions/woocommerce/app/order/order-customer/index.js
+++ b/client/extensions/woocommerce/app/order/order-customer/index.js
@@ -14,14 +14,13 @@ import { localize } from 'i18n-calypso';
 import AddressView from 'woocommerce/components/address-view';
 import Button from 'components/button';
 import Card from 'components/card';
+import CustomerAddressDialog from './dialog';
 import { editOrder } from 'woocommerce/state/ui/orders/actions';
 import { isCurrentlyEditingOrder, getOrderWithEdits } from 'woocommerce/state/ui/orders/selectors';
 import getAddressViewFormat from 'woocommerce/lib/get-address-view-format';
 import { getOrder } from 'woocommerce/state/sites/orders/selectors';
 import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
 import SectionHeader from 'components/section-header';
-
-const CustomerAddressDialog = () => null;
 
 class OrderCustomerInfo extends Component {
 	static propTypes = {
@@ -32,8 +31,44 @@ class OrderCustomerInfo extends Component {
 		} ),
 	};
 
-	toggleDialog = () => {
-		return () => {};
+	state = {
+		showDialog: false,
+	};
+
+	updateAddress = ( type = 'billing' ) => {
+		const { siteId, order } = this.props;
+		return address => {
+			if ( siteId ) {
+				this.props.editOrder( siteId, { id: order.id, [ type ]: address } );
+			}
+		};
+	};
+
+	toggleDialog = type => {
+		return () => {
+			this.setState( { showDialog: type } );
+		};
+	};
+
+	renderDialogs = () => {
+		const { billing, shipping } = this.props.order;
+		return [
+			<CustomerAddressDialog
+				key="dialog-billing"
+				address={ billing }
+				closeDialog={ this.toggleDialog( false ) }
+				isVisible={ 'billing' === this.state.showDialog }
+				updateAddress={ this.updateAddress( 'billing' ) }
+				showPhoneEmail
+			/>,
+			<CustomerAddressDialog
+				key="dialog-shipping"
+				address={ shipping }
+				closeDialog={ this.toggleDialog( false ) }
+				isVisible={ 'shipping' === this.state.showDialog }
+				updateAddress={ this.updateAddress( 'shipping' ) }
+			/>,
+		];
 	};
 
 	render() {
@@ -98,7 +133,7 @@ class OrderCustomerInfo extends Component {
 						</div>
 					</div>
 				</Card>
-				<CustomerAddressDialog />
+				{ isEditing && this.renderDialogs() }
 			</div>
 		);
 	}

--- a/client/extensions/woocommerce/app/order/order-customer/index.js
+++ b/client/extensions/woocommerce/app/order/order-customer/index.js
@@ -99,9 +99,9 @@ class OrderCustomerInfo extends Component {
 										compact
 										className="order-customer__edit-link"
 										onClick={ this.toggleDialog( 'billing' ) }
-										primary
+										borderless
 									>
-										{ translate( 'edit' ) }
+										{ translate( 'Edit' ) }
 									</Button>
 								) : null }
 							</h3>
@@ -126,9 +126,9 @@ class OrderCustomerInfo extends Component {
 										compact
 										className="order-customer__edit-link"
 										onClick={ this.toggleDialog( 'shipping' ) }
-										primary
+										borderless
 									>
-										{ translate( 'edit' ) }
+										{ translate( 'Edit' ) }
 									</Button>
 								) : null }
 							</h3>

--- a/client/extensions/woocommerce/app/order/order-customer/index.js
+++ b/client/extensions/woocommerce/app/order/order-customer/index.js
@@ -93,10 +93,10 @@ class OrderCustomerInfo extends Component {
 								{ translate( 'Billing Details' ) }
 								{ isEditing ? (
 									<Button
-										borderless
 										compact
 										className="order-customer__edit-link"
 										onClick={ this.toggleDialog( 'billing' ) }
+										primary
 									>
 										{ translate( 'edit' ) }
 									</Button>
@@ -120,10 +120,10 @@ class OrderCustomerInfo extends Component {
 								{ translate( 'Shipping Details' ) }
 								{ isEditing ? (
 									<Button
-										borderless
 										compact
 										className="order-customer__edit-link"
 										onClick={ this.toggleDialog( 'shipping' ) }
+										primary
 									>
 										{ translate( 'edit' ) }
 									</Button>

--- a/client/extensions/woocommerce/app/order/order-customer/index.js
+++ b/client/extensions/woocommerce/app/order/order-customer/index.js
@@ -24,11 +24,14 @@ import SectionHeader from 'components/section-header';
 
 class OrderCustomerInfo extends Component {
 	static propTypes = {
+		editOrder: PropTypes.func.isRequired,
+		isEditing: PropTypes.bool,
 		orderId: PropTypes.number.isRequired,
 		order: PropTypes.shape( {
 			billing: PropTypes.object.isRequired,
 			shipping: PropTypes.object.isRequired,
 		} ),
+		siteId: PropTypes.number.isRequired,
 	};
 
 	state = {

--- a/client/extensions/woocommerce/app/order/order-customer/style.scss
+++ b/client/extensions/woocommerce/app/order/order-customer/style.scss
@@ -1,7 +1,11 @@
 .order-customer {
-	
 	.order-customer__shipping-details {
 		margin-top: 32px;
+	}
+
+	.order-customer__edit-link {
+		float: right;
+		padding: 3px;
 	}
 
 	h4 {
@@ -25,7 +29,7 @@
 }
 
 .order-customer__billing-details,
-.order-create__billing-details, 
+.order-create__billing-details,
 .order-customer__shipping-details,
 .order-create__shipping-details {
 	margin-bottom: 16px;

--- a/client/extensions/woocommerce/app/order/order-customer/style.scss
+++ b/client/extensions/woocommerce/app/order/order-customer/style.scss
@@ -6,7 +6,7 @@
 
 	.order-customer__edit-link {
 		float: right;
-		padding: 3px;
+		margin-top: -7px;
 	}
 
 	h4 {

--- a/client/extensions/woocommerce/app/order/order-customer/style.scss
+++ b/client/extensions/woocommerce/app/order/order-customer/style.scss
@@ -1,3 +1,4 @@
+/** @format */
 .order-customer {
 	.order-customer__shipping-details {
 		margin-top: 32px;
@@ -29,12 +30,38 @@
 }
 
 .order-customer__billing-details,
-.order-create__billing-details,
-.order-customer__shipping-details,
-.order-create__shipping-details {
+.order-customer__shipping-details {
 	margin-bottom: 16px;
 	color: $gray-text-min;
 	font-size: 12px;
 	text-transform: uppercase;
 	font-weight: 500;
+}
+
+// Override the price inputs in details-table
+&.order-customer__dialog.dialog__content {
+	.form-text-input,
+	.form-text-input-with-affixes input {
+		text-align: left;
+	}
+}
+
+&.order-customer__dialog {
+	.order-customer__fieldset {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: flex-start;
+		justify-content: space-between;
+	}
+
+	.order-customer__field {
+		flex: 0 1 calc(50% - 10px);
+		max-width: calc(50% - 10px);
+		margin-bottom: 20px;
+	}
+
+	.address-view__editable-city-state-postcode .form-select {
+		max-width: none;
+		width: 100%;
+	}
 }

--- a/client/extensions/woocommerce/app/order/order-customer/style.scss
+++ b/client/extensions/woocommerce/app/order/order-customer/style.scss
@@ -75,4 +75,12 @@
 		max-width: none;
 		width: 100%;
 	}
+
+	.form-fieldset:last-child {
+		margin-bottom: 0;
+	}
+
+	.address-view__editable-city-state-postcode {
+		align-items: end;
+	}
 }

--- a/client/extensions/woocommerce/app/order/order-customer/style.scss
+++ b/client/extensions/woocommerce/app/order/order-customer/style.scss
@@ -36,6 +36,17 @@
 	font-size: 12px;
 	text-transform: uppercase;
 	font-weight: 500;
+	display: flex;
+	align-items: baseline;
+	justify-content: space-between;
+
+	.button {
+		color: $blue-wordpress;
+
+		&:hover {
+			color: $link-highlight;
+		}
+	}
 }
 
 // Override the price inputs in details-table


### PR DESCRIPTION
This PR adds the ability to edit the customer info - name, email, phone, and address (billing and shipping) for an order. Once in the "edit" state on the single order screen, two edit buttons show up next to the labels:

![addr-edit-state](https://user-images.githubusercontent.com/541093/31237715-bf2929f4-a9c5-11e7-9972-50989feba0a6.png)

These open modals, which are slightly different between billing/shipping – billing has phone and email, along with a "copy to shipping" checkbox

![billing-modal](https://user-images.githubusercontent.com/541093/31237717-bf306f52-a9c5-11e7-8098-245e1bf015de.png)
![shipping-modal](https://user-images.githubusercontent.com/541093/31237716-bf2bcdda-a9c5-11e7-91f2-ec6a75293341.png)

The changes in the modals are saved in component state, and the redux state is only updated when "Save" is clicked. The reason for this is that we want to be able to discard address changes if the user clicks cancel, without accidentally discarding any other pending edits.

**To test**

This is still behind a feature flag, so you can review on development, but it won't be on staging or production once merged.

- View an order, and click Edit Order to enter the edit state
- Scroll down to the address, click the edit button next to billing
- The billing modal should pop open, make some changes
- Click copy to shipping, save
- Your changes should update in both address displays
- Click save, the order should update with new info

Test again with other combos of edits, without copy to shipping selected, just change shipping, cancel out of the modal, cancel out of the edit state, etc.

