### PR TITLE
Fix tests which was broken because of a missing comma.

### DIFF
--- a/client/components/happiness-support/test/index.jsx
+++ b/client/components/happiness-support/test/index.jsx
@@ -36,7 +36,7 @@ describe( 'HappinessSupport', () => {
 		const content = wrapper.find( 'p.happiness-support__text' );
 		expect( content ).to.have.length( 1 );
 		expect( content.props().children ).to.equal(
-			'Translated: {{strong}}Need help?{{/strong}} A Happiness Engineer can answer questions about your site, your account or how to do just about anything.' // eslint-disable-line max-len
+			'Translated: {{strong}}Need help?{{/strong}} A Happiness Engineer can answer questions about your site, your account, or how to do just about anything.' // eslint-disable-line max-len
 		);
 	} );
 


### PR DESCRIPTION
@see #19048

In #19048 the message for help content was updated with a comma but the
corresopnding test wasn't updated, causing **master** to fail (as well
as any PRs built from it).

This update simply adds the comma into the test.

While these tests do have value, they also bring maintenance burden.
Right now its only value is making sure we don't accidentally change
a string constant, and the test failed to do that.