### PR TITLE
Cart: Turn cart-messages-mixin into component

### DIFF
--- a/client/my-sites/checkout/cart/cart-messages.jsx
+++ b/client/my-sites/checkout/cart/cart-messages.jsx
@@ -115,6 +115,10 @@ class CartMessages extends PureComponent {
 			);
 		}
 	}
+
+	render() {
+		return null;
+	}
 }
 
 export default localize( CartMessages );

--- a/client/my-sites/checkout/cart/cart-messages.jsx
+++ b/client/my-sites/checkout/cart/cart-messages.jsx
@@ -1,11 +1,11 @@
+/** @format */
 /**
  * External dependencies
- *
- * @format
  */
-
-import React from 'react';
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
 import { isEmpty } from 'lodash';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -13,12 +13,22 @@ import { isEmpty } from 'lodash';
 import notices from 'notices';
 import { getNewMessages } from 'lib/cart-values';
 
-export default {
+class CartMessages extends PureComponent {
+	static propTypes = {
+		cart: PropTypes.object.isRequired,
+		selectedSite: PropTypes.object.isRequired,
+
+		// connected
+		translate: PropTypes.func.isRequired,
+	};
+
+	state = { previousCart: null };
+
 	componentDidMount() {
 		// Makes sure that we display any messages from the current cart
 		// that might have been delivered when the cart was unmounted
 		this.displayCartMessages( this.props.cart );
-	},
+	}
 
 	componentWillReceiveProps( nextProps ) {
 		if ( ! nextProps.cart.hasLoadedFromServer ) {
@@ -28,7 +38,7 @@ export default {
 		if ( this.props.cart.messages !== nextProps.cart.messages ) {
 			this.displayCartMessages( nextProps.cart );
 		}
-	},
+	}
 
 	getChargebackErrorMessage() {
 		return this.props.translate(
@@ -42,7 +52,7 @@ export default {
 				},
 			}
 		);
-	},
+	}
 
 	getBlockedPurchaseErrorMessage() {
 		return this.props.translate(
@@ -61,7 +71,7 @@ export default {
 				},
 			}
 		);
-	},
+	}
 
 	getPrettyErrorMessages( messages ) {
 		if ( ! messages ) {
@@ -80,11 +90,11 @@ export default {
 					return error;
 			}
 		} );
-	},
+	}
 
 	displayCartMessages( newCart ) {
-		const previousCart = this.state ? this.state.previousCart : null,
-			messages = getNewMessages( previousCart, newCart );
+		const { previousCart } = this.state;
+		const messages = getNewMessages( previousCart, newCart );
 
 		messages.errors = this.getPrettyErrorMessages( messages.errors );
 
@@ -104,5 +114,7 @@ export default {
 				) )
 			);
 		}
-	},
-};
+	}
+}
+
+export default localize( CartMessages );

--- a/client/my-sites/checkout/cart/popover-cart.jsx
+++ b/client/my-sites/checkout/cart/popover-cart.jsx
@@ -16,7 +16,7 @@ import Gridicon from 'gridicons';
  */
 import CartBody from './cart-body';
 import CartBodyLoadingPlaceholder from './cart-body/loading-placeholder';
-import CartMessagesMixin from './cart-messages-mixin';
+import CartMessages from './cart-messages';
 import CartButtons from './cart-buttons';
 import Count from 'components/count';
 import Popover from 'components/popover';
