### PR TITLE
Add nudge for premium theme access

### DIFF
--- a/client/components/info-popover/index.jsx
+++ b/client/components/info-popover/index.jsx
@@ -19,6 +19,7 @@ export default class InfoPopover extends Component {
 		autoRtl: PropTypes.bool,
 		className: PropTypes.string,
 		gaEventCategory: PropTypes.string,
+		icon: PropTypes.string,
 		iconSize: PropTypes.number,
 		id: PropTypes.string,
 		ignoreContext: PropTypes.shape( {
@@ -40,6 +41,7 @@ export default class InfoPopover extends Component {
 
 	static defaultProps = {
 		autoRtl: true,
+		icon: 'info-outline',
 		iconSize: 18,
 		position: 'bottom',
 	};
@@ -73,7 +75,7 @@ export default class InfoPopover extends Component {
 					this.props.className
 				) }
 			>
-				<Gridicon icon="info-outline" size={ this.props.iconSize } />
+				<Gridicon icon={ this.props.icon } size={ this.props.iconSize } />
 				<Popover
 					autoRtl={ this.props.autoRtl }
 					id={ this.props.id }

--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -14,6 +14,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import Button from 'components/button';
 import Card from 'components/card';
 import ThemeMoreButton from './more-button';
 import PulsingDot from 'components/pulsing-dot';
@@ -136,14 +137,15 @@ export class Theme extends Component {
 
 	render() {
 		const { name, screenshot } = this.props.theme;
-		const { active, price, translate } = this.props;
+		const { active, price, translate, upsellUrl } = this.props;
 		const themeClass = classNames( 'theme', {
 			'is-active': active,
 			'is-actionable': !! ( this.props.screenshotClickUrl || this.props.onScreenshotClick ),
 		} );
 
+		const hasPrice = /\d/g.test( price );
 		const priceClass = classNames( 'theme-badge__price', {
-			'theme-badge__price-upgrade': ! /\d/g.test( price ),
+			'theme-badge__price-upgrade': ! hasPrice,
 		} );
 
 		// for performance testing
@@ -151,6 +153,20 @@ export class Theme extends Component {
 
 		if ( this.props.isPlaceholder ) {
 			return this.renderPlaceholder();
+		}
+
+		let secondaryContent = null;
+
+		if ( hasPrice && upsellUrl ) {
+			const freePrice = price.replace( /\d+/, '0' );
+			secondaryContent = (
+				<div className="theme__info-upsell">
+					<span>or </span>
+					<Button href={ this.props.upsellUrl } compact primary>
+						{ translate( '%(freePrice)s with the Premium Plan', { args: { freePrice } } ) }
+					</Button>
+				</div>
+			);
 		}
 
 		return (
@@ -181,15 +197,20 @@ export class Theme extends Component {
 					</a>
 
 					<div className="theme__info">
-						<h2 className="theme__info-title">{ name }</h2>
-						{ active && (
-							<span className="theme-badge__active">
-								{ translate( 'Active', {
-									context: 'singular noun, the currently active theme',
-								} ) }
-							</span>
-						) }
-						<span className={ priceClass }>{ price }</span>
+						<div className="theme__info-detail">
+							<div className="theme__info-primary">
+								<h2 className="theme__info-title">{ name }</h2>
+								{ active && (
+									<span className="theme__badge-active">
+										{ translate( 'Active', {
+											context: 'singular noun, the currently active theme',
+										} ) }
+									</span>
+								) }
+								<span className={ priceClass }>{ price }</span>
+							</div>
+							{ secondaryContent }
+						</div>
 						{ ! isEmpty( this.props.buttonContents ) ? (
 							<ThemeMoreButton
 								index={ this.props.index }

--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -158,7 +158,7 @@ export class Theme extends Component {
 		let secondaryContent = null;
 
 		if ( hasPrice && upsellUrl ) {
-			const freePrice = price.replace( /\d+/, '0' );
+			const freePrice = price.replace( /[0-9,]+/, '0' );
 			secondaryContent = (
 				<div className="theme__info-upsell">
 					<span>or </span>

--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -18,6 +18,8 @@ import Card from 'components/card';
 import ThemeMoreButton from './more-button';
 import PulsingDot from 'components/pulsing-dot';
 import Ribbon from 'components/ribbon';
+import InfoPopover from 'components/info-popover';
+import Button from 'components/button';
 
 /**
  * Component
@@ -157,7 +159,14 @@ export class Theme extends Component {
 		const upsell = hasPrice &&
 		upsellUrl && (
 			<span className="theme__upsell">
-				<Gridicon icon="info-outline" />
+				<InfoPopover position="top left">
+					<h2 className="theme__upsell-heading">
+						Access all our premium themes with our Premium and Business Plans
+					</h2>
+					<Button className="theme__upsell-cta" primary href={ upsellUrl }>
+						Upgrade Now
+					</Button>
+				</InfoPopover>
 			</span>
 		);
 

--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -14,7 +14,6 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import Button from 'components/button';
 import Card from 'components/card';
 import ThemeMoreButton from './more-button';
 import PulsingDot from 'components/pulsing-dot';
@@ -144,8 +143,8 @@ export class Theme extends Component {
 		} );
 
 		const hasPrice = /\d/g.test( price );
-		const priceClass = classNames( 'theme-badge__price', {
-			'theme-badge__price-upgrade': ! hasPrice,
+		const priceClass = classNames( 'theme__badge-price', {
+			'theme__badge-price-upgrade': ! hasPrice,
 		} );
 
 		// for performance testing
@@ -155,19 +154,12 @@ export class Theme extends Component {
 			return this.renderPlaceholder();
 		}
 
-		let secondaryContent = null;
-
-		if ( hasPrice && upsellUrl ) {
-			const freePrice = price.replace( /[0-9,]+/, '0' );
-			secondaryContent = (
-				<div className="theme__info-upsell">
-					<span>or </span>
-					<Button href={ this.props.upsellUrl } compact primary>
-						{ translate( '%(freePrice)s with the Premium Plan', { args: { freePrice } } ) }
-					</Button>
-				</div>
-			);
-		}
+		const upsell = hasPrice &&
+		upsellUrl && (
+			<span className="theme__upsell">
+				<Gridicon icon="info-outline" />
+			</span>
+		);
 
 		return (
 			<Card className={ themeClass }>
@@ -197,20 +189,16 @@ export class Theme extends Component {
 					</a>
 
 					<div className="theme__info">
-						<div className="theme__info-detail">
-							<div className="theme__info-primary">
-								<h2 className="theme__info-title">{ name }</h2>
-								{ active && (
-									<span className="theme__badge-active">
-										{ translate( 'Active', {
-											context: 'singular noun, the currently active theme',
-										} ) }
-									</span>
-								) }
-								<span className={ priceClass }>{ price }</span>
-							</div>
-							{ secondaryContent }
-						</div>
+						<h2 className="theme__info-title">{ name }</h2>
+						{ active && (
+							<span className="theme__badge-active">
+								{ translate( 'Active', {
+									context: 'singular noun, the currently active theme',
+								} ) }
+							</span>
+						) }
+						<span className={ priceClass }>{ price }</span>
+						{ upsell }
 						{ ! isEmpty( this.props.buttonContents ) ? (
 							<ThemeMoreButton
 								index={ this.props.index }

--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -161,7 +161,7 @@ export class Theme extends Component {
 			<span className="theme__upsell">
 				<InfoPopover icon="star-outline" position="top left">
 					<h2 className="theme__upsell-heading">
-						Access all our premium themes with our Premium and Business Plans
+						Access all our premium themes for free with our Premium and Business Plans
 					</h2>
 					<Button className="theme__upsell-cta" primary href={ upsellUrl }>
 						Upgrade Now

--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -5,6 +5,7 @@
  */
 
 import React, { Component } from 'react';
+import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { get, isEmpty, isEqual, noop, some } from 'lodash';
@@ -20,6 +21,8 @@ import PulsingDot from 'components/pulsing-dot';
 import Ribbon from 'components/ribbon';
 import InfoPopover from 'components/info-popover';
 import Button from 'components/button';
+import TrackComponentView from 'lib/analytics/track-component-view';
+import { recordTracksEvent } from 'state/analytics/actions';
 
 /**
  * Component
@@ -136,9 +139,16 @@ export class Theme extends Component {
 		}
 	};
 
+	onUpsellClick = () => {
+		this.props.recordTracksEvent( 'calypso_upgrade_nudge_cta_click', {
+			cta_name: 'theme-upsell-popup',
+			theme: this.props.theme.id,
+		} );
+	};
+
 	render() {
-		const { name, screenshot } = this.props.theme;
-		const { active, price, translate, upsellUrl } = this.props;
+		const { active, price, theme, translate, upsellUrl } = this.props;
+		const { name, screenshot } = theme;
 		const themeClass = classNames( 'theme', {
 			'is-active': active,
 			'is-actionable': !! ( this.props.screenshotClickUrl || this.props.onScreenshotClick ),
@@ -156,14 +166,30 @@ export class Theme extends Component {
 			return this.renderPlaceholder();
 		}
 
+		const impressionEventName = 'calypso_upgrade_nudge_impression';
+		const upsellEventProperties = { cta_name: 'theme-upsell', theme: theme.id };
+		const upsellPopupEventProperties = { cta_name: 'theme-upsell-popup', theme: theme.id };
 		const upsell = hasPrice &&
 		upsellUrl && (
 			<span className="theme__upsell">
+				<TrackComponentView
+					eventName={ impressionEventName }
+					eventProperties={ upsellEventProperties }
+				/>
 				<InfoPopover icon="star-outline" position="top left">
+					<TrackComponentView
+						eventName={ impressionEventName }
+						eventProperties={ upsellPopupEventProperties }
+					/>
 					<h2 className="theme__upsell-heading">
 						Access all our premium themes for free with our Premium and Business Plans
 					</h2>
-					<Button className="theme__upsell-cta" primary href={ upsellUrl }>
+					<Button
+						onClick={ this.onUpsellClick }
+						className="theme__upsell-cta"
+						primary
+						href={ upsellUrl }
+					>
 						Upgrade Now
 					</Button>
 				</InfoPopover>
@@ -224,4 +250,7 @@ export class Theme extends Component {
 	}
 }
 
-export default localize( Theme );
+const mapStateToProps = null;
+const mapDispatchToProps = { recordTracksEvent };
+
+export default connect( mapStateToProps, mapDispatchToProps )( localize( Theme ) );

--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -159,7 +159,7 @@ export class Theme extends Component {
 		const upsell = hasPrice &&
 		upsellUrl && (
 			<span className="theme__upsell">
-				<InfoPopover position="top left">
+				<InfoPopover icon="star-outline" position="top left">
 					<h2 className="theme__upsell-heading">
 						Access all our premium themes with our Premium and Business Plans
 					</h2>

--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -183,17 +183,19 @@ export class Theme extends Component {
 						eventName={ impressionEventName }
 						eventProperties={ upsellPopupEventProperties }
 					/>
-					<h2 className="theme__upsell-heading">
-						Access all our premium themes for free with our Premium and Business Plans
-					</h2>
-					<Button
-						onClick={ this.onUpsellClick }
-						className="theme__upsell-cta"
-						primary
-						href={ upsellUrl }
-					>
-						Upgrade Now
-					</Button>
+					<div className="theme__upsell-popover">
+						<h2 className="theme__upsell-heading">
+							Access all our premium themes for free with our Premium and Business Plans
+						</h2>
+						<Button
+							onClick={ this.onUpsellClick }
+							className="theme__upsell-cta"
+							primary
+							href={ upsellUrl }
+						>
+							Upgrade Now
+						</Button>
+					</div>
 				</InfoPopover>
 			</span>
 		);

--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -23,7 +23,6 @@ import InfoPopover from 'components/info-popover';
 import Button from 'components/button';
 import TrackComponentView from 'lib/analytics/track-component-view';
 import { recordTracksEvent } from 'state/analytics/actions';
-import { abtest } from 'lib/abtest';
 
 /**
  * Component
@@ -156,9 +155,10 @@ export class Theme extends Component {
 		} );
 
 		const hasPrice = /\d/g.test( price );
+		const showUpsell = hasPrice && upsellUrl;
 		const priceClass = classNames( 'theme__badge-price', {
 			'theme__badge-price-upgrade': ! hasPrice,
-			'theme__badge-price-test': abtest( 'unlimitedThemeNudge' ) === 'show',
+			'theme__badge-price-test': showUpsell,
 		} );
 
 		// for performance testing
@@ -171,8 +171,7 @@ export class Theme extends Component {
 		const impressionEventName = 'calypso_upgrade_nudge_impression';
 		const upsellEventProperties = { cta_name: 'theme-upsell', theme: theme.id };
 		const upsellPopupEventProperties = { cta_name: 'theme-upsell-popup', theme: theme.id };
-		const upsell = hasPrice &&
-		upsellUrl && (
+		const upsell = showUpsell && (
 			<span className="theme__upsell">
 				<TrackComponentView
 					eventName={ impressionEventName }

--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -23,6 +23,7 @@ import InfoPopover from 'components/info-popover';
 import Button from 'components/button';
 import TrackComponentView from 'lib/analytics/track-component-view';
 import { recordTracksEvent } from 'state/analytics/actions';
+import { abtest } from 'lib/abtest';
 
 /**
  * Component
@@ -157,6 +158,7 @@ export class Theme extends Component {
 		const hasPrice = /\d/g.test( price );
 		const priceClass = classNames( 'theme__badge-price', {
 			'theme__badge-price-upgrade': ! hasPrice,
+			'theme__badge-price-test': abtest( 'unlimitedThemeNudge' ) === 'show',
 		} );
 
 		// for performance testing
@@ -176,7 +178,7 @@ export class Theme extends Component {
 					eventName={ impressionEventName }
 					eventProperties={ upsellEventProperties }
 				/>
-				<InfoPopover icon="star-outline" position="top left">
+				<InfoPopover icon="star" className="theme__upsell-icon" position="top left">
 					<TrackComponentView
 						eventName={ impressionEventName }
 						eventProperties={ upsellPopupEventProperties }

--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -185,7 +185,7 @@ export class Theme extends Component {
 					/>
 					<div className="theme__upsell-popover">
 						<h2 className="theme__upsell-heading">
-							Access all our premium themes for free with our Premium and Business Plans
+							{ translate( 'Use this theme at no extra cost on our Premium or Business Plan' ) }
 						</h2>
 						<Button
 							onClick={ this.onUpsellClick }
@@ -193,7 +193,7 @@ export class Theme extends Component {
 							primary
 							href={ upsellUrl }
 						>
-							Upgrade Now
+							{ translate( 'Upgrade Now' ) }
 						</Button>
 					</div>
 				</InfoPopover>

--- a/client/components/theme/style.scss
+++ b/client/components/theme/style.scss
@@ -1,4 +1,4 @@
-$theme-info-height: 54px;
+$theme-info-height: 108px;
 
 .theme {
 	padding: 0;
@@ -62,6 +62,30 @@ $theme-info-height: 54px;
 	background: $white;
 }
 
+.theme__info-detail {
+	display: flex;
+	flex: 1 1 auto;
+	flex-direction: column;
+}
+
+.theme__info-primary {
+	display: flex;
+	flex-direction: row;
+}
+
+.theme__info-upsell {
+	display: flex;
+	align-self: center;
+	span {
+		color: $gray;
+		padding: 16px 4px;
+	}
+	.button {
+		margin: 14px 2px;
+		padding: 8px 4px;
+	}
+}
+
 .theme__info-title {
 	flex: 1 1 auto;
 	position: relative;
@@ -92,7 +116,7 @@ $theme-info-height: 54px;
 	font-size: 80%;
 }
 
-.theme-badge__active {
+.theme__badge-active {
 	flex: 0 0 auto;
 	padding: 18px 10px 0;
 	color: lighten( $blue-light, 10% );
@@ -118,7 +142,7 @@ $theme-info-height: 54px;
 		z-index: z-index( 'root', '.is-actionable .theme__active-focus' );
 		top: 0;
 		right: 0;
-		bottom: 54px;
+		bottom: 108px;
 		width: 100%;
 		padding-top: 36%;
 		cursor: pointer;

--- a/client/components/theme/style.scss
+++ b/client/components/theme/style.scss
@@ -1,4 +1,4 @@
-$theme-info-height: 108px;
+$theme-info-height: 54px;
 
 .theme {
 	padding: 0;
@@ -62,30 +62,6 @@ $theme-info-height: 108px;
 	background: $white;
 }
 
-.theme__info-detail {
-	display: flex;
-	flex: 1 1 auto;
-	flex-direction: column;
-}
-
-.theme__info-primary {
-	display: flex;
-	flex-direction: row;
-}
-
-.theme__info-upsell {
-	display: flex;
-	align-self: center;
-	span {
-		color: $gray;
-		padding: 16px 4px;
-	}
-	.button {
-		margin: 14px 2px;
-		padding: 8px 4px;
-	}
-}
-
 .theme__info-title {
 	flex: 1 1 auto;
 	position: relative;
@@ -103,7 +79,7 @@ $theme-info-height: 108px;
 	}
 }
 
-.theme-badge__price {
+.theme__badge-price {
 	flex: 0 0 auto;
 	padding: 18px 10px 0;
 	color: $alert-green;
@@ -111,7 +87,13 @@ $theme-info-height: 108px;
 	font-weight: 600;
 }
 
-.theme-badge__price-upgrade {
+.theme__upsell {
+	flex: 0 0 auto;
+	padding: 16px 10px 0 0;
+	color: $gray;
+}
+
+.theme__badge-price-upgrade {
 	text-transform: uppercase;
 	font-size: 80%;
 }
@@ -142,7 +124,7 @@ $theme-info-height: 108px;
 		z-index: z-index( 'root', '.is-actionable .theme__active-focus' );
 		top: 0;
 		right: 0;
-		bottom: 108px;
+		bottom: 54px;
 		width: 100%;
 		padding-top: 36%;
 		cursor: pointer;

--- a/client/components/theme/style.scss
+++ b/client/components/theme/style.scss
@@ -93,6 +93,17 @@ $theme-info-height: 54px;
 	color: $gray;
 }
 
+.theme__upsell-heading {
+	text-align: center
+}
+
+.theme__upsell-cta {
+	margin-top: 10px;
+	margin-left: auto;
+	margin-right: auto;
+	display: table;
+}
+
 .theme__badge-price-upgrade {
 	text-transform: uppercase;
 	font-size: 80%;

--- a/client/components/theme/style.scss
+++ b/client/components/theme/style.scss
@@ -87,10 +87,30 @@ $theme-info-height: 54px;
 	font-weight: 600;
 }
 
+.theme__badge-price-test {
+	padding: 18px 5px;
+}
+
 .theme__upsell {
 	flex: 0 0 auto;
 	padding: 16px 10px 0 0;
 	color: $gray;
+}
+
+.theme__upsell-icon svg {
+	transform: scale( 0.8 );
+	border: 2px solid lighten( $gray, 10% );
+	border-radius: 100%;
+	display: inline-block;
+	width: 22px;
+	height: 22px;
+	z-index: 0;
+	padding: 0 1px 1px 0;
+	box-sizing: border-box;
+
+	&:hover {
+		border-color: #000;
+	}
 }
 
 .theme__upsell-heading {

--- a/client/components/theme/style.scss
+++ b/client/components/theme/style.scss
@@ -113,15 +113,12 @@ $theme-info-height: 54px;
 	}
 }
 
-.theme__upsell-heading {
+.theme__upsell-popover {
 	text-align: center
 }
 
 .theme__upsell-cta {
 	margin-top: 10px;
-	margin-left: auto;
-	margin-right: auto;
-	display: table;
 }
 
 .theme__badge-price-upgrade {

--- a/client/components/theme/test/index.jsx
+++ b/client/components/theme/test/index.jsx
@@ -125,7 +125,7 @@ describe( 'Theme', () => {
 		} );
 
 		test( 'should show a price', () => {
-			assert( themeNode.getElementsByClassName( 'theme-badge__price' )[ 0 ].textContent === '$50' );
+			assert( themeNode.getElementsByClassName( 'theme__badge-price' )[ 0 ].textContent === '$50' );
 		} );
 	} );
 } );

--- a/client/components/themes-list/index.jsx
+++ b/client/components/themes-list/index.jsx
@@ -88,6 +88,7 @@ export const ThemesList = createReactClass( {
 				active={ this.props.isActive( theme.id ) }
 				price={ this.props.getPrice( theme.id ) }
 				installing={ this.props.isInstalling( theme.id ) }
+				upsellUrl={ this.props.upsellUrl }
 			/>
 		);
 	},

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -99,4 +99,13 @@ export default {
 		allowExistingUsers: true,
 		localeTargets: 'any',
 	},
+	unlimitedThemeNudge: {
+		datestamp: '20171016',
+		variations: {
+			hide: 50,
+			show: 50,
+		},
+		defaultVariation: 'hide',
+		allowExistingUsers: true,
+	},
 };

--- a/client/my-sites/themes/single-site-wpcom.jsx
+++ b/client/my-sites/themes/single-site-wpcom.jsx
@@ -8,9 +8,9 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { get } from 'lodash';
 
-/**
- * Internal dependencies
+/** * Internal dependencies
  */
+import { abtest } from 'lib/abtest';
 import CurrentTheme from 'my-sites/themes/current-theme';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import ThanksModal from 'my-sites/themes/thanks-modal';
@@ -25,6 +25,7 @@ import ThemeShowcase from './theme-showcase';
 const ConnectedSingleSiteWpcom = connectOptions( props => {
 	const { siteId, currentPlanSlug, translate } = props;
 
+	const upsellUrl = abtest( 'unlimitedThemeNudge' ) === 'show' && `/plans/${ props.siteSlug }`;
 	return (
 		<div>
 			<SidebarNavigation />
@@ -42,7 +43,7 @@ const ConnectedSingleSiteWpcom = connectOptions( props => {
 				/>
 			) }
 
-			<ThemeShowcase { ...props } siteId={ siteId }>
+			<ThemeShowcase { ...props } upsellUrl={ upsellUrl } siteId={ siteId }>
 				{ siteId && <QuerySitePlans siteId={ siteId } /> }
 				{ siteId && <QuerySitePurchases siteId={ siteId } /> }
 				<ThanksModal source={ 'list' } />

--- a/client/my-sites/themes/single-site-wpcom.jsx
+++ b/client/my-sites/themes/single-site-wpcom.jsx
@@ -10,7 +10,7 @@ import { get } from 'lodash';
 
 /** * Internal dependencies
  */
-// import { abtest } from 'lib/abtest';
+import { abtest } from 'lib/abtest';
 import CurrentTheme from 'my-sites/themes/current-theme';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import ThanksModal from 'my-sites/themes/thanks-modal';
@@ -26,8 +26,7 @@ import { getSiteSlug } from 'state/sites/selectors';
 const ConnectedSingleSiteWpcom = connectOptions( props => {
 	const { siteId, siteSlug, currentPlanSlug, translate } = props;
 
-	const upsellUrl = `/plans/${ siteSlug }`;
-	// const upsellUrl = abtest( 'unlimitedThemeNudge' ) === 'show' && `/plans/${ props.siteSlug }`;
+	const upsellUrl = abtest( 'unlimitedThemeNudge' ) === 'show' && `/plans/${ siteSlug }`;
 	return (
 		<div>
 			<SidebarNavigation />

--- a/client/my-sites/themes/single-site-wpcom.jsx
+++ b/client/my-sites/themes/single-site-wpcom.jsx
@@ -10,7 +10,7 @@ import { get } from 'lodash';
 
 /** * Internal dependencies
  */
-import { abtest } from 'lib/abtest';
+// import { abtest } from 'lib/abtest';
 import CurrentTheme from 'my-sites/themes/current-theme';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import ThanksModal from 'my-sites/themes/thanks-modal';
@@ -21,11 +21,13 @@ import { getCurrentPlan } from 'state/sites/plans/selectors';
 import QuerySitePlans from 'components/data/query-site-plans';
 import QuerySitePurchases from 'components/data/query-site-purchases';
 import ThemeShowcase from './theme-showcase';
+import { getSiteSlug } from 'state/sites/selectors';
 
 const ConnectedSingleSiteWpcom = connectOptions( props => {
-	const { siteId, currentPlanSlug, translate } = props;
+	const { siteId, siteSlug, currentPlanSlug, translate } = props;
 
-	const upsellUrl = abtest( 'unlimitedThemeNudge' ) === 'show' && `/plans/${ props.siteSlug }`;
+	const upsellUrl = `/plans/${ siteSlug }`;
+	// const upsellUrl = abtest( 'unlimitedThemeNudge' ) === 'show' && `/plans/${ props.siteSlug }`;
 	return (
 		<div>
 			<SidebarNavigation />
@@ -55,6 +57,7 @@ const ConnectedSingleSiteWpcom = connectOptions( props => {
 export default connect( ( state, { siteId } ) => {
 	const currentPlan = getCurrentPlan( state, siteId );
 	return {
+		siteSlug: getSiteSlug( state, siteId ),
 		currentPlanSlug: get( currentPlan, 'productSlug', null ),
 	};
 } )( ConnectedSingleSiteWpcom );

--- a/client/my-sites/themes/single-site-wpcom.jsx
+++ b/client/my-sites/themes/single-site-wpcom.jsx
@@ -8,7 +8,8 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { get } from 'lodash';
 
-/** * Internal dependencies
+/**
+ * Internal dependencies
  */
 import { abtest } from 'lib/abtest';
 import CurrentTheme from 'my-sites/themes/current-theme';

--- a/client/my-sites/themes/test/logged-out.jsx
+++ b/client/my-sites/themes/test/logged-out.jsx
@@ -17,6 +17,7 @@ import { receiveThemes } from 'state/themes/actions';
 import { DEFAULT_THEME_QUERY } from 'state/themes/constants';
 
 jest.mock( 'components/popover', () => require( 'components/empty-component' ) );
+jest.mock( 'lib/abtest', () => ( { abtest: () => {} } ) );
 jest.mock( 'lib/analytics', () => ( {} ) );
 jest.mock( 'lib/analytics/page-view-tracker', () => require( 'components/empty-component' ) );
 jest.mock( 'my-sites/themes/theme-preview', () => require( 'components/empty-component' ) );

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -235,6 +235,7 @@ class ThemeShowcase extends React.Component {
 						</Button>
 					) }
 					<ThemesSelection
+						upsellUrl={ this.props.upsellUrl }
 						search={ search }
 						tier={ this.props.tier }
 						filter={ filter }

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -12,6 +12,7 @@ import { compact, includes, isEqual, property, snakeCase } from 'lodash';
 /**
  * Internal dependencies
  */
+import { abtest } from 'lib/abtest';
 import { trackClick } from './helpers';
 import QueryThemes from 'components/data/query-themes';
 import ThemesList from 'components/themes-list';
@@ -140,11 +141,15 @@ class ThemesSelection extends Component {
 	render() {
 		const { source, query, listLabel, themesCount } = this.props;
 
+		const upsellUrl =
+			abtest( 'unlimitedThemeNudge' ) === 'show' && `/plans/${ this.props.siteSlug }`;
+
 		return (
 			<div className="themes__selection">
 				<QueryThemes query={ query } siteId={ source } />
 				<ThemesSelectionHeader label={ listLabel } count={ themesCount } />
 				<ThemesList
+					upsellUrl={ upsellUrl }
 					themes={ this.props.themes }
 					fetchNextPage={ this.fetchNextPage }
 					onMoreButtonClick={ this.recordSearchResultsClick }

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -12,7 +12,6 @@ import { compact, includes, isEqual, property, snakeCase } from 'lodash';
 /**
  * Internal dependencies
  */
-import { abtest } from 'lib/abtest';
 import { trackClick } from './helpers';
 import QueryThemes from 'components/data/query-themes';
 import ThemesList from 'components/themes-list';
@@ -139,10 +138,7 @@ class ThemesSelection extends Component {
 	};
 
 	render() {
-		const { source, query, listLabel, themesCount } = this.props;
-
-		const upsellUrl =
-			abtest( 'unlimitedThemeNudge' ) === 'show' && `/plans/${ this.props.siteSlug }`;
+		const { source, query, listLabel, themesCount, upsellUrl } = this.props;
 
 		return (
 			<div className="themes__selection">

--- a/webpack.config.node.js
+++ b/webpack.config.node.js
@@ -118,6 +118,7 @@ const webpackConfig = {
 			'PROJECT_NAME': JSON.stringify( config( 'project' ) )
 		} ),
 		new HappyPack( { loaders: [ babelLoader ] } ),
+		new webpack.NormalModuleReplacementPlugin( /^lib[\/\\]abtest$/, 'lodash/noop' ), // Depends on BOM
 		new webpack.NormalModuleReplacementPlugin( /^lib[\/\\]analytics$/, 'lodash/noop' ), // Depends on BOM
 		new webpack.NormalModuleReplacementPlugin( /^lib[\/\\]sites-list$/, 'lodash/noop' ), // Depends on BOM
 		new webpack.NormalModuleReplacementPlugin( /^lib[\/\\]olark$/, 'lodash/noop' ), // Depends on DOM


### PR DESCRIPTION
This change adds an upgrade nudge to the themes page.

Refer to p5uIfZ-7Mp-p2 for discussion.

Before:

<img width="1068" alt="screen shot 2017-10-26 at 1 46 39 pm" src="https://user-images.githubusercontent.com/1926/32034156-371fc6f4-ba54-11e7-8aa5-1adf1b2c1ca1.png">

After:

<img width="1064" alt="screen shot 2017-10-26 at 1 45 32 pm" src="https://user-images.githubusercontent.com/1926/32034151-29668ed0-ba54-11e7-8361-f8c8a85a3c02.png">

# Testing

This is part of an a/b test so you will need to force the 'show' variant by running:

```
localStorage.setItem( 'ABTests', '{"unlimitedThemeNudge_20171016":"show"}' );
```

Also enable tracks debugging by running:

```
localStorage.setItem('debug', 'calypso:analytics:tracks');
```

View `/themes/<site>`.

You should see the nudges above and the following tracks events:

- `calypso_upgrade_nudge_impression` with `{ cta_name: 'theme-upsell', theme: '(theme name)' }` for each visible upsell icon
- `calypso_upgrade_nudge_impression` with `{ cta_name: 'theme-upsell-popup', theme: '(theme name)' }` on clicking any icon
- `calypso_upgrade_nudge_cta_click` with `{ cta_name: 'theme-upsell-popup', theme: '(theme name)' }` on clicking the 'Upgrade now' cta

To verify that all these nudges do not appear for the other 50% of participants in the a/b test:  

```
localStorage.setItem( 'ABTests', '{"unlimitedThemeNudge_20171016":"hide"}' );
```

... then refresh `/themes/<site>` and the icons and new tracks events should disappear