### PR TITLE
Comments: Remove error notices on single comment failed requests

### DIFF
--- a/client/state/data-layer/wpcom/sites/comments/index.js
+++ b/client/state/data-layer/wpcom/sites/comments/index.js
@@ -109,7 +109,7 @@ export const receiveCommentSuccess = ( store, action, response ) => {
 	} );
 };
 
-export const receiveCommentError = ( { dispatch, getState }, { siteId, commentId } ) =>
+export const receiveCommentError = ( { dispatch }, { siteId, commentId } ) =>
 	dispatch( {
 		type: COMMENTS_RECEIVE_ERROR,
 		siteId,

--- a/client/state/data-layer/wpcom/sites/comments/index.js
+++ b/client/state/data-layer/wpcom/sites/comments/index.js
@@ -26,8 +26,6 @@ import likes from './likes';
 import { errorNotice, removeNotice } from 'state/notices/actions';
 import { getRawSite } from 'state/sites/selectors';
 import { getSiteComment } from 'state/selectors';
-import { getSiteName as getReaderSiteName } from 'reader/get-helpers';
-import { getSite as getReaderSite } from 'state/reader/sites/selectors';
 
 const changeCommentStatus = ( { dispatch, getState }, action ) => {
 	const { siteId, commentId, status } = action;
@@ -111,37 +109,12 @@ export const receiveCommentSuccess = ( store, action, response ) => {
 	} );
 };
 
-export const receiveCommentError = ( { dispatch, getState }, { siteId, commentId } ) => {
-	const site = getReaderSite( getState(), siteId );
-	const siteName = getReaderSiteName( { site } );
-
-	if ( siteName ) {
-		dispatch(
-			errorNotice(
-				translate( 'Failed to retrieve comment for site “%(siteName)s”', {
-					args: { siteName },
-				} ),
-				{ id: `request-comment-error-${ siteId }` }
-			)
-		);
-	} else {
-		const rawSite = getRawSite( getState(), siteId );
-		const error =
-			rawSite && rawSite.name
-				? translate( 'Failed to retrieve comment for site “%(siteName)s”', {
-						args: { siteName: rawSite.name },
-					} )
-				: translate( 'Failed to retrieve comment for your site' );
-
-		dispatch( errorNotice( error, { id: `request-comment-error-${ siteId }` } ) );
-	}
-
+export const receiveCommentError = ( { dispatch, getState }, { siteId, commentId } ) =>
 	dispatch( {
 		type: COMMENTS_RECEIVE_ERROR,
 		siteId,
 		commentId,
 	} );
-};
 
 // @see https://developer.wordpress.com/docs/api/1.1/get/sites/%24site/comments/
 export const fetchCommentsList = ( { dispatch }, action ) => {

--- a/client/state/data-layer/wpcom/sites/comments/test/index.js
+++ b/client/state/data-layer/wpcom/sites/comments/test/index.js
@@ -193,9 +193,8 @@ describe( '#receiveCommentError', () => {
 
 		receiveCommentError( { dispatch, getState }, action, response );
 		expect( dispatch ).to.have.been.calledWithMatch( {
-			notice: {
-				text: 'Failed to retrieve comment for site “sqeeeeee!”',
-			},
+			siteId,
+			commentId,
 		} );
 	} );
 } );


### PR DESCRIPTION
Closes #18322

The PR title says it all.
The reason is that users can't do anything about it anyway.

This change affects both Comments Management and the Reader.
I checked both, and they both work as expected (no notices shown on failed single comments requests).

As a follow-up, for Comments Management, @kwight [proposed](https://github.com/Automattic/wp-calypso/issues/18322#issuecomment-337732346) to replace the failed comments' placeholder with an error message.
I think we could do this by taking advantage of the `comments.errors` state updated by `COMMENTS_RECEIVE_ERROR`