### PR TITLE
Comments: Point the CommentButton within the Post card to the post-specific comments view.

### DIFF
--- a/client/blocks/comment-button/index.jsx
+++ b/client/blocks/comment-button/index.jsx
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { noop } from 'lodash';
+import { isNull, noop, omitBy } from 'lodash';
 
 /**
  * Internal dependencies
@@ -18,29 +18,46 @@ import { getPostTotalCommentsCount } from 'state/comments/selectors';
 
 class CommentButton extends Component {
 	static propTypes = {
-		onClick: PropTypes.func,
-		tagName: PropTypes.string,
 		commentCount: PropTypes.number,
+		link: PropTypes.string,
+		onClick: PropTypes.func,
 		showLabel: PropTypes.bool,
+		tagName: PropTypes.string,
+		target: PropTypes.string,
 	};
 
 	static defaultProps = {
-		onClick: noop,
-		tagName: 'li',
-		size: 24,
 		commentCount: 0,
+		link: null,
+		onClick: noop,
 		showLabel: true,
+		size: 24,
+		tagName: 'li',
+		target: null,
 	};
 
 	render() {
-		const { translate, commentCount, onClick, showLabel, tagName: containerTag } = this.props;
+		const {
+			commentCount,
+			link,
+			onClick,
+			showLabel,
+			tagName: containerTag,
+			target,
+			translate,
+		} = this.props;
 
 		return React.createElement(
 			containerTag,
-			{
-				className: 'comment-button',
-				onClick,
-			},
+			omitBy(
+				{
+					className: 'comment-button',
+					href: link,
+					onClick,
+					target,
+				},
+				isNull
+			),
 			<Gridicon icon="comment" size={ this.props.size } className="comment-button__icon" />,
 			<span className="comment-button__label">
 				{ commentCount > 0 && (

--- a/client/blocks/post-actions/index.jsx
+++ b/client/blocks/post-actions/index.jsx
@@ -21,7 +21,7 @@ import CommentButton from 'blocks/comment-button';
 import LikeButton from 'my-sites/post-like-button';
 import PostTotalViews from 'my-sites/posts/post-total-views';
 import { canCurrentUser } from 'state/selectors';
-import { isJetpackModuleActive, isJetpackSite } from 'state/sites/selectors';
+import { isJetpackModuleActive, isJetpackSite, getSiteDomain } from 'state/sites/selectors';
 import { getEditorPath } from 'state/ui/editor/selectors';
 
 const getContentLink = ( state, siteId, post ) => {
@@ -47,7 +47,7 @@ const PostActions = ( {
 	showComments,
 	showLikes,
 	showStats,
-	toggleComments,
+	siteDomain,
 	trackRelativeTimeStatusOnClick,
 	trackTotalViewsOnClick,
 } ) => {
@@ -72,8 +72,8 @@ const PostActions = ( {
 						post={ post }
 						showLabel={ false }
 						commentCount={ post.discussion.comment_count }
-						onClick={ toggleComments }
-						tagName="div"
+						tagName="a"
+						link={ '/comments/' + siteDomain + '/' + post.ID }
 					/>
 				</li>
 			) }
@@ -102,13 +102,13 @@ PostActions.propTypes = {
 	className: PropTypes.string,
 	post: PropTypes.object.isRequired,
 	siteId: PropTypes.number.isRequired,
-	toggleComments: PropTypes.func.isRequired,
 	trackRelativeTimeStatusOnClick: PropTypes.func,
 	trackTotalViewsOnClick: PropTypes.func,
 };
 
 const mapStateToProps = ( state, { siteId, post } ) => {
 	const isJetpack = isJetpackSite( state, siteId );
+	const siteDomain = getSiteDomain( state, siteId );
 
 	// TODO: Maybe add dedicated selectors for the following.
 	const showComments =
@@ -125,6 +125,7 @@ const mapStateToProps = ( state, { siteId, post } ) => {
 		showComments,
 		showLikes,
 		showStats,
+		siteDomain,
 	};
 };
 


### PR DESCRIPTION
This PR updates the `CommentButton` block to accept `link` and `target` props, allowing it to output an anchor tag pointing to the link. With this change, we can then point the `Post` card's `CommentButton` at `/posts/:site` to the upcoming post-specific view of comments (`/comments/:status/:site/:post-id`).

<img width="1174" alt="screen shot 2017-10-24 at 5 04 36 pm" src="https://user-images.githubusercontent.com/349751/31973945-90532ea0-b8dd-11e7-9951-cff1cbfae18d.png">

See #18332 . **Not to be merged until the view is complete; see #18315.**

Testing
* Switch to this branch.
* Go to the `/posts` view, and click the comments button on any post. This should take you to the new post-specific comments view, with a URL of `/comments/:status/:site/:post-id`.
* Go to the Reader, and ensure that the comments button appears normally, and links to the Reader view of comments.