### PR TITLE
Editor: Style HTML-mode dropzone to cover entire editor body

### DIFF
--- a/client/components/tinymce/index.jsx
+++ b/client/components/tinymce/index.jsx
@@ -542,14 +542,17 @@ export default React.createClass( {
 		} );
 
 		/*
-		 * Using `classnames()` here is just a hack to avoid the linter complaining that the
+		 * Using `classnames()` here is partly a hack to avoid the linter complaining that the
 		 * container is named `tinymce-container` instead of `tinymce`. Ideally the containing
 		 * `div` and the `textarea` should be refactored so that the `div` has the `tinymce`
 		 * class, but that would interfere with higher priority fixes. This component is slated
 		 * for some refactoring in the near future, so that will be a more convenient time to
 		 * clean this up.
 		 */
-		const containerClassName = classnames( 'tinymce-container' );
+		const containerClassName = classnames(
+			'tinymce-container',
+			'editor-mode-' + mode
+		);
 
 		return (
 			<div className={ containerClassName }>

--- a/client/post-editor/editor-html-toolbar/index.jsx
+++ b/client/post-editor/editor-html-toolbar/index.jsx
@@ -36,6 +36,7 @@ import AddImageDialog from './add-image-dialog';
 import AddLinkDialog from './add-link-dialog';
 import Button from 'components/button';
 import ContactFormDialog from 'components/tinymce/plugins/contact-form/dialog';
+import isDropZoneVisible from 'state/selectors/is-drop-zone-visible';
 import EditorMediaModal from 'post-editor/editor-media-modal';
 import MediaLibraryDropZone from 'my-sites/media-library/drop-zone';
 import config from 'config';
@@ -53,6 +54,7 @@ export class EditorHtmlToolbar extends Component {
 		fieldAdd: PropTypes.func,
 		fieldRemove: PropTypes.func,
 		fieldUpdate: PropTypes.func,
+		isDropZoneVisible: PropTypes.bool.isRequired,
 		moment: PropTypes.func,
 		onToolbarChangeContent: PropTypes.func,
 		settingsUpdate: PropTypes.func,
@@ -522,6 +524,7 @@ export class EditorHtmlToolbar extends Component {
 			'is-pinned': this.state.isPinned,
 			'is-scrollable': this.state.isScrollable,
 			'is-scrolled-full': this.state.isScrolledFull,
+			'has-active-drop-zone': this.props.isDropZoneVisible,
 		} );
 		const insertContentClasses = classNames( 'editor-html-toolbar__insert-content-dropdown', {
 			'is-visible': this.state.showInsertContentMenu,
@@ -693,6 +696,7 @@ export class EditorHtmlToolbar extends Component {
 
 const mapStateToProps = state => ( {
 	contactForm: get( state, 'ui.editor.contactForm', {} ),
+	isDropZoneVisible: isDropZoneVisible( state ),
 	site: getSelectedSite( state ),
 } );
 

--- a/client/post-editor/editor-html-toolbar/style.scss
+++ b/client/post-editor/editor-html-toolbar/style.scss
@@ -85,6 +85,17 @@
 		width: 0;
 	}
 
+	&.has-active-drop-zone {
+		/*
+		 * Allow the dropzone to overflow the toolbar and expand to fill the entire editor body.
+		 * `static` prevents `.html-editor-toolbar` from setting the positioning context for its
+		 * children (including the dropzone), which would constrain them to the dimensions of the
+		 * toolbar. Instead, it will be constrained to the next highest positioned element,
+		 * `.tinymce-container.`
+		 */
+		position: static;
+	}
+
 	.button {
 		border-right: 1px solid lighten( $gray, 30% );
 		color: darken( $gray, 20% );

--- a/client/post-editor/style.scss
+++ b/client/post-editor/style.scss
@@ -144,8 +144,12 @@
 	position: relative;
 }
 
-.post-editor .tinymce-container .drop-zone.is-active {
-	top: 80px; /* Move it below the TinyMCE toolbar, because it looks bad when they overlap */
+.post-editor .tinymce-container.editor-mode-tinymce .drop-zone.is-active {
+	top: 75px; /* Move it below the TinyMCE toolbar, because it looks bad when they overlap */
+}
+
+.post-editor .tinymce-container.editor-mode-html .drop-zone.is-active {
+	top: 40px; /* Move it below the TinyMCE toolbar, because it looks bad when they overlap */
 }
 
 .post-editor .tinymce {


### PR DESCRIPTION
A bug was introduced in #16819 which collapsed the editor's dropzone when in HTML-editing mode. Before that PR, the dropzone was full-screen, but now it needs to be constrained to the editor body, in order to leave room for the featured-image dropzones.

This is an alternate approach to #18558, which avoids all the refactoring and rabbit-holes, but may not be as pure, since the dropzone is breaking out of the DOM structure. See #18558 for details on that.

Fixes #18535

### Test Plan

1. Create a new post, or open an existing one
1. Switch to HTML mode
1. Drag a file onto the editor
1. A large, blue dropzone should cover the editor body
1. Drop the file onto the blue editor
1. The file should upload, and insert into the editor
1. Repeat the steps above, but drop multiple images. A gallery should be inserted.
1. Drop files onto the two orange featured image dropzones, to make sure they still work fine.
1. Switch to visual mode and drop a file onto the blue editor dropzone, to make sure it still works fine.
1. Scroll down in both visual and HTML modes, to make sure that the toolbar is pinned to the top of the page. Then scroll up to make sure it's un-pinned.