### PR TITLE
Store: MailChimp use cursor: pointer for resync action link.

### DIFF
--- a/client/extensions/woocommerce/app/settings/email/mailchimp/style.scss
+++ b/client/extensions/woocommerce/app/settings/email/mailchimp/style.scss
@@ -210,6 +210,7 @@
 .mailchimp__resync-link {
 	font-size: 12px;
 	margin-left: 8px;
+	cursor: pointer;
 }
 
 .mailchimp__dashboard-settings {


### PR DESCRIPTION
### Info
 The resync link needs cursor type pointer. Without it, users may not know that it is clickable.

![image](https://user-images.githubusercontent.com/17271089/31936675-1d0fffd4-b867-11e7-89b3-5f20b6335bb6.png)
