### PR TITLE
Atomic Store: Remove wp.com domains from Domains signup step

### DIFF
--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -31,6 +31,7 @@ import {
 import { composeAnalytics, recordGoogleEvent, recordTracksEvent } from 'state/analytics/actions';
 import { getCurrentUser, currentUserHasFlag } from 'state/current-user/selectors';
 import Notice from 'components/notice';
+import { getDesignType } from 'state/signup/steps/design-type/selectors';
 
 const productsList = productsListFactory();
 
@@ -192,6 +193,10 @@ class DomainsStep extends React.Component {
 		} );
 	};
 
+	isDomainForAtomicSite = () => {
+		return 'store' === this.props.designType;
+	};
+
 	domainForm = () => {
 		const initialState = this.props.step ? this.props.step.domainForm : this.state.domainForm;
 		const includeDotBlogSubdomain = this.props.flowName === 'subdomain';
@@ -209,9 +214,7 @@ class DomainsStep extends React.Component {
 				offerMappingOption={ ! this.props.isDomainOnly }
 				analyticsSection="signup"
 				domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
-				includeWordPressDotCom={
-					! this.props.isDomainOnly && 'atomic-store' !== this.props.flowName
-				}
+				includeWordPressDotCom={ ! this.props.isDomainOnly && ! this.isDomainForAtomicSite() }
 				includeDotBlogSubdomain={ includeDotBlogSubdomain }
 				isSignupStep
 				showExampleSuggestions
@@ -333,6 +336,7 @@ export default connect(
 			? currentUserHasFlag( state, DOMAINS_WITH_PLANS_ONLY )
 			: true,
 		surveyVertical: getSurveyVertical( state ),
+		designType: getDesignType( state ),
 	} ),
 	{
 		recordAddDomainButtonClick,

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -209,7 +209,9 @@ class DomainsStep extends React.Component {
 				offerMappingOption={ ! this.props.isDomainOnly }
 				analyticsSection="signup"
 				domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
-				includeWordPressDotCom={ ! this.props.isDomainOnly }
+				includeWordPressDotCom={
+					! this.props.isDomainOnly && 'atomic-store' !== this.props.flowName
+				}
 				includeDotBlogSubdomain={ includeDotBlogSubdomain }
 				isSignupStep
 				showExampleSuggestions


### PR DESCRIPTION
For atomic sites, WP.com domains (`*.wordpress.com`) cannot be used so they should not be included in list of available domains.

`RegisterDomainStep` component already supports `includeWordPressDotCom` prop which this PR sets to `false` if `flowName` is `atomic-store`.

##  Test Plan

1. Start the Atomic Store flow by navigating to `/start/atomic-store`.
2. Select **Store** as type of site
3. Enter a unique domain fragment (ex: `donatatwalker123`).
4. Confirm that WP.com domain is not shown (ex: `donatatwalker123.wordpress.com`)
5. Repeat steps with another type of site and verify that WP.com domain(s) are displayed.