### PR TITLE
Remove MailChimp Start setup wizard.

### DIFF
--- a/client/extensions/woocommerce/app/settings/email/mailchimp/index.js
+++ b/client/extensions/woocommerce/app/settings/email/mailchimp/index.js
@@ -67,7 +67,6 @@ class MailChimp extends React.Component {
 				{ mailChimpIsReady &&
 					<MailChimpDashboard
 						siteId={ siteId }
-						onClick={ this.startWizard }
 						wizardCompleted={ this.state.wizardCompleted }
 						onNoticeExit={ this.closeSetupFinishNotice } /> }
 				{ setupWizardStarted &&

--- a/client/extensions/woocommerce/app/settings/email/mailchimp/mailchimp_dashboard.js
+++ b/client/extensions/woocommerce/app/settings/email/mailchimp/mailchimp_dashboard.js
@@ -263,9 +263,6 @@ class MailChimpDashboard extends React.Component {
 							isSaving={ this.props.isSaving }
 							oldCheckbox={ this.props.settings.mailchimp_checkbox_defaults } />
 					</div>
-					<Button className="mailchimp__getting-started-button" onClick={ this.props.onClick }>
-						{ translate( 'Start setup wizard.' ) }
-					</Button>
 				</Card>
 			</div>
 		);


### PR DESCRIPTION
### Information

Removing The Start setup wizard from MailChimp Dashboard. 
To re-start the wizard you can use following url 
_https://wordpress.com/store/settings/email/site-name/wizard_