### PR TITLE
Reader: split full post CSS out of the main bundle

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -62,7 +62,6 @@
 @import 'blocks/reader-feed-header/style';
 @import 'blocks/reader-featured-image/style';
 @import 'blocks/reader-featured-video/style';
-@import 'blocks/reader-full-post/style';
 @import 'blocks/reader-import-button/style';
 @import 'blocks/reader-post-actions/style';
 @import 'blocks/reader-post-card/style';

--- a/assets/stylesheets/sections/reader-full-post.scss
+++ b/assets/stylesheets/sections/reader-full-post.scss
@@ -1,0 +1,5 @@
+@import '../shared/colors';
+@import '../shared/mixins/mixins'; // we use the noticon-style mixin from here
+@import '../shared/typography';
+
+@import 'blocks/reader-full-post/style';

--- a/client/wordpress-com.js
+++ b/client/wordpress-com.js
@@ -262,6 +262,7 @@ sections.push( {
 	module: 'reader/full-post',
 	secondary: false,
 	group: 'reader',
+	css: 'reader-full-post',
 } );
 
 sections.push( {


### PR DESCRIPTION
Using the CSS splitting functionality made available in https://github.com/Automattic/wp-calypso/pull/17988, this PR creates a separate stylesheet for Reader full post that is now loaded on demand.

The Reader full post CSS file is the largest for a single block at 24Kb.

### To test

- [ ] Open http://calypso.localhost:3000, navigate to a Reader full post and make sure the styles are applied correctly.
- [ ] ensure there is a new css asset being generated