### PR TITLE
DevDocs: fix sidebar layout for logged out users

### DIFF
--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -17,12 +17,15 @@ import { getSection } from 'state/ui/selectors';
 import OauthClientMasterbar from 'layout/masterbar/oauth-client';
 import { getCurrentOAuth2Client, showOAuth2Layout } from 'state/ui/oauth2-clients/selectors';
 
+// Returns true if given section should display sidebar for logged out users.
+const hasSidebar = sectionName => sectionName === 'devdocs';
+
 const LayoutLoggedOut = ( { oauth2Client, primary, section, redirectUri, useOAuth2Layout } ) => {
 	const classes = {
 		[ 'is-group-' + section.group ]: !! section,
 		[ 'is-section-' + section.name ]: !! section,
 		'focus-content': true,
-		'has-no-sidebar': true, // Logged-out never has a sidebar
+		'has-no-sidebar': ! hasSidebar( section.name ),
 		'wp-singletree-layout': !! primary,
 	};
 

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -8,6 +8,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
+import { includes } from 'lodash';
 
 /**
  * Internal dependencies
@@ -18,14 +19,21 @@ import OauthClientMasterbar from 'layout/masterbar/oauth-client';
 import { getCurrentOAuth2Client, showOAuth2Layout } from 'state/ui/oauth2-clients/selectors';
 
 // Returns true if given section should display sidebar for logged out users.
-const hasSidebar = sectionName => sectionName === 'devdocs';
+const hasSidebar = section => {
+	if ( section.name === 'devdocs' ) {
+		// Devdocs should always display a sidebar, except for landing page.
+		return ! includes( section.paths, '/devdocs/start' );
+	}
+
+	return false;
+};
 
 const LayoutLoggedOut = ( { oauth2Client, primary, section, redirectUri, useOAuth2Layout } ) => {
 	const classes = {
 		[ 'is-group-' + section.group ]: !! section,
 		[ 'is-section-' + section.name ]: !! section,
 		'focus-content': true,
-		'has-no-sidebar': ! hasSidebar( section.name ),
+		'has-no-sidebar': ! hasSidebar( section ),
 		'wp-singletree-layout': !! primary,
 	};
 


### PR DESCRIPTION
Fixes #8789, #15831
Related: #8815, #8454, #14812

The page layout is broken when viewing Calypso devdocs while logged out:

<img src="https://user-images.githubusercontent.com/253067/27835736-2efe526c-60d4-11e7-86e7-b114cfaf52c6.png">