### PR TITLE
Activity Log: tweak timeline vertical alignment in small screens

### DIFF
--- a/client/my-sites/stats/activity-log-day/style.scss
+++ b/client/my-sites/stats/activity-log-day/style.scss
@@ -7,7 +7,7 @@
 		background: transparent;
 
 		.foldable-card__content {
-			padding: 0 0 24px;
+			padding: 0 0 16px;
 			background: transparent;
 		}
 	}
@@ -109,8 +109,17 @@
 	top: 48px;
 }
 
-.activity-log-item:last-of-type:before {
-	height: 41px;
+.activity-log-day:last-of-type:before {
+	width: 0;
+}
+
+.activity-log-item:before {
+	bottom: -16px;
+	height: auto;
+
+	@include breakpoint( "<480px" ) {
+		left: 21px;
+	}
 }
 
 .activity-log-item__restore-confirm:before {


### PR DESCRIPTION
follow up to #19116. In addition to alignment, this also:
- finishes lines when there are many text lines
- remove line at the bottom of screen

#### Before: unfinished lines
<img width="521" alt="captura de pantalla 2017-10-24 a la s 23 59 33" src="https://user-images.githubusercontent.com/1041600/31999429-8e2e72a6-b969-11e7-9d8a-9193cb7dc103.png">

#### After: complete lines
<img width="231" alt="captura de pantalla 2017-10-25 a la s 09 47 08" src="https://user-images.githubusercontent.com/1041600/31999470-b3a2dd1a-b969-11e7-896c-c7b175eee049.png">

#### Before: line shows at the end
<img width="388" alt="captura de pantalla 2017-10-25 a la s 00 18 16" src="https://user-images.githubusercontent.com/1041600/31998054-b9ed2342-b964-11e7-803f-3c2180a73f10.png">

#### After: line is gone
<img width="420" alt="captura de pantalla 2017-10-25 a la s 00 18 21" src="https://user-images.githubusercontent.com/1041600/31998055-ba579326-b964-11e7-9dde-ca42505a471f.png">
