### PR TITLE
Guided Tours: fix main tour to work with View Site

### DIFF
--- a/client/layout/guided-tours/tours/main-tour.js
+++ b/client/layout/guided-tours/tours/main-tour.js
@@ -6,7 +6,7 @@
 
 import React from 'react';
 import { translate } from 'i18n-calypso';
-import { negate as not, overEvery as and } from 'lodash';
+import { overEvery as and } from 'lodash';
 
 /**
  * Internal dependencies
@@ -27,7 +27,6 @@ import {
 	isSelectedSitePreviewable,
 	isSelectedSiteCustomizable,
 } from 'state/ui/guided-tours/contexts';
-import { isPreviewShowing } from 'state/ui/selectors';
 import { getScrollableSidebar } from 'layout/guided-tours/positioning';
 import scrollTo from 'lib/scroll-to';
 
@@ -46,12 +45,12 @@ export const MainTour = makeTour(
 			<p>
 				{ translate(
 					"{{strong}}Need a hand?{{/strong}} We'd love to show you around the place, " +
-						'and give you some ideas for what to do next.',
-					{
-						components: {
-							strong: <strong />,
+											'and give you some ideas for what to do next.',
+						{
+							components: {
+								strong: <strong />,
 						},
-					}
+							}
 				) }
 			</p>
 			<ButtonRow>
@@ -64,12 +63,12 @@ export const MainTour = makeTour(
 			<p>
 				{ translate(
 					"{{strong}}First things first.{{/strong}} Up here, you'll find tools for managing " +
-						"your site's content and design.",
-					{
-						components: {
-							strong: <strong />,
+											"your site's content and design.",
+						{
+							components: {
+								strong: <strong />,
 						},
-					}
+							}
 				) }
 			</p>
 			<Continue click icon="my-sites" step="sidebar" target="my-sites" />
@@ -89,67 +88,32 @@ export const MainTour = makeTour(
 
 		<Step
 			name="click-preview"
-			target="site-card-preview"
+			target="sitePreview"
 			arrow="top-left"
 			placement="below"
 			when={ isSelectedSitePreviewable }
 			scrollContainer=".sidebar__region"
 		>
 			<p>
-				{ translate(
-					"This shows your currently {{strong}}selected site{{/strong}}'s name and address.",
-					{
+				{ translate( 'Want to take a look at your site?' ) }
+			</p>
+			<Continue click step="view-site" target="sitePreview">
+				{ translate( 'Click {{strong}}View Site{{/strong}} to continue.', {
 						components: {
 							strong: <strong />,
 						},
-					}
-				) }
-			</p>
-			<Continue click step="in-preview" target="site-card-preview">
-				{ translate( "Click {{strong}}your site's name{{/strong}} to continue.", {
-					components: {
-						strong: <strong />,
-					},
 				} ) }
 			</Continue>
 		</Step>
 
-		<Step name="in-preview" placement="center" when={ isSelectedSitePreviewable }>
+		<Step name="view-site" placement="center" when={ isSelectedSitePreviewable }>
 			<p>
-				{ translate(
-					"This is your site's {{strong}}Preview{{/strong}}. From here you can see how your site looks to others.",
-					{
-						components: {
-							strong: <strong />,
-						},
-					}
-				) }
+				{ translate( 'This is what your site looks like to visitors.' ) }
 			</p>
 			<ButtonRow>
-				<Next step="close-preview" />
+				<Next step="themes" />
 				<Quit />
-				<Continue hidden step="close-preview" when={ not( isPreviewShowing ) } />
 			</ButtonRow>
-		</Step>
-
-		<Step
-			name="close-preview"
-			target="web-preview__close"
-			arrow="left-top"
-			placement="beside"
-			when={ and( isSelectedSitePreviewable, isPreviewShowing ) }
-		>
-			<p>
-				{ translate(
-					'Take a look at your site — and then close the site preview. You can come back here anytime.'
-				) }
-			</p>
-			<Continue
-				icon="cross-small"
-				step="themes"
-				target="web-preview__close"
-				when={ not( isPreviewShowing ) }
-			/>
 		</Step>
 
 		<Step
@@ -164,12 +128,12 @@ export const MainTour = makeTour(
 			<p>
 				{ translate(
 					'Change your {{strong}}Theme{{/strong}} to choose a new layout, or {{strong}}Customize{{/strong}} ' +
-						"your theme's colors, fonts, and more.",
-					{
-						components: {
-							strong: <strong />,
+											"your theme's colors, fonts, and more.",
+						{
+							components: {
+								strong: <strong />,
 						},
-					}
+							}
 				) }
 			</p>
 			<ButtonRow>
@@ -182,11 +146,11 @@ export const MainTour = makeTour(
 			<p>
 				{ translate(
 					"{{strong}}That's it!{{/strong}} Now that you know a few of the basics, feel free to wander around.",
-					{
+				{
 						components: {
 							strong: <strong />,
 						},
-					}
+						}
 				) }
 			</p>
 			<ButtonRow>


### PR DESCRIPTION
Since we changed "Site Preview" (with a modal opening when clicking the site card) to "View Site" (which is now just a menu item in the side bar) we hadn't updated the `main` tour to account for these changes. This PR updates it. 

To test:
- visit `http://calypso.localhost:3000/?tour=main` to check the main tour works