### PR TITLE
Framework: Localize and fix client/layout/error

### DIFF
--- a/client/layout/error.jsx
+++ b/client/layout/error.jsx
@@ -5,6 +5,7 @@
  */
 
 import debug from 'debug';
+import { localize } from 'i18n-calypso';
 import { assign } from 'lodash';
 import ReactDom from 'react-dom';
 import React from 'react';
@@ -53,12 +54,12 @@ var LoadingError = React.createClass( {
 
 	render: function() {
 		return (
-			<EmptyContent
+            <EmptyContent
 				illustration="/calypso/images/illustrations/illustration-500.svg"
-				title={ this.translate( "We're sorry, but an unexpected error has occurred" ) }
+				title={ this.props.translate( "We're sorry, but an unexpected error has occurred" ) }
 			/>
-		);
+        );
 	},
 } );
 
-module.exports = LoadingError;
+module.exports = localize(LoadingError);

--- a/client/layout/error.jsx
+++ b/client/layout/error.jsx
@@ -54,12 +54,12 @@ var LoadingError = React.createClass( {
 
 	render: function() {
 		return (
-            <EmptyContent
+			<EmptyContent
 				illustration="/calypso/images/illustrations/illustration-500.svg"
 				title={ this.props.translate( "We're sorry, but an unexpected error has occurred" ) }
 			/>
-        );
+		);
 	},
 } );
 
-module.exports = localize(LoadingError);
+module.exports = localize( LoadingError );

--- a/client/layout/error.jsx
+++ b/client/layout/error.jsx
@@ -23,43 +23,31 @@ import EmptyContent from 'components/empty-content';
  */
 const log = debug( 'calypso:layout' );
 
-var LoadingError = React.createClass( {
-	statics: {
-		isRetry: function() {
-			var parsed = url.parse( location.href, true );
-			return parsed.query.retry === '1';
-		},
+const LoadingErrorMessage = localize( ( { translate } ) => (
+	<EmptyContent
+		illustration="/calypso/images/illustrations/illustration-500.svg"
+		title={ translate( "We're sorry, but an unexpected error has occurred" ) }
+	/>
+) );
 
-		retry: function( chunkName ) {
-			var parsed;
-			if ( ! LoadingError.isRetry() ) {
-				parsed = url.parse( location.href, true );
+export function isRetry() {
+	const parsed = url.parse( location.href, true );
+	return parsed.query.retry === '1';
+}
 
-				analytics.mc.bumpStat( 'calypso_chunk_retry', chunkName );
+export function retry( chunkName ) {
+	if ( ! isRetry() ) {
+		const parsed = url.parse( location.href, true );
 
-				// Trigger a full page load which should include script tags for the current chunk
-				window.location.search = qs.stringify( assign( parsed.query, { retry: '1' } ) );
-			}
-		},
+		analytics.mc.bumpStat( 'calypso_chunk_retry', chunkName );
 
-		show: function( chunkName ) {
-			log( 'Chunk %s could not be loaded', chunkName );
-			analytics.mc.bumpStat( 'calypso_chunk_error', chunkName );
-			ReactDom.render(
-				React.createElement( LoadingError, {} ),
-				document.getElementById( 'primary' )
-			);
-		},
-	},
+		// Trigger a full page load which should include script tags for the current chunk
+		window.location.search = qs.stringify( assign( parsed.query, { retry: '1' } ) );
+	}
+}
 
-	render: function() {
-		return (
-			<EmptyContent
-				illustration="/calypso/images/illustrations/illustration-500.svg"
-				title={ this.props.translate( "We're sorry, but an unexpected error has occurred" ) }
-			/>
-		);
-	},
-} );
-
-module.exports = localize( LoadingError );
+export function show( chunkName ) {
+	log( 'Chunk %s could not be loaded', chunkName );
+	analytics.mc.bumpStat( 'calypso_chunk_error', chunkName );
+	ReactDom.render( <LoadingErrorMessage />, document.getElementById( 'primary' ) );
+}


### PR DESCRIPTION
Up to now, server/bundler/loader was calling static methods of the component. This causes problems once the component is `localize()`d, since those methods aren't hoisted.
However, we can easily turn those static methods into module level functions.

Background: https://github.com/Automattic/wp-calypso/pull/18590#issuecomment-334708986

To test:
* Restart Calypso, and verify that it still runs.
* Now introduce an error in some module, and restart Calypso again; navigate to the section that contains the error. The error should be displayed in the console; verify that it's not the generic (`LoadingError` component-related) error described at https://github.com/Automattic/wp-calypso/pull/18590#issuecomment-334708986