### PR TITLE
Rewind: Update existing state, refactor

### DIFF
--- a/client/state/activity-log/log/reducer.js
+++ b/client/state/activity-log/log/reducer.js
@@ -1,41 +1,29 @@
 /** @format */
 /**
- * External dependencies
- */
-import { mapValues } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import ActivityQueryManager from 'lib/query-manager/activity';
 import { ACTIVITY_LOG_UPDATE, DESERIALIZE, SERIALIZE } from 'state/action-types';
-import { createReducer, isValidStateWithSchema } from 'state/utils';
+import { isValidStateWithSchema, keyedReducer } from 'state/utils';
 import { logItemsSchema } from './schema';
 
-export const logItems = createReducer(
-	{},
-	{
-		[ ACTIVITY_LOG_UPDATE ]: ( state, { data, found, query, siteId } ) => {
-			return state[ siteId ]
-				? {
-						...state,
-						[ siteId ]: state[ siteId ].receive( data, { found, query } ),
-					}
-				: {
-						...state,
-						[ siteId ]: new ActivityQueryManager().receive( data, { found, query } ),
-					};
-		},
-		[ DESERIALIZE ]: state => {
-			if ( ! isValidStateWithSchema( state, logItemsSchema ) ) {
-				return {};
-			}
-			return mapValues( state, ( { data, options } ) => {
-				return new ActivityQueryManager( data, options );
-			} );
-		},
-		[ SERIALIZE ]: state => {
-			return mapValues( state, ( { data, options } ) => ( { data, options } ) );
-		},
+export const logItem = ( state = undefined, { type, data, found, query } ) => {
+	switch ( type ) {
+		case ACTIVITY_LOG_UPDATE:
+			return ( state || new ActivityQueryManager() ).receive( data, { found, query } );
+
+		case DESERIALIZE:
+			return isValidStateWithSchema( state, logItemsSchema )
+				? new ActivityQueryManager( state.data, state.options )
+				: undefined;
+
+		case SERIALIZE:
+			return { data: state.data, options: state.options };
+
+		default:
+			return state;
 	}
-);
+};
+
+export const logItems = keyedReducer( 'siteId', logItem, [ DESERIALIZE, SERIALIZE ] );
+logItems.hasCustomPersistence = true;

--- a/client/state/activity-log/log/schema.js
+++ b/client/state/activity-log/log/schema.js
@@ -40,55 +40,49 @@ const activityItemSchema = {
 export const logItemsSchema = {
 	type: 'object',
 	additionalProperties: false,
-	patternProperties: {
-		'^\\d+$': {
+	properties: {
+		data: {
 			type: 'object',
 			additionalProperties: false,
+			required: [ 'items', 'queries' ],
 			properties: {
-				data: {
+				items: {
+					patternProperties: {
+						'^.+$': activityItemSchema,
+					},
+				},
+				queries: {
 					type: 'object',
 					additionalProperties: false,
-					required: [ 'items', 'queries' ],
-					properties: {
-						items: {
-							patternProperties: {
-								'^.+$': activityItemSchema,
-							},
-						},
-						queries: {
+					patternProperties: {
+						// Query key pairs
+						'^\\[.*\\]$': {
 							type: 'object',
 							additionalProperties: false,
-							patternProperties: {
-								// Query key pairs
-								'^\\[.*\\]$': {
-									type: 'object',
-									additionalProperties: false,
-									required: [ 'itemKeys' ],
-									properties: {
-										itemKeys: {
-											type: 'array',
-											items: {
-												type: 'string',
-											},
-										},
-										found: {
-											type: 'integer',
-										},
+							required: [ 'itemKeys' ],
+							properties: {
+								itemKeys: {
+									type: 'array',
+									items: {
+										type: 'string',
 									},
+								},
+								found: {
+									type: 'integer',
 								},
 							},
 						},
 					},
 				},
-				options: {
-					type: 'object',
-					additionalProperties: false,
-					required: [ 'itemKey' ],
-					properties: {
-						itemKey: {
-							type: 'string',
-						},
-					},
+			},
+		},
+		options: {
+			type: 'object',
+			additionalProperties: false,
+			required: [ 'itemKey' ],
+			properties: {
+				itemKey: {
+					type: 'string',
 				},
 			},
 		},

--- a/client/state/activity-log/rewind-status/reducer.js
+++ b/client/state/activity-log/rewind-status/reducer.js
@@ -10,25 +10,37 @@ import {
 	REWIND_STATUS_ERROR,
 	REWIND_STATUS_UPDATE,
 } from 'state/action-types';
-import { createReducer, keyedReducer } from 'state/utils';
+import { keyedReducer } from 'state/utils';
 
-export const rewindStatus = keyedReducer(
-	'siteId',
-	createReducer( undefined, {
-		[ REWIND_STATUS_ERROR ]: () => undefined,
-		[ REWIND_STATUS_UPDATE ]: ( state, { status } ) => status,
-		[ REWIND_ACTIVATE_SUCCESS ]: state => ( {
-			...state,
-			active: true,
-		} ),
-	} )
-);
+export const rewindStatusItem = ( state = undefined, { type, status } ) => {
+	switch ( type ) {
+		case REWIND_STATUS_ERROR:
+			return undefined;
+
+		case REWIND_STATUS_UPDATE:
+			return status;
+
+		case REWIND_ACTIVATE_SUCCESS:
+			return { ...state, active: true };
+
+		default:
+			return state;
+	}
+};
+export const rewindStatus = keyedReducer( 'siteId', rewindStatusItem );
 rewindStatus.schema = rewindStatusSchema;
 
-export const rewindStatusError = keyedReducer(
-	'siteId',
-	createReducer( undefined, {
-		[ REWIND_STATUS_ERROR ]: ( state, { error } ) => error,
-		[ REWIND_STATUS_UPDATE ]: () => undefined,
-	} )
-);
+export const rewindStatusErrorItem = ( state = undefined, { type, error } ) => {
+	switch ( type ) {
+		case REWIND_STATUS_ERROR:
+			return error;
+
+		case REWIND_STATUS_UPDATE:
+			return undefined;
+
+		default:
+			return state;
+	}
+};
+
+export const rewindStatusError = keyedReducer( 'siteId', rewindStatusErrorItem );

--- a/client/state/data-layer/wpcom/sites/activity/from-api.js
+++ b/client/state/data-layer/wpcom/sites/activity/from-api.js
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import { get, head, map, split } from 'lodash';
+import { get, map } from 'lodash';
 
 /**
  * Internal dependencies
@@ -35,33 +35,26 @@ export function transformer( apiResponse ) {
  * @return {object}       Processed Activity item ready for use in UI
  */
 export function processItem( item ) {
-	return {
-		...processItemBase( item ),
-	};
-}
+	const published = item.published;
+	const actor = item.actor;
 
-export function processItemActor( item ) {
 	return {
-		actorAvatarUrl: get( item, [ 'actor', 'icon', 'url' ], DEFAULT_GRAVATAR_URL ),
-		actorName: get( item, [ 'actor', 'name' ], '' ),
-		actorRemoteId: get( item, [ 'actor', 'external_user_id' ], 0 ),
-		actorRole: get( item, [ 'actor', 'role' ], '' ),
-		actorType: get( item, [ 'actor', 'type' ], '' ),
-		actorWpcomId: get( item, [ 'actor', 'wpcom_user_id' ], 0 ),
-	};
-}
+		/* activity actor */
+		actorAvatarUrl: get( actor, 'icon.url', DEFAULT_GRAVATAR_URL ),
+		actorName: get( actor, 'name', '' ),
+		actorRemoteId: get( actor, 'external_user_id', 0 ),
+		actorRole: get( actor, 'role', '' ),
+		actorType: get( actor, 'type', '' ),
+		actorWpcomId: get( actor, 'wpcom_user_id', 0 ),
 
-export function processItemBase( item ) {
-	const published = get( item, 'published' );
-	return {
-		...processItemActor( item ),
+		/* base activity info */
 		activityDate: published,
-		activityGroup: head( split( get( item, 'name' ), '__', 1 ) ),
+		activityGroup: ( item.name || '' ).split( '__', 1 )[ 0 ], // split always returns at least one item
 		activityIcon: get( item, 'gridicon', DEFAULT_GRIDICON ),
-		activityId: get( item, 'activity_id' ),
+		activityId: item.activity_id,
 		activityIsRewindable: item.is_rewindable,
-		activityName: get( item, 'name' ),
-		activityStatus: get( item, 'status' ),
+		activityName: item.name,
+		activityStatus: item.status,
 		activityTitle: get( item, 'summary', '' ),
 		activityTs: Date.parse( published ),
 	};

--- a/client/state/data-layer/wpcom/sites/activity/index.js
+++ b/client/state/data-layer/wpcom/sites/activity/index.js
@@ -2,8 +2,7 @@
 /**
  * External dependencies
  */
-import debugFactory from 'debug';
-import { get, includes, omitBy, reduce } from 'lodash';
+import { omitBy } from 'lodash';
 import { translate } from 'i18n-calypso';
 
 /**

--- a/client/state/data-layer/wpcom/sites/activity/index.js
+++ b/client/state/data-layer/wpcom/sites/activity/index.js
@@ -3,7 +3,7 @@
  * External dependencies
  */
 import debugFactory from 'debug';
-import { get, includes, reduce } from 'lodash';
+import { get, includes, omitBy, reduce } from 'lodash';
 import { translate } from 'i18n-calypso';
 
 /**
@@ -16,37 +16,8 @@ import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { errorNotice } from 'state/notices/actions';
 
-/**
- * Module constants
- */
-const debug = debugFactory( 'calypso:data-layer:activity' );
-const CALYPSO_TO_API_PARAMS = {
-	dateEnd: 'date_end',
-	dateStart: 'date_start',
-};
-const KNOWN_API_PARAMS = [ 'action', 'date_end', 'date_start', 'group', 'name', 'number' ];
-
 export const handleActivityLogRequest = ( { dispatch }, action ) => {
-	const { siteId } = action;
-
-	const query = reduce(
-		action.params,
-		( acc, value, param ) => {
-			const paramToStore = get( CALYPSO_TO_API_PARAMS, param, param );
-
-			if ( includes( KNOWN_API_PARAMS, paramToStore ) ) {
-				return {
-					...acc,
-					[ paramToStore ]: value,
-				};
-			}
-
-			return acc;
-		},
-		{}
-	);
-
-	debug( 'Handling activity request', query );
+	const { params = {}, siteId } = action;
 
 	// Clear current logs, this will allow loading placeholders to appear
 	dispatch( activityLogUpdate( siteId, undefined ) );
@@ -57,7 +28,17 @@ export const handleActivityLogRequest = ( { dispatch }, action ) => {
 				apiNamespace: 'wpcom/v2',
 				method: 'GET',
 				path: `/sites/${ siteId }/activity`,
-				query,
+				query: omitBy(
+					{
+						action: params.action,
+						date_end: params.date_end || params.dateEnd,
+						date_start: params.date_start || params.dateStart,
+						group: params.group,
+						name: params.name,
+						number: params.number,
+					},
+					a => a === undefined
+				),
 			},
 			action
 		)


### PR DESCRIPTION
This is a preparatory PR for work on the **Activity Log**.

@see #18944 for prior work

In this PR we're simplifying some reducer code and trying to simplify
thr structure to make it easier to see what's occurring in state while
the app is running and loading in remote data.

> **Depends on #19119** for the changes to `keyedReducer`

**Testing**
This should introduce no changes in behavior. A smoke-test should suffice (with the automated tests passing, of course).