### PR TITLE
DevDocs: Make component header links obvious

### DIFF
--- a/client/devdocs/docs-example/style.scss
+++ b/client/devdocs/docs-example/style.scss
@@ -62,4 +62,10 @@
 			height: 50px;
 		}
 	}
+
+	.gridicons-link {
+		margin-left: 6px;
+		top: 3px;
+		position: relative;
+	}
 }

--- a/client/devdocs/docs-example/wrapper.jsx
+++ b/client/devdocs/docs-example/wrapper.jsx
@@ -3,10 +3,14 @@
  *
  * @format
  */
-
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import classNames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import Gridicon from 'gridicons';
 
 const renderTitle = ( unique, name, url ) =>
 	unique ? (
@@ -14,6 +18,7 @@ const renderTitle = ( unique, name, url ) =>
 	) : (
 		<a className="docs-example__wrapper-header-title" href={ url }>
 			{ name }
+			<Gridicon icon="link" />
 		</a>
 	);
 


### PR DESCRIPTION
The DevDocs have a very useful feature where we can view a single component in isolation, rather than the full list. When developing an example, that feature massively improves the experience over constantly refreshing the full list and filtering.

Without some kind of indicator, though -- like a link icon or an underline -- it's easy to miss the fact that the title of each component is a link to the singular view of that component, leading to unnecessary frustration and wasted time.

This PR adds a link Gridicon next to the title in the list view. It doesn't affect the singular view.

### Before

<img width="994" alt="screen shot 2017-10-16 at 12 51 36 pm" src="https://user-images.githubusercontent.com/484068/31632177-dc1b50ba-b270-11e7-9314-3bcf4f2c7e30.png">

### After

<img width="996" alt="screen shot 2017-10-16 at 12 50 59 pm" src="https://user-images.githubusercontent.com/484068/31632182-e08927ee-b270-11e7-8b55-3c4d4460a7cc.png">