### PR TITLE
Clean Happychat components

### DIFF
--- a/client/components/happychat/composer.jsx
+++ b/client/components/happychat/composer.jsx
@@ -1,12 +1,15 @@
 /** @format */
+
 /**
  * External dependencies
  */
 import classNames from 'classnames';
 import React from 'react';
 import createReactClass from 'create-react-class';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { isEmpty } from 'lodash';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -17,7 +20,6 @@ import getCurrentMessage from 'state/happychat/selectors/get-happychat-current-m
 import { canUserSendMessages } from 'state/happychat/selectors';
 import { when, forEach, compose, propEquals, call, prop } from './functional';
 import scrollbleed from './scrollbleed';
-import { translate } from 'i18n-calypso';
 
 // helper function for detecting when a DOM event keycode is pressed
 const returnPressed = propEquals( 'which', 13 );
@@ -31,8 +33,24 @@ export const Composer = createReactClass( {
 	displayName: 'Composer',
 	mixins: [ scrollbleed ],
 
+	propTypes: {
+		disabled: PropTypes.bool,
+		message: PropTypes.string,
+		onFocus: PropTypes.func,
+		onSendChatMessage: PropTypes.func,
+		onUpdateChatMessage: PropTypes.func,
+		translate: PropTypes.func, // localize HOC
+	},
+
 	render() {
-		const { disabled, message, onUpdateChatMessage, onSendChatMessage, onFocus } = this.props;
+		const {
+			disabled,
+			message,
+			onFocus,
+			onSendChatMessage,
+			onUpdateChatMessage,
+			translate,
+		} = this.props;
 		const sendMessage = when( () => ! isEmpty( message ), () => onSendChatMessage( message ) );
 		const onChange = compose( prop( 'target.value' ), onUpdateChatMessage );
 		const onKeyDown = when( returnPressed, forEach( preventDefault, sendMessage ) );
@@ -82,4 +100,4 @@ const mapDispatch = dispatch => ( {
 	},
 } );
 
-export default connect( mapState, mapDispatch )( Composer );
+export default connect( mapState, mapDispatch )( localize( Composer ) );

--- a/client/components/happychat/connection.jsx
+++ b/client/components/happychat/connection.jsx
@@ -1,10 +1,10 @@
+/** @format */
+
 /**
  * External dependencies
- *
- * @format
  */
-
 import { Component } from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
 /**
@@ -14,9 +14,9 @@ import config from 'config';
 import { connectChat } from 'state/happychat/connection/actions';
 import isHappychatConnectionUninitialized from 'state/happychat/selectors/is-happychat-connection-uninitialized';
 
-class HappychatConnection extends Component {
+export class HappychatConnection extends Component {
 	componentDidMount() {
-		if ( config.isEnabled( 'happychat' ) && this.props.isUninitialized ) {
+		if ( this.props.isEnabled && this.props.isUninitialized ) {
 			this.props.connectChat();
 		}
 	}
@@ -26,8 +26,15 @@ class HappychatConnection extends Component {
 	}
 }
 
+HappychatConnection.propTypes = {
+	isEnabled: PropTypes.bool,
+	isUninitialized: PropTypes.bool,
+	connectChat: PropTypes.func,
+};
+
 export default connect(
 	state => ( {
+		isEnabled: config.isEnabled( 'happychat' ),
 		isUninitialized: isHappychatConnectionUninitialized( state ),
 	} ),
 	{ connectChat }

--- a/client/components/happychat/index.jsx
+++ b/client/components/happychat/index.jsx
@@ -1,50 +1,29 @@
+/** @format */
+
 /**
  * External dependencies
- *
- * @format
  */
-
 import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import classnames from 'classnames';
-import GridIcon from 'gridicons';
 
 /**
  * Internal dependencies
  */
-import { localize } from 'i18n-calypso';
-import getHappychatConnectionStatus from 'state/happychat/selectors/get-happychat-connection-status';
-import {
-	blur,
-	focus,
-	openChat,
-	closeChat,
-	minimizeChat,
-	minimizedChat,
-} from 'state/happychat/ui/actions';
+import { blur, focus, closeChat, minimizeChat, minimizedChat } from 'state/happychat/ui/actions';
 import isHappychatMinimizing from 'state/happychat/selectors/is-happychat-minimizing';
 import isHappychatOpen from 'state/happychat/selectors/is-happychat-open';
 import HappychatConnection from './connection';
+import Title from './title';
 import Composer from './composer';
 import Notices from './notices';
 import Timeline from './timeline';
 
-/**
- * React component for rendering title bar
- */
-const Title = localize( ( { onCloseChat, translate } ) => (
-	<div className="happychat__active-toolbar">
-		<h4>{ translate( 'Support Chat' ) }</h4>
-		<div onClick={ onCloseChat }>
-			<GridIcon icon="cross" />
-		</div>
-	</div>
-) );
-
 /*
  * Main chat UI component
  */
-class Happychat extends React.Component {
+export class Happychat extends React.Component {
 	componentDidMount() {
 		this.props.setFocused();
 	}
@@ -54,7 +33,15 @@ class Happychat extends React.Component {
 	}
 
 	render() {
-		const { isChatOpen, isMinimizing, onCloseChat } = this.props;
+		const { isChatOpen, isMinimizing, onCloseChat, onMinimizeChat, onMinimizedChat } = this.props;
+
+		const onCloseChatTitle = () => {
+			onMinimizeChat();
+			setTimeout( () => {
+				onMinimizedChat();
+				onCloseChat();
+			}, 500 );
+		};
 
 		return (
 			<div className="happychat">
@@ -65,9 +52,7 @@ class Happychat extends React.Component {
 						'is-minimizing': isMinimizing,
 					} ) }
 				>
-					<div className="happychat__title">
-						<Title onCloseChat={ onCloseChat } />
-					</div>
+					<Title onCloseChat={ onCloseChatTitle } />
 					<Timeline />
 					<Notices />
 					<Composer />
@@ -77,9 +62,18 @@ class Happychat extends React.Component {
 	}
 }
 
+Happychat.propTypes = {
+	isChatOpen: PropTypes.bool,
+	isMinimizing: PropTypes.bool,
+	onCloseChat: PropTypes.func,
+	onMinimizeChat: PropTypes.func,
+	onMinimizedChat: PropTypes.func,
+	setBlurred: PropTypes.func,
+	setFocused: PropTypes.func,
+};
+
 const mapState = state => {
 	return {
-		connectionStatus: getHappychatConnectionStatus( state ),
 		isChatOpen: isHappychatOpen( state ),
 		isMinimizing: isHappychatMinimizing( state ),
 	};
@@ -87,15 +81,14 @@ const mapState = state => {
 
 const mapDispatch = dispatch => {
 	return {
-		onOpenChat() {
-			dispatch( openChat() );
-		},
 		onCloseChat() {
+			dispatch( closeChat() );
+		},
+		onMinimizeChat() {
 			dispatch( minimizeChat() );
-			setTimeout( function() {
-				dispatch( minimizedChat() );
-				dispatch( closeChat() );
-			}, 500 );
+		},
+		onMinimizedChat() {
+			dispatch( minimizedChat() );
 		},
 		setBlurred() {
 			dispatch( blur() );

--- a/client/components/happychat/index.jsx
+++ b/client/components/happychat/index.jsx
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import classnames from 'classnames';
@@ -23,12 +23,7 @@ import Timeline from './timeline';
 /*
  * Main chat UI component
  */
-export class Happychat extends React.Component {
-	constructor( props ) {
-		super( props );
-		this.onCloseChatTitle = this.onCloseChatTitle.bind( this );
-	}
-
+export class Happychat extends Component {
 	componentDidMount() {
 		this.props.setFocused();
 	}
@@ -37,14 +32,15 @@ export class Happychat extends React.Component {
 		this.props.setBlurred();
 	}
 
-	onCloseChatTitle() {
+	// transform-class-properties syntax so this is bound within the function
+	onCloseChatTitle = () => {
 		const { onMinimizeChat, onMinimizedChat, onCloseChat } = this.props;
 		onMinimizeChat();
 		setTimeout( () => {
 			onMinimizedChat();
 			onCloseChat();
 		}, 500 );
-	}
+	};
 
 	render() {
 		const { isChatOpen, isMinimizing } = this.props;

--- a/client/components/happychat/index.jsx
+++ b/client/components/happychat/index.jsx
@@ -32,16 +32,17 @@ export class Happychat extends React.Component {
 		this.props.setBlurred();
 	}
 
-	render() {
-		const { isChatOpen, isMinimizing, onCloseChat, onMinimizeChat, onMinimizedChat } = this.props;
+	onCloseChatTitle() {
+		const { onMinimizeChat, onMinimizedChat, onCloseChat } = this.props;
+		onMinimizeChat();
+		setTimeout( () => {
+			onMinimizedChat();
+			onCloseChat();
+		}, 500 );
+	}
 
-		const onCloseChatTitle = () => {
-			onMinimizeChat();
-			setTimeout( () => {
-				onMinimizedChat();
-				onCloseChat();
-			}, 500 );
-		};
+	render() {
+		const { isChatOpen, isMinimizing } = this.props;
 
 		return (
 			<div className="happychat">
@@ -52,7 +53,7 @@ export class Happychat extends React.Component {
 						'is-minimizing': isMinimizing,
 					} ) }
 				>
-					<Title onCloseChat={ onCloseChatTitle } />
+					<Title onCloseChat={ this.onCloseChatTitle } />
 					<Timeline />
 					<Notices />
 					<Composer />

--- a/client/components/happychat/index.jsx
+++ b/client/components/happychat/index.jsx
@@ -24,6 +24,11 @@ import Timeline from './timeline';
  * Main chat UI component
  */
 export class Happychat extends React.Component {
+	constructor( props ) {
+		super( props );
+		this.onCloseChatTitle = this.onCloseChatTitle.bind( this );
+	}
+
 	componentDidMount() {
 		this.props.setFocused();
 	}

--- a/client/components/happychat/notices.jsx
+++ b/client/components/happychat/notices.jsx
@@ -25,7 +25,7 @@ import isHappychatServerReachable from 'state/happychat/selectors/is-happychat-s
 /*
  * Renders any notices about the chat session to the user
  */
-class Notices extends Component {
+export class Notices extends Component {
 	statusNotice() {
 		const { isServerReachable, connectionStatus, chatStatus, translate } = this.props;
 

--- a/client/components/happychat/timeline.jsx
+++ b/client/components/happychat/timeline.jsx
@@ -1,12 +1,15 @@
 /** @format */
+
 /**
  * External dependencies
  */
 import React from 'react';
 import createReactClass from 'create-react-class';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { assign, isArray, isEmpty } from 'lodash';
 import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -15,9 +18,7 @@ import { first, when, forEach } from './functional';
 import autoscroll from './autoscroll';
 import Emojify from 'components/emojify';
 import scrollbleed from './scrollbleed';
-import { translate } from 'i18n-calypso';
 import { getCurrentUser } from 'state/current-user/selectors';
-import getHappychatConnectionStatus from 'state/happychat/selectors/get-happychat-connection-status';
 import getHappychatTimeline from 'state/happychat/selectors/get-happychat-timeline';
 import { isExternal, addSchemeIfMissing, setUrlScheme } from 'lib/url';
 
@@ -147,7 +148,7 @@ const groupMessages = messages => {
 	return grouped.groups.concat( [ grouped.group ] );
 };
 
-const welcomeMessage = ( { currentUserEmail } ) => (
+const welcomeMessage = ( { currentUserEmail, translate } ) => (
 	<div className="happychat__welcome">
 		<p>
 			{ translate(
@@ -190,6 +191,14 @@ export const Timeline = createReactClass( {
 	displayName: 'Timeline',
 	mixins: [ autoscroll, scrollbleed ],
 
+	propTypes: {
+		currentUserEmail: PropTypes.string,
+		isCurrentUser: PropTypes.func,
+		onScrollContainer: PropTypes.func,
+		timeline: PropTypes.array,
+		translate: PropTypes.func,
+	},
+
 	getDefaultProps() {
 		return {
 			onScrollContainer: () => {},
@@ -215,7 +224,6 @@ export const Timeline = createReactClass( {
 const mapProps = state => {
 	const current_user = getCurrentUser( state );
 	return {
-		connectionStatus: getHappychatConnectionStatus( state ),
 		timeline: getHappychatTimeline( state ),
 		isCurrentUser: ( { user_id, source } ) => {
 			return user_id.toString() === current_user.ID.toString() && source === 'customer';
@@ -224,4 +232,4 @@ const mapProps = state => {
 	};
 };
 
-export default connect( mapProps )( Timeline );
+export default connect( mapProps )( localize( Timeline ) );

--- a/client/components/happychat/title.jsx
+++ b/client/components/happychat/title.jsx
@@ -1,0 +1,24 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import GridIcon from 'gridicons';
+import { localize } from 'i18n-calypso';
+
+/*
+ * React component for rendering title bar
+ */
+export const Title = ( { onCloseChat, translate } ) => (
+	<div className="happychat__title">
+		<div className="happychat__active-toolbar">
+			<h4>{ translate( 'Support Chat' ) }</h4>
+			<div onClick={ onCloseChat }>
+				<GridIcon icon="cross" />
+			</div>
+		</div>
+	</div>
+);
+
+export default localize( Title );

--- a/client/me/happychat/main.jsx
+++ b/client/me/happychat/main.jsx
@@ -1,17 +1,16 @@
+/** @format */
+
 /**
  * External dependencies
- *
- * @format
  */
-
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { findDOMNode } from 'react-dom';
+
 /**
  * Internal dependencies
  */
 import { blur, focus } from 'state/happychat/ui/actions';
-import viewport from 'lib/viewport';
 import HappychatConnection from 'components/happychat/connection';
 import Composer from 'components/happychat/composer';
 import Notices from 'components/happychat/notices';
@@ -20,23 +19,13 @@ import Timeline from 'components/happychat/timeline';
 /**
  * React component for rendering a happychat client as a full page
  */
-class HappychatPage extends Component {
+export class HappychatPage extends Component {
 	componentDidMount() {
 		this.props.setFocused();
 	}
 
 	componentWillUnmount() {
 		this.props.setBlurred();
-	}
-
-	onFocus() {
-		// TODO: Is this function ever called? I can't seem to get it to trigger --mattwondra
-		const composerNode = findDOMNode( this.refs.composer );
-
-		if ( viewport.isMobile() ) {
-			/* User tapped textfield on a phone. This shows the keyboard. Unless we scroll to the bottom, the chatbox will be invisible */
-			setTimeout( () => composerNode.scrollIntoView(), 500 ); /* Wait for the keyboard to appear */
-		}
 	}
 
 	render() {
@@ -50,6 +39,11 @@ class HappychatPage extends Component {
 		);
 	}
 }
+
+HappychatPage.propTypes = {
+	setBlurred: PropTypes.func,
+	setFocused: PropTypes.func,
+};
 
 const mapDispatch = {
 	setBlurred: blur,


### PR DESCRIPTION
Master issue: https://github.com/Automattic/wp-calypso/issues/18670

Just a warm-up PR for the upcoming work on components: converts to prop everything the components use (so no direct use of `config` or `translate` functions), adds `propTypes`, and removes unused code.