### PR TITLE
Cards: Remove create-react-class

### DIFF
--- a/client/components/card/compact.jsx
+++ b/client/components/card/compact.jsx
@@ -1,27 +1,20 @@
+/** @format */
 /**
  * External dependencies
- *
- * @format
  */
-
 import React from 'react';
 import { assign } from 'lodash';
 import classnames from 'classnames';
-import createClass from 'create-react-class';
 
 /**
  * Internal dependencies
  */
 import Card from 'components/card';
 
-export default createClass( {
-	displayName: 'CompactCard',
+export default function CompactCard( props ) {
+	const nextProps = assign( {}, props, {
+		className: classnames( props.className, 'is-compact' ),
+	} );
 
-	render: function() {
-		const props = assign( {}, this.props, {
-			className: classnames( this.props.className, 'is-compact' ),
-		} );
-
-		return <Card { ...props }>{ this.props.children }</Card>;
-	},
-} );
+	return <Card { ...nextProps }>{ props.children }</Card>;
+}

--- a/client/components/card/compact.jsx
+++ b/client/components/card/compact.jsx
@@ -3,7 +3,6 @@
  * External dependencies
  */
 import React from 'react';
-import { assign } from 'lodash';
 import classnames from 'classnames';
 
 /**
@@ -12,9 +11,9 @@ import classnames from 'classnames';
 import Card from 'components/card';
 
 export default function CompactCard( props ) {
-	const nextProps = assign( {}, props, {
-		className: classnames( props.className, 'is-compact' ),
-	} );
-
-	return <Card { ...nextProps }>{ props.children }</Card>;
+	return (
+		<Card { ...props } className={ classnames( props.className, 'is-compact' ) }>
+			{ props.children }
+		</Card>
+	);
 }

--- a/client/components/card/test/__snapshots__/index.js.snap
+++ b/client/components/card/test/__snapshots__/index.js.snap
@@ -404,13 +404,13 @@ ShallowWrapper {
   "renderer": ReactShallowRenderer {
     "_instance": ShallowComponentWrapper {
       "_calledComponentWillUnmount": false,
-      "_compositeType": 0,
+      "_compositeType": 2,
       "_context": Object {},
       "_currentElement": <CompactCard />,
       "_debugID": 9,
       "_hostContainerInfo": null,
       "_hostParent": null,
-      "_instance":  {
+      "_instance": StatelessComponent {
         "_reactInternalInstance": [Circular],
         "context": Object {},
         "props": Object {},
@@ -484,7 +484,7 @@ ShallowWrapper {
   "renderer": ReactShallowRenderer {
     "_instance": ShallowComponentWrapper {
       "_calledComponentWillUnmount": false,
-      "_compositeType": 0,
+      "_compositeType": 2,
       "_context": Object {},
       "_currentElement": <CompactCard
         className="test__ace"
@@ -492,7 +492,7 @@ ShallowWrapper {
       "_debugID": 11,
       "_hostContainerInfo": null,
       "_hostParent": null,
-      "_instance":  {
+      "_instance": StatelessComponent {
         "_reactInternalInstance": [Circular],
         "context": Object {},
         "props": Object {
@@ -574,7 +574,7 @@ ShallowWrapper {
   "renderer": ReactShallowRenderer {
     "_instance": ShallowComponentWrapper {
       "_calledComponentWillUnmount": false,
-      "_compositeType": 0,
+      "_compositeType": 2,
       "_context": Object {},
       "_currentElement": <CompactCard>
         This is a compact card
@@ -582,7 +582,7 @@ ShallowWrapper {
       "_debugID": 13,
       "_hostContainerInfo": null,
       "_hostParent": null,
-      "_instance":  {
+      "_instance": StatelessComponent {
         "_reactInternalInstance": [Circular],
         "context": Object {},
         "props": Object {
@@ -664,13 +664,13 @@ ShallowWrapper {
   "renderer": ReactShallowRenderer {
     "_instance": ShallowComponentWrapper {
       "_calledComponentWillUnmount": false,
-      "_compositeType": 0,
+      "_compositeType": 2,
       "_context": Object {},
       "_currentElement": <CompactCard />,
       "_debugID": 15,
       "_hostContainerInfo": null,
       "_hostParent": null,
-      "_instance":  {
+      "_instance": StatelessComponent {
         "_reactInternalInstance": [Circular],
         "context": Object {},
         "props": Object {},

--- a/client/components/card/test/__snapshots__/index.js.snap
+++ b/client/components/card/test/__snapshots__/index.js.snap
@@ -1,0 +1,721 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Card should be linkable 1`] = `
+ShallowWrapper {
+  "complexSelector": ComplexSelector {
+    "buildPredicate": [Function],
+    "childrenOfNode": [Function],
+    "findWhereUnwrapped": [Function],
+  },
+  "length": 1,
+  "node": <a
+    className="card is-card-link"
+    href="/test"
+  >
+    <t
+      className="card__link-indicator"
+      icon="chevron-right"
+      size={24}
+    />
+    This is a linked card
+  </a>,
+  "nodes": Array [
+    <a
+      className="card is-card-link"
+      href="/test"
+    >
+      <t
+        className="card__link-indicator"
+        icon="chevron-right"
+        size={24}
+      />
+      This is a linked card
+    </a>,
+  ],
+  "options": Object {},
+  "renderer": ReactShallowRenderer {
+    "_instance": ShallowComponentWrapper {
+      "_calledComponentWillUnmount": false,
+      "_compositeType": 0,
+      "_context": Object {},
+      "_currentElement": <Card
+        highlight={false}
+        href="/test"
+        tagName="div"
+      >
+        This is a linked card
+      </Card>,
+      "_debugID": 7,
+      "_hostContainerInfo": null,
+      "_hostParent": null,
+      "_instance": Card {
+        "_reactInternalInstance": [Circular],
+        "context": Object {},
+        "props": Object {
+          "children": "This is a linked card",
+          "highlight": false,
+          "href": "/test",
+          "tagName": "div",
+        },
+        "refs": Object {},
+        "state": null,
+        "updater": Object {
+          "enqueueCallback": [Function],
+          "enqueueCallbackInternal": [Function],
+          "enqueueElementInternal": [Function],
+          "enqueueForceUpdate": [Function],
+          "enqueueReplaceState": [Function],
+          "enqueueSetState": [Function],
+          "isMounted": [Function],
+          "validateCallback": [Function],
+        },
+      },
+      "_mountOrder": 4,
+      "_pendingCallbacks": null,
+      "_pendingElement": null,
+      "_pendingForceUpdate": false,
+      "_pendingReplaceState": false,
+      "_pendingStateQueue": null,
+      "_renderedComponent": NoopInternalComponent {
+        "_currentElement": <a
+          className="card is-card-link"
+          href="/test"
+        >
+          <t
+            className="card__link-indicator"
+            icon="chevron-right"
+            size={24}
+          />
+          This is a linked card
+        </a>,
+        "_debugID": 8,
+        "_renderedOutput": <a
+          className="card is-card-link"
+          href="/test"
+        >
+          <t
+            className="card__link-indicator"
+            icon="chevron-right"
+            size={24}
+          />
+          This is a linked card
+        </a>,
+      },
+      "_renderedNodeType": 0,
+      "_rootNodeID": 0,
+      "_topLevelWrapper": null,
+      "_updateBatchNumber": null,
+      "_warnedAboutRefsInRender": false,
+    },
+    "getRenderOutput": [Function],
+    "render": [Function],
+  },
+  "root": [Circular],
+  "unrendered": <Card
+    highlight={false}
+    href="/test"
+    tagName="div"
+  >
+    This is a linked card
+  </Card>,
+}
+`;
+
+exports[`Card should have \`card\` class 1`] = `
+ShallowWrapper {
+  "complexSelector": ComplexSelector {
+    "buildPredicate": [Function],
+    "childrenOfNode": [Function],
+    "findWhereUnwrapped": [Function],
+  },
+  "length": 1,
+  "node": <div
+    className="card"
+  />,
+  "nodes": Array [
+    <div
+      className="card"
+    />,
+  ],
+  "options": Object {},
+  "renderer": ReactShallowRenderer {
+    "_instance": ShallowComponentWrapper {
+      "_calledComponentWillUnmount": false,
+      "_compositeType": 0,
+      "_context": Object {},
+      "_currentElement": <Card
+        highlight={false}
+        tagName="div"
+      />,
+      "_debugID": 1,
+      "_hostContainerInfo": null,
+      "_hostParent": null,
+      "_instance": Card {
+        "_reactInternalInstance": [Circular],
+        "context": Object {},
+        "props": Object {
+          "highlight": false,
+          "tagName": "div",
+        },
+        "refs": Object {},
+        "state": null,
+        "updater": Object {
+          "enqueueCallback": [Function],
+          "enqueueCallbackInternal": [Function],
+          "enqueueElementInternal": [Function],
+          "enqueueForceUpdate": [Function],
+          "enqueueReplaceState": [Function],
+          "enqueueSetState": [Function],
+          "isMounted": [Function],
+          "validateCallback": [Function],
+        },
+      },
+      "_mountOrder": 1,
+      "_pendingCallbacks": null,
+      "_pendingElement": null,
+      "_pendingForceUpdate": false,
+      "_pendingReplaceState": false,
+      "_pendingStateQueue": null,
+      "_renderedComponent": NoopInternalComponent {
+        "_currentElement": <div
+          className="card"
+        />,
+        "_debugID": 2,
+        "_renderedOutput": <div
+          className="card"
+        />,
+      },
+      "_renderedNodeType": 0,
+      "_rootNodeID": 0,
+      "_topLevelWrapper": null,
+      "_updateBatchNumber": null,
+      "_warnedAboutRefsInRender": false,
+    },
+    "getRenderOutput": [Function],
+    "render": [Function],
+  },
+  "root": [Circular],
+  "unrendered": <Card
+    highlight={false}
+    tagName="div"
+  />,
+}
+`;
+
+exports[`Card should have custom class of \`test__ace\` 1`] = `
+ShallowWrapper {
+  "complexSelector": ComplexSelector {
+    "buildPredicate": [Function],
+    "childrenOfNode": [Function],
+    "findWhereUnwrapped": [Function],
+  },
+  "length": 1,
+  "node": <div
+    className="card test__ace"
+  />,
+  "nodes": Array [
+    <div
+      className="card test__ace"
+    />,
+  ],
+  "options": Object {},
+  "renderer": ReactShallowRenderer {
+    "_instance": ShallowComponentWrapper {
+      "_calledComponentWillUnmount": false,
+      "_compositeType": 0,
+      "_context": Object {},
+      "_currentElement": <Card
+        className="test__ace"
+        highlight={false}
+        tagName="div"
+      />,
+      "_debugID": 3,
+      "_hostContainerInfo": null,
+      "_hostParent": null,
+      "_instance": Card {
+        "_reactInternalInstance": [Circular],
+        "context": Object {},
+        "props": Object {
+          "className": "test__ace",
+          "highlight": false,
+          "tagName": "div",
+        },
+        "refs": Object {},
+        "state": null,
+        "updater": Object {
+          "enqueueCallback": [Function],
+          "enqueueCallbackInternal": [Function],
+          "enqueueElementInternal": [Function],
+          "enqueueForceUpdate": [Function],
+          "enqueueReplaceState": [Function],
+          "enqueueSetState": [Function],
+          "isMounted": [Function],
+          "validateCallback": [Function],
+        },
+      },
+      "_mountOrder": 2,
+      "_pendingCallbacks": null,
+      "_pendingElement": null,
+      "_pendingForceUpdate": false,
+      "_pendingReplaceState": false,
+      "_pendingStateQueue": null,
+      "_renderedComponent": NoopInternalComponent {
+        "_currentElement": <div
+          className="card test__ace"
+        />,
+        "_debugID": 4,
+        "_renderedOutput": <div
+          className="card test__ace"
+        />,
+      },
+      "_renderedNodeType": 0,
+      "_rootNodeID": 0,
+      "_topLevelWrapper": null,
+      "_updateBatchNumber": null,
+      "_warnedAboutRefsInRender": false,
+    },
+    "getRenderOutput": [Function],
+    "render": [Function],
+  },
+  "root": [Circular],
+  "unrendered": <Card
+    className="test__ace"
+    highlight={false}
+    tagName="div"
+  />,
+}
+`;
+
+exports[`Card should render children 1`] = `
+ShallowWrapper {
+  "complexSelector": ComplexSelector {
+    "buildPredicate": [Function],
+    "childrenOfNode": [Function],
+    "findWhereUnwrapped": [Function],
+  },
+  "length": 1,
+  "node": <div
+    className="card"
+  >
+    This is a card
+  </div>,
+  "nodes": Array [
+    <div
+      className="card"
+    >
+      This is a card
+    </div>,
+  ],
+  "options": Object {},
+  "renderer": ReactShallowRenderer {
+    "_instance": ShallowComponentWrapper {
+      "_calledComponentWillUnmount": false,
+      "_compositeType": 0,
+      "_context": Object {},
+      "_currentElement": <Card
+        highlight={false}
+        tagName="div"
+      >
+        This is a card
+      </Card>,
+      "_debugID": 5,
+      "_hostContainerInfo": null,
+      "_hostParent": null,
+      "_instance": Card {
+        "_reactInternalInstance": [Circular],
+        "context": Object {},
+        "props": Object {
+          "children": "This is a card",
+          "highlight": false,
+          "tagName": "div",
+        },
+        "refs": Object {},
+        "state": null,
+        "updater": Object {
+          "enqueueCallback": [Function],
+          "enqueueCallbackInternal": [Function],
+          "enqueueElementInternal": [Function],
+          "enqueueForceUpdate": [Function],
+          "enqueueReplaceState": [Function],
+          "enqueueSetState": [Function],
+          "isMounted": [Function],
+          "validateCallback": [Function],
+        },
+      },
+      "_mountOrder": 3,
+      "_pendingCallbacks": null,
+      "_pendingElement": null,
+      "_pendingForceUpdate": false,
+      "_pendingReplaceState": false,
+      "_pendingStateQueue": null,
+      "_renderedComponent": NoopInternalComponent {
+        "_currentElement": <div
+          className="card"
+        >
+          This is a card
+        </div>,
+        "_debugID": 6,
+        "_renderedOutput": <div
+          className="card"
+        >
+          This is a card
+        </div>,
+      },
+      "_renderedNodeType": 0,
+      "_rootNodeID": 0,
+      "_topLevelWrapper": null,
+      "_updateBatchNumber": null,
+      "_warnedAboutRefsInRender": false,
+    },
+    "getRenderOutput": [Function],
+    "render": [Function],
+  },
+  "root": [Circular],
+  "unrendered": <Card
+    highlight={false}
+    tagName="div"
+  >
+    This is a card
+  </Card>,
+}
+`;
+
+exports[`CompactCard should have \`is-compact\` class 1`] = `
+ShallowWrapper {
+  "complexSelector": ComplexSelector {
+    "buildPredicate": [Function],
+    "childrenOfNode": [Function],
+    "findWhereUnwrapped": [Function],
+  },
+  "length": 1,
+  "node": <Card
+    className="is-compact"
+    highlight={false}
+    tagName="div"
+  />,
+  "nodes": Array [
+    <Card
+      className="is-compact"
+      highlight={false}
+      tagName="div"
+    />,
+  ],
+  "options": Object {},
+  "renderer": ReactShallowRenderer {
+    "_instance": ShallowComponentWrapper {
+      "_calledComponentWillUnmount": false,
+      "_compositeType": 0,
+      "_context": Object {},
+      "_currentElement": <CompactCard />,
+      "_debugID": 9,
+      "_hostContainerInfo": null,
+      "_hostParent": null,
+      "_instance":  {
+        "_reactInternalInstance": [Circular],
+        "context": Object {},
+        "props": Object {},
+        "refs": Object {},
+        "state": null,
+        "updater": Object {
+          "enqueueCallback": [Function],
+          "enqueueCallbackInternal": [Function],
+          "enqueueElementInternal": [Function],
+          "enqueueForceUpdate": [Function],
+          "enqueueReplaceState": [Function],
+          "enqueueSetState": [Function],
+          "isMounted": [Function],
+          "validateCallback": [Function],
+        },
+      },
+      "_mountOrder": 5,
+      "_pendingCallbacks": null,
+      "_pendingElement": null,
+      "_pendingForceUpdate": false,
+      "_pendingReplaceState": false,
+      "_pendingStateQueue": null,
+      "_renderedComponent": NoopInternalComponent {
+        "_currentElement": <Card
+          className="is-compact"
+          highlight={false}
+          tagName="div"
+        />,
+        "_debugID": 10,
+        "_renderedOutput": <Card
+          className="is-compact"
+          highlight={false}
+          tagName="div"
+        />,
+      },
+      "_renderedNodeType": 1,
+      "_rootNodeID": 0,
+      "_topLevelWrapper": null,
+      "_updateBatchNumber": null,
+      "_warnedAboutRefsInRender": false,
+    },
+    "getRenderOutput": [Function],
+    "render": [Function],
+  },
+  "root": [Circular],
+  "unrendered": <CompactCard />,
+}
+`;
+
+exports[`CompactCard should have custom class of \`test__ace\` 1`] = `
+ShallowWrapper {
+  "complexSelector": ComplexSelector {
+    "buildPredicate": [Function],
+    "childrenOfNode": [Function],
+    "findWhereUnwrapped": [Function],
+  },
+  "length": 1,
+  "node": <Card
+    className="test__ace is-compact"
+    highlight={false}
+    tagName="div"
+  />,
+  "nodes": Array [
+    <Card
+      className="test__ace is-compact"
+      highlight={false}
+      tagName="div"
+    />,
+  ],
+  "options": Object {},
+  "renderer": ReactShallowRenderer {
+    "_instance": ShallowComponentWrapper {
+      "_calledComponentWillUnmount": false,
+      "_compositeType": 0,
+      "_context": Object {},
+      "_currentElement": <CompactCard
+        className="test__ace"
+      />,
+      "_debugID": 11,
+      "_hostContainerInfo": null,
+      "_hostParent": null,
+      "_instance":  {
+        "_reactInternalInstance": [Circular],
+        "context": Object {},
+        "props": Object {
+          "className": "test__ace",
+        },
+        "refs": Object {},
+        "state": null,
+        "updater": Object {
+          "enqueueCallback": [Function],
+          "enqueueCallbackInternal": [Function],
+          "enqueueElementInternal": [Function],
+          "enqueueForceUpdate": [Function],
+          "enqueueReplaceState": [Function],
+          "enqueueSetState": [Function],
+          "isMounted": [Function],
+          "validateCallback": [Function],
+        },
+      },
+      "_mountOrder": 6,
+      "_pendingCallbacks": null,
+      "_pendingElement": null,
+      "_pendingForceUpdate": false,
+      "_pendingReplaceState": false,
+      "_pendingStateQueue": null,
+      "_renderedComponent": NoopInternalComponent {
+        "_currentElement": <Card
+          className="test__ace is-compact"
+          highlight={false}
+          tagName="div"
+        />,
+        "_debugID": 12,
+        "_renderedOutput": <Card
+          className="test__ace is-compact"
+          highlight={false}
+          tagName="div"
+        />,
+      },
+      "_renderedNodeType": 1,
+      "_rootNodeID": 0,
+      "_topLevelWrapper": null,
+      "_updateBatchNumber": null,
+      "_warnedAboutRefsInRender": false,
+    },
+    "getRenderOutput": [Function],
+    "render": [Function],
+  },
+  "root": [Circular],
+  "unrendered": <CompactCard
+    className="test__ace"
+  />,
+}
+`;
+
+exports[`CompactCard should render children 1`] = `
+ShallowWrapper {
+  "complexSelector": ComplexSelector {
+    "buildPredicate": [Function],
+    "childrenOfNode": [Function],
+    "findWhereUnwrapped": [Function],
+  },
+  "length": 1,
+  "node": <Card
+    className="is-compact"
+    highlight={false}
+    tagName="div"
+  >
+    This is a compact card
+  </Card>,
+  "nodes": Array [
+    <Card
+      className="is-compact"
+      highlight={false}
+      tagName="div"
+    >
+      This is a compact card
+    </Card>,
+  ],
+  "options": Object {},
+  "renderer": ReactShallowRenderer {
+    "_instance": ShallowComponentWrapper {
+      "_calledComponentWillUnmount": false,
+      "_compositeType": 0,
+      "_context": Object {},
+      "_currentElement": <CompactCard>
+        This is a compact card
+      </CompactCard>,
+      "_debugID": 13,
+      "_hostContainerInfo": null,
+      "_hostParent": null,
+      "_instance":  {
+        "_reactInternalInstance": [Circular],
+        "context": Object {},
+        "props": Object {
+          "children": "This is a compact card",
+        },
+        "refs": Object {},
+        "state": null,
+        "updater": Object {
+          "enqueueCallback": [Function],
+          "enqueueCallbackInternal": [Function],
+          "enqueueElementInternal": [Function],
+          "enqueueForceUpdate": [Function],
+          "enqueueReplaceState": [Function],
+          "enqueueSetState": [Function],
+          "isMounted": [Function],
+          "validateCallback": [Function],
+        },
+      },
+      "_mountOrder": 7,
+      "_pendingCallbacks": null,
+      "_pendingElement": null,
+      "_pendingForceUpdate": false,
+      "_pendingReplaceState": false,
+      "_pendingStateQueue": null,
+      "_renderedComponent": NoopInternalComponent {
+        "_currentElement": <Card
+          className="is-compact"
+          highlight={false}
+          tagName="div"
+        >
+          This is a compact card
+        </Card>,
+        "_debugID": 14,
+        "_renderedOutput": <Card
+          className="is-compact"
+          highlight={false}
+          tagName="div"
+        >
+          This is a compact card
+        </Card>,
+      },
+      "_renderedNodeType": 1,
+      "_rootNodeID": 0,
+      "_topLevelWrapper": null,
+      "_updateBatchNumber": null,
+      "_warnedAboutRefsInRender": false,
+    },
+    "getRenderOutput": [Function],
+    "render": [Function],
+  },
+  "root": [Circular],
+  "unrendered": <CompactCard>
+    This is a compact card
+  </CompactCard>,
+}
+`;
+
+exports[`CompactCard should use the card component 1`] = `
+ShallowWrapper {
+  "complexSelector": ComplexSelector {
+    "buildPredicate": [Function],
+    "childrenOfNode": [Function],
+    "findWhereUnwrapped": [Function],
+  },
+  "length": 1,
+  "node": <Card
+    className="is-compact"
+    highlight={false}
+    tagName="div"
+  />,
+  "nodes": Array [
+    <Card
+      className="is-compact"
+      highlight={false}
+      tagName="div"
+    />,
+  ],
+  "options": Object {},
+  "renderer": ReactShallowRenderer {
+    "_instance": ShallowComponentWrapper {
+      "_calledComponentWillUnmount": false,
+      "_compositeType": 0,
+      "_context": Object {},
+      "_currentElement": <CompactCard />,
+      "_debugID": 15,
+      "_hostContainerInfo": null,
+      "_hostParent": null,
+      "_instance":  {
+        "_reactInternalInstance": [Circular],
+        "context": Object {},
+        "props": Object {},
+        "refs": Object {},
+        "state": null,
+        "updater": Object {
+          "enqueueCallback": [Function],
+          "enqueueCallbackInternal": [Function],
+          "enqueueElementInternal": [Function],
+          "enqueueForceUpdate": [Function],
+          "enqueueReplaceState": [Function],
+          "enqueueSetState": [Function],
+          "isMounted": [Function],
+          "validateCallback": [Function],
+        },
+      },
+      "_mountOrder": 8,
+      "_pendingCallbacks": null,
+      "_pendingElement": null,
+      "_pendingForceUpdate": false,
+      "_pendingReplaceState": false,
+      "_pendingStateQueue": null,
+      "_renderedComponent": NoopInternalComponent {
+        "_currentElement": <Card
+          className="is-compact"
+          highlight={false}
+          tagName="div"
+        />,
+        "_debugID": 16,
+        "_renderedOutput": <Card
+          className="is-compact"
+          highlight={false}
+          tagName="div"
+        />,
+      },
+      "_renderedNodeType": 1,
+      "_rootNodeID": 0,
+      "_topLevelWrapper": null,
+      "_updateBatchNumber": null,
+      "_warnedAboutRefsInRender": false,
+    },
+    "getRenderOutput": [Function],
+    "render": [Function],
+  },
+  "root": [Circular],
+  "unrendered": <CompactCard />,
+}
+`;

--- a/client/components/card/test/index.js
+++ b/client/components/card/test/index.js
@@ -2,7 +2,6 @@
 /**
  * External dependencies
  */
