### PR TITLE
Comments: Record bulk actions

### DIFF
--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -569,13 +569,14 @@ const mapDispatchToProps = ( dispatch, { siteId } ) => ( {
 			)
 		),
 
-	recordBulkAction: ( action, count, fromList ) =>
+	recordBulkAction: ( action, count, fromList, view = 'site' ) =>
 		dispatch(
 			composeAnalytics(
 				recordTracksEvent( 'calypso_comment_management_bulk_action', {
 					action,
 					count,
 					from_list: fromList,
+					view,
 				} ),
 				bumpStat( 'calypso_comment_management', 'bulk_action' )
 			)


### PR DESCRIPTION
Fixes #18941

Add analytics tracking for bulk actions.

I'm pushing this now because it was ready anyway.
Though, we might want to adapt and include this in @rodrigoi's #18932 instead.

### New events

- Bump: namespace `calypso_comment_management`, event `bulk_action`

- Track: event `calypso_comment_management_bulk_action`, properties:
  - `action`: the action performed, e.g. "approved", "delete", etc.
  - `count`: the number of comments affected by the action
  - `from_list`: the list originating the action, e.g. "all", "pending", etc.
