### PR TITLE
Revert "Data Layer: Update comments to use the new v1.1 comments tree endpoint."

### DIFF
--- a/client/state/data-layer/wpcom/sites/comments-tree/index.js
+++ b/client/state/data-layer/wpcom/sites/comments-tree/index.js
@@ -5,7 +5,7 @@
  */
 
 import { translate } from 'i18n-calypso';
-import { map, flatMap, flatten } from 'lodash';
+import { map } from 'lodash';
 
 /**
  * Internal dependencies
@@ -25,7 +25,7 @@ export const fetchCommentsTreeForSite = ( { dispatch }, action ) => {
 			{
 				method: 'GET',
 				path: `/sites/${ siteId }/comments-tree`,
-				apiVersion: '1.1',
+				apiVersion: '1',
 				query: {
 					status: 'unapproved' === status ? 'pending' : status,
 				},
@@ -35,25 +35,14 @@ export const fetchCommentsTreeForSite = ( { dispatch }, action ) => {
 	);
 };
 
-const mapPosts = ( commentIds, apiPostId ) => {
-	const postId = parseInt( apiPostId, 10 );
-	const [ topLevelIds, replyIds ] = commentIds;
-
-	return flatten( [
-		topLevelIds.map( commentId => [ commentId, postId, 0 ] ),
-		replyIds.map( ( [ commentId, commentParentId ] ) => [ commentId, postId, commentParentId ] ),
-	] );
-};
-
-const mapTree = ( tree, status, type ) => {
-	return map( flatMap( tree, mapPosts ), ( [ commentId, postId, commentParentId ] ) => ( {
+const mapTree = ( tree, status, type ) =>
+	map( tree, ( [ commentId, postId, commentParentId ] ) => ( {
 		commentId,
 		commentParentId,
 		postId,
 		status,
 		type,
 	} ) );
-};
 
 export const addCommentsTree = ( { dispatch }, { query }, data ) => {
 	const { siteId, status } = query;

--- a/client/state/data-layer/wpcom/sites/comments-tree/test/index.js
+++ b/client/state/data-layer/wpcom/sites/comments-tree/test/index.js
@@ -27,7 +27,7 @@ describe( 'comments-tree', () => {
 						method: 'GET',
 						path: '/sites/77203074/comments-tree',
 						query: { status: 'approved' },
-						apiVersion: '1.1',
+						apiVersion: '1',
 					},
 					action
 				)
@@ -39,9 +39,9 @@ describe( 'comments-tree', () => {
 		test( 'should dispatch comment tree updates', () => {
 			const dispatch = spy();
 			addCommentsTree( { dispatch }, action, {
-				comments_tree: { 1: [ [ 2 ], [] ] },
-				pingbacks_tree: { 1: [ [ 3 ], [] ] },
-				trackbacks_tree: { 1: [ [ 4 ], [] ] },
+				comments_tree: [ [ 2, 1, 0 ] ],
+				pingbacks_tree: [ [ 3, 1, 0 ] ],
+				trackbacks_tree: [ [ 4, 1, 0 ] ],
 			} );
 			expect( dispatch ).to.have.been.calledOnce;
 			expect( dispatch ).to.have.been.calledWith( {


### PR DESCRIPTION
Reverts Automattic/wp-calypso#18800