### PR TITLE
Jetpack Connect: Fix Happychat for logged out users

### DIFF
--- a/client/jetpack-connect/happychat-button.jsx
+++ b/client/jetpack-connect/happychat-button.jsx
@@ -15,15 +15,17 @@ import { localize } from 'i18n-calypso';
 import HappychatButton from 'components/happychat/button';
 import HappychatConnection from 'components/happychat/connection';
 import { isEnabled } from 'config';
+import { getCurrentUserId } from 'state/current-user/selectors';
 import { hasActiveHappychatSession, isHappychatAvailable } from 'state/happychat/selectors';
 
 const JetpackConnectHappychatButton = ( {
 	children,
 	isChatActive,
 	isChatAvailable,
+	isLoggedIn,
 	translate,
 } ) => {
-	if ( ! isEnabled( 'jetpack/happychat' ) ) {
+	if ( ! isEnabled( 'jetpack/happychat' ) || ! isLoggedIn ) {
 		return <div>{ children }</div>;
 	}
 
@@ -50,4 +52,5 @@ const JetpackConnectHappychatButton = ( {
 export default connect( state => ( {
 	isChatAvailable: isHappychatAvailable( state ),
 	isChatActive: hasActiveHappychatSession( state ),
+	isLoggedIn: Boolean( getCurrentUserId( state ) ),
 } ) )( localize( JetpackConnectHappychatButton ) );


### PR DESCRIPTION
This PR fixes a bad bug where for logged out users the `<HappychatConnection />` component breaks Jetpack Connect 😱 .

Seems like for logged in users we shouldn't be calling that component at all. This is what this PR does essentially.

To test:
* Checkout this branch
* Log out or open a new incognito session
* Go to http://calypso.localhost:3000/jetpack/connect
* Verify you can see the old buttons and no errors.
* Log in.
* Go to http://calypso.localhost:3000/jetpack/connect
* Make yourself available as an operator in HC.
* Verify you can see the new Happychat button.