### PR TITLE
Reader: hide link indicator arrow on x-posts

### DIFF
--- a/client/reader/stream/x-post.jsx
+++ b/client/reader/stream/x-post.jsx
@@ -172,7 +172,12 @@ class CrossPost extends PureComponent {
 		}
 
 		return (
-			<Card tagName="article" onClick={ this.handleCardClick } className={ articleClasses }>
+			<Card
+				tagName="article"
+				onClick={ this.handleCardClick }
+				className={ articleClasses }
+				showLinkIndicator={ false }
+			>
 				<ReaderAvatar
 					siteIcon={ siteIcon }
 					feedIcon={ feedIcon }


### PR DESCRIPTION
Following on from #19333, this PR hides the Card link indicator on x-posts.

Before:

<img width="820" alt="screen shot 2017-10-31 at 15 12 34" src="https://user-images.githubusercontent.com/17325/32231634-03b3b584-be4e-11e7-9b18-e563a94b8a63.png">

After:

<img width="824" alt="screen shot 2017-10-31 at 15 12 55" src="https://user-images.githubusercontent.com/17325/32231639-0596325a-be4e-11e7-9b88-70f2c087df9e.png">

### To test

Load a Reader stream with x-posts (e.g. a team stream), and verify that the right chevron is not shown.