### PR TITLE
Atomic Store: show Atomic checkout-thank-you for Atomic sites as well

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/index.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.jsx
@@ -76,7 +76,7 @@ import {
 	PLAN_JETPACK_BUSINESS,
 	PLAN_JETPACK_BUSINESS_MONTHLY,
 } from 'lib/plans/constants';
-import { getSiteOptions } from 'state/selectors';
+import { getSiteOptions, isSiteAutomatedTransfer } from 'state/selectors';
 
 function getPurchases( props ) {
 	return ( props.receipt.data && props.receipt.data.purchases ) || [];
@@ -267,9 +267,9 @@ const CheckoutThankYou = React.createClass( {
 			return <RebrandCitiesThankYou receipt={ this.props.receipt } />;
 		}
 
-		const { signupIsStore } = this.props;
+		const { signupIsStore, isAtomicSite } = this.props;
 
-		if ( wasDotcomPlanPurchased && signupIsStore ) {
+		if ( wasDotcomPlanPurchased && ( signupIsStore || isAtomicSite ) ) {
 			return (
 				<Main className="checkout-thank-you">
 					{ this.renderConfirmationNotice() }
@@ -453,6 +453,7 @@ export default connect(
 			user: getCurrentUser( state ),
 			userDate: getCurrentUserDate( state ),
 			signupIsStore: get( siteOptions, 'signup_is_store', false ),
+			isAtomicSite: isSiteAutomatedTransfer( state, siteId ),
 		};
 	},
 	dispatch => {


### PR DESCRIPTION
Currently, when you go through the Atomic Store flow (selecting the 'store' design type on the first step), we show a special checkout-thank-you page after purchasing the cart items.

The issue is that if a customer stays on this page while the site is transferred (thus becoming Atomic), the page will show a wrong design (a standard one for any Business plan).

In this patch, we fix that by showing the special checkout-thank-you page also to Atomic sites.

## Testing

It would be clearly visible if tested in conjunction with #18896. It can be tested without that, though:

1. First, let's verify the problem: go through Atomic Store signup flow. After getting to checkout-thank-you page, wait until site is transferred (you can check with [Dev Console](https://developer.wordpress.com/docs/api/console-2014/)). After it's transferred, hard-reload the checkout-thank-you page. You should see the wrong one.
2. Checkout the branch in this PR and follow the same steps in 1. Can you see the special Atomic checkout-thank-you page when reloading after the transfer finishes?