### PR TITLE
Comments: add link indicator to header

### DIFF
--- a/client/my-sites/comments/comment/comment-author.jsx
+++ b/client/my-sites/comments/comment/comment-author.jsx
@@ -27,6 +27,17 @@ export class CommentAuthor extends Component {
 		isExpanded: PropTypes.bool,
 	};
 
+	commentHasLink = () => {
+		if ( typeof DOMParser !== 'undefined' && DOMParser.prototype.parseFromString ) {
+			const parser = new DOMParser();
+			const commentDom = parser.parseFromString( this.props.commentContent, 'text/html' );
+
+			return !! commentDom.getElementsByTagName( 'a' ).length;
+		}
+
+		return false;
+	};
+
 	render() {
 		const {
 			authorAvatarUrl,
@@ -62,6 +73,9 @@ export class CommentAuthor extends Component {
 
 				<div className="comment__author-info">
 					<div className="comment__author-info-element">
+						{ this.commentHasLink() && (
+							<Gridicon icon="link" size="18" className="comment__author-has-link" />
+						) }
 						<strong className="comment__author-name">
 							<Emojify>{ authorDisplayName || translate( 'Anonymous' ) }</Emojify>
 						</strong>
@@ -92,7 +106,6 @@ export class CommentAuthor extends Component {
 const mapStateToProps = ( state, { commentId } ) => {
 	const siteId = getSelectedSiteId( state );
 	const comment = getSiteComment( state, siteId, commentId );
-
 	const authorAvatarUrl = get( comment, 'author.avatar_URL' );
 	const authorDisplayName = decodeEntities( get( comment, 'author.name' ) );
 	const gravatarUser = { avatar_URL: authorAvatarUrl, display_name: authorDisplayName };
@@ -101,6 +114,7 @@ const mapStateToProps = ( state, { commentId } ) => {
 		authorAvatarUrl,
 		authorDisplayName,
 		authorUrl: get( comment, 'author.URL', '' ),
+		commentContent: get( comment, 'content' ),
 		commentDate: get( comment, 'date' ),
 		commentType: get( comment, 'type', 'comment' ),
 		commentUrl: get( comment, 'URL' ),

--- a/client/my-sites/comments/comment/comment-author.jsx
+++ b/client/my-sites/comments/comment/comment-author.jsx
@@ -74,7 +74,7 @@ export class CommentAuthor extends Component {
 				<div className="comment__author-info">
 					<div className="comment__author-info-element">
 						{ this.commentHasLink() && (
-							<Gridicon icon="link" size="18" className="comment__author-has-link" />
+							<Gridicon icon="link" size={ 18 } className="comment__author-has-link" />
 						) }
 						<strong className="comment__author-name">
 							<Emojify>{ authorDisplayName || translate( 'Anonymous' ) }</Emojify>

--- a/client/my-sites/comments/comment/style.scss
+++ b/client/my-sites/comments/comment/style.scss
@@ -89,6 +89,12 @@
 	width: calc(100% - 48px);
 }
 
+.comment__author-has-link {
+	position: relative;
+	top: 4px;
+	margin-right: 5px;
+}
+
 .comment__author-info-element {
 	overflow: hidden;
 	text-overflow: ellipsis;

--- a/client/my-sites/comments/comment/style.scss
+++ b/client/my-sites/comments/comment/style.scss
@@ -90,9 +90,7 @@
 }
 
 .comment__author-has-link {
-	position: relative;
-	top: 4px;
-	margin-right: 5px;
+	margin: 0 4px -4px 0;
 }
 
 .comment__author-info-element {

--- a/client/my-sites/comments/comment/style.scss
+++ b/client/my-sites/comments/comment/style.scss
@@ -91,6 +91,7 @@
 
 .comment__author-has-link {
 	margin: 0 4px -4px 0;
+	color: $alert-red;
 }
 
 .comment__author-info-element {


### PR DESCRIPTION
Closes #14120

Displays a link icon next to author name if comment contains links.
Note: I relied on existing designs available in above issue and I'm not sure how it fits our new M3 designs. Also I decided to use the `link` Gridicon instead of the one outlined there.

### Visual changes

![commentlink](https://user-images.githubusercontent.com/1182160/32235699-7cb42e70-be60-11e7-952e-e9bc1754ee2f.png)

### Testing instructions

1. Start Calypso with: `ENABLE_FEATURES=comments/management/m3-design npm start`
2. Verify that link indicator is displayed for comments that have links.
3. Verify that link indicator is not present for comments that don't contain links.
