### PR TITLE
G Suite: Show a proper icon for a G Suite upgrade

### DIFF
--- a/client/me/purchases/purchase-item/index.jsx
+++ b/client/me/purchases/purchase-item/index.jsx
@@ -23,7 +23,7 @@ import {
 	purchaseType,
 	showCreditCardExpiringWarning,
 } from 'lib/purchases';
-import { isPlan, isDomainProduct, isTheme } from 'lib/products-values';
+import { isDomainProduct, isGoogleApps, isPlan, isTheme } from 'lib/products-values';
 import Notice from 'components/notice';
 import PlanIcon from 'components/plans/plan-icon';
 import Gridicon from 'gridicons';
@@ -129,6 +129,41 @@ class PurchaseItem extends Component {
 		window.scrollTo( 0, 0 );
 	}
 
+	renderIcon() {
+		const { purchase } = this.props;
+
+		if ( ! purchase ) {
+			return null;
+		}
+
+		if ( isPlan( purchase ) ) {
+			return (
+				<div className="purchase-item__plan-icon">
+					<PlanIcon plan={ purchase.productSlug } />
+				</div>
+			);
+		}
+
+		let icon;
+		if ( isDomainProduct( purchase ) ) {
+			icon = 'domains';
+		} else if ( isTheme( purchase ) ) {
+			icon = 'themes';
+		} else if ( isGoogleApps( purchase ) ) {
+			icon = 'mail';
+		}
+
+		if ( ! icon ) {
+			return null;
+		}
+
+		return (
+			<div className="purchase-item__plan-icon">
+				<Gridicon icon={ icon } size={ 24 } />
+			</div>
+		);
+	}
+
 	render() {
 		const { isPlaceholder, isDisconnectedSite, purchase } = this.props;
 		const classes = classNames(
@@ -138,39 +173,16 @@ class PurchaseItem extends Component {
 			{ 'is-included-with-plan': purchase && isIncludedWithPlan( purchase ) }
 		);
 
-		let icon;
-		if ( purchase && isPlan( purchase ) ) {
-			icon = (
-				<div className="purchase-item__plan-icon">
-					<PlanIcon plan={ purchase.productSlug } />
-				</div>
-			);
-		} else if ( purchase && isDomainProduct( purchase ) ) {
-			icon = (
-				<div className="purchase-item__plan-icon">
-					<Gridicon icon="domains" size={ 24 } />
-				</div>
-			);
-		} else if ( purchase && isTheme( purchase ) ) {
-			icon = (
-				<div className="purchase-item__plan-icon">
-					<Gridicon icon="themes" size={ 24 } />
-				</div>
-			);
-		}
-
 		let content;
 		if ( isPlaceholder ) {
 			content = this.placeholder();
 		} else {
 			content = (
 				<span className="purchase-item__wrapper">
-					{ icon }
+					{ this.renderIcon() }
 					<div className="purchase-item__details">
-						<div className="purchase-item__title">{ getName( this.props.purchase ) }</div>
-						<div className="purchase-item__purchase-type">
-							{ purchaseType( this.props.purchase ) }
-						</div>
+						<div className="purchase-item__title">{ getName( purchase ) }</div>
+						<div className="purchase-item__purchase-type">{ purchaseType( purchase ) }</div>
 						<div className="purchase-item__purchase-date">{ this.renewsOrExpiresOn() }</div>
 					</div>
 				</span>


### PR DESCRIPTION
The G Suite upgrade was missing an icon on the Purchases page.

It's been bugging me for some time now.
The https://gsuite.google.com/setup/resources/logos/ logo is very long and doesn't quite fit the space we have for it. So I've used the `mail` icon from Gridicons.

Took this opportunity to improve the code a bit.

### Testing
Before:
<img width="747" alt="screen shot 2017-10-09 at 17 13 22" src="https://user-images.githubusercontent.com/3392497/31345968-bad5e9f0-ad17-11e7-9be4-3980f8e159de.png">

After:
<img width="746" alt="screen shot 2017-10-09 at 17 29 11" src="https://user-images.githubusercontent.com/3392497/31345974-bfe65d9e-ad17-11e7-8b80-bc3f2c11b9ed.png">