### PR TITLE
Store: Omit pending orders from dashboard New Orders widget.

### DIFF
--- a/client/extensions/woocommerce/app/dashboard/index.js
+++ b/client/extensions/woocommerce/app/dashboard/index.js
@@ -10,6 +10,7 @@ import { bindActionCreators } from 'redux';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
+import { find } from 'lodash';
 
 /**
  * Internal dependencies
@@ -168,10 +169,12 @@ function mapStateToProps( state ) {
 	const selectedSite = getSelectedSiteWithFallback( state );
 	const loading =
 		areOrdersLoading( state ) || areSetupChoicesLoading( state ) || areProductsLoading( state );
-	const hasOrders = getOrders( state ).length > 0;
+	const newOrders = getOrders( state );
 	const hasProducts = getTotalProducts( state ) > 0;
 	const productsLoaded = areProductsLoaded( state );
 	const finishedInitialSetup = getFinishedInitialSetup( state );
+	const hasOrders = find( newOrders, { status: 'processing' } );
+
 	return {
 		finishedInitialSetup,
 		finishedInstallOfRequiredPlugins: getFinishedInstallOfRequiredPlugins( state ),

--- a/client/extensions/woocommerce/app/dashboard/index.js
+++ b/client/extensions/woocommerce/app/dashboard/index.js
@@ -10,7 +10,6 @@ import { bindActionCreators } from 'redux';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { find } from 'lodash';
 
 /**
  * Internal dependencies
@@ -24,7 +23,10 @@ import {
 	getFinishedInstallOfRequiredPlugins,
 	getFinishedPageSetup,
 } from 'woocommerce/state/sites/setup-choices/selectors';
-import { areOrdersLoading, getOrders } from 'woocommerce/state/sites/orders/selectors';
+import {
+	areOrdersLoading,
+	getNewOrdersWithoutPayPalPending,
+} from 'woocommerce/state/sites/orders/selectors';
 import { fetchOrders } from 'woocommerce/state/sites/orders/actions';
 import { fetchProducts } from 'woocommerce/state/sites/products/actions';
 import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
@@ -169,11 +171,10 @@ function mapStateToProps( state ) {
 	const selectedSite = getSelectedSiteWithFallback( state );
 	const loading =
 		areOrdersLoading( state ) || areSetupChoicesLoading( state ) || areProductsLoading( state );
-	const newOrders = getOrders( state );
+	const hasOrders = getNewOrdersWithoutPayPalPending( state ).length > 0;
 	const hasProducts = getTotalProducts( state ) > 0;
 	const productsLoaded = areProductsLoaded( state );
 	const finishedInitialSetup = getFinishedInitialSetup( state );
-	const hasOrders = find( newOrders, { status: 'processing' } );
 
 	return {
 		finishedInitialSetup,

--- a/client/extensions/woocommerce/app/dashboard/manage-orders-view.js
+++ b/client/extensions/woocommerce/app/dashboard/manage-orders-view.js
@@ -21,8 +21,8 @@ import { fetchReviews } from 'woocommerce/state/sites/reviews/actions';
 import {
 	areOrdersLoading,
 	areOrdersLoaded,
-	getNewOrders,
-	getNewOrdersRevenue,
+	getNewOrdersWithoutPayPalPending,
+	getNewOrdersWithoutPayPalPendingRevenue,
 } from 'woocommerce/state/sites/orders/selectors';
 import { getCurrentUser } from 'state/current-user/selectors';
 import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
@@ -185,8 +185,8 @@ function mapStateToProps( state ) {
 	const site = getSelectedSiteWithFallback( state );
 	const ordersLoading = areOrdersLoading( state );
 	const ordersLoaded = areOrdersLoaded( state );
-	const orders = getNewOrders( state );
-	const ordersRevenue = getNewOrdersRevenue( state );
+	const orders = getNewOrdersWithoutPayPalPending( state );
+	const ordersRevenue = getNewOrdersWithoutPayPalPendingRevenue( state );
 	const user = getCurrentUser( state );
 	const currency = getPaymentCurrencySettings( state );
 	const pendingReviews = getTotalReviews( state, { status: 'pending' } );

--- a/client/extensions/woocommerce/state/sites/orders/selectors.js
+++ b/client/extensions/woocommerce/state/sites/orders/selectors.js
@@ -215,3 +215,16 @@ export const getNewOrdersRevenue = ( state, siteId = getSelectedSiteId( state ) 
 	const orders = getNewOrders( state, siteId );
 	return sumBy( orders, order => parseFloat( order.total ) );
 };
+
+/**
+ * @param {Object} state Whole Redux state tree
+ * @param {Number} [siteId] Site ID to check. If not provided, the Site ID selected in the UI will be used
+ * @return {Number} Total from all new orders without PayPal Pending Orders.
+ */
+export const getNewOrdersWithoutPayPalPendingRevenue = (
+	state,
+	siteId = getSelectedSiteId( state )
+) => {
+	const orders = getNewOrdersWithoutPayPalPending( state, siteId );
+	return sumBy( orders, order => parseFloat( order.total ) );
+};

