### PR TITLE
Update my-sites error messages for single sites

### DIFF
--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -8,7 +8,7 @@ import page from 'page';
 import ReactDom from 'react-dom';
 import React from 'react';
 import i18n from 'i18n-calypso';
-import { uniq, some, startsWith } from 'lodash';
+import { uniq, some, startsWith, endsWith } from 'lodash';
 
 /**
  * Internal Dependencies
@@ -294,6 +294,9 @@ function showMissingPrimaryError( currentUser, dispatch ) {
 		);
 	} else {
 		analytics.tracks.recordEvent( 'calypso_mysites_single_site_error', tracksPayload );
+		dispatch(
+			warningNotice( i18n.translate( "We're sorry, but an unexpected error has occured" ) )
+		);
 	}
 }
 
@@ -318,7 +321,12 @@ export default {
 		const primary = getSite( getState(), primaryId ) || '';
 
 		const redirectToPrimary = () => {
-			let redirectPath = `${ context.pathname }/${ primary.slug }`;
+			let redirectPath;
+			if ( ! primary.slug && endsWith( context.pathname, 'undefined' ) ) {
+				redirectPath = context.pathname;
+			} else {
+				redirectPath = `${ context.pathname }/${ primary.slug }`;
+			}
 
 			redirectPath = context.querystring
 				? `${ redirectPath }?${ context.querystring }`
@@ -358,12 +366,12 @@ export default {
 			if ( hasInitialized ) {
 				if ( primary ) {
 					redirectToPrimary();
+					return;
 				} else {
 					// If the primary site does not exist, skip redirect
 					// and display a useful error notification
 					showMissingPrimaryError( currentUser, dispatch );
 				}
-				return;
 			}
 			dispatch( {
 				type: SITES_ONCE_CHANGED,


### PR DESCRIPTION
### Background
Some single site users have been getting stuck in a `/undefined/undefined/...` redirect loop. We determined some users had disconnected their primary jetpack site, causing problems. But WP.com users were also affected. Why? We placed Tracks events to answer this question.

### Peviously
PR https://github.com/Automattic/wp-calypso/pull/18683 fixes a bug where many, many users were erroneously reaching an error message. The message is now being delivered to the correct users.

![screen shot 2017-09-29 at 3 43 04 pm](https://user-images.githubusercontent.com/1922453/30998744-3bb42854-a52d-11e7-918e-099c57e13e4d.png)

### WP.com users whose single primary site can't be found
As mentioned, some wpcom users also had site that couldn't be found. We tracked by this event:
```
calypso_mysites_single_site_error
```
By looking through the recent user's audit logs, it finally becomes clear: They've just deleted their only blog and have no remaining blogs. However, the user table must not yet be updated and the `visible_site_count` remains at 1, not zero. This causes the controller to think there is a visible site, when in fact there isn't. 

Another oddity: 
```
const hasInitialized = getSites( getState() ).length;
```
Since all sites have been deleted, this should be false. Somehow the data is stale.

### What should we do?

When a wpcom user deletes their last site and `state` gets in a wacky situation of momentarily stale data, the "My Sites" button becomes unresponsive (see Testing section below) until the updated `/me` endpoint returns with `visible_site_count === 0`. The user then correctly sees this

![screen shot 2017-10-10 at 12 46 48 pm](https://user-images.githubusercontent.com/1922453/31474108-34ae2f5a-af55-11e7-962c-c6d4b8497bd6.png)

Looking at the Tracks logs, it appears the user is continually clicking the "My Sites" button. Lets show a warning message that something went wrong and the user should refresh.

# Changes in this PR

### Allow `next()` to be called
Ensure users see an updated screen when clicking on "My Sites".

### Checking for paths ending in `undefined`
While in the redirect loop and the primary does not exist, do not attempt to add another `/undefined` to the url.

![screen shot 2017-10-11 at 5 17 17 pm](https://user-images.githubusercontent.com/1922453/31422570-269ca946-aeab-11e7-8cdf-a7a5721da60a.png)

# Testing
### Jetpack users
1. http://calypso.localhost:3000
2. SU an account showing recent Tracks error
3. Click "My Sites"
4. See that the page goes to stats and the error directing to wp-admin is showing. On production, only the error shows, but the screen stays on Reader

### wpcom users
This a hard one to reproduce because you have to re-create an odd state in the data. You can ensure `showMissingPrimaryError` gets called by hard coding the if statements here:

https://github.com/Automattic/wp-calypso/blob/02718b0715ae07d40005344b03c5d1d595ae594f/client/my-sites/controller.js#L364-L375

Directly place `true`/`false` in a way such that `showMissingPrimaryError` is called. If your primary site is not jetpack, all good. If not, modify this line to `false`:

https://github.com/Automattic/wp-calypso/blob/02718b0715ae07d40005344b03c5d1d595ae594f/client/my-sites/controller.js#L284

1. http://calypso.localhost:3000
2. Click "My Sites"
3. See the page change to stats and a friendly error occur. (Previously nothing would occur)