### PR TITLE
Consolidate state shape for happychat.user

### DIFF
--- a/client/state/happychat/middleware.js
+++ b/client/state/happychat/middleware.js
@@ -45,9 +45,9 @@ import {
 	wasHappychatRecentlyActive,
 	isHappychatClientConnected,
 	isHappychatChatAssigned,
-	getGeoLocation,
 	getGroups,
 } from './selectors';
+import getGeoLocation from 'state/happychat/selectors/get-geolocation';
 import { getCurrentUser, getCurrentUserLocale } from 'state/current-user/selectors';
 import { getHelpSelectedSite } from 'state/help/selectors';
 import debugFactory from 'debug';

--- a/client/state/happychat/reducer.js
+++ b/client/state/happychat/reducer.js
@@ -26,10 +26,11 @@ import {
 	HAPPYCHAT_SET_CHAT_STATUS,
 	HAPPYCHAT_TRANSCRIPT_RECEIVE,
 } from 'state/action-types';
-import { combineReducers, createReducer, isValidStateWithSchema } from 'state/utils';
+import { combineReducers, isValidStateWithSchema } from 'state/utils';
 import { HAPPYCHAT_CHAT_STATUS_DEFAULT } from './selectors';
 import { HAPPYCHAT_MAX_STORED_MESSAGES } from './constants';
-import { timelineSchema, geoLocationSchema } from './schema';
+import { timelineSchema } from './schema';
+import user from './user/reducer';
 
 /**
  * Returns a timeline event from the redux action
@@ -63,27 +64,6 @@ const timeline_event = ( state = {}, action ) => {
 
 const validateTimeline = validator( timelineSchema );
 const sortTimeline = timeline => sortBy( timeline, event => parseInt( event.timestamp, 10 ) );
-
-/**
- * Tracks the current user geo location.
- *
- * @param  {Object} state  Current state
- * @param  {Object} action Action payload
- * @return {Object}        Updated state
- */
-export const geoLocation = createReducer(
-	null,
-	{
-		[ HAPPYCHAT_CONNECTED ]: ( state, action ) => {
-			const { user: { geo_location } } = action;
-			if ( geo_location && geo_location.country_long && geo_location.city ) {
-				return geo_location;
-			}
-			return state;
-		},
-	},
-	geoLocationSchema
-);
 
 /**
  * Adds timeline events for happychat
@@ -286,5 +266,5 @@ export default combineReducers( {
 	lostFocusAt,
 	message,
 	timeline,
-	geoLocation,
+	user,
 } );

--- a/client/state/happychat/schema.js
+++ b/client/state/happychat/schema.js
@@ -17,16 +17,6 @@ export const eventSchema = {
 	},
 };
 
-export const geoLocationSchema = {
-	type: [ 'object', 'null' ],
-	properties: {
-		city: { type: 'string' },
-		country_long: { type: 'string' },
-		country_short: { type: 'string' },
-		region: { type: 'string' },
-	},
-};
-
 export const timelineSchema = {
 	type: 'array',
 	additionalProperties: false,

--- a/client/state/happychat/selectors.js
+++ b/client/state/happychat/selectors.js
@@ -62,16 +62,6 @@ export const getGroups = ( state, siteId ) => {
 	return groups;
 };
 
-/**
- * Returns the geo location of the current user, based happychat session initiation (on ip)
- *
- * @param  {Object}  state  Global state tree
- * @return {?String}        Current user geo location
- */
-export function getGeoLocation( state ) {
-	return state.happychat.geoLocation || null;
-}
-
 export const getHappychatChatStatus = createSelector( state => state.happychat.chatStatus );
 
 export const getHappychatLastActivityTimestamp = state => state.happychat.lastActivityTimestamp;

--- a/client/state/happychat/selectors/get-geolocation.js
+++ b/client/state/happychat/selectors/get-geolocation.js
@@ -1,0 +1,8 @@
+/** @format */
+
+/**
+ * Returns the geo location of the current user, based happychat session initiation (on ip)
+ * @param {Object}  state  Global state tree
+ * @return {?String}        Current user geo location
+ */
+export default state => state.happychat.user.geoLocation || null;

--- a/client/state/happychat/selectors/get-geolocation.js
+++ b/client/state/happychat/selectors/get-geolocation.js
@@ -1,8 +1,13 @@
 /** @format */
 
 /**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
  * Returns the geo location of the current user, based happychat session initiation (on ip)
  * @param {Object}  state  Global state tree
  * @return {?String}        Current user geo location
  */
