### PR TITLE
Allow both approving and unapproving in bulk edit for Approved and Unapproved status filters.

### DIFF
--- a/client/my-sites/comments/comment-navigation/index.jsx
+++ b/client/my-sites/comments/comment-navigation/index.jsx
@@ -32,8 +32,8 @@ import { getSiteComment } from 'state/selectors';
 import { NEWEST_FIRST, OLDEST_FIRST } from '../constants';
 
 const bulkActions = {
-	unapproved: [ 'approve', 'spam', 'trash' ],
-	approved: [ 'unapprove', 'spam', 'trash' ],
+	unapproved: [ 'approve', 'unapprove', 'spam', 'trash' ],
+	approved: [ 'approve', 'unapprove', 'spam', 'trash' ],
 	spam: [ 'approve', 'delete' ],
 	trash: [ 'approve', 'spam', 'delete' ],
 	all: [ 'approve', 'unapprove', 'spam', 'trash' ],


### PR DESCRIPTION
Currently, only the All view has the option of both approving and unapproving any bulk-selected comments. However, the Approved and Pending views can end up in the same mixed-status display as the All view, only without both options; we currently tie the available bulk actions to the filter being displayed, making this UI possible:

![screen shot 2017-10-31 at 10 58 21 am](https://user-images.githubusercontent.com/349751/32240398-7aefead8-be2a-11e7-8e6f-a76ab950cac8.png)
_Being the Approved view, only the Unapprove bulk action is available – even though only unapproved comments are selected._

This PR takes the easy way, and just makes both bulk actions available on all views that can be mixed (so, adding them to the Approved and Pending views). At least a user won't get themselves into a situation where they _can't_ do what they want to do.

![screen shot 2017-10-31 at 11 02 57 am](https://user-images.githubusercontent.com/349751/32240666-1f299a22-be2b-11e7-9bba-3136949d97bf.png)

Maybe for M4, we can look at tying the bulk actions to the selected comments, rather than the filter view.
