### PR TITLE
Checkout: Edited checkout styles.scss to conform to stylelint rules

### DIFF
--- a/client/my-sites/checkout/checkout/style.scss
+++ b/client/my-sites/checkout/checkout/style.scss
@@ -11,7 +11,7 @@
 		&-enter {
 			height: 0;
 			opacity: 0.01;
-			transform: translateZ(0) scale(.8);
+			transform: translateZ(0) scale(0.8);
 		}
 
 		&-appear-active,
@@ -23,8 +23,8 @@
 			transition-duration: 400ms;
 		}
 
-		&:not(.domain-details) {
-			@include breakpoint( "<660px" ) {
+		&:not( .domain-details ) {
+			@include breakpoint( '<660px' ) {
 				box-shadow: none;
 			}
 		}
@@ -41,7 +41,7 @@
 			}
 
 			.placeholder {
-				animation: pulse-light 0.8s ease-in-out infinite;
+				animation: pulse-light 800ms ease-in-out infinite;
 				background: lighten( $gray, 20% );
 				width: 100%;
 				height: 100%;
@@ -52,7 +52,7 @@
 				height: 22px;
 				width: 130px;
 
-				:after {
+				::after {
 					content: '';
 				}
 
@@ -75,7 +75,7 @@
 				flex: 1 1 auto;
 				margin-bottom: 15px;
 
-				@include breakpoint( ">480px" ) {
+				@include breakpoint( '>480px' ) {
 					flex: 2 1 auto;
 				}
 			}
@@ -85,7 +85,7 @@
 			}
 
 			.placeholder-inline-pad-only-wide {
-				@include breakpoint( ">480px" ) {
+				@include breakpoint( '>480px' ) {
 					padding-right: 15px;
 				}
 			}
@@ -95,7 +95,7 @@
 				margin-bottom: 15px;
 				flex: 0 0 100%;
 
-				@include breakpoint( ">480px" ) {
+				@include breakpoint( '>480px' ) {
 					flex: 6 3 auto;
 				}
 			}
@@ -104,7 +104,7 @@
 				height: 50px;
 				width: 100%;
 
-				@include breakpoint ( ">480px" ) {
+				@include breakpoint ( '>480px' ) {
 					width: 80px;
 					height: 40px;
 				}
@@ -113,18 +113,18 @@
 			.placeholder-button-container {
 				margin-top: 55px;
 
-				@include breakpoint( ">480px" ) {
+				@include breakpoint( '>480px' ) {
 						margin-top: 20px;
 				}
 			}
 
 			.payment-box-hr {
-				margin: 40px 0 20px 0;
+				margin: 40px 0 20px;
 				width: 100%;
 				height: 0;
 				border-bottom: 1px solid lighten( $gray, 30% );
 
-				@include breakpoint( "<480px" ) {
+				@include breakpoint( '<480px' ) {
 					display: none;
 				}
 			}
@@ -146,7 +146,7 @@
 		opacity: 0.7;
 		text-transform: uppercase;
 
-		:after {
+		::after {
 			@include noticon( '\f470', (13 / 12) * 1em );
 			float: right;
 		}
@@ -155,14 +155,14 @@
 	.checkout__box-padding {
 		padding: 16px 8px;
 
-		@include breakpoint( ">660px" ) {
-			padding: 10px 30px 20px 30px;
+		@include breakpoint( '>660px' ) {
+			padding: 10px 30px 20px;
 		}
 	}
 
 	.domain-details {
 		.box-padding {
-			@include breakpoint( "<660px" ) {
+			@include breakpoint( '<660px' ) {
 				padding: 16px;
 			}
 		}
@@ -171,21 +171,21 @@
 	form {
 		margin-top: 5px;
 
-		@include breakpoint( ">660px" ) {
+		@include breakpoint( '>660px' ) {
 			@include clear-fix;
 		}
 	}
 
 	button[type=submit].button-pay, button[type=submit].checkout__button-pay {
-		@include breakpoint( "<660px" ) {
+		@include breakpoint( '<660px' ) {
 			width: 100%;
 
-			#wpcom & {
+			.wpcom-site & {
 				min-height: 50px;
 			}
 		}
 
-		@include breakpoint( ">660px" ) {
+		@include breakpoint( '>660px' ) {
 			clear: both;
 			float: left;
 		}
@@ -214,7 +214,7 @@
 			width: 100%;
 		}
 
-		input[ disabled ] {
+		input[disabled] {
 			cursor: not-allowed;
 		}
 	}
@@ -222,7 +222,7 @@
 	.form-button {
 		margin-top: 20px;
 
-		@include breakpoint( "<660px" ) {
+		@include breakpoint( '<660px' ) {
 			margin-bottom: 20px;
 		}
 	}
@@ -235,7 +235,7 @@
 		margin: 16px 0;
 		padding: 0;
 
-		@include breakpoint( ">660px" ) {
+		@include breakpoint( '>660px' ) {
 			padding: 0;
 			text-align: left;
 		}
@@ -245,7 +245,7 @@
 			font-weight: 100;
 			margin: 0;
 
-			@include breakpoint( ">660px" ) {
+			@include breakpoint( '>660px' ) {
 				margin-left: 24px;
 			}
 		}
@@ -253,7 +253,7 @@
 		.gridicon {
 			float: left;
 
-			@include breakpoint( "<660px" ) {
+			@include breakpoint( '<660px' ) {
 				display: none;
 			}
 		}
@@ -267,7 +267,7 @@
 		padding: 10px 0;
 
 		// On larger screens, users can use the coupon functionality present on the sidebar
-		@include breakpoint( "<660px" ) {
+		@include breakpoint( '<660px' ) {
 			display: block;
 			text-align: center;
 		}
@@ -279,8 +279,8 @@
 	}
 
 	.payment-box-actions, .checkout__payment-box-actions {
-		margin: 20px -30px 0px -30px;
-		padding: 20px 30px 0 30px;
+		margin: 20px -30px 0 -30px;
+		padding: 20px 30px 0;
 		@include clear-fix;
 	}
 
@@ -289,7 +289,7 @@
 			background-color: $white;
 			box-shadow: 0 1px 2px rgba(0, 0, 0, 0.075);
 
-			@include breakpoint( ">660px" ) {
+			@include breakpoint( '>660px' ) {
 				box-shadow: none;
 			}
 		}
@@ -346,7 +346,7 @@
 			overflow: hidden;
 			padding: 0 15px 0 12px;
 			position: relative;
-			transition: all 0.5s ease-in-out;
+			transition: all 500ms ease-in-out;
 		}
 
 		.payment-box-section.selected .new-card-fields {
@@ -374,14 +374,14 @@
 			font-size: 12px;
 			font-style: italic;
 
-			@include breakpoint( ">660px" ) {
+			@include breakpoint( '>660px' ) {
 				top: 7px;
 			}
 
 			&.has-saved-cards {
 				top: 18px;
 
-				@include breakpoint( ">660px" ) {
+				@include breakpoint( '>660px' ) {
 					position: absolute;
 						right: 18px;
 				}
@@ -396,7 +396,7 @@
 		padding: 10px;
 		text-align: center;
 
-		@include breakpoint( ">660px" ) {
+		@include breakpoint( '>660px' ) {
 			display: none;
 		}
 	}
@@ -410,7 +410,7 @@
 			background-color: $white;
 			box-shadow: 0 1px 2px rgba(0, 0, 0, 0.075);
 
-			@include breakpoint( ">660px" ) {
+			@include breakpoint( '>660px' ) {
 				border: 1px solid lighten( $gray, 30% );
 				box-shadow: none;
 			}
@@ -470,7 +470,7 @@
 				left: 10px;
 				position: absolute;
 				@include noticon( '\f205', 60px );
-				@include breakpoint( ">660px" ) {
+				@include breakpoint( '>660px' ) {
 					left: 20px;
 				}
 			}
@@ -485,7 +485,7 @@
 				font-size: 15px;
 			}
 
-			@include breakpoint( ">660px" ) {
+			@include breakpoint( '>660px' ) {
 				padding-left: 100px;
 			}
 		}
@@ -501,7 +501,7 @@
 		padding: 15px 0;
 		@include clear-fix;
 
-		@include breakpoint( ">660px" ) {
+		@include breakpoint( '>660px' ) {
 			border-bottom: 1px solid lighten( $gray, 20% );
 			margin: 30px 0;
 		}
@@ -510,13 +510,13 @@
 			color: lighten( $gray, 10% );
 			text-align: center;
 
-			@include breakpoint( ">660px" ) {
+			@include breakpoint( '>660px' ) {
 				float: left;
 				margin: 0 5%;
 				width: 40%;
 			}
 
-			@include breakpoint( "<660px" ) {
+			@include breakpoint( '<660px' ) {
 				margin: 0;
 				padding: 15px;
 			}
@@ -530,7 +530,7 @@
 			p {
 				font-size: 12px;
 				font-weight: 100;
-				margin: 10px 0 0 0;
+				margin: 10px 0 0;
 			}
 		}
 	}
@@ -550,7 +550,7 @@
 			margin-top: 0;
 		}
 
-		@include breakpoint( ">660px" ) {
+		@include breakpoint( '>660px' ) {
 			.last-name {
 				margin-top: 0;
 			}
@@ -610,7 +610,7 @@
 	margin-top: 15px;
 	padding: 10px;
 
-	@include breakpoint( ">660px" ) {
+	@include breakpoint( '>660px' ) {
 		box-sizing: border-box;
 		padding: 15px;
 		width: 100%;
@@ -632,13 +632,13 @@
 		display: block;
 		margin-top: 10px;
 		padding: 12px;
-		transition: all 0.3s ease-in-out;
+		transition: all 300ms ease-in-out;
 
 		&.selected {
-			border-color: #00AADC;
+			border-color: #00aadc;
 		}
 
-		@include breakpoint( ">660px" ) {
+		@include breakpoint( '>660px' ) {
 			display: flex;
 			flex-direction: column;
 			justify-content: space-between;
@@ -678,7 +678,7 @@
 
 // If there's no sidebar, we don't show the cart on the checkout page.
 
-@include breakpoint( ">660px" ) {
+@include breakpoint( '>660px' ) {
 	.pay-button, .checkout__pay-button {
 		float: left;
 	}
@@ -702,26 +702,26 @@
 		margin-left: 1em;
 	}
 
-	@include breakpoint( "<660px" ) {
+	@include breakpoint( '<660px' ) {
 		border-bottom: 1px solid lighten( $gray, 30% );
-		margin: 10px 0 0 0;
+		margin: 10px 0 0;
 		text-align: center;
 	}
 
-	@include breakpoint( ">960px" ) {
+	@include breakpoint( '>960px' ) {
 		float: right;
 		clear: none;
 	}
 }
 
 .credit-card-payment-box__switch-link-left {
-	@include breakpoint( ">960px" ) {
+	@include breakpoint( '>960px' ) {
 		float: left;
-		padding-left: 20px
+		padding-left: 20px;
 	}
 }
 
-@include breakpoint( ">660px" ) {
+@include breakpoint( '>660px' ) {
 	.payment-box__payment-buttons {
 		display: flex;
 		align-items: center;
@@ -732,7 +732,7 @@
 	margin-top: 10px;
 	color: lighten( $gray, 10% );
 
-	@include breakpoint( ">660px" ) {
+	@include breakpoint( '>660px' ) {
 		margin-left: 10px;
 		margin-top: 0;
 		display: inline-block;
@@ -744,7 +744,7 @@
 	align-items: center;
 	justify-content: center;
 
-	@include breakpoint( ">660px" ) {
+	@include breakpoint( '>660px' ) {
 		justify-content: left;
 	}
 }
@@ -755,18 +755,18 @@
 }
 
 .checkout__payment-chat-button {
-	@include breakpoint( "<660px" ) {
+	@include breakpoint( '<660px' ) {
 		width: 100%;
 		text-align: center;
 	}
 
-	@include breakpoint( ">960px" ) {
+	@include breakpoint( '>960px' ) {
 		float: right;
 	}
 }
 
 .credits-payment-box .checkout__payment-chat-button {
-	@include breakpoint( ">660px" ) {
+	@include breakpoint( '>660px' ) {
 		float: right;
 	}
 }
@@ -777,7 +777,7 @@
 
 .checkout__privacy-protection-price-text {
 	color: $gray;
-	margin: 4px 0 0 0;
+	margin: 4px 0 0;
 	font-size: 15px;
 
 	span {


### PR DESCRIPTION
### Why?
I was getting tired of looking at the 56 or so linting errors every time I checked in. :)

### Side effects
Nothing new added.

Only change was the reference to the root div: `.wpcom-site` instead of `#wpcom`

### Testing
https://calypso.live/?branch=update/domains-details-styles-stylelint
Throw a domain in your cart, and view the details and checkout forms. 