### PR TITLE
Components: Cleanup showLinkIndicator prop from Card

### DIFF
--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -252,11 +252,7 @@ class ReaderPostCard extends React.Component {
 		const followUrl = feed ? feed.feed_URL : post.site_URL;
 
 		return (
-			<Card
-				className={ classes }
-				onClick={ ! isPhotoPost && ! compact && this.handleCardClick }
-				showLinkIndicator={ false }
-			>
+			<Card className={ classes } onClick={ ! isPhotoPost && ! compact && this.handleCardClick }>
 				{ ! compact && postByline }
 				{ showPrimaryFollowButton &&
 				followUrl && (

--- a/client/components/card/index.jsx
+++ b/client/components/card/index.jsx
@@ -18,26 +18,15 @@ class Card extends Component {
 		compact: PropTypes.bool,
 		children: PropTypes.node,
 		highlight: PropTypes.oneOf( [ false, 'error', 'info', 'success', 'warning' ] ),
-		showLinkIndicator: PropTypes.bool,
 	};
 
 	static defaultProps = {
 		tagName: 'div',
 		highlight: false,
-		showLinkIndicator: true,
 	};
 
 	render() {
-		const {
-			children,
-			compact,
-			highlight,
-			href,
-			onClick,
-			showLinkIndicator,
-			tagName,
-			target,
-		} = this.props;
+		const { children, compact, highlight, href, onClick, tagName, target } = this.props;
 
 		const highlightClass = highlight ? 'is-' + highlight : false;
 
@@ -52,16 +41,14 @@ class Card extends Component {
 			highlightClass
 		);
 
-		const omitProps = [ 'compact', 'highlight', 'tagName', 'showLinkIndicator' ];
+		const omitProps = [ 'compact', 'highlight', 'tagName' ];
 
 		let linkIndicator;
-		if ( showLinkIndicator && ( href || onClick ) ) {
+		if ( href ) {
 			linkIndicator = (
 				<Gridicon className="card__link-indicator" icon={ target ? 'external' : 'chevron-right' } />
 			);
-		}
-
-		if ( ! href ) {
+		} else {
 			omitProps.push( 'href', 'target' );
 		}
 

--- a/client/components/card/test/__snapshots__/index.js.snap
+++ b/client/components/card/test/__snapshots__/index.js.snap
@@ -41,7 +41,6 @@ ShallowWrapper {
       "_currentElement": <Card
         highlight={false}
         href="/test"
-        showLinkIndicator={true}
         tagName="div"
       >
         This is a linked card
@@ -56,7 +55,6 @@ ShallowWrapper {
           "children": "This is a linked card",
           "highlight": false,
           "href": "/test",
-          "showLinkIndicator": true,
           "tagName": "div",
         },
         "refs": Object {},
@@ -116,7 +114,6 @@ ShallowWrapper {
   "unrendered": <Card
     highlight={false}
     href="/test"
-    showLinkIndicator={true}
     tagName="div"
   >
     This is a linked card
@@ -148,7 +145,6 @@ ShallowWrapper {
       "_context": Object {},
       "_currentElement": <Card
         highlight={false}
-        showLinkIndicator={true}
         tagName="div"
       />,
       "_debugID": 1,
@@ -159,7 +155,6 @@ ShallowWrapper {
         "context": Object {},
         "props": Object {
           "highlight": false,
-          "showLinkIndicator": true,
           "tagName": "div",
         },
         "refs": Object {},
@@ -202,7 +197,6 @@ ShallowWrapper {
   "root": [Circular],
   "unrendered": <Card
     highlight={false}
-    showLinkIndicator={true}
     tagName="div"
   />,
 }
@@ -233,7 +227,6 @@ ShallowWrapper {
       "_currentElement": <Card
         className="test__ace"
         highlight={false}
-        showLinkIndicator={true}
         tagName="div"
       />,
       "_debugID": 3,
@@ -245,7 +238,6 @@ ShallowWrapper {
         "props": Object {
           "className": "test__ace",
           "highlight": false,
-          "showLinkIndicator": true,
           "tagName": "div",
         },
         "refs": Object {},
@@ -289,7 +281,6 @@ ShallowWrapper {
   "unrendered": <Card
     className="test__ace"
     highlight={false}
-    showLinkIndicator={true}
     tagName="div"
   />,
 }
@@ -323,7 +314,6 @@ ShallowWrapper {
       "_context": Object {},
       "_currentElement": <Card
         highlight={false}
-        showLinkIndicator={true}
         tagName="div"
       >
         This is a card
@@ -337,7 +327,6 @@ ShallowWrapper {
         "props": Object {
           "children": "This is a card",
           "highlight": false,
-          "showLinkIndicator": true,
           "tagName": "div",
         },
         "refs": Object {},
@@ -384,7 +373,6 @@ ShallowWrapper {
   "root": [Circular],
   "unrendered": <Card
     highlight={false}
-    showLinkIndicator={true}
     tagName="div"
   >
     This is a card
@@ -403,14 +391,12 @@ ShallowWrapper {
   "node": <Card
     className="is-compact"
     highlight={false}
-    showLinkIndicator={true}
     tagName="div"
   />,
   "nodes": Array [
     <Card
       className="is-compact"
       highlight={false}
-      showLinkIndicator={true}
       tagName="div"
     />,
   ],
@@ -451,14 +437,12 @@ ShallowWrapper {
         "_currentElement": <Card
           className="is-compact"
           highlight={false}
-          showLinkIndicator={true}
           tagName="div"
         />,
         "_debugID": 10,
         "_renderedOutput": <Card
           className="is-compact"
           highlight={false}
-          showLinkIndicator={true}
           tagName="div"
         />,
       },
@@ -487,14 +471,12 @@ ShallowWrapper {
   "node": <Card
     className="test__ace is-compact"
     highlight={false}
-    showLinkIndicator={true}
     tagName="div"
   />,
   "nodes": Array [
     <Card
       className="test__ace is-compact"
       highlight={false}
-      showLinkIndicator={true}
       tagName="div"
     />,
   ],
@@ -539,14 +521,12 @@ ShallowWrapper {
         "_currentElement": <Card
           className="test__ace is-compact"
           highlight={false}
-          showLinkIndicator={true}
           tagName="div"
         />,
         "_debugID": 12,
         "_renderedOutput": <Card
           className="test__ace is-compact"
           highlight={false}
-          showLinkIndicator={true}
           tagName="div"
         />,
       },
@@ -577,7 +557,6 @@ ShallowWrapper {
   "node": <Card
     className="is-compact"
     highlight={false}
-    showLinkIndicator={true}
     tagName="div"
   >
     This is a compact card
@@ -586,7 +565,6 @@ ShallowWrapper {
     <Card
       className="is-compact"
       highlight={false}
-      showLinkIndicator={true}
       tagName="div"
     >
       This is a compact card
@@ -633,7 +611,6 @@ ShallowWrapper {
         "_currentElement": <Card
           className="is-compact"
           highlight={false}
-          showLinkIndicator={true}
           tagName="div"
         >
           This is a compact card
@@ -642,7 +619,6 @@ ShallowWrapper {
         "_renderedOutput": <Card
           className="is-compact"
           highlight={false}
-          showLinkIndicator={true}
           tagName="div"
         >
           This is a compact card
@@ -675,14 +651,12 @@ ShallowWrapper {
   "node": <Card
     className="is-compact"
     highlight={false}
-    showLinkIndicator={true}
     tagName="div"
   />,
   "nodes": Array [
     <Card
       className="is-compact"
       highlight={false}
-      showLinkIndicator={true}
       tagName="div"
     />,
   ],
@@ -723,14 +697,12 @@ ShallowWrapper {
         "_currentElement": <Card
           className="is-compact"
           highlight={false}
-          showLinkIndicator={true}
           tagName="div"
         />,
         "_debugID": 16,
         "_renderedOutput": <Card
           className="is-compact"
           highlight={false}
-          showLinkIndicator={true}
           tagName="div"
         />,
       },

--- a/client/reader/stream/x-post.jsx
+++ b/client/reader/stream/x-post.jsx
@@ -172,12 +172,7 @@ class CrossPost extends PureComponent {
 		}
 
 		return (
-			<Card
-				tagName="article"
-				onClick={ this.handleCardClick }
-				className={ articleClasses }
-				showLinkIndicator={ false }
-			>
+			<Card tagName="article" onClick={ this.handleCardClick } className={ articleClasses }>
 				<ReaderAvatar
 					siteIcon={ siteIcon }
 					feedIcon={ feedIcon }


### PR DESCRIPTION
This PR removes the newly introduced `showLinkIndicator` prop and fixes the chevron display in clickable cards to only be displayed when we have a `href`, but not when we just have an `onClick`.   This reverts some of what we did in #19272 and #19333 and fixes a bug that was found and reported by @rachelmcr (thanks!) here: #19272 (comment). 

This is an alternative (and a better one) to #19384.

To test:
* Checkout this branch.
* Go to http://calypso.localhost:3000/devdocs/design/banner
* Verify you don't see any unnecessary chevrons in the banners.
* Verify the banners with a `href` have a chevron.
* Go to http://calypso.localhost:3000/devdocs/blocks
* Verify there are no chevrons in any of the reader post cards.
* Go to http://calypso.localhost:3000/settings/manage-connection/:site, where `:site` is a Jetpack site.
* Verify the Disconnect link has a chevron.