### PR TITLE
Color Schemes: Add color schemes scss file

### DIFF
--- a/assets/stylesheets/shared/_color-schemes.scss
+++ b/assets/stylesheets/shared/_color-schemes.scss
@@ -1,0 +1,30 @@
+//default color scheme
+:root {
+	--masterbar-color: $white;
+	--masterbar-background-color: $blue-wordpress;
+	--masterbar-border-color: darken( $blue-wordpress, 4% );
+	--masterbar-item-hover-background: lighten( $blue-wordpress, 5% );
+	--masterbar-item-active-background: darken( $blue-wordpress, 17% );
+	--masterbar-item-new-color: $blue-wordpress;
+}
+
+//additional color schemes
+.color-scheme {
+	&.is-light {
+		--masterbar-color: $gray-text;
+		--masterbar-background-color: lighten( $gray, 20% );
+		--masterbar-border-color: lighten( $gray, 10% );
+		--masterbar-item-hover-background: lighten( $gray, 30% );
+		--masterbar-item-active-background: lighten( $gray, 10% );
+		--masterbar-item-new-color: $gray-text;
+	}
+
+	&.is-dark {
+		--masterbar-color: $white;
+		--masterbar-background-color: $gray-dark;
+		--masterbar-border-color: darken( $gray, 10% );
+		--masterbar-item-hover-background: darken( $gray, 10% );
+		--masterbar-item-active-background: $gray-text-min;
+		--masterbar-item-new-color: $gray-dark;
+	}
+}

--- a/assets/stylesheets/style.scss
+++ b/assets/stylesheets/style.scss
@@ -4,6 +4,7 @@
 // Shared
 @import 'shared/reset';                        // css reset before the rest of the styles are defined
 @import 'shared/utils';                        // utilities that are used by all CSS but don't produce any code
+@import 'shared/color-schemes';                // import color schemes
 @import 'shared/animation';                    // all UI animation
 @import 'shared/forms';                        // form styling
 @import 'shared/dropdowns';                    // dropdown styling


### PR DESCRIPTION
#### This PR 
- is part of a series of PRs aiming to provide support for Color Schemes in Calypso.

-  focuses on adding a scss file dedicated to the color scheme definitions

-  adds three color schemes: default, light and dark

- is a continuation of PR https://github.com/Automattic/wp-calypso/pull/17366, which will be closed in favor of this and a few other smaller PRs.

#### How to test

Run the CSS build and check if color scheme styles are in the `style.css` output.

#### Notes

This PR currently compares its changes to PR https://github.com/Automattic/wp-calypso/pull/18909 which in turn points to https://github.com/Automattic/wp-calypso/pull/18905. This is so the changes can be easily identified. This PR needs to be pointed at master once PR https://github.com/Automattic/wp-calypso/pull/18909 and https://github.com/Automattic/wp-calypso/pull/18905 have been merged.

For a more detailed description of the feature, the chosen approach and its advantages feel free to check out my post on the subject: p4TIVU-75d-p2 (internal reference).
