### PR TITLE
Comments: Remove "Approve and reply" placeholder from the reply textarea

### DIFF
--- a/client/blocks/comment-detail/comment-detail-reply.jsx
+++ b/client/blocks/comment-detail/comment-detail-reply.jsx
@@ -59,13 +59,11 @@ export class CommentDetailReply extends Component {
 	getTextareaPlaceholder = () => {
 		const { authorDisplayName, translate } = this.props;
 
-		if ( authorDisplayName ) {
-			return translate( 'Reply to %(commentAuthor)s…', {
-				args: { commentAuthor: authorDisplayName },
-			} );
-		}
-
-		return translate( 'Reply to comment…' );
+		return authorDisplayName
+			? translate( 'Reply to %(commentAuthor)s…', {
+					args: { commentAuthor: authorDisplayName },
+				} )
+			: translate( 'Reply to comment…' );
 	};
 
 	onChange = event => {

--- a/client/blocks/comment-detail/comment-detail-reply.jsx
+++ b/client/blocks/comment-detail/comment-detail-reply.jsx
@@ -57,21 +57,15 @@ export class CommentDetailReply extends Component {
 	};
 
 	getTextareaPlaceholder = () => {
-		const { authorDisplayName, comment: { status }, translate } = this.props;
+		const { authorDisplayName, translate } = this.props;
 
-		if ( 'approved' !== status ) {
-			return authorDisplayName
-				? translate( 'Approve and reply to %(commentAuthor)s…', {
-						args: { commentAuthor: authorDisplayName },
-					} )
-				: translate( 'Approve and reply to comment…' );
+		if ( authorDisplayName ) {
+			return translate( 'Reply to %(commentAuthor)s…', {
+				args: { commentAuthor: authorDisplayName },
+			} );
 		}
 
-		return authorDisplayName
-			? translate( 'Reply to %(commentAuthor)s…', {
-					args: { commentAuthor: authorDisplayName },
-				} )
-			: translate( 'Reply to comment…' );
+		return translate( 'Reply to comment…' );
 	};
 
 	onChange = event => {


### PR DESCRIPTION
Remove the "Approve and reply to..." placeholder from the `CommentDetail` reply textarea on non-approved comments, and replace it with "Reply to...".

| Before | After |
| --- | --- |
| <img width="564" alt="screen shot 2017-10-16 at 16 18 31" src="https://user-images.githubusercontent.com/2070010/31619994-f7d68ba4-b28d-11e7-8ae5-89a5316a905e.png"> | <img width="565" alt="screen shot 2017-10-16 at 16 18 37" src="https://user-images.githubusercontent.com/2070010/31619999-fcab5b46-b28d-11e7-8b42-3b560b7de5d6.png"> |