### PR TITLE
Media: Re-add style for media modal to components stylesheet

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -440,6 +440,7 @@
 @import 'my-sites/domains/domain-management/email/style';
 @import 'my-sites/domains/domain-management/components/icann-verification/style';
 @import 'notifications/style';
+@import 'post-editor/media-modal/style';
 @import 'reader/discover/style';
 @import 'reader/following/style';
 @import 'reader/following-manage/style';


### PR DESCRIPTION
This is a temporary fix for #18641. In #18500, we moved some stylesheets into a dedicated bundle. This included the stylesheet for `post-editor/media-modal/style`. This works for the editor because we have specified the CSS section that should be used for that specific route. You can see that in [wordpress-com.js here](https://github.com/Automattic/wp-calypso/blob/master/client/wordpress-com.js#L233). The /media route [does not have a specified CSS section](https://github.com/Automattic/wp-calypso/blob/master/client/wordpress-com.js#L65) so the CSS is not getting loaded. This is causing some appearance and functional issues with the image editor from /media. As a temporary fix, I re-added the stylesheet to `_components.scss`.

## To test
1. Load this branch
2. Visit http://calypso.localhost:3000/media/
3. Click on an image and then click "Edit" in the media toolbar.

You should see the appropriate media modal with only one image and one edit button compared to master where you would see two of each (among other issues).

## Screenshots

**Original**
<img width="1238" alt="screen shot 2017-10-07 at 12 00 16 pm" src="https://user-images.githubusercontent.com/7240478/31310551-204ea7da-ab57-11e7-9cb1-3eaf12f45ba9.png">

**Fixed**
<img width="1054" alt="screen shot 2017-10-07 at 12 00 25 pm" src="https://user-images.githubusercontent.com/7240478/31310554-2dfca562-ab57-11e7-8343-e5212b989964.png">