-import { expect } from 'chai';
 import { shallow } from 'enzyme';
 import React from 'react';
 
@@ -16,27 +15,27 @@ describe( 'Card', () => {
 	// it should have a class of `card`
 	test( 'should have `card` class', () => {
 		const card = shallow( <Card /> );
-		expect( card.is( '.card' ) ).to.equal( true );
+		expect( card.is( '.card' ) ).toBe( true );
 	} );
 
 	// it should accept a custom class of `test__ace`
 	test( 'should have custom class of `test__ace`', () => {
 		const card = shallow( <Card className="test__ace" /> );
-		expect( card.is( '.test__ace' ) ).to.equal( true );
+		expect( card.is( '.test__ace' ) ).toBe( true );
 	} );
 
 	// check that content within a card renders correctly
 	test( 'should render children', () => {
 		const card = shallow( <Card>This is a card</Card> );
-		expect( card.contains( 'This is a card' ) ).to.equal( true );
+		expect( card.contains( 'This is a card' ) ).toBe( true );
 	} );
 
 	// check it will accept a href
 	test( 'should be linkable', () => {
 		const card = shallow( <Card href="/test">This is a linked card</Card> );
-		expect( card.find( 'a[href="/test"]' ) ).to.have.length( 1 );
-		expect( card.props().href ).to.equal( '/test' );
-		expect( card.is( '.is-card-link' ) ).to.equal( true );
+		expect( card.find( 'a[href="/test"]' ) ).toHaveLength( 1 );
+		expect( card.props().href ).toBe( '/test' );
+		expect( card.is( '.is-card-link' ) ).toBe( true );
 	} );
 } );
 