@@ -45,9 +45,8 @@ const PopoverCart = React.createClass( {
 		return reject( this.props.cart.products, isCredits ).length;
 	},
 
-	mixins: [ CartMessagesMixin ],
-
 	render: function() {
+		const { cart, selectedSite } = this.props;
 		let countBadge;
 		const classes = classNames( {
 			'popover-cart': true,
@@ -65,6 +64,7 @@ const PopoverCart = React.createClass( {
 
 		return (
 			<div>
+				<CartMessages cart={ cart } selectedSite={ selectedSite } />
 				<div className={ classes }>
 					<button className="cart-toggle-button" ref="toggleButton" onClick={ this.onToggle }>
 						<div className="popover-cart__label">{ this.props.translate( 'Cart' ) }</div>

--- a/client/my-sites/checkout/cart/secondary-cart.jsx
+++ b/client/my-sites/checkout/cart/secondary-cart.jsx
@@ -15,7 +15,7 @@ import classNames from 'classnames';
  * Internal dependencies
  */
 import CartBody from 'my-sites/checkout/cart/cart-body';
-import CartMessagesMixin from './cart-messages-mixin';
+import CartMessages from './cart-messages';
 import CartSummaryBar from 'my-sites/checkout/cart/cart-summary-bar';
 import CartPlanAd from './cart-plan-ad';
 import CartPlanDiscountAd from './cart-plan-discount-ad';
@@ -31,7 +31,7 @@ const SecondaryCart = React.createClass( {
 		selectedSite: PropTypes.oneOfType( [ PropTypes.bool, PropTypes.object ] ),
 	},
 
-	mixins: [ CartMessagesMixin, observe( 'sites' ) ],
+	mixins: [ observe( 'sites' ) ],
 
 	getInitialState() {
 		return {
@@ -70,6 +70,7 @@ const SecondaryCart = React.createClass( {
 		if ( ! cart.hasLoadedFromServer ) {
 			return (
 				<Sidebar className={ cartClasses }>
+					<CartMessages cart={ cart } selectedSite={ selectedSite } />
 					<CartSummaryBar additionalClasses="cart-header" />
 					<CartBodyLoadingPlaceholder />
 				</Sidebar>
@@ -78,6 +79,7 @@ const SecondaryCart = React.createClass( {
 
 		return (
 			<Sidebar className={ cartClasses }>
+				<CartMessages cart={ cart } selectedSite={ selectedSite } />
 				<CartSummaryBar additionalClasses="cart-header" />
 				<CartPlanAd selectedSite={ selectedSite } cart={ cart } />
 				<CartBody ref="cartBody" cart={ cart } selectedSite={ selectedSite } showCoupon={ true } />


### PR DESCRIPTION
This PR turns cart-messages-mixin into a normal component to be rendered. The usage is very limited and was detected when looking for `this.props.translate` usage in un-localized components, a concern raised in #18590,

## History

Clean up usage of `this.props.{translate,moment,numberFormat}` on components that may not be localized (no `i18n-calypso` import). See #18590 

```
$ ack -L 'i18n-calypso' $( ack -l --js '(?:this\.props\.(?:translate|moment|numberFormat))|(?:(?:var|let|const)\s+\{[^}]*\W(?:translate|moment|numberFormat)\W[^}]*\}\s*=\s*this\.props)' client )

client/extensions/wp-super-cache/components/plugins/index.jsx
client/me/help/help-courses/courses.jsx
client/my-sites/checkout/cart/cart-messages-mixin.jsx
client/my-sites/sharing/connections/services/eventbrite.js
client/my-sites/sharing/connections/services/google-photos.js
client/my-sites/sharing/connections/services/instagram.js
client/my-sites/site-settings/form-discussion.jsx
client/my-sites/site-settings/form-general.jsx
client/my-sites/site-settings/form-writing.jsx
```

### Need review

- [x] `client/extensions/wp-super-cache/components/plugins/index.jsx` (`wrapSettingsForm`)
- [x] `client/me/help/help-courses/courses.jsx` (#18690)
- [x] `client/my-sites/checkout/cart/cart-messages-mixin.jsx`
- [x] `client/my-sites/sharing/connections/services/eventbrite.js` (`connectFor`)
- [x] `client/my-sites/sharing/connections/services/google-photos.js` (`connectFor`)
- [x] `client/my-sites/sharing/connections/services/instagram.js` (`connectFor`)
- [x] `client/my-sites/site-settings/form-discussion.jsx` (`wrapSettingsForm`)
- [x] `client/my-sites/site-settings/form-general.jsx` (`wrapSettingsForm`)
- [x] `client/my-sites/site-settings/form-writing.jsx` (`wrapSettingsForm`)
