### PR TITLE
Login: Refine Login page

### DIFF
--- a/client/account-recovery/lost-password-form/index.jsx
+++ b/client/account-recovery/lost-password-form/index.jsx
@@ -58,7 +58,7 @@ export class LostPasswordFormComponent extends Component {
 					<ol className="lost-password-form__instruction-list">
 						<li>
 							{ translate(
-								'Enter your {{strong}}WordPress.com{{/strong}} username or email address',
+								'Enter your {{strong}}WordPress.com{{/strong}} email address or username',
 								{ components: { strong: <strong /> } }
 							) }
 						</li>

--- a/client/auth/login.jsx
+++ b/client/auth/login.jsx
@@ -109,7 +109,7 @@ export const Login = createReactClass( {
 								<FormTextInput
 									name="login"
 									disabled={ requires2fa || inProgress }
-									placeholder={ translate( 'Username or email address' ) }
+									placeholder={ translate( 'Email address or username' ) }
 									onFocus={ this.recordFocusEvent( 'Username or email address' ) }
 									value={ this.state.login }
 									onChange={ this.handleChange }

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -5,7 +5,7 @@
  */
 
 import classNames from 'classnames';
-import { defer } from 'lodash';
+import { capitalize, defer } from 'lodash';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
@@ -194,17 +194,19 @@ export class LoginForm extends Component {
 								<p>
 									{ this.props.translate(
 										'We found a WordPress.com account with the email address "%(email)s". ' +
-											'Log in to this account to connect it to your %(service)s profile.',
+										'Log in to this account to connect it to your %(service)s profile, ' +
+										'or choose a different %(service)s profile.',
 										{
 											args: {
 												email: this.props.socialAccountLinkEmail,
-												service: this.props.socialAccountLinkService,
+												service: capitalize( this.props.socialAccountLinkService ),
 											},
 										}
 									) }
 								</p>
 							</div>
 						) }
+
 						<label htmlFor="usernameOrEmail" className="login__form-userdata-username">
 							{ this.props.translate( 'Email Address or Username' ) }
 						</label>
@@ -256,7 +258,8 @@ export class LoginForm extends Component {
 							{ preventWidows(
 								this.props.translate(
 									// To make any changes to this copy please speak to the legal team
-									'By logging in via any of the options below, you agree to our {{tosLink}}Terms of Service{{/tosLink}}.',
+									'By continuing with any of the options below, ' +
+									'you agree to our {{tosLink}}Terms of Service{{/tosLink}}.',
 									{
 										components: {
 											tosLink: (
@@ -289,18 +292,25 @@ export class LoginForm extends Component {
 						</div>
 					) }
 				</Card>
+
 				{ config.isEnabled( 'signup/social' ) && (
-					<Card className="login__form-social">
-						<SocialLoginForm
-							onSuccess={ this.props.onSuccess }
-							socialService={ this.props.socialService }
-							socialServiceResponse={ this.props.socialServiceResponse }
-							linkingSocialService={
-								this.props.socialAccountIsLinking ? this.props.socialAccountLinkService : null
-							}
-							uxMode={ this.shouldUseRedirectLoginFlow() ? 'redirect' : 'popup' }
-						/>
-					</Card>
+					<div className="login__form-social">
+						<div className="login__form-social-divider">
+							<span>{ this.props.translate( 'or' ) }</span>
+						</div>
+
+						<Card>
+							<SocialLoginForm
+								onSuccess={ this.props.onSuccess }
+								socialService={ this.props.socialService }
+								socialServiceResponse={ this.props.socialServiceResponse }
+								linkingSocialService={
+									this.props.socialAccountIsLinking ? this.props.socialAccountLinkService : null
+								}
+								uxMode={ this.shouldUseRedirectLoginFlow() ? 'redirect' : 'popup' }
+							/>
+						</Card>
+					</div>
 				) }
 			</form>
 		);

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -218,7 +218,7 @@ export class LoginForm extends Component {
 							</div>
 						) }
 						<label htmlFor="usernameOrEmail" className="login__form-userdata-username">
-							{ this.props.translate( 'Username or Email Address' ) }
+							{ this.props.translate( 'Email Address or Username' ) }
 						</label>
 
 						<FormTextInput

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -21,7 +21,6 @@ import FormInputValidation from 'components/forms/form-input-validation';
 import Card from 'components/card';
 import FormPasswordInput from 'components/forms/form-password-input';
 import FormTextInput from 'components/forms/form-text-input';
-import FormCheckbox from 'components/forms/form-checkbox';
 import { getCurrentQueryArguments } from 'state/ui/selectors';
 import { getCurrentUserId } from 'state/current-user/selectors';
 import { getCurrentOAuth2Client } from 'state/ui/oauth2-clients/selectors';
@@ -62,13 +61,12 @@ export class LoginForm extends Component {
 		isDisabledWhileLoading: true,
 		usernameOrEmail: this.props.socialAccountLinkEmail || this.props.userEmail || '',
 		password: '',
-		rememberMe: false,
 	};
 
 	componentDidMount() {
+		// eslint-disable-next-line react/no-did-mount-set-state
 		this.setState( { isDisabledWhileLoading: false }, () => {
-			// eslint-disable-line react/no-did-mount-set-state
-			this.usernameOrEmail && this.usernameOrEmail.focus();
+			this.usernameOrEmail.focus();
 		} );
 	}
 
@@ -106,26 +104,16 @@ export class LoginForm extends Component {
 		} );
 	};
 
-	onChangeRememberMe = event => {
-		const { name, checked } = event.target;
-
-		this.props.recordTracksEvent( 'calypso_login_block_remember_me_click', { new_value: checked } );
-
-		this.setState( { [ name ]: checked } );
-	};
-
 	onSubmitForm = event => {
 		event.preventDefault();
 
 		const { usernameOrEmail, password } = this.state;
 		const { onSuccess, redirectTo } = this.props;
 
-		const rememberMe = this.props.socialAccountIsLinking ? true : this.state.rememberMe;
-
 		this.props.recordTracksEvent( 'calypso_login_block_login_form_submit' );
 
 		this.props
-			.loginUser( usernameOrEmail, password, rememberMe, redirectTo )
+			.loginUser( usernameOrEmail, password, redirectTo )
 			.then( () => {
 				this.props.recordTracksEvent( 'calypso_login_block_login_form_success' );
 
@@ -262,20 +250,6 @@ export class LoginForm extends Component {
 							<FormInputValidation isError text={ requestError.message } />
 						) }
 					</div>
-
-					{ ! linkingSocialUser && (
-						<div className="login__form-remember-me">
-							<label>
-								<FormCheckbox
-									name="rememberMe"
-									checked={ this.state.rememberMe }
-									onChange={ this.onChangeRememberMe }
-									{ ...isDisabled }
-								/>
-								<span>{ this.props.translate( 'Keep me logged in' ) }</span>
-							</label>
-						</div>
-					) }
 
 					{ config.isEnabled( 'signup/social' ) && (
 						<p className="login__form-terms">

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -66,7 +66,9 @@ export class LoginForm extends Component {
 	componentDidMount() {
 		// eslint-disable-next-line react/no-did-mount-set-state
 		this.setState( { isDisabledWhileLoading: false }, () => {
-			this.usernameOrEmail.focus();
+			if ( this.usernameOrEmail ) {
+				this.usernameOrEmail.focus();
+			}
 		} );
 	}
 
@@ -194,8 +196,8 @@ export class LoginForm extends Component {
 								<p>
 									{ this.props.translate(
 										'We found a WordPress.com account with the email address "%(email)s". ' +
-										'Log in to this account to connect it to your %(service)s profile, ' +
-										'or choose a different %(service)s profile.',
+											'Log in to this account to connect it to your %(service)s profile, ' +
+											'or choose a different %(service)s profile.',
 										{
 											args: {
 												email: this.props.socialAccountLinkEmail,
@@ -259,7 +261,7 @@ export class LoginForm extends Component {
 								this.props.translate(
 									// To make any changes to this copy please speak to the legal team
 									'By continuing with any of the options below, ' +
-									'you agree to our {{tosLink}}Terms of Service{{/tosLink}}.',
+										'you agree to our {{tosLink}}Terms of Service{{/tosLink}}.',
 									{
 										components: {
 											tosLink: (

--- a/client/blocks/login/social.jsx
+++ b/client/blocks/login/social.jsx
@@ -9,7 +9,6 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import GoogleLoginButton from 'components/social-buttons/google';
 import { localize } from 'i18n-calypso';
-import { capitalize } from 'lodash';
 
 /**
  * Internal dependencies
@@ -114,26 +113,6 @@ class SocialLoginForm extends Component {
 		}
 	};
 
-	renderText() {
-		if ( this.props.linkingSocialService ) {
-			return (
-				<p className="login__social-text">
-					{ this.props.translate( 'Or, choose a different %(service)s account:', {
-						args: {
-							service: capitalize( this.props.linkingSocialService ),
-						},
-					} ) }
-				</p>
-			);
-		}
-
-		return (
-			<p className="login__social-text">
-				{ this.props.translate( 'Or log in with your existing social profile:' ) }
-			</p>
-		);
-	}
-
 	render() {
 		const { redirectTo, uxMode } = this.props;
 		const redirectUri = uxMode
@@ -143,8 +122,6 @@ class SocialLoginForm extends Component {
 
 		return (
 			<div className="login__social">
-				{ this.renderText() }
-
 				<div className="login__social-buttons">
 					<GoogleLoginButton
 						clientId={ config( 'google_oauth_client_id' ) }

--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -1,5 +1,5 @@
 .card.login__form,
-.card.login__form-social {
+.login__form-social .card {
 	margin-bottom: 0;
 }
 
@@ -73,13 +73,8 @@
 	}
 }
 
-.login__social-text {
-	text-align: center;
-}
-
 .login__social-buttons {
 	button {
-		margin: 0 0 10px;
 		width: 100%;
 	}
 
@@ -139,6 +134,24 @@
 	clear: both;
 	font-size: 11px;
 	padding: 1em 0;
+}
+
+.login__form-social-divider {
+	margin-bottom: -11px;
+	margin-top: -11px;
+	position: relative;
+	text-align: center;
+	text-transform: uppercase;
+
+	span {
+		background: $white;
+		color: $gray;
+		font-size: 14px;
+		padding-left: 8px;
+		padding-right: 8px;
+		position: relative;
+		z-index: 2;
+	}
 }
 
 .login__social-connect-prompt-logos {

--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -51,18 +51,6 @@
 	text-align: center;
 }
 
-.login__form-remember-me {
-	margin-bottom: 20px;
-
-	input {
-		margin-right: 10px;
-	}
-
-	label {
-		font-size: 14px;
-	}
-}
-
 .login__form-terms,
 .login__form-signup-link {
 	font-size: 11px;

--- a/client/layout/masterbar/oauth-client.scss
+++ b/client/layout/masterbar/oauth-client.scss
@@ -274,6 +274,11 @@
 		}
 	}
 
+	.login__form-social-divider {
+		margin-bottom: 0;
+		margin-top: -41px;
+	}
+
 	.wp-login__links {
 		margin-top: 20px;
 	}

--- a/client/state/data-layer/wpcom/login-2fa/index.js
+++ b/client/state/data-layer/wpcom/login-2fa/index.js
@@ -17,7 +17,6 @@ import {
 	TWO_FACTOR_AUTHENTICATION_PUSH_POLL_STOP,
 } from 'state/action-types';
 import {
-	getRememberMe,
 	getTwoFactorAuthNonce,
 	getTwoFactorPushPollInProgress,
 	getTwoFactorPushToken,
@@ -49,8 +48,8 @@ const requestTwoFactorPushNotificationStatus = ( store, action ) => {
 				body: {
 					user_id: getTwoFactorUserId( store.getState() ),
 					auth_type: authType,
+					remember_me: true,
 					two_step_nonce: getTwoFactorAuthNonce( store.getState(), authType ),
-					remember_me: getRememberMe( store.getState() ),
 					two_step_push_token: getTwoFactorPushToken( store.getState() ),
 					client_id: config( 'wpcom_signup_id' ),
 					client_secret: config( 'wpcom_signup_key' ),

--- a/client/state/login/actions.js
+++ b/client/state/login/actions.js
@@ -43,7 +43,7 @@ import {
 	TWO_FACTOR_AUTHENTICATION_SEND_SMS_CODE_REQUEST_SUCCESS,
 	TWO_FACTOR_AUTHENTICATION_UPDATE_NONCE,
 } from 'state/action-types';
-import { getRememberMe, getTwoFactorAuthNonce, getTwoFactorUserId } from 'state/login/selectors';
+import { getTwoFactorAuthNonce, getTwoFactorUserId } from 'state/login/selectors';
 import { getCurrentUser } from 'state/current-user/selectors';
 import wpcom from 'lib/wp';
 import { addLocaleToWpcomUrl, getLocaleSlug } from 'lib/i18n-utils';
@@ -164,11 +164,10 @@ const getErrorFromWPCOMError = wpcomError => ( {
  *
  * @param  {String}    usernameOrEmail    Username or email of the user.
  * @param  {String}    password           Password of the user.
- * @param  {Boolean}   rememberMe         Whether to persist the logged in state of the user
  * @param  {String}    redirectTo         Url to redirect the user to upon successful login
  * @return {Function}                     Action thunk to trigger the login process.
  */
-export const loginUser = ( usernameOrEmail, password, rememberMe, redirectTo ) => dispatch => {
+export const loginUser = ( usernameOrEmail, password, redirectTo ) => dispatch => {
 	dispatch( {
 		type: LOGIN_REQUEST,
 	} );
@@ -186,7 +185,7 @@ export const loginUser = ( usernameOrEmail, password, rememberMe, redirectTo ) =
 		.send( {
 			username: usernameOrEmail,
 			password,
-			remember_me: rememberMe,
+			remember_me: true,
 			redirect_to: redirectTo,
 			client_id: config( 'wpcom_signup_id' ),
 			client_secret: config( 'wpcom_signup_key' ),
@@ -194,7 +193,6 @@ export const loginUser = ( usernameOrEmail, password, rememberMe, redirectTo ) =
 		.then( response => {
 			dispatch( {
 				type: LOGIN_REQUEST_SUCCESS,
-				rememberMe,
 				data: response.body && response.body.data,
 			} );
 
@@ -249,7 +247,7 @@ export const loginUserWithTwoFactorVerificationCode = ( twoStepCode, twoFactorAu
 			auth_type: twoFactorAuthType,
 			two_step_code: twoStepCode,
 			two_step_nonce: getTwoFactorAuthNonce( getState(), twoFactorAuthType ),
-			remember_me: getRememberMe( getState() ),
+			remember_me: true,
 			client_id: config( 'wpcom_signup_id' ),
 			client_secret: config( 'wpcom_signup_key' ),
 		} )

--- a/client/state/login/magic-login/actions.js
+++ b/client/state/login/magic-login/actions.js
@@ -103,8 +103,6 @@ export const fetchMagicLoginAuthenticate = ( email, token, tt ) => dispatch => {
 			dispatch( {
 				type: LOGIN_REQUEST_SUCCESS,
 				data: get( response, 'body.data' ),
-				// @TODO figure how we should treat `rememberMe`...
-				rememberMe: 0,
 			} );
 			dispatch( {
 				type: MAGIC_LOGIN_REQUEST_AUTH_SUCCESS,

--- a/client/state/login/reducer.js
+++ b/client/state/login/reducer.js
@@ -74,12 +74,6 @@ export const redirectTo = createReducer( null, {
 	[ LOGOUT_REQUEST_FAILURE ]: () => null,
 } );
 
-export const rememberMe = createReducer( null, {
-	[ LOGIN_REQUEST ]: () => null,
-	[ LOGIN_REQUEST_SUCCESS ]: ( state, action ) => action.rememberMe,
-	[ LOGIN_REQUEST_FAILURE ]: () => false,
-} );
-
 export const isFormDisabled = createReducer( null, {
 	[ LOGIN_REQUEST ]: () => true,
 	[ LOGIN_REQUEST_FAILURE ]: () => false,
@@ -263,7 +257,6 @@ export default combineReducers( {
 	isRequestingTwoFactorAuth,
 	magicLogin,
 	redirectTo,
-	rememberMe,
 	isFormDisabled,
 	requestError,
 	requestNotice,

--- a/client/state/login/selectors.js
+++ b/client/state/login/selectors.js
@@ -1,9 +1,8 @@
+/** @format */
+
 /**
  * External dependencies
- *
- * @format
  */
-
 import { get, isEmpty } from 'lodash';
 
 /**
@@ -161,16 +160,6 @@ export const getRequestNotice = state => {
  */
 export const getRedirectTo = state => {
 	return get( state, 'login.redirectTo', null );
-};
-
-/***
- * Retrieves the remember me flag that was set when logging in.
- *
- * @param  {Object}   state  Global state tree
- * @return {Boolean}         Remember me flag for authentication
- */
-export const getRememberMe = state => {
-	return get( state, 'login.rememberMe', false );
 };
 
 /***

--- a/client/state/login/test/reducer.js
+++ b/client/state/login/test/reducer.js
@@ -170,22 +170,6 @@ describe( 'reducer', () => {
 
 			expect( state ).to.be.true;
 		} );
-
-		test( 'should not persist state', () => {
-			const state = isRequesting( true, {
-				type: SERIALIZE,
-			} );
-
-			expect( state ).to.be.false;
-		} );
-
-		test( 'should not load persisted state', () => {
-			const state = isRequesting( true, {
-				type: DESERIALIZE,
-			} );
-
-			expect( state ).to.be.false;
-		} );
 	} );
 
 	describe( 'isRequestingTwoFactorAuth', () => {

--- a/client/state/login/test/reducer.js
+++ b/client/state/login/test/reducer.js
@@ -53,7 +53,6 @@ describe( 'reducer', () => {
 			'isRequestingTwoFactorAuth',
 			'magicLogin',
 			'redirectTo',
-			'rememberMe',
 			'requestError',
 			'requestNotice',
 			'requestSuccess',
@@ -508,7 +507,6 @@ describe( 'reducer', () => {
 			const state = twoFactorAuth( null, {
 				type: LOGIN_REQUEST_SUCCESS,
 				data,
-				rememberMe: true,
 			} );
 
 			expect( state ).to.eql( { ...data } );
@@ -531,7 +529,6 @@ describe( 'reducer', () => {
 			const state = twoFactorAuth( null, {
 				type: SOCIAL_LOGIN_REQUEST_SUCCESS,
 				data,
-				rememberMe: true,
 			} );
 
 			expect( state ).to.eql( { ...data } );

--- a/client/state/login/test/selectors.js
+++ b/client/state/login/test/selectors.js
@@ -10,7 +10,6 @@ import deepFreeze from 'deep-freeze';
  * Internal dependencies
  */
 import {
-	getRememberMe,
 	getRequestError,
 	getTwoFactorAuthNonce,
 	getTwoFactorAuthRequestError,
@@ -267,23 +266,6 @@ describe( 'selectors', () => {
 					},
 				} )
 			).to.eql( token );
-		} );
-	} );
-
-	describe( 'getRememberMe()', () => {
-		test( 'should return false by default', () => {
-			expect( getRememberMe( undefined ) ).to.be.false;
-		} );
-
-		test( "should return remember me flag when it's set", () => {
-			const rememberMe = true;
-			expect(
-				getRememberMe( {
-					login: {
-						rememberMe,
-					},
-				} )
-			).to.eql( rememberMe );
 		} );
 	} );
 


### PR DESCRIPTION
This pull request is the first iteration of a new project aiming at updating the [`Login` page](https://wordpress.com/log-in) and any related page to better support **passwordless accounts**. Here it only involves cosmetic changes in addition to hiding the _remember me_ feature that will be enabled by default from now on:

##### Default login

Before | After
------ | -----
<img width="736" alt="screenshot" src="https://user-images.githubusercontent.com/594356/32185192-d3c53b7c-bd9e-11e7-8b89-4e499cfac10f.png"> | <img width="736" alt="screenshot" src="https://user-images.githubusercontent.com/594356/32185213-dfe96e6e-bd9e-11e7-856a-fc420af76609.png">

##### Default login (linking flow)

Before | After
------ | -----
<img width="947" alt="screenshot" src="https://user-images.githubusercontent.com/594356/32219985-4f64d58a-be30-11e7-8abf-6ff47d29d7f0.png"> | <img width="947" alt="screenshot" src="https://user-images.githubusercontent.com/594356/32220576-87f75a6a-be32-11e7-8d3a-16f8a95200df.png">


##### WooCommerce

Before | After
------ | -----
<img width="736" alt="screenshot" src="https://user-images.githubusercontent.com/594356/32186169-a7f3f94a-bda1-11e7-93d6-582e6f460a86.png"> | <img width="736" alt="screenshot" src="https://user-images.githubusercontent.com/594356/32186146-9883deb2-bda1-11e7-8d3d-1dd370d2538b.png">


##### Other OAuth apps

Before | After
------ | -----
<img width="736" alt="screenshot" src="https://user-images.githubusercontent.com/594356/32185285-04f2d9e8-bd9f-11e7-8395-86bba8f0899a.png"> | <img width="736" alt="screenshot" src="https://user-images.githubusercontent.com/594356/32186129-86270af0-bda1-11e7-8e2a-ecf36f6cd5c4.png">

#### Testing instructions

1. Run `git checkout update/login-flow` and start your server, or open a [live branch](https://calypso.live/?branch=update/login-flow)

##### Default login

2. Open the [`Login` page](http://calypso.localhost:3000/log-in) in an incognito window
3. Assert that the page looks like the screenshot above
4. Assert that you can still log in

##### Default login (linking flow)

2. Log in with a WordPress.com account that is already connected to Google
3. Navigate to the [`Social Login` page](http://calypso.localhost:3000/social-login)
4. Click the `Disconnect` button
5. Sign out from WordPress.com
6. Open the [`Login` page](http://calypso.localhost:3000/log-in)
7. Click the `Continue with Google` button
8. Authenticate with Google
9. Assert that a `We found a WordPress.com account with the email address [...]` message is displayed 
10. Assert that the page looks like the screenshot above
11. Assert that you can still log in

##### WooCommerce

2. Open the WooCommerce [`Home` page](https://woocommerce.com/) in an incognito window
3. Click the `SIGN IN WITH WORDPRESS.COM` link in the header
4. Replace https://wordpress.com with http://calypso.localhost:3000 in the address bar, and reload
5. Assert that the page looks like the screenshot above
6. Assert that you can still log in

##### Other OAuth apps

2. Open the Akismet [`Home` page](https://akismet.com/) in an incognito window
3. Click the `Sign In` button in the header
4. Replace https://wordpress.com with http://calypso.localhost:3000 in the address bar, and reload
5. Assert that the page looks like the screenshot above
6. Assert that you can still log in

#### Additional notes

The [`Signup` page](http://calypso.localhost:3000/start/account) also offers the option to use Google but this part should remain unchanged.

#### Reviews

- [x] Code
- [ ] Product
- [ ] Tests