### PR TITLE
Store Orders: Use the order's currency, rather than falling back to USD

### DIFF
--- a/client/extensions/woocommerce/app/order/order-payment/dialog.js
+++ b/client/extensions/woocommerce/app/order/order-payment/dialog.js
@@ -148,7 +148,7 @@ class RefundDialog extends Component {
 		const { order, paymentMethod, siteId, translate } = this.props;
 		// Refund total is negative, so this effectively subtracts the refund from total.
 		const maxRefund = parseFloat( order.total ) + getOrderRefundTotal( order );
-		const thisRefund = getCurrencyFormatDecimal( this.state.refundTotal );
+		const thisRefund = getCurrencyFormatDecimal( this.state.refundTotal, order.currency );
 		if ( thisRefund > maxRefund ) {
 			this.setState( {
 				errorMessage: translate(

--- a/client/extensions/woocommerce/app/order/order-payment/table.js
+++ b/client/extensions/woocommerce/app/order/order-payment/table.js
@@ -5,7 +5,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import { get, set } from 'lodash';
+import { clone, get, setWith } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -43,17 +43,18 @@ class OrderRefundTable extends Component {
 
 	constructor( props ) {
 		super( props );
-		const shippingTax = getOrderShippingTax( props.order );
-		const shippingTotal = parseFloat( shippingTax ) + parseFloat( props.order.shipping_total );
+		const { order } = props;
+		const shippingTax = getOrderShippingTax( order );
+		const shippingTotal = parseFloat( shippingTax ) + parseFloat( order.shipping_total );
 
 		this.state = {
 			quantities: {},
 			fees: props.order.fee_lines.map( item => {
 				const value =
 					parseFloat( item.total ) + parseFloat( getOrderFeeTax( props.order, item.id ) );
-				return getCurrencyFormatDecimal( value );
+				return getCurrencyFormatDecimal( value, order.currency );
 			} ),
-			shippingTotal: getCurrencyFormatDecimal( shippingTotal ),
+			shippingTotal: getCurrencyFormatDecimal( shippingTotal, order.currency ),
 		};
 	}
 
@@ -71,12 +72,12 @@ class OrderRefundTable extends Component {
 	};
 
 	formatInput = name => {
+		const { order } = this.props;
 		return () => {
 			this.setState( prevState => {
-				const newState = Object.assign(
-					{},
-					set( prevState, name, getCurrencyFormatDecimal( get( prevState, name ) ) )
-				);
+				const newValue = getCurrencyFormatDecimal( get( prevState, name ), order.currency );
+				// Update the new value in state without mutations https://github.com/lodash/lodash/issues/1696#issuecomment-328335502
+				const newState = setWith( clone( prevState ), name, newValue, clone );
 				return newState;
 			} );
 		};

--- a/client/extensions/woocommerce/app/order/order-payment/table.js
+++ b/client/extensions/woocommerce/app/order/order-payment/table.js
@@ -43,6 +43,16 @@ class OrderRefundTable extends Component {
 
 	constructor( props ) {
 		super( props );
+		this.initializeState( props );
+	}
+
+	componentWillReceiveProps( nextProps ) {
+		if ( nextProps.order.id !== this.props.order.id ) {
+			this.initializeState( nextProps );
+		}
+	}
+
+	initializeState = props => {
 		const { order } = props;
 		const shippingTax = getOrderShippingTax( order );
 		const shippingTotal = parseFloat( shippingTax ) + parseFloat( order.shipping_total );
@@ -56,7 +66,7 @@ class OrderRefundTable extends Component {
 			} ),
 			shippingTotal: getCurrencyFormatDecimal( shippingTotal, order.currency ),
 		};
-	}
+	};
 
 	shouldShowTax = () => {
 		const { order } = this.props;


### PR DESCRIPTION
In #18826 we added `getCurrencyFormatDecimal `, which rounds a number to the precision used in the given currency. When it was used in the refunds modal, though, the currency was not being passed through. This PR adds the currency to each call, so that we're not defaulting to USD always.

**To test**

- Open the modal to refund an order which was placed in USD
- In the shipping input, enter a number with more than 2 decimal places, ex `4.2456` 
- When you click/tab away the field should update to a whole-cent value
- Change your site settings to a currency with no decimals, ex JPY, and place an order
- View the order, open the refund modal
- In the shipping input, enter a number with any decimal places, ex `200.464`
- When you click/tab away the field should update to an whole-number value