### PR TITLE
Update styling of diffs to improve a11y

### DIFF
--- a/client/post-editor/editor-diff-viewer/style.scss
+++ b/client/post-editor/editor-diff-viewer/style.scss
@@ -22,12 +22,12 @@
 }
 
 .editor-diff-viewer__additions {
-	background: #e8f9fe;
+	background: lighten( $blue-wordpress, 58% );
 	border-bottom: 2px solid $blue-wordpress;
 }
 
 .editor-diff-viewer__deletions {
-	background: #fbeded;
+	background: lighten( $alert-red, 38% );
 	border-bottom: 2px solid $alert-red;
 	text-decoration: line-through;
 }

--- a/client/post-editor/editor-diff-viewer/style.scss
+++ b/client/post-editor/editor-diff-viewer/style.scss
@@ -22,10 +22,12 @@
 }
 
 .editor-diff-viewer__additions {
-	background: #e9f9fe;
+	background: #e8f9fe;
+	border-bottom: 2px solid $blue-wordpress;
 }
 
 .editor-diff-viewer__deletions {
-	color: #c83240;
+	background: #fbeded;
+	border-bottom: 2px solid $alert-red;
 	text-decoration: line-through;
 }


### PR DESCRIPTION
This PR includes a small visual update that fixes Issue #18551:
`Post Revisions: Improve Diff Styling for Accessibility` 

**How to test:**
Navigate to a post that has revisions and view a post revision.


**Before:**

<img width="290" alt="screen shot 2017-10-10 at 12 08 22" src="https://user-images.githubusercontent.com/1562646/31381087-c42bfb6a-adb3-11e7-8522-e1e57c270b9f.png">


**After:**

<img width="354" alt="screen shot 2017-10-10 at 11 21 57" src="https://user-images.githubusercontent.com/1562646/31380907-21f8c706-adb3-11e7-8952-cadc859a5e7d.png">

<img width="994" alt="screen shot 2017-10-10 at 11 58 20" src="https://user-images.githubusercontent.com/1562646/31380935-32f5711c-adb3-11e7-9be3-269f7c126f52.png">
