### PR TITLE
Add CSS assets to preloading for wpcalypso profiling

### DIFF
--- a/server/pages/index.jade
+++ b/server/pages/index.jade
@@ -98,26 +98,31 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class=isFluidWidth ? 'is-fluid-width'
 				link(rel='preconnect' href='https://accounts.google.com')
 				link(rel='preconnect' href='https://stats.g.doubleclick.net')
 
-		if shouldUsePreload
-			//- Preload our stylesheets
+		if shouldUseStylePreloadExternal
 			link(rel='preload' as='style' href='https://fonts.googleapis.com/css?family=Noto+Serif:400,400i,700,700i&subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext,vietnamese')
 			if shouldUseSingleCDN
 				link(rel='preload' as='style' href='//s0.wp.com/i/noticons/noticons.css?v=20150727')
 			else 
 				link(rel='preload' as='style' href='//s1.wp.com/i/noticons/noticons.css?v=20150727')
+
+		if shouldUseStylePreloadSection
 			if isRTL
-				link(rel='preload' as='style' href=urls['style-rtl.css'])
 				if sectionCssRtl
 					link(rel='preload' as='style' href=sectionCssRtl)
+			else
+				if sectionCss
+					link(rel='preload' as='style' href=sectionCss)
+		
+		if shouldUseStylePreloadCommon
+			if isRTL
+				link(rel='preload' as='style' href=urls['style-rtl.css'])
 			else
 				if 'development' === env || isDebug
 					link(rel='preload' as='style' href=urls['style-debug.css'])
 				else
 					link(rel='preload' as='style' href=urls['style.css'])
 
-				if sectionCss
-					link(rel='preload' as='style' href=sectionCss)
-
+		if shouldUseScriptPreload
 			//- Preload our scripts
 			if i18nLocaleScript
 				link(rel='preload' as='script' href=i18nLocaleScript)

--- a/server/pages/index.jade
+++ b/server/pages/index.jade
@@ -82,9 +82,6 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class=isFluidWidth ? 'is-fluid-width'
 			link(rel='preconnect' href='//s0.wp.com')
 			if ! shouldUseSingleCDN
 				link(rel='preconnect' href='//s1.wp.com')
-
-			//- Preconnect to Google's font CDN. Note the mandatory crossorigin attr for fonts.
-			link(rel='preconnect' crossorigin href='https://fonts.gstatic.com')
 			
 			//- Preconnect to our API.
 			link(rel='preconnect' href='https://public-api.wordpress.com')

--- a/server/pages/index.jade
+++ b/server/pages/index.jade
@@ -98,8 +98,27 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class=isFluidWidth ? 'is-fluid-width'
 				link(rel='preconnect' href='https://accounts.google.com')
 				link(rel='preconnect' href='https://stats.g.doubleclick.net')
 
-		//- Preload our scripts
 		if shouldUsePreload
+			//- Preload our stylesheets
+			link(rel='preload' as='style' href='https://fonts.googleapis.com/css?family=Noto+Serif:400,400i,700,700i&subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext,vietnamese')
+			if shouldUseSingleCDN
+				link(rel='preload' as='style' href='//s0.wp.com/i/noticons/noticons.css?v=20150727')
+			else 
+				link(rel='preload' as='style' href='//s1.wp.com/i/noticons/noticons.css?v=20150727')
+			if isRTL
+				link(rel='preload' as='style' href=urls['style-rtl.css'])
+				if sectionCssRtl
+					link(rel='preload' as='style' href=sectionCssRtl)
+			else
+				if 'development' === env || isDebug
+					link(rel='preload' as='style' href=urls['style-debug.css'])
+				else
+					link(rel='preload' as='style' href=urls['style.css'])
+
+				if sectionCss
+					link(rel='preload' as='style' href=sectionCss)
+
+			//- Preload our scripts
 			if i18nLocaleScript
 				link(rel='preload' as='script' href=i18nLocaleScript)
 

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -193,7 +193,14 @@ function getDefaultContext( request ) {
 		shouldUsePreconnect: config.isEnabled( 'try/preconnect' ) && !! request.query.enablePreconnect,
 		shouldUsePreconnectGoogle:
 			config.isEnabled( 'try/preconnect' ) && !! request.query.enablePreconnectGoogle,
-		shouldUsePreload: config.isEnabled( 'try/preload' ) && !! request.query.enablePreload,
+		shouldUseScriptPreload:
+			config.isEnabled( 'try/preload' ) && !! request.query.enableScriptPreload,
+		shouldUseStylePreloadCommon:
+			config.isEnabled( 'try/preload' ) && !! request.query.enableStylePreloadCommon,
+		shouldUseStylePreloadExternal:
+			config.isEnabled( 'try/preload' ) && !! request.query.enableStylePreloadExternal,
+		shouldUseStylePreloadSection:
+			config.isEnabled( 'try/preload' ) && !! request.query.enableStylePreloadSection,
 		shouldUseSingleCDN,
 		bodyClasses,
 		sectionCss,


### PR DESCRIPTION
Following up on #18512, this PR adds the ability to enable `preload` directives for our CSS assets.

It also removes a redundant `preconnect` resource hint for Google Font's CDN, which was already being specified by the Link header on the Google Font's CSS file.

I've tested this on a local Docker instance using production configuration, which unfortunately lacks HTTP/2 support due to lack of nginx. I would like to deploy to wpcalypso for profiling.