### PR TITLE
Reader Tracks: Add tracks property ui_algo to conversations and a8c streams

### DIFF
--- a/client/reader/stats.js
+++ b/client/reader/stats.js
@@ -48,6 +48,9 @@ function getLocation() {
 	if ( path === '/' ) {
 		return 'following';
 	}
+	if ( path.indexOf( '/read/a8c' ) === 0 ) {
+		return 'following_a8c';
+	}
 	if ( path.indexOf( '/tag/' ) === 0 ) {
 		return 'topic_page';
 	}
@@ -83,6 +86,12 @@ function getLocation() {
 	}
 	if ( path.indexOf( '/read/search' ) === 0 ) {
 		return 'search';
+	}
+	if ( path.indexOf( '/read/conversations/a8c' ) === 0 ) {
+		return 'conversations_a8c';
+	}
+	if ( path.indexOf( '/read/conversations' ) === 0 ) {
+		return 'conversations';
 	}
 	return 'unknown';
 }


### PR DESCRIPTION
Adds the Tracks property `ui_algo` to all events on the conversatons and a8c streams. This helps us determine where Tracks events occur. The following `ui_algo` names have been added:

- /read/a8c -> `ui_algo: following_a8c`
- /read/conversations -> `ui_algo: conversations`
- /read/conversations/a8c -> `ui_algo: conversations_a8c`