### PR TITLE
PrivacyPolicy-TOS: add add query component

### DIFF
--- a/client/components/data/query-privacy-policy/index.jsx
+++ b/client/components/data/query-privacy-policy/index.jsx
@@ -1,0 +1,30 @@
+/**
+ * External dependencies
+ *
+ * @format
+ */
+
+import PropTypes from 'prop-types';
+import { Component } from 'react';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import { requestPrivacyPolicy } from 'state/privacy-policy/actions';
+
+export class QueryPrivacyPolicy extends Component {
+	static propTypes = {
+		requestPrivacyPolicy: PropTypes.func,
+	};
+
+	componentDidMount() {
+		this.props.requestPrivacyPolicy();
+	}
+
+	render() {
+		return null;
+	}
+}
+
+export default connect( null, { requestPrivacyPolicy } )( QueryPrivacyPolicy );


### PR DESCRIPTION
This patch adds a data-component to get query the privacy policy data. Please take a look to #18980 to get the whole functionality of this approach.