### PR TITLE
Framework: Pre-emptive fixes for the create-class codemod

### DIFF
--- a/client/components/button-group/docs/example.jsx
+++ b/client/components/button-group/docs/example.jsx
@@ -15,7 +15,7 @@ import Button from 'components/button';
 import Card from 'components/card';
 import Gridicon from 'gridicons';
 
-var Buttons = React.createClass( {
+const Buttons = React.createClass( {
 	displayName: 'ButtonGroup',
 
 	mixins: [ PureRenderMixin ],

--- a/client/components/button/docs/example.jsx
+++ b/client/components/button/docs/example.jsx
@@ -16,7 +16,7 @@ import Card from 'components/card';
 import config from 'config';
 import DocsExample from 'devdocs/docs-example';
 
-var Buttons = React.createClass( {
+const Buttons = React.createClass( {
 	displayName: 'Buttons',
 
 	mixins: [ PureRenderMixin ],

--- a/client/components/card/docs/example.jsx
+++ b/client/components/card/docs/example.jsx
@@ -12,7 +12,7 @@ import React from 'react';
 import Card from 'components/card';
 import CompactCard from 'components/card/compact';
 
-var Cards = React.createClass( {
+const Cards = React.createClass( {
 	displayName: 'Cards',
 
 	getInitialState: function() {

--- a/client/components/data/cart/index.jsx
+++ b/client/components/data/cart/index.jsx
@@ -20,7 +20,7 @@ function getStateFromStores() {
 	};
 }
 
-var CartData = React.createClass( {
+const CartData = React.createClass( {
 	render: function() {
 		return (
 			<StoreConnection stores={ stores } getStateFromStores={ getStateFromStores }>

--- a/client/components/data/checkout/index.jsx
+++ b/client/components/data/checkout/index.jsx
@@ -22,7 +22,7 @@ function getStateFromStores() {
 	};
 }
 
-var CheckoutData = React.createClass( {
+const CheckoutData = React.createClass( {
 	render: function() {
 		return (
 			<StoreConnection stores={ stores } getStateFromStores={ getStateFromStores }>

--- a/client/components/infinite-list/README.md
+++ b/client/components/infinite-list/README.md
@@ -35,7 +35,7 @@ If you need to track when user scrolls to another page, do it in `fetchNextPage`
 
 ```jsx
 
-var Listing = React.createClass( {
+const Listing = React.createClass( {
 	...
 	fetchNextPage: funciton ( options ) {
 		if ( options.triggeredByScroll ) {

--- a/client/components/info-popover/docs/example.jsx
+++ b/client/components/info-popover/docs/example.jsx
@@ -12,7 +12,7 @@ import PureRenderMixin from 'react-pure-render/mixin';
 */
 import InfoPopover from 'components/info-popover';
 
-var InfoPopoverExample = React.createClass( {
+const InfoPopoverExample = React.createClass( {
 	displayName: 'InfoPopover',
 
 	mixins: [ PureRenderMixin ],

--- a/client/components/notice/docs/example.jsx
+++ b/client/components/notice/docs/example.jsx
@@ -13,7 +13,7 @@ import PureRenderMixin from 'react-pure-render/mixin';
 import NoticeAction from 'components/notice/notice-action';
 import Notice from 'components/notice';
 
-var Notices = React.createClass( {
+const Notices = React.createClass( {
 	mixins: [ PureRenderMixin ],
 
 	getInitialState: function() {

--- a/client/components/post-excerpt/index.jsx
+++ b/client/components/post-excerpt/index.jsx
@@ -1,11 +1,9 @@
+/** @format */
 /**
  * External dependencies
- *
- * @format
  */
-
-import PropTypes from 'prop-types';
 import React from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import AutoDirection from 'components/auto-direction';
 import Emojify from 'components/emojify';
@@ -16,8 +14,8 @@ const PostExcerpt = React.createClass( {
 		maxLength: PropTypes.number,
 	},
 
-	defaultProps: {
-		maxLength: 80,
+	getDefaultProps() {
+		return { maxLength: 80 };
 	},
 
 	render() {

--- a/client/components/pulsing-dot/index.jsx
+++ b/client/components/pulsing-dot/index.jsx
@@ -12,7 +12,7 @@ import classnames from 'classnames';
  */
 import analytics from 'lib/analytics';
 
-var PulsingDot = React.createClass( {
+const PulsingDot = React.createClass( {
 	getDefaultProps: function() {
 		return {
 			active: false,

--- a/client/components/segmented-control/docs/example.jsx
+++ b/client/components/segmented-control/docs/example.jsx
@@ -16,7 +16,7 @@ import ControlItem from 'components/segmented-control/item';
 /**
  * Segmented Control Demo
  */
-var SegmentedControlDemo = React.createClass( {
+const SegmentedControlDemo = React.createClass( {
 	displayName: 'SegmentedControl',
 
 	mixins: [ PureRenderMixin ],

--- a/client/components/segmented-control/index.jsx
+++ b/client/components/segmented-control/index.jsx
@@ -23,7 +23,7 @@ var _instance = 1;
 /**
  * SegmentedControl
  */
-var SegmentedControl = React.createClass( {
+const SegmentedControl = React.createClass( {
 	propTypes: {
 		initialSelected: PropTypes.string,
 		compact: PropTypes.bool,

--- a/client/components/segmented-control/item.jsx
+++ b/client/components/segmented-control/item.jsx
@@ -11,7 +11,7 @@ import classNames from 'classnames';
 /**
  * SegmentedControlItem
  */
-var SegmentedControlItem = React.createClass( {
+const SegmentedControlItem = React.createClass( {
 	propTypes: {
 		children: PropTypes.node.isRequired,
 		path: PropTypes.string,

--- a/client/components/select/docs/example.jsx
+++ b/client/components/select/docs/example.jsx
@@ -7,7 +7,7 @@
 import React from 'react';
 import PureRenderMixin from 'react-pure-render/mixin';
 
-var Selects = React.createClass( {
+const Selects = React.createClass( {
 	mixins: [ PureRenderMixin ],
 
 	render: function() {

--- a/client/components/stat-update-indicator/index.jsx
+++ b/client/components/stat-update-indicator/index.jsx
@@ -11,7 +11,7 @@ import classNames from 'classnames';
 /**
  * Internal dependencies
  */
-var StatUpdateIndicator = React.createClass( {
+const StatUpdateIndicator = React.createClass( {
 	propTypes: {
 		children: PropTypes.node.isRequired,
 		updateOn: PropTypes.oneOfType( [ PropTypes.string, PropTypes.number, PropTypes.bool ] )

--- a/client/components/tinymce/plugins/wplink/dialog.jsx
+++ b/client/components/tinymce/plugins/wplink/dialog.jsx
@@ -37,7 +37,7 @@ var REGEXP_EMAIL = /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,4}$/i,
 	REGEXP_URL = /^(https?|ftp):\/\/[A-Z0-9.-]+\.[A-Z]{2,4}[^ "]*$/i,
 	REGEXP_STANDALONE_URL = /^(?:[a-z]+:|#|\?|\.|\/)/;
 
-var LinkDialog = React.createClass( {
+const LinkDialog = React.createClass( {
 	propTypes: {
 		visible: PropTypes.bool,
 		editor: PropTypes.object,

--- a/client/components/token-field/docs/example.jsx
+++ b/client/components/token-field/docs/example.jsx
@@ -77,7 +77,7 @@ var suggestions = [
 	'their',
 ];
 
-var TokenFields = React.createClass( {
+const TokenFields = React.createClass( {
 	displayName: 'TokenFields',
 
 	mixins: [ PureRenderMixin ],

--- a/client/components/token-field/index.jsx
+++ b/client/components/token-field/index.jsx
@@ -19,7 +19,7 @@ import SuggestionsList from './suggestions-list';
 import Token from './token';
 import TokenInput from './token-input';
 
-var TokenField = React.createClass( {
+const TokenField = React.createClass( {
 	propTypes: {
 		suggestions: PropTypes.array,
 		maxSuggestions: PropTypes.number,

--- a/client/components/token-field/suggestions-list.jsx
+++ b/client/components/token-field/suggestions-list.jsx
@@ -11,7 +11,7 @@ import PureRenderMixin from 'react-pure-render/mixin';
 import classNames from 'classnames';
 import scrollIntoView from 'dom-scroll-into-view';
 
-var SuggestionsList = React.createClass( {
+const SuggestionsList = React.createClass( {
 	propTypes: {
 		isExpanded: PropTypes.bool,
 		match: PropTypes.string,

--- a/client/components/token-field/test/lib/token-field-wrapper.jsx
+++ b/client/components/token-field/test/lib/token-field-wrapper.jsx
@@ -49,7 +49,7 @@ var suggestions = [
 	'sound',
 ];
 
-var TokenFieldWrapper = React.createClass( {
+const TokenFieldWrapper = React.createClass( {
 	getInitialState: function() {
 		return {
 			tokenSuggestions: suggestions,

--- a/client/components/token-field/token-input.jsx
+++ b/client/components/token-field/token-input.jsx
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import PureRenderMixin from 'react-pure-render/mixin';
 
-var TokenInput = React.createClass( {
+const TokenInput = React.createClass( {
 	propTypes: {
 		onChange: PropTypes.func,
 		onBlur: PropTypes.func,

--- a/client/lib/mixins/data-observe/README.md
+++ b/client/lib/mixins/data-observe/README.md
@@ -10,7 +10,7 @@ A React mixin that makes it easy to trigger re-rendering of a component when a `
 ```js
 var observe = require( 'lib/mixins/data-observe' );
 
-var Component = React.createClass({
+const Component = React.createClass({
 	mixins: [ observe( 'sites', 'user' ) ]
 });
 ```

--- a/client/lib/mixins/data-observe/README.md
+++ b/client/lib/mixins/data-observe/README.md
@@ -1,6 +1,8 @@
 Data Change
 ===========
 
+**This is deprecated! Please use Redux instead. Refer to the [docs on data handling](/docs/our-approach-to-data.md).**
+
 A React mixin that makes it easy to trigger re-rendering of a component when a `prop` emits a `change` event.
 
 

--- a/client/lib/signup/README.md
+++ b/client/lib/signup/README.md
@@ -63,7 +63,7 @@ SignupDependencyStore.get() // => { userId: 1337 }
 var SignupFlowController = require( 'lib/signup/flow-controller' );
 
 // this is the component that renders the signup flow
-var SignupComponent = React.createClass( {
+const SignupComponent = React.createClass( {
 	componentWillMount: function() {
 		this.signupFlowController = SignupFlowController( {
 			flowName: 'default', // the name of the flow to begin, from flows.json

--- a/client/me/billing-history/transactions-table.jsx
+++ b/client/me/billing-history/transactions-table.jsx
@@ -18,7 +18,7 @@ import tableRows from './table-rows';
 
 import SearchCard from 'components/search-card';
 
-var TransactionsTable = React.createClass( {
+const TransactionsTable = React.createClass( {
 	displayName: 'TransactionsTable',
 
 	getInitialState: function() {

--- a/client/my-sites/checkout/cart/cart-empty.jsx
+++ b/client/my-sites/checkout/cart/cart-empty.jsx
@@ -9,7 +9,7 @@ import { localize } from 'i18n-calypso';
 import React from 'react';
 import page from 'page';
 
-var CartEmpty = React.createClass( {
+const CartEmpty = React.createClass( {
 	render: function() {
 		return (
 			<div>

--- a/client/my-sites/checkout/cart/cart-total.jsx
+++ b/client/my-sites/checkout/cart/cart-total.jsx
@@ -13,7 +13,7 @@ import { localize } from 'i18n-calypso';
  */
 import { cartItems } from 'lib/cart-values';
 
-var CartTotal = React.createClass( {
+const CartTotal = React.createClass( {
 	render: function() {
 		var cart = this.props.cart;
 

--- a/client/my-sites/checkout/checkout/credit-card-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/credit-card-payment-box.jsx
@@ -34,7 +34,7 @@ import { PLAN_BUSINESS } from 'lib/plans/constants';
 import ProgressBar from 'components/progress-bar';
 import CartToggle from './cart-toggle';
 
-var CreditCardPaymentBox = React.createClass( {
+const CreditCardPaymentBox = React.createClass( {
 	getInitialState: function() {
 		return {
 			progress: 0,

--- a/client/my-sites/checkout/checkout/credit-card-selector.jsx
+++ b/client/my-sites/checkout/checkout/credit-card-selector.jsx
@@ -17,7 +17,7 @@ import NewCardForm from './new-card-form';
 import storeTransactions from 'lib/store-transactions';
 import upgradesActions from 'lib/upgrades/actions';
 
-var CreditCardSelector = React.createClass( {
+const CreditCardSelector = React.createClass( {
 	getInitialState: function() {
 		if ( this.props.initialCard ) {
 			return { section: this.props.initialCard.stored_details_id };

--- a/client/my-sites/checkout/checkout/credits-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/credits-payment-box.jsx
@@ -21,7 +21,7 @@ import config from 'config';
 import { PLAN_BUSINESS } from 'lib/plans/constants';
 import CartToggle from './cart-toggle';
 
-var CreditsPaymentBox = React.createClass( {
+const CreditsPaymentBox = React.createClass( {
 	content: function() {
 		const { cart, transactionStep } = this.props;
 		const hasBusinessPlanInCart = some( cart.products, { product_slug: PLAN_BUSINESS } );

--- a/client/my-sites/checkout/checkout/free-cart-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/free-cart-payment-box.jsx
@@ -16,7 +16,7 @@ import PaymentBox from './payment-box';
 import TermsOfService from './terms-of-service';
 import CartToggle from './cart-toggle';
 
-var FreeCartPaymentBox = React.createClass( {
+const FreeCartPaymentBox = React.createClass( {
 	propTypes: {
 		products: PropTypes.object.isRequired,
 	},

--- a/client/my-sites/checkout/checkout/pay-button.jsx
+++ b/client/my-sites/checkout/checkout/pay-button.jsx
@@ -22,7 +22,7 @@ import {
 	SUBMITTING_WPCOM_REQUEST,
 } from 'lib/store-transactions/step-types';
 
-var PayButton = React.createClass( {
+const PayButton = React.createClass( {
 	buttonState: function() {
 		var state;
 

--- a/client/my-sites/domains/domain-management/email-forwarding/email-forwarding-details.jsx
+++ b/client/my-sites/domains/domain-management/email-forwarding/email-forwarding-details.jsx
@@ -14,7 +14,7 @@ import { localize } from 'i18n-calypso';
 import support from 'lib/url/support';
 import analyticsMixin from 'lib/mixins/analytics';
 
-var EmailForwardingDetails = React.createClass( {
+const EmailForwardingDetails = React.createClass( {
 	mixins: [ analyticsMixin( 'domainManagement', 'emailForwarding' ) ],
 
 	render: function() {

--- a/client/my-sites/domains/domain-management/email-forwarding/email-forwarding-list.jsx
+++ b/client/my-sites/domains/domain-management/email-forwarding/email-forwarding-list.jsx
@@ -13,7 +13,7 @@ import { localize } from 'i18n-calypso';
  */
 import EmailForwardingItem from './email-forwarding-item';
 
-var EmailForwardingList = React.createClass( {
+const EmailForwardingList = React.createClass( {
 	render: function() {
 		var emailForwardingItems,
 			{ list, hasLoadedFromServer } = this.props.emailForwarding;

--- a/client/my-sites/no-results/index.jsx
+++ b/client/my-sites/no-results/index.jsx
@@ -6,7 +6,7 @@
 
 import React from 'react';
 
-var noResults = React.createClass( {
+const noResults = React.createClass( {
 	getDefaultProps: function() {
 		return {
 			text: 'No results',

--- a/client/my-sites/no-results/index.jsx
+++ b/client/my-sites/no-results/index.jsx
@@ -1,12 +1,10 @@
+/** @format */
 /**
  * External dependencies
- *
- * @format
  */
-
 import React from 'react';
 
-const noResults = React.createClass( {
+const NoResults = React.createClass( {
 	getDefaultProps: function() {
 		return {
 			text: 'No results',
@@ -24,4 +22,4 @@ const noResults = React.createClass( {
 	},
 } );
 
-export default noResults;
+export default NoResults;

--- a/client/my-sites/post/post-image/index.jsx
+++ b/client/my-sites/post/post-image/index.jsx
@@ -12,7 +12,7 @@ import classnames from 'classnames';
 /**
  * Main
  */
-var PostImage = React.createClass( {
+const PostImage = React.createClass( {
 	mixins: [ PureRenderMixin ],
 
 	propTypes: {

--- a/client/my-sites/sites/README.md
+++ b/client/my-sites/sites/README.md
@@ -14,7 +14,7 @@ Handles the single site view. It can be used by any compoenent that needs to ren
 ```javascript
 var Site = require( 'my-sites/sites/site' );
 
-var Component = React.createClass({
+const Component = React.createClass({
   render: function() {
     return (
       <Site site={ site } />

--- a/docs/coding-guidelines/html.md
+++ b/docs/coding-guidelines/html.md
@@ -42,7 +42,7 @@ When mixing JavaScript and HTML (via JSX) together, indent JavaScript blocks to 
 Correct:
 
 ```js
-var Post = React.createClass({
+const Post = React.createClass({
 
 	render: function() {
 		var post = this.props.post;
@@ -62,7 +62,7 @@ var Post = React.createClass({
 Incorrect:
 
 ```js
-var Post = React.createClass({
+const Post = React.createClass({
 
 	render: function() {
 		var post = this.props.post;


### PR DESCRIPTION
Replace occurrences of 

```js
var MyComponent = React.createClass( { ...
```

with

```js
const MyComponent = React.createClass( { ...
```

(Rationale: #18889 seemed to indicate that the `create-class` codemod can't parse these instances.) 

Furthermore, in `components/post-excerpt/index.jsx`: fix one stray occurrence of `defaultProps` used in a `createClass` context (needs to be `getDefaultProps()` there)!