### PR TITLE
Fix issue #18599: categories search icon overlap

### DIFF
--- a/client/blocks/term-tree-selector/search.scss
+++ b/client/blocks/term-tree-selector/search.scss
@@ -9,7 +9,7 @@
 	top: 9px;
 }
 
-.term-tree-selector__search input {
+.term-tree-selector__search input[type="search"] {
 	right: 0;
 	width: 100%;
 	height: 35px;

--- a/client/my-sites/post-selector/style.scss
+++ b/client/my-sites/post-selector/style.scss
@@ -19,7 +19,7 @@
 	padding: 8px;
 }
 
-.post-selector__search input {
+.post-selector__search input[type="search"] {
 	right: 0;
 	width: 100%;
 	height: 35px;


### PR DESCRIPTION
This PR includes a small fix for Issue #18599:
`Components: search icon and text overlap`

The correct styles were already in the code base, the issue was related to selector specificity.

#### How to test
1. Use a site with lots of categories.
2. Go into post editor, and open Settings to see the sidebar menus.
3. Search for categories.

#### Before

<img width="246" alt="screen shot 2017-10-10 at 12 40 25" src="https://user-images.githubusercontent.com/1562646/31382968-a76bfad8-adb9-11e7-810a-842db7927cc5.png">


#### After

<img width="250" alt="screen shot 2017-10-10 at 12 39 57" src="https://user-images.githubusercontent.com/1562646/31382928-8801c98e-adb9-11e7-8458-c12345c718ea.png">




