### PR TITLE
Update the CommentButton block to be able to accept a link and target.

### DIFF
--- a/client/blocks/comment-button/README.md
+++ b/client/blocks/comment-button/README.md
@@ -18,7 +18,9 @@ render() {
 #### Props
 
 * `commentCount`: Number indicating the number of comments to be displayed next to the button.
+* `link`: String URL destination to be used with a `tagName` of `a`. Defaults to `null`.
 * `onClick`: Function to be executed when the user clicks the button.
-* `tagName`: String with the HTML tag we are going to use to render the component. Defaults to 'li'.
 * `showLabel`: Boolean indicating whether or not the label with the comments count is visible. Defaults to `true`.
 * `size`: Number with the size of the comments icon to be displayed. Defaults to 24.
+* `tagName`: String with the HTML tag we are going to use to render the component. Defaults to 'li'.
+* `target`: String `target` attribute to be used with a `tagName` of `a`. Defaults to `null`.

--- a/client/blocks/comment-button/index.jsx
+++ b/client/blocks/comment-button/index.jsx
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { noop } from 'lodash';
+import { isNull, noop, omitBy } from 'lodash';
 
 /**
  * Internal dependencies
@@ -18,29 +18,46 @@ import { getPostTotalCommentsCount } from 'state/comments/selectors';
 
 class CommentButton extends Component {
 	static propTypes = {
-		onClick: PropTypes.func,
-		tagName: PropTypes.string,
 		commentCount: PropTypes.number,
+		link: PropTypes.string,
+		onClick: PropTypes.func,
 		showLabel: PropTypes.bool,
+		tagName: PropTypes.string,
+		target: PropTypes.string,
 	};
 
 	static defaultProps = {
-		onClick: noop,
-		tagName: 'li',
-		size: 24,
 		commentCount: 0,
+		link: null,
+		onClick: noop,
 		showLabel: true,
+		size: 24,
+		tagName: 'li',
+		target: null,
 	};
 
 	render() {
-		const { translate, commentCount, onClick, showLabel, tagName: containerTag } = this.props;
+		const {
+			commentCount,
+			link,
+			onClick,
+			showLabel,
+			tagName: containerTag,
+			target,
+			translate,
+		} = this.props;
 
 		return React.createElement(
 			containerTag,
-			{
-				className: 'comment-button',
-				onClick,
-			},
+			omitBy(
+				{
+					className: 'comment-button',
+					href: link,
+					onClick,
+					target,
+				},
+				isNull
+			),
 			<Gridicon icon="comment" size={ this.props.size } className="comment-button__icon" />,
 			<span className="comment-button__label">
 				{ commentCount > 0 && (

--- a/client/blocks/comment-button/index.jsx
+++ b/client/blocks/comment-button/index.jsx
@@ -19,7 +19,7 @@ import { getPostTotalCommentsCount } from 'state/comments/selectors';
 class CommentButton extends Component {
 	static propTypes = {
 		commentCount: PropTypes.number,
-		link: PropTypes.string,
+		href: PropTypes.string,
 		onClick: PropTypes.func,
 		showLabel: PropTypes.bool,
 		tagName: PropTypes.string,
@@ -28,7 +28,7 @@ class CommentButton extends Component {
 
 	static defaultProps = {
 		commentCount: 0,
-		link: null,
+		href: null,
 		onClick: noop,
 		showLabel: true,
 		size: 24,
@@ -52,9 +52,9 @@ class CommentButton extends Component {
 			omitBy(
 				{
 					className: 'comment-button',
-					href: link,
+					href: 'a' === tagName ? href : null,
 					onClick,
-					target,
+					target: 'a' === tagName ? target : null,
 				},
 				isNull
 			),

--- a/client/blocks/comment-button/index.jsx
+++ b/client/blocks/comment-button/index.jsx
@@ -37,18 +37,10 @@ class CommentButton extends Component {
 	};
 
 	render() {
-		const {
-			commentCount,
-			link,
-			onClick,
-			showLabel,
-			tagName: containerTag,
-			target,
-			translate,
-		} = this.props;
+		const { commentCount, href, onClick, showLabel, tagName, target, translate } = this.props;
 
 		return React.createElement(
-			containerTag,
+			tagName,
 			omitBy(
 				{
 					className: 'comment-button',


### PR DESCRIPTION
This PR updates the `CommentButton` block to accept `link` and `target` props, allowing the component to better use anchor (`a`) elements as a link to elsewhere.

<img width="1174" alt="screen shot 2017-10-24 at 5 04 36 pm" src="https://user-images.githubusercontent.com/349751/32118960-85d5bfd8-bb08-11e7-89f3-43018b085615.png">

With this change, we can then point the Post card's `CommentButton` at `/posts/:site` to the upcoming post-specific view of comments (`/comments/:status/:site/:post-id`).

See: https://github.com/Automattic/wp-calypso/issues/18332

**Testing**
* Load this branch, and go to Blog Posts in the sidebar. Verify that the comments icon indicated in the screenshot above displays the post's comments properly, with no errors.
* In `/client/blocks/post-actions/index.jsx` at L76, change the `tagName` to an anchor and add a `link` and `target` to test with:
```
tagName="a"
link="http://google.com"
target="_blank"
```