### PR TITLE
Selectors: Add getParentComment selector

### DIFF
--- a/client/state/selectors/get-parent-comment.js
+++ b/client/state/selectors/get-parent-comment.js
@@ -1,0 +1,28 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { getPostCommentsTree } from 'state/comments/selectors';
+
+/**
+ * Returns the parent comment of a given comment
+ *
+ * @param {Object} state Redux state
+ * @param {Number} siteId Site identifier
+ * @param {Number} postId Post identifier
+ * @param {Number} commentId Comment identifier
+ * @return {Object} The parent comment
+ */
+export const getParentComment = ( state, siteId, postId, commentId ) => {
+	const commentsTree = getPostCommentsTree( state, siteId, postId, 'all' );
+	const parentCommentId = get( commentsTree, [ commentId, 'data', 'parent', 'ID' ], 0 );
+
+	return parentCommentId ? get( commentsTree, [ parentCommentId, 'data' ], {} ) : {};
+};
+
+export default getParentComment;

--- a/client/state/selectors/get-parent-comment.js
+++ b/client/state/selectors/get-parent-comment.js
@@ -21,8 +21,7 @@ import { getPostCommentsTree } from 'state/comments/selectors';
 export const getParentComment = ( state, siteId, postId, commentId ) => {
 	const commentsTree = getPostCommentsTree( state, siteId, postId, 'all' );
 	const parentCommentId = get( commentsTree, [ commentId, 'data', 'parent', 'ID' ], 0 );
-
-	return parentCommentId ? get( commentsTree, [ parentCommentId, 'data' ], {} ) : {};
+	return get( commentsTree, [ parentCommentId, 'data' ], {} );
 };
 
 export default getParentComment;

--- a/client/state/selectors/index.js
+++ b/client/state/selectors/index.js
@@ -68,6 +68,7 @@ export getMenuItemTypes from './get-menu-item-types';
 export getMenusUrl from './get-menus-url';
 export getNetworkSites from './get-network-sites';
 export getOriginalUserSetting from './get-original-user-setting';
+export getParentComment from './get-parent-comment';
 export getPastBillingTransaction from './get-past-billing-transaction';
 export getPastBillingTransactions from './get-past-billing-transactions';
 export getPluginUploadError from './get-plugin-upload-error';

--- a/client/state/selectors/test/get-parent-comment.js
+++ b/client/state/selectors/test/get-parent-comment.js
@@ -1,0 +1,48 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { getParentComment } from '../';
+
+const state = {
+	comments: {
+		items: {
+			'123-4': [
+				{
+					ID: 1,
+					parent: { ID: 0 },
+				},
+				{
+					ID: 2,
+					parent: { ID: 1 },
+				},
+			],
+		},
+	},
+};
+
+describe( 'getParentComment()', () => {
+	test( 'should return the parent comment if available', () => {
+		expect( getParentComment( state, 123, 4, 2 ) ).to.eql( {
+			ID: 1,
+			parent: { ID: 0 },
+		} );
+	} );
+	test( 'should return an empty object if the parent comment is not available', () => {
+		expect( getParentComment( state, 123, 4, 1 ) ).to.eql( {} );
+	} );
+	test( 'should return an empty object if the site does not exist', () => {
+		expect( getParentComment( state, 456, 4, 2 ) ).to.eql( {} );
+	} );
+	test( 'should return an empty object if the post does not exist', () => {
+		expect( getParentComment( state, 123, 5, 2 ) ).to.eql( {} );
+	} );
+	test( 'should return an empty object if the comment does not exist', () => {
+		expect( getParentComment( state, 123, 4, 3 ) ).to.eql( {} );
+	} );
+} );


### PR DESCRIPTION
Add a new `getParentComment` selector that returns a comment's parent comment object.

See #19184 for the reason why this is useful.