### PR TITLE
Implements connection.send for typing events

### DIFF
--- a/client/components/happychat/composer.jsx
+++ b/client/components/happychat/composer.jsx
@@ -8,7 +8,7 @@ import React from 'react';
 import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { isEmpty } from 'lodash';
+import { get, isEmpty, throttle } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -16,15 +16,10 @@ import { localize } from 'i18n-calypso';
  */
 import { sendChatMessage } from 'state/happychat/connection/actions';
 import { setCurrentMessage } from 'state/happychat/ui/actions';
+import { sendTyping, sendNotTyping } from 'state/happychat/connection/actions';
 import getCurrentMessage from 'state/happychat/selectors/get-happychat-current-message';
 import { canUserSendMessages } from 'state/happychat/selectors';
-import { when, forEach, compose, propEquals, call, prop } from './functional';
 import scrollbleed from './scrollbleed';
-
-// helper function for detecting when a DOM event keycode is pressed
-const returnPressed = propEquals( 'which', 13 );
-// helper function that calls prevents default on the DOM event
-const preventDefault = call( 'preventDefault' );
 
 /*
  * Renders a textarea to be used to comopose a message for the chat.
@@ -37,23 +32,47 @@ export const Composer = createReactClass( {
 		disabled: PropTypes.bool,
 		message: PropTypes.string,
 		onFocus: PropTypes.func,
-		onSendChatMessage: PropTypes.func,
-		onUpdateChatMessage: PropTypes.func,
+		onSendMessage: PropTypes.func,
+		onSendTyping: PropTypes.func,
+		onSendNotTyping: PropTypes.func,
+		onSetCurrentMessage: PropTypes.func,
 		translate: PropTypes.func, // localize HOC
 	},
 
+	onChange( event ) {
+		const { onSendTyping, onSendNotTyping, onSetCurrentMessage } = this.props;
+
+		const sendThrottledTyping = throttle(
+			msg => {
+				onSendTyping( msg );
+			},
+			1000,
+			{ leading: true, trailing: false }
+		);
+
+		const msg = get( event, 'target.value' );
+		onSetCurrentMessage( msg );
+		isEmpty( msg ) ? onSendNotTyping() : sendThrottledTyping( msg );
+	},
+
+	onKeyDown( event ) {
+		const RETURN_KEYCODE = 13;
+		if ( get( event, 'which' ) === RETURN_KEYCODE ) {
+			event.preventDefault();
+			this.sendMessage();
+		}
+	},
+
+	sendMessage() {
+		const { message, onSendMessage, onSendNotTyping } = this.props;
+		if ( ! isEmpty( message ) ) {
+			onSendMessage( message );
+			onSendNotTyping();
+		}
+	},
+
 	render() {
-		const {
-			disabled,
-			message,
-			onFocus,
-			onSendChatMessage,
-			onUpdateChatMessage,
-			translate,
-		} = this.props;
-		const sendMessage = when( () => ! isEmpty( message ), () => onSendChatMessage( message ) );
-		const onChange = compose( prop( 'target.value' ), onUpdateChatMessage );
-		const onKeyDown = when( returnPressed, forEach( preventDefault, sendMessage ) );
+		const { disabled, message, onFocus, translate } = this.props;
 		const composerClasses = classNames( 'happychat__composer', {
 			'is-disabled': disabled,
 		} );
@@ -70,13 +89,13 @@ export const Composer = createReactClass( {
 						onFocus={ onFocus }
 						type="text"
 						placeholder={ translate( 'Type a message …' ) }
-						onChange={ onChange }
-						onKeyDown={ onKeyDown }
+						onChange={ this.onChange }
+						onKeyDown={ this.onKeyDown }
 						disabled={ disabled }
 						value={ message }
 					/>
 				</div>
-				<button className="happychat__submit" disabled={ disabled } onClick={ sendMessage }>
+				<button className="happychat__submit" disabled={ disabled } onClick={ this.sendMessage }>
 					<svg viewBox="0 0 24 24" width="24" height="24">
 						<path d="M2 21l21-9L2 3v7l15 2-15 2z" />
 					</svg>
@@ -91,13 +110,11 @@ const mapState = state => ( {
 	message: getCurrentMessage( state ),
 } );
 
-const mapDispatch = dispatch => ( {
-	onUpdateChatMessage( message ) {
-		dispatch( setCurrentMessage( message ) );
-	},
-	onSendChatMessage( message ) {
-		dispatch( sendChatMessage( message ) );
-	},
-} );
+const mapDispatch = {
+	onSendTyping: sendTyping,
+	onSendNotTyping: sendNotTyping,
+	onSendMessage: sendChatMessage,
+	onSetCurrentMessage: setCurrentMessage,
+};
 
 export default connect( mapState, mapDispatch )( localize( Composer ) );

--- a/client/components/happychat/test/composer.jsx
+++ b/client/components/happychat/test/composer.jsx
@@ -1,0 +1,89 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { shallow } from 'enzyme';
+import { noop } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { Composer } from '../composer';
+
+describe( '<Composer />', () => {
+	describe( 'onChange event ', () => {
+		test( 'should call onSetCurrentMessage property and send a typing event if message is not empty', () => {
+			const onSendNotTyping = jest.fn();
+			const onSendTyping = jest.fn();
+			const onSetCurrentMessage = jest.fn();
+			const wrapper = shallow(
+				<Composer
+					message={ 'hey' }
+					onSetCurrentMessage={ onSetCurrentMessage }
+					onSendTyping={ onSendTyping }
+					onSendNotTyping={ onSendNotTyping }
+					translate={ noop }
+				/>
+			);
+			wrapper.find( 'textarea' ).simulate( 'change', { target: { value: 'hey' } } );
+			expect( onSetCurrentMessage ).toHaveBeenCalled();
+			expect( onSendTyping ).toHaveBeenCalled();
+			expect( onSendNotTyping ).not.toHaveBeenCalled();
+		} );
+
+		test( 'should call onSetCurrentMessage property and send a noTyping event if message is empty', () => {
+			const onSendNotTyping = jest.fn();
+			const onSendTyping = jest.fn();
+			const onSetCurrentMessage = jest.fn();
+			const wrapper = shallow(
+				<Composer
+					message={ '' }
+					onSetCurrentMessage={ onSetCurrentMessage }
+					onSendTyping={ onSendTyping }
+					onSendNotTyping={ onSendNotTyping }
+					translate={ noop }
+				/>
+			);
+			wrapper.find( 'textarea' ).simulate( 'change', { target: { value: '' } } );
+			expect( onSetCurrentMessage ).toHaveBeenCalled();
+			expect( onSendTyping ).not.toHaveBeenCalled();
+			expect( onSendNotTyping ).toHaveBeenCalled();
+		} );
+	} );
+
+	describe( 'onKeyDown event ', () => {
+		test( 'should call message and noTyping props if message is not empty', () => {
+			const onSendMessage = jest.fn();
+			const onSendNotTyping = jest.fn();
+			const wrapper = shallow(
+				<Composer
+					message={ 'hey' }
+					onSendMessage={ onSendMessage }
+					onSendNotTyping={ onSendNotTyping }
+					translate={ noop }
+				/>
+			);
+			wrapper.find( 'textarea' ).simulate( 'keydown', { which: 13, preventDefault: () => {} } );
+			expect( onSendMessage ).toHaveBeenCalled();
+			expect( onSendNotTyping ).toHaveBeenCalled();
+		} );
+
+		test( 'should call message and noTyping props if message is empty', () => {
+			const onSendMessage = jest.fn();
+			const onSendNotTyping = jest.fn();
+			const wrapper = shallow(
+				<Composer
+					message={ '' }
+					onSendMessage={ onSendMessage }
+					onSendNotTyping={ onSendNotTyping }
+					translate={ noop }
+				/>
+			);
+			wrapper.find( 'textarea' ).simulate( 'keydown', { which: 13, preventDefault: () => {} } );
+			expect( onSendMessage ).not.toHaveBeenCalled();
+			expect( onSendNotTyping ).not.toHaveBeenCalled();
+		} );
+	} );
+} );

--- a/client/lib/happychat/connection.js
+++ b/client/lib/happychat/connection.js
@@ -75,17 +75,29 @@ class Connection {
 		return this.openSocket;
 	}
 
-	typing( message ) {
-		this.openSocket.then(
-			socket => socket.emit( 'typing', { message } ),
-			e => debug( 'failed to send typing', e )
-		);
-	}
-
-	notTyping() {
-		this.openSocket.then(
-			socket => socket.emit( 'typing', false ),
-			e => debug( 'failed to send typing', e )
+	/**
+	 * Given a Redux action, emits a SocketIO event.
+	 *
+	 * @param  { Object } action A Redux action with props
+	 *                    {
+	 *                  		event: SocketIO event name,
+	 *                  	  payload: contents to be sent,
+	 *                  	  error: message to be shown should the event fails to be sent,
+	 *                  	}
+	 * @return { Promise } Fulfilled (returns nothing)
+	 *                     or rejected (returns an error message)
+	 */
+	sendNG( action ) {
+		if ( ! this.openSocket ) {
+			return;
+		}
+		return this.openSocket.then(
+			socket => socket.emit( action.event, action.payload ),
+			e => {
+				this.dispatch( receiveError( 'failed to send ' + action.event + ': ' + e ) );
+				// so we can relay the error message, for testing purposes
+				return Promise.reject( e );
+			}
 		);
 	}
 

