### PR TITLE
Domains: make getTld parsing a little smarter

### DIFF
--- a/client/lib/domains/index.js
+++ b/client/lib/domains/index.js
@@ -12,6 +12,8 @@ import { some, includes, find } from 'lodash';
  */
 import wpcom from 'lib/wp';
 import { type as domainTypes, domainAvailability } from './constants';
+import { parseDomainAgainstTldList } from './utils';
+import wpcomMultiLevelTlds from './tlds/wpcom-multi-level-tlds.json';
 
 const GOOGLE_APPS_INVALID_TLDS = [ 'in' ],
 	GOOGLE_APPS_BANNED_PHRASES = [ 'google' ];
@@ -144,10 +146,31 @@ function hasMappedDomain( domains ) {
 	return getMappedDomains( domains ).length > 0;
 }
 
+/**
+ * Parse the tld from a given domain name, semi-naively. The function
+ * first parses against a list of tlds that have been sold on WP.com
+ * and falls back to a simplistic "everything after the last dot" approach
+ * if the whitelist failed. This is ultimately not comprehensive as that
+ * is a poor base assumption (lots of second level tlds, etc). However,
+ * for our purposes, the approach should be "good enough" for a long time.
+ *
+ * @param {string}     domainName     The domain name parse the tld from
+ * @return {string}                   The TLD or an empty string
+ */
 function getTld( domainName ) {
 	const lastIndexOfDot = domainName.lastIndexOf( '.' );
 
-	return lastIndexOfDot !== -1 && domainName.substring( lastIndexOfDot + 1 );
+	if ( lastIndexOfDot === -1 ) {
+		return '';
+	}
+
+	let tld = parseDomainAgainstTldList( domainName, wpcomMultiLevelTlds );
+
+	if ( ! tld ) {
+		tld = domainName.substring( lastIndexOfDot + 1 );
+	}
+
+	return tld;
 }
 
 export {

--- a/client/lib/domains/tlds/wpcom-multi-level-tlds.json
+++ b/client/lib/domains/tlds/wpcom-multi-level-tlds.json
@@ -1,0 +1,10 @@
+{
+    "co.in": 1,
+    "com.br": 0,
+    "firm.in": 1,
+    "gen.in": 1,
+    "ind.in": 1,
+    "net.br": 0,
+    "net.in": 1,
+    "org.in": 1
+}

--- a/client/lib/domains/utils.js
+++ b/client/lib/domains/utils.js
@@ -3,8 +3,7 @@
  *
  * @format
  */
-
-import { isEmpty, find, values } from 'lodash';
+import { drop, isEmpty, join, find, split, values } from 'lodash';
 
 /**
  * Internal dependencies
@@ -56,4 +55,19 @@ function getDomainNameFromReceiptOrCart( receipt, cart ) {
 	return null;
 }
 
-export { getDomainNameFromReceiptOrCart, getDomainType };
+function parseDomainAgainstTldList( domainFragment, tldList ) {
+	if ( ! domainFragment ) {
+		return '';
+	}
+
+	if ( tldList[ domainFragment ] !== undefined ) {
+		return domainFragment;
+	}
+
+	const parts = split( domainFragment, '.' );
+	const suffix = join( drop( parts ), '.' );
+
+	return parseDomainAgainstTldList( suffix, tldList );
+}
+
+export { getDomainNameFromReceiptOrCart, getDomainType, parseDomainAgainstTldList };


### PR DESCRIPTION
TLDs can be second or even third level which means “everything after the last dot” is an unsafe assumption when trying to parse a TLD out of a string. The only safe way really is to parse against a whitelist. The problem, unfortunately, is that list is 150 KB uncompressed which is way overkill for what we do in Calypso.

So! This approach uses a stripped down whitelist (5 KB uncompressed, 1 KB gzipped) and falls back to the naive “after last dot” parsing if it fails. I think this will get us where we need to be for a long time on the client side.