### PR TITLE
JP Disconnect: Fix Tracks event

### DIFF
--- a/client/blocks/disconnect-jetpack/index.jsx
+++ b/client/blocks/disconnect-jetpack/index.jsx
@@ -44,7 +44,7 @@ class DisconnectJetpack extends PureComponent {
 		siteTitle: PropTypes.string,
 		setAllSitesSelected: PropTypes.func,
 		recordGoogleEvent: PropTypes.func,
-		recordTracksEventAction: PropTypes.func,
+		recordTracksEvent: PropTypes.func,
 		disconnect: PropTypes.func,
 		successNotice: PropTypes.func,
 		errorNotice: PropTypes.func,
@@ -167,7 +167,7 @@ class DisconnectJetpack extends PureComponent {
 			removeNotice: removeInfoNotice,
 			disconnect: disconnectSite,
 			recordGoogleEvent: recordGAEvent,
-			recordTracksEventAction: recordTracksEvent,
+			recordTracksEvent,
 		} = this.props;
 
 		onDisconnectClick();

--- a/client/blocks/disconnect-jetpack/index.jsx
+++ b/client/blocks/disconnect-jetpack/index.jsx
@@ -17,7 +17,7 @@ import { noop } from 'lodash';
 import Button from 'components/button';
 import Card from 'components/card';
 import {
-	recordGoogleEvent,
+	recordGoogleEvent as recordGoogleEventAction,
 	recordTracksEvent as recordTracksEventAction,
 } from 'state/analytics/actions';
 import { disconnect } from 'state/jetpack/connection/actions';
@@ -166,14 +166,14 @@ class DisconnectJetpack extends PureComponent {
 			infoNotice: showInfoNotice,
 			removeNotice: removeInfoNotice,
 			disconnect: disconnectSite,
-			recordGoogleEvent: recordGAEvent,
+			recordGoogleEvent,
 			recordTracksEvent,
 		} = this.props;
 
 		onDisconnectClick();
 
 		recordTracksEvent( 'calypso_jetpack_disconnect_confirm' );
-		recordGAEvent( 'Jetpack', 'Clicked To Confirm Disconnect Jetpack Dialog' );
+		recordGoogleEvent( 'Jetpack', 'Clicked To Confirm Disconnect Jetpack Dialog' );
 
 		const { notice } = showInfoNotice(
 			translate( 'Disconnecting %(siteName)s.', { args: { siteName: siteTitle } } ),
@@ -195,14 +195,14 @@ class DisconnectJetpack extends PureComponent {
 				showSuccessNotice(
 					translate( 'Successfully disconnected %(siteName)s.', { args: { siteName: siteTitle } } )
 				);
-				recordGAEvent( 'Jetpack', 'Successfully Disconnected' );
+				recordGoogleEvent( 'Jetpack', 'Successfully Disconnected' );
 			},
 			() => {
 				removeInfoNotice( notice.noticeId );
 				showErrorNotice(
 					translate( '%(siteName)s failed to disconnect', { args: { siteName: siteTitle } } )
 				);
-				recordGAEvent( 'Jetpack', 'Failed Disconnected Site' );
+				recordGoogleEvent( 'Jetpack', 'Failed Disconnected Site' );
 			}
 		);
 	};
@@ -287,7 +287,7 @@ export default connect(
 	},
 	{
 		setAllSitesSelected,
-		recordGoogleEvent,
+		recordGoogleEvent: recordGoogleEventAction,
 		recordTracksEvent: recordTracksEventAction,
 		disconnect,
 		successNotice,


### PR DESCRIPTION
#19164 was buggy: When clicking on the confirmation dialog's 'Disconnect'  button, you'd see the following warning in the console:

![image](https://user-images.githubusercontent.com/96308/32102831-4a687902-bb1e-11e7-8db4-1ddf28b8f26e.png)

This PR fixes the issue, and streamlines the google analytics event action's naming.

To test:
1. On `master`, go to  `/settings/disconnect-site/confirm/bernhardreiter.wpsandbox.me` and click 'Disconnect'. Verify that you get the warning.
2. Reconnect your JP site, switch to this PR's branch, repeat step 1. No warning this time!