### PR TITLE
Jetpack connect: Remove query object form Plans

### DIFF
--- a/client/jetpack-connect/plans.jsx
+++ b/client/jetpack-connect/plans.jsx
@@ -35,13 +35,17 @@ import QueryPlans from 'components/data/query-plans';
 import QuerySitePlans from 'components/data/query-site-plans';
 import { isRequestingPlans, getPlanBySlug } from 'state/plans/selectors';
 import { getSelectedSite } from 'state/ui/selectors';
-import { canCurrentUser, isRtl, isSiteOnPaidPlan } from 'state/selectors';
+import {
+	canCurrentUser,
+	getJetpackConnectRedirectAfterAuth,
+	isRtl,
+	isSiteOnPaidPlan,
+} from 'state/selectors';
 import {
 	getFlowType,
 	isRedirectingToWpAdmin,
 	getSiteSelectedPlan,
 	getGlobalSelectedPlan,
-	getAuthorizationData,
 	isCalypsoStartedConnection,
 } from 'state/jetpack-connect/selectors';
 import { mc } from 'lib/analytics';
@@ -124,9 +128,9 @@ class Plans extends Component {
 			return;
 		}
 
-		const { queryObject } = this.props.jetpackConnectAuthorize;
-		if ( queryObject ) {
-			this.props.goBackToWpAdmin( queryObject.redirect_after_auth );
+		const { redirectAfterAuth } = this.props;
+		if ( redirectAfterAuth ) {
+			this.props.goBackToWpAdmin( redirectAfterAuth );
 		} else if ( this.props.selectedSite ) {
 			this.props.goBackToWpAdmin( this.props.selectedSite.URL + JETPACK_ADMIN_PATH );
 		}
@@ -313,7 +317,7 @@ export default connect(
 			selectedPlan,
 			isAutomatedTransfer: selectedSite ? isSiteAutomatedTransfer( state, selectedSite.ID ) : false,
 			sitePlans: getPlansBySite( state, selectedSite ),
-			jetpackConnectAuthorize: getAuthorizationData( state ),
+			redirectAfterAuth: getJetpackConnectRedirectAfterAuth( state ),
 			userId: user ? user.ID : null,
 			canPurchasePlans: selectedSite
 				? canCurrentUser( state, selectedSite.ID, 'manage_options' )

--- a/client/jetpack-connect/plans.jsx
+++ b/client/jetpack-connect/plans.jsx
@@ -56,11 +56,6 @@ const CALYPSO_PLANS_PAGE = '/plans/my-plan/';
 const JETPACK_ADMIN_PATH = '/wp-admin/admin.php?page=jetpack';
 
 class Plans extends Component {
-	constructor( props ) {
-		super( props );
-		this.redirecting = false;
-	}
-
 	static propTypes = {
 		sitePlans: PropTypes.object.isRequired,
 		showJetpackFreePlan: PropTypes.bool,
@@ -69,6 +64,8 @@ class Plans extends Component {
 	static defaultProps = {
 		siteSlug: '*',
 	};
+
+	redirecting = false;
 
 	componentDidMount() {
 		if ( this.props.isAutomatedTransfer && ! this.redirecting && this.props.selectedSite ) {

--- a/client/state/selectors/get-jetpack-connect-redirect-after-auth.js
+++ b/client/state/selectors/get-jetpack-connect-redirect-after-auth.js
@@ -1,0 +1,20 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { getAuthorizationRemoteQueryData } from 'state/jetpack-connect/selectors';
+
+/**
+ * Returns redirect_after_auth provided as part of Jetpack Connect authorization.
+ *
+ * @param  {Object}  state Global state tree
+ * @return {?String}       Redirect URL
+ */
+export default function getJetpackConnectRedirectAfterAuth( state ) {
+	return get( getAuthorizationRemoteQueryData( state ), 'redirect_after_auth', null );
+}

--- a/client/state/selectors/index.js
+++ b/client/state/selectors/index.js
@@ -44,6 +44,7 @@ export getCurrentUserPaymentMethods from './get-current-user-payment-methods';
 export getImageEditorIsGreaterThanMinimumDimensions from './get-image-editor-is-greater-than-minimum-dimensions';
 export getImageEditorOriginalAspectRatio from './get-image-editor-original-aspect-ratio';
 export getJetpackConnectionStatus from './get-jetpack-connection-status';
+export getJetpackConnectRedirectAfterAuth from './get-jetpack-connect-redirect-after-auth';
 export getJetpackCredentials from './get-jetpack-credentials';
 export getJetpackJumpstartStatus from './get-jetpack-jumpstart-status';
 export getJetpackModule from './get-jetpack-module';


### PR DESCRIPTION
This PR replaces a large (nested objects) prop on the Plans component to use a selector for the single property it needs.

It also add the global selector for that single property.

- [x] Blocked by #19218, which ensures that the removed properties do not need to be passed to children.

## Testing
1. Does the plans page continue to render correctly?
1. Try connecting a new site with a free plan
1. Try connecting a new site with a paid plan