### PR TITLE
Store: MailChimp refactor dashboard and add list name tooltip.

### DIFF
--- a/client/extensions/woocommerce/app/settings/email/mailchimp/mailchimp_dashboard.js
+++ b/client/extensions/woocommerce/app/settings/email/mailchimp/mailchimp_dashboard.js
@@ -4,7 +4,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
-import { isEmpty } from 'lodash';
 
 /**
  * Internal dependencies
@@ -29,120 +28,7 @@ import {
 import { submitMailChimpNewsletterSettings, requestResync } from 'woocommerce/state/sites/settings/email/actions.js';
 import { isSubmittingNewsletterSetting, newsletterSettingsSubmitError } from 'woocommerce/state/sites/settings/email/selectors';
 import { errorNotice, successNotice } from 'state/notices/actions';
-
-const SyncTab = localize( ( { siteId, translate, syncState, resync, isRequesting } ) => {
-	const { account_name, store_syncing, product_count, mailchimp_total_products,
-		mailchimp_total_orders, order_count } = syncState;
-	const hasProductInfo = ( undefined !== product_count ) && ( undefined !== mailchimp_total_products );
-	const products = hasProductInfo ? ( product_count + '/' + mailchimp_total_products ) : '';
-	const hasOrdersInfo = ( undefined !== order_count ) && ( undefined !== mailchimp_total_orders );
-	const orders = hasOrdersInfo ? ( order_count + '/' + mailchimp_total_orders ) : '';
-
-	const synced = () => (
-		<Notice
-			status="is-success"
-			isCompact
-			showDismiss={ false }
-			text={ translate(
-				'{{div}}{{div_name}}%(mailingListname)s{{/div_name}} {{div_info}}list synced.{{/div_info}}{{/div}}',
-				{
-					components: {
-						div: <div className="mailchimp__sync-notice-content" />,
-						div_name: <span className="mailchimp__sync-notice-list" />,
-						div_info: <span className="mailchimp__sync-notice-info" />,
-					},
-					args: { mailingListname: syncState.mailchimp_list_name }
-				} ) }
-		/>
-	);
-
-	const syncing = () => (
-		<Notice
-			className="mailchimp__sync-notice-syncing"
-			status="is-info"
-			isCompact
-			showDismiss={ false }
-			text={ translate(
-				'{{div}}{{div_name}}%(mailingListname)s{{/div_name}} {{div_info}}list is being synced.{{/div_info}}{{/div}}',
-				{
-					components: {
-						div: <div className="mailchimp__sync-notice-content" />,
-						div_name: <span className="mailchimp__sync-notice-list" />,
-						div_info: <span className="mailchimp__sync-notice-info" />,
-					},
-					args: { mailingListname: syncState.mailchimp_list_name }
-				} ) }
-		/>
-	);
-
-	const loadingSyncStatus = () => (
-		<Notice
-			isCompact
-			showDismiss={ false }
-			text={ translate( 'Loading sync status.' ) }
-		/>
-	);
-
-	const onResyncClick = () => {
-		! store_syncing && resync( siteId );
-	};
-
-	const notice = ( () => {
-		if ( isRequesting && isEmpty( syncState ) ) {
-			return loadingSyncStatus();
-		}
-		return store_syncing ? syncing() : synced();
-	} )();
-
-	return (
-		<div>
-			<div className="mailchimp__account-info-name">
-				{ translate( '{{span_info}}MailChimp account:{{/span_info}} {{span}}%(account_name)s{{/span}}', {
-					components: {
-						span_info: <span className="mailchimp__account-info" />,
-						span: <span />,
-					},
-					args: {
-						account_name
-					}
-				} ) }
-			</div>
-			<span className="mailchimp__sync-status">
-				{ notice }
-				<a className="mailchimp__resync-link" onClick={ onResyncClick }>
-					{ translate( 'Resync', { comment: 'to synchronize again' } ) }
-				</a>
-			</span>
-			<div className="mailchimp__account-data">
-				{ translate( '{{span_info}}Products:{{/span_info}} {{span}}%(products)s{{/span}}', {
-					components: {
-						span_info: <span className="mailchimp__account-info" />,
-						span: <span />,
-					},
-					args: {
-						products
-					}
-				} ) }
-				{ translate( '{{span_info}}Orders:{{/span_info}} {{span}}%(orders)s{{/span}}', {
-					components: {
-						span_info: <span className="mailchimp__account-info-orders" />,
-						span: <span />,
-					},
-					args: {
-						orders
-					}
-				} ) }
-			</div>
-		</div>
-	);
-} );
-
-SyncTab.propTypes = {
-	siteId: PropTypes.number.isRequired,
-	syncState: PropTypes.object,
-	isRequestingSettings: PropTypes.bool,
-	resync: PropTypes.func.isRequired,
-};
+import SyncTab from './sync_tab.js';
 
 const Settings = localize( ( { translate, settings, oldCheckbox, onChange } ) => {
 	const onCheckedStateChange = () => {

--- a/client/extensions/woocommerce/app/settings/email/mailchimp/style.scss
+++ b/client/extensions/woocommerce/app/settings/email/mailchimp/style.scss
@@ -252,7 +252,7 @@
 
 .mailchimp__sync-notice-content {
 	display: flex;
-	width: 145px;
+	max-width: 145px;
 
 	@include breakpoint( "<960px" ) {
 		width: auto;

--- a/client/extensions/woocommerce/app/settings/email/mailchimp/sync_tab.js
+++ b/client/extensions/woocommerce/app/settings/email/mailchimp/sync_tab.js
@@ -19,8 +19,9 @@ class Tooltip extends React.Component {
 		this.state = { show: false };
 	}
 
-	open = () => {
-		this.setState( { show: true } );
+	open = ( e ) => {
+		const isTruncated = e.target.offsetWidth < e.target.scrollWidth;
+		this.setState( { show: isTruncated } );
 	}
 
 	close = () => {
@@ -29,7 +30,8 @@ class Tooltip extends React.Component {
 
 	render() {
 		return (
-			<span
+			<div
+				className={ this.props.divClassName }
 				ref="tooltip-reference"
 				onMouseEnter={ this.open }
 				onMouseLeave={ this.close }
@@ -44,7 +46,7 @@ class Tooltip extends React.Component {
 				>
 					<div>{ this.props.listName }</div>
 				</TooltipComponent>
-			</span>
+			</div>
 		);
 	}
 
@@ -64,18 +66,19 @@ const SyncTab = localize( ( { siteId, translate, syncState, resync, isRequesting
 			isCompact
 			showDismiss={ false }
 			text={ translate(
-				'{{div}}{{div_name}}%(mailingListname)s{{/div_name}} {{div_info}}list synced.{{/div_info}}{{/div}}',
+				'{{div}}{{tooltip}}%(mailingListname)s{{/tooltip}} {{div_info}}list synced.{{/div_info}}{{/div}}',
 				{
 					components: {
 						div: <div className="mailchimp__sync-notice-content" />,
-						div_name: <span className="mailchimp__sync-notice-list" />,
 						div_info: <span className="mailchimp__sync-notice-info" />,
+						tooltip: <Tooltip
+							divClassName="mailchimp__sync-notice-list"
+							listName={ syncState.mailchimp_list_name + ' very long list name ' } />,
 					},
-					args: { mailingListname: syncState.mailchimp_list_name }
+					args: { mailingListname: syncState.mailchimp_list_name + ' very long list name ' }
 				} ) }
 		/>
 	);
-
 	const syncing = () => (
 		<Notice
 			className="mailchimp__sync-notice-syncing"
@@ -83,12 +86,14 @@ const SyncTab = localize( ( { siteId, translate, syncState, resync, isRequesting
 			isCompact
 			showDismiss={ false }
 			text={ translate(
-				'{{div}}{{div_name}}%(mailingListname)s{{/div_name}} {{div_info}}list is being synced.{{/div_info}}{{/div}}',
+				'{{div}}{{tooltip}}%(mailingListname)s{{/tooltip}} {{div_info}}list is being synced.{{/div_info}}{{/div}}',
 				{
 					components: {
 						div: <div className="mailchimp__sync-notice-content" />,
-						div_name: <span className="mailchimp__sync-notice-list" />,
 						div_info: <span className="mailchimp__sync-notice-info" />,
+						tooltip: <Tooltip
+							divClassName="mailchimp__sync-notice-list"
+							listName={ syncState.mailchimp_list_name } />,
 					},
 					args: { mailingListname: syncState.mailchimp_list_name }
 				} ) }
@@ -128,11 +133,7 @@ const SyncTab = localize( ( { siteId, translate, syncState, resync, isRequesting
 				} ) }
 			</div>
 			<span className="mailchimp__sync-status">
-				<Tooltip
-					listName={ syncState.mailchimp_list_name }
-				>
-					{ notice }
-				</Tooltip>
+				{ notice }
 				<a className="mailchimp__resync-link" onClick={ onResyncClick }>
 					{ translate( 'Resync', { comment: 'to synchronize again' } ) }
 				</a>

--- a/client/extensions/woocommerce/app/settings/email/mailchimp/sync_tab.js
+++ b/client/extensions/woocommerce/app/settings/email/mailchimp/sync_tab.js
@@ -1,0 +1,171 @@
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import React from 'react';
+import { isEmpty } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { localize } from 'i18n-calypso';
+import Notice from 'components/notice';
+import TooltipComponent from 'components/tooltip';
+
+class Tooltip extends React.Component {
+
+	constructor( props ) {
+		super( props );
+		this.state = { show: false };
+	}
+
+	open = () => {
+		this.setState( { show: true } );
+	}
+
+	close = () => {
+		this.setState( { show: false } );
+	}
+
+	render() {
+		return (
+			<span
+				ref="tooltip-reference"
+				onMouseEnter={ this.open }
+				onMouseLeave={ this.close }
+			>
+				{ this.props.children }
+				<TooltipComponent
+					id="tooltip__example"
+					isVisible={ this.state.show }
+					onClose={ this.close }
+					position={ 'top' }
+					context={ this.refs && this.refs[ 'tooltip-reference' ] }
+				>
+					<div>{ this.props.listName }</div>
+				</TooltipComponent>
+			</span>
+		);
+	}
+
+}
+
+const SyncTab = localize( ( { siteId, translate, syncState, resync, isRequesting } ) => {
+	const { account_name, store_syncing, product_count, mailchimp_total_products,
+		mailchimp_total_orders, order_count } = syncState;
+	const hasProductInfo = ( undefined !== product_count ) && ( undefined !== mailchimp_total_products );
+	const products = hasProductInfo ? ( product_count + '/' + mailchimp_total_products ) : '';
+	const hasOrdersInfo = ( undefined !== order_count ) && ( undefined !== mailchimp_total_orders );
+	const orders = hasOrdersInfo ? ( order_count + '/' + mailchimp_total_orders ) : '';
+
+	const synced = () => (
+		<Notice
+			status="is-success"
+			isCompact
+			showDismiss={ false }
+			text={ translate(
+				'{{div}}{{div_name}}%(mailingListname)s{{/div_name}} {{div_info}}list synced.{{/div_info}}{{/div}}',
+				{
+					components: {
+						div: <div className="mailchimp__sync-notice-content" />,
+						div_name: <span className="mailchimp__sync-notice-list" />,
+						div_info: <span className="mailchimp__sync-notice-info" />,
+					},
+					args: { mailingListname: syncState.mailchimp_list_name }
+				} ) }
+		/>
+	);
+
+	const syncing = () => (
+		<Notice
+			className="mailchimp__sync-notice-syncing"
+			status="is-info"
+			isCompact
+			showDismiss={ false }
+			text={ translate(
+				'{{div}}{{div_name}}%(mailingListname)s{{/div_name}} {{div_info}}list is being synced.{{/div_info}}{{/div}}',
+				{
+					components: {
+						div: <div className="mailchimp__sync-notice-content" />,
+						div_name: <span className="mailchimp__sync-notice-list" />,
+						div_info: <span className="mailchimp__sync-notice-info" />,
+					},
+					args: { mailingListname: syncState.mailchimp_list_name }
+				} ) }
+		/>
+	);
+
+	const loadingSyncStatus = () => (
+		<Notice
+			isCompact
+			showDismiss={ false }
+			text={ translate( 'Loading sync status.' ) }
+		/>
+	);
+
+	const onResyncClick = () => {
+		! store_syncing && resync( siteId );
+	};
+
+	const notice = ( () => {
+		if ( isRequesting && isEmpty( syncState ) ) {
+			return loadingSyncStatus();
+		}
+		return store_syncing ? syncing() : synced();
+	} )();
+
+	return (
+		<div>
+			<div className="mailchimp__account-info-name">
+				{ translate( '{{span_info}}MailChimp account:{{/span_info}} {{span}}%(account_name)s{{/span}}', {
+					components: {
+						span_info: <span className="mailchimp__account-info" />,
+						span: <span />,
+					},
+					args: {
+						account_name
+					}
+				} ) }
+			</div>
+			<span className="mailchimp__sync-status">
+				<Tooltip
+					listName={ syncState.mailchimp_list_name }
+				>
+					{ notice }
+				</Tooltip>
+				<a className="mailchimp__resync-link" onClick={ onResyncClick }>
+					{ translate( 'Resync', { comment: 'to synchronize again' } ) }
+				</a>
+			</span>
+			<div className="mailchimp__account-data">
+				{ translate( '{{span_info}}Products:{{/span_info}} {{span}}%(products)s{{/span}}', {
+					components: {
+						span_info: <span className="mailchimp__account-info" />,
+						span: <span />,
+					},
+					args: {
+						products
+					}
+				} ) }
+				{ translate( '{{span_info}}Orders:{{/span_info}} {{span}}%(orders)s{{/span}}', {
+					components: {
+						span_info: <span className="mailchimp__account-info-orders" />,
+						span: <span />,
+					},
+					args: {
+						orders
+					}
+				} ) }
+			</div>
+		</div>
+	);
+} );
+
+SyncTab.propTypes = {
+	siteId: PropTypes.number.isRequired,
+	syncState: PropTypes.object,
+	isRequestingSettings: PropTypes.bool,
+	resync: PropTypes.func.isRequired,
+};
+
+export default SyncTab;

--- a/client/extensions/woocommerce/app/settings/email/mailchimp/sync_tab.js
+++ b/client/extensions/woocommerce/app/settings/email/mailchimp/sync_tab.js
@@ -4,11 +4,11 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { isEmpty } from 'lodash';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
-import { localize } from 'i18n-calypso';
 import Notice from 'components/notice';
 import TooltipComponent from 'components/tooltip';
 
@@ -38,7 +38,6 @@ class Tooltip extends React.Component {
 			>
 				{ this.props.children }
 				<TooltipComponent
-					id="tooltip__example"
 					isVisible={ this.state.show }
 					onClose={ this.close }
 					position={ 'top' }

--- a/client/extensions/woocommerce/app/settings/email/mailchimp/sync_tab.js
+++ b/client/extensions/woocommerce/app/settings/email/mailchimp/sync_tab.js
@@ -31,7 +31,7 @@ class Tooltip extends React.Component {
 	render() {
 		return (
 			<div
-				className={ this.props.divClassName }
+				className="mailchimp__sync-notice-list"
 				ref="tooltip-reference"
 				onMouseEnter={ this.open }
 				onMouseLeave={ this.close }
@@ -71,11 +71,9 @@ const SyncTab = localize( ( { siteId, translate, syncState, resync, isRequesting
 					components: {
 						div: <div className="mailchimp__sync-notice-content" />,
 						div_info: <span className="mailchimp__sync-notice-info" />,
-						tooltip: <Tooltip
-							divClassName="mailchimp__sync-notice-list"
-							listName={ syncState.mailchimp_list_name + ' very long list name ' } />,
+						tooltip: <Tooltip listName={ syncState.mailchimp_list_name } />,
 					},
-					args: { mailingListname: syncState.mailchimp_list_name + ' very long list name ' }
+					args: { mailingListname: syncState.mailchimp_list_name }
 				} ) }
 		/>
 	);
@@ -91,9 +89,7 @@ const SyncTab = localize( ( { siteId, translate, syncState, resync, isRequesting
 					components: {
 						div: <div className="mailchimp__sync-notice-content" />,
 						div_info: <span className="mailchimp__sync-notice-info" />,
-						tooltip: <Tooltip
-							divClassName="mailchimp__sync-notice-list"
-							listName={ syncState.mailchimp_list_name } />,
+						tooltip: <Tooltip listName={ syncState.mailchimp_list_name } />,
 					},
 					args: { mailingListname: syncState.mailchimp_list_name }
 				} ) }


### PR DESCRIPTION
### Information

Add tooltip for list name on sync tab. When the list name is too long it is truncated.
Tooltip shows full list name. 

### Testing
Open MailChimp settings ( UI visible after successful setup ). List name is displayed in the upper right part of the MailChimp UI component in the Sync tab. If your list name is too long then it will be truncated and hovering over the name will show a popup tooltip with the full name. If the name is not very long and not truncated then tooltip will not be shown. To simulate a name that is too long you can use browser dev tools and change the name directly in DOM for a longer one. 