### PR TITLE
Build: Add CSS files in `/public/sections` to the watched hot-reload files list

### DIFF
--- a/server/bundler/css-hot-reload.js
+++ b/server/bundler/css-hot-reload.js
@@ -117,7 +117,13 @@ function setup( io ) {
 
 	fs.readdirSync( PUBLIC_DIR ).forEach( function( file ) {
 		if ( '.css' === file.slice( -4 ) ) {
-			var fullPath = path.join( PUBLIC_DIR, file );
+			const fullPath = path.join( PUBLIC_DIR, file );
+			publicCssFiles[ fullPath ] = md5File.sync( fullPath );
+		}
+	} );
+	fs.readdirSync( path.join( PUBLIC_DIR, 'sections' ) ).forEach( function( file ) {
+		if ( '.css' === file.slice( -4 ) ) {
+			const fullPath = path.join( PUBLIC_DIR, 'sections', file );
 			publicCssFiles[ fullPath ] = md5File.sync( fullPath );
 		}
 	} );


### PR DESCRIPTION
After #18823 was merged, I noticed that hot-reloading CSS wasn't working in the Store extension anymore. I traced this to a list of watched CSS files, `publicCssFiles`, in `/server/bundler/css-hot-reload.js`. The very simple solution I've come to here is just adding the files in `/public/sections` to this list as well.

There are a few things I noticed, but I don't think they're necessarily problems:

- It always reloads `style-debug.css`, even though I'm pretty sure nothing's changed there
- It reloads section files regardless of whether you're on that section— if I make a change in the store extension CSS, it reloads onto any calypso.localhost, even if I'm not on a store page.

This still doesn't watch the files in `public/sections-rtl`, and at this point I'd suggest either something like [`recursive-readdir-sync`](https://github.com/battlejj/recursive-readdir-sync), or looping over an array whitelist of `PUBLIC_DIR`s.

**To test**

- Start calypso: `npm start`
- Load up a store page, ex the dashboard: `/store/:site` (where site is an atomic site)
- Make a change in store CSS (`extensions/woocommerce/style.scss`)
- Open the console and watch for `Building CSS…`, `Reloading CSS… <…woocommerce.css`
- See your changes 🎉