### PR TITLE
Notices: Import `impure-lodash` to enhance testability

### DIFF
--- a/client/state/notices/actions.js
+++ b/client/state/notices/actions.js
@@ -4,7 +4,7 @@
  * @format
  */
 
-import { uniqueId } from 'lodash';
+import { uniqueId } from 'lib/impure-lodash';
 
 /**
  * Internal dependencies


### PR DESCRIPTION
`createNotice()` relies on `lodash.uniqueId()` for generating ids for
created notices in Calypso which calling functions can use to later
refer to those, cancel them, or update them.

Sadly, because `uniqueId()` has global shared-state it can be difficult
to write tests for its behavior as it's not pure. We can't easily mock
out specific **lodash** methods either because of some internals on how
it works. Therefore we created `impure-lodash` as a way of intercepting
these calls in a way which _is_ mockable and therefore testable.

After this change we should be able to test expectations with
`createNotice()` without having to expose too much of the internals of
that function, other than that it relies on `uniqueId()`

```js
jest.mock( 'lib/impure-lodash', () => ( {
	uniqueId: () => 'test-13'
} )

expect( dispatch ).to.have.been.calledWith(
	createError( 'Test' )
)
```