### PR TITLE
Jetpack Connect: Hide plan icons for small devices

### DIFF
--- a/client/jetpack-connect/plans-grid.jsx
+++ b/client/jetpack-connect/plans-grid.jsx
@@ -12,6 +12,7 @@ import { localize } from 'i18n-calypso';
 import Main from 'components/main';
 import FormattedHeader from 'components/formatted-header';
 import PlansFeaturesMain from 'my-sites/plans-features-main';
+import { abtest } from 'lib/abtest';
 
 /**
  * Constants
@@ -49,8 +50,11 @@ class JetpackPlansGrid extends Component {
 	}
 
 	render() {
+		const mainClassName =
+			abtest( 'jetpackHidePlanIconsOnMobile' ) === 'hide' && 'jetpack-connect__hide-plan-icons';
+
 		return (
-			<Main wideLayout>
+			<Main wideLayout className={ mainClassName }>
 				<div className="jetpack-connect__plans">
 					{ this.renderConnectHeader() }
 					<div id="plans">

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -469,6 +469,7 @@
 
 .jetpack-connect__plans-nav-buttons {
 	text-align: center;
+	margin-bottom: 17px;
 
 	.button .gridicon {
 		padding-left: 4px;
@@ -491,10 +492,6 @@
 }
 
 .jetpack-connect__plans {
-	.plans-wrapper {
-		padding-bottom: 0;
-	}
-
 	.plan-features__header-figure {
 		height: 32px;
 		width: 32px;
@@ -503,14 +500,6 @@
 	.plan-features__header-timeframe {
 		height: 20px;
 		margin-top: 11px;
-	}
-
-	.plan-features__graphic {
-		display: none;
-	}
-
-	.plan-features__pricing {
-		padding-top: 16px;
 	}
 
 	.plan-price.is-original {
@@ -541,4 +530,24 @@
 
 .jetpack-connect__auth-form-header-image {
 	text-align: center;
+}
+
+@media ( max-height: 920px ) {
+	.jetpack-connect__plans-nav-buttons {
+		margin-bottom: 0;
+	}
+
+	.jetpack-connect__plans {
+		.plans-wrapper {
+			padding-bottom: 0;
+		}
+
+		.plan-features__graphic {
+			display: none;
+		}
+
+		.plan-features__pricing {
+			padding-top: 16px;
+		}
+	}
 }

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -533,21 +533,23 @@
 }
 
 @media ( max-height: 920px ) {
-	.jetpack-connect__plans-nav-buttons {
-		margin-bottom: 0;
-	}
-
-	.jetpack-connect__plans {
-		.plans-wrapper {
-			padding-bottom: 0;
+	.jetpack-connect__hide-plan-icons {
+		.jetpack-connect__plans-nav-buttons {
+			margin-bottom: 0;
 		}
 
-		.plan-features__graphic {
-			display: none;
-		}
+		.jetpack-connect__plans {
+			.plans-wrapper {
+				padding-bottom: 0;
+			}
 
-		.plan-features__pricing {
-			padding-top: 16px;
+			.plan-features__graphic {
+				display: none;
+			}
+
+			.plan-features__pricing {
+				padding-top: 16px;
+			}
 		}
 	}
 }

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -469,7 +469,6 @@
 
 .jetpack-connect__plans-nav-buttons {
 	text-align: center;
-	margin-bottom: 17px;
 
 	.button .gridicon {
 		padding-left: 4px;
@@ -492,6 +491,10 @@
 }
 
 .jetpack-connect__plans {
+	.plans-wrapper {
+		padding-bottom: 0;
+	}
+
 	.plan-features__header-figure {
 		height: 32px;
 		width: 32px;
@@ -500,6 +503,14 @@
 	.plan-features__header-timeframe {
 		height: 20px;
 		margin-top: 11px;
+	}
+
+	.plan-features__graphic {
+		display: none;
+	}
+
+	.plan-features__pricing {
+		padding-top: 16px;
 	}
 
 	.plan-price.is-original {

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -70,6 +70,15 @@ export default {
 		defaultVariation: 'hide',
 		allowExistingUsers: true,
 	},
+	jetpackHidePlanIconsOnMobile: {
+		datestamp: '20171031',
+		variations: {
+			show: 50,
+			hide: 50,
+		},
+		defaultVariation: 'show',
+		allowExistingUsers: true,
+	},
 	skipThemesSelectionModal: {
 		datestamp: '20170904',
 		variations: {


### PR DESCRIPTION
### Purpose

This PR updates the Jetpack Connect plans and plans landing pages to hide the plan icons and reduce the vertical spacing a little on smaller devices, so the Free plan and help button can be visible on smaller resolutions, including the most common laptop resolution of 1366x768. This change will affect only devices with height <= 920 px - larger devices will see no visual changes. Note: this functionality is wrapped in an AB test, see below for testing both ABtest cases.

### Preview

**1. Plans page - higher than 920px height (unchanged)**
![](https://cldup.com/NSqlOfqqf3.png)

**2. Plans page - 768px height**
![](https://cldup.com/EV9bnp3MeN.png)

**3. Plans landing page - higher than 920px height (unchanged)**
![](https://cldup.com/1zzwy6d-KE.png)

**4. Plans landing page - 768px height**
![](https://cldup.com/d21nAwoIBz.png)

### Testing
* Checkout this branch
* Test the following steps with a device with height > 920px.
  * Go to `/jetpack/connect/store`
  * Verify you see no visual changes (as shown on preview 3).
  * Go to `/jetpack/connect/`
  * Connect your Jetpack site and reach the plans page.
  * Verify you see no visual changes (as shown on preview 1).
* Test the following steps with a device with height < 920px.
  * Go to `/jetpack/connect/store`
  * Verify the plan icons are now hidden and the page looks as shown on preview 4.
  * Go to `/jetpack/connect/`
  * Connect your Jetpack site and reach the plans page.
  * Verify the plan icons are now hidden and the page looks as shown on preview 2.
* Use the dev A/B test tool to set the other variation (or `localStorage.setItem('ABTests','{"jetpackHidePlanIconsOnMobile_20171031":"show"}')` or use `hide` for the other variation).