### PR TITLE
Signup: fix suggestedUsernameSchema

### DIFF
--- a/client/state/signup/optional-dependencies/schema.js
+++ b/client/state/signup/optional-dependencies/schema.js
@@ -1,4 +1,4 @@
 /** @format */
-export const suggestedUsername = {
+export const suggestedUsernameSchema = {
 	type: [ 'string', 'null' ],
 };


### PR DESCRIPTION
While working on disabling common js transpilation to improve the calypso build process, I ran into [7 issues](https://github.com/Automattic/wp-calypso/pull/16057#issuecomment-335757214) where there were items being imported/exported that are missing.

One of them was: 

```
WARNING in ./client/state/signup/optional-dependencies/reducer.js
14:4-27 "export 'suggestedUsernameSchema' was not found in './schema'
```

It looks like the schema just has the wrong exported name. seems like a simple fix.
I'm not sure what this code does / how to test though and would appreciate guidance / pointers.

Thanks!

Note: this is a blocker for https://github.com/Automattic/wp-calypso/pull/16057

cc @bisko 