### PR TITLE
i18n-calypso: upgrade i18n-calypso for React 16 compat

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -13,7 +13,7 @@
       "dev": true,
       "dependencies": {
         "ast-types": {
-          "version": "0.9.12",
+          "version": "0.9.14",
           "dev": true
         },
         "esprima": {
@@ -25,7 +25,7 @@
           "dev": true
         },
         "recast": {
-          "version": "0.12.7",
+          "version": "0.12.8",
           "dev": true
         },
         "source-map": {
@@ -74,10 +74,10 @@
       "version": "0.8.1"
     },
     "ajv": {
-      "version": "5.2.4"
+      "version": "5.3.0"
     },
     "ajv-keywords": {
-      "version": "2.1.0"
+      "version": "2.1.1"
     },
     "align-text": {
       "version": "0.1.4"
@@ -185,7 +185,7 @@
       "version": "0.2.3"
     },
     "asn1.js": {
-      "version": "4.9.1"
+      "version": "4.9.2"
     },
     "assert": {
       "version": "1.4.1"
@@ -608,7 +608,7 @@
       "version": "1.6.0",
       "dependencies": {
         "browserslist": {
-          "version": "2.5.1"
+          "version": "2.6.1"
         },
         "semver": {
           "version": "5.4.1"
@@ -874,10 +874,10 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000749"
+      "version": "1.0.30000756"
     },
     "caniuse-lite": {
-      "version": "1.0.30000749"
+      "version": "1.0.30000756"
     },
     "cardinal": {
       "version": "1.0.0",
@@ -1949,7 +1949,7 @@
       "dev": true,
       "dependencies": {
         "acorn": {
-          "version": "5.1.2",
+          "version": "5.2.1",
           "dev": true
         }
       }
@@ -2093,6 +2093,9 @@
     },
     "fast-future": {
       "version": "1.0.2"
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0"
     },
     "fast-levenshtein": {
       "version": "1.1.4",
@@ -3099,7 +3102,7 @@
       }
     },
     "i18n-calypso": {
-      "version": "1.8.1",
+      "version": "1.8.2",
       "dependencies": {
         "async": {
           "version": "1.5.2"
@@ -3212,7 +3215,7 @@
       "version": "1.0.1"
     },
     "is-buffer": {
-      "version": "1.1.5"
+      "version": "1.1.6"
     },
     "is-builtin-module": {
       "version": "1.0.0"
@@ -3549,7 +3552,7 @@
           "dev": true
         },
         "chalk": {
-          "version": "2.2.0",
+          "version": "2.3.0",
           "dev": true
         },
         "cliui": {
@@ -3667,7 +3670,7 @@
           "dev": true
         },
         "chalk": {
-          "version": "2.2.0",
+          "version": "2.3.0",
           "dev": true
         },
         "escape-string-regexp": {
@@ -3697,7 +3700,7 @@
           "dev": true
         },
         "chalk": {
-          "version": "2.2.0",
+          "version": "2.3.0",
           "dev": true
         },
         "escape-string-regexp": {
@@ -3753,7 +3756,7 @@
           "dev": true
         },
         "chalk": {
-          "version": "2.2.0",
+          "version": "2.3.0",
           "dev": true
         },
         "escape-string-regexp": {
@@ -3783,7 +3786,7 @@
           "dev": true
         },
         "chalk": {
-          "version": "2.2.0",
+          "version": "2.3.0",
           "dev": true
         },
         "escape-string-regexp": {
@@ -3843,7 +3846,7 @@
           "dev": true
         },
         "chalk": {
-          "version": "2.2.0",
+          "version": "2.3.0",
           "dev": true
         },
         "escape-string-regexp": {
@@ -3877,7 +3880,7 @@
           "dev": true
         },
         "chalk": {
-          "version": "2.2.0",
+          "version": "2.3.0",
           "dev": true
         },
         "escape-string-regexp": {
@@ -3925,7 +3928,7 @@
           "dev": true
         },
         "chalk": {
-          "version": "2.2.0",
+          "version": "2.3.0",
           "dev": true
         },
         "cliui": {
@@ -4019,7 +4022,7 @@
           "dev": true
         },
         "chalk": {
-          "version": "2.2.0",
+          "version": "2.3.0",
           "dev": true
         },
         "escape-string-regexp": {
@@ -4049,7 +4052,7 @@
           "dev": true
         },
         "chalk": {
-          "version": "2.2.0",
+          "version": "2.3.0",
           "dev": true
         },
         "escape-string-regexp": {
@@ -4075,7 +4078,7 @@
           "dev": true
         },
         "chalk": {
-          "version": "2.2.0",
+          "version": "2.3.0",
           "dev": true
         },
         "escape-string-regexp": {
@@ -5349,7 +5352,7 @@
           "version": "3.2.0"
         },
         "chalk": {
-          "version": "2.2.0"
+          "version": "2.3.0"
         },
         "escape-string-regexp": {
           "version": "1.0.5"
@@ -5393,7 +5396,7 @@
           "dev": true
         },
         "chalk": {
-          "version": "2.2.0",
+          "version": "2.3.0",
           "dev": true
         },
         "escape-string-regexp": {
@@ -5541,7 +5544,7 @@
               "dev": true
             },
             "chalk": {
-              "version": "2.2.0",
+              "version": "2.3.0",
               "dev": true
             },
             "escape-string-regexp": {
@@ -6259,7 +6262,7 @@
       "dev": true
     },
     "resolve": {
-      "version": "1.4.0"
+      "version": "1.5.0"
     },
     "resolve-from": {
       "version": "1.0.1",
@@ -6517,7 +6520,7 @@
       "version": "1.1.2"
     },
     "sntp": {
-      "version": "2.0.2"
+      "version": "2.1.0"
     },
     "social-logos": {
       "version": "1.0.1"
@@ -6674,7 +6677,7 @@
       "version": "0.10.31"
     },
     "string-kit": {
-      "version": "0.6.2",
+      "version": "0.6.3",
       "dev": true
     },
     "string-length": {
@@ -7169,7 +7172,7 @@
       "version": "1.0.0"
     },
     "unquoted-property-validator": {
-      "version": "1.0.0",
+      "version": "1.0.2",
       "dev": true
     },
     "unreachable-branch-transform": {
@@ -7328,7 +7331,7 @@
       "version": "3.8.1",
       "dependencies": {
         "acorn": {
-          "version": "5.1.2"
+          "version": "5.2.1"
         },
         "ansi-regex": {
           "version": "3.0.0"
@@ -7414,7 +7417,7 @@
           "dev": true
         },
         "acorn": {
-          "version": "5.1.2",
+          "version": "5.2.1",
           "dev": true
         },
         "body-parser": {
@@ -7690,11 +7693,11 @@
       "version": "0.1.9"
     },
     "whatwg-encoding": {
-      "version": "1.0.2",
+      "version": "1.0.3",
       "dev": true,
       "dependencies": {
         "iconv-lite": {
-          "version": "0.4.13",
+          "version": "0.4.19",
           "dev": true
         }
       }
@@ -7731,7 +7734,7 @@
       "version": "0.0.2"
     },
     "worker-farm": {
-      "version": "1.5.0",
+      "version": "1.5.1",
       "dev": true
     },
     "wp-error": {

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "hash.js": "1.1.3",
     "he": "0.5.0",
     "html-loader": "0.4.0",
-    "i18n-calypso": "1.8.1",
+    "i18n-calypso": "1.8.2",
     "immutability-helper": "2.4.0",
     "immutable": "3.7.6",
     "imports-loader": "0.6.5",


### PR DESCRIPTION
This pull request upgrades `i18n-calypso` to a version that takes advantage of es6 classes instead of the deprecated `React.createClass` function

see: https://github.com/Automattic/i18n-calypso/pull/43
and: https://github.com/Automattic/wp-calypso/pull/19083

To test
-----
run `npm install`, boot up calypso, and then change your language in settings. ensure it behaves as expected