### PR TITLE
Jetpack Connect: Prune redirect_after_auth from logged in form

### DIFF
--- a/client/jetpack-connect/auth-logged-in-form.jsx
+++ b/client/jetpack-connect/auth-logged-in-form.jsx
@@ -4,16 +4,17 @@
  */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import Gridicon from 'gridicons';
 import addQueryArgs from 'lib/route/add-query-args';
 import debugModule from 'debug';
+import Gridicon from 'gridicons';
 import page from 'page';
-import { localize } from 'i18n-calypso';
 import { get, startsWith } from 'lodash';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
+import AuthFormHeader from './auth-form-header';
 import Button from 'components/button';
 import Card from 'components/card';
 import FormLabel from 'components/forms/form-label';
@@ -32,7 +33,6 @@ import userUtilities from 'lib/user/utils';
 import { decodeEntities } from 'lib/formatting';
 import { externalRedirect } from 'lib/route/path';
 import { login } from 'lib/paths';
-import AuthFormHeader from './auth-form-header';
 
 /**
  * Constants

--- a/client/jetpack-connect/authorize-form.jsx
+++ b/client/jetpack-connect/authorize-form.jsx
@@ -146,6 +146,8 @@ class JetpackConnectAuthorizeForm extends Component {
 	}
 }
 
+export { JetpackConnectAuthorizeForm as JetpackConnectAuthorizeFormTestComponent };
+
 export default connect(
 	state => {
 		const remoteSiteUrl = getAuthorizationRemoteSite( state );

--- a/client/jetpack-connect/test/__snapshots__/authorize-form.js.snap
+++ b/client/jetpack-connect/test/__snapshots__/authorize-form.js.snap
@@ -7,7 +7,7 @@ exports[`AuthorizeForm should render LoggedInForm when logged in 1`] = `
   <div
     className="jetpack-connect__authorize-form"
   >
-    <Localized(LoggedInForm)
+    <Connect(Localized(LoggedInForm))
       authAttempts={0}
       calypsoStartedConnection={false}
       isAlreadyOnSitesList={false}

--- a/client/jetpack-connect/test/__snapshots__/authorize-form.js.snap
+++ b/client/jetpack-connect/test/__snapshots__/authorize-form.js.snap
@@ -1,0 +1,59 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AuthorizeForm should render LoggedOutForm when logged out 1`] = `
+<JetpackConnectMainWrapper
+  isWide={false}
+>
+  <div
+    className="jetpack-connect__authorize-form"
+  >
+    <Connect(Localized(LoggedOutForm))
+      authAttempts={0}
+      calypsoStartedConnection={false}
+      isAlreadyOnSitesList={false}
+      isFetchingAuthorizationSite={false}
+      isFetchingSites={false}
+      isSSO={false}
+      isWoo={false}
+      jetpackConnectAuthorize={
+        Object {
+          "authorizeError": false,
+          "authorizeSuccess": false,
+          "clientNotResponding": true,
+          "isAuthorizing": false,
+          "queryObject": Object {
+            "_ui": "jetpack:fooBarBaz",
+            "_ut": "anon",
+            "_wp_nonce": "fooBarNonce",
+            "blogname": "Example Blog",
+            "calypso_env": "production",
+            "client_id": "98765",
+            "from": "banner-44-slide-1-dashboard",
+            "home_url": "http://an.example.site",
+            "jp_version": "5.4",
+            "locale": "en",
+            "redirect_after_auth": "http://an.example.site/wp-admin/admin.php?page=jetpack",
+            "redirect_uri": "http://an.example.site/wp-admin/admin.php?page=jetpack&action=authorize&_wpnonce=fooBarNonce&redirect=http%3A%2F%2Fan.example.site%2Fwp-admin%2Fadmin.php%3Fpage%3Djetpack",
+            "scope": "administrator:fooBarBaz",
+            "secret": "fooBarSecret",
+            "site": "http://an.example.site",
+            "site_icon": "",
+            "site_lang": "en_US",
+            "site_url": "http://an.example.site",
+            "state": "2",
+            "user_email": "email@an.example.site",
+            "user_login": "theUserLogin",
+          },
+          "timestamp": 1509368045859,
+          "userAlreadyConnected": false,
+        }
+      }
+      path="/jetpack/connect/authorize"
+      recordTracksEvent={[Function]}
+      setTracksAnonymousUserId={[Function]}
+      siteSlug="an.example.site"
+      user={null}
+    />
+  </div>
+</JetpackConnectMainWrapper>
+`;

--- a/client/jetpack-connect/test/__snapshots__/authorize-form.js.snap
+++ b/client/jetpack-connect/test/__snapshots__/authorize-form.js.snap
@@ -1,5 +1,68 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`AuthorizeForm should render LoggedInForm when logged in 1`] = `
+<JetpackConnectMainWrapper
+  isWide={false}
+>
+  <div
+    className="jetpack-connect__authorize-form"
+  >
+    <Localized(LoggedInForm)
+      authAttempts={0}
+      calypsoStartedConnection={false}
+      isAlreadyOnSitesList={false}
+      isFetchingAuthorizationSite={false}
+      isFetchingSites={false}
+      isSSO={false}
+      isWoo={false}
+      jetpackConnectAuthorize={
+        Object {
+          "authorizeError": false,
+          "authorizeSuccess": false,
+          "clientNotResponding": true,
+          "isAuthorizing": false,
+          "queryObject": Object {
+            "_ui": 1239876546,
+            "_ut": "wpcom:user_id",
+            "_wp_nonce": "fooBarNonce",
+            "blogname": "Example Blog",
+            "calypso_env": "production",
+            "client_id": "98765",
+            "from": "banner-44-slide-1-dashboard",
+            "home_url": "http://an.example.site",
+            "jp_version": "5.4",
+            "locale": "en",
+            "redirect_after_auth": "http://an.example.site/wp-admin/admin.php?page=jetpack",
+            "redirect_uri": "http://an.example.site/wp-admin/admin.php?page=jetpack&action=authorize&_wpnonce=fooBarNonce&redirect=http%3A%2F%2Fan.example.site%2Fwp-admin%2Fadmin.php%3Fpage%3Djetpack",
+            "scope": "administrator:fooBarBaz",
+            "secret": "fooBarSecret",
+            "site": "http://an.example.site",
+            "site_icon": "",
+            "site_lang": "en_US",
+            "site_url": "http://an.example.site",
+            "state": "2",
+            "user_email": "email@an.example.site",
+            "user_login": "theUserLogin",
+          },
+          "timestamp": 1509368045859,
+          "userAlreadyConnected": false,
+        }
+      }
+      path="/jetpack/connect/authorize"
+      recordTracksEvent={[Function]}
+      siteSlug="an.example.site"
+      user={
+        Object {
+          "ID": 1239876546,
+          "display_name": "An Example User's Name",
+          "username": "exampleusername",
+        }
+      }
+    />
+  </div>
+</JetpackConnectMainWrapper>
+`;
+
 exports[`AuthorizeForm should render LoggedOutForm when logged out 1`] = `
 <JetpackConnectMainWrapper
   isWide={false}

--- a/client/jetpack-connect/test/authorize-form.js
+++ b/client/jetpack-connect/test/authorize-form.js
@@ -12,8 +12,9 @@ import React from 'react';
  * Internal dependencies
  */
 import { JetpackConnectAuthorizeFormTestComponent as AuthorizeForm } from '../authorize-form';
