### PR TITLE
Comments Redesign: address separator when author has no address

### DIFF
--- a/client/my-sites/comments/comment/comment-author.jsx
+++ b/client/my-sites/comments/comment/comment-author.jsx
@@ -83,12 +83,14 @@ export class CommentAuthor extends Component {
 								{ isExpanded ? formattedDate : relativeDate }
 							</ExternalLink>
 						</span>
-						<span className="comment__author-url">
-							<span className="comment__author-url-separator">&middot;</span>
-							<ExternalLink href={ authorUrl }>
-								<Emojify>{ urlToDomainAndPath( authorUrl ) }</Emojify>
-							</ExternalLink>
-						</span>
+						{ authorUrl && (
+							<span className="comment__author-url">
+								<span className="comment__author-url-separator">&middot;</span>
+								<ExternalLink href={ authorUrl }>
+									<Emojify>{ urlToDomainAndPath( authorUrl ) }</Emojify>
+								</ExternalLink>
+							</span>
+						) }
 					</div>
 				</div>
 			</div>


### PR DESCRIPTION
Makes author address separator conditional to the presence of an address.

| Before | After | When Author has Address |
| - | - | - |
| ![screen shot 2017-10-31 at 12 50 57](https://user-images.githubusercontent.com/233601/32233932-576e02e2-be3a-11e7-90a1-27fa382544e1.png) | ![screen shot 2017-10-31 at 12 47 27](https://user-images.githubusercontent.com/233601/32233931-5745e12c-be3a-11e7-9263-a9f5a1c25e26.png) | ![screen shot 2017-10-31 at 12 46 16](https://user-images.githubusercontent.com/233601/32233929-5720ec6e-be3a-11e7-93da-01f16174340d.png) |
