### PR TITLE
Framework: Update Gridicons to v.2.0.5

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1718,7 +1718,7 @@
       }
     },
     "es5-ext": {
-      "version": "0.10.31"
+      "version": "0.10.35"
     },
     "es6-error": {
       "version": "4.0.2"
@@ -2209,7 +2209,7 @@
       "dev": true
     },
     "flow-parser": {
-      "version": "0.56.0",
+      "version": "0.57.3",
       "dev": true
     },
     "flux": {
@@ -2860,7 +2860,7 @@
       "dev": true
     },
     "gridicons": {
-      "version": "2.0.4"
+      "version": "2.0.5"
     },
     "growly": {
       "version": "1.3.0",
@@ -3191,7 +3191,7 @@
       "version": "1.0.5"
     },
     "irregular-plurals": {
-      "version": "1.3.0",
+      "version": "1.4.0",
       "dev": true
     },
     "is-arrayish": {
@@ -4366,6 +4366,17 @@
     "levn": {
       "version": "0.3.0",
       "dev": true
+    },
+    "libphonenumber-js": {
+      "version": "0.4.27",
+      "dependencies": {
+        "bluebird": {
+          "version": "3.5.1"
+        },
+        "minimist": {
+          "version": "1.2.0"
+        }
+      }
     },
     "lie": {
       "version": "3.0.2"
@@ -5558,7 +5569,7 @@
       }
     },
     "private": {
-      "version": "0.1.7"
+      "version": "0.1.8"
     },
     "process": {
       "version": "0.11.10"
@@ -5652,7 +5663,7 @@
       "version": "2.2.0"
     },
     "rc": {
-      "version": "1.2.1",
+      "version": "1.2.2",
       "dependencies": {
         "minimist": {
           "version": "1.2.0"
@@ -6334,8 +6345,7 @@
       }
     },
     "sax": {
-      "version": "1.2.4",
-      "dev": true
+      "version": "1.2.4"
     },
     "scss-tokenizer": {
       "version": "0.2.3",
@@ -7780,6 +7790,12 @@
     "xml-name-validator": {
       "version": "2.0.1",
       "dev": true
+    },
+    "xml2js": {
+      "version": "0.4.19"
+    },
+    "xmlbuilder": {
+      "version": "9.0.4"
     },
     "xmlhttprequest-ssl": {
       "version": "1.5.1"

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "fuse.js": "2.6.1",
     "get-video-id": "2.1.4",
     "globby": "6.1.0",
-    "gridicons": "2.0.4",
+    "gridicons": "2.0.5",
     "happypack": "4.0.0",
     "hard-source-webpack-plugin": "0.3.12",
     "hash.js": "1.1.3",


### PR DESCRIPTION
This PR updates Gridicons to v2.0.5 following this change: https://github.com/Automattic/gridicons/pull/255