### PR TITLE
Components: Turn a few into Component classes

### DIFF
--- a/client/blocks/term-tree-selector/terms.jsx
+++ b/client/blocks/term-tree-selector/terms.jsx
@@ -66,7 +66,7 @@ class TermTreeSelectorList extends Component {
 		analyticsPrefix: 'Category Selector',
 		searchThreshold: 8,
 		loading: true,
-		terms: [],
+		terms: Object.freeze( [] ),
 		onSearch: () => {},
 		onChange: () => {},
 		onNextPage: () => {},

--- a/client/blocks/term-tree-selector/terms.jsx
+++ b/client/blocks/term-tree-selector/terms.jsx
@@ -3,10 +3,8 @@
  *
  * @format
  */
-
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import React from 'react';
-import createReactClass from 'create-react-class';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
@@ -46,10 +44,8 @@ const DEFAULT_TERMS_PER_PAGE = 100;
 const LOAD_OFFSET = 10;
 const ITEM_HEIGHT = 25;
 
-const TermTreeSelectorList = createReactClass( {
-	displayName: 'TermTreeSelectorList',
-
-	propTypes: {
+class TermTreeSelectorList extends Component {
+	static propTypes = {
 		hideTermAndChildren: PropTypes.number,
 		terms: PropTypes.array,
 		taxonomy: PropTypes.string,
@@ -64,28 +60,26 @@ const TermTreeSelectorList = createReactClass( {
 		onChange: PropTypes.func,
 		isError: PropTypes.bool,
 		height: PropTypes.number,
-	},
+	};
 
-	getInitialState() {
-		// getInitialState is also used to reset state when a the taxonomy prop changes
-		return {
-			searchTerm: '',
-			requestedPages: [ 1 ],
-		};
-	},
+	static defaultProps = {
+		analyticsPrefix: 'Category Selector',
+		searchThreshold: 8,
+		loading: true,
+		terms: [],
+		onSearch: () => {},
+		onChange: () => {},
+		onNextPage: () => {},
+		height: 300,
+	};
 
-	getDefaultProps() {
-		return {
-			analyticsPrefix: 'Category Selector',
-			searchThreshold: 8,
-			loading: true,
-			terms: [],
-			onSearch: () => {},
-			onChange: () => {},
-			onNextPage: () => {},
-			height: 300,
-		};
-	},
+	// initialState is also used to reset state when a the taxonomy prop changes
+	static initialState = {
+		searchTerm: '',
+		requestedPages: [ 1 ],
+	};
+
+	state = this.constructor.initialState;
 
 	componentWillMount() {
 		this.itemHeights = {};
@@ -98,18 +92,18 @@ const TermTreeSelectorList = createReactClass( {
 		this.debouncedSearch = debounce( () => {
 			this.props.onSearch( this.state.searchTerm );
 		}, SEARCH_DEBOUNCE_TIME_MS );
-	},
+	}
 
 	componentWillReceiveProps( nextProps ) {
 		if ( nextProps.taxonomy !== this.props.taxonomy ) {
-			this.setState( this.getInitialState() );
+			this.setState( this.constructor.initialState );
 		}
 
 		if ( this.props.terms !== nextProps.terms ) {
 			this.getTermChildren.cache.clear();
 			this.termIds = map( nextProps.terms, 'ID' );
 		}
-	},
+	}
 
 	componentDidUpdate( prevProps ) {
 		const forceUpdate =
@@ -124,9 +118,9 @@ const TermTreeSelectorList = createReactClass( {
 		if ( this.props.terms !== prevProps.terms ) {
 			this.recomputeRowHeights();
 		}
-	},
+	}
 
-	recomputeRowHeights: function() {
+	recomputeRowHeights = () => {
 		if ( ! this.list ) {
 			return;
 		}
@@ -138,25 +132,25 @@ const TermTreeSelectorList = createReactClass( {
 		if ( this.isSmall() ) {
 			this.forceUpdate();
 		}
-	},
+	};
 
-	setSelectorRef( selectorRef ) {
+	setSelectorRef = selectorRef => {
 		if ( ! selectorRef ) {
 			return;
 		}
 
 		this.setState( { selectorRef } );
-	},
+	};
 
-	getPageForIndex( index ) {
+	getPageForIndex = index => {
 		const { query, lastPage } = this.props;
 		const perPage = query.number || DEFAULT_TERMS_PER_PAGE;
 		const page = Math.ceil( index / perPage );
 
 		return Math.max( Math.min( page, lastPage || Infinity ), 1 );
-	},
+	};
 
-	setRequestedPages( { startIndex, stopIndex } ) {
+	setRequestedPages = ( { startIndex, stopIndex } ) => {
 		const { requestedPages } = this.state;
 		const pagesToRequest = difference(
 			range(
@@ -173,9 +167,9 @@ const TermTreeSelectorList = createReactClass( {
 		this.setState( {
 			requestedPages: requestedPages.concat( pagesToRequest ),
 		} );
-	},
+	};
 
-	setItemRef( item, itemRef ) {
+	setItemRef = ( item, itemRef ) => {
 		if ( ! itemRef || ! item ) {
 			return;
 		}
@@ -192,44 +186,44 @@ const TermTreeSelectorList = createReactClass( {
 		if ( height !== nextHeight ) {
 			this.queueRecomputeRowHeights();
 		}
-	},
+	};
 
-	hasNoSearchResults() {
+	hasNoSearchResults = () => {
 		return (
 			! this.props.loading &&
 			( this.props.terms && ! this.props.terms.length ) &&
 			!! this.state.searchTerm.length
 		);
-	},
+	};
 
-	hasNoTerms() {
+	hasNoTerms = () => {
 		return ! this.props.loading && ( this.props.terms && ! this.props.terms.length );
-	},
+	};
 
-	getItem( index ) {
+	getItem = index => {
 		if ( this.props.terms ) {
 			return this.props.terms[ index ];
 		}
-	},
+	};
 
-	isSmall() {
+	isSmall = () => {
 		if ( ! this.props.terms || this.state.searchTerm ) {
 			return false;
 		}
 
 		return this.props.terms.length < this.props.searchThreshold;
-	},
+	};
 
-	isRowLoaded( { index } ) {
+	isRowLoaded = ( { index } ) => {
 		return this.props.lastPage || !! this.getItem( index );
-	},
+	};
 
-	getTermChildren( termId ) {
+	getTermChildren = termId => {
 		const { terms } = this.props;
 		return filter( terms, ( { parent } ) => parent === termId );
-	},
+	};
 
-	getItemHeight( item, _recurse = false ) {
+	getItemHeight = ( item, _recurse = false ) => {
 		if ( ! item ) {
 			return ITEM_HEIGHT;
 		}
@@ -255,28 +249,28 @@ const TermTreeSelectorList = createReactClass( {
 			},
 			ITEM_HEIGHT
 		);
-	},
+	};
 
-	getRowHeight( { index } ) {
+	getRowHeight = ( { index } ) => {
 		return this.getItemHeight( this.getItem( index ) );
-	},
+	};
 
-	getCompactContainerHeight() {
+	getCompactContainerHeight = () => {
 		return range( 0, this.getRowCount() ).reduce( ( memo, index ) => {
 			return memo + this.getRowHeight( { index } );
 		}, 0 );
-	},
+	};
 
-	getResultsWidth() {
+	getResultsWidth = () => {
 		const { selectorRef } = this.state;
 		if ( selectorRef ) {
 			return selectorRef.clientWidth;
 		}
 
 		return 0;
-	},
+	};
 
-	getRowCount() {
+	getRowCount = () => {
 		let count = 0;
 
 		if ( this.props.terms ) {
@@ -288,9 +282,9 @@ const TermTreeSelectorList = createReactClass( {
 		}
 
 		return count;
-	},
+	};
 
-	onSearch( event ) {
+	onSearch = event => {
 		const searchTerm = event.target.value;
 		if ( this.state.searchTerm && ! searchTerm ) {
 			this.props.onSearch( '' );
@@ -307,13 +301,13 @@ const TermTreeSelectorList = createReactClass( {
 
 		this.setState( { searchTerm } );
 		this.debouncedSearch();
-	},
+	};
 
-	setListRef( ref ) {
+	setListRef = ref => {
 		this.list = ref;
-	},
+	};
 
-	renderItem( item, _recurse = false ) {
+	renderItem = ( item, _recurse = false ) => {
 		// if item has a parent and it is in current props.terms, do not render
 		if ( item.parent && ! _recurse && includes( this.termIds, item.parent ) ) {
 			return;
@@ -359,9 +353,9 @@ const TermTreeSelectorList = createReactClass( {
 				) }
 			</div>
 		);
-	},
+	};
 
-	renderNoResults() {
+	renderNoResults = () => {
 		if ( this.hasNoSearchResults() || this.hasNoTerms() ) {
 			return (
 				<div key="no-results" className="term-tree-selector__list-item is-empty">
@@ -372,9 +366,9 @@ const TermTreeSelectorList = createReactClass( {
 				</div>
 			);
 		}
-	},
+	};
 
-	renderRow( { index } ) {
+	renderRow = ( { index } ) => {
 		const item = this.getItem( index );
 		if ( item ) {
 			return this.renderItem( item );
@@ -392,15 +386,15 @@ const TermTreeSelectorList = createReactClass( {
 				</label>
 			</div>
 		);
-	},
+	};
 
-	cellRendererWrapper( { key, style, ...rest } ) {
+	cellRendererWrapper = ( { key, style, ...rest } ) => {
 		return (
 			<div key={ key } style={ style }>
 				{ this.renderRow( rest ) }
 			</div>
 		);
-	},
+	};
 
 	render() {
 		const rowCount = this.getRowCount();
@@ -442,8 +436,8 @@ const TermTreeSelectorList = createReactClass( {
 				/>
 			</div>
 		);
-	},
-} );
+	}
+}
 
 export default connect( ( state, ownProps ) => {
 	const siteId = getSelectedSiteId( state );

--- a/client/blocks/term-tree-selector/terms.jsx
+++ b/client/blocks/term-tree-selector/terms.jsx
@@ -1,7 +1,6 @@
+/** @format */
 /**
  * External dependencies
- *
- * @format
  */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';

--- a/client/blocks/term-tree-selector/terms.jsx
+++ b/client/blocks/term-tree-selector/terms.jsx
@@ -76,7 +76,7 @@ class TermTreeSelectorList extends Component {
 	// initialState is also used to reset state when a the taxonomy prop changes
 	static initialState = {
 		searchTerm: '',
-		requestedPages: [ 1 ],
+		requestedPages: Object.freeze( [ 1 ] ),
 	};
 
 	state = this.constructor.initialState;

--- a/client/components/data/email-followers-data/index.jsx
+++ b/client/components/data/email-followers-data/index.jsx
@@ -3,9 +3,8 @@
  *
  * @format
  */
-
+import { Component } from 'react';
 import PropTypes from 'prop-types';
-import createReactClass from 'create-react-class';
 import { isEqual } from 'lodash';
 import debugModule from 'debug';
 
@@ -22,21 +21,19 @@ import pollers from 'lib/data-poller';
  */
 const debug = debugModule( 'calypso:email-followers-data' );
 
-export default createReactClass( {
-	displayName: 'EmailFollowersData',
-
-	propTypes: {
+export default class extends Component {
+	static propTypes = {
 		fetchOptions: PropTypes.object.isRequired,
-	},
+	};
 
-	getInitialState() {
-		return {
-			followers: false,
-			totalFollowers: false,
-			currentPage: false,
-			fetchInitialized: false,
-		};
-	},
+	static initialState = {
+		followers: false,
+		totalFollowers: false,
+		currentPage: false,
+		fetchInitialized: false,
+	};
+
+	state = this.constructor.initialState;
 
 	componentDidMount() {
 		EmailFollowersStore.on( 'change', this.refreshFollowers );
@@ -50,14 +47,14 @@ export default createReactClass( {
 			),
 			{ leading: false }
 		);
-	},
+	}
 
 	componentWillReceiveProps( nextProps ) {
 		if ( ! nextProps.fetchOptions ) {
 			return;
 		}
 		if ( ! isEqual( this.props.fetchOptions, nextProps.fetchOptions ) ) {
-			this.setState( this.getInitialState() );
+			this.setState( this.constructor.initialState );
 			this.fetchIfEmpty( nextProps.fetchOptions );
 			pollers.remove( this._poller );
 			this._poller = pollers.add(
@@ -70,14 +67,14 @@ export default createReactClass( {
 				{ leading: false }
 			);
 		}
-	},
+	}
 
 	componentWillUnmount() {
 		EmailFollowersStore.removeListener( 'change', this.refreshFollowers );
 		pollers.remove( this._poller );
-	},
+	}
 
-	fetchIfEmpty( fetchOptions ) {
+	fetchIfEmpty = fetchOptions => {
 		fetchOptions = fetchOptions || this.props.fetchOptions;
 		if ( ! fetchOptions || ! fetchOptions.siteId ) {
 			return;
@@ -97,9 +94,9 @@ export default createReactClass( {
 			this.setState( { fetchInitialized: true } );
 		}.bind( this );
 		setTimeout( defer, 0 );
-	},
+	};
 
-	isFetching: function() {
+	isFetching = () => {
 		let fetchOptions = this.props.fetchOptions;
 		if ( ! fetchOptions.siteId ) {
 			debug( 'Is fetching because siteId is falsey' );
@@ -117,9 +114,9 @@ export default createReactClass( {
 			return true;
 		}
 		return false;
-	},
+	};
 
-	refreshFollowers( fetchOptions ) {
+	refreshFollowers = fetchOptions => {
 		fetchOptions = fetchOptions || this.props.fetchOptions;
 		debug( 'Refreshing followers: ' + JSON.stringify( fetchOptions ) );
 		this.setState( {
@@ -127,9 +124,9 @@ export default createReactClass( {
 			totalFollowers: EmailFollowersStore.getPaginationData( fetchOptions ).totalFollowers,
 			currentPage: EmailFollowersStore.getPaginationData( fetchOptions ).followersCurrentPage,
 		} );
-	},
+	};
 
 	render() {
 		return passToChildren( this, Object.assign( {}, this.state, { fetching: this.isFetching() } ) );
-	},
-} );
+	}
+}

--- a/client/components/data/email-followers-data/index.jsx
+++ b/client/components/data/email-followers-data/index.jsx
@@ -1,7 +1,6 @@
+/** @format */
 /**
  * External dependencies
- *
- * @format
  */
 import { Component } from 'react';
 import PropTypes from 'prop-types';

--- a/client/components/data/email-followers-data/index.jsx
+++ b/client/components/data/email-followers-data/index.jsx
@@ -21,7 +21,7 @@ import pollers from 'lib/data-poller';
  */
 const debug = debugModule( 'calypso:email-followers-data' );
 
-export default class extends Component {
+export default class EmailFollowersData extends Component {
 	static propTypes = {
 		fetchOptions: PropTypes.object.isRequired,
 	};

--- a/client/components/data/followers-data/index.jsx
+++ b/client/components/data/followers-data/index.jsx
@@ -26,7 +26,7 @@ export default class extends Component {
 		fetchOptions: PropTypes.object.isRequired,
 	};
 
-	initialState = {
+	static initialState = {
 		followers: false,
 		totalFollowers: false,
 		currentPage: false,

--- a/client/components/data/followers-data/index.jsx
+++ b/client/components/data/followers-data/index.jsx
@@ -1,7 +1,6 @@
+/** @format */
 /**
  * External dependencies
- *
- * @format
  */
 import { Component } from 'react';
 import PropTypes from 'prop-types';

--- a/client/components/data/followers-data/index.jsx
+++ b/client/components/data/followers-data/index.jsx
@@ -3,9 +3,8 @@
  *
  * @format
  */
-
+import { Component } from 'react';
 import PropTypes from 'prop-types';
-import createReactClass from 'create-react-class';
 import { isEqual } from 'lodash';
 import debugModule from 'debug';
 
@@ -22,21 +21,19 @@ import pollers from 'lib/data-poller';
  */
 const debug = debugModule( 'calypso:followers-data' );
 
-export default createReactClass( {
-	displayName: 'FollowersData',
-
-	propTypes: {
+export default class extends Component {
+	static propTypes = {
 		fetchOptions: PropTypes.object.isRequired,
-	},
+	};
 
-	getInitialState() {
-		return {
-			followers: false,
-			totalFollowers: false,
-			currentPage: false,
-			fetchInitialized: false,
-		};
-	},
+	initialState = {
+		followers: false,
+		totalFollowers: false,
+		currentPage: false,
+		fetchInitialized: false,
+	};
+
+	state = this.constructor.initialState;
 
 	componentDidMount() {
 		FollowersStore.on( 'change', this.refreshFollowers );
@@ -46,14 +43,14 @@ export default createReactClass( {
 			FollowersActions.fetchFollowers.bind( FollowersActions, this.props.fetchOptions, true ),
 			{ leading: false }
 		);
-	},
+	}
 
 	componentWillReceiveProps( nextProps ) {
 		if ( ! nextProps.fetchOptions ) {
 			return;
 		}
 		if ( ! isEqual( this.props.fetchOptions, nextProps.fetchOptions ) ) {
-			this.setState( this.getInitialState() );
+			this.setState( this.constructor.initialState );
 			this.fetchIfEmpty( nextProps.fetchOptions );
 			pollers.remove( this._poller );
 			this._poller = pollers.add(
@@ -62,14 +59,14 @@ export default createReactClass( {
 				{ leading: false }
 			);
 		}
-	},
+	}
 
 	componentWillUnmount() {
 		FollowersStore.removeListener( 'change', this.refreshFollowers );
 		pollers.remove( this._poller );
-	},
+	}
 
-	fetchIfEmpty( fetchOptions ) {
+	fetchIfEmpty = fetchOptions => {
 		fetchOptions = fetchOptions || this.props.fetchOptions;
 		if ( ! fetchOptions || ! fetchOptions.siteId ) {
 			return;
@@ -88,9 +85,9 @@ export default createReactClass( {
 			this.setState( { fetchInitialized: true } );
 		}.bind( this );
 		setTimeout( defer, 0 );
-	},
+	};
 
-	isFetching: function() {
+	isFetching = () => {
 		let fetchOptions = this.props.fetchOptions;
 		if ( ! fetchOptions.siteId ) {
 			debug( 'Is fetching because siteId is falsey' );
@@ -108,9 +105,9 @@ export default createReactClass( {
 			return true;
 		}
 		return false;
-	},
+	};
 
-	refreshFollowers( fetchOptions ) {
+	refreshFollowers = fetchOptions => {
 		fetchOptions = fetchOptions || this.props.fetchOptions;
 		debug( 'Refreshing followers: ' + JSON.stringify( fetchOptions ) );
 		this.setState( {
@@ -118,9 +115,9 @@ export default createReactClass( {
 			totalFollowers: FollowersStore.getPaginationData( fetchOptions ).totalFollowers,
 			currentPage: FollowersStore.getPaginationData( fetchOptions ).followersCurrentPage,
 		} );
-	},
+	};
 
 	render() {
 		return passToChildren( this, Object.assign( {}, this.state, { fetching: this.isFetching() } ) );
-	},
-} );
+	}
+}

--- a/client/components/data/followers-data/index.jsx
+++ b/client/components/data/followers-data/index.jsx
@@ -21,7 +21,7 @@ import pollers from 'lib/data-poller';
  */
 const debug = debugModule( 'calypso:followers-data' );
 
-export default class extends Component {
+export default class FollowersData extends Component {
 	static propTypes = {
 		fetchOptions: PropTypes.object.isRequired,
 	};

--- a/client/components/data/viewers-data/README.md
+++ b/client/components/data/viewers-data/README.md
@@ -9,7 +9,7 @@ A component that fetches a private wpcom site's viewers and passes them to its c
 
 ## Usage
 
-A component wrapped with `<FollowersData />` will receive the following props:
+A component wrapped with `<ViewersData />` will receive the following props:
 
 - viewers: An array of viewer objects
 - totalViewers: The total number of viewers found for the site

--- a/client/components/data/viewers-data/index.jsx
+++ b/client/components/data/viewers-data/index.jsx
@@ -13,7 +13,7 @@ import ViewersStore from 'lib/viewers/store';
 import ViewersActions from 'lib/viewers/actions';
 import passToChildren from 'lib/react-pass-to-children';
 
-export default class extends Component {
+export default class ViewersData extends Component {
 	static propTypes = {
 		siteId: PropTypes.number.isRequired,
 	};

--- a/client/components/data/viewers-data/index.jsx
+++ b/client/components/data/viewers-data/index.jsx
@@ -1,7 +1,6 @@
+/** @format */
 /**
  * External dependencies
- *
- * @format
  */
 import { Component } from 'react';
 import PropTypes from 'prop-types';

--- a/client/components/data/viewers-data/index.jsx
+++ b/client/components/data/viewers-data/index.jsx
@@ -18,7 +18,7 @@ export default class extends Component {
 		siteId: PropTypes.number.isRequired,
 	};
 
-	initialState = {
+	static initialState = {
 		viewers: false,
 		totalViewers: false,
 		currentPage: false,

--- a/client/components/data/viewers-data/index.jsx
+++ b/client/components/data/viewers-data/index.jsx
@@ -3,9 +3,8 @@
  *
  * @format
  */
-
+import { Component } from 'react';
 import PropTypes from 'prop-types';
-import createReactClass from 'create-react-class';
 
 /**
  * Internal dependencies
@@ -14,42 +13,40 @@ import ViewersStore from 'lib/viewers/store';
 import ViewersActions from 'lib/viewers/actions';
 import passToChildren from 'lib/react-pass-to-children';
 
-export default createReactClass( {
-	displayName: 'ViewersData',
-
-	propTypes: {
+export default class extends Component {
+	static propTypes = {
 		siteId: PropTypes.number.isRequired,
-	},
+	};
 
-	getInitialState() {
-		return {
-			viewers: false,
-			totalViewers: false,
-			currentPage: false,
-			fetchInitialized: false,
-		};
-	},
+	initialState = {
+		viewers: false,
+		totalViewers: false,
+		currentPage: false,
+		fetchInitialized: false,
+	};
+
+	state = this.constructor.initialState;
 
 	componentDidMount() {
 		ViewersStore.on( 'change', this.refreshViewers );
 		this.fetchIfEmpty( this.props.siteId );
-	},
+	}
 
 	componentWillReceiveProps( nextProps ) {
 		if ( ! nextProps.siteId ) {
 			return;
 		}
 		if ( this.props.siteId !== nextProps.siteId ) {
-			this.setState( this.getInitialState() );
+			this.setState( this.constructor.initialState );
 			this.fetchIfEmpty( nextProps.siteId );
 		}
-	},
+	}
 
 	componentWillUnmount() {
 		ViewersStore.removeListener( 'change', this.refreshViewers );
-	},
+	}
 
-	fetchIfEmpty( siteId ) {
+	fetchIfEmpty = siteId => {
 		siteId = siteId || this.props.siteId;
 		if ( ! siteId ) {
 			return;
@@ -69,9 +66,9 @@ export default createReactClass( {
 			this.setState( { fetchInitialized: true } );
 		}.bind( this );
 		setTimeout( defer, 0 );
-	},
+	};
 
-	isFetching: function() {
+	isFetching = () => {
 		let siteId = this.props.siteId;
 		if ( ! siteId ) {
 			return true;
@@ -87,18 +84,18 @@ export default createReactClass( {
 			return true;
 		}
 		return false;
-	},
+	};
 
-	refreshViewers( siteId ) {
+	refreshViewers = siteId => {
 		siteId = siteId || this.props.siteId;
 		this.setState( {
 			viewers: ViewersStore.getViewers( siteId ),
 			totalViewers: ViewersStore.getPaginationData( siteId ).totalViewers,
 			currentPage: ViewersStore.getPaginationData( siteId ).currentViewersPage,
 		} );
-	},
+	};
 
 	render() {
 		return passToChildren( this, Object.assign( {}, this.state, { fetching: this.isFetching() } ) );
-	},
-} );
+	}
+}

--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -73,17 +73,19 @@ class SiteSelector extends Component {
 		groups: false,
 	};
 
-	state = {
+	static initialState = {
 		highlightedIndex: -1,
 		showSearch: false,
 		isKeyboardEngaged: false,
 	};
 
+	state = this.constructor.initialState;
+
 	reset() {
 		if ( this.props.sitesFound && this.refs.siteSearch ) {
 			this.refs.siteSearch.clear();
 		} else {
-			this.setState( this.getInitialState() );
+			this.setState( this.constructor.initialState );
 		}
 	}
 

--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -73,21 +73,11 @@ class SiteSelector extends Component {
 		groups: false,
 	};
 
-	static initialState = {
+	state = {
 		highlightedIndex: -1,
 		showSearch: false,
 		isKeyboardEngaged: false,
 	};
-
-	state = this.constructor.initialState;
-
-	reset() {
-		if ( this.props.sitesFound && this.refs.siteSearch ) {
-			this.refs.siteSearch.clear();
-		} else {
-			this.setState( this.constructor.initialState );
-		}
-	}
 
 	onSearch = terms => {
 		this.props.searchSites( terms );

--- a/client/me/purchases/cancel-privacy-protection/index.jsx
+++ b/client/me/purchases/cancel-privacy-protection/index.jsx
@@ -114,9 +114,7 @@ class CancelPrivacyProtection extends Component {
 			} );
 	};
 
-	resetState = () => {
-		this.setState( this.constructor.initialState );
-	};
+	resetState = () => this.setState( this.constructor.initialState );
 
 	renderDescriptionText = () => {
 		const purchase = getPurchase( this.props );

--- a/client/me/purchases/cancel-privacy-protection/index.jsx
+++ b/client/me/purchases/cancel-privacy-protection/index.jsx
@@ -1,7 +1,6 @@
+/** @format */
 /**
  * External dependencies
- *
- * @format
  */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';

--- a/client/me/purchases/cancel-privacy-protection/index.jsx
+++ b/client/me/purchases/cancel-privacy-protection/index.jsx
@@ -3,15 +3,12 @@
  *
  * @format
  */
-
-import classNames from 'classnames';
-import { localize } from 'i18n-calypso';
-import { connect } from 'react-redux';
-import page from 'page';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import React from 'react';
-
-import createReactClass from 'create-react-class';
+import { connect } from 'react-redux';
+import classNames from 'classnames';
+import page from 'page';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -40,42 +37,40 @@ import { CALYPSO_CONTACT } from 'lib/url/support';
 
 const user = userFactory();
 
-const CancelPrivacyProtection = createReactClass( {
-	displayName: 'CancelPrivacyProtection',
-
-	propTypes: {
+class CancelPrivacyProtection extends Component {
+	static propTypes = {
 		hasLoadedSites: PropTypes.bool.isRequired,
 		hasLoadedUserPurchasesFromServer: PropTypes.bool.isRequired,
 		selectedPurchase: PropTypes.object,
 		selectedSite: PropTypes.oneOfType( [ PropTypes.bool, PropTypes.object ] ),
-	},
+	};
 
-	getInitialState() {
-		return {
-			disabled: false,
-			cancelling: false,
-		};
-	},
+	initialState = {
+		disabled: false,
+		cancelling: false,
+	};
+
+	state = this.constructor.initialState;
 
 	componentWillMount() {
 		this.redirectIfDataIsInvalid();
 
 		recordPageView( 'cancel_private_registration', this.props );
-	},
+	}
 
 	componentWillReceiveProps( nextProps ) {
 		this.redirectIfDataIsInvalid( nextProps );
 
 		recordPageView( 'cancel_private_registration', this.props, nextProps );
-	},
+	}
 
-	redirectIfDataIsInvalid( props = this.props ) {
+	redirectIfDataIsInvalid = ( props = this.props ) => {
 		if ( ! this.isDataValid( props ) ) {
 			page.redirect( paths.purchasesRoot() );
 		}
-	},
+	};
 
-	isDataValid( props = this.props ) {
+	isDataValid = ( props = this.props ) => {
 		if ( isDataLoading( props ) ) {
 			return true;
 		}
@@ -84,9 +79,9 @@ const CancelPrivacyProtection = createReactClass( {
 			purchase = getPurchase( props );
 
 		return selectedSite && purchase && hasPrivacyProtection( purchase );
-	},
+	};
 
-	cancel( event ) {
+	cancel = event => {
 		// We call blur on the cancel button to remove the blue outline that shows up when you click on the button
 		event.target.blur();
 
@@ -117,13 +112,13 @@ const CancelPrivacyProtection = createReactClass( {
 			.catch( () => {
 				this.resetState();
 			} );
-	},
+	};
 
-	resetState() {
-		this.setState( this.getInitialState() );
-	},
+	resetState = () => {
+		this.setState( this.constructor.initialState );
+	};
 
-	renderDescriptionText() {
+	renderDescriptionText = () => {
 		const purchase = getPurchase( this.props );
 
 		return (
@@ -139,9 +134,9 @@ const CancelPrivacyProtection = createReactClass( {
 				) }
 			</p>
 		);
-	},
+	};
 
-	renderWarningText() {
+	renderWarningText = () => {
 		const purchase = getPurchase( this.props );
 
 		return (
@@ -153,9 +148,9 @@ const CancelPrivacyProtection = createReactClass( {
 				) }
 			</strong>
 		);
-	},
+	};
 
-	renderButton() {
+	renderButton = () => {
 		return (
 			<Button
 				onClick={ this.cancel }
@@ -169,9 +164,9 @@ const CancelPrivacyProtection = createReactClass( {
 				) }
 			</Button>
 		);
-	},
+	};
 
-	renderNotice() {
+	renderNotice = () => {
 		const { error, translate } = this.props;
 
 		if ( error ) {
@@ -186,7 +181,7 @@ const CancelPrivacyProtection = createReactClass( {
 		}
 
 		return null;
-	},
+	};
 
 	render() {
 		const classes = classNames( 'cancel-privacy-protection__card', {
@@ -233,8 +228,8 @@ const CancelPrivacyProtection = createReactClass( {
 				</Card>
 			</Main>
 		);
-	},
-} );
+	}
+}
 
 export default connect(
 	( state, props ) => ( {

--- a/client/me/purchases/cancel-privacy-protection/index.jsx
+++ b/client/me/purchases/cancel-privacy-protection/index.jsx
@@ -45,7 +45,7 @@ class CancelPrivacyProtection extends Component {
 		selectedSite: PropTypes.oneOfType( [ PropTypes.bool, PropTypes.object ] ),
 	};
 
-	initialState = {
+	static initialState = {
 		disabled: false,
 		cancelling: false,
 	};

--- a/client/post-editor/editor-featured-image/preview.jsx
+++ b/client/post-editor/editor-featured-image/preview.jsx
@@ -1,7 +1,6 @@
+/** @format */
 /**
  * External dependencies
- *
- * @format
  */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';

--- a/client/post-editor/editor-featured-image/preview.jsx
+++ b/client/post-editor/editor-featured-image/preview.jsx
@@ -3,10 +3,8 @@
  *
  * @format
  */
-
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import React from 'react';
-import createReactClass from 'create-react-class';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
 import { get, some } from 'lodash';
@@ -21,21 +19,19 @@ import SpinnerLine from 'components/spinner-line';
 import ImagePreloader from 'components/image-preloader';
 import { getSelectedSiteId } from 'state/ui/selectors';
 
-const EditorFeaturedImagePreview = createReactClass( {
-	displayName: 'EditorFeaturedImagePreview',
-
-	propTypes: {
+class EditorFeaturedImagePreview extends Component {
+	static propTypes = {
 		siteId: PropTypes.number,
 		image: PropTypes.object,
 		maxWidth: PropTypes.number,
-	},
+	};
 
-	getInitialState() {
-		return {
-			height: null,
-			transientSrc: null,
-		};
-	},
+	static initialState = {
+		height: null,
+		transientSrc: null,
+	};
+
+	state = this.constructor.initialState;
 
 	componentWillReceiveProps( nextProps ) {
 		const currentSrc = this.src();
@@ -57,9 +53,9 @@ const EditorFeaturedImagePreview = createReactClass( {
 		}
 
 		this.setState( nextState );
-	},
+	}
 
-	isReceivingPersistedImage( props, nextProps ) {
+	isReceivingPersistedImage = ( props, nextProps ) => {
 		const { siteId } = this.props;
 		if ( siteId !== nextProps.siteId ) {
 			return false;
@@ -75,9 +71,9 @@ const EditorFeaturedImagePreview = createReactClass( {
 		// to its persisted copy, so we can compare the resolved object IDs
 		const media = MediaStore.get( siteId, image.ID );
 		return media && media.ID === nextProps.image.ID;
-	},
+	};
 
-	src( props = this.props ) {
+	src = ( props = this.props ) => {
 		if ( ! props.image ) {
 			return;
 		}
@@ -86,15 +82,15 @@ const EditorFeaturedImagePreview = createReactClass( {
 			maxWidth: this.props.maxWidth,
 			size: 'post-thumbnail',
 		} );
-	},
+	};
 
-	clearState() {
+	clearState = () => {
 		if ( ! some( this.state ) ) {
 			return;
 		}
 
-		this.setState( this.getInitialState() );
-	},
+		this.setState( this.constructor.initialState );
+	};
 
 	render() {
 		const { height } = this.state;
@@ -121,8 +117,8 @@ const EditorFeaturedImagePreview = createReactClass( {
 				/>
 			</div>
 		);
-	},
-} );
+	}
+}
 
 export default connect( state => {
 	return {


### PR DESCRIPTION
Modeled after #19085. I grepped for `this.getInitialState()` and did the following (same as https://github.com/Automattic/wp-calypso/pull/19085#issuecomment-338959632):

* Temporarily replace the `this.getInitialState()` call with a dummy (I used a string, `'intialState'` 😄 )
* Replace `createReactClass` with `React.createClass` so the codemod would pick it up
* Run the codemod
* Introduce the `intialState` static, use it to init `state`, and replace the dummy `'initialState'` string with it.

To test: Verify that the affected components still work as before.