### PR TITLE
Store Orders: Add fees to an existing order

### DIFF
--- a/client/extensions/woocommerce/app/order/order-details/add-items.js
+++ b/client/extensions/woocommerce/app/order/order-details/add-items.js
@@ -4,6 +4,7 @@
  */
 import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
+import Gridicon from 'gridicons';
 
 /**
  * Internal dependencies
@@ -25,10 +26,12 @@ class OrderAddItems extends Component {
 		return (
 			<div className="order-details__actions">
 				<Button borderless onClick={ this.toggleDialog( 'product' ) }>
-					{ translate( '+ Add Product' ) }
+					<Gridicon icon="plus-small" />
+					{ translate( 'Add Product' ) }
 				</Button>
 				<Button borderless onClick={ this.toggleDialog( 'fee' ) }>
-					{ translate( '+ Add Fee' ) }
+					<Gridicon icon="plus-small" />
+					{ translate( 'Add Fee' ) }
 				</Button>
 				<OrderFeeDialog
 					isVisible={ 'fee' === this.state.showDialog }

--- a/client/extensions/woocommerce/app/order/order-details/add-items.js
+++ b/client/extensions/woocommerce/app/order/order-details/add-items.js
@@ -9,14 +9,31 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import Button from 'components/button';
+import OrderFeeDialog from './fee-dialog';
 
 class OrderAddItems extends Component {
+	state = {
+		showDialog: false,
+	};
+
+	toggleDialog = type => () => {
+		this.setState( { showDialog: type } );
+	};
+
 	render() {
 		const { translate } = this.props;
 		return (
 			<div className="order-details__actions">
-				<Button borderless>{ translate( '+ Add Product' ) }</Button>
-				<Button borderless>{ translate( '+ Add Fee' ) }</Button>
+				<Button borderless onClick={ this.toggleDialog( 'product' ) }>
+					{ translate( '+ Add Product' ) }
+				</Button>
+				<Button borderless onClick={ this.toggleDialog( 'fee' ) }>
+					{ translate( '+ Add Fee' ) }
+				</Button>
+				<OrderFeeDialog
+					isVisible={ 'fee' === this.state.showDialog }
+					closeDialog={ this.toggleDialog( false ) }
+				/>
 			</div>
 		);
 	}

--- a/client/extensions/woocommerce/app/order/order-details/add-items.js
+++ b/client/extensions/woocommerce/app/order/order-details/add-items.js
@@ -1,0 +1,25 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Button from 'components/button';
+
+class OrderAddItems extends Component {
+	render() {
+		const { translate } = this.props;
+		return (
+			<div className="order-details__actions">
+				<Button borderless>{ translate( '+ Add Product' ) }</Button>
+				<Button borderless>{ translate( '+ Add Fee' ) }</Button>
+			</div>
+		);
+	}
+}
+
+export default localize( OrderAddItems );

--- a/client/extensions/woocommerce/app/order/order-details/fee-dialog.js
+++ b/client/extensions/woocommerce/app/order/order-details/fee-dialog.js
@@ -53,7 +53,7 @@ class OrderFeeDialog extends Component {
 		const value = event.target.value;
 		switch ( event.target.name ) {
 			case 'new_fee_name':
-				this.setState( { name: trim( value ) } );
+				this.setState( { name: value } );
 				break;
 			case 'new_fee_total':
 				// If value is a positive number, we can use it
@@ -93,7 +93,7 @@ class OrderFeeDialog extends Component {
 		const hasName = !! trim( this.state.name );
 		const hasValue = getCurrencyFormatDecimal( this.state.total, currency ) > 0;
 		return hasName && hasValue;
-	}
+	};
 
 	render() {
 		const { closeDialog, isVisible, order, translate } = this.props;

--- a/client/extensions/woocommerce/app/order/order-details/fee-dialog.js
+++ b/client/extensions/woocommerce/app/order/order-details/fee-dialog.js
@@ -7,7 +7,7 @@ import PropTypes from 'prop-types';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { uniqueId } from 'lodash';
+import { trim, uniqueId } from 'lodash';
 
 /**
  * Internal dependencies
@@ -53,7 +53,7 @@ class OrderFeeDialog extends Component {
 		const value = event.target.value;
 		switch ( event.target.name ) {
 			case 'new_fee_name':
-				this.setState( { name: value } );
+				this.setState( { name: trim( value ) } );
 				break;
 			case 'new_fee_total':
 				this.setState( { total: value > 0 ? value : 0 } );
@@ -86,7 +86,7 @@ class OrderFeeDialog extends Component {
 		const { closeDialog, isVisible, order, translate } = this.props;
 		const dialogClass = 'woocommerce order-details__dialog'; // eslint/css specificity hack
 
-		const canSave = this.state.name && this.state.total;
+		const canSave = trim( this.state.name ) && this.state.total;
 
 		const dialogButtons = [
 			<Button onClick={ closeDialog }>{ translate( 'Cancel' ) }</Button>,
@@ -101,10 +101,9 @@ class OrderFeeDialog extends Component {
 				onClose={ closeDialog }
 				className={ dialogClass }
 				buttons={ dialogButtons }
-				additionalClassNames="order-payment__dialog woocommerce"
 			>
 				<h1>{ translate( 'Add a fee' ) }</h1>
-				<FormLabel htmlFor="newFeeName">{ translate( 'Fee name' ) }</FormLabel>
+				<FormLabel htmlFor="newFeeName">{ translate( 'Name' ) }</FormLabel>
 				<FormTextInput
 					id="new_fee_name"
 					name="new_fee_name"
@@ -112,7 +111,7 @@ class OrderFeeDialog extends Component {
 					value={ this.state.name }
 					onChange={ this.handleChange }
 				/>
-				<FormLabel htmlFor="newFeeTotal">{ translate( 'Fee value' ) }</FormLabel>
+			<FormLabel htmlFor="newFeeTotal">{ translate( 'Value' ) }</FormLabel>
 				<PriceInput
 					id="new_fee_total"
 					name="new_fee_total"

--- a/client/extensions/woocommerce/app/order/order-details/fee-dialog.js
+++ b/client/extensions/woocommerce/app/order/order-details/fee-dialog.js
@@ -56,7 +56,12 @@ class OrderFeeDialog extends Component {
 				this.setState( { name: trim( value ) } );
 				break;
 			case 'new_fee_total':
-				this.setState( { total: value > 0 ? value : 0 } );
+				// If value is a positive number, we can use it
+				if ( ! isNaN( parseFloat( value ) ) && parseFloat( value ) >= 0 ) {
+					this.setState( { total: value } );
+				} else {
+					this.setState( { total: '' } );
+				}
 				break;
 		}
 	};
@@ -111,7 +116,7 @@ class OrderFeeDialog extends Component {
 					value={ this.state.name }
 					onChange={ this.handleChange }
 				/>
-			<FormLabel htmlFor="newFeeTotal">{ translate( 'Value' ) }</FormLabel>
+				<FormLabel htmlFor="newFeeTotal">{ translate( 'Value' ) }</FormLabel>
 				<PriceInput
 					id="new_fee_total"
 					name="new_fee_total"

--- a/client/extensions/woocommerce/app/order/order-details/fee-dialog.js
+++ b/client/extensions/woocommerce/app/order/order-details/fee-dialog.js
@@ -87,11 +87,19 @@ class OrderFeeDialog extends Component {
 		this.props.closeDialog();
 	};
 
+	hasValidValues = () => {
+		const { currency } = this.props.order;
+
+		const hasName = !! trim( this.state.name );
+		const hasValue = getCurrencyFormatDecimal( this.state.total, currency ) > 0;
+		return hasName && hasValue;
+	}
+
 	render() {
 		const { closeDialog, isVisible, order, translate } = this.props;
 		const dialogClass = 'woocommerce order-details__dialog'; // eslint/css specificity hack
 
-		const canSave = trim( this.state.name ) && this.state.total;
+		const canSave = this.hasValidValues();
 
 		const dialogButtons = [
 			<Button onClick={ closeDialog }>{ translate( 'Cancel' ) }</Button>,

--- a/client/extensions/woocommerce/app/order/order-details/fee-dialog.js
+++ b/client/extensions/woocommerce/app/order/order-details/fee-dialog.js
@@ -17,6 +17,7 @@ import Dialog from 'components/dialog';
 import { editOrder } from 'woocommerce/state/ui/orders/actions';
 import FormLabel from 'components/forms/form-label';
 import FormTextInput from 'components/forms/form-text-input';
+import { getCurrencyFormatDecimal } from 'woocommerce/lib/currency';
 import { getOrderWithEdits } from 'woocommerce/state/ui/orders/selectors';
 import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
 import PriceInput from 'woocommerce/components/price-input';
@@ -57,6 +58,13 @@ class OrderFeeDialog extends Component {
 				this.setState( { total: event.target.value } );
 				break;
 		}
+	};
+
+	formatCurrencyInput = () => {
+		const { currency } = this.props.order;
+		this.setState( prevState => ( {
+			total: getCurrencyFormatDecimal( prevState.total, currency ),
+		} ) );
 	};
 
 	handleFeeSave = () => {
@@ -110,6 +118,7 @@ class OrderFeeDialog extends Component {
 					currency={ order.currency }
 					value={ this.state.total }
 					onChange={ this.handleChange }
+					onBlur={ this.formatCurrencyInput }
 				/>
 			</Dialog>
 		);

--- a/client/extensions/woocommerce/app/order/order-details/fee-dialog.js
+++ b/client/extensions/woocommerce/app/order/order-details/fee-dialog.js
@@ -77,9 +77,11 @@ class OrderFeeDialog extends Component {
 		const { closeDialog, isVisible, order, translate } = this.props;
 		const dialogClass = 'woocommerce order-details__dialog'; // eslint/css specificity hack
 
+		const canSave = this.state.name && this.state.total;
+
 		const dialogButtons = [
 			<Button onClick={ closeDialog }>{ translate( 'Cancel' ) }</Button>,
-			<Button primary onClick={ this.handleFeeSave }>
+			<Button primary onClick={ this.handleFeeSave } disabled={ ! canSave }>
 				{ translate( 'Add Fee' ) }
 			</Button>,
 		];

--- a/client/extensions/woocommerce/app/order/order-details/fee-dialog.js
+++ b/client/extensions/woocommerce/app/order/order-details/fee-dialog.js
@@ -50,12 +50,13 @@ class OrderFeeDialog extends Component {
 	}
 
 	handleChange = event => {
+		const value = event.target.value;
 		switch ( event.target.name ) {
 			case 'new_fee_name':
-				this.setState( { name: event.target.value } );
+				this.setState( { name: value } );
 				break;
 			case 'new_fee_total':
-				this.setState( { total: event.target.value } );
+				this.setState( { total: value > 0 ? value : 0 } );
 				break;
 		}
 	};

--- a/client/extensions/woocommerce/app/order/order-details/fee-dialog.js
+++ b/client/extensions/woocommerce/app/order/order-details/fee-dialog.js
@@ -1,0 +1,129 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+import { uniqueId } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import Button from 'components/button';
+import Dialog from 'components/dialog';
+import { editOrder } from 'woocommerce/state/ui/orders/actions';
+import FormLabel from 'components/forms/form-label';
+import FormTextInput from 'components/forms/form-text-input';
+import { getOrderWithEdits } from 'woocommerce/state/ui/orders/selectors';
+import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
+import PriceInput from 'woocommerce/components/price-input';
+
+class OrderFeeDialog extends Component {
+	static propTypes = {
+		isVisible: PropTypes.bool.isRequired,
+		editOrder: PropTypes.func.isRequired,
+		order: PropTypes.shape( {
+			currency: PropTypes.string.isRequired,
+			id: PropTypes.number.isRequired,
+		} ),
+		siteId: PropTypes.number.isRequired,
+		translate: PropTypes.func.isRequired,
+	};
+
+	state = {
+		name: '',
+		total: 0,
+	};
+
+	componentWillUpdate( nextProps ) {
+		// Dialog is being closed, clear the state
+		if ( this.props.isVisible && ! nextProps.isVisible ) {
+			this.setState( {
+				name: '',
+				total: 0,
+			} );
+		}
+	}
+
+	handleChange = event => {
+		switch ( event.target.name ) {
+			case 'new_fee_name':
+				this.setState( { name: event.target.value } );
+				break;
+			case 'new_fee_total':
+				this.setState( { total: event.target.value } );
+				break;
+		}
+	};
+
+	handleFeeSave = () => {
+		const { siteId, order } = this.props;
+		if ( siteId ) {
+			const { name, total } = this.state;
+			const feeLines = order.fee_lines || [];
+			const tempId = uniqueId( 'fee_' );
+			this.props.editOrder( siteId, {
+				id: order.id,
+				fee_lines: [ ...feeLines, { id: tempId, name, total } ],
+			} );
+		}
+		this.props.closeDialog();
+	};
+
+	render() {
+		const { closeDialog, isVisible, order, translate } = this.props;
+		const dialogClass = 'woocommerce order-details__dialog'; // eslint/css specificity hack
+
+		const dialogButtons = [
+			<Button onClick={ closeDialog }>{ translate( 'Cancel' ) }</Button>,
+			<Button primary onClick={ this.handleFeeSave }>
+				{ translate( 'Add Fee' ) }
+			</Button>,
+		];
+
+		return (
+			<Dialog
+				isVisible={ isVisible }
+				onClose={ closeDialog }
+				className={ dialogClass }
+				buttons={ dialogButtons }
+				additionalClassNames="order-payment__dialog woocommerce"
+			>
+				<h1>{ translate( 'Add a fee' ) }</h1>
+				<FormLabel htmlFor="newFeeName">{ translate( 'Fee name' ) }</FormLabel>
+				<FormTextInput
+					id="new_fee_name"
+					name="new_fee_name"
+					type="text"
+					value={ this.state.name }
+					onChange={ this.handleChange }
+				/>
+				<FormLabel htmlFor="newFeeTotal">{ translate( 'Fee value' ) }</FormLabel>
+				<PriceInput
+					id="new_fee_total"
+					name="new_fee_total"
+					currency={ order.currency }
+					value={ this.state.total }
+					onChange={ this.handleChange }
+				/>
+			</Dialog>
+		);
+	}
+}
+
+export default connect(
+	state => {
+		const site = getSelectedSiteWithFallback( state );
+		const siteId = site ? site.ID : false;
+		const order = getOrderWithEdits( state );
+
+		return {
+			siteId,
+			order,
+		};
+	},
+	dispatch => bindActionCreators( { editOrder }, dispatch )
+)( localize( OrderFeeDialog ) );

--- a/client/extensions/woocommerce/app/order/order-details/style.scss
+++ b/client/extensions/woocommerce/app/order/order-details/style.scss
@@ -45,6 +45,28 @@
 	text-align: right;
 }
 
+.order-details__actions {
+	margin: 0 -24px;
+	padding: 8px 78px 8px 24px;
+	border-bottom: 1px solid lighten($gray, 30%);
+	text-align: right;
+
+	.button + .button {
+		margin-left: 24px;
+	}
+
+	.button {
+		color: $blue-medium;
+
+		&:hover,
+		&:focus,
+		&:active {
+			color: $link-highlight;
+		}
+	}
+}
+
+
 // Duplicating `.table` for increased specificity
 .order-details__totals.table.table {
 	margin: 16px -24px;

--- a/client/extensions/woocommerce/app/order/order-details/table.js
+++ b/client/extensions/woocommerce/app/order/order-details/table.js
@@ -29,6 +29,7 @@ import {
 	getOrderRefundTotal,
 	getOrderTotal,
 } from 'woocommerce/lib/order-values/totals';
+import OrderAddItems from './add-items';
 import OrderTotalRow from './row-total';
 import ScreenReaderText from 'components/screen-reader-text';
 import Table from 'woocommerce/components/table';
@@ -270,6 +271,7 @@ class OrderDetailsTable extends Component {
 					{ order.line_items.map( this.renderOrderItem ) }
 					{ order.fee_lines.map( this.renderOrderFee ) }
 				</Table>
+				{ isEditing && <OrderAddItems /> }
 
 				<Table className={ totalsClasses } compact>
 					<OrderTotalRow

--- a/client/extensions/woocommerce/state/sites/orders/actions.js
+++ b/client/extensions/woocommerce/state/sites/orders/actions.js
@@ -9,7 +9,7 @@ import { omitBy } from 'lodash';
 /**
  * Internal dependencies
  */
