### PR TITLE
Atomic Store: handle progress bar on Woo setup page better

### DIFF
--- a/client/extensions/woocommerce/app/dashboard/required-pages-setup-view.js
+++ b/client/extensions/woocommerce/app/dashboard/required-pages-setup-view.js
@@ -40,7 +40,7 @@ class RequiredPagesSetupView extends Component {
 				<SetupHeader
 					imageSource={ '/calypso/images/extensions/woocommerce/woocommerce-store-creation.svg' }
 					imageWidth={ 160 }
-					title={ translate( 'Setting up your store' ) }
+					title={ translate( 'Building your store' ) }
 					subtitle={ translate( "Give us a minute and we'll move right along." ) }
 				>
 					<ProgressBar value={ 100 } isPulsing />

--- a/client/extensions/woocommerce/app/dashboard/required-plugins-install-view.js
+++ b/client/extensions/woocommerce/app/dashboard/required-plugins-install-view.js
@@ -430,11 +430,8 @@ class RequiredPluginsInstallView extends Component {
 				<SetupHeader
 					imageSource={ '/calypso/images/extensions/woocommerce/woocommerce-store-creation.svg' }
 					imageWidth={ 160 }
-					title={ translate( 'Building your storefront' ) }
-					subtitle={ translate(
-						'We’ll be done with the behind-the-scenes work in a moment, ' +
-							'and then you can start adding products.'
-					) }
+					title={ translate( 'Building your store' ) }
+					subtitle={ translate( "Give us a minute and we'll move right along." ) }
 				>
 					<ProgressBar value={ progress } total={ totalSeconds } isPulsing />
 				</SetupHeader>

--- a/client/state/automated-transfer/reducer.js
+++ b/client/state/automated-transfer/reducer.js
@@ -10,7 +10,12 @@ import { get } from 'lodash';
  * Internal dependencies
  */
 import eligibility from './eligibility/reducer';
-import { combineReducers, keyedReducer, withSchemaValidation } from 'state/utils';
+import {
+	combineReducers,
+	keyedReducer,
+	withSchemaValidation,
+	withoutPersistence,
+} from 'state/utils';
 import { transferStates } from './constants';
 import { automatedTransfer as schema } from './schema';
 import {
@@ -36,15 +41,18 @@ export const status = ( state = null, action ) =>
 		state
 	);
 
-export const fetchingStatus = ( state = false, action ) =>
-	get(
-		{
-			[ REQUEST_STATUS ]: true,
-			[ REQUEST_STATUS_FAILURE ]: false,
-		},
-		action.type,
-		state
-	);
+export const fetchingStatus = withoutPersistence( ( state = false, action ) => {
+	switch ( action.type ) {
+		case REQUEST_STATUS:
+			return true;
+
+		case REQUEST_STATUS_FAILURE:
+			return false;
+
+		default:
+			return state;
+	}
+} );
 
 export const siteReducer = combineReducers( {
 	eligibility,

--- a/client/state/automated-transfer/test/reducer.js
+++ b/client/state/automated-transfer/test/reducer.js
@@ -14,6 +14,8 @@ import {
 	AUTOMATED_TRANSFER_ELIGIBILITY_UPDATE as ELIGIBILITY_UPDATE,
 	AUTOMATED_TRANSFER_STATUS_REQUEST as REQUEST_STATUS,
 	AUTOMATED_TRANSFER_STATUS_REQUEST_FAILURE as REQUEST_STATUS_FAILURE,
+	SERIALIZE,
+	DESERIALIZE,
 } from 'state/action-types';
 
 describe( 'state', () => {
@@ -44,6 +46,20 @@ describe( 'state', () => {
 					const action = { type: REQUEST_STATUS };
 
 					expect( fetchingStatus( null, action ) ).to.be.true;
+				} );
+
+				test( "should never persist whether it's fetching status", () => {
+					expect(
+						fetchingStatus( true, {
+							type: SERIALIZE,
+						} )
+					).to.be.null;
+
+					expect(
+						fetchingStatus( true, {
+							type: DESERIALIZE,
+						} )
+					).to.be.false;
 				} );
 			} );
 		} );


### PR DESCRIPTION
In this PR, we are adding the following improvements to the Woo setup page ("Store" in sidebar) in the Atomic Store signup flow (`/start/atomic-store`):
- always show some progress, even if site is not transferring yet (better UX)
- if navigated away from the Woo setup page (to main Calypso view) and back to the page, the progress bar should show proper position according to transfer status
- stop persisting the `fetchingStatus` reducer so that we always try to fetch transfer status on full Calypso reload if a site has `has_peding_automated_transfer` site option

## Testing

Go through the Atomic Store signup flow. After clicking on the "create my store" on the checkout-thank-you page, you should be taken to the Woo setup page. Can you see a little bit of progress bar which is pulsing?

Now, try navigating away from the page while transfer is still not finished. Then, navigate back to it (either clicking on the "Store" button in sidebar or by using browser's back button). The progress bar size should respond to particular transfer status.

Try doing a full page reload on the Woo setup page. Is the progress bar on a correct place (in relation to particular transfer status)? Does it move when transfer progresses on the backend?