### PR TITLE
Use fake custom-elements for mocks

### DIFF
--- a/client/jetpack-connect/test/__snapshots__/plans.js.snap
+++ b/client/jetpack-connect/test/__snapshots__/plans.js.snap
@@ -8,7 +8,7 @@ initialize {
       Object {
         "attribs": Object {},
         "children": Array [],
-        "name": "div",
+        "name": "components--data--query-plans",
         "next": null,
         "parent": null,
         "prev": null,
@@ -44,11 +44,13 @@ initialize {
           Object {
             "attribs": Object {},
             "children": Array [],
-            "name": "div",
+            "name": "components--data--query-plans",
             "next": Object {
-              "attribs": Object {},
+              "attribs": Object {
+                "siteid": "1234567",
+              },
               "children": Array [],
-              "name": "div",
+              "name": "components--data--query-site-plans",
               "next": Object {
                 "attribs": Object {
                   "class": "main is-wide-layout",
@@ -348,11 +350,13 @@ initialize {
                                   "next": Object {
                                     "attribs": Object {},
                                     "children": Array [],
-                                    "name": "div",
+                                    "name": "components--data--query-plans",
                                     "next": Object {
-                                      "attribs": Object {},
+                                      "attribs": Object {
+                                        "siteid": "1234567",
+                                      },
                                       "children": Array [],
-                                      "name": "div",
+                                      "name": "components--data--query-site-plans",
                                       "next": Object {
                                         "attribs": Object {
                                           "class": "plans-features-main__group",
@@ -360,9 +364,40 @@ initialize {
                                         },
                                         "children": Array [
                                           Object {
-                                            "attribs": Object {},
+                                            "attribs": Object {
+                                              "baseplanspath": "/jetpack/connect/plans",
+                                              "displayjetpackplans": "true",
+                                              "isinsignup": "true",
+                                              "islandingpage": "false",
+                                              "onupgradeclick": "function (cartItem) {
+			var checkoutPath = '/checkout/' + _this.props.selectedSite.slug;
+			// clears whatever we had stored in local cache
+			_this.props.selectPlanInAdvance(null, _this.props.selectedSiteSlug);
+
+			if (!cartItem || cartItem.product_slug === _constants.PLAN_JETPACK_FREE) {
+				return _this.selectFreeJetpackPlan();
+			}
+
+			if (cartItem.product_slug === (0, _lodash.get)(_this.props, 'selectedSite.plan.product_slug', null)) {
+				return _this.redirect(CALYPSO_PLANS_PAGE);
+			}
+
+			_this.props.recordTracksEvent('calypso_jpc_plans_submit', {
+				user: _this.props.userId,
+				product_slug: cartItem.product_slug });
+
+			_analytics.mc.bumpStat('calypso_jpc_plan_selection', cartItem.product_slug);
+
+			(0, _actions2.addItem)(cartItem);
+			_this.redirecting = true;
+			_this.props.completeFlow();
+			_page2.default.redirect(checkoutPath);
+		}",
+                                              "plans": "jetpack_personal,jetpack_premium,jetpack_business",
+                                              "site": "[object Object]",
+                                            },
                                             "children": Array [],
-                                            "name": "div",
+                                            "name": "my-sites--plan-features",
                                             "next": null,
                                             "parent": [Circular],
                                             "prev": null,
@@ -390,11 +425,13 @@ initialize {
                                 Object {
                                   "attribs": Object {},
                                   "children": Array [],
-                                  "name": "div",
+                                  "name": "components--data--query-plans",
                                   "next": Object {
-                                    "attribs": Object {},
+                                    "attribs": Object {
+                                      "siteid": "1234567",
+                                    },
                                     "children": Array [],
-                                    "name": "div",
+                                    "name": "components--data--query-site-plans",
                                     "next": Object {
                                       "attribs": Object {
                                         "class": "plans-features-main__group",
@@ -402,9 +439,40 @@ initialize {
                                       },
                                       "children": Array [
                                         Object {
-                                          "attribs": Object {},
+                                          "attribs": Object {
+                                            "baseplanspath": "/jetpack/connect/plans",
+                                            "displayjetpackplans": "true",
+                                            "isinsignup": "true",
+                                            "islandingpage": "false",
+                                            "onupgradeclick": "function (cartItem) {
+			var checkoutPath = '/checkout/' + _this.props.selectedSite.slug;
+			// clears whatever we had stored in local cache
+			_this.props.selectPlanInAdvance(null, _this.props.selectedSiteSlug);
+
+			if (!cartItem || cartItem.product_slug === _constants.PLAN_JETPACK_FREE) {
+				return _this.selectFreeJetpackPlan();
+			}
+
+			if (cartItem.product_slug === (0, _lodash.get)(_this.props, 'selectedSite.plan.product_slug', null)) {
+				return _this.redirect(CALYPSO_PLANS_PAGE);
+			}
+
+			_this.props.recordTracksEvent('calypso_jpc_plans_submit', {
+				user: _this.props.userId,
+				product_slug: cartItem.product_slug });
+
+			_analytics.mc.bumpStat('calypso_jpc_plan_selection', cartItem.product_slug);
+
+			(0, _actions2.addItem)(cartItem);
+			_this.redirecting = true;
+			_this.props.completeFlow();
+			_page2.default.redirect(checkoutPath);
+		}",
+                                            "plans": "jetpack_personal,jetpack_premium,jetpack_business",
+                                            "site": "[object Object]",
+                                          },
                                           "children": Array [],
-                                          "name": "div",
+                                          "name": "my-sites--plan-features",
                                           "next": null,
                                           "parent": [Circular],
                                           "prev": null,
@@ -624,9 +692,11 @@ initialize {
                                   "type": "tag",
                                 },
                                 Object {
-                                  "attribs": Object {},
+                                  "attribs": Object {
+                                    "siteid": "1234567",
+                                  },
                                   "children": Array [],
-                                  "name": "div",
+                                  "name": "components--data--query-site-plans",
                                   "next": Object {
                                     "attribs": Object {
                                       "class": "plans-features-main__group",
@@ -634,9 +704,40 @@ initialize {
                                     },
                                     "children": Array [
                                       Object {
-                                        "attribs": Object {},
+                                        "attribs": Object {
+                                          "baseplanspath": "/jetpack/connect/plans",
+                                          "displayjetpackplans": "true",
+                                          "isinsignup": "true",
+                                          "islandingpage": "false",
+                                          "onupgradeclick": "function (cartItem) {
+			var checkoutPath = '/checkout/' + _this.props.selectedSite.slug;
+			// clears whatever we had stored in local cache
+			_this.props.selectPlanInAdvance(null, _this.props.selectedSiteSlug);
+
+			if (!cartItem || cartItem.product_slug === _constants.PLAN_JETPACK_FREE) {
+				return _this.selectFreeJetpackPlan();
+			}
+
+			if (cartItem.product_slug === (0, _lodash.get)(_this.props, 'selectedSite.plan.product_slug', null)) {
+				return _this.redirect(CALYPSO_PLANS_PAGE);
+			}
+
+			_this.props.recordTracksEvent('calypso_jpc_plans_submit', {
+				user: _this.props.userId,
+				product_slug: cartItem.product_slug });
+
+			_analytics.mc.bumpStat('calypso_jpc_plan_selection', cartItem.product_slug);
+
+			(0, _actions2.addItem)(cartItem);
+			_this.redirecting = true;
+			_this.props.completeFlow();
+			_page2.default.redirect(checkoutPath);
+		}",
+                                          "plans": "jetpack_personal,jetpack_premium,jetpack_business",
+                                          "site": "[object Object]",
+                                        },
                                         "children": Array [],
-                                        "name": "div",
+                                        "name": "my-sites--plan-features",
                                         "next": null,
                                         "parent": [Circular],
                                         "prev": null,
@@ -653,7 +754,7 @@ initialize {
                                   "prev": Object {
                                     "attribs": Object {},
                                     "children": Array [],
-                                    "name": "div",
+                                    "name": "components--data--query-plans",
                                     "next": [Circular],
                                     "parent": [Circular],
                                     "prev": Object {
@@ -866,9 +967,40 @@ initialize {
                                   },
                                   "children": Array [
                                     Object {
-                                      "attribs": Object {},
+                                      "attribs": Object {
+                                        "baseplanspath": "/jetpack/connect/plans",
+                                        "displayjetpackplans": "true",
+                                        "isinsignup": "true",
+                                        "islandingpage": "false",
+                                        "onupgradeclick": "function (cartItem) {
+			var checkoutPath = '/checkout/' + _this.props.selectedSite.slug;
+			// clears whatever we had stored in local cache
+			_this.props.selectPlanInAdvance(null, _this.props.selectedSiteSlug);
+
+			if (!cartItem || cartItem.product_slug === _constants.PLAN_JETPACK_FREE) {
+				return _this.selectFreeJetpackPlan();
+			}
+
+			if (cartItem.product_slug === (0, _lodash.get)(_this.props, 'selectedSite.plan.product_slug', null)) {
+				return _this.redirect(CALYPSO_PLANS_PAGE);
+			}
+
+			_this.props.recordTracksEvent('calypso_jpc_plans_submit', {
+				user: _this.props.userId,
+				product_slug: cartItem.product_slug });
+
+			_analytics.mc.bumpStat('calypso_jpc_plan_selection', cartItem.product_slug);
+
+			(0, _actions2.addItem)(cartItem);
+			_this.redirecting = true;
+			_this.props.completeFlow();
+			_page2.default.redirect(checkoutPath);
+		}",
+                                        "plans": "jetpack_personal,jetpack_premium,jetpack_business",
+                                        "site": "[object Object]",
+                                      },
                                       "children": Array [],
-                                      "name": "div",
+                                      "name": "my-sites--plan-features",
                                       "next": null,
                                       "parent": [Circular],
                                       "prev": null,
@@ -879,15 +1011,17 @@ initialize {
                                   "next": null,
                                   "parent": [Circular],
                                   "prev": Object {
-                                    "attribs": Object {},
+                                    "attribs": Object {
+                                      "siteid": "1234567",
+                                    },
                                     "children": Array [],
-                                    "name": "div",
+                                    "name": "components--data--query-site-plans",
                                     "next": [Circular],
                                     "parent": [Circular],
                                     "prev": Object {
                                       "attribs": Object {},
                                       "children": Array [],
-                                      "name": "div",
+                                      "name": "components--data--query-plans",
                                       "next": [Circular],
                                       "parent": [Circular],
                                       "prev": Object {
@@ -1209,9 +1343,113 @@ initialize {
                                   },
                                   "children": Array [
                                     Object {
-                                      "attribs": Object {},
-                                      "children": Array [],
-                                      "name": "div",
+                                      "attribs": Object {
+                                        "label": "Need help?",
+                                      },
+                                      "children": Array [
+                                        Object {
+                                          "attribs": Object {
+                                            "class": "logged-out-form__link-item jetpack-connect__help-button",
+                                            "href": "https://jetpack.com/contact-support",
+                                            "rel": "noopener noreferrer",
+                                            "target": "_blank",
+                                          },
+                                          "children": Array [
+                                            Object {
+                                              "attribs": Object {
+                                                "class": "gridicon gridicons-help-outline",
+                                                "height": "24",
+                                                "viewbox": "0 0 24 24",
+                                                "width": "24",
+                                                "xmlns": "http://www.w3.org/2000/svg",
+                                              },
+                                              "children": Array [
+                                                Object {
+                                                  "attribs": Object {},
+                                                  "children": Array [
+                                                    Object {
+                                                      "attribs": Object {
+                                                        "d": "M12 4c4.41 0 8 3.59 8 8s-3.59 8-8 8-8-3.59-8-8 3.59-8 8-8m0-2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm4 8c0-2.21-1.79-4-4-4s-4 1.79-4 4h2c0-1.103.897-2 2-2s2 .897 2 2-.897 2-2 2c-.552 0-1 .448-1 1v2h2v-1.14c1.722-.447 3-1.998 3-3.86zm-3 6h-2v2h2v-2z",
+                                                      },
+                                                      "children": Array [],
+                                                      "name": "path",
+                                                      "next": null,
+                                                      "parent": [Circular],
+                                                      "prev": null,
+                                                      "type": "tag",
+                                                    },
+                                                  ],
+                                                  "name": "g",
+                                                  "next": null,
+                                                  "parent": [Circular],
+                                                  "prev": null,
+                                                  "type": "tag",
+                                                },
+                                              ],
+                                              "name": "svg",
+                                              "next": Object {
+                                                "data": " Need help?",
+                                                "next": null,
+                                                "parent": [Circular],
+                                                "prev": [Circular],
+                                                "type": "text",
+                                              },
+                                              "parent": [Circular],
+                                              "prev": null,
+                                              "type": "tag",
+                                            },
+                                            Object {
+                                              "data": " Need help?",
+                                              "next": null,
+                                              "parent": [Circular],
+                                              "prev": Object {
+                                                "attribs": Object {
+                                                  "class": "gridicon gridicons-help-outline",
+                                                  "height": "24",
+                                                  "viewbox": "0 0 24 24",
+                                                  "width": "24",
+                                                  "xmlns": "http://www.w3.org/2000/svg",
+                                                },
+                                                "children": Array [
+                                                  Object {
+                                                    "attribs": Object {},
+                                                    "children": Array [
+                                                      Object {
+                                                        "attribs": Object {
+                                                          "d": "M12 4c4.41 0 8 3.59 8 8s-3.59 8-8 8-8-3.59-8-8 3.59-8 8-8m0-2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm4 8c0-2.21-1.79-4-4-4s-4 1.79-4 4h2c0-1.103.897-2 2-2s2 .897 2 2-.897 2-2 2c-.552 0-1 .448-1 1v2h2v-1.14c1.722-.447 3-1.998 3-3.86zm-3 6h-2v2h2v-2z",
+                                                        },
+                                                        "children": Array [],
+                                                        "name": "path",
+                                                        "next": null,
+                                                        "parent": [Circular],
+                                                        "prev": null,
+                                                        "type": "tag",
+                                                      },
+                                                    ],
+                                                    "name": "g",
+                                                    "next": null,
+                                                    "parent": [Circular],
+                                                    "prev": null,
+                                                    "type": "tag",
+                                                  },
+                                                ],
+                                                "name": "svg",
+                                                "next": [Circular],
+                                                "parent": [Circular],
+                                                "prev": null,
+                                                "type": "tag",
+                                              },
+                                              "type": "text",
+                                            },
+                                          ],
+                                          "name": "a",
+                                          "next": null,
+                                          "parent": [Circular],
+                                          "prev": null,
+                                          "type": "tag",
+                                        },
+                                      ],
+                                      "name": "jetpack-connect--happychat-button",
                                       "next": null,
                                       "parent": [Circular],
                                       "prev": null,
@@ -1344,9 +1582,113 @@ initialize {
                                 },
                                 "children": Array [
                                   Object {
-                                    "attribs": Object {},
-                                    "children": Array [],
-                                    "name": "div",
+                                    "attribs": Object {
+                                      "label": "Need help?",
+                                    },
+                                    "children": Array [
+                                      Object {
+                                        "attribs": Object {
+                                          "class": "logged-out-form__link-item jetpack-connect__help-button",
+                                          "href": "https://jetpack.com/contact-support",
+                                          "rel": "noopener noreferrer",
+                                          "target": "_blank",
+                                        },
+                                        "children": Array [
+                                          Object {
+                                            "attribs": Object {
+                                              "class": "gridicon gridicons-help-outline",
+                                              "height": "24",
+                                              "viewbox": "0 0 24 24",
+                                              "width": "24",
+                                              "xmlns": "http://www.w3.org/2000/svg",
+                                            },
+                                            "children": Array [
+                                              Object {
+                                                "attribs": Object {},
+                                                "children": Array [
+                                                  Object {
+                                                    "attribs": Object {
+                                                      "d": "M12 4c4.41 0 8 3.59 8 8s-3.59 8-8 8-8-3.59-8-8 3.59-8 8-8m0-2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm4 8c0-2.21-1.79-4-4-4s-4 1.79-4 4h2c0-1.103.897-2 2-2s2 .897 2 2-.897 2-2 2c-.552 0-1 .448-1 1v2h2v-1.14c1.722-.447 3-1.998 3-3.86zm-3 6h-2v2h2v-2z",
+                                                    },
+                                                    "children": Array [],
+                                                    "name": "path",
+                                                    "next": null,
+                                                    "parent": [Circular],
+                                                    "prev": null,
+                                                    "type": "tag",
+                                                  },
+                                                ],
+                                                "name": "g",
+                                                "next": null,
+                                                "parent": [Circular],
+                                                "prev": null,
+                                                "type": "tag",
+                                              },
+                                            ],
+                                            "name": "svg",
+                                            "next": Object {
+                                              "data": " Need help?",
+                                              "next": null,
+                                              "parent": [Circular],
+                                              "prev": [Circular],
+                                              "type": "text",
+                                            },
+                                            "parent": [Circular],
+                                            "prev": null,
+                                            "type": "tag",
+                                          },
+                                          Object {
+                                            "data": " Need help?",
+                                            "next": null,
+                                            "parent": [Circular],
+                                            "prev": Object {
+                                              "attribs": Object {
+                                                "class": "gridicon gridicons-help-outline",
+                                                "height": "24",
+                                                "viewbox": "0 0 24 24",
+                                                "width": "24",
+                                                "xmlns": "http://www.w3.org/2000/svg",
+                                              },
+                                              "children": Array [
+                                                Object {
+                                                  "attribs": Object {},
+                                                  "children": Array [
+                                                    Object {
+                                                      "attribs": Object {
+                                                        "d": "M12 4c4.41 0 8 3.59 8 8s-3.59 8-8 8-8-3.59-8-8 3.59-8 8-8m0-2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm4 8c0-2.21-1.79-4-4-4s-4 1.79-4 4h2c0-1.103.897-2 2-2s2 .897 2 2-.897 2-2 2c-.552 0-1 .448-1 1v2h2v-1.14c1.722-.447 3-1.998 3-3.86zm-3 6h-2v2h2v-2z",
+                                                      },
+                                                      "children": Array [],
+                                                      "name": "path",
+                                                      "next": null,
+                                                      "parent": [Circular],
+                                                      "prev": null,
+                                                      "type": "tag",
+                                                    },
+                                                  ],
+                                                  "name": "g",
+                                                  "next": null,
+                                                  "parent": [Circular],
+                                                  "prev": null,
+                                                  "type": "tag",
+                                                },
+                                              ],
+                                              "name": "svg",
+                                              "next": [Circular],
+                                              "parent": [Circular],
+                                              "prev": null,
+                                              "type": "tag",
+                                            },
+                                            "type": "text",
+                                          },
+                                        ],
+                                        "name": "a",
+                                        "next": null,
+                                        "parent": [Circular],
+                                        "prev": null,
+                                        "type": "tag",
+                                      },
+                                    ],
+                                    "name": "jetpack-connect--happychat-button",
                                     "next": null,
                                     "parent": [Circular],
                                     "prev": null,
@@ -1562,11 +1904,13 @@ initialize {
                                     "next": Object {
                                       "attribs": Object {},
                                       "children": Array [],
-                                      "name": "div",
+                                      "name": "components--data--query-plans",
                                       "next": Object {
-                                        "attribs": Object {},
+                                        "attribs": Object {
+                                          "siteid": "1234567",
+                                        },
                                         "children": Array [],
-                                        "name": "div",
+                                        "name": "components--data--query-site-plans",
                                         "next": Object {
                                           "attribs": Object {
                                             "class": "plans-features-main__group",
@@ -1574,9 +1918,40 @@ initialize {
                                           },
                                           "children": Array [
                                             Object {
-                                              "attribs": Object {},
+                                              "attribs": Object {
+                                                "baseplanspath": "/jetpack/connect/plans",
+                                                "displayjetpackplans": "true",
+                                                "isinsignup": "true",
+                                                "islandingpage": "false",
+                                                "onupgradeclick": "function (cartItem) {
+			var checkoutPath = '/checkout/' + _this.props.selectedSite.slug;
+			// clears whatever we had stored in local cache
+			_this.props.selectPlanInAdvance(null, _this.props.selectedSiteSlug);
+
+			if (!cartItem || cartItem.product_slug === _constants.PLAN_JETPACK_FREE) {
+				return _this.selectFreeJetpackPlan();
+			}
+
+			if (cartItem.product_slug === (0, _lodash.get)(_this.props, 'selectedSite.plan.product_slug', null)) {
+				return _this.redirect(CALYPSO_PLANS_PAGE);
+			}
+
+			_this.props.recordTracksEvent('calypso_jpc_plans_submit', {
+				user: _this.props.userId,
+				product_slug: cartItem.product_slug });
+
+			_analytics.mc.bumpStat('calypso_jpc_plan_selection', cartItem.product_slug);
+
+			(0, _actions2.addItem)(cartItem);
+			_this.redirecting = true;
+			_this.props.completeFlow();
+			_page2.default.redirect(checkoutPath);
+		}",
+                                                "plans": "jetpack_personal,jetpack_premium,jetpack_business",
+                                                "site": "[object Object]",
+                                              },
                                               "children": Array [],
-                                              "name": "div",
+                                              "name": "my-sites--plan-features",
                                               "next": null,
                                               "parent": [Circular],
                                               "prev": null,
@@ -1604,11 +1979,13 @@ initialize {
                                   Object {
                                     "attribs": Object {},
                                     "children": Array [],
-                                    "name": "div",
+                                    "name": "components--data--query-plans",
                                     "next": Object {
-                                      "attribs": Object {},
+                                      "attribs": Object {
+                                        "siteid": "1234567",
+                                      },
                                       "children": Array [],
-                                      "name": "div",
+                                      "name": "components--data--query-site-plans",
                                       "next": Object {
                                         "attribs": Object {
                                           "class": "plans-features-main__group",
@@ -1616,9 +1993,40 @@ initialize {
                                         },
                                         "children": Array [
                                           Object {
-                                            "attribs": Object {},
+                                            "attribs": Object {
+                                              "baseplanspath": "/jetpack/connect/plans",
+                                              "displayjetpackplans": "true",
+                                              "isinsignup": "true",
+                                              "islandingpage": "false",
+                                              "onupgradeclick": "function (cartItem) {
+			var checkoutPath = '/checkout/' + _this.props.selectedSite.slug;
+			// clears whatever we had stored in local cache
+			_this.props.selectPlanInAdvance(null, _this.props.selectedSiteSlug);
+
+			if (!cartItem || cartItem.product_slug === _constants.PLAN_JETPACK_FREE) {
+				return _this.selectFreeJetpackPlan();
+			}
+
+			if (cartItem.product_slug === (0, _lodash.get)(_this.props, 'selectedSite.plan.product_slug', null)) {
+				return _this.redirect(CALYPSO_PLANS_PAGE);
+			}
+
+			_this.props.recordTracksEvent('calypso_jpc_plans_submit', {
+				user: _this.props.userId,
+				product_slug: cartItem.product_slug });
+
+			_analytics.mc.bumpStat('calypso_jpc_plan_selection', cartItem.product_slug);
+
+			(0, _actions2.addItem)(cartItem);
+			_this.redirecting = true;
+			_this.props.completeFlow();
+			_page2.default.redirect(checkoutPath);
+		}",
+                                              "plans": "jetpack_personal,jetpack_premium,jetpack_business",
+                                              "site": "[object Object]",
+                                            },
                                             "children": Array [],
-                                            "name": "div",
+                                            "name": "my-sites--plan-features",
                                             "next": null,
                                             "parent": [Circular],
                                             "prev": null,
@@ -1838,9 +2246,11 @@ initialize {
                                     "type": "tag",
                                   },
                                   Object {
-                                    "attribs": Object {},
+                                    "attribs": Object {
+                                      "siteid": "1234567",
+                                    },
                                     "children": Array [],
-                                    "name": "div",
+                                    "name": "components--data--query-site-plans",
                                     "next": Object {
                                       "attribs": Object {
                                         "class": "plans-features-main__group",
@@ -1848,9 +2258,40 @@ initialize {
                                       },
                                       "children": Array [
                                         Object {
-                                          "attribs": Object {},
+                                          "attribs": Object {
+                                            "baseplanspath": "/jetpack/connect/plans",
+                                            "displayjetpackplans": "true",
+                                            "isinsignup": "true",
+                                            "islandingpage": "false",
+                                            "onupgradeclick": "function (cartItem) {
+			var checkoutPath = '/checkout/' + _this.props.selectedSite.slug;
+			// clears whatever we had stored in local cache
+			_this.props.selectPlanInAdvance(null, _this.props.selectedSiteSlug);
+
+			if (!cartItem || cartItem.product_slug === _constants.PLAN_JETPACK_FREE) {
+				return _this.selectFreeJetpackPlan();
+			}
+
+			if (cartItem.product_slug === (0, _lodash.get)(_this.props, 'selectedSite.plan.product_slug', null)) {
+				return _this.redirect(CALYPSO_PLANS_PAGE);
+			}
+
+			_this.props.recordTracksEvent('calypso_jpc_plans_submit', {
+				user: _this.props.userId,
+				product_slug: cartItem.product_slug });
+
+			_analytics.mc.bumpStat('calypso_jpc_plan_selection', cartItem.product_slug);
+
+			(0, _actions2.addItem)(cartItem);
+			_this.redirecting = true;
+			_this.props.completeFlow();
+			_page2.default.redirect(checkoutPath);
+		}",
+                                            "plans": "jetpack_personal,jetpack_premium,jetpack_business",
+                                            "site": "[object Object]",
+                                          },
                                           "children": Array [],
-                                          "name": "div",
+                                          "name": "my-sites--plan-features",
                                           "next": null,
                                           "parent": [Circular],
                                           "prev": null,
@@ -1867,7 +2308,7 @@ initialize {
                                     "prev": Object {
                                       "attribs": Object {},
                                       "children": Array [],
-                                      "name": "div",
+                                      "name": "components--data--query-plans",
                                       "next": [Circular],
                                       "parent": [Circular],
                                       "prev": Object {
@@ -2080,9 +2521,40 @@ initialize {
                                     },
                                     "children": Array [
                                       Object {
-                                        "attribs": Object {},
+                                        "attribs": Object {
+                                          "baseplanspath": "/jetpack/connect/plans",
+                                          "displayjetpackplans": "true",
+                                          "isinsignup": "true",
+                                          "islandingpage": "false",
+                                          "onupgradeclick": "function (cartItem) {
+			var checkoutPath = '/checkout/' + _this.props.selectedSite.slug;
+			// clears whatever we had stored in local cache
+			_this.props.selectPlanInAdvance(null, _this.props.selectedSiteSlug);
+
+			if (!cartItem || cartItem.product_slug === _constants.PLAN_JETPACK_FREE) {
+				return _this.selectFreeJetpackPlan();
+			}
+
+			if (cartItem.product_slug === (0, _lodash.get)(_this.props, 'selectedSite.plan.product_slug', null)) {
+				return _this.redirect(CALYPSO_PLANS_PAGE);
+			}
+
+			_this.props.recordTracksEvent('calypso_jpc_plans_submit', {
+				user: _this.props.userId,
+				product_slug: cartItem.product_slug });
+
+			_analytics.mc.bumpStat('calypso_jpc_plan_selection', cartItem.product_slug);
+
+			(0, _actions2.addItem)(cartItem);
+			_this.redirecting = true;
+			_this.props.completeFlow();
+			_page2.default.redirect(checkoutPath);
+		}",
+                                          "plans": "jetpack_personal,jetpack_premium,jetpack_business",
+                                          "site": "[object Object]",
+                                        },
                                         "children": Array [],
-                                        "name": "div",
+                                        "name": "my-sites--plan-features",
                                         "next": null,
                                         "parent": [Circular],
                                         "prev": null,
@@ -2093,15 +2565,17 @@ initialize {
                                     "next": null,
                                     "parent": [Circular],
                                     "prev": Object {
-                                      "attribs": Object {},
+                                      "attribs": Object {
+                                        "siteid": "1234567",
+                                      },
                                       "children": Array [],
-                                      "name": "div",
+                                      "name": "components--data--query-site-plans",
                                       "next": [Circular],
                                       "parent": [Circular],
                                       "prev": Object {
                                         "attribs": Object {},
                                         "children": Array [],
-                                        "name": "div",
+                                        "name": "components--data--query-plans",
                                         "next": [Circular],
                                         "parent": [Circular],
                                         "prev": Object {
@@ -2324,9 +2798,113 @@ initialize {
                               },
                               "children": Array [
                                 Object {
-                                  "attribs": Object {},
-                                  "children": Array [],
-                                  "name": "div",
+                                  "attribs": Object {
+                                    "label": "Need help?",
+                                  },
+                                  "children": Array [
+                                    Object {
+                                      "attribs": Object {
+                                        "class": "logged-out-form__link-item jetpack-connect__help-button",
+                                        "href": "https://jetpack.com/contact-support",
+                                        "rel": "noopener noreferrer",
+                                        "target": "_blank",
+                                      },
+                                      "children": Array [
+                                        Object {
+                                          "attribs": Object {
+                                            "class": "gridicon gridicons-help-outline",
+                                            "height": "24",
+                                            "viewbox": "0 0 24 24",
+                                            "width": "24",
+                                            "xmlns": "http://www.w3.org/2000/svg",
+                                          },
+                                          "children": Array [
+                                            Object {
+                                              "attribs": Object {},
+                                              "children": Array [
+                                                Object {
+                                                  "attribs": Object {
+                                                    "d": "M12 4c4.41 0 8 3.59 8 8s-3.59 8-8 8-8-3.59-8-8 3.59-8 8-8m0-2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm4 8c0-2.21-1.79-4-4-4s-4 1.79-4 4h2c0-1.103.897-2 2-2s2 .897 2 2-.897 2-2 2c-.552 0-1 .448-1 1v2h2v-1.14c1.722-.447 3-1.998 3-3.86zm-3 6h-2v2h2v-2z",
+                                                  },
+                                                  "children": Array [],
+                                                  "name": "path",
+                                                  "next": null,
+                                                  "parent": [Circular],
+                                                  "prev": null,
+                                                  "type": "tag",
+                                                },
+                                              ],
+                                              "name": "g",
+                                              "next": null,
+                                              "parent": [Circular],
+                                              "prev": null,
+                                              "type": "tag",
+                                            },
+                                          ],
+                                          "name": "svg",
+                                          "next": Object {
+                                            "data": " Need help?",
+                                            "next": null,
+                                            "parent": [Circular],
+                                            "prev": [Circular],
+                                            "type": "text",
+                                          },
+                                          "parent": [Circular],
+                                          "prev": null,
+                                          "type": "tag",
+                                        },
+                                        Object {
+                                          "data": " Need help?",
+                                          "next": null,
+                                          "parent": [Circular],
+                                          "prev": Object {
+                                            "attribs": Object {
+                                              "class": "gridicon gridicons-help-outline",
+                                              "height": "24",
+                                              "viewbox": "0 0 24 24",
+                                              "width": "24",
+                                              "xmlns": "http://www.w3.org/2000/svg",
+                                            },
+                                            "children": Array [
+                                              Object {
+                                                "attribs": Object {},
+                                                "children": Array [
+                                                  Object {
+                                                    "attribs": Object {
+                                                      "d": "M12 4c4.41 0 8 3.59 8 8s-3.59 8-8 8-8-3.59-8-8 3.59-8 8-8m0-2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm4 8c0-2.21-1.79-4-4-4s-4 1.79-4 4h2c0-1.103.897-2 2-2s2 .897 2 2-.897 2-2 2c-.552 0-1 .448-1 1v2h2v-1.14c1.722-.447 3-1.998 3-3.86zm-3 6h-2v2h2v-2z",
+                                                    },
+                                                    "children": Array [],
+                                                    "name": "path",
+                                                    "next": null,
+                                                    "parent": [Circular],
+                                                    "prev": null,
+                                                    "type": "tag",
+                                                  },
+                                                ],
+                                                "name": "g",
+                                                "next": null,
+                                                "parent": [Circular],
+                                                "prev": null,
+                                                "type": "tag",
+                                              },
+                                            ],
+                                            "name": "svg",
+                                            "next": [Circular],
+                                            "parent": [Circular],
+                                            "prev": null,
+                                            "type": "tag",
+                                          },
+                                          "type": "text",
+                                        },
+                                      ],
+                                      "name": "a",
+                                      "next": null,
+                                      "parent": [Circular],
+                                      "prev": null,
+                                      "type": "tag",
+                                    },
+                                  ],
+                                  "name": "jetpack-connect--happychat-button",
                                   "next": null,
                                   "parent": [Circular],
                                   "prev": null,
@@ -2646,11 +3224,13 @@ initialize {
                                       "next": Object {
                                         "attribs": Object {},
                                         "children": Array [],
-                                        "name": "div",
+                                        "name": "components--data--query-plans",
                                         "next": Object {
-                                          "attribs": Object {},
+                                          "attribs": Object {
+                                            "siteid": "1234567",
+                                          },
                                           "children": Array [],
-                                          "name": "div",
+                                          "name": "components--data--query-site-plans",
                                           "next": Object {
                                             "attribs": Object {
                                               "class": "plans-features-main__group",
@@ -2658,9 +3238,40 @@ initialize {
                                             },
                                             "children": Array [
                                               Object {
-                                                "attribs": Object {},
+                                                "attribs": Object {
+                                                  "baseplanspath": "/jetpack/connect/plans",
+                                                  "displayjetpackplans": "true",
+                                                  "isinsignup": "true",
+                                                  "islandingpage": "false",
+                                                  "onupgradeclick": "function (cartItem) {
+			var checkoutPath = '/checkout/' + _this.props.selectedSite.slug;
+			// clears whatever we had stored in local cache
+			_this.props.selectPlanInAdvance(null, _this.props.selectedSiteSlug);
+
+			if (!cartItem || cartItem.product_slug === _constants.PLAN_JETPACK_FREE) {
+				return _this.selectFreeJetpackPlan();
+			}
+
+			if (cartItem.product_slug === (0, _lodash.get)(_this.props, 'selectedSite.plan.product_slug', null)) {
+				return _this.redirect(CALYPSO_PLANS_PAGE);
+			}
+
+			_this.props.recordTracksEvent('calypso_jpc_plans_submit', {
+				user: _this.props.userId,
+				product_slug: cartItem.product_slug });
+
+			_analytics.mc.bumpStat('calypso_jpc_plan_selection', cartItem.product_slug);
+
+			(0, _actions2.addItem)(cartItem);
+			_this.redirecting = true;
+			_this.props.completeFlow();
+			_page2.default.redirect(checkoutPath);
+		}",
+                                                  "plans": "jetpack_personal,jetpack_premium,jetpack_business",
+                                                  "site": "[object Object]",
+                                                },
                                                 "children": Array [],
-                                                "name": "div",
+                                                "name": "my-sites--plan-features",
                                                 "next": null,
                                                 "parent": [Circular],
                                                 "prev": null,
@@ -2688,11 +3299,13 @@ initialize {
                                     Object {
                                       "attribs": Object {},
                                       "children": Array [],
-                                      "name": "div",
+                                      "name": "components--data--query-plans",
                                       "next": Object {
-                                        "attribs": Object {},
+                                        "attribs": Object {
+                                          "siteid": "1234567",
+                                        },
                                         "children": Array [],
-                                        "name": "div",
+                                        "name": "components--data--query-site-plans",
                                         "next": Object {
                                           "attribs": Object {
                                             "class": "plans-features-main__group",
@@ -2700,9 +3313,40 @@ initialize {
                                           },
                                           "children": Array [
                                             Object {
-                                              "attribs": Object {},
+                                              "attribs": Object {
+                                                "baseplanspath": "/jetpack/connect/plans",
+                                                "displayjetpackplans": "true",
+                                                "isinsignup": "true",
+                                                "islandingpage": "false",
+                                                "onupgradeclick": "function (cartItem) {
+			var checkoutPath = '/checkout/' + _this.props.selectedSite.slug;
+			// clears whatever we had stored in local cache
+			_this.props.selectPlanInAdvance(null, _this.props.selectedSiteSlug);
+
+			if (!cartItem || cartItem.product_slug === _constants.PLAN_JETPACK_FREE) {
+				return _this.selectFreeJetpackPlan();
+			}
+
+			if (cartItem.product_slug === (0, _lodash.get)(_this.props, 'selectedSite.plan.product_slug', null)) {
+				return _this.redirect(CALYPSO_PLANS_PAGE);
+			}
+
+			_this.props.recordTracksEvent('calypso_jpc_plans_submit', {
+				user: _this.props.userId,
+				product_slug: cartItem.product_slug });
+
+			_analytics.mc.bumpStat('calypso_jpc_plan_selection', cartItem.product_slug);
+
+			(0, _actions2.addItem)(cartItem);
+			_this.redirecting = true;
+			_this.props.completeFlow();
+			_page2.default.redirect(checkoutPath);
+		}",
+                                                "plans": "jetpack_personal,jetpack_premium,jetpack_business",
+                                                "site": "[object Object]",
+                                              },
                                               "children": Array [],
-                                              "name": "div",
+                                              "name": "my-sites--plan-features",
                                               "next": null,
                                               "parent": [Circular],
                                               "prev": null,
@@ -2922,9 +3566,11 @@ initialize {
                                       "type": "tag",
                                     },
                                     Object {
-                                      "attribs": Object {},
+                                      "attribs": Object {
+                                        "siteid": "1234567",
+                                      },
                                       "children": Array [],
-                                      "name": "div",
+                                      "name": "components--data--query-site-plans",
                                       "next": Object {
                                         "attribs": Object {
                                           "class": "plans-features-main__group",
@@ -2932,9 +3578,40 @@ initialize {
                                         },
                                         "children": Array [
                                           Object {
-                                            "attribs": Object {},
+                                            "attribs": Object {
+                                              "baseplanspath": "/jetpack/connect/plans",
+                                              "displayjetpackplans": "true",
+                                              "isinsignup": "true",
+                                              "islandingpage": "false",
+                                              "onupgradeclick": "function (cartItem) {
+			var checkoutPath = '/checkout/' + _this.props.selectedSite.slug;
+			// clears whatever we had stored in local cache
+			_this.props.selectPlanInAdvance(null, _this.props.selectedSiteSlug);
+
+			if (!cartItem || cartItem.product_slug === _constants.PLAN_JETPACK_FREE) {
+				return _this.selectFreeJetpackPlan();
+			}
+
+			if (cartItem.product_slug === (0, _lodash.get)(_this.props, 'selectedSite.plan.product_slug', null)) {
+				return _this.redirect(CALYPSO_PLANS_PAGE);
+			}
+
+			_this.props.recordTracksEvent('calypso_jpc_plans_submit', {
+				user: _this.props.userId,
+				product_slug: cartItem.product_slug });
+
+			_analytics.mc.bumpStat('calypso_jpc_plan_selection', cartItem.product_slug);
+
+			(0, _actions2.addItem)(cartItem);
+			_this.redirecting = true;
+			_this.props.completeFlow();
+			_page2.default.redirect(checkoutPath);
+		}",
+                                              "plans": "jetpack_personal,jetpack_premium,jetpack_business",
+                                              "site": "[object Object]",
+                                            },
                                             "children": Array [],
-                                            "name": "div",
+                                            "name": "my-sites--plan-features",
                                             "next": null,
                                             "parent": [Circular],
                                             "prev": null,
@@ -2951,7 +3628,7 @@ initialize {
                                       "prev": Object {
                                         "attribs": Object {},
                                         "children": Array [],
-                                        "name": "div",
+                                        "name": "components--data--query-plans",
                                         "next": [Circular],
                                         "parent": [Circular],
                                         "prev": Object {
@@ -3164,9 +3841,40 @@ initialize {
                                       },
                                       "children": Array [
                                         Object {
-                                          "attribs": Object {},
+                                          "attribs": Object {
+                                            "baseplanspath": "/jetpack/connect/plans",
+                                            "displayjetpackplans": "true",
+                                            "isinsignup": "true",
+                                            "islandingpage": "false",
+                                            "onupgradeclick": "function (cartItem) {
+			var checkoutPath = '/checkout/' + _this.props.selectedSite.slug;
+			// clears whatever we had stored in local cache
+			_this.props.selectPlanInAdvance(null, _this.props.selectedSiteSlug);
+
+			if (!cartItem || cartItem.product_slug === _constants.PLAN_JETPACK_FREE) {
+				return _this.selectFreeJetpackPlan();
+			}
+
+			if (cartItem.product_slug === (0, _lodash.get)(_this.props, 'selectedSite.plan.product_slug', null)) {
+				return _this.redirect(CALYPSO_PLANS_PAGE);
+			}
+
+			_this.props.recordTracksEvent('calypso_jpc_plans_submit', {
+				user: _this.props.userId,
+				product_slug: cartItem.product_slug });
+
+			_analytics.mc.bumpStat('calypso_jpc_plan_selection', cartItem.product_slug);
+
+			(0, _actions2.addItem)(cartItem);
+			_this.redirecting = true;
+			_this.props.completeFlow();
+			_page2.default.redirect(checkoutPath);
+		}",
+                                            "plans": "jetpack_personal,jetpack_premium,jetpack_business",
+                                            "site": "[object Object]",
+                                          },
                                           "children": Array [],
-                                          "name": "div",
+                                          "name": "my-sites--plan-features",
                                           "next": null,
                                           "parent": [Circular],
                                           "prev": null,
@@ -3177,15 +3885,17 @@ initialize {
                                       "next": null,
                                       "parent": [Circular],
                                       "prev": Object {
-                                        "attribs": Object {},
+                                        "attribs": Object {
+                                          "siteid": "1234567",
+                                        },
                                         "children": Array [],
-                                        "name": "div",
+                                        "name": "components--data--query-site-plans",
                                         "next": [Circular],
                                         "parent": [Circular],
                                         "prev": Object {
                                           "attribs": Object {},
                                           "children": Array [],
-                                          "name": "div",
+                                          "name": "components--data--query-plans",
                                           "next": [Circular],
                                           "parent": [Circular],
                                           "prev": Object {
@@ -3622,11 +4332,13 @@ initialize {
                                 "next": Object {
                                   "attribs": Object {},
                                   "children": Array [],
-                                  "name": "div",
+                                  "name": "components--data--query-plans",
                                   "next": Object {
-                                    "attribs": Object {},
+                                    "attribs": Object {
+                                      "siteid": "1234567",
+                                    },
                                     "children": Array [],
-                                    "name": "div",
+                                    "name": "components--data--query-site-plans",
                                     "next": Object {
                                       "attribs": Object {
                                         "class": "plans-features-main__group",
@@ -3634,9 +4346,40 @@ initialize {
                                       },
                                       "children": Array [
                                         Object {
-                                          "attribs": Object {},
+                                          "attribs": Object {
+                                            "baseplanspath": "/jetpack/connect/plans",
+                                            "displayjetpackplans": "true",
+                                            "isinsignup": "true",
+                                            "islandingpage": "false",
+                                            "onupgradeclick": "function (cartItem) {
+			var checkoutPath = '/checkout/' + _this.props.selectedSite.slug;
+			// clears whatever we had stored in local cache
+			_this.props.selectPlanInAdvance(null, _this.props.selectedSiteSlug);
+
+			if (!cartItem || cartItem.product_slug === _constants.PLAN_JETPACK_FREE) {
+				return _this.selectFreeJetpackPlan();
+			}
+
+			if (cartItem.product_slug === (0, _lodash.get)(_this.props, 'selectedSite.plan.product_slug', null)) {
+				return _this.redirect(CALYPSO_PLANS_PAGE);
+			}
+
+			_this.props.recordTracksEvent('calypso_jpc_plans_submit', {
+				user: _this.props.userId,
+				product_slug: cartItem.product_slug });
+
+			_analytics.mc.bumpStat('calypso_jpc_plan_selection', cartItem.product_slug);
+
+			(0, _actions2.addItem)(cartItem);
+			_this.redirecting = true;
+			_this.props.completeFlow();
+			_page2.default.redirect(checkoutPath);
+		}",
+                                            "plans": "jetpack_personal,jetpack_premium,jetpack_business",
+                                            "site": "[object Object]",
+                                          },
                                           "children": Array [],
-                                          "name": "div",
+                                          "name": "my-sites--plan-features",
                                           "next": null,
                                           "parent": [Circular],
                                           "prev": null,
@@ -3664,11 +4407,13 @@ initialize {
                               Object {
                                 "attribs": Object {},
                                 "children": Array [],
-                                "name": "div",
+                                "name": "components--data--query-plans",
                                 "next": Object {
-                                  "attribs": Object {},
+                                  "attribs": Object {
+                                    "siteid": "1234567",
+                                  },
                                   "children": Array [],
-                                  "name": "div",
+                                  "name": "components--data--query-site-plans",
                                   "next": Object {
                                     "attribs": Object {
                                       "class": "plans-features-main__group",
@@ -3676,9 +4421,40 @@ initialize {
                                     },
                                     "children": Array [
                                       Object {
-                                        "attribs": Object {},
+                                        "attribs": Object {
+                                          "baseplanspath": "/jetpack/connect/plans",
+                                          "displayjetpackplans": "true",
+                                          "isinsignup": "true",
+                                          "islandingpage": "false",
+                                          "onupgradeclick": "function (cartItem) {
+			var checkoutPath = '/checkout/' + _this.props.selectedSite.slug;
+			// clears whatever we had stored in local cache
+			_this.props.selectPlanInAdvance(null, _this.props.selectedSiteSlug);
+
+			if (!cartItem || cartItem.product_slug === _constants.PLAN_JETPACK_FREE) {
+				return _this.selectFreeJetpackPlan();
+			}
+
+			if (cartItem.product_slug === (0, _lodash.get)(_this.props, 'selectedSite.plan.product_slug', null)) {
+				return _this.redirect(CALYPSO_PLANS_PAGE);
+			}
+
+			_this.props.recordTracksEvent('calypso_jpc_plans_submit', {
+				user: _this.props.userId,
+				product_slug: cartItem.product_slug });
+
+			_analytics.mc.bumpStat('calypso_jpc_plan_selection', cartItem.product_slug);
+
+			(0, _actions2.addItem)(cartItem);
+			_this.redirecting = true;
+			_this.props.completeFlow();
+			_page2.default.redirect(checkoutPath);
+		}",
+                                          "plans": "jetpack_personal,jetpack_premium,jetpack_business",
+                                          "site": "[object Object]",
+                                        },
                                         "children": Array [],
-                                        "name": "div",
+                                        "name": "my-sites--plan-features",
                                         "next": null,
                                         "parent": [Circular],
                                         "prev": null,
@@ -3898,9 +4674,11 @@ initialize {
                                 "type": "tag",
                               },
                               Object {
-                                "attribs": Object {},
+                                "attribs": Object {
+                                  "siteid": "1234567",
+                                },
                                 "children": Array [],
-                                "name": "div",
+                                "name": "components--data--query-site-plans",
                                 "next": Object {
                                   "attribs": Object {
                                     "class": "plans-features-main__group",
@@ -3908,9 +4686,40 @@ initialize {
                                   },
                                   "children": Array [
                                     Object {
-                                      "attribs": Object {},
+                                      "attribs": Object {
+                                        "baseplanspath": "/jetpack/connect/plans",
+                                        "displayjetpackplans": "true",
+                                        "isinsignup": "true",
+                                        "islandingpage": "false",
+                                        "onupgradeclick": "function (cartItem) {
+			var checkoutPath = '/checkout/' + _this.props.selectedSite.slug;
+			// clears whatever we had stored in local cache
+			_this.props.selectPlanInAdvance(null, _this.props.selectedSiteSlug);
+
+			if (!cartItem || cartItem.product_slug === _constants.PLAN_JETPACK_FREE) {
+				return _this.selectFreeJetpackPlan();
+			}
+
+			if (cartItem.product_slug === (0, _lodash.get)(_this.props, 'selectedSite.plan.product_slug', null)) {
+				return _this.redirect(CALYPSO_PLANS_PAGE);
+			}
+
+			_this.props.recordTracksEvent('calypso_jpc_plans_submit', {
+				user: _this.props.userId,
+				product_slug: cartItem.product_slug });
+
+			_analytics.mc.bumpStat('calypso_jpc_plan_selection', cartItem.product_slug);
+
+			(0, _actions2.addItem)(cartItem);
+			_this.redirecting = true;
+			_this.props.completeFlow();
+			_page2.default.redirect(checkoutPath);
+		}",
+                                        "plans": "jetpack_personal,jetpack_premium,jetpack_business",
+                                        "site": "[object Object]",
+                                      },
                                       "children": Array [],
-                                      "name": "div",
+                                      "name": "my-sites--plan-features",
                                       "next": null,
                                       "parent": [Circular],
                                       "prev": null,
@@ -3927,7 +4736,7 @@ initialize {
                                 "prev": Object {
                                   "attribs": Object {},
                                   "children": Array [],
-                                  "name": "div",
+                                  "name": "components--data--query-plans",
                                   "next": [Circular],
                                   "parent": [Circular],
                                   "prev": Object {
@@ -4140,9 +4949,40 @@ initialize {
                                 },
                                 "children": Array [
                                   Object {
-                                    "attribs": Object {},
+                                    "attribs": Object {
+                                      "baseplanspath": "/jetpack/connect/plans",
+                                      "displayjetpackplans": "true",
+                                      "isinsignup": "true",
+                                      "islandingpage": "false",
+                                      "onupgradeclick": "function (cartItem) {
+			var checkoutPath = '/checkout/' + _this.props.selectedSite.slug;
+			// clears whatever we had stored in local cache
+			_this.props.selectPlanInAdvance(null, _this.props.selectedSiteSlug);
+
+			if (!cartItem || cartItem.product_slug === _constants.PLAN_JETPACK_FREE) {
+				return _this.selectFreeJetpackPlan();
+			}
+
+			if (cartItem.product_slug === (0, _lodash.get)(_this.props, 'selectedSite.plan.product_slug', null)) {
+				return _this.redirect(CALYPSO_PLANS_PAGE);
+			}
+
+			_this.props.recordTracksEvent('calypso_jpc_plans_submit', {
+				user: _this.props.userId,
+				product_slug: cartItem.product_slug });
+
+			_analytics.mc.bumpStat('calypso_jpc_plan_selection', cartItem.product_slug);
+
+			(0, _actions2.addItem)(cartItem);
+			_this.redirecting = true;
+			_this.props.completeFlow();
+			_page2.default.redirect(checkoutPath);
+		}",
+                                      "plans": "jetpack_personal,jetpack_premium,jetpack_business",
+                                      "site": "[object Object]",
+                                    },
                                     "children": Array [],
-                                    "name": "div",
+                                    "name": "my-sites--plan-features",
                                     "next": null,
                                     "parent": [Circular],
                                     "prev": null,
@@ -4153,15 +4993,17 @@ initialize {
                                 "next": null,
                                 "parent": [Circular],
                                 "prev": Object {
-                                  "attribs": Object {},
+                                  "attribs": Object {
+                                    "siteid": "1234567",
+                                  },
                                   "children": Array [],
-                                  "name": "div",
+                                  "name": "components--data--query-site-plans",
                                   "next": [Circular],
                                   "parent": [Circular],
                                   "prev": Object {
                                     "attribs": Object {},
                                     "children": Array [],
-                                    "name": "div",
+                                    "name": "components--data--query-plans",
                                     "next": [Circular],
                                     "parent": [Circular],
                                     "prev": Object {
@@ -4483,9 +5325,113 @@ initialize {
                                 },
                                 "children": Array [
                                   Object {
-                                    "attribs": Object {},
-                                    "children": Array [],
-                                    "name": "div",
+                                    "attribs": Object {
+                                      "label": "Need help?",
+                                    },
+                                    "children": Array [
+                                      Object {
+                                        "attribs": Object {
+                                          "class": "logged-out-form__link-item jetpack-connect__help-button",
+                                          "href": "https://jetpack.com/contact-support",
+                                          "rel": "noopener noreferrer",
+                                          "target": "_blank",
+                                        },
+                                        "children": Array [
+                                          Object {
+                                            "attribs": Object {
+                                              "class": "gridicon gridicons-help-outline",
+                                              "height": "24",
+                                              "viewbox": "0 0 24 24",
+                                              "width": "24",
+                                              "xmlns": "http://www.w3.org/2000/svg",
+                                            },
+                                            "children": Array [
+                                              Object {
+                                                "attribs": Object {},
+                                                "children": Array [
+                                                  Object {
+                                                    "attribs": Object {
+                                                      "d": "M12 4c4.41 0 8 3.59 8 8s-3.59 8-8 8-8-3.59-8-8 3.59-8 8-8m0-2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm4 8c0-2.21-1.79-4-4-4s-4 1.79-4 4h2c0-1.103.897-2 2-2s2 .897 2 2-.897 2-2 2c-.552 0-1 .448-1 1v2h2v-1.14c1.722-.447 3-1.998 3-3.86zm-3 6h-2v2h2v-2z",
+                                                    },
+                                                    "children": Array [],
+                                                    "name": "path",
+                                                    "next": null,
+                                                    "parent": [Circular],
+                                                    "prev": null,
+                                                    "type": "tag",
+                                                  },
+                                                ],
+                                                "name": "g",
+                                                "next": null,
+                                                "parent": [Circular],
+                                                "prev": null,
+                                                "type": "tag",
+                                              },
+                                            ],
+                                            "name": "svg",
+                                            "next": Object {
+                                              "data": " Need help?",
+                                              "next": null,
+                                              "parent": [Circular],
+                                              "prev": [Circular],
+                                              "type": "text",
+                                            },
+                                            "parent": [Circular],
+                                            "prev": null,
+                                            "type": "tag",
+                                          },
+                                          Object {
+                                            "data": " Need help?",
+                                            "next": null,
+                                            "parent": [Circular],
+                                            "prev": Object {
+                                              "attribs": Object {
+                                                "class": "gridicon gridicons-help-outline",
+                                                "height": "24",
+                                                "viewbox": "0 0 24 24",
+                                                "width": "24",
+                                                "xmlns": "http://www.w3.org/2000/svg",
+                                              },
+                                              "children": Array [
+                                                Object {
+                                                  "attribs": Object {},
+                                                  "children": Array [
+                                                    Object {
+                                                      "attribs": Object {
+                                                        "d": "M12 4c4.41 0 8 3.59 8 8s-3.59 8-8 8-8-3.59-8-8 3.59-8 8-8m0-2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm4 8c0-2.21-1.79-4-4-4s-4 1.79-4 4h2c0-1.103.897-2 2-2s2 .897 2 2-.897 2-2 2c-.552 0-1 .448-1 1v2h2v-1.14c1.722-.447 3-1.998 3-3.86zm-3 6h-2v2h2v-2z",
+                                                      },
+                                                      "children": Array [],
+                                                      "name": "path",
+                                                      "next": null,
+                                                      "parent": [Circular],
+                                                      "prev": null,
+                                                      "type": "tag",
+                                                    },
+                                                  ],
+                                                  "name": "g",
+                                                  "next": null,
+                                                  "parent": [Circular],
+                                                  "prev": null,
+                                                  "type": "tag",
+                                                },
+                                              ],
+                                              "name": "svg",
+                                              "next": [Circular],
+                                              "parent": [Circular],
+                                              "prev": null,
+                                              "type": "tag",
+                                            },
+                                            "type": "text",
+                                          },
+                                        ],
+                                        "name": "a",
+                                        "next": null,
+                                        "parent": [Circular],
+                                        "prev": null,
+                                        "type": "tag",
+                                      },
+                                    ],
+                                    "name": "jetpack-connect--happychat-button",
                                     "next": null,
                                     "parent": [Circular],
                                     "prev": null,
@@ -4618,9 +5564,113 @@ initialize {
                               },
                               "children": Array [
                                 Object {
-                                  "attribs": Object {},
-                                  "children": Array [],
-                                  "name": "div",
+                                  "attribs": Object {
+                                    "label": "Need help?",
+                                  },
+                                  "children": Array [
+                                    Object {
+                                      "attribs": Object {
+                                        "class": "logged-out-form__link-item jetpack-connect__help-button",
+                                        "href": "https://jetpack.com/contact-support",
+                                        "rel": "noopener noreferrer",
+                                        "target": "_blank",
+                                      },
+                                      "children": Array [
+                                        Object {
+                                          "attribs": Object {
+                                            "class": "gridicon gridicons-help-outline",
+                                            "height": "24",
+                                            "viewbox": "0 0 24 24",
+                                            "width": "24",
+                                            "xmlns": "http://www.w3.org/2000/svg",
+                                          },
+                                          "children": Array [
+                                            Object {
+                                              "attribs": Object {},
+                                              "children": Array [
+                                                Object {
+                                                  "attribs": Object {
+                                                    "d": "M12 4c4.41 0 8 3.59 8 8s-3.59 8-8 8-8-3.59-8-8 3.59-8 8-8m0-2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm4 8c0-2.21-1.79-4-4-4s-4 1.79-4 4h2c0-1.103.897-2 2-2s2 .897 2 2-.897 2-2 2c-.552 0-1 .448-1 1v2h2v-1.14c1.722-.447 3-1.998 3-3.86zm-3 6h-2v2h2v-2z",
+                                                  },
+                                                  "children": Array [],
+                                                  "name": "path",
+                                                  "next": null,
+                                                  "parent": [Circular],
+                                                  "prev": null,
+                                                  "type": "tag",
+                                                },
+                                              ],
+                                              "name": "g",
+                                              "next": null,
+                                              "parent": [Circular],
+                                              "prev": null,
+                                              "type": "tag",
+                                            },
+                                          ],
+                                          "name": "svg",
+                                          "next": Object {
+                                            "data": " Need help?",
+                                            "next": null,
+                                            "parent": [Circular],
+                                            "prev": [Circular],
+                                            "type": "text",
+                                          },
+                                          "parent": [Circular],
+                                          "prev": null,
+                                          "type": "tag",
+                                        },
+                                        Object {
+                                          "data": " Need help?",
+                                          "next": null,
+                                          "parent": [Circular],
+                                          "prev": Object {
+                                            "attribs": Object {
+                                              "class": "gridicon gridicons-help-outline",
+                                              "height": "24",
+                                              "viewbox": "0 0 24 24",
+                                              "width": "24",
+                                              "xmlns": "http://www.w3.org/2000/svg",
+                                            },
+                                            "children": Array [
+                                              Object {
+                                                "attribs": Object {},
+                                                "children": Array [
+                                                  Object {
+                                                    "attribs": Object {
+                                                      "d": "M12 4c4.41 0 8 3.59 8 8s-3.59 8-8 8-8-3.59-8-8 3.59-8 8-8m0-2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm4 8c0-2.21-1.79-4-4-4s-4 1.79-4 4h2c0-1.103.897-2 2-2s2 .897 2 2-.897 2-2 2c-.552 0-1 .448-1 1v2h2v-1.14c1.722-.447 3-1.998 3-3.86zm-3 6h-2v2h2v-2z",
+                                                    },
+                                                    "children": Array [],
+                                                    "name": "path",
+                                                    "next": null,
+                                                    "parent": [Circular],
+                                                    "prev": null,
+                                                    "type": "tag",
+                                                  },
+                                                ],
+                                                "name": "g",
+                                                "next": null,
+                                                "parent": [Circular],
+                                                "prev": null,
+                                                "type": "tag",
+                                              },
+                                            ],
+                                            "name": "svg",
+                                            "next": [Circular],
+                                            "parent": [Circular],
+                                            "prev": null,
+                                            "type": "tag",
+                                          },
+                                          "type": "text",
+                                        },
+                                      ],
+                                      "name": "a",
+                                      "next": null,
+                                      "parent": [Circular],
+                                      "prev": null,
+                                      "type": "tag",
+                                    },
+                                  ],
+                                  "name": "jetpack-connect--happychat-button",
                                   "next": null,
                                   "parent": [Circular],
                                   "prev": null,
@@ -4836,11 +5886,13 @@ initialize {
                                   "next": Object {
                                     "attribs": Object {},
                                     "children": Array [],
-                                    "name": "div",
+                                    "name": "components--data--query-plans",
                                     "next": Object {
-                                      "attribs": Object {},
+                                      "attribs": Object {
+                                        "siteid": "1234567",
+                                      },
                                       "children": Array [],
-                                      "name": "div",
+                                      "name": "components--data--query-site-plans",
                                       "next": Object {
                                         "attribs": Object {
                                           "class": "plans-features-main__group",
@@ -4848,9 +5900,40 @@ initialize {
                                         },
                                         "children": Array [
                                           Object {
-                                            "attribs": Object {},
+                                            "attribs": Object {
+                                              "baseplanspath": "/jetpack/connect/plans",
+                                              "displayjetpackplans": "true",
+                                              "isinsignup": "true",
+                                              "islandingpage": "false",
+                                              "onupgradeclick": "function (cartItem) {
+			var checkoutPath = '/checkout/' + _this.props.selectedSite.slug;
+			// clears whatever we had stored in local cache
+			_this.props.selectPlanInAdvance(null, _this.props.selectedSiteSlug);
+
+			if (!cartItem || cartItem.product_slug === _constants.PLAN_JETPACK_FREE) {
+				return _this.selectFreeJetpackPlan();
+			}
+
+			if (cartItem.product_slug === (0, _lodash.get)(_this.props, 'selectedSite.plan.product_slug', null)) {
+				return _this.redirect(CALYPSO_PLANS_PAGE);
+			}
+
+			_this.props.recordTracksEvent('calypso_jpc_plans_submit', {
+				user: _this.props.userId,
+				product_slug: cartItem.product_slug });
+
+			_analytics.mc.bumpStat('calypso_jpc_plan_selection', cartItem.product_slug);
+
+			(0, _actions2.addItem)(cartItem);
+			_this.redirecting = true;
+			_this.props.completeFlow();
+			_page2.default.redirect(checkoutPath);
+		}",
+                                              "plans": "jetpack_personal,jetpack_premium,jetpack_business",
+                                              "site": "[object Object]",
+                                            },
                                             "children": Array [],
-                                            "name": "div",
+                                            "name": "my-sites--plan-features",
                                             "next": null,
                                             "parent": [Circular],
                                             "prev": null,
@@ -4878,11 +5961,13 @@ initialize {
                                 Object {
                                   "attribs": Object {},
                                   "children": Array [],
-                                  "name": "div",
+                                  "name": "components--data--query-plans",
                                   "next": Object {
-                                    "attribs": Object {},
+                                    "attribs": Object {
+                                      "siteid": "1234567",
+                                    },
                                     "children": Array [],
-                                    "name": "div",
+                                    "name": "components--data--query-site-plans",
                                     "next": Object {
                                       "attribs": Object {
                                         "class": "plans-features-main__group",
@@ -4890,9 +5975,40 @@ initialize {
                                       },
                                       "children": Array [
                                         Object {
-                                          "attribs": Object {},
+                                          "attribs": Object {
+                                            "baseplanspath": "/jetpack/connect/plans",
+                                            "displayjetpackplans": "true",
+                                            "isinsignup": "true",
+                                            "islandingpage": "false",
+                                            "onupgradeclick": "function (cartItem) {
+			var checkoutPath = '/checkout/' + _this.props.selectedSite.slug;
+			// clears whatever we had stored in local cache
+			_this.props.selectPlanInAdvance(null, _this.props.selectedSiteSlug);
+
+			if (!cartItem || cartItem.product_slug === _constants.PLAN_JETPACK_FREE) {
+				return _this.selectFreeJetpackPlan();
+			}
+
+			if (cartItem.product_slug === (0, _lodash.get)(_this.props, 'selectedSite.plan.product_slug', null)) {
+				return _this.redirect(CALYPSO_PLANS_PAGE);
+			}
+
+			_this.props.recordTracksEvent('calypso_jpc_plans_submit', {
+				user: _this.props.userId,
+				product_slug: cartItem.product_slug });
+
+			_analytics.mc.bumpStat('calypso_jpc_plan_selection', cartItem.product_slug);
+
+			(0, _actions2.addItem)(cartItem);
+			_this.redirecting = true;
+			_this.props.completeFlow();
+			_page2.default.redirect(checkoutPath);
+		}",
+                                            "plans": "jetpack_personal,jetpack_premium,jetpack_business",
+                                            "site": "[object Object]",
+                                          },
                                           "children": Array [],
-                                          "name": "div",
+                                          "name": "my-sites--plan-features",
                                           "next": null,
                                           "parent": [Circular],
                                           "prev": null,
@@ -5112,9 +6228,11 @@ initialize {
                                   "type": "tag",
                                 },
                                 Object {
-                                  "attribs": Object {},
+                                  "attribs": Object {
+                                    "siteid": "1234567",
+                                  },
                                   "children": Array [],
-                                  "name": "div",
+                                  "name": "components--data--query-site-plans",
                                   "next": Object {
                                     "attribs": Object {
                                       "class": "plans-features-main__group",
@@ -5122,9 +6240,40 @@ initialize {
                                     },
                                     "children": Array [
                                       Object {
-                                        "attribs": Object {},
+                                        "attribs": Object {
+                                          "baseplanspath": "/jetpack/connect/plans",
+                                          "displayjetpackplans": "true",
+                                          "isinsignup": "true",
+                                          "islandingpage": "false",
+                                          "onupgradeclick": "function (cartItem) {
+			var checkoutPath = '/checkout/' + _this.props.selectedSite.slug;
+			// clears whatever we had stored in local cache
+			_this.props.selectPlanInAdvance(null, _this.props.selectedSiteSlug);
+
+			if (!cartItem || cartItem.product_slug === _constants.PLAN_JETPACK_FREE) {
+				return _this.selectFreeJetpackPlan();
+			}
+
+			if (cartItem.product_slug === (0, _lodash.get)(_this.props, 'selectedSite.plan.product_slug', null)) {
+				return _this.redirect(CALYPSO_PLANS_PAGE);
+			}
+
+			_this.props.recordTracksEvent('calypso_jpc_plans_submit', {
+				user: _this.props.userId,
+				product_slug: cartItem.product_slug });
+
+			_analytics.mc.bumpStat('calypso_jpc_plan_selection', cartItem.product_slug);
+
+			(0, _actions2.addItem)(cartItem);
+			_this.redirecting = true;
+			_this.props.completeFlow();
+			_page2.default.redirect(checkoutPath);
+		}",
+                                          "plans": "jetpack_personal,jetpack_premium,jetpack_business",
+                                          "site": "[object Object]",
+                                        },
                                         "children": Array [],
-                                        "name": "div",
+                                        "name": "my-sites--plan-features",
                                         "next": null,
                                         "parent": [Circular],
                                         "prev": null,
@@ -5141,7 +6290,7 @@ initialize {
                                   "prev": Object {
                                     "attribs": Object {},
                                     "children": Array [],
-                                    "name": "div",
+                                    "name": "components--data--query-plans",
                                     "next": [Circular],
                                     "parent": [Circular],
                                     "prev": Object {
@@ -5354,9 +6503,40 @@ initialize {
                                   },
                                   "children": Array [
                                     Object {
-                                      "attribs": Object {},
+                                      "attribs": Object {
+                                        "baseplanspath": "/jetpack/connect/plans",
+                                        "displayjetpackplans": "true",
+                                        "isinsignup": "true",
+                                        "islandingpage": "false",
+                                        "onupgradeclick": "function (cartItem) {
+			var checkoutPath = '/checkout/' + _this.props.selectedSite.slug;
+			// clears whatever we had stored in local cache
+			_this.props.selectPlanInAdvance(null, _this.props.selectedSiteSlug);
+
+			if (!cartItem || cartItem.product_slug === _constants.PLAN_JETPACK_FREE) {
+				return _this.selectFreeJetpackPlan();
+			}
+
+			if (cartItem.product_slug === (0, _lodash.get)(_this.props, 'selectedSite.plan.product_slug', null)) {
+				return _this.redirect(CALYPSO_PLANS_PAGE);
+			}
+
+			_this.props.recordTracksEvent('calypso_jpc_plans_submit', {
+				user: _this.props.userId,
+				product_slug: cartItem.product_slug });
+
+			_analytics.mc.bumpStat('calypso_jpc_plan_selection', cartItem.product_slug);
+
+			(0, _actions2.addItem)(cartItem);
+			_this.redirecting = true;
+			_this.props.completeFlow();
+			_page2.default.redirect(checkoutPath);
+		}",
+                                        "plans": "jetpack_personal,jetpack_premium,jetpack_business",
+                                        "site": "[object Object]",
+                                      },
                                       "children": Array [],
-                                      "name": "div",
+                                      "name": "my-sites--plan-features",
                                       "next": null,
                                       "parent": [Circular],
                                       "prev": null,
@@ -5367,15 +6547,17 @@ initialize {
                                   "next": null,
                                   "parent": [Circular],
                                   "prev": Object {
-                                    "attribs": Object {},
+                                    "attribs": Object {
+                                      "siteid": "1234567",
+                                    },
                                     "children": Array [],
-                                    "name": "div",
+                                    "name": "components--data--query-site-plans",
                                     "next": [Circular],
                                     "parent": [Circular],
                                     "prev": Object {
                                       "attribs": Object {},
                                       "children": Array [],
-                                      "name": "div",
+                                      "name": "components--data--query-plans",
                                       "next": [Circular],
                                       "parent": [Circular],
                                       "prev": Object {
@@ -5598,9 +6780,113 @@ initialize {
                             },
                             "children": Array [
                               Object {
-                                "attribs": Object {},
-                                "children": Array [],
-                                "name": "div",
+                                "attribs": Object {
+                                  "label": "Need help?",
+                                },
+                                "children": Array [
+                                  Object {
+                                    "attribs": Object {
+                                      "class": "logged-out-form__link-item jetpack-connect__help-button",
+                                      "href": "https://jetpack.com/contact-support",
+                                      "rel": "noopener noreferrer",
+                                      "target": "_blank",
+                                    },
+                                    "children": Array [
+                                      Object {
+                                        "attribs": Object {
+                                          "class": "gridicon gridicons-help-outline",
+                                          "height": "24",
+                                          "viewbox": "0 0 24 24",
+                                          "width": "24",
+                                          "xmlns": "http://www.w3.org/2000/svg",
+                                        },
+                                        "children": Array [
+                                          Object {
+                                            "attribs": Object {},
+                                            "children": Array [
+                                              Object {
+                                                "attribs": Object {
+                                                  "d": "M12 4c4.41 0 8 3.59 8 8s-3.59 8-8 8-8-3.59-8-8 3.59-8 8-8m0-2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm4 8c0-2.21-1.79-4-4-4s-4 1.79-4 4h2c0-1.103.897-2 2-2s2 .897 2 2-.897 2-2 2c-.552 0-1 .448-1 1v2h2v-1.14c1.722-.447 3-1.998 3-3.86zm-3 6h-2v2h2v-2z",
+                                                },
+                                                "children": Array [],
+                                                "name": "path",
+                                                "next": null,
+                                                "parent": [Circular],
+                                                "prev": null,
+                                                "type": "tag",
+                                              },
+                                            ],
+                                            "name": "g",
+                                            "next": null,
+                                            "parent": [Circular],
+                                            "prev": null,
+                                            "type": "tag",
+                                          },
+                                        ],
+                                        "name": "svg",
+                                        "next": Object {
+                                          "data": " Need help?",
+                                          "next": null,
+                                          "parent": [Circular],
+                                          "prev": [Circular],
+                                          "type": "text",
+                                        },
+                                        "parent": [Circular],
+                                        "prev": null,
+                                        "type": "tag",
+                                      },
+                                      Object {
+                                        "data": " Need help?",
+                                        "next": null,
+                                        "parent": [Circular],
+                                        "prev": Object {
+                                          "attribs": Object {
+                                            "class": "gridicon gridicons-help-outline",
+                                            "height": "24",
+                                            "viewbox": "0 0 24 24",
+                                            "width": "24",
+                                            "xmlns": "http://www.w3.org/2000/svg",
+                                          },
+                                          "children": Array [
+                                            Object {
+                                              "attribs": Object {},
+                                              "children": Array [
+                                                Object {
+                                                  "attribs": Object {
+                                                    "d": "M12 4c4.41 0 8 3.59 8 8s-3.59 8-8 8-8-3.59-8-8 3.59-8 8-8m0-2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm4 8c0-2.21-1.79-4-4-4s-4 1.79-4 4h2c0-1.103.897-2 2-2s2 .897 2 2-.897 2-2 2c-.552 0-1 .448-1 1v2h2v-1.14c1.722-.447 3-1.998 3-3.86zm-3 6h-2v2h2v-2z",
+                                                  },
+                                                  "children": Array [],
+                                                  "name": "path",
+                                                  "next": null,
+                                                  "parent": [Circular],
+                                                  "prev": null,
+                                                  "type": "tag",
+                                                },
+                                              ],
+                                              "name": "g",
+                                              "next": null,
+                                              "parent": [Circular],
+                                              "prev": null,
+                                              "type": "tag",
+                                            },
+                                          ],
+                                          "name": "svg",
+                                          "next": [Circular],
+                                          "parent": [Circular],
+                                          "prev": null,
+                                          "type": "tag",
+                                        },
+                                        "type": "text",
+                                      },
+                                    ],
+                                    "name": "a",
+                                    "next": null,
+                                    "parent": [Circular],
+                                    "prev": null,
+                                    "type": "tag",
+                                  },
+                                ],
+                                "name": "jetpack-connect--happychat-button",
                                 "next": null,
                                 "parent": [Circular],
                                 "prev": null,
@@ -5920,11 +7206,13 @@ initialize {
                                     "next": Object {
                                       "attribs": Object {},
                                       "children": Array [],
-                                      "name": "div",
+                                      "name": "components--data--query-plans",
                                       "next": Object {
-                                        "attribs": Object {},
+                                        "attribs": Object {
+                                          "siteid": "1234567",
+                                        },
                                         "children": Array [],
-                                        "name": "div",
+                                        "name": "components--data--query-site-plans",
                                         "next": Object {
                                           "attribs": Object {
                                             "class": "plans-features-main__group",
@@ -5932,9 +7220,40 @@ initialize {
                                           },
                                           "children": Array [
                                             Object {
-                                              "attribs": Object {},
+                                              "attribs": Object {
+                                                "baseplanspath": "/jetpack/connect/plans",
+                                                "displayjetpackplans": "true",
+                                                "isinsignup": "true",
+                                                "islandingpage": "false",
+                                                "onupgradeclick": "function (cartItem) {
+			var checkoutPath = '/checkout/' + _this.props.selectedSite.slug;
+			// clears whatever we had stored in local cache
+			_this.props.selectPlanInAdvance(null, _this.props.selectedSiteSlug);
+
+			if (!cartItem || cartItem.product_slug === _constants.PLAN_JETPACK_FREE) {
+				return _this.selectFreeJetpackPlan();
+			}
+
+			if (cartItem.product_slug === (0, _lodash.get)(_this.props, 'selectedSite.plan.product_slug', null)) {
+				return _this.redirect(CALYPSO_PLANS_PAGE);
+			}
+
+			_this.props.recordTracksEvent('calypso_jpc_plans_submit', {
+				user: _this.props.userId,
+				product_slug: cartItem.product_slug });
+
+			_analytics.mc.bumpStat('calypso_jpc_plan_selection', cartItem.product_slug);
+
+			(0, _actions2.addItem)(cartItem);
+			_this.redirecting = true;
+			_this.props.completeFlow();
+			_page2.default.redirect(checkoutPath);
+		}",
+                                                "plans": "jetpack_personal,jetpack_premium,jetpack_business",
+                                                "site": "[object Object]",
+                                              },
                                               "children": Array [],
-                                              "name": "div",
+                                              "name": "my-sites--plan-features",
                                               "next": null,
                                               "parent": [Circular],
                                               "prev": null,
@@ -5962,11 +7281,13 @@ initialize {
                                   Object {
                                     "attribs": Object {},
                                     "children": Array [],
-                                    "name": "div",
+                                    "name": "components--data--query-plans",
                                     "next": Object {
-                                      "attribs": Object {},
+                                      "attribs": Object {
+                                        "siteid": "1234567",
+                                      },
                                       "children": Array [],
-                                      "name": "div",
+                                      "name": "components--data--query-site-plans",
                                       "next": Object {
                                         "attribs": Object {
                                           "class": "plans-features-main__group",
@@ -5974,9 +7295,40 @@ initialize {
                                         },
                                         "children": Array [
                                           Object {
-                                            "attribs": Object {},
+                                            "attribs": Object {
+                                              "baseplanspath": "/jetpack/connect/plans",
+                                              "displayjetpackplans": "true",
+                                              "isinsignup": "true",
+                                              "islandingpage": "false",
+                                              "onupgradeclick": "function (cartItem) {
+			var checkoutPath = '/checkout/' + _this.props.selectedSite.slug;
+			// clears whatever we had stored in local cache
+			_this.props.selectPlanInAdvance(null, _this.props.selectedSiteSlug);
+
+			if (!cartItem || cartItem.product_slug === _constants.PLAN_JETPACK_FREE) {
+				return _this.selectFreeJetpackPlan();
+			}
+
+			if (cartItem.product_slug === (0, _lodash.get)(_this.props, 'selectedSite.plan.product_slug', null)) {
+				return _this.redirect(CALYPSO_PLANS_PAGE);
+			}
+
+			_this.props.recordTracksEvent('calypso_jpc_plans_submit', {
+				user: _this.props.userId,
+				product_slug: cartItem.product_slug });
+
+			_analytics.mc.bumpStat('calypso_jpc_plan_selection', cartItem.product_slug);
+
+			(0, _actions2.addItem)(cartItem);
+			_this.redirecting = true;
+			_this.props.completeFlow();
+			_page2.default.redirect(checkoutPath);
+		}",
+                                              "plans": "jetpack_personal,jetpack_premium,jetpack_business",
+                                              "site": "[object Object]",
+                                            },
                                             "children": Array [],
-                                            "name": "div",
+                                            "name": "my-sites--plan-features",
                                             "next": null,
                                             "parent": [Circular],
                                             "prev": null,
@@ -6196,9 +7548,11 @@ initialize {
                                     "type": "tag",
                                   },
                                   Object {
-                                    "attribs": Object {},
+                                    "attribs": Object {
+                                      "siteid": "1234567",
+                                    },
                                     "children": Array [],
-                                    "name": "div",
+                                    "name": "components--data--query-site-plans",
                                     "next": Object {
                                       "attribs": Object {
                                         "class": "plans-features-main__group",
@@ -6206,9 +7560,40 @@ initialize {
                                       },
                                       "children": Array [
                                         Object {
-                                          "attribs": Object {},
+                                          "attribs": Object {
+                                            "baseplanspath": "/jetpack/connect/plans",
+                                            "displayjetpackplans": "true",
+                                            "isinsignup": "true",
+                                            "islandingpage": "false",
+                                            "onupgradeclick": "function (cartItem) {
+			var checkoutPath = '/checkout/' + _this.props.selectedSite.slug;
+			// clears whatever we had stored in local cache
+			_this.props.selectPlanInAdvance(null, _this.props.selectedSiteSlug);
+
+			if (!cartItem || cartItem.product_slug === _constants.PLAN_JETPACK_FREE) {
+				return _this.selectFreeJetpackPlan();
+			}
+
+			if (cartItem.product_slug === (0, _lodash.get)(_this.props, 'selectedSite.plan.product_slug', null)) {
+				return _this.redirect(CALYPSO_PLANS_PAGE);
+			}
+
+			_this.props.recordTracksEvent('calypso_jpc_plans_submit', {
+				user: _this.props.userId,
+				product_slug: cartItem.product_slug });
+
+			_analytics.mc.bumpStat('calypso_jpc_plan_selection', cartItem.product_slug);
+
+			(0, _actions2.addItem)(cartItem);
+			_this.redirecting = true;
+			_this.props.completeFlow();
+			_page2.default.redirect(checkoutPath);
+		}",
+                                            "plans": "jetpack_personal,jetpack_premium,jetpack_business",
+                                            "site": "[object Object]",
+                                          },
                                           "children": Array [],
-                                          "name": "div",
+                                          "name": "my-sites--plan-features",
                                           "next": null,
                                           "parent": [Circular],
                                           "prev": null,
@@ -6225,7 +7610,7 @@ initialize {
                                     "prev": Object {
                                       "attribs": Object {},
                                       "children": Array [],
-                                      "name": "div",
+                                      "name": "components--data--query-plans",
                                       "next": [Circular],
                                       "parent": [Circular],
                                       "prev": Object {
@@ -6438,9 +7823,40 @@ initialize {
                                     },
                                     "children": Array [
                                       Object {
-                                        "attribs": Object {},
+                                        "attribs": Object {
+                                          "baseplanspath": "/jetpack/connect/plans",
+                                          "displayjetpackplans": "true",
+                                          "isinsignup": "true",
+                                          "islandingpage": "false",
+                                          "onupgradeclick": "function (cartItem) {
+			var checkoutPath = '/checkout/' + _this.props.selectedSite.slug;
+			// clears whatever we had stored in local cache
+			_this.props.selectPlanInAdvance(null, _this.props.selectedSiteSlug);
+
+			if (!cartItem || cartItem.product_slug === _constants.PLAN_JETPACK_FREE) {
+				return _this.selectFreeJetpackPlan();
+			}
+
+			if (cartItem.product_slug === (0, _lodash.get)(_this.props, 'selectedSite.plan.product_slug', null)) {
+				return _this.redirect(CALYPSO_PLANS_PAGE);
+			}
+
+			_this.props.recordTracksEvent('calypso_jpc_plans_submit', {
+				user: _this.props.userId,
+				product_slug: cartItem.product_slug });
+
+			_analytics.mc.bumpStat('calypso_jpc_plan_selection', cartItem.product_slug);
+
+			(0, _actions2.addItem)(cartItem);
+			_this.redirecting = true;
+			_this.props.completeFlow();
+			_page2.default.redirect(checkoutPath);
+		}",
+                                          "plans": "jetpack_personal,jetpack_premium,jetpack_business",
+                                          "site": "[object Object]",
+                                        },
                                         "children": Array [],
-                                        "name": "div",
+                                        "name": "my-sites--plan-features",
                                         "next": null,
                                         "parent": [Circular],
                                         "prev": null,
@@ -6451,15 +7867,17 @@ initialize {
                                     "next": null,
                                     "parent": [Circular],
                                     "prev": Object {
-                                      "attribs": Object {},
+                                      "attribs": Object {
+                                        "siteid": "1234567",
+                                      },
                                       "children": Array [],
-                                      "name": "div",
+                                      "name": "components--data--query-site-plans",
                                       "next": [Circular],
                                       "parent": [Circular],
                                       "prev": Object {
                                         "attribs": Object {},
                                         "children": Array [],
-                                        "name": "div",
+                                        "name": "components--data--query-plans",
                                         "next": [Circular],
                                         "parent": [Circular],
                                         "prev": Object {
@@ -6793,9 +8211,11 @@ initialize {
             "type": "tag",
           },
           Object {
-            "attribs": Object {},
+            "attribs": Object {
+              "siteid": "1234567",
+            },
             "children": Array [],
-            "name": "div",
+            "name": "components--data--query-site-plans",
             "next": Object {
               "attribs": Object {
                 "class": "main is-wide-layout",
@@ -7095,11 +8515,13 @@ initialize {
                                 "next": Object {
                                   "attribs": Object {},
                                   "children": Array [],
-                                  "name": "div",
+                                  "name": "components--data--query-plans",
                                   "next": Object {
-                                    "attribs": Object {},
+                                    "attribs": Object {
+                                      "siteid": "1234567",
+                                    },
                                     "children": Array [],
-                                    "name": "div",
+                                    "name": "components--data--query-site-plans",
                                     "next": Object {
                                       "attribs": Object {
                                         "class": "plans-features-main__group",
@@ -7107,9 +8529,40 @@ initialize {
                                       },
                                       "children": Array [
                                         Object {
-                                          "attribs": Object {},
+                                          "attribs": Object {
+                                            "baseplanspath": "/jetpack/connect/plans",
+                                            "displayjetpackplans": "true",
+                                            "isinsignup": "true",
+                                            "islandingpage": "false",
+                                            "onupgradeclick": "function (cartItem) {
+			var checkoutPath = '/checkout/' + _this.props.selectedSite.slug;
+			// clears whatever we had stored in local cache
+			_this.props.selectPlanInAdvance(null, _this.props.selectedSiteSlug);
+
+			if (!cartItem || cartItem.product_slug === _constants.PLAN_JETPACK_FREE) {
+				return _this.selectFreeJetpackPlan();
+			}
+
+			if (cartItem.product_slug === (0, _lodash.get)(_this.props, 'selectedSite.plan.product_slug', null)) {
+				return _this.redirect(CALYPSO_PLANS_PAGE);
+			}
+
+			_this.props.recordTracksEvent('calypso_jpc_plans_submit', {
+				user: _this.props.userId,
+				product_slug: cartItem.product_slug });
+
+			_analytics.mc.bumpStat('calypso_jpc_plan_selection', cartItem.product_slug);
+
+			(0, _actions2.addItem)(cartItem);
+			_this.redirecting = true;
+			_this.props.completeFlow();
+			_page2.default.redirect(checkoutPath);
+		}",
+                                            "plans": "jetpack_personal,jetpack_premium,jetpack_business",
+                                            "site": "[object Object]",
+                                          },
                                           "children": Array [],
-                                          "name": "div",
+                                          "name": "my-sites--plan-features",
                                           "next": null,
                                           "parent": [Circular],
                                           "prev": null,
@@ -7137,11 +8590,13 @@ initialize {
                               Object {
                                 "attribs": Object {},
                                 "children": Array [],
-                                "name": "div",
+                                "name": "components--data--query-plans",
                                 "next": Object {
-                                  "attribs": Object {},
+                                  "attribs": Object {
+                                    "siteid": "1234567",
+                                  },
                                   "children": Array [],
-                                  "name": "div",
+                                  "name": "components--data--query-site-plans",
                                   "next": Object {
                                     "attribs": Object {
                                       "class": "plans-features-main__group",
@@ -7149,9 +8604,40 @@ initialize {
                                     },
                                     "children": Array [
                                       Object {
-                                        "attribs": Object {},
+                                        "attribs": Object {
+                                          "baseplanspath": "/jetpack/connect/plans",
+                                          "displayjetpackplans": "true",
+                                          "isinsignup": "true",
+                                          "islandingpage": "false",
+                                          "onupgradeclick": "function (cartItem) {
+			var checkoutPath = '/checkout/' + _this.props.selectedSite.slug;
+			// clears whatever we had stored in local cache
+			_this.props.selectPlanInAdvance(null, _this.props.selectedSiteSlug);
+
+			if (!cartItem || cartItem.product_slug === _constants.PLAN_JETPACK_FREE) {
+				return _this.selectFreeJetpackPlan();
+			}
+
+			if (cartItem.product_slug === (0, _lodash.get)(_this.props, 'selectedSite.plan.product_slug', null)) {
+				return _this.redirect(CALYPSO_PLANS_PAGE);
+			}
+
+			_this.props.recordTracksEvent('calypso_jpc_plans_submit', {
+				user: _this.props.userId,
+				product_slug: cartItem.product_slug });
+
+			_analytics.mc.bumpStat('calypso_jpc_plan_selection', cartItem.product_slug);
+
+			(0, _actions2.addItem)(cartItem);
+			_this.redirecting = true;
+			_this.props.completeFlow();
+			_page2.default.redirect(checkoutPath);
+		}",
+                                          "plans": "jetpack_personal,jetpack_premium,jetpack_business",
+                                          "site": "[object Object]",
+                                        },
                                         "children": Array [],
-                                        "name": "div",
+                                        "name": "my-sites--plan-features",
                                         "next": null,
                                         "parent": [Circular],
                                         "prev": null,
@@ -7371,9 +8857,11 @@ initialize {
                                 "type": "tag",
                               },
                               Object {
-                                "attribs": Object {},
+                                "attribs": Object {
+                                  "siteid": "1234567",
+                                },
                                 "children": Array [],
-                                "name": "div",
+                                "name": "components--data--query-site-plans",
                                 "next": Object {
                                   "attribs": Object {
                                     "class": "plans-features-main__group",
@@ -7381,9 +8869,40 @@ initialize {
                                   },
                                   "children": Array [
                                     Object {
-                                      "attribs": Object {},
+                                      "attribs": Object {
+                                        "baseplanspath": "/jetpack/connect/plans",
+                                        "displayjetpackplans": "true",
+                                        "isinsignup": "true",
+                                        "islandingpage": "false",
+                                        "onupgradeclick": "function (cartItem) {
+			var checkoutPath = '/checkout/' + _this.props.selectedSite.slug;
+			// clears whatever we had stored in local cache
+			_this.props.selectPlanInAdvance(null, _this.props.selectedSiteSlug);
+
+			if (!cartItem || cartItem.product_slug === _constants.PLAN_JETPACK_FREE) {
+				return _this.selectFreeJetpackPlan();
+			}
+
+			if (cartItem.product_slug === (0, _lodash.get)(_this.props, 'selectedSite.plan.product_slug', null)) {
+				return _this.redirect(CALYPSO_PLANS_PAGE);
+			}
+
+			_this.props.recordTracksEvent('calypso_jpc_plans_submit', {
+				user: _this.props.userId,
+				product_slug: cartItem.product_slug });
+
+			_analytics.mc.bumpStat('calypso_jpc_plan_selection', cartItem.product_slug);
+
+			(0, _actions2.addItem)(cartItem);
+			_this.redirecting = true;
+			_this.props.completeFlow();
+			_page2.default.redirect(checkoutPath);
+		}",
+                                        "plans": "jetpack_personal,jetpack_premium,jetpack_business",
+                                        "site": "[object Object]",
+                                      },
                                       "children": Array [],
-                                      "name": "div",
+                                      "name": "my-sites--plan-features",
                                       "next": null,
                                       "parent": [Circular],
                                       "prev": null,
@@ -7400,7 +8919,7 @@ initialize {
                                 "prev": Object {
                                   "attribs": Object {},
                                   "children": Array [],
-                                  "name": "div",
+                                  "name": "components--data--query-plans",
                                   "next": [Circular],
                                   "parent": [Circular],
                                   "prev": Object {
@@ -7613,9 +9132,40 @@ initialize {
                                 },
                                 "children": Array [
                                   Object {
-                                    "attribs": Object {},
+                                    "attribs": Object {
+                                      "baseplanspath": "/jetpack/connect/plans",
+                                      "displayjetpackplans": "true",
+                                      "isinsignup": "true",
+                                      "islandingpage": "false",
+                                      "onupgradeclick": "function (cartItem) {
+			var checkoutPath = '/checkout/' + _this.props.selectedSite.slug;
+			// clears whatever we had stored in local cache
+			_this.props.selectPlanInAdvance(null, _this.props.selectedSiteSlug);
+
+			if (!cartItem || cartItem.product_slug === _constants.PLAN_JETPACK_FREE) {
+				return _this.selectFreeJetpackPlan();
+			}
+
+			if (cartItem.product_slug === (0, _lodash.get)(_this.props, 'selectedSite.plan.product_slug', null)) {
+				return _this.redirect(CALYPSO_PLANS_PAGE);
+			}
+
+			_this.props.recordTracksEvent('calypso_jpc_plans_submit', {
+				user: _this.props.userId,
+				product_slug: cartItem.product_slug });
+
+			_analytics.mc.bumpStat('calypso_jpc_plan_selection', cartItem.product_slug);
+
+			(0, _actions2.addItem)(cartItem);
+			_this.redirecting = true;
+			_this.props.completeFlow();
+			_page2.default.redirect(checkoutPath);
+		}",
+                                      "plans": "jetpack_personal,jetpack_premium,jetpack_business",
+                                      "site": "[object Object]",
+                                    },
                                     "children": Array [],
-                                    "name": "div",
+                                    "name": "my-sites--plan-features",
                                     "next": null,
                                     "parent": [Circular],
                                     "prev": null,
@@ -7626,15 +9176,17 @@ initialize {
                                 "next": null,
                                 "parent": [Circular],
                                 "prev": Object {
-                                  "attribs": Object {},
+                                  "attribs": Object {
+                                    "siteid": "1234567",
+                                  },
                                   "children": Array [],
-                                  "name": "div",
+                                  "name": "components--data--query-site-plans",
                                   "next": [Circular],
                                   "parent": [Circular],
                                   "prev": Object {
                                     "attribs": Object {},
                                     "children": Array [],
-                                    "name": "div",
+                                    "name": "components--data--query-plans",
                                     "next": [Circular],
                                     "parent": [Circular],
                                     "prev": Object {
@@ -7956,9 +9508,113 @@ initialize {
                                 },
                                 "children": Array [
                                   Object {
-                                    "attribs": Object {},
-                                    "children": Array [],
-                                    "name": "div",
+                                    "attribs": Object {
+                                      "label": "Need help?",
+                                    },
+                                    "children": Array [
+                                      Object {
+                                        "attribs": Object {
+                                          "class": "logged-out-form__link-item jetpack-connect__help-button",
+                                          "href": "https://jetpack.com/contact-support",
+                                          "rel": "noopener noreferrer",
+                                          "target": "_blank",
+                                        },
+                                        "children": Array [
+                                          Object {
+                                            "attribs": Object {
+                                              "class": "gridicon gridicons-help-outline",
+                                              "height": "24",
+                                              "viewbox": "0 0 24 24",
+                                              "width": "24",
+                                              "xmlns": "http://www.w3.org/2000/svg",
+                                            },
+                                            "children": Array [
+                                              Object {
+                                                "attribs": Object {},
+                                                "children": Array [
+                                                  Object {
+                                                    "attribs": Object {
+                                                      "d": "M12 4c4.41 0 8 3.59 8 8s-3.59 8-8 8-8-3.59-8-8 3.59-8 8-8m0-2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm4 8c0-2.21-1.79-4-4-4s-4 1.79-4 4h2c0-1.103.897-2 2-2s2 .897 2 2-.897 2-2 2c-.552 0-1 .448-1 1v2h2v-1.14c1.722-.447 3-1.998 3-3.86zm-3 6h-2v2h2v-2z",
+                                                    },
+                                                    "children": Array [],
+                                                    "name": "path",
+                                                    "next": null,
+                                                    "parent": [Circular],
+                                                    "prev": null,
+                                                    "type": "tag",
+                                                  },
+                                                ],
+                                                "name": "g",
+                                                "next": null,
+                                                "parent": [Circular],
+                                                "prev": null,
+                                                "type": "tag",
+                                              },
+                                            ],
+                                            "name": "svg",
+                                            "next": Object {
+                                              "data": " Need help?",
+                                              "next": null,
+                                              "parent": [Circular],
+                                              "prev": [Circular],
+                                              "type": "text",
+                                            },
+                                            "parent": [Circular],
+                                            "prev": null,
+                                            "type": "tag",
+                                          },
+                                          Object {
+                                            "data": " Need help?",
+                                            "next": null,
+                                            "parent": [Circular],
+                                            "prev": Object {
+                                              "attribs": Object {
+                                                "class": "gridicon gridicons-help-outline",
+                                                "height": "24",
+                                                "viewbox": "0 0 24 24",
+                                                "width": "24",
+                                                "xmlns": "http://www.w3.org/2000/svg",
+                                              },
+                                              "children": Array [
+                                                Object {
+                                                  "attribs": Object {},
+                                                  "children": Array [
+                                                    Object {
+                                                      "attribs": Object {
+                                                        "d": "M12 4c4.41 0 8 3.59 8 8s-3.59 8-8 8-8-3.59-8-8 3.59-8 8-8m0-2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm4 8c0-2.21-1.79-4-4-4s-4 1.79-4 4h2c0-1.103.897-2 2-2s2 .897 2 2-.897 2-2 2c-.552 0-1 .448-1 1v2h2v-1.14c1.722-.447 3-1.998 3-3.86zm-3 6h-2v2h2v-2z",
+                                                      },
+                                                      "children": Array [],
+                                                      "name": "path",
+                                                      "next": null,
+                                                      "parent": [Circular],
+                                                      "prev": null,
+                                                      "type": "tag",
+                                                    },
+                                                  ],
+                                                  "name": "g",
+                                                  "next": null,
+                                                  "parent": [Circular],
+                                                  "prev": null,
+                                                  "type": "tag",
+                                                },
+                                              ],
+                                              "name": "svg",
+                                              "next": [Circular],
+                                              "parent": [Circular],
+                                              "prev": null,
+                                              "type": "tag",
+                                            },
+                                            "type": "text",
+                                          },
+                                        ],
+                                        "name": "a",
+                                        "next": null,
+                                        "parent": [Circular],
+                                        "prev": null,
+                                        "type": "tag",
+                                      },
+                                    ],
+                                    "name": "jetpack-connect--happychat-button",
                                     "next": null,
                                     "parent": [Circular],
                                     "prev": null,
@@ -8091,9 +9747,113 @@ initialize {
                               },
                               "children": Array [
                                 Object {
-                                  "attribs": Object {},
-                                  "children": Array [],
-                                  "name": "div",
+                                  "attribs": Object {
+                                    "label": "Need help?",
+                                  },
+                                  "children": Array [
+                                    Object {
+                                      "attribs": Object {
+                                        "class": "logged-out-form__link-item jetpack-connect__help-button",
+                                        "href": "https://jetpack.com/contact-support",
+                                        "rel": "noopener noreferrer",
+                                        "target": "_blank",
+                                      },
+                                      "children": Array [
+                                        Object {
+                                          "attribs": Object {
+                                            "class": "gridicon gridicons-help-outline",
+                                            "height": "24",
+                                            "viewbox": "0 0 24 24",
+                                            "width": "24",
+                                            "xmlns": "http://www.w3.org/2000/svg",
+                                          },
+                                          "children": Array [
+                                            Object {
+                                              "attribs": Object {},
+                                              "children": Array [
+                                                Object {
+                                                  "attribs": Object {
+                                                    "d": "M12 4c4.41 0 8 3.59 8 8s-3.59 8-8 8-8-3.59-8-8 3.59-8 8-8m0-2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm4 8c0-2.21-1.79-4-4-4s-4 1.79-4 4h2c0-1.103.897-2 2-2s2 .897 2 2-.897 2-2 2c-.552 0-1 .448-1 1v2h2v-1.14c1.722-.447 3-1.998 3-3.86zm-3 6h-2v2h2v-2z",
+                                                  },
+                                                  "children": Array [],
+                                                  "name": "path",
+                                                  "next": null,
+                                                  "parent": [Circular],
+                                                  "prev": null,
+                                                  "type": "tag",
+                                                },
+                                              ],
+                                              "name": "g",
+                                              "next": null,
+                                              "parent": [Circular],
+                                              "prev": null,
+                                              "type": "tag",
+                                            },
+                                          ],
+                                          "name": "svg",
+                                          "next": Object {
+                                            "data": " Need help?",
+                                            "next": null,
+                                            "parent": [Circular],
+                                            "prev": [Circular],
+                                            "type": "text",
+                                          },
+                                          "parent": [Circular],
+                                          "prev": null,
+                                          "type": "tag",
+                                        },
+                                        Object {
+                                          "data": " Need help?",
+                                          "next": null,
+                                          "parent": [Circular],
+                                          "prev": Object {
+                                            "attribs": Object {
+                                              "class": "gridicon gridicons-help-outline",
+                                              "height": "24",
+                                              "viewbox": "0 0 24 24",
+                                              "width": "24",
+                                              "xmlns": "http://www.w3.org/2000/svg",
+                                            },
+                                            "children": Array [
+                                              Object {
+                                                "attribs": Object {},
+                                                "children": Array [
+                                                  Object {
+                                                    "attribs": Object {
+                                                      "d": "M12 4c4.41 0 8 3.59 8 8s-3.59 8-8 8-8-3.59-8-8 3.59-8 8-8m0-2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm4 8c0-2.21-1.79-4-4-4s-4 1.79-4 4h2c0-1.103.897-2 2-2s2 .897 2 2-.897 2-2 2c-.552 0-1 .448-1 1v2h2v-1.14c1.722-.447 3-1.998 3-3.86zm-3 6h-2v2h2v-2z",
+                                                    },
+                                                    "children": Array [],
+                                                    "name": "path",
+                                                    "next": null,
+                                                    "parent": [Circular],
+                                                    "prev": null,
+                                                    "type": "tag",
+                                                  },
+                                                ],
+                                                "name": "g",
+                                                "next": null,
+                                                "parent": [Circular],
+                                                "prev": null,
+                                                "type": "tag",
+                                              },
+                                            ],
+                                            "name": "svg",
+                                            "next": [Circular],
+                                            "parent": [Circular],
+                                            "prev": null,
+                                            "type": "tag",
+                                          },
+                                          "type": "text",
+                                        },
+                                      ],
+                                      "name": "a",
+                                      "next": null,
+                                      "parent": [Circular],
+                                      "prev": null,
+                                      "type": "tag",
+                                    },
+                                  ],
+                                  "name": "jetpack-connect--happychat-button",
                                   "next": null,
                                   "parent": [Circular],
                                   "prev": null,
@@ -8309,11 +10069,13 @@ initialize {
                                   "next": Object {
                                     "attribs": Object {},
                                     "children": Array [],
-                                    "name": "div",
+                                    "name": "components--data--query-plans",
                                     "next": Object {
-                                      "attribs": Object {},
+                                      "attribs": Object {
+                                        "siteid": "1234567",
+                                      },
                                       "children": Array [],
-                                      "name": "div",
+                                      "name": "components--data--query-site-plans",
                                       "next": Object {
                                         "attribs": Object {
                                           "class": "plans-features-main__group",
@@ -8321,9 +10083,40 @@ initialize {
                                         },
                                         "children": Array [
                                           Object {
-                                            "attribs": Object {},
+                                            "attribs": Object {
+                                              "baseplanspath": "/jetpack/connect/plans",
+                                              "displayjetpackplans": "true",
+                                              "isinsignup": "true",
+                                              "islandingpage": "false",
+                                              "onupgradeclick": "function (cartItem) {
+			var checkoutPath = '/checkout/' + _this.props.selectedSite.slug;
+			// clears whatever we had stored in local cache
+			_this.props.selectPlanInAdvance(null, _this.props.selectedSiteSlug);
+
+			if (!cartItem || cartItem.product_slug === _constants.PLAN_JETPACK_FREE) {
+				return _this.selectFreeJetpackPlan();
+			}
+
+			if (cartItem.product_slug === (0, _lodash.get)(_this.props, 'selectedSite.plan.product_slug', null)) {
+				return _this.redirect(CALYPSO_PLANS_PAGE);
+			}
+
+			_this.props.recordTracksEvent('calypso_jpc_plans_submit', {
+				user: _this.props.userId,
+				product_slug: cartItem.product_slug });
+
+			_analytics.mc.bumpStat('calypso_jpc_plan_selection', cartItem.product_slug);
+
+			(0, _actions2.addItem)(cartItem);
+			_this.redirecting = true;
+			_this.props.completeFlow();
+			_page2.default.redirect(checkoutPath);
+		}",
+                                              "plans": "jetpack_personal,jetpack_premium,jetpack_business",
+                                              "site": "[object Object]",
+                                            },
                                             "children": Array [],
-                                            "name": "div",
+                                            "name": "my-sites--plan-features",
                                             "next": null,
                                             "parent": [Circular],
                                             "prev": null,
@@ -8351,11 +10144,13 @@ initialize {
                                 Object {
                                   "attribs": Object {},
                                   "children": Array [],
-                                  "name": "div",
+                                  "name": "components--data--query-plans",
                                   "next": Object {
-                                    "attribs": Object {},
+                                    "attribs": Object {
+                                      "siteid": "1234567",
+                                    },
                                     "children": Array [],
-                                    "name": "div",
+                                    "name": "components--data--query-site-plans",
                                     "next": Object {
                                       "attribs": Object {
                                         "class": "plans-features-main__group",
@@ -8363,9 +10158,40 @@ initialize {
                                       },
                                       "children": Array [
                                         Object {
-                                          "attribs": Object {},
+                                          "attribs": Object {
+                                            "baseplanspath": "/jetpack/connect/plans",
+                                            "displayjetpackplans": "true",
+                                            "isinsignup": "true",
+                                            "islandingpage": "false",
+                                            "onupgradeclick": "function (cartItem) {
+			var checkoutPath = '/checkout/' + _this.props.selectedSite.slug;
+			// clears whatever we had stored in local cache
+			_this.props.selectPlanInAdvance(null, _this.props.selectedSiteSlug);
+
+			if (!cartItem || cartItem.product_slug === _constants.PLAN_JETPACK_FREE) {
+				return _this.selectFreeJetpackPlan();
+			}
+
+			if (cartItem.product_slug === (0, _lodash.get)(_this.props, 'selectedSite.plan.product_slug', null)) {
+				return _this.redirect(CALYPSO_PLANS_PAGE);
+			}
+
+			_this.props.recordTracksEvent('calypso_jpc_plans_submit', {
+				user: _this.props.userId,
+				product_slug: cartItem.product_slug });
+
+			_analytics.mc.bumpStat('calypso_jpc_plan_selection', cartItem.product_slug);
+
+			(0, _actions2.addItem)(cartItem);
+			_this.redirecting = true;
+			_this.props.completeFlow();
+			_page2.default.redirect(checkoutPath);
+		}",
+                                            "plans": "jetpack_personal,jetpack_premium,jetpack_business",
+                                            "site": "[object Object]",
+                                          },
                                           "children": Array [],
-                                          "name": "div",
+                                          "name": "my-sites--plan-features",
                                           "next": null,
                                           "parent": [Circular],
                                           "prev": null,
@@ -8585,9 +10411,11 @@ initialize {
                                   "type": "tag",
                                 },
                                 Object {
-                                  "attribs": Object {},
+                                  "attribs": Object {
+                                    "siteid": "1234567",
+                                  },
                                   "children": Array [],
-                                  "name": "div",
+                                  "name": "components--data--query-site-plans",
                                   "next": Object {
                                     "attribs": Object {
                                       "class": "plans-features-main__group",
@@ -8595,9 +10423,40 @@ initialize {
                                     },
                                     "children": Array [
                                       Object {
-                                        "attribs": Object {},
+                                        "attribs": Object {
+                                          "baseplanspath": "/jetpack/connect/plans",
+                                          "displayjetpackplans": "true",
+                                          "isinsignup": "true",
+                                          "islandingpage": "false",
+                                          "onupgradeclick": "function (cartItem) {
+			var checkoutPath = '/checkout/' + _this.props.selectedSite.slug;
+			// clears whatever we had stored in local cache
+			_this.props.selectPlanInAdvance(null, _this.props.selectedSiteSlug);
+
+			if (!cartItem || cartItem.product_slug === _constants.PLAN_JETPACK_FREE) {
+				return _this.selectFreeJetpackPlan();
+			}
+
+			if (cartItem.product_slug === (0, _lodash.get)(_this.props, 'selectedSite.plan.product_slug', null)) {
+				return _this.redirect(CALYPSO_PLANS_PAGE);
+			}
+
+			_this.props.recordTracksEvent('calypso_jpc_plans_submit', {
+				user: _this.props.userId,
+				product_slug: cartItem.product_slug });
+
+			_analytics.mc.bumpStat('calypso_jpc_plan_selection', cartItem.product_slug);
+
+			(0, _actions2.addItem)(cartItem);
+			_this.redirecting = true;
+			_this.props.completeFlow();
+			_page2.default.redirect(checkoutPath);
+		}",
+                                          "plans": "jetpack_personal,jetpack_premium,jetpack_business",
+                                          "site": "[object Object]",
+                                        },
                                         "children": Array [],
-                                        "name": "div",
+                                        "name": "my-sites--plan-features",
                                         "next": null,
                                         "parent": [Circular],
                                         "prev": null,
@@ -8614,7 +10473,7 @@ initialize {
                                   "prev": Object {
                                     "attribs": Object {},
                                     "children": Array [],
-                                    "name": "div",
+                                    "name": "components--data--query-plans",
                                     "next": [Circular],
                                     "parent": [Circular],
                                     "prev": Object {
@@ -8827,9 +10686,40 @@ initialize {
                                   },
                                   "children": Array [
                                     Object {
-                                      "attribs": Object {},
+                                      "attribs": Object {
+                                        "baseplanspath": "/jetpack/connect/plans",
+                                        "displayjetpackplans": "true",
+                                        "isinsignup": "true",
+                                        "islandingpage": "false",
+                                        "onupgradeclick": "function (cartItem) {
+			var checkoutPath = '/checkout/' + _this.props.selectedSite.slug;
+			// clears whatever we had stored in local cache
+			_this.props.selectPlanInAdvance(null, _this.props.selectedSiteSlug);
+
+			if (!cartItem || cartItem.product_slug === _constants.PLAN_JETPACK_FREE) {
+				return _this.selectFreeJetpackPlan();
+			}
+
+			if (cartItem.product_slug === (0, _lodash.get)(_this.props, 'selectedSite.plan.product_slug', null)) {
+				return _this.redirect(CALYPSO_PLANS_PAGE);
+			}
+
+			_this.props.recordTracksEvent('calypso_jpc_plans_submit', {
+				user: _this.props.userId,
+				product_slug: cartItem.product_slug });
+
+			_analytics.mc.bumpStat('calypso_jpc_plan_selection', cartItem.product_slug);
+
+			(0, _actions2.addItem)(cartItem);
+			_this.redirecting = true;
+			_this.props.completeFlow();
+			_page2.default.redirect(checkoutPath);
+		}",
+                                        "plans": "jetpack_personal,jetpack_premium,jetpack_business",
+                                        "site": "[object Object]",
+                                      },
                                       "children": Array [],
-                                      "name": "div",
+                                      "name": "my-sites--plan-features",
                                       "next": null,
                                       "parent": [Circular],
                                       "prev": null,
@@ -8840,15 +10730,17 @@ initialize {
                                   "next": null,
                                   "parent": [Circular],
                                   "prev": Object {
-                                    "attribs": Object {},
+                                    "attribs": Object {
+                                      "siteid": "1234567",
+                                    },
                                     "children": Array [],
-                                    "name": "div",
+                                    "name": "components--data--query-site-plans",
                                     "next": [Circular],
                                     "parent": [Circular],
                                     "prev": Object {
                                       "attribs": Object {},
                                       "children": Array [],
-                                      "name": "div",
+                                      "name": "components--data--query-plans",
                                       "next": [Circular],
                                       "parent": [Circular],
                                       "prev": Object {
@@ -9071,9 +10963,113 @@ initialize {
                             },
                             "children": Array [
                               Object {
-                                "attribs": Object {},
-                                "children": Array [],
-                                "name": "div",
+                                "attribs": Object {
+                                  "label": "Need help?",
+                                },
+                                "children": Array [
+                                  Object {
+                                    "attribs": Object {
+                                      "class": "logged-out-form__link-item jetpack-connect__help-button",
+                                      "href": "https://jetpack.com/contact-support",
+                                      "rel": "noopener noreferrer",
+                                      "target": "_blank",
+                                    },
+                                    "children": Array [
+                                      Object {
+                                        "attribs": Object {
+                                          "class": "gridicon gridicons-help-outline",
+                                          "height": "24",
+                                          "viewbox": "0 0 24 24",
+                                          "width": "24",
+                                          "xmlns": "http://www.w3.org/2000/svg",
+                                        },
+                                        "children": Array [
+                                          Object {
+                                            "attribs": Object {},
+                                            "children": Array [
+                                              Object {
+                                                "attribs": Object {
+                                                  "d": "M12 4c4.41 0 8 3.59 8 8s-3.59 8-8 8-8-3.59-8-8 3.59-8 8-8m0-2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm4 8c0-2.21-1.79-4-4-4s-4 1.79-4 4h2c0-1.103.897-2 2-2s2 .897 2 2-.897 2-2 2c-.552 0-1 .448-1 1v2h2v-1.14c1.722-.447 3-1.998 3-3.86zm-3 6h-2v2h2v-2z",
+                                                },
+                                                "children": Array [],
+                                                "name": "path",
+                                                "next": null,
+                                                "parent": [Circular],
+                                                "prev": null,
+                                                "type": "tag",
+                                              },
+                                            ],
+                                            "name": "g",
+                                            "next": null,
+                                            "parent": [Circular],
+                                            "prev": null,
+                                            "type": "tag",
+                                          },
+                                        ],
+                                        "name": "svg",
+                                        "next": Object {
+                                          "data": " Need help?",
+                                          "next": null,
+                                          "parent": [Circular],
+                                          "prev": [Circular],
+                                          "type": "text",
+                                        },
+                                        "parent": [Circular],
+                                        "prev": null,
+                                        "type": "tag",
+                                      },
+                                      Object {
+                                        "data": " Need help?",
+                                        "next": null,
+                                        "parent": [Circular],
+                                        "prev": Object {
+                                          "attribs": Object {
+                                            "class": "gridicon gridicons-help-outline",
+                                            "height": "24",
+                                            "viewbox": "0 0 24 24",
+                                            "width": "24",
+                                            "xmlns": "http://www.w3.org/2000/svg",
+                                          },
+                                          "children": Array [
+                                            Object {
+                                              "attribs": Object {},
+                                              "children": Array [
+                                                Object {
+                                                  "attribs": Object {
+                                                    "d": "M12 4c4.41 0 8 3.59 8 8s-3.59 8-8 8-8-3.59-8-8 3.59-8 8-8m0-2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm4 8c0-2.21-1.79-4-4-4s-4 1.79-4 4h2c0-1.103.897-2 2-2s2 .897 2 2-.897 2-2 2c-.552 0-1 .448-1 1v2h2v-1.14c1.722-.447 3-1.998 3-3.86zm-3 6h-2v2h2v-2z",
+                                                  },
+                                                  "children": Array [],
+                                                  "name": "path",
+                                                  "next": null,
+                                                  "parent": [Circular],
+                                                  "prev": null,
+                                                  "type": "tag",
+                                                },
+                                              ],
+                                              "name": "g",
+                                              "next": null,
+                                              "parent": [Circular],
+                                              "prev": null,
+                                              "type": "tag",
+                                            },
+                                          ],
+                                          "name": "svg",
+                                          "next": [Circular],
+                                          "parent": [Circular],
+                                          "prev": null,
+                                          "type": "tag",
+                                        },
+                                        "type": "text",
+                                      },
+                                    ],
+                                    "name": "a",
+                                    "next": null,
+                                    "parent": [Circular],
+                                    "prev": null,
+                                    "type": "tag",
+                                  },
+                                ],
+                                "name": "jetpack-connect--happychat-button",
                                 "next": null,
                                 "parent": [Circular],
                                 "prev": null,
@@ -9393,11 +11389,13 @@ initialize {
                                     "next": Object {
                                       "attribs": Object {},
                                       "children": Array [],
-                                      "name": "div",
+                                      "name": "components--data--query-plans",
                                       "next": Object {
-                                        "attribs": Object {},
+                                        "attribs": Object {
+                                          "siteid": "1234567",
+                                        },
                                         "children": Array [],
-                                        "name": "div",
+                                        "name": "components--data--query-site-plans",
                                         "next": Object {
                                           "attribs": Object {
                                             "class": "plans-features-main__group",
@@ -9405,9 +11403,40 @@ initialize {
                                           },
                                           "children": Array [
                                             Object {
-                                              "attribs": Object {},
+                                              "attribs": Object {
+                                                "baseplanspath": "/jetpack/connect/plans",
+                                                "displayjetpackplans": "true",
+                                                "isinsignup": "true",
+                                                "islandingpage": "false",
+                                                "onupgradeclick": "function (cartItem) {
+			var checkoutPath = '/checkout/' + _this.props.selectedSite.slug;
+			// clears whatever we had stored in local cache
+			_this.props.selectPlanInAdvance(null, _this.props.selectedSiteSlug);
+
+			if (!cartItem || cartItem.product_slug === _constants.PLAN_JETPACK_FREE) {
+				return _this.selectFreeJetpackPlan();
+			}
+
+			if (cartItem.product_slug === (0, _lodash.get)(_this.props, 'selectedSite.plan.product_slug', null)) {
+				return _this.redirect(CALYPSO_PLANS_PAGE);
+			}
+
+			_this.props.recordTracksEvent('calypso_jpc_plans_submit', {
+				user: _this.props.userId,
+				product_slug: cartItem.product_slug });
+
+			_analytics.mc.bumpStat('calypso_jpc_plan_selection', cartItem.product_slug);
+
+			(0, _actions2.addItem)(cartItem);
+			_this.redirecting = true;
+			_this.props.completeFlow();
+			_page2.default.redirect(checkoutPath);
+		}",
+                                                "plans": "jetpack_personal,jetpack_premium,jetpack_business",
+                                                "site": "[object Object]",
+                                              },
                                               "children": Array [],
-                                              "name": "div",
+                                              "name": "my-sites--plan-features",
                                               "next": null,
                                               "parent": [Circular],
                                               "prev": null,
@@ -9435,11 +11464,13 @@ initialize {
                                   Object {
                                     "attribs": Object {},
                                     "children": Array [],
-                                    "name": "div",
+                                    "name": "components--data--query-plans",
                                     "next": Object {
-                                      "attribs": Object {},
+                                      "attribs": Object {
+                                        "siteid": "1234567",
+                                      },
                                       "children": Array [],
-                                      "name": "div",
+                                      "name": "components--data--query-site-plans",
                                       "next": Object {
                                         "attribs": Object {
                                           "class": "plans-features-main__group",
@@ -9447,9 +11478,40 @@ initialize {
                                         },
                                         "children": Array [
                                           Object {
-                                            "attribs": Object {},
+                                            "attribs": Object {
+                                              "baseplanspath": "/jetpack/connect/plans",
+                                              "displayjetpackplans": "true",
+                                              "isinsignup": "true",
+                                              "islandingpage": "false",
+                                              "onupgradeclick": "function (cartItem) {
+			var checkoutPath = '/checkout/' + _this.props.selectedSite.slug;
+			// clears whatever we had stored in local cache
+			_this.props.selectPlanInAdvance(null, _this.props.selectedSiteSlug);
+
+			if (!cartItem || cartItem.product_slug === _constants.PLAN_JETPACK_FREE) {
+				return _this.selectFreeJetpackPlan();
+			}
+
+			if (cartItem.product_slug === (0, _lodash.get)(_this.props, 'selectedSite.plan.product_slug', null)) {
+				return _this.redirect(CALYPSO_PLANS_PAGE);
+			}
+
+			_this.props.recordTracksEvent('calypso_jpc_plans_submit', {
+				user: _this.props.userId,
+				product_slug: cartItem.product_slug });
+
+			_analytics.mc.bumpStat('calypso_jpc_plan_selection', cartItem.product_slug);
+
+			(0, _actions2.addItem)(cartItem);
+			_this.redirecting = true;
+			_this.props.completeFlow();
+			_page2.default.redirect(checkoutPath);
+		}",
+                                              "plans": "jetpack_personal,jetpack_premium,jetpack_business",
+                                              "site": "[object Object]",
+                                            },
                                             "children": Array [],
-                                            "name": "div",
+                                            "name": "my-sites--plan-features",
                                             "next": null,
                                             "parent": [Circular],
                                             "prev": null,
@@ -9669,9 +11731,11 @@ initialize {
                                     "type": "tag",
                                   },
                                   Object {
-                                    "attribs": Object {},
+                                    "attribs": Object {
+                                      "siteid": "1234567",
+                                    },
                                     "children": Array [],
-                                    "name": "div",
+                                    "name": "components--data--query-site-plans",
                                     "next": Object {
                                       "attribs": Object {
                                         "class": "plans-features-main__group",
@@ -9679,9 +11743,40 @@ initialize {
                                       },
                                       "children": Array [
                                         Object {
-                                          "attribs": Object {},
+                                          "attribs": Object {
+                                            "baseplanspath": "/jetpack/connect/plans",
+                                            "displayjetpackplans": "true",
+                                            "isinsignup": "true",
+                                            "islandingpage": "false",
+                                            "onupgradeclick": "function (cartItem) {
+			var checkoutPath = '/checkout/' + _this.props.selectedSite.slug;
+			// clears whatever we had stored in local cache
+			_this.props.selectPlanInAdvance(null, _this.props.selectedSiteSlug);
+
+			if (!cartItem || cartItem.product_slug === _constants.PLAN_JETPACK_FREE) {
+				return _this.selectFreeJetpackPlan();
+			}
+
+			if (cartItem.product_slug === (0, _lodash.get)(_this.props, 'selectedSite.plan.product_slug', null)) {
+				return _this.redirect(CALYPSO_PLANS_PAGE);
+			}
+
+			_this.props.recordTracksEvent('calypso_jpc_plans_submit', {
+				user: _this.props.userId,
+				product_slug: cartItem.product_slug });
+
+			_analytics.mc.bumpStat('calypso_jpc_plan_selection', cartItem.product_slug);
+
+			(0, _actions2.addItem)(cartItem);
+			_this.redirecting = true;
+			_this.props.completeFlow();
+			_page2.default.redirect(checkoutPath);
+		}",
+                                            "plans": "jetpack_personal,jetpack_premium,jetpack_business",
+                                            "site": "[object Object]",
+                                          },
                                           "children": Array [],
-                                          "name": "div",
+                                          "name": "my-sites--plan-features",
                                           "next": null,
                                           "parent": [Circular],
                                           "prev": null,
@@ -9698,7 +11793,7 @@ initialize {
                                     "prev": Object {
                                       "attribs": Object {},
                                       "children": Array [],
-                                      "name": "div",
+                                      "name": "components--data--query-plans",
                                       "next": [Circular],
                                       "parent": [Circular],
                                       "prev": Object {
@@ -9911,9 +12006,40 @@ initialize {
                                     },
                                     "children": Array [
                                       Object {
-                                        "attribs": Object {},
+                                        "attribs": Object {
+                                          "baseplanspath": "/jetpack/connect/plans",
+                                          "displayjetpackplans": "true",
+                                          "isinsignup": "true",
+                                          "islandingpage": "false",
+                                          "onupgradeclick": "function (cartItem) {
+			var checkoutPath = '/checkout/' + _this.props.selectedSite.slug;
+			// clears whatever we had stored in local cache
+			_this.props.selectPlanInAdvance(null, _this.props.selectedSiteSlug);
+
+			if (!cartItem || cartItem.product_slug === _constants.PLAN_JETPACK_FREE) {
+				return _this.selectFreeJetpackPlan();
+			}
+
+			if (cartItem.product_slug === (0, _lodash.get)(_this.props, 'selectedSite.plan.product_slug', null)) {
+				return _this.redirect(CALYPSO_PLANS_PAGE);
+			}
+
+			_this.props.recordTracksEvent('calypso_jpc_plans_submit', {
+				user: _this.props.userId,
+				product_slug: cartItem.product_slug });
+
+			_analytics.mc.bumpStat('calypso_jpc_plan_selection', cartItem.product_slug);
+
+			(0, _actions2.addItem)(cartItem);
+			_this.redirecting = true;
+			_this.props.completeFlow();
+			_page2.default.redirect(checkoutPath);
+		}",
+                                          "plans": "jetpack_personal,jetpack_premium,jetpack_business",
+                                          "site": "[object Object]",
+                                        },
                                         "children": Array [],
-                                        "name": "div",
+                                        "name": "my-sites--plan-features",
                                         "next": null,
                                         "parent": [Circular],
                                         "prev": null,
@@ -9924,15 +12050,17 @@ initialize {
                                     "next": null,
                                     "parent": [Circular],
                                     "prev": Object {
-                                      "attribs": Object {},
+                                      "attribs": Object {
+                                        "siteid": "1234567",
+                                      },
                                       "children": Array [],
-                                      "name": "div",
+                                      "name": "components--data--query-site-plans",
                                       "next": [Circular],
                                       "parent": [Circular],
                                       "prev": Object {
                                         "attribs": Object {},
                                         "children": Array [],
-                                        "name": "div",
+                                        "name": "components--data--query-plans",
                                         "next": [Circular],
                                         "parent": [Circular],
                                         "prev": Object {
@@ -10369,11 +12497,13 @@ initialize {
                               "next": Object {
                                 "attribs": Object {},
                                 "children": Array [],
-                                "name": "div",
+                                "name": "components--data--query-plans",
                                 "next": Object {
-                                  "attribs": Object {},
+                                  "attribs": Object {
+                                    "siteid": "1234567",
+                                  },
                                   "children": Array [],
-                                  "name": "div",
+                                  "name": "components--data--query-site-plans",
                                   "next": Object {
                                     "attribs": Object {
                                       "class": "plans-features-main__group",
@@ -10381,9 +12511,40 @@ initialize {
                                     },
                                     "children": Array [
                                       Object {
-                                        "attribs": Object {},
+                                        "attribs": Object {
+                                          "baseplanspath": "/jetpack/connect/plans",
+                                          "displayjetpackplans": "true",
+                                          "isinsignup": "true",
+                                          "islandingpage": "false",
+                                          "onupgradeclick": "function (cartItem) {
+			var checkoutPath = '/checkout/' + _this.props.selectedSite.slug;
+			// clears whatever we had stored in local cache
+			_this.props.selectPlanInAdvance(null, _this.props.selectedSiteSlug);
+
+			if (!cartItem || cartItem.product_slug === _constants.PLAN_JETPACK_FREE) {
+				return _this.selectFreeJetpackPlan();
+			}
+
+			if (cartItem.product_slug === (0, _lodash.get)(_this.props, 'selectedSite.plan.product_slug', null)) {
+				return _this.redirect(CALYPSO_PLANS_PAGE);
+			}
+
+			_this.props.recordTracksEvent('calypso_jpc_plans_submit', {
+				user: _this.props.userId,
+				product_slug: cartItem.product_slug });
+
+			_analytics.mc.bumpStat('calypso_jpc_plan_selection', cartItem.product_slug);
+
+			(0, _actions2.addItem)(cartItem);
+			_this.redirecting = true;
+			_this.props.completeFlow();
+			_page2.default.redirect(checkoutPath);
+		}",
+                                          "plans": "jetpack_personal,jetpack_premium,jetpack_business",
+                                          "site": "[object Object]",
+                                        },
                                         "children": Array [],
-                                        "name": "div",
+                                        "name": "my-sites--plan-features",
                                         "next": null,
                                         "parent": [Circular],
                                         "prev": null,
@@ -10411,11 +12572,13 @@ initialize {
                             Object {
                               "attribs": Object {},
                               "children": Array [],
-                              "name": "div",
+                              "name": "components--data--query-plans",
                               "next": Object {
-                                "attribs": Object {},
+                                "attribs": Object {
+                                  "siteid": "1234567",
+                                },
                                 "children": Array [],
-                                "name": "div",
+                                "name": "components--data--query-site-plans",
                                 "next": Object {
                                   "attribs": Object {
                                     "class": "plans-features-main__group",
@@ -10423,9 +12586,40 @@ initialize {
                                   },
                                   "children": Array [
                                     Object {
-                                      "attribs": Object {},
+                                      "attribs": Object {
+                                        "baseplanspath": "/jetpack/connect/plans",
+                                        "displayjetpackplans": "true",
+                                        "isinsignup": "true",
+                                        "islandingpage": "false",
+                                        "onupgradeclick": "function (cartItem) {
+			var checkoutPath = '/checkout/' + _this.props.selectedSite.slug;
+			// clears whatever we had stored in local cache
+			_this.props.selectPlanInAdvance(null, _this.props.selectedSiteSlug);
+
+			if (!cartItem || cartItem.product_slug === _constants.PLAN_JETPACK_FREE) {
+				return _this.selectFreeJetpackPlan();
+			}
+
+			if (cartItem.product_slug === (0, _lodash.get)(_this.props, 'selectedSite.plan.product_slug', null)) {
+				return _this.redirect(CALYPSO_PLANS_PAGE);
+			}
+
+			_this.props.recordTracksEvent('calypso_jpc_plans_submit', {
+				user: _this.props.userId,
+				product_slug: cartItem.product_slug });
+
+			_analytics.mc.bumpStat('calypso_jpc_plan_selection', cartItem.product_slug);
+
+			(0, _actions2.addItem)(cartItem);
+			_this.redirecting = true;
+			_this.props.completeFlow();
+			_page2.default.redirect(checkoutPath);
+		}",
+                                        "plans": "jetpack_personal,jetpack_premium,jetpack_business",
+                                        "site": "[object Object]",
+                                      },
                                       "children": Array [],
-                                      "name": "div",
+                                      "name": "my-sites--plan-features",
                                       "next": null,
                                       "parent": [Circular],
                                       "prev": null,
@@ -10645,9 +12839,11 @@ initialize {
                               "type": "tag",
                             },
                             Object {
-                              "attribs": Object {},
+                              "attribs": Object {
+                                "siteid": "1234567",
+                              },
                               "children": Array [],
-                              "name": "div",
+                              "name": "components--data--query-site-plans",
                               "next": Object {
                                 "attribs": Object {
                                   "class": "plans-features-main__group",
@@ -10655,9 +12851,40 @@ initialize {
                                 },
                                 "children": Array [
                                   Object {
-                                    "attribs": Object {},
+                                    "attribs": Object {
+                                      "baseplanspath": "/jetpack/connect/plans",
+                                      "displayjetpackplans": "true",
+                                      "isinsignup": "true",
+                                      "islandingpage": "false",
+                                      "onupgradeclick": "function (cartItem) {
+			var checkoutPath = '/checkout/' + _this.props.selectedSite.slug;
+			// clears whatever we had stored in local cache
+			_this.props.selectPlanInAdvance(null, _this.props.selectedSiteSlug);
+
+			if (!cartItem || cartItem.product_slug === _constants.PLAN_JETPACK_FREE) {
+				return _this.selectFreeJetpackPlan();
+			}
+
+			if (cartItem.product_slug === (0, _lodash.get)(_this.props, 'selectedSite.plan.product_slug', null)) {
+				return _this.redirect(CALYPSO_PLANS_PAGE);
+			}
+
+			_this.props.recordTracksEvent('calypso_jpc_plans_submit', {
+				user: _this.props.userId,
+				product_slug: cartItem.product_slug });
+
+			_analytics.mc.bumpStat('calypso_jpc_plan_selection', cartItem.product_slug);
+
+			(0, _actions2.addItem)(cartItem);
+			_this.redirecting = true;
+			_this.props.completeFlow();
+			_page2.default.redirect(checkoutPath);
+		}",
+                                      "plans": "jetpack_personal,jetpack_premium,jetpack_business",
+                                      "site": "[object Object]",
+                                    },
                                     "children": Array [],
-                                    "name": "div",
+                                    "name": "my-sites--plan-features",
                                     "next": null,
                                     "parent": [Circular],
                                     "prev": null,
@@ -10674,7 +12901,7 @@ initialize {
                               "prev": Object {
                                 "attribs": Object {},
                                 "children": Array [],
-                                "name": "div",
+                                "name": "components--data--query-plans",
                                 "next": [Circular],
                                 "parent": [Circular],
                                 "prev": Object {
@@ -10887,9 +13114,40 @@ initialize {
                               },
                               "children": Array [
                                 Object {
-                                  "attribs": Object {},
+                                  "attribs": Object {
+                                    "baseplanspath": "/jetpack/connect/plans",
+                                    "displayjetpackplans": "true",
+                                    "isinsignup": "true",
+                                    "islandingpage": "false",
+                                    "onupgradeclick": "function (cartItem) {
+			var checkoutPath = '/checkout/' + _this.props.selectedSite.slug;
+			// clears whatever we had stored in local cache
+			_this.props.selectPlanInAdvance(null, _this.props.selectedSiteSlug);
+
+			if (!cartItem || cartItem.product_slug === _constants.PLAN_JETPACK_FREE) {
+				return _this.selectFreeJetpackPlan();
+			}
+
+			if (cartItem.product_slug === (0, _lodash.get)(_this.props, 'selectedSite.plan.product_slug', null)) {
+				return _this.redirect(CALYPSO_PLANS_PAGE);
+			}
+
+			_this.props.recordTracksEvent('calypso_jpc_plans_submit', {
+				user: _this.props.userId,
+				product_slug: cartItem.product_slug });
+
+			_analytics.mc.bumpStat('calypso_jpc_plan_selection', cartItem.product_slug);
+
+			(0, _actions2.addItem)(cartItem);
+			_this.redirecting = true;
+			_this.props.completeFlow();
+			_page2.default.redirect(checkoutPath);
+		}",
+                                    "plans": "jetpack_personal,jetpack_premium,jetpack_business",
+                                    "site": "[object Object]",
+                                  },
                                   "children": Array [],
-                                  "name": "div",
+                                  "name": "my-sites--plan-features",
                                   "next": null,
                                   "parent": [Circular],
                                   "prev": null,
@@ -10900,15 +13158,17 @@ initialize {
                               "next": null,
                               "parent": [Circular],
                               "prev": Object {
-                                "attribs": Object {},
+                                "attribs": Object {
+                                  "siteid": "1234567",
+                                },
                                 "children": Array [],
-                                "name": "div",
+                                "name": "components--data--query-site-plans",
                                 "next": [Circular],
                                 "parent": [Circular],
                                 "prev": Object {
                                   "attribs": Object {},
                                   "children": Array [],
-                                  "name": "div",
+                                  "name": "components--data--query-plans",
                                   "next": [Circular],
                                   "parent": [Circular],
                                   "prev": Object {
@@ -11230,9 +13490,113 @@ initialize {
                               },
                               "children": Array [
                                 Object {
-                                  "attribs": Object {},
-                                  "children": Array [],
-                                  "name": "div",
+                                  "attribs": Object {
+                                    "label": "Need help?",
+                                  },
+                                  "children": Array [
+                                    Object {
+                                      "attribs": Object {
+                                        "class": "logged-out-form__link-item jetpack-connect__help-button",
+                                        "href": "https://jetpack.com/contact-support",
+                                        "rel": "noopener noreferrer",
+                                        "target": "_blank",
+                                      },
+                                      "children": Array [
+                                        Object {
+                                          "attribs": Object {
+                                            "class": "gridicon gridicons-help-outline",
+                                            "height": "24",
+                                            "viewbox": "0 0 24 24",
+                                            "width": "24",
+                                            "xmlns": "http://www.w3.org/2000/svg",
+                                          },
+                                          "children": Array [
+                                            Object {
+                                              "attribs": Object {},
+                                              "children": Array [
+                                                Object {
+                                                  "attribs": Object {
+                                                    "d": "M12 4c4.41 0 8 3.59 8 8s-3.59 8-8 8-8-3.59-8-8 3.59-8 8-8m0-2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm4 8c0-2.21-1.79-4-4-4s-4 1.79-4 4h2c0-1.103.897-2 2-2s2 .897 2 2-.897 2-2 2c-.552 0-1 .448-1 1v2h2v-1.14c1.722-.447 3-1.998 3-3.86zm-3 6h-2v2h2v-2z",
+                                                  },
+                                                  "children": Array [],
+                                                  "name": "path",
+                                                  "next": null,
+                                                  "parent": [Circular],
+                                                  "prev": null,
+                                                  "type": "tag",
+                                                },
+                                              ],
+                                              "name": "g",
+                                              "next": null,
+                                              "parent": [Circular],
+                                              "prev": null,
+                                              "type": "tag",
+                                            },
+                                          ],
+                                          "name": "svg",
+                                          "next": Object {
+                                            "data": " Need help?",
+                                            "next": null,
+                                            "parent": [Circular],
+                                            "prev": [Circular],
+                                            "type": "text",
+                                          },
+                                          "parent": [Circular],
+                                          "prev": null,
+                                          "type": "tag",
+                                        },
+                                        Object {
+                                          "data": " Need help?",
+                                          "next": null,
+                                          "parent": [Circular],
+                                          "prev": Object {
+                                            "attribs": Object {
+                                              "class": "gridicon gridicons-help-outline",
+                                              "height": "24",
+                                              "viewbox": "0 0 24 24",
+                                              "width": "24",
+                                              "xmlns": "http://www.w3.org/2000/svg",
+                                            },
+                                            "children": Array [
+                                              Object {
+                                                "attribs": Object {},
+                                                "children": Array [
+                                                  Object {
+                                                    "attribs": Object {
+                                                      "d": "M12 4c4.41 0 8 3.59 8 8s-3.59 8-8 8-8-3.59-8-8 3.59-8 8-8m0-2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm4 8c0-2.21-1.79-4-4-4s-4 1.79-4 4h2c0-1.103.897-2 2-2s2 .897 2 2-.897 2-2 2c-.552 0-1 .448-1 1v2h2v-1.14c1.722-.447 3-1.998 3-3.86zm-3 6h-2v2h2v-2z",
+                                                    },
+                                                    "children": Array [],
+                                                    "name": "path",
+                                                    "next": null,
+                                                    "parent": [Circular],
+                                                    "prev": null,
+                                                    "type": "tag",
+                                                  },
+                                                ],
+                                                "name": "g",
+                                                "next": null,
+                                                "parent": [Circular],
+                                                "prev": null,
+                                                "type": "tag",
+                                              },
+                                            ],
+                                            "name": "svg",
+                                            "next": [Circular],
+                                            "parent": [Circular],
+                                            "prev": null,
+                                            "type": "tag",
+                                          },
+                                          "type": "text",
+                                        },
+                                      ],
+                                      "name": "a",
+                                      "next": null,
+                                      "parent": [Circular],
+                                      "prev": null,
+                                      "type": "tag",
+                                    },
+                                  ],
+                                  "name": "jetpack-connect--happychat-button",
                                   "next": null,
                                   "parent": [Circular],
                                   "prev": null,
@@ -11365,9 +13729,113 @@ initialize {
                             },
                             "children": Array [
                               Object {
-                                "attribs": Object {},
-                                "children": Array [],
-                                "name": "div",
+                                "attribs": Object {
+                                  "label": "Need help?",
+                                },
+                                "children": Array [
+                                  Object {
+                                    "attribs": Object {
+                                      "class": "logged-out-form__link-item jetpack-connect__help-button",
+                                      "href": "https://jetpack.com/contact-support",
+                                      "rel": "noopener noreferrer",
+                                      "target": "_blank",
+                                    },
+                                    "children": Array [
+                                      Object {
+                                        "attribs": Object {
+                                          "class": "gridicon gridicons-help-outline",
+                                          "height": "24",
+                                          "viewbox": "0 0 24 24",
+                                          "width": "24",
+                                          "xmlns": "http://www.w3.org/2000/svg",
+                                        },
+                                        "children": Array [
+                                          Object {
+                                            "attribs": Object {},
+                                            "children": Array [
+                                              Object {
+                                                "attribs": Object {
+                                                  "d": "M12 4c4.41 0 8 3.59 8 8s-3.59 8-8 8-8-3.59-8-8 3.59-8 8-8m0-2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm4 8c0-2.21-1.79-4-4-4s-4 1.79-4 4h2c0-1.103.897-2 2-2s2 .897 2 2-.897 2-2 2c-.552 0-1 .448-1 1v2h2v-1.14c1.722-.447 3-1.998 3-3.86zm-3 6h-2v2h2v-2z",
+                                                },
+                                                "children": Array [],
+                                                "name": "path",
+                                                "next": null,
+                                                "parent": [Circular],
+                                                "prev": null,
+                                                "type": "tag",
+                                              },
+                                            ],
+                                            "name": "g",
+                                            "next": null,
+                                            "parent": [Circular],
+                                            "prev": null,
+                                            "type": "tag",
+                                          },
+                                        ],
+                                        "name": "svg",
+                                        "next": Object {
+                                          "data": " Need help?",
+                                          "next": null,
+                                          "parent": [Circular],
+                                          "prev": [Circular],
+                                          "type": "text",
+                                        },
+                                        "parent": [Circular],
+                                        "prev": null,
+                                        "type": "tag",
+                                      },
+                                      Object {
+                                        "data": " Need help?",
+                                        "next": null,
+                                        "parent": [Circular],
+                                        "prev": Object {
+                                          "attribs": Object {
+                                            "class": "gridicon gridicons-help-outline",
+                                            "height": "24",
+                                            "viewbox": "0 0 24 24",
+                                            "width": "24",
+                                            "xmlns": "http://www.w3.org/2000/svg",
+                                          },
+                                          "children": Array [
+                                            Object {
+                                              "attribs": Object {},
+                                              "children": Array [
+                                                Object {
+                                                  "attribs": Object {
+                                                    "d": "M12 4c4.41 0 8 3.59 8 8s-3.59 8-8 8-8-3.59-8-8 3.59-8 8-8m0-2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm4 8c0-2.21-1.79-4-4-4s-4 1.79-4 4h2c0-1.103.897-2 2-2s2 .897 2 2-.897 2-2 2c-.552 0-1 .448-1 1v2h2v-1.14c1.722-.447 3-1.998 3-3.86zm-3 6h-2v2h2v-2z",
+                                                  },
+                                                  "children": Array [],
+                                                  "name": "path",
+                                                  "next": null,
+                                                  "parent": [Circular],
+                                                  "prev": null,
+                                                  "type": "tag",
+                                                },
+                                              ],
+                                              "name": "g",
+                                              "next": null,
+                                              "parent": [Circular],
+                                              "prev": null,
+                                              "type": "tag",
+                                            },
+                                          ],
+                                          "name": "svg",
+                                          "next": [Circular],
+                                          "parent": [Circular],
+                                          "prev": null,
+                                          "type": "tag",
+                                        },
+                                        "type": "text",
+                                      },
+                                    ],
+                                    "name": "a",
+                                    "next": null,
+                                    "parent": [Circular],
+                                    "prev": null,
+                                    "type": "tag",
+                                  },
+                                ],
+                                "name": "jetpack-connect--happychat-button",
                                 "next": null,
                                 "parent": [Circular],
                                 "prev": null,
@@ -11583,11 +14051,13 @@ initialize {
                                 "next": Object {
                                   "attribs": Object {},
                                   "children": Array [],
-                                  "name": "div",
+                                  "name": "components--data--query-plans",
                                   "next": Object {
-                                    "attribs": Object {},
+                                    "attribs": Object {
+                                      "siteid": "1234567",
+                                    },
                                     "children": Array [],
-                                    "name": "div",
+                                    "name": "components--data--query-site-plans",
                                     "next": Object {
                                       "attribs": Object {
                                         "class": "plans-features-main__group",
@@ -11595,9 +14065,40 @@ initialize {
                                       },
                                       "children": Array [
                                         Object {
-                                          "attribs": Object {},
+                                          "attribs": Object {
+                                            "baseplanspath": "/jetpack/connect/plans",
+                                            "displayjetpackplans": "true",
+                                            "isinsignup": "true",
+                                            "islandingpage": "false",
+                                            "onupgradeclick": "function (cartItem) {
+			var checkoutPath = '/checkout/' + _this.props.selectedSite.slug;
+			// clears whatever we had stored in local cache
+			_this.props.selectPlanInAdvance(null, _this.props.selectedSiteSlug);
+
+			if (!cartItem || cartItem.product_slug === _constants.PLAN_JETPACK_FREE) {
+				return _this.selectFreeJetpackPlan();
+			}
+
+			if (cartItem.product_slug === (0, _lodash.get)(_this.props, 'selectedSite.plan.product_slug', null)) {
+				return _this.redirect(CALYPSO_PLANS_PAGE);
+			}
+
+			_this.props.recordTracksEvent('calypso_jpc_plans_submit', {
+				user: _this.props.userId,
+				product_slug: cartItem.product_slug });
+
+			_analytics.mc.bumpStat('calypso_jpc_plan_selection', cartItem.product_slug);
+
+			(0, _actions2.addItem)(cartItem);
+			_this.redirecting = true;
+			_this.props.completeFlow();
+			_page2.default.redirect(checkoutPath);
+		}",
+                                            "plans": "jetpack_personal,jetpack_premium,jetpack_business",
+                                            "site": "[object Object]",
+                                          },
                                           "children": Array [],
-                                          "name": "div",
+                                          "name": "my-sites--plan-features",
                                           "next": null,
                                           "parent": [Circular],
                                           "prev": null,
@@ -11625,11 +14126,13 @@ initialize {
                               Object {
                                 "attribs": Object {},
                                 "children": Array [],
-                                "name": "div",
+                                "name": "components--data--query-plans",
                                 "next": Object {
-                                  "attribs": Object {},
+                                  "attribs": Object {
+                                    "siteid": "1234567",
+                                  },
                                   "children": Array [],
-                                  "name": "div",
+                                  "name": "components--data--query-site-plans",
                                   "next": Object {
                                     "attribs": Object {
                                       "class": "plans-features-main__group",
@@ -11637,9 +14140,40 @@ initialize {
                                     },
                                     "children": Array [
                                       Object {
-                                        "attribs": Object {},
+                                        "attribs": Object {
+                                          "baseplanspath": "/jetpack/connect/plans",
+                                          "displayjetpackplans": "true",
+                                          "isinsignup": "true",
+                                          "islandingpage": "false",
+                                          "onupgradeclick": "function (cartItem) {
+			var checkoutPath = '/checkout/' + _this.props.selectedSite.slug;
+			// clears whatever we had stored in local cache
+			_this.props.selectPlanInAdvance(null, _this.props.selectedSiteSlug);
+
+			if (!cartItem || cartItem.product_slug === _constants.PLAN_JETPACK_FREE) {
+				return _this.selectFreeJetpackPlan();
+			}
+
+			if (cartItem.product_slug === (0, _lodash.get)(_this.props, 'selectedSite.plan.product_slug', null)) {
+				return _this.redirect(CALYPSO_PLANS_PAGE);
+			}
+
+			_this.props.recordTracksEvent('calypso_jpc_plans_submit', {
+				user: _this.props.userId,
+				product_slug: cartItem.product_slug });
+
+			_analytics.mc.bumpStat('calypso_jpc_plan_selection', cartItem.product_slug);
+
+			(0, _actions2.addItem)(cartItem);
+			_this.redirecting = true;
+			_this.props.completeFlow();
+			_page2.default.redirect(checkoutPath);
+		}",
+                                          "plans": "jetpack_personal,jetpack_premium,jetpack_business",
+                                          "site": "[object Object]",
+                                        },
                                         "children": Array [],
-                                        "name": "div",
+                                        "name": "my-sites--plan-features",
                                         "next": null,
                                         "parent": [Circular],
                                         "prev": null,
@@ -11859,9 +14393,11 @@ initialize {
                                 "type": "tag",
                               },
                               Object {
-                                "attribs": Object {},
+                                "attribs": Object {
+                                  "siteid": "1234567",
+                                },
                                 "children": Array [],
-                                "name": "div",
+                                "name": "components--data--query-site-plans",
                                 "next": Object {
                                   "attribs": Object {
                                     "class": "plans-features-main__group",
@@ -11869,9 +14405,40 @@ initialize {
                                   },
                                   "children": Array [
                                     Object {
-                                      "attribs": Object {},
+                                      "attribs": Object {
+                                        "baseplanspath": "/jetpack/connect/plans",
+                                        "displayjetpackplans": "true",
+                                        "isinsignup": "true",
+                                        "islandingpage": "false",
+                                        "onupgradeclick": "function (cartItem) {
+			var checkoutPath = '/checkout/' + _this.props.selectedSite.slug;
+			// clears whatever we had stored in local cache
+			_this.props.selectPlanInAdvance(null, _this.props.selectedSiteSlug);
+
+			if (!cartItem || cartItem.product_slug === _constants.PLAN_JETPACK_FREE) {
+				return _this.selectFreeJetpackPlan();
+			}
+
+			if (cartItem.product_slug === (0, _lodash.get)(_this.props, 'selectedSite.plan.product_slug', null)) {
+				return _this.redirect(CALYPSO_PLANS_PAGE);
+			}
+
+			_this.props.recordTracksEvent('calypso_jpc_plans_submit', {
+				user: _this.props.userId,
+				product_slug: cartItem.product_slug });
+
+			_analytics.mc.bumpStat('calypso_jpc_plan_selection', cartItem.product_slug);
+
+			(0, _actions2.addItem)(cartItem);
+			_this.redirecting = true;
+			_this.props.completeFlow();
+			_page2.default.redirect(checkoutPath);
+		}",
+                                        "plans": "jetpack_personal,jetpack_premium,jetpack_business",
+                                        "site": "[object Object]",
+                                      },
                                       "children": Array [],
-                                      "name": "div",
+                                      "name": "my-sites--plan-features",
                                       "next": null,
                                       "parent": [Circular],
                                       "prev": null,
@@ -11888,7 +14455,7 @@ initialize {
                                 "prev": Object {
                                   "attribs": Object {},
                                   "children": Array [],
-                                  "name": "div",
+                                  "name": "components--data--query-plans",
                                   "next": [Circular],
                                   "parent": [Circular],
                                   "prev": Object {
@@ -12101,9 +14668,40 @@ initialize {
                                 },
                                 "children": Array [
                                   Object {
-                                    "attribs": Object {},
+                                    "attribs": Object {
+                                      "baseplanspath": "/jetpack/connect/plans",
+                                      "displayjetpackplans": "true",
+                                      "isinsignup": "true",
+                                      "islandingpage": "false",
+                                      "onupgradeclick": "function (cartItem) {
+			var checkoutPath = '/checkout/' + _this.props.selectedSite.slug;
+			// clears whatever we had stored in local cache
+			_this.props.selectPlanInAdvance(null, _this.props.selectedSiteSlug);
+
+			if (!cartItem || cartItem.product_slug === _constants.PLAN_JETPACK_FREE) {
+				return _this.selectFreeJetpackPlan();
+			}
+
+			if (cartItem.product_slug === (0, _lodash.get)(_this.props, 'selectedSite.plan.product_slug', null)) {
+				return _this.redirect(CALYPSO_PLANS_PAGE);
+			}
+
+			_this.props.recordTracksEvent('calypso_jpc_plans_submit', {
+				user: _this.props.userId,
+				product_slug: cartItem.product_slug });
+
+			_analytics.mc.bumpStat('calypso_jpc_plan_selection', cartItem.product_slug);
+
+			(0, _actions2.addItem)(cartItem);
+			_this.redirecting = true;
+			_this.props.completeFlow();
+			_page2.default.redirect(checkoutPath);
+		}",
+                                      "plans": "jetpack_personal,jetpack_premium,jetpack_business",
+                                      "site": "[object Object]",
+                                    },
                                     "children": Array [],
-                                    "name": "div",
+                                    "name": "my-sites--plan-features",
                                     "next": null,
                                     "parent": [Circular],
                                     "prev": null,
@@ -12114,15 +14712,17 @@ initialize {
                                 "next": null,
                                 "parent": [Circular],
                                 "prev": Object {
-                                  "attribs": Object {},
+                                  "attribs": Object {
+                                    "siteid": "1234567",
+                                  },
                                   "children": Array [],
-                                  "name": "div",
+                                  "name": "components--data--query-site-plans",
                                   "next": [Circular],
                                   "parent": [Circular],
                                   "prev": Object {
                                     "attribs": Object {},
                                     "children": Array [],
-                                    "name": "div",
+                                    "name": "components--data--query-plans",
                                     "next": [Circular],
                                     "parent": [Circular],
                                     "prev": Object {
@@ -12345,9 +14945,113 @@ initialize {
                           },
                           "children": Array [
                             Object {
-                              "attribs": Object {},
-                              "children": Array [],
-                              "name": "div",
+                              "attribs": Object {
+                                "label": "Need help?",
+                              },
+                              "children": Array [
+                                Object {
+                                  "attribs": Object {
+                                    "class": "logged-out-form__link-item jetpack-connect__help-button",
+                                    "href": "https://jetpack.com/contact-support",
+                                    "rel": "noopener noreferrer",
+                                    "target": "_blank",
+                                  },
+                                  "children": Array [
+                                    Object {
+                                      "attribs": Object {
+                                        "class": "gridicon gridicons-help-outline",
+                                        "height": "24",
+                                        "viewbox": "0 0 24 24",
+                                        "width": "24",
+                                        "xmlns": "http://www.w3.org/2000/svg",
+                                      },
+                                      "children": Array [
+                                        Object {
+                                          "attribs": Object {},
+                                          "children": Array [
+                                            Object {
+                                              "attribs": Object {
+                                                "d": "M12 4c4.41 0 8 3.59 8 8s-3.59 8-8 8-8-3.59-8-8 3.59-8 8-8m0-2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm4 8c0-2.21-1.79-4-4-4s-4 1.79-4 4h2c0-1.103.897-2 2-2s2 .897 2 2-.897 2-2 2c-.552 0-1 .448-1 1v2h2v-1.14c1.722-.447 3-1.998 3-3.86zm-3 6h-2v2h2v-2z",
+                                              },
+                                              "children": Array [],
+                                              "name": "path",
+                                              "next": null,
+                                              "parent": [Circular],
+                                              "prev": null,
+                                              "type": "tag",
+                                            },
+                                          ],
+                                          "name": "g",
+                                          "next": null,
+                                          "parent": [Circular],
+                                          "prev": null,
+                                          "type": "tag",
+                                        },
+                                      ],
+                                      "name": "svg",
+                                      "next": Object {
+                                        "data": " Need help?",
+                                        "next": null,
+                                        "parent": [Circular],
+                                        "prev": [Circular],
+                                        "type": "text",
+                                      },
+                                      "parent": [Circular],
+                                      "prev": null,
+                                      "type": "tag",
+                                    },
+                                    Object {
+                                      "data": " Need help?",
+                                      "next": null,
+                                      "parent": [Circular],
+                                      "prev": Object {
+                                        "attribs": Object {
+                                          "class": "gridicon gridicons-help-outline",
+                                          "height": "24",
+                                          "viewbox": "0 0 24 24",
+                                          "width": "24",
+                                          "xmlns": "http://www.w3.org/2000/svg",
+                                        },
+                                        "children": Array [
+                                          Object {
+                                            "attribs": Object {},
+                                            "children": Array [
+                                              Object {
+                                                "attribs": Object {
+                                                  "d": "M12 4c4.41 0 8 3.59 8 8s-3.59 8-8 8-8-3.59-8-8 3.59-8 8-8m0-2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm4 8c0-2.21-1.79-4-4-4s-4 1.79-4 4h2c0-1.103.897-2 2-2s2 .897 2 2-.897 2-2 2c-.552 0-1 .448-1 1v2h2v-1.14c1.722-.447 3-1.998 3-3.86zm-3 6h-2v2h2v-2z",
+                                                },
+                                                "children": Array [],
+                                                "name": "path",
+                                                "next": null,
+                                                "parent": [Circular],
+                                                "prev": null,
+                                                "type": "tag",
+                                              },
+                                            ],
+                                            "name": "g",
+                                            "next": null,
+                                            "parent": [Circular],
+                                            "prev": null,
+                                            "type": "tag",
+                                          },
+                                        ],
+                                        "name": "svg",
+                                        "next": [Circular],
+                                        "parent": [Circular],
+                                        "prev": null,
+                                        "type": "tag",
+                                      },
+                                      "type": "text",
+                                    },
+                                  ],
+                                  "name": "a",
+                                  "next": null,
+                                  "parent": [Circular],
+                                  "prev": null,
+                                  "type": "tag",
+                                },
+                              ],
+                              "name": "jetpack-connect--happychat-button",
                               "next": null,
                               "parent": [Circular],
                               "prev": null,
@@ -12667,11 +15371,13 @@ initialize {
                                   "next": Object {
                                     "attribs": Object {},
                                     "children": Array [],
-                                    "name": "div",
+                                    "name": "components--data--query-plans",
                                     "next": Object {
-                                      "attribs": Object {},
+                                      "attribs": Object {
+                                        "siteid": "1234567",
+                                      },
                                       "children": Array [],
-                                      "name": "div",
+                                      "name": "components--data--query-site-plans",
                                       "next": Object {
                                         "attribs": Object {
                                           "class": "plans-features-main__group",
@@ -12679,9 +15385,40 @@ initialize {
                                         },
                                         "children": Array [
                                           Object {
-                                            "attribs": Object {},
+                                            "attribs": Object {
+                                              "baseplanspath": "/jetpack/connect/plans",
+                                              "displayjetpackplans": "true",
+                                              "isinsignup": "true",
+                                              "islandingpage": "false",
+                                              "onupgradeclick": "function (cartItem) {
+			var checkoutPath = '/checkout/' + _this.props.selectedSite.slug;
+			// clears whatever we had stored in local cache
+			_this.props.selectPlanInAdvance(null, _this.props.selectedSiteSlug);
+
+			if (!cartItem || cartItem.product_slug === _constants.PLAN_JETPACK_FREE) {
+				return _this.selectFreeJetpackPlan();
+			}
+
+			if (cartItem.product_slug === (0, _lodash.get)(_this.props, 'selectedSite.plan.product_slug', null)) {
+				return _this.redirect(CALYPSO_PLANS_PAGE);
+			}
+
+			_this.props.recordTracksEvent('calypso_jpc_plans_submit', {
+				user: _this.props.userId,
+				product_slug: cartItem.product_slug });
+
+			_analytics.mc.bumpStat('calypso_jpc_plan_selection', cartItem.product_slug);
+
+			(0, _actions2.addItem)(cartItem);
+			_this.redirecting = true;
+			_this.props.completeFlow();
+			_page2.default.redirect(checkoutPath);
+		}",
+                                              "plans": "jetpack_personal,jetpack_premium,jetpack_business",
+                                              "site": "[object Object]",
+                                            },
                                             "children": Array [],
-                                            "name": "div",
+                                            "name": "my-sites--plan-features",
                                             "next": null,
                                             "parent": [Circular],
                                             "prev": null,
@@ -12709,11 +15446,13 @@ initialize {
                                 Object {
                                   "attribs": Object {},
                                   "children": Array [],
-                                  "name": "div",
+                                  "name": "components--data--query-plans",
                                   "next": Object {
-                                    "attribs": Object {},
+                                    "attribs": Object {
+                                      "siteid": "1234567",
+                                    },
                                     "children": Array [],
-                                    "name": "div",
+                                    "name": "components--data--query-site-plans",
                                     "next": Object {
                                       "attribs": Object {
                                         "class": "plans-features-main__group",
@@ -12721,9 +15460,40 @@ initialize {
                                       },
                                       "children": Array [
                                         Object {
-                                          "attribs": Object {},
+                                          "attribs": Object {
+                                            "baseplanspath": "/jetpack/connect/plans",
+                                            "displayjetpackplans": "true",
+                                            "isinsignup": "true",
+                                            "islandingpage": "false",
+                                            "onupgradeclick": "function (cartItem) {
+			var checkoutPath = '/checkout/' + _this.props.selectedSite.slug;
+			// clears whatever we had stored in local cache
+			_this.props.selectPlanInAdvance(null, _this.props.selectedSiteSlug);
+
+			if (!cartItem || cartItem.product_slug === _constants.PLAN_JETPACK_FREE) {
+				return _this.selectFreeJetpackPlan();
+			}
+
+			if (cartItem.product_slug === (0, _lodash.get)(_this.props, 'selectedSite.plan.product_slug', null)) {
+				return _this.redirect(CALYPSO_PLANS_PAGE);
+			}
+
+			_this.props.recordTracksEvent('calypso_jpc_plans_submit', {
+				user: _this.props.userId,
+				product_slug: cartItem.product_slug });
+
+			_analytics.mc.bumpStat('calypso_jpc_plan_selection', cartItem.product_slug);
+
+			(0, _actions2.addItem)(cartItem);
+			_this.redirecting = true;
+			_this.props.completeFlow();
+			_page2.default.redirect(checkoutPath);
+		}",
+                                            "plans": "jetpack_personal,jetpack_premium,jetpack_business",
+                                            "site": "[object Object]",
+                                          },
                                           "children": Array [],
-                                          "name": "div",
+                                          "name": "my-sites--plan-features",
                                           "next": null,
                                           "parent": [Circular],
                                           "prev": null,
@@ -12943,9 +15713,11 @@ initialize {
                                   "type": "tag",
                                 },
                                 Object {
-                                  "attribs": Object {},
+                                  "attribs": Object {
+                                    "siteid": "1234567",
+                                  },
                                   "children": Array [],
-                                  "name": "div",
+                                  "name": "components--data--query-site-plans",
                                   "next": Object {
                                     "attribs": Object {
                                       "class": "plans-features-main__group",
@@ -12953,9 +15725,40 @@ initialize {
                                     },
                                     "children": Array [
                                       Object {
-                                        "attribs": Object {},
+                                        "attribs": Object {
+                                          "baseplanspath": "/jetpack/connect/plans",
+                                          "displayjetpackplans": "true",
+                                          "isinsignup": "true",
+                                          "islandingpage": "false",
+                                          "onupgradeclick": "function (cartItem) {
+			var checkoutPath = '/checkout/' + _this.props.selectedSite.slug;
+			// clears whatever we had stored in local cache
+			_this.props.selectPlanInAdvance(null, _this.props.selectedSiteSlug);
+
+			if (!cartItem || cartItem.product_slug === _constants.PLAN_JETPACK_FREE) {
+				return _this.selectFreeJetpackPlan();
+			}
+
+			if (cartItem.product_slug === (0, _lodash.get)(_this.props, 'selectedSite.plan.product_slug', null)) {
+				return _this.redirect(CALYPSO_PLANS_PAGE);
+			}
+
+			_this.props.recordTracksEvent('calypso_jpc_plans_submit', {
+				user: _this.props.userId,
+				product_slug: cartItem.product_slug });
+
+			_analytics.mc.bumpStat('calypso_jpc_plan_selection', cartItem.product_slug);
+
+			(0, _actions2.addItem)(cartItem);
+			_this.redirecting = true;
+			_this.props.completeFlow();
+			_page2.default.redirect(checkoutPath);
+		}",
+                                          "plans": "jetpack_personal,jetpack_premium,jetpack_business",
+                                          "site": "[object Object]",
+                                        },
                                         "children": Array [],
-                                        "name": "div",
+                                        "name": "my-sites--plan-features",
                                         "next": null,
                                         "parent": [Circular],
                                         "prev": null,
@@ -12972,7 +15775,7 @@ initialize {
                                   "prev": Object {
                                     "attribs": Object {},
                                     "children": Array [],
-                                    "name": "div",
+                                    "name": "components--data--query-plans",
                                     "next": [Circular],
                                     "parent": [Circular],
                                     "prev": Object {
@@ -13185,9 +15988,40 @@ initialize {
                                   },
                                   "children": Array [
                                     Object {
-                                      "attribs": Object {},
+                                      "attribs": Object {
+                                        "baseplanspath": "/jetpack/connect/plans",
+                                        "displayjetpackplans": "true",
+                                        "isinsignup": "true",
+                                        "islandingpage": "false",
+                                        "onupgradeclick": "function (cartItem) {
+			var checkoutPath = '/checkout/' + _this.props.selectedSite.slug;
+			// clears whatever we had stored in local cache
+			_this.props.selectPlanInAdvance(null, _this.props.selectedSiteSlug);
+
+			if (!cartItem || cartItem.product_slug === _constants.PLAN_JETPACK_FREE) {
+				return _this.selectFreeJetpackPlan();
+			}
+
+			if (cartItem.product_slug === (0, _lodash.get)(_this.props, 'selectedSite.plan.product_slug', null)) {
+				return _this.redirect(CALYPSO_PLANS_PAGE);
+			}
+
+			_this.props.recordTracksEvent('calypso_jpc_plans_submit', {
+				user: _this.props.userId,
+				product_slug: cartItem.product_slug });
+
+			_analytics.mc.bumpStat('calypso_jpc_plan_selection', cartItem.product_slug);
+
+			(0, _actions2.addItem)(cartItem);
+			_this.redirecting = true;
+			_this.props.completeFlow();
+			_page2.default.redirect(checkoutPath);
+		}",
+                                        "plans": "jetpack_personal,jetpack_premium,jetpack_business",
+                                        "site": "[object Object]",
+                                      },
                                       "children": Array [],
-                                      "name": "div",
+                                      "name": "my-sites--plan-features",
                                       "next": null,
                                       "parent": [Circular],
                                       "prev": null,
@@ -13198,15 +16032,17 @@ initialize {
                                   "next": null,
                                   "parent": [Circular],
                                   "prev": Object {
-                                    "attribs": Object {},
+                                    "attribs": Object {
+                                      "siteid": "1234567",
+                                    },
                                     "children": Array [],
-                                    "name": "div",
+                                    "name": "components--data--query-site-plans",
                                     "next": [Circular],
                                     "parent": [Circular],
                                     "prev": Object {
                                       "attribs": Object {},
                                       "children": Array [],
-                                      "name": "div",
+                                      "name": "components--data--query-plans",
                                       "next": [Circular],
                                       "parent": [Circular],
                                       "prev": Object {
@@ -13535,7 +16371,7 @@ initialize {
             "prev": Object {
               "attribs": Object {},
               "children": Array [],
-              "name": "div",
+              "name": "components--data--query-plans",
               "next": [Circular],
               "parent": [Circular],
               "prev": null,
@@ -13842,11 +16678,13 @@ initialize {
                               "next": Object {
                                 "attribs": Object {},
                                 "children": Array [],
-                                "name": "div",
+                                "name": "components--data--query-plans",
                                 "next": Object {
-                                  "attribs": Object {},
+                                  "attribs": Object {
+                                    "siteid": "1234567",
+                                  },
                                   "children": Array [],
-                                  "name": "div",
+                                  "name": "components--data--query-site-plans",
                                   "next": Object {
                                     "attribs": Object {
                                       "class": "plans-features-main__group",
@@ -13854,9 +16692,40 @@ initialize {
                                     },
                                     "children": Array [
                                       Object {
-                                        "attribs": Object {},
+                                        "attribs": Object {
+                                          "baseplanspath": "/jetpack/connect/plans",
+                                          "displayjetpackplans": "true",
+                                          "isinsignup": "true",
+                                          "islandingpage": "false",
+                                          "onupgradeclick": "function (cartItem) {
+			var checkoutPath = '/checkout/' + _this.props.selectedSite.slug;
+			// clears whatever we had stored in local cache
+			_this.props.selectPlanInAdvance(null, _this.props.selectedSiteSlug);
+
+			if (!cartItem || cartItem.product_slug === _constants.PLAN_JETPACK_FREE) {
+				return _this.selectFreeJetpackPlan();
+			}
+
+			if (cartItem.product_slug === (0, _lodash.get)(_this.props, 'selectedSite.plan.product_slug', null)) {
+				return _this.redirect(CALYPSO_PLANS_PAGE);
+			}
+
+			_this.props.recordTracksEvent('calypso_jpc_plans_submit', {
+				user: _this.props.userId,
+				product_slug: cartItem.product_slug });
+
+			_analytics.mc.bumpStat('calypso_jpc_plan_selection', cartItem.product_slug);
+
+			(0, _actions2.addItem)(cartItem);
+			_this.redirecting = true;
+			_this.props.completeFlow();
+			_page2.default.redirect(checkoutPath);
+		}",
+                                          "plans": "jetpack_personal,jetpack_premium,jetpack_business",
+                                          "site": "[object Object]",
+                                        },
                                         "children": Array [],
-                                        "name": "div",
+                                        "name": "my-sites--plan-features",
                                         "next": null,
                                         "parent": [Circular],
                                         "prev": null,
@@ -13884,11 +16753,13 @@ initialize {
                             Object {
                               "attribs": Object {},
                               "children": Array [],
-                              "name": "div",
+                              "name": "components--data--query-plans",
                               "next": Object {
-                                "attribs": Object {},
+                                "attribs": Object {
+                                  "siteid": "1234567",
+                                },
                                 "children": Array [],
-                                "name": "div",
+                                "name": "components--data--query-site-plans",
                                 "next": Object {
                                   "attribs": Object {
                                     "class": "plans-features-main__group",
@@ -13896,9 +16767,40 @@ initialize {
                                   },
                                   "children": Array [
                                     Object {
-                                      "attribs": Object {},
+                                      "attribs": Object {
+                                        "baseplanspath": "/jetpack/connect/plans",
+                                        "displayjetpackplans": "true",
+                                        "isinsignup": "true",
+                                        "islandingpage": "false",
+                                        "onupgradeclick": "function (cartItem) {
+			var checkoutPath = '/checkout/' + _this.props.selectedSite.slug;
+			// clears whatever we had stored in local cache
+			_this.props.selectPlanInAdvance(null, _this.props.selectedSiteSlug);
+
+			if (!cartItem || cartItem.product_slug === _constants.PLAN_JETPACK_FREE) {
+				return _this.selectFreeJetpackPlan();
+			}
+
+			if (cartItem.product_slug === (0, _lodash.get)(_this.props, 'selectedSite.plan.product_slug', null)) {
+				return _this.redirect(CALYPSO_PLANS_PAGE);
+			}
+
+			_this.props.recordTracksEvent('calypso_jpc_plans_submit', {
+				user: _this.props.userId,
+				product_slug: cartItem.product_slug });
+
+			_analytics.mc.bumpStat('calypso_jpc_plan_selection', cartItem.product_slug);
+
+			(0, _actions2.addItem)(cartItem);
+			_this.redirecting = true;
+			_this.props.completeFlow();
+			_page2.default.redirect(checkoutPath);
+		}",
+                                        "plans": "jetpack_personal,jetpack_premium,jetpack_business",
+                                        "site": "[object Object]",
+                                      },
                                       "children": Array [],
-                                      "name": "div",
+                                      "name": "my-sites--plan-features",
                                       "next": null,
                                       "parent": [Circular],
                                       "prev": null,
@@ -14118,9 +17020,11 @@ initialize {
                               "type": "tag",
                             },
                             Object {
-                              "attribs": Object {},
+                              "attribs": Object {
+                                "siteid": "1234567",
+                              },
                               "children": Array [],
-                              "name": "div",
+                              "name": "components--data--query-site-plans",
                               "next": Object {
                                 "attribs": Object {
                                   "class": "plans-features-main__group",
@@ -14128,9 +17032,40 @@ initialize {
                                 },
                                 "children": Array [
                                   Object {
-                                    "attribs": Object {},
+                                    "attribs": Object {
+                                      "baseplanspath": "/jetpack/connect/plans",
+                                      "displayjetpackplans": "true",
+                                      "isinsignup": "true",
+                                      "islandingpage": "false",
+                                      "onupgradeclick": "function (cartItem) {
+			var checkoutPath = '/checkout/' + _this.props.selectedSite.slug;
+			// clears whatever we had stored in local cache
+			_this.props.selectPlanInAdvance(null, _this.props.selectedSiteSlug);
+
+			if (!cartItem || cartItem.product_slug === _constants.PLAN_JETPACK_FREE) {
+				return _this.selectFreeJetpackPlan();
+			}
+
+			if (cartItem.product_slug === (0, _lodash.get)(_this.props, 'selectedSite.plan.product_slug', null)) {
+				return _this.redirect(CALYPSO_PLANS_PAGE);
+			}
+
+			_this.props.recordTracksEvent('calypso_jpc_plans_submit', {
+				user: _this.props.userId,
+				product_slug: cartItem.product_slug });
+
+			_analytics.mc.bumpStat('calypso_jpc_plan_selection', cartItem.product_slug);
+
+			(0, _actions2.addItem)(cartItem);
+			_this.redirecting = true;
+			_this.props.completeFlow();
+			_page2.default.redirect(checkoutPath);
+		}",
+                                      "plans": "jetpack_personal,jetpack_premium,jetpack_business",
+                                      "site": "[object Object]",
+                                    },
                                     "children": Array [],
-                                    "name": "div",
+                                    "name": "my-sites--plan-features",
                                     "next": null,
                                     "parent": [Circular],
                                     "prev": null,
@@ -14147,7 +17082,7 @@ initialize {
                               "prev": Object {
                                 "attribs": Object {},
                                 "children": Array [],
-                                "name": "div",
+                                "name": "components--data--query-plans",
                                 "next": [Circular],
                                 "parent": [Circular],
                                 "prev": Object {
@@ -14360,9 +17295,40 @@ initialize {
                               },
                               "children": Array [
                                 Object {
-                                  "attribs": Object {},
+                                  "attribs": Object {
+                                    "baseplanspath": "/jetpack/connect/plans",
+                                    "displayjetpackplans": "true",
+                                    "isinsignup": "true",
+                                    "islandingpage": "false",
+                                    "onupgradeclick": "function (cartItem) {
+			var checkoutPath = '/checkout/' + _this.props.selectedSite.slug;
+			// clears whatever we had stored in local cache
+			_this.props.selectPlanInAdvance(null, _this.props.selectedSiteSlug);
+
+			if (!cartItem || cartItem.product_slug === _constants.PLAN_JETPACK_FREE) {
+				return _this.selectFreeJetpackPlan();
+			}
+
+			if (cartItem.product_slug === (0, _lodash.get)(_this.props, 'selectedSite.plan.product_slug', null)) {
+				return _this.redirect(CALYPSO_PLANS_PAGE);
+			}
+
+			_this.props.recordTracksEvent('calypso_jpc_plans_submit', {
+				user: _this.props.userId,
+				product_slug: cartItem.product_slug });
+
+			_analytics.mc.bumpStat('calypso_jpc_plan_selection', cartItem.product_slug);
+
+			(0, _actions2.addItem)(cartItem);
+			_this.redirecting = true;
+			_this.props.completeFlow();
+			_page2.default.redirect(checkoutPath);
+		}",
+                                    "plans": "jetpack_personal,jetpack_premium,jetpack_business",
+                                    "site": "[object Object]",
+                                  },
                                   "children": Array [],
-                                  "name": "div",
+                                  "name": "my-sites--plan-features",
                                   "next": null,
                                   "parent": [Circular],
                                   "prev": null,
@@ -14373,15 +17339,17 @@ initialize {
                               "next": null,
                               "parent": [Circular],
                               "prev": Object {
-                                "attribs": Object {},
+                                "attribs": Object {
+                                  "siteid": "1234567",
+                                },
                                 "children": Array [],
-                                "name": "div",
+                                "name": "components--data--query-site-plans",
                                 "next": [Circular],
                                 "parent": [Circular],
                                 "prev": Object {
                                   "attribs": Object {},
                                   "children": Array [],
-                                  "name": "div",
+                                  "name": "components--data--query-plans",
                                   "next": [Circular],
                                   "parent": [Circular],
                                   "prev": Object {
@@ -14703,9 +17671,113 @@ initialize {
                               },
                               "children": Array [
                                 Object {
-                                  "attribs": Object {},
-                                  "children": Array [],
-                                  "name": "div",
+                                  "attribs": Object {
+                                    "label": "Need help?",
+                                  },
+                                  "children": Array [
+                                    Object {
+                                      "attribs": Object {
+                                        "class": "logged-out-form__link-item jetpack-connect__help-button",
+                                        "href": "https://jetpack.com/contact-support",
+                                        "rel": "noopener noreferrer",
+                                        "target": "_blank",
+                                      },
+                                      "children": Array [
+                                        Object {
+                                          "attribs": Object {
+                                            "class": "gridicon gridicons-help-outline",
+                                            "height": "24",
+                                            "viewbox": "0 0 24 24",
+                                            "width": "24",
+                                            "xmlns": "http://www.w3.org/2000/svg",
+                                          },
+                                          "children": Array [
+                                            Object {
+                                              "attribs": Object {},
+                                              "children": Array [
+                                                Object {
+                                                  "attribs": Object {
+                                                    "d": "M12 4c4.41 0 8 3.59 8 8s-3.59 8-8 8-8-3.59-8-8 3.59-8 8-8m0-2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm4 8c0-2.21-1.79-4-4-4s-4 1.79-4 4h2c0-1.103.897-2 2-2s2 .897 2 2-.897 2-2 2c-.552 0-1 .448-1 1v2h2v-1.14c1.722-.447 3-1.998 3-3.86zm-3 6h-2v2h2v-2z",
+                                                  },
+                                                  "children": Array [],
+                                                  "name": "path",
+                                                  "next": null,
+                                                  "parent": [Circular],
+                                                  "prev": null,
+                                                  "type": "tag",
+                                                },
+                                              ],
+                                              "name": "g",
+                                              "next": null,
+                                              "parent": [Circular],
+                                              "prev": null,
+                                              "type": "tag",
+                                            },
+                                          ],
+                                          "name": "svg",
+                                          "next": Object {
+                                            "data": " Need help?",
+                                            "next": null,
+                                            "parent": [Circular],
+                                            "prev": [Circular],
+                                            "type": "text",
+                                          },
+                                          "parent": [Circular],
+                                          "prev": null,
+                                          "type": "tag",
+                                        },
+                                        Object {
+                                          "data": " Need help?",
+                                          "next": null,
+                                          "parent": [Circular],
+                                          "prev": Object {
+                                            "attribs": Object {
+                                              "class": "gridicon gridicons-help-outline",
+                                              "height": "24",
+                                              "viewbox": "0 0 24 24",
+                                              "width": "24",
+                                              "xmlns": "http://www.w3.org/2000/svg",
+                                            },
+                                            "children": Array [
+                                              Object {
+                                                "attribs": Object {},
+                                                "children": Array [
+                                                  Object {
+                                                    "attribs": Object {
+                                                      "d": "M12 4c4.41 0 8 3.59 8 8s-3.59 8-8 8-8-3.59-8-8 3.59-8 8-8m0-2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm4 8c0-2.21-1.79-4-4-4s-4 1.79-4 4h2c0-1.103.897-2 2-2s2 .897 2 2-.897 2-2 2c-.552 0-1 .448-1 1v2h2v-1.14c1.722-.447 3-1.998 3-3.86zm-3 6h-2v2h2v-2z",
+                                                    },
+                                                    "children": Array [],
+                                                    "name": "path",
+                                                    "next": null,
+                                                    "parent": [Circular],
+                                                    "prev": null,
+                                                    "type": "tag",
+                                                  },
+                                                ],
+                                                "name": "g",
+                                                "next": null,
+                                                "parent": [Circular],
+                                                "prev": null,
+                                                "type": "tag",
+                                              },
+                                            ],
+                                            "name": "svg",
+                                            "next": [Circular],
+                                            "parent": [Circular],
+                                            "prev": null,
+                                            "type": "tag",
+                                          },
+                                          "type": "text",
+                                        },
+                                      ],
+                                      "name": "a",
+                                      "next": null,
+                                      "parent": [Circular],
+                                      "prev": null,
+                                      "type": "tag",
+                                    },
+                                  ],
+                                  "name": "jetpack-connect--happychat-button",
                                   "next": null,
                                   "parent": [Circular],
                                   "prev": null,
@@ -14838,9 +17910,113 @@ initialize {
                             },
                             "children": Array [
                               Object {
-                                "attribs": Object {},
-                                "children": Array [],
-                                "name": "div",
+                                "attribs": Object {
+                                  "label": "Need help?",
+                                },
+                                "children": Array [
+                                  Object {
+                                    "attribs": Object {
+                                      "class": "logged-out-form__link-item jetpack-connect__help-button",
+                                      "href": "https://jetpack.com/contact-support",
+                                      "rel": "noopener noreferrer",
+                                      "target": "_blank",
+                                    },
+                                    "children": Array [
+                                      Object {
+                                        "attribs": Object {
+                                          "class": "gridicon gridicons-help-outline",
+                                          "height": "24",
+                                          "viewbox": "0 0 24 24",
+                                          "width": "24",
+                                          "xmlns": "http://www.w3.org/2000/svg",
+                                        },
+                                        "children": Array [
+                                          Object {
+                                            "attribs": Object {},
+                                            "children": Array [
+                                              Object {
+                                                "attribs": Object {
+                                                  "d": "M12 4c4.41 0 8 3.59 8 8s-3.59 8-8 8-8-3.59-8-8 3.59-8 8-8m0-2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm4 8c0-2.21-1.79-4-4-4s-4 1.79-4 4h2c0-1.103.897-2 2-2s2 .897 2 2-.897 2-2 2c-.552 0-1 .448-1 1v2h2v-1.14c1.722-.447 3-1.998 3-3.86zm-3 6h-2v2h2v-2z",
+                                                },
+                                                "children": Array [],
+                                                "name": "path",
+                                                "next": null,
+                                                "parent": [Circular],
+                                                "prev": null,
+                                                "type": "tag",
+                                              },
+                                            ],
+                                            "name": "g",
+                                            "next": null,
+                                            "parent": [Circular],
+                                            "prev": null,
+                                            "type": "tag",
+                                          },
+                                        ],
+                                        "name": "svg",
+                                        "next": Object {
+                                          "data": " Need help?",
+                                          "next": null,
+                                          "parent": [Circular],
+                                          "prev": [Circular],
+                                          "type": "text",
+                                        },
+                                        "parent": [Circular],
+                                        "prev": null,
+                                        "type": "tag",
+                                      },
+                                      Object {
+                                        "data": " Need help?",
+                                        "next": null,
+                                        "parent": [Circular],
+                                        "prev": Object {
+                                          "attribs": Object {
+                                            "class": "gridicon gridicons-help-outline",
+                                            "height": "24",
+                                            "viewbox": "0 0 24 24",
+                                            "width": "24",
+                                            "xmlns": "http://www.w3.org/2000/svg",
+                                          },
+                                          "children": Array [
+                                            Object {
+                                              "attribs": Object {},
+                                              "children": Array [
+                                                Object {
+                                                  "attribs": Object {
+                                                    "d": "M12 4c4.41 0 8 3.59 8 8s-3.59 8-8 8-8-3.59-8-8 3.59-8 8-8m0-2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm4 8c0-2.21-1.79-4-4-4s-4 1.79-4 4h2c0-1.103.897-2 2-2s2 .897 2 2-.897 2-2 2c-.552 0-1 .448-1 1v2h2v-1.14c1.722-.447 3-1.998 3-3.86zm-3 6h-2v2h2v-2z",
+                                                  },
+                                                  "children": Array [],
+                                                  "name": "path",
+                                                  "next": null,
+                                                  "parent": [Circular],
+                                                  "prev": null,
+                                                  "type": "tag",
+                                                },
+                                              ],
+                                              "name": "g",
+                                              "next": null,
+                                              "parent": [Circular],
+                                              "prev": null,
+                                              "type": "tag",
+                                            },
+                                          ],
+                                          "name": "svg",
+                                          "next": [Circular],
+                                          "parent": [Circular],
+                                          "prev": null,
+                                          "type": "tag",
+                                        },
+                                        "type": "text",
+                                      },
+                                    ],
+                                    "name": "a",
+                                    "next": null,
+                                    "parent": [Circular],
+                                    "prev": null,
+                                    "type": "tag",
+                                  },
+                                ],
+                                "name": "jetpack-connect--happychat-button",
                                 "next": null,
                                 "parent": [Circular],
                                 "prev": null,
@@ -15056,11 +18232,13 @@ initialize {
                                 "next": Object {
                                   "attribs": Object {},
                                   "children": Array [],
-                                  "name": "div",
+                                  "name": "components--data--query-plans",
                                   "next": Object {
-                                    "attribs": Object {},
+                                    "attribs": Object {
+                                      "siteid": "1234567",
+                                    },
                                     "children": Array [],
-                                    "name": "div",
+                                    "name": "components--data--query-site-plans",
                                     "next": Object {
                                       "attribs": Object {
                                         "class": "plans-features-main__group",
@@ -15068,9 +18246,40 @@ initialize {
                                       },
                                       "children": Array [
                                         Object {
-                                          "attribs": Object {},
+                                          "attribs": Object {
+                                            "baseplanspath": "/jetpack/connect/plans",
+                                            "displayjetpackplans": "true",
+                                            "isinsignup": "true",
+                                            "islandingpage": "false",
+                                            "onupgradeclick": "function (cartItem) {
+			var checkoutPath = '/checkout/' + _this.props.selectedSite.slug;
+			// clears whatever we had stored in local cache
+			_this.props.selectPlanInAdvance(null, _this.props.selectedSiteSlug);
+
+			if (!cartItem || cartItem.product_slug === _constants.PLAN_JETPACK_FREE) {
+				return _this.selectFreeJetpackPlan();
+			}
+
+			if (cartItem.product_slug === (0, _lodash.get)(_this.props, 'selectedSite.plan.product_slug', null)) {
+				return _this.redirect(CALYPSO_PLANS_PAGE);
+			}
+
+			_this.props.recordTracksEvent('calypso_jpc_plans_submit', {
+				user: _this.props.userId,
+				product_slug: cartItem.product_slug });
+
+			_analytics.mc.bumpStat('calypso_jpc_plan_selection', cartItem.product_slug);
+
+			(0, _actions2.addItem)(cartItem);
+			_this.redirecting = true;
+			_this.props.completeFlow();
+			_page2.default.redirect(checkoutPath);
+		}",
+                                            "plans": "jetpack_personal,jetpack_premium,jetpack_business",
+                                            "site": "[object Object]",
+                                          },
                                           "children": Array [],
-                                          "name": "div",
+                                          "name": "my-sites--plan-features",
                                           "next": null,
                                           "parent": [Circular],
                                           "prev": null,
@@ -15098,11 +18307,13 @@ initialize {
                               Object {
                                 "attribs": Object {},
                                 "children": Array [],
-                                "name": "div",
+                                "name": "components--data--query-plans",
                                 "next": Object {
-                                  "attribs": Object {},
+                                  "attribs": Object {
+                                    "siteid": "1234567",
+                                  },
                                   "children": Array [],
-                                  "name": "div",
+                                  "name": "components--data--query-site-plans",
                                   "next": Object {
                                     "attribs": Object {
                                       "class": "plans-features-main__group",
@@ -15110,9 +18321,40 @@ initialize {
                                     },
                                     "children": Array [
                                       Object {
-                                        "attribs": Object {},
+                                        "attribs": Object {
+                                          "baseplanspath": "/jetpack/connect/plans",
+                                          "displayjetpackplans": "true",
+                                          "isinsignup": "true",
+                                          "islandingpage": "false",
+                                          "onupgradeclick": "function (cartItem) {
+			var checkoutPath = '/checkout/' + _this.props.selectedSite.slug;
+			// clears whatever we had stored in local cache
+			_this.props.selectPlanInAdvance(null, _this.props.selectedSiteSlug);
+
+			if (!cartItem || cartItem.product_slug === _constants.PLAN_JETPACK_FREE) {
+				return _this.selectFreeJetpackPlan();
+			}
+
+			if (cartItem.product_slug === (0, _lodash.get)(_this.props, 'selectedSite.plan.product_slug', null)) {
+				return _this.redirect(CALYPSO_PLANS_PAGE);
+			}
+
+			_this.props.recordTracksEvent('calypso_jpc_plans_submit', {
+				user: _this.props.userId,
+				product_slug: cartItem.product_slug });
+
+			_analytics.mc.bumpStat('calypso_jpc_plan_selection', cartItem.product_slug);
+
+			(0, _actions2.addItem)(cartItem);
+			_this.redirecting = true;
+			_this.props.completeFlow();
+			_page2.default.redirect(checkoutPath);
+		}",
+                                          "plans": "jetpack_personal,jetpack_premium,jetpack_business",
+                                          "site": "[object Object]",
+                                        },
                                         "children": Array [],
-                                        "name": "div",
+                                        "name": "my-sites--plan-features",
                                         "next": null,
                                         "parent": [Circular],
                                         "prev": null,
@@ -15332,9 +18574,11 @@ initialize {
                                 "type": "tag",
                               },
                               Object {
-                                "attribs": Object {},
+                                "attribs": Object {
+                                  "siteid": "1234567",
+                                },
                                 "children": Array [],
-                                "name": "div",
+                                "name": "components--data--query-site-plans",
                                 "next": Object {
                                   "attribs": Object {
                                     "class": "plans-features-main__group",
@@ -15342,9 +18586,40 @@ initialize {
                                   },
                                   "children": Array [
                                     Object {
-                                      "attribs": Object {},
+                                      "attribs": Object {
+                                        "baseplanspath": "/jetpack/connect/plans",
+                                        "displayjetpackplans": "true",
+                                        "isinsignup": "true",
+                                        "islandingpage": "false",
+                                        "onupgradeclick": "function (cartItem) {
+			var checkoutPath = '/checkout/' + _this.props.selectedSite.slug;
+			// clears whatever we had stored in local cache
+			_this.props.selectPlanInAdvance(null, _this.props.selectedSiteSlug);
+
+			if (!cartItem || cartItem.product_slug === _constants.PLAN_JETPACK_FREE) {
+				return _this.selectFreeJetpackPlan();
+			}
+
+			if (cartItem.product_slug === (0, _lodash.get)(_this.props, 'selectedSite.plan.product_slug', null)) {
+				return _this.redirect(CALYPSO_PLANS_PAGE);
+			}
+
+			_this.props.recordTracksEvent('calypso_jpc_plans_submit', {
+				user: _this.props.userId,
+				product_slug: cartItem.product_slug });
+
+			_analytics.mc.bumpStat('calypso_jpc_plan_selection', cartItem.product_slug);
+
+			(0, _actions2.addItem)(cartItem);
+			_this.redirecting = true;
+			_this.props.completeFlow();
+			_page2.default.redirect(checkoutPath);
+		}",
+                                        "plans": "jetpack_personal,jetpack_premium,jetpack_business",
+                                        "site": "[object Object]",
+                                      },
                                       "children": Array [],
-                                      "name": "div",
+                                      "name": "my-sites--plan-features",
                                       "next": null,
                                       "parent": [Circular],
                                       "prev": null,
@@ -15361,7 +18636,7 @@ initialize {
                                 "prev": Object {
                                   "attribs": Object {},
                                   "children": Array [],
-                                  "name": "div",
+                                  "name": "components--data--query-plans",
                                   "next": [Circular],
                                   "parent": [Circular],
                                   "prev": Object {
@@ -15574,9 +18849,40 @@ initialize {
                                 },
                                 "children": Array [
                                   Object {
-                                    "attribs": Object {},
+                                    "attribs": Object {
+                                      "baseplanspath": "/jetpack/connect/plans",
+                                      "displayjetpackplans": "true",
+                                      "isinsignup": "true",
+                                      "islandingpage": "false",
+                                      "onupgradeclick": "function (cartItem) {
+			var checkoutPath = '/checkout/' + _this.props.selectedSite.slug;
+			// clears whatever we had stored in local cache
+			_this.props.selectPlanInAdvance(null, _this.props.selectedSiteSlug);
+
+			if (!cartItem || cartItem.product_slug === _constants.PLAN_JETPACK_FREE) {
+				return _this.selectFreeJetpackPlan();
+			}
+
+			if (cartItem.product_slug === (0, _lodash.get)(_this.props, 'selectedSite.plan.product_slug', null)) {
+				return _this.redirect(CALYPSO_PLANS_PAGE);
+			}
+
+			_this.props.recordTracksEvent('calypso_jpc_plans_submit', {
+				user: _this.props.userId,
+				product_slug: cartItem.product_slug });
+
+			_analytics.mc.bumpStat('calypso_jpc_plan_selection', cartItem.product_slug);
+
+			(0, _actions2.addItem)(cartItem);
+			_this.redirecting = true;
+			_this.props.completeFlow();
+			_page2.default.redirect(checkoutPath);
+		}",
+                                      "plans": "jetpack_personal,jetpack_premium,jetpack_business",
+                                      "site": "[object Object]",
+                                    },
                                     "children": Array [],
-                                    "name": "div",
+                                    "name": "my-sites--plan-features",
                                     "next": null,
                                     "parent": [Circular],
                                     "prev": null,
@@ -15587,15 +18893,17 @@ initialize {
                                 "next": null,
                                 "parent": [Circular],
                                 "prev": Object {
-                                  "attribs": Object {},
+                                  "attribs": Object {
+                                    "siteid": "1234567",
+                                  },
                                   "children": Array [],
-                                  "name": "div",
+                                  "name": "components--data--query-site-plans",
                                   "next": [Circular],
                                   "parent": [Circular],
                                   "prev": Object {
                                     "attribs": Object {},
                                     "children": Array [],
-                                    "name": "div",
+                                    "name": "components--data--query-plans",
                                     "next": [Circular],
                                     "parent": [Circular],
                                     "prev": Object {
@@ -15818,9 +19126,113 @@ initialize {
                           },
                           "children": Array [
                             Object {
-                              "attribs": Object {},
-                              "children": Array [],
-                              "name": "div",
+                              "attribs": Object {
+                                "label": "Need help?",
+                              },
+                              "children": Array [
+                                Object {
+                                  "attribs": Object {
+                                    "class": "logged-out-form__link-item jetpack-connect__help-button",
+                                    "href": "https://jetpack.com/contact-support",
+                                    "rel": "noopener noreferrer",
+                                    "target": "_blank",
+                                  },
+                                  "children": Array [
+                                    Object {
+                                      "attribs": Object {
+                                        "class": "gridicon gridicons-help-outline",
+                                        "height": "24",
+                                        "viewbox": "0 0 24 24",
+                                        "width": "24",
+                                        "xmlns": "http://www.w3.org/2000/svg",
+                                      },
+                                      "children": Array [
+                                        Object {
+                                          "attribs": Object {},
+                                          "children": Array [
+                                            Object {
+                                              "attribs": Object {
+                                                "d": "M12 4c4.41 0 8 3.59 8 8s-3.59 8-8 8-8-3.59-8-8 3.59-8 8-8m0-2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm4 8c0-2.21-1.79-4-4-4s-4 1.79-4 4h2c0-1.103.897-2 2-2s2 .897 2 2-.897 2-2 2c-.552 0-1 .448-1 1v2h2v-1.14c1.722-.447 3-1.998 3-3.86zm-3 6h-2v2h2v-2z",
+                                              },
+                                              "children": Array [],
+                                              "name": "path",
+                                              "next": null,
+                                              "parent": [Circular],
+                                              "prev": null,
+                                              "type": "tag",
+                                            },
+                                          ],
+                                          "name": "g",
+                                          "next": null,
+                                          "parent": [Circular],
+                                          "prev": null,
+                                          "type": "tag",
+                                        },
+                                      ],
+                                      "name": "svg",
+                                      "next": Object {
+                                        "data": " Need help?",
+                                        "next": null,
+                                        "parent": [Circular],
+                                        "prev": [Circular],
+                                        "type": "text",
+                                      },
+                                      "parent": [Circular],
+                                      "prev": null,
+                                      "type": "tag",
+                                    },
+                                    Object {
+                                      "data": " Need help?",
+                                      "next": null,
+                                      "parent": [Circular],
+                                      "prev": Object {
+                                        "attribs": Object {
+                                          "class": "gridicon gridicons-help-outline",
+                                          "height": "24",
+                                          "viewbox": "0 0 24 24",
+                                          "width": "24",
+                                          "xmlns": "http://www.w3.org/2000/svg",
+                                        },
+                                        "children": Array [
+                                          Object {
+                                            "attribs": Object {},
+                                            "children": Array [
+                                              Object {
+                                                "attribs": Object {
+                                                  "d": "M12 4c4.41 0 8 3.59 8 8s-3.59 8-8 8-8-3.59-8-8 3.59-8 8-8m0-2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm4 8c0-2.21-1.79-4-4-4s-4 1.79-4 4h2c0-1.103.897-2 2-2s2 .897 2 2-.897 2-2 2c-.552 0-1 .448-1 1v2h2v-1.14c1.722-.447 3-1.998 3-3.86zm-3 6h-2v2h2v-2z",
+                                                },
+                                                "children": Array [],
+                                                "name": "path",
+                                                "next": null,
+                                                "parent": [Circular],
+                                                "prev": null,
+                                                "type": "tag",
+                                              },
+                                            ],
+                                            "name": "g",
+                                            "next": null,
+                                            "parent": [Circular],
+                                            "prev": null,
+                                            "type": "tag",
+                                          },
+                                        ],
+                                        "name": "svg",
+                                        "next": [Circular],
+                                        "parent": [Circular],
+                                        "prev": null,
+                                        "type": "tag",
+                                      },
+                                      "type": "text",
+                                    },
+                                  ],
+                                  "name": "a",
+                                  "next": null,
+                                  "parent": [Circular],
+                                  "prev": null,
+                                  "type": "tag",
+                                },
+                              ],
+                              "name": "jetpack-connect--happychat-button",
                               "next": null,
                               "parent": [Circular],
                               "prev": null,
@@ -16140,11 +19552,13 @@ initialize {
                                   "next": Object {
                                     "attribs": Object {},
                                     "children": Array [],
-                                    "name": "div",
+                                    "name": "components--data--query-plans",
                                     "next": Object {
-                                      "attribs": Object {},
+                                      "attribs": Object {
+                                        "siteid": "1234567",
+                                      },
                                       "children": Array [],
-                                      "name": "div",
+                                      "name": "components--data--query-site-plans",
                                       "next": Object {
                                         "attribs": Object {
                                           "class": "plans-features-main__group",
@@ -16152,9 +19566,40 @@ initialize {
                                         },
                                         "children": Array [
                                           Object {
-                                            "attribs": Object {},
+                                            "attribs": Object {
+                                              "baseplanspath": "/jetpack/connect/plans",
+                                              "displayjetpackplans": "true",
+                                              "isinsignup": "true",
+                                              "islandingpage": "false",
+                                              "onupgradeclick": "function (cartItem) {
+			var checkoutPath = '/checkout/' + _this.props.selectedSite.slug;
+			// clears whatever we had stored in local cache
+			_this.props.selectPlanInAdvance(null, _this.props.selectedSiteSlug);
+
+			if (!cartItem || cartItem.product_slug === _constants.PLAN_JETPACK_FREE) {
+				return _this.selectFreeJetpackPlan();
+			}
+
+			if (cartItem.product_slug === (0, _lodash.get)(_this.props, 'selectedSite.plan.product_slug', null)) {
+				return _this.redirect(CALYPSO_PLANS_PAGE);
+			}
+
+			_this.props.recordTracksEvent('calypso_jpc_plans_submit', {
+				user: _this.props.userId,
+				product_slug: cartItem.product_slug });
+
+			_analytics.mc.bumpStat('calypso_jpc_plan_selection', cartItem.product_slug);
+
+			(0, _actions2.addItem)(cartItem);
+			_this.redirecting = true;
+			_this.props.completeFlow();
+			_page2.default.redirect(checkoutPath);
+		}",
+                                              "plans": "jetpack_personal,jetpack_premium,jetpack_business",
+                                              "site": "[object Object]",
+                                            },
                                             "children": Array [],
-                                            "name": "div",
+                                            "name": "my-sites--plan-features",
                                             "next": null,
                                             "parent": [Circular],
                                             "prev": null,
@@ -16182,11 +19627,13 @@ initialize {
                                 Object {
                                   "attribs": Object {},
                                   "children": Array [],
-                                  "name": "div",
+                                  "name": "components--data--query-plans",
                                   "next": Object {
-                                    "attribs": Object {},
+                                    "attribs": Object {
+                                      "siteid": "1234567",
+                                    },
                                     "children": Array [],
-                                    "name": "div",
+                                    "name": "components--data--query-site-plans",
                                     "next": Object {
                                       "attribs": Object {
                                         "class": "plans-features-main__group",
@@ -16194,9 +19641,40 @@ initialize {
                                       },
                                       "children": Array [
                                         Object {
-                                          "attribs": Object {},
+                                          "attribs": Object {
+                                            "baseplanspath": "/jetpack/connect/plans",
+                                            "displayjetpackplans": "true",
+                                            "isinsignup": "true",
+                                            "islandingpage": "false",
+                                            "onupgradeclick": "function (cartItem) {
+			var checkoutPath = '/checkout/' + _this.props.selectedSite.slug;
+			// clears whatever we had stored in local cache
+			_this.props.selectPlanInAdvance(null, _this.props.selectedSiteSlug);
+
+			if (!cartItem || cartItem.product_slug === _constants.PLAN_JETPACK_FREE) {
+				return _this.selectFreeJetpackPlan();
+			}
+
+			if (cartItem.product_slug === (0, _lodash.get)(_this.props, 'selectedSite.plan.product_slug', null)) {
+				return _this.redirect(CALYPSO_PLANS_PAGE);
+			}
+
+			_this.props.recordTracksEvent('calypso_jpc_plans_submit', {
+				user: _this.props.userId,
+				product_slug: cartItem.product_slug });
+
+			_analytics.mc.bumpStat('calypso_jpc_plan_selection', cartItem.product_slug);
+
+			(0, _actions2.addItem)(cartItem);
+			_this.redirecting = true;
+			_this.props.completeFlow();
+			_page2.default.redirect(checkoutPath);
+		}",
+                                            "plans": "jetpack_personal,jetpack_premium,jetpack_business",
+                                            "site": "[object Object]",
+                                          },
                                           "children": Array [],
-                                          "name": "div",
+                                          "name": "my-sites--plan-features",
                                           "next": null,
                                           "parent": [Circular],
                                           "prev": null,
@@ -16416,9 +19894,11 @@ initialize {
                                   "type": "tag",
                                 },
                                 Object {
-                                  "attribs": Object {},
+                                  "attribs": Object {
+                                    "siteid": "1234567",
+                                  },
                                   "children": Array [],
-                                  "name": "div",
+                                  "name": "components--data--query-site-plans",
                                   "next": Object {
                                     "attribs": Object {
                                       "class": "plans-features-main__group",
@@ -16426,9 +19906,40 @@ initialize {
                                     },
                                     "children": Array [
                                       Object {
-                                        "attribs": Object {},
+                                        "attribs": Object {
+                                          "baseplanspath": "/jetpack/connect/plans",
+                                          "displayjetpackplans": "true",
+                                          "isinsignup": "true",
+                                          "islandingpage": "false",
+                                          "onupgradeclick": "function (cartItem) {
+			var checkoutPath = '/checkout/' + _this.props.selectedSite.slug;
+			// clears whatever we had stored in local cache
+			_this.props.selectPlanInAdvance(null, _this.props.selectedSiteSlug);
+
+			if (!cartItem || cartItem.product_slug === _constants.PLAN_JETPACK_FREE) {
+				return _this.selectFreeJetpackPlan();
+			}
+
+			if (cartItem.product_slug === (0, _lodash.get)(_this.props, 'selectedSite.plan.product_slug', null)) {
+				return _this.redirect(CALYPSO_PLANS_PAGE);
+			}
+
+			_this.props.recordTracksEvent('calypso_jpc_plans_submit', {
+				user: _this.props.userId,
+				product_slug: cartItem.product_slug });
+
+			_analytics.mc.bumpStat('calypso_jpc_plan_selection', cartItem.product_slug);
+
+			(0, _actions2.addItem)(cartItem);
+			_this.redirecting = true;
+			_this.props.completeFlow();
+			_page2.default.redirect(checkoutPath);
+		}",
+                                          "plans": "jetpack_personal,jetpack_premium,jetpack_business",
+                                          "site": "[object Object]",
+                                        },
                                         "children": Array [],
-                                        "name": "div",
+                                        "name": "my-sites--plan-features",
                                         "next": null,
                                         "parent": [Circular],
                                         "prev": null,
@@ -16445,7 +19956,7 @@ initialize {
                                   "prev": Object {
                                     "attribs": Object {},
                                     "children": Array [],
-                                    "name": "div",
+                                    "name": "components--data--query-plans",
                                     "next": [Circular],
                                     "parent": [Circular],
                                     "prev": Object {
@@ -16658,9 +20169,40 @@ initialize {
                                   },
                                   "children": Array [
                                     Object {
-                                      "attribs": Object {},
+                                      "attribs": Object {
+                                        "baseplanspath": "/jetpack/connect/plans",
+                                        "displayjetpackplans": "true",
+                                        "isinsignup": "true",
+                                        "islandingpage": "false",
+                                        "onupgradeclick": "function (cartItem) {
+			var checkoutPath = '/checkout/' + _this.props.selectedSite.slug;
+			// clears whatever we had stored in local cache
+			_this.props.selectPlanInAdvance(null, _this.props.selectedSiteSlug);
+
+			if (!cartItem || cartItem.product_slug === _constants.PLAN_JETPACK_FREE) {
+				return _this.selectFreeJetpackPlan();
+			}
+
+			if (cartItem.product_slug === (0, _lodash.get)(_this.props, 'selectedSite.plan.product_slug', null)) {
+				return _this.redirect(CALYPSO_PLANS_PAGE);
+			}
+
+			_this.props.recordTracksEvent('calypso_jpc_plans_submit', {
+				user: _this.props.userId,
+				product_slug: cartItem.product_slug });
+
+			_analytics.mc.bumpStat('calypso_jpc_plan_selection', cartItem.product_slug);
+
+			(0, _actions2.addItem)(cartItem);
+			_this.redirecting = true;
+			_this.props.completeFlow();
+			_page2.default.redirect(checkoutPath);
+		}",
+                                        "plans": "jetpack_personal,jetpack_premium,jetpack_business",
+                                        "site": "[object Object]",
+                                      },
                                       "children": Array [],
-                                      "name": "div",
+                                      "name": "my-sites--plan-features",
                                       "next": null,
                                       "parent": [Circular],
                                       "prev": null,
@@ -16671,15 +20213,17 @@ initialize {
                                   "next": null,
                                   "parent": [Circular],
                                   "prev": Object {
-                                    "attribs": Object {},
+                                    "attribs": Object {
+                                      "siteid": "1234567",
+                                    },
                                     "children": Array [],
-                                    "name": "div",
+                                    "name": "components--data--query-site-plans",
                                     "next": [Circular],
                                     "parent": [Circular],
                                     "prev": Object {
                                       "attribs": Object {},
                                       "children": Array [],
-                                      "name": "div",
+                                      "name": "components--data--query-plans",
                                       "next": [Circular],
                                       "parent": [Circular],
                                       "prev": Object {
@@ -17116,11 +20660,13 @@ initialize {
                             "next": Object {
                               "attribs": Object {},
                               "children": Array [],
-                              "name": "div",
+                              "name": "components--data--query-plans",
                               "next": Object {
-                                "attribs": Object {},
+                                "attribs": Object {
+                                  "siteid": "1234567",
+                                },
                                 "children": Array [],
-                                "name": "div",
+                                "name": "components--data--query-site-plans",
                                 "next": Object {
                                   "attribs": Object {
                                     "class": "plans-features-main__group",
@@ -17128,9 +20674,40 @@ initialize {
                                   },
                                   "children": Array [
                                     Object {
-                                      "attribs": Object {},
+                                      "attribs": Object {
+                                        "baseplanspath": "/jetpack/connect/plans",
+                                        "displayjetpackplans": "true",
+                                        "isinsignup": "true",
+                                        "islandingpage": "false",
+                                        "onupgradeclick": "function (cartItem) {
+			var checkoutPath = '/checkout/' + _this.props.selectedSite.slug;
+			// clears whatever we had stored in local cache
+			_this.props.selectPlanInAdvance(null, _this.props.selectedSiteSlug);
+
+			if (!cartItem || cartItem.product_slug === _constants.PLAN_JETPACK_FREE) {
+				return _this.selectFreeJetpackPlan();
+			}
+
+			if (cartItem.product_slug === (0, _lodash.get)(_this.props, 'selectedSite.plan.product_slug', null)) {
+				return _this.redirect(CALYPSO_PLANS_PAGE);
+			}
+
+			_this.props.recordTracksEvent('calypso_jpc_plans_submit', {
+				user: _this.props.userId,
+				product_slug: cartItem.product_slug });
+
+			_analytics.mc.bumpStat('calypso_jpc_plan_selection', cartItem.product_slug);
+
+			(0, _actions2.addItem)(cartItem);
+			_this.redirecting = true;
+			_this.props.completeFlow();
+			_page2.default.redirect(checkoutPath);
+		}",
+                                        "plans": "jetpack_personal,jetpack_premium,jetpack_business",
+                                        "site": "[object Object]",
+                                      },
                                       "children": Array [],
-                                      "name": "div",
+                                      "name": "my-sites--plan-features",
                                       "next": null,
                                       "parent": [Circular],
                                       "prev": null,
@@ -17158,11 +20735,13 @@ initialize {
                           Object {
                             "attribs": Object {},
                             "children": Array [],
-                            "name": "div",
+                            "name": "components--data--query-plans",
                             "next": Object {
-                              "attribs": Object {},
+                              "attribs": Object {
+                                "siteid": "1234567",
+                              },
                               "children": Array [],
-                              "name": "div",
+                              "name": "components--data--query-site-plans",
                               "next": Object {
                                 "attribs": Object {
                                   "class": "plans-features-main__group",
@@ -17170,9 +20749,40 @@ initialize {
                                 },
                                 "children": Array [
                                   Object {
-                                    "attribs": Object {},
+                                    "attribs": Object {
+                                      "baseplanspath": "/jetpack/connect/plans",
+                                      "displayjetpackplans": "true",
+                                      "isinsignup": "true",
+                                      "islandingpage": "false",
+                                      "onupgradeclick": "function (cartItem) {
+			var checkoutPath = '/checkout/' + _this.props.selectedSite.slug;
+			// clears whatever we had stored in local cache
+			_this.props.selectPlanInAdvance(null, _this.props.selectedSiteSlug);
+
+			if (!cartItem || cartItem.product_slug === _constants.PLAN_JETPACK_FREE) {
+				return _this.selectFreeJetpackPlan();
+			}
+
+			if (cartItem.product_slug === (0, _lodash.get)(_this.props, 'selectedSite.plan.product_slug', null)) {
+				return _this.redirect(CALYPSO_PLANS_PAGE);
+			}
+
+			_this.props.recordTracksEvent('calypso_jpc_plans_submit', {
+				user: _this.props.userId,
+				product_slug: cartItem.product_slug });
+
+			_analytics.mc.bumpStat('calypso_jpc_plan_selection', cartItem.product_slug);
+
+			(0, _actions2.addItem)(cartItem);
+			_this.redirecting = true;
+			_this.props.completeFlow();
+			_page2.default.redirect(checkoutPath);
+		}",
+                                      "plans": "jetpack_personal,jetpack_premium,jetpack_business",
+                                      "site": "[object Object]",
+                                    },
                                     "children": Array [],
-                                    "name": "div",
+                                    "name": "my-sites--plan-features",
                                     "next": null,
                                     "parent": [Circular],
                                     "prev": null,
@@ -17392,9 +21002,11 @@ initialize {
                             "type": "tag",
                           },
                           Object {
-                            "attribs": Object {},
+                            "attribs": Object {
+                              "siteid": "1234567",
+                            },
                             "children": Array [],
-                            "name": "div",
+                            "name": "components--data--query-site-plans",
                             "next": Object {
                               "attribs": Object {
                                 "class": "plans-features-main__group",
@@ -17402,9 +21014,40 @@ initialize {
                               },
                               "children": Array [
                                 Object {
-                                  "attribs": Object {},
+                                  "attribs": Object {
+                                    "baseplanspath": "/jetpack/connect/plans",
+                                    "displayjetpackplans": "true",
+                                    "isinsignup": "true",
+                                    "islandingpage": "false",
+                                    "onupgradeclick": "function (cartItem) {
+			var checkoutPath = '/checkout/' + _this.props.selectedSite.slug;
+			// clears whatever we had stored in local cache
+			_this.props.selectPlanInAdvance(null, _this.props.selectedSiteSlug);
+
+			if (!cartItem || cartItem.product_slug === _constants.PLAN_JETPACK_FREE) {
+				return _this.selectFreeJetpackPlan();
+			}
+
+			if (cartItem.product_slug === (0, _lodash.get)(_this.props, 'selectedSite.plan.product_slug', null)) {
+				return _this.redirect(CALYPSO_PLANS_PAGE);
+			}
+
+			_this.props.recordTracksEvent('calypso_jpc_plans_submit', {
+				user: _this.props.userId,
+				product_slug: cartItem.product_slug });
+
+			_analytics.mc.bumpStat('calypso_jpc_plan_selection', cartItem.product_slug);
+
+			(0, _actions2.addItem)(cartItem);
+			_this.redirecting = true;
+			_this.props.completeFlow();
+			_page2.default.redirect(checkoutPath);
+		}",
+                                    "plans": "jetpack_personal,jetpack_premium,jetpack_business",
+                                    "site": "[object Object]",
+                                  },
                                   "children": Array [],
-                                  "name": "div",
+                                  "name": "my-sites--plan-features",
                                   "next": null,
                                   "parent": [Circular],
                                   "prev": null,
@@ -17421,7 +21064,7 @@ initialize {
                             "prev": Object {
                               "attribs": Object {},
                               "children": Array [],
-                              "name": "div",
+                              "name": "components--data--query-plans",
                               "next": [Circular],
                               "parent": [Circular],
                               "prev": Object {
@@ -17634,9 +21277,40 @@ initialize {
                             },
                             "children": Array [
                               Object {
-                                "attribs": Object {},
+                                "attribs": Object {
+                                  "baseplanspath": "/jetpack/connect/plans",
+                                  "displayjetpackplans": "true",
+                                  "isinsignup": "true",
+                                  "islandingpage": "false",
+                                  "onupgradeclick": "function (cartItem) {
+			var checkoutPath = '/checkout/' + _this.props.selectedSite.slug;
+			// clears whatever we had stored in local cache
+			_this.props.selectPlanInAdvance(null, _this.props.selectedSiteSlug);
+
+			if (!cartItem || cartItem.product_slug === _constants.PLAN_JETPACK_FREE) {
+				return _this.selectFreeJetpackPlan();
+			}
+
+			if (cartItem.product_slug === (0, _lodash.get)(_this.props, 'selectedSite.plan.product_slug', null)) {
+				return _this.redirect(CALYPSO_PLANS_PAGE);
+			}
+
+			_this.props.recordTracksEvent('calypso_jpc_plans_submit', {
+				user: _this.props.userId,
+				product_slug: cartItem.product_slug });
+
+			_analytics.mc.bumpStat('calypso_jpc_plan_selection', cartItem.product_slug);
+
+			(0, _actions2.addItem)(cartItem);
+			_this.redirecting = true;
+			_this.props.completeFlow();
+			_page2.default.redirect(checkoutPath);
+		}",
+                                  "plans": "jetpack_personal,jetpack_premium,jetpack_business",
+                                  "site": "[object Object]",
+                                },
                                 "children": Array [],
-                                "name": "div",
+                                "name": "my-sites--plan-features",
                                 "next": null,
                                 "parent": [Circular],
                                 "prev": null,
@@ -17647,15 +21321,17 @@ initialize {
                             "next": null,
                             "parent": [Circular],
                             "prev": Object {
-                              "attribs": Object {},
+                              "attribs": Object {
+                                "siteid": "1234567",
+                              },
                               "children": Array [],
-                              "name": "div",
+                              "name": "components--data--query-site-plans",
                               "next": [Circular],
                               "parent": [Circular],
                               "prev": Object {
                                 "attribs": Object {},
                                 "children": Array [],
-                                "name": "div",
+                                "name": "components--data--query-plans",
                                 "next": [Circular],
                                 "parent": [Circular],
                                 "prev": Object {
@@ -17977,9 +21653,113 @@ initialize {
                             },
                             "children": Array [
                               Object {
-                                "attribs": Object {},
-                                "children": Array [],
-                                "name": "div",
+                                "attribs": Object {
+                                  "label": "Need help?",
+                                },
+                                "children": Array [
+                                  Object {
+                                    "attribs": Object {
+                                      "class": "logged-out-form__link-item jetpack-connect__help-button",
+                                      "href": "https://jetpack.com/contact-support",
+                                      "rel": "noopener noreferrer",
+                                      "target": "_blank",
+                                    },
+                                    "children": Array [
+                                      Object {
+                                        "attribs": Object {
+                                          "class": "gridicon gridicons-help-outline",
+                                          "height": "24",
+                                          "viewbox": "0 0 24 24",
+                                          "width": "24",
+                                          "xmlns": "http://www.w3.org/2000/svg",
+                                        },
+                                        "children": Array [
+                                          Object {
+                                            "attribs": Object {},
+                                            "children": Array [
+                                              Object {
+                                                "attribs": Object {
+                                                  "d": "M12 4c4.41 0 8 3.59 8 8s-3.59 8-8 8-8-3.59-8-8 3.59-8 8-8m0-2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm4 8c0-2.21-1.79-4-4-4s-4 1.79-4 4h2c0-1.103.897-2 2-2s2 .897 2 2-.897 2-2 2c-.552 0-1 .448-1 1v2h2v-1.14c1.722-.447 3-1.998 3-3.86zm-3 6h-2v2h2v-2z",
+                                                },
+                                                "children": Array [],
+                                                "name": "path",
+                                                "next": null,
+                                                "parent": [Circular],
+                                                "prev": null,
+                                                "type": "tag",
+                                              },
+                                            ],
+                                            "name": "g",
+                                            "next": null,
+                                            "parent": [Circular],
+                                            "prev": null,
+                                            "type": "tag",
+                                          },
+                                        ],
+                                        "name": "svg",
+                                        "next": Object {
+                                          "data": " Need help?",
+                                          "next": null,
+                                          "parent": [Circular],
+                                          "prev": [Circular],
+                                          "type": "text",
+                                        },
+                                        "parent": [Circular],
+                                        "prev": null,
+                                        "type": "tag",
+                                      },
+                                      Object {
+                                        "data": " Need help?",
+                                        "next": null,
+                                        "parent": [Circular],
+                                        "prev": Object {
+                                          "attribs": Object {
+                                            "class": "gridicon gridicons-help-outline",
+                                            "height": "24",
+                                            "viewbox": "0 0 24 24",
+                                            "width": "24",
+                                            "xmlns": "http://www.w3.org/2000/svg",
+                                          },
+                                          "children": Array [
+                                            Object {
+                                              "attribs": Object {},
+                                              "children": Array [
+                                                Object {
+                                                  "attribs": Object {
+                                                    "d": "M12 4c4.41 0 8 3.59 8 8s-3.59 8-8 8-8-3.59-8-8 3.59-8 8-8m0-2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm4 8c0-2.21-1.79-4-4-4s-4 1.79-4 4h2c0-1.103.897-2 2-2s2 .897 2 2-.897 2-2 2c-.552 0-1 .448-1 1v2h2v-1.14c1.722-.447 3-1.998 3-3.86zm-3 6h-2v2h2v-2z",
+                                                  },
+                                                  "children": Array [],
+                                                  "name": "path",
+                                                  "next": null,
+                                                  "parent": [Circular],
+                                                  "prev": null,
+                                                  "type": "tag",
+                                                },
+                                              ],
+                                              "name": "g",
+                                              "next": null,
+                                              "parent": [Circular],
+                                              "prev": null,
+                                              "type": "tag",
+                                            },
+                                          ],
+                                          "name": "svg",
+                                          "next": [Circular],
+                                          "parent": [Circular],
+                                          "prev": null,
+                                          "type": "tag",
+                                        },
+                                        "type": "text",
+                                      },
+                                    ],
+                                    "name": "a",
+                                    "next": null,
+                                    "parent": [Circular],
+                                    "prev": null,
+                                    "type": "tag",
+                                  },
+                                ],
+                                "name": "jetpack-connect--happychat-button",
                                 "next": null,
                                 "parent": [Circular],
                                 "prev": null,
@@ -18112,9 +21892,113 @@ initialize {
                           },
                           "children": Array [
                             Object {
-                              "attribs": Object {},
-                              "children": Array [],
-                              "name": "div",
+                              "attribs": Object {
+                                "label": "Need help?",
+                              },
+                              "children": Array [
+                                Object {
+                                  "attribs": Object {
+                                    "class": "logged-out-form__link-item jetpack-connect__help-button",
+                                    "href": "https://jetpack.com/contact-support",
+                                    "rel": "noopener noreferrer",
+                                    "target": "_blank",
+                                  },
+                                  "children": Array [
+                                    Object {
+                                      "attribs": Object {
+                                        "class": "gridicon gridicons-help-outline",
+                                        "height": "24",
+                                        "viewbox": "0 0 24 24",
+                                        "width": "24",
+                                        "xmlns": "http://www.w3.org/2000/svg",
+                                      },
+                                      "children": Array [
+                                        Object {
+                                          "attribs": Object {},
+                                          "children": Array [
+                                            Object {
+                                              "attribs": Object {
+                                                "d": "M12 4c4.41 0 8 3.59 8 8s-3.59 8-8 8-8-3.59-8-8 3.59-8 8-8m0-2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm4 8c0-2.21-1.79-4-4-4s-4 1.79-4 4h2c0-1.103.897-2 2-2s2 .897 2 2-.897 2-2 2c-.552 0-1 .448-1 1v2h2v-1.14c1.722-.447 3-1.998 3-3.86zm-3 6h-2v2h2v-2z",
+                                              },
+                                              "children": Array [],
+                                              "name": "path",
+                                              "next": null,
+                                              "parent": [Circular],
+                                              "prev": null,
+                                              "type": "tag",
+                                            },
+                                          ],
+                                          "name": "g",
+                                          "next": null,
+                                          "parent": [Circular],
+                                          "prev": null,
+                                          "type": "tag",
+                                        },
+                                      ],
+                                      "name": "svg",
+                                      "next": Object {
+                                        "data": " Need help?",
+                                        "next": null,
+                                        "parent": [Circular],
+                                        "prev": [Circular],
+                                        "type": "text",
+                                      },
+                                      "parent": [Circular],
+                                      "prev": null,
+                                      "type": "tag",
+                                    },
+                                    Object {
+                                      "data": " Need help?",
+                                      "next": null,
+                                      "parent": [Circular],
+                                      "prev": Object {
+                                        "attribs": Object {
+                                          "class": "gridicon gridicons-help-outline",
+                                          "height": "24",
+                                          "viewbox": "0 0 24 24",
+                                          "width": "24",
+                                          "xmlns": "http://www.w3.org/2000/svg",
+                                        },
+                                        "children": Array [
+                                          Object {
+                                            "attribs": Object {},
+                                            "children": Array [
+                                              Object {
+                                                "attribs": Object {
+                                                  "d": "M12 4c4.41 0 8 3.59 8 8s-3.59 8-8 8-8-3.59-8-8 3.59-8 8-8m0-2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm4 8c0-2.21-1.79-4-4-4s-4 1.79-4 4h2c0-1.103.897-2 2-2s2 .897 2 2-.897 2-2 2c-.552 0-1 .448-1 1v2h2v-1.14c1.722-.447 3-1.998 3-3.86zm-3 6h-2v2h2v-2z",
+                                                },
+                                                "children": Array [],
+                                                "name": "path",
+                                                "next": null,
+                                                "parent": [Circular],
+                                                "prev": null,
+                                                "type": "tag",
+                                              },
+                                            ],
+                                            "name": "g",
+                                            "next": null,
+                                            "parent": [Circular],
+                                            "prev": null,
+                                            "type": "tag",
+                                          },
+                                        ],
+                                        "name": "svg",
+                                        "next": [Circular],
+                                        "parent": [Circular],
+                                        "prev": null,
+                                        "type": "tag",
+                                      },
+                                      "type": "text",
+                                    },
+                                  ],
+                                  "name": "a",
+                                  "next": null,
+                                  "parent": [Circular],
+                                  "prev": null,
+                                  "type": "tag",
+                                },
+                              ],
+                              "name": "jetpack-connect--happychat-button",
                               "next": null,
                               "parent": [Circular],
                               "prev": null,
@@ -18330,11 +22214,13 @@ initialize {
                               "next": Object {
                                 "attribs": Object {},
                                 "children": Array [],
-                                "name": "div",
+                                "name": "components--data--query-plans",
                                 "next": Object {
-                                  "attribs": Object {},
+                                  "attribs": Object {
+                                    "siteid": "1234567",
+                                  },
                                   "children": Array [],
-                                  "name": "div",
+                                  "name": "components--data--query-site-plans",
                                   "next": Object {
                                     "attribs": Object {
                                       "class": "plans-features-main__group",
@@ -18342,9 +22228,40 @@ initialize {
                                     },
                                     "children": Array [
                                       Object {
-                                        "attribs": Object {},
+                                        "attribs": Object {
+                                          "baseplanspath": "/jetpack/connect/plans",
+                                          "displayjetpackplans": "true",
+                                          "isinsignup": "true",
+                                          "islandingpage": "false",
+                                          "onupgradeclick": "function (cartItem) {
+			var checkoutPath = '/checkout/' + _this.props.selectedSite.slug;
+			// clears whatever we had stored in local cache
+			_this.props.selectPlanInAdvance(null, _this.props.selectedSiteSlug);
+
+			if (!cartItem || cartItem.product_slug === _constants.PLAN_JETPACK_FREE) {
+				return _this.selectFreeJetpackPlan();
+			}
+
+			if (cartItem.product_slug === (0, _lodash.get)(_this.props, 'selectedSite.plan.product_slug', null)) {
+				return _this.redirect(CALYPSO_PLANS_PAGE);
+			}
+
+			_this.props.recordTracksEvent('calypso_jpc_plans_submit', {
+				user: _this.props.userId,
+				product_slug: cartItem.product_slug });
+
+			_analytics.mc.bumpStat('calypso_jpc_plan_selection', cartItem.product_slug);
+
+			(0, _actions2.addItem)(cartItem);
+			_this.redirecting = true;
+			_this.props.completeFlow();
+			_page2.default.redirect(checkoutPath);
+		}",
+                                          "plans": "jetpack_personal,jetpack_premium,jetpack_business",
+                                          "site": "[object Object]",
+                                        },
                                         "children": Array [],
-                                        "name": "div",
+                                        "name": "my-sites--plan-features",
                                         "next": null,
                                         "parent": [Circular],
                                         "prev": null,
@@ -18372,11 +22289,13 @@ initialize {
                             Object {
                               "attribs": Object {},
                               "children": Array [],
-                              "name": "div",
+                              "name": "components--data--query-plans",
                               "next": Object {
-                                "attribs": Object {},
+                                "attribs": Object {
+                                  "siteid": "1234567",
+                                },
                                 "children": Array [],
-                                "name": "div",
+                                "name": "components--data--query-site-plans",
                                 "next": Object {
                                   "attribs": Object {
                                     "class": "plans-features-main__group",
@@ -18384,9 +22303,40 @@ initialize {
                                   },
                                   "children": Array [
                                     Object {
-                                      "attribs": Object {},
+                                      "attribs": Object {
+                                        "baseplanspath": "/jetpack/connect/plans",
+                                        "displayjetpackplans": "true",
+                                        "isinsignup": "true",
+                                        "islandingpage": "false",
+                                        "onupgradeclick": "function (cartItem) {
+			var checkoutPath = '/checkout/' + _this.props.selectedSite.slug;
+			// clears whatever we had stored in local cache
+			_this.props.selectPlanInAdvance(null, _this.props.selectedSiteSlug);
+
+			if (!cartItem || cartItem.product_slug === _constants.PLAN_JETPACK_FREE) {
+				return _this.selectFreeJetpackPlan();
+			}
+
+			if (cartItem.product_slug === (0, _lodash.get)(_this.props, 'selectedSite.plan.product_slug', null)) {
+				return _this.redirect(CALYPSO_PLANS_PAGE);
+			}
+
+			_this.props.recordTracksEvent('calypso_jpc_plans_submit', {
+				user: _this.props.userId,
+				product_slug: cartItem.product_slug });
+
+			_analytics.mc.bumpStat('calypso_jpc_plan_selection', cartItem.product_slug);
+
+			(0, _actions2.addItem)(cartItem);
+			_this.redirecting = true;
+			_this.props.completeFlow();
+			_page2.default.redirect(checkoutPath);
+		}",
+                                        "plans": "jetpack_personal,jetpack_premium,jetpack_business",
+                                        "site": "[object Object]",
+                                      },
                                       "children": Array [],
-                                      "name": "div",
+                                      "name": "my-sites--plan-features",
                                       "next": null,
                                       "parent": [Circular],
                                       "prev": null,
@@ -18606,9 +22556,11 @@ initialize {
                               "type": "tag",
                             },
                             Object {
-                              "attribs": Object {},
+                              "attribs": Object {
+                                "siteid": "1234567",
+                              },
                               "children": Array [],
-                              "name": "div",
+                              "name": "components--data--query-site-plans",
                               "next": Object {
                                 "attribs": Object {
                                   "class": "plans-features-main__group",
@@ -18616,9 +22568,40 @@ initialize {
                                 },
                                 "children": Array [
                                   Object {
-                                    "attribs": Object {},
+                                    "attribs": Object {
+                                      "baseplanspath": "/jetpack/connect/plans",
+                                      "displayjetpackplans": "true",
+                                      "isinsignup": "true",
+                                      "islandingpage": "false",
+                                      "onupgradeclick": "function (cartItem) {
+			var checkoutPath = '/checkout/' + _this.props.selectedSite.slug;
+			// clears whatever we had stored in local cache
+			_this.props.selectPlanInAdvance(null, _this.props.selectedSiteSlug);
+
+			if (!cartItem || cartItem.product_slug === _constants.PLAN_JETPACK_FREE) {
+				return _this.selectFreeJetpackPlan();
+			}
+
+			if (cartItem.product_slug === (0, _lodash.get)(_this.props, 'selectedSite.plan.product_slug', null)) {
+				return _this.redirect(CALYPSO_PLANS_PAGE);
+			}
+
+			_this.props.recordTracksEvent('calypso_jpc_plans_submit', {
+				user: _this.props.userId,
+				product_slug: cartItem.product_slug });
+
+			_analytics.mc.bumpStat('calypso_jpc_plan_selection', cartItem.product_slug);
+
+			(0, _actions2.addItem)(cartItem);
+			_this.redirecting = true;
+			_this.props.completeFlow();
+			_page2.default.redirect(checkoutPath);
+		}",
+                                      "plans": "jetpack_personal,jetpack_premium,jetpack_business",
+                                      "site": "[object Object]",
+                                    },
                                     "children": Array [],
-                                    "name": "div",
+                                    "name": "my-sites--plan-features",
                                     "next": null,
                                     "parent": [Circular],
                                     "prev": null,
@@ -18635,7 +22618,7 @@ initialize {
                               "prev": Object {
                                 "attribs": Object {},
                                 "children": Array [],
-                                "name": "div",
+                                "name": "components--data--query-plans",
                                 "next": [Circular],
                                 "parent": [Circular],
                                 "prev": Object {
@@ -18848,9 +22831,40 @@ initialize {
                               },
                               "children": Array [
                                 Object {
-                                  "attribs": Object {},
+                                  "attribs": Object {
+                                    "baseplanspath": "/jetpack/connect/plans",
+                                    "displayjetpackplans": "true",
+                                    "isinsignup": "true",
+                                    "islandingpage": "false",
+                                    "onupgradeclick": "function (cartItem) {
+			var checkoutPath = '/checkout/' + _this.props.selectedSite.slug;
+			// clears whatever we had stored in local cache
+			_this.props.selectPlanInAdvance(null, _this.props.selectedSiteSlug);
+
+			if (!cartItem || cartItem.product_slug === _constants.PLAN_JETPACK_FREE) {
+				return _this.selectFreeJetpackPlan();
+			}
+
+			if (cartItem.product_slug === (0, _lodash.get)(_this.props, 'selectedSite.plan.product_slug', null)) {
+				return _this.redirect(CALYPSO_PLANS_PAGE);
+			}
+
+			_this.props.recordTracksEvent('calypso_jpc_plans_submit', {
+				user: _this.props.userId,
+				product_slug: cartItem.product_slug });
+
+			_analytics.mc.bumpStat('calypso_jpc_plan_selection', cartItem.product_slug);
+
+			(0, _actions2.addItem)(cartItem);
+			_this.redirecting = true;
+			_this.props.completeFlow();
+			_page2.default.redirect(checkoutPath);
+		}",
+                                    "plans": "jetpack_personal,jetpack_premium,jetpack_business",
+                                    "site": "[object Object]",
+                                  },
                                   "children": Array [],
-                                  "name": "div",
+                                  "name": "my-sites--plan-features",
                                   "next": null,
                                   "parent": [Circular],
                                   "prev": null,
@@ -18861,15 +22875,17 @@ initialize {
                               "next": null,
                               "parent": [Circular],
                               "prev": Object {
-                                "attribs": Object {},
+                                "attribs": Object {
+                                  "siteid": "1234567",
+                                },
                                 "children": Array [],
-                                "name": "div",
+                                "name": "components--data--query-site-plans",
                                 "next": [Circular],
                                 "parent": [Circular],
                                 "prev": Object {
                                   "attribs": Object {},
                                   "children": Array [],
-                                  "name": "div",
+                                  "name": "components--data--query-plans",
                                   "next": [Circular],
                                   "parent": [Circular],
                                   "prev": Object {
@@ -19092,9 +23108,113 @@ initialize {
                         },
                         "children": Array [
                           Object {
-                            "attribs": Object {},
-                            "children": Array [],
-                            "name": "div",
+                            "attribs": Object {
+                              "label": "Need help?",
+                            },
+                            "children": Array [
+                              Object {
+                                "attribs": Object {
+                                  "class": "logged-out-form__link-item jetpack-connect__help-button",
+                                  "href": "https://jetpack.com/contact-support",
+                                  "rel": "noopener noreferrer",
+                                  "target": "_blank",
+                                },
+                                "children": Array [
+                                  Object {
+                                    "attribs": Object {
+                                      "class": "gridicon gridicons-help-outline",
+                                      "height": "24",
+                                      "viewbox": "0 0 24 24",
+                                      "width": "24",
+                                      "xmlns": "http://www.w3.org/2000/svg",
+                                    },
+                                    "children": Array [
+                                      Object {
+                                        "attribs": Object {},
+                                        "children": Array [
+                                          Object {
+                                            "attribs": Object {
+                                              "d": "M12 4c4.41 0 8 3.59 8 8s-3.59 8-8 8-8-3.59-8-8 3.59-8 8-8m0-2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm4 8c0-2.21-1.79-4-4-4s-4 1.79-4 4h2c0-1.103.897-2 2-2s2 .897 2 2-.897 2-2 2c-.552 0-1 .448-1 1v2h2v-1.14c1.722-.447 3-1.998 3-3.86zm-3 6h-2v2h2v-2z",
+                                            },
+                                            "children": Array [],
+                                            "name": "path",
+                                            "next": null,
+                                            "parent": [Circular],
+                                            "prev": null,
+                                            "type": "tag",
+                                          },
+                                        ],
+                                        "name": "g",
+                                        "next": null,
+                                        "parent": [Circular],
+                                        "prev": null,
+                                        "type": "tag",
+                                      },
+                                    ],
+                                    "name": "svg",
+                                    "next": Object {
+                                      "data": " Need help?",
+                                      "next": null,
+                                      "parent": [Circular],
+                                      "prev": [Circular],
+                                      "type": "text",
+                                    },
+                                    "parent": [Circular],
+                                    "prev": null,
+                                    "type": "tag",
+                                  },
+                                  Object {
+                                    "data": " Need help?",
+                                    "next": null,
+                                    "parent": [Circular],
+                                    "prev": Object {
+                                      "attribs": Object {
+                                        "class": "gridicon gridicons-help-outline",
+                                        "height": "24",
+                                        "viewbox": "0 0 24 24",
+                                        "width": "24",
+                                        "xmlns": "http://www.w3.org/2000/svg",
+                                      },
+                                      "children": Array [
+                                        Object {
+                                          "attribs": Object {},
+                                          "children": Array [
+                                            Object {
+                                              "attribs": Object {
+                                                "d": "M12 4c4.41 0 8 3.59 8 8s-3.59 8-8 8-8-3.59-8-8 3.59-8 8-8m0-2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm4 8c0-2.21-1.79-4-4-4s-4 1.79-4 4h2c0-1.103.897-2 2-2s2 .897 2 2-.897 2-2 2c-.552 0-1 .448-1 1v2h2v-1.14c1.722-.447 3-1.998 3-3.86zm-3 6h-2v2h2v-2z",
+                                              },
+                                              "children": Array [],
+                                              "name": "path",
+                                              "next": null,
+                                              "parent": [Circular],
+                                              "prev": null,
+                                              "type": "tag",
+                                            },
+                                          ],
+                                          "name": "g",
+                                          "next": null,
+                                          "parent": [Circular],
+                                          "prev": null,
+                                          "type": "tag",
+                                        },
+                                      ],
+                                      "name": "svg",
+                                      "next": [Circular],
+                                      "parent": [Circular],
+                                      "prev": null,
+                                      "type": "tag",
+                                    },
+                                    "type": "text",
+                                  },
+                                ],
+                                "name": "a",
+                                "next": null,
+                                "parent": [Circular],
+                                "prev": null,
+                                "type": "tag",
+                              },
+                            ],
+                            "name": "jetpack-connect--happychat-button",
                             "next": null,
                             "parent": [Circular],
                             "prev": null,
@@ -19414,11 +23534,13 @@ initialize {
                                 "next": Object {
                                   "attribs": Object {},
                                   "children": Array [],
-                                  "name": "div",
+                                  "name": "components--data--query-plans",
                                   "next": Object {
-                                    "attribs": Object {},
+                                    "attribs": Object {
+                                      "siteid": "1234567",
+                                    },
                                     "children": Array [],
-                                    "name": "div",
+                                    "name": "components--data--query-site-plans",
                                     "next": Object {
                                       "attribs": Object {
                                         "class": "plans-features-main__group",
@@ -19426,9 +23548,40 @@ initialize {
                                       },
                                       "children": Array [
                                         Object {
-                                          "attribs": Object {},
+                                          "attribs": Object {
+                                            "baseplanspath": "/jetpack/connect/plans",
+                                            "displayjetpackplans": "true",
+                                            "isinsignup": "true",
+                                            "islandingpage": "false",
+                                            "onupgradeclick": "function (cartItem) {
+			var checkoutPath = '/checkout/' + _this.props.selectedSite.slug;
+			// clears whatever we had stored in local cache
+			_this.props.selectPlanInAdvance(null, _this.props.selectedSiteSlug);
+
+			if (!cartItem || cartItem.product_slug === _constants.PLAN_JETPACK_FREE) {
+				return _this.selectFreeJetpackPlan();
+			}
+
+			if (cartItem.product_slug === (0, _lodash.get)(_this.props, 'selectedSite.plan.product_slug', null)) {
+				return _this.redirect(CALYPSO_PLANS_PAGE);
+			}
+
+			_this.props.recordTracksEvent('calypso_jpc_plans_submit', {
+				user: _this.props.userId,
+				product_slug: cartItem.product_slug });
+
+			_analytics.mc.bumpStat('calypso_jpc_plan_selection', cartItem.product_slug);
+
+			(0, _actions2.addItem)(cartItem);
+			_this.redirecting = true;
+			_this.props.completeFlow();
+			_page2.default.redirect(checkoutPath);
+		}",
+                                            "plans": "jetpack_personal,jetpack_premium,jetpack_business",
+                                            "site": "[object Object]",
+                                          },
                                           "children": Array [],
-                                          "name": "div",
+                                          "name": "my-sites--plan-features",
                                           "next": null,
                                           "parent": [Circular],
                                           "prev": null,
@@ -19456,11 +23609,13 @@ initialize {
                               Object {
                                 "attribs": Object {},
                                 "children": Array [],
-                                "name": "div",
+                                "name": "components--data--query-plans",
                                 "next": Object {
-                                  "attribs": Object {},
+                                  "attribs": Object {
+                                    "siteid": "1234567",
+                                  },
                                   "children": Array [],
-                                  "name": "div",
+                                  "name": "components--data--query-site-plans",
                                   "next": Object {
                                     "attribs": Object {
                                       "class": "plans-features-main__group",
@@ -19468,9 +23623,40 @@ initialize {
                                     },
                                     "children": Array [
                                       Object {
-                                        "attribs": Object {},
+                                        "attribs": Object {
+                                          "baseplanspath": "/jetpack/connect/plans",
+                                          "displayjetpackplans": "true",
+                                          "isinsignup": "true",
+                                          "islandingpage": "false",
+                                          "onupgradeclick": "function (cartItem) {
+			var checkoutPath = '/checkout/' + _this.props.selectedSite.slug;
+			// clears whatever we had stored in local cache
+			_this.props.selectPlanInAdvance(null, _this.props.selectedSiteSlug);
+
+			if (!cartItem || cartItem.product_slug === _constants.PLAN_JETPACK_FREE) {
+				return _this.selectFreeJetpackPlan();
+			}
+
+			if (cartItem.product_slug === (0, _lodash.get)(_this.props, 'selectedSite.plan.product_slug', null)) {
+				return _this.redirect(CALYPSO_PLANS_PAGE);
+			}
+
+			_this.props.recordTracksEvent('calypso_jpc_plans_submit', {
+				user: _this.props.userId,
+				product_slug: cartItem.product_slug });
+
+			_analytics.mc.bumpStat('calypso_jpc_plan_selection', cartItem.product_slug);
+
+			(0, _actions2.addItem)(cartItem);
+			_this.redirecting = true;
+			_this.props.completeFlow();
+			_page2.default.redirect(checkoutPath);
+		}",
+                                          "plans": "jetpack_personal,jetpack_premium,jetpack_business",
+                                          "site": "[object Object]",
+                                        },
                                         "children": Array [],
-                                        "name": "div",
+                                        "name": "my-sites--plan-features",
                                         "next": null,
                                         "parent": [Circular],
                                         "prev": null,
@@ -19690,9 +23876,11 @@ initialize {
                                 "type": "tag",
                               },
                               Object {
-                                "attribs": Object {},
+                                "attribs": Object {
+                                  "siteid": "1234567",
+                                },
                                 "children": Array [],
-                                "name": "div",
+                                "name": "components--data--query-site-plans",
                                 "next": Object {
                                   "attribs": Object {
                                     "class": "plans-features-main__group",
@@ -19700,9 +23888,40 @@ initialize {
                                   },
                                   "children": Array [
                                     Object {
-                                      "attribs": Object {},
+                                      "attribs": Object {
+                                        "baseplanspath": "/jetpack/connect/plans",
+                                        "displayjetpackplans": "true",
+                                        "isinsignup": "true",
+                                        "islandingpage": "false",
+                                        "onupgradeclick": "function (cartItem) {
+			var checkoutPath = '/checkout/' + _this.props.selectedSite.slug;
+			// clears whatever we had stored in local cache
+			_this.props.selectPlanInAdvance(null, _this.props.selectedSiteSlug);
+
+			if (!cartItem || cartItem.product_slug === _constants.PLAN_JETPACK_FREE) {
+				return _this.selectFreeJetpackPlan();
+			}
+
+			if (cartItem.product_slug === (0, _lodash.get)(_this.props, 'selectedSite.plan.product_slug', null)) {
+				return _this.redirect(CALYPSO_PLANS_PAGE);
+			}
+
+			_this.props.recordTracksEvent('calypso_jpc_plans_submit', {
+				user: _this.props.userId,
+				product_slug: cartItem.product_slug });
+
+			_analytics.mc.bumpStat('calypso_jpc_plan_selection', cartItem.product_slug);
+
+			(0, _actions2.addItem)(cartItem);
+			_this.redirecting = true;
+			_this.props.completeFlow();
+			_page2.default.redirect(checkoutPath);
+		}",
+                                        "plans": "jetpack_personal,jetpack_premium,jetpack_business",
+                                        "site": "[object Object]",
+                                      },
                                       "children": Array [],
-                                      "name": "div",
+                                      "name": "my-sites--plan-features",
                                       "next": null,
                                       "parent": [Circular],
                                       "prev": null,
@@ -19719,7 +23938,7 @@ initialize {
                                 "prev": Object {
                                   "attribs": Object {},
                                   "children": Array [],
-                                  "name": "div",
+                                  "name": "components--data--query-plans",
                                   "next": [Circular],
                                   "parent": [Circular],
                                   "prev": Object {
@@ -19932,9 +24151,40 @@ initialize {
                                 },
                                 "children": Array [
                                   Object {
-                                    "attribs": Object {},
+                                    "attribs": Object {
+                                      "baseplanspath": "/jetpack/connect/plans",
+                                      "displayjetpackplans": "true",
+                                      "isinsignup": "true",
+                                      "islandingpage": "false",
+                                      "onupgradeclick": "function (cartItem) {
+			var checkoutPath = '/checkout/' + _this.props.selectedSite.slug;
+			// clears whatever we had stored in local cache
+			_this.props.selectPlanInAdvance(null, _this.props.selectedSiteSlug);
+
+			if (!cartItem || cartItem.product_slug === _constants.PLAN_JETPACK_FREE) {
+				return _this.selectFreeJetpackPlan();
+			}
+
+			if (cartItem.product_slug === (0, _lodash.get)(_this.props, 'selectedSite.plan.product_slug', null)) {
+				return _this.redirect(CALYPSO_PLANS_PAGE);
+			}
+
+			_this.props.recordTracksEvent('calypso_jpc_plans_submit', {
+				user: _this.props.userId,
+				product_slug: cartItem.product_slug });
+
+			_analytics.mc.bumpStat('calypso_jpc_plan_selection', cartItem.product_slug);
+
+			(0, _actions2.addItem)(cartItem);
+			_this.redirecting = true;
+			_this.props.completeFlow();
+			_page2.default.redirect(checkoutPath);
+		}",
+                                      "plans": "jetpack_personal,jetpack_premium,jetpack_business",
+                                      "site": "[object Object]",
+                                    },
                                     "children": Array [],
-                                    "name": "div",
+                                    "name": "my-sites--plan-features",
                                     "next": null,
                                     "parent": [Circular],
                                     "prev": null,
@@ -19945,15 +24195,17 @@ initialize {
                                 "next": null,
                                 "parent": [Circular],
                                 "prev": Object {
-                                  "attribs": Object {},
+                                  "attribs": Object {
+                                    "siteid": "1234567",
+                                  },
                                   "children": Array [],
-                                  "name": "div",
+                                  "name": "components--data--query-site-plans",
                                   "next": [Circular],
                                   "parent": [Circular],
                                   "prev": Object {
                                     "attribs": Object {},
                                     "children": Array [],
-                                    "name": "div",
+                                    "name": "components--data--query-plans",
                                     "next": [Circular],
                                     "parent": [Circular],
                                     "prev": Object {
@@ -20276,15 +24528,17 @@ initialize {
             "next": null,
             "parent": [Circular],
             "prev": Object {
-              "attribs": Object {},
+              "attribs": Object {
+                "siteid": "1234567",
+              },
               "children": Array [],
-              "name": "div",
+              "name": "components--data--query-site-plans",
               "next": [Circular],
               "parent": [Circular],
               "prev": Object {
                 "attribs": Object {},
                 "children": Array [],
-                "name": "div",
+                "name": "components--data--query-plans",
                 "next": [Circular],
                 "parent": [Circular],
                 "prev": null,

--- a/client/jetpack-connect/test/plans.js
+++ b/client/jetpack-connect/test/plans.js
@@ -14,10 +14,10 @@ import React from 'react';
 import PlansWrapper, { getSitePlans, SELECTED_SITE, SITE_PLAN_PRO } from './lib/plans';
 import { PLAN_JETPACK_BUSINESS } from 'lib/plans/constants';
 
-jest.mock( 'components/data/query-plans', () => require( 'components/empty-component' ) );
-jest.mock( 'components/data/query-site-plans', () => require( 'components/empty-component' ) );
-jest.mock( 'jetpack-connect/happychat-button', () => require( 'components/empty-component' ) );
-jest.mock( 'my-sites/plan-features', () => require( 'components/empty-component' ) );
+jest.mock( 'components/data/query-plans', () => 'components--data--query-plans' );
+jest.mock( 'components/data/query-site-plans', () => 'components--data--query-site-plans' );
+jest.mock( 'jetpack-connect/happychat-button', () => 'jetpack-connect--happychat-button' );
+jest.mock( 'my-sites/plan-features', () => 'my-sites--plan-features' );
 
 describe( 'Plans', () => {
 	test( 'should render with no plan (free)', () => {


### PR DESCRIPTION
After an exploration in #19037, we found it's possible to use [custom elements](https://w3c.github.io/webcomponents/spec/custom/#valid-custom-element-name) as React component mocks. This has the effect of "tagging" mocked components and providing more information in the snapshots.