### PR TITLE
Editor: update insert content button

### DIFF
--- a/client/components/tinymce/plugins/insert-menu/menu-items.jsx
+++ b/client/components/tinymce/plugins/insert-menu/menu-items.jsx
@@ -27,7 +27,7 @@ export const GridiconButton = ( { icon, label, e2e } ) => (
 export const menuItems = [
 	{
 		name: 'insert_media_item',
-		item: <GridiconButton icon="add-image" label={ i18n.translate( 'Add Media' ) } e2e="media" />,
+		item: <GridiconButton icon="add-image" label={ i18n.translate( 'Media' ) } e2e="media" />,
 		cmd: 'wpcomAddMedia',
 	},
 ];
@@ -38,7 +38,7 @@ if ( config.isEnabled( 'external-media' ) ) {
 		item: (
 			<GridiconButton
 				icon="add-image"
-				label={ i18n.translate( 'Add from Google' ) }
+				label={ i18n.translate( 'Media from Google' ) }
 				e2e="google-media"
 			/>
 		),
@@ -49,11 +49,7 @@ if ( config.isEnabled( 'external-media' ) ) {
 menuItems.push( {
 	name: 'insert_contact_form',
 	item: (
-		<GridiconButton
-			icon="mention"
-			label={ i18n.translate( 'Add Contact Form' ) }
-			e2e="contact-form"
-		/>
+		<GridiconButton icon="mention" label={ i18n.translate( 'Contact Form' ) } e2e="contact-form" />
 	),
 	cmd: 'wpcomContactForm',
 } );
@@ -64,7 +60,7 @@ if ( config.isEnabled( 'simple-payments' ) ) {
 		item: (
 			<GridiconButton
 				icon="money"
-				label={ i18n.translate( 'Add Payment Button' ) }
+				label={ i18n.translate( 'Payment Button' ) }
 				e2e="payment-button"
 			/>
 		),

--- a/client/components/tinymce/plugins/insert-menu/menu-items.jsx
+++ b/client/components/tinymce/plugins/insert-menu/menu-items.jsx
@@ -14,8 +14,8 @@ import i18n from 'i18n-calypso';
 import config from 'config';
 
 /* eslint-disable wpcalypso/jsx-classname-namespace */
-const GridiconButton = ( { icon, label, e2e } ) => (
-	<div>
+export const GridiconButton = ( { icon, label, e2e } ) => (
+	<div className="wpcom-insert-menu__menu">
 		<Gridicon className="wpcom-insert-menu__menu-icon" icon={ icon } />
 		<span className="wpcom-insert-menu__menu-label" data-e2e-insert-type={ e2e }>
 			{ label }
@@ -24,7 +24,7 @@ const GridiconButton = ( { icon, label, e2e } ) => (
 );
 /* eslint-enable wpcalypso/jsx-classname-namespace */
 
-const menuItems = [
+export const menuItems = [
 	{
 		name: 'insert_media_item',
 		item: <GridiconButton icon="add-image" label={ i18n.translate( 'Add Media' ) } e2e="media" />,
@@ -71,5 +71,3 @@ if ( config.isEnabled( 'simple-payments' ) ) {
 		cmd: 'simplePaymentsButton',
 	} );
 }
-
-export default menuItems;

--- a/client/components/tinymce/plugins/insert-menu/plugin.jsx
+++ b/client/components/tinymce/plugins/insert-menu/plugin.jsx
@@ -32,7 +32,7 @@ const initialize = editor => {
 			const [ insertContentElm ] = this.$el[ 0 ].children;
 
 			insertContentElm.innerHTML = renderToString(
-				<GridiconButton icon="add-outline" label="Add" classNames="foobar" />
+				<GridiconButton icon="add-outline" label={ i18n.translate( 'Add' ) } />
 			);
 
 			const addTooltipListener = ( el, text ) => {

--- a/client/components/tinymce/plugins/insert-menu/plugin.jsx
+++ b/client/components/tinymce/plugins/insert-menu/plugin.jsx
@@ -6,12 +6,11 @@ import React from 'react';
 import tinymce from 'tinymce/tinymce';
 import { renderToString } from 'react-dom/server';
 import i18n from 'i18n-calypso';
-import Gridicon from 'gridicons';
 
 /**
  * Internal dependencies
  */
-import menuItems from './menu-items';
+import { menuItems, GridiconButton } from './menu-items';
 
 const initialize = editor => {
 	menuItems.forEach( item =>
@@ -25,15 +24,16 @@ const initialize = editor => {
 	);
 
 	editor.addButton( 'wpcom_insert_menu', {
-		type: 'splitbutton',
+		type: 'menubutton',
 		title: i18n.translate( 'Insert content' ),
 		classes: 'btn wpcom-insert-menu insert-menu',
-		cmd: menuItems[ 0 ].cmd,
 		menu: menuItems.map( ( { name } ) => editor.menuItems[ name ] ),
 		onPostRender() {
-			const [ insertContentElm, insertSpecialElm ] = this.$el[ 0 ].children;
+			const [ insertContentElm ] = this.$el[ 0 ].children;
 
-			insertContentElm.innerHTML = renderToString( <Gridicon icon="add-outline" /> );
+			insertContentElm.innerHTML = renderToString(
+				<GridiconButton icon="add-outline" label="Add" classNames="foobar" />
+			);
 
 			const addTooltipListener = ( el, text ) => {
 				el.addEventListener( 'mouseenter', () => {
@@ -55,10 +55,8 @@ const initialize = editor => {
 				} );
 			};
 
-			// Listen to `mouseenter` events on the (+) and (v) parts of the Inserter menu to show
-			// the "Insert content" or "Insert special" tooltip.
+			// Listen to `mouseenter` events on the (+)
 			addTooltipListener( insertContentElm, i18n.translate( 'Insert content' ) );
-			addTooltipListener( insertSpecialElm, i18n.translate( 'Insert special' ) );
 		},
 	} );
 };

--- a/client/components/tinymce/plugins/insert-menu/plugin.jsx
+++ b/client/components/tinymce/plugins/insert-menu/plugin.jsx
@@ -25,7 +25,7 @@ const initialize = editor => {
 
 	editor.addButton( 'wpcom_insert_menu', {
 		type: 'menubutton',
-		title: i18n.translate( 'Insert content' ),
+		title: i18n.translate( 'Add content' ),
 		classes: 'btn wpcom-insert-menu insert-menu',
 		menu: menuItems.map( ( { name } ) => editor.menuItems[ name ] ),
 		onPostRender() {
@@ -56,7 +56,7 @@ const initialize = editor => {
 			};
 
 			// Listen to `mouseenter` events on the (+)
-			addTooltipListener( insertContentElm, i18n.translate( 'Insert content' ) );
+			addTooltipListener( insertContentElm, i18n.translate( 'Add content' ) );
 		},
 	} );
 };

--- a/client/components/tinymce/plugins/insert-menu/style.scss
+++ b/client/components/tinymce/plugins/insert-menu/style.scss
@@ -41,11 +41,15 @@
 
 .mce-container .wpcom-insert-menu__menu-label {
 	color: darken( $gray, 20% );
-	display: inline-block;
+	display: none;
 	font-family: $sans;
 	font-size: 13px;
 	margin-left: 4px;
 	margin-top: 3px;
+
+	@include breakpoint( '>660px' ) {
+		display: inline-block;
+	}
 }
 
 .wpcom-insert-menu__menu-icon {

--- a/client/components/tinymce/plugins/insert-menu/style.scss
+++ b/client/components/tinymce/plugins/insert-menu/style.scss
@@ -5,25 +5,13 @@
 		height: 36px;
 		margin: 0;
 
-
+		&.mce-active {
+			border-color: transparent;
+		}
 
 		&:hover .wpcom-insert-menu__menu-label,
 		&:focus .wpcom-insert-menu__menu-label {
-			color: lighten( $gray, 10% );
-		}
-
-		&:hover .wpcom-insert-menu__menu-icon,
-		&:focus .wpcom-insert-menu__menu-icon {
-			fill: lighten( $gray, 10% );
-		}
-
-		.wpcom-insert-menu__menu:hover {
-			.wpcom-insert-menu__menu-label {
-				color: $gray-dark;
-			}
-			.wpcom-insert-menu__menu-icon {
-				fill: $gray-dark;
-			}
+			color: $gray-dark;
 		}
 	}
 }
@@ -35,7 +23,7 @@
 }
 
 .mce-toolbar .mce-btn.mce-insert-menu button:first-child {
-	padding: 6px;
+	padding: 6px 11px 6px 9px;
 }
 
 .mce-splitbtn.mce-insert-menu .mce-open.mce-active {
@@ -52,11 +40,12 @@
 }
 
 .mce-container .wpcom-insert-menu__menu-label {
-	color: darken( $gray, 30% );
+	color: darken( $gray, 20% );
 	display: inline-block;
 	font-family: $sans;
-	margin-left: 8px;
-	margin-top: 2px;
+	font-size: 13px;
+	margin-left: 4px;
+	margin-top: 3px;
 }
 
 .wpcom-insert-menu__menu-icon {

--- a/client/components/tinymce/plugins/insert-menu/style.scss
+++ b/client/components/tinymce/plugins/insert-menu/style.scss
@@ -5,23 +5,23 @@
 		height: 36px;
 		margin: 0;
 
-		&:hover .mce-open i.mce-caret,
-		&:focus .mce-open i.mce-caret {
+
+
+		&:hover .wpcom-insert-menu__menu-label,
+		&:focus .wpcom-insert-menu__menu-label {
 			color: lighten( $gray, 10% );
 		}
 
-		&:hover .gridicons-add-outline,
-		&:focus .gridicons-add-outline {
+		&:hover.wpcom-insert-menu__menu-icon,
+		&:focus.wpcom-insert-menu__menu-icon {
 			fill: lighten( $gray, 10% );
 		}
 
-		.mce-open:hover i.mce-caret,
-		.mce-open:focus i.mce-caret {
+
+		.wpcom-insert-menu__menu-label:hover {
 			color: $gray-dark;
 		}
-
-		.gridicons-add-outline:hover,
-		.gridicons-add-outline:focus {
+		.wpcom-insert-menu__menu-icon:hover {
 			fill: $gray-dark;
 		}
 	}

--- a/client/components/tinymce/plugins/insert-menu/style.scss
+++ b/client/components/tinymce/plugins/insert-menu/style.scss
@@ -12,17 +12,18 @@
 			color: lighten( $gray, 10% );
 		}
 
-		&:hover.wpcom-insert-menu__menu-icon,
-		&:focus.wpcom-insert-menu__menu-icon {
+		&:hover .wpcom-insert-menu__menu-icon,
+		&:focus .wpcom-insert-menu__menu-icon {
 			fill: lighten( $gray, 10% );
 		}
 
-
-		.wpcom-insert-menu__menu-label:hover {
-			color: $gray-dark;
-		}
-		.wpcom-insert-menu__menu-icon:hover {
-			fill: $gray-dark;
+		.wpcom-insert-menu__menu:hover {
+			.wpcom-insert-menu__menu-label {
+				color: $gray-dark;
+			}
+			.wpcom-insert-menu__menu-icon {
+				fill: $gray-dark;
+			}
 		}
 	}
 }

--- a/client/layout/guided-tours/tours/editor-basics-tour.js
+++ b/client/layout/guided-tours/tours/editor-basics-tour.js
@@ -57,44 +57,25 @@ export const EditorBasicsTour = makeTour(
 				style={ { marginBottom: '10px', border: '3px solid #00AADC', borderRadius: '4px' } }
 			/>
 			<ButtonRow>
-				<Next step="add-image" />
+				<Next step="add-things" />
 				<Quit />
 			</ButtonRow>
 		</Step>
 		<Step
-			name="add-image"
+			name="add-things"
 			arrow="top-left"
 			target=".editor-html-toolbar__button-insert-media, .mce-wpcom-insert-menu button"
 			placement="below"
 			style={ { marginLeft: '-10px', zIndex: 'auto' } }
 		>
 			<p>
-				{ translate( 'Click the {{icon/}} to add images.', {
-					components: {
-						icon: <Gridicon icon="add-outline" />,
-					},
-				} ) }
-			</p>
-			<ButtonRow>
-				<Next step="add-other" />
-				<Quit />
-			</ButtonRow>
-		</Step>
-		<Step
-			name="add-other"
-			arrow="top-left"
-			target=".editor-html-toolbar__button-insert-media, .mce-wpcom-insert-menu button"
-			placement="below"
-			style={ { marginLeft: '22px', zIndex: 'auto' } }
-		>
-			<p>
 				{ translate(
-					'The {{icon/}} lets you add other things, like a contact form. ' +
+					'Click the {{icon/}} to add images and other things, like a contact form. ' +
 						'If your site is on the Premium or Business plan, you can even add {{strong}}payment buttons{{/strong}}!',
 					{
 						components: {
 							strong: <strong />,
-							icon: <Gridicon icon="chevron-down" />,
+							icon: <Gridicon icon="add-outline" />,
 						},
 					}
 				) }

--- a/client/layout/guided-tours/tours/editor-basics-tour.js
+++ b/client/layout/guided-tours/tours/editor-basics-tour.js
@@ -66,12 +66,13 @@ export const EditorBasicsTour = makeTour(
 			arrow="top-left"
 			target=".editor-html-toolbar__button-insert-media, .mce-wpcom-insert-menu button"
 			placement="below"
-			style={ { marginLeft: '-10px', zIndex: 'auto' } }
+			style={ { marginLeft: '-7px', zIndex: 'auto' } }
 		>
 			<p>
 				{ translate(
 					'Click the {{icon/}} to add images and other things, like a contact form. ' +
-						'If your site is on the Premium or Business plan, you can even add {{strong}}payment buttons{{/strong}}!',
+						'Sites on the Premium and Business plans can add {{strong}}payment buttons{{/strong}} -- ' +
+						'sell tickets, collect donations, accept tips, and more.',
 					{
 						components: {
 							strong: <strong />,


### PR DESCRIPTION
This combines "insert content" and "insert special" into one menu item in the editor. All the options previously available in the "insert special" menu are now accessible from the one single button.

See p3fqKv-5Oi-p2

before:
![before](https://user-images.githubusercontent.com/744755/31413133-c0535c4a-adcc-11e7-8c05-386b25b0a6d5.png)


after:
![after](https://user-images.githubusercontent.com/744755/31413135-c31c9950-adcc-11e7-9ff1-4f0a0e0522e3.png)


**Testing**

The button should open the 4 content types that can be added: media, from Google, Contact Form and Payment Button

 