### PR TITLE
Bump draft-js so that it is React 16 Compat

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1564,7 +1564,7 @@
       "version": "1.1.2"
     },
     "draft-js": {
-      "version": "0.8.1"
+      "version": "0.10.4"
     },
     "duplexer": {
       "version": "0.1.1"

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "doctrine": "2.0.0",
     "dom-helpers": "2.4.0",
     "dom-scroll-into-view": "1.0.1",
-    "draft-js": "0.8.1",
+    "draft-js": "0.10.4",
     "email-validator": "1.0.1",
     "emoji-text": "0.2.6",
     "escape-regexp": "0.0.1",


### PR DESCRIPTION
Is a blocker for upgrading to React 16: https://github.com/Automattic/wp-calypso/pull/19083.
Question: why do we have draft-js? Isn't it a very large dep and we are only using it in a single file.

To Test:
- [x] Ensure functionality for the form "Page Title Structure" at My Sites > Settings > Traffic still works