### PR TITLE
Reader Tags: remove recs

### DIFF
--- a/client/reader/tag-stream/index.js
+++ b/client/reader/tag-stream/index.js
@@ -7,12 +7,10 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import { recommendedTags, tagListing } from './controller';
+import { tagListing } from './controller';
 import { initAbTests, preloadReaderBundle, sidebar, updateLastRoute } from 'reader/controller';
 
 export default function() {
 	page( '/tag/*', preloadReaderBundle, initAbTests );
 	page( '/tag/:tag', updateLastRoute, sidebar, tagListing );
-
-	page( '/tags', initAbTests, updateLastRoute, sidebar, recommendedTags );
 }


### PR DESCRIPTION
While working on disabling common js transpilation to improve the calypso build process, I ran into [7 issues](https://github.com/Automattic/wp-calypso/pull/16057#issuecomment-335757214) where there were items being imported/exported that are missing.

One of them was: 

```
 WARNING in ./client/reader/tag-stream/index.js
17:55-70 "export 'recommendedTags' was not found in './controller'
```

Looks like there genuinely wasn't a `recommendedTags` inside of controller.  Whats up with that?
Is this the right fix?

Thanks!

Note: this is a blocker for https://github.com/Automattic/wp-calypso/pull/16057
