### PR TITLE
stop duplication of meta tags

### DIFF
--- a/client/components/data/document-head/index.jsx
+++ b/client/components/data/document-head/index.jsx
@@ -96,7 +96,7 @@ class DocumentHead extends Component {
 		if ( ! element ) {
 			const newTag = document.createElement( tagName );
 			forEach( properties, ( value, key ) => {
-				newTag[ key ] = value;
+				newTag.setAttribute( key, value );
 			} );
 			const head = document.getElementsByTagName( 'head' )[ 0 ];
 			head.appendChild( newTag );


### PR DESCRIPTION
If you view `/themes/<site>` you will currently see many hundreds of `meta` tag elements added to `head`.

This is because browsers ignore the attempt to add a 'property' attribute when creating the new `meta` element (and so a new element is added each time `componentWillReceiveProps` is called) presumably because this is not a standard attribute.

Using `setAttribute` instead of []= for head tags seems to avoid this issue.

# Testing

View `/themes/<site>` and verify that only a single set of 4 meta tags are added (instead of hundreds)

 - [x] IE 10
 - [x] IE Edge
 - [x] Safari
 - [x] Firefox
 - [x] Chrome
 - [x] Chrome Windows