### PR TITLE
Store `ProductSearch` Component: Rewrite to allow for multiple selections

### DIFF
--- a/client/extensions/woocommerce/app/order/order-create/index.js
+++ b/client/extensions/woocommerce/app/order/order-create/index.js
@@ -56,7 +56,10 @@ class OrderCreate extends Component {
 
 					<SectionHeader label={ translate( 'Add products to the order' ) } />
 					<Card className="order-create__card">
-						<ProductSearch onChange={ this.setTokens } />
+						<ProductSearch
+							onChange={ this.setTokens }
+							placeholder={ translate( 'Search products' ) }
+						/>
 						{ this.state.products.map( item => <p key={ item.key }>{ item.name }</p> ) }
 					</Card>
 

--- a/client/extensions/woocommerce/app/order/order-create/index.js
+++ b/client/extensions/woocommerce/app/order/order-create/index.js
@@ -22,14 +22,19 @@ import ProductSearch from 'woocommerce/components/product-search';
 import { ProtectFormGuard } from 'lib/protect-form';
 import SectionHeader from 'components/section-header';
 
-const noop = () => {};
-
 class OrderCreate extends Component {
+	state = {
+		products: [],
+	};
 	editOrder = order => {
 		const { site } = this.props;
 		if ( site && site.ID ) {
 			this.props.editOrder( site.ID, order );
 		}
+	};
+
+	setTokens = products => {
+		this.setState( { products } );
 	};
 
 	render() {
@@ -51,7 +56,8 @@ class OrderCreate extends Component {
 
 					<SectionHeader label={ translate( 'Add products to the order' ) } />
 					<Card className="order-create__card">
-						<ProductSearch onSelect={ noop } />
+						<ProductSearch onChange={ this.setTokens } />
+						{ this.state.products.map( item => <p key={ item.key }>{ item.name }</p> ) }
 					</Card>
 
 					<SectionHeader label={ translate( 'How will these products be shipped?' ) } />

--- a/client/extensions/woocommerce/components/product-search/README.md
+++ b/client/extensions/woocommerce/components/product-search/README.md
@@ -25,3 +25,4 @@ render: function() {
 #### Props
 
 * `onChange`: Function called when a result is clicked, with product object as an argument.
+* `maxLength`: A limit to the number of tokens that can be selected

--- a/client/extensions/woocommerce/components/product-search/README.md
+++ b/client/extensions/woocommerce/components/product-search/README.md
@@ -10,13 +10,13 @@ import Card from 'components/card';
 import ProductSearch from 'woocommerce/components/product-search';
 
 render: function() {
-	const onSelect = product => {
-		// Do something with product object
+	const onChange = products => {
+		// Do something with your products array
 	};
 
 	return (
 		<Card>
-			<ProductSearch onSelect={ onSelect } />
+			<ProductSearch onChange={ onChange } />
 		</Card>
 	);
 }
@@ -24,4 +24,4 @@ render: function() {
 
 #### Props
 
-* `onSelect`: Function called when a result is clicked, with product object as an argument.
+* `onChange`: Function called when a result is clicked, with product object as an argument.

--- a/client/extensions/woocommerce/components/product-search/index.js
+++ b/client/extensions/woocommerce/components/product-search/index.js
@@ -72,7 +72,11 @@ class ProductSearch extends Component {
 	};
 
 	hasToken = token => {
-		return !! find( this.state.tokens, { id: token.id, variation: token.variation } );
+		const match = { id: token.id };
+		if ( token.variation ) {
+			match.variation = token.variation;
+		}
+		return !! find( this.state.tokens, match );
 	};
 
 	addToken = token => {

--- a/client/extensions/woocommerce/components/product-search/index.js
+++ b/client/extensions/woocommerce/components/product-search/index.js
@@ -7,7 +7,7 @@ import PropTypes from 'prop-types';
 import { bindActionCreators } from 'redux';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
-import { debounce, find } from 'lodash';
+import { debounce, find, get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -16,6 +16,7 @@ import {
 	fetchProductSearchResults,
 	clearProductSearch,
 } from 'woocommerce/state/sites/products/actions';
+import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
 import ProductSearchField from './search';
 import ProductSearchResults from './results';
 
@@ -118,12 +119,16 @@ class ProductSearch extends Component {
 	}
 }
 
-export default connect( null, dispatch =>
-	bindActionCreators(
-		{
-			fetchProductSearchResults,
-			clearProductSearch,
-		},
-		dispatch
-	)
+export default connect(
+	state => ( {
+		siteId: get( getSelectedSiteWithFallback( state ), 'ID' ),
+	} ),
+	dispatch =>
+		bindActionCreators(
+			{
+				fetchProductSearchResults,
+				clearProductSearch,
+			},
+			dispatch
+		)
 )( ProductSearch );

--- a/client/extensions/woocommerce/components/product-search/index.js
+++ b/client/extensions/woocommerce/components/product-search/index.js
@@ -7,7 +7,7 @@ import PropTypes from 'prop-types';
 import { bindActionCreators } from 'redux';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
-import { find } from 'lodash';
+import { debounce, find } from 'lodash';
 
 /**
  * Internal dependencies
@@ -36,15 +36,7 @@ class ProductSearch extends Component {
 	};
 
 	componentDidMount() {
-		const { siteId } = this.props;
-		this.props.fetchProductSearchResults( siteId, 1, '' );
-	}
-
-	componentWillReceiveProps( newProps ) {
-		const { siteId } = newProps;
-		if ( this.props.siteId !== siteId ) {
-			this.props.fetchProductSearchResults( siteId, 1, '' );
-		}
+		this.debouncedSearch = debounce( this.fetchSearch, 500 );
 	}
 
 	componentWillUnmount() {
@@ -54,7 +46,10 @@ class ProductSearch extends Component {
 
 	handleSearch = query => {
 		this.setState( { currentSearch: query } );
-		// @todo Debounce this
+		this.debouncedSearch( query );
+	};
+
+	fetchSearch = query => {
 		const { siteId } = this.props;
 		this.props.fetchProductSearchResults( siteId, 1, query );
 	};

--- a/client/extensions/woocommerce/components/product-search/index.js
+++ b/client/extensions/woocommerce/components/product-search/index.js
@@ -5,6 +5,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { bindActionCreators } from 'redux';
+import classNames from 'classnames';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
@@ -33,6 +34,8 @@ class ProductSearch extends Component {
 
 	state = {
 		currentSearch: '',
+		isActive: false,
+		tokenInputHasFocus: false,
 		tokens: [ 'Mug' ],
 	};
 
@@ -55,8 +58,20 @@ class ProductSearch extends Component {
 		this.props.fetchProductSearchResults( siteId, 1, query );
 	};
 
+	onFocus = event => {
+		this.setState( { isActive: true, tokenInputHasFocus: true } );
+		if ( 'function' === typeof this.props.onFocus ) {
+			this.props.onFocus( event );
+		}
+	};
+
+	onBlur = () => {
+		this.setState( { isActive: false, tokenInputHasFocus: false } );
+	};
+
 	addToken = token => {
 		this.setState( prevState => ( {
+			tokenInputHasFocus: prevState.isActive,
 			currentSearch: '',
 			tokens: [ ...prevState.tokens, token ],
 		} ) );
@@ -77,14 +92,21 @@ class ProductSearch extends Component {
 
 	render() {
 		const { currentSearch, tokens } = this.state;
+		const classes = classNames( 'product-search', {
+			'is-active': this.state.isActive,
+			'is-disabled': this.props.disabled,
+		} );
+
 		return (
-			<div className="product-search">
+			<div className={ classes } onFocus={ this.onFocus } tabIndex="-1">
 				<ProductSearchField
 					ref="productSearch"
 					currentSearch={ this.state.currentSearch }
-					value={ tokens }
+					hasFocus={ this.state.tokenInputHasFocus }
 					onChange={ this.updateTokens }
 					onInputChange={ this.handleSearch }
+					value={ tokens }
+					onBlur={ this.onBlur }
 				/>
 				<ProductSearchResults search={ currentSearch } onSelect={ this.addToken } />
 			</div>

--- a/client/extensions/woocommerce/components/product-search/index.js
+++ b/client/extensions/woocommerce/components/product-search/index.js
@@ -25,6 +25,7 @@ class ProductSearch extends Component {
 		clearProductSearch: PropTypes.func,
 		disabled: PropTypes.bool,
 		fetchProductSearchResults: PropTypes.func.isRequired,
+		maxLength: PropTypes.number,
 		onChange: PropTypes.func.isRequired,
 		siteId: PropTypes.number.isRequired,
 	};
@@ -56,6 +57,9 @@ class ProductSearch extends Component {
 	};
 
 	onFocus = () => {
+		if ( this.state.tokens.length >= this.props.maxLength ) {
+			return;
+		}
 		this.setState( { isActive: true, tokenInputHasFocus: true } );
 	};
 
@@ -76,12 +80,19 @@ class ProductSearch extends Component {
 			return;
 		}
 		this.setState(
-			prevState => ( {
-				currentSearch: '',
-				isActive: true,
-				tokenInputHasFocus: true,
-				tokens: [ ...prevState.tokens, token ],
-			} ),
+			prevState => {
+				const tokens = [ ...prevState.tokens, token ];
+				let isActive = true;
+				if ( tokens.length >= this.props.maxLength ) {
+					isActive = false;
+				}
+				return {
+					currentSearch: '',
+					isActive,
+					tokenInputHasFocus: isActive,
+					tokens,
+				};
+			},
 			() => this.props.onChange( this.state.tokens )
 		);
 	};
@@ -108,6 +119,7 @@ class ProductSearch extends Component {
 					value={ tokens }
 					onFocus={ this.onFocus }
 					onBlur={ this.onBlur }
+					maxLength={ this.props.maxLength }
 				/>
 				<ProductSearchResults
 					search={ currentSearch }

--- a/client/extensions/woocommerce/components/product-search/index.js
+++ b/client/extensions/woocommerce/components/product-search/index.js
@@ -97,14 +97,6 @@ class ProductSearch extends Component {
 		this.setState( { tokens }, () => this.props.onChange( this.state.tokens ) );
 	};
 
-	getTokenValue = token => {
-		if ( 'object' === typeof token ) {
-			return token.name;
-		}
-
-		return token;
-	};
-
 	render() {
 		const { currentSearch, tokens } = this.state;
 		const classes = classNames( 'product-search', {
@@ -120,7 +112,7 @@ class ProductSearch extends Component {
 					hasFocus={ this.state.tokenInputHasFocus }
 					onChange={ this.updateTokens }
 					onInputChange={ this.handleSearch }
-					value={ tokens.map( this.getTokenValue ) }
+					value={ tokens }
 					onBlur={ this.onBlur }
 				/>
 				<ProductSearchResults

--- a/client/extensions/woocommerce/components/product-search/index.js
+++ b/client/extensions/woocommerce/components/product-search/index.js
@@ -104,10 +104,19 @@ class ProductSearch extends Component {
 			'is-disabled': this.props.disabled,
 		} );
 
+		const props = {
+			className: classes,
+		};
+		if ( ! this.props.disabled ) {
+			props.tabIndex = '-1';
+			props.onFocus = this.onFocus;
+		}
+
 		return (
-			<div className={ classes } onFocus={ this.onFocus } tabIndex="-1">
+			<div { ...props }>
 				<ProductSearchField
 					ref="productSearch"
+					disabled={ this.props.disabled }
 					currentSearch={ this.state.currentSearch }
 					hasFocus={ this.state.tokenInputHasFocus }
 					onChange={ this.updateTokens }

--- a/client/extensions/woocommerce/components/product-search/index.js
+++ b/client/extensions/woocommerce/components/product-search/index.js
@@ -12,14 +12,10 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import { areProductSearchResultsLoading } from 'woocommerce/state/sites/products/selectors';
 import {
 	fetchProductSearchResults,
 	clearProductSearch,
 } from 'woocommerce/state/sites/products/actions';
-import { getProductSearchResults } from 'woocommerce/state/ui/products/selectors';
-import { getProductSearchQuery } from 'woocommerce/state/sites/products/selectors';
-
 import ProductSearchField from './search';
 import ProductSearchResults from './results';
 
@@ -81,15 +77,6 @@ class ProductSearch extends Component {
 		this.setState( { tokens } );
 	};
 
-	getProductResults = () => {
-		const { isLoading, products } = this.props;
-		if ( isLoading || ! products.length ) {
-			return [];
-		}
-
-		return products;
-	};
-
 	render() {
 		const { currentSearch, tokens } = this.state;
 		const classes = classNames( 'product-search', {
@@ -114,26 +101,12 @@ class ProductSearch extends Component {
 	}
 }
 
-export default connect(
-	state => {
-		const search = getProductSearchQuery( state ) || '';
-		const query = {
-			page: 1,
-			per_page: 10,
-			search,
-		};
-
-		return {
-			isLoading: areProductSearchResultsLoading( state, query ),
-			products: getProductSearchResults( state ) || [],
-		};
-	},
-	dispatch =>
-		bindActionCreators(
-			{
-				fetchProductSearchResults,
-				clearProductSearch,
-			},
-			dispatch
-		)
+export default connect( null, dispatch =>
+	bindActionCreators(
+		{
+			fetchProductSearchResults,
+			clearProductSearch,
+		},
+		dispatch
+	)
 )( localize( ProductSearch ) );

--- a/client/extensions/woocommerce/components/product-search/index.js
+++ b/client/extensions/woocommerce/components/product-search/index.js
@@ -123,7 +123,11 @@ class ProductSearch extends Component {
 					value={ tokens.map( this.getTokenValue ) }
 					onBlur={ this.onBlur }
 				/>
-				<ProductSearchResults search={ currentSearch } onSelect={ this.addToken } />
+				<ProductSearchResults
+					search={ currentSearch }
+					isSelected={ this.hasToken }
+					onSelect={ this.addToken }
+				/>
 			</div>
 		);
 	}

--- a/client/extensions/woocommerce/components/product-search/index.js
+++ b/client/extensions/woocommerce/components/product-search/index.js
@@ -8,7 +8,6 @@ import { bindActionCreators } from 'redux';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
 import { find } from 'lodash';
-import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -23,10 +22,10 @@ import ProductSearchResults from './results';
 class ProductSearch extends Component {
 	static propTypes = {
 		clearProductSearch: PropTypes.func,
+		disabled: PropTypes.bool,
 		fetchProductSearchResults: PropTypes.func.isRequired,
 		onChange: PropTypes.func.isRequired,
-		selected: PropTypes.array,
-		translate: PropTypes.func,
+		siteId: PropTypes.number.isRequired,
 	};
 
 	state = {
@@ -82,9 +81,9 @@ class ProductSearch extends Component {
 		}
 		this.setState(
 			prevState => ( {
+				currentSearch: '',
 				isActive: true,
 				tokenInputHasFocus: true,
-				currentSearch: '',
 				tokens: [ ...prevState.tokens, token ],
 			} ),
 			() => this.props.onChange( this.state.tokens )
@@ -132,4 +131,4 @@ export default connect( null, dispatch =>
 		},
 		dispatch
 	)
-)( localize( ProductSearch ) );
+)( ProductSearch );

--- a/client/extensions/woocommerce/components/product-search/index.js
+++ b/client/extensions/woocommerce/components/product-search/index.js
@@ -111,20 +111,21 @@ class ProductSearch extends Component {
 		return (
 			<div className={ classes }>
 				<ProductSearchField
-					disabled={ this.props.disabled }
 					currentSearch={ this.state.currentSearch }
+					disabled={ this.props.disabled }
 					hasFocus={ this.state.tokenInputHasFocus }
-					onChange={ this.updateTokens }
-					onInputChange={ this.handleSearch }
-					value={ tokens }
-					onFocus={ this.onFocus }
-					onBlur={ this.onBlur }
 					maxLength={ this.props.maxLength }
+					onBlur={ this.onBlur }
+					onChange={ this.updateTokens }
+					onFocus={ this.onFocus }
+					onInputChange={ this.handleSearch }
+					placeholder={ this.props.placeholder }
+					value={ tokens }
 				/>
 				<ProductSearchResults
-					search={ currentSearch }
 					isSelected={ this.hasToken }
 					onSelect={ this.addToken }
+					search={ currentSearch }
 				/>
 			</div>
 		);

--- a/client/extensions/woocommerce/components/product-search/index.js
+++ b/client/extensions/woocommerce/components/product-search/index.js
@@ -103,7 +103,9 @@ class ProductSearch extends Component {
 
 	render() {
 		const { currentSearch, tokens } = this.state;
-		const classes = classNames( 'product-search', {
+		const classes = classNames( {
+			'product-search': true,
+			'token-field': true,
 			'is-active': this.state.isActive,
 			'is-disabled': this.props.disabled,
 		} );

--- a/client/extensions/woocommerce/components/product-search/index.js
+++ b/client/extensions/woocommerce/components/product-search/index.js
@@ -60,11 +60,8 @@ class ProductSearch extends Component {
 		this.props.fetchProductSearchResults( siteId, 1, query );
 	};
 
-	onFocus = event => {
+	onFocus = () => {
 		this.setState( { isActive: true, tokenInputHasFocus: true } );
-		if ( 'function' === typeof this.props.onFocus ) {
-			this.props.onFocus( event );
-		}
 	};
 
 	onBlur = () => {
@@ -85,7 +82,8 @@ class ProductSearch extends Component {
 		}
 		this.setState(
 			prevState => ( {
-				tokenInputHasFocus: prevState.isActive,
+				isActive: true,
+				tokenInputHasFocus: true,
 				currentSearch: '',
 				tokens: [ ...prevState.tokens, token ],
 			} ),
@@ -104,24 +102,16 @@ class ProductSearch extends Component {
 			'is-disabled': this.props.disabled,
 		} );
 
-		const props = {
-			className: classes,
-		};
-		if ( ! this.props.disabled ) {
-			props.tabIndex = '-1';
-			props.onFocus = this.onFocus;
-		}
-
 		return (
-			<div { ...props }>
+			<div className={ classes }>
 				<ProductSearchField
-					ref="productSearch"
 					disabled={ this.props.disabled }
 					currentSearch={ this.state.currentSearch }
 					hasFocus={ this.state.tokenInputHasFocus }
 					onChange={ this.updateTokens }
 					onInputChange={ this.handleSearch }
 					value={ tokens }
+					onFocus={ this.onFocus }
 					onBlur={ this.onBlur }
 				/>
 				<ProductSearchResults

--- a/client/extensions/woocommerce/components/product-search/index.js
+++ b/client/extensions/woocommerce/components/product-search/index.js
@@ -7,7 +7,7 @@ import PropTypes from 'prop-types';
 import { bindActionCreators } from 'redux';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
-import { debounce, find, get } from 'lodash';
+import { debounce, find, get, trim } from 'lodash';
 
 /**
  * Internal dependencies
@@ -48,6 +48,10 @@ class ProductSearch extends Component {
 
 	handleSearch = query => {
 		this.setState( { currentSearch: query } );
+		// Query is just empty spaces, don't trigger the search
+		if ( '' === trim( query ) ) {
+			return;
+		}
 		this.debouncedSearch( query );
 	};
 

--- a/client/extensions/woocommerce/components/product-search/item.js
+++ b/client/extensions/woocommerce/components/product-search/item.js
@@ -39,8 +39,7 @@ class ProductItem extends Component {
 		}
 	}
 
-	handleClick = () => {
-		const { product } = this.props;
+	handleClick = product => () => {
 		this.props.onClick( product );
 	};
 
@@ -77,8 +76,8 @@ class ProductItem extends Component {
 				className="product-search__item"
 				role="button"
 				tabIndex="0"
-				onClick={ this.handleClick }
-				onKeyDown={ getKeyboardHandler( this.handleClick ) }
+				onClick={ this.handleClick( product ) }
+				onKeyDown={ getKeyboardHandler( this.handleClick( product ) ) }
 			>
 				<div className="product-search__image">
 					{ featuredImage && <img src={ featuredImage.src } /> }

--- a/client/extensions/woocommerce/components/product-search/item.js
+++ b/client/extensions/woocommerce/components/product-search/item.js
@@ -5,6 +5,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { bindActionCreators } from 'redux';
+import classNames from 'classnames';
 import { connect } from 'react-redux';
 import { get } from 'lodash';
 
@@ -22,6 +23,7 @@ class ProductItem extends Component {
 	static propTypes = {
 		onClick: PropTypes.func.isRequired,
 		product: PropTypes.object.isRequired,
+		isSelected: PropTypes.func,
 	};
 
 	componentDidMount() {
@@ -70,15 +72,21 @@ class ProductItem extends Component {
 	renderItem = product => {
 		const { search } = this.props;
 		const featuredImage = get( product, 'images[0]', false );
+		const selected = this.props.isSelected( product );
+		const props = {
+			className: classNames( {
+				'product-search__item': true,
+				'is-selected': selected,
+			} ),
+		};
+		if ( ! selected ) {
+			props.role = 'button';
+			props.tabIndex = '0';
+			props.onClick = this.handleClick( product );
+			props.onKeyDown = getKeyboardHandler( this.handleClick( product ) );
+		}
 		return (
-			<CompactCard
-				key={ product.key }
-				className="product-search__item"
-				role="button"
-				tabIndex="0"
-				onClick={ this.handleClick( product ) }
-				onKeyDown={ getKeyboardHandler( this.handleClick( product ) ) }
-			>
+			<CompactCard key={ product.key } { ...props }>
 				<div className="product-search__image">
 					{ featuredImage && <img src={ featuredImage.src } /> }
 				</div>

--- a/client/extensions/woocommerce/components/product-search/item.js
+++ b/client/extensions/woocommerce/components/product-search/item.js
@@ -23,7 +23,7 @@ class ProductItem extends Component {
 	static propTypes = {
 		onClick: PropTypes.func.isRequired,
 		product: PropTypes.object.isRequired,
-		isSelected: PropTypes.func,
+		isSelected: PropTypes.func.isRequired,
 	};
 
 	componentDidMount() {

--- a/client/extensions/woocommerce/components/product-search/results.js
+++ b/client/extensions/woocommerce/components/product-search/results.js
@@ -26,6 +26,10 @@ class ProductSearchResults extends Component {
 		search: PropTypes.string.isRequired,
 	};
 
+	onSelect = product => () => {
+		this.props.onSelect( product.name );
+	};
+
 	renderLoading = () => {
 		return (
 			<div className="product-search__results is-placeholder">
@@ -62,7 +66,7 @@ class ProductSearchResults extends Component {
 	};
 
 	render() {
-		const { isLoaded, isLoading, onSelect, products, search } = this.props;
+		const { isLoaded, isLoading, products, search } = this.props;
 		if ( ! isLoaded && ! search ) {
 			return null;
 		}
@@ -80,7 +84,12 @@ class ProductSearchResults extends Component {
 			<div className={ classes }>
 				{ products.length ? (
 					products.map( p => (
-						<ProductItem key={ p.id } onClick={ onSelect } product={ p } search={ search } />
+						<ProductItem
+							key={ p.id }
+							onClick={ this.onSelect( p ) }
+							product={ p }
+							search={ search }
+						/>
 					) )
 				) : (
 					this.renderNotFound()

--- a/client/extensions/woocommerce/components/product-search/results.js
+++ b/client/extensions/woocommerce/components/product-search/results.js
@@ -22,6 +22,7 @@ import ProductItem from './item';
 
 class ProductSearchResults extends Component {
 	static propTypes = {
+		isSelected: PropTypes.func,
 		onSelect: PropTypes.func.isRequired,
 		search: PropTypes.string.isRequired,
 	};
@@ -85,6 +86,7 @@ class ProductSearchResults extends Component {
 							onClick={ this.props.onSelect }
 							product={ p }
 							search={ search }
+							isSelected={ this.props.isSelected }
 						/>
 					) )
 				) : (

--- a/client/extensions/woocommerce/components/product-search/results.js
+++ b/client/extensions/woocommerce/components/product-search/results.js
@@ -26,10 +26,6 @@ class ProductSearchResults extends Component {
 		search: PropTypes.string.isRequired,
 	};
 
-	onSelect = product => () => {
-		this.props.onSelect( product.name );
-	};
-
 	renderLoading = () => {
 		return (
 			<div className="product-search__results is-placeholder">
@@ -86,7 +82,7 @@ class ProductSearchResults extends Component {
 					products.map( p => (
 						<ProductItem
 							key={ p.id }
-							onClick={ this.onSelect( p ) }
+							onClick={ this.props.onSelect }
 							product={ p }
 							search={ search }
 						/>

--- a/client/extensions/woocommerce/components/product-search/results.js
+++ b/client/extensions/woocommerce/components/product-search/results.js
@@ -64,7 +64,7 @@ class ProductSearchResults extends Component {
 
 	render() {
 		const { isLoaded, isLoading, products, search } = this.props;
-		if ( ! isLoaded && ! search ) {
+		if ( ! isLoaded || ! search ) {
 			return null;
 		}
 

--- a/client/extensions/woocommerce/components/product-search/results.js
+++ b/client/extensions/woocommerce/components/product-search/results.js
@@ -22,7 +22,7 @@ import ProductItem from './item';
 
 class ProductSearchResults extends Component {
 	static propTypes = {
-		isSelected: PropTypes.func,
+		isSelected: PropTypes.func.isRequired,
 		onSelect: PropTypes.func.isRequired,
 		search: PropTypes.string.isRequired,
 	};

--- a/client/extensions/woocommerce/components/product-search/search.js
+++ b/client/extensions/woocommerce/components/product-search/search.js
@@ -151,7 +151,7 @@ class ProductSearchField extends Component {
 
 	render() {
 		const props = {
-			className: 'product-search__input-container',
+			className: 'product-search__input-container token-field__input-container',
 		};
 		if ( ! this.props.disabled ) {
 			props.tabIndex = '-1';

--- a/client/extensions/woocommerce/components/product-search/search.js
+++ b/client/extensions/woocommerce/components/product-search/search.js
@@ -22,7 +22,7 @@ class ProductSearchField extends Component {
 		value: PropTypes.array,
 	};
 
-	_getTokenValue = token => {
+	getTokenValue = token => {
 		if ( 'object' === typeof token ) {
 			return token.name;
 		}
@@ -30,37 +30,37 @@ class ProductSearchField extends Component {
 		return token;
 	};
 
-	_getIndexOfInput = () => {
+	getIndexOfInput = () => {
 		return this.props.value.length;
 	};
 
-	_isInputEmpty = () => {
+	isInputEmpty = () => {
 		return this.props.currentSearch.length === 0;
 	};
 
-	_deleteToken = token => {
+	deleteToken = token => {
 		const newTokens = filter( this.props.value, item => item.name !== token );
 		this.props.onChange( newTokens );
 	};
 
-	_onTokenClickRemove = event => {
-		this._deleteToken( event.value );
+	onTokenClickRemove = event => {
+		this.deleteToken( event.value );
 	};
 
-	_onInputChange = event => {
+	onInputChange = event => {
 		const text = event.value;
 		this.props.onInputChange( text );
 	};
 
-	_onKeyDown = event => {
+	onKeyDown = event => {
 		let preventDefault = false;
 
 		switch ( event.keyCode ) {
 			case 8: // backspace (delete to left)
-				preventDefault = this._handleDeleteKey();
+				preventDefault = this.handleDeleteKey();
 				break;
 			case 27: // escape
-				preventDefault = this._handleEscapeKey();
+				preventDefault = this.handleEscapeKey();
 			default:
 				break;
 		}
@@ -70,13 +70,13 @@ class ProductSearchField extends Component {
 		}
 	};
 
-	_handleDeleteKey = () => {
+	handleDeleteKey = () => {
 		let preventDefault = false;
 
-		if ( this.props.hasFocus && this._isInputEmpty() ) {
-			const index = this._getIndexOfInput() - 1;
+		if ( this.props.hasFocus && this.isInputEmpty() ) {
+			const index = this.getIndexOfInput() - 1;
 			if ( index > -1 ) {
-				this._deleteToken( get( this.props.value, `[${ index }].name` ) );
+				this.deleteToken( get( this.props.value, `[${ index }].name` ) );
 			}
 			preventDefault = true;
 		}
@@ -84,9 +84,9 @@ class ProductSearchField extends Component {
 		return preventDefault;
 	};
 
-	_handleEscapeKey = () => {
+	handleEscapeKey = () => {
 		let preventDefault = false;
-		if ( this.props.hasFocus && ! this._isInputEmpty() ) {
+		if ( this.props.hasFocus && ! this.isInputEmpty() ) {
 			this.props.onInputChange( '' );
 			this.props.onBlur();
 			preventDefault = true;
@@ -94,16 +94,16 @@ class ProductSearchField extends Component {
 		return preventDefault;
 	};
 
-	_renderTokensAndInput = () => {
-		const components = map( this.props.value, this._renderToken );
+	renderTokensAndInput = () => {
+		const components = map( this.props.value, this.renderToken );
 
-		components.splice( this._getIndexOfInput(), 0, this._renderInput() );
+		components.splice( this.getIndexOfInput(), 0, this.renderInput() );
 
 		return components;
 	};
 
-	_renderToken = token => {
-		const value = this._getTokenValue( token );
+	renderToken = token => {
+		const value = this.getTokenValue( token );
 
 		return (
 			<Token
@@ -111,14 +111,14 @@ class ProductSearchField extends Component {
 				value={ value }
 				displayTransform={ identity }
 				tooltip={ token.tooltip }
-				onClickRemove={ this._onTokenClickRemove }
+				onClickRemove={ this.onTokenClickRemove }
 				isBorderless={ token.isBorderless || this.props.isBorderless }
 				disabled={ 'error' !== status && this.props.disabled }
 			/>
 		);
 	};
 
-	_renderInput = () => {
+	renderInput = () => {
 		const {
 			currentSearch,
 			disabled,
@@ -143,7 +143,7 @@ class ProductSearchField extends Component {
 		}
 
 		if ( ! ( maxLength && value.length >= maxLength ) ) {
-			props = { ...props, onChange: this._onInputChange };
+			props = { ...props, onChange: this.onInputChange };
 		}
 
 		return <TokenInput key="input" { ...props } />;
@@ -156,9 +156,9 @@ class ProductSearchField extends Component {
 		if ( ! this.props.disabled ) {
 			props.tabIndex = '-1';
 			props.onFocus = this.props.onFocus;
-			props.onKeyDown = this._onKeyDown;
+			props.onKeyDown = this.onKeyDown;
 		}
-		return <div { ...props }>{ this._renderTokensAndInput() }</div>;
+		return <div { ...props }>{ this.renderTokensAndInput() }</div>;
 	}
 }
 

--- a/client/extensions/woocommerce/components/product-search/search.js
+++ b/client/extensions/woocommerce/components/product-search/search.js
@@ -60,13 +60,11 @@ class ProductSearchField extends Component {
 
 	_renderToken = token => {
 		const value = this._getTokenValue( token );
-		const status = token.status ? token.status : undefined;
 
 		return (
 			<Token
 				key={ 'token-' + value }
 				value={ value }
-				status={ status }
 				displayTransform={ identity }
 				tooltip={ token.tooltip }
 				onClickRemove={ this._onTokenClickRemove }

--- a/client/extensions/woocommerce/components/product-search/search.js
+++ b/client/extensions/woocommerce/components/product-search/search.js
@@ -73,14 +73,24 @@ class ProductSearchField extends Component {
 	};
 
 	_renderInput = () => {
-		const { currentSearch, hasFocus, id, onBlur, maxLength, value, placeholder } = this.props;
+		const {
+			currentSearch,
+			disabled,
+			hasFocus,
+			id,
+			onBlur,
+			maxLength,
+			value,
+			placeholder,
+		} = this.props;
 
 		let props = {
 			id,
+			disabled,
 			key: 'input',
-			value: currentSearch,
 			hasFocus,
 			onBlur,
+			value: currentSearch,
 		};
 
 		if ( value.length === 0 && placeholder ) {

--- a/client/extensions/woocommerce/components/product-search/search.js
+++ b/client/extensions/woocommerce/components/product-search/search.js
@@ -4,8 +4,8 @@
  */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import { filter, identity, map } from 'lodash';
 import { localize } from 'i18n-calypso';
-import { identity, map } from 'lodash';
 
 /**
  * Internal dependencies
@@ -24,7 +24,7 @@ class ProductSearchField extends Component {
 
 	_getTokenValue = token => {
 		if ( 'object' === typeof token ) {
-			return token.value;
+			return token.name;
 		}
 
 		return token;
@@ -35,9 +35,7 @@ class ProductSearchField extends Component {
 	};
 
 	_deleteToken = token => {
-		const newTokens = this.props.value.filter( item => {
-			return this._getTokenValue( item ) !== this._getTokenValue( token );
-		} );
+		const newTokens = filter( this.props.value, item => item.name !== token );
 		this.props.onChange( newTokens );
 	};
 

--- a/client/extensions/woocommerce/components/product-search/search.js
+++ b/client/extensions/woocommerce/components/product-search/search.js
@@ -77,12 +77,14 @@ class ProductSearchField extends Component {
 	};
 
 	_renderInput = () => {
-		const { currentSearch, id, maxLength, value, placeholder } = this.props;
+		const { currentSearch, hasFocus, id, onBlur, maxLength, value, placeholder } = this.props;
 
 		let props = {
 			id,
 			key: 'input',
 			value: currentSearch,
+			hasFocus,
+			onBlur,
 		};
 
 		if ( value.length === 0 && placeholder ) {

--- a/client/extensions/woocommerce/components/product-search/search.js
+++ b/client/extensions/woocommerce/components/product-search/search.js
@@ -1,0 +1,104 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { localize } from 'i18n-calypso';
+import { identity, map } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import Token from 'components/token-field/token';
+import TokenInput from 'components/token-field/token-input';
+
+class ProductSearchField extends Component {
+	static propTypes = {
+		disabled: PropTypes.bool,
+		isBorderless: PropTypes.bool,
+		onChange: PropTypes.func,
+		onInputChange: PropTypes.func,
+		value: PropTypes.array,
+	};
+
+	_getTokenValue = token => {
+		if ( 'object' === typeof token ) {
+			return token.value;
+		}
+
+		return token;
+	};
+
+	_getIndexOfInput = () => {
+		return this.props.value.length;
+	};
+
+	_deleteToken = token => {
+		const newTokens = this.props.value.filter( item => {
+			return this._getTokenValue( item ) !== this._getTokenValue( token );
+		} );
+		this.props.onChange( newTokens );
+	};
+
+	_onTokenClickRemove = event => {
+		this._deleteToken( event.value );
+	};
+
+	_onInputChange = event => {
+		const text = event.value;
+		this.props.onInputChange( text );
+	};
+
+	_renderTokensAndInput = () => {
+		const components = map( this.props.value, this._renderToken );
+
+		components.splice( this._getIndexOfInput(), 0, this._renderInput() );
+
+		return components;
+	};
+
+	_renderToken = token => {
+		const value = this._getTokenValue( token );
+		const status = token.status ? token.status : undefined;
+
+		return (
+			<Token
+				key={ 'token-' + value }
+				value={ value }
+				status={ status }
+				displayTransform={ identity }
+				tooltip={ token.tooltip }
+				onClickRemove={ this._onTokenClickRemove }
+				isBorderless={ token.isBorderless || this.props.isBorderless }
+				disabled={ 'error' !== status && this.props.disabled }
+			/>
+		);
+	};
+
+	_renderInput = () => {
+		const { currentSearch, id, maxLength, value, placeholder } = this.props;
+
+		let props = {
+			id,
+			key: 'input',
+			value: currentSearch,
+		};
+
+		if ( value.length === 0 && placeholder ) {
+			props.placeholder = placeholder;
+		}
+
+		if ( ! ( maxLength && value.length >= maxLength ) ) {
+			props = { ...props, onChange: this._onInputChange };
+		}
+
+		return <TokenInput { ...props } />;
+	};
+
+	render() {
+		return <div className="product-search__input-container">{ this._renderTokensAndInput() }</div>;
+	}
+}
+
+export default localize( ProductSearchField );

--- a/client/extensions/woocommerce/components/product-search/style.scss
+++ b/client/extensions/woocommerce/components/product-search/style.scss
@@ -1,38 +1,6 @@
 /** @format */
 .product-search {
 	position: relative;
-	@extend %form-field;
-
-	box-sizing: border-box;
-	width: 100%;
-	margin: 0;
-	padding: 0;
-	background-color: $white;
-	border: 1px solid lighten($gray, 20%);
-	color: $gray-dark;
-	cursor: text;
-	transition: all 0.15s ease-in-out;
-
-	&:hover {
-		border-color: lighten($gray, 10%);
-	}
-
-	&.is-disabled {
-		background: $gray-light;
-		border-color: lighten($gray, 30%);
-	}
-
-	&.is-active {
-		border-color: $blue-wordpress;
-		box-shadow: 0 0 0 2px $blue-light;
-	}
-}
-
-.product-search__input-container {
-	display: flex;
-	flex-wrap: wrap;
-	align-items: flex-start;
-	padding: 5px 14px 5px 0;
 }
 
 .product-search__results {

--- a/client/extensions/woocommerce/components/product-search/style.scss
+++ b/client/extensions/woocommerce/components/product-search/style.scss
@@ -127,6 +127,10 @@
 	.product-search__value-emphasis {
 		font-weight: bold;
 	}
+
+	&.is-selected {
+		font-style: italic;
+	}
 }
 
 .product-search__image {

--- a/client/extensions/woocommerce/components/product-search/style.scss
+++ b/client/extensions/woocommerce/components/product-search/style.scss
@@ -1,14 +1,38 @@
+/** @format */
 .product-search {
 	position: relative;
+	@extend %form-field;
 
-	.search-card {
-		box-shadow: none;
-		border: 1px solid darken( $gray-light, 10% );
+	box-sizing: border-box;
+	width: 100%;
+	margin: 0;
+	padding: 0;
+	background-color: $white;
+	border: 1px solid lighten($gray, 20%);
+	color: $gray-dark;
+	cursor: text;
+	transition: all 0.15s ease-in-out;
+
+	&:hover {
+		border-color: lighten($gray, 10%);
 	}
 
-	div.has-focus {
-		box-shadow: 0 0 0 1px $blue-wordpress, 0 0 0 4px $blue-light;
+	&.is-disabled {
+		background: $gray-light;
+		border-color: lighten($gray, 30%);
 	}
+
+	&.is-active {
+		border-color: $blue-wordpress;
+		box-shadow: 0 0 0 2px $blue-light;
+	}
+}
+
+.product-search__input-container {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: flex-start;
+	padding: 5px 14px 5px 0;
 }
 
 .product-search__results {
@@ -18,7 +42,7 @@
 	width: 100%;
 	max-height: 275px;
 	overflow-y: scroll;
-	border-bottom: 1px solid darken( $gray-light, 10% );
+	border-bottom: 1px solid darken($gray-light, 10%);
 
 	&.is-placeholder {
 		overflow-y: visible;
@@ -85,7 +109,7 @@
 	display: flex;
 	cursor: pointer;
 	box-shadow: none;
-	border: 1px solid darken( $gray-light, 10% );
+	border: 1px solid darken($gray-light, 10%);
 	border-bottom-width: 0;
 	margin: 0;
 	padding: 10px;
@@ -114,7 +138,7 @@
 	margin-right: 10px;
 
 	&:empty {
-		border: 1px solid darken( $gray-light, 10% );
+		border: 1px solid darken($gray-light, 10%);
 		box-sizing: border-box;
 	}
 

--- a/client/extensions/woocommerce/style.scss
+++ b/client/extensions/woocommerce/style.scss
@@ -1,6 +1,6 @@
 // Core CSS Dependencies
-@import 'assets/stylesheets/shared/utils'; // utilities that are used by all CSS but don't produce any code
-@import 'assets/stylesheets/shared/forms'; // form utilities
+@import 'assets/stylesheets/shared/utils';      // utilities that are used by all CSS but don't produce any code
+
 .woocommerce {
 	@import 'app/dashboard/style';
 	@import 'app/order/style';

--- a/client/extensions/woocommerce/style.scss
+++ b/client/extensions/woocommerce/style.scss
@@ -1,6 +1,6 @@
 // Core CSS Dependencies
-@import 'assets/stylesheets/shared/utils';      // utilities that are used by all CSS but don't produce any code
-
+@import 'assets/stylesheets/shared/utils'; // utilities that are used by all CSS but don't produce any code
+@import 'assets/stylesheets/shared/forms'; // form utilities
 .woocommerce {
 	@import 'app/dashboard/style';
 	@import 'app/order/style';


### PR DESCRIPTION
This PR updates the ProductSearch component to allow for multiple product selections. It uses some code from [`token-field`](https://github.com/Automattic/wp-calypso/tree/master/client/components/token-field) to build up the field, and allow for tokens (selected products) + the search field to be side-by-side.

<img width="695" alt="searching" src="https://user-images.githubusercontent.com/541093/32070480-7cf54f18-ba5a-11e7-8c9e-8d83ecc6d7c6.png">

This isn't in use anywhere yet, so I've updated the order creation screen to show how it would be used in a page (in lieu of having store devdocs):

<img width="736" alt="two selected" src="https://user-images.githubusercontent.com/541093/32070479-7cea9564-ba5a-11e7-8ff6-a47589c2c36f.png">

**To test**

- Go to the new order screen: `/store/order/:site`
- You can find the search under  "Add products to the order"
- As you select products, they're also listed under the search
