### PR TITLE
Update getDomainProductSlug slug generation logic

### DIFF
--- a/client/lib/domains/index.js
+++ b/client/lib/domains/index.js
@@ -5,7 +5,7 @@
  */
 
 import inherits from 'inherits';
-import { some, includes, find } from 'lodash';
+import { includes, find, replace, some } from 'lodash';
 
 /**
  * Internal dependencies
@@ -189,11 +189,23 @@ function getTld( domainName ) {
 	return tld;
 }
 
+function getDomainProductSlug( domain ) {
+	const tld = getTld( domain );
+	const tldSlug = replace( tld, /\./g, 'dot' );
+
+	if ( includes( [ 'com', 'net', 'org' ], tldSlug ) ) {
+		return 'domain_reg';
+	}
+
+	return `dot${ tldSlug }_domain`;
+}
+
 export {
 	canAddGoogleApps,
 	canRedirect,
 	checkDomainAvailability,
 	checkInboundTransferStatus,
+	getDomainProductSlug,
 	getFixedDomainSearch,
 	getGoogleAppsSupportedDomains,
 	getPrimaryDomain,

--- a/client/signup/steps/site-or-domain/index.jsx
+++ b/client/signup/steps/site-or-domain/index.jsx
@@ -7,7 +7,7 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { isEmpty, includes } from 'lodash';
+import { isEmpty } from 'lodash';
 
 /**
  * Internal dependencies
@@ -24,19 +24,9 @@ import ExistingSite from 'signup/steps/design-type-with-store/existing-site';
 import NavigationLink from 'signup/navigation-link';
 import QueryProductsList from 'components/data/query-products-list';
 import { getAvailableProductsList } from 'state/products-list/selectors';
-import { getTld } from 'lib/domains';
+import { getDomainProductSlug } from 'lib/domains';
 
 class SiteOrDomain extends Component {
-	getDomainProductSlug( domain ) {
-		const tld = getTld( domain );
-
-		if ( includes( [ 'com', 'net', 'org' ], tld ) ) {
-			return 'domain_reg';
-		}
-
-		return `dot${ tld }_domain`;
-	}
-
 	getDomainName() {
 		const { initialContext: { query }, step } = this.props;
 		let domain,
@@ -50,7 +40,7 @@ class SiteOrDomain extends Component {
 
 		if ( domain ) {
 			if ( domain.split( '.' ).length > 1 ) {
-				const productSlug = this.getDomainProductSlug( domain );
+				const productSlug = getDomainProductSlug( domain );
 
 				isValidDomain = !! this.props.productsList[ productSlug ];
 			}
@@ -140,7 +130,7 @@ class SiteOrDomain extends Component {
 		const { stepName, goToStep, goToNextStep } = this.props;
 
 		const domain = this.getDomainName();
-		const productSlug = this.getDomainProductSlug( domain );
+		const productSlug = getDomainProductSlug( domain );
 		const domainItem = cartItems.domainRegistration( { productSlug, domain } );
 		const siteUrl = domain;
 


### PR DESCRIPTION
The existing slug generation approach assumed a single dot in the domain when building the string. This approach does a find and replace of any . characters with ‘dot’ to match all expected product slugs.

Use in concert with D7992 and test store products.