### PR TITLE
Enable feature on wpcalypso

### DIFF
--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -75,6 +75,7 @@
 		"manage/themes/logged-out": true,
 		"manage/themes/upload": true,
 		"me/account": true,
+		"me/account/color-scheme-picker": true,
 		"me/find-friends": false,
 		"me/my-profile": true,
 		"me/next-steps": true,


### PR DESCRIPTION
#### This PR 
- is part of a series of PRs aiming to provide support for Color Schemes in Calypso.
- focuses on activating the feature on wpcalypso

![ezgif com-video-to-gif 3](https://user-images.githubusercontent.com/1562646/29487542-12f3aa90-84fb-11e7-937b-83e6bb4f69fb.gif)

### Notes

For a more detailed description of the feature, the chosen approach and its advantages feel free to check out my post on the subject: p4TIVU-75d-p2 (internal reference).