### PR TITLE
Atomic Store: enable the signup flow on wpcalypso and horizon

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -95,6 +95,7 @@
 		"signup/domain-first-flow": true,
 		"signup/social": true,
 		"signup/social-management": true,
+		"signup/atomic-store-flow": true,
 		"signup/wpcc": true,
 		"simple-payments": true,
 		"standalone-site-preview": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -118,6 +118,7 @@
 		"signup/domain-first-flow": true,
 		"signup/social": true,
 		"signup/social-management": true,
+		"signup/atomic-store-flow": true,
 		"signup/wpcc": true,
 		"simple-payments": true,
 		"standalone-site-preview": true,


### PR DESCRIPTION
This PR enables the `/start/atomic-store` signup flow on wpcalypso and horizon for better testing.