### PR TITLE
Post Editor: adds autosave parameter to outbound queries

### DIFF
--- a/client/lib/posts/actions.js
+++ b/client/lib/posts/actions.js
@@ -211,7 +211,7 @@ PostActions = {
 				}
 			);
 		} else {
-			PostActions.saveEdited( null, null, callback, { recordSaveEvent: false } );
+			PostActions.saveEdited( null, null, callback, { recordSaveEvent: false, autosave: true } );
 		}
 	},
 
@@ -347,6 +347,9 @@ PostActions = {
 			context: 'edit',
 			apiVersion: '1.2',
 		};
+		if ( options && options.autosave ) {
+			query.autosave = options.autosave;
+		}
 
 		if ( ! options || options.recordSaveEvent !== false ) {
 			recordSaveEvent( context ); // do this before changing status from 'future'


### PR DESCRIPTION
When the post editor decides to save automatically, add an autosave parameter to
the API query.

This allows the server to differentiate between autosaves, and manual saves, and cleans out unnecessary noise the Activity Log.