### PR TITLE
Store shipping: Fixed fulfillment & labels

### DIFF
--- a/client/extensions/woocommerce/app/dashboard/manage-no-orders-view.js
+++ b/client/extensions/woocommerce/app/dashboard/manage-no-orders-view.js
@@ -15,6 +15,7 @@ import page from 'page';
 import analytics from 'lib/analytics';
 import BasicWidget from 'woocommerce/components/basic-widget';
 import { getLink } from 'woocommerce/lib/nav-utils';
+import LabelsSetupNotice from 'woocommerce/woocommerce-services/components/labels-setup-notice';
 import ShareWidget from 'woocommerce/components/share-widget';
 import WidgetGroup from 'woocommerce/components/widget-group';
 
@@ -99,6 +100,7 @@ class ManageNoOrdersView extends Component {
 	render = () => {
 		return (
 			<div className="dashboard__manage-no-orders">
+				<LabelsSetupNotice />
 				{ this.renderShareWidget() }
 				<WidgetGroup>
 					{ this.renderStatsWidget() }

--- a/client/extensions/woocommerce/app/dashboard/manage-no-orders-view.js
+++ b/client/extensions/woocommerce/app/dashboard/manage-no-orders-view.js
@@ -15,7 +15,6 @@ import page from 'page';
 import analytics from 'lib/analytics';
 import BasicWidget from 'woocommerce/components/basic-widget';
 import { getLink } from 'woocommerce/lib/nav-utils';
-import LabelsSetupNotice from 'woocommerce/woocommerce-services/components/labels-setup-notice';
 import ShareWidget from 'woocommerce/components/share-widget';
 import WidgetGroup from 'woocommerce/components/widget-group';
 
@@ -100,7 +99,6 @@ class ManageNoOrdersView extends Component {
 	render = () => {
 		return (
 			<div className="dashboard__manage-no-orders">
-				<LabelsSetupNotice />
 				{ this.renderShareWidget() }
 				<WidgetGroup>
 					{ this.renderStatsWidget() }

--- a/client/extensions/woocommerce/app/dashboard/manage-orders-view.js
+++ b/client/extensions/woocommerce/app/dashboard/manage-orders-view.js
@@ -16,6 +16,7 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import Button from 'components/button';
+import LabelsSetupNotice from 'woocommerce/woocommerce-services/components/labels-setup-notice';
 import { fetchOrders } from 'woocommerce/state/sites/orders/actions';
 import { fetchReviews } from 'woocommerce/state/sites/reviews/actions';
 import {
@@ -150,6 +151,8 @@ class ManageOrdersView extends Component {
 						{ ( orders.length && <span>{ translate( 'You have new orders 🎉' ) }</span> ) || '' }
 					</h2>
 				</div>
+
+				<LabelsSetupNotice />
 
 				<div className="dashboard__queue-widgets">
 					{ this.possiblyRenderProcessOrdersWidget() }

--- a/client/extensions/woocommerce/app/order/index.js
+++ b/client/extensions/woocommerce/app/order/index.js
@@ -25,6 +25,7 @@ import {
 	getOrderWithEdits,
 } from 'woocommerce/state/ui/orders/selectors';
 import { isOrderUpdating, getOrder } from 'woocommerce/state/sites/orders/selectors';
+import LabelsSetupNotice from 'woocommerce/woocommerce-services/components/labels-setup-notice';
 import Main from 'components/main';
 import OrderCustomer from './order-customer';
 import OrderDetails from './order-details';
@@ -134,6 +135,7 @@ class Order extends Component {
 				</ActionHeader>
 
 				<div className="order__container">
+					<LabelsSetupNotice />
 					<OrderDetails orderId={ orderId } />
 					<OrderActivityLog orderId={ orderId } siteId={ site.ID } />
 					<OrderCustomer orderId={ orderId } />

--- a/client/extensions/woocommerce/app/order/order-fulfillment/index.js
+++ b/client/extensions/woocommerce/app/order/order-fulfillment/index.js
@@ -150,7 +150,7 @@ class OrderFulfillment extends Component {
 			wcsEnabled && labelsLoaded && labelsEnabled && hasLabelsPaymentMethod && ! orderCancelled;
 		const labelsLoading = wcsEnabled && ! labelsLoaded && ! orderCancelled;
 
-		if ( orderFinished && ! labelsLoading && ! showLabels ) {
+		if ( ( orderFinished || orderCancelled ) && ! labelsLoading && ! showLabels ) {
 			return null;
 		}
 

--- a/client/extensions/woocommerce/app/order/order-fulfillment/index.js
+++ b/client/extensions/woocommerce/app/order/order-fulfillment/index.js
@@ -144,26 +144,24 @@ class OrderFulfillment extends Component {
 			translate,
 			hasLabelsPaymentMethod,
 		} = this.props;
-		const isShippable = ! isOrderFinished( order.status );
-		const hideLabels = ! labelsEnabled || ! hasLabelsPaymentMethod;
-		const buttonClassName = classNames( {
-			'is-placeholder': wcsEnabled && ! labelsLoaded,
-		} );
+		const orderFinished = isOrderFinished( order.status );
+		const orderCancelled = 'cancelled' === order.status;
+		const showLabels =
+			wcsEnabled && labelsLoaded && labelsEnabled && hasLabelsPaymentMethod && ! orderCancelled;
+		const labelsLoading = wcsEnabled && ! labelsLoaded && ! orderCancelled;
 
-		if (
-			! isShippable &&
-			( ! wcsEnabled || ( labelsLoaded && hideLabels ) || 'cancelled' === order.status )
-		) {
+		if ( orderFinished && ! labelsLoading && ! showLabels ) {
 			return null;
 		}
 
-		if ( ! wcsEnabled || ! labelsLoaded || hideLabels ) {
+		if ( labelsLoading ) {
+			const buttonClassName = 'is-placeholder';
+			return <Button className={ buttonClassName }>{ translate( 'Fulfill' ) }</Button>;
+		}
+
+		if ( ! showLabels ) {
 			return (
-				<Button
-					primary={ ! wcsEnabled || labelsLoaded }
-					onClick={ this.toggleDialog }
-					className={ buttonClassName }
-				>
+				<Button primary onClick={ this.toggleDialog }>
 					{ translate( 'Fulfill' ) }
 				</Button>
 			);
@@ -171,7 +169,7 @@ class OrderFulfillment extends Component {
 
 		const onLabelPrint = () => this.props.openPrintingFlow( order.id, site.ID );
 
-		if ( ! isShippable ) {
+		if ( orderFinished ) {
 			return <Button onClick={ onLabelPrint }>{ translate( 'Print new label' ) }</Button>;
 		}
 

--- a/client/extensions/woocommerce/app/order/order-fulfillment/index.js
+++ b/client/extensions/woocommerce/app/order/order-fulfillment/index.js
@@ -159,7 +159,10 @@ class OrderFulfillment extends Component {
 			'is-placeholder': wcsEnabled && ! labelsLoaded,
 		} );
 
-		if ( ! isShippable && ( ! wcsEnabled || ( labelsLoaded && hideLabels ) ) ) {
+		if (
+			! isShippable &&
+			( ! wcsEnabled || ( labelsLoaded && hideLabels ) || 'cancelled' === order.status )
+		) {
 			return null;
 		}
 

--- a/client/extensions/woocommerce/app/order/order-fulfillment/index.js
+++ b/client/extensions/woocommerce/app/order/order-fulfillment/index.js
@@ -16,7 +16,6 @@ import { first } from 'lodash';
  */
 import { createNote } from 'woocommerce/state/sites/orders/notes/actions';
 import Button from 'components/button';
-import ButtonGroup from 'components/button-group';
 import config from 'config';
 import Dialog from 'components/dialog';
 import FormFieldset from 'components/forms/form-fieldset';
@@ -26,8 +25,6 @@ import FormTextInput from 'components/forms/form-text-input';
 import { isOrderFinished } from 'woocommerce/lib/order-status';
 import LabelPurchaseDialog from 'woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal';
 import Notice from 'components/notice';
-import PopoverMenu from 'components/popover/menu';
-import PopoverMenuItem from 'components/popover/menu-item';
 import QueryLabels from 'woocommerce/woocommerce-services/components/query-labels';
 import { updateOrder } from 'woocommerce/state/sites/orders/actions';
 import { openPrintingFlow } from 'woocommerce/woocommerce-services/state/shipping-label/actions';
@@ -57,19 +54,13 @@ class OrderFulfillment extends Component {
 		errorMessage: false,
 		shouldEmail: false,
 		showDialog: false,
-		showPopoverMenu: false,
 		trackingNumber: '',
 	};
 
-	toggleDialog = () => {
+	toggleDialog = event => {
+		event && event.preventDefault();
 		this.setState( {
 			showDialog: ! this.state.showDialog,
-		} );
-	};
-
-	togglePopoverMenu = () => {
-		this.setState( {
-			showPopoverMenu: ! this.state.showPopoverMenu,
 		} );
 	};
 
@@ -181,32 +172,17 @@ class OrderFulfillment extends Component {
 		const onLabelPrint = () => this.props.openPrintingFlow( order.id, site.ID );
 
 		if ( ! isShippable ) {
-			return (
-				<div>
-					<Button onClick={ onLabelPrint }>{ translate( 'Print new label' ) }</Button>
-				</div>
-			);
+			return <Button onClick={ onLabelPrint }>{ translate( 'Print new label' ) }</Button>;
 		}
 
 		return (
-			<div>
-				<ButtonGroup className="order-fulfillment__button-group">
-					<Button primary={ labelsLoaded } onClick={ onLabelPrint }>
-						{ translate( 'Print label & fulfill' ) }
-					</Button>
-					<Button onClick={ this.togglePopoverMenu } ref="popoverMenuButton">
-						<Gridicon icon="ellipsis" />
-					</Button>
-				</ButtonGroup>
-				<PopoverMenu
-					isVisible={ this.state.showPopoverMenu }
-					onClose={ this.togglePopoverMenu }
-					context={ this.refs && this.refs.popoverMenuButton }
-				>
-					<PopoverMenuItem onClick={ this.toggleDialog }>
-						{ translate( 'Fulfill without printing a label' ) }
-					</PopoverMenuItem>
-				</PopoverMenu>
+			<div className="order-fulfillment__print-container">
+				<a href="#" onClick={ this.toggleDialog }>
+					{ translate( 'Fulfill without printing a label' ) }
+				</a>
+				<Button primary={ labelsLoaded } onClick={ onLabelPrint }>
+					{ translate( 'Print label & fulfill' ) }
+				</Button>
 			</div>
 		);
 	}

--- a/client/extensions/woocommerce/app/order/order-fulfillment/style.scss
+++ b/client/extensions/woocommerce/app/order/order-fulfillment/style.scss
@@ -12,7 +12,30 @@
 
 .order-fulfillment__print-container {
 	display: flex;
+	flex-direction: column;
 	align-items: center;
+	justify-content: center;
+
+	a {
+		order: 2;
+		text-align: center;
+	}
+
+	button {
+		order: 1;
+	}
+
+	@include breakpoint( ">660px" ) {
+		flex-direction: row;
+
+		a {
+			order: 1;
+		}
+
+		button {
+			order: 2;
+		}
+	}
 }
 
 .order-fulfillment__tracking,

--- a/client/extensions/woocommerce/app/order/order-fulfillment/style.scss
+++ b/client/extensions/woocommerce/app/order/order-fulfillment/style.scss
@@ -1,4 +1,7 @@
 .order-fulfillment {
+	display: flex;
+	flex-wrap: wrap;
+	justify-content: flex-end;
 	background: lighten( $blue-light, 25% );
 
 	&.is-completed {
@@ -12,30 +15,7 @@
 
 .order-fulfillment__print-container {
 	display: flex;
-	flex-direction: column;
 	align-items: center;
-	justify-content: center;
-
-	a {
-		order: 2;
-		text-align: center;
-	}
-
-	button {
-		order: 1;
-	}
-
-	@include breakpoint( ">660px" ) {
-		flex-direction: row;
-
-		a {
-			order: 1;
-		}
-
-		button {
-			order: 2;
-		}
-	}
 }
 
 .order-fulfillment__tracking,

--- a/client/extensions/woocommerce/app/order/order-fulfillment/style.scss
+++ b/client/extensions/woocommerce/app/order/order-fulfillment/style.scss
@@ -10,6 +10,11 @@
 	}
 }
 
+.order-fulfillment__print-container {
+	display: flex;
+	align-items: center;
+}
+
 .order-fulfillment__tracking,
 .order-fulfillment__email {
 	margin: 0 0 24px;

--- a/client/extensions/woocommerce/app/settings/shipping/save-button.js
+++ b/client/extensions/woocommerce/app/settings/shipping/save-button.js
@@ -61,7 +61,18 @@ class ShippingSettingsSaveButton extends Component {
 			translate( 'There was a problem saving the shipping settings. Please try again.' )
 		);
 
-		this.props.createWcsShippingSaveActionList( successAction, failureAction );
+		const noLabelsPaymentAction = errorNotice(
+			translate( 'A payment method is required to print shipping labels.' ),
+			{
+				duration: 4000,
+			}
+		);
+
+		this.props.createWcsShippingSaveActionList(
+			successAction,
+			failureAction,
+			noLabelsPaymentAction
+		);
 	};
 
 	redirect = () => {

--- a/client/extensions/woocommerce/state/data-layer/ui/woocommerce-services/index.js
+++ b/client/extensions/woocommerce/state/data-layer/ui/woocommerce-services/index.js
@@ -16,7 +16,11 @@ import {
 	actionListStepFailure,
 	actionListClear,
 } from 'woocommerce/state/action-list/actions';
-import { getLabelSettingsFormMeta } from 'woocommerce/woocommerce-services/state/label-settings/selectors';
+import {
+	areLabelsEnabled,
+	getLabelSettingsFormMeta,
+	getSelectedPaymentMethodId,
+} from 'woocommerce/woocommerce-services/state/label-settings/selectors';
 import { getPackagesForm } from 'woocommerce/woocommerce-services/state/packages/selectors';
 import { submit as submitLabels } from 'woocommerce/woocommerce-services/state/label-settings/actions';
 import { submit as submitPackages } from 'woocommerce/woocommerce-services/state/packages/actions';
@@ -83,7 +87,13 @@ export default {
 		 * @param {Object} action - an action containing successAction and failureAction
 		 */
 		( store, action ) => {
-			const { successAction, failureAction } = action;
+			const { successAction, failureAction, noLabelsPaymentAction } = action;
+
+			const state = store.getState();
+			if ( areLabelsEnabled( state ) && ! getSelectedPaymentMethodId( state ) ) {
+				store.dispatch( noLabelsPaymentAction );
+				return;
+			}
 
 			/**
 			 * A callback issued after a successful request

--- a/client/extensions/woocommerce/woocommerce-services/components/labels-setup-notice/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/components/labels-setup-notice/index.js
@@ -1,0 +1,56 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Card from 'components/card';
+import config from 'config';
+import QueryLabelSettings from 'woocommerce/woocommerce-services/components/query-label-settings';
+import { getSelectedSite } from 'state/ui/selectors';
+import { getLink } from 'woocommerce/lib/nav-utils';
+import {
+	areSettingsLoaded,
+	areLabelsEnabled,
+	getSelectedPaymentMethodId,
+} from 'woocommerce/woocommerce-services/state/label-settings/selectors';
+
+const wcsEnabled = config.isEnabled( 'woocommerce/extension-wcservices' );
+
+const LabelsSetupNotice = ( { site, loaded, enabled, hasLabelsPaymentMethod, translate } ) => {
+	if ( ! wcsEnabled ) {
+		return null;
+	}
+
+	if ( ! loaded ) {
+		return <QueryLabelSettings siteId={ site.ID } />;
+	}
+
+	if ( enabled && ! hasLabelsPaymentMethod ) {
+		return (
+			<Card className="labels-setup-notice is-warning">
+				{ translate(
+					'To begin fulfilling orders by printing your own label, add a payment method in {{a}}Shipping Settings{{/a}}',
+					{ components: { a: <a href={ getLink( '/store/settings/shipping/:site/', site ) } /> } }
+				) }
+			</Card>
+		);
+	}
+
+	return null;
+};
+
+export default connect( state => {
+	const site = getSelectedSite( state );
+	return {
+		site,
+		loaded: areSettingsLoaded( state, site.ID ),
+		enabled: areLabelsEnabled( state, site.ID ),
+		hasLabelsPaymentMethod: Boolean( getSelectedPaymentMethodId( state, site.ID ) ),
+	};
+} )( localize( LabelsSetupNotice ) );

--- a/client/extensions/woocommerce/woocommerce-services/state/actions.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/actions.js
@@ -1,9 +1,7 @@
+/** @format */
 /**
  * Internal dependencies
- *
- * @format
  */
-
 import { WOOCOMMERCE_SERVICES_SHIPPING_ACTION_LIST_CREATE } from 'woocommerce/state/action-types';
 
 /**
@@ -12,12 +10,18 @@ import { WOOCOMMERCE_SERVICES_SHIPPING_ACTION_LIST_CREATE } from 'woocommerce/st
  * Saves the WCS settings
  * @param {Function} [successAction] Action to be dispatched upon successful completion.
  * @param {Function} [failureAction] Action to be dispatched upon failure of execution.
+ * @param {Function} [noLabelsPaymentAction] Action to be dispatched if labels are enabled but no payment method was selected.
  * @return {Object} Action object.
  */
-export function createWcsShippingSaveActionList( successAction, failureAction ) {
+export function createWcsShippingSaveActionList(
+	successAction,
+	failureAction,
+	noLabelsPaymentAction
+) {
 	return {
 		type: WOOCOMMERCE_SERVICES_SHIPPING_ACTION_LIST_CREATE,
 		successAction,
 		failureAction,
+		noLabelsPaymentAction,
 	};
 }


### PR DESCRIPTION
Fixes #19157 

To test:
* if you have label payments setup on your site you might have to disable and reinstall WCS in WP-Admin to clear them
* attempt to save the shipping settings with labels enabled, but no payment method. You should see an error notice 54d690a
* with labels enabled and no payment method (default state after fresh install) you should see a notice at the top of the dashboard and order pages acca890
* after you save the shipping settings with labels and payment method, no notices should appear
* the print label button should not appear on cancelled orders 8b72255
* the "fulfill without a label" control should appear as a link instead of in a popover menu