### PR TITLE
Enable "WooCommerce in non-atomic sites" in wpcalypso

### DIFF
--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -155,6 +155,7 @@
 		"woocommerce/extension-settings-stripe-connect-flows": false,
 		"woocommerce/extension-settings-tax": true,
 		"woocommerce/extension-wcservices": true,
+		"woocommerce/store-on-non-atomic-sites": true,
 		"wpcom-user-bootstrap": false
 	},
 	"siftscience_key": "e00e878351",


### PR DESCRIPTION
Follow up to #19142 that enables the store option on wpcalypso.

Right now we are unable to test the Store NUX on wpcalypso without this config.