### PR TITLE
WooCommerce Services - Readded the labels action log

### DIFF
--- a/client/extensions/woocommerce/app/order/order-notes/note.js
+++ b/client/extensions/woocommerce/app/order/order-notes/note.js
@@ -10,7 +10,10 @@ import React, { Component } from 'react';
 /**
  * Internal dependencies
  */
+import { EVENT_TYPES } from 'woocommerce/state/sites/orders/activity-log/selectors';
+import LabelItem from 'woocommerce/woocommerce-services/views/shipping-label/label-item';
 import { decodeEntities, stripHTML } from 'lib/formatting';
+import formatCurrency from 'lib/format-currency';
 
 class OrderNote extends Component {
 	static propTypes = {
@@ -19,28 +22,94 @@ class OrderNote extends Component {
 		note: PropTypes.string.isRequired,
 	};
 
+	static propTypes = {
+		event: PropTypes.object,
+	};
+
+	static defaultProps = {
+		event: {},
+	};
+
+	eventPropsByType = {
+		[ EVENT_TYPES.INTERNAL_NOTE ]: event => {
+			const { translate } = this.props;
+			return {
+				icon: 'aside',
+				// @todo Add comment author once we have that info
+				heading: translate( 'Internal note' ),
+				content: decodeEntities( stripHTML( event.content ) ),
+			};
+		},
+
+		[ EVENT_TYPES.CUSTOMER_NOTE ]: event => {
+			const { translate } = this.props;
+			return {
+				icon: 'mail',
+				// @todo Add comment author once we have that info
+				heading: translate( 'Note sent to customer' ),
+				content: decodeEntities( stripHTML( event.content ) ),
+			};
+		},
+
+		[ EVENT_TYPES.LABEL_PURCHASED ]: event => {
+			return {
+				icon: 'print',
+				content: (
+					<LabelItem label={ event } orderId={ this.props.orderId } siteId={ this.props.siteId } />
+				),
+			};
+		},
+
+		[ EVENT_TYPES.LABEL_REFUND_REQUESTED ]: event => {
+			return {
+				icon: 'time',
+				content: (
+					<div>
+						<span>Label #{ event.labelIndex + 1 } refund requested</span>
+						{ event.amount != null ? (
+							<span> ({ formatCurrency( event.amount, event.currency ) })</span>
+						) : null }
+					</div>
+				),
+			};
+		},
+
+		[ EVENT_TYPES.LABEL_REFUND_COMPLETED ]: event => {
+			return {
+				icon: 'refund',
+				content: (
+					<div>
+						Label #{ event.labelIndex + 1 } refunded ({ formatCurrency( event.amount, event.currency ) })
+					</div>
+				),
+			};
+		},
+
+		[ EVENT_TYPES.LABEL_REFUND_REJECTED ]: event => {
+			return {
+				icon: 'cross-small',
+				content: <div>Label #{ event.labelIndex + 1 } refund rejected</div>,
+			};
+		},
+
+		[ undefined ]: () => ( {} ),
+	};
+
 	render() {
-		const { customer_note, date_created_gmt, note, moment, translate } = this.props;
-
-		const createdMoment = date_created_gmt ? moment( date_created_gmt + 'Z' ) : moment();
-
-		// @todo Add comment author once we have that info
-		let icon = 'aside';
-		let note_type = translate( 'Internal note' );
-		if ( customer_note ) {
-			icon = 'mail';
-			note_type = translate( 'Note sent to customer' );
-		}
+		const { moment, event } = this.props;
+		const { icon, heading, content } = this.eventPropsByType[ event.type ]( event );
 
 		return (
 			<div className="order-notes__note">
 				<div className="order-notes__note-meta">
-					<span className="order-notes__note-time">{ createdMoment.format( 'LT' ) }</span>
-					<Gridicon icon={ icon } size={ 24 } />
+					<span className="order-notes__note-time">
+						{ moment( event.timestamp ).format( 'LT' ) }
+					</span>
+					{ icon && <Gridicon icon={ icon } size={ 24 } /> }
 				</div>
 				<div className="order-notes__note-body">
-					<div className="order-notes__note-type">{ note_type }</div>
-					<div className="order-notes__note-content">{ decodeEntities( stripHTML( note ) ) }</div>
+					<div className="order-notes__note-type">{ heading }</div>
+					<div className="order-notes__note-content">{ content }</div>
 				</div>
 			</div>
 		);

--- a/client/extensions/woocommerce/state/sites/orders/activity-log/selectors.js
+++ b/client/extensions/woocommerce/state/sites/orders/activity-log/selectors.js
@@ -97,7 +97,7 @@ export const getActivityLogEvents = ( state, orderId, siteId = getSelectedSiteId
 							type: EVENT_TYPES.LABEL_REFUND_COMPLETED,
 							timestamp: label.refund.refund_date,
 							labelIndex,
-							amount: parseFloat( label.refund.amount ),
+							amount: parseFloat( label.refund.amount ) || label.refundable_amount,
 							currency: label.currency,
 						} );
 						break;

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/index.js
@@ -6,7 +6,6 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { localize } from 'i18n-calypso';
-import { filter } from 'lodash';
 
 /**
  * Internal dependencies
@@ -15,7 +14,6 @@ import Button from 'components/button';
 import Spinner from 'components/spinner';
 import PurchaseDialog from './label-purchase-modal';
 import QueryLabels from 'woocommerce/woocommerce-services/components/query-labels';
-import LabelItem from './label-item';
 import { fetchLabelsStatus, openPrintingFlow } from 'woocommerce/woocommerce-services/state/shipping-label/actions';
 import Notice from 'components/notice';
 import { isLoaded, getShippingLabel } from 'woocommerce/woocommerce-services/state/shipping-label/selectors';
@@ -91,24 +89,6 @@ class ShippingLabelRootView extends Component {
 		);
 	};
 
-	renderLabels = () => {
-		//filter by blacklist (rather than just checking for PURCHASED) to handle legacy labels without the status field
-		const labelsToRender = filter( this.props.labels,
-			( label ) => 'PURCHASE_IN_PROGRESS' !== label.status && 'PURCHASE_ERROR' !== label.status );
-
-		return labelsToRender.map( ( label, index ) => {
-			return (
-				<LabelItem
-					key={ label.label_id }
-					siteId={ this.props.siteId }
-					orderId={ this.props.orderId }
-					label={ label }
-					labelNum={ labelsToRender.length - index }
-				/>
-			);
-		} );
-	};
-
 	renderLoading() {
 		return (
 			<div>
@@ -129,7 +109,6 @@ class ShippingLabelRootView extends Component {
 			<div className="shipping-label">
 				<QueryLabels orderId={ this.props.orderId } />
 				{ this.renderPurchaseLabelFlow() }
-				{ this.props.labels.length ? this.renderLabels() : null }
 			</div>
 		);
 	}
@@ -149,7 +128,6 @@ const mapStateToProps = ( state, { orderId } ) => {
 		needToFetchLabelStatus: loaded && ! shippingLabel.refreshedLabelStatus,
 		numPaymentMethods: loaded && shippingLabel.numPaymentMethods,
 		paymentMethod: loaded && shippingLabel.paymentMethod,
-		labels: loaded && shippingLabel.labels,
 	};
 };
 

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-item.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-item.js
@@ -5,8 +5,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
-import Gridicon from 'gridicons';
-import { translate as __, moment } from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -14,139 +13,83 @@ import { translate as __, moment } from 'i18n-calypso';
 import RefundDialog from './label-refund-modal';
 import ReprintDialog from './label-reprint-modal';
 import TrackingLink from './tracking-link';
-//import InfoTooltip from 'components/info-tooltip';
 import { openRefundDialog, openReprintDialog } from 'woocommerce/woocommerce-services/state/shipping-label/actions';
 
-const formatDate = ( date ) => {
-	return moment( date ).format( 'MMMM Do YYYY, h:mm a' );
-};
-
 class LabelItem extends Component {
-	renderRefundLink = ( label ) => {
-		const { orderId, siteId } = this.props;
+	renderRefund = ( label ) => {
+		const { orderId, siteId, translate } = this.props;
 
 		const today = new Date();
 		const thirtyDaysAgo = new Date().setDate( today.getDate() - 30 );
-		if ( ( label.used_date && label.used_date < today.getTime() ) || ( label.created_date && label.created_date < thirtyDaysAgo ) ) {
+		if ( ( label.usedDate && label.usedDate < today.getTime() ) || ( label.createdDate && label.createdDate < thirtyDaysAgo ) ) {
 			return null;
 		}
 
 		const openDialog = ( e ) => {
 			e.preventDefault();
-			this.props.openRefundDialog( orderId, siteId, label.label_id );
+			this.props.openRefundDialog( orderId, siteId, label.labelId );
 		};
 
 		return (
 			<span>
 				<RefundDialog siteId={ siteId } orderId={ orderId } { ...label } />
-				<a href="#" onClick={ openDialog } >
-					<Gridicon icon="refund" size={ 12 } />{ __( 'Request refund' ) }
-				</a>
+				<a href="#" onClick={ openDialog } >{ translate( 'Request refund' ) }</a>
 			</span>
-		);
-	};
-
-	renderRefund = ( label ) => {
-		if ( ! label.refund ) {
-			return this.renderRefundLink( label );
-		}
-
-		let text = '';
-		let className = '';
-		switch ( label.refund.status ) {
-			case 'pending':
-				if ( label.statusUpdated ) {
-					className = 'is-refund-pending';
-					text = __( 'Refund pending' );
-				} else {
-					className = 'is-refund-checking';
-					text = __( 'Checking refund status' );
-				}
-				break;
-			case 'complete':
-				className = 'is-refund-complete';
-				text = __( 'Refunded on %(date)s', { args: { date: formatDate( label.refund.refund_date ) } } );
-				break;
-			case 'rejected':
-				className = 'is-refund-rejected';
-				text = __( 'Refund rejected' );
-				break;
-			default:
-				return this.renderRefundLink( label );
-		}
-
-		return (
-			<span className={ className } ><Gridicon icon="time" size={ 12 } />{ text }</span>
 		);
 	};
 
 	renderReprint = ( label ) => {
 		const todayTime = new Date().getTime();
-		if ( label.refund ||
-			( label.used_date && label.used_date < todayTime ) ||
-			( label.expiry_date && label.expiry_date < todayTime ) ) {
+		if ( ( label.usedDate && label.usedDate < todayTime ) ||
+			( label.expiryDate && label.expiryDate < todayTime ) ) {
 			return null;
 		}
 
-		const { orderId, siteId } = this.props;
+		const { orderId, siteId, translate } = this.props;
 
 		const openDialog = ( e ) => {
 			e.preventDefault();
-			this.props.openReprintDialog( orderId, siteId, label.label_id );
+			this.props.openReprintDialog( orderId, siteId, label.labelId );
 		};
 
 		return (
 			<span>
 				<ReprintDialog siteId={ siteId } orderId={ orderId } { ...label } />
-				<a href="#" onClick={ openDialog } >
-					<Gridicon icon="print" size={ 12 } />{ __( 'Reprint' ) }
-				</a>
+				<a href="#" onClick={ openDialog } >{ translate( 'Reprint' ) }</a>
 			</span>
 		);
 	};
 
 	renderLabelDetails = ( label ) => {
-		if ( ! label.package_name || ! label.product_names ) {
-			return null;
-		}
-
+		const { translate } = this.props;
 		return (
 			<span className="shipping-label__item-detail">
-				{ __( 'Label #%(labelNum)s', { args: { labelNum: this.props.labelNum } } ) }
+				{ translate( 'Label #%(labelIndex)s', { args: { labelIndex: label.labelIndex + 1 } } ) }
 			</span>
 		);
-		// return (
-		// 	<InfoTooltip anchor={ tooltipAnchor }>
-		// 		<h3>{ label.package_name }</h3>
-		// 		<p>{ label.service_name }</p>
-		// 		<ul>
-		// 			{ label.product_names.map( ( productName, productIdx ) => <li key={ productIdx }>{ productName }</li> ) }
-		// 		</ul>
-		// 	</InfoTooltip>
-		// );
 	};
 
 	render() {
-		const { label } = this.props;
-		const purchased = moment( label.created ).fromNow();
+		const { label, translate } = this.props;
 
 		return (
-			<div key={ label.label_id } className="shipping-label__item" >
+			<div key={ label.labelId } className="shipping-label__item" >
 				<p className="shipping-label__item-created">
-					{ __( '{{labelDetails/}} purchased {{purchasedAt/}}', {
+					{ translate( '{{labelDetails/}} purchased', {
 						components: {
 							labelDetails: this.renderLabelDetails( label ),
-							purchasedAt: <span title={ formatDate( label.created ) }>{ purchased }</span>
 						}
 					} ) }
 				</p>
 				<p className="shipping-label__item-tracking">
-					{ __( 'Tracking #: {{trackingLink/}}', { components: { trackingLink: <TrackingLink { ...label } /> } } ) }
+					{ translate( 'Tracking #: {{trackingLink/}}', { components: { trackingLink: <TrackingLink { ...label } /> } } ) }
 				</p>
-				<p className="shipping-label__item-actions" >
-					{ this.renderRefund( label ) }
-					{ this.renderReprint( label ) }
-				</p>
+				{ label.showDetails &&
+					<p className="shipping-label__item-actions">
+						{ this.renderRefund( label ) }
+						{ this.renderReprint( label ) }
+					</p>
+				}
 			</div>
 		);
 	}
@@ -164,4 +107,4 @@ const mapDispatchToProps = ( dispatch ) => {
 	return bindActionCreators( { openRefundDialog, openReprintDialog }, dispatch );
 };
 
-export default connect( null, mapDispatchToProps )( LabelItem );
+export default connect( null, mapDispatchToProps )( localize( LabelItem ) );

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-refund-modal.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-refund-modal.js
@@ -5,7 +5,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
-import { translate as __, moment } from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -17,10 +17,10 @@ import { closeRefundDialog, confirmRefund } from 'woocommerce/woocommerce-servic
 import { isLoaded, getShippingLabel } from 'woocommerce/woocommerce-services/state/shipping-label/selectors';
 
 const RefundDialog = ( props ) => {
-	const { orderId, siteId, refundDialog, storeOptions, created, refundable_amount, label_id } = props;
+	const { orderId, siteId, refundDialog, storeOptions, created, refundableAmount, labelId, translate, moment } = props;
 
 	const getRefundableAmount = () => {
-		return storeOptions.currency_symbol + Number( refundable_amount ).toFixed( 2 );
+		return storeOptions.currency_symbol + Number( refundableAmount ).toFixed( 2 );
 	};
 
 	const onClose = () => props.closeRefundDialog( orderId, siteId );
@@ -28,21 +28,21 @@ const RefundDialog = ( props ) => {
 	return (
 		<Dialog
 			additionalClassNames="label-refund-modal woocommerce"
-			isVisible={ Boolean( refundDialog && refundDialog.labelId === label_id ) }
+			isVisible={ Boolean( refundDialog && refundDialog.labelId === labelId ) }
 			onClose={ onClose }>
 			<FormSectionHeading>
-				{ __( 'Request a refund' ) }
+				{ translate( 'Request a refund' ) }
 			</FormSectionHeading>
 			<p>
-				{ __( 'You can request a refund for a shipping label that has not been used to ship a package. ' +
+				{ translate( 'You can request a refund for a shipping label that has not been used to ship a package. ' +
 					'It will take at least 14 days to process.' ) }
 			</p>
 			<hr />
 			<dl>
-				<dt>{ __( 'Purchase date' ) }</dt>
+				<dt>{ translate( 'Purchase date' ) }</dt>
 				<dd>{ moment( created ).format( 'MMMM Do YYYY, h:mm a' ) }</dd>
 
-				<dt>{ __( 'Amount eligible for refund' ) }</dt>
+				<dt>{ translate( 'Amount eligible for refund' ) }</dt>
 				<dd>{ getRefundableAmount() }</dd>
 			</dl>
 			<ActionButtons buttons={ [
@@ -50,11 +50,11 @@ const RefundDialog = ( props ) => {
 					onClick: onConfirm,
 					isPrimary: true,
 					isDisabled: refundDialog && refundDialog.isSubmitting,
-					label: __( 'Refund label (-%(amount)s)', { args: { amount: getRefundableAmount() } } ),
+					label: translate( 'Refund label (-%(amount)s)', { args: { amount: getRefundableAmount() } } ),
 				},
 				{
 					onClick: onClose,
-					label: __( 'Cancel' ),
+					label: translate( 'Cancel' ),
 				},
 			] } />
 		</Dialog>
@@ -67,8 +67,8 @@ RefundDialog.propTypes = {
 	refundDialog: PropTypes.object,
 	storeOptions: PropTypes.object.isRequired,
 	created: PropTypes.number,
-	refundable_amount: PropTypes.number,
-	label_id: PropTypes.number,
+	refundableAmount: PropTypes.number,
+	labelId: PropTypes.number,
 	closeRefundDialog: PropTypes.func.isRequired,
 	confirmRefund: PropTypes.func.isRequired,
 };
@@ -86,4 +86,4 @@ const mapDispatchToProps = ( dispatch ) => {
 	return bindActionCreators( { closeRefundDialog, confirmRefund }, dispatch );
 };
 
-export default connect( mapStateToProps, mapDispatchToProps )( RefundDialog );
+export default connect( mapStateToProps, mapDispatchToProps )( localize( RefundDialog ) );

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-reprint-modal.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-reprint-modal.js
@@ -19,7 +19,7 @@ import { closeReprintDialog, confirmReprint, updatePaperSize } from 'woocommerce
 import { isLoaded, getShippingLabel } from 'woocommerce/woocommerce-services/state/shipping-label/selectors';
 
 const ReprintDialog = ( props ) => {
-	const { orderId, siteId, reprintDialog, paperSize, storeOptions, label_id, translate } = props;
+	const { orderId, siteId, reprintDialog, paperSize, storeOptions, labelId, translate } = props;
 
 	const onClose = () => props.closeReprintDialog( orderId, siteId );
 	const onConfirm = () => props.confirmReprint( orderId, siteId );
@@ -27,7 +27,7 @@ const ReprintDialog = ( props ) => {
 
 	return (
 		<Dialog
-			isVisible={ Boolean( reprintDialog && reprintDialog.labelId === label_id ) }
+			isVisible={ Boolean( reprintDialog && reprintDialog.labelId === labelId ) }
 			onClose={ onClose }
 			additionalClassNames="label-reprint-modal woocommerce">
 			<FormSectionHeading>
@@ -68,6 +68,7 @@ ReprintDialog.propTypes = {
 	reprintDialog: PropTypes.object,
 	paperSize: PropTypes.string.isRequired,
 	storeOptions: PropTypes.object.isRequired,
+	labelId: PropTypes.number,
 	closeReprintDialog: PropTypes.func.isRequired,
 	confirmReprint: PropTypes.func.isRequired,
 	updatePaperSize: PropTypes.func.isRequired,

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/style.scss
@@ -1,102 +1,71 @@
 @import './label-purchase-modal/style';
-.shipping-label {
-	margin-bottom: 0;
-	text-align: center;
+.shipping-label__payment .gridicon.notice__icon {
+	align-self: flex-start;
+	margin-top: 8px;
+}
 
-	.shipping-label__payment .gridicon.notice__icon {
-		align-self: flex-start;
-		margin-top: 8px;
+.shipping-label__item {
+	p {
+		margin-bottom: 3px;
+		text-align: left;
+
+		&.shipping-label__item-tracking {
+			font-size: 12px;
+
+			a:focus {
+				outline: none;
+				box-shadow: none;
+			}
+		}
 	}
 
-	.shipping-label__item {
-		padding: 16px;
-		border-bottom: 1px solid #eee;
+	.shipping-label__new-label-button {
+		width: 100%;
+		margin-top: 16px;
+	}
 
-		.shipping-label__item-created {
-			color: $gray;
-			font-size: 12px;
+	.shipping-label__item-actions {
+		display: flex;
+		justify-content: space-between;
+		font-size: 12px;
+		margin-bottom: 0;
+
+		a {
+			display: inline-block;
+			margin-top: 10px;
 		}
 
-		&:last-child {
-			border: none;
+		span svg,
+		a svg {
+			position: relative;
+			top: 2px;
+			margin-right: 2px;
 		}
 
-		p {
-			margin-bottom: 3px;
-			text-align: left;
-
-			&.shipping-label__item-tracking {
-				margin-bottom: 16px;
-				font-size: 12px;
-
-				a:focus {
-					outline: none;
-					box-shadow: none;
-				}
-			}
-
-			& .shipping-label__item-detail {
-				font-weight: bold;
-				font-size: 14px;
-				color: $gray-dark;
-				cursor: help;
-				text-decoration: underline;
-				text-decoration-color: $gray-dark;
-				text-decoration-style: dotted;
-			}
+		.is-refund-pending {
+			color: $alert-yellow;
 		}
 
-		.shipping-label__new-label-button {
-			width: 100%;
-			margin-top: 16px;
+		.is-refund-checking {
+			color: $alert-yellow;
+			animation: loading-fade 1.6s ease-in-out infinite;
 		}
 
-		.shipping-label__item-actions {
-			display: flex;
-			justify-content: space-between;
-			font-size: 12px;
-			margin-bottom: 0;
-
-			a {
-				text-decoration: none;
-			}
-
-			.gridicon {
-				margin-right: 4px;
-			}
-
-			span svg,
-			a svg {
-				position: relative;
-				top: 2px;
-				margin-right: 2px;
-			}
-
-			.is-refund-pending {
-				color: $alert-yellow;
-			}
-
-			.is-refund-checking {
-				color: $alert-yellow;
-				animation: loading-fade 1.6s ease-in-out infinite;
-			}
-
-			.is-refund-complete {
-				color: $alert-green;
-			}
-
-			.is-refund-rejected {
-				color: $alert-red;
-			}
+		.is-refund-complete {
+			color: $alert-green;
 		}
 
-		.shipping-label__purchase-error {
+		.is-refund-rejected {
 			color: $alert-red;
-			cursor: help;
-			text-decoration: underline;
-			text-decoration-color: $alert-red;
-			text-decoration-style: dotted;
 		}
+	}
+
+	.shipping-label__purchase-error {
+		color: $alert-red;
+		cursor: help;
+		text-decoration: underline;
+		text-decoration-color: $alert-red;
+		text-decoration-style: dotted;
 	}
 }
 

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/tracking-link.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/tracking-link.js
@@ -4,26 +4,31 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
+import Gridicon from 'gridicons';
 
 const TRACKING_URL_MAP = {
 	usps: ( tracking ) => `https://tools.usps.com/go/TrackConfirmAction.action?tLabels=${ tracking }`,
 	fedex: ( tracking ) => `https://www.fedex.com/apps/fedextrack/?action=track&tracknumbers=${ tracking }`,
 };
 
-const TrackingLink = ( { tracking, carrier_id, translate } ) => {
+const TrackingLink = ( { tracking, carrierId, translate } ) => {
 	if ( ! tracking ) {
 		return <span>{ translate( 'N/A' ) }</span>;
 	}
-	const url = TRACKING_URL_MAP[ carrier_id ]( tracking );
+	const url = TRACKING_URL_MAP[ carrierId ]( tracking );
 	if ( ! url ) {
 		return <span>{ tracking }</span>;
 	}
-	return <a target="_blank" rel="noopener noreferrer" href={ url }>{ tracking }</a>;
+	return (
+		<a target="_blank" rel="noopener noreferrer" href={ url }>
+			{ tracking } <Gridicon icon="external" size={ 12 } />
+		</a>
+	);
 };
 
 TrackingLink.propTypes = {
 	tracking: PropTypes.string,
-	carrier_id: PropTypes.string,
+	carrierId: PropTypes.string,
 };
 
 export default localize( TrackingLink );


### PR DESCRIPTION
When rebasing #17676 against `master`, the changes from #17757 had to be discarded due to too many conflicts.

This PR readds them. The difference is that the views in `order-notes` are modified instead of deleting them in favor of `activity-log`, like in the old PR. This will allow to handle the potential conflicts easier.

The order page should work in the same way as in #17757, i.e. the purchased labels should appear in the log, it should be possible to refund and reprint them.