### PR TITLE
Framework: Remove react-addons-create-fragment

### DIFF
--- a/client/lib/embed-frame-markup/index.jsx
+++ b/client/lib/embed-frame-markup/index.jsx
@@ -7,7 +7,7 @@
  */
 import React from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
-import { map } from 'lodash';
+import { flatMap, map } from 'lodash';
 
 /**
  * Constants
@@ -43,7 +43,7 @@ export default function generateEmbedFrameMarkup( { body, scripts, styles } = {}
 				`,
 					} }
 				/>
-				{ map( scripts, ( { extra, src }, key ) => {
+				{ flatMap( scripts, ( { extra, src }, key ) => {
 					return [
 						extra ? (
 							<script

--- a/client/lib/embed-frame-markup/index.jsx
+++ b/client/lib/embed-frame-markup/index.jsx
@@ -7,8 +7,7 @@
  */
 import React from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
-import createFragment from 'react-addons-create-fragment';
-import { mapValues } from 'lodash';
+import { map } from 'lodash';
 
 /**
  * Constants
@@ -23,11 +22,9 @@ export default function generateEmbedFrameMarkup( { body, scripts, styles } = {}
 	return renderToStaticMarkup(
 		<html>
 			<head>
-				{ createFragment(
-					mapValues( styles, style => {
-						return <link rel="stylesheet" media={ style.media } href={ style.src } />;
-					} )
-				) }
+				{ map( styles, ( { media, src }, key ) => (
+					<link key={ key } rel="stylesheet" media={ media } href={ src } />
+				) ) }
 				<style dangerouslySetInnerHTML={ { __html: 'a { cursor: default; }' } } />
 			</head>
 			<body style={ { margin: 0 } }>
@@ -46,25 +43,19 @@ export default function generateEmbedFrameMarkup( { body, scripts, styles } = {}
 				`,
 					} }
 				/>
-				{ createFragment(
-					mapValues( scripts, script => {
-						let extra;
-						if ( script.extra ) {
-							extra = (
-								<script
-									dangerouslySetInnerHTML={ {
-										__html: script.extra,
-									} }
-								/>
-							);
-						}
-
-						return createFragment( {
-							extra: extra,
-							script: <script src={ script.src } />,
-						} );
-					} )
-				) }
+				{ map( scripts, ( { extra, src }, key ) => {
+					return [
+						extra ? (
+							<script
+								key={ key + '-extra' }
+								dangerouslySetInnerHTML={ {
+									__html: extra,
+								} }
+							/>
+						) : null,
+						<script key={ key } src={ src } />,
+					];
+				} ) }
 			</body>
 		</html>
 	);

--- a/client/my-sites/media-library/content.jsx
+++ b/client/my-sites/media-library/content.jsx
@@ -6,8 +6,7 @@
 
 import React from 'react';
 import { connect } from 'react-redux';
-import createFragment from 'react-addons-create-fragment';
-import { groupBy, head, mapValues, noop, values } from 'lodash';
+import { groupBy, head, map, noop, values } from 'lodash';
 import PropTypes from 'prop-types';
 import page from 'page';
 import { localize } from 'i18n-calypso';
@@ -61,7 +60,7 @@ class MediaLibraryContent extends React.Component {
 
 	renderErrors() {
 		const errorTypes = values( this.props.mediaValidationErrors ).map( head );
-		const notices = mapValues( groupBy( errorTypes ), ( occurrences, errorType ) => {
+		return map( groupBy( errorTypes ), ( occurrences, errorType ) => {
 			let message, onDismiss;
 			const i18nOptions = {
 				count: occurrences.length,
@@ -145,14 +144,12 @@ class MediaLibraryContent extends React.Component {
 			}
 
 			return (
-				<Notice status={ status } text={ message } onDismissClick={ onDismiss }>
+				<Notice key={ errorType } status={ status } text={ message } onDismissClick={ onDismiss }>
 					{ this.renderNoticeAction( upgradeNudgeName, upgradeNudgeFeature ) }
 					{ tryAgain && this.renderTryAgain() }
 				</Notice>
 			);
 		} );
-
-		return createFragment( notices );
 	}
 
 	renderTryAgain() {

--- a/client/my-sites/pages/page/index.js
+++ b/client/my-sites/pages/page/index.js
@@ -199,26 +199,22 @@ class Page extends Component {
 		}
 
 		if ( this.props.page.status !== 'trash' ) {
-			return (
-				<div>
-					<MenuSeparator />
-					<PopoverMenuItem className="page__trash-item" onClick={ this.updateStatusTrash }>
-						<Gridicon icon="trash" size={ 18 } />
-						{ this.props.translate( 'Trash' ) }
-					</PopoverMenuItem>
-				</div>
-			);
+			return [
+				<MenuSeparator key="separator" />,
+				<PopoverMenuItem key="item" className="page__trash-item" onClick={ this.updateStatusTrash }>
+					<Gridicon icon="trash" size={ 18 } />
+					{ this.props.translate( 'Trash' ) }
+				</PopoverMenuItem>,
+			];
 		}
 
-		return (
-			<div>
-				<MenuSeparator />
-				<PopoverMenuItem className="page__delete-item" onClick={ this.updateStatusDelete }>
-					<Gridicon icon="trash" size={ 18 } />
-					{ this.props.translate( 'Delete' ) }
-				</PopoverMenuItem>
-			</div>
-		);
+		return [
+			<MenuSeparator key="separator" />,
+			<PopoverMenuItem key="item" className="page__delete-item" onClick={ this.updateStatusDelete }>
+				<Gridicon icon="trash" size={ 18 } />
+				{ this.props.translate( 'Delete' ) }
+			</PopoverMenuItem>,
+		];
 	}
 
 	getCopyItem() {

--- a/client/my-sites/pages/page/index.js
+++ b/client/my-sites/pages/page/index.js
@@ -7,7 +7,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import ReactCSSTransitionGroup from 'react-transition-group/CSSTransitionGroup';
-import createFragment from 'react-addons-create-fragment';
 import { localize } from 'i18n-calypso';
 import pageRouter from 'page';
 import { connect } from 'react-redux';
@@ -200,26 +199,26 @@ class Page extends Component {
 		}
 
 		if ( this.props.page.status !== 'trash' ) {
-			return createFragment( {
-				separator: <MenuSeparator />,
-				item: (
+			return (
+				<div>
+					<MenuSeparator />
 					<PopoverMenuItem className="page__trash-item" onClick={ this.updateStatusTrash }>
 						<Gridicon icon="trash" size={ 18 } />
 						{ this.props.translate( 'Trash' ) }
 					</PopoverMenuItem>
-				),
-			} );
+				</div>
+			);
 		}
 
-		return createFragment( {
-			separator: <MenuSeparator />,
-			item: (
+		return (
+			<div>
+				<MenuSeparator />
 				<PopoverMenuItem className="page__delete-item" onClick={ this.updateStatusDelete }>
 					<Gridicon icon="trash" size={ 18 } />
 					{ this.props.translate( 'Delete' ) }
 				</PopoverMenuItem>
-			),
-		} );
+			</div>
+		);
 	}
 
 	getCopyItem() {

--- a/client/post-editor/editor-drawer/index.jsx
+++ b/client/post-editor/editor-drawer/index.jsx
@@ -5,7 +5,6 @@
  */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import createFragment from 'react-addons-create-fragment';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { flow, get } from 'lodash';
