### PR TITLE
Disconnect Flow: Use TokenField in 'Missing Feature' Step

### DIFF
--- a/client/my-sites/site-settings/disconnect-site/missing-feature.jsx
+++ b/client/my-sites/site-settings/disconnect-site/missing-feature.jsx
@@ -2,23 +2,75 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { PureComponent } from 'react';
 import { localize } from 'i18n-calypso';
+import { findKey, isEmpty, toLower, values } from 'lodash';
 
 /**
  * Internal dependencies
  */
+import Button from 'components/button';
 import Card from 'components/card';
-import FormTextInput from 'components/forms/form-text-input';
 import SectionHeader from 'components/section-header';
+import TokenField from 'components/token-field';
+import { addQueryArgs } from 'lib/url';
 
-const MissingFeature = ( { translate } ) => (
-	<div>
-		<SectionHeader label={ translate( 'Which feature where you looking for?' ) } />
-		<Card>
-			<FormTextInput />
-		</Card>
-	</div>
-);
+class MissingFeature extends PureComponent {
+	state = {
+		tokens: [],
+	};
+
+	getSuggestions() {
+		const { translate } = this.props;
+		return {
+			themes: translate( 'Themes' ),
+			plugins: translate( 'Plugins' ),
+			support: translate( 'Support' ),
+			seo: translate( 'SEO' ),
+			ads: translate( 'Ads' ),
+			ecommerce: translate( 'Ecommerce' ),
+		};
+	}
+
+	normalizeToken = translatedToken => {
+		const tokenKey = findKey( this.getSuggestions(), token => token === translatedToken );
+		if ( tokenKey ) {
+			return tokenKey;
+		}
+		return toLower( translatedToken );
+	};
+
+	onChange = tokens => {
+		this.setState( { tokens } );
+	};
+
+	render() {
+		const { confirmHref, translate } = this.props;
+		const suggestions = values( this.getSuggestions() );
+
+		return (
+			<div>
+				<SectionHeader label={ translate( 'Which feature where you looking for?' ) } />
+				<Card>
+					<TokenField
+						onChange={ this.onChange }
+						suggestions={ suggestions }
+						value={ this.state.tokens }
+					/>
+					<Button
+						disabled={ isEmpty( this.state.tokens ) }
+						href={ addQueryArgs(
+							{ 'missing-features': this.state.tokens.map( this.normalizeToken ).join( '+' ) },
+							confirmHref
+						) }
+						primary
+					>
+						{ translate( 'Submit' ) }
+					</Button>
+				</Card>
+			</div>
+		);
+	}
+}
 
 export default localize( MissingFeature );

--- a/client/my-sites/site-settings/disconnect-site/missing-feature.jsx
+++ b/client/my-sites/site-settings/disconnect-site/missing-feature.jsx
@@ -60,7 +60,7 @@ class MissingFeature extends PureComponent {
 					<Button
 						disabled={ isEmpty( this.state.tokens ) }
 						href={ addQueryArgs(
-							{ 'missing-features': this.state.tokens.map( this.normalizeToken ).join( '+' ) },
+							{ 'missing-features': this.state.tokens.map( this.normalizeToken ) },
 							confirmHref
 						) }
 						primary

--- a/client/my-sites/site-settings/disconnect-site/missing-feature.jsx
+++ b/client/my-sites/site-settings/disconnect-site/missing-feature.jsx
@@ -40,7 +40,7 @@ class MissingFeature extends PureComponent {
 		return toLower( translatedToken );
 	};
 
-	onChange = tokens => {
+	handleTokenChange = tokens => {
 		this.setState( { tokens } );
 	};
 
@@ -53,7 +53,7 @@ class MissingFeature extends PureComponent {
 				<SectionHeader label={ translate( 'Which feature where you looking for?' ) } />
 				<Card>
 					<TokenField
-						onChange={ this.onChange }
+						onChange={ this.handleTokenChange }
 						suggestions={ suggestions }
 						value={ this.state.tokens }
 					/>

--- a/client/my-sites/site-settings/disconnect-site/missing-feature.jsx
+++ b/client/my-sites/site-settings/disconnect-site/missing-feature.jsx
@@ -49,7 +49,7 @@ class MissingFeature extends PureComponent {
 		const suggestions = values( this.getSuggestions() );
 
 		return (
-			<div>
+			<div className="disconnect-site__missing-feature">
 				<SectionHeader label={ translate( 'Which feature where you looking for?' ) } />
 				<Card>
 					<TokenField

--- a/client/my-sites/site-settings/disconnect-site/style.scss
+++ b/client/my-sites/site-settings/disconnect-site/style.scss
@@ -21,3 +21,11 @@
 .disconnect-site__navigation-links {
 	text-align: center;
 }
+
+// 'Missing Feature' page
+.disconnect-site__missing-feature {
+	.button {
+		margin-top: 10px;
+		float: right;
+	}
+}

--- a/client/my-sites/site-settings/disconnect-site/style.scss
+++ b/client/my-sites/site-settings/disconnect-site/style.scss
@@ -25,7 +25,7 @@
 // 'Missing Feature' page
 .disconnect-site__missing-feature {
 	.button {
-		margin-top: 10px;
+		margin-top: 16px;
 		float: right;
 	}
 }


### PR DESCRIPTION
As announced in #18749.

![image](https://user-images.githubusercontent.com/96308/31786402-a4fba66c-b508-11e7-94d7-7f82d22e00a3.png)


To Test:
* Navigate to `http://calypso.localhost:3000/settings/disconnect-site/missing-feature/:site`
* Click into the `TokenField`, select keyword from the dropdown (e.g. 'Ads')
* Enter your own keyword (e.g. 'Kittens'), press enter.
* Verify that upon clicking 'Submit', you're taken to `http://calypso.localhost:3000/settings/disconnect-site/confirm/bernhardreiter.wpsandbox.me?missing-features=ads%2Bkittens`. That query string will be used in a subsequent PR to submit the marketing survey.

Note that the query string is being normalized: While keywords in the autocomplete suggestions list are translated (e.g. 'Werbeanzeigen' for 'ads' in the screenshot), the canonical English version is used for the query arg. Unknown keywords are simply lowercased.

@rickybanister Could you lend me a hand styling this? I so suck when it comes to (S)CSS. I tried adding some classes and styling the button to `float:right` and the `TokenField` to only have `width: 80%`, but that neither worked, nor looked correct :slightly_frowning_face: 