### PR TITLE
Reader: remove email subscription endpoints from undocumented.js

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1541,68 +1541,9 @@ Undocumented.prototype.fetchSiteRecommendations = function( query, fn ) {
 	return this.wpcom.req.get( '/read/recommendations/mine', query, fn );
 };
 
-Undocumented.prototype.readRecommendationsStart = function( query, fn ) {
-	return this.wpcom.req.get( '/read/recommendations/start', query, fn );
-};
-
 Undocumented.prototype.graduateNewReader = function( fn ) {
 	const params = { apiVersion: '1.2' };
 	return this.wpcom.req.post( '/read/graduate-new-reader', params, {}, fn );
-};
-
-Undocumented.prototype.readNewPostEmailSubscription = function( query, fn ) {
-	var params = omit( query, [ 'site' ] );
-	debug( '/read/site/:site/post_email_subscriptions/new' );
-	return this.wpcom.req.post(
-		'/read/site/' + encodeURIComponent( query.site ) + '/post_email_subscriptions/new',
-		{ apiVersion: '1.2' },
-		params,
-		fn
-	);
-};
-
-Undocumented.prototype.readUpdatePostEmailSubscription = function( query, fn ) {
-	var params = omit( query, [ 'site' ] );
-	debug( '/read/site/:site/post_email_subscriptions/update' );
-	return this.wpcom.req.post(
-		'/read/site/' + encodeURIComponent( query.site ) + '/post_email_subscriptions/update',
-		{ apiVersion: '1.2' },
-		params,
-		fn
-	);
-};
-
-Undocumented.prototype.readDeletePostEmailSubscription = function( query, fn ) {
-	var params = omit( query, [ 'site' ] );
-	debug( '/read/site/:site/post_email_subscriptions/delete' );
-	return this.wpcom.req.post(
-		'/read/site/' + encodeURIComponent( query.site ) + '/post_email_subscriptions/delete',
-		{ apiVersion: '1.2' },
-		params,
-		fn
-	);
-};
-
-Undocumented.prototype.readNewCommentEmailSubscription = function( query, fn ) {
-	var params = omit( query, [ 'site' ] );
-	debug( '/read/site/:site/comment_email_subscriptions/new' );
-	return this.wpcom.req.post(
-		'/read/site/' + encodeURIComponent( query.site ) + '/comment_email_subscriptions/new',
-		{ apiVersion: '1.2' },
-		params,
-		fn
-	);
-};
-
-Undocumented.prototype.readDeleteCommentEmailSubscription = function( query, fn ) {
-	var params = omit( query, [ 'site' ] );
-	debug( '/read/site/:site/comment_email_subscriptions/delete' );
-	return this.wpcom.req.post(
-		'/read/site/' + encodeURIComponent( query.site ) + '/comment_email_subscriptions/delete',
-		{ apiVersion: '1.2' },
-		params,
-		fn
-	);
 };
 
 /**


### PR DESCRIPTION
Post and email comment subscriptions are now handled by the data layer:

https://github.com/Automattic/wp-calypso/tree/master/client/state/data-layer/wpcom/read/site

As a result, we can remove these endpoints from `undocumented.js`.

(I've also removed the old `read/recommendations/start` endpoint from Cold Start as a bonus.)

### To test

Manage your email subscriptions at http://calypso.localhost:3000/following/manage and make sure subscribing and unsubscribing to post and comment emails works as it should.