### PR TITLE
Site Setting Exporter: fix action-name in reducer

### DIFF
--- a/client/state/site-settings/exporter/reducers.js
+++ b/client/state/site-settings/exporter/reducers.js
@@ -5,7 +5,7 @@
  */
 
 import {
-	EXPORT_ADVANCED_SETTINGS_FAIL,
+	EXPORT_ADVANCED_SETTINGS_FETCH_FAIL,
 	EXPORT_ADVANCED_SETTINGS_FETCH,
 	EXPORT_ADVANCED_SETTINGS_RECEIVE,
 	EXPORT_POST_TYPE_SET,
@@ -101,7 +101,7 @@ export function fetchingAdvancedSettings( state = {}, action ) {
 			return Object.assign( {}, state, {
 				[ action.siteId ]: true,
 			} );
-		case EXPORT_ADVANCED_SETTINGS_FAIL:
+		case EXPORT_ADVANCED_SETTINGS_FETCH_FAIL:
 		case EXPORT_ADVANCED_SETTINGS_RECEIVE:
 			return Object.assign( {}, state, {
 				[ action.siteId ]: false,

--- a/client/state/site-settings/exporter/test/reducer.js
+++ b/client/state/site-settings/exporter/test/reducer.js
@@ -11,7 +11,7 @@ import { expect } from 'chai';
 import { selectedAdvancedSettings, advancedSettings, fetchingAdvancedSettings } from '../reducers';
 import { SAMPLE_ADVANCED_SETTINGS, SAMPLE_ADVANCED_SETTINGS_EMPTY } from './data';
 import {
-	EXPORT_ADVANCED_SETTINGS_FAIL,
+	EXPORT_ADVANCED_SETTINGS_FETCH_FAIL,
 	EXPORT_ADVANCED_SETTINGS_FETCH,
 	EXPORT_ADVANCED_SETTINGS_RECEIVE,
 	EXPORT_POST_TYPE_FIELD_SET,
@@ -78,7 +78,7 @@ describe( 'reducer', () => {
 
 		test( 'should reset fetching status after fail', () => {
 			const state = fetchingAdvancedSettings( null, {
-				type: EXPORT_ADVANCED_SETTINGS_FAIL,
+				type: EXPORT_ADVANCED_SETTINGS_FETCH_FAIL,
 				siteId: 100658273,
 				advancedSettings: {},
 			} );


### PR DESCRIPTION
While working on disabling common js transpilation to improve the calypso build process, I ran into [7 issues](https://github.com/Automattic/wp-calypso/pull/16057#issuecomment-335757214) where there were items being imported/exported that are missing.

One of them was: 

```
WARNING in ./client/state/site-settings/exporter/reducers.js
97:7-36 "export 'EXPORT_ADVANCED_SETTINGS_FAIL' was not found in 'state/action-types'
```

It looked like the reducer/test were just using the wrong action-type.  Is this the right fix?
Thanks for the help!

Note: this is a blocker for https://github.com/Automattic/wp-calypso/pull/16057

cc @jordwest @gwwar 