### PR TITLE
Color Schemes: Change appearance of write button based on context

### DIFF
--- a/assets/stylesheets/shared/_color-schemes.scss
+++ b/assets/stylesheets/shared/_color-schemes.scss
@@ -6,6 +6,11 @@
 	--masterbar-item-hover-background: lighten( $blue-wordpress, 5% );
 	--masterbar-item-active-background: darken( $blue-wordpress, 17% );
 	--masterbar-item-new-color: $blue-wordpress;
+	--masterbar-item-new-editor-background: darken( $blue-wordpress, 17% );
+	--masterbar-item-new-editor-hover-background: darken( $blue-wordpress, 13% );
+	--masterbar-toggle-drafts-editor-background: darken( $blue-wordpress, 12% );
+	--masterbar-toggle-drafts-editor-border: darken( $blue-wordpress, 5% );
+	--masterbar-toggle-drafts-editor-hover-background: darken( $blue-wordpress, 17% );
 }
 
 //additional color schemes
@@ -17,6 +22,11 @@
 		--masterbar-item-hover-background: lighten( $gray, 30% );
 		--masterbar-item-active-background: lighten( $gray, 10% );
 		--masterbar-item-new-color: $gray-text;
+		--masterbar-item-new-editor-background: darken( $gray, 20% );
+		--masterbar-item-new-editor-hover-background: darken( $gray, 10% );
+		--masterbar-toggle-drafts-editor-background: darken( $gray, 10% );
+		--masterbar-toggle-drafts-editor-border: lighten( $gray, 20% );
+		--masterbar-toggle-drafts-editor-hover-background: darken( $gray, 10% );
 	}
 
 	&.is-dark {
@@ -26,5 +36,10 @@
 		--masterbar-item-hover-background: darken( $gray, 10% );
 		--masterbar-item-active-background: $gray-text-min;
 		--masterbar-item-new-color: $gray-dark;
+		--masterbar-item-new-editor-background: $gray-text-min;
+		--masterbar-item-new-editor-hover-background: lighten( $gray-text-min, 5% );
+		--masterbar-toggle-drafts-editor-background: darken( $gray, 10% );
+		--masterbar-toggle-drafts-editor-border: $gray-dark;
+		--masterbar-toggle-drafts-editor-hover-background: lighten( $gray-text-min, 5% );
 	}
 }

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -212,7 +212,7 @@ $autobar-height: 20px;
 
 	// active state when editing
 	.is-group-editor & {
-		background: darken( $masterbar-color, 17% );
+		background: var( --masterbar-item-new-editor-background );
 		color: $white;
 	}
 
@@ -222,7 +222,7 @@ $autobar-height: 20px;
 	}
 
 	.is-group-editor &:hover {
-		background: darken( $masterbar-color, 13% );
+		background: var( --masterbar-item-new-editor-hover-background );
 	}
 
 }
@@ -391,8 +391,8 @@ $autobar-height: 20px;
 	}
 
 	.is-group-editor & {
-		background: darken( $masterbar-color, 12% );
-		border-left: 1px solid darken( $masterbar-color, 5% );
+		background: var( --masterbar-toggle-drafts-editor-background );
+		border-left: 1px solid var( --masterbar-toggle-drafts-editor-border );
 
 		.count {
 			color: $gray-light;
@@ -400,7 +400,7 @@ $autobar-height: 20px;
 	}
 
 	.is-group-editor &:hover {
-		background: darken( $masterbar-color, 17% );
+		background: var( --masterbar-toggle-drafts-editor-hover-background );
 
 		.count {
 			color: $white;


### PR DESCRIPTION
### This PR 
- is part of a series of PRs aiming to provide support for Color Schemes in Calypso.
- focuses on changing the appearance of the write button based on context

#### Before
<img width="297" alt="screen shot 2017-10-30 at 15 10 05" src="https://user-images.githubusercontent.com/1562646/32196692-80a66aba-bd8f-11e7-89e5-79293c6a33ea.png">

#### After
<img width="269" alt="screen shot 2017-10-30 at 15 16 54" src="https://user-images.githubusercontent.com/1562646/32196727-98b79246-bd8f-11e7-8d5c-5846f206f8f8.png">
Note: Size difference due to varying screenshot size. Only the colors changed.


### How to test
- Visit https://calypso.live/?branch=update/color-schemes/masterbar-button-appearance or test locally.
- Navigate to the `Accounts Settings` page and scroll down to the `Admin Color Scheme` section. 
- Select the `Dark` color scheme and save the selection.
- Navigate to the editor and verify the new look of the `Write` button.
- Repeat process for the other color schemes.


### Notes

For a more detailed description of the feature, the chosen approach and its advantages feel free to check out my post on the subject: p4TIVU-75d-p2 (internal reference).
