### PR TITLE
Signup: Remove the `signupSurveyStep` AB test.

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -9,14 +9,6 @@ export default {
 		},
 		defaultVariation: 'singlePurchaseFlow',
 	},
-	signupSurveyStep: {
-		datestamp: '20170329',
-		variations: {
-			showSurveyStep: 20,
-			hideSurveyStep: 80,
-		},
-		defaultVariation: 'hideSurveyStep',
-	},
 	signupPressableStoreFlow: {
 		datestamp: '20171018',
 		variations: {

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -425,7 +425,7 @@ const Flows = {
 		 */
 		if ( 'main' === flowName ) {
 			if ( '' === stepName ) {
-				abtest( 'signupSurveyStep' );
+				return;
 			}
 		}
 	},

--- a/client/signup/steps/design-type-with-atomic-store/index.jsx
+++ b/client/signup/steps/design-type-with-atomic-store/index.jsx
@@ -177,10 +177,6 @@ class DesignTypeWithAtomicStoreStep extends Component {
 			return translate( 'Create your WordPress Store' );
 		}
 
-		if ( abtest( 'signupSurveyStep' ) === 'showSurveyStep' ) {
-			return "We're excited to hear more about your project.";
-		}
-
 		return translate( 'Hello! Let’s create your new site.' );
 	}
 

--- a/client/signup/steps/design-type-with-store/index.jsx
+++ b/client/signup/steps/design-type-with-store/index.jsx
@@ -19,7 +19,6 @@ import { localize } from 'i18n-calypso';
 import { recordTracksEvent } from 'state/analytics/actions';
 import PressableStoreStep from './pressable-store';
 import { BlogImage, PageImage, GridImage, StoreImage } from '../design-type-with-store/type-images';
-import { abtest } from 'lib/abtest';
 import { setDesignType } from 'state/signup/steps/design-type/actions';
 
 import { getThemeForDesignType } from 'signup/utils';
@@ -177,10 +176,6 @@ class DesignTypeWithStoreStep extends Component {
 
 		if ( this.state.showStore ) {
 			return translate( 'Create your WordPress Store' );
-		}
-
-		if ( abtest( 'signupSurveyStep' ) === 'showSurveyStep' ) {
-			return "We're excited to hear more about your project.";
 		}
 
 		return translate( 'Hello! Let’s create your new site.' );


### PR DESCRIPTION
I went to signup today and saw this old (not very visually pleasing) AB test:

![screen shot 2017-10-31 at 12 56 31 pm](https://user-images.githubusercontent.com/349751/32247031-3a7b8cf0-be3e-11e7-9d3e-95f7fba2363f.png)

We've been serving it to 20% of signup since March (added in #12539), but I'm having a hard time finding the reasoning behind it, or if it should still be running months later. If there's no active purpose for it, let's get rid of it so that everyone sees the same first signup step.