### PR TITLE
Automated Transfers: show transfer status in site indicator

### DIFF
--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -60,6 +60,7 @@ import SitesComponent from 'my-sites/sites';
 import { isATEnabled } from 'lib/automated-transfer';
 import { warningNotice } from 'state/notices/actions';
 import { getPrimaryDomainBySiteId } from 'state/selectors';
+import { getAutomatedTransferStatus as fetchAutomatedTransferStatus } from 'state/automated-transfer/actions';
 
 /*
  * @FIXME Shorthand, but I might get rid of this.
@@ -243,6 +244,8 @@ function onSelectedSiteAvailable( context ) {
 			);
 		}
 	}
+
+	context.store.dispatch( fetchAutomatedTransferStatus( selectedSite.ID ) );
 
 	return true;
 }

--- a/client/my-sites/site-indicator/style.scss
+++ b/client/my-sites/site-indicator/style.scss
@@ -61,6 +61,11 @@
 		color: $white;
 	}
 
+	.is-transfer & {
+		background: $alert-purple;
+		color: $white;
+	}
+
 	.is-expanded & {
 		.accessible-focus &:focus {
 			border: 1px dotted $white;
@@ -102,6 +107,9 @@
 	}
 	.is-error & {
 		background: $alert-red;
+	}
+	.is-transfer & {
+		background: $alert-purple;
 	}
 }
 .site-indicator__action {

--- a/client/state/data-layer/wpcom/sites/automated-transfer/status/index.js
+++ b/client/state/data-layer/wpcom/sites/automated-transfer/status/index.js
@@ -21,6 +21,7 @@ import { transferStates } from 'state/automated-transfer/constants';
 
 export const requestStatus = ( { dispatch }, action ) => {
 	const { siteId } = action;
+	console.log( 'Fetching transfer status for:', siteId );
 
 	dispatch(
 		http(
@@ -34,13 +35,11 @@ export const requestStatus = ( { dispatch }, action ) => {
 	);
 };
 
-export const receiveStatus = (
-	{ dispatch },
-	{ siteId },
-	{ status, uploaded_plugin_slug, transfer_id }
-) => {
+export const receiveStatus = ( { dispatch }, { siteId }, data ) => {
+	const { status, uploaded_plugin_slug, transfer_id } = data;
 	const pluginId = uploaded_plugin_slug;
 
+	console.log( 'Received transfer status:', siteId, data );
 	dispatch( setAutomatedTransferStatus( siteId, status, pluginId ) );
 	if ( status !== transferStates.ERROR && status !== transferStates.COMPLETE ) {
 		delay( dispatch, 3000, getAutomatedTransferStatus( siteId ) );

--- a/client/state/data-layer/wpcom/sites/automated-transfer/status/index.js
+++ b/client/state/data-layer/wpcom/sites/automated-transfer/status/index.js
@@ -3,7 +3,7 @@
  *
  * @format
  */
-import { delay, noop } from 'lodash';
+import { delay } from 'lodash';
 
 /**
  * Internal dependencies
@@ -59,6 +59,12 @@ export const receiveStatus = ( { dispatch }, { siteId }, data ) => {
 	}
 };
 
+export const errorStatus = ( store, { siteId }, error ) => {
+	console.log( 'Failed to fetch transfer status:', siteId, error );
+};
+
 export default {
-	[ AUTOMATED_TRANSFER_STATUS_REQUEST ]: [ dispatchRequest( requestStatus, receiveStatus, noop ) ],
+	[ AUTOMATED_TRANSFER_STATUS_REQUEST ]: [
+		dispatchRequest( requestStatus, receiveStatus, errorStatus ),
+	],
 };


### PR DESCRIPTION
This shows transfer status in the site indicator of the selected site:

![site-indicator-transfer](https://user-images.githubusercontent.com/664258/31771877-f678e070-b4dd-11e7-9bf3-764d3c0ac48b.gif)

It's indented for debugging and testing Store NUX, but in a limited form, it should evolve into a production feature that shows transfer errors.

At various stages, the icon changes as the transfer status changes from `pending` to `active` to `uploading` to `backfilling` to `complete` or `error`.

See this screencast for a full example:
http://cld.wthms.co/oFLac6
