### PR TITLE
PrivacyPolicy-TOS: add PrivacyPolicyBanner component

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -54,6 +54,7 @@
 @import 'blocks/post-share/style';
 @import 'blocks/post-status/style';
 @import 'blocks/post-time/style';
+@import 'blocks/privacy-policy-banner/style';
 @import 'blocks/reader-author-link/style';
 @import 'blocks/reader-avatar/style';
 @import 'blocks/reader-combined-card/style';

--- a/client/blocks/privacy-policy-banner/constants.js
+++ b/client/blocks/privacy-policy-banner/constants.js
@@ -1,0 +1,3 @@
+
+export const AUTOMATTIC_ENTITY = 'automattic';
+export const PRIVACY_POLICY_PREFERENCE = 'privacy_policy';

--- a/client/blocks/privacy-policy-banner/index.jsx
+++ b/client/blocks/privacy-policy-banner/index.jsx
@@ -15,6 +15,7 @@ import { get, identity } from 'lodash';
 import { getPreference, isFetchingPreferences } from 'state/preferences/selectors';
 import { savePreference } from 'state/preferences/actions';
 import Banner from 'components/banner';
+import config from 'config';
 import PrivacyPolicyDialog from './privacy-policy-dialog';
 import QueryPrivacyPolicy from 'components/data/query-privacy-policy';
 import { getPrivacyPolicyByEntity } from 'state/selectors';
