### PR TITLE
Jetpack Disconnect Survey: Really disable Submit button if input field is empty

### DIFF
--- a/client/my-sites/site-settings/disconnect-site/missing-feature.jsx
+++ b/client/my-sites/site-settings/disconnect-site/missing-feature.jsx
@@ -59,13 +59,17 @@ class MissingFeature extends PureComponent {
 					/>
 					<Button
 						disabled={ isEmpty( this.state.tokens ) }
-						href={ addQueryArgs(
-							{
-								reason: 'missing-feature',
-								text: this.state.tokens.map( this.normalizeToken ).sort(),
-							},
-							confirmHref
-						) }
+						href={
+							! isEmpty( this.state.tokens ) ? (
+								addQueryArgs(
+									{
+										reason: 'missing-feature',
+										text: this.state.tokens.map( this.normalizeToken ).sort(),
+									},
+									confirmHref
+								)
+							) : null
+						}
 						primary
 					>
 						{ translate( 'Submit' ) }


### PR DESCRIPTION
Previously, while the button was styled in a way that suggested it was disabled, it was actually still clickable. (See wpcalypso or staging to verify!)

To test:
* Navigate to `/settings/disconnect-site/missing-feature/:site`
* Verify that the submit button can't be clicked as long as the input field is empty (and that it _can_ be clicked if it isn't)

![image](https://user-images.githubusercontent.com/96308/32223610-5092c788-be3e-11e7-8745-f25584341667.png)

Props @tyxla for finding this bug p7rd6c-15q-p2#comment-1768