### PR TITLE
Activity Log: Enable Rewind Button

### DIFF
--- a/client/my-sites/stats/activity-log-day/index.jsx
+++ b/client/my-sites/stats/activity-log-day/index.jsx
@@ -48,8 +48,7 @@ class ActivityLogDay extends Component {
 		isRewindActive: true,
 	};
 
-	handleClickRestore = event => {
-		event.stopPropagation();
+	handleClickRestore = () => {
 		const { logs, requestRestore } = this.props;
 		const lastLogId = get( logs, [ 0, 'activityId' ], null );
 		if ( lastLogId ) {


### PR DESCRIPTION
While giving https://github.com/Automattic/wp-calypso/pull/18241 a look through before deploying, I noticed the "Rewind" button wasn't doing anything. 

![screen shot 2017-10-10 at 12 14 12 pm](https://user-images.githubusercontent.com/1922453/31362760-b63dd1ce-adb6-11e7-9f12-5a49e55ef06e.png)

As a user, I expected it to open the confirmation dialog, similar to clicking on the down arrow.

FYI, I removed `event.stopPropagation()` without doing much digging into the underlying function. It _appears_ to work as expected.

@sirreal @eliorivero 
