### PR TITLE
WIP: Data Layer - Generic API data system

### DIFF
--- a/client/state/api-data/index.js
+++ b/client/state/api-data/index.js
@@ -1,0 +1,175 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { bindActionCreators, connect } from 'react-redux';
+import { get, identity, mapValues } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { http } from 'state/data-layer/wpcom-http/actions';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
+import { http as rawHttp } from 'state/http/actions';
+
+export const dataTypes = {
+	GEO: {
+		fetch: () => rawHttp( { method: 'GET', url: 'https://public-api.wordpress.com/geo/' } ),
+		dataPath: null,
+	},
+	POST: {
+		fetch: ( { siteId, postId } ) =>
+			http( { method: 'GET', apiVersion: '1.2', path: `/sites/${ siteId }/posts/${ postId }` } ),
+		dataPath: ( { siteId, postId } ) => [ siteId, postId ],
+	},
+};
+
+export const apiConnector = ( state, dispatch ) => ( apiType, id ) => {
+	if ( ! dataTypes.hasOwnProperty( apiType ) ) {
+		return null;
+	}
+
+	dispatch( { type: 'API_DATA_REQUEST', apiType, id } );
+
+	const { dataPath } = dataTypes[ apiType ];
+
+	return get( state, dataPath( id ) );
+};
+
+const isRequesting = state => ( type, id ) =>
+	get( state, dataTypes[ type ].dataPath( id ) )[ 0 ] === 'fetching';
+
+const didRequestFail = state => ( type, id ) =>
+	get( state, dataTypes[ type ].dataPath( id ) )[ 0 ] === 'failure';
+
+const lastUpdate = state => ( type, id ) => get( state, dataTypes[ type ].dataPath( id ) )[ 1 ];
+
+export const connectWithApi = (
+	mapStateToProps,
+	mapDispatchToProps,
+	mergeProps,
+	options
+) => Component => {
+	const stateMapper = ( state, ownProps ) => ( {
+		...mapStateToProps( state, ownProps ),
+		stolenState: state,
+	} );
+
+	const dispatchMapper =
+		'function' === typeof mapDispatchToProps
+			? ( dispatch, ownProps ) =>
+					Object.assign( {}, mapDispatchToProps( dispatch, ownProps ), {
+						stolenDispatch: dispatch,
+					} )
+			: dispatch =>
+					Object.assign( {}, bindActionCreators( mapDispatchToProps, dispatch ), {
+						stolenDispatch: dispatch,
+					} );
+
+	const apiMapper = props => {
+		const { stolenDispatch, stolenState, apiData } = props;
+
+		const connector = apiConnector( stolenState, stolenDispatch );
+
+		return mapValues( apiData, ( [ type, id ] ) => connector( type, id ) );
+	};
+
+	const propMerger = ( s, d, ownProps ) => {
+		const { stolenState, ...stateProps } = s;
+		const { stolenDispatch, ...dispatchProps } = d;
+
+		const baseProps =
+			'function' === typeof mergeProps
+				? mergeProps( stateProps, dispatchProps, ownProps )
+				: { ...ownProps, ...stateProps, ...dispatchProps };
+
+		return {
+			...baseProps,
+			...apiMapper( stolenState, stolenDispatch, baseProps ),
+			isRequesting: isRequesting( stolenState ),
+			didRequestFail: didRequestFail( stolenState ),
+			lastUpdate: lastUpdate( stolenState ),
+		};
+	};
+
+	return connect( stateMapper, dispatchMapper, propMerger, options )( Component );
+};
+
+const itemReducer = ( state = null, { data, error, apiState } ) => {
+	const [ , , oldData ] = state;
+
+	switch ( apiState ) {
+		case 'fetching':
+			return [ 'fetching', Date.now() ];
+
+		case 'success':
+			return [ 'loaded', Date.now(), data ];
+
+		case 'failure':
+			return [ 'failed', Date.now(), oldData, error ];
+	}
+
+	return state;
+};
+
+const reducer = ( state = {}, { type, apiType, id, status, data, error, progress } ) => {
+	if ( type !== 'API_DATA_UPDATE' ) {
+		return state;
+	}
+
+	const { dataPath } = dataTypes[ apiType ];
+	const path = dataPath( id );
+
+	return update(
+		state,
+		path,
+		itemReducer( get( state, path ), { status, data, error, progress } )
+	);
+};
+
+const makeRequestHandler = () => {
+	const fetcher = ( { dispatch, getState }, { apiType, id } ) => {
+		const lastUpdated = lastUpdate( getState() )( apiType, id );
+		const { fetch, fresherThan = Infinity } = dataTypes[ apiType ];
+
+		const requestAction = { type: 'API_DATA_REQUEST', apiType, id };
+		const HTTP_BASE = {
+			onSuccess: requestAction,
+			onFailure: requestAction,
+			onProgress: requestAction,
+		};
+
+		if ( Date.now() - lastUpdated > fresherThan ) {
+			dispatch( { ...fetch( id ), ...HTTP_BASE } );
+		}
+	};
+
+	const onFailure = ( { dispatch }, { apiType }, error ) =>
+		dispatch( { type: 'API_DATA_UPDATE', apiType, status: 'failure', error } );
+
+	const onSuccess = ( store, action, data ) => {
+		const { dispatch } = store;
+		const { apiType } = action;
+		const { fromApi = identity } = dataTypes[ apiType ];
+
+		try {
+			return dispatch( {
+				type: 'API_DATA_UPDATE',
+				apiType,
+				status: 'success',
+				data: fromApi( data ),
+			} );
+		} catch ( e ) {
+			return onFailure( store, action, e );
+		}
+	};
+
+	const onProgress = ( { dispatch }, { apiType }, progress ) =>
+		dispatch( { type: 'API_DATA_UPDATE', apiType, status: 'progress', progress } );
+
+	return dispatchRequest( fetcher, onSuccess, onFailure, { onProgress } );
+};
+
+export const middleware = {
+	API_DATA_REQUEST: [ makeRequestHandler() ],
+};


