### PR TITLE
Comments: Update Block User notice copy

### DIFF
--- a/client/blocks/comment-detail/comment-detail-author.jsx
+++ b/client/blocks/comment-detail/comment-detail-author.jsx
@@ -112,7 +112,9 @@ export class CommentDetailAuthor extends Component {
 		}
 
 		this.props.successNotice(
-			translate( 'User %(email)s blocked.', { args: { email: authorEmail } } ),
+			translate( 'User %(email)s is blocked and can no longer comment on your site.', {
+				args: { email: authorEmail },
+			} ),
 			noticeOptions
 		);
 


### PR DESCRIPTION
Closes #18675

Update the Block User notice to explicitly state what the Block User action actually entails.

I've chosen to _not_ update the Unblock notice because I think it'd be unnecessary.

Context: p7DVsv-3jO-p2 #comment-8919
cc @megsfulton @KokkieH 