### PR TITLE
Editor: Fix hidden add menu item in dropdown with small viewports

### DIFF
--- a/client/components/tinymce/plugins/insert-menu/style.scss
+++ b/client/components/tinymce/plugins/insert-menu/style.scss
@@ -41,15 +41,11 @@
 
 .mce-container .wpcom-insert-menu__menu-label {
 	color: darken( $gray, 20% );
-	display: none;
+	display: inline-block;
 	font-family: $sans;
 	font-size: 13px;
 	margin-left: 4px;
 	margin-top: 3px;
-
-	@include breakpoint( '>660px' ) {
-		display: inline-block;
-	}
 }
 
 .wpcom-insert-menu__menu-icon {
@@ -71,5 +67,11 @@
 		.wpcom-insert-menu__menu-icon {
 			fill: $blue-medium;
 		}
+	}
+}
+
+.mce-container .mce-wpcom-insert-menu .wpcom-insert-menu__menu-label {
+	@include breakpoint( '<660px' ) {
+		display: none;
 	}
 }


### PR DESCRIPTION
Overlooked in #18719. Only the "add" next to [+] should be hidden, not all of them with small viewports :)

Before:
<img width="223" alt="screen shot 2017-10-12 at 00 34 59" src="https://user-images.githubusercontent.com/908665/31472191-350de668-aee5-11e7-906f-3f8e76e7725b.png">

After:
<img width="223" alt="screen shot 2017-10-12 at 00 29 56" src="https://user-images.githubusercontent.com/908665/31472199-3b1510f4-aee5-11e7-9fd5-fbd2585c90cb.png">
