### PR TITLE
WordAds Settings: Add Display Toggles

### DIFF
--- a/client/my-sites/ads/form-settings.jsx
+++ b/client/my-sites/ads/form-settings.jsx
@@ -16,6 +16,7 @@ import { connect } from 'react-redux';
  */
 import Card from 'components/card';
 import StateSelector from 'components/forms/us-state-selector';
+import CompactFormToggle from 'components/forms/form-toggle/compact';
 import FormButton from 'components/forms/form-button';
 import FormButtonsBar from 'components/forms/form-buttons-bar';
 import FormSectionHeading from 'components/forms/form-section-heading';
@@ -110,6 +111,15 @@ class AdsFormSettings extends Component {
 		} );
 	};
 
+	handleDisplayToggle = name => () => {
+		this.setState( prevState => ( {
+			display_options: {
+				...prevState.display_options,
+				[ name ]: ! this.state.display_options[ name ],
+			},
+		} ) );
+	};
+
 	handleResidentCheckbox = () => {
 		const isResident = ! this.state.us_checked;
 
@@ -160,6 +170,7 @@ class AdsFormSettings extends Component {
 			us_checked: false,
 			who_owns: 'person',
 			zip: '',
+			display_options: {},
 			isLoading: false,
 			isSubmitting: false,
 			error: {},
@@ -182,6 +193,7 @@ class AdsFormSettings extends Component {
 			us_resident: this.state.us_resident,
 			who_owns: this.state.who_owns,
 			zip: this.state.zip,
+			display_options: this.state.display_options,
 		};
 	}
 
@@ -264,6 +276,70 @@ class AdsFormSettings extends Component {
 					</span>
 				</FormLabel>
 			</FormFieldset>
+		);
+	}
+
+	displayOptions() {
+		const { translate } = this.props;
+
+		return (
+			<div>
+				<FormFieldset className="ads__settings-display-toggles">
+					<FormLegend>{ translate( 'Display ads below posts on' ) }</FormLegend>
+					<CompactFormToggle
+						checked={ !! this.state.display_options.display_front_page }
+						disabled={ this.state.isLoading }
+						onChange={ this.handleDisplayToggle( 'display_front_page' ) }
+					>
+						{ translate( 'Front page' ) }
+					</CompactFormToggle>
+					<CompactFormToggle
+						checked={ !! this.state.display_options.display_post }
+						disabled={ this.state.isLoading }
+						onChange={ this.handleDisplayToggle( 'display_post' ) }
+					>
+						{ translate( 'Posts' ) }
+					</CompactFormToggle>
+					<CompactFormToggle
+						checked={ !! this.state.display_options.display_page }
+						disabled={ this.state.isLoading }
+						onChange={ this.handleDisplayToggle( 'display_page' ) }
+					>
+						{ translate( 'Pages' ) }
+					</CompactFormToggle>
+					<CompactFormToggle
+						checked={ !! this.state.display_options.display_archive }
+						disabled={ this.state.isLoading }
+						onChange={ this.handleDisplayToggle( 'display_archive' ) }
+					>
+						{ translate( 'Archives' ) }
+					</CompactFormToggle>
+				</FormFieldset>
+				<FormFieldset className="ads__settings-display-toggles">
+					<FormLegend>{ translate( 'Additional ad placements' ) }</FormLegend>
+					<CompactFormToggle
+						checked={ !! this.state.display_options.enable_header_ad }
+						disabled={ this.state.isLoading }
+						onChange={ this.handleDisplayToggle( 'enable_header_ad' ) }
+					>
+						{ translate( 'Top of each page' ) }
+					</CompactFormToggle>
+					<CompactFormToggle
+						checked={ !! this.state.display_options.second_belowpost }
+						disabled={ this.state.isLoading }
+						onChange={ this.handleDisplayToggle( 'second_belowpost' ) }
+					>
+						{ translate( 'Second ad below post' ) }
+					</CompactFormToggle>
+					<CompactFormToggle
+						checked={ !! this.state.display_options.sidebar }
+						disabled={ this.state.isLoading }
+						onChange={ this.handleDisplayToggle( 'sidebar' ) }
+					>
+						{ translate( 'Sidebar' ) }
+					</CompactFormToggle>
+				</FormFieldset>
+			</div>
 		);
 	}
 
@@ -461,6 +537,8 @@ class AdsFormSettings extends Component {
 					</FormButtonsBar>
 
 					{ ! this.props.siteIsJetpack ? this.showAdsToOptions() : null }
+
+					{ ! this.props.siteIsJetpack ? this.displayOptions() : null }
 
 					<FormSectionHeading>{ translate( 'Site Owner Information' ) }</FormSectionHeading>
 					{ this.siteOwnerOptions() }

--- a/client/my-sites/ads/style.scss
+++ b/client/my-sites/ads/style.scss
@@ -123,6 +123,10 @@
 	}
 }
 
+.ads__settings-display-toggles .form-toggle__wrapper {
+	display: block;
+}
+
 .ads__activate-header-title {
 	font-weight: 600;
 }


### PR DESCRIPTION
This update adds display toggles to WordAds that creates parity with similar options in Jetpack Ads. Users will be able to selectively choose which types of pages to display ads on as well as additional ad units. Options have already been handled via the API/backend, so this is mostly a UI update.

**Calypso Settings (new)**
<img width="443" alt="screen shot 2017-11-07 at 12 07 06 pm" src="https://user-images.githubusercontent.com/273708/32515225-5cf0cff4-c3b4-11e7-950e-8e9e7c67e2d0.png">

**Jetpack Settings (as of JP 5.3)**
<img width="735" alt="screen shot 2017-10-25 at 4 05 23 pm" src="https://user-images.githubusercontent.com/273708/32027560-9736a0e6-b99e-11e7-9635-a3bdaf44cb6e.png">

**To Test**
1. Go to a WordPress.com site w/ WordAds enabled.
    - <img width="956" alt="screen shot 2017-11-07 at 12 17 35 pm" src="https://user-images.githubusercontent.com/273708/32515666-b02a2700-c3b5-11e7-84bb-7a49b3417ffd.png">
1. See new display toggles
1. Toggle different options and check the page types/locations have been updated on your site.