### PR TITLE
Store: Prevent duplicate variant type names from being entered.

### DIFF
--- a/client/extensions/woocommerce/app/products/product-form.scss
+++ b/client/extensions/woocommerce/app/products/product-form.scss
@@ -334,6 +334,10 @@
 
 	.products__variation-types-form-fieldset {
 		margin-bottom: 16px;
+
+		&.is-error {
+			margin-bottom: 0;
+		}
 	}
 
 	.products__variation-types-form-field {

--- a/client/extensions/woocommerce/app/products/product-variation-types-form.js
+++ b/client/extensions/woocommerce/app/products/product-variation-types-form.js
@@ -93,7 +93,7 @@ class ProductVariationTypesForm extends Component {
 		const existingAttribute =
 			product.attributes &&
 			find( product.attributes, function( a ) {
-				return a.uid !== attributeId && a.name.toLowerCase() === name.toLowerCase();
+				return a.uid !== attributeId && a.name.trim().toLowerCase() === name.trim().toLowerCase();
 			} );
 
 		if ( existingAttribute ) {

--- a/client/extensions/woocommerce/app/products/product-variation-types-form.js
+++ b/client/extensions/woocommerce/app/products/product-variation-types-form.js
@@ -6,6 +6,7 @@
 
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 import { find, debounce, isNumber, indexOf, pull } from 'lodash';
 import { localize } from 'i18n-calypso';
 
@@ -13,6 +14,7 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import Button from 'components/button';
+import FormInputValidation from 'components/forms/form-input-validation';
 import FormLabel from 'components/forms/form-label';
 import FormTextInput from 'components/forms/form-text-input';
 import TokenField from 'components/token-field';
@@ -113,25 +115,33 @@ class ProductVariationTypesForm extends Component {
 
 		const attributeName = ( attributeNames && attributeNames[ attribute.uid ] ) || attribute.name;
 		const duplicateNameIssue = indexOf( attributeNameErrors, attribute.uid ) !== -1;
+		const classes = classNames( 'products__variation-types-form-fieldset', {
+			'is-error': duplicateNameIssue,
+		} );
 		return (
-			<div key={ index } className="products__variation-types-form-fieldset">
-				<FormTextInput
-					placeholder={ translate( 'Color' ) }
-					value={ attributeName }
-					id={ attribute.uid }
-					name="type"
-					className="products__variation-types-form-field"
-					isError={ duplicateNameIssue }
-					onChange={ this.updateNameHandler }
-				/>
-				<TokenField
-					placeholder={ translate( 'Red, Green, Blue' ) }
-					value={ attribute.options }
-					name="values"
-					disabled={ duplicateNameIssue }
-					/* eslint-disable react/jsx-no-bind */
-					onChange={ values => this.updateValues( values, attribute ) }
-				/>
+			<div key={ index }>
+				<div className={ classes }>
+					<FormTextInput
+						placeholder={ translate( 'Color' ) }
+						value={ attributeName }
+						id={ attribute.uid }
+						name="type"
+						className="products__variation-types-form-field"
+						isError={ duplicateNameIssue }
+						onChange={ this.updateNameHandler }
+					/>
+					<TokenField
+						placeholder={ translate( 'Red, Green, Blue' ) }
+						value={ attribute.options }
+						name="values"
+						disabled={ duplicateNameIssue }
+						/* eslint-disable react/jsx-no-bind */
+						onChange={ values => this.updateValues( values, attribute ) }
+					/>
+				</div>
+				{ duplicateNameIssue && (
+					<FormInputValidation isError text={ translate( 'Variation type already exists.' ) } />
+				) }
 			</div>
 		);
 	}


### PR DESCRIPTION
Fixes #16615 - currently one can enter in duplicate variant type names in the `<ProductVariationTypeForm />` which leads to some interesting UI experience as [seen here](https://cloudup.com/cqg_FFlpn9C). This branch seeks to fix that issue by validating that the name entered in the new Variation row does not already exist on the product.

If the name does already exist, the `isError` prop for the underlying text field is set to true, and the associated token field is disabled:

![error-message](https://user-images.githubusercontent.com/22080/31508522-33062710-af33-11e7-8621-1fbf3b105b7a.gif)

__To Test__
- Open up a product edit screen that has existing variations, or create a new product with one variation type
- Attempt to add another variation type with the same name. Note the text field will be highlighted red, and the token field will be disabled

__Questions__
- Should we disable the form update/save action when in an error state?