### PR TITLE
Show end-of-list marker for PostTypeList

### DIFF
--- a/client/my-sites/post-type-list/index.jsx
+++ b/client/my-sites/post-type-list/index.jsx
@@ -144,11 +144,7 @@ class PostTypeList extends Component {
 	maybeLoadNextPage() {
 		const { scrollContainer, lastPageToRequest, isRequestingPosts } = this.props;
 		const { maxRequestedPage } = this.state;
-		if (
-			! scrollContainer ||
-			isRequestingPosts ||
-			maxRequestedPage >= lastPageToRequest
-		) {
+		if ( ! scrollContainer || isRequestingPosts || maxRequestedPage >= lastPageToRequest ) {
 			return;
 		}
 
@@ -173,11 +169,8 @@ class PostTypeList extends Component {
 
 	renderMaxPagesNotice() {
 		const { siteId, totalPageCount, totalPostCount } = this.props;
-		const isTruncated = (
-			null === siteId &&
-			this.hasListFullyLoaded() &&
-			totalPageCount > MAX_ALL_SITES_PAGES
-		);
+		const isTruncated =
+			null === siteId && this.hasListFullyLoaded() && totalPageCount > MAX_ALL_SITES_PAGES;
 
 		if ( ! isTruncated ) {
 			return null;
@@ -219,13 +212,10 @@ class PostTypeList extends Component {
 
 		return (
 			<div className={ classes }>
-				{ query && range( 1, maxRequestedPage + 1 ).map( page => (
-					<QueryPosts
-						key={ `query-${ page }` }
-						siteId={ siteId }
-						query={ { ...query, page } }
-					/>
-				) ) }
+				{ query &&
+					range( 1, maxRequestedPage + 1 ).map( page => (
+						<QueryPosts key={ `query-${ page }` } siteId={ siteId } query={ { ...query, page } } />
+					) ) }
 				{ posts && posts.map( this.renderPost ) }
 				{ isLoadedAndEmpty && (
 					<PostTypeListEmptyContent type={ query.type } status={ query.status } />
@@ -241,11 +231,8 @@ export default connect( ( state, ownProps ) => {
 	const siteId = getSelectedSiteId( state );
 
 	const totalPageCount = getSitePostsLastPageForQuery( state, siteId, ownProps.query );
-	const lastPageToRequest = (
-		siteId === null
-			? Math.min( MAX_ALL_SITES_PAGES, totalPageCount )
-			: totalPageCount
-	);
+	const lastPageToRequest =
+		siteId === null ? Math.min( MAX_ALL_SITES_PAGES, totalPageCount ) : totalPageCount;
 
 	return {
 		siteId,

--- a/client/my-sites/post-type-list/index.jsx
+++ b/client/my-sites/post-type-list/index.jsx
@@ -143,29 +143,28 @@ class PostTypeList extends Component {
 
 	maybeLoadNextPage() {
 		const { scrollContainer, lastPageToRequest, isRequestingPosts } = this.props;
-		if ( ! scrollContainer ) {
+		const { maxRequestedPage } = this.state;
+		if (
+			! scrollContainer ||
+			isRequestingPosts ||
+			maxRequestedPage >= lastPageToRequest
+		) {
 			return;
 		}
+
 		const scrollTop = this.getScrollTop();
 		const { scrollHeight, clientHeight } = scrollContainer;
+		const pixelsBelowViewport = scrollHeight - scrollTop - clientHeight;
 		if (
 			typeof scrollTop !== 'number' ||
 			typeof scrollHeight !== 'number' ||
-			typeof clientHeight !== 'number'
+			typeof clientHeight !== 'number' ||
+			pixelsBelowViewport > LOAD_NEXT_PAGE_THRESHOLD_PIXELS
 		) {
 			return;
 		}
-		const pixelsBelowViewport = scrollHeight - scrollTop - clientHeight;
-		const { maxRequestedPage } = this.state;
-		if (
-			pixelsBelowViewport <= LOAD_NEXT_PAGE_THRESHOLD_PIXELS &&
-			maxRequestedPage < lastPageToRequest &&
-			! isRequestingPosts
-		) {
-			this.setState( {
-				maxRequestedPage: maxRequestedPage + 1,
-			} );
-		}
+
+		this.setState( { maxRequestedPage: maxRequestedPage + 1 } );
 	}
 
 	renderListEnd() {

--- a/client/my-sites/post-type-list/index.jsx
+++ b/client/my-sites/post-type-list/index.jsx
@@ -230,13 +230,12 @@ class PostTypeList extends Component {
 
 export default connect( ( state, ownProps ) => {
 	const siteId = getSelectedSiteId( state );
-	const lastPage = getSitePostsLastPageForQuery( state, siteId, ownProps.query );
 
 	return {
 		siteId,
 		posts: getSitePostsForQueryIgnoringPage( state, siteId, ownProps.query ),
 		isRequestingPosts: isRequestingSitePostsForQueryIgnoringPage( state, siteId, ownProps.query ),
-		lastPage,
+		lastPage: getSitePostsLastPageForQuery( state, siteId, ownProps.query ),
 		totalPosts: getSitePostsFoundForQuery( state, siteId, ownProps.query ),
 	};
 } )( PostTypeList );

--- a/client/my-sites/post-type-list/index.jsx
+++ b/client/my-sites/post-type-list/index.jsx
@@ -33,8 +33,8 @@ import PostTypeListMaxPagesNotice from './max-pages-notice';
 // When this many pixels or less are below the viewport, begin loading the next
 // page of items.
 const LOAD_NEXT_PAGE_THRESHOLD_PIXELS = 400;
-
-// The number of pages of results that are displayed in "All My Sites"
+// The maximum number of pages of results that can be displayed in "All My
+// Sites" (API endpoint limitation).
 const MAX_ALL_SITES_PAGES = 10;
 
 class PostTypeList extends Component {

--- a/client/my-sites/post-type-list/index.jsx
+++ b/client/my-sites/post-type-list/index.jsx
@@ -139,11 +139,6 @@ class PostTypeList extends Component {
 		return ! isRequestingPosts && maxRequestedPage >= lastPage;
 	}
 
-	isTruncatedResults() {
-		const { siteId, lastPage } = this.props;
-		return null === siteId && this.hasListFullyLoaded() && lastPage > MAX_ALL_SITES_PAGES;
-	}
-
 	maybeLoadNextPage() {
 		const { scrollContainer, lastPage, isRequestingPosts } = this.props;
 		if ( ! scrollContainer ) {
@@ -176,8 +171,14 @@ class PostTypeList extends Component {
 	}
 
 	renderMaxPagesNotice() {
-		const { totalPosts } = this.props;
+		const { totalPosts, siteId, lastPage } = this.props;
 		const displayedPosts = this.getPostsPerPageCount() * MAX_ALL_SITES_PAGES;
+		const isTruncated =
+			null === siteId && this.hasListFullyLoaded() && lastPage > MAX_ALL_SITES_PAGES;
+
+		if ( ! isTruncated ) {
+			return null;
+		}
 
 		return (
 			<PostTypeListMaxPagesNotice displayedPosts={ displayedPosts } totalPosts={ totalPosts } />
@@ -221,7 +222,7 @@ class PostTypeList extends Component {
 				{ isLoadedAndEmpty && (
 					<PostTypeListEmptyContent type={ query.type } status={ query.status } />
 				) }
-				{ this.isTruncatedResults() && this.renderMaxPagesNotice() }
+				{ this.renderMaxPagesNotice() }
 				{ this.hasListFullyLoaded() ? this.renderListEnd() : this.renderPlaceholder() }
 			</div>
 		);

--- a/client/my-sites/post-type-list/index.jsx
+++ b/client/my-sites/post-type-list/index.jsx
@@ -204,8 +204,18 @@ class PostTypeList extends Component {
 		);
 	}
 
+	renderQueryPosts( page ) {
+		const { query, siteId } = this.props;
+
+		if ( null === siteId && page > MAX_ALL_SITES_PAGES ) {
+			return null;
+		}
+
+		return <QueryPosts key={ `query-${ page }` } siteId={ siteId } query={ { ...query, page } } />;
+	}
+
 	render() {
-		const { query, siteId, posts, isRequestingPosts } = this.props;
+		const { query, posts, isRequestingPosts } = this.props;
 		const { maxRequestedPage } = this.state;
 		const isLoadedAndEmpty = query && posts && ! posts.length && ! isRequestingPosts;
 		const classes = classnames( 'post-type-list', {
@@ -214,10 +224,7 @@ class PostTypeList extends Component {
 
 		return (
 			<div className={ classes }>
-				{ query &&
-					range( 1, maxRequestedPage + 1 ).map( page => (
-						<QueryPosts key={ `query-${ page }` } siteId={ siteId } query={ { ...query, page } } />
-					) ) }
+				{ query && range( 1, maxRequestedPage + 1 ).map( page => this.renderQueryPosts( page ) ) }
 				{ posts && posts.map( this.renderPost ) }
 				{ isLoadedAndEmpty && (
 					<PostTypeListEmptyContent type={ query.type } status={ query.status } />

--- a/client/my-sites/post-type-list/max-pages-notice.jsx
+++ b/client/my-sites/post-type-list/max-pages-notice.jsx
@@ -1,0 +1,65 @@
+/**
+ * External dependencies
+ *
+ * @format
+ */
+
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import { setLayoutFocus } from 'state/ui/layout-focus/actions';
+import { recordTracksEvent } from 'state/analytics/actions';
+
+class PostTypeListMaxPagesNotice extends Component {
+	static propTypes = {
+		displayedPosts: PropTypes.number,
+		totalPosts: PropTypes.number,
+	};
+
+	componentWillMount() {
+		this.props.recordTracksEvent( 'calypso_post_type_list_max_pages_view' );
+	}
+
+	focusSiteSelector = event => {
+		event.preventDefault();
+
+		this.props.setLayoutFocus( 'sites' );
+	};
+
+	render() {
+		const { displayedPosts, totalPosts, translate } = this.props;
+
+		return (
+			<div className="post-type-list__max-pages-notice">
+				{ translate(
+					'%(displayedPosts)d of %(totalPosts)d posts shown' +
+						'{{br/}}to view more posts, {{a}}switch to a specific site{{/a}}.',
+					{
+						args: {
+							displayedPosts,
+							totalPosts,
+						},
+						components: {
+							a: (
+								<a
+									className="post-type-list__max-pages-notice-link"
+									onClick={ this.focusSiteSelector }
+								/>
+							),
+							br: <br />,
+						},
+					}
+				) }
+			</div>
+		);
+	}
+}
+
+export default connect( null, { recordTracksEvent, setLayoutFocus } )(
+	localize( PostTypeListMaxPagesNotice )
+);

--- a/client/my-sites/post-type-list/max-pages-notice.jsx
+++ b/client/my-sites/post-type-list/max-pages-notice.jsx
@@ -37,24 +37,26 @@ class PostTypeListMaxPagesNotice extends Component {
 		return (
 			<div className="post-type-list__max-pages-notice">
 				{ translate(
-					'%(displayedPosts)d of %(totalPosts)d posts shown' +
-						'{{br/}}to view more posts, {{a}}switch to a specific site{{/a}}.',
+					'Showing %(displayedPosts)d post of %(totalPosts)d.',
+					'Showing %(displayedPosts)d posts of %(totalPosts)d.',
 					{
 						args: {
 							displayedPosts,
 							totalPosts,
 						},
-						components: {
-							a: (
-								<a
-									className="post-type-list__max-pages-notice-link"
-									onClick={ this.focusSiteSelector }
-								/>
-							),
-							br: <br />,
-						},
 					}
 				) }
+				<br />
+				{ translate( 'To view more posts, {{a}}switch to a specific site{{/a}}.', {
+					components: {
+						a: (
+							<a
+								className="post-type-list__max-pages-notice-link"
+								onClick={ this.focusSiteSelector }
+							/>
+						),
+					},
+				} ) }
 			</div>
 		);
 	}

--- a/client/my-sites/post-type-list/style.scss
+++ b/client/my-sites/post-type-list/style.scss
@@ -46,3 +46,17 @@
 	max-height: 100%;
 	max-width: none;
 }
+
+
+.post-type-list__max-pages-notice {
+	text-align: center;
+	margin: 16px 0;
+	font-size: 14px;
+	color: $gray-text-min;
+}
+
+a.post-type-list__max-pages-notice-link {
+	cursor: pointer;
+	color: $gray-text-min;
+	text-decoration: underline;
+}


### PR DESCRIPTION
This PR adds end-of-list markers to PostTypeList:

![image](https://user-images.githubusercontent.com/363749/32191284-80a93cc4-bd7e-11e7-9821-8b16187fa2cc.png)

When the "All My Sites" view of the PostTypeList contains more than 400 posts, this PR also adds a message informing you how to view the remainder of your posts.

![image](https://user-images.githubusercontent.com/363749/32191338-b964df28-bd7e-11e7-9c5a-92adac8ac422.png)

To test:
* Apply PR.
* `ENABLE_FEATURES=posts/post-type-list npm start`.
* Visit your "Blog Posts" for a single site.
* Make sure at the end of the list (once all pages have loaded) you see the end of list marker.
* With a user that has fewer than 400 total blog posts, enter "All My Sites" mode. Scroll to the bottom of "Blog Posts" and verify the end of list marker is present, but the message about viewing the remainder of posts is not.
* With a user that has more than 400 total blog posts, , enter "All My Sites" mode. Scroll to the bottom of "Blog Posts" and verify both the end of list marker and the message about viewing the remainder of posts are present.
* Verify that clicking on "switch to a specific site" opens the site picker.