### PR TITLE
Store: Add a formatting helper function for currency values

### DIFF
--- a/client/extensions/woocommerce/lib/currency/index.js
+++ b/client/extensions/woocommerce/lib/currency/index.js
@@ -1,0 +1,24 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { getCurrencyDefaults } from 'lib/format-currency';
+
+/**
+ * Get the rounded decimal value of a number at the precision used for a given currency.
+ * This is a work-around for fraction-cents, meant to be used like `wc_format_decimal`
+ *
+ * @param {Number|String} number A floating point number (or integer), or string that converts to a number
+ * @param {String} currency A 3-character currency label, e.g. 'GBP' – see `getCurrencyDefaults`
+ * @return {Number} The original number rounded to a decimal point
+ */
+export function getCurrencyFormatDecimal( number, currency = 'USD' ) {
+	const { precision } = getCurrencyDefaults( currency );
+	if ( 'number' !== typeof number ) {
+		number = parseFloat( number );
+	}
+	if ( isNaN( number ) ) {
+		return 0;
+	}
+	return Math.round( number * Math.pow( 10, precision ) ) / Math.pow( 10, precision );
+}

--- a/client/extensions/woocommerce/lib/currency/test/index.js
+++ b/client/extensions/woocommerce/lib/currency/test/index.js
@@ -1,0 +1,45 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { getCurrencyFormatDecimal } from '../index';
+
+describe( 'getCurrencyFormatDecimal', () => {
+	it( 'should be a function', () => {
+		expect( getCurrencyFormatDecimal ).to.be.a( 'function' );
+	} );
+
+	it( 'should round a number to 2 decimal places in USD', () => {
+		expect( getCurrencyFormatDecimal( 9.49258, 'USD' ) ).to.eql( 9.49 );
+		expect( getCurrencyFormatDecimal( 30, 'USD' ) ).to.eql( 30 );
+		expect( getCurrencyFormatDecimal( 3.0002, 'USD' ) ).to.eql( 3 );
+	} );
+
+	it( 'should round a number to 2 decimal places in GBP', () => {
+		expect( getCurrencyFormatDecimal( 8.9272, 'GBP' ) ).to.eql( 8.93 );
+		expect( getCurrencyFormatDecimal( 11, 'GBP' ) ).to.eql( 11 );
+		expect( getCurrencyFormatDecimal( 7.0002, 'GBP' ) ).to.eql( 7 );
+	} );
+
+	it( 'should round a number to 0 decimal places in JPY', () => {
+		expect( getCurrencyFormatDecimal( 1239.88, 'JPY' ) ).to.eql( 1240 );
+		expect( getCurrencyFormatDecimal( 1500, 'JPY' ) ).to.eql( 1500 );
+		expect( getCurrencyFormatDecimal( 33715.02, 'JPY' ) ).to.eql( 33715 );
+	} );
+
+	it( 'should correctly convert and round a string', () => {
+		expect( getCurrencyFormatDecimal( '19.80', 'USD' ) ).to.eql( 19.8 );
+	} );
+
+	it( "should return 0 when given an input that isn't a number", () => {
+		expect( getCurrencyFormatDecimal( 'abc', 'USD' ) ).to.eql( 0 );
+		expect( getCurrencyFormatDecimal( false, 'USD' ) ).to.eql( 0 );
+		expect( getCurrencyFormatDecimal( null, 'USD' ) ).to.eql( 0 );
+	} );
+} );


### PR DESCRIPTION
This adds a new function to round values to a currency-specific precision. This way we can display values with no fraction cents in USD, or no fraction yen in JPY, etc. WooCommerce core has `wc_format_decimal` which is used similarly to display values, compare refund amounts, etc in full-currency increments. This should help the issue where refunds still have a fraction-cent cost associated and thus aren't considered fully refunded (or other confusing issues like this https://github.com/Automattic/wp-calypso/pull/18728#issuecomment-335665998).

To test:

Not used anywhere yet, just run the test: 

    npm run test-client client/extensions/woocommerce/lib/currency