### PR TITLE
Preview: remove unused code

### DIFF
--- a/client/my-sites/current-site/index.jsx
+++ b/client/my-sites/current-site/index.jsx
@@ -5,7 +5,6 @@
  */
 
 import React, { Component } from 'react';
-import classNames from 'classnames';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
@@ -20,7 +19,6 @@ import Button from 'components/button';
 import Card from 'components/card';
 import Site from 'blocks/site';
 import Gridicon from 'gridicons';
-import config from 'config';
 import SiteNotice from './notice';
 import CartStore from 'lib/cart/store';
 import { setLayoutFocus } from 'state/ui/layout-focus/actions';
@@ -33,7 +31,6 @@ import { recordTracksEvent } from 'state/analytics/actions';
 
 class CurrentSite extends Component {
 	static propTypes = {
-		isPreviewShowing: PropTypes.bool,
 		siteCount: PropTypes.number.isRequired,
 		setLayoutFocus: PropTypes.func.isRequired,
 		selectedSite: PropTypes.object,
@@ -91,37 +88,6 @@ class CurrentSite extends Component {
 		analytics.ga.recordEvent( 'Sidebar', 'Clicked Switch Site' );
 	};
 
-	previewSite = event => this.props.onClick && this.props.onClick( event );
-
-	renderSiteViewLink() {
-		if ( config.isEnabled( 'standalone-site-preview' ) ) {
-			return;
-		}
-
-		const { isPreviewShowing, selectedSite, translate } = this.props;
-
-		const viewText = selectedSite.is_previewable
-			? translate( 'Site Preview' )
-			: translate( 'View site' );
-
-		const viewIcon = selectedSite.is_previewable ? 'computer' : 'external';
-
-		return (
-			<a
-				href={ selectedSite.URL }
-				onClick={ this.previewSite }
-				className={ classNames( 'current-site__view-site', {
-					selected: isPreviewShowing,
-				} ) }
-				target="_blank"
-				rel="noopener noreferrer"
-			>
-				<span className="current-site__view-site-text">{ viewText }</span>
-				<Gridicon icon={ viewIcon } />
-			</a>
-		);
-	}
-
 	render() {
 		const { selectedSite, translate, anySiteSelected } = this.props;
 
@@ -158,7 +124,6 @@ class CurrentSite extends Component {
 				{ selectedSite ? (
 					<div>
 						<Site site={ selectedSite } />
-						{ this.renderSiteViewLink() }
 					</div>
 				) : (
 					<AllSites />

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -612,7 +612,7 @@ export class MySitesSidebar extends Component {
 			<div>
 				<SidebarMenu>
 					<ul>
-						{ config.isEnabled( 'standalone-site-preview' ) && this.preview() }
+						{ this.preview() }
 						{ this.stats() }
 						{ this.plan() }
 						{ this.store() }

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -34,7 +34,6 @@ import JetpackLogo from 'components/jetpack-logo';
 import { isPlan, isFreeTrial, isPersonal, isPremium, isBusiness } from 'lib/products-values';
 import { getCurrentUser } from 'state/current-user/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import { getCurrentLayoutFocus } from 'state/ui/layout-focus/selectors';
 import { setNextLayoutFocus, setLayoutFocus } from 'state/ui/layout-focus/actions';
 import {
 	canCurrentUser,
@@ -82,15 +81,6 @@ export class MySitesSidebar extends Component {
 		window.scrollTo( 0, 0 );
 	};
 
-	onPreviewSite = event => {
-		const { site } = this.props;
-		analytics.ga.recordEvent( 'Sidebar', 'Clicked View Site' );
-		if ( site.is_previewable && ! event.metaKey && ! event.ctrlKey ) {
-			event.preventDefault();
-			this.props.setLayoutFocus( 'preview' );
-		}
-	};
-
 	onViewSiteClick = event => {
 		const { isPreviewable, siteSuffix } = this.props;
 
@@ -128,10 +118,6 @@ export class MySitesSidebar extends Component {
 	};
 
 	isItemLinkSelected( paths ) {
-		if ( this.props.isPreviewShowing ) {
-			return false;
-		}
-
 		if ( ! Array.isArray( paths ) ) {
 			paths = [ paths ];
 		}
@@ -669,11 +655,7 @@ export class MySitesSidebar extends Component {
 		return (
 			<Sidebar>
 				<SidebarRegion>
-					<CurrentSite
-						allSitesPath={ this.props.allSitesPath }
-						isPreviewShowing={ this.props.isPreviewShowing }
-						onClick={ this.onPreviewSite }
-					/>
+					<CurrentSite allSitesPath={ this.props.allSitesPath } />
 					{ this.renderSidebarMenus() }
 				</SidebarRegion>
 				<SidebarFooter>{ this.addNewSite() }</SidebarFooter>
@@ -696,8 +678,6 @@ function mapStateToProps( state ) {
 		( isJetpackModuleActive( state, siteId, 'sharedaddy' ) &&
 			! isJetpackMinimumVersion( state, siteId, '3.4-dev' ) );
 
-	const isPreviewShowing = getCurrentLayoutFocus( state ) === 'preview';
-
 	const transferStatus = getAutomatedTransferStatus( state, siteId );
 	const hasSitePendingAT = hasSitePendingAutomatedTransfer( state, siteId );
 
@@ -714,7 +694,6 @@ function mapStateToProps( state ) {
 		isDomainOnly: isDomainOnlySite( state, selectedSiteId ),
 		isJetpack,
 		isPreviewable: isSitePreviewable( state, selectedSiteId ),
-		isPreviewShowing,
 		isSharingEnabledOnJetpackSite,
 		isSiteAutomatedTransfer: !! isSiteAutomatedTransfer( state, selectedSiteId ),
 		siteId,

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -94,7 +94,6 @@
 		"signup/domain-first-flow": true,
 		"signup/social": false,
 		"signup/social-management": true,
-		"standalone-site-preview": true,
 		"signup/wpcc": true,
 		"ui/first-view": false,
 		"upgrades/checkout": true,

--- a/config/development.json
+++ b/config/development.json
@@ -167,7 +167,6 @@
 		"signup/atomic-store-flow": true,
 		"signup/wpcc": true,
 		"simple-payments": true,
-		"standalone-site-preview": true,
 		"support-user": true,
 		"sync-handler": true,
 		"try/preconnect": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -108,7 +108,6 @@
 		"signup/atomic-store-flow": true,
 		"signup/wpcc": true,
 		"simple-payments": true,
-		"standalone-site-preview": true,
 		"support-user": true,
 		"sync-handler": true,
 		"ui/first-view": true,

--- a/config/production.json
+++ b/config/production.json
@@ -116,7 +116,6 @@
 		"signup/atomic-store-flow": true,
 		"signup/wpcc": true,
 		"simple-payments": true,
-		"standalone-site-preview": true,
 		"support-user": true,
 		"sync-handler": true,
 		"ui/first-view": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -123,7 +123,6 @@
 		"signup/atomic-store-flow": true,
 		"signup/wpcc": true,
 		"simple-payments": true,
-		"standalone-site-preview": true,
 		"support-user": true,
 		"sync-handler": true,
 		"ui/first-view": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -129,7 +129,6 @@
 		"signup/atomic-store-flow": true,
 		"signup/wpcc": true,
 		"simple-payments": true,
-		"standalone-site-preview": true,
 		"support-user": true,
 		"sync-handler": true,
 		"try/preconnect": true,


### PR DESCRIPTION
Removing what appears to be unused preview code for the site card component.

To test: 

- Attempt to open preview with View Site in My Site/s menu
- Click on other sidebar items and make sure highlighting still works in the menu
- Click the site card and make sure nothing happens

Props @lsinger 