### PR DESCRIPTION
**Quick highlights**
 - Add data from an API endpoint in 5-10 lines of code
 - Reduce size of data layer and network code by _ripping it out_
 - Freshness, request status, "static typing" data models
 - Declarative data needs without query components

**Current state of this PR**
This PR is in the _doodle_ state where no code is expected to be
run and it's more of a shared scratchpad for discussing the ideas.
Expect it to be full of holes.

**Questions**
 - Dynamic state paths are tricky because the knowledge we have to _request_ data may be different than what we get when _receiving_ data.
 - State retrieval is easy because we can `get()` it, but `set()` mutates. We need to build an immutable updater that can take a dynamic or stringy path and return a new object with that deep property updated. We may consider some kind of DSL such as React's `immutability-helper` uses or consider requiring a function of some kind.
 - This kind of prevents splitting separate data types when they come from one endpoint. However, the point of "shoving" is that we have already been neglecting these kinds of relationships in our state code.
 - As usual, I think much more about _getting_ data than _updating_ it. We should be able to plainly update data here by switching to a `POST` and submitting the resource in question, but I could use some input on how to make this work well.

**Running Idea**

Imagine you are displaying a post. You can require the data through `connect()` without changing anything but the version of `connect()`:

```js
import { connect } from 'state/api-data';

const Post = ( 
	author: { displayName },
	isLoading,
	post: { title, content },
	siteId,
	postId,
) => (
	<div>
		<h1>{ title }</h1>
		<h2>{ displayName }</h2>
		{ isLoading( 'POST', { siteId, postId } )
			? <Placeholder />
			: <div>{ content }</div>
		}
	</div>
);

export default connect( ( state, { userId, siteId, postId } ) => ( {
	apiData: {
		author: [ 'WP_USER', userId ],
		post: [ 'POST', { siteId, postId }, {
			fresherThan: MINUTE_IN_SECONDS, // overwrite default options
			forceUpdates: true, // keep polling even when we haven't re-rendered
		} ],
	},
	siteName: getSelectedSite( state, siteId ).title,
} ) )( Post );
```

