### PR TITLE
Jetpack Config: Add start & finish tracks events

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/jetpack-thank-you-card.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/jetpack-thank-you-card.jsx
@@ -107,18 +107,6 @@ class JetpackThankYouCard extends Component {
 		this.sentTracks = true;
 	}
 
-	trackManualInstall() {
-		analytics.tracks.recordEvent( 'calypso_plans_autoconfig_click_manual_error' );
-	}
-
-	trackManagePlans() {
-		analytics.tracks.recordEvent( 'calypso_plans_autoconfig_click_manage_plans' );
-	}
-
-	trackContactSupport() {
-		analytics.tracks.recordEvent( 'calypso_plans_autoconfig_click_contact_support' );
-	}
-
 	// plugins for Jetpack sites require additional data from the wporg-data store
 	addWporgDataToPlugins( plugins ) {
 		return plugins.map( plugin => {
@@ -138,6 +126,7 @@ class JetpackThankYouCard extends Component {
 	componentDidMount() {
 		window.addEventListener( 'beforeunload', this.warnIfNotFinished );
 		this.props.requestSites();
+		analytics.tracks.recordEvent( 'calypso_plans_autoconfig_start' );
 
 		page.exit( '/checkout/thank-you/*', ( context, next ) => {
 			const confirmText = this.warnIfNotFinished( {} );
@@ -595,6 +584,7 @@ class JetpackThankYouCard extends Component {
 			"Now that we've taken care of the plan, it's time to power up your site."
 		);
 		if ( 100 === progress ) {
+			this.trackConfigFinished( 'calypso_plans_autoconfig_success' );
 			return translate( "You are powered up, it's time to see your site." );
 		}
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1554855/31547517-ed912112-b027-11e7-934c-ad78557b8eac.png)

In the last iteration of the thank you page, we lack a tracks event for the start and the end of the autoconfig flow. This PR adds it (and cleans some not-used-anymore methods)

How to test:

1. Go to http://calypso.localhost:3000/plans and select a jetpack site
2. Open the developer console and run `localStorage.setItem('debug', 'calypso:analytics:tracks')`
3. Reload the page (I'm not sure if this is actually needed :D )
4. Purchase a plan, and when you are in the thank you page, check your developer console for 

![image](https://user-images.githubusercontent.com/1554855/31547600-42b826fe-b028-11e7-893f-7c5e80623372.png)
 
and 

![image](https://user-images.githubusercontent.com/1554855/31547607-4971b046-b028-11e7-9803-56230c1a0279.png)


