### PR TITLE
Post Revisions: Track related events. 

### DIFF
--- a/client/post-editor/editor-ground-control/history-button.jsx
+++ b/client/post-editor/editor-ground-control/history-button.jsx
@@ -3,12 +3,15 @@
  * External dependencies
  */
 import React, { PureComponent } from 'react';
+import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
+import { flow } from 'lodash';
 
 /**
  * Internal dependencies
  */
+import { recordTracksEvent } from 'state/analytics/actions';
 import {
 	NESTED_SIDEBAR_NONE,
 	NESTED_SIDEBAR_REVISIONS,
@@ -31,14 +34,22 @@ class HistoryButton extends PureComponent {
 			return;
 		}
 
+		// otherwise, show revisions...
+		this.trackPostRevisionsOpen();
 		selectRevision( null );
 		setNestedSidebar( NESTED_SIDEBAR_REVISIONS );
 
-		// open the sidebar when closed
+		// and open the sidebar if it's not open already.
 		if ( ! isSidebarOpened ) {
 			toggleSidebar();
 		}
 	};
+
+	trackPostRevisionsOpen() {
+		this.props.recordTracksEvent( 'calypso_editor_post_revisions_open', {
+			source: 'ground_control_history',
+		} );
+	}
 
 	render() {
 		return (
@@ -63,4 +74,4 @@ HistoryButton.PropTypes = {
 	translate: PropTypes.func,
 };
 
-export default localize( HistoryButton );
+export default flow( localize, connect( null, { recordTracksEvent } ) )( HistoryButton );

--- a/client/post-editor/editor-revisions/index.jsx
+++ b/client/post-editor/editor-revisions/index.jsx
@@ -8,18 +8,28 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import Gridicon from 'gridicons';
 import { localize } from 'i18n-calypso';
+import { connect } from 'react-redux';
+import { flow } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import { isEnabled } from 'config';
+import { recordTracksEvent } from 'state/analytics/actions';
 import { NESTED_SIDEBAR_REVISIONS } from 'post-editor/editor-sidebar/constants';
 
 class EditorRevisions extends Component {
 	showRevisionsNestedSidebar = () => {
+		this.trackPostRevisionsOpen();
 		this.props.selectRevision( null );
 		this.props.setNestedSidebar( NESTED_SIDEBAR_REVISIONS );
 	};
+
+	trackPostRevisionsOpen() {
+		this.props.recordTracksEvent( 'calypso_editor_post_revisions_open', {
+			source: 'settings_status_sidebar',
+		} );
+	}
 
 	render() {
 		const { adminUrl, revisions, translate } = this.props;
@@ -72,4 +82,4 @@ EditorRevisions.propTypes = {
 	selectRevision: PropTypes.func.isRequired,
 };
 
-export default localize( EditorRevisions );
+export default flow( localize, connect( null, { recordTracksEvent } ) )( EditorRevisions );

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -47,6 +47,7 @@ import {
 	isConfirmationSidebarEnabled,
 	isEditorOnlyRouteInHistory,
 } from 'state/ui/editor/selectors';
+import { recordTracksEvent } from 'state/analytics/actions';
 import { editPost, receivePost, savePostSuccess } from 'state/posts/actions';
 import { getPostEdits, isEditedPostDirty } from 'state/posts/selectors';
 import { getCurrentUserId } from 'state/current-user/selectors';
@@ -305,6 +306,12 @@ export const PostEditor = createReactClass( {
 		if ( isWithinBreakpoint( '<660px' ) ) {
 			this.props.setLayoutFocus( 'content' );
 		}
+
+		this.trackLoadRevision();
+	},
+
+	trackLoadRevision() {
+		this.props.recordTracksEvent( 'calypso_editor_post_revisions_load_revision' );
 	},
 
 	render: function() {
@@ -1414,6 +1421,7 @@ export default connect(
 				setLayoutFocus,
 				setNextLayoutFocus,
 				saveConfirmationSidebarPreference,
+				recordTracksEvent,
 			},
 			dispatch
 		);


### PR DESCRIPTION
This PR aims to add tracking to interactions around Post Revisions.

The interactions it aims to cover are:
- [x] Opening the revisions
- [x] Restore a revision

Note: Diff generation time will be tackled in a separate changeset.

### To test:

Before anything, set the debugger to show tracking events by popping this in to your console:
```js
localStorage.setItem('debug', 'calypso:analytics:*');
```

Then test each event:

- Opening the revisions
  - Test by opening from the EditorGroundControl header using the <kbd>history</kbd> button
  - You should see the event triggered in the console, along with a 'source' param that describes this button.
  - Test by opening from Post Settings sidebar (status drawer) header using the <kbd>XX Revisions</kbd> button
  - You should see the event triggered in the console, along with a source param that describes this button.
- Restore a revision
  -  Select a past revision in from the list of revisions
  - Click on the <kbd>Load Revision in Editor</kbd> button above the list
  - You should see an event in the console that describes this interaction.