### PR TITLE
Color Schemes: Add postcss custom properties plugin

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -5316,6 +5316,32 @@
         }
       }
     },
+    "postcss-custom-properties": {
+      "version": "6.2.0",
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0"
+        },
+        "chalk": {
+          "version": "2.1.0"
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5"
+        },
+        "has-flag": {
+          "version": "2.0.0"
+        },
+        "postcss": {
+          "version": "6.0.13"
+        },
+        "source-map": {
+          "version": "0.6.1"
+        },
+        "supports-color": {
+          "version": "4.4.0"
+        }
+      }
+    },
     "postcss-less": {
       "version": "1.1.1",
       "dev": true

--- a/package.json
+++ b/package.json
@@ -115,6 +115,7 @@
     "phone": "git+https://github.com/Automattic/node-phone.git#1.0.8",
     "photon": "2.0.0",
     "postcss-cli": "2.5.1",
+    "postcss-custom-properties": "6.2.0",
     "prismjs": "1.6.0",
     "prop-types": "15.5.10",
     "q": "1.0.1",


### PR DESCRIPTION
#### This PR 
- is part of a series of PRs aiming to provide support for Color Schemes in Calypso.

-  focuses on adding the postcss plugin `postcss-custom-properties` which will be used to create a fallback for non-supporting browsers. 

- is a continuation of PR https://github.com/Automattic/wp-calypso/pull/17366, which will be closed in favor of this and a few other smaller PRs.

#### How to test

The PR simply adds a new dependency that will be used by functionality added in future PRs. 
There is nothing to test at this point (apart from making sure `npm install` still works maybe).