### PR TITLE
Rewind: Refactor state and add "unknown" discard status

### DIFF
--- a/client/state/activity-log/log/schema.js
+++ b/client/state/activity-log/log/schema.js
@@ -7,6 +7,7 @@ const activityItemSchema = {
 		'activityGroup',
 		'activityIcon',
 		'activityId',
+		'activityIsDiscarded',
 		'activityName',
 		'activityTitle',
 		'activityTs',
@@ -20,6 +21,7 @@ const activityItemSchema = {
 		activityGroup: { type: 'string' },
 		activityIcon: { type: 'string' },
 		activityId: { type: 'string' },
+		activityIsDiscarded: { type: 'boolean' },
 		activityName: { type: 'string' },
 		activityStatus: {
 			oneOf: [ { type: 'string' }, { type: 'null' } ],

--- a/client/state/activity-log/rewind-status/reducer.js
+++ b/client/state/activity-log/rewind-status/reducer.js
@@ -1,7 +1,6 @@
+/** @format */
 /**
  * Internal dependencies
- *
- * @format
  */
 
 import { rewindStatusSchema } from './schema';
@@ -10,25 +9,36 @@ import {
 	REWIND_STATUS_ERROR,
 	REWIND_STATUS_UPDATE,
 } from 'state/action-types';
-import { createReducer, keyedReducer } from 'state/utils';
+import { keyedReducer } from 'state/utils';
 
-export const rewindStatus = keyedReducer(
-	'siteId',
-	createReducer( undefined, {
-		[ REWIND_STATUS_ERROR ]: () => undefined,
-		[ REWIND_STATUS_UPDATE ]: ( state, { status } ) => status,
-		[ REWIND_ACTIVATE_SUCCESS ]: state => ( {
-			...state,
-			active: true,
-		} ),
-	} )
-);
+export const rewindItem = ( state = undefined, { type, status } ) => {
+	switch ( type ) {
+		case REWIND_STATUS_ERROR:
+			return undefined;
+
+		case REWIND_STATUS_UPDATE:
+			return status;
+
+		case REWIND_ACTIVATE_SUCCESS:
+			return { ...state, active: true };
+	}
+
+	return state;
+};
+
+export const rewindStatus = keyedReducer( 'siteId', rewindItem );
 rewindStatus.schema = rewindStatusSchema;
 
-export const rewindStatusError = keyedReducer(
-	'siteId',
-	createReducer( undefined, {
-		[ REWIND_STATUS_ERROR ]: ( state, { error } ) => error,
-		[ REWIND_STATUS_UPDATE ]: () => undefined,
-	} )
-);
+export const rewindStatusErrorItem = ( state = undefined, { type, error } ) => {
+	switch ( type ) {
+		case REWIND_STATUS_ERROR:
+			return error;
+
+		case REWIND_STATUS_UPDATE:
+			return undefined;
+	}
+
+	return state;
+};
+
+export const rewindStatusError = keyedReducer( 'siteId', rewindStatusErrorItem );

--- a/client/state/data-layer/wpcom/sites/activity/from-api.js
+++ b/client/state/data-layer/wpcom/sites/activity/from-api.js
@@ -19,13 +19,24 @@ export const DEFAULT_GRIDICON = 'info-outline';
 /**
  * Transforms API response into array of activities
  *
- * @param  {object} apiResponse                      API response body
- * @param  {array}  apiResponse.current.orderedItems Array of item objects
- * @return {array}                                   Array of proccessed item objects
+ * @param  {Object} apiResponse                      API response body
+ * @param  {Array}  apiResponse.current.orderedItems Array of item objects
+ * @return {Array}                                   Array of proccessed item objects
  */
 export function transformer( apiResponse ) {
 	const orderedItems = get( apiResponse, [ 'current', 'orderedItems' ], [] );
 	return map( orderedItems, processItem );
+}
+
+export function processItemActor( actor ) {
+	return {
+		actorAvatarUrl: get( actor, [ 'icon', 'url' ], DEFAULT_GRAVATAR_URL ),
+		actorName: get( actor, [ 'name' ], '' ),
+		actorRemoteId: get( actor, [ 'external_user_id' ], 0 ),
+		actorRole: get( actor, [ 'role' ], '' ),
+		actorType: get( actor, [ 'type' ], '' ),
+		actorWpcomId: get( actor, [ 'wpcom_user_id' ], 0 ),
+	};
 }
 
 /**
@@ -35,32 +46,17 @@ export function transformer( apiResponse ) {
  * @return {object}       Processed Activity item ready for use in UI
  */
 export function processItem( item ) {
-	return {
-		...processItemBase( item ),
-	};
-}
+	const published = item.published;
 
-export function processItemActor( item ) {
 	return {
-		actorAvatarUrl: get( item, [ 'actor', 'icon', 'url' ], DEFAULT_GRAVATAR_URL ),
-		actorName: get( item, [ 'actor', 'name' ], '' ),
-		actorRemoteId: get( item, [ 'actor', 'external_user_id' ], 0 ),
-		actorRole: get( item, [ 'actor', 'role' ], '' ),
-		actorType: get( item, [ 'actor', 'type' ], '' ),
-		actorWpcomId: get( item, [ 'actor', 'wpcom_user_id' ], 0 ),
-	};
-}
-
-export function processItemBase( item ) {
-	const published = get( item, 'published' );
-	return {
-		...processItemActor( item ),
+		...processItemActor( item.actor ),
 		activityDate: published,
-		activityGroup: head( split( get( item, 'name' ), '__', 1 ) ),
+		activityGroup: head( split( item.name, '__', 1 ) ),
 		activityIcon: get( item, 'gridicon', DEFAULT_GRIDICON ),
-		activityId: get( item, 'activity_id' ),
-		activityName: get( item, 'name' ),
-		activityStatus: get( item, 'status' ),
+		activityId: item.activity_id,
+		activityIsDiscarded: null,
+		activityName: item.name,
+		activityStatus: item.status,
 		activityTitle: get( item, 'summary', '' ),
 		activityTs: Date.parse( published ),
 	};

--- a/client/state/data-layer/wpcom/sites/activity/test/from-api.js
+++ b/client/state/data-layer/wpcom/sites/activity/test/from-api.js
@@ -55,6 +55,7 @@ describe( 'processItem', () => {
 				'activityGroup',
 				'activityIcon',
 				'activityId',
+				'activityIsDiscarded',
 				'activityName',
 				'activityStatus',
 				'activityTitle',

--- a/client/state/data-layer/wpcom/sites/activity/test/index.js
+++ b/client/state/data-layer/wpcom/sites/activity/test/index.js
@@ -10,7 +10,7 @@ import { translate } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import { handleActivityLogRequest, receiveActivityLogError, receiveActivityLog } from '..';
+import { fetchActivity, announceFailure, updateActivityLog } from '..';
 import { ACTIVITY_LOG_UPDATE } from 'state/action-types';
 import { activityLogRequest } from 'state/activity-log/actions';
 import { http } from 'state/data-layer/wpcom-http/actions';
@@ -62,7 +62,7 @@ const SUCCESS_RESPONSE = deepFreeze( {
 describe( 'receiveActivityLog', () => {
 	test( 'should dispatch activity log update action', () => {
 		const dispatch = sinon.spy();
-		receiveActivityLog( { dispatch }, { siteId: SITE_ID }, SUCCESS_RESPONSE );
+		updateActivityLog( { dispatch }, { siteId: SITE_ID }, SUCCESS_RESPONSE );
 		expect( dispatch ).to.have.been.called.once;
 		expect( dispatch.args[ 0 ][ 0 ] )
 			.to.be.an( 'object' )
@@ -77,7 +77,7 @@ describe( 'receiveActivityLog', () => {
 describe( 'receiveActivityLogError', () => {
 	test( 'should dispatch activity log error action', () => {
 		const dispatch = sinon.spy();
-		receiveActivityLogError( { dispatch } );
+		announceFailure( { dispatch } );
 		expect( dispatch ).to.have.been.called.once;
 		expect( dispatch ).to.have.been.calledWith(
 			errorNotice( translate( 'Error receiving activity for site.' ), { id: '1' } )
@@ -90,7 +90,7 @@ describe( 'handleActivityLogRequest', () => {
 		const action = activityLogRequest( SITE_ID );
 		const dispatch = sinon.spy();
 
-		handleActivityLogRequest( { dispatch }, action );
+		fetchActivity( { dispatch }, action );
 
 		expect( dispatch ).to.have.been.calledTwice;
 		expect( dispatch ).to.have.been.calledWith(
@@ -116,7 +116,7 @@ describe( 'handleActivityLogRequest', () => {
 		} );
 		const dispatch = sinon.spy();
 
-		handleActivityLogRequest( { dispatch }, action );
+		fetchActivity( { dispatch }, action );
 
 		expect( dispatch ).to.have.been.calledTwice;
 		expect( dispatch ).to.have.been.calledWith(
@@ -145,7 +145,7 @@ describe( 'handleActivityLogRequest', () => {
 		} );
 		const dispatch = sinon.spy();
 
-		handleActivityLogRequest( { dispatch }, action );
+		fetchActivity( { dispatch }, action );
 
 		expect( dispatch ).to.have.been.calledTwice;
 		expect( dispatch ).to.have.been.calledWith(


### PR DESCRIPTION
In preparation for including information in Calypso about whether an
event in the activity stream has been discarded by a restore event, this
PR is doing some initial refactoring on the state code for `activity`
and also adds the initial "unknown" discarded status, meaning that we
have not yet been able to determine if the activity has been discarded.