### PR TITLE
Update/hide plan in signup

### DIFF
--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -82,6 +82,7 @@ class Signup extends React.Component {
 			user: user.get(),
 			loginHandler: null,
 			hasCartItems: false,
+			plans: false,
 		};
 	}
 
@@ -201,12 +202,19 @@ class Signup extends React.Component {
 	}
 
 	componentWillReceiveProps( { signupDependencies, stepName } ) {
+		const urlPath = location.href;
+		const query = url.parse( urlPath, true ).query;
+
 		if ( this.props.stepName !== stepName ) {
 			this.recordStep( stepName );
 		}
 
 		if ( stepName === this.state.resumingStep ) {
 			this.setState( { resumingStep: undefined } );
+		}
+
+		if ( query.plans ) {
+			this.setState( { plans: true } );
 		}
 
 		this.checkForCartItems( signupDependencies );
@@ -451,10 +459,11 @@ class Signup extends React.Component {
 			stepKey = this.state.loadingScreenStartTime ? 'processing' : this.props.stepName,
 			flow = flows.getFlow( this.props.flowName ),
 			hideFreePlan = !! (
-				this.props.signupDependencies &&
-				this.props.signupDependencies.domainItem &&
-				this.props.signupDependencies.domainItem.is_domain_registration &&
-				this.props.domainsWithPlansOnly
+				this.state.plans ||
+				( this.props.signupDependencies &&
+					this.props.signupDependencies.domainItem &&
+					this.props.signupDependencies.domainItem.is_domain_registration &&
+					this.props.domainsWithPlansOnly )
 			);
 
 		return (


### PR DESCRIPTION
The activation and affiliate teams are looking for a way to hide the free plan in signup. This PR introduces a a query string parameter that hides the free plan (`?plans=true`). Rather than create a whole new flow that does the same thing and needs to be maintained, I thought the query string approach would be less burdensome in the future if there were updates that needed to be made. 

## Testing

First test the signup flow and make sure the free plan shows when you pick a .wordpress subdomain. Then:

- Visit `/start?plans=true`
- proceed to the plans step by picking a .wordpress subdomain
- The free plan should not display

@markryall can you take a look?