### PR TITLE
Editor: Ground Control: Show the separator for save and/or history

### DIFF
--- a/client/post-editor/editor-ground-control/index.jsx
+++ b/client/post-editor/editor-ground-control/index.jsx
@@ -205,6 +205,64 @@ export class EditorGroundControl extends PureComponent {
 		}
 	};
 
+	renderGroundControlQuickSaveButtons() {
+		const {
+			isSaving,
+			isSidebarOpened,
+			nestedSidebar,
+			post,
+			selectRevision,
+			setNestedSidebar,
+			toggleSidebar,
+			translate,
+		} = this.props;
+
+		const isSaveAvailable = this.isSaveAvailable();
+		const showingStatusLabel = this.shouldShowStatusLabel();
+		const showingSaveStatus = isSaveAvailable || showingStatusLabel;
+		const hasRevisions = isEnabled( 'post-editor/revisions' ) && get( post, 'revisions.length' );
+
+		if ( ! ( showingSaveStatus || hasRevisions ) ) {
+			return;
+		}
+
+		return (
+			<div className="editor-ground-control__quick-save">
+				{ showingSaveStatus && (
+					<div className="editor-ground-control__status">
+						{ isSaveAvailable && (
+							<button
+								className="editor-ground-control__save button is-link"
+								onClick={ this.onSaveButtonClick }
+								tabIndex={ 3 }
+							>
+								{ translate( 'Save' ) }
+							</button>
+						) }
+						{ ! isSaveAvailable &&
+						showingStatusLabel && (
+							<span
+								className="editor-ground-control__save-status"
+								data-e2e-status={ isSaving ? 'Saving…' : 'Saved' }
+							>
+								{ isSaving ? translate( 'Saving…' ) : translate( 'Saved' ) }
+							</span>
+						) }
+					</div>
+				) }
+				{ hasRevisions && (
+					<HistoryButton
+						selectRevision={ selectRevision }
+						setNestedSidebar={ setNestedSidebar }
+						toggleSidebar={ toggleSidebar }
+						isSidebarOpened={ isSidebarOpened }
+						nestedSidebar={ nestedSidebar }
+					/>
+				) }
+			</div>
+		);
+	}
+
 	renderGroundControlActionButtons() {
 		if ( this.props.confirmationSidebarStatus === 'open' ) {
 			return;
@@ -259,11 +317,7 @@ export class EditorGroundControl extends PureComponent {
 	}
 
 	render() {
-		const { isSaving, translate } = this.props;
-		const isSaveAvailable = this.isSaveAvailable();
-		const shouldShowStatusLabel = this.shouldShowStatusLabel();
-		const hasRevisions =
-			isEnabled( 'post-editor/revisions' ) && get( this.props.post, 'revisions.length' );
+		const { translate } = this.props;
 
 		return (
 			<Card className="editor-ground-control">
@@ -299,37 +353,7 @@ export class EditorGroundControl extends PureComponent {
 						</span>
 					</div>
 				) }
-				{ ( isSaveAvailable || shouldShowStatusLabel ) && (
-					<div className="editor-ground-control__status">
-						{ isSaveAvailable && (
-							<button
-								className="editor-ground-control__save button is-link"
-								onClick={ this.onSaveButtonClick }
-								tabIndex={ 3 }
-							>
-								{ translate( 'Save' ) }
-							</button>
-						) }
-						{ ! isSaveAvailable &&
-						shouldShowStatusLabel && (
-							<span
-								className="editor-ground-control__save-status"
-								data-e2e-status={ isSaving ? 'Saving…' : 'Saved' }
-							>
-								{ isSaving ? translate( 'Saving…' ) : translate( 'Saved' ) }
-							</span>
-						) }
-					</div>
-				) }
-				{ hasRevisions && (
-					<HistoryButton
-						selectRevision={ this.props.selectRevision }
-						setNestedSidebar={ this.props.setNestedSidebar }
-						toggleSidebar={ this.props.toggleSidebar }
-						isSidebarOpened={ this.props.isSidebarOpened }
-						nestedSidebar={ this.props.nestedSidebar }
-					/>
-				) }
+				{ this.renderGroundControlQuickSaveButtons() }
 				{ this.renderGroundControlActionButtons() }
 			</Card>
 		);

--- a/client/post-editor/editor-ground-control/style.scss
+++ b/client/post-editor/editor-ground-control/style.scss
@@ -51,8 +51,12 @@
 	min-height: 20px;
 	justify-content: space-between;
 	position: relative;
-	border-left: 1px solid lighten( $gray, 25% );
 	padding-left: 16px;
+}
+
+.editor-ground-control__quick-save {
+	border-left: 1px solid lighten( $gray, 25% );
+	display: flex;
 
 	@include breakpoint( "<660px" ) {
 		border-left: none;


### PR DESCRIPTION
This change wraps the save status & history elements in a new element & adds the border there instead & pulls logic out of render to a new function.

### Before

<img width="133" alt="screen_shot_2017-10-20_at_12 49 04" src="https://user-images.githubusercontent.com/1587282/31838213-bc9b4204-b5a9-11e7-806a-6dbbbb563661.png">

### After

#### Draft

<img width="199" alt="screen shot 2017-10-20 at 3 14 41 pm" src="https://user-images.githubusercontent.com/1587282/31838166-810d2d4c-b5a9-11e7-9ece-55f1ed96006c.png">

#### Published

<img width="165" alt="screen shot 2017-10-20 at 3 14 27 pm" src="https://user-images.githubusercontent.com/1587282/31838147-731a287a-b5a9-11e7-8106-e864de61164d.png">

## To Test

* Create a post
  * Before it autosaves, there should be no separator or save / history buttons as before
* Let it autosave
  * You should see the separator & the save button as before
* Make another change & let it autosave
  * You should see the separator & the save & history buttons as before
* Publish the post
  * You should see the separator & the history button (the separator is the new behavior)