### PR TITLE
analyze-bundles: fix preanalyze-bundles to work with new bundler conf…

### DIFF
--- a/package.json
+++ b/package.json
@@ -168,7 +168,7 @@
     "npm": "3.10.10"
   },
   "scripts": {
-    "preanalyze-bundles": "cross-env WEBPACK_OUTPUT_JSON=1 CALYPSO_ENV=production NODE_ARGS=\"--max_old_space_size=8192\" npm run -s build",
+    "preanalyze-bundles": "cross-env WEBPACK_OUTPUT_JSON=1 CALYPSO_ENV=production npm run -s env -- node --max_old_space_size=8192 ./node_modules/webpack/bin/webpack.js --config webpack.config.js --profile --json > stats.json",
     "analyze-bundles": "webpack-bundle-analyzer stats.json public -h 0.0.0.0 -p 9898",
     "autoprefixer": "postcss -r --use autoprefixer",
     "prebuild": "npm run -s install-if-deps-outdated",

--- a/package.json
+++ b/package.json
@@ -168,7 +168,7 @@
     "npm": "3.10.10"
   },
   "scripts": {
-    "preanalyze-bundles": "cross-env WEBPACK_OUTPUT_JSON=1 CALYPSO_ENV=production npm run -s env -- node --max_old_space_size=8192 ./node_modules/webpack/bin/webpack.js --config webpack.config.js --profile --json > stats.json",
+    "preanalyze-bundles": "cross-env WEBPACK_OUTPUT_JSON=1 CALYPSO_ENV=production npm run -s env -- node --max_old_space_size=8192 ./node_modules/.bin/webpack --config webpack.config.js --profile --json > stats.json",
     "analyze-bundles": "webpack-bundle-analyzer stats.json public -h 0.0.0.0 -p 9898",
     "autoprefixer": "postcss -r --use autoprefixer",
     "prebuild": "npm run -s install-if-deps-outdated",


### PR DESCRIPTION
`npm run analyze-bundles` was broken in https://github.com/Automattic/wp-calypso/pull/18074 (by me).  This small PR restores the functionality.

Caveats:
1. node needs extra ram for this. i've given it 8GB but i'm pretty sure it only needs around 4