### PR TITLE
Comments Redesign: Add CommentContent and CommentPostLink blocks

### DIFF
--- a/client/my-sites/comments/comment/comment-author.jsx
+++ b/client/my-sites/comments/comment/comment-author.jsx
@@ -15,12 +15,13 @@ import { get } from 'lodash';
 import Emojify from 'components/emojify';
 import ExternalLink from 'components/external-link';
 import Gravatar from 'components/gravatar';
+import CommentPostLink from 'my-sites/comments/comment/comment-post-link';
 import { convertDateToUserLocation } from 'components/post-schedule/utils';
 import { gmtOffset, timezone } from 'lib/site/utils';
 import { urlToDomainAndPath } from 'lib/url';
-import { getAuthorDisplayName, getPostTitle } from 'my-sites/comments/comment/utils';
+import { getAuthorDisplayName } from 'my-sites/comments/comment/utils';
 import { getSiteComment } from 'state/selectors';
-import { getSelectedSite, getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
+import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 
 export class CommentAuthor extends Component {
 	static propTypes = {
@@ -33,15 +34,13 @@ export class CommentAuthor extends Component {
 			authorDisplayName,
 			authorUrl,
 			commentDate,
+			commentId,
 			commentType,
 			commentUrl,
 			gravatarUser,
 			isExpanded,
 			moment,
-			postId,
-			postTitle,
 			site,
-			siteSlug,
 		} = this.props;
 
 		const localizedDate = convertDateToUserLocation(
@@ -71,12 +70,7 @@ export class CommentAuthor extends Component {
 						<strong className="comment__author-name">
 							<Emojify>{ authorDisplayName }</Emojify>
 						</strong>
-						{ ! isExpanded && (
-							<span className="comment__post">
-								<Gridicon icon="chevron-right" size={ 18 } />
-								<a href={ `/comments/all/${ siteSlug }/${ postId }` }>{ postTitle }</a>
-							</span>
-						) }
+						{ ! isExpanded && <CommentPostLink { ...{ commentId } } /> }
 					</div>
 
 					<div className="comment__author-info-element">
@@ -115,10 +109,7 @@ const mapStateToProps = ( state, { commentId } ) => {
 		commentType: get( comment, 'type', 'comment' ),
 		commentUrl: get( comment, 'URL' ),
 		gravatarUser,
-		postId: get( comment, 'post.ID' ),
-		postTitle: getPostTitle( comment ),
 		site,
-		siteSlug: getSelectedSiteSlug( state ),
 	};
 };
 

--- a/client/my-sites/comments/comment/comment-author.jsx
+++ b/client/my-sites/comments/comment/comment-author.jsx
@@ -18,9 +18,9 @@ import Gravatar from 'components/gravatar';
 import { convertDateToUserLocation } from 'components/post-schedule/utils';
 import { gmtOffset, timezone } from 'lib/site/utils';
 import { urlToDomainAndPath } from 'lib/url';
+import { getAuthorDisplayName, getPostTitle } from 'my-sites/comments/comment/utils';
 import { getSiteComment } from 'state/selectors';
 import { getSelectedSite, getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
-import { getAuthorDisplayName, getPostTitle } from 'my-sites/comments/comment/utils';
 
 export class CommentAuthor extends Component {
 	static propTypes = {

--- a/client/my-sites/comments/comment/comment-author.jsx
+++ b/client/my-sites/comments/comment/comment-author.jsx
@@ -17,9 +17,9 @@ import ExternalLink from 'components/external-link';
 import Gravatar from 'components/gravatar';
 import CommentPostLink from 'my-sites/comments/comment/comment-post-link';
 import { convertDateToUserLocation } from 'components/post-schedule/utils';
+import { decodeEntities } from 'lib/formatting';
 import { gmtOffset, timezone } from 'lib/site/utils';
 import { urlToDomainAndPath } from 'lib/url';
-import { getAuthorDisplayName } from 'my-sites/comments/comment/utils';
 import { getSiteComment } from 'state/selectors';
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 
@@ -41,6 +41,7 @@ export class CommentAuthor extends Component {
 			isExpanded,
 			moment,
 			site,
+			translate,
 		} = this.props;
 
 		const localizedDate = convertDateToUserLocation(
@@ -68,7 +69,7 @@ export class CommentAuthor extends Component {
 				<div className="comment__author-info">
 					<div className="comment__author-info-element">
 						<strong className="comment__author-name">
-							<Emojify>{ authorDisplayName }</Emojify>
+							<Emojify>{ authorDisplayName || translate( 'Anonymous' ) }</Emojify>
 						</strong>
 						{ ! isExpanded && <CommentPostLink { ...{ commentId } } /> }
 					</div>
@@ -98,7 +99,7 @@ const mapStateToProps = ( state, { commentId } ) => {
 	const comment = getSiteComment( state, siteId, commentId );
 
 	const authorAvatarUrl = get( comment, 'author.avatar_URL' );
-	const authorDisplayName = getAuthorDisplayName( comment );
+	const authorDisplayName = decodeEntities( get( comment, 'author.name' ) );
 	const gravatarUser = { avatar_URL: authorAvatarUrl, display_name: authorDisplayName };
 
 	return {

--- a/client/my-sites/comments/comment/comment-content.jsx
+++ b/client/my-sites/comments/comment/comment-content.jsx
@@ -14,13 +14,13 @@ import { get, noop } from 'lodash';
  */
 import AutoDirection from 'components/auto-direction';
 import Emojify from 'components/emojify';
+import CommentPostLink from 'my-sites/comments/comment/comment-post-link';
 import { stripHTML, decodeEntities } from 'lib/formatting';
-import { getPostTitle } from 'my-sites/comments/comment/utils';
 import { bumpStat, composeAnalytics, recordTracksEvent } from 'state/analytics/actions';
 import { getSiteComment } from 'state/selectors';
 import { getPostCommentsTree } from 'state/comments/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
-import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
 
 export class CommentContent extends Component {
 	static propTypes = {
@@ -50,7 +50,7 @@ export class CommentContent extends Component {
 	};
 
 	render() {
-		const { commentContent, isExpanded, postId, postTitle, siteSlug } = this.props;
+		const { commentContent, commentId, isExpanded } = this.props;
 		return (
 			<div className="comment__content">
 				{ ! isExpanded && (
@@ -65,9 +65,7 @@ export class CommentContent extends Component {
 
 				{ isExpanded && (
 					<div className="comment__content-full">
-						<div className="comment__post">
-							<a href={ `/comments/all/${ siteSlug }/${ postId }` }>{ postTitle }</a>
-						</div>
+						<CommentPostLink { ...{ commentId } } />
 
 						{ this.renderInReplyTo() }
 
@@ -106,8 +104,6 @@ const mapStateToProps = ( state, { commentId } ) => {
 		isJetpack,
 		parentCommentContent,
 		postId,
-		postTitle: getPostTitle( comment ),
-		siteSlug: getSelectedSiteSlug( state ),
 	};
 };
 

--- a/client/my-sites/comments/comment/comment-content.jsx
+++ b/client/my-sites/comments/comment/comment-content.jsx
@@ -2,9 +2,12 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { get } from 'lodash';
+import { localize } from 'i18n-calypso';
+import Gridicon from 'gridicons';
+import { get, noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -13,47 +16,109 @@ import AutoDirection from 'components/auto-direction';
 import Emojify from 'components/emojify';
 import { stripHTML, decodeEntities } from 'lib/formatting';
 import { getPostTitle } from 'my-sites/comments/comment/utils';
+import { bumpStat, composeAnalytics, recordTracksEvent } from 'state/analytics/actions';
 import { getSiteComment } from 'state/selectors';
+import { getPostCommentsTree } from 'state/comments/selectors';
+import { isJetpackSite } from 'state/sites/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 
-export const CommentContent = ( { commentContent, isExpanded, postId, postTitle, siteSlug } ) => (
-	<div className="comment__content">
-		{ ! isExpanded && (
-			<div className="comment__content-preview">
-				<AutoDirection>
-					<Emojify>{ decodeEntities( stripHTML( commentContent ) ) }</Emojify>
-				</AutoDirection>
-			</div>
-		) }
+export class CommentContent extends Component {
+	static propTypes = {
+		commentId: PropTypes.number,
+		isExpanded: PropTypes.bool,
+	};
 
-		{ isExpanded && (
-			<div className="comment__content-full">
-				<div className="comment__post">
-					<a href={ `/comments/all/${ siteSlug }/${ postId }` }>{ postTitle }</a>
-				</div>
+	trackDeepReaderLinkClick = () =>
+		this.props.isJetpack ? noop : this.props.recordReaderCommentOpened();
 
-				<AutoDirection>
-					<Emojify>
-						<div
-							dangerouslySetInnerHTML={ { __html: commentContent } } //eslint-disable-line react/no-danger
-						/>
-					</Emojify>
-				</AutoDirection>
+	renderInReplyTo = () => {
+		const { commentUrl, parentCommentContent, translate } = this.props;
+
+		if ( ! parentCommentContent ) {
+			return null;
+		}
+
+		return (
+			<div className="comment__in-reply-to">
+				<Gridicon icon="reply" size={ 18 } />
+				<span>{ translate( 'In reply to:' ) }</span>
+				<a href={ commentUrl } onClick={ this.trackDeepReaderLinkClick }>
+					<Emojify>{ parentCommentContent }</Emojify>
+				</a>
 			</div>
-		) }
-	</div>
-);
+		);
+	};
+
+	render() {
+		const { commentContent, isExpanded, postId, postTitle, siteSlug } = this.props;
+		return (
+			<div className="comment__content">
+				{ ! isExpanded && (
+					<div className="comment__content-preview">
+						{ this.renderInReplyTo() }
+
+						<AutoDirection>
+							<Emojify>{ decodeEntities( stripHTML( commentContent ) ) }</Emojify>
+						</AutoDirection>
+					</div>
+				) }
+
+				{ isExpanded && (
+					<div className="comment__content-full">
+						<div className="comment__post">
+							<a href={ `/comments/all/${ siteSlug }/${ postId }` }>{ postTitle }</a>
+						</div>
+
+						{ this.renderInReplyTo() }
+
+						<AutoDirection>
+							<Emojify>
+								<div
+									dangerouslySetInnerHTML={ { __html: commentContent } } //eslint-disable-line react/no-danger
+								/>
+							</Emojify>
+						</AutoDirection>
+					</div>
+				) }
+			</div>
+		);
+	}
+}
 
 const mapStateToProps = ( state, { commentId } ) => {
 	const siteId = getSelectedSiteId( state );
+	const isJetpack = isJetpackSite( state, siteId );
+
 	const comment = getSiteComment( state, siteId, commentId );
+	const postId = get( comment, 'post.ID' );
+	const commentUrl = isJetpack
+		? get( comment, 'URL' )
+		: `/read/blogs/${ siteId }/posts/${ postId }#comment-${ commentId }`;
+
+	const commentsTree = getPostCommentsTree( state, siteId, postId, 'all' );
+	const parentCommentId = get( commentsTree, [ commentId, 'data', 'parent', 'ID' ], 0 );
+	const parentComment = get( commentsTree, [ parentCommentId, 'data' ], {} );
+	const parentCommentContent = decodeEntities( stripHTML( get( parentComment, 'content' ) ) );
 
 	return {
 		commentContent: get( comment, 'content' ),
-		postId: get( comment, 'post.ID' ),
+		commentUrl,
+		isJetpack,
+		parentCommentContent,
+		postId,
 		postTitle: getPostTitle( comment ),
 		siteSlug: getSelectedSiteSlug( state ),
 	};
 };
 
-export default connect( mapStateToProps )( CommentContent );
+const mapDispatchToProps = dispatch => ( {
+	recordReaderCommentOpened: () =>
+		dispatch(
+			composeAnalytics(
+				recordTracksEvent( 'calypso_comment_management_comment_opened' ),
+				bumpStat( 'calypso_comment_management', 'comment_opened' )
+			)
+		),
+} );
+
+export default connect( mapStateToProps, mapDispatchToProps )( localize( CommentContent ) );

--- a/client/my-sites/comments/comment/comment-content.jsx
+++ b/client/my-sites/comments/comment/comment-content.jsx
@@ -12,27 +12,34 @@ import { get } from 'lodash';
 import AutoDirection from 'components/auto-direction';
 import Emojify from 'components/emojify';
 import { stripHTML, decodeEntities } from 'lib/formatting';
+import { getPostTitle } from 'my-sites/comments/comment/utils';
 import { getSiteComment } from 'state/selectors';
-import { getSelectedSiteId } from 'state/ui/selectors';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 
-export const CommentContent = ( { commentContent, isExpanded } ) => (
+export const CommentContent = ( { commentContent, isExpanded, postId, postTitle, siteSlug } ) => (
 	<div className="comment__content">
 		{ ! isExpanded && (
-			<AutoDirection>
-				<div className="comment__content-preview">
+			<div className="comment__content-preview">
+				<AutoDirection>
 					<Emojify>{ decodeEntities( stripHTML( commentContent ) ) }</Emojify>
-				</div>
-			</AutoDirection>
+				</AutoDirection>
+			</div>
 		) }
+
 		{ isExpanded && (
-			<AutoDirection>
-				<Emojify>
-					<div
-						className="comment__content-full"
-						dangerouslySetInnerHTML={ { __html: commentContent } } //eslint-disable-line react/no-danger
-					/>
-				</Emojify>
-			</AutoDirection>
+			<div className="comment__content-full">
+				<div className="comment__post">
+					<a href={ `/comments/all/${ siteSlug }/${ postId }` }>{ postTitle }</a>
+				</div>
+
+				<AutoDirection>
+					<Emojify>
+						<div
+							dangerouslySetInnerHTML={ { __html: commentContent } } //eslint-disable-line react/no-danger
+						/>
+					</Emojify>
+				</AutoDirection>
+			</div>
 		) }
 	</div>
 );
@@ -43,6 +50,9 @@ const mapStateToProps = ( state, { commentId } ) => {
 
 	return {
 		commentContent: get( comment, 'content' ),
+		postId: get( comment, 'post.ID' ),
+		postTitle: getPostTitle( comment ),
+		siteSlug: getSelectedSiteSlug( state ),
 	};
 };
 

--- a/client/my-sites/comments/comment/comment-content.jsx
+++ b/client/my-sites/comments/comment/comment-content.jsx
@@ -17,8 +17,7 @@ import Emojify from 'components/emojify';
 import CommentPostLink from 'my-sites/comments/comment/comment-post-link';
 import { stripHTML, decodeEntities } from 'lib/formatting';
 import { bumpStat, composeAnalytics, recordTracksEvent } from 'state/analytics/actions';
-import { getSiteComment } from 'state/selectors';
-import { getPostCommentsTree } from 'state/comments/selectors';
+import { getParentComment, getSiteComment } from 'state/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 
@@ -32,7 +31,7 @@ export class CommentContent extends Component {
 		this.props.isJetpack ? noop : this.props.recordReaderCommentOpened();
 
 	renderInReplyTo = () => {
-		const { commentUrl, parentCommentContent, translate } = this.props;
+		const { commentUrl, isExpanded, parentCommentContent, translate } = this.props;
 
 		if ( ! parentCommentContent ) {
 			return null;
@@ -40,7 +39,7 @@ export class CommentContent extends Component {
 
 		return (
 			<div className="comment__in-reply-to">
-				<Gridicon icon="reply" size={ 18 } />
+				{ ! isExpanded && <Gridicon icon="reply" size={ 18 } /> }
 				<span>{ translate( 'In reply to:' ) }</span>
 				<a href={ commentUrl } onClick={ this.trackDeepReaderLinkClick }>
 					<Emojify>{ parentCommentContent }</Emojify>
@@ -89,13 +88,12 @@ const mapStateToProps = ( state, { commentId } ) => {
 
 	const comment = getSiteComment( state, siteId, commentId );
 	const postId = get( comment, 'post.ID' );
+
 	const commentUrl = isJetpack
 		? get( comment, 'URL' )
 		: `/read/blogs/${ siteId }/posts/${ postId }#comment-${ commentId }`;
 
-	const commentsTree = getPostCommentsTree( state, siteId, postId, 'all' );
-	const parentCommentId = get( commentsTree, [ commentId, 'data', 'parent', 'ID' ], 0 );
-	const parentComment = get( commentsTree, [ parentCommentId, 'data' ], {} );
+	const parentComment = getParentComment( state, siteId, postId, commentId );
 	const parentCommentContent = decodeEntities( stripHTML( get( parentComment, 'content' ) ) );
 
 	return {

--- a/client/my-sites/comments/comment/comment-content.jsx
+++ b/client/my-sites/comments/comment/comment-content.jsx
@@ -1,0 +1,49 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { connect } from 'react-redux';
+import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import AutoDirection from 'components/auto-direction';
+import Emojify from 'components/emojify';
+import { stripHTML, decodeEntities } from 'lib/formatting';
+import { getSiteComment } from 'state/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
+
+export const CommentContent = ( { commentContent, isExpanded } ) => (
+	<div className="comment__content">
+		{ ! isExpanded && (
+			<AutoDirection>
+				<div className="comment__content-preview">
+					<Emojify>{ decodeEntities( stripHTML( commentContent ) ) }</Emojify>
+				</div>
+			</AutoDirection>
+		) }
+		{ isExpanded && (
+			<AutoDirection>
+				<Emojify>
+					<div
+						className="comment__content-full"
+						dangerouslySetInnerHTML={ { __html: commentContent } } //eslint-disable-line react/no-danger
+					/>
+				</Emojify>
+			</AutoDirection>
+		) }
+	</div>
+);
+
+const mapStateToProps = ( state, { commentId } ) => {
+	const siteId = getSelectedSiteId( state );
+	const comment = getSiteComment( state, siteId, commentId );
+
+	return {
+		commentContent: get( comment, 'content' ),
+	};
+};
+
+export default connect( mapStateToProps )( CommentContent );

--- a/client/my-sites/comments/comment/comment-post-link.jsx
+++ b/client/my-sites/comments/comment/comment-post-link.jsx
@@ -11,13 +11,25 @@ import { get } from 'lodash';
 /**
  * Internal dependencies
  */
-import { decodeEntities } from 'lib/formatting';
+import QueryPosts from 'components/data/query-posts';
+import { decodeEntities, stripHTML } from 'lib/formatting';
 import { getSiteComment } from 'state/selectors';
+import { getSitePost } from 'state/posts/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 
-const CommentPostLink = ( { siteSlug, postId, postTitle, translate } ) => (
+const CommentPostLink = ( {
+	isPostTitleLoaded,
+	postId,
+	postTitle,
+	siteId,
+	siteSlug,
+	translate,
+} ) => (
 	<div className="comment__post-link">
+		{ ! isPostTitleLoaded && <QueryPosts siteId={ siteId } postId={ postId } /> }
+
 		<Gridicon icon="chevron-right" size={ 18 } />
+
 		<a href={ `/comments/all/${ siteSlug }/${ postId }` }>
 			{ postTitle || translate( 'Untitled' ) }
 		</a>
@@ -26,12 +38,21 @@ const CommentPostLink = ( { siteSlug, postId, postTitle, translate } ) => (
 
 const mapStateToProps = ( state, { commentId } ) => {
 	const siteId = getSelectedSiteId( state );
+	const siteSlug = getSelectedSiteSlug( state );
+
 	const comment = getSiteComment( state, siteId, commentId );
 
+	const postId = get( comment, 'post.ID' );
+	const post = getSitePost( state, siteId, postId );
+	const postTitle =
+		decodeEntities( get( comment, 'post.title' ) ) ||
+		decodeEntities( stripHTML( get( post, 'excerpt' ) ) );
+
 	return {
-		postId: get( comment, 'post.ID' ),
-		postTitle: decodeEntities( get( comment, 'post.title' ) ),
-		siteSlug: getSelectedSiteSlug( state ),
+		isPostTitleLoaded: !! postTitle || !! post,
+		postId,
+		postTitle,
+		siteSlug,
 	};
 };
 

--- a/client/my-sites/comments/comment/comment-post-link.jsx
+++ b/client/my-sites/comments/comment/comment-post-link.jsx
@@ -1,0 +1,38 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+import Gridicon from 'gridicons';
+import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { decodeEntities } from 'lib/formatting';
+import { getSiteComment } from 'state/selectors';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
+
+const CommentPostLink = ( { siteSlug, postId, postTitle, translate } ) => (
+	<div className="comment__post-link">
+		<Gridicon icon="chevron-right" size={ 18 } />
+		<a href={ `/comments/all/${ siteSlug }/${ postId }` }>
+			{ postTitle || translate( 'Untitled' ) }
+		</a>
+	</div>
+);
+
+const mapStateToProps = ( state, { commentId } ) => {
+	const siteId = getSelectedSiteId( state );
+	const comment = getSiteComment( state, siteId, commentId );
+
+	return {
+		postId: get( comment, 'post.ID' ),
+		postTitle: decodeEntities( get( comment, 'post.title' ) ),
+		siteSlug: getSelectedSiteSlug( state ),
+	};
+};
+
+export default connect( mapStateToProps )( localize( CommentPostLink ) );

--- a/client/my-sites/comments/comment/index.jsx
+++ b/client/my-sites/comments/comment/index.jsx
@@ -11,6 +11,7 @@ import ReactDom from 'react-dom';
  * Internal dependencies
  */
 import Card from 'components/card';
+import CommentContent from 'my-sites/comments/comment/comment-content';
 import CommentHeader from 'my-sites/comments/comment/comment-header';
 
 export class Comment extends Component {
@@ -80,6 +81,8 @@ export class Comment extends Component {
 							{ ...{ commentId, isBulkMode, isEditMode, isExpanded, isSelected } }
 							toggleExpanded={ this.toggleExpanded }
 						/>
+
+						<CommentContent { ...{ commentId, isExpanded } } />
 					</div>
 				) }
 			</Card>

--- a/client/my-sites/comments/comment/style.scss
+++ b/client/my-sites/comments/comment/style.scss
@@ -97,7 +97,7 @@
 	}
 
 	.comment__post-link {
-		display: inline-block;
+		display: inline;
 
 		.gridicon {
 			color: $gray;
@@ -153,22 +153,20 @@
 
 	.comment__post-link {
 		margin: 8px 0 16px;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
 
 		.gridicon {
 			display: none;
-		}
-
-		a {
-			color: $gray-text-min;
-		}
-		a:focus,
-		a:hover {
-			color: $blue-wordpress;
 		}
 	}
 
 	.comment__in-reply-to {
 		color: $gray-text-min;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
 
 		.gridicon {
 			fill: $gray-text-min;
@@ -213,6 +211,18 @@
 		&:after {
 			background: transparent;
 		}
+	}
+}
+
+// Comment Post Link Block
+
+.comment__post-link {
+	a {
+		color: $gray-text-min;
+	}
+	a:focus,
+	a:hover {
+		color: $blue-wordpress;
 	}
 }
 

--- a/client/my-sites/comments/comment/style.scss
+++ b/client/my-sites/comments/comment/style.scss
@@ -96,9 +96,13 @@
 		color: $blue-wordpress;
 	}
 
-	.comment__post .gridicon {
-		color: $gray;
-		margin-bottom: -4px;
+	.comment__post-link {
+		display: inline-block;
+
+		.gridicon {
+			color: $gray;
+			margin-bottom: -4px;
+		}
 	}
 
 	.comment__date,
@@ -147,8 +151,12 @@
 .comment__content {
 	padding: 0 56px 16px 56px;
 
-	.comment__post {
+	.comment__post-link {
 		margin: 8px 0 16px;
+
+		.gridicon {
+			display: none;
+		}
 
 		a {
 			color: $gray-text-min;

--- a/client/my-sites/comments/comment/style.scss
+++ b/client/my-sites/comments/comment/style.scss
@@ -46,7 +46,8 @@
 		transition: transform 0.15s cubic-bezier(0.175, 0.885, 0.32, 1.275), color 0.2s ease-in;
 	}
 
-	&:hover .gridicon {
+	a:focus .gridicon,
+	a:hover .gridicon {
 		fill: $blue-medium;
 	}
 }
@@ -90,6 +91,7 @@
 	a {
 		color: $gray-text-min;
 	}
+	a:focus,
 	a:hover {
 		color: $blue-wordpress;
 	}
@@ -122,7 +124,8 @@
 	flex-shrink: 0;
 	padding: 8px 16px 8px 8px;
 
-	&:hover {
+	a:focus,
+	a:hover {
 		.gridicon,
 		label {
 			color: $gray-dark;
@@ -140,6 +143,18 @@
 
 .comment__content {
 	padding: 0 56px 16px 56px;
+
+	.comment__post {
+		margin: 8px 0 16px;
+
+		a {
+			color: $gray-text-min;
+		}
+		a:focus,
+		a:hover {
+			color: $blue-wordpress;
+		}
+	}
 }
 
 .comment__content-preview {

--- a/client/my-sites/comments/comment/style.scss
+++ b/client/my-sites/comments/comment/style.scss
@@ -119,13 +119,16 @@
 	display: flex;
 	color: $gray-text-min;
 	cursor: pointer;
-	fill: lighten($gray, 10%);
 	flex-grow: 0;
 	flex-shrink: 0;
 	padding: 8px 16px 8px 8px;
 
-	a:focus,
-	a:hover {
+	.gridicon {
+		fill: $gray-text-min;
+	}
+
+	&:focus,
+	&:hover {
 		.gridicon,
 		label {
 			color: $gray-dark;
@@ -146,6 +149,27 @@
 
 	.comment__post {
 		margin: 8px 0 16px;
+
+		a {
+			color: $gray-text-min;
+		}
+		a:focus,
+		a:hover {
+			color: $blue-wordpress;
+		}
+	}
+
+	.comment__in-reply-to {
+		color: $gray-text-min;
+
+		.gridicon {
+			fill: $gray-text-min;
+			margin-bottom: -4px;
+		}
+
+		span {
+			margin: 0 4px;
+		}
 
 		a {
 			color: $gray-text-min;

--- a/client/my-sites/comments/comment/style.scss
+++ b/client/my-sites/comments/comment/style.scss
@@ -28,7 +28,7 @@
 
 .comment__bulk-select {
 	align-self: center;
-	padding-left: 16px;
+	padding: 16px;
 
 	.form-checkbox {
 		margin: 0;
@@ -188,5 +188,13 @@
 
 	.comment__content {
 		padding-top: 8px;
+	}
+}
+
+// Bulk Mode View
+
+.card.comment.is-bulk-mode {
+	.comment__header .comment__author {
+		padding-left: 0;
 	}
 }

--- a/client/my-sites/comments/comment/style.scss
+++ b/client/my-sites/comments/comment/style.scss
@@ -46,8 +46,7 @@
 		transition: transform 0.15s cubic-bezier(0.175, 0.885, 0.32, 1.275), color 0.2s ease-in;
 	}
 
-	a:focus .gridicon,
-	a:hover .gridicon {
+	&:hover .gridicon {
 		fill: $blue-medium;
 	}
 }
@@ -149,10 +148,15 @@
 // Comment Content Block
 
 .comment__content {
-	padding: 0 56px 16px 56px;
+	padding: 0 16px 16px 56px;
+
+	@include breakpoint( '>480px' ) {
+		padding-right: 56px;
+	}
 
 	.comment__post-link {
-		margin: 8px 0 16px;
+		font-weight: 600;
+		margin: 8px 0 1em 0;
 		overflow: hidden;
 		text-overflow: ellipsis;
 		white-space: nowrap;
@@ -245,6 +249,12 @@
 
 	.comment__content {
 		padding-top: 8px;
+
+		.comment__in-reply-to {
+			border-left: 4px solid lighten($gray, 30%);
+			margin-bottom: 1em;
+			padding: 2px 4px;
+		}
 	}
 }
 

--- a/client/my-sites/comments/comment/style.scss
+++ b/client/my-sites/comments/comment/style.scss
@@ -136,6 +136,39 @@
 	}
 }
 
+// Comment Content Block
+
+.comment__content {
+	padding: 0 56px 16px 56px;
+}
+
+.comment__content-preview {
+	overflow: hidden;
+	position: relative;
+
+	&:after {
+		background: linear-gradient(to right, rgba($white, 0), rgba($white, 1) 50%);
+		content: '';
+		height: 20px;
+		position: absolute;
+		bottom: 0;
+		right: 0;
+		width: 30%;
+	}
+}
+
+@supports (-webkit-line-clamp: 2) {
+	.comment__content-preview {
+		display: -webkit-box;
+		-webkit-box-orient: vertical;
+		-webkit-line-clamp: 2;
+
+		&:after {
+			background: transparent;
+		}
+	}
+}
+
 // Expanded View
 
 .card.comment.is-expanded {
@@ -143,7 +176,6 @@
 
 	.comment__header {
 		border-bottom: 1px solid lighten($gray, 30%);
-		cursor: default;
 
 		.button.comment__toggle-expanded {
 			border-left: 1px solid lighten($gray, 30%);
@@ -152,5 +184,9 @@
 		.comment__toggle-expanded .gridicon {
 			transform: rotate(180deg);
 		}
+	}
+
+	.comment__content {
+		padding-top: 8px;
 	}
 }

--- a/client/my-sites/comments/comment/utils.js
+++ b/client/my-sites/comments/comment/utils.js
@@ -43,15 +43,6 @@ export const getPostTitle = comment =>
 	decodeEntities( get( comment, 'post.title', translate( 'Untitled' ) ) );
 
 /**
- * Return a post's Reader URL.
- *
- * @param {Number} siteId A site identifier.
- * @param {Number} postId A post identifier.
- * @returns {String} The post's Reader URL.
- */
-export const getPostReaderUrl = ( siteId, postId ) => `/read/blogs/${ siteId }/posts/${ postId }`;
-
-/**
  * Check if a site blacklist contains an email address.
  *
  * @param {String} blacklist A site blacklist.

--- a/client/my-sites/comments/comment/utils.js
+++ b/client/my-sites/comments/comment/utils.js
@@ -34,15 +34,6 @@ export const getMinimalComment = comment => ( {
 } );
 
 /**
- * Return the comment parent post title, or "Untitled" if the parent post has no title.
- *
- * @param {Object} comment A comment object.
- * @returns {String} The comment parent post title.
- */
-export const getPostTitle = comment =>
-	decodeEntities( get( comment, 'post.title', translate( 'Untitled' ) ) );
-
-/**
  * Check if a site blacklist contains an email address.
  *
  * @param {String} blacklist A site blacklist.

--- a/client/my-sites/comments/comment/utils.js
+++ b/client/my-sites/comments/comment/utils.js
@@ -3,21 +3,6 @@
  * External dependencies
  */
 import { get, includes } from 'lodash';
-import { translate } from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import { decodeEntities } from 'lib/formatting';
-
-/**
- * Return the comment author display name, or "Anonymous" if the comment author has no name.
- *
- * @param {Object} comment A comment object.
- * @returns {String} The comment author display name.
- */
-export const getAuthorDisplayName = comment =>
-	decodeEntities( get( comment, 'author.name', translate( 'Anonymous' ) ) );
 
 /**
  * Create a stripped down comment object containing only the information needed by


### PR DESCRIPTION
Follow up to #19082

Add the new `CommentContent` block.
Also replaces `<div className="comment__post">` with a proper `CommentPostLink` block that handles the post title rendering and its fallbacks.

### Note

```es6
const commentsTree = getPostCommentsTree( state, siteId, postId, 'all' );
const parentCommentId = get( commentsTree, [ commentId, 'data', 'parent', 'ID' ], 0 );
const parentComment = get( commentsTree, [ parentCommentId, 'data' ], {} );
const parentCommentContent = decodeEntities( stripHTML( get( parentComment, 'content' ) ) );
```

This block is a good candidate for a global selector conversion.
I'll take care of it in a separate PR.

### Testing instructions

Add this code in `CommentList` to display a list of comments using the new design:

```jsx
{ ! isLoading &&
	map( commentsPage, commentId => (
		<Comment
			commentId={ commentId }
			key={ `comment-${ siteId }-${ commentId }` }
			isBulkMode={ isBulkEdit }
			isSelected={ this.isCommentSelected( commentId ) }
		/>
	) ) }
```

### Diagram

<img width="880" alt="screen shot 2017-10-23 at 21 11 14" src="https://user-images.githubusercontent.com/2070010/31910870-c56f930a-b836-11e7-8a85-0a0e6134cefb.png">
