### PR TITLE
Media: Correctly import EditorMediaModalDetail

### DIFF
--- a/client/my-sites/media/main.jsx
+++ b/client/my-sites/media/main.jsx
@@ -15,7 +15,7 @@ import { localize } from 'i18n-calypso';
 import MediaLibrary from 'my-sites/media-library';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import Dialog from 'components/dialog';
-import { EditorMediaModalDetail } from 'post-editor/media-modal/detail';
+import EditorMediaModalDetail from 'post-editor/media-modal/detail';
 import ImageEditor from 'blocks/image-editor';
 import VideoEditor from 'blocks/video-editor';
 import MediaActions from 'lib/media/actions';


### PR DESCRIPTION
Fixes a bug I introduced with #18590, as reported by @jorgefilipecosta in Slack:

> If open media and select an image and then press edit I get an error related with localize it may be related with the last changes

![image](https://user-images.githubusercontent.com/96308/31400930-890c24d6-adf1-11e7-9392-a77877568a93.png)

Turns out that `EditorMediaModalDetail` is [properly `localize()`d](https://github.com/Automattic/wp-calypso/blob/e7e4265d9b65eccb771c3977b54bc0d272bc3c7b/client/post-editor/media-modal/detail/index.jsx#L100), but `my-sites/media/main` was importing the unlocalized version of the component.

To test: Verify that the above error is gone, and that everything else works as before.