### PR TITLE
State: Fix deserialization

### DIFF
--- a/client/state/jetpack/credentials/schema.js
+++ b/client/state/jetpack/credentials/schema.js
@@ -1,3 +1,4 @@
+/** @format */
 export const itemsSchema = {
 	type: 'object',
 	items: {
@@ -7,7 +8,7 @@ export const itemsSchema = {
 			host: { type: 'string' },
 			port: { type: 'number' },
 			protocol: { type: 'string' },
-			pass: { type: 'bool' },
+			pass: { type: 'boolean' },
 			user: { type: 'string' },
 		},
 	},


### PR DESCRIPTION
Bad type in schema was causing validation to fail, preventing deserialization from persisted state.

**To Test**
* Check out this branch
* Load calypso
* turn on state debug: `localStorage.setItem('debug', 'calypso:state' );`
* Refresh
* Ensure that the following output does not appear in the console:

```
calypso:state failed to load initial redux-store state +69ms TypeError: c[(t || "any")] is not a function
    at build.922d8295b780feea126b.min.js:71
    at Array.map (<anonymous>)
    at j (build.922d8295b780feea126b.min.js:71)
    at build.922d8295b780feea126b.min.js:72
    at Array.forEach (<anonymous>)
    at j (build.922d8295b780feea126b.min.js:72)
    at j (build.922d8295b780feea126b.min.js:71)
    at p (build.922d8295b780feea126b.min.js:72)
    at e.exports (build.922d8295b780feea126b.min.js:72)
    at r (build.922d8295b780feea126b.min.js:67)
```

Introduced in #18962 

