### PR TITLE
Editor: Prevent navigation to the dropped file outside of the zone, fixes #18463

### DIFF
--- a/client/components/drop-zone/index.jsx
+++ b/client/components/drop-zone/index.jsx
@@ -196,6 +196,10 @@ export class DropZone extends React.Component {
 
 		this.resetDragState();
 
+		// Regardless of whether or not files are dropped in the zone,
+		// prevent the browser default action, which navigates to the file.
+		event.preventDefault();
+
 		if (
 			! this.props.fullScreen &&
 			! ReactDom.findDOMNode( this.refs.zone ).contains( event.target )
@@ -214,7 +218,6 @@ export class DropZone extends React.Component {
 		}
 
 		event.stopPropagation();
-		event.preventDefault();
 	};
 
 	renderContent = () => {


### PR DESCRIPTION
Fixes #18463. This is fortunately trivial enough to be fixed by moving a line.

I don't see any tests checking whether or not `preventDefault()` should be called; let me know if I should add that.