### PR TITLE
Jetpack Connect: Make footer link colors consistent

### DIFF
--- a/client/components/logged-out-form/style.scss
+++ b/client/components/logged-out-form/style.scss
@@ -44,7 +44,7 @@
 	}
 
 	&:visited {
-		color: $gray;
+		color: darken( $gray, 20% );
 	}
 
 	&:hover {

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -510,10 +510,6 @@
 	text-align: left;
 	width: 100%;
 
-	&:visited {
-		color: $gray;
-	}
-
 	&:hover {
 		color: $blue-medium;
 	}


### PR DESCRIPTION
This PR removes the `:visited` style from logged out links and updates the footer links throughout Jetpack Connect to be consistent, regardless of whether they've been visited or not.

Fixes #18652.

Before:
![](https://cldup.com/c2ZT-XlMgo.png)

After:
![](https://cldup.com/zhfcihyEce.png)

To test:
* Checkout this branch
* Go through various Jetpack Connect flows, try them with both Happychat enabled and disabled
* Verify all footer links have the same color in their normal and their hover state.