### PR TITLE
Comments: adds the comment date to the collapsed view

### DIFF
--- a/client/blocks/comment-detail/comment-detail-header.jsx
+++ b/client/blocks/comment-detail/comment-detail-header.jsx
@@ -26,16 +26,14 @@ import { convertDateToUserLocation } from 'components/post-schedule/utils';
 import { gmtOffset, timezone } from 'lib/site/utils';
 // import humanDate from 'lib/human-date';
 
-const getFormattedDate = (
-	commentDate,
-	site //humanDate(
-) =>
+const getFormattedDate = ( commentDate, site ) =>
+	// humanDate(
 	convertDateToUserLocation(
 		commentDate || new Date(),
 		timezone( site ),
 		gmtOffset( site )
 	).format( 'll LT' );
-//);
+// );
 
 export class CommentDetailHeader extends Component {
 	state = {

--- a/client/blocks/comment-detail/comment-detail-header.jsx
+++ b/client/blocks/comment-detail/comment-detail-header.jsx
@@ -24,16 +24,6 @@ import { urlToDomainAndPath } from 'lib/url';
 import viewport from 'lib/viewport';
 import { convertDateToUserLocation } from 'components/post-schedule/utils';
 import { gmtOffset, timezone } from 'lib/site/utils';
-import humanDate from 'lib/human-date';
-
-const getFormattedDate = ( commentDate, site ) =>
-	humanDate(
-		convertDateToUserLocation(
-			commentDate || new Date(),
-			timezone( site ),
-			gmtOffset( site )
-		).format( 'll LT' )
-	);
 
 export class CommentDetailHeader extends Component {
 	state = {
@@ -142,7 +132,11 @@ export class CommentDetailHeader extends Component {
 								</div>
 							</div>
 							<div className="comment-detail__author-info-timestamp">
-								{ getFormattedDate( commentDate, site ) }
+								{ convertDateToUserLocation(
+									commentDate || moment(),
+									timezone( site ),
+									gmtOffset( site )
+								).fromNow() }
 							</div>
 						</div>
 						<AutoDirection>

--- a/client/blocks/comment-detail/comment-detail-header.jsx
+++ b/client/blocks/comment-detail/comment-detail-header.jsx
@@ -24,16 +24,16 @@ import { urlToDomainAndPath } from 'lib/url';
 import viewport from 'lib/viewport';
 import { convertDateToUserLocation } from 'components/post-schedule/utils';
 import { gmtOffset, timezone } from 'lib/site/utils';
-// import humanDate from 'lib/human-date';
+import humanDate from 'lib/human-date';
 
 const getFormattedDate = ( commentDate, site ) =>
-	// humanDate(
-	convertDateToUserLocation(
-		commentDate || new Date(),
-		timezone( site ),
-		gmtOffset( site )
-	).format( 'll LT' );
-// );
+	humanDate(
+		convertDateToUserLocation(
+			commentDate || new Date(),
+			timezone( site ),
+			gmtOffset( site )
+		).format( 'll LT' )
+	);
 
 export class CommentDetailHeader extends Component {
 	state = {

--- a/client/blocks/comment-detail/comment-detail-header.jsx
+++ b/client/blocks/comment-detail/comment-detail-header.jsx
@@ -141,7 +141,7 @@ export class CommentDetailHeader extends Component {
 									</Emojify>
 								</div>
 							</div>
-							<div className="comment-detail__author-info-element is-timestamp">
+							<div className="comment-detail__author-info-timestamp">
 								{ getFormattedDate( commentDate, site ) }
 							</div>
 						</div>

--- a/client/blocks/comment-detail/comment-detail-header.jsx
+++ b/client/blocks/comment-detail/comment-detail-header.jsx
@@ -22,6 +22,20 @@ import FormCheckbox from 'components/forms/form-checkbox';
 import { stripHTML, decodeEntities } from 'lib/formatting';
 import { urlToDomainAndPath } from 'lib/url';
 import viewport from 'lib/viewport';
+import { convertDateToUserLocation } from 'components/post-schedule/utils';
+import { gmtOffset, timezone } from 'lib/site/utils';
+// import humanDate from 'lib/human-date';
+
+const getFormattedDate = (
+	commentDate,
+	site //humanDate(
+) =>
+	convertDateToUserLocation(
+		commentDate || new Date(),
+		timezone( site ),
+		gmtOffset( site )
+	).format( 'll LT' );
+//);
 
 export class CommentDetailHeader extends Component {
 	state = {
@@ -128,6 +142,9 @@ export class CommentDetailHeader extends Component {
 										} ) }
 									</Emojify>
 								</div>
+							</div>
+							<div className="comment-detail__author-info-element">
+								{ getFormattedDate( commentDate, site ) }
 							</div>
 						</div>
 						<AutoDirection>

--- a/client/blocks/comment-detail/comment-detail-header.jsx
+++ b/client/blocks/comment-detail/comment-detail-header.jsx
@@ -40,7 +40,7 @@ const getRelativeTimePeriod = ( commentDate, site, moment ) => {
 		return localizedDate.fromNow();
 	}
 
-	return localizedDate.format( 'll LT' );
+	return localizedDate.format( 'll' );
 };
 
 export class CommentDetailHeader extends Component {

--- a/client/blocks/comment-detail/comment-detail-header.jsx
+++ b/client/blocks/comment-detail/comment-detail-header.jsx
@@ -58,6 +58,7 @@ export class CommentDetailHeader extends Component {
 			authorDisplayName,
 			authorUrl,
 			commentContent,
+			commentDate,
 			commentIsLiked,
 			commentIsSelected,
 			commentStatus,
@@ -66,7 +67,9 @@ export class CommentDetailHeader extends Component {
 			isBulkEdit,
 			isEditMode,
 			isExpanded,
+			moment,
 			postTitle,
+			site,
 			toggleReply,
 			toggleApprove,
 			toggleEditMode,
@@ -148,9 +151,9 @@ export class CommentDetailHeader extends Component {
 										} ) }
 									</Emojify>
 								</div>
-							</div>
-							<div className="comment-detail__author-info-timestamp">
-								{ getRelativeTimePeriod( commentDate, site, moment ) }
+								<div className="comment-detail__author-info-timestamp">
+									{ getRelativeTimePeriod( commentDate, site, moment ) }
+								</div>
 							</div>
 						</div>
 						<AutoDirection>

--- a/client/blocks/comment-detail/comment-detail-header.jsx
+++ b/client/blocks/comment-detail/comment-detail-header.jsx
@@ -143,7 +143,7 @@ export class CommentDetailHeader extends Component {
 									</Emojify>
 								</div>
 							</div>
-							<div className="comment-detail__author-info-element">
+							<div className="comment-detail__author-info-element is-timestamp">
 								{ getFormattedDate( commentDate, site ) }
 							</div>
 						</div>

--- a/client/blocks/comment-detail/comment-detail-header.jsx
+++ b/client/blocks/comment-detail/comment-detail-header.jsx
@@ -25,6 +25,24 @@ import viewport from 'lib/viewport';
 import { convertDateToUserLocation } from 'components/post-schedule/utils';
 import { gmtOffset, timezone } from 'lib/site/utils';
 
+const getRelativeTimePeriod = ( commentDate, site, moment ) => {
+	const localizedDate = convertDateToUserLocation(
+		commentDate || moment(),
+		timezone( site ),
+		gmtOffset( site )
+	);
+
+	if (
+		moment()
+			.subtract( 1, 'month' )
+			.isBefore( localizedDate )
+	) {
+		return localizedDate.fromNow();
+	}
+
+	return localizedDate.format( 'll LT' );
+};
+
 export class CommentDetailHeader extends Component {
 	state = {
 		showQuickActions: false,
@@ -132,11 +150,7 @@ export class CommentDetailHeader extends Component {
 								</div>
 							</div>
 							<div className="comment-detail__author-info-timestamp">
-								{ convertDateToUserLocation(
-									commentDate || moment(),
-									timezone( site ),
-									gmtOffset( site )
-								).fromNow() }
+								{ getRelativeTimePeriod( commentDate, site, moment ) }
 							</div>
 						</div>
 						<AutoDirection>

--- a/client/blocks/comment-detail/index.jsx
+++ b/client/blocks/comment-detail/index.jsx
@@ -261,6 +261,7 @@ export class CommentDetail extends Component {
 			refreshCommentData,
 			repliedToComment,
 			replyComment,
+			site,
 			siteBlacklist,
 			siteId,
 			translate,
@@ -310,6 +311,7 @@ export class CommentDetail extends Component {
 					isExpanded={ isExpanded }
 					postId={ postId }
 					postTitle={ postTitle }
+					site={ site }
 					toggleApprove={ this.toggleApprove }
 					toggleEditMode={ this.toggleEditMode }
 					toggleExpanded={ this.toggleExpanded }

--- a/client/blocks/comment-detail/index.jsx
+++ b/client/blocks/comment-detail/index.jsx
@@ -25,7 +25,7 @@ import CommentDetailReply from './comment-detail-reply';
 import { decodeEntities, stripHTML } from 'lib/formatting';
 import { getPostCommentsTree } from 'state/comments/selectors';
 import getSiteComment from 'state/selectors/get-site-comment';
-import { isJetpackMinimumVersion, isJetpackSite } from 'state/sites/selectors';
+import { getSite, isJetpackMinimumVersion, isJetpackSite } from 'state/sites/selectors';
 import { bumpStat, composeAnalytics, recordTracksEvent } from 'state/analytics/actions';
 
 /**
@@ -299,6 +299,7 @@ export class CommentDetail extends Component {
 					authorDisplayName={ authorDisplayName }
 					authorUrl={ authorUrl }
 					commentContent={ commentContent }
+					commentDate={ commentDate }
 					commentIsLiked={ commentIsLiked }
 					commentIsSelected={ commentIsSelected }
 					commentStatus={ commentStatus }
@@ -437,6 +438,7 @@ const mapStateToProps = ( state, ownProps ) => {
 		postTitle,
 		repliedToComment: get( comment, 'replied' ), // TODO: not available in the current data structure
 		siteId: get( comment, 'siteId', siteId ),
+		site: getSite( state, siteId ),
 	};
 };
 

--- a/client/blocks/comment-detail/style.scss
+++ b/client/blocks/comment-detail/style.scss
@@ -81,6 +81,10 @@
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
+
+	&.is-timestamp {
+		font-size: 12px;
+	}
 }
 
 .comment-detail__header {

--- a/client/blocks/comment-detail/style.scss
+++ b/client/blocks/comment-detail/style.scss
@@ -77,14 +77,15 @@
 	float: left;
 }
 
-.comment-detail__author-info-element {
+.comment-detail__author-info-element,
+.comment-detail__author-info-timestamp {
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
+}
 
-	&.is-timestamp {
-		font-size: 12px;
-	}
+.comment-detail__author-info-timestamp {
+	font-size: 12px;
 }
 
 .comment-detail__header {

--- a/client/blocks/comment-detail/style.scss
+++ b/client/blocks/comment-detail/style.scss
@@ -86,6 +86,7 @@
 
 .comment-detail__author-info-timestamp {
 	font-size: 12px;
+	margin-top: 2px;
 }
 
 .comment-detail__header {

--- a/client/blocks/comment-detail/style.scss
+++ b/client/blocks/comment-detail/style.scss
@@ -201,15 +201,11 @@
 .comment-detail__comment-preview {
 	box-sizing: border-box;
 	line-height: 1.4;
-	max-height: 38px;
+	max-height: 56px;
 	overflow: hidden;
 	padding: 0 8px;
 	position: relative;
 	width: 60%;
-
-	@include breakpoint( "<960px" ) {
-		width: 100%;
-	}
 
 	&:after {
 		background: linear-gradient(
@@ -224,12 +220,22 @@
 			right: 0;
 		width: 30%;
 	}
-	@supports( -webkit-line-clamp: 2 ) {
+
+	@supports( -webkit-line-clamp: 3 ) {
 		display: -webkit-box;
 		-webkit-box-orient: vertical;
-		-webkit-line-clamp: 2;
+		-webkit-line-clamp: 3;
+
 		&:after {
 			background: transparent;
+		}
+	}
+
+	@include breakpoint( "<960px" ) {
+		width: 100%;
+
+		@supports( -webkit-line-clamp: 2 ) {
+			-webkit-line-clamp: 2;
 		}
 	}
 }

--- a/client/blocks/comment-detail/style.scss
+++ b/client/blocks/comment-detail/style.scss
@@ -657,6 +657,11 @@
 		}
 	}
 
+	.comment-detail__comment-preview {
+		height: 56px;
+		max-height: 56px;
+	}
+
 	.comment-detail__header.is-preview {
 		cursor: default;
 		@include breakpoint( "<960px" ) {


### PR DESCRIPTION
This PR adds the comment date to the collapsed view.

I'm presenting two options for consideration. The standard time formatted to the user's timezone:

![screen shot 2017-10-06 at 14 38 53](https://user-images.githubusercontent.com/233601/31290910-9f55a316-aaa4-11e7-8b0b-e7d3539fd2eb.png)

And the human readable time period of time we use in places like the reader.

![screen shot 2017-10-06 at 14 40 33](https://user-images.githubusercontent.com/233601/31290917-a3e6c612-aaa4-11e7-808b-2ce8466f8cb9.png)

There's a small duplication of code, and I had to add a couple of props to the already populated prop list of `comment-detail-header.jsx`, but it'll be fixed on #18406 so I'm not concerned.

References:

p3fqKv-5LC-p2