### PR TITLE
Rename geo_location to geoLocation

### DIFF
--- a/client/lib/happychat/connection.js
+++ b/client/lib/happychat/connection.js
@@ -31,7 +31,7 @@ const buildConnection = socket =>
 		: socket; // If socket is not an url, use it directly. Useful for testing.
 
 class Connection {
-	init( url, dispatch, { signer_user_id, jwt, locale, groups, geo_location } ) {
+	init( url, dispatch, { signer_user_id, jwt, locale, groups, geoLocation } ) {
 		if ( this.openSocket ) {
 			debug( 'socket is already connected' );
 			return this.openSocket;
@@ -45,7 +45,7 @@ class Connection {
 				.once( 'connect', () => debug( 'connected' ) )
 				.on( 'token', handler => handler( { signer_user_id, jwt, locale, groups } ) )
 				.on( 'init', () => {
-					dispatch( setConnected( { signer_user_id, locale, groups, geo_location } ) );
+					dispatch( setConnected( { signer_user_id, locale, groups, geoLocation } ) );
 					// TODO: There's no need to dispatch a separate action to request a transcript.
 					// The HAPPYCHAT_CONNECTED action should have its own middleware handler that does this.
 					dispatch( requestChatTranscript() );

--- a/client/lib/happychat/test/index.js
+++ b/client/lib/happychat/test/index.js
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -21,24 +22,30 @@ import {
 
 import buildConnection from '../connection';
 
-describe( 'connection', ( ) => {
-	describe( 'should bind socket ', ( ) => {
+describe( 'connection', () => {
+	describe( 'should bind socket ', () => {
 		const signer_user_id = 12;
 		const jwt = 'jwt';
 		const locale = 'locale';
 		const groups = 'groups';
-		const geo_location = 'location';
+		const geoLocation = 'location';
 
 		let openSocket, socket, dispatch;
 		beforeEach( () => {
 			socket = new EventEmitter();
 			dispatch = stub();
 			const connection = buildConnection();
-			openSocket = connection.init( socket, dispatch, { signer_user_id, jwt, locale, groups, geo_location } );
+			openSocket = connection.init( socket, dispatch, {
+				signer_user_id,
+				jwt,
+				locale,
+				groups,
+				geoLocation,
+			} );
 		} );
 
-		it( 'connect event', ( done ) => {
-			openSocket.then( ( ) => {
+		it( 'connect event', done => {
+			openSocket.then( () => {
 				// TODO: implement when connect event is used
 				expect( true ).to.equal( true );
 				done(); // tell mocha the promise chain ended
@@ -47,9 +54,9 @@ describe( 'connection', ( ) => {
 			socket.emit( 'init' ); // force openSocket promise to resolve
 		} );
 
-		it( 'token event', ( done ) => {
+		it( 'token event', done => {
 			const callback = stub();
-			openSocket.then( ( ) => {
+			openSocket.then( () => {
 				expect( callback ).to.have.been.calledWithMatch( { signer_user_id, jwt, locale, groups } );
 				done(); // tell mocha the promise chain ended
 			} );
@@ -57,22 +64,26 @@ describe( 'connection', ( ) => {
 			socket.emit( 'init' ); // force openSocket promise to resolve
 		} );
 
-		it( 'init event', ( done ) => {
-			openSocket.then( ( ) => {
-				expect( dispatch.getCall( 0 ) ).to.have.been.calledWithMatch( { type: HAPPYCHAT_CONNECTING } );
+		it( 'init event', done => {
+			openSocket.then( () => {
+				expect( dispatch.getCall( 0 ) ).to.have.been.calledWithMatch( {
+					type: HAPPYCHAT_CONNECTING,
+				} );
 				expect( dispatch.getCall( 1 ) ).to.have.been.calledWithMatch( {
 					type: HAPPYCHAT_CONNECTED,
-					user: { signer_user_id, locale, groups, geo_location }
+					user: { signer_user_id, locale, groups, geoLocation },
 				} );
-				expect( dispatch.getCall( 2 ) ).to.have.been.calledWithMatch( { type: HAPPYCHAT_TRANSCRIPT_REQUEST } );
+				expect( dispatch.getCall( 2 ) ).to.have.been.calledWithMatch( {
+					type: HAPPYCHAT_TRANSCRIPT_REQUEST,
+				} );
 				done(); // tell mocha the promise chain ended
 			} );
 			socket.emit( 'init' ); // force openSocket promise to resolve
 		} );
 
-		it( 'unauthorized event', ( done ) => {
-			socket.close = stub().returns( ()=>{} );
-			openSocket.then( ( ) => {
+		it( 'unauthorized event', done => {
+			socket.close = stub().returns( () => {} );
+			openSocket.then( () => {
 				expect( socket.close ).to.have.been.called;
 				done(); // tell mocha the promise chain ended
 			} );
@@ -80,12 +91,12 @@ describe( 'connection', ( ) => {
 			socket.emit( 'unauthorized' );
 		} );
 
-		it( 'disconnect event', ( done ) => {
+		it( 'disconnect event', done => {
 			const errorStatus = 'testing reasons';
-			openSocket.then( ( ) => {
+			openSocket.then( () => {
 				expect( dispatch.getCall( 3 ) ).to.have.been.calledWithMatch( {
 					type: HAPPYCHAT_DISCONNECTED,
-					errorStatus
+					errorStatus,
 				} );
 				done(); // tell mocha the promise chain ended
 			} );
@@ -93,21 +104,23 @@ describe( 'connection', ( ) => {
 			socket.emit( 'disconnect', errorStatus );
 		} );
 
-		it( 'reconnecting event', ( done ) => {
-			openSocket.then( ( ) => {
-				expect( dispatch.getCall( 3 ) ).to.have.been.calledWithMatch( { type: HAPPYCHAT_RECONNECTING } );
+		it( 'reconnecting event', done => {
+			openSocket.then( () => {
+				expect( dispatch.getCall( 3 ) ).to.have.been.calledWithMatch( {
+					type: HAPPYCHAT_RECONNECTING,
+				} );
 				done(); // tell mocha the promise chain ended
 			} );
 			socket.emit( 'init' ); // force openSocket promise to resolve
 			socket.emit( 'reconnecting' );
 		} );
 
-		it( 'status event', ( done ) => {
+		it( 'status event', done => {
 			const status = 'testing status';
-			openSocket.then( ( ) => {
+			openSocket.then( () => {
 				expect( dispatch.getCall( 3 ) ).to.have.been.calledWithMatch( {
 					type: HAPPYCHAT_SET_CHAT_STATUS,
-					status
+					status,
 				} );
 				done(); // tell mocha the promise chain ended
 			} );
@@ -115,12 +128,12 @@ describe( 'connection', ( ) => {
 			socket.emit( 'status', status );
 		} );
 
-		it( 'accept event', ( done ) => {
+		it( 'accept event', done => {
 			const isAvailable = true;
-			openSocket.then( ( ) => {
+			openSocket.then( () => {
 				expect( dispatch.getCall( 3 ) ).to.have.been.calledWithMatch( {
 					type: HAPPYCHAT_SET_AVAILABLE,
-					isAvailable
+					isAvailable,
 				} );
 				done(); // tell mocha the promise chain ended
 			} );
@@ -128,12 +141,12 @@ describe( 'connection', ( ) => {
 			socket.emit( 'accept', isAvailable );
 		} );
 
-		it( 'message event', ( done ) => {
+		it( 'message event', done => {
 			const event = 'testing msg';
-			openSocket.then( ( ) => {
+			openSocket.then( () => {
 				expect( dispatch.getCall( 3 ) ).to.have.been.calledWithMatch( {
 					type: HAPPYCHAT_RECEIVE_EVENT,
-					event
+					event,
 				} );
 				done(); // tell mocha the promise chain ended
 			} );

--- a/client/state/happychat/connection/test/actions.js
+++ b/client/state/happychat/connection/test/actions.js
@@ -14,11 +14,11 @@ import { setConnected } from '../actions';
 describe( 'actions', () => {
 	describe( '#setConnected()', () => {
 		test( 'should return an action object', () => {
-			const action = setConnected( { geo_location: { country_long: 'Romania' } } );
+			const action = setConnected( { geoLocation: { country_long: 'Romania' } } );
 
 			expect( action ).to.eql( {
 				type: HAPPYCHAT_CONNECTED,
-				user: { geo_location: { country_long: 'Romania' } },
+				user: { geoLocation: { country_long: 'Romania' } },
 			} );
 		} );
 	} );

--- a/client/state/happychat/middleware.js
+++ b/client/state/happychat/middleware.js
@@ -119,7 +119,7 @@ export const connectChat = ( connection, { getState, dispatch } ) => {
 
 	return startSession()
 		.then( ( { session_id, geo_location } ) => {
-			happychatUser.geo_location = geo_location;
+			happychatUser.geoLocation = geo_location;
 			return sign( { user, session_id } );
 		} )
 		.then( ( { jwt } ) => connection.init( url, dispatch, { jwt, ...happychatUser } ) )

--- a/client/state/happychat/user/reducer.js
+++ b/client/state/happychat/user/reducer.js
@@ -18,9 +18,9 @@ export const geoLocation = createReducer(
 	null,
 	{
 		[ HAPPYCHAT_CONNECTED ]: ( state, action ) => {
-			const { user: { geo_location } } = action;
-			if ( geo_location && geo_location.country_long && geo_location.city ) {
-				return geo_location;
+			const { user: { geoLocation: location } } = action;
+			if ( location && location.country_long && location.city ) {
+				return location;
 			}
 			return state;
 		},

--- a/client/state/happychat/user/test/reducer.js
+++ b/client/state/happychat/user/test/reducer.js
@@ -22,7 +22,7 @@ describe( '#geoLocation()', () => {
 		const state = geoLocation( null, {
 			type: HAPPYCHAT_CONNECTED,
 			user: {
-				geo_location: {
+				geoLocation: {
 					country_long: 'Romania',
 					city: 'Timisoara',
 				},


### PR DESCRIPTION
Master issue: https://github.com/Automattic/wp-calypso/issues/18670

Renames `state.happychat.user.geo_location` to `state.happychat.user.geoLocation`.

### Test

`npm run test-client happychat`
