### PR TITLE
PostItem: Update visited color

### DIFF
--- a/client/blocks/post-item/style.scss
+++ b/client/blocks/post-item/style.scss
@@ -85,7 +85,8 @@
 	}
 }
 
-a.post-item__title-link {
+a.post-item__title-link,
+a.post-item__title-link:visited {
 	color: $gray-dark;
 
 	&:hover {


### PR DESCRIPTION
Fixes #18935

This PR updates the styles for `PostItem` to also specify the color for visited items such that it matches non-visited items.