### PR TITLE
Updated the list of suggested themes. Fixes #18798

### DIFF
--- a/client/my-sites/theme/themes-related-card/index.jsx
+++ b/client/my-sites/theme/themes-related-card/index.jsx
@@ -26,16 +26,16 @@ const ThemesRelatedCard = React.createClass( {
 
 	getRelatedThemes() {
 		let themes = new Set( [
-			'twentysixteen',
-			'rowling',
+			'independent-publisher-2',
 			'hemingway-rewritten',
-			'gazette',
-			'intergalactic-2',
-			'isola',
-			'edin',
-			'sela',
-			'pique',
-			'harmonic',
+			'penscratch-2',
+			'cols',
+			'twentyfifteen',
+			'bushwick',
+			'radcliffe-2',
+			'karuna',
+			'dara',
+			'lodestar',
 		] );
 
 		//Remove current theme so we will not show it as related


### PR DESCRIPTION
This PR updates the list of suggested themes to match the themes from the signup flow. This edit was [suggested here](https://github.com/Automattic/wp-calypso/pull/18721).