### PR TITLE
Codemods: Add assign-component-to-displayname-variable codemod

### DIFF
--- a/bin/codemods/src/assign-component-to-displayname-variable.js
+++ b/bin/codemods/src/assign-component-to-displayname-variable.js
@@ -1,0 +1,140 @@
+/** @format */
+/*
+ This codemod updates
+
+ export default someHoC( React.createClass( {
+	displayName: 'SomeDisplayName',
+ } ) );
+
+ to
+
+ const SomeDisplayName = React.createClass({
+   displayName: 'SomeDisplayName',
+ });
+
+ export default someHoC( SomeDisplayName );
+
+ and
+
+ export default someHoC( class extends {Component|PureComponent|React.Component} {
+	static displayName = 'SomeDisplayName';
+ } );
+
+ to
+
+ class SomeDisplayName extends {Component|PureComponent|React.Component} {
+	static displayName = 'SomeDisplayName';
+ };
+
+ export default someHoC( SomeDisplayName );
+ */
+
+const createClassIdentifier = {
+	type: 'CallExpression',
+	callee: {
+		type: 'MemberExpression',
+		object: {
+			name: 'React',
+		},
+		property: {
+			name: 'createClass',
+		},
+	},
+};
+
+const displayNamePropertyIdentifier = {
+	key: {
+		name: 'displayName',
+	},
+};
+
+const isValidComponentString = string => string === 'Component' || string === 'PureComponent';
+
+const argIsCreateClassInstance = arg =>
+	arg.get( 'callee', 'object', 'name' ).value === 'React' &&
+	arg.get( 'callee', 'property', 'name' ).value === 'createClass';
+
+const argIsExtendsComponentInstance = arg =>
+	arg.get( 'type' ).value === 'ClassExpression' &&
+	( isValidComponentString( arg.get( 'superClass', 'name' ).value ) ||
+		( arg.get( 'superClass', 'object', 'name' ).value === 'React' &&
+			isValidComponentString( arg.get( 'superClass', 'property', 'name' ).value ) ) );
+
+const argIsComponent = arg =>
+	argIsCreateClassInstance( arg ) || argIsExtendsComponentInstance( arg );
+
+const getMatchingArg = args => args.filter( argIsComponent )[ 0 ];
+
+export default function transformer( file, api ) {
+	const j = api.jscodeshift;
+	const root = j( file.source );
+
+	// string => object =>
+	const replaceClassOrGetValue = displayName => arg =>
+		argIsComponent( arg ) ? j.identifier( displayName ) : arg.value;
+
+	const exportDefaultDeclarations = root.find( j.ExportDefaultDeclaration );
+
+	exportDefaultDeclarations.forEach( node => {
+		const calleeNameValue = node.get( 'declaration', 'callee', 'name' ).value;
+
+		if ( ! calleeNameValue ) {
+			// return early, no immediate function call
+			return;
+		}
+
+		const exportDefaultInstance = j( node );
+
+		const args = node.get( 'declaration', 'arguments' );
+		const matchingArg = getMatchingArg( args );
+
+		if ( ! matchingArg ) {
+			// return early, no createClass or extends Component argument found
+			return;
+		}
+
+		const isCreateClassInstance = argIsCreateClassInstance( matchingArg );
+
+		const propertyType = isCreateClassInstance ? j.Property : j.ClassProperty;
+
+		const classExpressions = isCreateClassInstance
+			? exportDefaultInstance.find( j.CallExpression, createClassIdentifier )
+			: exportDefaultInstance.find( j.ClassExpression );
+
+		const displayNameValue = classExpressions
+			.find( propertyType, displayNamePropertyIdentifier )
+			.at( 0 )
+			.get( 'value', 'value' ).value;
+
+		if ( ! displayNameValue ) {
+			// return early, no displayNameValue
+			return;
+		}
+
+		exportDefaultInstance.replaceWith( node => [
+			isCreateClassInstance
+				? // if createClass, replace with const x = React.createClass...
+					j.variableDeclaration( 'const', [
+						j.variableDeclarator( j.identifier( displayNameValue ), matchingArg.value ),
+					] )
+				: // else Replace with class x extends {original-super-class}...
+					j.classDeclaration(
+						j.identifier( displayNameValue ),
+						matchingArg.value.body,
+						matchingArg.value.superClass
+					),
+			// In both cases export with export default calleeName( x ),
+			// maintaining argument position
+			j.exportDefaultDeclaration(
+				j.callExpression(
+					j.identifier( calleeNameValue ),
+					args.map( replaceClassOrGetValue( displayNameValue ) )
+				)
+			),
+		] );
+	} );
+
+	return exportDefaultDeclarations.toSource( {
+		useTabs: true,
+	} );
+}

