### PR TITLE
Promotion edit: Protect form from navigating away

### DIFF
--- a/client/extensions/woocommerce/app/promotions/fields/currency-field.js
+++ b/client/extensions/woocommerce/app/promotions/fields/currency-field.js
@@ -7,7 +7,6 @@ import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
-import { getCurrencyFormatDecimal } from 'woocommerce/lib/currency';
 import PriceInput from 'woocommerce/components/price-input';
 import FormField from './form-field';
 
@@ -17,21 +16,14 @@ const CurrencyField = ( props ) => {
 
 	const onChange = ( e ) => {
 		const newValue = e.target.value;
-		if ( 0 === newValue.length ) {
-			edit( fieldName, '' );
-			return;
-		}
-
-		const numberValue = Number( newValue );
-		if ( 0 <= Number( newValue ) ) {
-			const formattedValue = getCurrencyFormatDecimal( numberValue, currency );
-			edit( fieldName, String( formattedValue ) );
-		}
+		edit( fieldName, String( newValue ) );
 	};
 
 	return (
 		<FormField { ...props } >
 			<PriceInput
+				noWrap
+				size="4"
 				htmlFor={ fieldName + '-label' }
 				aria-describedby={ explanationText && fieldName + '-description' }
 				currency={ currency }

--- a/client/extensions/woocommerce/app/promotions/promotion-create.js
+++ b/client/extensions/woocommerce/app/promotions/promotion-create.js
@@ -37,6 +37,7 @@ class PromotionCreate extends React.Component {
 	static propTypes = {
 		className: PropTypes.string,
 		currency: PropTypes.string,
+		hasEdits: PropTypes.bool.isRequired,
 		site: PropTypes.shape( {
 			ID: PropTypes.number,
 			slug: PropTypes.string,

--- a/client/extensions/woocommerce/app/promotions/promotion-create.js
+++ b/client/extensions/woocommerce/app/promotions/promotion-create.js
@@ -22,9 +22,11 @@ import { fetchProductCategories } from 'woocommerce/state/sites/product-categori
 import { fetchPromotions, createPromotion } from 'woocommerce/state/sites/promotions/actions';
 import { fetchSettingsGeneral } from 'woocommerce/state/sites/settings/general/actions';
 import { getPaymentCurrencySettings } from 'woocommerce/state/sites/settings/general/selectors';
+import { getProductCategories } from 'woocommerce/state/sites/product-categories/selectors';
 import {
 	getCurrentlyEditingPromotionId,
 	getPromotionEdits,
+	getPromotionableProducts,
 	getPromotionWithLocalEdits,
 } from 'woocommerce/state/selectors/promotions';
 import { isValidPromotion } from './helpers';
@@ -128,7 +130,15 @@ class PromotionCreate extends React.Component {
 	};
 
 	render() {
-		const { site, currency, className, promotion, hasEdits } = this.props;
+		const {
+			site,
+			currency,
+			className,
+			promotion,
+			hasEdits,
+			products,
+			productCategories
+		} = this.props;
 		const { busy } = this.state;
 
 		const isValid = 'undefined' !== typeof site && isValidPromotion( promotion );
@@ -148,6 +158,8 @@ class PromotionCreate extends React.Component {
 					currency={ currency }
 					promotion={ promotion }
 					editPromotion={ this.props.editPromotion }
+					products={ products }
+					productCategories={ productCategories }
 				/>
 			</Main>
 		);
@@ -161,12 +173,16 @@ function mapStateToProps( state ) {
 	const promotionId = getCurrentlyEditingPromotionId( state, site.ID );
 	const promotion = promotionId ? getPromotionWithLocalEdits( state, promotionId, site.ID ) : null;
 	const hasEdits = Boolean( getPromotionEdits( state, promotionId, site.ID ) );
+	const products = getPromotionableProducts( state, site.ID );
+	const productCategories = getProductCategories( state, site.ID );
 
 	return {
 		hasEdits,
 		site,
 		promotion,
 		currency,
+		products,
+		productCategories,
 	};
 }
 

--- a/client/extensions/woocommerce/app/promotions/promotion-update.js
+++ b/client/extensions/woocommerce/app/promotions/promotion-update.js
@@ -135,7 +135,6 @@ class PromotionUpdate extends React.Component {
 					args: { promotion: promotion.name },
 				} ),
 				{
-					displayOnNextPage: true,
 					duration: 8000,
 				}
 			);
@@ -143,9 +142,8 @@ class PromotionUpdate extends React.Component {
 
 		const successAction = dispatch => {
 			this.props.clearPromotionEdits( site.ID );
-
 			dispatch( getSuccessNotice( promotion ) );
-			page.redirect( getLink( '/store/promotions/:site', site ) );
+			this.setState( () => ( { busy: false } ) );
 		};
 
 		const failureAction = dispatch => {

--- a/client/extensions/woocommerce/app/promotions/promotion-update.js
+++ b/client/extensions/woocommerce/app/promotions/promotion-update.js
@@ -31,12 +31,14 @@ import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
 import { fetchSettingsGeneral } from 'woocommerce/state/sites/settings/general/actions';
 import { getPaymentCurrencySettings } from 'woocommerce/state/sites/settings/general/selectors';
 import {
+	getPromotionEdits,
 	getPromotionWithLocalEdits,
 	getPromotionableProducts,
 } from 'woocommerce/state/selectors/promotions';
 import { isValidPromotion } from './helpers';
 import PromotionHeader from './promotion-header';
 import PromotionForm from './promotion-form';
+import { ProtectFormGuard } from 'lib/protect-form';
 
 class PromotionUpdate extends React.Component {
 	static propTypes = {
@@ -98,12 +100,15 @@ class PromotionUpdate extends React.Component {
 
 	onTrash = () => {
 		const { translate, site, promotion, deletePromotion: dispatchDelete } = this.props;
-		const areYouSure = translate( 'Are you sure you want to delete this promotion?' );
+		const areYouSure = translate( 'Are you sure you want to permanently delete this promotion?' );
 		accept( areYouSure, accepted => {
 			if ( ! accepted ) {
 				return;
 			}
+
 			const successAction = dispatch => {
+				this.props.clearPromotionEdits( site.ID );
+
 				dispatch( successNotice( translate( 'Promotion successfully deleted.' ) ) );
 				debounce( () => {
 					page.redirect( getLink( '/store/promotions/:site/', site ) );
@@ -136,6 +141,8 @@ class PromotionUpdate extends React.Component {
 		};
 
 		const successAction = dispatch => {
+			this.props.clearPromotionEdits( site.ID );
+
 			dispatch( getSuccessNotice( promotion ) );
 			page.redirect( getLink( '/store/promotions/:site', site ) );
 		};
@@ -155,11 +162,19 @@ class PromotionUpdate extends React.Component {
 	};
 
 	render() {
-		const { site, currency, className, promotion, products, productCategories } = this.props;
+		const {
+			site,
+			currency,
+			className,
+			promotion,
+			products,
+			productCategories,
+			hasEdits,
+		} = this.props;
 		const { busy } = this.state;
 
 		const isValid = 'undefined' !== typeof site && isValidPromotion( promotion );
-		const saveEnabled = isValid && ! busy;
+		const saveEnabled = isValid && ! busy && hasEdits;
 
 		return (
 			<Main className={ className }>
@@ -170,6 +185,7 @@ class PromotionUpdate extends React.Component {
 					onSave={ saveEnabled ? this.onSave : false }
 					isBusy={ busy }
 				/>
+				<ProtectFormGuard isChanged={ hasEdits } />
 				<PromotionForm
 					siteId={ site && site.ID }
 					currency={ currency }
@@ -191,8 +207,10 @@ function mapStateToProps( state, ownProps ) {
 	const promotion = promotionId ? getPromotionWithLocalEdits( state, promotionId, site.ID ) : null;
 	const products = getPromotionableProducts( state, site.ID );
 	const productCategories = getProductCategories( state, site.ID );
+	const hasEdits = Boolean( getPromotionEdits( state, promotionId, site.ID ) );
 
 	return {
+		hasEdits,
 		site,
 		promotion,
 		currency,

--- a/client/extensions/woocommerce/app/promotions/promotion-update.js
+++ b/client/extensions/woocommerce/app/promotions/promotion-update.js
@@ -44,6 +44,7 @@ class PromotionUpdate extends React.Component {
 	static propTypes = {
 		className: PropTypes.string,
 		currency: PropTypes.string,
+		hasEdits: PropTypes.bool.isRequired,
 		products: PropTypes.array,
 		productCategories: PropTypes.array,
 		site: PropTypes.shape( {


### PR DESCRIPTION
This adds a protect guard while edits are present.
It also updates the delete notification to be more explicit that it is a
permanent delete.

To Test:
1. `npm start`
2. Visit `http://calypso.localhost:3000/store/promotions/<site url>`
3. Click "Add Promotion"
4. Type in any field, then try to navigate away.
5. Finish completing the form, click "Save & Publish"
6. From the list page, select a promotion to edit.
7. Type in any field, then try to navigate away.
8. Click "Update".
