### PR TITLE
Add code to remove themes selection step.

### DIFF
--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -122,7 +122,7 @@ const flows = {
 	},
 
 	store: {
-		steps: [ 'design-type-with-store', 'themes', 'domains', 'plans', 'user' ],
+		steps: [ 'design-type-with-store', 'domains', 'plans', 'user' ],
 		destination: getSiteDestination,
 		description: 'Signup flow for creating an online store',
 		lastModified: '2016-06-27',
@@ -162,7 +162,7 @@ const flows = {
 	},
 
 	main: {
-		steps: [ 'design-type', 'themes', 'domains', 'plans', 'user' ],
+		steps: [ 'design-type', 'domains', 'plans', 'user' ],
 		destination: getSiteDestination,
 		description: 'The current best performing flow in AB tests',
 		lastModified: '2016-05-23',
@@ -217,7 +217,7 @@ const flows = {
 	},
 
 	developer: {
-		steps: [ 'themes', 'site', 'user' ],
+		steps: [ 'site', 'user' ],
 		destination: '/devdocs/welcome',
 		description: 'Signup flow for developers in developer environment',
 		lastModified: '2015-11-23',

--- a/client/signup/config/steps.js
+++ b/client/signup/config/steps.js
@@ -78,12 +78,12 @@ export default {
 
 	'design-type': {
 		stepName: 'design-type',
-		providesDependencies: [ 'designType' ],
+		providesDependencies: [ 'designType', 'themeSlugWithRepo' ],
 	},
 
 	'design-type-with-store': {
 		stepName: 'design-type-with-store',
-		providesDependencies: [ 'designType' ],
+		providesDependencies: [ 'designType', 'themeSlugWithRepo' ],
 	},
 
 	'design-type-with-atomic-store': {

--- a/client/signup/steps/design-type-with-store/index.jsx
+++ b/client/signup/steps/design-type-with-store/index.jsx
@@ -22,6 +22,8 @@ import { BlogImage, PageImage, GridImage, StoreImage } from '../design-type-with
 import { abtest } from 'lib/abtest';
 import { setDesignType } from 'state/signup/steps/design-type/actions';
 
+import { getThemeForDesignType } from 'signup/utils';
+
 class DesignTypeWithStoreStep extends Component {
 	constructor( props ) {
 		super( props );
@@ -106,7 +108,12 @@ class DesignTypeWithStoreStep extends Component {
 			return;
 		}
 
-		SignupActions.submitSignupStep( { stepName: this.props.stepName }, [], { designType } );
+		const themeSlugWithRepo = getThemeForDesignType( designType );
+
+		SignupActions.submitSignupStep( { stepName: this.props.stepName }, [], {
+			designType,
+			themeSlugWithRepo,
+		} );
 
 		this.props.goToNextStep();
 	};

--- a/client/signup/steps/design-type/index.jsx
+++ b/client/signup/steps/design-type/index.jsx
@@ -21,6 +21,8 @@ import { BlogImage, PageImage, GridImage } from '../design-type-with-store/type-
 import { setDesignType } from 'state/signup/steps/design-type/actions';
 import { recordTracksEvent } from 'state/analytics/actions';
 
+import { getThemeForDesignType } from 'signup/utils';
+
 export class DesignTypeStep extends Component {
 	static propTypes = {
 		translate: PropTypes.func,
@@ -131,11 +133,16 @@ export class DesignTypeStep extends Component {
 	}
 
 	handleNextStep( designType ) {
+		const themeSlugWithRepo = getThemeForDesignType( designType );
+
 		this.props.setDesignType( designType );
 
 		this.props.recordTracksEvent( 'calypso_triforce_select_design', { category: designType } );
 
-		SignupActions.submitSignupStep( { stepName: this.props.stepName }, [], { designType } );
+		SignupActions.submitSignupStep( { stepName: this.props.stepName }, [], {
+			designType,
+			themeSlugWithRepo,
+		} );
 		this.props.goToNextStep();
 	}
 }

--- a/client/signup/utils.js
+++ b/client/signup/utils.js
@@ -130,6 +130,19 @@ function getDestination( destination, dependencies, flowName ) {
 	return flows.filterDestination( destination, dependencies, flowName );
 }
 
+function getThemeForDesignType( designType ) {
+	switch ( designType ) {
+		case 'blog':
+			return 'pub/independent-publisher-2';
+		case 'grid':
+			return 'pub/altofocus';
+		case 'page':
+			return 'pub/dara';
+		default:
+			return 'pub/twentyseventeen';
+	}
+}
+
 export default {
 	getFlowName: getFlowName,
 	getFlowSteps: getFlowSteps,
@@ -143,4 +156,5 @@ export default {
 	getValueFromProgressStore: getValueFromProgressStore,
 	getDestination: getDestination,
 	mergeFormWithValue: mergeFormWithValue,
+	getThemeForDesignType: getThemeForDesignType,
 };


### PR DESCRIPTION
The step has been removed for the 'themes', 'developer', and
'pressable' signup flows.