### PR TITLE
Guided Tours: fix css not applying anymore

### DIFF
--- a/client/layout/guided-tours/style.scss
+++ b/client/layout/guided-tours/style.scss
@@ -1,4 +1,4 @@
-.guided-tours__step {
+.card.guided-tours__step {
 	position: fixed;
 	width: calc( 100% - 10px );
 	max-width: 410px;
@@ -43,7 +43,7 @@
 	}
 }
 
-.guided-tours__step-first {
+.card.guided-tours__step-first {
 	animation-duration: 0.25s;
 	animation-name: guided-tours__step-slidein;
 	animation-timing-function: ease-out;
@@ -51,7 +51,7 @@
 	animation-fill-mode: both;
 }
 
-.guided-tours__step-finish {
+.card.guided-tours__step-finish {
 	top: 20%;
 }
 


### PR DESCRIPTION
Apparently there were a few changes in the CSS recently. I'm not sure which change it was exactly, but it broke a couple of guided tours (step would have a `position: relative` from `.card`, not `fixed` from `guided-tours__step`). 

This PR makes the Guided Tours selectors more specific so they don't get overridden by the `.card` rules any longer. 

To test: 
- confirm that positioning is off without this change by starting the `editorBasicsTour` by going to `/post/?tour=editorBasicsTour`, notice that the tour doesn't show (it's off-screen, bottom — and styled wrong (it's now white))
- apply this change and notice that the tour now shows properly