### PR TITLE
Reader Tracks: add counter prop to calypso_page_view event

### DIFF
--- a/client/lib/analytics/index.js
+++ b/client/lib/analytics/index.js
@@ -160,6 +160,11 @@ function buildQuerystringNoPrefix( group, name ) {
 // this helps avoid some nasty coupling, but it's not the cleanest code - sorry.
 let mostRecentUrlPath = null;
 
+// pathCounter is used to keep track of the order of calypso_page_view Tracks
+// events. The pathCounter value is appended to the last_pageview_path_with_count and
+// this_pageview_path_with_count Tracks event props.
+let pathCounter = 0;
+
 if ( typeof window !== 'undefined' ) {
 	window.addEventListener( 'popstate', function() {
 		// throw away our URL value if the user used the back/forward buttons
@@ -241,7 +246,10 @@ const analytics = {
 			// add delay to avoid stale `_dl` in recorded calypso_page_view event details
 			// `_dl` (browserdocumentlocation) is read from the current URL by external JavaScript
 			setTimeout( () => {
-				params.last_pageview_path = mostRecentUrlPath;
+				params.last_pageview_path_with_count =
+					mostRecentUrlPath + '(' + pathCounter.toString() + ')';
+				pathCounter++;
+				params.this_pageview_path_with_count = urlPath + '(' + pathCounter.toString() + ')';
 				analytics.tracks.recordPageView( urlPath, params );
 				analytics.ga.recordPageView( urlPath, pageTitle );
 				analytics.emit( 'page-view', urlPath, pageTitle );


### PR DESCRIPTION
Adds a pageCounter value to the properties on `calypso_page_view` events:

- last_pageview_path
- this_pageview_path

This is useful to determine which pages users are visiting (and in what order) when navigating Calypso.

## Example:

If a user views the Calypso pages in the following order:

- https://wordpress.com/
- https://wordpress.com/discover
- https://wordpress.com/read/blogs/53424024/posts/29496

Then we will have three `calypso_page_view` tracks events recorded each with the following properties:

- { last_pageview_path: null(0), this_pageview_path: /(1) }
- { last_pageview_path: /(1), this_pageview_path: /discover(2) }
- { last_pageview_path: /discover(2), this_pageview_path: /read/blogs/:blog_id/posts/:post_id(3) }
