### PR TITLE
Notifications: Update notifications panel to version 1.2.5

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1127,7 +1127,7 @@
           "dev": true
         },
         "q": {
-          "version": "1.5.0",
+          "version": "1.5.1",
           "dev": true
         }
       }
@@ -4977,7 +4977,7 @@
       "dev": true
     },
     "notifications-panel": {
-      "version": "1.2.4"
+      "version": "1.2.5"
     },
     "npm-path": {
       "version": "1.1.0",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4977,7 +4977,7 @@
       "dev": true
     },
     "notifications-panel": {
-      "version": "1.2.5"
+      "version": "1.2.6"
     },
     "npm-path": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "ms": "0.7.1",
     "name-all-modules-plugin": "1.0.1",
     "node-sass": "3.7.0",
-    "notifications-panel": "1.2.5",
+    "notifications-panel": "1.2.6",
     "npm-run-all": "4.0.2",
     "numeral": "2.0.4",
     "page": "1.6.4",

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "ms": "0.7.1",
     "name-all-modules-plugin": "1.0.1",
     "node-sass": "3.7.0",
-    "notifications-panel": "1.2.4",
+    "notifications-panel": "1.2.5",
     "npm-run-all": "4.0.2",
     "numeral": "2.0.4",
     "page": "1.6.4",


### PR DESCRIPTION
Fixes https://github.com/Automattic/notifications-panel/issues/186 for Calypso.

Updates the Notification Panel dependency to version ~`1.2.5`~ `1.2.6`, that supports the new reply gridicon and better exports for webpack's tree shaking (https://github.com/Automattic/notifications-panel/pull/184).

| Before | After |
| --- | --- |
| ![screen shot 2017-10-19 at 16 27 57](https://user-images.githubusercontent.com/233601/31790284-57c8c45a-b4eb-11e7-94dd-4998d4436d2b.png) | ![screen shot 2017-10-19 at 16 27 22](https://user-images.githubusercontent.com/233601/31790299-660e61dc-b4eb-11e7-91a1-c90da0d4167a.png) |

 