### PR TITLE
Reader Devdocs: fix conversations list component

### DIFF
--- a/client/blocks/conversations/docs/example.jsx
+++ b/client/blocks/conversations/docs/example.jsx
@@ -3,7 +3,7 @@
  * External dependencies
  */
 import React from 'react';
-import { noop } from 'lodash';
+import { noop, map, compact } from 'lodash';
 
 /**
  * Internal dependencies
@@ -22,6 +22,7 @@ const ConversationCommentListExample = () => {
 				blogId={ 123 }
 				postId={ 12 }
 				commentIds={ [ 1, 2, 3 ] }
+				sortedComments={ compact( map( commentsTree, 'data' ) ) }
 				post={ post }
 				enableCaterpillar={ false }
 				shouldRequestComments={ false }

--- a/client/blocks/conversations/list.jsx
+++ b/client/blocks/conversations/list.jsx
@@ -169,7 +169,7 @@ export class ConversationCommentList extends React.Component {
 		const { commentIds, expansions, commentsTree, sortedComments } = this.props;
 
 		const minId = min( commentIds );
-		const startingCommentIds = sortedComments
+		const startingCommentIds = ( sortedComments || [] )
 			.filter( comment => {
 				return comment.ID >= minId || comment.isPlaceholder;
 			} )


### PR DESCRIPTION
hotfix for devdocs that re-broke after merge of https://github.com/Automattic/wp-calypso/pull/18810.

The branch fixed the issue at the time the branch was made, but the pr https://github.com/Automattic/wp-calypso/pull/18806 meant that the fix was invalidated even though it didn't cause any merge conflicts.  

To Test
------

- ensure that its currently broken: https://wpcalypso.wordpress.com/devdocs/blocks/conversation-comment-list
- fire up branch and make sure the same page loads: http://calypso.localhost:3000/devdocs/blocks/conversation-comment-list.  