### PR TITLE
Follow button: use gridicons from library rather than inline SVGs

### DIFF
--- a/client/blocks/author-compact-profile/style.scss
+++ b/client/blocks/author-compact-profile/style.scss
@@ -18,7 +18,7 @@
 		border-radius: 0;
 		padding: 0;
 
-		.gridicon__follow {
+		.gridicons-reader-follow {
 			fill: $blue-medium;
 		}
 
@@ -38,7 +38,7 @@
 		// No hover if already following
 		&.is-following {
 			&:hover {
-				.gridicon__follow {
+				.gridicons-reader-follow {
 					fill: $alert-green;
 				}
 

--- a/client/blocks/follow-button/button.jsx
+++ b/client/blocks/follow-button/button.jsx
@@ -8,6 +8,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { noop } from 'lodash';
 import { localize } from 'i18n-calypso';
+import Gridicon from 'gridicons';
 
 class FollowButton extends React.Component {
 	static propTypes = {
@@ -63,39 +64,13 @@ class FollowButton extends React.Component {
 			menuClasses.push( 'is-disabled' );
 		}
 
-		const followingIcon = (
-				<svg
-					key="following"
-					className="gridicon gridicon__following"
-					height={ iconSize + 'px' }
-					width={ iconSize + 'px' }
-					xmlns="http://www.w3.org/2000/svg"
-					viewBox="0 0 24 24"
-				>
-					<g>
-						<path d="M23 13.482L15.508 21 12 17.4l1.412-1.388 2.106 2.188 6.094-6.094L23 13.482zm-7.455 1.862L20 10.89V2H2v14c0 1.1.9 2 2 2h4.538l4.913-4.832 2.095 2.176zM8 13H4v-1h4v1zm3-2H4v-1h7v1zm0-2H4V8h7v1zm7-3H4V4h14v2z" />
-					</g>
-				</svg>
-			),
-			followIcon = (
-				<svg
-					key="follow"
-					className="gridicon gridicon__follow"
-					height={ iconSize + 'px' }
-					width={ iconSize + 'px' }
-					xmlns="http://www.w3.org/2000/svg"
-					viewBox="0 0 24 24"
-				>
-					<g>
-						<path d="M23 16v2h-3v3h-2v-3h-3v-2h3v-3h2v3h3zM20 2v9h-4v3h-3v4H4c-1.1 0-2-.9-2-2V2h18zM8 13v-1H4v1h4zm3-3H4v1h7v-1zm0-2H4v1h7V8zm7-4H4v2h14V4z" />
-					</g>
-				</svg>
-			),
-			followLabelElement = (
-				<span key="label" className="follow-button__label">
-					{ label }
-				</span>
-			);
+		const followingIcon = <Gridicon key="following" icon="reader-following" size={ iconSize } />;
+		const followIcon = <Gridicon key="follow" icon="reader-follow" size={ iconSize } />;
+		const followLabelElement = (
+			<span key="label" className="follow-button__label">
+				{ label }
+			</span>
+		);
 
 		return React.createElement(
 			this.props.tagName,

--- a/client/blocks/follow-button/index.jsx
+++ b/client/blocks/follow-button/index.jsx
@@ -30,6 +30,7 @@ class FollowButtonContainer extends Component {
 	static defaultProps = {
 		onFollowToggle: noop,
 	};
+
 	handleFollowToggle = following => {
 		if ( following ) {
 			const followData = omitBy(

--- a/client/blocks/follow-button/style.scss
+++ b/client/blocks/follow-button/style.scss
@@ -5,7 +5,7 @@ button.follow-button {
 	border: 0;
 	padding: 0;
 
-	.gridicon__follow {
+	.gridicons-reader-follow {
 		fill: $blue-medium;
 		pointer-events: auto;
 	}
@@ -17,7 +17,7 @@ button.follow-button {
 	&:hover {
 		color: $blue-medium;
 
-		.gridicon__follow {
+		.gridicons-reader-follow {
 			fill: $blue-medium;
 		}
 	}
@@ -27,14 +27,14 @@ button.follow-button {
 	}
 
 	// Hides Following icon by default
-	.gridicon__following {
+	.gridicons-reader-following {
 		display: none;
 		pointer-events: none;
 	}
 
 	&.is-following {
 
-		.gridicon__following {
+		.gridicons-reader-following {
 			display: inline-block;
 			fill: $alert-green;
 			pointer-events: auto;
@@ -45,7 +45,7 @@ button.follow-button {
 		}
 
 		// Hides Follow icon if already following
-		.gridicon__follow {
+		.gridicons-reader-follow {
 			display: none;
 			pointer-events: none;
 		}
@@ -53,13 +53,13 @@ button.follow-button {
 		&:hover {
 			color: $alert-green;
 
-			.gridicon__following {
+			.gridicons-reader-following {
 				fill: $alert-green;
 			}
 		}
 	}
 
-	.gridicon__following {
+	.gridicons-reader-following {
 		pointer-events: none;
 	}
 

--- a/client/blocks/reader-recommended-sites/style.scss
+++ b/client/blocks/reader-recommended-sites/style.scss
@@ -137,7 +137,7 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 			}
 		}
 
-		.gridicon.gridicon__follow {
+		.gridicon.gridicons-reader-follow {
 
 			@include breakpoint( "<960px" ) {
 				left: 4px;

--- a/client/blocks/reader-related-card-v2/style.scss
+++ b/client/blocks/reader-related-card-v2/style.scss
@@ -569,7 +569,7 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 	padding: 0;
 	z-index: z-index( '.reader-related-card-v2__meta', '.follow-button' );
 
-	.gridicon__follow {
+	.gridicons-reader-follow {
 		fill: $blue-medium;
 	}
 

--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -341,7 +341,7 @@
 	display: none;
 }
 
-.search-stream__results.is-two-columns .gridicon__follow {
+.search-stream__results.is-two-columns .gridicons-reader-follow {
 	left: 2px;
 }
 


### PR DESCRIPTION
When the `follow-button` block was first built, I don't believe we had the follow/following icons in https://github.com/Automattic/gridicons.

Now we do! So I've switched over to use the library, rather than inline SVGs. I've also updated the classname accordingly wherever we've used it.

### To test

Check the Devdocs page and make sure everything looks fine and dandy:

http://calypso.localhost:3000/devdocs/blocks/follow-button

Check other uses of the follow button to make sure there are no changes in appearance, particularly author profile on full post, recommended sites, related posts, and search.