### PR TITLE
Editor: tweak visibility settings radio labels

### DIFF
--- a/client/post-editor/editor-visibility/index.jsx
+++ b/client/post-editor/editor-visibility/index.jsx
@@ -243,11 +243,16 @@ const EditorVisibility = React.createClass( {
 	},
 
 	renderPrivacyDropdown( visibility ) {
+		const publicLabelPublicSite = this.props.translate( 'Public', {
+			context: 'Editor: Radio label to set post visible to public',
+		} );
+		const publicLabelPrivateSite = this.props.translate( 'Site Members', {
+			context:
+				'Editor: Radio label to set post visible to public on a private site so that only site members can see it',
+		} );
 		const dropdownItems = [
 			{
-				label: this.props.translate( 'Public', {
-					context: 'Editor: Radio label to set post visible to public',
-				} ),
+				label: this.props.isPrivateSite ? publicLabelPrivateSite : publicLabelPublicSite,
 				icon: <Gridicon icon="globe" size={ 18 } />,
 				value: 'public',
 				onClick: () => {
@@ -255,8 +260,9 @@ const EditorVisibility = React.createClass( {
 				},
 			},
 			{
-				label: this.props.translate( 'Private', {
-					context: 'Editor: Radio label to set post to private',
+				label: this.props.translate( 'Admins and Editors', {
+					context:
+						'Editor: Radio label to set post to private so that only admins and editors can see it',
 				} ),
 				icon: <Gridicon icon="user" size={ 18 } />,
 				value: 'private',


### PR DESCRIPTION
This PR tweaks the labels for the publish confirmation screen's visibility settings dropdown. 

We rename "Private" to "Admins and Editors". For private sites, we rename "Public" to "Site Members". 

Screenshot:

<img width="271" alt="screen shot 2017-10-06 at 1 32 33 pm" src="https://user-images.githubusercontent.com/23619/31276184-d530486a-aa9a-11e7-8eef-0e3a7a3ad64f.png">


To test:
- make sure that for a private site, the "Private" label now says "Admins and Editors", and that the "Public" label now says "Site Members", for publishing both pages and posts
- make sure that for a public site, the "Private" label now says "Admins and Editors", and that the "Public" label still says "Public", for publishing both pages and posts
