### PR TITLE
Store Products: Give the variation price a little more space

### DIFF
--- a/client/extensions/woocommerce/app/products/product-form.scss
+++ b/client/extensions/woocommerce/app/products/product-form.scss
@@ -447,6 +447,10 @@
 	min-width: 80px;
 }
 
+.products__product-form-variation-table-wrapper .form-text-input-with-affixes .form-currency-input {
+	min-width: 100px;
+}
+
 .products__product-form-variation-table-wrapper {
 	.form-dimensions-input__length,
 	.form-dimensions-input__width,


### PR DESCRIPTION
Fixes #18918. This simply increases the variation input width a little, so that it fits prices `> 9.99`. It's just a CSS fix to increase the space to a 5-digit number - expensive products will still be cut off if they're `> 999.99` (or `99,999`).

I tried automatically expanding the input if the price is >5 characters, but there's an animation on the size which delays the increase a little and ends up feeling distracting.

In Chrome:

<img width="153" alt="chrome" src="https://user-images.githubusercontent.com/541093/32183239-2692e99c-bd6f-11e7-932c-cbb699dfe0fa.png">

in Firefox:

<img width="158" alt="firefox" src="https://user-images.githubusercontent.com/541093/32183240-269e5264-bd6f-11e7-8500-a2c87a284f16.png">

To test:

- View a product with variations
- Scroll to the variations table, enter different prices to check that it's not unreasonably cut off
