### PR TITLE
NitPick: Rename isSaveEnabled to isSaveAvailable

### DIFF
--- a/client/post-editor/editor-ground-control/index.jsx
+++ b/client/post-editor/editor-ground-control/index.jsx
@@ -158,7 +158,7 @@ export class EditorGroundControl extends PureComponent {
 		return isSaving || ( post && post.ID && ! postUtils.isPublished( post ) );
 	}
 
-	isSaveEnabled() {
+	isSaveAvailable() {
 		return (
 			! this.props.isSaving &&
 			! this.props.isSaveBlocked &&
@@ -259,7 +259,7 @@ export class EditorGroundControl extends PureComponent {
 
 	render() {
 		const { isSaving, translate } = this.props;
-		const isSaveEnabled = this.isSaveEnabled();
+		const isSaveAvailable = this.isSaveAvailable();
 		const shouldShowStatusLabel = this.shouldShowStatusLabel();
 
 		return (
@@ -296,9 +296,9 @@ export class EditorGroundControl extends PureComponent {
 						</span>
 					</div>
 				) }
-				{ ( isSaveEnabled || shouldShowStatusLabel ) && (
+				{ ( isSaveAvailable || shouldShowStatusLabel ) && (
 					<div className="editor-ground-control__status">
-						{ isSaveEnabled && (
+						{ isSaveAvailable && (
 							<button
 								className="editor-ground-control__save button is-link"
 								onClick={ this.onSaveButtonClick }
@@ -307,7 +307,7 @@ export class EditorGroundControl extends PureComponent {
 								{ translate( 'Save' ) }
 							</button>
 						) }
-						{ ! isSaveEnabled &&
+						{ ! isSaveAvailable &&
 						shouldShowStatusLabel && (
 							<span
 								className="editor-ground-control__save-status"

--- a/client/post-editor/editor-ground-control/test/index.jsx
+++ b/client/post-editor/editor-ground-control/test/index.jsx
@@ -64,17 +64,17 @@ describe( 'EditorGroundControl', () => {
 		} );
 	} );
 
-	describe( '#isSaveEnabled()', () => {
+	describe( '#isSaveAvailable()', () => {
 		test( 'should return false if form is saving', () => {
 			var tree = shallow( <EditorGroundControl isSaving /> ).instance();
 
-			expect( tree.isSaveEnabled() ).to.be.false;
+			expect( tree.isSaveAvailable() ).to.be.false;
 		} );
 
 		test( 'should return false if saving is blocked', () => {
 			var tree = shallow( <EditorGroundControl isSaveBlocked /> ).instance();
 
-			expect( tree.isSaveEnabled() ).to.be.false;
+			expect( tree.isSaveAvailable() ).to.be.false;
 		} );
 
 		test( 'should return false if post does not exist', () => {
@@ -82,7 +82,7 @@ describe( 'EditorGroundControl', () => {
 				<EditorGroundControl isSaving={ false } hasContent isDirty />
 			).instance();
 
-			expect( tree.isSaveEnabled() ).to.be.false;
+			expect( tree.isSaveAvailable() ).to.be.false;
 		} );
 
 		test( 'should return true if dirty and post has content and post is not published', () => {
@@ -90,13 +90,13 @@ describe( 'EditorGroundControl', () => {
 				<EditorGroundControl isSaving={ false } post={ {} } hasContent isDirty />
 			).instance();
 
-			expect( tree.isSaveEnabled() ).to.be.true;
+			expect( tree.isSaveAvailable() ).to.be.true;
 		} );
 
 		test( 'should return false if dirty, but post has no content', () => {
 			var tree = shallow( <EditorGroundControl isSaving={ false } isDirty /> ).instance();
 
-			expect( tree.isSaveEnabled() ).to.be.false;
+			expect( tree.isSaveAvailable() ).to.be.false;
 		} );
 
 		test( 'should return false if dirty and post is published', () => {
@@ -104,7 +104,7 @@ describe( 'EditorGroundControl', () => {
 				<EditorGroundControl isSaving={ false } post={ { status: 'publish' } } isDirty />
 			).instance();
 
-			expect( tree.isSaveEnabled() ).to.be.false;
+			expect( tree.isSaveAvailable() ).to.be.false;
 		} );
 	} );
 


### PR DESCRIPTION
### Summary
We use `isEnabled` and other similar uses of 'enabled' to show whether a feature or a config option is enabled or not.
The function `isSaveEnabled()` is using the same semantics to denote something different and this was bugging me a little while working on this file. To me, 'available' is more expressive of the behaviour, so I'm proposing a change to `isSaveAvailable`.

I fully understand that this change is quite subjective, so I'll not push strongly on this - happy to just ditch the PR if others deem it inconsequential.

Thanks!