### PR TITLE
Editor: Update the Add button in the HTML Editor toolbar

### DIFF
--- a/client/post-editor/editor-html-toolbar/index.jsx
+++ b/client/post-editor/editor-html-toolbar/index.jsx
@@ -598,21 +598,12 @@ export class EditorHtmlToolbar extends Component {
 							>
 								<Button
 									borderless
-									className="editor-html-toolbar__button-insert-media"
-									compact
-									onClick={ this.openMediaModal }
-								>
-									<Gridicon icon="add-outline" />
-								</Button>
-								<Button
-									borderless
 									className="editor-html-toolbar__button-insert-content-dropdown"
 									compact
 									onClick={ this.toggleInsertContentMenu }
 								>
-									<Gridicon
-										icon={ this.state.showInsertContentMenu ? 'chevron-up' : 'chevron-down' }
-									/>
+									<Gridicon icon="add-outline" />
+									<span>{ translate( 'Add' ) }</span>
 								</Button>
 							</div>
 							{ map( buttons, ( { disabled, label, onClick }, tag ) => (

--- a/client/post-editor/editor-html-toolbar/index.jsx
+++ b/client/post-editor/editor-html-toolbar/index.jsx
@@ -481,41 +481,53 @@ export class EditorHtmlToolbar extends Component {
 
 	isTagOpen = tag => -1 !== this.state.openTags.indexOf( tag );
 
-	renderExternal() {
+	renderAddEverythingDropdown = () => {
 		const { translate } = this.props;
 
-		if ( ! config.isEnabled( 'external-media' ) ) {
-			return null;
-		}
+		const insertContentClasses = classNames( 'editor-html-toolbar__insert-content-dropdown', {
+			'is-visible': this.state.showInsertContentMenu,
+		} );
 
 		return (
-			<div
-				className="editor-html-toolbar__insert-content-dropdown-item"
-				onClick={ this.openGoogleModal }
-			>
-				<Gridicon icon="add-image" />
-				<span data-e2e-insert-type="google-media">{ translate( 'Add from Google' ) }</span>
+			<div className={ insertContentClasses }>
+				<div
+					className="editor-html-toolbar__insert-content-dropdown-item"
+					onClick={ this.openMediaModal }
+				>
+					<Gridicon icon="add-image" />
+					<span data-e2e-insert-type="media">{ translate( 'Media' ) }</span>
+				</div>
+
+				{ config.isEnabled( 'external-media' ) && (
+					<div
+						className="editor-html-toolbar__insert-content-dropdown-item"
+						onClick={ this.openGoogleModal }
+					>
+						<Gridicon icon="add-image" />
+						<span data-e2e-insert-type="google-media">{ translate( 'Media from Google' ) }</span>
+					</div>
+				) }
+
+				<div
+					className="editor-html-toolbar__insert-content-dropdown-item"
+					onClick={ this.openContactFormDialog }
+				>
+					<Gridicon icon="mention" />
+					<span data-e2e-insert-type="contact-form">{ translate( 'Contact Form' ) }</span>
+				</div>
+
+				{ config.isEnabled( 'simple-payments' ) && (
+					<div
+						className="editor-html-toolbar__insert-content-dropdown-item"
+						onClick={ this.openSimplePaymentsDialog }
+					>
+						<Gridicon icon="money" />
+						<span data-e2e-insert-type="payment-button">{ translate( 'Payment Button' ) }</span>
+					</div>
+				) }
 			</div>
 		);
-	}
-
-	renderSimplePaymentsButton() {
-		const { translate } = this.props;
-
-		if ( ! config.isEnabled( 'simple-payments' ) ) {
-			return null;
-		}
-
-		return (
-			<div
-				className="editor-html-toolbar__insert-content-dropdown-item"
-				onClick={ this.openSimplePaymentsDialog }
-			>
-				<Gridicon icon="money" />
-				<span data-e2e-insert-type="payment-button">{ translate( 'Add Payment Button' ) }</span>
-			</div>
-		);
-	}
+	};
 
 	render() {
 		const { site, translate } = this.props;
@@ -525,9 +537,6 @@ export class EditorHtmlToolbar extends Component {
 			'is-scrollable': this.state.isScrollable,
 			'is-scrolled-full': this.state.isScrolledFull,
 			'has-active-drop-zone': this.props.isDropZoneVisible,
-		} );
-		const insertContentClasses = classNames( 'editor-html-toolbar__insert-content-dropdown', {
-			'is-visible': this.state.showInsertContentMenu,
 		} );
 
 		const buttons = {
@@ -622,27 +631,7 @@ export class EditorHtmlToolbar extends Component {
 							) ) }
 						</div>
 
-						<div className={ insertContentClasses }>
-							<div
-								className="editor-html-toolbar__insert-content-dropdown-item"
-								onClick={ this.openMediaModal }
-							>
-								<Gridicon icon="add-image" />
-								<span data-e2e-insert-type="media">{ translate( 'Add Media' ) }</span>
-							</div>
-
-							{ this.renderExternal() }
-
-							<div
-								className="editor-html-toolbar__insert-content-dropdown-item"
-								onClick={ this.openContactFormDialog }
-							>
-								<Gridicon icon="mention" />
-								<span data-e2e-insert-type="contact-form">{ translate( 'Add Contact Form' ) }</span>
-							</div>
-
-							{ this.renderSimplePaymentsButton() }
-						</div>
+						{ this.renderAddEverythingDropdown() }
 					</div>
 				</div>
 

--- a/client/post-editor/editor-html-toolbar/style.scss
+++ b/client/post-editor/editor-html-toolbar/style.scss
@@ -137,14 +137,27 @@
 		min-width: auto;
 		padding: 6px 12px 8px 10px;
 		text-transform: none;
+
 		.gridicon {
 			height: 24px;
+			margin-right: 4px;
 			vertical-align: sub;
 			width: 24px;
 		}
+
 		span {
 			font-size: 13px;
 			font-weight: 400;
+		}
+
+		@include breakpoint( "<660px" ) {
+			padding: 6px 12px 8px 12px;
+			.gridicon {
+				margin-right: 0;
+			}
+			span {
+				display: none;
+			}
 		}
 	}
 }

--- a/client/post-editor/editor-html-toolbar/style.scss
+++ b/client/post-editor/editor-html-toolbar/style.scss
@@ -130,39 +130,21 @@
 	display: inline-block;
 	height: 38px;
 
-	.editor-html-toolbar__button-insert-media.button {
-		border-right-color: transparent;
-		height: 38px;
-		margin: 0;
-		padding: 6px 7px 8px 7px;
-		.gridicon {
-			height: 24px;
-			width: 24px;
-		}
-	}
-
 	.editor-html-toolbar__button-insert-content-dropdown.button {
 		border-right: 1px solid lighten( $gray, 30% );
 		height: 38px;
 		margin: 0;
 		min-width: auto;
-		padding: 10px 5px 14px 5px;
+		padding: 6px 12px 8px 10px;
+		text-transform: none;
 		.gridicon {
-			color: $gray;
-			height: 14px;
-			width: 14px;
+			height: 24px;
+			vertical-align: sub;
+			width: 24px;
 		}
-	}
-
-	&:hover {
-		.editor-html-toolbar__button-insert-media.button {
-			border-right-color: lighten( $gray, 30% );
-		}
-		.button .gridicon {
-			color: lighten( $gray, 10% );
-		}
-		.button:hover .gridicon {
-			color: $gray-dark;
+		span {
+			font-size: 13px;
+			font-weight: 400;
 		}
 	}
 }
@@ -190,9 +172,9 @@
 			color: $gray;
 		}
 		span {
-			color: darken( $gray, 30% );
+			color: $gray-text-min;
 			display: inline-block;
-			font-size: 14px;
+			font-size: 13px;
 			margin-left: 8px;
 			margin-top: 2px;
 			vertical-align: top;


### PR DESCRIPTION
Follow up to #18719.

Combine "insert content" and "insert special" into one menu item in the HTML Editor toolbar.
All the options previously available in the "insert special" menu are now accessible from the one single button.

| Before | After |
| --- | --- |
|<img width="220" alt="screen shot 2017-10-12 at 10 44 20" src="https://user-images.githubusercontent.com/2070010/31489956-56723070-af3a-11e7-9914-4f93a9977521.png"> | <img width="217" alt="screen shot 2017-10-12 at 10 32 21" src="https://user-images.githubusercontent.com/2070010/31489935-45feadfe-af3a-11e7-83e2-bcc2fe486b3c.png">


### Testing

Compare the Add button in both Visual and HTML editor modes, and make sure they look and work the same.