### PR TITLE
Atomic Store: add 'is_store_signup' flag to Business Plan cart item

### DIFF
--- a/client/signup/steps/plans-atomic-store/index.jsx
+++ b/client/signup/steps/plans-atomic-store/index.jsx
@@ -50,7 +50,7 @@ class PlansAtomicStoreStep extends Component {
 				stepName,
 				goToNextStep,
 				translate,
-				signupDependencies: { domainItem },
+				signupDependencies: { designType, domainItem },
 			} = this.props,
 			privacyItem =
 				cartItem && domainItem && cartItems.domainPrivacyProtection( { domain: domainItem.meta } );
@@ -61,6 +61,15 @@ class PlansAtomicStoreStep extends Component {
 				free_trial: cartItem.free_trial,
 				from_section: stepSectionName ? stepSectionName : 'default',
 			} );
+
+			// If we're inside the store signup flow and the cart item is a Business Plan,
+			// set a flag on it. It will trigger Automated Transfer when the product is being
+			// activated at the end of the checkout process.
+			if ( designType === 'store' && cartItem.product_slug === PLAN_BUSINESS ) {
+				cartItem.extra = Object.assign( cartItem.extra || {}, {
+					is_store_signup: true,
+				} );
+			}
 		} else {
 			analytics.tracks.recordEvent( 'calypso_signup_free_plan_select', {
 				from_section: stepSectionName ? stepSectionName : 'default',


### PR DESCRIPTION
When adding a Business Plan to cart as part of the Atomic Store flow, it should be flagged. The backend will check the flag and start an AT for the site during the product activation after checkout.

**How to test that the flag is added when it should:**
1. Go to `/start/atomic-store` in Calypso, select "Online Store" as site type, and proceed all the way to checkout.
2. Before doing the actual purchase (i.e., clicking on the "Pay $299 in credits" button), start monitoring REST API calls in devtools Network tab.
3. Watch out for the `POST /rest/v1.1/me/transactions` request and check its parameters.
4. The Business Plan item in the cart should have a `is_store_signup` flag:

<img width="954" alt="checkout-signup-flag" src="https://user-images.githubusercontent.com/664258/31442680-6f917ee2-ae97-11e7-8572-8345f510eb02.png">

**How to test that the flag is not added when it shouldn't:**
1. Select any type other than Store in the `atomic-store` flow above. E.g., blog or portfolio. Verify that the flag is not added in this case, no matter which plan you choose (Business, Premium, ...)
2. Signup using any flow other than `atomic-store`. The flag shouldn't be added.
