### PR TITLE
Reader: show likes on hover

### DIFF
--- a/client/blocks/reader-post-actions/index.jsx
+++ b/client/blocks/reader-post-actions/index.jsx
@@ -21,125 +21,147 @@ import { userCan } from 'lib/posts/utils';
 import * as stats from 'reader/stats';
 import { localize } from 'i18n-calypso';
 import ReaderVisitLink from 'blocks/reader-visit-link';
+import Popover from 'components/popover';
+import PostLikes from 'blocks/post-likes';
 
-const ReaderPostActions = props => {
-	const {
-		post,
-		site,
-		onCommentClick,
-		showEdit,
-		showVisit,
-		showMenu,
-		showMenuFollow,
-		iconSize,
-		className,
-		visitUrl,
-		fullPost,
-		translate,
-	} = props;
-
-	const onEditClick = () => {
-		stats.recordAction( 'edit_post' );
-		stats.recordGaEvent( 'Clicked Edit Post', 'full_post' );
-		stats.recordTrackForPost( 'calypso_reader_edit_post_clicked', post );
+class ReaderPostActions extends React.Component {
+	static propTypes = {
+		post: PropTypes.object.isRequired,
+		site: PropTypes.object,
+		onCommentClick: PropTypes.func,
+		showEdit: PropTypes.bool,
+		iconSize: PropTypes.number,
+		showMenu: PropTypes.bool,
+		showMenuFollow: PropTypes.bool,
+		visitUrl: PropTypes.string,
+		fullPost: PropTypes.bool,
 	};
 
-	function onPermalinkVisit() {
-		stats.recordPermalinkClick( 'card', post );
-	}
+	static defaultProps = {
+		showEdit: true,
+		showVisit: false,
+		showMenu: false,
+		iconSize: 24,
+		showMenuFollow: true,
+	};
 
-	const listClassnames = classnames( 'reader-post-actions', className );
+	state = { showLikesTooltip: false };
+	showLikesTooltip = () => this.setState( { showLikesTooltip: true } );
+	hideLikesTooltip = () => this.setState( { showLikesTooltip: false } );
+	handleLikeButtonMount = ref => ( this.likeButtonRef = ref );
 
-	/* eslint-disable react/jsx-no-target-blank */
-	return (
-		<ul className={ listClassnames }>
-			{ showVisit && (
-				<li className="reader-post-actions__item reader-post-actions__visit">
-					<ReaderVisitLink
-						href={ visitUrl || post.URL }
-						iconSize={ iconSize }
-						onClick={ onPermalinkVisit }
+	render() {
+		const {
+			post,
+			site,
+			onCommentClick,
+			showEdit,
+			showVisit,
+			showMenu,
+			showMenuFollow,
+			iconSize,
+			className,
+			visitUrl,
+			fullPost,
+			translate,
+		} = this.props;
+
+		const onEditClick = () => {
+			stats.recordAction( 'edit_post' );
+			stats.recordGaEvent( 'Clicked Edit Post', 'full_post' );
+			stats.recordTrackForPost( 'calypso_reader_edit_post_clicked', post );
+		};
+
+		function onPermalinkVisit() {
+			stats.recordPermalinkClick( 'card', post );
+		}
+
+		const listClassnames = classnames( 'reader-post-actions', className );
+
+		/* eslint-disable react/jsx-no-target-blank */
+		return (
+			<ul className={ listClassnames }>
+				{ showVisit && (
+					<li className="reader-post-actions__item reader-post-actions__visit">
+						<ReaderVisitLink
+							href={ visitUrl || post.URL }
+							iconSize={ iconSize }
+							onClick={ onPermalinkVisit }
+						>
+							{ translate( 'Visit' ) }
+						</ReaderVisitLink>
+					</li>
+				) }
+				{ showEdit &&
+				site &&
+				userCan( 'edit_post', post ) && (
+					<li className="reader-post-actions__item">
+						<PostEditButton
+							post={ post }
+							site={ site }
+							onClick={ onEditClick }
+							iconSize={ iconSize }
+						/>
+					</li>
+				) }
+				{ shouldShowShare( post ) && (
+					<li className="reader-post-actions__item">
+						<ShareButton post={ post } position="bottom" tagName="div" iconSize={ iconSize } />
+					</li>
+				) }
+				{ shouldShowComments( post ) && (
+					<li className="reader-post-actions__item">
+						<CommentButton
+							key="comment-button"
+							commentCount={ post.discussion.comment_count }
+							onClick={ onCommentClick }
+							tagName="div"
+							size={ iconSize }
+						/>
+					</li>
+				) }
+				{ shouldShowLikes( post ) && (
+					<li
+						className="reader-post-actions__item"
+						onMouseOver={ this.showLikesTooltip }
+						onMouseOut={ this.hideLikesTooltip }
+						ref={ this.handleLikeButtonMount }
 					>
-						{ translate( 'Visit' ) }
-					</ReaderVisitLink>
-				</li>
-			) }
-			{ showEdit &&
-			site &&
-			userCan( 'edit_post', post ) && (
-				<li className="reader-post-actions__item">
-					<PostEditButton
-						post={ post }
-						site={ site }
-						onClick={ onEditClick }
-						iconSize={ iconSize }
-					/>
-				</li>
-			) }
-			{ shouldShowShare( post ) && (
-				<li className="reader-post-actions__item">
-					<ShareButton post={ post } position="bottom" tagName="div" iconSize={ iconSize } />
-				</li>
-			) }
-			{ shouldShowComments( post ) && (
-				<li className="reader-post-actions__item">
-					<CommentButton
-						key="comment-button"
-						commentCount={ post.discussion.comment_count }
-						onClick={ onCommentClick }
-						tagName="div"
-						size={ iconSize }
-					/>
-				</li>
-			) }
-			{ shouldShowLikes( post ) && (
-				<li className="reader-post-actions__item">
-					<LikeButton
-						key="like-button"
-						siteId={ +post.site_ID }
-						postId={ +post.ID }
-						post={ post }
-						site={ site }
-						fullPost={ fullPost }
-						tagName="div"
-						forceCounter={ true }
-						iconSize={ iconSize }
-						showZeroCount={ false }
-					/>
-				</li>
-			) }
-			{ showMenu && (
-				<li className="reader-post-actions__item">
-					<ReaderPostOptionsMenu
-						className="ignore-click"
-						showFollow={ showMenuFollow }
-						post={ post }
-					/>
-				</li>
-			) }
-		</ul>
-	);
-	/* eslint-enable react/jsx-no-target-blank */
-};
-
-ReaderPostActions.propTypes = {
-	post: PropTypes.object.isRequired,
-	site: PropTypes.object,
-	onCommentClick: PropTypes.func,
-	showEdit: PropTypes.bool,
-	iconSize: PropTypes.number,
-	showMenu: PropTypes.bool,
-	showMenuFollow: PropTypes.bool,
-	visitUrl: PropTypes.string,
-	fullPost: PropTypes.bool,
-};
-
-ReaderPostActions.defaultProps = {
-	showEdit: true,
-	showVisit: false,
-	showMenu: false,
-	iconSize: 24,
-	showMenuFollow: true,
-};
+						<LikeButton
+							key="like-button"
+							siteId={ +post.site_ID }
+							postId={ +post.ID }
+							post={ post }
+							site={ site }
+							fullPost={ fullPost }
+							tagName="div"
+							forceCounter={ true }
+							iconSize={ iconSize }
+							showZeroCount={ false }
+						/>
+						<Popover
+							isVisible={ this.state.showLikesTooltip }
+							onClose={ this.hideLikesTooltip }
+							context={ this.likeButtonRef }
+							postition="top"
+						>
+							<PostLikes siteId={ post.site_ID } postId={ post.ID } />
+						</Popover>
+					</li>
+				) }
+				{ showMenu && (
+					<li className="reader-post-actions__item">
+						<ReaderPostOptionsMenu
+							className="ignore-click"
+							showFollow={ showMenuFollow }
+							post={ post }
+						/>
+					</li>
+				) }
+			</ul>
+		);
+		/* eslint-enable react/jsx-no-target-blank */
+	}
+}
 
 export default localize( ReaderPostActions );

--- a/client/blocks/reader-post-actions/style.scss
+++ b/client/blocks/reader-post-actions/style.scss
@@ -9,6 +9,23 @@
 	margin: 10px 0 0;
 }
 
