### PR TITLE
Checkout: Fix broken thank you page for PayPal Express

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/header.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/header.jsx
@@ -186,7 +186,7 @@ class CheckoutThankYouHeader extends PureComponent {
 		const { translate, primaryPurchase, selectedSite } = this.props;
 		const headerButtonClassName = 'button is-primary';
 
-		if ( isPlan( primaryPurchase ) && ! selectedSite.jetpack ) {
+		if ( isPlan( primaryPurchase ) && selectedSite && ! selectedSite.jetpack ) {
 			return (
 				<div className="checkout-thank-you__header-button">
 					<button className={ headerButtonClassName } onClick={ this.visitSite }>


### PR DESCRIPTION
Similar to #18949.

For PayPal Express, user ends up redirected to Thank You page, which will do full load of Calypso, and selectedSite is not loaded yet during first render.

<img width="743" alt="cloudup-843575d7-3953-4d13-8728-69ffb95953dd" src="https://user-images.githubusercontent.com/203105/31722787-4d2da278-b41d-11e7-9be3-77ef52e8b4b5.png">

To test - make a personal plan purchase using PayPal Express, and verify that Thank You page loads without error.

cc @Automattic/neutron 