### PR TITLE
Reader Tracks: add tracking to clicking comment timestamp (permalink)

### DIFF
--- a/client/blocks/comments/post-comment.jsx
+++ b/client/blocks/comments/post-comment.jsx
@@ -17,7 +17,7 @@ import { isEnabled } from 'config';
 import { getCurrentUser } from 'state/current-user/selectors';
 import PostTime from 'reader/post-time';
 import Gravatar from 'components/gravatar';
-import { recordAction, recordGaEvent, recordTrack } from 'reader/stats';
+import { recordAction, recordGaEvent, recordTrack, recordPermalinkClick } from 'reader/stats';
 import { getStreamUrl } from 'reader/route';
 import PostCommentContent from './post-comment-content';
 import PostCommentForm from './form';
@@ -118,6 +118,19 @@ class PostComment extends React.PureComponent {
 			comment_id: this.props.commentId,
 			author_url: event.target.href,
 		} );
+	};
+
+	handleCommentPermalinkClick = event => {
+		recordPermalinkClick(
+			'timestamp_comment',
+			{},
+			{
+				blog_id: this.props.post.site_ID,
+				post_id: this.props.post.ID,
+				comment_id: this.props.commentId,
+				author_url: event.target.href,
+			}
+		);
 	};
 
 	getAllChildrenIds = id => {
@@ -399,7 +412,7 @@ class PostComment extends React.PureComponent {
 						</span>
 					) }
 					<div className="comments__comment-timestamp">
-						<a href={ comment.URL }>
+						<a href={ comment.URL } onClick={ this.handleCommentPermalinkClick }>
 							<PostTime date={ comment.date } />
 						</a>
 					</div>

--- a/client/blocks/comments/post-comment.jsx
+++ b/client/blocks/comments/post-comment.jsx
@@ -412,7 +412,12 @@ class PostComment extends React.PureComponent {
 						</span>
 					) }
 					<div className="comments__comment-timestamp">
-						<a href={ comment.URL } onClick={ this.handleCommentPermalinkClick }>
+						<a
+							href={ comment.URL }
+							target="_blank"
+							rel="noopener noreferrer"
+							onClick={ this.handleCommentPermalinkClick }
+						>
 							<PostTime date={ comment.date } />
 						</a>
 					</div>

--- a/client/reader/stats.js
+++ b/client/reader/stats.js
@@ -22,20 +22,21 @@ export function recordGaEvent( action, label, value ) {
 	ga.recordEvent( 'Reader', action, label, value );
 }
 
-export function recordPermalinkClick( where, post ) {
+export function recordPermalinkClick( source, post, eventProperties = {} ) {
 	mc.bumpStat( {
 		reader_actions: 'visited_post_permalink',
-		reader_permalink_source: where,
+		reader_permalink_source: source,
 	} );
-	recordGaEvent( 'Clicked Post Permalink', where );
+	recordGaEvent( 'Clicked Post Permalink', source );
 	const trackEvent = 'calypso_reader_permalink_click';
-	const args = {
-		source: where,
-	};
+
+	// Add source as Tracks event property
+	eventProperties = Object.assign( { source: source }, eventProperties );
+
 	if ( post ) {
-		recordTrackForPost( trackEvent, post, args );
+		recordTrackForPost( trackEvent, post, eventProperties );
 	} else {
-		recordTrack( trackEvent, args );
+		recordTrack( trackEvent, eventProperties );
 	}
 }
 

--- a/client/reader/stats.js
+++ b/client/reader/stats.js
@@ -31,7 +31,7 @@ export function recordPermalinkClick( source, post, eventProperties = {} ) {
 	const trackEvent = 'calypso_reader_permalink_click';
 
 	// Add source as Tracks event property
-	eventProperties = Object.assign( { source: source }, eventProperties );
+	eventProperties = Object.assign( { source }, eventProperties );
 
 	if ( post ) {
 		recordTrackForPost( trackEvent, post, eventProperties );


### PR DESCRIPTION
Adds tracking to the the comment timestamp (a permalink to the front-end site's comment). Also adjusts the stats method `recordPermalinkClick()` to be more flexible to non-post tracking.