### PR TITLE
Jetpack connect: Remove irrelevant logic and bad comma

### DIFF
--- a/client/jetpack-connect/auth-logged-in-form.jsx
+++ b/client/jetpack-connect/auth-logged-in-form.jsx
@@ -191,8 +191,9 @@ class LoggedInForm extends Component {
 		const { queryObject, authorizeError, authorizeSuccess } = this.props.jetpackConnectAuthorize;
 
 		if (
-			( ! this.props.isAlreadyOnSitesList && ! this.props.isFetchingSites,
-			queryObject.already_authorized )
+			! this.props.isAlreadyOnSitesList &&
+			! this.props.isFetchingSites &&
+			queryObject.already_authorized
 		) {
 			this.props.recordTracksEvent( 'calypso_jpc_back_wpadmin_click' );
 			return this.props.goBackToWpAdmin( queryObject.redirect_after_auth );


### PR DESCRIPTION
A bad logic operation and comma were introduced. This PR restores what is assumed to be the intended logic.

## Changes

This change would be functionally equivalent to the code that is in production right now and has been since #10296

```patch
diff --git a/client/jetpack-connect/auth-logged-in-form.jsx b/client/jetpack-connect/auth-logged-in-form.jsx
index c62cb54f1b..26f65bd458 100644
--- a/client/jetpack-connect/auth-logged-in-form.jsx
+++ b/client/jetpack-connect/auth-logged-in-form.jsx
@@ -190,10 +190,7 @@ class LoggedInForm extends Component {
 	handleSubmit = () => {
 		const { queryObject, authorizeError, authorizeSuccess } = this.props.jetpackConnectAuthorize;
 
-		if (
-			( ! this.props.isAlreadyOnSitesList && ! this.props.isFetchingSites,
-			queryObject.already_authorized )
-		) {
+		if ( queryObject.already_authorized ) {
 			this.props.recordTracksEvent( 'calypso_jpc_back_wpadmin_click' );
 			return this.props.goBackToWpAdmin( queryObject.redirect_after_auth );
 		}
```

However, after digging around and finding [this change](https://github.com/Automattic/wp-calypso/pull/10296/files#diff-bcb7ddf40321a1fc24c4ffe2e8719c62R312), I suspect the original intention was the change this PR makes.

## Archeology
* This line was changed from a method invocation to a property lookup in #11261.
* Prior to that, the check was introduced in #10296.

Fixes #15971