### PR TITLE
Comments Redesign: Add the actions

### DIFF
--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -479,8 +479,8 @@ export class CommentList extends Component {
 									! this.hasCommentJustMovedBackToCurrentStatus( commentId )
 								}
 								removeFromPersisted={ this.removeFromPersistedComments }
-								togglePersisted={ this.updatePersistedComments }
 								toggleSelected={ this.toggleCommentSelected }
+								updatePersisted={ this.updatePersistedComments }
 							/>
 						) ) }
 

--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -472,11 +472,14 @@ export class CommentList extends Component {
 								commentId={ commentId }
 								key={ `comment-${ siteId }-${ commentId }` }
 								isBulkMode={ isBulkEdit }
+								isPersistent={ this.isCommentPersisted( commentId ) }
 								isSelected={ this.isCommentSelected( commentId ) }
 								refreshCommentData={
 									isCommentsTreeSupported &&
 									! this.hasCommentJustMovedBackToCurrentStatus( commentId )
 								}
+								removeFromPersisted={ this.removeFromPersistedComments }
+								togglePersisted={ this.updatePersistedComments }
 								toggleSelected={ this.toggleCommentSelected }
 							/>
 						) ) }

--- a/client/my-sites/comments/comment/comment-actions.jsx
+++ b/client/my-sites/comments/comment/comment-actions.jsx
@@ -34,7 +34,6 @@ const commentActions = {
 export class CommentActions extends Component {
 	static propTypes = {
 		commentId: PropTypes.number,
-		isExpanded: PropTypes.bool,
 		removeFromPersisted: PropTypes.func,
 		updatePersisted: PropTypes.func,
 	};
@@ -117,17 +116,7 @@ export class CommentActions extends Component {
 	};
 
 	render() {
-		const {
-			commentIsApproved,
-			commentIsLiked,
-			commentIsPending,
-			isExpanded,
-			translate,
-		} = this.props;
-
-		if ( ! isExpanded && ! commentIsPending ) {
-			return null;
-		}
+		const { commentIsApproved, commentIsLiked, translate } = this.props;
 
 		return (
 			<div className="comment__actions">
@@ -191,7 +180,6 @@ const mapStateToProps = ( state, { commentId } ) => {
 	return {
 		commentIsApproved: 'approved' === commentStatus,
 		commentIsLiked: get( comment, 'i_like' ),
-		commentIsPending: 'unapproved' === commentStatus,
 		commentStatus,
 		postId: get( comment, 'post.ID' ),
 		siteId,

--- a/client/my-sites/comments/comment/comment-actions.jsx
+++ b/client/my-sites/comments/comment/comment-actions.jsx
@@ -34,6 +34,7 @@ const commentActions = {
 export class CommentActions extends Component {
 	static propTypes = {
 		commentId: PropTypes.number,
+		isExpanded: PropTypes.bool,
 		removeFromPersisted: PropTypes.func,
 		updatePersisted: PropTypes.func,
 	};
@@ -104,7 +105,17 @@ export class CommentActions extends Component {
 	};
 
 	render() {
-		const { commentIsApproved, commentIsLiked, translate } = this.props;
+		const {
+			commentIsApproved,
+			commentIsLiked,
+			commentIsPending,
+			isExpanded,
+			translate,
+		} = this.props;
+
+		if ( ! isExpanded && ! commentIsPending ) {
+			return null;
+		}
 
 		return (
 			<div className="comment__actions">
@@ -168,6 +179,7 @@ const mapStateToProps = ( state, { commentId } ) => {
 	return {
 		commentIsApproved: 'approved' === commentStatus,
 		commentIsLiked: get( comment, 'i_like' ),
+		commentIsPending: 'unapproved' === commentStatus,
 		commentStatus,
 		postId: get( comment, 'post.ID' ),
 		siteId,

--- a/client/my-sites/comments/comment/comment-actions.jsx
+++ b/client/my-sites/comments/comment/comment-actions.jsx
@@ -41,7 +41,13 @@ export class CommentActions extends Component {
 
 	hasAction = action => includes( commentActions[ this.props.commentStatus ], action );
 
-	setSpam = () => this.setStatus( 'spam' );
+	setSpam = () => {
+		const { commentId, removeFromPersisted } = this.props;
+
+		this.setStatus( 'spam' );
+
+		removeFromPersisted( commentId );
+	};
 
 	setStatus = status => {
 		const {
@@ -66,7 +72,13 @@ export class CommentActions extends Component {
 		}
 	};
 
-	setTrash = () => this.setStatus( 'trash' );
+	setTrash = () => {
+		const { commentId, removeFromPersisted } = this.props;
+
+		this.setStatus( 'trash' );
+
+		removeFromPersisted( commentId );
+	};
 
 	toggleApproved = () => {
 		const { commentId, commentIsApproved, commentStatus, updatePersisted } = this.props;

--- a/client/my-sites/comments/comment/comment-actions.jsx
+++ b/client/my-sites/comments/comment/comment-actions.jsx
@@ -40,6 +40,8 @@ export class CommentActions extends Component {
 
 	hasAction = action => includes( commentActions[ this.props.commentStatus ], action );
 
+	setSpam = () => this.setStatus( 'spam' );
+
 	setStatus = status => {
 		const {
 			changeStatus,
@@ -62,6 +64,8 @@ export class CommentActions extends Component {
 			unlike( siteId, postId, commentId );
 		}
 	};
+
+	setTrash = () => this.setStatus( 'trash' );
 
 	toggleApproved = () => {
 		const { commentId, commentIsApproved, commentStatus, updatePersisted } = this.props;
@@ -98,10 +102,6 @@ export class CommentActions extends Component {
 			updatePersisted( commentId );
 		}
 	};
-
-	setSpam = () => this.setStatus( 'spam' );
-
-	setTrash = () => this.setStatus( 'trash' );
 
 	render() {
 		const { commentIsApproved, commentIsLiked, translate } = this.props;

--- a/client/my-sites/comments/comment/comment-actions.jsx
+++ b/client/my-sites/comments/comment/comment-actions.jsx
@@ -41,11 +41,22 @@ export class CommentActions extends Component {
 	hasAction = action => includes( commentActions[ this.props.commentStatus ], action );
 
 	setStatus = status => {
-		const { changeStatus, commentId, commentIsLiked, postId, siteId, unlike } = this.props;
+		const {
+			changeStatus,
+			commentId,
+			commentIsLiked,
+			commentStatus,
+			postId,
+			siteId,
+			unlike,
+		} = this.props;
 
 		const alsoUnlike = commentIsLiked && 'approved' !== status;
 
-		changeStatus( siteId, postId, commentId, status, { alsoUnlike } );
+		changeStatus( siteId, postId, commentId, status, {
+			alsoUnlike,
+			previousStatus: commentStatus,
+		} );
 
 		if ( alsoUnlike ) {
 			unlike( siteId, postId, commentId );
@@ -164,7 +175,13 @@ const mapStateToProps = ( state, { commentId } ) => {
 };
 
 const mapDispatchToProps = dispatch => ( {
-	changeStatus: ( siteId, postId, commentId, status, analytics = { alsoUnlike: false } ) =>
+	changeStatus: (
+		siteId,
+		postId,
+		commentId,
+		status,
+		analytics = { alsoUnlike: false, isUndo: false }
+	) =>
 		dispatch(
 			withAnalytics(
 				composeAnalytics(

--- a/client/my-sites/comments/comment/comment-actions.jsx
+++ b/client/my-sites/comments/comment/comment-actions.jsx
@@ -1,0 +1,143 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+import Gridicon from 'gridicons';
+import classNames from 'classnames';
+import { get, includes } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import Button from 'components/button';
+import {
+	bumpStat,
+	composeAnalytics,
+	recordTracksEvent,
+	withAnalytics,
+} from 'state/analytics/actions';
+import { changeCommentStatus, likeComment, unlikeComment } from 'state/comments/actions';
+import { getSiteComment } from 'state/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
+
+const commentActions = {
+	unapproved: [ 'like', 'approve', 'edit', 'reply', 'spam', 'trash' ],
+	approved: [ 'like', 'approve', 'edit', 'reply', 'spam', 'trash' ],
+	spam: [ 'approve', 'delete' ],
+	trash: [ 'approve', 'spam', 'delete' ],
+};
+
+export class CommentActions extends Component {
+	hasAction = action => includes( commentActions[ this.props.commentStatus ], action );
+
+	setStatus = status => {
+		const {
+			changeStatus,
+			commentId,
+			commentIsLiked,
+			commentStatus,
+			postId,
+			siteId,
+			unlike,
+		} = this.props;
+		const alsoUnlike = commentIsLiked && 'approved' !== commentStatus;
+
+		changeStatus( siteId, postId, commentId, status, { alsoUnlike } );
+
+		if ( alsoUnlike ) {
+			unlike( siteId, postId, commentId );
+		}
+	};
+
+	toggleLike = () => {
+		const { commentId, commentIsLiked, commentStatus, like, postId, siteId, unlike } = this.props;
+
+		if ( commentIsLiked ) {
+			return unlike( siteId, postId, commentId );
+		}
+
+		const alsoApprove = 'unapproved' === commentStatus;
+
+		like( siteId, postId, commentId, { alsoApprove } );
+
+		if ( alsoApprove ) {
+			this.setStatus( 'approved' );
+		}
+	};
+
+	render() {
+		const { commentIsLiked, translate } = this.props;
+
+		return (
+			<div className="comment__actions">
+				{ this.hasAction( 'like' ) && (
+					<Button
+						borderless
+						className={ classNames( 'comment__action', { 'is-liked': commentIsLiked } ) }
+						onClick={ this.toggleLike }
+					>
+						<Gridicon icon={ commentIsLiked ? 'star' : 'star-outline' } />
+						<span>{ commentIsLiked ? translate( 'Liked' ) : translate( 'Like' ) }</span>
+					</Button>
+				) }
+			</div>
+		);
+	}
+}
+
+const mapStateToProps = ( state, { commentId } ) => {
+	const siteId = getSelectedSiteId( state );
+	const comment = getSiteComment( state, siteId, commentId );
+
+	return {
+		commentIsLiked: get( comment, 'i_like' ),
+		commentStatus: get( comment, 'status' ),
+		postId: get( comment, 'post.ID' ),
+		siteId,
+	};
+};
+
+const mapDispatchToProps = dispatch => ( {
+	changeStatus: ( siteId, postId, commentId, status, analytics = { alsoUnlike: false } ) =>
+		dispatch(
+			withAnalytics(
+				composeAnalytics(
+					recordTracksEvent( 'calypso_comment_management_change_status', {
+						also_unlike: analytics.alsoUnlike,
+						is_undo: analytics.isUndo,
+						previous_status: analytics.previousStatus,
+						status,
+					} ),
+					bumpStat( 'calypso_comment_management', 'comment_status_changed_to_' + status )
+				),
+				changeCommentStatus( siteId, postId, commentId, status )
+			)
+		),
+	like: ( siteId, postId, commentId, analytics = { alsoApprove: false } ) =>
+		dispatch(
+			withAnalytics(
+				composeAnalytics(
+					recordTracksEvent( 'calypso_comment_management_like', {
+						also_approve: analytics.alsoApprove,
+					} ),
+					bumpStat( 'calypso_comment_management', 'comment_liked' )
+				),
+				likeComment( siteId, postId, commentId )
+			)
+		),
+	unlike: ( siteId, postId, commentId ) =>
+		dispatch(
+			withAnalytics(
+				composeAnalytics(
+					recordTracksEvent( 'calypso_comment_management_unlike' ),
+					bumpStat( 'calypso_comment_management', 'comment_unliked' )
+				),
+				unlikeComment( siteId, postId, commentId )
+			)
+		),
+} );
+
+export default connect( mapStateToProps, mapDispatchToProps )( localize( CommentActions ) );

--- a/client/my-sites/comments/comment/comment-content.jsx
+++ b/client/my-sites/comments/comment/comment-content.jsx
@@ -77,6 +77,7 @@ export class CommentContent extends Component {
 						<AutoDirection>
 							<Emojify>
 								<div
+									className="comment__content-body"
 									dangerouslySetInnerHTML={ { __html: commentContent } } //eslint-disable-line react/no-danger
 								/>
 							</Emojify>

--- a/client/my-sites/comments/comment/index.jsx
+++ b/client/my-sites/comments/comment/index.jsx
@@ -30,8 +30,8 @@ export class Comment extends Component {
 		isSelected: PropTypes.bool,
 		refreshCommentData: PropTypes.bool,
 		removeFromPersisted: PropTypes.func,
-		togglePersisted: PropTypes.func,
 		toggleSelected: PropTypes.func,
+		updatePersisted: PropTypes.func,
 	};
 
 	static defaultProps = {
@@ -96,7 +96,7 @@ export class Comment extends Component {
 			refreshCommentData,
 			removeFromPersisted,
 			siteId,
-			togglePersisted,
+			updatePersisted,
 		} = this.props;
 		const { hasReplyFocus, isEditMode, isExpanded } = this.state;
 
@@ -129,7 +129,7 @@ export class Comment extends Component {
 
 						<CommentContent { ...{ commentId, isExpanded } } />
 
-						<CommentActions { ...{ commentId, removeFromPersisted, togglePersisted } } />
+						<CommentActions { ...{ commentId, removeFromPersisted, updatePersisted } } />
 
 						{ isExpanded && (
 							<CommentReply

--- a/client/my-sites/comments/comment/index.jsx
+++ b/client/my-sites/comments/comment/index.jsx
@@ -13,6 +13,7 @@ import { get, isUndefined } from 'lodash';
  * Internal dependencies
  */
 import Card from 'components/card';
+import CommentActions from 'my-sites/comments/comment/comment-actions';
 import CommentContent from 'my-sites/comments/comment/comment-content';
 import CommentHeader from 'my-sites/comments/comment/comment-header';
 import CommentReply from 'my-sites/comments/comment/comment-reply';
@@ -122,6 +123,8 @@ export class Comment extends Component {
 						/>
 
 						<CommentContent { ...{ commentId, isExpanded } } />
+
+						<CommentActions { ...{ commentId } } />
 
 						{ isExpanded && (
 							<CommentReply

--- a/client/my-sites/comments/comment/index.jsx
+++ b/client/my-sites/comments/comment/index.jsx
@@ -26,8 +26,11 @@ export class Comment extends Component {
 	static propTypes = {
 		commentId: PropTypes.number,
 		isBulkMode: PropTypes.bool,
+		isPersistent: PropTypes.bool,
 		isSelected: PropTypes.bool,
 		refreshCommentData: PropTypes.bool,
+		removeFromPersisted: PropTypes.func,
+		togglePersisted: PropTypes.func,
 		toggleSelected: PropTypes.func,
 	};
 
@@ -91,7 +94,9 @@ export class Comment extends Component {
 			isLoading,
 			isSelected,
 			refreshCommentData,
+			removeFromPersisted,
 			siteId,
+			togglePersisted,
 		} = this.props;
 		const { hasReplyFocus, isEditMode, isExpanded } = this.state;
 
@@ -124,7 +129,7 @@ export class Comment extends Component {
 
 						<CommentContent { ...{ commentId, isExpanded } } />
 
-						<CommentActions { ...{ commentId } } />
+						<CommentActions { ...{ commentId, removeFromPersisted, togglePersisted } } />
 
 						{ isExpanded && (
 							<CommentReply

--- a/client/my-sites/comments/comment/index.jsx
+++ b/client/my-sites/comments/comment/index.jsx
@@ -89,7 +89,7 @@ export class Comment extends Component {
 	render() {
 		const {
 			commentId,
-			commentStatus,
+			commentIsPending,
 			isBulkMode,
 			isLoading,
 			isSelected,
@@ -100,12 +100,14 @@ export class Comment extends Component {
 		} = this.props;
 		const { hasReplyFocus, isEditMode, isExpanded } = this.state;
 
+		const showActions = isExpanded || ( ! isBulkMode && commentIsPending );
+
 		const classes = classNames( 'comment', {
 			'is-bulk-mode': isBulkMode,
-			'is-collapsed': ! isExpanded && ! isBulkMode,
+			'is-collapsed': ! isExpanded,
 			'is-expanded': isExpanded,
 			'is-placeholder': isLoading,
-			'is-unapproved': 'unapproved' === commentStatus,
+			'is-pending': commentIsPending,
 		} );
 
 		return (
@@ -129,9 +131,11 @@ export class Comment extends Component {
 
 						<CommentContent { ...{ commentId, isExpanded } } />
 
-						<CommentActions
-							{ ...{ commentId, isExpanded, removeFromPersisted, updatePersisted } }
-						/>
+						{ showActions && (
+							<CommentActions
+								{ ...{ commentId, isExpanded, removeFromPersisted, updatePersisted } }
+							/>
+						) }
 
 						{ isExpanded && (
 							<CommentReply
@@ -150,8 +154,9 @@ export class Comment extends Component {
 const mapStateToProps = ( state, { commentId } ) => {
 	const siteId = getSelectedSiteId( state );
 	const comment = getSiteComment( state, siteId, commentId );
+	const commentStatus = get( comment, 'status' );
 	return {
-		commentStatus: get( comment, 'status' ),
+		commentIsPending: 'unapproved' === commentStatus,
 		isLoading: isUndefined( comment ),
 		minimumComment: getMinimumComment( comment ),
 		siteId,

--- a/client/my-sites/comments/comment/index.jsx
+++ b/client/my-sites/comments/comment/index.jsx
@@ -129,7 +129,9 @@ export class Comment extends Component {
 
 						<CommentContent { ...{ commentId, isExpanded } } />
 
-						<CommentActions { ...{ commentId, removeFromPersisted, updatePersisted } } />
+						<CommentActions
+							{ ...{ commentId, isExpanded, removeFromPersisted, updatePersisted } }
+						/>
 
 						{ isExpanded && (
 							<CommentReply

--- a/client/my-sites/comments/comment/style.scss
+++ b/client/my-sites/comments/comment/style.scss
@@ -441,7 +441,7 @@
 // Collapsed View
 
 .card.comment.is-collapsed {
-	&.is-unapproved {
+	&.is-pending {
 		background: mix($alert-yellow, $white, 8.5%);
 		box-shadow: inset 4px 0 0 0 $alert-yellow, 0 0 0 1px transparentize(lighten($gray, 20%), 0.5),
 			0 1px 2px lighten($gray, 30%);
@@ -516,6 +516,10 @@
 
 	.comment__header .comment__author {
 		padding-left: 0;
+	}
+
+	&.is-pending .comment__content {
+		padding-bottom: 16px;
 	}
 }
 

--- a/client/my-sites/comments/comment/style.scss
+++ b/client/my-sites/comments/comment/style.scss
@@ -243,6 +243,10 @@
 			color: $blue-wordpress;
 		}
 	}
+
+	.comment__content-body *:last-child {
+		margin-bottom: 0;
+	}
 }
 
 .comment__content-preview {
@@ -292,16 +296,18 @@
 	flex-flow: row;
 	flex-wrap: nowrap;
 	justify-content: space-between;
-	padding: 0px 48px 16px 48px;
+	margin: 0 56px;
+	padding-bottom: 8px;
 
 	@include breakpoint( '>960px' ) {
 		justify-content: flex-start;
-		padding-right: 16px;
+		margin-right: 16px;
+		margin-left: 40px;
 	}
 }
 
 .button.is-borderless.comment__action {
-	padding: 0 8px;
+	padding: 8px;
 
 	span {
 		display: none;
@@ -327,6 +333,8 @@
 	}
 
 	@include breakpoint( '>960px' ) {
+		padding: 8px 16px;
+
 		.gridicon {
 			margin-right: 4px;
 		}
@@ -437,6 +445,10 @@
 		background: mix($alert-yellow, $white, 8.5%);
 		box-shadow: inset 4px 0 0 0 $alert-yellow, 0 0 0 1px transparentize(lighten($gray, 20%), 0.5),
 			0 1px 2px lighten($gray, 30%);
+
+		.comment__content {
+			padding-bottom: 8px;
+		}
 	}
 }
 
@@ -459,6 +471,7 @@
 
 	.comment__content {
 		padding-top: 8px;
+		padding-bottom: 8px;
 
 		.comment__in-reply-to {
 			border-left: 4px solid lighten($gray, 30%);
@@ -468,6 +481,15 @@
 	}
 
 	@include breakpoint( '<960px' ) {
+		.comment__content {
+			padding-bottom: 16px;
+		}
+
+		.comment__actions {
+			border-top: 1px solid lighten($gray, 30%);
+			padding-top: 8px;
+		}
+
 		.comment__action {
 			text-align: center;
 			span {

--- a/client/my-sites/comments/comment/style.scss
+++ b/client/my-sites/comments/comment/style.scss
@@ -552,4 +552,8 @@
 	.comment__in-reply-to {
 		display: none;
 	}
+
+	.comment__actions {
+		display: none;
+	}
 }

--- a/client/my-sites/comments/comment/style.scss
+++ b/client/my-sites/comments/comment/style.scss
@@ -284,6 +284,59 @@
 	}
 }
 
+// Comment Actions Block
+
+.comment__actions {
+	align-items: center;
+	display: flex;
+	flex-flow: row;
+	flex-wrap: nowrap;
+	justify-content: space-between;
+	padding: 0px 48px 16px 48px;
+
+	@include breakpoint( '>960px' ) {
+		justify-content: flex-start;
+		padding-right: 16px;
+	}
+}
+
+.button.is-borderless.comment__action {
+	padding: 0 8px;
+
+	span {
+		display: none;
+		font-weight: 400;
+	}
+
+	&.comment__action-approve:hover {
+		color: $alert-green;
+	}
+	&.comment__action-like:hover {
+		color: $orange-jazzy;
+	}
+	&.comment__action-spam:hover,
+	&.comment__action-trash:hover {
+		color: $alert-red;
+	}
+
+	&.is-approved {
+		color: $alert-green;
+	}
+	&.is-liked {
+		color: $orange-jazzy;
+	}
+
+	@include breakpoint( '>960px' ) {
+		.gridicon {
+			margin-right: 4px;
+		}
+
+		span {
+			display: inline;
+		}
+	}
+}
+
 // Comment Reply Block
 
 .comment__reply {
@@ -411,6 +464,16 @@
 			border-left: 4px solid lighten($gray, 30%);
 			margin-bottom: 1em;
 			padding: 2px 4px;
+		}
+	}
+
+	@include breakpoint( '<960px' ) {
+		.comment__action {
+			text-align: center;
+			span {
+				display: block;
+				padding-top: 4px;
+			}
 		}
 	}
 }


### PR DESCRIPTION
Follow up to: #19280

Add the Approve/Unapprove, Spam, Trash, and Like actions to the new `Comment` component.
Moved the whole logic away from `CommentList` and inside `CommentActions`, as close as possible to the various action buttons.

This implementation is barebone and lacks some features:

- No Edit and Reply actions.
- No `CommentList` cleanup.
- No success notices and therefore **no undos**.

### Notices and Undos

Internal discussion: p7jreA-1ca-p2

We've been talking of dropping success notices altogether. The only thing blocking us is that the notices are currently necessary for the undos.

@vindl suggested an approach similar to the one already featured in the Posts List.
On spam/trash (which are the "semi-destructive" actions), the comment persist and enter a "disabled" state. It gets covered by an overlay with a message such as "Comment Deleted - Undo?".

By moving the Undo into the actual comment, we'd drastically reduce all the required back and forth between `Comment` and `CommentList`.
Basically we'd end up with just the persistence functions, which can't go anywhere else but in the `List`.
There will be a little bit of duplication between the single and the bulk actions, but it's a fair trade-off imho.

What about approve/unapprove? I'd actually suggest that we don't persist them anymore.
We have the All list where they're shown together, and I can't see any reason why the Approved and Pending lists should behave _almost but not completely_ the same.

### Screenshots (WIP)

Large screens collapsed
<img width="737" alt="screen shot 2017-11-01 at 10 30 51" src="https://user-images.githubusercontent.com/2070010/32270985-e6a06dc8-beef-11e7-8ed7-002971291d22.png">

Large screens expanded
<img width="738" alt="screen shot 2017-11-01 at 10 31 14" src="https://user-images.githubusercontent.com/2070010/32270986-e6bba0ac-beef-11e7-940d-745d3a9f11c4.png">

Small screens collapsed
<img width="447" alt="screen shot 2017-11-01 at 10 33 03" src="https://user-images.githubusercontent.com/2070010/32271055-2f4cc620-bef0-11e7-9027-fa09b53b3f94.png">

Small screens expanded
<img width="448" alt="screen shot 2017-11-01 at 10 33 11" src="https://user-images.githubusercontent.com/2070010/32271066-34d6f066-bef0-11e7-834e-9bbfc1e0c267.png">

### Testing instructions

Checkout this branch and run it with
`env ENABLE_FEATURES=comments/management/m3-design npm start`