### PR TITLE
reformat-files: dep should be on 'jest-docblock' not on 'docblock'

### DIFF
--- a/bin/reformat-files.js
+++ b/bin/reformat-files.js
@@ -9,7 +9,7 @@ const glob = require( 'glob' );
 const ignore = require( 'ignore' );
 const path = require( 'path' );
 const prettier = require( 'prettier' );
-const docblock = require( 'docblock' );
+const docblock = require( 'jest-docblock' );
 
 /**
  * Returns true if the given text contains @format.


### PR DESCRIPTION
`require('docblock')` --> `require('jest-docblock')`

🤕 