### PR TITLE
Simple Payments: Minor style fix for modal navigation

### DIFF
--- a/client/components/tinymce/plugins/simple-payments/style.scss
+++ b/client/components/tinymce/plugins/simple-payments/style.scss
@@ -99,8 +99,10 @@
 }
 
 .editor-simple-payments-modal__navigation.card {
+	height: 48px;
 	margin: 0;
 	flex: none;
+	z-index: 1;
 }
 
 .editor-simple-payments-modal__form {


### PR DESCRIPTION
This PR intends to fix the missing border and shadow attached to the modal navigation. Also it sets its height so that it's uniform between the list view and the creation view.

Before:
<img width="1212" alt="screen shot 2017-10-09 at 13 24 46" src="https://user-images.githubusercontent.com/908665/31338359-c963ce54-acf6-11e7-81dd-b78a7dfbb46d.png">

After: 
<img width="1220" alt="screen shot 2017-10-09 at 13 24 29" src="https://user-images.githubusercontent.com/908665/31338362-cf13cdd6-acf6-11e7-9670-de1091d9bc76.png">
