### PR TITLE
Activity Log: don't display the progress bar when it's queued

### DIFF
--- a/client/my-sites/stats/activity-log-banner/progress-banner.jsx
+++ b/client/my-sites/stats/activity-log-banner/progress-banner.jsx
@@ -48,11 +48,7 @@ function ProgressBanner( {
 
 			<div>
 				<em>{ restoreStatusDescription }</em>
-				<ProgressBar
-					className={ status === 'queued' ? 'activity-log-banner__progress-bar--queued' : null }
-					isPulsing
-					value={ status === 'queued' ? 100 : percent }
-				/>
+				{ 'running' === status && <ProgressBar isPulsing value={ percent } /> }
 			</div>
 		</ActivityLogBanner>
 	);


### PR DESCRIPTION
Only display it when restore begins.