### PR TITLE
Remove `sanitize-html` dependency

### DIFF
--- a/client/lib/plugins/sanitize-section-content.js
+++ b/client/lib/plugins/sanitize-section-content.js
@@ -91,12 +91,7 @@ export const sanitizeSectionContent = content => {
 	const doc = parser.parseFromString( content, 'text/html' );
 
 	// this will let us visit every single DOM node programmatically
-	const walker = doc.createTreeWalker(
-		doc.body,
-		NodeFilter.SHOW_ALL,
-		{ acceptNode: () => NodeFilter.FILTER_ACCEPT },
-		false
-	);
+	const walker = doc.createTreeWalker( doc.body );
 
 	// we don't want to remove nodes while walking the tree
 	// or we'll invite data-race bugs. instead, we'll track

--- a/client/lib/plugins/sanitize-section-content.js
+++ b/client/lib/plugins/sanitize-section-content.js
@@ -166,11 +166,19 @@ export const sanitizeSectionContent = content => {
 	}
 
 	// once done walking the DOM tree
-	// remove the unwanted nodes
+	// remove the unwanted tags and transfer
+	// their children up a level in their place
 	removeList.forEach( node => {
+		const parent = node.parentNode;
+		let child;
+
 		try {
-			// DOM is fun
-			node.parentNode.removeChild( node );
+			// eslint-disable-next-line no-cond-assign
+			while ( ( child = node.firstChild ) ) {
+				parent.insertBefore( child, node );
+			}
+
+			parent.removeChild( node );
 		} catch ( e ) {
 			// this one could have originally existed
 			// under a node that we already removed,

--- a/client/lib/plugins/sanitize-section-content.js
+++ b/client/lib/plugins/sanitize-section-content.js
@@ -1,0 +1,189 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import validUrl from 'valid-url';
+
+const isAllowedTag = tagName => {
+	switch ( tagName ) {
+		case '#text':
+		case 'a':
+		case 'b':
+		case 'blockquote':
+		case 'code':
+		case 'div':
+		case 'em':
+		case 'h1':
+		case 'h2':
+		case 'h3':
+		case 'h4':
+		case 'h5':
+		case 'h6':
+		case 'i':
+		case 'img':
+		case 'li':
+		case 'ol':
+		case 'p':
+		case 'span':
+		case 'strong':
+		case 'ul':
+			return true;
+		default:
+			return false;
+	}
+};
+
+const isAllowedAttr = ( tagName, attrName ) => {
+	if ( 'a' === tagName && 'href' === attrName ) {
+		return true;
+	}
+
+	if ( 'iframe' === tagName ) {
+		switch ( attrName ) {
+			case 'class':
+			case 'type':
+			case 'height':
+			case 'width':
+			case 'src':
+				return true;
+			default:
+				return false;
+		}
+	}
+
+	if ( 'img' === tagName && ( 'alt' === attrName || 'src' === attrName ) ) {
+		return true;
+	}
+
+	return false;
+};
+
+const isValidYoutubeEmbed = node => {
+	if ( node.nodeName.toLowerCase() !== 'iframe' ) {
+		return false;
+	}
+
+	if ( node.getAttribute( 'class' ) !== 'youtube-player' ) {
+		return false;
+	}
+
+	if ( node.getAttribute( 'type' ) !== 'text/html' ) {
+		return false;
+	}
+
+	const link = document.createElement( 'a' );
+	link.href = node.getAttribute( 'src' );
+
+	return (
+		validUrl.isWebUri( node.getAttribute( 'src' ) ) &&
+		( link.hostname === 'youtube.com' || link.hostname === 'www.youtube.com' )
+	);
+};
+
+/**
+ * Sanitizes input HTML for security and styling
+ *
+ * @param {String} content unverified HTML
+ * @returns {string} sanitized HTML
+ */
+export const sanitizeSectionContent = content => {
+	const parser = new DOMParser();
+	const doc = parser.parseFromString( content, 'text/html' );
+
+	// this will let us visit every single DOM node programmatically
+	const walker = doc.createTreeWalker(
+		doc.body,
+		NodeFilter.SHOW_ALL,
+		{ acceptNode: () => NodeFilter.FILTER_ACCEPT },
+		false
+	);
+
+	// we don't want to remove nodes while walking the tree
+	// or we'll invite data-race bugs. instead, we'll track
+	// which ones we want to remove then drop them at the end
+	const removeList = [];
+
+	// walk over every DOM node
+	while ( walker.nextNode() ) {
+		const node = walker.currentNode;
+		const tagName = node.nodeName.toLowerCase();
+
+		if ( ! isAllowedTag( tagName ) && ! isValidYoutubeEmbed( node ) ) {
+			removeList.push( node );
+			continue;
+		}
+
+		// strip out anything not explicitly allowed
+		// in the attributes. we want to eliminate
+		// potential cross-site scripting attacks _and_
+		// prevent custom styles from interfering with
+		// our page's own rendering
+
+		const attrRemoveList = [];
+
+		// these aren't Arrays, so iteration is odd
+		for ( let i = 0; node.attributes && i < node.attributes.length; i++ ) {
+			const { name: attrName, value } = node.attributes[ i ];
+
+			// get rid of non-whitelisted attributes
+			if ( ! isAllowedAttr( tagName, attrName ) ) {
+				attrRemoveList.push( attrName );
+				continue;
+			}
+
+			// for some, specifically links, we don't want to
+			// "sanitize" the values because we could mess them up
+			// for example, encoding a real URL will break it
+			if (
+				( ( 'src' === attrName || 'href' === attrName ) && validUrl.isWebUri( value ) ) ||
+				( 'iframe' === tagName && 'type' === attrName && isValidYoutubeEmbed( node ) )
+			) {
+				continue;
+			}
+
+			// just don't even allow non-url links
+			if ( ( 'href' === attrName || 'src' === attrName ) && ! validUrl.isWebUri( value ) ) {
+				attrRemoveList.push( attrName );
+				continue;
+			}
+
+			// every other other allowed attribute must be sanitized
+			// this is a broad and clumsy stroke but it should be
+			// effective, leaning towards safety instead of
+			// compatability with the remote HTML
+			node.setAttribute( attrName, encodeURIComponent( value ) );
+		}
+
+		// actually remove the attributes
+		attrRemoveList.forEach( name => node.removeAttribute( name ) );
+
+		// of course, all links need to be normalized since
+		// they now exist inside of the Calypso context
+		if ( 'a' === tagName && node.getAttribute( 'href' ) ) {
+			node.setAttribute( 'target', '_blank' );
+			node.setAttribute( 'rel', 'external noopener noreferrer' );
+		}
+	}
+
+	// once done walking the DOM tree
+	// remove the unwanted nodes
+	for ( let i = 0; i < removeList.length; i++ ) {
+		const node = removeList[ i ];
+
+		try {
+			// DOM is fun
+			node.parentNode.removeChild( node );
+		} catch ( e ) {
+			// this one could have originally existed
+			// under a node that we already removed,
+			// which would lead to a failure right now
+			// this is fine, just continue along
+		}
+	}
+
+	const html = doc.body.innerHTML;
+
+	// finally, bump higher-level headers down a few levels
+	// because we're sitting under an <h2> context already
+	return html.replace( /<h[12]/, '<h3' ).replace( /<\/h[12]/, '</h3' );
+};

--- a/client/lib/plugins/sanitize-section-content.js
+++ b/client/lib/plugins/sanitize-section-content.js
@@ -2,6 +2,7 @@
 /**
  * External dependencies
  */
+import { forEach } from 'lodash';
 import validUrl from 'valid-url';
 
 const isAllowedTag = tagName => {
@@ -117,13 +118,11 @@ export const sanitizeSectionContent = content => {
 		const attrRemoveList = [];
 
 		// these aren't Arrays, so iteration is odd
-		for ( let i = 0; node.attributes && i < node.attributes.length; i++ ) {
-			const { name: attrName, value } = node.attributes[ i ];
-
+		forEach( node.attributes, ( { name: attrName, value } ) => {
 			// get rid of non-whitelisted attributes
 			if ( ! isAllowedAttr( tagName, attrName ) ) {
 				attrRemoveList.push( attrName );
-				continue;
+				return;
 			}
 
 			// for some, specifically links, we don't want to
@@ -133,21 +132,14 @@ export const sanitizeSectionContent = content => {
 				( ( 'src' === attrName || 'href' === attrName ) && validUrl.isWebUri( value ) ) ||
 				( 'iframe' === tagName && 'type' === attrName && isValidYoutubeEmbed( node ) )
 			) {
-				continue;
+				return;
 			}
 
 			// just don't even allow non-url links
 			if ( ( 'href' === attrName || 'src' === attrName ) && ! validUrl.isWebUri( value ) ) {
 				attrRemoveList.push( attrName );
-				continue;
 			}
-
-			// every other other allowed attribute must be sanitized
-			// this is a broad and clumsy stroke but it should be
-			// effective, leaning towards safety instead of
-			// compatibility with the remote HTML
-			node.setAttribute( attrName, encodeURIComponent( value ) );
-		}
+		} );
 
 		// actually remove the attributes
 		attrRemoveList.forEach( name => node.removeAttribute( name ) );

--- a/client/lib/plugins/sanitize-section-content.js
+++ b/client/lib/plugins/sanitize-section-content.js
@@ -5,6 +5,15 @@
 import { forEach } from 'lodash';
 import validUrl from 'valid-url';
 
+/**
+ * Determine if a given tag is allowed
+ *
+ * This only looks at the name of the tag to
+ * determine if it's white-listed.
+ *
+ * @param {String} tagName name of tag under inspection
+ * @returns {Boolean} whether the tag is allowed
+ */
 const isAllowedTag = tagName => {
 	switch ( tagName ) {
 		case '#text':
@@ -34,29 +43,48 @@ const isAllowedTag = tagName => {
 	}
 };
 
+/**
+ * Determine if a given attribute is allowed
+ *
+ * Note! Before adding more attributes here
+ *       make sure that we don't open up an
+ *       attribute which could allow for a
+ *       snippet of code to execute, such
+ *       as `onclick` or `onmouseover`
+ *
+ * @param {String} tagName name of tag on which attribute is found
+ * @param {String} attrName name of attribute under inspection
+ * @returns {Boolean} whether the attribute is allowed
+ */
 const isAllowedAttr = ( tagName, attrName ) => {
-	if ( 'a' === tagName && 'href' === attrName ) {
-		return true;
-	}
+	switch ( tagName ) {
+		case 'a':
+			return 'href' === attrName;
 
-	if ( 'iframe' === tagName ) {
-		switch ( attrName ) {
-			case 'class':
-			case 'type':
-			case 'height':
-			case 'width':
-			case 'src':
-				return true;
-			default:
-				return false;
-		}
-	}
+		case 'iframe':
+			switch ( attrName ) {
+				case 'class':
+				case 'type':
+				case 'height':
+				case 'width':
+				case 'src':
+					return true;
+				default:
+					return false;
+			}
 
-	if ( 'img' === tagName && ( 'alt' === attrName || 'src' === attrName ) ) {
-		return true;
-	}
+		case 'img':
+			switch ( attrName ) {
+				case 'alt':
+				case 'src':
+					return true;
+				default:
+					return false;
+			}
 
-	return false;
+		default:
+			return false;
+	}
 };
 
 const isValidYoutubeEmbed = node => {

--- a/client/lib/plugins/sanitize-section-content.js
+++ b/client/lib/plugins/sanitize-section-content.js
@@ -150,7 +150,7 @@ export const sanitizeSectionContent = content => {
 			// every other other allowed attribute must be sanitized
 			// this is a broad and clumsy stroke but it should be
 			// effective, leaning towards safety instead of
-			// compatability with the remote HTML
+			// compatibility with the remote HTML
 			node.setAttribute( attrName, encodeURIComponent( value ) );
 		}
 
@@ -167,9 +167,7 @@ export const sanitizeSectionContent = content => {
 
 	// once done walking the DOM tree
 	// remove the unwanted nodes
-	for ( let i = 0; i < removeList.length; i++ ) {
-		const node = removeList[ i ];
-
+	removeList.forEach( node => {
 		try {
 			// DOM is fun
 			node.parentNode.removeChild( node );
@@ -179,7 +177,7 @@ export const sanitizeSectionContent = content => {
 			// which would lead to a failure right now
 			// this is fine, just continue along
 		}
-	}
+	} );
 
 	const html = doc.body.innerHTML;
 

--- a/client/lib/plugins/test/sanitize-section-content.js
+++ b/client/lib/plugins/test/sanitize-section-content.js
@@ -23,19 +23,24 @@ const cleanNode = html => {
 };
 
 test( 'should allow whitelisted tags', () =>
-	expect( clean( '<div></div>' ) ).toBe( '<div></div>' ) );
+	expect( clean( '<div>👍</div>' ) ).toBe( '<div>👍</div>' ) );
 
 test( 'should strip out non-whitelisted tags', () =>
 	expect( clean( '<marquee></marquee>' ) ).toBe( '' ) );
 
+test( 'should preserve children of stripped tags', () =>
+	expect( clean( '<unsupported><b>👍</b></unsupported>' ) ).toBe( '<b>👍</b>' ) );
+
 test( 'should strip out content with non-whitelisted tags', () =>
-	expect( clean( '<p><script>alert("do bad things")</script></p>' ) ).toBe( '<p></p>' ) );
+	expect( clean( '<p><script>alert("do bad things")</script>👍</p>' ) ).toBe(
+		'<p>alert("do bad things")👍</p>'
+	) );
 
 test( 'should allow whitelisted attributes', () =>
 	expect( clean( '<img alt="graphic">' ) ).toBe( '<img alt="graphic">' ) );
 
 test( 'should strip out non-whitelisted attributes', () =>
-	expect( clean( '<span style="font-size: 128px;"></span>' ) ).toBe( '<span></span>' ) );
+	expect( clean( '<span style="font-size: 128px;">👍</span>' ) ).toBe( '<span>👍</span>' ) );
 
 test( 'should encode whitelisted attributes', () =>
 	expect( clean( '<img alt="javascript:foo()">' ) ).toBe( '<img alt="javascript%3Afoo()">' ) );
@@ -64,10 +69,10 @@ test( 'should only set link params if href set', () => {
 } );
 
 test( 'should bump up header levels', () => {
-	expect( clean( '<h1></h1>' ) ).toBe( '<h3></h3>' );
-	expect( clean( '<h2></h2>' ) ).toBe( '<h3></h3>' );
-	expect( clean( '<h3></h3>' ) ).toBe( '<h3></h3>' );
-	expect( clean( '<h4></h4>' ) ).toBe( '<h4></h4>' );
+	expect( clean( '<h1>👍</h1>' ) ).toBe( '<h3>👍</h3>' );
+	expect( clean( '<h2>👍</h2>' ) ).toBe( '<h3>👍</h3>' );
+	expect( clean( '<h3>👍</h3>' ) ).toBe( '<h3>👍</h3>' );
+	expect( clean( '<h4>👍</h4>' ) ).toBe( '<h4>👍</h4>' );
 } );
 
 test( 'should strip out <script> tags', () => expect( clean( '<script></script>' ) ).toBe( '' ) );
@@ -97,7 +102,7 @@ test( 'should prevent known XSS attacks', () => {
 
 	expect( clean( '<IMG SRC=javascript:alert(&quot;XSS&quot;)>' ) ).toBe( '<img>' );
 
-	expect( clean( '<IMG """><SCRIPT>alert("XSS")</SCRIPT>">' ) ).toBe( '<img>"&gt;' );
+	expect( clean( '<IMG """><SCRIPT>alert("XSS")</SCRIPT>">' ) ).toBe( '<img>alert("XSS")"&gt;' );
 
 	expect(
 		clean(

--- a/client/lib/plugins/test/sanitize-section-content.js
+++ b/client/lib/plugins/test/sanitize-section-content.js
@@ -1,0 +1,114 @@
+/**
+ * @format
+ * @jest-environment jsdom
+ */
+
+/**
+ * Internal dependencies
+ */
+import { sanitizeSectionContent as clean } from '../sanitize-section-content';
+
+/**
+ * Attempts to create a DOM node from given HTML
+ *
+ * @param {String} html expected HTML to create node
+ * @returns {Node | null} possible node described by HTML
+ */
+const cleanNode = html => {
+	const div = document.createElement( 'div' );
+
+	div.innerHTML = clean( html );
+
+	return div.firstChild;
+};
+
+test( 'should allow whitelisted tags', () =>
+	expect( clean( '<div></div>' ) ).toBe( '<div></div>' ) );
+
+test( 'should strip out non-whitelisted tags', () =>
+	expect( clean( '<marquee></marquee>' ) ).toBe( '' ) );
+
+test( 'should strip out content with non-whitelisted tags', () =>
+	expect( clean( '<p><script>alert("do bad things")</script></p>' ) ).toBe( '<p></p>' ) );
+
+test( 'should allow whitelisted attributes', () =>
+	expect( clean( '<img alt="graphic">' ) ).toBe( '<img alt="graphic">' ) );
+
+test( 'should strip out non-whitelisted attributes', () =>
+	expect( clean( '<span style="font-size: 128px;"></span>' ) ).toBe( '<span></span>' ) );
+
+test( 'should encode whitelisted attributes', () =>
+	expect( clean( '<img alt="javascript:foo()">' ) ).toBe( '<img alt="javascript%3Afoo()">' ) );
+
+test( 'should not encode links', () => {
+	const img = cleanNode( '<img src="http://example.com/images/1f39.png?v=25">' );
+	expect( img.getAttribute( 'src' ) ).toBe( 'http://example.com/images/1f39.png?v=25' );
+
+	const link = cleanNode( '<a id="test" href="https://github.com/README.md">docs</a>' );
+	expect( link.getAttribute( 'href' ) ).toBe( 'https://github.com/README.md' );
+} );
+
+test( 'should set link params', () => {
+	const link = cleanNode( '<a href="https://example.com">' );
+
+	expect( link.getAttribute( 'target' ) ).toBe( '_blank' );
+
+	const rel = link.getAttribute( 'rel' ).split( ' ' );
+	expect( rel ).toContain( 'external' );
+	expect( rel ).toContain( 'noopener' );
+	expect( rel ).toContain( 'noreferrer' );
+} );
+
+test( 'should only set link params if href set', () => {
+	expect( clean( '<a>link</a>' ) ).toBe( '<a>link</a>' );
+} );
+
+test( 'should bump up header levels', () => {
+	expect( clean( '<h1></h1>' ) ).toBe( '<h3></h3>' );
+	expect( clean( '<h2></h2>' ) ).toBe( '<h3></h3>' );
+	expect( clean( '<h3></h3>' ) ).toBe( '<h3></h3>' );
+	expect( clean( '<h4></h4>' ) ).toBe( '<h4></h4>' );
+} );
+
+test( 'should prevent known XSS attacks', () => {
+	expect( clean( "<IMG SRC=JaVaScRiPt:alert('XSS')>" ) ).toBe( '<img>' );
+
+	expect( clean( '<IMG SRC=javascript:alert(&quot;XSS&quot;)>' ) ).toBe( '<img>' );
+
+	expect( clean( '<IMG """><SCRIPT>alert("XSS")</SCRIPT>">' ) ).toBe( '<img>"&gt;' );
+
+	expect(
+		clean(
+			// <IMG SRC=javascript:alert(
+			// 'XSS')>
+			'<IMG SRC=&#106;&#97;&#118;&#97;&#115;&#99;&#114;&#105;&#112;&#116;&#58;&#97;&#108;&#101;&#114;&#116;&#40;\n' +
+				'&#39;&#88;&#83;&#83;&#39;&#41;>'
+		)
+	).toBe( '<img>' );
+
+	expect( clean( "<img/onload=alert('XSS')>" ) ).toBe( '<img>' );
+
+	expect( clean( '¼script¾alert(¢XSS¢)¼/script¾' ) ).toBe( '¼script¾alert(¢XSS¢)¼/script¾' );
+
+	expect( clean( '<IFRAME SRC="javascript:alert(\'XSS\');"></IFRAME>' ) ).toBe( '' );
+
+	expect( clean( '<DIV STYLE="background-image: url(javascript:alert(\'XSS\'))">' ) ).toBe(
+		'<div></div>'
+	);
+
+	expect(
+		clean( '<!--[if gte IE 4]>\n' + " <SCRIPT>alert('XSS');</SCRIPT>\n" + ' <![endif]-->' )
+	).toBe( '' );
+
+	expect( clean( '<IMG SRC="javas<!-- -->cript:alert(\'XSS\')">' ) ).toBe( '<img>' );
+
+	expect(
+		clean( '<META HTTP-EQUIV="Set-Cookie" Content="USERID=<SCRIPT>alert(\'XSS\')</SCRIPT>">' )
+	).toBe( '' );
+
+	expect(
+		cleanNode(
+			'<A HREF="javascript:document.location=\'http://www.google.com/\'">XSS</A>'
+		).getAttribute( 'href' )
+	).toBeNull();
+} );

--- a/client/lib/plugins/test/sanitize-section-content.js
+++ b/client/lib/plugins/test/sanitize-section-content.js
@@ -36,6 +36,9 @@ test( 'should strip out content with non-whitelisted tags', () =>
 		'<p>alert("do bad things")👍</p>'
 	) );
 
+test( 'should strip out non-whitelisted children', () =>
+	expect( clean( '<marquee><marquee>👍</marquee></marquee>' ) ).toBe( '👍' ) );
+
 test( 'should allow whitelisted attributes', () =>
 	expect( clean( '<img alt="graphic">' ) ).toBe( '<img alt="graphic">' ) );
 

--- a/client/lib/plugins/test/sanitize-section-content.js
+++ b/client/lib/plugins/test/sanitize-section-content.js
@@ -39,6 +39,9 @@ test( 'should strip out content with non-whitelisted tags', () =>
 test( 'should strip out non-whitelisted children', () =>
 	expect( clean( '<marquee><marquee>👍</marquee></marquee>' ) ).toBe( '👍' ) );
 
+test( 'should not break when no attributes present', () =>
+	expect( clean( '<p></p>' ) ).toBe( '<p></p>' ) );
+
 test( 'should allow whitelisted attributes', () =>
 	expect( clean( '<img alt="graphic">' ) ).toBe( '<img alt="graphic">' ) );
 

--- a/client/lib/plugins/test/sanitize-section-content.js
+++ b/client/lib/plugins/test/sanitize-section-content.js
@@ -70,6 +70,28 @@ test( 'should bump up header levels', () => {
 	expect( clean( '<h4></h4>' ) ).toBe( '<h4></h4>' );
 } );
 
+test( 'should strip out <script> tags', () => expect( clean( '<script></script>' ) ).toBe( '' ) );
+
+/**
+ * The following tests have borrowed from the OWASP XSS Cheat Sheet
+ * @see https://www.owasp.org/index.php/XSS_Filter_Evasion_Cheat_Sheet
+ *
+ * Instead of pulling all of the tests the ones included are a sampling
+ * subjectively chosen to represent the visible attack vectors. For
+ * example, many of the attacks center around improper parsing of HTML
+ * which leads to unexpected `<script>` tags. However, we are using
+ * the browser's parser and not our own and thus don't need to test for
+ * some of those situations. We are already verifying that we strip
+ * <script> tags as well as non-whitelisted attributes, so in order for
+ * those security-related tests to fail our earlier tests would have
+ * also failed, and again we don't need to double-test them.
+ *
+ * Other tests were skipped because unless specifically verified as a
+ * viable URL in an `href` or `src` attribute, all other attribute
+ * data is encoded so that it should be impossible to end up with any
+ * javascript code. Therefore attacks through event handlers and the
+ * like should simply not be possible.
+ */
 test( 'should prevent known XSS attacks', () => {
 	expect( clean( "<IMG SRC=JaVaScRiPt:alert('XSS')>" ) ).toBe( '<img>' );
 

--- a/client/lib/plugins/test/sanitize-section-content.js
+++ b/client/lib/plugins/test/sanitize-section-content.js
@@ -142,3 +142,11 @@ test( 'should prevent known XSS attacks', () => {
 		).getAttribute( 'href' )
 	).toBeNull();
 } );
+
+test( 'should prevent backspace-based XSS attacks', () => {
+	const link = cleanNode(
+		'<a href="http://example.com">' + '\u0008'.repeat( 71 ) + 'javascript:alert(1)\u0022>xss</a>'
+	);
+
+	expect( link.getAttribute( 'href' ) ).toBe( 'http://example.com' );
+} );

--- a/client/lib/plugins/test/sanitize-section-content.js
+++ b/client/lib/plugins/test/sanitize-section-content.js
@@ -45,15 +45,19 @@ test( 'should allow whitelisted attributes', () =>
 test( 'should strip out non-whitelisted attributes', () =>
 	expect( clean( '<span style="font-size: 128px;">👍</span>' ) ).toBe( '<span>👍</span>' ) );
 
-test( 'should encode whitelisted attributes', () =>
-	expect( clean( '<img alt="javascript:foo()">' ) ).toBe( '<img alt="javascript%3Afoo()">' ) );
-
-test( 'should not encode links', () => {
+test( 'should allow http(s) links', () => {
 	const img = cleanNode( '<img src="http://example.com/images/1f39.png?v=25">' );
 	expect( img.getAttribute( 'src' ) ).toBe( 'http://example.com/images/1f39.png?v=25' );
 
 	const link = cleanNode( '<a id="test" href="https://github.com/README.md">docs</a>' );
 	expect( link.getAttribute( 'href' ) ).toBe( 'https://github.com/README.md' );
+} );
+
+test( 'should omit non http(s) links', () => {
+	expect( cleanNode( '<a href="file:///etc/passwd">a</a>' ).getAttribute( 'href' ) ).toBeNull();
+	expect( cleanNode( '<a href="javascript:alert(o)">a</a>' ).getAttribute( 'href' ) ).toBeNull();
+	expect( cleanNode( '<a href="ssh://bankvault">a</a>' ).getAttribute( 'href' ) ).toBeNull();
+	expect( cleanNode( '<a href="deep+link">a</a>' ).getAttribute( 'href' ) ).toBeNull();
 } );
 
 test( 'should set link params', () => {

--- a/package.json
+++ b/package.json
@@ -135,7 +135,6 @@
     "redux-form": "7.0.2",
     "redux-thunk": "1.0.0",
     "rtlcss": "2.0.5",
-    "sanitize-html": "1.11.1",
     "semver": "5.1.0",
     "social-logos": "2.0.0",
     "socket.io-client": "1.4.5",


### PR DESCRIPTION
Closes #18606

The `sanitize-html` dependency is pulled in just to sanitize the
HTML content returned from calls to the WordPress.org API for
plugin descriptions and other data. It's 160kB in total and
about 50kB gzip'd.

Instead of pushing it into a vendor bundle or asynchronously
loading it I think that we can simply eliminate it.

Our goal is to sanitize HTML and prevent cross-site scripting
attacks (XSS) but we should be able to do this easily enough
by harnesing the browser's built-in HTML parser and walking
through each node to clean them up. Anything that's not
explicitly allowed will either be removed or escaped to prevent
any possibility of running JavaScript.

Since this PR introduces a custom parser I took the libery of
adding in support for a few more tags (`div` and `span`) as
well as support for embedding YouTube videos, figuring that if
we are conservative enough we won't have to worry about trouble
including those.

Obviously this needs some tests, even some rudimentary tests.
Also it should be cleaned up. For now, I'm hoping this patch
gathers enough feedback to see if we support this approach.

For now, I'm seeing that the new code is about 1700B and only
about 850B gzip'd, which is significantly smaller than it was
with the dependency.

**Testing**

Open up the plugins pages and see if things look properly
We need to run a decent suite of tests against this to verify that
we're not allowing in XSS attacks.