### PR TITLE
Boot: Remove XSS console warning message from the development environment.

### DIFF
--- a/server/pages/index.jade
+++ b/server/pages/index.jade
@@ -240,7 +240,7 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class=isFluidWidth ? 'is-fluid-width'
 
 		script.
 			(function() {
-				if ( window.console ) {
+				if ( window.console && 'development' !== window.configData.env ) {
 					console.log( "%cSTOP!", "color:#f00;font-size:xx-large" );
 					console.log(
 						"%cWait! This browser feature runs code that can alter your website or its security, " +

--- a/server/pages/index.jade
+++ b/server/pages/index.jade
@@ -240,7 +240,7 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class=isFluidWidth ? 'is-fluid-width'
 
 		script.
 			(function() {
-				if ( window.console && 'development' !== window.configData.env ) {
+				if ( window.console && window.configData && 'development' !== window.configData.env ) {
 					console.log( "%cSTOP!", "color:#f00;font-size:xx-large" );
 					console.log(
 						"%cWait! This browser feature runs code that can alter your website or its security, " +


### PR DESCRIPTION
Agreeing with @stephanethomas [here](https://github.com/Automattic/wp-calypso/pull/18088#issuecomment-340753609), this PR removes the following XSS warning message from #18088 from the console while in the development environment. It's very distracting and adds more clutter; people using devtools in the  development environment should be well aware of the warning.

![screen shot 2017-10-31 at 9 47 33 am](https://user-images.githubusercontent.com/349751/32241865-822b37e0-be2e-11e7-87c2-a380b9184d70.png)

**Testing**
* Load this branch normally, and be sure the notice doesn't appear.
* Restart Calypso with another environment (eg. `NODE_ENV=production npm start`), and be sure you do see the message.
