### PR TITLE
Pre-commit: Do not prettier + add dirty files

### DIFF
--- a/bin/pre-commit-hook.js
+++ b/bin/pre-commit-hook.js
@@ -12,7 +12,6 @@ const spawnSync = require( 'child_process' ).spawnSync;
 const chalk = require( 'chalk' );
 const fs = require( 'fs' );
 const prettier = require( 'prettier' );
-const path = require( 'path' );
 
 /**
  * Internal dependencies
@@ -39,8 +38,7 @@ function parseGitDiffToPathArray( command ) {
 		.toString()
 		.split( '\n' )
 		.map( name => name.trim() )
-		.filter( name => name.endsWith( '.js' ) || name.endsWith( '.jsx' ) )
-		.map( file => path.join( __dirname, '../', file ) );
+		.filter( name => name.endsWith( '.js' ) || name.endsWith( '.jsx' ) );
 }
 
 const dirtyFiles = new Set( parseGitDiffToPathArray( 'git diff --name-only --diff-filter=ACM' ) );

--- a/bin/pre-commit-hook.js
+++ b/bin/pre-commit-hook.js
@@ -28,51 +28,49 @@ console.log(
 // Make quick pass over config files on every change
 require( '../server/config/validate-config-keys' );
 
-const dirtyFiles = new Set(
-	execSync( 'git diff --name-only --diff-filter=ACM' )
+/**
+ * Parses the output of a git diff command into javascript file paths.
+ *
+ * @param   {String} command Command to run. Expects output like `git diff --name-only […]`
+ * @returns {Array}          Paths output from git command
+ */
+function parseGitDiffToPathArray( command ) {
+	return execSync( command )
 		.toString()
 		.split( '\n' )
 		.map( name => name.trim() )
 		.filter( name => name.endsWith( '.js' ) || name.endsWith( '.jsx' ) )
-		.map( file => path.join( __dirname, '../', file ) )
-);
+		.map( file => path.join( __dirname, '../', file ) );
+}
 
-const files = execSync( 'git diff --cached --name-only --diff-filter=ACM' )
-	.toString()
-	.split( '\n' )
-	.map( name => name.trim() )
-	.filter( name => name.endsWith( '.js' ) || name.endsWith( '.jsx' ) );
+const dirtyFiles = new Set( parseGitDiffToPathArray( 'git diff --name-only --diff-filter=ACM' ) );
+
+const files = parseGitDiffToPathArray( 'git diff --cached --name-only --diff-filter=ACM' );
 
 // run prettier for any files in the commit that have @format within their first docblock
-files
-	.map( file => [ file, path.join( __dirname, '../', file ) ] )
-	.forEach( ( [ file, fullPath ] ) => {
-		const text = fs.readFileSync( fullPath, 'utf8' );
-		if ( shouldFormat( text ) ) {
-			const formattedText = prettier.format( text, {} );
-
-			// No change required.
-			if ( text === formattedText ) {
-				return;
-			}
-
-			// File has unstaged changes. It's a bad idea to modify and add it before commit.
-			if ( dirtyFiles.has( fullPath ) ) {
-				console.log(
-					chalk.red(
-						`Prettier will not be attempted for file: ${ chalk.white(
-							file
-						) } because it has unstaged changes.`
-					)
-				);
-				return;
-			}
-
-			fs.writeFileSync( fullPath, formattedText );
-			console.log( `Prettier formatting file: ${ fullPath } because it contains the @format flag` );
-			execSync( `git add ${ fullPath }` );
+files.forEach( file => {
+	const text = fs.readFileSync( file, 'utf8' );
+	if ( shouldFormat( text ) ) {
+		// File has unstaged changes. It's a bad idea to modify and add it before commit.
+		if ( dirtyFiles.has( file ) ) {
+			console.log(
+				chalk.red( `${ file } will not be auto-formatted because it has unstaged changes.` )
+			);
+			return;
 		}
-	} );
+
+		const formattedText = prettier.format( text, {} );
+
+		// No change required.
+		if ( text === formattedText ) {
+			return;
+		}
+
+		fs.writeFileSync( file, formattedText );
+		console.log( `Prettier formatting file: ${ file } because it contains the @format flag` );
+		execSync( `git add ${ file }` );
+	}
+} );
 
 // linting should happen after formatting
 const lintResult = spawnSync( 'eslint-eslines', [ ...files, '--', '--diff=index' ], {


### PR DESCRIPTION
When a prettier flagged file is partially staged and commited, the pre-commit hook will run prttier and commit the whole file (#17039). This breaks workflows that rely on partial commits.

This PR includes the following changes:

* Do not take action if `prettier` does not need to format files.
* Do not `prettier` or `git add` dirty files.
* ~Minor: extract unified `shouldFormat` utility function from `pre-commit` and `reformat-files`~ moved to #18991 

~If there is significant discussion about the approach I've take to ignore dirty files for the pre-commit `prettier`, I'm happy to factor out the other bits into a separate PRs.~

## Testing
1. Make some changes to the repo (at least two independent changes to 1 file).
1. Partially commit the file `git add -p $FILE`, pick `y`es and `n`o for different patches. You may need to `s`plit them if the changes are adjacent.
1. Make changes that adhere to prettier formatting and that _do not_. Dirty files that are already prettier formatted do not cause problems.
1. run `git ci`.
1. When the pre-commit script runs on your partially staged (dirty) file, does it abort the `prettier` + `git add`? 👍 

## Feedback 🙏 

* How's the messaging? Colors?
* Do we want to auto-run `prettier`, but not commit? It seems safest just to not touch the file.
* Rather than a per file message, should we should a big warning at the end like:
  > You're have committed the following files which are flagged for auto-formatting but *are not* correctly formatted and cannot be auto-formatted by the commit because they have unstaged changes:
  > * …
  > 
  > Try running `npm run reformat-files` and try ammending the previous commit before you push

Fixes #17039