### PR TITLE
Fix wrong page title and missing head tags on login

### DIFF
--- a/server/isomorphic-routing/index.js
+++ b/server/isomorphic-routing/index.js
@@ -1,15 +1,8 @@
 /** @format */
 /**
- * External dependencies
- */
-
-import { isEmpty, pick } from 'lodash';
-import qs from 'qs';
-
-/**
  * Internal dependencies
  */
-import { serverRender } from 'render';
+import { serverRender, serverRenderIfCached } from 'render';
 import { setSection as setSectionMiddlewareFactory } from '../../client/controller';
 import { setRoute as setRouteAction } from 'state/ui/actions';
 
@@ -35,6 +28,7 @@ export function serverRouter( expressApp, setUpRoute, section ) {
 			expressApp.get(
 				route,
 				setUpRoute,
+				serverRenderIfCached,
 				combineMiddlewares(
 					setSectionMiddlewareFactory( section ),
 					setRouteMiddleware,
@@ -92,17 +86,4 @@ function applyMiddlewares( context, expressNext, ...middlewares ) {
 
 function compose( ...functions ) {
 	return functions.reduceRight( ( composed, f ) => () => f( composed ), () => {} );
-}
-
-export function getCacheKey( context ) {
-	if ( isEmpty( context.query ) || isEmpty( context.cacheQueryKeys ) ) {
-		return context.pathname;
-	}
-
-	const cachedQueryParams = pick( context.query, context.cacheQueryKeys );
-	return (
-		context.pathname +
-		'?' +
-		qs.stringify( cachedQueryParams, { sort: ( a, b ) => a.localCompare( b ) } )
-	);
 }

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -9,7 +9,7 @@ import qs from 'qs';
 import { execSync } from 'child_process';
 import cookieParser from 'cookie-parser';
 import debugFactory from 'debug';
-import { get, pick, forEach, intersection } from 'lodash';
+import { get, forEach, intersection } from 'lodash';
 
 /**
  * Internal dependencies
@@ -18,11 +18,10 @@ import config from 'config';
 import sanitize from 'sanitize';
 import utils from 'bundler/utils';
 import sectionsModule from '../../client/sections';
-import { serverRouter, getCacheKey } from 'isomorphic-routing';
+import { serverRouter } from 'isomorphic-routing';
 import { serverRender, serverRenderError } from 'render';
-import stateCache from 'state-cache';
-import { createReduxStore, reducer } from 'state';
-import { DESERIALIZE, LOCALE_SET } from 'state/action-types';
+import { createReduxStore } from 'state';
+import { LOCALE_SET } from 'state/action-types';
 import { login } from 'lib/paths';
 import { logSectionResponseTime } from './analytics';
 
@@ -57,13 +56,6 @@ const prideLanguages = [];
 const prideLocations = [];
 
 const sections = sectionsModule.get();
-
-// TODO: Re-use (a modified version of) client/state/initial-state#getInitialServerState here
-function getInitialServerState( serializedServerState ) {
-	// Bootstrapped state from a server-render
-	const serverState = reducer( serializedServerState, { type: DESERIALIZE } );
-	return pick( serverState, Object.keys( serializedServerState ) );
-}
 
 const ASSETS_PATH = path.join( __dirname, '../', 'bundler', 'assets.json' );
 const getAssets = ( () => {
@@ -141,17 +133,10 @@ function getAcceptedLanguagesFromHeader( header ) {
 }
 
 function getDefaultContext( request ) {
-	let initialServerState = {};
 	const bodyClasses = [];
-	const cacheKey = getCacheKey( request );
 	const geoLocation = ( request.headers[ 'x-geoip-country-code' ] || '' ).toLowerCase();
 	const isDebug = calypsoEnv === 'development' || request.query.debug !== undefined;
 	let sectionCss;
-
-	if ( cacheKey ) {
-		const serializeCachedServerState = stateCache.get( cacheKey ) || {};
-		initialServerState = getInitialServerState( serializeCachedServerState );
-	}
 
 	// Note: The x-geoip-country-code header should *not* be considered 100% accurate.
 	// It should only be used for guestimating the visitor's location.
@@ -190,7 +175,7 @@ function getDefaultContext( request ) {
 		isFluidWidth: !! config.isEnabled( 'fluid-width' ),
 		abTestHelper: !! config.isEnabled( 'dev/test-helper' ),
 		devDocsURL: '/devdocs',
-		store: createReduxStore( initialServerState ),
+		store: createReduxStore( {} ),
 		shouldUsePreconnect: config.isEnabled( 'try/preconnect' ) && !! request.query.enablePreconnect,
 		shouldUsePreconnectGoogle:
 			config.isEnabled( 'try/preconnect' ) && !! request.query.enablePreconnectGoogle,

--- a/server/render/index.js
+++ b/server/render/index.js
@@ -6,8 +6,9 @@
 import ReactDomServer from 'react-dom/server';
 import superagent from 'superagent';
 import Lru from 'lru';
-import { pick } from 'lodash';
+import { isEmpty, pick } from 'lodash';
 import debugFactory from 'debug';
+import qs from 'qs';
 
 /**
  * Internal dependencies
@@ -22,10 +23,9 @@ import {
 } from 'state/document-head/selectors';
 import isRTL from 'state/selectors/is-rtl';
 import getCurrentLocaleSlug from 'state/selectors/get-current-locale-slug';
-import { reducer } from 'state';
-import { SERIALIZE } from 'state/action-types';
+import { createReduxStore, reducer } from 'state';
+import { SERIALIZE, DESERIALIZE } from 'state/action-types';
 import stateCache from 'state-cache';
-import { getCacheKey } from 'isomorphic-routing';
 
 const debug = debugFactory( 'calypso:server-render' );
 const HOUR_IN_MS = 3600000;
@@ -42,25 +42,70 @@ function bumpStat( group, name ) {
 	}
 }
 
+export function getCacheKey( context ) {
+	const pathname = context.pathname;
+	const isIsomorphic = isSectionIsomorphic( context.store.getState() );
+
+	if ( ! isIsomorphic ) {
+		return JSON.stringify( context.layout );
+	}
+
+	if ( isEmpty( context.query ) || isEmpty( context.cacheQueryKeys ) ) {
+		return pathname;
+	}
+
+	const cachedQueryParams = pick( context.query, context.cacheQueryKeys );
+
+	if ( isEmpty( cachedQueryParams ) ) {
+		return pathname;
+	}
+
+	return (
+		pathname + '?' + qs.stringify( cachedQueryParams, { sort: ( a, b ) => a.localeCompare( b ) } )
+	);
+}
+
 /**
 * Render and cache supplied React element to a markup string.
 * Cache is keyed by stringified element by default.
 *
-* @param {object} element - React element to be rendered to html
+* @param {object} context - React element to be rendered to html
 * @param {string} key - (optional) custom key
-* @return {string} The rendered Layout
 */
-export function render( element, key = JSON.stringify( element ) ) {
+export function renderLayout( context ) {
 	try {
 		const startTime = Date.now();
+		const isIsomorphic = isSectionIsomorphic( context.store.getState() );
+		const key = getCacheKey( context );
+
 		debug( 'cache access for key', key );
 
 		let renderedLayout = markupCache.get( key );
 		if ( ! renderedLayout ) {
 			bumpStat( 'calypso-ssr', 'loggedout-design-cache-miss' );
 			debug( 'cache miss for key', key );
-			renderedLayout = ReactDomServer.renderToString( element );
+			renderedLayout = ReactDomServer.renderToString( context.layout );
 			markupCache.set( key, renderedLayout );
+
+			// save the state of the store with the same key as the layout
+			if ( context.store ) {
+				let reduxSubtrees = [ 'documentHead' ];
+
+				if ( isIsomorphic ) {
+					reduxSubtrees = reduxSubtrees.concat( [ 'ui', 'themes' ] );
+				}
+
+				// Send state to client
+				context.initialReduxState = pick( context.store.getState(), reduxSubtrees );
+				const serverState = reducer( context.initialReduxState, { type: SERIALIZE } );
+				stateCache.set( key, serverState );
+			}
+		} else {
+			const serializedServerState = stateCache.get( key );
+			if ( serializedServerState ) {
+				context.initialReduxState = reducer( serializedServerState, { type: DESERIALIZE } );
+				context.store = createReduxStore( context.initialReduxState );
+			}
 		}
 		const rtsTimeMs = Date.now() - startTime;
 		debug( 'Server render time (ms)', rtsTimeMs );
@@ -70,25 +115,16 @@ export function render( element, key = JSON.stringify( element ) ) {
 			bumpStat( 'calypso-ssr', 'over-100ms-rendertostring' );
 		}
 
-		return renderedLayout;
+		context.renderedLayout = renderedLayout;
 	} catch ( ex ) {
 		if ( config( 'env' ) === 'development' ) {
 			throw ex;
 		}
 	}
-	//todo: render an error?
 }
 
 export function serverRender( req, res ) {
 	const context = req.context;
-	let title,
-		metas = [],
-		links = [],
-		cacheKey = false;
-
-	if ( isSectionIsomorphic( context.store.getState() ) && ! context.user ) {
-		cacheKey = getCacheKey( context );
-	}
 
 	if ( ! isDefaultLocale( context.lang ) ) {
 		context.i18nLocaleScript = '//widgets.wp.com/languages/calypso/' + context.lang + '.js';
@@ -98,39 +134,17 @@ export function serverRender( req, res ) {
 		config.isEnabled( 'server-side-rendering' ) &&
 		context.layout &&
 		! context.user &&
-		cacheKey &&
 		isDefaultLocale( context.lang )
 	) {
-		context.renderedLayout = render( context.layout, req.error ? req.error.message : cacheKey );
+		renderLayout( context );
 	}
 
-	if ( context.store ) {
-		title = getDocumentHeadFormattedTitle( context.store.getState() );
-		metas = getDocumentHeadMeta( context.store.getState() );
-		links = getDocumentHeadLink( context.store.getState() );
+	const title = getDocumentHeadFormattedTitle( context.store.getState() );
+	const metas = getDocumentHeadMeta( context.store.getState() );
+	const links = getDocumentHeadLink( context.store.getState() );
 
-		const cacheableReduxSubtrees = [ 'documentHead' ];
-		let reduxSubtrees;
-
-		if ( isSectionIsomorphic( context.store.getState() ) ) {
-			reduxSubtrees = cacheableReduxSubtrees.concat( [ 'ui', 'themes' ] );
-		} else {
-			reduxSubtrees = cacheableReduxSubtrees;
-		}
-
-		// Send state to client
-		context.initialReduxState = pick( context.store.getState(), reduxSubtrees );
-
-		// And cache on the server, too.
-		if ( cacheKey ) {
-			const cacheableInitialState = pick( context.store.getState(), cacheableReduxSubtrees );
-			const serverState = reducer( cacheableInitialState, { type: SERIALIZE } );
-			stateCache.set( cacheKey, serverState );
-		}
-
-		context.isRTL = isRTL( context.store.getState() );
-		context.lang = getCurrentLocaleSlug( context.store.getState() );
-	}
+	context.isRTL = isRTL( context.store.getState() );
+	context.lang = getCurrentLocaleSlug( context.store.getState() );
 
 	context.head = { title, metas, links };
 	context.config = config.ssrConfig;
@@ -150,6 +164,16 @@ export function serverRenderError( err, req, res, next ) {
 		req.error = err;
 		res.status( err.status || 500 );
 		res.render( '500', req.context );
+		return;
+	}
+
+	next();
+}
+
+export function serverRenderIfCached( req, res, next ) {
+	const context = req.context;
+	if ( markupCache.get( getCacheKey( context ) ) ) {
+		serverRender( req, res );
 		return;
 	}
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/18919

https://github.com/Automattic/wp-calypso/pull/17134 introduced a new bug because of `setRouteMiddleware` called for isomorphic sections. It would dispatch a `ROUTE_SET` action which would reset the page title and meta as defined in the reducer https://github.com/Automattic/wp-calypso/blob/6ec964c85d93bdc7f63400e573a7df6babd64e51/client/state/document-head/reducer.js#L26

While investigating a fix, I noticed another [problem with the `cacheQueryKeys`](https://github.com/Automattic/wp-calypso/pull/19036#issuecomment-341728386) feature. 

In order to fix both issues, the solution adopted in this PR is simple, refactor the caching part of the state so we:
- always start with an empty state when creating the initial context
- cache the state only after a page is rendered with SSR (we don't need to cache the state in other cases)
- retrieve the state and the rendered page at the same time (and overwrite the existing store).

This approach has a pros:
- It's cleaner to always start with an empty state and it makes reasoning with SSR simpler
- It fixes our issue with `ROUTE_SET` and any potential action dispatched on a pre-rendered route that would modify the state.
- It fixes the `context.cacheQueryKeys` feature as it will always be defined when `context.layout` is set.

And cons:
- middlewares that bind the store (`context.store.subscribe`) will cease to work after we replace `context.store`. It's not a problem currently as rendering is the last middleware in the stack and there shouldn't be any code that listen for changes in the state on the server.

### Testing Instructions

You should execute the following `curl` commands **at least two times** in order to check the behavior when the cache is empty (first page load), and filled (subsequent page loads):

1. Run `git checkout fix/ssr-head` and start your server
2. Assert that the English `Login` page has the right title:
```
curl -s http://calypso.localhost:3000/log-in | grep -o '<title>[^<]*</title>'
<title>Log In — WordPress.com</title>
```
3. Assert that non-English `Login` pages have a default title:
```
curl -s http://calypso.localhost:3000/log-in/fr | grep -o '<title>[^<]*</title>'
<title>WordPress.com</title>
```
4. Assert that the English `Login` page has a `canonical` tag:
```
curl -s http://calypso.localhost:3000/log-in | grep -o '<link rel="canonical"[^>]*>'
<link rel="canonical" href="https://wordpress.com/login">
```
5. Assert that non-English `Login` pages don't have this tag:
```
curl -s http://calypso.localhost:3000/log-in/he | grep -o '<link rel="canonical"[^>]*>'
```
6. Assert that the WooCommerce `Login` page has the right title:
```
curl -s "http://calypso.localhost:3000/log-in?client_id=50916&redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fresponse_type%3Dcode%26client_id%3D50916%26state%3Dce55c88fc2fc12dadf7c12874e4178ab%26redirect_uri%3Dhttps%253A%252F%252Fwoocommerce.com%252Fwc-api%252Fwpcom-signin%253Fnext%253Dmy-dashboard%26blog_id%3D0%26wpcom_connect%3D1" | grep -o '<title>[^<]*</title>'
<title>Log In — WordPress.com</title>
```
And that it contains the WooCommerce logo:
```
curl -s "http://calypso.localhost:3000/log-in?client_id=50916&redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fresponse_type%3Dcode%26client_id%3D50916%26state%3Dce55c88fc2fc12dadf7c12874e4178ab%26redirect_uri%3Dhttps%253A%252F%252Fwoocommerce.com%252Fwc-api%252Fwpcom-signin%253Fnext%253Dmy-dashboard%26blog_id%3D0%26wpcom_connect%3D1" | grep -o '<img[^>]*logo-woocommerce@2x.png'
<img src="https://woocommerce.com/wp-content/themes/woo/images/logo-woocommerce@2x.png
```

### Reviews
- [x] Code
- [x] Product
