### PR TITLE
Comments: moves analytics side-effects to the data-layer for unlike comment action

### DIFF
--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -605,16 +605,7 @@ const mapDispatchToProps = ( dispatch, { siteId } ) => ( {
 			)
 		),
 
-	unlikeComment: ( commentId, postId ) =>
-		dispatch(
-			withAnalytics(
-				composeAnalytics(
-					recordTracksEvent( 'calypso_comment_management_unlike' ),
-					bumpStat( 'calypso_comment_management', 'comment_unliked' )
-				),
-				unlikeComment( siteId, postId, commentId )
-			)
-		),
+	unlikeComment: ( commentId, postId ) => dispatch( unlikeComment( siteId, postId, commentId ) ),
 } );
 
 export default connect( mapStateToProps, mapDispatchToProps )( localize( CommentList ) );

--- a/client/state/data-layer/wpcom/sites/comments/likes/mine/delete/index.js
+++ b/client/state/data-layer/wpcom/sites/comments/likes/mine/delete/index.js
@@ -13,6 +13,12 @@ import { COMMENTS_LIKE, COMMENTS_UNLIKE } from 'state/action-types';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { bypassDataLayer } from 'state/data-layer/utils';
 import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
+import {
+	bumpStat,
+	composeAnalytics,
+	recordTracksEvent,
+	withAnalytics,
+} from 'state/analytics/actions';
 import { errorNotice } from 'state/notices/actions';
 
 export const unlikeComment = ( { dispatch }, action ) => {
@@ -30,13 +36,19 @@ export const unlikeComment = ( { dispatch }, action ) => {
 
 export const updateCommentLikes = ( { dispatch }, { siteId, postId, commentId }, { like_count } ) =>
 	dispatch(
-		bypassDataLayer( {
-			type: COMMENTS_UNLIKE,
-			siteId,
-			postId,
-			commentId,
-			like_count,
-		} )
+		withAnalytics(
+			composeAnalytics(
+				recordTracksEvent( 'calypso_comment_management_unlike' ),
+				bumpStat( 'calypso_comment_management', 'comment_unliked' )
+			),
+			bypassDataLayer( {
+				type: COMMENTS_UNLIKE,
+				siteId,
+				postId,
+				commentId,
+				like_count,
+			} )
+		)
 	);
 
 /***

--- a/client/state/data-layer/wpcom/sites/comments/likes/mine/delete/test/index.js
+++ b/client/state/data-layer/wpcom/sites/comments/likes/mine/delete/test/index.js
@@ -63,6 +63,26 @@ describe( '#updateCommentLikes()', () => {
 				postId: POST_ID,
 				commentId: 1,
 				like_count: 4,
+				meta: {
+					analytics: [
+						{
+							type: 'ANALYTICS_EVENT_RECORD',
+							payload: {
+								name: 'calypso_comment_management_unlike',
+								properties: undefined,
+								service: 'tracks',
+							},
+						},
+						{
+							type: 'ANALYTICS_STAT_BUMP',
+							payload: {
+								group: 'calypso_comment_management',
+								name: 'comment_unliked',
+							},
+						},
+					],
+					dataLayer: { doBypass: true },
+				},
 			} )
 		);
 	} );


### PR DESCRIPTION
This PR is moves analytics from `CommentList` to the `data-layer` for the unlike a comment action. One small step in the way of removing responsibility from `CommentList`.

To test:

- enable analytics debug messages by localStorage.setItem( 'debug', 'calypso:analytics*' );
- unlike a comment:
  - event `calypso_comment_management_unlike` with `also_approve: false`  should be recorded.
  - MC stats for `calypso_comment_management:comment_unliked` should be bumped

Observations:

Tests need a small update before merging.