### PR TITLE
Validation: fix validation warning since the type is initially null

### DIFF
--- a/client/state/happychat/ui/reducer.js
+++ b/client/state/happychat/ui/reducer.js
@@ -31,7 +31,7 @@ export const lostFocusAt = ( state = null, action ) => {
 			}
 			return state;
 		case DESERIALIZE:
-			if ( isValidStateWithSchema( state, { type: 'number' } ) ) {
+			if ( isValidStateWithSchema( state, { type: [ 'null', 'number' ] } ) ) {
 				return state;
 			}
 			return null;


### PR DESCRIPTION
...instead of number

This is in response to https://github.com/Automattic/wp-calypso/pull/19010#issuecomment-337955349 that I also experienced. Probably not related exclusively to AL but good to fix anyway.