### PR TITLE
Add e2e attributes to site preview dropdown

### DIFF
--- a/client/components/select-dropdown/item.jsx
+++ b/client/components/select-dropdown/item.jsx
@@ -50,6 +50,7 @@ class SelectDropdownItem extends Component {
 					role="menuitem"
 					tabIndex={ this.props.isDropdownOpen ? 0 : '' }
 					aria-selected={ this.props.selected }
+					data-e2e-title={ this.props.e2eTitle }
 				>
 					<span className="select-dropdown__item-text">
 						{ this.props.icon && this.props.icon.type === Gridicon ? this.props.icon : null }

--- a/client/components/web-preview/toolbar.jsx
+++ b/client/components/web-preview/toolbar.jsx
@@ -111,7 +111,13 @@ class PreviewToolbar extends Component {
 								key={ device }
 								selected={ device === currentDevice }
 								onClick={ partial( setDeviceViewport, device ) }
-								icon={ <Gridicon size={ 18 } icon={ this.devices[ device ].icon } /> }
+								icon={
+									<Gridicon
+										size={ 18 }
+										icon={ this.devices[ device ].icon }
+										data-e2e-title={ device }
+									/>
+								}
 							>
 								{ this.devices[ device ].title }
 							</DropdownItem>

--- a/client/components/web-preview/toolbar.jsx
+++ b/client/components/web-preview/toolbar.jsx
@@ -111,13 +111,8 @@ class PreviewToolbar extends Component {
 								key={ device }
 								selected={ device === currentDevice }
 								onClick={ partial( setDeviceViewport, device ) }
-								icon={
-									<Gridicon
-										size={ 18 }
-										icon={ this.devices[ device ].icon }
-										data-e2e-title={ device }
-									/>
-								}
+								icon={ <Gridicon size={ 18 } icon={ this.devices[ device ].icon } /> }
+								e2eTitle={ device }
 							>
 								{ this.devices[ device ].title }
 							</DropdownItem>


### PR DESCRIPTION
This PR add data attributes to the site preview dropdown for use in e2e tests.

To test:

1. Go to My Sites > View Site.
2. Check the markup to confirm that a `data-e2e-title` attribute is added to each item in the dropdown.

You can also change your interface language and confirm that the e2e attributes stay the same.

(Note: This PR is also being used to test the new Canaries 2.0, internal ref: p6jOYE-1mW-p2)