### PR TITLE
Devdocs: fix block example for ConversationCommentList

### DIFF
--- a/client/blocks/comments/comment-likes.jsx
+++ b/client/blocks/comments/comment-likes.jsx
@@ -67,7 +67,7 @@ CommentLikeButtonContainer.propTypes = {
 	tagName: PropTypes.string,
 
 	// connected props:
-	commentLike: PropTypes.object.isRequired,
+	commentLike: PropTypes.object,
 	likeComment: PropTypes.func.isRequired,
 	unlikeComment: PropTypes.func.isRequired,
 };

--- a/client/blocks/conversations/list.jsx
+++ b/client/blocks/conversations/list.jsx
@@ -5,7 +5,19 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { map, zipObject, fill, size, filter, get, compact, partition, some, min } from 'lodash';
+import {
+	map,
+	zipObject,
+	fill,
+	size,
+	filter,
+	get,
+	compact,
+	partition,
+	some,
+	min,
+	noop,
+} from 'lodash';
 
 /***
  * Internal dependencies
@@ -50,11 +62,13 @@ export class ConversationCommentList extends React.Component {
 		post: PropTypes.object.isRequired, // required by PostComment
 		commentIds: PropTypes.array.isRequired,
 		shouldRequestComments: PropTypes.bool,
+		setActiveReply: PropTypes.func,
 	};
 
 	static defaultProps = {
 		enableCaterpillar: true,
 		shouldRequestComments: true,
+		setActiveReply: noop,
 	};
 
 	state = {


### PR DESCRIPTION
As reported by @rachelmcr in https://github.com/Automattic/wp-calypso/issues/18780, a recent change to ConversationCommentList in https://github.com/Automattic/wp-calypso/pull/18671 broke the Blocks page in Devdocs.

This PR repairs it:

<img width="702" alt="screen shot 2017-10-13 at 10 08 07" src="https://user-images.githubusercontent.com/17325/31538759-72434126-affe-11e7-9b8c-250621fd8a25.png">

### To test 

Check http://calypso.localhost:3000/devdocs/blocks and http://calypso.localhost:3000/devdocs/blocks/conversation-comment-list. Ensure the examples display correctly.