@@ -44,24 +43,24 @@ describe( 'CompactCard', () => {
 	// it should have a class of `is-compact`
 	test( 'should have `is-compact` class', () => {
 		const compactCard = shallow( <CompactCard /> );
-		expect( compactCard.find( '.is-compact' ) ).to.have.length( 1 );
+		expect( compactCard.find( '.is-compact' ) ).toHaveLength( 1 );
 	} );
 
 	// it should accept a custom class of `test__ace`
 	test( 'should have custom class of `test__ace`', () => {
 		const compactCard = shallow( <CompactCard className="test__ace" /> );
-		expect( compactCard.is( '.test__ace' ) ).to.equal( true );
+		expect( compactCard.is( '.test__ace' ) ).toBe( true );
 	} );
 
-	// check that content within a card renders correctly
+	// check that content within a CompactCard renders correctly
 	test( 'should render children', () => {
 		const compactCard = shallow( <CompactCard>This is a compact card</CompactCard> );
-		expect( compactCard.contains( 'This is a compact card' ) ).to.equal( true );
+		expect( compactCard.contains( 'This is a compact card' ) ).toBe( true );
 	} );
 
 	// test for card component
 	test( 'should use the card component', () => {
 		const compactCard = shallow( <CompactCard /> );
-		expect( compactCard.find( 'Card' ) ).to.have.length( 1 );
+		expect( compactCard.find( 'Card' ) ).toHaveLength( 1 );
 	} );
 } );

