### PR TITLE
Color Schemes: Add CSS custom properties to Masterbar

### DIFF
--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -3,9 +3,9 @@ $autobar-height: 20px;
 
 // The WordPress.com Masterbar
 .masterbar {
-	background: $masterbar-color;
-	border-bottom: 1px solid darken( $masterbar-color, 4% );
-	color: $white;
+	background: var( --masterbar-background-color );
+	border-bottom: 1px solid var( --masterbar-border-color );
+	color: var( --masterbar-color );
 	font-size: 16px;
 	display: flex;
 	height: $masterbar-height;
@@ -68,7 +68,7 @@ $autobar-height: 20px;
 	display: flex;
 		align-items: center;
 	position: relative;
-	color: $white;
+	color: var( --masterbar-color );
 	font-size: 14px;
 	height: $masterbar-height;
 	line-height: $masterbar-height;
@@ -78,7 +78,7 @@ $autobar-height: 20px;
 	transition: all 150ms ease-in;
 
 	&:visited {
-		color: $white;
+		color: var( --masterbar-color );
 	}
 
 	&[href] {
@@ -86,7 +86,7 @@ $autobar-height: 20px;
 	}
 
 	.masterbar__item-content {
-		color: $white;
+		color: var( --masterbar-color );
 	}
 
 	.gridicon + .masterbar__item-content {
@@ -95,13 +95,13 @@ $autobar-height: 20px;
 
 	&:hover,
 	&:focus {
-		background: lighten( $masterbar-color, 5% );
-		color: $white;
+		background: var( --masterbar-item-hover-background );
+		color: var( --masterbar-color );
 		outline: 0;
 	}
 
 	&.is-active {
-		background: darken( $masterbar-color, 17% );
+		background: var( --masterbar-item-active-background );
 	}
 
 	.is-support-user &.is-active {
@@ -170,13 +170,13 @@ $autobar-height: 20px;
 .masterbar__item-new {
 	background: $white;
 	border-radius: 3px;
-	color: $blue-wordpress;
+	color: var( --masterbar-item-new-color );
 	height: 36px;
 	margin: 5px 8px;
 	transition: all 0.2s ease-out;
 
 	&:visited {
-		color: $blue-wordpress;
+		color: var( --masterbar-item-new-color );
 	}
 
 	&.is-active {
@@ -186,11 +186,11 @@ $autobar-height: 20px;
 	&:hover,
 	&:focus {
 		background: $gray-light;
-		color: $blue-wordpress;
+		color: var( --masterbar-item-new-color );
 	}
 
 	.masterbar__item-content {
-		color: $blue-wordpress;
+		color: var( --masterbar-item-new-color );
 		display: none;
 
 		@include breakpoint( ">960px" ) {

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -174,7 +174,7 @@
 }
 
 .layout__loader {
-	border-bottom: 1px solid darken( $blue-wordpress, 4% );
+	border-bottom: 1px solid var( --masterbar-border-color );
 	height: 46px;
 	margin-left: -10%;
 	position: absolute;
@@ -191,7 +191,7 @@
 	transition-delay: 0.4s;
 
 	@include breakpoint( "<480px" ) {
-		background: $blue-wordpress;
+		background: var( --masterbar-background-color );
 	}
 }
 


### PR DESCRIPTION
#### This PR 
- is part of a series of PRs aiming to provide support for Color Schemes in Calypso.
- focuses on adding color scheme support to the Masterbar via CSS custom properties.
- is a continuation of PR #17366, which will be closed in favor of this and a few other smaller PRs.


![ezgif com-video-to-gif 3](https://user-images.githubusercontent.com/1562646/29487542-12f3aa90-84fb-11e7-937b-83e6bb4f69fb.gif)

### How to test
- Visit https://calypso.live/?branch=add/color-schemes/add-masterbar-color-schemes or test locally.
- Navigate to the `Accounts Settings` page and scroll down to the `Admin Color Scheme` section. 
- Depending on whether the browser supports CSS custom properties, the Admin Color Scheme Picker will be present or not (for browser support see http://caniuse.com/#feat=css-variables)
- Select a color scheme to change the appearance of the Masterbar
- Save to persist or reload without saving to discard your selection

### Notes

This PR currently compares its changes to PR https://github.com/Automattic/wp-calypso/pull/18912 which in turn points to https://github.com/Automattic/wp-calypso/pull/18911, https://github.com/Automattic/wp-calypso/pull/18909 and https://github.com/Automattic/wp-calypso/pull/18905. This is so the changes can be easily identified. This PR needs to be pointed at master once PR https://github.com/Automattic/wp-calypso/pull/18912, https://github.com/Automattic/wp-calypso/pull/18911, https://github.com/Automattic/wp-calypso/pull/18909 and https://github.com/Automattic/wp-calypso/pull/18905 have been merged.

For a more detailed description of the feature, the chosen approach and its advantages feel free to check out my post on the subject: p4TIVU-75d-p2 (internal reference).