### PR TITLE
Login: Fix language switching no longer working

### DIFF
--- a/client/components/locale-suggestions/index.jsx
+++ b/client/components/locale-suggestions/index.jsx
@@ -3,7 +3,7 @@
  *
  * @format
  */
-
+import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { getLocaleSlug } from 'i18n-calypso';
 
@@ -17,8 +17,14 @@ import Notice from 'components/notice';
 import switchLocale from 'lib/i18n-utils/switch-locale';
 
 class LocaleSuggestions extends Component {
+	static propTypes = {
+		locale: PropTypes.string.isRequired,
+		path: PropTypes.string.isRequired,
+	};
+
 	constructor( props ) {
 		super( props );
+
 		this.state = {
 			dismissed: false,
 			locales: LocaleSuggestionStore.get(),

--- a/client/components/locale-suggestions/index.jsx
+++ b/client/components/locale-suggestions/index.jsx
@@ -81,6 +81,7 @@ class LocaleSuggestions extends Component {
 				<LocaleSuggestionsListItem
 					key={ 'locale-' + locale.locale }
 					locale={ locale }
+					onLocaleSuggestionClick={ this.dismiss }
 					path={ this.getPathWithLocale( locale.locale ) }
 				/>
 			);
@@ -89,7 +90,9 @@ class LocaleSuggestions extends Component {
 		return (
 			<div className="locale-suggestions">
 				<Notice icon="globe" showDismiss={ true } onDismissClick={ this.dismiss }>
-					<div className="locale-suggestions__list">{ localeMarkup }</div>
+					<div className="locale-suggestions__list">
+						{ localeMarkup }
+					</div>
 				</Notice>
 			</div>
 		);

--- a/client/components/locale-suggestions/index.jsx
+++ b/client/components/locale-suggestions/index.jsx
@@ -11,7 +11,7 @@ import { getLocaleSlug } from 'i18n-calypso';
  * Internal dependencies
  */
 import { addLocaleToPath } from 'lib/i18n-utils';
-import LocaleSuggestionListItem from './list-item';
+import LocaleSuggestionsListItem from './list-item';
 import LocaleSuggestionStore from 'lib/locale-suggestions';
 import Notice from 'components/notice';
 import switchLocale from 'lib/i18n-utils/switch-locale';
@@ -78,7 +78,7 @@ class LocaleSuggestions extends Component {
 
 		const localeMarkup = usersOtherLocales.map( locale => {
 			return (
-				<LocaleSuggestionListItem
+				<LocaleSuggestionsListItem
 					key={ 'locale-' + locale.locale }
 					locale={ locale }
 					path={ this.getPathWithLocale( locale.locale ) }

--- a/client/components/locale-suggestions/list-item.jsx
+++ b/client/components/locale-suggestions/list-item.jsx
@@ -17,15 +17,21 @@ import { getLanguage } from 'lib/i18n-utils';
 class LocaleSuggestionsListItem extends Component {
 	static propTypes = {
 		locale: PropTypes.object.isRequired,
+		onLocaleSuggestionClick: PropTypes.func,
 		path: PropTypes.string.isRequired,
 	};
 
 	handleLocaleSuggestionClick = event => {
-		const { locale, path } = this.props;
+		const { locale, onLocaleSuggestionClick, path } = this.props;
 
 		if ( this.hasLocaleDirectionChanged( locale ) ) {
 			event.preventDefault();
+
 			window.location = path;
+		}
+
+		if ( onLocaleSuggestionClick ) {
+			onLocaleSuggestionClick();
 		}
 
 		// TODO: record analytics event here
@@ -44,6 +50,7 @@ class LocaleSuggestionsListItem extends Component {
 		return (
 			<div className="locale-suggestions__list-item" dir="auto">
 				{ locale.availability_text }
+
 				<a
 					href={ path }
 					onClick={ this.handleLocaleSuggestionClick }

--- a/client/controller/shared.js
+++ b/client/controller/shared.js
@@ -10,6 +10,7 @@ import { noop } from 'lodash';
 /**
  * Internal dependencies
  */
+import config from 'config';
 import { switchCSS } from 'lib/i18n-utils/switch-locale';
 import { getCurrentUser } from 'state/current-user/selectors';
 import { setSection as setSectionAction } from 'state/ui/actions';
@@ -69,9 +70,7 @@ export function setUpLocale( context, next ) {
 		context.lang = currentUser.localeSlug;
 	}
 
-	if ( context.lang ) {
-		context.store.dispatch( setLocale( context.lang ) );
-	}
+	context.store.dispatch( setLocale( context.lang || config( 'i18n_default_locale_slug' ) ) );
 
 	loadSectionCSS( context, next );
 }

--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -19,13 +19,12 @@ import { fetchOAuth2ClientData } from 'state/oauth2-clients/actions';
 import { recordTracksEvent } from 'state/analytics/actions';
 
 const enhanceContextWithLogin = context => {
-	const { lang, path, params: { flow, twoFactorAuthType, socialService } } = context;
+	const { path, params: { flow, twoFactorAuthType, socialService } } = context;
 
 	context.cacheQueryKeys = [ 'client_id' ];
 
 	context.primary = (
 		<WPLogin
-			locale={ lang }
 			path={ path }
 			twoFactorAuthType={ twoFactorAuthType }
 			socialService={ socialService }

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -17,6 +17,7 @@ import { localize } from 'i18n-calypso';
 import { addLocaleToWpcomUrl } from 'lib/i18n-utils';
 import DocumentHead from 'components/data/document-head';
 import LoginLinks from './login-links';
+import getCurrentLocaleSlug from 'state/selectors/get-current-locale-slug';
 import { getCurrentUserId } from 'state/current-user/selectors';
 import { getCurrentOAuth2Client } from 'state/ui/oauth2-clients/selectors';
 import Main from 'components/main';
@@ -197,6 +198,7 @@ export class Login extends React.Component {
 export default connect(
 	state => ( {
 		isLoggedIn: Boolean( getCurrentUserId( state ) ),
+		locale: getCurrentLocaleSlug( state ),
 		oauth2Client: getCurrentOAuth2Client( state ),
 	} ),
 	{

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -14,6 +14,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import { addLocaleToWpcomUrl } from 'lib/i18n-utils';
 import DocumentHead from 'components/data/document-head';
 import LoginLinks from './login-links';
 import { getCurrentUserId } from 'state/current-user/selectors';
@@ -160,7 +161,7 @@ export class Login extends React.Component {
 
 	render() {
 		const { locale, privateSite, socialConnect, translate, twoFactorAuthType } = this.props;
-		const canonicalUrl = `https://${ locale !== 'en' ? locale + '.' : '' }wordpress.com/login`;
+		const canonicalUrl = addLocaleToWpcomUrl( 'https://wordpress.com/login', locale );
 
 		return (
 			<div>


### PR DESCRIPTION
This pull request fixes https://github.com/Automattic/wp-calypso/issues/18866 by retrieving the locale from the global state tree instead of the request parameter (since https://github.com/Automattic/wp-calypso/pull/18297, the locale is indeed managed via Redux). This fixes the link in the locale suggestion notice that appears on the `Login` page that would be otherwise ineffective:
 
<img width="753" alt="screenshot" src="https://user-images.githubusercontent.com/594356/31669801-5f591c4c-b356-11e7-8025-cce01e6a3308.png">
  
#### Testing instructions
 
1. Run `git checkout fix/login-language-switcher` and start your server, or open a [live branch](https://calypso.live/?branch=[branch])
2. Set English as main supported language in your browser's settings
3. Open the [`Login` page](http://calypso.localhost:3000/log-in/fr) in French
4. Click the link in the `Also available in English` notice
5. Assert that you are redirected to http://calypso.localhost:3000/log-in
6. Assert that the page is now displayed in English
7. Try again all these steps with [any RTL language](http://calypso.localhost:3000/log-in/he)
 
#### Reviews
 
- [x] Code
- [x] Product