### PR TITLE
Comments Redesign: fixes relative time calculations

### DIFF
--- a/client/my-sites/comments/comment/comment-author.jsx
+++ b/client/my-sites/comments/comment/comment-author.jsx
@@ -16,12 +16,10 @@ import Emojify from 'components/emojify';
 import ExternalLink from 'components/external-link';
 import Gravatar from 'components/gravatar';
 import CommentPostLink from 'my-sites/comments/comment/comment-post-link';
-import { convertDateToUserLocation } from 'components/post-schedule/utils';
 import { decodeEntities } from 'lib/formatting';
-import { gmtOffset, timezone } from 'lib/site/utils';
 import { urlToDomainAndPath } from 'lib/url';
 import { getSiteComment } from 'state/selectors';
-import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
 
 export class CommentAuthor extends Component {
 	static propTypes = {
@@ -41,23 +39,16 @@ export class CommentAuthor extends Component {
 			gravatarUser,
 			isExpanded,
 			moment,
-			site,
 			translate,
 		} = this.props;
 
-		const localizedDate = convertDateToUserLocation(
-			commentDate || moment(),
-			timezone( site ),
-			gmtOffset( site )
-		);
-
-		const formattedDate = localizedDate.format( 'll LT' );
+		const formattedDate = moment( commentDate ).format( 'll LT' );
 
 		const relativeDate = moment()
 			.subtract( 1, 'month' )
-			.isBefore( localizedDate )
-			? localizedDate.fromNow()
-			: localizedDate.format( 'll' );
+			.isBefore( commentDate )
+			? moment( commentDate ).fromNow()
+			: moment( commentDate ).format( 'll' );
 
 		return (
 			<div className="comment__author">
@@ -97,7 +88,6 @@ export class CommentAuthor extends Component {
 }
 
 const mapStateToProps = ( state, { commentId } ) => {
-	const site = getSelectedSite( state );
 	const siteId = getSelectedSiteId( state );
 	const comment = getSiteComment( state, siteId, commentId );
 
@@ -113,7 +103,6 @@ const mapStateToProps = ( state, { commentId } ) => {
 		commentType: get( comment, 'type', 'comment' ),
 		commentUrl: get( comment, 'URL' ),
 		gravatarUser,
-		site,
 	};
 };
 


### PR DESCRIPTION
Follows #19285.

This PR fixes the relative time calculations to use the user's timezone for the redesigned components.

| Before | After |
| --- | --- |
| ![screen shot 2017-10-31 at 12 19 47](https://user-images.githubusercontent.com/233601/32232259-6bec3f26-be36-11e7-9c15-43fad14dfd8c.png) | ![screen shot 2017-10-31 at 12 16 33](https://user-images.githubusercontent.com/233601/32232265-6f8f0a28-be36-11e7-9519-c1bbfef2f81f.png) |
