### PR TITLE
Atomic Store: remove word 'atomic' from URL & theme-selection step auto-skip

### DIFF
--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -244,8 +244,8 @@ const flows = {
 };
 
 if ( config.isEnabled( 'signup/atomic-store-flow' ) ) {
-	flows[ 'atomic-store' ] = {
-		steps: [ 'design-type-with-atomic-store', 'themes', 'domains', 'plans-atomic-store', 'user' ],
+	flows[ 'store-nux' ] = {
+		steps: [ 'design-type-with-store-nux', 'themes', 'domains', 'plans-store-nux', 'user' ],
 		destination: getSiteDestination,
 		description: 'Signup flow for creating an online store with an Atomic site',
 		lastModified: '2017-09-27',

--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -25,7 +25,7 @@ import PlansAtomicStoreComponent from 'signup/steps/plans-atomic-store';
 export default {
 	'design-type': DesignTypeComponent,
 	'design-type-with-store': DesignTypeWithStoreComponent,
-	'design-type-with-atomic-store': DesignTypeWithAtomicStoreComponent,
+	'design-type-with-store-nux': DesignTypeWithAtomicStoreComponent,
 	domains: DomainsStepComponent,
 	'domain-only': DomainsStepComponent,
 	'domains-theme-preselected': DomainsStepComponent,
@@ -33,7 +33,7 @@ export default {
 	'get-dot-blog-plans': GetDotBlogPlansStepComponent,
 	'get-dot-blog-themes': ThemeSelectionComponent,
 	plans: PlansStepComponent,
-	'plans-atomic-store': PlansAtomicStoreComponent,
+	'plans-store-nux': PlansAtomicStoreComponent,
 	'plans-site-selected': PlansStepWithoutFreePlan,
 	site: SiteComponent,
 	'rebrand-cities-welcome': RebrandCitiesWelcomeComponent,

--- a/client/signup/config/steps.js
+++ b/client/signup/config/steps.js
@@ -86,8 +86,8 @@ export default {
 		providesDependencies: [ 'designType', 'themeSlugWithRepo' ],
 	},
 
-	'design-type-with-atomic-store': {
-		stepName: 'design-type-with-atomic-store',
+	'design-type-with-store-nux': {
+		stepName: 'design-type-with-store-nux',
 		providesDependencies: [ 'designType', 'themeSlugWithRepo' ],
 	},
 
@@ -134,8 +134,8 @@ export default {
 		providesDependencies: [ 'cartItem', 'privacyItem' ],
 	},
 
-	'plans-atomic-store': {
-		stepName: 'plans-atomic-store',
+	'plans-store-nux': {
+		stepName: 'plans-store-nux',
 		apiRequestFunction: stepActions.addPlanToCart,
 		dependencies: [ 'siteSlug', 'siteId', 'domainItem' ],
 		providesDependencies: [ 'cartItem', 'privacyItem' ],

--- a/client/signup/steps/theme-selection/index.jsx
+++ b/client/signup/steps/theme-selection/index.jsx
@@ -89,22 +89,6 @@ class ThemeSelectionStep extends Component {
 		);
 	}
 
-	componentWillMount() {
-		SignupActions.submitSignupStep(
-			{
-				stepName: this.props.stepName,
-				processingMessage: this.props.translate( 'Adding your theme' ),
-				repoSlug: '',
-			},
-			null,
-			{
-				themeSlugWithRepo: '',
-			}
-		);
-
-		this.props.goToNextStep();
-	}
-
 	render = () => {
 		const storeSignup = this.isStoreSignup();
 		const defaultDependencies = this.props.useHeadstart

--- a/client/signup/steps/theme-selection/index.jsx
+++ b/client/signup/steps/theme-selection/index.jsx
@@ -80,20 +80,6 @@ class ThemeSelectionStep extends Component {
 		);
 	}
 
-	shouldGoToFirstStep() {
-		const { dependencyStore } = this.props;
-
-		return (
-			isEnabled( 'signup/atomic-store-flow' ) &&
-			this.props.designType === 'store' &&
-			dependencyStore.themeSlugWithRepo
-		);
-	}
-
-	shouldSkipStep() {
-		return false;
-	}
-
 	isStoreSignup() {
 		const { signupDependencies = {} } = this.props;
 
@@ -104,30 +90,22 @@ class ThemeSelectionStep extends Component {
 	}
 
 	componentWillMount() {
-		if ( this.shouldGoToFirstStep() ) {
-			this.props.goToStep( 'design-type-with-atomic-store' );
-		} else if ( this.shouldSkipStep() ) {
-			SignupActions.submitSignupStep(
-				{
-					stepName: this.props.stepName,
-					processingMessage: this.props.translate( 'Adding your theme' ),
-					repoSlug: '',
-				},
-				null,
-				{
-					themeSlugWithRepo: '',
-				}
-			);
+		SignupActions.submitSignupStep(
+			{
+				stepName: this.props.stepName,
+				processingMessage: this.props.translate( 'Adding your theme' ),
+				repoSlug: '',
+			},
+			null,
+			{
+				themeSlugWithRepo: '',
+			}
+		);
 
-			this.props.goToNextStep();
-		}
+		this.props.goToNextStep();
 	}
 
 	render = () => {
-		if ( this.shouldGoToFirstStep() || this.shouldSkipStep() ) {
-			return null;
-		}
-
 		const storeSignup = this.isStoreSignup();
 		const defaultDependencies = this.props.useHeadstart
 			? { themeSlugWithRepo: 'pub/twentysixteen' }


### PR DESCRIPTION
Word 'atomic' is for internal-use only. This PR replaces phrase `atomic-store` with `store-nux` in places affecting URL.

When theme-selection was re-enabled in a previous PR, skipping for back navigation was left as-is.
This PR removes it as well.

## Test Plan

1. Start Atomic Store signup from `/start/store-nux`
2. Verify in each step that word 'atomic' is not shown in browser location bar.
3. Step through *theme selection* to *domain choose* step.
4. Go back a step and verify that *theme selection* step is not skipped.
5. Proceed normally and complete checkout.