### PR TITLE
Fix locale switching when user bootstrapping is disabled

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -124,9 +124,7 @@ class Login extends Component {
 		// user data is persisted in localstorage at `lib/user/user` line 157
 		// therefor we need to reset it before we redirect, otherwise we'll get
 		// mixed data from old and new user
-		user.clear();
-
-		window.location.href = url;
+		user.clear( () => ( window.location.href = url ) );
 	};
 
 	renderHeader() {

--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -21,8 +21,6 @@ import { setCurrentUserId, setCurrentUserFlags } from 'state/current-user/action
 import { setRoute as setRouteAction } from 'state/ui/actions';
 import touchDetect from 'lib/touch-detect';
 import { setLocale, setLocaleRawData } from 'state/ui/language/actions';
-import { isDefaultLocale } from 'lib/i18n-utils';
-import getCurrentLocaleSlug from 'state/selectors/get-current-locale-slug';
 
 const debug = debugFactory( 'calypso' );
 

--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -21,6 +21,8 @@ import { setCurrentUserId, setCurrentUserFlags } from 'state/current-user/action
 import { setRoute as setRouteAction } from 'state/ui/actions';
 import touchDetect from 'lib/touch-detect';
 import { setLocale, setLocaleRawData } from 'state/ui/language/actions';
+import { isDefaultLocale } from 'lib/i18n-utils';
+import getCurrentLocaleSlug from 'state/selectors/get-current-locale-slug';
 
 const debug = debugFactory( 'calypso' );
 
@@ -133,8 +135,14 @@ export const locales = ( currentUser, reduxStore ) => {
 		reduxStore.dispatch( setLocaleRawData( i18nLocaleStringsObject ) );
 	}
 
+	const currentLocaleSlug = getCurrentLocaleSlug( reduxStore.getState() );
+
 	// Use current user's locale if it was not bootstrapped
-	if ( ! config.isEnabled( 'wpcom-user-bootstrap' ) && currentUser.get() ) {
+	if (
+		! config.isEnabled( 'wpcom-user-bootstrap' ) &&
+		currentUser.get() &&
+		isDefaultLocale( currentLocaleSlug )
+	) {
 		switchUserLocale( currentUser, reduxStore );
 	}
 };

--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -135,10 +135,8 @@ export const locales = ( currentUser, reduxStore ) => {
 		reduxStore.dispatch( setLocaleRawData( i18nLocaleStringsObject ) );
 	}
 
-	// When the user is not bootstrapped, we also bootstrap the
-	// user locale strings, unless the locale was already set in the initial store during SSR
-	const currentLocaleSlug = getCurrentLocaleSlug( reduxStore.getState() );
-	if ( ! config.isEnabled( 'wpcom-user-bootstrap' ) && isDefaultLocale( currentLocaleSlug ) ) {
+	// Use current user's locale if it was not bootstrapped
+	if ( ! config.isEnabled( 'wpcom-user-bootstrap' ) && currentUser.get() ) {
 		switchUserLocale( currentUser, reduxStore );
 	}
 };

--- a/client/lib/user/user.js
+++ b/client/lib/user/user.js
@@ -237,6 +237,8 @@ User.prototype.clear = function( onClear ) {
 	store.clear();
 	if ( config.isEnabled( 'persist-redux' ) ) {
 		localforage.clear( onClear );
+	} else if ( onClear ) {
+		onClear();
 	}
 };
 

--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -17,6 +17,7 @@ import MagicLogin from './magic-login';
 import HandleEmailedLinkForm from './magic-login/handle-emailed-link-form';
 import { fetchOAuth2ClientData } from 'state/oauth2-clients/actions';
 import { recordTracksEvent } from 'state/analytics/actions';
+import { getCurrentUser } from 'state/current-user/selectors';
 
 const enhanceContextWithLogin = context => {
 	const { path, params: { flow, twoFactorAuthType, socialService } } = context;
@@ -103,5 +104,19 @@ export default {
 		);
 
 		next();
+	},
+
+	redirectDefaultLocale( context, next ) {
+		// Do not redirect if user is logged in
+		if ( getCurrentUser( context.store.getState() ) ) {
+			return next();
+		}
+
+		// only redirect `/log-in/en` to `/log-in`
+		if ( context.pathname !== '/log-in/en' ) {
+			return next();
+		}
+
+		page.replace( '/log-in', context.query );
 	},
 };

--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -12,12 +12,13 @@ import qs from 'qs';
 /**
  * Internal dependencies
  */
