### PR TITLE
Activity Log: use rewind Id instead of timestamp.

### DIFF
--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -148,11 +148,11 @@ class ActivityLog extends Component {
 
 	handleRestoreDialogConfirm = () => {
 		const { recordTracksEvent, requestedRestoreActivity, rewindRestore, siteId } = this.props;
-		const { activityTs: timestamp } = requestedRestoreActivity;
+		const { rewindId } = requestedRestoreActivity;
 
 		debug( 'Restore requested for after activity %o', requestedRestoreActivity );
-		recordTracksEvent( 'calypso_activitylog_restore_confirm', { timestamp } );
-		rewindRestore( siteId, timestamp );
+		recordTracksEvent( 'calypso_activitylog_restore_confirm', { rewindId } );
+		rewindRestore( siteId, rewindId );
 	};
 
 	/**


### PR DESCRIPTION
In order to guarantee correct rewind behavior, it was decided to use the original timestamp from JP Sync everywhere possible, which is being called the `rewind_id`. This is the final piece of the switchover from initiating restores with millisecond timestamps to using the `rewind_id` instead, which is now present in the activity stream.

Follow up to https://github.com/Automattic/wp-calypso/pull/19301