### PR TITLE
Store NUX: fix redirect at setup store setup step

### DIFF
--- a/client/extensions/woocommerce/app/index.js
+++ b/client/extensions/woocommerce/app/index.js
@@ -18,6 +18,7 @@ import config from 'config';
 import DocumentHead from 'components/data/document-head';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { isSiteAutomatedTransfer } from 'state/selectors';
+import { hasSitePendingAutomatedTransfer } from 'state/selectors';
 import route from 'lib/route';
 
 class App extends Component {
@@ -89,10 +90,13 @@ function mapStateToProps( state ) {
 	const canUserManageOptions =
 		( siteId && canCurrentUser( state, siteId, 'manage_options' ) ) || false;
 	const isAtomicSite = ( siteId && !! isSiteAutomatedTransfer( state, siteId ) ) || false;
+	const isPendingAutomatedTransfer =
+		( siteId && !! hasSitePendingAutomatedTransfer( state, siteId ) ) || false;
+
 	return {
 		siteId,
 		canUserManageOptions,
-		isAtomicSite,
+		isAtomicSite: isAtomicSite || isPendingAutomatedTransfer,
 		currentRoute: page.current,
 	};
 }

--- a/client/extensions/woocommerce/app/index.js
+++ b/client/extensions/woocommerce/app/index.js
@@ -17,8 +17,7 @@ import { canCurrentUser } from 'state/selectors';
 import config from 'config';
 import DocumentHead from 'components/data/document-head';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import { isSiteAutomatedTransfer } from 'state/selectors';
-import { hasSitePendingAutomatedTransfer } from 'state/selectors';
+import { isSiteAutomatedTransfer, hasSitePendingAutomatedTransfer } from 'state/selectors';
 import route from 'lib/route';
 
 class App extends Component {
@@ -28,6 +27,7 @@ class App extends Component {
 		canUserManageOptions: PropTypes.bool.isRequired,
 		currentRoute: PropTypes.string.isRequired,
 		isAtomicSite: PropTypes.bool.isRequired,
+		hasPendingAutomatedTransfer: PropTypes.bool.isRequired,
 		children: PropTypes.element.isRequired,
 	};
 
@@ -47,6 +47,7 @@ class App extends Component {
 			children,
 			canUserManageOptions,
 			isAtomicSite,
+			hasPendingAutomatedTransfer,
 			currentRoute,
 			translate,
 		} = this.props;
@@ -63,7 +64,11 @@ class App extends Component {
 			return null;
 		}
 
-		if ( ! isAtomicSite && ! config.isEnabled( 'woocommerce/store-on-non-atomic-sites' ) ) {
+		if (
+			! isAtomicSite &&
+			! hasPendingAutomatedTransfer &&
+			! config.isEnabled( 'woocommerce/store-on-non-atomic-sites' )
+		) {
 			this.redirect();
 			return null;
 		}
@@ -90,13 +95,14 @@ function mapStateToProps( state ) {
 	const canUserManageOptions =
 		( siteId && canCurrentUser( state, siteId, 'manage_options' ) ) || false;
 	const isAtomicSite = ( siteId && !! isSiteAutomatedTransfer( state, siteId ) ) || false;
-	const isPendingAutomatedTransfer =
+	const hasPendingAutomatedTransfer =
 		( siteId && !! hasSitePendingAutomatedTransfer( state, siteId ) ) || false;
 
 	return {
 		siteId,
 		canUserManageOptions,
-		isAtomicSite: isAtomicSite || isPendingAutomatedTransfer,
+		isAtomicSite,
+		hasPendingAutomatedTransfer,
 		currentRoute: page.current,
 	};
 }


### PR DESCRIPTION
As part of the Store NUX we redirect to `/store/{site}`. At that point in the flow the site is only pending transfer so just checking `isSiteAutomatedTransfer` will not work.

This adds the `hasSitePendingAutomatedTransfer` selector to make sure we keep the signup on the store flow.

**Testing**
- visit `http://calypso.localhost:3000/start/atomic-store/design-type-with-atomic-store` and create a new site with the store option.
- The signup flow should continue to the "Building your storefront" page and not redirect to `/stats/day` 
