### PR TITLE
Jetpack connect: Remove redundant bindActionCreators

### DIFF
--- a/client/jetpack-connect/jetpack-new-site/index.jsx
+++ b/client/jetpack-connect/jetpack-new-site/index.jsx
@@ -4,7 +4,6 @@
  */
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
 import page from 'page';
 import { localize } from 'i18n-calypso';
 
@@ -136,11 +135,4 @@ class JetpackNewSite extends Component {
 	}
 }
 
-export default connect( null, dispatch =>
-	bindActionCreators(
-		{
-			recordTracksEvent,
-		},
-		dispatch
-	)
-)( localize( JetpackNewSite ) );
+export default connect( null, { recordTracksEvent } )( localize( JetpackNewSite ) );

--- a/client/jetpack-connect/jetpack-new-site/index.jsx
+++ b/client/jetpack-connect/jetpack-new-site/index.jsx
@@ -2,9 +2,9 @@
 /**
  * External dependencies
  */
+import page from 'page';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import page from 'page';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -13,11 +13,11 @@ import { localize } from 'i18n-calypso';
 import Button from 'components/button';
 import Card from 'components/card';
 import config from 'config';
-import { recordTracksEvent } from 'state/analytics/actions';
-import SiteUrlInput from '../site-url-input';
-import ReaderBack from 'blocks/reader-full-post/back';
-import WordPressLogo from 'components/wordpress-logo';
 import JetpackLogo from 'components/jetpack-logo';
+import ReaderBack from 'blocks/reader-full-post/back';
+import SiteUrlInput from '../site-url-input';
+import WordPressLogo from 'components/wordpress-logo';
+import { recordTracksEvent } from 'state/analytics/actions';
 
 class JetpackNewSite extends Component {
 	constructor() {

--- a/client/jetpack-connect/sso.jsx
+++ b/client/jetpack-connect/sso.jsx
@@ -2,43 +2,43 @@
 /**
  * External dependencies
  */
+import cookie from 'cookie';
+import debugModule from 'debug';
+import Gridicon from 'gridicons';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import debugModule from 'debug';
 import { get, map } from 'lodash';
-import Gridicon from 'gridicons';
-import cookie from 'cookie';
 import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
-import Main from 'components/main';
-import FormattedHeader from 'components/formatted-header';
+import addQueryArgs from 'lib/route/add-query-args';
+import analytics from 'lib/analytics';
+import Button from 'components/button';
 import Card from 'components/card';
 import CompactCard from 'components/card/compact';
-import Gravatar from 'components/gravatar';
-import Button from 'components/button';
-import LoggedOutFormLinks from 'components/logged-out-form/links';
-import LoggedOutFormLinkItem from 'components/logged-out-form/link-item';
-import { login } from 'lib/paths';
-import { validateSSONonce, authorizeSSO } from 'state/jetpack-connect/actions';
-import { getSSO } from 'state/jetpack-connect/selectors';
-import addQueryArgs from 'lib/route/add-query-args';
 import config from 'config';
+import Dialog from 'components/dialog';
+import EmailVerificationGate from 'components/email-verification/email-verification-gate';
 import EmptyContent from 'components/empty-content';
+import FormattedHeader from 'components/formatted-header';
+import Gravatar from 'components/gravatar';
+import HelpButton from './help-button';
+import JetpackConnectHappychatButton from './happychat-button';
+import LoggedOutFormFooter from 'components/logged-out-form/footer';
+import LoggedOutFormLinkItem from 'components/logged-out-form/link-item';
+import LoggedOutFormLinks from 'components/logged-out-form/links';
+import Main from 'components/main';
+import MainWrapper from './main-wrapper';
 import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
 import Site from 'blocks/site';
 import SitePlaceholder from 'blocks/site/placeholder';
 import { decodeEntities } from 'lib/formatting';
-import LoggedOutFormFooter from 'components/logged-out-form/footer';
-import Dialog from 'components/dialog';
-import analytics from 'lib/analytics';
-import MainWrapper from './main-wrapper';
-import HelpButton from './help-button';
-import JetpackConnectHappychatButton from './happychat-button';
-import EmailVerificationGate from 'components/email-verification/email-verification-gate';
+import { getSSO } from 'state/jetpack-connect/selectors';
+import { login } from 'lib/paths';
+import { validateSSONonce, authorizeSSO } from 'state/jetpack-connect/actions';
 
 /*
  * Module variables

--- a/client/jetpack-connect/sso.jsx
+++ b/client/jetpack-connect/sso.jsx
@@ -4,7 +4,6 @@
  */
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
 import debugModule from 'debug';
 import { get, map } from 'lodash';
 import Gridicon from 'gridicons';
@@ -484,12 +483,8 @@ export default connect(
 			sharedDetails: get( jetpackSSO, 'sharedDetails' ),
 		};
 	},
-	dispatch =>
-		bindActionCreators(
-			{
-				authorizeSSO,
-				validateSSONonce,
-			},
-			dispatch
-		)
+	{
+		authorizeSSO,
+		validateSSONonce,
+	}
 )( localize( JetpackSsoForm ) );


### PR DESCRIPTION
This PR removes redundant `bindActionCreators` from `jetpack-connect`. I also took the liberty of alphabetizing `import`s.

The explicit `bindActionCreators` call is not required and a simple object can be passed to achieve the same behavior.

## Testing
1. Run this branch
1. Get appropriate debug output: `localStorage.debug = 'calypso:jetpack-connect:sso,calypso:analytics:tracks'`
1. Does everything continue to work correctly?
   * Tracks on https://calypso.live/jetpack/new?branch=update/jetpack-connect/remove-redundant-bindactioncreators
   * Make sure SSO continues to work correctly.