### PR TITLE
Reader Conversations: use Redux state for active reply comment

### DIFF
--- a/client/blocks/comments/post-comment-list.jsx
+++ b/client/blocks/comments/post-comment-list.jsx
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 import { translate } from 'i18n-calypso';
-import { get, size, takeRight, delay, filter } from 'lodash';
+import { get, size, takeRight, delay, some } from 'lodash';
 
 /**
  * Internal dependencies
@@ -278,17 +278,15 @@ class PostCommentList extends React.Component {
 	};
 
 	renderCommentForm = () => {
-		const post = this.props.post;
+		const { post, commentsTree } = this.props;
 		const commentText = this.state.commentText;
 
 		// Are we displaying the comment form at the top-level?
 		if (
 			this.props.activeReplyCommentId ||
-			size(
-				filter( this.props.commentsTree, comment => {
-					return comment.data && comment.data.isPlaceholder && ! comment.data.parent;
-				} )
-			) > 0
+			some( commentsTree, comment => {
+				return comment.data && comment.data.isPlaceholder && ! comment.data.parent;
+			} )
 		) {
 			return null;
 		}

--- a/client/blocks/comments/post-comment-list.jsx
+++ b/client/blocks/comments/post-comment-list.jsx
@@ -253,6 +253,11 @@ class PostCommentList extends React.Component {
 	setActiveReplyComment = commentId => {
 		const siteId = get( this.props, 'post.site_ID' );
 		const postId = get( this.props, 'post.ID' );
+
+		if ( ! siteId || ! postId ) {
+			return;
+		}
+
 		this.props.setActiveReply( {
 			siteId,
 			postId,

--- a/client/blocks/conversations/list.jsx
+++ b/client/blocks/conversations/list.jsx
@@ -26,7 +26,7 @@ import { requestPostComments, requestComment, setActiveReply } from 'state/comme
 
 /**
  * ConversationsCommentList is the component that represents all of the comments for a conversations-stream
- * Some of it is boilerplate stolen from PostCommnentList (all the activeXCommentId bits) but the special
+ * Some of it is boilerplate stolen from PostCommentList (all the activeXCommentId bits) but the special
  * convos parts are related to:
  *  1. caterpillars
  *  2. commentsToShow
@@ -40,7 +40,7 @@ import { requestPostComments, requestComment, setActiveReply } from 'state/comme
  *   hands that down to all of the PostComments so they will know how to render.
  *
  * This component will also display a caterpillar if it has any children comments that are hidden.
- * It can determine hidden state by seeing that the number of commentsToShow < totalCommentsForPost
+ * It can determine hidden state by seeing that the number of commentsToShow < totalCommentsForPost.
  */
 
 const FETCH_NEW_COMMENTS_THRESHOLD = 20;

--- a/client/blocks/conversations/list.jsx
+++ b/client/blocks/conversations/list.jsx
@@ -75,6 +75,7 @@ export class ConversationCommentList extends React.Component {
 	};
 
 	onReplyCancel = () => {
+		this.setState( { commentText: null } );
 		recordAction( 'comment_reply_cancel_click' );
 		recordGaEvent( 'Clicked Cancel Reply to Comment' );
 		recordTrack( 'calypso_reader_comment_reply_cancel_click', {

--- a/client/blocks/conversations/list.jsx
+++ b/client/blocks/conversations/list.jsx
@@ -170,6 +170,11 @@ export class ConversationCommentList extends React.Component {
 	setActiveReplyComment = commentId => {
 		const siteId = get( this.props, 'post.site_ID' );
 		const postId = get( this.props, 'post.ID' );
+
+		if ( ! siteId || ! postId ) {
+			return;
+		}
+
 		this.props.setActiveReply( {
 			siteId,
 			postId,

--- a/client/blocks/conversations/list.jsx
+++ b/client/blocks/conversations/list.jsx
@@ -5,7 +5,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { map, zipObject, fill, size, filter, get, compact, partition } from 'lodash';
+import { map, zipObject, fill, size, filter, get, compact, partition, some } from 'lodash';
 
 /***
  * Internal dependencies
@@ -187,17 +187,15 @@ export class ConversationCommentList extends React.Component {
 	};
 
 	renderCommentForm = () => {
-		const post = this.props.post;
+		const { post, commentsTree } = this.props;
 		const commentText = this.state.commentText;
 
 		// Are we displaying the comment form at the top-level?
 		if (
 			this.props.activeReplyCommentId ||
-			size(
-				filter( this.props.commentsTree, comment => {
-					return comment.data && comment.data.isPlaceholder && ! comment.data.parent;
-				} )
-			) > 0
+			some( commentsTree, comment => {
+				return comment.data && comment.data.isPlaceholder && ! comment.data.parent;
+			} )
 		) {
 			return null;
 		}


### PR DESCRIPTION
Following on from https://github.com/Automattic/wp-calypso/pull/18409, this PR switches Reader Conversations to use Redux state rather than component state.

Conversations does not use `PostCommentList` from `blocks/comments`, so we need to make changes to `reader/conversations/list.jsx`.

### To test

In a comment thread:
* ensure that clicking 'reply' makes the comment textbox appear under the current comment
* ensure that clicking 'cancel reply' returns the comment textbox to the top level
* ensure that submitting a comment successfully returns the comment textbox to the top level
* ensure that the active comment is not preserved when revisiting a page (it should be reset on mount)

![31025669-5019baee-a53b-11e7-9740-8ea6f24078bb](https://user-images.githubusercontent.com/17325/31398714-c3882458-ade1-11e7-8e1b-3676ea8b620c.png)

### Known issue

If you successfully post a comment, you will run into https://github.com/Automattic/wp-calypso/issues/18595 (or https://github.com/Automattic/wp-calypso/issues/18701 if there's an error). The comment doesn't appear where you expect it to, and might be "hidden" in a caterpillar. That's definitely something we'll fix, but it's outside the scope of this PR.