### PR TITLE
Reader Tracks: add tracking when "Read More" on a comment is clicked

### DIFF
--- a/client/blocks/comments/post-comment.jsx
+++ b/client/blocks/comments/post-comment.jsx
@@ -294,6 +294,13 @@ class PostComment extends React.PureComponent {
 				postId: this.props.post.ID,
 				displayType: POST_COMMENT_DISPLAY_TYPES.full,
 			} );
+		recordAction( 'comment_read_more_click' );
+		recordGaEvent( 'Clicked Comment Read More' );
+		recordTrack( 'calypso_reader_comment_read_more_click', {
+			blog_id: this.props.post.site_ID,
+			post_id: this.props.post.ID,
+			comment_id: this.props.commentId,
+		} );
 	};
 
 	render() {


### PR DESCRIPTION
Adds Tracks event calypso_reader_comment_read_more_click when the comment "Read More" item is clicked on in Conversations Tool. References #18587