### PR TITLE
Comments Redesign: Persistence and Undo

### DIFF
--- a/client/my-sites/comments/comment/comment-actions.jsx
+++ b/client/my-sites/comments/comment/comment-actions.jsx
@@ -183,69 +183,72 @@ export class CommentActions extends Component {
 			translate,
 		} = this.props;
 
-		if ( isPersistent && ! includes( [ 'approved', 'unapproved' ], commentStatus ) ) {
-			return <CommentConfirmation { ...{ commentId } } undo={ this.undo } />;
-		}
-
 		return (
-			<div className="comment__actions">
-				{ this.hasAction( 'approve' ) && (
-					<Button
-						borderless
-						className={ classNames( 'comment__action comment__action-approve', {
-							'is-approved': commentIsApproved,
-						} ) }
-						onClick={ this.toggleApproved }
-					>
-						<Gridicon icon={ commentIsApproved ? 'checkmark-circle' : 'checkmark' } />
-						<span>{ commentIsApproved ? translate( 'Approved' ) : translate( 'Approve' ) }</span>
-					</Button>
-				) }
+			<div>
+				<div className="comment__actions">
+					{ this.hasAction( 'approve' ) && (
+						<Button
+							borderless
+							className={ classNames( 'comment__action comment__action-approve', {
+								'is-approved': commentIsApproved,
+							} ) }
+							onClick={ this.toggleApproved }
+						>
+							<Gridicon icon={ commentIsApproved ? 'checkmark-circle' : 'checkmark' } />
+							<span>{ commentIsApproved ? translate( 'Approved' ) : translate( 'Approve' ) }</span>
+						</Button>
+					) }
 
-				{ this.hasAction( 'spam' ) && (
-					<Button
-						borderless
-						className="comment__action comment__action-spam"
-						onClick={ this.setSpam }
-					>
-						<Gridicon icon="spam" />
-						<span>{ translate( 'Spam' ) }</span>
-					</Button>
-				) }
+					{ this.hasAction( 'spam' ) && (
+						<Button
+							borderless
+							className="comment__action comment__action-spam"
+							onClick={ this.setSpam }
+						>
+							<Gridicon icon="spam" />
+							<span>{ translate( 'Spam' ) }</span>
+						</Button>
+					) }
 
-				{ this.hasAction( 'trash' ) && (
-					<Button
-						borderless
-						className="comment__action comment__action-trash"
-						onClick={ this.setTrash }
-					>
-						<Gridicon icon="trash" />
-						<span>{ translate( 'Trash' ) }</span>
-					</Button>
-				) }
+					{ this.hasAction( 'trash' ) && (
+						<Button
+							borderless
+							className="comment__action comment__action-trash"
+							onClick={ this.setTrash }
+						>
+							<Gridicon icon="trash" />
+							<span>{ translate( 'Trash' ) }</span>
+						</Button>
+					) }
 
-				{ this.hasAction( 'delete' ) && (
-					<Button
-						borderless
-						className="comment__action comment__action-delete"
-						onClick={ this.delete }
-					>
-						<Gridicon icon="trash" />
-						<span>{ translate( 'Delete Permanently' ) }</span>
-					</Button>
-				) }
+					{ this.hasAction( 'delete' ) && (
+						<Button
+							borderless
+							className="comment__action comment__action-delete"
+							onClick={ this.delete }
+						>
+							<Gridicon icon="trash" />
+							<span>{ translate( 'Delete Permanently' ) }</span>
+						</Button>
+					) }
 
-				{ this.hasAction( 'like' ) && (
-					<Button
-						borderless
-						className={ classNames( 'comment__action comment__action-like', {
-							'is-liked': commentIsLiked,
-						} ) }
-						onClick={ this.toggleLike }
-					>
-						<Gridicon icon={ commentIsLiked ? 'star' : 'star-outline' } />
-						<span>{ commentIsLiked ? translate( 'Liked' ) : translate( 'Like' ) }</span>
-					</Button>
+					{ this.hasAction( 'like' ) && (
+						<Button
+							borderless
+							className={ classNames( 'comment__action comment__action-like', {
+								'is-liked': commentIsLiked,
+							} ) }
+							onClick={ this.toggleLike }
+						>
+							<Gridicon icon={ commentIsLiked ? 'star' : 'star-outline' } />
+							<span>{ commentIsLiked ? translate( 'Liked' ) : translate( 'Like' ) }</span>
+						</Button>
+					) }
+				</div>
+
+				{ isPersistent &&
+				! includes( [ 'approved', 'unapproved' ], commentStatus ) && (
+					<CommentConfirmation { ...{ commentId } } undo={ this.undo } />
 				) }
 			</div>
 		);

--- a/client/my-sites/comments/comment/comment-actions.jsx
+++ b/client/my-sites/comments/comment/comment-actions.jsx
@@ -14,6 +14,7 @@ import { get, includes } from 'lodash';
  * Internal dependencies
  */
 import Button from 'components/button';
+import CommentConfirmation from 'my-sites/comments/comment/comment-confirmation';
 import {
 	bumpStat,
 	composeAnalytics,
@@ -39,7 +40,10 @@ const commentActions = {
 export class CommentActions extends Component {
 	static propTypes = {
 		commentId: PropTypes.number,
+		isExpanded: PropTypes.bool,
+		isPersistent: PropTypes.bool,
 		removeFromPersisted: PropTypes.func,
+		toggleExpanded: PropTypes.func,
 		updatePersisted: PropTypes.func,
 	};
 
@@ -54,11 +58,12 @@ export class CommentActions extends Component {
 	hasAction = action => includes( commentActions[ this.props.commentStatus ], action );
 
 	setSpam = () => {
-		const { commentId, removeFromPersisted } = this.props;
-
+		const { commentId, isExpanded, toggleExpanded, updatePersisted } = this.props;
+		if ( isExpanded ) {
+			toggleExpanded();
+		}
 		this.setStatus( 'spam' );
-
-		removeFromPersisted( commentId );
+		updatePersisted( commentId );
 	};
 
 	setStatus = status => {
@@ -85,11 +90,12 @@ export class CommentActions extends Component {
 	};
 
 	setTrash = () => {
-		const { commentId, removeFromPersisted } = this.props;
-
+		const { commentId, isExpanded, toggleExpanded, updatePersisted } = this.props;
+		if ( isExpanded ) {
+			toggleExpanded();
+		}
 		this.setStatus( 'trash' );
-
-		removeFromPersisted( commentId );
+		updatePersisted( commentId );
 	};
 
 	toggleApproved = () => {
@@ -129,7 +135,11 @@ export class CommentActions extends Component {
 	};
 
 	render() {
-		const { commentIsApproved, commentIsLiked, translate } = this.props;
+		const { commentId, commentIsApproved, commentIsLiked, isPersistent, translate } = this.props;
+
+		if ( isPersistent ) {
+			return <CommentConfirmation { ...{ commentId } } />;
+		}
 
 		return (
 			<div className="comment__actions">

--- a/client/my-sites/comments/comment/comment-actions.jsx
+++ b/client/my-sites/comments/comment/comment-actions.jsx
@@ -128,6 +128,10 @@ export class CommentActions extends Component {
 		}
 	};
 
+	setSpam = () => this.setStatus( 'spam' );
+
+	setTrash = () => this.setStatus( 'trash' );
+
 	render() {
 		const { commentIsApproved, commentIsLiked, translate } = this.props;
 

--- a/client/my-sites/comments/comment/comment-actions.jsx
+++ b/client/my-sites/comments/comment/comment-actions.jsx
@@ -9,6 +9,7 @@ import { localize } from 'i18n-calypso';
 import Gridicon from 'gridicons';
 import classNames from 'classnames';
 import { get, includes, isEmpty } from 'lodash';
+import ReactCSSTransitionGroup from 'react-transition-group/CSSTransitionGroup';
 
 /**
  * Internal dependencies
@@ -246,10 +247,21 @@ export class CommentActions extends Component {
 					) }
 				</div>
 
-				{ isPersistent &&
-				! includes( [ 'approved', 'unapproved' ], commentStatus ) && (
-					<CommentConfirmation { ...{ commentId } } undo={ this.undo } />
-				) }
+				<ReactCSSTransitionGroup
+					className="comment__confirmation-transition"
+					transitionEnterTimeout={ 150 }
+					transitionLeaveTimeout={ 150 }
+					transitionName="comment__confirmation-transition"
+				>
+					{ isPersistent &&
+					! includes( [ 'approved', 'unapproved' ], commentStatus ) && (
+						<CommentConfirmation
+							{ ...{ commentId } }
+							key="comment__confirmation"
+							undo={ this.undo }
+						/>
+					) }
+				</ReactCSSTransitionGroup>
 			</div>
 		);
 	}

--- a/client/my-sites/comments/comment/comment-actions.jsx
+++ b/client/my-sites/comments/comment/comment-actions.jsx
@@ -128,10 +128,6 @@ export class CommentActions extends Component {
 		}
 	};
 
-	setSpam = () => this.setStatus( 'spam' );
-
-	setTrash = () => this.setStatus( 'trash' );
-
 	render() {
 		const { commentIsApproved, commentIsLiked, translate } = this.props;
 

--- a/client/my-sites/comments/comment/comment-actions.jsx
+++ b/client/my-sites/comments/comment/comment-actions.jsx
@@ -174,9 +174,16 @@ export class CommentActions extends Component {
 	};
 
 	render() {
-		const { commentId, commentIsApproved, commentIsLiked, isPersistent, translate } = this.props;
+		const {
+			commentId,
+			commentIsApproved,
+			commentIsLiked,
+			commentStatus,
+			isPersistent,
+			translate,
+		} = this.props;
 
-		if ( isPersistent ) {
+		if ( isPersistent && ! includes( [ 'approved', 'unapproved' ], commentStatus ) ) {
 			return <CommentConfirmation { ...{ commentId } } undo={ this.undo } />;
 		}
 

--- a/client/my-sites/comments/comment/comment-confirmation.jsx
+++ b/client/my-sites/comments/comment/comment-confirmation.jsx
@@ -7,7 +7,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'gridicons';
-import { get, noop } from 'lodash';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -18,10 +18,11 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 export class CommentConfirmation extends Component {
 	static propTypes = {
 		commentId: PropTypes.number,
+		undo: PropTypes.func,
 	};
 
 	render() {
-		const { commentIsSpam, commentIsTrash, translate } = this.props;
+		const { commentIsSpam, commentIsTrash, undo, translate } = this.props;
 
 		return (
 			<div className="comment__confirmation">
@@ -38,7 +39,7 @@ export class CommentConfirmation extends Component {
 							<Gridicon icon="trash" size={ 18 } />
 						</div>
 					) }
-					<a onClick={ noop }>{ translate( 'Undo?' ) }</a>
+					<a onClick={ undo }>{ translate( 'Undo?' ) }</a>
 				</div>
 			</div>
 		);

--- a/client/my-sites/comments/comment/comment-confirmation.jsx
+++ b/client/my-sites/comments/comment/comment-confirmation.jsx
@@ -26,21 +26,23 @@ export class CommentConfirmation extends Component {
 
 		return (
 			<div className="comment__confirmation">
-				<div className="comment__confirmation-alert">
-					{ commentIsSpam && (
-						<div>
-							{ translate( 'Marked as Spam' ) }
-							<Gridicon icon="spam" size={ 18 } />
-						</div>
-					) }
-					{ commentIsTrash && (
-						<div>
-							{ translate( 'Moved to Trash' ) }
-							<Gridicon icon="trash" size={ 18 } />
-						</div>
-					) }
-					<a onClick={ undo }>{ translate( 'Undo?' ) }</a>
-				</div>
+				{ ( commentIsSpam || commentIsTrash ) && (
+					<div className="comment__confirmation-alert">
+						{ commentIsSpam && (
+							<div>
+								{ translate( 'Marked as Spam' ) }
+								<Gridicon icon="spam" size={ 18 } />
+							</div>
+						) }
+						{ commentIsTrash && (
+							<div>
+								{ translate( 'Moved to Trash' ) }
+								<Gridicon icon="trash" size={ 18 } />
+							</div>
+						) }
+						<a onClick={ undo }>{ translate( 'Undo?' ) }</a>
+					</div>
+				) }
 			</div>
 		);
 	}

--- a/client/my-sites/comments/comment/comment-confirmation.jsx
+++ b/client/my-sites/comments/comment/comment-confirmation.jsx
@@ -1,0 +1,61 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+import Gridicon from 'gridicons';
+import { get, noop } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { getSiteComment } from 'state/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
+
+export class CommentConfirmation extends Component {
+	static propTypes = {
+		commentId: PropTypes.number,
+	};
+
+	render() {
+		const { commentIsSpam, commentIsTrash, translate } = this.props;
+
+		return (
+			<div className="comment__confirmation">
+				<div className="comment__confirmation-alert">
+					{ commentIsSpam && (
+						<div>
+							{ translate( 'Marked as Spam' ) }
+							<Gridicon icon="spam" size={ 18 } />
+						</div>
+					) }
+					{ commentIsTrash && (
+						<div>
+							{ translate( 'Moved to Trash' ) }
+							<Gridicon icon="trash" size={ 18 } />
+						</div>
+					) }
+					<a onClick={ noop }>{ translate( 'Undo?' ) }</a>
+				</div>
+			</div>
+		);
+	}
+}
+
+const mapStateToProps = ( state, { commentId } ) => {
+	const siteId = getSelectedSiteId( state );
+	const comment = getSiteComment( state, siteId, commentId );
+	const commentStatus = get( comment, 'status' );
+
+	return {
+		commentIsSpam: 'spam' === commentStatus,
+		commentIsTrash: 'trash' === commentStatus,
+		postId: get( comment, 'post.ID' ),
+		siteId,
+	};
+};
+
+export default connect( mapStateToProps )( localize( CommentConfirmation ) );

--- a/client/my-sites/comments/comment/index.jsx
+++ b/client/my-sites/comments/comment/index.jsx
@@ -88,6 +88,7 @@ export class Comment extends Component {
 			commentIsPending,
 			isBulkMode,
 			isLoading,
+			isPersistent,
 			isPostView,
 			isSelected,
 			refreshCommentData,
@@ -130,7 +131,8 @@ export class Comment extends Component {
 
 						{ showActions && (
 							<CommentActions
-								{ ...{ commentId, isExpanded, removeFromPersisted, updatePersisted } }
+								{ ...{ commentId, isExpanded, isPersistent, removeFromPersisted, updatePersisted } }
+								toggleExpanded={ this.toggleExpanded }
 							/>
 						) }
 

--- a/client/my-sites/comments/comment/index.jsx
+++ b/client/my-sites/comments/comment/index.jsx
@@ -98,7 +98,7 @@ export class Comment extends Component {
 		} = this.props;
 		const { hasReplyFocus, isEditMode, isExpanded } = this.state;
 
-		const showActions = isExpanded || ( ! isBulkMode && commentIsPending );
+		const showActions = isExpanded || isPersistent || ( ! isBulkMode && commentIsPending );
 
 		const classes = classNames( 'comment', {
 			'is-bulk-mode': isBulkMode,

--- a/client/my-sites/comments/comment/style.scss
+++ b/client/my-sites/comments/comment/style.scss
@@ -485,6 +485,21 @@
 	}
 }
 
+.comment__confirmation-transition-enter {
+	opacity: 0.01;
+}
+.comment__confirmation-transition-enter-active {
+	opacity: 1;
+	transition: opacity 0.15s linear;
+}
+.comment__confirmation-transition-leave {
+	opacity: 1;
+}
+.comment__confirmation-transition-leave-active {
+	opacity: 0.01;
+	transition: opacity 0.15s linear;
+}
+
 // Collapsed View
 
 .card.comment.is-collapsed {

--- a/client/my-sites/comments/comment/style.scss
+++ b/client/my-sites/comments/comment/style.scss
@@ -6,6 +6,7 @@
 	font-size: 14px;
 	margin: 0 auto;
 	padding: 0;
+	position: relative;
 
 	.accessible-focus &:focus {
 		box-shadow: 0 0 0 1px $blue-medium, 0 0 0 3px $blue-light;
@@ -348,6 +349,46 @@
 		span {
 			display: inline;
 		}
+	}
+}
+
+// Comment Confirmation Block
+
+.comment__confirmation {
+	align-items: center;
+	background-color: rgba($white, 0.8);
+	display: flex;
+	justify-content: center;
+	position: absolute;
+	top: 0;
+	right: 0;
+	bottom: 0;
+	left: 0;
+}
+
+.comment__confirmation-alert {
+	background: $white;
+	border: 1px solid $alert-red;
+	border-radius: 3px;
+	color: $alert-red;
+	min-width: 200px;
+	padding: 8px;
+	text-align: center;
+
+	.gridicon {
+		margin-left: 4px;
+		vertical-align: text-bottom;
+	}
+
+	a {
+		color: $gray-text-min;
+		cursor: pointer;
+		display: block;
+		font-size: 12px;
+		padding-top: 8px;
+	}
+	a:hover {
+		color: $blue-wordpress;
 	}
 }
 


### PR DESCRIPTION
Branched off #19332

This is an experimental PR to see if this approach to the Comments set status undo makes sense.

<img width="650" alt="screen shot 2017-10-31 at 18 03 21" src="https://user-images.githubusercontent.com/2070010/32240673-d077835e-be65-11e7-9d74-05c584809087.png">

This what I said earlier:

> Internal discussion: p7jreA-1ca-p2
>
> We've been talking of dropping success notices altogether. The only thing blocking us is that the notices are currently necessary for the undos.
> 
> @vindl suggested an approach similar to the one already featured in the Posts List.
> On spam/trash (which are the "semi-destructive" actions), the comment persist and enter a "disabled" state. It gets covered by an overlay with a message such as "Comment Deleted - Undo?".
> 
> By moving the Undo into the actual comment, we'd drastically reduce all the required back and forth between `Comment` and `CommentList`.
> Basically we'd end up with just the persistence functions, which can't go anywhere else but in the `List`.
> There will be a little bit of duplication between the single and the bulk actions, but it's a fair trade-off imho.
>
> What about approve/unapprove? I'd actually suggest that we don't persist them anymore.
> We have the All list where they're shown together, and I can't see any reason why the Approved and Pending lists should behave _almost but not completely_ the same.

This PR achieves it by not touching `CommentList` once (except for the persistence functions, of course), never firing a notice, and with a massively reduced undo spaghetti-logic.
It also keeps the persistence for the approved/unapproved toggle, just to avoid messing up with the established behaviour.

### Note to @Automattic/lannister 

Please excuse the +505 -0 changes, and do not waste time reviewing the code, but instead check if the behaviour actually works for you.

### Testing instructions

Checkout this branch and run it with
`env ENABLE_FEATURES=comments/management/m3-design npm start`