### PR TITLE
PostRevisions: Add Keyboard Navigation

### DIFF
--- a/client/post-editor/editor-revisions-list/index.jsx
+++ b/client/post-editor/editor-revisions-list/index.jsx
@@ -1,14 +1,12 @@
+/** @format */
 /**
  * External dependencies
- *
- * @format
  */
-
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
-import { map } from 'lodash';
+import { findIndex, get, isUndefined, map } from 'lodash';
 
 /**
  * Internal dependencies
@@ -22,6 +20,7 @@ import { getPostRevision, getPostRevisions, getPostRevisionsAuthorsId } from 'st
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getEditorPostId } from 'state/ui/editor/selectors';
 import { isWithinBreakpoint } from 'lib/viewport';
+import KeyboardShortcuts from 'lib/keyboard-shortcuts';
 
 class EditorRevisionsList extends PureComponent {
 	static propTypes = {
@@ -57,11 +56,43 @@ class EditorRevisionsList extends PureComponent {
 	componentDidMount() {
 		// Make sure that scroll position in the editor is not preserved.
 		window.scrollTo( 0, 0 );
+
+		KeyboardShortcuts.on( 'move-selection-up', this.selectNextRevision );
+		KeyboardShortcuts.on( 'move-selection-down', this.selectPreviousRevision );
+	}
+
+	componentWillUnmount() {
+		KeyboardShortcuts.off( 'move-selection-up', this.selectNextRevision );
+		KeyboardShortcuts.off( 'move-selection-down', this.selectPreviousRevision );
 	}
 
 	componentDidUpdate() {
 		this.trySelectingRevision();
 	}
+
+	selectNextRevision = () => {
+		const { revisions, selectedRevision } = this.props;
+		const selectedIdIndex = findIndex( revisions, selectedRevision );
+		const nextRevisionId = get( revisions, [ selectedIdIndex + 1, 'id' ] );
+
+		if ( isUndefined( nextRevisionId ) ) {
+			return;
+		}
+
+		this.props.selectRevision( nextRevisionId );
+	};
+
+	selectPreviousRevision = () => {
+		const { revisions, selectedRevision } = this.props;
+		const selectedIdIndex = findIndex( revisions, selectedRevision );
+		const previousRevisionId = get( revisions, [ selectedIdIndex - 1, 'id' ] );
+
+		if ( isUndefined( previousRevisionId ) ) {
+			return;
+		}
+
+		this.props.selectRevision( previousRevisionId );
+	};
 
 	render() {
 		return (


### PR DESCRIPTION
### Summary
This PR adds <kbd>j</kbd> & <kbd>k</kbd> hotkeys for navigating through a posts revision history while looking at the `Post Settings → Revisions` view.

### Why?
Enabling the user to scroll through revisions without having to look at the sidebar and select a particular revision may help avoid breaking their flow 🙂 👍 

### Testing

- Go to https://calypso.live/?branch=add/post-revisions/keyboard-navigation
- Open the editor to a post that already has a number of revisions, or make a few edits, saving in between.
- Open the revisions list (Either through the sidebar or the history button in the editor header).
- Attempt to navigate through the list using <kbd>j</kbd> and <kbd>k</kbd> keys.
- The 'selected' state should be present on the revision that is newly selected.
- The diff view should reflect the newly selected list items as you scroll through them.

Testing that the event is registered/unregistered successfully

- Close the revisions list (to unmount) and reopen (to re-mount).
- Check the original test flow works properly without unexpected effects.