### PR TITLE
Reader: fix convos to display just-added comments

### DIFF
--- a/client/blocks/conversations/list.jsx
+++ b/client/blocks/conversations/list.jsx
@@ -156,8 +156,10 @@ export class ConversationCommentList extends React.Component {
 
 		const minId = min( commentIds );
 		const startingCommentIds = sortedComments
-			.map( comment => comment.ID )
-			.filter( id => id >= minId );
+			.filter( comment => {
+				return comment.ID >= minId || comment.isPlaceholder;
+			} )
+			.map( comment => comment.ID );
 
 		const parentIds = compact(
 			map( startingCommentIds, id => this.getParentId( commentsTree, id ) )


### PR DESCRIPTION
In Conversations, reveal newly-posted comments and attempted new comments with errors. Prior to this PR, they were hidden from view.

Fixes https://github.com/Automattic/wp-calypso/issues/17957, https://github.com/Automattic/wp-calypso/issues/18701 and #18595.

### To test 

Try posting a new comment in http://calypso.localhost:3000/read/conversations and make sure it appears.

Try scuppering the `replies/new` endpoint (by doing a global find and replace for `replies/new` with `replies/broken` for example), and check that you're able to edit and retry your comment posting.

### Notes

@samouri says:

> Its pretty hard to figure out the new commentId from the data-layer to expand.
> What I've done here is assume that any comments newer that the ones attached to the postKey are essentially by definition ones you have added.  So render those.