### PR TITLE
Store Orders: Refactor refund modal

### DIFF
--- a/client/extensions/woocommerce/app/order/order-details/index.js
+++ b/client/extensions/woocommerce/app/order/order-details/index.js
@@ -62,7 +62,7 @@ class OrderDetails extends Component {
 		return [
 			<OrderCreated key="order-date" order={ order } site={ site } />,
 			<OrderDetailsTable key="order-details" order={ order } site={ site } />,
-			<OrderPaymentCard key="order-payment" order={ order } site={ site } />,
+			<OrderPaymentCard key="order-payment" order={ order } siteId={ site.ID || null } />,
 			<OrderFulfillment key="order-fulfillment" order={ order } site={ site } />,
 		];
 	};

--- a/client/extensions/woocommerce/app/order/order-payment/dialog.js
+++ b/client/extensions/woocommerce/app/order/order-payment/dialog.js
@@ -22,6 +22,7 @@ import formatCurrency from 'lib/format-currency';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
 import FormTextarea from 'components/forms/form-textarea';
+import { getOrderRefundTotal } from 'woocommerce/lib/order-values';
 import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
 import Notice from 'components/notice';
 import OrderRefundTable from './table';
@@ -70,10 +71,6 @@ class OrderPaymentCard extends Component {
 		}
 	};
 
