### PR TITLE
Store: Add loading placeholder to dashboard.

### DIFF
--- a/client/extensions/woocommerce/app/dashboard/index.js
+++ b/client/extensions/woocommerce/app/dashboard/index.js
@@ -39,6 +39,7 @@ import {
 import Main from 'components/main';
 import ManageNoOrdersView from './manage-no-orders-view';
 import ManageOrdersView from './manage-orders-view';
+import Placeholder from './placeholder';
 import PreSetupView from './pre-setup-view';
 import RequiredPagesSetupView from './required-pages-setup-view';
 import RequiredPluginsInstallView from './required-plugins-install-view';
@@ -129,9 +130,14 @@ class Dashboard extends Component {
 			finishedInitialSetup,
 			hasOrders,
 			hasProducts,
+			loading,
 			selectedSite,
 			setStoreAddressDuringInitialSetup,
 		} = this.props;
+
+		if ( loading || ! selectedSite ) {
+			return <Placeholder />;
+		}
 
 		if ( ! finishedInstallOfRequiredPlugins ) {
 			return <RequiredPluginsInstallView site={ selectedSite } />;
@@ -168,14 +174,12 @@ class Dashboard extends Component {
 	render = () => {
 		const { className, loading, selectedSite } = this.props;
 
-		if ( loading || ! selectedSite ) {
-			// TODO have a placeholder/loading view instead
-			return null;
-		}
-
 		return (
 			<Main className={ classNames( 'dashboard', className ) }>
-				<ActionHeader breadcrumbs={ this.getBreadcrumb() } />
+				<ActionHeader
+					breadcrumbs={ this.getBreadcrumb() }
+					isLoading={ loading || ! selectedSite }
+				/>
 				{ this.renderDashboardContent() }
 			</Main>
 		);

--- a/client/extensions/woocommerce/app/dashboard/placeholder.js
+++ b/client/extensions/woocommerce/app/dashboard/placeholder.js
@@ -9,14 +9,19 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import Card from 'components/card';
+import BasicWidget from 'woocommerce/components/basic-widget';
+import WidgetGroup from 'woocommerce/components/widget-group';
 
 const DashboardPlaceholder = () => {
+	const loading = <BasicWidget title="…" className="dashboard__placeholder-small" />;
+
 	return (
 		<div className="dashboard__placeholder">
-			<Card />
-			<Card />
-			<Card />
+			<BasicWidget className="dashboard__placeholder-large card" />
+			<WidgetGroup>
+				{ loading }
+				{ loading }
+			</WidgetGroup>
 		</div>
 	);
 };

--- a/client/extensions/woocommerce/app/dashboard/placeholder.js
+++ b/client/extensions/woocommerce/app/dashboard/placeholder.js
@@ -1,0 +1,24 @@
+/**
+ * External dependencies
+ *
+ * @format
+ */
+
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import Card from 'components/card';
+
+const DashboardPlaceholder = () => {
+	return (
+		<div className="dashboard__placeholder">
+			<Card />
+			<Card />
+			<Card />
+		</div>
+	);
+};
+
+export default DashboardPlaceholder;

--- a/client/extensions/woocommerce/app/dashboard/style.scss
+++ b/client/extensions/woocommerce/app/dashboard/style.scss
@@ -1,9 +1,14 @@
 .dashboard__manage-has-orders,
 .dashboard__manage-no-orders,
+.dashboard__placeholder,
 .dashboard__setup-wrapper {
 	@include breakpoint( ">660px" ) {
 		margin-top: 58px;
 	}
+}
+
+.dashboard__placeholder .card {
+	@include placeholder();
 }
 
 .dashboard__setup-header {

--- a/client/extensions/woocommerce/app/dashboard/style.scss
+++ b/client/extensions/woocommerce/app/dashboard/style.scss
@@ -11,6 +11,20 @@
 	@include placeholder();
 }
 
+.dashboard__placeholder-large button,
+.dashboard__placeholder-small button {
+	display: none;
+}
+
+.dashboard__placeholder-small {
+	height: 250px;
+}
+
+.dashboard__placeholder-large {
+	margin-bottom: 16px;
+	height: 200px;
+}
+
 .dashboard__setup-header {
 	text-align: center;
 	padding-top: 16px;

--- a/client/extensions/woocommerce/components/action-header/index.js
+++ b/client/extensions/woocommerce/components/action-header/index.js
@@ -6,6 +6,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 import { isArray } from 'lodash';
 
 /**
@@ -15,7 +16,7 @@ import Card from 'components/card';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import StickyPanel from 'components/sticky-panel';
 
-const ActionHeader = ( { children, breadcrumbs } ) => {
+const ActionHeader = ( { children, breadcrumbs, isLoading } ) => {
 	// TODO: Implement proper breadcrumbs component.
 	// For v1, we will just pass in a prop from each page.
 	let breadcrumbsOutput = breadcrumbs;
@@ -34,11 +35,13 @@ const ActionHeader = ( { children, breadcrumbs } ) => {
 		} );
 	}
 
+	const breadcrumbClasses = classNames( 'action-header__breadcrumbs', { 'is-loading': isLoading } );
+
 	return (
 		<StickyPanel>
 			<SidebarNavigation />
 			<Card className="action-header__header">
-				<span className="action-header__breadcrumbs">{ breadcrumbsOutput }</span>
+				<span className={ breadcrumbClasses }>{ breadcrumbsOutput }</span>
 				<div className="action-header__actions">{ children }</div>
 			</Card>
 		</StickyPanel>

--- a/client/extensions/woocommerce/components/action-header/style.scss
+++ b/client/extensions/woocommerce/components/action-header/style.scss
@@ -18,6 +18,10 @@
 	@include breakpoint( "<660px" ) {
 		padding-left: 24px;
 	}
+
+	&.is-loading {
+		@include placeholder();
+	}
 }
 
 .action-header__breadcrumbs-separator {


### PR DESCRIPTION
This branch fixes #19087 by adding in a loading placeholder on the dashboard for sites that have been fully configured. Since the configuration/size of the widgets on the dashboard can vary widely depending on things like presence of new orders or reviews - the current placeholder design is quite minimal:

__Before__
![dashboard-load](https://user-images.githubusercontent.com/22080/31919246-e1e43dfe-b815-11e7-9448-d0619f864371.gif)

__After__
![loading-placeholder](https://user-images.githubusercontent.com/22080/32080833-b3a1c5d0-ba66-11e7-9715-b2699e151e47.gif)

__To Test__
- Load a store dashboard
- Sandbox the API for ultimate slowness

__Random Thoughts__
It looks like the dashboard is still waiting to render longer than the sidebar does - I think this might be due to MailChimp but I might try to get that fixed up here.