### PR TITLE
ConversationCaterpillar: Specify commentsToShow prop in example

### DIFF
--- a/client/blocks/conversation-caterpillar/docs/example.jsx
+++ b/client/blocks/conversation-caterpillar/docs/example.jsx
@@ -19,7 +19,7 @@ const ConversationCaterpillarExample = () => {
 				blogId={ 123 }
 				postId={ 12 }
 				commentsTree={ commentsTree }
-				hiddenComments={ commentsTree }
+				commentsToShow={ {} }
 				expandComments={ () => {} }
 			/>
 		</div>


### PR DESCRIPTION
This fixes `devdocs/blocks`, which is currently broken, as reported by @jsnmoon and @rachelmcr in Slack.

(I'm not sure it's the correct fix -- e.g. should there be a default prop instead? @Automattic/reader folks, please enlighten!)

Edit: Breakage was likely introduced by https://github.com/Automattic/wp-calypso/pull/18247