### PR TITLE
Bump MC stats for post actions

### DIFF
--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/duplicate.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/duplicate.jsx
@@ -87,14 +87,8 @@ const mapStateToProps = ( state, { globalId } ) => {
 const mapDispatchToProps = { bumpAnalyticsStat };
 
 const mergeProps = ( stateProps, dispatchProps, ownProps ) => {
-	const bumpStat = bumpStatGenerator(
-		stateProps.type.name,
-		'duplicate',
-		dispatchProps.bumpAnalyticsStat
-	);
+	const bumpStat = bumpStatGenerator( stateProps.type.name, 'duplicate', dispatchProps.bumpAnalyticsStat );
 	return Object.assign( {}, ownProps, stateProps, dispatchProps, { bumpStat } );
 };
 
-export default connect( mapStateToProps, mapDispatchToProps, mergeProps )(
-	localize( PostActionsEllipsisMenuDuplicate )
-);
+export default connect( mapStateToProps, mapDispatchToProps, mergeProps )( localize( PostActionsEllipsisMenuDuplicate ) );

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/duplicate.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/duplicate.jsx
@@ -87,8 +87,14 @@ const mapStateToProps = ( state, { globalId } ) => {
 const mapDispatchToProps = { bumpAnalyticsStat };
 
 const mergeProps = ( stateProps, dispatchProps, ownProps ) => {
-	const bumpStat = bumpStatGenerator( stateProps.type.name, 'duplicate', dispatchProps.bumpAnalyticsStat );
+	const bumpStat = bumpStatGenerator(
+		stateProps.type.name,
+		'duplicate',
+		dispatchProps.bumpAnalyticsStat
+	);
 	return Object.assign( {}, ownProps, stateProps, dispatchProps, { bumpStat } );
 };
 
-export default connect( mapStateToProps, mapDispatchToProps, mergeProps )( localize( PostActionsEllipsisMenuDuplicate ) );
+export default connect( mapStateToProps, mapDispatchToProps, mergeProps )(
+	localize( PostActionsEllipsisMenuDuplicate )
+);

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/edit.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/edit.jsx
@@ -84,8 +84,14 @@ const mapStateToProps = ( state, { globalId } ) => {
 const mapDispatchToProps = { bumpAnalyticsStat };
 
 const mergeProps = ( stateProps, dispatchProps, ownProps ) => {
-	const bumpStat = bumpStatGenerator( stateProps.type.name, 'edit', dispatchProps.bumpAnalyticsStat );
+	const bumpStat = bumpStatGenerator(
+		stateProps.type.name,
+		'edit',
+		dispatchProps.bumpAnalyticsStat
+	);
 	return Object.assign( {}, ownProps, stateProps, dispatchProps, { bumpStat } );
 };
 
-export default connect( mapStateToProps, mapDispatchToProps, mergeProps )( localize( PostActionsEllipsisMenuEdit ) );
+export default connect( mapStateToProps, mapDispatchToProps, mergeProps )(
+	localize( PostActionsEllipsisMenuEdit )
+);

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/edit.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/edit.jsx
@@ -84,14 +84,8 @@ const mapStateToProps = ( state, { globalId } ) => {
 const mapDispatchToProps = { bumpAnalyticsStat };
 
 const mergeProps = ( stateProps, dispatchProps, ownProps ) => {
-	const bumpStat = bumpStatGenerator(
-		stateProps.type.name,
-		'edit',
-		dispatchProps.bumpAnalyticsStat
-	);
+	const bumpStat = bumpStatGenerator( stateProps.type.name, 'edit', dispatchProps.bumpAnalyticsStat );
 	return Object.assign( {}, ownProps, stateProps, dispatchProps, { bumpStat } );
 };
 
-export default connect( mapStateToProps, mapDispatchToProps, mergeProps )(
-	localize( PostActionsEllipsisMenuEdit )
-);
+export default connect( mapStateToProps, mapDispatchToProps, mergeProps )( localize( PostActionsEllipsisMenuEdit ) );

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/publish.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/publish.jsx
@@ -81,14 +81,9 @@ const mapStateToProps = ( state, { globalId } ) => {
 const mapDispatchToProps = { savePost, bumpAnalyticsStat };
 
 const mergeProps = ( stateProps, dispatchProps, ownProps ) => {
-	const bumpStat = bumpStatGenerator(
-		stateProps.type.name,
-		'publish',
-		dispatchProps.bumpAnalyticsStat
-	);
+	const bumpStat = bumpStatGenerator( stateProps.type.name, 'publish', dispatchProps.bumpAnalyticsStat );
 	return Object.assign( {}, ownProps, stateProps, dispatchProps, { bumpStat } );
 };
 
-export default connect( mapStateToProps, mapDispatchToProps, mergeProps )(
-	localize( PostActionsEllipsisMenuPublish )
-);
+export default connect( mapStateToProps, mapDispatchToProps, mergeProps )( localize( PostActionsEllipsisMenuPublish ) );
+

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/publish.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/publish.jsx
@@ -81,9 +81,14 @@ const mapStateToProps = ( state, { globalId } ) => {
 const mapDispatchToProps = { savePost, bumpAnalyticsStat };
 
 const mergeProps = ( stateProps, dispatchProps, ownProps ) => {
-	const bumpStat = bumpStatGenerator( stateProps.type.name, 'publish', dispatchProps.bumpAnalyticsStat );
+	const bumpStat = bumpStatGenerator(
+		stateProps.type.name,
+		'publish',
+		dispatchProps.bumpAnalyticsStat
+	);
 	return Object.assign( {}, ownProps, stateProps, dispatchProps, { bumpStat } );
 };
 
-export default connect( mapStateToProps, mapDispatchToProps, mergeProps )( localize( PostActionsEllipsisMenuPublish ) );
-
+export default connect( mapStateToProps, mapDispatchToProps, mergeProps )(
+	localize( PostActionsEllipsisMenuPublish )
+);

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/restore.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/restore.jsx
@@ -88,14 +88,8 @@ const mapStateToProps = ( state, { globalId } ) => {
 const mapDispatchToProps = { restorePost, bumpAnalyticsStat };
 
 const mergeProps = ( stateProps, dispatchProps, ownProps ) => {
-	const bumpStat = bumpStatGenerator(
-		stateProps.type.name,
-		'restore',
-		dispatchProps.bumpAnalyticsStat
-	);
+	const bumpStat = bumpStatGenerator( stateProps.type.name, 'restore', dispatchProps.bumpAnalyticsStat );
 	return Object.assign( {}, ownProps, stateProps, dispatchProps, { bumpStat } );
 };
 
-export default connect( mapStateToProps, mapDispatchToProps, mergeProps )(
-	localize( PostActionsEllipsisMenuRestore )
-);
+export default connect( mapStateToProps, mapDispatchToProps, mergeProps )( localize( PostActionsEllipsisMenuRestore ) );

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/restore.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/restore.jsx
@@ -88,8 +88,14 @@ const mapStateToProps = ( state, { globalId } ) => {
 const mapDispatchToProps = { restorePost, bumpAnalyticsStat };
 
 const mergeProps = ( stateProps, dispatchProps, ownProps ) => {
-	const bumpStat = bumpStatGenerator( stateProps.type.name, 'restore', dispatchProps.bumpAnalyticsStat );
+	const bumpStat = bumpStatGenerator(
+		stateProps.type.name,
+		'restore',
+		dispatchProps.bumpAnalyticsStat
+	);
 	return Object.assign( {}, ownProps, stateProps, dispatchProps, { bumpStat } );
 };
 
-export default connect( mapStateToProps, mapDispatchToProps, mergeProps )( localize( PostActionsEllipsisMenuRestore ) );
+export default connect( mapStateToProps, mapDispatchToProps, mergeProps )(
+	localize( PostActionsEllipsisMenuRestore )
+);

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/share.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/share.jsx
@@ -77,14 +77,8 @@ const mapStateToProps = ( state, { globalId } ) => {
 const mapDispatchToProps = { toggleSharePanel, bumpAnalyticsStat };
 
 const mergeProps = ( stateProps, dispatchProps, ownProps ) => {
-	const bumpStat = bumpStatGenerator(
-		stateProps.type.name,
-		'share',
-		dispatchProps.bumpAnalyticsStat
-	);
+	const bumpStat = bumpStatGenerator( stateProps.type.name, 'share', dispatchProps.bumpAnalyticsStat );
 	return Object.assign( {}, ownProps, stateProps, dispatchProps, { bumpStat } );
 };
 
-export default connect( mapStateToProps, mapDispatchToProps, mergeProps )(
-	localize( PostActionsEllipsisMenuShare )
-);
+export default connect( mapStateToProps, mapDispatchToProps, mergeProps )( localize( PostActionsEllipsisMenuShare ) );

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/share.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/share.jsx
@@ -77,8 +77,14 @@ const mapStateToProps = ( state, { globalId } ) => {
 const mapDispatchToProps = { toggleSharePanel, bumpAnalyticsStat };
 
 const mergeProps = ( stateProps, dispatchProps, ownProps ) => {
-	const bumpStat = bumpStatGenerator( stateProps.type.name, 'share', dispatchProps.bumpAnalyticsStat );
+	const bumpStat = bumpStatGenerator(
+		stateProps.type.name,
+		'share',
+		dispatchProps.bumpAnalyticsStat
+	);
 	return Object.assign( {}, ownProps, stateProps, dispatchProps, { bumpStat } );
 };
 
-export default connect( mapStateToProps, mapDispatchToProps, mergeProps )( localize( PostActionsEllipsisMenuShare ) );
+export default connect( mapStateToProps, mapDispatchToProps, mergeProps )(
+	localize( PostActionsEllipsisMenuShare )
+);

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/stats.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/stats.jsx
@@ -13,15 +13,20 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import PopoverMenuItem from 'components/popover/menu-item';
-import { mc } from 'lib/analytics';
+import { bumpStat as bumpAnalyticsStat } from 'state/analytics/actions';
+import { bumpStatGenerator } from './utils';
 import { getSiteSlug, isJetpackModuleActive } from 'state/sites/selectors';
 import { getPost } from 'state/posts/selectors';
+import { getPostType } from 'state/post-types/selectors';
 
-function bumpStat() {
-	mc.bumpStat( 'calypso_cpt_actions', 'stats' );
-}
-
-function PostActionsEllipsisMenuStats( { translate, siteSlug, postId, status, isStatsActive } ) {
+function PostActionsEllipsisMenuStats( {
+	translate,
+	siteSlug,
+	postId,
+	status,
+	isStatsActive,
+	bumpStat,
+} ) {
 	if ( ! isStatsActive || 'publish' !== status ) {
 		return null;
 	}
@@ -44,10 +49,11 @@ PostActionsEllipsisMenuStats.propTypes = {
 	postId: PropTypes.number,
 	status: PropTypes.string,
 	isStatsActive: PropTypes.bool,
+	bumpStat: PropTypes.func,
 };
 
-export default connect( ( state, ownProps ) => {
-	const post = getPost( state, ownProps.globalId );
+const mapStateToProps = ( state, { globalId } ) => {
+	const post = getPost( state, globalId );
 	if ( ! post ) {
 		return {};
 	}
@@ -57,5 +63,21 @@ export default connect( ( state, ownProps ) => {
 		postId: post.ID,
 		status: post.status,
 		isStatsActive: false !== isJetpackModuleActive( state, post.site_ID, 'stats' ),
+		type: getPostType( state, post.site_ID, post.type ),
 	};
-} )( localize( PostActionsEllipsisMenuStats ) );
+};
+
+const mapDispatchToProps = { bumpAnalyticsStat };
+
+const mergeProps = ( stateProps, dispatchProps, ownProps ) => {
+	const bumpStat = bumpStatGenerator(
+		stateProps.type.name,
+		'stats',
+		dispatchProps.bumpAnalyticsStat
+	);
+	return Object.assign( {}, ownProps, stateProps, dispatchProps, { bumpStat } );
+};
+
+export default connect( mapStateToProps, mapDispatchToProps, mergeProps )(
+	localize( PostActionsEllipsisMenuStats )
+);

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/stats.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/stats.jsx
@@ -19,14 +19,7 @@ import { getSiteSlug, isJetpackModuleActive } from 'state/sites/selectors';
 import { getPost } from 'state/posts/selectors';
 import { getPostType } from 'state/post-types/selectors';
 
-function PostActionsEllipsisMenuStats( {
-	translate,
-	siteSlug,
-	postId,
-	status,
-	isStatsActive,
-	bumpStat,
-} ) {
+function PostActionsEllipsisMenuStats( { translate, siteSlug, postId, status, isStatsActive, bumpStat, } ) {
 	if ( ! isStatsActive || 'publish' !== status ) {
 		return null;
 	}
@@ -70,14 +63,8 @@ const mapStateToProps = ( state, { globalId } ) => {
 const mapDispatchToProps = { bumpAnalyticsStat };
 
 const mergeProps = ( stateProps, dispatchProps, ownProps ) => {
-	const bumpStat = bumpStatGenerator(
-		stateProps.type.name,
-		'stats',
-		dispatchProps.bumpAnalyticsStat
-	);
+	const bumpStat = bumpStatGenerator( stateProps.type.name, 'stats', dispatchProps.bumpAnalyticsStat );
 	return Object.assign( {}, ownProps, stateProps, dispatchProps, { bumpStat } );
 };
 
-export default connect( mapStateToProps, mapDispatchToProps, mergeProps )(
-	localize( PostActionsEllipsisMenuStats )
-);
+export default connect( mapStateToProps, mapDispatchToProps, mergeProps )( localize( PostActionsEllipsisMenuStats ) );

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/stats.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/stats.jsx
@@ -19,7 +19,14 @@ import { getSiteSlug, isJetpackModuleActive } from 'state/sites/selectors';
 import { getPost } from 'state/posts/selectors';
 import { getPostType } from 'state/post-types/selectors';
 
-function PostActionsEllipsisMenuStats( { translate, siteSlug, postId, status, isStatsActive, bumpStat, } ) {
+function PostActionsEllipsisMenuStats( {
+	translate,
+	siteSlug,
+	postId,
+	status,
+	isStatsActive,
+	bumpStat,
+} ) {
 	if ( ! isStatsActive || 'publish' !== status ) {
 		return null;
 	}
@@ -63,8 +70,14 @@ const mapStateToProps = ( state, { globalId } ) => {
 const mapDispatchToProps = { bumpAnalyticsStat };
 
 const mergeProps = ( stateProps, dispatchProps, ownProps ) => {
-	const bumpStat = bumpStatGenerator( stateProps.type.name, 'stats', dispatchProps.bumpAnalyticsStat );
+	const bumpStat = bumpStatGenerator(
+		stateProps.type.name,
+		'stats',
+		dispatchProps.bumpAnalyticsStat
+	);
 	return Object.assign( {}, ownProps, stateProps, dispatchProps, { bumpStat } );
 };
 
-export default connect( mapStateToProps, mapDispatchToProps, mergeProps )( localize( PostActionsEllipsisMenuStats ) );
+export default connect( mapStateToProps, mapDispatchToProps, mergeProps )(
+	localize( PostActionsEllipsisMenuStats )
+);

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/trash.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/trash.jsx
@@ -99,10 +99,22 @@ const mapStateToProps = ( state, { globalId } ) => {
 const mapDispatchToProps = { trashPost, deletePost, bumpAnalyticsStat };
 
 const mergeProps = ( stateProps, dispatchProps, ownProps ) => {
-	const bumpTrashStat = bumpStatGenerator( stateProps.type.name, 'trash', dispatchProps.bumpAnalyticsStat );
-	const bumpDeleteStat = bumpStatGenerator( stateProps.type.name, 'delete', dispatchProps.bumpAnalyticsStat );
-	return Object.assign( {}, ownProps, stateProps, dispatchProps, { bumpTrashStat, bumpDeleteStat } );
+	const bumpTrashStat = bumpStatGenerator(
+		stateProps.type.name,
+		'trash',
+		dispatchProps.bumpAnalyticsStat
+	);
+	const bumpDeleteStat = bumpStatGenerator(
+		stateProps.type.name,
+		'delete',
+		dispatchProps.bumpAnalyticsStat
+	);
+	return Object.assign( {}, ownProps, stateProps, dispatchProps, {
+		bumpTrashStat,
+		bumpDeleteStat,
+	} );
 };
 
-export default connect( mapStateToProps, mapDispatchToProps, mergeProps )( localize( PostActionsEllipsisMenuTrash ) );
-
+export default connect( mapStateToProps, mapDispatchToProps, mergeProps )(
+	localize( PostActionsEllipsisMenuTrash )
+);

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/trash.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/trash.jsx
@@ -99,22 +99,10 @@ const mapStateToProps = ( state, { globalId } ) => {
 const mapDispatchToProps = { trashPost, deletePost, bumpAnalyticsStat };
 
 const mergeProps = ( stateProps, dispatchProps, ownProps ) => {
-	const bumpTrashStat = bumpStatGenerator(
-		stateProps.type.name,
-		'trash',
-		dispatchProps.bumpAnalyticsStat
-	);
-	const bumpDeleteStat = bumpStatGenerator(
-		stateProps.type.name,
-		'delete',
-		dispatchProps.bumpAnalyticsStat
-	);
-	return Object.assign( {}, ownProps, stateProps, dispatchProps, {
-		bumpTrashStat,
-		bumpDeleteStat,
-	} );
+	const bumpTrashStat = bumpStatGenerator( stateProps.type.name, 'trash', dispatchProps.bumpAnalyticsStat );
+	const bumpDeleteStat = bumpStatGenerator( stateProps.type.name, 'delete', dispatchProps.bumpAnalyticsStat );
+	return Object.assign( {}, ownProps, stateProps, dispatchProps, { bumpTrashStat, bumpDeleteStat } );
 };
 
-export default connect( mapStateToProps, mapDispatchToProps, mergeProps )(
-	localize( PostActionsEllipsisMenuTrash )
-);
+export default connect( mapStateToProps, mapDispatchToProps, mergeProps )( localize( PostActionsEllipsisMenuTrash ) );
+

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/utils.js
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/utils.js
@@ -1,0 +1,11 @@
+export function bumpStatGenerator( type, name, bumpStat ) {
+	return () => {
+		let group;
+		if ( type !== 'page' && type !== 'post' ) {
+			group = 'calypso_cpt_actions';
+		} else {
+			group = 'calypso_' + type + '_actions';
+		}
+		bumpStat( group, name );
+	};
+}

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/view.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/view.jsx
@@ -97,14 +97,8 @@ const mapStateToProps = ( state, { globalId } ) => {
 const mapDispatchToProps = { setPreviewUrl, setLayoutFocus, bumpAnalyticsStat };
 
 const mergeProps = ( stateProps, dispatchProps, ownProps ) => {
-	const bumpStat = bumpStatGenerator(
-		stateProps.type.name,
-		'view',
-		dispatchProps.bumpAnalyticsStat
-	);
+	const bumpStat = bumpStatGenerator( stateProps.type.name, 'view', dispatchProps.bumpAnalyticsStat );
 	return Object.assign( {}, ownProps, stateProps, dispatchProps, { bumpStat } );
 };
 
-export default connect( mapStateToProps, mapDispatchToProps, mergeProps )(
-	localize( PostActionsEllipsisMenuView )
-);
+export default connect( mapStateToProps, mapDispatchToProps, mergeProps )( localize( PostActionsEllipsisMenuView ) );

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/view.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/view.jsx
@@ -97,8 +97,14 @@ const mapStateToProps = ( state, { globalId } ) => {
 const mapDispatchToProps = { setPreviewUrl, setLayoutFocus, bumpAnalyticsStat };
 
 const mergeProps = ( stateProps, dispatchProps, ownProps ) => {
-	const bumpStat = bumpStatGenerator( stateProps.type.name, 'view', dispatchProps.bumpAnalyticsStat );
+	const bumpStat = bumpStatGenerator(
+		stateProps.type.name,
+		'view',
+		dispatchProps.bumpAnalyticsStat
+	);
 	return Object.assign( {}, ownProps, stateProps, dispatchProps, { bumpStat } );
 };
 
-export default connect( mapStateToProps, mapDispatchToProps, mergeProps )( localize( PostActionsEllipsisMenuView ) );
+export default connect( mapStateToProps, mapDispatchToProps, mergeProps )(
+	localize( PostActionsEllipsisMenuView )
+);


### PR DESCRIPTION
This PR records stats for user interactions with the actions menu.

To test:
- Checkout branch
- `ENABLE_FEATURES=posts/post-type-list npm start`
- In the browser console: `localStorage.setItem( 'debug', 'calypso:analytics:mc' );`
- Navigate to the posts list and select menu items: duplicate, edit, publish, restore, share, stats, trash, view
- Verify that stats are bumped: search the console log for lines like `calypso:analytics:mc Bumping stat calypso_post_actions:duplicate`