### PR TITLE
Stats: Use current user's ip country code for chart

### DIFF
--- a/client/my-sites/stats/geochart/index.jsx
+++ b/client/my-sites/stats/geochart/index.jsx
@@ -20,6 +20,7 @@ import StatsModulePlaceholder from '../stats-module/placeholder';
 import QuerySiteStats from 'components/data/query-site-stats';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSiteStatsNormalizedData } from 'state/stats/lists/selectors';
+import { getCurrentUserCountryCode } from 'state/current-user/selectors';
 
 class StatsGeochart extends Component {
 	static propTypes = {
@@ -91,7 +92,7 @@ class StatsGeochart extends Component {
 	};
 
 	drawData = () => {
-		const { data, translate } = this.props;
+		const { currentUserCountryCode, data, translate } = this.props;
 
 		if ( ! data || ! data.length ) {
 			return;
@@ -121,6 +122,7 @@ class StatsGeochart extends Component {
 			enableRegionInteractivity: true,
 			region: 'world',
 			colorAxis: { colors: [ '#FFF088', '#F34605' ] },
+			domain: currentUserCountryCode,
 		};
 
 		const regions = uniq( map( data, 'region' ) );
@@ -173,6 +175,7 @@ export default connect( ( state, ownProps ) => {
 	const { query } = ownProps;
 
 	return {
+		currentUserCountryCode: getCurrentUserCountryCode( state ),
 		data: getSiteStatsNormalizedData( state, siteId, statType, query ),
 		siteId,
 		statType,

--- a/client/state/current-user/selectors.js
+++ b/client/state/current-user/selectors.js
@@ -56,6 +56,14 @@ export const createCurrentUserSelector = ( path, otherwise = null ) => state => 
 export const getCurrentUserLocale = createCurrentUserSelector( 'localeSlug' );
 
 /**
+ * Returns the country code for the current user.
+ *
+ * @param  {Object}  state  Global state tree
+ * @return {?String}        Current user country code
+ */
+export const getCurrentUserCountryCode = createCurrentUserSelector( 'user_ip_country_code' );
+
+/**
  * Returns the number of sites for the current user.
  *
  * @param  {Object}  state  Global state tree


### PR DESCRIPTION
This PR updates the geochart component to pass the user's country code as `domain` to the Google chart API. See the [Google docs](https://developers.google.com/chart/interactive/docs/gallery/geochart#configuration-options) for more information about the `domain` configuration option.

Context: p56BUd-hb-p2