### PR TITLE
Framework: Put react-hot-loader behind a feature flag

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -175,6 +175,7 @@
 		"upgrades/removal-survey": true,
 		"upgrades/precancellation-chat": true,
 		"upgrades/presale-chat": true,
+		"webpack/hot-loader": false,
 		"webpack/persistent-caching": false,
 		"woocommerce/extension-dashboard": true,
 		"woocommerce/extension-orders": true,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -145,7 +145,7 @@ const webpackConfig = {
 		new CopyWebpackPlugin( [ { from: 'node_modules/flag-icon-css/flags/4x3', to: 'images/flags' } ] ),
 		new HappyPack( {
 			loaders: _.compact( [
-				calypsoEnv === 'development' && 'react-hot-loader',
+				calypsoEnv === 'development' && config.isEnabled( 'webpack/hot-loader' ) && 'react-hot-loader',
 				babelLoader
 			] )
 		} ),


### PR DESCRIPTION
This PR puts react-hot-loader behind `webpack/hot-loader` feature flag in development environment.  
The reason this is needed is that our current version of `react-hot-loader` is incompatible with `redux-form` and is causing pages using it to crash. The long term solution is to update `react-hot-loader` to v3 or higher.
This issue went undetected until we recently fixed our hot loader configuration ( #18771 ).

Putting the hot loader behind a feature flag will still allow people to use it if it helps their workflow without hindering anyone else.

# Testing

- Hot loader should be turned off by default, you should be required to refresh the page every time you change a component.
- Change `webpack/hot-loader` feature flag to `true` for `development` environment and restart webpack. Changes to a component should now be immediately visible without the need for a refresh.