### PR TITLE
Fix Google button disabled after first display

### DIFF
--- a/client/components/social-buttons/google.js
+++ b/client/components/social-buttons/google.js
@@ -87,25 +87,28 @@ class GoogleLoginButton extends Component {
 			.then( gapi =>
 				gapi.client
 					.init( {
-						client_id: this.props.clientId,
-						scope: this.props.scope,
 						fetch_basic_profile: this.props.fetchBasicProfile,
 						ux_mode: this.props.uxMode,
 						redirect_uri: this.props.redirectUri,
 					} )
-					.then( () => {
-						this.setState( { isDisabled: false } );
+					.then( () =>
+						gapi.auth2.init( {
+							client_id: this.props.clientId,
+							scope: this.props.scope,
+						} ).then( () => {
+							this.setState( { isDisabled: false } );
 
-						const googleAuth = gapi.auth2.getAuthInstance();
-						const currentUser = googleAuth.currentUser.get();
+							const googleAuth = gapi.auth2.getAuthInstance();
+							const currentUser = googleAuth.currentUser.get();
 
-						// handle social authentication response from a redirect-based oauth2 flow
-						if ( currentUser && this.props.uxMode === 'redirect' ) {
-							this.props.responseHandler( currentUser, false );
-						}
+							// handle social authentication response from a redirect-based oauth2 flow
+							if ( currentUser && this.props.uxMode === 'redirect' ) {
+								this.props.responseHandler( currentUser, false );
+							}
 
-						return gapi; // don't try to return googleAuth here, it's a thenable but not a valid promise
-					} )
+							return gapi; // don't try to return googleAuth here, it's a thenable but not a valid promise
+						} )
+					)
 			)
 			.catch( error => {
 				this.initialized = null;


### PR DESCRIPTION
This pull request fixes https://github.com/Automattic/wp-calypso/issues/19289 to make sure the `Continue with Google`  button on the `Login` page and on the `User` step of the signup flow is always enabled. Previously it would be enabled only the first time it would be displayed.

##### Login

<img width="736" alt="screenshot" src="https://user-images.githubusercontent.com/594356/32241845-7f174b5a-be71-11e7-95d1-0bbd27c48f87.png">

##### Signup

<img width="736" alt="screenshot" src="https://user-images.githubusercontent.com/594356/32242169-641030b4-be72-11e7-96bc-c316ec4574a6.png">

#### Testing instructions

1. Run `git checkout fix/google-button` and start your server, or open a [live branch](https://calypso.live/?branch=fix/google-button)
2. Open the [`Signup` page](http://calypso.localhost:3000/start/account) in an incognito tab
3. Assert that the `Continue With Google` button is enabled
4. Click the `Already have a WordPress.com account? Log in now.` link in the footer
5. Assert that the `Continue With Google` button on the [`Login` page](http://calypso.localhost:3000/log-in?redirect_to=http%3A%2F%2Fcalypso.localhost%3A3000%2Fstart%2Faccount) is enabled
6. Assert that you can still log in with Google, and create a site

You should try again but starting the flow from the `Login` page this time.

#### Reviews

- [ ] Code
- [ ] Product