### PR TITLE
Comments: Refactor comments routing to allow single post and comment views

### DIFF
--- a/client/my-sites/comments/constants.js
+++ b/client/my-sites/comments/constants.js
@@ -7,3 +7,5 @@ export const COMMENTS_PER_PAGE = 20;
 // and relying on the fact that more recent comments have higher ID values.
 export const NEWEST_FIRST = 'desc';
 export const OLDEST_FIRST = 'asc';
+
+export const VALID_STATUSES = [ 'all', 'pending', 'approved', 'spam', 'trash' ];

--- a/client/my-sites/comments/constants.js
+++ b/client/my-sites/comments/constants.js
@@ -7,5 +7,3 @@ export const COMMENTS_PER_PAGE = 20;
 // and relying on the fact that more recent comments have higher ID values.
 export const NEWEST_FIRST = 'desc';
 export const OLDEST_FIRST = 'asc';
-
-export const VALID_STATUSES = [ 'all', 'pending', 'approved', 'spam', 'trash' ];

--- a/client/my-sites/comments/controller.js
+++ b/client/my-sites/comments/controller.js
@@ -26,6 +26,11 @@ const changePage = path => pageNumber => {
 
 export const siteComments = ( { params, path, query, store } ) => {
 	const siteFragment = route.getSiteFragment( path );
+
+	if ( ! siteFragment ) {
+		return page.redirect( '/comments/all' );
+	}
+
 	const status = mapPendingStatusToUnapproved( params.status );
 
 	const pageNumber = parseInt( query.page, 10 );
@@ -48,6 +53,11 @@ export const siteComments = ( { params, path, query, store } ) => {
 
 export const postComments = ( { params, path, query, store } ) => {
 	const siteFragment = route.getSiteFragment( path );
+
+	if ( ! siteFragment ) {
+		return page.redirect( '/comments/all' );
+	}
+
 	const status = mapPendingStatusToUnapproved( params.status );
 	const postId = parseInt( params.post, 10 );
 

--- a/client/my-sites/comments/controller.js
+++ b/client/my-sites/comments/controller.js
@@ -88,13 +88,10 @@ export const comment = ( { params, path, store } ) => {
 	const siteFragment = route.getSiteFragment( path );
 	const commentId = parseInt( params.comment, 10 );
 
-	// Likely, this is a leak from a site view route with invalid status
-	// e.g. '/comments/foobar/example.com'
-	if ( ! siteFragment && ! isFinite( commentId ) ) {
-		return page.redirect( `/comments/all/${ params.comment }` );
-	}
-	if ( siteFragment && ! isFinite( commentId ) ) {
-		return page.redirect( `/comments/all/${ siteFragment }` );
+	if ( ! isFinite( commentId ) ) {
+		return siteFragment
+			? page.redirect( `/comments/all/${ siteFragment }` )
+			: page.redirect( '/comments/all' );
 	}
 
 	renderWithReduxStore(

--- a/client/my-sites/comments/controller.js
+++ b/client/my-sites/comments/controller.js
@@ -5,7 +5,7 @@
 import { renderWithReduxStore } from 'lib/react-helpers';
 import React from 'react';
 import page from 'page';
-import { each, isFinite, startsWith } from 'lodash';
+import { each, isNaN, startsWith } from 'lodash';
 
 /**
  * Internal dependencies
@@ -16,6 +16,11 @@ import { removeNotice } from 'state/notices/actions';
 import { getNotices } from 'state/notices/selectors';
 
 const mapPendingStatusToUnapproved = status => ( 'pending' === status ? 'unapproved' : status );
+
+const sanitizeInt = number => {
+	const integer = parseInt( number, 10 );
+	return ! isNaN( integer ) && integer > 0 ? integer : false;
+};
 
 const changePage = path => pageNumber => {
 	if ( window ) {
@@ -33,8 +38,8 @@ export const siteComments = ( { params, path, query, store } ) => {
 
 	const status = mapPendingStatusToUnapproved( params.status );
 
-	const pageNumber = parseInt( query.page, 10 );
-	if ( isNaN( pageNumber ) || pageNumber < 1 ) {
+	const pageNumber = sanitizeInt( query.page );
+	if ( ! pageNumber ) {
 		return changePage( path )( 1 );
 	}
 
@@ -59,14 +64,14 @@ export const postComments = ( { params, path, query, store } ) => {
 	}
 
 	const status = mapPendingStatusToUnapproved( params.status );
-	const postId = parseInt( params.post, 10 );
+	const postId = sanitizeInt( params.post );
 
-	if ( ! isFinite( postId ) ) {
+	if ( ! postId ) {
 		return page.redirect( `/comments/${ params.status }/${ siteFragment }` );
 	}
 
-	const pageNumber = parseInt( query.page, 10 );
-	if ( isNaN( pageNumber ) || pageNumber < 1 ) {
+	const pageNumber = sanitizeInt( query.page );
+	if ( ! pageNumber ) {
 		return changePage( path )( 1 );
 	}
 
@@ -86,9 +91,9 @@ export const postComments = ( { params, path, query, store } ) => {
 
 export const comment = ( { params, path, store } ) => {
 	const siteFragment = route.getSiteFragment( path );
-	const commentId = parseInt( params.comment, 10 );
+	const commentId = sanitizeInt( params.comment );
 
-	if ( ! isFinite( commentId ) ) {
+	if ( ! commentId ) {
 		return siteFragment
 			? page.redirect( `/comments/all/${ siteFragment }` )
 			: page.redirect( '/comments/all' );

--- a/client/my-sites/comments/controller.js
+++ b/client/my-sites/comments/controller.js
@@ -52,7 +52,7 @@ export const postComments = ( { params, path, query, store } ) => {
 	const postId = parseInt( params.post, 10 );
 
 	if ( ! isFinite( postId ) ) {
-		return page.redirect( `/comments/${ status }/${ siteFragment }` );
+		return page.redirect( `/comments/${ params.status }/${ siteFragment }` );
 	}
 
 	const pageNumber = parseInt( query.page, 10 );

--- a/client/my-sites/comments/controller.js
+++ b/client/my-sites/comments/controller.js
@@ -80,8 +80,11 @@ export const comment = ( { params, path, store } ) => {
 
 	// Likely, this is a leak from a site view route with invalid status
 	// e.g. '/comments/foobar/example.com'
-	if ( ! isFinite( commentId ) ) {
+	if ( ! siteFragment && ! isFinite( commentId ) ) {
 		return page.redirect( `/comments/all/${ params.comment }` );
+	}
+	if ( siteFragment && ! isFinite( commentId ) ) {
+		return page.redirect( `/comments/all/${ siteFragment }` );
 	}
 
 	renderWithReduxStore(

--- a/client/my-sites/comments/index.js
+++ b/client/my-sites/comments/index.js
@@ -35,12 +35,14 @@ export default function() {
 		);
 
 		// Comment View
-		page( '/comments/:site/:comment', siteSelection, navigation, comment );
+		page( '/comment/:site/:comment', siteSelection, navigation, comment );
 
 		// Redirect
 		page( `/comments/:status(${ VALID_STATUSES.join( '|' ) })`, siteSelection, sites );
 		page( '/comments/*', siteSelection, redirect );
 		page( '/comments', siteSelection, redirect );
+		page( '/comment/*', siteSelection, redirect );
+		page( '/comment', siteSelection, redirect );
 
 		// Leaving Comment Management
 		page.exit( '/comments/*', clearCommentNotices );

--- a/client/my-sites/comments/index.js
+++ b/client/my-sites/comments/index.js
@@ -10,7 +10,6 @@ import page from 'page';
 import { siteSelection, navigation, sites } from 'my-sites/controller';
 import { clearCommentNotices, comment, postComments, redirect, siteComments } from './controller';
 import config from 'config';
-import { VALID_STATUSES } from './constants';
 
 export default function() {
 	if ( ! config.isEnabled( 'comments/management' ) ) {
@@ -20,7 +19,7 @@ export default function() {
 	if ( config.isEnabled( 'comments/management' ) ) {
 		// Site View
 		page(
-			`/comments/:status(${ VALID_STATUSES.join( '|' ) })/:site`,
+			'/comments/:status(all|pending|approved|spam|trash)/:site',
 			siteSelection,
 			navigation,
 			siteComments
@@ -29,7 +28,7 @@ export default function() {
 		// Post View
 		if ( config.isEnabled( 'comments/management/post-view' ) ) {
 			page(
-				`/comments/:status(${ VALID_STATUSES.join( '|' ) })/:site/:post`,
+				'/comments/:status(all|pending|approved|spam|trash)/:site/:post',
 				siteSelection,
 				navigation,
 				postComments
@@ -42,7 +41,7 @@ export default function() {
 		}
 
 		// Redirect
-		page( `/comments/:status(${ VALID_STATUSES.join( '|' ) })`, siteSelection, sites );
+		page( '/comments/:status(all|pending|approved|spam|trash)', siteSelection, sites );
 		page( '/comments/*', siteSelection, redirect );
 		page( '/comments', siteSelection, redirect );
 		page( '/comment/*', siteSelection, redirect );

--- a/client/my-sites/comments/index.js
+++ b/client/my-sites/comments/index.js
@@ -7,9 +7,10 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import controller from 'my-sites/controller';
-import { clearCommentNotices, comments, redirect } from './controller';
+import { siteSelection, navigation, sites } from 'my-sites/controller';
+import { clearCommentNotices, comment, postComments, redirect, siteComments } from './controller';
 import config from 'config';
+import { VALID_STATUSES } from './constants';
 
 export default function() {
 	if ( ! config.isEnabled( 'comments/management' ) ) {
@@ -17,16 +18,31 @@ export default function() {
 	}
 
 	if ( config.isEnabled( 'comments/management' ) ) {
-		page( '/comments/:status?', controller.siteSelection, redirect, controller.sites );
-
+		// Site View
 		page(
-			'/comments/:status/:site',
-			controller.siteSelection,
-			redirect,
-			controller.navigation,
-			comments
+			`/comments/:status(${ VALID_STATUSES.join( '|' ) })/:site`,
+			siteSelection,
+			navigation,
+			siteComments
 		);
 
+		// Post View
+		page(
+			`/comments/:status(${ VALID_STATUSES.join( '|' ) })/:site/:post`,
+			siteSelection,
+			navigation,
+			postComments
+		);
+
+		// Comment View
+		page( '/comments/:site/:comment', siteSelection, navigation, comment );
+
+		// Redirect
+		page( `/comments/:status(${ VALID_STATUSES.join( '|' ) })`, siteSelection, sites );
+		page( '/comments/*', siteSelection, redirect );
+		page( '/comments', siteSelection, redirect );
+
+		// Leaving Comment Management
 		page.exit( '/comments/*', clearCommentNotices );
 	}
 }

--- a/client/my-sites/comments/index.js
+++ b/client/my-sites/comments/index.js
@@ -50,5 +50,6 @@ export default function() {
 
 		// Leaving Comment Management
 		page.exit( '/comments/*', clearCommentNotices );
+		page.exit( '/comment/*', clearCommentNotices );
 	}
 }

--- a/client/my-sites/comments/index.js
+++ b/client/my-sites/comments/index.js
@@ -27,15 +27,19 @@ export default function() {
 		);
 
 		// Post View
-		page(
-			`/comments/:status(${ VALID_STATUSES.join( '|' ) })/:site/:post`,
-			siteSelection,
-			navigation,
-			postComments
-		);
+		if ( config.isEnabled( 'comments/management/post-view' ) ) {
+			page(
+				`/comments/:status(${ VALID_STATUSES.join( '|' ) })/:site/:post`,
+				siteSelection,
+				navigation,
+				postComments
+			);
+		}
 
 		// Comment View
-		page( '/comment/:site/:comment', siteSelection, navigation, comment );
+		if ( config.isEnabled( 'comments/management/comment-view' ) ) {
+			page( '/comment/:site/:comment', siteSelection, navigation, comment );
+		}
 
 		// Redirect
 		page( `/comments/:status(${ VALID_STATUSES.join( '|' ) })`, siteSelection, sites );

--- a/client/wordpress-com.js
+++ b/client/wordpress-com.js
@@ -381,7 +381,7 @@ sections.push( {
 
 sections.push( {
 	name: 'comments',
-	paths: [ '/comments' ],
+	paths: [ '/comments', '/comment' ],
 	module: 'my-sites/comments',
 	group: 'sites',
 	secondary: true,

--- a/config/development.json
+++ b/config/development.json
@@ -42,6 +42,8 @@
 		"comments/filters-in-posts": true,
 		"comments/moderation-tools-in-posts": true,
 		"comments/management": true,
+		"comments/management/comment-view": true,
+		"comments/management/post-view": true,
 		"comments/management/quick-actions": true,
 		"comments/management/sorting": true,
 		"css-hot-reload": true,


### PR DESCRIPTION
Closes #18330
Context: p4TIVU-8uu-p2

Refactor the Comment Managemement routing to take more advantage of Page.js matching capabilities.
Also introduce two new routes for the Single Post View and the Single Comment View.

### Routes

Site View
`/comments/:status/:site`

Single Post View
`/comments/:status/:site/:post`

Single Comment View
`/comment/:site/:comment`

### Redirect Cases

`/comments`
`/comment`
Redirects to `/comments/all`.

`/comments/:status` (valid status)
Shows the site selector on the requested status.

`/comments/:status` (invalid status)
Shows the site selector on the "all" status.

`/comments/:status/:site/:post` (non-numeric post ID)
Redirects to `/comments/:status/:site`.

`/comment/:site/:comment` (non-numeric comment ID)
Redirects to `/comments/all/:site`.

`/comments/*` (invalid site fragment, non-numeric post or comment ID, etc.)
`/comment/*` (same)
Redirects to `/comments/all`.

### Testing instructions

Follow the suggestions above, or just do your worst!