--- a/client/extensions/woocommerce/state/sites/orders/selectors.js
+++ b/client/extensions/woocommerce/state/sites/orders/selectors.js
@@ -195,6 +195,20 @@ export const getNewOrders = ( state, siteId = getSelectedSiteId( state ) ) => {
 /**
  * @param {Object} state Whole Redux state tree
  * @param {Number} [siteId] Site ID to check. If not provided, the Site ID selected in the UI will be used
+ * @return {array} List of new orders without PayPal Pending Orders.
+ */
+export const getNewOrdersWithoutPayPalPending = ( state, siteId = getSelectedSiteId( state ) ) => {
+	const orders = getNewOrders( state, siteId );
+
+	return filter( orders, function( order ) {
+		const { status, payment_method } = order;
+		return ! ( 'pending' === status && 'paypal' === payment_method );
+	} );
+};
+
+/**
+ * @param {Object} state Whole Redux state tree
+ * @param {Number} [siteId] Site ID to check. If not provided, the Site ID selected in the UI will be used
  * @return {Number} Total from all new orders.
  */
 export const getNewOrdersRevenue = ( state, siteId = getSelectedSiteId( state ) ) => {

--- a/client/extensions/woocommerce/state/sites/orders/test/selectors.js
+++ b/client/extensions/woocommerce/state/sites/orders/test/selectors.js
@@ -20,6 +20,7 @@ import {
 	isOrderUpdating,
 	getNewOrders,
 	getNewOrdersRevenue,
+	getNewOrdersWithoutPayPalPendingRevenue,
 	getNewOrdersWithoutPayPalPending,
 } from '../selectors';
 import order from './fixtures/order';
@@ -396,6 +397,28 @@ describe( 'selectors', () => {
 			expect( getNewOrdersWithoutPayPalPending( loadedStatePayPal, 321 ) ).to.not.have.members(
 				paypalPendingOrder
 			);
+		} );
+	} );
+
+	describe( '#getNewOrdersWithoutPayPalPendingRevenue', () => {
+		it( 'should be 0 when woocommerce state is not available.', () => {
+			expect( getNewOrdersWithoutPayPalPendingRevenue( preInitializedState, 123 ) ).to.eql( 0 );
+		} );
+
+		it( 'should be 0 when orders are loading.', () => {
+			expect( getNewOrdersWithoutPayPalPendingRevenue( loadingState, 123 ) ).to.eql( 0 );
+		} );
+
+		it( 'should return the total of new orders only', () => {
+			expect( getNewOrdersWithoutPayPalPendingRevenue( loadedStatePayPal, 321 ) ).to.eql( 30.0 );
+		} );
+
+		it( 'should be 0 when orders are loaded only for a different site.', () => {
+			expect( getNewOrdersWithoutPayPalPendingRevenue( loadedState, 456 ) ).to.eql( 0 );
+		} );
+
+		it( 'should get the siteId from the UI tree if not provided and not include PayPal Pending Order.', () => {
+			expect( getNewOrdersWithoutPayPalPendingRevenue( loadedStatePayPal, 321 ) ).to.eql( 30.0 );
 		} );
 	} );
 } );

--- a/client/extensions/woocommerce/state/sites/orders/test/selectors.js
+++ b/client/extensions/woocommerce/state/sites/orders/test/selectors.js
@@ -20,6 +20,7 @@ import {
 	isOrderUpdating,
 	getNewOrders,
 	getNewOrdersRevenue,
+	getNewOrdersWithoutPayPalPending,
 } from '../selectors';
 import order from './fixtures/order';
 import orders from './fixtures/orders';
@@ -82,6 +83,75 @@ const loadedState = {
 							'{}': false,
 						},
 						items: keyBy( [ ...orders, ...additionalOrders ], 'id' ),
