### PR TITLE
Comments: Fix condition to render QueryPosts

### DIFF
--- a/client/blocks/comment-detail/index.jsx
+++ b/client/blocks/comment-detail/index.jsx
@@ -300,7 +300,7 @@ export class CommentDetail extends Component {
 			>
 				{ refreshCommentData && <QueryComment commentId={ commentId } siteId={ siteId } /> }
 
-				{ isPostTitleLoaded && <QueryPosts siteId={ siteId } postId={ postId } /> }
+				{ ! isPostTitleLoaded && <QueryPosts siteId={ siteId } postId={ postId } /> }
 
 				<CommentDetailHeader
 					authorAvatarUrl={ authorAvatarUrl }


### PR DESCRIPTION
Fix an issue introduced in #18884

The original idea was to request a post when the comment's post title wasn't available, to use the post excerpt instead.
After testing, I've decided to simplify a bit the logic, missed a `!` and didn't test well enough to notice it (it's necessary to clean the cache and check the network requests to notice that something is wrong).