### PR TITLE
Data Layer: Update comments to use the new v1.1 comments tree endpoint.

### DIFF
--- a/client/state/data-layer/wpcom/sites/comments-tree/index.js
+++ b/client/state/data-layer/wpcom/sites/comments-tree/index.js
@@ -35,8 +35,8 @@ export const fetchCommentsTreeForSite = ( { dispatch }, action ) => {
 	);
 };
 
-const mapPosts = ( commentIds, postId ) => {
-	postId = parseInt( postId, 10 );
+const mapPosts = ( commentIds, apiPostId ) => {
+	const postId = parseInt( apiPostId, 10 );
 	const [ topLevelIds, replyIds ] = commentIds;
 
 	return flatten( [

--- a/client/state/data-layer/wpcom/sites/comments-tree/index.js
+++ b/client/state/data-layer/wpcom/sites/comments-tree/index.js
@@ -5,7 +5,7 @@
  */
 
 import { translate } from 'i18n-calypso';
-import { map, flatMap } from 'lodash';
+import { map, flatMap, flatten } from 'lodash';
 
 /**
  * Internal dependencies
@@ -37,18 +37,12 @@ export const fetchCommentsTreeForSite = ( { dispatch }, action ) => {
 
 const mapPosts = ( commentIds, postId ) => {
 	postId = parseInt( postId, 10 );
+	const [ topLevelIds, replyIds ] = commentIds;
 
-	const topLevelComments = map( commentIds[ 0 ], commentId => [ commentId, postId, 0 ] );
-
-	const commentReplies = commentIds[ 1 ]
-		? map( commentIds[ 1 ], ( [ commentId, commentParentId ] ) => [
-				commentId,
-				postId,
-				commentParentId,
-			] )
-		: [];
-
-	return topLevelComments.concat( commentReplies );
+	return flatten( [
+		topLevelIds.map( commentId => [ commentId, postId, 0 ] ),
+		replyIds.map( ( [ commentId, commentParentId ] ) => [ commentId, postId, commentParentId ] ),
+	] );
 };
 
 const mapTree = ( tree, status, type ) => {

--- a/client/state/data-layer/wpcom/sites/comments-tree/index.js
+++ b/client/state/data-layer/wpcom/sites/comments-tree/index.js
@@ -27,7 +27,7 @@ export const fetchCommentsTreeForSite = ( { dispatch }, action ) => {
 				path: `/sites/${ siteId }/comments-tree`,
 				apiVersion: '1.1',
 				query: {
-					status,
+					status: 'unapproved' === status ? 'pending' : status,
 				},
 			},
 			action

--- a/client/state/data-layer/wpcom/sites/comments-tree/test/index.js
+++ b/client/state/data-layer/wpcom/sites/comments-tree/test/index.js
@@ -27,7 +27,7 @@ describe( 'comments-tree', () => {
 						method: 'GET',
 						path: '/sites/77203074/comments-tree',
 						query: { status: 'approved' },
-						apiVersion: '1',
+						apiVersion: '1.1',
 					},
 					action
 				)
@@ -39,9 +39,9 @@ describe( 'comments-tree', () => {
 		test( 'should dispatch comment tree updates', () => {
 			const dispatch = spy();
 			addCommentsTree( { dispatch }, action, {
-				comments_tree: [ [ 2, 1, 0 ] ],
-				pingbacks_tree: [ [ 3, 1, 0 ] ],
-				trackbacks_tree: [ [ 4, 1, 0 ] ],
+				comments_tree: { 1: [ [ 2 ], [] ] },
+				pingbacks_tree: { 1: [ [ 3 ], [] ] },
+				trackbacks_tree: { 1: [ [ 4 ], [] ] },
 			} );
 			expect( dispatch ).to.have.been.calledOnce;
 			expect( dispatch ).to.have.been.calledWith( {


### PR DESCRIPTION
A new, more efficient v1.1 comments tree endpoint has been added, so this PR updates the data layer to work with the new endpoint's response shape. Note that the new endpoint also now accepts `unapproved` in addition to `pending` for the `status` param.

See: https://github.com/Automattic/jetpack/pull/7933

Fixes #17547 

**Testing**
* Load this PR, and do a smoke test through `/comments` on a dotcom site (the new endpoint is already in production on dotcom). If anything's wrong, it should be glaringly apparent right away.
* To test with a Jetpack site, apply https://github.com/Automattic/jetpack/pull/7933 to the site, as well as https://github.com/Automattic/wp-calypso/pull/17956 to make Calypso request the comments tree from the remote site.