### PR TITLE
Signup: Add data attribute for e2e testing

### DIFF
--- a/client/signup/steps/site-or-domain/choice.jsx
+++ b/client/signup/steps/site-or-domain/choice.jsx
@@ -40,7 +40,7 @@ export default class SiteOrDomainChoice extends Component {
 		}
 
 		return (
-			<div className="site-or-domain__choice" key={ choice.type }>
+			<div className="site-or-domain__choice" data-e2e-type={ choice.type } key={ choice.type }>
 				<a className="site-or-domain__choice-link" onClick={ this.handleClickChoice }>
 					<Card compact className="site-or-domain__choice-image">
 						{ choice.image }


### PR DESCRIPTION
Adds a `data-e2e-type` attribute to the `SiteOrDomain` choice component.

Testing Instructions:

1. Visit http://calypso.localhost:3000/start/domain-first/site-or-domain?new=random-domain.blog
2. Check `.site-or-domain__choice`elements to ensure they have a new `data-e2e-type` attribute