### PR TITLE
Analytics: add Yandex and Outbrain

### DIFF
--- a/client/lib/analytics/ad-tracking.js
+++ b/client/lib/analytics/ad-tracking.js
@@ -39,8 +39,10 @@ const isQuantcastEnabled = true;
 const isTwitterEnabled = true;
 const isAolEnabled = true;
 const isLinkedinEnabled = true;
+const isYandexEnabled = true;
+const isOutbrainEnabled = true;
 const isAtlasEnabled = false;
-const isPanoraEnabled = false;
+const isPandoraEnabled = false;
 const isQuoraEnabled = false;
 const isMediaWallahEnabled = false;
 
@@ -75,8 +77,10 @@ const FACEBOOK_TRACKING_SCRIPT_URL = 'https://connect.facebook.net/en_US/fbevent
 	TWITTER_TRACKING_SCRIPT_URL = 'https://static.ads-twitter.com/uwt.js',
 	DCM_FLOODLIGHT_IFRAME_URL = 'https://6355556.fls.doubleclick.net/activityi',
 	LINKED_IN_SCRIPT_URL = 'https://snap.licdn.com/li.lms-analytics/insight.min.js',
-	MEDIA_WALLAH_URL = 'https://d3ir0rz7vxwgq5.cloudfront.net/mwData.min.js',
-	QUORA_URL = 'https://a.quora.com/qevents.js',
+	MEDIA_WALLAH_SCRIPT_URL = 'https://d3ir0rz7vxwgq5.cloudfront.net/mwData.min.js',
+	QUORA_SCRIPT_URL = 'https://a.quora.com/qevents.js',
+	YANDEX_SCRIPT_URL = 'https://mc.yandex.ru/metrika/watch.js',
+	OUTBRAIN_SCRIPT_URL = '//amplify.outbrain.com/cp/obtp.js',
 	TRACKING_IDS = {
 		bingInit: '4074038',
 		facebookInit: '823166884443641',
@@ -91,6 +95,7 @@ const FACEBOOK_TRACKING_SCRIPT_URL = 'https://connect.facebook.net/en_US/fbevent
 		dcmFloodlightAdvertiserId: '6355556',
 		linkedInPartnerId: '36622',
 		quoraPixelId: '420845cb70e444938cf0728887a74ca1',
+		outbrainAdvId: '00f0f5287433c2851cc0cb917c7ff0465e'
 	},
 	// This name is something we created to store a session id for DCM Floodlight session tracking
 	DCM_FLOODLIGHT_SESSION_COOKIE_NAME = 'dcmsid',
