### PR TITLE
Add e2e attributes to the editor for e2e tests

### DIFF
--- a/client/blocks/image-editor/image-editor-buttons.jsx
+++ b/client/blocks/image-editor/image-editor-buttons.jsx
@@ -46,7 +46,11 @@ class ImageEditorButtons extends Component {
 		return (
 			<div className="image-editor__buttons">
 				{ onCancel && (
-					<Button className="image-editor__buttons-button" onClick={ onCancel }>
+					<Button
+						className="image-editor__buttons-button"
+						onClick={ onCancel }
+						data-e2e-button="cancel"
+					>
 						{ translate( 'Cancel' ) }
 					</Button>
 				) }
@@ -54,6 +58,7 @@ class ImageEditorButtons extends Component {
 					className="image-editor__buttons-button"
 					disabled={ ! hasChanges }
 					onClick={ onReset }
+					data-e2e-button="reset"
 				>
 					{ translate( 'Reset' ) }
 				</Button>
@@ -62,6 +67,7 @@ class ImageEditorButtons extends Component {
 					disabled={ ! src }
 					primary
 					onClick={ onDone }
+					data-e2e-button="done"
 				>
 					{ doneButtonText || translate( ' Done ' ) }
 				</Button>

--- a/client/post-editor/editor-drawer/page-options.jsx
+++ b/client/post-editor/editor-drawer/page-options.jsx
@@ -30,7 +30,7 @@ function EditorDrawerPageOptions( { translate, postType, hierarchical } ) {
 	}
 
 	return (
-		<Accordion title={ title } e2etitle="page-options">
+		<Accordion title={ title } e2eTitle="page-options">
 			{ hierarchical && <PageParent /> }
 			<PageTemplates />
 			<PageOrder />

--- a/client/post-editor/media-modal/secondary-actions.jsx
+++ b/client/post-editor/media-modal/secondary-actions.jsx
@@ -91,6 +91,7 @@ class MediaModalSecondaryActions extends Component {
 				{ this.getButtons().map( button => (
 					<Button
 						className={ classNames( 'editor-media-modal__secondary-action', button.className ) }
+						data-e2e-button={ button.key }
 						icon={ !! button.icon }
 						compact
 						{ ...pick( button, [ 'key', 'disabled', 'onClick', 'primary' ] ) }


### PR DESCRIPTION
This PR adds data attributes to several places in the editor for use in e2e tests:

- The "Page Attributes" accordion section in the page editor (https://wordpress.com/page)
- The media library modal "Edit" and "Delete" buttons for media items
- The image editor "Cancel," "Reset," and "Done" buttons

To test, check each of those sections to confirm that the appropriate e2e data attribute has been added.