### PR TITLE
Atomic Store: create a new site with default theme

### DIFF
--- a/client/signup/steps/theme-selection/index.jsx
+++ b/client/signup/steps/theme-selection/index.jsx
@@ -107,11 +107,11 @@ class ThemeSelectionStep extends Component {
 				{
 					stepName: this.props.stepName,
 					processingMessage: this.props.translate( 'Adding your theme' ),
-					repoSlug: 'pub/storefront',
+					repoSlug: '',
 				},
 				null,
 				{
-					themeSlugWithRepo: 'pub/storefront',
+					themeSlugWithRepo: '',
 				}
 			);
 


### PR DESCRIPTION
Part of the Atomic Store signup flow work.

We should not try to pre-install the Storefront theme since it doesn't exist on WP.com. It gets installed on an Atomic site automatically if you transfer with Woo (or if you install Woo and activate it /cc @mendezcode if true).

In this PR, we are simply submitting empty `themeSlugWithRepo` during the 'themes' signup step so that the default theme is selected on the backend.

## Testing

Run Calypso locally and go to `/start/atomic-store`. Select the 'store' design type and complete the signup. Does the site have Twenty Sixteen theme installed?