### PR TITLE
TinyMCE: ContactForm View: Localize and fix

### DIFF
--- a/client/components/tinymce/plugins/wpcom-view/views.js
+++ b/client/components/tinymce/plugins/wpcom-view/views.js
@@ -12,7 +12,7 @@ import { forEach, map, mapValues, values } from 'lodash';
  */
 import GalleryView from './gallery-view';
 import EmbedViewManager from './views/embed';
-import ContactFormView from './views/contact-form';
+import * as ContactFormView from './views/contact-form';
 import * as VideoView from './views/video';
 import SimplePaymentsView from './views/simple-payments';
 import { isEnabled } from 'config';

--- a/client/components/tinymce/plugins/wpcom-view/views.js
+++ b/client/components/tinymce/plugins/wpcom-view/views.js
@@ -20,7 +20,7 @@ import { isEnabled } from 'config';
 /**
  * Module variables
  */
-let views = {
+const views = {
 	gallery: GalleryView,
 	embed: new EmbedViewManager(),
 	contactForm: ContactFormView,
@@ -52,7 +52,7 @@ export default {
 	 * @return {String} The string with markers.
 	 */
 	setMarkers( content ) {
-		var pieces = [ { content: content } ],
+		let pieces = [ { content: content } ],
 			current;
 
 		forEach( views, function( view, type ) {
@@ -60,7 +60,7 @@ export default {
 			pieces = [];
 
 			forEach( current, function( piece ) {
-				var remaining = piece.content,
+				let remaining = piece.content,
 					result;
 
 				// Ignore processed pieces, but retain their location.

--- a/client/components/tinymce/plugins/wpcom-view/views/contact-form/index.jsx
+++ b/client/components/tinymce/plugins/wpcom-view/views/contact-form/index.jsx
@@ -14,41 +14,43 @@ import { deserialize } from 'components/tinymce/plugins/contact-form/shortcode-u
 import shortcodeUtils from 'lib/shortcode';
 import renderField from './preview-fields';
 
-export default localize(React.createClass({
-	displayName: 'ContactForm',
+export default localize(
+	React.createClass( {
+		displayName: 'ContactForm',
 
-	statics: {
-		match( content ) {
-			const match = shortcodeUtils.next( 'contact-form', content );
+		statics: {
+			match( content ) {
+				const match = shortcodeUtils.next( 'contact-form', content );
 
-			if ( match ) {
-				return {
-					index: match.index,
-					content: match.content,
-					options: {
-						shortcode: match.shortcode,
-					},
-				};
-			}
+				if ( match ) {
+					return {
+						index: match.index,
+						content: match.content,
+						options: {
+							shortcode: match.shortcode,
+						},
+					};
+				}
+			},
+
+			serialize( content ) {
+				return encodeURIComponent( content );
+			},
+
+			edit( editor, content ) {
+				editor.execCommand( 'wpcomContactForm', content );
+			},
 		},
 
-		serialize( content ) {
-			return encodeURIComponent( content );
+		render() {
+			const { fields } = deserialize( this.props.content );
+
+			return (
+				<div className="wpview-content wpview-type-contact-form">
+					{ [].concat( fields ).map( renderField ) }
+					<button disabled>{ this.props.translate( 'Submit' ) }</button>
+				</div>
+			);
 		},
-
-		edit( editor, content ) {
-			editor.execCommand( 'wpcomContactForm', content );
-		},
-	},
-
-	render() {
-		const { fields } = deserialize( this.props.content );
-
-		return (
-            <div className="wpview-content wpview-type-contact-form">
-				{ [].concat( fields ).map( renderField ) }
-				<button disabled>{ this.props.translate( 'Submit' ) }</button>
-			</div>
-        );
-	},
-}));
+	} )
+);

--- a/client/components/tinymce/plugins/wpcom-view/views/contact-form/index.jsx
+++ b/client/components/tinymce/plugins/wpcom-view/views/contact-form/index.jsx
@@ -14,43 +14,39 @@ import { deserialize } from 'components/tinymce/plugins/contact-form/shortcode-u
 import shortcodeUtils from 'lib/shortcode';
 import renderField from './preview-fields';
 
-export default localize(
-	React.createClass( {
-		displayName: 'ContactForm',
+export default localize(class extends React.Component {
+    static displayName = 'ContactForm';
 
-		statics: {
-			match( content ) {
-				const match = shortcodeUtils.next( 'contact-form', content );
+	static match(content) {
+		const match = shortcodeUtils.next( 'contact-form', content );
 
-				if ( match ) {
-					return {
-						index: match.index,
-						content: match.content,
-						options: {
-							shortcode: match.shortcode,
-						},
-					};
-				}
-			},
+		if ( match ) {
+			return {
+				index: match.index,
+				content: match.content,
+				options: {
+					shortcode: match.shortcode,
+				},
+			};
+		}
+	}
 
-			serialize( content ) {
-				return encodeURIComponent( content );
-			},
+	static serialize(content) {
+		return encodeURIComponent( content );
+	}
 
-			edit( editor, content ) {
-				editor.execCommand( 'wpcomContactForm', content );
-			},
-		},
+	static edit(editor, content) {
+		editor.execCommand( 'wpcomContactForm', content );
+	}
 
-		render() {
-			const { fields } = deserialize( this.props.content );
+	render() {
+		const { fields } = deserialize( this.props.content );
 
-			return (
-				<div className="wpview-content wpview-type-contact-form">
-					{ [].concat( fields ).map( renderField ) }
-					<button disabled>{ this.props.translate( 'Submit' ) }</button>
-				</div>
-			);
-		},
-	} )
-);
+		return (
+			<div className="wpview-content wpview-type-contact-form">
+				{ [].concat( fields ).map( renderField ) }
+				<button disabled>{ this.props.translate( 'Submit' ) }</button>
+			</div>
+		);
+	}
+});

--- a/client/components/tinymce/plugins/wpcom-view/views/contact-form/index.jsx
+++ b/client/components/tinymce/plugins/wpcom-view/views/contact-form/index.jsx
@@ -14,41 +14,41 @@ import { deserialize } from 'components/tinymce/plugins/contact-form/shortcode-u
 import shortcodeUtils from 'lib/shortcode';
 import renderField from './preview-fields';
 
-export default localize(
-	class extends React.Component {
-		static displayName = 'ContactForm';
+const ContactForm = localize(
+	( { content, translate } ) => {
+		const { fields } = deserialize( content );
 
-		static match( content ) {
-			const match = shortcodeUtils.next( 'contact-form', content );
-
-			if ( match ) {
-				return {
-					index: match.index,
-					content: match.content,
-					options: {
-						shortcode: match.shortcode,
-					},
-				};
-			}
-		}
-
-		static serialize( content ) {
-			return encodeURIComponent( content );
-		}
-
-		static edit( editor, content ) {
-			editor.execCommand( 'wpcomContactForm', content );
-		}
-
-		render() {
-			const { fields } = deserialize( this.props.content );
-
-			return (
-				<div className="wpview-content wpview-type-contact-form">
-					{ [].concat( fields ).map( renderField ) }
-					<button disabled>{ this.props.translate( 'Submit' ) }</button>
-				</div>
-			);
-		}
+		return (
+			<div className="wpview-content wpview-type-contact-form">
+				{ [].concat( fields ).map( renderField ) }
+				<button disabled>{ translate( 'Submit' ) }</button>
+			</div>
+		);
 	}
 );
+
+export function match( content ) {
+	const m = shortcodeUtils.next( 'contact-form', content );
+
+	if ( m ) {
+		return {
+			index: m.index,
+			content: m.content,
+			options: {
+				shortcode: m.shortcode,
+			},
+		};
+	}
+}
+
+export function serialize( content ) {
+	return encodeURIComponent( content );
+}
+
+export function edit( editor, content ) {
+	editor.execCommand( 'wpcomContactForm', content );
+}
+
+export function getComponent() {
+	return ContactForm;
+}

--- a/client/components/tinymce/plugins/wpcom-view/views/contact-form/index.jsx
+++ b/client/components/tinymce/plugins/wpcom-view/views/contact-form/index.jsx
@@ -14,39 +14,41 @@ import { deserialize } from 'components/tinymce/plugins/contact-form/shortcode-u
 import shortcodeUtils from 'lib/shortcode';
 import renderField from './preview-fields';
 
-export default localize(class extends React.Component {
-    static displayName = 'ContactForm';
+export default localize(
+	class extends React.Component {
+		static displayName = 'ContactForm';
 
-	static match(content) {
-		const match = shortcodeUtils.next( 'contact-form', content );
+		static match( content ) {
+			const match = shortcodeUtils.next( 'contact-form', content );
 
-		if ( match ) {
-			return {
-				index: match.index,
-				content: match.content,
-				options: {
-					shortcode: match.shortcode,
-				},
-			};
+			if ( match ) {
+				return {
+					index: match.index,
+					content: match.content,
+					options: {
+						shortcode: match.shortcode,
+					},
+				};
+			}
+		}
+
+		static serialize( content ) {
+			return encodeURIComponent( content );
+		}
+
+		static edit( editor, content ) {
+			editor.execCommand( 'wpcomContactForm', content );
+		}
+
+		render() {
+			const { fields } = deserialize( this.props.content );
+
+			return (
+				<div className="wpview-content wpview-type-contact-form">
+					{ [].concat( fields ).map( renderField ) }
+					<button disabled>{ this.props.translate( 'Submit' ) }</button>
+				</div>
+			);
 		}
 	}
-
-	static serialize(content) {
-		return encodeURIComponent( content );
-	}
-
-	static edit(editor, content) {
-		editor.execCommand( 'wpcomContactForm', content );
-	}
-
-	render() {
-		const { fields } = deserialize( this.props.content );
-
-		return (
-			<div className="wpview-content wpview-type-contact-form">
-				{ [].concat( fields ).map( renderField ) }
-				<button disabled>{ this.props.translate( 'Submit' ) }</button>
-			</div>
-		);
-	}
-});
+);

--- a/client/components/tinymce/plugins/wpcom-view/views/contact-form/index.jsx
+++ b/client/components/tinymce/plugins/wpcom-view/views/contact-form/index.jsx
@@ -5,6 +5,7 @@
  */
 
 import React from 'react';
+import { localize } from 'i18n-calypso';
 import { deserialize } from 'components/tinymce/plugins/contact-form/shortcode-utils';
 
 /**
@@ -13,7 +14,7 @@ import { deserialize } from 'components/tinymce/plugins/contact-form/shortcode-u
 import shortcodeUtils from 'lib/shortcode';
 import renderField from './preview-fields';
 
-export default React.createClass( {
+export default localize(React.createClass({
 	displayName: 'ContactForm',
 
 	statics: {
@@ -44,10 +45,10 @@ export default React.createClass( {
 		const { fields } = deserialize( this.props.content );
 
 		return (
-			<div className="wpview-content wpview-type-contact-form">
+            <div className="wpview-content wpview-type-contact-form">
 				{ [].concat( fields ).map( renderField ) }
-				<button disabled>{ this.translate( 'Submit' ) }</button>
+				<button disabled>{ this.props.translate( 'Submit' ) }</button>
 			</div>
-		);
+        );
 	},
-} );
+}));


### PR DESCRIPTION
Pre-emptive fix factored out of https://github.com/Automattic/wp-calypso/pull/18590.

Background: https://github.com/Automattic/wp-calypso/blob/master/client/components/tinymce/plugins/wpcom-view/views.js imports TinyMCE plugins, iterates over them, and calls `.method()`s, such as `.match()` or `.serialize()`. For the `ContactForm` plugin, those were `static` methods defined on the `ContactForm` component.

If that component is now wrapped in a `localize()` call, those methods are no longer accessible (as they aren't hoisted by `localize()`). This PR turns them into module-level functions (modelled after https://github.com/Automattic/wp-calypso/blob/master/client/components/tinymce/plugins/wpcom-view/views/simple-payments/index.jsx), using the `getComponent()` method to return the actual component.

To test:
* Restart Calypso
* Verify that the Post Editor still works
* In particular, verify that the Contact Form item is still there and works:

![image](https://user-images.githubusercontent.com/96308/31274500-74bf2d54-aa93-11e7-909e-142434e814f6.png)
