### PR TITLE
My-sites: Controller: Check for primary after check for initialized

### DIFF
--- a/client/lib/user/shared-utils.js
+++ b/client/lib/user/shared-utils.js
@@ -58,6 +58,7 @@ module.exports = {
 				'user_ip_country_code',
 				'logout_URL',
 				'primary_blog',
+				'primary_blog_is_jetpack',
 				'primary_blog_url',
 				'meta',
 				'is_new_reader',

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -272,6 +272,31 @@ function createSitesComponent( context ) {
 	);
 }
 
+function showMissingPrimaryError( currentUser, dispatch ) {
+	const { username, primary_blog, primary_blog_url, primary_blog_is_jetpack } = currentUser;
+	const tracksPayload = {
+		username,
+		primary_blog,
+		primary_blog_url,
+		primary_blog_is_jetpack,
+	};
+
+	if ( currentUser.primary_blog_is_jetpack ) {
+		dispatch(
+			warningNotice( i18n.translate( "Please check your Primary Site's Jetpack connection" ), {
+				button: 'wp-admin',
+				href: `${ currentUser.primary_blog_url }/wp-admin`,
+			} )
+		);
+		analytics.tracks.recordEvent(
+			'calypso_mysites_single_site_jetpack_connection_error',
+			tracksPayload
+		);
+	} else {
+		analytics.tracks.recordEvent( 'calypso_mysites_single_site_error', tracksPayload );
+	}
+}
+
 module.exports = {
 	// Clears selected site from global redux state
 	noSite( context, next ) {
@@ -320,36 +345,30 @@ module.exports = {
 			return next();
 		}
 
-		// If the user has only one site, redirect to the single site
-		// context instead of rendering the all-site views.
+		/**
+		 * If the user has only one site, redirect to the single site
+		 * context instead of rendering the all-site views.
+		 *
+		 * Note: The redirectToPrimary function will be continually executed
+		 * by repeatedly querying /stats/day/undefined until the /sites
+		 * endpoint has returned.
+		 */
 		if ( hasOneSite && ! siteFragment ) {
-			if ( primary ) {
-				const hasInitialized = getSites( getState() ).length;
-				if ( hasInitialized ) {
+			const hasInitialized = getSites( getState() ).length;
+			if ( hasInitialized ) {
+				if ( primary ) {
 					redirectToPrimary();
-					return;
+				} else {
+					// If the primary site does not exist, skip redirect
+					// and display a useful error notification
+					showMissingPrimaryError( currentUser, dispatch );
 				}
-				dispatch( {
-					type: SITES_ONCE_CHANGED,
-					listener: redirectToPrimary,
-				} );
-			} else {
-				// If the primary site does not exist, skip redirect and display a useful error notification
-				dispatch(
-					warningNotice( i18n.translate( "Please check your Primary Site's Jetpack connection" ), {
-						button: 'wp-admin',
-						href: `${ currentUser.primary_blog_url }/wp-admin`,
-					} )
-				);
-
-				const { username, primary_blog, primary_blog_url, primary_blog_is_jetpack } = currentUser;
-				analytics.tracks.recordEvent( 'calypso_mysites_single_site_jetpack_connection_error', {
-					username,
-					primary_blog,
-					primary_blog_url,
-					primary_blog_is_jetpack,
-				} );
+				return;
 			}
+			dispatch( {
+				type: SITES_ONCE_CHANGED,
+				listener: redirectToPrimary,
+			} );
 		}
 
 		// If the path fragment does not resemble a site, set all sites to visible


### PR DESCRIPTION
### Problem
An error was showing to users who should not see it. More info in https://github.com/Automattic/wp-calypso/issues/18682

![screen shot 2017-09-29 at 3 43 04 pm](https://user-images.githubusercontent.com/1922453/30998744-3bb42854-a52d-11e7-918e-099c57e13e4d.png)

### Cause
Jetpack users who have a disconnected primary blog don't have the site available in `state.sites`. The check was being performed before the controller had initialized, affecting wpcom users as well.

The controller was initializing by continually redirecting to `/stats/day/undefined` until the `/sites` response came back. The check was prematurely exiting this loop, leaving `primary` to always be undefined.

### Fix
Check if the primary blog is available only after the controller has initialized. This way, we can be sure the `/sites` endpoint has returned. 

**jetpack site**
If the primary site is still not available and the primary blog is a jetpack site, show a relevant error and log the occurrence in Tracks. The error is the same as above.

**not jetpack site**
If the site is not jetpack, log the occurrence in Tracks. I've decided to not show an error to the user because, in theory, they should never reach this point in the code. Tracks logs seem to indicate it may be happening. At this point, I don't know what the cause is, so I'm not sure what to tell the user. I'll keep an eye on the event to see whats happening.

Fixes https://github.com/Automattic/wp-calypso/issues/18682