### PR TITLE
Store Orders: Add fees to single order views

### DIFF
--- a/client/extensions/woocommerce/app/order/order-details/row-total.js
+++ b/client/extensions/woocommerce/app/order/order-details/row-total.js
@@ -12,6 +12,7 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import formatCurrency from 'lib/format-currency';
+import { getCurrencyFormatDecimal } from 'woocommerce/lib/currency';
 import PriceInput from 'woocommerce/components/price-input';
 
 class OrderTotalRow extends Component {
@@ -40,13 +41,14 @@ class OrderTotalRow extends Component {
 		if ( ! name ) {
 			name = snakeCase( label );
 		}
+		const total = getCurrencyFormatDecimal( value );
 
 		const classes = classnames( className, 'order-details__total order-details__total-edit' );
 		return (
 			<div className={ classes }>
 				<div className="order-details__totals-label">{ label }</div>
 				<div className="order-details__totals-value">
-					<PriceInput name={ name } onChange={ onChange } currency={ currency } value={ value } />
+					<PriceInput name={ name } onChange={ onChange } currency={ currency } value={ total } />
 				</div>
 			</div>
 		);

--- a/client/extensions/woocommerce/app/order/order-details/row-total.js
+++ b/client/extensions/woocommerce/app/order/order-details/row-total.js
@@ -12,7 +12,6 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import formatCurrency from 'lib/format-currency';
-import { getCurrencyFormatDecimal } from 'woocommerce/lib/currency';
 import PriceInput from 'woocommerce/components/price-input';
 
 class OrderTotalRow extends Component {
@@ -21,6 +20,7 @@ class OrderTotalRow extends Component {
 		isEditable: PropTypes.bool,
 		label: PropTypes.string.isRequired,
 		name: PropTypes.string,
+		onBlur: PropTypes.func,
 		onChange: PropTypes.func,
 		showTax: PropTypes.bool,
 		taxValue: PropTypes.oneOfType( [ PropTypes.number, PropTypes.string ] ),
@@ -31,23 +31,30 @@ class OrderTotalRow extends Component {
 	static defaultProps = {
 		currency: 'USD',
 		isEditable: false,
+		onBlur: noop,
 		onChange: noop,
 	};
 
 	renderEditable = () => {
-		const { className, currency, label, value, onChange } = this.props;
+		const { className, currency, label, onBlur, onChange, value } = this.props;
 		let name = this.props.name;
 		if ( ! name ) {
 			name = snakeCase( label );
 		}
-		const total = getCurrencyFormatDecimal( value );
+		const total = isNaN( parseFloat( value ) ) ? 0 : value;
 
 		const classes = classnames( className, 'order-details__total order-details__total-edit' );
 		return (
 			<div className={ classes }>
 				<div className="order-details__totals-label">{ label }</div>
 				<div className="order-details__totals-value">
-					<PriceInput name={ name } onChange={ onChange } currency={ currency } value={ total } />
+					<PriceInput
+						name={ name }
+						currency={ currency }
+						onBlur={ onBlur }
+						onChange={ onChange }
+						value={ total }
+					/>
 				</div>
 			</div>
 		);

--- a/client/extensions/woocommerce/app/order/order-details/row-total.js
+++ b/client/extensions/woocommerce/app/order/order-details/row-total.js
@@ -12,7 +12,6 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import formatCurrency from 'lib/format-currency';
-import { getCurrencyDefaults } from 'lib/format-currency';
 import PriceInput from 'woocommerce/components/price-input';
 
 class OrderTotalRow extends Component {
@@ -36,24 +35,18 @@ class OrderTotalRow extends Component {
 	};
 
 	renderEditable = () => {
-		const { className, currency, label, value, onChange, numberFormat } = this.props;
+		const { className, currency, label, value, onChange } = this.props;
 		let name = this.props.name;
 		if ( ! name ) {
 			name = snakeCase( label );
 		}
-		const { decimal, grouping, precision } = getCurrencyDefaults( currency );
-		const total = numberFormat( Math.abs( value ), {
-			decimals: precision,
-			decPoint: decimal,
-			thousandsSep: grouping,
-		} );
 
 		const classes = classnames( className, 'order-details__total order-details__total-edit' );
 		return (
 			<div className={ classes }>
 				<div className="order-details__totals-label">{ label }</div>
 				<div className="order-details__totals-value">
-					<PriceInput name={ name } onChange={ onChange } currency={ currency } value={ total } />
+					<PriceInput name={ name } onChange={ onChange } currency={ currency } value={ value } />
 				</div>
 			</div>
 		);

--- a/client/extensions/woocommerce/app/order/order-details/row-total.js
+++ b/client/extensions/woocommerce/app/order/order-details/row-total.js
@@ -21,7 +21,6 @@ class OrderTotalRow extends Component {
 		isEditable: PropTypes.bool,
 		label: PropTypes.string.isRequired,
 		name: PropTypes.string,
-		numberFormat: PropTypes.func,
 		onChange: PropTypes.func,
 		showTax: PropTypes.bool,
 		taxValue: PropTypes.oneOfType( [ PropTypes.number, PropTypes.string ] ),

--- a/client/extensions/woocommerce/app/order/order-details/style.scss
+++ b/client/extensions/woocommerce/app/order/order-details/style.scss
@@ -3,18 +3,6 @@
 	box-shadow: none;
 	border-bottom: 1px solid lighten( $gray, 30% );
 
-	.order-details__item-cost,
-	.order-details__item-quantity,
-	.order-details__item-tax,
-	.order-details__item-total {
-		text-align: right;
-		width: 70px;
-
-		input {
-			width: 70px;
-		}
-	}
-
 	.order-details__item-sku {
 		display: block;
 		margin-top: 6px;
@@ -32,6 +20,10 @@
 			background: transparent;
 		}
 	}
+}
+
+.order-details__item-total {
+	text-align: right;
 }
 
 .order-details__totals {
@@ -54,11 +46,16 @@
 		}
 	}
 
+	.form-text-input-with-affixes,
+	.form-text-input-with-suffixes {
+		text-align: left;
+	}
+
 	&.is-refund-modal,
 	&.has-taxes {
 		.order-details__total {
 			.order-details__totals-label {
-				flex: 1 0 calc(100% - 204px);
+				flex: 1 0 calc(100% - 250px);
 			}
 		}
 	}
@@ -66,12 +63,6 @@
 	&.has-taxes {
 		.order-details__total-edit .order-details__totals-value {
 			flex: 1 0 192px;
-		}
-	}
-
-	.order-details__total-edit {
-		.form-text-input-with-affixes {
-			width: 130px;
 		}
 	}
 

--- a/client/extensions/woocommerce/app/order/order-details/table.js
+++ b/client/extensions/woocommerce/app/order/order-details/table.js
@@ -14,6 +14,7 @@ import formatCurrency from 'lib/format-currency';
 import { getLink } from 'woocommerce/lib/nav-utils';
 import {
 	getOrderDiscountTax,
+	getOrderFeeTax,
 	getOrderLineItemTax,
 	getOrderRefundTotal,
 	getOrderShippingTax,
@@ -101,6 +102,26 @@ class OrderDetailsTable extends Component {
 		);
 	};
 
+	renderOrderFees = ( item, i ) => {
+		const { order } = this.props;
+		const tax = getOrderFeeTax( order, i );
+		return (
+			<TableRow key={ i } className="order-details__items">
+				<TableItem isRowHeader className="order-details__item-product">
+					{ item.name }
+				</TableItem>
+				<TableItem className="order-details__item-cost" />
+				<TableItem className="order-details__item-quantity" />
+				<TableItem className="order-details__item-tax">
+					{ formatCurrency( tax, order.currency ) }
+				</TableItem>
+				<TableItem className="order-details__item-total">
+					{ formatCurrency( item.total, order.currency ) }
+				</TableItem>
+			</TableRow>
+		);
+	};
+
 	render() {
 		const { order, translate } = this.props;
 		if ( ! order ) {
@@ -118,6 +139,7 @@ class OrderDetailsTable extends Component {
 			<div>
 				<Table className="order-details__table" header={ this.renderTableHeader() }>
 					{ order.line_items.map( this.renderOrderItems ) }
+					{ order.fee_lines.map( this.renderOrderFees ) }
 				</Table>
 
 				<div className={ totalsClasses }>

--- a/client/extensions/woocommerce/app/order/order-details/table.js
+++ b/client/extensions/woocommerce/app/order/order-details/table.js
@@ -16,10 +16,10 @@ import {
 	getOrderDiscountTax,
 	getOrderFeeTax,
 	getOrderLineItemTax,
-	getOrderRefundTotal,
 	getOrderShippingTax,
 	getOrderTotalTax,
 } from 'woocommerce/lib/order-values';
+import { getOrderRefundTotal } from 'woocommerce/lib/order-values/totals';
 import OrderTotalRow from './row-total';
 import Table from 'woocommerce/components/table';
 import TableRow from 'woocommerce/components/table/table-row';

--- a/client/extensions/woocommerce/app/order/order-details/table.js
+++ b/client/extensions/woocommerce/app/order/order-details/table.js
@@ -103,12 +103,13 @@ class OrderDetailsTable extends Component {
 	};
 
 	renderOrderFees = ( item, i ) => {
-		const { order } = this.props;
+		const { order, translate } = this.props;
 		const tax = getOrderFeeTax( order, i );
 		return (
 			<TableRow key={ i } className="order-details__items">
 				<TableItem isRowHeader className="order-details__item-product">
 					{ item.name }
+					<span className="order-details__item-sku">{ translate( 'Fee' ) }</span>
 				</TableItem>
 				<TableItem className="order-details__item-cost" />
 				<TableItem className="order-details__item-quantity" />

--- a/client/extensions/woocommerce/app/order/order-payment/dialog.js
+++ b/client/extensions/woocommerce/app/order/order-payment/dialog.js
@@ -27,9 +27,9 @@ import { getCurrencyFormatDecimal } from 'woocommerce/lib/currency';
 import {
 	getOrderFeeTax,
 	getOrderLineItemTax,
-	getOrderRefundTotal,
 	getOrderShippingTax,
 } from 'woocommerce/lib/order-values';
+import { getOrderRefundTotal } from 'woocommerce/lib/order-values/totals';
 import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
 import Notice from 'components/notice';
 import OrderRefundTable from './table';

--- a/client/extensions/woocommerce/app/order/order-payment/dialog.js
+++ b/client/extensions/woocommerce/app/order/order-payment/dialog.js
@@ -23,6 +23,7 @@ import formatCurrency from 'lib/format-currency';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
 import FormTextarea from 'components/forms/form-textarea';
+import { getCurrencyFormatDecimal } from 'woocommerce/lib/currency';
 import {
 	getOrderFeeTax,
 	getOrderLineItemTax,
@@ -147,7 +148,8 @@ class RefundDialog extends Component {
 		const { order, paymentMethod, siteId, translate } = this.props;
 		// Refund total is negative, so this effectively subtracts the refund from total.
 		const maxRefund = parseFloat( order.total ) + getOrderRefundTotal( order );
-		if ( this.state.refundTotal > maxRefund ) {
+		const thisRefund = getCurrencyFormatDecimal( this.state.refundTotal );
+		if ( thisRefund > maxRefund ) {
 			this.setState( {
 				errorMessage: translate(
 					'Refund must be less than or equal to the order balance, %(total)s',
@@ -159,13 +161,13 @@ class RefundDialog extends Component {
 				),
 			} );
 			return;
-		} else if ( this.state.refundTotal <= 0 ) {
+		} else if ( thisRefund <= 0 ) {
 			this.setState( { errorMessage: translate( 'Refund must be greater than zero.' ) } );
 			return;
 		}
 		this.toggleDialog();
 		const refundObj = {
-			amount: this.state.refundTotal.toPrecision(),
+			amount: thisRefund.toPrecision(),
 			reason: this.state.refundNote,
 			api_refund: paymentMethod && -1 !== paymentMethod.method_supports.indexOf( 'refunds' ),
 		};

--- a/client/extensions/woocommerce/app/order/order-payment/dialog.js
+++ b/client/extensions/woocommerce/app/order/order-payment/dialog.js
@@ -113,7 +113,7 @@ class RefundDialog extends Component {
 			return 0;
 		}
 		const subtotal = sum( [
-			...data.fees,
+			...map( data.fees, parseFloat ),
 			...map( data.quantities, ( q, id ) => {
 				id = parseInt( id );
 				const line_item = find( order.line_items, { id } );

--- a/client/extensions/woocommerce/app/order/order-payment/index.js
+++ b/client/extensions/woocommerce/app/order/order-payment/index.js
@@ -14,7 +14,7 @@ import { localize } from 'i18n-calypso';
  */
 import Button from 'components/button';
 import formatCurrency from 'lib/format-currency';
-import { getOrderRefundTotal } from 'woocommerce/lib/order-values';
+import { getOrderRefundTotal } from 'woocommerce/lib/order-values/totals';
 import { isOrderFailed, isOrderWaitingPayment } from 'woocommerce/lib/order-status';
 import RefundDialog from './dialog';
 import { updateOrder } from 'woocommerce/state/sites/orders/actions';

--- a/client/extensions/woocommerce/app/order/order-payment/style.scss
+++ b/client/extensions/woocommerce/app/order/order-payment/style.scss
@@ -19,6 +19,10 @@
 			font-weight: normal;
 		}
 	}
+
+	.order-payment__item-total .form-text-input-with-affixes__prefix {
+		max-width: 14px;
+	}
 }
 
 .order-payment__container {

--- a/client/extensions/woocommerce/app/order/order-payment/style.scss
+++ b/client/extensions/woocommerce/app/order/order-payment/style.scss
@@ -23,6 +23,19 @@
 	.order-payment__item-total .form-text-input-with-affixes__prefix {
 		max-width: 14px;
 	}
+
+	.form-text-input-with-affixes,
+	.form-text-input-with-suffixes {
+		max-width: 130px;
+
+		input {
+			text-align: left;
+		}
+	}
+
+	.order-payment__amount-label {
+		margin-right: 16px;
+	}
 }
 
 .order-payment__container {
@@ -59,11 +72,7 @@
 		padding-bottom: 16px;
 		margin-bottom: 16px;
 		border-bottom: 1px solid lighten( $gray, 30% );
-
-		.order-payment__amount-label,
-		.order-payment__amount-value {
-			flex: 1;
-		}
+		justify-content: flex-end;
 	}
 
 	.order-payment__method h3 {

--- a/client/extensions/woocommerce/app/order/order-payment/style.scss
+++ b/client/extensions/woocommerce/app/order/order-payment/style.scss
@@ -1,5 +1,4 @@
 &.order-payment__dialog {
-	max-width: 720px;
 	display: flex;
 	flex-direction: column;
 	padding: 0;
@@ -9,24 +8,16 @@
 		color: $gray-dark;
 	}
 
-	.form-text-input,
-	.form-text-input-with-affixes input {
-		text-align: right;
-	}
-
 	.form-label {
 		.form-text-input-with-affixes {
 			font-weight: normal;
 		}
 	}
 
-	.order-payment__item-total .form-text-input-with-affixes__prefix {
-		max-width: 14px;
-	}
-
 	.form-text-input-with-affixes,
 	.form-text-input-with-suffixes {
-		max-width: 130px;
+		width: 155px;
+		text-align: left;
 
 		input {
 			text-align: left;
@@ -35,6 +26,10 @@
 
 	.order-payment__amount-label {
 		margin-right: 16px;
+	}
+
+	.order-payment__item-total {
+		text-align: right;
 	}
 }
 
@@ -47,13 +42,14 @@
 	border-top: 1px solid lighten( $gray, 30% );
 	background: lighten( $gray, 35% );
 
-	.order-payment__note,
-	.order-payment__details {
-		flex: 1;
-	}
-
 	.order-payment__note {
-		margin-bottom: 0;
+		margin-bottom: 16px;
+		width: 100%;
+
+		@include breakpoint( ">660px" ) {
+			width: 40%;
+			margin-bottom: 0;
+		}
 
 		.form-textarea {
 			margin-top: 8px;
@@ -61,8 +57,11 @@
 	}
 
 	.order-payment__details {
-		margin-left: 50px;
 		margin-bottom: 0;
+
+		@include breakpoint( ">660px" ) {
+			width: 55%;
+		}
 	}
 
 	.order-payment__amount {

--- a/client/extensions/woocommerce/app/order/order-payment/style.scss
+++ b/client/extensions/woocommerce/app/order/order-payment/style.scss
@@ -2,6 +2,11 @@
 	display: flex;
 	flex-direction: column;
 	padding: 0;
+	flex-grow: 0;
+
+	@include breakpoint( ">660px" ) {
+		width: 640px;
+	}
 
 	.order__detail-header,
 	.order__details-total {

--- a/client/extensions/woocommerce/app/order/order-payment/table.js
+++ b/client/extensions/woocommerce/app/order/order-payment/table.js
@@ -71,10 +71,21 @@ class OrderRefundTable extends Component {
 			this.setState( { shippingTotal }, this.triggerRecalculate );
 		} else {
 			// Name is `quantity-x`, where x is the ID in the line_items array
-			const i = event.target.name.split( '-' )[ 1 ];
-			const newQuants = this.state.quantities;
-			newQuants[ i ] = event.target.value;
-			this.setState( { quantities: newQuants }, this.triggerRecalculate );
+			const [ type, i ] = event.target.name.split( '-' );
+			const value = event.target.value;
+			if ( 'quantity' === type ) {
+				this.setState( prevState => {
+					const newQuants = prevState.quantities;
+					newQuants[ i ] = value;
+					return { quantities: newQuants };
+				}, this.triggerRecalculate );
+			} else {
+				this.setState( prevState => {
+					const newFees = prevState.fees;
+					newFees[ i ] = parseFloat( value );
+					return { fees: newFees };
+				}, this.triggerRecalculate );
+			}
 		}
 	};
 

--- a/client/extensions/woocommerce/app/order/order-payment/table.js
+++ b/client/extensions/woocommerce/app/order/order-payment/table.js
@@ -12,7 +12,6 @@ import { localize } from 'i18n-calypso';
  */
 import formatCurrency from 'lib/format-currency';
 import FormTextInput from 'components/forms/form-text-input';
-import { getCurrencyDefaults } from 'lib/format-currency';
 import {
 	getOrderDiscountTax,
 	getOrderFeeTax,
@@ -145,20 +144,13 @@ class OrderRefundTable extends Component {
 	};
 
 	renderOrderFees = ( item, i ) => {
-		const { numberFormat, order } = this.props;
-		const { decimal, grouping, precision } = getCurrencyDefaults( order.currency );
-		const value = numberFormat( Math.abs( this.state.fees[ i ] ), {
-			decimals: precision,
-			decPoint: decimal,
-			thousandsSep: grouping,
-		} );
+		const { order } = this.props;
+		const value = this.state.fees[ i ];
 		return (
 			<TableRow key={ i } className="order-payment__items order-details__items">
-				<TableItem isRowHeader className="order-payment__item-product order-details__item-product">
+				<TableItem isRowHeader colSpan="3" className="order-payment__item-product order-details__item-product">
 					{ item.name }
 				</TableItem>
-				<TableItem className="order-payment__item-cost order-details__item-cost" />
-				<TableItem className="order-payment__item-quantity order-details__item-quantity" />
 				<TableItem colSpan="2" className="order-payment__item-total order-details__item-total">
 					<PriceInput
 						name={ `fee_line-${ i }` }

--- a/client/extensions/woocommerce/app/order/order-payment/table.js
+++ b/client/extensions/woocommerce/app/order/order-payment/table.js
@@ -12,6 +12,7 @@ import { localize } from 'i18n-calypso';
  */
 import formatCurrency from 'lib/format-currency';
 import FormTextInput from 'components/forms/form-text-input';
+import { getCurrencyFormatDecimal } from 'woocommerce/lib/currency';
 import {
 	getOrderDiscountTax,
 	getOrderFeeTax,
@@ -145,10 +146,14 @@ class OrderRefundTable extends Component {
 
 	renderOrderFees = ( item, i ) => {
 		const { order } = this.props;
-		const value = this.state.fees[ i ];
+		const value = getCurrencyFormatDecimal( this.state.fees[ i ] );
 		return (
 			<TableRow key={ i } className="order-payment__items order-details__items">
-				<TableItem isRowHeader colSpan="3" className="order-payment__item-product order-details__item-product">
+				<TableItem
+					isRowHeader
+					colSpan="3"
+					className="order-payment__item-product order-details__item-product"
+				>
 					{ item.name }
 				</TableItem>
 				<TableItem colSpan="2" className="order-payment__item-total order-details__item-total">

--- a/client/extensions/woocommerce/app/order/order-payment/table.js
+++ b/client/extensions/woocommerce/app/order/order-payment/table.js
@@ -18,10 +18,10 @@ import {
 	getOrderDiscountTax,
 	getOrderFeeTax,
 	getOrderLineItemTax,
-	getOrderRefundTotal,
 	getOrderShippingTax,
 	getOrderTotalTax,
 } from 'woocommerce/lib/order-values';
+import { getOrderRefundTotal } from 'woocommerce/lib/order-values/totals';
 import OrderTotalRow from '../order-details/row-total';
 import PriceInput from 'woocommerce/components/price-input';
 import Table from 'woocommerce/components/table';

--- a/client/extensions/woocommerce/app/order/order-payment/table.js
+++ b/client/extensions/woocommerce/app/order/order-payment/table.js
@@ -161,7 +161,7 @@ class OrderRefundTable extends Component {
 	};
 
 	renderOrderFees = ( item, i ) => {
-		const { order } = this.props;
+		const { order, translate } = this.props;
 		const value = this.state.fees[ i ];
 		return (
 			<TableRow key={ i } className="order-payment__items order-details__items">
@@ -171,6 +171,9 @@ class OrderRefundTable extends Component {
 					className="order-payment__item-product order-details__item-product"
 				>
 					{ item.name }
+					<span className="order-payment__item-sku order-details__item-sku">
+						{ translate( 'Fee' ) }
+					</span>
 				</TableItem>
 				<TableItem colSpan="2" className="order-payment__item-total order-details__item-total">
 					<PriceInput

--- a/client/extensions/woocommerce/lib/order-values/index.js
+++ b/client/extensions/woocommerce/lib/order-values/index.js
@@ -42,6 +42,17 @@ export function getOrderFeeTax( order, index ) {
 }
 
 /**
+ * Get the total tax for all fees in an order (total of all fee lines)
+ *
+ * @param {Object} order An order as returned from API
+ * @return {Float} Tax amount as a decimal number
+ */
+export function getOrderFeeTotalTax( order ) {
+	const lines = get( order, 'fee_lines', [] );
+	return reduce( lines, ( sum, value, key ) => sum + getOrderFeeTax( order, key ), 0 );
+}
+
+/**
  * Get the total tax for the shipping value
  *
  * @param {Object} order An order as returned from API

--- a/client/extensions/woocommerce/lib/order-values/index.js
+++ b/client/extensions/woocommerce/lib/order-values/index.js
@@ -88,6 +88,17 @@ export function getOrderTotalTax( order ) {
 }
 
 /**
+ * Get the fee total on a given order
+ *
+ * @param {Object} order An order as returned from API
+ * @return {Float} The total fee amount as a decimal number
+ */
+export function getOrderFeeTotal( order ) {
+	const fees = get( order, 'fee_lines', [] );
+	return reduce( fees, ( sum, value ) => sum + parseFloat( value.total ), 0 );
+}
+
+/**
  * Get the refund value on a given order
  *
  * @param {Object} order An order as returned from API

--- a/client/extensions/woocommerce/lib/order-values/index.js
+++ b/client/extensions/woocommerce/lib/order-values/index.js
@@ -30,6 +30,18 @@ export function getOrderLineItemTax( order, id ) {
 }
 
 /**
+ * Get the total tax for a given line item's value
+ *
+ * @param {Object} order An order as returned from API
+ * @param {Number} index The index of a fee line in this order
+ * @return {Float} Tax amount as a decimal number
+ */
+export function getOrderFeeTax( order, index ) {
+	const tax = get( order, `fee_lines[${ index }].taxes[0].total`, 0 );
+	return parseFloat( tax ) || 0;
+}
+
+/**
  * Get the total tax for the shipping value
  *
  * @param {Object} order An order as returned from API

--- a/client/extensions/woocommerce/lib/order-values/index.js
+++ b/client/extensions/woocommerce/lib/order-values/index.js
@@ -30,7 +30,7 @@ export function getOrderLineItemTax( order, id ) {
 }
 
 /**
- * Get the total tax for a given line item's value
+ * Get the total tax for a given fee
  *
  * @param {Object} order An order as returned from API
  * @param {Number} index The index of a fee line in this order
@@ -85,26 +85,4 @@ export function getOrderTotalTax( order ) {
 	const shipping = getOrderShippingTax( order );
 	const fees = getOrderFeeTotalTax( order );
 	return subtotal + shipping + fees;
-}
-
-/**
- * Get the fee total on a given order
- *
- * @param {Object} order An order as returned from API
- * @return {Float} The total fee amount as a decimal number
- */
-export function getOrderFeeTotal( order ) {
-	const fees = get( order, 'fee_lines', [] );
-	return reduce( fees, ( sum, value ) => sum + parseFloat( value.total ), 0 );
-}
-
-/**
- * Get the refund value on a given order
- *
- * @param {Object} order An order as returned from API
- * @return {Float} The refund amount as a decimal number
- */
-export function getOrderRefundTotal( order ) {
-	const refunds = get( order, 'refunds', [] );
-	return reduce( refunds, ( sum, value ) => sum + parseFloat( value.total ), 0 );
 }

--- a/client/extensions/woocommerce/lib/order-values/index.js
+++ b/client/extensions/woocommerce/lib/order-values/index.js
@@ -83,7 +83,8 @@ export function getOrderSubtotalTax( order ) {
 export function getOrderTotalTax( order ) {
 	const subtotal = getOrderSubtotalTax( order );
 	const shipping = getOrderShippingTax( order );
-	return subtotal + shipping;
+	const fees = getOrderFeeTotalTax( order );
+	return subtotal + shipping + fees;
 }
 
 /**

--- a/client/extensions/woocommerce/lib/order-values/test/fixtures/order-no-tax.js
+++ b/client/extensions/woocommerce/lib/order-values/test/fixtures/order-no-tax.js
@@ -12,7 +12,14 @@ export default {
 	],
 	tax_lines: [],
 	shipping_lines: [],
-	fee_lines: [],
+	fee_lines: [
+		{
+			id: 2,
+			name: 'Extra length fee',
+			total: '20.00',
+			total_tax: '0.00',
+		},
+	],
 	coupon_lines: [],
 	refunds: [],
 };

--- a/client/extensions/woocommerce/lib/order-values/test/fixtures/order-no-tax.js
+++ b/client/extensions/woocommerce/lib/order-values/test/fixtures/order-no-tax.js
@@ -5,9 +5,11 @@ export default {
 		{
 			id: 1,
 			name: 'Scarf',
-			product_id: 49,
-			taxes: [],
 			price: 25,
+			quantity: 1,
+			subtotal: 25,
+			total: 25,
+			taxes: [],
 		},
 	],
 	tax_lines: [],

--- a/client/extensions/woocommerce/lib/order-values/test/fixtures/order-with-coupons.js
+++ b/client/extensions/woocommerce/lib/order-values/test/fixtures/order-with-coupons.js
@@ -55,7 +55,36 @@ export default {
 			],
 		},
 	],
-	fee_lines: [],
+	fee_lines: [
+		{
+			id: 40,
+			name: 'fee',
+			amount: '5.00',
+			total: '5.00',
+			total_tax: '0.31',
+			taxes: [
+				{
+					id: 1,
+					total: '0.3125',
+					subtotal: '',
+				},
+			],
+		},
+		{
+			id: 41,
+			name: 'additional fee',
+			amount: '10.00',
+			total: '10.00',
+			total_tax: '0.63',
+			taxes: [
+				{
+					id: 1,
+					total: '0.625',
+					subtotal: '',
+				},
+			],
+		},
+	],
 	coupon_lines: [
 		{
 			id: 30,

--- a/client/extensions/woocommerce/lib/order-values/test/fixtures/order-with-coupons.js
+++ b/client/extensions/woocommerce/lib/order-values/test/fixtures/order-with-coupons.js
@@ -5,7 +5,10 @@ export default {
 		{
 			id: 26,
 			name: 'Mug',
-			product_id: 71,
+			price: 11.64,
+			quantity: 2,
+			subtotal: 31.98,
+			total: 23.28,
 			taxes: [
 				{
 					id: 4,
@@ -13,11 +16,14 @@ export default {
 					subtotal: '2.0307',
 				},
 			],
-			price: 11.6408,
 		},
 		{
 			id: 27,
 			name: 'Scarf - Blue',
+			price: 36.39,
+			quantity: 1,
+			subtotal: 49.99,
+			total: 36.39,
 			taxes: [
 				{
 					id: 4,
@@ -25,7 +31,6 @@ export default {
 					subtotal: '3.1744',
 				},
 			],
-			price: 36.3929,
 		},
 	],
 	tax_lines: [

--- a/client/extensions/woocommerce/lib/order-values/test/fixtures/order-with-refunds.js
+++ b/client/extensions/woocommerce/lib/order-values/test/fixtures/order-with-refunds.js
@@ -5,7 +5,10 @@ export default {
 		{
 			id: 15,
 			name: 'Scarf - Striped',
-			product_id: 49,
+			price: 42.49,
+			quantity: 1,
+			subtotal: 49.99,
+			total: 42.49,
 			taxes: [
 				{
 					id: 4,
@@ -13,12 +16,14 @@ export default {
 					subtotal: '6.3487',
 				},
 			],
-			price: 42.4915,
 		},
 		{
 			id: 19,
 			name: 'T-Shirt',
-			product_id: 62,
+			price: 17.99,
+			quantity: 1,
+			subtotal: 17.99,
+			total: 17.99,
 			taxes: [
 				{
 					id: 4,
@@ -26,7 +31,6 @@ export default {
 					subtotal: '1.1424',
 				},
 			],
-			price: 17.99,
 		},
 	],
 	tax_lines: [

--- a/client/extensions/woocommerce/lib/order-values/test/fixtures/order.js
+++ b/client/extensions/woocommerce/lib/order-values/test/fixtures/order.js
@@ -56,7 +56,22 @@ export default {
 			],
 		},
 	],
-	fee_lines: [],
+	fee_lines: [
+		{
+			id: 48,
+			name: 'fee',
+			amount: '1.53',
+			total: '1.53',
+			total_tax: '0.13',
+			taxes: [
+				{
+					id: 1,
+					total: '0.1262',
+					subtotal: '',
+				},
+			],
+		},
+	],
 	coupon_lines: [
 		{
 			id: 18,

--- a/client/extensions/woocommerce/lib/order-values/test/fixtures/order.js
+++ b/client/extensions/woocommerce/lib/order-values/test/fixtures/order.js
@@ -5,7 +5,10 @@ export default {
 		{
 			id: 15,
 			name: 'Scarf - Striped',
-			product_id: 49,
+			price: 42.49,
+			quantity: 1,
+			subtotal: 49.99,
+			total: 42.49,
 			taxes: [
 				{
 					id: 4,
@@ -13,12 +16,14 @@ export default {
 					subtotal: '6.3487',
 				},
 			],
-			price: 42.4915,
 		},
 		{
 			id: 19,
 			name: 'T-Shirt',
-			product_id: 62,
+			price: 17.99,
+			quantity: 1,
+			subtotal: 17.99,
+			total: 17.99,
 			taxes: [
 				{
 					id: 4,
@@ -26,7 +31,6 @@ export default {
 					subtotal: '1.1424',
 				},
 			],
-			price: 17.99,
 		},
 	],
 	tax_lines: [

--- a/client/extensions/woocommerce/lib/order-values/test/index.js
+++ b/client/extensions/woocommerce/lib/order-values/test/index.js
@@ -11,6 +11,7 @@ import { expect } from 'chai';
 import {
 	getOrderDiscountTax,
 	getOrderFeeTax,
+	getOrderFeeTotal,
 	getOrderFeeTotalTax,
 	getOrderLineItemTax,
 	getOrderRefundTotal,
@@ -154,6 +155,24 @@ describe( 'getOrderTotalTax', () => {
 
 	it( 'should get the correct tax amount with multiple coupons', () => {
 		expect( getOrderTotalTax( orderWithCoupons ) ).to.eql( 5.3618 );
+	} );
+} );
+
+describe( 'getOrderFeeTotal', () => {
+	it( 'should be a function', () => {
+		expect( getOrderFeeTotal ).to.be.a( 'function' );
+	} );
+
+	it( 'should get the correct tax amount', () => {
+		expect( getOrderFeeTotal( orderWithTax ) ).to.eql( 1.53 );
+	} );
+
+	it( 'should get the correct tax amount with multiple fees', () => {
+		expect( getOrderFeeTotal( orderWithCoupons ) ).to.eql( 15 );
+	} );
+
+	it( 'should return 0 if there is no tax', () => {
+		expect( getOrderFeeTotal( orderWithoutTax ) ).to.eql( 20 );
 	} );
 } );
 

--- a/client/extensions/woocommerce/lib/order-values/test/index.js
+++ b/client/extensions/woocommerce/lib/order-values/test/index.js
@@ -11,6 +11,7 @@ import { expect } from 'chai';
 import {
 	getOrderDiscountTax,
 	getOrderFeeTax,
+	getOrderFeeTotalTax,
 	getOrderLineItemTax,
 	getOrderRefundTotal,
 	getOrderShippingTax,
@@ -59,6 +60,24 @@ describe( 'getOrderFeeTax', () => {
 
 	it( 'should return 0 if there is no tax', () => {
 		expect( getOrderFeeTax( orderWithoutTax, 0 ) ).to.eql( 0 );
+	} );
+} );
+
+describe( 'getOrderFeeTotalTax', () => {
+	it( 'should be a function', () => {
+		expect( getOrderFeeTotalTax ).to.be.a( 'function' );
+	} );
+
+	it( 'should get the correct tax amount', () => {
+		expect( getOrderFeeTotalTax( orderWithTax ) ).to.eql( 0.1262 );
+	} );
+
+	it( 'should get the correct tax amount with multiple fees', () => {
+		expect( getOrderFeeTotalTax( orderWithCoupons ) ).to.eql( 0.9375 );
+	} );
+
+	it( 'should return 0 if there is no tax', () => {
+		expect( getOrderFeeTotalTax( orderWithoutTax ) ).to.eql( 0 );
 	} );
 } );
 

--- a/client/extensions/woocommerce/lib/order-values/test/index.js
+++ b/client/extensions/woocommerce/lib/order-values/test/index.js
@@ -144,16 +144,16 @@ describe( 'getOrderTotalTax', () => {
 		expect( getOrderTotalTax ).to.be.a( 'function' );
 	} );
 
-	test( 'should get the correct tax amount', () => {
-		expect( getOrderTotalTax( orderWithTax ) ).to.eql( 7.1738 );
+	it( 'should get the correct tax amount', () => {
+		expect( getOrderTotalTax( orderWithTax ) ).to.eql( 7.3 );
 	} );
 
 	test( 'should return 0 if there is no tax', () => {
 		expect( getOrderTotalTax( orderWithoutTax ) ).to.eql( 0 );
 	} );
 
-	test( 'should get the correct tax amount with multiple coupons', () => {
-		expect( getOrderTotalTax( orderWithCoupons ) ).to.eql( 4.4243 );
+	it( 'should get the correct tax amount with multiple coupons', () => {
+		expect( getOrderTotalTax( orderWithCoupons ) ).to.eql( 5.3618 );
 	} );
 } );
 

--- a/client/extensions/woocommerce/lib/order-values/test/index.js
+++ b/client/extensions/woocommerce/lib/order-values/test/index.js
@@ -11,10 +11,8 @@ import { expect } from 'chai';
 import {
 	getOrderDiscountTax,
 	getOrderFeeTax,
-	getOrderFeeTotal,
 	getOrderFeeTotalTax,
 	getOrderLineItemTax,
-	getOrderRefundTotal,
 	getOrderShippingTax,
 	getOrderSubtotalTax,
 	getOrderTotalTax,
@@ -22,7 +20,6 @@ import {
 import orderWithTax from './fixtures/order';
 import orderWithoutTax from './fixtures/order-no-tax';
 import orderWithCoupons from './fixtures/order-with-coupons';
-import orderWithRefunds from './fixtures/order-with-refunds';
 
 describe( 'getOrderDiscountTax', () => {
 	test( 'should be a function', () => {
@@ -155,41 +152,5 @@ describe( 'getOrderTotalTax', () => {
 
 	test( 'should get the correct tax amount with multiple coupons', () => {
 		expect( getOrderTotalTax( orderWithCoupons ) ).to.eql( 5.3618 );
-	} );
-} );
-
-describe( 'getOrderFeeTotal', () => {
-	test( 'should be a function', () => {
-		expect( getOrderFeeTotal ).to.be.a( 'function' );
-	} );
-
-	test( 'should get the correct tax amount', () => {
-		expect( getOrderFeeTotal( orderWithTax ) ).to.eql( 1.53 );
-	} );
-
-	test( 'should get the correct tax amount with multiple fees', () => {
-		expect( getOrderFeeTotal( orderWithCoupons ) ).to.eql( 15 );
-	} );
-
-	test( 'should return 0 if there is no tax', () => {
-		expect( getOrderFeeTotal( orderWithoutTax ) ).to.eql( 20 );
-	} );
-} );
-
-describe( 'getOrderRefundTotal', () => {
-	test( 'should be a function', () => {
-		expect( getOrderRefundTotal ).to.be.a( 'function' );
-	} );
-
-	test( 'should get the correct refund amount', () => {
-		expect( getOrderRefundTotal( orderWithCoupons ) ).to.eql( -10.0 );
-	} );
-
-	test( 'should return 0 if there are no refunds', () => {
-		expect( getOrderRefundTotal( orderWithoutTax ) ).to.eql( 0 );
-	} );
-
-	test( 'should get the correct refund amount with multiple refunds', () => {
-		expect( getOrderRefundTotal( orderWithRefunds ) ).to.eql( -25.0 );
 	} );
 } );

--- a/client/extensions/woocommerce/lib/order-values/test/index.js
+++ b/client/extensions/woocommerce/lib/order-values/test/index.js
@@ -10,6 +10,7 @@ import { expect } from 'chai';
  */
 import {
 	getOrderDiscountTax,
+	getOrderFeeTax,
 	getOrderLineItemTax,
 	getOrderRefundTotal,
 	getOrderShippingTax,
@@ -40,6 +41,24 @@ describe( 'getOrderDiscountTax', () => {
 
 	test( 'should return 0 if the order is malformed', () => {
 		expect( getOrderDiscountTax( {} ) ).to.eql( 0 );
+	} );
+} );
+
+describe( 'getOrderFeeTax', () => {
+	it( 'should be a function', () => {
+		expect( getOrderFeeTax ).to.be.a( 'function' );
+	} );
+
+	it( 'should get the correct tax amount', () => {
+		expect( getOrderFeeTax( orderWithTax, 0 ) ).to.eql( 0.1262 );
+	} );
+
+	it( 'should get the correct tax amount with multiple fees', () => {
+		expect( getOrderFeeTax( orderWithCoupons, 1 ) ).to.eql( 0.625 );
+	} );
+
+	it( 'should return 0 if there is no tax', () => {
+		expect( getOrderFeeTax( orderWithoutTax, 0 ) ).to.eql( 0 );
 	} );
 } );
 

--- a/client/extensions/woocommerce/lib/order-values/test/index.js
+++ b/client/extensions/woocommerce/lib/order-values/test/index.js
@@ -47,37 +47,37 @@ describe( 'getOrderDiscountTax', () => {
 } );
 
 describe( 'getOrderFeeTax', () => {
-	it( 'should be a function', () => {
+	test( 'should be a function', () => {
 		expect( getOrderFeeTax ).to.be.a( 'function' );
 	} );
 
-	it( 'should get the correct tax amount', () => {
+	test( 'should get the correct tax amount', () => {
 		expect( getOrderFeeTax( orderWithTax, 0 ) ).to.eql( 0.1262 );
 	} );
 
-	it( 'should get the correct tax amount with multiple fees', () => {
+	test( 'should get the correct tax amount with multiple fees', () => {
 		expect( getOrderFeeTax( orderWithCoupons, 1 ) ).to.eql( 0.625 );
 	} );
 
-	it( 'should return 0 if there is no tax', () => {
+	test( 'should return 0 if there is no tax', () => {
 		expect( getOrderFeeTax( orderWithoutTax, 0 ) ).to.eql( 0 );
 	} );
 } );
 
 describe( 'getOrderFeeTotalTax', () => {
-	it( 'should be a function', () => {
+	test( 'should be a function', () => {
 		expect( getOrderFeeTotalTax ).to.be.a( 'function' );
 	} );
 
-	it( 'should get the correct tax amount', () => {
+	test( 'should get the correct tax amount', () => {
 		expect( getOrderFeeTotalTax( orderWithTax ) ).to.eql( 0.1262 );
 	} );
 
-	it( 'should get the correct tax amount with multiple fees', () => {
+	test( 'should get the correct tax amount with multiple fees', () => {
 		expect( getOrderFeeTotalTax( orderWithCoupons ) ).to.eql( 0.9375 );
 	} );
 
-	it( 'should return 0 if there is no tax', () => {
+	test( 'should return 0 if there is no tax', () => {
 		expect( getOrderFeeTotalTax( orderWithoutTax ) ).to.eql( 0 );
 	} );
 } );
@@ -145,7 +145,7 @@ describe( 'getOrderTotalTax', () => {
 		expect( getOrderTotalTax ).to.be.a( 'function' );
 	} );
 
-	it( 'should get the correct tax amount', () => {
+	test( 'should get the correct tax amount', () => {
 		expect( getOrderTotalTax( orderWithTax ) ).to.eql( 7.3 );
 	} );
 
@@ -153,43 +153,43 @@ describe( 'getOrderTotalTax', () => {
 		expect( getOrderTotalTax( orderWithoutTax ) ).to.eql( 0 );
 	} );
 
-	it( 'should get the correct tax amount with multiple coupons', () => {
+	test( 'should get the correct tax amount with multiple coupons', () => {
 		expect( getOrderTotalTax( orderWithCoupons ) ).to.eql( 5.3618 );
 	} );
 } );
 
 describe( 'getOrderFeeTotal', () => {
-	it( 'should be a function', () => {
+	test( 'should be a function', () => {
 		expect( getOrderFeeTotal ).to.be.a( 'function' );
 	} );
 
-	it( 'should get the correct tax amount', () => {
+	test( 'should get the correct tax amount', () => {
 		expect( getOrderFeeTotal( orderWithTax ) ).to.eql( 1.53 );
 	} );
 
-	it( 'should get the correct tax amount with multiple fees', () => {
+	test( 'should get the correct tax amount with multiple fees', () => {
 		expect( getOrderFeeTotal( orderWithCoupons ) ).to.eql( 15 );
 	} );
 
-	it( 'should return 0 if there is no tax', () => {
+	test( 'should return 0 if there is no tax', () => {
 		expect( getOrderFeeTotal( orderWithoutTax ) ).to.eql( 20 );
 	} );
 } );
 
 describe( 'getOrderRefundTotal', () => {
-	it( 'should be a function', () => {
+	test( 'should be a function', () => {
 		expect( getOrderRefundTotal ).to.be.a( 'function' );
 	} );
 
-	it( 'should get the correct refund amount', () => {
+	test( 'should get the correct refund amount', () => {
 		expect( getOrderRefundTotal( orderWithCoupons ) ).to.eql( -10.0 );
 	} );
 
-	it( 'should return 0 if there are no refunds', () => {
+	test( 'should return 0 if there are no refunds', () => {
 		expect( getOrderRefundTotal( orderWithoutTax ) ).to.eql( 0 );
 	} );
 
-	it( 'should get the correct refund amount with multiple refunds', () => {
+	test( 'should get the correct refund amount with multiple refunds', () => {
 		expect( getOrderRefundTotal( orderWithRefunds ) ).to.eql( -25.0 );
 	} );
 } );

--- a/client/extensions/woocommerce/lib/order-values/test/totals.js
+++ b/client/extensions/woocommerce/lib/order-values/test/totals.js
@@ -1,0 +1,149 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import {
+	getOrderDiscountTotal,
+	getOrderFeeTotal,
+	getOrderItemCost,
+	getOrderRefundTotal,
+	getOrderShippingTotal,
+	getOrderSubtotal,
+	getOrderTotal,
+} from '../totals';
+import orderWithTax from './fixtures/order';
+import orderWithoutTax from './fixtures/order-no-tax';
+import orderWithCoupons from './fixtures/order-with-coupons';
+import orderWithRefunds from './fixtures/order-with-refunds';
+
+describe( 'getOrderDiscountTotal', () => {
+	it( 'should be a function', () => {
+		expect( getOrderDiscountTotal ).to.be.a( 'function' );
+	} );
+
+	it( 'should get the correct discount amount', () => {
+		expect( getOrderDiscountTotal( orderWithRefunds ) ).to.eql( 15 );
+	} );
+
+	it( 'should return 0 if there are no discounts', () => {
+		expect( getOrderDiscountTotal( orderWithoutTax ) ).to.eql( 0 );
+	} );
+
+	it( 'should get the correct discount amount with multiple coupons', () => {
+		expect( getOrderDiscountTotal( orderWithCoupons ) ).to.eql( 22.3 );
+	} );
+} );
+
+describe( 'getOrderFeeTotal', () => {
+	test( 'should be a function', () => {
+		expect( getOrderFeeTotal ).to.be.a( 'function' );
+	} );
+
+	test( 'should get the correct tax amount', () => {
+		expect( getOrderFeeTotal( orderWithTax ) ).to.eql( 1.53 );
+	} );
+
+	test( 'should get the correct tax amount with multiple fees', () => {
+		expect( getOrderFeeTotal( orderWithCoupons ) ).to.eql( 15 );
+	} );
+
+	test( 'should return 0 if there is no tax', () => {
+		expect( getOrderFeeTotal( orderWithoutTax ) ).to.eql( 20 );
+	} );
+} );
+
+describe( 'getOrderItemCost', () => {
+	it( 'should be a function', () => {
+		expect( getOrderItemCost ).to.be.a( 'function' );
+	} );
+
+	it( 'should get the singular cost of an item', () => {
+		expect( getOrderItemCost( orderWithTax, 19 ) ).to.eql( 17.99 );
+	} );
+
+	it( 'should get the singular cost of an item, before discounts', () => {
+		expect( getOrderItemCost( orderWithTax, 15 ) ).to.eql( 49.99 );
+	} );
+
+	it( 'should get the singular cost of an item, even if quantity > 1', () => {
+		expect( getOrderItemCost( orderWithCoupons, 26 ) ).to.eql( 15.99 );
+	} );
+
+	it( 'should return 0 if this ID does not exist in line_items', () => {
+		expect( getOrderItemCost( orderWithoutTax, 2 ) ).to.eql( 0 );
+	} );
+} );
+
+describe( 'getOrderRefundTotal', () => {
+	it( 'should be a function', () => {
+		expect( getOrderRefundTotal ).to.be.a( 'function' );
+	} );
+
+	it( 'should get the correct refund amount', () => {
+		expect( getOrderRefundTotal( orderWithCoupons ) ).to.eql( -10.0 );
+	} );
+
+	it( 'should return 0 if there are no refunds', () => {
+		expect( getOrderRefundTotal( orderWithoutTax ) ).to.eql( 0 );
+	} );
+
+	it( 'should get the correct refund amount with multiple refunds', () => {
+		expect( getOrderRefundTotal( orderWithRefunds ) ).to.eql( -25.0 );
+	} );
+} );
+
+describe( 'getOrderShippingTotal', () => {
+	it( 'should be a function', () => {
+		expect( getOrderShippingTotal ).to.be.a( 'function' );
+	} );
+
+	it( 'should get the correct shipping amount', () => {
+		expect( getOrderShippingTotal( orderWithTax ) ).to.eql( 10 );
+	} );
+
+	it( 'should return 0 if there is no shipping', () => {
+		expect( getOrderShippingTotal( orderWithoutTax ) ).to.eql( 0 );
+	} );
+} );
+
+describe( 'getOrderSubtotal', () => {
+	it( 'should be a function', () => {
+		expect( getOrderSubtotal ).to.be.a( 'function' );
+	} );
+
+	it( 'should get the sum of line_item totals', () => {
+		expect( getOrderSubtotal( orderWithTax ) ).to.eql( 67.98 );
+	} );
+
+	it( 'should get the sum of line_item totals regardless of coupons', () => {
+		expect( getOrderSubtotal( orderWithCoupons ) ).to.eql( 81.97 );
+	} );
+
+	it( 'should return 0 if there are no line_items', () => {
+		expect( getOrderSubtotal( { line_items: [] } ) ).to.eql( 0 );
+	} );
+} );
+
+describe( 'getOrderTotal', () => {
+	it( 'should be a function', () => {
+		expect( getOrderTotal ).to.be.a( 'function' );
+	} );
+
+	it( 'should get the sum of line_item totals', () => {
+		expect( getOrderTotal( orderWithTax ).toFixed( 2 ) ).to.eql( '64.51' );
+	} );
+
+	it( 'should get the sum of line_item totals regardless of coupons', () => {
+		expect( getOrderTotal( orderWithCoupons ).toFixed( 2 ) ).to.eql( '74.67' );
+	} );
+
+	it( 'should return 0 if there is nothing in the order', () => {
+		expect( getOrderTotal( { line_items: [] } ) ).to.eql( 0 );
+	} );
+} );

--- a/client/extensions/woocommerce/lib/order-values/totals.js
+++ b/client/extensions/woocommerce/lib/order-values/totals.js
@@ -1,0 +1,91 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { find, get, reduce } from 'lodash';
+
+/**
+ * Get the total for the discount value
+ *
+ * @param {Object} order An order as returned from API
+ * @return {Float} Total amount as a decimal number
+ */
+export function getOrderDiscountTotal( order ) {
+	const coupons = get( order, 'coupon_lines', [] );
+	const total = reduce( coupons, ( sum, value ) => sum + parseFloat( value.discount ), 0 );
+	return parseFloat( total ) || 0;
+}
+
+/**
+ * Get the fee total on a given order
+ *
+ * @param {Object} order An order as returned from API
+ * @return {Float} The total fee amount as a decimal number
+ */
+export function getOrderFeeTotal( order ) {
+	const fees = get( order, 'fee_lines', [] );
+	return reduce( fees, ( sum, value ) => sum + parseFloat( value.total ), 0 );
+}
+
+/**
+ * Get the individual price for a given item, pre-discounts.
+ *
+ * @param {Object} order An order as returned from API
+ * @param {Number} id The ID of the line_item
+ * @return {Float} Total amount as a decimal number
+ */
+export function getOrderItemCost( order, id ) {
+	const item = find( get( order, 'line_items', [] ), { id } );
+	const subtotal = parseFloat( get( item, 'subtotal', 0 ) ) || 0;
+	const qty = parseFloat( get( item, 'quantity', 1 ) ) || 1;
+	return subtotal / qty;
+}
+
+/**
+ * Get the refund value on a given order
+ *
+ * @param {Object} order An order as returned from API
+ * @return {Float} The refund amount as a decimal number
+ */
+export function getOrderRefundTotal( order ) {
+	const refunds = get( order, 'refunds', [] );
+	return reduce( refunds, ( sum, value ) => sum + parseFloat( value.total ), 0 );
+}
+
+/**
+ * Get the total for the shipping value
+ *
+ * @param {Object} order An order as returned from API
+ * @return {Float} Total amount as a decimal number
+ */
+export function getOrderShippingTotal( order ) {
+	const shipping = get( order, 'shipping_lines', [] );
+	return reduce( shipping, ( sum, value ) => sum + parseFloat( value.total ), 0 );
+}
+
+/**
+ * Get the total for the subtotal value (total of all line items)
+ *
+ * @param {Object} order An order as returned from API
+ * @return {Float} Total amount as a decimal number
+ */
+export function getOrderSubtotal( order ) {
+	const items = get( order, 'line_items', [] );
+	return reduce( items, ( sum, value ) => sum + parseFloat( value.subtotal ), 0 );
+}
+
+/**
+ * Get the total value on a given order
+ *
+ * @param {Object} order An order as returned from API
+ * @return {Float} The total amount as a decimal number
+ */
+export function getOrderTotal( order ) {
+	const discount = getOrderDiscountTotal( order );
+	const fees = getOrderFeeTotal( order );
+	const refunds = getOrderRefundTotal( order );
+	const shipping = getOrderShippingTotal( order );
+	const subtotal = getOrderSubtotal( order );
+	// Refunds are negative, but discounts are not
+	return subtotal - discount + fees + shipping + refunds;
+}


### PR DESCRIPTION
This PR adds rows to the order table to display the fees on an order. On the single order view:

<img width="735" alt="screen shot 2017-10-10 at 10 17 45 pm" src="https://user-images.githubusercontent.com/541093/31419288-018847d4-ae09-11e7-93eb-af85599a0e91.png">

This is also added to the refunds modal:

<img width="737" alt="screen shot 2017-10-10 at 10 18 03 pm" src="https://user-images.githubusercontent.com/541093/31419289-01b1b862-ae09-11e7-8877-5728d625c505.png">

Additionally this adds (and uses) some helper functions to `woocommerce/lib/order-values`, with tests:

- `getOrderFeeTax`
- `getOrderFeeTotalTax`
- `getOrderFeeTotal`

Note: This PR uses the new refund process in #18728.

**To test**

- View a single order with fees (can add by editing an on-hold or pending order in wp-admin)
- Open the refund modal by clicking "Submit Refund" (might have to Mark as Paid first)
- Make sure the fee displays correctly in both places, and the refund total is as expected
- Test out the new values helper functions: `npm run test-client client/extensions/woocommerce/lib/order-values/test/index.js`

@kellychoffman @jameskoster I went off the design in the order edit mockup, but I'm not sure about in the refund dialog.

