### PR TITLE
Fix error thrown when loading Browse Happy page

### DIFF
--- a/server/pages/browsehappy.jade
+++ b/server/pages/browsehappy.jade
@@ -58,10 +58,13 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class=isFluidWidth ? 'is-fluid-width'
 								h2.empty-content__title Unsupported Browser
 								h3.empty-content__line
 									| Unfortunately this page cannot be used by your browser. You can either
+									=  ' '
 									a(
 										href=dashboardUrl
 									) use the classic WordPress dashboard
 									| , or
+									=  ' '
 									a(
 										href="https://browsehappy.com"
 									) upgrade your browser
+									=  '.'

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -165,7 +165,7 @@ function getDefaultContext( request ) {
 		bodyClasses.push( 'pride' );
 	}
 
-	if ( request.context.sectionCss ) {
+	if ( request.context && request.context.sectionCss ) {
 		const urls = utils.getCssUrls( request.context.sectionCss );
 		sectionCss = urls.ltr;
 		sectionCssRtl = urls.rtl;


### PR DESCRIPTION
This pull request fixes an error displayed when accessing the [`Browse Happy` page](http://calypso.localhost:3000/browsehappy) in development:
 
```
TypeError: /var/sources/server/pages/500.jade:15
    13|                 link(rel='stylesheet', href='https://fonts.googleapis.com/css?family=Noto+Serif:400,400i,700,700i&subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext,vietnamese')
    14|                 link(rel='stylesheet', href='//s1.wp.com/i/noticons/noticons.css?v=20150727')
  > 15|                 link(rel='stylesheet', href=urls['style.css'])
    16|         body
    17|                 #wpcom.wpcom-site
    18|                         div.wp(class='has-no-sidebar')

Cannot read property 'style.css' of undefined
    at eval (eval at wrap (/var/sources/node_modules/jade-runtime/wrap.js:6:10), <anonymous>:34:85)
    at template (eval at wrap (/var/sources/node_modules/jade-runtime/wrap.js:6:10), <anonymous>:52:248)
    at Object.exports.renderFile (/var/sources/node_modules/jade/lib/index.js:331:38)
    at Object.exports.renderFile (/var/sources/node_modules/jade/lib/index.js:321:21)
    at View.exports.__express [as engine] (/var/sources/node_modules/jade/lib/index.js:368:11)
    at View.render (/var/sources/node_modules/express/lib/view.js:126:8)
    at tryRender (/var/sources/node_modules/express/lib/application.js:639:10)
    at EventEmitter.render (/var/sources/node_modules/express/lib/application.js:591:3)
    at ServerResponse.render (/var/sources/node_modules/express/lib/response.js:961:7)
    at serverRenderError (/var/sources/build/webpack:/server/render/index.js:147:7)
    at Layer.handle_error (/var/sources/node_modules/express/lib/router/layer.js:71:5)
    at trim_prefix (/var/sources/node_modules/express/lib/router/index.js:310:13)
    at /var/sources/node_modules/express/lib/router/index.js:280:7
    at Function.process_params (/var/sources/node_modules/express/lib/router/index.js:330:12)
    at next (/var/sources/node_modules/express/lib/router/index.js:271:10)
    at Layer.handle_error (/var/sources/node_modules/express/lib/router/layer.js:67:12)
    at trim_prefix (/var/sources/node_modules/express/lib/router/index.js:310:13)
    at /var/sources/node_modules/express/lib/router/index.js:280:7
    at Function.process_params (/var/sources/node_modules/express/lib/router/index.js:330:12)
    at next (/var/sources/node_modules/express/lib/router/index.js:271:10)
    at next (/var/sources/node_modules/express/lib/router/route.js:121:14)
    at Layer.handle_error (/var/sources/node_modules/express/lib/router/layer.js:67:12)
```

The actual root issue appears in the server logs:

```
TypeError: Cannot read property 'sectionCss' of undefined
    at getDefaultContext (/var/sources/build/webpack:/server/pages/index.js:168:7)
    at setUpLoggedOutRoute (/var/sources/build/webpack:/server/pages/index.js:249:16)
    at setUpRoute (/var/sources/build/webpack:/server/pages/index.js:366:3)
    at Layer.handle [as handle_request] (/var/sources/node_modules/express/lib/router/layer.js:95:5)
    at next (/var/sources/node_modules/express/lib/router/route.js:131:13)
    at Route.dispatch (/var/sources/node_modules/express/lib/router/route.js:112:3)
    at Layer.handle [as handle_request] (/var/sources/node_modules/express/lib/router/layer.js:95:5)
    at /var/sources/node_modules/express/lib/router/index.js:277:22
    at Function.process_params (/var/sources/node_modules/express/lib/router/index.js:330:12)
    at next (/var/sources/node_modules/express/lib/router/index.js:271:10)
    at Layer.handle [as handle_request] (/var/sources/node_modules/express/lib/router/layer.js:91:12)
    at trim_prefix (/var/sources/node_modules/express/lib/router/index.js:312:13)
    at /var/sources/node_modules/express/lib/router/index.js:280:7
    at Function.process_params (/var/sources/node_modules/express/lib/router/index.js:330:12)
    at next (/var/sources/node_modules/express/lib/router/index.js:271:10)
    at Layer.handle [as handle_request] (/var/sources/node_modules/express/lib/router/layer.js:91:12)
    at trim_prefix (/var/sources/node_modules/express/lib/router/index.js:312:13)
    at /var/sources/node_modules/express/lib/router/index.js:280:7
    at Function.process_params (/var/sources/node_modules/express/lib/router/index.js:330:12)
    at next (/var/sources/node_modules/express/lib/router/index.js:271:10)
    at cookieParser (/var/sources/node_modules/cookie-parser/index.js:25:29)
    at Layer.handle [as handle_request] (/var/sources/node_modules/express/lib/router/layer.js:95:5)
```

This pull request also fixes minor spacing issues.

#### Testing instructions
 
1. Run `git checkout fix/browse-happy` and start your server, or open a [live branch](https://calypso.live/?branch=fix/browse-happy)
2. Open the [`Browse Happy` page](http://calypso.localhost:3000/browsehappy)
3. Check that no error is thrown, and that the page is similar to the one [in production](https://wordpress.com/browsehappy)
 
#### Reviews
 
- [ ] Code
- [ ] Product









