### PR TITLE
Store Orders: Add ability to edit product quantity on orders

### DIFF
--- a/client/extensions/woocommerce/app/order/order-details/index.js
+++ b/client/extensions/woocommerce/app/order/order-details/index.js
@@ -56,7 +56,7 @@ class OrderDetails extends Component {
 	renderDetails = () => {
 		const { isEditing, order, site } = this.props;
 		if ( isEditing ) {
-			return <OrderDetailsTable order={ order } site={ site } />;
+			return <OrderDetailsTable order={ order } site={ site } isEditing />;
 		}
 
 		return [

--- a/client/extensions/woocommerce/app/order/order-details/index.js
+++ b/client/extensions/woocommerce/app/order/order-details/index.js
@@ -43,6 +43,13 @@ class OrderDetails extends Component {
 		}
 	};
 
+	updateLineItems = item => {
+		const { siteId, order } = this.props;
+		if ( siteId ) {
+			this.props.editOrder( siteId, { id: order.id, line_items: [ item ] } );
+		}
+	};
+
 	renderStatus = () => {
 		const { isEditing, order } = this.props;
 
@@ -56,7 +63,14 @@ class OrderDetails extends Component {
 	renderDetails = () => {
 		const { isEditing, order, site } = this.props;
 		if ( isEditing ) {
-			return <OrderDetailsTable order={ order } site={ site } isEditing />;
+			return (
+				<OrderDetailsTable
+					order={ order }
+					site={ site }
+					isEditing
+					onChange={ this.updateLineItems }
+				/>
+			);
 		}
 
 		return [

--- a/client/extensions/woocommerce/app/order/order-details/index.js
+++ b/client/extensions/woocommerce/app/order/order-details/index.js
@@ -46,7 +46,7 @@ class OrderDetails extends Component {
 	updateLineItems = item => {
 		const { siteId, order } = this.props;
 		if ( siteId ) {
-			this.props.editOrder( siteId, { id: order.id, line_items: [ item ] } );
+			this.props.editOrder( siteId, { id: order.id, line_items: item } );
 		}
 	};
 

--- a/client/extensions/woocommerce/app/order/order-details/style.scss
+++ b/client/extensions/woocommerce/app/order/order-details/style.scss
@@ -11,6 +11,11 @@
 		text-transform: uppercase;
 	}
 
+	&.is-editing .order-details__item-tax {
+		color: $gray-text-min;
+		font-style: italic;
+	}
+
 	thead .table-heading {
 		border-bottom: 1px solid lighten( $gray, 30% );
 	}
@@ -53,6 +58,11 @@
 	.form-text-input-with-affixes,
 	.form-text-input-with-suffixes {
 		text-align: left;
+	}
+
+	&.is-editing .order-details__totals-tax {
+		color: $gray-text-min;
+		font-style: italic;
 	}
 
 	&.is-refund-modal,

--- a/client/extensions/woocommerce/app/order/order-details/style.scss
+++ b/client/extensions/woocommerce/app/order/order-details/style.scss
@@ -16,6 +16,10 @@
 		font-style: italic;
 	}
 
+	&.hide-taxes.is-editing .order-details__item-tax {
+		display: none;
+	}
+
 	thead .table-heading {
 		border-bottom: 1px solid lighten( $gray, 30% );
 	}

--- a/client/extensions/woocommerce/app/order/order-details/style.scss
+++ b/client/extensions/woocommerce/app/order/order-details/style.scss
@@ -20,6 +20,10 @@
 			background: transparent;
 		}
 	}
+
+	.order-details__item-quantity .form-text-input {
+		width: 5em;
+	}
 }
 
 .order-details__item-total {

--- a/client/extensions/woocommerce/app/order/order-details/table.js
+++ b/client/extensions/woocommerce/app/order/order-details/table.js
@@ -185,10 +185,16 @@ class OrderDetailsTable extends Component {
 			return null;
 		}
 
+		const tableClasses = classnames( {
+			'order-details__table': true,
+			'is-editing': isEditing,
+		} );
+
 		const showTax = this.shouldShowTax();
 		const totalsClasses = classnames( {
 			'order-details__totals': true,
 			'has-taxes': showTax,
+			'is-editing': isEditing,
 		} );
 		const refundValue = getOrderRefundTotal( order );
 		const totalTaxValue = getOrderTotalTax( order );
@@ -196,7 +202,7 @@ class OrderDetailsTable extends Component {
 
 		return (
 			<div>
-				<Table className="order-details__table" header={ this.renderTableHeader() }>
+				<Table className={ tableClasses } header={ this.renderTableHeader() }>
 					{ order.line_items.map( this.renderOrderItems ) }
 					{ order.fee_lines.map( this.renderOrderFees ) }
 				</Table>

--- a/client/extensions/woocommerce/app/order/order-details/table.js
+++ b/client/extensions/woocommerce/app/order/order-details/table.js
@@ -12,6 +12,7 @@ import { find, findIndex, noop } from 'lodash';
  * Internal dependencies
  */
 import formatCurrency from 'lib/format-currency';
+import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import FormTextInput from 'components/forms/form-text-input';
 import { getLink } from 'woocommerce/lib/nav-utils';
 import {
@@ -238,6 +239,13 @@ class OrderDetailsTable extends Component {
 							value={ refundValue }
 							showTax={ showTax }
 						/>
+					) }
+					{ isEditing && (
+						<FormSettingExplanation>
+							{ translate(
+								'The total might not reflect updated tax values, tax will update when saved.'
+							) }
+						</FormSettingExplanation>
 					) }
 				</div>
 			</div>

--- a/client/extensions/woocommerce/app/order/order-details/table.js
+++ b/client/extensions/woocommerce/app/order/order-details/table.js
@@ -6,11 +6,13 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
+import { noop } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import formatCurrency from 'lib/format-currency';
+import FormTextInput from 'components/forms/form-text-input';
 import { getLink } from 'woocommerce/lib/nav-utils';
 import {
 	getOrderDiscountTax,
@@ -27,6 +29,8 @@ import TableItem from 'woocommerce/components/table/table-item';
 
 class OrderDetailsTable extends Component {
 	static propTypes = {
+		isEditing: PropTypes.bool,
+		onChange: PropTypes.func,
 		order: PropTypes.shape( {
 			currency: PropTypes.string.isRequired,
 			discount_total: PropTypes.string.isRequired,
@@ -40,6 +44,11 @@ class OrderDetailsTable extends Component {
 			slug: PropTypes.string.isRequired,
 		} ),
 		translate: PropTypes.func,
+	};
+
+	static defaultProps = {
+		isEditing: false,
+		onChange: noop,
 	};
 
 	shouldShowTax = () => {
@@ -74,24 +83,55 @@ class OrderDetailsTable extends Component {
 		);
 	};
 
-	renderOrderItems = item => {
-		const { order, site } = this.props;
+	onChange = event => {
+		this.props.onChange( event );
+	};
+
+	renderQuantity = item => {
+		const { isEditing } = this.props;
+		if ( isEditing ) {
+			return (
+				<FormTextInput
+					type="number"
+					name={ `quantity-${ item.id }` }
+					onChange={ this.onChange }
+					value={ item.quantity }
+				/>
+			);
+		}
+		return item.quantity;
+	};
+
+	renderName = item => {
+		const { isEditing, site } = this.props;
+		if ( isEditing ) {
+			return <span className="order-details__item-link">{ item.name }</span>;
+		}
+		return (
+			<a
+				href={ getLink( `/store/product/:site/${ item.product_id }`, site ) }
+				className="order-details__item-link"
+			>
+				{ item.name }
+			</a>
+		);
+	};
+
+	renderOrderItems = ( item, i ) => {
+		const { order } = this.props;
 		const tax = getOrderLineItemTax( order, item.id );
 		return (
 			<TableRow key={ item.id } className="order-details__items">
 				<TableItem isRowHeader className="order-details__item-product">
-					<a
-						href={ getLink( `/store/product/:site/${ item.product_id }`, site ) }
-						className="order-details__item-link"
-					>
-						{ item.name }
-					</a>
+					{ this.renderName( item ) }
 					<span className="order-details__item-sku">{ item.sku }</span>
 				</TableItem>
 				<TableItem className="order-details__item-cost">
 					{ formatCurrency( item.price, order.currency ) }
 				</TableItem>
-				<TableItem className="order-details__item-quantity">{ item.quantity }</TableItem>
+				<TableItem className="order-details__item-quantity">
+					{ this.renderQuantity( item, i ) }
+				</TableItem>
 				<TableItem className="order-details__item-tax">
 					{ formatCurrency( tax, order.currency ) }
 				</TableItem>

--- a/client/extensions/woocommerce/app/order/order-details/table.js
+++ b/client/extensions/woocommerce/app/order/order-details/table.js
@@ -147,12 +147,10 @@ class OrderDetailsTable extends Component {
 		const tax = getOrderFeeTax( order, i );
 		return (
 			<TableRow key={ i } className="order-details__items">
-				<TableItem isRowHeader className="order-details__item-product">
+				<TableItem isRowHeader className="order-details__item-product" colSpan="3">
 					{ item.name }
 					<span className="order-details__item-sku">{ translate( 'Fee' ) }</span>
 				</TableItem>
-				<TableItem className="order-details__item-cost" />
-				<TableItem className="order-details__item-quantity" />
 				<TableItem className="order-details__item-tax">
 					{ formatCurrency( tax, order.currency ) }
 				</TableItem>

--- a/client/extensions/woocommerce/app/order/order-details/table.js
+++ b/client/extensions/woocommerce/app/order/order-details/table.js
@@ -110,6 +110,7 @@ class OrderDetailsTable extends Component {
 			return (
 				<FormTextInput
 					type="number"
+					min={ 1 }
 					name={ `quantity-${ item.id }` }
 					onChange={ this.onChange }
 					value={ item.quantity }

--- a/client/extensions/woocommerce/app/order/order-details/table.js
+++ b/client/extensions/woocommerce/app/order/order-details/table.js
@@ -6,7 +6,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
-import { find, noop } from 'lodash';
+import { find, findIndex, noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -91,10 +91,12 @@ class OrderDetailsTable extends Component {
 		if ( ! item ) {
 			return;
 		}
+		const index = findIndex( order.line_items, { id } );
 		const quantity = parseInt( event.target.value );
 		const total = parseFloat( item.price ) * quantity;
-		// @todo Can we live-update the tax? Should we "hide" that somehow
-		this.props.onChange( { ...item, quantity, total } );
+		// @todo Can we live-update the tax? Should we "hide" that somehow?
+		const newItem = { ...item, quantity, total };
+		this.props.onChange( { [ index ]: newItem } );
 	};
 
 	renderQuantity = item => {

--- a/client/extensions/woocommerce/app/order/order-details/table.js
+++ b/client/extensions/woocommerce/app/order/order-details/table.js
@@ -186,12 +186,13 @@ class OrderDetailsTable extends Component {
 			return null;
 		}
 
+		const showTax = this.shouldShowTax();
 		const tableClasses = classnames( {
 			'order-details__table': true,
+			'hide-taxes': ! showTax,
 			'is-editing': isEditing,
 		} );
 
-		const showTax = this.shouldShowTax();
 		const totalsClasses = classnames( {
 			'order-details__totals': true,
 			'has-taxes': showTax,

--- a/client/extensions/woocommerce/app/order/order-details/table.js
+++ b/client/extensions/woocommerce/app/order/order-details/table.js
@@ -84,7 +84,11 @@ class OrderDetailsTable extends Component {
 	};
 
 	onChange = event => {
-		this.props.onChange( event );
+		const { order } = this.props;
+		// Name is `quantity-x`, where x is the ID of the item
+		const id = parseInt( event.target.name.split( '-' )[ 1 ] );
+		const line_item = find( order.line_items, { id } );
+		this.props.onChange( { ...line_item, quantity: event.target.value } );
 	};
 
 	renderQuantity = item => {

--- a/client/extensions/woocommerce/app/order/order-details/table.js
+++ b/client/extensions/woocommerce/app/order/order-details/table.js
@@ -6,7 +6,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
-import { noop } from 'lodash';
+import { find, noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -87,8 +87,14 @@ class OrderDetailsTable extends Component {
 		const { order } = this.props;
 		// Name is `quantity-x`, where x is the ID of the item
 		const id = parseInt( event.target.name.split( '-' )[ 1 ] );
-		const line_item = find( order.line_items, { id } );
-		this.props.onChange( { ...line_item, quantity: event.target.value } );
+		const item = find( order.line_items, { id } );
+		if ( ! item ) {
+			return;
+		}
+		const quantity = parseInt( event.target.value );
+		const total = parseFloat( item.price ) * quantity;
+		// @todo Can we live-update the tax? Should we "hide" that somehow
+		this.props.onChange( { ...item, quantity, total } );
 	};
 
 	renderQuantity = item => {


### PR DESCRIPTION
See #15681. This PR enables editing of quantity on products in existing orders.

<img width="746" alt="editing-order" src="https://user-images.githubusercontent.com/541093/31831886-05e739fc-b593-11e7-8ffc-965ad17be259.png">

As the quantity is updated, the line item total & order total are updated. Saving the order updates the new quantities.

**Taxes…**

We don't know the tax rate from just the order API response (and I guess it would vary based on shop/customer address?), so I've opted to grey out the tax rate and leave a note that the order total is an estimate before updating taxes. Currently the text is basically a placeholder, and it says:

> The total might not reflect updated tax values, tax will update when saved.

Does this work as a flow? Once the order is saved, it loads in the new data which includes the correct tax/total.

**To test**

- View an order
- Click "Edit Order" in top right
- The order table changes & quantity should become editable
- Change the quantity
- "Total" for that line item should update
- The total for the order should also update

Note: currently you can edit any order status, but before editing is launched to everyone I'll put this part behind a status check.