+import config from 'config';
 import WPLogin from './wp-login';
 import MagicLogin from './magic-login';
 import HandleEmailedLinkForm from './magic-login/handle-emailed-link-form';
 import { fetchOAuth2ClientData } from 'state/oauth2-clients/actions';
 import { recordTracksEvent } from 'state/analytics/actions';
-import { getCurrentUser } from 'state/current-user/selectors';
+import { getCurrentUser, getCurrentUserLocale } from 'state/current-user/selectors';
 
 const enhanceContextWithLogin = context => {
 	const { path, params: { flow, twoFactorAuthType, socialService } } = context;
@@ -107,16 +108,26 @@ export default {
 	},
 
 	redirectDefaultLocale( context, next ) {
-		// Do not redirect if user is logged in
-		if ( getCurrentUser( context.store.getState() ) ) {
-			return next();
-		}
-
 		// only redirect `/log-in/en` to `/log-in`
 		if ( context.pathname !== '/log-in/en' ) {
 			return next();
 		}
 
-		page.replace( '/log-in', context.query );
+		// Do not redirect if user bootrapping is disabled
+		if (
+			! getCurrentUser( context.store.getState() ) &&
+			! config.isEnabled( 'wpcom-user-bootstrap' )
+		) {
+			return next();
+		}
+
+		// Do not redirect if user is logged in and the locale is different than english
+		// so we force the page to display in english
+		const currentUserLocale = getCurrentUserLocale( context.store.getState() );
+		if ( currentUserLocale && currentUserLocale !== 'en' ) {
+			return next();
+		}
+
+		context.redirect( '/log-in' );
 	},
 };

