### PR TITLE
Comments: Add post view

### DIFF
--- a/client/my-sites/comments/comment-list/comment-list-header.jsx
+++ b/client/my-sites/comments/comment-list/comment-list-header.jsx
@@ -15,6 +15,7 @@ import QueryPosts from 'components/data/query-posts';
 import { convertDateToUserLocation } from 'components/post-schedule/utils';
 import { decodeEntities, stripHTML } from 'lib/formatting';
 import { gmtOffset, timezone } from 'lib/site/utils';
+import { getSiteComments } from 'state/selectors';
 import { getSitePost } from 'state/posts/selectors';
 import { getSelectedSite, getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 
@@ -57,9 +58,13 @@ const mapStateToProps = ( state, { postId } ) => {
 	const post = getSitePost( state, siteId, postId );
 
 	const postDate = get( post, 'date' );
-	const postTitle =
-		decodeEntities( stripHTML( get( post, 'title' ) ) ) ||
-		decodeEntities( stripHTML( get( post, 'excerpt' ) ) );
+	const postTitle = decodeEntities(
+		stripHTML(
+			get( post, 'title' ) ||
+				get( post, 'excerpt' ) ||
+				get( getSiteComments( state, siteId ), '[0].post.title' )
+		)
+	);
 
 	return {
 		postDate,

--- a/client/my-sites/comments/comment-list/comment-list-header.jsx
+++ b/client/my-sites/comments/comment-list/comment-list-header.jsx
@@ -1,0 +1,73 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+import { get, noop } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import HeaderCake from 'components/header-cake';
+import QueryPosts from 'components/data/query-posts';
+import { convertDateToUserLocation } from 'components/post-schedule/utils';
+import { decodeEntities, stripHTML } from 'lib/formatting';
+import { gmtOffset, timezone } from 'lib/site/utils';
+import { getSitePost } from 'state/posts/selectors';
+import { getSelectedSite, getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
+
+export const CommentListHeader = ( {
+	postDate,
+	postId,
+	postTitle,
+	site,
+	siteId,
+	siteSlug,
+	translate,
+} ) => {
+	const formattedDate = postDate
+		? convertDateToUserLocation( postDate, timezone( site ), gmtOffset( site ) ).format( 'll LT' )
+		: '';
+
+	return (
+		<div className="comment-list__header">
+			<QueryPosts siteId={ siteId } postId={ postId } />
+
+			<HeaderCake
+				actionHref={ `/comments/all/${ siteSlug }/${ postId }` }
+				actionIcon="visible"
+				actionOnClick={ noop }
+				actionText={ translate( 'View Post' ) }
+				backHref={ `/comments/all/${ siteSlug }` }
+			>
+				<div className="comment-list__header-title">{ postTitle }</div>
+				<div className="comment-list__header-date">{ formattedDate }</div>
+			</HeaderCake>
+		</div>
+	);
+};
+
+const mapStateToProps = ( state, { postId } ) => {
+	const site = getSelectedSite( state );
+	const siteId = getSelectedSiteId( state );
+	const siteSlug = getSelectedSiteSlug( state );
+
+	const post = getSitePost( state, siteId, postId );
+
+	const postDate = get( post, 'date' );
+	const postTitle =
+		decodeEntities( stripHTML( get( post, 'title' ) ) ) ||
+		decodeEntities( stripHTML( get( post, 'excerpt' ) ) );
+
+	return {
+		postDate,
+		postTitle,
+		site,
+		siteId,
+		siteSlug,
+	};
+};
+
+export default connect( mapStateToProps )( localize( CommentListHeader ) );

--- a/client/my-sites/comments/comment-list/comment-list-header.jsx
+++ b/client/my-sites/comments/comment-list/comment-list-header.jsx
@@ -58,9 +58,7 @@ const mapStateToProps = ( state, { postId } ) => {
 	const site = getSelectedSite( state );
 	const siteId = getSelectedSiteId( state );
 	const siteSlug = getSelectedSiteSlug( state );
-
 	const post = getSitePost( state, siteId, postId );
-
 	const postDate = get( post, 'date' );
 	const postTitle = decodeEntities(
 		stripHTML(
@@ -69,7 +67,6 @@ const mapStateToProps = ( state, { postId } ) => {
 				get( getSiteComments( state, siteId ), '[0].post.title' )
 		)
 	);
-
 	const isJetpack = isJetpackSite( state, siteId );
 
 	return {

--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -190,7 +190,7 @@ export class CommentList extends Component {
 	};
 
 	setBulkStatus = status => () => {
-		const { recordBulkAction, status: listStatus } = this.props;
+		const { postId, recordBulkAction, status: listStatus } = this.props;
 		const { selectedComments } = this.state;
 
 		this.props.removeNotice( 'comment-notice-bulk' );
@@ -213,7 +213,7 @@ export class CommentList extends Component {
 			} );
 		} );
 
-		recordBulkAction( status, selectedComments.length, listStatus );
+		recordBulkAction( status, selectedComments.length, listStatus, !! postId ? 'post' : 'site' );
 
 		this.showBulkNotice( status );
 

--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -8,7 +8,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { each, find, get, map, orderBy, size, slice, uniq } from 'lodash';
+import { each, filter, find, get, map, orderBy, size, slice, uniq } from 'lodash';
 import ReactCSSTransitionGroup from 'react-transition-group/CSSTransitionGroup';
 
 /**
@@ -534,8 +534,12 @@ export class CommentList extends Component {
 	}
 }
 
-const mapStateToProps = ( state, { siteId, status } ) => {
-	const comments = map( getSiteCommentsTree( state, siteId, status ), 'commentId' );
+const mapStateToProps = ( state, { postId, siteId, status } ) => {
+	const siteCommentsTree = getSiteCommentsTree( state, siteId, status );
+	const comments = !! postId
+		? map( filter( siteCommentsTree, { postId } ), 'commentId' )
+		: map( siteCommentsTree, 'commentId' );
+
 	const isLoading = ! isCommentsTreeInitialized( state, siteId, status );
 	return {
 		comments,

--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -448,6 +448,7 @@ export class CommentList extends Component {
 					commentsPage={ commentsPage }
 					isBulkEdit={ isBulkEdit }
 					isSelectedAll={ this.isSelectedAll() }
+					postId={ postId }
 					selectedCount={ size( selectedComments ) }
 					setBulkStatus={ this.setBulkStatus }
 					setSortOrder={ this.setSortOrder }

--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -27,7 +27,8 @@ import { removeNotice, successNotice } from 'state/notices/actions';
 import Comment from 'my-sites/comments/comment';
 import CommentDetail from 'blocks/comment-detail';
 import CommentDetailPlaceholder from 'blocks/comment-detail/comment-detail-placeholder';
-import CommentNavigation from '../comment-navigation';
+import CommentListHeader from 'my-sites/comments/comment-list/comment-list-header';
+import CommentNavigation from 'my-sites/comments/comment-navigation';
 import EmptyContent from 'components/empty-content';
 import Pagination from 'components/pagination';
 import QuerySiteCommentsList from 'components/data/query-site-comments-list';
@@ -408,6 +409,7 @@ export class CommentList extends Component {
 			isCommentsTreeSupported,
 			isLoading,
 			page,
+			postId,
 			siteBlacklist,
 			siteId,
 			siteFragment,
@@ -439,6 +441,8 @@ export class CommentList extends Component {
 					/>
 				) }
 				{ isCommentsTreeSupported && <QuerySiteCommentsTree siteId={ siteId } status={ status } /> }
+
+				{ !! postId && <CommentListHeader postId={ postId } /> }
 
 				<CommentNavigation
 					commentsPage={ commentsPage }

--- a/client/my-sites/comments/comment-navigation/index.jsx
+++ b/client/my-sites/comments/comment-navigation/index.jsx
@@ -82,10 +82,15 @@ export class CommentNavigation extends Component {
 		return navItems;
 	};
 
-	getStatusPath = status =>
-		'unapproved' !== status
-			? `/comments/${ status }/${ this.props.siteFragment }`
-			: `/comments/pending/${ this.props.siteFragment }`;
+	getStatusPath = status => {
+		const { postId } = this.props;
+
+		const appendPostId = !! postId ? `/${ postId }` : '';
+
+		return 'unapproved' !== status
+			? `/comments/${ status }/${ this.props.siteFragment }${ appendPostId }`
+			: `/comments/pending/${ this.props.siteFragment }${ appendPostId }`;
+	};
 
 	statusHasAction = action => includes( bulkActions[ this.props.status ], action );
 

--- a/client/my-sites/comments/comment/comment-post-link.jsx
+++ b/client/my-sites/comments/comment/comment-post-link.jsx
@@ -23,6 +23,7 @@ const CommentPostLink = ( {
 	postTitle,
 	siteId,
 	siteSlug,
+	status,
 	translate,
 } ) => (
 	<div className="comment__post-link">
@@ -30,7 +31,7 @@ const CommentPostLink = ( {
 
 		<Gridicon icon="chevron-right" size={ 18 } />
 
-		<a href={ `/comments/all/${ siteSlug }/${ postId }` }>
+		<a href={ `/comments/${ status }/${ siteSlug }/${ postId }` }>
 			{ postTitle || translate( 'Untitled' ) }
 		</a>
 	</div>
@@ -41,6 +42,7 @@ const mapStateToProps = ( state, { commentId } ) => {
 	const siteSlug = getSelectedSiteSlug( state );
 
 	const comment = getSiteComment( state, siteId, commentId );
+	const commentStatus = get( comment, 'status' );
 
 	const postId = get( comment, 'post.ID' );
 	const post = getSitePost( state, siteId, postId );
@@ -54,6 +56,7 @@ const mapStateToProps = ( state, { commentId } ) => {
 		postTitle,
 		siteSlug,
 		siteId,
+		status: 'unapproved' === commentStatus ? 'pending' : commentStatus,
 	};
 };
 

--- a/client/my-sites/comments/main.jsx
+++ b/client/my-sites/comments/main.jsx
@@ -24,6 +24,7 @@ export class CommentsManagement extends Component {
 	static propTypes = {
 		comments: PropTypes.array,
 		page: PropTypes.number,
+		postId: PropTypes.number,
 		showPermissionError: PropTypes.bool,
 		siteId: PropTypes.number,
 		siteFragment: PropTypes.oneOfType( [ PropTypes.string, PropTypes.number ] ),
@@ -38,9 +39,10 @@ export class CommentsManagement extends Component {
 
 	render() {
 		const {
-			showPermissionError,
-			page,
 			changePage,
+			page,
+			postId,
+			showPermissionError,
 			siteId,
 			siteFragment,
 			status,
@@ -65,12 +67,13 @@ export class CommentsManagement extends Component {
 				) }
 				{ ! showPermissionError && (
 					<CommentList
-						page={ page }
 						changePage={ changePage }
+						order={ 'desc' }
+						page={ page }
+						postId={ postId }
 						siteId={ siteId }
 						siteFragment={ siteFragment }
 						status={ status }
-						order={ 'desc' }
 					/>
 				) }
 			</Main>

--- a/client/my-sites/comments/style.scss
+++ b/client/my-sites/comments/style.scss
@@ -1,5 +1,6 @@
+/** @format */
 .comment-navigation {
-	@include breakpoint( "<480px" ) {
+	@include breakpoint( '<480px' ) {
 		.section-nav__mobile-header:after {
 			padding-left: 8px;
 		}
@@ -20,13 +21,13 @@
 .comment-navigation.is-bulk-edit {
 	padding-right: 0;
 
-	@include breakpoint( "<480px" ) {
+	@include breakpoint( '<480px' ) {
 		.section-nav__mobile-header {
 			display: none;
 		}
 
 		.comment-navigation__bulk-count {
-			width: calc( 100% - 70px );
+			width: calc(100% - 70px);
 		}
 
 		.comment-navigation__close-bulk {
@@ -73,6 +74,19 @@
 	}
 }
 
+.comment-list__header-title {
+	font-weight: 600;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+.comment-list__header-date {
+	font-size: 13px;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
 .comment-list .pagination {
 	margin-top: 16px;
 }
@@ -81,7 +95,7 @@
 	display: none;
 
 	&.comment-list__transition-enter-active {
-		animation: comment-list__transition-enter .15s linear;
+		animation: comment-list__transition-enter 0.15s linear;
 	}
 }
 
@@ -90,7 +104,7 @@
 
 	&.comment-list__transition-leave-active {
 		opacity: 0.01;
-		transition: opacity .15s linear;
+		transition: opacity 0.15s linear;
 	}
 }
 


### PR DESCRIPTION
Closes #18315, #18332

Introduces a new Post View in Comments Management.

<img width="1054" alt="screen shot 2017-10-27 at 17 13 58" src="https://user-images.githubusercontent.com/2070010/32114085-458bc59e-bb3a-11e7-8ffc-cc0a02e8e830.png">

### Changes

- Add a new header for Post View containing:
  - The post title and date.
  - A link to the post in the Reader (or to the front end for Jetpack sites), with tracking enabled
  - A Back link to the Site View.
- Update `CommentNavigation` to handle the `postId`.
- Modify the `CommentDetailPost` post link to open the Post View instead of the Reader (or the front end for Jetpack sites).
This link points to the Post View, filtered on the comment status.

### Discussion

- The `CommentDetailPost` post link can be either a simple post link or a post link anchored to a precise comment.
In this case, I've chosen to still open the Post View (at the first page of the comment status list).
Though, we (cc @megsfulton) should decide if we want to:
  - Open the Comment View (eventually).
  - Open the post on the Reader/Front-end scrolled to the comment.
  - Open the Post View scrolled to the comment (but mind the pagination!).
- The current comments filtering is performed in the `CommentList`'s `mapStateToProps`. It should go into its own selector, but I've chosen to avoid doing so here, because new global selector increase the LOC by quite a lot. 🙂 

### Note

The Post View is currently limited to `dev` only.