### PR TITLE
MailChimp dashboard UI view.

### DIFF
--- a/client/extensions/woocommerce/app/settings/email/mailchimp/mailchimp_dashboard.js
+++ b/client/extensions/woocommerce/app/settings/email/mailchimp/mailchimp_dashboard.js
@@ -15,8 +15,7 @@ import FormCheckbox from 'components/forms/form-checkbox';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
 import FormLegend from 'components/forms/form-legend';
-import FormToggle from 'components/forms/form-toggle';
-import FormRadio from 'components/forms/form-radio';
+import CompactFormToggle from 'components/forms/form-toggle/compact';
 import FormTextInput from 'components/forms/form-text-input';
 import Notice from 'components/notice';
 import QueryMailChimpSyncStatus from 'woocommerce/state/sites/settings/email/querySyncStatus';
@@ -109,8 +108,10 @@ SyncTab.propTypes = {
 };
 
 const Settings = localize( ( { translate, settings, oldCheckbox, isSaving, onChange, onSave } ) => {
-	const onRadioChange = ( e ) => {
-		onChange( { mailchimp_checkbox_defaults: e.target.value } );
+	const onCheckedStateChange = () => {
+		const currentValue = settings.mailchimp_checkbox_defaults;
+		const nextValue = currentValue === 'check' ? 'uncheck' : 'check';
+		onChange( { mailchimp_checkbox_defaults: nextValue } );
 	};
 
 	const onNewsletterLabelChange = ( e ) => {
@@ -132,40 +133,31 @@ const Settings = localize( ( { translate, settings, oldCheckbox, isSaving, onCha
 			<span className="mailchimp__dashboard-settings-form">
 				<FormFieldset>
 					<FormLegend>{ translate( 'Newsletter subscriptions' ) }</FormLegend>
-					<FormLabel>
-						<FormToggle
+					<FormLabel className="mailchimp__dashboard-settings-form-field">
+						<CompactFormToggle
 							checked={ toggle }
 							onChange={ onToggleSubscribeMessage }
 							id="show-subscribe-message"
 						/>
 						<span>{ translate( 'Show a subscribe message to customer at checkout' ) }</span>
 					</FormLabel>
-					<FormLabel>
-						<FormRadio
-							disabled={ ! toggle }
-							value="check"
+					<FormLabel className="mailchimp__dashboard-settings-form-field">
+						<FormCheckbox
+							className="mailchimp__dashboard-settings-form-checkbox"
 							checked={ 'check' === subscriptionPromptState }
-							onChange={ onRadioChange }
+							disabled={ ! toggle }
+							onChange={ onCheckedStateChange }
 						/>
 						<span>{ translate( 'Subscribe message is checked by default' ) }</span>
 					</FormLabel>
-					<FormLabel>
-						<FormRadio
-							disabled={ ! toggle }
-							value="uncheck"
-							checked={ 'uncheck' === subscriptionPromptState }
-							onChange={ onRadioChange }
+					<FormLabel className="mailchimp__dashboard-settings-form-field">
+						<span>{ translate( 'Subscribe message' ) }</span>
+						<FormTextInput
+							name="newsletter_label"
+							onChange={ onNewsletterLabelChange }
+							value={ settings.newsletter_label }
 						/>
-						<span>{ translate( 'Subscribe message is unchecked by default' ) }</span>
 					</FormLabel>
-					<FormLabel>
-						{ translate( 'Subscribe message' ) }
-					</FormLabel>
-					<FormTextInput
-						name="newsletter_label"
-						onChange={ onNewsletterLabelChange }
-						value={ settings.newsletter_label }
-					/>
 				</FormFieldset>
 			</span>
 			<span className="mailchimp__dashboard-settings-preview">
@@ -214,7 +206,7 @@ class MailChimpDashboard extends React.Component {
 			if ( nextProps.newsletterSettingsSubmitError ) {
 				nextProps.errorNotice( translate( 'There was a problem saving the email settings. Please try again.' ) );
 			} else {
-				nextProps.successNotice( translate( 'Email settings saved.' ), { duration: 4000 } );
+				nextProps.successNotice( translate( 'Email settings saved.' ), /*{ duration: 4000 }*/ );
 			}
 		}
 	}
@@ -279,7 +271,7 @@ MailChimpDashboard.propTypes = {
 	syncStatusData: PropTypes.object,
 	isRequestingSettings: PropTypes.bool,
 	isSaving: PropTypes.bool,
-	newsletterSettingsSubmitError: PropTypes.onOfType( [
+	newsletterSettingsSubmitError: PropTypes.oneOfType( [
 		PropTypes.object,
 		PropTypes.bool,
 	] ),

--- a/client/extensions/woocommerce/app/settings/email/mailchimp/mailchimp_dashboard.js
+++ b/client/extensions/woocommerce/app/settings/email/mailchimp/mailchimp_dashboard.js
@@ -274,6 +274,22 @@ class MailChimpDashboard extends React.Component {
 	}
 }
 
+MailChimpDashboard.propTypes = {
+	siteId: PropTypes.number.isRequired,
+	syncStatusData: PropTypes.object,
+	isRequestingSettings: PropTypes.bool,
+	isSaving: PropTypes.bool,
+	newsletterSettingsSubmitError: PropTypes.onOfType( [
+		PropTypes.object,
+		PropTypes.bool,
+	] ),
+	settings: PropTypes.object.isRequired,
+	errorNotice: PropTypes.func.isRequired,
+	successNotice: PropTypes.func.isRequired,
+	submitMailChimpNewsletterSettings: PropTypes.func.isRequired,
+	requestResync: PropTypes.func.isRequired,
+};
+
 export default connect(
 	( state, { siteId } ) => ( {
 		siteId,

--- a/client/extensions/woocommerce/app/settings/email/mailchimp/mailchimp_dashboard.js
+++ b/client/extensions/woocommerce/app/settings/email/mailchimp/mailchimp_dashboard.js
@@ -1,0 +1,249 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import { localize } from 'i18n-calypso';
+import Button from 'components/button';
+import Card from 'components/card';
+import FormCheckbox from 'components/forms/form-checkbox';
+import FormFieldset from 'components/forms/form-fieldset';
+import FormLabel from 'components/forms/form-label';
+import FormLegend from 'components/forms/form-legend';
+import FormToggle from 'components/forms/form-toggle';
+import FormRadio from 'components/forms/form-radio';
+import FormTextInput from 'components/forms/form-text-input';
+import Notice from 'components/notice';
+import QueryMailChimpSyncStatus from 'woocommerce/state/sites/settings/email/querySyncStatus';
+import {
+	syncStatus,
+	mailchimpSettings,
+	isRequestingSettings } from 'woocommerce/state/sites/settings/email/selectors';
+import { submitMailchimpNewsletterSettings, requestResync } from 'woocommerce/state/sites/settings/email/actions.js';
+import { isSubmittingNewsletterSetting, newsletterSettingsSubmitError } from 'woocommerce/state/sites/settings/email/selectors';
+import { errorNotice, successNotice } from 'state/notices/actions';
+
+const SyncTab = localize( ( { siteId, translate, syncState, resync } ) => {
+	const { account_name, store_syncing, product_count, mailchimp_total_products,
+		mailchimp_total_orders, order_count } = syncState;
+	const hasProductInfo = ( product_count !== undefined ) && ( mailchimp_total_products !== undefined );
+	const products = hasProductInfo ? ( product_count + '/' + mailchimp_total_products ) : 'X/X';
+	const hasOrdersInfo = ( order_count !== undefined ) && ( mailchimp_total_orders !== undefined );
+	const orders = hasOrdersInfo ? ( order_count + '/' + mailchimp_total_orders ) : 'X/X';
+
+	const synced = () => (
+		<Notice
+			status="is-success"
+			isCompact={ true }
+			showDismiss={ false }
+			text={ syncState.mailchimp_list_name + ' ' + translate( 'list synced' ) }>
+		</Notice>
+	);
+
+	const syncing = () => (
+		<Notice
+			status="is-warning"
+			isCompact={ true }
+			showDismiss={ false }
+			text={ syncState.mailchimp_list_name + ' ' + translate( 'list is being synced' ) }>
+		</Notice>
+	);
+
+	const onResyncCLick = () => {
+		resync( siteId );
+	};
+
+	return (
+		<div>
+			<div>
+				<span className="mailchimp__account-info">{ translate( 'MailChimp account:' ) }</span>
+				<span>{ account_name }</span>
+			</div>
+			<span>{ store_syncing ? syncing() : synced() }</span>
+			<a onClick={ onResyncCLick }>Resync</a>
+			<div>
+				<span className="mailchimp__account-info" >{ translate( 'Products:' ) }</span>
+				<span>{ products }</span>
+				<span className="mailchimp__account-info" >{ ' ' + translate( 'Orders:' ) }</span>
+				<span>{ orders || '' }</span>
+			</div>
+		</div>
+	);
+} );
+
+const Settings = localize( ( { translate, settings, oldCheckbox, isSubbmittingSettings, onChange, onSave } ) => {
+	const onRadioChange = ( e ) => {
+		onChange( { mailchimp_checkbox_defaults: e.target.value } );
+	};
+
+	const onNewslatterLabelChange = ( e ) => {
+		onChange( { newsletter_label: e.target.value } );
+	};
+
+	const onToggle = ( e ) => {
+		const visibleOption = oldCheckbox !== 'hide' ? oldCheckbox : 'check';
+		onChange( { mailchimp_checkbox_defaults: e ? visibleOption : 'hide' } );
+	};
+
+	const checkbox = settings.mailchimp_checkbox_defaults;
+	const toggle = checkbox === 'check' || checkbox === 'uncheck';
+	return (
+		<div className="mailchimp__dashboard-settings">
+			<span className="mailchimp__dashboard-settings-form">
+				<FormFieldset>
+					<FormLegend>{ translate( 'Newsletter subscriptions' ) }</FormLegend>
+					<FormLabel>
+						<FormToggle
+							checked={ toggle }
+							onChange={ onToggle }
+							id="show-subscribe-message"
+						/>
+						<span>{ translate( 'Show a subscribe message to ustomer at checkout' ) }</span>
+					</FormLabel>
+					<FormLabel>
+						<FormRadio
+							disabled={ ! toggle }
+							value="check"
+							checked={ 'check' === checkbox }
+							onChange={ onRadioChange }
+						/>
+						<span>{ translate( 'Subscribe message is checked by default' ) }</span>
+					</FormLabel>
+					<FormLabel>
+						<FormRadio
+							disabled={ ! toggle }
+							value="uncheck"
+							checked={ 'uncheck' === checkbox }
+							onChange={ onRadioChange }
+						/>
+						<span>{ translate( 'Subscribe message is unchecked by default' ) }</span>
+					</FormLabel>
+					<FormLabel>
+						{ translate( 'Subscribe message is unchecked by default' ) }
+					</FormLabel>
+					<FormTextInput
+						name={ 'newsletter_label' }
+						onChange={ onNewslatterLabelChange }
+						value={ settings.newsletter_label }
+					/>
+				</FormFieldset>
+			</span>
+			<span className="mailchimp__dashboard-settings-preview">
+				<div>{ translate( 'PREVIEW' ) }</div>
+				<div className="mailchimp__dashboard-settings-preview-view">
+					{toggle && <FormLabel>
+							<FormCheckbox checked={ checkbox === 'check' } disabled={ true } />
+							<span>{ settings.newsletter_label }</span>
+						</FormLabel>}
+				</div>
+				<div className="mailchimp__dashboard-settings-save">
+					<Button
+						primary
+						onClick={ onSave }
+						busy={ isSubbmittingSettings }
+						disabled={ isSubbmittingSettings }>
+						{ translate( 'Save' ) }
+					</Button>
+				</div>
+			</span>
+		</div>
+	);
+} );
+
+class MailChimpDashboard extends React.Component {
+
+	constructor( props ) {
+		super( props );
+		this.state = {
+			syncStatus: null,
+			settings: props.settings
+		};
+	}
+
+	componentWillReceiveProps( nextProps ) {
+		const { translate } = nextProps;
+		if ( ( nextProps.isSubmittingNewsletterSetting === false ) && this.props.isSubmittingNewsletterSetting ) {
+			if ( nextProps.newsletterSettingsSubmitError ) {
+				nextProps.errorNotice( translate( 'There was a problem saving the email settings. Please try again.' ) );
+			} else {
+				nextProps.successNotice( translate( 'Email settings saved.' ), { duration: 4000 } );
+			}
+		}
+	}
+
+	onSettingsChange = ( change ) => {
+		this.setState( { settings: Object.assign( {}, this.state.settings, change ) } );
+	}
+
+	onSave = () => {
+		const { submitMailchimpNewsletterSettings: submit, siteId } = this.props;
+		const settings = this.state.settings;
+		const message = {
+			mailchimp_list: settings.mailchimp_list,
+			newsletter_label: settings.newsletter_label,
+			mailchimp_auto_subscribe: settings.mailchimp_auto_subscribe,
+			mailchimp_checkbox_defaults: settings.mailchimp_checkbox_defaults,
+			mailchimp_checkbox_action: settings.mailchimp_checkbox_action,
+		};
+		submit( siteId, message );
+	}
+
+	render() {
+		const { siteId, syncStatusData, translate } = this.props;
+		const slogan = translate( 'Allow customers to subscribe to your MailChimp email list' );
+
+		return (
+			<div>
+				<QueryMailChimpSyncStatus siteId={ siteId } />
+				<Card className="mailchimp__dashboard" >
+					<div className="mailchimp__dashboard-first-section" >
+						<span className="mailchimp__dashboard-title-and-slogan">
+							<div className="mailchimp__dashboard-title">Mailchimp</div>
+							<div>{ slogan }</div>
+						</span>
+						<span className="mailchimp__dashboard-sync-status" >
+							<SyncTab
+								siteId={ siteId }
+								syncState={ syncStatusData }
+								resync={ this.props.requestResync } />
+						</span>
+					</div>
+					<div className="mailchimp__dashboard-second-section" >
+						<Settings
+							settings={ this.state.settings }
+							isRequesting={ this.props.isRequestingSettings }
+							onChange={ this.onSettingsChange }
+							onSave={ this.onSave }
+							isSubbmittingSettings={ this.props.isSubmittingNewsletterSetting }
+							oldCheckbox={ this.props.settings.mailchimp_checkbox_defaults } />
+					</div>
+					<Button className="mailchimp__getting-started-button" onClick={ this.props.onClick }>
+						{ translate( 'Start setup wizard.' ) }
+					</Button>
+
+				</Card>
+			</div>
+		);
+	}
+}
+
+export default connect(
+	( state, { siteId } ) => ( {
+		siteId,
+		syncStatusData: syncStatus( state, siteId ),
+		isRequestingSettings: isRequestingSettings( state, siteId ),
+		isSubmittingNewsletterSetting: isSubmittingNewsletterSetting( state, siteId ),
+		newsletterSettingsSubmitError: newsletterSettingsSubmitError( state, siteId ),
+		settings: mailchimpSettings( state, siteId ),
+	} ),
+	{
+		errorNotice,
+		successNotice,
+		submitMailchimpNewsletterSettings,
+		requestResync
+	}
+)( localize( MailChimpDashboard ) );

--- a/client/extensions/woocommerce/app/settings/email/mailchimp/mailchimp_dashboard.js
+++ b/client/extensions/woocommerce/app/settings/email/mailchimp/mailchimp_dashboard.js
@@ -22,7 +22,8 @@ import QueryMailChimpSyncStatus from 'woocommerce/state/sites/settings/email/que
 import {
 	syncStatus,
 	mailchimpSettings,
-	isRequestingSettings } from 'woocommerce/state/sites/settings/email/selectors';
+	isRequestingSettings
+	} from 'woocommerce/state/sites/settings/email/selectors';
 import { submitMailchimpNewsletterSettings, requestResync } from 'woocommerce/state/sites/settings/email/actions.js';
 import { isSubmittingNewsletterSetting, newsletterSettingsSubmitError } from 'woocommerce/state/sites/settings/email/selectors';
 import { errorNotice, successNotice } from 'state/notices/actions';
@@ -31,30 +32,32 @@ const SyncTab = localize( ( { siteId, translate, syncState, resync } ) => {
 	const { account_name, store_syncing, product_count, mailchimp_total_products,
 		mailchimp_total_orders, order_count } = syncState;
 	const hasProductInfo = ( product_count !== undefined ) && ( mailchimp_total_products !== undefined );
-	const products = hasProductInfo ? ( product_count + '/' + mailchimp_total_products ) : 'X/X';
+	const products = hasProductInfo ? ( product_count + '/' + mailchimp_total_products ) : '';
 	const hasOrdersInfo = ( order_count !== undefined ) && ( mailchimp_total_orders !== undefined );
-	const orders = hasOrdersInfo ? ( order_count + '/' + mailchimp_total_orders ) : 'X/X';
+	const orders = hasOrdersInfo ? ( order_count + '/' + mailchimp_total_orders ) : '';
 
 	const synced = () => (
 		<Notice
 			status="is-success"
-			isCompact={ true }
+			isCompact
 			showDismiss={ false }
-			text={ syncState.mailchimp_list_name + ' ' + translate( 'list synced' ) }>
-		</Notice>
+			text={ translate( '%(mailingListname)s list synced.', {
+				args: { mailingListname: syncState.mailchimp_list_name } } ) }
+		/>
 	);
 
 	const syncing = () => (
 		<Notice
 			status="is-warning"
-			isCompact={ true }
+			isCompact
 			showDismiss={ false }
-			text={ syncState.mailchimp_list_name + ' ' + translate( 'list is being synced' ) }>
-		</Notice>
+			text={ translate( '%(mailingListname)s list is being synced.', {
+				args: { mailingListname: syncState.mailchimp_list_name } } ) }
+		/>
 	);
 
-	const onResyncCLick = () => {
-		resync( siteId );
+	const onResyncClick = () => {
+		! store_syncing && resync( siteId );
 	};
 
 	return (
@@ -64,7 +67,7 @@ const SyncTab = localize( ( { siteId, translate, syncState, resync } ) => {
 				<span>{ account_name }</span>
 			</div>
 			<span>{ store_syncing ? syncing() : synced() }</span>
-			<a onClick={ onResyncCLick }>Resync</a>
+			<a onClick={ onResyncClick }>{ translate( 'Resync' ) }</a>
 			<div>
 				<span className="mailchimp__account-info" >{ translate( 'Products:' ) }</span>
 				<span>{ products }</span>
@@ -102,7 +105,7 @@ const Settings = localize( ( { translate, settings, oldCheckbox, isSubbmittingSe
 							onChange={ onToggle }
 							id="show-subscribe-message"
 						/>
-						<span>{ translate( 'Show a subscribe message to ustomer at checkout' ) }</span>
+						<span>{ translate( 'Show a subscribe message to customer at checkout' ) }</span>
 					</FormLabel>
 					<FormLabel>
 						<FormRadio
@@ -123,10 +126,10 @@ const Settings = localize( ( { translate, settings, oldCheckbox, isSubbmittingSe
 						<span>{ translate( 'Subscribe message is unchecked by default' ) }</span>
 					</FormLabel>
 					<FormLabel>
-						{ translate( 'Subscribe message is unchecked by default' ) }
+						{ translate( 'Subscribe message' ) }
 					</FormLabel>
 					<FormTextInput
-						name={ 'newsletter_label' }
+						name="newsletter_label"
 						onChange={ onNewslatterLabelChange }
 						value={ settings.newsletter_label }
 					/>
@@ -135,7 +138,7 @@ const Settings = localize( ( { translate, settings, oldCheckbox, isSubbmittingSe
 			<span className="mailchimp__dashboard-settings-preview">
 				<div>{ translate( 'PREVIEW' ) }</div>
 				<div className="mailchimp__dashboard-settings-preview-view">
-					{toggle && <FormLabel>
+					{ toggle && <FormLabel>
 							<FormCheckbox checked={ checkbox === 'check' } disabled={ true } />
 							<span>{ settings.newsletter_label }</span>
 						</FormLabel>}
@@ -160,13 +163,13 @@ class MailChimpDashboard extends React.Component {
 		super( props );
 		this.state = {
 			syncStatus: null,
-			settings: props.settings
+			settings: props.settings,
 		};
 	}
 
 	componentWillReceiveProps( nextProps ) {
 		const { translate } = nextProps;
-		if ( ( nextProps.isSubmittingNewsletterSetting === false ) && this.props.isSubmittingNewsletterSetting ) {
+		if ( ( false === nextProps.isSubmittingNewsletterSetting ) && this.props.isSubmittingNewsletterSetting ) {
 			if ( nextProps.newsletterSettingsSubmitError ) {
 				nextProps.errorNotice( translate( 'There was a problem saving the email settings. Please try again.' ) );
 			} else {
@@ -194,16 +197,14 @@ class MailChimpDashboard extends React.Component {
 
 	render() {
 		const { siteId, syncStatusData, translate } = this.props;
-		const slogan = translate( 'Allow customers to subscribe to your MailChimp email list' );
-
 		return (
 			<div>
 				<QueryMailChimpSyncStatus siteId={ siteId } />
 				<Card className="mailchimp__dashboard" >
 					<div className="mailchimp__dashboard-first-section" >
 						<span className="mailchimp__dashboard-title-and-slogan">
-							<div className="mailchimp__dashboard-title">Mailchimp</div>
-							<div>{ slogan }</div>
+							<div className="mailchimp__dashboard-title">MailChimp</div>
+							<div>{ translate( 'Allow customers to subscribe to your MailChimp email list' ) }</div>
 						</span>
 						<span className="mailchimp__dashboard-sync-status" >
 							<SyncTab
@@ -224,7 +225,6 @@ class MailChimpDashboard extends React.Component {
 					<Button className="mailchimp__getting-started-button" onClick={ this.props.onClick }>
 						{ translate( 'Start setup wizard.' ) }
 					</Button>
-
 				</Card>
 			</div>
 		);

--- a/client/extensions/woocommerce/app/settings/email/mailchimp/mailchimp_dashboard.js
+++ b/client/extensions/woocommerce/app/settings/email/mailchimp/mailchimp_dashboard.js
@@ -206,7 +206,7 @@ class MailChimpDashboard extends React.Component {
 			if ( nextProps.newsletterSettingsSubmitError ) {
 				nextProps.errorNotice( translate( 'There was a problem saving the email settings. Please try again.' ) );
 			} else {
-				nextProps.successNotice( translate( 'Email settings saved.' ), /*{ duration: 4000 }*/ );
+				nextProps.successNotice( translate( 'Email settings saved.' ), { duration: 4000 } );
 			}
 		}
 	}

--- a/client/extensions/woocommerce/app/settings/email/mailchimp/mailchimp_dashboard.js
+++ b/client/extensions/woocommerce/app/settings/email/mailchimp/mailchimp_dashboard.js
@@ -229,10 +229,16 @@ class MailChimpDashboard extends React.Component {
 	}
 
 	render() {
-		const { siteId, syncStatusData, translate } = this.props;
+		const { siteId, syncStatusData, translate, onNoticeExit, wizardCompleted } = this.props;
 		return (
 			<div>
 				<QueryMailChimpSyncStatus siteId={ siteId } />
+				{ wizardCompleted && <Notice className="mailchimp__dashboard-success-notice"
+					status="is-success"
+					showDismiss
+					onDismissClick={ onNoticeExit }
+					text={ translate( 'Nice! The last thing to do is to make sure the newsletter subscriptions are looking good.' ) }
+				/> }
 				<Card className="mailchimp__dashboard" >
 					<div className="mailchimp__dashboard-first-section" >
 						<span className="mailchimp__dashboard-title-and-slogan">


### PR DESCRIPTION
### Information

This is a part of #17434 PR that represents MailChimp Dashboard UI view. This is what user sees when MailChimp is ready and configured.
This is provided for review as a separate PR because the original (spike) PR is too big for the review to be comfortable. 

To test this component in action please refer to #17434.

#### Warning

In the final version, the button to start setup wizard will be removed. The design does include it in this place/stage.

The card needs some styling. 

![image](https://user-images.githubusercontent.com/17271089/31545973-4ff3bf60-afd6-11e7-8907-b4971707512f.png)
