### PR TITLE
Framework: Update react-hot-loader to 3.1.1

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -14,6 +14,7 @@
 	],
 	"plugins": [
 		"add-module-exports",
+		"react-hot-loader/babel",
 		"syntax-jsx",
 		"transform-export-extensions",
 		"transform-react-display-name",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -874,10 +874,10 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000746"
+      "version": "1.0.30000747"
     },
     "caniuse-lite": {
-      "version": "1.0.30000746"
+      "version": "1.0.30000747"
     },
     "cardinal": {
       "version": "1.0.0",
@@ -1075,16 +1075,14 @@
       "dev": true
     },
     "color-convert": {
-      "version": "1.9.0",
-      "dev": true
+      "version": "1.9.0"
     },
     "color-diff": {
       "version": "0.1.7",
       "dev": true
     },
     "color-name": {
-      "version": "1.1.3",
-      "dev": true
+      "version": "1.1.3"
     },
     "colorguard": {
       "version": "1.2.0",
@@ -1540,6 +1538,9 @@
         }
       }
     },
+    "dom-walk": {
+      "version": "0.1.1"
+    },
     "domain-browser": {
       "version": "1.1.7"
     },
@@ -1703,6 +1704,9 @@
     "error-ex": {
       "version": "1.3.1"
     },
+    "error-stack-parser": {
+      "version": "1.3.6"
+    },
     "es-abstract": {
       "version": "1.9.0"
     },
@@ -1724,7 +1728,7 @@
       "version": "4.0.2"
     },
     "es6-iterator": {
-      "version": "2.0.1"
+      "version": "2.0.3"
     },
     "es6-map": {
       "version": "0.1.5"
@@ -2806,6 +2810,9 @@
         }
       }
     },
+    "global": {
+      "version": "4.3.2"
+    },
     "globals": {
       "version": "9.18.0"
     },
@@ -2905,7 +2912,7 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.0.10",
+      "version": "4.0.11",
       "dev": true,
       "dependencies": {
         "async": {
@@ -3538,7 +3545,7 @@
           "dev": true
         },
         "chalk": {
-          "version": "2.1.0",
+          "version": "2.2.0",
           "dev": true
         },
         "cliui": {
@@ -3630,7 +3637,7 @@
           "dev": true
         },
         "supports-color": {
-          "version": "4.4.0",
+          "version": "4.5.0",
           "dev": true
         },
         "which-module": {
@@ -3660,7 +3667,7 @@
           "dev": true
         },
         "chalk": {
-          "version": "2.1.0",
+          "version": "2.2.0",
           "dev": true
         },
         "escape-string-regexp": {
@@ -3676,7 +3683,7 @@
           "dev": true
         },
         "supports-color": {
-          "version": "4.4.0",
+          "version": "4.5.0",
           "dev": true
         }
       }
@@ -3690,7 +3697,7 @@
           "dev": true
         },
         "chalk": {
-          "version": "2.1.0",
+          "version": "2.2.0",
           "dev": true
         },
         "diff": {
@@ -3706,7 +3713,7 @@
           "dev": true
         },
         "supports-color": {
-          "version": "4.4.0",
+          "version": "4.5.0",
           "dev": true
         }
       }
@@ -3750,7 +3757,7 @@
           "dev": true
         },
         "chalk": {
-          "version": "2.1.0",
+          "version": "2.2.0",
           "dev": true
         },
         "escape-string-regexp": {
@@ -3762,7 +3769,7 @@
           "dev": true
         },
         "supports-color": {
-          "version": "4.4.0",
+          "version": "4.5.0",
           "dev": true
         }
       }
@@ -3780,7 +3787,7 @@
           "dev": true
         },
         "chalk": {
-          "version": "2.1.0",
+          "version": "2.2.0",
           "dev": true
         },
         "escape-string-regexp": {
@@ -3792,7 +3799,7 @@
           "dev": true
         },
         "supports-color": {
-          "version": "4.4.0",
+          "version": "4.5.0",
           "dev": true
         }
       }
