### PR TITLE
MySites Sharing: give services a shimmed hasOwnProperty

### DIFF
--- a/client/my-sites/sharing/connections/services/index.js
+++ b/client/my-sites/sharing/connections/services/index.js
@@ -2,3 +2,6 @@
 export eventbrite from './eventbrite';
 export instagram from './instagram';
 export google_photos from './google-photos';
+
+const services = new Set( [ 'eventbrite', 'instagram', 'google_photos' ] );
+export const hasOwnProperty = name => services.has( name );


### PR DESCRIPTION
While working on disabling common js transpilation to improve the calypso build process, I ran into [7 issues](https://github.com/Automattic/wp-calypso/pull/16057#issuecomment-335757214) where there were items being imported/exported that are missing.

One of them was: 

```
WARNING in ./client/my-sites/sharing/connections/services-group.jsx
44:20-45 "export 'hasOwnProperty' (imported as 'Components') was not found in './services'
```

it looks like theres an `import * as Component from 'services'` and then later in the code calling `hasOwnProperty` on Component.  The tricky thing here is that Component isn't a standard js object according to the es6 spec (need source). 

I've fixed the issue here by shimming `hasOwnProperty`.

Feel free to add commit here if you'd prefer a different fix.


Note: this is a blocker for https://github.com/Automattic/wp-calypso/pull/16057


To Test
-----
Don't know yet, would appreciate guidance