### PR TITLE
Framework: Remove i18n mixin auto-injection

### DIFF
--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -7,8 +7,6 @@
 import debugFactory from 'debug';
 import page from 'page';
 import qs from 'querystring';
-import ReactClass from 'react/lib/ReactClass';
-import i18n from 'i18n-calypso';
 import { some, startsWith } from 'lodash';
 import url from 'url';
 
@@ -140,9 +138,6 @@ const unsavedFormsMiddleware = () => {
 
 export const locales = ( currentUser, reduxStore ) => {
 	debug( 'Executing Calypso locales.' );
-
-	// Initialize i18n mixin
-	ReactClass.injection.injectMixin( i18n.mixin );
 
 	if ( window.i18nLocaleStrings ) {
 		const i18nLocaleStringsObject = JSON.parse( window.i18nLocaleStrings );


### PR DESCRIPTION
- [ ] Depends on #18590.

We are removing `i18n-mixin` auto-injection in preparation for React 15.6 (#18555).

Context: React has closed access to 'react/lib/*' packages. We were relying on 'react/lib/ReactClass' for mixin auto-injection. Going forward, this will no longer be possible.