### PR TITLE
Signup: Domain Selection: Improve accessibility of the domain selection screen

### DIFF
--- a/client/components/domains/domain-suggestion/index.jsx
+++ b/client/components/domains/domain-suggestion/index.jsx
@@ -26,9 +26,9 @@ class DomainSuggestion extends React.Component {
 	};
 
 	keyboardHandler = event => {
-		switch ( event.which ) {
-			case 13:
-			case 32:
+		switch ( event.key ) {
+			case 'Enter':
+			case ' ':
 				this.props.onButtonClick( event );
 				break;
 		}

--- a/client/components/domains/domain-suggestion/index.jsx
+++ b/client/components/domains/domain-suggestion/index.jsx
@@ -25,6 +25,15 @@ class DomainSuggestion extends React.Component {
 		domain: PropTypes.string,
 	};
 
+	keyboardHandler = event => {
+		switch ( event.which ) {
+			case 13:
+			case 32:
+				this.props.onButtonClick( event );
+				break;
+		}
+	};
+
 	render() {
 		const { price, isAdded, extraClasses, children, priceRule } = this.props;
 		const classes = classNames(
@@ -44,6 +53,8 @@ class DomainSuggestion extends React.Component {
 				onClick={ this.props.onButtonClick }
 				role="button"
 				data-e2e-domain={ this.props.domain }
+				onKeyPress={ this.keyboardHandler }
+				tabIndex="0"
 			>
 				<div className="domain-suggestion__content">
 					{ children }

--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -16,7 +16,7 @@
 	&.is-clickable {
 		cursor: pointer;
 
-		&:hover {
+		&:hover, &:focus {
 			box-shadow: 0 0 0 1px $gray;
 			z-index: z-index('root', '.domain-suggestion.is-clickable:hover');
 		}


### PR DESCRIPTION
This PR is a fix for #19194 .

Previously the domain selection screen results weren't accessible when pressing the Tab key to switch focus.

This PR improves the accessibility by:
* Adding a `tabIndex` property to the elements, so they appear in the tab order of the page
* Handling of keyboard actions ( Enter and Space keys ) to submit the selection
* Added a `:focus` CSS rule to highlight the selected element

### To test
1. Checkout branch or use Calypso.live link
2. Go to `/start` to start the Signup process
3. Search for a domain
4. Try using the Tab key to move the focus around the page
5. Verify that the results are properly focusing
6. Verify that when pressing enter, the selected result is properly submitted (finish Signup and verify the domain is added in the cart)
7. Verify there aren't JS errors in the console. 