### PR TITLE
Signup: Remove last two sections from rebrand cities thank you page

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/rebrand-cities-thank-you.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/rebrand-cities-thank-you.jsx
@@ -37,18 +37,10 @@ class RebrandCitiesThankYou extends Component {
 										'a digital footprint and reaching more customers.'
 								) }
 							</p>
-							<p>
-								{ translate(
-									'Please complete our business survey so we can learn more about you ' +
-										'and your business.'
-								) }
-							</p>
 						</div>
 					}
-					buttonUrl={ 'https://rebrandcities.typeform.com/to/cesv1j?typeform-welcome=0' }
-					buttonText={ translate( 'Start our business survey' ) }
 					icon={ this.renderLogo() }
-					action={ null }
+					action=" "
 				/>
 			</div>
 		);


### PR DESCRIPTION
This change removes the last paragraph of content and link to rebrand city thank you page from the rebrand city signup flow.

Before:

![screen shot 2017-10-20 at 1 57 40 pm](https://user-images.githubusercontent.com/1926/31804735-c8215858-b59e-11e7-9be6-4ea1ca67f3eb.png)

After:

![screen shot 2017-10-20 at 1 57 07 pm](https://user-images.githubusercontent.com/1926/31804741-d07e0780-b59e-11e7-94ed-ee1a96c52dbb.png)

Testing:

- signup from `/start/rebrand-cities`
- purchase business plan
- verify the change of content in thank you page