### PR TITLE
Reader: Un-flip Reply icon

### DIFF
--- a/client/blocks/comments/style.scss
+++ b/client/blocks/comments/style.scss
@@ -443,10 +443,6 @@ a.comments__comment-username {
 
 		&.comments__comment-actions-reply {
 			margin-left: -7px;
-
-			.gridicon {
-				transform: rotate( 180deg );
-			}
 		}
 
 		&.like-button {


### PR DESCRIPTION
The current Reply icon is being flipped using css. However, we recently decided to rotate the actual icon source itself: https://github.com/Automattic/gridicons/pull/255 so we no longer need to do it programmatically.

There are no functionality changes in this PR. I'm in the process of publishing the icon to npm, so please do not merge this PR yet.