### PR TITLE
Selectors: Add isEmailBlacklisted selector

### DIFF
--- a/client/state/selectors/index.js
+++ b/client/state/selectors/index.js
@@ -184,6 +184,7 @@ export isDropZoneVisible from './is-drop-zone-visible';
 export isEditingPublicizeSharePostAction from './is-editing-publicize-share-post-action';
 export isEligibleForDomainToPaidPlanUpsell from './is-eligible-for-domain-to-paid-plan-upsell';
 export isEligibleForFreeToPaidUpsell from './is-eligible-for-free-to-paid-upsell';
+export isEmailBlacklisted from './is-email-blacklisted';
 export isFetchingAutomatedTransferStatus from './is-fetching-automated-transfer-status';
 export isFetchingJetpackModules from './is-fetching-jetpack-modules';
 export isFetchingMagicLoginAuth from './is-fetching-magic-login-auth';

--- a/client/state/selectors/is-email-blacklisted.js
+++ b/client/state/selectors/is-email-blacklisted.js
@@ -1,0 +1,25 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { includes } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { getSiteSetting } from 'state/selectors';
+
+/**
+ * Check if a site blacklist contains an email address.
+ *
+ * @param {Object} state Global state tree
+ * @param {Number} siteId Site ID
+ * @param {String} email An email address.
+ * @returns {Boolean} If the blacklist contains the email address.
+ */
+export const isEmailBlacklisted = ( state, siteId, email ) => {
+	const blacklist = getSiteSetting( state, siteId, 'blacklist_keys' );
+	return !! email && !! blacklist ? includes( blacklist.split( '\n' ), email ) : false;
+};
+
+export default isEmailBlacklisted;

--- a/client/state/selectors/is-email-blacklisted.js
+++ b/client/state/selectors/is-email-blacklisted.js
@@ -17,9 +17,9 @@ import { getSiteSetting } from 'state/selectors';
  * @param {String} email An email address.
  * @returns {Boolean} If the blacklist contains the email address.
  */
-export const isEmailBlacklisted = ( state, siteId, email ) => {
-	const blacklist = getSiteSetting( state, siteId, 'blacklist_keys' );
-	return !! email && !! blacklist ? includes( blacklist.split( '\n' ), email ) : false;
+export const isEmailBlacklisted = ( state, siteId, email = '' ) => {
+	const blacklist = getSiteSetting( state, siteId, 'blacklist_keys' ) || '';
+	return includes( blacklist.split( '\n' ), email );
 };
 
 export default isEmailBlacklisted;

--- a/client/state/selectors/test/is-email-blacklisted.js
+++ b/client/state/selectors/test/is-email-blacklisted.js
@@ -1,0 +1,40 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { isEmailBlacklisted } from '../';
+
+const email = 'foo@bar.baz';
+
+const state = {
+	siteSettings: {
+		items: {
+			123: {
+				blacklist_keys: 'mail@mail.com\ntest@example.com\nfoo@bar.baz\nyadda@yadda.yadda',
+			},
+			456: {
+				blacklist_keys: 'mail@mail.com\ntest@example.com\nyadda@yadda.yadda',
+			},
+			789: {
+				blacklist_keys: '',
+			},
+		},
+	},
+};
+
+describe( 'isEmailBlacklisted()', () => {
+	test( 'should return true if email is blacklisted', () => {
+		expect( isEmailBlacklisted( state, 123, email ) ).to.be.true;
+	} );
+	test( 'should return false if email is not blacklisted', () => {
+		expect( isEmailBlacklisted( state, 456, email ) ).to.be.false;
+	} );
+	test( 'should return false if blacklist is empty', () => {
+		expect( isEmailBlacklisted( state, 789, email ) ).to.be.false;
+	} );
+} );

--- a/client/state/selectors/test/is-email-blacklisted.js
+++ b/client/state/selectors/test/is-email-blacklisted.js
@@ -27,6 +27,8 @@ const state = {
 	},
 };
 
+const noSiteSettingsState = { siteSettings: {} };
+
 describe( 'isEmailBlacklisted()', () => {
 	test( 'should return true if email is blacklisted', () => {
 		expect( isEmailBlacklisted( state, 123, email ) ).to.be.true;
@@ -36,5 +38,14 @@ describe( 'isEmailBlacklisted()', () => {
 	} );
 	test( 'should return false if blacklist is empty', () => {
 		expect( isEmailBlacklisted( state, 789, email ) ).to.be.false;
+	} );
+	test( 'should return false if there are no site settings in state', () => {
+		expect( isEmailBlacklisted( noSiteSettingsState, 123, email ) ).to.be.false;
+	} );
+	test( 'should return false if no email is provided', () => {
+		expect( isEmailBlacklisted( state, 123 ) ).to.be.false;
+	} );
+	test( 'should return false if email is empty', () => {
+		expect( isEmailBlacklisted( state, 123, '' ) ).to.be.false;
 	} );
 } );


### PR DESCRIPTION
Improvement on https://github.com/Automattic/wp-calypso/pull/19082/files/6b841239e7035dbda91fce1a4bd61dcbf2938876#r146656231

Add a new `isEmailBlacklisted` selector that checks if a site blacklist contains an email address.