### PR TITLE
Comments: Fixes the select functionality on the comment header

### DIFF
--- a/client/blocks/comment-detail/index.jsx
+++ b/client/blocks/comment-detail/index.jsx
@@ -159,6 +159,8 @@ export class CommentDetail extends Component {
 		}
 	};
 
+	toggleSelected = () => this.props.toggleCommentSelected( getCommentStatusAction( this.props ) );
+
 	toggleLike = e => {
 		e.stopPropagation();
 


### PR DESCRIPTION
This PR restores the click functionality on the comment header checkbox, apparently missing during a rebase.

| before | after |
| --- | --- |
| ![before](https://user-images.githubusercontent.com/233601/31568456-e6781e3a-b04a-11e7-86ca-7bc1f0e11865.gif) | ![after](https://user-images.githubusercontent.com/233601/31568455-e653d7be-b04a-11e7-8833-4233a568a401.gif) |

To test, switch to _bulk edit_. Clicking on both the checkbox and the comment header should select the comment and increase the counter.
