### PR TITLE
 Store Orders: Add “Delete” button to products & fees on an order

### DIFF
--- a/client/extensions/woocommerce/app/order/order-details/index.js
+++ b/client/extensions/woocommerce/app/order/order-details/index.js
@@ -43,10 +43,10 @@ class OrderDetails extends Component {
 		}
 	};
 
-	updateLineItems = item => {
+	updateOrder = newOrder => {
 		const { siteId, order } = this.props;
 		if ( siteId ) {
-			this.props.editOrder( siteId, { id: order.id, line_items: item } );
+			this.props.editOrder( siteId, { id: order.id, ...newOrder } );
 		}
 	};
 
@@ -64,12 +64,7 @@ class OrderDetails extends Component {
 		const { isEditing, order, site } = this.props;
 		if ( isEditing ) {
 			return (
-				<OrderDetailsTable
-					order={ order }
-					site={ site }
-					isEditing
-					onChange={ this.updateLineItems }
-				/>
+				<OrderDetailsTable order={ order } site={ site } isEditing onChange={ this.updateOrder } />
 			);
 		}
 

--- a/client/extensions/woocommerce/app/order/order-details/row-total.js
+++ b/client/extensions/woocommerce/app/order/order-details/row-total.js
@@ -13,6 +13,8 @@ import { localize } from 'i18n-calypso';
  */
 import formatCurrency from 'lib/format-currency';
 import PriceInput from 'woocommerce/components/price-input';
+import TableRow from 'woocommerce/components/table/table-row';
+import TableItem from 'woocommerce/components/table/table-item';
 
 class OrderTotalRow extends Component {
 	static propTypes = {
@@ -45,9 +47,11 @@ class OrderTotalRow extends Component {
 
 		const classes = classnames( className, 'order-details__total order-details__total-edit' );
 		return (
-			<div className={ classes }>
-				<div className="order-details__totals-label">{ label }</div>
-				<div className="order-details__totals-value">
+			<TableRow className={ classes }>
+				<TableItem isRowHeader className="order-details__totals-label">
+					{ label }
+				</TableItem>
+				<TableItem className="order-details__totals-value" colSpan="2">
 					<PriceInput
 						name={ name }
 						currency={ currency }
@@ -55,8 +59,8 @@ class OrderTotalRow extends Component {
 						onChange={ onChange }
 						value={ total }
 					/>
-				</div>
-			</div>
+				</TableItem>
+			</TableRow>
 		);
 	};
 
@@ -67,16 +71,22 @@ class OrderTotalRow extends Component {
 		const { className, currency, label, value, showTax, taxValue } = this.props;
 
 		const tax = (
-			<div className="order-details__totals-tax">{ formatCurrency( taxValue, currency ) }</div>
+			<TableItem className="order-details__totals-tax">
+				{ formatCurrency( taxValue, currency ) }
+			</TableItem>
 		);
 		const classes = classnames( className, 'order-details__total' );
 
 		return (
-			<div className={ classes }>
-				<div className="order-details__totals-label">{ label }</div>
+			<TableRow className={ classes }>
+				<TableItem isRowHeader className="order-details__totals-label">
+					{ label }
+				</TableItem>
 				{ showTax && tax }
-				<div className="order-details__totals-value">{ formatCurrency( value, currency ) }</div>
-			</div>
+				<TableItem className="order-details__totals-value">
+					{ formatCurrency( value, currency ) }
+				</TableItem>
+			</TableRow>
 		);
 	}
 }

--- a/client/extensions/woocommerce/app/order/order-details/style.scss
+++ b/client/extensions/woocommerce/app/order/order-details/style.scss
@@ -1,7 +1,8 @@
+/** @format */
 .order-details__table {
 	margin: 0 -24px;
 	box-shadow: none;
-	border-bottom: 1px solid lighten( $gray, 30% );
+	border-bottom: 1px solid lighten($gray, 30%);
 
 	.order-details__item-sku {
 		display: block;
@@ -21,7 +22,7 @@
 	}
 
 	thead .table-heading {
-		border-bottom: 1px solid lighten( $gray, 30% );
+		border-bottom: 1px solid lighten($gray, 30%);
 	}
 
 	.table-row {
@@ -40,61 +41,15 @@
 	text-align: right;
 }
 
-.order-details__totals {
-	padding: 24px 0;
+.order-details__totals.table {
+	margin: 0 -24px;
+	box-shadow: none;
+	border: none;
 	text-align: right;
-	font-size: 14px;
 
-	.order-details__total {
-		margin-bottom: 8px;
-		display: flex;
-		align-items: center;
-
-		.order-details__totals-label {
-			flex: 1 0 calc(100% - 104px);
-		}
-
-		.order-details__totals-tax,
-		.order-details__totals-value {
-			flex: 1 0 92px;
-		}
-	}
-
-	.form-text-input-with-affixes,
-	.form-text-input-with-suffixes {
-		text-align: left;
-	}
-
-	&.is-editing .order-details__totals-tax {
-		color: $gray-text-min;
-		font-style: italic;
-	}
-
-	&.is-refund-modal,
-	&.has-taxes {
-		.order-details__total {
-			.order-details__totals-label {
-				flex: 1 0 calc(100% - 250px);
-			}
-		}
-	}
-
-	&.has-taxes {
-		.order-details__total-edit .order-details__totals-value {
-			flex: 1 0 192px;
-		}
-	}
-
-	.order-details__total-refund {
-		color: $alert-red;
-	}
-
-	.order-details__total-full .order-details__totals-label,
-	.order-details__total-full .order-details__totals-value {
-		font-weight: 600;
-	}
-
-	& > div:last-child {
-		margin-bottom: 0;
+	.table-heading:last-child,
+	.table-item:last-child {
+		padding-right: 24px;
+		font-size: 14px;
 	}
 }

--- a/client/extensions/woocommerce/app/order/order-details/style.scss
+++ b/client/extensions/woocommerce/app/order/order-details/style.scss
@@ -34,6 +34,10 @@
 	.order-details__item-quantity .form-text-input {
 		width: 5em;
 	}
+
+	.order-details__item-delete {
+		width: 1.5em;
+	}
 }
 
 .order-details__item-delete,
@@ -41,15 +45,53 @@
 	text-align: right;
 }
 
-.order-details__totals.table {
-	margin: 0 -24px;
+// Duplicating `.table` for increased specificity
+.order-details__totals.table.table {
+	margin: 16px -24px;
 	box-shadow: none;
 	border: none;
 	text-align: right;
 
-	.table-heading:last-child,
-	.table-item:last-child {
-		padding-right: 24px;
+	.table-row {
+		&:hover {
+			background: transparent;
+		}
+	}
+
+	.table-item {
 		font-size: 14px;
+	}
+
+	.order-details__total-refund {
+		color: $alert-red;
+	}
+
+	.order-details__total-full .order-details__totals-label,
+	.order-details__total-full .order-details__totals-value {
+		font-weight: 600;
+	}
+
+	.order-details__totals-value.table-item {
+		padding-right: 24px;
+		width: 10em;
+	}
+
+	&.has-taxes {
+		.order-details__totals-tax,
+		.order-details__totals-value {
+			width: 8em;
+		}
+	}
+
+	&.is-editing {
+		.order-details__totals-value {
+			// Indent enough to account for delete button
+			padding-right: 78px !important;
+		}
+
+		.order-details__totals-tax {
+			color: $gray-text-min;
+			font-style: italic;
+		}
 	}
 }

--- a/client/extensions/woocommerce/app/order/order-details/style.scss
+++ b/client/extensions/woocommerce/app/order/order-details/style.scss
@@ -35,6 +35,7 @@
 	}
 }
 
+.order-details__item-delete,
 .order-details__item-total {
 	text-align: right;
 }

--- a/client/extensions/woocommerce/app/order/order-details/style.scss
+++ b/client/extensions/woocommerce/app/order/order-details/style.scss
@@ -95,3 +95,8 @@
 		}
 	}
 }
+
+.order-details__card .form-setting-explanation {
+	margin: -8px 0 16px;
+	text-align: right;
+}

--- a/client/extensions/woocommerce/app/order/order-details/table.js
+++ b/client/extensions/woocommerce/app/order/order-details/table.js
@@ -121,7 +121,7 @@ class OrderDetailsTable extends Component {
 				if ( 'line_items' === type ) {
 					newItem = { id, quantity: 0, subtotal: 0 };
 				} else {
-					newItem = { id, total: 0 };
+					newItem = { id, name: null, total: 0 };
 				}
 				this.props.onChange( { [ type ]: { [ index ]: newItem } } );
 			}

--- a/client/extensions/woocommerce/app/order/order-details/table.js
+++ b/client/extensions/woocommerce/app/order/order-details/table.js
@@ -261,7 +261,7 @@ class OrderDetailsTable extends Component {
 					{ order.fee_lines.map( this.renderOrderFee ) }
 				</Table>
 
-				<div className={ totalsClasses }>
+				<Table className={ totalsClasses } compact>
 					<OrderTotalRow
 						currency={ order.currency }
 						label={ translate( 'Discount' ) }
@@ -300,7 +300,7 @@ class OrderDetailsTable extends Component {
 							) }
 						</FormSettingExplanation>
 					) }
