### PR TITLE
Comments hide bulk and sort controls if no comments are in view

### DIFF
--- a/client/my-sites/comments/comment-navigation/index.jsx
+++ b/client/my-sites/comments/comment-navigation/index.jsx
@@ -101,6 +101,7 @@ export class CommentNavigation extends Component {
 		const {
 			doSearch,
 			hasSearch,
+			hasComments,
 			isBulkEdit,
 			isCommentsTreeSupported,
 			isSelectedAll,
@@ -203,7 +204,8 @@ export class CommentNavigation extends Component {
 
 				<CommentNavigationTab className="comment-navigation__actions comment-navigation__open-bulk">
 					{ isEnabled( 'comments/management/sorting' ) &&
-					isCommentsTreeSupported && (
+					isCommentsTreeSupported &&
+					hasComments && (
 						<SegmentedControl compact className="comment-navigation__sort-buttons">
 							<ControlItem
 								onClick={ setSortOrder( NEWEST_FIRST ) }
@@ -224,9 +226,11 @@ export class CommentNavigation extends Component {
 						</SegmentedControl>
 					) }
 
-					<Button compact onClick={ toggleBulkEdit }>
-						{ translate( 'Bulk Edit' ) }
-					</Button>
+					{ hasComments && (
+						<Button compact onClick={ toggleBulkEdit }>
+							{ translate( 'Bulk Edit' ) }
+						</Button>
+					) }
 				</CommentNavigationTab>
 
 				{ hasSearch && (
@@ -252,6 +256,7 @@ const mapStateToProps = ( state, { commentsPage, siteId } ) => {
 
 	return {
 		visibleComments,
+		hasComments: visibleComments.length > 0,
 		isCommentsTreeSupported:
 			! isJetpackSite( state, siteId ) || isJetpackMinimumVersion( state, siteId, '5.3' ),
 	};


### PR DESCRIPTION
This closes #19019 which asks us to not display sort or bulk actions if no comments are available.

Without comments:

<img width="945" alt="screen shot 2017-10-30 at 4 59 49 pm" src="https://user-images.githubusercontent.com/1270189/32201543-fdaf7808-bd94-11e7-88c9-d5376ee517a0.png">

With comments:

<img width="961" alt="screen shot 2017-10-30 at 5 00 04 pm" src="https://user-images.githubusercontent.com/1270189/32201552-0ee88998-bd95-11e7-86f3-39e8c5bb8212.png">

### Testing Instructions
- Navigate to /comments
- Select a site that has some comments
- No regressions for bulk actions or sorting
- Navigate to /comments
- Select a site that has no comments in a view
- Verify that controls are not displayed