### PR TITLE
DisconnectJetpackDialog: Factor out DisconnectJetpack Component

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -34,7 +34,7 @@
 @import 'blocks/conversation-caterpillar/style';
 @import 'blocks/conversations/style';
 @import 'blocks/daily-post-button/style';
-@import 'blocks/disconnect-jetpack-dialog/style';
+@import 'blocks/disconnect-jetpack/style';
 @import 'blocks/dismissible-card/style';
 @import 'blocks/domain-to-plan-nudge/style';
 @import 'blocks/edit-gravatar/style';

--- a/client/blocks/disconnect-jetpack-dialog/index.jsx
+++ b/client/blocks/disconnect-jetpack-dialog/index.jsx
@@ -242,9 +242,10 @@ class DisconnectJetpackDialog extends PureComponent {
 DisconnectJetpackDialog.displayName = 'DisconnectJetpackDialog';
 
 DisconnectJetpackDialog.propTypes = {
+	isBroken: PropTypes.bool,
 	isVisible: PropTypes.bool,
 	onClose: PropTypes.func,
-	isBroken: PropTypes.bool,
+	redirect: PropTypes.string,
 	siteId: PropTypes.number,
 	// Connected props
 	plan: PropTypes.string,

--- a/client/blocks/disconnect-jetpack-dialog/index.jsx
+++ b/client/blocks/disconnect-jetpack-dialog/index.jsx
@@ -26,6 +26,19 @@ import { getPlanClass } from 'lib/plans/constants';
 import { getSite, getSiteSlug, getSiteTitle } from 'state/sites/selectors';
 
 class DisconnectJetpackDialog extends PureComponent {
+	static displayName = 'DisconnectJetpackDialog';
+
+	static propTypes = {
+		isBroken: PropTypes.bool,
+		isVisible: PropTypes.bool,
+		onClose: PropTypes.func,
+		redirect: PropTypes.string,
+		siteId: PropTypes.number,
+		// Connected props
+		plan: PropTypes.string,
+		siteSlug: PropTypes.string,
+	};
+
 	trackReadMoreClick = () => {
 		this.props.recordGoogleEvent(
 			'Disconnect Jetpack Dialog',
@@ -238,19 +251,6 @@ class DisconnectJetpackDialog extends PureComponent {
 		);
 	}
 }
-
-DisconnectJetpackDialog.displayName = 'DisconnectJetpackDialog';
-
-DisconnectJetpackDialog.propTypes = {
-	isBroken: PropTypes.bool,
-	isVisible: PropTypes.bool,
-	onClose: PropTypes.func,
-	redirect: PropTypes.string,
-	siteId: PropTypes.number,
-	// Connected props
-	plan: PropTypes.string,
-	siteSlug: PropTypes.string,
-};
 
 export default connect(
 	( state, { siteId } ) => {

--- a/client/blocks/disconnect-jetpack/dialog.jsx
+++ b/client/blocks/disconnect-jetpack/dialog.jsx
@@ -1,0 +1,38 @@
+/**
+ * @format
+ *
+ * External dependencies
+ */
+import React from 'react';
+import PropTypes from 'prop-types';
+
+/**
+ * Internal dependencies
+ */
+import Dialog from 'components/dialog';
+import DisconnectJetpack from '.';
+
+const DisconnectJetpackDialog = ( { isBroken, isVisible, onClose, redirect, siteId } ) => (
+	<Dialog
+		isVisible={ isVisible }
+		additionalClassNames="disconnect-jetpack-dialog"
+		onClose={ onClose }
+	>
+		<DisconnectJetpack
+			isBroken={ isBroken }
+			onClose={ onClose }
+			redirect={ redirect }
+			siteId={ siteId }
+		/>
+	</Dialog>
+);
+
+DisconnectJetpackDialog.propTypes = {
+	isBroken: PropTypes.bool,
+	isVisible: PropTypes.bool,
+	onClose: PropTypes.func,
+	redirect: PropTypes.string,
+	siteId: PropTypes.number,
+};
+
+export default DisconnectJetpackDialog;

--- a/client/blocks/disconnect-jetpack/dialog.jsx
+++ b/client/blocks/disconnect-jetpack/dialog.jsx
@@ -10,9 +10,16 @@ import PropTypes from 'prop-types';
  * Internal dependencies
  */
 import Dialog from 'components/dialog';
-import DisconnectJetpack from '.';
+import DisconnectJetpack from './';
 
-const DisconnectJetpackDialog = ( { isBroken, isVisible, onClose, disconnectHref, siteId } ) => (
+const DisconnectJetpackDialog = ( {
+	disconnectHref,
+	isBroken,
+	isVisible,
+	onClose,
+	siteId,
+	stayConnectedHref,
+} ) => (
 	<Dialog
 		isVisible={ isVisible }
 		additionalClassNames="disconnect-jetpack-dialog"
@@ -21,9 +28,10 @@ const DisconnectJetpackDialog = ( { isBroken, isVisible, onClose, disconnectHref
 		<DisconnectJetpack
 			disconnectHref={ disconnectHref }
 			isBroken={ isBroken }
-			onDisconnect={ onClose }
-			onStayConnected={ onClose }
+			onDisconnectClick={ onClose }
+			onStayConnectedClick={ onClose }
 			siteId={ siteId }
+			stayConnectedHref={ stayConnectedHref }
 		/>
 	</Dialog>
 );
@@ -33,7 +41,6 @@ DisconnectJetpackDialog.propTypes = {
 	isBroken: PropTypes.bool,
 	isVisible: PropTypes.bool,
 	onClose: PropTypes.func,
-	redirect: PropTypes.string,
 	siteId: PropTypes.number,
 	stayConnectedHref: PropTypes.string,
 };

--- a/client/blocks/disconnect-jetpack/dialog.jsx
+++ b/client/blocks/disconnect-jetpack/dialog.jsx
@@ -12,27 +12,30 @@ import PropTypes from 'prop-types';
 import Dialog from 'components/dialog';
 import DisconnectJetpack from '.';
 
-const DisconnectJetpackDialog = ( { isBroken, isVisible, onClose, redirect, siteId } ) => (
+const DisconnectJetpackDialog = ( { isBroken, isVisible, onClose, disconnectHref, siteId } ) => (
 	<Dialog
 		isVisible={ isVisible }
 		additionalClassNames="disconnect-jetpack-dialog"
 		onClose={ onClose }
 	>
 		<DisconnectJetpack
+			disconnectHref={ disconnectHref }
 			isBroken={ isBroken }
-			onClose={ onClose }
-			redirect={ redirect }
+			onDisconnect={ onClose }
+			onStayConnected={ onClose }
 			siteId={ siteId }
 		/>
 	</Dialog>
 );
 
 DisconnectJetpackDialog.propTypes = {
+	disconnectHref: PropTypes.string,
 	isBroken: PropTypes.bool,
 	isVisible: PropTypes.bool,
 	onClose: PropTypes.func,
 	redirect: PropTypes.string,
 	siteId: PropTypes.number,
+	stayConnectedHref: PropTypes.string,
 };
 
 export default DisconnectJetpackDialog;

--- a/client/blocks/disconnect-jetpack/docs/example.jsx
+++ b/client/blocks/disconnect-jetpack/docs/example.jsx
@@ -9,7 +9,7 @@ import React, { Component } from 'react';
 /**
  * Internal dependencies
  */
-import DisconnectJetpackDialog from '../';
+import DisconnectJetpackDialog from '../dialog';
 import Card from 'components/card';
 import Button from 'components/button';
 

--- a/client/blocks/disconnect-jetpack/index.jsx
+++ b/client/blocks/disconnect-jetpack/index.jsx
@@ -26,23 +26,30 @@ import { getPlanClass } from 'lib/plans/constants';
 import { getSite, getSiteSlug, getSiteTitle } from 'state/sites/selectors';
 
 class DisconnectJetpack extends PureComponent {
-	static displayName = 'DisconnectJetpack';
-
 	static propTypes = {
 		disconnectHref: PropTypes.string,
 		isBroken: PropTypes.bool,
-		onDisconnect: PropTypes.func,
-		onStayConnected: PropTypes.func,
+		onDisconnectClick: PropTypes.func,
+		onStayConnectedClick: PropTypes.func,
 		siteId: PropTypes.number,
 		stayConnectedHref: PropTypes.string,
 		// Connected props
 		plan: PropTypes.string,
+		site: PropTypes.object,
 		siteSlug: PropTypes.string,
+		siteTitle: PropTypes.string,
+		setAllSitesSelected: PropTypes.func,
+		recordGoogleEvent: PropTypes.func,
+		disconnect: PropTypes.func,
+		successNotice: PropTypes.func,
+		errorNotice: PropTypes.func,
+		infoNotice: PropTypes.func,
+		removeNotice: PropTypes.func,
 	};
 
 	static defaultProps = {
-		onDisconnect: noop,
-		onStayConnected: noop,
+		onDisconnectClick: noop,
+		onStayConnectedClick: noop,
 	};
 
 	trackReadMoreClick = () => {
@@ -143,7 +150,7 @@ class DisconnectJetpack extends PureComponent {
 
 	disconnectJetpack = () => {
 		const {
-			onDisconnect,
+			onDisconnectClick,
 			site,
 			siteId,
 			siteTitle,
@@ -156,7 +163,7 @@ class DisconnectJetpack extends PureComponent {
 			recordGoogleEvent: recordGAEvent,
 		} = this.props;
 
-		onDisconnect();
+		onDisconnectClick();
 
 		recordGAEvent( 'Jetpack', 'Clicked To Confirm Disconnect Jetpack Dialog' );
 
@@ -196,7 +203,7 @@ class DisconnectJetpack extends PureComponent {
 		const {
 			disconnectHref,
 			isBroken,
-			onStayConnected,
+			onStayConnectedClick,
 			siteSlug,
 			stayConnectedHref,
 			translate,
@@ -234,7 +241,7 @@ class DisconnectJetpack extends PureComponent {
 				{ this.planFeatures() }
 
 				<div className="disconnect-jetpack__button-wrap">
-					<Button href={ stayConnectedHref } onClick={ onStayConnected }>
+					<Button href={ stayConnectedHref } onClick={ onStayConnectedClick }>
 						{ translate( 'Stay Connected' ) }
 					</Button>
 					<Button primary scary href={ disconnectHref } onClick={ this.disconnectJetpack }>

--- a/client/blocks/disconnect-jetpack/index.jsx
+++ b/client/blocks/disconnect-jetpack/index.jsx
@@ -8,12 +8,12 @@ import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
 import Gridicon from 'gridicons';
 import { connect } from 'react-redux';
-import page from 'page';
+import { localize } from 'i18n-calypso';
+import { noop } from 'lodash';
 
 /**
  * Internal dependencies
  */
-import { localize } from 'i18n-calypso';
 import Button from 'components/button';
 import Card from 'components/card';
 import { recordGoogleEvent } from 'state/analytics/actions';
@@ -29,14 +29,20 @@ class DisconnectJetpack extends PureComponent {
 	static displayName = 'DisconnectJetpack';
 
 	static propTypes = {
+		disconnectHref: PropTypes.string,
 		isBroken: PropTypes.bool,
-		isVisible: PropTypes.bool,
-		onClose: PropTypes.func,
-		redirect: PropTypes.string,
+		onDisconnect: PropTypes.func,
+		onStayConnected: PropTypes.func,
 		siteId: PropTypes.number,
+		stayConnectedHref: PropTypes.string,
 		// Connected props
 		plan: PropTypes.string,
 		siteSlug: PropTypes.string,
+	};
+
+	static defaultProps = {
+		onDisconnect: noop,
+		onStayConnected: noop,
 	};
 
 	trackReadMoreClick = () => {
@@ -137,8 +143,7 @@ class DisconnectJetpack extends PureComponent {
 
 	disconnectJetpack = () => {
 		const {
-			onClose,
-			redirect,
+			onDisconnect,
 			site,
 			siteId,
 			siteTitle,
@@ -151,7 +156,7 @@ class DisconnectJetpack extends PureComponent {
 			recordGoogleEvent: recordGAEvent,
 		} = this.props;
 
-		onClose();
+		onDisconnect();
 
 		recordGAEvent( 'Jetpack', 'Clicked To Confirm Disconnect Jetpack Dialog' );
 
@@ -185,12 +190,17 @@ class DisconnectJetpack extends PureComponent {
 				recordGAEvent( 'Jetpack', 'Failed Disconnected Site' );
 			}
 		);
-
-		page.redirect( redirect );
 	};
 
 	render() {
-		const { onClose, translate, isBroken, siteSlug } = this.props;
+		const {
+			disconnectHref,
+			isBroken,
+			onStayConnected,
+			siteSlug,
+			stayConnectedHref,
+			translate,
+		} = this.props;
 		if ( isBroken ) {
 			return (
 				<Card className="disconnect-jetpack">
@@ -224,8 +234,10 @@ class DisconnectJetpack extends PureComponent {
 				{ this.planFeatures() }
 
 				<div className="disconnect-jetpack__button-wrap">
-					<Button onClick={ onClose }>{ translate( 'Stay Connected' ) }</Button>
-					<Button primary scary onClick={ this.disconnectJetpack }>
+					<Button href={ stayConnectedHref } onClick={ onStayConnected }>
+						{ translate( 'Stay Connected' ) }
+					</Button>
+					<Button primary scary href={ disconnectHref } onClick={ this.disconnectJetpack }>
 						{ translate( 'Disconnect', {
 							context: 'Jetpack: Action user takes to disconnect Jetpack site from .com',
 						} ) }

--- a/client/blocks/disconnect-jetpack/index.jsx
+++ b/client/blocks/disconnect-jetpack/index.jsx
@@ -14,8 +14,8 @@ import page from 'page';
  * Internal dependencies
  */
 import { localize } from 'i18n-calypso';
-import Dialog from 'components/dialog';
 import Button from 'components/button';
+import Card from 'components/card';
 import { recordGoogleEvent } from 'state/analytics/actions';
 import { disconnect } from 'state/jetpack/connection/actions';
 import { disconnectedSite as disconnectedSiteDeprecated } from 'lib/sites-list/actions';
@@ -25,8 +25,8 @@ import { getCurrentPlan } from 'state/sites/plans/selectors';
 import { getPlanClass } from 'lib/plans/constants';
 import { getSite, getSiteSlug, getSiteTitle } from 'state/sites/selectors';
 
-class DisconnectJetpackDialog extends PureComponent {
-	static displayName = 'DisconnectJetpackDialog';
+class DisconnectJetpack extends PureComponent {
+	static displayName = 'DisconnectJetpack';
 
 	static propTypes = {
 		isBroken: PropTypes.bool,
@@ -128,10 +128,7 @@ class DisconnectJetpackDialog extends PureComponent {
 
 		return features.map( ( freature, index ) => {
 			return (
-				<div
-					key={ 'disconnect-jetpack-dialog__feature-' + index }
-					className="disconnect-jetpack-dialog__feature"
-				>
+				<div key={ 'disconnect-jetpack__feature-' + index } className="disconnect-jetpack__feature">
 					{ freature }
 				</div>
 			);
@@ -193,37 +190,31 @@ class DisconnectJetpackDialog extends PureComponent {
 	};
 
 	render() {
-		const { onClose, isVisible, translate, isBroken, siteSlug } = this.props;
+		const { onClose, translate, isBroken, siteSlug } = this.props;
 		if ( isBroken ) {
 			return (
-				<Dialog
-					isVisible={ isVisible }
-					additionalClassNames="disconnect-jetpack-dialog"
-					onClose={ onClose }
-				>
+				<Card className="disconnect-jetpack">
 					<h1>{ translate( 'Disconnect Jetpack' ) }</h1>
-					<p className="disconnect-jetpack-dialog__highlight">
+					<p className="disconnect-jetpack__highlight">
 						{ translate( 'WordPress.com has not been able to reach %(siteSlug)s for a while.', {
 							args: { siteSlug },
 						} ) }
 					</p>
-					<div className="disconnect-jetpack-dialog__button-wrap">
+					<div className="disconnect-jetpack__button-wrap">
 						<Button primary scary onClick={ this.disconnectJetpack }>
 							{ translate( 'Remove Site' ) }
 						</Button>
 					</div>
-				</Dialog>
+				</Card>
 			);
 		}
 
 		return (
-			<Dialog
-				isVisible={ isVisible }
-				additionalClassNames="disconnect-jetpack-dialog"
-				onClose={ onClose }
-			>
-				<h1>{ translate( 'Disconnect from WordPress.com?' ) }</h1>
-				<p className="disconnect-jetpack-dialog__highlight">
+			<Card className="disconnect-jetpack">
+				<h1 className="disconnect-jetpack__header">
+					{ translate( 'Disconnect from WordPress.com?' ) }
+				</h1>
+				<p className="disconnect-jetpack__highlight">
 					{ translate(
 						'By disconnecting %(siteSlug)s from WordPress.com you will no longer have access to the following:',
 						{ args: { siteSlug } }
@@ -232,7 +223,7 @@ class DisconnectJetpackDialog extends PureComponent {
 
 				{ this.planFeatures() }
 
-				<div className="disconnect-jetpack-dialog__button-wrap">
+				<div className="disconnect-jetpack__button-wrap">
 					<Button onClick={ onClose }>{ translate( 'Stay Connected' ) }</Button>
 					<Button primary scary onClick={ this.disconnectJetpack }>
 						{ translate( 'Disconnect', {
@@ -242,12 +233,12 @@ class DisconnectJetpackDialog extends PureComponent {
 				</div>
 				<a
 					onClick={ this.trackReadMoreClick }
-					className="disconnect-jetpack-dialog__more-info-link"
+					className="disconnect-jetpack__more-info-link"
 					href="https://jetpack.com/features/"
 				>
 					{ translate( 'Read More about Jetpack benefits' ) }
 				</a>
-			</Dialog>
+			</Card>
 		);
 	}
 }
@@ -273,4 +264,4 @@ export default connect(
 		infoNotice,
 		removeNotice,
 	}
-)( localize( DisconnectJetpackDialog ) );
+)( localize( DisconnectJetpack ) );

--- a/client/blocks/disconnect-jetpack/index.jsx
+++ b/client/blocks/disconnect-jetpack/index.jsx
@@ -21,7 +21,7 @@ import { disconnect } from 'state/jetpack/connection/actions';
 import { disconnectedSite as disconnectedSiteDeprecated } from 'lib/sites-list/actions';
 import { setAllSitesSelected } from 'state/ui/actions';
 import { successNotice, errorNotice, infoNotice, removeNotice } from 'state/notices/actions';
-import { getCurrentPlan } from 'state/sites/plans/selectors';
+import { getSitePlanSlug } from 'state/sites/selectors';
 import { getPlanClass } from 'lib/plans/constants';
 import { getSite, getSiteSlug, getSiteTitle } from 'state/sites/selectors';
 
@@ -257,8 +257,8 @@ class DisconnectJetpack extends PureComponent {
 
 export default connect(
 	( state, { siteId } ) => {
-		const plan = getCurrentPlan( state, siteId );
-		const planClass = plan && plan.productSlug ? getPlanClass( plan.productSlug ) : 'is-free-plan';
+		const planSlug = getSitePlanSlug( state, siteId );
+		const planClass = planSlug ? getPlanClass( planSlug ) : 'is-free-plan';
 
 		return {
 			plan: planClass,

--- a/client/blocks/disconnect-jetpack/style.scss
+++ b/client/blocks/disconnect-jetpack/style.scss
@@ -1,37 +1,35 @@
+/** @format */
 
-.disconnect-jetpack-dialog.dialog.card {
+.disconnect-jetpack {
 	text-align: center;
 	max-width: 400px;
-}
+	color: darken($gray, 20%);
 
-.disconnect-jetpack-dialog .dialog__content {
-	color: darken( $gray, 20% );
-
-	h1 {
+	.disconnect-jetpack__header {
 		color: $gray-dark;
 		font-size: 24px;
 		font-weight: 300;
 		height: 2em;
 		line-height: 32px;
-		margin-top: .5em;
-		margin-bottom: .5em;
+		margin-top: 0.5em;
+		margin-bottom: 0.5em;
 	}
 }
 
-.disconnect-jetpack-dialog__highlight {
-	color: darken( $gray, 10% );
+.disconnect-jetpack__highlight {
+	color: darken($gray, 10%);
 	margin-bottom: 1.5em;
 	font-size: 16px;
 }
 
-.disconnect-jetpack-dialog__feature {
+.disconnect-jetpack__feature {
 	padding: 14px 24px 14px 44px;
 	text-align: left;
 	font-size: 13px;
-	border-bottom: 1px solid lighten( $gray, 25% );
+	border-bottom: 1px solid lighten($gray, 25%);
 
 	&:first-of-type {
-		border-top: 1px solid lighten( $gray, 25% );
+		border-top: 1px solid lighten($gray, 25%);
 	}
 
 	.gridicon {
@@ -42,22 +40,34 @@
 	}
 }
 
-.disconnect-jetpack-dialog__button-wrap {
+.disconnect-jetpack__button-wrap {
 	margin-top: 32px;
-	margin-bottom:16px;
+	margin-bottom: 16px;
 
 	.button {
 		margin: 0 4px;
 	}
 }
 
-.disconnect-jetpack-dialog__more-info-link {
+.disconnect-jetpack__more-info-link {
 	font-size: 13px;
+}
+
+// Dialog
+
+.disconnect-jetpack-dialog .dialog__content {
+	padding: 0;
+}
+
+.disconnect-jetpack-dialog {
+	.disconnect-jetpack {
+		margin-bottom: 0;
+	}
 }
 
 .disconnect-jetpack-dialog__dialog__action-buttons {
 	overflow: hidden;
-	border-top: 1px solid lighten( $gray, 30% );
+	border-top: 1px solid lighten($gray, 30%);
 	padding: 16px;
 	margin: 0 -24px -24px;
 	text-align: right;

--- a/client/devdocs/design/blocks.jsx
+++ b/client/devdocs/design/blocks.jsx
@@ -26,7 +26,7 @@ import CalendarPopover from 'blocks/calendar-popover/docs/example';
 import AuthorSelector from 'blocks/author-selector/docs/example';
 import CommentButtons from 'blocks/comment-button/docs/example';
 import CommentDetail from 'blocks/comment-detail/docs/example';
-import DisconnectJetpackDialog from 'blocks/disconnect-jetpack-dialog/docs/example';
+import DisconnectJetpackDialog from 'blocks/disconnect-jetpack/docs/example';
 import FollowButton from 'blocks/follow-button/docs/example';
 import LikeButtons from 'blocks/like-button/docs/example';
 import PostSchedule from 'components/post-schedule/docs/example';

--- a/client/my-sites/plugins/disconnect-jetpack/disconnect-jetpack-button.jsx
+++ b/client/my-sites/plugins/disconnect-jetpack/disconnect-jetpack-button.jsx
@@ -13,7 +13,7 @@ import PropTypes from 'prop-types';
  * Internal dependencies
  */
 import Button from 'components/button';
-import DisconnectJetpackDialog from 'blocks/disconnect-jetpack-dialog';
+import DisconnectJetpackDialog from 'blocks/disconnect-jetpack/dialog';
 import QuerySitePlans from 'components/data/query-site-plans';
 
 class DisconnectJetpackButton extends Component {

--- a/client/my-sites/plugins/disconnect-jetpack/disconnect-jetpack-button.jsx
+++ b/client/my-sites/plugins/disconnect-jetpack/disconnect-jetpack-button.jsx
@@ -75,7 +75,7 @@ class DisconnectJetpackButton extends Component {
 					onClose={ this.hideDialog }
 					isBroken={ false }
 					siteId={ site.ID }
-					redirect={ this.props.redirect }
+					disconnectHref={ this.props.redirect }
 				/>
 			</Button>
 		);

--- a/client/my-sites/site-settings/manage-connection/disconnect-site-link.jsx
+++ b/client/my-sites/site-settings/manage-connection/disconnect-site-link.jsx
@@ -62,7 +62,7 @@ class DisconnectSiteLink extends Component {
 					onClose={ this.handleHideDialog }
 					isBroken={ false }
 					siteId={ siteId }
-					redirect="/stats"
+					disconnectHref="/stats"
 				/>
 			</div>
 		);

--- a/client/my-sites/site-settings/manage-connection/disconnect-site-link.jsx
+++ b/client/my-sites/site-settings/manage-connection/disconnect-site-link.jsx
@@ -11,7 +11,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import DisconnectJetpackDialog from 'blocks/disconnect-jetpack-dialog';
+import DisconnectJetpackDialog from 'blocks/disconnect-jetpack/dialog';
 import QuerySitePlans from 'components/data/query-site-plans';
 import SiteToolsLink from 'my-sites/site-settings/site-tools/link';
 import { getSelectedSiteId } from 'state/ui/selectors';


### PR DESCRIPTION
This is needed for #18796, where we're going to display the contents of the `DisconnectJetpackDialog`, but as part of a multi-step flow, not a dialog.

The structure of `DisconnectJetpackDialog` fortunately lends itself to splitting into a component proper, and a `Dialog` wrapper. Note that props have been re-arranged a little: E.g. the concept of an `onClose` prop doesn't make sense for the component, so we're passing `onDisconnect` and `onStayConnected` instead. The Dialog OTOH continues to use an `onClose` prop (and sets both `onDisconnect` and `onStayConnected` to `onClose`).

To test: Same as for #18764.