### PR TITLE
Webpack: upgrade from version 3.7.1 to 3.8.1

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -74,7 +74,7 @@
       "version": "0.8.1"
     },
     "ajv": {
-      "version": "5.2.3"
+      "version": "5.2.4"
     },
     "ajv-keywords": {
       "version": "2.1.0"
@@ -874,10 +874,10 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000748"
+      "version": "1.0.30000749"
     },
     "caniuse-lite": {
-      "version": "1.0.30000748"
+      "version": "1.0.30000749"
     },
     "cardinal": {
       "version": "1.0.0",
@@ -1203,7 +1203,7 @@
       "version": "1.0.4"
     },
     "content-type-parser": {
-      "version": "1.0.1",
+      "version": "1.0.2",
       "dev": true
     },
     "convert-source-map": {
@@ -1456,6 +1456,10 @@
       "dependencies": {
         "globby": {
           "version": "5.0.0",
+          "dev": true
+        },
+        "pify": {
+          "version": "2.3.0",
           "dev": true
         }
       }
@@ -2818,6 +2822,9 @@
       "dependencies": {
         "glob": {
           "version": "7.1.2"
+        },
+        "pify": {
+          "version": "2.3.0"
         }
       }
     },
@@ -3015,7 +3022,7 @@
       "dev": true
     },
     "html-encoding-sniffer": {
-      "version": "1.0.1",
+      "version": "1.0.2",
       "dev": true
     },
     "html-entities": {
@@ -3405,7 +3412,7 @@
       }
     },
     "istanbul-api": {
-      "version": "1.1.14",
+      "version": "1.2.1",
       "dev": true,
       "dependencies": {
         "async": {
@@ -3419,11 +3426,11 @@
       "dev": true
     },
     "istanbul-lib-hook": {
-      "version": "1.0.7",
+      "version": "1.1.0",
       "dev": true
     },
     "istanbul-lib-instrument": {
-      "version": "1.8.0",
+      "version": "1.9.1",
       "dev": true,
       "dependencies": {
         "semver": {
@@ -3433,15 +3440,15 @@
       }
     },
     "istanbul-lib-report": {
-      "version": "1.1.1",
+      "version": "1.1.2",
       "dev": true
     },
     "istanbul-lib-source-maps": {
-      "version": "1.2.1",
+      "version": "1.2.2",
       "dev": true,
       "dependencies": {
         "debug": {
-          "version": "2.6.9",
+          "version": "3.1.0",
           "dev": true
         },
         "ms": {
@@ -3455,7 +3462,7 @@
       }
     },
     "istanbul-reports": {
-      "version": "1.1.2",
+      "version": "1.1.3",
       "dev": true
     },
     "iterall": {
@@ -3602,10 +3609,6 @@
               "dev": true
             }
           }
-        },
-        "pify": {
-          "version": "3.0.0",
-          "dev": true
         },
         "read-pkg": {
           "version": "2.0.0",
@@ -3902,10 +3905,6 @@
         "jest-docblock": {
           "version": "21.2.0",
           "dev": true
-        },
-        "pify": {
-          "version": "3.0.0",
-          "dev": true
         }
       }
     },
@@ -3957,6 +3956,10 @@
         },
         "path-type": {
           "version": "2.0.0",
+          "dev": true
+        },
+        "pify": {
+          "version": "2.3.0",
           "dev": true
         },
         "read-pkg": {
@@ -4378,7 +4381,12 @@
       "version": "3.0.2"
     },
     "load-json-file": {
-      "version": "1.1.0"
+      "version": "1.1.0",
+      "dependencies": {
+        "pify": {
+          "version": "2.3.0"
+        }
+      }
     },
     "loader-runner": {
       "version": "2.3.0"
@@ -4604,7 +4612,7 @@
       "version": "0.5.7"
     },
     "make-dir": {
-      "version": "1.0.0"
+      "version": "1.1.0"
     },
     "makeerror": {
       "version": "1.0.11",
@@ -5005,6 +5013,9 @@
         "path-type": {
           "version": "2.0.0"
         },
+        "pify": {
+          "version": "2.3.0"
+        },
         "read-pkg": {
           "version": "2.0.0"
         },
@@ -5240,7 +5251,12 @@
       "version": "0.1.7"
     },
     "path-type": {
-      "version": "1.1.0"
+      "version": "1.1.0",
+      "dependencies": {
+        "pify": {
+          "version": "2.3.0"
+        }
+      }
     },
     "pause-stream": {
       "version": "0.0.11"
@@ -5263,7 +5279,7 @@
       "version": "2.0.0"
     },
     "pify": {
-      "version": "2.3.0"
+      "version": "3.0.0"
     },
     "pinkie": {
       "version": "2.0.4"
@@ -5314,6 +5330,9 @@
         },
         "globby": {
           "version": "3.0.1"
+        },
+        "pify": {
+          "version": "2.3.0"
         },
         "pinkie": {
           "version": "1.0.0"
@@ -6617,7 +6636,7 @@
       "dev": true
     },
     "statuses": {
-      "version": "1.3.1"
+      "version": "1.4.0"
     },
     "stdin": {
       "version": "0.0.1",
@@ -6777,6 +6796,10 @@
         },
         "minimist": {
           "version": "1.2.0",
+          "dev": true
+        },
+        "pify": {
+          "version": "2.3.0",
           "dev": true
         },
         "postcss-less": {
@@ -7316,7 +7339,7 @@
       "dev": true
     },
     "webpack": {
-      "version": "3.7.1",
+      "version": "3.8.1",
       "dependencies": {
         "acorn": {
           "version": "5.1.2"
@@ -7349,6 +7372,9 @@
         },
         "path-type": {
           "version": "2.0.0"
+        },
+        "pify": {
+          "version": "2.3.0"
         },
         "read-pkg": {
           "version": "2.0.0"
@@ -7521,6 +7547,10 @@
           "version": "1.1.0",
           "dev": true
         },
+        "statuses": {
+          "version": "1.3.1",
+          "dev": true
+        },
         "supports-color": {
           "version": "2.0.0",
           "dev": true
@@ -7674,7 +7704,7 @@
       "version": "0.1.9"
     },
     "whatwg-encoding": {
-      "version": "1.0.1",
+      "version": "1.0.2",
       "dev": true,
       "dependencies": {
         "iconv-lite": {

--- a/package.json
+++ b/package.json
@@ -154,7 +154,7 @@
     "uuid": "2.0.1",
     "valid-url": "1.0.9",
     "walk": "2.3.4",
-    "webpack": "3.7.1",
+    "webpack": "3.8.1",
     "webpack-dashboard": "0.2.1",
     "webpack-dev-middleware": "1.11.0",
     "webpack-hot-middleware": "2.15.0",


### PR DESCRIPTION
Webpack released a new version 6 days ago, [3.8.1](https://github.com/webpack/webpack/releases). 

It has performance improvements and according to the releases notes (I'm quoting them):
1. chunk graph is now build in breath-first traversal, which is faster
2. fix a performance problem in some edge cases


To test
-----
just do the usual smoke test. build calypso and see it load. there should be no functional changes here.