### PR TITLE
Store: Set receiver_email to the same as PayPal email.

### DIFF
--- a/client/extensions/woocommerce/app/settings/payments/payment-method-paypal.js
+++ b/client/extensions/woocommerce/app/settings/payments/payment-method-paypal.js
@@ -39,6 +39,11 @@ class PaymentMethodPaypal extends Component {
 
 	onEditFieldHandler = e => {
 		this.props.onEditField( e.target.name, e.target.value );
+
+		if ( 'email' === e.target.name ) {
+			// also set receiver_email to same value.
+			this.props.onEditField( 'receiver_email', e.target.value );
+		}
 	};
 
 	buttons = [


### PR DESCRIPTION
Fixes #19030

Currently the `receiver_email` from PayPal defaults to the store owner's email during setup - which is fine if the PayPal email is the same - but will lead to IPN email mis-match issues which result in valid orders being put on "Hold".

This PR seeks to fix the issue by updating the `receiver_email` to be the same as the PayPal email which is set in http://calypso.localhost:3000/store/settings/{site}

__To Test__
- Visit http://calypso.localhost:3000/store/settings/troutbumm.in
- Click on "Manage" for PayPal
- Set the email address to one that is not the same as your site owner's email address
- Visit `/wp-admin/admin.php?page=wc-settings&tab=checkout&section=paypal` for the same site and verify that both the PayPal email and receiver email are the same as the one you entered.

<img width="1094" alt="woocommerce_settings_ _trout_bummin_ _wordpress" src="https://user-images.githubusercontent.com/22080/31842338-98c7569e-b5a2-11e7-95ea-8004048d30de.png">
