### PR TITLE
Jetpack connect: Fix missing auto-authorizations

### DIFF
--- a/client/state/jetpack-connect/reducer/index.js
+++ b/client/state/jetpack-connect/reducer/index.js
@@ -5,7 +5,7 @@
 import jetpackAuthAttempts from './jetpack-auth-attempts';
 import jetpackConnectAuthorize from './jetpack-connect-authorize';
 import jetpackConnectSelectedPlans from './jetpack-connect-selected-plans';
-import jetpackConnectSessions from './jetpack-connect-site';
+import jetpackConnectSessions from './jetpack-connect-sessions';
 import jetpackConnectSite from './jetpack-connect-site';
 import jetpackSSO from './jetpack-sso';
 import { combineReducers } from 'state/utils';


### PR DESCRIPTION
Bad import was pulling in same reducer twice.

**To Test**
* create a poopy.life from this URL http://poopy.life/create?src=weary-duck&key=pVP6jBZR1C6wALZh
* go here http://calypso.localhost:3000/jetpack/new?ref=calypso-selector and add the new site url in the box

Expected: should not need to click an _Approve_ button during authorization

NOTE: I can't get this to work without needing to click the _Approve_ button. There is a redirect involved somewhere so this depends on state being persisted, which makes things random. This PR should be merged anyway in my opinion.
