### PR TITLE
Color Schemes: Update color scheme classes on Layout

### DIFF
--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -140,14 +140,15 @@ const Layout = React.createClass( {
 	render: function() {
 		const sectionClass = classnames(
 				'layout',
+				'color-scheme',
+				`is-${ this.props.colorSchemePreference }`,
 				`is-group-${ this.props.section.group }`,
 				`is-section-${ this.props.section.name }`,
 				`focus-${ this.props.currentLayoutFocus }`,
 				{ 'is-support-user': this.props.isSupportUser },
 				{ 'has-no-sidebar': ! this.props.hasSidebar },
 				{ 'wp-singletree-layout': !! this.props.primary },
-				{ 'has-chat': this.props.chatIsOpen },
-				`is-${ this.props.colorSchemePreference }-theme`
+				{ 'has-chat': this.props.chatIsOpen }
 			),
 			loadingClass = classnames( {
 				layout__loader: true,


### PR DESCRIPTION
#### This PR 
- is part of a series of PRs aiming to provide support for Color Schemes in Calypso.

-  focuses on updating the color scheme classes set on Layout 

- is a continuation of PR https://github.com/Automattic/wp-calypso/pull/17366, which will be closed in favor of this and a few other smaller PRs.

#### How to test

Navigate to Account settings. Open the console and check `data-reactroot` in the elements tab. When selecting the different color schemes, the classes on `data-reactroot` should update accordingly.

#### Notes

This PR currently compares its changes to PR https://github.com/Automattic/wp-calypso/pull/18911 which in turn points to https://github.com/Automattic/wp-calypso/pull/18909 and https://github.com/Automattic/wp-calypso/pull/18905. This is so the changes can be easily identified. This PR needs to be pointed at master once PR https://github.com/Automattic/wp-calypso/pull/18911, https://github.com/Automattic/wp-calypso/pull/18909 and https://github.com/Automattic/wp-calypso/pull/18905 have been merged.

For a more detailed description of the feature, the chosen approach and its advantages feel free to check out my post on the subject: p4TIVU-75d-p2 (internal reference).
