### PR TITLE
Promotion edit: Add cards to model

### DIFF
--- a/client/extensions/woocommerce/app/promotions/README.md
+++ b/client/extensions/woocommerce/app/promotions/README.md
@@ -16,12 +16,22 @@ by promotion type.
 
 For each promotion type, a model is returned in the following format:
 
-**Note: this will be expanded to include different kinds of fields, like constraints.**
-
 ```js
 {
-	field1: <promotion field>,
-	field2: <promotion field>,
+	cardModel1: {
+		labelText: translate( 'Card 1' ),
+		fields: {
+			fieldModel1: <promotion field>,
+			fieldModel2: <promotion field>,
+		},
+	},
+	cardModel2: {
+		labelText: translate( 'Card 2' ),
+		fields: {
+			fieldModel3: <promotion field>,
+			fieldModel4: <promotion field>,
+		},
+	},
 }
 ```
 

--- a/client/extensions/woocommerce/app/promotions/promotion-form-card.js
+++ b/client/extensions/woocommerce/app/promotions/promotion-form-card.js
@@ -3,14 +3,11 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { localize } from 'i18n-calypso';
-import warn from 'lib/warn';
 
 /**
  * Internal dependencies
  */
 import Card from 'components/card';
-import promotionModels from './promotion-models';
 import { renderField } from './fields';
 import SectionHeader from 'components/section-header';
 
@@ -22,50 +19,24 @@ const promotionFieldEdit = ( siteId, promotion, editPromotion ) => ( fieldName, 
 	editPromotion( siteId, promotion, newPromotion );
 };
 
-function renderFields( promotion, edit, translate, currency ) {
-	const model = promotionModels[ promotion.type ];
-
-	if ( ! model ) {
-		warn( 'No model found for promotion type: ' + promotion.type );
-		return null;
-	}
-
-	return Object.keys( model ).map( ( fieldName ) => {
-		const fieldModel = model[ fieldName ];
-		return renderField( fieldName, fieldModel, promotion, edit, currency );
-	} );
-}
-
-function getHeaderText( promotionType, translate ) {
-	switch ( promotionType ) {
-		case 'product_sale':
-			return translate( 'Product & Sale Price' );
-		case 'fixed_product':
-		case 'fixed_cart':
-		case 'percent':
-			return translate( 'Coupon Code & Discount' );
-	}
-}
-
 const PromotionFormCard = ( {
 	siteId,
 	currency,
 	promotion,
+	cardModel,
 	editPromotion,
-	translate
 } ) => {
 	const edit = promotionFieldEdit( siteId, promotion, editPromotion );
+	const fields = Object.keys( cardModel.fields ).map( ( fieldName ) => {
+		const fieldModel = cardModel.fields[ fieldName ];
+		return renderField( fieldName, fieldModel, promotion, edit, currency );
+	} );
 
 	return (
 		<div>
-			<SectionHeader label={ getHeaderText( promotion.type, translate ) } />
+			<SectionHeader label={ cardModel.labelText } />
 			<Card className="promotions__promotion-form-card">
-				{ renderFields(
-					promotion,
-					edit,
-					translate,
-					currency
-				) }
+				{ fields }
 			</Card>
 		</div>
 	);
@@ -79,7 +50,11 @@ PromotionFormCard.PropTypes = {
 		type: PropTypes.string.isRequired,
 	} ),
 	editPromotion: PropTypes.func.isRequired,
+	cardModel: PropTypes.shape( {
+		labelText: PropTypes.string.isRequired,
+		fields: PropTypes.object.isRequired,
+	} ).isRequired,
 };
 
-export default localize( PromotionFormCard );
+export default PromotionFormCard;
 

--- a/client/extensions/woocommerce/app/promotions/promotion-form.js
+++ b/client/extensions/woocommerce/app/promotions/promotion-form.js
@@ -5,12 +5,14 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { uniqueId } from 'lodash';
+import warn from 'lib/warn';
 
 /**
  * Internal dependencies
  */
 import PromotionFormCard from './promotion-form-card';
 import PromotionFormTypeCard from './promotion-form-type-card';
