### PR TITLE
Color Schemes: Make custom property use more predictable

### DIFF
--- a/assets/stylesheets/shared/_color-schemes.scss
+++ b/assets/stylesheets/shared/_color-schemes.scss
@@ -1,7 +1,7 @@
 //default color scheme
 :root {
 	--masterbar-color: $white;
-	--masterbar-background-color: $blue-wordpress;
+	--masterbar-background: $blue-wordpress;
 	--masterbar-border-color: darken( $blue-wordpress, 4% );
 	--masterbar-item-hover-background: lighten( $blue-wordpress, 5% );
 	--masterbar-item-active-background: darken( $blue-wordpress, 17% );
@@ -9,7 +9,7 @@
 	--masterbar-item-new-editor-background: darken( $blue-wordpress, 17% );
 	--masterbar-item-new-editor-hover-background: darken( $blue-wordpress, 13% );
 	--masterbar-toggle-drafts-editor-background: darken( $blue-wordpress, 12% );
-	--masterbar-toggle-drafts-editor-border: darken( $blue-wordpress, 5% );
+	--masterbar-toggle-drafts-editor-border-color: darken( $blue-wordpress, 5% );
 	--masterbar-toggle-drafts-editor-hover-background: darken( $blue-wordpress, 17% );
 }
 
@@ -17,7 +17,7 @@
 .color-scheme {
 	&.is-light {
 		--masterbar-color: $gray-text;
-		--masterbar-background-color: lighten( $gray, 20% );
+		--masterbar-background: lighten( $gray, 20% );
 		--masterbar-border-color: lighten( $gray, 10% );
 		--masterbar-item-hover-background: lighten( $gray, 30% );
 		--masterbar-item-active-background: lighten( $gray, 10% );
@@ -25,13 +25,13 @@
 		--masterbar-item-new-editor-background: darken( $gray, 20% );
 		--masterbar-item-new-editor-hover-background: darken( $gray, 10% );
 		--masterbar-toggle-drafts-editor-background: darken( $gray, 10% );
-		--masterbar-toggle-drafts-editor-border: lighten( $gray, 20% );
+		--masterbar-toggle-drafts-editor-border-color: lighten( $gray, 20% );
 		--masterbar-toggle-drafts-editor-hover-background: darken( $gray, 10% );
 	}
 
 	&.is-dark {
 		--masterbar-color: $white;
-		--masterbar-background-color: $gray-dark;
+		--masterbar-background: $gray-dark;
 		--masterbar-border-color: darken( $gray, 10% );
 		--masterbar-item-hover-background: darken( $gray, 10% );
 		--masterbar-item-active-background: $gray-text-min;
@@ -39,7 +39,7 @@
 		--masterbar-item-new-editor-background: $gray-text-min;
 		--masterbar-item-new-editor-hover-background: lighten( $gray-text-min, 5% );
 		--masterbar-toggle-drafts-editor-background: darken( $gray, 10% );
-		--masterbar-toggle-drafts-editor-border: $gray-dark;
+		--masterbar-toggle-drafts-editor-border-color: $gray-dark;
 		--masterbar-toggle-drafts-editor-hover-background: lighten( $gray-text-min, 5% );
 	}
 }

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -3,7 +3,7 @@ $autobar-height: 20px;
 
 // The WordPress.com Masterbar
 .masterbar {
-	background: var( --masterbar-background-color );
+	background: var( --masterbar-background );
 	border-bottom: 1px solid var( --masterbar-border-color );
 	color: var( --masterbar-color );
 	font-size: 16px;
@@ -392,7 +392,7 @@ $autobar-height: 20px;
 
 	.is-group-editor & {
 		background: var( --masterbar-toggle-drafts-editor-background );
-		border-left: 1px solid var( --masterbar-toggle-drafts-editor-border );
+		border-left: 1px solid var( --masterbar-toggle-drafts-editor-border-color );
 
 		.count {
 			color: $gray-light;

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -191,7 +191,7 @@
 	transition-delay: 0.4s;
 
 	@include breakpoint( "<480px" ) {
-		background: var( --masterbar-background-color );
+		background: var( --masterbar-background );
 	}
 }
 


### PR DESCRIPTION
### This PR 
- is part of a series of PRs aiming to provide support for Color Schemes in Calypso.
- focuses on enforcing a strict naming convention for custom properties

We want color schemes to be easily extendable while at the same time making it easy to understand how the color schemes work just by looking at `_color-schemes.scss`.

There we want to streamline the way custom properties are named. The custom property should always match the property it represents, so the value can take on different forms e.g.: 

`background: var( --some-class-background );`

where `--some-class-background` can flexibly take on the form of e.g.:
```
--some-class-background: #000000;
--some-class-background: linear-gradient(...);
--some-class-background: url(...) cover;
```

This allows for flexible changes to the design from `_color-schemes.scss` alone.

If we want/need a custom property to specifically represent a certain type of value, we indicate this in the naming of the custom property e.g.:

```
border: 1px solid var( --some-class-border-color );
border-color: var( --some-class-border-color );
```
Where `--some-class-border-color` should explicitely only take the form of a color value.


### How to test
- Visit https://calypso.live/?branch=update/color-schemes/predictable-custom-props or test locally.
- Navigate to the `Accounts Settings` page and scroll down to the `Admin Color Scheme` section. 
- Switch between the different themes
- Compare against https://calypso.live/?branch=update/color-schemes/masterbar-button-appearance (or master if https://github.com/Automattic/wp-calypso/pull/19304 is already merged)
- As this PR only changes the names of variables, there should be no visual changes between the two branches.
- Run the CSS build, it should build without errors.

### Notes

For a more detailed description of the feature, the chosen approach and its advantages feel free to check out my post on the subject: p4TIVU-75d-p2 (internal reference).
