### PR TITLE
Jetpack Connect: Factor authorization form header into own component

### DIFF
--- a/client/jetpack-connect/auth-form-header.jsx
+++ b/client/jetpack-connect/auth-form-header.jsx
@@ -1,0 +1,96 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { getAuthorizationData, isRemoteSiteOnSitesList } from 'state/jetpack-connect/selectors';
+import { getCurrentUser } from 'state/current-user/selectors';
+import FormattedHeader from 'components/formatted-header';
+import SiteCard from './site-card';
+import versionCompare from 'lib/version-compare';
+
+class AuthFormHeader extends Component {
+	getState() {
+		const { user, authorize } = this.props;
+
+		if ( ! user ) {
+			return 'logged-out';
+		}
+
+		if ( authorize.authorizeSuccess ) {
+			return 'logged-in-success';
+		}
+
+		return 'logged-in';
+	}
+
+	getHeaderText() {
+		const { translate } = this.props;
+
+		switch ( this.getState() ) {
+			case 'logged-out':
+				return translate( 'Create your account' );
+			case 'logged-in-success':
+				return translate( 'You are connected!' );
+			case 'logged-in':
+			default:
+				return translate( 'Completing connection' );
+		}
+	}
+
+	getSubHeaderText() {
+		const { translate } = this.props;
+
+		switch ( this.getState() ) {
+			case 'logged-out':
+				return translate( 'You are moments away from connecting your site.' );
+			case 'logged-in-success':
+				return translate( 'Thank you for flying with Jetpack' );
+			case 'logged-in':
+			default:
+				return translate( 'Jetpack is finishing up the connection process' );
+		}
+	}
+
+	getSiteCard() {
+		const version = get( this.props, [ 'authorize', 'queryObject', 'jp_version' ], '0.1' );
+		if ( ! versionCompare( version, '4.0.3', '>' ) ) {
+			return null;
+		}
+
+		return (
+			<SiteCard
+				queryObject={ get( this.props, [ 'authorize', 'queryObject' ], {} ) }
+				isAlreadyOnSitesList={ !! this.props.isAlreadyOnSitesList }
+			/>
+		);
+	}
+
+	render() {
+		return (
+			<div>
+				<FormattedHeader
+					headerText={ this.getHeaderText() }
+					subHeaderText={ this.getSubHeaderText() }
+				/>
+				{ this.getSiteCard() }
+			</div>
+		);
+	}
+}
+
+export default connect( state => {
+	const authorize = getAuthorizationData( state );
+	return {
+		authorize,
+		user: getCurrentUser( state ),
+		isAlreadyOnSitesList: isRemoteSiteOnSitesList( state ),
+	};
+} )( localize( AuthFormHeader ) );

--- a/client/jetpack-connect/auth-logged-in-form.jsx
+++ b/client/jetpack-connect/auth-logged-in-form.jsx
@@ -27,14 +27,12 @@ import LoggedOutFormLinkItem from 'components/logged-out-form/link-item';
 import LoggedOutFormLinks from 'components/logged-out-form/links';
 import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
-import SiteCard from './site-card';
 import Spinner from 'components/spinner';
-import FormattedHeader from 'components/formatted-header';
 import userUtilities from 'lib/user/utils';
-import versionCompare from 'lib/version-compare';
 import { decodeEntities } from 'lib/formatting';
 import { externalRedirect } from 'lib/route/path';
 import { login } from 'lib/paths';
