### PR TITLE
i18n: Bump i18n-calypso version to 1.8.1

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1605,7 +1605,7 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.26"
+      "version": "1.3.27"
     },
     "element-class": {
       "version": "0.2.2"
@@ -3092,7 +3092,7 @@
       }
     },
     "i18n-calypso": {
-      "version": "1.8.0",
+      "version": "1.8.1",
       "dependencies": {
         "async": {
           "version": "1.5.2"

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "hash.js": "1.1.3",
     "he": "0.5.0",
     "html-loader": "0.4.0",
-    "i18n-calypso": "1.8.0",
+    "i18n-calypso": "1.8.1",
     "immutability-helper": "2.4.0",
     "immutable": "3.7.6",
     "imports-loader": "0.6.5",


### PR DESCRIPTION
This fixes the invalid POT file produced by `npm run translate` through https://github.com/Automattic/i18n-calypso/pull/41

**Testing**
- create `calypso-strings.pot` by running `npm run translate`
- the command `msgcat calypso-strings.pot` should run without an error.