### PR TITLE
Build: move sanitize-html to vendor chunk

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -183,6 +183,7 @@ if ( calypsoEnv === 'desktop' ) {
 		'react-redux',
 		'redux',
 		'redux-thunk',
+		'sanitize-html',
 		'store',
 		'wpcom',
 	];


### PR DESCRIPTION
The Plugins store fetches plugin info from `wordpress.org` API. One of the returned fields is a HTML markup with plugin description. We use the `sanitize-html` library to remove some dangerous tags from that HTML.

The `sanitize-html` library has `htmlparser2` as dependency, which in turn uses a lot of `node-lib-browserify` compat modules that bring support for Node.js streams and buffers into the browser.

In total, this is 160kB of JavaScript code to parse, and 50kB of gzipped data to download.

This is what happens to chunk sizes if I move `sanitize-html` to the `vendor` chunk:
```
async-load-my-sites-guided-transfer:              parsed_size:  -57424 gzip_size:  -15130
async-load-my-sites-site-settings-section-export: parsed_size:  -57424 gzip_size:  -15118
build:                                            parsed_size:   -9492 gzip_size:   -3214
checkout:                                         parsed_size: -154098 gzip_size:  -49872
devdocs:                                          parsed_size: -154098 gzip_size:  -50465
domains:                                          parsed_size:  -57424 gzip_size:  -15223
jetpack-connect:                                  parsed_size:  -57424 gzip_size:  -15074
manifest:                                         parsed_size:       0 gzip_size:      -3
plans:                                            parsed_size:  -57424 gzip_size:  -15156
plugins:                                          parsed_size: -154098 gzip_size:  -50192
purchases:                                        parsed_size:  -57424 gzip_size:  -15100
signup:                                           parsed_size:  -57424 gzip_size:  -15141
vendor:                                           parsed_size:  163661 gzip_size:   54096
woocommerce:                                      parsed_size: -154098 gzip_size:  -50319

Total:                                            parsed_size: -864191 gzip_size: -255911
```
All chunks that use the Plugins Flux store for anything get much smaller.

Moving `sanitize-html` to `vendor` is probably not a great idea. The intent of this PR is to show how much code we ship just because of one innocent-looking dependency. Can we do better?
