### PR TITLE
Store Orders: Add functions to calculate total prices based on order data

### DIFF
--- a/client/extensions/woocommerce/app/order/order-details/table.js
+++ b/client/extensions/woocommerce/app/order/order-details/table.js
@@ -16,10 +16,10 @@ import {
 	getOrderDiscountTax,
 	getOrderFeeTax,
 	getOrderLineItemTax,
-	getOrderRefundTotal,
 	getOrderShippingTax,
 	getOrderTotalTax,
 } from 'woocommerce/lib/order-values';
+import { getOrderRefundTotal } from 'woocommerce/lib/order-values/totals';
 import OrderTotalRow from './row-total';
 import Table from 'woocommerce/components/table';
 import TableRow from 'woocommerce/components/table/table-row';

--- a/client/extensions/woocommerce/app/order/order-payment/dialog.js
+++ b/client/extensions/woocommerce/app/order/order-payment/dialog.js
@@ -27,9 +27,9 @@ import { getCurrencyFormatDecimal } from 'woocommerce/lib/currency';
 import {
 	getOrderFeeTax,
 	getOrderLineItemTax,
-	getOrderRefundTotal,
 	getOrderShippingTax,
 } from 'woocommerce/lib/order-values';
+import { getOrderRefundTotal } from 'woocommerce/lib/order-values/totals';
 import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
 import Notice from 'components/notice';
 import OrderRefundTable from './table';

--- a/client/extensions/woocommerce/app/order/order-payment/index.js
+++ b/client/extensions/woocommerce/app/order/order-payment/index.js
@@ -14,7 +14,7 @@ import { localize } from 'i18n-calypso';
  */
 import Button from 'components/button';
 import formatCurrency from 'lib/format-currency';
-import { getOrderRefundTotal } from 'woocommerce/lib/order-values';
+import { getOrderRefundTotal } from 'woocommerce/lib/order-values/totals';
 import { isOrderFailed, isOrderWaitingPayment } from 'woocommerce/lib/order-status';
 import RefundDialog from './dialog';
 import { updateOrder } from 'woocommerce/state/sites/orders/actions';

--- a/client/extensions/woocommerce/app/order/order-payment/table.js
+++ b/client/extensions/woocommerce/app/order/order-payment/table.js
@@ -17,10 +17,10 @@ import {
 	getOrderDiscountTax,
 	getOrderFeeTax,
 	getOrderLineItemTax,
-	getOrderRefundTotal,
 	getOrderShippingTax,
 	getOrderTotalTax,
 } from 'woocommerce/lib/order-values';
+import { getOrderRefundTotal } from 'woocommerce/lib/order-values/totals';
 import OrderTotalRow from '../order-details/row-total';
 import PriceInput from 'woocommerce/components/price-input';
 import Table from 'woocommerce/components/table';

--- a/client/extensions/woocommerce/lib/order-values/index.js
+++ b/client/extensions/woocommerce/lib/order-values/index.js
@@ -30,7 +30,7 @@ export function getOrderLineItemTax( order, id ) {
 }
 
 /**
- * Get the total tax for a given line item's value
+ * Get the total tax for a given fee
  *
  * @param {Object} order An order as returned from API
  * @param {Number} index The index of a fee line in this order

--- a/client/extensions/woocommerce/lib/order-values/index.js
+++ b/client/extensions/woocommerce/lib/order-values/index.js
@@ -97,14 +97,3 @@ export function getOrderFeeTotal( order ) {
 	const fees = get( order, 'fee_lines', [] );
 	return reduce( fees, ( sum, value ) => sum + parseFloat( value.total ), 0 );
 }
-
-/**
- * Get the refund value on a given order
- *
- * @param {Object} order An order as returned from API
- * @return {Float} The refund amount as a decimal number
- */
-export function getOrderRefundTotal( order ) {
-	const refunds = get( order, 'refunds', [] );
-	return reduce( refunds, ( sum, value ) => sum + parseFloat( value.total ), 0 );
-}

--- a/client/extensions/woocommerce/lib/order-values/index.js
+++ b/client/extensions/woocommerce/lib/order-values/index.js
@@ -86,14 +86,3 @@ export function getOrderTotalTax( order ) {
 	const fees = getOrderFeeTotalTax( order );
 	return subtotal + shipping + fees;
 }
