### PR TITLE
Activity Log: break timeline before the Rewind confirmation dialog

### DIFF
--- a/client/my-sites/stats/activity-log-day/style.scss
+++ b/client/my-sites/stats/activity-log-day/style.scss
@@ -131,3 +131,16 @@
 .activity-log-item.is-before-dialog:before {
 	content: none;
 }
+.has-rewind-dialog .activity-log-item__restore-confirm:first-child:after {
+	content: " ";
+	position: absolute;
+	top: -24px;
+	left: 33px;
+	height: 20px;
+	width: 4px;
+	background: $gray-light;
+
+	@include breakpoint( "<480px" ) {
+		left: 21px;
+	}
+}

--- a/client/my-sites/stats/activity-log-day/style.scss
+++ b/client/my-sites/stats/activity-log-day/style.scss
@@ -127,3 +127,7 @@
 	height: auto;
 	top: 57px;
 }
+
+.activity-log-item.is-before-dialog:before {
+	content: none;
+}


### PR DESCRIPTION
Fixes #18745

#### Before
<img width="403" alt="captura de pantalla 2017-10-26 a la s 22 34 19" src="https://user-images.githubusercontent.com/1041600/32084279-807f0b6c-ba9e-11e7-909b-5c6799b7e5b5.png">

#### After
<img width="397" alt="captura de pantalla 2017-10-26 a la s 22 33 56" src="https://user-images.githubusercontent.com/1041600/32084186-01201a82-ba9e-11e7-8f25-da247676e24e.png">

#### Before
<img width="730" alt="captura de pantalla 2017-10-27 a la s 18 53 58" src="https://user-images.githubusercontent.com/1041600/32126991-311087ca-bb4a-11e7-866b-19f15d228aee.png">

#### After
<img width="629" alt="captura de pantalla 2017-10-27 a la s 19 02 46" src="https://user-images.githubusercontent.com/1041600/32126994-344600f0-bb4a-11e7-9cac-4322eac8cbd9.png">
