### PR TITLE
Activity Log: remove empty days from view

### DIFF
--- a/client/my-sites/stats/activity-log-day/index.jsx
+++ b/client/my-sites/stats/activity-log-day/index.jsx
@@ -199,22 +199,16 @@ class ActivityLogDay extends Component {
 			tsEndOfSiteDay,
 		} = this.props;
 
-		const hasLogs = ! isEmpty( logs );
 		const rewindHere = this.state.rewindHere;
 		const dayExpanded = this.state.dayExpanded ? true : rewindHere;
 
-		const hasConfirmDialog =
-			hasLogs &&
-			logs.some(
+		const hasConfirmDialog = logs.some(
 				( { activityId, activityTs } ) =>
 					activityId === requestedRestoreActivityId &&
 					( tsEndOfSiteDay - DAY_IN_MILLISECONDS <= activityTs && activityTs <= tsEndOfSiteDay )
 			);
 
-		const rewindButton = hasLogs
-			? this.renderRewindButton( hasConfirmDialog ? '' : 'primary' )
-			: null;
-
+		const rewindButton = this.renderRewindButton( hasConfirmDialog ? '' : 'primary' );
 		const elementsInDay = rewriteStream( logs );
 
 		// Include the Rewind dialog in the right place in the collection
@@ -229,20 +223,19 @@ class ActivityLogDay extends Component {
 		return (
 			<div
 				className={ classNames( 'activity-log-day', {
-					'is-empty': ! hasLogs,
 					'has-rewind-dialog': hasConfirmDialog,
 				} ) }
 			>
 				<FoldableCard
-					clickableHeader={ hasLogs }
-					expanded={ hasLogs && ( isToday || dayExpanded ) }
+					clickableHeader={ true }
+					expanded={ isToday || dayExpanded }
 					expandedSummary={ rewindButton }
 					summary={ rewindButton }
 					header={ this.renderEventsHeading() }
 					onOpen={ this.trackOpenDay }
 					onClose={ this.handleCloseDay( hasConfirmDialog ) }
 				>
-					{ hasLogs &&
+					{ flatMap( rewriteStream( logs ), log => [
 						map(
 							elementsInDay,
 							( elem, index, list ) =>

--- a/client/my-sites/stats/activity-log-day/index.jsx
+++ b/client/my-sites/stats/activity-log-day/index.jsx
@@ -10,7 +10,7 @@ import classNames from 'classnames';
 import Gridicon from 'gridicons';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { map, findKey, get, isEmpty } from 'lodash';
+import { flatMap, get, isEmpty, noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -43,12 +43,13 @@ class ActivityLogDay extends Component {
 		disableRestore: PropTypes.bool.isRequired,
 		hideRestore: PropTypes.bool,
 		isRewindActive: PropTypes.bool,
-		logs: PropTypes.array.isRequired,
+		logs: PropTypes.array,
 		requestedRestoreActivityId: PropTypes.string,
-		requestRestore: PropTypes.func.isRequired,
+		requestRestore: PropTypes.func,
 		rewindConfirmDialog: PropTypes.element,
 		siteId: PropTypes.number,
 		tsEndOfSiteDay: PropTypes.number.isRequired,
+		emptyRangeDate: PropTypes.string,
 
 		// Connected props
 		isToday: PropTypes.bool.isRequired,
@@ -60,6 +61,9 @@ class ActivityLogDay extends Component {
 	static defaultProps = {
 		disableRestore: false,
 		isRewindActive: true,
+		emptyRangeDate: '',
+		requestRestore: noop,
+		logs: [],
 	};
 
 	state = {
@@ -154,7 +158,15 @@ class ActivityLogDay extends Component {
 	 * @returns { object } Heading to display with date and number of events
 	 */
 	renderEventsHeading() {
-		const { applySiteOffset, isToday, logs, moment, translate, tsEndOfSiteDay } = this.props;
+		const {
+			applySiteOffset,
+			isToday,
+			logs,
+			moment,
+			translate,
+			tsEndOfSiteDay,
+			emptyRangeDate,
+		} = this.props;
 
 		const formattedDate = applySiteOffset( moment.utc( tsEndOfSiteDay ) ).format( 'LL' );
 		const noActivityText = isToday ? translate( 'No activity yet!' ) : translate( 'No activity' );

--- a/client/my-sites/stats/activity-log-day/index.jsx
+++ b/client/my-sites/stats/activity-log-day/index.jsx
@@ -10,7 +10,7 @@ import classNames from 'classnames';
 import Gridicon from 'gridicons';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { flatMap, get, isEmpty } from 'lodash';
+import { findKey, flatMap, get, isEmpty, map } from 'lodash';
 
 /**
  * Internal dependencies
@@ -203,10 +203,10 @@ class ActivityLogDay extends Component {
 		const dayExpanded = this.state.dayExpanded ? true : rewindHere;
 
 		const hasConfirmDialog = logs.some(
-				( { activityId, activityTs } ) =>
-					activityId === requestedRestoreActivityId &&
-					( tsEndOfSiteDay - DAY_IN_MILLISECONDS <= activityTs && activityTs <= tsEndOfSiteDay )
-			);
+			( { activityId, activityTs } ) =>
+				activityId === requestedRestoreActivityId &&
+				( tsEndOfSiteDay - DAY_IN_MILLISECONDS <= activityTs && activityTs <= tsEndOfSiteDay )
+		);
 
 		const rewindButton = this.renderRewindButton( hasConfirmDialog ? '' : 'primary' );
 		const elementsInDay = rewriteStream( logs );
@@ -235,7 +235,7 @@ class ActivityLogDay extends Component {
 					onOpen={ this.trackOpenDay }
 					onClose={ this.handleCloseDay( hasConfirmDialog ) }
 				>
-					{ flatMap( rewriteStream( logs ), log => [
+					{ flatMap(
 						map(
 							elementsInDay,
 							( elem, index, list ) =>
@@ -259,7 +259,8 @@ class ActivityLogDay extends Component {
 										siteId={ siteId }
 									/>
 								)
-						) }
+						)
+					) }
 				</FoldableCard>
 			</div>
 		);

--- a/client/my-sites/stats/activity-log-day/index.jsx
+++ b/client/my-sites/stats/activity-log-day/index.jsx
@@ -10,7 +10,7 @@ import classNames from 'classnames';
 import Gridicon from 'gridicons';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { flatMap, get, isEmpty, noop } from 'lodash';
+import { flatMap, get, isEmpty } from 'lodash';
 
 /**
  * Internal dependencies
@@ -43,13 +43,12 @@ class ActivityLogDay extends Component {
 		disableRestore: PropTypes.bool.isRequired,
 		hideRestore: PropTypes.bool,
 		isRewindActive: PropTypes.bool,
-		logs: PropTypes.array,
+		logs: PropTypes.array.isRequired,
 		requestedRestoreActivityId: PropTypes.string,
-		requestRestore: PropTypes.func,
+		requestRestore: PropTypes.func.isRequired,
 		rewindConfirmDialog: PropTypes.element,
 		siteId: PropTypes.number,
 		tsEndOfSiteDay: PropTypes.number.isRequired,
-		emptyRangeDate: PropTypes.string,
 
 		// Connected props
 		isToday: PropTypes.bool.isRequired,
@@ -61,9 +60,6 @@ class ActivityLogDay extends Component {
 	static defaultProps = {
 		disableRestore: false,
 		isRewindActive: true,
-		emptyRangeDate: '',
-		requestRestore: noop,
-		logs: [],
 	};
 
 	state = {
@@ -158,15 +154,7 @@ class ActivityLogDay extends Component {
 	 * @returns { object } Heading to display with date and number of events
 	 */
 	renderEventsHeading() {
-		const {
-			applySiteOffset,
-			isToday,
-			logs,
-			moment,
-			translate,
-			tsEndOfSiteDay,
-			emptyRangeDate,
-		} = this.props;
+		const { applySiteOffset, isToday, logs, moment, translate, tsEndOfSiteDay } = this.props;
 
 		const formattedDate = applySiteOffset( moment.utc( tsEndOfSiteDay ) ).format( 'LL' );
 		const noActivityText = isToday ? translate( 'No activity yet!' ) : translate( 'No activity' );

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -70,7 +70,7 @@ const flushEmptyDays = days => [
 
 /**
  * Takes a list of [ day, eventList ] pairs and produces
- * a list of [ type, [ start, end? ], eventList? ] triplets
+ * a list of [ type, [ start, end ], eventList? ] triplets
  *
  * We have three ways to represent any given day with
  * Activity Log events:
@@ -134,7 +134,7 @@ const intoVisualGroups = ( remainingDays, groups = [], emptyDays = [] ) => {
 	if ( ! emptyDays.length ) {
 		return intoVisualGroups(
 			nextRemaining,
-			[ ...groups, [ 'non-empty-day', [ day ], events ] ],
+			[ ...groups, [ 'non-empty-day', [ day, day ], events ] ],
 			[]
 		);
 	}
@@ -145,7 +145,7 @@ const intoVisualGroups = ( remainingDays, groups = [], emptyDays = [] ) => {
 	if ( emptyDays.length ) {
 		return intoVisualGroups(
 			nextRemaining,
-			[ ...groups, flushEmptyDays( emptyDays ), [ 'non-empty-day', [ day ], events ] ],
+			[ ...groups, flushEmptyDays( emptyDays ), [ 'non-empty-day', [ day, day ], events ] ],
 			[]
 		);
 	}
@@ -486,14 +486,13 @@ class ActivityLog extends Component {
 							.slice()
 							.reverse() // show with newest event on top
 							.map( ( [ type, time, events ] ) => {
-								const date = last( time );
+								const [ start, end ] = time;
 								const isToday = today.isSame(
-									date
+									end
 										.clone()
 										.utc()
 										.startOf( 'day' )
 								);
-								const [ start, end ] = time;
 
 								switch ( type ) {
 									case 'empty-day':

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -320,6 +320,10 @@ class ActivityLog extends Component {
 		);
 
 		const activityDays = [];
+
+		// Save first empty day
+		let thatEmptyDay = '';
+
 		// loop backwards through each day in the month
 		for (
 			const m = moment.min(
@@ -337,6 +341,28 @@ class ActivityLog extends Component {
 			m.subtract( 1, 'day' )
 		) {
 			const dayEnd = m.endOf( 'day' ).valueOf();
+			const dayLogs = get( logsGroupedByDay, dayEnd, [] );
+
+			if ( '' === thatEmptyDay && isEmpty( dayLogs ) ) {
+				thatEmptyDay = dayEnd;
+			} else if ( '' !== thatEmptyDay && ! isEmpty( dayLogs ) ) {
+				const thisEmptyDay = m
+					.endOf( 'day' )
+					.add( 1, 'day' )
+					.valueOf();
+				activityDays.push(
+					<div className="activity-log-day">
+						{ thisEmptyDay !== thatEmptyDay ? (
+							`${ this.applySiteOffset( moment.utc( thisEmptyDay ) ).format( 'LL' ) }
+								 - ${ this.applySiteOffset( moment.utc( thatEmptyDay ) ).format( 'LL' ) }`
+						) : (
+							`${ this.applySiteOffset( moment.utc( thatEmptyDay ) ).format( 'LL' ) }`
+						) }
+					</div>
+				);
+				thatEmptyDay = '';
+			}
+
 			activityDays.push(
 				<ActivityLogDay
 					applySiteOffset={ this.applySiteOffset }
@@ -346,7 +372,7 @@ class ActivityLog extends Component {
 					hideRestore={ ! rewindEnabledByConfig || ! isPressable }
 					isRewindActive={ isRewindActive }
 					key={ dayEnd }
-					logs={ get( logsGroupedByDay, dayEnd, [] ) }
+					logs={ dayLogs }
 					requestRestore={ this.handleRequestRestore }
 					siteId={ siteId }
 					tsEndOfSiteDay={ dayEnd }

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -5,7 +5,6 @@
  */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import classNames from 'classnames';
 import config from 'config';
 import debugFactory from 'debug';
 import scrollTo from 'lib/scroll-to';

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -351,33 +351,38 @@ class ActivityLog extends Component {
 					.add( 1, 'day' )
 					.valueOf();
 				activityDays.push(
-					<div className="activity-log-day">
-						{ thisEmptyDay !== thatEmptyDay ? (
-							`${ this.applySiteOffset( moment.utc( thisEmptyDay ) ).format( 'LL' ) }
+					<ActivityLogDay
+						applySiteOffset={ this.applySiteOffset }
+						key={ `empty-${ dayEnd }` }
+						tsEndOfSiteDay={ dayEnd }
+						emptyRangeDate={
+							thisEmptyDay !== thatEmptyDay ? (
+								`${ this.applySiteOffset( moment.utc( thisEmptyDay ) ).format( 'LL' ) }
 								 - ${ this.applySiteOffset( moment.utc( thatEmptyDay ) ).format( 'LL' ) }`
-						) : (
-							`${ this.applySiteOffset( moment.utc( thatEmptyDay ) ).format( 'LL' ) }`
-						) }
-					</div>
+							) : (
+								`${ this.applySiteOffset( moment.utc( thatEmptyDay ) ).format( 'LL' ) }`
+							)
+						}
+					/>
 				);
 				thatEmptyDay = '';
+			} else if ( ! isEmpty( dayLogs ) ) {
+				activityDays.push(
+					<ActivityLogDay
+						applySiteOffset={ this.applySiteOffset }
+						requestedRestoreActivityId={ requestedRestoreActivityId }
+						rewindConfirmDialog={ rewindConfirmDialog }
+						disableRestore={ disableRestore }
+						hideRestore={ ! rewindEnabledByConfig || ! isPressable }
+						isRewindActive={ isRewindActive }
+						key={ dayEnd }
+						logs={ dayLogs }
+						requestRestore={ this.handleRequestRestore }
+						siteId={ siteId }
+						tsEndOfSiteDay={ dayEnd }
+					/>
+				);
 			}
-
-			activityDays.push(
-				<ActivityLogDay
-					applySiteOffset={ this.applySiteOffset }
-					requestedRestoreActivityId={ requestedRestoreActivityId }
-					rewindConfirmDialog={ rewindConfirmDialog }
-					disableRestore={ disableRestore }
-					hideRestore={ ! rewindEnabledByConfig || ! isPressable }
-					isRewindActive={ isRewindActive }
-					key={ dayEnd }
-					logs={ dayLogs }
-					requestRestore={ this.handleRequestRestore }
-					siteId={ siteId }
-					tsEndOfSiteDay={ dayEnd }
-				/>
-			);
 		}
 
 		return (

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -155,12 +155,11 @@ const daysInMonth = ( moment, startMoment, today ) => {
 		.endOf( 'month' )
 		.startOf( 'day' );
 	const startOfMonth = startMoment.clone().startOf( 'month' );
-	const startOfToday = today.startOf( 'day' );
+	const startOfToday = today.clone().startOf( 'day' );
 	const endOfStream = moment.min( endOfMonth, startOfToday );
 
-	return range( endOfStream.date() ).map( dayNumber =>
-		startOfMonth.clone().add( dayNumber, 'day' )
-	);
+	const asDayInMonth = n => startOfMonth.clone().add( n, 'day' );
+	return range( endOfStream.date() ).map( asDayInMonth );
 };
 
 const logsByDay = ( moment, logs, startMoment, applyOffset ) => {

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -485,8 +485,7 @@ class ActivityLog extends Component {
 						{ visualGroups
 							.slice()
 							.reverse() // show with newest event on top
-							.map( ( [ type, time, events ] ) => {
-								const [ start, end ] = time;
+							.map( ( [ type, [ start, end ], events ] ) => {
 								const isToday = today.isSame(
 									end
 										.clone()

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -1,4 +1,5 @@
 /** @format */
+/* eslint-disable wpcalypso/jsx-classname-namespace */
 /**
  * External dependencies
  */
@@ -10,7 +11,7 @@ import debugFactory from 'debug';
 import scrollTo from 'lib/scroll-to';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { get, groupBy, includes, isEmpty, isNull } from 'lodash';
+import { first, get, groupBy, includes, isEmpty, isNull, last, range } from 'lodash';
 
 /**
  * Internal dependencies
@@ -61,6 +62,126 @@ import {
  */
 const debug = debugFactory( 'calypso:activity-log' );
 const rewindEnabledByConfig = config.isEnabled( 'jetpack/activity-log/rewind' );
+
+const flushEmptyDays = days =>
+	days.length === 1 ? [ 'empty-day', days ] : [ 'empty-range', [ last( days ), first( days ) ] ];
+
+/**
+ * Takes a list of [ day, eventList ] pairs and produces
+ * a list of [ type, [ start, end? ], eventList? ] triplets
+ *
+ * We have three ways to represent any given day with
+ * Activity Log events:
+ *
+ *  - The day has events
+ *  - The day has no events
+ *  - The day has no events _and_
+ *    neither did the previous day
+ *
+ * When "empty days" follow other empty days then we
+ * want to group them into "empty ranges" so that we
+ * don't end up showing a bunch of needless empty
+ * day visual components on the page.
+ *
+ * Note: although this is recursive, since we don't
+ *       expect to ever be descending more than than
+ *       31 times (in the worst case because there are
+ *       no months with more than 31 days) we don't
+ *       need to guard against stack overflow here, it
+ *       just won't recurse that deeply.
+ *
+ * Example input:
+ * [ [ moment( '2017-10-08 14:48:01' ), [] ]
+ * , [ moment( '2017-10-09 03:13:48' ), [ event1, event2, … ] ]
+ * , [ moment( … ), [] ]
+ * , [ moment( … ), [] ]
+ * , [ moment( … ), [ event3 ] ]
+ * ]
+ *
+ * Example output:
+ * [ [ 'empty-day', [ moment( … ) ] ]
+ * , [ 'non-empty-day', [ moment( … ) ], [ event1, event2, … ] ]
+ * , [ 'empty-range', [ moment( … ), moment( … ) ] ]
+ * , [ 'non-empty-day', [ moment( …) ], [ event3 ] ]
+ * ]
+ *
+ * Note: the days coming into this function must be sorted.
+ *       it doesn't matter in which direction, but they must
+ *       be sequential one way or the other
+ *
+ * @param {Array} remainingDays remaining _sorted_ days to process
+ * @param {Array} groups final output data structure (see comment above)
+ * @param {Array} emptyDays running track of empty days to group
+ * @returns {Array} grouped days and events
+ */
+const intoVisualGroups = ( remainingDays, groups = [], emptyDays = [] ) => {
+	if ( ! remainingDays.length ) {
+		return emptyDays.length ? [ ...groups, flushEmptyDays( emptyDays ) ] : groups;
+	}
+
+	const [ nextDay, ...nextRemaining ] = remainingDays;
+	const [ day, events ] = nextDay;
+
+	// without activity we track the day in order to group empty days
+	if ( ! events.length ) {
+		return intoVisualGroups( nextRemaining, groups, [ ...emptyDays, day ] );
+	}
+
+	// if we have activity but no previously-tracked empty days
+	// then just push out this day onto the output
+	if ( ! emptyDays.length ) {
+		return intoVisualGroups(
+			nextRemaining,
+			[ ...groups, [ 'non-empty-day', [ day ], events ] ],
+			[]
+		);
+	}
+
+	// otherwise we want to flush out the tracked group into the output
+	// push this day out as well
+	// and restart without any tracked empty days
+	if ( emptyDays.length ) {
+		return intoVisualGroups(
+			nextRemaining,
+			[ ...groups, flushEmptyDays( emptyDays ), [ 'non-empty-day', [ day ], events ] ],
+			[]
+		);
+	}
+};
+
+const daysInMonth = ( moment, startMoment, today ) => {
+	const endOfMonth = startMoment
+		.clone()
+		.endOf( 'month' )
+		.startOf( 'day' );
+	const startOfMonth = startMoment.clone().startOf( 'month' );
+	const startOfToday = today.startOf( 'day' );
+	const endOfStream = moment.min( endOfMonth, startOfToday );
+
+	return range( endOfStream.date() ).map( dayNumber =>
+		startOfMonth.clone().add( dayNumber, 'day' )
+	);
+};
+
+const logsByDay = ( moment, logs, startMoment, applyOffset ) => {
+	const dayGroups = groupBy( logs, log =>
+		applyOffset( moment.utc( log.activityTs ) )
+			.endOf( 'day' )
+			.valueOf()
+	);
+
+	return daysInMonth( moment, startMoment, applyOffset( moment.utc() ) ).map( day => [
+		day,
+		get(
+			dayGroups,
+			day
+				.clone()
+				.endOf( 'day' )
+				.valueOf(),
+			[]
+		),
+	] );
+};
 
 class ActivityLog extends Component {
 	static propTypes = {
@@ -252,150 +373,6 @@ class ActivityLog extends Component {
 		}
 	}
 
-	renderLogs() {
-		const {
-			isPressable,
-			isRewindActive,
-			logs,
-			moment,
-			requestedRestoreActivity,
-			requestedRestoreActivityId,
-			siteId,
-			translate,
-			rewindStartDate,
-		} = this.props;
-		const startMoment = this.getStartMoment();
-
-		if ( isNull( logs ) ) {
-			return (
-				<section className="activity-log__wrapper">
-					<ActivityLogDayPlaceholder />
-					<ActivityLogDayPlaceholder />
-					<ActivityLogDayPlaceholder />
-				</section>
-			);
-		}
-
-		if ( isEmpty( rewindStartDate ) ) {
-			return [
-				<EmptyContent
-					title={ translate( 'Your site is being synced' ) }
-					line={
-						<span>
-							{ translate( 'Come back in a little while to see your site activity.' ) }
-							<br />
-							{ translate( "You will receive a notification once it's complete!" ) }
-						</span>
-					}
-					illustration="/calypso/images/illustrations/al-syncing-site.svg"
-					className="activity-log__first-sync"
-				/>,
-			];
-		}
-
-		if ( isEmpty( logs ) ) {
-			return (
-				<EmptyContent
-					title={ translate( 'No activity for %s', {
-						args: startMoment.format( 'MMMM YYYY' ),
-					} ) }
-				/>
-			);
-		}
-
-		const disableRestore = this.isRestoreInProgress();
-		const logsGroupedByDay = groupBy( logs, log =>
-			this.applySiteOffset( moment.utc( log.activityTs ) )
-				.endOf( 'day' )
-				.valueOf()
-		);
-		const rewindConfirmDialog = requestedRestoreActivity && (
-			<ActivityLogConfirmDialog
-				applySiteOffset={ this.applySiteOffset }
-				key="activity-rewind-dialog"
-				onClose={ this.handleRestoreDialogClose }
-				onConfirm={ this.handleRestoreDialogConfirm }
-				timestamp={ requestedRestoreActivity.activityTs }
-			/>
-		);
-
-		const activityDays = [];
-
-		// Save first empty day
-		let thatEmptyDay = '';
-
-		// loop backwards through each day in the month
-		for (
-			const m = moment.min(
-					startMoment
-						.clone()
-						.endOf( 'month' )
-						.startOf( 'day' ),
-					this.applySiteOffset( moment.utc() ).startOf( 'day' )
-				),
-				startOfMonth = startMoment
-					.clone()
-					.startOf( 'month' )
-					.valueOf();
-			startOfMonth <= m.valueOf();
-			m.subtract( 1, 'day' )
-		) {
-			const dayEnd = m.endOf( 'day' ).valueOf();
-			const dayLogs = get( logsGroupedByDay, dayEnd, [] );
-
-			if ( '' === thatEmptyDay && isEmpty( dayLogs ) ) {
-				thatEmptyDay = dayEnd;
-			} else if ( '' !== thatEmptyDay && ! isEmpty( dayLogs ) ) {
-				const thisEmptyDay = m
-					.endOf( 'day' )
-					.add( 1, 'day' )
-					.valueOf();
-				activityDays.push(
-					<ActivityLogDay
-						applySiteOffset={ this.applySiteOffset }
-						key={ `empty-${ dayEnd }` }
-						tsEndOfSiteDay={ dayEnd }
-						emptyRangeDate={
-							thisEmptyDay !== thatEmptyDay ? (
-								`${ this.applySiteOffset( moment.utc( thisEmptyDay ) ).format( 'LL' ) }
-								 - ${ this.applySiteOffset( moment.utc( thatEmptyDay ) ).format( 'LL' ) }`
-							) : (
-								`${ this.applySiteOffset( moment.utc( thatEmptyDay ) ).format( 'LL' ) }`
-							)
-						}
-					/>
-				);
-				thatEmptyDay = '';
-			} else if ( ! isEmpty( dayLogs ) ) {
-				activityDays.push(
-					<ActivityLogDay
-						applySiteOffset={ this.applySiteOffset }
-						requestedRestoreActivityId={ requestedRestoreActivityId }
-						rewindConfirmDialog={ rewindConfirmDialog }
-						disableRestore={ disableRestore }
-						hideRestore={ ! rewindEnabledByConfig || ! isPressable }
-						isRewindActive={ isRewindActive }
-						key={ dayEnd }
-						logs={ dayLogs }
-						requestRestore={ this.handleRequestRestore }
-						siteId={ siteId }
-						tsEndOfSiteDay={ dayEnd }
-					/>
-				);
-			}
-		}
-
-		return (
-			<section
-				className={ classNames( 'activity-log__wrapper', {
-					'rewind-requested': this.props.requestedRestoreActivity,
-				} ) }
-			>
-				{ activityDays }
-			</section>
-		);
-	}
-
 	renderMonthNavigation( position ) {
 		const { logs, slug } = this.props;
 		const startOfMonth = this.getStartMoment().startOf( 'month' );
@@ -428,6 +405,10 @@ class ActivityLog extends Component {
 			gmtOffset,
 			isPressable,
 			isRewindActive,
+			logs,
+			moment,
+			requestedRestoreActivity,
+			requestedRestoreActivityId,
 			siteId,
 			slug,
 			startDate,
@@ -449,6 +430,25 @@ class ActivityLog extends Component {
 			);
 		}
 
+		const disableRestore = this.isRestoreInProgress();
+
+		const rewindConfirmDialog = requestedRestoreActivity && (
+			<ActivityLogConfirmDialog
+				applySiteOffset={ this.applySiteOffset }
+				key="activity-rewind-dialog"
+				onClose={ this.handleRestoreDialogClose }
+				onConfirm={ this.handleRestoreDialogConfirm }
+				timestamp={ requestedRestoreActivity.activityTs }
+			/>
+		);
+
+		const visualGroups = intoVisualGroups(
+			logsByDay( moment, logs, this.getStartMoment(), this.applySiteOffset )
+		);
+		const today = moment()
+			.utc()
+			.startOf( 'day' );
+
 		return (
 			<Main wideLayout>
 				{ rewindEnabledByConfig && <QueryRewindStatus siteId={ siteId } /> }
@@ -464,7 +464,79 @@ class ActivityLog extends Component {
 				{ hasFirstBackup && this.renderMonthNavigation() }
 				{ this.renderBanner() }
 				{ ! isRewindActive && !! isPressable && <ActivityLogRewindToggle siteId={ siteId } /> }
-				{ this.renderLogs() }
+				{ isNull( logs ) && (
+					<section className="activity-log__wrapper">
+						<ActivityLogDayPlaceholder />
+						<ActivityLogDayPlaceholder />
+						<ActivityLogDayPlaceholder />
+					</section>
+				) }
+				{ ! isNull( logs ) &&
+				isEmpty( logs ) && (
+					<EmptyContent
+						title={ translate( 'No activity for %s', {
+							args: this.getStartMoment().format( 'MMMM YYYY' ),
+						} ) }
+					/>
+				) }
+				{ ! isEmpty( logs ) && (
+					<section className="activity-log__wrapper">
+						{ visualGroups
+							.slice()
+							.reverse() // show with newest event on top
+							.map( ( [ type, time, events ] ) => {
+								const date = last( time );
+								const isToday = today.isSame(
+									date
+										.clone()
+										.utc()
+										.startOf( 'day' )
+								);
+								const [ start, end ] = time;
+
+								switch ( type ) {
+									case 'empty-day':
+										return (
+											<div key={ start.format() } className="activity-log-day is-empty">
+												<div>
+													{ start.format( 'LL' ) }
+													{ isToday && ` \u2014 ${ translate( 'Today' ) }` }
+												</div>
+												<div>{ translate( 'No activity' ) }</div>
+											</div>
+										);
+
+									case 'empty-range':
+										return (
+											<div key={ start.format( 'LL' ) } className="activity-log-day is-empty">
+												<div>
+													{ `${ start.format( 'LL' ) } - ${ end.format( 'LL' ) }` }
+													{ isToday && ` \u2014 ${ translate( 'Today' ) }` }
+												</div>
+												<div>{ translate( 'No activity' ) }</div>
+											</div>
+										);
+
+									case 'non-empty-day':
+										return (
+											<ActivityLogDay
+												key={ start.format() }
+												applySiteOffset={ this.applySiteOffset }
+												requestedRestoreActivityId={ requestedRestoreActivityId }
+												rewindConfirmDialog={ rewindConfirmDialog }
+												disableRestore={ disableRestore }
+												hideRestore={ ! rewindEnabledByConfig || ! isPressable }
+												isRewindActive={ isRewindActive }
+												logs={ events }
+												requestRestore={ this.handleRequestRestore }
+												siteId={ siteId }
+												tsEndOfSiteDay={ start.valueOf() }
+											/>
+										);
+								}
+							} ) }
+					</section>
+				) }
 				{ hasFirstBackup && this.renderMonthNavigation( 'bottom' ) }
 				<JetpackColophon />
 			</Main>

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -496,23 +496,27 @@ class ActivityLog extends Component {
 								switch ( type ) {
 									case 'empty-day':
 										return (
-											<div key={ start.format() } className="activity-log-day is-empty">
-												<div>
+											<div key={ start.format() } className="activity-log__empty-day">
+												<div className="activity-log__empty-day-title">
 													{ start.format( 'LL' ) }
 													{ isToday && ` \u2014 ${ translate( 'Today' ) }` }
 												</div>
-												<div>{ translate( 'No activity' ) }</div>
+												<div className="activity-log__empty-day-events">
+													{ translate( 'No activity' ) }
+												</div>
 											</div>
 										);
 
 									case 'empty-range':
 										return (
-											<div key={ start.format( 'LL' ) } className="activity-log-day is-empty">
-												<div>
+											<div key={ start.format( 'LL' ) } className="activity-log__empty-day">
+												<div className="activity-log__empty-day-title">
 													{ `${ start.format( 'LL' ) } - ${ end.format( 'LL' ) }` }
 													{ isToday && ` \u2014 ${ translate( 'Today' ) }` }
 												</div>
-												<div>{ translate( 'No activity' ) }</div>
+												<div className="activity-log__empty-day-events">
+													{ translate( 'No activity' ) }
+												</div>
 											</div>
 										);
 

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -63,8 +63,10 @@ import {
 const debug = debugFactory( 'calypso:activity-log' );
 const rewindEnabledByConfig = config.isEnabled( 'jetpack/activity-log/rewind' );
 
-const flushEmptyDays = days =>
-	days.length === 1 ? [ 'empty-day', days ] : [ 'empty-range', [ last( days ), first( days ) ] ];
+const flushEmptyDays = days => [
+	days.length === 1 ? 'empty-day' : 'empty-range',
+	[ first( days ), last( days ) ],
+];
 
 /**
  * Takes a list of [ day, eventList ] pairs and produces

--- a/client/my-sites/stats/activity-log/style.scss
+++ b/client/my-sites/stats/activity-log/style.scss
@@ -22,3 +22,21 @@
 .rewind-requested .has-rewind-dialog ~ .activity-log-day {
 	opacity: 1;
 }
+
+.activity-log__empty-day {
+	background: $gray-light;
+	width: 100%;
+	padding: 0 16px 4px;
+	position: relative;
+	z-index: 2;
+	margin-bottom: 16px;
+}
+
+.activity-log__empty-day-title {
+	font-weight: 600;
+}
+
+.activity-log__empty-day-events {
+	font-size: 12px;
+	color: $gray;
+}


### PR DESCRIPTION
fixes #18974

replace days without activity with a date range explaining there was no activity during that time

### Before
<img width="859" alt="captura de pantalla 2017-10-19 a la s 16 07 15" src="https://user-images.githubusercontent.com/1041600/31789284-0a7d185c-b4e8-11e7-964f-5731445be3ed.png">

### After
<img width="858" alt="captura de pantalla 2017-10-19 a la s 16 07 23" src="https://user-images.githubusercontent.com/1041600/31789286-0aaf6726-b4e8-11e7-91d5-0d14eb2bcef6.png">


#### Initial and dismissed attempt for history purposes:
hide days without activity

<img width="954" alt="captura de pantalla 2017-10-18 a la s 17 25 48" src="https://user-images.githubusercontent.com/1041600/31741151-b82a69ce-b429-11e7-942c-cd72b91cccd9.png">
