### PR TITLE
Simple Payment: Vertical alignment fix for Simple Payment button in Editor

### DIFF
--- a/client/components/tinymce/plugins/wpcom-view/views/simple-payments/style.scss
+++ b/client/components/tinymce/plugins/wpcom-view/views/simple-payments/style.scss
@@ -116,14 +116,15 @@
 	position: relative;
 	text-align: left;
 	text-shadow: rgb(204, 204, 204) 0px -1px;
-	top: -3px;
+	top: 50%;
 	width: 43px;
-	perspective-origin: 21.125px 6px;
-	font-family: "Helvetica Neue",Helvetica, Arial, sans-serif;
+	font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
 	font-size: 10px;
 	font-style: normal;
 	font-weight: 500;
 	line-height: normal;
+	transform: translateY(-50%);
+	vertical-align: top;
 }
 
 .wpview-type-simple-payments_paypal-logo {


### PR DESCRIPTION
For some reason, the vertical alignment is now a bit off. This PR fixes the issue.

Before:
<img width="525" alt="screen shot 2017-10-27 at 19 26 58" src="https://user-images.githubusercontent.com/908665/32119631-be3cad06-bb4d-11e7-8e43-39e2c1bcb433.png">

After:
<img width="520" alt="screen shot 2017-10-27 at 19 26 05" src="https://user-images.githubusercontent.com/908665/32119638-c60c5f72-bb4d-11e7-99b3-73f81c4f1bfc.png">

