### PR TITLE
Fix #18062 keyed Suggestions uses wrong target to hover/select the suggestion

### DIFF
--- a/client/components/keyed-suggestions/index.jsx
+++ b/client/components/keyed-suggestions/index.jsx
@@ -135,12 +135,12 @@ class KeyedSuggestions extends React.Component {
 	onMouseDown = event => {
 		event.stopPropagation();
 		event.preventDefault();
-		const suggestion = event.target.textContent.split( ' ' )[ 0 ];
+		const suggestion = event.currentTarget.textContent.split( ' ' )[ 0 ];
 		this.props.suggest( suggestion );
 	};
 
 	onMouseOver = event => {
-		const suggestion = event.target.textContent.split( ' ' )[ 0 ];
+		const suggestion = event.currentTarget.textContent.split( ' ' )[ 0 ];
 		this.setState( {
 			suggestionPosition: this.getPositionForSuggestion( suggestion ),
 			currentSuggestion: suggestion,


### PR DESCRIPTION
Keyed Suggestions `mousedown` and `mouseover` events used the event's `target` property, which is what triggered the event, instead of `currentTarget` which is what the listener was attached to.

Practically speaking, this means when clicking or hovering inside deeply nested HTML in a suggestion, we were getting the `textContent` of only part of the suggestion, which then breaks the rest fo the suggestion extraction chain.