--- a/client/lib/happychat/test/index.js
+++ b/client/lib/happychat/test/index.js
@@ -13,6 +13,7 @@ import {
 	receiveTranscript,
 	receiveTranscriptTimeout,
 	requestTranscript,
+	sendTyping,
 	setConnected,
 	setDisconnected,
 	setReconnecting,
@@ -234,16 +235,15 @@ describe( 'connection', () => {
 			connection.init( dispatch, config );
 		} );
 
-		// TODO: to be enabled when corresponding connection changes land
-		// test( 'connection.send should emit a SocketIO event', () => {
-		// 	socket.emit( 'init' ); // resolve internal openSocket promise
-		//
-		// 	socket.emit = jest.fn();
-		// 	const action = sendMessage( 'my msg' );
-		// 	return connection.send( action ).then( () => {
-		// 		expect( socket.emit ).toHaveBeenCalledWith( action.event, action.payload );
-		// 	} );
-		// } );
+		test( 'connection.send should emit a SocketIO event', () => {
+			socket.emit( 'init' ); // resolve internal openSocket promise
+
+			socket.emit = jest.fn();
+			const action = sendTyping( 'my msg' );
+			return connection.sendNG( action ).then( () => {
+				expect( socket.emit ).toHaveBeenCalledWith( action.event, action.payload );
+			} );
+		} );
 
 		describe( 'connection.request should emit a SocketIO event', () => {
 			test( 'and dispatch callbackTimeout if request ran out of time', () => {
@@ -303,14 +303,15 @@ describe( 'connection', () => {
 			connection.init( dispatch, config );
 		} );
 
-		// TODO: to be enabled when corresponding connection changes land
-		// test( 'connection.send should dispatch receiveError action', () => {
-		// 	socket.emit = jest.fn();
-		// 	const action = sendMessage( 'content' );
-		// 	return connection.send( action ).catch( e => {
-		// 		expect( dispatch ).toHaveBeenCalledWith( receiveError( action.error + ': ' + e ) );
-		// 	} );
-		// } );
+		test( 'connection.send should dispatch receiveError action', () => {
+			socket.emit = jest.fn();
+			const action = sendTyping( 'content' );
+			return connection.sendNG( action ).catch( e => {
+				expect( dispatch ).toHaveBeenCalledWith(
+					receiveError( 'failed to send ' + action.event + ': ' + e )
+				);
+			} );
+		} );
 
 		test( 'connection.request should dispatch receiveError action', () => {
 			socket.emit = jest.fn();

--- a/client/state/happychat/test/middleware-ng.js
+++ b/client/state/happychat/test/middleware-ng.js
@@ -22,8 +22,8 @@ import {
 	// sendMessage,
 	// sendUserInfo,
 	// sendPreferences,
-	// sendTyping,
-	// sendNotTyping,
+	sendTyping,
+	sendNotTyping,
 } from 'state/happychat/connection/actions';
 // import { selectSiteId } from 'state/help/actions';
 // import { setRoute } from 'state/ui/actions';
@@ -50,6 +50,7 @@ describe( 'middleware', () => {
 		connection = {
 			init: jest.fn(),
 			// send: jest.fn(),
+			sendNG: jest.fn(),
 			request: jest.fn(),
 		};
 
@@ -69,50 +70,50 @@ describe( 'middleware', () => {
 		} );
 	} );
 
-	// TODO: to be enabled when the corresponding changes are merged
-	// describe( 'connection.send actions are connected', () => {
-	// 	test( 'HAPPYCHAT_IO_SEND_MESSAGE_EVENT', () => {
-	// 		const action = sendEvent( 'msg' );
-	// 		actionMiddleware( action );
-	// 		expect( connection.send ).toHaveBeenCalledWith( action );
-	// 	} );
-	//
-	// 	test( 'HAPPYCHAT_IO_SEND_MESSAGE_LOG', () => {
-	// 		const action = sendLog( 'msg' );
-	// 		actionMiddleware( action );
-	// 		expect( connection.send ).toHaveBeenCalledWith( action );
-	// 	} );
-	//
-	// 	test( 'HAPPYCHAT_IO_SEND_MESSAGE_MESSAGE', () => {
-	// 		const action = sendMessage( 'msg' );
-	// 		actionMiddleware( action );
-	// 		expect( connection.send ).toHaveBeenCalledWith( action );
-	// 	} );
-	//
-	// 	test( 'HAPPYCHAT_IO_SEND_MESSAGE_USERINFO', () => {
-	// 		const action = sendUserInfo( { user: 'user' } );
-	// 		actionMiddleware( action );
-	// 		expect( connection.send ).toHaveBeenCalledWith( action );
-	// 	} );
-	//
-	// 	test( 'HAPPYCHAT_IO_SEND_MESSAGE_PREFERENCES', () => {
-	// 		const action = sendPreferences( 'locale', [] );
-	// 		actionMiddleware( action );
-	// 		expect( connection.send ).toHaveBeenCalledWith( action );
-	// 	} );
-	//
-	// 	test( 'HAPPYCHAT_IO_SEND_MESSAGE_TYPING (sendTyping)', () => {
-	// 		const action = sendTyping( 'msg' );
-	// 		actionMiddleware( action );
-	// 		expect( connection.send ).toHaveBeenCalledWith( action );
-	// 	} );
-	//
-	// 	test( 'HAPPYCHAT_IO_SEND_MESSAGE_TYPING (sendNotTyping)', () => {
-	// 		const action = sendNotTyping( 'msg' );
-	// 		actionMiddleware( action );
-	// 		expect( connection.send ).toHaveBeenCalledWith( action );
-	// 	} );
-	// } );
+	// TODO: to be fully enabled when the corresponding changes are merged
+	describe( 'connection.send actions are connected', () => {
+		// 	test( 'HAPPYCHAT_IO_SEND_MESSAGE_EVENT', () => {
+		// 		const action = sendEvent( 'msg' );
+		// 		actionMiddleware( action );
+		// 		expect( connection.send ).toHaveBeenCalledWith( action );
+		// 	} );
+		//
+		// 	test( 'HAPPYCHAT_IO_SEND_MESSAGE_LOG', () => {
+		// 		const action = sendLog( 'msg' );
+		// 		actionMiddleware( action );
+		// 		expect( connection.send ).toHaveBeenCalledWith( action );
+		// 	} );
+		//
+		// 	test( 'HAPPYCHAT_IO_SEND_MESSAGE_MESSAGE', () => {
+		// 		const action = sendMessage( 'msg' );
+		// 		actionMiddleware( action );
+		// 		expect( connection.send ).toHaveBeenCalledWith( action );
+		// 	} );
+		//
+		// 	test( 'HAPPYCHAT_IO_SEND_MESSAGE_USERINFO', () => {
+		// 		const action = sendUserInfo( { user: 'user' } );
+		// 		actionMiddleware( action );
+		// 		expect( connection.send ).toHaveBeenCalledWith( action );
+		// 	} );
+		//
+		// 	test( 'HAPPYCHAT_IO_SEND_MESSAGE_PREFERENCES', () => {
+		// 		const action = sendPreferences( 'locale', [] );
+		// 		actionMiddleware( action );
+		// 		expect( connection.send ).toHaveBeenCalledWith( action );
+		// 	} );
+
+		test( 'HAPPYCHAT_IO_SEND_MESSAGE_TYPING (sendTyping)', () => {
+			const action = sendTyping( 'msg' );
+			actionMiddleware( action );
+			expect( connection.sendNG ).toHaveBeenCalledWith( action );
+		} );
+
+		test( 'HAPPYCHAT_IO_SEND_MESSAGE_TYPING (sendNotTyping)', () => {
+			const action = sendNotTyping( 'msg' );
+			actionMiddleware( action );
+			expect( connection.sendNG ).toHaveBeenCalledWith( action );
+		} );
+	} );
 
 	describe( 'connection.request actions are connected', () => {
 		test( 'HAPPYCHAT_IO_REQUEST_TRANSCRIPT', () => {

--- a/client/state/happychat/test/middleware.js
+++ b/client/state/happychat/test/middleware.js
@@ -31,7 +31,6 @@ import {
 	HAPPYCHAT_BLUR,
 	HAPPYCHAT_SEND_USER_INFO,
 	HAPPYCHAT_SEND_MESSAGE,
-	HAPPYCHAT_SET_CURRENT_MESSAGE,
 } from 'state/action-types';
 import { useSandbox } from 'test/helpers/use-sinon';
 
@@ -109,30 +108,13 @@ describe( 'middleware', () => {
 	} );
 
 	describe( 'HAPPYCHAT_SEND_MESSAGE action', () => {
-		test( 'should send the message through the connection and send a notTyping signal', () => {
+		test( 'should send the message through the connection', () => {
 			const action = { type: HAPPYCHAT_SEND_MESSAGE, message: 'Hello world' };
 			const connection = {
 				send: spy(),
-				notTyping: spy(),
 			};
 			middleware( connection )( { getState: noop } )( noop )( action );
 			expect( connection.send ).to.have.been.calledWith( action.message );
-			expect( connection.notTyping ).to.have.been.calledOnce;
-		} );
-	} );
-
-	describe( 'HAPPYCHAT_SET_CURRENT_MESSAGE action', () => {
-		test( 'should send the connection a typing signal when a message is present', () => {
-			const action = { type: HAPPYCHAT_SET_CURRENT_MESSAGE, message: 'Hello world' };
-			const connection = { typing: spy() };
-			middleware( connection )( { getState: noop } )( noop )( action );
-			expect( connection.typing ).to.have.been.calledWith( action.message );
-		} );
-		test( 'should send the connection a notTyping signal when the message is blank', () => {
-			const action = { type: HAPPYCHAT_SET_CURRENT_MESSAGE, message: '' };
-			const connection = { notTyping: spy() };
-			middleware( connection )( { getState: noop } )( noop )( action );
-			expect( connection.notTyping ).to.have.been.calledOnce;
 		} );
 	} );
 


### PR DESCRIPTION
Master issue: https://github.com/Automattic/wp-calypso/issues/18670

This PR implements `connection.sendNG` for typing events. Note that the method was called `sendNG` to avoid conflicts with the existing `send` method. The NG suffix will be removed after every action is ported to the new system.

This PR builds upon https://github.com/Automattic/wp-calypso/pull/19227 and needs it to be merged first. 19227 is set as the base branch for ease of review.

### Test

`npm run test-client happychat`

Manually: 

* Start a new chat session and make sure that customer typing events are signaled to the operator.
