### PR TITLE
Disconnect Survey: Add 'Troubleshooting' option

### DIFF
--- a/client/my-sites/site-settings/disconnect-site/confirm.jsx
+++ b/client/my-sites/site-settings/disconnect-site/confirm.jsx
@@ -40,6 +40,7 @@ class ConfirmDisconnection extends PureComponent {
 			'missing-feature': 'didNotInclude',
 			'too-difficult': 'tooHard',
 			'too-expensive': 'onlyNeedFree',
+			troubleshooting: 'troubleshooting',
 		};
 
 		const surveyData = {

--- a/client/my-sites/site-settings/disconnect-site/disconnect-survey.jsx
+++ b/client/my-sites/site-settings/disconnect-site/disconnect-survey.jsx
@@ -3,6 +3,7 @@
  * External dependencies
  */
 import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
@@ -54,6 +55,15 @@ const DisconnectSurvey = ( { confirmHref, isPaidPlan, siteId, siteSlug, translat
 		</CompactCard>
 	</div>
 );
+
+DisconnectSurvey.propTypes = {
+	confirmHref: PropTypes.string,
+	// Provided by HOCs
+	isPaidPlan: PropTypes.bool,
+	siteId: PropTypes.number,
+	siteSlug: PropTypes.string,
+	translate: PropTypes.func,
+};
 
 export default connect( state => {
 	const siteId = getSelectedSiteId( state );

--- a/client/my-sites/site-settings/disconnect-site/disconnect-survey.jsx
+++ b/client/my-sites/site-settings/disconnect-site/disconnect-survey.jsx
@@ -51,7 +51,7 @@ const DisconnectSurvey = ( { confirmHref, isPaidPlan, siteId, siteSlug, translat
 			href={ confirmHref + '?reason=troubleshooting' }
 			className="disconnect-site__survey-one"
 		>
-			{ translate( "This is temporary -- I'm troubleshooting a problem" ) }
+			{ translate( "Troubleshooting -- I'll be reconnecting afterwards" ) }
 		</CompactCard>
 	</div>
 );

--- a/client/my-sites/site-settings/disconnect-site/disconnect-survey.jsx
+++ b/client/my-sites/site-settings/disconnect-site/disconnect-survey.jsx
@@ -15,7 +15,7 @@ import SectionHeader from 'components/section-header';
 import { isSiteOnPaidPlan } from 'state/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 
-const DisconnectSurvey = ( { isPaidPlan, siteId, siteSlug, translate } ) => (
+const DisconnectSurvey = ( { confirmHref, isPaidPlan, siteId, siteSlug, translate } ) => (
 	<div className="disconnect-site__survey main">
 		<QuerySitePlans siteId={ siteId } />
 		<SectionHeader
@@ -46,6 +46,12 @@ const DisconnectSurvey = ( { isPaidPlan, siteId, siteSlug, translate } ) => (
 				{ translate( 'This plan is too expensive' ) }
 			</CompactCard>
 		) }
+		<CompactCard
+			href={ confirmHref + '?reason=troubleshooting' }
+			className="disconnect-site__survey-one"
+		>
+			{ translate( "This is temporary -- I'm troubleshooting a problem" ) }
+		</CompactCard>
 	</div>
 );
 


### PR DESCRIPTION
Add the `This is temporary -- I'm troubleshooting a problem` option. Supersedes (part of) #17962. Also mentioned here: p7rd6c-12Q-p2#comment-1736

![image](https://user-images.githubusercontent.com/96308/32020745-7e8c3294-b9d1-11e7-9cd7-8de321f96df5.png)

**Question:** Upon disconnection, this will submit the survey with `response` set to `troubleshooting`. @bubel Is that okay, do we have precedent for different wording here, or do we rather not submit the survey at all?

To test:
* Start at `/settings/disconnect-site/:site`, verify that the option is available.
* Click on the option. You're taken to the confirmation page.
* Switch to your browser console's network tab, and clear it.
* Confirm the disconnect.
* In the browser console, watch out for the request to the `survey` endpoint. Verify the request contains `survey_responses[why-cancel][response]: troubleshooting` (should be at the very bottom).