### PR TITLE
Editor: Revisions: Keep restore button fixed

### DIFF
--- a/client/post-editor/editor-revisions-list/index.jsx
+++ b/client/post-editor/editor-revisions-list/index.jsx
@@ -65,7 +65,7 @@ class EditorRevisionsList extends PureComponent {
 
 	render() {
 		return (
-			<div>
+			<div className="editor-revisions-list">
 				<QueryPostRevisions
 					postId={ this.props.postId }
 					postType={ this.props.type }
@@ -76,21 +76,23 @@ class EditorRevisionsList extends PureComponent {
 					loadRevision={ this.loadRevision }
 					selectedRevisionId={ this.props.selectedRevisionId }
 				/>
-				<ul className="editor-revisions-list__list">
-					{ map( this.props.revisions, revision => {
-						const itemClasses = classNames( 'editor-revisions-list__revision', {
-							'is-selected': revision.id === this.props.selectedRevisionId,
-						} );
-						return (
-							<li className={ itemClasses } key={ revision.id }>
-								<EditorRevisionsListItem
-									revision={ revision }
-									selectRevision={ this.props.selectRevision }
-								/>
-							</li>
-						);
-					} ) }
-				</ul>
+				<div className="editor-revisions-list__scroller">
+					<ul className="editor-revisions-list__list">
+						{ map( this.props.revisions, revision => {
+							const itemClasses = classNames( 'editor-revisions-list__revision', {
+								'is-selected': revision.id === this.props.selectedRevisionId,
+							} );
+							return (
+								<li className={ itemClasses } key={ revision.id }>
+									<EditorRevisionsListItem
+										revision={ revision }
+										selectRevision={ this.props.selectRevision }
+									/>
+								</li>
+							);
+						} ) }
+					</ul>
+				</div>
 			</div>
 		);
 	}

--- a/client/post-editor/editor-revisions-list/style.scss
+++ b/client/post-editor/editor-revisions-list/style.scss
@@ -1,6 +1,12 @@
 /** @format */
 @import 'components/accordion/style';
 
+.editor-revisions-list {
+	display: flex;
+	flex-direction: column;
+	flex: 1;
+}
+
 .editor-revisions-list__button {
 	// NOTE: this is imitating the style of an accordion (with subtitle), with
 	// support for being "selected" and no right arrow
@@ -53,6 +59,14 @@
 	color: $gray-text-min;
 }
 
+.editor-revisions-list__scroller {
+	padding: 10px 0;
+	height: 100%;
+	overflow-y: auto;
+	overflow-x: hidden;
+	-webkit-overflow-scrolling: touch;
+}
+
 .editor-revisions-list__list,
 .editor-revisions-list__header {
 	background: $white;
@@ -62,7 +76,6 @@
 }
 
 .editor-revisions-list__header {
-	margin-bottom: 10px;
 	padding: 1rem;
 }
 

--- a/client/post-editor/editor-revisions-list/style.scss
+++ b/client/post-editor/editor-revisions-list/style.scss
@@ -5,6 +5,7 @@
 	display: flex;
 	flex-direction: column;
 	flex: 1;
+	overflow: hidden;
 }
 
 .editor-revisions-list__button {

--- a/client/post-editor/editor-revisions-list/style.scss
+++ b/client/post-editor/editor-revisions-list/style.scss
@@ -76,6 +76,10 @@
 	font-size: 13px;
 }
 
+.editor-revisions-list__list {
+	border-top: none;
+}
+
 .editor-revisions-list__header {
 	padding: 1rem;
 }

--- a/client/post-editor/editor-sidebar/index.jsx
+++ b/client/post-editor/editor-sidebar/index.jsx
@@ -102,7 +102,7 @@ export default class EditorSidebar extends Component {
 						selectRevision={ selectRevision }
 					/>
 				</SidebarRegion>
-				<SidebarRegion className="editor-sidebar__nested-region">
+				<SidebarRegion className="editor-sidebar__nested-region editor-sidebar__nonscrolling-region">
 					{ nestedSidebar === NESTED_SIDEBAR_REVISIONS && (
 						<EditorRevisionsList
 							loadRevision={ loadRevision }

--- a/client/post-editor/editor-sidebar/style.scss
+++ b/client/post-editor/editor-sidebar/style.scss
@@ -127,6 +127,10 @@
 	}
 }
 
+.editor-sidebar__nonscrolling-region {
+	overflow: hidden;
+}
+
 .editor-sidebar__header-title {
 	padding: 0;
 	font-size: 13px;


### PR DESCRIPTION
This PR makes "restore revision" button fixed and only the list scrollable.

| Before | After |
| - | - |
| ![restore-before](https://user-images.githubusercontent.com/156676/31615023-7e6c6f5e-b288-11e7-86de-5bb5f8545035.gif) | ![restore-after](https://user-images.githubusercontent.com/156676/31615032-82ab3960-b288-11e7-8f0b-0762ef5cd983.gif) |

Test:
- open a post with multiple revisions
- resize the browser window height so you can test vertical scroll of the sidebar
- make sure restore button stays on top when you scroll
- make sure you can reach whole revision list when scrolling