### PR TITLE
Store Orders: Switch to using the `line_item` ID as its identifier

### DIFF
--- a/client/extensions/woocommerce/app/order/order-details/table.js
+++ b/client/extensions/woocommerce/app/order/order-details/table.js
@@ -73,11 +73,11 @@ class OrderDetailsTable extends Component {
 		);
 	};
 
-	renderOrderItems = ( item, i ) => {
+	renderOrderItems = item => {
 		const { order, site } = this.props;
-		const tax = getOrderLineItemTax( order, i );
+		const tax = getOrderLineItemTax( order, item.id );
 		return (
-			<TableRow key={ i } className="order-details__items">
+			<TableRow key={ item.id } className="order-details__items">
 				<TableItem isRowHeader className="order-details__item-product">
 					<a
 						href={ getLink( `/store/product/:site/${ item.product_id }`, site ) }

--- a/client/extensions/woocommerce/app/order/order-payment/dialog.js
+++ b/client/extensions/woocommerce/app/order/order-payment/dialog.js
@@ -6,8 +6,8 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
+import { find, map, sum } from 'lodash';
 import { localize } from 'i18n-calypso';
-import { sum } from 'lodash';
 
 /**
  * Internal dependencies
@@ -103,17 +103,19 @@ class RefundDialog extends Component {
 			return 0;
 		}
 		const subtotal = sum(
-			data.quantities.map( ( q, i ) => {
-				if ( ! order.line_items[ i ] ) {
+			map( data.quantities, ( q, id ) => {
+				id = parseInt( id );
+				const line_item = find( order.line_items, { id } );
+				if ( ! line_item ) {
 					return 0;
 				}
 
-				const price = parseFloat( order.line_items[ i ].price );
+				const price = parseFloat( line_item.price );
 				if ( order.prices_include_tax ) {
 					return price * q;
 				}
 
-				const tax = getOrderLineItemTax( order, i ) / order.line_items[ i ].quantity;
+				const tax = getOrderLineItemTax( order, id ) / line_item.quantity;
 				return ( price + tax ) * q;
 			} )
 		);

--- a/client/extensions/woocommerce/app/order/order-payment/table.js
+++ b/client/extensions/woocommerce/app/order/order-payment/table.js
@@ -41,7 +41,7 @@ class OrderRefundTable extends Component {
 		super( props );
 		const shippingTax = getOrderShippingTax( props.order );
 		this.state = {
-			quantities: [],
+			quantities: {},
 			shippingTotal: parseFloat( shippingTax ) + parseFloat( props.order.shipping_total ),
 		};
 	}
@@ -95,11 +95,11 @@ class OrderRefundTable extends Component {
 		);
 	};
 
-	renderOrderItems = ( item, i ) => {
+	renderOrderItems = item => {
 		const { order } = this.props;
-		const tax = getOrderLineItemTax( order, i );
+		const tax = getOrderLineItemTax( order, item.id );
 		return (
-			<TableRow key={ i } className="order-payment__items order-details__items">
+			<TableRow key={ item.id } className="order-payment__items order-details__items">
 				<TableItem isRowHeader className="order-payment__item-product order-details__item-product">
 					<span className="order-payment__item-link order-details__item-link">{ item.name }</span>
 					<span className="order-payment__item-sku order-details__item-sku">{ item.sku }</span>
@@ -110,11 +110,11 @@ class OrderRefundTable extends Component {
 				<TableItem className="order-payment__item-quantity order-details__item-quantity">
 					<FormTextInput
 						type="number"
-						name={ `quantity-${ i }` }
+						name={ `quantity-${ item.id }` }
 						onChange={ this.onChange }
 						min="0"
 						max={ item.quantity }
-						value={ this.state.quantities[ i ] || 0 }
+						value={ this.state.quantities[ item.id ] || 0 }
 					/>
 				</TableItem>
 				<TableItem className="order-payment__item-tax order-details__item-tax">

--- a/client/extensions/woocommerce/lib/order-values/index.js
+++ b/client/extensions/woocommerce/lib/order-values/index.js
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import { get, reduce } from 'lodash';
+import { find, get, reduce } from 'lodash';
 
 /**
  * Get the total tax for the discount value
@@ -20,11 +20,12 @@ export function getOrderDiscountTax( order ) {
  * Get the total tax for a given line item's value
  *
  * @param {Object} order An order as returned from API
- * @param {Number} index The index of a line item in this order
+ * @param {Number} id The ID of the line_item
  * @return {Float} Tax amount as a decimal number
  */
-export function getOrderLineItemTax( order, index ) {
-	const tax = get( order, `line_items[${ index }].taxes[0].total`, 0 );
+export function getOrderLineItemTax( order, id ) {
+	const items = get( order, 'line_items', [] );
+	const tax = get( find( items, { id } ), 'taxes[0].total', 0 );
 	return parseFloat( tax ) || 0;
 }
 
@@ -47,7 +48,7 @@ export function getOrderShippingTax( order ) {
  */
 export function getOrderSubtotalTax( order ) {
 	const items = get( order, 'line_items', [] );
-	return reduce( items, ( sum, value, key ) => sum + getOrderLineItemTax( order, key ), 0 );
+	return reduce( items, ( sum, value ) => sum + getOrderLineItemTax( order, value.id ), 0 );
 }
 
 /**

--- a/client/extensions/woocommerce/lib/order-values/test/index.js
+++ b/client/extensions/woocommerce/lib/order-values/test/index.js
@@ -49,19 +49,19 @@ describe( 'getOrderLineItemTax', () => {
 	} );
 
 	test( 'should get the correct tax amount', () => {
-		expect( getOrderLineItemTax( orderWithTax, 0 ) ).to.eql( 5.3964 );
+		expect( getOrderLineItemTax( orderWithTax, 15 ) ).to.eql( 5.3964 );
 	} );
 
 	test( 'should get the correct tax amount for the second item', () => {
-		expect( getOrderLineItemTax( orderWithTax, 1 ) ).to.eql( 1.1424 );
+		expect( getOrderLineItemTax( orderWithTax, 19 ) ).to.eql( 1.1424 );
 	} );
 
 	test( 'should return 0 if there is no tax', () => {
-		expect( getOrderLineItemTax( orderWithoutTax, 0 ) ).to.eql( 0 );
+		expect( getOrderLineItemTax( orderWithoutTax, 1 ) ).to.eql( 0 );
 	} );
 
 	test( 'should get the correct tax amount for an item with multiple coupons', () => {
-		expect( getOrderLineItemTax( orderWithCoupons, 1 ) ).to.eql( 2.3109 );
+		expect( getOrderLineItemTax( orderWithCoupons, 27 ) ).to.eql( 2.3109 );
 	} );
 } );
 


### PR DESCRIPTION
Currently the products list table on an order uses the index in `line_items` as the identifier for component `key`s and calculating refund amounts, but each line item has an ID, which we should be using instead – because it makes updating quantities and adding/deleting products more stable.

There should be no functionality change in this PR, just a under-the-hood refactor of index to ID.

**To test**

- Run the tests: `npm run test-client client/extensions/woocommerce/lib/order-values`
- Check out a few orders to make sure the line items are displaying as expected, taxes are correct
- Check out refunding an order to make sure the prices add up correctly (if you notice a refunds issue, make sure it's not an issue in production too ([existing refunds issues](https://github.com/Automattic/wp-calypso/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Astore%20refund)))
