### PR TITLE
Site Settings: Connect 'Disconnect' button to new Disconnect Survey

### DIFF
--- a/client/my-sites/plugins/disconnect-jetpack/disconnect-jetpack-button.jsx
+++ b/client/my-sites/plugins/disconnect-jetpack/disconnect-jetpack-button.jsx
@@ -13,9 +13,10 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
-import Button from 'components/button';
 import DisconnectJetpackDialog from 'blocks/disconnect-jetpack/dialog';
+import Button from 'components/button';
 import QuerySitePlans from 'components/data/query-site-plans';
+import { isEnabled } from 'config';
 import {
 	recordGoogleEvent as recordGoogleEventAction,
 	recordTracksEvent as recordTracksEventAction,
@@ -24,8 +25,7 @@ import {
 class DisconnectJetpackButton extends Component {
 	state = { dialogVisible: false };
 
-	handleClick = event => {
-		event.preventDefault();
+	handleClick = () => {
 		const { isMock, recordGoogleEvent, recordTracksEvent } = this.props;
 
 		if ( isMock ) {
@@ -64,6 +64,11 @@ class DisconnectJetpackButton extends Component {
 				/* eslint-disable wpcalypso/jsx-classname-namespace */
 				className="disconnect-jetpack-button"
 				compact
+				href={
+					isEnabled( 'manage/site-settings/disconnect-flow' ) ? (
+						'/settings/disconnect-site/' + site.slug
+					) : null
+				}
 				id={ `disconnect-jetpack-${ site.ID }` }
 				onClick={ this.handleClick }
 				scary
@@ -73,13 +78,15 @@ class DisconnectJetpackButton extends Component {
 						context: 'Jetpack: Action user takes to disconnect Jetpack site from .com',
 					} ) }
 				<QuerySitePlans siteId={ site.ID } />
-				<DisconnectJetpackDialog
-					isVisible={ this.state.dialogVisible }
-					onClose={ this.hideDialog }
-					isBroken={ false }
-					siteId={ site.ID }
-					disconnectHref={ this.props.redirect }
-				/>
+				{ ! isEnabled( 'manage/site-settings/disconnect-flow' ) && (
+					<DisconnectJetpackDialog
+						isVisible={ this.state.dialogVisible }
+						onClose={ this.hideDialog }
+						isBroken={ false }
+						siteId={ site.ID }
+						disconnectHref={ this.props.redirect }
+					/>
+				) }
 			</Button>
 		);
 	}

--- a/client/my-sites/site-settings/manage-connection/disconnect-site-link.jsx
+++ b/client/my-sites/site-settings/manage-connection/disconnect-site-link.jsx
@@ -13,7 +13,9 @@ import { localize } from 'i18n-calypso';
  */
 import DisconnectJetpackDialog from 'blocks/disconnect-jetpack/dialog';
 import QuerySitePlans from 'components/data/query-site-plans';
+import { isEnabled } from 'config';
 import SiteToolsLink from 'my-sites/site-settings/site-tools/link';
+import { getSiteSlug } from 'state/sites/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { isSiteAutomatedTransfer } from 'state/selectors';
 import { recordTracksEvent } from 'state/analytics/actions';
@@ -23,9 +25,7 @@ class DisconnectSiteLink extends Component {
 		dialogVisible: false,
 	};
 
-	handleClick = event => {
-		event.preventDefault();
-
+	handleClick = () => {
 		this.setState( {
 			dialogVisible: true,
 		} );
@@ -40,7 +40,7 @@ class DisconnectSiteLink extends Component {
 	};
 
 	render() {
-		const { isAutomatedTransfer, siteId, translate } = this.props;
+		const { isAutomatedTransfer, siteId, siteSlug, translate } = this.props;
 
 		if ( ! siteId || isAutomatedTransfer ) {
 			return null;
@@ -51,7 +51,13 @@ class DisconnectSiteLink extends Component {
 				<QuerySitePlans siteId={ siteId } />
 
 				<SiteToolsLink
-					href="#"
+					href={
+						isEnabled( 'manage/site-settings/disconnect-flow' ) ? (
+							'/settings/disconnect-site/' + siteSlug
+						) : (
+							'#'
+						)
+					}
 					onClick={ this.handleClick }
 					title={ translate( 'Disconnect from WordPress.com' ) }
 					description={ translate(
@@ -60,13 +66,15 @@ class DisconnectSiteLink extends Component {
 					isWarning
 				/>
 
-				<DisconnectJetpackDialog
-					isVisible={ this.state.dialogVisible }
-					onClose={ this.handleHideDialog }
-					isBroken={ false }
-					siteId={ siteId }
-					disconnectHref="/stats"
-				/>
+				{ ! isEnabled( 'manage/site-settings/disconnect-flow' ) && (
+					<DisconnectJetpackDialog
+						isVisible={ this.state.dialogVisible }
+						onClose={ this.handleHideDialog }
+						isBroken={ false }
+						siteId={ siteId }
+						disconnectHref="/stats"
+					/>
+				) }
 			</div>
 		);
 	}
@@ -79,6 +87,7 @@ export default connect(
 		return {
 			isAutomatedTransfer: isSiteAutomatedTransfer( state, siteId ),
 			siteId,
+			siteSlug: getSiteSlug( state, siteId ),
 		};
 	},
 	{ recordTracksEvent }

--- a/client/my-sites/site-settings/manage-connection/disconnect-site-link.jsx
+++ b/client/my-sites/site-settings/manage-connection/disconnect-site-link.jsx
@@ -25,7 +25,11 @@ class DisconnectSiteLink extends Component {
 		dialogVisible: false,
 	};
 
-	handleClick = () => {
+	handleClick = event => {
+		if ( ! isEnabled( 'manage/site-settings/disconnect-flow' ) ) {
+			event.preventDefault();
+		}
+
 		this.setState( {
 			dialogVisible: true,
 		} );


### PR DESCRIPTION
To test:

Verify that all entry points to the disconnect flow now trigger the survey (i.e. point to `/settings/disconnect-site/:site`).

1. `/settings/manage-connection/:site` -- Click the 'Disconnect from WordPress.com' button at the bottom of the page

![image](https://user-images.githubusercontent.com/96308/31471251-3b2258a6-aee8-11e7-87e6-ece683dccf69.png)

2. In siteslist in the sidebar, if you have a “broken” jetpack site, it will let you disconnect from the site there. (For example, rename `jetpack` plugin folder on the site.)

<img width="273" alt="screen shot 2017-06-23 at 12 41 17" src="https://user-images.githubusercontent.com/7767559/27480757-4ad41862-5811-11e7-8036-64202338667c.png">

Then, set `manage/site-settings/disconnect-flow` to `false` in `config/development.json`, and restart Calypso. Verify that both entry points still bring up the Disconnect modal directly (no survey, just like in production).