### PR TITLE
Reader: Switch to using the 1.2 api for feed streams

### DIFF
--- a/client/lib/feed-stream-store/index.js
+++ b/client/lib/feed-stream-store/index.js
@@ -145,7 +145,7 @@ function getStoreForFeed( storeId ) {
 	return new FeedStream( {
 		id: storeId,
 		fetcher: fetcher,
-		keyMaker: feedKeyMaker,
+		keyMaker: mixedKeyMaker,
 		onNextPageFetch: addMetaToNextPageFetch,
 	} );
 }

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1263,7 +1263,7 @@ Undocumented.prototype.discoverFeed = function( query, fn ) {
 Undocumented.prototype.readFeedPosts = function( query, fn ) {
 	var params = omit( query, 'ID' );
 	debug( '/read/feed/' + query.ID + '/posts' );
-	params.apiVersion = '1.3';
+	params.apiVersion = '1.2';
 	addReaderContentWidth( params );
 
 	return this.wpcom.req.get(
@@ -1276,7 +1276,7 @@ Undocumented.prototype.readFeedPosts = function( query, fn ) {
 Undocumented.prototype.readFeedPost = function( query, fn ) {
 	var params = omit( query, [ 'feedId', 'postId' ] );
 	debug( '/read/feed/' + query.feedId + '/posts/' + query.postId );
-	params.apiVersion = '1.3';
+	params.apiVersion = '1.2';
 	addReaderContentWidth( params );
 
 	return this.wpcom.req.get(


### PR DESCRIPTION
Switch out to the mixedKeyMaker too since we may get posts without a feed_item_id from 1.2.

This requires extensive testing.
- Try opening up feed streams from a variety of sources, including the following/manage page, the main following stream, search results, etc.
- Try to find feed streams for VIPs, wpcom sites, jetpack sites, and external feeds