### PR TITLE
Jetpack: Send user to wp-admin after buying a plan

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/jetpack-thank-you-card.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/jetpack-thank-you-card.jsx
@@ -32,6 +32,7 @@ import HappyChatButton from 'components/happychat/button';
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 import {
 	getRawSite,
+	getSiteAdminUrl,
 	isJetpackSite,
 	isJetpackSiteMainNetworkSite,
 	isJetpackSiteMultiSite,
@@ -540,8 +541,8 @@ class JetpackThankYouCard extends Component {
 	}
 
 	renderAction( progress = 0 ) {
-		const { selectedSite: site, translate } = this.props;
-		const buttonUrl = site && site.URL;
+		const { jetpackAdminPageUrl, selectedSite: site, translate } = this.props;
+		const buttonUrl = site && jetpackAdminPageUrl;
 		// We return instructions for setting up manually
 		// when we finish if something errored
 		if ( this.isErrored() && ! this.props.isInstalling ) {
@@ -661,6 +662,7 @@ export default connect(
 			selectedSite: selectedSite,
 			isRequestingSites: isRequestingSites( state ),
 			siteId,
+			jetpackAdminPageUrl: getSiteAdminUrl( state, siteId, 'admin.php?page=jetpack' ),
 			planFeatures,
 			planClass,
 			planSlug,


### PR DESCRIPTION
Fixes #18970.

#### Changes introduced by this PR

Makes the link in the **Visit your site** button take the users to the Jetpack Admin Page in their site.

#### Testing instructions.

1. Upgrade a site to a paid plan.
1. Wait for autoconfig to finish
1. Expect the **Visit your site** link to take you to your site's Admin Page for Jetpack.

![linkadmin](https://user-images.githubusercontent.com/746152/31823942-0e71786c-b584-11e7-83b3-6eac08d65bc5.gif)
