### PR TITLE
Resolve auth promise

### DIFF
--- a/client/lib/happychat/connection.js
+++ b/client/lib/happychat/connection.js
@@ -40,8 +40,7 @@ class Connection {
 		dispatch( setConnecting() );
 
 		const socket = buildConnection( url );
-		this.openSocket = new Promise( resolve => {
-			// TODO: reject this promise
+		this.openSocket = new Promise( ( resolve, reject ) => {
 			socket
 				.once( 'connect', () => debug( 'connected' ) )
 				.on( 'token', handler => handler( { signer_user_id, jwt, locale, groups } ) )
@@ -52,7 +51,10 @@ class Connection {
 					dispatch( requestChatTranscript() );
 					resolve( socket );
 				} )
-				.on( 'unauthorized', () => socket.close() )
+				.on( 'unauthorized', () => {
+					socket.close();
+					reject( 'user is not authorized' );
+				} )
 				.on( 'disconnect', reason => dispatch( setDisconnected( reason ) ) )
 				.on( 'reconnecting', () => dispatch( setReconnecting() ) )
 				.on( 'status', status => dispatch( setHappychatChatStatus( status ) ) )


### PR DESCRIPTION
Master issue: https://github.com/Automattic/wp-calypso/issues/18670

Current SocketIO authentication doesn't reject the auth promise. If the authentication mechanism fails, the user won't be able to reconnect the socket until Calypso is reloaded (which forces the creation of a new connection).

### Testing

Would love to have specific steps. Unfortunately, I'm still not sure about this one: what would be the conditions under which the authentication fails for a user and then it works? Perhaps a dotcom server failure that prevents any of the HTTP requests from working? SocketIO server fails during auth mechanism?
