### PR TITLE
Promotion update: Stay on page after save.

### DIFF
--- a/client/extensions/woocommerce/app/promotions/fields/currency-field.js
+++ b/client/extensions/woocommerce/app/promotions/fields/currency-field.js
@@ -7,7 +7,6 @@ import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
-import { getCurrencyFormatDecimal } from 'woocommerce/lib/currency';
 import PriceInput from 'woocommerce/components/price-input';
 import FormField from './form-field';
 
@@ -17,21 +16,14 @@ const CurrencyField = ( props ) => {
 
 	const onChange = ( e ) => {
 		const newValue = e.target.value;
-		if ( 0 === newValue.length ) {
-			edit( fieldName, '' );
-			return;
-		}
-
-		const numberValue = Number( newValue );
-		if ( 0 <= Number( newValue ) ) {
-			const formattedValue = getCurrencyFormatDecimal( numberValue, currency );
-			edit( fieldName, String( formattedValue ) );
-		}
+		edit( fieldName, String( newValue ) );
 	};
 
 	return (
 		<FormField { ...props } >
 			<PriceInput
+				noWrap
+				size="4"
 				htmlFor={ fieldName + '-label' }
 				aria-describedby={ explanationText && fieldName + '-description' }
 				currency={ currency }

--- a/client/extensions/woocommerce/app/promotions/promotion-update.js
+++ b/client/extensions/woocommerce/app/promotions/promotion-update.js
@@ -135,7 +135,6 @@ class PromotionUpdate extends React.Component {
 					args: { promotion: promotion.name },
 				} ),
 				{
-					displayOnNextPage: true,
 					duration: 8000,
 				}
 			);
@@ -143,9 +142,8 @@ class PromotionUpdate extends React.Component {
 
 		const successAction = dispatch => {
 			this.props.clearPromotionEdits( site.ID );
-
 			dispatch( getSuccessNotice( promotion ) );
-			page.redirect( getLink( '/store/promotions/:site', site ) );
+			this.setState( () => ( { busy: false } ) );
 		};
 
 		const failureAction = dispatch => {


### PR DESCRIPTION
This updates the code to not go back to the list, but stay on the edit
page.

To Test:
1. `npm start`
2. Visit `http://calypso.localhost:3000/store/promotions/<site url>`
3. Select an existing promotion
4. Update a field, click Save.
5. You should still be on the edit page.
