### PR TITLE
Comments: extract the duplicated logic for renderCommentForm into a new component

### DIFF
--- a/client/blocks/comments/form-root.jsx
+++ b/client/blocks/comments/form-root.jsx
@@ -1,0 +1,56 @@
+/**
+ * @format
+ */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import PropTypes from 'prop-types';
+import { noop, some } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import PostCommentForm from './form';
+
+/*
+ * A component for displaying a comment form at the root of a conversation.
+ */
+const PostCommentFormRoot = ( {
+	post,
+	commentText,
+	activeReplyCommentId,
+	commentsTree,
+	onUpdateCommentText = noop,
+} ) => {
+	// Are we displaying the comment form elsewhere? If so, don't render the root form.
+	if (
+		activeReplyCommentId ||
+		some( commentsTree, comment => {
+			return comment.data && comment.data.isPlaceholder && ! comment.data.parent;
+		} )
+	) {
+		return null;
+	}
+
+	return (
+		<PostCommentForm
+			ref="postCommentForm"
+			post={ post }
+			parentCommentId={ null }
+			commentText={ commentText }
+			onUpdateCommentText={ onUpdateCommentText }
+		/>
+	);
+};
+
+PostCommentFormRoot.propTypes = {
+	post: PropTypes.object.isRequired,
+	commentText: PropTypes.string,
+	activeReplyCommentId: PropTypes.number,
+	commentsTree: PropTypes.object,
+	onUpdateCommentText: PropTypes.func,
+};
+
+export default PostCommentFormRoot;

--- a/client/blocks/comments/form-root.jsx
+++ b/client/blocks/comments/form-root.jsx
@@ -36,7 +36,6 @@ const PostCommentFormRoot = ( {
 
 	return (
 		<PostCommentForm
-			ref="postCommentForm"
 			post={ post }
 			parentCommentId={ null }
 			commentText={ commentText }

--- a/client/blocks/comments/post-comment-list.jsx
+++ b/client/blocks/comments/post-comment-list.jsx
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 import { translate } from 'i18n-calypso';
-import { get, size, takeRight, delay, some } from 'lodash';
+import { get, size, takeRight, delay } from 'lodash';
 
 /**
  * Internal dependencies
@@ -21,7 +21,7 @@ import { requestPostComments, requestComment, setActiveReply } from 'state/comme
 import { NUMBER_OF_COMMENTS_PER_FETCH } from 'state/comments/constants';
 import { recordAction, recordGaEvent, recordTrack } from 'reader/stats';
 import PostComment from './post-comment';
-import PostCommentForm from './form';
+import PostCommentFormRoot from './form-root';
 import CommentCount from './comment-count';
 import SegmentedControl from 'components/segmented-control';
 import SegmentedControlItem from 'components/segmented-control/item';
@@ -277,31 +277,6 @@ class PostCommentList extends React.Component {
 		);
 	};
 
-	renderCommentForm = () => {
-		const { post, commentsTree } = this.props;
-		const commentText = this.state.commentText;
-
-		// Are we displaying the comment form at the top-level?
-		if (
-			this.props.activeReplyCommentId ||
-			some( commentsTree, comment => {
-				return comment.data && comment.data.isPlaceholder && ! comment.data.parent;
-			} )
-		) {
-			return null;
-		}
-
-		return (
-			<PostCommentForm
-				ref="postCommentForm"
-				post={ post }
-				parentCommentId={ null }
-				commentText={ commentText }
-				onUpdateCommentText={ this.onUpdateCommentText }
-			/>
-		);
-	};
-
 	scrollToComment = () => {
 		const comment = window.document.getElementById( window.location.hash.substring( 1 ) );
 		comment.scrollIntoView();
@@ -460,7 +435,13 @@ class PostCommentList extends React.Component {
 						} ) }
 					</span>
 				) }
-				{ this.renderCommentForm() }
+				<PostCommentFormRoot
+					post={ this.props.post }
+					commentsTree={ this.props.commentsTree }
+					commentText={ this.state.commentText }
+					onUpdateCommentText={ this.onUpdateCommentText }
+					activeReplyCommentId={ this.props.activeReplyCommentId }
+				/>
 			</div>
 		);
 	}

--- a/client/blocks/conversations/list.jsx
+++ b/client/blocks/conversations/list.jsx
@@ -5,19 +5,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import {
-	map,
-	zipObject,
-	fill,
-	size,
-	filter,
-	get,
-	compact,
-	partition,
-	some,
-	min,
-	noop,
-} from 'lodash';
+import { map, zipObject, fill, size, filter, get, compact, partition, min, noop } from 'lodash';
 
 /***
  * Internal dependencies
@@ -34,7 +22,7 @@ import {
 } from 'state/comments/selectors';
 import ConversationCaterpillar from 'blocks/conversation-caterpillar';
 import { recordAction, recordGaEvent, recordTrack } from 'reader/stats';
-import PostCommentForm from 'blocks/comments/form';
+import PostCommentFormRoot from 'blocks/comments/form-root';
 import { requestPostComments, requestComment, setActiveReply } from 'state/comments/actions';
 
 /**
@@ -211,31 +199,6 @@ export class ConversationCommentList extends React.Component {
 		this.setActiveReplyComment( null );
 	};
 
-	renderCommentForm = () => {
-		const { post, commentsTree } = this.props;
-		const commentText = this.state.commentText;
-
-		// Are we displaying the comment form at the top-level?
-		if (
-			this.props.activeReplyCommentId ||
-			some( commentsTree, comment => {
-				return comment.data && comment.data.isPlaceholder && ! comment.data.parent;
-			} )
-		) {
-			return null;
-		}
-
-		return (
-			<PostCommentForm
-				ref="postCommentForm"
-				post={ post }
-				parentCommentId={ null }
-				commentText={ commentText }
-				onUpdateCommentText={ this.onUpdateCommentText }
-			/>
-		);
-	};
-
 	render() {
 		const { commentsTree, post, enableCaterpillar } = this.props;
 
@@ -283,7 +246,13 @@ export class ConversationCommentList extends React.Component {
 							/>
 						);
 					} ) }
-					{ this.renderCommentForm() }
+					<PostCommentFormRoot
+						post={ this.props.post }
+						commentsTree={ this.props.commentsTree }
+						commentText={ this.state.commentText }
+						onUpdateCommentText={ this.onUpdateCommentText }
+						activeReplyCommentId={ this.props.activeReplyCommentId }
+					/>
 				</ul>
 			</div>
 		);


### PR DESCRIPTION
When we render a comment form at the root of a thread, we do some extra checks:
- is there an active reply comment set? (i.e. are we displaying a reply box elsewhere in the thread?)
- do we have a comment placeholder set? (i.e. do we have a pending comment elsewhere in the thread, which usually indicates a failed attempt to post a comment?)

If either of those checks is `true`, we don't display the comment box at the root level.

Currently this logic is wrapped up in a function `renderCommentForm`, which is duplicated in PostCommentList and ConversationsList.

This PR creates a new component that performs the above checks and splits out a PostCommentForm where appropriate. It reduces code duplication and addresses the `renderSomething` code smell.

### To test

Try posting a comment at the root of a thread in both a regular comments thread, e.g.:

http://calypso.localhost:3000/read/feeds/40474296/posts/1385874605

and in the Conversations tool:

http://calypso.localhost:3000/read/conversations

There should be no functional changes.