### PR TITLE
Comments: add quick actions to the comments list view

### DIFF
--- a/client/blocks/comment-detail/comment-detail-actions.jsx
+++ b/client/blocks/comment-detail/comment-detail-actions.jsx
@@ -13,6 +13,7 @@ import { includes } from 'lodash';
 /**
  * Internal dependencies
  */
+import ButtonGroup from 'components/button-group';
 import Button from 'components/button';
 
 const commentActions = {
@@ -24,7 +25,17 @@ const commentActions = {
 
 const hasAction = ( status, action ) => includes( commentActions[ status ], action );
 
+const CommentDetailActionsContainer = ( { compact, children } ) =>
+	compact ? (
+		<div className="comment-detail__actions is-quick">
+			<ButtonGroup>{ children }</ButtonGroup>
+		</div>
+	) : (
+		<div className="comment-detail__actions">{ children }</div>
+	);
+
 export const CommentDetailActions = ( {
+	compact,
 	commentIsLiked,
 	commentStatus,
 	deleteCommentPermanently,
@@ -40,71 +51,79 @@ export const CommentDetailActions = ( {
 	const isTrash = 'trash' === commentStatus;
 
 	return (
-		<div className="comment-detail__actions">
+		<CommentDetailActionsContainer { ...{ compact } }>
 			{ hasAction( commentStatus, 'like' ) && (
 				<Button
-					borderless
+					{ ...{ borderless: ! compact, compact } }
 					className={ classNames( 'comment-detail__action-like', { 'is-liked': commentIsLiked } ) }
 					onClick={ toggleLike }
 				>
 					<Gridicon icon={ commentIsLiked ? 'star' : 'star-outline' } />
-					<span>{ commentIsLiked ? translate( 'Liked' ) : translate( 'Like' ) }</span>
+					{ compact || (
+						<span>{ commentIsLiked ? translate( 'Liked' ) : translate( 'Like' ) }</span>
+					) }
 				</Button>
 			) }
 
 			{ hasAction( commentStatus, 'approve' ) && (
 				<Button
-					borderless
+					{ ...{ borderless: ! compact, compact } }
 					className={ classNames( 'comment-detail__action-approve', {
 						'is-approved': isApproved,
 					} ) }
 					onClick={ toggleApprove }
 				>
 					<Gridicon icon={ isApproved ? 'checkmark-circle' : 'checkmark' } />
-					<span>{ isApproved ? translate( 'Approved' ) : translate( 'Approve' ) }</span>
+					{ compact || (
+						<span>{ isApproved ? translate( 'Approved' ) : translate( 'Approve' ) }</span>
+					) }
 				</Button>
 			) }
 
 			{ hasAction( commentStatus, 'edit' ) && (
-				<Button borderless className="comment-detail__action-edit" onClick={ toggleEditMode }>
+				<Button
+					{ ...{ borderless: ! compact, compact } }
+					className="comment-detail__action-edit"
+					onClick={ toggleEditMode }
+				>
 					<Gridicon icon="pencil" />
-					<span>{ translate( 'Edit' ) }</span>
+					{ compact || <span>{ translate( 'Edit' ) }</span> }
 				</Button>
 			) }
 
 			{ hasAction( commentStatus, 'spam' ) && (
 				<Button
-					borderless
+					{ ...{ borderless: ! compact, compact } }
 					className={ classNames( 'comment-detail__action-spam', { 'is-spam': isSpam } ) }
 					onClick={ toggleSpam }
 				>
 					<Gridicon icon="spam" />
-					<span>{ isSpam ? translate( 'Spammed' ) : translate( 'Spam' ) }</span>
+					{ compact || <span>{ isSpam ? translate( 'Spammed' ) : translate( 'Spam' ) }</span> }
 				</Button>
 			) }
 
 			{ hasAction( commentStatus, 'trash' ) && (
 				<Button
-					borderless
+					{ ...{ borderless: ! compact, compact } }
 					className={ classNames( 'comment-detail__action-trash', { 'is-trash': isTrash } ) }
 					onClick={ toggleTrash }
 				>
 					<Gridicon icon="trash" />
-					<span>{ isTrash ? translate( 'Trashed' ) : translate( 'Trash' ) }</span>
+					{ compact || <span>{ isTrash ? translate( 'Trashed' ) : translate( 'Trash' ) }</span> }
 				</Button>
 			) }
 
 			{ hasAction( commentStatus, 'delete' ) && (
 				<Button
-					borderless
+					{ ...{ borderless: ! compact, compact } }
 					className="comment-detail__action-delete"
 					onClick={ deleteCommentPermanently }
 				>
 					<Gridicon icon="trash" />
-					<span>{ translate( 'Delete Permanently' ) }</span>
+					{ compact || <span>{ translate( 'Delete Permanently' ) }</span> }
 				</Button>
 			) }
-		</div>
+		</CommentDetailActionsContainer>
 	);
 };
 

--- a/client/blocks/comment-detail/comment-detail-actions.jsx
+++ b/client/blocks/comment-detail/comment-detail-actions.jsx
@@ -53,6 +53,13 @@ export const CommentDetailActions = ( {
 
 	return (
 		<CommentDetailActionsContainer { ...{ compact } }>
+			{ hasAction( commentStatus, 'reply' ) &&
+			compact && (
+				<Button compact={ compact } className="comment-detail__action-edit" onClick={ toggleReply }>
+					<Gridicon icon="reply" />
+				</Button>
+			) }
+
 			{ hasAction( commentStatus, 'like' ) && (
 				<Button
 					{ ...{ borderless: ! compact, compact } }
@@ -90,13 +97,6 @@ export const CommentDetailActions = ( {
 				>
 					<Gridicon icon="pencil" />
 					{ compact || <span>{ translate( 'Edit' ) }</span> }
-				</Button>
-			) }
-
-			{ hasAction( commentStatus, 'reply' ) &&
-			compact && (
-				<Button compact={ compact } className="comment-detail__action-edit" onClick={ toggleReply }>
-					<Gridicon icon="reply" />
 				</Button>
 			) }
 

--- a/client/blocks/comment-detail/comment-detail-actions.jsx
+++ b/client/blocks/comment-detail/comment-detail-actions.jsx
@@ -80,7 +80,8 @@ export const CommentDetailActions = ( {
 				</Button>
 			) }
 
-			{ hasAction( commentStatus, 'edit' ) && (
+			{ hasAction( commentStatus, 'edit' ) &&
+			! compact && (
 				<Button
 					{ ...{ borderless: ! compact, compact } }
 					className="comment-detail__action-edit"

--- a/client/blocks/comment-detail/comment-detail-actions.jsx
+++ b/client/blocks/comment-detail/comment-detail-actions.jsx
@@ -73,7 +73,7 @@ export const CommentDetailActions = ( {
 					} ) }
 					onClick={ toggleApprove }
 				>
-					<Gridicon icon={ isApproved ? 'checkmark-circle' : 'checkmark' } />
+					<Gridicon icon="checkmark-circle" />
 					{ compact || (
 						<span>{ isApproved ? translate( 'Approved' ) : translate( 'Approve' ) }</span>
 					) }

--- a/client/blocks/comment-detail/comment-detail-actions.jsx
+++ b/client/blocks/comment-detail/comment-detail-actions.jsx
@@ -17,8 +17,8 @@ import ButtonGroup from 'components/button-group';
 import Button from 'components/button';
 
 const commentActions = {
-	unapproved: [ 'like', 'approve', 'edit', 'spam', 'trash' ],
-	approved: [ 'like', 'approve', 'edit', 'spam', 'trash' ],
+	unapproved: [ 'like', 'approve', 'edit', 'reply', 'spam', 'trash' ],
+	approved: [ 'like', 'approve', 'edit', 'reply', 'spam', 'trash' ],
 	spam: [ 'approve', 'delete' ],
 	trash: [ 'approve', 'spam', 'delete' ],
 };
@@ -39,6 +39,7 @@ export const CommentDetailActions = ( {
 	commentIsLiked,
 	commentStatus,
 	deleteCommentPermanently,
+	toggleReply,
 	toggleApprove,
 	toggleEditMode,
 	toggleLike,
@@ -89,6 +90,13 @@ export const CommentDetailActions = ( {
 				>
 					<Gridicon icon="pencil" />
 					{ compact || <span>{ translate( 'Edit' ) }</span> }
+				</Button>
+			) }
+
+			{ hasAction( commentStatus, 'reply' ) &&
+			compact && (
+				<Button compact={ compact } className="comment-detail__action-edit" onClick={ toggleReply }>
+					<Gridicon icon="reply" />
 				</Button>
 			) }
 

--- a/client/blocks/comment-detail/comment-detail-actions.jsx
+++ b/client/blocks/comment-detail/comment-detail-actions.jsx
@@ -74,7 +74,7 @@ export const CommentDetailActions = ( {
 					} ) }
 					onClick={ toggleApprove }
 				>
-					<Gridicon icon="checkmark-circle" />
+					<Gridicon icon={ isApproved ? 'checkmark-circle' : 'checkmark' } />
 					{ compact || (
 						<span>{ isApproved ? translate( 'Approved' ) : translate( 'Approve' ) }</span>
 					) }

--- a/client/blocks/comment-detail/comment-detail-header.jsx
+++ b/client/blocks/comment-detail/comment-detail-header.jsx
@@ -45,6 +45,7 @@ export class CommentDetailHeader extends Component {
 			isEditMode,
 			isExpanded,
 			postTitle,
+			toggleReply,
 			toggleApprove,
 			toggleEditMode,
 			toggleExpanded,
@@ -142,6 +143,7 @@ export class CommentDetailHeader extends Component {
 						commentIsLiked={ commentIsLiked }
 						commentStatus={ commentStatus }
 						deleteCommentPermanently={ deleteCommentPermanently }
+						toggleReply={ toggleReply }
 						toggleApprove={ toggleApprove }
 						toggleEditMode={ toggleEditMode }
 						toggleLike={ toggleLike }

--- a/client/blocks/comment-detail/comment-detail-header.jsx
+++ b/client/blocks/comment-detail/comment-detail-header.jsx
@@ -20,6 +20,7 @@ import Gravatar from 'components/gravatar';
 import FormCheckbox from 'components/forms/form-checkbox';
 import { stripHTML, decodeEntities } from 'lib/formatting';
 import { urlToDomainAndPath } from 'lib/url';
+import viewport from 'lib/viewport';
 
 export class CommentDetailHeader extends Component {
 	state = {
@@ -136,7 +137,7 @@ export class CommentDetailHeader extends Component {
 					</div>
 				) }
 
-				{ ( showQuickActions || isExpanded ) &&
+				{ ( ( showQuickActions && ! viewport.isMobile() ) || isExpanded ) &&
 				! isEditMode && (
 					<CommentDetailActions
 						compact={ showQuickActions && ! isExpanded }

--- a/client/blocks/comment-detail/comment-detail-header.jsx
+++ b/client/blocks/comment-detail/comment-detail-header.jsx
@@ -12,6 +12,7 @@ import { noop } from 'lodash';
 /**
  * Internal dependencies
  */
+import { isEnabled } from 'config';
 import AutoDirection from 'components/auto-direction';
 import Button from 'components/button';
 import CommentDetailActions from './comment-detail-actions';
@@ -137,7 +138,10 @@ export class CommentDetailHeader extends Component {
 					</div>
 				) }
 
-				{ ( ( showQuickActions && ! viewport.isMobile() ) || isExpanded ) &&
+				{ ( ( isEnabled( 'comments/management/quick-actions' ) &&
+					showQuickActions &&
+					! viewport.isMobile() ) ||
+					isExpanded ) &&
 				! isEditMode && (
 					<CommentDetailActions
 						compact={ showQuickActions && ! isExpanded }

--- a/client/blocks/comment-detail/comment-detail-header.jsx
+++ b/client/blocks/comment-detail/comment-detail-header.jsx
@@ -3,8 +3,7 @@
  *
  * @format
  */
-
-import React from 'react';
+import React, { Component } from 'react';
 import Gridicon from 'gridicons';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
@@ -22,123 +21,149 @@ import FormCheckbox from 'components/forms/form-checkbox';
 import { stripHTML, decodeEntities } from 'lib/formatting';
 import { urlToDomainAndPath } from 'lib/url';
 
-export const CommentDetailHeader = ( {
-	authorAvatarUrl,
-	authorDisplayName,
-	authorUrl,
-	commentContent,
-	commentIsLiked,
-	commentIsSelected,
-	commentStatus,
-	commentType,
-	deleteCommentPermanently,
-	isBulkEdit,
-	isEditMode,
-	isExpanded,
-	postTitle,
-	toggleApprove,
-	toggleEditMode,
-	toggleExpanded,
-	toggleLike,
-	toggleSelected,
-	toggleSpam,
-	toggleTrash,
-	translate,
-} ) => {
-	const author = {
-		avatar_URL: authorAvatarUrl,
-		display_name: authorDisplayName,
+export class CommentDetailHeader extends Component {
+	state = {
+		showQuickActions: false,
 	};
 
-	const classes = classNames( 'comment-detail__header', {
-		'is-preview': ! isExpanded,
-		'is-bulk-edit': isBulkEdit,
-	} );
+	onMouseEnter = () => this.setState( { showQuickActions: true } );
 
-	const handleFullHeaderClick = isBulkEdit ? toggleSelected : toggleExpanded;
+	onMouseLeave = () => this.setState( { showQuickActions: false } );
 
-	return (
-		<div className={ classes } onClick={ isExpanded ? noop : handleFullHeaderClick }>
-			{ isExpanded &&
-			! isEditMode && (
-				<CommentDetailActions
-					commentIsLiked={ commentIsLiked }
-					commentStatus={ commentStatus }
-					deleteCommentPermanently={ deleteCommentPermanently }
-					toggleApprove={ toggleApprove }
-					toggleEditMode={ toggleEditMode }
-					toggleLike={ toggleLike }
-					toggleSpam={ toggleSpam }
-					toggleTrash={ toggleTrash }
-				/>
-			) }
+	render() {
+		const {
+			authorAvatarUrl,
+			authorDisplayName,
+			authorUrl,
+			commentContent,
+			commentIsLiked,
+			commentIsSelected,
+			commentStatus,
+			commentType,
+			deleteCommentPermanently,
+			isBulkEdit,
+			isEditMode,
+			isExpanded,
+			postTitle,
+			toggleApprove,
+			toggleEditMode,
+			toggleExpanded,
+			toggleLike,
+			toggleSelected,
+			toggleSpam,
+			toggleTrash,
+			translate,
+		} = this.props;
 
-			{ isExpanded &&
-			isEditMode && (
-				<div className="comment-detail__header-edit-mode">
-					<div className="comment-detail__header-edit-title">
-						<Gridicon icon="pencil" />
-						<span>{ translate( 'Edit Comment' ) }</span>
+		const { showQuickActions } = this.state;
+
+		const author = {
+			avatar_URL: authorAvatarUrl,
+			display_name: authorDisplayName,
+		};
+
+		const classes = classNames( 'comment-detail__header', {
+			'is-preview': ! isExpanded,
+			'is-bulk-edit': isBulkEdit,
+		} );
+
+		const handleFullHeaderClick = isBulkEdit ? toggleSelected : toggleExpanded;
+
+		return (
+			<div
+				className={ classes }
+				onClick={ isExpanded ? noop : handleFullHeaderClick }
+				onMouseEnter={ this.onMouseEnter }
+				onMouseLeave={ this.onMouseLeave }
+			>
+				{ isExpanded &&
+				isEditMode && (
+					<div className="comment-detail__header-edit-mode">
+						<div className="comment-detail__header-edit-title">
+							<Gridicon icon="pencil" />
+							<span>{ translate( 'Edit Comment' ) }</span>
+						</div>
+						<Button
+							borderless
+							className="comment-detail__action-collapse"
+							onClick={ toggleEditMode }
+						>
+							<Gridicon icon="cross" />
+						</Button>
 					</div>
-					<Button borderless className="comment-detail__action-collapse" onClick={ toggleEditMode }>
-						<Gridicon icon="cross" />
+				) }
+
+				{ ! isExpanded && (
+					<div className="comment-detail__header-content">
+						<div className="comment-detail__author-preview">
+							{ isBulkEdit && (
+								<label className="comment-detail__checkbox">
+									<FormCheckbox checked={ commentIsSelected } onChange={ noop } />
+								</label>
+							) }
+							<div className="comment-detail__author-avatar">
+								{ 'comment' === commentType && <Gravatar user={ author } /> }
+								{ 'comment' !== commentType && <Gridicon icon="link" size={ 24 } /> }
+							</div>
+							<div className="comment-detail__author-info">
+								<div className="comment-detail__author-info-element">
+									<strong>
+										<Emojify>{ authorDisplayName }</Emojify>
+									</strong>
+									<span>
+										<Emojify>{ urlToDomainAndPath( authorUrl ) }</Emojify>
+									</span>
+								</div>
+								<div className="comment-detail__author-info-element">
+									<Emojify>
+										{ translate( 'on %(postTitle)s', {
+											args: {
+												postTitle: postTitle
+													? decodeEntities( postTitle )
+													: translate( 'Untitled' ),
+											},
+										} ) }
+									</Emojify>
+								</div>
+							</div>
+						</div>
+						<AutoDirection>
+							<div className="comment-detail__comment-preview">
+								<Emojify>{ decodeEntities( stripHTML( commentContent ) ) }</Emojify>
+							</div>
+						</AutoDirection>
+					</div>
+				) }
+
+				{ ( showQuickActions || isExpanded ) &&
+				! isEditMode && (
+					<CommentDetailActions
+						compact={ showQuickActions && ! isExpanded }
+						commentIsLiked={ commentIsLiked }
+						commentStatus={ commentStatus }
+						deleteCommentPermanently={ deleteCommentPermanently }
+						toggleApprove={ toggleApprove }
+						toggleEditMode={ toggleEditMode }
+						toggleLike={ toggleLike }
+						toggleSpam={ toggleSpam }
+						toggleTrash={ toggleTrash }
+					/>
+				) }
+
+				{ ! isBulkEdit &&
+				! isEditMode && (
+					<Button
+						borderless
+						className="comment-detail__action-collapse"
+						disabled={ isEditMode }
+						onClick={ isExpanded ? toggleExpanded : noop }
+					>
+						<Gridicon icon="chevron-down" />
 					</Button>
-				</div>
-			) }
-
-			{ ! isExpanded && (
-				<div className="comment-detail__header-content">
-					<div className="comment-detail__author-preview">
-						{ isBulkEdit && (
-							<label className="comment-detail__checkbox">
-								<FormCheckbox checked={ commentIsSelected } onChange={ noop } />
-							</label>
-						) }
-						<div className="comment-detail__author-avatar">
-							{ 'comment' === commentType && <Gravatar user={ author } /> }
-							{ 'comment' !== commentType && <Gridicon icon="link" size={ 24 } /> }
-						</div>
-						<div className="comment-detail__author-info">
-							<div className="comment-detail__author-info-element">
-								<strong>
-									<Emojify>{ authorDisplayName }</Emojify>
-								</strong>
-								<span>
-									<Emojify>{ urlToDomainAndPath( authorUrl ) }</Emojify>
-								</span>
-							</div>
-							<div className="comment-detail__author-info-element">
-								<Emojify>
-									{ translate( 'on %(postTitle)s', {
-										args: {
-											postTitle: postTitle ? decodeEntities( postTitle ) : translate( 'Untitled' ),
-										},
-									} ) }
-								</Emojify>
-							</div>
-						</div>
-					</div>
-					<AutoDirection>
-						<div className="comment-detail__comment-preview">
-							<Emojify>{ decodeEntities( stripHTML( commentContent ) ) }</Emojify>
-						</div>
-					</AutoDirection>
-				</div>
-			) }
-
-			{ ! isBulkEdit &&
-			! isEditMode && (
-				<Button
-					borderless
-					className="comment-detail__action-collapse"
-					disabled={ isEditMode }
-					onClick={ isExpanded ? toggleExpanded : noop }
-				>
-					<Gridicon icon="chevron-down" />
-				</Button>
-			) }
-		</div>
-	);
-};
+				) }
+			</div>
+		);
+	}
+}
 
 export default localize( CommentDetailHeader );

--- a/client/blocks/comment-detail/comment-detail-reply.jsx
+++ b/client/blocks/comment-detail/comment-detail-reply.jsx
@@ -24,9 +24,24 @@ const TEXTAREA_VERTICAL_BORDER = 2;
 export class CommentDetailReply extends Component {
 	state = {
 		commentText: '',
-		hasFocus: false,
 		textareaHeight: TEXTAREA_HEIGHT_COLLAPSED,
 	};
+
+	componentDidMount() {
+		if ( this.props.hasFocus ) {
+			this.textarea.focus();
+		}
+	}
+
+	componentWillReceiveProps( nextProps ) {
+		if ( this.props.hasFocus !== nextProps.hasFocus ) {
+			this.setState( {
+				textareaHeight: nextProps.hasFocus
+					? this.calculateTextareaHeight()
+					: TEXTAREA_HEIGHT_COLLAPSED,
+			} );
+		}
+	}
 
 	bindTextareaRef = textarea => {
 		this.textarea = textarea;
@@ -59,7 +74,7 @@ export class CommentDetailReply extends Component {
 			: translate( 'Reply to comment…' );
 	};
 
-	handleTextChange = event => {
+	onChange = event => {
 		const { value } = event.target;
 		const textareaHeight = this.calculateTextareaHeight();
 
@@ -68,12 +83,6 @@ export class CommentDetailReply extends Component {
 			textareaHeight,
 		} );
 	};
-
-	setFocus = () =>
-		this.setState( {
-			hasFocus: true,
-			textareaHeight: this.calculateTextareaHeight(),
-		} );
 
 	submit = () => {
 		const { comment, replyComment } = this.props;
@@ -88,7 +97,7 @@ export class CommentDetailReply extends Component {
 		this.submit();
 	};
 
-	submitCommentOnCtrlEnter = event => {
+	onKeyDown = event => {
 		// Use Ctrl+Enter to submit comment
 		if ( event.keyCode === 13 && ( event.ctrlKey || event.metaKey ) ) {
 			event.preventDefault();
@@ -96,15 +105,9 @@ export class CommentDetailReply extends Component {
 		}
 	};
 
-	unsetFocus = () =>
-		this.setState( {
-			hasFocus: false,
-			textareaHeight: TEXTAREA_HEIGHT_COLLAPSED,
-		} );
-
 	render() {
-		const { currentUser, translate } = this.props;
-		const { commentText, hasFocus, textareaHeight } = this.state;
+		const { currentUser, hasFocus, translate, enterReplyState, exitReplyState } = this.props;
+		const { commentText, textareaHeight } = this.state;
 
 		const hasCommentText = commentText.trim().length > 0;
 
@@ -135,10 +138,10 @@ export class CommentDetailReply extends Component {
 				<AutoDirection>
 					<textarea
 						className={ textareaClasses }
-						onBlur={ this.unsetFocus }
-						onChange={ this.handleTextChange }
-						onFocus={ this.setFocus }
-						onKeyDown={ this.submitCommentOnCtrlEnter }
+						onBlur={ exitReplyState }
+						onChange={ this.onChange }
+						onFocus={ enterReplyState }
+						onKeyDown={ this.onKeyDown }
 						placeholder={ this.getTextareaPlaceholder() }
 						ref={ this.bindTextareaRef }
 						style={ textareaStyle }

--- a/client/blocks/comment-detail/index.jsx
+++ b/client/blocks/comment-detail/index.jsx
@@ -93,6 +93,7 @@ export class CommentDetail extends Component {
 
 	state = {
 		isEditMode: false,
+		isReplyMode: false,
 	};
 
 	componentWillReceiveProps( nextProps ) {
@@ -121,6 +122,10 @@ export class CommentDetail extends Component {
 		!! this.props.authorEmail && !! this.props.siteBlacklist
 			? -1 !== this.props.siteBlacklist.split( '\n' ).indexOf( this.props.authorEmail )
 			: false;
+
+	enterReplyState = () => this.setState( { isReplyMode: true } );
+
+	exitReplyState = () => this.setState( { isReplyMode: false } );
 
 	toggleApprove = e => {
 		e.stopPropagation();
@@ -163,8 +168,6 @@ export class CommentDetail extends Component {
 
 		this.props.toggleCommentLike( getCommentStatusAction( this.props ) );
 	};
-
-	toggleSelected = () => this.props.toggleCommentSelected( getCommentStatusAction( this.props ) );
 
 	toggleSpam = e => {
 		e.stopPropagation();
@@ -310,6 +313,7 @@ export class CommentDetail extends Component {
 					toggleEditMode={ this.toggleEditMode }
 					toggleExpanded={ this.toggleExpanded }
 					toggleLike={ this.toggleLike }
+					toggleReply={ this.enterReplyState }
 					toggleSelected={ this.toggleSelected }
 					toggleSpam={ this.toggleSpam }
 					toggleTrash={ this.toggleTrash }
@@ -368,8 +372,11 @@ export class CommentDetail extends Component {
 									authorAvatarUrl={ authorAvatarUrl }
 									authorDisplayName={ authorDisplayName }
 									comment={ getCommentStatusAction( this.props ) }
+									hasFocus={ this.state.isReplyMode }
 									postTitle={ postTitle }
 									replyComment={ replyComment }
+									enterReplyState={ this.enterReplyState }
+									exitReplyState={ this.exitReplyState }
 								/>
 							</div>
 						) }

--- a/client/blocks/comment-detail/index.jsx
+++ b/client/blocks/comment-detail/index.jsx
@@ -101,7 +101,9 @@ export class CommentDetail extends Component {
 		}
 	}
 
-	deleteCommentPermanently = () => {
+	deleteCommentPermanently = e => {
+		e.stopPropagation();
+
 		if ( this.state.isEditMode ) {
 			return;
 		}
@@ -120,7 +122,9 @@ export class CommentDetail extends Component {
 			? -1 !== this.props.siteBlacklist.split( '\n' ).indexOf( this.props.authorEmail )
 			: false;
 
-	toggleApprove = () => {
+	toggleApprove = e => {
+		e.stopPropagation();
+
 		if ( this.state.isEditMode ) {
 			return;
 		}
@@ -150,7 +154,9 @@ export class CommentDetail extends Component {
 		}
 	};
 
-	toggleLike = () => {
+	toggleLike = e => {
+		e.stopPropagation();
+
 		if ( this.state.isEditMode ) {
 			return;
 		}
@@ -160,7 +166,9 @@ export class CommentDetail extends Component {
 
 	toggleSelected = () => this.props.toggleCommentSelected( getCommentStatusAction( this.props ) );
 
-	toggleSpam = () => {
+	toggleSpam = e => {
+		e.stopPropagation();
+
 		if ( this.state.isEditMode ) {
 			return;
 		}
@@ -172,7 +180,9 @@ export class CommentDetail extends Component {
 		);
 	};
 
-	toggleTrash = () => {
+	toggleTrash = e => {
+		e.stopPropagation();
+
 		if ( this.state.isEditMode ) {
 			return;
 		}

--- a/client/blocks/comment-detail/style.scss
+++ b/client/blocks/comment-detail/style.scss
@@ -254,7 +254,7 @@
 		}
 	}
 
-	.button.is-borderless {
+	.button {
 		span {
 			display: none;
 			font-weight: normal;

--- a/client/blocks/comment-detail/style.scss
+++ b/client/blocks/comment-detail/style.scss
@@ -34,7 +34,6 @@
 
 	.gridicon {
 		margin-right: 4px;
-		vertical-align: middle;
 	}
 
 	.comment-detail__author-avatar {
@@ -132,7 +131,9 @@
 		fill: $gray;
 		transform: rotate( 180deg );
 		transition: transform .15s cubic-bezier(0.175, .885, .32, 1.275), color .20s ease-in;
+		vertical-align: middle;
 	}
+
 	.comment-detail__action-collapse:hover .gridicon {
 		fill: $blue-medium;
 	}

--- a/client/blocks/comment-detail/style.scss
+++ b/client/blocks/comment-detail/style.scss
@@ -242,6 +242,13 @@
 	padding-left: 4px;
 	user-select: none;
 
+	&.is-quick {
+		position: absolute;
+		display: flex;
+		right: 44px;
+		padding: 0;
+	}
+
 	.button.is-borderless {
 		span {
 			display: none;

--- a/client/blocks/comment-detail/style.scss
+++ b/client/blocks/comment-detail/style.scss
@@ -34,6 +34,7 @@
 
 	.gridicon {
 		margin-right: 4px;
+		vertical-align: middle;
 	}
 
 	.comment-detail__author-avatar {
@@ -131,7 +132,6 @@
 		fill: $gray;
 		transform: rotate( 180deg );
 		transition: transform .15s cubic-bezier(0.175, .885, .32, 1.275), color .20s ease-in;
-		vertical-align: middle;
 	}
 
 	.comment-detail__action-collapse:hover .gridicon {
@@ -248,6 +248,10 @@
 		display: flex;
 		right: 44px;
 		padding: 0;
+
+		.gridicon {
+			vertical-align: baseline;
+		}
 	}
 
 	.button.is-borderless {

--- a/config/development.json
+++ b/config/development.json
@@ -42,6 +42,7 @@
 		"comments/filters-in-posts": true,
 		"comments/moderation-tools-in-posts": true,
 		"comments/management": true,
+		"comments/management/quick-actions": true,
 		"comments/management/sorting": true,
 		"css-hot-reload": true,
 		"desktop-promo": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -19,6 +19,7 @@
 		"automated-transfer": true,
 		"apple-pay": true,
 		"comments/management": true,
+		"comments/management/quick-actions": true,
 		"comments/management/sorting": true,
 		"catch-js-errors": true,
 		"code-splitting": true,


### PR DESCRIPTION
This PR makes a small modification to `CommentDetailActions` so it can be reused for quick actions on hover.

![oct-09-2017 09-40-02](https://user-images.githubusercontent.com/233601/31338508-ee997a6e-acd5-11e7-9633-4dcd259f5aa2.gif)

Changes include:

- Upgrading `CommentDetailHeader` from stateless component to a `class` so it can hold the `hover` in local state.
- Adding a `is-quick` css rule to `comment-detail__actions`.
- Selectively showing the action buttons as children of a `ButtonGroup` depending on the hover state.
- Change the style and content of the action buttons depending on the hover state.

To test:

- Go to a site's comments.
- Quick actions should show on hover and work as expected.

References:

Fixes #14119.
p3fqKv-5LC-p2