### PR TITLE
Domains: Fix DNS editor not loading on page refresh

### DIFF
--- a/client/components/data/domain-management/dns/index.jsx
+++ b/client/components/data/domain-management/dns/index.jsx
@@ -52,6 +52,7 @@ export class DnsData extends Component {
 	}
 
 	loadDns = () => {
+		upgradesActions.fetchDomains( this.props.selectedSite.ID );
 		upgradesActions.fetchDns( this.props.selectedDomainName );
 	};
 

--- a/server/user-bootstrap/index.js
+++ b/server/user-bootstrap/index.js
@@ -20,6 +20,10 @@ module.exports = function( authCookieValue, callback ) {
 	if ( authCookieValue ) {
 		authCookieValue = decodeURIComponent( authCookieValue );
 
+		if ( typeof API_KEY !== 'string' ) {
+			throw new Error( 'Unable to boostrap user because of invalid API key in secrets.json' );
+		}
+
 		hmac = crypto.createHmac( 'md5', API_KEY );
 		hmac.update( authCookieValue );
 		hash = hmac.digest( 'hex' );


### PR DESCRIPTION
This pull request fixes https://github.com/Automattic/wp-calypso/issues/18639 by making sure that the list of domains is fetched when displaying the [`DNS Records` page](https://wordpress.com/domains/manage/:site/dns/:domain) when the user reloads this page:

<img width="564" alt="screenshot" src="https://user-images.githubusercontent.com/594356/31400229-1b35c572-adef-11e7-8b25-840208358739.png">

This pull request actually fixes a side effect of https://github.com/Automattic/wp-calypso/pull/18427 that updated domain warnings to use data from the [global state tree](https://github.com/Automattic/wp-calypso/tree/72431a9ba6de67f18fd164e689990d65420106f6/client/state/sites/domains) instead of the [`Domains` store](https://github.com/Automattic/wp-calypso/blob/72431a9ba6de67f18fd164e689990d65420106f6/client/components/data/domain-management/dns/index.jsx), which meant this store would now be empty when accessing the `DNS Records` page.

#### Testing instructions

You'll have to enable user bootstrapping in development to be able to reload the `DNS Records` page as otherwise you'll be redirected to the [`Domains` page](https://wordpress.com/domains/manage):

1. Open the [`Login` page](https://wordpress.com/log-in), and log in to WordPress.com
2. Retrieve the value of the `wordpress_logged_in` cookie from your browser's devtools
3. Run `git checkout fix/dns-editor`
4. Set `wpcom-user-bootstrap` to `true` in [`development.json`](https://github.com/Automattic/wp-calypso/blob/cca7d11b62f22467866de3cb34bfb6895967b622/config/development.json#L187)
5. Create a `secrets.json` file in the [`config` folder](https://github.com/Automattic/wp-calypso/tree/master/config) with the following content:
```
{
  "wpcom_calypso_rest_api_key": "...",
  "wordpress_logged_in_cookie": "..."
}
```
6. Update the value of `wordpress_logged_in_cookie` with the value of the`wordpress_logged_in` cookie
7. Update the value of `wpcom_calypso_rest_api_key` as well
8. Start your server
9. Navigate to the [`DNS Records` page](https://wordpress.com/domains/manage/:site/dns/:domain)
10. Asserts that the page displays correctly
11. Refresh the page
12. Asserts that the page still displays correctly, and that no Javascript error is thrown

#### Reviews

- [ ] Code
- [ ] Product
- [ ] Tests