### PR TITLE
Activity Log: fix state validation for activityId 

### DIFF
--- a/client/state/activity-log/log/schema.js
+++ b/client/state/activity-log/log/schema.js
@@ -20,7 +20,7 @@ const activityItemSchema = {
 		activityDate: { type: 'string' },
 		activityGroup: { type: 'string' },
 		activityIcon: { type: 'string' },
-		activityId: { type: 'string' },
+		activityId: { type: [ 'undefined', 'string' ] },
 		activityIsRewindable: { type: 'boolean' },
 		activityName: { type: 'string' },
 		activityStatus: {


### PR DESCRIPTION
…since initially it's `undefined` instead of `string` as pointed by `client/state/activity-log/log/reducer.js`

<img width="588" alt="captura de pantalla 2017-10-31 a la s 13 38 17" src="https://user-images.githubusercontent.com/1041600/32236517-28ca4b9c-be41-11e7-9da3-b78092541f35.png">
