### PR TITLE
Editor: Revisions: Auto-open the sidebar when clicking "History"

### DIFF
--- a/client/post-editor/editor-ground-control/history-button.jsx
+++ b/client/post-editor/editor-ground-control/history-button.jsx
@@ -3,6 +3,7 @@
  * External dependencies
  */
 import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -11,34 +12,33 @@ import { localize } from 'i18n-calypso';
 import {
 	NESTED_SIDEBAR_NONE,
 	NESTED_SIDEBAR_REVISIONS,
+	NestedSidebarPropType,
 } from 'post-editor/editor-sidebar/constants';
 
 class HistoryButton extends PureComponent {
-	state = {
-		showingHistory: false,
-	};
-
 	toggleShowing = () => {
-		this.setState( {
-			showingHistory: ! this.state.showingHistory,
-		} );
-	};
+		const {
+			isSidebarOpened,
+			nestedSidebar,
+			selectRevision,
+			setNestedSidebar,
+			toggleSidebar,
+		} = this.props;
 
-	componentWillUpdate( nextProps, nextState ) {
-		if ( nextState.showingHistory === this.state.showingHistory ) {
+		// hide revisions if visible
+		if ( nestedSidebar === NESTED_SIDEBAR_REVISIONS ) {
+			setNestedSidebar( NESTED_SIDEBAR_NONE );
 			return;
 		}
-
-		const { selectRevision, setNestedSidebar } = this.props;
 
 		selectRevision( null );
+		setNestedSidebar( NESTED_SIDEBAR_REVISIONS );
 
-		if ( nextState.showingHistory ) {
-			setNestedSidebar( NESTED_SIDEBAR_REVISIONS );
-			return;
+		// open the sidebar when closed
+		if ( ! isSidebarOpened ) {
+			toggleSidebar();
 		}
-		setNestedSidebar( NESTED_SIDEBAR_NONE );
-	}
+	};
 
 	render() {
 		return (
@@ -53,5 +53,14 @@ class HistoryButton extends PureComponent {
 		);
 	}
 }
+
+HistoryButton.PropTypes = {
+	isSidebarOpened: PropTypes.bool,
+	nestedSidebar: NestedSidebarPropType,
+	selectRevision: PropTypes.func,
+	setNestedSidebar: PropTypes.func,
+	toggleSidebar: PropTypes.func,
+	translate: PropTypes.func,
+};
 
 export default localize( HistoryButton );

--- a/client/post-editor/editor-ground-control/index.jsx
+++ b/client/post-editor/editor-ground-control/index.jsx
@@ -37,6 +37,7 @@ export class EditorGroundControl extends PureComponent {
 		isSaveBlocked: PropTypes.bool,
 		isPublishing: PropTypes.bool,
 		isSaving: PropTypes.bool,
+		isSidebarOpened: PropTypes.bool,
 		nestedSidebar: NestedSidebarPropType,
 		moment: PropTypes.func,
 		onPreview: PropTypes.func,
@@ -324,6 +325,9 @@ export class EditorGroundControl extends PureComponent {
 					<HistoryButton
 						selectRevision={ this.props.selectRevision }
 						setNestedSidebar={ this.props.setNestedSidebar }
+						toggleSidebar={ this.props.toggleSidebar }
+						isSidebarOpened={ this.props.isSidebarOpened }
+						nestedSidebar={ this.props.nestedSidebar }
 					/>
 				) }
 				{ this.renderGroundControlActionButtons() }

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -365,6 +365,7 @@ export const PostEditor = React.createClass( {
 						nestedSidebar={ this.state.nestedSidebar }
 						setNestedSidebar={ this.setNestedSidebar }
 						selectRevision={ this.selectRevision }
+						isSidebarOpened={ this.props.layoutFocus === 'sidebar' }
 					/>
 					<div className="post-editor__content">
 						<div className="post-editor__content-editor">


### PR DESCRIPTION
Previously, clicking "History" in editor ground controls only showed revisions inside the sidebar, but it didn't check if the sidebar is in fact opened. This PR adds that together with state deduplication and some bonus `PropTypes`.

To test:

- open a post with revisions in the editor (or make a new one)
- close sidebar
- click "History" in ground controls
- make sure sidebar opened and you see revisions
- close revisions but keep the sidebar opened
- click "History" again
- make sure sidebar is still opened and you see revisions

Possible enhancement:

If the sidebar was auto-opened by clicking "History", it would not close on subsequent click on the same button — it will just deactivate revisions and show the general sidebar content. The enhancement would be to also close the sidebar.