### PR TITLE
Change tooltip text on plans page when discounted.

### DIFF
--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -131,7 +131,7 @@ class PlanFeaturesHeader extends Component {
 							className="plan-features__header-tip-info"
 							position={ isMobile() ? 'top' : 'bottom left' }
 						>
-							{ translate( 'Discount for first year' ) }
+							{ translate( 'Price for the next 12 months' ) }
 						</InfoPopover>
 					) }
 				</p>


### PR DESCRIPTION
The tooltip text on the plans page is confusing some users - the price displayed is not the discount, it is the discounted price for the first year.

From

<img width="331" alt="screen shot 2017-10-06 at 4 40 32 pm" src="https://user-images.githubusercontent.com/1926/31266009-1ebb7f58-aab5-11e7-9fb7-319cf3ddae21.png">

To

<img width="328" alt="screen shot 2017-10-06 at 4 56 58 pm" src="https://user-images.githubusercontent.com/1926/31266501-67bfcbbc-aab7-11e7-8286-2fe8675efb8f.png">

# Testing

For a site with a personal/premium plan, view the plans page and verify that the expected tooltip change has been made.