### PR TITLE
PrivacyPolicy-TOS: data-layer

### DIFF
--- a/client/state/data-layer/wpcom/index.js
+++ b/client/state/data-layer/wpcom/index.js
@@ -14,6 +14,7 @@ import me from './me';
 import meta from './meta';
 import plans from './plans';
 import posts from './posts';
+import privacyPolicy from './privacy-policy';
 import read from './read';
 import sites from './sites';
 import timezones from './timezones';
@@ -32,6 +33,7 @@ export const handlers = mergeHandlers(
 	meta,
 	plans,
 	posts,
+	privacyPolicy,
 	read,
 	sites,
 	timezones,

--- a/client/state/data-layer/wpcom/privacy-policy/index.js
+++ b/client/state/data-layer/wpcom/privacy-policy/index.js
@@ -1,0 +1,35 @@
+/**
+ * External dependencies
+ *
+ * @format
+ */
+import { get } from 'lodash';
+/**
+ * Internal dependencies
+ */
+import { http } from 'state/data-layer/wpcom-http/actions';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
+import { PRIVACY_POLICY_REQUEST } from 'state/action-types';
+import { privacyPolicyReceive } from 'state/privacy-policy/actions';
+
+/*
+ * Start a request to WordPress.com server to get the privacy policy data
+ */
+export const fetchPrivacyPolicy = ( { dispatch }, action ) =>
+	dispatch(
+		http(
+			{
+				method: 'GET',
+				path: '/privacy-policy',
+				apiNamespace: 'wpcom/v2',
+			},
+			action
+		)
+	);
+
+export const addPrivacyPolicy = ( { dispatch }, action, data ) =>
+	dispatch( privacyPolicyReceive( get( data, 'entities', {} ) ) );
+
+export default {
+	[ PRIVACY_POLICY_REQUEST ]: [ dispatchRequest( fetchPrivacyPolicy, addPrivacyPolicy ) ],
+};

--- a/client/state/data-layer/wpcom/privacy-policy/test/index.js
+++ b/client/state/data-layer/wpcom/privacy-policy/test/index.js
@@ -1,0 +1,58 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+import { spy } from 'sinon';
+
+/**
+ * Internal dependencies
+ */
+import { addPrivacyPolicy, fetchPrivacyPolicy } from '../';
+import { http } from 'state/data-layer/wpcom-http/actions';
+import { privacyPolicyReceive } from 'state/privacy-policy/actions';
+
+describe( 'privacy-policy request', () => {
+	describe( 'successful requests', () => {
+		test( 'should dispatch HTTP GET request to /privacy-policy endpoint', () => {
+			const action = { type: 'DUMMY' };
+			const dispatch = spy();
+
+			fetchPrivacyPolicy( { dispatch }, action );
+
+			expect( dispatch ).to.have.been.calledOnce;
+			expect( dispatch ).to.have.been.calledWith(
+				http(
+					{
+						apiNamespace: 'wpcom/v2',
+						method: 'GET',
+						path: '/privacy-policy',
+					},
+					action
+				)
+			);
+		} );
+	} );
+
+	describe( '#addPrivacyPolicy', () => {
+		test( 'should dispatch privacy-policy receive', () => {
+			const responseData = {
+				count: 1,
+				entities: {
+					automattic: {
+						id: 'automattic_privacy_policy_v1',
+						title: 'Automattic Privacy Policy',
+					},
+				},
+			};
+
+			const action = privacyPolicyReceive( responseData );
+			const dispatch = spy();
+
+			addPrivacyPolicy( { dispatch }, action, responseData );
+
+			expect( dispatch ).to.have.been.calledOncee;
+			expect( dispatch ).to.have.been.calledWith( privacyPolicyReceive( responseData.entities ) );
+		} );
+	} );
+} );


### PR DESCRIPTION
~This patch depends on #18975 and it shouldn't be merged before to this.~
-------------------------------------------------------------------------

It implements the data-layer for the privacy policy endpoint. It's part the Privacy Policy implementation. Take a look at #18980 to get the whole idea.

### Testing

```cli
> npm run test-client client/state/data-layer/wpcom/privacy-policy/test/index.js
```

<img src="https://user-images.githubusercontent.com/77539/32215612-b68ce472-be22-11e7-9c86-a3f961c05613.png" width="600px" />