### PR TITLE
SitesList Notices: Turn into actual React Component

### DIFF
--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -62,7 +62,7 @@ const Layout = React.createClass( {
 	/* eslint-enable react/no-deprecated */
 	displayName: 'Layout',
 
-	mixins: [ SitesListNotices, observe( 'user', 'nuxWelcome', 'translatorInvitation' ) ],
+	mixins: [ observe( 'user', 'nuxWelcome', 'translatorInvitation' ) ],
 
 	propTypes: {
 		primary: PropTypes.element,
@@ -156,6 +156,7 @@ const Layout = React.createClass( {
 		return (
 			<div className={ sectionClass }>
 				<DocumentHead />
+				<SitesListNotices />
 				<QuerySites allSites />
 				<QueryPreferences />
 				{ <GuidedTours /> }

--- a/client/lib/sites-list/notices.js
+++ b/client/lib/sites-list/notices.js
@@ -12,158 +12,160 @@ import notices from 'notices';
 import SitesLog from 'lib/sites-list/log-store';
 import SitesListActions from 'lib/sites-list/actions';
 
-module.exports = localize(class extends React.Component {
-    componentDidMount() {
-		SitesLog.on( 'change', this.showNotification );
-	}
-
-	componentWillUnmount() {
-		SitesLog.removeListener( 'change', this.showNotification );
-	}
-
-	refreshSiteNotices = () => {
-		return {
-			errors: SitesLog.getErrors(),
-			inProgress: SitesLog.getInProgress(),
-			completed: SitesLog.getCompleted(),
-		};
-	};
-
-	showNotification = () => {
-		var logNotices = this.refreshSiteNotices();
-
-		this.setState( { notices: logNotices } );
-
-		if ( logNotices.inProgress.length > 0 ) {
-			notices.info( this.getMessage( logNotices.inProgress, this.inProgressMessage ), {
-				persistent: true,
-			} );
-			return;
+module.exports = localize(
+	class extends React.Component {
+		componentDidMount() {
+			SitesLog.on( 'change', this.showNotification );
 		}
-		if ( logNotices.completed.length > 0 && logNotices.errors.length > 0 ) {
-			notices.warning( this.erroredAndCompletedMessage( logNotices ), {
-				onRemoveCallback: SitesListActions.removeSitesNotices.bind(
-					this,
-					logNotices.completed.concat( logNotices.errors )
-				),
-			} );
-		} else if ( logNotices.errors.length > 0 ) {
-			notices.error( this.getMessage( logNotices.errors, this.errorMessage ), {
-				onRemoveCallback: SitesListActions.removeSitesNotices.bind( this, logNotices.errors ),
-			} );
-		} else if ( logNotices.completed.length > 0 ) {
-			notices.success( this.getMessage( logNotices.completed, this.successMessage ), {
-				onRemoveCallback: SitesListActions.removeSitesNotices.bind( this, logNotices.completed ),
-			} );
-		}
-	};
 
-	getMessage = (logs, messageFunction) => {
-		const sampleLog = logs[ 0 ],
-			sites = logs.map( function( log ) {
-				return log.site && log.site.title;
-			} ),
-			translateArg = {
-				count: logs.length,
-				args: {
-					siteName: sampleLog.site.title,
-					siteNames: sites.join( ', ' ),
-					numberOfSites: sites.length,
-				},
+		componentWillUnmount() {
+			SitesLog.removeListener( 'change', this.showNotification );
+		}
+
+		refreshSiteNotices = () => {
+			return {
+				errors: SitesLog.getErrors(),
+				inProgress: SitesLog.getInProgress(),
+				completed: SitesLog.getCompleted(),
 			};
+		};
 
-		return messageFunction( sampleLog.action, translateArg, sampleLog );
-	};
+		showNotification = () => {
+			var logNotices = this.refreshSiteNotices();
 
-	successMessage = (action, translateArg) => {
-		switch ( action ) {
-			case 'DISCONNECT_SITE':
-				if ( 1 === translateArg.args.numberOfSites ) {
-					return this.props.translate( 'Successfully disconnected %(siteName)s.', translateArg );
-				}
-				return this.props.translate(
-					'Successfully disconnected %(numberOfSites)d site.',
-					'Successfully disconnected %(numberOfSites)d sites.',
-					translateArg
-				);
-		}
-	};
+			this.setState( { notices: logNotices } );
 
-	inProgressMessage = (action, translateArg) => {
-		translateArg.context =
-			'In progress message for when a Jetpack site is disconnecting from WP.com';
-		switch ( action ) {
-			case 'DISCONNECT_SITE':
-				if ( 1 === translateArg.args.numberOfSites ) {
-					return this.props.translate( 'Disconnecting %(siteName)s.', translateArg );
-				}
-				return this.props.translate(
-					'Disconnecting %(numberOfSites)d site.',
-					'Disconnecting %(numberOfSites)d sites.',
-					translateArg
-				);
-		}
-	};
+			if ( logNotices.inProgress.length > 0 ) {
+				notices.info( this.getMessage( logNotices.inProgress, this.inProgressMessage ), {
+					persistent: true,
+				} );
+				return;
+			}
+			if ( logNotices.completed.length > 0 && logNotices.errors.length > 0 ) {
+				notices.warning( this.erroredAndCompletedMessage( logNotices ), {
+					onRemoveCallback: SitesListActions.removeSitesNotices.bind(
+						this,
+						logNotices.completed.concat( logNotices.errors )
+					),
+				} );
+			} else if ( logNotices.errors.length > 0 ) {
+				notices.error( this.getMessage( logNotices.errors, this.errorMessage ), {
+					onRemoveCallback: SitesListActions.removeSitesNotices.bind( this, logNotices.errors ),
+				} );
+			} else if ( logNotices.completed.length > 0 ) {
+				notices.success( this.getMessage( logNotices.completed, this.successMessage ), {
+					onRemoveCallback: SitesListActions.removeSitesNotices.bind( this, logNotices.completed ),
+				} );
+			}
+		};
 
-	erroredAndCompletedMessage = logNotices => {
-		var completedMessage = this.getMessage( logNotices.completed, this.successMessage ),
-			errorMessage = this.getMessage( logNotices.errors, this.errorMessage );
+		getMessage = ( logs, messageFunction ) => {
+			const sampleLog = logs[ 0 ],
+				sites = logs.map( function( log ) {
+					return log.site && log.site.title;
+				} ),
+				translateArg = {
+					count: logs.length,
+					args: {
+						siteName: sampleLog.site.title,
+						siteNames: sites.join( ', ' ),
+						numberOfSites: sites.length,
+					},
+				};
 
-		return this.props.translate( '%(completedMessage)s %(errorMessage)s', {
-			args: {
-				completedMessage: completedMessage,
-				errorMessage: errorMessage,
-			},
-			context:
-				'The success message and the error message after the disconnection success and failure.',
-			comment: '%(completedMessage)s %(errorMessage)s are complete sentences.',
-		} );
-	};
+			return messageFunction( sampleLog.action, translateArg, sampleLog );
+		};
 
-	errorMessage = (action, translateArg, sampleLog) => {
-		switch ( action ) {
-			case 'RECEIVE_PLUGINS':
-				if ( 1 === translateArg.args.numberOfSites ) {
-					return this.props.translate( 'Error fetching plugins on %(siteName)s.', translateArg );
-				}
-				return this.props.translate(
-					'Error fetching plugins on %(numberOfSites)d site: %(siteNames)s.',
-					'Error fetching plugins on %(numberOfSites)d sites: %(siteNames)s.',
-					translateArg
-				);
+		successMessage = ( action, translateArg ) => {
+			switch ( action ) {
+				case 'DISCONNECT_SITE':
+					if ( 1 === translateArg.args.numberOfSites ) {
+						return this.props.translate( 'Successfully disconnected %(siteName)s.', translateArg );
+					}
+					return this.props.translate(
+						'Successfully disconnected %(numberOfSites)d site.',
+						'Successfully disconnected %(numberOfSites)d sites.',
+						translateArg
+					);
+			}
+		};
 
-			case 'DISCONNECT_SITE':
-				switch ( sampleLog.error.error ) {
-					case 'unauthorized':
-					case 'unauthorized_access':
-						if ( 1 === translateArg.args.numberOfSites ) {
+		inProgressMessage = ( action, translateArg ) => {
+			translateArg.context =
+				'In progress message for when a Jetpack site is disconnecting from WP.com';
+			switch ( action ) {
+				case 'DISCONNECT_SITE':
+					if ( 1 === translateArg.args.numberOfSites ) {
+						return this.props.translate( 'Disconnecting %(siteName)s.', translateArg );
+					}
+					return this.props.translate(
+						'Disconnecting %(numberOfSites)d site.',
+						'Disconnecting %(numberOfSites)d sites.',
+						translateArg
+					);
+			}
+		};
+
+		erroredAndCompletedMessage = logNotices => {
+			var completedMessage = this.getMessage( logNotices.completed, this.successMessage ),
+				errorMessage = this.getMessage( logNotices.errors, this.errorMessage );
+
+			return this.props.translate( '%(completedMessage)s %(errorMessage)s', {
+				args: {
+					completedMessage: completedMessage,
+					errorMessage: errorMessage,
+				},
+				context:
+					'The success message and the error message after the disconnection success and failure.',
+				comment: '%(completedMessage)s %(errorMessage)s are complete sentences.',
+			} );
+		};
+
+		errorMessage = ( action, translateArg, sampleLog ) => {
+			switch ( action ) {
+				case 'RECEIVE_PLUGINS':
+					if ( 1 === translateArg.args.numberOfSites ) {
+						return this.props.translate( 'Error fetching plugins on %(siteName)s.', translateArg );
+					}
+					return this.props.translate(
+						'Error fetching plugins on %(numberOfSites)d site: %(siteNames)s.',
+						'Error fetching plugins on %(numberOfSites)d sites: %(siteNames)s.',
+						translateArg
+					);
+
+				case 'DISCONNECT_SITE':
+					switch ( sampleLog.error.error ) {
+						case 'unauthorized':
+						case 'unauthorized_access':
+							if ( 1 === translateArg.args.numberOfSites ) {
+								return this.props.translate(
+									"You don't have permission to disconnect %(siteName)s.",
+									translateArg
+								);
+							}
 							return this.props.translate(
-								"You don't have permission to disconnect %(siteName)s.",
+								"You don't have permission to disconnect %(numberOfSites)d site: %(siteNames)s.",
+								"You don't have permission to disconnect %(numberOfSites)d sites: %(siteNames)s.",
 								translateArg
 							);
-						}
-						return this.props.translate(
-							"You don't have permission to disconnect %(numberOfSites)d site: %(siteNames)s.",
-							"You don't have permission to disconnect %(numberOfSites)d sites: %(siteNames)s.",
-							translateArg
-						);
 
-					default:
-						if ( 1 === translateArg.args.numberOfSites ) {
-							return this.props.translate( 'Error disconnecting %(siteName)s.', translateArg );
-						}
-						return this.props.translate(
-							'Error disconnecting %(numberOfSites)d site: %(siteNames)s.',
-							'Error disconnecting %(numberOfSites)d sites: %(siteNames)s.',
-							translateArg
-						);
-				}
+						default:
+							if ( 1 === translateArg.args.numberOfSites ) {
+								return this.props.translate( 'Error disconnecting %(siteName)s.', translateArg );
+							}
+							return this.props.translate(
+								'Error disconnecting %(numberOfSites)d site: %(siteNames)s.',
+								'Error disconnecting %(numberOfSites)d sites: %(siteNames)s.',
+								translateArg
+							);
+					}
+			}
+		};
+
+		state = { notices: this.refreshSiteNotices() };
+
+		render() {
+			return null;
 		}
-	};
-
-	state = { notices: this.refreshSiteNotices() };
-
-	render() {
-		return null;
 	}
-});
+);

--- a/client/lib/sites-list/notices.js
+++ b/client/lib/sites-list/notices.js
@@ -12,27 +12,24 @@ import notices from 'notices';
 import SitesLog from 'lib/sites-list/log-store';
 import SitesListActions from 'lib/sites-list/actions';
 
-module.exports = localize( React.createClass( {
-	getInitialState: function() {
-		return { notices: this.refreshSiteNotices() };
-	},
-	componentDidMount: function() {
+module.exports = localize(class extends React.Component {
+    componentDidMount() {
 		SitesLog.on( 'change', this.showNotification );
-	},
+	}
 
-	componentWillUnmount: function() {
+	componentWillUnmount() {
 		SitesLog.removeListener( 'change', this.showNotification );
-	},
+	}
 
-	refreshSiteNotices: function() {
+	refreshSiteNotices = () => {
 		return {
 			errors: SitesLog.getErrors(),
 			inProgress: SitesLog.getInProgress(),
 			completed: SitesLog.getCompleted(),
 		};
-	},
+	};
 
-	showNotification: function() {
+	showNotification = () => {
 		var logNotices = this.refreshSiteNotices();
 
 		this.setState( { notices: logNotices } );
@@ -59,9 +56,9 @@ module.exports = localize( React.createClass( {
 				onRemoveCallback: SitesListActions.removeSitesNotices.bind( this, logNotices.completed ),
 			} );
 		}
-	},
+	};
 
-	getMessage: function( logs, messageFunction ) {
+	getMessage = (logs, messageFunction) => {
 		const sampleLog = logs[ 0 ],
 			sites = logs.map( function( log ) {
 				return log.site && log.site.title;
@@ -76,9 +73,9 @@ module.exports = localize( React.createClass( {
 			};
 
 		return messageFunction( sampleLog.action, translateArg, sampleLog );
-	},
+	};
 
-	successMessage: function( action, translateArg ) {
+	successMessage = (action, translateArg) => {
 		switch ( action ) {
 			case 'DISCONNECT_SITE':
 				if ( 1 === translateArg.args.numberOfSites ) {
@@ -90,9 +87,9 @@ module.exports = localize( React.createClass( {
 					translateArg
 				);
 		}
-	},
+	};
 
-	inProgressMessage: function( action, translateArg ) {
+	inProgressMessage = (action, translateArg) => {
 		translateArg.context =
 			'In progress message for when a Jetpack site is disconnecting from WP.com';
 		switch ( action ) {
@@ -106,9 +103,9 @@ module.exports = localize( React.createClass( {
 					translateArg
 				);
 		}
-	},
+	};
 
-	erroredAndCompletedMessage: function( logNotices ) {
+	erroredAndCompletedMessage = logNotices => {
 		var completedMessage = this.getMessage( logNotices.completed, this.successMessage ),
 			errorMessage = this.getMessage( logNotices.errors, this.errorMessage );
 
@@ -121,9 +118,9 @@ module.exports = localize( React.createClass( {
 				'The success message and the error message after the disconnection success and failure.',
 			comment: '%(completedMessage)s %(errorMessage)s are complete sentences.',
 		} );
-	},
+	};
 
-	errorMessage: function( action, translateArg, sampleLog ) {
+	errorMessage = (action, translateArg, sampleLog) => {
 		switch ( action ) {
 			case 'RECEIVE_PLUGINS':
 				if ( 1 === translateArg.args.numberOfSites ) {
@@ -162,9 +159,11 @@ module.exports = localize( React.createClass( {
 						);
 				}
 		}
-	},
+	};
 
-	render: function() {
+	state = { notices: this.refreshSiteNotices() };
+
+	render() {
 		return null;
 	}
-} ) );
+});

--- a/client/lib/sites-list/notices.js
+++ b/client/lib/sites-list/notices.js
@@ -1,14 +1,17 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import React from 'react';
+
 /**
  * Internal dependencies
- *
- * @format
  */
-
 import notices from 'notices';
 import SitesLog from 'lib/sites-list/log-store';
 import SitesListActions from 'lib/sites-list/actions';
 
-module.exports = {
+module.exports = React.createClass( {
 	getInitialState: function() {
 		return { notices: this.refreshSiteNotices() };
 	},
@@ -159,4 +162,8 @@ module.exports = {
 				}
 		}
 	},
-};
+
+	render: function() {
+		return null;
+	}
+} );

--- a/client/lib/sites-list/notices.js
+++ b/client/lib/sites-list/notices.js
@@ -3,6 +3,7 @@
  * External dependencies
  */
 import React from 'react';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -11,7 +12,7 @@ import notices from 'notices';
 import SitesLog from 'lib/sites-list/log-store';
 import SitesListActions from 'lib/sites-list/actions';
 
-module.exports = React.createClass( {
+module.exports = localize( React.createClass( {
 	getInitialState: function() {
 		return { notices: this.refreshSiteNotices() };
 	},
@@ -81,9 +82,9 @@ module.exports = React.createClass( {
 		switch ( action ) {
 			case 'DISCONNECT_SITE':
 				if ( 1 === translateArg.args.numberOfSites ) {
-					return this.translate( 'Successfully disconnected %(siteName)s.', translateArg );
+					return this.props.translate( 'Successfully disconnected %(siteName)s.', translateArg );
 				}
-				return this.translate(
+				return this.props.translate(
 					'Successfully disconnected %(numberOfSites)d site.',
 					'Successfully disconnected %(numberOfSites)d sites.',
 					translateArg
@@ -97,9 +98,9 @@ module.exports = React.createClass( {
 		switch ( action ) {
 			case 'DISCONNECT_SITE':
 				if ( 1 === translateArg.args.numberOfSites ) {
-					return this.translate( 'Disconnecting %(siteName)s.', translateArg );
+					return this.props.translate( 'Disconnecting %(siteName)s.', translateArg );
 				}
-				return this.translate(
+				return this.props.translate(
 					'Disconnecting %(numberOfSites)d site.',
 					'Disconnecting %(numberOfSites)d sites.',
 					translateArg
@@ -111,7 +112,7 @@ module.exports = React.createClass( {
 		var completedMessage = this.getMessage( logNotices.completed, this.successMessage ),
 			errorMessage = this.getMessage( logNotices.errors, this.errorMessage );
 
-		return this.translate( '%(completedMessage)s %(errorMessage)s', {
+		return this.props.translate( '%(completedMessage)s %(errorMessage)s', {
 			args: {
 				completedMessage: completedMessage,
 				errorMessage: errorMessage,
@@ -126,9 +127,9 @@ module.exports = React.createClass( {
 		switch ( action ) {
 			case 'RECEIVE_PLUGINS':
 				if ( 1 === translateArg.args.numberOfSites ) {
-					return this.translate( 'Error fetching plugins on %(siteName)s.', translateArg );
+					return this.props.translate( 'Error fetching plugins on %(siteName)s.', translateArg );
 				}
-				return this.translate(
+				return this.props.translate(
 					'Error fetching plugins on %(numberOfSites)d site: %(siteNames)s.',
 					'Error fetching plugins on %(numberOfSites)d sites: %(siteNames)s.',
 					translateArg
@@ -139,12 +140,12 @@ module.exports = React.createClass( {
 					case 'unauthorized':
 					case 'unauthorized_access':
 						if ( 1 === translateArg.args.numberOfSites ) {
-							return this.translate(
+							return this.props.translate(
 								"You don't have permission to disconnect %(siteName)s.",
 								translateArg
 							);
 						}
-						return this.translate(
+						return this.props.translate(
 							"You don't have permission to disconnect %(numberOfSites)d site: %(siteNames)s.",
 							"You don't have permission to disconnect %(numberOfSites)d sites: %(siteNames)s.",
 							translateArg
@@ -152,9 +153,9 @@ module.exports = React.createClass( {
 
 					default:
 						if ( 1 === translateArg.args.numberOfSites ) {
-							return this.translate( 'Error disconnecting %(siteName)s.', translateArg );
+							return this.props.translate( 'Error disconnecting %(siteName)s.', translateArg );
 						}
-						return this.translate(
+						return this.props.translate(
 							'Error disconnecting %(numberOfSites)d site: %(siteNames)s.',
 							'Error disconnecting %(numberOfSites)d sites: %(siteNames)s.',
 							translateArg
@@ -166,4 +167,4 @@ module.exports = React.createClass( {
 	render: function() {
 		return null;
 	}
-} );
+} ) );

--- a/client/lib/sites-list/notices.js
+++ b/client/lib/sites-list/notices.js
@@ -31,7 +31,7 @@ module.exports = localize(
 		};
 
 		showNotification = () => {
-			var logNotices = this.refreshSiteNotices();
+			const logNotices = this.refreshSiteNotices();
 
 			this.setState( { notices: logNotices } );
 
@@ -107,8 +107,8 @@ module.exports = localize(
 		};
 
 		erroredAndCompletedMessage = logNotices => {
-			var completedMessage = this.getMessage( logNotices.completed, this.successMessage ),
-				errorMessage = this.getMessage( logNotices.errors, this.errorMessage );
+			const completedMessage = this.getMessage( logNotices.completed, this.successMessage );
+			const errorMessage = this.getMessage( logNotices.errors, this.errorMessage );
 
 			return this.props.translate( '%(completedMessage)s %(errorMessage)s', {
 				args: {

--- a/client/lib/sites-list/notices.js
+++ b/client/lib/sites-list/notices.js
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import { Component } from 'react';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -12,160 +12,160 @@ import notices from 'notices';
 import SitesLog from 'lib/sites-list/log-store';
 import SitesListActions from 'lib/sites-list/actions';
 
-module.exports = localize(
-	class extends React.Component {
-		componentDidMount() {
-			SitesLog.on( 'change', this.showNotification );
-		}
-
-		componentWillUnmount() {
-			SitesLog.removeListener( 'change', this.showNotification );
-		}
-
-		refreshSiteNotices = () => {
-			return {
-				errors: SitesLog.getErrors(),
-				inProgress: SitesLog.getInProgress(),
-				completed: SitesLog.getCompleted(),
-			};
-		};
-
-		showNotification = () => {
-			const logNotices = this.refreshSiteNotices();
-
-			this.setState( { notices: logNotices } );
-
-			if ( logNotices.inProgress.length > 0 ) {
-				notices.info( this.getMessage( logNotices.inProgress, this.inProgressMessage ), {
-					persistent: true,
-				} );
-				return;
-			}
-			if ( logNotices.completed.length > 0 && logNotices.errors.length > 0 ) {
-				notices.warning( this.erroredAndCompletedMessage( logNotices ), {
-					onRemoveCallback: SitesListActions.removeSitesNotices.bind(
-						this,
-						logNotices.completed.concat( logNotices.errors )
-					),
-				} );
-			} else if ( logNotices.errors.length > 0 ) {
-				notices.error( this.getMessage( logNotices.errors, this.errorMessage ), {
-					onRemoveCallback: SitesListActions.removeSitesNotices.bind( this, logNotices.errors ),
-				} );
-			} else if ( logNotices.completed.length > 0 ) {
-				notices.success( this.getMessage( logNotices.completed, this.successMessage ), {
-					onRemoveCallback: SitesListActions.removeSitesNotices.bind( this, logNotices.completed ),
-				} );
-			}
-		};
-
-		getMessage = ( logs, messageFunction ) => {
-			const sampleLog = logs[ 0 ],
-				sites = logs.map( function( log ) {
-					return log.site && log.site.title;
-				} ),
-				translateArg = {
-					count: logs.length,
-					args: {
-						siteName: sampleLog.site.title,
-						siteNames: sites.join( ', ' ),
-						numberOfSites: sites.length,
-					},
-				};
-
-			return messageFunction( sampleLog.action, translateArg, sampleLog );
-		};
-
-		successMessage = ( action, translateArg ) => {
-			switch ( action ) {
-				case 'DISCONNECT_SITE':
-					if ( 1 === translateArg.args.numberOfSites ) {
-						return this.props.translate( 'Successfully disconnected %(siteName)s.', translateArg );
-					}
-					return this.props.translate(
-						'Successfully disconnected %(numberOfSites)d site.',
-						'Successfully disconnected %(numberOfSites)d sites.',
-						translateArg
-					);
-			}
-		};
-
-		inProgressMessage = ( action, translateArg ) => {
-			translateArg.context =
-				'In progress message for when a Jetpack site is disconnecting from WP.com';
-			switch ( action ) {
-				case 'DISCONNECT_SITE':
-					if ( 1 === translateArg.args.numberOfSites ) {
-						return this.props.translate( 'Disconnecting %(siteName)s.', translateArg );
-					}
-					return this.props.translate(
-						'Disconnecting %(numberOfSites)d site.',
-						'Disconnecting %(numberOfSites)d sites.',
-						translateArg
-					);
-			}
-		};
-
-		erroredAndCompletedMessage = logNotices => {
-			const completedMessage = this.getMessage( logNotices.completed, this.successMessage );
-			const errorMessage = this.getMessage( logNotices.errors, this.errorMessage );
-
-			return this.props.translate( '%(completedMessage)s %(errorMessage)s', {
-				args: {
-					completedMessage: completedMessage,
-					errorMessage: errorMessage,
-				},
-				context:
-					'The success message and the error message after the disconnection success and failure.',
-				comment: '%(completedMessage)s %(errorMessage)s are complete sentences.',
-			} );
-		};
-
-		errorMessage = ( action, translateArg, sampleLog ) => {
-			switch ( action ) {
-				case 'RECEIVE_PLUGINS':
-					if ( 1 === translateArg.args.numberOfSites ) {
-						return this.props.translate( 'Error fetching plugins on %(siteName)s.', translateArg );
-					}
-					return this.props.translate(
-						'Error fetching plugins on %(numberOfSites)d site: %(siteNames)s.',
-						'Error fetching plugins on %(numberOfSites)d sites: %(siteNames)s.',
-						translateArg
-					);
-
-				case 'DISCONNECT_SITE':
-					switch ( sampleLog.error.error ) {
-						case 'unauthorized':
-						case 'unauthorized_access':
-							if ( 1 === translateArg.args.numberOfSites ) {
-								return this.props.translate(
-									"You don't have permission to disconnect %(siteName)s.",
-									translateArg
-								);
-							}
-							return this.props.translate(
-								"You don't have permission to disconnect %(numberOfSites)d site: %(siteNames)s.",
-								"You don't have permission to disconnect %(numberOfSites)d sites: %(siteNames)s.",
-								translateArg
-							);
-
-						default:
-							if ( 1 === translateArg.args.numberOfSites ) {
-								return this.props.translate( 'Error disconnecting %(siteName)s.', translateArg );
-							}
-							return this.props.translate(
-								'Error disconnecting %(numberOfSites)d site: %(siteNames)s.',
-								'Error disconnecting %(numberOfSites)d sites: %(siteNames)s.',
-								translateArg
-							);
-					}
-			}
-		};
-
-		state = { notices: this.refreshSiteNotices() };
-
-		render() {
-			return null;
-		}
+class SitesListNotices extends Component {
+	componentDidMount() {
+		SitesLog.on( 'change', this.showNotification );
 	}
-);
+
+	componentWillUnmount() {
+		SitesLog.removeListener( 'change', this.showNotification );
+	}
+
+	refreshSiteNotices = () => {
+		return {
+			errors: SitesLog.getErrors(),
+			inProgress: SitesLog.getInProgress(),
+			completed: SitesLog.getCompleted(),
+		};
+	};
+
+	showNotification = () => {
+		const logNotices = this.refreshSiteNotices();
+
+		this.setState( { notices: logNotices } );
+
+		if ( logNotices.inProgress.length > 0 ) {
+			notices.info( this.getMessage( logNotices.inProgress, this.inProgressMessage ), {
+				persistent: true,
+			} );
+			return;
+		}
+		if ( logNotices.completed.length > 0 && logNotices.errors.length > 0 ) {
+			notices.warning( this.erroredAndCompletedMessage( logNotices ), {
+				onRemoveCallback: SitesListActions.removeSitesNotices.bind(
+					this,
+					logNotices.completed.concat( logNotices.errors )
+				),
+			} );
+		} else if ( logNotices.errors.length > 0 ) {
+			notices.error( this.getMessage( logNotices.errors, this.errorMessage ), {
+				onRemoveCallback: SitesListActions.removeSitesNotices.bind( this, logNotices.errors ),
+			} );
+		} else if ( logNotices.completed.length > 0 ) {
+			notices.success( this.getMessage( logNotices.completed, this.successMessage ), {
+				onRemoveCallback: SitesListActions.removeSitesNotices.bind( this, logNotices.completed ),
+			} );
+		}
+	};
+
+	getMessage = ( logs, messageFunction ) => {
+		const sampleLog = logs[ 0 ],
+			sites = logs.map( function( log ) {
+				return log.site && log.site.title;
+			} ),
+			translateArg = {
+				count: logs.length,
+				args: {
+					siteName: sampleLog.site.title,
+					siteNames: sites.join( ', ' ),
+					numberOfSites: sites.length,
+				},
+			};
+
+		return messageFunction( sampleLog.action, translateArg, sampleLog );
+	};
+
+	successMessage = ( action, translateArg ) => {
+		switch ( action ) {
+			case 'DISCONNECT_SITE':
+				if ( 1 === translateArg.args.numberOfSites ) {
+					return this.props.translate( 'Successfully disconnected %(siteName)s.', translateArg );
+				}
+				return this.props.translate(
+					'Successfully disconnected %(numberOfSites)d site.',
+					'Successfully disconnected %(numberOfSites)d sites.',
+					translateArg
+				);
+		}
+	};
+
+	inProgressMessage = ( action, translateArg ) => {
+		translateArg.context =
+			'In progress message for when a Jetpack site is disconnecting from WP.com';
+		switch ( action ) {
+			case 'DISCONNECT_SITE':
+				if ( 1 === translateArg.args.numberOfSites ) {
+					return this.props.translate( 'Disconnecting %(siteName)s.', translateArg );
+				}
+				return this.props.translate(
+					'Disconnecting %(numberOfSites)d site.',
+					'Disconnecting %(numberOfSites)d sites.',
+					translateArg
+				);
+		}
+	};
+
+	erroredAndCompletedMessage = logNotices => {
+		const completedMessage = this.getMessage( logNotices.completed, this.successMessage );
+		const errorMessage = this.getMessage( logNotices.errors, this.errorMessage );
+
+		return this.props.translate( '%(completedMessage)s %(errorMessage)s', {
+			args: {
+				completedMessage: completedMessage,
+				errorMessage: errorMessage,
+			},
+			context:
+				'The success message and the error message after the disconnection success and failure.',
+			comment: '%(completedMessage)s %(errorMessage)s are complete sentences.',
+		} );
+	};
+
+	errorMessage = ( action, translateArg, sampleLog ) => {
+		switch ( action ) {
+			case 'RECEIVE_PLUGINS':
+				if ( 1 === translateArg.args.numberOfSites ) {
+					return this.props.translate( 'Error fetching plugins on %(siteName)s.', translateArg );
+				}
+				return this.props.translate(
+					'Error fetching plugins on %(numberOfSites)d site: %(siteNames)s.',
+					'Error fetching plugins on %(numberOfSites)d sites: %(siteNames)s.',
+					translateArg
+				);
+
+			case 'DISCONNECT_SITE':
+				switch ( sampleLog.error.error ) {
+					case 'unauthorized':
+					case 'unauthorized_access':
+						if ( 1 === translateArg.args.numberOfSites ) {
+							return this.props.translate(
+								"You don't have permission to disconnect %(siteName)s.",
+								translateArg
+							);
+						}
+						return this.props.translate(
+							"You don't have permission to disconnect %(numberOfSites)d site: %(siteNames)s.",
+							"You don't have permission to disconnect %(numberOfSites)d sites: %(siteNames)s.",
+							translateArg
+						);
+
+					default:
+						if ( 1 === translateArg.args.numberOfSites ) {
+							return this.props.translate( 'Error disconnecting %(siteName)s.', translateArg );
+						}
+						return this.props.translate(
+							'Error disconnecting %(numberOfSites)d site: %(siteNames)s.',
+							'Error disconnecting %(numberOfSites)d sites: %(siteNames)s.',
+							translateArg
+						);
+				}
+		}
+	};
+
+	state = { notices: this.refreshSiteNotices() };
+
+	render() {
+		return null;
+	}
+}
+
+export default localize( SitesListNotices );


### PR DESCRIPTION
Another #18590 spin-off. I hope this works as I think it should...

So previously, this was a mixin, and AFAICS, it's only used by `client/layout`. But what it does seems to be simply display some "global" `notices` on some `sites-list` changes. I think we can get away with turning it into an actual react component (that renders `null`).

To test: Restart Calypso, verify that things still work. Ideally come up with a scenario that triggers one of these notices.