### PR TITLE
Activity Log: if an item is not rewindable, don't show the ellipsis menu

### DIFF
--- a/client/my-sites/stats/activity-log-item/index.jsx
+++ b/client/my-sites/stats/activity-log-item/index.jsx
@@ -119,10 +119,10 @@ class ActivityLogItem extends Component {
 		);
 	}
 
-	renderSummary() {
-		const { disableRestore, hideRestore, translate } = this.props;
+	renderItemAction() {
+		const { disableRestore, hideRestore, translate, log: { activityIsRewindable } } = this.props;
 
-		if ( hideRestore ) {
+		if ( hideRestore || ! activityIsRewindable ) {
 			return null;
 		}
 
@@ -168,10 +168,10 @@ class ActivityLogItem extends Component {
 				<FoldableCard
 					className="activity-log-item__card"
 					clickableHeader
-					expandedSummary={ this.renderSummary() }
+					expandedSummary={ this.renderItemAction() }
 					header={ this.renderHeader() }
 					onClick={ this.handleOpen }
-					summary={ this.renderSummary() }
+					summary={ this.renderItemAction() }
 				/>
 			</div>
 		);


### PR DESCRIPTION
If we later add more stuff inside this menu, we'll have to update this so it hides only the "Restore to this point" menu item.