### PR TITLE
Jetpack Connect: Replace hasPlan method with isSiteOnPaidPlan selector

### DIFF
--- a/client/jetpack-connect/plans.jsx
+++ b/client/jetpack-connect/plans.jsx
@@ -35,7 +35,7 @@ import QueryPlans from 'components/data/query-plans';
 import QuerySitePlans from 'components/data/query-site-plans';
 import { isRequestingPlans, getPlanBySlug } from 'state/plans/selectors';
 import { getSelectedSite } from 'state/ui/selectors';
-import { canCurrentUser, isRtl } from 'state/selectors';
+import { canCurrentUser, isRtl, isSiteOnPaidPlan } from 'state/selectors';
 import {
 	getFlowType,
 	isRedirectingToWpAdmin,
@@ -85,7 +85,7 @@ class Plans extends Component {
 			this.props.goBackToWpAdmin( this.props.selectedSite.URL + JETPACK_ADMIN_PATH );
 		}
 
-		if ( this.hasPlan( this.props.selectedSite ) && ! this.redirecting ) {
+		if ( this.props.hasPlan && ! this.redirecting ) {
 			this.redirect( CALYPSO_PLANS_PAGE );
 		}
 		if ( ! this.props.canPurchasePlans && ! this.redirecting ) {
@@ -145,19 +145,6 @@ class Plans extends Component {
 		}
 
 		return !! this.props.selectedPlan;
-	}
-
-	hasPlan( site ) {
-		return (
-			site &&
-			site.plan &&
-			( site.plan.product_slug === PLAN_JETPACK_BUSINESS ||
-				site.plan.product_slug === PLAN_JETPACK_BUSINESS_MONTHLY ||
-				site.plan.product_slug === PLAN_JETPACK_PREMIUM ||
-				site.plan.product_slug === PLAN_JETPACK_PREMIUM_MONTHLY ||
-				site.plan.product_slug === PLAN_JETPACK_PERSONAL ||
-				site.plan.product_slug === PLAN_JETPACK_PERSONAL_MONTHLY )
-		);
 	}
 
 	autoselectPlan() {
@@ -274,7 +261,7 @@ class Plans extends Component {
 			this.redirecting ||
 			this.hasPreSelectedPlan() ||
 			( ! this.props.showFirst && ! this.props.canPurchasePlans ) ||
-			( ! this.props.showFirst && this.hasPlan( this.props.selectedSite ) )
+			( ! this.props.showFirst && this.props.hasPlan )
 		) {
 			return <QueryPlans />;
 		}
@@ -340,6 +327,7 @@ export default connect(
 			calypsoStartedConnection: isCalypsoStartedConnection( state, selectedSiteSlug ),
 			redirectingToWpAdmin: isRedirectingToWpAdmin( state ),
 			isRtlLayout: isRtl( state ),
+			hasPlan: isSiteOnPaidPlan( state, selectedSite.ID ),
 		};
 	},
 	{

--- a/client/jetpack-connect/test/__snapshots__/plans.js.snap
+++ b/client/jetpack-connect/test/__snapshots__/plans.js.snap
@@ -78,6 +78,7 @@ ShallowWrapper {
         flowType={false}
         getPlanBySlug={[Function]}
         goBackToWpAdmin={[Function]}
+        hasPlan={true}
         isAutomatedTransfer={false}
         isRequestingPlans={false}
         isRtlLayout={false}
@@ -469,6 +470,7 @@ ShallowWrapper {
           "flowType": false,
           "getPlanBySlug": [Function],
           "goBackToWpAdmin": [Function],
+          "hasPlan": true,
           "isAutomatedTransfer": false,
           "isRequestingPlans": false,
           "isRtlLayout": false,
@@ -887,6 +889,7 @@ ShallowWrapper {
     flowType={false}
     getPlanBySlug={[Function]}
     goBackToWpAdmin={[Function]}
+    hasPlan={true}
     isAutomatedTransfer={false}
     isRequestingPlans={false}
     isRtlLayout={false}
@@ -1290,6 +1293,7 @@ ShallowWrapper {
       flowType={false}
       getPlanBySlug={[Function]}
       goBackToWpAdmin={[Function]}
+      hasPlan={true}
       hideFreePlan={true}
       isAutomatedTransfer={false}
       isRequestingPlans={false}
@@ -1702,6 +1706,7 @@ ShallowWrapper {
         flowType={false}
         getPlanBySlug={[Function]}
         goBackToWpAdmin={[Function]}
+        hasPlan={true}
         hideFreePlan={true}
         isAutomatedTransfer={false}
         isRequestingPlans={false}
@@ -2115,6 +2120,7 @@ ShallowWrapper {
         flowType={false}
         getPlanBySlug={[Function]}
         goBackToWpAdmin={[Function]}
+        hasPlan={true}
         isAutomatedTransfer={false}
         isRequestingPlans={false}
         isRtlLayout={false}
@@ -2507,6 +2513,7 @@ ShallowWrapper {
           "flowType": false,
           "getPlanBySlug": [Function],
           "goBackToWpAdmin": [Function],
+          "hasPlan": true,
           "isAutomatedTransfer": false,
           "isRequestingPlans": false,
           "isRtlLayout": false,
@@ -2917,6 +2924,7 @@ ShallowWrapper {
             flowType={false}
             getPlanBySlug={[Function]}
             goBackToWpAdmin={[Function]}
+            hasPlan={true}
             hideFreePlan={true}
             isAutomatedTransfer={false}
             isRequestingPlans={false}
@@ -3329,6 +3337,7 @@ ShallowWrapper {
             flowType={false}
             getPlanBySlug={[Function]}
             goBackToWpAdmin={[Function]}
+            hasPlan={true}
             hideFreePlan={true}
             isAutomatedTransfer={false}
             isRequestingPlans={false}
@@ -3746,6 +3755,7 @@ ShallowWrapper {
     flowType={false}
     getPlanBySlug={[Function]}
     goBackToWpAdmin={[Function]}
+    hasPlan={true}
     isAutomatedTransfer={false}
     isRequestingPlans={false}
     isRtlLayout={false}
@@ -4150,6 +4160,7 @@ ShallowWrapper {
       flowType={false}
       getPlanBySlug={[Function]}
       goBackToWpAdmin={[Function]}
+      hasPlan={false}
       hideFreePlan={true}
       isAutomatedTransfer={false}
       isRequestingPlans={false}
@@ -4561,6 +4572,7 @@ ShallowWrapper {
         flowType={false}
         getPlanBySlug={[Function]}
         goBackToWpAdmin={[Function]}
+        hasPlan={false}
         hideFreePlan={true}
         isAutomatedTransfer={false}
         isRequestingPlans={false}
@@ -4973,6 +4985,7 @@ ShallowWrapper {
         flowType={false}
         getPlanBySlug={[Function]}
         goBackToWpAdmin={[Function]}
+        hasPlan={false}
         isAutomatedTransfer={false}
         isRequestingPlans={false}
         isRtlLayout={false}
@@ -5364,6 +5377,7 @@ ShallowWrapper {
           "flowType": false,
           "getPlanBySlug": [Function],
           "goBackToWpAdmin": [Function],
+          "hasPlan": false,
           "isAutomatedTransfer": false,
           "isRequestingPlans": false,
           "isRtlLayout": false,
@@ -5773,6 +5787,7 @@ ShallowWrapper {
             flowType={false}
             getPlanBySlug={[Function]}
             goBackToWpAdmin={[Function]}
+            hasPlan={false}
             hideFreePlan={true}
             isAutomatedTransfer={false}
             isRequestingPlans={false}
@@ -6184,6 +6199,7 @@ ShallowWrapper {
             flowType={false}
             getPlanBySlug={[Function]}
             goBackToWpAdmin={[Function]}
+            hasPlan={false}
             hideFreePlan={true}
             isAutomatedTransfer={false}
             isRequestingPlans={false}
@@ -6600,6 +6616,7 @@ ShallowWrapper {
     flowType={false}
     getPlanBySlug={[Function]}
     goBackToWpAdmin={[Function]}
+    hasPlan={false}
     isAutomatedTransfer={false}
     isRequestingPlans={false}
     isRtlLayout={false}

--- a/client/jetpack-connect/test/lib/plans.js
+++ b/client/jetpack-connect/test/lib/plans.js
@@ -432,6 +432,7 @@ export const DEFAULT_PROPS = {
 	flowType: false,
 	getPlanBySlug: noop,
 	goBackToWpAdmin: noop,
+	hasPlan: false,
 	isAutomatedTransfer: false,
 	isRequestingPlans: false,
 	isRtlLayout: false,

--- a/client/jetpack-connect/test/plans.js
+++ b/client/jetpack-connect/test/plans.js
@@ -35,6 +35,7 @@ describe( 'Plans', () => {
 		const wrapper = shallow(
 			<Plans
 				{ ...DEFAULT_PROPS }
+				hasPlan={ true }
 				selectedSite={ { ...SELECTED_SITE, plan: SITE_PLAN_PRO } }
 				sitePlans={ getSitePlans( PLAN_JETPACK_BUSINESS ) }
 			/>
@@ -49,6 +50,7 @@ describe( 'Plans', () => {
 		const wrapper = shallow(
 			<Plans
 				{ ...DEFAULT_PROPS }
+				hasPlan={ true }
 				selectedSite={ { ...SELECTED_SITE, plan: SITE_PLAN_PRO } }
 				showFirst={ true }
 				sitePlans={ getSitePlans( PLAN_JETPACK_BUSINESS ) }
@@ -66,6 +68,7 @@ describe( 'Plans', () => {
 		const redirect = ( wrapper.instance().redirect = jest.fn() );
 
 		wrapper.setProps( {
+			hasPlan: true,
 			selectedSite: { ...SELECTED_SITE, plan: SITE_PLAN_PRO },
 			sitePlans: getSitePlans( PLAN_JETPACK_BUSINESS ),
 		} );
@@ -82,6 +85,7 @@ describe( 'Plans', () => {
 			<Plans
 				{ ...DEFAULT_PROPS }
 				goBackToWpAdmin={ goBackToWpAdmin }
+				hasPlan={ true }
 				isAutomatedTransfer={ true }
 				selectedSite={ {
 					...SELECTED_SITE,


### PR DESCRIPTION
Replaces component level `hasPlan` logic with global `isSiteOnPaidPlan` selector which serves the same purpose.

There should be no behavioral changes.

## Testing
* Verify that the affected behavior is covered by tests
* Deep render snapshots show no changes as expected 🎉 .
* When #19151 lands, we should see the addition of `hasPlan` on the `PlansGrid` shallow renders as props are `{ ...spread }` to that descendent.
