### PR TITLE
Me: Remove LinkedStateMixin where obsolete

### DIFF
--- a/client/me/account-password/index.jsx
+++ b/client/me/account-password/index.jsx
@@ -8,7 +8,6 @@ import { localize } from 'i18n-calypso';
 import { debounce, flowRight as compose, head, isEmpty } from 'lodash';
 import { bindActionCreators } from 'redux';
 import React from 'react';
-import LinkedStateMixin from 'react-addons-linked-state-mixin';
 import debugFactory from 'debug';
 const debug = debugFactory( 'calypso:me:account-password' );
 import classNames from 'classnames';
@@ -34,7 +33,7 @@ import { errorNotice } from 'state/notices/actions';
 const AccountPassword = React.createClass( {
 	displayName: 'AccountPassword',
 
-	mixins: [ LinkedStateMixin, observe( 'accountPasswordData' ), eventRecorder ],
+	mixins: [ observe( 'accountPasswordData' ), eventRecorder ],
 
 	componentDidMount: function() {
 		this.debouncedPasswordValidate = debounce( this.validatePassword, 300 );

--- a/client/me/notification-settings/reader-subscriptions/index.jsx
+++ b/client/me/notification-settings/reader-subscriptions/index.jsx
@@ -25,12 +25,9 @@ import FormSelect from 'components/forms/form-select';
 import FormSectionHeading from 'components/forms/form-section-heading';
 import ReauthRequired from 'me/reauth-required';
 import twoStepAuthorization from 'lib/two-step-authorization';
-import observe from 'lib/mixins/data-observe'; //eslint-disable-line no-restricted-imports
+import observe from 'lib/mixins/data-observe';
 import eventRecorder from 'me/event-recorder';
 import Main from 'components/main';
-
-/* eslint-disable react/no-deprecated */
-/* eslint-disable wpcalypso/jsx-classname-namespace */
 
 module.exports = protectForm(
 	localize(
@@ -58,7 +55,6 @@ module.exports = protectForm(
 			},
 
 			render() {
-				/* eslint-disable max-len */
 				return (
 					<Main className="notifications-settings">
 						<MeSidebarNavigation />

--- a/client/me/notification-settings/reader-subscriptions/index.jsx
+++ b/client/me/notification-settings/reader-subscriptions/index.jsx
@@ -6,7 +6,6 @@
 
 import React from 'react';
 import { localize } from 'i18n-calypso';
-import LinkedStateMixin from 'react-addons-linked-state-mixin';
 
 /**
  * Internal dependencies
@@ -31,190 +30,202 @@ import eventRecorder from 'me/event-recorder';
 import Main from 'components/main';
 
 module.exports = protectForm(
-	localize(React.createClass( {
-		displayName: 'NotificationSubscriptions',
+	localize(
+		React.createClass( {
+			displayName: 'NotificationSubscriptions',
 
-		mixins: [ formBase, LinkedStateMixin, observe( 'userSettings' ), eventRecorder ],
+			mixins: [ formBase, observe( 'userSettings' ), eventRecorder ],
 
-		getDeliveryHourLabel( hour ) {
-			return this.props.translate( '%(fromHour)s - %(toHour)s', {
-				context: 'Hour range between which subscriptions are delivered',
-				args: {
-					fromHour: this.props.moment()
-						.hour( hour )
-						.minute( 0 )
-						.format( 'LT' ),
-					toHour: this.props.moment()
-						.hour( hour + 2 )
-						.minute( 0 )
-						.format( 'LT' ),
-				},
-			} );
-		},
+			getDeliveryHourLabel( hour ) {
+				return this.props.translate( '%(fromHour)s - %(toHour)s', {
+					context: 'Hour range between which subscriptions are delivered',
+					args: {
+						fromHour: this.props
+							.moment()
+							.hour( hour )
+							.minute( 0 )
+							.format( 'LT' ),
+						toHour: this.props
+							.moment()
+							.hour( hour + 2 )
+							.minute( 0 )
+							.format( 'LT' ),
+					},
+				} );
+			},
 
-		render() {
-			return (
-                <Main className="notifications-settings">
-					<MeSidebarNavigation />
-					<ReauthRequired twoStepAuthorization={ twoStepAuthorization } />
+			render() {
+				return (
+					<Main className="notifications-settings">
+						<MeSidebarNavigation />
+						<ReauthRequired twoStepAuthorization={ twoStepAuthorization } />
 
-					<Navigation path={ this.props.path } />
+						<Navigation path={ this.props.path } />
 
-					<Card className="me-notification-settings">
-						<form
-							id="notification-settings"
-							onChange={ this.props.markChanged }
-							onSubmit={ this.submitForm }
-						>
-							<FormSectionHeading>
-								{ this.props.translate( 'Subscriptions Delivery' ) }
-							</FormSectionHeading>
-							<p>
-								{ this.props.translate(
-									'{{readerLink}}Use the Reader{{/readerLink}} to adjust delivery settings for your existing subscriptions.',
-									{
-										components: {
-											readerLink: (
-												<a
-													href="/following/edit"
-													onClick={ this.recordClickEvent( 'Edit Subscriptions in Reader Link' ) }
-												/>
-											),
-										},
-									}
-								) }
-							</p>
-
-							<FormFieldset>
-								<FormLabel htmlFor="subscription_delivery_email_default">
-									{ this.props.translate( 'Default Email Delivery' ) }
-								</FormLabel>
-								<FormSelect
-									disabled={ this.getDisabledState() }
-									id="subscription_delivery_email_default"
-									name="subscription_delivery_email_default"
-									onFocus={ this.recordFocusEvent( 'Default Email Delivery' ) }
-									valueLink={ this.valueLink( 'subscription_delivery_email_default' ) }
-								>
-									<option value="never">{ this.props.translate( 'Never send email' ) }</option>
-									<option value="instantly">{ this.props.translate( 'Send email instantly' ) }</option>
-									<option value="daily">{ this.props.translate( 'Send email daily' ) }</option>
-									<option value="weekly">{ this.props.translate( 'Send email every week' ) }</option>
-								</FormSelect>
-							</FormFieldset>
-
-							<FormFieldset>
-								<FormLegend>{ this.props.translate( 'Jabber Subscription Delivery' ) }</FormLegend>
-								<FormLabel>
-									<FormCheckbox
-										checkedLink={ this.valueLink( 'subscription_delivery_jabber_default' ) }
-										disabled={ this.getDisabledState() }
-										id="subscription_delivery_jabber_default"
-										name="subscription_delivery_jabber_default"
-										onClick={ this.recordCheckboxEvent( 'Notification Delivery by Jabber' ) }
-									/>
-									<span>{ this.props.translate( 'Default delivery via Jabber instant message' ) }</span>
-								</FormLabel>
-							</FormFieldset>
-
-							<FormFieldset>
-								<FormLabel htmlFor="subscription_delivery_mail_option">
-									{ this.props.translate( 'Email Delivery Format' ) }
-								</FormLabel>
-								<FormSelect
-									disabled={ this.getDisabledState() }
-									id="subscription_delivery_mail_option"
-									name="subscription_delivery_mail_option"
-									onFocus={ this.recordFocusEvent( 'Email Delivery Format' ) }
-									valueLink={ this.valueLink( 'subscription_delivery_mail_option' ) }
-								>
-									<option value="html">{ this.props.translate( 'HTML' ) }</option>
-									<option value="text">{ this.props.translate( 'Plain Text' ) }</option>
-								</FormSelect>
-							</FormFieldset>
-
-							<FormFieldset>
-								<FormLabel htmlFor="subscription_delivery_day">
-									{ this.props.translate( 'Email Delivery Window' ) }
-								</FormLabel>
-								<FormSelect
-									disabled={ this.getDisabledState() }
-									className="me-notification-settings__delivery-window"
-									id="subscription_delivery_day"
-									name="subscription_delivery_day"
-									onFocus={ this.recordFocusEvent( 'Email Delivery Window Day' ) }
-									valueLink={ this.valueLink( 'subscription_delivery_day' ) }
-								>
-									<option value="0">{ this.props.translate( 'Sunday' ) }</option>
-									<option value="1">{ this.props.translate( 'Monday' ) }</option>
-									<option value="2">{ this.props.translate( 'Tuesday' ) }</option>
-									<option value="3">{ this.props.translate( 'Wednesday' ) }</option>
-									<option value="4">{ this.props.translate( 'Thursday' ) }</option>
-									<option value="5">{ this.props.translate( 'Friday' ) }</option>
-									<option value="6">{ this.props.translate( 'Saturday' ) }</option>
-								</FormSelect>
-
-								<FormSelect
-									disabled={ this.getDisabledState() }
-									id="subscription_delivery_hour"
-									name="subscription_delivery_hour"
-									onFocus={ this.recordFocusEvent( 'Email Delivery Window Time' ) }
-									valueLink={ this.valueLink( 'subscription_delivery_hour' ) }
-								>
-									<option value="0">{ this.getDeliveryHourLabel( 0 ) }</option>
-									<option value="2">{ this.getDeliveryHourLabel( 2 ) }</option>
-									<option value="4">{ this.getDeliveryHourLabel( 4 ) }</option>
-									<option value="6">{ this.getDeliveryHourLabel( 6 ) }</option>
-									<option value="8">{ this.getDeliveryHourLabel( 8 ) }</option>
-									<option value="10">{ this.getDeliveryHourLabel( 10 ) }</option>
-									<option value="12">{ this.getDeliveryHourLabel( 12 ) }</option>
-									<option value="14">{ this.getDeliveryHourLabel( 14 ) }</option>
-									<option value="16">{ this.getDeliveryHourLabel( 16 ) }</option>
-									<option value="18">{ this.getDeliveryHourLabel( 18 ) }</option>
-									<option value="20">{ this.getDeliveryHourLabel( 20 ) }</option>
-									<option value="22">{ this.getDeliveryHourLabel( 22 ) }</option>
-								</FormSelect>
-
-								<FormSettingExplanation>
-									{ this.props.translate(
-										'When choosing daily or weekly email delivery, which time of day would you prefer?'
-									) }
-								</FormSettingExplanation>
-							</FormFieldset>
-
-							<FormFieldset>
-								<FormLegend>{ this.props.translate( 'Block Emails' ) }</FormLegend>
-								<FormLabel>
-									<FormCheckbox
-										checkedLink={ this.valueLink( 'subscription_delivery_email_blocked' ) }
-										disabled={ this.getDisabledState() }
-										id="subscription_delivery_email_blocked"
-										name="subscription_delivery_email_blocked"
-										onClick={ this.recordCheckboxEvent( 'Block All Notification Emails' ) }
-									/>
-									<span>
-										{ this.props.translate(
-											'Block all email updates from blogs you’re following on WordPress.com'
-										) }
-									</span>
-								</FormLabel>
-							</FormFieldset>
-
-							<FormButton
-								isSubmitting={ this.state.submittingForm }
-								disabled={ this.getDisabledState() }
-								onClick={ this.recordClickEvent( 'Save Notification Settings Button' ) }
+						<Card className="me-notification-settings">
+							<form
+								id="notification-settings"
+								onChange={ this.props.markChanged }
+								onSubmit={ this.submitForm }
 							>
-								{ this.state.submittingForm ? (
-									this.props.translate( 'Saving…' )
-								) : (
-									this.props.translate( 'Save Notification Settings' )
-								) }
-							</FormButton>
-						</form>
-					</Card>
-				</Main>
-            );
-		},
-	} ))
+								<FormSectionHeading>
+									{ this.props.translate( 'Subscriptions Delivery' ) }
+								</FormSectionHeading>
+								<p>
+									{ this.props.translate(
+										'{{readerLink}}Use the Reader{{/readerLink}} to adjust delivery settings for your existing subscriptions.',
+										{
+											components: {
+												readerLink: (
+													<a
+														href="/following/edit"
+														onClick={ this.recordClickEvent( 'Edit Subscriptions in Reader Link' ) }
+													/>
+												),
+											},
+										}
+									) }
+								</p>
+
+								<FormFieldset>
+									<FormLabel htmlFor="subscription_delivery_email_default">
+										{ this.props.translate( 'Default Email Delivery' ) }
+									</FormLabel>
+									<FormSelect
+										disabled={ this.getDisabledState() }
+										id="subscription_delivery_email_default"
+										name="subscription_delivery_email_default"
+										onFocus={ this.recordFocusEvent( 'Default Email Delivery' ) }
+										valueLink={ this.valueLink( 'subscription_delivery_email_default' ) }
+									>
+										<option value="never">{ this.props.translate( 'Never send email' ) }</option>
+										<option value="instantly">
+											{ this.props.translate( 'Send email instantly' ) }
+										</option>
+										<option value="daily">{ this.props.translate( 'Send email daily' ) }</option>
+										<option value="weekly">
+											{ this.props.translate( 'Send email every week' ) }
+										</option>
+									</FormSelect>
+								</FormFieldset>
+
+								<FormFieldset>
+									<FormLegend>
+										{ this.props.translate( 'Jabber Subscription Delivery' ) }
+									</FormLegend>
+									<FormLabel>
+										<FormCheckbox
+											checkedLink={ this.valueLink( 'subscription_delivery_jabber_default' ) }
+											disabled={ this.getDisabledState() }
+											id="subscription_delivery_jabber_default"
+											name="subscription_delivery_jabber_default"
+											onClick={ this.recordCheckboxEvent( 'Notification Delivery by Jabber' ) }
+										/>
+										<span>
+											{ this.props.translate( 'Default delivery via Jabber instant message' ) }
+										</span>
+									</FormLabel>
+								</FormFieldset>
+
+								<FormFieldset>
+									<FormLabel htmlFor="subscription_delivery_mail_option">
+										{ this.props.translate( 'Email Delivery Format' ) }
+									</FormLabel>
+									<FormSelect
+										disabled={ this.getDisabledState() }
+										id="subscription_delivery_mail_option"
+										name="subscription_delivery_mail_option"
+										onFocus={ this.recordFocusEvent( 'Email Delivery Format' ) }
+										valueLink={ this.valueLink( 'subscription_delivery_mail_option' ) }
+									>
+										<option value="html">{ this.props.translate( 'HTML' ) }</option>
+										<option value="text">{ this.props.translate( 'Plain Text' ) }</option>
+									</FormSelect>
+								</FormFieldset>
+
+								<FormFieldset>
+									<FormLabel htmlFor="subscription_delivery_day">
+										{ this.props.translate( 'Email Delivery Window' ) }
+									</FormLabel>
+									<FormSelect
+										disabled={ this.getDisabledState() }
+										className="me-notification-settings__delivery-window"
+										id="subscription_delivery_day"
+										name="subscription_delivery_day"
+										onFocus={ this.recordFocusEvent( 'Email Delivery Window Day' ) }
+										valueLink={ this.valueLink( 'subscription_delivery_day' ) }
+									>
+										<option value="0">{ this.props.translate( 'Sunday' ) }</option>
+										<option value="1">{ this.props.translate( 'Monday' ) }</option>
+										<option value="2">{ this.props.translate( 'Tuesday' ) }</option>
+										<option value="3">{ this.props.translate( 'Wednesday' ) }</option>
+										<option value="4">{ this.props.translate( 'Thursday' ) }</option>
+										<option value="5">{ this.props.translate( 'Friday' ) }</option>
+										<option value="6">{ this.props.translate( 'Saturday' ) }</option>
+									</FormSelect>
+
+									<FormSelect
+										disabled={ this.getDisabledState() }
+										id="subscription_delivery_hour"
+										name="subscription_delivery_hour"
+										onFocus={ this.recordFocusEvent( 'Email Delivery Window Time' ) }
+										valueLink={ this.valueLink( 'subscription_delivery_hour' ) }
+									>
+										<option value="0">{ this.getDeliveryHourLabel( 0 ) }</option>
+										<option value="2">{ this.getDeliveryHourLabel( 2 ) }</option>
+										<option value="4">{ this.getDeliveryHourLabel( 4 ) }</option>
+										<option value="6">{ this.getDeliveryHourLabel( 6 ) }</option>
+										<option value="8">{ this.getDeliveryHourLabel( 8 ) }</option>
+										<option value="10">{ this.getDeliveryHourLabel( 10 ) }</option>
+										<option value="12">{ this.getDeliveryHourLabel( 12 ) }</option>
+										<option value="14">{ this.getDeliveryHourLabel( 14 ) }</option>
+										<option value="16">{ this.getDeliveryHourLabel( 16 ) }</option>
+										<option value="18">{ this.getDeliveryHourLabel( 18 ) }</option>
+										<option value="20">{ this.getDeliveryHourLabel( 20 ) }</option>
+										<option value="22">{ this.getDeliveryHourLabel( 22 ) }</option>
+									</FormSelect>
+
+									<FormSettingExplanation>
+										{ this.props.translate(
+											'When choosing daily or weekly email delivery, which time of day would you prefer?'
+										) }
+									</FormSettingExplanation>
+								</FormFieldset>
+
+								<FormFieldset>
+									<FormLegend>{ this.props.translate( 'Block Emails' ) }</FormLegend>
+									<FormLabel>
+										<FormCheckbox
+											checkedLink={ this.valueLink( 'subscription_delivery_email_blocked' ) }
+											disabled={ this.getDisabledState() }
+											id="subscription_delivery_email_blocked"
+											name="subscription_delivery_email_blocked"
+											onClick={ this.recordCheckboxEvent( 'Block All Notification Emails' ) }
+										/>
+										<span>
+											{ this.props.translate(
+												'Block all email updates from blogs you’re following on WordPress.com'
+											) }
+										</span>
+									</FormLabel>
+								</FormFieldset>
+
+								<FormButton
+									isSubmitting={ this.state.submittingForm }
+									disabled={ this.getDisabledState() }
+									onClick={ this.recordClickEvent( 'Save Notification Settings Button' ) }
+								>
+									{ this.state.submittingForm ? (
+										this.props.translate( 'Saving…' )
+									) : (
+										this.props.translate( 'Save Notification Settings' )
+									) }
+								</FormButton>
+							</form>
+						</Card>
+					</Main>
+				);
+			},
+		} )
+	)
 );

--- a/client/me/notification-settings/reader-subscriptions/index.jsx
+++ b/client/me/notification-settings/reader-subscriptions/index.jsx
@@ -25,9 +25,12 @@ import FormSelect from 'components/forms/form-select';
 import FormSectionHeading from 'components/forms/form-section-heading';
 import ReauthRequired from 'me/reauth-required';
 import twoStepAuthorization from 'lib/two-step-authorization';
-import observe from 'lib/mixins/data-observe';
+import observe from 'lib/mixins/data-observe'; //eslint-disable-line no-restricted-imports
 import eventRecorder from 'me/event-recorder';
 import Main from 'components/main';
+
+/* eslint-disable react/no-deprecated */
+/* eslint-disable wpcalypso/jsx-classname-namespace */
 
 module.exports = protectForm(
 	localize(
@@ -55,6 +58,7 @@ module.exports = protectForm(
 			},
 
 			render() {
+				/* eslint-disable max-len */
 				return (
 					<Main className="notifications-settings">
 						<MeSidebarNavigation />

--- a/client/me/profile/index.jsx
+++ b/client/me/profile/index.jsx
@@ -25,12 +25,15 @@ import userProfileLinks from 'lib/user-profile-links';
 import ReauthRequired from 'me/reauth-required';
 import twoStepAuthorization from 'lib/two-step-authorization';
 import Card from 'components/card';
-import observe from 'lib/mixins/data-observe';
+import observe from 'lib/mixins/data-observe'; //eslint-disable-line no-restricted-imports
 import eventRecorder from 'me/event-recorder';
 import Main from 'components/main';
 import SectionHeader from 'components/section-header';
 
 const debug = debugFactory( 'calypso:me:profile' );
+
+/* eslint-disable react/no-deprecated */
+/* eslint-disable wpcalypso/jsx-classname-namespace */
 
 export default protectForm(
 	localize(

--- a/client/me/profile/index.jsx
+++ b/client/me/profile/index.jsx
@@ -6,7 +6,6 @@
 
 import React from 'react';
 import { localize } from 'i18n-calypso';
-import LinkedStateMixin from 'react-addons-linked-state-mixin';
 import debugFactory from 'debug';
 
 /**
@@ -34,124 +33,130 @@ import SectionHeader from 'components/section-header';
 const debug = debugFactory( 'calypso:me:profile' );
 
 export default protectForm(
-	localize(React.createClass( {
-		displayName: 'Profile',
+	localize(
+		React.createClass( {
+			displayName: 'Profile',
 
-		mixins: [ formBase, LinkedStateMixin, observe( 'userSettings' ), eventRecorder ],
+			mixins: [ formBase, observe( 'userSettings' ), eventRecorder ],
 
-		componentDidMount() {
-			debug( this.displayName + ' component is mounted.' );
-		},
+			componentDidMount() {
+				debug( this.displayName + ' component is mounted.' );
+			},
 
-		componentWillUnmount() {
-			debug( this.displayName + ' component is unmounting.' );
-		},
+			componentWillUnmount() {
+				debug( this.displayName + ' component is unmounting.' );
+			},
 
-		render() {
-			const gravatarProfileLink =
-				'https://gravatar.com/' + this.props.userSettings.getSetting( 'user_login' );
+			render() {
+				const gravatarProfileLink =
+					'https://gravatar.com/' + this.props.userSettings.getSetting( 'user_login' );
 
-			return (
-                <Main className="profile">
-					<MeSidebarNavigation />
-					<ReauthRequired twoStepAuthorization={ twoStepAuthorization } />
-					<SectionHeader label={ this.props.translate( 'Profile' ) } />
-					<Card className="me-profile-settings">
-						<EditGravatar />
+				return (
+					<Main className="profile">
+						<MeSidebarNavigation />
+						<ReauthRequired twoStepAuthorization={ twoStepAuthorization } />
+						<SectionHeader label={ this.props.translate( 'Profile' ) } />
+						<Card className="me-profile-settings">
+							<EditGravatar />
 
-						<form onSubmit={ this.submitForm } onChange={ this.props.markChanged }>
-							<FormFieldset>
-								<FormLabel htmlFor="first_name">{ this.props.translate( 'First Name' ) }</FormLabel>
-								<FormTextInput
-									disabled={ this.getDisabledState() }
-									id="first_name"
-									name="first_name"
-									onFocus={ this.recordFocusEvent( 'First Name Field' ) }
-									valueLink={ this.valueLink( 'first_name' ) }
-								/>
-							</FormFieldset>
+							<form onSubmit={ this.submitForm } onChange={ this.props.markChanged }>
+								<FormFieldset>
+									<FormLabel htmlFor="first_name">
+										{ this.props.translate( 'First Name' ) }
+									</FormLabel>
+									<FormTextInput
+										disabled={ this.getDisabledState() }
+										id="first_name"
+										name="first_name"
+										onFocus={ this.recordFocusEvent( 'First Name Field' ) }
+										valueLink={ this.valueLink( 'first_name' ) }
+									/>
+								</FormFieldset>
 
-							<FormFieldset>
-								<FormLabel htmlFor="last_name">{ this.props.translate( 'Last Name' ) }</FormLabel>
-								<FormTextInput
-									disabled={ this.getDisabledState() }
-									id="last_name"
-									name="last_name"
-									onFocus={ this.recordFocusEvent( 'Last Name Field' ) }
-									valueLink={ this.valueLink( 'last_name' ) }
-								/>
-							</FormFieldset>
+								<FormFieldset>
+									<FormLabel htmlFor="last_name">{ this.props.translate( 'Last Name' ) }</FormLabel>
+									<FormTextInput
+										disabled={ this.getDisabledState() }
+										id="last_name"
+										name="last_name"
+										onFocus={ this.recordFocusEvent( 'Last Name Field' ) }
+										valueLink={ this.valueLink( 'last_name' ) }
+									/>
+								</FormFieldset>
 
-							<FormFieldset>
-								<FormLabel htmlFor="display_name">
-									{ this.props.translate( 'Public Display Name' ) }
-								</FormLabel>
-								<FormTextInput
-									disabled={ this.getDisabledState() }
-									id="display_name"
-									name="display_name"
-									onFocus={ this.recordFocusEvent( 'Display Name Field' ) }
-									valueLink={ this.valueLink( 'display_name' ) }
-								/>
-							</FormFieldset>
+								<FormFieldset>
+									<FormLabel htmlFor="display_name">
+										{ this.props.translate( 'Public Display Name' ) }
+									</FormLabel>
+									<FormTextInput
+										disabled={ this.getDisabledState() }
+										id="display_name"
+										name="display_name"
+										onFocus={ this.recordFocusEvent( 'Display Name Field' ) }
+										valueLink={ this.valueLink( 'display_name' ) }
+									/>
+								</FormFieldset>
 
-							<FormFieldset>
-								<FormLabel htmlFor="description">{ this.props.translate( 'About Me' ) }</FormLabel>
-								<FormTextarea
-									disabled={ this.getDisabledState() }
-									id="description"
-									name="description"
-									onFocus={ this.recordFocusEvent( 'About Me Field' ) }
-									valueLink={ this.valueLink( 'description' ) }
-								/>
-							</FormFieldset>
+								<FormFieldset>
+									<FormLabel htmlFor="description">
+										{ this.props.translate( 'About Me' ) }
+									</FormLabel>
+									<FormTextarea
+										disabled={ this.getDisabledState() }
+										id="description"
+										name="description"
+										onFocus={ this.recordFocusEvent( 'About Me Field' ) }
+										valueLink={ this.valueLink( 'description' ) }
+									/>
+								</FormFieldset>
 
-							<p>
-								<FormButton
-									disabled={
-										! this.props.userSettings.hasUnsavedSettings() || this.getDisabledState()
+								<p>
+									<FormButton
+										disabled={
+											! this.props.userSettings.hasUnsavedSettings() || this.getDisabledState()
+										}
+										onClick={ this.recordClickEvent( 'Save Profile Details Button' ) }
+									>
+										{ this.state.submittingForm ? (
+											this.props.translate( 'Saving…' )
+										) : (
+											this.props.translate( 'Save Profile Details' )
+										) }
+									</FormButton>
+								</p>
+							</form>
+							<p className="me-profile-settings__info-text">
+								{ this.props.translate(
+									'This information will be displayed publicly on {{profilelink}}your profile{{/profilelink}} and in ' +
+										'{{hovercardslink}}Gravatar Hovercards{{/hovercardslink}}.',
+									{
+										components: {
+											profilelink: (
+												<a
+													onClick={ this.recordClickEvent( 'My Profile Link' ) }
+													href={ gravatarProfileLink }
+													target="_blank"
+													rel="noopener noreferrer"
+												/>
+											),
+											hovercardslink: (
+												<a
+													onClick={ this.recordClickEvent( 'Gravatar Hovercards Link' ) }
+													href="https://support.wordpress.com/gravatar-hovercards/"
+													target="_blank"
+													rel="noopener noreferrer"
+												/>
+											),
+										},
 									}
-									onClick={ this.recordClickEvent( 'Save Profile Details Button' ) }
-								>
-									{ this.state.submittingForm ? (
-										this.props.translate( 'Saving…' )
-									) : (
-										this.props.translate( 'Save Profile Details' )
-									) }
-								</FormButton>
+								) }
 							</p>
-						</form>
-						<p className="me-profile-settings__info-text">
-							{ this.props.translate(
-								'This information will be displayed publicly on {{profilelink}}your profile{{/profilelink}} and in ' +
-									'{{hovercardslink}}Gravatar Hovercards{{/hovercardslink}}.',
-								{
-									components: {
-										profilelink: (
-											<a
-												onClick={ this.recordClickEvent( 'My Profile Link' ) }
-												href={ gravatarProfileLink }
-												target="_blank"
-												rel="noopener noreferrer"
-											/>
-										),
-										hovercardslink: (
-											<a
-												onClick={ this.recordClickEvent( 'Gravatar Hovercards Link' ) }
-												href="https://support.wordpress.com/gravatar-hovercards/"
-												target="_blank"
-												rel="noopener noreferrer"
-											/>
-										),
-									},
-								}
-							) }
-						</p>
-					</Card>
+						</Card>
 
-					<ProfileLinks userProfileLinks={ userProfileLinks } />
-				</Main>
-            );
-		},
-	} ))
+						<ProfileLinks userProfileLinks={ userProfileLinks } />
+					</Main>
+				);
+			},
+		} )
+	)
 );

--- a/client/me/profile/index.jsx
+++ b/client/me/profile/index.jsx
@@ -25,15 +25,12 @@ import userProfileLinks from 'lib/user-profile-links';
 import ReauthRequired from 'me/reauth-required';
 import twoStepAuthorization from 'lib/two-step-authorization';
 import Card from 'components/card';
-import observe from 'lib/mixins/data-observe'; //eslint-disable-line no-restricted-imports
+import observe from 'lib/mixins/data-observe';
 import eventRecorder from 'me/event-recorder';
 import Main from 'components/main';
 import SectionHeader from 'components/section-header';
 
 const debug = debugFactory( 'calypso:me:profile' );
-
-/* eslint-disable react/no-deprecated */
-/* eslint-disable wpcalypso/jsx-classname-namespace */
 
 export default protectForm(
 	localize(

--- a/client/me/security-2fa-sms-settings/index.jsx
+++ b/client/me/security-2fa-sms-settings/index.jsx
@@ -7,7 +7,6 @@
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import React from 'react';
-import LinkedStateMixin from 'react-addons-linked-state-mixin';
 import debugFactory from 'debug';
 
 /**
@@ -28,222 +27,239 @@ const debug = debugFactory( 'calypso:me:security:2fa-sms-settings' );
 const countriesList = forSms();
 
 module.exports = protectForm(
-	localize(React.createClass( {
-		displayName: 'Security2faSMSSettings',
+	localize(
+		React.createClass( {
+			displayName: 'Security2faSMSSettings',
 
-		componentDidMount: function() {
-			debug( this.constructor.displayName + ' React component is mounted.' );
-			this.props.userSettings.getSettings();
-		},
+			componentDidMount: function() {
+				debug( this.constructor.displayName + ' React component is mounted.' );
+				this.props.userSettings.getSettings();
+			},
 
-		componentWillUnmount: function() {
-			debug( this.constructor.displayName + ' React component will unmount.' );
-		},
+			componentWillUnmount: function() {
+				debug( this.constructor.displayName + ' React component will unmount.' );
+			},
 
-		mixins: [ formBase, LinkedStateMixin, observe( 'userSettings' ) ],
+			mixins: [ formBase, observe( 'userSettings' ) ],
 
-		propTypes: {
-			onCancel: PropTypes.func.isRequired,
-			onVerifyByApp: PropTypes.func.isRequired,
-			onVerifyBySMS: PropTypes.func.isRequired,
-			markChanged: PropTypes.func.isRequired,
-			markSaved: PropTypes.func.isRequired,
-		},
+			propTypes: {
+				onCancel: PropTypes.func.isRequired,
+				onVerifyByApp: PropTypes.func.isRequired,
+				onVerifyBySMS: PropTypes.func.isRequired,
+				markChanged: PropTypes.func.isRequired,
+				markSaved: PropTypes.func.isRequired,
+			},
 
-		verifyByApp: null,
+			verifyByApp: null,
 
-		getInitialState: function() {
-			let phoneNumber = null;
-			let storedCountry = this.props.userSettings.getSetting( 'two_step_sms_country' );
-			let storedNumber = this.props.userSettings.getSetting( 'two_step_sms_phone_number' );
-			if ( storedCountry && storedNumber ) {
-				phoneNumber = {
-					countryCode: storedCountry,
-					phoneNumber: storedNumber,
-					isValid: true,
+			getInitialState: function() {
+				let phoneNumber = null;
+				let storedCountry = this.props.userSettings.getSetting( 'two_step_sms_country' );
+				let storedNumber = this.props.userSettings.getSetting( 'two_step_sms_phone_number' );
+				if ( storedCountry && storedNumber ) {
+					phoneNumber = {
+						countryCode: storedCountry,
+						phoneNumber: storedNumber,
+						isValid: true,
+					};
+				}
+
+				return {
+					lastError: false,
+					phoneNumber,
 				};
-			}
+			},
 
-			return {
-				lastError: false,
-				phoneNumber,
-			};
-		},
+			getSubmitDisabled: function() {
+				if ( this.getDisabledState() ) {
+					return true;
+				}
 
-		getSubmitDisabled: function() {
-			if ( this.getDisabledState() ) {
-				return true;
-			}
+				// empty phone number, disable the submit button
+				if ( ! this.state.phoneNumber ) {
+					return true;
+				}
 
-			// empty phone number, disable the submit button
-			if ( ! this.state.phoneNumber ) {
-				return true;
-			}
+				if ( ! this.state.phoneNumber.phoneNumber.length ) {
+					return true;
+				}
 
-			if ( ! this.state.phoneNumber.phoneNumber.length ) {
-				return true;
-			}
+				return false;
+			},
 
-			return false;
-		},
+			onVerifyByApp: function( event ) {
+				event.preventDefault();
+				this.verifyByApp = true;
+				this.submitSMSSettings();
+			},
 
-		onVerifyByApp: function( event ) {
-			event.preventDefault();
-			this.verifyByApp = true;
-			this.submitSMSSettings();
-		},
+			onVerifyBySMS: function( event ) {
+				event.preventDefault();
+				this.verifyByApp = false;
+				this.submitSMSSettings();
+			},
 
-		onVerifyBySMS: function( event ) {
-			event.preventDefault();
-			this.verifyByApp = false;
-			this.submitSMSSettings();
-		},
-
-		/**
+			/**
 	 * Note:  We purposely do not use form-base's submitForm so that we can
 	 * manage Notices ourselves
 	 */
-		submitSMSSettings: function() {
-			var phoneNumber;
+			submitSMSSettings: function() {
+				var phoneNumber;
 
-			if ( ! this.refs.phoneInput ) {
-				return;
-			}
+				if ( ! this.refs.phoneInput ) {
+					return;
+				}
 
-			phoneNumber = this.state.phoneNumber;
+				phoneNumber = this.state.phoneNumber;
 
-			if ( ! phoneNumber.isValid ) {
-				this.setState( { lastError: phoneNumber.validation } );
-				return;
-			}
+				if ( ! phoneNumber.isValid ) {
+					this.setState( { lastError: phoneNumber.validation } );
+					return;
+				}
 
-			this.props.userSettings.updateSetting( 'two_step_sms_phone_number', phoneNumber.phoneNumber );
-			this.props.userSettings.updateSetting( 'two_step_sms_country', phoneNumber.countryCode );
+				this.props.userSettings.updateSetting(
+					'two_step_sms_phone_number',
+					phoneNumber.phoneNumber
+				);
+				this.props.userSettings.updateSetting( 'two_step_sms_country', phoneNumber.countryCode );
 
-			this.setState( { submittingForm: true } );
-			this.props.userSettings.saveSettings( this.onSubmitResponse );
-		},
+				this.setState( { submittingForm: true } );
+				this.props.userSettings.saveSettings( this.onSubmitResponse );
+			},
 
-		onChangePhoneInput: function( phoneNumber ) {
-			this.setState( {
-				phoneNumber: {
-					phoneNumber: phoneNumber.phoneNumber,
-					countryCode: phoneNumber.countryData.code,
-					isValid: phoneNumber.isValid,
-					validation: phoneNumber.validation,
-				},
-			} );
-		},
+			onChangePhoneInput: function( phoneNumber ) {
+				this.setState( {
+					phoneNumber: {
+						phoneNumber: phoneNumber.phoneNumber,
+						countryCode: phoneNumber.countryData.code,
+						isValid: phoneNumber.isValid,
+						validation: phoneNumber.validation,
+					},
+				} );
+			},
 
-		onSubmitResponse: function( error ) {
-			this.setState( { submittingForm: false } );
+			onSubmitResponse: function( error ) {
+				this.setState( { submittingForm: false } );
 
-			if ( error ) {
-				this.setState( { lastError: error } );
-				return;
-			}
+				if ( error ) {
+					this.setState( { lastError: error } );
+					return;
+				}
 
-			if ( this.verifyByApp ) {
-				this.props.onVerifyByApp();
-			} else {
-				this.props.onVerifyBySMS();
-			}
-		},
+				if ( this.verifyByApp ) {
+					this.props.onVerifyByApp();
+				} else {
+					this.props.onVerifyBySMS();
+				}
+			},
 
-		clearLastError: function() {
-			this.setState( { lastError: false } );
-		},
+			clearLastError: function() {
+				this.setState( { lastError: false } );
+			},
 
-		possiblyRenderError: function() {
-			var errorMessage;
+			possiblyRenderError: function() {
+				var errorMessage;
 
-			if ( ! this.state.lastError ) {
-				return null;
-			}
+				if ( ! this.state.lastError ) {
+					return null;
+				}
 
-			if ( ! this.state.lastError.message ) {
-				errorMessage = this.props.translate( 'An unknown error occurred. Please try again later.' );
-			} else {
-				errorMessage = this.state.lastError.message;
-			}
+				if ( ! this.state.lastError.message ) {
+					errorMessage = this.props.translate(
+						'An unknown error occurred. Please try again later.'
+					);
+				} else {
+					errorMessage = this.state.lastError.message;
+				}
 
-			return (
-				<Notice status="is-error" onDismissClick={ this.clearLastError } text={ errorMessage } />
-			);
-		},
+				return (
+					<Notice status="is-error" onDismissClick={ this.clearLastError } text={ errorMessage } />
+				);
+			},
 
-		render: function() {
-			var savingLabel = this.props.translate( 'Saving…' );
+			render: function() {
+				var savingLabel = this.props.translate( 'Saving…' );
 
-			return (
-                <div className="security-2fa-sms-settings__container">
-					<form className="security-2fa-sms-settings">
-						<Security2faProgress step={ 1 } />
-						<p>
-							{ this.props.translate(
-								'First, we need your Mobile Phone number to ' +
-									'send you verification codes when you choose the SMS method or ' +
-									'in cases where the authenticator app on your phone is ' +
-									'unavailable.'
-							) }
-						</p>
-						<div className="security-2fa-sms-settings__fieldset-container">
-							<FormPhoneInput
-								ref="phoneInput"
-								countriesList={ countriesList }
-								disabled={ this.state.submittingForm }
-								countrySelectProps={ {
-									onFocus: function() {
-										analytics.ga.recordEvent( 'Me', 'Focused On 2fa SMS Country Select' );
-									},
-								} }
-								phoneInputProps={ {
-									onFocus: function() {
-										analytics.ga.recordEvent( 'Me', 'Focused On 2fa SMS Phone Number' );
-									},
-								} }
-								initialCountryCode={ this.props.userSettings.getSetting( 'two_step_sms_country' ) }
-								initialPhoneNumber={ this.props.userSettings.getSetting(
-									'two_step_sms_phone_number'
+				return (
+					<div className="security-2fa-sms-settings__container">
+						<form className="security-2fa-sms-settings">
+							<Security2faProgress step={ 1 } />
+							<p>
+								{ this.props.translate(
+									'First, we need your Mobile Phone number to ' +
+										'send you verification codes when you choose the SMS method or ' +
+										'in cases where the authenticator app on your phone is ' +
+										'unavailable.'
 								) }
-								onChange={ this.onChangePhoneInput }
-							/>
-							{ this.possiblyRenderError() }
-						</div>
-						<FormButtonsBar className="security-2fa-sms-settings__buttons">
-							<FormButton
-								disabled={ this.getSubmitDisabled() }
-								onClick={ function( event ) {
-									analytics.ga.recordEvent( 'Me', 'Clicked On 2fa Use App Button' );
-									this.onVerifyByApp( event );
-								}.bind( this ) }
-							>
-								{ this.state.submittingForm ? savingLabel : this.props.translate( 'Verify via App' ) }
-							</FormButton>
-							<FormButton
-								disabled={ this.getSubmitDisabled() }
-								isPrimary={ false }
-								onClick={ function( event ) {
-									analytics.ga.recordEvent( 'Me', 'Clicked On 2fa Use SMS Button' );
-									this.onVerifyBySMS( event );
-								}.bind( this ) }
-							>
-								{ this.state.submittingForm ? savingLabel : this.props.translate( 'Verify via SMS' ) }
-							</FormButton>
-							<FormButton
-								className="security-2fa-sms-settings__cancel-button"
-								isPrimary={ false }
-								onClick={ function( event ) {
-									analytics.ga.recordEvent( 'Me', 'Clicked On Step 1 2fa Cancel Button' );
-									this.props.onCancel( event );
-								}.bind( this ) }
-							>
-								{ this.state.submittingForm ? savingLabel : this.props.translate( 'Cancel' ) }
-							</FormButton>
-						</FormButtonsBar>
-					</form>
-				</div>
-            );
-		},
-	} ))
+							</p>
+							<div className="security-2fa-sms-settings__fieldset-container">
+								<FormPhoneInput
+									ref="phoneInput"
+									countriesList={ countriesList }
+									disabled={ this.state.submittingForm }
+									countrySelectProps={ {
+										onFocus: function() {
+											analytics.ga.recordEvent( 'Me', 'Focused On 2fa SMS Country Select' );
+										},
+									} }
+									phoneInputProps={ {
+										onFocus: function() {
+											analytics.ga.recordEvent( 'Me', 'Focused On 2fa SMS Phone Number' );
+										},
+									} }
+									initialCountryCode={ this.props.userSettings.getSetting(
+										'two_step_sms_country'
+									) }
+									initialPhoneNumber={ this.props.userSettings.getSetting(
+										'two_step_sms_phone_number'
+									) }
+									onChange={ this.onChangePhoneInput }
+								/>
+								{ this.possiblyRenderError() }
+							</div>
+							<FormButtonsBar className="security-2fa-sms-settings__buttons">
+								<FormButton
+									disabled={ this.getSubmitDisabled() }
+									onClick={ function( event ) {
+										analytics.ga.recordEvent( 'Me', 'Clicked On 2fa Use App Button' );
+										this.onVerifyByApp( event );
+									}.bind( this ) }
+								>
+									{ this.state.submittingForm ? (
+										savingLabel
+									) : (
+										this.props.translate( 'Verify via App' )
+									) }
+								</FormButton>
+								<FormButton
+									disabled={ this.getSubmitDisabled() }
+									isPrimary={ false }
+									onClick={ function( event ) {
+										analytics.ga.recordEvent( 'Me', 'Clicked On 2fa Use SMS Button' );
+										this.onVerifyBySMS( event );
+									}.bind( this ) }
+								>
+									{ this.state.submittingForm ? (
+										savingLabel
+									) : (
+										this.props.translate( 'Verify via SMS' )
+									) }
+								</FormButton>
+								<FormButton
+									className="security-2fa-sms-settings__cancel-button"
+									isPrimary={ false }
+									onClick={ function( event ) {
+										analytics.ga.recordEvent( 'Me', 'Clicked On Step 1 2fa Cancel Button' );
+										this.props.onCancel( event );
+									}.bind( this ) }
+								>
+									{ this.state.submittingForm ? savingLabel : this.props.translate( 'Cancel' ) }
+								</FormButton>
+							</FormButtonsBar>
+						</form>
+					</div>
+				);
+			},
+		} )
+	)
 );

--- a/client/me/security-2fa-sms-settings/index.jsx
+++ b/client/me/security-2fa-sms-settings/index.jsx
@@ -19,12 +19,16 @@ import Notice from 'components/notice';
 import formBase from 'me/form-base';
 import Security2faProgress from 'me/security-2fa-progress';
 import analytics from 'lib/analytics';
-import observe from 'lib/mixins/data-observe';
+import observe from 'lib/mixins/data-observe'; //eslint-disable-line no-restricted-imports
 import { protectForm } from 'lib/protect-form';
 import { forSms } from 'lib/countries-list';
 
 const debug = debugFactory( 'calypso:me:security:2fa-sms-settings' );
 const countriesList = forSms();
+
+/* eslint-disable react/jsx-no-bind */
+/* eslint-disable react/no-deprecated */
+/* eslint-disable wpcalypso/jsx-classname-namespace */
 
 module.exports = protectForm(
 	localize(
@@ -54,8 +58,8 @@ module.exports = protectForm(
 
 			getInitialState: function() {
 				let phoneNumber = null;
-				let storedCountry = this.props.userSettings.getSetting( 'two_step_sms_country' );
-				let storedNumber = this.props.userSettings.getSetting( 'two_step_sms_phone_number' );
+				const storedCountry = this.props.userSettings.getSetting( 'two_step_sms_country' );
+				const storedNumber = this.props.userSettings.getSetting( 'two_step_sms_phone_number' );
 				if ( storedCountry && storedNumber ) {
 					phoneNumber = {
 						countryCode: storedCountry,
@@ -104,13 +108,11 @@ module.exports = protectForm(
 	 * manage Notices ourselves
 	 */
 			submitSMSSettings: function() {
-				var phoneNumber;
-
 				if ( ! this.refs.phoneInput ) {
 					return;
 				}
 
-				phoneNumber = this.state.phoneNumber;
+				const phoneNumber = this.state.phoneNumber;
 
 				if ( ! phoneNumber.isValid ) {
 					this.setState( { lastError: phoneNumber.validation } );
@@ -158,7 +160,7 @@ module.exports = protectForm(
 			},
 
 			possiblyRenderError: function() {
-				var errorMessage;
+				let errorMessage;
 
 				if ( ! this.state.lastError ) {
 					return null;
@@ -178,7 +180,7 @@ module.exports = protectForm(
 			},
 
 			render: function() {
-				var savingLabel = this.props.translate( 'Saving…' );
+				const savingLabel = this.props.translate( 'Saving…' );
 
 				return (
 					<div className="security-2fa-sms-settings__container">

--- a/client/me/security-2fa-sms-settings/index.jsx
+++ b/client/me/security-2fa-sms-settings/index.jsx
@@ -19,16 +19,12 @@ import Notice from 'components/notice';
 import formBase from 'me/form-base';
 import Security2faProgress from 'me/security-2fa-progress';
 import analytics from 'lib/analytics';
-import observe from 'lib/mixins/data-observe'; //eslint-disable-line no-restricted-imports
+import observe from 'lib/mixins/data-observe';
 import { protectForm } from 'lib/protect-form';
 import { forSms } from 'lib/countries-list';
 
 const debug = debugFactory( 'calypso:me:security:2fa-sms-settings' );
 const countriesList = forSms();
-
-/* eslint-disable react/jsx-no-bind */
-/* eslint-disable react/no-deprecated */
-/* eslint-disable wpcalypso/jsx-classname-namespace */
 
 module.exports = protectForm(
 	localize(


### PR DESCRIPTION
While these components are using `valueLink`, they're using a custom handler instead of `this.linkState()`, so they don't actually make use of `LinkedStateMixin`. (FWIW, I couldn't find any such cases outside `/me`.)

Quoting from #5951:

>  Note that some of our components have been importing the `LinkedStateMixin` even though they weren't really using `this.linkState()`but only `valueLink`. Those are two separate things: `valueLink` is a custom prop added to `input` by React which will be removed as of React 16. It can be used with `LinkedStateMixin` (through the `linkState()` method which the latter provides), but also without. See https://facebook.github.io/react/docs/two-way-binding-helpers.html for different ways to implement the same functionality.


Code review:
* Verify that the affected files don't refer to `this.linkState()`, and that any `valueLink` props are set to custom handlers instead.

To test:
* Verify that the affected components still work.