### PR TITLE
i18n-calypso: upgrade i18n-calypso for React 16 compat (#19358) take2

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -13,7 +13,7 @@
       "dev": true,
       "dependencies": {
         "ast-types": {
-          "version": "0.9.12",
+          "version": "0.9.14",
           "dev": true
         },
         "esprima": {
@@ -25,7 +25,7 @@
           "dev": true
         },
         "recast": {
-          "version": "0.12.7",
+          "version": "0.12.8",
           "dev": true
         },
         "source-map": {
@@ -185,7 +185,7 @@
       "version": "0.2.3"
     },
     "asn1.js": {
-      "version": "4.9.1"
+      "version": "4.9.2"
     },
     "assert": {
       "version": "1.4.1"
@@ -3099,7 +3099,7 @@
       }
     },
     "i18n-calypso": {
-      "version": "1.8.1",
+      "version": "1.8.2",
       "dependencies": {
         "async": {
           "version": "1.5.2"

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "hash.js": "1.1.3",
     "he": "0.5.0",
     "html-loader": "0.4.0",
-    "i18n-calypso": "1.8.1",
+    "i18n-calypso": "1.8.2",
     "immutability-helper": "2.4.0",
     "immutable": "3.7.6",
     "imports-loader": "0.6.5",


### PR DESCRIPTION
To Test
----
for both docker and local mess with changing the lang.
this broke staging on first attempt and was reverted here: https://github.com/Automattic/wp-calypso/pull/19362

- [ ] docker
- [ ] local