### PR TITLE
jsdiff / diff lib dependency: update to version 3.4.0

### DIFF
--- a/client/state/selectors/test/get-post-revision-changes.js
+++ b/client/state/selectors/test/get-post-revision-changes.js
@@ -100,12 +100,14 @@ describe( 'getPostRevisionChanges', () => {
 		const diff = getPostRevisionChanges( outOfOrderState, 12345678, 10, 11 );
 		expect( diff.content ).to.eql( [
 			{
+				count: 3,
 				added: true,
 				value: 'Hello World',
 			},
 		] );
 		expect( diff.title ).to.eql( [
 			{
+				count: 3,
 				added: true,
 				value: 'Test Title',
 			},
@@ -116,12 +118,14 @@ describe( 'getPostRevisionChanges', () => {
 		const diff = getPostRevisionChanges( outOfOrderState, 12345678, 10, 16 );
 		expect( diff.content ).to.eql( [
 			{
+				count: 11,
 				added: true,
 				value: 'L’usage d’un instrument savant',
 			},
 		] );
 		expect( diff.title ).to.eql( [
 			{
+				count: 5,
 				added: true,
 				value: 'Foo & Baz',
 			},

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3,7 +3,7 @@
   "version": "0.17.0",
   "dependencies": {
     "@types/node": {
-      "version": "6.0.89",
+      "version": "6.0.90",
       "dev": true
     },
     "5to6-codemod": {
@@ -809,7 +809,7 @@
       }
     },
     "browserify-aes": {
-      "version": "1.1.0"
+      "version": "1.1.1"
     },
     "browserify-cipher": {
       "version": "1.0.0"
@@ -874,10 +874,10 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000746"
+      "version": "1.0.30000748"
     },
     "caniuse-lite": {
-      "version": "1.0.30000746"
+      "version": "1.0.30000748"
     },
     "cardinal": {
       "version": "1.0.0",
@@ -1496,14 +1496,20 @@
       }
     },
     "diff": {
-      "version": "1.4.0"
+      "version": "3.4.0"
     },
     "diffie-hellman": {
       "version": "5.0.2"
     },
     "disparity": {
       "version": "2.0.0",
-      "dev": true
+      "dev": true,
+      "dependencies": {
+        "diff": {
+          "version": "1.4.0",
+          "dev": true
+        }
+      }
     },
     "doctrine": {
       "version": "2.0.0"
@@ -3536,7 +3542,7 @@
           "dev": true
         },
         "chalk": {
-          "version": "2.1.0",
+          "version": "2.2.0",
           "dev": true
         },
         "cliui": {
@@ -3628,7 +3634,7 @@
           "dev": true
         },
         "supports-color": {
-          "version": "4.4.0",
+          "version": "4.5.0",
           "dev": true
         },
         "which-module": {
@@ -3658,7 +3664,7 @@
           "dev": true
         },
         "chalk": {
-          "version": "2.1.0",
+          "version": "2.2.0",
           "dev": true
         },
         "escape-string-regexp": {
@@ -3674,7 +3680,7 @@
           "dev": true
         },
         "supports-color": {
-          "version": "4.4.0",
+          "version": "4.5.0",
           "dev": true
         }
       }
@@ -3688,11 +3694,7 @@
           "dev": true
         },
         "chalk": {
-          "version": "2.1.0",
-          "dev": true
-        },
-        "diff": {
-          "version": "3.4.0",
+          "version": "2.2.0",
           "dev": true
         },
         "escape-string-regexp": {
@@ -3704,7 +3706,7 @@
           "dev": true
         },
         "supports-color": {
-          "version": "4.4.0",
+          "version": "4.5.0",
           "dev": true
         }
       }
@@ -3748,7 +3750,7 @@
           "dev": true
         },
         "chalk": {
-          "version": "2.1.0",
+          "version": "2.2.0",
           "dev": true
         },
         "escape-string-regexp": {
@@ -3760,7 +3762,7 @@
           "dev": true
         },
         "supports-color": {
-          "version": "4.4.0",
+          "version": "4.5.0",
           "dev": true
         }
       }
@@ -3778,7 +3780,7 @@
           "dev": true
         },
         "chalk": {
-          "version": "2.1.0",
+          "version": "2.2.0",
           "dev": true
         },
         "escape-string-regexp": {
@@ -3790,7 +3792,7 @@
           "dev": true
         },
         "supports-color": {
-          "version": "4.4.0",
+          "version": "4.5.0",
           "dev": true
         }
       }
@@ -3801,10 +3803,6 @@
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
-          "dev": true
-        },
-        "diff": {
-          "version": "3.4.0",
           "dev": true
         },
         "jest-diff": {
@@ -3842,7 +3840,7 @@
           "dev": true
         },
         "chalk": {
-          "version": "2.1.0",
+          "version": "2.2.0",
           "dev": true
         },
         "escape-string-regexp": {
@@ -3854,7 +3852,7 @@
           "dev": true
         },
         "supports-color": {
-          "version": "4.4.0",
+          "version": "4.5.0",
           "dev": true
         }
       }
