### PR TITLE
Fix theme showcase tracks events

### DIFF
--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -67,6 +67,7 @@ class ThemesSelection extends Component {
 			search_term: search_term || null,
 			search_taxonomies,
 			theme: theme.id,
+			free_or_premium: theme.price ? 'premium' : 'free',
 			results_rank: resultsRank + 1,
 			results: themes.map( property( 'id' ) ).join(),
 			page_number: query.page,

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -7,7 +7,7 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { compact, includes, isEqual, property, snakeCase } from 'lodash';
+import { compact, find, includes, isEqual, property, snakeCase } from 'lodash';
 
 /**
  * Internal dependencies
@@ -86,9 +86,14 @@ class ThemesSelection extends Component {
 	}
 
 	onScreenshotClick = ( theme, resultsRank ) => {
+		const themes = this.props.themes;
 		trackClick( 'theme', 'screenshot' );
 		if ( ! this.props.isThemeActive( theme ) ) {
-			this.recordSearchResultsClick( theme, resultsRank, 'screenshot_info' );
+			this.recordSearchResultsClick(
+				find( themes, t => t.id === theme ),
+				resultsRank,
+				'screenshot_info'
+			);
 		}
 		this.props.onScreenshotClick && this.props.onScreenshotClick( theme );
 	};


### PR DESCRIPTION
The tracks event fired when a user clicks on the screenshot of a theme (to open the theme page for that theme) was not correctly recording the theme id.

This PR also adds a `free_or_premium` attribute to the event.

# Testing

- browse to `/themes/<site>`
- open a js console
- enable tracks debugging with `localStorage.setItem('debug', 'calypso:analytics:tracks');` and refresh
- click on the screenshot thumbnail for a theme
- verify that the `theme` and `free_or_premium` attributes are correctly populated