### PR TITLE
Components: Improve banner show link indicator logic

### DIFF
--- a/client/components/banner/index.jsx
+++ b/client/components/banner/index.jsx
@@ -184,6 +184,7 @@ class Banner extends Component {
 			dismissPreferenceName,
 			dismissTemporary,
 			plan,
+			price,
 		} = this.props;
 
 		const classes = classNames(
@@ -225,11 +226,14 @@ class Banner extends Component {
 			);
 		}
 
+		const showLinkIndicator = ! callToAction && ! disableHref && ! dismissPreferenceName && ! price;
+
 		return (
 			<Card
 				className={ classes }
 				href={ disableHref || callToAction ? null : this.getHref() }
 				onClick={ callToAction ? noop : this.handleClick }
+				showLinkIndicator={ showLinkIndicator }
 			>
 				{ this.getIcon() }
 				{ this.getContent() }


### PR DESCRIPTION
This PR takes advantage of the `showLinkIndicator` prop of `Card` in order to hide the link indicator in some cases when we don't want it to be shown. Those cases are when the banner matches at least one of the following:

* Has a call to action
* Specifically has the `href` disabled
* Is dismissable
* Has a price specified

Found and reported by @rachelmcr (thanks!) here: https://github.com/Automattic/wp-calypso/pull/19272#issuecomment-341084524. Probably caused by #19333 as a consequence from #19272.

To test:
* Checkout this branch
* Visit http://calypso.localhost:3000/devdocs/design/banner
* Verify link indicators are visible only where expected.