### PR TITLE
Jetpack Plans: Don't render Connect Plans before redirecting to regular plans page if the site is already connected

### DIFF
--- a/client/jetpack-connect/plans-landing.jsx
+++ b/client/jetpack-connect/plans-landing.jsx
@@ -15,7 +15,7 @@ import PlansSkipButton from './plans-skip-button';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { selectPlanInAdvance } from 'state/jetpack-connect/actions';
 import { getJetpackSiteByUrl } from 'state/jetpack-connect/selectors';
-import { getSite } from 'state/sites/selectors';
+import { getSite, isRequestingSites } from 'state/sites/selectors';
 import QueryPlans from 'components/data/query-plans';
 import addQueryArgs from 'lib/route/add-query-args';
 
@@ -77,11 +77,11 @@ class PlansLanding extends Component {
 	};
 
 	render() {
-		const { basePlansPath, interval, site } = this.props;
+		const { basePlansPath, interval, requestingSites, site } = this.props;
 
 		// We're redirecting in componentDidMount if the site is already connected
 		// so don't bother rendering any markup if this is the case
-		if ( site ) {
+		if ( site || requestingSites ) {
 			return null;
 		}
 
@@ -110,6 +110,7 @@ export default connect(
 		const site = rawSite ? getSite( state, rawSite.ID ) : null;
 
 		return {
+			requestingSites: isRequestingSites( state ),
 			site,
 		};
 	},

--- a/client/jetpack-connect/plans-landing.jsx
+++ b/client/jetpack-connect/plans-landing.jsx
@@ -77,7 +77,13 @@ class PlansLanding extends Component {
 	};
 
 	render() {
-		const { basePlansPath, interval } = this.props;
+		const { basePlansPath, interval, site } = this.props;
+
+		// We're redirecting in componentDidMount if the site is already connected
+		// so don't bother rendering any markup if this is the case
+		if ( site ) {
+			return null;
+		}
 
 		return (
 			<div>


### PR DESCRIPTION
Fixes #18574.

#### Changes introduced by this PR

* Makes the `PlansLanding` component render `null` if the site is already among the props (meaning that the site is already connected or we don't have sites data yet.

#### Testing instructions

1. Have a site with a Jetpack already connected.
1. Before checking this branch, visit `https://wordpress.com/jetpack/connect/store/?site=your-already-connected-site-slug` and confirm that you get to see first the Jetpack Connect Plans page (the one without a sidebar) and then the regular Plans page.
1. Check out branch
1. Visit `/jetpack/connect/store/?site=your-already-connected-site-slug`, confirm that you only see the regular Plans Page this time.

#### Before


![before](https://user-images.githubusercontent.com/746152/31290059-8a15b174-aaa1-11e7-9386-a8e0e0f69017.gif)


#### After

![after](https://user-images.githubusercontent.com/746152/31290660-a6376774-aaa3-11e7-8bc4-dab286c96372.gif)




