### PR TITLE
Jetpack Connect: Add css class to connect button for automated testing

### DIFF
--- a/client/jetpack-connect/site-url-input.jsx
+++ b/client/jetpack-connect/site-url-input.jsx
@@ -116,7 +116,12 @@ class JetpackConnectSiteUrlInput extends PureComponent {
 				</div>
 				<Card className="jetpack-connect__connect-button-card">
 					{ this.renderTermsOfServiceLink() }
-					<Button primary disabled={ ! url || isFetching || hasError } onClick={ onSubmit }>
+					<Button
+						className="jetpack-connect__connect-button"
+						primary
+						disabled={ ! url || isFetching || hasError }
+						onClick={ onSubmit }
+					>
 						{ this.renderButtonLabel() }
 					</Button>
 				</Card>


### PR DESCRIPTION
No visual changes.

Allows e2e test browser driver to find the button by css class.

**To Test**
* Go to http://calypso.localhost:3000/jetpack/new?ref=calypso-selector
* Check the green _Connect Now_ button has the new css class