### PR TITLE
State/keyed reducer global actions

### DIFF
--- a/client/state/README.md
+++ b/client/state/README.md
@@ -147,6 +147,37 @@ dispatch( { type: DELETE, username: 'hunter02' } );
 state.users === {}
 ```
 
+Finally, it's sometimes desirable to apply specific actions to all items in the collection.
+In these cases we can tell the `keyedReducer` which actions are in this class.
+Even without the necessary key in the action they will still get applied.
+For example, each item may have a custom persistence need or an action may have related data which is applicable to the items being reduced in this collection.
+
+For these cases we can simply add in a list of global action types.
+
+```js
+const hexPersister = ( state = 0, { type } ) => {
+	switch ( type ) {
+		case INCREMENT:
+			return state + 1;
+		
+		case DECREMENT:
+			return state - 1;
+		
+		case DESERIALIZE:
+			return parseInt( state, 16 );
+		
+		case SERIALIZE:
+			return state.toString( 16 );
+		
+		default:
+			return state;
+	}
+}
+
+const hexNumbers = keyedReducer( 'counterId', hexPersister, [ DESERIALIZE, SERIALIZE ] );
+hexNumbers.hasCustomPersistence = true;
+```
+
 ### withSchemaValidation( schema, reducer )
 
 When Calypso boots up it loads the last-known state out of persistent storage in the browser.

--- a/client/state/test/utils.js
+++ b/client/state/test/utils.js
@@ -351,6 +351,71 @@ describe( 'utils', () => {
 			const keyed = keyedReducer( 'name', age );
 			expect( keyed( { 10: 10 }, remove( '10' ) ) ).to.eql( {} );
 		} );
+
+		test( 'should apply global actions to every item', () => {
+			const counter = ( state = 0, { type } ) => {
+				switch ( type ) {
+					case 'INC':
+						return state + 1;
+					case 'DESERIALIZE':
+						return parseInt( state, 16 );
+					case 'SERIALIZE':
+						return state.toString( 16 );
+					default:
+						return state;
+				}
+			};
+
+			const keyed = keyedReducer( 'id', counter, [ 'DESERIALIZE', 'SERIALIZE' ] );
+
+			const prev = { 14: 5, 23: 19 };
+
+			expect( keyed( prev, { type: 'INC', id: 14 } ) ).to.eql( { 14: 6, 23: 19 } );
+			expect( keyed( prev, { type: 'SERIALIZE' } ) ).to.eql( { 14: '5', 23: '13' } );
+			expect( keyed( prev, { type: 'DESERIALIZE' } ) ).to.eql( { 14: 5, 23: 25 } );
+		} );
+
+		test( 'should not apply global actions if not whitelisted', () => {
+			const counter = ( state = 0, { type } ) => {
+				switch ( type ) {
+					case 'INC':
+						return state + 1;
+					case 'DESERIALIZE':
+						return parseInt( state, 16 );
+					case 'SERIALIZE':
+						return state.toString( 16 );
+					default:
+						return state;
+				}
+			};
+
+			const keyed = keyedReducer( 'id', counter );
+
+			const prev = { 14: 5, 23: 19 };
+
+			expect( keyed( prev, { type: 'INC', id: 14 } ) ).to.eql( { 14: 6, 23: 19 } );
+			expect( keyed( prev, { type: 'SERIALIZE' } ) ).to.equal( prev );
+			expect( keyed( prev, { type: 'DESERIALIZE' } ) ).to.equal( prev );
+		} );
+
+		test( 'should prune items after global actions are applied', () => {
+			const counter = ( state = 0, { type } ) => {
+				switch ( type ) {
+					case 'INC':
+						return state + 1;
+					case 'PURGE':
+						return state <= 10 ? state : undefined;
+					default:
+						return state;
+				}
+			};
+
+			const keyed = keyedReducer( 'id', counter, [ 'PURGE' ] );
+
+			const prev = { 14: 5, 23: 19 };
+
+			expect( keyed( prev, { type: 'PURGE' } ) ).to.eql( { 14: 5 } );
+		} );
 	} );
 
 	describe( '#withSchemaValidation', () => {

--- a/client/state/utils.js
+++ b/client/state/utils.js
@@ -5,7 +5,17 @@
  */
 
 import validator from 'is-my-json-valid';
-import { merge, flow, partialRight, reduce, isEqual, omit } from 'lodash';
+import {
+	flow,
+	includes,
+	isEqual,
+	mapValues,
+	merge,
+	partialRight,
+	omit,
+	omitBy,
+	reduce,
+} from 'lodash';
 import { combineReducers as combine } from 'redux'; // eslint-disable-line wpcalypso/import-no-redux-combine-reducers
 import LRU from 'lru-cache';
 
@@ -42,8 +52,12 @@ export function isValidStateWithSchema( state, schema ) {
  * previous state.
  *
  * If some action should apply to every single item
- * in the map of keyed objects, this utility cannot be
- * used as it will only reduce the referenced item.
+ * in the map of keyed objects, then that action type
+ * should be supplied in the list of `globalActions`
+ * These will apply to every item in the collection
+ * and they may not have the necessary key: for
+ * example, the DESERIALIZE and SERIALIZE actions
+ * may apply to all items.
  *
  * @example
  * const age = ( state = 0, action ) =>
@@ -72,11 +86,18 @@ export function isValidStateWithSchema( state, schema ) {
  *     }
  * }
  *
- * @param {string} keyName name of key in action referencing item in state map
- * @param {function} reducer applied to referenced item in state map
- * @return {function} super-reducer applying reducer over map of keyed items
+ * @example
+ * const reducer = keyedReducer( 'username', userReducer, [ DESERIALIZE, SERIALIZE ] );
+ * reducer.hasCustomerPersistence = true;
+ *
+ * // now every item can decide what to do for persistence
+ *
+ * @param {String} keyName name of key in action referencing item in state map
+ * @param {Function} reducer applied to referenced item in state map
+ * @param {Array} globalActions set of types which apply to every item in the collection
+ * @return {Function} super-reducer applying reducer over map of keyed items
  */
-export const keyedReducer = ( keyName, reducer ) => {
+export const keyedReducer = ( keyName, reducer, globalActions ) => {
 	// some keys are invalid
 	if ( 'string' !== typeof keyName ) {
 		throw new TypeError(
@@ -96,7 +117,16 @@ export const keyedReducer = ( keyName, reducer ) => {
 		);
 	}
 
+	const initialState = reducer( undefined, { type: '@@calypso/INIT' } );
+
 	return ( state = {}, action ) => {
+		if ( globalActions && includes( globalActions, action.type ) ) {
+			return omitBy(
+				mapValues( state, item => reducer( item, action ) ),
+				a => a === undefined || a === initialState
+			);
+		}
+
 		// don't allow coercion of key name: null => 0
 		if ( ! action.hasOwnProperty( keyName ) ) {
 			return state;
@@ -114,7 +144,6 @@ export const keyedReducer = ( keyName, reducer ) => {
 		// pass the old sub-state from that item into the reducer
 		// we need this to update state and also to compare if
 		// we had any changes, thus the initialState
-		const initialState = reducer( undefined, { type: '@@calypso/INIT' } );
 		const oldItemState = state[ itemKey ];
 		const newItemState = reducer( oldItemState, action );
 


### PR DESCRIPTION
Something I have pondered since originally implementing the
`keyedReducer()` is to allow an optional list of global actions
which should apply to every item in the collection. Namely this
has come up with serialization but also at some point in time
with pruning elements based on some other action (imagine removing all
comments for a given post when the post is trashed).

In this PR I've added the list of global actions to the `keyedReducer()`
and it will apply those action types to all items, removing ones which
return `undefined` or `initialState`.

We can note that this will _always_ return a new `state` atom. I chose
this instead of performing deep equality at the global level because I
figured that it would actually be faster to simply return a new object
than to deeply compare; we shouldn't expect global actions to occur too
frequently.

This is prompted by work in the **Activity Log** state.

**Testing**

This should include no changes in any behavior in Calypso as nothing is
yet build upon these changes. Therefore any difference in behavior or
any glitch or any failing test is likely an indication that I neglected to
foresee the consequences of the change.