### PR TITLE
WooCommerce - Refreshing the label status on page load

### DIFF
--- a/client/extensions/woocommerce/woocommerce-services/components/query-labels/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/components/query-labels/index.js
@@ -11,27 +11,30 @@ import { bindActionCreators } from 'redux';
  */
 import QueryLabelSettings from 'woocommerce/woocommerce-services/components/query-label-settings';
 import QueryPackages from 'woocommerce/woocommerce-services/components/query-packages';
-import { fetchLabelsData } from 'woocommerce/woocommerce-services/state/shipping-label/actions';
-import { isLoaded, isFetching, isError } from 'woocommerce/woocommerce-services/state/shipping-label/selectors';
+import { fetchLabelsData, fetchLabelsStatus } from 'woocommerce/woocommerce-services/state/shipping-label/actions';
+import {
+	hasRefreshedLabelStatus,
+	isError,
+	isFetching,
+	isLoaded,
+} from 'woocommerce/woocommerce-services/state/shipping-label/selectors';
 
 class QueryLabels extends Component {
-	fetch() {
-		const { orderId, siteId } = this.props;
-		this.props.fetchLabelsData( orderId, siteId );
+	fetch( props ) {
+		const { orderId, siteId, loaded, fetching, error, refreshedLabelStatus } = props;
+		if ( ! loaded && ! fetching && ! error ) {
+			this.props.fetchLabelsData( orderId, siteId );
+		} else if ( loaded && ! refreshedLabelStatus ) {
+			this.props.fetchLabelsStatus( orderId, siteId );
+		}
 	}
 
 	componentWillMount() {
-		const { loaded, fetching, error } = this.props;
-		if ( ! loaded && ! fetching && ! error ) {
-			this.fetch();
-		}
+		this.fetch( this.props );
 	}
 
-	componentWillReceiveProps( props ) {
-		const { loaded, fetching, error } = props;
-		if ( ! loaded && ! fetching && ! error ) {
-			this.fetch();
-		}
+	componentWillReceiveProps( newProps ) {
+		this.fetch( newProps );
 	}
 
 	render() {
@@ -56,8 +59,10 @@ export default connect(
 		loaded: isLoaded( state, orderId ),
 		fetching: isFetching( state, orderId ),
 		error: isError( state, orderId ),
+		refreshedLabelStatus: hasRefreshedLabelStatus( state, orderId ),
 	} ),
 	( dispatch ) => bindActionCreators( {
 		fetchLabelsData,
+		fetchLabelsStatus,
 	}, dispatch )
 )( QueryLabels );

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/actions.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/actions.js
@@ -779,7 +779,7 @@ export const fetchLabelsStatus = ( orderId, siteId ) => ( dispatch, getState ) =
 		};
 		const setIsSaving = ( saving ) => {
 			if ( ! saving ) {
-				dispatch( { type: WOOCOMMERCE_SERVICES_SHIPPING_LABEL_STATUS_RESPONSE, labelId, response, error } );
+				dispatch( { type: WOOCOMMERCE_SERVICES_SHIPPING_LABEL_STATUS_RESPONSE, orderId, siteId, labelId, response, error } );
 				if ( error ) {
 					dispatch( NoticeActions.errorNotice( error.toString() ) );
 				}

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/selectors.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/selectors.js
@@ -61,6 +61,11 @@ export const getSelectedPaymentMethod = ( state, orderId, siteId = getSelectedSi
 	return shippingLabel.paymentMethod;
 };
 
+export const hasRefreshedLabelStatus = ( state, orderId, siteId = getSelectedSiteId( state ) ) => {
+	const shippingLabel = getShippingLabel( state, orderId, siteId );
+	return shippingLabel && shippingLabel.refreshedLabelStatus;
+};
+
 export const getForm = ( state, orderId, siteId = getSelectedSiteId( state ) ) => {
 	const shippingLabel = getShippingLabel( state, orderId, siteId );
 	return shippingLabel && shippingLabel.form;


### PR DESCRIPTION
Fixes #19286 

To test:
* in a site pointing to staging, attempt to refund a label, it will most probably error out due to the id conflicts in the staging env
* refresh the page
* after label status is refreshed, you should see an entry in the activity log about the refund
* without this change, the entry would not appear

The test steps are just a way to see the change in action. Normally it allows to check for the status of a successfully submitted refund request.