### PR TITLE
Checkout: clearing progress bar interval when there are errors

### DIFF
--- a/client/my-sites/checkout/checkout/credit-card-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/credit-card-payment-box.jsx
@@ -36,14 +36,12 @@ import CartToggle from './cart-toggle';
 export class CreditCardPaymentBox extends React.Component {
 	static propTypes = {
 		cart: PropTypes.object.isRequired,
-		selectedSite: PropTypes.object.isRequired,
 		transaction: PropTypes.object.isRequired,
 		transactionStep: PropTypes.object.isRequired,
 		cards: PropTypes.array,
 		countriesList: PropTypes.object,
 		initialCard: PropTypes.object,
 		onSubmit: PropTypes.func,
-		onToggle: PropTypes.func,
 	};
 
 	static defaultProps = {
@@ -51,7 +49,6 @@ export class CreditCardPaymentBox extends React.Component {
 		countriesList: {},
 		initialCard: null,
 		onSubmit: noop,
-		onToggle: noop,
 	};
 
 	constructor( props ) {
@@ -129,7 +126,7 @@ export class CreditCardPaymentBox extends React.Component {
 	};
 
 	paymentButtons = () => {
-		const cart = this.props.cart,
+		const { cart, transactionStep, translate } = this.props,
 			hasBusinessPlanInCart = some( cart.products, { product_slug: PLAN_BUSINESS } ),
 			showPaymentChatButton =
 				config.isEnabled( 'upgrades/presale-chat' ) &&
@@ -139,12 +136,12 @@ export class CreditCardPaymentBox extends React.Component {
 
 		return (
 			<div className={ paymentButtonClasses }>
-				<PayButton cart={ this.props.cart } transactionStep={ this.props.transactionStep } />
+				<PayButton cart={ cart } transactionStep={ transactionStep } />
 
 				<div className="checkout__secure-payment">
 					<div className="checkout__secure-payment-content">
 						<Gridicon icon="lock" />
-						{ this.props.translate( 'Secure Payment' ) }
+						{ translate( 'Secure Payment' ) }
 					</div>
 				</div>
 
@@ -155,8 +152,8 @@ export class CreditCardPaymentBox extends React.Component {
 				{ showPaymentChatButton && (
 					<PaymentChatButton
 						paymentType="credits"
-						cart={ this.props.cart }
-						transactionStep={ this.props.transactionStep }
+						cart={ cart }
+						transactionStep={ transactionStep }
 					/>
 				) }
 			</div>
@@ -181,15 +178,15 @@ export class CreditCardPaymentBox extends React.Component {
 	};
 
 	render = () => {
-		const { cart } = this.props;
+		const { cart, cards, countriesList, initialCard, transaction } = this.props;
 
 		return (
 			<form autoComplete="off" onSubmit={ this.submit }>
 				<CreditCardSelector
-					cards={ this.props.cards }
-					countriesList={ this.props.countriesList }
-					initialCard={ this.props.initialCard }
-					transaction={ this.props.transaction }
+					cards={ cards }
+					countriesList={ countriesList }
+					initialCard={ initialCard }
+					transaction={ transaction }
 				/>
 
 				<TermsOfService

--- a/client/my-sites/checkout/checkout/credit-card-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/credit-card-payment-box.jsx
@@ -3,9 +3,10 @@
  *
  * @format
  */
-
+import PropTypes from 'prop-types';
 import React from 'react';
-import { some } from 'lodash';
+import some from 'lodash/some';
+import noop from 'lodash/noop';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'gridicons';
 
@@ -32,11 +33,35 @@ import { PLAN_BUSINESS } from 'lib/plans/constants';
 import ProgressBar from 'components/progress-bar';
 import CartToggle from './cart-toggle';
 
-class CreditCardPaymentBox extends React.Component {
-	state = {
-		progress: 0,
-		previousCart: null,
+export class CreditCardPaymentBox extends React.Component {
+	static propTypes = {
+		cart: PropTypes.object.isRequired,
+		selectedSite: PropTypes.object.isRequired,
+		transaction: PropTypes.object.isRequired,
+		transactionStep: PropTypes.object.isRequired,
+		cards: PropTypes.array,
+		countriesList: PropTypes.object,
+		initialCard: PropTypes.object,
+		onSubmit: PropTypes.func,
+		onToggle: PropTypes.func,
 	};
+
+	static defaultProps = {
+		cards: [],
+		countriesList: {},
+		initialCard: null,
+		onSubmit: noop,
+		onToggle: noop,
+	};
+
+	constructor( props ) {
+		super( props );
+		this.state = {
+			progress: 0,
+			previousCart: null,
+		};
+		this.timer = null;
+	}
 
 	componentWillReceiveProps( nextProps ) {
 		if (
@@ -45,10 +70,19 @@ class CreditCardPaymentBox extends React.Component {
 		) {
 			this.timer = setInterval( this.tick, 100 );
 		}
+
+		if ( nextProps.transactionStep.error ) {
+			this.clearTickInterval();
+		}
 	}
 
 	componentWillUnmount() {
+		this.clearTickInterval();
+	}
+
+	clearTickInterval() {
 		clearInterval( this.timer );
+		this.timer = null;
 	}
 
 	tick = () => {
@@ -64,7 +98,7 @@ class CreditCardPaymentBox extends React.Component {
 				return false;
 
 			case INPUT_VALIDATION:
-				if ( this.props.transactionStep.error ) {
+				if ( transactionStep.error ) {
 					return false;
 				}
 				return true;
@@ -87,7 +121,7 @@ class CreditCardPaymentBox extends React.Component {
 
 	progressBar = () => {
 		return (
-			<div className="credit-card-payment-box__progress-bar">
+			<div className="checkout__credit-card-payment-box-progress-bar">
 				{ this.props.translate( 'Processing payment…' ) }
 				<ProgressBar value={ Math.round( this.state.progress ) } isPulsing />
 			</div>
@@ -135,7 +169,7 @@ class CreditCardPaymentBox extends React.Component {
 			content = this.progressBar();
 		}
 
-		return <div className="payment-box-actions">{ content }</div>;
+		return <div className="checkout__payment-box-actions">{ content }</div>;
 	};
 
 	submit = event => {
@@ -147,7 +181,7 @@ class CreditCardPaymentBox extends React.Component {
 	};
 
 	render = () => {
-		var cart = this.props.cart;
+		const { cart } = this.props;
 
 		return (
 			<form autoComplete="off" onSubmit={ this.submit }>

--- a/client/my-sites/checkout/checkout/style.scss
+++ b/client/my-sites/checkout/checkout/style.scss
@@ -792,7 +792,7 @@
 	padding-left: 8px;
 }
 
-.credit-card-payment-box__progress-bar {
+.checkout__credit-card-payment-box-progress-bar {
 	color: $gray;
 	font-size: 12px;
 	padding-bottom: 1em;

--- a/client/my-sites/checkout/checkout/test/credit-card-payment-box.js
+++ b/client/my-sites/checkout/checkout/test/credit-card-payment-box.js
@@ -1,0 +1,122 @@
+/**
+ * @format
+ * @jest-environment jsdom
+ */
+
+/**
+ * External dependencies
+ */
+import { shallow } from 'enzyme';
+import { identity, noop } from 'lodash';
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { CreditCardPaymentBox } from '../credit-card-payment-box';
+import { isPayPalExpressEnabled } from 'lib/cart-values';
+import { INPUT_VALIDATION } from 'lib/store-transactions/step-types';
+
+jest.mock( 'lib/abtest', () => ( { abtest: () => {} } ) );
+jest.mock( 'lib/analytics', () => {} );
+jest.mock( 'lib/cart-values', () => ( {
+	isPayPalExpressEnabled: jest.fn( false ),
+	cartItems: {
+		hasRenewableSubscription: jest.fn( false ),
+	},
+} ) );
+
+jest.useFakeTimers();
+
+describe( 'Credit Card Payment Box', () => {
+	const defaultProps = {
+		cards: [],
+		transaction: {},
+		cart: {},
+		countriesList: {},
+		initialCard: {},
+		selectedSite: {},
+		transactionStep: {},
+		onSubmit: noop,
+		onToggle: noop,
+		translate: identity,
+	};
+
+	test( 'does not blow up with default props', () => {
+		const wrapper = shallow( <CreditCardPaymentBox { ...defaultProps } /> );
+		expect( wrapper ).toHaveLength( 1 );
+	} );
+
+	test( 'should set progress timer when incoming validation transaction step contains no errors', () => {
+		const wrapper = shallow( <CreditCardPaymentBox { ...defaultProps } /> );
+		const tickSpy = jest.spyOn( wrapper.instance(), 'tick' );
+		wrapper.update();
+		expect( wrapper.instance().timer ).toBe( null );
+		wrapper.setProps( {
+			transactionStep: {
+				name: INPUT_VALIDATION,
+			},
+		} );
+		jest.runOnlyPendingTimers();
+		expect( wrapper.instance().timer ).not.toBe( null );
+		expect( tickSpy.mock.calls.length ).toBe( 1 );
+		expect( setInterval.mock.calls.length ).toBe( 1 );
+		setInterval.mockClear();
+	} );
+
+	test( 'should not set progress timer when incoming validation transaction step contains errors', () => {
+		const wrapper = shallow( <CreditCardPaymentBox { ...defaultProps } /> );
+		const tickSpy = jest.spyOn( wrapper.instance(), 'tick' );
+		wrapper.update();
+		expect( wrapper.instance().timer ).toBe( null );
+		wrapper.setProps( {
+			transactionStep: {
+				name: INPUT_VALIDATION,
+				error: {},
+			},
+		} );
+		jest.runOnlyPendingTimers();
+		expect( wrapper.instance().timer ).toBe( null );
+		expect( tickSpy.mock.calls.length ).toBe( 0 );
+		expect( setInterval.mock.calls.length ).toBe( 0 );
+		setInterval.mockClear();
+	} );
+
+	test( 'should clear progress timer when incoming validation transaction step contains errors ', () => {
+		const wrapper = shallow( <CreditCardPaymentBox { ...defaultProps } /> );
+		const tickSpy = jest.spyOn( wrapper.instance(), 'tick' );
+		wrapper.update();
+		expect( wrapper.instance().timer ).toBe( null );
+		wrapper.setProps( {
+			transactionStep: {
+				name: INPUT_VALIDATION,
+			},
+		} );
+		jest.runOnlyPendingTimers();
+		expect( wrapper.instance().timer ).not.toBe( null );
+		expect( tickSpy.mock.calls.length ).toBe( 1 );
+		expect( setInterval.mock.calls.length ).toBe( 1 );
+		wrapper.setProps( {
+			transactionStep: {
+				name: INPUT_VALIDATION,
+				error: {},
+			},
+		} );
+		jest.runOnlyPendingTimers();
+		expect( wrapper.instance().timer ).toBe( null );
+		expect( tickSpy.mock.calls.length ).toBe( 1 );
+		expect( setInterval.mock.calls.length ).toBe( 1 );
+		setInterval.mockClear();
+	} );
+
+	test( 'should display PayPal payment button when PayPal express is not enabled', () => {
+		const wrapper = shallow( <CreditCardPaymentBox { ...defaultProps } /> );
+		expect( wrapper.find( '.credit-card-payment-box__switch-link' ) ).toHaveLength( 0 );
+	} );
+
+	test( 'should display PayPal payment button when PayPal express is enabled', () => {
+		isPayPalExpressEnabled.mockReturnValue( true );
+		const wrapper = shallow( <CreditCardPaymentBox { ...defaultProps } /> );
+		expect( wrapper.find( '.credit-card-payment-box__switch-link' ) ).toHaveLength( 1 );
+	} );
+} );

--- a/client/my-sites/checkout/checkout/test/credit-card-payment-box.js
+++ b/client/my-sites/checkout/checkout/test/credit-card-payment-box.js
@@ -14,13 +14,10 @@ import React from 'react';
  * Internal dependencies
  */
 import { CreditCardPaymentBox } from '../credit-card-payment-box';
-import { isPayPalExpressEnabled } from 'lib/cart-values';
 import { INPUT_VALIDATION } from 'lib/store-transactions/step-types';
 
 jest.mock( 'lib/abtest', () => ( { abtest: () => {} } ) );
-jest.mock( 'lib/analytics', () => {} );
 jest.mock( 'lib/cart-values', () => ( {
-	isPayPalExpressEnabled: jest.fn( false ),
 	cartItems: {
 		hasRenewableSubscription: jest.fn( false ),
 	},
@@ -35,10 +32,8 @@ describe( 'Credit Card Payment Box', () => {
 		cart: {},
 		countriesList: {},
 		initialCard: {},
-		selectedSite: {},
 		transactionStep: {},
 		onSubmit: noop,
-		onToggle: noop,
 		translate: identity,
 	};
 
@@ -107,16 +102,5 @@ describe( 'Credit Card Payment Box', () => {
 		expect( tickSpy.mock.calls.length ).toBe( 1 );
 		expect( setInterval.mock.calls.length ).toBe( 1 );
 		setInterval.mockClear();
-	} );
-
-	test( 'should display PayPal payment button when PayPal express is not enabled', () => {
-		const wrapper = shallow( <CreditCardPaymentBox { ...defaultProps } /> );
-		expect( wrapper.find( '.credit-card-payment-box__switch-link' ) ).toHaveLength( 0 );
-	} );
-
-	test( 'should display PayPal payment button when PayPal express is enabled', () => {
-		isPayPalExpressEnabled.mockReturnValue( true );
-		const wrapper = shallow( <CreditCardPaymentBox { ...defaultProps } /> );
-		expect( wrapper.find( '.credit-card-payment-box__switch-link' ) ).toHaveLength( 1 );
 	} );
 } );


### PR DESCRIPTION
### Why?

In `<CreditCardPaymentBox />` we use `setInterval` to update the value of the payment progress bar every 100ms. The callback calls `setState`, which triggers a rerender.

Submitting the form with errors however also sets the interval timer, which leads to multiple rerenders.

![before](https://user-images.githubusercontent.com/6458278/32260356-80e20b0a-bf1b-11e7-83a7-075dff5a57ba.gif)

## The fix

When we notice that ` nextProps.transactionStep` contains errors, we [clear the interval](https://github.com/Automattic/wp-calypso/blob/fix/credit-card-payment-box-rerendering/client/my-sites/checkout/checkout/credit-card-payment-box.jsx#L76). 

```
		if ( nextProps.transactionStep.error ) {
			this.clearTickInterval();
		}
```

![after](https://user-images.githubusercontent.com/6458278/32261267-7fd2d1ee-bf21-11e7-9c44-829ad687d1b9.gif)

The interval is reset when there are no errors and the form is being submitted.

![payment-progress](https://user-images.githubusercontent.com/6458278/32261283-a28d3ec2-bf21-11e7-9535-8b2dfe251d99.gif)

## Misc
I took the opportunity to correct minor linting errors as well.

## Testing
Switch on highlight rendering in React Developer Tools, and simply submit an empty checkout credit card form to trigger an error. The component should not rerender every 100ms.

You can test the progress bar using fake store details or by faking a response in [client/lib/store-transactions/index.js](https://github.com/Automattic/wp-calypso/blob/fix/credit-card-payment-box-rerendering/client/lib/store-transactions/index.js) in`_submitWithPayment()`.

Sorry for all the gifs! 🥔 

#dogfooding #manual-testing