### PR TITLE
Site settings: Hide "Press this on" mobile devices

### DIFF
--- a/client/my-sites/site-settings/form-writing.jsx
+++ b/client/my-sites/site-settings/form-writing.jsx
@@ -52,6 +52,10 @@ class SiteSettingsFormWriting extends Component {
 		);
 	}
 
+	isMobile() {
+		return /Mobile|iP(hone|od|ad)|Android|BlackBerry|IEMobile|Silk/.test( navigator.userAgent );
+	}
+
 	render() {
 		const {
 			eventTracker,
@@ -159,6 +163,7 @@ class SiteSettingsFormWriting extends Component {
 				) }
 
 				{ config.isEnabled( 'press-this' ) &&
+				! this.isMobile() &&
 				! ( this.props.isJetpackSite || this.props.jetpackSettingsUISupported ) && (
 					<div>
 						{ this.renderSectionHeader(


### PR DESCRIPTION
This PR is a fix for #18334 .

Unfortunately bookmarklets don't work as straightforward on mobile OS devices, as on "desktop" OS-es (which support dragging/dropping of links on the bookmark bar).

The best course of action is to hide the the whole block for *Press This* in the writing settings.

### To test:
1. Use the Calypso.live link (it's easier to test on mobile devices :))
2. Open Settings
3. Go to Writing
4. Check if Press This is hidden on a mobile device, but visible on desktop
5. Verify no JS errors in the console

cc @lancewillett 