### PR TITLE
Jetpack Disconnect: Remove fading effect from header

### DIFF
--- a/client/my-sites/site-settings/disconnect-site/style.scss
+++ b/client/my-sites/site-settings/disconnect-site/style.scss
@@ -18,6 +18,12 @@
 	}
 }
 
+.disconnect-site__site-settings {
+	.section-header__label:before {
+		background: inherit;
+	}
+}
+
 .disconnect-site__navigation-links {
 	text-align: center;
 }


### PR DESCRIPTION
As requested by @tyxla here: p7rd6c-15q-p2#comment-1768

Before:

![image](https://user-images.githubusercontent.com/96308/32224395-8130117c-be41-11e7-90d3-38ebec8c7919.png)

After:

![image](https://user-images.githubusercontent.com/96308/32224324-46ed3f6c-be41-11e7-96ef-4333df496d31.png)

To test: Navigate to `/settings/disconnect-site/:site` and verify that the header text isn't fading out to the right. (You might have to decrease your browser window's width.)