### PR TITLE
Add MailChimp to plugins installation process.

### DIFF
--- a/client/extensions/woocommerce/app/dashboard/required-plugins-install-view.js
+++ b/client/extensions/woocommerce/app/dashboard/required-plugins-install-view.js
@@ -45,12 +45,13 @@ class RequiredPluginsInstallView extends Component {
 		site: PropTypes.shape( {
 			ID: PropTypes.number.isRequired,
 		} ),
+		skipConfirmation: PropTypes.bool,
 	};
 
 	constructor( props ) {
 		super( props );
 		this.state = {
-			engineState: 'CONFIRMING',
+			engineState: props.skipConfirmation ? 'INITIALIZING' : 'CONFIRMING',
 			toActivate: [],
 			toInstall: [],
 			workingOn: '',
@@ -162,6 +163,9 @@ class RequiredPluginsInstallView extends Component {
 			woocommerce: translate( 'WooCommerce' ),
 			'woocommerce-gateway-stripe': translate( 'WooCommerce Stripe Gateway' ),
 			'woocommerce-services': translate( 'WooCommerce Services' ),
+			'mailchimp-for-woocommerce': translate(
+				'MailChimp is the world’s largest marketing automation platform'
+			),
 		};
 	};
 

--- a/client/extensions/woocommerce/app/dashboard/required-plugins-install-view.js
+++ b/client/extensions/woocommerce/app/dashboard/required-plugins-install-view.js
@@ -45,7 +45,6 @@ class RequiredPluginsInstallView extends Component {
 		site: PropTypes.shape( {
 			ID: PropTypes.number.isRequired,
 		} ),
-		skipConfirmation: PropTypes.bool,
 	};
 
 	constructor( props ) {


### PR DESCRIPTION
### Information

This is a part of #17434 PR that represents installation of MailChimp for the newly created store.
This is provided for review as a separate PR because the original (spike) PR is too big for the review to be comfortable. 

To test these elements in action please refer to #17434.

Integration of MailChimp requires that MailChimp will be installed in the store. MailChimp is added to the list of plugins that should be installed.

This will work nicely for newly created stores. For stores that are already created this component will need to be included into MailChimp setup flow. This is why additional prop was added that allows skipping confirmation - another part of MailChimp UI will act as a confirmation step. With the skip, the `RequiredPluginsInstallView` will jump right into the installation procedure bypassing the second and now awkward confirmation.