### PR TITLE
Store: Fix error and propType warning in Packages

### DIFF
--- a/client/extensions/woocommerce/woocommerce-services/views/packages/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/packages/index.js
@@ -129,7 +129,7 @@ Packages.propTypes = {
 		dimensionUnit: PropTypes.string,
 		weightUnit: PropTypes.string,
 		packageSchema: PropTypes.object,
-		predefinedSchema: PropTypes.object,
+		predefinedSchema: PropTypes.oneOfType( [ PropTypes.object, PropTypes.array ] ),
 	} ).isRequired,
 };
 
@@ -141,7 +141,7 @@ export default connect(
 			siteId,
 			isFetching: ! form || ! form.packages || form.isFetching,
 			form,
-			allSelectedPackages: getAllSelectedPackages( state, siteId ),
+			allSelectedPackages: getAllSelectedPackages( state, siteId ) || [],
 		};
 	},
 	dispatch => ( {


### PR DESCRIPTION
Fixes #17963 - I hit this error while migrating my personal site to AT/Store - so figured I would fix it up.

__To Test__
- Create a new site, or migrate an existing one to store
- Click on Settings | Shipping when the dashboard setup wizard is displayed
- Verify no errors are thrown in the console, nor propType warnings