### PR TITLE
Update/promotion applies to selection

### DIFF
--- a/client/extensions/woocommerce/app/promotions/fields/form-field.js
+++ b/client/extensions/woocommerce/app/promotions/fields/form-field.js
@@ -52,12 +52,16 @@ const FormField = ( {
 		{ 'fields__fieldset-children-enableable': enableCheckbox }
 	);
 
+	const formLabel = ( enableCheckbox || labelText ) && (
+		<FormLabel id={ fieldName + '-label' } required={ isRequired }>
+			{ enableCheckbox }
+			{ labelText }
+		</FormLabel>
+	);
+
 	return (
 		<FormFieldset className="fields__fieldset">
-			<FormLabel id={ fieldName + '-label' } required={ isRequired }>
-				{ enableCheckbox }
-				{ labelText }
-			</FormLabel>
+			{ formLabel }
 			<div className={ childrenClassNames }>
 				{ showChildren && children }
 				{ explanation }
@@ -68,7 +72,7 @@ const FormField = ( {
 
 FormField.PropTypes = {
 	fieldName: PropTypes.string.isRequired,
-	labelText: PropTypes.string.isRequired,
+	labelText: PropTypes.string,
 	explanationText: PropTypes.string,
 	isRequired: PropTypes.bool,
 	isEnableable: PropTypes.bool,

--- a/client/extensions/woocommerce/app/promotions/fields/promotion-applies-to-field/applies-to-filtered-list.js
+++ b/client/extensions/woocommerce/app/promotions/fields/promotion-applies-to-field/applies-to-filtered-list.js
@@ -287,8 +287,13 @@ function mapStateToProps( state ) {
 	const products = getPromotionableProducts( state, siteId );
 	const productCategories = getProductCategories( state, siteId );
 
+	// TODO: This is temporary until we can support variable products.
+	const nonVariableProducts = products && products.filter(
+		( product ) => 'variable' !== product.type
+	);
+
 	return {
-		products,
+		products: nonVariableProducts,
 		productCategories,
 	};
 }

--- a/client/extensions/woocommerce/app/promotions/fields/style.scss
+++ b/client/extensions/woocommerce/app/promotions/fields/style.scss
@@ -75,6 +75,10 @@
 
 	select + .promotion-applies-to-field__filtered-list {
 		margin-top: 16px;
+
+		&:empty {
+			margin-top: 0;
+		}
 	}
 
 	.promotion-applies-to-field__list {

--- a/client/extensions/woocommerce/app/promotions/promotion-models.js
+++ b/client/extensions/woocommerce/app/promotions/promotion-models.js
@@ -41,8 +41,6 @@ const appliesToCouponField = {
 			] }
 		/>
 	),
-	labelText: translate( 'Applies to' ),
-	isRequired: true,
 };
 
 /**
@@ -76,15 +74,10 @@ const endDate = {
  * Promotion Type: Product Sale (e.g. $5 off the "I <3 Robots" t-shirt)
  */
 const productSaleModel = {
-	productAndSalePrice: {
-		labelText: translate( 'Product & sale price' ),
-		cssClass: 'promotions__promotion-form-card-primary',
+	appliesTo: {
+		labelText: translate( 'Applies to product' ),
+		cssClass: 'promotions__promotion-form-card-applies-to',
 		fields: {
-			salePrice: {
-				component: CurrencyField,
-				labelText: translate( 'Product sale price' ),
-				isRequired: true,
-			},
 			appliesTo: {
 				component: (
 					<PromotionAppliesToField
@@ -92,7 +85,16 @@ const productSaleModel = {
 						singular={ true }
 					/>
 				),
-				labelText: translate( 'Applies to product' ),
+			},
+		},
+	},
+	productAndSalePrice: {
+		labelText: translate( 'Product & Sale Price' ),
+		cssClass: 'promotions__promotion-form-card-primary',
+		fields: {
+			salePrice: {
+				component: CurrencyField,
+				labelText: translate( 'Product Sale Price' ),
 				isRequired: true,
 			},
 		}
@@ -150,6 +152,13 @@ const couponConditions = {
  * Promotion Type: Fixed Product Discount (e.g. $5 off any t-shirt)
  */
 const fixedProductModel = {
+	appliesTo: {
+		labelText: translate( 'Applies to' ),
+		cssClass: 'promotions__promotion-form-card-applies-to',
+		fields: {
+			appliesTo: appliesToCouponField,
+		},
+	},
 	couponCodeAndDiscount: {
 		labelText: translate( 'Coupon Code & Discount' ),
 		cssClass: 'promotions__promotion-form-card-primary',
@@ -159,7 +168,6 @@ const fixedProductModel = {
 				...fixedDiscountField,
 				labelText: translate( 'Product Discount', { context: 'noun' } )
 			},
-			appliesTo: appliesToCouponField,
 		},
 	},
 	conditions: couponConditions,
@@ -169,6 +177,13 @@ const fixedProductModel = {
  * Promotion Type: Fixed Cart Discount (e.g. $10 off my cart)
  */
 const fixedCartModel = {
+	appliesTo: {
+		labelText: translate( 'Applies to' ),
+		cssClass: 'promotions__promotion-form-card-applies-to',
+		fields: {
+			appliesTo: appliesToCouponField,
+		},
+	},
 	couponCodeAndDiscount: {
 		labelText: translate( 'Coupon Code & Discount' ),
 		cssClass: 'promotions__promotion-form-card-primary',
@@ -178,7 +193,6 @@ const fixedCartModel = {
 				...fixedDiscountField,
 				labelText: translate( 'Cart Discount', { context: 'noun' } ),
 			},
-			appliesTo: appliesToCouponField,
 		},
 	},
 	conditions: couponConditions,
@@ -188,6 +202,13 @@ const fixedCartModel = {
  * Promotion Type: Percentage Cart Discount (e.g. 10% off my cart)
  */
 const percentCartModel = {
+	appliesTo: {
+		labelText: translate( 'Applies to' ),
+		cssClass: 'promotions__promotion-form-card-applies-to',
+		fields: {
+			appliesTo: appliesToCouponField,
+		},
+	},
 	couponCodeAndDiscount: {
 		labelText: translate( 'Coupon Code & Discount' ),
 		cssClass: 'promotions__promotion-form-card-primary',
@@ -198,7 +219,6 @@ const percentCartModel = {
 				labelText: translate( 'Percent Cart Discount', { context: 'noun' } ),
 				isRequired: true,
 			},
-			appliesTo: appliesToCouponField,
 		},
 	},
 	conditions: couponConditions,

--- a/client/extensions/woocommerce/app/promotions/promotion-models.js
+++ b/client/extensions/woocommerce/app/promotions/promotion-models.js
@@ -45,6 +45,11 @@ const appliesToCoupon = {
 					] }
 				/>
 			),
+			// TODO: Remove this text after variable products are supported.
+			explanationText: translate(
+				'Note: Variable products cannot be selected directly, ' +
+				'only via Product Categories or All Products.'
+			),
 		},
 	},
 };
@@ -74,6 +79,33 @@ const appliesWhenCoupon = {
 						},
 					] }
 				/>
+			),
+			// TODO: Remove this text after variable products are supported.
+			explanationText: translate(
+				'Note: Variable products cannot be selected directly, ' +
+				'only via Product Categories or All Products.'
+			),
+		},
+	},
+};
+
+/**
+ * Product sale "Applies to" card.
+ */
+const appliesToProductSale = {
+	labelText: translate( 'Applies to product' ),
+	cssClass: 'promotions__promotion-form-card-applies-to',
+	fields: {
+		appliesTo: {
+			component: (
+				<PromotionAppliesToField
+					selectionTypes={ [ { type: 'productIds' } ] }
+					singular={ true }
+				/>
+			),
+			// TODO: Remove this text after variable products are supported.
+			explanationText: translate(
+				'Note: Variable products cannot be selected.'
 			),
 		},
 	},
@@ -110,20 +142,7 @@ const endDate = {
  * Promotion Type: Product Sale (e.g. $5 off the "I <3 Robots" t-shirt)
  */
 const productSaleModel = {
-	appliesTo: {
-		labelText: translate( 'Applies to product' ),
-		cssClass: 'promotions__promotion-form-card-applies-to',
-		fields: {
-			appliesTo: {
-				component: (
-					<PromotionAppliesToField
-						selectionTypes={ [ { type: 'productIds' } ] }
-						singular={ true }
-					/>
-				),
-			},
-		},
-	},
+	appliesToProductSale,
 	productAndSalePrice: {
 		labelText: translate( 'Product & Sale Price' ),
 		cssClass: 'promotions__promotion-form-card-primary',

--- a/client/extensions/woocommerce/app/promotions/promotion-models.js
+++ b/client/extensions/woocommerce/app/promotions/promotion-models.js
@@ -29,18 +29,54 @@ const couponCodeField = {
 };
 
 /**
- * "Applies to" field reused for all coupon promotion types.
+ * Coupon "Applies to" card.
  */
-const appliesToCouponField = {
-	component: (
-		<PromotionAppliesToField
-			selectionTypes={ [
-				{ labelText: translate( 'All Products' ), type: 'all' },
-				{ labelText: translate( 'Specific Products' ), type: 'productIds' },
-				{ labelText: translate( 'Product Categories' ), type: 'productCategoryIds' },
-			] }
-		/>
-	),
+const appliesToCoupon = {
+	labelText: translate( 'Applies to' ),
+	cssClass: 'promotions__promotion-form-card-applies-to',
+	fields: {
+		appliesTo: {
+			component: (
+				<PromotionAppliesToField
+					selectionTypes={ [
+						{ labelText: translate( 'All Products' ), type: 'all' },
+						{ labelText: translate( 'Specific Products' ), type: 'productIds' },
+						{ labelText: translate( 'Product Categories' ), type: 'productCategoryIds' },
+					] }
+				/>
+			),
+		},
+	},
+};
+
+/**
+ * Coupon "Applies when" card.
+ */
+const appliesWhenCoupon = {
+	labelText: translate( 'Applies when' ),
+	cssClass: 'promotions__promotion-form-card-applies-to',
+	fields: {
+		appliesTo: {
+			component: (
+				<PromotionAppliesToField
+					selectionTypes={ [
+						{
+							labelText: translate( 'Any product is in the cart' ),
+							type: 'all'
+						},
+						{
+							labelText: translate( 'A specific product is in the cart' ),
+							type: 'productIds'
+						},
+						{
+							labelText: translate( 'A product from a specific category is in the cart' ),
+							type: 'productCategoryIds'
+						},
+					] }
+				/>
+			),
+		},
+	},
 };
 
 /**
@@ -152,13 +188,7 @@ const couponConditions = {
  * Promotion Type: Fixed Product Discount (e.g. $5 off any t-shirt)
  */
 const fixedProductModel = {
-	appliesTo: {
-		labelText: translate( 'Applies to' ),
-		cssClass: 'promotions__promotion-form-card-applies-to',
-		fields: {
-			appliesTo: appliesToCouponField,
-		},
-	},
+	appliesToCoupon,
 	couponCodeAndDiscount: {
 		labelText: translate( 'Coupon Code & Discount' ),
 		cssClass: 'promotions__promotion-form-card-primary',
@@ -177,13 +207,7 @@ const fixedProductModel = {
  * Promotion Type: Fixed Cart Discount (e.g. $10 off my cart)
  */
 const fixedCartModel = {
-	appliesTo: {
-		labelText: translate( 'Applies to' ),
-		cssClass: 'promotions__promotion-form-card-applies-to',
-		fields: {
-			appliesTo: appliesToCouponField,
-		},
-	},
+	appliesWhenCoupon,
 	couponCodeAndDiscount: {
 		labelText: translate( 'Coupon Code & Discount' ),
 		cssClass: 'promotions__promotion-form-card-primary',
@@ -202,13 +226,7 @@ const fixedCartModel = {
  * Promotion Type: Percentage Cart Discount (e.g. 10% off my cart)
  */
 const percentCartModel = {
-	appliesTo: {
-		labelText: translate( 'Applies to' ),
-		cssClass: 'promotions__promotion-form-card-applies-to',
-		fields: {
-			appliesTo: appliesToCouponField,
-		},
-	},
+	appliesWhenCoupon,
 	couponCodeAndDiscount: {
 		labelText: translate( 'Coupon Code & Discount' ),
 		cssClass: 'promotions__promotion-form-card-primary',


### PR DESCRIPTION
Addresses #19330

This moves appliesTo to its own card, and removes the label for the
selector.

**Note: Variable products are excluded from being directly selected for now, until we can support their variations.**

To Test:
1. `npm start`
2. Visit `http://calypso.localhost:3000/store/promotion/<site url>`
3. Try out a coupon type and then the different appliesTo selections to observe the results.
4. Try out a product sale and the singular product selection.

![new_promotion_ _coderkevin_ _wordpress_com](https://user-images.githubusercontent.com/945228/32301564-770bec66-bf2c-11e7-9b40-a6238a56c8c4.png)

![new_promotion_ _coderkevin_ _wordpress_com](https://user-images.githubusercontent.com/945228/32301593-983c3a44-bf2c-11e7-802b-e63fcf07b15e.png)