### PR TITLE
Reader: add reducer for conversation follow and mute

### DIFF
--- a/client/state/data-layer/wpcom/read/sites/posts/follow/index.js
+++ b/client/state/data-layer/wpcom/read/sites/posts/follow/index.js
@@ -31,7 +31,7 @@ export function requestConversationFollow( { dispatch }, action ) {
 			{
 				method: 'POST',
 				apiNamespace: 'wpcom/v2',
-				path: `/read/sites/${ action.payload.blogId }/posts/${ action.payload.postId }/follow`,
+				path: `/read/sites/${ action.payload.siteId }/posts/${ action.payload.postId }/follow`,
 				body: {}, // have to have an empty body to make wpcom-http happy
 			},
 			actionWithRevert
@@ -56,7 +56,7 @@ export function receiveConversationFollow( store, action, response ) {
 
 export function receiveConversationFollowError(
 	{ dispatch },
-	{ payload: { blogId, postId }, meta: { previousState } }
+	{ payload: { siteId, postId }, meta: { previousState } }
 ) {
 	dispatch(
 		errorNotice(
@@ -67,8 +67,8 @@ export function receiveConversationFollowError(
 	dispatch(
 		bypassDataLayer(
 			updateConversationFollowStatus( {
-				blogId: blogId,
-				postId: postId,
+				siteId,
+				postId,
 				followStatus: previousState,
 			} )
 		)

--- a/client/state/data-layer/wpcom/read/sites/posts/follow/test/index.js
+++ b/client/state/data-layer/wpcom/read/sites/posts/follow/test/index.js
@@ -21,7 +21,7 @@ describe( 'conversation-follow', () => {
 	describe( 'requestConversationFollow', () => {
 		test( 'should dispatch an http request', () => {
 			const dispatch = jest.fn();
-			const action = followConversation( { blogId: 123, postId: 456 } );
+			const action = followConversation( { siteId: 123, postId: 456 } );
 			const actionWithRevert = merge( {}, action, {
 				meta: {
 					previousState: CONVERSATION_FOLLOW_STATUS_MUTING,
@@ -48,7 +48,7 @@ describe( 'conversation-follow', () => {
 			receiveConversationFollow(
 				{ dispatch },
 				{
-					payload: { blogId: 123, postId: 456 },
+					payload: { siteId: 123, postId: 456 },
 					meta: { previousState: CONVERSATION_FOLLOW_STATUS_MUTING },
 				},
 				{ success: true }
@@ -67,7 +67,7 @@ describe( 'conversation-follow', () => {
 			receiveConversationFollow(
 				{ dispatch },
 				{
-					payload: { blogId: 123, postId: 456 },
+					payload: { siteId: 123, postId: 456 },
 					meta: { previousState: CONVERSATION_FOLLOW_STATUS_MUTING },
 				},
 				{
@@ -84,7 +84,7 @@ describe( 'conversation-follow', () => {
 			expect( dispatch ).toHaveBeenCalledWith(
 				bypassDataLayer(
 					updateConversationFollowStatus( {
-						blogId: 123,
+						siteId: 123,
 						postId: 456,
 						followStatus: CONVERSATION_FOLLOW_STATUS_MUTING,
 					} )

--- a/client/state/data-layer/wpcom/read/sites/posts/mute/index.js
+++ b/client/state/data-layer/wpcom/read/sites/posts/mute/index.js
@@ -31,7 +31,7 @@ export function requestConversationMute( { dispatch }, action ) {
 			{
 				method: 'POST',
 				apiNamespace: 'wpcom/v2',
-				path: `/read/sites/${ action.payload.blogId }/posts/${ action.payload.postId }/mute`,
+				path: `/read/sites/${ action.payload.siteId }/posts/${ action.payload.postId }/mute`,
 				body: {}, // have to have an empty body to make wpcom-http happy
 			},
 			actionWithRevert
@@ -56,7 +56,7 @@ export function receiveConversationMute( store, action, response ) {
 
 export function receiveConversationMuteError(
 	{ dispatch },
-	{ payload: { blogId, postId }, meta: { previousState } }
+	{ payload: { siteId, postId }, meta: { previousState } }
 ) {
 	dispatch(
 		errorNotice(
@@ -67,8 +67,8 @@ export function receiveConversationMuteError(
 	dispatch(
 		bypassDataLayer(
 			updateConversationFollowStatus( {
-				blogId: blogId,
-				postId: postId,
+				siteId,
+				postId,
 				followStatus: previousState,
 			} )
 		)

--- a/client/state/data-layer/wpcom/read/sites/posts/mute/test/index.js
+++ b/client/state/data-layer/wpcom/read/sites/posts/mute/test/index.js
@@ -21,7 +21,7 @@ describe( 'conversation-mute', () => {
 	describe( 'requestConversationMute', () => {
 		test( 'should dispatch an http request', () => {
 			const dispatch = jest.fn();
-			const action = muteConversation( { blogId: 123, postId: 456 } );
+			const action = muteConversation( { siteId: 123, postId: 456 } );
 			const actionWithRevert = merge( {}, action, {
 				meta: {
 					previousState: CONVERSATION_FOLLOW_STATUS_FOLLOWING,
@@ -48,7 +48,7 @@ describe( 'conversation-mute', () => {
 			receiveConversationMute(
 				{ dispatch },
 				{
-					payload: { blogId: 123, postId: 456 },
+					payload: { siteId: 123, postId: 456 },
 					meta: { previousState: CONVERSATION_FOLLOW_STATUS_FOLLOWING },
 				},
 				{ success: true }
@@ -67,7 +67,7 @@ describe( 'conversation-mute', () => {
 			receiveConversationMute(
 				{ dispatch },
 				{
-					payload: { blogId: 123, postId: 456 },
+					payload: { siteId: 123, postId: 456 },
 					meta: { previousState: CONVERSATION_FOLLOW_STATUS_FOLLOWING },
 				},
 				{
@@ -84,7 +84,7 @@ describe( 'conversation-mute', () => {
 			expect( dispatch ).toHaveBeenCalledWith(
 				bypassDataLayer(
 					updateConversationFollowStatus( {
-						blogId: 123,
+						siteId: 123,
 						postId: 456,
 						followStatus: CONVERSATION_FOLLOW_STATUS_FOLLOWING,
 					} )

--- a/client/state/reader/conversations/actions.js
+++ b/client/state/reader/conversations/actions.js
@@ -11,31 +11,31 @@ import {
 	READER_CONVERSATION_UPDATE_FOLLOW_STATUS,
 } from 'state/action-types';
 
-export function followConversation( { blogId, postId } ) {
+export function followConversation( { siteId, postId } ) {
 	return {
 		type: READER_CONVERSATION_FOLLOW,
 		payload: {
-			blogId,
+			siteId,
 			postId,
 		},
 	};
 }
 
-export function muteConversation( { blogId, postId } ) {
+export function muteConversation( { siteId, postId } ) {
 	return {
 		type: READER_CONVERSATION_MUTE,
 		payload: {
-			blogId,
+			siteId,
 			postId,
 		},
 	};
 }
 
-export function updateConversationFollowStatus( { blogId, postId, followStatus } ) {
+export function updateConversationFollowStatus( { siteId, postId, followStatus } ) {
 	return {
 		type: READER_CONVERSATION_UPDATE_FOLLOW_STATUS,
 		payload: {
-			blogId,
+			siteId,
 			postId,
 			followStatus,
 		},

--- a/client/state/reader/conversations/reducer.js
+++ b/client/state/reader/conversations/reducer.js
@@ -17,7 +17,7 @@ import {
 	CONVERSATION_FOLLOW_STATUS_NOT_FOLLOWING,
 	CONVERSATION_FOLLOW_STATUS_MUTING,
 } from './follow-status';
-import { combineReducers, createReducer, keyedReducer } from 'state/utils';
+import { combineReducers, createReducer } from 'state/utils';
 import { key } from './utils';
 
 /**
@@ -29,7 +29,7 @@ export const items = createReducer(
 		[ READER_CONVERSATION_FOLLOW ]: ( state, action ) => {
 			state = assign( {}, state, {
 				[ key(
-					action.payload.blogId,
+					action.payload.siteId,
 					action.payload.postId
 				) ]: CONVERSATION_FOLLOW_STATUS_FOLLOWING,
 			} );

--- a/client/state/reader/conversations/reducer.js
+++ b/client/state/reader/conversations/reducer.js
@@ -14,10 +14,10 @@ import {
 } from 'state/action-types';
 import {
 	CONVERSATION_FOLLOW_STATUS_FOLLOWING,
-	CONVERSATION_FOLLOW_STATUS_NOT_FOLLOWING,
 	CONVERSATION_FOLLOW_STATUS_MUTING,
 } from './follow-status';
-import { combineReducers, createReducer } from 'state/utils';
+import { combineReducers, createReducer, isValidStateWithSchema } from 'state/utils';
+import { itemsSchema } from './schema';
 import { key } from './utils';
 
 /**
@@ -27,15 +27,34 @@ export const items = createReducer(
 	{},
 	{
 		[ READER_CONVERSATION_FOLLOW ]: ( state, action ) => {
-			state = assign( {}, state, {
+			const newState = assign( {}, state, {
 				[ key(
 					action.payload.siteId,
 					action.payload.postId
 				) ]: CONVERSATION_FOLLOW_STATUS_FOLLOWING,
 			} );
-			return state;
+			return newState;
 		},
-	}
+		[ READER_CONVERSATION_MUTE ]: ( state, action ) => {
+			const newState = assign( {}, state, {
+				[ key( action.payload.siteId, action.payload.postId ) ]: CONVERSATION_FOLLOW_STATUS_MUTING,
+			} );
+			return newState;
+		},
+		[ READER_CONVERSATION_UPDATE_FOLLOW_STATUS ]: ( state, action ) => {
+			// Use of a valid follow status is enforced by the schema
+			const newState = assign( {}, state, {
+				[ key( action.payload.siteId, action.payload.postId ) ]: action.payload.followStatus,
+			} );
+
+			if ( ! isValidStateWithSchema( newState, itemsSchema ) ) {
+				return state;
+			}
+
+			return newState;
+		},
+	},
+	itemsSchema
 );
 
 export default combineReducers( {

--- a/client/state/reader/conversations/reducer.js
+++ b/client/state/reader/conversations/reducer.js
@@ -16,7 +16,7 @@ import {
 	CONVERSATION_FOLLOW_STATUS_FOLLOWING,
 	CONVERSATION_FOLLOW_STATUS_MUTING,
 } from './follow-status';
-import { combineReducers, createReducer, isValidStateWithSchema } from 'state/utils';
+import { combineReducers, createReducer } from 'state/utils';
 import { itemsSchema } from './schema';
 import { key } from './utils';
 
@@ -42,14 +42,9 @@ export const items = createReducer(
 			return newState;
 		},
 		[ READER_CONVERSATION_UPDATE_FOLLOW_STATUS ]: ( state, action ) => {
-			// Use of a valid follow status is enforced by the schema
 			const newState = assign( {}, state, {
 				[ key( action.payload.siteId, action.payload.postId ) ]: action.payload.followStatus,
 			} );
-
-			if ( ! isValidStateWithSchema( newState, itemsSchema ) ) {
-				return state;
-			}
 
 			return newState;
 		},

--- a/client/state/reader/conversations/reducer.js
+++ b/client/state/reader/conversations/reducer.js
@@ -1,0 +1,43 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { assign } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import {
+	READER_CONVERSATION_FOLLOW,
+	READER_CONVERSATION_MUTE,
+	READER_CONVERSATION_UPDATE_FOLLOW_STATUS,
+} from 'state/action-types';
+import {
+	CONVERSATION_FOLLOW_STATUS_FOLLOWING,
+	CONVERSATION_FOLLOW_STATUS_NOT_FOLLOWING,
+	CONVERSATION_FOLLOW_STATUS_MUTING,
+} from './follow-status';
+import { combineReducers, createReducer, keyedReducer } from 'state/utils';
+import { key } from './utils';
+
+/**
+ * Tracks all known conversation following statuses.
+ */
+export const items = createReducer(
+	{},
+	{
+		[ READER_CONVERSATION_FOLLOW ]: ( state, action ) => {
+			state = assign( {}, state, {
+				[ key(
+					action.payload.blogId,
+					action.payload.postId
+				) ]: CONVERSATION_FOLLOW_STATUS_FOLLOWING,
+			} );
+			return state;
+		},
+	}
+);
+
+export default combineReducers( {
+	items,
+} );

--- a/client/state/reader/conversations/schema.js
+++ b/client/state/reader/conversations/schema.js
@@ -1,0 +1,26 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+import {
+	CONVERSATION_FOLLOW_STATUS_FOLLOWING,
+	CONVERSATION_FOLLOW_STATUS_NOT_FOLLOWING,
+	CONVERSATION_FOLLOW_STATUS_MUTING,
+} from './follow-status';
+
+/* eslint-disable quote-props */
+export const itemsSchema = {
+	type: 'object',
+	patternProperties: {
+		'^[0-9]+-[0-9]+$': {
+			enum: [
+				CONVERSATION_FOLLOW_STATUS_FOLLOWING,
+				CONVERSATION_FOLLOW_STATUS_NOT_FOLLOWING,
+				CONVERSATION_FOLLOW_STATUS_MUTING,
+			],
+		},
+	},
+	additionalProperties: false,
+};
+/* eslint-enable quote-props */

--- a/client/state/reader/conversations/test/actions.js
+++ b/client/state/reader/conversations/test/actions.js
@@ -18,20 +18,20 @@ import { CONVERSATION_FOLLOW_STATUS_MUTING } from 'state/reader/conversations/fo
 describe( 'actions', () => {
 	describe( '#followConversation', () => {
 		test( 'should return an action when a conversation is followed', () => {
-			const action = followConversation( { blogId: 123, postId: 456 } );
+			const action = followConversation( { siteId: 123, postId: 456 } );
 			expect( action ).toEqual( {
 				type: READER_CONVERSATION_FOLLOW,
-				payload: { blogId: 123, postId: 456 },
+				payload: { siteId: 123, postId: 456 },
 			} );
 		} );
 	} );
 
 	describe( '#muteConversation', () => {
 		test( 'should return an action when a conversation is muted', () => {
-			const action = muteConversation( { blogId: 123, postId: 456 } );
+			const action = muteConversation( { siteId: 123, postId: 456 } );
 			expect( action ).toEqual( {
 				type: READER_CONVERSATION_MUTE,
-				payload: { blogId: 123, postId: 456 },
+				payload: { siteId: 123, postId: 456 },
 			} );
 		} );
 	} );
@@ -39,13 +39,13 @@ describe( 'actions', () => {
 	describe( '#updateConversationFollowStatus', () => {
 		test( 'should return an action when a conversation follow status is updated', () => {
 			const action = updateConversationFollowStatus( {
-				blogId: 123,
+				siteId: 123,
 				postId: 456,
 				followStatus: CONVERSATION_FOLLOW_STATUS_MUTING,
 			} );
 			expect( action ).toEqual( {
 				type: READER_CONVERSATION_UPDATE_FOLLOW_STATUS,
-				payload: { blogId: 123, postId: 456, followStatus: CONVERSATION_FOLLOW_STATUS_MUTING },
+				payload: { siteId: 123, postId: 456, followStatus: CONVERSATION_FOLLOW_STATUS_MUTING },
 			} );
 		} );
 	} );

--- a/client/state/reader/conversations/test/reducer.js
+++ b/client/state/reader/conversations/test/reducer.js
@@ -1,0 +1,24 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import deepFreeze from 'deep-freeze';
+
+/**
+ * Internal dependencies
+ */
+import { items } from '../reducer';
+import {
+	READER_CONVERSATION_FOLLOW,
+	READER_CONVERSATION_MUTE,
+	READER_CONVERSATION_UPDATE_FOLLOW_STATUS,
+} from 'state/action-types';
+
+describe( 'reducer', () => {
+	describe( '#items()', () => {
+		test( 'should default to an empty object', () => {
+			const state = items( undefined, {} );
+			expect( state ).toEqual( {} );
+		} );
+	} );
+} );

--- a/client/state/reader/conversations/test/reducer.js
+++ b/client/state/reader/conversations/test/reducer.js
@@ -12,6 +12,8 @@ import {
 	READER_CONVERSATION_FOLLOW,
 	READER_CONVERSATION_MUTE,
 	READER_CONVERSATION_UPDATE_FOLLOW_STATUS,
+	SERIALIZE,
+	DESERIALIZE,
 } from 'state/action-types';
 
 describe( 'reducer', () => {
@@ -52,6 +54,21 @@ describe( 'reducer', () => {
 			} );
 
 			expect( state[ '123-456' ] ).toEqual( 'F' );
+		} );
+
+		test( 'will deserialize valid state', () => {
+			const validState = { '123-456': 'M' };
+			expect( items( validState, { type: DESERIALIZE } ) ).toEqual( validState );
+		} );
+
+		test( 'will not deserialize invalid state', () => {
+			const invalidState = { '123-456': 'X' };
+			expect( items( invalidState, { type: DESERIALIZE } ) ).toEqual( {} );
+		} );
+
+		test( 'will serialize', () => {
+			const validState = { '123-456': 'M' };
+			expect( items( validState, { type: SERIALIZE } ) ).toEqual( validState );
 		} );
 	} );
 } );

--- a/client/state/reader/conversations/test/reducer.js
+++ b/client/state/reader/conversations/test/reducer.js
@@ -53,16 +53,5 @@ describe( 'reducer', () => {
 
 			expect( state[ '123-456' ] ).toEqual( 'F' );
 		} );
-
-		test( 'should not update when given an invalid follow status', () => {
-			const original = deepFreeze( { '123-456': 'M' } );
-
-			const state = items( original, {
-				type: READER_CONVERSATION_UPDATE_FOLLOW_STATUS,
-				payload: { siteId: 123, postId: 456, followStatus: 'X' },
-			} );
-
-			expect( state[ '123-456' ] ).toEqual( 'M' );
-		} );
 	} );
 } );

--- a/client/state/reader/conversations/test/reducer.js
+++ b/client/state/reader/conversations/test/reducer.js
@@ -20,5 +20,49 @@ describe( 'reducer', () => {
 			const state = items( undefined, {} );
 			expect( state ).toEqual( {} );
 		} );
+
+		test( 'should update for successful follow', () => {
+			const original = deepFreeze( {} );
+
+			const state = items( original, {
+				type: READER_CONVERSATION_FOLLOW,
+				payload: { siteId: 123, postId: 456 },
+			} );
+
+			expect( state[ '123-456' ] ).toEqual( 'F' );
+		} );
+
+		test( 'should update for successful mute', () => {
+			const original = deepFreeze( {} );
+
+			const state = items( original, {
+				type: READER_CONVERSATION_MUTE,
+				payload: { siteId: 123, postId: 456 },
+			} );
+
+			expect( state[ '123-456' ] ).toEqual( 'M' );
+		} );
+
+		test( 'should update when given a valid follow status', () => {
+			const original = deepFreeze( { '123-456': 'M' } );
+
+			const state = items( original, {
+				type: READER_CONVERSATION_UPDATE_FOLLOW_STATUS,
+				payload: { siteId: 123, postId: 456, followStatus: 'F' },
+			} );
+
+			expect( state[ '123-456' ] ).toEqual( 'F' );
+		} );
+
+		test( 'should not update when given an invalid follow status', () => {
+			const original = deepFreeze( { '123-456': 'M' } );
+
+			const state = items( original, {
+				type: READER_CONVERSATION_UPDATE_FOLLOW_STATUS,
+				payload: { siteId: 123, postId: 456, followStatus: 'X' },
+			} );
+
+			expect( state[ '123-456' ] ).toEqual( 'M' );
+		} );
 	} );
 } );

--- a/client/state/reader/conversations/utils.js
+++ b/client/state/reader/conversations/utils.js
@@ -1,0 +1,5 @@
+/** @format */
+
+export function key( siteId, postId ) {
+	return `${ siteId }-${ postId }`;
+}

--- a/client/state/selectors/get-reader-conversation-follow-status.js
+++ b/client/state/selectors/get-reader-conversation-follow-status.js
@@ -1,0 +1,25 @@
+/*
+ * @format
+ */
+
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { key } from 'state/reader/conversations/utils';
+
+/*
+ * Get the follow status for a given post
+ *
+ * @param  {Object}  state  Global state tree
+ * @param  {Number} siteId
+ * @param  {Number} postId
+ * @return {String} Follow status
+ */
+export default function getReaderConversationFollowStatus( state, { siteId, postId } ) {
+	return get( state, [ 'reader', 'conversations', 'items', key( siteId, postId ) ], null );
+}

--- a/client/state/selectors/index.js
+++ b/client/state/selectors/index.js
@@ -87,6 +87,7 @@ export getPublicizeConnection from './get-publicize-connection';
 export getPublicSites from './get-public-sites';
 export getRawOffsets from './get-raw-offsets';
 export getReaderAliasedFollowFeedUrl from './get-reader-aliased-follow-feed-url';
+export getReaderConversationFollowStatus from './get-reader-conversation-follow-status';
 export getReaderFeedsCountForQuery from './get-reader-feeds-count-for-query';
 export getReaderFeedsForQuery from './get-reader-feeds-for-query';
 export getReaderFollowedTags from './get-reader-followed-tags';

--- a/client/state/selectors/test/get-reader-conversation-follow-status.js
+++ b/client/state/selectors/test/get-reader-conversation-follow-status.js
@@ -1,10 +1,6 @@
 /** @format */
 
 /**
- * External dependencies
- */
-
-/**
  * Internal dependencies
  */
 import { getReaderConversationFollowStatus } from '../';

--- a/client/state/selectors/test/get-reader-conversation-follow-status.js
+++ b/client/state/selectors/test/get-reader-conversation-follow-status.js
@@ -1,0 +1,40 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+/**
+ * Internal dependencies
+ */
+import { getReaderConversationFollowStatus } from '../';
+
+describe( 'getReaderConversationFollowStatus()', () => {
+	test( 'should return follow status for a known post', () => {
+		const prevState = {
+			reader: {
+				conversations: {
+					items: {
+						'123-456': 'F',
+					},
+				},
+			},
+		};
+		const nextState = getReaderConversationFollowStatus( prevState, { siteId: 123, postId: 456 } );
+		expect( nextState ).toEqual( 'F' );
+	} );
+
+	test( 'should return null for an unknown post', () => {
+		const prevState = {
+			reader: {
+				conversations: {
+					items: {
+						'123-456': 'F',
+					},
+				},
+			},
+		};
+		const nextState = getReaderConversationFollowStatus( prevState, { siteId: 234, postId: 456 } );
+		expect( nextState ).toEqual( null );
+	} );
+} );


### PR DESCRIPTION
This PR adds the reducer for following and muting Reader conversations.

It also adds a selector, `getReaderConversationFollowStatus`.

### To test

`npm run test-client client/state/reader/conversations`
`npm run test-client client/state/selectors`