### PR TITLE
Activity Log: fade days/items before the Rewind dialog insertion point

### DIFF
--- a/client/my-sites/stats/activity-log-day/style.scss
+++ b/client/my-sites/stats/activity-log-day/style.scss
@@ -41,6 +41,7 @@
 
 	.foldable-card.card.is-expanded {
 		box-shadow: none;
+		margin: 0;
 
 		.foldable-card__header {
 			box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ),
@@ -86,3 +87,34 @@
 	}
 }
 
+.activity-log-day, .activity-log-item {
+	position: relative;
+
+	&:before {
+		content: "";
+		position: absolute;
+		top: 73px;
+		height: 16px;
+		left: 33px;
+		width: 2px;
+		background-color: lighten( $gray, 20% );
+
+		@include breakpoint( "<480px" ) {
+			left: 29px;
+		}
+	}
+}
+
+.activity-log-day.is-empty:before {
+	top: 48px;
+}
+
+.activity-log-item:last-of-type:before {
+	height: 41px;
+}
+
+.activity-log-item__restore-confirm:before {
+	bottom: 0;
+	height: auto;
+	top: 57px;
+}

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -4,6 +4,7 @@
  */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 import config from 'config';
 import debugFactory from 'debug';
 import scrollTo from 'lib/scroll-to';
@@ -353,7 +354,15 @@ class ActivityLog extends Component {
 			);
 		}
 
-		return <section className="activity-log__wrapper">{ activityDays }</section>;
+		return (
+			<section
+				className={ classNames( 'activity-log__wrapper', {
+					'rewind-requested': this.props.requestedRestoreActivity,
+				} ) }
+			>
+				{ activityDays }
+			</section>
+		);
 	}
 
 	renderMonthNavigation( position ) {

--- a/client/my-sites/stats/activity-log/style.scss
+++ b/client/my-sites/stats/activity-log/style.scss
@@ -28,3 +28,15 @@
 		max-width: 200px;
 	}
 }
+
+.rewind-requested .activity-log-day:not(.has-rewind-dialog),
+.has-rewind-dialog .activity-log-item,
+.has-rewind-dialog > .foldable-card > .foldable-card__header {
+	opacity: .5;
+}
+
+.has-rewind-dialog .activity-log-item__restore-confirm,
+.activity-log-item__restore-confirm ~ .activity-log-item,
+.rewind-requested .has-rewind-dialog ~ .activity-log-day {
+	opacity: 1;
+}

--- a/client/my-sites/stats/activity-log/style.scss
+++ b/client/my-sites/stats/activity-log/style.scss
@@ -1,23 +1,5 @@
 // Activity Log
 
-.activity-log__wrapper {
-	position: relative;
-
-	&:before {
-		content: "";
-		position: absolute;
-		top: 0;
-		bottom: 0;
-		left: 33px;
-		width: 2px;
-		background-color: lighten( $gray, 20% );
-
-		@include breakpoint( "<480px" ) {
-			left: 29px;
-		}
-	}
-}
-
 .activity-log__rewind-toggle {
 	margin-bottom: 18px;
 }


### PR DESCRIPTION
Related #18745

This PR enhances what happens visually to the days and items in timeline when a rewind is requested and the Rewind dialog is inserted:
- adds a `.rewind-requested` CSS class to content wrapper when a Rewind dialog is displayed
- days and items before this inserted Rewind dialog will be faded
- replaces how the vertical line is created so it doesn't show behind when days and items are faded

<img width="317" alt="captura de pantalla 2017-10-24 a la s 14 41 36" src="https://user-images.githubusercontent.com/1041600/31959881-626ab12c-b8cc-11e7-8fd3-93f6badc7702.png">
<img width="532" alt="captura de pantalla 2017-10-24 a la s 14 41 14" src="https://user-images.githubusercontent.com/1041600/31959882-62ad2d22-b8cc-11e7-9b50-8d2cecd3a5ae.png">
<img width="362" alt="captura de pantalla 2017-10-24 a la s 14 41 45" src="https://user-images.githubusercontent.com/1041600/31959883-62ecc2fc-b8cc-11e7-9888-9c72bc808f25.png">
