### PR TITLE
WooCommerce - hiding the labels button on completed orders

### DIFF
--- a/client/extensions/woocommerce/app/order/order-fulfillment/index.js
+++ b/client/extensions/woocommerce/app/order/order-fulfillment/index.js
@@ -145,12 +145,10 @@ class OrderFulfillment extends Component {
 			hasLabelsPaymentMethod,
 		} = this.props;
 		const orderFinished = isOrderFinished( order.status );
-		const orderCancelled = 'cancelled' === order.status;
-		const showLabels =
-			wcsEnabled && labelsLoaded && labelsEnabled && hasLabelsPaymentMethod && ! orderCancelled;
-		const labelsLoading = wcsEnabled && ! labelsLoaded && ! orderCancelled;
+		const showLabels = wcsEnabled && labelsLoaded && labelsEnabled && hasLabelsPaymentMethod;
+		const labelsLoading = wcsEnabled && ! labelsLoaded;
 
-		if ( ( orderFinished || orderCancelled ) && ! labelsLoading && ! showLabels ) {
+		if ( orderFinished ) {
 			return null;
 		}
 


### PR DESCRIPTION
To test:
* there should be no labels or fulfil button visible on processed orders (cancelled, completed, failed or refunded status)
* there should be no loading indicator on the processed orders, next to the fulfilment status
* the button should still be visible on the orders that are being processed