### PR TITLE
Blocks: De-dupe disconnectJetpack() method

### DIFF
--- a/client/blocks/disconnect-jetpack-dialog/docs/example.jsx
+++ b/client/blocks/disconnect-jetpack-dialog/docs/example.jsx
@@ -48,9 +48,6 @@ class DisconnectJetpackDialogExample extends Component {
 					isVisible={ this.state.isVisible.free }
 					siteId={ this.props.primarySiteId }
 					onClose={ this.toggleVisibilityFree }
-					onDisconnect={ this.toggleVisibilityFree }
-					siteName="example.com"
-					plan="free"
 				/>
 
 				<p>
@@ -60,9 +57,6 @@ class DisconnectJetpackDialogExample extends Component {
 					isVisible={ this.state.isVisible.personal }
 					siteId={ this.props.primarySiteId }
 					onClose={ this.toggleVisibilityPersonal }
-					onDisconnect={ this.toggleVisibilityPersonal }
-					siteName="example.com"
-					plan="personal"
 				/>
 
 				<p>
@@ -72,9 +66,6 @@ class DisconnectJetpackDialogExample extends Component {
 					isVisible={ this.state.isVisible.premium }
 					siteId={ this.props.primarySiteId }
 					onClose={ this.toggleVisibilityPremium }
-					onDisconnect={ this.toggleVisibilityPremium }
-					siteName="example.com"
-					plan="premium"
 				/>
 
 				<p>
@@ -86,9 +77,6 @@ class DisconnectJetpackDialogExample extends Component {
 					isVisible={ this.state.isVisible.professional }
 					siteId={ this.props.primarySiteId }
 					onClose={ this.toggleVisibilityProfessional }
-					onDisconnect={ this.toggleVisibilityProfessional }
-					siteName="example.com"
-					plan="professional"
 				/>
 
 				<p>
@@ -100,9 +88,6 @@ class DisconnectJetpackDialogExample extends Component {
 					isVisible={ this.state.isVisible.broken }
 					siteId={ this.props.primarySiteId }
 					onClose={ this.toggleVisibilityBroken }
-					onDisconnect={ this.toggleVisibilityBroken }
-					siteName="example.com"
-					plan="personal"
 					isBroken={ true }
 				/>
 			</Card>

--- a/client/blocks/disconnect-jetpack-dialog/index.jsx
+++ b/client/blocks/disconnect-jetpack-dialog/index.jsx
@@ -157,7 +157,7 @@ class DisconnectJetpackDialog extends PureComponent {
 			() => {
 				// Removing the domain from a domain-only site results
 				// in the site being deleted entirely. We need to call
-				// `receiveDeletedSiteDeprecated` here because the site
+				// `disconnectedSiteDeprecated` here because the site
 				// exists in `sites-list` as well as the global store.
 				disconnectedSiteDeprecated( site );
 				this.props.setAllSitesSelected();

--- a/client/my-sites/plugins/disconnect-jetpack/disconnect-jetpack-button.jsx
+++ b/client/my-sites/plugins/disconnect-jetpack/disconnect-jetpack-button.jsx
@@ -5,9 +5,7 @@
  */
 
 import React, { Component } from 'react';
-import { connect } from 'react-redux';
 import { pick } from 'lodash';
-import page from 'page';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 
@@ -16,13 +14,6 @@ import PropTypes from 'prop-types';
  */
 import Button from 'components/button';
 import DisconnectJetpackDialog from 'blocks/disconnect-jetpack-dialog';
-import { recordGoogleEvent } from 'state/analytics/actions';
-import { disconnect } from 'state/jetpack/connection/actions';
-import { disconnectedSite as disconnectedSiteDeprecated } from 'lib/sites-list/actions';
-import { setAllSitesSelected } from 'state/ui/actions';
-import { getCurrentPlan } from 'state/sites/plans/selectors';
-import { getPlanClass } from 'lib/plans/constants';
-import { successNotice, errorNotice, infoNotice, removeNotice } from 'state/notices/actions';
 import QuerySitePlans from 'components/data/query-site-plans';
 
 class DisconnectJetpackButton extends Component {
@@ -48,54 +39,8 @@ class DisconnectJetpackButton extends Component {
 		recordGAEvent( 'Jetpack', 'Clicked To Cancel Disconnect Jetpack Dialog' );
 	};
 
-	disconnectJetpack = () => {
-		const {
-			site,
-			translate,
-			successNotice: showSuccessNotice,
-			errorNotice: showErrorNotice,
-			infoNotice: showInfoNotice,
-			removeNotice: removeInfoNotice,
-			disconnect: disconnectSite,
-			recordGoogleEvent: recordGAEvent,
-		} = this.props;
-
-		this.setState( { dialogVisible: false } );
-		recordGAEvent( 'Jetpack', 'Clicked To Confirm Disconnect Jetpack Dialog' );
-
-		const { notice } = showInfoNotice(
-			translate( 'Disconnecting %(siteName)s.', { args: { siteName: site.title } } ),
-			{ isPersistent: true, showDismiss: false }
-		);
-
-		disconnectSite( site.ID ).then(
-			() => {
-				// Removing the domain from a domain-only site results
-				// in the site being deleted entirely. We need to call
-				// `receiveDeletedSiteDeprecated` here because the site
-				// exists in `sites-list` as well as the global store.
-				disconnectedSiteDeprecated( site );
-				this.props.setAllSitesSelected();
-				removeInfoNotice( notice.noticeId );
-				showSuccessNotice(
-					translate( 'Successfully disconnected %(siteName)s.', { args: { siteName: site.title } } )
-				);
-				recordGAEvent( 'Jetpack', 'Successfully Disconnected' );
-			},
-			() => {
-				removeInfoNotice( notice.noticeId );
-				showErrorNotice(
-					translate( '%(siteName)s failed to disconnect', { args: { siteName: site.title } } )
-				);
-				recordGAEvent( 'Jetpack', 'Failed Disconnected Site' );
-			}
-		);
-
-		page.redirect( this.props.redirect );
-	};
-
 	render() {
-		const { linkDisplay, planClass, site, text, translate } = this.props;
+		const { linkDisplay, site, text, translate } = this.props;
 		const buttonPropsList = [
 			'borderless',
 			'busy',
@@ -127,11 +72,10 @@ class DisconnectJetpackButton extends Component {
 				<QuerySitePlans siteId={ site.ID } />
 				<DisconnectJetpackDialog
 					isVisible={ this.state.dialogVisible }
-					onDisconnect={ this.disconnectJetpack }
 					onClose={ this.hideDialog }
-					plan={ planClass }
 					isBroken={ false }
-					siteName={ site.slug }
+					siteId={ site.ID }
+					redirect={ this.props.redirect }
 				/>
 			</Button>
 		);
@@ -151,21 +95,4 @@ DisconnectJetpackButton.defaultProps = {
 	linkDisplay: true,
 };
 
-export default connect(
-	( state, ownProps ) => {
-		const plan = getCurrentPlan( state, ownProps.site.ID );
-		const planClass = plan && plan.productSlug ? getPlanClass( plan.productSlug ) : 'is-free-plan';
-		return {
-			planClass,
-		};
-	},
-	{
-		setAllSitesSelected,
-		recordGoogleEvent,
-		disconnect,
-		successNotice,
-		errorNotice,
-		infoNotice,
-		removeNotice,
-	}
-)( localize( DisconnectJetpackButton ) );
+export default localize( DisconnectJetpackButton );

--- a/client/my-sites/site-settings/manage-connection/disconnect-site-link.jsx
+++ b/client/my-sites/site-settings/manage-connection/disconnect-site-link.jsx
@@ -7,7 +7,6 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import page from 'page';
 
 /**
  * Internal dependencies
@@ -15,15 +14,8 @@ import page from 'page';
 import DisconnectJetpackDialog from 'blocks/disconnect-jetpack-dialog';
 import QuerySitePlans from 'components/data/query-site-plans';
 import SiteToolsLink from 'my-sites/site-settings/site-tools/link';
-import { recordGoogleEvent } from 'state/analytics/actions';
-import { disconnect } from 'state/jetpack/connection/actions';
-import { disconnectedSite as disconnectedSiteDeprecated } from 'lib/sites-list/actions';
-import { setAllSitesSelected } from 'state/ui/actions';
-import { getSelectedSite, getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
-import { getCurrentPlan } from 'state/sites/plans/selectors';
-import { getPlanClass } from 'lib/plans/constants';
+import { getSelectedSiteId } from 'state/ui/selectors';
 import { isSiteAutomatedTransfer } from 'state/selectors';
-import { successNotice, errorNotice, infoNotice, removeNotice } from 'state/notices/actions';
 
 class DisconnectSiteLink extends Component {
 	state = {
@@ -44,63 +36,10 @@ class DisconnectSiteLink extends Component {
 		} );
 	};
 
-	disconnectJetpack = () => {
-		const {
-			site,
-			siteId,
-			translate,
-			successNotice: showSuccessNotice,
-			errorNotice: showErrorNotice,
-			infoNotice: showInfoNotice,
-			removeNotice: removeInfoNotice,
-			disconnect: disconnectSite,
-			recordGoogleEvent: recordGAEvent,
-		} = this.props;
-
-		this.setState( {
-			dialogVisible: false,
-		} );
-
-		recordGAEvent( 'Jetpack', 'Clicked To Confirm Disconnect Jetpack Dialog' );
-
-		const { notice } = showInfoNotice(
-			translate( 'Disconnecting %(siteName)s.', { args: { siteName: site.title } } ),
-			{
-				isPersistent: true,
-				showDismiss: false,
-			}
-		);
-
-		disconnectSite( siteId ).then(
-			() => {
-				// Removing the domain from a domain-only site results
-				// in the site being deleted entirely. We need to call
-				// `receiveDeletedSiteDeprecated` here because the site
-				// exists in `sites-list` as well as the global store.
-				disconnectedSiteDeprecated( site );
-				this.props.setAllSitesSelected();
-				removeInfoNotice( notice.noticeId );
-				showSuccessNotice(
-					translate( 'Successfully disconnected %(siteName)s.', { args: { siteName: site.title } } )
-				);
-				recordGAEvent( 'Jetpack', 'Successfully Disconnected' );
-			},
-			() => {
-				removeInfoNotice( notice.noticeId );
-				showErrorNotice(
-					translate( '%(siteName)s failed to disconnect', { args: { siteName: site.title } } )
-				);
-				recordGAEvent( 'Jetpack', 'Failed Disconnected Site' );
-			}
-		);
-
-		page.redirect( '/stats' );
-	};
-
 	render() {
-		const { isAutomatedTransfer, planClass, site, siteId, siteSlug, translate } = this.props;
+		const { isAutomatedTransfer, siteId, translate } = this.props;
 
-		if ( ! site || isAutomatedTransfer ) {
+		if ( ! siteId || isAutomatedTransfer ) {
 			return null;
 		}
 
@@ -120,40 +59,21 @@ class DisconnectSiteLink extends Component {
 
 				<DisconnectJetpackDialog
 					isVisible={ this.state.dialogVisible }
-					onDisconnect={ this.disconnectJetpack }
 					onClose={ this.handleHideDialog }
-					plan={ planClass }
 					isBroken={ false }
-					siteName={ siteSlug }
+					siteId={ siteId }
+					redirect="/stats"
 				/>
 			</div>
 		);
 	}
 }
 
-export default connect(
-	state => {
-		const site = getSelectedSite( state );
-		const siteId = getSelectedSiteId( state );
-		const siteSlug = getSelectedSiteSlug( state );
-		const plan = getCurrentPlan( state, siteId );
-		const planClass = plan && plan.productSlug ? getPlanClass( plan.productSlug ) : 'is-free-plan';
+export default connect( state => {
+	const siteId = getSelectedSiteId( state );
 
-		return {
-			isAutomatedTransfer: isSiteAutomatedTransfer( state, siteId ),
-			planClass,
-			site,
-			siteId,
-			siteSlug,
-		};
-	},
-	{
-		setAllSitesSelected,
-		recordGoogleEvent,
-		disconnect,
-		successNotice,
-		errorNotice,
-		infoNotice,
-		removeNotice,
-	}
-)( localize( DisconnectSiteLink ) );
+	return {
+		isAutomatedTransfer: isSiteAutomatedTransfer( state, siteId ),
+		siteId,
+	};
+} )( localize( DisconnectSiteLink ) );


### PR DESCRIPTION
This removes the duplicated `disconnectJetpack()` method from both 

* `my-sites/site-settings/manage-connection/disconnect-site-link.jsx` and 
* `my-sites/plugins/disconnect-jetpack/disconnect-jetpack-button.jsx`

and moves it to `blocks/disconnect-jetpack-dialog/index.jsx` (which both other files use) instead, where I think it belongs. The immediate rationale is that I'm going to need `blocks/disconnect-jetpack-dialog` for #18039, and I don't want to triplicate that code.

The method in question calls a number of Redux actions, which is something that can easily be solved by adding those to the block's `mapDispatchToProps` call. The little state handling it does (hiding the dialog) can be abstracted by simply invoking the `onClose` prop.

The devdocs example is broken, but it was before -- see https://wpcalypso.wordpress.com/devdocs/blocks/disconnect-jetpack-dialog

To test:
Devdocs aside, the component is used in two places. Verify that it still works in both.

1. `http://calypso.localhost:3000/settings/manage-connection/<JPsite>`

Click on the card at the very bottom:

![image](https://user-images.githubusercontent.com/96308/31471251-3b2258a6-aee8-11e7-87e6-ece683dccf69.png)

2. In siteslist in the sidebar, if you have a “broken” jetpack site, it will let you disconnect from the site there. (For example, rename `jetpack` plugin folder on the site. Thanks @seear for pointing this out to me!)

<img width="273" alt="screen shot 2017-06-23 at 12 41 17" src="https://user-images.githubusercontent.com/7767559/27480757-4ad41862-5811-11e7-8036-64202338667c.png">
