### PR TITLE
Framework: convert Card back to component so we can hold refs

### DIFF
--- a/client/components/card/index.jsx
+++ b/client/components/card/index.jsx
@@ -1,62 +1,63 @@
+/** @format */
+
 /**
  * External dependencies
- *
- * @format
  */
-
-import React from 'react';
+import React, { Component } from 'react';
 import { assign, omit } from 'lodash';
 import classnames from 'classnames';
 import Gridicon from 'gridicons';
 import PropTypes from 'prop-types';
 
-const Card = props => {
-	const { href, tagName, target, compact, children, highlight } = props;
+class Card extends Component {
+	static propTypes = {
+		className: PropTypes.string,
+		href: PropTypes.string,
+		tagName: PropTypes.string,
+		target: PropTypes.string,
+		compact: PropTypes.bool,
+		children: PropTypes.node,
+		highlight: PropTypes.oneOf( [ false, 'error', 'info', 'success', 'warning' ] ),
+	};
 
-	const highlightClass = highlight ? 'is-' + highlight : false;
+	static defaultProps = {
+		tagName: 'div',
+		highlight: false,
+	};
 
-	const className = classnames(
-		'card',
-		props.className,
-		{
-			'is-card-link': !! href,
-			'is-compact': compact,
-		},
-		highlightClass
-	);
+	render() {
+		const { href, tagName, target, compact, children, highlight } = this.props;
 
-	const omitProps = [ 'compact', 'highlight', 'tagName' ];
+		const highlightClass = highlight ? 'is-' + highlight : false;
 
-	let linkIndicator;
-	if ( href ) {
-		linkIndicator = (
-			<Gridicon className="card__link-indicator" icon={ target ? 'external' : 'chevron-right' } />
+		const className = classnames(
+			'card',
+			this.props.className,
+			{
+				'is-card-link': !! href,
+				'is-compact': compact,
+			},
+			highlightClass
 		);
-	} else {
-		omitProps.push( 'href', 'target' );
+
+		const omitProps = [ 'compact', 'highlight', 'tagName' ];
+
+		let linkIndicator;
+		if ( href ) {
+			linkIndicator = (
+				<Gridicon className="card__link-indicator" icon={ target ? 'external' : 'chevron-right' } />
+			);
+		} else {
+			omitProps.push( 'href', 'target' );
+		}
+
+		return React.createElement(
+			href ? 'a' : tagName,
+			assign( omit( this.props, omitProps ), { className } ),
+			linkIndicator,
+			children
+		);
 	}
-
-	return React.createElement(
-		href ? 'a' : tagName,
-		assign( omit( props, omitProps ), { className } ),
-		linkIndicator,
-		children
-	);
-};
-
-Card.propTypes = {
-	className: PropTypes.string,
-	href: PropTypes.string,
-	tagName: PropTypes.string,
-	target: PropTypes.string,
-	compact: PropTypes.bool,
-	children: PropTypes.node,
-	highlight: PropTypes.oneOf( [ false, 'error', 'info', 'success', 'warning' ] ),
-};
-
-Card.defaultProps = {
-	tagName: 'div',
-	highlight: false,
-};
+}
 
 export default Card;


### PR DESCRIPTION
This PR fixes #18948, where folks were unable to interact with a mobile app banner in notifications. The regression occurred because Card was refactored to a functional component in #18089. When this happened we were unable to hold a reference to Card, and the proper event handlers were never applied.

See: "You may not use the ref attribute on functional components" from https://reactjs.org/docs/refs-and-the-dom.html


### Testing instructions

No regressions for the Card component.

1. Use your physical Mobile device using this calypso.live branch: https://calypso.live/?branch=fix/app-banner
2. Visit the reader, stats, editor, and notifications
3. Banners should be visible and behave as expected.
4. Open notifications again. Click on any part of the banner should not toggle notifications. Open in app and dismiss banner should work as expected.

In Desktop Chrome:
1. This banner should not be visible on any page in non-mobile browsers.
2. In order to test it, you can open up DevTools in Chrome and use `Toggle device toolbar`. Along making the screen size smaller, this will also change the `userAgent` which we use to test whether the app banner should be shown. Another option would be to select the `userAgent` manually in Chrome DevTools by following option 2 of [this guide](https://www.technipages.com/google-chrome-change-user-agent-string).
3. Verify that app banner is shown on stats, reader, and editor pages. It should also be shown on any page when notification panel is open.
4. Verify that correct text and icons are shown for each page as described in https://github.com/Automattic/wp-calypso/issues/15228.
5. Verify that impression tracks event has been recorded upon banner rendering.
6. Verify that `Open in app` redirects to app store and that appropriate tracks event/stat bump is recorded.
7. Verify that `No thanks` closes the banner and that appropriate tracks event/stat bump is recorded.

**_Note:_** If you've dismissed the widget and want to bring it back for testing in current session, you can run the following line in your console: 
```javascript
dispatch( { type: 'PREFERENCES_SET', key: 'appBannerDismissTimes', value: null } );
```

Another trick is to update the example for `/client/blocks/dismissible-card/docs/example.jsx` and update line 37 to 
```jsx
clearPreference: partial( savePreference, 'appBannerDismissTimes', null ),
```
Visit the dismissible-card example page and click the button to reset your pref.

### Visual changes (stats example):

<img src="https://user-images.githubusercontent.com/1182160/28293508-bdd14fa0-6b54-11e7-94bf-77cec8f282cb.png" width="300px" alt="stats-example" />

### Expected Analytics Events:
You can see this by setting `localStorage.debug = 'calypso:analytics:*'`
<img width="802" alt="screen shot 2017-07-21 at 3 27 14 pm" src="https://user-images.githubusercontent.com/1270189/28484823-912ce25c-6e29-11e7-8842-f4558cb7a879.png">