### PR TITLE
Me: Drop valueLink

### DIFF
--- a/client/components/forms/form-checkbox/index.jsx
+++ b/client/components/forms/form-checkbox/index.jsx
@@ -1,9 +1,7 @@
+/** @format */
 /**
  * External dependencies
- *
- * @format
  */
-
 import React from 'react';
 import classnames from 'classnames';
 

--- a/client/me/account-password/index.jsx
+++ b/client/me/account-password/index.jsx
@@ -45,6 +45,7 @@ const AccountPassword = React.createClass( {
 
 	getInitialState: function() {
 		return {
+			password: '',
 			pendingValidation: true,
 			savingPassword: false,
 			isUnsaved: false,
@@ -70,7 +71,8 @@ const AccountPassword = React.createClass( {
 		);
 	},
 
-	handlePasswordChange: function( newPassword ) {
+	handlePasswordChange: function( event ) {
+		const newPassword = event.currentTarget.value;
 		debug( 'Handle password change has been called.' );
 		this.debouncedPasswordValidate();
 		this.setState( {
@@ -128,10 +130,6 @@ const AccountPassword = React.createClass( {
 
 	render: function() {
 		const { translate } = this.props;
-		const passwordValueLink = {
-			value: this.state.password,
-			requestChange: this.handlePasswordChange,
-		};
 		const passwordInputClasses = classNames( {
 			'account-password__password-field': true,
 			'is-error': this.props.accountPasswordData.getValidationFailures().length,
@@ -149,8 +147,9 @@ const AccountPassword = React.createClass( {
 						className={ passwordInputClasses }
 						id="password"
 						name="password"
+						onChange={ this.handlePasswordChange }
 						onFocus={ this.recordFocusEvent( 'New Password Field' ) }
-						valueLink={ passwordValueLink }
+						value={ this.state.password }
 						submitting={ this.state.savingPassword }
 					/>
 

--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -60,6 +60,7 @@ const Account = localize(
 	React.createClass( {
 		displayName: 'Account',
 
+		// form-base mixin is needed for getDisabledState() (and possibly other uses?)
 		mixins: [ formBase, observe( 'userSettings', 'username' ), eventRecorder ],
 
 		propTypes: {

--- a/client/me/form-base/index.js
+++ b/client/me/form-base/index.js
@@ -56,7 +56,7 @@ export default {
 	},
 
 	getSetting: function( settingName ) {
-		return this.props.userSettings.getSetting( settingName );
+		return this.props.userSettings.getSetting( settingName ) || '';
 	},
 
 	toggleSetting: function( event ) {

--- a/client/me/form-base/index.js
+++ b/client/me/form-base/index.js
@@ -59,6 +59,12 @@ export default {
 		return this.props.userSettings.getSetting( settingName );
 	},
 
+	toggleSetting: function( settingName ) {
+		return () => {
+			this.props.userSettings.updateSetting( settingName, ! this.getSetting( settingName ) );
+		};
+	},
+
 	updateSetting: function( settingName ) {
 		return event => {
 			this.props.userSettings.updateSetting( settingName, event.currentTarget.value );

--- a/client/me/form-base/index.js
+++ b/client/me/form-base/index.js
@@ -60,8 +60,8 @@ export default {
 	},
 
 	updateSetting: function( settingName ) {
-		return value => {
-			this.props.userSettings.updateSetting( settingName, value );
+		return event => {
+			this.props.userSettings.updateSetting( settingName, event.currentTarget.value );
 		};
 	},
 

--- a/client/me/form-base/index.js
+++ b/client/me/form-base/index.js
@@ -59,16 +59,14 @@ export default {
 		return this.props.userSettings.getSetting( settingName );
 	},
 
-	toggleSetting: function( settingName ) {
-		return () => {
-			this.props.userSettings.updateSetting( settingName, ! this.getSetting( settingName ) );
-		};
+	toggleSetting: function( event ) {
+		const { name } = event.currentTarget;
+		this.props.userSettings.updateSetting( name, ! this.getSetting( name ) );
 	},
 
-	updateSetting: function( settingName ) {
-		return event => {
-			this.props.userSettings.updateSetting( settingName, event.currentTarget.value );
-		};
+	updateSetting: function( event ) {
+		const { name, value } = event.currentTarget;
+		this.props.userSettings.updateSetting( name, value );
 	},
 
 	submitForm: function( event ) {

--- a/client/me/form-base/index.js
+++ b/client/me/form-base/index.js
@@ -55,12 +55,13 @@ export default {
 		}
 	},
 
-	valueLink: function( settingName ) {
-		return {
-			value: this.props.userSettings.getSetting( settingName ),
-			requestChange: function( value ) {
-				this.props.userSettings.updateSetting( settingName, value );
-			}.bind( this ),
+	getSetting: function( settingName ) {
+		return this.props.userSettings.getSetting( settingName );
+	},
+
+	updateSetting: function( settingName ) {
+		return value => {
+			this.props.userSettings.updateSetting( settingName, value );
 		};
 	},
 

--- a/client/me/notification-settings/reader-subscriptions/index.jsx
+++ b/client/me/notification-settings/reader-subscriptions/index.jsx
@@ -95,7 +95,7 @@ export default protectForm(
 										disabled={ this.getDisabledState() }
 										id="subscription_delivery_email_default"
 										name="subscription_delivery_email_default"
-										onChange={ this.updateSetting( 'subscription_delivery_email_default' ) }
+										onChange={ this.updateSetting }
 										onFocus={ this.recordFocusEvent( 'Default Email Delivery' ) }
 										value={ this.getSetting( 'subscription_delivery_email_default' ) }
 									>
@@ -120,7 +120,7 @@ export default protectForm(
 											disabled={ this.getDisabledState() }
 											id="subscription_delivery_jabber_default"
 											name="subscription_delivery_jabber_default"
-											onChange={ this.toggleSetting( 'subscription_delivery_jabber_default' ) }
+											onChange={ this.toggleSetting }
 											onClick={ this.recordCheckboxEvent( 'Notification Delivery by Jabber' ) }
 										/>
 										<span>
@@ -137,7 +137,7 @@ export default protectForm(
 										disabled={ this.getDisabledState() }
 										id="subscription_delivery_mail_option"
 										name="subscription_delivery_mail_option"
-										onChange={ this.updateSetting( 'subscription_delivery_mail_option' ) }
+										onChange={ this.updateSetting }
 										onFocus={ this.recordFocusEvent( 'Email Delivery Format' ) }
 										value={ this.getSetting( 'subscription_delivery_mail_option' ) }
 									>
@@ -155,7 +155,7 @@ export default protectForm(
 										className="me-notification-settings__delivery-window"
 										id="subscription_delivery_day"
 										name="subscription_delivery_day"
-										onChange={ this.updateSetting( 'subscription_delivery_day' ) }
+										onChange={ this.updateSetting }
 										onFocus={ this.recordFocusEvent( 'Email Delivery Window Day' ) }
 										value={ this.getSetting( 'subscription_delivery_day' ) }
 									>
@@ -172,7 +172,7 @@ export default protectForm(
 										disabled={ this.getDisabledState() }
 										id="subscription_delivery_hour"
 										name="subscription_delivery_hour"
-										onChange={ this.updateSetting( 'subscription_delivery_hour' ) }
+										onChange={ this.updateSetting }
 										onFocus={ this.recordFocusEvent( 'Email Delivery Window Time' ) }
 										value={ this.getSetting( 'subscription_delivery_hour' ) }
 									>
@@ -205,7 +205,7 @@ export default protectForm(
 											disabled={ this.getDisabledState() }
 											id="subscription_delivery_email_blocked"
 											name="subscription_delivery_email_blocked"
-											onChange={ this.toggleSetting( 'subscription_delivery_email_blocked' ) }
+											onChange={ this.toggleSetting }
 											onClick={ this.recordCheckboxEvent( 'Block All Notification Emails' ) }
 										/>
 										<span>

--- a/client/me/notification-settings/reader-subscriptions/index.jsx
+++ b/client/me/notification-settings/reader-subscriptions/index.jsx
@@ -120,7 +120,7 @@ export default protectForm(
 											disabled={ this.getDisabledState() }
 											id="subscription_delivery_jabber_default"
 											name="subscription_delivery_jabber_default"
-											onChange={ this.updateSetting( 'subscription_delivery_jabber_default' ) }
+											onChange={ this.toggleSetting( 'subscription_delivery_jabber_default' ) }
 											onClick={ this.recordCheckboxEvent( 'Notification Delivery by Jabber' ) }
 										/>
 										<span>
@@ -205,7 +205,7 @@ export default protectForm(
 											disabled={ this.getDisabledState() }
 											id="subscription_delivery_email_blocked"
 											name="subscription_delivery_email_blocked"
-											onChange={ this.updateSetting( 'subscription_delivery_email_blocked' ) }
+											onChange={ this.toggleSetting( 'subscription_delivery_email_blocked' ) }
 											onClick={ this.recordCheckboxEvent( 'Block All Notification Emails' ) }
 										/>
 										<span>

--- a/client/me/notification-settings/reader-subscriptions/index.jsx
+++ b/client/me/notification-settings/reader-subscriptions/index.jsx
@@ -95,9 +95,9 @@ export default protectForm(
 										disabled={ this.getDisabledState() }
 										id="subscription_delivery_email_default"
 										name="subscription_delivery_email_default"
+										onChange={ this.updateSetting( 'subscription_delivery_email_default' ) }
 										onFocus={ this.recordFocusEvent( 'Default Email Delivery' ) }
 										value={ this.getSetting( 'subscription_delivery_email_default' ) }
-										onChange={ this.updateSetting( 'subscription_delivery_email_default' ) }
 									>
 										<option value="never">{ this.props.translate( 'Never send email' ) }</option>
 										<option value="instantly">
@@ -116,10 +116,11 @@ export default protectForm(
 									</FormLegend>
 									<FormLabel>
 										<FormCheckbox
-											checkedLink={ this.valueLink( 'subscription_delivery_jabber_default' ) }
+											checked={ this.getSetting( 'subscription_delivery_jabber_default' ) }
 											disabled={ this.getDisabledState() }
 											id="subscription_delivery_jabber_default"
 											name="subscription_delivery_jabber_default"
+											onChange={ this.updateSetting( 'subscription_delivery_jabber_default' ) }
 											onClick={ this.recordCheckboxEvent( 'Notification Delivery by Jabber' ) }
 										/>
 										<span>
@@ -136,8 +137,9 @@ export default protectForm(
 										disabled={ this.getDisabledState() }
 										id="subscription_delivery_mail_option"
 										name="subscription_delivery_mail_option"
+										onChange={ this.updateSetting( 'subscription_delivery_mail_option' ) }
 										onFocus={ this.recordFocusEvent( 'Email Delivery Format' ) }
-										valueLink={ this.valueLink( 'subscription_delivery_mail_option' ) }
+										value={ this.getSetting( 'subscription_delivery_mail_option' ) }
 									>
 										<option value="html">{ this.props.translate( 'HTML' ) }</option>
 										<option value="text">{ this.props.translate( 'Plain Text' ) }</option>
@@ -153,8 +155,9 @@ export default protectForm(
 										className="me-notification-settings__delivery-window"
 										id="subscription_delivery_day"
 										name="subscription_delivery_day"
+										onChange={ this.updateSetting( 'subscription_delivery_day' ) }
 										onFocus={ this.recordFocusEvent( 'Email Delivery Window Day' ) }
-										valueLink={ this.valueLink( 'subscription_delivery_day' ) }
+										value={ this.getSetting( 'subscription_delivery_day' ) }
 									>
 										<option value="0">{ this.props.translate( 'Sunday' ) }</option>
 										<option value="1">{ this.props.translate( 'Monday' ) }</option>
@@ -169,8 +172,9 @@ export default protectForm(
 										disabled={ this.getDisabledState() }
 										id="subscription_delivery_hour"
 										name="subscription_delivery_hour"
+										onChange={ this.updateSetting( 'subscription_delivery_hour' ) }
 										onFocus={ this.recordFocusEvent( 'Email Delivery Window Time' ) }
-										valueLink={ this.valueLink( 'subscription_delivery_hour' ) }
+										value={ this.getSetting( 'subscription_delivery_hour' ) }
 									>
 										<option value="0">{ this.getDeliveryHourLabel( 0 ) }</option>
 										<option value="2">{ this.getDeliveryHourLabel( 2 ) }</option>
@@ -197,10 +201,11 @@ export default protectForm(
 									<FormLegend>{ this.props.translate( 'Block Emails' ) }</FormLegend>
 									<FormLabel>
 										<FormCheckbox
-											checkedLink={ this.valueLink( 'subscription_delivery_email_blocked' ) }
+											checked={ this.getSetting( 'subscription_delivery_email_blocked' ) }
 											disabled={ this.getDisabledState() }
 											id="subscription_delivery_email_blocked"
 											name="subscription_delivery_email_blocked"
+											onChange={ this.updateSetting( 'subscription_delivery_email_blocked' ) }
 											onClick={ this.recordCheckboxEvent( 'Block All Notification Emails' ) }
 										/>
 										<span>

--- a/client/me/notification-settings/reader-subscriptions/index.jsx
+++ b/client/me/notification-settings/reader-subscriptions/index.jsx
@@ -96,7 +96,8 @@ export default protectForm(
 										id="subscription_delivery_email_default"
 										name="subscription_delivery_email_default"
 										onFocus={ this.recordFocusEvent( 'Default Email Delivery' ) }
-										valueLink={ this.valueLink( 'subscription_delivery_email_default' ) }
+										value={ this.getSetting( 'subscription_delivery_email_default' ) }
+										onChange={ this.updateSetting( 'subscription_delivery_email_default' ) }
 									>
 										<option value="never">{ this.props.translate( 'Never send email' ) }</option>
 										<option value="instantly">

--- a/client/me/profile/index.jsx
+++ b/client/me/profile/index.jsx
@@ -68,7 +68,7 @@ export default protectForm(
 										disabled={ this.getDisabledState() }
 										id="first_name"
 										name="first_name"
-										onChange={ this.updateSetting( 'first_name' ) }
+										onChange={ this.updateSetting }
 										onFocus={ this.recordFocusEvent( 'First Name Field' ) }
 										value={ this.getSetting( 'first_name' ) }
 									/>
@@ -80,7 +80,7 @@ export default protectForm(
 										disabled={ this.getDisabledState() }
 										id="last_name"
 										name="last_name"
-										onChange={ this.updateSetting( 'last_name' ) }
+										onChange={ this.updateSetting }
 										onFocus={ this.recordFocusEvent( 'Last Name Field' ) }
 										value={ this.getSetting( 'last_name' ) }
 									/>
@@ -94,7 +94,7 @@ export default protectForm(
 										disabled={ this.getDisabledState() }
 										id="display_name"
 										name="display_name"
-										onChange={ this.updateSetting( 'display_name' ) }
+										onChange={ this.updateSetting }
 										onFocus={ this.recordFocusEvent( 'Display Name Field' ) }
 										value={ this.getSetting( 'display_name' ) }
 									/>
@@ -108,7 +108,7 @@ export default protectForm(
 										disabled={ this.getDisabledState() }
 										id="description"
 										name="description"
-										onChange={ this.updateSetting( 'description' ) }
+										onChange={ this.updateSetting }
 										onFocus={ this.recordFocusEvent( 'About Me Field' ) }
 										value={ this.getSetting( 'description' ) }
 									/>

--- a/client/me/profile/index.jsx
+++ b/client/me/profile/index.jsx
@@ -68,8 +68,9 @@ export default protectForm(
 										disabled={ this.getDisabledState() }
 										id="first_name"
 										name="first_name"
+										onChange={ this.updateSetting( 'first_name' ) }
 										onFocus={ this.recordFocusEvent( 'First Name Field' ) }
-										valueLink={ this.valueLink( 'first_name' ) }
+										value={ this.getSetting( 'first_name' ) }
 									/>
 								</FormFieldset>
 
@@ -79,8 +80,9 @@ export default protectForm(
 										disabled={ this.getDisabledState() }
 										id="last_name"
 										name="last_name"
+										onChange={ this.updateSetting( 'last_name' ) }
 										onFocus={ this.recordFocusEvent( 'Last Name Field' ) }
-										valueLink={ this.valueLink( 'last_name' ) }
+										value={ this.getSetting( 'last_name' ) }
 									/>
 								</FormFieldset>
 
@@ -92,8 +94,9 @@ export default protectForm(
 										disabled={ this.getDisabledState() }
 										id="display_name"
 										name="display_name"
+										onChange={ this.updateSetting( 'display_name' ) }
 										onFocus={ this.recordFocusEvent( 'Display Name Field' ) }
-										valueLink={ this.valueLink( 'display_name' ) }
+										value={ this.getSetting( 'display_name' ) }
 									/>
 								</FormFieldset>
 
@@ -105,8 +108,9 @@ export default protectForm(
 										disabled={ this.getDisabledState() }
 										id="description"
 										name="description"
+										onChange={ this.updateSetting( 'description' ) }
 										onFocus={ this.recordFocusEvent( 'About Me Field' ) }
-										valueLink={ this.valueLink( 'description' ) }
+										value={ this.getSetting( 'description' ) }
 									/>
 								</FormFieldset>
 


### PR DESCRIPTION
A number of files in `/me` use the `form-base` mixin, which has provided a `valueLink` method (i.e. `linkState` drop-in replacement). This PR removes that method in favor of a `getSetting()`, `updateSetting()`, and `toggleSetting()` method, and changes `form-base` consumers to use those methods.

Doesn't use #13925, since these methods are defined in a different file than where they're used. cc @jsnajdr

In addition, this PR removes some other simple `valueLink` cases that aren't suitable for codemodding.

To test: Verify that changing (and saving) settings still works on the following pages:
* http://calypso.localhost:3000/me
* http://calypso.localhost:3000/me/security (Password)
* http://calypso.localhost:3000/me/notifications/subscriptions

Addresses #5951.