### PR TITLE
Forward geo location header in user bootstrap requests

### DIFF
--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -256,7 +256,7 @@ function setUpLoggedOutRoute( req, res, next ) {
 }
 
 function setUpLoggedInRoute( req, res, next ) {
-	let redirectUrl, protocol, start;
+	let redirectUrl, start;
 
 	res.set( {
 		'X-Frame-Options': 'SAMEORIGIN',
@@ -267,7 +267,8 @@ function setUpLoggedInRoute( req, res, next ) {
 	if ( config.isEnabled( 'wpcom-user-bootstrap' ) ) {
 		const user = require( 'user-bootstrap' );
 
-		protocol = req.get( 'X-Forwarded-Proto' ) === 'https' ? 'https' : 'http';
+		const geoCountry = req.get[ 'x-geoip-country-code' ] || '';
+		const protocol = req.get( 'X-Forwarded-Proto' ) === 'https' ? 'https' : 'http';
 
 		redirectUrl = login( {
 			isNative: config.isEnabled( 'login/native-login-links' ),
@@ -284,7 +285,7 @@ function setUpLoggedInRoute( req, res, next ) {
 		start = new Date().getTime();
 
 		debug( 'Issuing API call to fetch user object' );
-		user( req.cookies.wordpress_logged_in, function( error, data ) {
+		user( req.cookies.wordpress_logged_in, geoCountry, function( error, data ) {
 			let searchParam, errorMessage;
 
 			if ( error ) {

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -267,7 +267,7 @@ function setUpLoggedInRoute( req, res, next ) {
 	if ( config.isEnabled( 'wpcom-user-bootstrap' ) ) {
 		const user = require( 'user-bootstrap' );
 
-		const geoCountry = req.get[ 'x-geoip-country-code' ] || '';
+		const geoCountry = req.get( 'x-geoip-country-code' ) || '';
 		const protocol = req.get( 'X-Forwarded-Proto' ) === 'https' ? 'https' : 'http';
 
 		redirectUrl = login( {

--- a/server/user-bootstrap/index.js
+++ b/server/user-bootstrap/index.js
@@ -12,7 +12,7 @@ var config = require( 'config' ),
 	*/
 	url = 'https://public-api.wordpress.com/rest/v1/me?meta=flags';
 
-module.exports = function( authCookieValue, callback ) {
+module.exports = function( authCookieValue, geoCountry, callback ) {
 	// create HTTP Request object
 	var req = superagent.get( url ),
 		hmac,
@@ -30,6 +30,7 @@ module.exports = function( authCookieValue, callback ) {
 		hmac.update( authCookieValue );
 		hash = hmac.digest( 'hex' );
 
+		req.set( 'X-Forwarded-GeoIP-Country-Code', geoCountry );
 		req.set( 'Authorization', 'X-WPCALYPSO ' + hash );
 		req.set( 'Cookie', AUTH_COOKIE_NAME + '=' + authCookieValue );
 		req.set( 'User-Agent', 'WordPress.com Calypso' );


### PR DESCRIPTION
This PR forwards the geo-location country code in the user bootstrap request. 

This will ensure that the user object contains the correct geo code, and not the one set by the server IP.

**Testing:**
 this can be tested in *docker mode* with the public API sandboxed: 
- Add a `x-geoip-country-code` header to your initial request, with a value other than your local ip country code
- check that the return value for the bootstrap request has the country value in the `user_ip_country_code` key. 

  