-
-/**
- * Get the fee total on a given order
- *
- * @param {Object} order An order as returned from API
- * @return {Float} The total fee amount as a decimal number
- */
-export function getOrderFeeTotal( order ) {
-	const fees = get( order, 'fee_lines', [] );
-	return reduce( fees, ( sum, value ) => sum + parseFloat( value.total ), 0 );
-}

--- a/client/extensions/woocommerce/lib/order-values/test/fixtures/order-no-tax.js
+++ b/client/extensions/woocommerce/lib/order-values/test/fixtures/order-no-tax.js
@@ -5,9 +5,11 @@ export default {
 		{
 			id: 1,
 			name: 'Scarf',
-			product_id: 49,
-			taxes: [],
 			price: 25,
+			quantity: 1,
+			subtotal: 25,
+			total: 25,
+			taxes: [],
 		},
 	],
 	tax_lines: [],

--- a/client/extensions/woocommerce/lib/order-values/test/fixtures/order-with-coupons.js
+++ b/client/extensions/woocommerce/lib/order-values/test/fixtures/order-with-coupons.js
@@ -5,7 +5,10 @@ export default {
 		{
 			id: 26,
 			name: 'Mug',
-			product_id: 71,
+			price: 11.64,
+			quantity: 2,
+			subtotal: 31.98,
+			total: 23.28,
 			taxes: [
 				{
 					id: 4,
@@ -13,11 +16,14 @@ export default {
 					subtotal: '2.0307',
 				},
 			],
-			price: 11.6408,
 		},
 		{
 			id: 27,
 			name: 'Scarf - Blue',
+			price: 36.39,
+			quantity: 1,
+			subtotal: 49.99,
+			total: 36.39,
 			taxes: [
 				{
 					id: 4,
@@ -25,7 +31,6 @@ export default {
 					subtotal: '3.1744',
 				},
 			],
-			price: 36.3929,
 		},
 	],
 	tax_lines: [

--- a/client/extensions/woocommerce/lib/order-values/test/fixtures/order-with-refunds.js
+++ b/client/extensions/woocommerce/lib/order-values/test/fixtures/order-with-refunds.js
@@ -5,7 +5,10 @@ export default {
 		{
 			id: 15,
 			name: 'Scarf - Striped',
-			product_id: 49,
+			price: 42.49,
+			quantity: 1,
+			subtotal: 49.99,
+			total: 42.49,
 			taxes: [
 				{
 					id: 4,
@@ -13,12 +16,14 @@ export default {
 					subtotal: '6.3487',
 				},
 			],
-			price: 42.4915,
 		},
 		{
 			id: 19,
 			name: 'T-Shirt',
-			product_id: 62,
+			price: 17.99,
+			quantity: 1,
+			subtotal: 17.99,
+			total: 17.99,
 			taxes: [
 				{
 					id: 4,
@@ -26,7 +31,6 @@ export default {
 					subtotal: '1.1424',
 				},
 			],
-			price: 17.99,
 		},
 	],
 	tax_lines: [

--- a/client/extensions/woocommerce/lib/order-values/test/fixtures/order.js
+++ b/client/extensions/woocommerce/lib/order-values/test/fixtures/order.js
@@ -5,7 +5,10 @@ export default {
 		{
 			id: 15,
 			name: 'Scarf - Striped',
-			product_id: 49,
+			price: 42.49,
+			quantity: 1,
+			subtotal: 49.99,
+			total: 42.49,
 			taxes: [
 				{
 					id: 4,
@@ -13,12 +16,14 @@ export default {
 					subtotal: '6.3487',
 				},
 			],
-			price: 42.4915,
 		},
 		{
 			id: 19,
 			name: 'T-Shirt',
-			product_id: 62,
+			price: 17.99,
+			quantity: 1,
+			subtotal: 17.99,
+			total: 17.99,
 			taxes: [
 				{
 					id: 4,
@@ -26,7 +31,6 @@ export default {
 					subtotal: '1.1424',
 				},
 			],
-			price: 17.99,
 		},
 	],
 	tax_lines: [

--- a/client/extensions/woocommerce/lib/order-values/test/index.js
+++ b/client/extensions/woocommerce/lib/order-values/test/index.js
@@ -14,7 +14,6 @@ import {
 	getOrderFeeTotal,
 	getOrderFeeTotalTax,
 	getOrderLineItemTax,
-	getOrderRefundTotal,
 	getOrderShippingTax,
 	getOrderSubtotalTax,
 	getOrderTotalTax,
@@ -22,7 +21,6 @@ import {
 import orderWithTax from './fixtures/order';
 import orderWithoutTax from './fixtures/order-no-tax';
 import orderWithCoupons from './fixtures/order-with-coupons';
-import orderWithRefunds from './fixtures/order-with-refunds';
 
 describe( 'getOrderDiscountTax', () => {
 	test( 'should be a function', () => {
@@ -173,23 +171,5 @@ describe( 'getOrderFeeTotal', () => {
 
 	test( 'should return 0 if there is no tax', () => {
 		expect( getOrderFeeTotal( orderWithoutTax ) ).to.eql( 20 );
-	} );
-} );
-
-describe( 'getOrderRefundTotal', () => {
-	test( 'should be a function', () => {
-		expect( getOrderRefundTotal ).to.be.a( 'function' );
-	} );
-
-	test( 'should get the correct refund amount', () => {
-		expect( getOrderRefundTotal( orderWithCoupons ) ).to.eql( -10.0 );
-	} );
-
-	test( 'should return 0 if there are no refunds', () => {
-		expect( getOrderRefundTotal( orderWithoutTax ) ).to.eql( 0 );
-	} );
-
-	test( 'should get the correct refund amount with multiple refunds', () => {
-		expect( getOrderRefundTotal( orderWithRefunds ) ).to.eql( -25.0 );
 	} );
 } );

--- a/client/extensions/woocommerce/lib/order-values/test/index.js
+++ b/client/extensions/woocommerce/lib/order-values/test/index.js
@@ -11,7 +11,6 @@ import { expect } from 'chai';
 import {
 	getOrderDiscountTax,
 	getOrderFeeTax,
-	getOrderFeeTotal,
 	getOrderFeeTotalTax,
 	getOrderLineItemTax,
 	getOrderShippingTax,
@@ -153,23 +152,5 @@ describe( 'getOrderTotalTax', () => {
 
 	test( 'should get the correct tax amount with multiple coupons', () => {
 		expect( getOrderTotalTax( orderWithCoupons ) ).to.eql( 5.3618 );
-	} );
-} );
-
-describe( 'getOrderFeeTotal', () => {
-	test( 'should be a function', () => {
-		expect( getOrderFeeTotal ).to.be.a( 'function' );
-	} );
-
-	test( 'should get the correct tax amount', () => {
-		expect( getOrderFeeTotal( orderWithTax ) ).to.eql( 1.53 );
-	} );
-
-	test( 'should get the correct tax amount with multiple fees', () => {
-		expect( getOrderFeeTotal( orderWithCoupons ) ).to.eql( 15 );
-	} );
-
-	test( 'should return 0 if there is no tax', () => {
-		expect( getOrderFeeTotal( orderWithoutTax ) ).to.eql( 20 );
 	} );
 } );

--- a/client/extensions/woocommerce/lib/order-values/test/totals.js
+++ b/client/extensions/woocommerce/lib/order-values/test/totals.js
@@ -10,6 +10,7 @@ import { expect } from 'chai';
  */
 import {
 	getOrderDiscountTotal,
+	getOrderFeeTotal,
 	getOrderItemCost,
 	getOrderRefundTotal,
 	getOrderShippingTotal,
@@ -36,6 +37,24 @@ describe( 'getOrderDiscountTotal', () => {
 
 	it( 'should get the correct discount amount with multiple coupons', () => {
 		expect( getOrderDiscountTotal( orderWithCoupons ) ).to.eql( 22.3 );
+	} );
+} );
+
+describe( 'getOrderFeeTotal', () => {
+	test( 'should be a function', () => {
+		expect( getOrderFeeTotal ).to.be.a( 'function' );
+	} );
+
+	test( 'should get the correct tax amount', () => {
+		expect( getOrderFeeTotal( orderWithTax ) ).to.eql( 1.53 );
+	} );
+
+	test( 'should get the correct tax amount with multiple fees', () => {
+		expect( getOrderFeeTotal( orderWithCoupons ) ).to.eql( 15 );
+	} );
+
+	test( 'should return 0 if there is no tax', () => {
+		expect( getOrderFeeTotal( orderWithoutTax ) ).to.eql( 20 );
 	} );
 } );
 

--- a/client/extensions/woocommerce/lib/order-values/test/totals.js
+++ b/client/extensions/woocommerce/lib/order-values/test/totals.js
@@ -10,6 +10,7 @@ import { expect } from 'chai';
  */
 import {
 	getOrderDiscountTotal,
+	getOrderItemCost,
 	getOrderRefundTotal,
 	getOrderShippingTotal,
 	getOrderSubtotal,
@@ -35,6 +36,28 @@ describe( 'getOrderDiscountTotal', () => {
 
 	it( 'should get the correct discount amount with multiple coupons', () => {
 		expect( getOrderDiscountTotal( orderWithCoupons ) ).to.eql( 22.3 );
+	} );
+} );
+
+describe( 'getOrderItemCost', () => {
+	it( 'should be a function', () => {
+		expect( getOrderItemCost ).to.be.a( 'function' );
+	} );
+
+	it( 'should get the singular cost of an item', () => {
+		expect( getOrderItemCost( orderWithTax, 19 ) ).to.eql( 17.99 );
+	} );
+
+	it( 'should get the singular cost of an item, before discounts', () => {
+		expect( getOrderItemCost( orderWithTax, 15 ) ).to.eql( 49.99 );
+	} );
+
+	it( 'should get the singular cost of an item, even if quantity > 1', () => {
+		expect( getOrderItemCost( orderWithCoupons, 26 ) ).to.eql( 15.99 );
+	} );
+
+	it( 'should return 0 if this ID does not exist in line_items', () => {
+		expect( getOrderItemCost( orderWithoutTax, 2 ) ).to.eql( 0 );
 	} );
 } );
 

--- a/client/extensions/woocommerce/lib/order-values/test/totals.js
+++ b/client/extensions/woocommerce/lib/order-values/test/totals.js
@@ -1,0 +1,89 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import {
+	getOrderDiscountTotal,
+	getOrderRefundTotal,
+	getOrderShippingTotal,
+	getOrderSubtotal,
+	// getOrderTotal,
+} from '../totals';
+import orderWithTax from './fixtures/order';
+import orderWithoutTax from './fixtures/order-no-tax';
+import orderWithCoupons from './fixtures/order-with-coupons';
+import orderWithRefunds from './fixtures/order-with-refunds';
+
+describe( 'getOrderDiscountTotal', () => {
+	it( 'should be a function', () => {
+		expect( getOrderDiscountTotal ).to.be.a( 'function' );
+	} );
+
+	it( 'should get the correct discount amount', () => {
+		expect( getOrderDiscountTotal( orderWithRefunds ) ).to.eql( 15 );
+	} );
+
+	it( 'should return 0 if there are no discounts', () => {
+		expect( getOrderDiscountTotal( orderWithoutTax ) ).to.eql( 0 );
+	} );
+
+	it( 'should get the correct discount amount with multiple coupons', () => {
+		expect( getOrderDiscountTotal( orderWithCoupons ) ).to.eql( 22.3 );
+	} );
+} );
+
+describe( 'getOrderRefundTotal', () => {
+	it( 'should be a function', () => {
+		expect( getOrderRefundTotal ).to.be.a( 'function' );
+	} );
+
+	it( 'should get the correct refund amount', () => {
+		expect( getOrderRefundTotal( orderWithCoupons ) ).to.eql( -10.0 );
+	} );
+
+	it( 'should return 0 if there are no refunds', () => {
+		expect( getOrderRefundTotal( orderWithoutTax ) ).to.eql( 0 );
+	} );
+
+	it( 'should get the correct refund amount with multiple refunds', () => {
+		expect( getOrderRefundTotal( orderWithRefunds ) ).to.eql( -25.0 );
+	} );
+} );
+
+describe( 'getOrderShippingTotal', () => {
+	it( 'should be a function', () => {
+		expect( getOrderShippingTotal ).to.be.a( 'function' );
+	} );
+
+	it( 'should get the correct shipping amount', () => {
+		expect( getOrderShippingTotal( orderWithTax ) ).to.eql( 10 );
+	} );
+
+	it( 'should return 0 if there is no shipping', () => {
+		expect( getOrderShippingTotal( orderWithoutTax ) ).to.eql( 0 );
+	} );
+} );
+
+describe( 'getOrderSubtotal', () => {
+	it( 'should be a function', () => {
+		expect( getOrderSubtotal ).to.be.a( 'function' );
+	} );
+
+	it( 'should get the sum of line_item totals', () => {
+		expect( getOrderSubtotal( orderWithTax ) ).to.eql( 67.98 );
+	} );
+
+	it( 'should get the sum of line_item totals regardless of coupons', () => {
+		expect( getOrderSubtotal( orderWithCoupons ) ).to.eql( 81.97 );
+	} );
+
+	it( 'should return 0 if there are no line_items', () => {
+		expect( getOrderSubtotal( { line_items: [] } ) ).to.eql( 0 );
+	} );
+} );

--- a/client/extensions/woocommerce/lib/order-values/test/totals.js
+++ b/client/extensions/woocommerce/lib/order-values/test/totals.js
@@ -136,11 +136,11 @@ describe( 'getOrderTotal', () => {
 	} );
 
 	it( 'should get the sum of line_item totals', () => {
-		expect( getOrderTotal( orderWithTax ).toFixed( 2 ) ).to.eql( '62.98' );
+		expect( getOrderTotal( orderWithTax ).toFixed( 2 ) ).to.eql( '64.51' );
 	} );
 
 	it( 'should get the sum of line_item totals regardless of coupons', () => {
-		expect( getOrderTotal( orderWithCoupons ).toFixed( 2 ) ).to.eql( '59.67' );
+		expect( getOrderTotal( orderWithCoupons ).toFixed( 2 ) ).to.eql( '74.67' );
 	} );
 
 	it( 'should return 0 if there is nothing in the order', () => {

--- a/client/extensions/woocommerce/lib/order-values/test/totals.js
+++ b/client/extensions/woocommerce/lib/order-values/test/totals.js
@@ -14,7 +14,7 @@ import {
 	getOrderRefundTotal,
 	getOrderShippingTotal,
 	getOrderSubtotal,
-	// getOrderTotal,
+	getOrderTotal,
 } from '../totals';
 import orderWithTax from './fixtures/order';
 import orderWithoutTax from './fixtures/order-no-tax';
@@ -108,5 +108,23 @@ describe( 'getOrderSubtotal', () => {
 
 	it( 'should return 0 if there are no line_items', () => {
 		expect( getOrderSubtotal( { line_items: [] } ) ).to.eql( 0 );
+	} );
+} );
+
+describe( 'getOrderTotal', () => {
+	it( 'should be a function', () => {
+		expect( getOrderTotal ).to.be.a( 'function' );
+	} );
+
+	it( 'should get the sum of line_item totals', () => {
+		expect( getOrderTotal( orderWithTax ).toFixed( 2 ) ).to.eql( '62.98' );
+	} );
+
+	it( 'should get the sum of line_item totals regardless of coupons', () => {
+		expect( getOrderTotal( orderWithCoupons ).toFixed( 2 ) ).to.eql( '59.67' );
+	} );
+
+	it( 'should return 0 if there is nothing in the order', () => {
+		expect( getOrderTotal( { line_items: [] } ) ).to.eql( 0 );
 	} );
 } );

--- a/client/extensions/woocommerce/lib/order-values/totals.js
+++ b/client/extensions/woocommerce/lib/order-values/totals.js
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import { get, reduce } from 'lodash';
+import { find, get, reduce } from 'lodash';
 
 /**
  * Get the total for the discount value
@@ -14,6 +14,20 @@ export function getOrderDiscountTotal( order ) {
 	const coupons = get( order, 'coupon_lines', [] );
 	const total = reduce( coupons, ( sum, value ) => sum + parseFloat( value.discount ), 0 );
 	return parseFloat( total ) || 0;
+}
+
+/**
+ * Get the individual price for a given item, pre-discounts.
+ *
+ * @param {Object} order An order as returned from API
+ * @param {Number} id The ID of the line_item
+ * @return {Float} Total amount as a decimal number
+ */
+export function getOrderItemCost( order, id ) {
+	const item = find( get( order, 'line_items', [] ), { id } );
+	const subtotal = parseFloat( get( item, 'subtotal', 0 ) ) || 0;
+	const qty = parseFloat( get( item, 'quantity', 1 ) ) || 1;
+	return subtotal / qty;
 }
 
 /**

--- a/client/extensions/woocommerce/lib/order-values/totals.js
+++ b/client/extensions/woocommerce/lib/order-values/totals.js
@@ -82,9 +82,10 @@ export function getOrderSubtotal( order ) {
  */
 export function getOrderTotal( order ) {
 	const discount = getOrderDiscountTotal( order );
+	const fees = getOrderFeeTotal( order );
 	const refunds = getOrderRefundTotal( order );
 	const shipping = getOrderShippingTotal( order );
 	const subtotal = getOrderSubtotal( order );
 	// Refunds are negative, but discounts are not
-	return subtotal - discount + shipping + refunds;
+	return subtotal - discount + fees + shipping + refunds;
 }

--- a/client/extensions/woocommerce/lib/order-values/totals.js
+++ b/client/extensions/woocommerce/lib/order-values/totals.js
@@ -17,6 +17,17 @@ export function getOrderDiscountTotal( order ) {
 }
 
 /**
+ * Get the fee total on a given order
+ *
+ * @param {Object} order An order as returned from API
+ * @return {Float} The total fee amount as a decimal number
+ */
+export function getOrderFeeTotal( order ) {
+	const fees = get( order, 'fee_lines', [] );
+	return reduce( fees, ( sum, value ) => sum + parseFloat( value.total ), 0 );
+}
+
+/**
  * Get the individual price for a given item, pre-discounts.
  *
  * @param {Object} order An order as returned from API

--- a/client/extensions/woocommerce/lib/order-values/totals.js
+++ b/client/extensions/woocommerce/lib/order-values/totals.js
@@ -1,0 +1,65 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { get, reduce } from 'lodash';
+
+/**
+ * Get the total for the discount value
+ *
+ * @param {Object} order An order as returned from API
+ * @return {Float} Total amount as a decimal number
+ */
+export function getOrderDiscountTotal( order ) {
+	const coupons = get( order, 'coupon_lines', [] );
+	const total = reduce( coupons, ( sum, value ) => sum + parseFloat( value.discount ), 0 );
+	return parseFloat( total ) || 0;
+}
+
+/**
+ * Get the refund value on a given order
+ *
+ * @param {Object} order An order as returned from API
+ * @return {Float} The refund amount as a decimal number
+ */
+export function getOrderRefundTotal( order ) {
+	const refunds = get( order, 'refunds', [] );
+	return reduce( refunds, ( sum, value ) => sum + parseFloat( value.total ), 0 );
+}
+
+/**
+ * Get the total for the shipping value
+ *
+ * @param {Object} order An order as returned from API
+ * @return {Float} Total amount as a decimal number
+ */
+export function getOrderShippingTotal( order ) {
+	const shipping = get( order, 'shipping_lines', [] );
+	return reduce( shipping, ( sum, value ) => sum + parseFloat( value.total ), 0 );
+}
+
+/**
+ * Get the total for the subtotal value (total of all line items)
+ *
+ * @param {Object} order An order as returned from API
+ * @return {Float} Total amount as a decimal number
+ */
+export function getOrderSubtotal( order ) {
+	const items = get( order, 'line_items', [] );
+	return reduce( items, ( sum, value ) => sum + parseFloat( value.subtotal ), 0 );
+}
+
+/**
+ * Get the total value on a given order
+ *
+ * @param {Object} order An order as returned from API
+ * @return {Float} The total amount as a decimal number
+ */
+export function getOrderTotal( order ) {
+	const discount = getOrderDiscountTotal( order );
+	const refunds = getOrderRefundTotal( order );
+	const shipping = getOrderShippingTotal( order );
+	const subtotal = getOrderSubtotal( order );
+	// Refunds are negative, but discounts are not
+	return subtotal - discount + shipping + refunds;
+}


### PR DESCRIPTION
This PR adds a new file in the `order-values` lib which contains functions to get totals for a given order. I've also updated the tests to contain all the relevant line-item data, based off real (testing) order API data.

The new functions are:

	getOrderDiscountTotal
	getOrderShippingTotal
	getOrderSubtotal
	getOrderTotal
	getOrderItemCost

- `getOrderRefundTotal` & `getOrderFeeTotal` already exist and are just moved into the new file, the other functions are new. These fetch the total costs for each thing (discount, fees, refunds, etc) without tax.
- `getOrderTotal` uses these to tally the cost of an order before tax (and can be used with `getOrderTotalTax` to get the complete cost of an order).
- `getOrderItemCost` gets the cost of a single item before tax and discounts, which is used when changing quantity.

These are needed for editing an order (and eventually creating an order), where we might change parts of an order (quantity of product, adding fees), and we need to re-calculate the order total.

**To test**

- Run the tests: `npm run test-client client/extensions/woocommerce/lib/order-values`

_(Note: this is branched off #18729, but there are no functionality changes here.)_