### PR TITLE
Reader post card: turn off the link indicator in the Card component

### DIFF
--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -252,7 +252,11 @@ class ReaderPostCard extends React.Component {
 		const followUrl = feed ? feed.feed_URL : post.site_URL;
 
 		return (
-			<Card className={ classes } onClick={ ! isPhotoPost && ! compact && this.handleCardClick }>
+			<Card
+				className={ classes }
+				onClick={ ! isPhotoPost && ! compact && this.handleCardClick }
+				showLinkIndicator={ false }
+			>
 				{ ! compact && postByline }
 				{ showPrimaryFollowButton &&
 				followUrl && (

--- a/client/components/card/index.jsx
+++ b/client/components/card/index.jsx
@@ -18,15 +18,26 @@ class Card extends Component {
 		compact: PropTypes.bool,
 		children: PropTypes.node,
 		highlight: PropTypes.oneOf( [ false, 'error', 'info', 'success', 'warning' ] ),
+		showLinkIndicator: PropTypes.bool,
 	};
 
 	static defaultProps = {
 		tagName: 'div',
 		highlight: false,
+		showLinkIndicator: true,
 	};
 
 	render() {
-		const { children, compact, highlight, href, onClick, tagName, target } = this.props;
+		const {
+			children,
+			compact,
+			highlight,
+			href,
+			onClick,
+			showLinkIndicator,
+			tagName,
+			target,
+		} = this.props;
 
 		const highlightClass = highlight ? 'is-' + highlight : false;
 
@@ -44,7 +55,7 @@ class Card extends Component {
 		const omitProps = [ 'compact', 'highlight', 'tagName' ];
 
 		let linkIndicator;
-		if ( href || onClick ) {
+		if ( showLinkIndicator && ( href || onClick ) ) {
 			linkIndicator = (
 				<Gridicon className="card__link-indicator" icon={ target ? 'external' : 'chevron-right' } />
 			);

--- a/client/components/card/index.jsx
+++ b/client/components/card/index.jsx
@@ -52,7 +52,7 @@ class Card extends Component {
 			highlightClass
 		);
 
-		const omitProps = [ 'compact', 'highlight', 'tagName' ];
+		const omitProps = [ 'compact', 'highlight', 'tagName', 'showLinkIndicator' ];
 
 		let linkIndicator;
 		if ( showLinkIndicator && ( href || onClick ) ) {

--- a/client/components/card/test/__snapshots__/index.js.snap
+++ b/client/components/card/test/__snapshots__/index.js.snap
@@ -41,6 +41,7 @@ ShallowWrapper {
       "_currentElement": <Card
         highlight={false}
         href="/test"
+        showLinkIndicator={true}
         tagName="div"
       >
         This is a linked card
@@ -55,6 +56,7 @@ ShallowWrapper {
           "children": "This is a linked card",
           "highlight": false,
           "href": "/test",
+          "showLinkIndicator": true,
           "tagName": "div",
         },
         "refs": Object {},
@@ -114,6 +116,7 @@ ShallowWrapper {
   "unrendered": <Card
     highlight={false}
     href="/test"
+    showLinkIndicator={true}
     tagName="div"
   >
     This is a linked card
@@ -145,6 +148,7 @@ ShallowWrapper {
       "_context": Object {},
       "_currentElement": <Card
         highlight={false}
+        showLinkIndicator={true}
         tagName="div"
       />,
       "_debugID": 1,
@@ -155,6 +159,7 @@ ShallowWrapper {
         "context": Object {},
         "props": Object {
           "highlight": false,
+          "showLinkIndicator": true,
           "tagName": "div",
         },
         "refs": Object {},
@@ -197,6 +202,7 @@ ShallowWrapper {
   "root": [Circular],
   "unrendered": <Card
     highlight={false}
+    showLinkIndicator={true}
     tagName="div"
   />,
 }
@@ -227,6 +233,7 @@ ShallowWrapper {
       "_currentElement": <Card
         className="test__ace"
         highlight={false}
+        showLinkIndicator={true}
         tagName="div"
       />,
       "_debugID": 3,
@@ -238,6 +245,7 @@ ShallowWrapper {
         "props": Object {
           "className": "test__ace",
           "highlight": false,
+          "showLinkIndicator": true,
           "tagName": "div",
         },
         "refs": Object {},
@@ -281,6 +289,7 @@ ShallowWrapper {
   "unrendered": <Card
     className="test__ace"
     highlight={false}
+    showLinkIndicator={true}
     tagName="div"
   />,
 }
@@ -314,6 +323,7 @@ ShallowWrapper {
       "_context": Object {},
       "_currentElement": <Card
         highlight={false}
+        showLinkIndicator={true}
         tagName="div"
       >
         This is a card
@@ -327,6 +337,7 @@ ShallowWrapper {
         "props": Object {
           "children": "This is a card",
           "highlight": false,
+          "showLinkIndicator": true,
           "tagName": "div",
         },
         "refs": Object {},
@@ -373,6 +384,7 @@ ShallowWrapper {
   "root": [Circular],
   "unrendered": <Card
     highlight={false}
+    showLinkIndicator={true}
     tagName="div"
   >
     This is a card
@@ -391,12 +403,14 @@ ShallowWrapper {
   "node": <Card
     className="is-compact"
     highlight={false}
+    showLinkIndicator={true}
     tagName="div"
   />,
   "nodes": Array [
     <Card
       className="is-compact"
       highlight={false}
+      showLinkIndicator={true}
       tagName="div"
     />,
   ],
@@ -437,12 +451,14 @@ ShallowWrapper {
         "_currentElement": <Card
           className="is-compact"
           highlight={false}
+          showLinkIndicator={true}
           tagName="div"
         />,
         "_debugID": 10,
         "_renderedOutput": <Card
           className="is-compact"
           highlight={false}
+          showLinkIndicator={true}
           tagName="div"
         />,
       },
@@ -471,12 +487,14 @@ ShallowWrapper {
   "node": <Card
     className="test__ace is-compact"
     highlight={false}
+    showLinkIndicator={true}
     tagName="div"
   />,
   "nodes": Array [
     <Card
       className="test__ace is-compact"
       highlight={false}
+      showLinkIndicator={true}
       tagName="div"
     />,
   ],
@@ -521,12 +539,14 @@ ShallowWrapper {
         "_currentElement": <Card
           className="test__ace is-compact"
           highlight={false}
+          showLinkIndicator={true}
           tagName="div"
         />,
         "_debugID": 12,
         "_renderedOutput": <Card
           className="test__ace is-compact"
           highlight={false}
+          showLinkIndicator={true}
           tagName="div"
         />,
       },
@@ -557,6 +577,7 @@ ShallowWrapper {
   "node": <Card
     className="is-compact"
     highlight={false}
+    showLinkIndicator={true}
     tagName="div"
   >
     This is a compact card
@@ -565,6 +586,7 @@ ShallowWrapper {
     <Card
       className="is-compact"
       highlight={false}
+      showLinkIndicator={true}
       tagName="div"
     >
       This is a compact card
@@ -611,6 +633,7 @@ ShallowWrapper {
         "_currentElement": <Card
           className="is-compact"
           highlight={false}
+          showLinkIndicator={true}
           tagName="div"
         >
           This is a compact card
@@ -619,6 +642,7 @@ ShallowWrapper {
         "_renderedOutput": <Card
           className="is-compact"
           highlight={false}
+          showLinkIndicator={true}
           tagName="div"
         >
           This is a compact card
@@ -651,12 +675,14 @@ ShallowWrapper {
   "node": <Card
     className="is-compact"
     highlight={false}
+    showLinkIndicator={true}
     tagName="div"
   />,
   "nodes": Array [
     <Card
       className="is-compact"
       highlight={false}
+      showLinkIndicator={true}
       tagName="div"
     />,
   ],
@@ -697,12 +723,14 @@ ShallowWrapper {
         "_currentElement": <Card
           className="is-compact"
           highlight={false}
+          showLinkIndicator={true}
           tagName="div"
         />,
         "_debugID": 16,
         "_renderedOutput": <Card
           className="is-compact"
           highlight={false}
+          showLinkIndicator={true}
           tagName="div"
         />,
       },


### PR DESCRIPTION
@shaunandrews noticed that Reader post cards had gained a mysterious chevron on the right-hand side:

<img width="824" alt="screen shot 2017-10-31 at 13 39 39" src="https://user-images.githubusercontent.com/17325/32227986-c4e02b02-be44-11e7-82b6-240c36b6885c.png">

This was caused by a slight change in behaviour to the Card component in https://github.com/Automattic/wp-calypso/pull/19272/files.

This PR adds a new prop to Card called `showLinkIndicator`. It defaults to true. When showLinkIndicator is specified as false, no link indicator will be shown. Reader post cards now provide this prop.

### To test

Check a Reader stream and make sure no chevrons appear on the right of post cards.

Also check the Card component in Devdocs, to ensure that the linkable cards still have their icon on the right-hand side:

http://calypso.localhost:3000/devdocs/design/cards