### PR TITLE
Product Values: es6ify exports

### DIFF
--- a/client/lib/analytics/ad-tracking.js
+++ b/client/lib/analytics/ad-tracking.js
@@ -14,7 +14,7 @@ import { v4 as uuid } from 'uuid';
  * Internal dependencies
  */
 import config from 'config';
-import productsValues from 'lib/products-values';
+import { isJetpackPlan } from 'lib/products-values';
 import userModule from 'lib/user';
 import { loadScript } from 'lib/load-script';
 import { shouldSkipAds } from 'lib/analytics/utils';
@@ -612,9 +612,9 @@ function recordProduct( product, orderId ) {
 		return loadTrackingScripts( recordProduct.bind( null, product, orderId ) );
 	}
 
-	const isJetpackPlan = productsValues.isJetpackPlan( product );
+	const isJetpack = isJetpackPlan( product );
 
-	if ( isJetpackPlan ) {
+	if ( isJetpack ) {
 		debug( 'Recording Jetpack purchase', product );
 	} else {
 		debug( 'Recording purchase', product );
@@ -636,10 +636,8 @@ function recordProduct( product, orderId ) {
 		if ( isAdwordsEnabled ) {
 			if ( window.google_trackConversion ) {
 				window.google_trackConversion( {
-					google_conversion_id: isJetpackPlan
-						? ADWORDS_CONVERSION_ID_JETPACK
-						: ADWORDS_CONVERSION_ID,
-					google_conversion_label: isJetpackPlan
+					google_conversion_id: isJetpack ? ADWORDS_CONVERSION_ID_JETPACK : ADWORDS_CONVERSION_ID,
+					google_conversion_label: isJetpack
 						? TRACKING_IDS.googleConversionLabelJetpack
 						: TRACKING_IDS.googleConversionLabel,
 					google_conversion_value: product.cost,
@@ -697,7 +695,7 @@ function recordProduct( product, orderId ) {
 					ec: 'purchase',
 					gv: costUSD,
 				};
-				if ( isJetpackPlan ) {
+				if ( isJetpack ) {
 					// `el` must be included only for jetpack plans
 					bingParams.el = 'jetpack';
 				}

--- a/client/lib/cart-values/index.js
+++ b/client/lib/cart-values/index.js
@@ -13,7 +13,7 @@ import config from 'config';
  * Internal dependencies
  */
 import cartItems from './cart-items';
-import productsValues from 'lib/products-values';
+import { isCredits, isPrivacyProtection, whitelistAttributes } from 'lib/products-values';
 
 /**
  * Create a new empty cart.
@@ -41,11 +41,11 @@ function applyCoupon( coupon ) {
 }
 
 function canRemoveFromCart( cart, cartItem ) {
-	if ( productsValues.isCredits( cartItem ) ) {
+	if ( isCredits( cartItem ) ) {
 		return false;
 	}
 
-	if ( cartItems.hasRenewalItem( cart ) && productsValues.isPrivacyProtection( cartItem ) ) {
+	if ( cartItems.hasRenewalItem( cart ) && isPrivacyProtection( cartItem ) ) {
 		return false;
 	}
 
@@ -111,7 +111,7 @@ function fillInAllCartItemAttributes( cart, products ) {
 
 function fillInSingleCartItemAttributes( cartItem, products ) {
 	var product = products[ cartItem.product_slug ],
-		attributes = productsValues.whitelistAttributes( product );
+		attributes = whitelistAttributes( product );
 
 	return extend( {}, cartItem, attributes );
 }

--- a/client/lib/products-values/index.js
+++ b/client/lib/products-values/index.js
@@ -53,7 +53,7 @@ function assertValidProduct( product ) {
 	}
 }
 
-function formatProduct( product ) {
+export function formatProduct( product ) {
 	return assign( {}, product, {
 		product_slug: product.product_slug || product.productSlug,
 		product_type: product.product_type || product.productType,
@@ -65,42 +65,42 @@ function formatProduct( product ) {
 	} );
 }
 
-function isChargeback( product ) {
+export function isChargeback( product ) {
 	product = formatProduct( product );
 	assertValidProduct( product );
 
 	return product.product_slug === PLAN_CHARGEBACK;
 }
 
-function includesProduct( products, product ) {
+export function includesProduct( products, product ) {
 	product = formatProduct( product );
 	assertValidProduct( product );
 
 	return products.indexOf( product.product_slug ) >= 0;
 }
 
-function isFreePlan( product ) {
+export function isFreePlan( product ) {
 	product = formatProduct( product );
 	assertValidProduct( product );
 
 	return product.product_slug === PLAN_FREE;
 }
 
-function isFreeJetpackPlan( product ) {
+export function isFreeJetpackPlan( product ) {
 	product = formatProduct( product );
 	assertValidProduct( product );
 
 	return product.product_slug === PLAN_JETPACK_FREE;
 }
 
-function isFreeTrial( product ) {
+export function isFreeTrial( product ) {
 	product = formatProduct( product );
 	assertValidProduct( product );
 
 	return Boolean( product.free_trial );
 }
 
-function isPersonal( product ) {
+export function isPersonal( product ) {
 	const personalProducts = [ PLAN_PERSONAL, PLAN_JETPACK_PERSONAL, PLAN_JETPACK_PERSONAL_MONTHLY ];
 
 	product = formatProduct( product );
@@ -109,7 +109,7 @@ function isPersonal( product ) {
 	return personalProducts.indexOf( product.product_slug ) >= 0;
 }
 
-function isPremium( product ) {
+export function isPremium( product ) {
 	const premiumProducts = [ PLAN_PREMIUM, PLAN_JETPACK_PREMIUM, PLAN_JETPACK_PREMIUM_MONTHLY ];
 
 	product = formatProduct( product );
@@ -118,7 +118,7 @@ function isPremium( product ) {
 	return premiumProducts.indexOf( product.product_slug ) >= 0;
 }
 
-function isBusiness( product ) {
+export function isBusiness( product ) {
 	const businessProducts = [ PLAN_BUSINESS, PLAN_JETPACK_BUSINESS, PLAN_JETPACK_BUSINESS_MONTHLY ];
 
 	product = formatProduct( product );
@@ -127,60 +127,60 @@ function isBusiness( product ) {
 	return businessProducts.indexOf( product.product_slug ) >= 0;
 }
 
-function isEnterprise( product ) {
+export function isEnterprise( product ) {
 	product = formatProduct( product );
 	assertValidProduct( product );
 
 	return product.product_slug === PLAN_WPCOM_ENTERPRISE;
 }
 
-function isJetpackPlan( product ) {
+export function isJetpackPlan( product ) {
 	product = formatProduct( product );
 	assertValidProduct( product );
 
 	return JETPACK_PLANS.indexOf( product.product_slug ) >= 0;
 }
 
-function isJetpackBusiness( product ) {
+export function isJetpackBusiness( product ) {
 	product = formatProduct( product );
 	assertValidProduct( product );
 
 	return isBusiness( product ) && isJetpackPlan( product );
 }
 
-function isJetpackPremium( product ) {
+export function isJetpackPremium( product ) {
 	product = formatProduct( product );
 	assertValidProduct( product );
 
 	return isPremium( product ) && isJetpackPlan( product );
 }
 
-function isVipPlan( product ) {
+export function isVipPlan( product ) {
 	product = formatProduct( product );
 	assertValidProduct( product );
 
 	return 'vip' === product.product_slug;
 }
 
-function isJetpackMonthlyPlan( product ) {
+export function isJetpackMonthlyPlan( product ) {
 	return isMonthly( product ) && isJetpackPlan( product );
 }
 
-function isMonthly( product ) {
+export function isMonthly( product ) {
 	product = formatProduct( product );
 	assertValidProduct( product );
 
 	return parseInt( product.bill_period, 10 ) === PLAN_MONTHLY_PERIOD;
 }
 
-function isJpphpBundle( product ) {
+export function isJpphpBundle( product ) {
 	product = formatProduct( product );
 	assertValidProduct( product );
 
 	return product.product_slug === PLAN_HOST_BUNDLE;
 }
 
-function isPlan( product ) {
+export function isPlan( product ) {
 	product = formatProduct( product );
 	assertValidProduct( product );
 
@@ -193,18 +193,18 @@ function isPlan( product ) {
 	);
 }
 
-function isDotComPlan( product ) {
+export function isDotComPlan( product ) {
 	return isPlan( product ) && ! isJetpackPlan( product );
 }
 
-function isPrivacyProtection( product ) {
+export function isPrivacyProtection( product ) {
 	product = formatProduct( product );
 	assertValidProduct( product );
 
 	return product.product_slug === 'private_whois';
 }
 
-function isDomainProduct( product ) {
+export function isDomainProduct( product ) {
 	product = formatProduct( product );
 	assertValidProduct( product );
 
@@ -213,42 +213,42 @@ function isDomainProduct( product ) {
 	);
 }
 
-function isDomainRedemption( product ) {
+export function isDomainRedemption( product ) {
 	product = formatProduct( product );
 	assertValidProduct( product );
 
 	return product.product_slug === 'domain_redemption';
 }
 
-function isDomainRegistration( product ) {
+export function isDomainRegistration( product ) {
 	product = formatProduct( product );
 	assertValidProduct( product );
 
 	return !! product.is_domain_registration;
 }
 
-function isDomainMapping( product ) {
+export function isDomainMapping( product ) {
 	product = formatProduct( product );
 	assertValidProduct( product );
 
 	return product.product_slug === 'domain_map';
 }
 
-function isSiteRedirect( product ) {
+export function isSiteRedirect( product ) {
 	product = formatProduct( product );
 	assertValidProduct( product );
 
 	return product.product_slug === 'offsite_redirect';
 }
 
-function isCredits( product ) {
+export function isCredits( product ) {
 	product = formatProduct( product );
 	assertValidProduct( product );
 
 	return 'wordpress-com-credits' === product.product_slug;
 }
 
-function getDomainProductRanking( product ) {
+export function getDomainProductRanking( product ) {
 	product = formatProduct( product );
 	assertValidProduct( product );
 
@@ -261,7 +261,7 @@ function getDomainProductRanking( product ) {
 	}
 }
 
-function isDependentProduct( product, dependentProduct, domainsWithPlansOnly ) {
+export function isDependentProduct( product, dependentProduct, domainsWithPlansOnly ) {
 	let isPlansOnlyDependent = false;
 
 	product = formatProduct( product );
@@ -285,13 +285,14 @@ function isDependentProduct( product, dependentProduct, domainsWithPlansOnly ) {
 			product.meta === dependentProduct.meta )
 	);
 }
-function isFreeWordPressComDomain( product ) {
+
+export function isFreeWordPressComDomain( product ) {
 	product = formatProduct( product );
 	assertValidProduct( product );
 	return product.is_free === true;
 }
 
-function isGoogleApps( product ) {
+export function isGoogleApps( product ) {
 	product = formatProduct( product );
 	assertValidProduct( product );
 
@@ -302,60 +303,60 @@ function isGoogleApps( product ) {
 	);
 }
 
-function isGuidedTransfer( product ) {
+export function isGuidedTransfer( product ) {
 	product = formatProduct( product );
 	assertValidProduct( product );
 
 	return 'guided_transfer' === product.product_slug;
 }
 
-function isTheme( product ) {
+export function isTheme( product ) {
 	product = formatProduct( product );
 	assertValidProduct( product );
 
 	return 'premium_theme' === product.product_slug;
 }
 
-function isCustomDesign( product ) {
+export function isCustomDesign( product ) {
 	product = formatProduct( product );
 	assertValidProduct( product );
 
 	return 'custom-design' === product.product_slug;
 }
 
-function isNoAds( product ) {
+export function isNoAds( product ) {
 	product = formatProduct( product );
 	assertValidProduct( product );
 
 	return 'no-adverts/no-adverts.php' === product.product_slug;
 }
 
-function isVideoPress( product ) {
+export function isVideoPress( product ) {
 	product = formatProduct( product );
 	assertValidProduct( product );
 
 	return 'videopress' === product.product_slug;
 }
 
-function isUnlimitedSpace( product ) {
+export function isUnlimitedSpace( product ) {
 	product = formatProduct( product );
 	assertValidProduct( product );
 
 	return 'unlimited_space' === product.product_slug;
 }
 
-function isUnlimitedThemes( product ) {
+export function isUnlimitedThemes( product ) {
 	product = formatProduct( product );
 	assertValidProduct( product );
 
 	return 'unlimited_themes' === product.product_slug;
 }
 
-function whitelistAttributes( product ) {
+export function whitelistAttributes( product ) {
 	return pick( product, Object.keys( schema.properties ) );
 }
 
-function isSpaceUpgrade( product ) {
+export function isSpaceUpgrade( product ) {
 	product = formatProduct( product );
 	assertValidProduct( product );
 
@@ -367,45 +368,3 @@ function isSpaceUpgrade( product ) {
 		'100gb_space_upgrade' === product.product_slug
 	);
 }
-
-export default {
-	formatProduct,
-	getDomainProductRanking,
-	includesProduct,
-	isBusiness,
-	isChargeback,
-	isCredits,
-	isCustomDesign,
-	isDependentProduct,
-	isDomainMapping,
-	isDomainProduct,
-	isDomainRedemption,
-	isDomainRegistration,
-	isDotComPlan,
-	isEnterprise,
-	isFreeJetpackPlan,
-	isFreePlan,
-	isPersonal,
-	isFreeTrial,
-	isFreeWordPressComDomain,
-	isGoogleApps,
-	isGuidedTransfer,
-	isJetpackBusiness,
-	isJetpackPlan,
-	isJetpackPremium,
-	isJetpackMonthlyPlan,
-	isVipPlan,
-	isMonthly,
-	isJpphpBundle,
-	isNoAds,
-	isPlan,
-	isPremium,
-	isPrivacyProtection,
-	isSiteRedirect,
-	isSpaceUpgrade,
-	isTheme,
-	isUnlimitedSpace,
-	isUnlimitedThemes,
-	isVideoPress,
-	whitelistAttributes,
-};

--- a/client/me/next-steps/index.jsx
+++ b/client/me/next-steps/index.jsx
@@ -15,7 +15,7 @@ import NextStepsBox from './next-steps-box';
 import MeSidebarNavigation from 'me/sidebar-navigation';
 import steps from './steps';
 import analytics from 'lib/analytics';
-import productsValues from 'lib/products-values';
+import { isPlan } from 'lib/products-values';
 /* eslint-disable no-restricted-imports */
 import observe from 'lib/mixins/data-observe';
 import sitesFactory from 'lib/sites-list';
@@ -163,7 +163,7 @@ export default localize(
 
 		userHasPurchasedAPlan: function() {
 			return this.props.sites.get().some( function( site ) {
-				return productsValues.isPlan( site.plan );
+				return isPlan( site.plan );
 			} );
 		},
 

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -21,7 +21,6 @@ import analytics from 'lib/analytics';
 import Button from 'components/button';
 import config from 'config';
 import CurrentSite from 'my-sites/current-site';
-import productsValues from 'lib/products-values';
 import ManageMenu from './manage-menu';
 import Sidebar from 'layout/sidebar';
 import SidebarButton from 'layout/sidebar/button';
@@ -32,7 +31,7 @@ import SidebarMenu from 'layout/sidebar/menu';
 import SidebarRegion from 'layout/sidebar/region';
 import StatsSparkline from 'blocks/stats-sparkline';
 import JetpackLogo from 'components/jetpack-logo';
-import { isPersonal, isPremium, isBusiness } from 'lib/products-values';
+import { isPersonal, isPremium, isBusiness, isPlan, isFreeTrial } from 'lib/products-values';
 import { getCurrentUser } from 'state/current-user/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getCurrentLayoutFocus } from 'state/ui/layout-focus/selectors';
@@ -343,13 +342,13 @@ export class MySitesSidebar extends Component {
 
 		let linkClass = 'upgrades-nudge';
 
-		if ( site && productsValues.isPlan( site.plan ) ) {
+		if ( site && isPlan( site.plan ) ) {
 			linkClass += ' is-paid-plan';
 		}
 
 		let planName = site && site.plan.product_name_short;
 
-		if ( site && productsValues.isFreeTrial( site.plan ) ) {
+		if ( site && isFreeTrial( site.plan ) ) {
 			planName = this.props.translate( 'Trial', {
 				context: 'Label in the sidebar indicating that the user is on the free trial for a plan.',
 			} );


### PR DESCRIPTION
In order to enable tree-shaking in our build step, exporting needs to adhere to proper es6 rules.

More info here: https://github.com/Automattic/wp-calypso/pull/16057#issuecomment-335047339

### Changes
`my-sites/controller.js`
```js
export default {
    func1 () {},
    func2 () {},
}

// becomes

export func1 = () => {}
export func2 = () => {}
```

Consuming js
```js
import controller from 'my-sites/controller';
...
controller.func1();
controller.func2();

// becomes

import { func1, func2 } from 'my-sites/controller';
```

### Testing
Navigate around all sections of My Sites and see if any errors occur.
