### PR TITLE
Fix `theme` property in Tracks event fired on a screenshot click in the theme showcase

### DIFF
--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -193,7 +193,7 @@ export class Theme extends Component {
 						{ ! isEmpty( this.props.buttonContents ) ? (
 							<ThemeMoreButton
 								index={ this.props.index }
-								theme={ this.props.theme }
+								themeId={ this.props.theme.id }
 								active={ this.props.active }
 								onMoreButtonClick={ this.props.onMoreButtonClick }
 								options={ this.props.buttonContents }

--- a/client/components/theme/more-button.jsx
+++ b/client/components/theme/more-button.jsx
@@ -32,7 +32,7 @@ class ThemeMoreButton extends Component {
 	togglePopover() {
 		this.setState( { showPopover: ! this.state.showPopover } );
 		! this.state.showPopover &&
-			this.props.onMoreButtonClick( this.props.theme, this.props.index, 'popup_open' );
+			this.props.onMoreButtonClick( this.props.themeId, this.props.index, 'popup_open' );
 	}
 
 	closePopover( action ) {
@@ -43,8 +43,8 @@ class ThemeMoreButton extends Component {
 	}
 
 	popoverAction( action, label ) {
-		action( this.props.theme.id );
-		this.props.onMoreButtonClick( this.props.theme, this.props.index, 'popup_' + label );
+		action( this.props.themeId );
+		this.props.onMoreButtonClick( this.props.themeId, this.props.index, 'popup_' + label );
 	}
 
 	onPopoverActionClick( action, label ) {
@@ -85,7 +85,7 @@ class ThemeMoreButton extends Component {
 								return <hr key={ key } className="popover__hr" />;
 							}
 							if ( option.getUrl ) {
-								const url = option.getUrl( this.props.theme.id );
+								const url = option.getUrl( this.props.themeId );
 								return (
 									<a
 										className="theme__more-button-menu-item popover__menu-item"
@@ -120,8 +120,7 @@ class ThemeMoreButton extends Component {
 }
 
 ThemeMoreButton.propTypes = {
-	// See Theme component propTypes
-	theme: PropTypes.object,
+	themeId: PropTypes.string,
 	// Index of theme in results list
 	index: PropTypes.number,
 	// More elaborate onClick action, used for tracking.

--- a/client/my-sites/themes/single-site-jetpack.jsx
+++ b/client/my-sites/themes/single-site-jetpack.jsx
@@ -126,11 +126,11 @@ const ConnectedSingleSiteJetpack = connectOptions( props => {
 								}
 								return getScreenshotOption( theme ).getUrl( theme );
 							} }
-							onScreenshotClick={ function( theme ) {
-								if ( ! getScreenshotOption( theme ).action ) {
+							onScreenshotClick={ function( themeId ) {
+								if ( ! getScreenshotOption( themeId ).action ) {
 									return;
 								}
-								getScreenshotOption( theme ).action( theme );
+								getScreenshotOption( themeId ).action( themeId );
 							} }
 							getActionLabel={ function( theme ) {
 								return getScreenshotOption( theme ).label;

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -254,11 +254,11 @@ const ThemeShowcase = React.createClass( {
 							}
 							return getScreenshotOption( theme ).getUrl( theme );
 						} }
-						onScreenshotClick={ function( theme ) {
-							if ( ! getScreenshotOption( theme ).action ) {
+						onScreenshotClick={ function( themeId ) {
+							if ( ! getScreenshotOption( themeId ).action ) {
 								return;
 							}
-							getScreenshotOption( theme ).action( theme );
+							getScreenshotOption( themeId ).action( themeId );
 						} }
 						getActionLabel={ function( theme ) {
 							return getScreenshotOption( theme ).label;

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -59,14 +59,14 @@ class ThemesSelection extends Component {
 		showUploadButton: true,
 	};
 
-	recordSearchResultsClick = ( theme, resultsRank, action ) => {
+	recordSearchResultsClick = ( themeId, resultsRank, action ) => {
 		const { query, themes, filterString } = this.props;
 		const search_taxonomies = filterString;
 		const search_term = search_taxonomies + ( query.search || '' );
 		this.props.recordTracksEvent( 'calypso_themeshowcase_theme_click', {
 			search_term: search_term || null,
 			search_taxonomies,
-			theme: theme.id,
+			theme: themeId,
 			results_rank: resultsRank + 1,
 			results: themes.map( property( 'id' ) ).join(),
 			page_number: query.page,
@@ -85,12 +85,12 @@ class ThemesSelection extends Component {
 		this.props.recordTracksEvent( 'calypso_themeshowcase_last_page_scroll' );
 	}
 
-	onScreenshotClick = ( theme, resultsRank ) => {
+	onScreenshotClick = ( themeId, resultsRank ) => {
 		trackClick( 'theme', 'screenshot' );
-		if ( ! this.props.isThemeActive( theme ) ) {
-			this.recordSearchResultsClick( theme, resultsRank, 'screenshot_info' );
+		if ( ! this.props.isThemeActive( themeId ) ) {
+			this.recordSearchResultsClick( themeId, resultsRank, 'screenshot_info' );
 		}
-		this.props.onScreenshotClick && this.props.onScreenshotClick( theme );
+		this.props.onScreenshotClick && this.props.onScreenshotClick( themeId );
 	};
 
 	fetchNextPage = options => {


### PR DESCRIPTION
Turns out the event we're sending to Tracks when we get a click on a Theme screenshot is actually `undefined`, because we're getting the [ID](https://github.com/Automattic/wp-calypso/blob/49cc1c92c1c86767a33ef4e586141e05e0b835cc/client/my-sites/themes/themes-selection.jsx#L69) of an [ID](https://github.com/Automattic/wp-calypso/blob/49cc1c92c1c86767a33ef4e586141e05e0b835cc/client/components/theme/index.jsx#L96), which never ends well.

## Testing

1- Load this PR
2- go to `/themes`
3- make sure that interacting with a theme triggers Tracks events (`t.gif`) that actually contain a proper `theme` in the querystring.