### PR TITLE
Activity Log: fix positioning of last step tooltip

### DIFF
--- a/client/layout/guided-tours/tours/activity-log-tour.js
+++ b/client/layout/guided-tours/tours/activity-log-tour.js
@@ -86,8 +86,12 @@ export const ActivityLogTour = makeTour(
 		<Step
 			name="actions"
 			arrow="top-right"
-			target=".has-expanded-summary .activity-log-item:not(.is-discarded) .foldable-card__secondary"
-			placement="beside"
+			target={
+				'.has-expanded-summary .activity-log-item:not(.is-discarded) ' +
+				'.foldable-card__secondary .foldable-card__summary-expanded .ellipsis-menu__toggle'
+			}
+			placement="below"
+			style={ { marginLeft: '-18px' } }
 		>
 			<p>
 				{ translate(


### PR DESCRIPTION
… so it's properly aligned below ellipsis menu

#### Before
<img width="853" alt="captura de pantalla 2017-10-31 a la s 13 35 55" src="https://user-images.githubusercontent.com/1041600/32236293-81e95714-be40-11e7-8d7f-34e6515471fd.png">


#### After
<img width="588" alt="captura de pantalla 2017-10-31 a la s 13 31 31" src="https://user-images.githubusercontent.com/1041600/32236297-83d537be-be40-11e7-86c1-cae6b8c8a69c.png">
