### PR TITLE
Promotions list: Update empty content page.

### DIFF
--- a/client/extensions/woocommerce/app/promotions/fields/currency-field.js
+++ b/client/extensions/woocommerce/app/promotions/fields/currency-field.js
@@ -7,7 +7,6 @@ import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
-import { getCurrencyFormatDecimal } from 'woocommerce/lib/currency';
 import PriceInput from 'woocommerce/components/price-input';
 import FormField from './form-field';
 
@@ -17,21 +16,14 @@ const CurrencyField = ( props ) => {
 
 	const onChange = ( e ) => {
 		const newValue = e.target.value;
-		if ( 0 === newValue.length ) {
-			edit( fieldName, '' );
-			return;
-		}
-
-		const numberValue = Number( newValue );
-		if ( 0 <= Number( newValue ) ) {
-			const formattedValue = getCurrencyFormatDecimal( numberValue, currency );
-			edit( fieldName, String( formattedValue ) );
-		}
+		edit( fieldName, String( newValue ) );
 	};
 
 	return (
 		<FormField { ...props } >
 			<PriceInput
+				noWrap
+				size="4"
 				htmlFor={ fieldName + '-label' }
 				aria-describedby={ explanationText && fieldName + '-description' }
 				currency={ currency }

--- a/client/extensions/woocommerce/app/promotions/index.js
+++ b/client/extensions/woocommerce/app/promotions/index.js
@@ -15,6 +15,7 @@ import { noop } from 'lodash';
 /**
  * Internal dependencies
  */
+import EmptyContent from 'components/empty-content';
 import { fetchPromotions } from 'woocommerce/state/sites/promotions/actions';
 import { getPromotions } from 'woocommerce/state/selectors/promotions';
 import ActionHeader from 'woocommerce/components/action-header';
@@ -67,9 +68,38 @@ class Promotions extends Component {
 		);
 	}
 
+	renderEmptyContent() {
+		const { site, translate } = this.props;
+
+		const emptyContentAction = (
+			<Button href={ getLink( '/store/promotion/:site/', site ) }>
+				{ translate( 'Add a promotion!' ) }
+			</Button>
+		);
+
+		return (
+			<EmptyContent
+				title={ translate( "You don't have any promotions." ) }
+				action={ emptyContentAction }
+			/>
+		);
+	}
+
+	renderContent() {
+		return (
+			<div>
+				{ this.renderSearchCard() }
+				<PromotionsList />
+			</div>
+		);
+	}
+
 	render() {
-		const { site, className, translate } = this.props;
+		const { site, className, promotions, translate } = this.props;
 		const classes = classNames( 'promotions__list', className );
+		const isEmpty = site && promotions && 0 === promotions.length;
+
+		const content = isEmpty ? this.renderEmptyContent() : this.renderContent();
 
 		return (
 			<Main className={ classes }>
@@ -79,8 +109,7 @@ class Promotions extends Component {
 						{ translate( 'Add promotion' ) }
 					</Button>
 				</ActionHeader>
-				{ this.renderSearchCard() }
-				<PromotionsList />
+				{ content }
 			</Main>
 		);
 	}

--- a/client/extensions/woocommerce/app/promotions/promotion-create.js
+++ b/client/extensions/woocommerce/app/promotions/promotion-create.js
@@ -37,6 +37,7 @@ class PromotionCreate extends React.Component {
 	static propTypes = {
 		className: PropTypes.string,
 		currency: PropTypes.string,
+		hasEdits: PropTypes.bool.isRequired,
 		site: PropTypes.shape( {
 			ID: PropTypes.number,
 			slug: PropTypes.string,

--- a/client/extensions/woocommerce/app/promotions/promotion-create.js
+++ b/client/extensions/woocommerce/app/promotions/promotion-create.js
@@ -22,9 +22,11 @@ import { fetchProductCategories } from 'woocommerce/state/sites/product-categori
 import { fetchPromotions, createPromotion } from 'woocommerce/state/sites/promotions/actions';
 import { fetchSettingsGeneral } from 'woocommerce/state/sites/settings/general/actions';
 import { getPaymentCurrencySettings } from 'woocommerce/state/sites/settings/general/selectors';
+import { getProductCategories } from 'woocommerce/state/sites/product-categories/selectors';
 import {
 	getCurrentlyEditingPromotionId,
 	getPromotionEdits,
+	getPromotionableProducts,
 	getPromotionWithLocalEdits,
 } from 'woocommerce/state/selectors/promotions';
 import { isValidPromotion } from './helpers';
@@ -128,7 +130,15 @@ class PromotionCreate extends React.Component {
 	};
 
 	render() {
-		const { site, currency, className, promotion, hasEdits } = this.props;
+		const {
+			site,
+			currency,
+			className,
+			promotion,
+			hasEdits,
+			products,
+			productCategories
+		} = this.props;
 		const { busy } = this.state;
 
 		const isValid = 'undefined' !== typeof site && isValidPromotion( promotion );
@@ -148,6 +158,8 @@ class PromotionCreate extends React.Component {
 					currency={ currency }
 					promotion={ promotion }
 					editPromotion={ this.props.editPromotion }
+					products={ products }
+					productCategories={ productCategories }
 				/>
 			</Main>
 		);
@@ -161,12 +173,16 @@ function mapStateToProps( state ) {
 	const promotionId = getCurrentlyEditingPromotionId( state, site.ID );
 	const promotion = promotionId ? getPromotionWithLocalEdits( state, promotionId, site.ID ) : null;
 	const hasEdits = Boolean( getPromotionEdits( state, promotionId, site.ID ) );
+	const products = getPromotionableProducts( state, site.ID );
+	const productCategories = getProductCategories( state, site.ID );
 
 	return {
 		hasEdits,
 		site,
 		promotion,
 		currency,
+		products,
+		productCategories,
 	};
 }
 

--- a/client/extensions/woocommerce/app/promotions/promotion-update.js
+++ b/client/extensions/woocommerce/app/promotions/promotion-update.js
@@ -99,7 +99,7 @@ class PromotionUpdate extends React.Component {
 	onTrash = () => {
 		const { translate, site, promotion, deletePromotion: dispatchDelete } = this.props;
 		const areYouSure = translate( 'Are you sure you want to delete this promotion?' );
-		accept( areYouSure, function( accepted ) {
+		accept( areYouSure, accepted => {
 			if ( ! accepted ) {
 				return;
 			}

--- a/client/extensions/woocommerce/app/promotions/promotion-update.js
+++ b/client/extensions/woocommerce/app/promotions/promotion-update.js
@@ -135,7 +135,6 @@ class PromotionUpdate extends React.Component {
 					args: { promotion: promotion.name },
 				} ),
 				{
-					displayOnNextPage: true,
 					duration: 8000,
 				}
 			);
@@ -143,9 +142,8 @@ class PromotionUpdate extends React.Component {
 
 		const successAction = dispatch => {
 			this.props.clearPromotionEdits( site.ID );
-
 			dispatch( getSuccessNotice( promotion ) );
-			page.redirect( getLink( '/store/promotions/:site', site ) );
+			this.setState( () => ( { busy: false } ) );
 		};
 
 		const failureAction = dispatch => {

--- a/client/extensions/woocommerce/app/promotions/promotion-update.js
+++ b/client/extensions/woocommerce/app/promotions/promotion-update.js
@@ -31,12 +31,14 @@ import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
 import { fetchSettingsGeneral } from 'woocommerce/state/sites/settings/general/actions';
 import { getPaymentCurrencySettings } from 'woocommerce/state/sites/settings/general/selectors';
 import {
+	getPromotionEdits,
 	getPromotionWithLocalEdits,
 	getPromotionableProducts,
 } from 'woocommerce/state/selectors/promotions';
 import { isValidPromotion } from './helpers';
 import PromotionHeader from './promotion-header';
 import PromotionForm from './promotion-form';
+import { ProtectFormGuard } from 'lib/protect-form';
 
 class PromotionUpdate extends React.Component {
 	static propTypes = {
@@ -98,12 +100,15 @@ class PromotionUpdate extends React.Component {
 
 	onTrash = () => {
 		const { translate, site, promotion, deletePromotion: dispatchDelete } = this.props;
-		const areYouSure = translate( 'Are you sure you want to delete this promotion?' );
+		const areYouSure = translate( 'Are you sure you want to permanently delete this promotion?' );
 		accept( areYouSure, accepted => {
 			if ( ! accepted ) {
 				return;
 			}
+
 			const successAction = dispatch => {
+				this.props.clearPromotionEdits( site.ID );
+
 				dispatch( successNotice( translate( 'Promotion successfully deleted.' ) ) );
 				debounce( () => {
 					page.redirect( getLink( '/store/promotions/:site/', site ) );
@@ -136,6 +141,8 @@ class PromotionUpdate extends React.Component {
 		};
 
 		const successAction = dispatch => {
+			this.props.clearPromotionEdits( site.ID );
+
 			dispatch( getSuccessNotice( promotion ) );
 			page.redirect( getLink( '/store/promotions/:site', site ) );
 		};
@@ -155,11 +162,19 @@ class PromotionUpdate extends React.Component {
 	};
 
 	render() {
-		const { site, currency, className, promotion, products, productCategories } = this.props;
+		const {
+			site,
+			currency,
+			className,
+			promotion,
+			products,
+			productCategories,
+			hasEdits,
+		} = this.props;
 		const { busy } = this.state;
 
 		const isValid = 'undefined' !== typeof site && isValidPromotion( promotion );
-		const saveEnabled = isValid && ! busy;
+		const saveEnabled = isValid && ! busy && hasEdits;
 
 		return (
 			<Main className={ className }>
@@ -170,6 +185,7 @@ class PromotionUpdate extends React.Component {
 					onSave={ saveEnabled ? this.onSave : false }
 					isBusy={ busy }
 				/>
+				<ProtectFormGuard isChanged={ hasEdits } />
 				<PromotionForm
 					siteId={ site && site.ID }
 					currency={ currency }
@@ -191,8 +207,10 @@ function mapStateToProps( state, ownProps ) {
 	const promotion = promotionId ? getPromotionWithLocalEdits( state, promotionId, site.ID ) : null;
 	const products = getPromotionableProducts( state, site.ID );
 	const productCategories = getProductCategories( state, site.ID );
+	const hasEdits = Boolean( getPromotionEdits( state, promotionId, site.ID ) );
 
 	return {
+		hasEdits,
 		site,
 		promotion,
 		currency,

--- a/client/extensions/woocommerce/app/promotions/promotion-update.js
+++ b/client/extensions/woocommerce/app/promotions/promotion-update.js
@@ -44,6 +44,7 @@ class PromotionUpdate extends React.Component {
 	static propTypes = {
 		className: PropTypes.string,
 		currency: PropTypes.string,
+		hasEdits: PropTypes.bool.isRequired,
 		products: PropTypes.array,
 		productCategories: PropTypes.array,
 		site: PropTypes.shape( {

--- a/client/extensions/woocommerce/app/promotions/promotions-list.js
+++ b/client/extensions/woocommerce/app/promotions/promotions-list.js
@@ -8,14 +8,10 @@ import React from 'react';
 import { bindActionCreators } from 'redux';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
-import Button from 'components/button';
-import EmptyContent from 'components/empty-content';
-import { getLink } from 'woocommerce/lib/nav-utils';
 import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
 import {
 	getPromotions,
@@ -28,31 +24,13 @@ import PromotionsListPagination from './promotions-list-pagination';
 import { setPromotionsPage } from 'woocommerce/state/ui/promotions/actions';
 
 const PromotionsList = props => {
-	const { site, translate, promotions, promotionsPage, currentPage, perPage } = props;
-
-	const renderEmptyContent = () => {
-		const emptyContentAction = (
-			<Button href={ getLink( '/store/promotions/:site/', site ) }>
-				{ translate( 'Start a promotion!' ) }
-			</Button>
-		);
-		return (
-			<EmptyContent
-				title={ translate( "You don't have any promotions." ) }
-				action={ emptyContentAction }
-			/>
-		);
-	};
+	const { site, promotions, promotionsPage, currentPage, perPage } = props;
 
 	const switchPage = index => {
 		if ( site ) {
 			props.setPromotionsPage( site.ID, index, perPage );
 		}
 	};
-
-	if ( promotions && promotions.length === 0 ) {
-		return renderEmptyContent();
-	}
 
 	return (
 		<div className="promotions__list-wrapper">
@@ -102,4 +80,4 @@ function mapDispatchToProps( dispatch ) {
 	);
 }
 
-export default connect( mapStateToProps, mapDispatchToProps )( localize( PromotionsList ) );
+export default connect( mapStateToProps, mapDispatchToProps )( PromotionsList );


### PR DESCRIPTION
This updates the empty content page to bring it up a level so the search
component doesn't show, and fixes the link for the button.

To Test:
1. `npm start`
2. Delete all promotions or use a fresh site.
3. Visit `http://calypso.localhost:3000/store/promotions/<site url>`
4. View the empty content page, and click the "Add a promotion!" button.
