### PR TITLE
Move gridicons and social-logos to vendor chunk

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -174,6 +174,7 @@ if ( calypsoEnv === 'desktop' ) {
 	webpackConfig.entry.vendor = [
 		'classnames',
 		'create-react-class',
+		'gridicons',
 		'i18n-calypso',
 		'lodash',
 		'moment',
@@ -184,6 +185,7 @@ if ( calypsoEnv === 'desktop' ) {
 		'react-redux',
 		'redux',
 		'redux-thunk',
+		'social-logos',
 		'store',
 		'wpcom',
 	];

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -173,13 +173,13 @@ if ( calypsoEnv === 'desktop' ) {
 	// vendor chunk
 	webpackConfig.entry.vendor = [
 		'classnames',
+		'create-react-class',
 		'i18n-calypso',
 		'lodash',
 		'moment',
 		'page',
-		'react',
-		'create-react-class',
 		'prop-types',
+		'react',
 		'react-dom',
 		'react-redux',
 		'redux',


### PR DESCRIPTION
This pull request seeks to improve performance by moving two modules that rarely changes out of the `build` chunk, and into the `vendor` chunk. That way, we will only send the `gridicons` and `social-logos` modules to the browser when the latter is invalidated, which should happen way less often than the former.

###### `build.js` chunk
* Before: 2823KB
* After: 2695KB

###### `vendor.js` chunk
* Before: 833KB
* After: 962KB

Said differently, this moves 128924 bytes from `build.js` to `vendor.js`.

#### Testing instructions

1. Run `git checkout update/vendor-chunk` and start your server, or open a [live branch](https://calypso.live/?branch=update/vendor-chunk)
2. Open the [`Home` page](http://calypso.localhost:3000/)
3. Check that everything works as before

#### Additional notes

It was mentioned internally that we may want to lazy load those modules. I'm not entirely sure how we could achieve that with `<AsyncLoad />` given the [number of places](https://github.com/Automattic/wp-calypso/search?l=JSX&q=Gridicon&type=&utf8=%E2%9C%93) we use the `<Gridicon />` component.

#### Reviews

- [x] Code
- [ ] Product