### PR TITLE
JP Disconnect Survey: Remove obsolete styling

### DIFF
--- a/client/my-sites/site-settings/disconnect-site/style.scss
+++ b/client/my-sites/site-settings/disconnect-site/style.scss
@@ -29,11 +29,3 @@
 		float: right;
 	}
 }
-
-// 'Troubleshooting' section
-.disconnect-site__troubleshooting {
-	.jetpack-connect__happychat-button,
-	.jetpack-connect__help-button {
-		text-align: center;
-	}
-}


### PR DESCRIPTION
Obsolete as of https://github.com/Automattic/wp-calypso/pull/19224, where the relevant `className` was [removed](https://github.com/Automattic/wp-calypso/pull/19224/files#diff-1ea929ab05c5c3de5c3c02bdb660aa4eL17) and [replaced](https://github.com/Automattic/wp-calypso/pull/19224/files#diff-1ea929ab05c5c3de5c3c02bdb660aa4eR22) by a `LoggedOutFormLinks` component which gets us the relevant styling for free.

To test: Verify that the `disconnect-site__troubleshooting` `className` isn't used anywhere.