### PR TITLE
Promotions edit: Update promotion name during edit

### DIFF
--- a/client/extensions/woocommerce/app/promotions/fields/currency-field.js
+++ b/client/extensions/woocommerce/app/promotions/fields/currency-field.js
@@ -7,7 +7,6 @@ import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
-import { getCurrencyFormatDecimal } from 'woocommerce/lib/currency';
 import PriceInput from 'woocommerce/components/price-input';
 import FormField from './form-field';
 
@@ -17,21 +16,14 @@ const CurrencyField = ( props ) => {
 
 	const onChange = ( e ) => {
 		const newValue = e.target.value;
-		if ( 0 === newValue.length ) {
-			edit( fieldName, '' );
-			return;
-		}
-
-		const numberValue = Number( newValue );
-		if ( 0 <= Number( newValue ) ) {
-			const formattedValue = getCurrencyFormatDecimal( numberValue, currency );
-			edit( fieldName, String( formattedValue ) );
-		}
+		edit( fieldName, String( newValue ) );
 	};
 
 	return (
 		<FormField { ...props } >
 			<PriceInput
+				noWrap
+				size="4"
 				htmlFor={ fieldName + '-label' }
 				aria-describedby={ explanationText && fieldName + '-description' }
 				currency={ currency }

--- a/client/extensions/woocommerce/app/promotions/promotion-create.js
+++ b/client/extensions/woocommerce/app/promotions/promotion-create.js
@@ -22,9 +22,11 @@ import { fetchProductCategories } from 'woocommerce/state/sites/product-categori
 import { fetchPromotions, createPromotion } from 'woocommerce/state/sites/promotions/actions';
 import { fetchSettingsGeneral } from 'woocommerce/state/sites/settings/general/actions';
 import { getPaymentCurrencySettings } from 'woocommerce/state/sites/settings/general/selectors';
+import { getProductCategories } from 'woocommerce/state/sites/product-categories/selectors';
 import {
 	getCurrentlyEditingPromotionId,
 	getPromotionEdits,
+	getPromotionableProducts,
 	getPromotionWithLocalEdits,
 } from 'woocommerce/state/selectors/promotions';
 import { isValidPromotion } from './helpers';
@@ -128,7 +130,15 @@ class PromotionCreate extends React.Component {
 	};
 
 	render() {
-		const { site, currency, className, promotion, hasEdits } = this.props;
+		const {
+			site,
+			currency,
+			className,
+			promotion,
+			hasEdits,
+			products,
+			productCategories
+		} = this.props;
 		const { busy } = this.state;
 
 		const isValid = 'undefined' !== typeof site && isValidPromotion( promotion );
@@ -148,6 +158,8 @@ class PromotionCreate extends React.Component {
 					currency={ currency }
 					promotion={ promotion }
 					editPromotion={ this.props.editPromotion }
+					products={ products }
+					productCategories={ productCategories }
 				/>
 			</Main>
 		);
@@ -161,12 +173,16 @@ function mapStateToProps( state ) {
 	const promotionId = getCurrentlyEditingPromotionId( state, site.ID );
 	const promotion = promotionId ? getPromotionWithLocalEdits( state, promotionId, site.ID ) : null;
 	const hasEdits = Boolean( getPromotionEdits( state, promotionId, site.ID ) );
+	const products = getPromotionableProducts( state, site.ID );
+	const productCategories = getProductCategories( state, site.ID );
 
 	return {
 		hasEdits,
 		site,
 		promotion,
 		currency,
+		products,
+		productCategories,
 	};
 }
 

--- a/client/extensions/woocommerce/app/promotions/promotion-update.js
+++ b/client/extensions/woocommerce/app/promotions/promotion-update.js
@@ -135,7 +135,6 @@ class PromotionUpdate extends React.Component {
 					args: { promotion: promotion.name },
 				} ),
 				{
-					displayOnNextPage: true,
 					duration: 8000,
 				}
 			);
@@ -143,9 +142,8 @@ class PromotionUpdate extends React.Component {
 
 		const successAction = dispatch => {
 			this.props.clearPromotionEdits( site.ID );
-
 			dispatch( getSuccessNotice( promotion ) );
-			page.redirect( getLink( '/store/promotions/:site', site ) );
+			this.setState( () => ( { busy: false } ) );
 		};
 
 		const failureAction = dispatch => {


### PR DESCRIPTION
This adds code to update the promotion name while editing to allow for a
correct notification when it's been saved.

To Test:
1. `npm start`
2. Visit `http://calypso.localhost:3000/store/promotion/<site url>`
3. Fill out an individual product sale promotion and click Save.
4. Observe the notice that names the promotion correctly by product name.
5. Fill out a coupon-oriented promotion and click Save.
6. Observe that the notice names the promotion correctly by coupon code.
