### PR TITLE
Activity Log: update color of icon shown in Rewind confirmation dialog

### DIFF
--- a/client/my-sites/stats/activity-log-confirm-dialog/style.scss
+++ b/client/my-sites/stats/activity-log-confirm-dialog/style.scss
@@ -10,6 +10,9 @@
 		box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ),
 		0 2px 5px lighten( $gray, 20% );
 	}
+	.activity-log-item__activity-icon {
+		background: $blue-medium;
+	}
 }
 
 .activity-log-confirm-dialog .dialog__content {


### PR DESCRIPTION
Related to #18745

#### Before
<img width="486" alt="captura de pantalla 2017-10-23 a la s 14 07 04" src="https://user-images.githubusercontent.com/1041600/31902521-8dc78060-b7fb-11e7-8cba-83d6776fa84f.png">


#### After
<img width="489" alt="captura de pantalla 2017-10-23 a la s 14 07 12" src="https://user-images.githubusercontent.com/1041600/31902523-8ea2c706-b7fb-11e7-9dc7-0f888c2bd6d7.png">
