### PR TITLE
Site Settings: Add Troubleshoot section to Disconnect JP Flow

### DIFF
--- a/client/jetpack-connect/happychat-button.jsx
+++ b/client/jetpack-connect/happychat-button.jsx
@@ -26,6 +26,7 @@ const JetpackConnectHappychatButton = ( {
 	isChatAvailable,
 	isLoggedIn,
 	label,
+	onClick,
 	translate,
 } ) => {
 	if ( ! isEnabled( 'jetpack/happychat' ) || ! isLoggedIn ) {
@@ -43,8 +44,9 @@ const JetpackConnectHappychatButton = ( {
 
 	return (
 		<HappychatButton
-			className="logged-out-form__link-item jetpack-connect__happychat-button"
 			borderless={ false }
+			className="logged-out-form__link-item jetpack-connect__happychat-button"
+			onClick={ onClick }
 		>
 			<HappychatConnection />
 			<Gridicon icon="chat" /> { label || translate( 'Get help connecting your site' ) }
@@ -54,6 +56,7 @@ const JetpackConnectHappychatButton = ( {
 
 JetpackConnectHappychatButton.propTypes = {
 	label: PropTypes.string,
+	onClick: PropTypes.func,
 };
 
 export default connect( state => ( {

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -3,13 +3,6 @@
 
 	.logged-out-form__links {
 		max-width: 100%;
-
-		.logged-out-form__link-item {
-			.gridicon {
-				position: relative;
-				top: 4px;
-			}
-		}
 	}
 
 	.formatted-header{
@@ -35,13 +28,6 @@
 	.logged-out-form__links {
 		margin-top: 15px;
 		text-align: center;
-
-		.logged-out-form__link-item {
-			.gridicon {
-				position: relative;
-				top: 4px;
-			}
-		}
 
 		.jetpack-connect__happychat-button {
 			text-align: center;
@@ -485,6 +471,8 @@
 	.gridicon {
 		width: 18px;
 		height: 18px;
+		position: relative;
+		top: 4px;
 	}
 }
 
@@ -550,13 +538,6 @@
 	.logged-out-form__links,
 	.jetpack-connect__happychat-button {
 		text-align: center;
-	}
-
-	.logged-out-form__link-item {
-		.gridicon {
-			position: relative;
-			top: 4px;
-		}
 	}
 }
 

--- a/client/my-sites/site-settings/disconnect-site/index.jsx
+++ b/client/my-sites/site-settings/disconnect-site/index.jsx
@@ -6,6 +6,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { flowRight, get } from 'lodash';
 import { localize } from 'i18n-calypso';
+
 /**
  * Internal dependencies
  */
@@ -13,6 +14,7 @@ import DisconnectSurvey from './disconnect-survey';
 import MissingFeature from './missing-feature';
 import TooDifficult from './too-difficult';
 import TooExpensive from './too-expensive';
+import Troubleshoot from './troubleshoot';
 import DocumentHead from 'components/data/document-head';
 import FormattedHeader from 'components/formatted-header';
 import NavigationLink from 'components/wizard/navigation-link';
@@ -55,6 +57,7 @@ const DisconnectSite = ( { reason, siteSlug, translate } ) => {
 					<NavigationLink href={ backHref } direction="back" />
 					<NavigationLink href={ confirmHref } direction="forward" />
 				</div>
+				<Troubleshoot />
 			</Main>
 		</div>
 	);

--- a/client/my-sites/site-settings/disconnect-site/style.scss
+++ b/client/my-sites/site-settings/disconnect-site/style.scss
@@ -29,3 +29,11 @@
 		float: right;
 	}
 }
+
+// 'Troubleshooting' section
+.disconnect-site__troubleshooting {
+	.jetpack-connect__happychat-button,
+	.jetpack-connect__help-button {
+		text-align: center;
+	}
+}

--- a/client/my-sites/site-settings/disconnect-site/troubleshoot.jsx
+++ b/client/my-sites/site-settings/disconnect-site/troubleshoot.jsx
@@ -1,0 +1,40 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Button from 'components/button';
+import CompactCard from 'components/card/compact';
+import FoldableCard from 'components/foldable-card';
+import FormTextInput from 'components/forms/form-text-input';
+import SectionHeader from 'components/section-header';
+import { openChat as openChatAction } from 'state/happychat/ui/actions';
+import { getSelectedSiteSlug } from 'state/ui/selectors';
+
+const Troubleshoot = ( { openChat, siteSlug, translate } ) => (
+	<div className="disconnect-site__troubleshooting">
+		<SectionHeader label={ translate( 'Having problems with your connection?' ) } />
+		<CompactCard href={ 'https://jetpack.com/support/debug/?url=' + siteSlug } target="_blank">
+			{ translate( 'Diagnose a connection problem' ) }
+		</CompactCard>
+		<FoldableCard header={ translate( 'Get help from our Happiness Engineers' ) }>
+			<FormTextInput />
+			<Button primary compact onClick={ openChat }>
+				{ translate( 'Start Chat' ) }
+			</Button>
+		</FoldableCard>
+	</div>
+);
+
+export default connect(
+	state => ( {
+		siteSlug: getSelectedSiteSlug( state ),
+	} ),
+	{ openChat: openChatAction }
+)( localize( Troubleshoot ) );

--- a/client/my-sites/site-settings/disconnect-site/troubleshoot.jsx
+++ b/client/my-sites/site-settings/disconnect-site/troubleshoot.jsx
@@ -14,6 +14,8 @@ import CompactCard from 'components/card/compact';
 import FoldableCard from 'components/foldable-card';
 import FormTextInput from 'components/forms/form-text-input';
 import SectionHeader from 'components/section-header';
+import JetpackConnectHappychatButton from 'jetpack-connect/happychat-button';
+import HelpButton from 'jetpack-connect/help-button';
 import { openChat as openChatAction } from 'state/happychat/ui/actions';
 import { getSelectedSiteSlug } from 'state/ui/selectors';
 
@@ -29,6 +31,10 @@ const Troubleshoot = ( { openChat, siteSlug, translate } ) => (
 				{ translate( 'Start Chat' ) }
 			</Button>
 		</FoldableCard>
+
+		<JetpackConnectHappychatButton label={ translate( 'Get help from our Happiness Engineers' ) }>
+			<HelpButton label={ translate( 'Get help from our Happiness Engineers' ) } />
+		</JetpackConnectHappychatButton>
 	</div>
 );
 

--- a/client/my-sites/site-settings/disconnect-site/troubleshoot.jsx
+++ b/client/my-sites/site-settings/disconnect-site/troubleshoot.jsx
@@ -9,38 +9,26 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import Button from 'components/button';
-import CompactCard from 'components/card/compact';
-import FoldableCard from 'components/foldable-card';
-import FormTextInput from 'components/forms/form-text-input';
-import SectionHeader from 'components/section-header';
 import JetpackConnectHappychatButton from 'jetpack-connect/happychat-button';
 import HelpButton from 'jetpack-connect/help-button';
-import { openChat as openChatAction } from 'state/happychat/ui/actions';
-import { getSelectedSiteSlug } from 'state/ui/selectors';
+import { recordTracksEvent, withAnalytics } from 'state/analytics/actions';
 
-const Troubleshoot = ( { openChat, siteSlug, translate } ) => (
+const Troubleshoot = ( { trackSupportClick, translate } ) => (
 	<div className="disconnect-site__troubleshooting">
-		<SectionHeader label={ translate( 'Having problems with your connection?' ) } />
-		<CompactCard href={ 'https://jetpack.com/support/debug/?url=' + siteSlug } target="_blank">
-			{ translate( 'Diagnose a connection problem' ) }
-		</CompactCard>
-		<FoldableCard header={ translate( 'Get help from our Happiness Engineers' ) }>
-			<FormTextInput />
-			<Button primary compact onClick={ openChat }>
-				{ translate( 'Start Chat' ) }
-			</Button>
-		</FoldableCard>
-
-		<JetpackConnectHappychatButton label={ translate( 'Get help from our Happiness Engineers' ) }>
-			<HelpButton label={ translate( 'Get help from our Happiness Engineers' ) } />
+		<JetpackConnectHappychatButton
+			label={ translate( 'Get help from our Happiness Engineers' ) }
+			onClick={ trackSupportClick }
+		>
+			<HelpButton
+				label={ translate( 'Get help from our Happiness Engineers' ) }
+				onClick={ trackSupportClick }
+			/>
 		</JetpackConnectHappychatButton>
 	</div>
 );
 
-export default connect(
-	state => ( {
-		siteSlug: getSelectedSiteSlug( state ),
-	} ),
-	{ openChat: openChatAction }
-)( localize( Troubleshoot ) );
+export default connect( null, {
+	trackSupportClick: withAnalytics(
+		recordTracksEvent( 'calypso_jetpack_disconnect_support_click' )
+	),
+} )( localize( Troubleshoot ) );

--- a/client/state/analytics/README.md
+++ b/client/state/analytics/README.md
@@ -3,15 +3,15 @@
 ## Overview
 
 Analytics track things. By their very nature they are side-effecting actions, usually by sending API calls to one or more analytics servers.
- 
+
 Calypso supports a variety of analytics methods including (but not limited to) Google Analytics, stat bumping, and Tracks events.
- 
+
 As we develop the different view components in React for Calypso, we should work hard to keep them as pure and simple as they can be. This brings with it many benefits, including the ability to easily test those components. Calling out these side-effecting operations can break those tests among other things.
- 
+
 _**Middleware**_ is a stage in the **Redux** pipeline that runs between dispatching an action and when that action runs through the reducers. By incorporating the side-effecting operations at this point, we decouple those breaking effects from the other parts of the app.
- 
+
 This module provides just such a middleware: it allows React components to now fire off Redux actions indicating the _intent_ to send an analytics metric instead of actually sending it, keeping the otherwise-unreleted dependencies out of the components.
- 
+
 ## Usage
 
 As this middleware follows the [Flux Standard Action](https://github.com/acdlite/flux-standard-action) pattern, you can start tracking analytics simply by adding a new `meta` block to your existing actions. A helper function `withAnalytics()` is provided to make this easy.
@@ -51,8 +51,8 @@ dispatch( withAnalytics(
 
 // passed as a component prop
 const trackSelection =
-    withAnalytics( recordTrackEvent( 'selected_page', { 'page': 'somePage' } ) );
-    
+    withAnalytics( recordTracksEvent( 'selected_page', { page: 'somePage' } ) );
+
 const mapDispatchToProps = {
     selectPage: trackSelection( selectPage ),
     recordPageLoad: bumpStat( 'page_loaded', 'page_selected_page' )
@@ -65,7 +65,7 @@ const mapDispatchToProps = {
 `composeAnalytics( ...analytics )`: Combines analytics actions by themselves into one mutli-analytic-tracking action.
 
 `withAnalytics :: Object -> ( Object | function ) -> ( Object | function )`<br />
-`withAnalytics( analytics, action )`: Combines analytics action with other action. Can be called with two arguments, which returns a new action, or with only an `analytics` action, which returns a new function of a single argument taking an action. This curried form is useful for reusing a single analytics action with multiple other actions. 
+`withAnalytics( analytics, action )`: Combines analytics action with other action. Can be called with two arguments, which returns a new action, or with only an `analytics` action, which returns a new function of a single argument taking an action. This curried form is useful for reusing a single analytics action with multiple other actions.
 
 `bumpStat :: String -> String -> Object`<br />
 `bumpStat( group, name )`: Creates an action to bump the stat with given group and name.
@@ -83,7 +83,7 @@ const mapDispatchToProps = {
 `recordGooglePageView( url, title )`: Creates an action to record a page view in Google Analytics.
 
 `loadTrackingTool :: String -> String -> Object`<br />
-`loadTrackingTool ( trackingTool )`: Creates an action to load a tracking tool that gets attached to the DOM on component mount. Pass tracking tool reference through to middleware and manage loading scripts there. 
+`loadTrackingTool ( trackingTool )`: Creates an action to load a tracking tool that gets attached to the DOM on component mount. Pass tracking tool reference through to middleware and manage loading scripts there.
 
 ### Internal Helpers
 
@@ -93,4 +93,4 @@ These can be used in client code but are intended to be used internally within t
 `recordEvent( service, args )`: Used to create event-tracking action-creators. The actions will be dispatched based on the `service` name and passed the `args` in the action payload.
 
 `recordPageView :: String -> String -> String* -> Object`<br />
-`recordPageView( url, title, service* )`: Creates an action to record a page view. If service is omitted, the default behavior is to record in both Google Analytics _and_ in Tracks. 
+`recordPageView( url, title, service* )`: Creates an action to record a page view. If service is omitted, the default behavior is to record in both Google Analytics _and_ in Tracks.


### PR DESCRIPTION
Add a button to get help (either via HappyChat, or the contact form). Implement the mockup found at https://github.com/Automattic/wp-calypso/pull/17962#issuecomment-328552222. Note that I've opted to stick with that mockup instead of https://github.com/Automattic/wp-calypso/pull/17962#issuecomment-334140696, since it's more consistent with prior art, such as #18397.

This PR uses `jetpack-connect/happychat-button`, to which it adds an `onClick` prop in order to be able to pass the tracking event to it. It unifies some styling that was previously scattered across three different selectors, which ensures that the styling also works for this PR without having to add a fourth selector. (Bonus points for verifying that the styling still works for the other instances -- see testing instructions for #18397.)

It also fixes the `state/analytics` README which I consulted while writing this PR :slightly_smiling_face:

Discussion about functionality (what each button is supposed to do) is at https://github.com/Automattic/wp-calypso/pull/17962#issuecomment-334140696.

![image](https://user-images.githubusercontent.com/96308/32023659-3a2d3aea-b9da-11e7-8b66-b251a9eef8c3.png)

**Question:** Is the Tracks event naming okay? Do we want it to include more information? Do we want distinct events for Happychat vs Contact form?

### To test:

* Navigate to `/settings/disconnect-site/:site`
* In the browser console, enter `localStorage.setItem( 'debug', 'calypso:analytics*' )`, and reload.
* Note the Gridicon next to 'Get help from our Happiness Engineers'
  * If it is a question mark (like in the above screenshot), it will open `https://jetpack.com/contact-support/` in a new tab.
  * Verify in the browser console that a `calypso_jetpack_disconnect_support_click` event is tracked.
* Now in order to force the help link to open Happychat, enter the following into your browser console:

```
dispatch( { type: 'HAPPYCHAT_CONNECTED', user: { geoLocation: 'Anywhere' } } );
dispatch( { type: 'HAPPYCHAT_SET_AVAILABLE', isAvailable: true } );
```

* Note that the Gridicon next to 'Get help from our Happiness Engineers' changes to a speech bubble
* Click the link and verify that it opens a Happychat window
* Also verify that a `calypso_jetpack_disconnect_support_click` event is tracked.

### Follow-up work (future PRs):
* Add `Diagnose a connection problem` button, point to `'https://jetpack.com/support/debug/?url=' + siteSlug`.
* Bundle `JetpackConnectHappychatButton` and `HelpButton` into a unified, reusable component.