### PR TITLE
Store orders: Set initial refund value in modal

### DIFF
--- a/client/extensions/woocommerce/app/order/order-payment/dialog.js
+++ b/client/extensions/woocommerce/app/order/order-payment/dialog.js
@@ -7,6 +7,7 @@ import PropTypes from 'prop-types';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
+import { sum } from 'lodash';
 
 /**
  * Internal dependencies
@@ -22,7 +23,11 @@ import formatCurrency from 'lib/format-currency';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
 import FormTextarea from 'components/forms/form-textarea';
-import { getOrderRefundTotal } from 'woocommerce/lib/order-values';
+import {
+	getOrderLineItemTax,
+	getOrderRefundTotal,
+	getOrderShippingTax,
+} from 'woocommerce/lib/order-values';
 import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
 import Notice from 'components/notice';
 import OrderRefundTable from './table';
@@ -48,11 +53,15 @@ class OrderPaymentCard extends Component {
 		translate: PropTypes.func.isRequired,
 	};
 
-	state = {
-		errorMessage: false,
-		refundTotal: 0,
-		refundNote: '',
-	};
+	constructor( props ) {
+		super( props );
+
+		this.state = {
+			errorMessage: false,
+			refundTotal: this.getInitialRefund(),
+			refundNote: '',
+		};
+	}
 
 	componentDidMount = () => {
 		const { siteId } = this.props;
@@ -80,8 +89,37 @@ class OrderPaymentCard extends Component {
 		this.props.toggleDialog();
 	};
 
-	recalculateRefund = total => {
-		this.setState( { refundTotal: total } );
+	getInitialRefund = () => {
+		const { order } = this.props;
+		return parseFloat( getOrderShippingTax( order ) ) + parseFloat( order.shipping_total );
+	};
+
+	recalculateRefund = data => {
+		const { order } = this.props;
+		if ( ! order ) {
+			return 0;
+		}
+		const subtotal = sum(
+			data.quantities.map( ( q, i ) => {
+				if ( ! order.line_items[ i ] ) {
+					return 0;
+				}
+
+				const price = parseFloat( order.line_items[ i ].price );
+				if ( order.prices_include_tax ) {
+					return price * q;
+				}
+
+				const tax = getOrderLineItemTax( order, i ) / order.line_items[ i ].quantity;
+				return ( price + tax ) * q;
+			} )
+		);
+		const total = subtotal + ( parseFloat( data.shippingTotal ) || 0 );
+		return total;
+	};
+
+	recalculateAndSetState = data => {
+		this.setState( { refundTotal: this.recalculateRefund( data ) } );
 	};
 
 	updateNote = event => {
@@ -183,7 +221,7 @@ class OrderPaymentCard extends Component {
 				additionalClassNames="order-payment__dialog woocommerce"
 			>
 				<h1>{ translate( 'Refund order' ) }</h1>
-				<OrderRefundTable order={ order } onChange={ this.recalculateRefund } />
+				<OrderRefundTable order={ order } onChange={ this.recalculateAndSetState } />
 				<form className="order-payment__container">
 					<FormLabel className="order-payment__note">
 						{ translate( 'Refund note', { comment: "Label for refund's comment field" } ) }

--- a/client/extensions/woocommerce/app/order/order-payment/dialog.js
+++ b/client/extensions/woocommerce/app/order/order-payment/dialog.js
@@ -83,7 +83,7 @@ class OrderPaymentCard extends Component {
 	toggleDialog = () => {
 		this.setState( {
 			errorMessage: false,
-			refundTotal: 0,
+			refundTotal: this.getInitialRefund(),
 			refundNote: '',
 		} );
 		this.props.toggleDialog();

--- a/client/extensions/woocommerce/app/order/order-payment/dialog.js
+++ b/client/extensions/woocommerce/app/order/order-payment/dialog.js
@@ -78,14 +78,17 @@ class OrderPaymentCard extends Component {
 		if ( oldSiteId !== newSiteId ) {
 			this.props.fetchPaymentMethods( newSiteId );
 		}
+		// Has been opened and closed before, let's reset the values.
+		if ( newProps.isVisible && ! this.props.isVisible ) {
+			this.setState( {
+				errorMessage: false,
+				refundTotal: this.getInitialRefund(),
+				refundNote: '',
+			} );
+		}
 	};
 
 	toggleDialog = () => {
-		this.setState( {
-			errorMessage: false,
-			refundTotal: this.getInitialRefund(),
-			refundNote: '',
-		} );
 		this.props.toggleDialog();
 	};
 

--- a/client/extensions/woocommerce/app/order/order-payment/table.js
+++ b/client/extensions/woocommerce/app/order/order-payment/table.js
@@ -6,7 +6,6 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
-import { sum } from 'lodash';
 
 /**
  * Internal dependencies
@@ -56,40 +55,20 @@ class OrderRefundTable extends Component {
 		return !! order.tax_lines.length;
 	};
 
-	recalculateRefund = () => {
-		const { order } = this.props;
-		if ( ! order ) {
-			return 0;
-		}
-		const subtotal = sum(
-			this.state.quantities.map( ( q, i ) => {
-				if ( ! order.line_items[ i ] ) {
-					return 0;
-				}
-
-				const price = parseFloat( order.line_items[ i ].price );
-				if ( order.prices_include_tax ) {
-					return price * q;
-				}
-
-				const tax = getOrderLineItemTax( order, i ) / order.line_items[ i ].quantity;
-				return ( price + tax ) * q;
-			} )
-		);
-		const total = subtotal + ( parseFloat( this.state.shippingTotal ) || 0 );
-		this.props.onChange( total );
+	triggerRecalculate = () => {
+		this.props.onChange( this.state );
 	};
 
 	onChange = event => {
 		if ( 'shipping_total' === event.target.name ) {
 			const shippingTotal = event.target.value.replace( /[^0-9,.]/g, '' );
-			this.setState( { shippingTotal }, this.recalculateRefund );
+			this.setState( { shippingTotal }, this.triggerRecalculate );
 		} else {
 			// Name is `quantity-x`, where x is the ID in the line_items array
 			const i = event.target.name.split( '-' )[ 1 ];
 			const newQuants = this.state.quantities;
 			newQuants[ i ] = event.target.value;
-			this.setState( { quantities: newQuants }, this.recalculateRefund );
+			this.setState( { quantities: newQuants }, this.triggerRecalculate );
 		}
 	};
 


### PR DESCRIPTION
Move refund calculation into the dialog, so that we can set an initial refund value when the dialog is opened. Fixes #18673

To test:

- View an order
- Open the refund modal by clicking "Submit Refund"
- The "Total refund amount" should pre-fill with the shipping amount, not be zero