### PR TITLE
TokenField: Turn into React.PureComponent

### DIFF
--- a/client/components/token-field/index.jsx
+++ b/client/components/token-field/index.jsx
@@ -18,8 +18,6 @@ import TokenInput from './token-input';
 const debug = debugFactory( 'calypso:token-field' );
 
 class TokenField extends PureComponent {
-	static displayName = 'TokenField';
-
 	static propTypes = {
 		suggestions: PropTypes.array,
 		maxSuggestions: PropTypes.number,

--- a/client/components/token-field/index.jsx
+++ b/client/components/token-field/index.jsx
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { clone, difference, each, forEach, identity, last, map, some, take, uniq } from 'lodash';
 import classNames from 'classnames';
@@ -17,7 +17,7 @@ import TokenInput from './token-input';
 
 const debug = debugFactory( 'calypso:token-field' );
 
-class TokenField extends React.PureComponent {
+class TokenField extends PureComponent {
 	static displayName = 'TokenField';
 
 	static propTypes = {

--- a/client/components/token-field/index.jsx
+++ b/client/components/token-field/index.jsx
@@ -3,9 +3,7 @@
  * External dependencies
  */
 import React from 'react';
-import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
-import PureRenderMixin from 'react-pure-render/mixin';
 import { clone, difference, each, forEach, identity, last, map, some, take, uniq } from 'lodash';
 import classNames from 'classnames';
 import debugFactory from 'debug';
@@ -19,10 +17,10 @@ import TokenInput from './token-input';
 
 const debug = debugFactory( 'calypso:token-field' );
 
-const TokenField = createReactClass( {
-	displayName: 'TokenField',
+class TokenField extends React.PureComponent {
+	static displayName = 'TokenField';
 
-	propTypes: {
+	static propTypes = {
 		suggestions: PropTypes.array,
 		maxSuggestions: PropTypes.number,
 		displayTransform: PropTypes.func,
@@ -51,37 +49,33 @@ const TokenField = createReactClass( {
 				}
 			} );
 		},
-	},
+	};
 
-	getDefaultProps: function() {
-		return {
-			suggestions: Object.freeze( [] ),
-			maxSuggestions: 100,
-			value: Object.freeze( [] ),
-			placeholder: '',
-			displayTransform: identity,
-			saveTransform: function( token ) {
-				return token.trim();
-			},
-			onChange: function() {},
-			isBorderless: false,
-			disabled: false,
-			tokenizeOnSpace: false,
-		};
-	},
+	static defaultProps = {
+		suggestions: Object.freeze( [] ),
+		maxSuggestions: 100,
+		value: Object.freeze( [] ),
+		placeholder: '',
+		displayTransform: identity,
+		saveTransform: function( token ) {
+			return token.trim();
+		},
+		onChange: function() {},
+		isBorderless: false,
+		disabled: false,
+		tokenizeOnSpace: false,
+	};
 
-	mixins: [ PureRenderMixin ],
+	static initialState = {
+		incompleteTokenValue: '',
+		inputOffsetFromEnd: 0,
+		isActive: false,
+		selectedSuggestionIndex: -1,
+		selectedSuggestionScroll: false,
+		tokenInputHasFocus: false,
+	};
 
-	getInitialState: function() {
-		return {
-			incompleteTokenValue: '',
-			inputOffsetFromEnd: 0,
-			isActive: false,
-			selectedSuggestionIndex: -1,
-			selectedSuggestionScroll: false,
-			tokenInputHasFocus: false,
-		};
-	},
+	state = this.constructor.initialState;
 
 	componentWillReceiveProps( nextProps ) {
 		if ( nextProps.disabled && this.state.isActive ) {
@@ -90,9 +84,9 @@ const TokenField = createReactClass( {
 				incompleteTokenValue: '',
 			} );
 		}
-	},
+	}
 
-	render: function() {
+	render() {
 		var classes = classNames( 'token-field', {
 			'is-active': this.state.isActive,
 			'is-disabled': this.props.disabled,
@@ -135,17 +129,17 @@ const TokenField = createReactClass( {
 				/>
 			</div>
 		);
-	},
+	}
 
-	_renderTokensAndInput: function() {
+	_renderTokensAndInput = () => {
 		var components = map( this.props.value, this._renderToken );
 
 		components.splice( this._getIndexOfInput(), 0, this._renderInput() );
 
 		return components;
-	},
+	};
 
-	_renderToken: function( token ) {
+	_renderToken = token => {
 		const value = this._getTokenValue( token );
 		const status = token.status ? token.status : undefined;
 
@@ -163,9 +157,9 @@ const TokenField = createReactClass( {
 				disabled={ 'error' !== status && this.props.disabled }
 			/>
 		);
-	},
+	};
 
-	_renderInput: function() {
+	_renderInput = () => {
 		const { autoCapitalize, autoComplete, id, maxLength, value, placeholder } = this.props;
 
 		let props = {
@@ -188,34 +182,34 @@ const TokenField = createReactClass( {
 		}
 
 		return <TokenInput { ...props } />;
-	},
+	};
 
-	setTokensAndInput: function( input ) {
+	setTokensAndInput = input => {
 		this.tokensAndInput = input;
-	},
+	};
 
-	_onFocus: function( event ) {
+	_onFocus = event => {
 		this.setState( { isActive: true, tokenInputHasFocus: true } );
 		if ( 'function' === typeof this.props.onFocus ) {
 			this.props.onFocus( event );
 		}
-	},
+	};
 
-	_onBlur: function() {
+	_onBlur = () => {
 		if ( this._inputHasValidValue() ) {
 			debug( '_onBlur adding current token' );
 			this.setState( { isActive: false }, this._addCurrentToken );
 		} else {
 			debug( '_onBlur not adding current token' );
-			this.setState( this.getInitialState() );
+			this.setState( this.constructor.initialState );
 		}
-	},
+	};
 
-	_onTokenClickRemove: function( event ) {
+	_onTokenClickRemove = event => {
 		this._deleteToken( event.value );
-	},
+	};
 
-	_onSuggestionHovered: function( suggestion ) {
+	_onSuggestionHovered = suggestion => {
 		var index = this._getMatchingSuggestions().indexOf( suggestion );
 
 		if ( index >= 0 ) {
@@ -224,14 +218,14 @@ const TokenField = createReactClass( {
 				selectedSuggestionScroll: false,
 			} );
 		}
-	},
+	};
 
-	_onSuggestionSelected: function( suggestion ) {
+	_onSuggestionSelected = suggestion => {
 		debug( '_onSuggestionSelected', suggestion );
 		this._addNewToken( suggestion );
-	},
+	};
 
-	_onInputChange: function( event ) {
+	_onInputChange = event => {
 		const text = event.value;
 		const separator = this.props.tokenizeOnSpace ? /[ ,\t]+/ : /[,\t]+/;
 		const items = text.split( separator );
@@ -245,17 +239,17 @@ const TokenField = createReactClass( {
 			selectedSuggestionIndex: -1,
 			selectedSuggestionScroll: false,
 		} );
-	},
+	};
 
-	_onContainerTouched: function( event ) {
+	_onContainerTouched = event => {
 		// Prevent clicking/touching the tokensAndInput container from blurring
 		// the input and adding the current token.
 		if ( event.target === this.tokensAndInput && this.state.isActive ) {
 			event.preventDefault();
 		}
-	},
+	};
 
-	_onKeyDown: function( event ) {
+	_onKeyDown = event => {
 		var preventDefault = false;
 
 		switch ( event.keyCode ) {
@@ -295,9 +289,9 @@ const TokenField = createReactClass( {
 		if ( preventDefault ) {
 			event.preventDefault();
 		}
-	},
+	};
 
-	_onKeyPress: function( event ) {
+	_onKeyPress = event => {
 		var preventDefault = false;
 
 		switch ( event.charCode ) {
@@ -311,9 +305,9 @@ const TokenField = createReactClass( {
 		if ( preventDefault ) {
 			event.preventDefault();
 		}
-	},
+	};
 
-	_handleDeleteKey: function( deleteToken ) {
+	_handleDeleteKey = deleteToken => {
 		var preventDefault = false;
 
 		if ( this.state.tokenInputHasFocus && this._isInputEmpty() ) {
@@ -322,9 +316,9 @@ const TokenField = createReactClass( {
 		}
 
 		return preventDefault;
-	},
+	};
 
-	_getMatchingSuggestions: function() {
+	_getMatchingSuggestions = () => {
 		var suggestions = this.props.suggestions,
 			match = this.props.saveTransform( this.state.incompleteTokenValue ),
 			startsWithMatch = [],
@@ -353,15 +347,15 @@ const TokenField = createReactClass( {
 		}
 
 		return take( suggestions, this.props.maxSuggestions );
-	},
+	};
 
-	_getSelectedSuggestion: function() {
+	_getSelectedSuggestion = () => {
 		if ( this.state.selectedSuggestionIndex !== -1 ) {
 			return this._getMatchingSuggestions()[ this.state.selectedSuggestionIndex ];
 		}
-	},
+	};
 
-	_addCurrentToken: function() {
+	_addCurrentToken = () => {
 		var preventDefault = false,
 			selectedSuggestion = this._getSelectedSuggestion();
 
@@ -374,9 +368,9 @@ const TokenField = createReactClass( {
 		}
 
 		return preventDefault;
-	},
+	};
 
-	_handleLeftArrowKey: function() {
+	_handleLeftArrowKey = () => {
 		var preventDefault = false;
 
 		if ( this._isInputEmpty() ) {
@@ -385,9 +379,9 @@ const TokenField = createReactClass( {
 		}
 
 		return preventDefault;
-	},
+	};
 
-	_handleRightArrowKey: function() {
+	_handleRightArrowKey = () => {
 		var preventDefault = false;
 
 		if ( this._isInputEmpty() ) {
@@ -396,18 +390,18 @@ const TokenField = createReactClass( {
 		}
 
 		return preventDefault;
-	},
+	};
 
-	_handleUpArrowKey: function() {
+	_handleUpArrowKey = () => {
 		this.setState( {
 			selectedSuggestionIndex: Math.max( ( this.state.selectedSuggestionIndex || 0 ) - 1, 0 ),
 			selectedSuggestionScroll: true,
 		} );
 
 		return true; // preventDefault
-	},
+	};
 
-	_handleDownArrowKey: function() {
+	_handleDownArrowKey = () => {
 		this.setState( {
 			selectedSuggestionIndex: Math.min(
 				this.state.selectedSuggestionIndex + 1 || 0,
@@ -417,9 +411,9 @@ const TokenField = createReactClass( {
 		} );
 
 		return true; // preventDefault
-	},
+	};
 
-	_handleCommaKey: function() {
+	_handleCommaKey = () => {
 		var preventDefault = true;
 
 		if ( this._inputHasValidValue() ) {
@@ -427,25 +421,25 @@ const TokenField = createReactClass( {
 		}
 
 		return preventDefault;
-	},
+	};
 
-	_isInputEmpty: function() {
+	_isInputEmpty = () => {
 		return this.state.incompleteTokenValue.length === 0;
-	},
+	};
 
-	_inputHasValidValue: function() {
+	_inputHasValidValue = () => {
 		return this.props.saveTransform( this.state.incompleteTokenValue ).length > 0;
-	},
+	};
 
-	_deleteTokenBeforeInput: function() {
+	_deleteTokenBeforeInput = () => {
 		var index = this._getIndexOfInput() - 1;
 
 		if ( index > -1 ) {
 			this._deleteToken( this.props.value[ index ] );
 		}
-	},
+	};
 
-	_deleteTokenAfterInput: function() {
+	_deleteTokenAfterInput = () => {
 		var index = this._getIndexOfInput();
 
 		if ( index < this.props.value.length ) {
@@ -453,34 +447,34 @@ const TokenField = createReactClass( {
 			// update input offset since it's the offset from the last token
 			this._moveInputToIndex( index );
 		}
-	},
+	};
 
-	_deleteToken: function( token ) {
+	_deleteToken = token => {
 		const newTokens = this.props.value.filter( item => {
 			return this._getTokenValue( item ) !== this._getTokenValue( token );
 		} );
 		this.props.onChange( newTokens );
-	},
+	};
 
-	_moveInputToIndex: function( index ) {
+	_moveInputToIndex = index => {
 		this.setState( {
 			inputOffsetFromEnd: this.props.value.length - Math.max( index, -1 ) - 1,
 		} );
-	},
+	};
 
-	_moveInputBeforePreviousToken: function() {
+	_moveInputBeforePreviousToken = () => {
 		this.setState( {
 			inputOffsetFromEnd: Math.min( this.state.inputOffsetFromEnd + 1, this.props.value.length ),
 		} );
-	},
+	};
 
-	_moveInputAfterNextToken: function() {
+	_moveInputAfterNextToken = () => {
 		this.setState( {
 			inputOffsetFromEnd: Math.max( this.state.inputOffsetFromEnd - 1, 0 ),
 		} );
-	},
+	};
 
-	_addNewTokens: function( tokens ) {
+	_addNewTokens = tokens => {
 		const tokensToAdd = uniq(
 			tokens
 				.map( this.props.saveTransform )
@@ -495,9 +489,9 @@ const TokenField = createReactClass( {
 			debug( '_addNewTokens: onChange', newValue );
 			this.props.onChange( newValue );
 		}
-	},
+	};
 
-	_addNewToken: function( token ) {
+	_addNewToken = token => {
 		this._addNewTokens( [ token ] );
 
 		this.setState( {
@@ -510,25 +504,25 @@ const TokenField = createReactClass( {
 			debug( '_addNewToken focusing input' );
 			this.setState( { tokenInputHasFocus: true } );
 		}
-	},
+	};
 
-	_valueContainsToken( token ) {
+	_valueContainsToken = token => {
 		return some( this.props.value, item => {
 			return this._getTokenValue( token ) === this._getTokenValue( item );
 		} );
-	},
+	};
 
-	_getTokenValue( token ) {
+	_getTokenValue = token => {
 		if ( 'object' === typeof token ) {
 			return token.value;
 		}
 
 		return token;
-	},
+	};
 
-	_getIndexOfInput: function() {
+	_getIndexOfInput = () => {
 		return this.props.value.length - this.state.inputOffsetFromEnd;
-	},
-} );
+	};
+}
 
 export default TokenField;


### PR DESCRIPTION
This wasn't done by #18889 since the component referenced `this.getInitialState()` in a method. The fix is to define a `static initialState` and use that instead (also to initialize `state`).

## To test
* Compare:
  * http://calypso.localhost:3000/devdocs/design/token-fields or https://calypso.live/devdocs/design/token-fields?branch=update/token-field-component-class
  * https://wpcalypso.wordpress.com/devdocs/design/token-fields
* Ensure things work as before.
