### PR TITLE
Fix redirectTo value used after login

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -73,7 +73,7 @@ class Login extends Component {
 		}
 	};
 
-	handleValidLogin = redirectTo => {
+	handleValidLogin = () => {
 		if ( this.props.twoFactorEnabled ) {
 			page(
 				login( {
@@ -83,7 +83,6 @@ class Login extends Component {
 						'none',
 						'authenticator'
 					),
-					redirectTo,
 				} )
 			);
 		} else if ( this.props.isLinking ) {
@@ -91,11 +90,10 @@ class Login extends Component {
 				login( {
 					isNative: true,
 					socialConnect: true,
-					redirectTo,
 				} )
 			);
 		} else {
-			this.rebootAfterLogin( redirectTo );
+			this.rebootAfterLogin();
 		}
 	};
 
@@ -112,8 +110,8 @@ class Login extends Component {
 		}
 	};
 
-	rebootAfterLogin = redirectTo => {
-		redirectTo = redirectTo || this.props.redirectTo;
+	rebootAfterLogin = () => {
+		const { redirectTo } = this.props;
 
 		this.props.recordTracksEvent( 'calypso_login_success', {
 			two_factor_enabled: this.props.twoFactorEnabled,

--- a/client/blocks/login/social.jsx
+++ b/client/blocks/login/social.jsx
@@ -37,7 +37,7 @@ function shouldUseRedirectFlow() {
 	const isPopup = typeof window !== 'undefined' && window.opener && window.opener !== window;
 	// also disable the popup flow for all safari versions
 	// See https://github.com/google/google-api-javascript-client/issues/297#issuecomment-333869742
-	return isPopup || isSafari();
+	return true || isPopup || isSafari();
 }
 
 class SocialLoginForm extends Component {
@@ -88,7 +88,7 @@ class SocialLoginForm extends Component {
 			() => {
 				this.recordEvent( 'calypso_login_social_login_success' );
 
-				onSuccess( redirectTo );
+				onSuccess();
 			},
 			error => {
 				if ( error.code === 'unknown_user' ) {


### PR DESCRIPTION
Fixes https://github.com/Automattic/jpop-issues/issues/1116
The change introduced [here](https://github.com/Automattic/wp-calypso/commit/9a1d3fc5101c6224742aa1298291f3f6d7f50b11#diff-3438d0da23b3176f5d05d0d0650da6a3R116) in https://github.com/Automattic/wp-calypso/pull/18464 was causing the `redirect_to` param sent back by the server to be ignored in favor of the original one.

### Testing Instructions
- Navigate to https://calypso.live/?branch=fix/social-login-redirect and wait for it to boot
- From an un-connected site's wp-admin, get the link from 'connect jetpack' and enter it in curl to get the Location header:
```
curl -I "https://jetpack.wordpress.com/jetpack.authorize/1/?response_type=code&client_id=1301..."
HTTP/1.1 302 Found
Server: nginx
...
Location: https://wordpress.com/jetpack/connect/authorize?client_id=130198313&redirect_uri=http...
```
Get the link from the `Location` header and replace `https://wordpress.com/` with `https://calypso.live/`
- Past this url in your browser's address bar
- On the connection screen click 'sign in as a different user'
( or click 'Already have an account? Sign in' if you are logged out )
- sign in to an existing wordpress account
- Authorize on the next screen, it should work on the first try

### Reviews
- [ ] Code
- [x] Product