### PR TITLE
updating Authy's download page link (from current 404 link)

### DIFF
--- a/client/me/security-2fa-enable/index.jsx
+++ b/client/me/security-2fa-enable/index.jsx
@@ -277,7 +277,7 @@ class Security2faEnable extends React.Component {
 							components: {
 								authyLink: (
 									<a
-										href="https://www.authy.com/users/"
+										href="https://www.authy.com/download/"
 										target="_blank"
 										rel="noopener noreferrer"
 										onClick={ function() {


### PR DESCRIPTION
Reported in #18859

The download link for Authy is currently broken and needs updating.

This PR updates the link from https://www.authy.com/users/ (broken) to https://www.authy.com/download/ (works!)

![screenshot](https://user-images.githubusercontent.com/22805865/31585579-2a07f97a-b192-11e7-9a3c-d16f48e07133.png)