### PR TITLE
Reader: Prevent Settings link from overlapping with Site Title

### DIFF
--- a/client/blocks/reader-feed-header/style.scss
+++ b/client/blocks/reader-feed-header/style.scss
@@ -3,13 +3,15 @@
 	flex-direction: column;
 	padding-top: 5px;
 }
+
 .reader-feed-header__site-icon {
 	align-self: center;
 	padding-bottom: 20px;
 }
 
 .reader-feed-header__site-icon .site-icon.is-blank {
-	display: none;
+	height: 30px !important; // Prevents Settings from overlapping with Site Title
+	visibility: hidden;
 }
 
 .reader-feed-header .reader-feed-header__site-badge {


### PR DESCRIPTION
This fixes: https://github.com/Automattic/wp-calypso/issues/18899

Before:
![screenshot 2017-10-17 14 35 29](https://user-images.githubusercontent.com/4924246/31690749-805abab2-b348-11e7-950d-f21f77fc3168.png)

After:
![screenshot 2017-10-17 14 39 02](https://user-images.githubusercontent.com/4924246/31690867-edec5504-b348-11e7-9276-2febb52e59d5.png)

(with Back button):
![screenshot 2017-10-17 14 39 37](https://user-images.githubusercontent.com/4924246/31690897-04c1f874-b349-11e7-8dae-ff0144c7bf4f.png)

Making sure it still looks good if a site icon was present:

![screenshot 2017-10-17 14 39 15](https://user-images.githubusercontent.com/4924246/31690912-0f29760c-b349-11e7-8462-ea35c7fa4c3e.png)
![screenshot 2017-10-17 14 39 21](https://user-images.githubusercontent.com/4924246/31690913-0f65210c-b349-11e7-8e57-6866ec78cd00.png)

