### PR TITLE
Store Order: Use `isOrderFinished` in fulfillment card

### DIFF
--- a/client/extensions/woocommerce/app/order/order-fulfillment/index.js
+++ b/client/extensions/woocommerce/app/order/order-fulfillment/index.js
@@ -20,6 +20,7 @@ import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
 import FormInputCheckbox from 'components/forms/form-checkbox';
 import FormTextInput from 'components/forms/form-text-input';
+import { isOrderFinished } from 'woocommerce/lib/order-status';
 import Notice from 'components/notice';
 import { updateOrder } from 'woocommerce/state/sites/orders/actions';
 
@@ -39,10 +40,6 @@ class OrderFulfillment extends Component {
 		shouldEmail: false,
 		showDialog: false,
 		trackingNumber: '',
-	};
-
-	isShippable = order => {
-		return -1 === [ 'completed', 'failed', 'cancelled', 'refunded' ].indexOf( order.status );
 	};
 
 	toggleDialog = () => {
@@ -134,7 +131,7 @@ class OrderFulfillment extends Component {
 					{ this.getFulfillmentStatus() }
 				</div>
 				<div className="order-fulfillment__action">
-					{ this.isShippable( order ) ? (
+					{ ! isOrderFinished( order.status ) ? (
 						<Button primary onClick={ this.toggleDialog }>
 							{ translate( 'Fulfill' ) }
 						</Button>


### PR DESCRIPTION
Rather than hardcoding order statuses, this PR switches the order fulfillment card to use `isOrderFinished` to determine whether to display the "Fulfill" button.

**To test:**

- View an order
- If the order is awaiting payment or awaiting fulfillment, it should show the Fulfill button
- If the order is completed, cancelled, failed or refunded (all "completed" statuses in the filter bar), there should be no Fulfill button.

_Note: there should be no functionality change from production_