### PR TITLE
Question: Should we be avoiding function creators in connect/mapDispatchToProps?

### DIFF
--- a/client/blocks/image-editor/index.jsx
+++ b/client/blocks/image-editor/index.jsx
@@ -303,6 +303,7 @@ export default connect(
 			{
 				setImageEditorFileInfo,
 				setImageEditorDefaultAspectRatio,
+				// In this case, we can't move the partials out easily because there is a dependence on ownProp(s)
 				resetImageEditorState: partial( resetImageEditorState, resetActionsAdditionalData ),
 				resetAllImageEditorState: partial( resetAllImageEditorState, resetActionsAdditionalData ),
 			},

--- a/client/blocks/product-purchase-features/product-purchase-features-list/index.jsx
+++ b/client/blocks/product-purchase-features/product-purchase-features-list/index.jsx
@@ -219,6 +219,11 @@ class ProductPurchaseFeaturesList extends Component {
 	}
 }
 
+const recordBusinessOnboardingClick = partial(
+	recordTracksEvent,
+	'calypso_plan_features_onboarding_click'
+);
+
 export default connect(
 	state => {
 		const selectedSite = getSelectedSite( state ),
@@ -230,9 +235,6 @@ export default connect(
 		};
 	},
 	{
-		recordBusinessOnboardingClick: partial(
-			recordTracksEvent,
-			'calypso_plan_features_onboarding_click'
-		),
+		recordBusinessOnboardingClick,
 	}
 )( ProductPurchaseFeaturesList );

--- a/client/my-sites/media-library/scale.jsx
+++ b/client/my-sites/media-library/scale.jsx
@@ -147,12 +147,15 @@ class MediaLibraryScale extends Component {
 	}
 }
 
+const setMediaScalePreference = partial( setPreference, 'mediaScale' );
+const saveMediaScalePreference = partial( savePreference, 'mediaScale' );
+
 export default connect(
 	state => ( {
 		scale: getPreference( state, 'mediaScale' ),
 	} ),
 	{
-		setMediaScalePreference: partial( setPreference, 'mediaScale' ),
-		saveMediaScalePreference: partial( savePreference, 'mediaScale' ),
+		setMediaScalePreference,
+		saveMediaScalePreference,
 	}
 )( localize( MediaLibraryScale ) );

--- a/client/my-sites/site-settings/form-jetpack-monitor.jsx
+++ b/client/my-sites/site-settings/form-jetpack-monitor.jsx
@@ -165,6 +165,8 @@ class SiteSettingsFormJetpackMonitor extends Component {
 	}
 }
 
+const trackEvent = partial( recordGoogleEvent, 'Site Settings' );
+
 export default connect(
 	state => {
 		const siteId = getSelectedSiteId( state );
@@ -181,7 +183,7 @@ export default connect(
 		};
 	},
 	{
-		trackEvent: partial( recordGoogleEvent, 'Site Settings' ),
+		trackEvent,
 		updateSiteMonitorSettings,
 	}
 )( localize( SiteSettingsFormJetpackMonitor ) );

--- a/client/my-sites/site-settings/seo-settings/site-verification.jsx
+++ b/client/my-sites/site-settings/seo-settings/site-verification.jsx
@@ -440,6 +440,12 @@ class SiteVerification extends Component {
 	}
 }
 
