### PR TITLE
Disconnect Flow: Submit Survey on Disconnect

### DIFF
--- a/client/my-sites/site-settings/controller.js
+++ b/client/my-sites/site-settings/controller.js
@@ -117,9 +117,10 @@ const controller = {
 	},
 
 	disconnectSiteConfirm( context ) {
+		const { reason, text } = context.query;
 		ReactDom.unmountComponentAtNode( document.getElementById( 'secondary' ) );
 		context.store.dispatch( setSection( null, { hasSidebar: false } ) );
-		renderPage( context, <ConfirmDisconnection /> );
+		renderPage( context, <ConfirmDisconnection reason={ reason } text={ text } /> );
 	},
 
 	startOver( context ) {

--- a/client/my-sites/site-settings/disconnect-site/confirm.jsx
+++ b/client/my-sites/site-settings/disconnect-site/confirm.jsx
@@ -2,9 +2,10 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { flowRight } from 'lodash';
+import { flowRight, get, isArray } from 'lodash';
 import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
@@ -13,39 +14,86 @@ import DisconnectJetpack from 'blocks/disconnect-jetpack';
 import DocumentHead from 'components/data/document-head';
 import FormattedHeader from 'components/formatted-header';
 import Main from 'components/main';
+import enrichedSurveyData from 'components/marketing-survey/cancel-purchase-form/enrichedSurveyData';
+import { submitSurvey } from 'lib/upgrades/actions';
 import Placeholder from 'my-sites/site-settings/placeholder';
 import redirectNonJetpack from 'my-sites/site-settings/redirect-non-jetpack';
-import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
+import { getSelectedSite, getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
+import { getCurrentPlan } from 'state/sites/plans/selectors';
 
-const ConfirmDisconnection = ( { siteId, siteSlug, translate } ) => {
-	if ( ! siteId ) {
-		return <Placeholder />;
+class ConfirmDisconnection extends PureComponent {
+	static propTypes = {
+		reason: PropTypes.string,
+		text: PropTypes.oneOfType( [ PropTypes.string, PropTypes.arrayOf( PropTypes.string ) ] ),
+		// Provided by HOCs
+		moment: PropTypes.func,
+		purchase: PropTypes.object,
+		siteId: PropTypes.number,
+		siteSlug: PropTypes.string,
+		translate: PropTypes.func,
+	};
+
+	submitSurvey = () => {
+		const { moment, purchase, reason, site, siteId, text } = this.props;
+
+		const reasonWhitelist = {
+			'missing-feature': 'didNotInclude',
+			'too-difficult': 'tooHard',
+			'too-expensive': 'onlyNeedFree',
+		};
+
+		const surveyData = {
+			'why-cancel': {
+				response: get( reasonWhitelist, reason ),
+				text: isArray( text ) ? text.join() : text,
+			},
+		};
+
+		submitSurvey(
+			'calypso-disconnect-jetpack',
+			siteId,
+			enrichedSurveyData( surveyData, moment(), site, purchase )
+		);
+	};
+
+	render() {
+		const { siteId, siteSlug, translate } = this.props;
+
+		if ( ! siteId ) {
+			return <Placeholder />;
+		}
+
+		return (
+			<Main className="disconnect-site__confirm">
+				<DocumentHead title={ translate( 'Site Settings' ) } />
+				<FormattedHeader
+					headerText={ translate( 'Confirm Disconnection' ) }
+					subHeaderText={ translate(
+						'Confirm that you want to disconnect your site from WordPress.com.'
+					) }
+				/>
+				<DisconnectJetpack
+					disconnectHref="/stats"
+					isBroken={ false }
+					onDisconnectClick={ this.submitSurvey }
+					showTitle={ false }
+					siteId={ siteId }
+					stayConnectedHref={ '/settings/manage-connection/' + siteSlug }
+				/>
+			</Main>
+		);
 	}
+}
 
-	return (
-		<Main className="disconnect-site__confirm">
-			<DocumentHead title={ translate( 'Site Settings' ) } />
-			<FormattedHeader
-				headerText={ translate( 'Confirm Disconnection' ) }
-				subHeaderText={ translate(
-					'Confirm that you want to disconnect your site from WordPress.com.'
-				) }
-			/>
-			<DisconnectJetpack
-				disconnectHref="/stats"
-				isBroken={ false }
-				showTitle={ false }
-				siteId={ siteId }
-				stayConnectedHref={ '/settings/manage-connection/' + siteSlug }
-			/>
-		</Main>
-	);
-};
-
-const connectComponent = connect( state => ( {
-	siteId: getSelectedSiteId( state ),
-	siteSlug: getSelectedSiteSlug( state ),
-} ) );
+const connectComponent = connect( state => {
+	const siteId = getSelectedSiteId( state );
+	return {
+		purchase: getCurrentPlan( state, siteId ),
+		site: getSelectedSite( state ),
+		siteId,
+		siteSlug: getSelectedSiteSlug( state ),
+	};
+} );
 
 export default flowRight( connectComponent, localize, redirectNonJetpack() )(
 	ConfirmDisconnection

--- a/client/my-sites/site-settings/disconnect-site/missing-feature.jsx
+++ b/client/my-sites/site-settings/disconnect-site/missing-feature.jsx
@@ -60,7 +60,10 @@ class MissingFeature extends PureComponent {
 					<Button
 						disabled={ isEmpty( this.state.tokens ) }
 						href={ addQueryArgs(
-							{ 'missing-features': this.state.tokens.map( this.normalizeToken ) },
+							{
+								reason: 'missing-feature',
+								text: this.state.tokens.map( this.normalizeToken ),
+							},
 							confirmHref
 						) }
 						primary

--- a/client/my-sites/site-settings/disconnect-site/missing-feature.jsx
+++ b/client/my-sites/site-settings/disconnect-site/missing-feature.jsx
@@ -62,7 +62,7 @@ class MissingFeature extends PureComponent {
 						href={ addQueryArgs(
 							{
 								reason: 'missing-feature',
-								text: this.state.tokens.map( this.normalizeToken ),
+								text: this.state.tokens.map( this.normalizeToken ).sort(),
 							},
 							confirmHref
 						) }

--- a/client/my-sites/site-settings/disconnect-site/too-difficult.jsx
+++ b/client/my-sites/site-settings/disconnect-site/too-difficult.jsx
@@ -16,6 +16,7 @@ import SectionHeader from 'components/section-header';
 import { getSitePlanSlug } from 'state/sites/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getPlanClass } from 'lib/plans/constants';
+import { addQueryArgs } from 'lib/url';
 
 function getFeatures( planClass, translate ) {
 	const features = {
@@ -50,7 +51,16 @@ const TooDifficult = ( { confirmHref, features, siteId, translate } ) => (
 		<QuerySitePlans siteId={ siteId } />
 		<SectionHeader label={ translate( 'Which feature or service caused you problems?' ) } />
 		{ map( features, ( label, slug ) => (
-			<CompactCard key={ slug } href={ confirmHref }>
+			<CompactCard
+				key={ slug }
+				href={ addQueryArgs(
+					{
+						reason: 'too-difficult',
+						text: slug,
+					},
+					confirmHref
+				) }
+			>
 				{ label }
 			</CompactCard>
 		) ) }

--- a/client/my-sites/site-settings/disconnect-site/too-expensive.jsx
+++ b/client/my-sites/site-settings/disconnect-site/too-expensive.jsx
@@ -15,6 +15,7 @@ import QuerySitePlans from 'components/data/query-site-plans';
 import { getCurrentPlanPurchaseId } from 'state/selectors';
 import { getSiteSlug } from 'state/sites/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
+import { addQueryArgs } from 'lib/url';
 
 const TooExpensive = ( { confirmHref, planPurchaseId, siteId, siteSlug, translate } ) => {
 	if ( ! siteSlug || ! planPurchaseId ) {
@@ -31,7 +32,9 @@ const TooExpensive = ( { confirmHref, planPurchaseId, siteId, siteSlug, translat
 			<CompactCard href={ `/me/purchases/${ siteSlug }/${ planPurchaseId }` }>
 				{ translate( 'Manage your purchases' ) }
 			</CompactCard>
-			<CompactCard href={ confirmHref }>{ translate( 'Proceed to disconnect' ) }</CompactCard>
+			<CompactCard href={ addQueryArgs( { reason: 'too-expensive' }, confirmHref ) }>
+				{ translate( 'Proceed to disconnect' ) }
+			</CompactCard>
 		</div>
 	);
 };


### PR DESCRIPTION
Use information gathered from survey steps to submit the 'Marketing Survey', which are passed as query args to the confirmation page.

This re-uses code from and is modelled after the other 'Marketing Survey' that you're asked to complete when you remove a plan via `/plans/my-plan/:site` > 'Manage Purchases' > 'Remove (plan name)'. For the required survey object layout, see https://github.com/Automattic/wp-calypso/blob/2fae5c0f96db3a30e9d2ead2efa90652d76b3aaa/client/me/purchases/remove-purchase/index.jsx#L167-L178

Since the Disconnect Flow survey has different steps (most notably no `next-adventure` and `what-better` questions), we aren't populating all fields here.

Note that this PR also normalizes the reasons. I picked names like `missing-feature`, `too-difficult`, and `too-expensive` for the routes and components since those seemed more semantic, but the marketing survey has already established `didNotInclude`, `tooHard`, and `onlyNeedFree` instead, so I have to  map to those names.

To test: You might want to use the following patch so you don't actually have to disconnect and reconnect every time:

```diff
diff --git a/client/blocks/disconnect-jetpack/index.jsx b/client/blocks/disconnect-jetpack/index.jsx
index 242e8f3..5191ecd 100644
--- a/client/blocks/disconnect-jetpack/index.jsx
+++ b/client/blocks/disconnect-jetpack/index.jsx
@@ -177,7 +177,7 @@ class DisconnectJetpack extends PureComponent {
                        }
                );
 
-               disconnectSite( siteId ).then(
+               /*disconnectSite( siteId ).then(
                        () => {
                                // Removing the domain from a domain-only site results
                                // in the site being deleted entirely. We need to call
@@ -198,7 +198,7 @@ class DisconnectJetpack extends PureComponent {
                                );
                                recordGAEvent( 'Jetpack', 'Failed Disconnected Site' );
                        }
-               );
+               );*/
        };
 
        render() {
diff --git a/client/my-sites/site-settings/disconnect-site/confirm.jsx b/client/my-sites/site-settings/disconnect-site/confirm.jsx
index 7609acd..1fbb038 100644
--- a/client/my-sites/site-settings/disconnect-site/confirm.jsx
+++ b/client/my-sites/site-settings/disconnect-site/confirm.jsx
@@ -49,11 +49,13 @@ class ConfirmDisconnection extends PureComponent {
                        },
                };
 
-               submitSurvey(
+               console.log( enrichedSurveyData( surveyData, moment(), site, purchase ) );
+
+               /*submitSurvey(
                        'calypso-disconnect-jetpack',
                        siteId,
                        enrichedSurveyData( surveyData, moment(), site, purchase )
-               );
+               );*/
        };
 
        render() {

```



* Start at `/settings/disconnect-site/:site`
* Follow thru the flow -- be sure to cover each option once. 
* At the confirmation step, click the red 'Disconnect' button.
* Verify in the dev console that the survey data that would be submitted match what you specified in the survey.
* Make sure to test at least once _without_ the above patch; since `submitSurvey` isn't a Redux but a Flux action, watch the Network tab to make sure your data are actually sent.

cc @bubel for review of the data we're sending