### PR TITLE
Refactor JetpackPlanDetails

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/jetpack-plan-details.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/jetpack-plan-details.jsx
@@ -5,7 +5,7 @@
  */
 
 import React, { Component } from 'react';
-import { connect } from 'redux';
+import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -87,22 +87,25 @@ const getTracksDataForAutoconfigHalt = selectedSite => {
 	const reasons = utils.getSiteFileModDisableReason( selectedSite, 'modifyFiles' );
 
 	if ( reasons && reasons.length > 0 ) {
-		return [ 'calypso_plans_autoconfig_halt_filemod', { error: reasons[ 0 ] } ];
+		return {
+			name: 'calypso_plans_autoconfig_halt_filemod',
+			properties: { error: reasons[ 0 ] },
+		};
 	}
 
 	if ( ! selectedSite.hasMinimumJetpackVersion ) {
-		return [
-			'calypso_plans_autoconfig_halt_jpversion',
-			{ jetpack_version: selectedSite.options.jetpack_version },
-		];
+		return {
+			name: 'calypso_plans_autoconfig_halt_jpversion',
+			properties: { jetpack_version: selectedSite.options.jetpack_version },
+		};
 	}
 
 	if ( selectedSite.is_multisite && ! selectedSite.isMainNetworkSite ) {
-		return [ 'calypso_plans_autoconfig_halt_multisite', undefined ];
+		return { name: 'calypso_plans_autoconfig_halt_multisite' };
 	}
 
 	if ( selectedSite.options.is_multi_network ) {
-		return [ 'calypso_plans_autoconfig_halt_multinetwork', undefined ];
+		return { name: 'calypso_plans_autoconfig_halt_multinetwork' };
 	}
 
 	return null;
@@ -116,7 +119,7 @@ const mapDispatchToProps = ( dispatch, { selectedSite } ) => ( {
 			return;
 		}
 
-		const [ name, properties ] = eventData;
+		const { name, properties } = eventData;
 
 		dispatch( recordTracksEvent( name, properties ) );
 	},


### PR DESCRIPTION
Just happened to notice this component in an unrelated conversation and
saw it was missing out on some key Claypso principles so I refactored it
to try and simplify the component and bring it in line with our code
guidelines.

This is _bigger_ than before but I think I find it easier to follow what's happening in the component with some of the different concerns split out.

**Major changes**
 - Stop calling analytics directly and instead dispatch Redux actions
 - Split apart the enhanced from the basic component
 - Wrap components in `connect()` and `localize()` for side effects and
   translation
 - Extract the function to get tracks data for early-abort instead of
   chained if/else structures
 - Prefer declarative style over mutating a `props` object when
   building the JSX.
 - Remove a bug where the tracks events could end up firing off a number
   of times on re-render when it should only fire once.

**Note**

We could have wrapped the `EnhancedDetails` in another component to add the "record Tracks event on load" which would have been nice again but I felt like the additional overhead for wrapping wasn't as pragmatic as just making the thing a `Component` itself and doing it there; in other words, the interleaving logic there is both easy to change and not all that distracting from the UI code.

**Testing**

?? Smoke test and look for the analytics to fly by in the Redux dev tools or in the console at `actionLog.history`