### PR TITLE
Jetpack Connect: Add snapshot test for plans-skip-button.jsx

### DIFF
--- a/client/jetpack-connect/test/__snapshots__/plans-skip-button.jsx.snap
+++ b/client/jetpack-connect/test/__snapshots__/plans-skip-button.jsx.snap
@@ -1,0 +1,57 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PlansSkipButton should render 1`] = `
+<div
+  className="jetpack-connect__plans-nav-buttons"
+>
+  <button
+    className="button"
+    onClick={undefined}
+    type="button"
+  >
+    Start with free
+    <svg
+      className="gridicon gridicons-arrow-right"
+      height={24}
+      onClick={undefined}
+      viewBox="0 0 24 24"
+      width={24}
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <g>
+        <path
+          d="M12 4l-1.41 1.41L16.17 11H4v2h12.17l-5.58 5.59L12 20l8-8-8-8z"
+        />
+      </g>
+    </svg>
+  </button>
+</div>
+`;
+
+exports[`PlansSkipButton should render arrow-left in rtl mode 1`] = `
+<div
+  className="jetpack-connect__plans-nav-buttons"
+>
+  <button
+    className="button"
+    onClick={undefined}
+    type="button"
+  >
+    Start with free
+    <svg
+      className="gridicon gridicons-arrow-left"
+      height={24}
+      onClick={undefined}
+      viewBox="0 0 24 24"
+      width={24}
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <g>
+        <path
+          d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20v-2z"
+        />
+      </g>
+    </svg>
+  </button>
+</div>
+`;

--- a/client/jetpack-connect/test/plans-skip-button.jsx
+++ b/client/jetpack-connect/test/plans-skip-button.jsx
@@ -1,0 +1,25 @@
+/**
+ * @format
+ * @jest-environment jsdom
+ */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import PlansSkipButton from 'jetpack-connect/plans-skip-button';
+import renderer from 'react-test-renderer';
+
+describe( 'PlansSkipButton', () => {
+	test( 'should render', () => {
+		const component = renderer.create( <PlansSkipButton /> );
+		const tree = component.toJSON();
+		expect( tree ).toMatchSnapshot();
+	} );
+
+	test( 'should render arrow-left in rtl mode', () => {
+		const component = renderer.create( <PlansSkipButton isRtl /> );
+		const tree = component.toJSON();
+		expect( tree ).toMatchSnapshot();
+	} );
+} );


### PR DESCRIPTION
A really simple test, more play with snapshot testing for components than anything.

**To Test**
* Run the new test:
  ```sh
  npm run test-client client/jetpack-connect/test/plans-skip-button.jsx
  ```


/cc @blowery @gziolo 