--- a/client/components/card/test/index.js
+++ b/client/components/card/test/index.js
@@ -16,18 +16,21 @@ describe( 'Card', () => {
 	test( 'should have `card` class', () => {
 		const card = shallow( <Card /> );
 		expect( card.is( '.card' ) ).toBe( true );
+		expect( card ).toMatchSnapshot();
 	} );
 
 	// it should accept a custom class of `test__ace`
 	test( 'should have custom class of `test__ace`', () => {
 		const card = shallow( <Card className="test__ace" /> );
 		expect( card.is( '.test__ace' ) ).toBe( true );
+		expect( card ).toMatchSnapshot();
 	} );
 
 	// check that content within a card renders correctly
 	test( 'should render children', () => {
 		const card = shallow( <Card>This is a card</Card> );
 		expect( card.contains( 'This is a card' ) ).toBe( true );
+		expect( card ).toMatchSnapshot();
 	} );
 
 	// check it will accept a href
@@ -36,6 +39,7 @@ describe( 'Card', () => {
 		expect( card.find( 'a[href="/test"]' ) ).toHaveLength( 1 );
 		expect( card.props().href ).toBe( '/test' );
 		expect( card.is( '.is-card-link' ) ).toBe( true );
+		expect( card ).toMatchSnapshot();
 	} );
 } );
 
