### PR TITLE
[Store] Fixed modal styles in IE11

### DIFF
--- a/client/extensions/woocommerce/style.scss
+++ b/client/extensions/woocommerce/style.scss
@@ -2,8 +2,6 @@
 @import 'assets/stylesheets/shared/utils';      // utilities that are used by all CSS but don't produce any code
 
 .woocommerce {
-	flex-grow: 1;
-
 	@import 'app/dashboard/style';
 	@import 'app/order/style';
 	@import 'app/order/order-create/style';

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/style.scss
@@ -4,7 +4,8 @@
 @import './rates-step/style';
 
 &.label-purchase-modal {
-	min-height: 90%;
+	height: 90%;
+	width: 90%;
 
 	.dialog__content {
 		flex-grow: 1;


### PR DESCRIPTION
IE11 shoots itself in the foot when there's (`min-`)`width` rules and also `flex`-related rules for the same element. That resulted in the label-related modals to be shifted partially off-screen in IE11. I've removed an (apparently unneeded) `flex-grow` rule so now the Refund and Reprint dialogs are normal size. I added specific `width/height` rules for the Label Purchase dialog because we want it to be bigger.

@coderkevin I've traced the `flex-grow: 1` line to a commit of yours. Is it actually needed? For what I've seen, its only purpose was making the dialogs super wide. The main section of the Orders, Products, Promotions, etc screens has a fixed width, so the `flex-grow: 1` rule has no effect. Do we have any full-width pages?

To test, since I'm gonna assume you don't have a IE11 at hand, you can just trust me when I say that now it works. If you want to test it, just open an Order screen in IE11 and open the `Purchase Label`, `Refund label` and `Reprint` dialogs, and check that they appear with reasonable dimensions and centered in the screen. I'd appreciate if you test in the regular browsers for any obvious regression, since I've modified a root-level CSS rule. I haven't found anything in my testing.