### PR TITLE
Media: Create media-specific route for stylesheet bundle

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -339,8 +339,7 @@
 @import 'my-sites/invites/invite-header/style';
 @import 'my-sites/invites/invite-accept-logged-in/style';
 @import 'my-sites/invites/invite-accept/style';
-@import 'my-sites/media-library/style';
-@import 'my-sites/media/style';
+@import 'my-sites/media-library/upload-button';
 @import 'my-sites/no-results/style';
 @import 'my-sites/pages/style';
 @import 'my-sites/pages/blog-posts-page/style';
@@ -458,7 +457,6 @@
 @import 'my-sites/domains/domain-management/components/email-verification/style';
 @import 'my-sites/domains/domain-management/components/icann-verification/style';
 @import 'notifications/style';
-@import 'post-editor/media-modal/style';
 @import 'reader/conversations/style';
 @import 'reader/discover/style';
 @import 'reader/following/style';

--- a/assets/stylesheets/sections/media.scss
+++ b/assets/stylesheets/sections/media.scss
@@ -1,0 +1,17 @@
+/** @format */
+
+@import '../shared/functions/z-index';
+@import '../shared/mixins/breakpoints';
+@import '../shared/mixins/clear-text';
+@import '../shared/mixins/heading';
+@import '../shared/mixins/long-content-fade';
+@import '../shared/mixins/noticon';
+
+@import '../shared/colors';
+@import '../shared/extends';
+@import '../shared/typography';
+
+@import 'components/screen-reader-text/style';
+@import 'my-sites/media/style';
+@import 'my-sites/media-library/style';
+@import 'post-editor/media-modal/style';

--- a/assets/stylesheets/sections/post-editor.scss
+++ b/assets/stylesheets/sections/post-editor.scss
@@ -15,6 +15,7 @@
 @import '../main';
 @import '../shared/forms';
 
+@import './media';
 @import 'post-editor/style';
 @import 'post-editor/edit-post-status/style';
 @import 'post-editor/editor-action-bar/style';

--- a/client/wordpress-com.js
+++ b/client/wordpress-com.js
@@ -74,6 +74,7 @@ const sections = [
 		module: 'my-sites/media',
 		group: 'sites',
 		secondary: true,
+		css: 'media',
 	},
 	{
 		name: 'people',


### PR DESCRIPTION
This is a follow-up to #18642. In that PR, we temporarily re-added the media modal style back into the `_components` stylesheet to fix some display issues with the media library in the post editor. This follow-up creates a separate bundle instead for the `/media` and `post-editor` routes specifically. This shouldn't create any visual changes. We're just moving stylesheets around.

I left some inline comments as well for comments.

### To test
1. Run `git checkout update/create-media-css-bundle` and start your local server.
2. Open http://calypso.localhost:3000/media/. Select a site if necessary.
3. Resize the media library, edit an image, upload an image/document/audio file. You shouldn't notice any issues.
4. Open the post editor at http://calypso.localhost:3000/post/. Add a media item to your post. Try to edit that media item by pressing Edit at the top of the media library after selecting an image. You shouldn't notice any regressions.

Fixes: #18641