### PR TITLE
My-Sites: Fix Tracks name on single-site jetpack error

### DIFF
--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -8,7 +8,7 @@ import page from 'page';
 import ReactDom from 'react-dom';
 import React from 'react';
 import i18n from 'i18n-calypso';
-import { uniq, some, startsWith, omit } from 'lodash';
+import { uniq, some, startsWith } from 'lodash';
 
 /**
  * Internal Dependencies
@@ -342,10 +342,13 @@ module.exports = {
 					} )
 				);
 
-				analytics.tracks.recordEvent(
-					'calypso_my-sites_single_site_jetpack_connection_error',
-					omit( currentUser, 'meta' )
-				);
+				const { username, primary_blog, primary_blog_url, primary_blog_is_jetpack } = currentUser;
+				analytics.tracks.recordEvent( 'calypso_mysites_single_site_jetpack_connection_error', {
+					username,
+					primary_blog,
+					primary_blog_url,
+					primary_blog_is_jetpack,
+				} );
 			}
 		}
 


### PR DESCRIPTION
[A previous PR](https://github.com/Automattic/wp-calypso/pull/18382) introduced a Tracks events named incorrectly. Specifically:
* inclusion of a dash in the event name (instead of underscore)
* payload object with property names containing a capital letter

This addresses those issues.