### PR TITLE
Component `PhoneInput`: Set the input value when the component is mounted

### DIFF
--- a/client/components/phone-input/index.jsx
+++ b/client/components/phone-input/index.jsx
@@ -76,6 +76,7 @@ class PhoneInput extends React.PureComponent {
 			this.props.value,
 			this.props.countryCode
 		);
+		this.numberInput.value = value;
 		if ( value !== this.props.value || countryCode !== this.props.countryCode ) {
 			this.props.onChange( { value, countryCode } );
 		}


### PR DESCRIPTION
The `PhoneInput` component only sets the input value on `componentWillUpdate`, not the initial render. This is misleading, because unformatted values are formatted, then the `onChange` triggers and update, and the number appears. However, if you pass an already-formatted phone number, it won't trigger a change in formatting.

This was leading to a bug in https://github.com/Automattic/wp-calypso/pull/18579#pullrequestreview-67463909

> If you edit the billing address twice, so click edit on billing - make no changes, close the dialog. Then open it backup again, the phone number is no longer displayed in the modal form.

The number was formatted when the dialog opened, and so when the dialog opened the second time, the number was never sent to the input value.

This fix simply sets the input value on mount (which might then be re-set by the `onChange` on the next line, but that would trigger the existing `componentWillUpdate` logic).

**To test**

- Currently this component is used by the domains checkout flow, so you can check that it still works there.
- Alternately, edit the devdocs demo to display a formatted phone number (like `(555) 123-4567`)
- Or merge this into the PR #18579, and test opening the dialog twice.