### PR TITLE
PostEditor: Use this.props.moment

### DIFF
--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -999,8 +999,8 @@ export const PostEditor = React.createClass( {
 			return;
 		}
 
-		const currentDate = this.moment( date );
-		const modifiedDate = this.moment( savedPost.date );
+		const currentDate = this.props.moment( date );
+		const modifiedDate = this.props.moment( savedPost.date );
 		const dateChange = ! (
 			currentDate.get( 'date' ) === modifiedDate.get( 'date' ) &&
 			currentDate.get( 'month' ) === modifiedDate.get( 'month' ) &&


### PR DESCRIPTION
Another pre-emptive fix from #18590. `PostEditor` [is `localize()`d already](https://github.com/Automattic/wp-calypso/blob/85156842837d092d4c95f80c1b6fdc9def9cc7b9/client/post-editor/post-editor.jsx#L1415), but was still using `this.moment()` instead of `this.props.moment()`.

To test:
Verify that the editor still works, in particular whatever uses that date calculation: On an already published post, try setting a past and/or a future publishing date; you should get a warning reading `'Are you sure about that? If you change the date, existing links to your post will stop working.`