### PR TITLE
Store: standardize static city/state/postcode formatting

### DIFF
--- a/client/extensions/woocommerce/components/address-view/index.js
+++ b/client/extensions/woocommerce/components/address-view/index.js
@@ -154,8 +154,8 @@ class AddressView extends Component {
 				{ street2 && <p>{ street2 }</p> }
 				<p>
 					{ city && <span className="address-view__city">{ city }</span> }
-					{ state && <span className="address-view__state">{ state }</span> }
-					{ postcode && <span className="address-view__postcode">{ postcode }</span> }
+					, { state && <span className="address-view__state">{ state }</span> }
+					&nbsp; { postcode && <span className="address-view__postcode">{ postcode }</span> }
 				</p>
 				<p>{ country }</p>
 			</div>

--- a/client/extensions/woocommerce/components/address-view/index.js
+++ b/client/extensions/woocommerce/components/address-view/index.js
@@ -147,6 +147,9 @@ class AddressView extends Component {
 
 	renderStatic = () => {
 		const { name, street, street2, city, state, postcode, country } = this.props.address;
+
+		const countryData = find( getCountries(), { code: country } );
+
 		return (
 			<div className="address-view__fields-static">
 				<p className="address-view__address-name">{ name }</p>
@@ -157,7 +160,7 @@ class AddressView extends Component {
 					, { state && <span className="address-view__state">{ state }</span> }
 					&nbsp; { postcode && <span className="address-view__postcode">{ postcode }</span> }
 				</p>
-				<p>{ country }</p>
+				<p>{ countryData ? countryData.name : country }</p>
 			</div>
 		);
 	};

--- a/client/extensions/woocommerce/components/address-view/style.scss
+++ b/client/extensions/woocommerce/components/address-view/style.scss
@@ -1,14 +1,6 @@
 .address-view__address {
 	margin-bottom: 8px;
 
- .address-view__city {
-		margin-right: 8px;
-	}
-
-	.address-view__state {
-		margin-right: 8px;
-	}
-
 	p {
 		margin-bottom: 0;
 

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/address-step/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/address-step/index.js
@@ -39,11 +39,11 @@ const renderSummary = ( {
 	}
 	const { countriesData } = storeOptions;
 	const { city, postcode, state, country } = ( normalized && selectNormalized ) ? normalized : values;
-	// Summary format: "city, state postcode [, country]"
+	// Summary format: "city, state  postcode [, country]"
 	let str = city + ', ';
 	if ( state ) {
 		const statesMap = ( countriesData[ country ] || {} ).states || {};
-		str += ( statesMap[ state ] || state ) + ' ';
+		str += ( statesMap[ state ] || state ) + '\xa0 ';
 	}
 	str += ( 'US' === country ? postcode.split( '-' )[ 0 ] : postcode );
 	if ( showCountry ) {

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/address-step/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/address-step/index.js
@@ -43,7 +43,7 @@ const renderSummary = ( {
 	let str = city + ', ';
 	if ( state ) {
 		const statesMap = ( countriesData[ country ] || {} ).states || {};
-		str += ( statesMap[ state ] || state ) + '\xa0 ';
+		str += ( statesMap[ state ] || state ) + '\xa0 ';  // append two spaces: non-breaking and normal
 	}
 	str += ( 'US' === country ? postcode.split( '-' )[ 0 ] : postcode );
 	if ( showCountry ) {

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/address-step/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/address-step/index.js
@@ -30,6 +30,7 @@ const renderSummary = ( {
 		storeOptions,
 		errors,
 		translate,
+		expandStateName = false,
 	}, showCountry ) => {
 	if ( normalizationInProgress ) {
 		return translate( 'Validating address…' );
@@ -42,7 +43,7 @@ const renderSummary = ( {
 	// Summary format: "city, state  postcode [, country]"
 	let str = city + ', ';
 	if ( state ) {
-		const statesMap = ( countriesData[ country ] || {} ).states || {};
+		const statesMap = ( expandStateName && ( countriesData[ country ] || {} ).states ) || {};
 		str += ( statesMap[ state ] || state ) + '\xa0 ';  // append two spaces: non-breaking and normal
 	}
 	str += ( 'US' === country ? postcode.split( '-' )[ 0 ] : postcode );

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/address-step/suggestion.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/address-step/suggestion.js
@@ -57,7 +57,7 @@ const AddressSummary = ( { values, originalValues, countriesData } ) => {
 		<div className="address-step__suggestion-summary">
 			<p>{ getValue( 'name' ) }</p>
 			<p>{ getValue( 'address' ) } { getValue( 'address_2' ) }</p>
-			<p>{ getValue( 'city' ) }, { getValue( 'postcode' ) } { getValue( 'state' ) }</p>
+			<p>{ getValue( 'city' ) }, { getValue( 'state' ) }&nbsp; { getValue( 'postcode' ) }</p>
 			<p>{ getValue( 'country' ) }</p>
 		</div>
 	);

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/address-step/suggestion.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/address-step/suggestion.js
@@ -24,13 +24,13 @@ const RadioButton = ( props ) => {
 	);
 };
 
-const AddressSummary = ( { values, originalValues, countriesData } ) => {
+const AddressSummary = ( { values, originalValues, countriesData, expandStateName = false } ) => {
 	originalValues = originalValues || {};
 	const { state, country } = values;
 
 	let stateStr = '';
 	if ( state ) {
-		const statesMap = ( countriesData[ country ] || {} ).states || {};
+		const statesMap = ( expandStateName && ( countriesData[ country ] || {} ).states ) || {};
 		stateStr = statesMap[ state ] || state;
 	}
 	const countryStr = countriesData[ country ].name;


### PR DESCRIPTION
Minor address formatting tweaks for visual appearance and text handling.

Open to feedback on the precise format itself — I've gone with how I always have written it, which is partially supported by [USPS address formatting guidelines](https://pe.usps.com/businessmail101?ViewName=DeliveryAddress) ("Two spaces between state and ZIP Code") but not entirely ("No punctuation").

- `<AddressView>` (in settings and in order customer info):

Before | After
-- | --
<img width="233" src="https://user-images.githubusercontent.com/1867547/32130583-ecdea608-bb68-11e7-99c5-ce1a7f9ee017.png"> | <img width="238" src="https://user-images.githubusercontent.com/1867547/32130580-e63c37c0-bb68-11e7-8eb7-24e02ea202dc.png">
CSS margins | HTML string separators
_Copy & paste:_ New YorkNY10021 | _Copy & paste:_ New York, NY&nbsp; 10021

- Shipping label purchase dialog

Before | After
-- | --
<img width="180" src="https://user-images.githubusercontent.com/1867547/32130854-fe793036-bb6d-11e7-82d5-731171f14bff.png"> | <img width="186" src="https://user-images.githubusercontent.com/1867547/32130855-ffd62b0a-bb6d-11e7-83d4-f181bca1af21.png">
<img width="333" src="https://user-images.githubusercontent.com/1867547/32130832-7f2f261e-bb6d-11e7-8f86-1b0c510f00b5.png"> | <img width="333" src="https://user-images.githubusercontent.com/1867547/32130840-9d77bbae-bb6d-11e7-8918-becca86c9a38.png">

Unchanged but could perhaps be discussed within the scope of this PR:
- "United States (US)" as [expanded](https://github.com/Automattic/wp-calypso/blob/b718bbe6f74ce9ba2ee2cb1738f7c44c5a800ecb/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/address-step/suggestion.js#L36) in the label purchase dialog is preferable to "US"
- Not so sure about [expanding](https://github.com/Automattic/wp-calypso/blob/b718bbe6f74ce9ba2ee2cb1738f7c44c5a800ecb/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/address-step/suggestion.js#L34) the State name, especially if this is lowercase while the rest of the address is being normalized to uppercase
- Not sure how best to internationalize