### PR TITLE
Reader: fix emoji margin in full post

### DIFF
--- a/client/blocks/reader-full-post/_content.scss
+++ b/client/blocks/reader-full-post/_content.scss
@@ -64,7 +64,7 @@
 		display: inline;
 		margin: auto;
 
-		&.emoji {
+		&.emojify__emoji {
 			height: 1em;
 			margin-bottom: 0;
 		}
@@ -154,7 +154,7 @@
 			display: block;
 			margin: 0 auto;
 
-			&.emoji {
+			&.emojify__emoji {
 				display: inline;
 			}
 		}

--- a/client/blocks/reader-full-post/test/featured-image.jsx
+++ b/client/blocks/reader-full-post/test/featured-image.jsx
@@ -13,8 +13,8 @@ import FeaturedImage from '../featured-image';
 
 describe( 'FeaturedImage', () => {
 	test( 'sets the source to an empty string if the image fails to load', () => {
-		const nonExistantImage = 'http://sketchy-feed.com/missing-image-2.jpg';
-		const wrapper = shallow( <FeaturedImage src={ nonExistantImage } /> );
+		const nonExistentImage = 'http://sketchy-feed.com/missing-image-2.jpg';
+		const wrapper = shallow( <FeaturedImage src={ nonExistentImage } /> );
 		wrapper.instance().handleImageError();
 		assert.equal( '', wrapper.state( 'src' ) );
 	} );


### PR DESCRIPTION
Now that all emoji in full post content are converted with the `<Emojify>` component, they are given the class `emojify__emoji` rather than just `emoji`.

This PR updates the class name in the full post stylesheet so inline emoji display correctly on Reader full post.

#### Before

<img width="206" alt="screen shot 2017-10-26 at 17 58 42" src="https://user-images.githubusercontent.com/17325/32066414-92ecc5e0-ba77-11e7-8bc5-0150dc92d57e.png">

https://wordpress.com/read/feeds/40474296/posts/1641611492

#### After 

<img width="212" alt="screen shot 2017-10-26 at 17 59 08" src="https://user-images.githubusercontent.com/17325/32066430-99bb2844-ba77-11e7-8327-e8655947dcba.png">

http://calypso.localhost:3000/read/feeds/40474296/posts/1641611492

cc @ceripower 