### PR TITLE
Comments Redesign: Add CommentAuthorMoreInfo

### DIFF
--- a/client/my-sites/comments/comment/comment-author-more-info.jsx
+++ b/client/my-sites/comments/comment/comment-author-more-info.jsx
@@ -33,7 +33,7 @@ import {
 import { getCurrentUserEmail } from 'state/current-user/selectors';
 import { successNotice } from 'state/notices/actions';
 import { saveSiteSettings } from 'state/site-settings/actions';
-import { getSelectedSiteId } from 'state/ui/selectors';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 
 export class CommentAuthorMoreInfo extends Component {
 	static propTypes = {
@@ -105,6 +105,8 @@ export class CommentAuthorMoreInfo extends Component {
 			authorUsername,
 			isAuthorBlacklisted,
 			showBlockUser,
+			siteSlug,
+			trackAnonymousModeration,
 			translate,
 		} = this.props;
 
@@ -125,12 +127,14 @@ export class CommentAuthorMoreInfo extends Component {
 								<div>{ authorUsername }</div>
 							</div>
 						</div>
+
 						<div className="comment__author-more-info-popover-element">
 							<Gridicon icon="mail" />
 							<div className="comment__author-more-info-popover-element-text">
 								{ authorEmail || <em>{ translate( 'No email address' ) }</em> }
 							</div>
 						</div>
+
 						<div className="comment__author-more-info-popover-element">
 							<Gridicon icon="link" />
 							<div className="comment__author-more-info-popover-element-text">
@@ -141,24 +145,41 @@ export class CommentAuthorMoreInfo extends Component {
 								) }
 								{ ! authorUrl && <em>{ translate( 'No website' ) }</em> }
 							</div>
-							<div className="comment__author-more-info-popover-element">
-								<Gridicon icon="globe" />
-								<div className="comment__author-more-info-popover-element-text">
-									{ authorIp || <em>{ translate( 'No IP address' ) }</em> }
-								</div>
-							</div>
-							{ showBlockUser && (
-								<div className="comment__author-more-info-popover-element">
-									<Button onClick={ this.toggleBlockUser } scary={ ! isAuthorBlacklisted }>
-										{ isAuthorBlacklisted ? (
-											translate( 'Unblock user' )
-										) : (
-											translate( 'Block user' )
-										) }
-									</Button>
-								</div>
-							) }
 						</div>
+
+						<div className="comment__author-more-info-popover-element">
+							<Gridicon icon="globe" />
+							<div className="comment__author-more-info-popover-element-text">
+								{ authorIp || <em>{ translate( 'No IP address' ) }</em> }
+							</div>
+						</div>
+
+						{ showBlockUser && (
+							<div className="comment__author-more-info-popover-element">
+								<Button onClick={ this.toggleBlockUser } scary={ ! isAuthorBlacklisted }>
+									{ isAuthorBlacklisted ? translate( 'Unblock user' ) : translate( 'Block user' ) }
+								</Button>
+							</div>
+						) }
+
+						{ ! authorEmail && (
+							<div className="comment__author-more-info-popover-element">
+								{ translate(
+									// eslint-disable-next-line max-len
+									"Anonymous messages can't be blocked individually, but you can update your {{a}}settings{{/a}} to only allow comments from registered users.",
+									{
+										components: {
+											a: (
+												<a
+													href={ `/settings/discussion/${ siteSlug }` }
+													onClick={ trackAnonymousModeration }
+												/>
+											),
+										},
+									}
+								) }
+							</div>
+						) }
 					</div>
 				</InfoPopover>
 				<label>{ translate( 'User Info' ) }</label>
@@ -190,6 +211,7 @@ const mapStateToProps = ( state, { commentId } ) => {
 		showBlockUser,
 		siteBlacklist: getSiteSetting( state, siteId, 'blacklist_keys' ),
 		siteId,
+		siteSlug: getSelectedSiteSlug( state ),
 	};
 };
 

--- a/client/my-sites/comments/comment/comment-author-more-info.jsx
+++ b/client/my-sites/comments/comment/comment-author-more-info.jsx
@@ -174,8 +174,9 @@ export class CommentAuthorMoreInfo extends Component {
 						<div className="comment__author-more-info-element">
 							<div>
 								{ translate(
-									// eslint-disable-next-line max-len
-									"Anonymous messages can't be blocked individually, but you can update your {{a}}settings{{/a}} to only allow comments from registered users.",
+									"Anonymous messages can't be blocked individually, " +
+										'but you can update your {{a}}settings{{/a}} to ' +
+										'only allow comments from registered users.',
 									{
 										components: {
 											a: (

--- a/client/my-sites/comments/comment/comment-author-more-info.jsx
+++ b/client/my-sites/comments/comment/comment-author-more-info.jsx
@@ -15,10 +15,10 @@ import { get } from 'lodash';
 import Emojify from 'components/emojify';
 import ExternalLink from 'components/external-link';
 import InfoPopover from 'components/info-popover';
+import { decodeEntities } from 'lib/formatting';
 import { urlToDomainAndPath } from 'lib/url';
 import { getSiteComment } from 'state/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import { getAuthorDisplayName } from 'my-sites/comments/comment/utils';
 
 export class CommentAuthorMoreInfo extends Component {
 	static propTypes = {
@@ -93,7 +93,7 @@ const mapStateToProps = ( state, { commentId } ) => {
 	const siteId = getSelectedSiteId( state );
 	const comment = getSiteComment( state, siteId, commentId );
 
-	const authorDisplayName = getAuthorDisplayName( comment );
+	const authorDisplayName = decodeEntities( get( comment, 'author.name' ) );
 
 	return {
 		authorDisplayName,

--- a/client/my-sites/comments/comment/comment-author-more-info.jsx
+++ b/client/my-sites/comments/comment/comment-author-more-info.jsx
@@ -15,7 +15,7 @@ import { get } from 'lodash';
 import Button from 'components/button';
 import Emojify from 'components/emojify';
 import ExternalLink from 'components/external-link';
-import InfoPopover from 'components/info-popover';
+import Popover from 'components/popover';
 import { decodeEntities } from 'lib/formatting';
 import { urlToDomainAndPath } from 'lib/url';
 import {
@@ -40,11 +40,15 @@ export class CommentAuthorMoreInfo extends Component {
 		commentId: PropTypes.number,
 	};
 
-	storeLabelRef = label => ( this.authorMoreInfoLabel = label );
+	state = {
+		showPopover: false,
+	};
 
-	storePopoverRef = popover => ( this.authorMoreInfoPopover = popover );
+	storePopoverButtonRef = button => ( this.popoverButton = button );
 
-	openAuthorMoreInfoPopover = event => this.authorMoreInfoPopover.handleClick( event );
+	closePopover = () => this.setState( { showPopover: false } );
+
+	togglePopover = () => this.setState( ( { showPopover } ) => ( { showPopover: ! showPopover } ) );
 
 	toggleBlockUser = () => {
 		const {
@@ -110,16 +114,21 @@ export class CommentAuthorMoreInfo extends Component {
 			translate,
 		} = this.props;
 
+		const { showPopover } = this.state;
+
 		return (
-			<div
-				className="comment__author-more-info"
-				onClick={ this.openAuthorMoreInfoPopover }
-				ref={ this.storeLabelRef }
-			>
-				<InfoPopover
+			<div className="comment__author-more-info">
+				<Button borderless onClick={ this.togglePopover } ref={ this.storePopoverButtonRef }>
+					<Gridicon icon="info-outline" size={ 18 } />
+					{ translate( 'User Info' ) }
+				</Button>
+
+				<Popover
 					className="comment__author-more-info-popover"
-					ignoreContext={ this.authorMoreInfoLabel }
-					ref={ this.storePopoverRef }
+					context={ this.popoverButton }
+					isVisible={ showPopover }
+					onClose={ this.closePopover }
+					position="bottom"
 				>
 					<div className="comment__author-more-info-element">
 						<Gridicon icon="user-circle" />
@@ -181,8 +190,7 @@ export class CommentAuthorMoreInfo extends Component {
 							</div>
 						</div>
 					) }
-				</InfoPopover>
-				<label>{ translate( 'User Info' ) }</label>
+				</Popover>
 			</div>
 		);
 	}

--- a/client/my-sites/comments/comment/comment-author-more-info.jsx
+++ b/client/my-sites/comments/comment/comment-author-more-info.jsx
@@ -116,54 +116,54 @@ export class CommentAuthorMoreInfo extends Component {
 				onClick={ this.openAuthorMoreInfoPopover }
 				ref={ this.storeLabelRef }
 			>
-				<InfoPopover ignoreContext={ this.authorMoreInfoLabel } ref={ this.storePopoverRef }>
-					<div className="comment__author-more-info-popover">
-						<div className="comment__author-more-info-popover-element">
-							<Gridicon icon="user-circle" />
-							<div className="comment__author-more-info-popover-element-text">
-								<div>
-									<strong>{ authorDisplayName || translate( 'Anonymous' ) }</strong>
-								</div>
-								<div>{ authorUsername }</div>
+				<InfoPopover
+					className="comment__author-more-info-popover"
+					ignoreContext={ this.authorMoreInfoLabel }
+					ref={ this.storePopoverRef }
+				>
+					<div className="comment__author-more-info-element">
+						<Gridicon icon="user-circle" />
+						<div>
+							<div>
+								<strong>{ authorDisplayName || translate( 'Anonymous' ) }</strong>
 							</div>
+							<div>{ authorUsername }</div>
 						</div>
+					</div>
 
-						<div className="comment__author-more-info-popover-element">
-							<Gridicon icon="mail" />
-							<div className="comment__author-more-info-popover-element-text">
-								{ authorEmail || <em>{ translate( 'No email address' ) }</em> }
-							</div>
+					<div className="comment__author-more-info-element">
+						<Gridicon icon="mail" />
+						<div>{ authorEmail || <em>{ translate( 'No email address' ) }</em> }</div>
+					</div>
+
+					<div className="comment__author-more-info-element">
+						<Gridicon icon="link" />
+						<div>
+							{ !! authorUrl && (
+								<ExternalLink href={ authorUrl }>
+									<Emojify>{ urlToDomainAndPath( authorUrl ) }</Emojify>
+								</ExternalLink>
+							) }
+							{ ! authorUrl && <em>{ translate( 'No website' ) }</em> }
 						</div>
+					</div>
 
-						<div className="comment__author-more-info-popover-element">
-							<Gridicon icon="link" />
-							<div className="comment__author-more-info-popover-element-text">
-								{ !! authorUrl && (
-									<ExternalLink href={ authorUrl }>
-										<Emojify>{ urlToDomainAndPath( authorUrl ) }</Emojify>
-									</ExternalLink>
-								) }
-								{ ! authorUrl && <em>{ translate( 'No website' ) }</em> }
-							</div>
+					<div className="comment__author-more-info-element">
+						<Gridicon icon="globe" />
+						<div>{ authorIp || <em>{ translate( 'No IP address' ) }</em> }</div>
+					</div>
+
+					{ showBlockUser && (
+						<div className="comment__author-more-info-element">
+							<Button onClick={ this.toggleBlockUser } scary={ ! isAuthorBlacklisted }>
+								{ isAuthorBlacklisted ? translate( 'Unblock user' ) : translate( 'Block user' ) }
+							</Button>
 						</div>
+					) }
 
-						<div className="comment__author-more-info-popover-element">
-							<Gridicon icon="globe" />
-							<div className="comment__author-more-info-popover-element-text">
-								{ authorIp || <em>{ translate( 'No IP address' ) }</em> }
-							</div>
-						</div>
-
-						{ showBlockUser && (
-							<div className="comment__author-more-info-popover-element">
-								<Button onClick={ this.toggleBlockUser } scary={ ! isAuthorBlacklisted }>
-									{ isAuthorBlacklisted ? translate( 'Unblock user' ) : translate( 'Block user' ) }
-								</Button>
-							</div>
-						) }
-
-						{ ! authorEmail && (
-							<div className="comment__author-more-info-popover-element">
+					{ ! authorEmail && (
+						<div className="comment__author-more-info-element">
+							<div>
 								{ translate(
 									// eslint-disable-next-line max-len
 									"Anonymous messages can't be blocked individually, but you can update your {{a}}settings{{/a}} to only allow comments from registered users.",
@@ -179,8 +179,8 @@ export class CommentAuthorMoreInfo extends Component {
 									}
 								) }
 							</div>
-						) }
-					</div>
+						</div>
+					) }
 				</InfoPopover>
 				<label>{ translate( 'User Info' ) }</label>
 			</div>

--- a/client/my-sites/comments/comment/comment-author-more-info.jsx
+++ b/client/my-sites/comments/comment/comment-author-more-info.jsx
@@ -3,13 +3,28 @@
  * External dependencies
  */
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+import Gridicon from 'gridicons';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
  */
+import Emojify from 'components/emojify';
+import ExternalLink from 'components/external-link';
 import InfoPopover from 'components/info-popover';
+import { urlToDomainAndPath } from 'lib/url';
+import { getSiteComment } from 'state/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { getAuthorDisplayName } from 'my-sites/comments/comment/utils';
 
 export class CommentAuthorMoreInfo extends Component {
+	static propTypes = {
+		commentId: PropTypes.number,
+	};
+
 	storeLabelRef = label => ( this.authorMoreInfoLabel = label );
 
 	storePopoverRef = popover => ( this.authorMoreInfoPopover = popover );
@@ -17,6 +32,15 @@ export class CommentAuthorMoreInfo extends Component {
 	openAuthorMoreInfoPopover = event => this.authorMoreInfoPopover.handleClick( event );
 
 	render() {
+		const {
+			authorDisplayName,
+			authorEmail,
+			authorIp,
+			authorUrl,
+			authorUsername,
+			translate,
+		} = this.props;
+
 		return (
 			<div
 				className="comment__author-more-info"
@@ -24,12 +48,62 @@ export class CommentAuthorMoreInfo extends Component {
 				ref={ this.storeLabelRef }
 			>
 				<InfoPopover ignoreContext={ this.authorMoreInfoLabel } ref={ this.storePopoverRef }>
-					Author More Info
+					<div className="comment__author-more-info-popover">
+						<div className="comment__author-more-info-popover-element">
+							<Gridicon icon="user-circle" />
+							<div className="comment__author-more-info-popover-element-text">
+								<div>
+									<strong>{ authorDisplayName || translate( 'Anonymous' ) }</strong>
+								</div>
+								<div>{ authorUsername }</div>
+							</div>
+						</div>
+						<div className="comment__author-more-info-popover-element">
+							<Gridicon icon="mail" />
+							<div className="comment__author-more-info-popover-element-text">
+								{ authorEmail || <em>{ translate( 'No email address' ) }</em> }
+							</div>
+						</div>
+						<div className="comment__author-more-info-popover-element">
+							<Gridicon icon="link" />
+							<div className="comment__author-more-info-popover-element-text">
+								{ !! authorUrl && (
+									<ExternalLink href={ authorUrl }>
+										<Emojify>{ urlToDomainAndPath( authorUrl ) }</Emojify>
+									</ExternalLink>
+								) }
+								{ ! authorUrl && <em>{ translate( 'No website' ) }</em> }
+							</div>
+							<div className="comment__author-more-info-popover-element">
+								<Gridicon icon="globe" />
+								<div className="comment__author-more-info-popover-element-text">
+									{ authorIp || <em>{ translate( 'No IP address' ) }</em> }
+								</div>
+							</div>
+						</div>
+					</div>
 				</InfoPopover>
-				<label>User Info</label>
+				<label>{ translate( 'User Info' ) }</label>
 			</div>
 		);
 	}
 }
 
-export default CommentAuthorMoreInfo;
+const mapStateToProps = ( state, { commentId } ) => {
+	const siteId = getSelectedSiteId( state );
+	const comment = getSiteComment( state, siteId, commentId );
+
+	const authorDisplayName = getAuthorDisplayName( comment );
+
+	return {
+		authorDisplayName,
+		authorEmail: get( comment, 'author.email' ),
+		authorIp: get( comment, 'author.ip_address' ),
+		authorUsername: get( comment, 'author.nice_name' ),
+		authorUrl: get( comment, 'author.URL', '' ),
+	};
+};
+
+const mapDispatchToProps = () => ( {} );
+
+export default connect( mapStateToProps, mapDispatchToProps )( localize( CommentAuthorMoreInfo ) );

--- a/client/my-sites/comments/comment/comment-header.jsx
+++ b/client/my-sites/comments/comment/comment-header.jsx
@@ -31,7 +31,7 @@ export const CommentHeader = ( {
 
 		<CommentAuthor { ...{ commentId, isExpanded } } />
 
-		{ isExpanded && <CommentAuthorMoreInfo /> }
+		{ isExpanded && <CommentAuthorMoreInfo { ...{ commentId } } /> }
 
 		{ ! isBulkMode && (
 			<Button

--- a/client/my-sites/comments/comment/comment-header.jsx
+++ b/client/my-sites/comments/comment/comment-header.jsx
@@ -3,8 +3,9 @@
  * External dependencies
  */
 import React from 'react';
+import { connect } from 'react-redux';
 import Gridicon from 'gridicons';
-import noop from 'lodash';
+import { get, noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -13,6 +14,8 @@ import Button from 'components/button';
 import CommentAuthor from 'my-sites/comments/comment/comment-author';
 import CommentAuthorMoreInfo from 'my-sites/comments/comment/comment-author-more-info';
 import FormCheckbox from 'components/forms/form-checkbox';
+import { getSiteComment } from 'state/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
 
 export const CommentHeader = ( {
 	commentId,
@@ -20,6 +23,7 @@ export const CommentHeader = ( {
 	isEditMode,
 	isExpanded,
 	isSelected,
+	showAuthorMoreInfo,
 	toggleExpanded,
 } ) => (
 	<div className="comment__header">
@@ -31,7 +35,7 @@ export const CommentHeader = ( {
 
 		<CommentAuthor { ...{ commentId, isExpanded } } />
 
-		{ isExpanded && <CommentAuthorMoreInfo { ...{ commentId } } /> }
+		{ showAuthorMoreInfo && <CommentAuthorMoreInfo { ...{ commentId } } /> }
 
 		{ ! isBulkMode && (
 			<Button
@@ -46,4 +50,14 @@ export const CommentHeader = ( {
 	</div>
 );
 
-export default CommentHeader;
+const mapStateToProps = ( state, { commentId, isExpanded } ) => {
+	const siteId = getSelectedSiteId( state );
+	const comment = getSiteComment( state, siteId, commentId );
+	const commentType = get( comment, 'type', 'comment' );
+
+	return {
+		showAuthorMoreInfo: isExpanded && 'comment' === commentType,
+	};
+};
+
+export default connect( mapStateToProps )( CommentHeader );

--- a/client/my-sites/comments/comment/style.scss
+++ b/client/my-sites/comments/comment/style.scss
@@ -118,36 +118,36 @@
 // Comment Author More Info Block
 
 .comment__author-more-info {
-	align-items: center;
+	align-items: stretch;
 	display: flex;
-	color: $gray-text-min;
-	cursor: pointer;
 	flex-grow: 0;
 	flex-shrink: 0;
-	padding: 8px 16px 8px 8px;
 
-	.gridicon {
-		fill: $gray-text-min;
-	}
+	.button.is-borderless {
+		border-radius: 0;
+		font-weight: 400;
+		padding: 0 16px 0 8px;
 
-	&:focus,
-	&:hover {
-		.gridicon,
-		label {
-			color: $gray-dark;
-			cursor: pointer;
-			fill: $gray-dark;
+		.gridicon {
+			height: 18px;
+			margin-right: 4px;
+			top: 3px;
+			width: 18px;
 		}
-	}
-
-	.gridicon {
-		margin: 4px 4px 0 0;
 	}
 }
 
 .popover.comment__author-more-info-popover {
 	/* applying a lower z-index to ensure it is layered behind global notice */
 	z-index: z-index('root', '.popover.comment-detail__author-more-info');
+
+	.popover__inner {
+		color: $gray-text-min;
+		font-size: 13px;
+		max-width: 320px;
+		padding: 16px;
+		text-align: left;
+	}
 }
 
 .comment__author-more-info-element {
@@ -156,6 +156,10 @@
 	flex-flow: row;
 	flex-wrap: nowrap;
 	margin-bottom: 8px;
+
+	&:last-child {
+		margin-bottom: 0;
+	}
 
 	.gridicon {
 		flex-grow: 0;

--- a/client/my-sites/comments/comment/style.scss
+++ b/client/my-sites/comments/comment/style.scss
@@ -144,7 +144,7 @@
 	.popover__inner {
 		color: $gray-text-min;
 		font-size: 13px;
-		max-width: 320px;
+		max-width: 220px;
 		padding: 16px;
 		text-align: left;
 	}

--- a/client/my-sites/comments/comment/style.scss
+++ b/client/my-sites/comments/comment/style.scss
@@ -156,6 +156,7 @@
 	flex-flow: row;
 	flex-wrap: nowrap;
 	margin-bottom: 8px;
+	word-break: break-all;
 
 	&:last-child {
 		margin-bottom: 0;

--- a/client/my-sites/comments/comment/style.scss
+++ b/client/my-sites/comments/comment/style.scss
@@ -145,6 +145,30 @@
 	}
 }
 
+.popover.comment__author-more-info-popover {
+	/* applying a lower z-index to ensure it is layered behind global notice */
+	z-index: z-index('root', '.popover.comment-detail__author-more-info');
+}
+
+.comment__author-more-info-element {
+	align-items: center;
+	display: flex;
+	flex-flow: row;
+	flex-wrap: nowrap;
+	margin-bottom: 8px;
+
+	.gridicon {
+		flex-grow: 0;
+		flex-shrink: 0;
+		margin-right: 8px;
+		width: 24px;
+	}
+
+	.button {
+		width: 100%;
+	}
+}
+
 // Comment Content Block
 
 .comment__content {

--- a/client/my-sites/comments/comment/utils.js
+++ b/client/my-sites/comments/comment/utils.js
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import { get, includes } from 'lodash';
+import { get } from 'lodash';
 
 /**
  * Create a stripped down comment object containing only the information needed by
@@ -17,13 +17,3 @@ export const getMinimalComment = comment => ( {
 	postId: get( comment, 'post.ID' ),
 	status: get( comment, 'status' ),
 } );
-
-/**
- * Check if a site blacklist contains an email address.
- *
- * @param {String} blacklist A site blacklist.
- * @param {String} email An email address.
- * @returns {Boolean} If the blacklist contains the email address.
- */
-export const isEmailBlacklisted = ( blacklist, email ) =>
-	!! email && !! blacklist ? includes( blacklist.split( '\n' ), email ) : false;


### PR DESCRIPTION
Follow up to #19184

Add the new `CommentAuthorMoreInfo` block.

<img width="765" alt="screen shot 2017-10-27 at 15 21 29" src="https://user-images.githubusercontent.com/2070010/32108743-8bfbe7b2-bb2a-11e7-8733-fa1c1eab3b65.png">

<img width="267" alt="screen shot 2017-10-27 at 15 20 00" src="https://user-images.githubusercontent.com/2070010/32108689-57c2a2ec-bb2a-11e7-9fa7-dc6b17628346.png">


### Testing instructions

Add this code in `CommentList` to display a list of comments using the new design:

```jsx
import Comment from 'my-sites/comments/comment';
//...
{ ! isLoading &&
	map( commentsPage, commentId => (
		<Comment
			commentId={ commentId }
			key={ `comment-${ siteId }-${ commentId }` }
			isBulkMode={ isBulkEdit }
			isSelected={ this.isCommentSelected( commentId ) }
		/>
	) ) }
```

### Diagram

<img width="880" alt="screen shot 2017-10-23 at 21 11 14" src="https://user-images.githubusercontent.com/2070010/31910870-c56f930a-b836-11e7-8a85-0a0e6134cefb.png">
