### PR TITLE
Components: Remove `valueLink` prop from `SelectDropdown`

### DIFF
--- a/client/components/select-dropdown/index.jsx
+++ b/client/components/select-dropdown/index.jsx
@@ -236,7 +236,6 @@ class SelectDropdown extends Component {
 				<div
 					ref="dropdownContainer"
 					className="select-dropdown__container"
-					valueLink={ this.props.valueLink }
 					onKeyDown={ this.navigateItem }
 					tabIndex={ this.props.tabIndex || 0 }
 					aria-haspopup="true"


### PR DESCRIPTION
I mean, what's a valueLink supposed to do on a `<div />` anyway? :-D