### PR TITLE
Store Orders: Add a function to remove temporary IDs from line_items

### DIFF
--- a/client/extensions/woocommerce/state/sites/orders/test/utils.js
+++ b/client/extensions/woocommerce/state/sites/orders/test/utils.js
@@ -1,0 +1,109 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+import deepFreeze from 'deep-freeze';
+
+/**
+ * Internal dependencies
+ */
+import existingOrder from './fixtures/order';
+import { removeTemporaryIds } from '../utils';
+
+describe( 'removeTemporaryIds', () => {
+	test( 'should return the same order when there are no temporary IDs', () => {
+		expect( removeTemporaryIds( existingOrder ) ).to.eql( existingOrder );
+	} );
+
+	test( 'should remove the temporary ID, but leave both line items', () => {
+		const order = deepFreeze( {
+			line_items: [
+				{
+					id: 1,
+					name: 'Coffee',
+					price: 5,
+				},
+				{
+					id: 'product_2',
+					name: 'Mug',
+					price: 15,
+				},
+			],
+		} );
+		const newOrder = removeTemporaryIds( order );
+		expect( newOrder.line_items ).to.eql( [
+			{
+				id: 1,
+				name: 'Coffee',
+				price: 5,
+			},
+			{
+				name: 'Mug',
+				price: 15,
+			},
+		] );
+	} );
+
+	test( 'should remove the temporary ID, but leave the fee lines', () => {
+		const order = deepFreeze( {
+			fee_lines: [
+				{
+					id: 'fee_1',
+					name: 'Something extra',
+					total: 10,
+				},
+			],
+		} );
+		const newOrder = removeTemporaryIds( order );
+		expect( newOrder.fee_lines ).to.eql( [
+			{
+				name: 'Something extra',
+				total: 10,
+			},
+		] );
+	} );
+
+	test( 'should work when there are line_items and fee_lines', () => {
+		const order = deepFreeze( {
+			line_items: [
+				{
+					id: 1,
+					name: 'Coffee',
+					price: 5,
+				},
+				{
+					id: 'product_2',
+					name: 'Mug',
+					price: 15,
+				},
+			],
+			fee_lines: [
+				{
+					id: 'fee_1',
+					name: 'Something extra',
+					total: 10,
+				},
+			],
+		} );
+		const newOrder = removeTemporaryIds( order );
+		expect( newOrder.line_items ).to.eql( [
+			{
+				id: 1,
+				name: 'Coffee',
+				price: 5,
+			},
+			{
+				name: 'Mug',
+				price: 15,
+			},
+		] );
+		expect( newOrder.fee_lines ).to.eql( [
+			{
+				name: 'Something extra',
+				total: 10,
+			},
+		] );
+	} );
+} );

--- a/client/extensions/woocommerce/state/sites/orders/utils.js
+++ b/client/extensions/woocommerce/state/sites/orders/utils.js
@@ -1,10 +1,8 @@
+/** @format */
 /**
  * External dependencies
- *
- * @format
  */
-
-import { omitBy } from 'lodash';
+import { omitBy, isNumber, omit } from 'lodash';
 
 export const DEFAULT_QUERY = {
 	page: 1,
@@ -35,4 +33,28 @@ export function getSerializedOrdersQuery( query = {} ) {
 	const serializedQuery = JSON.stringify( normalizedQuery );
 
 	return serializedQuery;
+}
+
+/**
+ * Remove temporary IDs used for adding products & fees to an existing order
+ * The IDs for items needs to be null when sent to the API for the remote site
+ * to correctly save them as new line items/fee items.
+ *
+ * @param  {Object} order  Order object
+ * @return {Object}        Order object, with no temporary IDs
+ */
+export function removeTemporaryIds( order ) {
+	const newOrder = { ...order };
+	for ( const type of [ 'line_items', 'fee_lines', 'coupon_lines', 'shipping_lines' ] ) {
+		if ( order[ type ] ) {
+			newOrder[ type ] = order[ type ].map( item => {
+				if ( ! isNumber( item.id ) ) {
+					return omit( item, 'id' );
+				}
+				return item;
+			} );
+		}
+	}
+
+	return newOrder;
 }


### PR DESCRIPTION
When creating fees, or adding products to an order, we'll need to create temporary IDs so that we can control quantity, and delete them (if needed). When the order is saved to the API, it needs the ID to be null so that it knows to create a new `fee_line` or `line_item`. This new helper function will be used in the `updateOrder` action to strip out any placeholder IDs before sending off to the remote site.

`line_items`, `fee_lines`, `coupon_lines`, `shipping_lines` are all considered types of items attached to an order, so this function will be used for all these (even if the latter 2 aren't going to be implemented immediately).

To test

- Run the test: `npm run test-client client/extensions/woocommerce/state/sites/orders/test/utils.js`

There are no functionality changes yet.