### PR TITLE
Promotions list: Implement search

### DIFF
--- a/client/extensions/woocommerce/app/promotions/index.js
+++ b/client/extensions/woocommerce/app/promotions/index.js
@@ -10,7 +10,6 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -36,6 +35,14 @@ class Promotions extends Component {
 		fetchPromotions: PropTypes.func.isRequired,
 	};
 
+	constructor( props ) {
+		super( props );
+
+		this.state = {
+			searchFilter: '',
+		};
+	}
+
 	componentDidMount() {
 		const { site } = this.props;
 		if ( site && site.ID ) {
@@ -53,13 +60,16 @@ class Promotions extends Component {
 		}
 	}
 
+	onSearch = searchFilter => {
+		this.setState( () => ( { searchFilter } ) );
+	};
+
 	renderSearchCard() {
 		const { site, promotions, translate } = this.props;
 
-		// TODO: Implement onSearch
 		return (
 			<SearchCard
-				onSearch={ noop }
+				onSearch={ this.onSearch }
 				delaySearch
 				delayTimeout={ 400 }
 				disabled={ ! site || ! promotions }
@@ -86,10 +96,12 @@ class Promotions extends Component {
 	}
 
 	renderContent() {
+		const { searchFilter } = this.state;
+
 		return (
 			<div>
 				{ this.renderSearchCard() }
-				<PromotionsList />
+				<PromotionsList searchFilter={ searchFilter } />
 			</div>
 		);
 	}

--- a/client/extensions/woocommerce/app/promotions/promotion-form-type-card.js
+++ b/client/extensions/woocommerce/app/promotions/promotion-form-type-card.js
@@ -16,7 +16,7 @@ import FormSettingExplanation from 'components/forms/form-setting-explanation';
 function getExplanation( promotionType, translate ) {
 	switch ( promotionType ) {
 		case 'product_sale':
-			return translate( 'Put a product on sale for all customers.' );
+			return translate( 'Place a single product on sale for all customers.' );
 		case 'fixed_product':
 			return translate( 'Issue a coupon with a discount for one or more products.' );
 		case 'fixed_cart':
@@ -47,17 +47,17 @@ const PromotionFormTypeCard = ( {
 			<SectionHeader label={ translate( 'Promotion type' ) } />
 			<Card className="promotions__promotion-form-type-card">
 				<FormSelect value={ promotionType } onChange={ onTypeSelect }>
-					<option value="product_sale" disabled={ productTypesDisabled }>
-						{ translate( 'Individual Product Sale' ) }
-					</option>
 					<option value="fixed_product" disabled={ couponTypesDisabled }>
-						{ translate( 'Product Discount' ) }
+						{ translate( 'Product discount coupon' ) }
 					</option>
 					<option value="fixed_cart" disabled={ couponTypesDisabled }>
-						{ translate( 'Cart Discount' ) }
+						{ translate( 'Cart discount coupon' ) }
 					</option>
 					<option value="percent" disabled={ couponTypesDisabled }>
-						{ translate( 'Percent Cart Discount' ) }
+						{ translate( 'Percent cart discount coupon' ) }
+					</option>
+					<option value="product_sale" disabled={ productTypesDisabled }>
+						{ translate( 'Individual product sale' ) }
 					</option>
 				</FormSelect>
 				<FormSettingExplanation>
@@ -80,4 +80,3 @@ PromotionFormTypeCard.PropTypes = {
 };
 
 export default localize( PromotionFormTypeCard );
-

--- a/client/extensions/woocommerce/app/promotions/promotion-form.js
+++ b/client/extensions/woocommerce/app/promotions/promotion-form.js
@@ -93,7 +93,7 @@ export default class PromotionForm extends React.PureComponent {
 		}
 
 		const promotion = this.props.promotion ||
-			{ id: { placeholder: uniqueId( 'promotion_' ) }, type: 'percent' };
+			{ id: { placeholder: uniqueId( 'promotion_' ) }, type: 'fixed_product' };
 
 		return (
 			<div className={ classNames( 'promotions__form', this.props.className ) }>

--- a/client/extensions/woocommerce/app/promotions/promotion-models.js
+++ b/client/extensions/woocommerce/app/promotions/promotion-models.js
@@ -77,12 +77,12 @@ const endDate = {
  */
 const productSaleModel = {
 	productAndSalePrice: {
-		labelText: translate( 'Product & Sale Price' ),
+		labelText: translate( 'Product & sale price' ),
 		cssClass: 'promotions__promotion-form-card-primary',
 		fields: {
 			salePrice: {
 				component: CurrencyField,
-				labelText: translate( 'Product Sale Price' ),
+				labelText: translate( 'Product sale price' ),
 				isRequired: true,
 			},
 			appliesTo: {

--- a/client/extensions/woocommerce/app/promotions/promotions-list-row.js
+++ b/client/extensions/woocommerce/app/promotions/promotions-list-row.js
@@ -47,13 +47,13 @@ function getTimeframeText( promotion, translate, moment ) {
 		} );
 	}
 	if ( promotion.startDate ) {
-		return translate( '%(startDate)s - No expiration date', {
+		return translate( '%(startDate)s - No end date', {
 			args: {
 				startDate: moment( promotion.startDate ).format( 'll' ),
 			},
 		} );
 	}
-	return translate( 'No expiration date' );
+	return translate( 'No end date' );
 }
 
 const PromotionsListRow = ( { site, promotion, translate, moment } ) => {

--- a/client/extensions/woocommerce/app/promotions/promotions-list-row.js
+++ b/client/extensions/woocommerce/app/promotions/promotions-list-row.js
@@ -17,14 +17,14 @@ import TableItem from 'woocommerce/components/table/table-item';
 
 function getPromotionTypeText( promotionType, translate ) {
 	switch ( promotionType ) {
-		case 'product_sale':
-			return translate( 'Product Sale' );
-		case 'fixed_cart':
-			return translate( 'Cart Discount' );
 		case 'fixed_product':
-			return translate( 'Product Discount' );
+			return translate( 'Product discount coupon' );
+		case 'fixed_cart':
+			return translate( 'Cart discount coupon' );
 		case 'percent':
-			return translate( 'Percent Discount' );
+			return translate( 'Percent cart discount coupon' );
+		case 'product_sale':
+			return translate( 'Individual product sale' );
 	}
 }
 

--- a/client/extensions/woocommerce/state/selectors/promotions.js
+++ b/client/extensions/woocommerce/state/selectors/promotions.js
@@ -26,13 +26,11 @@ export function getPromotion(
 }
 
 export function getPromotionsPage(
-	rootState,
-	siteId = getSelectedSiteWithFallback( rootState ),
+	promotions,
 	page,
 	perPage
 ) {
 	const offset = ( page - 1 ) * perPage;
-	const promotions = getPromotions( rootState, siteId );
 	return promotions ? promotions.slice( offset, offset + perPage ) : null;
 }
 

--- a/client/extensions/woocommerce/state/selectors/test/promotions.js
+++ b/client/extensions/woocommerce/state/selectors/test/promotions.js
@@ -76,7 +76,8 @@ describe( 'promotions', () => {
 
 	describe( '#getPromotionsPage', () => {
 		test( 'should return only promotions for a given page.', () => {
-			const page = getPromotionsPage( rootState, 123, 1, 2 );
+			const promotions = getPromotions( rootState, 123 );
+			const page = getPromotionsPage( promotions, 1, 2 );
 
 			expect( page ).to.exist;
 			expect( page.length ).to.equal( 2 );
@@ -85,7 +86,8 @@ describe( 'promotions', () => {
 		} );
 
 		test( 'should advance the offset for pages > 1.', () => {
-			const page = getPromotionsPage( rootState, 123, 2, 2 );
+			const promotions = getPromotions( rootState, 123 );
+			const page = getPromotionsPage( promotions, 2, 2 );
 
 			expect( page ).to.exist;
 			expect( page.length ).to.equal( 1 );
@@ -117,11 +119,9 @@ describe( 'promotions', () => {
 			const editedState = cloneDeep( rootState );
 			editedState.extensions.woocommerce.ui.promotions.edits = {
 				[ 123 ]: {
-					creates: [
-						{ id: 'coupon:4', type: 'empty4' },
-					],
+					creates: [ { id: 'coupon:4', type: 'empty4' } ],
 					currentlyEditingId: 'coupon:4',
-				}
+				},
 			};
 
 			const id = getCurrentlyEditingPromotionId( editedState, 123 );
@@ -140,11 +140,9 @@ describe( 'promotions', () => {
 			const editedState = cloneDeep( rootState );
 			editedState.extensions.woocommerce.ui.promotions.edits = {
 				[ 123 ]: {
-					updates: [
-						{ id: 'coupon:3', type: 'empty33' },
-					],
+					updates: [ { id: 'coupon:3', type: 'empty33' } ],
 					currentlyEditingId: 'coupon:3',
-				}
+				},
 			};
 
 			const edits = getPromotionEdits( editedState, 'coupon:3', 123 );
@@ -174,11 +172,9 @@ describe( 'promotions', () => {
 			const editedState = cloneDeep( rootState );
 			editedState.extensions.woocommerce.ui.promotions.edits = {
 				[ 123 ]: {
-					updates: [
-						{ id: 'coupon:3', type: 'empty33' },
-					],
+					updates: [ { id: 'coupon:3', type: 'empty33' } ],
 					currentlyEditingId: 'coupon:3',
-				}
+				},
 			};
 
 			const editedPromotion = getPromotionWithLocalEdits( editedState, 'coupon:3', 123 );


### PR DESCRIPTION
The search box has been at the top, but nonfunctional. This adds code to
implement the list.
It also adds code to replace "expiration date" copy with "end date" copy.

To Test:
1. `npm start`
2. Visit `http://calypso.localhost:3000/store/promotions/<site url>`
3. Type in the search box and observe it filtering the list