### PR TITLE
Domains: refactored HiddenInput Component to ES6

### DIFF
--- a/client/my-sites/checkout/checkout/style.scss
+++ b/client/my-sites/checkout/checkout/style.scss
@@ -555,7 +555,7 @@
 				margin-top: 0;
 			}
 
-			.hidden-input a,
+			.form__hidden-input a,
 			.checkout-field {
 				float: left;
 				width: 100%;
@@ -595,7 +595,7 @@
 			}
 		}
 
-		.hidden-input a {
+		.form__hidden-input a {
 			display: block;
 			font-size: 12px;
 			margin-top: 5px;

--- a/client/my-sites/domains/components/form/hidden-input.jsx
+++ b/client/my-sites/domains/components/form/hidden-input.jsx
@@ -43,7 +43,7 @@ export class HiddenInput extends PureComponent {
 		}
 
 		return (
-			<div className="form__hidden-input hidden-input">
+			<div className="form__hidden-input">
 				<a href="" onClick={ this.handleClick }>
 					{ this.props.text }
 				</a>

--- a/client/my-sites/domains/components/form/hidden-input.jsx
+++ b/client/my-sites/domains/components/form/hidden-input.jsx
@@ -3,56 +3,53 @@
  *
  * @format
  */
-
-import { isEmpty } from 'lodash';
-import React from 'react';
+import React, { PureComponent } from 'react';
+import isEmpty from 'lodash/isEmpty';
 
 /**
  * Internal dependencies
  */
 import Input from './input';
 
-export default React.createClass( {
-	displayName: 'HiddenInput',
-
-	componentWillReceiveProps: function( nextProps ) {
-		if ( ! this.state.toggled && ! isEmpty( nextProps.value ) ) {
-			this.setState( { toggled: true } );
-		}
-	},
-
-	getInitialState: function() {
-		return {
-			toggled: false,
+export class HiddenInput extends PureComponent {
+	constructor( props, context ) {
+		super( props, context );
+		this.state = {
+			toggled: ! isEmpty( props.value ),
 		};
-	},
+		this.inputField = null;
+	}
 
-	componentDidUpdate: function( prevProps, prevState ) {
-		// Focus the input only when the user explicitly clicked the toggle link
-		if ( ! prevState.toggled && this.state.toggled && prevProps.value === this.props.value ) {
-			this.refs.input.focus();
-		}
-	},
-
-	handleClick: function( event ) {
+	handleClick = event => {
 		event.preventDefault();
 
-		this.setState( {
-			toggled: true,
-		} );
-	},
+		this.setState(
+			{
+				toggled: true,
+			},
+			() => {
+				this.inputField && this.inputField.focus();
+			}
+		);
+	};
 
-	render: function() {
+	assignInputFieldRef = input => {
+		this.inputField = input;
+	};
+
+	render() {
 		if ( this.state.toggled ) {
-			return <Input ref="input" { ...this.props } />;
+			return <Input ref={ this.assignInputFieldRef } { ...this.props } />;
 		}
 
 		return (
-			<div className="hidden-input">
+			<div className="form__hidden-input hidden-input">
 				<a href="" onClick={ this.handleClick }>
 					{ this.props.text }
 				</a>
 			</div>
 		);
-	},
-} );
+	}
+}
+
+export default HiddenInput;

--- a/client/my-sites/domains/components/form/test/hidden-input.js
+++ b/client/my-sites/domains/components/form/test/hidden-input.js
@@ -20,8 +20,8 @@ describe( 'HiddenInput', () => {
 	test( 'it should return expected elements with defaultProps and no props value', () => {
 		const wrapper = shallow( <HiddenInput { ...defaultProps } /> );
 		expect( wrapper.state( 'toggled' ) ).to.be.false;
-		expect( wrapper.find( '.hidden-input' ) ).to.have.length( 1 );
-		expect( wrapper.find( '.hidden-input a' ).text() ).to.equal( defaultProps.text );
+		expect( wrapper.find( '.form__hidden-input' ) ).to.have.length( 1 );
+		expect( wrapper.find( '.form__hidden-input a' ).text() ).to.equal( defaultProps.text );
 		const inputComponent = wrapper.find( 'Input' );
 		expect( inputComponent ).to.have.length( 0 );
 	} );
@@ -30,7 +30,7 @@ describe( 'HiddenInput', () => {
 		const fieldValue = 'Not empty';
 		const wrapper = shallow( <HiddenInput { ...defaultProps } value={ fieldValue } /> );
 		expect( wrapper.state( 'toggled' ) ).to.be.true;
-		expect( wrapper.find( '.hidden-input' ) ).to.have.length( 0 );
+		expect( wrapper.find( '.form__hidden-input' ) ).to.have.length( 0 );
 		const inputComponent = wrapper.find( 'Input' );
 		expect( inputComponent ).to.have.length( 1 );
 		expect( inputComponent.get( 0 ).props.value ).to.equal( fieldValue );
@@ -39,10 +39,10 @@ describe( 'HiddenInput', () => {
 	test( 'it should toggle input field when the toggle link is clicked', () => {
 		const wrapper = shallow( <HiddenInput { ...defaultProps } /> );
 		expect( wrapper.state( 'toggled' ) ).to.be.false;
-		expect( wrapper.find( '.hidden-input' ) ).to.have.length( 1 );
-		wrapper.find( '.hidden-input a' ).simulate( 'click', { preventDefault() {} } );
+		expect( wrapper.find( '.form__hidden-input' ) ).to.have.length( 1 );
+		wrapper.find( '.form__hidden-input a' ).simulate( 'click', { preventDefault() {} } );
 		expect( wrapper.state( 'toggled' ) ).to.be.true;
-		expect( wrapper.find( '.hidden-input' ) ).to.have.length( 0 );
+		expect( wrapper.find( '.form__hidden-input' ) ).to.have.length( 0 );
 		const inputComponent = wrapper.find( 'Input' );
 		expect( inputComponent ).to.have.length( 1 );
 	} );

--- a/client/my-sites/domains/components/form/test/hidden-input.js
+++ b/client/my-sites/domains/components/form/test/hidden-input.js
@@ -1,0 +1,49 @@
+/**
+ * @format
+ * @jest-environment jsdom
+ */
+
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+import React from 'react';
+
+import { HiddenInput } from '../hidden-input';
+
+describe( 'HiddenInput', () => {
+	const defaultProps = {
+		text: 'Love cannot be hidden.',
+	};
+
+	test( 'it should return expected elements with defaultProps and no props value', () => {
+		const wrapper = shallow( <HiddenInput { ...defaultProps } /> );
+		expect( wrapper.state( 'toggled' ) ).to.be.false;
+		expect( wrapper.find( '.hidden-input' ) ).to.have.length( 1 );
+		expect( wrapper.find( '.hidden-input a' ).text() ).to.equal( defaultProps.text );
+		const inputComponent = wrapper.find( 'Input' );
+		expect( inputComponent ).to.have.length( 0 );
+	} );
+
+	test( 'it should hide toggle link and render a full input field when the field value is not empty', () => {
+		const fieldValue = 'Not empty';
+		const wrapper = shallow( <HiddenInput { ...defaultProps } value={ fieldValue } /> );
+		expect( wrapper.state( 'toggled' ) ).to.be.true;
+		expect( wrapper.find( '.hidden-input' ) ).to.have.length( 0 );
+		const inputComponent = wrapper.find( 'Input' );
+		expect( inputComponent ).to.have.length( 1 );
+		expect( inputComponent.get( 0 ).props.value ).to.equal( fieldValue );
+	} );
+
+	test( 'it should toggle input field when the toggle link is clicked', () => {
+		const wrapper = shallow( <HiddenInput { ...defaultProps } /> );
+		expect( wrapper.state( 'toggled' ) ).to.be.false;
+		expect( wrapper.find( '.hidden-input' ) ).to.have.length( 1 );
+		wrapper.find( '.hidden-input a' ).simulate( 'click', { preventDefault() {} } );
+		expect( wrapper.state( 'toggled' ) ).to.be.true;
+		expect( wrapper.find( '.hidden-input' ) ).to.have.length( 0 );
+		const inputComponent = wrapper.find( 'Input' );
+		expect( inputComponent ).to.have.length( 1 );
+	} );
+} );


### PR DESCRIPTION
### Background

The impetus for this change was to ensure that this component renders an `<Input />` immediately if an input value exists by setting `this.state.toggle` in the constructor.

Previously, the toggled state was set in `componentWillReceiveProps`, which is not called during mounting. If rendered conditionally, this caused a slight 'jump effect'.

Similarly, a `focus()` was called on the element in `componentDidUpdate`, when we only want to focus when someone clicks the toggle link (unless I'm mistaken?).

![oct-19-2017 14-28-40](https://user-images.githubusercontent.com/6458278/31753075-1e3a6470-b4da-11e7-9bc0-9f66ef8ca87c.gif)

### This PR:
Sets `this.state.toggle` in the constructor based on the status of `props.value`.

Focusses on the field only after clicking on the 'expand' text.

![fix](https://user-images.githubusercontent.com/6458278/31753288-5b1b0678-b4db-11e7-99a3-c1ab39e7f16c.gif)

### Side-effects
None that I've found. This component is, for the moment, only used in the domain checkout form.