### PR TITLE
Checkout: fix broken thank you page for /domains site-less purchases

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/index.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.jsx
@@ -132,7 +132,8 @@ const CheckoutThankYou = React.createClass( {
 		if (
 			! this.props.receipt.hasLoadedFromServer &&
 			nextProps.receipt.hasLoadedFromServer &&
-			this.hasPlanOrDomainProduct( nextProps )
+			this.hasPlanOrDomainProduct( nextProps ) &&
+			this.props.selectedSite
 		) {
 			this.props.refreshSitePlans( this.props.selectedSite );
 		}


### PR DESCRIPTION
Bug: when making a Paypal Express purchase of a domain via `/domains` (without existing account, or site), the user is redirected to /checkout/thank-you/no-site/xxxxxx.
That page currently throws a fatal because `selectedSite` is not defined.

<img width="1477" alt="screen shot 2017-10-18 at 11 43 12" src="https://user-images.githubusercontent.com/844866/31709934-35496e9c-b3fc-11e7-9a46-94d7ef3aaae1.png">

This fixes it by making sure we test if `selectedSite` is set before calling `refreshSitePlans`.

Note: this only happens with a Paypal Express purchase, because of the redirect that loads Calypso from scratch.

