### PR TITLE
Add privacy_available from suggestion to domainItem

### DIFF
--- a/client/my-sites/domains/domain-search/domain-search.jsx
+++ b/client/my-sites/domains/domain-search/domain-search.jsx
@@ -86,6 +86,7 @@ class DomainSearch extends Component {
 			cartItems.domainRegistration( {
 				domain: suggestion.domain_name,
 				productSlug: suggestion.product_slug,
+				extra: { privacy_available: suggestion.supports_privacy },
 			} ),
 		];
 


### PR DESCRIPTION
This PR fixes #18723 by passing the information about whether privacy is an option on domains from the domain suggestions in `DomainSearch` into the cart, to make them available in `DomainDetailsForm`:

![no-privacy-flicker](https://user-images.githubusercontent.com/5952255/31422626-6b50964c-ae92-11e7-8021-1d1b43fe2a50.gif)
