### PR TITLE
Comments: Align the comments architecture with posts and pages.

### DIFF
--- a/client/components/section-nav/index.jsx
+++ b/client/components/section-nav/index.jsx
@@ -12,7 +12,7 @@ import { isEqual, includes } from 'lodash';
 /**
  * Internal Dependencies
  */
-import CommentNavigationTab from 'my-sites/comments/comment-navigation/comment-navigation-tab';
+import CommentNavigationTab from 'my-sites/comments/comments-navigation/comments-navigation-tab';
 import NavTabs from 'components/section-nav/tabs';
 import NavItem from 'components/section-nav/item';
 import Search from 'components/search';

--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -27,7 +27,6 @@ import CommentDetail from 'blocks/comment-detail';
 import CommentDetailPlaceholder from 'blocks/comment-detail/comment-detail-placeholder';
 import CommentNavigation from '../comment-navigation';
 import EmptyContent from 'components/empty-content';
-import Pagination from 'components/pagination';
 import QuerySiteCommentsList from 'components/data/query-site-comments-list';
 import QuerySiteCommentsTree from 'components/data/query-site-comments-tree';
 import QuerySiteSettings from 'components/data/query-site-settings';
@@ -479,17 +478,6 @@ export class CommentList extends Component {
 						/>
 					) }
 				</ReactCSSTransitionGroup>
-
-				{ ! showPlaceholder &&
-				! showEmptyContent && (
-					<Pagination
-						key="comment-list-pagination"
-						page={ validPage }
-						pageClick={ this.changePage }
-						perPage={ COMMENTS_PER_PAGE }
-						total={ commentsCount }
-					/>
-				) }
 			</div>
 		);
 	}