+import promotionModels from './promotion-models';
 
 function renderPlaceholder() {
 	const { className } = this.props;
@@ -34,8 +36,31 @@ export default class PromotionForm extends React.PureComponent {
 		editPromotion: PropTypes.func.isRequired,
 	};
 
-	render() {
+	renderFormCards( promotion ) {
 		const { siteId, currency, editPromotion } = this.props;
+		const model = promotionModels[ promotion.type ];
+
+		if ( ! model ) {
+			warn( 'No model found for promotion type: ' + promotion.type );
+			return null;
+		}
+
+		return Object.keys( model ).map( ( key ) => {
+			const cardModel = model[ key ];
+			return (
+				<PromotionFormCard key={ key } { ...{
+					cardModel,
+					siteId,
+					currency,
+					promotion,
+					editPromotion,
+				} } />
+			);
+		} );
+	}
+
+	render() {
+		const { siteId, editPromotion } = this.props;
 
 		if ( ! siteId ) {
 			return renderPlaceholder();
@@ -47,13 +72,7 @@ export default class PromotionForm extends React.PureComponent {
 		return (
 			<div className={ classNames( 'promotions__form', this.props.className ) }>
 				<PromotionFormTypeCard { ...{ siteId, promotion, editPromotion } } />
-
-				<PromotionFormCard { ...{
-					siteId,
-					currency,
-					promotion,
-					editPromotion,
-				} } />
+				{ this.renderFormCards( promotion ) }
 			</div>
 		);
 	}

--- a/client/extensions/woocommerce/app/promotions/promotion-models.js
+++ b/client/extensions/woocommerce/app/promotions/promotion-models.js
@@ -55,20 +55,25 @@ const fixedDiscountField = {
  * Promotion Type: Product Sale (e.g. $5 off the "I <3 Robots" t-shirt)
  */
 const productSaleModel = {
-	salePrice: {
-		component: CurrencyField,
-		labelText: translate( 'Product Sale Price' ),
-		isRequired: true,
-	},
-	appliesTo: {
-		component: (
-			<PromotionAppliesToField
-				selectionTypes={ [ { type: 'productIds' } ] }
-				singular={ true }
-			/>
-		),
-		labelText: translate( 'Applies to product' ),
-		isRequired: true,
+	productAndSalePrice: {
+		labelText: translate( 'Product & Sale Price' ),
+		fields: {
+			salePrice: {
+				component: CurrencyField,
+				labelText: translate( 'Product Sale Price' ),
+				isRequired: true,
+			},
+			appliesTo: {
+				component: (
+					<PromotionAppliesToField
+						selectionTypes={ [ { type: 'productIds' } ] }
+						singular={ true }
+					/>
+				),
+				labelText: translate( 'Applies to product' ),
+				isRequired: true,
+			},
+		}
 	},
 };
 
@@ -76,37 +81,52 @@ const productSaleModel = {
  * Promotion Type: Fixed Product Discount (e.g. $5 off any t-shirt)
  */
 const fixedProductModel = {
-	couponCode: couponCodeField,
-	fixedDiscount: {
-		...fixedDiscountField,
-		labelText: translate( 'Product Discount', { context: 'noun' } )
+	couponCodeAndDiscount: {
+		labelText: translate( 'Coupon Code & Discount' ),
+		fields: {
+			couponCode: couponCodeField,
+			fixedDiscount: {
+				...fixedDiscountField,
+				labelText: translate( 'Product Discount', { context: 'noun' } )
+			},
+			appliesTo: appliesToCouponField,
+		},
 	},
-	appliesTo: appliesToCouponField,
 };
 
 /**
  * Promotion Type: Fixed Cart Discount (e.g. $10 off my cart)
  */
 const fixedCartModel = {
-	couponCode: couponCodeField,
-	fixedDiscount: {
-		...fixedDiscountField,
-		labelText: translate( 'Cart Discount', { context: 'noun' } ),
-	},
-	appliesTo: appliesToCouponField,
+	couponCodeAndDiscount: {
+		labelText: translate( 'Coupon Code & Discount' ),
+		fields: {
+			couponCode: couponCodeField,
+			fixedDiscount: {
+				...fixedDiscountField,
+				labelText: translate( 'Cart Discount', { context: 'noun' } ),
+			},
+			appliesTo: appliesToCouponField,
+		},
+	}
 };
 
 /**
  * Promotion Type: Percentage Cart Discount (e.g. 10% off my cart)
  */
 const percentCartModel = {
-	couponCode: couponCodeField,
-	percentDiscount: {
-		component: PercentField,
-		labelText: translate( 'Percent Cart Discount', { context: 'noun' } ),
-		isRequired: true,
-	},
-	appliesTo: appliesToCouponField,
+	couponCodeAndDiscount: {
+		labelText: translate( 'Coupon Code & Discount' ),
+		fields: {
+			couponCode: couponCodeField,
+			percentDiscount: {
+				component: PercentField,
+				labelText: translate( 'Percent Cart Discount', { context: 'noun' } ),
+				isRequired: true,
+			},
+			appliesTo: appliesToCouponField,
+		},
+	}
 };
 
 /**


### PR DESCRIPTION
This extends the promotion models by adding cards to the model instead
of hard-coding them in the promotions-form-card. This will allow an
additional card for constraints to be added via the model as a next
step.

To Test:
1. `npm start`
2. `http://calypso.localhost:3000/store/promotion/<site url>`
3. Ensure the "Coupon Code & Discount" card is visible and renders correctly.
4. Select "Individual Product Sale"
5. Ensure the "Product & Sale Price" card is visible and renders correctly.
