### PR TITLE
Enable "WooCommerce in non-atomic sites" in dev/staging

### DIFF
--- a/client/extensions/woocommerce/app/index.js
+++ b/client/extensions/woocommerce/app/index.js
@@ -62,17 +62,14 @@ class App extends Component {
 			return null;
 		}
 
-		if ( 'wpcalypso' !== config( 'env_id' ) && 'development' !== config( 'env_id' ) ) {
-			// Show stats page for non Atomic sites for now
-			if ( ! isAtomicSite && ! config.isEnabled( 'woocommerce/store-on-non-atomic-sites' ) ) {
-				this.redirect();
-				return null;
-			}
+		if ( ! isAtomicSite && ! config.isEnabled( 'woocommerce/store-on-non-atomic-sites' ) ) {
+			this.redirect();
+			return null;
+		}
 
-			if ( ! canUserManageOptions ) {
-				this.redirect();
-				return null;
-			}
+		if ( ! canUserManageOptions ) {
+			this.redirect();
+			return null;
 		}
 
 		const documentTitle = this.props.documentTitle || translate( 'Store' );

--- a/client/extensions/woocommerce/components/action-header/index.js
+++ b/client/extensions/woocommerce/components/action-header/index.js
@@ -14,8 +14,6 @@ import { isArray } from 'lodash';
 import Card from 'components/card';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import StickyPanel from 'components/sticky-panel';
-import Notice from 'components/notice';
-import config from 'config';
 
 const ActionHeader = ( { children, breadcrumbs } ) => {
 	// TODO: Implement proper breadcrumbs component.

--- a/client/extensions/woocommerce/components/action-header/index.js
+++ b/client/extensions/woocommerce/components/action-header/index.js
@@ -36,20 +36,9 @@ const ActionHeader = ( { children, breadcrumbs } ) => {
 		} );
 	}
 
-	const showNonAtomicWarrningNotice = config.isEnabled( 'woocommerce/store-on-non-atomic-sites' );
-
 	return (
 		<StickyPanel>
 			<SidebarNavigation />
-			{ showNonAtomicWarrningNotice && (
-				<Notice
-					status="is-warning"
-					className="action-header__notice"
-					isCompact={ true }
-					text={ 'Store on non Atomic Jetpack site development mode!' }
-					showDismiss={ false }
-				/>
-			) }
 			<Card className="action-header__header">
 				<span className="action-header__breadcrumbs">{ breadcrumbsOutput }</span>
 				<div className="action-header__actions">{ children }</div>

--- a/config/development.json
+++ b/config/development.json
@@ -193,7 +193,7 @@
 		"woocommerce/extension-settings-stripe-connect-flows": true,
 		"woocommerce/extension-settings-tax": true,
 		"woocommerce/extension-wcservices": true,
-		"woocommerce/store-on-non-atomic-sites": false,
+		"woocommerce/store-on-non-atomic-sites": true,
 		"wpcom-user-bootstrap": false
 	}
 }

--- a/config/stage.json
+++ b/config/stage.json
@@ -141,6 +141,7 @@
 		"woocommerce/extension-settings-stripe-connect-flows": false,
 		"woocommerce/extension-settings-tax": true,
 		"woocommerce/extension-wcservices": true,
+		"woocommerce/store-on-non-atomic-sites": true,
 		"wpcom-user-bootstrap": false
 	},
 	"siftscience_key": "e00e878351",


### PR DESCRIPTION
This PR enables the flag `woocommerce/store-on-non-atomic-sites` in `development` and `staging`. That allows us to test WooCommerce features in Jetpack sites.

It also removes the notice that pops up if the feature is enabled.

I don't consider this a "dev-only" feature anymore. The changes in this PR allow us to just enable the flag in `production` when we're ready to open Store to non-Atomic sites.