### PR TITLE
Reader Tracks: add event tracking when comment caterpillar is clicked

### DIFF
--- a/client/blocks/conversation-caterpillar/index.jsx
+++ b/client/blocks/conversation-caterpillar/index.jsx
@@ -13,6 +13,7 @@ import Gridicon from 'gridicons';
  * Internal dependencies
  */
 import Gravatar from 'components/gravatar';
+import { recordAction, recordGaEvent, recordTrack } from 'reader/stats';
 import { getPostCommentsTree, getDateSortedPostComments } from 'state/comments/selectors';
 import { expandComments } from 'state/comments/actions';
 import { POST_COMMENT_DISPLAY_TYPES } from 'state/comments/constants';
@@ -74,6 +75,12 @@ class ConversationCaterpillarComponent extends React.Component {
 			postId,
 			commentIds: compact( map( commentsToExpand, c => get( c, 'parent.ID', null ) ) ),
 			displayType: POST_COMMENT_DISPLAY_TYPES.excerpt,
+		} );
+		recordAction( 'comment_caterpillar_click' );
+		recordGaEvent( 'Clicked Caterpillar' );
+		recordTrack( 'calypso_reader_comment_caterpillar_click', {
+			blog_id: blogId,
+			post_id: postId,
 		} );
 	};
 


### PR DESCRIPTION
Adds Tracks event calypso_reader_comment_caterpillar_click when the comment caterpillar is clicked. References #18584.