### PR TITLE
Activity log: Replace equivalent reduce with map

### DIFF
--- a/client/state/data-layer/wpcom/sites/activity/from-api.js
+++ b/client/state/data-layer/wpcom/sites/activity/from-api.js
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import { concat, get, head, reduce, split } from 'lodash';
+import { get, head, map, split } from 'lodash';
 
 /**
  * Internal dependencies
@@ -25,19 +25,7 @@ export const DEFAULT_GRIDICON = 'info-outline';
  */
 export function transformer( apiResponse ) {
 	const orderedItems = get( apiResponse, [ 'current', 'orderedItems' ], [] );
-	return reduce( orderedItems, itemsReducer, [] );
-}
-
-/**
- * Reducer which recieves an array of processed items and an item to process and returns a new array
- * with the processed item appended if it is valid.
- *
- * @param  {array}  processedItems Array of processed items
- * @param  {object} item           API format item to process
- * @return {array}                 Array of items with current item appended if valid
- */
-export function itemsReducer( processedItems, item ) {
-	return concat( processedItems, processItem( item ) );
+	return map( orderedItems, processItem );
 }
 
 /**

--- a/client/state/data-layer/wpcom/sites/activity/test/from-api.js
+++ b/client/state/data-layer/wpcom/sites/activity/test/from-api.js
@@ -8,7 +8,7 @@ import deepFreeze from 'deep-freeze';
 /**
  * Internal dependencies
  */
-import { itemsReducer, processItem } from '../from-api';
+import { processItem } from '../from-api';
 
 const SITE_ID = 123456;
 
@@ -44,25 +44,6 @@ const VALID_API_ITEM = deepFreeze( {
 	gridicon: 'posts',
 	activity_id: 'foobarbaz',
 	status: 'warning',
-} );
-
-describe( 'itemsReducer', () => {
-	it( 'should return a new array', () => {
-		const accumulator = [];
-		expect( itemsReducer( accumulator, VALID_API_ITEM ) ).to.not.equal( accumulator );
-	} );
-
-	it( 'should add items to array', () => {
-		expect( itemsReducer( [], VALID_API_ITEM ) ).to.be.an( 'array' ).that.is.not.empty;
-	} );
-
-	it( 'should append valid items to array', () => {
-		const existingItem = Object.create( null );
-		const result = itemsReducer( [ existingItem ], VALID_API_ITEM );
-		expect( result ).to.be.an( 'array' );
-		expect( result.length ).to.equal( 2 );
-		expect( result[ 0 ] ).to.equal( existingItem );
-	} );
 } );
 
 describe( 'processItem', () => {


### PR DESCRIPTION
Since #18177, the complete API response is validated and items are not individually omitted if they fail to validate.

This means that `reduce` has become just a more verbose `map`. Replace with the equivalent `map` and _rip out_ redundant code.

## Testing
1. Tests pass
1. Behavior is unchanged at https://calypso.live/stats/activity?branch=update/activity-log/process-via-map