### PR TITLE
Revert "Start monthly/yearly billing button test (#18233)"

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -87,12 +87,4 @@ module.exports = {
 		allowExistingUsers: true,
 		localeTargets: 'any',
 	},
-	jetpackBillingButtonTextI1: {
-		datestamp: '20170925',
-		variations: {
-			original: 50,
-			modified: 50,
-		},
-		defaultVariation: 'original',
-	},
 };

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -36,7 +36,6 @@ import purchasesPaths from 'me/purchases/paths';
 import { plansLink } from 'lib/plans';
 import SegmentedControl from 'components/segmented-control';
 import SegmentedControlItem from 'components/segmented-control/item';
-import { abtest } from 'lib/abtest';
 
 class PlansFeaturesMain extends Component {
 	getPlanFeatures() {
@@ -350,26 +349,20 @@ class PlansFeaturesMain extends Component {
 			plansUrl = basePlansPath;
 		}
 
-		const isInBillingButtonTest = abtest( 'jetpackBillingButtonTextI1' ) === 'modified';
-
 		return (
 			<SegmentedControl compact className={ segmentClasses } primary={ true }>
 				<SegmentedControlItem
 					selected={ intervalType === 'monthly' }
 					path={ plansLink( plansUrl, site, 'monthly' ) }
 				>
-					{ isInBillingButtonTest ? translate( 'Monthly' ) : translate( 'Monthly billing' ) }
+					{ translate( 'Monthly billing' ) }
 				</SegmentedControlItem>
 
 				<SegmentedControlItem
 					selected={ intervalType === 'yearly' }
 					path={ plansLink( plansUrl, site, 'yearly' ) }
 				>
-					{ isInBillingButtonTest ? (
-						translate( 'Yearly (Cheaper)' )
-					) : (
-						translate( 'Yearly billing' )
-					) }
+					{ translate( 'Yearly billing' ) }
 				</SegmentedControlItem>
 			</SegmentedControl>
 		);


### PR DESCRIPTION
This reverts commit 00c59296a1244281008ee4d8c0c207e32db316ad.

Finish this A/B test (added in #18233) in preparation for pricing changes on the Jetpack plans.

## Testing
1. Visit `/plans` for a jetpack site and verify that the buttons read _Monthly billing_ and _Yearly billing_

![original](https://user-images.githubusercontent.com/841763/30802222-10ef5f7a-a1e6-11e7-8976-3340141d028e.png)
