### PR TITLE
JP Disconnect Survey: Add Debug Link

### DIFF
--- a/client/my-sites/site-settings/disconnect-site/troubleshoot.jsx
+++ b/client/my-sites/site-settings/disconnect-site/troubleshoot.jsx
@@ -9,12 +9,21 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import JetpackConnectHappychatButton from 'jetpack-connect/happychat-button';
 import HelpButton from 'jetpack-connect/help-button';
+import JetpackConnectHappychatButton from 'jetpack-connect/happychat-button';
+import LoggedOutFormLinkItem from 'components/logged-out-form/link-item';
+import LoggedOutFormLinks from 'components/logged-out-form/links';
 import { recordTracksEvent, withAnalytics } from 'state/analytics/actions';
+import { getSelectedSiteSlug } from 'state/ui/selectors';
 
-const Troubleshoot = ( { trackSupportClick, translate } ) => (
-	<div className="disconnect-site__troubleshooting">
+const Troubleshoot = ( { siteSlug, trackDebugClick, trackSupportClick, translate } ) => (
+	<LoggedOutFormLinks>
+		<LoggedOutFormLinkItem
+			href={ 'https://jetpack.com/support/debug/?url=' + siteSlug }
+			onClick={ trackDebugClick }
+		>
+			{ translate( 'Diagnose a connection problem' ) }
+		</LoggedOutFormLinkItem>
 		<JetpackConnectHappychatButton
 			label={ translate( 'Get help from our Happiness Engineers' ) }
 			onClick={ trackSupportClick }
@@ -24,11 +33,17 @@ const Troubleshoot = ( { trackSupportClick, translate } ) => (
 				onClick={ trackSupportClick }
 			/>
 		</JetpackConnectHappychatButton>
-	</div>
+	</LoggedOutFormLinks>
 );
 
-export default connect( null, {
-	trackSupportClick: withAnalytics(
-		recordTracksEvent( 'calypso_jetpack_disconnect_support_click' )
-	),
-} )( localize( Troubleshoot ) );
+export default connect(
+	state => ( {
+		siteSlug: getSelectedSiteSlug( state ),
+	} ),
+	{
+		trackDebugClick: withAnalytics( recordTracksEvent( 'calypso_jetpack_disconnect_debug_click' ) ),
+		trackSupportClick: withAnalytics(
+			recordTracksEvent( 'calypso_jetpack_disconnect_support_click' )
+		),
+	}
+)( localize( Troubleshoot ) );

--- a/client/my-sites/site-settings/disconnect-site/troubleshoot.jsx
+++ b/client/my-sites/site-settings/disconnect-site/troubleshoot.jsx
@@ -13,13 +13,15 @@ import HelpButton from 'jetpack-connect/help-button';
 import JetpackConnectHappychatButton from 'jetpack-connect/happychat-button';
 import LoggedOutFormLinkItem from 'components/logged-out-form/link-item';
 import LoggedOutFormLinks from 'components/logged-out-form/links';
+import addQueryArgs from 'lib/route/add-query-args';
 import { recordTracksEvent, withAnalytics } from 'state/analytics/actions';
-import { getSelectedSiteSlug } from 'state/ui/selectors';
+import { getSiteUrl } from 'state/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
 
-const Troubleshoot = ( { siteSlug, trackDebugClick, trackSupportClick, translate } ) => (
+const Troubleshoot = ( { siteUrl, trackDebugClick, trackSupportClick, translate } ) => (
 	<LoggedOutFormLinks>
 		<LoggedOutFormLinkItem
-			href={ 'https://jetpack.com/support/debug/?url=' + siteSlug }
+			href={ addQueryArgs( { url: siteUrl }, 'https://jetpack.com/support/debug/' ) }
 			onClick={ trackDebugClick }
 		>
 			{ translate( 'Diagnose a connection problem' ) }
@@ -38,7 +40,7 @@ const Troubleshoot = ( { siteSlug, trackDebugClick, trackSupportClick, translate
 
 export default connect(
 	state => ( {
-		siteSlug: getSelectedSiteSlug( state ),
+		siteUrl: getSiteUrl( state, getSelectedSiteId( state ) ),
 	} ),
 	{
 		trackDebugClick: withAnalytics( recordTracksEvent( 'calypso_jetpack_disconnect_debug_click' ) ),


### PR DESCRIPTION
The `Diagnose a connection problem` thing:

![image](https://user-images.githubusercontent.com/96308/32108657-a325218a-bb32-11e7-9882-75159250951d.png)

To test:
* Verify that link triggers a `calypso_jetpack_disconnect_debug_click`, and takes you to `'https://jetpack.com/support/debug/?url=' + siteSlug`.

Follow up from #18968. This uses `LoggedOutFormLinks` and `LoggedOutFormLinkItem` components because they're styled exactly like we need 'em here, but they're a bit of a misnomer it seems. Maybe we should rename them to `FullScreenForm...`.