### PR TITLE
Fix import of lib/oauth-token which doesn't have a default export

### DIFF
--- a/client/lib/desktop/index.js
+++ b/client/lib/desktop/index.js
@@ -17,7 +17,7 @@ import userFactory from 'lib/user';
 const user = userFactory();
 import { ipcRenderer as ipc } from 'electron'; // From Electron
 import store from 'store';
-import oAuthToken from 'lib/oauth-token';
+import * as oAuthToken from 'lib/oauth-token';
 import userUtilities from 'lib/user/utils';
 import location from 'lib/route/page-notifier';
 import { getStatsPathForTab } from 'lib/route/path';


### PR DESCRIPTION
Fixes
```
build.js:225081 Uncaught (in promise) TypeError: Cannot read property 'getToken' of undefined
    at Object.sendUserLoginStatus (build.js:225081)
    at Object.init (build.js:225040)
    at Object.setupMiddlewares (build.js:41693)
    at apply (build.js:636268)
    at baseInvoke (build.js:638891)
    at apply (build.js:636269)
    at build.js:639616
    at build.js:41113
sendUserLoginStatus @ build.js:225081
init @ build.js:225040
setupMiddlewares @ build.js:41693
apply @ build.js:636268
baseInvoke @ build.js:638891
apply @ build.js:636269
(anonymous) @ build.js:639616
(anonymous) @ build.js:41113
public-api.wordpress.com/rest/v1.1/pinghub/wpcom/me/newest-note-data:1 GET https://public-api.wordpress.com/rest/v1.1/pinghub/wpcom/me/newest-note-data 404 ()
```

In the desktop build. It seems this change broke it: https://github.com/Automattic/wp-calypso/pull/18359/files#diff-ae1ff44673035d4641bec63b8bdf05e0L14
/cc @ockham 

### Testing instruction
- Load this branch on the `calypso` submodule of `wp-desktop`.
- From the `wp-desktop` directory, run `make clean` then `make run`.
- Wait for the app to boot (this can take a while)
- Assert that you can log in.

### Reviews
- [x] Code
- [x] Product
