### PR TITLE
Store: Remove over-general CSS selector which forced all inputs in dialogs to be right-aligned

### DIFF
--- a/client/extensions/woocommerce/app/order/order-customer/style.scss
+++ b/client/extensions/woocommerce/app/order/order-customer/style.scss
@@ -49,14 +49,6 @@
 	}
 }
 
-// Override the price inputs in details-table
-&.order-customer__dialog.dialog__content {
-	.form-text-input,
-	.form-text-input-with-affixes input {
-		text-align: left;
-	}
-}
-
 &.order-customer__dialog {
 	.order-customer__fieldset {
 		display: flex;

--- a/client/extensions/woocommerce/app/order/order-payment/style.scss
+++ b/client/extensions/woocommerce/app/order/order-payment/style.scss
@@ -13,6 +13,11 @@
 		color: $gray-dark;
 	}
 
+	.form-text-input,
+	.form-text-input-with-affixes input {
+		text-align: right;
+	}
+
 	.form-label {
 		.form-text-input-with-affixes {
 			font-weight: normal;
@@ -22,11 +27,6 @@
 	.form-text-input-with-affixes,
 	.form-text-input-with-suffixes {
 		width: 155px;
-		text-align: left;
-
-		input {
-			text-align: left;
-		}
 	}
 
 	.order-payment__amount-label {

--- a/client/extensions/woocommerce/app/order/style.scss
+++ b/client/extensions/woocommerce/app/order/style.scss
@@ -102,10 +102,3 @@
 		margin-right: 8px;
 	}
 }
-
-&.dialog__content {
-	.form-text-input,
-	.form-text-input-with-affixes input {
-		text-align: right;
-	}
-}


### PR DESCRIPTION
When it was first launched, the refund dialog needed the inputs to be right-aligned to match the order table. The CSS used was over-generalized, and so I've been overriding it in subsequent dialogs. This PR cleans up the CSS by applying the text alignment to only the payment modal, and removes the overrides.

**To test**

- View the orders page `/store/orders/:site`
- Click into an order
- Check that each dialog inputs are displayed correctly
- On the order view screen: refunds, fulfillment with shipping labels, fulfillment w/o labels
- On the order edit screen: customer shipping & billing dialogs