### PR TITLE
Components: Update AcceptDialog for deprecation

### DIFF
--- a/client/lib/accept/dialog.jsx
+++ b/client/lib/accept/dialog.jsx
@@ -6,40 +6,53 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import createReactClass from 'create-react-class';
 import { localize } from 'i18n-calypso';
 import classnames from 'classnames';
+import { noop } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import Dialog from 'components/dialog';
 
-const AcceptDialog = createReactClass( {
-	displayName: 'AcceptDialog',
-
-	propTypes: {
-		translate: PropTypes.func,
+class AcceptDialog extends React.Component {
+	static propTypes = {
+		translate: PropTypes.func.isRequired,
 		message: PropTypes.node,
 		onClose: PropTypes.func.isRequired,
 		confirmButtonText: PropTypes.node,
 		cancelButtonText: PropTypes.node,
 		options: PropTypes.object,
-	},
+	};
 
-	getInitialState: function() {
-		return { isVisible: true };
-	},
+	constructor( props ) {
+		super( props );
 
-	onClose: function( action ) {
+		this.state = {
+			isVisible: true,
+		};
+
+		this.hide = noop;
+	}
+
+	componentDidMount() {
+		this.hide = () => {
+			this.setState( () => {
+				isVisible: false;
+			} );
+		};
+	}
+
+	componentWillUnmount() {
+		this.hide = noop;
+	}
+
+	onClose = action => {
 		this.props.onClose( 'accept' === action );
+		this.hide();
+	};
 
-		if ( this.isMounted() ) {
-			this.setState( { isVisible: false } );
-		}
-	},
-
-	getActionButtons: function() {
+	getActionButtons = () => {
 		const { options } = this.props;
 		const isScary = options && options.isScary;
 		const additionalClassNames = classnames( { 'is-scary': isScary } );
@@ -59,9 +72,9 @@ const AcceptDialog = createReactClass( {
 				additionalClassNames,
 			},
 		];
-	},
+	};
 
-	render: function() {
+	render() {
 		if ( ! this.state.isVisible ) {
 			return null;
 		}
@@ -76,7 +89,7 @@ const AcceptDialog = createReactClass( {
 				{ this.props.message }
 			</Dialog>
 		);
-	},
-} );
+	}
+}
 
 export default localize( AcceptDialog );


### PR DESCRIPTION
AcceptDialog was using `isMounted` which was causing a deprecation
warning (see: https://github.com/facebook/react/issues/3417)

It was also using `createReactClass`. This commit updates it in both
ways.

To Test:
1. `npm test`
2. `npm start`
3. Go to edit a post, click on "Status" on the right, then "Public", then "Admins and Editors"
4. Select No
5. Go back and this time select Yes
