### PR TITLE
Comments: moves analytics side-effects to the data-layer for like comment action

### DIFF
--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -365,11 +365,9 @@ export class CommentList extends Component {
 			return;
 		}
 
-		const alsoApprove = 'unapproved' === status;
+		this.props.likeComment( commentId, postId );
 
-		this.props.likeComment( commentId, postId, { alsoApprove } );
-
-		if ( alsoApprove ) {
+		if ( 'unapproved' === status ) {
 			this.props.removeNotice( `comment-notice-${ commentId }` );
 			this.setCommentStatus( comment, 'approved', { doPersist: true, showNotice: true } );
 			this.updatePersistedComments( commentId );
@@ -556,18 +554,7 @@ const mapDispatchToProps = ( dispatch, { siteId } ) => ( {
 			)
 		),
 
-	likeComment: ( commentId, postId, analytics = { alsoApprove: false } ) =>
-		dispatch(
-			withAnalytics(
-				composeAnalytics(
-					recordTracksEvent( 'calypso_comment_management_like', {
-						also_approve: analytics.alsoApprove,
-					} ),
-					bumpStat( 'calypso_comment_management', 'comment_liked' )
-				),
-				likeComment( siteId, postId, commentId )
-			)
-		),
+	likeComment: ( commentId, postId ) => dispatch( likeComment( siteId, postId, commentId ) ),
 
 	recordBulkAction: ( action, count, fromList, view = 'site' ) =>
 		dispatch(

--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -343,7 +343,7 @@ export class CommentList extends Component {
 					showNotice: false,
 				} );
 				if ( previousIsLiked ) {
-					this.props.likeComment( commentId, postId );
+					this.props.likeComment( commentId, postId, newStatus );
 				} else if ( ! previousIsLiked && 'approved' !== previousStatus ) {
 					this.props.unlikeComment( commentId, postId );
 				}
@@ -365,7 +365,7 @@ export class CommentList extends Component {
 			return;
 		}
 
-		this.props.likeComment( commentId, postId );
+		this.props.likeComment( commentId, postId, status );
 
 		if ( 'unapproved' === status ) {
 			this.props.removeNotice( `comment-notice-${ commentId }` );
@@ -554,7 +554,8 @@ const mapDispatchToProps = ( dispatch, { siteId } ) => ( {
 			)
 		),
 
-	likeComment: ( commentId, postId ) => dispatch( likeComment( siteId, postId, commentId ) ),
+	likeComment: ( commentId, postId, status ) =>
+		dispatch( likeComment( siteId, postId, commentId, status ) ),
 
 	recordBulkAction: ( action, count, fromList, view = 'site' ) =>
 		dispatch(

--- a/client/state/comments/actions.js
+++ b/client/state/comments/actions.js
@@ -144,11 +144,12 @@ export const replyComment = ( commentText, siteId, postId, parentCommentId ) => 
  * @param {Number} commentId comment identifier
  * @returns {Function} think that likes a comment
  */
-export const likeComment = ( siteId, postId, commentId ) => ( {
+export const likeComment = ( siteId, postId, commentId, status ) => ( {
 	type: COMMENTS_LIKE,
 	siteId,
 	postId,
 	commentId,
+	status,
 } );
 
 /***

--- a/client/state/data-layer/wpcom/sites/comments/likes/new/index.js
+++ b/client/state/data-layer/wpcom/sites/comments/likes/new/index.js
@@ -20,7 +20,6 @@ import {
 	withAnalytics,
 } from 'state/analytics/actions';
 import { errorNotice } from 'state/notices/actions';
-import { getSiteComment } from 'state/selectors';
 
 export const likeComment = ( { dispatch }, action ) => {
 	dispatch(
@@ -36,17 +35,15 @@ export const likeComment = ( { dispatch }, action ) => {
 };
 
 export const updateCommentLikes = (
-	{ dispatch, getState },
-	{ siteId, postId, commentId },
+	{ dispatch },
+	{ siteId, postId, commentId, status },
 	{ like_count }
-) => {
-	const comment = getSiteComment( getState(), siteId, commentId );
-
+) =>
 	dispatch(
 		withAnalytics(
 			composeAnalytics(
 				recordTracksEvent( 'calypso_comment_management_like', {
-					also_approve: 'unapproved' !== comment.status,
+					also_approve: 'unapproved' === status,
 				} ),
 				bumpStat( 'calypso_comment_management', 'comment_liked' )
 			),
@@ -59,7 +56,6 @@ export const updateCommentLikes = (
 			} )
 		)
 	);
-};
 
 /***
  * dispatches a error notice if creating a new comment request failed

--- a/client/state/data-layer/wpcom/sites/comments/likes/new/test/index.js
+++ b/client/state/data-layer/wpcom/sites/comments/likes/new/test/index.js
@@ -76,7 +76,7 @@ describe( '#updateCommentLikes()', () => {
 							type: 'ANALYTICS_EVENT_RECORD',
 							payload: {
 								name: 'calypso_comment_management_like',
-								properties: { also_approve: true },
+								properties: { also_approve: false },
 								service: 'tracks',
 							},
 						},

--- a/client/state/data-layer/wpcom/sites/comments/likes/new/test/index.js
+++ b/client/state/data-layer/wpcom/sites/comments/likes/new/test/index.js
@@ -46,9 +46,16 @@ describe( '#likeComment()', () => {
 describe( '#updateCommentLikes()', () => {
 	test( 'should dispatch a comment like update action', () => {
 		const dispatch = spy();
+		const getState = () => ( {
+			comments: {
+				items: {
+					[ `${ SITE_ID }-${ POST_ID }` ]: [ { ID: 1, status: 'approved' } ],
+				},
+			},
+		} );
 
 		updateCommentLikes(
-			{ dispatch },
+			{ dispatch, getState },
 			{ siteId: SITE_ID, postId: POST_ID, commentId: 1 },
 			{
 				like_count: 4,
@@ -63,6 +70,26 @@ describe( '#updateCommentLikes()', () => {
 				postId: POST_ID,
 				commentId: 1,
 				like_count: 4,
+				meta: {
+					analytics: [
+						{
+							type: 'ANALYTICS_EVENT_RECORD',
+							payload: {
+								name: 'calypso_comment_management_like',
+								properties: { also_approve: true },
+								service: 'tracks',
+							},
+						},
+						{
+							type: 'ANALYTICS_STAT_BUMP',
+							payload: {
+								group: 'calypso_comment_management',
+								name: 'comment_liked',
+							},
+						},
+					],
+					dataLayer: { doBypass: true },
+				},
 			} )
 		);
 	} );


### PR DESCRIPTION
This PR is moves analytics from `CommentList` to the `data-layer` for the like a comment action. One small step in the way of removing responsibility from `CommentList`.

To test:

- enable analytics debug messages by localStorage.setItem( 'debug', 'calypso:analytics*' );
- like an approved comment:
  - event `calypso_comment_management_like` with `also_approve: false`  should be recorded.
  - MC stats for `calypso_comment_management:comment_liked` should be bumped
- like an unapproved comment:
  - event `calypso_comment_management_like` with `also_approve: true`  should be recorded.
  - MC stats for `calypso_comment_management:comment_liked` should be bumped

Observations:

Ideally, the comment status should be extracted from the state by the `data-layer`, but for that we'l need to refactor `setCommentStatus` to dispatch that status change as another side effect from the `data-layer`.

Tests need a small update before merging.