### PR TITLE
Comments: Replace user more info with a popover

### DIFF
--- a/assets/stylesheets/shared/functions/_z-index.scss
+++ b/assets/stylesheets/shared/functions/_z-index.scss
@@ -121,6 +121,7 @@ $z-layers: (
 		'.first-view': 175,
 		'.editor-confirmation-sidebar__overlay': 176,
 		'.editor-confirmation-sidebar__sidebar': 177,
+		'.popover.comment-detail__author-more-info': 178,
 		'.popover.editor-ground-control__post-schedule-popover': 178,
 		'.popover.editor-visibility__popover': 179,
 		'.feature-example__gradient': 179,

--- a/client/blocks/comment-detail/comment-detail-author-more-info.jsx
+++ b/client/blocks/comment-detail/comment-detail-author-more-info.jsx
@@ -1,0 +1,194 @@
+/**
+ * External dependencies
+ *
+ * @format
+ */
+import React from 'react';
+import { connect } from 'react-redux';
+import Gridicon from 'gridicons';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Button from 'components/button';
+import Emojify from 'components/emojify';
+import ExternalLink from 'components/external-link';
+import InfoPopover from 'components/info-popover';
+import { urlToDomainAndPath } from 'lib/url';
+import { getSite } from 'state/sites/selectors';
+import { saveSiteSettings } from 'state/site-settings/actions';
+import { successNotice } from 'state/notices/actions';
+import { canCurrentUser } from 'state/selectors';
+import { getCurrentUserEmail } from 'state/current-user/selectors';
+import {
+	bumpStat,
+	composeAnalytics,
+	recordTracksEvent,
+	withAnalytics,
+} from 'state/analytics/actions';
+
+export const CommentDetailAuthorMoreInfo = ( {
+	authorDisplayName,
+	authorEmail,
+	authorId,
+	authorIp,
+	authorIsBlocked,
+	authorUrl,
+	authorUsername,
+	canUserBlacklist,
+	commentId,
+	currentUserEmail,
+	showNotice,
+	site,
+	siteBlacklist,
+	trackAnonymousModeration,
+	translate,
+	updateBlacklist,
+} ) => {
+	const showBlockUser = canUserBlacklist && !! authorEmail && authorEmail !== currentUserEmail;
+
+	const toggleBlockUser = () => {
+		const noticeOptions = {
+			duration: 5000,
+			id: `comment-notice-${ commentId }`,
+			isPersistent: true,
+		};
+
+		const analytics = {
+			action: authorIsBlocked ? 'unblock_user' : 'block_user',
+			user_type: authorId ? 'wpcom' : 'email_only',
+		};
+
+		if ( authorIsBlocked ) {
+			showNotice(
+				translate( 'User %(email)s unblocked.', { args: { email: authorEmail } } ),
+				noticeOptions
+			);
+
+			const newBlacklist = siteBlacklist
+				.split( '\n' )
+				.filter( item => item !== authorEmail )
+				.join( '\n' );
+
+			return updateBlacklist( newBlacklist, analytics );
+		}
+
+		showNotice(
+			translate( 'User %(email)s is blocked and can no longer comment on your site.', {
+				args: { email: authorEmail },
+			} ),
+			noticeOptions
+		);
+
+		const newBlacklist = !! siteBlacklist ? siteBlacklist + '\n' + authorEmail : authorEmail;
+
+		return updateBlacklist( newBlacklist, analytics );
+	};
+
+	return (
+		<InfoPopover
+			className="comment-detail__author-more-info"
+			iconSize={ 24 }
+			position="bottom left"
+		>
+			<div className="comment-detail__author-more-element comment-detail__author-more-element-author">
+				<Gridicon icon="user-circle" />
+				<div className="comment-detail__author-info">
+					<div className="comment-detail__author-name">
+						<strong>
+							<Emojify>{ authorDisplayName }</Emojify>
+						</strong>
+					</div>
+					<div className="comment-detail__author-username">{ authorUsername }</div>
+				</div>
+			</div>
+			<div className="comment-detail__author-more-element">
+				<Gridicon icon="mail" />
+				<span>{ authorEmail || <em>{ translate( 'No email address' ) }</em> }</span>
+			</div>
+			<div className="comment-detail__author-more-element">
+				<Gridicon icon="link" />
+				{ !! authorUrl && (
+					<ExternalLink href={ authorUrl }>
+						<Emojify>{ urlToDomainAndPath( authorUrl ) }</Emojify>
+					</ExternalLink>
+				) }
+				{ ! authorUrl && <em>{ translate( 'No website' ) }</em> }
+			</div>
+			<div className="comment-detail__author-more-element">
+				<Gridicon icon="globe" />
+				<span>{ authorIp || <em>{ translate( 'No IP address' ) }</em> }</span>
+			</div>
+			{ showBlockUser && (
+				<div className="comment-detail__author-more-element">
+					<Button compact onClick={ toggleBlockUser }>
+						<Gridicon icon="block" />
+						<span>
+							{ authorIsBlocked ? translate( 'Unblock user' ) : translate( 'Block user' ) }
+						</span>
+					</Button>
+				</div>
+			) }
+			{ ! authorEmail && (
+				<div className="comment-detail__author-more-element comment-detail__author-more-element-block-anonymous-user">
+					<span>
+						{ translate(
+							// eslint-disable-next-line max-len
+							"Anonymous messages can't be blocked individually, but you can update your {{a}}settings{{/a}} to only allow comments from registered users.",
+							{
+								components: {
+									a: (
+										<a
+											href={ `/settings/discussion/${ site.slug }` }
+											onClick={ trackAnonymousModeration }
+										/>
+									),
+								},
+							}
+						) }
+					</span>
+				</div>
+			) }
+		</InfoPopover>
+	);
+};
+
+const mapStateToProps = ( state, { siteId } ) => ( {
+	canUserBlacklist: canCurrentUser( state, siteId, 'manage_options' ),
+	currentUserEmail: getCurrentUserEmail( state ),
+	site: getSite( state, siteId ),
+} );
+
+const mapDispatchToProps = ( dispatch, { siteId } ) => ( {
+	showNotice: ( text, options ) => dispatch( successNotice( text, options ) ),
+	updateBlacklist: ( blacklist_keys, analytics ) =>
+		dispatch(
+			withAnalytics(
+				composeAnalytics(
+					recordTracksEvent( 'calypso_comment_management_moderate_user', analytics ),
+					bumpStat(
+						'calypso_comment_management',
+						'block_user' === analytics.action
+							? 'comment_author_blocked'
+							: 'comment_author_unblocked'
+					)
+				),
+				saveSiteSettings( siteId, { blacklist_keys } )
+			)
+		),
+	trackAnonymousModeration: () =>
+		dispatch(
+			composeAnalytics(
+				recordTracksEvent( 'calypso_comment_management_moderate_user', {
+					action: 'open_discussion_settings',
+					user_type: 'anonymous',
+				} ),
+				bumpStat( 'calypso_comment_management', 'open_discussion_settings' )
+			)
+		),
+} );
+
+export default connect( mapStateToProps, mapDispatchToProps )(
+	localize( CommentDetailAuthorMoreInfo )
+);

--- a/client/blocks/comment-detail/comment-detail-author-more-info.jsx
+++ b/client/blocks/comment-detail/comment-detail-author-more-info.jsx
@@ -3,7 +3,7 @@
  *
  * @format
  */
-import React from 'react';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import Gridicon from 'gridicons';
 import { localize } from 'i18n-calypso';
@@ -28,27 +28,24 @@ import {
 	withAnalytics,
 } from 'state/analytics/actions';
 
-export const CommentDetailAuthorMoreInfo = ( {
-	authorDisplayName,
-	authorEmail,
-	authorId,
-	authorIp,
-	authorIsBlocked,
-	authorUrl,
-	authorUsername,
-	canUserBlacklist,
-	commentId,
-	currentUserEmail,
-	showNotice,
-	site,
-	siteBlacklist,
-	trackAnonymousModeration,
-	translate,
-	updateBlacklist,
-} ) => {
-	const showBlockUser = canUserBlacklist && !! authorEmail && authorEmail !== currentUserEmail;
+export class CommentDetailAuthorMoreInfo extends Component {
+	showBlockUser = () =>
+		this.props.canUserBlacklist &&
+		!! this.props.authorEmail &&
+		this.props.authorEmail !== this.props.currentUserEmail;
 
-	const toggleBlockUser = () => {
+	toggleBlockUser = () => {
+		const {
+			authorEmail,
+			authorId,
+			authorIsBlocked,
+			commentId,
+			showNotice,
+			siteBlacklist,
+			translate,
+			updateBlacklist,
+		} = this.props;
+
 		const noticeOptions = {
 			duration: 5000,
 			id: `comment-notice-${ commentId }`,
@@ -86,73 +83,87 @@ export const CommentDetailAuthorMoreInfo = ( {
 		return updateBlacklist( newBlacklist, analytics );
 	};
 
-	return (
-		<InfoPopover
-			className="comment-detail__author-more-info"
-			iconSize={ 24 }
-			position="bottom left"
-		>
-			<div className="comment-detail__author-more-element comment-detail__author-more-element-author">
-				<Gridicon icon="user-circle" />
-				<div className="comment-detail__author-info">
-					<div className="comment-detail__author-name">
-						<strong>
-							<Emojify>{ authorDisplayName }</Emojify>
-						</strong>
+	render() {
+		const {
+			authorDisplayName,
+			authorEmail,
+			authorIp,
+			authorIsBlocked,
+			authorUrl,
+			authorUsername,
+			site,
+			trackAnonymousModeration,
+			translate,
+		} = this.props;
+
+		return (
+			<InfoPopover
+				className="comment-detail__author-more-info"
+				iconSize={ 24 }
+				position="bottom left"
+			>
+				<div className="comment-detail__author-more-element comment-detail__author-more-element-author">
+					<Gridicon icon="user-circle" />
+					<div className="comment-detail__author-info">
+						<div className="comment-detail__author-name">
+							<strong>
+								<Emojify>{ authorDisplayName }</Emojify>
+							</strong>
+						</div>
+						<div className="comment-detail__author-username">{ authorUsername }</div>
 					</div>
-					<div className="comment-detail__author-username">{ authorUsername }</div>
 				</div>
-			</div>
-			<div className="comment-detail__author-more-element">
-				<Gridicon icon="mail" />
-				<span>{ authorEmail || <em>{ translate( 'No email address' ) }</em> }</span>
-			</div>
-			<div className="comment-detail__author-more-element">
-				<Gridicon icon="link" />
-				{ !! authorUrl && (
-					<ExternalLink href={ authorUrl }>
-						<Emojify>{ urlToDomainAndPath( authorUrl ) }</Emojify>
-					</ExternalLink>
-				) }
-				{ ! authorUrl && <em>{ translate( 'No website' ) }</em> }
-			</div>
-			<div className="comment-detail__author-more-element">
-				<Gridicon icon="globe" />
-				<span>{ authorIp || <em>{ translate( 'No IP address' ) }</em> }</span>
-			</div>
-			{ showBlockUser && (
 				<div className="comment-detail__author-more-element">
-					<Button compact onClick={ toggleBlockUser }>
-						<Gridicon icon="block" />
+					<Gridicon icon="mail" />
+					<span>{ authorEmail || <em>{ translate( 'No email address' ) }</em> }</span>
+				</div>
+				<div className="comment-detail__author-more-element">
+					<Gridicon icon="link" />
+					{ !! authorUrl && (
+						<ExternalLink href={ authorUrl }>
+							<Emojify>{ urlToDomainAndPath( authorUrl ) }</Emojify>
+						</ExternalLink>
+					) }
+					{ ! authorUrl && <em>{ translate( 'No website' ) }</em> }
+				</div>
+				<div className="comment-detail__author-more-element">
+					<Gridicon icon="globe" />
+					<span>{ authorIp || <em>{ translate( 'No IP address' ) }</em> }</span>
+				</div>
+				{ this.showBlockUser() && (
+					<div className="comment-detail__author-more-element">
+						<Button compact onClick={ this.toggleBlockUser }>
+							<Gridicon icon="block" />
+							<span>
+								{ authorIsBlocked ? translate( 'Unblock user' ) : translate( 'Block user' ) }
+							</span>
+						</Button>
+					</div>
+				) }
+				{ ! authorEmail && (
+					<div className="comment-detail__author-more-element comment-detail__author-more-element-block-anonymous-user">
 						<span>
-							{ authorIsBlocked ? translate( 'Unblock user' ) : translate( 'Block user' ) }
+							{ translate(
+								// eslint-disable-next-line max-len
+								"Anonymous messages can't be blocked individually, but you can update your {{a}}settings{{/a}} to only allow comments from registered users.",
+								{
+									components: {
+										a: (
+											<a
+												href={ `/settings/discussion/${ site.slug }` }
+												onClick={ trackAnonymousModeration }
+											/>
+										),
+									},
+								}
+							) }
 						</span>
-					</Button>
-				</div>
-			) }
-			{ ! authorEmail && (
-				<div className="comment-detail__author-more-element comment-detail__author-more-element-block-anonymous-user">
-					<span>
-						{ translate(
-							// eslint-disable-next-line max-len
-							"Anonymous messages can't be blocked individually, but you can update your {{a}}settings{{/a}} to only allow comments from registered users.",
-							{
-								components: {
-									a: (
-										<a
-											href={ `/settings/discussion/${ site.slug }` }
-											onClick={ trackAnonymousModeration }
-										/>
-									),
-								},
-							}
-						) }
-					</span>
-				</div>
-			) }
-		</InfoPopover>
-	);
-};
+					</div>
+				) }
+			</InfoPopover>
+		);
+	}
+}
 
 const mapStateToProps = ( state, { siteId } ) => ( {
 	canUserBlacklist: canCurrentUser( state, siteId, 'manage_options' ),

--- a/client/blocks/comment-detail/comment-detail-author-more-info.jsx
+++ b/client/blocks/comment-detail/comment-detail-author-more-info.jsx
@@ -132,8 +132,7 @@ export class CommentDetailAuthorMoreInfo extends Component {
 				</div>
 				{ this.showBlockUser() && (
 					<div className="comment-detail__author-more-element">
-						<Button compact onClick={ this.toggleBlockUser }>
-							<Gridicon icon="block" />
+						<Button scary={ ! authorIsBlocked } onClick={ this.toggleBlockUser }>
 							<span>
 								{ authorIsBlocked ? translate( 'Unblock user' ) : translate( 'Block user' ) }
 							</span>

--- a/client/blocks/comment-detail/comment-detail-author.jsx
+++ b/client/blocks/comment-detail/comment-detail-author.jsx
@@ -4,8 +4,8 @@
  * @format
  */
 
-import React, { Component } from 'react';
-import PropTypes from 'prop-types';
+import React from 'react';
+import { connect } from 'react-redux';
 import Gridicon from 'gridicons';
 import { localize } from 'i18n-calypso';
 import { some } from 'lodash';
@@ -20,114 +20,97 @@ import Gravatar from 'components/gravatar';
 import { urlToDomainAndPath } from 'lib/url';
 import { convertDateToUserLocation } from 'components/post-schedule/utils';
 import { gmtOffset, timezone } from 'lib/site/utils';
+import { getSite } from 'state/sites/selectors';
 
-export class CommentDetailAuthor extends Component {
-	static propTypes = {
-		authorAvatarUrl: PropTypes.string,
-		authorDisplayName: PropTypes.string,
-		authorEmail: PropTypes.oneOfType( [ PropTypes.bool, PropTypes.string ] ),
-		authorId: PropTypes.number,
-		authorIp: PropTypes.string,
-		authorIsBlocked: PropTypes.bool,
-		authorUrl: PropTypes.string,
-		authorUsername: PropTypes.string,
-		commentDate: PropTypes.string,
-		commentId: PropTypes.number,
-		commentStatus: PropTypes.string,
-		commentType: PropTypes.string,
-		commentUrl: PropTypes.string,
-		siteBlacklist: PropTypes.string,
-		siteId: PropTypes.number,
-	};
+export const CommentDetailAuthor = ( {
+	authorAvatarUrl,
+	authorDisplayName,
+	authorEmail,
+	authorId,
+	authorIp,
+	authorIsBlocked,
+	authorUrl,
+	authorUsername,
+	commentDate,
+	commentId,
+	commentStatus,
+	commentType,
+	commentUrl,
+	siteBlacklist,
+	site,
+	siteId,
+	translate,
+} ) => {
+	const formattedDate = convertDateToUserLocation(
+		commentDate || new Date(),
+		timezone( site ),
+		gmtOffset( site )
+	).format( 'll LT' );
 
-	getFormattedDate = () =>
-		convertDateToUserLocation(
-			this.props.commentDate || new Date(),
-			timezone( this.props.site ),
-			gmtOffset( this.props.site )
-		).format( 'll LT' );
+	const showMoreInfo = 'comment' === commentType && some( [ authorEmail, authorIp, authorUrl ] );
 
-	showMoreInfo = () =>
-		'comment' === this.props.commentType &&
-		some( [ this.props.authorEmail, this.props.authorIp, this.props.authorUrl ] );
-
-	render() {
-		const {
-			authorDisplayName,
-			authorEmail,
-			authorId,
-			authorIp,
-			authorIsBlocked,
-			authorUrl,
-			authorUsername,
-			commentId,
-			commentStatus,
-			commentType,
-			commentUrl,
-			siteBlacklist,
-			siteId,
-			translate,
-		} = this.props;
-
-		return (
-			<div className="comment-detail__author">
-				<div className="comment-detail__author-preview">
+	return (
+		<div className="comment-detail__author">
+			<div className="comment-detail__author-preview">
+				<div className="comment-detail__author-avatar">
 					<div className="comment-detail__author-avatar">
-						<div className="comment-detail__author-avatar">
-							{ 'comment' === commentType && (
-								<Gravatar
-									user={ {
-										avatar_URL: this.props.authorAvatarUrl,
-										display_name: this.props.authorDisplayName,
-									} }
-								/>
-							) }
-							{ 'comment' !== commentType && <Gridicon icon="link" size={ 24 } /> }
-						</div>
-					</div>
-					<div className="comment-detail__author-info">
-						<div className="comment-detail__author-info-element comment-detail__author-name">
-							<strong>
-								<Emojify>{ authorDisplayName }</Emojify>
-							</strong>
-							<ExternalLink href={ authorUrl }>
-								<Emojify>{ urlToDomainAndPath( authorUrl ) }</Emojify>
-							</ExternalLink>
-						</div>
-						<ExternalLink
-							className="comment-detail__author-info-element comment-detail__comment-date"
-							href={ commentUrl }
-						>
-							{ this.getFormattedDate() }
-						</ExternalLink>
-					</div>
-
-					<div className="comment-detail__author-preview-actions">
-						{ 'unapproved' === commentStatus && (
-							<div className="comment-detail__status-label is-unapproved">
-								{ translate( 'Pending' ) }
-							</div>
-						) }
-
-						{ this.showMoreInfo() && (
-							<CommentDetailAuthorMoreInfo
-								authorDisplayName={ authorDisplayName }
-								authorEmail={ authorEmail }
-								authorId={ authorId }
-								authorIp={ authorIp }
-								authorIsBlocked={ authorIsBlocked }
-								authorUrl={ authorUrl }
-								authorUsername={ authorUsername }
-								commentId={ commentId }
-								siteBlacklist={ siteBlacklist }
-								siteId={ siteId }
+						{ 'comment' === commentType && (
+							<Gravatar
+								user={ {
+									avatar_URL: authorAvatarUrl,
+									display_name: authorDisplayName,
+								} }
 							/>
 						) }
+						{ 'comment' !== commentType && <Gridicon icon="link" size={ 24 } /> }
 					</div>
 				</div>
-			</div>
-		);
-	}
-}
+				<div className="comment-detail__author-info">
+					<div className="comment-detail__author-info-element comment-detail__author-name">
+						<strong>
+							<Emojify>{ authorDisplayName }</Emojify>
+						</strong>
+						<ExternalLink href={ authorUrl }>
+							<Emojify>{ urlToDomainAndPath( authorUrl ) }</Emojify>
+						</ExternalLink>
+					</div>
+					<ExternalLink
+						className="comment-detail__author-info-element comment-detail__comment-date"
+						href={ commentUrl }
+					>
+						{ formattedDate }
+					</ExternalLink>
+				</div>
 
-export default localize( CommentDetailAuthor );
+				<div className="comment-detail__author-preview-actions">
+					{ 'unapproved' === commentStatus && (
+						<div className="comment-detail__status-label is-unapproved">
+							{ translate( 'Pending' ) }
+						</div>
+					) }
+
+					{ showMoreInfo && (
+						<CommentDetailAuthorMoreInfo
+							authorDisplayName={ authorDisplayName }
+							authorEmail={ authorEmail }
+							authorId={ authorId }
+							authorIp={ authorIp }
+							authorIsBlocked={ authorIsBlocked }
+							authorUrl={ authorUrl }
+							authorUsername={ authorUsername }
+							commentId={ commentId }
+							siteBlacklist={ siteBlacklist }
+							siteId={ siteId }
+						/>
+					) }
+				</div>
+			</div>
+		</div>
+	);
+};
+
+const mapStateToProps = ( state, { siteId } ) => ( {
+	site: getSite( state, siteId ),
+} );
+
+export default connect( mapStateToProps )( localize( CommentDetailAuthor ) );

--- a/client/blocks/comment-detail/style.scss
+++ b/client/blocks/comment-detail/style.scss
@@ -453,54 +453,36 @@
 }
 
 .comment-detail__author-more-info {
-	border-bottom: 1px solid lighten( $gray, 30% );
-	color: $gray-text-min;
-	display: none;
-	transform: scaleY( 0 );
-	transform-origin: top;
-
-	.gridicon {
-		color: $gray;
+	> .gridicon {
 		fill: $gray;
-	}
-}
-.comment-detail__author.is-expanded .comment-detail__author-more-info {
-	animation: comment-detail__author-more-info .15s linear;
-	display: block;
-	transform: scaleY( 1 );
-}
+		margin-left: 8px;
 
-.comment-detail__author-more-actions {
-	border-top: 1px solid lighten( $gray, 30% );
-	display: flex;
-	flex-flow: row wrap;
-	padding: 16px 8px;
+		&:focus,
+		&:hover {
+			color: $blue-wordpress;
+			fill: $blue-wordpress;
+		}
+	}
 }
 
 .comment-detail__author-more-element {
 	align-items: center;
-	box-sizing: border-box;
-	display: block;
-	flex-shrink: 0;
-	flex-grow: 0;
+	display: flex;
+	flex-flow: row nowrap;
+	margin-bottom: 8px;
 	overflow: hidden;
-	padding: 8px;
 	text-overflow: ellipsis;
 	white-space: nowrap;
 	width: 100%;
 
-	@include breakpoint( ">660px" ) {
-		width: 50%;
+	&:last-child {
+		margin-bottom: 0;
 	}
-}
 
-.comment-detail__author-more-element-author {
-	display: flex;
-	flex-flow: row nowrap;
-
-	.gravatar {
-		height: 24px;
-		width: 24px;
+	.gridicon {
+		fill: $gray;
+		margin-right: 4px;
+		vertical-align: middle;
 	}
 
 	.comment-detail__author-info {
@@ -512,10 +494,14 @@
 	strong {
 		float: none;
 	}
-}
 
-.comment-detail.card .comment-detail__author-more-element-block-user .gridicon {
-	vertical-align: baseline;
+	.button {
+		width: 100%;
+
+		.gridicon {
+			vertical-align: baseline;
+		}
+	}
 }
 
 .comment-detail__author-more-element-block-anonymous-user {

--- a/client/blocks/comment-detail/style.scss
+++ b/client/blocks/comment-detail/style.scss
@@ -497,10 +497,6 @@
 
 	.button {
 		width: 100%;
-
-		.gridicon {
-			vertical-align: baseline;
-		}
 	}
 }
 

--- a/client/blocks/comment-detail/style.scss
+++ b/client/blocks/comment-detail/style.scss
@@ -438,30 +438,19 @@
 	}
 }
 
-.comment-detail__author-more-info-toggle {
-	color: $gray;
-	cursor: pointer;
-	display: block;
+.popover.comment-detail__author-more-info {
+	/* applying a lower z-index to ensure it is layered behind global notice */
+	z-index: z-index( 'root', '.popover.comment-detail__author-more-info' );
+}
+
+.info-popover.comment-detail__author-more-info > .gridicon {
 	fill: $gray;
-	height: 24px;
 	margin-left: 8px;
+
 	&:focus,
 	&:hover {
 		color: $blue-wordpress;
 		fill: $blue-wordpress;
-	}
-}
-
-.comment-detail__author-more-info {
-	> .gridicon {
-		fill: $gray;
-		margin-left: 8px;
-
-		&:focus,
-		&:hover {
-			color: $blue-wordpress;
-			fill: $blue-wordpress;
-		}
 	}
 }
 

--- a/client/components/info-popover/index.jsx
+++ b/client/components/info-popover/index.jsx
@@ -3,16 +3,15 @@
  *
  * @format
  */
-
-import PropTypes from 'prop-types';
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import Gridicon from 'gridicons';
+import classNames from 'classnames';
 
 /**
-* Internal dependencies
-*/
+ * Internal dependencies
+ */
 import Popover from 'components/popover';
-import classNames from 'classnames';
 import analytics from 'lib/analytics';
 
 export default class InfoPopover extends Component {
@@ -20,6 +19,7 @@ export default class InfoPopover extends Component {
 		autoRtl: PropTypes.bool,
 		className: PropTypes.string,
 		gaEventCategory: PropTypes.string,
+		iconSize: PropTypes.number,
 		id: PropTypes.string,
 		ignoreContext: PropTypes.shape( {
 			getDOMNode: PropTypes.func,
@@ -40,6 +40,7 @@ export default class InfoPopover extends Component {
 
 	static defaultProps = {
 		autoRtl: true,
+		iconSize: 18,
 		position: 'bottom',
 	};
 
@@ -72,7 +73,7 @@ export default class InfoPopover extends Component {
 					this.props.className
 				) }
 			>
-				<Gridicon icon="info-outline" size={ 18 } />
+				<Gridicon icon="info-outline" size={ this.props.iconSize } />
 				<Popover
 					autoRtl={ this.props.autoRtl }
 					id={ this.props.id }


### PR DESCRIPTION
Closes #18596

Move the `CommentDetail`'s "User More Info" away from a box inside the details and into an `InfoPopover`.

| Before | After |
| --- | --- |
| <img width="621" alt="screen shot 2017-10-10 at 14 23 51" src="https://user-images.githubusercontent.com/2070010/31388683-b21e8cd6-adc6-11e7-8623-98b258d742f2.png"> | <img width="689" alt="screen shot 2017-10-11 at 11 35 36" src="https://user-images.githubusercontent.com/2070010/31435903-0c2d3c7e-ae79-11e7-8dae-e268c133e053.png"> |

### Variations

<img width="266" alt="screen shot 2017-10-10 at 14 15 46" src="https://user-images.githubusercontent.com/2070010/31388619-8479be04-adc6-11e7-8225-0115587377b0.png"> <img width="268" alt="screen shot 2017-10-10 at 14 16 02" src="https://user-images.githubusercontent.com/2070010/31388620-8498608e-adc6-11e7-9520-c2baf3a6cddf.png">

### Information

I've opted for moving the More Info code into its own file for clarity (thus the big changed LOC).
This will inevitably clash with the ongoing [Redux refactor](https://github.com/Automattic/wp-calypso/pull/18406), but at the same time won't add any more hurdles after fixing the conflicts.