-				</div>
+				</Table>
 			</div>
 		);
 	}

--- a/client/extensions/woocommerce/app/order/order-details/table.js
+++ b/client/extensions/woocommerce/app/order/order-details/table.js
@@ -233,6 +233,15 @@ class OrderDetailsTable extends Component {
 		);
 	};
 
+	renderTaxWarning = () => {
+		const { translate } = this.props;
+		return (
+			<FormSettingExplanation>
+				{ translate( 'If applicable, taxes will be applied or updated after saving.' ) }
+			</FormSettingExplanation>
+		);
+	};
+
 	render() {
 		const { isEditing, order, translate } = this.props;
 		if ( ! order ) {
@@ -294,14 +303,8 @@ class OrderDetailsTable extends Component {
 							showTax={ showTax }
 						/>
 					) }
-					{ isEditing && (
-						<FormSettingExplanation>
-							{ translate(
-								'The total might not reflect updated tax values, tax will update when saved.'
-							) }
-						</FormSettingExplanation>
-					) }
 				</Table>
+				{ isEditing && this.renderTaxWarning() }
 			</div>
 		);
 	}

--- a/client/extensions/woocommerce/app/order/order-details/table.js
+++ b/client/extensions/woocommerce/app/order/order-details/table.js
@@ -113,9 +113,8 @@ class OrderDetailsTable extends Component {
 	};
 
 	onDelete = ( id, type = 'line_items' ) => {
-		const { order } = this.props;
 		return () => {
-			const index = findIndex( order[ type ], { id } );
+			const index = findIndex( this.props.order[ type ], { id } );
 			if ( index >= 0 ) {
 				let newItem;
 				if ( 'line_items' === type ) {
@@ -170,8 +169,8 @@ class OrderDetailsTable extends Component {
 					compact
 					borderless
 					icon
-					aria-label={ translate( 'Remove %(product)s from this order', {
-						args: { product: item.name },
+					aria-label={ translate( 'Remove %(itemName)s from this order', {
+						args: { itemName: item.name },
 					} ) }
 					onClick={ this.onDelete( item.id, type ) }
 				>
@@ -181,7 +180,7 @@ class OrderDetailsTable extends Component {
 		);
 	};
 
-	renderOrderItems = ( item, i ) => {
+	renderOrderItem = ( item, i ) => {
 		const { order } = this.props;
 		const tax = getOrderLineItemTax( order, item.id );
 		if ( item.quantity <= 0 ) {
@@ -210,7 +209,7 @@ class OrderDetailsTable extends Component {
 		);
 	};
 
-	renderOrderFees = item => {
+	renderOrderFee = item => {
 		const { order, translate } = this.props;
 		const tax = getOrderFeeTax( order, item.id );
 		if ( item.total <= 0 ) {
@@ -258,8 +257,8 @@ class OrderDetailsTable extends Component {
 		return (
 			<div>
 				<Table className={ tableClasses } header={ this.renderTableHeader() }>
-					{ order.line_items.map( this.renderOrderItems ) }
-					{ order.fee_lines.map( this.renderOrderFees ) }
+					{ order.line_items.map( this.renderOrderItem ) }
+					{ order.fee_lines.map( this.renderOrderFee ) }
 				</Table>
 
 				<div className={ totalsClasses }>

--- a/client/extensions/woocommerce/app/order/order-details/table.js
+++ b/client/extensions/woocommerce/app/order/order-details/table.js
@@ -30,6 +30,7 @@ import {
 	getOrderTotal,
 } from 'woocommerce/lib/order-values/totals';
 import OrderTotalRow from './row-total';
+import ScreenReaderText from 'components/screen-reader-text';
 import Table from 'woocommerce/components/table';
 import TableRow from 'woocommerce/components/table/table-row';
 import TableItem from 'woocommerce/components/table/table-item';
@@ -88,7 +89,7 @@ class OrderDetailsTable extends Component {
 				</TableItem>
 				{ isEditing && (
 					<TableItem isHeader className="order-details__item-delete">
-						{ translate( 'Delete' ) }
+						<ScreenReaderText>{ translate( 'Delete' ) }</ScreenReaderText>
 					</TableItem>
 				) }
 			</TableRow>

--- a/client/extensions/woocommerce/app/order/order-details/table.js
+++ b/client/extensions/woocommerce/app/order/order-details/table.js
@@ -237,7 +237,7 @@ class OrderDetailsTable extends Component {
 		const { translate } = this.props;
 		return (
 			<FormSettingExplanation>
-				{ translate( 'If applicable, taxes will be applied or updated after saving.' ) }
+				{ translate( 'If applicable, taxes will be updated after saving.' ) }
 			</FormSettingExplanation>
 		);
 	};

--- a/client/extensions/woocommerce/app/order/order-payment/table.js
+++ b/client/extensions/woocommerce/app/order/order-payment/table.js
@@ -214,7 +214,7 @@ class OrderRefundTable extends Component {
 					{ order.fee_lines.map( this.renderOrderFees ) }
 				</Table>
 
-				<div className={ totalsClasses }>
+				<Table className={ totalsClasses } compact>
 					<OrderTotalRow
 						currency={ order.currency }
 						label={ translate( 'Discount' ) }
@@ -248,7 +248,7 @@ class OrderRefundTable extends Component {
 							showTax={ showTax }
 						/>
 					) }
-				</div>
+				</Table>
 			</div>
 		);
 	}


### PR DESCRIPTION
See #15681 This PR builds on #19047 to add a delete button to each line item on an order. Visually I think this needs work, since now all the totals are misaligned:

![delete-items](https://user-images.githubusercontent.com/541093/31842292-7f0cc41e-b5bb-11e7-82b9-a162cfc99706.png)

It is possible to delete everything from an order & save an "empty" order, but I don't think we need to do anything about this _right now_. It just looks strange:

<img width="739" alt="no-products" src="https://user-images.githubusercontent.com/541093/31837907-97fe27e6-b5a8-11e7-8f8f-c3bcab3485df.png">

**To test**

- View an order, click Edit Order
- Each line item & fee should have a delete button
- You can click the delete button to remove the item
- After clicking Save, your order no longer has the item(s) you removed
- You can verify this by looking at the order in wp-admin too