--- a/client/login/index.node.js
+++ b/client/login/index.node.js
@@ -10,8 +10,13 @@ import { makeLayout, redirectLoggedIn, setUpLocale } from 'controller';
 
 export default router => {
 	if ( config.isEnabled( 'login/wp-login' ) ) {
-		router( '/log-in/en', ( { res } ) => {
-			res.redirect( 301, '/log-in' );
+		router( '/log-in/en', ( { res, user }, next ) => {
+			// do not redirect if user is logged in
+			if ( user ) {
+				return next();
+			}
+
+			res.redirect( 302, '/log-in' );
 		} );
 	}
 

--- a/client/login/index.node.js
+++ b/client/login/index.node.js
@@ -9,17 +9,6 @@ import webRouter from './index.web';
 import { makeLayout, redirectLoggedIn, setUpLocale } from 'controller';
 
 export default router => {
-	if ( config.isEnabled( 'login/wp-login' ) ) {
-		router( '/log-in/en', ( { res, user }, next ) => {
-			// do not redirect if user is logged in
-			if ( user ) {
-				return next();
-			}
-
-			res.redirect( 302, '/log-in' );
-		} );
-	}
-
 	if ( config.isEnabled( 'login/magic-login' ) ) {
 		// Only do the basics for layout on the server-side
 		router( '/log-in/link/use/:lang?', setUpLocale, redirectLoggedIn, makeLayout );

--- a/client/login/index.web.js
+++ b/client/login/index.web.js
@@ -5,7 +5,7 @@
  */
 
 import config from 'config';
-import { login, magicLogin, magicLoginUse } from './controller';
+import { login, magicLogin, magicLoginUse, redirectDefaultLocale } from './controller';
 import { makeLayout, redirectLoggedIn, setUpLocale } from 'controller';
 
 export default router => {
@@ -16,7 +16,6 @@ export default router => {
 	}
 
 	if ( config.isEnabled( 'login/wp-login' ) ) {
-		router( '/log-in/en', '/log-in' );
 		router(
 			[
 				'/log-in/:twoFactorAuthType(authenticator|backup|sms|push)/:lang?',
@@ -24,6 +23,7 @@ export default router => {
 				'/log-in/:socialService(google)/callback/:lang?',
 				'/log-in/:lang?',
 			],
+			redirectDefaultLocale,
 			setUpLocale,
 			login,
 			makeLayout

--- a/client/login/magic-login/handle-emailed-link-form.jsx
+++ b/client/login/magic-login/handle-emailed-link-form.jsx
@@ -117,9 +117,7 @@ class HandleEmailedLinkForm extends React.Component {
 		// user data is persisted in localstorage at `lib/user/user` line 157
 		// therefore we need to reset it before we redirect, otherwise we'll get
 		// mixed data from old and new user
-		user.clear();
-
-		window.location.href = url;
+		user.clear( () => ( window.location.href = url ) );
 	};
 
 	componentWillUpdate( nextProps, nextState ) {

--- a/client/me/form-base/index.js
+++ b/client/me/form-base/index.js
@@ -12,6 +12,9 @@ const debug = debugFactory( 'calypso:me:form-base' );
  * Internal dependencies
  */
 import notices from 'notices';
+import userFactory from 'lib/user';
+
+const user = userFactory();
 
 export default {
 	componentDidMount: function() {
@@ -90,9 +93,11 @@ export default {
 					this.props.markSaved && this.props.markSaved();
 
 					if ( this.state && this.state.redirect ) {
-						// Sometimes changes in settings require a url refresh to update the UI.
-						// For example when the user changes the language.
-						window.location = this.state.redirect + '?updated=success';
+						user.clear( () => {
+							// Sometimes changes in settings require a url refresh to update the UI.
+							// For example when the user changes the language.
+							window.location = this.state.redirect + '?updated=success';
+						} );
 						return;
 					}
 

--- a/client/state/ui/language/reducer.js
+++ b/client/state/ui/language/reducer.js
@@ -17,7 +17,7 @@ import { localeSlugSchema } from './schema';
  *
  */
 export const localeSlug = createReducer(
-	'en',
+	false,
 	{
 		[ LOCALE_SET ]: ( state, action ) => action.localeSlug,
 	},

--- a/server/isomorphic-routing/index.js
+++ b/server/isomorphic-routing/index.js
@@ -67,7 +67,7 @@ function getEnhancedContext( req, res ) {
 		query: req.query,
 		protocol: req.protocol,
 		host: req.headers.host,
-		res,
+		redirect: res.redirect.bind( res ),
 	} );
 }
 

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -24,6 +24,7 @@ import { createReduxStore } from 'state';
 import { LOCALE_SET } from 'state/action-types';
 import { login } from 'lib/paths';
 import { logSectionResponseTime } from './analytics';
+import { receiveUser } from 'state/users/actions';
 
 const debug = debugFactory( 'calypso:pages' );
 
@@ -299,6 +300,9 @@ function setUpLoggedInRoute( req, res, next ) {
 
 			debug( 'Rendering with bootstrapped user object. Fetched in %d ms', end );
 			req.context.user = data;
+
+			// Setting user in the state is safe as long as we don't cache it
+			req.context.store.dispatch( receiveUser( data ) );
 
 			if ( data.localeSlug ) {
 				req.context.lang = data.localeSlug;

--- a/server/render/index.js
+++ b/server/render/index.js
@@ -1,8 +1,8 @@
 /** @format */
+
 /**
  * External dependencies
  */
-
 import ReactDomServer from 'react-dom/server';
 import superagent from 'superagent';
 import Lru from 'lru';
@@ -143,8 +143,9 @@ export function serverRender( req, res ) {
 	const metas = getDocumentHeadMeta( context.store.getState() );
 	const links = getDocumentHeadLink( context.store.getState() );
 
-	context.isRTL = isRTL( context.store.getState() );
-	context.lang = getCurrentLocaleSlug( context.store.getState() );
+	context.lang = getCurrentLocaleSlug( context.store.getState() ) || context.lang;
+	const isLocaleRTL = isRTL( context.store.getState() );
+	context.isRTL = isLocaleRTL !== null ? isLocaleRTL : context.isRTL;
 
 	context.head = { title, metas, links };
 	context.config = config.ssrConfig;


### PR DESCRIPTION
Locale switching is currently broken in the `development` and `stage` environment where user bootstrapping is disabled. This is because the user is currently loaded from cache on page reload so the locale update isn't taken into account unless we reload the page again. To fix this we decide to clear the cached user data before reloading the app. 

### Testing Instructions
- Boot the app locally
- Go to http://calypso.localhost:3000/me/account
- Switch the language of your account and save multiple times, check that it works correctly
- While logged in navigate to http://calypso.localhost:3000/log-in/fr http://calypso.localhost:3000/log-in/es and http://calypso.localhost:3000/log-in/he and check that the page locale is respected
 - While logged out try going to http://calypso.localhost:3000/log-in/fr http://calypso.localhost:3000/log-in/es and http://calypso.localhost:3000/log-in/he and check that the locale is respected
- Edit `config/development.json` and set `"wpcom-user-bootstrap": true`. Also edit `config/secrets.json` and add the entry `"wordpress_logged_in_cookie": "<current value of your wordpress_logged_in cookie>"`.
- Reboot the app, go back to http://calypso.localhost:3000/me/account and try switching languages, also try to load the log in page in multiple languages while logged in and logged out.

### Reviews
- [ ] Code
- [ ] Product
