### PR TITLE
Media: Fix Media Modal Edit Image/Video Button

### DIFF
--- a/client/my-sites/media/main.jsx
+++ b/client/my-sites/media/main.jsx
@@ -15,7 +15,7 @@ import { localize } from 'i18n-calypso';
 import MediaLibrary from 'my-sites/media-library';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import Dialog from 'components/dialog';
-import EditorMediaModalDetail from 'post-editor/media-modal/detail';
+import { EditorMediaModalDetail } from 'post-editor/media-modal/detail';
 import ImageEditor from 'blocks/image-editor';
 import VideoEditor from 'blocks/video-editor';
 import MediaActions from 'lib/media/actions';

--- a/client/post-editor/media-modal/detail/index.jsx
+++ b/client/post-editor/media-modal/detail/index.jsx
@@ -20,84 +20,94 @@ import preloadImage from '../preload-image';
 import { ModalViews } from 'state/ui/media-modal/constants';
 import { setEditorMediaModalView } from 'state/ui/editor/actions';
 
-const EditorMediaModalDetail = React.createClass( {
-	propTypes: {
-		site: PropTypes.object,
-		items: PropTypes.array,
-		selectedIndex: PropTypes.number,
-		onSelectedIndexChange: PropTypes.func,
-		onReturnToList: PropTypes.func,
-		onEdit: PropTypes.func,
-		onRestore: PropTypes.func,
-	},
+// Don't move `localize()` to the default export (below)! See comment there.
+export const EditorMediaModalDetail = localize(
+	React.createClass( {
+		propTypes: {
+			site: PropTypes.object,
+			items: PropTypes.array,
+			selectedIndex: PropTypes.number,
+			onSelectedIndexChange: PropTypes.func,
+			onReturnToList: PropTypes.func,
+			onEdit: PropTypes.func,
+			onRestore: PropTypes.func,
+		},
 
-	getDefaultProps: function() {
-		return {
-			selectedIndex: 0,
-			onSelectedIndexChange: noop,
-		};
-	},
+		getDefaultProps: function() {
+			return {
+				selectedIndex: 0,
+				onSelectedIndexChange: noop,
+			};
+		},
 
-	componentDidMount: function() {
-		this.preloadImages();
-	},
+		componentDidMount: function() {
+			this.preloadImages();
+		},
 
-	componentDidUpdate: function() {
-		this.preloadImages();
-	},
+		componentDidUpdate: function() {
+			this.preloadImages();
+		},
 
-	preloadImages: function() {
-		MediaUtils.filterItemsByMimePrefix( this.props.items, 'image' ).forEach( function( image ) {
-			var src = MediaUtils.url( image, {
-				photon: this.props.site && ! this.props.site.is_private,
-			} );
+		preloadImages: function() {
+			MediaUtils.filterItemsByMimePrefix( this.props.items, 'image' ).forEach( function( image ) {
+				var src = MediaUtils.url( image, {
+					photon: this.props.site && ! this.props.site.is_private,
+				} );
 
-			preloadImage( src );
-		}, this );
-	},
+				preloadImage( src );
+			}, this );
+		},
 
-	incrementIndex: function( increment ) {
-		this.props.onSelectedIndexChange( this.props.selectedIndex + increment );
-	},
+		incrementIndex: function( increment ) {
+			this.props.onSelectedIndexChange( this.props.selectedIndex + increment );
+		},
 
-	render: function() {
-		const {
-			items,
-			selectedIndex,
-			site,
+		render: function() {
+			const {
+				items,
+				selectedIndex,
+				site,
 
-			onEditImageItem,
-			onEditVideoItem,
-			onRestoreItem,
-			onReturnToList,
-		} = this.props;
+				onEditImageItem,
+				onEditVideoItem,
+				onRestoreItem,
+				onReturnToList,
+			} = this.props;
 
-		const item = items[ selectedIndex ];
-		const mimePrefix = MediaUtils.getMimePrefix( item );
+			const item = items[ selectedIndex ];
+			const mimePrefix = MediaUtils.getMimePrefix( item );
 
-		return (
-			<div className="editor-media-modal-detail">
-				<HeaderCake
-					onClick={ onReturnToList }
-					backText={ this.props.translate( 'Media Library' ) }
-				/>
-				<DetailItem
-					site={ site }
-					item={ item }
-					hasPreviousItem={ selectedIndex - 1 >= 0 }
-					hasNextItem={ selectedIndex + 1 < items.length }
-					onShowPreviousItem={ this.incrementIndex.bind( this, -1 ) }
-					onShowNextItem={ this.incrementIndex.bind( this, 1 ) }
-					onRestore={ onRestoreItem }
-					onEdit={ 'video' === mimePrefix ? onEditVideoItem : onEditImageItem }
-				/>
-			</div>
-		);
-	},
-} );
+			return (
+				<div className="editor-media-modal-detail">
+					<HeaderCake
+						onClick={ onReturnToList }
+						backText={ this.props.translate( 'Media Library' ) }
+					/>
+					<DetailItem
+						site={ site }
+						item={ item }
+						hasPreviousItem={ selectedIndex - 1 >= 0 }
+						hasNextItem={ selectedIndex + 1 < items.length }
+						onShowPreviousItem={ this.incrementIndex.bind( this, -1 ) }
+						onShowNextItem={ this.incrementIndex.bind( this, 1 ) }
+						onRestore={ onRestoreItem }
+						onEdit={ 'video' === mimePrefix ? onEditVideoItem : onEditImageItem }
+					/>
+				</div>
+			);
+		},
+	} )
+);
 
+// The default export is only used by the post editor, which displays the image or
+// video editor depending on Redux state, which is set by the actions below.
+// In the Media library (i.e. `/media`) OTOH, we're explicitly passing `onEditImageItem`
+// and `onEditVideoItem` as props to the _named_ export (above), and use them to set
+// component state there to conditionally display the image/video editor.
+// (This is also the reason why we're `localize()`ing the named export.)
+// TODO: Fix this mess, rely on Redux state everywhere.
 export default connect( null, {
 	onReturnToList: partial( setEditorMediaModalView, ModalViews.LIST ),
 	onEditImageItem: partial( setEditorMediaModalView, ModalViews.IMAGE_EDITOR ),
 	onEditVideoItem: partial( setEditorMediaModalView, ModalViews.VIDEO_EDITOR ),
-} )( localize( EditorMediaModalDetail ) );
+} )( EditorMediaModalDetail );


### PR DESCRIPTION
Fixes #18727, which was caused by #18705 (tangential: #18707).

The fix is to re-introduce the un-`connect()`ed named export of `EditorMediaModalDetail` again, and to use that in `media/main`.

Rationale: Quoting a comment I'm adding to `post-editor/media-modal/detail/index.jsx`:

> The default export is only used by the post editor, which displays the image or
> video editor depending on Redux state, which is set by the actions below.
> In the Media library (i.e. `/media`) OTOH, we're explicitly passing `onEditImageItem`
> and `onEditVideoItem` as props to the _named_ export (above), and use them to set
> component state there to conditionally display the image/video editor.
> (This is also the reason why we're `localize()`ing the named export.)
> TODO: Fix this mess, rely on Redux state everywhere.

This is the kind of inconsistency that makes our lives harder 😠 

To test:
* Verify that #18272 is fixed. Verify that the image/video editor buttons also still work when accessed coming from the post editor.