### PR TITLE
Jetpack Connect: Enable Happychat button in production

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -32,6 +32,7 @@
 		"jetpack/api-cache": false,
 		"jetpack/google-analytics-anonymize-ip": true,
 		"jetpack/google-analytics-for-stores": true,
+		"jetpack/happychat": true,
 		"login/magic-login": true,
 		"login/native-login-links": true,
 		"login/wp-login": true,


### PR DESCRIPTION
This PR enables the Happychat button for the Jetpack Connect flows in the production environment.

For more information, see: p1HpG7-4hr-p2.