### PR TITLE
Promotions edit: Add enable-able conditions

### DIFF
--- a/client/extensions/woocommerce/app/promotions/README.md
+++ b/client/extensions/woocommerce/app/promotions/README.md
@@ -46,6 +46,8 @@ For each field in a promotion model, there is a model in the following format:
 	explanationText: string (optional),
 	placeholderText: string (optional),
 	isRequired: boolean (optional),
+	isEnableable: boolean (optional),
+	defaultValue: any (optional),
 }
 ```
 

--- a/client/extensions/woocommerce/app/promotions/fields/README.md
+++ b/client/extensions/woocommerce/app/promotions/fields/README.md
@@ -33,6 +33,10 @@ Translated text to be shown below the field children.
 
 If true, show a "Required" annotation next to the label.
 
+### `isEnableable` (optional)
+
+If true, show a checkbox next to the label that will enable and disable this field.
+
 ### `fieldName` (required)
 
 The name of the promotion field.
@@ -40,6 +44,10 @@ The name of the promotion field.
 ### `placeholderText` (optional)
 
 The placeholder text to display within the input before anything is entered.
+
+### `defaultValue` (optional)
+
+The default value to be used upon initialization or when enabled if `isEnableable`.
 
 ### `value` (optional)
 

--- a/client/extensions/woocommerce/app/promotions/fields/date-field.js
+++ b/client/extensions/woocommerce/app/promotions/fields/date-field.js
@@ -1,0 +1,41 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import PropTypes from 'prop-types';
+
+/**
+ * Internal dependencies
+ */
+import DatePicker from 'components/date-picker';
+import FormField from './form-field';
+
+const DateField = ( props ) => {
+	const { fieldName, explanationText, value, edit } = props;
+	const selectedDay = ( value ? new Date( value ) : new Date() );
+
+	const onSelectDay = ( day ) => {
+		edit( fieldName, day.toISOString() );
+	};
+
+	return (
+		<FormField { ...props }>
+			<DatePicker
+				aria-describedby={ explanationText && fieldName + '-description' }
+				initialMonth={ selectedDay }
+				selectedDay={ selectedDay }
+				onSelectDay={ onSelectDay }
+			/>
+		</FormField>
+	);
+};
+
+DateField.PropTypes = {
+	fieldName: PropTypes.string.isRequired,
+	explanationText: PropTypes.string,
+	value: PropTypes.number,
+	edit: PropTypes.func.isRequired,
+};
+
+export default DateField;
+

--- a/client/extensions/woocommerce/app/promotions/fields/form-field.js
+++ b/client/extensions/woocommerce/app/promotions/fields/form-field.js
@@ -7,6 +7,7 @@ import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
+import FormCheckbox from 'components/forms/form-checkbox';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
@@ -16,20 +17,42 @@ const FormField = ( {
 	labelText,
 	explanationText,
 	isRequired,
+	isEnableable,
+	defaultValue,
 	children,
+	value,
+	edit,
 } ) => {
+	const isValueValid = ! ( 'undefined' === typeof value );
+	const showChildren = ( isEnableable ? isValueValid : true );
+
 	const explanation = ( explanationText &&
 		<FormSettingExplanation id={ fieldName + '-description' }>
 			{ explanationText }
 		</FormSettingExplanation>
 	);
 
+	let enableCheckbox = null;
+
+	if ( isEnableable ) {
+		const enableCheckboxChanged =
+			() => edit( fieldName, ( isValueValid ? undefined : ( defaultValue || null ) ) );
+
+		enableCheckbox = (
+			<FormCheckbox
+				checked={ isValueValid }
+				onChange={ enableCheckboxChanged }
+			/>
+		);
+	}
+
 	return (
-		<FormFieldset>
+		<FormFieldset className="fields__fieldset">
 			<FormLabel id={ fieldName + '-label' } required={ isRequired }>
+				{ enableCheckbox }
 				{ labelText }
 			</FormLabel>
-			{ children }
+			{ showChildren && children }
 			{ explanation }
 		</FormFieldset>
 	);
@@ -40,6 +63,8 @@ FormField.PropTypes = {
 	labelText: PropTypes.string.isRequired,
 	explanationText: PropTypes.string,
 	isRequired: PropTypes.bool,
+	isEnableable: PropTypes.bool,
+	defaultValue: PropTypes.any,
 	children: PropTypes.isRequired,
 };
 

--- a/client/extensions/woocommerce/app/promotions/fields/form-field.js
+++ b/client/extensions/woocommerce/app/promotions/fields/form-field.js
@@ -52,8 +52,10 @@ const FormField = ( {
 				{ enableCheckbox }
 				{ labelText }
 			</FormLabel>
-			{ showChildren && children }
-			{ explanation }
+			<div className="fields__fieldset-children">
+				{ showChildren && children }
+				{ explanation }
+			</div>
 		</FormFieldset>
 	);
 };

--- a/client/extensions/woocommerce/app/promotions/fields/form-field.js
+++ b/client/extensions/woocommerce/app/promotions/fields/form-field.js
@@ -3,6 +3,7 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies
@@ -46,13 +47,18 @@ const FormField = ( {
 		);
 	}
 
+	const childrenClassNames = classNames(
+		'fields__fieldset-children',
+		{ 'fields__fieldset-children-enableable': enableCheckbox }
+	);
+
 	return (
 		<FormFieldset className="fields__fieldset">
 			<FormLabel id={ fieldName + '-label' } required={ isRequired }>
 				{ enableCheckbox }
 				{ labelText }
 			</FormLabel>
-			<div className="fields__fieldset-children">
+			<div className={ childrenClassNames }>
 				{ showChildren && children }
 				{ explanation }
 			</div>

--- a/client/extensions/woocommerce/app/promotions/fields/index.js
+++ b/client/extensions/woocommerce/app/promotions/fields/index.js
@@ -4,29 +4,30 @@
 import React from 'react';
 import warn from 'lib/warn';
 
-export function renderField( fieldName, fieldModel, promotion, edit, currency ) {
-	const { component, labelText, explanationText, placeholderText, isRequired } = fieldModel;
-
-	const props = {
-		key: fieldName,
-		fieldName,
-		labelText,
-		explanationText,
-		placeholderText,
-		isRequired,
-		value: promotion[ fieldName ],
-		edit,
-		currency,
-	};
-
+export function renderComponent( component, props ) {
 	switch ( typeof component ) {
+		case 'undefined':
+			return null;
 		case 'function':
 			return React.createElement( component, props );
 		case 'object':
 			return React.cloneElement( component, props );
 		default:
-			warn( 'Unrecognized model.component type: ' + ( typeof component ) );
+			warn( 'Unrecognized component type: ' + ( typeof component ) );
 			return null;
 	}
+}
+
+export function renderField( fieldName, fieldModel, promotion, edit, currency ) {
+	const { component, ...props } = fieldModel;
+
+	return renderComponent( component, {
+		...props,
+		key: fieldName,
+		value: promotion[ fieldName ],
+		fieldName,
+		edit,
+		currency,
+	} );
 }
 

--- a/client/extensions/woocommerce/app/promotions/fields/number-field.js
+++ b/client/extensions/woocommerce/app/promotions/fields/number-field.js
@@ -7,50 +7,51 @@ import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
-import { getCurrencyFormatDecimal } from 'woocommerce/lib/currency';
-import PriceInput from 'woocommerce/components/price-input';
+import FormTextInput from 'components/forms/form-text-input';
 import FormField from './form-field';
 
-const CurrencyField = ( props ) => {
-	const { fieldName, explanationText, placeholderText, value, edit, currency } = props;
+const NumberField = ( props ) => {
+	const { fieldName, explanationText, placeholderText, value, edit, minValue, maxValue } = props;
 	const renderedValue = ( 'undefined' !== typeof value ? value : '' );
 
 	const onChange = ( e ) => {
 		const newValue = e.target.value;
-		if ( 0 === newValue.length ) {
-			edit( fieldName, '' );
+
+		if ( 'undefined' !== minValue && newValue < minValue ) {
+			return;
+		}
+		if ( 'undefined' !== maxValue && newValue > maxValue ) {
 			return;
 		}
 
-		const numberValue = Number( newValue );
-		if ( 0 <= Number( newValue ) ) {
-			const formattedValue = getCurrencyFormatDecimal( numberValue, currency );
-			edit( fieldName, formattedValue );
-		}
+		edit( fieldName, newValue );
 	};
 
 	return (
 		<FormField { ...props } >
-			<PriceInput
+			<FormTextInput
 				htmlFor={ fieldName + '-label' }
 				aria-describedby={ explanationText && fieldName + '-description' }
-				currency={ currency }
+				type="number"
+				min={ minValue }
+				max={ maxValue }
+				placeholder={ placeholderText || '10' }
 				value={ renderedValue }
-				placeholder={ placeholderText }
 				onChange={ onChange }
 			/>
 		</FormField>
 	);
 };
 
-CurrencyField.PropTypes = {
+NumberField.PropTypes = {
 	fieldName: PropTypes.string.isRequired,
 	explanationText: PropTypes.string,
 	placeholderText: PropTypes.string,
 	value: PropTypes.number,
+	minValue: PropTypes.number,
+	maxValue: PropTypes.number,
 	edit: PropTypes.func.isRequired,
-	currency: PropTypes.string.isRequired,
 };
 
-export default CurrencyField;
+export default NumberField;
 

--- a/client/extensions/woocommerce/app/promotions/fields/percent-field.js
+++ b/client/extensions/woocommerce/app/promotions/fields/percent-field.js
@@ -10,15 +10,8 @@ import PropTypes from 'prop-types';
 import FormTextInputWithAffixes from 'components/forms/form-text-input-with-affixes';
 import FormField from './form-field';
 
-const PercentField = ( {
-	fieldName,
-	labelText,
-	explanationText,
-	placeholderText,
-	isRequired,
-	value,
-	edit,
-} ) => {
+const PercentField = ( props ) => {
+	const { fieldName, explanationText, placeholderText, value, edit } = props;
 	const renderedValue = ( 'undefined' !== typeof value ? value : '' );
 
 	const onChange = ( e ) => {
@@ -29,12 +22,7 @@ const PercentField = ( {
 	};
 
 	return (
-		<FormField
-			fieldName={ fieldName }
-			labelText={ labelText }
-			explanationText={ explanationText }
-			isRequired={ isRequired }
-		>
+		<FormField { ...props } >
 			<FormTextInputWithAffixes
 				htmlFor={ fieldName + '-label' }
 				aria-describedby={ explanationText && fieldName + '-description' }
@@ -52,10 +40,8 @@ const PercentField = ( {
 
 PercentField.PropTypes = {
 	fieldName: PropTypes.string.isRequired,
-	labelText: PropTypes.string.isRequired,
 	explanationText: PropTypes.string,
 	placeholderText: PropTypes.string,
-	isRequired: PropTypes.bool,
 	value: PropTypes.number,
 	edit: PropTypes.func.isRequired,
 };

--- a/client/extensions/woocommerce/app/promotions/fields/promotion-applies-to-field/index.js
+++ b/client/extensions/woocommerce/app/promotions/fields/promotion-applies-to-field/index.js
@@ -15,13 +15,9 @@ import AppliesToFilteredList from './applies-to-filtered-list';
 class PromotionAppliesToField extends React.Component {
 	static propTypes = {
 		selectionTypes: PropTypes.array.isRequired,
-		singular: PropTypes.bool,
-		fieldName: PropTypes.string.isRequired,
-		labelText: PropTypes.string.isRequired,
-		explanationText: PropTypes.string,
-		isRequired: PropTypes.bool,
 		value: PropTypes.object,
 		edit: PropTypes.func.isRequired,
+		singular: PropTypes.bool,
 	};
 
 	constructor( props ) {
@@ -108,10 +104,6 @@ class PromotionAppliesToField extends React.Component {
 
 	render() {
 		const {
-			fieldName,
-			labelText,
-			explanationText,
-			isRequired,
 			value,
 			edit,
 			singular,
@@ -120,12 +112,7 @@ class PromotionAppliesToField extends React.Component {
 
 		return (
 			<div className="promotion-applies-to-field">
-				<FormField
-					fieldName={ fieldName }
-					labelText={ labelText }
-					explanationText={ explanationText }
-					isRequired={ isRequired }
-				>
+				<FormField { ...this.props }>
 					{ this.renderTypeSelect() }
 					<AppliesToFilteredList
 						appliesToType={ appliesToType }

--- a/client/extensions/woocommerce/app/promotions/fields/style.scss
+++ b/client/extensions/woocommerce/app/promotions/fields/style.scss
@@ -1,3 +1,17 @@
+.fields__fieldset {
+	.form-label {
+		input[type=checkbox] {
+			margin-right: 8px;
+		}
+	}
+}
+
+.fields__fieldset {
+	.date-picker {
+		max-width: 300px;
+		border: 1px solid lighten( $gray, 20% );
+	}
+}
 
 .promotion-applies-to-field {
 	.search {

--- a/client/extensions/woocommerce/app/promotions/fields/style.scss
+++ b/client/extensions/woocommerce/app/promotions/fields/style.scss
@@ -7,7 +7,7 @@
 }
 
 .fields__fieldset {
-	.fields__fieldset-children {
+	.fields__fieldset-children-enableable {
 		// Offset for checkbox border + width + margin-right
 		margin-left: ( 1px + 14px + 1px + 8px );
 	}

--- a/client/extensions/woocommerce/app/promotions/fields/style.scss
+++ b/client/extensions/woocommerce/app/promotions/fields/style.scss
@@ -7,6 +7,11 @@
 }
 
 .fields__fieldset {
+	.fields__fieldset-children {
+		// Offset for checkbox border + width + margin-right
+		margin-left: ( 1px + 14px + 1px + 8px );
+	}
+
 	.date-picker {
 		max-width: 300px;
 		border: 1px solid lighten( $gray, 20% );

--- a/client/extensions/woocommerce/app/promotions/fields/style.scss
+++ b/client/extensions/woocommerce/app/promotions/fields/style.scss
@@ -8,13 +8,55 @@
 
 .fields__fieldset {
 	.fields__fieldset-children-enableable {
-		// Offset for checkbox border + width + margin-right
-		margin-left: ( 1px + 14px + 1px + 8px );
+		margin-top: 8px;
+
+		&:empty {
+			margin: 0;
+		}
 	}
 
 	.date-picker {
-		max-width: 300px;
-		border: 1px solid lighten( $gray, 20% );
+		max-width: 280px;
+		border: 1px solid lighten( $gray, 30% );
+		padding: 16px;
+
+		.DayPicker-NavBar {
+			margin-left: 16px;
+			margin-right: 16px;
+		}
+	}
+}
+
+.promotions__promotion-form-card-conditions {
+	padding-top: 16px;
+	padding-bottom: 16px;
+
+	.form-label {
+		font-weight: 400;
+		margin-bottom: 0;
+	}
+
+	.form-fieldset {
+		border-bottom: 1px solid lighten( $gray, 32% );
+		padding-bottom: 16px;
+		margin-bottom: 16px;
+		margin-left: -16px;
+		margin-right: -16px;
+		padding-left: 16px;
+		padding-right: 16px;
+
+		@include breakpoint( ">480px" ) {
+			margin-left: -24px;
+			margin-right: -24px;
+			padding-left: 24px;
+			padding-right: 24px;
+		}
+
+		&:last-child {
+			margin-bottom: 0;
+			padding-bottom: 0;
+			border-bottom: 0;
+		}
 	}
 }
 

--- a/client/extensions/woocommerce/app/promotions/fields/text-field.js
+++ b/client/extensions/woocommerce/app/promotions/fields/text-field.js
@@ -10,15 +10,8 @@ import PropTypes from 'prop-types';
 import FormTextInput from 'components/forms/form-text-input';
 import FormField from './form-field';
 
-const TextField = ( {
-	fieldName,
-	labelText,
-	explanationText,
-	placeholderText,
-	isRequired,
-	value,
-	edit,
-} ) => {
+const TextField = ( props ) => {
+	const { fieldName, explanationText, placeholderText, value, edit } = props;
 	const renderedValue = ( 'undefined' !== typeof value ? value : '' );
 
 	const onChange = ( e ) => {
@@ -27,12 +20,7 @@ const TextField = ( {
 	};
 
 	return (
-		<FormField
-			fieldName={ fieldName }
-			labelText={ labelText }
-			explanationText={ explanationText }
-			isRequired={ isRequired }
-		>
+		<FormField { ...props } >
 			<FormTextInput
 				htmlFor={ fieldName + '-label' }
 				aria-describedby={ explanationText && fieldName + '-description' }
@@ -46,10 +34,8 @@ const TextField = ( {
 
 TextField.PropTypes = {
 	fieldName: PropTypes.string.isRequired,
-	labelText: PropTypes.string.isRequired,
 	explanationText: PropTypes.string,
 	placeholderText: PropTypes.string,
-	isRequired: PropTypes.bool,
 	value: PropTypes.number,
 	edit: PropTypes.func.isRequired,
 };

--- a/client/extensions/woocommerce/app/promotions/promotion-form-card.js
+++ b/client/extensions/woocommerce/app/promotions/promotion-form-card.js
@@ -3,6 +3,7 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies
@@ -32,10 +33,15 @@ const PromotionFormCard = ( {
 		return renderField( fieldName, fieldModel, promotion, edit, currency );
 	} );
 
+	const classes = classNames(
+		'promotions__promotion-form-card',
+		{ [ cardModel.cssClass ]: cardModel.cssClass }
+	);
+
 	return (
 		<div>
 			<SectionHeader label={ cardModel.labelText } />
-			<Card className="promotions__promotion-form-card">
+			<Card className={ classes }>
 				{ fields }
 			</Card>
 		</div>

--- a/client/extensions/woocommerce/app/promotions/promotion-form.scss
+++ b/client/extensions/woocommerce/app/promotions/promotion-form.scss
@@ -35,5 +35,8 @@
 		display: inline-block;
 		margin-bottom: 5px;
 	}
-}
 
+	.form-fieldset:last-child {
+		margin-bottom: 0;
+	}
+}

--- a/client/extensions/woocommerce/app/promotions/promotion-form.scss
+++ b/client/extensions/woocommerce/app/promotions/promotion-form.scss
@@ -31,11 +31,6 @@
 		}
 	}
 
-	.form-label {
-		display: inline-block;
-		margin-bottom: 5px;
-	}
-
 	.form-fieldset:last-child {
 		margin-bottom: 0;
 	}

--- a/client/extensions/woocommerce/app/promotions/promotion-models.js
+++ b/client/extensions/woocommerce/app/promotions/promotion-models.js
@@ -8,6 +8,9 @@ import { translate } from 'i18n-calypso';
  * Internal dependencies
  */
 import CurrencyField from './fields/currency-field';
+import DateField from './fields/date-field';
+import FormField from './fields/form-field';
+import NumberField from './fields/number-field';
 import PercentField from './fields/percent-field';
 import TextField from './fields/text-field';
 import PromotionAppliesToField from './fields/promotion-applies-to-field';
@@ -52,6 +55,24 @@ const fixedDiscountField = {
 };
 
 /**
+ * General purpose start date condition.
+ */
+const startDate = {
+	component: DateField,
+	labelText: translate( 'Start Date' ),
+	isEnableable: true,
+};
+
+/**
+ * General purpose end date condition.
+ */
+const endDate = {
+	component: DateField,
+	labelText: translate( 'End Date' ),
+	isEnableable: true,
+};
+
+/**
  * Promotion Type: Product Sale (e.g. $5 off the "I <3 Robots" t-shirt)
  */
 const productSaleModel = {
@@ -75,6 +96,55 @@ const productSaleModel = {
 			},
 		}
 	},
+	conditions: {
+		labelText: translate( 'Conditions', { context: 'noun' } ),
+		fields: {
+			startDate,
+			endDate,
+		}
+	},
+};
+
+/**
+ * Conditions for all coupon types.
+ */
+const couponConditions = {
+	labelText: translate( 'Conditions', { context: 'noun' } ),
+	fields: {
+		endDate,
+		minimumAmount: {
+			component: CurrencyField,
+			labelText: translate( 'Minimum spend to qualify' ),
+			isEnableable: true,
+			defaultValue: 10,
+		},
+		maximumAmount: {
+			component: CurrencyField,
+			labelText: translate( 'Maximum amount for applicable discount' ),
+			isEnableable: true,
+			defaultValue: 100,
+		},
+		usageLimit: {
+			component: NumberField,
+			labelText: translate( 'Limit total times used' ),
+			isEnableable: true,
+			defaultValue: 10,
+			minValue: 0,
+		},
+		usageLimitPerUser: {
+			component: NumberField,
+			labelText: translate( 'Limit times each user can use' ),
+			isEnableable: true,
+			defaultValue: 1,
+			minValue: 0,
+		},
+		individualUse: {
+			component: FormField,
+			labelText: translate( 'Cannot be used with other coupons' ),
+			isEnableable: true,
+			defaultValue: true,
+		},
+	},
 };
 
 /**
@@ -92,6 +162,7 @@ const fixedProductModel = {
 			appliesTo: appliesToCouponField,
 		},
 	},
+	conditions: couponConditions,
 };
 
 /**
@@ -108,7 +179,8 @@ const fixedCartModel = {
 			},
 			appliesTo: appliesToCouponField,
 		},
-	}
+	},
+	conditions: couponConditions,
 };
 
 /**
@@ -126,7 +198,8 @@ const percentCartModel = {
 			},
 			appliesTo: appliesToCouponField,
 		},
-	}
+	},
+	conditions: couponConditions,
 };
 
 /**

--- a/client/extensions/woocommerce/app/promotions/promotion-models.js
+++ b/client/extensions/woocommerce/app/promotions/promotion-models.js
@@ -114,33 +114,33 @@ const couponConditions = {
 		endDate,
 		minimumAmount: {
 			component: CurrencyField,
-			labelText: translate( 'Minimum spend to qualify' ),
+			labelText: translate( 'This promotion requires a minimum purchase' ),
 			isEnableable: true,
 			defaultValue: 10,
 		},
 		maximumAmount: {
 			component: CurrencyField,
-			labelText: translate( 'Maximum amount for applicable discount' ),
+			labelText: translate( 'The total discount cannot exceed a certain amount' ),
 			isEnableable: true,
 			defaultValue: 100,
 		},
 		usageLimit: {
 			component: NumberField,
-			labelText: translate( 'Limit total times used' ),
+			labelText: translate( 'Limit number of times this promotion can be used in total' ),
 			isEnableable: true,
 			defaultValue: 10,
 			minValue: 0,
 		},
 		usageLimitPerUser: {
 			component: NumberField,
-			labelText: translate( 'Limit times each user can use' ),
+			labelText: translate( 'Limit total times each customer can use this promotion' ),
 			isEnableable: true,
 			defaultValue: 1,
 			minValue: 0,
 		},
 		individualUse: {
 			component: FormField,
-			labelText: translate( 'Cannot be used with other coupons' ),
+			labelText: translate( 'Cannot be combined with any other promotion' ),
 			isEnableable: true,
 			defaultValue: true,
 		},
@@ -213,4 +213,3 @@ export default {
 	fixed_cart: fixedCartModel,
 	percent: percentCartModel,
 };
-

--- a/client/extensions/woocommerce/app/promotions/promotion-models.js
+++ b/client/extensions/woocommerce/app/promotions/promotion-models.js
@@ -120,7 +120,7 @@ const couponConditions = {
 		},
 		maximumAmount: {
 			component: CurrencyField,
-			labelText: translate( 'The total discount cannot exceed a certain amount' ),
+			labelText: translate( 'Don\'t apply this promotion if the order value exceeds a specific amount' ),
 			isEnableable: true,
 			defaultValue: 100,
 		},

--- a/client/extensions/woocommerce/app/promotions/promotion-models.js
+++ b/client/extensions/woocommerce/app/promotions/promotion-models.js
@@ -78,6 +78,7 @@ const endDate = {
 const productSaleModel = {
 	productAndSalePrice: {
 		labelText: translate( 'Product & Sale Price' ),
+		cssClass: 'promotions__promotion-form-card-primary',
 		fields: {
 			salePrice: {
 				component: CurrencyField,
@@ -98,6 +99,7 @@ const productSaleModel = {
 	},
 	conditions: {
 		labelText: translate( 'Conditions', { context: 'noun' } ),
+		cssClass: 'promotions__promotion-form-card-conditions',
 		fields: {
 			startDate,
 			endDate,
@@ -110,6 +112,7 @@ const productSaleModel = {
  */
 const couponConditions = {
 	labelText: translate( 'Conditions', { context: 'noun' } ),
+	cssClass: 'promotions__promotion-form-card-conditions',
 	fields: {
 		endDate,
 		minimumAmount: {
@@ -153,6 +156,7 @@ const couponConditions = {
 const fixedProductModel = {
 	couponCodeAndDiscount: {
 		labelText: translate( 'Coupon Code & Discount' ),
+		cssClass: 'promotions__promotion-form-card-primary',
 		fields: {
 			couponCode: couponCodeField,
 			fixedDiscount: {
@@ -171,6 +175,7 @@ const fixedProductModel = {
 const fixedCartModel = {
 	couponCodeAndDiscount: {
 		labelText: translate( 'Coupon Code & Discount' ),
+		cssClass: 'promotions__promotion-form-card-primary',
 		fields: {
 			couponCode: couponCodeField,
 			fixedDiscount: {
@@ -189,6 +194,7 @@ const fixedCartModel = {
 const percentCartModel = {
 	couponCodeAndDiscount: {
 		labelText: translate( 'Coupon Code & Discount' ),
+		cssClass: 'promotions__promotion-form-card-primary',
 		fields: {
 			couponCode: couponCodeField,
 			percentDiscount: {


### PR DESCRIPTION
This adds enable-able conditions and some supporting code including a
DateField, NumberField, and some modifications to the way FormField
works that allows pass-thru props, and default values.

To Test:
1. `npm start`
2. `http://calypso.localhost:3000/store/promotion/<site url>`
3. For a coupon type, try out each condition to ensure you can enter data and it stays (can also check in redux devtools to verify)
4. For a product sale, try out the start date and end date fields.

![new_promotion_ _coderkevin_ _wordpress_com](https://user-images.githubusercontent.com/945228/32132256-514652e0-bb86-11e7-8a32-a7005e2e76ed.png)