-export default state => state.happychat.user.geoLocation || null;
+export default state => get( state, 'happychat.user.geoLocation', null );

--- a/client/state/happychat/selectors/test/get-geolocation.js
+++ b/client/state/happychat/selectors/test/get-geolocation.js
@@ -1,0 +1,35 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import getGeoLocation from '../get-geolocation';
+
+describe( 'getGeoLocation', () => {
+	test( 'should return null if geoLocation is not set', () => {
+		const selected = getGeoLocation( {
+			happychat: {
+				user: { geoLocation: null },
+			},
+		} );
+		expect( selected ).to.equal( null );
+	} );
+
+	test( 'should return value if geoLocation is set', () => {
+		const selected = getGeoLocation( {
+			happychat: {
+				user: {
+					geoLocation: {
+						city: 'Timisoara',
+					},
+				},
+			},
+		} );
+		expect( selected.city ).to.equal( 'Timisoara' );
+	} );
+} );

--- a/client/state/happychat/selectors/test/get-geolocation.js
+++ b/client/state/happychat/selectors/test/get-geolocation.js
@@ -30,6 +30,6 @@ describe( 'getGeoLocation', () => {
 				},
 			},
 		} );
-		expect( selected.city ).to.equal( 'Timisoara' );
+		expect( selected ).to.eql( { city: 'Timisoara' } );
 	} );
 } );

--- a/client/state/happychat/test/middleware.js
+++ b/client/state/happychat/test/middleware.js
@@ -94,8 +94,10 @@ describe( 'middleware', () => {
 	describe( 'HAPPYCHAT_SEND_USER_INFO action', () => {
 		const state = {
 			happychat: {
-				geoLocation: {
-					city: 'Timisoara',
+				user: {
+					geoLocation: {
+						city: 'Timisoara',
+					},
 				},
 			},
 		};
@@ -140,7 +142,7 @@ describe( 'middleware', () => {
 					height: 'windowInnerHeight',
 				},
 				userAgent: 'navigatorUserAgent',
-				geoLocation: state.happychat.geoLocation,
+				geoLocation: state.happychat.user.geoLocation,
 			};
 
 			const getState = () => state;

--- a/client/state/happychat/test/reducer.js
+++ b/client/state/happychat/test/reducer.js
@@ -8,7 +8,7 @@ import { expect } from 'chai';
 /**
  * Internal dependencies
  */
-import { lastActivityTimestamp, lostFocusAt, message, geoLocation } from '../reducer';
+import { lastActivityTimestamp, lostFocusAt, message } from '../reducer';
 import {
 	HAPPYCHAT_RECEIVE_EVENT,
 	HAPPYCHAT_BLUR,
@@ -16,8 +16,6 @@ import {
 	HAPPYCHAT_SEND_MESSAGE,
 	HAPPYCHAT_SET_MESSAGE,
 	SERIALIZE,
-	DESERIALIZE,
-	HAPPYCHAT_CONNECTED,
 } from 'state/action-types';
 import { useSandbox } from 'test/helpers/use-sinon';
 
@@ -82,39 +80,6 @@ describe( 'reducers', () => {
 			const action = { type: HAPPYCHAT_SEND_MESSAGE, message: 'abcd' };
 			const result = message( 'abcd', action );
 			expect( result ).to.eql( '' );
-		} );
-	} );
-
-	describe( '#geoLocation()', () => {
-		test( 'should default to null', () => {
-			const state = geoLocation( undefined, {} );
-
-			expect( state ).to.be.null;
-		} );
-
-		test( 'should set the current user geolocation', () => {
-			const state = geoLocation( null, {
-				type: HAPPYCHAT_CONNECTED,
-				user: {
-					geo_location: {
-						country_long: 'Romania',
-						city: 'Timisoara',
-					},
-				},
-			} );
-
-			expect( state ).to.eql( { country_long: 'Romania', city: 'Timisoara' } );
-		} );
-
-		test( 'returns valid geolocation', () => {
-			const state = geoLocation(
-				{ country_long: 'Romania', city: 'Timisoara' },
-				{
-					type: DESERIALIZE,
-				}
-			);
-
-			expect( state ).to.eql( { country_long: 'Romania', city: 'Timisoara' } );
 		} );
 	} );
 } );

--- a/client/state/happychat/test/selectors.js
+++ b/client/state/happychat/test/selectors.js
@@ -26,7 +26,6 @@ import {
 	hasActiveHappychatSession,
 	isHappychatAvailable,
 	wasHappychatRecentlyActive,
-	getGeoLocation,
 	getGroups,
 } from '../selectors';
 import { isEnabled } from 'config';
@@ -251,27 +250,6 @@ describe( 'selectors', () => {
 				},
 			} );
 			expect( isHappychatAvailable( state ) ).to.be.true;
-		} );
-	} );
-
-	describe( 'getGeoLocation', () => {
-		test( 'should return null if geoLocation is not set', () => {
-			const selected = getGeoLocation( {
-				happychat: {
-					geoLocation: null,
-				},
-			} );
-			expect( selected ).to.equal( null );
-		} );
-		test( 'should return value if geoLocation is set', () => {
-			const selected = getGeoLocation( {
-				happychat: {
-					geoLocation: {
-						city: 'Timisoara',
-					},
-				},
-			} );
-			expect( selected.city ).to.equal( 'Timisoara' );
 		} );
 	} );
 

