### PR TITLE
Fix social signup

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -73,7 +73,7 @@ class Login extends Component {
 		}
 	};
 
-	handleValidLogin = redirectTo => {
+	handleValidLogin = () => {
 		if ( this.props.twoFactorEnabled ) {
 			page(
 				login( {
@@ -83,7 +83,6 @@ class Login extends Component {
 						'none',
 						'authenticator'
 					),
-					redirectTo,
 				} )
 			);
 		} else if ( this.props.isLinking ) {
@@ -91,11 +90,10 @@ class Login extends Component {
 				login( {
 					isNative: true,
 					socialConnect: true,
-					redirectTo,
 				} )
 			);
 		} else {
-			this.rebootAfterLogin( redirectTo );
+			this.rebootAfterLogin();
 		}
 	};
 
@@ -112,8 +110,8 @@ class Login extends Component {
 		}
 	};
 
-	rebootAfterLogin = redirectTo => {
-		redirectTo = redirectTo || this.props.redirectTo;
+	rebootAfterLogin = () => {
+		const { redirectTo } = this.props;
 
 		this.props.recordTracksEvent( 'calypso_login_success', {
 			two_factor_enabled: this.props.twoFactorEnabled,

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -139,6 +139,19 @@ export class LoginForm extends Component {
 			} );
 	};
 
+	shouldUseRedirectLoginFlow() {
+		const { oauth2Client } = this.props;
+		// If calypso is loaded in a popup, we don't want to open a second popup for social login
+		// let's use the redirect flow instead in that case
+		const isPopup = typeof window !== 'undefined' && window.opener && window.opener !== window;
+		// also disable the popup flow for all safari versions
+		// See https://github.com/google/google-api-javascript-client/issues/297#issuecomment-333869742
+		const isSafari =
+			typeof window !== 'undefined' && /^(?!.*chrome).*safari/i.test( window.navigator.userAgent );
+		// disable for oauth2 flows for now
+		return ! oauth2Client && ( isPopup || isSafari );
+	}
+
 	savePasswordRef = input => {
 		this.password = input;
 	};
@@ -311,6 +324,7 @@ export class LoginForm extends Component {
 							linkingSocialService={
 								this.props.socialAccountIsLinking ? this.props.socialAccountLinkService : null
 							}
+							uxMode={ this.shouldUseRedirectLoginFlow() ? 'redirect' : 'popup' }
 						/>
 					</Card>
 				) }

--- a/client/blocks/login/social.jsx
+++ b/client/blocks/login/social.jsx
@@ -88,7 +88,7 @@ class SocialLoginForm extends Component {
 			() => {
 				this.recordEvent( 'calypso_login_social_login_success' );
 
-				onSuccess( redirectTo );
+				onSuccess();
 			},
 			error => {
 				if ( error.code === 'unknown_user' ) {

--- a/client/blocks/login/social.jsx
+++ b/client/blocks/login/social.jsx
@@ -28,7 +28,9 @@ import { InfoNotice } from 'blocks/global-notice';
 import { login } from 'lib/paths';
 
 function isSafari() {
-	return typeof window !== 'undefined' && window.navigator.userAgent.match( /safari/i );
+	return (
+		typeof window !== 'undefined' && /^(?!.*chrome).*safari/i.test( window.navigator.userAgent )
+	);
 }
 
 function shouldUseRedirectFlow() {

--- a/client/blocks/login/social.jsx
+++ b/client/blocks/login/social.jsx
@@ -27,21 +27,6 @@ import WpcomLoginForm from 'signup/wpcom-login-form';
 import { InfoNotice } from 'blocks/global-notice';
 import { login } from 'lib/paths';
 
-function isSafari() {
-	return (
-		typeof window !== 'undefined' && /^(?!.*chrome).*safari/i.test( window.navigator.userAgent )
-	);
-}
-
-function shouldUseRedirectFlow() {
-	// If calypso is loaded in a popup, we don't want to open a second popup for social login
-	// let's use the redirect flow instead in that case
-	const isPopup = typeof window !== 'undefined' && window.opener && window.opener !== window;
-	// also disable the popup flow for all safari versions
-	// See https://github.com/google/google-api-javascript-client/issues/297#issuecomment-333869742
-	return isPopup || isSafari();
-}
-
 class SocialLoginForm extends Component {
 	static propTypes = {
 		createSocialUser: PropTypes.func.isRequired,
@@ -50,6 +35,7 @@ class SocialLoginForm extends Component {
 		onSuccess: PropTypes.func.isRequired,
 		translate: PropTypes.func.isRequired,
 		loginSocialUser: PropTypes.func.isRequired,
+		uxMode: PropTypes.string.isRequired,
 		linkingSocialService: PropTypes.string,
 		socialService: PropTypes.string,
 		socialServiceResponse: PropTypes.object,
@@ -149,8 +135,8 @@ class SocialLoginForm extends Component {
 	}
 
 	render() {
-		const { redirectTo } = this.props;
-		const redirectUri = shouldUseRedirectFlow()
+		const { redirectTo, uxMode } = this.props;
+		const redirectUri = uxMode
 			? `https://${ ( typeof window !== 'undefined' && window.location.host ) +
 					login( { isNative: true, socialService: 'google' } ) }`
 			: null;
@@ -163,6 +149,7 @@ class SocialLoginForm extends Component {
 					<GoogleLoginButton
 						clientId={ config( 'google_oauth_client_id' ) }
 						responseHandler={ this.handleGoogleResponse }
+						uxMode={ uxMode }
 						redirectUri={ redirectUri }
 						onClick={ this.trackGoogleLogin }
 					/>

--- a/client/components/social-buttons/google.js
+++ b/client/components/social-buttons/google.js
@@ -27,6 +27,7 @@ class GoogleLoginButton extends Component {
 		clientId: PropTypes.string.isRequired,
 		scope: PropTypes.string,
 		fetchBasicProfile: PropTypes.bool,
+		uxMode: PropTypes.string,
 		recordTracksEvent: PropTypes.func.isRequired,
 		responseHandler: PropTypes.func.isRequired,
 		translate: PropTypes.func.isRequired,
@@ -89,7 +90,7 @@ class GoogleLoginButton extends Component {
 						client_id: this.props.clientId,
 						scope: this.props.scope,
 						fetch_basic_profile: this.props.fetchBasicProfile,
-						ux_mode: this.props.redirectUri ? 'redirect' : 'popup',
+						ux_mode: this.props.uxMode,
 						redirect_uri: this.props.redirectUri,
 					} )
 					.then( () => {


### PR DESCRIPTION
This fixes social login by re-enabling the popup flow for Chrome.
It also has commits from https://github.com/Automattic/wp-calypso/pull/18712 which did not actually introduce any bug but was reverted.

### Testing Instructions

- Open an incognito session in google chrome
- Boot https://calypso.live/?branch=fix/social-signup-redirect
 go to https://woocommerce.com/ and click on `SIGN IN WITH WORDPRESS.COM`
- Replace `wordpress.com` in your url by `calypso.live`
- Click on the `Continue with Google` button
- Assert that it uses the popup flow and that you can sign-in/sign-up as usual with your google account
- Open Safari and navigate to https://calypso.live/?branch=fix/social-signup-redirect click on Log In
- click on `SIGN IN WITH WORDPRESS.COM`
- Assert that it uses the redirect flow and that you can log in
- Log out and navigate to https://woocommerce.com/
- click on `SIGN IN WITH WORDPRESS.COM`
- Replace `wordpress.com` in your url by `calypso.live`
- Click on the `Continue with Google` button
- Assert that it uses the redirect flow and that you can log in and authorize woo (or continue the flow)

### Reviews
- [ ] Code
- [ ] Product
