### PR TITLE
Tests: Use jest-codemods to convert chai assert to expect

### DIFF
--- a/client/blocks/daily-post-button/test/helper.js
+++ b/client/blocks/daily-post-button/test/helper.js
@@ -3,36 +3,31 @@
 /**
  * External dependencies
  */
-import { assert } from 'chai';
-
-/**
- * Internal dependencies
- */
 import * as helper from '../helper';
 import * as posts from './fixtures';
 
 describe( 'daily post helper', () => {
 	describe( 'isDailyPostChallengeOrPrompt', () => {
 		test( 'returns false if the post is not from daily post', () => {
-			assert.isFalse( helper.isDailyPostChallengeOrPrompt( posts.basicPost ) );
+			expect( helper.isDailyPostChallengeOrPrompt( posts.basicPost ) ).toBe( false );
 		} );
 
 		test( 'returns false if the post is from daily post but is not a challenge or prompt', () => {
-			assert.isFalse( helper.isDailyPostChallengeOrPrompt( posts.dailyPostSitePost ) );
+			expect( helper.isDailyPostChallengeOrPrompt( posts.dailyPostSitePost ) ).toBe( false );
 		} );
 	} );
 
 	describe( 'getDailyPostType', () => {
 		test( 'returns "prompt" if the post is a daily prompt', () => {
-			assert.equal( 'prompt', helper.getDailyPostType( posts.dailyPromptPost ) );
+			expect( 'prompt' ).toEqual( helper.getDailyPostType( posts.dailyPromptPost ) );
 		} );
 
 		test( 'returns "photo" if the post is a photo challenge', () => {
-			assert.equal( 'photo', helper.getDailyPostType( posts.photoChallengePost ) );
+			expect( 'photo' ).toEqual( helper.getDailyPostType( posts.photoChallengePost ) );
 		} );
 
 		test( 'returns "discover" if the post is a discover challenge', () => {
-			assert.equal( 'discover', helper.getDailyPostType( posts.discoverChallengePost ) );
+			expect( 'discover' ).toEqual( helper.getDailyPostType( posts.discoverChallengePost ) );
 		} );
 	} );
 } );

--- a/client/blocks/daily-post-button/test/index.jsx
+++ b/client/blocks/daily-post-button/test/index.jsx
@@ -6,7 +6,6 @@
 /**
  * External dependencies
  */
-import { assert } from 'chai';
 import { shallow } from 'enzyme';
 import { noop } from 'lodash';
 import pageSpy from 'page';
@@ -47,7 +46,7 @@ describe( 'DailyPostButton', () => {
 					onlyOneSite={ false }
 				/>
 			);
-			assert.isNull( dailyPostPrompt.type() );
+			expect( dailyPostPrompt.type() ).toBeNull();
 		} );
 
 		test( 'renders as a span tag by default', () => {
@@ -60,7 +59,7 @@ describe( 'DailyPostButton', () => {
 					onlyOneSite={ true }
 				/>
 			);
-			assert.equal( 'span', renderAsSpan.type() );
+			expect( 'span' ).toEqual( renderAsSpan.type() );
 		} );
 
 		test( 'renders as the tag specified in props tagName', () => {
@@ -74,7 +73,7 @@ describe( 'DailyPostButton', () => {
 					onlyOneSite={ true }
 				/>
 			);
-			assert.equal( 'span', renderAsSpan.type() );
+			expect( 'span' ).toEqual( renderAsSpan.type() );
 		} );
 	} );
 
@@ -90,7 +89,7 @@ describe( 'DailyPostButton', () => {
 				/>
 			);
 			dailyPostButton.simulate( 'click', { preventDefault: noop } );
-			assert.isTrue( pageSpy.calledWithMatch( /post\/apps.wordpress.com?/ ) );
+			expect( pageSpy.calledWithMatch( /post\/apps.wordpress.com?/ ) ).toBe( true );
 		} );
 
 		test( 'shows the site selector if the user has more than one site', done => {
@@ -125,7 +124,7 @@ describe( 'DailyPostButton', () => {
 			const pageArgs = pageSpy.lastCall.args[ 0 ];
 			const query = qs.parse( pageArgs.split( '?' )[ 1 ] );
 			const { title, URL } = dailyPromptPost;
-			assert.deepEqual( query, { title: `Daily Prompt: ${ title }`, url: URL } );
+			expect( query ).toEqual( { title: `Daily Prompt: ${ title }`, url: URL } );
 		} );
 	} );
 } );

--- a/client/blocks/reader-full-post/test/featured-image.jsx
+++ b/client/blocks/reader-full-post/test/featured-image.jsx
@@ -2,7 +2,6 @@
 /**
  * External dependencies
  */
-import { assert } from 'chai';
 import { shallow } from 'enzyme';
 import React from 'react';
 
@@ -16,6 +15,6 @@ describe( 'FeaturedImage', () => {
 		const nonExistantImage = 'http://sketchy-feed.com/missing-image-2.jpg';
 		const wrapper = shallow( <FeaturedImage src={ nonExistantImage } /> );
 		wrapper.instance().handleImageError();
-		assert.equal( '', wrapper.state( 'src' ) );
+		expect( '' ).toEqual( wrapper.state( 'src' ) );
 	} );
 } );

--- a/client/components/bulk-select/test/index.js
+++ b/client/components/bulk-select/test/index.js
@@ -6,7 +6,6 @@
 /**
  * External dependencies
  */
-import { assert } from 'chai';
 import { shallow } from 'enzyme';
 import { noop } from 'lodash';
 import React from 'react';
@@ -21,35 +20,35 @@ describe( 'index', () => {
 		const bulkSelect = shallow(
 			<BulkSelect selectedElements={ 0 } totalElements={ 3 } onToggle={ noop } />
 		);
-		assert.equal( 1, bulkSelect.find( '.bulk-select' ).length );
+		expect( 1 ).toEqual( bulkSelect.find( '.bulk-select' ).length );
 	} );
 
 	test( 'should not be checked when initialized without selectedElements', () => {
 		const bulkSelect = shallow(
 			<BulkSelect selectedElements={ 0 } totalElements={ 3 } onToggle={ noop } />
 		);
-		assert.equal( 0, bulkSelect.find( '.is-checked' ).length );
+		expect( 0 ).toEqual( bulkSelect.find( '.is-checked' ).length );
 	} );
 
 	test( 'should be checked when initialized with all elements selected', () => {
 		const bulkSelect = shallow(
 			<BulkSelect selectedElements={ 3 } totalElements={ 3 } onToggle={ noop } />
 		);
-		assert.equal( 1, bulkSelect.find( '.is-checked' ).length );
+		expect( 1 ).toEqual( bulkSelect.find( '.is-checked' ).length );
 	} );
 
 	test( 'should not be checked when initialized with some elements selected', () => {
 		const bulkSelect = shallow(
 			<BulkSelect selectedElements={ 2 } totalElements={ 3 } onToggle={ noop } />
 		);
-		assert.equal( 0, bulkSelect.find( '.is-checked' ).length );
+		expect( 0 ).toEqual( bulkSelect.find( '.is-checked' ).length );
 	} );
 
 	test( 'should render line gridicon when initialized with some elements selected', () => {
 		const bulkSelect = shallow(
 			<BulkSelect selectedElements={ 2 } totalElements={ 3 } onToggle={ noop } />
 		);
-		assert.equal( 1, bulkSelect.find( '.bulk-select__some-checked-icon' ).length );
+		expect( 1 ).toEqual( bulkSelect.find( '.bulk-select__some-checked-icon' ).length );
 	} );
 
 	test( 'should be call onToggle when clicked', () => {
@@ -61,12 +60,12 @@ describe( 'index', () => {
 			<BulkSelect selectedElements={ 0 } totalElements={ 3 } onToggle={ callback } />
 		);
 		bulkSelect.simulate( 'click' );
-		assert.equal( hasBeenCalled, true );
+		expect( hasBeenCalled ).toEqual( true );
 	} );
 
 	test( 'should be call onToggle with the new state when there are no selected elements', done => {
 		const callback = function( newState ) {
-			assert.equal( newState, true );
+			expect( newState ).toEqual( true );
 			done();
 		};
 		const bulkSelect = shallow(
@@ -77,7 +76,7 @@ describe( 'index', () => {
 
 	test( 'should be call onToggle with the new state when there are some selected elements', done => {
 		const callback = function( newState ) {
-			assert.equal( newState, false );
+			expect( newState ).toEqual( false );
 			done();
 		};
 		const bulkSelect = shallow(
@@ -88,7 +87,7 @@ describe( 'index', () => {
 
 	test( 'should be call onToggle with the new state when there all elements are selected', done => {
 		const callback = function( newState ) {
-			assert.equal( newState, false );
+			expect( newState ).toEqual( false );
 			done();
 		};
 		const bulkSelect = shallow(

--- a/client/components/button-group/test/index.js
+++ b/client/components/button-group/test/index.js
@@ -3,7 +3,6 @@
 /**
  * External dependencies
  */
-import { assert } from 'chai';
 import { shallow } from 'enzyme';
 import React from 'react';
 import sinon from 'sinon';
@@ -26,7 +25,7 @@ describe( 'ButtonGroup', () => {
 
 	test( 'should have ButtonGroup class', () => {
 		const buttonGroup = shallow( <ButtonGroup /> );
-		assert.equal( 1, buttonGroup.find( '.button-group' ).length );
+		expect( 1 ).toEqual( buttonGroup.find( '.button-group' ).length );
 	} );
 
 	test( 'should contains the same number of .button nodes than <Button>s it receives', () => {
@@ -36,12 +35,12 @@ describe( 'ButtonGroup', () => {
 				<Button>test2</Button>
 			</ButtonGroup>
 		);
-		assert.equal( 2, buttonGroup.find( Button ).length );
+		expect( 2 ).toEqual( buttonGroup.find( Button ).length );
 	} );
 
 	test( 'should get the busy `is-busy` class when passed the `busy` prop', () => {
 		const buttonGroup = shallow( <ButtonGroup busy /> );
-		assert.equal( 1, buttonGroup.find( '.is-busy' ).length );
+		expect( 1 ).toEqual( buttonGroup.find( '.is-busy' ).length );
 	} );
 
 	test( 'should throw an error if any of the children is not a <Button>', () => {

--- a/client/components/external-link/test/index.js
+++ b/client/components/external-link/test/index.js
@@ -3,7 +3,6 @@
 /**
  * External dependencies
  */
-import { assert } from 'chai';
 import { shallow } from 'enzyme';
 import Gridicon from 'gridicons';
 import React from 'react';
@@ -16,51 +15,51 @@ import ExternalLink from '../index';
 describe( 'External Link', () => {
 	test( 'should have external-link class', () => {
 		const externalLink = shallow( <ExternalLink /> );
-		assert.lengthOf( externalLink.find( '.external-link' ), 1 );
+		expect( externalLink.find( '.external-link' ).length ).toBe( 1 );
 	} );
 
 	test( 'should have className if provided', () => {
 		const externalLink = shallow( <ExternalLink className="test__foobar" /> );
-		assert.lengthOf( externalLink.find( '.test__foobar' ), 1 );
+		expect( externalLink.find( '.test__foobar' ).length ).toBe( 1 );
 	} );
 
 	test( 'should have href if provided', () => {
 		const externalLink = shallow( <ExternalLink href="http://foobar.bang" /> );
-		assert.lengthOf( externalLink.find( { href: 'http://foobar.bang' } ), 1 );
+		expect( externalLink.find( { href: 'http://foobar.bang' } ).length ).toBe( 1 );
 	} );
 
 	test( 'should have icon if provided', () => {
 		const externalLink = shallow( <ExternalLink icon={ true } /> );
-		assert.lengthOf( externalLink.find( Gridicon ), 1 );
+		expect( externalLink.find( Gridicon ).length ).toBe( 1 );
 	} );
 
 	test( 'should have a target if given one', () => {
 		const externalLink = shallow( <ExternalLink target="_blank" /> );
-		assert.lengthOf( externalLink.find( { target: '_blank' } ), 1 );
+		expect( externalLink.find( { target: '_blank' } ).length ).toBe( 1 );
 	} );
 
 	test( 'should have an icon className if specified', () => {
 		const externalLink = shallow( <ExternalLink icon={ true } iconClassName="foo" /> );
-		assert.equal( 'foo', externalLink.find( Gridicon ).prop( 'className' ) );
+		expect( 'foo' ).toEqual( externalLink.find( Gridicon ).prop( 'className' ) );
 	} );
 
 	test( 'should have an icon default size of 18', () => {
 		const externalLink = shallow( <ExternalLink icon={ true } iconClassName="foo" /> );
-		assert.equal( '18', externalLink.find( Gridicon ).prop( 'size' ) );
+		expect( '18' ).toEqual( externalLink.find( Gridicon ).prop( 'size' ) );
 	} );
 
 	test( 'should have an icon size that is provided', () => {
 		const externalLink = shallow( <ExternalLink icon={ true } iconSize={ 20 } /> );
-		assert.equal( '20', externalLink.find( Gridicon ).prop( 'size' ) );
+		expect( '20' ).toEqual( externalLink.find( Gridicon ).prop( 'size' ) );
 	} );
 
 	test( 'should have icon first if specified', () => {
 		const externalLink = shallow( <ExternalLink icon={ true } iconClassName="foo" /> );
-		assert.isTrue(
+		expect(
 			externalLink
 				.children()
 				.first()
 				.is( Gridicon )
-		);
+		).toBe( true );
 	} );
 } );

--- a/client/components/feature-example/test/index.js
+++ b/client/components/feature-example/test/index.js
@@ -3,7 +3,6 @@
 /**
  * External dependencies
  */
-import { assert } from 'chai';
 import { shallow } from 'enzyme';
 import React from 'react';
 
@@ -15,7 +14,7 @@ import FeatureExample from '../index';
 describe( 'Feature Example', () => {
 	test( 'should have Feature-example class', () => {
 		const featureExample = shallow( <FeatureExample /> );
-		assert.lengthOf( featureExample.find( '.feature-example' ), 1 );
+		expect( featureExample.find( '.feature-example' ).length ).toBe( 1 );
 	} );
 
 	test( 'should contains the passed children wrapped by a feature-example div', () => {
@@ -24,6 +23,6 @@ describe( 'Feature Example', () => {
 				<div>test</div>
 			</FeatureExample>
 		);
-		assert.isTrue( featureExample.contains( <div>test</div> ) );
+		expect( featureExample.contains( <div>test</div> ) ).toBe( true );
 	} );
 } );

--- a/client/components/infinite-list/test/scroll-helper.js
+++ b/client/components/infinite-list/test/scroll-helper.js
@@ -4,7 +4,6 @@
  * External dependencies
  */
 import { range } from 'lodash';
-import { assert } from 'chai';
 
 /**
  * Internal dependencies
@@ -26,19 +25,19 @@ describe( 'scroll-helper', () => {
 			helper.updateContextHeight( 1000 );
 
 			test( 'top hard hide levels is 1 vh above context', () => {
-				assert.equal( helper.topHideLevelHard, -1000 );
+				expect( helper.topHideLevelHard ).toEqual( -1000 );
 			} );
 			test( 'top soft hide level is 2 vh above context', () => {
-				assert.equal( helper.topHideLevelSoft, -2000 );
+				expect( helper.topHideLevelSoft ).toEqual( -2000 );
 			} );
 			test( 'bottom hard hide level is 1 vh below context', () => {
-				assert.equal( helper.bottomHideLevelHard, 2000 );
+				expect( helper.bottomHideLevelHard ).toEqual( 2000 );
 			} );
 			test( 'bottom soft hide level is 2 vh below context', () => {
-				assert.equal( helper.bottomHideLevelSoft, 3000 );
+				expect( helper.bottomHideLevelSoft ).toEqual( 3000 );
 			} );
 			test( 'bottom 3rd hide level is 3 vh below context', () => {
-				assert.equal( helper.bottomHideLevelUltraSoft, 4000 );
+				expect( helper.bottomHideLevelUltraSoft ).toEqual( 4000 );
 			} );
 		} );
 
@@ -51,19 +50,19 @@ describe( 'scroll-helper', () => {
 			helper.updateContextHeight( 200 );
 
 			test( 'top hard hide levels is 5 items above context', () => {
-				assert.equal( helper.topHideLevelHard, -500 );
+				expect( helper.topHideLevelHard ).toEqual( -500 );
 			} );
 			test( 'top soft hide level is 10 items above context', () => {
-				assert.equal( helper.topHideLevelSoft, -1000 );
+				expect( helper.topHideLevelSoft ).toEqual( -1000 );
 			} );
 			test( 'bottom hard hide level is 5 items below context', () => {
-				assert.equal( helper.bottomHideLevelHard, 700 );
+				expect( helper.bottomHideLevelHard ).toEqual( 700 );
 			} );
 			test( 'bottom soft hide level is 10 items below context', () => {
-				assert.equal( helper.bottomHideLevelSoft, 1200 );
+				expect( helper.bottomHideLevelSoft ).toEqual( 1200 );
 			} );
 			test( 'bottom 3rd hide level is 15 items below context', () => {
-				assert.equal( helper.bottomHideLevelUltraSoft, 1700 );
+				expect( helper.bottomHideLevelUltraSoft ).toEqual( 1700 );
 			} );
 		} );
 	} );
@@ -86,16 +85,16 @@ describe( 'scroll-helper', () => {
 		helper.updatePlaceholderDimensions();
 
 		test( 'Placeholders height determined using their bounds ', () => {
-			assert.equal( helper.topPlaceholderHeight, 1000 );
-			assert.equal( helper.bottomPlaceholderHeight, 2000 );
+			expect( helper.topPlaceholderHeight ).toEqual( 1000 );
+			expect( helper.bottomPlaceholderHeight ).toEqual( 2000 );
 		} );
 
 		test( 'Container top determined using top placeholder bounds', () => {
-			assert.equal( helper.containerTop, -2000 );
+			expect( helper.containerTop ).toEqual( -2000 );
 		} );
 
 		test( 'Container bottom determined using bottom placeholder bounds', () => {
-			assert.equal( helper.containerBottom, 4000 );
+			expect( helper.containerBottom ).toEqual( 4000 );
 		} );
 	} );
 
@@ -112,12 +111,12 @@ describe( 'scroll-helper', () => {
 
 		test( 'renders only up to bottom soft hide level', () => {
 			helper.props.items = range( 100 );
-			assert.equal( helper.initialLastRenderedIndex(), 14 ); // 3000 / 200 - 1
+			expect( helper.initialLastRenderedIndex() ).toEqual( 14 ); // 3000 / 200 - 1
 		} );
 
 		test( 'renders everything if it should fit', () => {
 			helper.props.items = range( 10 );
-			assert.equal( helper.initialLastRenderedIndex(), 9 );
+			expect( helper.initialLastRenderedIndex() ).toEqual( 9 );
 		} );
 	} );
 
@@ -128,10 +127,10 @@ describe( 'scroll-helper', () => {
 			helper.topPlaceholderHeight = 500;
 			helper.topHideLevelSoft = -2000;
 
-			assert.ok( helper.shouldHideItemsAbove() );
+			expect( helper.shouldHideItemsAbove() ).toBeTruthy();
 
 			helper.topPlaceholderHeight = 1500;
-			assert.notOk( helper.shouldHideItemsAbove() );
+			expect( helper.shouldHideItemsAbove() ).toBeFalsy();
 		} );
 
 		describe( 'Hiding batch of items', () => {
@@ -166,26 +165,23 @@ describe( 'scroll-helper', () => {
 			helper.hideItemsAbove();
 
 			test( 'updated state', () => {
-				assert( helper.stateUpdated );
+				expect( helper.stateUpdated ).toBeTruthy();
 			} );
 
 			test( 'created placeholder for 3 items', () => {
-				assert.equal( 900, helper.topPlaceholderHeight );
+				expect( 900 ).toEqual( helper.topPlaceholderHeight );
 			} );
 
 			test( 'hid 3 items', () => {
-				assert.equal( 3, helper.firstRenderedIndex );
+				expect( 3 ).toEqual( helper.firstRenderedIndex );
 			} );
 
 			test( 'stored hidden items height', () => {
-				assert.deepEqual(
-					{
-						i0: 250,
-						i1: 350,
-						i2: 300,
-					},
-					helper.itemHeights
-				);
+				expect( {
+					i0: 250,
+					i1: 350,
+					i2: 300,
+				} ).toEqual( helper.itemHeights );
 			} );
 		} );
 
@@ -219,11 +215,11 @@ describe( 'scroll-helper', () => {
 			helper.hideItemsAbove();
 
 			test( 'created placeholder for 2 items', () => {
-				assert.equal( 600, helper.topPlaceholderHeight );
+				expect( 600 ).toEqual( helper.topPlaceholderHeight );
 			} );
 
 			test( 'hid 2 items', () => {
-				assert.equal( 2, helper.firstRenderedIndex );
+				expect( 2 ).toEqual( helper.firstRenderedIndex );
 			} );
 		} );
 
@@ -233,10 +229,10 @@ describe( 'scroll-helper', () => {
 			helper.topPlaceholderHeight = 2500;
 			helper.topHideLevelHard = -1000;
 
-			assert.ok( helper.shouldShowItemsAbove() );
+			expect( helper.shouldShowItemsAbove() ).toBeTruthy();
 
 			helper.topPlaceholderHeight = 1500;
-			assert.notOk( helper.shouldShowItemsAbove() );
+			expect( helper.shouldShowItemsAbove() ).toBeFalsy();
 		} );
 
 		describe( 'Showing batch of items', () => {
@@ -264,24 +260,21 @@ describe( 'scroll-helper', () => {
 			helper.showItemsAbove();
 
 			test( 'updated state', () => {
-				assert( helper.stateUpdated );
+				expect( helper.stateUpdated ).toBeTruthy();
 			} );
 
 			test( 'reduced placeholder height', () => {
-				assert.equal( 250, helper.topPlaceholderHeight );
+				expect( 250 ).toEqual( helper.topPlaceholderHeight );
 			} );
 
 			test( 'shown 4 items', () => {
-				assert.equal( 1, helper.firstRenderedIndex );
+				expect( 1 ).toEqual( helper.firstRenderedIndex );
 			} );
 
 			test( 'removed shown items height', () => {
-				assert.deepEqual(
-					{
-						i0: 250,
-					},
-					helper.itemHeights
-				);
+				expect( {
+					i0: 250,
+				} ).toEqual( helper.itemHeights );
 			} );
 		} );
 
@@ -305,11 +298,11 @@ describe( 'scroll-helper', () => {
 			helper.showItemsAbove();
 
 			test( 'placeholder height is never negative', () => {
-				assert.equal( 0, helper.topPlaceholderHeight );
+				expect( 0 ).toEqual( helper.topPlaceholderHeight );
 			} );
 
 			test( 'shown all items', () => {
-				assert.equal( 0, helper.firstRenderedIndex );
+				expect( 0 ).toEqual( helper.firstRenderedIndex );
 			} );
 		} );
 
@@ -331,7 +324,7 @@ describe( 'scroll-helper', () => {
 
 			helper.showItemsAbove();
 
-			assert.equal( 0, helper.topPlaceholderHeight );
+			expect( 0 ).toEqual( helper.topPlaceholderHeight );
 		} );
 	} );
 
@@ -342,10 +335,10 @@ describe( 'scroll-helper', () => {
 			helper.bottomPlaceholderHeight = 500;
 			helper.bottomHideLevelUltraSoft = 4000;
 
-			assert.ok( helper.shouldHideItemsBelow() );
+			expect( helper.shouldHideItemsBelow() ).toBeTruthy();
 
 			helper.bottomPlaceholderHeight = 1500;
-			assert.notOk( helper.shouldHideItemsBelow() );
+			expect( helper.shouldHideItemsBelow() ).toBeFalsy();
 		} );
 
 		describe( 'Hiding batch of items', () => {
@@ -384,27 +377,24 @@ describe( 'scroll-helper', () => {
 			helper.hideItemsBelow();
 
 			test( 'updated state', () => {
-				assert.ok( helper.stateUpdated );
+				expect( helper.stateUpdated ).toBeTruthy();
 			} );
 
 			test( 'created placeholder for 3 items', () => {
-				assert.equal( 2800, helper.bottomPlaceholderHeight );
+				expect( 2800 ).toEqual( helper.bottomPlaceholderHeight );
 			} );
 
 			test( 'hid 4 items', () => {
-				assert.equal( 5, helper.lastRenderedIndex );
+				expect( 5 ).toEqual( helper.lastRenderedIndex );
 			} );
 
 			test( 'stored hidden items height', () => {
-				assert.deepEqual(
-					{
-						i6: 300,
-						i7: 900,
-						i8: 300,
-						i9: 500,
-					},
-					helper.itemHeights
-				);
+				expect( {
+					i6: 300,
+					i7: 900,
+					i8: 300,
+					i9: 500,
+				} ).toEqual( helper.itemHeights );
 			} );
 		} );
 
@@ -431,11 +421,11 @@ describe( 'scroll-helper', () => {
 			helper.hideItemsBelow();
 
 			test( 'created placeholder for 2 items', () => {
-				assert.equal( 1400, helper.bottomPlaceholderHeight );
+				expect( 1400 ).toEqual( helper.bottomPlaceholderHeight );
 			} );
 
 			test( 'hid all items', () => {
-				assert.equal( -1, helper.lastRenderedIndex );
+				expect( -1 ).toEqual( helper.lastRenderedIndex );
 			} );
 		} );
 
@@ -445,10 +435,10 @@ describe( 'scroll-helper', () => {
 			helper.bottomPlaceholderHeight = 3500;
 			helper.bottomHideLevelHard = 2000;
 
-			assert.ok( helper.shouldShowItemsBelow() );
+			expect( helper.shouldShowItemsBelow() ).toBeTruthy();
 
 			helper.bottomPlaceholderHeight = 2500;
-			assert.notOk( helper.shouldShowItemsBelow() );
+			expect( helper.shouldShowItemsBelow() ).toBeFalsy();
 		} );
 
 		describe( 'Showing batch of items', () => {
@@ -477,24 +467,21 @@ describe( 'scroll-helper', () => {
 			helper.showItemsBelow();
 
 			test( 'updated state', () => {
-				assert( helper.stateUpdated );
+				expect( helper.stateUpdated ).toBeTruthy();
 			} );
 
 			test( 'reduced placeholder height', () => {
-				assert.equal( 2500, helper.bottomPlaceholderHeight );
+				expect( 2500 ).toEqual( helper.bottomPlaceholderHeight );
 			} );
 
 			test( 'shown 2 items', () => {
-				assert.equal( 6, helper.lastRenderedIndex );
+				expect( 6 ).toEqual( helper.lastRenderedIndex );
 			} );
 
 			test( 'removed shown items height', () => {
-				assert.deepEqual(
-					{
-						i7: 900,
-					},
-					helper.itemHeights
-				);
+				expect( {
+					i7: 900,
+				} ).toEqual( helper.itemHeights );
 			} );
 		} );
 
@@ -523,11 +510,11 @@ describe( 'scroll-helper', () => {
 			helper.showItemsBelow();
 
 			test( 'reduced placeholder height', () => {
-				assert.equal( 1900, helper.bottomPlaceholderHeight );
+				expect( 1900 ).toEqual( helper.bottomPlaceholderHeight );
 			} );
 
 			test( 'shown 2 items', () => {
-				assert.equal( 5, helper.lastRenderedIndex );
+				expect( 5 ).toEqual( helper.lastRenderedIndex );
 			} );
 		} );
 
@@ -551,15 +538,15 @@ describe( 'scroll-helper', () => {
 			helper.showItemsBelow();
 
 			test( 'placeholder height is never negative', () => {
-				assert.equal( 0, helper.bottomPlaceholderHeight );
+				expect( 0 ).toEqual( helper.bottomPlaceholderHeight );
 			} );
 
 			test( 'container bottom is increased', () => {
-				assert.equal( 1600, helper.containerBottom );
+				expect( 1600 ).toEqual( helper.containerBottom );
 			} );
 
 			test( 'shown 3 items', () => {
-				assert.equal( 7, helper.lastRenderedIndex );
+				expect( 7 ).toEqual( helper.lastRenderedIndex );
 			} );
 		} );
 
@@ -583,8 +570,8 @@ describe( 'scroll-helper', () => {
 
 			helper.showItemsBelow();
 
-			assert.equal( 0, helper.bottomPlaceholderHeight );
-			assert.equal( 7, helper.lastRenderedIndex );
+			expect( 0 ).toEqual( helper.bottomPlaceholderHeight );
+			expect( 7 ).toEqual( helper.lastRenderedIndex );
 		} );
 	} );
 
@@ -604,22 +591,22 @@ describe( 'scroll-helper', () => {
 		} );
 
 		test( 'loaded when container bottom above hard limit', () => {
-			assert.ok( helper.shouldLoadNextPage() );
+			expect( helper.shouldLoadNextPage() ).toBeTruthy();
 		} );
 
 		test( 'not loaded when loading previous', () => {
 			helper.props.fetchingNextPage = true;
-			assert.notOk( helper.shouldLoadNextPage() );
+			expect( helper.shouldLoadNextPage() ).toBeFalsy();
 		} );
 
 		test( 'not loaded on last page', () => {
 			helper.props.lastPage = true;
-			assert.notOk( helper.shouldLoadNextPage() );
+			expect( helper.shouldLoadNextPage() ).toBeFalsy();
 		} );
 
 		test( 'not loaded if some items hidden', () => {
 			helper.bottomPlaceholderHeight = 100;
-			assert.notOk( helper.shouldLoadNextPage() );
+			expect( helper.shouldLoadNextPage() ).toBeFalsy();
 		} );
 	} );
 } );

--- a/client/components/notice/test/index.js
+++ b/client/components/notice/test/index.js
@@ -3,7 +3,6 @@
 /**
  * External dependencies
  */
-import { assert } from 'chai';
 import { shallow } from 'enzyme';
 import { identity } from 'lodash';
 import React from 'react';
@@ -16,53 +15,53 @@ import { Notice } from '../index';
 describe( 'Notice', () => {
 	test( 'should output the component', () => {
 		const wrapper = shallow( <Notice translate={ identity } /> );
-		assert.isOk( wrapper.find( '.notice' ).length );
+		expect( wrapper.find( '.notice' ).length ).toBeTruthy();
 	} );
 
 	test( 'should have dismiss button when showDismiss passed as true', () => {
 		const wrapper = shallow( <Notice showDismiss={ true } translate={ identity } /> );
-		assert.isOk( wrapper.find( '.is-dismissable' ).length );
+		expect( wrapper.find( '.is-dismissable' ).length ).toBeTruthy();
 	} );
 
 	test( 'should have dismiss button by default if isCompact is false', () => {
 		const wrapper = shallow( <Notice isCompact={ false } translate={ identity } /> );
-		assert.isOk( wrapper.find( '.is-dismissable' ).length );
+		expect( wrapper.find( '.is-dismissable' ).length ).toBeTruthy();
 	} );
 
 	test( 'should have compact look when isCompact passed as true', () => {
 		const wrapper = shallow( <Notice isCompact={ true } translate={ identity } /> );
-		assert.isOk( wrapper.find( '.is-compact' ).length );
+		expect( wrapper.find( '.is-compact' ).length ).toBeTruthy();
 	} );
 
 	test( 'should not have dismiss button by default if isCompact is true', () => {
 		const wrapper = shallow( <Notice isCompact={ true } translate={ identity } /> );
-		assert.isOk( wrapper.find( '.is-dismissable' ).length === 0 );
+		expect( wrapper.find( '.is-dismissable' ).length === 0 ).toBeTruthy();
 	} );
 
 	test( 'should have dismiss button when showDismiss is true and isCompact is true', () => {
 		const wrapper = shallow(
 			<Notice isCompact={ true } showDismiss={ true } translate={ identity } />
 		);
-		assert.isOk( wrapper.find( '.is-dismissable' ).length );
+		expect( wrapper.find( '.is-dismissable' ).length ).toBeTruthy();
 	} );
 
 	test( 'should have proper class for is-info status parameter', () => {
 		const wrapper = shallow( <Notice status="is-info" translate={ identity } /> );
-		assert.isOk( wrapper.find( '.is-info' ).length );
+		expect( wrapper.find( '.is-info' ).length ).toBeTruthy();
 	} );
 
 	test( 'should have proper class for is-success status parameter', () => {
 		const wrapper = shallow( <Notice status="is-success" translate={ identity } /> );
-		assert.isOk( wrapper.find( '.is-success' ).length );
+		expect( wrapper.find( '.is-success' ).length ).toBeTruthy();
 	} );
 
 	test( 'should have proper class for is-error status parameter', () => {
 		const wrapper = shallow( <Notice status="is-error" translate={ identity } /> );
-		assert.isOk( wrapper.find( '.is-error' ).length );
+		expect( wrapper.find( '.is-error' ).length ).toBeTruthy();
 	} );
 
 	test( 'should have proper class for is-warning status parameter', () => {
 		const wrapper = shallow( <Notice status="is-warning" translate={ identity } /> );
-		assert.isOk( wrapper.find( '.is-warning' ).length );
+		expect( wrapper.find( '.is-warning' ).length ).toBeTruthy();
 	} );
 } );

--- a/client/components/section-nav/test/index.jsx
+++ b/client/components/section-nav/test/index.jsx
@@ -6,7 +6,6 @@
 /**
  * External dependencies
  */
-import { assert } from 'chai';
 import React from 'react';
 import TestUtils from 'react-addons-test-utils';
 import ReactDom from 'react-dom';
@@ -54,20 +53,20 @@ describe( 'section-nav', () => {
 		} );
 
 		test( 'should render a header and a panel', () => {
-			assert.equal( headerElem.props.className, 'section-nav__mobile-header' );
-			assert.equal( panelElem.props.className, 'section-nav__panel' );
-			assert.equal( headerTextElem.props.className, 'section-nav__mobile-header-text' );
+			expect( headerElem.props.className ).toEqual( 'section-nav__mobile-header' );
+			expect( panelElem.props.className ).toEqual( 'section-nav__panel' );
+			expect( headerTextElem.props.className ).toEqual( 'section-nav__mobile-header-text' );
 		} );
 
 		test( 'should render selectedText within mobile header', () => {
-			assert.equal( text, 'test' );
+			expect( text ).toEqual( 'test' );
 		} );
 
 		test( 'should render children', done => {
 			//React.Children.only should work here but gives an error about not being the only child
 			React.Children.map( panelElem.props.children, function( obj ) {
 				if ( obj.type === 'p' ) {
-					assert.equal( obj.props.children, 'mmyellow' );
+					expect( obj.props.children ).toEqual( 'mmyellow' );
 					done();
 				}
 			} );
@@ -83,7 +82,7 @@ describe( 'section-nav', () => {
 				<p>mmyellow</p>
 			);
 
-			assert.notEqual( component.props.children[ 0 ].className, 'section-nav__mobile-header' );
+			expect( component.props.children[ 0 ].className ).not.toEqual( 'section-nav__mobile-header' );
 		} );
 	} );
 
@@ -100,13 +99,13 @@ describe( 'section-nav', () => {
 				<p>placeholder</p>
 			);
 			const tree = TestUtils.renderIntoDocument( elem );
-			assert( ! tree.state.mobileOpen );
+			expect( ! tree.state.mobileOpen ).toBeTruthy();
 			TestUtils.Simulate.click(
 				ReactDom.findDOMNode(
 					TestUtils.findRenderedDOMComponentWithClass( tree, 'section-nav__mobile-header' )
 				)
 			);
-			assert( tree.state.mobileOpen );
+			expect( tree.state.mobileOpen ).toBeTruthy();
 		} );
 
 		test( 'should call onMobileNavPanelOpen function passed as a prop twice when tapped three times', done => {
@@ -121,27 +120,27 @@ describe( 'section-nav', () => {
 			);
 			const tree = TestUtils.renderIntoDocument( elem );
 
-			assert( ! tree.state.mobileOpen );
+			expect( ! tree.state.mobileOpen ).toBeTruthy();
 			TestUtils.Simulate.click(
 				ReactDom.findDOMNode(
 					TestUtils.findRenderedDOMComponentWithClass( tree, 'section-nav__mobile-header' )
 				)
 			);
-			assert( tree.state.mobileOpen );
+			expect( tree.state.mobileOpen ).toBeTruthy();
 			TestUtils.Simulate.click(
 				ReactDom.findDOMNode(
 					TestUtils.findRenderedDOMComponentWithClass( tree, 'section-nav__mobile-header' )
 				)
 			);
-			assert( ! tree.state.mobileOpen );
+			expect( ! tree.state.mobileOpen ).toBeTruthy();
 			TestUtils.Simulate.click(
 				ReactDom.findDOMNode(
 					TestUtils.findRenderedDOMComponentWithClass( tree, 'section-nav__mobile-header' )
 				)
 			);
-			assert( tree.state.mobileOpen );
+			expect( tree.state.mobileOpen ).toBeTruthy();
 
-			assert( spy.calledTwice );
+			expect( spy.calledTwice ).toBeTruthy();
 			done();
 		} );
 	} );

--- a/client/components/theme/test/index.jsx
+++ b/client/components/theme/test/index.jsx
@@ -6,7 +6,6 @@
 /**
  * External dependencies
  */
-import { assert } from 'chai';
 import { identity } from 'lodash';
 import React from 'react';
 import TestUtils from 'react-addons-test-utils';
@@ -46,40 +45,35 @@ describe( 'Theme', () => {
 			} );
 
 			test( 'should render a <div> with a className of "theme"', () => {
-				assert( themeNode !== null, "DOM node doesn't exist" );
-				assert( themeNode.nodeName === 'DIV', 'nodeName doesn\'t equal "DIV"' );
-				assert.include(
-					themeNode.className,
-					'theme is-actionable',
-					'className does not contain "theme is-actionable"'
-				);
+				expect( themeNode !== null ).toBeTruthy();
+				expect( themeNode.nodeName === 'DIV' ).toBeTruthy();
+				expect( themeNode.className ).toContain( 'theme is-actionable' );
 
-				assert( themeNode.getElementsByTagName( 'h2' )[ 0 ].textContent === 'Theme name' );
+				expect(
+					themeNode.getElementsByTagName( 'h2' )[ 0 ].textContent === 'Theme name'
+				).toBeTruthy();
 			} );
 
 			test( 'should render a screenshot', () => {
 				const imgNode = themeNode.getElementsByTagName( 'img' )[ 0 ];
-				assert.include( imgNode.getAttribute( 'src' ), '/theme/screenshot.png' );
+				expect( imgNode.getAttribute( 'src' ) ).toContain( '/theme/screenshot.png' );
 			} );
 
 			test( 'should call onScreenshotClick() on click on screenshot', () => {
 				const imgNode = themeNode.getElementsByTagName( 'img' )[ 0 ];
 				TestUtils.Simulate.click( imgNode );
-				assert( props.onScreenshotClick.calledOnce, 'onClick did not trigger onScreenshotClick' );
+				expect( props.onScreenshotClick.calledOnce ).toBeTruthy();
 			} );
 
 			test( 'should not show a price when there is none', () => {
-				assert(
-					themeNode.getElementsByClassName( 'price' ).length === 0,
-					'price should not appear'
-				);
+				expect( themeNode.getElementsByClassName( 'price' ).length === 0 ).toBeTruthy();
 			} );
 
 			test( 'should render a More button', () => {
 				const more = themeNode.getElementsByClassName( 'theme__more-button' );
 
-				assert( more.length === 1, 'More button container not found' );
-				assert( more[ 0 ].getElementsByTagName( 'button' ).length === 1, 'More button not found' );
+				expect( more.length === 1 ).toBeTruthy();
+				expect( more[ 0 ].getElementsByTagName( 'button' ).length === 1 ).toBeTruthy();
 			} );
 		} );
 
@@ -93,7 +87,7 @@ describe( 'Theme', () => {
 			test( 'should not render a More button', () => {
 				const more = themeNode.getElementsByClassName( 'theme__more-button' );
 
-				assert( more.length === 0, 'More button container found' );
+				expect( more.length === 0 ).toBeTruthy();
 			} );
 		} );
 	} );
@@ -111,8 +105,8 @@ describe( 'Theme', () => {
 		} );
 
 		test( 'should render a <div> with an is-placeholder class', () => {
-			assert( themeNode.nodeName === 'DIV', 'nodeName doesn\'t equal "DIV"' );
-			assert.include( themeNode.className, 'is-placeholder', 'no is-placeholder' );
+			expect( themeNode.nodeName === 'DIV' ).toBeTruthy();
+			expect( themeNode.className ).toContain( 'is-placeholder' );
 		} );
 	} );
 
@@ -125,7 +119,9 @@ describe( 'Theme', () => {
 		} );
 
 		test( 'should show a price', () => {
-			assert( themeNode.getElementsByClassName( 'theme-badge__price' )[ 0 ].textContent === '$50' );
+			expect(
+				themeNode.getElementsByClassName( 'theme-badge__price' )[ 0 ].textContent === '$50'
+			).toBeTruthy();
 		} );
 	} );
 } );

--- a/client/components/themes-list/test/index.jsx
+++ b/client/components/themes-list/test/index.jsx
@@ -6,7 +6,6 @@
 /**
  * External dependencies
  */
-import { assert } from 'chai';
 import { noop } from 'lodash';
 import React from 'react';
 import TestUtils from 'react-addons-test-utils';
@@ -49,7 +48,7 @@ describe( 'ThemesList', () => {
 
 	describe( 'propTypes', () => {
 		test( 'specifies the required propType', () => {
-			assert( themesList.type.propTypes.themes, 'themes propType missing' );
+			expect( themesList.type.propTypes.themes ).toBeTruthy();
 		} );
 	} );
 
@@ -62,11 +61,8 @@ describe( 'ThemesList', () => {
 		} );
 
 		test( 'should render a div with a className of "themes-list"', () => {
-			assert( themesListElement, 'element does not exist' );
-			assert(
-				themesListElement.props.className === 'themes-list',
-				'className does not equal "themes-list"'
-			);
+			expect( themesListElement ).toBeTruthy();
+			expect( themesListElement.props.className === 'themes-list' ).toBeTruthy();
 		} );
 
 		describe( 'when no themes are found', () => {
@@ -80,7 +76,7 @@ describe( 'ThemesList', () => {
 			} );
 
 			test( 'displays the EmptyContent component', () => {
-				assert( themesListElement.type.displayName === 'EmptyContent', 'No EmptyContent' );
+				expect( themesListElement.type.displayName === 'EmptyContent' ).toBeTruthy();
 			} );
 		} );
 	} );

--- a/client/components/tinymce/plugins/contact-form/test/shortcode.js
+++ b/client/components/tinymce/plugins/contact-form/test/shortcode.js
@@ -3,18 +3,13 @@
 /**
  * External dependencies
  */
-import { assert } from 'chai';
-
-/**
- * Internal dependencies
- */
 import { serialize, deserialize } from '../shortcode-utils';
 
 describe( 'contact form shortcode serializer', () => {
 	test( 'should create an empty form if no definition provided', () => {
 		const shortcode = serialize();
 
-		assert.equal( shortcode, '[contact-form][/contact-form]' );
+		expect( shortcode ).toEqual( '[contact-form][/contact-form]' );
 	} );
 
 	test( 'should correctly add both to and subject attributes', () => {
@@ -23,8 +18,7 @@ describe( 'contact form shortcode serializer', () => {
 			subject: 'contact form subject',
 		} );
 
-		assert.equal(
-			shortcode,
+		expect( shortcode ).toEqual(
 			'[contact-form to="user@example.com" subject="contact form subject"][/contact-form]'
 		);
 	} );
@@ -34,7 +28,7 @@ describe( 'contact form shortcode serializer', () => {
 			fields: [],
 		} );
 
-		assert.equal( shortcode, '[contact-form][/contact-form]' );
+		expect( shortcode ).toEqual( '[contact-form][/contact-form]' );
 	} );
 
 	test( 'should not add empty fields for empty objects', () => {
@@ -42,7 +36,7 @@ describe( 'contact form shortcode serializer', () => {
 			fields: [ {} ],
 		} );
 
-		assert.equal( shortcode, '[contact-form][/contact-form]' );
+		expect( shortcode ).toEqual( '[contact-form][/contact-form]' );
 	} );
 
 	test( 'should not serialize fields with missing type', () => {
@@ -50,7 +44,7 @@ describe( 'contact form shortcode serializer', () => {
 			fields: [ { label: 'Name' } ],
 		} );
 
-		assert.equal( shortcode, '[contact-form][/contact-form]' );
+		expect( shortcode ).toEqual( '[contact-form][/contact-form]' );
 	} );
 
 	test( 'should not serialize fields with missing labels', () => {
@@ -58,7 +52,7 @@ describe( 'contact form shortcode serializer', () => {
 			fields: [ { type: 'Name' } ],
 		} );
 
-		assert.equal( shortcode, '[contact-form][/contact-form]' );
+		expect( shortcode ).toEqual( '[contact-form][/contact-form]' );
 	} );
 
 	test( 'should serialize a single field', () => {
@@ -66,8 +60,7 @@ describe( 'contact form shortcode serializer', () => {
 			fields: [ { type: 'text', label: 'Name' } ],
 		} );
 
-		assert.equal(
-			shortcode,
+		expect( shortcode ).toEqual(
 			'[contact-form][contact-field label="Name" type="text" /][/contact-form]'
 		);
 	} );
@@ -77,8 +70,7 @@ describe( 'contact form shortcode serializer', () => {
 			fields: [ { type: 'text', label: 'First Name' }, { type: 'text', label: 'Last Name' } ],
 		} );
 
-		assert.equal(
-			shortcode,
+		expect( shortcode ).toEqual(
 			'[contact-form][contact-field label="First Name" type="text" /][contact-field label="Last Name" type="text" /][/contact-form]'
 		);
 	} );
@@ -88,8 +80,7 @@ describe( 'contact form shortcode serializer', () => {
 			fields: [ { type: 'text', label: 'Name', required: true } ],
 		} );
 
-		assert.equal(
-			shortcode,
+		expect( shortcode ).toEqual(
 			'[contact-form][contact-field label="Name" type="text" required="1" /][/contact-form]'
 		);
 	} );
@@ -106,8 +97,7 @@ describe( 'contact form shortcode serializer', () => {
 			],
 		} );
 
-		assert.equal(
-			shortcode,
+		expect( shortcode ).toEqual(
 			'[contact-form][contact-field label="options" type="dropdown" options="option 1,option 2,option 3" required="1" /][/contact-form]'
 		);
 	} );
@@ -117,7 +107,7 @@ describe( 'contact form shortcode deserializer', () => {
 	test( 'should deserialize an empty contact form', () => {
 		const contactForm = deserialize( '[contact-form][/contact-form]' );
 
-		assert.deepEqual( contactForm, { fields: [] } );
+		expect( contactForm ).toEqual( { fields: [] } );
 	} );
 
 	test( 'should deserialize both to and subject attribute from the contact form shortcode', () => {
@@ -125,7 +115,7 @@ describe( 'contact form shortcode deserializer', () => {
 			'[contact-form to="user@example.com" subject="contact form subject"][/contact-form]'
 		);
 
-		assert.deepEqual( contactForm, {
+		expect( contactForm ).toEqual( {
 			to: 'user@example.com',
 			subject: 'contact form subject',
 			fields: [],
@@ -137,7 +127,7 @@ describe( 'contact form shortcode deserializer', () => {
 			'[contact-form][contact-field label="name" type="text" /][/contact-form]'
 		);
 
-		assert.deepEqual( contactForm, {
+		expect( contactForm ).toEqual( {
 			fields: [ { label: 'name', type: 'text' } ],
 		} );
 	} );
@@ -147,7 +137,7 @@ describe( 'contact form shortcode deserializer', () => {
 			'[contact-form][contact-field label="name" type="text" required="1" /][/contact-form]'
 		);
 
-		assert.deepEqual( contactForm, {
+		expect( contactForm ).toEqual( {
 			fields: [ { label: 'name', type: 'text', required: true } ],
 		} );
 	} );
@@ -157,7 +147,7 @@ describe( 'contact form shortcode deserializer', () => {
 			'[contact-form][contact-field label="name" type="text" /][contact-field this is invalid [/contact-form]'
 		);
 
-		assert.deepEqual( contactForm, {
+		expect( contactForm ).toEqual( {
 			fields: [ { label: 'name', type: 'text' } ],
 		} );
 	} );
@@ -167,7 +157,7 @@ describe( 'contact form shortcode deserializer', () => {
 			'[contact-form][contact-field label="options" type="dropdown" options="option 1,option 2,option 3" required="1" /][/contact-form]'
 		);
 
-		assert.deepEqual( contactForm, {
+		expect( contactForm ).toEqual( {
 			fields: [
 				{
 					type: 'dropdown',

--- a/client/components/tinymce/plugins/embed/test/dialog.js
+++ b/client/components/tinymce/plugins/embed/test/dialog.js
@@ -5,7 +5,6 @@
  */
 
 import React from 'react';
-import { assert } from 'chai';
 import { shallow } from 'enzyme';
 import { identity, noop } from 'lodash';
 import { spy } from 'sinon';
@@ -24,10 +23,10 @@ describe( 'EmbedDialog', () => {
 			<EmbedDialog embedUrl={ url } onCancel={ noop } onUpdate={ noop } translate={ identity } />
 		);
 
-		assert.isFalse( wrapper.instance().props.isVisible );
-		assert.strictEqual( wrapper.find( '.embed__title' ).length, 1 );
-		assert.strictEqual( wrapper.find( FormTextInput ).length, 1 );
-		assert.strictEqual( wrapper.find( FormTextInput ).get( 0 ).props.defaultValue, url );
+		expect( wrapper.instance().props.isVisible ).toBe( false );
+		expect( wrapper.find( '.embed__title' ).length ).toBe( 1 );
+		expect( wrapper.find( FormTextInput ).length ).toBe( 1 );
+		expect( wrapper.find( FormTextInput ).get( 0 ).props.defaultValue ).toBe( url );
 	} );
 
 	test( "should update the input field's value when input changes", () => {
@@ -49,10 +48,10 @@ describe( 'EmbedDialog', () => {
 		};
 		let inputField = wrapper.find( FormTextInput ).get( 0 );
 
-		assert.strictEqual( inputField.props.defaultValue, originalUrl );
+		expect( inputField.props.defaultValue ).toBe( originalUrl );
 		wrapper.find( FormTextInput ).simulate( 'change', mockChangeEvent );
 		inputField = wrapper.find( FormTextInput ).get( 0 );
-		assert.strictEqual( inputField.props.defaultValue, newUrl );
+		expect( inputField.props.defaultValue ).toBe( newUrl );
 	} );
 
 	test( 'should return the new url to onUpdate when updating', () => {
@@ -77,10 +76,10 @@ describe( 'EmbedDialog', () => {
 			/>
 		);
 
-		assert.strictEqual( currentUrl, originalUrl );
+		expect( currentUrl ).toBe( originalUrl );
 		wrapper.find( FormTextInput ).simulate( 'change', mockChangeEvent );
 		wrapper.instance().onUpdate();
-		assert.strictEqual( currentUrl, newUrl );
+		expect( currentUrl ).toBe( newUrl );
 	} );
 
 	test( 'should not return the new url to onUpdate when canceling', () => {
@@ -106,11 +105,11 @@ describe( 'EmbedDialog', () => {
 			/>
 		);
 
-		assert.strictEqual( currentUrl, originalUrl );
+		expect( currentUrl ).toBe( originalUrl );
 		wrapper.find( FormTextInput ).simulate( 'change', mockChangeEvent );
-		assert.isFalse( noopSpy.called );
+		expect( noopSpy.called ).toBe( false );
 		wrapper.find( Dialog ).simulate( 'cancel' );
-		assert.isTrue( noopSpy.called );
-		assert.strictEqual( currentUrl, originalUrl );
+		expect( noopSpy.called ).toBe( true );
+		expect( currentUrl ).toBe( originalUrl );
 	} );
 } );

--- a/client/components/tinymce/plugins/wpcom/test/utils.js
+++ b/client/components/tinymce/plugins/wpcom/test/utils.js
@@ -3,48 +3,42 @@
 /**
  * External dependencies
  */
-import { assert } from 'chai';
-
-/**
- * Internal dependencies
- */
 import { removeEmptySpacesInParagraphs } from '../wpcom-utils';
 
 describe( 'remove empty spaces in paragraphs', () => {
 	test( 'should not modify paragraphs with content', () => {
 		const content = '<p>Chicken &amp; Ribs</p>';
 
-		assert.equal( content, removeEmptySpacesInParagraphs( content ) );
+		expect( content ).toEqual( removeEmptySpacesInParagraphs( content ) );
 	} );
 
 	test( 'should remove &nbsp; from empty paragraphs', () => {
 		const content = '<p>&nbsp;</p>';
 
-		assert.equal( '<p><br /></p>', removeEmptySpacesInParagraphs( content ) );
+		expect( '<p><br /></p>' ).toEqual( removeEmptySpacesInParagraphs( content ) );
 	} );
 
 	test( 'should not remove &nbsp; from paragraphs with content', () => {
 		const content = '<p>chicken&nbsp;ribs</p>';
 
-		assert.equal( content, removeEmptySpacesInParagraphs( content ) );
+		expect( content ).toEqual( removeEmptySpacesInParagraphs( content ) );
 	} );
 
 	test( 'should remove &nbsp; from paragraphs without content and not ones with content', () => {
 		const content = '<div>&nbsp;</div><p>&nbsp;</p><p>chicken&nbsp;ribs</p>';
 
-		assert.equal(
-			'<div>&nbsp;</div><p><br /></p><p>chicken&nbsp;ribs</p>',
+		expect( '<div>&nbsp;</div><p><br /></p><p>chicken&nbsp;ribs</p>' ).toEqual(
 			removeEmptySpacesInParagraphs( content )
 		);
 	} );
 
 	test( 'should remove unicode spaces from empty paragraphs', () => {
 		const content = '<p>\u00a0\ufeff\ufeff\ufeff</p>';
-		assert.equal( '<p><br /></p>', removeEmptySpacesInParagraphs( content ) );
+		expect( '<p><br /></p>' ).toEqual( removeEmptySpacesInParagraphs( content ) );
 	} );
 
 	test( 'should note remove unicode spaces from paragraphs with content', () => {
 		const content = '<p>chicken\u00a0ribs</p>';
-		assert.equal( content, removeEmptySpacesInParagraphs( content ) );
+		expect( content ).toEqual( removeEmptySpacesInParagraphs( content ) );
 	} );
 } );

--- a/client/devdocs/docs-example/test/index.jsx
+++ b/client/devdocs/docs-example/test/index.jsx
@@ -6,7 +6,6 @@
 /**
  * External dependencies
  */
-import { assert } from 'chai';
 import { shallow, mount } from 'enzyme';
 import { noop } from 'lodash';
 import React from 'react';
@@ -28,12 +27,12 @@ describe( 'DocsExample', () => {
 	test( 'should render', () => {
 		// TODO: when chai-enzyme is available use `shallow` instead
 		const docsExample = mount( <DocsExample { ...props }>{ childrenFixture }</DocsExample> );
-		assert.lengthOf( docsExample.find( '.docs-example' ), 1 );
-		assert.lengthOf( docsExample.find( '.docs-example__main' ), 1 );
-		assert.lengthOf( docsExample.find( '.docs-example__footer' ), 1 );
-		assert.ok( docsExample.contains( childrenFixture ) );
-		assert.lengthOf( docsExample.find( '.docs-example__toggle' ), 0 );
-		assert.lengthOf( docsExample.find( '.docs-example__stats' ), 0 );
+		expect( docsExample.find( '.docs-example' ).length ).toBe( 1 );
+		expect( docsExample.find( '.docs-example__main' ).length ).toBe( 1 );
+		expect( docsExample.find( '.docs-example__footer' ).length ).toBe( 1 );
+		expect( docsExample.contains( childrenFixture ) ).toBeTruthy();
+		expect( docsExample.find( '.docs-example__toggle' ).length ).toBe( 0 );
+		expect( docsExample.find( '.docs-example__stats' ).length ).toBe( 0 );
 	} );
 
 	test( 'should render the toggle button', () => {
@@ -45,7 +44,7 @@ describe( 'DocsExample', () => {
 			<DocsExample { ...propsWithToggle }>{ childrenFixture }</DocsExample>
 		);
 
-		assert.lengthOf( docsExample.find( '.docs-example__toggle' ), 1 );
+		expect( docsExample.find( '.docs-example__toggle' ).length ).toBe( 1 );
 	} );
 
 	test( 'should render the stats', () => {
@@ -58,7 +57,7 @@ describe( 'DocsExample', () => {
 			<DocsExample { ...propsWithStats }>{ childrenFixture }</DocsExample>
 		);
 
-		assert.lengthOf( docsExample.find( '.docs-example__stats' ), 1 );
+		expect( docsExample.find( '.docs-example__stats' ).length ).toBe( 1 );
 	} );
 } );
 
@@ -71,7 +70,7 @@ describe( 'DocsExampleToggle', () => {
 	test( 'should render', () => {
 		const docsExampleToggle = shallow( <DocsExampleToggle { ...props } /> );
 
-		assert.lengthOf( docsExampleToggle.find( Button ), 1 );
+		expect( docsExampleToggle.find( Button ).length ).toBe( 1 );
 	} );
 } );
 
@@ -83,12 +82,12 @@ describe( 'DocsExampleStats', () => {
 	test( 'should render', () => {
 		const docsExampleStats = shallow( <DocsExampleStats { ...props } /> );
 
-		assert.lengthOf( docsExampleStats.find( 'p' ), 1 );
+		expect( docsExampleStats.find( 'p' ).length ).toBe( 1 );
 	} );
 
 	test( "should have the component's usage count", () => {
 		const docsExampleStats = shallow( <DocsExampleStats { ...props } /> );
 
-		assert.lengthOf( docsExampleStats.find( Count ), 1 );
+		expect( docsExampleStats.find( Count ).length ).toBe( 1 );
 	} );
 } );

--- a/client/extensions/woocommerce/app/store-stats/test/utils.js
+++ b/client/extensions/woocommerce/app/store-stats/test/utils.js
@@ -3,7 +3,6 @@
 /**
  * External dependencies
  */
-import { assert } from 'chai';
 import { moment } from 'i18n-calypso';
 
 /**
@@ -24,46 +23,46 @@ describe( 'calculateDelta', () => {
 		const item = { doodads: 75 };
 		const previousItem = { doodads: 50 };
 		const delta = calculateDelta( item, previousItem, 'doodads', 'day' );
-		assert.isObject( delta );
-		assert.isString( delta.value );
-		assert.isString( delta.since );
-		assert.isArray( delta.classes );
+		expect( typeof delta ).toBe( 'object' );
+		expect( typeof delta.value ).toBe( 'string' );
+		expect( typeof delta.since ).toBe( 'string' );
+		expect( Array.isArray( delta.classes ) ).toBe( true );
 	} );
 
 	test( 'should return correct values', () => {
 		const item = { doodads: 75 };
 		const previousItem = { doodads: 50, labelDay: 'a fortnight' };
 		const delta = calculateDelta( item, previousItem, 'doodads', 'day' );
-		assert.equal( delta.value, '50%' );
-		assert.equal( delta.since, 'since a fortnight' );
-		assert.include( delta.classes, 'is-favorable' );
-		assert.include( delta.classes, 'is-increase' );
+		expect( delta.value ).toEqual( '50%' );
+		expect( delta.since ).toEqual( 'since a fortnight' );
+		expect( delta.classes ).toContain( 'is-favorable' );
+		expect( delta.classes ).toContain( 'is-increase' );
 	} );
 
 	test( 'should return correct sign and direction', () => {
 		const item = { doodads: 75 };
 		const previousItem = { doodads: 100 };
 		const delta = calculateDelta( item, previousItem, 'doodads', 'day' );
-		assert.include( delta.classes, 'is-unfavorable' );
-		assert.include( delta.classes, 'is-decrease' );
-		assert.lengthOf( delta.classes, 2 );
+		expect( delta.classes ).toContain( 'is-unfavorable' );
+		expect( delta.classes ).toContain( 'is-decrease' );
+		expect( delta.classes.length ).toBe( 2 );
 	} );
 
 	test( 'should return correct sign and direction for properties where less is good', () => {
 		const item = { total_refund: 75 };
 		const previousItem = { total_refund: 100 };
 		const delta = calculateDelta( item, previousItem, 'total_refund', 'day' );
-		assert.include( delta.classes, 'is-favorable' );
-		assert.include( delta.classes, 'is-decrease' );
-		assert.lengthOf( delta.classes, 2 );
+		expect( delta.classes ).toContain( 'is-favorable' );
+		expect( delta.classes ).toContain( 'is-decrease' );
+		expect( delta.classes.length ).toBe( 2 );
 	} );
 
 	test( 'should return correct sign and direction for value of 0', () => {
 		const item = { doodads: 100 };
 		const previousItem = { doodads: 100 };
 		const delta = calculateDelta( item, previousItem, 'doodads', 'day' );
-		assert.include( delta.classes, 'is-neutral' );
-		assert.lengthOf( delta.classes, 1 );
+		expect( delta.classes ).toContain( 'is-neutral' );
+		expect( delta.classes.length ).toBe( 1 );
 	} );
 } );
 
@@ -74,7 +73,7 @@ describe( 'getQueryDate', () => {
 			query: { startDate: '2017-06-12' },
 		};
 		const queryDate = getQueryDate( context );
-		assert.isString( queryDate );
+		expect( typeof queryDate ).toBe( 'string' );
 	} );
 
 	test( 'should return a value for today given an undefined startDate queryParameter', () => {
@@ -84,7 +83,7 @@ describe( 'getQueryDate', () => {
 		};
 		const today = moment().format( 'YYYY-MM-DD' );
 		const queryDate = getQueryDate( context );
-		assert.strictEqual( queryDate, today );
+		expect( queryDate ).toBe( today );
 	} );
 
 	test( 'should return a value for today given a startDate of less than the quantity', () => {
@@ -98,7 +97,7 @@ describe( 'getQueryDate', () => {
 		};
 		const queryDate = getQueryDate( context );
 		const today = moment().format( 'YYYY-MM-DD' );
-		assert.strictEqual( queryDate, today );
+		expect( queryDate ).toBe( today );
 	} );
 
 	test( 'should return a value going back only in multiples of the specified quantity', () => {
@@ -115,7 +114,7 @@ describe( 'getQueryDate', () => {
 		const todayShouldBe = moment()
 			.subtract( quantity * 2, 'days' )
 			.format( 'YYYY-MM-DD' );
-		assert.strictEqual( queryDate, todayShouldBe );
+		expect( queryDate ).toBe( todayShouldBe );
 	} );
 
 	test( 'should work in weeks as well', () => {
@@ -132,91 +131,91 @@ describe( 'getQueryDate', () => {
 		const todayShouldBe = moment()
 			.subtract( quantity * 2, 'weeks' )
 			.format( 'YYYY-MM-DD' );
-		assert.strictEqual( queryDate, todayShouldBe );
+		expect( queryDate ).toBe( todayShouldBe );
 	} );
 } );
 
 describe( 'getUnitPeriod', () => {
 	test( 'should return a string', () => {
 		const queryDate = getUnitPeriod( '2017-07-05', 'week' );
-		assert.isString( queryDate );
+		expect( typeof queryDate ).toBe( 'string' );
 	} );
 	test( 'should return an isoWeek format for a week unit', () => {
 		const queryDate = getUnitPeriod( '2017-07-05', 'week' );
-		assert.strictEqual( queryDate, '2017-W27' );
+		expect( queryDate ).toBe( '2017-W27' );
 	} );
 	test( 'should return a well formatted period for a month unit', () => {
 		const queryDate = getUnitPeriod( '2017-07-05', 'month' );
-		assert.strictEqual( queryDate, '2017-07' );
+		expect( queryDate ).toBe( '2017-07' );
 	} );
 	test( 'should return a well formatted period for a year unit', () => {
 		const queryDate = getUnitPeriod( '2017-07-05', 'year' );
-		assert.strictEqual( queryDate, '2017' );
+		expect( queryDate ).toBe( '2017' );
 	} );
 	test( 'should return a well formatted period for a day unit', () => {
 		const queryDate = getUnitPeriod( '2017-07-05', 'day' );
-		assert.strictEqual( queryDate, '2017-07-05' );
+		expect( queryDate ).toBe( '2017-07-05' );
 	} );
 } );
 
 describe( 'getEndPeriod', () => {
 	test( 'should return a string', () => {
 		const queryDate = getEndPeriod( '2017-07-05', 'week' );
-		assert.isString( queryDate );
+		expect( typeof queryDate ).toBe( 'string' );
 	} );
 	test( 'should return an the date for the end of the week', () => {
 		const queryDate = getEndPeriod( '2017-07-05', 'week' );
-		assert.strictEqual( queryDate, '2017-07-09' );
+		expect( queryDate ).toBe( '2017-07-09' );
 	} );
 	test( 'should return an the date for the end of the month', () => {
 		const queryDate = getEndPeriod( '2017-07-05', 'month' );
-		assert.strictEqual( queryDate, '2017-07-31' );
+		expect( queryDate ).toBe( '2017-07-31' );
 	} );
 	test( 'should return an the date for the end of the year', () => {
 		const queryDate = getEndPeriod( '2017-07-05', 'year' );
-		assert.strictEqual( queryDate, '2017-12-31' );
+		expect( queryDate ).toBe( '2017-12-31' );
 	} );
 	test( 'should return an the date for the end of the day', () => {
 		const queryDate = getEndPeriod( '2017-07-05', 'day' );
-		assert.strictEqual( queryDate, '2017-07-05' );
+		expect( queryDate ).toBe( '2017-07-05' );
 	} );
 } );
 
 describe( 'formatValue', () => {
 	test( 'should return a correctly formatted currency for NZD', () => {
 		const response = formatValue( 12.34, 'currency', 'NZD' );
-		assert.isString( response );
-		assert.strictEqual( response, 'NZ$12.34' );
+		expect( typeof response ).toBe( 'string' );
+		expect( response ).toBe( 'NZ$12.34' );
 	} );
 	test( 'should return a correctly formatted currency for USD', () => {
 		const response = formatValue( 12.34, 'currency', 'USD' );
-		assert.isString( response );
-		assert.strictEqual( response, '$12.34' );
+		expect( typeof response ).toBe( 'string' );
+		expect( response ).toBe( '$12.34' );
 	} );
 	test( 'should return a correctly formatted currency for ZAR', () => {
 		const response = formatValue( 12.34, 'currency', 'ZAR' );
-		assert.isString( response );
-		assert.strictEqual( response, 'R12,34' );
+		expect( typeof response ).toBe( 'string' );
+		expect( response ).toBe( 'R12,34' );
 	} );
 	test( 'should return a correctly formatted USD currency for unknown code', () => {
 		const response = formatValue( 12.34, 'currency', 'XXX' );
-		assert.isString( response );
-		assert.strictEqual( response, '$12.34' );
+		expect( typeof response ).toBe( 'string' );
+		expect( response ).toBe( '$12.34' );
 	} );
 	test( 'should return a correctly formatted USD currency for missing code', () => {
 		const response = formatValue( 12.34, 'currency' );
-		assert.isString( response );
-		assert.strictEqual( response, '$12.34' );
+		expect( typeof response ).toBe( 'string' );
+		expect( response ).toBe( '$12.34' );
 	} );
 	test( 'should return a correctly formatted number to 2 decimals', () => {
 		const response = formatValue( 12.3456, 'number' );
-		assert.isNumber( response );
-		assert.strictEqual( response, 12.35 );
+		expect( typeof response ).toBe( 'number' );
+		expect( response ).toBe( 12.35 );
 	} );
 	test( 'should return a correctly formatted string', () => {
 		const response = formatValue( 'string', 'text' );
-		assert.isString( response );
-		assert.strictEqual( response, 'string' );
+		expect( typeof response ).toBe( 'string' );
+		expect( response ).toBe( 'string' );
 	} );
 } );
 
@@ -247,11 +246,11 @@ const deltas = [
 describe( 'getDelta', () => {
 	test( 'should return an Object', () => {
 		const delta = getDelta( deltas, '2017-07-06', 'right' );
-		assert.isObject( delta );
+		expect( typeof delta ).toBe( 'object' );
 	} );
 	test( 'should return the correct delta', () => {
 		const delta = getDelta( deltas, '2017-07-06', 'right' );
-		assert.strictEqual( delta.right, true );
-		assert.strictEqual( delta.period, '2017-07-06' );
+		expect( delta.right ).toBe( true );
+		expect( delta.period ).toBe( '2017-07-06' );
 	} );
 } );

--- a/client/extensions/woocommerce/components/sparkline/test/index.jsx
+++ b/client/extensions/woocommerce/components/sparkline/test/index.jsx
@@ -3,7 +3,6 @@
 /**
  * External dependencies
  */
-import { assert } from 'chai';
 import { shallow } from 'enzyme';
 import React from 'react';
 
@@ -15,59 +14,59 @@ import Sparkline from '../index';
 describe( 'Sparkline', () => {
 	test( 'should allow data to be set.', () => {
 		const sparkline = shallow( <Sparkline data={ [ 1, 2, 3, 4, 5 ] } /> );
-		assert.deepEqual( [ 1, 2, 3, 4, 5 ], sparkline.instance().props.data );
+		expect( [ 1, 2, 3, 4, 5 ] ).toEqual( sparkline.instance().props.data );
 	} );
 
 	test( 'should have sparkline class', () => {
 		const sparkline = shallow( <Sparkline data={ [ 1, 2, 3, 4, 5 ] } /> );
-		assert.lengthOf( sparkline.find( '.sparkline' ), 1 );
+		expect( sparkline.find( '.sparkline' ).length ).toBe( 1 );
 	} );
 
 	test( 'should have className if provided, as well as sparkline class', () => {
 		const sparkline = shallow( <Sparkline data={ [ 1, 2, 3, 4, 5 ] } className="test__foobar" /> );
-		assert.lengthOf( sparkline.find( '.test__foobar' ), 1 );
-		assert.lengthOf( sparkline.find( '.sparkline' ), 1 );
+		expect( sparkline.find( '.test__foobar' ).length ).toBe( 1 );
+		expect( sparkline.find( '.sparkline' ).length ).toBe( 1 );
 	} );
 
 	test( 'should have a default aspectRatio of 4.5', () => {
 		const sparkline = shallow( <Sparkline data={ [ 1, 2, 3, 4, 5 ] } /> );
-		assert.equal( '4.5', sparkline.instance().props.aspectRatio );
+		expect( '4.5' ).toEqual( sparkline.instance().props.aspectRatio );
 	} );
 
 	test( 'should have a defined aspectRatio if set', () => {
 		const sparkline = shallow( <Sparkline data={ [ 1, 2, 3, 4, 5 ] } aspectRatio={ 10 } /> );
-		assert.equal( '10', sparkline.instance().props.aspectRatio );
+		expect( '10' ).toEqual( sparkline.instance().props.aspectRatio );
 	} );
 
 	test( 'should have a default highlightRadius of 3.5', () => {
 		const sparkline = shallow( <Sparkline data={ [ 1, 2, 3, 4, 5 ] } /> );
-		assert.equal( '3.5', sparkline.instance().props.highlightRadius );
+		expect( '3.5' ).toEqual( sparkline.instance().props.highlightRadius );
 	} );
 
 	test( 'should have a defined highlightRadius if set', () => {
 		const sparkline = shallow( <Sparkline data={ [ 1, 2, 3, 4, 5 ] } highlightRadius={ 10 } /> );
-		assert.equal( '10', sparkline.instance().props.highlightRadius );
+		expect( '10' ).toEqual( sparkline.instance().props.highlightRadius );
 	} );
 
 	test( 'should have a default margin', () => {
 		const sparkline = shallow( <Sparkline data={ [ 1, 2, 3, 4, 5 ] } /> );
-		assert.deepEqual( { top: 4, right: 4, bottom: 4, left: 4 }, sparkline.instance().props.margin );
+		expect( { top: 4, right: 4, bottom: 4, left: 4 } ).toEqual( sparkline.instance().props.margin );
 	} );
 
 	test( 'should have a defined margin if set', () => {
 		const sparkline = shallow(
 			<Sparkline data={ [ 1, 2, 3, 4, 5 ] } margin={ { top: 1, right: 1, bottom: 1, left: 1 } } />
 		);
-		assert.deepEqual( { top: 1, right: 1, bottom: 1, left: 1 }, sparkline.instance().props.margin );
+		expect( { top: 1, right: 1, bottom: 1, left: 1 } ).toEqual( sparkline.instance().props.margin );
 	} );
 
 	test( 'should allow maxHeight to be defined.', () => {
 		const sparkline = shallow( <Sparkline data={ [ 1, 2, 3, 4, 5 ] } maxHeight={ 10 } /> );
-		assert.equal( '10', sparkline.instance().props.maxHeight );
+		expect( '10' ).toEqual( sparkline.instance().props.maxHeight );
 	} );
 
 	test( 'should allow highlightIndex to be defined.', () => {
 		const sparkline = shallow( <Sparkline data={ [ 1, 2, 3, 4, 5 ] } highlightIndex={ 10 } /> );
-		assert.equal( '10', sparkline.instance().props.highlightIndex );
+		expect( '10' ).toEqual( sparkline.instance().props.highlightIndex );
 	} );
 } );

--- a/client/lib/ads/test/stores.js
+++ b/client/lib/ads/test/stores.js
@@ -6,11 +6,6 @@
 /**
  * External dependencies
  */
-import { assert } from 'chai';
-
-/**
- * Internal dependencies
- */
 import actions from './lib/mock-actions';
 import site from './lib/mock-site';
 
@@ -25,21 +20,21 @@ describe( 'Ads Stores; EarningsStore, SettingsStore, TosStore', () => {
 	} );
 
 	test( 'Stores should be an object', () => {
-		assert.isObject( EarningsStore );
-		assert.isObject( SettingsStore );
-		assert.isObject( TosStore );
+		expect( typeof EarningsStore ).toBe( 'object' );
+		expect( typeof SettingsStore ).toBe( 'object' );
+		expect( typeof TosStore ).toBe( 'object' );
 	} );
 
 	test( 'Stores should have method getById', () => {
-		assert.isFunction( EarningsStore.getById );
-		assert.isFunction( SettingsStore.getById );
-		assert.isFunction( TosStore.getById );
+		expect( typeof EarningsStore.getById ).toBe( 'function' );
+		expect( typeof SettingsStore.getById ).toBe( 'function' );
+		expect( typeof TosStore.getById ).toBe( 'function' );
 	} );
 
 	test( 'Stores should have method emitChange', () => {
-		assert.isFunction( EarningsStore.emitChange );
-		assert.isFunction( SettingsStore.emitChange );
-		assert.isFunction( TosStore.emitChange );
+		expect( typeof EarningsStore.emitChange ).toBe( 'function' );
+		expect( typeof SettingsStore.emitChange ).toBe( 'function' );
+		expect( typeof TosStore.emitChange ).toBe( 'function' );
 	} );
 
 	describe( 'Fetch', () => {
@@ -54,9 +49,9 @@ describe( 'Ads Stores; EarningsStore, SettingsStore, TosStore', () => {
 				settings = SettingsStore.getById( site.ID ),
 				tos = TosStore.getById( site.ID );
 
-			assert.isObject( earnings );
-			assert.isObject( settings );
-			assert.isObject( tos );
+			expect( typeof earnings ).toBe( 'object' );
+			expect( typeof settings ).toBe( 'object' );
+			expect( typeof tos ).toBe( 'object' );
 		} );
 
 		test( 'The object should not be null after RECEIVE', () => {
@@ -64,9 +59,9 @@ describe( 'Ads Stores; EarningsStore, SettingsStore, TosStore', () => {
 				settings = SettingsStore.getById( site.ID ),
 				tos = TosStore.getById( site.ID );
 
-			assert.isNotNull( earnings.earnings );
-			assert.isNotNull( settings.settings );
-			assert.isNotNull( tos.tos );
+			expect( earnings.earnings ).not.toBeNull();
+			expect( settings.settings ).not.toBeNull();
+			expect( tos.tos ).not.toBeNull();
 		} );
 	} );
 } );

--- a/client/lib/email-followers/test/store.js
+++ b/client/lib/email-followers/test/store.js
@@ -6,11 +6,6 @@
 /**
  * External dependencies
  */
-import { assert } from 'chai';
-
-/**
- * Internal dependencies
- */
 import actions from './lib/mock-actions';
 import site from './lib/mock-site';
 
@@ -28,7 +23,7 @@ describe( 'Email Followers Store', () => {
 	} );
 
 	test( 'Store should be an object', () => {
-		assert.isObject( EmailFollowersStore );
+		expect( typeof EmailFollowersStore ).toBe( 'object' );
 	} );
 
 	describe( 'Fetch Email Followers', () => {
@@ -38,33 +33,33 @@ describe( 'Email Followers Store', () => {
 
 		test( 'Should update the store on RECEIVE_EMAIL_FOLLOWERS', () => {
 			var followers = EmailFollowersStore.getFollowers( options );
-			assert.equal( 2, followers.length );
+			expect( 2 ).toEqual( followers.length );
 		} );
 
 		test( 'The store should return an array of objects when fetching email followers', () => {
 			var followers = EmailFollowersStore.getFollowers( options );
-			assert.isArray( followers );
-			assert.isObject( followers[ 0 ] );
+			expect( Array.isArray( followers ) ).toBe( true );
+			expect( typeof followers[ 0 ] ).toBe( 'object' );
 		} );
 
 		test( 'Fetching more email followers should update the array in the store', () => {
 			var followers = EmailFollowersStore.getFollowers( options ),
 				followersAgain;
-			assert.equal( followers.length, 2 );
+			expect( followers.length ).toEqual( 2 );
 			Dispatcher.handleServerAction( actions.fetchedMoreFollowers );
 			followersAgain = EmailFollowersStore.getFollowers( options );
-			assert.equal( followersAgain.length, 4 );
+			expect( followersAgain.length ).toEqual( 4 );
 		} );
 
 		test( 'Pagination data should update when we fetch more email followers', () => {
 			var pagination = EmailFollowersStore.getPaginationData( options );
-			assert.equal( pagination.totalFollowers, 4 );
-			assert.equal( pagination.numFollowersFetched, 2 );
-			assert.equal( pagination.followersCurrentPage, 1 );
+			expect( pagination.totalFollowers ).toEqual( 4 );
+			expect( pagination.numFollowersFetched ).toEqual( 2 );
+			expect( pagination.followersCurrentPage ).toEqual( 1 );
 			Dispatcher.handleServerAction( actions.fetchedMoreFollowers );
 			pagination = EmailFollowersStore.getPaginationData( options );
-			assert.equal( pagination.numFollowersFetched, 4 );
-			assert.equal( pagination.followersCurrentPage, 2 );
+			expect( pagination.numFollowersFetched ).toEqual( 4 );
+			expect( pagination.followersCurrentPage ).toEqual( 2 );
 		} );
 	} );
 
@@ -76,23 +71,23 @@ describe( 'Email Followers Store', () => {
 			var followers = EmailFollowersStore.getFollowers( options ),
 				followersAgain;
 
-			assert.equal( followers.length, 2 );
+			expect( followers.length ).toEqual( 2 );
 			Dispatcher.handleServerAction( actions.removeFollower );
 			Dispatcher.handleServerAction( actions.removeFollowerSuccess );
 			followersAgain = EmailFollowersStore.getFollowers( options );
-			assert.equal( followersAgain.length, 1 );
+			expect( followersAgain.length ).toEqual( 1 );
 		} );
 		test( 'Should restore a single follower on removal error.', () => {
 			var followers = EmailFollowersStore.getFollowers( options ),
 				followersAfterRemove,
 				followersAfterError;
-			assert.equal( followers.length, 2 );
+			expect( followers.length ).toEqual( 2 );
 			Dispatcher.handleServerAction( actions.removeFollower );
 			followersAfterRemove = EmailFollowersStore.getFollowers( options );
-			assert.equal( followersAfterRemove.length, 1 );
+			expect( followersAfterRemove.length ).toEqual( 1 );
 			Dispatcher.handleServerAction( actions.removeFollowerError );
 			followersAfterError = EmailFollowersStore.getFollowers( options );
-			assert.equal( followersAfterError.length, 2 );
+			expect( followersAfterError.length ).toEqual( 2 );
 		} );
 	} );
 } );

--- a/client/lib/follow-list/test/index.js
+++ b/client/lib/follow-list/test/index.js
@@ -5,7 +5,6 @@
 
 jest.mock( 'lib/wp', () => require( './mocks/lib/wp' ) );
 
-import { assert } from 'chai';
 import sinon from 'sinon';
 
 describe( 'index', () => {
@@ -22,20 +21,20 @@ describe( 'index', () => {
 		describe( 'add', () => {
 			test( 'should add a site', () => {
 				followList.add( { site_id: 95327318, is_following: false } );
-				assert.equal( followList.data.length, 1 );
+				expect( followList.data.length ).toEqual( 1 );
 			} );
 
 			test( 'should create an instance of FollowListSite', () => {
 				followList.add( { site_id: 95327318, is_following: false } );
-				assert.isTrue( followList.data[ 0 ] instanceof FollowListSite );
+				expect( followList.data[ 0 ] instanceof FollowListSite ).toBe( true );
 			} );
 
 			test( 'should not add a duplicate site_id', () => {
 				followList.add( { site_id: 95327318, is_following: false } );
-				assert.equal( followList.data.length, 1 );
+				expect( followList.data.length ).toEqual( 1 );
 				followList.add( { site_id: 95327318, is_following: false } );
 				followList.add( { site_id: 71611100, is_following: false } );
-				assert.equal( followList.data.length, 2 );
+				expect( followList.data.length ).toEqual( 2 );
 			} );
 		} );
 	} );
@@ -43,8 +42,8 @@ describe( 'index', () => {
 	describe( 'FollowListSite', () => {
 		describe( 'instantiation', () => {
 			test( 'should set the attributes', () => {
-				assert.equal( site.site_id, 95327318 );
-				assert.equal( site.is_following, false );
+				expect( site.site_id ).toEqual( 95327318 );
+				expect( site.is_following ).toEqual( false );
 			} );
 		} );
 
@@ -53,8 +52,8 @@ describe( 'index', () => {
 				var changeCallback = sinon.spy();
 				site.on( 'change', changeCallback );
 				site.follow();
-				assert.isTrue( changeCallback.called, 'callbacks subscribed to change should be called' );
-				assert.isTrue( site.is_following );
+				expect( changeCallback.called ).toBe( true );
+				expect( site.is_following ).toBe( true );
 			} );
 
 			test( 'should not call the follow endpoint or execute the callback if already following', () => {
@@ -62,8 +61,8 @@ describe( 'index', () => {
 				site.is_following = true;
 				site.on( 'change', changeCallback );
 				site.follow();
-				assert.isFalse( changeCallback.called, 'callbacks subscribed to change should not called' );
-				assert.isTrue( site.is_following );
+				expect( changeCallback.called ).toBe( false );
+				expect( site.is_following ).toBe( true );
 			} );
 		} );
 
@@ -73,8 +72,8 @@ describe( 'index', () => {
 				site.is_following = true;
 				site.on( 'change', changeCallback );
 				site.unfollow();
-				assert.isTrue( changeCallback.called, 'callbacks subscribed to change should be called' );
-				assert.isFalse( site.is_following );
+				expect( changeCallback.called ).toBe( true );
+				expect( site.is_following ).toBe( false );
 			} );
 
 			test( 'should not call the unfollow endpoint or execute the callback if already following', () => {
@@ -82,8 +81,8 @@ describe( 'index', () => {
 				site.is_following = false;
 				site.on( 'change', changeCallback );
 				site.unfollow();
-				assert.isFalse( changeCallback.called, 'callbacks subscribed to change should not called' );
-				assert.isFalse( site.is_following );
+				expect( changeCallback.called ).toBe( false );
+				expect( site.is_following ).toBe( false );
 			} );
 		} );
 	} );

--- a/client/lib/followers/test/store.js
+++ b/client/lib/followers/test/store.js
@@ -6,11 +6,6 @@
 /**
  * External dependencies
  */
-import { assert } from 'chai';
-
-/**
- * Internal dependencies
- */
 import actions from './lib/mock-actions';
 import site from './lib/mock-site';
 
@@ -28,7 +23,7 @@ describe( 'WPCOM Followers Store', () => {
 	} );
 
 	test( 'Store should be an object', () => {
-		assert.isObject( FollowersStore );
+		expect( typeof FollowersStore ).toBe( 'object' );
 	} );
 
 	describe( 'Fetch Followers', () => {
@@ -38,33 +33,33 @@ describe( 'WPCOM Followers Store', () => {
 
 		test( 'Should update the store on RECEIVE_FOLLOWERS', () => {
 			var followers = FollowersStore.getFollowers( options );
-			assert.equal( 2, followers.length );
+			expect( 2 ).toEqual( followers.length );
 		} );
 
 		test( 'The store should return an array of objects when fetching followers', () => {
 			var followers = FollowersStore.getFollowers( options );
-			assert.isArray( followers );
-			assert.isObject( followers[ 0 ] );
+			expect( Array.isArray( followers ) ).toBe( true );
+			expect( typeof followers[ 0 ] ).toBe( 'object' );
 		} );
 
 		test( 'Fetching more followers should update the array in the store', () => {
 			var followers = FollowersStore.getFollowers( options ),
 				followersAgain;
-			assert.equal( followers.length, 2 );
+			expect( followers.length ).toEqual( 2 );
 			Dispatcher.handleServerAction( actions.fetchedMoreFollowers );
 			followersAgain = FollowersStore.getFollowers( options );
-			assert.equal( followersAgain.length, 4 );
+			expect( followersAgain.length ).toEqual( 4 );
 		} );
 
 		test( 'Pagination data should update when we fetch more followers', () => {
 			var pagination = FollowersStore.getPaginationData( options );
-			assert.equal( pagination.totalFollowers, 4 );
-			assert.equal( pagination.numFollowersFetched, 2 );
-			assert.equal( pagination.followersCurrentPage, 1 );
+			expect( pagination.totalFollowers ).toEqual( 4 );
+			expect( pagination.numFollowersFetched ).toEqual( 2 );
+			expect( pagination.followersCurrentPage ).toEqual( 1 );
 			Dispatcher.handleServerAction( actions.fetchedMoreFollowers );
 			pagination = FollowersStore.getPaginationData( options );
-			assert.equal( pagination.numFollowersFetched, 4 );
-			assert.equal( pagination.followersCurrentPage, 2 );
+			expect( pagination.numFollowersFetched ).toEqual( 4 );
+			expect( pagination.followersCurrentPage ).toEqual( 2 );
 		} );
 	} );
 
@@ -76,23 +71,23 @@ describe( 'WPCOM Followers Store', () => {
 			var followers = FollowersStore.getFollowers( options ),
 				followersAgain;
 
-			assert.equal( followers.length, 2 );
+			expect( followers.length ).toEqual( 2 );
 			Dispatcher.handleServerAction( actions.removeFollower );
 			Dispatcher.handleServerAction( actions.removeFollowerSuccess );
 			followersAgain = FollowersStore.getFollowers( options );
-			assert.equal( followersAgain.length, 1 );
+			expect( followersAgain.length ).toEqual( 1 );
 		} );
 		test( 'Should restore a single follower on removal error.', () => {
 			var followers = FollowersStore.getFollowers( options ),
 				followersAfterRemove,
 				followersAfterError;
-			assert.equal( followers.length, 2 );
+			expect( followers.length ).toEqual( 2 );
 			Dispatcher.handleServerAction( actions.removeFollower );
 			followersAfterRemove = FollowersStore.getFollowers( options );
-			assert.equal( followersAfterRemove.length, 1 );
+			expect( followersAfterRemove.length ).toEqual( 1 );
 			Dispatcher.handleServerAction( actions.removeFollowerError );
 			followersAfterError = FollowersStore.getFollowers( options );
-			assert.equal( followersAfterError.length, 2 );
+			expect( followersAfterError.length ).toEqual( 2 );
 		} );
 	} );
 } );

--- a/client/lib/help-search/test/store.js
+++ b/client/lib/help-search/test/store.js
@@ -3,7 +3,6 @@
  * Internal dependencies
  */
 import actions from './lib/mock-actions';
-import { assert } from 'chai';
 
 describe( 'Help search Store', () => {
 	var Dispatcher, HelpSearchStore;
@@ -17,8 +16,8 @@ describe( 'Help search Store', () => {
 		test( 'Should return empty array when there are no help links', () => {
 			var helpLinks = HelpSearchStore.getHelpLinks();
 
-			assert( Array.isArray( helpLinks ), 'help links is not an array' );
-			assert( 0 === helpLinks.length, 'help links is empty' );
+			expect( Array.isArray( helpLinks ) ).toBeTruthy();
+			expect( 0 === helpLinks.length ).toBeTruthy();
 		} );
 
 		test( 'Should return an array of help link when there are help links', () => {
@@ -27,8 +26,8 @@ describe( 'Help search Store', () => {
 			Dispatcher.handleServerAction( actions.fetchedHelpLinks );
 			helpLinks = HelpSearchStore.getHelpLinks();
 
-			assert( Array.isArray( helpLinks ), 'help links is not an array' );
-			assert.isObject( helpLinks[ 0 ] );
+			expect( Array.isArray( helpLinks ) ).toBeTruthy();
+			expect( typeof helpLinks[ 0 ] ).toBe( 'object' );
 		} );
 	} );
 } );

--- a/client/lib/invites/reducers/test/invites-create-validation.js
+++ b/client/lib/invites/reducers/test/invites-create-validation.js
@@ -3,11 +3,6 @@
 /**
  * External dependencies
  */
-import { assert } from 'chai';
-
-/**
- * Internal dependencies
- */
 import Dispatcher from 'dispatcher';
 import { action as ActionTypes } from 'lib/invites/constants';
 
@@ -46,9 +41,9 @@ describe( 'Invites Create Validation Store', () => {
 
 		test( 'Validation is not empty', () => {
 			const success = InvitesCreateValidationStore.getSuccess( siteId );
-			assert.lengthOf( success, 2 );
+			expect( success.length ).toBe( 2 );
 			const errors = InvitesCreateValidationStore.getErrors( siteId );
-			assert.equal( errors, validationData.errors );
+			expect( errors ).toEqual( validationData.errors );
 		} );
 	} );
 } );

--- a/client/lib/invites/stores/test/invites-list.js
+++ b/client/lib/invites/stores/test/invites-list.js
@@ -3,11 +3,6 @@
 /**
  * External dependencies
  */
-import { assert } from 'chai';
-
-/**
- * Internal dependencies
- */
 import Dispatcher from 'dispatcher';
 import { action as ActionTypes } from 'lib/invites/constants';
 
@@ -64,16 +59,16 @@ describe( 'List Invites Store', () => {
 
 		test( 'List of invites should be an object', () => {
 			const invites = ListInvitesStore.getInvites( siteId );
-			assert.isObject( invites );
+			expect( typeof invites ).toBe( 'object' );
 		} );
 
 		test( 'Fetching more invites should add to the object', () => {
 			const invites = ListInvitesStore.getInvites( siteId );
 			let invitesAgain = [];
-			assert.equal( 1, invites.size );
+			expect( 1 ).toEqual( invites.size );
 			Dispatcher.handleServerAction( actions.receiveMoreInvites );
 			invitesAgain = ListInvitesStore.getInvites( siteId );
-			assert.equal( 2, invitesAgain.size );
+			expect( 2 ).toEqual( invitesAgain.size );
 		} );
 	} );
 } );

--- a/client/lib/local-list/test/index.js
+++ b/client/lib/local-list/test/index.js
@@ -6,11 +6,6 @@
 /**
  * External dependencies
  */
-import { assert } from 'chai';
-
-/**
- * Internal dependencies
- */
 import LocalList from '../';
 
 jest.mock( 'store', () => {
@@ -46,46 +41,46 @@ describe( 'LocalList', () => {
 	describe( 'options', () => {
 		test( 'should set the localStoreKey', () => {
 			const statList2 = new LocalList( { localStoreKey: 'RandomKey' } );
-			assert.equal( statList2.localStoreKey, 'RandomKey' );
+			expect( statList2.localStoreKey ).toEqual( 'RandomKey' );
 		} );
 
 		test( 'should set the limit', () => {
 			const statList2 = new LocalList( { localStoreKey: 'RandomKey2', limit: 25 } );
-			assert.equal( statList2.limit, 25 );
+			expect( statList2.limit ).toEqual( 25 );
 		} );
 	} );
 
 	describe( 'functions', () => {
 		test( 'should have set function', () => {
-			assert.isFunction( statList.set, 'set should be a function' );
+			expect( typeof statList.set ).toBe( 'function' );
 		} );
 
 		test( 'should have find function', () => {
-			assert.isFunction( statList.find, 'find should be a function' );
+			expect( typeof statList.find ).toBe( 'function' );
 		} );
 
 		test( 'should have getData function', () => {
-			assert.isFunction( statList.getData, 'getData should be a function' );
+			expect( typeof statList.getData ).toBe( 'function' );
 		} );
 
 		test( 'should have clear function', () => {
-			assert.isFunction( statList.clear, 'clear should be a function' );
+			expect( typeof statList.clear ).toBe( 'function' );
 		} );
 	} );
 
 	describe( 'getData', () => {
 		test( 'should return an empty array', () => {
-			assert.lengthOf( statList.getData(), 0, 'localData should be empty' );
+			expect( statList.getData().length ).toBe( 0 );
 		} );
 	} );
 
 	describe( 'clear', () => {
 		test( 'should empty the localStorage', () => {
 			createLocalRecords( statList, 2 );
-			assert.lengthOf( statList.getData(), 2, 'localData should have two records' );
+			expect( statList.getData().length ).toBe( 2 );
 
 			statList.clear();
-			assert.lengthOf( statList.getData(), 0, 'localData should have no records' );
+			expect( statList.getData().length ).toBe( 0 );
 		} );
 	} );
 
@@ -96,19 +91,19 @@ describe( 'LocalList', () => {
 
 		test( 'should store local data for a given key', () => {
 			statList.set( anExampleKey, {} );
-			assert.lengthOf( statList.getData(), 1, 'localData should have one record' );
+			expect( statList.getData().length ).toBe( 1 );
 		} );
 
 		test( 'should only store one record for a given key', () => {
 			statList.set( anExampleKey, {} );
 			statList.set( anExampleKey, {} );
-			assert.lengthOf( statList.getData(), 1, 'localData should have one record' );
+			expect( statList.getData().length ).toBe( 1 );
 		} );
 
 		test( 'should store multiple records for different keys', () => {
 			statList.set( anExampleKey, {} );
 			statList.set( anExampleKey + '-too', {} );
-			assert.lengthOf( statList.getData(), 2, 'localData should have two records' );
+			expect( statList.getData().length ).toBe( 2 );
 		} );
 
 		test( 'should store the newest record for a given key', () => {
@@ -117,8 +112,8 @@ describe( 'LocalList', () => {
 			statList.set( anExampleKey, { newest: true } );
 
 			const localRecord = statList.getData()[ 0 ];
-			assert.lengthOf( statList.getData(), 1, 'localData should have one record' );
-			assert.isTrue( localRecord.data.newest );
+			expect( statList.getData().length ).toBe( 1 );
+			expect( localRecord.data.newest ).toBe( true );
 		} );
 
 		describe( 'record', () => {
@@ -126,17 +121,17 @@ describe( 'LocalList', () => {
 				statList.clear();
 				const localRecord = statList.set( anExampleKey, {} );
 
-				assert.equal( localRecord.key, anExampleKey, 'It should have the correct key' );
+				expect( localRecord.key ).toEqual( anExampleKey );
 			} );
 
 			test( 'should set a createdAt attribute', () => {
 				const localRecord = statList.getData()[ 0 ];
-				assert.typeOf( localRecord.createdAt, 'number', 'It should have a timestamp' );
+				expect( typeof localRecord.createdAt ).toBe( 'number' );
 			} );
 
 			test( 'should set the data', () => {
 				const localRecord = statList.getData()[ 0 ];
-				assert.typeOf( localRecord.data, 'object', 'It should have a data object' );
+				expect( typeof localRecord.data ).toBe( 'object' );
 			} );
 		} );
 	} );
@@ -145,40 +140,28 @@ describe( 'LocalList', () => {
 		test( 'should default to only allow 10 records to be stored', () => {
 			statList.clear();
 			createLocalRecords( statList, 12 );
-			assert.lengthOf( statList.getData(), 10, 'localData should have 10 records' );
-			assert.equal(
-				statList.getData()[ 9 ].key,
-				anExampleKey + '||' + 11,
-				'the last record should be the last created'
-			);
-			assert.equal(
-				statList.getData()[ 0 ].key,
-				anExampleKey + '||' + 2,
-				'the oldest record should be correct'
-			);
+			expect( statList.getData().length ).toBe( 10 );
+			expect( statList.getData()[ 9 ].key ).toEqual( anExampleKey + '||' + 11 );
+			expect( statList.getData()[ 0 ].key ).toEqual( anExampleKey + '||' + 2 );
 		} );
 
 		test( 'should allow default limit to be overidden', () => {
 			const limit = 14,
 				statList2 = new LocalList( { localStoreKey: 'TestLocalListKey2', limit: limit } );
-			assert.equal( statList2.limit, limit );
+			expect( statList2.limit ).toEqual( limit );
 
 			for ( let i = 0; i < limit; i++ ) {
 				const key = anExampleKey + '||' + i;
 				statList2.set( key, {} );
 			}
 
-			assert.equal(
-				statList2.getData().length,
-				limit,
-				'localData should have ' + limit + ' records'
-			);
+			expect( statList2.getData().length ).toEqual( limit );
 		} );
 	} );
 
 	describe( 'find', () => {
 		test( 'should return false if record not found', () => {
-			assert.isFalse( statList.find( 'chewbacca' ), 'there should not be a chewbacca in here' );
+			expect( statList.find( 'chewbacca' ) ).toBe( false );
 		} );
 
 		test( 'should return the correct record', () => {
@@ -186,7 +169,7 @@ describe( 'LocalList', () => {
 			statList.set( anExampleKey, {} );
 			createLocalRecords( statList, 2 );
 			const record = statList.find( anExampleKey );
-			assert.equal( record.key, anExampleKey, 'Keys should match' );
+			expect( record.key ).toEqual( anExampleKey );
 		} );
 	} );
 } );

--- a/client/lib/local-storage/test/index.js
+++ b/client/lib/local-storage/test/index.js
@@ -3,8 +3,6 @@
 /**
  * External dependencies
  */
-import { assert } from 'chai';
-
 describe( 'localStorage', () => {
 	describe( 'when window.localStorage does not exist', () => {
 		const window = {};
@@ -14,13 +12,13 @@ describe( 'localStorage', () => {
 		} );
 
 		test( 'should create a window.localStorage instance', () => {
-			assert( window.localStorage );
+			expect( window.localStorage ).toBeTruthy();
 		} );
 
 		test( 'should correctly store and retrieve data', () => {
 			window.localStorage.setItem( 'foo', 'bar' );
-			assert.equal( window.localStorage.getItem( 'foo' ), 'bar' );
-			assert.equal( window.localStorage.length, 1 );
+			expect( window.localStorage.getItem( 'foo' ) ).toEqual( 'bar' );
+			expect( window.localStorage.length ).toEqual( 1 );
 		} );
 	} );
 
@@ -34,16 +32,16 @@ describe( 'localStorage', () => {
 		} );
 
 		test( 'should overwrite broken or missing methods', () => {
-			assert( window.localStorage.setItem );
-			assert( window.localStorage.getItem );
-			assert( window.localStorage.removeItem );
-			assert( window.localStorage.clear );
+			expect( window.localStorage.setItem ).toBeTruthy();
+			expect( window.localStorage.getItem ).toBeTruthy();
+			expect( window.localStorage.removeItem ).toBeTruthy();
+			expect( window.localStorage.clear ).toBeTruthy();
 		} );
 
 		test( 'should correctly store and retrieve data', () => {
 			window.localStorage.setItem( 'foo', 'bar' );
-			assert.equal( window.localStorage.getItem( 'foo' ), 'bar' );
-			assert.equal( window.localStorage.length, 1 );
+			expect( window.localStorage.getItem( 'foo' ) ).toEqual( 'bar' );
+			expect( window.localStorage.length ).toEqual( 1 );
 		} );
 	} );
 } );

--- a/client/lib/mixins/data-observe/test/index.js
+++ b/client/lib/mixins/data-observe/test/index.js
@@ -4,12 +4,6 @@
  * @format
  */
 
-import { assert } from 'chai';
-
-/**
- * Internal dependencies
- */
-/* eslint-disable no-restricted-imports */
 import observe from 'lib/mixins/data-observe';
 /* eslint-enable no-restricted-imports */
 
@@ -29,15 +23,15 @@ describe( 'observe()', () => {
 			var mixin = observe( 'baba', 'dyado' ),
 				context = mockContext( 'baba', 'dyado', 'pancho' );
 			mixin.componentDidMount.call( context );
-			assert.deepEqual( [ 'baba', 'dyado' ], context.onCalls );
-			assert.deepEqual( [], context.offCalls );
+			expect( [ 'baba', 'dyado' ] ).toEqual( context.onCalls );
+			expect( [] ).toEqual( context.offCalls );
 		} );
 		test( 'should not call .on() if the props are missing', () => {
 			var mixin = observe( 'baba', 'dyado' ),
 				context = mockContext( 'wink', 'blurp', 'foo' );
 			mixin.componentDidMount.call( context );
-			assert.deepEqual( [], context.onCalls );
-			assert.deepEqual( [], context.offCalls );
+			expect( [] ).toEqual( context.onCalls );
+			expect( [] ).toEqual( context.offCalls );
 		} );
 	} );
 
@@ -46,15 +40,15 @@ describe( 'observe()', () => {
 			var mixin = observe( 'baba', 'dyado' ),
 				context = mockContext( 'baba', 'non-existant' );
 			mixin.componentWillUnmount.call( context );
-			assert.deepEqual( [], context.onCalls );
-			assert.deepEqual( [ 'baba' ], context.offCalls );
+			expect( [] ).toEqual( context.onCalls );
+			expect( [ 'baba' ] ).toEqual( context.offCalls );
 		} );
 		test( 'should not call .off() on the props if the props are missing', () => {
 			var mixin = observe( 'baba', 'dyado' ),
 				context = mockContext( 'non-existant' );
 			mixin.componentWillUnmount.call( context );
-			assert.deepEqual( [], context.onCalls );
-			assert.deepEqual( [], context.offCalls );
+			expect( [] ).toEqual( context.onCalls );
+			expect( [] ).toEqual( context.offCalls );
 		} );
 	} );
 
@@ -63,8 +57,8 @@ describe( 'observe()', () => {
 			var mixin = observe( 'baba', 'dyado' ),
 				context = mockContext( 'baba', 'dyado', 'wink' );
 			mixin.componentWillReceiveProps.call( context, context.props );
-			assert.deepEqual( [], context.onCalls );
-			assert.deepEqual( [], context.offCalls );
+			expect( [] ).toEqual( context.onCalls );
+			expect( [] ).toEqual( context.offCalls );
 		} );
 		test( 'should re-bind the event handlers if the props reference changed', () => {
 			var mixin = observe( 'baba', 'dyado' ),
@@ -73,15 +67,15 @@ describe( 'observe()', () => {
 				baba: context.props.baba,
 				dyado: mockEventEmitter( context, 'dyado' ),
 			} );
-			assert.deepEqual( [ 'dyado' ], context.onCalls );
-			assert.deepEqual( [ 'dyado' ], context.offCalls );
+			expect( [ 'dyado' ] ).toEqual( context.onCalls );
+			expect( [ 'dyado' ] ).toEqual( context.offCalls );
 		} );
 		test( 'should only unbind the event if the prop goes missing, but not bind it', () => {
 			var mixin = observe( 'baba', 'dyado' ),
 				context = mockContext( 'baba', 'dyado' );
 			mixin.componentWillReceiveProps.call( context, { baba: context.props.baba } );
-			assert.deepEqual( [], context.onCalls );
-			assert.deepEqual( [ 'dyado' ], context.offCalls );
+			expect( [] ).toEqual( context.onCalls );
+			expect( [ 'dyado' ] ).toEqual( context.offCalls );
 		} );
 		test( 'should only bind the event if the prop appears, but not unbind it', () => {
 			var mixin = observe( 'baba', 'dyado' ),
@@ -89,8 +83,8 @@ describe( 'observe()', () => {
 			mixin.componentWillReceiveProps.call( context, {
 				baba: mockEventEmitter( context, 'baba' ),
 			} );
-			assert.deepEqual( [ 'baba' ], context.onCalls );
-			assert.deepEqual( [], context.offCalls );
+			expect( [ 'baba' ] ).toEqual( context.onCalls );
+			expect( [] ).toEqual( context.offCalls );
 		} );
 	} );
 } );
@@ -113,19 +107,19 @@ function mockEventEmitter( context, name ) {
 	return {
 		on: function( event, callback ) {
 			context.onCalls.push( name );
-			assert.deepEqual( 'change', event );
-			assert.deepEqual( 'callback', callback );
+			expect( 'change' ).toEqual( event );
+			expect( 'callback' ).toEqual( callback );
 		},
 		off: function( event, callback ) {
 			context.offCalls.push( name );
-			assert.deepEqual( 'change', event );
-			assert.deepEqual( 'callback', callback );
+			expect( 'change' ).toEqual( event );
+			expect( 'callback' ).toEqual( callback );
 		},
 	};
 }
 
 function assertMixin( mixin ) {
-	assert.isFunction( mixin.componentDidMount );
-	assert.isFunction( mixin.componentWillUnmount );
-	assert.isFunction( mixin.componentWillReceiveProps );
+	expect( typeof mixin.componentDidMount ).toBe( 'function' );
+	expect( typeof mixin.componentWillUnmount ).toBe( 'function' );
+	expect( typeof mixin.componentWillReceiveProps ).toBe( 'function' );
 }

--- a/client/lib/notification-settings-store/test/index.js
+++ b/client/lib/notification-settings-store/test/index.js
@@ -2,7 +2,6 @@
 /**
  * External dependencies
  */
-import { assert } from 'chai';
 import sinon from 'sinon';
 
 /**
@@ -44,7 +43,7 @@ describe( 'index', () => {
 	} );
 
 	test( 'should have a dispatch token', () => {
-		assert.property( NotificationSettingsStore, 'dispatchToken' );
+		expect( 'dispatchToken' in NotificationSettingsStore ).toBeTruthy();
 	} );
 
 	describe( 'get blog settings', () => {
@@ -77,8 +76,8 @@ describe( 'index', () => {
 
 			const state = NotificationSettingsStore.getStateFor( 'blogs' );
 
-			assert.equal( getNotificationSettingsStub.callCount, 1 );
-			assert.deepEqual( state.settings.toJS(), blogsSettings );
+			expect( getNotificationSettingsStub.callCount ).toEqual( 1 );
+			expect( state.settings.toJS() ).toEqual( blogsSettings );
 		} );
 	} );
 
@@ -109,8 +108,8 @@ describe( 'index', () => {
 
 			const state = NotificationSettingsStore.getStateFor( 'other' );
 
-			assert.equal( getNotificationSettingsStub.callCount, 1 );
-			assert.deepEqual( state.settings.toJS(), otherSettings );
+			expect( getNotificationSettingsStub.callCount ).toEqual( 1 );
+			expect( state.settings.toJS() ).toEqual( otherSettings );
 		} );
 	} );
 
@@ -127,8 +126,8 @@ describe( 'index', () => {
 
 			const state = NotificationSettingsStore.getStateFor( 'wpcom' );
 
-			assert.equal( getNotificationSettingsStub.callCount, 1 );
-			assert.deepEqual( state.settings.toJS(), emailSettings );
+			expect( getNotificationSettingsStub.callCount ).toEqual( 1 );
+			expect( state.settings.toJS() ).toEqual( emailSettings );
 		} );
 	} );
 
@@ -166,22 +165,22 @@ describe( 'index', () => {
 			NotificationSettingsStoreActions.toggle( 1234567, 'timeline', 'new_comment' );
 
 			const state = NotificationSettingsStore.getStateFor( 'blogs' );
-			assert.notOk(
+			expect(
 				state.settings
 					.find( blog => blog.get( 'blog_id' ) === 123456 )
 					.getIn( [ 'timeline', 'new_comment' ] )
-			);
+			).toBeFalsy();
 
-			assert.ok(
+			expect(
 				state.settings
 					.find( blog => blog.get( 'blog_id' ) === 1234567 )
 					.getIn( [ 'timeline', 'new_comment' ] )
-			);
-			assert.notOk(
+			).toBeTruthy();
+			expect(
 				state.settings
 					.find( blog => blog.get( 'blog_id' ) === 1234567 )
 					.getIn( [ 'email', 'new_comment' ] )
-			);
+			).toBeFalsy();
 		} );
 
 		test( 'should toggle a device setting for a blog by device id and blog id', () => {
@@ -189,29 +188,29 @@ describe( 'index', () => {
 
 			const state = NotificationSettingsStore.getStateFor( 'blogs' );
 
-			assert.ok(
+			expect(
 				state.settings
 					.find( blog => blog.get( 'blog_id' ) === 1234567 )
 					.get( 'devices' )
 					.find( device => device.get( 'device_id' ) === 1234 )
 					.get( 'new_comment' )
-			);
+			).toBeTruthy();
 
-			assert.notOk(
+			expect(
 				state.settings
 					.find( blog => blog.get( 'blog_id' ) === 123456 )
 					.get( 'devices' )
 					.find( device => device.get( 'device_id' ) === 1234 )
 					.get( 'new_comment' )
-			);
+			).toBeFalsy();
 
-			assert.notOk(
+			expect(
 				state.settings
 					.find( blog => blog.get( 'blog_id' ) === 1234567 )
 					.get( 'devices' )
 					.find( device => device.get( 'device_id' ) === 123 )
 					.get( 'new_comment' )
-			);
+			).toBeFalsy();
 		} );
 	} );
 
@@ -236,7 +235,7 @@ describe( 'index', () => {
 			NotificationSettingsStoreActions.toggle( 'other', 'timeline', 'new_comment' );
 
 			const state = NotificationSettingsStore.getStateFor( 'other' );
-			assert.ok( state.settings.getIn( [ 'timeline', 'new_comment' ] ) );
+			expect( state.settings.getIn( [ 'timeline', 'new_comment' ] ) ).toBeTruthy();
 		} );
 
 		test( 'should toggle a device setting by device id', () => {
@@ -244,19 +243,19 @@ describe( 'index', () => {
 
 			const state = NotificationSettingsStore.getStateFor( 'other' );
 
-			assert.ok(
+			expect(
 				state.settings
 					.get( 'devices' )
 					.find( device => device.get( 'device_id' ) === 1234 )
 					.get( 'new_comment' )
-			);
+			).toBeTruthy();
 
-			assert.notOk(
+			expect(
 				state.settings
 					.get( 'devices' )
 					.find( device => device.get( 'device_id' ) === 12345 )
 					.get( 'new_comment' )
-			);
+			).toBeFalsy();
 		} );
 	} );
 
@@ -274,8 +273,8 @@ describe( 'index', () => {
 			NotificationSettingsStoreActions.toggle( 'wpcom', null, 'new_comment' );
 
 			const state = NotificationSettingsStore.getStateFor( 'wpcom' );
-			assert.ok( state.settings.get( 'new_comment' ) );
-			assert.notOk( state.settings.get( 'comment_like' ) );
+			expect( state.settings.get( 'new_comment' ) ).toBeTruthy();
+			expect( state.settings.get( 'comment_like' ) ).toBeFalsy();
 		} );
 	} );
 } );

--- a/client/lib/olark-store/test/index.js
+++ b/client/lib/olark-store/test/index.js
@@ -3,23 +3,18 @@
 /**
  * External dependencies
  */
-import { assert } from 'chai';
-
-/**
- * Internal dependencies
- */
 import olarkStore from 'lib/olark-store';
 
 describe( 'index', () => {
 	test( 'Olark store data should be an object', () => {
 		const data = olarkStore.get();
-		assert.isObject( data );
+		expect( typeof data ).toBe( 'object' );
 	} );
 
 	test( 'Olark store data should have expected properties', () => {
 		const data = olarkStore.get();
-		assert.isBoolean( data.isOlarkReady );
-		assert.isBoolean( data.isOperatorAvailable );
-		assert.isObject( data.details );
+		expect( typeof data.isOlarkReady ).toBe( 'boolean' );
+		expect( typeof data.isOperatorAvailable ).toBe( 'boolean' );
+		expect( typeof data.details ).toBe( 'object' );
 	} );
 } );

--- a/client/lib/people/test/log-store.js
+++ b/client/lib/people/test/log-store.js
@@ -6,11 +6,6 @@
 /**
  * External dependencies
  */
-import { assert } from 'chai';
-
-/**
- * Internal dependencies
- */
 import actions from './fixtures/actions';
 import site from './fixtures/site';
 import userActions from 'lib/users/test/fixtures/actions';
@@ -26,90 +21,90 @@ describe( 'Viewers Store', () => {
 
 	describe( 'Shape of store', () => {
 		test( 'Store should be an object', () => {
-			assert.isObject( PeopleLogStore );
+			expect( typeof PeopleLogStore ).toBe( 'object' );
 		} );
 
 		test( 'Store should have method emitChange', () => {
-			assert.isFunction( PeopleLogStore.emitChange );
+			expect( typeof PeopleLogStore.emitChange ).toBe( 'function' );
 		} );
 
 		test( 'Store should have method hasUnauthorizedError', () => {
-			assert.isFunction( PeopleLogStore.hasUnauthorizedError );
+			expect( typeof PeopleLogStore.hasUnauthorizedError ).toBe( 'function' );
 		} );
 
 		test( 'Store should have method getErrors', () => {
-			assert.isFunction( PeopleLogStore.getErrors );
+			expect( typeof PeopleLogStore.getErrors ).toBe( 'function' );
 		} );
 	} );
 
 	describe( 'hasUnauthorizedError', () => {
 		test( 'Should return false when there are no errors', () => {
-			assert.isFalse( PeopleLogStore.hasUnauthorizedError( site.ID ) );
+			expect( PeopleLogStore.hasUnauthorizedError( site.ID ) ).toBe( false );
 		} );
 
 		test( 'Should return true when there is an unauthorized error', () => {
 			Dispatcher.handleServerAction( actions.unauthorizedFetchingUsers );
-			assert.isTrue( PeopleLogStore.hasUnauthorizedError( site.ID ) );
+			expect( PeopleLogStore.hasUnauthorizedError( site.ID ) ).toBe( true );
 		} );
 	} );
 
 	describe( 'Logging and retrieving errors', () => {
 		test( 'getErrors should return an empty array when there are no errors', () => {
 			const errors = PeopleLogStore.getErrors();
-			assert.isArray( errors );
-			assert.lengthOf( errors, 0, 'there are no errors' );
+			expect( Array.isArray( errors ) ).toBe( true );
+			expect( errors.length ).toBe( 0 );
 		} );
 
 		test( 'An error should increase the number of errors in the store', () => {
 			let errors;
 			Dispatcher.handleServerAction( actions.errorWhenFetchingUsers );
 			errors = PeopleLogStore.getErrors();
-			assert.isArray( errors );
-			assert.lengthOf( errors, 1, 'there is one error' );
+			expect( Array.isArray( errors ) ).toBe( true );
+			expect( errors.length ).toBe( 1 );
 		} );
 	} );
 
 	describe( 'inProgress and completed actions', () => {
 		test( 'getInProgress should return an empty array on init', () => {
 			const inProgress = PeopleLogStore.getInProgress();
-			assert.isArray( inProgress );
-			assert.lengthOf( inProgress, 0, 'there are no in progress actions' );
+			expect( Array.isArray( inProgress ) ).toBe( true );
+			expect( inProgress.length ).toBe( 0 );
 		} );
 
 		test( 'getCompleted should return an empty array on init', () => {
 			const completed = PeopleLogStore.getCompleted();
-			assert.isArray( completed );
-			assert.lengthOf( completed, 0, 'there are no completed actions' );
+			expect( Array.isArray( completed ) ).toBe( true );
+			expect( completed.length ).toBe( 0 );
 		} );
 
 		test( 'An action should increase the number of inProgress in the store', () => {
 			let inProgress;
 			Dispatcher.handleServerAction( userActions.deleteUser );
 			inProgress = PeopleLogStore.getInProgress();
-			assert.isArray( inProgress );
-			assert.lengthOf( inProgress, 1, 'there is one in progress' );
+			expect( Array.isArray( inProgress ) ).toBe( true );
+			expect( inProgress.length ).toBe( 1 );
 		} );
 
 		test( 'An error should decrease the number of inProgress in the store', () => {
 			let inProgress;
 			Dispatcher.handleServerAction( userActions.deleteUser );
 			inProgress = PeopleLogStore.getInProgress();
-			assert.lengthOf( inProgress, 1, 'there is one in progress' );
+			expect( inProgress.length ).toBe( 1 );
 
 			Dispatcher.handleServerAction( userActions.deleteUserError );
 			inProgress = PeopleLogStore.getInProgress();
-			assert.lengthOf( inProgress, 0, 'there is none in progress' );
+			expect( inProgress.length ).toBe( 0 );
 		} );
 
 		test( 'A completed action should decrease the number of inProgress in the store', () => {
 			let inProgress;
 			Dispatcher.handleServerAction( userActions.deleteUser );
 			inProgress = PeopleLogStore.getInProgress();
-			assert.lengthOf( inProgress, 1, 'there is one in progress' );
+			expect( inProgress.length ).toBe( 1 );
 
 			Dispatcher.handleServerAction( userActions.deleteUserSuccess );
 			inProgress = PeopleLogStore.getInProgress();
-			assert.lengthOf( inProgress, 0, 'there is none in progress' );
+			expect( inProgress.length ).toBe( 0 );
 		} );
 	} );
 } );

--- a/client/lib/plugins/test/actions.js
+++ b/client/lib/plugins/test/actions.js
@@ -6,7 +6,6 @@
 /**
  * External dependencies
  */
-import { assert } from 'chai';
 import { noop } from 'lodash';
 
 /**
@@ -30,29 +29,29 @@ describe( 'WPcom Data Actions', () => {
 	} );
 
 	test( 'Actions should be an object', () => {
-		assert.isObject( actions );
+		expect( typeof actions ).toBe( 'object' );
 	} );
 
 	test( 'Actions should have method installPlugin', () => {
-		assert.isFunction( actions.installPlugin );
+		expect( typeof actions.installPlugin ).toBe( 'function' );
 	} );
 
 	test( 'when installing a plugin, it should send a install request to .com', () => {
 		return actions.installPlugin( siteData, 'test', noop ).then( () => {
-			assert.equal( mockedWpcom.getActivity().pluginsInstallCalls, 1 );
+			expect( mockedWpcom.getActivity().pluginsInstallCalls ).toEqual( 1 );
 		} );
 	} );
 
 	test( 'when installing a plugin, it should send an activate request to .com', () => {
 		return actions.installPlugin( siteData, 'test', noop ).then( () => {
-			assert.equal( mockedWpcom.getActivity().pluginsActivateCalls, 1 );
+			expect( mockedWpcom.getActivity().pluginsActivateCalls ).toEqual( 1 );
 		} );
 	} );
 
 	test( "when installing a plugin, it should not send a request to .com when the site doesn't allow us to update its files", () => {
 		return actions.installPlugin( { canUpdateFiles: false }, 'test', noop ).catch( error => {
-			assert.equal( error, "Error: Can't update files on the site" );
-			assert.equal( mockedWpcom.getActivity().pluginsInstallCalls, 0 );
+			expect( error ).toEqual( "Error: Can't update files on the site" );
+			expect( mockedWpcom.getActivity().pluginsInstallCalls ).toEqual( 0 );
 		} );
 	} );
 
@@ -63,7 +62,7 @@ describe( 'WPcom Data Actions', () => {
 				'test',
 				noop
 			)
-			.catch( error => assert.equal( error, "Error: Can't update files on the site" ) );
+			.catch( error => expect( error ).toEqual( "Error: Can't update files on the site" ) );
 	} );
 
 	test( "when installing a plugin, it should return a rejected promise if user can't manage the site", () => {
@@ -73,11 +72,11 @@ describe( 'WPcom Data Actions', () => {
 				'test',
 				noop
 			)
-			.catch( error => assert.equal( error, "Error: Can't update files on the site" ) );
+			.catch( error => expect( error ).toEqual( "Error: Can't update files on the site" ) );
 	} );
 
 	test( 'Actions should have method removePlugin', () => {
-		assert.isFunction( actions.removePlugin );
+		expect( typeof actions.removePlugin ).toBe( 'function' );
 	} );
 
 	test( 'when removing a plugin, it should send a remove request to .com', () => {
@@ -92,7 +91,7 @@ describe( 'WPcom Data Actions', () => {
 				noop
 			)
 			.then( () => {
-				assert.equal( mockedWpcom.getActivity().pluginsRemoveCalls, 1 );
+				expect( mockedWpcom.getActivity().pluginsRemoveCalls ).toEqual( 1 );
 			} );
 	} );
 
@@ -109,12 +108,12 @@ describe( 'WPcom Data Actions', () => {
 				noop
 			)
 			.then( () => {
-				assert.equal( mockedWpcom.getActivity().pluginsDeactivateCalls, 1 );
+				expect( mockedWpcom.getActivity().pluginsDeactivateCalls ).toEqual( 1 );
 			} );
 	} );
 
 	test( "when removing a plugin, it should not send a request to .com when the site doesn't allow us to update its files", () => {
 		actions.removePlugin( { canUpdateFiles: false }, {}, noop );
-		assert.equal( mockedWpcom.getActivity().pluginsRemoveCalls, 0 );
+		expect( mockedWpcom.getActivity().pluginsRemoveCalls ).toEqual( 0 );
 	} );
 } );

--- a/client/lib/plugins/test/log-store.js
+++ b/client/lib/plugins/test/log-store.js
@@ -3,11 +3,6 @@
 /**
  * External dependencies
  */
-import { assert } from 'chai';
-
-/**
- * Internal dependencies
- */
 import actions from './fixtures/actions';
 
 describe( 'Plugins Log Store', () => {
@@ -21,11 +16,11 @@ describe( 'Plugins Log Store', () => {
 
 	test( 'logs an update error', () => {
 		Dispatcher.handleServerAction( actions.updatedPluginError );
-		assert.lengthOf( LogStore.getErrors(), initialErrors + 1 );
+		expect( LogStore.getErrors().length ).toBe( initialErrors + 1 );
 	} );
 
 	test( 'removing an error notice deletes an error', () => {
 		Dispatcher.handleServerAction( actions.removeErrorNotice );
-		assert.lengthOf( LogStore.getErrors(), initialErrors - 1 );
+		expect( LogStore.getErrors().length ).toBe( initialErrors - 1 );
 	} );
 } );

--- a/client/lib/plugins/test/store.js
+++ b/client/lib/plugins/test/store.js
@@ -6,11 +6,6 @@
 /**
  * External dependencies
  */
-import { assert } from 'chai';
-
-/**
- * Internal dependencies
- */
 import actions from './fixtures/actions';
 import multiSite from './fixtures/multi-site';
 import plugins from './fixtures/plugins';
@@ -25,11 +20,11 @@ jest.mock( 'lib/analytics', () => ( {} ) );
 
 describe( 'Plugins Store', () => {
 	test( 'Store should be an object', () => {
-		assert.isObject( PluginsStore );
+		expect( typeof PluginsStore ).toBe( 'object' );
 	} );
 
 	test( 'Store should have method emitChange', () => {
-		assert.isFunction( PluginsStore.emitChange );
+		expect( typeof PluginsStore.emitChange ).toBe( 'function' );
 	} );
 
 	describe( 'Fetch Plugins', () => {
@@ -38,139 +33,138 @@ describe( 'Plugins Store', () => {
 		} );
 
 		test( 'Should update the store on RECEIVE_PLUGINS', () => {
-			assert.isNotNull( PluginsStore.getSitePlugins( site ) );
+			expect( PluginsStore.getSitePlugins( site ) ).not.toBeNull();
 		} );
 
 		describe( 'getPlugin method', () => {
 			test( 'Store should have method getPlugin', () => {
-				assert.isFunction( PluginsStore.getPlugin );
+				expect( typeof PluginsStore.getPlugin ).toBe( 'function' );
 			} );
 
 			test( 'should return an object', () => {
-				assert.isObject( PluginsStore.getPlugin( site, 'akismet' ) );
+				expect( typeof PluginsStore.getPlugin( site, 'akismet' ) ).toBe( 'object' );
 			} );
 
 			test( 'should accept sites as an array of objects or object', () => {
-				assert.deepEqual(
-					PluginsStore.getPlugin( site, 'akismet' ),
+				expect( PluginsStore.getPlugin( site, 'akismet' ) ).toEqual(
 					PluginsStore.getPlugin( [ site ], 'akismet' )
 				);
 			} );
 
 			test( 'should return an object with attribute sites array', () => {
 				const Plugin = PluginsStore.getPlugin( site, 'akismet' );
-				assert.isArray( Plugin.sites );
+				expect( Array.isArray( Plugin.sites ) ).toBe( true );
 			} );
 		} );
 
 		describe( 'getPlugins method', () => {
 			test( 'Store should have method getPlugins', () => {
-				assert.isFunction( PluginsStore.getPlugins );
+				expect( typeof PluginsStore.getPlugins ).toBe( 'function' );
 			} );
 
 			test( 'should return an array of objects', () => {
 				const Plugins = PluginsStore.getPlugins( site );
-				assert.isArray( Plugins );
-				assert.isObject( Plugins[ 0 ] );
+				expect( Array.isArray( Plugins ) ).toBe( true );
+				expect( typeof Plugins[ 0 ] ).toBe( 'object' );
 			} );
 
 			test( 'should return an object with attribute sites array', () => {
 				const Plugins = PluginsStore.getPlugins( site );
-				assert.isArray( Plugins[ 0 ].sites );
-				assert.isObject( Plugins[ 0 ].sites[ 0 ] );
+				expect( Array.isArray( Plugins[ 0 ].sites ) ).toBe( true );
+				expect( typeof Plugins[ 0 ].sites[ 0 ] ).toBe( 'object' );
 			} );
 
 			test( 'should return the same object as getPlugin', () => {
 				const Plugins = PluginsStore.getPlugins( site ),
 					Plugin = PluginsStore.getPlugin( site, Plugins[ 0 ].slug );
-				assert.deepEqual( Plugins[ 0 ], Plugin );
+				expect( Plugins[ 0 ] ).toEqual( Plugin );
 			} );
 
 			test( 'should return active Plugins', () => {
 				const Plugins = PluginsStore.getPlugins( site, 'active' ),
 					Plugin = PluginsStore.getPlugin( site, Plugins[ 0 ].slug );
-				assert.deepEqual( Plugins[ 0 ], Plugin );
-				assert.isTrue( Plugins[ 0 ].active );
+				expect( Plugins[ 0 ] ).toEqual( Plugin );
+				expect( Plugins[ 0 ].active ).toBe( true );
 			} );
 
 			test( 'should return inactive Plugins', () => {
 				const Plugins = PluginsStore.getPlugins( site, 'inactive' ),
 					Plugin = PluginsStore.getPlugin( site, Plugins[ 0 ].slug );
-				assert.deepEqual( Plugins[ 0 ], Plugin );
-				assert.isFalse( Plugins[ 0 ].active );
+				expect( Plugins[ 0 ] ).toEqual( Plugin );
+				expect( Plugins[ 0 ].active ).toBe( false );
 			} );
 
 			test( 'should return needs update Plugins', () => {
 				const Plugins = PluginsStore.getPlugins( site, 'updates' ),
 					Plugin = PluginsStore.getPlugin( site, Plugins[ 0 ].slug );
-				assert.deepEqual( Plugins[ 0 ], Plugin );
-				assert.isObject( Plugins[ 0 ].update );
+				expect( Plugins[ 0 ] ).toEqual( Plugin );
+				expect( typeof Plugins[ 0 ].update ).toBe( 'object' );
 			} );
 
 			test( 'should return all Plugin', () => {
 				const Plugins = PluginsStore.getPlugins( site, 'all' );
-				assert.equal( Plugins.length, plugins.length );
+				expect( Plugins.length ).toEqual( plugins.length );
 			} );
 
 			test( 'should return none Plugin', () => {
 				const Plugins = PluginsStore.getPlugins( site, 'none' );
-				assert.equal( Plugins.length, 0 );
+				expect( Plugins.length ).toEqual( 0 );
 			} );
 		} );
 
 		describe( 'getSitePlugin method', () => {
 			test( 'Store should have method getSitePlugin', () => {
-				assert.isFunction( PluginsStore.getSitePlugin );
+				expect( typeof PluginsStore.getSitePlugin ).toBe( 'function' );
 			} );
 
 			test( 'Should have return a plugin object for a site', () => {
 				const Aksimet = PluginsStore.getSitePlugin( site, 'akismet' );
-				assert.isObject( Aksimet );
+				expect( typeof Aksimet ).toBe( 'object' );
 			} );
 
 			test( "Should have return undefined for a site if the plugin doesn't exist", () => {
-				assert.isUndefined( PluginsStore.getSitePlugin( site, 'non-plugin-slug' ) );
+				expect( PluginsStore.getSitePlugin( site, 'non-plugin-slug' ) ).not.toBeDefined();
 			} );
 		} );
 
 		describe( 'getSitePlugins method', () => {
 			test( 'Store should have method getSitePlugins', () => {
-				assert.isFunction( PluginsStore.getSitePlugins );
+				expect( typeof PluginsStore.getSitePlugins ).toBe( 'function' );
 			} );
 
 			test( 'Should have return Array of Objects', () => {
 				const Plugins = PluginsStore.getSitePlugins( site );
-				assert.isArray( Plugins );
-				assert.isObject( Plugins[ 0 ] );
+				expect( Array.isArray( Plugins ) ).toBe( true );
+				expect( typeof Plugins[ 0 ] ).toBe( 'object' );
 			} );
 
 			test( "Should have return undefined if site doesn't exist", () => {
-				assert.isUndefined(
+				expect(
 					PluginsStore.getSitePlugins( {
 						ID: 1,
 						jetpack: false,
 						plan: { product_slug: 'free_plan' },
 					} )
-				);
+				).not.toBeDefined();
 			} );
 		} );
 
 		describe( 'getSites method', () => {
 			test( 'Store should have method getSites', () => {
-				assert.isFunction( PluginsStore.getSites );
+				expect( typeof PluginsStore.getSites ).toBe( 'function' );
 			} );
 
 			test( 'Should return Array of Objects', () => {
 				const Sites = PluginsStore.getSites( site, 'akismet' );
-				assert.isArray( Sites );
-				assert.isObject( Sites[ 0 ] );
+				expect( Array.isArray( Sites ) ).toBe( true );
+				expect( typeof Sites[ 0 ] ).toBe( 'object' );
 			} );
 
 			test( 'Should return Array of Objects that has the pluginSlug as a attribute', () => {
 				const Sites = PluginsStore.getSites( site, 'akismet' );
-				assert.isArray( Sites );
-				assert.isObject( Sites[ 0 ] );
-				assert.equal( Sites[ 0 ].plugin.slug, 'akismet' );
+				expect( Array.isArray( Sites ) ).toBe( true );
+				expect( typeof Sites[ 0 ] ).toBe( 'object' );
+				expect( Sites[ 0 ].plugin.slug ).toEqual( 'akismet' );
 			} );
 		} );
 
@@ -181,19 +175,19 @@ describe( 'Plugins Store', () => {
 				jetpack: false,
 				plan: { product_slug: 'free_plan' },
 			} );
-			assert.lengthOf( UpdatedStore, 0 );
+			expect( UpdatedStore.length ).toBe( 0 );
 		} );
 
 		test( 'Should not set value of the site if NOT_ALLOWED_TO_RECEIVE_PLUGINS errors', () => {
 			Dispatcher.handleServerAction( actions.fetchedNotAllowed );
 			const UpdatedStore = PluginsStore.getPlugins( { ID: 123 } );
-			assert.isDefined( UpdatedStore );
-			assert.lengthOf( UpdatedStore, 0 );
+			expect( UpdatedStore ).toBeDefined();
+			expect( UpdatedStore.length ).toBe( 0 );
 		} );
 
 		test( 'Should not be set as "fetching" after NOT_ALLOWED_TO_RECEIVE_PLUGINS is triggered', () => {
 			Dispatcher.handleServerAction( actions.fetchedNotAllowed );
-			assert.isFalse( PluginsStore.isFetchingSite( { ID: 123 } ) );
+			expect( PluginsStore.isFetchingSite( { ID: 123 } ) ).toBe( false );
 		} );
 	} );
 
@@ -206,12 +200,12 @@ describe( 'Plugins Store', () => {
 			const Plugins = PluginsStore.getSitePlugins( site );
 			let PluginsAgain = [];
 
-			assert.lengthOf( Plugins, 4 );
+			expect( Plugins.length ).toBe( 4 );
 
 			// Lets check if we can update the plugin list to something new.
 			Dispatcher.handleServerAction( actions.fetchedAgain );
 			PluginsAgain = PluginsStore.getSitePlugins( site );
-			assert.lengthOf( PluginsAgain, 2 );
+			expect( PluginsAgain.length ).toBe( 2 );
 		} );
 
 		afterAll( () => {
@@ -227,7 +221,7 @@ describe( 'Plugins Store', () => {
 
 		test( 'should contain the list of latest plugins', () => {
 			const Plugins = PluginsStore.getSitePlugins( multiSite );
-			assert.lengthOf( Plugins, 3 );
+			expect( Plugins.length ).toBe( 3 );
 		} );
 
 		afterAll( () => {
@@ -247,13 +241,13 @@ describe( 'Plugins Store', () => {
 		test( 'it should remove the plugin from the sites list', () => {
 			Dispatcher.handleServerAction( actions.removedPlugin );
 			const PluginsAfterRemoval = PluginsStore.getPlugins( [ site ] );
-			assert.equal( Plugins.length, PluginsAfterRemoval.length + 1 );
+			expect( Plugins.length ).toEqual( PluginsAfterRemoval.length + 1 );
 		} );
 
 		test( 'it should bring the plugin back if there is an error while removing the plugin', () => {
 			Dispatcher.handleViewAction( actions.removedPluginError );
 			const PluginsAfterRemoval = PluginsStore.getPlugins( [ site ] );
-			assert.equal( Plugins.length, PluginsAfterRemoval.length );
+			expect( Plugins.length ).toEqual( PluginsAfterRemoval.length );
 		} );
 	} );
 
@@ -267,7 +261,7 @@ describe( 'Plugins Store', () => {
 			} );
 
 			test( "doesn't remove update when lauched", () => {
-				assert.isNotNull( HelloDolly.update );
+				expect( HelloDolly.update ).not.toBeNull();
 			} );
 		} );
 
@@ -281,15 +275,15 @@ describe( 'Plugins Store', () => {
 			} );
 
 			test( 'should set lastUpdated', () => {
-				assert.isNotNull( HelloDolly.update.lastUpdated );
+				expect( HelloDolly.update.lastUpdated ).not.toBeNull();
 			} );
 
 			test( 'should update the plugin data', () => {
-				assert.equal( HelloDolly.version, updatePluginData.version );
-				assert.equal( HelloDolly.author, updatePluginData.author );
-				assert.equal( HelloDolly.description, updatePluginData.description );
-				assert.equal( HelloDolly.author_url, updatePluginData.author_url );
-				assert.equal( HelloDolly.name, updatePluginData.name );
+				expect( HelloDolly.version ).toEqual( updatePluginData.version );
+				expect( HelloDolly.author ).toEqual( updatePluginData.author );
+				expect( HelloDolly.description ).toEqual( updatePluginData.description );
+				expect( HelloDolly.author_url ).toEqual( updatePluginData.author_url );
+				expect( HelloDolly.name ).toEqual( updatePluginData.name );
 			} );
 		} );
 
@@ -300,7 +294,7 @@ describe( 'Plugins Store', () => {
 			} );
 
 			test( 'should remove lastUpdated', () => {
-				assert.isNull( HelloDolly.update );
+				expect( HelloDolly.update ).toBeNull();
 			} );
 		} );
 
@@ -311,7 +305,7 @@ describe( 'Plugins Store', () => {
 			} );
 
 			test( 'should set update to an object', () => {
-				assert.isObject( HelloDolly.update );
+				expect( typeof HelloDolly.update ).toBe( 'object' );
 			} );
 		} );
 	} );
@@ -320,35 +314,35 @@ describe( 'Plugins Store', () => {
 		describe( 'Activaiting Plugin', () => {
 			test( 'Should set active = true if plugin is being activated', () => {
 				Dispatcher.handleViewAction( actions.activatePlugin );
-				assert.isTrue( PluginsStore.getSitePlugin( site, 'developer' ).active );
+				expect( PluginsStore.getSitePlugin( site, 'developer' ).active ).toBe( true );
 			} );
 		} );
 
 		describe( 'Succesfully Activated Plugin', () => {
 			test( 'Should set active = true', () => {
 				Dispatcher.handleViewAction( actions.activatedPlugin );
-				assert.isTrue( PluginsStore.getSitePlugin( site, 'developer' ).active );
+				expect( PluginsStore.getSitePlugin( site, 'developer' ).active ).toBe( true );
 			} );
 		} );
 
 		describe( 'Error while Activating Plugin', () => {
 			test( 'Should set active = false', () => {
 				Dispatcher.handleServerAction( actions.activatedPluginError );
-				assert.isFalse( PluginsStore.getSitePlugin( site, 'developer' ).active );
+				expect( PluginsStore.getSitePlugin( site, 'developer' ).active ).toBe( false );
 			} );
 		} );
 
 		describe( 'Error while Activating Plugin with activation_error', () => {
 			test( 'Should set active = true if plugin is being activated with error plugin already active', () => {
 				Dispatcher.handleServerAction( actions.activatedPluginErrorAlreadyActive );
-				assert.isTrue( PluginsStore.getSitePlugin( site, 'developer' ).active );
+				expect( PluginsStore.getSitePlugin( site, 'developer' ).active ).toBe( true );
 			} );
 		} );
 
 		describe( 'Error while Activating Broken Plugin', () => {
 			test( 'Should set active = false', () => {
 				Dispatcher.handleServerAction( actions.activatedBrokenPluginError );
-				assert.isFalse( PluginsStore.getSitePlugin( site, 'developer' ).active );
+				expect( PluginsStore.getSitePlugin( site, 'developer' ).active ).toBe( false );
 			} );
 		} );
 	} );
@@ -357,28 +351,28 @@ describe( 'Plugins Store', () => {
 		describe( 'Deactivating Plugin', () => {
 			test( 'Should set active = false if plugin is being activated', () => {
 				Dispatcher.handleViewAction( actions.deactivatePlugin );
-				assert.isFalse( PluginsStore.getSitePlugin( site, 'developer' ).active );
+				expect( PluginsStore.getSitePlugin( site, 'developer' ).active ).toBe( false );
 			} );
 		} );
 
 		describe( 'Succesfully Deactivated Plugin', () => {
 			test( 'Should set active = false', () => {
 				Dispatcher.handleViewAction( actions.deactivatedPlugin );
-				assert.isFalse( PluginsStore.getSitePlugin( site, 'developer' ).active );
+				expect( PluginsStore.getSitePlugin( site, 'developer' ).active ).toBe( false );
 			} );
 		} );
 
 		describe( 'Error while Deactivating Plugin', () => {
 			test( 'Should set active = true', () => {
 				Dispatcher.handleServerAction( actions.deactivatedPluginError );
-				assert.isTrue( PluginsStore.getSitePlugin( site, 'developer' ).active );
+				expect( PluginsStore.getSitePlugin( site, 'developer' ).active ).toBe( true );
 			} );
 		} );
 
 		describe( 'Error while Deactivating Plugin with deactivation_error', () => {
 			test( 'Should set active = false if plugin is being deactivated with error plugin already deactived', () => {
 				Dispatcher.handleServerAction( actions.deactivatedPluginErrorAlreadyNotActive );
-				assert.isFalse( PluginsStore.getSitePlugin( site, 'developer' ).active );
+				expect( PluginsStore.getSitePlugin( site, 'developer' ).active ).toBe( false );
 			} );
 		} );
 	} );
@@ -386,34 +380,34 @@ describe( 'Plugins Store', () => {
 	describe( 'Enable AutoUpdates for Plugin', () => {
 		test( 'Should set autoupdate = true if autoupdates are being enabled', () => {
 			Dispatcher.handleViewAction( actions.enableAutoupdatePlugin );
-			assert.isTrue( PluginsStore.getSitePlugin( site, 'developer' ).autoupdate );
+			expect( PluginsStore.getSitePlugin( site, 'developer' ).autoupdate ).toBe( true );
 		} );
 
 		test( 'Should set autoupdate = true after autoupdates enabling was successfully', () => {
 			Dispatcher.handleServerAction( actions.enabledAutoupdatePlugin );
-			assert.isTrue( PluginsStore.getSitePlugin( site, 'developer' ).autoupdate );
+			expect( PluginsStore.getSitePlugin( site, 'developer' ).autoupdate ).toBe( true );
 		} );
 
 		test( 'Should set autoupdate = false after autoupdates enabling errored ', () => {
 			Dispatcher.handleServerAction( actions.enabledAutoupdatePluginError );
-			assert.isFalse( PluginsStore.getSitePlugin( site, 'developer' ).autoupdate );
+			expect( PluginsStore.getSitePlugin( site, 'developer' ).autoupdate ).toBe( false );
 		} );
 	} );
 
 	describe( 'Disable AutoUpdated for Plugins', () => {
 		test( 'Should set autoupdate = false if autoupdates are being disabled', () => {
 			Dispatcher.handleViewAction( actions.disableAutoupdatePlugin );
-			assert.isFalse( PluginsStore.getSitePlugin( site, 'developer' ).autoupdate, false );
+			expect( PluginsStore.getSitePlugin( site, 'developer' ).autoupdate ).toBe( false );
 		} );
 
 		test( 'Should set autoupdate = false after autoupdates disabling was successfully', () => {
 			Dispatcher.handleServerAction( actions.disabledAutoupdatePlugin );
-			assert.isFalse( PluginsStore.getSitePlugin( site, 'developer' ).autoupdate, false );
+			expect( PluginsStore.getSitePlugin( site, 'developer' ).autoupdate ).toBe( false );
 		} );
 
 		test( 'Should set autoupdate = true after autoupdates disabling errored ', () => {
 			Dispatcher.handleServerAction( actions.disabledAutoupdatePluginError );
-			assert.isTrue( PluginsStore.getSitePlugin( site, 'developer' ).autoupdate, true );
+			expect( PluginsStore.getSitePlugin( site, 'developer' ).autoupdate ).toBe( true );
 		} );
 	} );
 } );

--- a/client/lib/plugins/test/utils.js
+++ b/client/lib/plugins/test/utils.js
@@ -6,52 +6,47 @@
 /**
  * External dependencies
  */
-import { assert } from 'chai';
-
-/**
- * Internal dependencies
- */
 import PluginUtils from '../utils';
 
 describe( 'Plugins Utils', () => {
 	describe( 'normalizePluginData', () => {
 		test( 'should have a method normalizePluginData', () => {
-			assert.isFunction( PluginUtils.normalizePluginData );
+			expect( typeof PluginUtils.normalizePluginData ).toBe( 'function' );
 		} );
 
 		test( 'normalizePluginData should normalise the plugin data', () => {
 			const plugin = { name: '&lt;a href=&quot;http://google.com&quot;&gt;google&lt;/a&gt;' },
 				decodedPlugin = { name: '<a href="http://google.com">google</a>' };
-			assert.notEqual( decodedPlugin, PluginUtils.normalizePluginData( plugin ) );
+			expect( decodedPlugin ).not.toEqual( PluginUtils.normalizePluginData( plugin ) );
 		} );
 
 		test( 'should add the author name to the plugins object', () => {
 			const plugin = JSON.parse( '{"author":"<a href=\\"http://jetpack.me\\">Automattic</a>"}' ),
 				normalizedPlugin = PluginUtils.normalizePluginData( plugin );
-			assert.equal( normalizedPlugin.author_name, 'Automattic' );
+			expect( normalizedPlugin.author_name ).toEqual( 'Automattic' );
 		} );
 
 		test( 'should add the author url to the plugins object', () => {
 			const plugin = JSON.parse( '{"author":"<a href=\\"http://jetpack.me\\">Automattic</a>"}' ),
 				normalizedPlugin = PluginUtils.normalizePluginData( plugin );
-			assert.equal( normalizedPlugin.author_url, 'http://jetpack.me' );
+			expect( normalizedPlugin.author_url ).toEqual( 'http://jetpack.me' );
 		} );
 
 		test( 'should get the best possible icon if available', () => {
 			const plugin = { icons: { '1x': '1x test icon', '2x': '2x test icon' } },
 				normalizedPlugin = PluginUtils.normalizePluginData( plugin );
-			assert.equal( normalizedPlugin.icon, '2x test icon' );
+			expect( normalizedPlugin.icon ).toEqual( '2x test icon' );
 		} );
 	} );
 
 	describe( 'whiteListPluginData', () => {
 		test( 'should have a method whiteListPluginData', () => {
-			assert.isFunction( PluginUtils.whiteListPluginData );
+			expect( typeof PluginUtils.whiteListPluginData ).toBe( 'function' );
 		} );
 
 		test( 'should stip out unknown keys', () => {
 			const plugin = { unknownKey: true };
-			assert.deepEqual( PluginUtils.whiteListPluginData( plugin ), {} );
+			expect( PluginUtils.whiteListPluginData( plugin ) ).toEqual( {} );
 		} );
 
 		test( 'should keep known keys', () => {
@@ -70,7 +65,7 @@ describe( 'Plugins Utils', () => {
 				update: {},
 				updating: false,
 			};
-			assert.deepEqual( PluginUtils.whiteListPluginData( plugin ), plugin );
+			expect( PluginUtils.whiteListPluginData( plugin ) ).toEqual( plugin );
 		} );
 	} );
 
@@ -79,14 +74,14 @@ describe( 'Plugins Utils', () => {
 			const jetpackAuthorObj = JSON.parse(
 				'{"author":"<a href=\\"http://jetpack.me\\">Automattic</a>"}'
 			);
-			assert.equal( PluginUtils.extractAuthorName( jetpackAuthorObj.author ), 'Automattic' );
+			expect( PluginUtils.extractAuthorName( jetpackAuthorObj.author ) ).toEqual( 'Automattic' );
 		} );
 
 		test( 'should support names with special chars', () => {
 			const plugin = JSON.parse(
 				'{"author":"<a href=\\"http://test.com/\\">&#209;&#225;&#240;</a>"}'
 			);
-			assert.equal( PluginUtils.extractAuthorName( plugin.author ), 'Ñáð' );
+			expect( PluginUtils.extractAuthorName( plugin.author ) ).toEqual( 'Ñáð' );
 		} );
 	} );
 
@@ -96,9 +91,9 @@ describe( 'Plugins Utils', () => {
 					'{"screenshots":"<ul><li><a href=\\"http://jetpack.me\\"><img src=\\"http://url-toscreenshot.com\\" /></a><p>Caption!</p></li></ul>"}'
 				),
 				extractedScreenshotData = PluginUtils.extractScreenshots( screenshotData.screenshots );
-			assert.isArray( extractedScreenshotData );
-			assert.equal( extractedScreenshotData[ 0 ].url, 'http://url-toscreenshot.com/' );
-			assert.equal( extractedScreenshotData[ 0 ].caption, 'Caption!' );
+			expect( Array.isArray( extractedScreenshotData ) ).toBe( true );
+			expect( extractedScreenshotData[ 0 ].url ).toEqual( 'http://url-toscreenshot.com/' );
+			expect( extractedScreenshotData[ 0 ].caption ).toEqual( 'Caption!' );
 		} );
 
 		test( 'should extract the screenshot data from the .org api response with removed items', () => {
@@ -106,9 +101,9 @@ describe( 'Plugins Utils', () => {
 					'{"screenshots":"<ul><li><a href=\\"http://jetpack.me\\"><img /></a><p>Caption!</p></li><li><a href=\\"http://jetpack.me\\"><img src=\\"http://url-toscreenshot.com\\" /></a><p>Caption!</p></li></ul>"}'
 				),
 				extractedScreenshotData = PluginUtils.extractScreenshots( screenshotData.screenshots );
-			assert.isArray( extractedScreenshotData );
-			assert.equal( extractedScreenshotData[ 0 ].url, 'http://url-toscreenshot.com/' );
-			assert.equal( extractedScreenshotData[ 0 ].caption, 'Caption!' );
+			expect( Array.isArray( extractedScreenshotData ) ).toBe( true );
+			expect( extractedScreenshotData[ 0 ].url ).toEqual( 'http://url-toscreenshot.com/' );
+			expect( extractedScreenshotData[ 0 ].caption ).toEqual( 'Caption!' );
 		} );
 
 		test( 'should extract the screenshot data from the .org api response but if no screenshots urls then return null', () => {
@@ -116,30 +111,30 @@ describe( 'Plugins Utils', () => {
 					'{"screenshots":"<ul><li><a href=\\"http://jetpack.me\\"><img /></a><p>Caption!</p></li></ul>"}'
 				),
 				extractedScreenshotData = PluginUtils.extractScreenshots( screenshotData.screenshots );
-			assert.isNull( extractedScreenshotData );
+			expect( extractedScreenshotData ).toBeNull();
 		} );
 
 		test( 'should return null if screenshots is empty string', () => {
 			const screenshotData = JSON.parse( '{"screenshots":""}' ),
 				extractedScreenshotData = PluginUtils.extractScreenshots( screenshotData.screenshots );
-			assert.isNull( extractedScreenshotData );
+			expect( extractedScreenshotData ).toBeNull();
 		} );
 
 		test( 'should return null if we pass null instead of JSON”', () => {
 			const extractedScreenshotData = PluginUtils.extractScreenshots( null );
-			assert.isNull( extractedScreenshotData );
+			expect( extractedScreenshotData ).toBeNull();
 		} );
 	} );
 
 	describe( 'normalizeCompatibilityList', () => {
 		test( 'should trunc the hotfix number if 0', () => {
 			const compatibility = { '1.5.0': {} };
-			assert.equal( PluginUtils.normalizeCompatibilityList( compatibility )[ 0 ], '1.5' );
+			expect( PluginUtils.normalizeCompatibilityList( compatibility )[ 0 ] ).toEqual( '1.5' );
 		} );
 
 		test( 'should not trunc the minor number if 0', () => {
 			const compatibility = { '1.0': {} };
-			assert.equal( PluginUtils.normalizeCompatibilityList( compatibility )[ 0 ], '1.0' );
+			expect( PluginUtils.normalizeCompatibilityList( compatibility )[ 0 ] ).toEqual( '1.0' );
 		} );
 
 		test( 'should provide an ordered compatibility list', () => {
@@ -150,8 +145,8 @@ describe( 'Plugins Utils', () => {
 					1.5: {},
 				},
 				orderedCompatibility = PluginUtils.normalizeCompatibilityList( compatibility );
-			assert.equal( orderedCompatibility.length, 4 );
-			assert.deepEqual( orderedCompatibility, [ '1.1.3', '1.1.4', '1.5', '10.3' ] );
+			expect( orderedCompatibility.length ).toEqual( 4 );
+			expect( orderedCompatibility ).toEqual( [ '1.1.3', '1.1.4', '1.5', '10.3' ] );
 		} );
 	} );
 
@@ -178,17 +173,17 @@ describe( 'Plugins Utils', () => {
 		test( 'should return a list of notices that match the site', () => {
 			logs[ 0 ].plugin = {};
 			const log = PluginUtils.filterNotices( logs, { ID: '123' }, null );
-			assert.deepEqual( log, [ logs[ 0 ] ] );
+			expect( log ).toEqual( [ logs[ 0 ] ] );
 		} );
 
 		test( 'should return a list of notices that match a plugin', () => {
 			const log = PluginUtils.filterNotices( logs, null, 'jetpack' );
-			assert.deepEqual( log, [ logs[ 0 ] ] );
+			expect( log ).toEqual( [ logs[ 0 ] ] );
 		} );
 
 		test( 'should return a list of notices that match the site and plugin', () => {
 			const log = PluginUtils.filterNotices( logs, { ID: '123' }, 'jetpack' );
-			assert.deepEqual( log, [ logs[ 0 ] ] );
+			expect( log ).toEqual( [ logs[ 0 ] ] );
 		} );
 	} );
 } );

--- a/client/lib/plugins/wporg-data/test/actions.js
+++ b/client/lib/plugins/wporg-data/test/actions.js
@@ -2,7 +2,6 @@
 /**
  * External dependencies
  */
-import { assert } from 'chai';
 import { spy } from 'sinon';
 
 /**
@@ -22,55 +21,55 @@ describe( 'WPorg Data Actions', () => {
 	} );
 
 	test( 'Actions should be an object', () => {
-		assert.isObject( WPorgActions );
+		expect( typeof WPorgActions ).toBe( 'object' );
 	} );
 
 	test( 'Actions should have method fetchPluginsList', () => {
-		assert.isFunction( WPorgActions.fetchPluginsList );
+		expect( typeof WPorgActions.fetchPluginsList ).toBe( 'function' );
 	} );
 
 	test( 'Actions should have method fetchCuratedList', () => {
-		assert.isFunction( WPorgActions.fetchCuratedList );
+		expect( typeof WPorgActions.fetchCuratedList ).toBe( 'function' );
 	} );
 
 	test( 'Actions should have method fetchNextCategoryPage', () => {
-		assert.isFunction( WPorgActions.fetchNextCategoryPage );
+		expect( typeof WPorgActions.fetchNextCategoryPage ).toBe( 'function' );
 	} );
 
 	test( "when fetching a plugin list, it shouldn't do the wporg request if there's a previous one still not finished for the same category", () => {
 		mockedWporg.deactivatedCallbacks = true;
 		WPorgActions.fetchPluginsList( 'new', 1 );
 		WPorgActions.fetchPluginsList( 'new', 1 );
-		assert.equal( mockedWporg.getActivity().fetchPluginsList, 1 );
+		expect( mockedWporg.getActivity().fetchPluginsList ).toEqual( 1 );
 	} );
 
 	test( 'should return our Calypso curated feature list', () => {
 		const curatedSpy = spy( WPorgActions, 'fetchCuratedList' );
 		WPorgActions.fetchPluginsList( 'featured', 1 );
-		assert.isTrue( curatedSpy.called );
+		expect( curatedSpy.called ).toBe( true );
 	} );
 
 	test( 'does not return the community featured list', () => {
 		WPorgActions.fetchPluginsList( 'featured', 1 );
-		assert.equal( mockedWporg.getActivity().fetchPluginsList, 0 );
+		expect( mockedWporg.getActivity().fetchPluginsList ).toEqual( 0 );
 	} );
 
 	test( 'when fetching for the next page, the next page number should be calculated automatically', () => {
 		WPorgActions.fetchPluginsList( 'new', 1 );
 		WPorgActions.fetchNextCategoryPage( 'new' );
-		assert.equal( mockedWporg.getActivity().lastRequestParams.page, 2 );
+		expect( mockedWporg.getActivity().lastRequestParams.page ).toEqual( 2 );
 	} );
 
 	test( 'when fetching for the next page, it should do a request if the next page is not over the number of total pages', () => {
 		WPorgActions.fetchPluginsList( 'new', 1 );
 		WPorgActions.fetchNextCategoryPage( 'new' );
-		assert.equal( mockedWporg.getActivity().fetchPluginsList, 2 );
+		expect( mockedWporg.getActivity().fetchPluginsList ).toEqual( 2 );
 	} );
 
 	test( 'when fetching for the next page, it should not do any request if the next page is over the number of total pages', () => {
 		mockedWporg.mockedNumberOfReturnedPages = 1;
 		WPorgActions.fetchPluginsList( 'new', 1 );
 		WPorgActions.fetchNextCategoryPage( 'new' );
-		assert.equal( mockedWporg.getActivity().fetchPluginsList, 1 );
+		expect( mockedWporg.getActivity().fetchPluginsList ).toEqual( 1 );
 	} );
 } );

--- a/client/lib/plugins/wporg-data/test/list-store.js
+++ b/client/lib/plugins/wporg-data/test/list-store.js
@@ -2,11 +2,6 @@
 /**
  * External dependencies
  */
-import { assert } from 'chai';
-
-/**
- * Internal dependencies
- */
 import actionsData from './fixtures/actions';
 import actionsSpies from './mocks/actions';
 import Dispatcher from 'dispatcher';
@@ -30,118 +25,118 @@ describe( 'WPORG Plugins Lists Store', () => {
 	} );
 
 	test( 'Store should be an object', () => {
-		assert.isObject( PluginsListsStore );
+		expect( typeof PluginsListsStore ).toBe( 'object' );
 	} );
 
 	test( 'Store should have method emitChange', () => {
-		assert.isFunction( PluginsListsStore.emitChange );
+		expect( typeof PluginsListsStore.emitChange ).toBe( 'function' );
 	} );
 
 	test( 'Store should have method getShortList', () => {
-		assert.isFunction( PluginsListsStore.getShortList );
+		expect( typeof PluginsListsStore.getShortList ).toBe( 'function' );
 	} );
 
 	test( 'Store should have method getFullList', () => {
-		assert.isFunction( PluginsListsStore.getFullList );
+		expect( typeof PluginsListsStore.getFullList ).toBe( 'function' );
 	} );
 
 	test( 'should return if a list is fetching or not when requested', () => {
 		pluginsList = PluginsListsStore.getFullList( 'popular' );
-		assert.isDefined( pluginsList.fetching );
+		expect( pluginsList.fetching ).toBeDefined();
 	} );
 
 	test( 'Store should have method getSearchList', () => {
-		assert.isFunction( PluginsListsStore.getSearchList );
+		expect( typeof PluginsListsStore.getSearchList ).toBe( 'function' );
 	} );
 
 	test( 'should return the content of a list when requested', () => {
 		pluginsList = PluginsListsStore.getFullList( 'popular' );
-		assert.isDefined( pluginsList.list );
+		expect( pluginsList.list ).toBeDefined();
 	} );
 
 	describe( 'short lists', () => {
 		test( 'should be empty if the list has not been fetched yet', () => {
 			const newPlugins = PluginsListsStore.getShortList( 'new' );
-			assert.lengthOf( newPlugins.list, 0 );
+			expect( newPlugins.list.length ).toBe( 0 );
 		} );
 
 		test( 'should return a list of plugins if the list has been fetched already', () => {
 			Dispatcher.handleServerAction( actionsData.fetchedNewPluginsList );
 			const newPlugins = PluginsListsStore.getShortList( 'new' );
-			assert.isArray( newPlugins.list );
-			assert.lengthOf( newPlugins.list, 1 );
+			expect( Array.isArray( newPlugins.list ) ).toBe( true );
+			expect( newPlugins.list.length ).toBe( 1 );
 		} );
 
 		test( 'should not fetch from wporg if the category list is already in store', () => {
 			Dispatcher.handleServerAction( actionsData.fetchedPopularPluginsList );
 			PluginsListsStore.getShortList( 'popular' );
-			assert.isFalse( actionsSpies.fetchPluginsList.called );
+			expect( actionsSpies.fetchPluginsList.called ).toBe( false );
 		} );
 
 		test( 'should fetch from wporg if the category list is not already in store', () => {
 			PluginsListsStore.getShortList( 'popular' );
-			assert.isTrue( actionsSpies.fetchPluginsList.called );
+			expect( actionsSpies.fetchPluginsList.called ).toBe( true );
 		} );
 	} );
 
 	describe( 'Full lists', () => {
 		test( 'should be empty if the list has not been fetched yet', () => {
 			const newPlugins = PluginsListsStore.getFullList( 'new' );
-			assert.lengthOf( newPlugins.list, 0 );
+			expect( newPlugins.list.length ).toBe( 0 );
 		} );
 
 		test( 'should be populated after the processing a list fetched event', () => {
 			let newPlugins;
 			Dispatcher.handleServerAction( actionsData.fetchedNewPluginsList );
 			newPlugins = PluginsListsStore.getFullList( 'new' );
-			assert.isArray( newPlugins.list );
-			assert.lengthOf( newPlugins.list, 1 );
+			expect( Array.isArray( newPlugins.list ) ).toBe( true );
+			expect( newPlugins.list.length ).toBe( 1 );
 		} );
 
 		test( 'should fetch for the list when the fullList is requested', () => {
 			PluginsListsStore.getFullList( 'popular' );
-			assert.isTrue( actionsSpies.fetchPluginsList.called );
+			expect( actionsSpies.fetchPluginsList.called ).toBe( true );
 		} );
 
 		test( 'should mark a list as `not being fetched`  when the fetch ends', () => {
 			Dispatcher.handleViewAction( actionsData.fetchingPopularPluginsList );
 			Dispatcher.handleServerAction( actionsData.fetchedPopularPluginsList );
 			pluginsList = PluginsListsStore.getFullList( 'popular' );
-			assert.notOk( pluginsList.fetching );
+			expect( pluginsList.fetching ).toBeFalsy();
 		} );
 
 		test( 'should mark a list as `being fetched`  when the fetch begin', () => {
 			Dispatcher.handleViewAction( actionsData.fetchingPopularPluginsList );
 			pluginsList = PluginsListsStore.getFullList( 'popular' );
-			assert.ok( pluginsList.fetching );
+			expect( pluginsList.fetching ).toBeTruthy();
 		} );
 
 		test( 'should append the content of the response to the list when the requested page is not the first', () => {
 			Dispatcher.handleServerAction( actionsData.fetchedNewPluginsList );
 			Dispatcher.handleServerAction( actionsData.fetchedNewPluginsListSecondPage );
 			pluginsList = PluginsListsStore.getFullList( 'new' );
-			assert.lengthOf( pluginsList.list, 2 );
+			expect( pluginsList.list.length ).toBe( 2 );
 		} );
 
 		test( 'should not mark a list as `not being fetched` when the fetch of a different list ends', () => {
 			Dispatcher.handleViewAction( actionsData.fetchingPopularPluginsList );
 			Dispatcher.handleServerAction( actionsData.fetchedNewPluginsList );
 			pluginsList = PluginsListsStore.getFullList( 'popular' );
-			assert.ok( pluginsList.fetching );
+			expect( pluginsList.fetching ).toBeTruthy();
 		} );
 
 		test( 'should overwrite the list with the content of the request when the requested page is the first', () => {
 			Dispatcher.handleServerAction( actionsData.fetchedNewPluginsList );
 			Dispatcher.handleServerAction( actionsData.fetchedNewPluginsList );
 			pluginsList = PluginsListsStore.getFullList( 'new' );
-			assert.lengthOf( pluginsList.list, 1 );
+			expect( pluginsList.list.length ).toBe( 1 );
 		} );
 	} );
 
 	describe( 'Search lists', () => {
 		test( 'should be empty if the search list has not been fetched yet', () => {
 			const newPlugins = PluginsListsStore.getSearchList( 'test' );
-			assert.lengthOf( newPlugins.list, 0 );
+			expect( newPlugins.list.length ).toBe( 0 );
 		} );
 
 		test( 'should be populated after the processing a search list fetched event', () => {
@@ -149,13 +144,13 @@ describe( 'WPORG Plugins Lists Store', () => {
 			PluginsListsStore.getSearchList( 'test' );
 			Dispatcher.handleServerAction( actionsData.fetchedSearchPluginsList );
 			searchPlugins = PluginsListsStore.getSearchList( 'test' );
-			assert.isArray( searchPlugins.list );
-			assert.lengthOf( searchPlugins.list, 1 );
+			expect( Array.isArray( searchPlugins.list ) ).toBe( true );
+			expect( searchPlugins.list.length ).toBe( 1 );
 		} );
 
 		test( 'should fetch for the search list when the search is requested', () => {
 			PluginsListsStore.getSearchList( 'test' );
-			assert.isTrue( actionsSpies.fetchPluginsList.called );
+			expect( actionsSpies.fetchPluginsList.called ).toBe( true );
 		} );
 
 		test( 'should mark a search list as `not being fetched`  when the fetch ends', () => {
@@ -163,13 +158,13 @@ describe( 'WPORG Plugins Lists Store', () => {
 			Dispatcher.handleViewAction( actionsData.fetchedSearchPluginsList );
 			Dispatcher.handleServerAction( actionsData.fetchedSearchPluginsList );
 			pluginsList = PluginsListsStore.getSearchList( 'test' );
-			assert.notOk( pluginsList.fetching );
+			expect( pluginsList.fetching ).toBeFalsy();
 		} );
 
 		test( 'should mark a search list as `being fetched` when the fetch begin', () => {
 			Dispatcher.handleViewAction( actionsData.fetchingSearchPluginsList );
 			pluginsList = PluginsListsStore.getSearchList( 'test' );
-			assert.ok( pluginsList.fetching );
+			expect( pluginsList.fetching ).toBeTruthy();
 		} );
 
 		test( 'should append the content of the response to the search list when the requested page is not the first', () => {
@@ -177,14 +172,14 @@ describe( 'WPORG Plugins Lists Store', () => {
 			Dispatcher.handleViewAction( actionsData.fetchedSearchPluginsList );
 			Dispatcher.handleViewAction( actionsData.fetchedSearchPluginsListSecondPage );
 			pluginsList = PluginsListsStore.getSearchList( 'test' );
-			assert.lengthOf( pluginsList.list, 2 );
+			expect( pluginsList.list.length ).toBe( 2 );
 		} );
 
 		test( 'should not mark a search list as `not being fetched` when the fetch of a different list ends', () => {
 			Dispatcher.handleViewAction( actionsData.fetchingSearchPluginsList );
 			Dispatcher.handleServerAction( actionsData.fetchedNewPluginsList );
 			pluginsList = PluginsListsStore.getSearchList( 'test' );
-			assert.ok( pluginsList.fetching );
+			expect( pluginsList.fetching ).toBeTruthy();
 		} );
 
 		test( 'should overwrite the search list with the content of the request when the requested page is the first', () => {
@@ -192,19 +187,19 @@ describe( 'WPORG Plugins Lists Store', () => {
 			Dispatcher.handleViewAction( actionsData.fetchedSearchPluginsList );
 			Dispatcher.handleViewAction( actionsData.fetchedSearchPluginsList );
 			pluginsList = PluginsListsStore.getSearchList( 'test' );
-			assert.lengthOf( pluginsList.list, 1 );
+			expect( pluginsList.list.length ).toBe( 1 );
 		} );
 
 		test( 'should not repeat a search if the search term is the same', () => {
 			pluginsList = PluginsListsStore.getSearchList( 'test' );
 			pluginsList = PluginsListsStore.getSearchList( 'test' );
-			assert.isTrue( actionsSpies.fetchPluginsList.called );
+			expect( actionsSpies.fetchPluginsList.called ).toBe( true );
 		} );
 
 		test( 'should repeat a search if the search term is the different', () => {
 			pluginsList = PluginsListsStore.getSearchList( 'test' );
 			pluginsList = PluginsListsStore.getSearchList( 'not-a-test' );
-			assert.isTrue( actionsSpies.fetchPluginsList.calledTwice );
+			expect( actionsSpies.fetchPluginsList.calledTwice ).toBe( true );
 		} );
 	} );
 } );

--- a/client/lib/post-normalizer/test/index.js
+++ b/client/lib/post-normalizer/test/index.js
@@ -4,10 +4,6 @@
  */
 jest.mock( 'lib/safe-image-url', () => require( './mocks/lib/safe-image-url' ) );
 
-/**
- * External dependencies
- */
-import { assert } from 'chai';
 import { trim } from 'lodash';
 import { spy } from 'sinon';
 
@@ -23,7 +19,7 @@ function identifyTransform( post, callback ) {
 }
 
 function failIfCalledTransform() {
-	assert( false, 'should not have been called' );
+	expect( false ).toBeTruthy();
 	// intentionally don't call callback
 }
 
@@ -61,12 +57,12 @@ describe( 'index', () => {
 	} );
 
 	test( 'should export a function', () => {
-		assert.equal( typeof normalizer, 'function' );
+		expect( typeof normalizer ).toEqual( 'function' );
 	} );
 
 	test( 'should return null if passed null', done => {
 		normalizer( null, null, function( err, post ) {
-			assert.strictEqual( post, null );
+			expect( post ).toBe( null );
 			done( err );
 		} );
 	} );
@@ -74,7 +70,7 @@ describe( 'index', () => {
 	test( 'should return a copy of what it was passed', done => {
 		const post = {};
 		normalizer( post, [ identifyTransform ], function( err, normalized ) {
-			assert.notStrictEqual( normalized, post );
+			expect( normalized ).not.toBe( post );
 			done( err );
 		} );
 	} );
@@ -82,7 +78,7 @@ describe( 'index', () => {
 	test( 'should leave an empty object alone', done => {
 		const post = {};
 		normalizer( post, allTransforms, function( err, normalized ) {
-			assert.deepEqual( normalized, post );
+			expect( normalized ).toEqual( post );
 			done( err );
 		} );
 	} );
@@ -92,7 +88,7 @@ describe( 'index', () => {
 			title: 'title',
 		};
 		normalizer( post, [ asyncTransform, asyncTransform ], function( err, normalized ) {
-			assert.deepEqual( normalized, post );
+			expect( normalized ).toEqual( post );
 			done( err );
 		} );
 	} );
@@ -103,8 +99,8 @@ describe( 'index', () => {
 		}
 
 		normalizer( {}, [ errorInTransform, failIfCalledTransform ], function( err, normalized ) {
-			assert( err, 'error should have been supplied' );
-			assert( ! normalized, 'no normalized post should have been provided' );
+			expect( err ).toBeTruthy();
+			expect( ! normalized ).toBeTruthy();
 			done();
 		} );
 	} );
@@ -117,8 +113,8 @@ describe( 'index', () => {
 		}
 
 		normalizer( {}, [ errorInTransform, failIfCalledTransform ], function( err, normalized ) {
-			assert( err, 'error should have been supplied' );
-			assert( ! normalized, 'no normalized post should have been provided' );
+			expect( err ).toBeTruthy();
+			expect( ! normalized ).toBeTruthy();
 			done();
 		} );
 	} );
@@ -133,7 +129,7 @@ describe( 'index', () => {
 		};
 
 		normalizer( post, [ normalizer.decodeEntities ], function( err, normalized ) {
-			assert.deepEqual( normalized, {
+			expect( normalized ).toEqual( {
 				title: 'title <i>& bar</i>',
 				excerpt: 'excerpt & bar',
 				author: {
@@ -150,7 +146,7 @@ describe( 'index', () => {
 		};
 
 		normalizer( post, [ normalizer.preventWidows ], function( err, normalized ) {
-			assert.deepEqual( normalized, {
+			expect( normalized ).toEqual( {
 				excerpt: 'this is a longer excerpt\xA0bar',
 			} );
 			done( err );
@@ -163,7 +159,7 @@ describe( 'index', () => {
 		};
 
 		normalizer( post, [ normalizer.preventWidows ], function( err, normalized ) {
-			assert.deepEqual( normalized, {
+			expect( normalized ).toEqual( {
 				excerpt: '',
 			} );
 			done( err );
@@ -180,7 +176,7 @@ describe( 'index', () => {
 		};
 
 		normalizer( post, [ normalizer.stripHTML ], function( err, normalized ) {
-			assert.deepEqual( normalized, {
+			expect( normalized ).toEqual( {
 				title: 'title bar',
 				excerpt: 'excerpt bar',
 				author: {
@@ -199,7 +195,7 @@ describe( 'index', () => {
 				},
 				[ normalizer.makeSiteIDSafeForAPI ],
 				function( err, normalized ) {
-					assert.strictEqual( normalized.normalized_site_id, '12345' );
+					expect( normalized.normalized_site_id ).toBe( '12345' );
 					done( err );
 				}
 			);
@@ -212,8 +208,8 @@ describe( 'index', () => {
 				},
 				[ normalizer.makeSiteIDSafeForAPI ],
 				function( err, normalized ) {
-					assert.strictEqual( normalized.normalized_site_id, 'foo/bar' );
-					assert.strictEqual( normalized.site_id, 'foo::bar' );
+					expect( normalized.normalized_site_id ).toBe( 'foo/bar' );
+					expect( normalized.site_id ).toBe( 'foo::bar' );
 					done( err );
 				}
 			);
@@ -249,27 +245,22 @@ describe( 'index', () => {
 				},
 			};
 			normalizer( post, [ normalizer.safeImageProperties( 200 ) ], function( err, normalized ) {
-				assert.strictEqual(
-					normalized.author.avatar_URL,
+				expect( normalized.author.avatar_URL ).toBe(
 					'http://example.com/me.jpg-SAFE?quality=80&strip=info&w=200'
 				);
-				assert.strictEqual(
-					normalized.featured_image,
+				expect( normalized.featured_image ).toBe(
 					'http://foo.bar/-SAFE?quality=80&strip=info&w=200'
 				);
-				assert.strictEqual(
-					normalized.post_thumbnail.URL,
+				expect( normalized.post_thumbnail.URL ).toBe(
 					'http://example.com/thumb.jpg-SAFE?quality=80&strip=info&w=200'
 				);
-				assert.strictEqual(
-					normalized.featured_media.uri,
+				expect( normalized.featured_media.uri ).toBe(
 					'http://example.com/media.jpg-SAFE?quality=80&strip=info&w=200'
 				);
-				assert.strictEqual(
-					normalized.attachments[ '1234' ].URL,
+				expect( normalized.attachments[ '1234' ].URL ).toBe(
 					'http://example.com/media.jpg-SAFE?quality=80&strip=info&w=200'
 				);
-				assert.strictEqual( normalized.attachments[ '3456' ].URL, 'http://example.com/media.jpg' );
+				expect( normalized.attachments[ '3456' ].URL ).toBe( 'http://example.com/media.jpg' );
 				done( err );
 			} );
 		} );
@@ -281,7 +272,7 @@ describe( 'index', () => {
 				},
 			};
 			normalizer( post, [ normalizer.safeImageProperties( 200 ) ], function( err, normalized ) {
-				assert.strictEqual( normalized.featured_media.uri, 'http://example.com/media.jpg' );
+				expect( normalized.featured_media.uri ).toBe( 'http://example.com/media.jpg' );
 				done( err );
 			} );
 		} );
@@ -303,7 +294,7 @@ describe( 'index', () => {
 			};
 
 			normalizer( post, [ normalizer.pickPrimaryTag ], function( err, normalized ) {
-				assert.deepEqual( normalized.primary_tag, post.tags.second );
+				expect( normalized.primary_tag ).toEqual( post.tags.second );
 				done( err );
 			} );
 		} );
@@ -323,7 +314,7 @@ describe( 'index', () => {
 			};
 
 			normalizer( post, [ normalizer.pickPrimaryTag ], function( err, normalized ) {
-				assert.deepEqual( normalized.primary_tag, post.tags.first );
+				expect( normalized.primary_tag ).toEqual( post.tags.first );
 				done( err );
 			} );
 		} );
@@ -337,7 +328,7 @@ describe( 'index', () => {
 				},
 				[ normalizer.withContentDOM( [ normalizer.content.disableAutoPlayOnMedia ] ) ],
 				function( err, normalized ) {
-					assert.deepEqual( normalized, { content: '<video></video>' } );
+					expect( normalized ).toEqual( { content: '<video></video>' } );
 					done( err );
 				}
 			);
@@ -350,7 +341,7 @@ describe( 'index', () => {
 				},
 				[ normalizer.withContentDOM( [ normalizer.content.disableAutoPlayOnMedia ] ) ],
 				function( err, normalized ) {
-					assert.deepEqual( normalized, { content: '<audio></audio>' } );
+					expect( normalized ).toEqual( { content: '<audio></audio>' } );
 					done( err );
 				}
 			);
@@ -366,16 +357,16 @@ describe( 'index', () => {
 				err,
 				normalized
 			) {
-				assert.deepEqual( normalized, post );
+				expect( normalized ).toEqual( post );
 				done( err );
 			} );
 		} );
 
 		test( 'should provide a __contentDOM property to transforms and remove it after', done => {
 			function detectTimeTransform( post, dom ) {
-				assert.ok( dom );
-				assert.ok( dom.querySelectorAll );
-				assert.equal( dom.querySelectorAll( 'time' ).length, 1 );
+				expect( dom ).toBeTruthy();
+				expect( dom.querySelectorAll ).toBeTruthy();
+				expect( dom.querySelectorAll( 'time' ).length ).toEqual( 1 );
 				return post;
 			}
 			normalizer(
@@ -384,7 +375,7 @@ describe( 'index', () => {
 				},
 				[ normalizer.withContentDOM( [ detectTimeTransform ] ) ],
 				function( err, normalized ) {
-					assert.ok( normalized );
+					expect( normalized ).toBeTruthy();
 					done( err );
 				}
 			);
@@ -399,7 +390,7 @@ describe( 'index', () => {
 				},
 				[ normalizer.withContentDOM( [ normalizer.content.removeStyles ] ) ],
 				function( err, normalized ) {
-					assert.equal( normalized.content, '<div>some content</div>' );
+					expect( normalized.content ).toEqual( '<div>some content</div>' );
 					done( err );
 				}
 			);
@@ -412,7 +403,7 @@ describe( 'index', () => {
 				},
 				[ normalizer.withContentDOM( [ normalizer.content.removeStyles ] ) ],
 				function( err, normalized ) {
-					assert.equal( normalized.content, '<div><img align="right">some content</div>' );
+					expect( normalized.content ).toEqual( '<div><img align="right">some content</div>' );
 					done( err );
 				}
 			);
@@ -426,8 +417,7 @@ describe( 'index', () => {
 				},
 				[ normalizer.withContentDOM( [ normalizer.content.removeStyles ] ) ],
 				function( err, normalized ) {
-					assert.equal(
-						normalized.content,
+					expect( normalized.content ).toEqual(
 						'<div class="gallery" style="width: 100000px">' +
 							'<style>.gallery{}</style><div style="width:100px">some content</div></div>'
 					);
@@ -445,8 +435,7 @@ describe( 'index', () => {
 				[ normalizer.withContentDOM( [ normalizer.content.removeStyles ] ) ],
 				function( err, normalized ) {
 					/** @format */
-					assert.equal(
-						normalized.content,
+					expect( normalized.content ).toEqual(
 						'<div class="embed-twitter"><blockquote class="twitter-tweet">' +
 							'<p lang="en" dir="ltr"></p></blockquote>' +
 							'<script async="" src="//platform.twitter.com/widgets.js" charset="utf-8"></script></div>'
@@ -464,8 +453,7 @@ describe( 'index', () => {
 				},
 				[ normalizer.withContentDOM( [ normalizer.content.removeStyles ] ) ],
 				function( err, normalized ) {
-					assert.equal(
-						normalized.content,
+					expect( normalized.content ).toEqual(
 						'<blockquote class="instagram-media" style="background:#FFF;">' +
 							'<div style="padding:8px;">' +
 							'<p style="margin:8px 0 0 0;"> <a style="color:#000;"></a></p>' +
@@ -484,7 +472,7 @@ describe( 'index', () => {
 				{ content: '', URL: 'javascript:foo' },
 				[ normalizer.makeLinksSafe ],
 				( err, normalized ) => {
-					assert.equal( normalized.URL, '' );
+					expect( normalized.URL ).toEqual( '' );
 					done( err );
 				}
 			);
@@ -505,7 +493,7 @@ describe( 'index', () => {
 					{ content: '<a href="' + badLink + '">hi there</a>' },
 					[ normalizer.withContentDOM( [ normalizer.content.makeContentLinksSafe ] ) ],
 					( err, normalized ) => {
-						assert.equal( normalized.content, '<a>hi there</a>' );
+						expect( normalized.content ).toEqual( '<a>hi there</a>' );
 						done( err );
 					}
 				);
@@ -522,8 +510,7 @@ describe( 'index', () => {
 				},
 				[ normalizer.withContentDOM( [ normalizer.content.makeImagesSafe() ] ) ],
 				function( err, normalized ) {
-					assert.equal(
-						normalized.content,
+					expect( normalized.content ).toEqual(
 						'<img src="http://example.com/example.jpg-SAFE"><img src="http://example.com/example2.jpg-SAFE">'
 					);
 					done( err );
@@ -539,8 +526,7 @@ describe( 'index', () => {
 				},
 				[ normalizer.withContentDOM( [ normalizer.content.makeImagesSafe() ] ) ],
 				function( err, normalized ) {
-					assert.equal(
-						normalized.content,
+					expect( normalized.content ).toEqual(
 						'<img src="http://example.wordpress.com/example.jpg-SAFE">' +
 							'<img src="http://example.wordpress.com/example2.jpg-SAFE">'
 					);
@@ -557,8 +543,7 @@ describe( 'index', () => {
 				},
 				[ normalizer.withContentDOM( [ normalizer.content.makeImagesSafe() ] ) ],
 				function( err, normalized ) {
-					assert.equal(
-						normalized.content,
+					expect( normalized.content ).toEqual(
 						'<img src="http://example.wordpress.com/example.jpg-SAFE">'
 					);
 					done( err );
@@ -574,8 +559,7 @@ describe( 'index', () => {
 				},
 				[ normalizer.withContentDOM( [ normalizer.content.makeImagesSafe( 400 ) ] ) ],
 				function( err, normalized ) {
-					assert.equal(
-						normalized.content,
+					expect( normalized.content ).toEqual(
 						'<img src="http://example.com/example.jpg-SAFE?quality=80&amp;strip=info&amp;w=400">' +
 							'<img src="http://example.com/example2.jpg-SAFE?quality=80&amp;strip=info&amp;w=400">'
 					);
@@ -592,7 +576,7 @@ describe( 'index', () => {
 				},
 				[ normalizer.withContentDOM( [ normalizer.content.makeImagesSafe( 400 ) ] ) ],
 				function( err, normalized ) {
-					assert.equal( normalized.content, '' );
+					expect( normalized.content ).toEqual( '' );
 					done( err );
 				}
 			);
@@ -607,8 +591,7 @@ describe( 'index', () => {
 				},
 				[ normalizer.withContentDOM( [ normalizer.content.makeImagesSafe( 400 ) ] ) ],
 				function( err, normalized ) {
-					assert.equal(
-						normalized.content,
+					expect( normalized.content ).toEqual(
 						'<img width="700" height="700" src="https://example.com/example.jpg?nope">'
 					);
 					done( err );
@@ -624,7 +607,7 @@ describe( 'index', () => {
 				},
 				[ normalizer.withContentDOM( [ normalizer.content.makeImagesSafe() ] ) ],
 				function( err, normalized ) {
-					assert.equal( normalized.content, '<img src="http://example.com/example.jpg-SAFE">' );
+					expect( normalized.content ).toEqual( '<img src="http://example.com/example.jpg-SAFE">' );
 					done( err );
 				}
 			);
@@ -638,7 +621,7 @@ describe( 'index', () => {
 				},
 				[ normalizer.withContentDOM( [ normalizer.content.makeImagesSafe() ] ) ],
 				function( err, normalized ) {
-					assert.equal( normalized.content, '<img src="http://example.com/example.jpg-SAFE">' );
+					expect( normalized.content ).toEqual( '<img src="http://example.com/example.jpg-SAFE">' );
 					done( err );
 				}
 			);
@@ -652,7 +635,7 @@ describe( 'index', () => {
 				},
 				[ normalizer.withContentDOM( [ normalizer.content.makeImagesSafe() ] ) ],
 				function( err, normalized ) {
-					assert.equal( normalized.content, '<img src="http://example.com/example.jpg-SAFE">' );
+					expect( normalized.content ).toEqual( '<img src="http://example.com/example.jpg-SAFE">' );
 					done( err );
 				}
 			);
@@ -712,7 +695,7 @@ describe( 'index', () => {
 				};
 
 			normalizer( post, [ normalizer.waitForImagesToLoad ], function( err, normalized ) {
-				assert.equal( normalized.images.length, 2 );
+				expect( normalized.images.length ).toEqual( 2 );
 				done( err );
 			} );
 		} );
@@ -751,8 +734,8 @@ describe( 'index', () => {
 				err,
 				normalized
 			) {
-				assert.deepEqual( normalized.images, postRunThroughWaitForImagesToLoad.images );
-				assert.strictEqual( normalized.canonical_image.uri, 'http://example.com/image.jpg' );
+				expect( normalized.images ).toEqual( postRunThroughWaitForImagesToLoad.images );
+				expect( normalized.canonical_image.uri ).toBe( 'http://example.com/image.jpg' );
 				done( err );
 			} );
 		} );
@@ -768,7 +751,7 @@ describe( 'index', () => {
 				},
 				[ normalizer.pickCanonicalImage ],
 				function( err, normalized ) {
-					assert.strictEqual( normalized.canonical_image.uri, 'http://example.com/featured.jpg' );
+					expect( normalized.canonical_image.uri ).toBe( 'http://example.com/featured.jpg' );
 					done( err );
 				}
 			);
@@ -791,7 +774,7 @@ describe( 'index', () => {
 				},
 				[ normalizer.pickCanonicalImage ],
 				function( err, normalized ) {
-					assert.strictEqual( normalized.canonical_image.uri, 'http://example.com/thumb.jpg' );
+					expect( normalized.canonical_image.uri ).toBe( 'http://example.com/thumb.jpg' );
 					done( err );
 				}
 			);
@@ -819,10 +802,10 @@ describe( 'index', () => {
 
 			normalizer.keepValidImages( 100, 200 )( post, callbackSpy );
 
-			assert.isTrue( callbackSpy.called );
+			expect( callbackSpy.called ).toBe( true );
 
-			assert.lengthOf( post.images, 1 );
-			assert.lengthOf( post.content_images, 2 );
+			expect( post.images.length ).toBe( 1 );
+			expect( post.content_images.length ).toBe( 2 );
 		} );
 	} );
 
@@ -834,8 +817,7 @@ describe( 'index', () => {
 				},
 				[ normalizer.withContentDOM( [ normalizer.content.makeEmbedsSafe ] ) ],
 				function( err, normalized ) {
-					assert.strictEqual(
-						normalized.content,
+					expect( normalized.content ).toBe(
 						'<iframe src="https://example.com/" sandbox=""></iframe>'
 					);
 					done( err );
@@ -850,7 +832,7 @@ describe( 'index', () => {
 				},
 				[ normalizer.withContentDOM( [ normalizer.content.makeEmbedsSafe ] ) ],
 				function( err, normalized ) {
-					assert.strictEqual( normalized.content, '<iframe src="https://spotify.com/"></iframe>' );
+					expect( normalized.content ).toBe( '<iframe src="https://spotify.com/"></iframe>' );
 					done( err );
 				}
 			);
@@ -863,8 +845,7 @@ describe( 'index', () => {
 				},
 				[ normalizer.withContentDOM( [ normalizer.content.makeEmbedsSafe ] ) ],
 				function( err, normalized ) {
-					assert.strictEqual(
-						normalized.content,
+					expect( normalized.content ).toBe(
 						'<iframe src="https://youtube.com/" sandbox="allow-same-origin allow-scripts allow-popups"></iframe>'
 					);
 					done( err );
@@ -879,7 +860,7 @@ describe( 'index', () => {
 				},
 				[ normalizer.withContentDOM( [ normalizer.content.makeEmbedsSafe ] ) ],
 				function( err, normalized ) {
-					assert.strictEqual( normalized.content, '' );
+					expect( normalized.content ).toBe( '' );
 					done( err );
 				}
 			);
@@ -894,7 +875,7 @@ describe( 'index', () => {
 				},
 				[ normalizer.withContentDOM( [ normalizer.content.makeEmbedsSafe ] ) ],
 				function( err, normalized ) {
-					assert.strictEqual( normalized.content, '' );
+					expect( normalized.content ).toBe( '' );
 					done( err );
 				}
 			);
@@ -908,7 +889,7 @@ describe( 'index', () => {
 				},
 				[ normalizer.withContentDOM( [ normalizer.content.makeEmbedsSafe ] ) ],
 				function( err, normalized ) {
-					assert.strictEqual( normalized.content, '' );
+					expect( normalized.content ).toBe( '' );
 					done( err );
 				}
 			);
@@ -923,17 +904,16 @@ describe( 'index', () => {
 				},
 				[ normalizer.withContentDOM( [ normalizer.content.detectMedia ] ) ],
 				function( err, normalized ) {
-					assert.lengthOf( normalized.content_embeds, 1 );
+					expect( normalized.content_embeds.length ).toBe( 1 );
 
 					const embed = normalized.content_embeds[ 0 ];
-					assert.strictEqual(
-						embed.iframe,
+					expect( embed.iframe ).toBe(
 						'<iframe width="100" height="50" src="https://youtube.com"></iframe>'
 					);
-					assert.strictEqual( embed.height, 50 );
-					assert.strictEqual( embed.width, 100 );
-					assert.isNull( embed.type );
-					assert.strictEqual( embed.aspectRatio, 2 );
+					expect( embed.height ).toBe( 50 );
+					expect( embed.width ).toBe( 100 );
+					expect( embed.type ).toBeNull();
+					expect( embed.aspectRatio ).toBe( 2 );
 
 					done( err );
 				}
@@ -948,12 +928,12 @@ describe( 'index', () => {
 				},
 				[ normalizer.withContentDOM( [ normalizer.content.detectMedia ] ) ],
 				function( err, normalized ) {
-					assert.lengthOf( normalized.content_media, 3 );
-					assert.lengthOf( normalized.content_images, 2 );
-					assert.lengthOf( normalized.content_embeds, 1 );
-					assert.equal( normalized.content_media[ 0 ], normalized.content_images[ 0 ] );
-					assert.equal( normalized.content_media[ 1 ], normalized.content_embeds[ 0 ] );
-					assert.equal( normalized.content_media[ 2 ], normalized.content_images[ 1 ] );
+					expect( normalized.content_media.length ).toBe( 3 );
+					expect( normalized.content_images.length ).toBe( 2 );
+					expect( normalized.content_embeds.length ).toBe( 1 );
+					expect( normalized.content_media[ 0 ] ).toEqual( normalized.content_images[ 0 ] );
+					expect( normalized.content_media[ 1 ] ).toEqual( normalized.content_embeds[ 0 ] );
+					expect( normalized.content_media[ 2 ] ).toEqual( normalized.content_images[ 1 ] );
 					done( err );
 				}
 			);
@@ -968,9 +948,9 @@ describe( 'index', () => {
 				},
 				[ normalizer.withContentDOM( [ normalizer.content.detectMedia ] ) ],
 				function( err, normalized ) {
-					assert.lengthOf( normalized.content_media, 3 );
-					assert.lengthOf( normalized.content_images, 3 );
-					assert.lengthOf( normalized.content_embeds, 0 );
+					expect( normalized.content_media.length ).toBe( 3 );
+					expect( normalized.content_images.length ).toBe( 3 );
+					expect( normalized.content_embeds.length ).toBe( 0 );
 
 					done( err );
 				}
@@ -984,11 +964,10 @@ describe( 'index', () => {
 				},
 				[ normalizer.withContentDOM( [ normalizer.content.detectMedia ] ) ],
 				function( err, normalized ) {
-					assert.lengthOf( normalized.content_embeds, 1 );
+					expect( normalized.content_embeds.length ).toBe( 1 );
 
 					const embed = normalized.content_embeds[ 0 ];
-					assert.strictEqual(
-						embed.iframe,
+					expect( embed.iframe ).toBe(
 						'<iframe width="100" height="50" src="https://embed.spotify.com"></iframe>'
 					);
 					done( err );
@@ -1005,7 +984,7 @@ describe( 'index', () => {
 				},
 				[ normalizer.withContentDOM( [ normalizer.content.detectMedia ] ) ],
 				function( err, normalized ) {
-					assert.strictEqual( normalized.content_embeds[ 0 ].type, 'youtube' );
+					expect( normalized.content_embeds[ 0 ].type ).toBe( 'youtube' );
 					done( err );
 				}
 			);
@@ -1018,7 +997,7 @@ describe( 'index', () => {
 				},
 				[ normalizer.withContentDOM( [ normalizer.content.detectMedia ] ) ],
 				function( err, normalized ) {
-					assert.strictEqual( normalized.content_embeds[ 0 ].type, 'vimeo' );
+					expect( normalized.content_embeds[ 0 ].type ).toBe( 'vimeo' );
 					done( err );
 				}
 			);
@@ -1030,7 +1009,7 @@ describe( 'index', () => {
 				},
 				[ normalizer.withContentDOM( [ normalizer.content.detectMedia ] ) ],
 				function( err, normalized ) {
-					assert.isUndefined( normalized.content_embeds );
+					expect( normalized.content_embeds ).not.toBeDefined();
 					done( err );
 				}
 			);
@@ -1042,7 +1021,7 @@ describe( 'index', () => {
 				},
 				[ normalizer.withContentDOM( [ normalizer.content.detectMedia ] ) ],
 				function( err, normalized ) {
-					assert.deepEqual( normalized.content_embeds, [] );
+					expect( normalized.content_embeds ).toEqual( [] );
 					done( err );
 				}
 			);
@@ -1063,11 +1042,7 @@ describe( 'index', () => {
 				},
 				[ normalizer.withContentDOM( [ normalizer.content.detectMedia ] ) ],
 				function( err, normalized ) {
-					assert.deepEqual(
-						normalized.content_embeds,
-						[],
-						'No content_embeds should have been found'
-					);
+					expect( normalized.content_embeds ).toEqual( [] );
 					done( err );
 				}
 			);
@@ -1084,9 +1059,9 @@ describe( 'index', () => {
 				},
 				[ normalizer.withContentDOM( [ normalizer.content.detectPolls ] ) ],
 				function( err, normalized ) {
-					assert.include(
-						normalized.content,
-						'<p><a target="_blank" rel="external noopener noreferrer" href="https://polldaddy.com/poll/8980420">Take our poll</a></p>' //eslint-disable-line max-len
+					expect( normalized.content ).toContain(
+						//eslint-disable-line max-len
+						'<p><a target="_blank" rel="external noopener noreferrer" href="https://polldaddy.com/poll/8980420">Take our poll</a></p>'
 					);
 					done( err );
 				}
@@ -1114,7 +1089,7 @@ describe( 'index', () => {
 				},
 				[ normalizer.withContentDOM( [ normalizer.content.removeElementsBySelector ] ) ],
 				function( err, normalized ) {
-					assert.equal( trim( normalized.content ), '' );
+					expect( trim( normalized.content ) ).toEqual( '' );
 					done( err );
 				}
 			);
@@ -1127,7 +1102,7 @@ describe( 'index', () => {
 				err,
 				normalized
 			) {
-				assert.strictEqual( normalized.better_excerpt, expected );
+				expect( normalized.better_excerpt ).toBe( expected );
 				done( err );
 			} );
 		}
@@ -1195,7 +1170,7 @@ describe( 'index', () => {
 				err,
 				normalized
 			) {
-				assert.strictEqual( normalized.content_no_html, 'hi there' );
+				expect( normalized.content_no_html ).toBe( 'hi there' );
 				done( err );
 			} );
 		} );
@@ -1237,7 +1212,7 @@ describe( 'index', () => {
 				{ content: source },
 				[ normalizer.withContentDOM( [ linkJetpackCarousels ] ) ],
 				( err, normalized ) => {
-					assert.deepEqual( normalized.content.trim(), expected.trim() );
+					expect( normalized.content.trim() ).toEqual( expected.trim() );
 					done( err );
 				}
 			);

--- a/client/lib/posts/test/post-list-store.js
+++ b/client/lib/posts/test/post-list-store.js
@@ -6,7 +6,6 @@
 /**
  * External dependencies
  */
-import { assert } from 'chai';
 import { isPlainObject, isArray } from 'lodash';
 
 /**
@@ -141,39 +140,39 @@ describe( 'post-list-store', () => {
 
 	describe( 'postListStoreId', () => {
 		test( 'should set the default postListStoreId', () => {
-			assert.equal( defaultPostListStore.id, DEFAULT_POST_LIST_ID );
+			expect( defaultPostListStore.id ).toEqual( DEFAULT_POST_LIST_ID );
 		} );
 	} );
 
 	describe( 'dispatcher', () => {
 		test( 'should have a dispatch token', () => {
-			assert.typeOf( defaultPostListStore.dispatchToken, 'string' );
+			expect( typeof defaultPostListStore.dispatchToken ).toBe( 'string' );
 		} );
 	} );
 
 	describe( '#get', () => {
 		test( 'should return an object', () => {
-			assert.isTrue( isPlainObject( defaultPostListStore.get() ) );
+			expect( isPlainObject( defaultPostListStore.get() ) ).toBe( true );
 		} );
 
 		test( 'should return the correct default values', () => {
 			const postList = defaultPostListStore.get();
-			assert.isTrue( isArray( postList.postIds ) );
-			assert.equal( postList.postIds.length, 0 );
-			assert.isTrue( isArray( postList.errors ) );
-			assert.isTrue( isPlainObject( postList.query ) );
-			assert.equal( postList.errors.length, 0 );
-			assert.equal( postList.page, 0 );
-			assert.isFalse( postList.nextPageHandle );
-			assert.isFalse( postList.isLastPage );
-			assert.isFalse( postList.isFetchingNextPage );
-			assert.isFalse( postList.isFetchingUpdated );
+			expect( isArray( postList.postIds ) ).toBe( true );
+			expect( postList.postIds.length ).toEqual( 0 );
+			expect( isArray( postList.errors ) ).toBe( true );
+			expect( isPlainObject( postList.query ) ).toBe( true );
+			expect( postList.errors.length ).toEqual( 0 );
+			expect( postList.page ).toEqual( 0 );
+			expect( postList.nextPageHandle ).toBe( false );
+			expect( postList.isLastPage ).toBe( false );
+			expect( postList.isFetchingNextPage ).toBe( false );
+			expect( postList.isFetchingUpdated ).toBe( false );
 		} );
 	} );
 
 	describe( '#getId', () => {
 		test( 'should the return list ID', () => {
-			assert.equal( defaultPostListStore.getID(), defaultPostListStore.get().id );
+			expect( defaultPostListStore.getID() ).toEqual( defaultPostListStore.get().id );
 		} );
 
 		// fairly certain this doesn't actually work. Thes store ID is not part of the cache key...
@@ -187,48 +186,47 @@ describe( 'post-list-store', () => {
 				type: 'page',
 				order: 'ASC',
 			} );
-			assert.equal( defaultPostListStore.getID(), anotherPostListStore.getID() );
+			expect( defaultPostListStore.getID() ).toEqual( anotherPostListStore.getID() );
 		} );
 	} );
 
 	describe( '#getSiteId', () => {
 		test( 'should the return site ID', () => {
-			assert.equal( defaultPostListStore.getSiteId(), defaultPostListStore.get().query.siteId );
+			expect( defaultPostListStore.getSiteId() ).toEqual( defaultPostListStore.get().query.siteId );
 		} );
 	} );
 
 	describe( '#getAll', () => {
 		test( 'should return an array of posts', () => {
 			const allPosts = defaultPostListStore.getAll();
-			assert.isTrue( isArray( allPosts ) );
-			assert.equal( allPosts.length, 0 );
+			expect( isArray( allPosts ) ).toBe( true );
+			expect( allPosts.length ).toEqual( 0 );
 		} );
 	} );
 
 	describe( '#getTree', () => {
 		test( 'should return a tree-ified array of posts', () => {
 			const treePosts = defaultPostListStore.getTree();
-			assert.isTrue( isArray( treePosts ) );
-			assert.equal( treePosts.length, 0 );
+			expect( isArray( treePosts ) ).toBe( true );
+			expect( treePosts.length ).toEqual( 0 );
 		} );
 	} );
 
 	describe( '#getPage', () => {
 		test( 'should return the page number', () => {
-			assert.equal( defaultPostListStore.getPage(), defaultPostListStore.get().page );
+			expect( defaultPostListStore.getPage() ).toEqual( defaultPostListStore.get().page );
 		} );
 	} );
 
 	describe( '#isLastPage', () => {
 		test( 'should return isLastPage boolean', () => {
-			assert.equal( defaultPostListStore.isLastPage(), defaultPostListStore.get().isLastPage );
+			expect( defaultPostListStore.isLastPage() ).toEqual( defaultPostListStore.get().isLastPage );
 		} );
 	} );
 
 	describe( '#isFetchingNextPage', () => {
 		test( 'should return isFetchingNextPage boolean', () => {
-			assert.equal(
-				defaultPostListStore.isFetchingNextPage(),
+			expect( defaultPostListStore.isFetchingNextPage() ).toEqual(
 				defaultPostListStore.get().isFetchingNextPage
 			);
 		} );
@@ -236,7 +234,7 @@ describe( 'post-list-store', () => {
 
 	describe( '#getNextPageParams', () => {
 		test( 'should return an object of params', () => {
-			assert.isTrue( isPlainObject( defaultPostListStore.getNextPageParams() ) );
+			expect( isPlainObject( defaultPostListStore.getNextPageParams() ) ).toBe( true );
 		} );
 	} );
 
@@ -245,20 +243,20 @@ describe( 'post-list-store', () => {
 			const storedList = [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ];
 			const freshList = [ 3, 5, 7, 9 ];
 			const expectedResults = [ 4, 6, 8 ];
-			assert.deepEqual( getRemovedPosts( storedList, freshList ), expectedResults );
+			expect( getRemovedPosts( storedList, freshList ) ).toEqual( expectedResults );
 		} );
 	} );
 
 	describe( '#getUpdatesParams', () => {
 		test( 'should return an object of params', () => {
-			assert.isTrue( isPlainObject( defaultPostListStore.getUpdatesParams() ) );
+			expect( isPlainObject( defaultPostListStore.getUpdatesParams() ) ).toBe( true );
 		} );
 	} );
 
 	describe( '#hasRecentError', () => {
 		test( 'should return false if there are no errors', () => {
 			dispatchReceivePostsPage( defaultPostListStore.getID(), defaultPostListStore.id );
-			assert.isFalse( defaultPostListStore.hasRecentError() );
+			expect( defaultPostListStore.hasRecentError() ).toBe( false );
 		} );
 
 		test( 'should return true if recent payload had error', () => {
@@ -271,25 +269,25 @@ describe( 'post-list-store', () => {
 					omg: 'error!',
 				},
 			} );
-			assert.isTrue( defaultPostListStore.hasRecentError() );
+			expect( defaultPostListStore.hasRecentError() ).toBe( true );
 		} );
 	} );
 
 	describe( 'RECEIVE_POSTS_PAGE', () => {
 		test( 'should add post ids for matching postListStore', () => {
 			dispatchReceivePostsPage( defaultPostListStore.getID(), defaultPostListStore.id );
-			assert.equal( defaultPostListStore.getAll().length, 1 );
+			expect( defaultPostListStore.getAll().length ).toEqual( 1 );
 		} );
 
 		test( 'should add additional post ids for matching postListStore', () => {
 			dispatchReceivePostsPage( defaultPostListStore.getID(), defaultPostListStore.id );
-			assert.equal( defaultPostListStore.getAll().length, 1 );
+			expect( defaultPostListStore.getAll().length ).toEqual( 1 );
 			dispatchReceivePostsPage(
 				defaultPostListStore.getID(),
 				defaultPostListStore.id,
 				TWO_POST_PAYLOAD
 			);
-			assert.equal( defaultPostListStore.getAll().length, 3 );
+			expect( defaultPostListStore.getAll().length ).toEqual( 3 );
 		} );
 
 		test( 'should remove posts omitted in a follow-up post-list page', () => {
@@ -298,13 +296,13 @@ describe( 'post-list-store', () => {
 				defaultPostListStore.id,
 				THREE_POST_PAYLOAD
 			);
-			assert.equal( defaultPostListStore.getAll().length, 3 );
+			expect( defaultPostListStore.getAll().length ).toEqual( 3 );
 			dispatchReceivePostsPage(
 				defaultPostListStore.getID(),
 				defaultPostListStore.id,
 				OMITTED_POST_PAYLOAD
 			);
-			assert.equal( defaultPostListStore.getAll().length, 2 );
+			expect( defaultPostListStore.getAll().length ).toEqual( 2 );
 		} );
 
 		test( 'should remove posts omitted in a follow-up server response', () => {
@@ -313,37 +311,37 @@ describe( 'post-list-store', () => {
 				defaultPostListStore.id,
 				THREE_POST_PAYLOAD_LOCAL
 			);
-			assert.equal( defaultPostListStore.getAll().length, 3 );
+			expect( defaultPostListStore.getAll().length ).toEqual( 3 );
 			dispatchReceivePostsPage(
 				defaultPostListStore.getID(),
 				defaultPostListStore.id,
 				OMIT_INITIAL_POST_PAYLOAD_SERVER
 			);
-			assert.equal( defaultPostListStore.getAll().length, 2 );
+			expect( defaultPostListStore.getAll().length ).toEqual( 2 );
 		} );
 
 		test( 'should add only unique post.global_IDs postListStore', () => {
 			dispatchReceivePostsPage( defaultPostListStore.getID(), defaultPostListStore.id );
-			assert.equal( defaultPostListStore.getAll().length, 1 );
+			expect( defaultPostListStore.getAll().length ).toEqual( 1 );
 			dispatchReceivePostsPage( defaultPostListStore.getID(), defaultPostListStore.id );
-			assert.equal( defaultPostListStore.getAll().length, 1 );
+			expect( defaultPostListStore.getAll().length ).toEqual( 1 );
 		} );
 
 		test( 'should not update if cached store id does not match', () => {
 			dispatchReceivePostsPage( defaultPostListStore.getID(), defaultPostListStore.id );
-			assert.equal( defaultPostListStore.getAll().length, 1 );
+			expect( defaultPostListStore.getAll().length ).toEqual( 1 );
 			dispatchReceivePostsPage( 999, defaultPostListStore.id );
-			assert.equal( defaultPostListStore.getAll().length, 1 );
+			expect( defaultPostListStore.getAll().length ).toEqual( 1 );
 		} );
 
 		test( 'should not add post ids if postListStore does not match', () => {
 			dispatchReceivePostsPage( defaultPostListStore.getID(), 'some-other-post-list-store' );
-			assert.equal( defaultPostListStore.getAll().length, 0 );
+			expect( defaultPostListStore.getAll().length ).toEqual( 0 );
 		} );
 
 		test( 'should set isLastPage true if no next page handle returned', () => {
 			dispatchReceivePostsPage( defaultPostListStore.getID(), defaultPostListStore.id );
-			assert.isTrue( defaultPostListStore.isLastPage() );
+			expect( defaultPostListStore.isLastPage() ).toBe( true );
 		} );
 	} );
 
@@ -353,19 +351,19 @@ describe( 'post-list-store', () => {
 			dispatchReceivePostsPage( DEFAULT_POST_LIST_ID );
 			const currentCacheId = defaultPostListStore.getID();
 			dispatchQueryPosts( DEFAULT_POST_LIST_ID, {} );
-			assert.equal( currentCacheId, defaultPostListStore.getID() );
+			expect( currentCacheId ).toEqual( defaultPostListStore.getID() );
 		} );
 
 		test( 'should change the active query and id when query options change', () => {
 			dispatchQueryPosts( DEFAULT_POST_LIST_ID, {} );
 			const currentCacheId = defaultPostListStore.getID();
 			dispatchQueryPosts( DEFAULT_POST_LIST_ID, { type: 'page' } );
-			assert.notEqual( currentCacheId, defaultPostListStore.getID() );
+			expect( currentCacheId ).not.toEqual( defaultPostListStore.getID() );
 		} );
 
 		test( 'should set site_visibility if no siteId is present', () => {
 			dispatchQueryPosts( DEFAULT_POST_LIST_ID, { type: 'page' } );
-			assert.equal( defaultPostListStore.getNextPageParams().site_visibility, 'visible' );
+			expect( defaultPostListStore.getNextPageParams().site_visibility ).toEqual( 'visible' );
 		} );
 
 		test( 'should set query options passed in', () => {
@@ -374,8 +372,8 @@ describe( 'post-list-store', () => {
 				order: 'ASC',
 			} );
 			const params = defaultPostListStore.getNextPageParams();
-			assert.equal( params.type, 'page' );
-			assert.equal( params.order, 'ASC' );
+			expect( params.type ).toEqual( 'page' );
+			expect( params.order ).toEqual( 'ASC' );
 		} );
 
 		test( 'should remove null query options passed in', () => {
@@ -385,14 +383,14 @@ describe( 'post-list-store', () => {
 				search: null,
 			} );
 			const params = defaultPostListStore.getNextPageParams();
-			assert.isUndefined( params.search );
+			expect( params.search ).not.toBeDefined();
 		} );
 
 		test( 'should not set query options on a different postListStore instance', () => {
 			dispatchQueryPosts( 'some-other-post-list-store', { type: 'page' } );
 			const params = defaultPostListStore.getNextPageParams();
-			assert.equal( params.type, 'post' );
-			assert.equal( params.order, 'DESC' );
+			expect( params.type ).toEqual( 'post' );
+			expect( params.order ).toEqual( 'DESC' );
 		} );
 	} );
 } );

--- a/client/lib/sites-list/test/index.js
+++ b/client/lib/sites-list/test/index.js
@@ -6,7 +6,6 @@
 /**
  * External dependencies
  */
-import { assert } from 'chai';
 import { cloneDeep, forEach } from 'lodash';
 import sinon from 'sinon';
 
@@ -31,12 +30,12 @@ describe( 'SitesList', () => {
 
 	describe( 'initialization', () => {
 		test( 'should create the correct number of sites', () => {
-			assert.equal( initializedSites.length, originalData.length );
+			expect( initializedSites.length ).toEqual( originalData.length );
 		} );
 
 		test( 'should create Site objects', () => {
 			forEach( initializedSites, site => {
-				assert.instanceOf( site, Site );
+				expect( site ).toBeInstanceOf( Site );
 			} );
 		} );
 
@@ -45,13 +44,13 @@ describe( 'SitesList', () => {
 			const origSite = originalData[ 0 ];
 
 			forEach( origSite, ( value, prop ) => {
-				assert.deepEqual( value, site[ prop ] );
+				expect( value ).toEqual( site[ prop ] );
 			} );
 		} );
 
 		test( 'should add change handlers', () => {
 			forEach( initializedSites, site => {
-				assert.isDefined( site.listeners( 'change' ) );
+				expect( site.listeners( 'change' ) ).toBeDefined();
 			} );
 		} );
 	} );
@@ -69,7 +68,7 @@ describe( 'SitesList', () => {
 			const updatedList = sitesList.get();
 
 			forEach( originalList, ( site, index ) => {
-				assert.strictEqual( site, updatedList[ index ] );
+				expect( site ).toBe( updatedList[ index ] );
 			} );
 		} );
 
@@ -82,7 +81,7 @@ describe( 'SitesList', () => {
 			const updatedList = sitesList.get();
 
 			forEach( updatedList, site => {
-				assert.notProperty( site, 'icon' );
+				expect( 'icon' in site ).toBeFalsy();
 			} );
 		} );
 
@@ -92,7 +91,7 @@ describe( 'SitesList', () => {
 			const updatedSite = updatedData[ 0 ];
 
 			forEach( updatedSite, ( updatedValue, prop ) => {
-				assert.deepEqual( updatedValue, site[ prop ] );
+				expect( updatedValue ).toEqual( site[ prop ] );
 			} );
 		} );
 	} );
@@ -107,7 +106,7 @@ describe( 'SitesList', () => {
 
 			const site = sitesList.getSite( siteId );
 			site.set( { description: 'Calypso rocks!' } );
-			assert.isTrue( changeCallback.called );
+			expect( changeCallback.called ).toBe( true );
 		} );
 	} );
 } );

--- a/client/lib/sites-list/test/log-store.js
+++ b/client/lib/sites-list/test/log-store.js
@@ -3,8 +3,6 @@
 /**
  * External dependencies
  */
-import { assert } from 'chai';
-
 describe( 'Sites Log Store', () => {
 	let Dispatcher, LogStore, actions;
 
@@ -15,11 +13,11 @@ describe( 'Sites Log Store', () => {
 	} );
 
 	test( 'should initialize with no Errors', () => {
-		assert.lengthOf( LogStore.getErrors(), 0 );
+		expect( LogStore.getErrors().length ).toBe( 0 );
 	} );
 
 	test( 'removing an error notice deletes an error', () => {
 		Dispatcher.handleServerAction( actions.removeNotices );
-		assert.lengthOf( LogStore.getErrors(), 0 );
+		expect( LogStore.getErrors().length ).toBe( 0 );
 	} );
 } );

--- a/client/lib/string/test/index.js
+++ b/client/lib/string/test/index.js
@@ -3,11 +3,6 @@
 /**
  * External dependencies
  */
-import { assert } from 'chai';
-
-/**
- * Internal dependencies
- */
 import { areEqualIgnoringWhitespaceAndCase } from '../';
 
 describe( 'lib/string/areEqualIgnoringWhitespaceAndCase', () => {
@@ -21,10 +16,7 @@ describe( 'lib/string/areEqualIgnoringWhitespaceAndCase', () => {
 			[ 'hi_there', 'Hi THERE' ],
 		];
 		pairs.forEach( pair => {
-			assert.isTrue(
-				areEqualIgnoringWhitespaceAndCase( pair[ 0 ], pair[ 1 ] ),
-				`'${ pair[ 0 ] }' v '${ pair[ 1 ] }'`
-			);
+			expect( areEqualIgnoringWhitespaceAndCase( pair[ 0 ], pair[ 1 ] ) ).toBe( true );
 		} );
 	} );
 } );

--- a/client/lib/user-settings/test/index.js
+++ b/client/lib/user-settings/test/index.js
@@ -6,11 +6,6 @@
 /**
  * External dependencies
  */
-import { assert, expect } from 'chai';
-
-/**
- * Internal dependencies
- */
 import userSettings from '..';
 
 jest.mock( 'lib/localforage', () => require( 'lib/localforage/localforage-bypass' ) );
@@ -23,17 +18,17 @@ describe( 'User Settings', () => {
 	} );
 
 	test( 'should consider overridden settings as saved', done => {
-		assert.isTrue( userSettings.updateSetting( 'test', true ) );
-		assert.isTrue( userSettings.updateSetting( 'lang_id', true ) );
+		expect( userSettings.updateSetting( 'test', true ) ).toBe( true );
+		expect( userSettings.updateSetting( 'lang_id', true ) ).toBe( true );
 
-		assert.isTrue( userSettings.unsavedSettings.test );
-		assert.isTrue( userSettings.unsavedSettings.lang_id );
+		expect( userSettings.unsavedSettings.test ).toBe( true );
+		expect( userSettings.unsavedSettings.lang_id ).toBe( true );
 
 		userSettings.saveSettings( assertCorrectSettingIsRemoved, { test: true } );
 
 		function assertCorrectSettingIsRemoved() {
-			assert.isUndefined( userSettings.unsavedSettings.test );
-			assert.isTrue( userSettings.unsavedSettings.lang_id );
+			expect( userSettings.unsavedSettings.test ).not.toBeDefined();
+			expect( userSettings.unsavedSettings.lang_id ).toBe( true );
 			done();
 		}
 	} );
@@ -77,22 +72,22 @@ describe( 'User Settings', () => {
 	} );
 
 	test( 'should support flat and deep settings', done => {
-		assert.isFalse( userSettings.settings.lang_id );
-		assert.isFalse( userSettings.settings.testParent.testChild );
+		expect( userSettings.settings.lang_id ).toBe( false );
+		expect( userSettings.settings.testParent.testChild ).toBe( false );
 
-		assert.isTrue( userSettings.updateSetting( 'lang_id', true ) );
-		assert.isTrue( userSettings.updateSetting( 'testParent.testChild', true ) );
+		expect( userSettings.updateSetting( 'lang_id', true ) ).toBe( true );
+		expect( userSettings.updateSetting( 'testParent.testChild', true ) ).toBe( true );
 
-		assert.isTrue( userSettings.unsavedSettings.lang_id );
-		assert.isTrue( userSettings.unsavedSettings.testParent.testChild );
+		expect( userSettings.unsavedSettings.lang_id ).toBe( true );
+		expect( userSettings.unsavedSettings.testParent.testChild ).toBe( true );
 
 		userSettings.saveSettings( assertCorrectSettingIsSaved );
 
 		function assertCorrectSettingIsSaved() {
-			assert.isUndefined( userSettings.unsavedSettings.lang_id );
-			assert.isUndefined( userSettings.unsavedSettings.testParent );
-			assert.isTrue( userSettings.settings.lang_id );
-			assert.isTrue( userSettings.settings.testParent.testChild );
+			expect( userSettings.unsavedSettings.lang_id ).not.toBeDefined();
+			expect( userSettings.unsavedSettings.testParent ).not.toBeDefined();
+			expect( userSettings.settings.lang_id ).toBe( true );
+			expect( userSettings.settings.testParent.testChild ).toBe( true );
 			done();
 		}
 	} );

--- a/client/lib/users/test/store.js
+++ b/client/lib/users/test/store.js
@@ -6,7 +6,6 @@
 /**
  * External dependencies
  */
-import { assert } from 'chai';
 import { findIndex, isUndefined, some } from 'lodash';
 
 /**
@@ -27,20 +26,20 @@ describe( 'Users Store', () => {
 	} );
 
 	test( 'Store should be an object', () => {
-		assert.isObject( UsersStore );
+		expect( typeof UsersStore ).toBe( 'object' );
 	} );
 
 	test( 'Store should have method emitChange', () => {
-		assert.isFunction( UsersStore.emitChange );
+		expect( typeof UsersStore.emitChange ).toBe( 'function' );
 	} );
 
 	describe( 'Getting user by login', () => {
 		test( 'Store should have method getUserByLogin', () => {
-			assert.isFunction( UsersStore.getUserByLogin );
+			expect( typeof UsersStore.getUserByLogin ).toBe( 'function' );
 		} );
 
 		test( 'Should return undefined when user not in store', () => {
-			assert.isUndefined( UsersStore.getUserByLogin( siteId, usersData.users[ 0 ].login ) );
+			expect( UsersStore.getUserByLogin( siteId, usersData.users[ 0 ].login ) ).not.toBeDefined();
 		} );
 
 		test( 'Should return a user object when the user exists', () => {
@@ -48,8 +47,8 @@ describe( 'Users Store', () => {
 			Dispatcher.handleServerAction( actions.fetched );
 			user = UsersStore.getUserByLogin( siteId, usersData.users[ 0 ].login );
 
-			assert.isObject( user );
-			assert.equal( user.ID, usersData.users[ 0 ].ID );
+			expect( typeof user ).toBe( 'object' );
+			expect( user.ID ).toEqual( usersData.users[ 0 ].ID );
 		} );
 	} );
 
@@ -62,30 +61,30 @@ describe( 'Users Store', () => {
 		} );
 
 		test( 'Should update the store on RECEIVE_USERS', () => {
-			assert.isNotNull( users );
+			expect( users ).not.toBeNull();
 		} );
 
 		test( 'The users store should return an array of objects when fetching users', () => {
-			assert.isArray( users );
-			assert.isObject( users[ 0 ] );
+			expect( Array.isArray( users ) ).toBe( true );
+			expect( typeof users[ 0 ] ).toBe( 'object' );
 		} );
 
 		test( 'A user object from the store should contain an array of roles', () => {
-			assert.isArray( users[ 0 ].roles );
+			expect( Array.isArray( users[ 0 ].roles ) ).toBe( true );
 		} );
 
 		test( 'Re-fetching a list of users when a users was deleted from the site should result in a smaller array', () => {
 			let lessUsers;
 			Dispatcher.handleServerAction( actions.fetchAgainUserDeleted );
 			lessUsers = UsersStore.getUsers( options );
-			assert.isBelow( lessUsers.length, users.length );
+			expect( lessUsers.length ).toBeLessThan( users.length );
 		} );
 
 		test( 'Fetching more users should add to the array of objects', () => {
 			let moreUsers;
 			Dispatcher.handleServerAction( actions.fetchMoreUsers );
 			moreUsers = UsersStore.getUsers( options );
-			assert.isAbove( moreUsers.length, users.length );
+			expect( moreUsers.length ).toBeGreaterThan( users.length );
 		} );
 	} );
 
@@ -97,15 +96,15 @@ describe( 'Users Store', () => {
 		} );
 
 		test( 'has the correct total users', () => {
-			assert.equal( pagination.totalUsers, 7 );
+			expect( pagination.totalUsers ).toEqual( 7 );
 		} );
 
 		test( 'has the correct offset', () => {
-			assert.equal( pagination.usersCurrentOffset, 0 );
+			expect( pagination.usersCurrentOffset ).toEqual( 0 );
 		} );
 
 		test( 'fetches the correct number of users', () => {
-			assert.equal( pagination.numUsersFetched, 5 );
+			expect( pagination.numUsersFetched ).toEqual( 5 );
 		} );
 
 		describe( 'after fetching more users', () => {
@@ -115,11 +114,11 @@ describe( 'Users Store', () => {
 			} );
 
 			test( 'has the correct offset', () => {
-				assert.equal( pagination.usersCurrentOffset, 5 );
+				expect( pagination.usersCurrentOffset ).toEqual( 5 );
 			} );
 
 			test( 'fetches the correct number of users', () => {
-				assert.equal( pagination.numUsersFetched, 7 );
+				expect( pagination.numUsersFetched ).toEqual( 7 );
 			} );
 		} );
 	} );
@@ -133,17 +132,17 @@ describe( 'Users Store', () => {
 
 		test( 'getUpdatedParams returns correct params', () => {
 			const updatedParams = UsersStore.getUpdatedParams( options );
-			assert.equal( updatedParams.offset, 0 );
-			assert.equal( updatedParams.number, usersData.found );
+			expect( updatedParams.offset ).toEqual( 0 );
+			expect( updatedParams.number ).toEqual( usersData.found );
 		} );
 
 		test( 'Polling updates expected users', () => {
 			const updatedUsers = UsersStore.getUsers( options );
-			assert.equal( updatedUsers.length, usersData.found );
+			expect( updatedUsers.length ).toEqual( usersData.found );
 
 			// The last two users should have a 'contributor' role
 			updatedUsers.slice( -2, 2 ).forEach( user => {
-				assert.equal( user.roles[ 0 ], 'contributor' );
+				expect( user.roles[ 0 ] ).toEqual( 'contributor' );
 			} );
 		} );
 	} );
@@ -160,7 +159,7 @@ describe( 'Users Store', () => {
 
 			Dispatcher.handleServerAction( actions.updateSingleUser );
 			usersAgain = UsersStore.getUsers( options );
-			assert.equal( usersAgain[ testUserIndex ].name, 'Test Won' );
+			expect( usersAgain[ testUserIndex ].name ).toEqual( 'Test Won' );
 		} );
 
 		test( 'Error should restore the updated user', () => {
@@ -168,15 +167,15 @@ describe( 'Users Store', () => {
 				user = UsersStore.getUser( siteId, userId );
 			let userAgain, userRestored;
 
-			assert.equal( user.name, 'Test One' );
+			expect( user.name ).toEqual( 'Test One' );
 
 			Dispatcher.handleServerAction( actions.updateSingleUser );
 			userAgain = UsersStore.getUser( siteId, userId );
-			assert.equal( userAgain.name, 'Test Won' );
+			expect( userAgain.name ).toEqual( 'Test Won' );
 
 			Dispatcher.handleServerAction( actions.updateUserError );
 			userRestored = UsersStore.getUser( siteId, userId );
-			assert.equal( userRestored.name, 'Test One' );
+			expect( userRestored.name ).toEqual( 'Test One' );
 		} );
 	} );
 
@@ -191,7 +190,7 @@ describe( 'Users Store', () => {
 		test( 'Should delete a specific user', () => {
 			Dispatcher.handleServerAction( actions.deleteUser );
 			userAgain = UsersStore.getUser( siteId, userId );
-			assert.equal( userAgain, null );
+			expect( userAgain ).toEqual( null );
 		} );
 
 		test( 'Error should restore the deleted user', () => {
@@ -199,11 +198,11 @@ describe( 'Users Store', () => {
 
 			Dispatcher.handleServerAction( actions.deleteUser );
 			userAgain = UsersStore.getUser( siteId, userId );
-			assert.equal( userAgain, null );
+			expect( userAgain ).toEqual( null );
 
 			Dispatcher.handleServerAction( actions.deleteUserError );
 			userRestored = UsersStore.getUser( siteId, userId );
-			assert.equal( userRestored.name, 'Test One' );
+			expect( userRestored.name ).toEqual( 'Test One' );
 		} );
 
 		test( 'There should be no undefined objects in user array after deleting a user', () => {
@@ -211,7 +210,7 @@ describe( 'Users Store', () => {
 			Dispatcher.handleServerAction( actions.deleteUser );
 			users = UsersStore.getUsers( options );
 			someUndefined = some( users, isUndefined );
-			assert.isFalse( someUndefined );
+			expect( someUndefined ).toBe( false );
 		} );
 	} );
 
@@ -222,10 +221,10 @@ describe( 'Users Store', () => {
 		test( 'Fetching a single user should add to the store', () => {
 			const users = UsersStore.getUsers( options );
 			let usersAgain;
-			assert.lengthOf( users, 5 );
+			expect( users.length ).toBe( 5 );
 			Dispatcher.handleServerAction( actions.receiveSingleUser );
 			usersAgain = UsersStore.getUsers( options );
-			assert.lengthOf( usersAgain, 6 );
+			expect( usersAgain.length ).toBe( 6 );
 		} );
 	} );
 } );

--- a/client/lib/viewers/test/store.js
+++ b/client/lib/viewers/test/store.js
@@ -6,11 +6,6 @@
 /**
  * External dependencies
  */
-import { assert } from 'chai';
-
-/**
- * Internal dependencies
- */
 import actions from './fixtures/actions';
 import site from './fixtures/site';
 
@@ -25,19 +20,19 @@ describe( 'Viewers Store', () => {
 
 	describe( 'Shape of store', () => {
 		test( 'Store should be an object', () => {
-			assert.isObject( ViewersStore );
+			expect( typeof ViewersStore ).toBe( 'object' );
 		} );
 
 		test( 'Store should have method emitChange', () => {
-			assert.isFunction( ViewersStore.emitChange );
+			expect( typeof ViewersStore.emitChange ).toBe( 'function' );
 		} );
 
 		test( 'Store should have method getViewers', () => {
-			assert.isFunction( ViewersStore.getViewers );
+			expect( typeof ViewersStore.getViewers ).toBe( 'function' );
 		} );
 
 		test( 'Store should have method getPaginationData', () => {
-			assert.isFunction( ViewersStore.getPaginationData );
+			expect( typeof ViewersStore.getPaginationData ).toBe( 'function' );
 		} );
 	} );
 
@@ -45,7 +40,7 @@ describe( 'Viewers Store', () => {
 		test( "Should return false when viewers haven't been fetched", () => {
 			const viewers = ViewersStore.getViewers( siteId );
 
-			assert.isFalse( viewers, 'viewers is false' );
+			expect( viewers ).toBe( false );
 		} );
 
 		test( 'Should return an array of objects when there are viewers', () => {
@@ -54,8 +49,8 @@ describe( 'Viewers Store', () => {
 			Dispatcher.handleServerAction( actions.fetchedViewers );
 			viewers = ViewersStore.getViewers( siteId );
 
-			assert.isArray( viewers, 'viewers is an array' );
-			assert.isObject( viewers[ 0 ] );
+			expect( Array.isArray( viewers ) ).toBe( true );
+			expect( typeof viewers[ 0 ] ).toBe( 'object' );
 		} );
 	} );
 
@@ -69,13 +64,13 @@ describe( 'Viewers Store', () => {
 		test( 'Fetching zero users should not affect store size', () => {
 			Dispatcher.handleServerAction( actions.fetchedViewersEmpty );
 			viewersAgain = ViewersStore.getViewers( siteId );
-			assert.equal( viewers.length, viewersAgain.length, 'the viewers store was not affected' );
+			expect( viewers.length ).toEqual( viewersAgain.length );
 		} );
 
 		test( 'Fetching more viewers should increase the store size', () => {
 			Dispatcher.handleServerAction( actions.fetchedMoreViewers );
 			viewersAgain = ViewersStore.getViewers( siteId );
-			assert.notEqual( viewersAgain.length, viewers.length, 'the viewers store increased' );
+			expect( viewersAgain.length ).not.toEqual( viewers.length );
 		} );
 	} );
 
@@ -87,15 +82,15 @@ describe( 'Viewers Store', () => {
 		} );
 
 		test( 'has the correct total viewers', () => {
-			assert.equal( pagination.totalViewers, 4 );
+			expect( pagination.totalViewers ).toEqual( 4 );
 		} );
 
 		test( 'has the correct number of viewers fetched', () => {
-			assert.equal( pagination.numViewersFetched, 2 );
+			expect( pagination.numViewersFetched ).toEqual( 2 );
 		} );
 
 		test( 'has the correct page', () => {
-			assert.equal( pagination.currentViewersPage, 1 );
+			expect( pagination.currentViewersPage ).toEqual( 1 );
 		} );
 
 		describe( 'after fetching more viewers', () => {
@@ -105,11 +100,11 @@ describe( 'Viewers Store', () => {
 			} );
 
 			test( 'has the correct updated number of viewers fetched', () => {
-				assert.equal( pagination.numViewersFetched, 4 );
+				expect( pagination.numViewersFetched ).toEqual( 4 );
 			} );
 
 			test( 'advances to the next page', () => {
-				assert.equal( pagination.currentViewersPage, 2 );
+				expect( pagination.currentViewersPage ).toEqual( 2 );
 			} );
 		} );
 	} );
@@ -124,7 +119,7 @@ describe( 'Viewers Store', () => {
 		test( 'Should remove a single viewer.', () => {
 			Dispatcher.handleServerAction( actions.removeViewer );
 			viewersAgain = ViewersStore.getViewers( siteId );
-			assert.lengthOf( viewersAgain, 1 );
+			expect( viewersAgain.length ).toBe( 1 );
 		} );
 
 		test( 'Should restore a single viewer on removal error.', () => {
@@ -132,11 +127,11 @@ describe( 'Viewers Store', () => {
 
 			Dispatcher.handleServerAction( actions.removeViewer );
 			viewersAfterRemove = ViewersStore.getViewers( siteId );
-			assert.lengthOf( viewersAfterRemove, 1 );
+			expect( viewersAfterRemove.length ).toBe( 1 );
 
 			Dispatcher.handleServerAction( actions.removeViewerError );
 			viewersAfterError = ViewersStore.getViewers( siteId );
-			assert.lengthOf( viewersAfterError, 2 );
+			expect( viewersAfterError.length ).toBe( 2 );
 		} );
 	} );
 } );

--- a/client/my-sites/theme/test/main.jsx
+++ b/client/my-sites/theme/test/main.jsx
@@ -2,7 +2,6 @@
 /**
  * External dependencies
  */
-import { assert } from 'chai';
 import React from 'react';
 import { renderToString } from 'react-dom/server';
 import { Provider as ReduxProvider } from 'react-redux';
@@ -51,10 +50,10 @@ describe( 'main', () => {
 				</ReduxProvider>
 			);
 			let markup;
-			assert.doesNotThrow( () => {
+			expect( () => {
 				markup = renderToString( layout );
-			} );
-			assert.isTrue( markup.includes( 'theme__sheet' ) );
+			} ).not.toThrow();
+			expect( markup.includes( 'theme__sheet' ) ).toBe( true );
 		} );
 
 		test( "doesn't throw an exception with theme data", () => {
@@ -66,10 +65,10 @@ describe( 'main', () => {
 				</ReduxProvider>
 			);
 			let markup;
-			assert.doesNotThrow( () => {
+			expect( () => {
 				markup = renderToString( layout );
-			} );
-			assert.isTrue( markup.includes( 'theme__sheet' ) );
+			} ).not.toThrow();
+			expect( markup.includes( 'theme__sheet' ) ).toBe( true );
 		} );
 
 		test( "doesn't throw an exception with invalid theme data", () => {
@@ -81,10 +80,10 @@ describe( 'main', () => {
 				</ReduxProvider>
 			);
 			let markup;
-			assert.doesNotThrow( () => {
+			expect( () => {
 				markup = renderToString( layout );
-			} );
-			assert.isTrue( markup.includes( 'empty-content' ) );
+			} ).not.toThrow();
+			expect( markup.includes( 'empty-content' ) ).toBe( true );
 		} );
 	} );
 } );

--- a/client/my-sites/themes/test/logged-out.jsx
+++ b/client/my-sites/themes/test/logged-out.jsx
@@ -2,7 +2,6 @@
 /**
  * External dependencies
  */
-import { assert } from 'chai';
 import React from 'react';
 import { renderToString } from 'react-dom/server';
 import { Provider as ReduxProvider } from 'react-redux';
@@ -93,24 +92,24 @@ describe( 'logged-out', () => {
 
 		test( 'renders without error when no themes are present', () => {
 			let markup;
-			assert.doesNotThrow( () => {
+			expect( () => {
 				markup = renderToString( layout );
-			} );
+			} ).not.toThrow();
 			// Should show a "No themes found" message
-			assert.isTrue( markup.includes( 'empty-content' ) );
+			expect( markup.includes( 'empty-content' ) ).toBe( true );
 		} );
 
 		test( 'renders without error when themes are present', () => {
 			store.dispatch( receiveThemes( themes, 'wpcom', DEFAULT_THEME_QUERY, themes.length ) );
 
 			let markup;
-			assert.doesNotThrow( () => {
+			expect( () => {
 				markup = renderToString( layout );
-			} );
+			} ).not.toThrow();
 			// All 5 themes should appear...
-			assert.equal( 5, markup.match( /theme__content/g ).length );
+			expect( 5 ).toEqual( markup.match( /theme__content/g ).length );
 			// .. and no empty content placeholders should appear
-			assert.isFalse( markup.includes( 'empty-content' ) );
+			expect( markup.includes( 'empty-content' ) ).toBe( false );
 		} );
 
 		test( 'renders without error when theme fetch fails', () => {
@@ -122,11 +121,11 @@ describe( 'logged-out', () => {
 			} );
 
 			let markup;
-			assert.doesNotThrow( () => {
+			expect( () => {
 				markup = renderToString( layout );
-			} );
+			} ).not.toThrow();
 			// Should show a "No themes found" message
-			assert.isTrue( markup.includes( 'empty-content' ) );
+			expect( markup.includes( 'empty-content' ) ).toBe( true );
 		} );
 	} );
 } );

--- a/client/reader/discover/test/helper.js
+++ b/client/reader/discover/test/helper.js
@@ -6,7 +6,6 @@
 /**
  * External dependencies
  */
-import { assert } from 'chai';
 import { get, omit } from 'lodash';
 
 /**
@@ -24,83 +23,83 @@ describe( 'helper', () => {
 
 	describe( 'isDiscoverPost', () => {
 		test( 'returns true if discover metadata is present', () => {
-			assert.isTrue( helper.isDiscoverPost( discoverPost ) );
+			expect( helper.isDiscoverPost( discoverPost ) ).toBe( true );
 		} );
 
 		test( 'returns true if the site id is discovery_blog_id', () => {
 			const withoutMetadata = omit( fixtures.discoverSiteFormat, 'discover_metadata' );
-			assert.isTrue( helper.isDiscoverPost( withoutMetadata ) );
+			expect( helper.isDiscoverPost( withoutMetadata ) ).toBe( true );
 		} );
 
 		test( 'returns false if the site is not disover or discover metadata is not present', () => {
-			assert.isFalse( helper.isDiscoverPost( fixtures.nonDiscoverPost ) );
+			expect( helper.isDiscoverPost( fixtures.nonDiscoverPost ) ).toBe( false );
 		} );
 
 		test( 'returns false if the post is undefined', () => {
-			assert.isFalse( helper.isDiscoverPost() );
+			expect( helper.isDiscoverPost() ).toBe( false );
 		} );
 	} );
 
 	describe( 'isDiscoverSitePick', () => {
 		test( 'returns true if the post is a site pick', () => {
-			assert.isTrue( helper.isDiscoverSitePick( fixtures.discoverSiteFormat ) );
+			expect( helper.isDiscoverSitePick( fixtures.discoverSiteFormat ) ).toBe( true );
 		} );
 
 		test( 'returns false if the post is not a site pick', () => {
-			assert.isFalse( helper.isDiscoverSitePick( discoverPost ) );
+			expect( helper.isDiscoverSitePick( discoverPost ) ).toBe( false );
 		} );
 
 		test( 'returns false if the post is undefined', () => {
-			assert.isFalse( helper.isDiscoverSitePick() );
+			expect( helper.isDiscoverSitePick() ).toBe( false );
 		} );
 	} );
 
 	describe( 'isInternalDiscoverPost', () => {
 		test( 'returns true if the post is internal to wpcom', () => {
-			assert.isTrue( helper.isInternalDiscoverPost( discoverPost ) );
+			expect( helper.isInternalDiscoverPost( discoverPost ) ).toBe( true );
 		} );
 
 		test( 'returns false if the post is not internal to wpcom', () => {
-			assert.isFalse( helper.isInternalDiscoverPost( fixtures.externalDiscoverPost ) );
+			expect( helper.isInternalDiscoverPost( fixtures.externalDiscoverPost ) ).toBe( false );
 		} );
 	} );
 
 	describe( 'getSiteUrl', () => {
 		test( 'returns a reader route if the post is internal', () => {
-			assert.match( helper.getSiteUrl( discoverPost ), /^\/read\/blogs/ );
+			expect( helper.getSiteUrl( discoverPost ) ).toMatch( /^\/read\/blogs/ );
 		} );
 
 		test( 'returns the permalink if the post is not internal', () => {
 			const permalink = get( fixtures.externalDiscoverPost, 'discover_metadata.permalink' );
-			assert.equal( permalink, helper.getSiteUrl( fixtures.externalDiscoverPost ) );
+			expect( permalink ).toEqual( helper.getSiteUrl( fixtures.externalDiscoverPost ) );
 		} );
 
 		test( 'returns undefined if the post is not a discover post', () => {
-			assert.isUndefined( helper.getSiteUrl( fixtures.nonDiscoverPost ) );
+			expect( helper.getSiteUrl( fixtures.nonDiscoverPost ) ).not.toBeDefined();
 		} );
 	} );
 
 	describe( 'hasSource', () => {
 		test( 'returns true if the post is not a site pick', () => {
-			assert.isTrue( helper.hasSource( discoverPost ) );
+			expect( helper.hasSource( discoverPost ) ).toBe( true );
 		} );
 
 		test( 'returns false if the post is a site pick', () => {
-			assert.isFalse( helper.hasSource( fixtures.discoverSiteFormat ) );
+			expect( helper.hasSource( fixtures.discoverSiteFormat ) ).toBe( false );
 		} );
 
 		test( 'returns false if the post is undefined', () => {
-			assert.isFalse( helper.hasSource() );
+			expect( helper.hasSource() ).toBe( false );
 		} );
 	} );
 
 	describe( 'getSourceData', () => {
 		test( 'returns empty object if the post is not a discover post', () => {
-			assert.deepEqual( {}, helper.getSourceData( fixtures.nonDiscoverPost ) );
+			expect( {} ).toEqual( helper.getSourceData( fixtures.nonDiscoverPost ) );
 		} );
 
 		test( 'returns empty object if the post is external', () => {
-			assert.deepEqual( {}, helper.getSourceData( fixtures.externalDiscoverPost ) );
+			expect( {} ).toEqual( helper.getSourceData( fixtures.externalDiscoverPost ) );
 		} );
 
 		test( 'returns blog id if the post is a discover site pick', () => {
@@ -111,7 +110,7 @@ describe( 'helper', () => {
 				),
 				postId: undefined,
 			};
-			assert.deepEqual( fixtureData, helper.getSourceData( fixtures.discoverSiteFormat ) );
+			expect( fixtureData ).toEqual( helper.getSourceData( fixtures.discoverSiteFormat ) );
 		} );
 
 		test( 'returns the post and blog id', () => {
@@ -119,31 +118,31 @@ describe( 'helper', () => {
 				blogId: get( discoverPost, 'discover_metadata.featured_post_wpcom_data.blog_id' ),
 				postId: get( discoverPost, 'discover_metadata.featured_post_wpcom_data.post_id' ),
 			};
-			assert.deepEqual( fixtureData, helper.getSourceData( discoverPost ) );
+			expect( fixtureData ).toEqual( helper.getSourceData( discoverPost ) );
 		} );
 	} );
 
 	describe( 'getLinkProps', () => {
 		test( 'returns empty props if the post is internal', () => {
 			const siteUrl = helper.getSiteUrl( discoverPost );
-			assert.deepEqual( helper.getLinkProps( siteUrl ), { rel: '', target: '' } );
+			expect( helper.getLinkProps( siteUrl ) ).toEqual( { rel: '', target: '' } );
 		} );
 
 		test( 'returns props for external posts', () => {
 			const siteUrl = helper.getSiteUrl( fixtures.externalDiscoverPost );
-			assert.deepEqual( helper.getLinkProps( siteUrl ), { rel: 'external', target: '_blank' } );
+			expect( helper.getLinkProps( siteUrl ) ).toEqual( { rel: 'external', target: '_blank' } );
 		} );
 	} );
 
 	describe( 'getSourceFollowUrl', () => {
 		test( 'returns the site url if its a discover pick to an internal site', () => {
 			const followUrl = helper.getSourceFollowUrl( discoverPost );
-			assert.equal( followUrl, get( discoverPost, 'discover_metadata.attribution.blog_url' ) );
+			expect( followUrl ).toEqual( get( discoverPost, 'discover_metadata.attribution.blog_url' ) );
 		} );
 
 		test( 'returns undefined if the post is not a discover pick', () => {
 			const followUrl = helper.getSourceFollowUrl( fixtures.nonDiscoverPost );
-			assert.isUndefined( followUrl );
+			expect( followUrl ).not.toBeDefined();
 		} );
 	} );
 } );

--- a/client/state/account-recovery/reset/test/actions.js
+++ b/client/state/account-recovery/reset/test/actions.js
@@ -3,11 +3,6 @@
 /**
  * External dependencies
  */
-import { assert } from 'chai';
-
-/**
- * Internal dependencies
- */
 import { requestReset, updatePasswordResetUserData, setResetMethod } from '../actions';
 import {
 	ACCOUNT_RECOVERY_RESET_SET_METHOD,
@@ -25,7 +20,7 @@ describe( '#updatePasswordResetUserData', () => {
 		};
 		const action = updatePasswordResetUserData( userData );
 
-		assert.deepEqual( action, {
+		expect( action ).toEqual( {
 			type: ACCOUNT_RECOVERY_RESET_UPDATE_USER_DATA,
 			userData,
 		} );
@@ -39,7 +34,7 @@ describe( '#requestReset', () => {
 
 		const action = requestReset( userData, method );
 
-		assert.deepEqual( action, {
+		expect( action ).toEqual( {
 			type: ACCOUNT_RECOVERY_RESET_REQUEST,
 			userData,
 			method,
@@ -52,7 +47,7 @@ describe( '#setResetMethod', () => {
 		const method = 'primary_email';
 		const action = setResetMethod( method );
 
-		assert.deepEqual( action, {
+		expect( action ).toEqual( {
 			type: ACCOUNT_RECOVERY_RESET_SET_METHOD,
 			method,
 		} );

--- a/client/state/account-recovery/reset/test/reducer.js
+++ b/client/state/account-recovery/reset/test/reducer.js
@@ -3,7 +3,6 @@
 /**
  * External dependencies
  */
-import { assert } from 'chai';
 import deepFreeze from 'deep-freeze';
 
 /**
@@ -45,7 +44,7 @@ describe( '#account-recovery/reset reducer', () => {
 			type: ACCOUNT_RECOVERY_RESET_OPTIONS_REQUEST,
 		} );
 
-		assert.isTrue( state.options.isRequesting );
+		expect( state.options.isRequesting ).toBe( true );
 	} );
 
 	const hasItemsState = deepFreeze( {
@@ -59,7 +58,7 @@ describe( '#account-recovery/reset reducer', () => {
 			type: ACCOUNT_RECOVERY_RESET_OPTIONS_REQUEST,
 		} );
 
-		assert.deepEqual( state.options.items, [] );
+		expect( state.options.items ).toEqual( [] );
 	} );
 
 	test( 'ACCOUNT_RECOVERY_RESET_OPTIONS_ERROR action should delete the previous items.', () => {
@@ -68,7 +67,7 @@ describe( '#account-recovery/reset reducer', () => {
 			error: {},
 		} );
 
-		assert.deepEqual( state.options.items, [] );
+		expect( state.options.items ).toEqual( [] );
 	} );
 
 	const requestingState = deepFreeze( {
@@ -83,7 +82,7 @@ describe( '#account-recovery/reset reducer', () => {
 			items: [],
 		} );
 
-		assert.isFalse( state.options.isRequesting );
+		expect( state.options.isRequesting ).toBe( false );
 	} );
 
 	test( 'ACCOUNT_RECOVERY_RESET_OPTIONS_ERROR action should unset isRequesting flag.', () => {
@@ -92,7 +91,7 @@ describe( '#account-recovery/reset reducer', () => {
 			error: {},
 		} );
 
-		assert.isFalse( state.options.isRequesting );
+		expect( state.options.isRequesting ).toBe( false );
 	} );
 
 	test( 'ACCOUNT_RECOVERY_RESET_OPTIONS_RECEIVE action should populate the items field.', () => {
@@ -101,7 +100,7 @@ describe( '#account-recovery/reset reducer', () => {
 			items: fetchedOptions,
 		} );
 
-		assert.deepEqual( state.options.items, fetchedOptions );
+		expect( state.options.items ).toEqual( fetchedOptions );
 	} );
 
 	const mockError = deepFreeze( {
@@ -115,7 +114,7 @@ describe( '#account-recovery/reset reducer', () => {
 			error: mockError,
 		} );
 
-		assert.deepEqual( state.options.error, mockError );
+		expect( state.options.error ).toEqual( mockError );
 	} );
 
 	test( 'ACCOUNT_RECOVERY_RESET_UPDATE_USER_DATA action should populate the userData field.', () => {
@@ -130,7 +129,7 @@ describe( '#account-recovery/reset reducer', () => {
 			userData,
 		} );
 
-		assert.deepEqual( state.userData, userData );
+		expect( state.userData ).toEqual( userData );
 	} );
 
 	test( 'ACCOUNT_RECOVERY_RESET_SET_METHOD action should populate the method field', () => {
@@ -140,7 +139,7 @@ describe( '#account-recovery/reset reducer', () => {
 			method,
 		} );
 
-		assert.equal( state.method, method );
+		expect( state.method ).toEqual( method );
 	} );
 
 	test( 'ACCOUNT_RECOVERY_RESET_REQUEST action should set the requesting status flag', () => {
@@ -148,7 +147,7 @@ describe( '#account-recovery/reset reducer', () => {
 			type: ACCOUNT_RECOVERY_RESET_REQUEST,
 		} );
 
-		assert.isTrue( state.requestReset.isRequesting );
+		expect( state.requestReset.isRequesting ).toBe( true );
 	} );
 
 	const requestingResetState = deepFreeze( {
@@ -162,7 +161,7 @@ describe( '#account-recovery/reset reducer', () => {
 			type: ACCOUNT_RECOVERY_RESET_REQUEST_SUCCESS,
 		} );
 
-		assert.isFalse( state.requestReset.isRequesting );
+		expect( state.requestReset.isRequesting ).toBe( false );
 	} );
 
 	test( 'ACCOUNT_RECOVERY_RESET_REQUEST_ERROR action should unset the requesting status flag', () => {
@@ -171,7 +170,7 @@ describe( '#account-recovery/reset reducer', () => {
 			error: {},
 		} );
 
-		assert.isFalse( state.requestReset.isRequesting );
+		expect( state.requestReset.isRequesting ).toBe( false );
 	} );
 
 	test( 'ACCOUNT_RECOVERY_RESET_REQUEST_ERROR action should populate the error field', () => {
@@ -180,7 +179,7 @@ describe( '#account-recovery/reset reducer', () => {
 			error: mockError,
 		} );
 
-		assert.deepEqual( state.requestReset.error, mockError );
+		expect( state.requestReset.error ).toEqual( mockError );
 	} );
 
 	test( 'ACCOUNT_RECOVERY_RESET_SET_VALIDATION_KEY action should set the key field', () => {
@@ -190,7 +189,7 @@ describe( '#account-recovery/reset reducer', () => {
 			key,
 		} );
 
-		assert.equal( state.key, key );
+		expect( state.key ).toEqual( key );
 	} );
 
 	test( 'ACCOUNT_RECOVERY_RESET_VALIDATE_REQUEST action should set the requesting status flag of the validate state tree', () => {
@@ -198,7 +197,7 @@ describe( '#account-recovery/reset reducer', () => {
 			type: ACCOUNT_RECOVERY_RESET_VALIDATE_REQUEST,
 		} );
 
-		assert.isTrue( state.validate.isRequesting );
+		expect( state.validate.isRequesting ).toBe( true );
 	} );
 
 	const validatingState = deepFreeze( {
@@ -212,7 +211,7 @@ describe( '#account-recovery/reset reducer', () => {
 			type: ACCOUNT_RECOVERY_RESET_VALIDATE_REQUEST_SUCCESS,
 		} );
 
-		assert.isFalse( state.validate.isRequesting );
+		expect( state.validate.isRequesting ).toBe( false );
 	} );
 
 	test( 'ACCOUNT_RECOVERY_RESET_VALIDATE_REQUEST_ERROR action should unset the requesting status flag of the validate state tree', () => {
@@ -221,7 +220,7 @@ describe( '#account-recovery/reset reducer', () => {
 			error: {},
 		} );
 
-		assert.isFalse( state.validate.isRequesting );
+		expect( state.validate.isRequesting ).toBe( false );
 	} );
 
 	test( 'ACCOUNT_RECOVERY_RESET_VALIDATE_REQUEST_ERROR action should save the error data in the validate state tree', () => {
@@ -230,7 +229,7 @@ describe( '#account-recovery/reset reducer', () => {
 			error: mockError,
 		} );
 
-		assert.deepEqual( state.validate.error, mockError );
+		expect( state.validate.error ).toEqual( mockError );
 	} );
 
 	const validateErrorState = deepFreeze( {
@@ -244,7 +243,7 @@ describe( '#account-recovery/reset reducer', () => {
 			type: ACCOUNT_RECOVERY_RESET_VALIDATE_REQUEST,
 		} );
 
-		assert.isNull( state.validate.error );
+		expect( state.validate.error ).toBeNull();
 	} );
 
 	test( 'ACCOUNT_RECOVERY_RESET_VALIDATE_REQUEST_SUCCESS action should clear the error field of the validate state tree', () => {
@@ -252,7 +251,7 @@ describe( '#account-recovery/reset reducer', () => {
 			type: ACCOUNT_RECOVERY_RESET_VALIDATE_REQUEST_SUCCESS,
 		} );
 
-		assert.isNull( state.validate.error );
+		expect( state.validate.error ).toBeNull();
 	} );
 
 	test( 'ACCOUNT_RECOVERY_RESET_PASSWORD_REQUEST action should set the requesting status flag as true.', () => {
@@ -260,7 +259,7 @@ describe( '#account-recovery/reset reducer', () => {
 			type: ACCOUNT_RECOVERY_RESET_PASSWORD_REQUEST,
 		} );
 
-		assert.isTrue( state.resetPassword.isRequesting );
+		expect( state.resetPassword.isRequesting ).toBe( true );
 	} );
 
 	const requestingResetPasswordState = deepFreeze( {
@@ -274,7 +273,7 @@ describe( '#account-recovery/reset reducer', () => {
 			type: ACCOUNT_RECOVERY_RESET_PASSWORD_REQUEST_SUCCESS,
 		} );
 
-		assert.isFalse( state.resetPassword.isRequesting );
+		expect( state.resetPassword.isRequesting ).toBe( false );
 	} );
 
 	test( 'ACCOUNT_RECOVERY_RESET_PASSWORD_REQUEST_ERROR action should set the requesting flag as false.', () => {
@@ -283,7 +282,7 @@ describe( '#account-recovery/reset reducer', () => {
 			error: {},
 		} );
 
-		assert.isFalse( state.resetPassword.isRequesting );
+		expect( state.resetPassword.isRequesting ).toBe( false );
 	} );
 
 	test( 'ACCOUNT_RECOVERY_RESET_PASSWORD_REQUEST_SUCCESS action should set the succeeded flag as true.', () => {
@@ -291,7 +290,7 @@ describe( '#account-recovery/reset reducer', () => {
 			type: ACCOUNT_RECOVERY_RESET_PASSWORD_REQUEST_SUCCESS,
 		} );
 
-		assert.isTrue( state.resetPassword.succeeded );
+		expect( state.resetPassword.succeeded ).toBe( true );
 	} );
 
 	const resetPasswordSucceededState = deepFreeze( {
@@ -306,7 +305,7 @@ describe( '#account-recovery/reset reducer', () => {
 			error: {},
 		} );
 
-		assert.isFalse( state.resetPassword.succeeded );
+		expect( state.resetPassword.succeeded ).toBe( false );
 	} );
 
 	test( 'ACCOUNT_RECOVERY_RESET_PASSWORD_REQUEST action should set the succeeded flag as false.', () => {
@@ -314,7 +313,7 @@ describe( '#account-recovery/reset reducer', () => {
 			type: ACCOUNT_RECOVERY_RESET_PASSWORD_REQUEST,
 		} );
 
-		assert.isFalse( state.resetPassword.succeeded );
+		expect( state.resetPassword.succeeded ).toBe( false );
 	} );
 
 	test( 'ACCOUNT_RECOVERY_RESET_PASSWORD_REQUEST_ERROR action should populate the error field.', () => {
@@ -327,7 +326,7 @@ describe( '#account-recovery/reset reducer', () => {
 			error,
 		} );
 
-		assert.deepEqual( state.resetPassword.error, error );
+		expect( state.resetPassword.error ).toEqual( error );
 	} );
 
 	const resetPasswordErrorState = deepFreeze( {
@@ -344,7 +343,7 @@ describe( '#account-recovery/reset reducer', () => {
 			type: ACCOUNT_RECOVERY_RESET_PASSWORD_REQUEST,
 		} );
 
-		assert.isNull( state.resetPassword.error );
+		expect( state.resetPassword.error ).toBeNull();
 	} );
 
 	test( 'ACCOUNT_RECOVERY_RESET_PASSWORD_REQUEST_SUCCESS action should clear the error field.', () => {
@@ -352,6 +351,6 @@ describe( '#account-recovery/reset reducer', () => {
 			type: ACCOUNT_RECOVERY_RESET_PASSWORD_REQUEST_SUCCESS,
 		} );
 
-		assert.isNull( state.resetPassword.error );
+		expect( state.resetPassword.error ).toBeNull();
 	} );
 } );

--- a/client/state/account-recovery/settings/test/actions.js
+++ b/client/state/account-recovery/settings/test/actions.js
@@ -3,7 +3,6 @@
 /**
  * External dependencies
  */
-import { assert } from 'chai';
 import sinon from 'sinon';
 
 /**
@@ -72,31 +71,32 @@ describe( 'account-recovery actions', () => {
 			errorResponse: errorResponse,
 		},
 		thunk: () => accountRecoverySettingsFetch()( spy ),
-		preCondition: () => assert( spy.calledWith( { type: ACCOUNT_RECOVERY_SETTINGS_FETCH } ) ),
+		preCondition: () =>
+			expect( spy.calledWith( { type: ACCOUNT_RECOVERY_SETTINGS_FETCH } ) ).toBeTruthy(),
 		postConditionSuccess: () => {
-			assert(
+			expect(
 				spy.calledWith( {
 					type: ACCOUNT_RECOVERY_SETTINGS_FETCH_SUCCESS,
 					settings: dummyData,
 				} )
-			);
+			).toBeTruthy();
 		},
 		postConditionFailed: () => {
-			assert(
+			expect(
 				spy.calledWith(
 					sinon.match( {
 						type: ACCOUNT_RECOVERY_SETTINGS_FETCH_FAILED,
 						error: errorResponse,
 					} )
 				)
-			);
+			).toBeTruthy();
 		},
 	} );
 
 	describe( '#accountRecoverySettingsFetchSuccess()', () => {
 		test( 'should return ACCOUNT_RECOVERY_SETTINGS_FETCH_SUCCESS', () => {
 			const action = accountRecoverySettingsFetchSuccess( dummyData );
-			assert.deepEqual( action, {
+			expect( action ).toEqual( {
 				type: ACCOUNT_RECOVERY_SETTINGS_FETCH_SUCCESS,
 				settings: dummyData,
 			} );
@@ -107,7 +107,7 @@ describe( 'account-recovery actions', () => {
 		test( 'should return ACCOUNT_RECOVERY_SETTINGS_FETCH_FAILED', () => {
 			const action = accountRecoverySettingsFetchFailed( errorResponse );
 
-			assert.deepEqual( action, {
+			expect( action ).toEqual( {
 				type: ACCOUNT_RECOVERY_SETTINGS_FETCH_FAILED,
 				error: errorResponse,
 			} );
@@ -131,22 +131,22 @@ describe( 'account-recovery actions', () => {
 		},
 		thunk: () => updateAccountRecoveryPhone( newPhoneValue )( spy ),
 		preCondition: () =>
-			assert(
+			expect(
 				spy.calledWith( {
 					type: ACCOUNT_RECOVERY_SETTINGS_UPDATE,
 					target: 'phone',
 				} )
-			),
+			).toBeTruthy(),
 		postConditionSuccess: () =>
-			assert(
+			expect(
 				spy.calledWith( {
 					type: ACCOUNT_RECOVERY_SETTINGS_UPDATE_SUCCESS,
 					target: 'phone',
 					value: newPhoneValue,
 				} )
-			),
+			).toBeTruthy(),
 		postConditionFailed: () =>
-			assert(
+			expect(
 				spy.calledWith(
 					sinon.match( {
 						type: ACCOUNT_RECOVERY_SETTINGS_UPDATE_FAILED,
@@ -154,7 +154,7 @@ describe( 'account-recovery actions', () => {
 						error: errorResponse,
 					} )
 				)
-			),
+			).toBeTruthy(),
 	} );
 
 	describe( '#updateAccountRecoveryPhoneSuccess', () => {
@@ -162,7 +162,7 @@ describe( 'account-recovery actions', () => {
 			const phone = dummyData.phone;
 			const action = updateAccountRecoveryPhoneSuccess( phone );
 
-			assert.deepEqual( action, {
+			expect( action ).toEqual( {
 				type: ACCOUNT_RECOVERY_SETTINGS_UPDATE_SUCCESS,
 				target: 'phone',
 				value: phone,
@@ -174,7 +174,7 @@ describe( 'account-recovery actions', () => {
 		test( 'should return ACCOUNT_RECOVERY_SETTINGS_UPDATE_FAILED with target: phone', () => {
 			const action = updateAccountRecoveryPhoneFailed( errorResponse );
 
-			assert.deepEqual( action, {
+			expect( action ).toEqual( {
 				type: ACCOUNT_RECOVERY_SETTINGS_UPDATE_FAILED,
 				target: 'phone',
 				error: errorResponse,
@@ -192,21 +192,21 @@ describe( 'account-recovery actions', () => {
 		},
 		thunk: () => deleteAccountRecoveryPhone()( spy ),
 		preCondition: () =>
-			assert(
+			expect(
 				spy.calledWith( {
 					type: ACCOUNT_RECOVERY_SETTINGS_DELETE,
 					target: 'phone',
 				} )
-			),
+			).toBeTruthy(),
 		postConditionSuccess: () =>
-			assert(
+			expect(
 				spy.calledWith( {
 					type: ACCOUNT_RECOVERY_SETTINGS_DELETE_SUCCESS,
 					target: 'phone',
 				} )
-			),
+			).toBeTruthy(),
 		postConditionFailed: () =>
-			assert(
+			expect(
 				spy.calledWith(
 					sinon.match( {
 						type: ACCOUNT_RECOVERY_SETTINGS_DELETE_FAILED,
@@ -214,14 +214,14 @@ describe( 'account-recovery actions', () => {
 						error: errorResponse,
 					} )
 				)
-			),
+			).toBeTruthy(),
 	} );
 
 	describe( '#deleteAccountRecoveryPhoneSuccess', () => {
 		test( 'should return ACCOUNT_RECOVERY_SETTINGS_DELETE_SUCCESS with target: phone', () => {
 			const action = deleteAccountRecoveryPhoneSuccess();
 
-			assert.deepEqual( action, {
+			expect( action ).toEqual( {
 				type: ACCOUNT_RECOVERY_SETTINGS_DELETE_SUCCESS,
 				target: 'phone',
 			} );
@@ -232,7 +232,7 @@ describe( 'account-recovery actions', () => {
 		test( 'should return ACCOUNT_RECOVERY_SETTINGS_DELETE_FAILED with target: phone', () => {
 			const action = deleteAccountRecoveryPhoneFailed( errorResponse );
 
-			assert.deepEqual( action, {
+			expect( action ).toEqual( {
 				type: ACCOUNT_RECOVERY_SETTINGS_DELETE_FAILED,
 				target: 'phone',
 				error: errorResponse,
@@ -250,23 +250,23 @@ describe( 'account-recovery actions', () => {
 		},
 		thunk: () => updateAccountRecoveryEmail( dummyNewEmail )( spy ),
 		preCondition: () =>
-			assert(
+			expect(
 				spy.calledWith( {
 					type: ACCOUNT_RECOVERY_SETTINGS_UPDATE,
 					target: 'email',
 				} )
-			),
+			).toBeTruthy(),
 		postConditionSuccess: () => {
-			assert(
+			expect(
 				spy.calledWith( {
 					type: ACCOUNT_RECOVERY_SETTINGS_UPDATE_SUCCESS,
 					target: 'email',
 					value: dummyNewEmail,
 				} )
-			);
+			).toBeTruthy();
 		},
 		postConditionFailed: () => {
-			assert(
+			expect(
 				spy.calledWith(
 					sinon.match( {
 						type: ACCOUNT_RECOVERY_SETTINGS_UPDATE_FAILED,
@@ -274,7 +274,7 @@ describe( 'account-recovery actions', () => {
 						error: errorResponse,
 					} )
 				)
-			);
+			).toBeTruthy();
 		},
 	} );
 
@@ -282,7 +282,7 @@ describe( 'account-recovery actions', () => {
 		test( 'should return ACCOUNT_RECOVERY_SETTINGS_UPDATE_SUCCESS with target: email', () => {
 			const action = updateAccountRecoveryEmailSuccess( dummyData.email );
 
-			assert.deepEqual( action, {
+			expect( action ).toEqual( {
 				type: ACCOUNT_RECOVERY_SETTINGS_UPDATE_SUCCESS,
 				target: 'email',
 				value: dummyData.email,
@@ -294,7 +294,7 @@ describe( 'account-recovery actions', () => {
 		test( 'should return ACCOUNT_RECOVERY_SETTINGS_FAILED with target: email', () => {
 			const action = updateAccountRecoveryEmailFailed( errorResponse );
 
-			assert.deepEqual( action, {
+			expect( action ).toEqual( {
 				type: ACCOUNT_RECOVERY_SETTINGS_UPDATE_FAILED,
 				target: 'email',
 				error: errorResponse,
@@ -312,21 +312,21 @@ describe( 'account-recovery actions', () => {
 		},
 		thunk: () => deleteAccountRecoveryEmail()( spy ),
 		preCondition: () =>
-			assert(
+			expect(
 				spy.calledWith( {
 					type: ACCOUNT_RECOVERY_SETTINGS_DELETE,
 					target: 'email',
 				} )
-			),
+			).toBeTruthy(),
 		postConditionSuccess: () =>
-			assert(
+			expect(
 				spy.calledWith( {
 					type: ACCOUNT_RECOVERY_SETTINGS_DELETE_SUCCESS,
 					target: 'email',
 				} )
-			),
+			).toBeTruthy(),
 		postConditionFailed: () =>
-			assert(
+			expect(
 				spy.calledWith(
 					sinon.match( {
 						type: ACCOUNT_RECOVERY_SETTINGS_DELETE_FAILED,
@@ -334,14 +334,14 @@ describe( 'account-recovery actions', () => {
 						error: errorResponse,
 					} )
 				)
-			),
+			).toBeTruthy(),
 	} );
 
 	describe( '#deleteAccountRecoveryEmailSuccess', () => {
 		test( 'should return ACCOUNT_RECOVERY_SETTINGS_DELETE_SUCCESS with target: email', () => {
 			const action = deleteAccountRecoveryEmailSuccess();
 
-			assert.deepEqual( action, {
+			expect( action ).toEqual( {
 				type: ACCOUNT_RECOVERY_SETTINGS_DELETE_SUCCESS,
 				target: 'email',
 			} );
@@ -352,7 +352,7 @@ describe( 'account-recovery actions', () => {
 		test( 'should return ACCOUNT_RECOVERY_SETTINGS_DELETE_FAILED with target: email', () => {
 			const action = deleteAccountRecoveryEmailFailed( errorResponse );
 
-			assert.deepEqual( action, {
+			expect( action ).toEqual( {
 				type: ACCOUNT_RECOVERY_SETTINGS_DELETE_FAILED,
 				target: 'email',
 				error: errorResponse,
@@ -363,7 +363,7 @@ describe( 'account-recovery actions', () => {
 	describe( '#resendAccountRecoveryEmailValidationSuccess', () => {
 		test( 'should return ACCOUNT_RECOVERY_SETTINGS_RESEND_VALIDATION_SUCCESS with target: email', () => {
 			const action = resendAccountRecoveryEmailValidationSuccess();
-			assert.deepEqual( action, {
+			expect( action ).toEqual( {
 				type: ACCOUNT_RECOVERY_SETTINGS_RESEND_VALIDATION_SUCCESS,
 				target: 'email',
 			} );
@@ -373,7 +373,7 @@ describe( 'account-recovery actions', () => {
 	describe( '#resendAccountRecoveryEmailValidationFailed', () => {
 		test( 'should return ACCOUNT_RECOVERY_SETTINGS_RESEND_VALIDATION_FAILED with target: email', () => {
 			const action = resendAccountRecoveryEmailValidationFailed( errorResponse );
-			assert.deepEqual( action, {
+			expect( action ).toEqual( {
 				type: ACCOUNT_RECOVERY_SETTINGS_RESEND_VALIDATION_FAILED,
 				target: 'email',
 				error: errorResponse,
@@ -391,21 +391,21 @@ describe( 'account-recovery actions', () => {
 		},
 		thunk: () => resendAccountRecoveryEmailValidation()( spy ),
 		preCondition: () =>
-			assert(
+			expect(
 				spy.calledWith( {
 					type: ACCOUNT_RECOVERY_SETTINGS_RESEND_VALIDATION,
 					target: 'email',
 				} )
-			),
+			).toBeTruthy(),
 		postConditionSuccess: () =>
-			assert(
+			expect(
 				spy.calledWith( {
 					type: ACCOUNT_RECOVERY_SETTINGS_RESEND_VALIDATION_SUCCESS,
 					target: 'email',
 				} )
-			),
+			).toBeTruthy(),
 		postConditionFailed: () =>
-			assert(
+			expect(
 				spy.calledWith(
 					sinon.match( {
 						type: ACCOUNT_RECOVERY_SETTINGS_RESEND_VALIDATION_FAILED,
@@ -413,13 +413,13 @@ describe( 'account-recovery actions', () => {
 						error: errorResponse,
 					} )
 				)
-			),
+			).toBeTruthy(),
 	} );
 
 	describe( '#resendAccountRecoveryPhoneValidationSuccess', () => {
 		test( 'should return ACCOUNT_RECOVERY_SETTINGS_RESEND_VALIDATION_SUCCESS with target: phone', () => {
 			const action = resendAccountRecoveryPhoneValidationSuccess();
-			assert.deepEqual( action, {
+			expect( action ).toEqual( {
 				type: ACCOUNT_RECOVERY_SETTINGS_RESEND_VALIDATION_SUCCESS,
 				target: 'phone',
 			} );
@@ -429,7 +429,7 @@ describe( 'account-recovery actions', () => {
 	describe( '#resendAccountRecoveryPhoneValidationFailed', () => {
 		test( 'should return ACCOUNT_RECOVERY_SETTINGS_RESEND_VALIDATION_FAILED with target: phone', () => {
 			const action = resendAccountRecoveryPhoneValidationFailed( errorResponse );
-			assert.deepEqual( action, {
+			expect( action ).toEqual( {
 				type: ACCOUNT_RECOVERY_SETTINGS_RESEND_VALIDATION_FAILED,
 				target: 'phone',
 				error: errorResponse,
@@ -447,21 +447,21 @@ describe( 'account-recovery actions', () => {
 		},
 		thunk: () => resendAccountRecoveryPhoneValidation()( spy ),
 		preCondition: () =>
-			assert(
+			expect(
 				spy.calledWith( {
 					type: ACCOUNT_RECOVERY_SETTINGS_RESEND_VALIDATION,
 					target: 'phone',
 				} )
-			),
+			).toBeTruthy(),
 		postConditionSuccess: () =>
-			assert(
+			expect(
 				spy.calledWith( {
 					type: ACCOUNT_RECOVERY_SETTINGS_RESEND_VALIDATION_SUCCESS,
 					target: 'phone',
 				} )
-			),
+			).toBeTruthy(),
 		postConditionFailed: () =>
-			assert(
+			expect(
 				spy.calledWith(
 					sinon.match( {
 						type: ACCOUNT_RECOVERY_SETTINGS_RESEND_VALIDATION_FAILED,
@@ -469,13 +469,13 @@ describe( 'account-recovery actions', () => {
 						error: errorResponse,
 					} )
 				)
-			),
+			).toBeTruthy(),
 	} );
 
 	describe( '#validateAccountRecoveryPhoneSuccess', () => {
 		test( 'should return ACCOUNT_RECOVERY_SETTINGS_VALIDATE_PHONE_SUCCESS', () => {
 			const action = validateAccountRecoveryPhoneSuccess();
-			assert.deepEqual( action, {
+			expect( action ).toEqual( {
 				type: ACCOUNT_RECOVERY_SETTINGS_VALIDATE_PHONE_SUCCESS,
 			} );
 		} );
@@ -484,7 +484,7 @@ describe( 'account-recovery actions', () => {
 	describe( '#validateAccountRecoveryPhoneFailed', () => {
 		test( 'should return ACCOUNT_RECOVERY_SETTINGS_VALIDATE_PHONE_FAILED', () => {
 			const action = validateAccountRecoveryPhoneFailed( errorResponse );
-			assert.deepEqual( action, {
+			expect( action ).toEqual( {
 				type: ACCOUNT_RECOVERY_SETTINGS_VALIDATE_PHONE_FAILED,
 				error: errorResponse,
 			} );
@@ -501,25 +501,25 @@ describe( 'account-recovery actions', () => {
 		},
 		thunk: () => validateAccountRecoveryPhone()( spy ),
 		preCondition: () =>
-			assert(
+			expect(
 				spy.calledWith( {
 					type: ACCOUNT_RECOVERY_SETTINGS_VALIDATE_PHONE,
 				} )
-			),
+			).toBeTruthy(),
 		postConditionSuccess: () =>
-			assert(
+			expect(
 				spy.calledWith( {
 					type: ACCOUNT_RECOVERY_SETTINGS_VALIDATE_PHONE_SUCCESS,
 				} )
-			),
+			).toBeTruthy(),
 		postConditionFailed: () =>
-			assert(
+			expect(
 				spy.calledWith(
 					sinon.match( {
 						type: ACCOUNT_RECOVERY_SETTINGS_VALIDATE_PHONE_FAILED,
 						error: errorResponse,
 					} )
 				)
-			),
+			).toBeTruthy(),
 	} );
 } );

--- a/client/state/account-recovery/settings/test/reducer.js
+++ b/client/state/account-recovery/settings/test/reducer.js
@@ -3,11 +3,6 @@
 /**
  * External dependencies
  */
-import { assert } from 'chai';
-
-/**
- * Internal dependencies
- */
 import reducer from '../reducer';
 import { dummyData, dummyNewPhone, dummyNewEmail } from './test-data';
 import {
@@ -44,7 +39,7 @@ describe( '#account-recovery reducer fetch:', () => {
 			settings: dummyData,
 		} );
 
-		assert.deepEqual( initState.data, expectedState );
+		expect( initState.data ).toEqual( expectedState );
 	} );
 } );
 
@@ -72,7 +67,7 @@ describe( '#account-recovery/settings reducer:', () => {
 			value: newPhoneValue,
 		} );
 
-		assert.deepEqual( state.data, {
+		expect( state.data ).toEqual( {
 			...initState.data,
 			phone: newPhoneValue,
 		} );
@@ -84,7 +79,7 @@ describe( '#account-recovery/settings reducer:', () => {
 			target: 'phone',
 		} );
 
-		assert.isNull( state.data.phone );
+		expect( state.data.phone ).toBeNull();
 	} );
 
 	test( 'ACCOUNT_RECOVERY_SETTINGS_UPDATE_SUCCESS action with email target should update the email field', () => {
@@ -94,7 +89,7 @@ describe( '#account-recovery/settings reducer:', () => {
 			value: dummyNewEmail,
 		} );
 
-		assert.equal( state.data.email, dummyNewEmail );
+		expect( state.data.email ).toEqual( dummyNewEmail );
 	} );
 
 	test( 'ACCOUNT_RECOVERY_SETTINGS_DELETE_SUCCESS action with email target should wipe the email field', () => {
@@ -103,7 +98,7 @@ describe( '#account-recovery/settings reducer:', () => {
 			target: 'email',
 		} );
 
-		assert.equal( state.data.email, '' );
+		expect( state.data.email ).toEqual( '' );
 	} );
 
 	const arbitraryTargetName = 'whatever';
@@ -114,7 +109,7 @@ describe( '#account-recovery/settings reducer:', () => {
 			target: arbitraryTargetName,
 		} );
 
-		assert.isTrue( state.isUpdating[ arbitraryTargetName ] );
+		expect( state.isUpdating[ arbitraryTargetName ] ).toBe( true );
 	} );
 
 	test( 'ACCOUNT_RECOVERY_SETTINGS_UPDATE_SUCCESS action should unset the isUpdating sub field', () => {
@@ -123,7 +118,7 @@ describe( '#account-recovery/settings reducer:', () => {
 			target: arbitraryTargetName,
 		} );
 
-		assert.isFalse( state.isUpdating[ arbitraryTargetName ] );
+		expect( state.isUpdating[ arbitraryTargetName ] ).toBe( false );
 	} );
 
 	test( 'ACCOUNT_RECOVERY_SETTINGS_UPDATE_SUCCESS action should set the hasSentValidation sub field', () => {
@@ -132,7 +127,7 @@ describe( '#account-recovery/settings reducer:', () => {
 			target: arbitraryTargetName,
 		} );
 
-		assert.isTrue( state.hasSentValidation[ arbitraryTargetName ] );
+		expect( state.hasSentValidation[ arbitraryTargetName ] ).toBe( true );
 	} );
 
 	test( 'ACCOUNT_RECOVERY_SETTINGS_UPDATE_FAILED action should unset the isUpdating sub field', () => {
@@ -141,7 +136,7 @@ describe( '#account-recovery/settings reducer:', () => {
 			target: arbitraryTargetName,
 		} );
 
-		assert.isFalse( state.isUpdating[ arbitraryTargetName ] );
+		expect( state.isUpdating[ arbitraryTargetName ] ).toBe( false );
 	} );
 
 	test( 'ACCOUNT_RECOVERY_SETTINS_DELETE action should set the isDeleting sub field', () => {
@@ -150,7 +145,7 @@ describe( '#account-recovery/settings reducer:', () => {
 			target: arbitraryTargetName,
 		} );
 
-		assert.isTrue( state.isDeleting[ arbitraryTargetName ] );
+		expect( state.isDeleting[ arbitraryTargetName ] ).toBe( true );
 	} );
 
 	test( 'ACCOUNT_RECOVERY_SETTINGS_DELETE_SUCCESS action should unset the isDeleting sub field', () => {
@@ -159,7 +154,7 @@ describe( '#account-recovery/settings reducer:', () => {
 			target: arbitraryTargetName,
 		} );
 
-		assert.isFalse( state.isDeleting[ arbitraryTargetName ] );
+		expect( state.isDeleting[ arbitraryTargetName ] ).toBe( false );
 	} );
 
 	test( 'ACCOUNT_RECOVERY_SETTINGS_DELETE_FAILED action should unset the isDeleting sub field', () => {
@@ -168,7 +163,7 @@ describe( '#account-recovery/settings reducer:', () => {
 			target: arbitraryTargetName,
 		} );
 
-		assert.isFalse( state.isDeleting[ arbitraryTargetName ] );
+		expect( state.isDeleting[ arbitraryTargetName ] ).toBe( false );
 	} );
 
 	test( 'ACCOUNT_RECOVERY_SETTINGS_RESEND_VALIDATION action should set hasSentValidation sub field', () => {
@@ -177,7 +172,7 @@ describe( '#account-recovery/settings reducer:', () => {
 			target: arbitraryTargetName,
 		} );
 
-		assert.isTrue( state.hasSentValidation[ arbitraryTargetName ] );
+		expect( state.hasSentValidation[ arbitraryTargetName ] ).toBe( true );
 	} );
 
 	test( 'ACCOUNT_RECOVERY_SETTINGS_VALIDATE_PHONE_SUCCESS action should set phoneValidated as true', () => {
@@ -185,7 +180,7 @@ describe( '#account-recovery/settings reducer:', () => {
 			type: ACCOUNT_RECOVERY_SETTINGS_VALIDATE_PHONE_SUCCESS,
 		} );
 
-		assert.isTrue( state.data.phoneValidated );
+		expect( state.data.phoneValidated ).toBe( true );
 	} );
 
 	test( 'ACCOUNT_RECOVERY_SETTINGS_VALIDATE_PHONE action should set isValidatingPhone as true', () => {
@@ -193,7 +188,7 @@ describe( '#account-recovery/settings reducer:', () => {
 			type: ACCOUNT_RECOVERY_SETTINGS_VALIDATE_PHONE,
 		} );
 
-		assert.isTrue( state.isValidatingPhone );
+		expect( state.isValidatingPhone ).toBe( true );
 	} );
 
 	test( 'ACCOUNT_RECOVERY_SETTINGS_VALIDATE_PHONE_SUCCESS action should set isValidatingPhone as false', () => {
@@ -201,7 +196,7 @@ describe( '#account-recovery/settings reducer:', () => {
 			type: ACCOUNT_RECOVERY_SETTINGS_VALIDATE_PHONE_SUCCESS,
 		} );
 
-		assert.isFalse( state.isValidatingPhone );
+		expect( state.isValidatingPhone ).toBe( false );
 	} );
 
 	test( 'ACCOUNT_RECOVERY_SETTINGS_VALIDATE_PHONE action should set isValidatingPhone as false', () => {
@@ -209,6 +204,6 @@ describe( '#account-recovery/settings reducer:', () => {
 			type: ACCOUNT_RECOVERY_SETTINGS_VALIDATE_PHONE_FAILED,
 		} );
 
-		assert.isFalse( state.isValidatingPhone );
+		expect( state.isValidatingPhone ).toBe( false );
 	} );
 } );

--- a/client/state/account-recovery/settings/test/selectors.js
+++ b/client/state/account-recovery/settings/test/selectors.js
@@ -3,11 +3,6 @@
 /**
  * External dependencies
  */
-import { assert } from 'chai';
-
-/**
- * Internal dependencies
- */
 import {
 	isAccountRecoverySettingsReady,
 	isAccountRecoveryEmailValidated,
@@ -64,51 +59,51 @@ describe( '#account-recovery/settings/selectors', () => {
 
 	describe( '#isAccountRecoverySettingsReady', () => {
 		test( 'should return false on absence', () => {
-			assert.isFalse( isAccountRecoverySettingsReady( stateBeforeFetching ) );
+			expect( isAccountRecoverySettingsReady( stateBeforeFetching ) ).toBe( false );
 		} );
 
 		test( 'should return true if exists', () => {
-			assert.isTrue( isAccountRecoverySettingsReady( stateAfterFetching ) );
+			expect( isAccountRecoverySettingsReady( stateAfterFetching ) ).toBe( true );
 		} );
 	} );
 
 	describe( '#isAccountRecoveryEmailValidated:', () => {
 		test( 'should return false on absence', () => {
-			assert.isFalse( isAccountRecoveryEmailValidated( stateBeforeFetching ) );
+			expect( isAccountRecoveryEmailValidated( stateBeforeFetching ) ).toBe( false );
 		} );
 
 		test( 'should return the emailValidated field', () => {
-			assert.isTrue( isAccountRecoveryEmailValidated( stateAfterFetching ) );
+			expect( isAccountRecoveryEmailValidated( stateAfterFetching ) ).toBe( true );
 		} );
 	} );
 
 	describe( '#isAccountRecoveryPhoneValidated:', () => {
 		test( 'should return false on absence', () => {
-			assert.isFalse( isAccountRecoveryPhoneValidated( stateBeforeFetching ) );
+			expect( isAccountRecoveryPhoneValidated( stateBeforeFetching ) ).toBe( false );
 		} );
 
 		test( 'should return the phoneValidated field', () => {
-			assert.isTrue( isAccountRecoveryPhoneValidated( stateAfterFetching ) );
+			expect( isAccountRecoveryPhoneValidated( stateAfterFetching ) ).toBe( true );
 		} );
 	} );
 
 	describe( '#getAccountRecoveryEmail:', () => {
 		test( 'should return a default value on absence', () => {
-			assert.equal( getAccountRecoveryEmail( stateBeforeFetching ), '' );
+			expect( getAccountRecoveryEmail( stateBeforeFetching ) ).toEqual( '' );
 		} );
 
 		test( 'should return the email field', () => {
-			assert.equal( getAccountRecoveryEmail( stateAfterFetching ), dummyNewEmail );
+			expect( getAccountRecoveryEmail( stateAfterFetching ) ).toEqual( dummyNewEmail );
 		} );
 	} );
 
 	describe( '#getAccountRecoveryPhone', () => {
 		test( 'should return a default value on absence', () => {
-			assert.isNull( getAccountRecoveryPhone( stateBeforeFetching ) );
+			expect( getAccountRecoveryPhone( stateBeforeFetching ) ).toBeNull();
 		} );
 
 		test( 'should return the phone field', () => {
-			assert.deepEqual( getAccountRecoveryPhone( stateAfterFetching ), {
+			expect( getAccountRecoveryPhone( stateAfterFetching ) ).toEqual( {
 				countryCode: dummyNewPhone.country_code,
 				countryNumericCode: dummyNewPhone.country_numeric_code,
 				number: dummyNewPhone.number,
@@ -138,21 +133,21 @@ describe( '#account-recovery/settings/selectors', () => {
 
 	describe( '#isUpdatingAccountRecoveryPhone', () => {
 		test( 'should return false on absence', () => {
-			assert.isFalse( isUpdatingAccountRecoveryPhone( stateBeforeUpdating ) );
+			expect( isUpdatingAccountRecoveryPhone( stateBeforeUpdating ) ).toBe( false );
 		} );
 
 		test( 'should return isUpdating.phone', () => {
-			assert.isTrue( isUpdatingAccountRecoveryPhone( stateDuringUpdating ) );
+			expect( isUpdatingAccountRecoveryPhone( stateDuringUpdating ) ).toBe( true );
 		} );
 	} );
 
 	describe( '#isUpdatingAccountRecoveryEmail', () => {
 		test( 'should return false on absence', () => {
-			assert.isFalse( isUpdatingAccountRecoveryEmail( stateBeforeUpdating ) );
+			expect( isUpdatingAccountRecoveryEmail( stateBeforeUpdating ) ).toBe( false );
 		} );
 
 		test( 'should return isUpdating.email', () => {
-			assert.isTrue( isUpdatingAccountRecoveryEmail( stateDuringUpdating ) );
+			expect( isUpdatingAccountRecoveryEmail( stateDuringUpdating ) ).toBe( true );
 		} );
 	} );
 
@@ -177,49 +172,49 @@ describe( '#account-recovery/settings/selectors', () => {
 
 	describe( '#isDeletingAccountRecoveryPhone', () => {
 		test( 'should return false on absence', () => {
-			assert.isFalse( isDeletingAccountRecoveryPhone( stateBeforeDeleting ) );
+			expect( isDeletingAccountRecoveryPhone( stateBeforeDeleting ) ).toBe( false );
 		} );
 
 		test( 'should return isDeleting.phone', () => {
-			assert.isTrue( isDeletingAccountRecoveryPhone( stateDuringDeleting ) );
+			expect( isDeletingAccountRecoveryPhone( stateDuringDeleting ) ).toBe( true );
 		} );
 	} );
 
 	describe( '#isDeletingAccountRecoveryEmail', () => {
 		test( 'should return false on absence', () => {
-			assert.isFalse( isDeletingAccountRecoveryEmail( stateBeforeDeleting ) );
+			expect( isDeletingAccountRecoveryEmail( stateBeforeDeleting ) ).toBe( false );
 		} );
 
 		test( 'should return isDeleting.email', () => {
-			assert.isTrue( isDeletingAccountRecoveryEmail( stateDuringDeleting ) );
+			expect( isDeletingAccountRecoveryEmail( stateDuringDeleting ) ).toBe( true );
 		} );
 	} );
 
 	describe( '#isAccountRecoveryEmailActionInProgress', () => {
 		test( 'should return true if the whole data is not in place yet', () => {
-			assert.isTrue( isAccountRecoveryEmailActionInProgress( stateBeforeFetching ) );
+			expect( isAccountRecoveryEmailActionInProgress( stateBeforeFetching ) ).toBe( true );
 		} );
 
 		test( 'should return true if isUpdating.email is set', () => {
-			assert.isTrue( isAccountRecoveryEmailActionInProgress( stateDuringUpdating ) );
+			expect( isAccountRecoveryEmailActionInProgress( stateDuringUpdating ) ).toBe( true );
 		} );
 
 		test( 'should return true if isDeleting.email is set', () => {
-			assert.isTrue( isAccountRecoveryEmailActionInProgress( stateDuringDeleting ) );
+			expect( isAccountRecoveryEmailActionInProgress( stateDuringDeleting ) ).toBe( true );
 		} );
 	} );
 
 	describe( '#isAccountRecoveryPhoneActionInProgress', () => {
 		test( 'should return true if the whole data is not in place yet', () => {
-			assert.isTrue( isAccountRecoveryPhoneActionInProgress( stateBeforeFetching ) );
+			expect( isAccountRecoveryPhoneActionInProgress( stateBeforeFetching ) ).toBe( true );
 		} );
 
 		test( 'should return true if isUpdating.email is set', () => {
-			assert.isTrue( isAccountRecoveryPhoneActionInProgress( stateDuringUpdating ) );
+			expect( isAccountRecoveryPhoneActionInProgress( stateDuringUpdating ) ).toBe( true );
 		} );
 
 		test( 'should return true if isDeleting.email is set', () => {
-			assert.isTrue( isAccountRecoveryPhoneActionInProgress( stateDuringDeleting ) );
+			expect( isAccountRecoveryPhoneActionInProgress( stateDuringDeleting ) ).toBe( true );
 		} );
 	} );
 
@@ -233,7 +228,7 @@ describe( '#account-recovery/settings/selectors', () => {
 				},
 			};
 
-			assert.isFalse( hasSentAccountRecoveryEmailValidation( state ) );
+			expect( hasSentAccountRecoveryEmailValidation( state ) ).toBe( false );
 		} );
 
 		test( 'should return hasSentValidation.email', () => {
@@ -247,7 +242,7 @@ describe( '#account-recovery/settings/selectors', () => {
 				},
 			};
 
-			assert.isTrue( hasSentAccountRecoveryEmailValidation( state ) );
+			expect( hasSentAccountRecoveryEmailValidation( state ) ).toBe( true );
 		} );
 	} );
 
@@ -261,7 +256,7 @@ describe( '#account-recovery/settings/selectors', () => {
 				},
 			};
 
-			assert.isFalse( hasSentAccountRecoveryPhoneValidation( state ) );
+			expect( hasSentAccountRecoveryPhoneValidation( state ) ).toBe( false );
 		} );
 
 		test( 'should return hasSentValidation.phone', () => {
@@ -275,7 +270,7 @@ describe( '#account-recovery/settings/selectors', () => {
 				},
 			};
 
-			assert.isTrue( hasSentAccountRecoveryPhoneValidation( state ) );
+			expect( hasSentAccountRecoveryPhoneValidation( state ) ).toBe( true );
 		} );
 	} );
 
@@ -289,7 +284,7 @@ describe( '#account-recovery/settings/selectors', () => {
 				},
 			};
 
-			assert.isTrue( isValidatingAccountRecoveryPhone( state ) );
+			expect( isValidatingAccountRecoveryPhone( state ) ).toBe( true );
 		} );
 	} );
 
@@ -310,19 +305,25 @@ describe( '#account-recovery/settings/selectors', () => {
 				},
 			};
 
-			assert.isTrue( shouldPromptAccountRecoveryEmailValidationNotice( state ) );
+			expect( shouldPromptAccountRecoveryEmailValidationNotice( state ) ).toBe( true );
 		} );
 
 		test( 'should not prompt if the settings data is not ready.', () => {
-			assert.isFalse( shouldPromptAccountRecoveryEmailValidationNotice( stateBeforeFetching ) );
+			expect( shouldPromptAccountRecoveryEmailValidationNotice( stateBeforeFetching ) ).toBe(
+				false
+			);
 		} );
 
 		test( 'should not prompt if isUpdating.email is set.', () => {
-			assert.isFalse( shouldPromptAccountRecoveryEmailValidationNotice( stateDuringUpdating ) );
+			expect( shouldPromptAccountRecoveryEmailValidationNotice( stateDuringUpdating ) ).toBe(
+				false
+			);
 		} );
 
 		test( 'should not prompt if isDeleting.email is set.', () => {
-			assert.isFalse( shouldPromptAccountRecoveryEmailValidationNotice( stateDuringDeleting ) );
+			expect( shouldPromptAccountRecoveryEmailValidationNotice( stateDuringDeleting ) ).toBe(
+				false
+			);
 		} );
 	} );
 
@@ -348,19 +349,25 @@ describe( '#account-recovery/settings/selectors', () => {
 				},
 			};
 
-			assert.isTrue( shouldPromptAccountRecoveryPhoneValidationNotice( state ) );
+			expect( shouldPromptAccountRecoveryPhoneValidationNotice( state ) ).toBe( true );
 		} );
 
 		test( 'should not prompt if the settings data is not ready.', () => {
-			assert.isFalse( shouldPromptAccountRecoveryPhoneValidationNotice( stateBeforeFetching ) );
+			expect( shouldPromptAccountRecoveryPhoneValidationNotice( stateBeforeFetching ) ).toBe(
+				false
+			);
 		} );
 
 		test( 'should not prompt if isUpdating.phone is set.', () => {
-			assert.isFalse( shouldPromptAccountRecoveryPhoneValidationNotice( stateDuringUpdating ) );
+			expect( shouldPromptAccountRecoveryPhoneValidationNotice( stateDuringUpdating ) ).toBe(
+				false
+			);
 		} );
 
 		test( 'should not prompt if isDeleting.phone is set.', () => {
-			assert.isFalse( shouldPromptAccountRecoveryPhoneValidationNotice( stateDuringDeleting ) );
+			expect( shouldPromptAccountRecoveryPhoneValidationNotice( stateDuringDeleting ) ).toBe(
+				false
+			);
 		} );
 	} );
 } );

--- a/client/state/account-recovery/test/reducer.js
+++ b/client/state/account-recovery/test/reducer.js
@@ -3,11 +3,6 @@
 /**
  * External dependencies
  */
-import { assert } from 'chai';
-
-/**
- * Internal dependencies
- */
 import reducer from '../reducer';
 import {
 	ACCOUNT_RECOVERY_SETTINGS_FETCH,
@@ -21,7 +16,7 @@ describe( '#account-recovery/isFetchingSettings reducer :', () => {
 			type: ACCOUNT_RECOVERY_SETTINGS_FETCH,
 		} );
 
-		assert.isTrue( state.isFetchingSettings );
+		expect( state.isFetchingSettings ).toBe( true );
 	} );
 
 	test( 'should unset isFetchingSettings flag on success.', () => {
@@ -35,7 +30,7 @@ describe( '#account-recovery/isFetchingSettings reducer :', () => {
 			},
 		} );
 
-		assert.isFalse( state.isFetchingSettings );
+		expect( state.isFetchingSettings ).toBe( false );
 	} );
 
 	test( 'should unset isFetchingSettings flag on failure.', () => {
@@ -43,6 +38,6 @@ describe( '#account-recovery/isFetchingSettings reducer :', () => {
 			type: ACCOUNT_RECOVERY_SETTINGS_FETCH_FAILED,
 		} );
 
-		assert.isFalse( state.isFetchingSettings );
+		expect( state.isFetchingSettings ).toBe( false );
 	} );
 } );

--- a/client/state/account-recovery/test/selectors.js
+++ b/client/state/account-recovery/test/selectors.js
@@ -3,11 +3,6 @@
 /**
  * External dependencies
  */
-import { assert } from 'chai';
-
-/**
- * Internal dependencies
- */
 import { isFetchingAccountRecoverySettings } from '../selectors';
 
 describe( '#account-recovery selector isFetchingAccountRecoverySettings:', () => {
@@ -18,6 +13,6 @@ describe( '#account-recovery selector isFetchingAccountRecoverySettings:', () =>
 			},
 		};
 
-		assert.isTrue( isFetchingAccountRecoverySettings( state ) );
+		expect( isFetchingAccountRecoverySettings( state ) ).toBe( true );
 	} );
 } );

--- a/client/state/data-layer/wpcom/account-recovery/lookup/test/index.js
+++ b/client/state/data-layer/wpcom/account-recovery/lookup/test/index.js
@@ -3,7 +3,6 @@
 /**
  * External dependencies
  */
-import { assert } from 'chai';
 import sinon from 'sinon';
 
 /**
@@ -25,30 +24,26 @@ const validResponse = {
 
 describe( 'validate()', () => {
 	test( 'should validate successfully and throw nothing.', () => {
-		assert.doesNotThrow( () => validate( validResponse ) );
+		expect( () => validate( validResponse ) ).not.toThrow();
 	} );
 
 	test( 'should invalidate missing keys and throw an error.', () => {
-		assert.throws(
-			() =>
-				validate( {
-					primary_email: 'foo@example.com',
-				} ),
-			Error
-		);
+		expect( () =>
+			validate( {
+				primary_email: 'foo@example.com',
+			} )
+		).toThrow();
 	} );
 
 	test( 'should invalidate unexpected value type and throw an error', () => {
-		assert.throws(
-			() =>
-				validate( {
-					primary_email: 'foo@example.com',
-					primary_sms: '123456',
-					secondary_email: 'bar@example.com',
-					secondary_sms: 123456,
-				} ),
-			Error
-		);
+		expect( () =>
+			validate( {
+				primary_email: 'foo@example.com',
+				primary_sms: '123456',
+				secondary_email: 'bar@example.com',
+				secondary_sms: 123456,
+			} )
+		).toThrow();
 	} );
 } );
 
@@ -61,12 +56,12 @@ describe( 'handleRequestResetOptions()', () => {
 		test( 'should dispatch RECEIVE action on success', done => {
 			const dispatch = sinon.spy( action => {
 				if ( action.type === ACCOUNT_RECOVERY_RESET_OPTIONS_RECEIVE ) {
-					assert.isTrue(
+					expect(
 						dispatch.calledWith( {
 							type: ACCOUNT_RECOVERY_RESET_OPTIONS_RECEIVE,
 							items: fromApi( validResponse ),
 						} )
-					);
+					).toBe( true );
 
 					done();
 				}
@@ -78,12 +73,12 @@ describe( 'handleRequestResetOptions()', () => {
 		test( 'should dispatch UPDATE_USER_DATA action on success', done => {
 			const dispatch = sinon.spy( action => {
 				if ( action.type === ACCOUNT_RECOVERY_RESET_UPDATE_USER_DATA ) {
-					assert.isTrue(
+					expect(
 						dispatch.calledWith( {
 							type: ACCOUNT_RECOVERY_RESET_UPDATE_USER_DATA,
 							userData,
 						} )
-					);
+					).toBe( true );
 
 					done();
 				}
@@ -101,12 +96,12 @@ describe( 'handleRequestResetOptions()', () => {
 
 		test( 'should dispatch ERROR action on failure', done => {
 			const dispatch = sinon.spy( () => {
-				assert.isTrue(
+				expect(
 					dispatch.calledWithMatch( {
 						type: ACCOUNT_RECOVERY_RESET_OPTIONS_ERROR,
 						error: errorResponse,
 					} )
-				);
+				).toBe( true );
 
 				done();
 			} );
@@ -120,12 +115,12 @@ describe( 'handleRequestResetOptions()', () => {
 			};
 
 			const dispatch = sinon.spy( () => {
-				assert.isTrue(
+				expect(
 					dispatch.calledWithMatch( {
 						type: ACCOUNT_RECOVERY_RESET_OPTIONS_ERROR,
 						error: { message: 'Unexpected response format from /account-recovery/lookup' },
 					} )
-				);
+				).toBe( true );
 
 				done();
 			} );

--- a/client/state/help/ticket/test/actions.js
+++ b/client/state/help/ticket/test/actions.js
@@ -3,7 +3,6 @@
 /**
  * External dependencies
  */
-import { assert } from 'chai';
 import sinon from 'sinon';
 
 /**
@@ -33,7 +32,7 @@ describe( 'ticket-support/configuration actions', () => {
 		test( 'should return HELP_TICKET_CONFIGURATION_REQUEST_SUCCESS', () => {
 			const action = ticketSupportConfigurationRequestSuccess( dummyConfiguration );
 
-			assert.deepEqual( action, {
+			expect( action ).toEqual( {
 				type: HELP_TICKET_CONFIGURATION_REQUEST_SUCCESS,
 				configuration: dummyConfiguration,
 			} );
@@ -44,7 +43,7 @@ describe( 'ticket-support/configuration actions', () => {
 		test( 'should return HELP_TICKET_CONFIGURATION_REQUEST_FAILURE', () => {
 			const action = ticketSupportConfigurationRequestFailure( dummyError );
 
-			assert.deepEqual( action, {
+			expect( action ).toEqual( {
 				type: HELP_TICKET_CONFIGURATION_REQUEST_FAILURE,
 				error: dummyError,
 			} );
@@ -64,15 +63,15 @@ describe( 'ticket-support/configuration actions', () => {
 		test( 'should be successful.', () => {
 			const action = ticketSupportConfigurationRequest()( spy );
 
-			assert( spy.calledWith( { type: HELP_TICKET_CONFIGURATION_REQUEST } ) );
+			expect( spy.calledWith( { type: HELP_TICKET_CONFIGURATION_REQUEST } ) ).toBeTruthy();
 
 			action.then( () => {
-				assert(
+				expect(
 					spy.calledWith( {
 						type: HELP_TICKET_CONFIGURATION_REQUEST_SUCCESS,
 						configuration: dummyConfiguration,
 					} )
-				);
+				).toBeTruthy();
 			} );
 		} );
 	} );
@@ -87,17 +86,17 @@ describe( 'ticket-support/configuration actions', () => {
 		test( 'should be failed.', () => {
 			const action = ticketSupportConfigurationRequest()( spy );
 
-			assert( spy.calledWith( { type: HELP_TICKET_CONFIGURATION_REQUEST } ) );
+			expect( spy.calledWith( { type: HELP_TICKET_CONFIGURATION_REQUEST } ) ).toBeTruthy();
 
 			action.then( () => {
-				assert(
+				expect(
 					spy.calledWith(
 						sinon.match( {
 							type: HELP_TICKET_CONFIGURATION_REQUEST_FAILURE,
 							error: dummyError,
 						} )
 					)
-				);
+				).toBeTruthy();
 			} );
 		} );
 	} );
@@ -106,7 +105,7 @@ describe( 'ticket-support/configuration actions', () => {
 		test( 'should return HELP_TICKET_CONFIGURATION_DISMISS_ERROR', () => {
 			const action = ticketSupportConfigurationDismissError();
 
-			assert.deepEqual( action, {
+			expect( action ).toEqual( {
 				type: HELP_TICKET_CONFIGURATION_DISMISS_ERROR,
 			} );
 		} );

--- a/client/state/help/ticket/test/reducer.js
+++ b/client/state/help/ticket/test/reducer.js
@@ -3,11 +3,6 @@
 /**
  * External dependencies
  */
-import { assert } from 'chai';
-
-/**
- * Internal dependencies
- */
 import reducer from '../reducer';
 import { dummyConfiguration, dummyError } from './test-data';
 import {
@@ -21,7 +16,7 @@ describe( 'ticket-support/configuration reducer', () => {
 	test( 'should default to the expected structure', () => {
 		const defaultState = reducer( undefined, {} );
 
-		assert.deepEqual( defaultState, {
+		expect( defaultState ).toEqual( {
 			isReady: false,
 			isRequesting: false,
 			isUserEligible: false,
@@ -34,7 +29,7 @@ describe( 'ticket-support/configuration reducer', () => {
 			type: HELP_TICKET_CONFIGURATION_REQUEST,
 		} );
 
-		assert.isTrue( state.isRequesting );
+		expect( state.isRequesting ).toBe( true );
 	} );
 
 	test( 'should set isUserEligible as is and isReady to true', () => {
@@ -43,9 +38,9 @@ describe( 'ticket-support/configuration reducer', () => {
 			configuration: dummyConfiguration,
 		} );
 
-		assert.isTrue( state.isReady );
-		assert.equal( state.isUserEligible, dummyConfiguration.is_user_eligible );
-		assert.isFalse( state.isRequesting );
+		expect( state.isReady ).toBe( true );
+		expect( state.isUserEligible ).toEqual( dummyConfiguration.is_user_eligible );
+		expect( state.isRequesting ).toBe( false );
 	} );
 
 	test( 'should leave isReady as it is and requestError as the error on failed requests', () => {
@@ -57,9 +52,9 @@ describe( 'ticket-support/configuration reducer', () => {
 			}
 		);
 
-		assert.isFalse( state.isReady );
-		assert.isFalse( state.isRequesting );
-		assert.deepEqual( state.requestError, dummyError );
+		expect( state.isReady ).toBe( false );
+		expect( state.isRequesting ).toBe( false );
+		expect( state.requestError ).toEqual( dummyError );
 	} );
 
 	const requestErrorState = { requestError: dummyError };
@@ -69,7 +64,7 @@ describe( 'ticket-support/configuration reducer', () => {
 			type: HELP_TICKET_CONFIGURATION_DISMISS_ERROR,
 		} );
 
-		assert.isNull( state.requestError );
+		expect( state.requestError ).toBeNull();
 	} );
 
 	test( 'should set requestError as false on receiving the new request', () => {
@@ -77,7 +72,7 @@ describe( 'ticket-support/configuration reducer', () => {
 			type: HELP_TICKET_CONFIGURATION_REQUEST,
 		} );
 
-		assert.isNull( state.requestError );
+		expect( state.requestError ).toBeNull();
 	} );
 
 	test( 'should set requestError as false on receiving the successful action', () => {
@@ -86,6 +81,6 @@ describe( 'ticket-support/configuration reducer', () => {
 			configuration: dummyConfiguration,
 		} );
 
-		assert.isNull( state.requestError );
+		expect( state.requestError ).toBeNull();
 	} );
 } );

--- a/client/state/help/ticket/test/selectors.js
+++ b/client/state/help/ticket/test/selectors.js
@@ -3,11 +3,6 @@
 /**
  * External dependencies
  */
-import { assert } from 'chai';
-
-/**
- * Internal dependencies
- */
 import {
 	isTicketSupportEligible,
 	isTicketSupportConfigurationReady,
@@ -41,27 +36,27 @@ describe( 'ticket-support/configuration/selectors', () => {
 
 	describe( '#isTicketSupportEligible', () => {
 		test( 'should default to false', () => {
-			assert.isFalse( isTicketSupportEligible( uninitState ) );
+			expect( isTicketSupportEligible( uninitState ) ).toBe( false );
 		} );
 
 		test( 'should return true', () => {
-			assert.isTrue( isTicketSupportEligible( initedState ) );
+			expect( isTicketSupportEligible( initedState ) ).toBe( true );
 		} );
 	} );
 
 	describe( '#isTicketSupportConfigurationReady', () => {
 		test( 'should return false', () => {
-			assert.isFalse( isTicketSupportConfigurationReady( uninitState ) );
+			expect( isTicketSupportConfigurationReady( uninitState ) ).toBe( false );
 		} );
 
 		test( 'should return true', () => {
-			assert.isTrue( isTicketSupportConfigurationReady( initedState ) );
+			expect( isTicketSupportConfigurationReady( initedState ) ).toBe( true );
 		} );
 	} );
 
 	describe( '#isRequestingTicketSupportConfiguration', () => {
 		test( 'should return true', () => {
-			assert.isTrue(
+			expect(
 				isRequestingTicketSupportConfiguration( {
 					help: {
 						ticket: {
@@ -69,7 +64,7 @@ describe( 'ticket-support/configuration/selectors', () => {
 						},
 					},
 				} )
-			);
+			).toBe( true );
 		} );
 	} );
 
@@ -83,7 +78,7 @@ describe( 'ticket-support/configuration/selectors', () => {
 				},
 			};
 
-			assert.deepEqual( getTicketSupportRequestError( errorState ), dummyError );
+			expect( getTicketSupportRequestError( errorState ) ).toEqual( dummyError );
 		} );
 	} );
 } );

--- a/client/state/plugins/premium/test/selectors.js
+++ b/client/state/plugins/premium/test/selectors.js
@@ -3,7 +3,6 @@
 /**
  * External dependencies
  */
-import { assert } from 'chai';
 import deepFreeze from 'deep-freeze';
 
 /**
@@ -31,143 +30,145 @@ const state = deepFreeze( {
 
 describe( 'Premium Plugin Selectors', () => {
 	test( 'should contain isRequesting method', () => {
-		assert.equal( typeof selectors.isRequesting, 'function' );
+		expect( typeof selectors.isRequesting ).toEqual( 'function' );
 	} );
 
 	test( 'should contain isStarted method', () => {
-		assert.equal( typeof selectors.isStarted, 'function' );
+		expect( typeof selectors.isStarted ).toEqual( 'function' );
 	} );
 
 	test( 'should contain isFinished method', () => {
-		assert.equal( typeof selectors.isFinished, 'function' );
+		expect( typeof selectors.isFinished ).toEqual( 'function' );
 	} );
 
 	test( 'should contain getPluginsForSite method', () => {
-		assert.equal( typeof selectors.getPluginsForSite, 'function' );
+		expect( typeof selectors.getPluginsForSite ).toEqual( 'function' );
 	} );
 
 	test( 'should contain getActivePlugin method', () => {
-		assert.equal( typeof selectors.getActivePlugin, 'function' );
+		expect( typeof selectors.getActivePlugin ).toEqual( 'function' );
 	} );
 
 	test( 'should contain getNextPlugin method', () => {
-		assert.equal( typeof selectors.getNextPlugin, 'function' );
+		expect( typeof selectors.getNextPlugin ).toEqual( 'function' );
 	} );
 
 	describe( 'isRequesting', () => {
 		test( 'Should get `true` if the requested site is not in the current state', () => {
-			assert.equal( selectors.isRequesting( state, 'no.site' ), true );
+			expect( selectors.isRequesting( state, 'no.site' ) ).toEqual( true );
 		} );
 
 		test( 'Should get `false` if the requested site is not being fetched', () => {
-			assert.equal( selectors.isRequesting( state, 'finished.site' ), false );
+			expect( selectors.isRequesting( state, 'finished.site' ) ).toEqual( false );
 		} );
 
 		test( 'Should get `true` if the requested site is being fetched', () => {
-			assert.equal( selectors.isRequesting( state, 'wait.site' ), true );
+			expect( selectors.isRequesting( state, 'wait.site' ) ).toEqual( true );
 		} );
 	} );
 
 	describe( 'isStarted', () => {
 		test( 'Should get `false` if the requested site is not in the current state', () => {
-			assert.equal( selectors.isStarted( state, 'no.site' ), false );
+			expect( selectors.isStarted( state, 'no.site' ) ).toEqual( false );
 		} );
 
 		test( 'Should get `false` if there are no plugins installing on the requested site', () => {
-			assert.equal( selectors.isStarted( state, 'start.site' ), false );
+			expect( selectors.isStarted( state, 'start.site' ) ).toEqual( false );
 		} );
 
 		test( 'Should get `true` if there is a plugin installing on the requested site', () => {
-			assert.equal( selectors.isStarted( state, 'installing.site' ), true );
+			expect( selectors.isStarted( state, 'installing.site' ) ).toEqual( true );
 		} );
 
 		test( 'Should get `true` if all plugins on the requested site are either done or have errors', () => {
-			assert.equal( selectors.isStarted( state, 'finished.site' ), true );
+			expect( selectors.isStarted( state, 'finished.site' ) ).toEqual( true );
 		} );
 	} );
 
 	describe( 'isFinished', () => {
 		test( 'Should get `true` if the requested site is not in the current state', () => {
-			assert.equal( selectors.isFinished( state, 'no.site' ), true );
+			expect( selectors.isFinished( state, 'no.site' ) ).toEqual( true );
 		} );
 
 		test( 'Should get `false` if there is a plugin installing on the requested site', () => {
-			assert.equal( selectors.isFinished( state, 'installing.site' ), false );
+			expect( selectors.isFinished( state, 'installing.site' ) ).toEqual( false );
 		} );
 
 		test( 'Should get `true` if all plugins on the requested site are either done or have errors', () => {
-			assert.equal( selectors.isFinished( state, 'finished.site' ), true );
+			expect( selectors.isFinished( state, 'finished.site' ) ).toEqual( true );
 		} );
 	} );
 
 	describe( 'isInstalling', () => {
 		test( 'Should get `false` if the requested site is not in the current state', () => {
-			assert.equal( selectors.isInstalling( state, 'no.site' ), false );
+			expect( selectors.isInstalling( state, 'no.site' ) ).toEqual( false );
 		} );
 
 		test( 'Should get `true` if there is a plugin installing on the requested site', () => {
-			assert.equal( selectors.isInstalling( state, 'installing.site' ), true );
+			expect( selectors.isInstalling( state, 'installing.site' ) ).toEqual( true );
 		} );
 
 		test( 'Should get `true` if there is a plugin installing on the requested site, using whitelist', () => {
-			assert.equal( selectors.isInstalling( state, 'installing.site', 'akismet' ), true );
+			expect( selectors.isInstalling( state, 'installing.site', 'akismet' ) ).toEqual( true );
 		} );
 
 		test( 'Should get `true` if there is a plugin installing on the requested site, using whitelist', () => {
-			assert.equal( selectors.isInstalling( state, 'config.site', 'akismet' ), true );
+			expect( selectors.isInstalling( state, 'config.site', 'akismet' ) ).toEqual( true );
 		} );
 
 		test( 'Should get `false` if all plugins on the requested site are either done or have errors', () => {
-			assert.equal( selectors.isInstalling( state, 'finished.site' ), false );
+			expect( selectors.isInstalling( state, 'finished.site' ) ).toEqual( false );
 		} );
 	} );
 
 	describe( 'getPluginsForSite', () => {
 		test( 'Should get `false` if the requested site is not in the current state', () => {
-			assert.equal( selectors.getPluginsForSite( state, 'no.site' ), false );
+			expect( selectors.getPluginsForSite( state, 'no.site' ) ).toEqual( false );
 		} );
 
 		test( 'Should get the list of plugins if the site exists in the current state', () => {
-			assert.equal( selectors.getPluginsForSite( state, 'start.site' ).length, 3 );
-			assert.equal( selectors.getPluginsForSite( state, 'start.site' )[ 0 ].slug, 'vaultpress' );
-			assert.equal( selectors.getPluginsForSite( state, 'start.site' )[ 1 ].slug, 'akismet' );
-			assert.equal( selectors.getPluginsForSite( state, 'start.site' )[ 2 ].slug, 'polldaddy' );
+			expect( selectors.getPluginsForSite( state, 'start.site' ).length ).toEqual( 3 );
+			expect( selectors.getPluginsForSite( state, 'start.site' )[ 0 ].slug ).toEqual(
+				'vaultpress'
+			);
+			expect( selectors.getPluginsForSite( state, 'start.site' )[ 1 ].slug ).toEqual( 'akismet' );
+			expect( selectors.getPluginsForSite( state, 'start.site' )[ 2 ].slug ).toEqual( 'polldaddy' );
 		} );
 	} );
 
 	describe( 'getActivePlugin', () => {
 		test( 'Should get `false` if the requested site is not in the current state', () => {
-			assert.equal( selectors.getActivePlugin( state, 'no.site' ), false );
+			expect( selectors.getActivePlugin( state, 'no.site' ) ).toEqual( false );
 		} );
 
 		test( 'Should get `false` if no plugins on the requested site are currently being installed', () => {
-			assert.equal( selectors.getActivePlugin( state, 'start.site' ), false );
+			expect( selectors.getActivePlugin( state, 'start.site' ) ).toEqual( false );
 		} );
 
 		test( 'Should get `false` if all plugins on the requested site are finished installing', () => {
-			assert.equal( selectors.getActivePlugin( state, 'finished.site' ), false );
+			expect( selectors.getActivePlugin( state, 'finished.site' ) ).toEqual( false );
 		} );
 
 		test( 'Should get `akismet` if akismet is the currently being installed on the requested site', () => {
-			assert.equal( selectors.getActivePlugin( state, 'installing.site' ).slug, 'akismet' );
+			expect( selectors.getActivePlugin( state, 'installing.site' ).slug ).toEqual( 'akismet' );
 		} );
 	} );
 
 	describe( 'getNextPlugin', () => {
 		test( 'Should get `false` if the requested site is not in the current state', () => {
-			assert.equal( selectors.getNextPlugin( state, 'no.site' ), false );
+			expect( selectors.getNextPlugin( state, 'no.site' ) ).toEqual( false );
 		} );
 
 		test( "Should get the first plugin in the list if the requested site hasn't started yet", () => {
-			assert.equal( selectors.getNextPlugin( state, 'start.site' ).slug, 'vaultpress' );
+			expect( selectors.getNextPlugin( state, 'start.site' ).slug ).toEqual( 'vaultpress' );
 		} );
 
 		test( 'Should get `polldaddy`, next in the list, if the requested site is installing akismet', () => {
-			assert.equal( selectors.getNextPlugin( state, 'installing.site' ).slug, 'polldaddy' );
+			expect( selectors.getNextPlugin( state, 'installing.site' ).slug ).toEqual( 'polldaddy' );
 		} );
 
 		test( 'Should get `false`, if the requested site is finished installing all plugins', () => {
-			assert.equal( selectors.getNextPlugin( state, 'finished.site' ), false );
+			expect( selectors.getNextPlugin( state, 'finished.site' ) ).toEqual( false );
 		} );
 	} );
 } );

--- a/client/state/plugins/wporg/test/actions.js
+++ b/client/state/plugins/wporg/test/actions.js
@@ -2,11 +2,6 @@
 /**
  * External dependencies
  */
-import { assert } from 'chai';
-
-/**
- * Internal dependencies
- */
 import WPorgActions from '../actions';
 import wporg from 'lib/wporg';
 jest.mock( 'lib/wporg', () => require( './mocks/lib/wporg' ) );
@@ -30,17 +25,17 @@ describe( 'WPorg Data Actions', () => {
 	} );
 
 	test( 'Actions should be an object', () => {
-		assert.isObject( WPorgActions );
+		expect( typeof WPorgActions ).toBe( 'object' );
 	} );
 
 	test( 'Actions should have method fetchPluginData', () => {
-		assert.isFunction( WPorgActions.fetchPluginData );
+		expect( typeof WPorgActions.fetchPluginData ).toBe( 'function' );
 	} );
 
 	test( 'FetchPluginData action should make a request', done => {
 		WPorgActions.fetchPluginData( 'test' )(
 			testDispatch( function() {
-				assert.equal( wporg.getActivity().fetchPluginInformation, 1 );
+				expect( wporg.getActivity().fetchPluginInformation ).toEqual( 1 );
 				done();
 			}, 2 )
 		);
@@ -57,7 +52,7 @@ describe( 'WPorg Data Actions', () => {
 	test( 'FetchPluginData action should return a plugin ', done => {
 		WPorgActions.fetchPluginData( 'test' )(
 			testDispatch( function( action ) {
-				assert.equal( action.data.slug, 'test' );
+				expect( action.data.slug ).toEqual( 'test' );
 				done();
 			}, 2 )
 		);
@@ -67,6 +62,6 @@ describe( 'WPorg Data Actions', () => {
 		wporg.deactivatedCallbacks = true;
 		WPorgActions.fetchPluginData( 'test' )( function() {} );
 		WPorgActions.fetchPluginData( 'test' )( function() {} );
-		assert.equal( wporg.getActivity().fetchPluginInformation, 1 );
+		expect( wporg.getActivity().fetchPluginInformation ).toEqual( 1 );
 	} );
 } );

--- a/client/state/plugins/wporg/test/selectors.js
+++ b/client/state/plugins/wporg/test/selectors.js
@@ -3,7 +3,6 @@
 /**
  * External dependencies
  */
-import { assert } from 'chai';
 import deepFreeze from 'deep-freeze';
 
 /**
@@ -26,58 +25,58 @@ const fetchingItems = deepFreeze( {
 
 describe( 'WPorg Selectors', () => {
 	test( 'Should contain getPlugin method', () => {
-		assert.equal( typeof selectors.getPlugin, 'function' );
+		expect( typeof selectors.getPlugin ).toEqual( 'function' );
 	} );
 
 	test( 'Should contain isFetching method', () => {
-		assert.equal( typeof selectors.isFetching, 'function' );
+		expect( typeof selectors.isFetching ).toEqual( 'function' );
 	} );
 
 	describe( 'getPlugin', () => {
 		test( 'Should get null if the requested plugin is not in the current state', () => {
-			assert.equal( selectors.getPlugin( items, 'no-test' ), null );
+			expect( selectors.getPlugin( items, 'no-test' ) ).toEqual( null );
 		} );
 
 		test( 'Should get the plugin if the requested plugin is in the current state', () => {
-			assert.equal( selectors.getPlugin( items, 'test' ).slug, 'test' );
+			expect( selectors.getPlugin( items, 'test' ).slug ).toEqual( 'test' );
 		} );
 
 		test( 'Should return a new object with no pointers to the one stored in state', () => {
 			let plugin = selectors.getPlugin( items, 'fetchedTest' );
 			plugin.fetched = false;
-			assert.equal( selectors.getPlugin( items, 'fetchedTest' ).fetched, true );
+			expect( selectors.getPlugin( items, 'fetchedTest' ).fetched ).toEqual( true );
 		} );
 	} );
 
 	describe( 'isFetching', () => {
 		test( 'Should get `true` if the requested plugin is not in the current state', () => {
-			assert.equal( selectors.isFetching( fetchingItems, 'no.test' ), true );
+			expect( selectors.isFetching( fetchingItems, 'no.test' ) ).toEqual( true );
 		} );
 
 		test( 'Should get `false` if the requested plugin is not being fetched', () => {
-			assert.equal( selectors.isFetching( fetchingItems, 'test' ), false );
+			expect( selectors.isFetching( fetchingItems, 'test' ) ).toEqual( false );
 		} );
 
 		test( 'Should get `true` if the requested plugin is being fetched', () => {
-			assert.equal( selectors.isFetching( fetchingItems, 'fetchingTest' ), true );
+			expect( selectors.isFetching( fetchingItems, 'fetchingTest' ) ).toEqual( true );
 		} );
 	} );
 
 	describe( 'isFetched', () => {
 		test( 'Should get `false` if the requested plugin is not in the current state', () => {
-			assert.equal( selectors.isFetched( items, 'no.test' ), false );
+			expect( selectors.isFetched( items, 'no.test' ) ).toEqual( false );
 		} );
 
 		test( 'Should get `false` if the requested plugin has not being fetched', () => {
-			assert.equal( selectors.isFetched( items, 'test' ), false );
+			expect( selectors.isFetched( items, 'test' ) ).toEqual( false );
 		} );
 
 		test( 'Should get `true` if the requested plugin has being fetched', () => {
-			assert.equal( selectors.isFetched( items, 'fetchedTest' ), true );
+			expect( selectors.isFetched( items, 'fetchedTest' ) ).toEqual( true );
 		} );
 
 		test( "Should get `true` if the requested plugin has being fetched even if it's being fetche again", () => {
-			assert.equal( selectors.isFetched( items, 'fetchedTest2' ), true );
+			expect( selectors.isFetched( items, 'fetchedTest2' ) ).toEqual( true );
 		} );
 	} );
 } );

--- a/client/state/reader/feeds/test/actions.js
+++ b/client/state/reader/feeds/test/actions.js
@@ -2,7 +2,6 @@
 /**
  * External dependencies
  */
-import { assert, expect } from 'chai';
 import sinon from 'sinon';
 
 /**
@@ -52,7 +51,7 @@ describe( 'actions', () => {
 					} );
 				},
 				err => {
-					assert.fail( 'Errback should not be invoked!', err );
+					expect( false ).toBe( true );
 					return err;
 				}
 			);
@@ -82,7 +81,7 @@ describe( 'actions', () => {
 		test( 'should dispatch error, eventually', () => {
 			return request.then(
 				() => {
-					assert.fail( 'callback should not be invoked!', arguments );
+					expect( false ).toBe( true );
 					throw new Error( 'errback should have been invoked' );
 				},
 				() => {

--- a/client/state/reader/feeds/test/schema.js
+++ b/client/state/reader/feeds/test/schema.js
@@ -2,7 +2,6 @@
 /**
  * External dependencies
  */
-import { assert } from 'chai';
 import validate from 'is-my-json-valid';
 
 /**
@@ -23,7 +22,7 @@ describe( 'schema', () => {
 				blog_ID: 2,
 			},
 		} );
-		assert.isTrue( isValid, validator.error );
+		expect( isValid ).toBe( true );
 	} );
 
 	test( 'should validate a full object', () => {
@@ -39,7 +38,7 @@ describe( 'schema', () => {
 				meta: {},
 			},
 		} );
-		assert.isTrue( isValid, validator.error );
+		expect( isValid ).toBe( true );
 	} );
 
 	test( 'should allow null props', () => {
@@ -55,11 +54,11 @@ describe( 'schema', () => {
 				meta: null,
 			},
 		} );
-		assert.isTrue( isValid, validator.error );
+		expect( isValid ).toBe( true );
 	} );
 
 	test( 'shall not let bad data pass', () => {
-		assert.isFalse(
+		expect(
 			validator( {
 				1234: {
 					feed_ID: '1', // feed_ID should be an actual integer, not a string
@@ -72,6 +71,6 @@ describe( 'schema', () => {
 					meta: null,
 				},
 			} )
-		);
+		).toBe( false );
 	} );
 } );

--- a/client/state/reader/site-blocks/test/actions.js
+++ b/client/state/reader/site-blocks/test/actions.js
@@ -2,7 +2,6 @@
 /**
  * External dependencies
  */
-import { assert, expect } from 'chai';
 import deepFreeze from 'deep-freeze';
 import sinon from 'sinon';
 
@@ -58,7 +57,7 @@ describe( 'actions', () => {
 						} );
 					} )
 					.catch( err => {
-						assert.fail( err, undefined, 'errback should not have been called' );
+						expect( false ).toBe( true );
 					} );
 			} );
 		} );
@@ -145,7 +144,7 @@ describe( 'actions', () => {
 						} );
 					} )
 					.catch( err => {
-						assert.fail( err, undefined, 'errback should not have been called' );
+						expect( false ).toBe( true );
 					} );
 			} );
 		} );

--- a/client/state/reader/sites/test/actions.js
+++ b/client/state/reader/sites/test/actions.js
@@ -2,7 +2,6 @@
 /**
  * External dependencies
  */
-import { assert, expect } from 'chai';
 import sinon from 'sinon';
 
 /**
@@ -70,7 +69,7 @@ describe( 'actions', () => {
 					} );
 				},
 				err => {
-					assert.fail( 'Errback should not be invoked!', err );
+					expect( false ).toBe( true );
 					return err;
 				}
 			);
@@ -100,7 +99,7 @@ describe( 'actions', () => {
 		test( 'should dispatch error, eventually', () => {
 			return request.then(
 				() => {
-					assert.fail( 'callback should not be invoked!', arguments );
+					expect( false ).toBe( true );
 					throw new Error( 'errback should have been invoked' );
 				},
 				() => {

--- a/client/state/reader/tags/images/test/actions.js
+++ b/client/state/reader/tags/images/test/actions.js
@@ -2,7 +2,6 @@
 /**
  * External dependencies
  */
-import { assert, expect } from 'chai';
 import deepFreeze from 'deep-freeze';
 import sinon from 'sinon';
 
@@ -71,7 +70,7 @@ describe( 'actions', () => {
 					} );
 				} )
 				.catch( err => {
-					assert.fail( err, undefined, 'errback should not have been called' );
+					expect( false ).toBe( true );
 				} );
 		} );
 	} );

--- a/client/state/reader/teams/test/reducer.js
+++ b/client/state/reader/teams/test/reducer.js
@@ -2,7 +2,6 @@
 /**
  * External dependencies
  */
-import { assert, expect } from 'chai';
 import deepfreeze from 'deep-freeze';
 
 /**
@@ -66,16 +65,16 @@ describe( 'reducer', () => {
 		} );
 
 		test( 'deserialize: should succeed with good data', () => {
-			assert.deepEqual( validState, items( validState, { type: DESERIALIZE } ) );
+			expect( validState ).toEqual( items( validState, { type: DESERIALIZE } ) );
 		} );
 
 		test( 'deserialize: should ignore bad data', () => {
 			let state;
 			try {
 				state = items( invalidState, { type: DESERIALIZE } );
-				assert.fail();
+				expect( false ).toBe( true );
 			} catch ( err ) {
-				assert.deepEqual( [], state );
+				expect( [] ).toEqual( state );
 			}
 		} );
 	} );

--- a/client/state/reader/thumbnails/test/actions.js
+++ b/client/state/reader/thumbnails/test/actions.js
@@ -2,7 +2,6 @@
 /**
  * External dependencies
  */
-import { assert, expect } from 'chai';
 import deepFreeze from 'deep-freeze';
 import sinon from 'sinon';
 
@@ -84,7 +83,7 @@ describe( 'actions', () => {
 					expect( dispatchSpy.calledTwice );
 				} )
 				.catch( err => {
-					assert.fail( err, undefined, 'errback should not have been called' );
+					expect( false ).toBe( true );
 				} );
 		} );
 
@@ -119,7 +118,7 @@ describe( 'actions', () => {
 					expect( dispatchSpy.calledTwice );
 				} )
 				.catch( err => {
-					assert.fail( err, undefined, 'errback should not have been called' );
+					expect( false ).toBe( true );
 				} );
 		} );
 

--- a/client/state/selectors/test/get-account-recovery-reset-options-error.js
+++ b/client/state/selectors/test/get-account-recovery-reset-options-error.js
@@ -3,11 +3,6 @@
 /**
  * External dependencies
  */
-import { assert } from 'chai';
-
-/**
- * Internal dependencies
- */
 import { getAccountRecoveryResetOptionsError } from '../';
 
 describe( 'getAccountRecoveryResetOptionsError()', () => {
@@ -26,7 +21,7 @@ describe( 'getAccountRecoveryResetOptionsError()', () => {
 			},
 		};
 
-		assert.deepEqual( getAccountRecoveryResetOptionsError( state ), expectedError );
+		expect( getAccountRecoveryResetOptionsError( state ) ).toEqual( expectedError );
 	} );
 
 	test( 'should return null if no error exists.', () => {
@@ -38,6 +33,6 @@ describe( 'getAccountRecoveryResetOptionsError()', () => {
 			},
 		};
 
-		assert.isNull( getAccountRecoveryResetOptionsError( state ) );
+		expect( getAccountRecoveryResetOptionsError( state ) ).toBeNull();
 	} );
 } );

--- a/client/state/selectors/test/get-account-recovery-reset-options.js
+++ b/client/state/selectors/test/get-account-recovery-reset-options.js
@@ -3,11 +3,6 @@
 /**
  * External dependencies
  */
-import { assert } from 'chai';
-
-/**
- * Internal dependencies
- */
 import { getAccountRecoveryResetOptions } from '../';
 
 describe( 'getAccountRecoveryResetOptions()', () => {
@@ -33,6 +28,6 @@ describe( 'getAccountRecoveryResetOptions()', () => {
 			},
 		};
 
-		assert.deepEqual( getAccountRecoveryResetOptions( state ), resetOptionItems );
+		expect( getAccountRecoveryResetOptions( state ) ).toEqual( resetOptionItems );
 	} );
 } );

--- a/client/state/selectors/test/get-account-recovery-reset-password-error.js
+++ b/client/state/selectors/test/get-account-recovery-reset-password-error.js
@@ -3,7 +3,6 @@
 /**
  * External dependencies
  */
-import { assert } from 'chai';
 import deepFreeze from 'deep-freeze';
 
 /**
@@ -27,10 +26,10 @@ describe( 'getAccountRecoveryResetPasswordError()', () => {
 			},
 		} );
 
-		assert.deepEqual( getAccountRecoveryResetPasswordError( state ), error );
+		expect( getAccountRecoveryResetPasswordError( state ) ).toEqual( error );
 	} );
 
 	test( 'should return null as default value.', () => {
-		assert.isNull( getAccountRecoveryResetPasswordError( undefined ) );
+		expect( getAccountRecoveryResetPasswordError( undefined ) ).toBeNull();
 	} );
 } );

--- a/client/state/selectors/test/get-account-recovery-reset-request-error.js
+++ b/client/state/selectors/test/get-account-recovery-reset-request-error.js
@@ -3,7 +3,6 @@
 /**
  * External dependencies
  */
-import { assert } from 'chai';
 import deepFreeze from 'deep-freeze';
 
 /**
@@ -27,7 +26,7 @@ describe( 'getAccountRecoveryResetRequestError()', () => {
 			},
 		} );
 
-		assert.deepEqual( getAccountRecoveryResetRequestError( state ), error );
+		expect( getAccountRecoveryResetRequestError( state ) ).toEqual( error );
 	} );
 
 	test( 'should return null when there is no error stored in the request-reset substate tree.', () => {
@@ -39,6 +38,6 @@ describe( 'getAccountRecoveryResetRequestError()', () => {
 			},
 		} );
 
-		assert.isNull( getAccountRecoveryResetRequestError( state ) );
+		expect( getAccountRecoveryResetRequestError( state ) ).toBeNull();
 	} );
 } );

--- a/client/state/selectors/test/get-account-recovery-reset-selected-method.js
+++ b/client/state/selectors/test/get-account-recovery-reset-selected-method.js
@@ -3,7 +3,6 @@
 /**
  * External dependencies
  */
-import { assert } from 'chai';
 import deepFreeze from 'deep-freeze';
 
 /**
@@ -22,6 +21,6 @@ describe( 'getAccountRecoveryResetSelectedMethod()', () => {
 			},
 		} );
 
-		assert.equal( getAccountRecoveryResetSelectedMethod( state ), method );
+		expect( getAccountRecoveryResetSelectedMethod( state ) ).toEqual( method );
 	} );
 } );

--- a/client/state/selectors/test/get-account-recovery-reset-user-data.js
+++ b/client/state/selectors/test/get-account-recovery-reset-user-data.js
@@ -3,7 +3,6 @@
 /**
  * External dependencies
  */
-import { assert } from 'chai';
 import deepFreeze from 'deep-freeze';
 
 /**
@@ -27,6 +26,6 @@ describe( 'getAccountRecoveryResetUserData()', () => {
 			},
 		} );
 
-		assert.deepEqual( getAccountRecoveryResetUserData( state ), expectedUserData );
+		expect( getAccountRecoveryResetUserData( state ) ).toEqual( expectedUserData );
 	} );
 } );

--- a/client/state/selectors/test/get-account-recovery-validation-key.js
+++ b/client/state/selectors/test/get-account-recovery-validation-key.js
@@ -3,7 +3,6 @@
 /**
  * External dependencies
  */
-import { assert } from 'chai';
 import deepFreeze from 'deep-freeze';
 
 /**
@@ -22,10 +21,10 @@ describe( 'getAccountRecoveryValidationKey()', () => {
 			},
 		} );
 
-		assert.equal( getAccountRecoveryValidationKey( state ), key );
+		expect( getAccountRecoveryValidationKey( state ) ).toEqual( key );
 	} );
 
 	test( 'should return null as the default value.', () => {
-		assert.isNull( getAccountRecoveryValidationKey( undefined ) );
+		expect( getAccountRecoveryValidationKey( undefined ) ).toBeNull();
 	} );
 } );

--- a/client/state/selectors/test/get-theme-filter-string-from-term.js
+++ b/client/state/selectors/test/get-theme-filter-string-from-term.js
@@ -3,25 +3,20 @@
 /**
  * External dependencies
  */
-import { assert } from 'chai';
-
-/**
- * Internal dependencies
- */
 import { getThemeFilterStringFromTerm } from '../';
 import { state } from './fixtures/theme-filters';
 
 describe( 'getThemeFilterStringFromTerm', () => {
 	test( 'should return taxonomy:term filter given the term', () => {
-		assert.equal( getThemeFilterStringFromTerm( state, 'artwork' ), 'subject:artwork' );
-		assert.equal( getThemeFilterStringFromTerm( state, 'bright' ), 'style:bright' );
+		expect( getThemeFilterStringFromTerm( state, 'artwork' ) ).toEqual( 'subject:artwork' );
+		expect( getThemeFilterStringFromTerm( state, 'bright' ) ).toEqual( 'style:bright' );
 	} );
 
 	test( 'should return empty string given an invalid term', () => {
-		assert.equal( getThemeFilterStringFromTerm( state, '' ), '' );
-		assert.equal( getThemeFilterStringFromTerm( state, ' ' ), '' );
-		assert.equal( getThemeFilterStringFromTerm( state, ' artwork' ), '' );
-		assert.equal( getThemeFilterStringFromTerm( state, 'artwork ' ), '' );
-		assert.equal( getThemeFilterStringFromTerm( state, 'aartwork' ), '' );
+		expect( getThemeFilterStringFromTerm( state, '' ) ).toEqual( '' );
+		expect( getThemeFilterStringFromTerm( state, ' ' ) ).toEqual( '' );
+		expect( getThemeFilterStringFromTerm( state, ' artwork' ) ).toEqual( '' );
+		expect( getThemeFilterStringFromTerm( state, 'artwork ' ) ).toEqual( '' );
+		expect( getThemeFilterStringFromTerm( state, 'aartwork' ) ).toEqual( '' );
 	} );
 } );

--- a/client/state/selectors/test/is-account-recovery-reset-options-ready.js
+++ b/client/state/selectors/test/is-account-recovery-reset-options-ready.js
@@ -3,11 +3,6 @@
 /**
  * External dependencies
  */
-import { assert } from 'chai';
-
-/**
- * Internal dependencies
- */
 import { isAccountRecoveryResetOptionsReady } from '../';
 
 describe( 'isAccountRecoveryResetOptionsReady()', () => {
@@ -22,7 +17,7 @@ describe( 'isAccountRecoveryResetOptionsReady()', () => {
 			},
 		};
 
-		assert.isFalse( isAccountRecoveryResetOptionsReady( state ) );
+		expect( isAccountRecoveryResetOptionsReady( state ) ).toBe( false );
 	} );
 
 	test( 'should return false if there is an existing error', () => {
@@ -45,7 +40,7 @@ describe( 'isAccountRecoveryResetOptionsReady()', () => {
 			},
 		};
 
-		assert.isFalse( isAccountRecoveryResetOptionsReady( state ) );
+		expect( isAccountRecoveryResetOptionsReady( state ) ).toBe( false );
 	} );
 
 	test( 'should return true if items array is populated and there is no error', () => {
@@ -64,6 +59,6 @@ describe( 'isAccountRecoveryResetOptionsReady()', () => {
 			},
 		};
 
-		assert.isTrue( isAccountRecoveryResetOptionsReady( state ) );
+		expect( isAccountRecoveryResetOptionsReady( state ) ).toBe( true );
 	} );
 } );

--- a/client/state/selectors/test/is-account-recovery-reset-password-succeeded.js
+++ b/client/state/selectors/test/is-account-recovery-reset-password-succeeded.js
@@ -3,7 +3,6 @@
 /**
  * External dependencies
  */
-import { assert } from 'chai';
 import deepFreeze from 'deep-freeze';
 
 /**
@@ -23,10 +22,10 @@ describe( 'isAccountRecoveryResetPasswordSucceeded()', () => {
 			},
 		} );
 
-		assert.isTrue( isAccountRecoveryResetPasswordSucceeded( state ) );
+		expect( isAccountRecoveryResetPasswordSucceeded( state ) ).toBe( true );
 	} );
 
 	test( 'should return false as default value.', () => {
-		assert.isFalse( isAccountRecoveryResetPasswordSucceeded( undefined ) );
+		expect( isAccountRecoveryResetPasswordSucceeded( undefined ) ).toBe( false );
 	} );
 } );

--- a/client/state/selectors/test/is-account-recovery-user-data-ready.js
+++ b/client/state/selectors/test/is-account-recovery-user-data-ready.js
@@ -3,7 +3,6 @@
 /**
  * External dependencies
  */
-import { assert } from 'chai';
 import deepFreeze from 'deep-freeze';
 
 /**
@@ -23,7 +22,7 @@ describe( 'isAccountRecoveryUserDataReady()', () => {
 			},
 		} );
 
-		assert.isTrue( isAccountRecoveryUserDataReady( state ) );
+		expect( isAccountRecoveryUserDataReady( state ) ).toBe( true );
 	} );
 
 	test( 'should return true if firstname, lastname, and url is set.', () => {
@@ -39,7 +38,7 @@ describe( 'isAccountRecoveryUserDataReady()', () => {
 			},
 		} );
 
-		assert.isTrue( isAccountRecoveryUserDataReady( state ) );
+		expect( isAccountRecoveryUserDataReady( state ) ).toBe( true );
 	} );
 
 	test( 'should return false if one of ( firstname, lastname, url ) is missing.', () => {
@@ -54,7 +53,7 @@ describe( 'isAccountRecoveryUserDataReady()', () => {
 			},
 		} );
 
-		assert.isFalse( isAccountRecoveryUserDataReady( noFirstname ) );
+		expect( isAccountRecoveryUserDataReady( noFirstname ) ).toBe( false );
 
 		const noLastname = deepFreeze( {
 			accountRecovery: {
@@ -67,7 +66,7 @@ describe( 'isAccountRecoveryUserDataReady()', () => {
 			},
 		} );
 
-		assert.isFalse( isAccountRecoveryUserDataReady( noLastname ) );
+		expect( isAccountRecoveryUserDataReady( noLastname ) ).toBe( false );
 
 		const noUrl = deepFreeze( {
 			accountRecovery: {
@@ -80,10 +79,10 @@ describe( 'isAccountRecoveryUserDataReady()', () => {
 			},
 		} );
 
-		assert.isFalse( isAccountRecoveryUserDataReady( noUrl ) );
+		expect( isAccountRecoveryUserDataReady( noUrl ) ).toBe( false );
 	} );
 
 	test( 'should return false as default value', () => {
-		assert.isFalse( isAccountRecoveryUserDataReady( undefined ) );
+		expect( isAccountRecoveryUserDataReady( undefined ) ).toBe( false );
 	} );
 } );

--- a/client/state/selectors/test/is-business-plan-user.js
+++ b/client/state/selectors/test/is-business-plan-user.js
@@ -3,7 +3,6 @@
 /**
  * External dependencies
  */
-import { assert } from 'chai';
 import deepFreeze from 'deep-freeze';
 
 /**
@@ -33,7 +32,7 @@ describe( 'isBusinessPlanUser()', () => {
 			},
 		} );
 
-		assert.isTrue( isBusinessPlanUser( state ) );
+		expect( isBusinessPlanUser( state ) ).toBe( true );
 	} );
 
 	test( 'should return false if non of the purchases is a business plan.', () => {
@@ -56,7 +55,7 @@ describe( 'isBusinessPlanUser()', () => {
 			},
 		} );
 
-		assert.isFalse( isBusinessPlanUser( state ) );
+		expect( isBusinessPlanUser( state ) ).toBe( false );
 	} );
 
 	test( 'should return false if current user id is null.', () => {
@@ -64,7 +63,7 @@ describe( 'isBusinessPlanUser()', () => {
 			currentUser: {},
 		} );
 
-		assert.isFalse( isBusinessPlanUser( state ) );
+		expect( isBusinessPlanUser( state ) ).toBe( false );
 	} );
 
 	test( 'should return false if purchasing data is null.', () => {
@@ -84,6 +83,6 @@ describe( 'isBusinessPlanUser()', () => {
 			},
 		} );
 
-		assert.isFalse( isBusinessPlanUser( state ) );
+		expect( isBusinessPlanUser( state ) ).toBe( false );
 	} );
 } );

--- a/client/state/selectors/test/is-requesting-account-recovery-reset-options.js
+++ b/client/state/selectors/test/is-requesting-account-recovery-reset-options.js
@@ -3,11 +3,6 @@
 /**
  * External dependencies
  */
-import { assert } from 'chai';
-
-/**
- * Internal dependencies
- */
 import { isRequestingAccountRecoveryResetOptions } from '../';
 
 describe( 'isRequestingAccountRecoveryResetOptions()', () => {
@@ -22,6 +17,6 @@ describe( 'isRequestingAccountRecoveryResetOptions()', () => {
 			},
 		};
 
-		assert.isTrue( isRequestingAccountRecoveryResetOptions( state ) );
+		expect( isRequestingAccountRecoveryResetOptions( state ) ).toBe( true );
 	} );
 } );

--- a/client/state/selectors/test/is-requesting-account-recovery-reset.js
+++ b/client/state/selectors/test/is-requesting-account-recovery-reset.js
@@ -3,7 +3,6 @@
 /**
  * External dependencies
  */
-import { assert } from 'chai';
 import deepFreeze from 'deep-freeze';
 
 /**
@@ -23,6 +22,6 @@ describe( 'isRequestingAccountRecoveryReset()', () => {
 			},
 		} );
 
-		assert.isTrue( isRequestingAccountRecoveryReset( state ) );
+		expect( isRequestingAccountRecoveryReset( state ) ).toBe( true );
 	} );
 } );

--- a/client/state/selectors/test/is-requesting-reset-password.js
+++ b/client/state/selectors/test/is-requesting-reset-password.js
@@ -3,7 +3,6 @@
 /**
  * External dependencies
  */
-import { assert } from 'chai';
 import deepFreeze from 'deep-freeze';
 
 /**
@@ -23,10 +22,10 @@ describe( 'isRequestingResetPassword()', () => {
 			},
 		} );
 
-		assert.isTrue( isRequestingResetPassword( state ) );
+		expect( isRequestingResetPassword( state ) ).toBe( true );
 	} );
 
 	test( 'should return false as default value.', () => {
-		assert.isFalse( isRequestingResetPassword( undefined ) );
+		expect( isRequestingResetPassword( undefined ) ).toBe( false );
 	} );
 } );

--- a/client/state/selectors/test/is-validating-account-recovery-key.js
+++ b/client/state/selectors/test/is-validating-account-recovery-key.js
@@ -3,7 +3,6 @@
 /**
  * External dependencies
  */
-import { assert } from 'chai';
 import deepFreeze from 'deep-freeze';
 
 /**
@@ -23,10 +22,10 @@ describe( 'isValidatingAccountRecoveryKey()', () => {
 			},
 		} );
 
-		assert.isTrue( isValidatingAccountRecoveryKey( state ) );
+		expect( isValidatingAccountRecoveryKey( state ) ).toBe( true );
 	} );
 
 	test( 'should return false as the default value.', () => {
-		assert.isFalse( isValidatingAccountRecoveryKey( undefined ) );
+		expect( isValidatingAccountRecoveryKey( undefined ) ).toBe( false );
 	} );
 } );

--- a/client/state/selectors/test/prepend-theme-filter-keys.js
+++ b/client/state/selectors/test/prepend-theme-filter-keys.js
@@ -3,19 +3,14 @@
 /**
  * External dependencies
  */
-import { assert, expect } from 'chai';
-
-/**
- * Internal dependencies
- */
 import { prependThemeFilterKeys } from '../';
 import { state } from './fixtures/theme-filters';
 
 describe( 'getThemeFilterStringFromTerm', () => {
 	test( 'should handle invalid input', () => {
-		assert.equal( prependThemeFilterKeys( state, '' ), '' );
-		assert.equal( prependThemeFilterKeys( state, '     ' ), '' );
-		assert.equal( prependThemeFilterKeys( state, ' tsr tsr .' ), '' );
+		expect( prependThemeFilterKeys( state, '' ) ).toEqual( '' );
+		expect( prependThemeFilterKeys( state, '     ' ) ).toEqual( '' );
+		expect( prependThemeFilterKeys( state, ' tsr tsr .' ) ).toEqual( '' );
 	} );
 
 	test( 'should prepend keys for valid terms and leave a trailing space', () => {

--- a/client/state/stats/lists/test/utils.js
+++ b/client/state/stats/lists/test/utils.js
@@ -3,7 +3,6 @@
 /**
  * External dependencies
  */
-import { assert, expect } from 'chai';
 import { moment } from 'i18n-calypso';
 
 /**
@@ -79,8 +78,8 @@ describe( 'utils', () => {
 
 		test( 'should return empty array if payload is null', () => {
 			const actualDeltas = parseOrderDeltas( null );
-			assert.isArray( actualDeltas );
-			assert.isTrue( actualDeltas.length === 0 );
+			expect( Array.isArray( actualDeltas ) ).toBe( true );
+			expect( actualDeltas.length === 0 ).toBe( true );
 		} );
 
 		test( 'should return empty array if payload.deltas has no keys', () => {
@@ -89,26 +88,26 @@ describe( 'utils', () => {
 				deltas: {},
 				delta_fields: [ 'period' ],
 			} );
-			assert.isArray( actualDeltas );
-			assert.isTrue( actualDeltas.length === 0 );
+			expect( Array.isArray( actualDeltas ) ).toBe( true );
+			expect( actualDeltas.length === 0 ).toBe( true );
 		} );
 
 		test( 'should return empty array if payload.deltas or delta_fields are missing', () => {
 			const actualDeltas = parseOrderDeltas( { date: '2017' } );
-			assert.isArray( actualDeltas );
-			assert.isTrue( actualDeltas.length === 0 );
+			expect( Array.isArray( actualDeltas ) ).toBe( true );
+			expect( actualDeltas.length === 0 ).toBe( true );
 		} );
 
 		test( 'should return a well formed array of delta objects', () => {
 			const actualDeltas = parseOrderDeltas( orderPayload );
-			assert.isArray( actualDeltas );
-			assert.isObject( actualDeltas[ 0 ] );
-			assert.isObject( actualDeltas[ 0 ].orders );
+			expect( Array.isArray( actualDeltas ) ).toBe( true );
+			expect( typeof actualDeltas[ 0 ] ).toBe( 'object' );
+			expect( typeof actualDeltas[ 0 ].orders ).toBe( 'object' );
 		} );
 
 		test( 'should return an array of delta objects as expected', () => {
 			const actualDeltas = parseOrderDeltas( orderPayload );
-			assert.deepEqual( actualDeltas, expectedDeltas );
+			expect( actualDeltas ).toEqual( expectedDeltas );
 		} );
 	} );
 	describe( 'parseOrdersChartData', () => {
@@ -137,60 +136,60 @@ describe( 'utils', () => {
 
 		test( 'should return empty array if payload.data is missing', () => {
 			const actualOrders = parseOrdersChartData( { date: '2017' } );
-			assert.isArray( actualOrders );
-			assert.isTrue( actualOrders.length === 0 );
+			expect( Array.isArray( actualOrders ) ).toBe( true );
+			expect( actualOrders.length === 0 ).toBe( true );
 		} );
 
 		test( 'should return a well formed array of objects', () => {
 			const actualOrders = parseOrdersChartData( orderPayload );
-			assert.isArray( actualOrders );
-			assert.isObject( actualOrders[ 0 ] );
+			expect( Array.isArray( actualOrders ) ).toBe( true );
+			expect( typeof actualOrders[ 0 ] ).toBe( 'object' );
 		} );
 
 		test( 'should return an array of objects as expected', () => {
 			const actualOrders = parseOrdersChartData( orderPayload );
-			assert.deepEqual( actualOrders, expectedOrders );
+			expect( actualOrders ).toEqual( expectedOrders );
 		} );
 	} );
 	describe( 'getPeriodFormat', () => {
 		test( 'should return correctly day format for long formats', () => {
 			const response = getPeriodFormat( 'day', '2017-07-07' );
-			assert.strictEqual( response, 'YYYY-MM-DD' );
+			expect( response ).toBe( 'YYYY-MM-DD' );
 		} );
 
 		test( 'should return correctly week format for long formats', () => {
 			const response = getPeriodFormat( 'week', '2017-07-07' );
-			assert.strictEqual( response, 'YYYY-MM-DD' );
+			expect( response ).toBe( 'YYYY-MM-DD' );
 		} );
 
 		test( 'should return correctly month format for long formats', () => {
 			const response = getPeriodFormat( 'month', '2017-07-07' );
-			assert.strictEqual( response, 'YYYY-MM-DD' );
+			expect( response ).toBe( 'YYYY-MM-DD' );
 		} );
 
 		test( 'should return correctly year format for long formats', () => {
 			const response = getPeriodFormat( 'year', '2017-07-07' );
-			assert.strictEqual( response, 'YYYY-MM-DD' );
+			expect( response ).toBe( 'YYYY-MM-DD' );
 		} );
 
 		test( 'should return correctly day format for short (new) formats', () => {
 			const response = getPeriodFormat( 'day', '2017-07-07' );
-			assert.strictEqual( response, 'YYYY-MM-DD' );
+			expect( response ).toBe( 'YYYY-MM-DD' );
 		} );
 
 		test( 'should return correctly week format for short (new) formats', () => {
 			const response = getPeriodFormat( 'week', '2017-W27' );
-			assert.strictEqual( response, 'YYYY-[W]WW' );
+			expect( response ).toBe( 'YYYY-[W]WW' );
 		} );
 
 		test( 'should return correctly month format for short (new) formats', () => {
 			const response = getPeriodFormat( 'month', '2017-07' );
-			assert.strictEqual( response, 'YYYY-MM' );
+			expect( response ).toBe( 'YYYY-MM' );
 		} );
 
 		test( 'should return correctly year format for short (new) formats', () => {
 			const response = getPeriodFormat( 'year', '2017' );
-			assert.strictEqual( response, 'YYYY' );
+			expect( response ).toBe( 'YYYY' );
 		} );
 	} );
 

--- a/client/state/ui/editor/contact-form/test/actions.js
+++ b/client/state/ui/editor/contact-form/test/actions.js
@@ -3,11 +3,6 @@
 /**
  * External dependencies
  */
-import { assert } from 'chai';
-
-/**
- * Internal dependencies
- */
 import {
 	formClear,
 	formLoad,
@@ -30,7 +25,7 @@ describe( 'actions', () => {
 	test( 'should return an action object to signal the initialization of the store', () => {
 		const action = formLoad( CONTACT_FORM_DEFAULT );
 
-		assert.deepEqual( action, {
+		expect( action ).toEqual( {
 			type: EDITOR_CONTACT_FORM_LOAD,
 			contactForm: CONTACT_FORM_DEFAULT,
 		} );
@@ -39,13 +34,13 @@ describe( 'actions', () => {
 	test( 'should return an action object to signal the creation of a new default field', () => {
 		const action = fieldAdd();
 
-		assert.deepEqual( action, { type: EDITOR_CONTACT_FORM_FIELD_ADD } );
+		expect( action ).toEqual( { type: EDITOR_CONTACT_FORM_FIELD_ADD } );
 	} );
 
 	test( 'should return an action object to signal the removal of a field by index', () => {
 		const action = fieldRemove( 1 );
 
-		assert.deepEqual( action, {
+		expect( action ).toEqual( {
 			type: EDITOR_CONTACT_FORM_FIELD_REMOVE,
 			index: 1,
 		} );
@@ -54,13 +49,13 @@ describe( 'actions', () => {
 	test( 'should return an action object to signal the removal of the contact form data', () => {
 		const action = formClear();
 
-		assert.deepEqual( action, { type: EDITOR_CONTACT_FORM_CLEAR } );
+		expect( action ).toEqual( { type: EDITOR_CONTACT_FORM_CLEAR } );
 	} );
 
 	test( 'should return an action object to signal the update of a field by index', () => {
 		const action = fieldUpdate( 1, { label: 'Name', type: 'text', required: true } );
 
-		assert.deepEqual( action, {
+		expect( action ).toEqual( {
 			type: EDITOR_CONTACT_FORM_FIELD_UPDATE,
 			index: 1,
 			field: { label: 'Name', type: 'text', required: true },
@@ -70,7 +65,7 @@ describe( 'actions', () => {
 	test( 'should return an action object to signal the update of the form settings', () => {
 		const action = settingsUpdate( { to: 'user@example.com', subject: 'this is the subject' } );
 
-		assert.deepEqual( action, {
+		expect( action ).toEqual( {
 			type: EDITOR_CONTACT_FORM_SETTINGS_UPDATE,
 			settings: {
 				to: 'user@example.com',

--- a/client/state/ui/editor/contact-form/test/reducer.js
+++ b/client/state/ui/editor/contact-form/test/reducer.js
@@ -3,7 +3,6 @@
 /**
  * External dependencies
  */
-import { assert } from 'chai';
 import deepFreeze from 'deep-freeze';
 
 /**
@@ -29,12 +28,8 @@ describe( "editor's contact form state reducer", () => {
 	test( 'should return the default contact form when neither state nor action is provided', () => {
 		const state = reducer( undefined, {} );
 
-		assert.deepEqual( state, CONTACT_FORM_DEFAULT );
-		assert.notStrictEqual(
-			state,
-			CONTACT_FORM_DEFAULT,
-			'returned state is strictly equal to CONTACT_FORM_DEFAULT.'
-		);
+		expect( state ).toEqual( CONTACT_FORM_DEFAULT );
+		expect( state ).not.toBe( CONTACT_FORM_DEFAULT );
 	} );
 
 	describe( 'load form', () => {
@@ -55,17 +50,9 @@ describe( "editor's contact form state reducer", () => {
 				contactForm,
 			} );
 
-			assert.deepEqual( state, contactForm );
-			assert.notStrictEqual(
-				state,
-				contactForm,
-				'the returned state and contactForm are strictly equal.'
-			);
-			assert.notStrictEqual(
-				state.fields,
-				contactForm.fields,
-				'fields on the returned state and contactForm are strictly equal.'
-			);
+			expect( state ).toEqual( contactForm );
+			expect( state ).not.toBe( contactForm );
+			expect( state.fields ).not.toBe( contactForm.fields );
 		} );
 	} );
 
@@ -84,7 +71,7 @@ describe( "editor's contact form state reducer", () => {
 				type: EDITOR_CONTACT_FORM_FIELD_ADD,
 			} );
 
-			assert.deepEqual( state, {
+			expect( state ).toEqual( {
 				fields: [
 					{ label: 'Name' },
 					{ label: 'Email' },
@@ -98,7 +85,7 @@ describe( "editor's contact form state reducer", () => {
 		test( 'should add the default new field to the inital state when no state is provided', () => {
 			const state = reducer( undefined, { type: EDITOR_CONTACT_FORM_FIELD_ADD } );
 
-			assert.deepEqual( state, {
+			expect( state ).toEqual( {
 				fields: [
 					{ label: 'Name', type: 'name', required: true },
 					{ label: 'Email', type: 'email', required: true },
@@ -107,7 +94,7 @@ describe( "editor's contact form state reducer", () => {
 					{ label: 'Text', type: 'text', isExpanded: true },
 				],
 			} );
-			assert.deepEqual( CONTACT_FORM_DEFAULT, {
+			expect( CONTACT_FORM_DEFAULT ).toEqual( {
 				fields: [
 					{ label: 'Name', type: 'name', required: true },
 					{ label: 'Email', type: 'email', required: true },
@@ -134,7 +121,7 @@ describe( "editor's contact form state reducer", () => {
 				index: 2,
 			} );
 
-			assert.deepEqual( state, {
+			expect( state ).toEqual( {
 				fields: [ { label: 'Name' }, { label: 'Email' }, { label: 'Comment' } ],
 			} );
 		} );
@@ -145,25 +132,21 @@ describe( "editor's contact form state reducer", () => {
 				index: 2,
 			} );
 
-			assert.deepEqual( state, {
+			expect( state ).toEqual( {
 				fields: [
 					{ label: 'Name', type: 'name', required: true },
 					{ label: 'Email', type: 'email', required: true },
 					{ label: 'Comment', type: 'textarea', required: true },
 				],
 			} );
-			assert.deepEqual(
-				CONTACT_FORM_DEFAULT,
-				{
-					fields: [
-						{ label: 'Name', type: CONTACT_FORM_FIELD_TYPES.name, required: true },
-						{ label: 'Email', type: CONTACT_FORM_FIELD_TYPES.email, required: true },
-						{ label: 'Website', type: CONTACT_FORM_FIELD_TYPES.website },
-						{ label: 'Comment', type: CONTACT_FORM_FIELD_TYPES.textarea, required: true },
-					],
-				},
-				'contact form default values were mutated.'
-			);
+			expect( CONTACT_FORM_DEFAULT ).toEqual( {
+				fields: [
+					{ label: 'Name', type: CONTACT_FORM_FIELD_TYPES.name, required: true },
+					{ label: 'Email', type: CONTACT_FORM_FIELD_TYPES.email, required: true },
+					{ label: 'Website', type: CONTACT_FORM_FIELD_TYPES.website },
+					{ label: 'Comment', type: CONTACT_FORM_FIELD_TYPES.textarea, required: true },
+				],
+			} );
 		} );
 	} );
 
@@ -178,17 +161,9 @@ describe( "editor's contact form state reducer", () => {
 				}
 			);
 
-			assert.deepEqual( state, CONTACT_FORM_DEFAULT );
-			assert.notStrictEqual(
-				state,
-				CONTACT_FORM_DEFAULT,
-				'the returned state and the default contact form are strictly equal.'
-			);
-			assert.notStrictEqual(
-				state.fields,
-				CONTACT_FORM_DEFAULT.fields,
-				'the fields on the returned state and the default contact form are strictly equal.'
-			);
+			expect( state ).toEqual( CONTACT_FORM_DEFAULT );
+			expect( state ).not.toBe( CONTACT_FORM_DEFAULT );
+			expect( state.fields ).not.toBe( CONTACT_FORM_DEFAULT.fields );
 		} );
 	} );
 
@@ -209,7 +184,7 @@ describe( "editor's contact form state reducer", () => {
 				field: { label: 'Web Address', type: 'url', required: true },
 			} );
 
-			assert.deepEqual( state, {
+			expect( state ).toEqual( {
 				fields: [
 					{ label: 'Name' },
 					{ label: 'Email' },
@@ -230,7 +205,7 @@ describe( "editor's contact form state reducer", () => {
 				field: { options: 'Option One,Option Two,Option Three' },
 			} );
 
-			assert.deepEqual( state, {
+			expect( state ).toEqual( {
 				fields: [
 					{ label: 'Drop Down List', type: 'radio', options: 'Option One,Option Two,Option Three' },
 				],
@@ -248,7 +223,7 @@ describe( "editor's contact form state reducer", () => {
 				field: deepFreeze( { type: 'text' } ),
 			} );
 
-			assert.deepEqual( state, {
+			expect( state ).toEqual( {
 				fields: [ { label: 'Drop Down List', type: 'text' } ],
 			} );
 		} );
@@ -264,7 +239,7 @@ describe( "editor's contact form state reducer", () => {
 				field: deepFreeze( { type: 'text' } ),
 			} );
 
-			assert.deepEqual( state, {
+			expect( state ).toEqual( {
 				fields: [ { label: 'Drop Down List', type: 'text' } ],
 			} );
 		} );
@@ -280,7 +255,7 @@ describe( "editor's contact form state reducer", () => {
 				field: deepFreeze( { type: 'radio' } ),
 			} );
 
-			assert.deepEqual( state, {
+			expect( state ).toEqual( {
 				fields: [ { label: 'Name', type: 'radio', options: 'Option One,Option Two' } ],
 			} );
 		} );
@@ -296,7 +271,7 @@ describe( "editor's contact form state reducer", () => {
 				field: deepFreeze( { type: 'select' } ),
 			} );
 
-			assert.deepEqual( state, {
+			expect( state ).toEqual( {
 				fields: [ { label: 'Name', type: 'select', options: 'Option One,Option Two' } ],
 			} );
 		} );
@@ -312,7 +287,7 @@ describe( "editor's contact form state reducer", () => {
 				field: deepFreeze( { type: 'radio' } ),
 			} );
 
-			assert.deepEqual( state, {
+			expect( state ).toEqual( {
 				fields: [ { label: 'List', type: 'radio', options: 'option1,option2' } ],
 			} );
 		} );
@@ -328,7 +303,7 @@ describe( "editor's contact form state reducer", () => {
 				field: deepFreeze( { options: '' } ),
 			} );
 
-			assert.deepEqual( state, {
+			expect( state ).toEqual( {
 				fields: [ { label: 'List', type: 'radio', options: '' } ],
 			} );
 		} );
@@ -344,7 +319,7 @@ describe( "editor's contact form state reducer", () => {
 				field: deepFreeze( { options: '' } ),
 			} );
 
-			assert.deepEqual( state, {
+			expect( state ).toEqual( {
 				fields: [ { label: 'List', type: 'select', options: '' } ],
 			} );
 		} );
@@ -368,7 +343,7 @@ describe( "editor's contact form state reducer", () => {
 				settings: { to: 'someone@example.com' },
 			} );
 
-			assert.deepEqual( state, {
+			expect( state ).toEqual( {
 				to: 'someone@example.com',
 				subject: 'here be dragons',
 				fields: [
@@ -397,7 +372,7 @@ describe( "editor's contact form state reducer", () => {
 				settings: { subject: 'to boldly go' },
 			} );
 
-			assert.deepEqual( state, {
+			expect( state ).toEqual( {
 				to: 'user@example.com',
 				subject: 'to boldly go',
 				fields: [

--- a/client/state/users/suggestions/test/actions.js
+++ b/client/state/users/suggestions/test/actions.js
@@ -2,7 +2,6 @@
 /**
  * External dependencies
  */
-import { assert, expect } from 'chai';
 import deepFreeze from 'deep-freeze';
 import sinon from 'sinon';
 
@@ -71,7 +70,7 @@ describe( 'actions', () => {
 					} );
 				} )
 				.catch( err => {
-					assert.fail( err, undefined, 'errback should not have been called' );
+					expect( false ).toBe( true );
 				} );
 		} );
 	} );


### PR DESCRIPTION
This PR tries to convert all usages of `assert` from `chai` to `expect` from Jest using `jest-codemods`.