### PR TITLE
Store Orders: Switch to line ID as the identifier for fee items

### DIFF
--- a/client/extensions/woocommerce/app/order/order-details/table.js
+++ b/client/extensions/woocommerce/app/order/order-details/table.js
@@ -161,11 +161,11 @@ class OrderDetailsTable extends Component {
 		);
 	};
 
-	renderOrderFees = ( item, i ) => {
+	renderOrderFees = item => {
 		const { order, translate } = this.props;
-		const tax = getOrderFeeTax( order, i );
+		const tax = getOrderFeeTax( order, item.id );
 		return (
-			<TableRow key={ i } className="order-details__items">
+			<TableRow key={ item.id } className="order-details__items">
 				<TableItem isRowHeader className="order-details__item-product" colSpan="3">
 					{ item.name }
 					<span className="order-details__item-sku">{ translate( 'Fee' ) }</span>

--- a/client/extensions/woocommerce/app/order/order-payment/dialog.js
+++ b/client/extensions/woocommerce/app/order/order-payment/dialog.js
@@ -98,8 +98,8 @@ class RefundDialog extends Component {
 		const { order } = this.props;
 		return (
 			sum(
-				order.fee_lines.map( ( item, i ) => {
-					return parseFloat( item.total ) + parseFloat( getOrderFeeTax( order, i ) );
+				order.fee_lines.map( item => {
+					return parseFloat( item.total ) + parseFloat( getOrderFeeTax( order, item.id ) );
 				} )
 			) +
 			parseFloat( getOrderShippingTax( order ) ) +

--- a/client/extensions/woocommerce/app/order/order-payment/table.js
+++ b/client/extensions/woocommerce/app/order/order-payment/table.js
@@ -48,8 +48,9 @@ class OrderRefundTable extends Component {
 
 		this.state = {
 			quantities: {},
-			fees: props.order.fee_lines.map( ( item, i ) => {
-				const value = parseFloat( item.total ) + parseFloat( getOrderFeeTax( props.order, i ) );
+			fees: props.order.fee_lines.map( item => {
+				const value =
+					parseFloat( item.total ) + parseFloat( getOrderFeeTax( props.order, item.id ) );
 				return getCurrencyFormatDecimal( value );
 			} ),
 			shippingTotal: getCurrencyFormatDecimal( shippingTotal ),

--- a/client/extensions/woocommerce/lib/order-values/index.js
+++ b/client/extensions/woocommerce/lib/order-values/index.js
@@ -33,11 +33,12 @@ export function getOrderLineItemTax( order, id ) {
  * Get the total tax for a given fee
  *
  * @param {Object} order An order as returned from API
- * @param {Number} index The index of a fee line in this order
+ * @param {Number} id The ID of a fee line in this order
  * @return {Float} Tax amount as a decimal number
  */
-export function getOrderFeeTax( order, index ) {
-	const tax = get( order, `fee_lines[${ index }].taxes[0].total`, 0 );
+export function getOrderFeeTax( order, id ) {
+	const items = get( order, 'fee_lines', [] );
+	const tax = get( find( items, { id } ), 'taxes[0].total', 0 );
 	return parseFloat( tax ) || 0;
 }
 
@@ -49,7 +50,7 @@ export function getOrderFeeTax( order, index ) {
  */
 export function getOrderFeeTotalTax( order ) {
 	const lines = get( order, 'fee_lines', [] );
-	return reduce( lines, ( sum, value, key ) => sum + getOrderFeeTax( order, key ), 0 );
+	return reduce( lines, ( sum, value ) => sum + getOrderFeeTax( order, value.id ), 0 );
 }
 
 /**

--- a/client/extensions/woocommerce/lib/order-values/test/index.js
+++ b/client/extensions/woocommerce/lib/order-values/test/index.js
@@ -49,15 +49,19 @@ describe( 'getOrderFeeTax', () => {
 	} );
 
 	test( 'should get the correct tax amount', () => {
-		expect( getOrderFeeTax( orderWithTax, 0 ) ).to.eql( 0.1262 );
+		expect( getOrderFeeTax( orderWithTax, 48 ) ).to.eql( 0.1262 );
 	} );
 
 	test( 'should get the correct tax amount with multiple fees', () => {
-		expect( getOrderFeeTax( orderWithCoupons, 1 ) ).to.eql( 0.625 );
+		expect( getOrderFeeTax( orderWithCoupons, 41 ) ).to.eql( 0.625 );
 	} );
 
 	test( 'should return 0 if there is no tax', () => {
-		expect( getOrderFeeTax( orderWithoutTax, 0 ) ).to.eql( 0 );
+		expect( getOrderFeeTax( orderWithoutTax, 2 ) ).to.eql( 0 );
+	} );
+
+	test( 'should return 0 if there is no fee with that ID', () => {
+		expect( getOrderFeeTax( orderWithoutTax, 50 ) ).to.eql( 0 );
 	} );
 } );
 


### PR DESCRIPTION
This is basically the same thing as #18882, but for the fees on an order. We currently use index in the `fee_lines` array as an identifier to get tax values, but once we allow editing/deleting/adding fees, the index isn't reliable. Each line has an ID, so we'll use that instead.

There should be no functionality change in this PR, just a under-the-hood refactor of index to ID.

**To test**

- Run the tests: npm run test-client client/extensions/woocommerce/lib/order-values
- Check out a few orders to make sure fees are displaying as expected, taxes are correct
- Check out refunding an order to make sure the prices add up correctly