### PR TITLE
Editor: Fix flashing restore dialogue when post is trashed

### DIFF
--- a/client/post-editor/editor-delete-post/index.jsx
+++ b/client/post-editor/editor-delete-post/index.jsx
@@ -32,22 +32,20 @@ class EditorDeletePost extends React.Component {
 	};
 
 	sendToTrash = () => {
+		if ( ! utils.userCan( 'delete_post', this.props.post ) ) {
+			return;
+		}
+
 		this.setState( { isTrashing: true } );
 
-		const handleTrashingPost = function( error ) {
-			if ( error ) {
-				this.setState( { isTrashing: false } );
-			}
+		// TODO: REDUX - remove flux actions when whole post-editor is reduxified
+		actions.trash( this.props.post, error => {
+			this.setState( { isTrashing: false } );
 
 			if ( this.props.onTrashingPost ) {
 				this.props.onTrashingPost( error );
 			}
-		}.bind( this );
-
-		if ( utils.userCan( 'delete_post', this.props.post ) ) {
-			// TODO: REDUX - remove flux actions when whole post-editor is reduxified
-			actions.trash( this.props.post, handleTrashingPost );
-		}
+		} );
 	};
 
 	onSendToTrash = () => {

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -735,7 +735,6 @@ export const PostEditor = createReactClass( {
 			recordStat( isPage ? 'page_trashed' : 'post_trashed' );
 			recordEvent( isPage ? 'Clicked Trash Page Button' : 'Clicked Trash Post Button' );
 			this.props.markSaved();
-			this.onClose();
 		}
 	},
 


### PR DESCRIPTION
Currently, when you trash a post, we flash a restore post dialog at the same time we call onClose(). The result is a flashing dialogue that appears briefly before you're navigated to another page. This is happening because we're calling `onClose()` in `onTrashingPost()` [here](https://github.com/Automattic/wp-calypso/blob/master/client/post-editor/post-editor.jsx#L725). The popup briefly appears because `isTrashed` returns `true` temporarily [here](https://github.com/Automattic/wp-calypso/blob/master/client/post-editor/post-editor.jsx#L497).

We could approach this two ways:
1. Don't show the restore dialog at all.
2. Show the restore dialog and wait for a user action.

I opted to go with 2. We already provide the same `onClose()` function to `RestorePostDialog` [here](https://github.com/Automattic/wp-calypso/blob/master/client/post-editor/restore-post-dialog.jsx#L86). As a result, I removed the original call from `onTrashingPost`. This means the user either needs to restore the post or elect to finish trashing it to move on.

We have to add the `this.setState( { isTrashing: false } )` call. Otherwise, the `Move to Trash` action in the bottom right-hand corner remains on `Trashing...` even after you restore a post.

## To test
(Some of these actions are best demonstrated if you throttle your internet connection to slow 3G)

1. Load this branch and open a new post at http://calypso.localhost:3000/post/.
2. Type in some content into the post and manually save it using the save icon in the top left corner.
3. Click the "Move to Trash" link in the bottom right-hand corner.
4. On the confirmation dialogue, press "Move to Trash" to confirm.
5. You should see a "Deleted Post" restore dialog that requires action before you can move forward. Press "Restore." You should see the post restored to the editor.
6. Repeat the "Move to Trash" click and then select "Don't Restore" on the dialog. You should either A) be brought back to the previous page you were on or B) go back to the all posts screen.

## GIF
![trash](https://user-images.githubusercontent.com/7240478/31497451-5ee8ae64-af1c-11e7-881c-7a36aef3ac34.gif)

Fixes: #4795