### PR TITLE
Jetpack Disconnect: Add Tracks event to beginning of Flow

### DIFF
--- a/client/my-sites/plugins/disconnect-jetpack/disconnect-jetpack-button.jsx
+++ b/client/my-sites/plugins/disconnect-jetpack/disconnect-jetpack-button.jsx
@@ -29,20 +29,20 @@ class DisconnectJetpackButton extends Component {
 
 	handleClick = event => {
 		event.preventDefault();
-		const { isMock, recordGoogleEvent } = this.props;
+		const { isMock, recordGoogleEvent, recordTracksEvent } = this.props;
 
 		if ( isMock ) {
 			return;
 		}
 		this.setState( { dialogVisible: true } );
 		recordGoogleEvent( 'Jetpack', 'Clicked To Open Disconnect Jetpack Dialog' );
+		recordTracksEvent( 'calypso_jetpack_disconnect_start' );
 	};
 
 	hideDialog = () => {
-		const { recordGoogleEvent, recordTracksEvent } = this.props;
+		const { recordGoogleEvent } = this.props;
 		this.setState( { dialogVisible: false } );
 		recordGoogleEvent( 'Jetpack', 'Clicked To Cancel Disconnect Jetpack Dialog' );
-		recordTracksEvent( 'calypso_jetpack_disconnect_start' );
 	};
 
 	render() {

--- a/client/my-sites/plugins/disconnect-jetpack/disconnect-jetpack-button.jsx
+++ b/client/my-sites/plugins/disconnect-jetpack/disconnect-jetpack-button.jsx
@@ -22,10 +22,7 @@ import {
 } from 'state/analytics/actions';
 
 class DisconnectJetpackButton extends Component {
-	constructor( props ) {
-		super( props );
-		this.state = { dialogVisible: false };
-	}
+	state = { dialogVisible: false };
 
 	handleClick = event => {
 		event.preventDefault();

--- a/client/my-sites/plugins/disconnect-jetpack/disconnect-jetpack-button.jsx
+++ b/client/my-sites/plugins/disconnect-jetpack/disconnect-jetpack-button.jsx
@@ -16,7 +16,10 @@ import { connect } from 'react-redux';
 import Button from 'components/button';
 import DisconnectJetpackDialog from 'blocks/disconnect-jetpack/dialog';
 import QuerySitePlans from 'components/data/query-site-plans';
-import { recordGoogleEvent } from 'state/analytics/actions';
+import {
+	recordGoogleEvent,
+	recordTracksEvent as recordTracksEventAction,
+} from 'state/analytics/actions';
 
 class DisconnectJetpackButton extends Component {
 	constructor( props ) {
@@ -36,9 +39,13 @@ class DisconnectJetpackButton extends Component {
 	};
 
 	hideDialog = () => {
-		const { recordGoogleEvent: recordGAEvent } = this.props;
+		const {
+			recordGoogleEvent: recordGAEvent,
+			recordTracksEventAction: recordTracksEvent,
+		} = this.props;
 		this.setState( { dialogVisible: false } );
 		recordGAEvent( 'Jetpack', 'Clicked To Cancel Disconnect Jetpack Dialog' );
+		recordTracksEvent( 'calypso_jetpack_disconnect_start' );
 	};
 
 	render() {
@@ -92,10 +99,14 @@ DisconnectJetpackButton.propTypes = {
 	isMock: PropTypes.bool,
 	text: PropTypes.string,
 	recordGoogleEvent: PropTypes.func.isRequired,
+	recordTracksEventAction: PropTypes.func.isRequired,
 };
 
 DisconnectJetpackButton.defaultProps = {
 	linkDisplay: true,
 };
 
-export default connect( null, { recordGoogleEvent } )( localize( DisconnectJetpackButton ) );
+export default connect( null, {
+	recordGoogleEvent,
+	recordTracksEvent: recordTracksEventAction,
+} )( localize( DisconnectJetpackButton ) );

--- a/client/my-sites/plugins/disconnect-jetpack/disconnect-jetpack-button.jsx
+++ b/client/my-sites/plugins/disconnect-jetpack/disconnect-jetpack-button.jsx
@@ -17,7 +17,7 @@ import Button from 'components/button';
 import DisconnectJetpackDialog from 'blocks/disconnect-jetpack/dialog';
 import QuerySitePlans from 'components/data/query-site-plans';
 import {
-	recordGoogleEvent,
+	recordGoogleEvent as recordGoogleEventAction,
 	recordTracksEvent as recordTracksEventAction,
 } from 'state/analytics/actions';
 
@@ -29,22 +29,19 @@ class DisconnectJetpackButton extends Component {
 
 	handleClick = event => {
 		event.preventDefault();
-		const { isMock, recordGoogleEvent: recordGAEvent } = this.props;
+		const { isMock, recordGoogleEvent } = this.props;
 
 		if ( isMock ) {
 			return;
 		}
 		this.setState( { dialogVisible: true } );
-		recordGAEvent( 'Jetpack', 'Clicked To Open Disconnect Jetpack Dialog' );
+		recordGoogleEvent( 'Jetpack', 'Clicked To Open Disconnect Jetpack Dialog' );
 	};
 
 	hideDialog = () => {
-		const {
-			recordGoogleEvent: recordGAEvent,
-			recordTracksEventAction: recordTracksEvent,
-		} = this.props;
+		const { recordGoogleEvent, recordTracksEvent } = this.props;
 		this.setState( { dialogVisible: false } );
-		recordGAEvent( 'Jetpack', 'Clicked To Cancel Disconnect Jetpack Dialog' );
+		recordGoogleEvent( 'Jetpack', 'Clicked To Cancel Disconnect Jetpack Dialog' );
 		recordTracksEvent( 'calypso_jetpack_disconnect_start' );
 	};
 
@@ -99,7 +96,7 @@ DisconnectJetpackButton.propTypes = {
 	isMock: PropTypes.bool,
 	text: PropTypes.string,
 	recordGoogleEvent: PropTypes.func.isRequired,
-	recordTracksEventAction: PropTypes.func.isRequired,
+	recordTracksEvent: PropTypes.func.isRequired,
 };
 
 DisconnectJetpackButton.defaultProps = {
@@ -107,6 +104,6 @@ DisconnectJetpackButton.defaultProps = {
 };
 
 export default connect( null, {
-	recordGoogleEvent,
+	recordGoogleEvent: recordGoogleEventAction,
 	recordTracksEvent: recordTracksEventAction,
 } )( localize( DisconnectJetpackButton ) );

--- a/client/my-sites/site-settings/manage-connection/disconnect-site-link.jsx
+++ b/client/my-sites/site-settings/manage-connection/disconnect-site-link.jsx
@@ -16,6 +16,7 @@ import QuerySitePlans from 'components/data/query-site-plans';
 import SiteToolsLink from 'my-sites/site-settings/site-tools/link';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { isSiteAutomatedTransfer } from 'state/selectors';
+import { recordTracksEvent } from 'state/analytics/actions';
 
 class DisconnectSiteLink extends Component {
 	state = {
@@ -28,6 +29,8 @@ class DisconnectSiteLink extends Component {
 		this.setState( {
 			dialogVisible: true,
 		} );
+
+		this.props.recordTracksEvent( 'calypso_jetpack_disconnect_start' );
 	};
 
 	handleHideDialog = () => {
@@ -69,11 +72,14 @@ class DisconnectSiteLink extends Component {
 	}
 }
 
-export default connect( state => {
-	const siteId = getSelectedSiteId( state );
+export default connect(
+	state => {
+		const siteId = getSelectedSiteId( state );
 
-	return {
-		isAutomatedTransfer: isSiteAutomatedTransfer( state, siteId ),
-		siteId,
-	};
-} )( localize( DisconnectSiteLink ) );
+		return {
+			isAutomatedTransfer: isSiteAutomatedTransfer( state, siteId ),
+			siteId,
+		};
+	},
+	{ recordTracksEvent }
+)( localize( DisconnectSiteLink ) );


### PR DESCRIPTION
Counterpart to #19164. Track whenever a user first starts the disconnect flow (which right now only consists of the confirmation dialog) so we have a funnel to see what percentage actually follows thru and compare that to the [new flow](https://github.com/Automattic/wp-calypso/projects/49) we're currently implementing.

To test:
* In your browser console, enter `localStorage.setItem( 'debug', 'calypso:analytics*' )`, and reload.
* Verify that the `calypso_jetpack_disconnect_start` Tracks event is fired in the following cases:

1. `/settings/manage-connection/:site` -- Click the 'Disconnect from WordPress.com' button at the bottom of the page

![image](https://user-images.githubusercontent.com/96308/31471251-3b2258a6-aee8-11e7-87e6-ece683dccf69.png)

2. In siteslist in the sidebar, if you have a “broken” jetpack site, it will let you disconnect from the site there. (For example, rename `jetpack` plugin folder on the site.)

<img width="273" alt="screen shot 2017-06-23 at 12 41 17" src="https://user-images.githubusercontent.com/7767559/27480757-4ad41862-5811-11e7-8036-64202338667c.png">


Question: Did I miss any entry points for the current Disconnect flow?