### PR TITLE
Comments Redesign: Enable in development environment

### DIFF
--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -14,6 +14,7 @@ import ReactCSSTransitionGroup from 'react-transition-group/CSSTransitionGroup';
 /**
  * Internal dependencies
  */
+import { isEnabled } from 'config';
 import {
 	changeCommentStatus,
 	deleteComment,
@@ -40,6 +41,8 @@ import {
 } from 'state/analytics/actions';
 import { isJetpackMinimumVersion, isJetpackSite } from 'state/sites/selectors';
 import { COMMENTS_PER_PAGE, NEWEST_FIRST } from '../constants';
+
+import Comment from '../comment';
 
 export class CommentList extends Component {
 	static propTypes = {
@@ -452,34 +455,54 @@ export class CommentList extends Component {
 					toggleBulkEdit={ this.toggleBulkEdit }
 					toggleSelectAll={ this.toggleSelectAll }
 				/>
+
 				<ReactCSSTransitionGroup
 					className="comment-list__transition-wrapper"
 					transitionEnterTimeout={ 150 }
 					transitionLeaveTimeout={ 150 }
 					transitionName="comment-list__transition"
 				>
-					{ map( commentsPage, commentId => (
-						<CommentDetail
-							commentId={ commentId }
-							commentIsSelected={ this.isCommentSelected( commentId ) }
-							deleteCommentPermanently={ this.deleteCommentPermanently }
-							editComment={ this.editComment }
-							isBulkEdit={ isBulkEdit }
-							key={ `comment-${ siteId }-${ commentId }` }
-							refreshCommentData={
-								isCommentsTreeSupported &&
-								! this.hasCommentJustMovedBackToCurrentStatus( commentId )
-							}
-							replyComment={ this.replyComment }
-							setCommentStatus={ this.setCommentStatus }
-							siteBlacklist={ siteBlacklist }
-							siteId={ siteId }
-							toggleCommentLike={ this.toggleCommentLike }
-							toggleCommentSelected={ this.toggleCommentSelected }
-						/>
-					) ) }
+					{ isEnabled( 'comments/management/m3-design' ) &&
+						map( commentsPage, commentId => (
+							<Comment
+								commentId={ commentId }
+								key={ `comment-${ siteId }-${ commentId }` }
+								isBulkMode={ isBulkEdit }
+								isSelected={ this.isCommentSelected( commentId ) }
+								refreshCommentData={
+									isCommentsTreeSupported &&
+									! this.hasCommentJustMovedBackToCurrentStatus( commentId )
+								}
+							/>
+						) ) }
 
-					{ showPlaceholder && <CommentDetailPlaceholder key="comment-detail-placeholder" /> }
+					{ isEnabled( 'comments/management/m3-design' ) &&
+					showPlaceholder && <Comment commentId={ 0 } key="comment-detail-placeholder" /> }
+
+					{ ! isEnabled( 'comments/management/m3-design' ) &&
+						map( commentsPage, commentId => (
+							<CommentDetail
+								commentId={ commentId }
+								commentIsSelected={ this.isCommentSelected( commentId ) }
+								deleteCommentPermanently={ this.deleteCommentPermanently }
+								editComment={ this.editComment }
+								isBulkEdit={ isBulkEdit }
+								key={ `comment-${ siteId }-${ commentId }` }
+								refreshCommentData={
+									isCommentsTreeSupported &&
+									! this.hasCommentJustMovedBackToCurrentStatus( commentId )
+								}
+								replyComment={ this.replyComment }
+								setCommentStatus={ this.setCommentStatus }
+								siteBlacklist={ siteBlacklist }
+								siteId={ siteId }
+								toggleCommentLike={ this.toggleCommentLike }
+								toggleCommentSelected={ this.toggleCommentSelected }
+							/>
+						) ) }
+
+					{ ! isEnabled( 'comments/management/m3-design' ) &&
+					showPlaceholder && <CommentDetailPlaceholder key="comment-detail-placeholder" /> }
 
 					{ showEmptyContent && (
 						<EmptyContent

--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -24,6 +24,7 @@ import {
 	unlikeComment,
 } from 'state/comments/actions';
 import { removeNotice, successNotice } from 'state/notices/actions';
+import Comment from 'my-sites/comments/comment';
 import CommentDetail from 'blocks/comment-detail';
 import CommentDetailPlaceholder from 'blocks/comment-detail/comment-detail-placeholder';
 import CommentNavigation from '../comment-navigation';
@@ -41,8 +42,6 @@ import {
 } from 'state/analytics/actions';
 import { isJetpackMinimumVersion, isJetpackSite } from 'state/sites/selectors';
 import { COMMENTS_PER_PAGE, NEWEST_FIRST } from '../constants';
-
-import Comment from '../comment';
 
 export class CommentList extends Component {
 	static propTypes = {
@@ -473,6 +472,7 @@ export class CommentList extends Component {
 									isCommentsTreeSupported &&
 									! this.hasCommentJustMovedBackToCurrentStatus( commentId )
 								}
+								toggleSelected={ this.toggleCommentSelected }
 							/>
 						) ) }
 

--- a/client/my-sites/comments/comment/comment-author.jsx
+++ b/client/my-sites/comments/comment/comment-author.jsx
@@ -31,6 +31,7 @@ export class CommentAuthor extends Component {
 
 	render() {
 		const {
+			authorAvatarUrl,
 			authorDisplayName,
 			authorUrl,
 			commentDate,
@@ -62,7 +63,9 @@ export class CommentAuthor extends Component {
 			<div className="comment__author">
 				<div className="comment__author-avatar">
 					{ /* A comment can be of type 'comment', 'pingback' or 'trackback'. */ }
-					{ 'comment' === commentType && <Gravatar user={ gravatarUser } /> }
+					{ 'comment' === commentType && !! authorAvatarUrl && <Gravatar user={ gravatarUser } /> }
+					{ 'comment' === commentType &&
+					! authorAvatarUrl && <span className="comment__author-gravatar-placeholder" /> }
 					{ 'comment' !== commentType && <Gridicon icon="link" size={ 24 } /> }
 				</div>
 

--- a/client/my-sites/comments/comment/comment-content.jsx
+++ b/client/my-sites/comments/comment/comment-content.jsx
@@ -49,7 +49,7 @@ export class CommentContent extends Component {
 	};
 
 	render() {
-		const { commentContent, commentId, isExpanded } = this.props;
+		const { commentContent, commentId, commentStatus, isExpanded, translate } = this.props;
 		return (
 			<div className="comment__content">
 				{ ! isExpanded && (
@@ -64,7 +64,13 @@ export class CommentContent extends Component {
 
 				{ isExpanded && (
 					<div className="comment__content-full">
-						<CommentPostLink { ...{ commentId } } />
+						<div className="comment__content-info">
+							<CommentPostLink { ...{ commentId } } />
+
+							{ 'unapproved' === commentStatus && (
+								<div className="comment__status-label">{ translate( 'Pending' ) }</div>
+							) }
+						</div>
 
 						{ this.renderInReplyTo() }
 
@@ -98,6 +104,7 @@ const mapStateToProps = ( state, { commentId } ) => {
 
 	return {
 		commentContent: get( comment, 'content' ),
+		commentStatus: get( comment, 'status' ),
 		commentUrl,
 		isJetpack,
 		parentCommentContent,

--- a/client/my-sites/comments/comment/comment-header.jsx
+++ b/client/my-sites/comments/comment/comment-header.jsx
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import React, { Component } from 'react';
+import React, { PureComponent } from 'react';
 import { connect } from 'react-redux';
 import Gridicon from 'gridicons';
 import { get } from 'lodash';
@@ -18,7 +18,7 @@ import { getMinimumComment } from 'my-sites/comments/comment/utils';
 import { getSiteComment } from 'state/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 
-export class CommentHeader extends Component {
+export class CommentHeader extends PureComponent {
 	toggleSelected = () => this.props.toggleSelected( this.props.minimumComment );
 
 	render() {

--- a/client/my-sites/comments/comment/comment-header.jsx
+++ b/client/my-sites/comments/comment/comment-header.jsx
@@ -2,10 +2,10 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import Gridicon from 'gridicons';
-import { get, noop } from 'lodash';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -14,41 +14,50 @@ import Button from 'components/button';
 import CommentAuthor from 'my-sites/comments/comment/comment-author';
 import CommentAuthorMoreInfo from 'my-sites/comments/comment/comment-author-more-info';
 import FormCheckbox from 'components/forms/form-checkbox';
+import { getMinimumComment } from 'my-sites/comments/comment/utils';
 import { getSiteComment } from 'state/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 
-export const CommentHeader = ( {
-	commentId,
-	isBulkMode,
-	isEditMode,
-	isExpanded,
-	isSelected,
-	showAuthorMoreInfo,
-	toggleExpanded,
-} ) => (
-	<div className="comment__header">
-		{ isBulkMode && (
-			<label className="comment__bulk-select">
-				<FormCheckbox checked={ isSelected } onChange={ noop } />
-			</label>
-		) }
+export class CommentHeader extends Component {
+	toggleSelected = () => this.props.toggleSelected( this.props.minimumComment );
 
-		<CommentAuthor { ...{ commentId, isExpanded } } />
+	render() {
+		const {
+			commentId,
+			isBulkMode,
+			isEditMode,
+			isExpanded,
+			isSelected,
+			showAuthorMoreInfo,
+			toggleExpanded,
+		} = this.props;
 
-		{ showAuthorMoreInfo && <CommentAuthorMoreInfo { ...{ commentId } } /> }
+		return (
+			<div className="comment__header">
+				{ isBulkMode && (
+					<label className="comment__bulk-select">
+						<FormCheckbox checked={ isSelected } onChange={ this.toggleSelected } />
+					</label>
+				) }
 
-		{ ! isBulkMode && (
-			<Button
-				borderless
-				className="comment__toggle-expanded"
-				disabled={ isEditMode }
-				onClick={ toggleExpanded }
-			>
-				<Gridicon icon="chevron-down" />
-			</Button>
-		) }
-	</div>
-);
+				<CommentAuthor { ...{ commentId, isExpanded } } />
+
+				{ showAuthorMoreInfo && <CommentAuthorMoreInfo { ...{ commentId } } /> }
+
+				{ ! isBulkMode && (
+					<Button
+						borderless
+						className="comment__toggle-expanded"
+						disabled={ isEditMode }
+						onClick={ toggleExpanded }
+					>
+						<Gridicon icon="chevron-down" />
+					</Button>
+				) }
+			</div>
+		);
+	}
+}
 
 const mapStateToProps = ( state, { commentId, isExpanded } ) => {
 	const siteId = getSelectedSiteId( state );
@@ -56,6 +65,7 @@ const mapStateToProps = ( state, { commentId, isExpanded } ) => {
 	const commentType = get( comment, 'type', 'comment' );
 
 	return {
+		minimumComment: getMinimumComment( comment ),
 		showAuthorMoreInfo: isExpanded && 'comment' === commentType,
 	};
 };

--- a/client/my-sites/comments/comment/comment-post-link.jsx
+++ b/client/my-sites/comments/comment/comment-post-link.jsx
@@ -53,6 +53,7 @@ const mapStateToProps = ( state, { commentId } ) => {
 		postId,
 		postTitle,
 		siteSlug,
+		siteId,
 	};
 };
 

--- a/client/my-sites/comments/comment/index.jsx
+++ b/client/my-sites/comments/comment/index.jsx
@@ -15,6 +15,7 @@ import { isUndefined } from 'lodash';
 import Card from 'components/card';
 import CommentContent from 'my-sites/comments/comment/comment-content';
 import CommentHeader from 'my-sites/comments/comment/comment-header';
+import QueryComment from 'components/data/query-comment';
 import { getSiteComment } from 'state/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 
@@ -23,6 +24,7 @@ export class Comment extends Component {
 		commentId: PropTypes.number,
 		isBulkMode: PropTypes.bool,
 		isSelected: PropTypes.bool,
+		refreshCommentData: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -61,7 +63,7 @@ export class Comment extends Component {
 	};
 
 	render() {
-		const { commentId, isBulkMode, isLoading, isSelected } = this.props;
+		const { commentId, isBulkMode, isLoading, isSelected, refreshCommentData, siteId } = this.props;
 		const { isEditMode, isExpanded } = this.state;
 
 		const classes = classNames( 'comment', {
@@ -78,6 +80,8 @@ export class Comment extends Component {
 				ref={ this.storeCardRef }
 				tabIndex="0"
 			>
+				{ refreshCommentData && <QueryComment commentId={ commentId } siteId={ siteId } /> }
+
 				{ ! isEditMode && (
 					<div className="comment__detail">
 						<CommentHeader
@@ -98,6 +102,7 @@ const mapStateToProps = ( state, { commentId } ) => {
 	const comment = getSiteComment( state, siteId, commentId );
 	return {
 		isLoading: isUndefined( comment ),
+		siteId,
 	};
 };
 

--- a/client/my-sites/comments/comment/index.jsx
+++ b/client/my-sites/comments/comment/index.jsx
@@ -25,6 +25,7 @@ export class Comment extends Component {
 		isBulkMode: PropTypes.bool,
 		isSelected: PropTypes.bool,
 		refreshCommentData: PropTypes.bool,
+		toggleSelected: PropTypes.func,
 	};
 
 	static defaultProps = {
@@ -63,7 +64,15 @@ export class Comment extends Component {
 	};
 
 	render() {
-		const { commentId, isBulkMode, isLoading, isSelected, refreshCommentData, siteId } = this.props;
+		const {
+			commentId,
+			isBulkMode,
+			isLoading,
+			isSelected,
+			refreshCommentData,
+			siteId,
+			toggleSelected,
+		} = this.props;
 		const { isEditMode, isExpanded } = this.state;
 
 		const classes = classNames( 'comment', {
@@ -85,7 +94,7 @@ export class Comment extends Component {
 				{ ! isEditMode && (
 					<div className="comment__detail">
 						<CommentHeader
-							{ ...{ commentId, isBulkMode, isEditMode, isExpanded, isSelected } }
+							{ ...{ commentId, isBulkMode, isEditMode, isExpanded, isSelected, toggleSelected } }
 							toggleExpanded={ this.toggleExpanded }
 						/>
 

--- a/client/my-sites/comments/comment/index.jsx
+++ b/client/my-sites/comments/comment/index.jsx
@@ -38,6 +38,12 @@ export class Comment extends Component {
 		isExpanded: false,
 	};
 
+	componentWillReceiveProps( nextProps ) {
+		if ( nextProps.isBulkMode && ! this.props.isBulkMode ) {
+			this.setState( { isExpanded: false } );
+		}
+	}
+
 	storeCardRef = card => ( this.commentCard = card );
 
 	keyDownHandler = event => {

--- a/client/my-sites/comments/comment/index.jsx
+++ b/client/my-sites/comments/comment/index.jsx
@@ -7,7 +7,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
 import ReactDom from 'react-dom';
-import { isUndefined } from 'lodash';
+import { get, isUndefined } from 'lodash';
 
 /**
  * Internal dependencies
@@ -66,6 +66,7 @@ export class Comment extends Component {
 	render() {
 		const {
 			commentId,
+			commentStatus,
 			isBulkMode,
 			isLoading,
 			isSelected,
@@ -80,6 +81,7 @@ export class Comment extends Component {
 			'is-collapsed': ! isExpanded && ! isBulkMode,
 			'is-expanded': isExpanded,
 			'is-placeholder': isLoading,
+			'is-unapproved': 'unapproved' === commentStatus,
 		} );
 
 		return (
@@ -110,6 +112,7 @@ const mapStateToProps = ( state, { commentId } ) => {
 	const siteId = getSelectedSiteId( state );
 	const comment = getSiteComment( state, siteId, commentId );
 	return {
+		commentStatus: get( comment, 'status' ),
 		isLoading: isUndefined( comment ),
 		siteId,
 	};

--- a/client/my-sites/comments/comment/index.jsx
+++ b/client/my-sites/comments/comment/index.jsx
@@ -4,8 +4,10 @@
  */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
 import classNames from 'classnames';
 import ReactDom from 'react-dom';
+import { isUndefined } from 'lodash';
 
 /**
  * Internal dependencies
@@ -13,18 +15,18 @@ import ReactDom from 'react-dom';
 import Card from 'components/card';
 import CommentContent from 'my-sites/comments/comment/comment-content';
 import CommentHeader from 'my-sites/comments/comment/comment-header';
+import { getSiteComment } from 'state/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
 
 export class Comment extends Component {
 	static propTypes = {
 		commentId: PropTypes.number,
 		isBulkMode: PropTypes.bool,
-		isLoading: PropTypes.bool,
 		isSelected: PropTypes.bool,
 	};
 
 	static defaultProps = {
 		isBulkMode: false,
-		isLoading: false,
 		isSelected: false,
 	};
 
@@ -59,13 +61,14 @@ export class Comment extends Component {
 	};
 
 	render() {
-		const { commentId, isBulkMode, isSelected } = this.props;
+		const { commentId, isBulkMode, isLoading, isSelected } = this.props;
 		const { isEditMode, isExpanded } = this.state;
 
 		const classes = classNames( 'comment', {
 			'is-bulk-mode': isBulkMode,
 			'is-collapsed': ! isExpanded && ! isBulkMode,
 			'is-expanded': isExpanded,
+			'is-placeholder': isLoading,
 		} );
 
 		return (
@@ -90,4 +93,12 @@ export class Comment extends Component {
 	}
 }
 
-export default Comment;
+const mapStateToProps = ( state, { commentId } ) => {
+	const siteId = getSelectedSiteId( state );
+	const comment = getSiteComment( state, siteId, commentId );
+	return {
+		isLoading: isUndefined( comment ),
+	};
+};
+
+export default connect( mapStateToProps )( Comment );

--- a/client/my-sites/comments/comment/style.scss
+++ b/client/my-sites/comments/comment/style.scss
@@ -46,8 +46,11 @@
 		transition: transform 0.15s cubic-bezier(0.175, 0.885, 0.32, 1.275), color 0.2s ease-in;
 	}
 
-	&:hover .gridicon {
-		fill: $blue-medium;
+	&:focus,
+	&:hover {
+		.gridicon {
+			fill: $blue-medium;
+		}
 	}
 }
 
@@ -292,5 +295,58 @@
 .card.comment.is-bulk-mode {
 	.comment__header .comment__author {
 		padding-left: 0;
+	}
+}
+
+// Placeholder View
+
+.card.comment.is-placeholder {
+	@include placeholder();
+
+	background-color: $white;
+
+	.comment__author-gravatar-placeholder {
+		background-color: lighten($gray, 30%);
+		border-radius: 50%;
+		display: block;
+		height: 32px;
+		width: 32px;
+	}
+
+	.comment__author-info {
+		padding: 5px 8px 5px 0;
+	}
+
+	.comment__author-info-element {
+		background-color: lighten($gray, 30%);
+		color: transparent;
+		height: 16px;
+
+		a,
+		a:focus,
+		a:hover,
+		.gridicon,
+		.comment__author-url-separator {
+			color: transparent;
+			cursor: default;
+		}
+	}
+
+	.button.comment__toggle-expanded {
+		display: none;
+	}
+
+	.comment__content {
+		padding-right: 16px;
+	}
+
+	.comment__content-preview {
+		background-color: lighten($gray, 30%);
+		color: transparent;
+		height: 21px;
+	}
+
+	.comment__in-reply-to {
+		display: none;
 	}
 }

--- a/client/my-sites/comments/comment/style.scss
+++ b/client/my-sites/comments/comment/style.scss
@@ -6,12 +6,16 @@
 	font-size: 14px;
 	margin: 0 auto;
 	padding: 0;
-	transition: margin 0.15s linear;
 
 	.accessible-focus &:focus {
 		box-shadow: 0 0 0 1px $blue-medium, 0 0 0 3px $blue-light;
 		z-index: z-index('root', '.comment-detail.card.accessible-focus:focus');
 	}
+}
+
+// `transition` here is applied with less specificity to avoid overwriting ReactCSSTransitionGroup's animation.
+.comment {
+	transition: margin 0.15s linear;
 }
 
 // Comment Header Block

--- a/client/my-sites/comments/comment/style.scss
+++ b/client/my-sites/comments/comment/style.scss
@@ -305,6 +305,14 @@
 
 	background-color: $white;
 
+	.comment__bulk-select {
+		display: none;
+	}
+
+	.comment__header .comment__author {
+		padding: 8px;
+	}
+
 	.comment__author-gravatar-placeholder {
 		background-color: lighten($gray, 30%);
 		border-radius: 50%;

--- a/client/my-sites/comments/comment/style.scss
+++ b/client/my-sites/comments/comment/style.scss
@@ -182,13 +182,16 @@
 .comment__content {
 	padding: 0 16px 16px 56px;
 
-	@include breakpoint( '>480px' ) {
-		padding-right: 56px;
+	.comment__content-info {
+		display: flex;
+		flex-flow: row;
+		flex-wrap: nowrap;
+		justify-content: space-between;
+		margin: 8px 0 1em 0;
 	}
 
 	.comment__post-link {
 		font-weight: 600;
-		margin: 8px 0 1em 0;
 		overflow: hidden;
 		text-overflow: ellipsis;
 		white-space: nowrap;
@@ -196,6 +199,16 @@
 		.gridicon {
 			display: none;
 		}
+	}
+
+	.comment__status-label {
+		align-self: center;
+		background: lighten($alert-yellow, 18%);
+		border-radius: 9px;
+		flex-grow: 0;
+		flex-shrink: 0;
+		font-size: 12px;
+		padding: 0 10px;
 	}
 
 	.comment__in-reply-to {
@@ -259,6 +272,16 @@
 	a:focus,
 	a:hover {
 		color: $blue-wordpress;
+	}
+}
+
+// Collapsed View
+
+.card.comment.is-collapsed {
+	&.is-unapproved {
+		background: mix($alert-yellow, $white, 8.5%);
+		box-shadow: inset 4px 0 0 0 $alert-yellow, 0 0 0 1px transparentize(lighten($gray, 20%), 0.5),
+			0 1px 2px lighten($gray, 30%);
 	}
 }
 
@@ -342,10 +365,6 @@
 
 	.button.comment__toggle-expanded {
 		display: none;
-	}
-
-	.comment__content {
-		padding-right: 16px;
 	}
 
 	.comment__content-preview {

--- a/client/my-sites/comments/comment/utils.js
+++ b/client/my-sites/comments/comment/utils.js
@@ -5,13 +5,12 @@
 import { get } from 'lodash';
 
 /**
- * Create a stripped down comment object containing only the information needed by
- * CommentList's change status and reply functions, and their respective undos.
+ * Create a stripped down comment object containing only the bare minimum fields needed by CommentList's actions.
  *
  * @param {Object} comment A comment object.
  * @returns {Object} A stripped down comment object.
  */
-export const getMinimalComment = comment => ( {
+export const getMinimumComment = comment => ( {
 	commentId: get( comment, 'ID' ),
 	isLiked: get( comment, 'i_like' ),
 	postId: get( comment, 'post.ID' ),

--- a/config/development.json
+++ b/config/development.json
@@ -43,6 +43,7 @@
 		"comments/moderation-tools-in-posts": true,
 		"comments/management": true,
 		"comments/management/comment-view": true,
+		"comments/management/m3-design": true,
 		"comments/management/post-view": true,
 		"comments/management/quick-actions": true,
 		"comments/management/sorting": true,

--- a/config/development.json
+++ b/config/development.json
@@ -43,7 +43,7 @@
 		"comments/moderation-tools-in-posts": true,
 		"comments/management": true,
 		"comments/management/comment-view": true,
-		"comments/management/m3-design": true,
+		"comments/management/m3-design": false,
 		"comments/management/post-view": true,
 		"comments/management/quick-actions": true,
 		"comments/management/sorting": true,


### PR DESCRIPTION
Follow up to #19225

This PR replaces `CommentDetail` with `Comment` in the `development` environment.
`Comment` is not yet complete (currently missing: actions, reply, edit), but it's in a good enough state that can be tested by @Automattic/lannister without hacks.

### Screenshots

Collapsed
<img width="606" alt="screen shot 2017-10-30 at 15 13 02" src="https://user-images.githubusercontent.com/2070010/32178657-2f385cce-bd85-11e7-95ee-26832276057b.png">

Expanded
<img width="604" alt="screen shot 2017-10-30 at 15 13 11" src="https://user-images.githubusercontent.com/2070010/32178660-30c4e292-bd85-11e7-85a4-986c358ad6f1.png">

Placeholder
<img width="673" alt="screen shot 2017-10-30 at 13 20 28" src="https://user-images.githubusercontent.com/2070010/32178662-32185f0c-bd85-11e7-9816-bcc861307224.png">

### Gaps

To fill the visual gaps I've also:

- Added the placeholder style: we don't need a specific component as before, but just some well-thought CSS overwrites.
- Added the missing Pending style and the Pending label.
- Added the `QueryComment` component and restored the persistence logic.
- Fixed the missing `toggleSelected` function: now `Comment` is completely compatible with bulk actions).
- Fixed the missing enter-leave animations.
- Fixed missing `siteId` props on `QueryPosts` to retrieve the post excerpt when its title is missing.