### PR TITLE
Jetpack: add events in happychat buttons

### DIFF
--- a/client/jetpack-connect/auth-logged-in-form.jsx
+++ b/client/jetpack-connect/auth-logged-in-form.jsx
@@ -482,7 +482,7 @@ class LoggedInForm extends Component {
 				<LoggedOutFormLinkItem onClick={ this.handleSignOut }>
 					{ translate( 'Create a new account' ) }
 				</LoggedOutFormLinkItem>
-				<JetpackConnectHappychatButton>
+				<JetpackConnectHappychatButton eventName="calypso_jpc_authorize_chat_initiated">
 					<HelpButton onClick={ this.handleClickHelp } />
 				</JetpackConnectHappychatButton>
 			</LoggedOutFormLinks>

--- a/client/jetpack-connect/authorize-form.jsx
+++ b/client/jetpack-connect/authorize-form.jsx
@@ -113,7 +113,7 @@ class JetpackConnectAuthorizeForm extends Component {
 					actionURL="/jetpack/connect"
 				/>
 				<LoggedOutFormLinks>
-					<JetpackConnectHappychatButton>
+					<JetpackConnectHappychatButton eventName="calypso_jpc_404_chat_initiated">
 						<HelpButton onClick={ this.handleClickHelp } />
 					</JetpackConnectHappychatButton>
 				</LoggedOutFormLinks>

--- a/client/jetpack-connect/authorize-form.jsx
+++ b/client/jetpack-connect/authorize-form.jsx
@@ -113,7 +113,7 @@ class JetpackConnectAuthorizeForm extends Component {
 					actionURL="/jetpack/connect"
 				/>
 				<LoggedOutFormLinks>
-					<JetpackConnectHappychatButton eventName="calypso_jpc_404_chat_initiated">
+					<JetpackConnectHappychatButton eventName="calypso_jpc_noqueryarguments_chat_initiated">
 						<HelpButton onClick={ this.handleClickHelp } />
 					</JetpackConnectHappychatButton>
 				</LoggedOutFormLinks>

--- a/client/jetpack-connect/happychat-button.jsx
+++ b/client/jetpack-connect/happychat-button.jsx
@@ -22,11 +22,8 @@ import { getCurrentUserId } from 'state/current-user/selectors';
 import hasActiveHappychatSession from 'state/happychat/selectors/has-active-happychat-session';
 import isHappychatAvailable from 'state/happychat/selectors/is-happychat-available';
 
-const getHappyChatButtonClickHandler = ( eventName = 'calypso_jpc_chat_initiated' ) => {
-	return () => {
-		analytics.tracks.recordEvent( eventName );
-	};
-};
+const getHappyChatButtonClickHandler = ( eventName = 'calypso_jpc_chat_initiated' ) => () =>
+	analytics.tracks.recordEvent( eventName );
 
 const JetpackConnectHappychatButton = ( {
 	children,
@@ -63,6 +60,7 @@ const JetpackConnectHappychatButton = ( {
 };
 
 JetpackConnectHappychatButton.propTypes = {
+	eventName: PropTypes.string,
 	label: PropTypes.string,
 };
 

--- a/client/jetpack-connect/happychat-button.jsx
+++ b/client/jetpack-connect/happychat-button.jsx
@@ -13,12 +13,21 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+
+import analytics from 'lib/analytics';
 import HappychatButton from 'components/happychat/button';
 import HappychatConnection from 'components/happychat/connection';
 import { isEnabled } from 'config';
 import { getCurrentUserId } from 'state/current-user/selectors';
 import hasActiveHappychatSession from 'state/happychat/selectors/has-active-happychat-session';
 import isHappychatAvailable from 'state/happychat/selectors/is-happychat-available';
+
+const getHappyChatButtonClickHandler = eventName => {
+	eventName = eventName || 'calypso_jpc_chat_initiated';
+	return () => {
+		analytics.tracks.recordEvent( eventName );
+	};
+};
 
 const JetpackConnectHappychatButton = ( {
 	children,
@@ -28,6 +37,7 @@ const JetpackConnectHappychatButton = ( {
 	label,
 	onClick,
 	translate,
+	eventName,
 } ) => {
 	if ( ! isEnabled( 'jetpack/happychat' ) || ! isLoggedIn ) {
 		return <div>{ children }</div>;
@@ -46,7 +56,7 @@ const JetpackConnectHappychatButton = ( {
 		<HappychatButton
 			borderless={ false }
 			className="logged-out-form__link-item jetpack-connect__happychat-button"
-			onClick={ onClick }
+			onClick={ getHappyChatButtonClickHandler( eventName ) }
 		>
 			<HappychatConnection />
 			<Gridicon icon="chat" /> { label || translate( 'Get help connecting your site' ) }
@@ -55,8 +65,7 @@ const JetpackConnectHappychatButton = ( {
 };
 
 JetpackConnectHappychatButton.propTypes = {
-	label: PropTypes.string,
-	onClick: PropTypes.func,
+	label: PropTypes.string
 };
 
 export default connect( state => ( {

--- a/client/jetpack-connect/happychat-button.jsx
+++ b/client/jetpack-connect/happychat-button.jsx
@@ -22,8 +22,7 @@ import { getCurrentUserId } from 'state/current-user/selectors';
 import hasActiveHappychatSession from 'state/happychat/selectors/has-active-happychat-session';
 import isHappychatAvailable from 'state/happychat/selectors/is-happychat-available';
 
-const getHappyChatButtonClickHandler = eventName => {
-	eventName = eventName || 'calypso_jpc_chat_initiated';
+const getHappyChatButtonClickHandler = ( eventName = 'calypso_jpc_chat_initiated' ) => {
 	return () => {
 		analytics.tracks.recordEvent( eventName );
 	};
@@ -35,7 +34,6 @@ const JetpackConnectHappychatButton = ( {
 	isChatAvailable,
 	isLoggedIn,
 	label,
-	onClick,
 	translate,
 	eventName,
 } ) => {
@@ -65,7 +63,7 @@ const JetpackConnectHappychatButton = ( {
 };
 
 JetpackConnectHappychatButton.propTypes = {
-	label: PropTypes.string
+	label: PropTypes.string,
 };
 
 export default connect( state => ( {

--- a/client/jetpack-connect/main.jsx
+++ b/client/jetpack-connect/main.jsx
@@ -348,7 +348,7 @@ class JetpackConnectMain extends Component {
 		const { translate } = this.props;
 		return (
 			<LoggedOutFormLinks>
-				<JetpackConnectHappychatButton>
+				<JetpackConnectHappychatButton eventName="calypso_jpc_firststep_chat_initiated">
 					<LoggedOutFormLinkItem href="https://jetpack.com/support/installing-jetpack/">
 						{ translate( 'Install Jetpack manually' ) }
 					</LoggedOutFormLinkItem>
@@ -479,7 +479,7 @@ class JetpackConnectMain extends Component {
 					<div className="jetpack-connect__navigation">{ this.renderBackButton() }</div>
 				</div>
 				<LoggedOutFormLinks>
-					<JetpackConnectHappychatButton>
+					<JetpackConnectHappychatButton eventName="calypso_jpc_instructions_chat_initiated">
 						<HelpButton />
 					</JetpackConnectHappychatButton>
 				</LoggedOutFormLinks>

--- a/client/jetpack-connect/main.jsx
+++ b/client/jetpack-connect/main.jsx
@@ -348,7 +348,7 @@ class JetpackConnectMain extends Component {
 		const { translate } = this.props;
 		return (
 			<LoggedOutFormLinks>
-				<JetpackConnectHappychatButton eventName="calypso_jpc_firststep_chat_initiated">
+				<JetpackConnectHappychatButton eventName="calypso_jpc_siteentry_chat_initiated">
 					<LoggedOutFormLinkItem href="https://jetpack.com/support/installing-jetpack/">
 						{ translate( 'Install Jetpack manually' ) }
 					</LoggedOutFormLinkItem>

--- a/client/jetpack-connect/plans-landing.jsx
+++ b/client/jetpack-connect/plans-landing.jsx
@@ -106,7 +106,7 @@ class PlansLanding extends Component {
 				>
 					<PlansSkipButton onClick={ this.handleSkipButtonClick } />
 					<LoggedOutFormLinks>
-						<JetpackConnectHappychatButton>
+						<JetpackConnectHappychatButton eventName="calypso_jpc_plansanding_chat_initiated">
 							<HelpButton onClick={ this.handleHelpButtonClick } />
 						</JetpackConnectHappychatButton>
 					</LoggedOutFormLinks>

--- a/client/jetpack-connect/plans-landing.jsx
+++ b/client/jetpack-connect/plans-landing.jsx
@@ -106,7 +106,7 @@ class PlansLanding extends Component {
 				>
 					<PlansSkipButton onClick={ this.handleSkipButtonClick } />
 					<LoggedOutFormLinks>
-						<JetpackConnectHappychatButton eventName="calypso_jpc_plansanding_chat_initiated">
+						<JetpackConnectHappychatButton eventName="calypso_jpc_planslanding_chat_initiated">
 							<HelpButton onClick={ this.handleHelpButtonClick } />
 						</JetpackConnectHappychatButton>
 					</LoggedOutFormLinks>

--- a/client/jetpack-connect/plans.jsx
+++ b/client/jetpack-connect/plans.jsx
@@ -278,7 +278,10 @@ class Plans extends Component {
 				>
 					<PlansSkipButton onClick={ this.handleSkipButtonClick } isRtl={ isRtlLayout } />
 					<LoggedOutFormLinks>
-						<JetpackConnectHappychatButton label={ helpButtonLabel }>
+						<JetpackConnectHappychatButton
+							label={ helpButtonLabel }
+							eventName="calypso_jpc_plans_chat_initiated"
+						>
 							<HelpButton onClick={ this.handleHelpButtonClick } label={ helpButtonLabel } />
 						</JetpackConnectHappychatButton>
 					</LoggedOutFormLinks>

--- a/client/jetpack-connect/sso.jsx
+++ b/client/jetpack-connect/sso.jsx
@@ -457,7 +457,7 @@ class JetpackSsoForm extends Component {
 						>
 							{ this.getReturnToSiteText() }
 						</LoggedOutFormLinkItem>
-						<JetpackConnectHappychatButton>
+						<JetpackConnectHappychatButton eventName="calypso_jpc_sso_chat_initiated">
 							<HelpButton />
 						</JetpackConnectHappychatButton>
 					</LoggedOutFormLinks>

--- a/client/jetpack-connect/test/__snapshots__/plans.js.snap
+++ b/client/jetpack-connect/test/__snapshots__/plans.js.snap
@@ -846,6 +846,7 @@ ShallowWrapper {
       />
       <LoggedOutFormLinks>
         <jetpack-connect--happychat-button
+          eventName="calypso_jpc_plans_chat_initiated"
           label="Need help?"
         >
           <Localized(JetpackConnectHelpButton)
@@ -1004,6 +1005,7 @@ ShallowWrapper {
         />
         <LoggedOutFormLinks>
           <jetpack-connect--happychat-button
+            eventName="calypso_jpc_plans_chat_initiated"
             label="Need help?"
           >
             <Localized(JetpackConnectHelpButton)
@@ -1615,6 +1617,7 @@ ShallowWrapper {
             />
             <LoggedOutFormLinks>
               <jetpack-connect--happychat-button
+                eventName="calypso_jpc_plans_chat_initiated"
                 label="Need help?"
               >
                 <Localized(JetpackConnectHelpButton)
@@ -1773,6 +1776,7 @@ ShallowWrapper {
             />
             <LoggedOutFormLinks>
               <jetpack-connect--happychat-button
+                eventName="calypso_jpc_plans_chat_initiated"
                 label="Need help?"
               >
                 <Localized(JetpackConnectHelpButton)
@@ -2164,6 +2168,7 @@ ShallowWrapper {
       />
       <LoggedOutFormLinks>
         <jetpack-connect--happychat-button
+          eventName="calypso_jpc_plans_chat_initiated"
           label="Need help?"
         >
           <Localized(JetpackConnectHelpButton)
@@ -2322,6 +2327,7 @@ ShallowWrapper {
         />
         <LoggedOutFormLinks>
           <jetpack-connect--happychat-button
+            eventName="calypso_jpc_plans_chat_initiated"
             label="Need help?"
           >
             <Localized(JetpackConnectHelpButton)
@@ -2931,6 +2937,7 @@ ShallowWrapper {
             />
             <LoggedOutFormLinks>
               <jetpack-connect--happychat-button
+                eventName="calypso_jpc_plans_chat_initiated"
                 label="Need help?"
               >
                 <Localized(JetpackConnectHelpButton)
@@ -3089,6 +3096,7 @@ ShallowWrapper {
             />
             <LoggedOutFormLinks>
               <jetpack-connect--happychat-button
+                eventName="calypso_jpc_plans_chat_initiated"
                 label="Need help?"
               >
                 <Localized(JetpackConnectHelpButton)

--- a/client/my-sites/site-settings/disconnect-site/troubleshoot.jsx
+++ b/client/my-sites/site-settings/disconnect-site/troubleshoot.jsx
@@ -28,7 +28,7 @@ const Troubleshoot = ( { siteUrl, trackDebugClick, trackSupportClick, translate 
 		</LoggedOutFormLinkItem>
 		<JetpackConnectHappychatButton
 			label={ translate( 'Get help from our Happiness Engineers' ) }
-			onClick={ trackSupportClick }
+			eventName="calypso_jetpack_disconnect_chat_initiated"
 		>
 			<HelpButton
 				label={ translate( 'Get help from our Happiness Engineers' ) }


### PR DESCRIPTION
fixes https://github.com/Automattic/wp-calypso/issues/19166

This PR adds several events that are missing for the happychat buttons during the jetpack connection flow.

How to test:
========

0. Open happychat hud: https://hud.happychat.io/?service=https://happychat-io-staging.go-vip.co/operator so there are operators (you) available 
1. Go to https://calypso.live/jetpack/connect?branch=add/Jetpack-connect-happychat-events
2. Open developer tools and run `localStorage.setItem('debug', 'calypso:analytics:tracks')`, so tracks event gets logged in the console
3. Open happy chat. Make sure the correct event have been triggered
4. Connect a new site. Jurassic.ninja or Poopy.live are your friends
5. Every time that is available, open happy chat again. Every button should trigger a new event.