@@ -3844,7 +3851,7 @@
           "dev": true
         },
         "chalk": {
-          "version": "2.1.0",
+          "version": "2.2.0",
           "dev": true
         },
         "escape-string-regexp": {
@@ -3856,7 +3863,7 @@
           "dev": true
         },
         "supports-color": {
-          "version": "4.4.0",
+          "version": "4.5.0",
           "dev": true
         }
       }
@@ -3878,7 +3885,7 @@
           "dev": true
         },
         "chalk": {
-          "version": "2.1.0",
+          "version": "2.2.0",
           "dev": true
         },
         "escape-string-regexp": {
@@ -3890,7 +3897,7 @@
           "dev": true
         },
         "supports-color": {
-          "version": "4.4.0",
+          "version": "4.5.0",
           "dev": true
         }
       }
@@ -3930,7 +3937,7 @@
           "dev": true
         },
         "chalk": {
-          "version": "2.1.0",
+          "version": "2.2.0",
           "dev": true
         },
         "cliui": {
@@ -3990,7 +3997,7 @@
           "dev": true
         },
         "supports-color": {
-          "version": "4.4.0",
+          "version": "4.5.0",
           "dev": true
         },
         "which-module": {
@@ -4020,7 +4027,7 @@
           "dev": true
         },
         "chalk": {
-          "version": "2.1.0",
+          "version": "2.2.0",
           "dev": true
         },
         "escape-string-regexp": {
@@ -4032,7 +4039,7 @@
           "dev": true
         },
         "supports-color": {
-          "version": "4.4.0",
+          "version": "4.5.0",
           "dev": true
         }
       }
@@ -4050,7 +4057,7 @@
           "dev": true
         },
         "chalk": {
-          "version": "2.1.0",
+          "version": "2.2.0",
           "dev": true
         },
         "escape-string-regexp": {
@@ -4062,7 +4069,7 @@
           "dev": true
         },
         "supports-color": {
-          "version": "4.4.0",
+          "version": "4.5.0",
           "dev": true
         }
       }
@@ -4076,7 +4083,7 @@
           "dev": true
         },
         "chalk": {
-          "version": "2.1.0",
+          "version": "2.2.0",
           "dev": true
         },
         "escape-string-regexp": {
@@ -4092,7 +4099,7 @@
           "dev": true
         },
         "supports-color": {
-          "version": "4.4.0",
+          "version": "4.5.0",
           "dev": true
         }
       }
@@ -4720,6 +4727,9 @@
     "mimic-fn": {
       "version": "1.1.0"
     },
+    "min-document": {
+      "version": "2.19.0"
+    },
     "minimalistic-assert": {
       "version": "1.0.0"
     },
@@ -4870,6 +4880,9 @@
       "dependencies": {
         "inherits": {
           "version": "2.0.3"
+        },
+        "process": {
+          "version": "0.11.10"
         },
         "readable-stream": {
           "version": "2.3.3",
@@ -5216,7 +5229,13 @@
     },
     "path": {
       "version": "0.12.7",
-      "dev": true
+      "dev": true,
+      "dependencies": {
+        "process": {
+          "version": "0.11.10",
+          "dev": true
+        }
+      }
     },
     "path-browserify": {
       "version": "0.0.0"
@@ -5334,7 +5353,7 @@
           "version": "3.2.0"
         },
         "chalk": {
-          "version": "2.1.0"
+          "version": "2.2.0"
         },
         "escape-string-regexp": {
           "version": "1.0.5"
@@ -5349,7 +5368,7 @@
           "version": "0.6.1"
         },
         "supports-color": {
-          "version": "4.4.0"
+          "version": "4.5.0"
         }
       }
     },
@@ -5378,7 +5397,7 @@
           "dev": true
         },
         "chalk": {
-          "version": "2.1.0",
+          "version": "2.2.0",
           "dev": true
         },
         "escape-string-regexp": {
@@ -5398,7 +5417,7 @@
           "dev": true
         },
         "supports-color": {
-          "version": "4.4.0",
+          "version": "4.5.0",
           "dev": true
         }
       }
@@ -5468,7 +5487,7 @@
               "dev": true
             },
             "supports-color": {
-              "version": "4.4.0",
+              "version": "4.5.0",
               "dev": true
             }
           }
