### PR TITLE
Jetpack Connect: Improve spacing between skip and help buttons

### DIFF
--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -494,6 +494,7 @@
 
 .jetpack-connect__plans-nav-buttons {
 	text-align: center;
+	margin-bottom: 17px;
 
 	.button .gridicon {
 		padding-left: 4px;


### PR DESCRIPTION
@seear noticed that we have some inconsistent spacing when we display the skip button and the help button. This PR adds some spacing below the skip button to fix that.

**Before:**
![](https://cldup.com/CnOap3jiJB.png)

**After:**
![](https://cldup.com/4E6QqZGQpX.png)

To test:
* Checkout this branch
* Go to http://calypso.localhost:3000/jetpack/connect/store
* Verify the spacing looks as shown in the screenshot.