### PR TITLE
Blog Posts: Fix Like button alignment

### DIFF
--- a/client/blocks/like-button/style.scss
+++ b/client/blocks/like-button/style.scss
@@ -9,7 +9,6 @@
 	.gridicon {
 		position: absolute;
 		left: 0;
-		top: 4px;
 	}
 
 	.gridicons-star {

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -319,6 +319,10 @@
 	}
 }
 
+.reader-full-post .like-button .gridicon {
+	top: 4px;
+}
+
 .reader-full-post__sidebar .like-button {
 
 	@include breakpoint( "<660px" ) {


### PR DESCRIPTION
Misalignment happens in My Sites > Blog Posts that was introduced in this PR: https://github.com/Automattic/wp-calypso/pull/18943

**Before:**
![screenshot 2017-10-25 16 40 43](https://user-images.githubusercontent.com/4924246/32028393-47d28f06-b9a3-11e7-8ccb-54ed7155d751.png)

**After:**
![screenshot 2017-10-25 16 40 46](https://user-images.githubusercontent.com/4924246/32028397-4b62fb10-b9a3-11e7-9e3f-9b7d35eedc5a.png)

Still looks good in Reader fullpost:
![screenshot 2017-10-25 16 42 07](https://user-images.githubusercontent.com/4924246/32028442-79de8d42-b9a3-11e7-8bd9-4219680fe457.png)

Also checked My Sites > Comments, but that doesn't look to be using the same component.
