### PR TITLE
Editor: trigger editor basics tour on both page and post editing

### DIFF
--- a/client/layout/guided-tours/tours/editor-basics-tour.js
+++ b/client/layout/guided-tours/tours/editor-basics-tour.js
@@ -29,7 +29,7 @@ export const EditorBasicsTour = makeTour(
 	<Tour
 		name="editorBasicsTour"
 		version="20170503"
-		path="/post/"
+		path={ [ '/post/', '/page/' ] }
 		when={ and( isDesktop, isNewUser ) }
 	>
 		<Step


### PR DESCRIPTION
The `EditorBasicsTour` is only triggered on `/post/` paths. If a new user starts by making pages, however, they do not get to see this introductory tour, even though it would be useful for them (as it covers the Editor, not making posts as such).

This PR adds the `/page/` path to the tour. Fixes #18580. 

To test:
- remove the `isNewUser` condition from the tour.
- use `?tour=reset` to reset your seen tours. 
- add a new page to your blog and confirm that the tour shows up when in the editor after a few seconds. 
- again use `?tour=reset` to reset your seen tours. 
- add a new post to your blog and confirm that the tour shows up when in the editor after a few seconds. 
