### PR TITLE
Atomic Store: improve atomic store signup flow wordings

### DIFF
--- a/client/extensions/woocommerce/app/dashboard/required-plugins-install-view.js
+++ b/client/extensions/woocommerce/app/dashboard/required-plugins-install-view.js
@@ -470,8 +470,11 @@ class RequiredPluginsInstallView extends Component {
 				<SetupHeader
 					imageSource={ '/calypso/images/extensions/woocommerce/woocommerce-store-creation.svg' }
 					imageWidth={ 160 }
-					title={ translate( 'Setting up your store' ) }
-					subtitle={ translate( "Give us a minute and we'll move right along." ) }
+					title={ translate( 'Building your storefront' ) }
+					subtitle={ translate(
+						'We’ll be done with the behind-the-scenes work in a moment, ' +
+							'and then you can start adding products.'
+					) }
 				>
 					<ProgressBar value={ progress } total={ totalSeconds } isPulsing />
 				</SetupHeader>

--- a/client/my-sites/checkout/checkout-thank-you/atomic-store-thank-you-card.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/atomic-store-thank-you-card.jsx
@@ -27,7 +27,7 @@ class AtomicStoreThankYouCard extends Component {
 					className={ classNames( 'button', 'thank-you-card__button' ) }
 					href={ `/store/${ site.slug }` }
 				>
-					{ translate( 'Set up my store!' ) }
+					{ translate( 'Create your store!' ) }
 				</a>
 			</div>
 		);

--- a/client/signup/processing-screen/index.jsx
+++ b/client/signup/processing-screen/index.jsx
@@ -146,7 +146,7 @@ export class SignupProcessingScreen extends Component {
 						}
 					)
 				: this.props.translate(
-						'{{strong}}Awesome!{{/strong}} Give us one minute while we set up %(domain)s for you.',
+						'{{strong}}Awesome!{{/strong}} Give us one minute and we’ll move right along.',
 						{
 							components: { strong: <strong /> },
 							args: { domain },


### PR DESCRIPTION
This PR changes wordings of few screens in Atomic Store signup flow as suggested by @michelleweber.

## What Changed

In **Step 6**, changed "Awesome! Give us one minute while we set up %(domain)s for you." to **"Awesome! Give us one minute and we’ll move right along."** to hide potentially confusing details.

In **Step 8**, changed button title "Set up my store!" to **"Create your store!"** to avoid using generic and repetitive phrase "set up". Also offers a sense of ownership.

In **Step 9**, changed title from "Setting up your store" to **"Building your storefront"** and subtitle from "Give us a minute and we'll move right along." to **"We’ll be done with the behind-the-scenes work in a moment, and then you can start adding products."**

Step 10 was left as-is.

## Test Plan

Only wordings have changed so just following the Atomic Store signup flow (navigate to `/start/atomic-store`) and verify the text on changes mentioned above.
