### PR TITLE
Store: Remove TaxJar from installation routine

### DIFF
--- a/client/extensions/woocommerce/app/dashboard/required-plugins-install-view.js
+++ b/client/extensions/woocommerce/app/dashboard/required-plugins-install-view.js
@@ -162,9 +162,6 @@ class RequiredPluginsInstallView extends Component {
 			woocommerce: translate( 'WooCommerce' ),
 			'woocommerce-gateway-stripe': translate( 'WooCommerce Stripe Gateway' ),
 			'woocommerce-services': translate( 'WooCommerce Services' ),
-			'taxjar-simplified-taxes-for-woocommerce': translate(
-				'TaxJar - Sales Tax Automation for WooCommerce'
-			),
 		};
 	};
 


### PR DESCRIPTION
As WooCommerce Services 1.8 subsumes relevant TaxJar functionality, we no longer need the "TaxJar - Sales Tax Automation for WooCommerce" plugin installed. To test:
- uninstall TaxJar and install WCS 1.8 — or preferably, with TaxJar and WooCommerce Services uninstalled and `finished_initial_install_of_required_plugins=0`, re-run Store setup
- verify that sales tax works exactly as before