### PR TITLE
Editor: fix small typo in editor basics tour

### DIFF
--- a/client/layout/guided-tours/tours/editor-basics-tour.js
+++ b/client/layout/guided-tours/tours/editor-basics-tour.js
@@ -71,7 +71,7 @@ export const EditorBasicsTour = makeTour(
 			<p>
 				{ translate(
 					'Click the {{icon/}} to add images and other things, like a contact form. ' +
-						'Sites on the Premium and Business plans can add {{strong}}payment buttons{{/strong}} -- ' +
+						'Sites on the Premium and Business plans can add {{strong}}payment buttons{{/strong}} — ' +
 						'sell tickets, collect donations, accept tips, and more.',
 					{
 						components: {


### PR DESCRIPTION
#18719 changed how the insert button works and, in consequence, also the Guided Tour that explains Editor basics. In this process, an em-dash was entered as "--" when it should have been entered as "—". This PR corrects this typo. 

To test:
- ¯\_(ツ)_/¯