--- a/client/state/happychat/user/reducer.js
+++ b/client/state/happychat/user/reducer.js
@@ -1,0 +1,31 @@
+/** @format */
+/**
+ * Internal dependencies
+ */
+import { HAPPYCHAT_CONNECTED } from 'state/action-types';
+import { combineReducers, createReducer } from 'state/utils';
+import { geoLocationSchema } from './schema';
+
+/**
+ * Tracks the current user geo location.
+ *
+ *
+ * @format
+ * @param {Object} action Action payload
+ * @return {Object}        Updated state
+ */
+export const geoLocation = createReducer(
+	null,
+	{
+		[ HAPPYCHAT_CONNECTED ]: ( state, action ) => {
+			const { user: { geo_location } } = action;
+			if ( geo_location && geo_location.country_long && geo_location.city ) {
+				return geo_location;
+			}
+			return state;
+		},
+	},
+	geoLocationSchema
+);
+
+export default combineReducers( { geoLocation } );

--- a/client/state/happychat/user/schema.js
+++ b/client/state/happychat/user/schema.js
@@ -1,0 +1,11 @@
+/** @format */
+
+export const geoLocationSchema = {
+	type: [ 'object', 'null' ],
+	properties: {
+		city: { type: 'string' },
+		country_long: { type: 'string' },
+		country_short: { type: 'string' },
+		region: { type: 'string' },
+	},
+};

--- a/client/state/happychat/user/test/reducer.js
+++ b/client/state/happychat/user/test/reducer.js
@@ -1,0 +1,45 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { HAPPYCHAT_CONNECTED, DESERIALIZE } from 'state/action-types';
+import { geoLocation } from '../reducer';
+
+describe( '#geoLocation()', () => {
+	test( 'should default to null', () => {
+		const state = geoLocation( undefined, {} );
+
+		expect( state ).to.be.null;
+	} );
+
+	test( 'should set the current user geolocation', () => {
+		const state = geoLocation( null, {
+			type: HAPPYCHAT_CONNECTED,
+			user: {
+				geo_location: {
+					country_long: 'Romania',
+					city: 'Timisoara',
+				},
+			},
+		} );
+
+		expect( state ).to.eql( { country_long: 'Romania', city: 'Timisoara' } );
+	} );
+
+	test( 'returns valid geolocation', () => {
+		const state = geoLocation(
+			{ country_long: 'Romania', city: 'Timisoara' },
+			{
+				type: DESERIALIZE,
+			}
+		);
+
+		expect( state ).to.eql( { country_long: 'Romania', city: 'Timisoara' } );
+	} );
+} );

--- a/client/state/happychat/user/test/reducer.js
+++ b/client/state/happychat/user/test/reducer.js
@@ -32,7 +32,7 @@ describe( '#geoLocation()', () => {
 		expect( state ).to.eql( { country_long: 'Romania', city: 'Timisoara' } );
 	} );
 
-	test( 'returns valid geolocation', () => {
+	test( 'deserializes correctly', () => {
 		const state = geoLocation(
 			{ country_long: 'Romania', city: 'Timisoara' },
 			{


### PR DESCRIPTION
Master issue: #18670

Previous work to change the Happychat state shape (#18638) was divided into pieces to help in their review. This PR addresses the changes related to `happychat.user` key. 

### Test

`npm run test-client happychat`

Manually test that happychat works as expected (open a session with an operator, reconnecting after going offline, etc).

