### PR TITLE
Store Orders: Add products to existing orders

### DIFF
--- a/client/extensions/woocommerce/app/order/order-details/add-items.js
+++ b/client/extensions/woocommerce/app/order/order-details/add-items.js
@@ -11,6 +11,7 @@ import Gridicon from 'gridicons';
  */
 import Button from 'components/button';
 import OrderFeeDialog from './fee-dialog';
+import OrderProductDialog from './product-dialog';
 
 class OrderAddItems extends Component {
 	state = {
@@ -35,6 +36,10 @@ class OrderAddItems extends Component {
 				</Button>
 				<OrderFeeDialog
 					isVisible={ 'fee' === this.state.showDialog }
+					closeDialog={ this.toggleDialog( false ) }
+				/>
+				<OrderProductDialog
+					isVisible={ 'product' === this.state.showDialog }
 					closeDialog={ this.toggleDialog( false ) }
 				/>
 			</div>

--- a/client/extensions/woocommerce/app/order/order-details/product-dialog.js
+++ b/client/extensions/woocommerce/app/order/order-details/product-dialog.js
@@ -62,7 +62,6 @@ class OrderProductDialog extends Component {
 			const line = {
 				id: uniqueId( 'fee_' ),
 				name: item.name || '',
-				sku: item.sku,
 				price: item.price,
 				subtotal: item.price,
 				total: item.price,

--- a/client/extensions/woocommerce/app/order/order-details/product-dialog.js
+++ b/client/extensions/woocommerce/app/order/order-details/product-dialog.js
@@ -23,6 +23,7 @@ import ProductSearch from 'woocommerce/components/product-search';
 
 class OrderProductDialog extends Component {
 	static propTypes = {
+		allProducts: PropTypes.array.isRequired,
 		isVisible: PropTypes.bool.isRequired,
 		editOrder: PropTypes.func.isRequired,
 		order: PropTypes.shape( {

--- a/client/extensions/woocommerce/app/order/order-details/product-dialog.js
+++ b/client/extensions/woocommerce/app/order/order-details/product-dialog.js
@@ -1,0 +1,107 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Button from 'components/button';
+import Dialog from 'components/dialog';
+import { editOrder } from 'woocommerce/state/ui/orders/actions';
+import { getOrderWithEdits } from 'woocommerce/state/ui/orders/selectors';
+import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
+import ProductSearch from 'woocommerce/components/product-search';
+
+class OrderProductDialog extends Component {
+	static propTypes = {
+		isVisible: PropTypes.bool.isRequired,
+		editOrder: PropTypes.func.isRequired,
+		order: PropTypes.shape( {
+			id: PropTypes.number.isRequired,
+		} ),
+		siteId: PropTypes.number.isRequired,
+		translate: PropTypes.func.isRequired,
+	};
+
+	state = {
+		products: [],
+	};
+
+	componentWillUpdate( nextProps ) {
+		// Dialog is being closed, clear the state
+		if ( this.props.isVisible && ! nextProps.isVisible ) {
+			this.setState( {
+				products: [],
+			} );
+		}
+	}
+
+	handleChange = products => {
+		this.setState( {
+			products,
+		} );
+	};
+
+	handleProductSave = () => {
+		// map product IDs to products/variations:
+		// {
+		// 	product_id: item.id,
+		// 	name: item.name,
+		// 	sku: item.sku,
+		// 	price: item.price,
+		// 	subtotal: item.price,
+		// 	total: item.price,
+		// 	quantity: 1,
+		// }
+		this.props.closeDialog();
+	};
+
+	render() {
+		const { closeDialog, isVisible, translate } = this.props;
+		const dialogClass = 'woocommerce order-details__dialog'; // eslint/css specificity hack
+
+		const dialogButtons = [
+			<Button onClick={ closeDialog }>{ translate( 'Cancel' ) }</Button>,
+			<Button primary onClick={ this.handleProductSave } disabled={ ! this.state.products.length }>
+				{ translate( 'Add Product' ) }
+			</Button>,
+		];
+
+		return (
+			<Dialog
+				isVisible={ isVisible }
+				onClose={ closeDialog }
+				className={ dialogClass }
+				buttons={ dialogButtons }
+			>
+				<h1>{ translate( 'Add a product' ) }</h1>
+				<p>
+					{ translate(
+						'Add products by searching for them. You can change the quantity after adding them.'
+					) }
+				</p>
+				<ProductSearch onChange={ this.handleChange } value={ this.state.products } />
+			</Dialog>
+		);
+	}
+}
+
+export default connect(
+	state => {
+		const site = getSelectedSiteWithFallback( state );
+		const siteId = site ? site.ID : false;
+		const order = getOrderWithEdits( state );
+
+		return {
+			siteId,
+			order,
+		};
+	},
+	dispatch => bindActionCreators( { editOrder }, dispatch )
+)( localize( OrderProductDialog ) );

--- a/client/extensions/woocommerce/app/order/order-details/product-dialog.js
+++ b/client/extensions/woocommerce/app/order/order-details/product-dialog.js
@@ -120,10 +120,16 @@ class OrderProductDialog extends Component {
 		const { closeDialog, isVisible, translate } = this.props;
 		const dialogClass = 'woocommerce order-details__dialog'; // eslint/css specificity hack
 
+		// Fake 1 so the string is already at singular when the first item is selected
+		const productsCount = this.state.products.length ? this.state.products.length : 1;
+		const buttonLabel = translate( 'Add Product', 'Add Products', {
+			count: productsCount,
+		} );
+
 		const dialogButtons = [
 			<Button onClick={ closeDialog }>{ translate( 'Cancel' ) }</Button>,
 			<Button primary onClick={ this.handleProductSave } disabled={ ! this.state.products.length }>
-				{ translate( 'Add Product' ) }
+				{ buttonLabel }
 			</Button>,
 		];
 

--- a/client/extensions/woocommerce/app/order/order-details/table.js
+++ b/client/extensions/woocommerce/app/order/order-details/table.js
@@ -173,7 +173,6 @@ class OrderDetailsTable extends Component {
 				<Button
 					compact
 					borderless
-					icon
 					aria-label={ translate( 'Remove %(itemName)s from this order', {
 						args: { itemName: item.name },
 					} ) }

--- a/client/extensions/woocommerce/app/order/order-details/table.js
+++ b/client/extensions/woocommerce/app/order/order-details/table.js
@@ -100,7 +100,10 @@ class OrderDetailsTable extends Component {
 	onChange = event => {
 		const { order } = this.props;
 		// Name is `quantity-x`, where x is the ID of the item
-		const id = parseInt( event.target.name.split( '-' )[ 1 ] );
+		let id = event.target.name.split( '-' )[ 1 ];
+		if ( ! isNaN( parseInt( id ) ) ) {
+			id = parseInt( id );
+		}
 		const item = find( order.line_items, { id } );
 		if ( ! item ) {
 			return;

--- a/client/extensions/woocommerce/state/sites/products/selectors.js
+++ b/client/extensions/woocommerce/state/sites/products/selectors.js
@@ -4,7 +4,7 @@
  * @format
  */
 
-import { get, find } from 'lodash';
+import { get, find, flatten, map } from 'lodash';
 
 /**
  * Internal dependencies
@@ -31,6 +31,28 @@ export const getProduct = ( state, productId, siteId = getSelectedSiteId( state 
  */
 export const getAllProducts = ( state, siteId = getSelectedSiteId( state ) ) => {
 	return get( state, [ 'extensions', 'woocommerce', 'sites', siteId, 'products', 'products' ], [] );
+};
+
+/**
+ * @param {Object} state Whole Redux state tree
+ * @param {Number} [siteId] Site ID to check. If not provided, the Site ID selected in the UI will be used
+ * @return {Array}  The entire list of products for this site with variations inline as "products"
+ */
+export const getAllProductsWithVariations = ( state, siteId = getSelectedSiteId( state ) ) => {
+	const products = get( state, `extensions.woocommerce.sites[${ siteId }].products.products`, [] );
+	const variations = get(
+		state,
+		`extensions.woocommerce.sites[${ siteId }].productVariations`,
+		{}
+	);
+	// Flatten variations from their productId mapping down into a single array
+	const variationsList = flatten(
+		map( variations, ( items, productId ) => {
+			return items.map( item => ( { ...item, productId: Number( productId ) } ) );
+		} )
+	);
+
+	return [ ...products, ...variationsList ];
 };
 
 /**

--- a/client/extensions/woocommerce/state/sites/products/test/selectors.js
+++ b/client/extensions/woocommerce/state/sites/products/test/selectors.js
@@ -10,6 +10,7 @@ import { expect } from 'chai';
  */
 import {
 	getAllProducts,
+	getAllProductsWithVariations,
 	getProduct,
 	getProducts,
 	areProductsLoaded,
@@ -18,6 +19,7 @@ import {
 	getTotalProducts,
 } from '../selectors';
 import products from './fixtures/products';
+import productVariations from '../../product-variations/test/fixtures/variations';
 
 const preInitializedState = {
 	extensions: {
@@ -71,6 +73,7 @@ const loadedState = {
 						},
 						products,
 					},
+					productVariations,
 				},
 				401: {
 					products: {
@@ -114,6 +117,24 @@ describe( 'selectors', () => {
 
 		test( 'should return all loaded products for a given site.', () => {
 			expect( getAllProducts( loadedState, 123 ) ).to.eql( products );
+		} );
+	} );
+
+	describe( '#getAllProductsWithVariations', () => {
+		test( 'should get an empty array when woocommerce state is not available.', () => {
+			expect( getAllProductsWithVariations( preInitializedState, 123 ) ).to.eql( [] );
+		} );
+
+		test( 'should get an empty array if no products have loaded yet.', () => {
+			expect( getAllProductsWithVariations( loadingState, 123 ) ).to.eql( [] );
+		} );
+
+		test( 'should return all loaded products and variations for a given site.', () => {
+			const allProducts = getAllProductsWithVariations( loadedState, 123 );
+			expect( allProducts ).to.be.an( 'array' );
+			expect( allProducts ).to.include( products[ 1 ] );
+			expect( allProducts ).to.include( { ...productVariations[ 15 ][ 0 ], productId: 15 } );
+			expect( allProducts.length ).to.eql( 4 );
 		} );
 	} );
 


### PR DESCRIPTION
See #15681. This PR is based off #19531 for the new ProductSearch component. This connects the "+ Add Product" button on the edit order screen to a new product modal:

![screen shot 2017-11-07 at 3 59 03 pm](https://user-images.githubusercontent.com/541093/32517709-3838a45e-c3d5-11e7-9b94-5cebfb3042fe.png)

Now you can select products to add to an order. You can select multiple products, and use the variations form to select a specific product variation. Clicking Add Product on here adds the selected products to the order with quantity 1, and you can change the quantity or delete it from the order table, just like an existing product. [Click here for a screen recording demo](https://cloudup.com/cwl3IbhZjVU).

Note: There's an issue with the API where deleting a product off an order and adding a product to the order doesn't correctly update the total when saved - I'm looking into that. See https://github.com/woocommerce/woocommerce/issues/17624

**To Test**

- View an order (pick one from `/store/orders/:site`), and click Edit Order to get into the edit state
- Click + Add Product to open the product search modal
- Play around by adding products
- Change quantities, ~delete~, add more products (hold off on testing delete)
- Try adding fees too, they shouldn't conflict
- Save your order and verify that it updated correctly by checking in wp-admin

Note: Shipping still doesn't update, and taxes only update on save.