### PR TITLE
Rewind credentials: Default port settings

### DIFF
--- a/client/my-sites/site-settings/jetpack-credentials/credentials-form/index.jsx
+++ b/client/my-sites/site-settings/jetpack-credentials/credentials-form/index.jsx
@@ -41,8 +41,23 @@ export class CredentialsForm extends Component {
 	};
 
 	handleFieldChange = event => {
+		const newForm = {
+			...this.state.form,
+			[ event.target.name ]: event.target.value,
+		};
+
+		if ( 'protocol' === event.target.name ) {
+			switch ( event.target.value ) {
+				case 'ftp':
+					newForm.port = 21;
+					break;
+				default:
+					newForm.port = 22;
+			}
+		}
+
 		this.setState( {
-			form: { ...this.state.form, [ event.target.name ]: event.target.value },
+			form: newForm,
 			formErrors: { ...this.state.formErrors, [ event.target.name ]: false },
 		} );
 	};

--- a/client/my-sites/site-settings/jetpack-credentials/credentials-form/index.jsx
+++ b/client/my-sites/site-settings/jetpack-credentials/credentials-form/index.jsx
@@ -41,17 +41,18 @@ export class CredentialsForm extends Component {
 	};
 
 	handleFieldChange = event => {
-		const newForm = {
-			...this.state.form,
-			[ event.target.name ]: event.target.value,
-		};
+		const { name, value } = event.target;
+		const changedProtocol = 'protocol' === name;
+		const defaultPort = 'ftp' === value ? 21 : 22;
 
-		if ( 'protocol' === event.target.name ) {
-			newForm.port = 'ftp' === event.target.value ? 21 : 22;
-		}
+		const form = Object.assign(
+			this.state.form,
+			{ [ name ]: value },
+			changedProtocol && { port: defaultPort }
+		);
 
 		this.setState( {
-			form: newForm,
+			form,
 			formErrors: { ...this.state.formErrors, [ event.target.name ]: false },
 		} );
 	};

--- a/client/my-sites/site-settings/jetpack-credentials/credentials-form/index.jsx
+++ b/client/my-sites/site-settings/jetpack-credentials/credentials-form/index.jsx
@@ -40,8 +40,7 @@ export class CredentialsForm extends Component {
 		},
 	};
 
-	handleFieldChange = event => {
-		const { name, value } = event.target;
+	handleFieldChange = ( { target: { name, value } } ) => {
 		const changedProtocol = 'protocol' === name;
 		const defaultPort = 'ftp' === value ? 21 : 22;
 

--- a/client/my-sites/site-settings/jetpack-credentials/credentials-form/index.jsx
+++ b/client/my-sites/site-settings/jetpack-credentials/credentials-form/index.jsx
@@ -47,13 +47,7 @@ export class CredentialsForm extends Component {
 		};
 
 		if ( 'protocol' === event.target.name ) {
-			switch ( event.target.value ) {
-				case 'ftp':
-					newForm.port = 21;
-					break;
-				default:
-					newForm.port = 22;
-			}
+			newForm.port = 'ftp' === event.target.value ? 21 : 22;
 		}
 
 		this.setState( {

--- a/client/my-sites/site-settings/jetpack-credentials/credentials-setup-flow/setup-form.jsx
+++ b/client/my-sites/site-settings/jetpack-credentials/credentials-setup-flow/setup-form.jsx
@@ -15,7 +15,7 @@ const SetupForm = ( { formIsSubmitting, reset, siteId, updateCredentials } ) => 
 			formIsSubmitting,
 			protocol: 'ssh',
 			host: '',
-			port: '',
+			port: '22',
 			user: '',
 			pass: '',
 			abspath: '',


### PR DESCRIPTION
Defaults port number (22 to correspond with default protocol SSH) to the credentials form. Also, switches port to 21 or 22 to correspond with changes in the protocol selector.

Testing Instructions:
1. Visit Site Settings/Security on a rewind-enabled non-pressable site with no credentials.
2. Ensure the port field is defaulted to 22 (not a placeholder).
3. Ensure the port field changes to 21 when protocol is changed to FTP.
4. Ensure the port field changes back to 22 when switching protocol to SSH or SFTP.
5. After saving credentials, verify the port field is defaulted correctly to your port setting. 
6. Verify the port switching behavior remains. Port should always default when changing the protocol value.