In this component Calypso will automatically make sure that the requested information is requested from the network and kept up-to-date based on some expiry/freshness data specified in the `api-data` data type definitions. What does that look like?

```js
const postTypes = {
	POST: {
		// creates an HTTP/WP_HTTP action to fetch the data
		// no need to provide `onSuccess` and friends
		fetch: ( { siteId, postId } ) => http( {
			method: 'GET',
			apiVersion: '1.2',
			path: `/sites/${ siteId }/posts/${ postId }`
		} ),

		// where in the apiData state tree this stuff lives
		// lodash like?
		dataPath: ( { siteId, postId } ) => `${ siteId }.${ postId }`,
	},
	POSTS: {
		fetch: siteId => http( {
			method: 'GET',
			apiVersion: '1.2',
			path: `/sites/${ siteId }/posts`
		} ),
		dataPath: siteId => [ siteId ],
		whenMissing: DO_NOT_REMOVE,
	},
	…
};
```

Of course, we have many different options available to us for additional stuff like freshness and what to do when we get a collection of things and what to do when items from missing from newer API responses that were already in state etc… all of these are details I think will be easy to add as we better understand our needs.

> This system heavily relies on the foundation which the data layer has established for decoupling network calls from their fulfillment and for separating requests of data with the actual fetching of that data.

---

A while back in a discussion with @gziolo I tossed around an idea for
dynamically creating the code needed to "shove" data from an API request
into Redux state. The purpose of the conversation was to discuss the
growing bulk of code doing nothing more than "shoving." While I think
that this practice of "shoving" is missing out on many advantages that
Redux has to offer, the more I dove into this hypothetical system for
interacting with "API data" the more I realized we could have real
pragmatic benefits from building it out:

 - Significantly less code for adding data from new API endpoints
 - The ability to declaratively list data needs at the UI level without
   query components
 - A common and standardized way of interacting with remote data
 - Strongly-typed data models

So in time I drafted an API spec for how I would like to interact with
such a system and doodled the following snippet:

```js
const apiTypes = {
  [ GEO ]: [ apiDump(
    // creates the request object
    () => rawHttp( { path: 'public-api.wordpress.com/geo' } ),

    // base path for sub-tree (top-level state)
    '',

    // array of pairs of sub-paths and values to inject
    // will end up at 'state.geo'
    ( { geo } ) => [ [ 'geo', geo ] ],

    // optional parameters
    {
      fresherThan: DAY_IN_SECONDS,
      onFailure: () => errorNotice( translate(
        'Could not fetch geolocation information, sorry.'
      ) ),
    }
  ) ],

  [ ZORPS ]: [ apiDump(
    // creates the request object
    ( { siteId } ) => http( { path: `​/sites/${ siteId }/zorps`, apiVersion: 'v1', method: 'GET' } ),

    // base path for sub-tree
    'misc.zorps',

    // array of pairs of sub-paths and values to inject
    // will end up at 'state.misc.zorps[ zorp.id ]'
    ( { zorps } ) => zorps.map( zorp => [ zorp.id, zorp ] ),
  ) ],
}

// use it
const geo = apiData( GEO );
const zorp = apiData( ZORPS, { id: zorpId } );

const isRequestingGeo = isApiRequesting( GEO );
const hasValidZorps = didApiFail( ZORPS );

dispatch( requestApiData( GEO ) );
dispatch( requestApiData( ZORPS, { siteId } ) );
```

This "doodle" demonstrates one way we could tell Calypso about the new
types of data we're connecting (`apiTypes`), how to access that data
from a UI component (`apiData()`), how to determine meta informationa
about the data (`isApiRequesting()`, `didApiFail()`), and how to request
the data (`requestApiData()`).

Since the time I wrote the doodle the ideas have been stewing in my head
and I decided that it should probably be "mandatory" to provide a type
of explicit, whitelisted, schema for the API responses so that we can
have an official definition of the type and shape of the data we're
sucking into the application.

As I started writing up this PR (frankly another code doodling session)
I made some further refinements and discovered some additional questions
that we'll need to deal with in order to make this happen.

Please see the README in the PR for the ongoing explanation and
motivation for this new data system.