### PR TITLE
Rewind: Add `is-discarded` CSS class to events in local testing

### DIFF
--- a/client/my-sites/stats/activity-log-item/index.jsx
+++ b/client/my-sites/stats/activity-log-item/index.jsx
@@ -5,6 +5,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import config from 'config';
 import debugFactory from 'debug';
 import { connect } from 'react-redux';
 import { pick } from 'lodash';
@@ -154,7 +155,9 @@ class ActivityLogItem extends Component {
 		const { className, log } = this.props;
 		const { activityIcon, activityStatus } = log;
 
-		const classes = classNames( 'activity-log-item', className );
+		const classes = classNames( 'activity-log-item', className, {
+			'is-discarded': config( 'env' ) === 'development' && Math.random() > 0.8,
+		} );
 
 		return (
 			<div className={ classes }>


### PR DESCRIPTION
In preparation for work associating specific events in the activity log
with a status of whether or not they appear to be active or discarded
(when looking from the perspective of the latest restore operation) I'm
adding in a flag set randomly when in local development environments in
order to enable UI design work to start.

Soon we should be replacing this with an actual discard-status field in
the event data itself.

**Testing**

Since this only adds a new CSS class and only in local development you
will have to run locally and check for the random presence of the
`is-discarded` class on `activity-log-item` `<div>`s