@@ -73,6 +74,10 @@ class PrivacyPolicyBanner extends Component {
 	};
 
 	render() {
+		if ( ! config.isEnabled( 'privacy-policy' ) ) {
+			return null;
+		}
+
 		const {
 			fetchingPreferences,
 			isPolicyAlreadyAccepted,
@@ -86,14 +91,18 @@ class PrivacyPolicyBanner extends Component {
 		}
 
 		// check if the user has already accepted/read the privacy policy.
-		if ( isPolicyAlreadyAccepted === true ) {
+		if ( isPolicyAlreadyAccepted === true && ! config.isEnabled( 'privacy-policy/test' ) ) {
 			return <QueryPrivacyPolicy />;
 		}
 
 		// check if the current policy is under the notification period.
 		const notifyFrom = moment( get( privacyPolicy, 'notification_period.from' ) );
 		const notifyTo = moment( get( privacyPolicy, 'notification_period.to' ) );
-		if ( ! notifyFrom.isBefore() || ! notifyTo.isAfter() ) {
+
+		if (
+			( ! notifyFrom.isBefore() || ! notifyTo.isAfter() ) &&
+			! config.isEnabled( 'privacy-policy/test' )
+		) {
 			return <QueryPrivacyPolicy />;
 		}
 
@@ -115,7 +124,6 @@ class PrivacyPolicyBanner extends Component {
 					content={ privacyPolicy.content }
 					title={ privacyPolicy.title }
 					version={ privacyPolicy.id }
-
 					onClose={ this.closePrivacyPolicyDialog }
 					onDismiss={ this.closePrivacyPolicyDialog }
 				/>

--- a/client/blocks/privacy-policy-banner/index.jsx
+++ b/client/blocks/privacy-policy-banner/index.jsx
@@ -43,6 +43,13 @@ class PrivacyPolicyBanner extends Component {
 		this.props.acceptPrivacyPolicy( privacyPolicyId, privacyPolicyState );
 	};
 
+	openPrivacyPolicyDialog = () => this.setState( { showDialog: true } );
+
+	closePrivacyPolicyDialog = () => {
+		this.setState( { showDialog: false } );
+		this.acceptUpdates();
+	};
+
 	getDescription( date ) {
 		const { moment, translate } = this.props;
 

--- a/client/blocks/privacy-policy-banner/index.jsx
+++ b/client/blocks/privacy-policy-banner/index.jsx
@@ -15,6 +15,7 @@ import { getPreference, isFetchingPreferences } from 'state/preferences/selector
 import { savePreference } from 'state/preferences/actions';
 import { identity } from 'lodash';
 import Banner from 'components/banner';
+import PrivacyPolicyDialog from './privacy-policy-dialog';
 import QueryPrivacyPolicy from 'components/data/query-privacy-policy';
 import { getPrivacyPolicyByEntity } from 'state/selectors';
 import { AUTOMATTIC_ENTITY, PRIVACY_POLICY_PREFERENCE } from './constants';
@@ -32,6 +33,10 @@ class PrivacyPolicyBanner extends Component {
 		privacyPolicy: {},
 		text: '',
 		translate: identity,
+	};
+
+	state = {
+		showDialog: false,
 	};
 
 	acceptUpdates = () => {
@@ -60,6 +65,13 @@ class PrivacyPolicyBanner extends Component {
 		} );
 	}
 
+	openPrivacyPolicyDialog = () => this.setState( { showDialog: true } );
+
+	closePrivacyPolicyDialog = () => {
+		this.setState( { showDialog: false } );
+		this.acceptUpdates();
+	};
+
 	render() {
 		const { fetchingPreferences, isPolicyAlreadyAccepted, translate } = this.props;
 
@@ -74,15 +86,24 @@ class PrivacyPolicyBanner extends Component {
 		return (
 			<div className="privacy-policy-banner">
 				<QueryPrivacyPolicy />
+
 				<Banner
 					callToAction={ translate( 'Learn More' ) }
 					description={ this.getDescription( this.props.privacyPolicy.modified ) }
 					disableHref={ true }
 					icon="pages"
-					href="https://automattic.com/privacy/"
-					target="_blank"
-					onClick={ this.acceptUpdates }
+					onClick={ this.openPrivacyPolicyDialog }
 					title={ translate( 'Privacy Policy Updates.' ) }
+				/>
+
+				<PrivacyPolicyDialog
+					isVisible={ this.state.showDialog }
+					content={ this.props.privacyPolicy.content }
+					title={ this.props.privacyPolicy.title }
+					version={ this.props.privacyPolicy.id }
+
+					onClose={ this.closePrivacyPolicyDialog }
+					onDismiss={ this.closePrivacyPolicyDialog }
 				/>
 			</div>
 		);

--- a/client/blocks/privacy-policy-banner/index.jsx
+++ b/client/blocks/privacy-policy-banner/index.jsx
@@ -78,21 +78,17 @@ class PrivacyPolicyBanner extends Component {
 			return null;
 		}
 
-		const {
-			fetchingPreferences,
-			isPolicyAlreadyAccepted,
-			moment,
-			privacyPolicy,
-			translate,
-		} = this.props;
-
-		if ( fetchingPreferences ) {
+		if ( this.props.fetchingPreferences ) {
 			return null;
 		}
 
+		const { isPolicyAlreadyAccepted, moment, privacyPolicy, translate } = this.props;
+
+		let showPrivacyPolicyBanner = true;
+
 		// check if the user has already accepted/read the privacy policy.
 		if ( isPolicyAlreadyAccepted === true && ! config.isEnabled( 'privacy-policy/test' ) ) {
-			return <QueryPrivacyPolicy />;
+			showPrivacyPolicyBanner = false;
 		}
 
 		// check if the current policy is under the notification period.
@@ -103,30 +99,34 @@ class PrivacyPolicyBanner extends Component {
 			( ! notifyFrom.isBefore() || ! notifyTo.isAfter() ) &&
 			! config.isEnabled( 'privacy-policy/test' )
 		) {
-			return <QueryPrivacyPolicy />;
+			showPrivacyPolicyBanner = false;
 		}
 
 		return (
 			<div className="privacy-policy-banner">
 				<QueryPrivacyPolicy />
 
-				<Banner
-					callToAction={ translate( 'Learn More' ) }
-					description={ this.getDescription( privacyPolicy.modified ) }
-					disableHref={ true }
-					icon="pages"
-					onClick={ this.openPrivacyPolicyDialog }
-					title={ translate( 'Privacy Policy Updates.' ) }
-				/>
+				{ showPrivacyPolicyBanner && (
+					<Banner
+						callToAction={ translate( 'Learn More' ) }
+						description={ this.getDescription( privacyPolicy.modified ) }
+						disableHref={ true }
+						icon="pages"
+						onClick={ this.openPrivacyPolicyDialog }
+						title={ translate( 'Privacy Policy Updates.' ) }
+					/>
+				) }
 
-				<PrivacyPolicyDialog
-					isVisible={ this.state.showDialog }
-					content={ privacyPolicy.content }
-					title={ privacyPolicy.title }
-					version={ privacyPolicy.id }
-					onClose={ this.closePrivacyPolicyDialog }
-					onDismiss={ this.closePrivacyPolicyDialog }
-				/>
+				{ showPrivacyPolicyBanner && (
+					<PrivacyPolicyDialog
+						isVisible={ this.state.showDialog }
+						content={ privacyPolicy.content }
+						title={ privacyPolicy.title }
+						version={ privacyPolicy.id }
+						onClose={ this.closePrivacyPolicyDialog }
+						onDismiss={ this.closePrivacyPolicyDialog }
+					/>
+				) }
 			</div>
 		);
 	}

--- a/client/blocks/privacy-policy-banner/index.jsx
+++ b/client/blocks/privacy-policy-banner/index.jsx
@@ -1,0 +1,109 @@
+/** @format */
+/**
+ * External dependencies
+ *
+ */
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import { getPreference, isFetchingPreferences } from 'state/preferences/selectors';
+import { savePreference } from 'state/preferences/actions';
+import { identity } from 'lodash';
+import Banner from 'components/banner';
+import QueryPrivacyPolicy from 'components/data/query-privacy-policy';
+import { getPrivacyPolicyByEntity } from 'state/selectors';
+import { AUTOMATTIC_ENTITY, PRIVACY_POLICY_PREFERENCE } from './constants';
+
+class PrivacyPolicyBanner extends Component {
+	static propTypes = {
+		isPolicyAlreadyAccepted: PropTypes.bool,
+		privacyPolicy: PropTypes.object,
+		privacyPolicyId: PropTypes.string,
+		text: PropTypes.string,
+		translate: PropTypes.func,
+	};
+
+	static defaultProps = {
+		privacyPolicy: {},
+		text: '',
+		translate: identity,
+	};
+
+	acceptUpdates = () => {
+		if ( ! this.props.privacyPolicyId ) {
+			return;
+		}
+
+		const { privacyPolicyId, privacyPolicyState } = this.props;
+		this.props.acceptPrivacyPolicy( privacyPolicyId, privacyPolicyState );
+	};
+
+	getDescription( date ) {
+		const { moment, translate } = this.props;
+
+		return translate( "We're updating our privacy policy on %(date)s.", {
+			args: {
+				date: moment( date ).format( 'LL' ),
+			},
+		} );
+	}
+
+	render() {
+		const { fetchingPreferences, isPolicyAlreadyAccepted, translate } = this.props;
+
+		if ( fetchingPreferences ) {
+			return null;
+		}
+
+		if ( isPolicyAlreadyAccepted === true ) {
+			return <QueryPrivacyPolicy />;
+		}
+
+		return (
+			<div className="privacy-policy-banner">
+				<QueryPrivacyPolicy />
+				<Banner
+					callToAction={ translate( 'Learn More' ) }
+					description={ this.getDescription( this.props.privacyPolicy.modified ) }
+					disableHref={ true }
+					icon="pages"
+					href="https://automattic.com/privacy/"
+					target="_blank"
+					onClick={ this.acceptUpdates }
+					title={ translate( 'Privacy Policy Updates.' ) }
+				/>
+			</div>
+		);
+	}
+}
+
+const mapStateToProps = state => {
+	const privacyPolicy = getPrivacyPolicyByEntity( state, AUTOMATTIC_ENTITY );
+	const privacyPolicyState = getPreference( state, PRIVACY_POLICY_PREFERENCE ) || {};
+	const privacyPolicyId = privacyPolicy.id;
+
+	return {
+		fetchingPreferences: isFetchingPreferences( state ),
+		isPolicyAlreadyAccepted: privacyPolicyState[ privacyPolicyId ] || false,
+		privacyPolicyState,
+		privacyPolicy,
+		privacyPolicyId,
+	};
+};
+
+const mapDispatchToProps = {
+	acceptPrivacyPolicy: ( privacyPolicyId, privacyPolicyState ) =>
+		savePreference( PRIVACY_POLICY_PREFERENCE, {
+			...privacyPolicyState,
+			[ privacyPolicyId ]: true,
+		} ),
+};
+
+export default connect( mapStateToProps, mapDispatchToProps )(
+	localize( PrivacyPolicyBanner )
+);

--- a/client/blocks/privacy-policy-banner/privacy-policy-dialog.jsx
+++ b/client/blocks/privacy-policy-banner/privacy-policy-dialog.jsx
@@ -1,0 +1,44 @@
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Dialog from 'components/dialog';
+import Button from 'components/button';
+
+class PrivacyPolicyDialog extends Component {
+	render() {
+		const buttons = <Button
+			primary
+			onClick={ this.props.onClose }
+		>
+			{ this.props.translate( 'Close' ) }
+		</Button>;
+
+		return (
+			<Dialog
+				isVisible={ this.props.isVisible }
+				buttons={ [ buttons ] }
+				additionalClassNames="privacy-policy-banner__dialog"
+			>
+				<div className="privacy-policy-banner__dialog-header">
+					<div className="privacy-policy-banner__dialog-header-text">
+						<h1>{ this.props.title }</h1>
+						<p><em>version: { this.props.version }</em></p>
+					</div>
+				</div>
+
+				<div className="privacy-policy-banner__dialog-body">
+					{ this.props.content }
+				</div>
+			</Dialog>
+		);
+	}
+}
+
+export default localize( PrivacyPolicyDialog );
+

--- a/client/blocks/privacy-policy-banner/privacy-policy-dialog.jsx
+++ b/client/blocks/privacy-policy-banner/privacy-policy-dialog.jsx
@@ -19,6 +19,9 @@ class PrivacyPolicyDialog extends Component {
 			{ this.props.translate( 'Close' ) }
 		</Button>;
 
+		// let's enable `dangerouslySetInnerHTML` since we trust in the content.
+		// It's gotten from the privacy-policy WP REST API.
+		/* eslint-disable react/no-danger */
 		return (
 			<Dialog
 				isVisible={ this.props.isVisible }
@@ -32,9 +35,10 @@ class PrivacyPolicyDialog extends Component {
 					</div>
 				</div>
 
-				<div className="privacy-policy-banner__dialog-body">
-					{ this.props.content }
-				</div>
+				<div
+					className="privacy-policy-banner__dialog-body"
+					dangerouslySetInnerHTML={ { __html: this.props.content } }
+				/>
 			</Dialog>
 		);
 	}

--- a/client/blocks/privacy-policy-banner/style.scss
+++ b/client/blocks/privacy-policy-banner/style.scss
@@ -19,11 +19,15 @@
 	display: flex;
 	align-items: center;
 	margin: -24px -24px 0;
-	padding: 20px 24px 24px;
+	padding: 0 24px;
 	background-color: #fbfcfd;
 	height: 116px;
 	box-shadow: 0 1px 0 0 lighten( $gray, 20% ),
 		0 1px 0 lighten( $gray, 40% );
+
+	p {
+		margin: 0;
+	}
 }
 
 .privacy-policy-banner__dialog-header-image {

--- a/client/blocks/privacy-policy-banner/style.scss
+++ b/client/blocks/privacy-policy-banner/style.scss
@@ -1,0 +1,43 @@
+// dialog
+.dialog.card.privacy-policy-banner__dialog {
+	max-width: 700px;
+	font-size: 14px;
+	overflow: hidden;
+
+	ol {
+		list-style-position: inside;
+		margin: 0;
+
+		@include breakpoint( ">660px" ) {
+			list-style-position: outside;
+			margin: 0 3em 1.5em;
+		}
+	}
+}
+
+.privacy-policy-banner__dialog-header {
+	display: flex;
+	align-items: center;
+	margin: -24px -24px 0;
+	padding: 20px 24px 24px;
+	background-color: #fbfcfd;
+	height: 116px;
+	box-shadow: 0 1px 0 0 lighten( $gray, 20% ),
+		0 1px 0 lighten( $gray, 40% );
+}
+
+.privacy-policy-banner__dialog-header-image {
+	width: (149 / 482) * 100%;
+	margin-right: 20px;
+}
+
+.privacy-policy-banner__dialog-header-text {
+	flex: 1;
+}
+
+.privacy-policy-banner__dialog-body {
+	overflow-y: auto;
+	height: 320px;
+	padding-top: 10px;
+	padding-bottom: 10px;
+}

--- a/client/blocks/privacy-policy-banner/style.scss
+++ b/client/blocks/privacy-policy-banner/style.scss
@@ -1,3 +1,37 @@
+// banner
+.privacy-policy-banner {
+	max-width: 1040px;
+	margin: auto;
+}
+
+.is-reader-page .privacy-policy-banner {
+	margin: 30px auto;
+	max-width: 800px;
+}
+
+.is-section-preview .privacy-policy-banner {
+	margin: 24px;
+}
+
+// banner - editor section
+.is-section-post-editor .privacy-policy-banner {
+	margin: 60px auto 0;
+	max-width: 740px;
+
+	.card {
+		margin-left: 12px;
+		margin-right: 12px;
+	}
+}
+
+.is-section-post-editor.focus-sidebar .privacy-policy-banner {
+    @include breakpoint( ">660px" ) {
+		width: calc( 100% - ( 272px ) );
+		position: relative;
+		left: -135px;
+	}
+}
+
 // dialog
 .dialog.card.privacy-policy-banner__dialog {
 	max-width: 700px;

--- a/client/components/banner/index.jsx
+++ b/client/components/banner/index.jsx
@@ -39,7 +39,7 @@ class Banner extends Component {
 	static propTypes = {
 		callToAction: PropTypes.string,
 		className: PropTypes.string,
-		description: PropTypes.string,
+		description: PropTypes.oneOfType( [ PropTypes.string, PropTypes.array ] ),
 		disableHref: PropTypes.bool,
 		dismissPreferenceName: PropTypes.string,
 		dismissTemporary: PropTypes.bool,
@@ -53,6 +53,7 @@ class Banner extends Component {
 		plan: PropTypes.string,
 		price: PropTypes.oneOfType( [ PropTypes.number, PropTypes.arrayOf( PropTypes.number ) ] ),
 		siteSlug: PropTypes.string,
+		target: PropTypes.string,
 		title: PropTypes.string.isRequired,
 	};
 
@@ -126,7 +127,7 @@ class Banner extends Component {
 	}
 
 	getContent() {
-		const { callToAction, description, event, feature, list, price, title } = this.props;
+		const { callToAction, description, event, feature, list, price, title, target } = this.props;
 
 		const prices = Array.isArray( price ) ? price : [ price ];
 
@@ -166,7 +167,13 @@ class Banner extends Component {
 							</div>
 						) }
 						{ callToAction && (
-							<Button compact href={ this.getHref() } onClick={ this.handleClick } primary>
+							<Button
+								compact
+								href={ this.getHref() }
+								onClick={ this.handleClick }
+								primary
+								target={ target }
+							>
 								{ callToAction }
 							</Button>
 						) }

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -20,6 +20,7 @@ import MasterbarLoggedOut from 'layout/masterbar/logged-out';
 import observe from 'lib/mixins/data-observe';
 /* eslint-enable no-restricted-imports */
 import GlobalNotices from 'components/global-notices';
+import PrivacyPolicyBanner from 'blocks/privacy-policy-banner';
 import notices from 'notices';
 import translator from 'lib/translator-jumpstart';
 import TranslatorInvitation from './community-translator/invitation';
@@ -179,6 +180,9 @@ const Layout = createReactClass( {
 						notices={ notices.list }
 						forcePinned={ 'post' === this.props.section.name }
 					/>
+
+					<PrivacyPolicyBanner />
+
 					<div id="primary" className="layout__primary">
 						{ this.props.primary }
 					</div>

--- a/config/development.json
+++ b/config/development.json
@@ -136,6 +136,7 @@
 		"posts/post-type-list": false,
 		"posts/post-type-list/bulk-edit": false,
 		"press-this": true,
+		"privacy-policy": true,
 		"publicize-preview": true,
 		"push-notifications": true,
 		"reader": true,


### PR DESCRIPTION
~This PR depends on other ones. Take a look at #18980 before to merger this one.~
----------------------------------------------------------------------------------

This patch implements the privacy policy banner into the application. It's the final part of #18980.
The idea is showing a notification banner in the ~plans pages~ whole application when the privacy policy changes to let to the customers know about this.

![image](https://user-images.githubusercontent.com/77539/32073979-583315b6-ba6e-11e7-8fd8-92bf1017c2cb.png)

![privacy-policy-dialog-02](https://user-images.githubusercontent.com/77539/32218879-a3d16f6a-be2c-11e7-8e91-df811c06ad88.gif)

The logic for this starts with the data gotten from the privacy-policy endpoint. The body has, among all data, the notification period and the version of the policy. The sync data process is done in #18975 and #18972.

If the current date is between the notification period and the read-privacy-policy flag is not true then the banner shows. This flag is built based on the privacy-policy entity, type, and version. It's obtained from the response body of the endpoint as well.

Once the user opens the dialog with the privacy policy data the flag sets to true into the user preferences (server-side). At this point, we consider that the user already read the privacy policy.

### Testing

**Note**
_Since the privacy policy has defined a notification period and maybe when you test this feature the current date is out of this period I've added a `privacy-policy/test` flag in order to force showing the banner beyond of the read/accept the status of the user. Restart  calypso enabling this flag:_

```cli
> ENABLE_FEATURES=privacy-policy/test npm start
```

#### Requestion the privacy-policy data

The first thing that you could try is detecting is the request of the privacy-policy endpoint. Just open the dev tools, focus the network tab, and filter the requests to get the privacy-policy one. ~Keep in mind the banner is allowed on `my plan` and `plans` pages:~

After a hard refresh, you should see something like the following:

![image](https://user-images.githubusercontent.com/77539/32219927-1c78c834-be30-11e7-80b7-f8aca3b3e328.png)

![image](https://user-images.githubusercontent.com/77539/32219938-28294dca-be30-11e7-9ced-74f5d238e32f.png)

#### Syncing privacy-policy request

Using the Redux dev extension you could check how the data get from the endpoint is propagated into the state-tree.

![image](https://user-images.githubusercontent.com/77539/32220048-84c23cae-be30-11e7-85b6-2d6767f7f709.png)

<img src="https://user-images.githubusercontent.com/77539/32220081-a6706f2e-be30-11e7-897a-a028fc196b23.png" witdh="600px" />

#### Reading the privacy policy - Setting user preference

When the user closes the dialog the flag according to the privacy policy version sets true. You could detect this request in a similar way that above:

![image](https://user-images.githubusercontent.com/77539/32220252-5a4b802e-be31-11e7-924e-e57dc57dede9.png)

<img src="https://user-images.githubusercontent.com/77539/32220288-7e99f5aa-be31-11e7-9172-3a1da7317e8e.png" witdh="600px" />

_note: I've been testing with many different versions. You should see only one version into the `privacy_policy` field.

The action can be detected as well:

![privacy-policy-redux](https://user-images.githubusercontent.com/77539/32220505-3fbf5d88-be32-11e7-8b5f-5a6a95e51564.gif)