### PR TITLE
Editor Ground Control: Hide Save Status element when it is empty.

### DIFF
--- a/client/post-editor/editor-ground-control/index.jsx
+++ b/client/post-editor/editor-ground-control/index.jsx
@@ -152,16 +152,10 @@ export class EditorGroundControl extends PureComponent {
 		return buttonLabels[ primaryButtonState ];
 	}
 
-	getSaveStatusLabel( translate ) {
-		if ( this.props.isSaving ) {
-			return translate( 'Saving…' );
-		}
+	shouldShowStatusLabel() {
+		const { isSaving, post } = this.props;
 
-		if ( ! this.props.post || postUtils.isPublished( this.props.post ) || ! this.props.post.ID ) {
-			return null;
-		}
-
-		return translate( 'Saved' );
+		return isSaving || ( post && post.ID && ! postUtils.isPublished( post ) );
 	}
 
 	isSaveEnabled() {
@@ -264,6 +258,10 @@ export class EditorGroundControl extends PureComponent {
 	}
 
 	render() {
+		const { isSaving, translate } = this.props;
+		const isSaveEnabled = this.isSaveEnabled();
+		const shouldShowStatusLabel = this.shouldShowStatusLabel();
+
 		return (
 			<Card className="editor-ground-control">
 				<Button
@@ -271,7 +269,7 @@ export class EditorGroundControl extends PureComponent {
 					className="editor-ground-control__back"
 					href={ '' }
 					onClick={ page.back.bind( page, this.props.allPostsUrl ) }
-					aria-label={ this.props.translate( 'Go back' ) }
+					aria-label={ translate( 'Go back' ) }
 				>
 					<Gridicon icon="arrow-left" />
 				</Button>
@@ -294,29 +292,32 @@ export class EditorGroundControl extends PureComponent {
 						/>
 						{ this.getVerificationNoticeLabel() }{' '}
 						<span className="editor-ground-control__email-verification-notice-more">
-							{ this.props.translate( 'Learn More' ) }
+							{ translate( 'Learn More' ) }
 						</span>
 					</div>
 				) }
-				<div className="editor-ground-control__status">
-					{ this.isSaveEnabled() && (
-						<button
-							className="editor-ground-control__save button is-link"
-							onClick={ this.onSaveButtonClick }
-							tabIndex={ 3 }
-						>
-							{ this.props.translate( 'Save' ) }
-						</button>
-					) }
-					{ ! this.isSaveEnabled() && (
-						<span
-							className="editor-ground-control__save-status"
-							data-e2e-status={ this.getSaveStatusLabel( identity ) }
-						>
-							{ this.getSaveStatusLabel( this.props.translate ) }
-						</span>
-					) }
-				</div>
+				{ ( isSaveEnabled || shouldShowStatusLabel ) && (
+					<div className="editor-ground-control__status">
+						{ isSaveEnabled && (
+							<button
+								className="editor-ground-control__save button is-link"
+								onClick={ this.onSaveButtonClick }
+								tabIndex={ 3 }
+							>
+								{ translate( 'Save' ) }
+							</button>
+						) }
+						{ ! isSaveEnabled &&
+						shouldShowStatusLabel && (
+							<span
+								className="editor-ground-control__save-status"
+								data-e2e-status={ isSaving ? 'Saving…' : 'Saved' }
+							>
+								{ isSaving ? translate( 'Saving…' ) : translate( 'Saved' ) }
+							</span>
+						) }
+					</div>
+				) }
 				{ this.renderGroundControlActionButtons() }
 			</Card>
 		);

--- a/client/post-editor/editor-ground-control/style.scss
+++ b/client/post-editor/editor-ground-control/style.scss
@@ -49,7 +49,6 @@
 	display: flex;
 	min-height: 20px;
 	justify-content: space-between;
-	margin: 0 auto 0 0;
 	position: relative;
 	border-left: 1px solid lighten( $gray, 25% );
 	padding-left: 16px;
@@ -60,6 +59,7 @@
 }
 
 .editor-ground-control__action-buttons {
+	margin-left: auto;
 	align-items: center;
 	display: flex;
 	flex-wrap: wrap;


### PR DESCRIPTION
### Summary
This PR makes some very minor changes to how the Editor Ground Control Header renders it's content. The main aim here is to remove the excess 16px of padding that is left over when the save/saving... status is empty.

### Context
These changes are a precursor to another PR ( #18484 ) that I'll be opening soon that adds another button along side. The extra 16px padding, plus the 16px padding of the new button, make the new button look 'off' unless there is some save status to show.

### Testing
Note: I'm in an airport at the time of writing this and I'm not able to test for some reason. I tested earlier and all seemed fine but I can't confidently remove the 'in progress' status label just yet in case this test plan needs some tweaking.

- Create a new post and go to the editor
- Note that there is no 'save status'
- Inspect the `editor-ground-control` element and note that there is no `editor-ground-control__status` child element as there was before.
- Make a few edits, waiting in between each change to watch the 'save status'
- Note that the post will be autosaved, denoted by a 'Saving...' label.
- Once saved, the label will reflect that state by showing 'Saved'
