### PR TITLE
Dialog: Add PropTypes to DialogBase

### DIFF
--- a/client/components/dialog/dialog-base.jsx
+++ b/client/components/dialog/dialog-base.jsx
@@ -9,6 +9,17 @@ import classnames from 'classnames';
 
 class DialogBase extends Component {
 	static propTypes = {
+		additionalClassNames: PropTypes.oneOfType( [ PropTypes.object, PropTypes.string ] ),
+		autoFocus: PropTypes.bool,
+		baseClassName: PropTypes.string,
+		buttons: PropTypes.array,
+		children: PropTypes.element,
+		className: PropTypes.string,
+		isFullScreen: PropTypes.bool,
+		isVisible: PropTypes.bool,
+		label: PropTypes.string,
+		leaveTimeout: PropTypes.number,
+		onDialogClose: PropTypes.func,
 		shouldCloseOnEsc: PropTypes.bool,
 	};
 


### PR DESCRIPTION
### Summary
In the lead up to fixing some existing issues (#17534) with our implementation of `react-modal` I noticed `dailog-base.jsx` could use a lick of TLC.
One such improvement is to add the propTypes property to the component which this PR aims to achieve.

### Testing
I'm not 100% sure that this PR needs testing as such, rather it just needs a sanity check to make sure that the prop types are accurate and make sense (have I missed any? should any of those be required?).