### PR TITLE
Reader: Release conversations to staging, expand flags

### DIFF
--- a/client/reader/conversations/index.js
+++ b/client/reader/conversations/index.js
@@ -7,25 +7,31 @@ import page from 'page';
 /**
  * Internal dependencies
  */
+import config from 'config';
 import { conversations, conversationsA8c } from './controller';
 import { initAbTests, preloadReaderBundle, sidebar, updateLastRoute } from 'reader/controller';
 
 export default function() {
-	page(
-		'/read/conversations',
-		preloadReaderBundle,
-		updateLastRoute,
-		initAbTests,
-		sidebar,
-		conversations
-	);
+	if ( config.isEnabled( 'reader/conversations' ) ) {
+		page(
+			'/read/conversations',
+			preloadReaderBundle,
+			updateLastRoute,
+			initAbTests,
+			sidebar,
+			conversations
+		);
 
-	page(
-		'/read/conversations/a8c',
-		preloadReaderBundle,
-		updateLastRoute,
-		initAbTests,
-		sidebar,
-		conversationsA8c
-	);
+		page(
+			'/read/conversations/a8c',
+			preloadReaderBundle,
+			updateLastRoute,
+			initAbTests,
+			sidebar,
+			conversationsA8c
+		);
+	} else {
+		page( '/read/conversations', '/' );
+		page( '/read/conversations/a8c', '/' );
+	}
 }

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -10,7 +10,11 @@
 	"facebook_api_key": "249643311490",
 	"discover_logged_out_redirect_url": "/",
 	"rebrand_cities_prefix": "rebrandcitiessite",
-	"support_locales": [ "en", "es", "pt-br" ],
+	"support_locales": [
+		"en",
+		"es",
+		"pt-br"
+	],
 	"features": {
 		"ad-tracking": true,
 		"always_use_logout_url": true,
@@ -75,6 +79,7 @@
 		"reader/following-intro": true,
 		"reader/full-errors": false,
 		"reader/search": true,
+		"reader/conversations": false,
 		"resume-editing": true,
 		"republicize": false,
 		"rubberband-scroll-disable": false,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -12,7 +12,11 @@
 	"facebook_api_key": "249643311490",
 	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
 	"rebrand_cities_prefix": "rebrandcitiestestsite",
-	"support_locales": [ "en", "es", "pt-br" ],
+	"support_locales": [
+		"en",
+		"es",
+		"pt-br"
+	],
 	"features": {
 		"ad-tracking": false,
 		"apple-pay": false,
@@ -82,6 +86,7 @@
 		"press-this": true,
 		"preview-layout": true,
 		"reader": true,
+		"reader/conversations": false,
 		"reader/following-intro": true,
 		"reader/following-manage-refresh": true,
 		"reader/nesting-arrow": true,

--- a/config/production.json
+++ b/config/production.json
@@ -11,7 +11,11 @@
 	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
 	"facebook_app_id": "2373049596",
 	"rebrand_cities_prefix": "rebrandcitiessite",
-	"support_locales": [ "en", "es", "pt-br" ],
+	"support_locales": [
+		"en",
+		"es",
+		"pt-br"
+	],
 	"features": {
 		"ad-tracking": true,
 		"apple-pay": true,
@@ -86,6 +90,7 @@
 		"publicize-preview": true,
 		"push-notifications": true,
 		"reader": true,
+		"reader/conversations": false,
 		"reader/following-intro": true,
 		"reader/following-manage-refresh": true,
 		"reader/full-errors": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -13,7 +13,11 @@
 	"facebook_api_key": "249643311490",
 	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
 	"rebrand_cities_prefix": "rebrandcitiestestsite",
-	"support_locales": [ "en", "es", "pt-br" ],
+	"support_locales": [
+		"en",
+		"es",
+		"pt-br"
+	],
 	"features": {
 		"ad-tracking": false,
 		"apple-pay": true,
@@ -89,6 +93,7 @@
 		"publicize-preview": true,
 		"push-notifications": true,
 		"reader": true,
+		"reader/conversations": true,
 		"reader/following-intro": true,
 		"reader/following-manage-refresh": true,
 		"reader/full-errors": true,


### PR DESCRIPTION
Releases Reader Conversations to staging and expands the usage of the feature flag to cover the routes used.

To test, a normal dev install should see both conversations streams in the sidebar and both streams should load normally. Non-a8c users will only see the main conversations stream.

Restart calypso with the `reader/conversations` feature disabled: `DISABLE_FEATURES=reader/conversations npm start`

Now neither stream should appear and visiting the conversations URLs should redirect you to the main following stream at `/`.