### PR TITLE
Build: Replace JSON shims with environment provided JSON

### DIFF
--- a/client/lib/shims/json.js
+++ b/client/lib/shims/json.js
@@ -1,0 +1,5 @@
+/** @format */
+/**
+ * A shim that lets us replace JSON shims with the default provided JSON implementation
+ */
+export default JSON;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -183,6 +183,7 @@ const webpackConfig = {
 			global: 'window',
 		} ),
 		new webpack.NormalModuleReplacementPlugin( /^path$/, 'path-browserify' ),
+		new webpack.NormalModuleReplacementPlugin( /^(json3|jsonify)$/, 'lib/shims/json' ),
 		new webpack.IgnorePlugin( /^props$/ ),
 		new CopyWebpackPlugin( [
 			{ from: 'node_modules/flag-icon-css/flags/4x3', to: 'images/flags' },
@@ -273,10 +274,6 @@ if ( isDevelopment ) {
 } else {
 	webpackConfig.entry.build = path.join( __dirname, 'client', 'boot', 'app' );
 }
-
-webpackConfig.plugins.push(
-	new webpack.NormalModuleReplacementPlugin( /^(json3|jsonify)$/, 'lib/shims/json' )
-);
 
 if ( ! config.isEnabled( 'desktop' ) ) {
 	webpackConfig.plugins.push(

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -57,6 +57,7 @@ _.remove( babelConfig.env.test.plugins, elem => /babel-lodash-es/.test( elem ) )
  *
  * Providing webpack with these aliases instead of telling it to scan client/extensions for every
  * module resolution speeds up builds significantly.
+ * @returns {Object} a mapping of extension name to path
  */
 function getAliasesForExtensions() {
 	const extensionsDirectory = path.join( __dirname, 'client', 'extensions' );
@@ -272,6 +273,10 @@ if ( isDevelopment ) {
 } else {
 	webpackConfig.entry.build = path.join( __dirname, 'client', 'boot', 'app' );
 }
+
+webpackConfig.plugins.push(
+	new webpack.NormalModuleReplacementPlugin( /^(json3|jsonify)$/, 'lib/shims/json' )
+);
 
 if ( ! config.isEnabled( 'desktop' ) ) {
 	webpackConfig.plugins.push(


### PR DESCRIPTION
`JSON3` and `jsonify` are shims that polyfill missing and broken JSON implementations. We don't really have that problem in calypso, so replace them with the enviroment-provided JSON module. A shim for a shim.

You may notice that `json3` doesn't appear in our package.json; it's purely a transitive dependency, used by `socket.io` and a few other pieces. 

`jsonify` is pulled in by `json-stable-stringify`

```
Delta:
chunk                                stat_size            parsed_size            gzip_size
async-load-lib-happychat-connection   -43378 B  (-24.9%)      -8205 B  (-11.9%)    -3499 B  (-17.2%)
build                                 -12295 B   (-0.3%)      -3413 B   (-0.2%)    -1198 B   (-0.3%)
manifest                                  +0 B                   +0 B                 +0 B
```