### PR TITLE
Atomic Store: Restore Theme Selection

### DIFF
--- a/client/lib/signup/themes-data.js
+++ b/client/lib/signup/themes-data.js
@@ -1,6 +1,15 @@
 /** @format */
 export const themes = [
 	{
+		name: 'Shoreditch',
+		slug: 'shoreditch',
+		repo: 'pub',
+		fallback: true,
+		design: [ 'page', 'store' ],
+		demo_uri: 'https://wordpress.com/theme/shoreditch',
+		verticals: [],
+	},
+	{
 		name: 'Independent Publisher',
 		slug: 'independent-publisher-2',
 		repo: 'pub',
@@ -68,7 +77,7 @@ export const themes = [
 		slug: 'karuna',
 		repo: 'pub',
 		fallback: false,
-		design: 'page',
+		design: [ 'page', 'store' ],
 		demo_uri: 'https://karunademo.wordpress.com',
 		verticals: [],
 	},
@@ -77,7 +86,7 @@ export const themes = [
 		slug: 'dara',
 		repo: 'pub',
 		fallback: true,
-		design: 'page',
+		design: [ 'page', 'store' ],
 		demo_uri: 'https://darademo.wordpress.com',
 		verticals: [],
 	},

--- a/client/lib/signup/themes.js
+++ b/client/lib/signup/themes.js
@@ -24,7 +24,11 @@ export function getDefaultThemes() {
 }
 
 export default function getThemes( vertical, designType, quantity = 9 ) {
-	const filterByType = theme => theme.design === designType;
+	const filterByType = theme => {
+		return Array.isArray( theme.design )
+			? includes( theme.design, designType )
+			: theme.design === designType;
+	};
 	const themePool = themes;
 	const themesByType = themePool.filter( filterByType );
 	let themeSet = themesByType;

--- a/client/signup/steps/theme-selection/index.jsx
+++ b/client/signup/steps/theme-selection/index.jsx
@@ -91,6 +91,10 @@ class ThemeSelectionStep extends Component {
 	}
 
 	shouldSkipStep() {
+		return false;
+	}
+
+	isStoreSignup() {
 		const { signupDependencies = {} } = this.props;
 
 		return (
@@ -124,15 +128,22 @@ class ThemeSelectionStep extends Component {
 			return null;
 		}
 
+		const storeSignup = this.isStoreSignup();
 		const defaultDependencies = this.props.useHeadstart
 			? { themeSlugWithRepo: 'pub/twentysixteen' }
 			: undefined;
 		const { translate } = this.props;
-		const headerText = translate( 'Choose a theme.' );
-		const subHeaderText = translate(
-			'Pick one of our popular themes to get started or choose from hundreds more after you sign up.',
-			{ context: 'Themes step subheader in Signup' }
-		);
+		const headerText = storeSignup
+			? translate( 'Choose a store theme.' )
+			: translate( 'Choose a theme.' );
+		const subHeaderText = storeSignup
+			? translate( 'Pick one of our store themes to start with. You can change this later.', {
+					context: 'Themes step subheader in Signup',
+				} )
+			: translate(
+					'Pick one of our popular themes to get started or choose from hundreds more after you sign up.',
+					{ context: 'Themes step subheader in Signup' }
+				);
 
 		return (
 			<StepWrapper


### PR DESCRIPTION
This PR restores theme selection screen to Atomic Store signup flow.

Only themes marked with `store` in its `design` field will be displayed.

## Test Plan

1. Start Atomic Store signup flow (`/start/atomic-store`) and select Store option.
2. You should see theme selection like image below.

<img width="984" alt="screenshot_368" src="https://user-images.githubusercontent.com/127594/32003602-7057acb2-b954-11e7-8966-83cec255e304.png">
