### PR TITLE
Framework: Remove react-test-env

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -5974,36 +5974,6 @@
         }
       }
     },
-    "react-test-env": {
-      "version": "0.2.0",
-      "dev": true,
-      "dependencies": {
-        "acorn": {
-          "version": "2.7.0",
-          "dev": true
-        },
-        "acorn-globals": {
-          "version": "1.0.9",
-          "dev": true
-        },
-        "jsdom": {
-          "version": "9.4.1",
-          "dev": true
-        },
-        "lodash.assign": {
-          "version": "4.1.0",
-          "dev": true
-        },
-        "webidl-conversions": {
-          "version": "3.0.1",
-          "dev": true
-        },
-        "whatwg-url": {
-          "version": "3.1.0",
-          "dev": true
-        }
-      }
-    },
     "react-test-renderer": {
       "version": "15.6.2",
       "dev": true

--- a/package.json
+++ b/package.json
@@ -277,7 +277,6 @@
     "pretty-bytes": "4.0.2",
     "react-addons-test-utils": "15.6.2",
     "react-codemod": "reactjs/react-codemod",
-    "react-test-env": "0.2.0",
     "react-test-renderer": "15.6.2",
     "readline-sync": "1.4.5",
     "sinon": "1.17.7",


### PR DESCRIPTION
Obsolete, as of the move to Jest.

To test -- verify that tests still pass.