### PR TITLE
Editor: fix tours relying on separate quick insert / insert dropdown buttons

### DIFF
--- a/client/layout/guided-tours/tours/editor-basics-tour.js
+++ b/client/layout/guided-tours/tours/editor-basics-tour.js
@@ -64,7 +64,7 @@ export const EditorBasicsTour = makeTour(
 		<Step
 			name="add-things"
 			arrow="top-left"
-			target=".editor-html-toolbar__button-insert-media, .mce-wpcom-insert-menu button"
+			target=".editor-html-toolbar__button-insert-content-dropdown, .mce-wpcom-insert-menu button"
 			placement="below"
 			style={ { marginLeft: '-7px', zIndex: 'auto' } }
 		>

--- a/client/layout/guided-tours/tours/simple-payments-tour.js
+++ b/client/layout/guided-tours/tours/simple-payments-tour.js
@@ -25,7 +25,7 @@ export const SimplePaymentsTour = makeTour(
 		<Step
 			name="init"
 			arrow="top-left"
-			target=".editor-html-toolbar__button-insert-media, .mce-wpcom-insert-menu button"
+			target=".editor-html-toolbar__button-insert-content-dropdown, .mce-wpcom-insert-menu button"
 			placement="below"
 			style={ { marginLeft: '-10px', zIndex: 'auto' } }
 		>


### PR DESCRIPTION
When the two Editor buttons for "insert image" and "insert ..." (dropdown) were unified a few days ago, two guided tours ("editor basics" and "simple payments") relying on these buttons stopped working properly. Instead of pointing at the now gone button, they'd point at (0,0). Which made no sense. This PR corrects this behavior. 

This was noticed late because the problematic behavior only shows when the HTML editor mode is active during the tour. 

To test:
- go through both tours (below) — once with the Visual Editor, once with the HTML Editor. make sure all steps are positioned properly. 

Tours:
- http://calypso.localhost:3000/post/SITE_URL?tour=simplePaymentsTour
- http://calypso.localhost:3000/post/SITE_URL?tour=editorBasicsTour
