### PR TITLE
Atomic Store: add special checkout-thank-you page for store signup flow

### DIFF
--- a/client/lib/sites-list/list.js
+++ b/client/lib/sites-list/list.js
@@ -85,7 +85,7 @@ SitesList.prototype.fetch = function() {
 			fields:
 				'ID,URL,name,capabilities,jetpack,visible,is_private,is_vip,icon,plan,jetpack_modules,single_user_site,is_multisite,options', //eslint-disable-line max-len
 			options:
-				'is_mapped_domain,unmapped_url,admin_url,is_redirect,is_automated_transfer,allowed_file_types,show_on_front,main_network_site,jetpack_version,software_version,default_post_format,created_at,frame_nonce,publicize_permanently_disabled,page_on_front,page_for_posts,advanced_seo_front_page_description,advanced_seo_title_formats,verification_services_codes,podcasting_archive,is_domain_only,default_sharing_status,default_likes_enabled,wordads,upgraded_filetypes_enabled,videopress_enabled,permalink_structure,gmt_offset', //eslint-disable-line max-len
+				'is_mapped_domain,unmapped_url,admin_url,is_redirect,is_automated_transfer,allowed_file_types,show_on_front,main_network_site,jetpack_version,software_version,default_post_format,created_at,frame_nonce,publicize_permanently_disabled,page_on_front,page_for_posts,advanced_seo_front_page_description,advanced_seo_title_formats,verification_services_codes,podcasting_archive,is_domain_only,default_sharing_status,default_likes_enabled,wordads,upgraded_filetypes_enabled,videopress_enabled,permalink_structure,gmt_offset,signup_is_store', //eslint-disable-line max-len
 		},
 		function( error, data ) {
 			if ( error ) {

--- a/client/my-sites/checkout/checkout-thank-you/atomic-store-thank-you-card.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/atomic-store-thank-you-card.jsx
@@ -1,0 +1,67 @@
+/**
+ * External dependencies
+ *
+ * @format
+ */
+
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+import classNames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import PlanThankYouCard from 'blocks/plan-thank-you-card';
+import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
+import { getCurrentPlan } from 'state/sites/plans/selectors';
+import { getPlanClass } from 'lib/plans/constants';
+
+class AtomicStoreThankYouCard extends Component {
+	renderAction() {
+		const { site, translate } = this.props;
+
+		return (
+			<div className="checkout-thank-you__atomic-store-action-buttons">
+				<a
+					className={ classNames( 'button', 'thank-you-card__button' ) }
+					href={ `/store/${ site.slug }` }
+				>
+					{ translate( 'Set up my store!' ) }
+				</a>
+			</div>
+		);
+	}
+
+	render() {
+		const { translate, siteId, planClass } = this.props;
+
+		const classes = classNames( 'checkout-thank-you__atomic-store', planClass );
+
+		return (
+			<div className={ classes }>
+				<PlanThankYouCard
+					siteId={ siteId }
+					action={ this.renderAction() }
+					heading={ translate( 'Thank you for your purchase!' ) }
+					description={ translate(
+						"Now that we've taken care of the plan, it's time to start setting up your store"
+					) }
+				/>
+			</div>
+		);
+	}
+}
+
+export default connect( state => {
+	const site = getSelectedSite( state );
+	const siteId = getSelectedSiteId( state );
+	const plan = getCurrentPlan( state, siteId );
+	const planClass = plan && plan.productSlug ? getPlanClass( plan.productSlug ) : '';
+
+	return {
+		siteId,
+		site,
+		planClass,
+	};
+} )( localize( AtomicStoreThankYouCard ) );

--- a/client/my-sites/checkout/checkout-thank-you/index.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.jsx
@@ -6,7 +6,7 @@
 
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { find } from 'lodash';
+import { find, get } from 'lodash';
 import page from 'page';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -36,6 +36,7 @@ import HappinessSupport from 'components/happiness-support';
 import HeaderCake from 'components/header-cake';
 import PlanThankYouCard from 'blocks/plan-thank-you-card';
 import JetpackThankYouCard from './jetpack-thank-you-card';
+import AtomicStoreThankYouCard from './atomic-store-thank-you-card';
 import {
 	isChargeback,
 	isDomainMapping,
@@ -75,6 +76,7 @@ import {
 	PLAN_JETPACK_BUSINESS,
 	PLAN_JETPACK_BUSINESS_MONTHLY,
 } from 'lib/plans/constants';
+import { getSiteOptions } from 'state/selectors';
 
 function getPurchases( props ) {
 	return ( props.receipt.data && props.receipt.data.purchases ) || [];
@@ -148,7 +150,7 @@ const CheckoutThankYou = React.createClass( {
 		}
 
 		return (
-            <Notice
+			<Notice
 				className="checkout-thank-you__verification-notice"
 				showDismiss={ false }
 				status="is-warning"
@@ -164,7 +166,7 @@ const CheckoutThankYou = React.createClass( {
 					}
 				) }
 			</Notice>
-        );
+		);
 	},
 
 	isDataLoaded() {
@@ -264,6 +266,8 @@ const CheckoutThankYou = React.createClass( {
 			return <RebrandCitiesThankYou receipt={ this.props.receipt } />;
 		}
 
+		const { signupIsStore } = this.props;
+
 		// streamlined paid NUX thanks page
 		if ( this.isNewUser() && wasDotcomPlanPurchased ) {
 			return (
@@ -279,13 +283,20 @@ const CheckoutThankYou = React.createClass( {
 					<JetpackThankYouCard siteId={ this.props.selectedSite.ID } />
 				</Main>
 			);
+		} else if ( wasDotcomPlanPurchased && signupIsStore ) {
+			return (
+				<Main className="checkout-thank-you">
+					{ this.renderConfirmationNotice() }
+					<AtomicStoreThankYouCard siteId={ this.props.selectedSite.ID } />
+				</Main>
+			);
 		}
 
 		if ( this.props.domainOnlySiteFlow && purchases.length > 0 && ! failedPurchases.length ) {
 			const domainName = find( purchases, isDomainRegistration ).meta;
 
 			return (
-                <Main className="checkout-thank-you">
+				<Main className="checkout-thank-you">
 					{ this.renderConfirmationNotice() }
 
 					<ThankYouCard
@@ -299,7 +310,7 @@ const CheckoutThankYou = React.createClass( {
 						buttonText={ this.props.translate( 'Go To Your Domain' ) }
 					/>
 				</Main>
-            );
+			);
 		}
 
 		const goBackText = this.props.selectedSite
@@ -432,6 +443,7 @@ export default connect(
 	( state, props ) => {
 		const siteId = getSelectedSiteId( state );
 		const planSlug = getSitePlanSlug( state, siteId );
+		const siteOptions = getSiteOptions( state, siteId );
 
 		return {
 			planSlug,
@@ -439,6 +451,7 @@ export default connect(
 			sitePlans: getPlansBySite( state, props.selectedSite ),
 			user: getCurrentUser( state ),
 			userDate: getCurrentUserDate( state ),
+			signupIsStore: get( siteOptions, 'signup_is_store', false ),
 		};
 	},
 	dispatch => {
@@ -460,4 +473,4 @@ export default connect(
 			},
 		};
 	}
-)( localize(CheckoutThankYou) );
+)( localize( CheckoutThankYou ) );

--- a/client/state/sites/actions.js
+++ b/client/state/sites/actions.js
@@ -103,7 +103,7 @@ export function requestSites() {
 				fields:
 					'ID,URL,name,capabilities,jetpack,visible,is_private,is_vip,icon,plan,jetpack_modules,single_user_site,is_multisite,options', //eslint-disable-line max-len
 				options:
-					'is_mapped_domain,unmapped_url,admin_url,is_redirect,is_automated_transfer,allowed_file_types,show_on_front,main_network_site,jetpack_version,software_version,default_post_format,created_at,frame_nonce,publicize_permanently_disabled,page_on_front,page_for_posts,advanced_seo_front_page_description,advanced_seo_title_formats,verification_services_codes,podcasting_archive,is_domain_only,default_sharing_status,default_likes_enabled,wordads,upgraded_filetypes_enabled,videopress_enabled,permalink_structure,gmt_offset', //eslint-disable-line max-len
+					'is_mapped_domain,unmapped_url,admin_url,is_redirect,is_automated_transfer,allowed_file_types,show_on_front,main_network_site,jetpack_version,software_version,default_post_format,created_at,frame_nonce,publicize_permanently_disabled,page_on_front,page_for_posts,advanced_seo_front_page_description,advanced_seo_title_formats,verification_services_codes,podcasting_archive,is_domain_only,default_sharing_status,default_likes_enabled,wordads,upgraded_filetypes_enabled,videopress_enabled,permalink_structure,gmt_offset,signup_is_store', //eslint-disable-line max-len
 			} )
 			.then( response => {
 				dispatch( receiveSites( response.sites ) );


### PR DESCRIPTION
Part of the Atomic Store signup flow work.

In this PR, we introduce a new checkout-thank-you page according to mockups in p3fqKv-5f6-p2:

![image](https://user-images.githubusercontent.com/4988512/31408038-6e90a012-ae07-11e7-851d-2cbc91561d2e.png)

## Testing

Run Calypso locally and start with `/start/atomic-store`. Select the 'store' site design type on the first step and continue the flow. After paying for the Business plan, you should be taken to this new checkout-thank-you page. After clicking the "Set up my store" link, you should be taken to `/store/<site>`.

Don't forget to test the other design types/flows: whether the checkout-thank-you page shows proper stuff.

## Questions

@kellychoffman in your mockups on the P2, there are no features/texts except what is visible on the screenshot above. Is that okay for this flow? I would say yes since we want the customers to finish setting up the store and don't click on anything else during that time (+ AT is running on the backend so they should not really interact with Calypso much during that time (normally we lock it)). 

/cc @iamtakashi 