### PR TITLE
Revert "Revert "Revert "Fix redirectTo value used after login"""

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -73,7 +73,7 @@ class Login extends Component {
 		}
 	};
 
-	handleValidLogin = () => {
+	handleValidLogin = redirectTo => {
 		if ( this.props.twoFactorEnabled ) {
 			page(
 				login( {
@@ -83,6 +83,7 @@ class Login extends Component {
 						'none',
 						'authenticator'
 					),
+					redirectTo,
 				} )
 			);
 		} else if ( this.props.isLinking ) {
@@ -90,10 +91,11 @@ class Login extends Component {
 				login( {
 					isNative: true,
 					socialConnect: true,
+					redirectTo,
 				} )
 			);
 		} else {
-			this.rebootAfterLogin();
+			this.rebootAfterLogin( redirectTo );
 		}
 	};
 
@@ -110,8 +112,8 @@ class Login extends Component {
 		}
 	};
 
-	rebootAfterLogin = () => {
-		const { redirectTo } = this.props;
+	rebootAfterLogin = redirectTo => {
+		redirectTo = redirectTo || this.props.redirectTo;
 
 		this.props.recordTracksEvent( 'calypso_login_success', {
 			two_factor_enabled: this.props.twoFactorEnabled,

--- a/client/blocks/login/social.jsx
+++ b/client/blocks/login/social.jsx
@@ -88,7 +88,7 @@ class SocialLoginForm extends Component {
 			() => {
 				this.recordEvent( 'calypso_login_social_login_success' );
 
-				onSuccess();
+				onSuccess( redirectTo );
 			},
 			error => {
 				if ( error.code === 'unknown_user' ) {


### PR DESCRIPTION
Reverts Automattic/wp-calypso#18709

This apparently innocent change did not work as expected: https://github.com/Automattic/wp-calypso/commit/a2f63a7a1fcb56de8c8e1d243420ceaad3bd57f2

The redirect flow is enabled in all cases at the moment (in stage), even signup which is not ready, we have to revert!