### PR TITLE
Fix rewindStatus schema validation when a site doesn't have a backup yet

### DIFF
--- a/client/state/activity-log/rewind-status/schema.js
+++ b/client/state/activity-log/rewind-status/schema.js
@@ -9,7 +9,7 @@ export const rewindStatusSchema = {
 				active: { type: 'boolean' },
 				plan: { type: 'string' },
 				isPressable: { type: 'boolean' },
-				firstBackupDate: { type: 'string' },
+				firstBackupDate: { type: [ 'null', 'string' ] },
 			},
 		},
 	},


### PR DESCRIPTION
Schema validation fails when a site doesn't yet have a backup, due to the api response returning `null` for `rewindStatus.firstBackupDate`. This allows the response to be `null` and still validate.

**Testing Instructions**

Load up the activity log (or any screen that queries rewindStatus) for any site that doesn't yet have a backup. You should receive the following error in the console:

![screen shot 2017-10-17 at 10 41 08 am](https://user-images.githubusercontent.com/5528445/31671665-7cd539c8-b328-11e7-8f1e-ee8357191869.png)

Apply this patch, refresh the page. Notice should be gone.