### PR TITLE
Store: Add a setting for the new order notification.

### DIFF
--- a/client/me/notification-settings/blogs-settings/blog.jsx
+++ b/client/me/notification-settings/blogs-settings/blog.jsx
@@ -56,6 +56,20 @@ class BlogSettings extends Component {
 			'is-expanded': isExpanded,
 		} );
 
+		const settingKeys = [
+			'new_comment',
+			'comment_like',
+			'post_like',
+			'follow',
+			'achievement',
+			'mentions',
+			'scheduled_publicize',
+		];
+
+		if ( site.options.is_wpcom_store ) {
+			settingKeys.push( 'store_order' );
+		}
+
 		return (
 			<Card className={ styles }>
 				<Header { ...{ site, settings, disableToggle } } onToggle={ this.onToggle } />
@@ -72,15 +86,7 @@ class BlogSettings extends Component {
 									onSave,
 									onSaveToAll,
 								} }
-								settingKeys={ [
-									'new_comment',
-									'comment_like',
-									'post_like',
-									'follow',
-									'achievement',
-									'mentions',
-									'scheduled_publicize',
-								] }
+								settingKeys={ settingKeys }
 							/>
 						);
 					}

--- a/client/me/notification-settings/settings-form/constants.js
+++ b/client/me/notification-settings/settings-form/constants.js
@@ -1,4 +1,4 @@
 /** @format */
 export const NOTIFICATIONS_EXCEPTIONS = {
-	email: [ 'achievement', 'scheduled_publicize' ],
+	email: [ 'achievement', 'scheduled_publicize', 'store_order' ],
 };

--- a/client/me/notification-settings/settings-form/locales.js
+++ b/client/me/notification-settings/settings-form/locales.js
@@ -16,6 +16,8 @@ export const settingLabels = {
 	achievement: () => i18n.translate( 'Site achievements' ),
 	mentions: () => i18n.translate( 'Username mentions' ),
 	scheduled_publicize: () => i18n.translate( 'Post Publicized' ),
+
+	store_order: () => i18n.translate( 'New order' ),
 };
 
 export const getLabelForStream = stream =>

--- a/client/state/sites/actions.js
+++ b/client/state/sites/actions.js
@@ -103,7 +103,7 @@ export function requestSites() {
 				fields:
 					'ID,URL,name,capabilities,jetpack,visible,is_private,is_vip,icon,plan,jetpack_modules,single_user_site,is_multisite,options', //eslint-disable-line max-len
 				options:
-					'is_mapped_domain,unmapped_url,admin_url,is_redirect,is_automated_transfer,allowed_file_types,show_on_front,main_network_site,jetpack_version,software_version,default_post_format,created_at,frame_nonce,publicize_permanently_disabled,page_on_front,page_for_posts,advanced_seo_front_page_description,advanced_seo_title_formats,verification_services_codes,podcasting_archive,is_domain_only,default_sharing_status,default_likes_enabled,wordads,upgraded_filetypes_enabled,videopress_enabled,permalink_structure,gmt_offset,signup_is_store,has_pending_automated_transfer', //eslint-disable-line max-len
+					'is_mapped_domain,unmapped_url,admin_url,is_redirect,is_automated_transfer,allowed_file_types,show_on_front,main_network_site,jetpack_version,software_version,default_post_format,created_at,frame_nonce,publicize_permanently_disabled,page_on_front,page_for_posts,advanced_seo_front_page_description,advanced_seo_title_formats,verification_services_codes,podcasting_archive,is_domain_only,default_sharing_status,default_likes_enabled,wordads,upgraded_filetypes_enabled,videopress_enabled,permalink_structure,gmt_offset,is_wpcom_store,signup_is_store,has_pending_automated_transfer', //eslint-disable-line max-len
 			} )
 			.then( response => {
 				dispatch( receiveSites( response.sites ) );


### PR DESCRIPTION
This PR adds a new setting for Store on .com sites, that allow them to disable the 'New order' notification.

See #16181.

<img width="790" alt="screen shot 2017-10-26 at 12 43 59 pm" src="https://user-images.githubusercontent.com/689165/32073558-66be8066-ba4b-11e7-9081-2354afbf3d31.png">

To Test:
* Apply the patch from D7802-code and follow the testing steps there.
* Apply this branch, and go to your notification settings.
* Select a normal WordPress.com blog. Make sure that the 'New order' option doesn't display.
* Select a normal Jetpack blog if you have one, Make sure that the 'New order' option doesn't display.
* Select one of your AT Stores. Verify that you see a 'New order' option.
* Toggle the option, and place a new order on your test site from D7802-code. Make sure you do not receive a notification.