### PR TITLE
Testing: Try to run client and server tests together

### DIFF
--- a/package.json
+++ b/package.json
@@ -223,7 +223,7 @@
     "poststart": "npm run -s env -- cross-env node $NODE_ARGS build/bundle.js",
     "reformat-files": "node bin/reformat-files.js",
     "pretest": "npm run -s install-if-deps-outdated",
-    "test": "run-s -s test-client test-server",
+    "test": "jest",
     "pretest-client": "npm run -s pretest",
     "test-client": "jest -c=test/client/jest.config.json",
     "test-client:ci": "cross-env TEST_REPORT_FILENAME=./test-results-client.xml jest -c=test/client/jest.config.ci.js -w=2",
@@ -288,5 +288,11 @@
   },
   "optionalDependencies": {
     "fsevents": "1.1.1"
+  },
+  "jest": {
+    "projects": [
+      "test/client/jest.config.json",
+      "test/server/jest.config.json"
+    ]
   }
 }


### PR DESCRIPTION
This PR tries to combine two Jest project into one execution. If that would work we could use one command to verify if all existing tests pass like this:

`npm test`

This implementation mirrors one of the PRs from the React's repository: https://github.com/facebook/react/pull/10214.

At the moment we have to run two projects independently which isn't the best developer's experience in my opinion.

### Issues

At the moment a few tests fail when I run `npm test`:

> Summary of all failing tests
>  FAIL  server/pages/test/analytics.js
>    Test suite failed to run
> 
>     Cannot find module 'pages/analytics' from 'analytics.js'
>       
>       at Resolver.resolveModule (node_modules/jest-resolve/build/index.js:191:17)
>       at Object.<anonymous> (server/pages/test/analytics.js:15:19)
> 
>  FAIL  server/config/test/parser.js
>    parser › should return empty objects for an invalid path
> 
>     Cannot find module 'config/parser' from 'parser.js'
>       
>       at Resolver.resolveModule (node_modules/jest-resolve/build/index.js:191:17)
>       at Object.<anonymous> (server/config/test/parser.js:8:12)
> 
>    parser › server should have secrets and client should not
> 
>     TypeError: require(...).__setValidSecrets is not a function
>       
>       at Object.<anonymous> (server/config/test/parser.js:16:17)
>       at process._tickCallback (internal/process/next_tick.js:109:7)
> 
>    parser › should cascade configs
> 
>     TypeError: require(...).__setValidEnvFiles is not a function
>       
>       at Object.<anonymous> (server/config/test/parser.js:26:17)
>       at process._tickCallback (internal/process/next_tick.js:109:7)
> 
>    parser › should override enabled feature when disabledFeatures set
> 
>     TypeError: require(...).__setValidEnvFiles is not a function
>       
>       at Object.<anonymous> (server/config/test/parser.js:47:17)
>       at process._tickCallback (internal/process/next_tick.js:109:7)
> 
>    parser › should override disabled feature when enabledFeatures set
> 
>     TypeError: require(...).__setValidEnvFiles is not a function
>       
>       at Object.<anonymous> (server/config/test/parser.js:59:17)
>       at process._tickCallback (internal/process/next_tick.js:109:7)
> 
> 
> Test Suites: 2 failed, 1023 passed, 1025 total
> Tests:       5 failed, 8 skipped, 9491 passed, 9504 total
> Snapshots:   2 passed, 2 total
> Time:        65.965s
> Ran all test suites in 2 projects.

If you run only subset of tests using the following command `npm run test server`, then all the failing tests pass:

> Test Suites: 6 passed, 6 total
> Tests:       29 passed, 29 total
> Snapshots:   0 total
> Time:        2.434s
> Ran all test suites matching /server/i in 2 projects.

We use different setup for both projects and my bet is that the module paths is the source of this error as they differ in those two config files:
```json
"modulePaths": [
	"<rootDir>/test/",
	"<rootDir>/client/",
	"<rootDir>/client/extensions/"
],
```
[full config file](https://github.com/Automattic/wp-calypso/blob/b5f739943df8c31ca6aaccb787d1684117a61b6b/test/client/jest.config.json)

vs

```json
"modulePaths": [
	"<rootDir>/test/",
	"<rootDir>/server/",
	"<rootDir>/client/",
	"<rootDir>/client/extensions/"
],
```
[full config file](https://github.com/Automattic/wp-calypso/blob/b5f739943df8c31ca6aaccb787d1684117a61b6b/test/server/jest.config.json)
