### PR TITLE
Preview: tweak wording of the loading screen

### DIFF
--- a/client/post-editor/editor-preview/index.jsx
+++ b/client/post-editor/editor-preview/index.jsx
@@ -144,7 +144,7 @@ const EditorPreview = React.createClass( {
 						editUrl={ this.props.editUrl }
 						externalUrl={ this.cleanExternalUrl( this.props.externalUrl ) }
 						loadingMessage={ this.props.translate(
-							'{{strong}}One moment, please…{{/strong}} loading your new post.',
+							"{{strong}}One moment, please.{{/strong}} We're loading your preview.",
 							{ components: { strong: <strong /> } }
 						) }
 					/>


### PR DESCRIPTION
This PR tweaks the wording that appears when loading the preview for a site / page / post. Previously, the loading screen said "loading your new post", which wasn't always what we should have been saying (e.g. maybe we were loading a pre-existing page). 

Screenshot:

<img width="516" alt="screen shot 2017-10-11 at 1 00 56 pm" src="https://user-images.githubusercontent.com/23619/31437058-4180f040-ae84-11e7-9eb7-bef8e4ffe69f.png">

This PR changes the wording to a more generic "We're loading your preview."