### PR TITLE
My Sites: Fix sidebar plan name when selected

### DIFF
--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -232,6 +232,10 @@ form.sidebar__button input {
 		a {
 			color: $white;
 
+			.sidebar__menu-link-secondary-text {
+				color: inherit;
+			}
+
 			&:first-child:after {
 				background: linear-gradient(
 					to right,


### PR DESCRIPTION
The comment here brought to an attention that plan name got broken: https://github.com/Automattic/wp-calypso/pull/17876#issuecomment-338860799

I'm 100% positive that the original PR did work correctly so something else must have changed. However, this fix was very easy so I did not investigate further.

Test:
- go to my sites
- select a site
- click "plan" link
- make sure plan name is white and legible