+import LoggedInForm from '../auth-logged-in-form';
 import LoggedOutForm from '../auth-logged-out-form';
-import { LOGGED_OUT_PROPS } from './lib/authorize-form';
+import { LOGGED_IN_PROPS, LOGGED_OUT_PROPS } from './lib/authorize-form';
 
 describe( 'AuthorizeForm', () => {
 	test( 'should render LoggedOutForm when logged out', () => {
@@ -21,5 +22,12 @@ describe( 'AuthorizeForm', () => {
 
 		expect( wrapper ).toMatchSnapshot();
 		expect( wrapper.find( LoggedOutForm ) ).toHaveLength( 1 );
+	} );
+
+	test( 'should render LoggedInForm when logged in', () => {
+		const wrapper = shallow( <AuthorizeForm { ...LOGGED_IN_PROPS } /> );
+
+		expect( wrapper ).toMatchSnapshot();
+		expect( wrapper.find( LoggedInForm ) ).toHaveLength( 1 );
 	} );
 } );

--- a/client/jetpack-connect/test/authorize-form.js
+++ b/client/jetpack-connect/test/authorize-form.js
@@ -1,0 +1,25 @@
+/**
+ * @format
+ * @jest-environment jsdom
+ */
+/**
+ * External dependencies
+ */
+import { shallow } from 'enzyme';
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { JetpackConnectAuthorizeFormTestComponent as AuthorizeForm } from '../authorize-form';
+import LoggedOutForm from '../auth-logged-out-form';
+import { LOGGED_OUT_PROPS } from './lib/authorize-form';
+
+describe( 'AuthorizeForm', () => {
+	test( 'should render LoggedOutForm when logged out', () => {
+		const wrapper = shallow( <AuthorizeForm { ...LOGGED_OUT_PROPS } /> );
+
+		expect( wrapper ).toMatchSnapshot();
+		expect( wrapper.find( LoggedOutForm ) ).toHaveLength( 1 );
+	} );
+} );

--- a/client/jetpack-connect/test/lib/authorize-form.js
+++ b/client/jetpack-connect/test/lib/authorize-form.js
@@ -11,6 +11,7 @@ import { noop } from 'lodash';
 export const CLIENT_ID = '98765';
 export const SITE_ID = 1234567;
 export const SITE_SLUG = 'an.example.site';
+export const USER_ID = 1239876546;
 
 export const LOGGED_OUT_PROPS = deepFreeze( {
 	authAttempts: 0,
@@ -55,4 +56,52 @@ export const LOGGED_OUT_PROPS = deepFreeze( {
 	setTracksAnonymousUserId: noop,
 	siteSlug: SITE_SLUG,
 	user: null,
+} );
+
+export const LOGGED_IN_PROPS = deepFreeze( {
+	authAttempts: 0,
+	calypsoStartedConnection: false,
+	isAlreadyOnSitesList: false,
+	isFetchingAuthorizationSite: false,
+	isFetchingSites: false,
+	jetpackConnectAuthorize: {
+		authorizeError: false,
+		authorizeSuccess: false,
+		clientNotResponding: true,
+		isAuthorizing: false,
+		queryObject: {
+			_ui: USER_ID,
+			_ut: 'wpcom:user_id',
+			_wp_nonce: 'fooBarNonce',
+			blogname: 'Example Blog',
+			calypso_env: 'production',
+			client_id: CLIENT_ID,
+			from: 'banner-44-slide-1-dashboard',
+			home_url: `http://${ SITE_SLUG }`,
+			jp_version: '5.4',
+			locale: 'en',
+			redirect_after_auth: `http://${ SITE_SLUG }/wp-admin/admin.php?page=jetpack`,
+			// eslint-disable-next-line max-len
+			redirect_uri: `http://${ SITE_SLUG }/wp-admin/admin.php?page=jetpack&action=authorize&_wpnonce=fooBarNonce&redirect=http%3A%2F%2F${ SITE_SLUG }%2Fwp-admin%2Fadmin.php%3Fpage%3Djetpack`,
+			scope: 'administrator:fooBarBaz',
+			secret: 'fooBarSecret',
+			site: `http://${ SITE_SLUG }`,
+			site_icon: '',
+			site_lang: 'en_US',
+			site_url: `http://${ SITE_SLUG }`,
+			state: '2',
+			user_email: `email@${ SITE_SLUG }`,
+			user_login: 'theUserLogin',
+		},
+		timestamp: 1509368045859,
+		userAlreadyConnected: false,
+	},
+	path: '/jetpack/connect/authorize',
+	recordTracksEvent: noop,
+	siteSlug: SITE_SLUG,
+	user: {
+		ID: USER_ID,
+		display_name: "An Example User's Name",
+		username: 'exampleusername',
+	},
 } );

--- a/client/jetpack-connect/test/lib/authorize-form.js
+++ b/client/jetpack-connect/test/lib/authorize-form.js
@@ -1,0 +1,58 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import deepFreeze from 'deep-freeze';
+import { noop } from 'lodash';
+
+/**
+ * Test fixtures
+ */
+export const CLIENT_ID = '98765';
+export const SITE_ID = 1234567;
+export const SITE_SLUG = 'an.example.site';
+
+export const LOGGED_OUT_PROPS = deepFreeze( {
+	authAttempts: 0,
+	calypsoStartedConnection: false,
+	isAlreadyOnSitesList: false,
+	isFetchingAuthorizationSite: false,
+	isFetchingSites: false,
+	jetpackConnectAuthorize: {
+		authorizeError: false,
+		authorizeSuccess: false,
+		clientNotResponding: true,
+		isAuthorizing: false,
+		queryObject: {
+			_ui: 'jetpack:fooBarBaz',
+			_ut: 'anon',
+			_wp_nonce: 'fooBarNonce',
+			blogname: 'Example Blog',
+			calypso_env: 'production',
+			client_id: CLIENT_ID,
+			from: 'banner-44-slide-1-dashboard',
+			home_url: `http://${ SITE_SLUG }`,
+			jp_version: '5.4',
+			locale: 'en',
+			redirect_after_auth: `http://${ SITE_SLUG }/wp-admin/admin.php?page=jetpack`,
+			// eslint-disable-next-line max-len
+			redirect_uri: `http://${ SITE_SLUG }/wp-admin/admin.php?page=jetpack&action=authorize&_wpnonce=fooBarNonce&redirect=http%3A%2F%2F${ SITE_SLUG }%2Fwp-admin%2Fadmin.php%3Fpage%3Djetpack`,
+			scope: 'administrator:fooBarBaz',
+			secret: 'fooBarSecret',
+			site: `http://${ SITE_SLUG }`,
+			site_icon: '',
+			site_lang: 'en_US',
+			site_url: `http://${ SITE_SLUG }`,
+			state: '2',
+			user_email: `email@${ SITE_SLUG }`,
+			user_login: 'theUserLogin',
+		},
+		timestamp: 1509368045859,
+		userAlreadyConnected: false,
+	},
+	path: '/jetpack/connect/authorize',
+	recordTracksEvent: noop,
+	setTracksAnonymousUserId: noop,
+	siteSlug: SITE_SLUG,
+	user: null,
+} );

--- a/client/jetpack-connect/test/lib/plans.js
+++ b/client/jetpack-connect/test/lib/plans.js
@@ -1,7 +1,4 @@
-/**
- * @format
- * @jest-environment jsdom
- */
+/** @format */
 /**
  * External dependencies
  */


### PR DESCRIPTION
This PR starts work removing the `jetpackConnectAuthorize` and `queryObject` from component state in the Jetpack Connect Authorize components.

This PR includes the addition of some tests and begins 🔪  work by using the `getJetpackConnectRedirectAfterAuth` selector added in #19273

## Testing
1. Tests should pass
1. Verify that various **logged in** connection flows work as expected:
   - Starting from Calypso
   - Starting from wp-admin

## Follow-up
- Add more dedicated selectors
- Connect both `AuthLogged[ In | Out]Form` components
- Remove `{ ...this.props }` spread from `AuthorizeForm`