### PR TITLE
Automated Transfers: stop polling for transfer status if the status is 'error'

### DIFF
--- a/client/state/automated-transfer/constants.js
+++ b/client/state/automated-transfer/constants.js
@@ -9,6 +9,7 @@ export const transferStates = {
 	UPLOADING: 'uploading',
 	BACKFILLING: 'backfilling',
 	COMPLETE: 'complete',
+	ERROR: 'error',
 };
 
 export const eligibilityHolds = {

--- a/client/state/data-layer/wpcom/sites/automated-transfer/status/index.js
+++ b/client/state/data-layer/wpcom/sites/automated-transfer/status/index.js
@@ -17,6 +17,7 @@ import {
 	getAutomatedTransferStatus,
 	setAutomatedTransferStatus,
 } from 'state/automated-transfer/actions';
+import { transferStates } from 'state/automated-transfer/constants';
 
 export const requestStatus = ( { dispatch }, action ) => {
 	const { siteId } = action;
@@ -34,18 +35,18 @@ export const requestStatus = ( { dispatch }, action ) => {
 };
 
 export const receiveStatus = (
-	{ dispatch, getState },
+	{ dispatch },
 	{ siteId },
 	{ status, uploaded_plugin_slug, transfer_id }
 ) => {
 	const pluginId = uploaded_plugin_slug;
 
 	dispatch( setAutomatedTransferStatus( siteId, status, pluginId ) );
-	if ( status !== 'complete' ) {
+	if ( status !== transferStates.ERROR && status !== transferStates.COMPLETE ) {
 		delay( dispatch, 3000, getAutomatedTransferStatus( siteId ) );
 	}
 
-	if ( status === 'complete' ) {
+	if ( status === transferStates.COMPLETE ) {
 		dispatch(
 			recordTracksEvent( 'calypso_automated_transfer_complete', {
 				context: 'plugin_upload',


### PR DESCRIPTION
If the returned status is 'error', stop polling. This is the final state and it's not going to change. Until now, we only stopped polling on 'complete'. On an 'error' status, we continued polling forever.

**How to test:**
Hard to do without further code changes. I discovered this bug when adding transfer status polling to `SiteIndicator`, while working on Store NUX. You need to have a test site with a failed transfer and then some code that polls the transfer status. On the failed site, it will start requesting status in an infinite loop.
