### PR TITLE
Webpack: use thread-loader instead of happypack

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,6 @@
     "get-video-id": "2.1.4",
     "globby": "6.1.0",
     "gridicons": "2.0.4",
-    "happypack": "4.0.0",
     "hard-source-webpack-plugin": "0.3.12",
     "hash.js": "1.1.3",
     "he": "0.5.0",
@@ -283,6 +282,7 @@
     "socket.io": "1.4.5",
     "stylelint": "6.9.0",
     "supertest": "2.0.0",
+    "thread-loader": "1.1.2",
     "uglify-js": "2.7.0",
     "webpack-bundle-analyzer": "2.8.2"
   },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -81,7 +81,11 @@ const webpackConfig = {
 			{
 				test: /\.jsx?$/,
 				exclude: /node_modules[\/\\](?!notifications-panel)/,
-				loader: [ 'thread-loader', babelLoader ]
+				loader: _.compact( [
+					'thread-loader',
+					process.env.NODE_ENV === 'development' && 'react-hot-loader',
+					babelLoader,
+				] ),
 			},
 			{
 				test: /extensions[\/\\]index/,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,7 +7,6 @@ const _ = require( 'lodash' );
 const CopyWebpackPlugin = require( 'copy-webpack-plugin' );
 const DashboardPlugin = require( 'webpack-dashboard/plugin' );
 const fs = require( 'fs' );
-const HappyPack = require( 'happypack' );
 const HardSourceWebpackPlugin = require( 'hard-source-webpack-plugin' );
 const path = require( 'path' );
 const webpack = require( 'webpack' );
@@ -82,7 +81,7 @@ const webpackConfig = {
 			{
 				test: /\.jsx?$/,
 				exclude: /node_modules[\/\\](?!notifications-panel)/,
-				loader: [ 'happypack/loader' ]
+				loader: [ 'thread-loader', babelLoader ]
 			},
 			{
 				test: /extensions[\/\\]index/,
@@ -143,12 +142,6 @@ const webpackConfig = {
 		} ),
 		new webpack.IgnorePlugin( /^props$/ ),
 		new CopyWebpackPlugin( [ { from: 'node_modules/flag-icon-css/flags/4x3', to: 'images/flags' } ] ),
-		new HappyPack( {
-			loaders: _.compact( [
-				process.env.NODE_ENV === 'development' && 'react-hot-loader',
-				babelLoader
-			] )
-		} ),
 		new webpack.NamedModulesPlugin(),
 		new webpack.NamedChunksPlugin( chunk => {
 			if ( chunk.name ) {

--- a/webpack.config.node.js
+++ b/webpack.config.node.js
@@ -4,7 +4,6 @@
  * External dependencies
  */
 const fs = require( 'fs' );
-const HappyPack = require( 'happypack' );
 const HardSourceWebpackPlugin = require( 'hard-source-webpack-plugin' );
 const path = require( 'path' );
 const webpack = require( 'webpack' );
@@ -91,7 +90,7 @@ const webpackConfig = {
 			{
 				test: /\.jsx?$/,
 				exclude: /(node_modules|devdocs[\/\\]search-index)/,
-				loader: [ 'happypack/loader' ]
+				loader: [ 'thread-loader', babelLoader ]
 			},
 		]
 	},
@@ -117,7 +116,6 @@ const webpackConfig = {
 		new webpack.DefinePlugin( {
 			'PROJECT_NAME': JSON.stringify( config( 'project' ) )
 		} ),
-		new HappyPack( { loaders: [ babelLoader ] } ),
 		new webpack.NormalModuleReplacementPlugin( /^lib[\/\\]analytics$/, 'lodash/noop' ), // Depends on BOM
 		new webpack.NormalModuleReplacementPlugin( /^lib[\/\\]sites-list$/, 'lodash/noop' ), // Depends on BOM
 		new webpack.NormalModuleReplacementPlugin( /^lib[\/\\]olark$/, 'lodash/noop' ), // Depends on DOM


### PR DESCRIPTION
This PR is an experiment in using [thread-loader](https://github.com/webpack-contrib/thread-loader) instead of [happypack](https://github.com/amireh/happypack) for parallelization.

I believe that thread-loader will be better supported in the future considering it is part of of the official `webpack-contrib`.

From some basic tests it seems to be on-par with happypack.