### PR TITLE
Store: Add getProductsSettingValue selector.

### DIFF
--- a/client/extensions/woocommerce/state/sites/settings/products/selectors.js
+++ b/client/extensions/woocommerce/state/sites/settings/products/selectors.js
@@ -59,3 +59,17 @@ export function getDimensionsUnitSetting( state, siteId = getSelectedSiteId( sta
 	const unit = find( productsSettings, item => item.id === 'woocommerce_dimension_unit' );
 	return unit || {};
 }
+
+/**
+ * Gets an arbitrary product setting value from API data.
+ *
+ * @param {Object} state Global state tree
+ * @param {String} id setting name / id of the products setting you would like the value of
+ * @param {Number} siteId wpcom site id. If not provided, the Site ID selected in the UI will be used
+ * @return {mixed} value for the products setting returned from the API
+ */
+export function getProductsSettingValue( state, id, siteId = getSelectedSiteId( state ) ) {
+	const productsSettings = getRawProductsSettings( state, siteId );
+	const setting = find( productsSettings, item => item.id === id );
+	return setting ? setting.value : null;
+}

--- a/client/extensions/woocommerce/state/sites/settings/products/test/selectors.js
+++ b/client/extensions/woocommerce/state/sites/settings/products/test/selectors.js
@@ -13,6 +13,7 @@ import {
 	areSettingsProductsLoading,
 	getWeightUnitSetting,
 	getDimensionsUnitSetting,
+	getProductsSettingValue,
 } from '../selectors';
 import { LOADING } from 'woocommerce/state/constants';
 
@@ -56,13 +57,53 @@ const dimensionsUnitSetting = {
 	default: 'cm',
 	value: 'in',
 };
+
+const notifyLowStockSetting = {
+	id: 'woocommerce_notify_low_stock',
+	description: 'Enable low stock notifications',
+	label: 'Notifications',
+	type: 'checkbox',
+	value: 'yes',
+};
+
+const lowStockAmountSetting = {
+	id: 'woocommerce_notify_low_stock_amount',
+	description: 'When product stock reaches this amount you will be notified via email.',
+	label: 'Low stock threshold',
+	type: 'number',
+	value: '2',
+};
+
+const notifyNoStockSetting = {
+	id: 'woocommerce_notify_no_stock',
+	description: 'Enable out of stock notifications',
+	label: '',
+	type: 'checkbox',
+	value: 'no',
+};
+
+const manageStockSetting = {
+	id: 'woocommerce_manage_stock',
+	description: 'Enable stock management',
+	label: 'Manage stock',
+	type: 'checkbox',
+	value: 'yes',
+};
+
 const loadedState = {
 	extensions: {
 		woocommerce: {
 			sites: {
 				123: {
 					settings: {
-						products: [ weightUnitSetting, dimensionsUnitSetting ],
+						products: [
+							dimensionsUnitSetting,
+							lowStockAmountSetting,
+							manageStockSetting,
+							notifyLowStockSetting,
+							notifyNoStockSetting,
+							weightUnitSetting,
+						],
 					},
 				},
 			},
@@ -135,6 +176,42 @@ describe( 'selectors', () => {
 
 		test( 'should get the siteId from the UI tree if not provided.', () => {
 			expect( getDimensionsUnitSetting( loadedStateWithUi ) ).to.eql( dimensionsUnitSetting );
+		} );
+	} );
+
+	describe( '#getProductsSettingValue', () => {
+		test( 'should be null when woocommerce state is not available', () => {
+			expect(
+				getProductsSettingValue( preInitializedState, 'woocommerce_notify_low_stock_amount', 123 )
+			).to.be.null;
+		} );
+
+		test( 'should be null when woocommerce state is available but setting key is invalid', () => {
+			expect( getProductsSettingValue( loadedState, 'not-a-valid-key', 123 ) ).to.be.null;
+		} );
+
+		test( 'should return correct woocommerce_notify_low_stock_amount', () => {
+			expect(
+				getProductsSettingValue( loadedState, 'woocommerce_notify_low_stock_amount', 123 )
+			).to.equal( '2' );
+		} );
+
+		test( 'should return correct woocommerce_notify_low_stock', () => {
+			expect(
+				getProductsSettingValue( loadedStateWithUi, 'woocommerce_notify_low_stock' )
+			).to.equal( 'yes' );
+		} );
+
+		test( 'should return correct woocommerce_notify_no_stock', () => {
+			expect( getProductsSettingValue( loadedState, 'woocommerce_notify_no_stock', 123 ) ).to.equal(
+				'no'
+			);
+		} );
+
+		test( 'should return correct woocommerce_manage_stock', () => {
+			expect( getProductsSettingValue( loadedStateWithUi, 'woocommerce_manage_stock' ) ).to.equal(
+				'yes'
+			);
 		} );
 	} );
 } );


### PR DESCRIPTION
For #16732 - this branch adds in a new selector for the `sites/settings/products` sub-tree that allows grabbing an arbitrary value for a given `id` ( setting name ). This selector will enable the retrieval of current settings needed to create the Inventory Alerts widget.

__To Test__
No visual changes are made in this branch - to test ensure the new test cases pass:

`npm run test-client client/extensions/woocommerce/state/sites/settings/products`