--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -8,7 +8,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { each, find, get, map, noop, orderBy, size, slice, uniq } from 'lodash';
+import { each, find, get, map, noop, orderBy, slice, uniq } from 'lodash';
 import ReactCSSTransitionGroup from 'react-transition-group/CSSTransitionGroup';
 
 /**
@@ -25,11 +25,7 @@ import {
 import { removeNotice, successNotice } from 'state/notices/actions';
 import CommentDetail from 'blocks/comment-detail';
 import CommentDetailPlaceholder from 'blocks/comment-detail/comment-detail-placeholder';
-import CommentNavigation from '../comment-navigation';
 import EmptyContent from 'components/empty-content';
-import QuerySiteCommentsList from 'components/data/query-site-comments-list';
-import QuerySiteCommentsTree from 'components/data/query-site-comments-tree';
-import QuerySiteSettings from 'components/data/query-site-settings';
 import { getSiteCommentsTree, getSiteSetting, isCommentsTreeInitialized } from 'state/selectors';
 import {
 	bumpStat,
@@ -149,12 +145,12 @@ export class CommentList extends Component {
 
 	isRequestedPageValid = () => this.getTotalPages() >= this.props.page;
 
-	isSelectedAll = () => {
-		const { page } = this.props;
-		const { selectedComments } = this.state;
-		const visibleComments = this.getCommentsPage( this.getComments(), page );
-		return selectedComments.length && selectedComments.length === visibleComments.length;
-	};
+	// isSelectedAll = () => {
+	// 	const { page } = this.props;
+	// 	const { selectedComments } = this.state;
+	// 	const visibleComments = this.getCommentsPage( this.getComments(), page );
+	// 	return selectedComments.length && selectedComments.length === visibleComments.length;
+	// };
 
 	removeFromPersistedComments = commentId =>
 		this.setState( ( { persistedComments } ) => ( {
@@ -252,12 +248,12 @@ export class CommentList extends Component {
 		}
 	};
 
-	setSortOrder = order => () => {
-		this.setState( {
-			sortOrder: order,
-			page: 1,
-		} );
-	};
+	// setSortOrder = order => () => {
+	// 	this.setState( {
+	// 		sortOrder: order,
+	// 		page: 1,
+	// 	} );
+	// };
 
 	showEditNotice = ( commentId, postId, undoCommentData ) => {
 		const { translate } = this.props;
@@ -398,8 +394,8 @@ export class CommentList extends Component {
 	};
 
 	render() {
-		const { isJetpack, isLoading, page, siteBlacklist, siteId, siteFragment, status } = this.props;
-		const { isBulkEdit, selectedComments } = this.state;
+		const { isJetpack, isLoading, page, siteBlacklist, siteId } = this.props;
+		const { isBulkEdit } = this.state;
 
 		const validPage = this.isRequestedPageValid() ? page : 1;
 
@@ -414,32 +410,6 @@ export class CommentList extends Component {
 
 		return (
 			<div className="comment-list">
-				<QuerySiteSettings siteId={ siteId } />
-
-				{ isJetpack && (
-					<QuerySiteCommentsList
-						number={ 100 }
-						offset={ ( validPage - 1 ) * COMMENTS_PER_PAGE }
-						siteId={ siteId }
-						status={ status }
-					/>
-				) }
-				{ ! isJetpack && <QuerySiteCommentsTree siteId={ siteId } status={ status } /> }
-
-				<CommentNavigation
-					commentsPage={ commentsPage }
-					isBulkEdit={ isBulkEdit }
-					isSelectedAll={ this.isSelectedAll() }
-					selectedCount={ size( selectedComments ) }
-					setBulkStatus={ this.setBulkStatus }
-					setSortOrder={ this.setSortOrder }
-					sortOrder={ this.state.sortOrder }
-					siteId={ siteId }
-					siteFragment={ siteFragment }
-					status={ status }
-					toggleBulkEdit={ this.toggleBulkEdit }
-					toggleSelectAll={ this.toggleSelectAll }
-				/>
 				<ReactCSSTransitionGroup
 					className="comment-list__transition-wrapper"
 					transitionEnterTimeout={ 150 }

--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -42,8 +42,6 @@ export class CommentList extends Component {
 		comments: PropTypes.array,
 		deleteComment: PropTypes.func,
 		likeComment: PropTypes.func,
-		recordChangePage: PropTypes.func,
-		changePage: PropTypes.func,
 		replyComment: PropTypes.func,
 		setBulkStatus: PropTypes.func,
 		siteBlacklist: PropTypes.string,
@@ -54,41 +52,37 @@ export class CommentList extends Component {
 		unlikeComment: PropTypes.func,
 	};
 
-	state = {
-		isBulkEdit: false,
-		// TODO: replace with [] when adding back Bulk Actions
-		lastUndo: null,
-		persistedComments: [],
-		selectedComments: [],
-		sortOrder: NEWEST_FIRST,
-	};
+	// state = {
+	// 	isBulkEdit: false,
+	// 	// TODO: replace with [] when adding back Bulk Actions
+	// 	lastUndo: null,
+	// 	persistedComments: [],
+	// 	selectedComments: [],
+	// 	sortOrder: NEWEST_FIRST,
+	// };
 
-	componentWillReceiveProps( nextProps ) {
-		const { siteId, status, changePage } = this.props;
-		const totalPages = this.getTotalPages();
-		if ( ! this.isRequestedPageValid() && totalPages > 1 ) {
-			return changePage( totalPages );
-		}
+	// componentWillReceiveProps( nextProps ) {
+	// 	const { siteId, status } = this.props;
 
-		if ( siteId !== nextProps.siteId || status !== nextProps.status ) {
-			this.setState( {
-				isBulkEdit: false,
-				lastUndo: null,
-				persistedComments: [],
-				selectedComments: [],
-			} );
-		}
-	}
+	// 	if ( siteId !== nextProps.siteId || status !== nextProps.status ) {
+	// 		this.setState( {
+	// 			isBulkEdit: false,
+	// 			lastUndo: null,
+	// 			persistedComments: [],
+	// 			selectedComments: [],
+	// 		} );
+	// 	}
+	// }
 
-	changePage = page => {
-		const { recordChangePage, changePage } = this.props;
+	// changePage = page => {
+	// 	const { recordChangePage, changePage } = this.props;
 
-		recordChangePage( page, this.getTotalPages() );
+	// 	recordChangePage( page, this.getTotalPages() );
 
-		this.setState( { selectedComments: [] } );
+	// 	this.setState( { selectedComments: [] } );
 
-		changePage( page );
-	};
+	// 	changePage( page );
+	// };
 
 	deleteCommentPermanently = ( commentId, postId ) => {
 		this.props.removeNotice( `comment-notice-${ commentId }` );

--- a/client/my-sites/comments/comments-list/index.jsx
+++ b/client/my-sites/comments/comments-list/index.jsx
@@ -1,0 +1,103 @@
+/**
+ * External dependencies
+ *
+ * @format
+ */
+
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { localize } from 'i18n-calypso';
+import ReactCSSTransitionGroup from 'react-transition-group/CSSTransitionGroup';
+import { map } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import CommentDetail from 'blocks/comment-detail';
+import CommentDetailPlaceholder from 'blocks/comment-detail/comment-detail-placeholder';
+import EmptyContent from 'components/empty-content';
+
+export class CommentsList extends Component {
+	static propTypes = {
+		changeCommentStatus: PropTypes.func,
+		comments: PropTypes.array,
+		deleteComment: PropTypes.func,
+		emptyMessageLine: PropTypes.string,
+		emptyMessageTitle: PropTypes.string,
+		isCommentSelected: PropTypes.func,
+		isJetpack: PropTypes.bool,
+		isBulkEdit: PropTypes.bool,
+		likeComment: PropTypes.func,
+		replyComment: PropTypes.func,
+		setBulkStatus: PropTypes.func,
+		showEmptyContent: PropTypes.bool,
+		showPlaceholder: PropTypes.bool,
+		siteBlacklist: PropTypes.string,
+		siteId: PropTypes.number,
+		status: PropTypes.string,
+		translate: PropTypes.func,
+		undoBulkStatus: PropTypes.func,
+		unlikeComment: PropTypes.func,
+		hasCommentJustMovedBackToCurrentStatus: PropTypes.func,
+	};
+
+	render() {
+		const {
+			comments,
+			emptyMessageLine,
+			emptyMessageTitle,
+			showEmptyContent,
+			showPlaceholder,
+			siteId,
+			siteBlacklist,
+			isCommentSelected,
+			isJetpack,
+			isBulkEdit,
+			hasCommentJustMovedBackToCurrentStatus,
+		} = this.props;
+		return (
+			<div className="comments-list">
+				<ReactCSSTransitionGroup
+					className="comments-list__transition-wrapper"
+					transitionEnterTimeout={ 150 }
+					transitionLeaveTimeout={ 150 }
+					transitionName="comment-list__transition"
+				>
+					{ map( comments, commentId => (
+						<CommentDetail
+							commentId={ commentId }
+							commentIsSelected={ isCommentSelected( commentId ) }
+							deleteCommentPermanently={ this.deleteCommentPermanently }
+							editComment={ this.editComment }
+							isBulkEdit={ isBulkEdit }
+							key={ `comment-${ siteId }-${ commentId }` }
+							refreshCommentData={
+								! isJetpack && ! hasCommentJustMovedBackToCurrentStatus( commentId )
+							}
+							replyComment={ this.replyComment }
+							setCommentStatus={ this.setCommentStatus }
+							siteBlacklist={ siteBlacklist }
+							siteId={ siteId }
+							toggleCommentLike={ this.toggleCommentLike }
+							toggleCommentSelected={ this.toggleCommentSelected }
+						/>
+					) ) }
+
+					{ showPlaceholder && <CommentDetailPlaceholder key="comment-detail-placeholder" /> }
+
+					{ showEmptyContent && (
+						<EmptyContent
+							illustration="/calypso/images/comments/illustration_comments_gray.svg"
+							illustrationWidth={ 150 }
+							key="comment-list-empty"
+							line={ emptyMessageLine }
+							title={ emptyMessageTitle }
+						/>
+					) }
+				</ReactCSSTransitionGroup>
+			</div>
+		);
+	}
+}
+
+export default localize( CommentsList );

