### PR TITLE
Editor: Wrap lines in EditorDiffViewer

### DIFF
--- a/client/post-editor/editor-diff-viewer/index.jsx
+++ b/client/post-editor/editor-diff-viewer/index.jsx
@@ -18,7 +18,7 @@ import { getPostRevision, getPostRevisionChanges } from 'state/selectors';
 const EditorDiffViewer = ( { contentChanges, revision } ) => (
 	<div className="editor-diff-viewer">
 		<h1 className="editor-diff-viewer__title">{ get( revision, 'title' ) }</h1>
-		<div className="editor-diff-viewer__content">
+		<pre className="editor-diff-viewer__content">
 			{ map( contentChanges, ( change, changeIndex ) => {
 				const changeClassNames = classNames( {
 					'editor-diff-viewer__additions': change.added,
@@ -30,7 +30,7 @@ const EditorDiffViewer = ( { contentChanges, revision } ) => (
 					</span>
 				);
 			} ) }
-		</div>
+		</pre>
 	</div>
 );
 

--- a/client/post-editor/editor-diff-viewer/style.scss
+++ b/client/post-editor/editor-diff-viewer/style.scss
@@ -19,6 +19,14 @@
 
 .editor-diff-viewer__content {
 	padding: 11px;
+	white-space: pre-wrap;
+	// following css is a reset from the general <pre> rule that matches
+	background: transparent;
+	font-family: inherit;
+	font-size: inherit;
+	line-height: inherit;
+	margin-bottom: inherit;
+	overflow: auto;
 }
 
 .editor-diff-viewer__additions {


### PR DESCRIPTION
This PR wraps the content in `<pre>` so newlines are kept.

| Before | After |
| - | - |
| ![diff-multiline-before](https://user-images.githubusercontent.com/156676/31499509-4c8dad3e-af65-11e7-8c75-87e2da988244.gif) | ![diff-multiline](https://user-images.githubusercontent.com/156676/31499406-fb72fd46-af64-11e7-8191-cd5d62d025b2.gif)

Test:
- try any diff with multiple paragraphs