### PR TITLE
Atomic Store: redirect users from ineligible countries to Pressable flow

### DIFF
--- a/client/signup/steps/design-type-with-atomic-store/index.jsx
+++ b/client/signup/steps/design-type-with-atomic-store/index.jsx
@@ -36,7 +36,7 @@ import { getCurrentUserCountryCode } from 'state/current-user/selectors';
 class DesignTypeWithAtomicStoreStep extends Component {
 	state = {
 		showStore: false,
-		pendingClickWithDesignType: null,
+		pendingStoreClick: false,
 	};
 	setPressableStore = ref => ( this.pressableStore = ref );
 
@@ -97,13 +97,13 @@ class DesignTypeWithAtomicStoreStep extends Component {
 	};
 
 	handleNextStep = designType => {
-		if ( ! this.props.countryCode ) {
+		if ( designType === DESIGN_TYPE_STORE && ! this.props.countryCode ) {
 			// if we don't know the country code, we can't proceed. Continue after the code arrives
-			this.setState( { pendingClickWithDesignType: designType } );
+			this.setState( { pendingStoreClick: true } );
 			return;
 		}
 
-		this.setState( { pendingClickWithDesignType: null } );
+		this.setState( { pendingStoreClick: false } );
 
 		this.props.setDesignType( designType );
 
@@ -136,7 +136,7 @@ class DesignTypeWithAtomicStoreStep extends Component {
 
 	renderChoice = choice => {
 		const buttonClassName = classNames( 'button design-type-with-atomic-store__cta is-compact', {
-			'is-busy': this.state.pendingClickWithDesignType === choice.type,
+			'is-busy': choice.type === DESIGN_TYPE_STORE && this.state.pendingStoreClick,
 		} );
 
 		return (
@@ -222,11 +222,10 @@ class DesignTypeWithAtomicStoreStep extends Component {
 	}
 
 	componentDidUpdate( prevProps ) {
-		// If geoip data arrived, check if there is a pending click on a design type choice and
+		// If geoip data arrived, check if there is a pending click on a "store" choice and
 		// process it -- all data are available now to proceed.
-		const { pendingClickWithDesignType } = this.state;
-		if ( pendingClickWithDesignType && ! prevProps.countryCode && this.props.countryCode ) {
-			this.handleNextStep( pendingClickWithDesignType );
+		if ( this.state.pendingStoreClick && ! prevProps.countryCode && this.props.countryCode ) {
+			this.handleNextStep( DESIGN_TYPE_STORE );
 		}
 	}
 

--- a/client/signup/steps/design-type-with-atomic-store/index.jsx
+++ b/client/signup/steps/design-type-with-atomic-store/index.jsx
@@ -174,7 +174,7 @@ class DesignTypeWithAtomicStoreStep extends Component {
 
 		return (
 			<div className="design-type-with-atomic-store__substep-wrapper">
-				{ ! countryCode && <QueryGeo /> }
+				{ this.state.pendingStoreClick && ! countryCode && <QueryGeo /> }
 				<div className={ storeWrapperClassName }>
 					<PressableStoreStep
 						{ ...this.props }


### PR DESCRIPTION
If the user comes from an ineligible country (not US or Canada), disable the Atomic Store flow for them and always redirect to Pressable flow.

I use the `<QueryGeo>` API to retrieve user's geolocation (even in logged-out) state and determine the country.

There's a problem that should be solved somehow before merging: if the user clicks on the "Store" design type before the geolocation info is retrieved from network (we call the `public-api.wordpress.com/geo` endpoint), the detected country is `null` and considered as ineligible. User is redirected to Pressable flow even if their country would eventually be US or CA.

There's also an `user_ip_country_code` field in the `currentUser` Redux state object, but that's not available for logged-out users. It's interesting that I get a different value here: `user_ip_country_code` is ES (Spain, location of my proxy), the `state.geo.geo.country_short` value is AT (Austria). My real location is CZ :)

**How to test**
1. You might want to edit the code to remove the check for `development` environment and change the list of eligible countries to match your location.
2. Go to `/start/atomic-store` and select "Store" as your design type.
3. Check that you're redirected to Pressable flow if your country is not eligible, and to the theme selection and the Atomic flow if it is eligible.
