### PR TITLE
Refactor assign-component-to-displayname-variable

### DIFF
--- a/bin/codemods/src/assign-component-to-displayname-variable.js
+++ b/bin/codemods/src/assign-component-to-displayname-variable.js
@@ -77,8 +77,8 @@ export default function transformer( file, api ) {
 	const defaultExportDeclaration = _.head( root.find( j.ExportDefaultDeclaration ).nodes() );
 	const hocIdentifier = _.get( defaultExportDeclaration, [ 'declaration', 'callee', 'name' ] );
 
-	const args = _.get( defaultExportDeclaration, [ 'declaration', 'arguments' ] );
-	const component = getComponentFromArgs( args );
+	const hocArgs = _.get( defaultExportDeclaration, [ 'declaration', 'arguments' ] );
+	const component = getComponentFromArgs( hocArgs );
 	const displayName = extractDisplayName( component, j );
 
 	// noop if the file does not have a default export of a react component that has a displayName
@@ -103,7 +103,7 @@ export default function transformer( file, api ) {
 			j.exportDefaultDeclaration(
 				j.callExpression(
 					j.identifier( hocIdentifier ),
-					args.map( classToIdentifier( displayName, j ) )
+					hocArgs.map( classToIdentifier( displayName, j ) )
 				)
 			),
 		] )

--- a/bin/codemods/src/assign-component-to-displayname-variable.js
+++ b/bin/codemods/src/assign-component-to-displayname-variable.js
@@ -83,7 +83,7 @@ export default function transformer( file, api ) {
 
 	// noop if the file does not have a default export of a react component that has a displayName
 	if ( ! defaultExportDeclaration || ! component || ! displayName ) {
-		return file;
+		return;
 	}
 
 	const isCreateClass = isCreateClassComponent( component );


### PR DESCRIPTION
While reviewing https://github.com/Automattic/wp-calypso/pull/18710, I realized I don't actually know how to read codemods that well and wasn't sure what the different parts meant.  In order to understand how it was working I started placing `console.log` statements throughout the codemod to understand.  One thing led to another and i started extracting some functions + renaming variables/functions to make things a bit more clear.

Refactors made:
1. removed `forEach` since the return was always going to be of size 0 or 1. That allowed the rest of the function to be indented one less tab.
2. changed all function/variable names to be more semantic.  Instead of describing the ast type they are extracting (can glean from code), the names now describe what the variables represent.  As an example, I renamed `calleeNameValue` --> `hocIdentifier` and `matchingArg` to `component`
3. use lodash's `get` instead of the one in `Collections`
4. skipped the whole bit finding all `ClassExpression` seeing as we already had the path to the default exported class expression from earlier in the code


Let me know your thoughts @spen!  If you'd like to take the changes in you can merge them into your branch (this is a "stacked" branch, so its based off of 18710)