### PR TITLE
Stats: adds a property `last_pageview_path` to the Tracks page view event

### DIFF
--- a/client/lib/analytics/index.js
+++ b/client/lib/analytics/index.js
@@ -237,14 +237,15 @@ const analytics = {
 
 	// pageView is a wrapper for pageview events across Tracks and GA
 	pageView: {
-		record: function( urlPath, pageTitle, params ) {
+		record: function( urlPath, pageTitle, params = {} ) {
 			// add delay to avoid stale `_dl` in recorded calypso_page_view event details
 			// `_dl` (browserdocumentlocation) is read from the current URL by external JavaScript
 			setTimeout( () => {
-				mostRecentUrlPath = urlPath;
+				params.last_pageview_path = mostRecentUrlPath;
 				analytics.tracks.recordPageView( urlPath, params );
 				analytics.ga.recordPageView( urlPath, pageTitle );
 				analytics.emit( 'page-view', urlPath, pageTitle );
+				mostRecentUrlPath = urlPath;
 			}, 0 );
 		},
 	},


### PR DESCRIPTION
When a page is loaded, the Tracks event `calypso_page_view` is created. With each successive page view, let's track the previous page view path so we can more easily look at user behavior on Calypso.

## Example:

User clicks on the following sequence of pages:

- /
- /stats/day/:site
- /settings/general/:site

We want to have three `calypso_page_views` with the following properties:

- { path: "/", last_pageview_path: null }
- { path: "/stats/day/:site", last_pageview_path: "/" }
- { path: "/settings/general/:site", last_pageview_path: "/stats/day/:site" }