@@ -3876,7 +3874,7 @@
           "dev": true
         },
         "chalk": {
-          "version": "2.1.0",
+          "version": "2.2.0",
           "dev": true
         },
         "escape-string-regexp": {
@@ -3888,7 +3886,7 @@
           "dev": true
         },
         "supports-color": {
-          "version": "4.4.0",
+          "version": "4.5.0",
           "dev": true
         }
       }
@@ -3928,7 +3926,7 @@
           "dev": true
         },
         "chalk": {
-          "version": "2.1.0",
+          "version": "2.2.0",
           "dev": true
         },
         "cliui": {
@@ -3988,7 +3986,7 @@
           "dev": true
         },
         "supports-color": {
-          "version": "4.4.0",
+          "version": "4.5.0",
           "dev": true
         },
         "which-module": {
@@ -4018,7 +4016,7 @@
           "dev": true
         },
         "chalk": {
-          "version": "2.1.0",
+          "version": "2.2.0",
           "dev": true
         },
         "escape-string-regexp": {
@@ -4030,7 +4028,7 @@
           "dev": true
         },
         "supports-color": {
-          "version": "4.4.0",
+          "version": "4.5.0",
           "dev": true
         }
       }
@@ -4048,7 +4046,7 @@
           "dev": true
         },
         "chalk": {
-          "version": "2.1.0",
+          "version": "2.2.0",
           "dev": true
         },
         "escape-string-regexp": {
@@ -4060,7 +4058,7 @@
           "dev": true
         },
         "supports-color": {
-          "version": "4.4.0",
+          "version": "4.5.0",
           "dev": true
         }
       }
@@ -4074,7 +4072,7 @@
           "dev": true
         },
         "chalk": {
-          "version": "2.1.0",
+          "version": "2.2.0",
           "dev": true
         },
         "escape-string-regexp": {
@@ -4090,7 +4088,7 @@
           "dev": true
         },
         "supports-color": {
-          "version": "4.4.0",
+          "version": "4.5.0",
           "dev": true
         }
       }
@@ -5332,7 +5330,7 @@
           "version": "3.2.0"
         },
         "chalk": {
-          "version": "2.1.0"
+          "version": "2.2.0"
         },
         "escape-string-regexp": {
           "version": "1.0.5"
@@ -5347,7 +5345,7 @@
           "version": "0.6.1"
         },
         "supports-color": {
-          "version": "4.4.0"
+          "version": "4.5.0"
         }
       }
     },
@@ -5376,7 +5374,7 @@
           "dev": true
         },
         "chalk": {
-          "version": "2.1.0",
+          "version": "2.2.0",
           "dev": true
         },
         "escape-string-regexp": {
@@ -5396,7 +5394,7 @@
           "dev": true
         },
         "supports-color": {
-          "version": "4.4.0",
+          "version": "4.5.0",
           "dev": true
         }
       }
@@ -5466,7 +5464,7 @@
               "dev": true
             },
             "supports-color": {
-              "version": "4.4.0",
+              "version": "4.5.0",
               "dev": true
             }
           }
@@ -5524,7 +5522,7 @@
               "dev": true
             },
             "chalk": {
-              "version": "2.1.0",
+              "version": "2.2.0",
               "dev": true
             },
             "escape-string-regexp": {
@@ -5532,7 +5530,7 @@
               "dev": true
             },
             "supports-color": {
-              "version": "4.4.0",
+              "version": "4.5.0",
               "dev": true
             }
           }
@@ -5751,10 +5749,6 @@
         },
         "cliui": {
           "version": "3.2.0",
-          "dev": true
-        },
-        "diff": {
-          "version": "3.4.0",
           "dev": true
         },
         "doctrine": {
@@ -7383,7 +7377,7 @@
           "version": "3.0.0"
         },
         "supports-color": {
-          "version": "4.4.0"
+          "version": "4.5.0"
         },
         "webpack-sources": {
           "version": "1.0.1"
@@ -7460,7 +7454,7 @@
           "dev": true
         },
         "filesize": {
-          "version": "3.5.10",
+          "version": "3.5.11",
           "dev": true
         },
         "finalhandler": {
@@ -7608,7 +7602,7 @@
           "version": "1.3.2"
         },
         "filesize": {
-          "version": "3.5.10"
+          "version": "3.5.11"
         },
         "isarray": {
           "version": "0.0.1"

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "d3-selection": "1.1.0",
     "d3-shape": "1.2.0",
     "debug": "2.2.0",
-    "diff": "1.4.0",
+    "diff": "3.4.0",
     "doctrine": "2.0.0",
     "dom-helpers": "2.4.0",
     "dom-scroll-into-view": "1.0.1",


### PR DESCRIPTION
We're currently pulling in version ([1.4.0](https://github.com/kpdecker/jsdiff/releases/tag/v1.4.0)). It's ~ 2.5 years old & there have been plenty of releases since.

This change brings us to [3.4.0](https://github.com/kpdecker/jsdiff/releases/tag/v3.4.0).

[changelog](https://github.com/kpdecker/jsdiff/blob/e03e1fc6d2d8c37ff5adf616f198228dc8ab1b74/release-notes.md)

## Test Plan

Run this branch & smoke test the Post Revisions feature. Diffs should be sensical, performance should not degrade, loading a revision in the editor should work as planned, no errors should be introduced.