### PR TITLE
Make dispatchRequest options optional

### DIFF
--- a/client/state/data-layer/wpcom-http/utils.js
+++ b/client/state/data-layer/wpcom-http/utils.js
@@ -134,7 +134,10 @@ const defaultOptions = {
  + @param {Function} [options.onProgress] called on progress events when uploading
  * @returns {?*} please ignore return values, they are undefined
  */
-export const dispatchRequest = ( initiator, onSuccess, onError, options ) => ( store, action ) => {
+export const dispatchRequest = ( initiator, onSuccess, onError, options = {} ) => (
+	store,
+	action
+) => {
 	const { fromApi, onProgress } = { ...defaultOptions, ...options };
 
 	const error = getError( action );


### PR DESCRIPTION
There are some cases where the options may be intentionally left empty, so this makes it optional so that the call doesn't look weird.