### PR TITLE
Atomic Store: replace store with store-nux

### DIFF
--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -302,22 +302,6 @@ function removeUserStepFromFlow( flow ) {
 	} );
 }
 
-function filterDesignTypeInFlow( flow ) {
-	if ( ! flow ) {
-		return;
-	}
-
-	if ( ! includes( flow.steps, 'design-type' ) ) {
-		return flow;
-	}
-
-	return assign( {}, flow, {
-		steps: flow.steps.map(
-			stepName => ( stepName === 'design-type' ? 'design-type-with-store' : stepName )
-		),
-	} );
-}
-
 /**
  * Properly filter the current flow.
  *
@@ -374,13 +358,23 @@ const Flows = {
 			return flow;
 		}
 
-		if ( user.get() ) {
-			flow = removeUserStepFromFlow( flow );
+		// Replace design-type step with Store NUX flow steps if exists.
+		// Otherwise use Pressable store step for new English users as before
+		if ( includes( flow.steps, 'design-type' ) ) {
+			const storeNuxFlow = Flows.getFlows()[ 'store-nux' ];
+			const isNewEnglishUser = ! user.get() && 'en' === i18n.getLocaleSlug();
+			if ( storeNuxFlow || isNewEnglishUser ) {
+				const steps = storeNuxFlow
+					? storeNuxFlow.steps.slice()
+					: flow.steps.map(
+							stepName => ( stepName === 'design-type' ? 'design-type-with-store' : stepName )
+						);
+				flow = assign( {}, flow, { steps } );
+			}
 		}
 
-		// Show design type with store option only to new users with EN locale.
-		if ( ! user.get() && 'en' === i18n.getLocaleSlug() ) {
-			flow = filterDesignTypeInFlow( flow );
+		if ( user.get() ) {
+			flow = removeUserStepFromFlow( flow );
 		}
 
 		Flows.preloadABTestVariationsForStep( flowName, currentStepName );

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -69,6 +69,7 @@ const flows = {
 		lastModified: '2016-06-02',
 		meta: {
 			skipBundlingPlan: true,
+			enableStore: true,
 		},
 	},
 
@@ -361,7 +362,8 @@ const Flows = {
 		// Replace design-type step with Store NUX flow steps if exists.
 		// Otherwise use Pressable store step for new English users as before
 		if ( includes( flow.steps, 'design-type' ) ) {
-			const storeNuxFlow = Flows.getFlows()[ 'store-nux' ];
+			const enableStore = includes( flow.steps, 'plans' ) || ( flow.meta && flow.meta.enableStore );
+			const storeNuxFlow = enableStore ? Flows.getFlows()[ 'store-nux' ] : undefined;
 			const isNewEnglishUser = ! user.get() && 'en' === i18n.getLocaleSlug();
 			if ( storeNuxFlow || isNewEnglishUser ) {
 				const steps = storeNuxFlow


### PR DESCRIPTION
This PR replaces Store with Store NUX if enabled.

Note Store NUX requirement check differs from Store in following ways:

- Store verifies New User with EN locale before `design-type-with-store` step.
- Store NUX verifies US and Canada geo-location during `design-type-with-store-nux` step.

## Test Plan

This PR affects signup flows which has many entry points. Store option is now enabled if one of following conditions is true:

* flow steps include `plans` step
* `enableStore` flow spec meta flag is true.

Intention is to enable flow if user can select a plan or plan already determined by entry point supports store option.

1. Verify `design-type-with-store-nux` in URL path after navigating from following starting points:

    * `/start`
    * `/start/business`
    * `/jetpack/new?ref=calypso-selector`

2. Verify store option is **not** shown after navigating from following starting points:

    * `/start/premium?ref=homepage`

3. Disable Store NUX and verify signup flow is same as before.
