### PR TITLE
Store: Add a new feature flag specific to editing orders

### DIFF
--- a/client/extensions/woocommerce/app/order/index.js
+++ b/client/extensions/woocommerce/app/order/index.js
@@ -130,7 +130,7 @@ class Order extends Component {
 		return (
 			<Main className={ className }>
 				<ActionHeader breadcrumbs={ breadcrumbs }>
-					{ config.isEnabled( 'woocommerce/extension-orders-create' ) && button }
+					{ config.isEnabled( 'woocommerce/extension-orders-edit' ) && button }
 				</ActionHeader>
 
 				<div className="order__container">

--- a/config/development.json
+++ b/config/development.json
@@ -173,6 +173,7 @@
 		"woocommerce/extension-dashboard": true,
 		"woocommerce/extension-orders": true,
 		"woocommerce/extension-orders-create": true,
+		"woocommerce/extension-orders-edit": true,
 		"woocommerce/extension-products": true,
 		"woocommerce/extension-promotions": true,
 		"woocommerce/extension-reviews": true,

--- a/config/production.json
+++ b/config/production.json
@@ -117,6 +117,7 @@
 		"woocommerce/extension-dashboard": true,
 		"woocommerce/extension-orders": true,
 		"woocommerce/extension-orders-create": false,
+		"woocommerce/extension-orders-edit": false,
 		"woocommerce/extension-products": true,
 		"woocommerce/extension-promotions": false,
 		"woocommerce/extension-reviews": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -124,6 +124,7 @@
 		"woocommerce/extension-dashboard": true,
 		"woocommerce/extension-orders": true,
 		"woocommerce/extension-orders-create": false,
+		"woocommerce/extension-orders-edit": false,
 		"woocommerce/extension-products": true,
 		"woocommerce/extension-promotions": false,
 		"woocommerce/extension-reviews": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -136,6 +136,7 @@
 		"woocommerce/extension-dashboard": true,
 		"woocommerce/extension-orders": true,
 		"woocommerce/extension-orders-create": true,
+		"woocommerce/extension-orders-edit": true,
 		"woocommerce/extension-products": true,
 		"woocommerce/extension-promotions": false,
 		"woocommerce/extension-reviews": true,


### PR DESCRIPTION
Previously we'd been using the same feature flag to gatekeep the new order creation flow and order editing flow, but since editing will wrap up earlier, let's use a separate flag. The new flag is `woocommerce/extension-orders-edit`.

**To test**

- Run `npm start` on development
- Visit a single order, you should see an edit order button in the top right
- Run `DISABLE_FEATURES=woocommerce/extension-orders-edit npm start`
- Visit a single order, there should be no action in the top right anymore

Like the create order feature flag, this is enabled in development and wpcalypso, just for easier (+ maybe wider) testing. 