### PR TITLE
Framework: Remove react-addons-test-utils

### DIFF
--- a/client/my-sites/plugins/plugins-list/test/index.jsx
+++ b/client/my-sites/plugins/plugins-list/test/index.jsx
@@ -11,7 +11,7 @@ import React from 'react';
 import {
 	renderIntoDocument as testRenderer,
 	scryRenderedComponentsWithType,
-} from 'react-addons-test-utils';
+} from 'react-dom/test-utils';
 import { Provider as ReduxProvider } from 'react-redux';
 
 /**

--- a/client/post-editor/test/post-editor.jsx
+++ b/client/post-editor/test/post-editor.jsx
@@ -8,7 +8,7 @@
  */
 import { expect } from 'chai';
 import React from 'react';
-import { renderIntoDocument } from 'react-addons-test-utils';
+import { renderIntoDocument } from 'react-dom/test-utils';
 
 /**
  * Internal dependencies

--- a/package.json
+++ b/package.json
@@ -275,7 +275,6 @@
     "nodemon": "1.4.1",
     "prettier": "github:automattic/calypso-prettier#14307ba5cc6bcfc00243f5e2d1b25c72d52c28c8",
     "pretty-bytes": "4.0.2",
-    "react-addons-test-utils": "15.6.2",
     "react-codemod": "reactjs/react-codemod",
     "react-test-env": "0.2.0",
     "react-test-renderer": "15.6.2",


### PR DESCRIPTION
See https://www.npmjs.com/package/react-addons-test-utils

I've run `npm run update-deps`, but the shrinkwrap file didn't change -- I guess one of our dependencies is still requiring `react-addons-test-utils`.

Relevant for https://github.com/Automattic/wp-calypso/pull/19083

To test: Verify that no tests fail (CircleCI should be sufficient to check!). Also verify that `react-addons-test-utils` isn't used anywhere else in the codebase.