### PR TITLE
Activity log: Add is_rewindable to schema and items

### DIFF
--- a/client/state/activity-log/log/schema.js
+++ b/client/state/activity-log/log/schema.js
@@ -7,6 +7,7 @@ const activityItemSchema = {
 		'activityGroup',
 		'activityIcon',
 		'activityId',
+		'activityIsRewindable',
 		'activityName',
 		'activityTitle',
 		'activityTs',
@@ -20,6 +21,7 @@ const activityItemSchema = {
 		activityGroup: { type: 'string' },
 		activityIcon: { type: 'string' },
 		activityId: { type: 'string' },
+		activityIsRewindable: { type: 'boolean' },
 		activityName: { type: 'string' },
 		activityStatus: {
 			oneOf: [ { type: 'string' }, { type: 'null' } ],

--- a/client/state/activity-log/log/test/reducer.js
+++ b/client/state/activity-log/log/test/reducer.js
@@ -20,6 +20,7 @@ const ACTIVITY_ITEM = deepFreeze( {
 	activityGroup: 'plugin',
 	activityIcon: 'plugins',
 	activityId: 'foobarbas',
+	activityIsRewindable: false,
 	activityName: 'plugin__updated',
 	activityStatus: 'warning',
 	activityTitle: 'Jetpack by WordPress.com plugin was updated to version 5.3',

--- a/client/state/data-layer/wpcom/sites/activity/from-api.js
+++ b/client/state/data-layer/wpcom/sites/activity/from-api.js
@@ -59,6 +59,7 @@ export function processItemBase( item ) {
 		activityGroup: head( split( get( item, 'name' ), '__', 1 ) ),
 		activityIcon: get( item, 'gridicon', DEFAULT_GRIDICON ),
 		activityId: get( item, 'activity_id' ),
+		activityIsRewindable: item.is_rewindable,
 		activityName: get( item, 'name' ),
 		activityStatus: get( item, 'status' ),
 		activityTitle: get( item, 'summary', '' ),

--- a/client/state/data-layer/wpcom/sites/activity/schema.json
+++ b/client/state/data-layer/wpcom/sites/activity/schema.json
@@ -33,7 +33,7 @@
 	"definitions": {
 		"item": {
 			"type": "object",
-			"required": [ "activity_id", "name", "published", "summary" ],
+			"required": [ "activity_id", "is_rewindable", "name", "published", "summary" ],
 			"properties": {
 				"activity_id": { "type": "string" },
 				"actor": {
@@ -59,6 +59,7 @@
 				},
 				"generator": { "type": "object" },
 				"gridicon": { "type": "string" },
+				"is_rewindable": { "type": "boolean" },
 				"items": {
 					"type": "array",
 					"items": { "type": "object" }

--- a/client/state/data-layer/wpcom/sites/activity/test/from-api.js
+++ b/client/state/data-layer/wpcom/sites/activity/test/from-api.js
@@ -44,6 +44,7 @@ const VALID_API_ITEM = deepFreeze( {
 	gridicon: 'posts',
 	activity_id: 'foobarbaz',
 	status: 'warning',
+	is_rewindable: false,
 } );
 
 describe( 'processItem', () => {
@@ -55,6 +56,7 @@ describe( 'processItem', () => {
 				'activityGroup',
 				'activityIcon',
 				'activityId',
+				'activityIsRewindable',
 				'activityName',
 				'activityStatus',
 				'activityTitle',

--- a/client/state/data-layer/wpcom/sites/activity/test/index.js
+++ b/client/state/data-layer/wpcom/sites/activity/test/index.js
@@ -52,6 +52,7 @@ const SUCCESS_RESPONSE = deepFreeze( {
 			},
 			gridicon: 'posts',
 			activity_id: 'foobarbaz',
+			is_rewindable: false,
 		},
 	],
 	summary: 'Activity log',


### PR DESCRIPTION
`is_rewindable` was recently added to the API response. This additional property does not pass schema validation.

This PR adds the `is_rewindable` property to the API response schema and transforms to `activityIsRewindable`.
It also adds `activityIsRewindable` to the persistence schema.

## Testing
1. Visit the activity log https://calypso.live/stats/activity?branch=fix/activity-log/is-rewindable-schema
1. Verify the API response is accepted (do you see data and no errors about fetching Activity?)
1. Refresh the page and look for messages about invalidated persisted data. You shouldn't see any 🙂 