### PR TITLE
Simple Payments: Item label change and add some examples

### DIFF
--- a/client/components/tinymce/plugins/simple-payments/dialog/form.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/form.jsx
@@ -182,8 +182,11 @@ class ProductForm extends Component {
 				<div className="editor-simple-payments-modal__form-fields">
 					<ReduxFormFieldset
 						name="title"
-						label={ translate( 'What are you selling?' ) }
+						label={ translate( 'What is this payment for?' ) }
 						component={ FormTextInput }
+						explanation={ translate(
+							'For example: event tickets, charitable donations, training courses, coaching fees, etc.'
+						) }
 					/>
 					<ReduxFormFieldset
 						name="description"


### PR DESCRIPTION
As a part of the effort of reducing "product bias", this PR suggests to change the item label, and add some example including charitable donations.

Before:
<img width="561" alt="screen shot 2017-10-17 at 15 05 04" src="https://user-images.githubusercontent.com/908665/31669406-e83e3164-b34c-11e7-91b4-99b6c3d7ef42.png">

After:
<img width="614" alt="screen shot 2017-10-17 at 15 04 14" src="https://user-images.githubusercontent.com/908665/31669417-edc9a938-b34c-11e7-9bb3-ce1c0d6c69bd.png">
