### PR TITLE
Extensions: Try splitting CSS into separate files when building calypso

### DIFF
--- a/assets/stylesheets/style.scss
+++ b/assets/stylesheets/style.scss
@@ -18,7 +18,6 @@
 @import 'components';
 
 // Extensions
-@import 'extensions/woocommerce/style';
 @import 'extensions/wp-job-manager/style';
 @import 'extensions/wp-super-cache/style';
 @import 'extensions/zoninator/style';

--- a/bin/process-extensions-scss.js
+++ b/bin/process-extensions-scss.js
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+
+const fs = require( 'fs' );
+const path = require( 'path' );
+const sass = require( 'node-sass' );
+
+function getExtensionsWithScss() {
+	const extensionsDirectory = path.resolve( __dirname, '..', 'client', 'extensions' );
+	const extensionsNames = fs.readdirSync( extensionsDirectory ).filter( filename => {
+		// Return if this is a file (has extension)
+		if ( filename.indexOf( '.' ) !== -1 ) {
+			return false;
+		}
+		// Check for a package.json
+		const packageJsonPath = path.resolve( extensionsDirectory, filename, 'package.json' );
+		if ( ! fs.existsSync( packageJsonPath ) ) {
+			return false;
+		}
+		// Use package.json to check if there is a `css` definition for this extension's section
+		const packageJson = JSON.parse( fs.readFileSync( packageJsonPath, 'utf8' ) );
+		return !! packageJson.section.css;
+	} );
+
+	return extensionsNames.map( extensionName => path.resolve( extensionsDirectory, extensionName ) );
+}
+
+const extensions = getExtensionsWithScss();
+
+extensions.forEach( extension => {
+	const outFile = path.resolve(
+		__dirname,
+		'..',
+		'public',
+		'sections',
+		path.basename( extension ) + '.css'
+	);
+	sass.render(
+		{
+			file: path.resolve( extension, 'style.scss' ),
+			outFile: outFile,
+			includePaths: [ path.resolve( __dirname, '..', 'client' ) ],
+			sourceMap: true,
+		},
+		( error, result ) => {
+			if ( error ) {
+				console.warn( 'Failed to process scss', extension, error );
+				return;
+			}
+			// No errors during the compilation, write this result on the disk
+			fs.writeFile( outFile, result.css, fileError => {
+				if ( fileError ) {
+					console.warn( 'Failed to save CSS', extension, fileError );
+				}
+			} );
+			fs.writeFile( outFile + '.map', result.map, fileError => {
+				if ( fileError ) {
+					console.warn( 'Failed to save sourcemap', extension, fileError );
+				}
+			} );
+		}
+	);
+} );

--- a/client/extensions/woocommerce/package.json
+++ b/client/extensions/woocommerce/package.json
@@ -9,6 +9,7 @@
 		"paths": [ "/store" ],
 		"module": "woocommerce",
 		"group": "sites",
-		"secondary": true
+		"secondary": true,
+		"css": "woocommerce"
 	}
 }

--- a/client/extensions/woocommerce/style.scss
+++ b/client/extensions/woocommerce/style.scss
@@ -1,3 +1,6 @@
+// Core CSS Dependencies
+@import 'assets/stylesheets/shared/utils';      // utilities that are used by all CSS but don't produce any code
+
 .woocommerce {
 	flex-grow: 1;
 

--- a/package.json
+++ b/package.json
@@ -180,7 +180,7 @@
     "build-css:directly": "node-sass --include-path client assets/stylesheets/directly.scss public/directly.css && npm run -s autoprefixer -- public/directly.css",
     "build-css:editor": "node-sass --include-path client assets/stylesheets/editor.scss public/editor.css && npm run -s autoprefixer -- public/editor.css",
     "build-css:style": "node-sass --include-path client assets/stylesheets/style.scss public/style.css && npm run -s postcss -- public/style.css && rtlcss public/style.css public/style-rtl.css",
-    "build-css:sections": "node-sass assets/stylesheets/sections --include-path client -o public/sections --source-map public/sections && npm run -s autoprefixer -- public/sections/*.css && rtlcss -d public/sections public/sections-rtl",
+    "build-css:sections": "node-sass assets/stylesheets/sections --include-path client -o public/sections --source-map public/sections && node bin/process-extensions-scss.js && npm run -s autoprefixer -- public/sections/*.css && rtlcss -d public/sections public/sections-rtl",
     "prebuild-desktop": "npm run -s install-if-deps-outdated",
     "build-desktop": "run-p -s build-server build-css",
     "postbuild-desktop": "npm run -s bundle",


### PR DESCRIPTION
Inspired by talk of trimmimg down the main CSS file in calypso (see p4TIVU-8cI-p2), I've made this PR to enable extensions to build their CSS separately, rather than bundling into the main style.scss.

Specifically for the Store extension, we load a lot of CSS into the main style.css, when not many people are using Store (yet 😉). We can extract this to a separate file, and only load it when needed. This takes advantage of the existing work with section-specific CSS files and the fact that extensions define their own sections. 

There is now a new step in `build-css:sections`, a node script which checks if an extension calls for a css file ([woocommerce example](https://github.com/Automattic/wp-calypso/blob/try/extract-extension-css/client/extensions/woocommerce/package.json#L13)). This script knows that if there is a `css` entry, there is a `style.scss` file in the extension root that should be built into the `public/sections` folder. The script processed the scss and saves the CSS into `public/sections`. Then the rest of the `build-css:sections` steps take over, and autoprefixer & RTL are run on them.

This is a script, rather than a call directly to `node-sass`, because we need to filter out only the extensions that directly call for section-based CSS. It can't be enabled for all extensions by default because a) not all extensions have CSS, and b) each scss file will probably need to be updated to import the `shared/utils` file.

**TLDR;** This pulls out the woocommerce CSS into a new folder, and cuts almost 200K from `style.css`, and will be ready to use for any other extension to enable just by adding `css` to their section definition.

**BEFORE**

	1.5M public/style.css
	1.5M public/style-rtl.css

**AFTER**

	184K public/sections/woocommerce.css
	184K public/sections-rtl/woocommerce.rtl.css
	1.3M public/style.css
	1.3M public/style-rtl.css

**To test**

- Build calypso
- Check that there are new files in `public/sections` for woocommerce.css
- Load up calypso, keep the network tab open
- Select an atomic site with Store set up
- Click on Store in the sidebar, see the woocommerce.css file load
- Visit a store page directly: `/store/product/:site`
- See that the woocommerce.css file loads
