### PR TITLE
Checkout: Disable paymentTabs a/b test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -89,16 +89,6 @@ export default {
 		allowExistingUsers: true,
 		localeTargets: 'any',
 	},
-	checkoutPaymentMethodTabs: {
-		datestamp: '20171019',
-		variations: {
-			tabs: 50,
-			original: 50,
-		},
-		defaultVariation: 'original',
-		allowExistingUsers: true,
-		localeTargets: 'any',
-	},
 	unlimitedThemeNudge: {
 		datestamp: '20171016',
 		variations: {

--- a/client/my-sites/checkout/checkout/credit-card-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/credit-card-payment-box.jsx
@@ -105,7 +105,7 @@ class CreditCardPaymentBox extends React.Component {
 	};
 
 	renderSecurePaymentNotice = () => {
-		if ( abtest( 'checkoutPaymentMethodTabs' ) === 'tabs' ) {
+		if ( ! this.props.onToggle ) {
 			return (
 				<div className="checkout__secure-payment">
 					<div className="checkout__secure-payment-content">
@@ -130,7 +130,7 @@ class CreditCardPaymentBox extends React.Component {
 				'credit-card-payment-box__switch-link-left': showPaymentChatButton,
 			} ),
 			paymentButtonsClasses = classnames( 'payment-box__payment-buttons', {
-				'payment-box__payment-buttons-test': abtest( 'checkoutPaymentMethodTabs' ) === 'tabs',
+				'payment-box__payment-buttons-test': ! this.props.onToggle,
 			} );
 
 		return (

--- a/client/my-sites/checkout/checkout/credit-card-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/credit-card-payment-box.jsx
@@ -5,7 +5,6 @@
  */
 
 import React from 'react';
-import classnames from 'classnames';
 import { some } from 'lodash';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'gridicons';
@@ -16,7 +15,6 @@ import Gridicon from 'gridicons';
 import PayButton from './pay-button';
 import CreditCardSelector from './credit-card-selector';
 import TermsOfService from './terms-of-service';
-import analytics from 'lib/analytics';
 import cartValues from 'lib/cart-values';
 import {
 	BEFORE_SUBMIT,
@@ -87,14 +85,6 @@ class CreditCardPaymentBox extends React.Component {
 		}
 	};
 
-	handleToggle = event => {
-		event.preventDefault();
-
-		analytics.ga.recordEvent( 'Upgrades', 'Clicked Or Use Paypal Link' );
-		analytics.tracks.recordEvent( 'calypso_checkout_switch_to_paypal' );
-		this.props.onToggle( 'paypal' );
-	};
-
 	progressBar = () => {
 		return (
 			<div className="credit-card-payment-box__progress-bar">
@@ -104,21 +94,6 @@ class CreditCardPaymentBox extends React.Component {
 		);
 	};
 
-	renderSecurePaymentNotice = () => {
-		if ( ! this.props.onToggle ) {
-			return (
-				<div className="checkout__secure-payment">
-					<div className="checkout__secure-payment-content">
-						<Gridicon icon="lock" />
-						{ this.props.translate( 'Secure Payment' ) }
-					</div>
-				</div>
-			);
-		}
-
-		return null;
-	};
-
 	paymentButtons = () => {
 		const cart = this.props.cart,
 			hasBusinessPlanInCart = some( cart.products, { product_slug: PLAN_BUSINESS } ),
@@ -126,28 +101,18 @@ class CreditCardPaymentBox extends React.Component {
 				config.isEnabled( 'upgrades/presale-chat' ) &&
 				abtest( 'presaleChatButton' ) === 'showChatButton' &&
 				hasBusinessPlanInCart,
-			paypalButtonClasses = classnames( 'credit-card-payment-box__switch-link', {
-				'credit-card-payment-box__switch-link-left': showPaymentChatButton,
-			} ),
-			paymentButtonsClasses = classnames( 'payment-box__payment-buttons', {
-				'payment-box__payment-buttons-test': ! this.props.onToggle,
-			} );
+			paymentButtonClasses = 'payment-box__payment-buttons';
 
 		return (
-			<div className={ paymentButtonsClasses }>
+			<div className={ paymentButtonClasses }>
 				<PayButton cart={ this.props.cart } transactionStep={ this.props.transactionStep } />
 
-				{ this.renderSecurePaymentNotice() }
-
-				{ this.props.onToggle && cartValues.isPayPalExpressEnabled( cart ) ? (
-					<a className={ paypalButtonClasses } href="" onClick={ this.handleToggle }>
-						{ this.props.translate( 'or use {{paypal/}}', {
-							components: {
-								paypal: <img src="/calypso/images/upgrades/paypal.svg" alt="PayPal" width="80" />,
-							},
-						} ) }
-					</a>
-				) : null }
+				<div className="checkout__secure-payment">
+					<div className="checkout__secure-payment-content">
+						<Gridicon icon="lock" />
+						{ this.props.translate( 'Secure Payment' ) }
+					</div>
+				</div>
 
 				<CartCoupon cart={ cart } />
 

--- a/client/my-sites/checkout/checkout/payment-box.jsx
+++ b/client/my-sites/checkout/checkout/payment-box.jsx
@@ -19,7 +19,6 @@ import SectionNav from 'components/section-nav';
 import SectionHeader from 'components/section-header';
 import analytics from 'lib/analytics';
 import cartValues from 'lib/cart-values';
-import { abtest } from 'lib/abtest';
 
 class PaymentBox extends PureComponent {
 	constructor() {
@@ -100,7 +99,7 @@ class PaymentBox extends PureComponent {
 	}
 
 	getCardTitle() {
-		if ( abtest( 'checkoutPaymentMethodTabs' ) === 'tabs' ) {
+		if ( this.props.tabsEnabled ) {
 			const formatHeaderClass = 'formatted-header',
 				formatHeaderTitleClass = 'formatted-header__title';
 
@@ -121,7 +120,7 @@ class PaymentBox extends PureComponent {
 	}
 
 	getSectionNav() {
-		if ( abtest( 'checkoutPaymentMethodTabs' ) === 'tabs' ) {
+		if ( this.props.tabsEnabled ) {
 			const titleText = this.props.currentPaymentMethod
 				? translate( 'Pay with %(paymentMethod)s', {
 						args: {

--- a/client/my-sites/checkout/checkout/payment-box.jsx
+++ b/client/my-sites/checkout/checkout/payment-box.jsx
@@ -98,55 +98,25 @@ class PaymentBox extends PureComponent {
 		} );
 	}
 
-	getCardTitle() {
-		if ( this.props.tabsEnabled ) {
-			const formatHeaderClass = 'formatted-header',
-				formatHeaderTitleClass = 'formatted-header__title';
-
-			return (
-				<header className={ formatHeaderClass }>
-					<h1 className={ formatHeaderTitleClass }>
-						{ this.props.paymentMethods ? (
-							translate( 'Great choice! How would you like to pay?' )
-						) : (
-							this.props.title
-						) }
-					</h1>
-				</header>
-			);
-		}
-
-		return <SectionHeader label={ this.props.title } />;
-	}
-
-	getSectionNav() {
-		if ( this.props.tabsEnabled ) {
-			const titleText = this.props.currentPaymentMethod
-				? translate( 'Pay with %(paymentMethod)s', {
-						args: {
-							paymentMethod: this.getPaymentProviderName( this.props.currentPaymentMethod ),
-						},
-					} )
-				: translate( 'Loading…' );
-
-			return (
-				<SectionNav selectedText={ titleText }>
-					<NavTabs>{ this.getPaymentMethods() }</NavTabs>
-				</SectionNav>
-			);
-		}
-
-		return null;
-	}
-
 	render() {
 		const cardClass = classNames( 'payment-box', this.props.classSet ),
 			contentClass = classNames( 'payment-box__content', this.props.contentClassSet );
 
+		const titleText = this.props.currentPaymentMethod
+			? translate( 'Pay with %(paymentMethod)s', {
+					args: {
+						paymentMethod: this.getPaymentProviderName( this.props.currentPaymentMethod ),
+					},
+				} )
+			: translate( 'Loading…' );
+
 		return (
 			<div className="checkout__payment-box-container" key={ this.props.currentPage }>
-				{ this.getCardTitle() }
-				{ this.getSectionNav() }
+				{ this.props.title ? <SectionHeader label={ this.props.title } /> : null }
+
+				<SectionNav selectedText={ titleText }>
+					<NavTabs>{ this.getPaymentMethods() }</NavTabs>
+				</SectionNav>
 
 				<Card className={ cardClass }>
 					<div className="checkout__box-padding">

--- a/client/my-sites/checkout/checkout/paypal-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/paypal-payment-box.jsx
@@ -146,7 +146,7 @@ class PaypalPaymentBox extends React.Component {
 	};
 
 	renderSecurePaymentNotice = () => {
-		if ( abtest( 'checkoutPaymentMethodTabs' ) === 'tabs' ) {
+		if ( ! this.props.onToggle ) {
 			return (
 				<div className="checkout__secure-payment">
 					<div className="checkout__secure-payment-content">
@@ -172,7 +172,7 @@ class PaypalPaymentBox extends React.Component {
 				'credit-card-payment-box__switch-link-left': showPaymentChatButton,
 			} ),
 			paymentButtonsClasses = classnames( 'payment-box__payment-buttons', {
-				'payment-box__payment-buttons-test': abtest( 'checkoutPaymentMethodTabs' ) === 'tabs',
+				'payment-box__payment-buttons-test': ! this.props.onToggle,
 			} );
 		return (
 			<form onSubmit={ this.redirectToPayPal }>

--- a/client/my-sites/checkout/checkout/paypal-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/paypal-payment-box.jsx
@@ -12,7 +12,6 @@ import Gridicon from 'gridicons';
 /**
  * Internal dependencies
  */
-import classnames from 'classnames';
 import analytics from 'lib/analytics';
 import cartValues from 'lib/cart-values';
 import CountrySelect from 'my-sites/domains/components/form/country-select';
@@ -36,14 +35,6 @@ class PaypalPaymentBox extends React.Component {
 	state = {
 		country: null,
 		formDisabled: false,
-	};
-
-	handleToggle = event => {
-		event.preventDefault();
-
-		analytics.ga.recordEvent( 'Upgrades', 'Clicked Or Use Credit Card Link' );
-		analytics.tracks.recordEvent( 'calypso_checkout_switch_to_card' );
-		this.props.onToggle( 'credit-card' );
 	};
 
 	handleChange = event => {
@@ -145,21 +136,6 @@ class PaypalPaymentBox extends React.Component {
 		} );
 	};
 
-	renderSecurePaymentNotice = () => {
-		if ( ! this.props.onToggle ) {
-			return (
-				<div className="checkout__secure-payment">
-					<div className="checkout__secure-payment-content">
-						<Gridicon icon="lock" />
-						{ this.props.translate( 'Secure Payment' ) }
-					</div>
-				</div>
-			);
-		}
-
-		return null;
-	};
-
 	render = () => {
 		const hasBusinessPlanInCart = some( this.props.cart.products, {
 			product_slug: PLAN_BUSINESS,
@@ -168,12 +144,8 @@ class PaypalPaymentBox extends React.Component {
 				config.isEnabled( 'upgrades/presale-chat' ) &&
 				abtest( 'presaleChatButton' ) === 'showChatButton' &&
 				hasBusinessPlanInCart,
-			creditCardButtonClasses = classnames( 'credit-card-payment-box__switch-link', {
-				'credit-card-payment-box__switch-link-left': showPaymentChatButton,
-			} ),
-			paymentButtonsClasses = classnames( 'payment-box__payment-buttons', {
-				'payment-box__payment-buttons-test': ! this.props.onToggle,
-			} );
+			paymentButtonClasses = 'payment-box__payment-buttons';
+
 		return (
 			<form onSubmit={ this.redirectToPayPal }>
 				<div className="checkout__payment-box-sections">
@@ -206,7 +178,7 @@ class PaypalPaymentBox extends React.Component {
 				/>
 
 				<div className="payment-box-actions">
-					<div className={ paymentButtonsClasses }>
+					<div className={ paymentButtonClasses }>
 						<span className="checkout__pay-button">
 							<button
 								type="submit"
@@ -218,17 +190,12 @@ class PaypalPaymentBox extends React.Component {
 							<SubscriptionText cart={ this.props.cart } />
 						</span>
 
-						{ this.renderSecurePaymentNotice() }
-
-						{ this.props.onToggle &&
-						cartValues.isCreditCardPaymentsEnabled( this.props.cart ) && (
-							<a href="" className={ creditCardButtonClasses } onClick={ this.handleToggle }>
-								{ this.props.translate( 'or use a credit card', {
-									context: 'Upgrades: PayPal checkout screen',
-									comment: 'Checkout with PayPal -- or use a credit card',
-								} ) }
-							</a>
-						) }
+						<div className="checkout__secure-payment">
+							<div className="checkout__secure-payment-content">
+								<Gridicon icon="lock" />
+								{ this.props.translate( 'Secure Payment' ) }
+							</div>
+						</div>
 
 						{ showPaymentChatButton && (
 							<PaymentChatButton paymentType="paypal" cart={ this.props.cart } />

--- a/client/my-sites/checkout/checkout/secure-payment-form.jsx
+++ b/client/my-sites/checkout/checkout/secure-payment-form.jsx
@@ -29,7 +29,6 @@ import cartValues, { isPaidForFullyInCredits, isFree, cartItems } from 'lib/cart
 import Notice from 'components/notice';
 import { preventWidows } from 'lib/formatting';
 import PaymentBox from './payment-box';
-import { abtest } from 'lib/abtest';
 
 /**
  * Module variables
@@ -60,7 +59,6 @@ const SecurePaymentForm = createReactClass( {
 		let i;
 		const primary = 0,
 			secondary = 1;
-		const tabsEnabled = abtest( 'checkoutPaymentMethodTabs' ) === 'tabs';
 
 		if ( isPaidForFullyInCredits( cart ) ) {
 			return 'credits';
@@ -72,7 +70,7 @@ const SecurePaymentForm = createReactClass( {
 			return this.state.userSelectedPaymentBox;
 		}
 
-		if ( tabsEnabled ) {
+		if ( this.shouldDisplayTabs() ) {
 			for ( i = 0; i < paymentMethods.length; i++ ) {
 				if ( cartValues.isPaymentMethodEnabled( cart, get( paymentMethods, [ i ] ) ) ) {
 					return paymentMethods[ i ];
@@ -94,6 +92,11 @@ const SecurePaymentForm = createReactClass( {
 		this.setState( {
 			visiblePaymentBox: this.getVisiblePaymentBox( nextProps.cart, nextProps.paymentMethods ),
 		} );
+	},
+
+	shouldDisplayTabs() {
+		// return abtest( 'checkoutPaymentMethodTabs' ) === 'tabs';
+		return this.props.paymentMethods && this.props.paymentMethods.length > 2;
 	},
 
 	handlePaymentBoxSubmit( event ) {
@@ -192,12 +195,13 @@ const SecurePaymentForm = createReactClass( {
 	},
 
 	renderCreditCardPaymentBox() {
-		const tabsEnabled = abtest( 'checkoutPaymentMethodTabs' ) === 'tabs';
+		const tabsEnabled = this.shouldDisplayTabs();
 		return (
 			<PaymentBox
 				classSet="credit-card-payment-box"
 				cart={ this.props.cart }
 				paymentMethods={ tabsEnabled ? this.props.paymentMethods : null }
+				tabsEnabled={ tabsEnabled }
 				title={ this.props.translate( 'Secure Payment' ) }
 				currentPaymentMethod="credit-card"
 				onSelectPaymentMethod={ this.selectPaymentBox }
@@ -218,13 +222,14 @@ const SecurePaymentForm = createReactClass( {
 	},
 
 	renderPayPalPaymentBox() {
-		const tabsEnabled = abtest( 'checkoutPaymentMethodTabs' ) === 'tabs';
+		const tabsEnabled = this.shouldDisplayTabs();
 		return (
 			<PaymentBox
 				classSet="paypal-payment-box"
 				cart={ this.props.cart }
 				title={ this.props.translate( 'Secure Payment with PayPal' ) }
 				paymentMethods={ tabsEnabled ? this.props.paymentMethods : null }
+				tabsEnabled={ tabsEnabled }
 				currentPaymentMethod="paypal"
 				onSelectPaymentMethod={ this.selectPaymentBox }
 			>

--- a/client/my-sites/checkout/checkout/secure-payment-form.jsx
+++ b/client/my-sites/checkout/checkout/secure-payment-form.jsx
@@ -57,8 +57,6 @@ const SecurePaymentForm = createReactClass( {
 
 	getVisiblePaymentBox( cart, paymentMethods ) {
 		let i;
-		const primary = 0,
-			secondary = 1;
 
 		if ( isPaidForFullyInCredits( cart ) ) {
 			return 'credits';
@@ -70,17 +68,12 @@ const SecurePaymentForm = createReactClass( {
 			return this.state.userSelectedPaymentBox;
 		}
 
-		if ( this.shouldDisplayTabs() ) {
-			for ( i = 0; i < paymentMethods.length; i++ ) {
-				if ( cartValues.isPaymentMethodEnabled( cart, get( paymentMethods, [ i ] ) ) ) {
-					return paymentMethods[ i ];
-				}
+		for ( i = 0; i < paymentMethods.length; i++ ) {
+			if ( cartValues.isPaymentMethodEnabled( cart, get( paymentMethods, [ i ] ) ) ) {
+				return paymentMethods[ i ];
 			}
-		} else if ( cartValues.isPaymentMethodEnabled( cart, get( paymentMethods, [ primary ] ) ) ) {
-			return paymentMethods[ primary ];
-		} else if ( cartValues.isPaymentMethodEnabled( cart, get( paymentMethods, [ secondary ] ) ) ) {
-			return paymentMethods[ secondary ];
 		}
+
 		return null;
 	},
 
@@ -92,11 +85,6 @@ const SecurePaymentForm = createReactClass( {
 		this.setState( {
 			visiblePaymentBox: this.getVisiblePaymentBox( nextProps.cart, nextProps.paymentMethods ),
 		} );
-	},
-
-	shouldDisplayTabs() {
-		// return abtest( 'checkoutPaymentMethodTabs' ) === 'tabs';
-		return this.props.paymentMethods && this.props.paymentMethods.length > 2;
 	},
 
 	handlePaymentBoxSubmit( event ) {
@@ -195,14 +183,11 @@ const SecurePaymentForm = createReactClass( {
 	},
 
 	renderCreditCardPaymentBox() {
-		const tabsEnabled = this.shouldDisplayTabs();
 		return (
 			<PaymentBox
 				classSet="credit-card-payment-box"
 				cart={ this.props.cart }
-				paymentMethods={ tabsEnabled ? this.props.paymentMethods : null }
-				tabsEnabled={ tabsEnabled }
-				title={ this.props.translate( 'Secure Payment' ) }
+				paymentMethods={ this.props.paymentMethods }
 				currentPaymentMethod="credit-card"
 				onSelectPaymentMethod={ this.selectPaymentBox }
 			>
@@ -215,21 +200,17 @@ const SecurePaymentForm = createReactClass( {
 					selectedSite={ this.props.selectedSite }
 					onSubmit={ this.handlePaymentBoxSubmit }
 					transactionStep={ this.props.transaction.step }
-					onToggle={ tabsEnabled ? null : this.selectPaymentBox }
 				/>
 			</PaymentBox>
 		);
 	},
 
 	renderPayPalPaymentBox() {
-		const tabsEnabled = this.shouldDisplayTabs();
 		return (
 			<PaymentBox
 				classSet="paypal-payment-box"
 				cart={ this.props.cart }
-				title={ this.props.translate( 'Secure Payment with PayPal' ) }
-				paymentMethods={ tabsEnabled ? this.props.paymentMethods : null }
-				tabsEnabled={ tabsEnabled }
+				paymentMethods={ this.props.paymentMethods }
 				currentPaymentMethod="paypal"
 				onSelectPaymentMethod={ this.selectPaymentBox }
 			>
@@ -239,7 +220,6 @@ const SecurePaymentForm = createReactClass( {
 					countriesList={ countriesListForPayments }
 					selectedSite={ this.props.selectedSite }
 					redirectTo={ this.props.redirectTo }
-					onToggle={ tabsEnabled ? null : this.selectPaymentBox }
 				/>
 			</PaymentBox>
 		);
@@ -283,15 +263,30 @@ const SecurePaymentForm = createReactClass( {
 				return this.renderFreeCartPaymentBox();
 
 			case 'credit-card':
+				this.renderGreatChoiceHeader();
 				return this.renderCreditCardPaymentBox();
 
 			case 'paypal':
+				this.renderGreatChoiceHeader();
 				return this.renderPayPalPaymentBox();
 
 			default:
 				debug( 'WARN: %o payment unknown', visiblePaymentBox );
 				return null;
 		}
+	},
+
+	renderGreatChoiceHeader() {
+		const formatHeaderClass = 'formatted-header',
+			formatHeaderTitleClass = 'formatted-header__title';
+
+		return (
+			<header className={ formatHeaderClass }>
+				<h1 className={ formatHeaderTitleClass }>
+					{ this.props.translate( 'Great choice! How would you like to pay?' ) }
+				</h1>
+			</header>
+		);
 	},
 
 	render() {

--- a/client/my-sites/checkout/checkout/secure-payment-form.jsx
+++ b/client/my-sites/checkout/checkout/secure-payment-form.jsx
@@ -263,12 +263,20 @@ const SecurePaymentForm = createReactClass( {
 				return this.renderFreeCartPaymentBox();
 
 			case 'credit-card':
-				this.renderGreatChoiceHeader();
-				return this.renderCreditCardPaymentBox();
+				return (
+					<div>
+						{ this.renderGreatChoiceHeader() }
+						{ this.renderCreditCardPaymentBox() }
+					</div>
+				);
 
 			case 'paypal':
-				this.renderGreatChoiceHeader();
-				return this.renderPayPalPaymentBox();
+				return (
+					<div>
+						{ this.renderGreatChoiceHeader() }
+						{ this.renderPayPalPaymentBox() }
+					</div>
+				);
 
 			default:
 				debug( 'WARN: %o payment unknown', visiblePaymentBox );

--- a/client/my-sites/checkout/checkout/style.scss
+++ b/client/my-sites/checkout/checkout/style.scss
@@ -718,7 +718,7 @@
 }
 
 @include breakpoint( ">660px" ) {
-	.payment-box__payment-buttons-test {
+	.payment-box__payment-buttons {
 		display: flex;
 		align-items: center;
 	}


### PR DESCRIPTION
This disables the a/b test `checkoutPaymentMethodTabs` (see #19006) while still enabling tabs when there are more than 2 payment methods. This is to prevent interfering with another running test.