--- a/client/my-sites/comments/comments-list/index.jsx
+++ b/client/my-sites/comments/comments-list/index.jsx
@@ -22,6 +22,7 @@ export class CommentsList extends Component {
 		changeCommentStatus: PropTypes.func,
 		comments: PropTypes.array,
 		deleteComment: PropTypes.func,
+		editComment: PropTypes.func,
 		emptyMessageLine: PropTypes.string,
 		emptyMessageTitle: PropTypes.string,
 		isCommentSelected: PropTypes.func,
@@ -44,12 +45,18 @@ export class CommentsList extends Component {
 	render() {
 		const {
 			comments,
+			deleteCommentPermanently,
+			editComment,
 			emptyMessageLine,
 			emptyMessageTitle,
+			replyComment,
+			setCommentStatus,
 			showEmptyContent,
 			showPlaceholder,
 			siteId,
 			siteBlacklist,
+			toggleCommentLike,
+			toggleCommentSelected,
 			isCommentSelected,
 			isJetpack,
 			isBulkEdit,
@@ -67,19 +74,19 @@ export class CommentsList extends Component {
 						<CommentDetail
 							commentId={ commentId }
 							commentIsSelected={ isCommentSelected( commentId ) }
-							deleteCommentPermanently={ this.deleteCommentPermanently }
-							editComment={ this.editComment }
+							deleteCommentPermanently={ deleteCommentPermanently }
+							editComment={ editComment }
 							isBulkEdit={ isBulkEdit }
 							key={ `comment-${ siteId }-${ commentId }` }
 							refreshCommentData={
 								! isJetpack && ! hasCommentJustMovedBackToCurrentStatus( commentId )
 							}
-							replyComment={ this.replyComment }
-							setCommentStatus={ this.setCommentStatus }
+							replyComment={ replyComment }
+							setCommentStatus={ setCommentStatus }
 							siteBlacklist={ siteBlacklist }
 							siteId={ siteId }
-							toggleCommentLike={ this.toggleCommentLike }
-							toggleCommentSelected={ this.toggleCommentSelected }
+							toggleCommentLike={ toggleCommentLike }
+							toggleCommentSelected={ toggleCommentSelected }
 						/>
 					) ) }
 

--- a/client/my-sites/comments/comments-navigation/comments-navigation-tab.jsx
+++ b/client/my-sites/comments/comments-navigation/comments-navigation-tab.jsx
@@ -7,10 +7,14 @@
 import React from 'react';
 import classNames from 'classnames';
 
-export const CommentNavigationTab = ( { children, className, onClick } ) => (
+/**
+ * Internal dependencies
+ */
+
+export const CommentsNavigationTab = ( { children, className, onClick } ) => (
 	<div className={ classNames( 'comment-navigation__tab', className ) } onClick={ onClick }>
 		{ children }
 	</div>
 );
 
-export default CommentNavigationTab;
+export default CommentsNavigationTab;

--- a/client/my-sites/comments/comments-navigation/index.jsx
+++ b/client/my-sites/comments/comments-navigation/index.jsx
@@ -17,7 +17,7 @@ import Button from 'components/button';
 import ButtonGroup from 'components/button-group';
 import ControlItem from 'components/segmented-control/item';
 import Count from 'components/count';
-import CommentNavigationTab from './comment-navigation-tab';
+import CommentsNavigationTab from './comments-navigation-tab';
 import FormCheckbox from 'components/forms/form-checkbox';
 import { isJetpackMinimumVersion, isJetpackSite } from 'state/sites/selectors';
 import NavItem from 'components/section-nav/item';
@@ -39,7 +39,7 @@ const bulkActions = {
 	all: [ 'approve', 'unapprove', 'spam', 'trash' ],
 };
 
-export class CommentNavigation extends Component {
+export class CommentsNavigation extends Component {
 	static defaultProps = {
 		isSelectedAll: false,
 		selectedCount: 0,
@@ -118,12 +118,12 @@ export class CommentNavigation extends Component {
 
 		if ( isBulkEdit ) {
 			return (
-				<SectionNav className="comment-navigation is-bulk-edit">
-					<CommentNavigationTab className="comment-navigation__bulk-count">
+				<SectionNav className="comments-navigation is-bulk-edit">
+					<CommentsNavigationTab className="comments-navigation__bulk-count">
 						<FormCheckbox checked={ isSelectedAll } onChange={ this.toggleSelectAll } />
 						<Count count={ selectedCount } />
-					</CommentNavigationTab>
-					<CommentNavigationTab className="comment-navigation__actions">
+					</CommentsNavigationTab>
+					<CommentsNavigationTab className="comments-navigation__actions">
 						<ButtonGroup>
 							{ this.statusHasAction( 'approve' ) && (
 								<Button
@@ -176,18 +176,18 @@ export class CommentNavigation extends Component {
 								</Button>
 							) }
 						</ButtonGroup>
-					</CommentNavigationTab>
-					<CommentNavigationTab className="comment-navigation__close-bulk">
+					</CommentsNavigationTab>
+					<CommentsNavigationTab className="comments-navigation__close-bulk">
 						<a onClick={ toggleBulkEdit }>
 							<Gridicon icon="cross" />
 						</a>
-					</CommentNavigationTab>
+					</CommentsNavigationTab>
 				</SectionNav>
 			);
 		}
 
 		return (
-			<SectionNav className="comment-navigation" selectedText={ navItems[ queryStatus ].label }>
+			<SectionNav className="comments-navigation" selectedText={ navItems[ queryStatus ].label }>
 				<NavTabs selectedText={ navItems[ queryStatus ].label }>
 					{ map( navItems, ( { label }, status ) => (
 						<NavItem
@@ -201,10 +201,10 @@ export class CommentNavigation extends Component {
 					) ) }
 				</NavTabs>
 
-				<CommentNavigationTab className="comment-navigation__actions comment-navigation__open-bulk">
+				<CommentsNavigationTab className="comments-navigation__actions comments-navigation__open-bulk">
 					{ isEnabled( 'comments/management/sorting' ) &&
 					isCommentsTreeSupported && (
-						<SegmentedControl compact className="comment-navigation__sort-buttons">
+						<SegmentedControl compact className="comments-navigation__sort-buttons">
 							<ControlItem
 								onClick={ setSortOrder( NEWEST_FIRST ) }
 								selected={ sortOrder === NEWEST_FIRST }
@@ -227,7 +227,7 @@ export class CommentNavigation extends Component {
 					<Button compact onClick={ toggleBulkEdit }>
 						{ translate( 'Bulk Edit' ) }
 					</Button>
-				</CommentNavigationTab>
+				</CommentsNavigationTab>
 
 				{ hasSearch && (
 					<Search delaySearch fitsContainer initialValue={ query } onSearch={ doSearch } pinned />
@@ -266,5 +266,5 @@ const mapDispatchToProps = {
 };
 
 export default connect( mapStateToProps, mapDispatchToProps )(
-	localize( UrlSearch( CommentNavigation ) )
+	localize( UrlSearch( CommentsNavigation ) )
 );

--- a/client/my-sites/comments/controller.js
+++ b/client/my-sites/comments/controller.js
@@ -10,7 +10,7 @@ import { each, includes, startsWith } from 'lodash';
 /**
  * Internal dependencies
  */
-import CommentsManagement from './main';
+import Comments from './main';
 import route, { addQueryArgs } from 'lib/route';
 import { removeNotice } from 'state/notices/actions';
 import { getNotices } from 'state/notices/selectors';
@@ -64,7 +64,7 @@ export const comments = function( context ) {
 	}
 
 	renderWithReduxStore(
-		<CommentsManagement
+		<Comments
 			basePath={ context.path }
 			page={ pageNumber }
 			changePage={ changePage( status, siteFragment ) }

--- a/client/my-sites/comments/main.jsx
+++ b/client/my-sites/comments/main.jsx
@@ -10,22 +10,36 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import {
+	changeCommentStatus,
+	deleteComment,
+	editComment,
+	likeComment,
+	replyComment,
+	unlikeComment,
+} from 'state/comments/actions';
 import getSiteId from 'state/selectors/get-site-id';
 import Main from 'components/main';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import Pagination from 'components/pagination';
 import DocumentHead from 'components/data/document-head';
 import CommentsList from './comments-list';
+import { removeNotice, successNotice } from 'state/notices/actions';
 import CommentsNavigation from './comments-navigation';
 import QuerySiteCommentsList from 'components/data/query-site-comments-list';
 import QuerySiteCommentsTree from 'components/data/query-site-comments-tree';
 import QuerySiteSettings from 'components/data/query-site-settings';
-import { get, map, noop, orderBy, slice, size, uniq } from 'lodash';
+import { each, get, map, noop, orderBy, slice, size, uniq } from 'lodash';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import { getSiteCommentsTree, canCurrentUser, isCommentsTreeInitialized } from 'state/selectors';
 import { preventWidows } from 'lib/formatting';
 import EmptyContent from 'components/empty-content';
-import { bumpStat, composeAnalytics, recordTracksEvent } from 'state/analytics/actions';
+import {
+	bumpStat,
+	composeAnalytics,
+	recordTracksEvent,
+	withAnalytics,
+} from 'state/analytics/actions';
 import { COMMENTS_PER_PAGE, NEWEST_FIRST } from './constants';
 
 export class Comments extends Component {
@@ -82,6 +96,19 @@ export class Comments extends Component {
 		changePage( page );
 	};
 
+	deleteCommentPermanently = ( commentId, postId ) => {
+		this.props.removeNotice( `comment-notice-${ commentId }` );
+
+		this.props.deleteComment( commentId, postId );
+	};
+
+	editComment = ( commentId, postId, commentData, undoCommentData, showNotice = true ) => {
+		this.props.editComment( commentId, postId, commentData );
+		if ( showNotice ) {
+			this.showEditNotice( commentId, postId, undoCommentData );
+		}
+	};
+
 	getComments = () => {
 		const comments = uniq( [ ...this.state.persistedComments, ...this.props.comments ] );
 
@@ -131,11 +158,245 @@ export class Comments extends Component {
 		return selectedComments.length && selectedComments.length === visibleComments.length;
 	};
 
+	removeFromPersistedComments = commentId =>
+		this.setState( ( { persistedComments } ) => ( {
+			persistedComments: persistedComments.filter( c => c !== commentId ),
+		} ) );
+
+	replyComment = ( commentText, parentComment ) => {
+		const { translate } = this.props;
+		const { commentId: parentCommentId, postId, status } = parentComment;
+		const alsoApprove = 'approved' !== status;
+
+		this.props.removeNotice( `comment-notice-${ parentCommentId }` );
+
+		const noticeMessage = alsoApprove
+			? translate( 'Comment approved and reply submitted.' )
+			: translate( 'Reply submitted.' );
+
+		const noticeOptions = {
+			duration: 5000,
+			id: `comment-notice-${ parentCommentId }`,
+			isPersistent: true,
+		};
+
+		if ( alsoApprove ) {
+			this.setCommentStatus( parentComment, 'approved', { doPersist: true, showNotice: false } );
+		}
+
+		this.props.successNotice( noticeMessage, noticeOptions );
+		this.props.replyComment( commentText, postId, parentCommentId, { alsoApprove } );
+	};
+
+	setBulkStatus = status => () => {
+		const { status: listStatus } = this.props;
+		this.props.removeNotice( 'comment-notice-bulk' );
+
+		// Only persist comments if they toggle between approved and unapproved
+		const doPersist =
+			( 'approved' === listStatus && 'unapproved' === status ) ||
+			( 'unapproved' === listStatus && 'approved' === status );
+
+		each( this.state.selectedComments, comment => {
+			if ( 'delete' === status ) {
+				this.props.deleteComment( comment.commentId, comment.postId, { showSuccessNotice: false } );
+				return;
+			}
+
+			this.setCommentStatus( comment, status, {
+				isUndo: false,
+				doPersist,
+				showNotice: false,
+			} );
+		} );
+
+		this.showBulkNotice( status );
+
+		this.setState( { isBulkEdit: false, selectedComments: [] } );
+	};
+
+	setCommentStatus = (
+		comment,
+		status,
+		options = { isUndo: false, doPersist: false, showNotice: true }
+	) => {
+		const { commentId, postId, isLiked, status: previousStatus } = comment;
+		const { isUndo, doPersist, showNotice } = options;
+		const alsoUnlikeComment = isLiked && 'approved' !== status;
+
+		if ( isUndo ) {
+			this.setState( { lastUndo: commentId } );
+		} else {
+			this.setState( { lastUndo: null } );
+		}
+
+		if ( doPersist ) {
+			this.updatePersistedComments( commentId, isUndo );
+		} else {
+			this.removeFromPersistedComments( commentId );
+		}
+
+		this.props.removeNotice( `comment-notice-${ commentId }` );
+
+		if ( showNotice ) {
+			this.showNotice( comment, status, { doPersist } );
+		}
+
+		this.props.changeCommentStatus( commentId, postId, status, {
+			alsoUnlike: alsoUnlikeComment,
+			isUndo,
+			previousStatus,
+		} );
+
+		// If the comment is not approved anymore, also remove the like
+		if ( alsoUnlikeComment ) {
+			this.props.unlikeComment( commentId, postId );
+		}
+	};
+
 	setSortOrder = order => () => {
 		this.setState( {
 			sortOrder: order,
 			page: 1,
 		} );
+	};
+
+	showEditNotice = ( commentId, postId, undoCommentData ) => {
+		const { translate } = this.props;
+
+		const message = translate( 'Your comment has been updated.' );
+
+		const noticeOptions = {
+			button: translate( 'Undo' ),
+			duration: 5000,
+			id: `comment-notice-${ commentId }`,
+			isPersistent: true,
+			onClick: () => {
+				this.editComment( commentId, postId, undoCommentData, false );
+				this.props.removeNotice( `comment-notice-${ commentId }` );
+			},
+		};
+
+		this.props.successNotice( message, noticeOptions );
+	};
+
+	showBulkNotice = newStatus => {
+		const { translate } = this.props;
+
+		const message = get(
+			{
+				approved: translate( 'All selected comments approved.' ),
+				unapproved: translate( 'All selected comments unapproved.' ),
+				spam: translate( 'All selected comments marked as spam.' ),
+				trash: translate( 'All selected comments moved to trash.' ),
+				delete: translate( 'All selected comments deleted permanently.' ),
+			},
+			newStatus
+		);
+
+		if ( ! message ) {
+			return;
+		}
+
+		const noticeOptions = {
+			duration: 5000,
+			id: 'comment-notice-bulk',
+			isPersistent: true,
+		};
+
+		this.props.successNotice( message, noticeOptions );
+	};
+
+	showNotice = ( comment, newStatus, options = { doPersist: false } ) => {
+		const { translate } = this.props;
+		const { commentId, isLiked: previousIsLiked, postId, status: previousStatus } = comment;
+
+		const message = get(
+			{
+				approved: translate( 'Comment approved.' ),
+				unapproved: translate( 'Comment unapproved.' ),
+				spam: translate( 'Comment marked as spam.' ),
+				trash: translate( 'Comment moved to trash.' ),
+			},
+			newStatus
+		);
+
+		if ( ! message ) {
+			return;
+		}
+
+		const noticeOptions = {
+			button: translate( 'Undo' ),
+			duration: 5000,
+			id: `comment-notice-${ commentId }`,
+			isPersistent: true,
+			onClick: () => {
+				const updatedComment = {
+					...comment,
+					status: newStatus,
+				};
+				this.setCommentStatus( updatedComment, previousStatus, {
+					isUndo: true,
+					doPersist: options.doPersist,
+					showNotice: false,
+				} );
+				if ( previousIsLiked ) {
+					this.props.likeComment( commentId, postId );
+				} else if ( ! previousIsLiked && 'approved' !== previousStatus ) {
+					this.props.unlikeComment( commentId, postId );
+				}
+			},
+		};
+
+		this.props.successNotice( message, noticeOptions );
+	};
+
+	toggleBulkEdit = () => {
+		this.setState( ( { isBulkEdit } ) => ( { isBulkEdit: ! isBulkEdit } ) );
+	};
+
+	toggleCommentLike = comment => {
+		const { commentId, isLiked, postId, status } = comment;
+
+		if ( isLiked ) {
+			this.props.unlikeComment( commentId, postId );
+			return;
+		}
+
+		const alsoApprove = 'unapproved' === status;
+
+		this.props.likeComment( commentId, postId, { alsoApprove } );
+
+		if ( alsoApprove ) {
+			this.props.removeNotice( `comment-notice-${ commentId }` );
+			this.setCommentStatus( comment, 'approved', { doPersist: true, showNotice: true } );
+			this.updatePersistedComments( commentId );
+		}
+	};
+
+	toggleCommentSelected = comment => {
+		if ( this.isCommentSelected( comment.commentId ) ) {
+			return this.setState( ( { selectedComments } ) => ( {
+				selectedComments: selectedComments.filter(
+					( { commentId } ) => comment.commentId !== commentId
+				),
+			} ) );
+		}
+		this.setState( ( { selectedComments } ) => ( {
+			selectedComments: selectedComments.concat( comment ),
+		} ) );
+	};
+
+	toggleSelectAll = selectedComments => this.setState( { selectedComments } );
+
+	updatePersistedComments = ( commentId, isUndo ) => {
+		if ( isUndo ) {
+			this.removeFromPersistedComments( commentId );
+		} else if ( ! this.isCommentPersisted( commentId ) ) {
+			this.setState( ( { persistedComments } ) => ( {
+				persistedComments: persistedComments.concat( commentId ),
+			} ) );
+		}
 	};
 
 	render() {
@@ -207,7 +468,6 @@ export class Comments extends Component {
 					<CommentsList
 						comments={ comments }
 						siteId={ siteId }
-						siteFragment={ siteFragment }
 						status={ status }
 						order={ 'desc' }
 						showEmptyContent={ showEmptyContent }
@@ -218,6 +478,9 @@ export class Comments extends Component {
 						isBulkEdit={ isBulkEdit }
 						isCommentSelected={ this.isCommentSelected }
 						hasCommentJustMovedBackToCurrentStatus={ this.hasCommentJustMovedBackToCurrentStatus }
+						setCommentStatus={ this.setCommentStatus }
+						toggleCommentSelected={ this.toggleCommentSelected }
+						toggleCommentLike={ this.toggleCommentLike }
 					/>
 				) }
 
@@ -249,64 +512,64 @@ const mapStateToProps = ( state, { siteFragment, status } ) => {
 	};
 };
 
-const mapDispatchToProps = dispatch => ( {
-	// changeCommentStatus: (
-	// 	commentId,
-	// 	postId,
-	// 	status,
-	// 	analytics = { alsoUnlike: false, isUndo: false }
-	// ) =>
-	// 	dispatch(
-	// 		withAnalytics(
-	// 			composeAnalytics(
-	// 				recordTracksEvent( 'calypso_comment_management_change_status', {
-	// 					also_unlike: analytics.alsoUnlike,
-	// 					is_undo: analytics.isUndo,
-	// 					previous_status: analytics.previousStatus,
-	// 					status,
-	// 				} ),
-	// 				bumpStat( 'calypso_comment_management', 'comment_status_changed_to_' + status )
-	// 			),
-	// 			changeCommentStatus( siteId, postId, commentId, status )
-	// 		)
-	// 	),
+const mapDispatchToProps = ( dispatch, { siteId } ) => ( {
+	changeCommentStatus: (
+		commentId,
+		postId,
+		status,
+		analytics = { alsoUnlike: false, isUndo: false }
+	) =>
+		dispatch(
+			withAnalytics(
+				composeAnalytics(
+					recordTracksEvent( 'calypso_comment_management_change_status', {
+						also_unlike: analytics.alsoUnlike,
+						is_undo: analytics.isUndo,
+						previous_status: analytics.previousStatus,
+						status,
+					} ),
+					bumpStat( 'calypso_comment_management', 'comment_status_changed_to_' + status )
+				),
+				changeCommentStatus( siteId, postId, commentId, status )
+			)
+		),
 
-	// successNotice: ( text, options ) => dispatch( successNotice( text, options ) ),
+	successNotice: ( text, options ) => dispatch( successNotice( text, options ) ),
 
-	// deleteComment: ( commentId, postId, options = { showSuccessNotice: true } ) =>
-	// 	dispatch(
-	// 		withAnalytics(
-	// 			composeAnalytics(
-	// 				recordTracksEvent( 'calypso_comment_management_delete' ),
-	// 				bumpStat( 'calypso_comment_management', 'comment_deleted' )
-	// 			),
-	// 			deleteComment( siteId, postId, commentId, options )
-	// 		)
-	// 	),
+	deleteComment: ( commentId, postId, options = { showSuccessNotice: true } ) =>
+		dispatch(
+			withAnalytics(
+				composeAnalytics(
+					recordTracksEvent( 'calypso_comment_management_delete' ),
+					bumpStat( 'calypso_comment_management', 'comment_deleted' )
+				),
+				deleteComment( siteId, postId, commentId, options )
+			)
+		),
 
-	// editComment: ( commentId, postId, comment ) =>
-	// 	dispatch(
-	// 		withAnalytics(
-	// 			composeAnalytics(
-	// 				recordTracksEvent( 'calypso_comment_management_edit' ),
-	// 				bumpStat( 'calypso_comment_management', 'comment_updated' )
-	// 			),
-	// 			editComment( siteId, postId, commentId, comment )
-	// 		)
-	// 	),
+	editComment: ( commentId, postId, comment ) =>
+		dispatch(
+			withAnalytics(
+				composeAnalytics(
+					recordTracksEvent( 'calypso_comment_management_edit' ),
+					bumpStat( 'calypso_comment_management', 'comment_updated' )
+				),
+				editComment( siteId, postId, commentId, comment )
+			)
+		),
 
-	// likeComment: ( commentId, postId, analytics = { alsoApprove: false } ) =>
-	// 	dispatch(
-	// 		withAnalytics(
-	// 			composeAnalytics(
-	// 				recordTracksEvent( 'calypso_comment_management_like', {
-	// 					also_approve: analytics.alsoApprove,
-	// 				} ),
-	// 				bumpStat( 'calypso_comment_management', 'comment_liked' )
-	// 			),
-	// 			likeComment( siteId, postId, commentId )
-	// 		)
-	// 	),
+	likeComment: ( commentId, postId, analytics = { alsoApprove: false } ) =>
+		dispatch(
+			withAnalytics(
+				composeAnalytics(
+					recordTracksEvent( 'calypso_comment_management_like', {
+						also_approve: analytics.alsoApprove,
+					} ),
+					bumpStat( 'calypso_comment_management', 'comment_liked' )
+				),
+				likeComment( siteId, postId, commentId )
+			)
+		),
 
 	recordChangePage: ( page, total ) =>
 		dispatch(
@@ -316,34 +579,34 @@ const mapDispatchToProps = dispatch => ( {
 			)
 		),
 
-	// removeNotice: noticeId => dispatch( removeNotice( noticeId ) ),
+	removeNotice: noticeId => dispatch( removeNotice( noticeId ) ),
 
-	// replyComment: ( commentText, postId, parentCommentId, analytics = { alsoApprove: false } ) =>
-	// 	dispatch(
-	// 		withAnalytics(
-	// 			composeAnalytics(
-	// 				recordTracksEvent( 'calypso_comment_management_reply', {
-	// 					also_approve: analytics.alsoApprove,
-	// 				} ),
-	// 				bumpStat( 'calypso_comment_management', 'comment_reply' )
-	// 			),
-	// 			replyComment( commentText, siteId, postId, parentCommentId )
-	// 		)
-	// 	),
+	replyComment: ( commentText, postId, parentCommentId, analytics = { alsoApprove: false } ) =>
+		dispatch(
+			withAnalytics(
+				composeAnalytics(
+					recordTracksEvent( 'calypso_comment_management_reply', {
+						also_approve: analytics.alsoApprove,
+					} ),
+					bumpStat( 'calypso_comment_management', 'comment_reply' )
+				),
+				replyComment( commentText, siteId, postId, parentCommentId )
+			)
+		),
 
 	setBulkStatus: noop,
 	undoBulkStatus: noop,
 
-	// unlikeComment: ( commentId, postId ) =>
-	// 	dispatch(
-	// 		withAnalytics(
-	// 			composeAnalytics(
-	// 				recordTracksEvent( 'calypso_comment_management_unlike' ),
-	// 				bumpStat( 'calypso_comment_management', 'comment_unliked' )
-	// 			),
-	// 			unlikeComment( siteId, postId, commentId )
-	// 		)
-	// 	),
+	unlikeComment: ( commentId, postId ) =>
+		dispatch(
+			withAnalytics(
+				composeAnalytics(
+					recordTracksEvent( 'calypso_comment_management_unlike' ),
+					bumpStat( 'calypso_comment_management', 'comment_unliked' )
+				),
+				unlikeComment( siteId, postId, commentId )
+			)
+		),
 } );
 
 export default connect( mapStateToProps, mapDispatchToProps )( localize( Comments ) );

--- a/client/my-sites/comments/main.jsx
+++ b/client/my-sites/comments/main.jsx
@@ -13,17 +13,24 @@ import { localize } from 'i18n-calypso';
 import getSiteId from 'state/selectors/get-site-id';
 import Main from 'components/main';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
+import Pagination from 'components/pagination';
 import DocumentHead from 'components/data/document-head';
 import CommentList from './comment-list';
+import { map, orderBy, uniq } from 'lodash';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
-import { canCurrentUser } from 'state/selectors';
+import { getSiteCommentsTree, canCurrentUser, isCommentsTreeInitialized } from 'state/selectors';
 import { preventWidows } from 'lib/formatting';
 import EmptyContent from 'components/empty-content';
+import { bumpStat, composeAnalytics, recordTracksEvent } from 'state/analytics/actions';
+import { COMMENTS_PER_PAGE, NEWEST_FIRST } from './constants';
 
-export class CommentsManagement extends Component {
+export class Comments extends Component {
 	static propTypes = {
 		comments: PropTypes.array,
+		isLoading: PropTypes.bool,
 		page: PropTypes.number,
+		recordChangePage: PropTypes.func,
+		changePage: PropTypes.func,
 		showPermissionError: PropTypes.bool,
 		siteId: PropTypes.number,
 		siteFragment: PropTypes.oneOfType( [ PropTypes.string, PropTypes.number ] ),
@@ -36,8 +43,58 @@ export class CommentsManagement extends Component {
 		status: 'all',
 	};
 
+	state = {
+		isBulkEdit: false,
+		// TODO: replace with [] when adding back Bulk Actions
+		lastUndo: null,
+		persistedComments: [],
+		selectedComments: [],
+		sortOrder: NEWEST_FIRST,
+	};
+
+	componentWillReceiveProps( nextProps ) {
+		const { siteId, status, changePage } = this.props;
+		const totalPages = this.getTotalPages();
+		if ( ! this.isRequestedPageValid() && totalPages > 1 ) {
+			return changePage( totalPages );
+		}
+
+		if ( siteId !== nextProps.siteId || status !== nextProps.status ) {
+			this.setState( {
+				isBulkEdit: false,
+				lastUndo: null,
+				persistedComments: [],
+				selectedComments: [],
+			} );
+		}
+	}
+
+	changePage = page => {
+		const { recordChangePage, changePage } = this.props;
+
+		recordChangePage( page, this.getTotalPages() );
+
+		this.setState( { selectedComments: [] } );
+
+		changePage( page );
+	};
+
+	getComments = () => {
+		const comments = uniq( [ ...this.state.persistedComments, ...this.props.comments ] );
+
+		return orderBy( comments, null, this.state.sortOrder );
+	};
+
+	getTotalPages = () =>
+		Math.ceil(
+			( this.props.comments.length + this.state.persistedComments.length ) / COMMENTS_PER_PAGE
+		);
+
+	isRequestedPageValid = () => this.getTotalPages() >= this.props.page;
+
 	render() {
 		const {
+			isLoading,
 			showPermissionError,
 			page,
 			changePage,
@@ -46,6 +103,12 @@ export class CommentsManagement extends Component {
 			status,
 			translate,
 		} = this.props;
+
+		const validPage = this.isRequestedPageValid() ? page : 1;
+		const comments = this.getComments();
+		const commentsCount = comments.length;
+		const showPlaceholder = ( ! siteId || isLoading ) && ! commentsCount;
+		const showEmptyContent = ! commentsCount && ! showPlaceholder;
 
 		return (
 			<Main className="comments" wideLayout>
@@ -73,18 +136,130 @@ export class CommentsManagement extends Component {
 						order={ 'desc' }
 					/>
 				) }
+
+				{ ! showPlaceholder &&
+				! showEmptyContent && (
+					<Pagination
+						key="comment-list-pagination"
+						page={ validPage }
+						pageClick={ this.changePage }
+						perPage={ COMMENTS_PER_PAGE }
+						total={ commentsCount }
+					/>
+				) }
 			</Main>
 		);
 	}
 }
 
-const mapStateToProps = ( state, { siteFragment } ) => {
+const mapStateToProps = ( state, { siteFragment, status } ) => {
 	const siteId = getSiteId( state, siteFragment );
+	const comments = map( getSiteCommentsTree( state, siteId, status ), 'commentId' );
+	const isLoading = ! isCommentsTreeInitialized( state, siteId, status );
 	const canModerateComments = canCurrentUser( state, siteId, 'moderate_comments' );
 	return {
+		comments,
+		isLoading,
 		siteId,
 		showPermissionError: canModerateComments === false,
 	};
 };
 
-export default connect( mapStateToProps )( localize( CommentsManagement ) );
+const mapDispatchToProps = dispatch => ( {
+	// changeCommentStatus: (
+	// 	commentId,
+	// 	postId,
+	// 	status,
+	// 	analytics = { alsoUnlike: false, isUndo: false }
+	// ) =>
+	// 	dispatch(
+	// 		withAnalytics(
+	// 			composeAnalytics(
+	// 				recordTracksEvent( 'calypso_comment_management_change_status', {
+	// 					also_unlike: analytics.alsoUnlike,
+	// 					is_undo: analytics.isUndo,
+	// 					previous_status: analytics.previousStatus,
+	// 					status,
+	// 				} ),
+	// 				bumpStat( 'calypso_comment_management', 'comment_status_changed_to_' + status )
+	// 			),
+	// 			changeCommentStatus( siteId, postId, commentId, status )
+	// 		)
+	// 	),
+
+	// successNotice: ( text, options ) => dispatch( successNotice( text, options ) ),
+
+	// deleteComment: ( commentId, postId, options = { showSuccessNotice: true } ) =>
+	// 	dispatch(
+	// 		withAnalytics(
+	// 			composeAnalytics(
+	// 				recordTracksEvent( 'calypso_comment_management_delete' ),
+	// 				bumpStat( 'calypso_comment_management', 'comment_deleted' )
+	// 			),
+	// 			deleteComment( siteId, postId, commentId, options )
+	// 		)
+	// 	),
+
+	// editComment: ( commentId, postId, comment ) =>
+	// 	dispatch(
+	// 		withAnalytics(
+	// 			composeAnalytics(
+	// 				recordTracksEvent( 'calypso_comment_management_edit' ),
+	// 				bumpStat( 'calypso_comment_management', 'comment_updated' )
+	// 			),
+	// 			editComment( siteId, postId, commentId, comment )
+	// 		)
+	// 	),
+
+	// likeComment: ( commentId, postId, analytics = { alsoApprove: false } ) =>
+	// 	dispatch(
+	// 		withAnalytics(
+	// 			composeAnalytics(
+	// 				recordTracksEvent( 'calypso_comment_management_like', {
+	// 					also_approve: analytics.alsoApprove,
+	// 				} ),
+	// 				bumpStat( 'calypso_comment_management', 'comment_liked' )
+	// 			),
+	// 			likeComment( siteId, postId, commentId )
+	// 		)
+	// 	),
+
+	recordChangePage: ( page, total ) =>
+		dispatch(
+			composeAnalytics(
+				recordTracksEvent( 'calypso_comment_management_change_page', { page, total } ),
+				bumpStat( 'calypso_comment_management', 'change_page' )
+			)
+		),
+
+	// removeNotice: noticeId => dispatch( removeNotice( noticeId ) ),
+
+	// replyComment: ( commentText, postId, parentCommentId, analytics = { alsoApprove: false } ) =>
+	// 	dispatch(
+	// 		withAnalytics(
+	// 			composeAnalytics(
+	// 				recordTracksEvent( 'calypso_comment_management_reply', {
+	// 					also_approve: analytics.alsoApprove,
+	// 				} ),
+	// 				bumpStat( 'calypso_comment_management', 'comment_reply' )
+	// 			),
+	// 			replyComment( commentText, siteId, postId, parentCommentId )
+	// 		)
+	// 	),
+
+	// setBulkStatus: noop,
+	// undoBulkStatus: noop,
+
+	// unlikeComment: ( commentId, postId ) =>
+	// 	dispatch(
+	// 		withAnalytics(
+	// 			composeAnalytics(
+	// 				recordTracksEvent( 'calypso_comment_management_unlike' ),
+	// 				bumpStat( 'calypso_comment_management', 'comment_unliked' )
+	// 			),
+	// 			unlikeComment( siteId, postId, commentId )
+	// 		)
+	// 	),
+} );
+
+export default connect( mapStateToProps, mapDispatchToProps )( localize( Comments ) );

--- a/client/my-sites/comments/style.scss
+++ b/client/my-sites/comments/style.scss
@@ -1,5 +1,6 @@
-.comment-navigation {
-	@include breakpoint( "<480px" ) {
+/** @format */
+.comments-navigation {
+	@include breakpoint( '<480px' ) {
 		.section-nav__mobile-header:after {
 			padding-left: 8px;
 		}
@@ -8,7 +9,7 @@
 			width: auto;
 		}
 
-		.comment-navigation__open-bulk {
+		.comments-navigation__open-bulk {
 			padding-top: 9px;
 			position: absolute;
 			right: 0;
@@ -17,19 +18,19 @@
 	}
 }
 
-.comment-navigation.is-bulk-edit {
+.comments-navigation.is-bulk-edit {
 	padding-right: 0;
 
-	@include breakpoint( "<480px" ) {
+	@include breakpoint( '<480px' ) {
 		.section-nav__mobile-header {
 			display: none;
 		}
 
-		.comment-navigation__bulk-count {
-			width: calc( 100% - 70px );
+		.comments-navigation__bulk-count {
+			width: calc(100% - 70px);
 		}
 
-		.comment-navigation__close-bulk {
+		.comments-navigation__close-bulk {
 			position: absolute;
 			right: 0;
 			top: 3px;
@@ -38,19 +39,19 @@
 	}
 }
 
-.comment-navigation__bulk-count {
+.comments-navigation__bulk-count {
 	display: inline-flex;
 }
 
-.comment-navigation__bulk-count .count {
+.comments-navigation__bulk-count .count {
 	margin-left: 8px;
 }
 
-.comment-navigation__tab {
+.comments-navigation__tab {
 	padding: 16px;
 }
 
-.comment-navigation__actions {
+.comments-navigation__actions {
 	display: flex;
 	padding: 11px 16px;
 
@@ -59,11 +60,11 @@
 	}
 }
 
-.comment-navigation__open-bulk .button {
+.comments-navigation__open-bulk .button {
 	margin-left: 16px;
 }
 
-.comment-navigation__close-bulk {
+.comments-navigation__close-bulk {
 	margin-left: auto;
 	padding: 0;
 	a {
@@ -81,7 +82,7 @@
 	display: none;
 
 	&.comment-list__transition-enter-active {
-		animation: comment-list__transition-enter .15s linear;
+		animation: comment-list__transition-enter 0.15s linear;
 	}
 }
 
@@ -90,7 +91,7 @@
 
 	&.comment-list__transition-leave-active {
 		opacity: 0.01;
-		transition: opacity .15s linear;
+		transition: opacity 0.15s linear;
 	}
 }
 


### PR DESCRIPTION
_WIP for demonstration and discussion of a high-level refactor for comments_

Posts and pages have the same general component structure (with slight naming variations):
```
<Pages>
    <Main>
        <SidebarNavigation>
        <SectionNav>
        <PageList>
```

For comments, we currently have:
```
<CommentsManagement>
    <Main>
        <SidebarNavigation>
        <CommentsList>
            <CommentNavigation>
            <CSSTransitionGroup>
                <CommentDetail>
                ...
            <Pagination>
```

I'd like to propose the following changes to comments to better align all three (posts, pages, and comments):
```
<Comments>
    <Main>
        <SidebarNavigation>
        <CommentsNavigation>
        <CommentsList>
            <CSSTransitionGroup>
                <CommentDetail> // connect()ed
                ...
        <Pagination>
```

Local state would be handled by `<Comments>` (HOC), meaning `<CommentsList>` can become a more typical stateless component just rendering blocks for a list of comments passed to it. We can further factor out the large amount of methods cluttering up `Comments>`, and after work with `CommentsDetail` in #19082, we should be left with a healthy spread of reasonable-sized files performing duties that are easier to understand (both for us, and anyone jumping into this section of the codebase).

See #18988 .