### PR TITLE
Posts: Expanded post item styling

### DIFF
--- a/client/blocks/post-item/index.jsx
+++ b/client/blocks/post-item/index.jsx
@@ -25,7 +25,6 @@ import {
 	isPostSelected,
 } from 'state/ui/post-type-list/selectors';
 import { hideSharePanel, togglePostSelection } from 'state/ui/post-type-list/actions';
-import Card from 'components/card';
 import FormInputCheckbox from 'components/forms/form-checkbox';
 import PostTime from 'blocks/post-time';
 import PostStatus from 'blocks/post-status';
@@ -102,7 +101,6 @@ class PostItem extends React.Component {
 			post,
 			globalId,
 			isAllSitesModeSelected,
-			compact,
 			editUrl,
 			translate,
 			largeTitle,
@@ -111,9 +109,8 @@ class PostItem extends React.Component {
 
 		const title = post ? post.title : null;
 
-		const cardClasses = classnames( 'post-item__card', className, {
+		const panelClasses = classnames( 'post-item__panel', className, {
 			'is-untitled': ! title,
-			'is-mini': compact,
 			'is-placeholder': ! globalId,
 			'has-large-title': largeTitle,
 			'has-wrapped-title': wrapTitle,
@@ -122,11 +119,7 @@ class PostItem extends React.Component {
 		const isSiteInfoVisible = isEnabled( 'posts/post-type-list' ) && isAllSitesModeSelected;
 
 		const isAuthorVisible =
-			isEnabled( 'posts/post-type-list' ) &&
-			this.hasMultipleUsers() &&
-			! compact &&
-			post &&
-			post.author;
+			isEnabled( 'posts/post-type-list' ) && this.hasMultipleUsers() && post && post.author;
 
 		const variableHeightContent = this.renderVariableHeightContent();
 		this.hasVariableHeightContent = !! variableHeightContent;
@@ -137,7 +130,7 @@ class PostItem extends React.Component {
 
 		return (
 			<div className={ rootClasses } ref={ this.setDomNode }>
-				<Card compact className={ cardClasses }>
+				<div className={ panelClasses }>
 					{ this.renderSelectionCheckbox() }
 					<div className="post-item__detail">
 						<div className="post-item__info">
@@ -156,7 +149,7 @@ class PostItem extends React.Component {
 					</div>
 					<PostTypeListPostThumbnail globalId={ globalId } />
 					<PostActionsEllipsisMenu globalId={ globalId } />
-				</Card>
+				</div>
 				{ variableHeightContent }
 			</div>
 		);

--- a/client/blocks/post-item/style.scss
+++ b/client/blocks/post-item/style.scss
@@ -1,23 +1,38 @@
+$post-item-border-color: darken( $sidebar-bg-color, 5% );
+$expanded-post-item-outline-color: $sidebar-selected-color;
+
+$post-item-border: solid 1px $post-item-border-color;
+$expanded-post-item-border: 1px solid $expanded-post-item-outline-color;
+$expanded-post-item-outline: 4px solid $post-item-border-color;
+
 .post-item {
-	// The padding here ensures that margins of child elements are included
-	// within the height of this element, and the margin cancels the padding.
-	// See https://stackoverflow.com/a/28121477
-	padding: 1px 0;
-	margin: -1px 0;
+	box-sizing: border-box;
+	margin: 0 -1px; // to line up with SectionNav, which still uses box-shadow
+
+	&,
+	&.is-expanded + & {
+		border: $post-item-border;
+	}
+
+	&:not( :first-child ) {
+		border-top: 0;
+	}
 
 	&.is-expanded {
-		margin: 11px 0;
+		margin-top: 16px;
+		margin-bottom: 16px;
+
+		border: $expanded-post-item-border;
+		outline: $expanded-post-item-outline;
 	}
 }
 
 .post-item__panel {
 	box-sizing: border-box;
-	background: $white;
 	display: flex;
 	justify-content: space-between;
 	align-items: center;
 	padding: 0 16px;
-	margin: 0 0 1px;
 
 	min-height: 84px;
 	&.has-large-title {
@@ -27,6 +42,8 @@
 	@include breakpoint( ">480px" ) {
 		padding: 0 24px;
 	}
+
+	background: $white;
 }
 
 .post-item__select {

--- a/client/blocks/post-item/style.scss
+++ b/client/blocks/post-item/style.scss
@@ -10,21 +10,22 @@
 	}
 }
 
-.card.is-compact.post-item__card /* for specificity */ {
+.post-item__panel {
+	box-sizing: border-box;
+	background: $white;
 	display: flex;
 	justify-content: space-between;
 	align-items: center;
-	padding-top: 0;
-	padding-bottom: 0;
-	margin: 0;
+	padding: 0 16px;
+	margin: 0 0 1px;
 
 	min-height: 84px;
 	&.has-large-title {
 		min-height: 89px;
 	}
-	// <PostItem compact> -> <Card className="... is-mini">
-	&.is-mini {
-		min-height: 50px;
+
+	@include breakpoint( ">480px" ) {
+		padding: 0 24px;
 	}
 }
 
@@ -57,7 +58,7 @@
 		padding: 12px 0;
 	}
 
-	.post-item__card:not( .has-wrapped-title ) & {
+	.post-item__panel:not( .has-wrapped-title ) & {
 		overflow: hidden;
 		&::after {
 			@include long-content-fade( $size: 40px );
@@ -75,12 +76,12 @@
 	margin-bottom: 2px;
 	font-weight: 700;
 
-	.post-item__card.has-large-title & {
+	.post-item__panel.has-large-title & {
 		font-size: 20px;
 		line-height: 1.2;
 	}
 
-	.post-item__card:not( .has-wrapped-title ) & {
+	.post-item__panel:not( .has-wrapped-title ) & {
 		white-space: nowrap;
 	}
 }
@@ -93,12 +94,12 @@ a.post-item__title-link:visited {
 		color: darken( $gray, 20% );
 	}
 
-	.post-item__card.is-untitled & {
+	.post-item__panel.is-untitled & {
 		color: $gray;
 		font-style: italic;
 	}
 
-	.post-item__card.is-placeholder & {
+	.post-item__panel.is-placeholder & {
 		@include placeholder;
 	}
 }
@@ -125,26 +126,4 @@ a.post-item__title-link:visited {
 	height: 14px;
 	margin-top: -3px;
 	margin-right: 2px;
-}
-
-.post-item__card.is-mini.is-compact {
-	padding: 0 16px;
-
-	.post-item__meta {
-		display: none;
-	}
-
-	.post-item__title {
-		display: inline;
-		font-size: 13px;
-		margin: 0;
-	}
-
-	.post-type-site-info__title {
-		font-size: 11px;
-	}
-
-	.post-actions-ellipsis-menu {
-		margin: 0;
-	}
 }

--- a/client/my-sites/post-type-list/style.scss
+++ b/client/my-sites/post-type-list/style.scss
@@ -1,8 +1,3 @@
-.post-type-list:not( .is-empty ) {
-	box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ),
-		0 1px 2px lighten( $gray, 30% );
-}
-
 .post-type-list__bulk-edit-bar {
 	display: flex;
 	align-items: center;


### PR DESCRIPTION
This PR tweaks the expanded post item styling to match the latest design.

<img width="740" alt="screencapture at wed oct 25 16 29 05 edt 2017" src="https://user-images.githubusercontent.com/2098816/32021711-25307694-b9a2-11e7-9916-d12e6dc195c5.png">

**Note: The borders in the share panel at the top need to be cleaned up. I will do that in a subsequent PR to keep this one smaller and more focused.**

Acceptance criteria:

1.
- Given an item expanded in the posts list
- When the item is viewed
- Then the top and bottom margins that separate it from adjacent items doesn't have a border on the left and right sides

2.
- Given an item expanded in the posts list
- When the item is viewed
- Then it has a border around it (see mockup)

3.
- Given a site with one of more CPT items
- When the CPT section is viewed
- Then the list looks good

To run:

```
ENABLE_FEATURES=posts/post-type-list npm start
```