### PR TITLE
Webpack: fix react-hot-loader configuration

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -145,7 +145,7 @@ const webpackConfig = {
 		new CopyWebpackPlugin( [ { from: 'node_modules/flag-icon-css/flags/4x3', to: 'images/flags' } ] ),
 		new HappyPack( {
 			loaders: _.compact( [
-				process.env.NODE_ENV === 'development' && 'react-hot-loader',
+				calypsoEnv === 'development' && 'react-hot-loader',
 				babelLoader
 			] )
 		} ),


### PR DESCRIPTION
React hot loading is a great feature enabling you to skip the reload after making source code changes.

It was misconfigured and wasn't including the right loader that enables the components to hot-reload themselves. Can't believe how close it was 😂 .

**demo**

![rhl](https://user-images.githubusercontent.com/4656974/31484076-d9e1ba9a-aefc-11e7-8174-8d828987b448.gif)


To Test
------
run this branch locally, make local changes to src, see if you can instantly spot the changes in the browser without a refresh