+.reader-post-actions__liker {
+	display: flex;
+	max-height: 24px;
+	padding-top: 10px;
+	padding-left: 10px;
+	padding-right: 10px;
+}
+.reader-post-actions__liker:last-child {
+	padding-bottom: 10px;
+}
+
+.reader-post-actions__liker-name {
+	// display: flex;
+	font-size: 14px;
+	padding-left: 10px;
+}
+
 .reader-post-actions .reader-post-actions__item {
 	margin-right: 13px;
 

--- a/client/reader/like-button/index.jsx
+++ b/client/reader/like-button/index.jsx
@@ -3,6 +3,7 @@
  * External dependencies
  */
 import React from 'react';
+import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -13,6 +14,10 @@ import { markSeen } from 'lib/feed-post-store/actions';
 import { recordAction, recordGaEvent, recordTrackForPost } from 'reader/stats';
 
 class ReaderLikeButton extends React.Component {
+	static defaultProps = {
+		getRef: noop,
+	};
+
 	recordLikeToggle = liked => {
 		const post =
 			this.props.post ||
@@ -34,7 +39,11 @@ class ReaderLikeButton extends React.Component {
 	};
 
 	render() {
-		return <LikeButtonContainer { ...this.props } onLikeToggle={ this.recordLikeToggle } />;
+		return (
+			<div ref={ this.props.getRef }>
+				<LikeButtonContainer { ...this.props } onLikeToggle={ this.recordLikeToggle } />
+			</div>
+		);
 	}
 }
 


### PR DESCRIPTION
Wouldn't it be great if you could see who liked a post when hovering your mouse over the likes button?

implements: https://github.com/Automattic/wp-calypso/issues/17607.

To Do:
- [ ] make scrollable
- [ ] handle just-liked and just-unliked case
- [x] mobile. what to do, what to do: https://github.com/Automattic/wp-calypso/pull/18807#issuecomment-336490685