### PR TITLE
Store: Reload shipping label PDF when updating paper size in reprint dialog

### DIFF
--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/actions.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/actions.js
@@ -537,15 +537,6 @@ export const updateRate = ( orderId, siteId, packageId, value ) => {
 	};
 };
 
-export const updatePaperSize = ( orderId, siteId, value ) => {
-	return {
-		type: WOOCOMMERCE_SERVICES_SHIPPING_LABEL_UPDATE_PAPER_SIZE,
-		siteId,
-		orderId,
-		value,
-	};
-};
-
 export const setEmailDetailsOption = ( orderId, siteId, value ) => {
 	return {
 		type: WOOCOMMERCE_SERVICES_SHIPPING_LABEL_SET_EMAIL_DETAILS,
@@ -849,4 +840,18 @@ export const confirmReprint = ( orderId, siteId ) => ( dispatch, getState ) => {
 			dispatch( NoticeActions.errorNotice( error.toString() ) );
 		} )
 		.then( () => dispatch( closeReprintDialog( orderId, siteId ) ) );
+};
+
+export const updatePaperSize = ( orderId, siteId, value ) => ( dispatch, getState ) => {
+	dispatch( {
+		type: WOOCOMMERCE_SERVICES_SHIPPING_LABEL_UPDATE_PAPER_SIZE,
+		siteId,
+		orderId,
+		value,
+	} );
+
+	const shippingLabel = getShippingLabel( getState(), orderId, siteId );
+	if ( shippingLabel.reprintDialog != null ) {
+		dispatch( openReprintDialog( orderId, siteId, shippingLabel.reprintDialog.labelId ) );
+	}
 };

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/actions.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/actions.js
@@ -822,7 +822,10 @@ export const openReprintDialog = ( orderId, siteId, labelId ) => ( dispatch, get
 
 	api.get( siteId, printUrl )
 		.then( ( fileData ) => {
-			dispatch( { type: WOOCOMMERCE_SERVICES_SHIPPING_LABEL_REPRINT_DIALOG_READY, labelId, orderId, siteId, fileData } );
+			const shippingLabelAfter = getShippingLabel( getState(), orderId, siteId );
+			if ( shippingLabel.paperSize === shippingLabelAfter.paperSize ) {
+				dispatch( { type: WOOCOMMERCE_SERVICES_SHIPPING_LABEL_REPRINT_DIALOG_READY, labelId, orderId, siteId, fileData } );
+			}
 		} );
 };
 


### PR DESCRIPTION
Label reprint dialog isn't responding to changes in the paper size dropdown until it's closed and reopened. This change triggers a re-fetch of the label file in response to update of the paper size.

Open to refactoring this so we're not dispatching something called `openReprintDialog` when it's already open — perhaps splitting `openReprintDialog` into separate `open` and `fetch` actions?