### PR TITLE
Posts: Cleanup share panel borders

### DIFF
--- a/client/blocks/post-share/index.jsx
+++ b/client/blocks/post-share/index.jsx
@@ -562,7 +562,20 @@ class PostShare extends Component {
 
 				<div className={ classes }>
 					<div className="post-share__head">
-						<h4 className="post-share__title">{ translate( 'Share this post' ) }</h4>
+						<h4 className="post-share__title">
+							<span>{ translate( 'Share this post' ) }</span>
+							{ showClose && (
+								<Button
+									borderless
+									aria-label={ translate( 'Close post sharing' ) }
+									className="post-share__close"
+									data-tip-target="post-share__close"
+									onClick={ onClose }
+								>
+									<Gridicon icon="cross" />
+								</Button>
+							) }
+						</h4>
 						<div className="post-share__subtitle">
 							{ translate(
 								'Share your post on all of your connected social media accounts using ' +
@@ -575,17 +588,6 @@ class PostShare extends Component {
 							) }
 						</div>
 					</div>
-					{ showClose && (
-						<Button
-							borderless
-							aria-label={ translate( 'Close post sharing' ) }
-							className="post-share__close"
-							data-tip-target="post-share__close"
-							onClick={ onClose }
-						>
-							<Gridicon icon="cross" />
-						</Button>
-					) }
 					{ ! hasFetchedConnections && <div className="post-share__placeholder" /> }
 					{ this.renderRequestSharingNotice() }
 					{ this.renderConnectionsWarning() }

--- a/client/blocks/post-share/publicize-actions-list.jsx
+++ b/client/blocks/post-share/publicize-actions-list.jsx
@@ -15,7 +15,6 @@ import Gridicon from 'gridicons';
  */
 import { getPostShareScheduledActions, getPostSharePublishedActions } from 'state/selectors';
 import QuerySharePostActions from 'components/data/query-share-post-actions/index.jsx';
-import CompactCard from 'components/card/compact';
 import SocialLogo from 'social-logos';
 import EllipsisMenu from 'components/ellipsis-menu';
 import PopoverMenuItem from 'components/popover/menu-item';
@@ -68,7 +67,7 @@ class PublicizeActionsList extends PureComponent {
 		const { service, connectionName, shareDate, message } = item;
 
 		return (
-			<CompactCard className="post-share__footer-items" key={ index }>
+			<div className="post-share__footer-items" key={ index }>
 				<div className="post-share__footer-item">
 					<div className="post-share__handle">
 						<SocialLogo icon={ service === 'google_plus' ? 'google-plus' : service } />
@@ -81,7 +80,7 @@ class PublicizeActionsList extends PureComponent {
 					<div className="post-share__message">{ message }</div>
 				</div>
 				{ this.renderFooterSectionItemActions( item ) }
-			</CompactCard>
+			</div>
 		);
 	}
 

--- a/client/blocks/post-share/style.scss
+++ b/client/blocks/post-share/style.scss
@@ -18,11 +18,17 @@ $section-border: solid 1px darken( $sidebar-bg-color, 5% );
 }
 
 .post-share__title {
+	display: flex;
+
 	font-size: 15px;
 	margin: 16px 0 4px;
 
 	@include breakpoint( ">660px" ) {
 		font-size: 18px;
+	}
+
+	span {
+		flex: 1;
 	}
 }
 
@@ -59,13 +65,9 @@ $section-border: solid 1px darken( $sidebar-bg-color, 5% );
 	}
 }
 
-.post-share__close {
-	position: absolute;
-	top: 0;
-	right: 0;
-	&.button.is-borderless { // for specificity
-		padding: 10px;
-	}
+.button.post-share__close {
+	margin-top: -6px;
+	padding: 0;
 }
 
 .post-share__form {

--- a/client/blocks/post-share/style.scss
+++ b/client/blocks/post-share/style.scss
@@ -286,9 +286,24 @@ $section-border: solid 1px transparentize( lighten( $gray, 20% ), .5 );
 
 .post-share .post-share__footer-items {
 	align-items: center;
+	box-sizing: border-box;
 	display: flex;
 	flex-wrap: nowrap;
 	justify-content: space-between;
+
+	margin: 0 auto 1px;
+	padding: 16px;
+
+	background: $white;
+
+	&:not( :first-child ) {
+		border-top: 1px solid darken( $sidebar-bg-color, 5% );
+	}
+
+	@include breakpoint( ">480px" ) {
+		margin-bottom: 1px;
+		padding: 16px 24px;
+	}
 
 	&::after {
 		content: '';

--- a/client/blocks/post-share/style.scss
+++ b/client/blocks/post-share/style.scss
@@ -1,4 +1,4 @@
-$section-border: solid 1px transparentize( lighten( $gray, 20% ), .5 );
+$section-border: solid 1px darken( $sidebar-bg-color, 5% );
 
 .post-share .card.banner,
 .card.post-share__upgrade-nudge {
@@ -282,6 +282,8 @@ $section-border: solid 1px transparentize( lighten( $gray, 20% ), .5 );
 
 .post-share .post-share__footer-nav {
 	margin: 0;
+	box-shadow: none;
+	border-top: $section-border;
 }
 
 .post-share .post-share__footer-items {
@@ -296,9 +298,7 @@ $section-border: solid 1px transparentize( lighten( $gray, 20% ), .5 );
 
 	background: $white;
 
-	&:not( :first-child ) {
-		border-top: 1px solid darken( $sidebar-bg-color, 5% );
-	}
+	border-top: $section-border;
 
 	@include breakpoint( ">480px" ) {
 		margin-bottom: 1px;


### PR DESCRIPTION
This PR cleans up the share panel borders to work well with the updated expanded post item design.

Current post list:

<img width="736" alt="screencapture at thu oct 26 15 02 43 edt 2017" src="https://user-images.githubusercontent.com/2098816/32072170-b7dc617a-ba5f-11e7-8072-88f099be2a0c.png">

Condensed post list (feature flag: `posts/post-type-list`):

<img width="750" alt="screencapture at thu oct 26 15 04 38 edt 2017" src="https://user-images.githubusercontent.com/2098816/32072174-b93f0202-ba5f-11e7-8a03-18c25185926e.png">


Acceptance criteria:

1.
- Given an item expanded in the posts list
- When the item is viewed
- Then the top and bottom margins that separate it from adjacent items doesn't have a border on the left and right sides

2.
- Given an item expanded in the posts list
- When the item is viewed
- Then it has a border around it (see mockup)

3.
- Given a site with one of more CPT items
- When the CPT section is viewed
- Then the list looks good

To run:

For condensed post list:
```
ENABLE_FEATURES=posts/post-type-list npm start
```

For current post list (verify no regression):
```
npm start
```