### PR TITLE
Styles: update body font size to 16

### DIFF
--- a/assets/stylesheets/_main.scss
+++ b/assets/stylesheets/_main.scss
@@ -127,7 +127,7 @@ body.rtl,
 
 body {
 	color: $gray-dark;
-	font-size: 15px;
+	font-size: 16px;
 	line-height: 1.5;
 }
 

--- a/assets/stylesheets/shared/_reset.scss
+++ b/assets/stylesheets/shared/_reset.scss
@@ -17,7 +17,6 @@ table, caption, tbody, tfoot, thead, tr, th, td {
 	vertical-align: baseline;
 }
 html {
-	font-size: 62.5%; /* Corrects text resizing oddly in IE6/7 when body font-size is set using em units http://clagnut.com/blog/348/#c790 */
 	overflow-y: scroll; /* Keeps page centred in all browsers regardless of content height */
 	-webkit-text-size-adjust: 100%; /* Prevents iOS text size adjust after orientation change, without disabling user zoom */
 	-ms-text-size-adjust: 100%; /* www.456bereastreet.com/archive/201012/controlling_text_size_in_safari_for_ios_without_disabling_user_zoom/ */


### PR DESCRIPTION
The body font size is currently 15, which is not good for a harmonious scale. This PR:
- removes downsizing in html to 10px
- updates the body size to 16 to achieve a correct rhythm that also follows typography standards in Calypso as specified in https://wordpress.com/design-handbook/typography/