### PR TITLE
Site Settings: Enable Disconnect Flow in wpcalypso

### DIFF
--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -66,6 +66,7 @@
 		"manage/security": true,
 		"manage/site-settings/analytics": true,
 		"manage/site-settings/categories": true,
+		"manage/site-settings/disconnect-flow": true,
 		"manage/stats": true,
 		"manage/stats/podcasts": true,
 		"manage/themes": true,


### PR DESCRIPTION
Makes it easier to test.