### PR TITLE
Jetpack Connect: Change help button copy for connected site plans

### DIFF
--- a/client/jetpack-connect/happychat-button.jsx
+++ b/client/jetpack-connect/happychat-button.jsx
@@ -6,6 +6,7 @@
 
 import React from 'react';
 import Gridicon from 'gridicons';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
@@ -23,6 +24,7 @@ const JetpackConnectHappychatButton = ( {
 	isChatActive,
 	isChatAvailable,
 	isLoggedIn,
+	text,
 	translate,
 } ) => {
 	if ( ! isEnabled( 'jetpack/happychat' ) || ! isLoggedIn ) {
@@ -44,9 +46,13 @@ const JetpackConnectHappychatButton = ( {
 			borderless={ false }
 		>
 			<HappychatConnection />
-			<Gridicon icon="chat" /> { translate( 'Get help connecting your site' ) }
+			<Gridicon icon="chat" /> { text || translate( 'Get help connecting your site' ) }
 		</HappychatButton>
 	);
+};
+
+JetpackConnectHappychatButton.propTypes = {
+	text: PropTypes.string,
 };
 
 export default connect( state => ( {

--- a/client/jetpack-connect/happychat-button.jsx
+++ b/client/jetpack-connect/happychat-button.jsx
@@ -24,7 +24,7 @@ const JetpackConnectHappychatButton = ( {
 	isChatActive,
 	isChatAvailable,
 	isLoggedIn,
-	text,
+	label,
 	translate,
 } ) => {
 	if ( ! isEnabled( 'jetpack/happychat' ) || ! isLoggedIn ) {
@@ -46,13 +46,13 @@ const JetpackConnectHappychatButton = ( {
 			borderless={ false }
 		>
 			<HappychatConnection />
-			<Gridicon icon="chat" /> { text || translate( 'Get help connecting your site' ) }
+			<Gridicon icon="chat" /> { label || translate( 'Get help connecting your site' ) }
 		</HappychatButton>
 	);
 };
 
 JetpackConnectHappychatButton.propTypes = {
-	text: PropTypes.string,
+	label: PropTypes.string,
 };
 
 export default connect( state => ( {

--- a/client/jetpack-connect/help-button.jsx
+++ b/client/jetpack-connect/help-button.jsx
@@ -12,7 +12,7 @@ import Gridicon from 'gridicons';
 import LoggedOutFormLinkItem from 'components/logged-out-form/link-item';
 import { localize } from 'i18n-calypso';
 
-const JetpackConnectHelpButton = ( { translate, onClick } ) => {
+const JetpackConnectHelpButton = ( { translate, onClick, text } ) => {
 	return (
 		<LoggedOutFormLinkItem
 			className="jetpack-connect__help-button"
@@ -21,13 +21,14 @@ const JetpackConnectHelpButton = ( { translate, onClick } ) => {
 			rel="noopener noreferrer"
 			onClick={ onClick }
 		>
-			<Gridicon icon="help-outline" /> { translate( 'Get help connecting your site' ) }
+			<Gridicon icon="help-outline" /> { text || translate( 'Get help connecting your site' ) }
 		</LoggedOutFormLinkItem>
 	);
 };
 
 JetpackConnectHelpButton.propTypes = {
 	onClick: PropTypes.func,
+	text: PropTypes.string,
 };
 
 export default localize( JetpackConnectHelpButton );

--- a/client/jetpack-connect/help-button.jsx
+++ b/client/jetpack-connect/help-button.jsx
@@ -12,7 +12,7 @@ import Gridicon from 'gridicons';
 import LoggedOutFormLinkItem from 'components/logged-out-form/link-item';
 import { localize } from 'i18n-calypso';
 
-const JetpackConnectHelpButton = ( { translate, onClick, text } ) => {
+const JetpackConnectHelpButton = ( { label, translate, onClick } ) => {
 	return (
 		<LoggedOutFormLinkItem
 			className="jetpack-connect__help-button"
@@ -21,14 +21,14 @@ const JetpackConnectHelpButton = ( { translate, onClick, text } ) => {
 			rel="noopener noreferrer"
 			onClick={ onClick }
 		>
-			<Gridicon icon="help-outline" /> { text || translate( 'Get help connecting your site' ) }
+			<Gridicon icon="help-outline" /> { label || translate( 'Get help connecting your site' ) }
 		</LoggedOutFormLinkItem>
 	);
 };
 
 JetpackConnectHelpButton.propTypes = {
 	onClick: PropTypes.func,
-	text: PropTypes.string,
+	label: PropTypes.string,
 };
 
 export default localize( JetpackConnectHelpButton );

--- a/client/jetpack-connect/plans.jsx
+++ b/client/jetpack-connect/plans.jsx
@@ -281,7 +281,7 @@ class Plans extends Component {
 			return <QueryPlans />;
 		}
 
-		const helpButtonText = translate( 'Need help?' );
+		const helpButtonLabel = translate( 'Need help?' );
 
 		return (
 			<div>
@@ -301,8 +301,8 @@ class Plans extends Component {
 				>
 					<PlansSkipButton onClick={ this.handleSkipButtonClick } isRtl={ isRtlLayout } />
 					<LoggedOutFormLinks>
-						<JetpackConnectHappychatButton text={ helpButtonText }>
-							<HelpButton onClick={ this.handleHelpButtonClick } text={ helpButtonText } />
+						<JetpackConnectHappychatButton label={ helpButtonLabel }>
+							<HelpButton onClick={ this.handleHelpButtonClick } label={ helpButtonLabel } />
 						</JetpackConnectHappychatButton>
 					</LoggedOutFormLinks>
 				</PlansGrid>

--- a/client/jetpack-connect/plans.jsx
+++ b/client/jetpack-connect/plans.jsx
@@ -270,7 +270,7 @@ class Plans extends Component {
 	}
 
 	render() {
-		const { isRtlLayout } = this.props;
+		const { isRtlLayout, translate } = this.props;
 
 		if (
 			this.redirecting ||
@@ -280,6 +280,8 @@ class Plans extends Component {
 		) {
 			return <QueryPlans />;
 		}
+
+		const helpButtonText = translate( 'Need help?' );
 
 		return (
 			<div>
@@ -299,8 +301,8 @@ class Plans extends Component {
 				>
 					<PlansSkipButton onClick={ this.handleSkipButtonClick } isRtl={ isRtlLayout } />
 					<LoggedOutFormLinks>
-						<JetpackConnectHappychatButton>
-							<HelpButton onClick={ this.handleHelpButtonClick } />
+						<JetpackConnectHappychatButton text={ helpButtonText }>
+							<HelpButton onClick={ this.handleHelpButtonClick } text={ helpButtonText } />
 						</JetpackConnectHappychatButton>
 					</LoggedOutFormLinks>
 				</PlansGrid>


### PR DESCRIPTION
### Purpose & how it works

This PR updates the text within the help button on the Jetpack Connect plans page that is displayed for sites when they're already connected. The text was previously saying **Get help connecting your site**, but that doesn't make sense if your site is already connected. So we're changing the text in that case to **Need help?**

To achieve this, we're modifying the current help button and Happychat button to allow the text to be modified.

Fixes #18659.

### Preview

Notice the text of the button at the bottom.

**When Happychat is unavailable**
![](https://cldup.com/PhRP2sNbRf.png)

**When Happychat is available**
![](https://cldup.com/fbquo6zDEU.png)

### To test
* Checkout this branch
* Connect a Jetpack site.
* When you reach the plans page, verify you can see the updated text **Need help?** of the buttons when both HC is available and unavailable.
* Go to http://calypso.localhost:3000/jetpack/connect/store
* Verify the button still says **Get help connecting your site** both when Happychat is available and unavailable.

I'd appreciate a copy review to confirm the new text makes sense, cc @Automattic/editorial 