### PR TITLE
Atomic Store: show proper checkout-thank-you to new users

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/index.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.jsx
@@ -268,8 +268,15 @@ const CheckoutThankYou = React.createClass( {
 
 		const { signupIsStore } = this.props;
 
-		// streamlined paid NUX thanks page
-		if ( this.isNewUser() && wasDotcomPlanPurchased ) {
+		if ( wasDotcomPlanPurchased && signupIsStore ) {
+			return (
+				<Main className="checkout-thank-you">
+					{ this.renderConfirmationNotice() }
+					<AtomicStoreThankYouCard siteId={ this.props.selectedSite.ID } />
+				</Main>
+			);
+		} else if ( this.isNewUser() && wasDotcomPlanPurchased ) {
+			// streamlined paid NUX thanks page
 			return (
 				<Main className="checkout-thank-you">
 					{ this.renderConfirmationNotice() }
@@ -281,13 +288,6 @@ const CheckoutThankYou = React.createClass( {
 				<Main className="checkout-thank-you">
 					{ this.renderConfirmationNotice() }
 					<JetpackThankYouCard siteId={ this.props.selectedSite.ID } />
-				</Main>
-			);
-		} else if ( wasDotcomPlanPurchased && signupIsStore ) {
-			return (
-				<Main className="checkout-thank-you">
-					{ this.renderConfirmationNotice() }
-					<AtomicStoreThankYouCard siteId={ this.props.selectedSite.ID } />
 				</Main>
 			);
 		}


### PR DESCRIPTION
When testing Atomic Store, @lancewillett identified an issue in which if you go through the Atomic Store flow as a new user, you would be shown a wrong checkout-thank-you page directing you to "Visit your site" instead of "Set up your store".

In this PR, we fix that.

## Testing

Navigate to `/start/atomic-store` and go through the Atomic Store flow. After purchasing the Business plan, you should be presented with the proper checkout thank you page prompting you to "Set up your store".

Verify also whether other flows aren't affected by this change.