### PR TITLE
Guided Tour: improve positioning of step during scroll

### DIFF
--- a/client/layout/guided-tours/config-elements/step.js
+++ b/client/layout/guided-tours/config-elements/step.js
@@ -7,7 +7,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { debounce, defer } from 'lodash';
+import { defer } from 'lodash';
 import debugFactory from 'debug';
 
 /**
@@ -59,6 +59,12 @@ export default class Step extends Component {
 	};
 
 	static contextTypes = contextTypes;
+
+	/**
+	 * Flag to determine if we're repositioning the Step dialog
+	 * @type {boolean} True if the Step dialog is being repositioned.
+	 */
+	isUpdatingPosition = false;
 
 	componentWillMount() {
 		this.start();
@@ -210,9 +216,15 @@ export default class Step extends Component {
 		return this.lastTransitionTimestamp && Date.now() - this.lastTransitionTimestamp < 500;
 	}
 
-	onScrollOrResize = debounce( () => {
-		this.setStepPosition( this.props );
-	}, 50 );
+	onScrollOrResize = () => {
+		if ( ! this.isUpdatingPosition ) {
+			requestAnimationFrame( () => {
+				this.setStepPosition( this.props );
+				this.isUpdatingPosition = false;
+			} );
+			this.isUpdatingPosition = true;
+		}
+	};
 
 	setStepPosition( props, shouldScrollTo ) {
 		const { placement, target } = props;


### PR DESCRIPTION
This PR aims to improve the positioning of the Step dialog so it doesn't lag too much when user scrolls. It replaces `debounce` with native `requestAnimationFrame`. This PR is meant to offer an alternative but can and probably should be iterated.
The following examples show the step on Activity Log, implemented in #19148

#### Before
![tourdebounce](https://user-images.githubusercontent.com/1041600/32179528-6467f9ac-bd6e-11e7-91eb-c1e97548ae65.gif)

#### After
![tourraf](https://user-images.githubusercontent.com/1041600/32179529-649f4632-bd6e-11e7-98ff-38a40e8c082b.gif)

cc @MichaelArestad 