### PR TITLE
Analytics: disable Yandex if .Ya object missing

### DIFF
--- a/client/lib/analytics/ad-tracking.js
+++ b/client/lib/analytics/ad-tracking.js
@@ -7,7 +7,7 @@
 import async from 'async';
 import cookie from 'cookie';
 import debugFactory from 'debug';
-import { assign, clone, cloneDeep, noop, some } from 'lodash';
+import { assign, clone, cloneDeep, noop } from 'lodash';
 import { v4 as uuid } from 'uuid';
 
 /**
@@ -39,7 +39,7 @@ const isQuantcastEnabled = true;
 const isTwitterEnabled = true;
 const isAolEnabled = true;
 const isLinkedinEnabled = true;
-const isYandexEnabled = true;
+let isYandexEnabled = true;
 const isOutbrainEnabled = true;
 const isAtlasEnabled = false;
 const isPandoraEnabled = false;
@@ -322,8 +322,10 @@ function loadTrackingScripts( callback ) {
 		} );
 	}
 
-	async.series( scripts, function( errors ) {
-		if ( ! some( errors ) ) {
+	async.series( scripts, function( error ) {
+		if ( error ) {
+			debug( 'Some scripts failed to load: ', error );
+		} else {
 			// init Facebook
 			if ( isFacebookEnabled ) {
 				window.fbq( 'init', TRACKING_IDS.facebookInit );
@@ -360,7 +362,12 @@ function loadTrackingScripts( callback ) {
 
 			// init Yandex counter
 			if ( isYandexEnabled ) {
-				window.yaCounter45268389 = new window.Ya.Metrika( { id: 45268389 } );
+				if ( window.Ya ) {
+					window.yaCounter45268389 = new window.Ya.Metrika( { id: 45268389 } );
+				} else {
+					debug( "Error: Yandex's window.Ya not ready or missing" );
+					isYandexEnabled = false;
+				}
 			}
 
 			hasFinishedFetchingScripts = true;
@@ -369,8 +376,6 @@ function loadTrackingScripts( callback ) {
 				callback();
 			}
 			debug( 'Scripts loaded successfully' );
-		} else {
-			debug( 'Some scripts failed to load: ', errors );
 		}
 	} );
 }


### PR DESCRIPTION
Yandex as it is generating a "Cannot read property 'Metrika' of undefined" for 10-20% of users. The error is caused by the `window.Ya` object not being available after the script has been successfully loaded (it's normally created by the script). Could be due to ad-blockers or Yandex returning an empty JS or a version of the script that does not initialize `.Ya` immediately. This creates problems for the other scripts as well.

This PR disables Yandex if the `.Ya` object  is missing.