+					},
+				},
+			},
+		},
+	},
+};
+
+const paypalPendingOrder = [
+	{
+		id: 40,
+		status: 'pending',
+		currency: 'USD',
+		total: '50.87',
+		total_tax: '0.00',
+		prices_include_tax: false,
+		billing: {},
+		shipping: {},
+		payment_method: 'paypal',
+		payment_method_title: 'PayPal',
+		meta_data: [],
+		line_items: [
+			{
+				id: 12,
+				name: 'Coffee',
+				price: 15.29,
+			},
+		],
+		tax_lines: [],
+		shipping_lines: [
+			{
+				id: 13,
+				method_title: 'Flat rate',
+				method_id: 'flat_rate:2',
+				total: '5.00',
+				total_tax: '0.00',
+				taxes: [],
+			},
+		],
+	},
+];
+
+const loadedStatePayPal = {
+	extensions: {
+		woocommerce: {
+			sites: {
+				123: {
+					orders: {
+						isLoading: {
+							35: false,
+						},
+						isQueryLoading: {
+							'{}': false,
+						},
+						isUpdating: {
+							20: false,
+						},
+						items: keyBy( orders, 'id' ),
+						queries: {
+							'{}': [ 35, 26 ],
+						},
+						total: { '{}': 54 },
+					},
+				},
+				321: {
+					orders: {
+						isQueryLoading: {
+							'{}': false,
+						},
+						items: keyBy( [ ...orders, ...paypalPendingOrder ], 'id' ),
 					},
 				},
 			},
@@ -307,6 +377,25 @@ describe( 'selectors', () => {
 
 		test( 'should get the siteId from the UI tree if not provided.', () => {
 			expect( getNewOrdersRevenue( loadedState, 321 ) ).to.eql( 30.0 );
+		} );
+	} );
+
+	describe( '#getNewOrdersWithoutPayPalPending', () => {
+		it( 'should return an empty array when no data is available', () => {
+			expect( getNewOrdersWithoutPayPalPending( preInitializedState, 123 ) ).to.eql( [] );
+		} );
+
+		it( 'should return an array with proper new order data', () => {
+			expect( getNewOrdersWithoutPayPalPending( loadedState, 321 ) ).to.have.members( orders );
+		} );
+
+		it( 'should not return PayPal payment orders that are pending', () => {
+			expect( getNewOrdersWithoutPayPalPending( loadedStatePayPal, 321 ) ).to.have.members(
+				orders
+			);
+			expect( getNewOrdersWithoutPayPalPending( loadedStatePayPal, 321 ) ).to.not.have.members(
+				paypalPendingOrder
+			);
 		} );
 	} );
 } );

--- a/client/extensions/woocommerce/store-sidebar/index.js
+++ b/client/extensions/woocommerce/store-sidebar/index.js
@@ -20,7 +20,7 @@ import { fetchOrders } from 'woocommerce/state/sites/orders/actions';
 import { fetchProducts } from 'woocommerce/state/sites/products/actions';
 import { fetchReviews } from 'woocommerce/state/sites/reviews/actions';
 import { fetchSetupChoices } from 'woocommerce/state/sites/setup-choices/actions';
-import { getNewOrders } from 'woocommerce/state/sites/orders/selectors';
+import { getNewOrdersWithoutPayPalPending } from 'woocommerce/state/sites/orders/selectors';
 import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
 import { getSetStoreAddressDuringInitialSetup } from 'woocommerce/state/sites/setup-choices/selectors';
 import { getTotalProducts, areProductsLoaded } from 'woocommerce/state/sites/products/selectors';
@@ -257,7 +257,7 @@ class StoreSidebar extends Component {
 function mapStateToProps( state ) {
 	const finishedAddressSetup = getSetStoreAddressDuringInitialSetup( state );
 	const hasProducts = getTotalProducts( state ) > 0;
-	const orders = getNewOrders( state );
+	const orders = getNewOrdersWithoutPayPalPending( state );
 	const productsLoaded = areProductsLoaded( state );
 	const site = getSelectedSiteWithFallback( state );
 	const totalPendingReviews = getTotalReviews( state, { status: 'pending' } );


### PR DESCRIPTION
This PR fixes #18594 - but putting this out here for more discussion on the topic. Currently, when an order is _Pending_ ( i.e. a user goes to PayPal but never pays ), the Dashboard shows the order as "New", and gives the celebratory emoji:

__Before__
![store_ _care_for_animals_ _wordpress_com](https://user-images.githubusercontent.com/22080/31337494-734c7a8e-acb0-11e7-947f-b47674eb9558.png)

As stated in the original issue, these non-paid orders are eventually swept away into the database rubbish bin, after an hour I believe. With this branch applied, the same state above would now look like:

__After__
![store_ _care_for_animals_ _wordpress_com](https://user-images.githubusercontent.com/22080/31337526-918f28b6-acb0-11e7-850b-3ffc48331eb6.png)

Note the Orders indicator in the sidebar still has the old logic - which made me begin to think this was an intentional thing - to treat Payment Pending orders as "new" to the user so maybe they could follow-up with the customer to complete payment ... or? /cc @kellychoffman @jameskoster 

__To Recreate__
- Configure a site with PayPal payment option
- Build a cart/checkout and use PayPal
- Do not remit payment
- Visit the Dashboard, verify the order is not shown as new, and the sidebar count does not show a new order either.
- Then create a new valid order, and verify that the dashboard and sidebar count show as expected.