### PR TITLE
Refactor getAutomatedTransferStatus to fetchAutomatedTransferStatus

### DIFF
--- a/client/extensions/woocommerce/app/dashboard/required-plugins-install-view.js
+++ b/client/extensions/woocommerce/app/dashboard/required-plugins-install-view.js
@@ -28,7 +28,7 @@ import SetupHeader from './setup-header';
 import { setFinishedInstallOfRequiredPlugins } from 'woocommerce/state/sites/setup-choices/actions';
 import QuerySites from 'components/data/query-sites';
 import { getSiteOptions } from 'state/selectors';
-import { getAutomatedTransferStatus as fetchAutomatedTransferStatus } from 'state/automated-transfer/actions';
+import { fetchAutomatedTransferStatus } from 'state/automated-transfer/actions';
 import { getAutomatedTransferStatus } from 'state/automated-transfer/selectors';
 import { transferStates } from 'state/automated-transfer/constants';
 import { isSiteAutomatedTransfer as isSiteAutomatedTransferSelector } from 'state/selectors';

--- a/client/state/automated-transfer/actions.js
+++ b/client/state/automated-transfer/actions.js
@@ -34,7 +34,7 @@ export const initiateAutomatedTransferWithPluginZip = ( siteId, pluginZip ) => (
  * @param {number} siteId The id of the site to query.
  * @returns {Object} An action object
  */
-export const getAutomatedTransferStatus = siteId => ( {
+export const fetchAutomatedTransferStatus = siteId => ( {
 	type: AUTOMATED_TRANSFER_STATUS_REQUEST,
 	siteId,
 } );

--- a/client/state/data-layer/wpcom/sites/automated-transfer/initiate/index.js
+++ b/client/state/data-layer/wpcom/sites/automated-transfer/initiate/index.js
@@ -15,7 +15,7 @@ import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { errorNotice } from 'state/notices/actions';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { updatePluginUploadProgress, pluginUploadError } from 'state/plugins/upload/actions';
-import { getAutomatedTransferStatus } from 'state/automated-transfer/actions';
+import { fetchAutomatedTransferStatus } from 'state/automated-transfer/actions';
 
 /*
  * Currently this module is only used for initiating transfers
@@ -91,7 +91,7 @@ export const receiveResponse = ( { dispatch }, { siteId }, { success } ) => {
 			context: 'plugin_upload',
 		} )
 	);
-	dispatch( getAutomatedTransferStatus( siteId ) );
+	dispatch( fetchAutomatedTransferStatus( siteId ) );
 };
 
 export const updateUploadProgress = ( { dispatch }, { siteId }, { loaded, total } ) => {

--- a/client/state/data-layer/wpcom/sites/automated-transfer/initiate/test/index.js
+++ b/client/state/data-layer/wpcom/sites/automated-transfer/initiate/test/index.js
@@ -16,7 +16,7 @@ import {
 	updateUploadProgress,
 } from '../';
 import { recordTracksEvent } from 'state/analytics/actions';
-import { getAutomatedTransferStatus } from 'state/automated-transfer/actions';
+import { fetchAutomatedTransferStatus } from 'state/automated-transfer/actions';
 import { pluginUploadError, updatePluginUploadProgress } from 'state/plugins/upload/actions';
 
 const siteId = 1916284;
@@ -64,7 +64,7 @@ describe( 'receiveResponse', () => {
 	test( 'should dispatch a status request', () => {
 		const dispatch = sinon.spy();
 		receiveResponse( { dispatch }, { siteId }, INITIATE_SUCCESS_RESPONSE );
-		expect( dispatch ).to.have.been.calledWith( getAutomatedTransferStatus( siteId ) );
+		expect( dispatch ).to.have.been.calledWith( fetchAutomatedTransferStatus( siteId ) );
 	} );
 
 	test( 'should dispatch a tracks call', () => {

--- a/client/state/data-layer/wpcom/sites/automated-transfer/status/index.js
+++ b/client/state/data-layer/wpcom/sites/automated-transfer/status/index.js
@@ -14,7 +14,7 @@ import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { requestSite } from 'state/sites/actions';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import {
-	getAutomatedTransferStatus,
+	fetchAutomatedTransferStatus,
 	setAutomatedTransferStatus,
 } from 'state/automated-transfer/actions';
 import { transferStates } from 'state/automated-transfer/constants';
@@ -43,7 +43,7 @@ export const receiveStatus = (
 
 	dispatch( setAutomatedTransferStatus( siteId, status, pluginId ) );
 	if ( status !== transferStates.ERROR && status !== transferStates.COMPLETE ) {
-		delay( dispatch, 3000, getAutomatedTransferStatus( siteId ) );
+		delay( dispatch, 3000, fetchAutomatedTransferStatus( siteId ) );
 	}
 
 	if ( status === transferStates.COMPLETE ) {

--- a/client/state/data-layer/wpcom/sites/automated-transfer/status/test/index.js
+++ b/client/state/data-layer/wpcom/sites/automated-transfer/status/test/index.js
@@ -12,7 +12,7 @@ import sinon from 'sinon';
 import { requestStatus, receiveStatus } from '../';
 import { recordTracksEvent } from 'state/analytics/actions';
 import {
-	getAutomatedTransferStatus,
+	fetchAutomatedTransferStatus,
 	setAutomatedTransferStatus,
 } from 'state/automated-transfer/actions';
 import { useFakeTimers } from 'test/helpers/use-sinon';
@@ -75,6 +75,6 @@ describe( 'receiveStatus', () => {
 		clock.tick( 4000 );
 
 		expect( dispatch ).to.have.been.calledTwice;
-		expect( dispatch ).to.have.been.calledWith( getAutomatedTransferStatus( siteId ) );
+		expect( dispatch ).to.have.been.calledWith( fetchAutomatedTransferStatus( siteId ) );
 	} );
 } );


### PR DESCRIPTION
It was creating confusion since we already have a selector called
`getAutomatedTransferStatus` which returns the current AT status for a
site. On the other hand, `fetchAutomatedTransferStatus` sends a request
to fetch the status.

## Testing

1. Run all test with `npm run test`
2. Purchase a Business site and upload a custom plugin. AT should work.
3. Go through the Atomic Store signup flow (`/start/atomic-store` and 'store' design type): AT should work.