### PR TITLE
Store Orders: Update status labels for "cash on delivery" orders

### DIFF
--- a/client/extensions/woocommerce/app/order/order-details/index.js
+++ b/client/extensions/woocommerce/app/order/order-details/index.js
@@ -49,7 +49,7 @@ class OrderDetails extends Component {
 		return isEditing ? (
 			<OrderStatusSelect value={ order.status } onChange={ this.updateStatus } />
 		) : (
-			<OrderStatus status={ order.status } showShipping={ false } />
+			<OrderStatus order={ order } showShipping={ false } />
 		);
 	};
 

--- a/client/extensions/woocommerce/app/order/order-payment/index.js
+++ b/client/extensions/woocommerce/app/order/order-payment/index.js
@@ -63,6 +63,13 @@ class OrderPaymentCard extends Component {
 					refund: formatCurrency( refund, order.currency ),
 				},
 			} );
+		} else if ( 'cod' === order.payment_method && 'processing' === order.status ) {
+			paymentStatus = translate( 'Payment of %(total)s on delivery', {
+				args: {
+					total: formatCurrency( order.total, order.currency ),
+					method: order.payment_method_title,
+				},
+			} );
 		} else {
 			paymentStatus = translate( 'Payment of %(total)s received via %(method)s', {
 				args: {
@@ -76,7 +83,8 @@ class OrderPaymentCard extends Component {
 
 	getPaymentAction = () => {
 		const { order, translate } = this.props;
-		if ( 'refunded' === order.status ) {
+		const codProcessing = 'cod' === order.payment_method && 'processing' === order.status;
+		if ( 'refunded' === order.status || codProcessing ) {
 			return null;
 		} else if ( isOrderWaitingPayment( order.status ) ) {
 			return <Button onClick={ this.markAsPaid }>{ translate( 'Mark as Paid' ) }</Button>;

--- a/client/extensions/woocommerce/app/order/order-payment/index.js
+++ b/client/extensions/woocommerce/app/order/order-payment/index.js
@@ -67,7 +67,6 @@ class OrderPaymentCard extends Component {
 			paymentStatus = translate( 'Payment of %(total)s on delivery', {
 				args: {
 					total: formatCurrency( order.total, order.currency ),
-					method: order.payment_method_title,
 				},
 			} );
 		} else {

--- a/client/extensions/woocommerce/app/orders/orders-list.js
+++ b/client/extensions/woocommerce/app/orders/orders-list.js
@@ -146,7 +146,7 @@ class Orders extends Component {
 					{ humanDate( order.date_created_gmt + 'Z' ) }
 				</TableItem>
 				<TableItem className="orders__table-status">
-					<OrderStatus status={ order.status } />
+					<OrderStatus order={ order } />
 				</TableItem>
 				<TableItem className="orders__table-total">
 					{ formatCurrency( order.total, order.currency ) || order.total }

--- a/client/extensions/woocommerce/components/order-status/README.md
+++ b/client/extensions/woocommerce/components/order-status/README.md
@@ -11,7 +11,7 @@ Some statuses don't have a shipping status: `cancelled`, `refunded`, and `failed
 render: function() {
     return (
         <SectionHeader label="Order Details">
-            <OrderStatus status={ 'pending' } />
+            <OrderStatus order={ { status: 'pending' } } />
         </SectionHeader>
     );
 }

--- a/client/extensions/woocommerce/components/order-status/index.js
+++ b/client/extensions/woocommerce/components/order-status/index.js
@@ -26,7 +26,7 @@ export class OrderStatus extends Component {
 				return translate( 'Payment pending' );
 			case 'processing':
 				if ( 'cod' === payment_method ) {
-					return translate( 'Payment pending' );
+					return translate( 'Paid on delivery' );
 				}
 				return translate( 'Paid in full' );
 			case 'completed':

--- a/client/extensions/woocommerce/components/order-status/index.js
+++ b/client/extensions/woocommerce/components/order-status/index.js
@@ -8,20 +8,27 @@ import { localize } from 'i18n-calypso';
 
 export class OrderStatus extends Component {
 	static propTypes = {
+		order: PropTypes.shape( {
+			payment_method: PropTypes.string,
+			status: PropTypes.string.isRequired,
+		} ),
 		showPayment: PropTypes.bool,
 		showShipping: PropTypes.bool,
-		status: PropTypes.string.isRequired,
 		translate: PropTypes.func.isRequired,
 	};
 
 	getPaymentLabel = () => {
-		const { status, translate } = this.props;
+		const { order, translate } = this.props;
+		const { status, payment_method } = order;
 		switch ( status ) {
 			case 'pending':
-				return translate( 'Payment pending' );
 			case 'on-hold':
 				return translate( 'Payment pending' );
 			case 'processing':
+				if ( 'cod' === payment_method ) {
+					return translate( 'Payment pending' );
+				}
+				return translate( 'Paid in full' );
 			case 'completed':
 				return translate( 'Paid in full' );
 			case 'cancelled':
@@ -35,8 +42,8 @@ export class OrderStatus extends Component {
 	};
 
 	getShippingLabel = () => {
-		const { status, translate } = this.props;
-		switch ( status ) {
+		const { order, translate } = this.props;
+		switch ( order.status ) {
 			case 'pending':
 			case 'processing':
 				return translate( 'New order' );

--- a/client/extensions/woocommerce/components/order-status/index.js
+++ b/client/extensions/woocommerce/components/order-status/index.js
@@ -1,52 +1,73 @@
+/** @format */
 /**
  * External dependencies
- *
- * @format
  */
-
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
-import React from 'react';
 
-function OrderStatus( { showPayment = true, showShipping = true, status, translate } ) {
-	const classes = `order-status__item is-${ status }`;
-	let paymentLabel;
-	let shippingLabel;
-	switch ( status ) {
-		case 'pending':
-			shippingLabel = translate( 'New order' );
-			paymentLabel = translate( 'Payment pending' );
-			break;
-		case 'processing':
-			shippingLabel = translate( 'New order' );
-			paymentLabel = translate( 'Paid in full' );
-			break;
-		case 'on-hold':
-			shippingLabel = translate( 'On hold' );
-			paymentLabel = translate( 'Payment pending' );
-			break;
-		case 'completed':
-			shippingLabel = translate( 'Fulfilled' );
-			paymentLabel = translate( 'Paid in full' );
-			break;
-		case 'cancelled':
-			paymentLabel = translate( 'Cancelled' );
-			break;
-		case 'refunded':
-			paymentLabel = translate( 'Refunded' );
-			break;
-		case 'failed':
-			paymentLabel = translate( 'Payment failed' );
-			break;
+export class OrderStatus extends Component {
+	static propTypes = {
+		showPayment: PropTypes.bool,
+		showShipping: PropTypes.bool,
+		status: PropTypes.string.isRequired,
+		translate: PropTypes.func.isRequired,
+	};
+
+	getPaymentLabel = () => {
+		const { status, translate } = this.props;
+		switch ( status ) {
+			case 'pending':
+				return translate( 'Payment pending' );
+			case 'on-hold':
+				return translate( 'Payment pending' );
+			case 'processing':
+			case 'completed':
+				return translate( 'Paid in full' );
+			case 'cancelled':
+				return translate( 'Cancelled' );
+			case 'refunded':
+				return translate( 'Refunded' );
+			case 'failed':
+				return translate( 'Payment failed' );
+		}
+		return false;
+	};
+
+	getShippingLabel = () => {
+		const { status, translate } = this.props;
+		switch ( status ) {
+			case 'pending':
+			case 'processing':
+				return translate( 'New order' );
+			case 'on-hold':
+				return translate( 'On hold' );
+			case 'completed':
+				return translate( 'Fulfilled' );
+		}
+		return false;
+	};
+
+	render() {
+		const { showPayment = true, showShipping = true, status } = this.props;
+		const classes = `order-status__item is-${ status }`;
+		const paymentLabel = this.getPaymentLabel();
+		const shippingLabel = this.getShippingLabel();
+
+		// Status was unrecognized, there is no label content to display
+		if ( ! shippingLabel && ! paymentLabel ) {
+			return null;
+		}
+
+		return (
+			<span className={ classes }>
+				{ shippingLabel && showShipping ? (
+					<span className="order-status__shipping">{ shippingLabel }</span>
+				) : null }
+				{ showPayment ? <span className="order-status__payment">{ paymentLabel }</span> : null }
+			</span>
+		);
 	}
-
-	return (
-		<span className={ classes }>
-			{ shippingLabel && showShipping ? (
-				<span className="order-status__shipping">{ shippingLabel }</span>
-			) : null }
-			{ showPayment ? <span className="order-status__payment">{ paymentLabel }</span> : null }
-		</span>
-	);
 }
 
 export default localize( OrderStatus );

--- a/client/extensions/woocommerce/components/order-status/index.js
+++ b/client/extensions/woocommerce/components/order-status/index.js
@@ -56,7 +56,7 @@ export class OrderStatus extends Component {
 	};
 
 	render() {
-		const { showPayment = true, showShipping = true, status } = this.props;
+		const { order: { status }, showPayment = true, showShipping = true } = this.props;
 		const classes = `order-status__item is-${ status }`;
 		const paymentLabel = this.getPaymentLabel();
 		const shippingLabel = this.getShippingLabel();

--- a/client/extensions/woocommerce/components/order-status/test/index.js
+++ b/client/extensions/woocommerce/components/order-status/test/index.js
@@ -16,15 +16,20 @@ import { OrderStatus } from '../';
 
 describe( 'OrderStatus', () => {
 	test( 'should render a label with shipping and payment content', () => {
-		const wrapper = shallow( <OrderStatus status={ 'pending' } translate={ identity } /> );
+		const order = {
+			status: 'pending',
+			payment_method: 'paypal',
+		};
+		const wrapper = shallow( <OrderStatus order={ order } translate={ identity } /> );
 		expect( wrapper.find( '.order-status__item' ) ).to.have.length( 1 );
 		expect( wrapper.find( '.order-status__shipping' ) ).to.have.length( 1 );
 		expect( wrapper.find( '.order-status__payment' ) ).to.have.length( 1 );
 	} );
 
 	test( 'should render only payment label when showShipping is false', () => {
+		const order = { status: 'pending' };
 		const wrapper = shallow(
-			<OrderStatus status={ 'pending' } showShipping={ false } translate={ identity } />
+			<OrderStatus order={ order } showShipping={ false } translate={ identity } />
 		);
 		expect( wrapper.find( '.order-status__item' ) ).to.have.length( 1 );
 		expect( wrapper.find( '.order-status__shipping' ) ).to.have.length( 0 );
@@ -32,8 +37,9 @@ describe( 'OrderStatus', () => {
 	} );
 
 	test( 'should render only payment label when shipping does not apply to this status', () => {
+		const order = { status: 'refunded' };
 		const wrapper = shallow(
-			<OrderStatus status={ 'refunded' } showShipping={ false } translate={ identity } />
+			<OrderStatus order={ order } showShipping={ false } translate={ identity } />
 		);
 		expect( wrapper.find( '.order-status__item' ) ).to.have.length( 1 );
 		expect( wrapper.find( '.order-status__shipping' ) ).to.have.length( 0 );
@@ -41,16 +47,29 @@ describe( 'OrderStatus', () => {
 	} );
 
 	test( 'should render only shipping label when showPayment is false', () => {
+		const order = { status: 'completed' };
 		const wrapper = shallow(
-			<OrderStatus status={ 'completed' } showPayment={ false } translate={ identity } />
+			<OrderStatus order={ order } showPayment={ false } translate={ identity } />
 		);
 		expect( wrapper.find( '.order-status__item' ) ).to.have.length( 1 );
 		expect( wrapper.find( '.order-status__shipping' ) ).to.have.length( 1 );
 		expect( wrapper.find( '.order-status__payment' ) ).to.have.length( 0 );
 	} );
 
+	test( 'should render only payment as "Pending" when for a processing cash-on-delivery order', () => {
+		const order = {
+			status: 'processing',
+			payment_method: 'cod',
+		};
+		const wrapper = shallow( <OrderStatus order={ order } translate={ identity } /> );
+		expect( wrapper.find( '.order-status__item' ) ).to.have.length( 1 );
+		expect( wrapper.find( '.order-status__shipping' ).text() ).to.eql( 'New order' );
+		expect( wrapper.find( '.order-status__payment' ).text() ).to.eql( 'Payment pending' );
+	} );
+
 	test( 'should not render anything if the status is not recognized', () => {
-		const wrapper = shallow( <OrderStatus status={ 'fake-status' } translate={ identity } /> );
+		const order = { status: 'fake-status' };
+		const wrapper = shallow( <OrderStatus order={ order } translate={ identity } /> );
 		expect( wrapper.getNode() ).to.be.null;
 	} );
 } );

--- a/client/extensions/woocommerce/components/order-status/test/index.js
+++ b/client/extensions/woocommerce/components/order-status/test/index.js
@@ -56,7 +56,7 @@ describe( 'OrderStatus', () => {
 		expect( wrapper.find( '.order-status__payment' ) ).to.have.length( 0 );
 	} );
 
-	test( 'should render only payment as "Pending" when for a processing cash-on-delivery order', () => {
+	test( 'should render correct labels for a processing cash-on-delivery order', () => {
 		const order = {
 			status: 'processing',
 			payment_method: 'cod',
@@ -64,7 +64,7 @@ describe( 'OrderStatus', () => {
 		const wrapper = shallow( <OrderStatus order={ order } translate={ identity } /> );
 		expect( wrapper.find( '.order-status__item' ) ).to.have.length( 1 );
 		expect( wrapper.find( '.order-status__shipping' ).text() ).to.eql( 'New order' );
-		expect( wrapper.find( '.order-status__payment' ).text() ).to.eql( 'Payment pending' );
+		expect( wrapper.find( '.order-status__payment' ).text() ).to.eql( 'Paid on delivery' );
 	} );
 
 	test( 'should not render anything if the status is not recognized', () => {

--- a/client/extensions/woocommerce/components/order-status/test/index.js
+++ b/client/extensions/woocommerce/components/order-status/test/index.js
@@ -1,0 +1,56 @@
+/**
+ * External dependencies
+ *
+ * @format
+ */
+
+import React from 'react';
+import { expect } from 'chai';
+import { identity } from 'lodash';
+import { shallow } from 'enzyme';
+
+/**
+ * Internal dependencies
+ */
+import { OrderStatus } from '../';
+
+describe( 'OrderStatus', () => {
+	test( 'should render a label with shipping and payment content', () => {
+		const wrapper = shallow( <OrderStatus status={ 'pending' } translate={ identity } /> );
+		expect( wrapper.find( '.order-status__item' ) ).to.have.length( 1 );
+		expect( wrapper.find( '.order-status__shipping' ) ).to.have.length( 1 );
+		expect( wrapper.find( '.order-status__payment' ) ).to.have.length( 1 );
+	} );
+
+	test( 'should render only payment label when showShipping is false', () => {
+		const wrapper = shallow(
+			<OrderStatus status={ 'pending' } showShipping={ false } translate={ identity } />
+		);
+		expect( wrapper.find( '.order-status__item' ) ).to.have.length( 1 );
+		expect( wrapper.find( '.order-status__shipping' ) ).to.have.length( 0 );
+		expect( wrapper.find( '.order-status__payment' ) ).to.have.length( 1 );
+	} );
+
+	test( 'should render only payment label when shipping does not apply to this status', () => {
+		const wrapper = shallow(
+			<OrderStatus status={ 'refunded' } showShipping={ false } translate={ identity } />
+		);
+		expect( wrapper.find( '.order-status__item' ) ).to.have.length( 1 );
+		expect( wrapper.find( '.order-status__shipping' ) ).to.have.length( 0 );
+		expect( wrapper.find( '.order-status__payment' ) ).to.have.length( 1 );
+	} );
+
+	test( 'should render only shipping label when showPayment is false', () => {
+		const wrapper = shallow(
+			<OrderStatus status={ 'completed' } showPayment={ false } translate={ identity } />
+		);
+		expect( wrapper.find( '.order-status__item' ) ).to.have.length( 1 );
+		expect( wrapper.find( '.order-status__shipping' ) ).to.have.length( 1 );
+		expect( wrapper.find( '.order-status__payment' ) ).to.have.length( 0 );
+	} );
+
+	test( 'should not render anything if the status is not recognized', () => {
+		const wrapper = shallow( <OrderStatus status={ 'fake-status' } translate={ identity } /> );
+		expect( wrapper.getNode() ).to.be.null;
+	} );
+} );

--- a/client/extensions/woocommerce/components/order-status/test/index.js
+++ b/client/extensions/woocommerce/components/order-status/test/index.js
@@ -22,6 +22,7 @@ describe( 'OrderStatus', () => {
 		};
 		const wrapper = shallow( <OrderStatus order={ order } translate={ identity } /> );
 		expect( wrapper.find( '.order-status__item' ) ).to.have.length( 1 );
+		expect( wrapper.find( '.order-status__item' ).hasClass( 'is-pending' ) ).to.equal( true );
 		expect( wrapper.find( '.order-status__shipping' ) ).to.have.length( 1 );
 		expect( wrapper.find( '.order-status__payment' ) ).to.have.length( 1 );
 	} );
@@ -42,6 +43,7 @@ describe( 'OrderStatus', () => {
 			<OrderStatus order={ order } showShipping={ false } translate={ identity } />
 		);
 		expect( wrapper.find( '.order-status__item' ) ).to.have.length( 1 );
+		expect( wrapper.find( '.order-status__item' ).hasClass( 'is-refunded' ) ).to.equal( true );
 		expect( wrapper.find( '.order-status__shipping' ) ).to.have.length( 0 );
 		expect( wrapper.find( '.order-status__payment' ) ).to.have.length( 1 );
 	} );
@@ -52,6 +54,7 @@ describe( 'OrderStatus', () => {
 			<OrderStatus order={ order } showPayment={ false } translate={ identity } />
 		);
 		expect( wrapper.find( '.order-status__item' ) ).to.have.length( 1 );
+		expect( wrapper.find( '.order-status__item' ).hasClass( 'is-completed' ) ).to.equal( true );
 		expect( wrapper.find( '.order-status__shipping' ) ).to.have.length( 1 );
 		expect( wrapper.find( '.order-status__payment' ) ).to.have.length( 0 );
 	} );
@@ -63,6 +66,7 @@ describe( 'OrderStatus', () => {
 		};
 		const wrapper = shallow( <OrderStatus order={ order } translate={ identity } /> );
 		expect( wrapper.find( '.order-status__item' ) ).to.have.length( 1 );
+		expect( wrapper.find( '.order-status__item' ).hasClass( 'is-processing' ) ).to.equal( true );
 		expect( wrapper.find( '.order-status__shipping' ).text() ).to.eql( 'New order' );
 		expect( wrapper.find( '.order-status__payment' ).text() ).to.eql( 'Paid on delivery' );
 	} );


### PR DESCRIPTION
Fixes #18955: Orders placed with "cash on delivery" as payment are sent into the processing status, which we currently label as "Paid in full". This isn't true for COD orders, but they do need to be shipped out, so they're not awaiting payment either. This PR updates the `OrderStatus` component to take the whole `order` object, and check the payment status for the special "COD" case. I've also added tests for this component (thus increasing PR size 😣 ).

New label in context, with other statuses:

![screen shot 2017-10-18 at 4 35 28 pm](https://user-images.githubusercontent.com/541093/31743598-ab5d1d90-b429-11e7-8500-a871f5cb3e41.png)

On the single order screen:

![screen shot 2017-10-18 at 4 35 56 pm](https://user-images.githubusercontent.com/541093/31743599-ab696bd6-b429-11e7-87fa-46df4d60ea5e.png)

And the payment card has also been updated to indicate that payment will happen later, and no refund button (since no payment to refund yet). Could use better copy, maybe?

![screen shot 2017-10-18 at 4 54 48 pm](https://user-images.githubusercontent.com/541093/31743600-ab750aa4-b429-11e7-9e33-e0851179e8c9.png)

To test

- Run tests: `npm run test-client client/extensions/woocommerce/components/order-status`
- Create a cash on delivery order (you might need to enable the payment option in settings)
- View your orders, see the new order with the new label
- Click into the order, see the payment status label in the top right
- The payment card notes payment on delivery, with no refund option