### PR TITLE
Reader Tracks: add `referralStream` property to FullPost

### DIFF
--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -76,6 +76,7 @@ export class FullPostView extends React.Component {
 		post: PropTypes.object.isRequired,
 		onClose: PropTypes.func.isRequired,
 		referralPost: PropTypes.object,
+		referralStream: PropTypes.string,
 	};
 
 	hasScrolledToCommentAnchor = false;
@@ -244,7 +245,9 @@ export class FullPostView extends React.Component {
 		}
 
 		if ( ! this.hasLoaded && post && post._state !== 'pending' ) {
-			recordTrackForPost( 'calypso_reader_article_opened', post );
+			recordTrackForPost( 'calypso_reader_article_opened', post, {
+				overwriteLocationPath: this.props.referralStream,
+			} );
 			this.hasLoaded = true;
 		}
 	};
@@ -548,6 +551,7 @@ export default class FullPostFluxContainer extends React.Component {
 				onClose={ this.props.onClose }
 				post={ this.state.post }
 				referralPost={ this.state.referralPost }
+				referralStream={ this.props.referralStream }
 			/>
 		) : null;
 	}

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -245,9 +245,14 @@ export class FullPostView extends React.Component {
 		}
 
 		if ( ! this.hasLoaded && post && post._state !== 'pending' ) {
-			recordTrackForPost( 'calypso_reader_article_opened', post, {
-				overwriteLocationPath: this.props.referralStream,
-			} );
+			recordTrackForPost(
+				'calypso_reader_article_opened',
+				post,
+				{},
+				{
+					pathnameOverride: this.props.referralStream,
+				}
+			);
 			this.hasLoaded = true;
 		}
 	};

--- a/client/reader/full-post/controller.js
+++ b/client/reader/full-post/controller.js
@@ -57,6 +57,7 @@ export function blogPost( context ) {
 			blogId={ blogId }
 			postId={ postId }
 			referral={ referral }
+			referralStream={ context.lastRoute }
 			onClose={ function() {
 				page.back( context.lastRoute || '/' );
 			} }
@@ -86,6 +87,7 @@ export function feedPost( context ) {
 			feedId={ feedId }
 			postId={ postId }
 			onClose={ closer }
+			referralStream={ context.lastRoute }
 			onPostNotFound={ renderPostNotFound }
 		/>,
 		document.getElementById( 'primary' ),

--- a/client/reader/stats.js
+++ b/client/reader/stats.js
@@ -39,12 +39,10 @@ export function recordPermalinkClick( where, post ) {
 	}
 }
 
-function getLocation() {
-	if ( typeof window === 'undefined' ) {
+function getLocation( path ) {
+	if ( path === undefined || path === '' ) {
 		return 'unknown';
 	}
-
-	const path = window.location.pathname;
 	if ( path === '/' ) {
 		return 'following';
 	}
@@ -100,9 +98,19 @@ export function recordTrack( eventName, eventProperties ) {
 	debug( 'reader track', ...arguments );
 	const subCount = 0; // todo: fix subCount by moving to redux middleware for recordTrack
 
-	// Add location as ui_algo prop
-	const location = getLocation();
-	eventProperties = Object.assign( { ui_algo: location }, eventProperties );
+	// Get location from locationPath and set as ui_algo prop.
+	let locationPath = window.location.pathname;
+	/* Overwrites the existing locationPath if provided in eventProperties
+	Useful for when recordTrack() is called after loading the next window.
+	For example: opening an article (calypso_reader_article_opened) would call
+	recordTrack after changing windows and would result in a `ui_algo: single_post`
+	regardless of the stream the post was opened. This now allows the article_opened
+	Tracks event to correctly specify which stream the post was opened. */
+	if ( eventProperties && 'overwriteLocationPath' in eventProperties ) {
+		locationPath = eventProperties.overwriteLocationPath;
+		delete eventProperties.overwriteLocationPath;
+	}
+	eventProperties = Object.assign( { ui_algo: getLocation( locationPath ) }, eventProperties );
 
 	if ( subCount != null ) {
 		eventProperties = Object.assign( { subscription_count: subCount }, eventProperties );
@@ -208,7 +216,7 @@ export function pageViewForPost( blogId, blogUrl, postId, isPrivate ) {
 }
 
 export function recordFollow( url, railcar, additionalProps = {} ) {
-	const source = additionalProps.source || getLocation();
+	const source = additionalProps.source || getLocation( window.location.pathname );
 	mc.bumpStat( 'reader_follows', source );
 	recordAction( 'followed_blog' );
 	recordGaEvent( 'Clicked Follow Blog', source );
@@ -223,7 +231,7 @@ export function recordFollow( url, railcar, additionalProps = {} ) {
 }
 
 export function recordUnfollow( url, railcar, additionalProps = {} ) {
-	const source = getLocation();
+	const source = getLocation( window.location.pathname );
 	mc.bumpStat( 'reader_unfollows', source );
 	recordAction( 'unfollowed_blog' );
 	recordGaEvent( 'Clicked Unfollow Blog', source );


### PR DESCRIPTION
When tracking `calypso_reader_article_opened`, it would be nice to know which stream the user opened a post. By passing along the `referralStream` URL ('/', '/tag', '/read/search', etc.), we would have a better understanding of which posts our users are opening.