### PR TITLE
Editor: Post Revisions: Only show the cog icon in the sidebar

### DIFF
--- a/client/post-editor/editor-ground-control/index.jsx
+++ b/client/post-editor/editor-ground-control/index.jsx
@@ -22,10 +22,7 @@ import { recordEvent, recordStat } from 'lib/posts/stats';
 import EditorPublishButton, { getPublishButtonStatus } from 'post-editor/editor-publish-button';
 import Button from 'components/button';
 import EditorPostType from 'post-editor/editor-post-type';
-import {
-	NESTED_SIDEBAR_REVISIONS,
-	NestedSidebarPropType,
-} from 'post-editor/editor-sidebar/constants';
+import { NestedSidebarPropType } from 'post-editor/editor-sidebar/constants';
 import HistoryButton from 'post-editor/editor-ground-control/history-button';
 
 export class EditorGroundControl extends PureComponent {
@@ -285,9 +282,7 @@ export class EditorGroundControl extends PureComponent {
 					className="editor-ground-control__toggle-sidebar"
 					onClick={ this.props.toggleSidebar }
 				>
-					<Gridicon
-						icon={ this.props.nestedSidebar === NESTED_SIDEBAR_REVISIONS ? 'history' : 'cog' }
-					/>
+					<Gridicon icon="cog" />
 					<span className="editor-ground-control__button-label">
 						{' '}
 						<EditorPostType isSettings />


### PR DESCRIPTION
i.e. Remove the History Gridicon from the sidebar ground control button

## Before

<img width="364" alt="screen shot 2017-10-26 at 10 53 47 am" src="https://user-images.githubusercontent.com/1587282/32060496-e52f0c36-ba3c-11e7-9713-b8dce9bd2104.png">

## After
<img width="354" alt="screen shot 2017-10-26 at 10 59 48 am" src="https://user-images.githubusercontent.com/1587282/32060508-ed947e7e-ba3c-11e7-8c72-a7ca1b81c532.png">


