### PR TITLE
Store Orders: Add `isOrderFailed` helper for checking order status

### DIFF
--- a/client/extensions/woocommerce/app/order/order-payment/dialog.js
+++ b/client/extensions/woocommerce/app/order/order-payment/dialog.js
@@ -24,7 +24,6 @@ import FormLabel from 'components/forms/form-label';
 import FormTextarea from 'components/forms/form-textarea';
 import { getOrderRefundTotal } from 'woocommerce/lib/order-values';
 import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
-import { isOrderFailed } from 'woocommerce/lib/order-status';
 import Notice from 'components/notice';
 import OrderRefundTable from './table';
 import PriceInput from 'woocommerce/components/price-input';
@@ -157,10 +156,6 @@ class OrderPaymentCard extends Component {
 		const { isPaymentLoading, order, isVisible, translate } = this.props;
 		const { errorMessage, refundNote } = this.state;
 		const dialogClass = 'woocommerce'; // eslint/css specificity hack
-
-		if ( isOrderFailed( order.status ) ) {
-			return null;
-		}
 
 		let refundTotal = formatCurrency( 0, order.currency );
 		if ( this.state.refundTotal ) {

--- a/client/extensions/woocommerce/app/order/order-payment/dialog.js
+++ b/client/extensions/woocommerce/app/order/order-payment/dialog.js
@@ -24,6 +24,7 @@ import FormLabel from 'components/forms/form-label';
 import FormTextarea from 'components/forms/form-textarea';
 import { getOrderRefundTotal } from 'woocommerce/lib/order-values';
 import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
+import { isOrderFailed } from 'woocommerce/lib/order-status';
 import Notice from 'components/notice';
 import OrderRefundTable from './table';
 import PriceInput from 'woocommerce/components/price-input';
@@ -157,7 +158,7 @@ class OrderPaymentCard extends Component {
 		const { errorMessage, refundNote } = this.state;
 		const dialogClass = 'woocommerce'; // eslint/css specificity hack
 
-		if ( 'cancelled' === order.status || 'failed' === order.status ) {
+		if ( isOrderFailed( order.status ) ) {
 			return null;
 		}
 

--- a/client/extensions/woocommerce/app/order/order-payment/dialog.js
+++ b/client/extensions/woocommerce/app/order/order-payment/dialog.js
@@ -29,7 +29,7 @@ import OrderRefundTable from './table';
 import PriceInput from 'woocommerce/components/price-input';
 import { sendRefund } from 'woocommerce/state/sites/orders/refunds/actions';
 
-class OrderPaymentCard extends Component {
+class RefundDialog extends Component {
 	static propTypes = {
 		isPaymentLoading: PropTypes.bool,
 		fetchPaymentMethods: PropTypes.func.isRequired,
@@ -228,4 +228,4 @@ export default connect(
 		};
 	},
 	dispatch => bindActionCreators( { fetchPaymentMethods, sendRefund }, dispatch )
-)( localize( OrderPaymentCard ) );
+)( localize( RefundDialog ) );

--- a/client/extensions/woocommerce/app/order/order-payment/index.js
+++ b/client/extensions/woocommerce/app/order/order-payment/index.js
@@ -15,7 +15,7 @@ import { localize } from 'i18n-calypso';
 import Button from 'components/button';
 import formatCurrency from 'lib/format-currency';
 import { getOrderRefundTotal } from 'woocommerce/lib/order-values';
-import { isOrderWaitingPayment } from 'woocommerce/lib/order-status';
+import { isOrderFailed, isOrderWaitingPayment } from 'woocommerce/lib/order-status';
 import RefundDialog from './dialog';
 import { updateOrder } from 'woocommerce/state/sites/orders/actions';
 
@@ -98,7 +98,7 @@ class OrderPaymentCard extends Component {
 	render() {
 		const { order } = this.props;
 
-		if ( 'cancelled' === order.status || 'failed' === order.status ) {
+		if ( isOrderFailed( order.status ) ) {
 			return null;
 		}
 

--- a/client/extensions/woocommerce/lib/order-status/index.js
+++ b/client/extensions/woocommerce/lib/order-status/index.js
@@ -22,6 +22,7 @@ export const statusEditable = [ 'on-hold', 'pending' ];
 export const statusWaitingPayment = [ 'on-hold', 'pending' ];
 export const statusWaitingFulfillment = [ 'processing' ];
 export const statusFinished = [ 'cancelled', 'completed', 'failed', 'refunded' ];
+export const statusFailed = [ 'cancelled', 'failed' ];
 
 /**
  * Get a list of order statuses for display (including a translated label)
@@ -99,4 +100,14 @@ export function isOrderWaitingFulfillment( status ) {
  */
 export function isOrderFinished( status ) {
 	return -1 !== statusFinished.indexOf( status );
+}
+
+/**
+ * Checks if this status (from an order) is in the "failed" group
+ *
+ * @param {String} status Order status
+ * @return {Boolean} true if the status is cancelled or failed– not a successful order
+ */
+export function isOrderFailed( status ) {
+	return -1 !== statusFailed.indexOf( status );
 }

--- a/client/extensions/woocommerce/lib/order-status/test/index.js
+++ b/client/extensions/woocommerce/lib/order-status/test/index.js
@@ -12,6 +12,7 @@ import {
 	isOrderWaitingPayment,
 	isOrderWaitingFulfillment,
 	isOrderFinished,
+	isOrderFailed,
 } from '../index';
 
 describe( 'isOrderEditable', () => {
@@ -115,5 +116,31 @@ describe( 'isOrderFinished', () => {
 
 	test( 'should be false for a fake order status', () => {
 		expect( isOrderFinished( 'fake' ) ).to.be.false;
+	} );
+} );
+
+describe( 'isOrderFailed', () => {
+	it( 'should be false for a pending order', () => {
+		expect( isOrderFailed( 'pending' ) ).to.be.false;
+	} );
+
+	it( 'should be false for an on-hold order', () => {
+		expect( isOrderFailed( 'on-hold' ) ).to.be.false;
+	} );
+
+	it( 'should be false for a processing order', () => {
+		expect( isOrderFailed( 'processing' ) ).to.be.false;
+	} );
+
+	it( 'should be false for a completed order', () => {
+		expect( isOrderFailed( 'completed' ) ).to.be.false;
+	} );
+
+	it( 'should be true for a failed order', () => {
+		expect( isOrderFailed( 'failed' ) ).to.be.true;
+	} );
+
+	it( 'should be false for a fake order status', () => {
+		expect( isOrderFailed( 'fake' ) ).to.be.false;
 	} );
 } );


### PR DESCRIPTION
This PR adds `isOrderFailed` (and tests), which checks if an order is `cancelled` or `failed` (WC core statuses). In these cases we don't show the order payment card or offer refunding.

This also removes a redundant check from `order-payment/dialog`: this component isn't rendered unless the order is not failed, so we don't need to check again.

**To test**

- Run the tests: `npm run test-client client/extensions/woocommerce/lib/order-status`
- View a few orders of different statuses -- awaiting payment (pending), awaiting fulfillment (processing), completed, or cancelled, etc
- You should see the payment card on all but the cancelled or failed orders. 