### PR TITLE
MailChimp API key input.

### DIFF
--- a/client/extensions/woocommerce/app/settings/email/mailchimp/setup-steps/key-input.js
+++ b/client/extensions/woocommerce/app/settings/email/mailchimp/setup-steps/key-input.js
@@ -1,28 +1,29 @@
 /**
  * External dependencies
  */
+import PropTypes from 'prop-types';
 import React from 'react';
 
 /**
  * Internal dependencies
  */
 import FormFieldset from 'components/forms/form-fieldset';
-import FormInputValidation from 'components/forms/form-input-validation';
 import FormLabel from 'components/forms/form-label';
 import FormTextInput from 'components/forms/form-text-input';
+import FormInputValidation from 'components/forms/form-input-validation';
 import { localize } from 'i18n-calypso';
 
-export default localize( ( { translate, onChange, apiKey, isKeyCorrect } ) => (
+const KeyInputStep = localize( ( { translate, onChange, apiKey, isKeyCorrect } ) => (
 	<FormFieldset className="setup-steps__mailchimp-key-input">
 		<div className="setup-steps__mailchimp-api-intro-notice">
 			{ translate( 'Now that you\'re signed in to MailChimp, you need an API key to start the connection process' ) }
 		</div>
 		<div className="setup-steps__mailchimp-api-directions" >
-			<span>{ translate( 'To find your Mailchimp API key, go to ' ) }</span>
+			<span>{ translate( 'To find your Mailchimp API key ' ) }</span>
 			<span className="setup-steps__mailchimp-api-directions-bold">
-				{ translate( 'Settting > Extras > API keys.' ) }
+				{ translate( 'click your profile picture, select \'Account\', and go to Extras > API keys.' ) }
 			</span>
-			<div>{ translate( 'From there, grab an existing key or generate a new on for your store.' ) } </div>
+			<div>{ translate( 'From there, grab an existing key or generate a new one for your store.' ) } </div>
 		</div>
 		<FormLabel required={ ! isKeyCorrect }>
 			{ translate( 'Mailchimp API Key:' ) }
@@ -37,3 +38,11 @@ export default localize( ( { translate, onChange, apiKey, isKeyCorrect } ) => (
 		{ ! isKeyCorrect && <FormInputValidation isError text="Key appears to be invalid" /> }
 	</FormFieldset>
 ) );
+
+KeyInputStep.propTypes = {
+	apiKey: PropTypes.string,
+	isKeyCorrect: PropTypes.bool,
+	onChange: PropTypes.func.isRequired,
+};
+
+export default KeyInputStep;

--- a/client/extensions/woocommerce/app/settings/email/mailchimp/setup-steps/key-input.js
+++ b/client/extensions/woocommerce/app/settings/email/mailchimp/setup-steps/key-input.js
@@ -1,0 +1,39 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import FormFieldset from 'components/forms/form-fieldset';
+import FormInputValidation from 'components/forms/form-input-validation';
+import FormLabel from 'components/forms/form-label';
+import FormTextInput from 'components/forms/form-text-input';
+import { localize } from 'i18n-calypso';
+
+export default localize( ( { translate, onChange, apiKey, isKeyCorrect } ) => (
+	<FormFieldset className="setup-steps__mailchimp-key-input">
+		<div className="setup-steps__mailchimp-api-intro-notice">
+			{ translate( 'Now that you\'re signed in to MailChimp, you need an API key to start the connection process' ) }
+		</div>
+		<div className="setup-steps__mailchimp-api-directions" >
+			<span>{ translate( 'To find your Mailchimp API key, go to ' ) }</span>
+			<span className="setup-steps__mailchimp-api-directions-bold">
+				{ translate( 'Settting > Extras > API keys.' ) }
+			</span>
+			<div>{ translate( 'From there, grab an existing key or generate a new on for your store.' ) } </div>
+		</div>
+		<FormLabel required={ ! isKeyCorrect }>
+			{ translate( 'Mailchimp API Key:' ) }
+		</FormLabel>
+		<FormTextInput
+			name={ 'api_key' }
+			isError={ ! isKeyCorrect }
+			placeholder={ 'Enter your MailChimp API key' }
+			onChange={ onChange }
+			value={ apiKey }
+		/>
+		{ ! isKeyCorrect && <FormInputValidation isError text="Key appears to be invalid" /> }
+	</FormFieldset>
+) );


### PR DESCRIPTION
### Information

This is a part of #17434 PR that represents MailChimp API key input UI view. This is the second step of the setup procedure.
This is provided for review as a separate PR because the original (spike) PR is too big for the review to be comfortable. 

To test this component in action please refer to #17434.

![image](https://user-images.githubusercontent.com/17271089/31504834-44bd3d96-af28-11e7-9e92-4183c908d3b5.png)

![image](https://user-images.githubusercontent.com/17271089/31504842-4999629a-af28-11e7-87e3-b2aa5eb7ec15.png)
