### PR TITLE
Promotion edit: Adjust promotion type text

### DIFF
--- a/client/extensions/woocommerce/app/promotions/promotion-form-type-card.js
+++ b/client/extensions/woocommerce/app/promotions/promotion-form-type-card.js
@@ -16,7 +16,7 @@ import FormSettingExplanation from 'components/forms/form-setting-explanation';
 function getExplanation( promotionType, translate ) {
 	switch ( promotionType ) {
 		case 'product_sale':
-			return translate( 'Put a product on sale for all customers.' );
+			return translate( 'Place a single product on sale for all customers.' );
 		case 'fixed_product':
 			return translate( 'Issue a coupon with a discount for one or more products.' );
 		case 'fixed_cart':
@@ -48,16 +48,16 @@ const PromotionFormTypeCard = ( {
 			<Card className="promotions__promotion-form-type-card">
 				<FormSelect value={ promotionType } onChange={ onTypeSelect }>
 					<option value="fixed_product" disabled={ couponTypesDisabled }>
-						{ translate( 'Product Discount Coupon' ) }
+						{ translate( 'Product discount coupon' ) }
 					</option>
 					<option value="fixed_cart" disabled={ couponTypesDisabled }>
-						{ translate( 'Cart Discount Coupon' ) }
+						{ translate( 'Cart discount coupon' ) }
 					</option>
 					<option value="percent" disabled={ couponTypesDisabled }>
-						{ translate( 'Percent Cart Discount Coupon' ) }
+						{ translate( 'Percent cart discount coupon' ) }
 					</option>
 					<option value="product_sale" disabled={ productTypesDisabled }>
-						{ translate( 'Specific Product Sale' ) }
+						{ translate( 'Individual product sale' ) }
 					</option>
 				</FormSelect>
 				<FormSettingExplanation>
@@ -80,4 +80,3 @@ PromotionFormTypeCard.PropTypes = {
 };
 
 export default localize( PromotionFormTypeCard );
-

--- a/client/extensions/woocommerce/app/promotions/promotion-form-type-card.js
+++ b/client/extensions/woocommerce/app/promotions/promotion-form-type-card.js
@@ -47,17 +47,17 @@ const PromotionFormTypeCard = ( {
 			<SectionHeader label={ translate( 'Promotion type' ) } />
 			<Card className="promotions__promotion-form-type-card">
 				<FormSelect value={ promotionType } onChange={ onTypeSelect }>
-					<option value="product_sale" disabled={ productTypesDisabled }>
-						{ translate( 'Individual Product Sale' ) }
-					</option>
 					<option value="fixed_product" disabled={ couponTypesDisabled }>
-						{ translate( 'Product Discount' ) }
+						{ translate( 'Product Discount Coupon' ) }
 					</option>
 					<option value="fixed_cart" disabled={ couponTypesDisabled }>
-						{ translate( 'Cart Discount' ) }
+						{ translate( 'Cart Discount Coupon' ) }
 					</option>
 					<option value="percent" disabled={ couponTypesDisabled }>
-						{ translate( 'Percent Cart Discount' ) }
+						{ translate( 'Percent Cart Discount Coupon' ) }
+					</option>
+					<option value="product_sale" disabled={ productTypesDisabled }>
+						{ translate( 'Specific Product Sale' ) }
 					</option>
 				</FormSelect>
 				<FormSettingExplanation>

--- a/client/extensions/woocommerce/app/promotions/promotion-form.js
+++ b/client/extensions/woocommerce/app/promotions/promotion-form.js
@@ -93,7 +93,7 @@ export default class PromotionForm extends React.PureComponent {
 		}
 
 		const promotion = this.props.promotion ||
-			{ id: { placeholder: uniqueId( 'promotion_' ) }, type: 'percent' };
+			{ id: { placeholder: uniqueId( 'promotion_' ) }, type: 'fixed_product' };
 
 		return (
 			<div className={ classNames( 'promotions__form', this.props.className ) }>

--- a/client/extensions/woocommerce/app/promotions/promotion-models.js
+++ b/client/extensions/woocommerce/app/promotions/promotion-models.js
@@ -77,12 +77,12 @@ const endDate = {
  */
 const productSaleModel = {
 	productAndSalePrice: {
-		labelText: translate( 'Product & Sale Price' ),
+		labelText: translate( 'Product & sale price' ),
 		cssClass: 'promotions__promotion-form-card-primary',
 		fields: {
 			salePrice: {
 				component: CurrencyField,
-				labelText: translate( 'Product Sale Price' ),
+				labelText: translate( 'Product sale price' ),
 				isRequired: true,
 			},
 			appliesTo: {

--- a/client/extensions/woocommerce/app/promotions/promotions-list-row.js
+++ b/client/extensions/woocommerce/app/promotions/promotions-list-row.js
@@ -18,13 +18,13 @@ import TableItem from 'woocommerce/components/table/table-item';
 function getPromotionTypeText( promotionType, translate ) {
 	switch ( promotionType ) {
 		case 'fixed_product':
-			return translate( 'Product Discount Coupon' );
+			return translate( 'Product discount coupon' );
 		case 'fixed_cart':
-			return translate( 'Cart Discount Coupon' );
+			return translate( 'Cart discount coupon' );
 		case 'percent':
-			return translate( 'Percent Cart Discount Coupon' );
+			return translate( 'Percent cart discount coupon' );
 		case 'product_sale':
-			return translate( 'Specific Product Sale' );
+			return translate( 'Individual product sale' );
 	}
 }
 

--- a/client/extensions/woocommerce/app/promotions/promotions-list-row.js
+++ b/client/extensions/woocommerce/app/promotions/promotions-list-row.js
@@ -17,14 +17,14 @@ import TableItem from 'woocommerce/components/table/table-item';
 
 function getPromotionTypeText( promotionType, translate ) {
 	switch ( promotionType ) {
-		case 'product_sale':
-			return translate( 'Product Sale' );
-		case 'fixed_cart':
-			return translate( 'Cart Discount' );
 		case 'fixed_product':
-			return translate( 'Product Discount' );
+			return translate( 'Product Discount Coupon' );
+		case 'fixed_cart':
+			return translate( 'Cart Discount Coupon' );
 		case 'percent':
-			return translate( 'Percent Discount' );
+			return translate( 'Percent Cart Discount Coupon' );
+		case 'product_sale':
+			return translate( 'Specific Product Sale' );
 	}
 }
 


### PR DESCRIPTION
Addresses #19331

This adjusts the names of the promotion types as they appear in the
selector on the edit form, and in the table under the Type column.

To Test:
1. `npm start`
2. Visit `http://calypso.localhost:3000/store/promotions/<site id>`
3. Observe the types of promotions in the Type column.
4. Click `Add Promotion`
5. Inspect type selection for text.