### PR TITLE
Framework: Bump social-logos version to 2.x

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -6523,7 +6523,7 @@
       "version": "2.0.2"
     },
     "social-logos": {
-      "version": "1.0.1"
+      "version": "2.0.0"
     },
     "socket.io": {
       "version": "1.4.5",

--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
     "rtlcss": "2.0.5",
     "sanitize-html": "1.11.1",
     "semver": "5.1.0",
-    "social-logos": "1.0.1",
+    "social-logos": "2.0.0",
     "socket.io-client": "1.4.5",
     "source-map": "0.1.39",
     "source-map-support": "0.3.2",


### PR DESCRIPTION
To ensure compatibility with React 16. Companion PR: https://github.com/Automattic/social-logos/pull/51.

To test: Run Calypso, verify it works. Try something social-logos heavy -- e.g. `/sharing/:site`

![image](https://user-images.githubusercontent.com/96308/31961368-cfd37130-b8fa-11e7-9044-539d2cf39f88.png)
