### PR TITLE
TinyMCE: Add displayName on embed example to fix issue with DevDocs

### DIFF
--- a/client/components/tinymce/plugins/embed/docs/example.jsx
+++ b/client/components/tinymce/plugins/embed/docs/example.jsx
@@ -15,6 +15,8 @@ import Card from 'components/card';
 import EmbedDialog from '../dialog';
 
 export default class EmbedDialogExample extends PureComponent {
+	static displayName = 'EmbedDialog';
+
 	state = {
 		embedUrl: 'https://www.youtube.com/watch?v=R54QEvTyqO4',
 		showDialog: false,


### PR DESCRIPTION
Without the `displayName` property, the embed dialog on the DevDocs example reads incorrectly. This adds the EmbedDialog display name to fix the issue mentioned in #18650.

## To test
1. Checkout this branch and start with `npm start`
2. Visit http://calypso.localhost:3000/devdocs/design.
3. Find the EmbedDialog component. It should be rendering with the correct name. You can compare against https://wpcalypso.wordpress.com/devdocs/design.
4. Visit http://calypso.localhost:3000/devdocs/design/embed-dialog. You should only see one element. Compare against https://wpcalypso.wordpress.com/devdocs/design/t, which shows both the embed dialog and the rating component.

## Screenshots

**Current**
<img width="1194" alt="screen shot 2017-10-19 at 7 53 12 am" src="https://user-images.githubusercontent.com/7240478/31774301-9431c0ac-b4a2-11e7-90d5-2937de72c800.png">
<img width="1091" alt="screen shot 2017-10-19 at 7 53 05 am" src="https://user-images.githubusercontent.com/7240478/31774302-9443e93a-b4a2-11e7-8376-d2d738ad1b9e.png">

**Updated**

<img width="1091" alt="screen shot 2017-10-19 at 7 48 59 am" src="https://user-images.githubusercontent.com/7240478/31774268-7f101002-b4a2-11e7-8fb0-ff71fd97448e.png">
<img width="1038" alt="screen shot 2017-10-19 at 7 49 04 am" src="https://user-images.githubusercontent.com/7240478/31774269-7f22524e-b4a2-11e7-9ccf-180a72c87c86.png">
