### PR TITLE
Editor: clean up insert content tooltip

### DIFF
--- a/client/components/tinymce/plugins/insert-menu/plugin.jsx
+++ b/client/components/tinymce/plugins/insert-menu/plugin.jsx
@@ -34,29 +34,6 @@ const initialize = editor => {
 			insertContentElm.innerHTML = renderToString(
 				<GridiconButton icon="add-outline" label={ i18n.translate( 'Add' ) } />
 			);
-
-			const addTooltipListener = ( el, text ) => {
-				el.addEventListener( 'mouseenter', () => {
-					// We need to select the tooltip during the `mouseenter` event and not outside.
-					// Otherwise, Tinymce renders an empty tooltip somewhere in the editor.
-					// The following code is very inspired by the `mouseenter` handler in TinyMCE
-					// (tinymce.core.ui.Widget.init)
-					const btnTooltip = this.tooltip();
-
-					btnTooltip.text( text );
-
-					const rel = btnTooltip.testMoveRel( el, [ 'bc-tc', 'bc-tl', 'bc-tr' ] );
-
-					btnTooltip.classes.toggle( 'tooltip-n', rel === 'bc-tc' );
-					btnTooltip.classes.toggle( 'tooltip-nw', rel === 'bc-tl' );
-					btnTooltip.classes.toggle( 'tooltip-ne', rel === 'bc-tr' );
-
-					btnTooltip.moveRel( el, rel );
-				} );
-			};
-
-			// Listen to `mouseenter` events on the (+)
-			addTooltipListener( insertContentElm, i18n.translate( 'Add content' ) );
 		},
 	} );
 };


### PR DESCRIPTION
This removes the custom logic to show the "Add content" tooltip on the "+ Add" button. It returns the tooltip logic back to TinyMCE. The custom behavior is no longer needed since we are no longer using a split menu button.

fixes #18781

**Testing**

- The "Add content" tool should appear when hovering over the (+) Add button in the editor toolbar
- On iOS the tooltip does not appear but this is the expected behavior for tinyMCE
