### PR TITLE
Domains: Changing countries in checkout/whois causes state control to change value

### DIFF
--- a/client/my-sites/domains/components/form/state-select.jsx
+++ b/client/my-sites/domains/components/form/state-select.jsx
@@ -51,11 +51,22 @@ class StateSelect extends Component {
 
 	render() {
 		const classes = classNames( this.props.additionalClasses, 'state' );
+		const {
+			countryCode,
+			countryStates,
+			errorMessage,
+			name,
+			value,
+			disabled,
+			onChange,
+			isError,
+			inputRef,
+		} = this.props;
 
 		return (
 			<div>
-				{ this.props.countryCode && <QueryCountryStates countryCode={ this.props.countryCode } /> }
-				{ isEmpty( this.props.countryStates ) ? (
+				{ countryCode && <QueryCountryStates countryCode={ countryCode } /> }
+				{ isEmpty( countryStates ) ? (
 					<Input ref="input" { ...this.props } />
 				) : (
 					<div className={ classes }>
@@ -65,26 +76,24 @@ class StateSelect extends Component {
 						<FormSelect
 							ref="input"
 							id={ `${ this.constructor.name }-${ this.instance }` }
-							name={ this.props.name }
-							value={ this.props.value }
-							disabled={ this.props.disabled }
-							onChange={ this.props.onChange }
+							name={ name }
+							value={ value }
+							disabled={ disabled }
+							onChange={ onChange }
 							onClick={ this.recordStateSelectClick }
-							isError={ this.props.isError }
-							inputRef={ this.props.inputRef }
+							isError={ isError }
+							inputRef={ inputRef }
 						>
-							<option key="--" value="--" disabled="disabled">
+							<option key="--" value="" disabled="disabled">
 								{ this.props.translate( 'Select State' ) }
 							</option>
-							{ this.props.countryStates.map( state => (
+							{ countryStates.map( state => (
 								<option key={ state.code } value={ state.code }>
 									{ state.name }
 								</option>
 							) ) }
 						</FormSelect>
-						{ this.props.errorMessage && (
-							<FormInputValidation text={ this.props.errorMessage } isError />
-						) }
+						{ errorMessage && <FormInputValidation text={ errorMessage } isError /> }
 					</div>
 				) }
 			</div>


### PR DESCRIPTION
Fixes issue: #18724

The parent component resets the value of the state to `''` when the countryCode changes.

However the first value of the select field was '--'. So now, when a re-render after a countryCode change occurs, the `<StateSelect />` component will set the value of a valid item.

I just changed the value of the first option: `<option key="--" value="" disabled="disabled">`.

![oct-11-2017 16-56-00](https://user-images.githubusercontent.com/6458278/31424462-290ae652-aea6-11e7-9bc1-8f187997ea6e.gif)

I've tried rather unconvincingly to demonstrate this effect in this [jsfiddle](https://jsfiddle.net/ramonjd/06rjvzn1/9/). Programmatically setting a select field value, if the value isn't there, won't display the first option if that first option's value is something else.

Unrelate to the PR, I also destructured the props. :)