### PR TITLE
Bin: Extract shouldFormat util for prettier scripting

### DIFF
--- a/bin/pre-commit-hook.js
+++ b/bin/pre-commit-hook.js
@@ -4,12 +4,20 @@
  * A blank docblock to prevent prettier from formatting this file
  */
 
+/**
+ * External dependencies
+ */
 const execSync = require( 'child_process' ).execSync;
 const spawnSync = require( 'child_process' ).spawnSync;
 const chalk = require( 'chalk' );
 const fs = require( 'fs' );
 const prettier = require( 'prettier' );
 const path = require( 'path' );
+
+/**
+ * Internal dependencies
+ */
+const shouldFormat = require( './utils/should-format' );
 
 console.log(
 	'\nBy contributing to this project, you license the materials you contribute ' +
@@ -25,29 +33,6 @@ const files = execSync( 'git diff --cached --name-only --diff-filter=ACM' )
 	.split( '\n' )
 	.map( name => name.trim() )
 	.filter( name => name.endsWith( '.js' ) || name.endsWith( '.jsx' ) );
-
-/**
- * Returns true if the given text contain `@format`
- * within its first docblock. False otherwise.
- *
- * @param {String} text text to scan for the format keyword within the first docblock
- */
-const shouldFormat = text => {
-	const firstDocBlockStartIndex = text.indexOf( '/**' );
-
-	if ( -1 === firstDocBlockStartIndex ) {
-		return false;
-	}
-
-	const firstDocBlockEndIndex = text.indexOf( '*/', firstDocBlockStartIndex + 1 );
-
-	if ( -1 === firstDocBlockEndIndex ) {
-		return false;
-	}
-
-	const firstDocBlockText = text.substring( firstDocBlockStartIndex, firstDocBlockEndIndex + 1 );
-	return firstDocBlockText.indexOf( '@format' ) >= 0;
-};
 
 // run prettier for any files in the commit that have @format within their first docblock
 files

--- a/bin/reformat-files.js
+++ b/bin/reformat-files.js
@@ -1,23 +1,24 @@
+/** @format */
+
 /**
- * Find all JS and JSX files in the project that have the @format tag
- * and reformat them with Prettier. Useful when upgrading Prettier to
- * a newer version.
- * @format
+ * External dependencies
  */
 const fs = require( 'fs' );
 const glob = require( 'glob' );
 const ignore = require( 'ignore' );
 const path = require( 'path' );
 const prettier = require( 'prettier' );
-const docblock = require( 'jest-docblock' );
 
 /**
- * Returns true if the given text contains @format.
- * within its first docblock. False otherwise.
- *
- * @param {String} text text to scan for the format keyword within the first docblock
+ * Internal dependencies
  */
-const shouldFormat = text => 'format' in docblock.parse( docblock.extract( text ) );
+const shouldFormat = require( './utils/should-format' );
+
+/**
+ * Find all JS and JSX files in the project that have the @format tag
+ * and reformat them with Prettier. Useful when upgrading Prettier to
+ * a newer version.
+ */
 
 // Load ignore file
 const ignoreFile = fs.readFileSync( '.eslintignore', 'utf-8' );

--- a/bin/utils/should-format.js
+++ b/bin/utils/should-format.js
@@ -1,0 +1,14 @@
+/** @format */
+const docblock = require( 'jest-docblock' );
+
+/**
+ * Test whether a text contains @format within its first docblock.
+ *
+ * @param   {String}  text The text to scan for the format keyword within the first docblock
+ * @returns {boolean}      True if the first docblock contains @format keyword, otherwise false.
+ */
+function shouldFormat( text ) {
+	return 'format' in docblock.parse( docblock.extract( text ) );
+}
+
+module.exports = shouldFormat;


### PR DESCRIPTION
Multiple scripts depended on different implementations of a `shouldFormat` function. This PR extracts that function to a utility and shares it between the `pre-commit` and `reformat-files`.

## Testing
* Test the pre-commit script to ensure it continues to behave as expected:
  * Commit files with `@format` flag. Does prettier run?
  * Commit files without flag. Does prettier not run?
* Test `reformat-files` by executing `npm run reformat-files`. Does it behave as expected?


Extracted from #18868