### PR TITLE
Jetpack connect: No explicit bind, handle props correctly

### DIFF
--- a/client/jetpack-connect/plans.jsx
+++ b/client/jetpack-connect/plans.jsx
@@ -52,8 +52,8 @@ const CALYPSO_PLANS_PAGE = '/plans/my-plan/';
 const JETPACK_ADMIN_PATH = '/wp-admin/admin.php?page=jetpack';
 
 class Plans extends Component {
-	constructor() {
-		super();
+	constructor( props ) {
+		super( props );
 		this.redirecting = false;
 	}
 

--- a/client/jetpack-connect/plans.jsx
+++ b/client/jetpack-connect/plans.jsx
@@ -54,8 +54,6 @@ const JETPACK_ADMIN_PATH = '/wp-admin/admin.php?page=jetpack';
 class Plans extends Component {
 	constructor() {
 		super();
-		this.selectPlan = this.selectPlan.bind( this );
-		this.storeSelectedPlan = this.storeSelectedPlan.bind( this );
 		this.redirecting = false;
 	}
 
@@ -233,7 +231,7 @@ class Plans extends Component {
 		}
 	}
 
-	selectPlan( cartItem ) {
+	selectPlan = cartItem => {
 		const checkoutPath = `/checkout/${ this.props.selectedSite.slug }`;
 		// clears whatever we had stored in local cache
 		this.props.selectPlanInAdvance( null, this.props.selectedSiteSlug );
@@ -256,9 +254,9 @@ class Plans extends Component {
 		this.redirecting = true;
 		this.props.completeFlow();
 		page.redirect( checkoutPath );
-	}
+	};
 
-	storeSelectedPlan( cartItem ) {
+	storeSelectedPlan = cartItem => {
 		this.props.recordTracksEvent( 'calypso_jpc_plans_store_plan', {
 			user: this.props.userId,
 			plan: cartItem ? cartItem.product_slug : 'free',
@@ -267,7 +265,7 @@ class Plans extends Component {
 			cartItem ? cartItem.product_slug : 'free',
 			this.props.siteSlug
 		);
-	}
+	};
 
 	render() {
 		const { isRtlLayout, translate } = this.props;


### PR DESCRIPTION
Just 2 improvements to the `plans` constructor:

* Correctly handle props (and pass to `super`!).
* Use arrow functions over explicitly bound methods.

## Testing
- Should be functionally equivalent.
- Which plans page is this? TBD