### PR TITLE
Domains: Do separate query when searching for a WordPress.com subdomain.

### DIFF
--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -142,6 +142,10 @@ class DomainSearchResults extends React.Component {
 
 		if ( this.props.suggestions.length ) {
 			suggestionElements = this.props.suggestions.map( function( suggestion, i ) {
+				if ( suggestion.is_placeholder ) {
+					return <DomainSuggestion.Placeholder key={ 'suggestion-' + i } />;
+				}
+
 				return (
 					<DomainRegistrationSuggestion
 						suggestion={ suggestion }


### PR DESCRIPTION
### Overview

Since the query for finding a WordPress.com subdomain can be relatively slow with some query strings that are relatively common (ex. "john"), this PR separates the query to search for an available subdomain from the query to search for suggested custom domain names.

This will allow the results list to begin showing the custom domain suggestions as soon as they are returned rather than having to wait for an available subdomain to be found before any results show.

The first suggestion result in the results list is always the WordPress.com subdomain, so this suggestion will continue to be rendered as a DomainSuggestion placeholder until a result is returned.

### Testing

- Build and run this branch locally.
- Browse to: http://calypso.localhost:3000/start/with-theme/domains-theme-preselected
- Enter a common search term into the search field (ex. "john")
- You should see 9 suggestions populate fairly quickly and then several seconds later, the top suggestion will populate.

Since this same code is used when searching for a domain here: http://calypso.localhost:3000/domains/add/, you should also test this page to make sure that everthing works as expected. (This page should also return 10 results, but does not show a WordPress.com subdomain.)

Note: D7604-code is working to speed up the subdomain suggestions, but this PR is not dependent on that differential.

### Example

![2017-10-12 13 21 25](https://user-images.githubusercontent.com/1379730/31509723-7b3f0746-af50-11e7-87ab-d49e80c41b9f.gif)
