### PR TITLE
TokenField: Refactor to drop isMounted and strings refs

### DIFF
--- a/client/components/token-field/index.jsx
+++ b/client/components/token-field/index.jsx
@@ -1,16 +1,13 @@
+/** @format */
 /**
  * External dependencies
- *
- * @format
  */
-
-import { clone, difference, each, forEach, identity, last, map, some, take, uniq } from 'lodash';
 import React from 'react';
+import PropTypes from 'prop-types';
 import PureRenderMixin from 'react-pure-render/mixin';
+import { clone, difference, each, forEach, identity, last, map, some, take, uniq } from 'lodash';
 import classNames from 'classnames';
 import debugFactory from 'debug';
-const debug = debugFactory( 'calypso:token-field' );
-import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies
@@ -18,6 +15,8 @@ import PropTypes from 'prop-types';
 import SuggestionsList from './suggestions-list';
 import Token from './token';
 import TokenInput from './token-input';
+
+const debug = debugFactory( 'calypso:token-field' );
 
 const TokenField = React.createClass( {
 	propTypes: {
@@ -77,14 +76,8 @@ const TokenField = React.createClass( {
 			isActive: false,
 			selectedSuggestionIndex: -1,
 			selectedSuggestionScroll: false,
+			tokenInputHasFocus: false,
 		};
-	},
-
-	componentDidUpdate: function() {
-		if ( this.state.isActive && ! this.refs.input.hasFocus() ) {
-			debug( 'componentDidUpdate focusing input' );
-			this.refs.input.focus(); // make sure focus is on input
-		}
 	},
 
 	componentWillReceiveProps( nextProps ) {
@@ -119,7 +112,7 @@ const TokenField = React.createClass( {
 		return (
 			<div { ...tokenFieldProps }>
 				<div
-					ref="tokensAndInput"
+					ref={ this.setTokensAndInput }
 					className="token-field__input-container"
 					tabIndex="-1"
 					onMouseDown={ this._onContainerTouched }
@@ -175,12 +168,12 @@ const TokenField = React.createClass( {
 		let props = {
 			autoCapitalize,
 			autoComplete,
-			ref: 'input',
-			key: 'input',
 			disabled: this.props.disabled,
-			value: this.state.incompleteTokenValue,
-			onBlur: this._onBlur,
+			hasFocus: this.state.tokenInputHasFocus,
 			id,
+			key: 'input',
+			onBlur: this._onBlur,
+			value: this.state.incompleteTokenValue,
 		};
 
 		if ( value.length === 0 && placeholder ) {
@@ -194,8 +187,12 @@ const TokenField = React.createClass( {
 		return <TokenInput { ...props } />;
 	},
 
+	setTokensAndInput: function( input ) {
+		this.tokensAndInput = input;
+	},
+
 	_onFocus: function( event ) {
-		this.setState( { isActive: true } );
+		this.setState( { isActive: true, tokenInputHasFocus: true } );
 		if ( 'function' === typeof this.props.onFocus ) {
 			this.props.onFocus( event );
 		}
@@ -250,7 +247,7 @@ const TokenField = React.createClass( {
 	_onContainerTouched: function( event ) {
 		// Prevent clicking/touching the tokensAndInput container from blurring
 		// the input and adding the current token.
-		if ( event.target === this.refs.tokensAndInput && this.state.isActive ) {
+		if ( event.target === this.tokensAndInput && this.state.isActive ) {
 			event.preventDefault();
 		}
 	},
@@ -316,7 +313,7 @@ const TokenField = React.createClass( {
 	_handleDeleteKey: function( deleteToken ) {
 		var preventDefault = false;
 
-		if ( this.refs.input.hasFocus() && this._isInputEmpty() ) {
+		if ( this.state.tokenInputHasFocus && this._isInputEmpty() ) {
 			deleteToken();
 			preventDefault = true;
 		}
@@ -508,7 +505,7 @@ const TokenField = React.createClass( {
 
 		if ( this.state.isActive ) {
 			debug( '_addNewToken focusing input' );
-			this.refs.input.focus();
+			this.setState( { tokenInputHasFocus: true } );
 		}
 	},
 

--- a/client/components/token-field/test/lib/token-field-wrapper.jsx
+++ b/client/components/token-field/test/lib/token-field-wrapper.jsx
@@ -1,9 +1,7 @@
+/** @format */
 /**
  * External dependencies
- *
- * @format
  */
-
 import React from 'react';
 
 /**
@@ -12,7 +10,7 @@ import React from 'react';
 import TokenField from 'components/token-field';
 import { unescapeAndFormatSpaces } from 'lib/formatting';
 
-var suggestions = [
+const suggestions = [
 	'the',
 	'of',
 	'and',

--- a/client/components/token-field/token-input.jsx
+++ b/client/components/token-field/token-input.jsx
@@ -1,56 +1,63 @@
+/** @format */
 /**
  * External dependencies
- *
- * @format
  */
-
 import PropTypes from 'prop-types';
 import React from 'react';
 import PureRenderMixin from 'react-pure-render/mixin';
+import { omit, noop } from 'lodash';
 
 const TokenInput = React.createClass( {
 	propTypes: {
+		disabled: PropTypes.bool,
+		hasFocus: PropTypes.bool,
 		onChange: PropTypes.func,
 		onBlur: PropTypes.func,
-		value: PropTypes.string,
 		placeholder: PropTypes.string,
-		disabled: PropTypes.bool,
+		value: PropTypes.string,
 	},
 
 	getDefaultProps: function() {
 		return {
-			onChange: function() {},
-			onBlur: function() {},
-			value: '',
 			disabled: false,
+			hasFocus: false,
+			onChange: noop,
+			onBlur: noop,
 			placeholder: '',
+			value: '',
 		};
 	},
 
 	mixins: [ PureRenderMixin ],
 
+	componentDidUpdate: function() {
+		if ( this.props.hasFocus ) {
+			this.textInput.focus();
+		}
+	},
+
 	render: function() {
-		const props = { ...this.props, onChange: this._onChange };
-		const { value, placeholder } = props;
+		const { placeholder, value } = this.props;
 		const size =
 			( ( value.length === 0 && placeholder && placeholder.length ) || value.length ) + 1;
 
 		return (
-			<input ref="input" type="text" { ...props } size={ size } className="token-field__input" />
+			<input
+				className="token-field__input"
+				onChange={ this.onChange }
+				ref={ this.setTextInput }
+				size={ size }
+				type="text"
+				{ ...omit( this.props, 'hasFocus' ) }
+			/>
 		);
 	},
 
-	focus: function() {
-		if ( this.isMounted() ) {
-			this.refs.input.focus();
-		}
+	setTextInput: function( input ) {
+		this.textInput = input;
 	},
 
-	hasFocus: function() {
-		return this.isMounted() && this.refs.input === document.activeElement;
-	},
-
-	_onChange: function( event ) {
+	onChange: function( event ) {
 		this.props.onChange( {
 			value: event.target.value,
 		} );

--- a/client/components/token-field/token-input.jsx
+++ b/client/components/token-field/token-input.jsx
@@ -48,7 +48,7 @@ const TokenInput = React.createClass( {
 				ref={ this.setTextInput }
 				size={ size }
 				type="text"
-				{ ...omit( this.props, 'hasFocus' ) }
+				{ ...omit( this.props, [ 'hasFocus', 'onChange' ] ) }
 			/>
 		);
 	},


### PR DESCRIPTION
Using component state and lifecycle methods instead.

## To test
* Compare:
  * http://calypso.localhost:3000/devdocs/design/token-fields or https://calypso.live/devdocs/design/token-fields?branch=remove/is-mounted-from-token-field 
  * https://wpcalypso.wordpress.com/devdocs/design/token-fields
* Ensure things work as before.

Fixes parts of #18926.