### PR TITLE
Build: test out autoddlplugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -242,6 +242,7 @@
   },
   "devDependencies": {
     "5to6-codemod": "5to6/5to6-codemod#v1.7.0",
+    "autodll-webpack-plugin": "0.2.1",
     "babel-eslint": "6.1.2",
     "cash-touch": "0.2.0",
     "chai": "3.5.0",

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -90,6 +90,10 @@ function generateStaticUrls() {
 			config( 'env' ) === 'development' ? asset.js : asset.js.replace( '.js', '.min.js' );
 	} );
 
+	if ( config( 'env' ) === 'development' ) {
+		urls.vendor = '/calypso/vendor.js';
+	}
+
 	return urls;
 }
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -186,7 +186,6 @@ const vendorLibs = [
 	'i18n-calypso',
 	'lodash',
 	'moment',
-	'fs',
 	'page',
 	'react',
 	'create-react-class',
@@ -197,7 +196,7 @@ const vendorLibs = [
 	'redux-thunk',
 	'store',
 	'superagent',
-	'wpcom',
+	// 'wpcom',
 ];
 
 if ( calypsoEnv === 'desktop' ) {
@@ -213,7 +212,7 @@ if ( calypsoEnv === 'desktop' ) {
 	// it extracts the "runtime" so that the frequently changing mapping doesn't break caching of the entry chunks
 	// NOTE: order matters. vendor must be before manifest.
 	webpackConfig.plugins = webpackConfig.plugins.concat( [
-		new webpack.optimize.CommonsChunkPlugin( { name: 'vendor', minChunks: Infinity } ),
+		// new webpack.optimize.CommonsChunkPlugin( { name: 'vendor', minChunks: Infinity } ),
 		new webpack.optimize.CommonsChunkPlugin( { name: 'manifest' } )
 	] );
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,6 +13,7 @@ const path = require( 'path' );
 const webpack = require( 'webpack' );
 const NameAllModulesPlugin = require( 'name-all-modules-plugin' );
 const AssetsPlugin = require( 'assets-webpack-plugin' );
+const AutoDllPlugin = require( 'autodll-webpack-plugin' );
 
 /**
  * Internal dependencies
@@ -166,27 +167,45 @@ const webpackConfig = {
 	externals: [ 'electron' ]
 };
 
+const vendorLibs = [
+	'classnames',
+	'd3-array',
+	'd3-scale',
+	'd3-selection',
+	'd3-shape',
+	'dom-helpers',
+	'flux',
+	'get-video-id',
+	'jquery',
+	'marked',
+	'q',
+	'twemoji',
+	'tween.js',
+	'tinymce',
+	'is-my-json-valid',
+	'i18n-calypso',
+	'lodash',
+	'moment',
+	'fs',
+	'page',
+	'react',
+	'create-react-class',
+	'prop-types',
+	'react-dom',
+	'react-redux',
+	'redux',
+	'redux-thunk',
+	'store',
+	'superagent',
+	'wpcom',
+];
+
 if ( calypsoEnv === 'desktop' ) {
 	// no chunks or dll here, just one big file for the desktop app
 	webpackConfig.output.filename = '[name].js';
 } else {
 	// vendor chunk
-	webpackConfig.entry.vendor = [
-		'classnames',
-		'i18n-calypso',
-		'lodash',
-		'moment',
-		'page',
-		'react',
-		'create-react-class',
-		'prop-types',
-		'react-dom',
-		'react-redux',
-		'redux',
-		'redux-thunk',
-		'store',
-		'wpcom',
-	];
+	// webpackConfig.entry.vendor = vendorLibs;
 
 	// for details on what the manifest is, see: https://webpack.js.org/guides/caching/
 	// tldr: webpack maintains a mapping from chunk ids --> filenames.  whenever a filename changes
@@ -211,6 +230,13 @@ if ( calypsoEnv === 'development' ) {
 	webpackConfig.plugins = webpackConfig.plugins.concat( [
 		new webpack.HotModuleReplacementPlugin(),
 		new webpack.LoaderOptionsPlugin( { debug: true } ),
+		new AutoDllPlugin( {
+			debug: true,
+			filename: '[name].js',
+			entry: {
+				vendor: vendorLibs
+			}
+		} )
 	] );
 	webpackConfig.entry.build = [
 		'webpack-hot-middleware/client',


### PR DESCRIPTION
tests out for speeding up builds in dev: https://github.com/asfktz/autodll-webpack-plugin

seems to double inc build speed (to ~2s) and drop cached builds by 20% (40s --> 32s)