### PR TITLE
Comments: add Jetpack update screen

### DIFF
--- a/config/desktop.json
+++ b/config/desktop.json
@@ -22,6 +22,7 @@
 		"catch-js-errors": false,
 		"code-splitting": false,
 		"comments/management": true,
+		"comments/management/jetpack-5.5": false,
 		"comments/management/sorting": false,
 		"desktop": true,
 		"desktop-promo": false,

--- a/config/development.json
+++ b/config/development.json
@@ -43,6 +43,7 @@
 		"comments/moderation-tools-in-posts": true,
 		"comments/management": true,
 		"comments/management/comment-view": true,
+		"comments/management/jetpack-5.5": false,
 		"comments/management/m3-design": false,
 		"comments/management/post-view": true,
 		"comments/management/quick-actions": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -24,6 +24,7 @@
 		"catch-js-errors": true,
 		"code-splitting": true,
 		"comments/management": true,
+		"comments/management/jetpack-5.5": false,
 		"comments/management/sorting": true,
 		"devdocs": false,
 		"domains/cctlds": true,

--- a/config/production.json
+++ b/config/production.json
@@ -23,6 +23,7 @@
 		"catch-js-errors": true,
 		"code-splitting": true,
 		"comments/management": true,
+		"comments/management/jetpack-5.5": false,
 		"comments/management/sorting": false,
 		"desktop-promo": true,
 		"domains/cctlds": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -25,6 +25,7 @@
 		"catch-js-errors": true,
 		"code-splitting": true,
 		"comments/management": true,
+		"comments/management/jetpack-5.5": false,
 		"comments/management/sorting": false,
 		"desktop-promo": true,
 		"domains/cctlds": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -19,6 +19,7 @@
 		"automated-transfer": true,
 		"apple-pay": true,
 		"comments/management": true,
+		"comments/management/jetpack-5.5": false,
 		"comments/management/quick-actions": true,
 		"comments/management/sorting": true,
 		"catch-js-errors": true,


### PR DESCRIPTION
Closes #18965

Force users to update to Jetpack 5.5 in order to use comments section.
Until Jetpack 5.5 is released this will be gated behind a feature flag and turned off in all environments.

### Visual changes

![updatenudge](https://user-images.githubusercontent.com/1182160/32083561-daff98d4-bac3-11e7-939c-cec6ba7efc7f.png)


### Testing instructions

1. Start Calypso with: `ENABLE_FEATURES=comments/management/jetpack-5.5 npm start`
2. Navigate to `comments/all/` section for a Dotcom site and verify that comments are displayed as usual.
3. Navigate to `comments/all/` section for a Jetpack site and verify that update screen is shown. We are relying on the fact that Jetpack 5.5 hasn't been released yet, so whatever you are running won't meet the minimum version criteria.