### PR TITLE
Jetpack Disconnect: Add Icon to 'Diagnose a connection problem'

### DIFF
--- a/client/my-sites/site-settings/disconnect-site/troubleshoot.jsx
+++ b/client/my-sites/site-settings/disconnect-site/troubleshoot.jsx
@@ -3,9 +3,9 @@
  * External dependencies
  */
 import React from 'react';
+import Gridicon from 'gridicons';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
 
 /**
  * Internal dependencies

--- a/client/my-sites/site-settings/disconnect-site/troubleshoot.jsx
+++ b/client/my-sites/site-settings/disconnect-site/troubleshoot.jsx
@@ -5,6 +5,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
+import Gridicon from 'gridicons';
 
 /**
  * Internal dependencies
@@ -22,8 +23,10 @@ const Troubleshoot = ( { siteUrl, trackDebugClick, trackSupportClick, translate 
 	<LoggedOutFormLinks>
 		<LoggedOutFormLinkItem
 			href={ addQueryArgs( { url: siteUrl }, 'https://jetpack.com/support/debug/' ) }
+			icon
 			onClick={ trackDebugClick }
 		>
+			<Gridicon size={ 18 } icon="offline" />
 			{ translate( 'Diagnose a connection problem' ) }
 		</LoggedOutFormLinkItem>
 		<JetpackConnectHappychatButton


### PR DESCRIPTION
As suggested by @tyxla (p7rd6c-15q-p2#comment-1768):

> I think it would be more consistent if we have an icon to the left of the “Diagnose a connection problem link” text. There are many icons that might work here – for example offline, notice/notice-outline, bug, etc.

_notice_/_notice-outline_ don't seem right, I think they're really meant to notify the user of something that's wrong. _Bug_ doesn't feel quite right either, so I chose _offline_ which I think is the best fit.

Before:

![image](https://user-images.githubusercontent.com/96308/32225334-175aaa10-be45-11e7-9f1e-da6adea4d98a.png)

After:

![image](https://user-images.githubusercontent.com/96308/32225309-fc06c686-be44-11e7-816d-091cc2bc6701.png)


Ignore the misalignment for now, I'll address that in a separate PR.

To test:
* Have a look at `/settings/disconnect-site/:site`.