### PR TITLE
Reader a8c convos: modify copy of intro box

### DIFF
--- a/client/reader/conversations/intro.jsx
+++ b/client/reader/conversations/intro.jsx
@@ -70,11 +70,11 @@ class ConversationsIntro extends React.Component {
 										'and reply to all your P2 conversations in one place. ' +
 										"Automattic P2 posts you've liked or commented on " +
 										'will appear when they have new comments.' +
-										'{{a}} More info {{/a}}.',
+										'{{a}} More info. {{/a}}',
 									{
 										components: {
 											strong: <strong />,
-											a: <a href="https://readersquad.wordpress.com/?p=15654" />,
+											a: <a href="http://wp.me/p5PDj3-44u" />,
 										},
 									}
 								)

--- a/client/reader/conversations/intro.jsx
+++ b/client/reader/conversations/intro.jsx
@@ -66,13 +66,15 @@ class ConversationsIntro extends React.Component {
 						<span>
 							{ isInternal ? (
 								translate(
-									'{{strong}}Welcome to A8C Conversations.{{/strong}} You can read ' +
+									'{{strong}}Welcome to A8C Conversations{{/strong}}, where you can read ' +
 										'and reply to all your P2 conversations in one place. ' +
 										"Automattic P2 posts you've liked or commented on " +
-										'will appear when they have new comments.',
+										'will appear when they have new comments.' +
+										'{{a}} More info {{/a}}',
 									{
 										components: {
 											strong: <strong />,
+											a: <a href="https://readersquad.wordpress.com/?p=15654" />,
 										},
 									}
 								)

--- a/client/reader/conversations/intro.jsx
+++ b/client/reader/conversations/intro.jsx
@@ -69,8 +69,8 @@ class ConversationsIntro extends React.Component {
 									'{{strong}}Welcome to A8C Conversations{{/strong}}, where you can read ' +
 										'and reply to all your P2 conversations in one place. ' +
 										"Automattic P2 posts you've liked or commented on " +
-										'will appear when they have new comments.' +
-										'{{a}} More info. {{/a}}',
+										'will appear when they have new comments. ' +
+										'{{a}}More info. {{/a}}',
 									{
 										components: {
 											strong: <strong />,

--- a/client/reader/conversations/intro.jsx
+++ b/client/reader/conversations/intro.jsx
@@ -70,7 +70,7 @@ class ConversationsIntro extends React.Component {
 										'and reply to all your P2 conversations in one place. ' +
 										"Automattic P2 posts you've liked or commented on " +
 										'will appear when they have new comments.' +
-										'{{a}} More info {{/a}}',
+										'{{a}} More info {{/a}}.',
 									{
 										components: {
 											strong: <strong />,


### PR DESCRIPTION
Modifies the copy of the a8c intro box and adds link to point to internal call for testing.

To Test
-----
go to a8c convos and manually copy/paste this into the console
```
dispatch( {
	type: 'PREFERENCES_SET',
	key: 'has_used_reader_conversations_a8c',
	value: false
} );
```

cc @fraying 