### PR TITLE
Editor: Don't error out when attempting to decode query arguments in images

### DIFF
--- a/client/lib/post-normalizer/utils.js
+++ b/client/lib/post-normalizer/utils.js
@@ -41,7 +41,15 @@ export function maxWidthPhotonishURL( imageURL, width ) {
 		return imageURL;
 	}
 
-	const parsedURL = url.parse( imageURL, true, true ); // true, true means allow protocol-less hosts and parse the querystring
+	let parsedURL = {};
+	try {
+		parsedURL = url.parse( imageURL, true, true ); // true, true means allow protocol-less hosts and parse the querystring
+	} catch ( e ) {
+		/**
+		 * `url.parse` throws in a few places where it calls decodeURIComponent
+		 * @see e.g. https://github.com/Automattic/wp-calypso/issues/18645
+		 */
+	}
 
 	if ( ! parsedURL.host ) {
 		return imageURL;


### PR DESCRIPTION
`maxWidthPhotonishURL` calls `url.parse` with an argument to parse query strings.

That, in turn, [calls](https://github.com/nodejs/node/blob/v6.x/lib/url.js#L173) `querystring.parse` which calls [`decodeURIComponent`](https://github.com/Gozala/querystring/blob/bc2c26505d145b2c9bdfd555a4d5fb809f12822f/decode.js#L67-L68) which throws on "malformed" character sequences in the query portion of an image's URL.

This change simply wraps the call in a try / catch block and abandons parsing the URL for the sake of `maxWidthPhotonishURL` on an error.

## To Test:

* Create a post with the following: `<img src="https://example.com/path/?%e0%a4%a" />`
* Without this change, you'll see the `Uncaught URIError: URI malformed at decodeURIComponent` error
* With this change, no error should be shown (other than the 404 when the Editor tries to source the image)
* Repeat the above with more portions of 1b9b7-pb (as noted in #18645). The editor should not fatal

NOTE: You may need to drop to wp-admin to remove the query args & re-save the post to be able to load the Calypso Editor again after it errors

Fixes #18645