### PR TITLE
Editor/GroundControl: Move save-status in to it's own component

### DIFF
--- a/client/post-editor/editor-ground-control/index.jsx
+++ b/client/post-editor/editor-ground-control/index.jsx
@@ -27,6 +27,7 @@ import {
 	NestedSidebarPropType,
 } from 'post-editor/editor-sidebar/constants';
 import HistoryButton from 'post-editor/editor-ground-control/history-button';
+import SaveStatus from 'post-editor/editor-ground-control/save-status';
 
 export class EditorGroundControl extends PureComponent {
 	static propTypes = {
@@ -153,12 +154,6 @@ export class EditorGroundControl extends PureComponent {
 		return buttonLabels[ primaryButtonState ];
 	}
 
-	shouldShowStatusLabel() {
-		const { isSaving, post } = this.props;
-
-		return isSaving || ( post && post.ID && ! postUtils.isPublished( post ) );
-	}
-
 	isSaveAvailable() {
 		return (
 			! this.props.isSaving &&
@@ -259,11 +254,9 @@ export class EditorGroundControl extends PureComponent {
 	}
 
 	render() {
-		const { isSaving, translate } = this.props;
+		const { isSaving, post, translate } = this.props;
 		const isSaveAvailable = this.isSaveAvailable();
-		const shouldShowStatusLabel = this.shouldShowStatusLabel();
-		const hasRevisions =
-			isEnabled( 'post-editor/revisions' ) && get( this.props.post, 'revisions.length' );
+		const hasRevisions = isEnabled( 'post-editor/revisions' ) && get( post, 'revisions.length' );
 
 		return (
 			<Card className="editor-ground-control">
@@ -299,28 +292,12 @@ export class EditorGroundControl extends PureComponent {
 						</span>
 					</div>
 				) }
-				{ ( isSaveAvailable || shouldShowStatusLabel ) && (
-					<div className="editor-ground-control__status">
-						{ isSaveAvailable && (
-							<button
-								className="editor-ground-control__save button is-link"
-								onClick={ this.onSaveButtonClick }
-								tabIndex={ 3 }
-							>
-								{ translate( 'Save' ) }
-							</button>
-						) }
-						{ ! isSaveAvailable &&
-						shouldShowStatusLabel && (
-							<span
-								className="editor-ground-control__save-status"
-								data-e2e-status={ isSaving ? 'Saving…' : 'Saved' }
-							>
-								{ isSaving ? translate( 'Saving…' ) : translate( 'Saved' ) }
-							</span>
-						) }
-					</div>
-				) }
+				<SaveStatus
+					isSaving={ isSaving }
+					isSaveAvailable={ isSaveAvailable }
+					onClick={ this.onSaveButtonClick }
+					post={ post }
+				/>
 				{ hasRevisions && (
 					<HistoryButton
 						selectRevision={ this.props.selectRevision }

--- a/client/post-editor/editor-ground-control/index.jsx
+++ b/client/post-editor/editor-ground-control/index.jsx
@@ -297,6 +297,7 @@ export class EditorGroundControl extends PureComponent {
 					isSaveAvailable={ isSaveAvailable }
 					onClick={ this.onSaveButtonClick }
 					post={ post }
+					tabIndex={ 3 }
 				/>
 				{ hasRevisions && (
 					<HistoryButton

--- a/client/post-editor/editor-ground-control/save-status.jsx
+++ b/client/post-editor/editor-ground-control/save-status.jsx
@@ -1,0 +1,56 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import React from 'react';
+import PropTypes from 'prop-types';
+import { localize } from 'i18n-calypso';
+import { get, noop } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import postUtils from 'lib/posts/utils';
+
+// First, validate that the post had an ID, presumably this
+// allows us to determine whether or not it is stored as a draft.
+// More semantic way to express this??
+const isPostNotYetPublished = post => get( post, 'ID' ) && ! postUtils.isPublished( post );
+
+const SaveStatus = ( { isSaveAvailable, isSaving, onClick, post, translate } ) => {
+	const shouldShowStatusLabel = isSaveAvailable || isSaving || isPostNotYetPublished( post );
+
+	if ( ! shouldShowStatusLabel ) {
+		return null;
+	}
+
+	return (
+		<div className="editor-ground-control__status">
+			{ isSaveAvailable ? (
+				<button className="editor-ground-control__save button is-link" onClick={ onClick }>
+					{ translate( 'Save' ) }
+				</button>
+			) : (
+				<span
+					className="editor-ground-control__save-status"
+					data-e2e-status={ isSaving ? 'Saving…' : 'Saved' }
+				>
+					{ isSaving ? translate( 'Saving…' ) : translate( 'Saved' ) }
+				</span>
+			) }
+		</div>
+	);
+};
+
+SaveStatus.propTypes = {
+	isSaveAvailable: PropTypes.bool,
+	isSaving: PropTypes.bool,
+	post: PropTypes.object,
+	translate: PropTypes.func,
+};
+
+SaveStatus.defaultProps = {
+	onClick: noop,
+};
+
+export default localize( SaveStatus );

--- a/client/post-editor/editor-ground-control/save-status.jsx
+++ b/client/post-editor/editor-ground-control/save-status.jsx
@@ -17,7 +17,7 @@ import postUtils from 'lib/posts/utils';
 // More semantic way to express this??
 const isPostNotYetPublished = post => get( post, 'ID' ) && ! postUtils.isPublished( post );
 
-const SaveStatus = ( { isSaveAvailable, isSaving, onClick, post, translate } ) => {
+const SaveStatus = ( { isSaveAvailable, isSaving, onClick, post, tabIndex, translate } ) => {
 	const shouldShowStatusLabel = isSaveAvailable || isSaving || isPostNotYetPublished( post );
 
 	if ( ! shouldShowStatusLabel ) {
@@ -27,7 +27,11 @@ const SaveStatus = ( { isSaveAvailable, isSaving, onClick, post, translate } ) =
 	return (
 		<div className="editor-ground-control__status">
 			{ isSaveAvailable ? (
-				<button className="editor-ground-control__save button is-link" onClick={ onClick }>
+				<button
+					className="editor-ground-control__save button is-link"
+					onClick={ onClick }
+					tabIndex={ tabIndex }
+				>
 					{ translate( 'Save' ) }
 				</button>
 			) : (
@@ -46,11 +50,13 @@ SaveStatus.propTypes = {
 	isSaveAvailable: PropTypes.bool,
 	isSaving: PropTypes.bool,
 	post: PropTypes.object,
+	tabIndex: PropTypes.number,
 	translate: PropTypes.func,
 };
 
 SaveStatus.defaultProps = {
 	onClick: noop,
+	tabIndex: 0,
 };
 
 export default localize( SaveStatus );


### PR DESCRIPTION
### Summary
While working on changes to #18643 we noticed that the render logic had started to become more complex than we'd like to see embedded in the JSX.
To solve this, I've pulled this element out in to it's own component file and refactored the logic a little.

### Testing
There should be no change to the functionality - it should behave exactly as before.

The test plan at #18643 sums up how best to test this feature:
- Create a new post and go to the editor
- Note that there is no 'save status'
- Inspect the `editor-ground-control` element and note that there is no `editor-ground-control__status` child element as there was before.
- Make a few edits, waiting in between each change to watch the 'save status'
- Note that the post will be autosaved, denoted by a 'Saving...' label.
- Once saved, the label will reflect that state by showing 'Saved'
