### PR TITLE
Color Schemes: fix css build logging

### DIFF
--- a/package.json
+++ b/package.json
@@ -176,7 +176,7 @@
     "prebuild": "npm run -s install-if-deps-outdated",
     "build": "run-p -s build-devdocs:* build-server build-client-if-prod build-client-if-desktop build-css",
     "build-css": "run-p -s build-css:*",
-    "build-css:debug": "node-sass --include-path client --source-map \"public/style-debug.css.map\" assets/stylesheets/style.scss public/style-debug.css && npm run -s autoprefixer -- public/style-debug.css",
+    "build-css:debug": "node-sass --include-path client --source-map \"public/style-debug.css.map\" assets/stylesheets/style.scss public/style-debug.css && npm run -s postcss -- public/style-debug.css",
     "build-css:directly": "node-sass --include-path client assets/stylesheets/directly.scss public/directly.css && npm run -s autoprefixer -- public/directly.css",
     "build-css:editor": "node-sass --include-path client assets/stylesheets/editor.scss public/editor.css && npm run -s autoprefixer -- public/editor.css",
     "build-css:style": "node-sass --include-path client assets/stylesheets/style.scss public/style.css && npm run -s postcss -- public/style.css && rtlcss public/style.css public/style-rtl.css",

--- a/postcss.config.json
+++ b/postcss.config.json
@@ -1,6 +1,6 @@
 {
     "postcss-custom-properties": {
-        "preserve": "true",
-        "warnings": "false"
+        "preserve": true,
+        "warnings": false
     }
 }


### PR DESCRIPTION
#### This PR 
- is part of a series of PRs aiming to provide support for Color Schemes in Calypso.
- focuses on fixing an issue where unnecessary information was logged during the build step

In order to provide the default theme as a fallback for browsers that don't support CSS custom properties, we're using the postcss plugin postcss-custom-properties. The plugin looks at the `:root` selector and takes variable definitions from there. By default, during the build, it notifies if it found variable definitions outside the `:root` selector, as it ignores those. This is expected behavior in our use case and we don't want to have this information to be logged during the build. 

Unfortunately, it was being logged due to a minor misconfiguration (string vs. boolean), which resulted in the log looking similar to what was reported here: https://github.com/Automattic/wp-calypso/pull/18911#issuecomment-338139138

In addition, this PR adds the postcss step that we're using for the main style build to the style debug build step as well. The idea here is to have the local build match the prod build as closely as possible. The postcss step includes autoprefixer (which is a postcss plugin itself) as well as the postcss-custom-properties plugin.

### How to test

- Run `npm run build-css:style` and `npm run build-css:debug` to check if the logs reported in https://github.com/Automattic/wp-calypso/pull/18911#issuecomment-338139138 don't appear anymore
- Check the CSS output of `style-debug.css` and validate that the following exists (custom property rule plus fallback):
```
.layout__loader {
  border-bottom: 1px solid #0079aa;
  border-bottom: 1px solid var(--masterbar-border-color);
```

### Notes

For a more detailed description of the feature, the chosen approach and its advantages feel free to check out my post on the subject: p4TIVU-75d-p2 (internal reference).