@@ -143,6 +148,11 @@ if ( isLinkedinEnabled && ! window._linkedin_data_partner_id ) {
 // Quora
 if ( isQuoraEnabled && ! window.qp ) {
 	setupQuoraGlobal();
+}
+
+// Outbrain
+if ( isOutbrainEnabled ) {
+	setupOutbrainGlobal();
 }
 
 /**
@@ -225,6 +235,16 @@ function setUpTwitterGlobal() {
 	twq.queue = [];
 }
 
+function setupOutbrainGlobal() {
+	const api = window.obApi = function() {
+		api.dispatch ? api.dispatch.apply( api, arguments ) : api.queue.push( arguments );
+	};
+	api.version = '1.0';
+	api.loaded = true;
+	api.marketerId = TRACKING_IDS.outbrainAdvId;
+	api.queue = [];
+}
+
 function loadTrackingScripts( callback ) {
 	hasStartedFetchingScripts = true;
 
@@ -280,13 +300,25 @@ function loadTrackingScripts( callback ) {
 
 	if ( isMediaWallahEnabled ) {
 		scripts.push( function( onComplete ) {
-			loadScript( MEDIA_WALLAH_URL, onComplete );
+			loadScript( MEDIA_WALLAH_SCRIPT_URL, onComplete );
 		} );
 	}
 
 	if ( isQuoraEnabled ) {
 		scripts.push( function( onComplete ) {
-			loadScript( QUORA_URL, onComplete );
+			loadScript( QUORA_SCRIPT_URL, onComplete );
+		} );
+	}
+
+	if ( isYandexEnabled ) {
+		scripts.push( function( onComplete ) {
+			loadScript( YANDEX_SCRIPT_URL, onComplete );
+		} );
+	}
+
+	if ( isOutbrainEnabled ) {
+		scripts.push( function( onComplete ) {
+			loadScript( OUTBRAIN_SCRIPT_URL, onComplete );
 		} );
 	}
 
@@ -324,6 +356,11 @@ function loadTrackingScripts( callback ) {
 			// init Quora
 			if ( isQuoraEnabled ) {
 				window.qp( 'init', TRACKING_IDS.quoraPixelId );
+			}
+
+			// init Yandex counter
+			if ( isYandexEnabled ) {
+				window.yaCounter45268389 = new window.Ya.Metrika( { id: 45268389 } );
 			}
 
 			hasFinishedFetchingScripts = true;
@@ -417,6 +454,16 @@ function retarget() {
 	// Quora
 	if ( isQuoraEnabled ) {
 		window.qp( 'track', 'ViewContent' );
+	}
+
+	// Yandex
+	if ( isYandexEnabled ) {
+		window.yaCounter45268389.hit( document.location.href );
+	}
+
+	// Outbrain
+	if ( isOutbrainEnabled ) {
+		window.obApi( 'track', 'PAGE_VIEW' );
 	}
 }
 
@@ -536,7 +583,7 @@ function recordOrder( cart, orderId ) {
 		new Image().src = ONE_BY_AOL_CONVERSION_PIXEL_URL;
 	}
 
-	if ( isPanoraEnabled ) {
+	if ( isPandoraEnabled ) {
 		new Image().src = PANDORA_CONVERSION_PIXEL_URL;
 	}
 
@@ -624,6 +671,16 @@ function recordProduct( product, orderId ) {
 				content_ids: [ product.product_slug ],
 				num_items: product.volume,
 				order_id: orderId,
+			} );
+		}
+
+		// Yandex Goal
+		if ( isYandexEnabled ) {
+			window.yaCounter45268389.reachGoal( 'ProductPurchase', {
+				order_id: orderId,
+				product_slug: product.product_slug,
+				order_price: product.cost,
+				currency: product.currency
 			} );
 		}
 


### PR DESCRIPTION
Adds Yandex and Outbrain conversion tracking and retargeting.

Yandex: it's used to keep a close eye to conversions coming from Yandex and retargeting.

Outbrain: is and advanced retargeting platform.

More info can be found in the FG page "Marketing Trackers Codex".

## Testing

**Setup**

- Edit `/config/development.json` and set `"ad-tracking": true`.
- Restart Calypso

### Yandex

**Check Page View Events**

- In Chrome's network tab filter by 45268389
- After reloading Calypso you should see a https://mc.yandex.ru/watch/45268389 event being fired in the Network panel with a `page-url` parameter corresponding to the current page.

![yandex-page-view](https://user-images.githubusercontent.com/10284338/29122879-1e53c102-7d14-11e7-9bbf-86a87de3c9e5.png)

**Conversion Tracking**

- While keeping the Network tab open (you may want to check on the "Preserve log" option) make a purchase like upgrading a plan on a site, you can use your free credits.

- Once you're in the "thank you" page, filter the Network panel by "ProductPurchase".

- You should see an entry similar to:

![yandex-conversion](https://user-images.githubusercontent.com/10284338/29124458-41368ea2-7d19-11e7-97fc-0b43caeba110.png)

Note that the payload when decoded with `decodeURIComponent()` contains info similar to `site-info={"order_id":"24827349","product_slug":"value_bundle","order_price":85,"currency":"GBP"}`.

## Outbrain

**Page View Events**

- After reloading Calypso, on the network tab if you filter by `00f0f5287433c2851cc0cb917c7ff0465e`, you should see a few entries similar to http://amplifypixel.outbrain.com/pixel?mid=00f0f5287433c2851cc0cb917c7ff0465e&dl=http%3A%2F%2Fcalypso.localhost%3A3000%2F&bust=08604862408732246

Thank you!