@@ -116,27 +115,28 @@ class EditorDrawer extends Component {
 		recordEvent( 'Changed Excerpt' );
 	}
 
-	renderTaxonomies() {
-		const { type, canJetpackUseTaxonomies } = this.props;
+	// Categories & Tags
+	renderCategories() {
+		const { type } = this.props;
 
 		// Compatibility: Allow Tags for pages when supported prior to launch
 		// of custom post types feature (#6934). [TODO]: Remove after launch.
 		const isCustomTypesEnabled = config.isEnabled( 'manage/custom-post-types' );
 		const typeSupportsTags = ! isCustomTypesEnabled && this.currentPostTypeSupports( 'tags' );
 
-		// Categories & Tags
-		let categories;
 		if ( 'post' === type || typeSupportsTags ) {
-			categories = <CategoriesTagsAccordion />;
+			return <CategoriesTagsAccordion />;
 		}
+	}
 
-		// Custom Taxonomies
-		let taxonomies;
+	// Custom Taxonomies
+	renderTaxonomies() {
+		const { canJetpackUseTaxonomies } = this.props;
+		const isCustomTypesEnabled = config.isEnabled( 'manage/custom-post-types' );
+
 		if ( isCustomTypesEnabled && false !== canJetpackUseTaxonomies ) {
-			taxonomies = <EditorDrawerTaxonomies />;
+			return <EditorDrawerTaxonomies />;
 		}
-
-		return createFragment( { categories, taxonomies } );
 	}
 
 	renderPostFormats() {
@@ -349,6 +349,7 @@ class EditorDrawer extends Component {
 				{ site && <QueryPostTypes siteId={ site.ID } /> }
 				{ site && <QuerySiteSettings siteId={ site.ID } /> }
 				{ this.renderStatus() }
+				{ this.renderCategories() }
 				{ this.renderTaxonomies() }
 				{ this.renderFeaturedImage() }
 				{ this.renderPageOptions() }

--- a/client/post-editor/media-modal/detail/detail-file-info.jsx
+++ b/client/post-editor/media-modal/detail/detail-file-info.jsx
@@ -7,7 +7,6 @@
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import React from 'react';
-import createFragment from 'react-addons-create-fragment';
 import classNames from 'classnames';
 
 /**
@@ -35,19 +34,17 @@ class EditorMediaModalDetailFileInfo extends React.Component {
 				break;
 
 			case 'dimensions':
-				value = createFragment( {
-					width: (
+				value = (
+					<span>
 						<abbr title={ this.props.translate( 'Width in pixels' ) }>
 							{ this.props.item.width }
 						</abbr>
-					),
-					separator: ' ✕ ',
-					height: (
+						{ ' ✕ ' }
 						<abbr title={ this.props.translate( 'Height in pixels' ) }>
 							{ this.props.item.height }
 						</abbr>
-					),
-				} );
+					</span>
+				);
 				break;
 
 			case 'date':

--- a/client/post-editor/media-modal/detail/detail-file-info.jsx
+++ b/client/post-editor/media-modal/detail/detail-file-info.jsx
@@ -34,17 +34,15 @@ class EditorMediaModalDetailFileInfo extends React.Component {
 				break;
 
 			case 'dimensions':
-				value = (
-					<span>
-						<abbr title={ this.props.translate( 'Width in pixels' ) }>
-							{ this.props.item.width }
-						</abbr>
-						{ ' ✕ ' }
-						<abbr title={ this.props.translate( 'Height in pixels' ) }>
-							{ this.props.item.height }
-						</abbr>
-					</span>
-				);
+				value = [
+					<abbr key="width" title={ this.props.translate( 'Width in pixels' ) }>
+						{ this.props.item.width }
+					</abbr>,
+					' ✕ ',
+					<abbr key="height" title={ this.props.translate( 'Height in pixels' ) }>
+						{ this.props.item.height }
+					</abbr>,
+				];
 				break;
 
 			case 'date':

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -874,10 +874,10 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000750"
+      "version": "1.0.30000751"
     },
     "caniuse-lite": {
-      "version": "1.0.30000750"
+      "version": "1.0.30000751"
     },
     "cardinal": {
       "version": "1.0.0",
@@ -6490,7 +6490,7 @@
       "version": "1.1.2"
     },
     "sntp": {
-      "version": "2.0.2"
+      "version": "2.1.0"
     },
     "social-logos": {
       "version": "2.0.0"
@@ -7142,7 +7142,7 @@
       "version": "1.0.0"
     },
     "unquoted-property-validator": {
-      "version": "1.0.1",
+      "version": "1.0.2",
       "dev": true
     },
     "unreachable-branch-transform": {

--- a/package.json
+++ b/package.json
@@ -122,7 +122,6 @@
     "qrcode.react": "0.6.1",
     "qs": "4.0.0",
     "react": "15.6.2",
-    "react-addons-create-fragment": "15.6.2",
     "react-click-outside": "2.3.1",
     "react-day-picker": "6.0.2",
     "react-dom": "15.6.2",


### PR DESCRIPTION
That addon contains the `createFragment` function, which [does the following](https://reactjs.org/docs/create-fragment.html): given an object of components, e.g. 

```js
    children = createFragment({
      left: props.leftChildren,
      right: props.rightChildren
    });
```

It adds the object keys as React `key`s to the components, and spits out an array consisting of these components. So I think its main use case is around working with arrays of components, which in turn is mostly relevant for ordering of sets of somewhat dynamically generated components, see https://reactjs.org/docs/create-fragment.html.

The fix is to add `key`s directly to those components. Easy example: https://github.com/Automattic/wp-calypso/pull/19105/files#diff-0e2c0c04cc568a7b0c3c3cb7c66b01c9

However, this can be tricky in some cases -- e.g. when we iterate over a list of inputs and want to produce a list of components, but there are more than just one component per input. Wrap in a `div` you say? `<script />` tags in `<head />` [I say](https://github.com/Automattic/wp-calypso/pull/19105/files#diff-370b76809f7f0f9d1c9eeb6ae359656cL49).

## To test: Check the relevant occurrences -- they should still work.

### Pages: Trash/Delete button in popover menu:

![image](https://user-images.githubusercontent.com/96308/31946325-d3307266-b8d1-11e7-8c60-0b55471b37e1.png)

### Editor Drawer: Categories

![image](https://user-images.githubusercontent.com/96308/31946463-34190e62-b8d2-11e7-91d9-86784391a54f.png)

### Editor Drawer: Taxonomies (example: Portfolio CPT with 'project' specific taxonomies)

![image](https://user-images.githubusercontent.com/96308/31946455-298a08b6-b8d2-11e7-8aef-316e208192b2.png)

### Media Modal: Dimensions ('5184 ✕ 3456' in the example screenshot)

![image](https://user-images.githubusercontent.com/96308/31946653-b1860d78-b8d2-11e7-9ced-035d4133e1b8.png)

### Media Library: Notices

Try e.g. uploading a video file to a site that doesn't have a plan that includes VideoPress.

![image](https://user-images.githubusercontent.com/96308/31946934-71e4e7d8-b8d3-11e7-8fab-c9bd37289ec2.png)

### `lib/embed-frame-markup/index.jsx`

This is the trickiest to test. It's used by TinyMCE to display embeds. Try embedding something...