@@ -5526,7 +5545,7 @@
               "dev": true
             },
             "chalk": {
-              "version": "2.1.0",
+              "version": "2.2.0",
               "dev": true
             },
             "escape-string-regexp": {
@@ -5534,7 +5553,7 @@
               "dev": true
             },
             "supports-color": {
-              "version": "4.4.0",
+              "version": "4.5.0",
               "dev": true
             }
           }
@@ -5598,7 +5617,7 @@
       "version": "0.1.8"
     },
     "process": {
-      "version": "0.11.10"
+      "version": "0.5.2"
     },
     "process-nextick-args": {
       "version": "1.0.7"
@@ -5920,6 +5939,9 @@
     "react-day-picker": {
       "version": "6.0.2"
     },
+    "react-deep-force-update": {
+      "version": "2.1.1"
+    },
     "react-docgen": {
       "version": "2.13.0",
       "dependencies": {
@@ -5941,14 +5963,11 @@
       "version": "3.2.0",
       "dev": true
     },
-    "react-hot-api": {
-      "version": "0.4.7"
-    },
     "react-hot-loader": {
-      "version": "1.3.1",
+      "version": "3.1.1",
       "dependencies": {
         "source-map": {
-          "version": "0.4.4"
+          "version": "0.6.1"
         }
       }
     },
@@ -5959,6 +5978,9 @@
           "version": "4.2.0"
         }
       }
+    },
+    "react-proxy": {
+      "version": "3.0.0-alpha.1"
     },
     "react-pure-render": {
       "version": "1.0.2"
@@ -6084,6 +6106,9 @@
           "version": "0.5.7"
         }
       }
+    },
+    "redbox-react": {
+      "version": "1.5.0"
     },
     "redent": {
       "version": "1.0.0"
@@ -6577,6 +6602,14 @@
         }
       }
     },
+    "sourcemapped-stacktrace": {
+      "version": "1.1.7",
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.6"
+        }
+      }
+    },
     "sparkles": {
       "version": "1.0.0",
       "dev": true
@@ -6611,6 +6644,9 @@
     "stable": {
       "version": "0.1.6",
       "dev": true
+    },
+    "stackframe": {
+      "version": "0.3.1"
     },
     "statuses": {
       "version": "1.3.1"
@@ -7373,7 +7409,7 @@
           "version": "3.0.0"
         },
         "supports-color": {
-          "version": "4.4.0"
+          "version": "4.5.0"
         },
         "webpack-sources": {
           "version": "1.0.1"
@@ -7450,7 +7486,7 @@
           "dev": true
         },
         "filesize": {
-          "version": "3.5.10",
+          "version": "3.5.11",
           "dev": true
         },
         "finalhandler": {
@@ -7598,7 +7634,7 @@
           "version": "1.3.2"
         },
         "filesize": {
-          "version": "3.5.10"
+          "version": "3.5.11"
         },
         "isarray": {
           "version": "0.0.1"

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "react-day-picker": "6.0.2",
     "react-docgen": "2.13.0",
     "react-dom": "15.4.0",
-    "react-hot-loader": "1.3.1",
+    "react-hot-loader": "3.1.1",
     "react-modal": "1.6.5",
     "react-pure-render": "1.0.2",
     "react-redux": "5.0.3",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -145,8 +145,7 @@ const webpackConfig = {
 		new CopyWebpackPlugin( [ { from: 'node_modules/flag-icon-css/flags/4x3', to: 'images/flags' } ] ),
 		new HappyPack( {
 			loaders: _.compact( [
-				calypsoEnv === 'development' && 'react-hot-loader',
-				babelLoader
+				babelLoader,
 			] )
 		} ),
 		new webpack.NamedModulesPlugin(),


### PR DESCRIPTION
Updates `react-hot-loader` to `v3` in order to fix an issue with pages involving `redux-form` crashing on dev environment.
Apparently `redux-form` is incompatible with lower `react-hot-loader` versions, but that issue only came up when we fixed our config to actually enable hot loading on dev ( #18771 ).

It looks like upgrading to React 16 would also need this `react-hot-loader` to be updated.

# Testing

- Run this branch locally and check if changes to source files are being reflected in the browser without a refresh.
- Go to a page that requires `redux-form` ( for example `http://calypso.localhost:3000/extensions/zoninator/` ) and make sure it loads correctly.