### PR TITLE
Jetpack: Send user to wp-admin after buying a plan

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/jetpack-thank-you-card.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/jetpack-thank-you-card.jsx
@@ -541,7 +541,7 @@ class JetpackThankYouCard extends Component {
 
 	renderAction( progress = 0 ) {
 		const { selectedSite: site, translate } = this.props;
-		const buttonUrl = site && site.URL;
+		const buttonUrl = site ? site.URL + '/wp-admin' : false;
 		// We return instructions for setting up manually
 		// when we finish if something errored
 		if ( this.isErrored() && ! this.props.isInstalling ) {


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/18970

![image](https://user-images.githubusercontent.com/1554855/31824350-0ea999ce-b5af-11e7-804d-fb24034c9486.png)


Really dumb PR that sends users to their wp-admin instead of their front-end when they finish the autosetup config of a jetpack plan

how to test
==========

0. Go to https://calypso.live/plans?branch=fix/jetpack-wp-admin and select one or your jetpack sites
1. Purchase an upgrade
2. Once the autosetup process ends, click on "visit your site"
3. You should be taken to your wp-admin