### PR TITLE
Rewind: Simplify rendering logic for dialog, fix some stuff

### DIFF
--- a/client/components/data/query-rewind-restore-status/index.js
+++ b/client/components/data/query-rewind-restore-status/index.js
@@ -20,7 +20,7 @@ class QueryRewindRestoreStatus extends PureComponent {
 		queryDelay: PropTypes.number.isRequired,
 		restoreId: PropTypes.number,
 		siteId: PropTypes.number.isRequired,
-		timestamp: PropTypes.number.isRequired,
+		timestamp: PropTypes.string.isRequired,
 	};
 
 	static defaultProps = {

--- a/client/my-sites/stats/activity-log-banner/error-banner.jsx
+++ b/client/my-sites/stats/activity-log-banner/error-banner.jsx
@@ -21,7 +21,7 @@ class ErrorBanner extends PureComponent {
 		failureReason: PropTypes.string.isRequired,
 		requestRestore: PropTypes.func.isRequired,
 		siteId: PropTypes.number.isRequired,
-		timestamp: PropTypes.number.isRequired,
+		timestamp: PropTypes.string.isRequired,
 
 		// connect
 		dismissRewindRestoreProgress: PropTypes.func.isRequired,

--- a/client/my-sites/stats/activity-log-banner/progress-banner.jsx
+++ b/client/my-sites/stats/activity-log-banner/progress-banner.jsx
@@ -59,7 +59,7 @@ ProgressBanner.propTypes = {
 	percent: PropTypes.number.isRequired,
 	siteId: PropTypes.number,
 	status: PropTypes.oneOf( [ 'queued', 'running' ] ).isRequired,
-	timestamp: PropTypes.number.isRequired,
+	timestamp: PropTypes.string.isRequired,
 };
 
 export default localize( ProgressBanner );

--- a/client/my-sites/stats/activity-log-banner/progress-banner.jsx
+++ b/client/my-sites/stats/activity-log-banner/progress-banner.jsx
@@ -13,6 +13,25 @@ import ActivityLogBanner from './index';
 import ProgressBar from 'components/progress-bar';
 import QueryRewindRestoreStatus from 'components/data/query-rewind-restore-status';
 
+/**
+ * Normalize timestamp values
+ *
+ * Some timestamps are in seconds instead
+ * of in milliseconds and this will make
+ * sure they are all reported in ms
+ *
+ * The chosen comparison date is older than
+ * WordPress so no backups should already
+ * exist prior to that date 😉
+ *
+ * @param {Number} ts timestamp in 's' or 'ms'
+ * @returns {Number} timestamp in 'ms'
+ */
+const ms = ts =>
+	ts < 946702800000 // Jan 1, 2001 @ 00:00:00
+		? ts * 1000 // convert s -> ms
+		: ts;
+
 function ProgressBanner( {
 	applySiteOffset,
 	moment,
@@ -42,7 +61,7 @@ function ProgressBanner( {
 				{ translate(
 					"We're in the process of restoring your site back to %s. " +
 						"You'll be notified once it's complete.",
-					{ args: applySiteOffset( moment.utc( timestamp ) ).format( 'LLLL' ) }
+					{ args: applySiteOffset( moment.utc( ms( timestamp ) ) ).format( 'LLLL' ) }
 				) }
 			</p>
 

--- a/client/my-sites/stats/activity-log-banner/success-banner.jsx
+++ b/client/my-sites/stats/activity-log-banner/success-banner.jsx
@@ -21,7 +21,7 @@ class SuccessBanner extends PureComponent {
 		applySiteOffset: PropTypes.func.isRequired,
 		siteId: PropTypes.number.isRequired,
 		siteUrl: PropTypes.string.isRequired,
-		timestamp: PropTypes.number.isRequired,
+		timestamp: PropTypes.string.isRequired,
 
 		// connect
 		dismissRewindRestoreProgress: PropTypes.func.isRequired,

--- a/client/my-sites/stats/activity-log-day/index.jsx
+++ b/client/my-sites/stats/activity-log-day/index.jsx
@@ -10,7 +10,7 @@ import classNames from 'classnames';
 import Gridicon from 'gridicons';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { findKey, flatMap, get, isEmpty, map } from 'lodash';
+import { findIndex, get, isEmpty } from 'lodash';
 
 /**
  * Internal dependencies
@@ -30,12 +30,37 @@ import { rewriteStream } from 'state/activity-log/log/is-discarded';
 const DAY_IN_MILLISECONDS = 1000 * 60 * 60 * 24;
 
 /**
- * Check that the object passed is the Rewind dialog.
+ * Separates events into those before, at, and after a rewind operation
  *
- * @param {object} item Can be a regular object or a React element.
- * @returns {boolean} True if this is the React element for the Rewind dialog.
+ * @param {Array} logs activity log items
+ * @param {Number} activityId selected rewind operation
+ * @returns {[Array, Array, Array]} [ before, at, after ]
  */
-const isRewindDialog = ( { key } ) => 'activity-rewind-dialog' === key;
+const splitByRewind = ( logs, activityId ) => {
+	const rewindIndex = findIndex( logs, log => log.activityId === activityId );
+
+	// no dialog is open
+	if ( -1 === rewindIndex ) {
+		return [ logs, [], [] ];
+	}
+
+	// dialog is open at first item
+	if ( 0 === rewindIndex ) {
+		return [ [], [], logs ];
+	}
+
+	// first item is immediately before
+	if ( 1 === rewindIndex ) {
+		return [ [], [ logs[ 0 ] ], logs.slice( 1 ) ];
+	}
+
+	// everything else is standard
+	return [
+		logs.slice( 0, rewindIndex - 1 ),
+		[ logs[ rewindIndex ] ],
+		logs.slice( rewindIndex + 1 ),
+	];
+};
 
 class ActivityLogDay extends Component {
 	static propTypes = {
@@ -209,16 +234,22 @@ class ActivityLogDay extends Component {
 		);
 
 		const rewindButton = this.renderRewindButton( hasConfirmDialog ? '' : 'primary' );
-		const elementsInDay = rewriteStream( logs );
+		const [ newer, ontop, older ] = splitByRewind(
+			rewriteStream( logs ),
+			requestedRestoreActivityId
+		);
 
-		// Include the Rewind dialog in the right place in the collection
-		if ( hasConfirmDialog ) {
-			elementsInDay.splice(
-				findKey( elementsInDay, [ 'activityId', requestedRestoreActivityId ] ),
-				0,
-				rewindConfirmDialog
-			);
-		}
+		const LogItem = ( { log, extraClasses } ) => (
+			<ActivityLogItem
+				className={ extraClasses }
+				applySiteOffset={ applySiteOffset }
+				disableRestore={ disableRestore }
+				hideRestore={ hideRestore }
+				log={ log }
+				requestRestore={ requestRestore }
+				siteId={ siteId }
+			/>
+		);
 
 		return (
 			<div
@@ -235,32 +266,12 @@ class ActivityLogDay extends Component {
 					onOpen={ this.trackOpenDay }
 					onClose={ this.handleCloseDay( hasConfirmDialog ) }
 				>
-					{ flatMap(
-						map(
-							elementsInDay,
-							( elem, index, list ) =>
-								isRewindDialog( elem ) ? (
-									// If this is the Rewind dialog, insert it in timeline
-									elem
-								) : (
-									// Otherwise it's a regular event
-									<ActivityLogItem
-										className={ classNames( {
-											// Is this event right before the Rewind dialog?
-											'is-before-dialog':
-												index < list.length - 1 && isRewindDialog( list[ ++index ] ),
-										} ) }
-										applySiteOffset={ applySiteOffset }
-										disableRestore={ disableRestore }
-										hideRestore={ hideRestore }
-										key={ elem.activityId }
-										log={ elem }
-										requestRestore={ requestRestore }
-										siteId={ siteId }
-									/>
-								)
-						)
-					) }
+					{ newer.map( log => <LogItem { ...{ key: log.activityId, log } } /> ) }
+					{ ontop.map( log => (
+						<LogItem { ...{ key: log.activityId, log, extraClasses: 'is-before-dialog' } } />
+					) ) }
+					{ older.length > 0 && rewindConfirmDialog }
+					{ older.map( log => <LogItem { ...{ key: log.activityId, log } } /> ) }
 				</FoldableCard>
 			</div>
 		);

--- a/client/my-sites/stats/activity-log-day/index.jsx
+++ b/client/my-sites/stats/activity-log-day/index.jsx
@@ -230,9 +230,9 @@ class ActivityLogDay extends Component {
 			requestedRestoreActivityId
 		);
 
-		const LogItem = ( { log, extraClasses } ) => (
+		const LogItem = ( { log, hasBreak } ) => (
 			<ActivityLogItem
-				className={ extraClasses }
+				className={ hasBreak ? 'is-before-dialog' : '' }
 				applySiteOffset={ applySiteOffset }
 				disableRestore={ disableRestore }
 				hideRestore={ hideRestore }
@@ -258,11 +258,7 @@ class ActivityLogDay extends Component {
 					onClose={ this.handleCloseDay( hasConfirmDialog ) }
 				>
 					{ newer.map( log => <LogItem { ...{ key: log.activityId, log } } /> ) }
-					{ above && (
-						<LogItem
-							{ ...{ key: above.activityId, log: above, extraClasses: 'is-before-dialog' } }
-						/>
-					) }
+					{ above && <LogItem { ...{ key: above.activityId, log: above, hasBreak: true } } /> }
 					{ older.length > 0 && rewindConfirmDialog }
 					{ older.map( log => <LogItem { ...{ key: log.activityId, log } } /> ) }
 				</FoldableCard>

--- a/client/my-sites/stats/activity-log-day/style.scss
+++ b/client/my-sites/stats/activity-log-day/style.scss
@@ -97,12 +97,16 @@
 		height: 16px;
 		left: 33px;
 		width: 2px;
-		background-color: lighten( $gray, 20% );
+		border-left: 2px solid lighten( $gray, 20% );
 
 		@include breakpoint( "<480px" ) {
 			left: 29px;
 		}
 	}
+}
+
+.activity-log-item.is-discarded:before {
+	border-left-style: dotted;
 }
 
 .activity-log-day.is-empty:before {

--- a/client/my-sites/stats/activity-log-item/style.scss
+++ b/client/my-sites/stats/activity-log-item/style.scss
@@ -56,6 +56,14 @@
 	.foldable-card__main {
 		flex: 5 1;
 	}
+
+	&.is-discarded {
+		margin-left: 80px;
+	}
+
+	&.is-discarded * {
+		background-color: unset;
+	}
 }
 
 .activity-log-item__type {

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -203,7 +203,7 @@ class ActivityLog extends Component {
 				// 'success',
 				// 'success-with-errors',
 			] ).isRequired,
-			timestamp: PropTypes.number.isRequired,
+			timestamp: PropTypes.string.isRequired,
 		} ),
 		recordTracksEvent: PropTypes.func.isRequired,
 		requestedRestoreActivity: PropTypes.shape( {


### PR DESCRIPTION
This PR follows #19207 in an attempt to rein in some growing
complexity in the render logic for inserting the rewind
confirmation dialog and the extra classes for the preceeding
activity log entry (if any).

What was more mangled in the imperative sense is now split up
in another function into events that occur _before_ a restore
request, at the same time as a restore request, and _after_ a
restore request. The `render()` function then applies it's own
styling to these events and inserts the dialog right where it's
needed without having to alter the array of events.

This also follows up on #19301 where I _think_ some places were
missed when converting `timestamp` values into `rewindId` values.
These changes could use some extra auditing because I'm not so
sure I did everything properly.

---

At some point in the jumble of #18981 and #19207 the rewind
confirmation dialog stopped appearing. I think it could have
been due to some rebase conflict that I didn't handle properly.
In this PR that bug has been resolved.

---

While working on this I noted that the error banner wasn't
restarting an attempt to restore a backup after clicking on
the `Try Again` button. While investigating I found that
nothing is watching for that action `_PLEASE` other than a
reducer and so I assumed it was pre-existing and maybe alreadyd
slated for finished. Nonetheless, it will be erroneous here.

Further, I could not restore a backup, instead receiving at
the very end an error message indicating `error 1: Error: incorrect
header check`. Not sure if this is related to the code here
or in the preceding PRs or if this is related to issues on
the server or the `rewindId` vs. `timestamp` stuff.

**Testing**

Open up a _Rewind-activated_ site in **Stats** > **Activity** and
scan through the days. Try to open and close the foldable day cards.
Try to click on the full backup rewind buttons (the ones on the card
headers) and try to click on the partial backup buttons (the ones on
the events themselves, hidden under the horizontal ellipses).

When one rewind confirmation dialog is already open, then clicking
on another one should close the first one.

When confirming a restore, the dialog should close and a progress
bar should appear at the top of the page.