### PR TITLE
My-Sites: SharingButtonsLabelEditor: i18n codemod fix

### DIFF
--- a/client/my-sites/sharing/buttons/label-editor.jsx
+++ b/client/my-sites/sharing/buttons/label-editor.jsx
@@ -5,6 +5,7 @@
  */
 
 import PropTypes from 'prop-types';
+import { localize } from 'i18n-calypso';
 import React from 'react';
 import classNames from 'classnames';
 
@@ -13,60 +14,59 @@ import classNames from 'classnames';
  */
 import { decodeEntities } from 'lib/formatting';
 
-var SharingButtonsLabelEditor = ( module.exports = React.createClass( {
-	displayName: 'SharingButtonsLabelEditor',
+const closeKeyCodes = [
+	13, // Return
+	27, // Escape
+];
 
-	propTypes: {
+class SharingButtonsLabelEditor extends React.Component {
+	static displayName = 'SharingButtonsLabelEditor';
+
+	static propTypes = {
 		active: PropTypes.bool,
 		value: PropTypes.string,
 		onChange: PropTypes.func,
 		onClose: PropTypes.func,
 		hasEnabledButtons: PropTypes.bool,
-	},
+	};
 
-	statics: {
-		closeKeyCodes: [
-			13, // Return
-			27, // Escape
-		],
-	},
+	static defaultProps = {
+		active: false,
+		value: '',
+		onChange: function() {},
+		onClose: function() {},
+		hasEnabledButtons: true,
+	};
 
-	getDefaultProps: function() {
-		return {
-			active: false,
-			value: '',
-			onChange: function() {},
-			onClose: function() {},
-			hasEnabledButtons: true,
-		};
-	},
-
-	onKeyDown: function( event ) {
-		if ( -1 !== SharingButtonsLabelEditor.closeKeyCodes.indexOf( event.keyCode ) ) {
+	onKeyDown = event => {
+		if ( -1 !== closeKeyCodes.indexOf( event.keyCode ) ) {
 			event.target.blur();
 			event.preventDefault();
 			this.props.onClose();
 		}
-	},
+	};
 
-	onInputChange: function( event ) {
+	onInputChange = event => {
 		this.props.onChange( event.target.value );
-	},
+	};
 
-	getNoButtonsNoticeElement: function() {
+	getNoButtonsNoticeElement = () => {
 		if ( ! this.props.hasEnabledButtons ) {
 			return (
 				<em className="sharing-buttons-preview__panel-notice">
-					{ this.translate( "This text won't appear until you add at least one sharing button.", {
-						context: 'Sharing: Buttons',
-					} ) }
+					{ this.props.translate(
+						"This text won't appear until you add at least one sharing button.",
+						{
+							context: 'Sharing: Buttons',
+						}
+					) }
 				</em>
 			);
 		}
-	},
+	};
 
-	render: function() {
-		var classes = classNames(
+	render() {
+		const classes = classNames(
 			'sharing-buttons-preview__panel',
 			'is-top',
 			'sharing-buttons-label-editor',
@@ -79,10 +79,10 @@ var SharingButtonsLabelEditor = ( module.exports = React.createClass( {
 			<div className={ classes }>
 				<div className="sharing-buttons-preview__panel-content">
 					<h3 className="sharing-buttons-preview__panel-heading">
-						{ this.translate( 'Edit label text', { context: 'Sharing: buttons' } ) }
+						{ this.props.translate( 'Edit label text', { context: 'Sharing: buttons' } ) }
 					</h3>
 					<p className="sharing-buttons-preview__panel-instructions">
-						{ this.translate( 'Change the text of the sharing buttons label' ) }
+						{ this.props.translate( 'Change the text of the sharing buttons label' ) }
 					</p>
 					<input
 						type="text"
@@ -95,10 +95,12 @@ var SharingButtonsLabelEditor = ( module.exports = React.createClass( {
 				</div>
 				<footer className="sharing-buttons-preview__panel-actions">
 					<button type="button" className="button" onClick={ this.props.onClose }>
-						{ this.translate( 'Close' ) }
+						{ this.props.translate( 'Close' ) }
 					</button>
 				</footer>
 			</div>
 		);
-	},
-} ) );
+	}
+}
+
+export default localize( SharingButtonsLabelEditor );


### PR DESCRIPTION
Pre-emptive fix factored out of https://github.com/Automattic/wp-calypso/pull/18590

The i18n codemod uses the `localize` function to add props. This function does not hoist static methods on the component. More conversation about that in https://github.com/Automattic/wp-calypso/pull/18590#issuecomment-334708986.

It turns out static methods used here would have eventually been made legit by the `react-create-class` codemod because they were only used internally. Until then we get this error:

![screen shot 2017-10-09 at 12 56 46 pm](https://user-images.githubusercontent.com/1922453/31322613-797bbe96-acf7-11e7-8c24-dbbd1a0839aa.png)

### Fix
Make this a Component. Seeing how the static method in question was simply an internally used object, I added it as a `const` above the class definition.

### Test
http://calypso.localhost:3000/sharing/buttons/<my-cool-site>
1. Click "Edit Label Text"
2. Press a key, any key
3. Ensure no errors are logged to the console

### Failing CI tests
My favorite linting rule fails.
```
error  className should follow CSS namespace guidelines
```
The whole folder structure would need to be re-worked in order to avoid confusion with the `button__` prefix. I'm skipping this for now. How are we handling this btw? 

