### PR TITLE
Signup: Domains only flow fix

### DIFF
--- a/client/signup/steps/site-or-domain/index.jsx
+++ b/client/signup/steps/site-or-domain/index.jsx
@@ -38,12 +38,12 @@ class SiteOrDomain extends Component {
 	}
 
 	getDomainName() {
-		const { queryObject, step } = this.props;
+		const { initialContext: { query }, step } = this.props;
 		let domain,
 			isValidDomain = false;
 
-		if ( queryObject && queryObject.new ) {
-			domain = queryObject.new;
+		if ( query && query.new ) {
+			domain = query.new;
 		} else if ( step && step.domainItem ) {
 			domain = step.domainItem.meta;
 		}


### PR DESCRIPTION
Domains only flow was broken by https://github.com/Automattic/wp-calypso/pull/18557

Fix to make it unbroken.