--- a/bin/codemods/src/assign-component-to-displayname-variable.js
+++ b/bin/codemods/src/assign-component-to-displayname-variable.js
@@ -3,7 +3,7 @@
  This codemod updates
 
  export default someHoC( React.createClass( {
-	displayName: 'SomeDisplayName',
+    displayName: 'SomeDisplayName',
  } ) );
 
  to
@@ -17,30 +17,19 @@
  and
 
  export default someHoC( class extends {Component|PureComponent|React.Component} {
-	static displayName = 'SomeDisplayName';
+    static displayName = 'SomeDisplayName';
  } );
 
  to
 
  class SomeDisplayName extends {Component|PureComponent|React.Component} {
-	static displayName = 'SomeDisplayName';
+    static displayName = 'SomeDisplayName';
  };
 
  export default someHoC( SomeDisplayName );
  */
 
-const createClassIdentifier = {
-	type: 'CallExpression',
-	callee: {
-		type: 'MemberExpression',
-		object: {
-			name: 'React',
-		},
-		property: {
-			name: 'createClass',
-		},
-	},
-};
+import * as _ from 'lodash';
 
 const displayNamePropertyIdentifier = {
 	key: {
@@ -50,91 +39,73 @@ const displayNamePropertyIdentifier = {
 
 const isValidComponentString = string => string === 'Component' || string === 'PureComponent';
 
-const argIsCreateClassInstance = arg =>
-	arg.get( 'callee', 'object', 'name' ).value === 'React' &&
-	arg.get( 'callee', 'property', 'name' ).value === 'createClass';
+const isCreateClassComponent = arg =>
+	_.get( arg, [ 'callee', 'object', 'name' ] ) === 'React' &&
+	_.get( arg, [ 'callee', 'property', 'name' ] ) === 'createClass';
 
-const argIsExtendsComponentInstance = arg =>
-	arg.get( 'type' ).value === 'ClassExpression' &&
-	( isValidComponentString( arg.get( 'superClass', 'name' ).value ) ||
-		( arg.get( 'superClass', 'object', 'name' ).value === 'React' &&
-			isValidComponentString( arg.get( 'superClass', 'property', 'name' ).value ) ) );
+const isEs6ClassComponent = arg =>
+	_.get( arg, 'type' ) === 'ClassExpression' &&
+	( isValidComponentString( _.get( arg, [ 'superClass', 'name' ] ) ) ||
+		( _.get( arg, [ 'superClass', 'object', 'name' ] ) === 'React' &&
+			isValidComponentString( _.get( arg, [ 'superClass', 'property', 'name' ] ) ) ) );
 
-const argIsComponent = arg =>
-	argIsCreateClassInstance( arg ) || argIsExtendsComponentInstance( arg );
+const isComponent = arg => isCreateClassComponent( arg ) || isEs6ClassComponent( arg );
 
-const getMatchingArg = args => args.filter( argIsComponent )[ 0 ];
+const getComponentFromArgs = args => _.filter( args, isComponent )[ 0 ];
+
+const classToIdentifier = ( displayName, j ) => arg =>
+	isComponent( arg ) ? j.identifier( displayName ) : arg;
+
+const extractDisplayName = ( reactComponent, j ) => {
+	if ( ! reactComponent ) {
+		return;
+	}
+	const component = j( reactComponent );
+	// can work on both es6 classes and React.createClass functions.
+	return []
+		.concat(
+			component.find( j.Property, displayNamePropertyIdentifier ).nodes(),
+			component.find( j.ClassProperty, displayNamePropertyIdentifier ).nodes()
+		)
+		.map( node => _.get( node, 'value.value' ) )[ 0 ];
+};
 
 export default function transformer( file, api ) {
 	const j = api.jscodeshift;
 	const root = j( file.source );
 
-	// string => object =>
-	const replaceClassOrGetValue = displayName => arg =>
-		argIsComponent( arg ) ? j.identifier( displayName ) : arg.value;
+	const defaultExportDeclaration = _.head( root.find( j.ExportDefaultDeclaration ).nodes() );
+	const hocIdentifier = _.get( defaultExportDeclaration, [ 'declaration', 'callee', 'name' ] );
 
-	const exportDefaultDeclarations = root.find( j.ExportDefaultDeclaration );
+	const hocArgs = _.get( defaultExportDeclaration, [ 'declaration', 'arguments' ] );
+	const component = getComponentFromArgs( hocArgs );
+	const displayName = extractDisplayName( component, j );
 
-	exportDefaultDeclarations.forEach( node => {
-		const calleeNameValue = node.get( 'declaration', 'callee', 'name' ).value;
+	// noop if the file does not have a default export of a react component that has a displayName
+	if ( ! defaultExportDeclaration || ! component || ! displayName ) {
+		return;
+	}
 
-		if ( ! calleeNameValue ) {
-			// return early, no immediate function call
-			return;
-		}
+	const isCreateClass = isCreateClassComponent( component );
 
-		const exportDefaultInstance = j( node );
-
-		const args = node.get( 'declaration', 'arguments' );
-		const matchingArg = getMatchingArg( args );
-
-		if ( ! matchingArg ) {
-			// return early, no createClass or extends Component argument found
-			return;
-		}
-
-		const isCreateClassInstance = argIsCreateClassInstance( matchingArg );
-
-		const propertyType = isCreateClassInstance ? j.Property : j.ClassProperty;
-
-		const classExpressions = isCreateClassInstance
-			? exportDefaultInstance.find( j.CallExpression, createClassIdentifier )
-			: exportDefaultInstance.find( j.ClassExpression );
-
-		const displayNameValue = classExpressions
-			.find( propertyType, displayNamePropertyIdentifier )
-			.at( 0 )
-			.get( 'value', 'value' ).value;
-
-		if ( ! displayNameValue ) {
-			// return early, no displayNameValue
-			return;
-		}
-
-		exportDefaultInstance.replaceWith( node => [
-			isCreateClassInstance
+	return root
+		.find( j.ExportDefaultDeclaration )
+		.replaceWith( () => [
+			isCreateClass
 				? // if createClass, replace with const x = React.createClass...
 					j.variableDeclaration( 'const', [
-						j.variableDeclarator( j.identifier( displayNameValue ), matchingArg.value ),
+						j.variableDeclarator( j.identifier( displayName ), component ),
 					] )
 				: // else Replace with class x extends {original-super-class}...
-					j.classDeclaration(
-						j.identifier( displayNameValue ),
-						matchingArg.value.body,
-						matchingArg.value.superClass
-					),
-			// In both cases export with export default calleeName( x ),
+					j.classDeclaration( j.identifier( displayName ), component.body, component.superClass ),
+			// In both cases export with export default hoc( ...args, displayName, ...args ),
 			// maintaining argument position
 			j.exportDefaultDeclaration(
 				j.callExpression(
-					j.identifier( calleeNameValue ),
-					args.map( replaceClassOrGetValue( displayNameValue ) )
+					j.identifier( hocIdentifier ),
+					hocArgs.map( classToIdentifier( displayName, j ) )
 				)
 			),
-		] );
-	} );
-
-	return exportDefaultDeclarations.toSource( {
-		useTabs: true,
-	} );
+		] )
+		.toSource( { useTabs: true } );
 }


### PR DESCRIPTION
### Summary

This codemod aims to fix up instances where a component is directly wrapped by a HoC and exported.
It tackles the same issue that #18390 aims to fix, but retrospectively.

### The Problem
Wrapping a `.createClass` or `class extends Component` instance in `localize` is a bit of an ugly pattern and likely encourages folks towards the `c( b ( a( Component ) ) )` pattern for enhancing components - either directly or indirectly through some flavour of the following, where enhancements end up scattered:
```js
const SomeComponent = localize( -ComponentDeclaration- );

export default connect( ...)( SomeComponent );
```
I've seen a couple of instance like the above, but by their nature they're pretty hard to search for.

Also, when we export `localize( React.createClass() );` we lose the ability to shallow render the component in unit tests and make access to the base component trickier.

### Testing
I've added some test files to show the effects of this codemod. If we decide to proceed with this codemod I'll remove them (or replace with actual 'expected vs actual' type testing.

Run the following to see these effects:
```bash
npm run codemod assign-component-to-displayname-variable bin/codemods/test-files-will-be-deleted
```

### Notes:
I've written this codemod with flexibility in mind. Though the focus was to fix cases of `localize( class extends...` it will pick out components from any arbitrary HoC or function call. Since the component isn't necessarily the first and only argument of such a HoC or function call it also maintains the argument order when substituting the component with a variable name.