+const trackSiteVerificationUpdated = service =>
+	recordTracksEvent( 'calypso_seo_tools_site_verification_updated', {
+		service,
+	} );
+const trackFormSubmitted = partial( recordTracksEvent, 'calypso_seo_settings_form_submit' );
+
 export default connect(
 	state => {
 		const site = getSelectedSite( state );
@@ -459,11 +465,8 @@ export default connect(
 		requestSite,
 		requestSiteSettings,
 		saveSiteSettings,
-		trackSiteVerificationUpdated: service =>
-			recordTracksEvent( 'calypso_seo_tools_site_verification_updated', {
-				service,
-			} ),
-		trackFormSubmitted: partial( recordTracksEvent, 'calypso_seo_settings_form_submit' ),
+		trackSiteVerificationUpdated,
+		trackFormSubmitted,
 		activateModule,
 	},
 	undefined,

--- a/client/my-sites/site-settings/site-icon-setting/index.jsx
+++ b/client/my-sites/site-settings/site-icon-setting/index.jsx
@@ -341,6 +341,12 @@ class SiteIconSetting extends Component {
 	}
 }
 
+const onEditSelectedMedia = partial( setEditorMediaModalView, ModalViews.IMAGE_EDITOR );
+const onCancelEditingIcon = partial( setEditorMediaModalView, ModalViews.LIST );
+const removeSiteIcon = partialRight( saveSiteSettings, { site_icon: '' } );
+const recordEvent = action => recordGoogleEvent( 'Site Settings', action );
+const updateSiteIcon = ( siteId, mediaId ) => updateSiteSettings( siteId, { site_icon: mediaId } );
+
 export default connect(
 	state => {
 		const siteId = getSelectedSiteId( state );
@@ -361,13 +367,13 @@ export default connect(
 		};
 	},
 	{
-		recordEvent: action => recordGoogleEvent( 'Site Settings', action ),
-		onEditSelectedMedia: partial( setEditorMediaModalView, ModalViews.IMAGE_EDITOR ),
-		onCancelEditingIcon: partial( setEditorMediaModalView, ModalViews.LIST ),
+		recordEvent,
+		onEditSelectedMedia,
+		onCancelEditingIcon,
 		resetAllImageEditorState,
 		saveSiteSettings,
-		updateSiteIcon: ( siteId, mediaId ) => updateSiteSettings( siteId, { site_icon: mediaId } ),
-		removeSiteIcon: partialRight( saveSiteSettings, { site_icon: '' } ),
+		updateSiteIcon,
+		removeSiteIcon,
 		receiveMedia,
 		deleteMedia,
 		errorNotice,

--- a/client/post-editor/media-modal/index.jsx
+++ b/client/post-editor/media-modal/index.jsx
@@ -610,6 +610,15 @@ export class EditorMediaModal extends Component {
 	}
 }
 
+// I'd actually be tempted to say that this particular case is too smart
+// to be included in the connection - such logic/composition might be better off
+// in the component or in an action.
+const onViewDetails = flow(
+	withAnalytics( bumpStat( 'editor_media_actions', 'edit_button_dialog' ) ),
+	withAnalytics( recordGoogleEvent( 'Media', 'Clicked Dialog Edit Button' ) ),
+	partial( setEditorMediaModalView, ModalViews.DETAIL )
+);
+
 export default connect(
 	( state, { site, siteId } ) => ( {
 		view: getMediaModalView( state ),
@@ -622,10 +631,6 @@ export default connect(
 		setView: setEditorMediaModalView,
 		resetView: resetMediaModalView,
 		deleteMedia,
-		onViewDetails: flow(
-			withAnalytics( bumpStat( 'editor_media_actions', 'edit_button_dialog' ) ),
-			withAnalytics( recordGoogleEvent( 'Media', 'Clicked Dialog Edit Button' ) ),
-			partial( setEditorMediaModalView, ModalViews.DETAIL )
-		),
+		onViewDetails,
 	}
 )( localize( EditorMediaModal ) );

--- a/client/post-editor/media-modal/secondary-actions.jsx
+++ b/client/post-editor/media-modal/secondary-actions.jsx
@@ -105,6 +105,12 @@ class MediaModalSecondaryActions extends Component {
 	}
 }
 
+const onViewDetails = flow(
+	withAnalytics( bumpStat( 'editor_media_actions', 'edit_button_dialog' ) ),
+	withAnalytics( recordGoogleEvent( 'Media', 'Clicked Dialog Edit Button' ) ),
+	partial( setEditorMediaModalView, ModalViews.DETAIL )
+);
+
 export default connect(
 	( state, ownProps ) => ( {
 		view: getMediaModalView( state ),
@@ -112,11 +118,7 @@ export default connect(
 		siteSlug: ownProps.site ? getSiteSlug( state, ownProps.site.ID ) : '',
 	} ),
 	{
-		onViewDetails: flow(
-			withAnalytics( bumpStat( 'editor_media_actions', 'edit_button_dialog' ) ),
-			withAnalytics( recordGoogleEvent( 'Media', 'Clicked Dialog Edit Button' ) ),
-			partial( setEditorMediaModalView, ModalViews.DETAIL )
-		),
+		onViewDetails,
 	},
 	function mergeProps( stateProps, dispatchProps, ownProps ) {
 		//We want to overwrite connected props if 'onViewDetails', 'view' were provided

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -9,7 +9,7 @@ import createReactClass from 'create-react-class';
 import ReactDom from 'react-dom';
 import page from 'page';
 import PropTypes from 'prop-types';
-import { debounce, throttle, get } from 'lodash';
+import { debounce, throttle, get, partial } from 'lodash';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { localize } from 'i18n-calypso';
@@ -1384,6 +1384,9 @@ export const PostEditor = createReactClass( {
 	},
 } );
 
+const setEditorModePreference = partial( savePreference, 'editor-mode' );
+const setEditorSidebar = partial( savePreference, 'editor-sidebar' );
+
 export default connect(
 	state => {
 		const siteId = getSelectedSiteId( state );
@@ -1416,8 +1419,8 @@ export default connect(
 				receivePost,
 				editPost,
 				savePostSuccess,
-				setEditorModePreference: savePreference.bind( null, 'editor-mode' ),
-				setEditorSidebar: savePreference.bind( null, 'editor-sidebar' ),
+				setEditorModePreference,
+				setEditorSidebar,
 				setLayoutFocus,
 				setNextLayoutFocus,
 				saveConfirmationSidebarPreference,

--- a/client/state/preferences/README.md
+++ b/client/state/preferences/README.md
@@ -9,6 +9,8 @@ They are persisted in `calypso_preferences` key of `/me/settings`.
 1. Render `QueryPreferences` from `components/data/query-preferences`
 2. Connect your component specifying proper option keys:
 ```es6
+const saveEditorModePreference = savePreference.bind( null, 'editor-mode' );
+
 export default connect(
 	( state ) => {
 		return {
@@ -17,7 +19,7 @@ export default connect(
 	},
 	( dispatch ) => {
 		return bindActionCreators( {
-			saveEditorModePreference: savePreference.bind( null, 'editor-mode' ),
+			saveEditorModePreference,
 		}, dispatch );
 	},
 )( PostEditor );


### PR DESCRIPTION
Note: this is not to be merged - it's purely for discussion.

I've seen a few cases where we use `xx.bind( null, 'curriedValue' )`, `partial( xx, 'curriedValue' )` or more elaborate function creators (anything that results in a new function) in the `mapDispatchToProps` argument of `connect`...

My worry is that by doing this we're creating new (but identical) functions on every update request of the component.


Here's some code to better explain:

```js
connect(
  mapStateToProps,
  {
    someAction,
    anotherAction,
    // this is fine, the partial is created once since this is a plain object
    trackSomeEvent: partial( recordTracksEvent, 'some_event' ),
  }
)( Component )

connect(
  mapStateToProps,
  dispatch => {
      // Try this in any similar existing case and you'll see this log repeatedly
      console.log( 'calling mapDispatchToProps' )

      return {
        someAction,
        anotherAction,
        // Not ideal. Because this is a plain old function call that is called each time mapDispatchToProps is called...
        trackSomeEvent: partial( recordTracksEvent, 'some_event' ),
      }
  }
    
)( Component )
```

I've created a branch with a crude test: https://github.com/Automattic/wp-calypso/blob/test/partial-in-connect-issue

Here's the commit if you'd like to see details: https://github.com/Automattic/wp-calypso/commit/c36423aae5eb96ad3adecf36cfccceb28814a395


Note: I found these instances by using the following regex (I'm not so hot with them, so sorry if this looks horrendous to any of you!): 
```regex
(connect\((\n|s))(\n|.)*((\.bind\(|partial\())
```