### PR TITLE
MediaModal: Use CloseOnEscape to handle esc key

### DIFF
--- a/client/components/dialog/dialog-base.jsx
+++ b/client/components/dialog/dialog-base.jsx
@@ -1,14 +1,17 @@
+/** @format */
 /**
  * External dependencies
- *
- * @format
  */
-
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import Modal from 'react-modal';
 import classnames from 'classnames';
 
 class DialogBase extends Component {
+	static propTypes = {
+		shouldCloseOnEsc: PropTypes.bool,
+	};
+
 	static defaultProps = {
 		baseClassName: 'dialog',
 		isFullScreen: true,
@@ -17,7 +20,7 @@ class DialogBase extends Component {
 	};
 
 	render() {
-		const { additionalClassNames, baseClassName, isFullScreen } = this.props,
+		const { additionalClassNames, baseClassName, isFullScreen, shouldCloseOnEsc } = this.props,
 			contentClassName = baseClassName + '__content',
 			// Previous implementation used a `<Card />`, styling still relies on the 'card' class being present
 			dialogClassName = classnames( baseClassName, 'card', additionalClassNames ),
@@ -34,6 +37,7 @@ class DialogBase extends Component {
 				overlayClassName={ backdropClassName } // We use flex here which react-modal doesn't
 				className={ dialogClassName }
 				role="dialog"
+				shouldCloseOnEsc={ shouldCloseOnEsc }
 			>
 				<div
 					className={ classnames( this.props.className, contentClassName ) }

--- a/client/components/dialog/index.jsx
+++ b/client/components/dialog/index.jsx
@@ -1,9 +1,7 @@
+/** @format */
 /**
  * External dependencies
- *
- * @format
  */
-
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { defer, noop } from 'lodash';
@@ -21,6 +19,7 @@ class Dialog extends Component {
 		leaveTimeout: PropTypes.number,
 		onClose: PropTypes.func,
 		onClosed: PropTypes.func,
+		shouldCloseOnEsc: PropTypes.bool,
 	};
 
 	static defaultProps = {

--- a/client/post-editor/media-modal/index.jsx
+++ b/client/post-editor/media-modal/index.jsx
@@ -34,6 +34,7 @@ import MediaModalGallery from './gallery';
 import MediaActions from 'lib/media/actions';
 import MediaUtils from 'lib/media/utils';
 import Dialog from 'components/dialog';
+import CloseOnEscape from 'components/close-on-escape';
 import accept from 'lib/accept';
 import { getMediaModalView } from 'state/ui/media-modal/selectors';
 import { getSite } from 'state/sites/selectors';
@@ -603,7 +604,9 @@ export class EditorMediaModal extends Component {
 				onClose={ this.onClose }
 				additionalClassNames="editor-media-modal"
 				shouldCloseOnOverlayClick={ this.shouldClose() }
+				shouldCloseOnEsc={ false }
 			>
+				<CloseOnEscape onEscape={ this.onClose } />
 				{ this.renderContent() }
 			</Dialog>
 		);


### PR DESCRIPTION
### Summary
We recently upgraded our `react-modal` dependancy to a version that allows the use of the `shouldCloseOnEsc` prop. With this we can essentially stop `react-modal` from handling the key event and handle it ourselves.

This brings some benefits - we can avoid closing in certain cases (the focused element is an input for example) and we can now implement our `CloseOnEscape` component to properly handle 'stacked' modals.

This PR does just that, and fixes #17534 (finally! 🎉)

### Testing

- Go to a blog post
- Select 'Featured Image' > 'Set Featured Image' from the side-bar
  <img width="228" alt="featured-image" src="https://cloud.githubusercontent.com/assets/4335450/21477448/20ec2d3a-cb96-11e6-9094-50eb2c8dba78.png">
- Upload or select an image from your media library
- follow through to the image editor for that image
  ![image-editor](https://cloud.githubusercontent.com/assets/4335450/21477547/f941f87c-cb96-11e6-896d-221121b5ce22.gif)
- There's now a 'stack' of escapable components, `dialog-base` and `image-editor`
- Press esc once, the image editor should close.
- Press esc again, the media library (uses dialog-base) should now close too.
- Repeat this process but hold 'esc' down.
- Both components should close in succession.
- Reopen the media modal, focus an input and note that <kbd>esc</kbd> does not close until you move the focus.