-import { DEFAULT_QUERY, getNormalizedOrdersQuery } from './utils';
+import { DEFAULT_QUERY, getNormalizedOrdersQuery, removeTemporaryIds } from './utils';
 import { areOrdersLoaded, areOrdersLoading, isOrderLoaded, isOrderLoading } from './selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import request from '../request';
@@ -135,6 +135,8 @@ export const updateOrder = ( siteId, { id: orderId, ...order } ) => ( dispatch, 
 	if ( ! siteId ) {
 		siteId = getSelectedSiteId( state );
 	}
+
+	order = removeTemporaryIds( order );
 
 	const updateAction = {
 		type: WOOCOMMERCE_ORDER_UPDATE,


### PR DESCRIPTION
This PR adds a flow to add fees to an existing order. There are now two buttons under the items table, for adding fees and products. This PR only adds the  `+ Fee` dialog.

<img width="735" alt="order-with-buttons" src="https://user-images.githubusercontent.com/541093/32004458-c830becc-b96f-11e7-8d23-fa21f386c650.png">

Once clicked, + Fee opens this modal (the misaligned text input will be fixed with #19130). The Add Fee button is disabled until content is entered in both the name and value inputs. The mockup initially asked for just a value, with the option of flat fee or percentage fee — we need a name as well, so I've added the input for that, and percentage fees aren't supported by the API, so I'm just asking for a flat fee.

<img width="657" alt="fee-modal" src="https://user-images.githubusercontent.com/541093/32004459-c8471154-b96f-11e7-92a1-3d77155d573b.png">

Once added, the new fee shows up in the orders table, with the ability to delete it if necessary:

<img width="743" alt="added-fee" src="https://user-images.githubusercontent.com/541093/32004460-c85be462-b96f-11e7-9ceb-2a90978a5daa.png">

**To test**

- View your orders, and click into a single order. Toggle on the edit state by clicking Edit Order
- Click the `+ Fee` button, make sure the fee modal opens
- Note that save is disabled until you fill out the form, but you can close the modal by clicking Cancel
- Enter a few different values for fees, make sure they're added to the order as you'd expect

Note: This doesn't save yet, if you go to save the order you'll get an error, `woocommerce_rest_invalid_item_id`– "Order item ID provided is not associated with order." This is due to the fee's placeholder ID, and is fixed by using the removeTemporaryIds function that's added in #19128 
