### PR TITLE
Comments: Link the post list comments button to the comments post view.

### DIFF
--- a/client/blocks/post-actions/index.jsx
+++ b/client/blocks/post-actions/index.jsx
@@ -15,13 +15,14 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import config from 'config';
 import { recordGoogleEvent } from 'state/analytics/actions';
 import PostRelativeTimeStatus from 'my-sites/post-relative-time-status';
 import CommentButton from 'blocks/comment-button';
 import LikeButton from 'my-sites/post-like-button';
 import PostTotalViews from 'my-sites/posts/post-total-views';
 import { canCurrentUser } from 'state/selectors';
-import { isJetpackModuleActive, isJetpackSite } from 'state/sites/selectors';
+import { isJetpackModuleActive, isJetpackSite, getSiteDomain } from 'state/sites/selectors';
 import { getEditorPath } from 'state/ui/editor/selectors';
 
 const getContentLink = ( state, siteId, post ) => {
@@ -47,6 +48,7 @@ const PostActions = ( {
 	showComments,
 	showLikes,
 	showStats,
+	siteDomain,
 	toggleComments,
 	trackRelativeTimeStatusOnClick,
 	trackTotalViewsOnClick,
@@ -67,14 +69,25 @@ const PostActions = ( {
 			{ ! isDraft &&
 			showComments && (
 				<li className="post-actions__item">
-					<CommentButton
-						key="comment-button"
-						post={ post }
-						showLabel={ false }
-						commentCount={ post.discussion.comment_count }
-						onClick={ toggleComments }
-						tagName="div"
-					/>
+					{ config.isEnabled( 'comments/management/post-view' ) ? (
+						<CommentButton
+							key="comment-button"
+							post={ post }
+							showLabel={ false }
+							commentCount={ post.discussion.comment_count }
+							tagName="a"
+							link={ `/comments/all/${ siteDomain }/${ post.ID }` }
+						/>
+					) : (
+						<CommentButton
+							key="comment-button"
+							post={ post }
+							showLabel={ false }
+							commentCount={ post.discussion.comment_count }
+							onClick={ toggleComments }
+							tagName="div"
+						/>
+					) }
 				</li>
 			) }
 			{ ! isDraft &&
@@ -109,6 +122,7 @@ PostActions.propTypes = {
 
 const mapStateToProps = ( state, { siteId, post } ) => {
 	const isJetpack = isJetpackSite( state, siteId );
+	const siteDomain = getSiteDomain( state, siteId );
 
 	// TODO: Maybe add dedicated selectors for the following.
 	const showComments =
@@ -125,6 +139,7 @@ const mapStateToProps = ( state, { siteId, post } ) => {
 		showComments,
 		showLikes,
 		showStats,
+		siteDomain,
 	};
 };
 

--- a/client/blocks/post-actions/index.jsx
+++ b/client/blocks/post-actions/index.jsx
@@ -22,7 +22,7 @@ import CommentButton from 'blocks/comment-button';
 import LikeButton from 'my-sites/post-like-button';
 import PostTotalViews from 'my-sites/posts/post-total-views';
 import { canCurrentUser } from 'state/selectors';
-import { isJetpackModuleActive, isJetpackSite, getSiteDomain } from 'state/sites/selectors';
+import { isJetpackModuleActive, isJetpackSite, getSiteSlug } from 'state/sites/selectors';
 import { getEditorPath } from 'state/ui/editor/selectors';
 
 const getContentLink = ( state, siteId, post ) => {
@@ -48,7 +48,7 @@ const PostActions = ( {
 	showComments,
 	showLikes,
 	showStats,
-	siteDomain,
+	siteSlug,
 	toggleComments,
 	trackRelativeTimeStatusOnClick,
 	trackTotalViewsOnClick,
@@ -76,7 +76,7 @@ const PostActions = ( {
 							showLabel={ false }
 							commentCount={ post.discussion.comment_count }
 							tagName="a"
-							link={ `/comments/all/${ siteDomain }/${ post.ID }` }
+							link={ `/comments/all/${ siteSlug }/${ post.ID }` }
 						/>
 					) : (
 						<CommentButton
@@ -122,7 +122,7 @@ PostActions.propTypes = {
 
 const mapStateToProps = ( state, { siteId, post } ) => {
 	const isJetpack = isJetpackSite( state, siteId );
-	const siteDomain = getSiteDomain( state, siteId );
+	const siteSlug = getSiteSlug( state, siteId );
 
 	// TODO: Maybe add dedicated selectors for the following.
 	const showComments =
@@ -139,7 +139,7 @@ const mapStateToProps = ( state, { siteId, post } ) => {
 		showComments,
 		showLikes,
 		showStats,
-		siteDomain,
+		siteSlug,
 	};
 };
 


### PR DESCRIPTION
_Relies on #19239 ._

Currently at `/posts/:site`, clicking the comment icon for a post will expose its comments immediately below. This PR will instead redirect the user to the new post-specific view of comments management. The redirection is hidden behind a flag enabled only in development.

**Testing**
* Switch to this branch and `git cherry-pick f58450568b4542de91d6aad80680796d807f56b2` (this will load the changes needed from #19239).
* From the post list view (`/posts/:site`), click the comment icon for a post and verify that you are sent to a URL with the format `/comments/all/:site/:post-id` (the view is not active yet, so you will see the existing comments view).