@@ -44,23 +48,27 @@ describe( 'CompactCard', () => {
 	test( 'should have `is-compact` class', () => {
 		const compactCard = shallow( <CompactCard /> );
 		expect( compactCard.find( '.is-compact' ) ).toHaveLength( 1 );
+		expect( compactCard ).toMatchSnapshot();
 	} );
 
 	// it should accept a custom class of `test__ace`
 	test( 'should have custom class of `test__ace`', () => {
 		const compactCard = shallow( <CompactCard className="test__ace" /> );
 		expect( compactCard.is( '.test__ace' ) ).toBe( true );
+		expect( compactCard ).toMatchSnapshot();
 	} );
 
 	// check that content within a CompactCard renders correctly
 	test( 'should render children', () => {
 		const compactCard = shallow( <CompactCard>This is a compact card</CompactCard> );
 		expect( compactCard.contains( 'This is a compact card' ) ).toBe( true );
+		expect( compactCard ).toMatchSnapshot();
 	} );
 
 	// test for card component
 	test( 'should use the card component', () => {
 		const compactCard = shallow( <CompactCard /> );
 		expect( compactCard.find( 'Card' ) ).toHaveLength( 1 );
+		expect( compactCard ).toMatchSnapshot();
 	} );
 } );


### PR DESCRIPTION
`CompactCard` was using `create-react-class` for no apparent reason. This PR replaces the `createClass` usage with a stateless functional component.

Additionally, it updates the Card tests to use Jest over Chai (b4870ff) and adds snapshot tests before any component changes are made to ensure the component is not modified in unexpected ways (7df0fe3).

Note that the only snapshot changes are related to the [type of component](https://github.com/Automattic/wp-calypso/commit/e1a907376b7f296902eb384cb0e5ac6cb69e4ce3#diff-eee72f51db0725a419cffc9aa156ff7a) and not any of the contents.

This PR includes _no behavioral changes_.

## Testing
1. Do tests continue to pass?
1. Visit this branch on [calypso.localhost](http://calypso.localhost:3000/devdocs/design/cards#cards) or [calypso.live](https://calypso.live/devdocs/design/cards?branch=remove/create-class/card-component).
1. Verify the component continues to behave as before.