-	getRefundedTotal = order => {
-		return order.refunds.reduce( ( sum, i ) => sum + parseFloat( i.total ), 0 );
-	};
-
 	toggleDialog = () => {
 		this.setState( {
 			errorMessage: false,
@@ -95,7 +92,7 @@ class OrderPaymentCard extends Component {
 
 	sendRefund = () => {
 		const { order, paymentMethod, siteId, translate } = this.props;
-		const maxRefund = parseFloat( order.total ) + this.getRefundedTotal( order );
+		const maxRefund = parseFloat( order.total ) + getOrderRefundTotal( order );
 		if ( this.state.refundTotal > maxRefund ) {
 			this.setState( {
 				errorMessage: translate( 'Refund must be less than or equal to the order total.' ),

--- a/client/extensions/woocommerce/app/order/order-payment/dialog.js
+++ b/client/extensions/woocommerce/app/order/order-payment/dialog.js
@@ -36,7 +36,6 @@ class OrderPaymentCard extends Component {
 		order: PropTypes.shape( {
 			currency: PropTypes.string.isRequired,
 			id: PropTypes.number.isRequired,
-			payment_method_title: PropTypes.string.isRequired,
 			refunds: PropTypes.array.isRequired,
 			status: PropTypes.string.isRequired,
 			total: PropTypes.string.isRequired,
@@ -45,6 +44,7 @@ class OrderPaymentCard extends Component {
 		sendRefund: PropTypes.func.isRequired,
 		siteId: PropTypes.number.isRequired,
 		toggleDialog: PropTypes.func,
+		translate: PropTypes.func.isRequired,
 	};
 
 	state = {

--- a/client/extensions/woocommerce/app/order/order-payment/dialog.js
+++ b/client/extensions/woocommerce/app/order/order-payment/dialog.js
@@ -24,7 +24,7 @@ import FormLabel from 'components/forms/form-label';
 import FormTextarea from 'components/forms/form-textarea';
 import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
 import Notice from 'components/notice';
-import OrderDetailsTable from '../order-details/table';
+import OrderRefundTable from './table';
 import PriceInput from 'woocommerce/components/price-input';
 import { sendRefund } from 'woocommerce/state/sites/orders/refunds/actions';
 
@@ -177,7 +177,7 @@ class OrderPaymentCard extends Component {
 				additionalClassNames="order-payment__dialog woocommerce"
 			>
 				<h1>{ translate( 'Refund order' ) }</h1>
-				<OrderDetailsTable order={ order } isEditable onChange={ this.recalculateRefund } />
+				<OrderRefundTable order={ order } onChange={ this.recalculateRefund } />
 				<form className="order-payment__container">
 					<FormLabel className="order-payment__note">
 						{ translate( 'Refund note' ) }

--- a/client/extensions/woocommerce/app/order/order-payment/dialog.js
+++ b/client/extensions/woocommerce/app/order/order-payment/dialog.js
@@ -1,0 +1,229 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import {
+	arePaymentMethodsLoaded,
+	getPaymentMethod,
+} from 'woocommerce/state/sites/payment-methods/selectors';
+import Button from 'components/button';
+import Dialog from 'components/dialog';
+import { fetchPaymentMethods } from 'woocommerce/state/sites/payment-methods/actions';
+import formatCurrency from 'lib/format-currency';
+import FormFieldset from 'components/forms/form-fieldset';
+import FormLabel from 'components/forms/form-label';
+import FormTextarea from 'components/forms/form-textarea';
+import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
+import Notice from 'components/notice';
+import OrderDetailsTable from '../order-details/table';
+import PriceInput from 'woocommerce/components/price-input';
+import { sendRefund } from 'woocommerce/state/sites/orders/refunds/actions';
+
+class OrderPaymentCard extends Component {
+	static propTypes = {
+		isPaymentLoading: PropTypes.bool,
+		fetchPaymentMethods: PropTypes.func.isRequired,
+		isVisible: PropTypes.bool.isRequired,
+		order: PropTypes.shape( {
+			currency: PropTypes.string.isRequired,
+			id: PropTypes.number.isRequired,
+			payment_method_title: PropTypes.string.isRequired,
+			refunds: PropTypes.array.isRequired,
+			status: PropTypes.string.isRequired,
+			total: PropTypes.string.isRequired,
+		} ),
+		paymentMethod: PropTypes.oneOfType( [ PropTypes.object, PropTypes.bool ] ),
+		sendRefund: PropTypes.func.isRequired,
+		siteId: PropTypes.number.isRequired,
+		toggleDialog: PropTypes.func,
+	};
+
+	state = {
+		errorMessage: false,
+		refundTotal: 0,
+		refundNote: '',
+	};
+
+	componentDidMount = () => {
+		const { siteId } = this.props;
+
+		if ( siteId ) {
+			this.props.fetchPaymentMethods( siteId );
+		}
+	};
+
+	componentWillReceiveProps = newProps => {
+		const newSiteId = newProps.siteId;
+		const oldSiteId = this.props.siteId;
+
+		if ( oldSiteId !== newSiteId ) {
+			this.props.fetchPaymentMethods( newSiteId );
+		}
+	};
+
+	getRefundedTotal = order => {
+		return order.refunds.reduce( ( sum, i ) => sum + parseFloat( i.total ), 0 );
+	};
+
+	toggleDialog = () => {
+		this.setState( {
+			errorMessage: false,
+			refundTotal: 0,
+			refundNote: '',
+		} );
+		this.props.toggleDialog();
+	};
+
+	recalculateRefund = total => {
+		this.setState( { refundTotal: total } );
+	};
+
+	updateNote = event => {
+		this.setState( {
+			refundNote: event.target.value,
+		} );
+	};
+
+	sendRefund = () => {
+		const { order, paymentMethod, siteId, translate } = this.props;
+		const maxRefund = parseFloat( order.total ) + this.getRefundedTotal( order );
+		if ( this.state.refundTotal > maxRefund ) {
+			this.setState( {
+				errorMessage: translate( 'Refund must be less than or equal to the order total.' ),
+			} );
+			return;
+		} else if ( this.state.refundTotal <= 0 ) {
+			this.setState( { errorMessage: translate( 'Refund must be greater than zero.' ) } );
+			return;
+		}
+		this.toggleDialog();
+		const refundObj = {
+			amount: this.state.refundTotal + '', // API expects a string
+			reason: this.state.refundNote,
+			api_refund: paymentMethod && -1 !== paymentMethod.method_supports.indexOf( 'refunds' ),
+		};
+		this.props.sendRefund( siteId, order.id, refundObj );
+	};
+
+	renderCreditCard = () => {
+		const { isPaymentLoading, paymentMethod, translate } = this.props;
+		if ( isPaymentLoading ) {
+			return null;
+		}
+
+		if ( paymentMethod && -1 === paymentMethod.method_supports.indexOf( 'refunds' ) ) {
+			return (
+				<div className="order-payment__method">
+					<h3>{ translate( 'Manual Refund' ) }</h3>
+					<p>
+						{ translate(
+							"This payment method doesn't support automated refunds and must be submitted manually."
+						) }
+					</p>
+				</div>
+			);
+		}
+
+		return (
+			<div className="order-payment__method">
+				<h3>
+					{ translate( 'Refunding payment via %(method)s', {
+						args: {
+							method: paymentMethod.title,
+						},
+					} ) }
+				</h3>
+			</div>
+		);
+	};
+
+	render() {
+		const { isPaymentLoading, order, isVisible, translate } = this.props;
+		const { errorMessage, refundNote } = this.state;
+		const dialogClass = 'woocommerce'; // eslint/css specificity hack
+
+		if ( 'cancelled' === order.status || 'failed' === order.status ) {
+			return null;
+		}
+
+		let refundTotal = formatCurrency( 0, order.currency );
+		if ( this.state.refundTotal ) {
+			refundTotal = formatCurrency( this.state.refundTotal, order.currency );
+		}
+		refundTotal = refundTotal.replace( /[^0-9.,]/g, '' );
+
+		const dialogButtons = [
+			<Button onClick={ this.toggleDialog }>{ translate( 'Cancel' ) }</Button>,
+			<Button primary onClick={ this.sendRefund } disabled={ isPaymentLoading }>
+				{ translate( 'Refund' ) }
+			</Button>,
+		];
+
+		return (
+			<Dialog
+				isVisible={ isVisible }
+				onClose={ this.toggleDialog }
+				className={ dialogClass }
+				buttons={ dialogButtons }
+				additionalClassNames="order-payment__dialog woocommerce"
+			>
+				<h1>{ translate( 'Refund order' ) }</h1>
+				<OrderDetailsTable order={ order } isEditable onChange={ this.recalculateRefund } />
+				<form className="order-payment__container">
+					<FormLabel className="order-payment__note">
+						{ translate( 'Refund note' ) }
+						<FormTextarea onChange={ this.updateNote } name="refund_note" value={ refundNote } />
+					</FormLabel>
+
+					<FormFieldset className="order-payment__details">
+						<FormLabel className="order-payment__amount">
+							<span className="order-payment__amount-label">
+								{ translate( 'Total refund amount' ) }
+							</span>
+							<div className="order-payment__amount-value">
+								<PriceInput
+									name="refund_total"
+									readOnly
+									currency={ order.currency }
+									value={ refundTotal }
+								/>
+							</div>
+						</FormLabel>
+
+						{ this.renderCreditCard() }
+					</FormFieldset>
+
+					{ errorMessage && (
+						<Notice status="is-error" showDismiss={ false }>
+							{ errorMessage }
+						</Notice>
+					) }
+				</form>
+			</Dialog>
+		);
+	}
+}
+
+export default connect(
+	( state, props ) => {
+		const site = getSelectedSiteWithFallback( state );
+		const siteId = site ? site.ID : false;
+		const paymentMethod = getPaymentMethod( state, props.order.payment_method );
+		const isPaymentLoading = ! arePaymentMethodsLoaded( state );
+		return {
+			isPaymentLoading,
+			paymentMethod,
+			siteId,
+		};
+	},
+	dispatch => bindActionCreators( { fetchPaymentMethods, sendRefund }, dispatch )
+)( localize( OrderPaymentCard ) );

--- a/client/extensions/woocommerce/app/order/order-payment/index.js
+++ b/client/extensions/woocommerce/app/order/order-payment/index.js
@@ -4,6 +4,8 @@
  */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
 import Gridicon from 'gridicons';
 import { localize } from 'i18n-calypso';
 
@@ -13,7 +15,9 @@ import { localize } from 'i18n-calypso';
 import Button from 'components/button';
 import formatCurrency from 'lib/format-currency';
 import { getOrderRefundTotal } from 'woocommerce/lib/order-values';
+import { isOrderWaitingPayment } from 'woocommerce/lib/order-status';
 import RefundDialog from './dialog';
+import { updateOrder } from 'woocommerce/state/sites/orders/actions';
 
 class OrderPaymentCard extends Component {
 	static propTypes = {
@@ -26,6 +30,8 @@ class OrderPaymentCard extends Component {
 			total: PropTypes.string.isRequired,
 		} ),
 		siteId: PropTypes.number.isRequired,
+		translate: PropTypes.func.isRequired,
+		updateOrder: PropTypes.func.isRequired,
 	};
 
 	state = {
@@ -72,7 +78,7 @@ class OrderPaymentCard extends Component {
 		const { order, translate } = this.props;
 		if ( 'refunded' === order.status ) {
 			return null;
-		} else if ( 'on-hold' === order.status || 'pending' === order.status ) {
+		} else if ( isOrderWaitingPayment( order.status ) ) {
 			return <Button onClick={ this.markAsPaid }>{ translate( 'Mark as Paid' ) }</Button>;
 		}
 		return <Button onClick={ this.toggleDialog }>{ translate( 'Submit Refund' ) }</Button>;
@@ -114,4 +120,6 @@ class OrderPaymentCard extends Component {
 	}
 }
 
-export default localize( OrderPaymentCard );
+export default connect( null, dispatch => bindActionCreators( { updateOrder }, dispatch ) )(
+	localize( OrderPaymentCard )
+);

--- a/client/extensions/woocommerce/app/order/order-payment/index.js
+++ b/client/extensions/woocommerce/app/order/order-payment/index.js
@@ -4,31 +4,16 @@
  */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { bindActionCreators } from 'redux';
-import { connect } from 'react-redux';
 import Gridicon from 'gridicons';
 import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
-import {
-	arePaymentMethodsLoaded,
-	getPaymentMethod,
-} from 'woocommerce/state/sites/payment-methods/selectors';
 import Button from 'components/button';
-import Dialog from 'components/dialog';
-import { fetchPaymentMethods } from 'woocommerce/state/sites/payment-methods/actions';
 import formatCurrency from 'lib/format-currency';
-import FormFieldset from 'components/forms/form-fieldset';
-import FormLabel from 'components/forms/form-label';
-import FormTextarea from 'components/forms/form-textarea';
 import { getOrderRefundTotal } from 'woocommerce/lib/order-values';
-import Notice from 'components/notice';
-import OrderDetailsTable from '../order-details/table';
-import PriceInput from 'woocommerce/components/price-input';
-import { sendRefund } from 'woocommerce/state/sites/orders/refunds/actions';
-import { updateOrder } from 'woocommerce/state/sites/orders/actions';
+import RefundDialog from './dialog';
 
 class OrderPaymentCard extends Component {
 	static propTypes = {
@@ -40,35 +25,11 @@ class OrderPaymentCard extends Component {
 			status: PropTypes.string.isRequired,
 			total: PropTypes.string.isRequired,
 		} ),
-		site: PropTypes.shape( {
-			ID: PropTypes.number.isRequired,
-			slug: PropTypes.string.isRequired,
-		} ),
+		siteId: PropTypes.number.isRequired,
 	};
 
 	state = {
-		errorMessage: false,
-		refundTotal: 0,
-		refundNote: '',
 		showDialog: false,
-	};
-
-	componentDidMount = () => {
-		const { site } = this.props;
-
-		if ( site && site.ID ) {
-			this.props.fetchPaymentMethods( site.ID );
-		}
-	};
-
-	componentWillReceiveProps = newProps => {
-		const { site } = this.props;
-		const newSiteId = ( newProps.site && newProps.site.ID ) || null;
-		const oldSiteId = ( site && site.ID ) || null;
-
-		if ( oldSiteId !== newSiteId ) {
-			this.props.fetchPaymentMethods( newSiteId );
-		}
 	};
 
 	getPaymentStatus = () => {
@@ -123,98 +84,17 @@ class OrderPaymentCard extends Component {
 	};
 
 	toggleDialog = () => {
-		this.setState( {
-			errorMessage: false,
-			refundTotal: 0,
-			refundNote: '',
-			showDialog: ! this.state.showDialog,
-		} );
-	};
-
-	recalculateRefund = total => {
-		this.setState( { refundTotal: total } );
-	};
-
-	updateNote = event => {
-		this.setState( {
-			refundNote: event.target.value,
-		} );
-	};
-
-	sendRefund = () => {
-		const { order, paymentMethod, site, translate } = this.props;
-		const maxRefund = parseFloat( order.total ) + getOrderRefundTotal( order );
-		if ( this.state.refundTotal > maxRefund ) {
-			this.setState( {
-				errorMessage: translate( 'Refund must be less than or equal to the order total.' ),
-			} );
-			return;
-		} else if ( this.state.refundTotal <= 0 ) {
-			this.setState( { errorMessage: translate( 'Refund must be greater than zero.' ) } );
-			return;
-		}
-		this.toggleDialog();
-		const refundObj = {
-			amount: this.state.refundTotal + '', // API expects a string
-			reason: this.state.refundNote,
-			api_refund: paymentMethod && -1 !== paymentMethod.method_supports.indexOf( 'refunds' ),
-		};
-		this.props.sendRefund( site.ID, order.id, refundObj );
-	};
-
-	renderCreditCard = () => {
-		const { isPaymentLoading, paymentMethod, translate } = this.props;
-		if ( isPaymentLoading ) {
-			return null;
-		}
-
-		if ( paymentMethod && -1 === paymentMethod.method_supports.indexOf( 'refunds' ) ) {
-			return (
-				<div className="order-payment__method">
-					<h3>{ translate( 'Manual Refund' ) }</h3>
-					<p>
-						{ translate(
-							"This payment method doesn't support automated refunds and must be submitted manually."
-						) }
-					</p>
-				</div>
-			);
-		}
-
-		return (
-			<div className="order-payment__method">
-				<h3>
-					{ translate( 'Refunding payment via %(method)s', {
-						args: {
-							method: paymentMethod.title,
-						},
-					} ) }
-				</h3>
-			</div>
-		);
+		this.setState( prevState => ( {
+			showDialog: ! prevState.showDialog,
+		} ) );
 	};
 
 	render() {
-		const { isPaymentLoading, order, site, translate } = this.props;
-		const { errorMessage, refundNote, showDialog } = this.state;
-		const dialogClass = 'woocommerce'; // eslint/css specificity hack
+		const { order } = this.props;
 
 		if ( 'cancelled' === order.status || 'failed' === order.status ) {
 			return null;
 		}
-
-		let refundTotal = formatCurrency( 0, order.currency );
-		if ( this.state.refundTotal ) {
-			refundTotal = formatCurrency( this.state.refundTotal, order.currency );
-		}
-		refundTotal = refundTotal.replace( /[^0-9.,]/g, '' );
-
-		const dialogButtons = [
-			<Button onClick={ this.toggleDialog }>{ translate( 'Cancel' ) }</Button>,
-			<Button primary onClick={ this.sendRefund } disabled={ isPaymentLoading }>
-				{ translate( 'Refund', { context: 'Button to open refund dialog' } ) }
-			</Button>,
-		];
 
 		return (
 			<div className="order-payment">
@@ -224,64 +104,14 @@ class OrderPaymentCard extends Component {
 				</div>
 				<div className="order-payment__action">{ this.getPaymentAction() }</div>
 
-				<Dialog
-					isVisible={ showDialog }
-					onClose={ this.toggleDialog }
-					className={ dialogClass }
-					buttons={ dialogButtons }
-					additionalClassNames="order-payment__dialog woocommerce"
-				>
-					<h1>{ translate( 'Refund order' ) }</h1>
-					<OrderDetailsTable
-						order={ order }
-						isEditable
-						onChange={ this.recalculateRefund }
-						site={ site }
-					/>
-					<form className="order-payment__container">
-						<FormLabel className="order-payment__note">
-							{ translate( 'Refund note' ) }
-							<FormTextarea onChange={ this.updateNote } name="refund_note" value={ refundNote } />
-						</FormLabel>
-
-						<FormFieldset className="order-payment__details">
-							<FormLabel className="order-payment__amount">
-								<span className="order-payment__amount-label">
-									{ translate( 'Total refund amount' ) }
-								</span>
-								<div className="order-payment__amount-value">
-									<PriceInput
-										name="refund_total"
-										readOnly
-										currency={ order.currency }
-										value={ refundTotal }
-									/>
-								</div>
-							</FormLabel>
-
-							{ this.renderCreditCard() }
-						</FormFieldset>
-
-						{ errorMessage && (
-							<Notice status="is-error" showDismiss={ false }>
-								{ errorMessage }
-							</Notice>
-						) }
-					</form>
-				</Dialog>
+				<RefundDialog
+					isVisible={ this.state.showDialog }
+					order={ order }
+					toggleDialog={ this.toggleDialog }
+				/>
 			</div>
 		);
 	}
 }
 
-export default connect(
-	( state, props ) => {
-		const paymentMethod = getPaymentMethod( state, props.order.payment_method );
-		const isPaymentLoading = ! arePaymentMethodsLoaded( state );
-		return {
-			isPaymentLoading,
-			paymentMethod,
-		};
-	},
-	dispatch => bindActionCreators( { fetchPaymentMethods, sendRefund, updateOrder }, dispatch )
-)( localize( OrderPaymentCard ) );
+export default localize( OrderPaymentCard );

--- a/client/extensions/woocommerce/app/order/order-payment/table.js
+++ b/client/extensions/woocommerce/app/order/order-payment/table.js
@@ -1,0 +1,213 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import classnames from 'classnames';
+import { localize } from 'i18n-calypso';
+import { sum } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import formatCurrency from 'lib/format-currency';
+import FormTextInput from 'components/forms/form-text-input';
+import {
+	getOrderDiscountTax,
+	getOrderLineItemTax,
+	getOrderShippingTax,
+	getOrderTotalTax,
+	getRefundedTotal,
+} from 'woocommerce/lib/order-values';
+import OrderTotalRow from '../order-details/row-total';
+import Table from 'woocommerce/components/table';
+import TableRow from 'woocommerce/components/table/table-row';
+import TableItem from 'woocommerce/components/table/table-item';
+
+class OrderRefundTable extends Component {
+	static propTypes = {
+		onChange: PropTypes.func,
+		order: PropTypes.shape( {
+			currency: PropTypes.string.isRequired,
+			discount_total: PropTypes.string.isRequired,
+			line_items: PropTypes.array.isRequired,
+			refunds: PropTypes.array.isRequired,
+			shipping_total: PropTypes.string.isRequired,
+			total: PropTypes.string.isRequired,
+		} ),
+	};
+
+	constructor( props ) {
+		super( props );
+		const shippingTax = getOrderShippingTax( props.order );
+		this.state = {
+			quantities: [],
+			shippingTotal: parseFloat( shippingTax ) + parseFloat( props.order.shipping_total ),
+		};
+	}
+
+	shouldShowTax = () => {
+		const { order } = this.props;
+		if ( ! order ) {
+			return false;
+		}
+		// If there are any items in `tax_lines`, we have taxes on this order.
+		return !! order.tax_lines.length;
+	};
+
+	recalculateRefund = () => {
+		const { order } = this.props;
+		if ( ! order ) {
+			return 0;
+		}
+		const subtotal = sum(
+			this.state.quantities.map( ( q, i ) => {
+				if ( ! order.line_items[ i ] ) {
+					return 0;
+				}
+
+				const price = parseFloat( order.line_items[ i ].price );
+				if ( order.prices_include_tax ) {
+					return price * q;
+				}
+
+				const tax = getOrderLineItemTax( order, i ) / order.line_items[ i ].quantity;
+				return ( price + tax ) * q;
+			} )
+		);
+		const total = subtotal + ( parseFloat( this.state.shippingTotal ) || 0 );
+		this.props.onChange( total );
+	};
+
+	onChange = event => {
+		if ( 'shipping_total' === event.target.name ) {
+			const shippingTotal = event.target.value.replace( /[^0-9,.]/g, '' );
+			this.setState( { shippingTotal }, this.recalculateRefund );
+		} else {
+			// Name is `quantity-x`, where x is the ID in the line_items array
+			const i = event.target.name.split( '-' )[ 1 ];
+			const newQuants = this.state.quantities;
+			newQuants[ i ] = event.target.value;
+			this.setState( { quantities: newQuants }, this.recalculateRefund );
+		}
+	};
+
+	renderTableHeader = () => {
+		const { translate } = this.props;
+		return (
+			<TableRow className="order-payment__header order-details__header">
+				<TableItem isHeader className="order-payment__item-product order-details__item-product">
+					{ translate( 'Product' ) }
+				</TableItem>
+				<TableItem isHeader className="order-payment__item-cost order-details__item-cost">
+					{ translate( 'Cost' ) }
+				</TableItem>
+				<TableItem isHeader className="order-payment__item-quantity order-details__item-quantity">
+					{ translate( 'Quantity' ) }
+				</TableItem>
+				<TableItem isHeader className="order-payment__item-tax order-details__item-tax">
+					{ translate( 'Tax' ) }
+				</TableItem>
+				<TableItem isHeader className="order-payment__item-total order-details__item-total">
+					{ translate( 'Total' ) }
+				</TableItem>
+			</TableRow>
+		);
+	};
+
+	renderOrderItems = ( item, i ) => {
+		const { order } = this.props;
+		const tax = getOrderLineItemTax( order, i );
+		return (
+			<TableRow key={ i } className="order-payment__items order-details__items">
+				<TableItem isRowHeader className="order-payment__item-product order-details__item-product">
+					<span className="order-payment__item-link order-details__item-link">{ item.name }</span>
+					<span className="order-payment__item-sku order-details__item-sku">{ item.sku }</span>
+				</TableItem>
+				<TableItem className="order-payment__item-cost order-details__item-cost">
+					{ formatCurrency( item.price, order.currency ) }
+				</TableItem>
+				<TableItem className="order-payment__item-quantity order-details__item-quantity">
+					<FormTextInput
+						type="number"
+						name={ `quantity-${ i }` }
+						onChange={ this.onChange }
+						min="0"
+						max={ item.quantity }
+						value={ this.state.quantities[ i ] || 0 }
+					/>
+				</TableItem>
+				<TableItem className="order-payment__item-tax order-details__item-tax">
+					{ formatCurrency( tax, order.currency ) }
+				</TableItem>
+				<TableItem className="order-payment__item-total order-details__item-total">
+					{ formatCurrency( item.total, order.currency ) }
+				</TableItem>
+			</TableRow>
+		);
+	};
+
+	render() {
+		const { order, translate } = this.props;
+		if ( ! order ) {
+			return null;
+		}
+
+		const showTax = this.shouldShowTax();
+		const totalsClasses = classnames( {
+			'order-payment__totals order-details__totals': true,
+			'has-taxes': showTax,
+			'is-refund-modal': true,
+		} );
+		const refundValue = getRefundedTotal( order );
+
+		return (
+			<div>
+				<Table
+					className="order-payment__table order-details__table"
+					header={ this.renderTableHeader() }
+				>
+					{ order.line_items.map( this.renderOrderItems ) }
+				</Table>
+
+				<div className={ totalsClasses }>
+					<OrderTotalRow
+						currency={ order.currency }
+						label={ translate( 'Discount' ) }
+						value={ order.discount_total }
+						taxValue={ getOrderDiscountTax( order ) }
+						showTax={ showTax }
+					/>
+					<OrderTotalRow
+						isEditable
+						currency={ order.currency }
+						label={ translate( 'Shipping' ) }
+						value={ this.state.shippingTotal }
+						name="shipping_total"
+						onChange={ this.onChange }
+					/>
+					<OrderTotalRow
+						className="order-payment__total-full order-details__total-full"
+						currency={ order.currency }
+						label={ translate( 'Total' ) }
+						value={ order.total }
+						taxValue={ getOrderTotalTax( order ) }
+						showTax={ showTax }
+					/>
+					{ !! refundValue && (
+						<OrderTotalRow
+							className="order-payment__total-refund order-details__total-refund"
+							currency={ order.currency }
+							label={ translate( 'Refunded' ) }
+							value={ refundValue }
+							showTax={ showTax }
+						/>
+					) }
+				</div>
+			</div>
+		);
+	}
+}
+
+export default localize( OrderRefundTable );

--- a/client/extensions/woocommerce/app/order/order-payment/table.js
+++ b/client/extensions/woocommerce/app/order/order-payment/table.js
@@ -156,7 +156,8 @@ class OrderRefundTable extends Component {
 
 		const showTax = this.shouldShowTax();
 		const totalsClasses = classnames( {
-			'order-payment__totals order-details__totals': true,
+			'order-payment__totals': true,
+			'order-details__totals': true,
 			'has-taxes': showTax,
 			'is-refund-modal': true,
 		} );

--- a/client/extensions/woocommerce/app/order/order-payment/table.js
+++ b/client/extensions/woocommerce/app/order/order-payment/table.js
@@ -16,9 +16,9 @@ import FormTextInput from 'components/forms/form-text-input';
 import {
 	getOrderDiscountTax,
 	getOrderLineItemTax,
+	getOrderRefundTotal,
 	getOrderShippingTax,
 	getOrderTotalTax,
-	getRefundedTotal,
 } from 'woocommerce/lib/order-values';
 import OrderTotalRow from '../order-details/row-total';
 import Table from 'woocommerce/components/table';
@@ -160,7 +160,7 @@ class OrderRefundTable extends Component {
 			'has-taxes': showTax,
 			'is-refund-modal': true,
 		} );
-		const refundValue = getRefundedTotal( order );
+		const refundValue = getOrderRefundTotal( order );
 
 		return (
 			<div>


### PR DESCRIPTION
This PR moves a lot of the refund-related code out of `OrderDetailsTable` and into new components in `order-payment`. This creates a separate component to hold the dialog code, which simplifies the `OrderPaymentCard`, and a new component for the table of products shown when refunding (with editable quantities).

The existing `OrderDetailsTable` will need to be updated to handle the editing orders UI, with product addition and deletion, and to work with the new redux UI state for pending edits. It seems easier to pull out the refund table view into a separate table to keep that functionality, rather than create some kind of "tri-state" table (view, edit, and refund).

There should be no visual changes here. **Note:** This is based off #18633, not master.

**To test**

- View an order
- Open the refunds modal
- Submit a refund, with or without notes
- Start to create a refund, but cancel out
- Make sure refunding works as expected