### PR TITLE
ReactModal: bump version to make shouldCloseOnEsc available

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -5950,7 +5950,7 @@
       }
     },
     "react-modal": {
-      "version": "3.0.4"
+      "version": "3.1.0"
     },
     "react-pure-render": {
       "version": "1.0.2"
@@ -7161,7 +7161,7 @@
       "version": "1.0.0"
     },
     "unquoted-property-validator": {
-      "version": "1.0.0",
+      "version": "1.0.1",
       "dev": true
     },
     "unreachable-branch-transform": {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1611,9 +1611,6 @@
     "electron-to-chromium": {
       "version": "1.3.27"
     },
-    "element-class": {
-      "version": "0.2.2"
-    },
     "elliptic": {
       "version": "6.4.0"
     },
@@ -1996,7 +1993,7 @@
       "dev": true
     },
     "exenv": {
-      "version": "1.2.0"
+      "version": "1.2.2"
     },
     "exit-hook": {
       "version": "1.1.1",
@@ -5937,9 +5934,6 @@
     "react-dom": {
       "version": "15.6.2"
     },
-    "react-dom-factories": {
-      "version": "1.0.2"
-    },
     "react-element-to-jsx-string": {
       "version": "3.2.0",
       "dev": true
@@ -5956,12 +5950,7 @@
       }
     },
     "react-modal": {
-      "version": "1.9.7",
-      "dependencies": {
-        "lodash.assign": {
-          "version": "4.2.0"
-        }
-      }
+      "version": "3.0.4"
     },
     "react-pure-render": {
       "version": "1.0.2"

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "react-day-picker": "6.0.2",
     "react-dom": "15.6.2",
     "react-hot-loader": "1.3.1",
-    "react-modal": "1.9.7",
+    "react-modal": "3.0.4",
     "react-pure-render": "1.0.2",
     "react-redux": "5.0.6",
     "react-transition-group": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "react-day-picker": "6.0.2",
     "react-dom": "15.6.2",
     "react-hot-loader": "1.3.1",
-    "react-modal": "3.0.4",
+    "react-modal": "3.1.0",
     "react-pure-render": "1.0.2",
     "react-redux": "5.0.6",
     "react-transition-group": "1.2.1",


### PR DESCRIPTION
### Summary
I recently submitted a patch for `react-modal` which has been released as part of `v3.0.2`.
This patch allows the `esc` handling to be switched off, which would allow us to handle that event our selves.
This should help us solve the issues mentioned in #17534.

Changelog: https://github.com/reactjs/react-modal/blob/master/CHANGELOG.md

### Testing
Follow the test plan of #17150 to test that the modals still work as expected.
Feel free to go beyond and try out different modal functionality too :)
There are a couple of caveats to be aware of, which are detailed in #17534
I'll be aiming to iron those out once we are using the updated version :)
