### PR TITLE
Simple Payments: fix data layer warnings about missing `onError` handler

### DIFF
--- a/client/state/data-layer/wpcom/sites/simple-payments/index.js
+++ b/client/state/data-layer/wpcom/sites/simple-payments/index.js
@@ -4,7 +4,7 @@
  * @format
  */
 
-import { get, toPairs } from 'lodash';
+import { get, noop, toPairs } from 'lodash';
 
 /**
  * Internal dependencies
@@ -155,6 +155,7 @@ export const handleProductGet = dispatchRequestEx( {
 		),
 	fromApi: customPostToProduct,
 	onSuccess: addOrUpdateProduct,
+	onError: noop,
 } );
 
 export const handleProductList = dispatchRequestEx( {
@@ -172,6 +173,7 @@ export const handleProductList = dispatchRequestEx( {
 		),
 	fromApi: customPostsToProducts,
 	onSuccess: replaceProductList,
+	onError: noop,
 } );
 
 export const handleProductListAdd = dispatchRequestEx( {
@@ -186,6 +188,7 @@ export const handleProductListAdd = dispatchRequestEx( {
 		),
 	fromApi: customPostToProduct,
 	onSuccess: addOrUpdateProduct,
+	onError: noop,
 } );
 
 export const handleProductListEdit = dispatchRequestEx( {
@@ -200,6 +203,7 @@ export const handleProductListEdit = dispatchRequestEx( {
 		),
 	fromApi: customPostToProduct,
 	onSuccess: addOrUpdateProduct,
+	onError: noop,
 } );
 
 export const handleProductListDelete = dispatchRequestEx( {
@@ -212,6 +216,7 @@ export const handleProductListDelete = dispatchRequestEx( {
 			action
 		),
 	onSuccess: deleteProduct,
+	onError: noop,
 } );
 
 export default {


### PR DESCRIPTION
Bug introduced in #18733: the new `dispatchRequestEx` function checks if the `onError` handler was passed and issues a console warning if it wasn't.

This PR adds a dummy `onError: noop` handlers to the refactored Simple Payments handlers.

**To test:**
- check that there are warnings in console before this patch is applied:
![data-layer-warnings](https://user-images.githubusercontent.com/664258/32271485-6481d272-befa-11e7-9b27-b9941e8e9806.png)

- check that they all disappear after applying this patch