+import AuthFormHeader from './auth-form-header';
 
 /**
  * Constants
@@ -133,27 +131,6 @@ class LoggedInForm extends Component {
 			this.retryingAuth = true;
 			return this.props.retryAuth( queryObject.site, attempts + 1 );
 		}
-	}
-
-	renderFormHeader( isConnected ) {
-		const { translate, isAlreadyOnSitesList } = this.props;
-		const { queryObject } = this.props.jetpackConnectAuthorize;
-		const headerText = isConnected
-			? translate( 'You are connected!' )
-			: translate( 'Completing connection' );
-		const subHeaderText = isConnected
-			? translate( 'Thank you for flying with Jetpack' )
-			: translate( 'Jetpack is finishing up the connection process' );
-		const siteCard = versionCompare( queryObject.jp_version, '4.0.3', '>' ) ? (
-			<SiteCard queryObject={ queryObject } isAlreadyOnSitesList={ isAlreadyOnSitesList } />
-		) : null;
-
-		return (
-			<div>
-				<FormattedHeader headerText={ headerText } subHeaderText={ subHeaderText } />
-				{ siteCard }
-			</div>
-		);
 	}
 
 	redirect() {
@@ -540,10 +517,9 @@ class LoggedInForm extends Component {
 	}
 
 	render() {
-		const { authorizeSuccess } = this.props.jetpackConnectAuthorize;
 		return (
 			<div className="jetpack-connect__logged-in-form">
-				{ this.renderFormHeader( authorizeSuccess ) }
+				<AuthFormHeader />
 				<Card>
 					<Gravatar user={ this.props.user } size={ 64 } />
 					<p className="jetpack-connect__logged-in-form-user-text">{ this.getUserText() }</p>

--- a/client/jetpack-connect/auth-logged-out-form.jsx
+++ b/client/jetpack-connect/auth-logged-out-form.jsx
@@ -20,9 +20,7 @@ import addQueryArgs from 'lib/route/add-query-args';
 import LocaleSuggestions from 'components/locale-suggestions';
 import SignupForm from 'components/signup-form';
 import WpcomLoginForm from 'signup/wpcom-login-form';
-import versionCompare from 'lib/version-compare';
-import FormattedHeader from 'components/formatted-header';
-import SiteCard from './site-card';
+import AuthFormHeader from './auth-form-header';
 
 const debug = debugModule( 'calypso:jetpack-connect:authorize-form' );
 
@@ -71,23 +69,6 @@ class LoggedOutForm extends Component {
 		);
 	}
 
-	renderFormHeader() {
-		const { translate, isAlreadyOnSitesList } = this.props;
-		const headerText = translate( 'Create your account' );
-		const subHeaderText = translate( 'You are moments away from connecting your site.' );
-		const { queryObject } = this.props.jetpackConnectAuthorize;
-		const siteCard = versionCompare( queryObject.jp_version, '4.0.3', '>' ) ? (
-			<SiteCard queryObject={ queryObject } isAlreadyOnSitesList={ isAlreadyOnSitesList } />
-		) : null;
-
-		return (
-			<div>
-				<FormattedHeader headerText={ headerText } subHeaderText={ subHeaderText } />
-				{ siteCard }
-			</div>
-		);
-	}
-
 	renderLocaleSuggestions() {
 		return this.props.locale ? (
 			<LocaleSuggestions path={ this.props.path } locale={ this.props.locale } />
@@ -120,7 +101,7 @@ class LoggedOutForm extends Component {
 		return (
 			<div>
 				{ this.renderLocaleSuggestions() }
-				{ this.renderFormHeader() }
+				<AuthFormHeader />
 				<SignupForm
 					redirectToAfterLoginUrl={ this.getRedirectAfterLoginUrl() }
 					disabled={ isAuthorizing }


### PR DESCRIPTION
In preparation to co-brand JPC, where we will likely do something similar to this:

<img width="450" alt="screen shot 2017-10-10 at 4 30 52 pm" src="https://user-images.githubusercontent.com/1126811/31452062-77ab90a0-ae73-11e7-8421-03ab2ce13daa.png">

I wanted to get rid of some duplication of the form header logic between the logged in and logged out authorization form header.

This PR adds the `AuthFormHeader` component which now holds the logic for displaying the form header. This removes some duplication and will also make it a bit easier to handle the cobranding the JPC flow for our hosting partners.

To test:

- Checkout PR
- Disconnect and then connect a site
- Grab the URL before it is rewritten and replace `wordpress.com` with `calypso.localhost:3000`
- Ensure you can connect both logged in and logged out
- When logged in, ensure that the wording updates after authorization is finished
