### PR TITLE
Data Layer: refactor dispatchRequest to avoid repetitive code

### DIFF
--- a/client/state/data-layer/wpcom-http/README.md
+++ b/client/state/data-layer/wpcom-http/README.md
@@ -179,16 +179,22 @@ dispatch( http( {
 ```
 
 If given, the action passed as the second and optional parameter will take the place of all unspecified `onSuccess`, `onFailure`, and `onProgress` responder events.
+
 Because we have a very common pattern when issuing requests there is a built-in helper to hand each action off to the right function based on the (possibly) attached metadata.
 
 ```js
 import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 
 // create request when no meta present, add on success, alert on failure
-dispatchRequest( fetchMenu, addMenuItems, alertFailure );
+dispatchRequest( { fetch: fetchMenu, onSuccess: addMenuItems, onError: alertFailure } );
 
 // create request when no meta present, indicate on success, undo on failure, update on progress
-dispatchRequest( sendRecipe, indicateSuccess, removeRecipe, { onProgress: updateRecipeProgress } );
+dispatchRequest( {
+	fetch: sendRecipe,
+	onSuccess: indicateSuccess,
+	onError: removeRecipe,
+	onProgress: updateRecipeProgress
+} );
 ```
 
 ### `dispatchRequest()` helper
@@ -202,7 +208,13 @@ Additionally there are other semantics of network requests it can manage.
  - A schema to validate the response data and fail invalid formats
  - A way to indicate data "freshness" or how new data must be to fetch it (coming soon!)
 
-Each of these lifecycle functions will take as arguments the Redux store, the associated action, and the data coming from the response.
+Each of these lifecycle functions is in fact an action creator. As arguments, it takes the original
+associated action and the data coming from the response. It returns the action we want to be dispatched
+when a certain type of API event (request, response, error) happens. If you need to execute more
+complex logic in response to an API event, the action creator can return a thunk. Most use cases
+just dispatch a single action though, and this case is optimized to require as little code as
+possible.
+
 Please note that for this example we have included a progress event even though one would not normally exist for liking posts.
 Its inclusion here is meant merely to illustrate how the pieces can fit together.
 
@@ -215,74 +227,76 @@ import { QUEUE_REQUEST } from 'state/data-layer/wpcom-http/constants';
 /**
  * @see https://developer.wordpress.com/docs/api/1.1/post/sites/%24site/posts/%24post_ID/likes/new/ API description
  */
-const likePost = ( { dispatch }, action ) => {
-	// dispatch intent to issue HTTP request
-	// by not supplying onSuccess, onError, and onProgress
-	// _and_ by supplying the second optional `action`
-	// argument we will be reusing the original action to
-	// follow-up with these requests, but when it comes
-	// back it will be wrapped with meta information
+const likePost = ( action ) => (
+	// dispatch intent to issue HTTP request by not supplying onSuccess, onError,
+	// and onProgress, but when it comes back it will be wrapped with meta information
 	// describing the response from the HTTP events
-	dispatch( http( {
+	// The `dispatchRequest` helper will extend the `http` action with the appropriate
+	// `onSuccess` and `onError` handlers. Therefore, you don't need to pass the second `action`
+	// argument to the `http` action creator.
+	http( {
 		method: 'POST',
 		path: `/sites/{ action.siteId }/posts/${ action.postId }/likes/new`,
-		
+
 		// indicate what should happen if we have
 		// no network connection: queue to replay
 		// when the network reconnects
 		// (not implemented yet)
 		whenOffline: QUEUE_REQUEST,
-	}, action ) );
-}
+	} )
+);
 
 /**
  * Called on success from HTTP middleware with `data` parameter
  *
  * This is the place to map fromAPI to Calypso formats
  */
-const verifyLike = ( { dispatch }, { siteId, postId }, data ) => {
+const verifyLike = ( { siteId, postId }, data ) => {
 	if ( ! data.hasOwnProperty( 'i_like' ) ) {
 		// something went wrong, so failover
-		return undoLike( { dispatch }, { siteId, postId }, 'Invalid data' );
+		return undoLike( { siteId, postId }, 'Invalid data' );
 	}
 
 	// this is a response to data coming in from the data layer,
 	// so skip further data-layer middleware with local
-	dispatch( bypassDataLayer( {
+	return bypassDataLayer( {
 		type: data.i_like ? LIKE_POST : UNLIKE_POST,
 		siteId,
 		postId,
 		likeCount: data.like_count,
-	} ) );
+	} );
 }
 
 /**
  * Called on failure from the HTTP middleware with `error` parameter
  */
-const undoLike = ( { dispatch }, { siteId, postId }, error ) => {
+const undoLike = ( { siteId, postId }, error ) => (
 	// skip data-layer middleware
-	dispatch( bypassDataLayer( {
+	bypassDataLayer( {
 		type: UNLIKE_POST,
 		siteId,
 		postId,
-	} ) );
-}
+	} )
+);
 
 /**
  * Maps progress information from the API into a Calypso-native representation
  */
-const updateProgress = ( store, { siteId, postId }, progress ) => {
-	dispatch( {
-		type: LIKE_POST_PROGRESS,
-		siteId,
-		postId,
-		percentage: 100 * progress.loaded / ( progress.total + Number.EPSILON )
-	} );
-}
+const updateProgress = ( { siteId, postId }, progress ) => ( {
+	type: LIKE_POST_PROGRESS,
+	siteId,
+	postId,
+	percentage: 100 * progress.loaded / ( progress.total + Number.EPSILON )
+} );
 
 export default {
-	// watch for this action       -> initiate, onSuccess,  onFailure, options: { onProgress }
-	[ LIKE_POST ]: [ dispatchRequest( likePost, verifyLike, undoLike, { onProgress: updateProgress } ) ],
+	// watch for this action
+	[ LIKE_POST ]: [ dispatchRequest( {
+		fetch: likePost,
+		onSuccess: verifyLike,
+		onError: undoLike,
+		onProgress: updateProgress
+	} ) ],
 };
 ```
 
@@ -320,15 +334,13 @@ const toLike = ( { i_like } ) => ( {
 } );
 
 export default {
-	[ LIKE_POST ]: [ dispatchRequest(
-		likePost, // initiate the request
-		verifyLike, // update the Redux store if need be
-		undoLike, // remove the like if we failed
-		{
-			fromApi: makeParser( likeSchema, {}, toLike ), // validate and convert to internal Calypso object
-			onProgress: updateProgress, // update progress tracking UI
-		}
-	) ]
+	[ LIKE_POST ]: [ dispatchRequest( {
+		fetch: likePost, // initiate the request
+		onSuccess: verifyLike, // update the Redux store if need be
+		onError: undoLike, // remove the like if we failed
+		onProgress: updateProgress, // update progress tracking UI
+		fromApi: makeParser( likeSchema, {}, toLike ), // validate and convert to internal Calypso object
+	} ) ]
 }
 ```
 

--- a/client/state/data-layer/wpcom-http/utils.js
+++ b/client/state/data-layer/wpcom-http/utils.js
@@ -8,6 +8,11 @@ import schemaValidator from 'is-my-json-valid';
 import { get, identity, noop } from 'lodash';
 
 /**
+ * Internal dependencies
+ */
+import warn from 'lib/warn';
+
+/**
  * Returns response data from an HTTP request success action if available
  *
  * @param {Object} action may contain HTTP response data
@@ -46,18 +51,18 @@ export const getHeaders = action => get( action, 'meta.dataLayer.headers', undef
  */
 export const getProgress = action => get( action, 'meta.dataLayer.progress', undefined );
 
-class SchemaError extends Error {
+export class SchemaError extends Error {
 	constructor( errors ) {
 		super( 'Failed to validate with JSON schema' );
 		this.schemaErrors = errors;
 	}
 }
 
-class TransformerError extends Error {
-	constructor( error, transformer, data ) {
+export class TransformerError extends Error {
+	constructor( error, data, transformer ) {
 		super( error.message );
-		this.transformer = transformer;
 		this.inputData = data;
+		this.transformer = transformer;
 	}
 }
 
@@ -83,7 +88,7 @@ export const makeParser = ( schema, schemaOptions = {}, transformer = identity )
 		try {
 			return transformer( data );
 		} catch ( e ) {
-			throw new TransformerError( e, transformer, data );
+			throw new TransformerError( e, data, transformer );
 		}
 	};
 
@@ -161,3 +166,101 @@ export const dispatchRequest = ( initiator, onSuccess, onError, options = {} ) =
 
 	return initiator( store, action );
 };
+
+/**
+ * Dispatches to appropriate function based on HTTP request meta
+ *
+ * @see state/data-layer/wpcom-http/actions#fetch creates HTTP requests
+ *
+ * When the WPCOM HTTP data layer handles requests it will add
+ * response data and errors to a meta property on the given success
+ * error, and progress handling actions.
+ *
+ * This function accepts several functions as the fetch, success, error and
+ * progress handlers for actions and it will call the appropriate
+ * one based on the stored meta.
+ *
+ * These handlers are action creators: based on the input data coming from the HTTP request,
+ * it will return an action (or an action thunk) to be executed as a response to the given
+ * HTTP event.
+ *
+ * If both error and response data is available this will call the
+ * error handler in preference over the success handler, but the
+ * response data will also still be available through the action meta.
+ *
+ * The functions should conform to the following type signatures:
+ *   fetch  :: Action -> Action (action creator with one Action parameter)
+ *   onSuccess  :: Action -> ResponseData -> Action (action creator with two params)
+ *   onError    :: Action -> ErrorData -> Action
+ *   onProgress :: Action -> ProgressData -> Action
+ *   fromApi    :: ResponseData -> TransformedData throws TransformerError|SchemaError
+ *
+ * @param {Object} options object with named parameters:
+ * @param {Function} fetch called if action lacks response meta; should create HTTP request
+ * @param {Function} onSuccess called if the action meta includes response data
+ * @param {Function} onError called if the action meta includes error data
+ * @param {Function} onProgress called on progress events when uploading
+ * @param {Function} fromApi maps between API data and Calypso data
+ * @returns {Action} action or action thunk to be executed in response to HTTP event
+ */
+export const dispatchRequestEx = options => {
+	if ( ! options.fetch ) {
+		warn( 'fetch handler is not defined: no request will ever be issued' );
+	}
+
+	if ( ! options.onSuccess ) {
+		warn( 'onSuccess handler is not defined: response to the request is being ignored' );
+	}
+
+	if ( ! options.onError ) {
+		warn( 'onError handler is not defined: error during the request is being ignored' );
+	}
+
+	return ( store, action ) => {
+		// create the low-level action we want to dispatch
+		const requestAction = createRequestAction( options, action );
+		// dispatch the low level action (if any was created) and return the result
+		return requestAction ? store.dispatch( requestAction ) : undefined;
+	};
+};
+
+/*
+ * Converts an application-level Calypso action that's handled by the data-layer middleware
+ * into a low-level action. For example, HTTP request that's being initiated, or a response
+ * action with a `meta.dataLayer` property.
+ */
+function createRequestAction( options, action ) {
+	const {
+		fetch = noop,
+		onSuccess = noop,
+		onError = noop,
+		onProgress = noop,
+		fromApi = identity,
+	} = options;
+
+	const error = getError( action );
+	if ( error ) {
+		return onError( action, error );
+	}
+
+	const data = getData( action );
+	if ( data ) {
+		try {
+			return onSuccess( action, fromApi( data ) );
+		} catch ( err ) {
+			return onError( action, err );
+		}
+	}
+
+	const progress = getProgress( action );
+	if ( progress ) {
+		return onProgress( action, progress );
+	}
+
+	const fetchAction = fetch( action );
+	if ( ! fetchAction ) {
+		warn( "The `fetch` handler didn't return any action: no request will be issued" );
+	}
+
+	return fetchAction;
+}

--- a/client/state/data-layer/wpcom/sites/simple-payments/index.js
+++ b/client/state/data-layer/wpcom/sites/simple-payments/index.js
@@ -4,7 +4,7 @@
  * @format
  */
 
-import { filter, toPairs, noop } from 'lodash';
+import { get, toPairs } from 'lodash';
 
 /**
  * Internal dependencies
@@ -17,14 +17,13 @@ import {
 	SIMPLE_PAYMENTS_PRODUCTS_LIST_DELETE,
 } from 'state/action-types';
 import {
-	receiveProduct,
 	receiveProductsList,
 	receiveUpdateProduct,
 	receiveDeleteProduct,
 } from 'state/simple-payments/product-list/actions';
 import { metaKeyToSchemaKeyMap, metadataSchema } from 'state/simple-payments/product-list/schema';
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequestEx, TransformerError } from 'state/data-layer/wpcom-http/utils';
 import { SIMPLE_PAYMENTS_PRODUCT_POST_TYPE } from 'lib/simple-payments/constants';
 import { isValidSimplePaymentsProduct } from 'lib/simple-payments/utils';
 import formatCurrency from 'lib/format-currency';
@@ -59,11 +58,15 @@ function customPostMetadataToProductAttributes( metadata ) {
 }
 
 /**
- * Formats /posts endpoint response into a product object
+ * Validates a `/posts` endpoint response and converts it into a product object
  * @param { Object } customPost raw /post endpoint response to format
  * @returns { Object } sanitized and formatted product
  */
 export function customPostToProduct( customPost ) {
+	if ( ! isValidSimplePaymentsProduct( customPost ) ) {
+		throw new TransformerError( 'Custom post is not a valid simple payment product', customPost );
+	}
+
 	const metadataAttributes = customPostMetadataToProductAttributes( customPost.metadata );
 
 	return {
@@ -73,6 +76,26 @@ export function customPostToProduct( customPost ) {
 		featuredImageId: getFeaturedImageId( customPost ),
 		...metadataAttributes,
 	};
+}
+
+/**
+ * Extract custom posts array from `responseData`, filter out invalid items and convert the
+ * valid custom posts to products.
+ * @param {Object} responseData JSON data with shape `{ posts }`
+ * @return {Array} validated and converted product list
+ */
+export function customPostsToProducts( responseData ) {
+	const posts = get( responseData, 'posts', [] );
+	const validProducts = posts
+		.map( post => {
+			try {
+				return customPostToProduct( post );
+			} catch ( error ) {
+				return null;
+			}
+		} )
+		.filter( Boolean );
+	return validProducts;
 }
 
 /**
@@ -117,143 +140,84 @@ export function productToCustomPost( product ) {
 	};
 }
 
-/**
- * Issues an API request to fetch a product by its ID for a site.
- *
- * @param  {Object}  store  Redux store
- * @param  {Object}  action Action object
- */
-export function requestSimplePaymentsProduct( { dispatch }, action ) {
-	const { siteId, productId } = action;
+const replaceProductList = ( { siteId }, products ) => receiveProductsList( siteId, products );
+const addOrUpdateProduct = ( { siteId }, newProduct ) => receiveUpdateProduct( siteId, newProduct );
+const deleteProduct = ( { siteId }, deletedPost ) => receiveDeleteProduct( siteId, deletedPost.ID );
 
-	dispatch(
+export const handleProductGet = dispatchRequestEx( {
+	fetch: action =>
 		http(
 			{
 				method: 'GET',
-				path: `/sites/${ siteId }/posts/${ productId }`,
+				path: `/sites/${ action.siteId }/posts/${ action.productId }`,
 			},
 			action
-		)
-	);
-}
+		),
+	fromApi: customPostToProduct,
+	onSuccess: addOrUpdateProduct,
+} );
 
-/**
- * Issues an API request to fetch products for a site.
- *
- * @param  {Object}  store  Redux store
- * @param  {Object}  action Action object
- */
-export function requestSimplePaymentsProducts( { dispatch }, action ) {
-	const { siteId } = action;
-
-	dispatch(
+export const handleProductList = dispatchRequestEx( {
+	fetch: action =>
 		http(
 			{
 				method: 'GET',
-				path: `/sites/${ siteId }/posts`,
+				path: `/sites/${ action.siteId }/posts`,
 				query: {
 					type: SIMPLE_PAYMENTS_PRODUCT_POST_TYPE,
 					status: 'publish',
 				},
 			},
 			action
-		)
-	);
-}
+		),
+	fromApi: customPostsToProducts,
+	onSuccess: replaceProductList,
+} );
 
-/**
- * Issues an API request to add a new product
- * @param {Object} store Redux store
- * @param {Object} action Action object
- */
-export function requestSimplePaymentsProductAdd( { dispatch }, action ) {
-	const { siteId, product } = action;
-
-	dispatch(
+export const handleProductListAdd = dispatchRequestEx( {
+	fetch: action =>
 		http(
 			{
 				method: 'POST',
-				path: `/sites/${ siteId }/posts/new`,
-				body: productToCustomPost( product ),
+				path: `/sites/${ action.siteId }/posts/new`,
+				body: productToCustomPost( action.product ),
 			},
 			action
-		)
-	);
-}
+		),
+	fromApi: customPostToProduct,
+	onSuccess: addOrUpdateProduct,
+} );
 
-/**
- * Issues an API request to edit a product
- * @param {Object} store Redux store
- * @param {Object} action Action object
- */
-export function requestSimplePaymentsProductEdit( { dispatch }, action ) {
-	const { siteId, product, productId } = action;
-
-	dispatch(
+export const handleProductListEdit = dispatchRequestEx( {
+	fetch: action =>
 		http(
 			{
 				method: 'POST',
-				path: `/sites/${ siteId }/posts/${ productId }`,
-				body: productToCustomPost( product ),
+				path: `/sites/${ action.siteId }/posts/${ action.productId }`,
+				body: productToCustomPost( action.product ),
 			},
 			action
-		)
-	);
-}
+		),
+	fromApi: customPostToProduct,
+	onSuccess: addOrUpdateProduct,
+} );
 
-/**
- * Issues an API request to delete a product
- * @param {Object} store Redux store
- * @param {Object} action Action object
- */
-export function requestSimplePaymentsProductDelete( { dispatch }, action ) {
-	const { siteId, productId } = action;
-
-	dispatch(
+export const handleProductListDelete = dispatchRequestEx( {
+	fetch: action =>
 		http(
 			{
 				method: 'POST',
-				path: `/sites/${ siteId }/posts/${ productId }/delete`,
+				path: `/sites/${ action.siteId }/posts/${ action.productId }/delete`,
 			},
 			action
-		)
-	);
-}
-
-export const addProduct = ( { dispatch }, { siteId }, newProduct ) =>
-	dispatch( receiveUpdateProduct( siteId, customPostToProduct( newProduct ) ) );
-
-export const deleteProduct = ( { dispatch }, { siteId }, deletedProduct ) =>
-	dispatch( receiveDeleteProduct( siteId, deletedProduct.ID ) );
-
-export const listProduct = ( { dispatch }, { siteId }, product ) => {
-	if ( ! isValidSimplePaymentsProduct( product ) ) {
-		return;
-	}
-
-	dispatch( receiveProduct( siteId, customPostToProduct( product ) ) );
-};
-
-export const listProducts = ( { dispatch }, { siteId }, { posts: products } ) => {
-	const validProducts = filter( products, isValidSimplePaymentsProduct );
-
-	dispatch( receiveProductsList( siteId, validProducts.map( customPostToProduct ) ) );
-};
+		),
+	onSuccess: deleteProduct,
+} );
 
 export default {
-	[ SIMPLE_PAYMENTS_PRODUCT_GET ]: [
-		dispatchRequest( requestSimplePaymentsProduct, listProduct, noop ),
-	],
-	[ SIMPLE_PAYMENTS_PRODUCTS_LIST ]: [
-		dispatchRequest( requestSimplePaymentsProducts, listProducts, noop ),
-	],
-	[ SIMPLE_PAYMENTS_PRODUCTS_LIST_ADD ]: [
-		dispatchRequest( requestSimplePaymentsProductAdd, addProduct, noop ),
-	],
-	[ SIMPLE_PAYMENTS_PRODUCTS_LIST_EDIT ]: [
-		dispatchRequest( requestSimplePaymentsProductEdit, addProduct, noop ),
-	],
-	[ SIMPLE_PAYMENTS_PRODUCTS_LIST_DELETE ]: [
-		dispatchRequest( requestSimplePaymentsProductDelete, deleteProduct, noop ),
-	],
+	[ SIMPLE_PAYMENTS_PRODUCT_GET ]: [ handleProductGet ],
+	[ SIMPLE_PAYMENTS_PRODUCTS_LIST ]: [ handleProductList ],
+	[ SIMPLE_PAYMENTS_PRODUCTS_LIST_ADD ]: [ handleProductListAdd ],
+	[ SIMPLE_PAYMENTS_PRODUCTS_LIST_EDIT ]: [ handleProductListEdit ],
+	[ SIMPLE_PAYMENTS_PRODUCTS_LIST_DELETE ]: [ handleProductListDelete ],
 };

--- a/client/state/data-layer/wpcom/sites/simple-payments/test/index.js
+++ b/client/state/data-layer/wpcom/sites/simple-payments/test/index.js
@@ -12,8 +12,9 @@ import { customPostToProduct, productToCustomPost } from '../';
 describe( '#simplePayments', () => {
 	test( 'should convert customPost to product', () => {
 		const customPost = {
-			type: 'jp_pay_product',
 			ID: 1,
+			type: 'jp_pay_product',
+			status: 'publish',
 			title: 'The Button',
 			content: 'A very nice button for sale',
 			featured_image: 2,
@@ -42,6 +43,8 @@ describe( '#simplePayments', () => {
 	test( 'should decode special characters when converting to product', () => {
 		const customPost = {
 			ID: 2,
+			type: 'jp_pay_product',
+			status: 'publish',
 			title: '\u201d\u221e\u201d and &#8216;so much more&#8217;\u2122 \u2026',
 			content: 'Accepting $, \u20bf, &amp; \u2603',
 			featured_image: 2,


### PR DESCRIPTION
This PR introduces a new `handleDataRequest` API for Data Layer that's intended to replace the `dispatchRequest` function. By applying several simple refactorings to `dispatchRequest`, I think I made the function more usable and less verbose.

I applied the new API to the Simple Payments code (I worked on it recently) and it made the code much shorter (260 lines to 210) and I believe it's more readable.

What are the refactorings I did?

**Don't distinguish between mandatory and optional arguments**
All parameters for the handler are now part of one big object:
```js
handleDataRequest( {
  initiate,
  onSuccess,
  onProgress,
} );
```
In the past, the opinion about what's optional and what's not has changed quite often, each time requiring a refactoring of all call sites. Now, everything is a named parameter of a single `options` object. If a mandatory parameter is missing, I issue a console warning: experience shows that Calypso contributors tend to be annoyed by warnings and fix them quickly.

**Change the handler signature to a classic action creator**
Until now, the `initiate`/`onSuccess`/... handlers had an unusual signature like this:
```js
onSuccess = ( store, action, data ) => {
  store.dispatch( someOtherAction( action.siteId, data ) );
}
```
It's somewhat similar to a middleware, but it's not a middleware. It's something very data-layer-specific.

I'm changing this into a classic action creator:
```js
onSuccess = ( action, data ) => someOtherAction( action.siteId, data );
```
and do the `dispatch` call at one place, in the framework code in `handleDataRequest`. This removes a lot of verbosity from the code.

If your handler did something more complex, it can always return an action thunk:
```js
onSuccess = ( action, data ) => dispatch => {
  doSomething();
  dispatch( someOtherAction() );
  doSomethingElse();
}
```
But most handlers don't require a thunk at all. This change removes some mystery from the handlers and converts them into a familiar language of action creators and thunks, something every Redux developer is already fluent in.

Doing the dispatch in the framework code has another advantage: the framework can change the action before dispatching it. For example, `handleDataRequest` decorates the `http` actions with `onSuccess` and `onError` properties. Again, user code can be simplified and complexity is moved to the framework.

**Return array of handlers**
The `handleDataRequest` returns an one-element array of handler functions, so the return can be conveniently passed directly as part of `mergeHandlers` argument.

I personally think that supporting multiple handlers for a data-layer action is not a great idea. One handler is sufficient for a vast majority of cases and the rest can be converted. But most importantly, having one handler allows to return a value from the `dispatch` call. That'd be extremely useful for sequencing requests together (using Promises or other async primitives) and using them outside Redux (like in `page` handlers or React components with local state).

If we decide to do this change, the user code that uses `handleDataRequest` won't need to be changed -- only the framework internals will be updated.

**Example:**
This is an example usage of the new API:
```js
export const handleProductListEdit = handleDataRequest( {
	initiate: action =>
		http( {
			method: 'POST',
			path: `/sites/${ action.siteId }/posts/${ action.productId }`,
			body: productToCustomPost( action.product ),
		} ),
	fromApi: customPostToProduct,
	onSuccess: ( action, newProduct ) => receiveUpdateProduct( action.siteId, newProduct ),
} );

export default {
	[ SIMPLE_PAYMENTS_PRODUCTS_LIST_EDIT ]: handleProductListEdit,
};
```

**Further development:**
Here are some ideas on how to further improve the API:
1. Introduce nice API for creating the HTTP actions. The idea is to call `initiateAction = wpcom.site( siteId ).addPost( post )` -- the same idiomatic API we already know, but it just creates actions instead of executing the request. No need to know the details of the WP.com REST API (methods, paths).
2. Auto-generate the code that reads and updates the Redux state. Avoid creating the same CRUD actions, reducers and selectors over and over. Provide parametrized helpers that generate them.

