### PR TITLE
Fix printing labels in iOS & Android

### DIFF
--- a/client/extensions/woocommerce/woocommerce-services/lib/utils/pdf-support.js
+++ b/client/extensions/woocommerce/woocommerce-services/lib/utils/pdf-support.js
@@ -18,6 +18,13 @@ export default memoize( () => {
 		return 'ie';
 	}
 
+	if ( /iPad|iPhone|iPod/.test( navigator.userAgent ) && ! window.MSStream ) {
+		// iOS doesn't support triggering a print dialog, so we should load the pdf in a new tab
+		// instead. Windows Phones are filtered out with `! window.MSStream` since the user agent
+		// string can contain the false positive 'like iPhone'
+		return 'addon';
+	}
+
 	if ( includes( navigator.userAgent, 'Firefox' ) ) {
 		// Firefox has a long-lived bug (https://bugzilla.mozilla.org/show_bug.cgi?id=911444),
 		// it's not reliable to consider its PDF reader "native"

--- a/client/extensions/woocommerce/woocommerce-services/lib/utils/print-document.js
+++ b/client/extensions/woocommerce/woocommerce-services/lib/utils/print-document.js
@@ -84,7 +84,7 @@ export default ( { b64Content, mimeType }, fileName ) => {
 			// If browser doesn't support PDFs at all, this will trigger the "Download" pop-up.
 			// No need to wait for the iframe to load, it will never finish.
 			loadDocumentInFrame( blobUrl );
-			URL.revokeObjectURL( blobUrl );
+			setTimeout( () => URL.revokeObjectURL( blobUrl ), 0 );
 			return Promise.resolve();
 	}
 };


### PR DESCRIPTION
For printing labels on iOS, I've ported the change made in https://github.com/Automattic/woocommerce-services/pull/1185 (props to @joshuaja!).

For labels on Android, turns out that Chrome for Android immediately purges from memory a blob after calling `URL.revokeObjectURL(blob)`. A simple `setTimeout` fixes it.

To test (can be done in `calypso.live`):
* Try to `Reprint` a label on an Android device. You should get the "Download" prompt and the downloaded PDF should contain a label.
* Same for an iOS device.