### PR TITLE
Magic Logic: interstitial page constant missing

### DIFF
--- a/client/state/login/magic-login/constants.js
+++ b/client/state/login/magic-login/constants.js
@@ -3,3 +3,4 @@ export const AUTHENTICATE_URL = 'https://wordpress.com/wp-login.php?action=magic
 export const CHECK_YOUR_EMAIL_PAGE = 'CHECK_YOUR_EMAIL_PAGE';
 export const LINK_EXPIRED_PAGE = 'LINK_EXPIRED_PAGE';
 export const REQUEST_FORM = 'REQUEST_FORM';
+export const INTERSTITIAL_PAGE = 'INTERSTITIAL_PAGE';


### PR DESCRIPTION
While working on disabling common js transpilation to improve the calypso build process, I ran into [7 issues](https://github.com/Automattic/wp-calypso/pull/16057#issuecomment-335757214) where there were items being imported/exported that are missing.

One of them was: 

```
WARNING in ./client/state/login/magic-login/reducer.js
23:8-25 "export 'INTERSTITIAL_PAGE' was not found in './constants'
```

It looks like the constant is being used by the reducer but doesn't actually exist. I _really_ don't know this area of Calypso and would appreciate guidance in fixing this.

Thanks!

Note: this is a blocker for https://github.com/Automattic/wp-calypso/pull/16057
Disclaimer: if this comes off as rude just know it wasn't meant to be, just hastily written.

cc @jblz 