### PR TITLE
Jetpack connect: Add test for hasPlan update redirect

### DIFF
--- a/client/jetpack-connect/test/lib/plans.js
+++ b/client/jetpack-connect/test/lib/plans.js
@@ -424,33 +424,32 @@ export function getSitePlans( currentPlan = PLAN_JETPACK_FREE ) {
 	};
 }
 
+export const DEFAULT_PROPS = {
+	basePlansPath: BASE_PLANS_PATH,
+	calypsoStartedConnection: false,
+	canPurchasePlans: true,
+	cart: CART,
+	completeFlow: noop,
+	context: CONTEXT,
+	flowType: false,
+	getPlanBySlug: noop,
+	goBackToWpAdmin: noop,
+	isAutomatedTransfer: false,
+	isRequestingPlans: false,
+	isRtlLayout: false,
+	jetpackConnectAuthorize: {},
+	recordTracksEvent: noop,
+	redirectingToWpAdmin: false,
+	selectedSite: SELECTED_SITE,
+	selectedSiteSlug: SITE_SLUG,
+	selectPlanInAdvance: noop,
+	sitePlans: getSitePlans(),
+	siteSlug: PLANS_SLUG,
+	transaction: TRANSACTION,
+	translate: identity,
+	userId: USER_ID,
+};
+
 export default function PlansWrapper( props ) {
-	return (
-		<Plans
-			basePlansPath={ BASE_PLANS_PATH }
-			calypsoStartedConnection={ false }
-			canPurchasePlans={ true }
-			cart={ CART }
-			completeFlow={ noop }
-			context={ CONTEXT }
-			flowType={ false }
-			getPlanBySlug={ noop }
-			goBackToWpAdmin={ noop }
-			isAutomatedTransfer={ false }
-			isRequestingPlans={ false }
-			isRtlLayout={ false }
-			jetpackConnectAuthorize={ {} }
-			recordTracksEvent={ noop }
-			redirectingToWpAdmin={ false }
-			selectedSite={ SELECTED_SITE }
-			selectedSiteSlug={ SITE_SLUG }
-			selectPlanInAdvance={ noop }
-			sitePlans={ getSitePlans() }
-			siteSlug={ PLANS_SLUG }
-			transaction={ TRANSACTION }
-			translate={ identity }
-			userId={ USER_ID }
-			{ ...props }
-		/>
-	);
+	return <Plans { ...DEFAULT_PROPS } { ...props } />;
 }

--- a/client/jetpack-connect/test/plans.js
+++ b/client/jetpack-connect/test/plans.js
@@ -11,7 +11,13 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import PlansWrapper, { getSitePlans, SELECTED_SITE, SITE_PLAN_PRO } from './lib/plans';
+import PlansWrapper, {
+	DEFAULT_PROPS,
+	getSitePlans,
+	SELECTED_SITE,
+	SITE_PLAN_PRO,
+} from './lib/plans';
+import { PlansTestComponent as Plans } from '../plans';
 import { PLAN_JETPACK_BUSINESS } from 'lib/plans/constants';
 
 jest.mock( 'components/data/query-plans', () => 'components--data--query-plans' );
@@ -35,6 +41,21 @@ describe( 'Plans', () => {
 		);
 
 		expect( wrapper ).toMatchSnapshot();
+	} );
+
+	test( 'should redirect on update from free to paid plan', () => {
+		const wrapper = mount( <Plans { ...DEFAULT_PROPS } /> );
+
+		const redirect = ( wrapper.instance().redirect = jest.fn() );
+
+		wrapper.setProps( {
+			selectedSite: { ...SELECTED_SITE, plan: SITE_PLAN_PRO },
+			sitePlans: getSitePlans( PLAN_JETPACK_BUSINESS ),
+		} );
+
+		expect( redirect.mock.calls.length ).toBe( 1 );
+
+		wrapper.unmount();
 	} );
 
 	test( 'should redirect if Atomic', () => {

--- a/client/jetpack-connect/test/plans.js
+++ b/client/jetpack-connect/test/plans.js
@@ -40,7 +40,7 @@ describe( 'Plans', () => {
 	test( 'should redirect if Atomic', () => {
 		const goBackToWpAdmin = jest.fn();
 
-		mount(
+		const wrapper = mount(
 			<PlansWrapper
 				goBackToWpAdmin={ goBackToWpAdmin }
 				isAutomatedTransfer={ true }
@@ -54,5 +54,7 @@ describe( 'Plans', () => {
 		);
 
 		expect( goBackToWpAdmin.mock.calls.length ).toBe( 1 );
+
+		wrapper.unmount();
 	} );
 } );


### PR DESCRIPTION
This PR includes 3 test changes:

* unmount component after testing with `mount`.
* Exports default props used in component wrapper test fixture.
* Adds a test to verify the `redirect` method is called when props are updated so the site has a paid plan.

In the future, the wrapper fixture will probably be removed `{ ...DEFAULTS_PROPS }` will be used. The wrapper is a bit inconvenient when working with component tests. In this case, `instance()` was required but is only available on the root, which was not the desired component.

The tests added should improve confidence about the correctness of #19145 

/cc @seear 