### PR TITLE
Publicize Actions: fix typo in the schema

### DIFF
--- a/client/state/sharing/publicize/publicize-actions/schema.js
+++ b/client/state/sharing/publicize/publicize-actions/schema.js
@@ -1,5 +1,5 @@
 /** @format */
-export const publicizeActionSchema = {
+export const publicizeActionsSchema = {
 	type: 'object',
 	patternProperties: {
 		'^\\d+$': {


### PR DESCRIPTION
While working on disabling common js transpilation to improve the calypso build process, I ran into [7 issues](https://github.com/Automattic/wp-calypso/pull/16057#issuecomment-335757214) where there were items being imported/exported that are missing.

One of them was: 
```
WARNING in ./client/state/sharing/publicize/publicize-actions/reducer.js
61:21-43 "export 'publicizeActionsSchema' was not found in './schema'
```

It looks like the schema just has the wrong exported name. seems like a simple fix.
I'm not sure what this code does / how to test though and would appreciate guidance / pointers.

Thanks!

Note: this is a blocker for https://github.com/Automattic/wp-calypso/pull/16057

cc @retrofox 