### PR TITLE
Enable jitms in staging

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -38,7 +38,7 @@
 		"jetpack/api-cache": true,
 		"jetpack/happychat": true,
 		"jetpack_core_inline_update": true,
-		"jitms": false,
+		"jitms": true,
 		"keyboard-shortcuts": true,
 		"login/native-login-links": true,
 		"login/wp-login": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -43,7 +43,7 @@
 		"jetpack/google-analytics-anonymize-ip": true,
 		"jetpack/google-analytics-for-stores": true,
 		"jetpack_core_inline_update": true,
-		"jitms": false,
+		"jitms": true,
 		"login/magic-login": true,
 		"login/native-login-links": true,
 		"login/wp-login": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -43,7 +43,7 @@
 		"jetpack/google-analytics-anonymize-ip": true,
 		"jetpack/google-analytics-for-stores": true,
 		"jetpack_core_inline_update": true,
-		"jitms": false,
+		"jitms": true,
 		"login/magic-login": true,
 		"login/native-login-links": true,
 		"login/wp-login": true,


### PR DESCRIPTION
See #17118 and #18895 for code context.

This PR enables Just In Time Messages in Staging, Horizon and wpcalypso.

To test:

1. Click test live below
2. Visit the comments section of a Jetpack site with a free plan
3. See a JITM

<img width="1606" alt="screen shot 2017-10-30 at 3 06 52 pm" src="https://user-images.githubusercontent.com/1883296/32190371-02924aaa-bd84-11e7-8317-a614b8a446d1.png">

4. See the jitm under the comments section of wp-admin
5. Dismiss the jitm in Calypso
6. JITM should no longer show in either location after a refresh.