### PR TITLE
Jetpack Plans: Enable jetpack auto-config Thank You Page v2 in production

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -75,6 +75,7 @@
 		"perfmon": true,
 		"persist-redux": true,
 		"plans/personal-plan": true,
+		"plans/jetpack-config-v2": true,
 		"post-editor/author-selector": true,
 		"post-editor/html-toolbar": true,
 		"post-editor/image-editor": true,


### PR DESCRIPTION
This PR enables the new Jetpack auto-config v2 Thank You Page in **Production**

#### Testing instructions

1. Visit https://wordpress.com.
1. Buy a plan for a Jetpack site that's already connected.
1. Expect to be redirected to the new thank you page and watch it install and autoconfigure the plugins.

