### PR TITLE
Add `/me/concierge/` section scaffolding code.

### DIFF
--- a/client/me/concierge/controller.js
+++ b/client/me/concierge/controller.js
@@ -9,12 +9,11 @@ import React from 'react';
  * Internal dependencies
  */
 import { renderWithReduxStore } from 'lib/react-helpers';
+import ConciergeMain from './main';
 
 const concierge = context => {
-	const ConciergeRootComponent = <div />;
-
 	renderWithReduxStore(
-		React.createElement( ConciergeRootComponent, {} ),
+		React.createElement( ConciergeMain, {} ),
 		document.getElementById( 'primary' ),
 		context.store
 	);

--- a/client/me/concierge/controller.js
+++ b/client/me/concierge/controller.js
@@ -1,0 +1,25 @@
+/**
+ * External dependencies
+ *
+ * @format
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { renderWithReduxStore } from 'lib/react-helpers';
+
+const concierge = context => {
+	const ConciergeRootComponent = <div />;
+
+	renderWithReduxStore(
+		React.createElement( ConciergeRootComponent, {} ),
+		document.getElementById( 'primary' ),
+		context.store
+	);
+};
+
+export default {
+	concierge,
+};

--- a/client/me/concierge/index.js
+++ b/client/me/concierge/index.js
@@ -1,0 +1,17 @@
+/**
+ * External dependencies
+ *
+ * @format
+ */
+
+import page from 'page';
+
+/**
+ * Internal dependencies
+ */
+import meController from 'me/controller';
+import controller from './controller';
+
+export default () => {
+	page( '/me/concierge', meController.sidebar, controller.concierge );
+};

--- a/client/me/concierge/index.js
+++ b/client/me/concierge/index.js
@@ -9,9 +9,12 @@ import page from 'page';
 /**
  * Internal dependencies
  */
+import config from 'config';
 import meController from 'me/controller';
 import controller from './controller';
 
 export default () => {
-	page( '/me/concierge', meController.sidebar, controller.concierge );
+	if ( config.isEnabled( 'business-concierge' ) ) {
+		page( '/me/concierge', meController.sidebar, controller.concierge );
+	}
 };

--- a/client/me/concierge/index.js
+++ b/client/me/concierge/index.js
@@ -14,7 +14,7 @@ import meController from 'me/controller';
 import controller from './controller';
 
 export default () => {
-	if ( config.isEnabled( 'business-concierge' ) ) {
+	if ( config.isEnabled( 'concierge-chats' ) ) {
 		page( '/me/concierge', meController.sidebar, controller.concierge );
 	}
 };

--- a/client/me/concierge/index.js
+++ b/client/me/concierge/index.js
@@ -10,11 +10,10 @@ import page from 'page';
  * Internal dependencies
  */
 import config from 'config';
-import meController from 'me/controller';
 import controller from './controller';
 
 export default () => {
 	if ( config.isEnabled( 'concierge-chats' ) ) {
-		page( '/me/concierge', meController.sidebar, controller.concierge );
+		page( '/me/concierge', controller.concierge );
 	}
 };

--- a/client/me/concierge/main.js
+++ b/client/me/concierge/main.js
@@ -1,0 +1,13 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { localize } from 'i18n-calypso';
+
+const ConciergeMain = () => {
+	return (
+		<div>{ 'Business concierge page placeholder.' }</div>
+	);
+};
+
+export default localize( ConciergeMain );

--- a/client/me/concierge/main.js
+++ b/client/me/concierge/main.js
@@ -6,7 +6,7 @@ import { localize } from 'i18n-calypso';
 
 const ConciergeMain = () => {
 	return (
-		<div>{ 'Business concierge page placeholder.' }</div>
+		<div>{ 'Concierge chats page placeholder.' }</div>
 	);
 };
 

--- a/client/wordpress-com.js
+++ b/client/wordpress-com.js
@@ -63,7 +63,7 @@ const sections = [
 	},
 	{
 		name: 'concierge',
-		paths: [ '/me/concierge/' ],
+		paths: [ '/me/concierge' ],
 		module: 'me/concierge',
 		group: 'me',
 		secondary: true,

--- a/client/wordpress-com.js
+++ b/client/wordpress-com.js
@@ -62,6 +62,13 @@ const sections = [
 		secondary: true,
 	},
 	{
+		name: 'concierge',
+		paths: [ '/me/concierge/' ],
+		module: 'me/concierge',
+		group: 'me',
+		secondary: true,
+	},
+	{
 		name: 'media',
 		paths: [ '/media' ],
 		module: 'my-sites/media',

--- a/client/wordpress-com.js
+++ b/client/wordpress-com.js
@@ -66,7 +66,6 @@ const sections = [
 		paths: [ '/me/concierge' ],
 		module: 'me/concierge',
 		group: 'me',
-		secondary: true,
 	},
 	{
 		name: 'media',

--- a/config/development.json
+++ b/config/development.json
@@ -38,6 +38,7 @@
 		"ad-tracking": false,
 		"automated-transfer": true,
 		"apple-pay": true,
+		"business-concierge": true,
 		"code-splitting": true,
 		"comments/filters-in-posts": true,
 		"comments/moderation-tools-in-posts": true,

--- a/config/development.json
+++ b/config/development.json
@@ -38,7 +38,7 @@
 		"ad-tracking": false,
 		"automated-transfer": true,
 		"apple-pay": true,
-		"business-concierge": true,
+		"concierge-chats": true,
 		"code-splitting": true,
 		"comments/filters-in-posts": true,
 		"comments/moderation-tools-in-posts": true,


### PR DESCRIPTION
## Summary
This PR scaffolds the working directory and the route for the concierge chats project. For more details, please refer to Automattic/hg#438.

* Create the directory, `client/me/concierge`, for containing the source.
* Add the route, `/me/concierge`, for accessing the page.

## Test Plan
1. Accessing http://calypso.localhost:3000/me/concierge should show you this:
![image](https://user-images.githubusercontent.com/1842898/32364340-3daec1ac-c042-11e7-8c20-04c38c8696ed.png)

1. Disabling the feature flag, `concierge-chats`, should make the page unaccessible.


