### PR TITLE
Fix incorrect stylesheet order for all non-EN locales

### DIFF
--- a/client/lib/i18n-utils/switch-locale.js
+++ b/client/lib/i18n-utils/switch-locale.js
@@ -66,7 +66,7 @@ export function switchCSS( elementId, cssUrl, callback = noop ) {
 		return callback();
 	}
 
-	loadCSS( cssUrl, ( error, newLink ) => {
+	loadCSS( cssUrl, currentLink, ( error, newLink ) => {
 		if ( currentLink && currentLink.parentElement ) {
 			currentLink.parentElement.removeChild( currentLink );
 		}
@@ -80,9 +80,10 @@ export function switchCSS( elementId, cssUrl, callback = noop ) {
 /**
  * Loads a css stylesheet into the page
  * @param {string} cssUrl - a url to a css resource to be inserted into the page
+ * @param {Element} currentLink - a <link> DOM element that we want to use as a reference for stylesheet order
  * @param {Function} callback - a callback function to be called when the CSS has been loaded (after 500ms have passed).
  */
-function loadCSS( cssUrl, callback = noop ) {
+function loadCSS( cssUrl, currentLink = null, callback = noop ) {
 	const link = Object.assign( document.createElement( 'link' ), {
 		rel: 'stylesheet',
 		type: 'text/css',
@@ -102,5 +103,5 @@ function loadCSS( cssUrl, callback = noop ) {
 		setTimeout( onload, 500 );
 	}
 
-	document.head.appendChild( link );
+	document.head.insertBefore( link, currentLink ? currentLink.nextSibling : null );
 }

--- a/client/lib/i18n-utils/switch-locale.js
+++ b/client/lib/i18n-utils/switch-locale.js
@@ -50,9 +50,10 @@ export default function switchLocale( localeSlug ) {
 		if ( typeof document !== 'undefined' ) {
 			document.documentElement.lang = localeSlug;
 			document.documentElement.dir = language.rtl ? 'rtl' : 'ltr';
-			const cssUrl = language.rtl
-				? window.app.staticUrls[ 'style-rtl.css' ]
-				: window.app.staticUrls[ 'style.css' ];
+
+			const directionFlag = language.rtl ? '-rtl' : '';
+			const debugFlag = process.env.NODE_ENV === 'development' ? '-debug' : '';
+			const cssUrl = window.app.staticUrls[ `style${ debugFlag }${ directionFlag }.css` ];
 			switchCSS( 'main-css', cssUrl );
 		}
 	} );

--- a/client/lib/i18n-utils/switch-locale.js
+++ b/client/lib/i18n-utils/switch-locale.js
@@ -83,7 +83,7 @@ export function switchCSS( elementId, cssUrl, callback = noop ) {
  * @param {Element} currentLink - a <link> DOM element that we want to use as a reference for stylesheet order
  * @param {Function} callback - a callback function to be called when the CSS has been loaded (after 500ms have passed).
  */
-function loadCSS( cssUrl, currentLink = null, callback = noop ) {
+function loadCSS( cssUrl, currentLink, callback = noop ) {
 	const link = Object.assign( document.createElement( 'link' ), {
 		rel: 'stylesheet',
 		type: 'text/css',

--- a/package.json
+++ b/package.json
@@ -174,7 +174,7 @@
     "prebuild": "npm run -s install-if-deps-outdated",
     "build": "run-p -s build-devdocs:* build-server build-client-if-prod build-client-if-desktop build-css",
     "build-css": "run-p -s build-css:*",
-    "build-css:debug": "node-sass --include-path client --source-map \"public/style-debug.css.map\" assets/stylesheets/style.scss public/style-debug.css && npm run -s postcss -- public/style-debug.css",
+    "build-css:debug": "node-sass --include-path client --source-map \"public/style-debug.css.map\" assets/stylesheets/style.scss public/style-debug.css && npm run -s postcss -- public/style-debug.css && rtlcss public/style-debug.css public/style-debug-rtl.css",
     "build-css:directly": "node-sass --include-path client assets/stylesheets/directly.scss public/directly.css && npm run -s autoprefixer -- public/directly.css",
     "build-css:editor": "node-sass --include-path client assets/stylesheets/editor.scss public/editor.css && npm run -s autoprefixer -- public/editor.css",
     "build-css:style": "node-sass --include-path client assets/stylesheets/style.scss public/style.css && npm run -s postcss -- public/style.css && rtlcss public/style.css public/style-rtl.css",

--- a/server/pages/browsehappy.jade
+++ b/server/pages/browsehappy.jade
@@ -40,12 +40,15 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class=isFluidWidth ? 'is-fluid-width'
 		link(rel='stylesheet', href='https://fonts.googleapis.com/css?family=Noto+Serif:400,400i,700,700i&subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext,vietnamese')
 		link(rel='stylesheet', href='//s1.wp.com/i/noticons/noticons.css?v=20150727')
 		if isRTL
-			link(rel='stylesheet', href=urls['style-rtl.css'])
+			if 'development' === env || isDebug
+				link(rel='stylesheet', id='main-css', href=urls['style-debug-rtl.css'])
+			else
+				link(rel='stylesheet', id='main-css', href=urls['style-rtl.css'])
 		else
 			if 'development' === env || isDebug
-				link(rel='stylesheet', href=urls['style-debug.css'])
+				link(rel='stylesheet', id='main-css', href=urls['style-debug.css'])
 			else
-				link(rel='stylesheet', href=urls['style.css'])
+				link(rel='stylesheet', id='main-css', href=urls['style.css'])
 
 	body(class=isRTL ? 'rtl' : '')
 		#wpcom.wpcom-site

--- a/server/pages/desktop.jade
+++ b/server/pages/desktop.jade
@@ -14,12 +14,15 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class='is-desktop' + ( isFluidWidth ?
 		link(rel='stylesheet', href='https://fonts.googleapis.com/css?family=Noto+Serif:400,400i,700,700i&subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext,vietnamese')
 		link(rel='stylesheet', href='//s1.wp.com/i/noticons/noticons.css?v=20150727')
 		if isRTL
-			link(rel='stylesheet', href=urls['style-rtl.css'])
+			if 'development' === env || isDebug
+				link(rel='stylesheet', id='main-css', href=urls['style-debug-rtl.css'])
+			else
+				link(rel='stylesheet', id='main-css', href=urls['style-rtl.css'])
 		else
 			if 'development' === env || isDebug
-				link(rel='stylesheet', href=urls['style-debug.css'])
+				link(rel='stylesheet', id='main-css', href=urls['style-debug.css'])
 			else
-				link(rel='stylesheet', href=urls['style.css'])
+				link(rel='stylesheet', id='main-css', href=urls['style.css'])
 		link(rel='stylesheet', href='/desktop/wordpress-desktop.css')
 	body(class=isRTL ? 'rtl' : '')
 		#wpcom.wpcom-site

--- a/server/pages/index.jade
+++ b/server/pages/index.jade
@@ -69,6 +69,7 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class=isFluidWidth ? 'is-fluid-width'
 				link(rel='stylesheet', id='main-css', href=urls['style-debug-rtl.css'])
 			else
 				link(rel='stylesheet', id='main-css', href=urls['style-rtl.css'])
+
 			if sectionCssRtl
 				link(rel='stylesheet', id='section-css', href=sectionCssRtl)
 		else
@@ -118,12 +119,15 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class=isFluidWidth ? 'is-fluid-width'
 
 		if shouldUseStylePreloadCommon
 			if isRTL
-				link(rel='preload' as='style' href=urls['style-rtl.css'])
+				if 'development' === env || isDebug
+					link(rel='preload', as='style', href=urls['style-debug-rtl.css'])
+				else
+					link(rel='preload', as='style', href=urls['style-rtl.css'])
 			else
 				if 'development' === env || isDebug
-					link(rel='preload' as='style' href=urls['style-debug.css'])
+					link(rel='preload', as='style', href=urls['style-debug.css'])
 				else
-					link(rel='preload' as='style' href=urls['style.css'])
+					link(rel='preload', as='style', href=urls['style.css'])
 
 		if shouldUseScriptPreload
 			//- Preload our scripts

--- a/server/pages/index.jade
+++ b/server/pages/index.jade
@@ -43,7 +43,7 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class=isFluidWidth ? 'is-fluid-width'
 			link(rel='apple-touch-icon', sizes='144x144', href='//s0.wp.com/i/favicons/apple-touch-icon-144x144.png')
 			link(rel='apple-touch-icon', sizes='152x152', href='//s0.wp.com/i/favicons/apple-touch-icon-152x152.png')
 			link(rel='apple-touch-icon', sizes='180x180', href='//s0.wp.com/i/favicons/apple-touch-icon-180x180.png')
-		else 
+		else
 			link(rel='icon', type='image/png', href='//s1.wp.com/i/favicons/favicon-64x64.png', sizes='64x64')
 			link(rel='icon', type='image/png', href='//s1.wp.com/i/favicons/favicon-96x96.png', sizes='96x96')
 			link(rel='icon', type='image/png', href='//s1.wp.com/i/favicons/android-chrome-192x192.png', sizes='192x192')
@@ -58,14 +58,17 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class=isFluidWidth ? 'is-fluid-width'
 			link(rel='apple-touch-icon', sizes='180x180', href='//s1.wp.com/i/favicons/apple-touch-icon-180x180.png')
 		link(rel='profile', href='http://gmpg.org/xfn/11')
 		link(rel='manifest', href='/calypso/manifest.json')
-		
+
 		link(rel='stylesheet', href='https://fonts.googleapis.com/css?family=Noto+Serif:400,400i,700,700i&subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext,vietnamese')
 		if shouldUseSingleCDN
 			link(rel='stylesheet', href='//s0.wp.com/i/noticons/noticons.css?v=20150727')
-		else 
+		else
 			link(rel='stylesheet', href='//s1.wp.com/i/noticons/noticons.css?v=20150727')
 		if isRTL
-			link(rel='stylesheet', id='main-css', href=urls['style-rtl.css'])
+			if 'development' === env || isDebug
+				link(rel='stylesheet', id='main-css', href=urls['style-debug-rtl.css'])
+			else
+				link(rel='stylesheet', id='main-css', href=urls['style-rtl.css'])
 			if sectionCssRtl
 				link(rel='stylesheet', id='section-css', href=sectionCssRtl)
 		else
@@ -76,20 +79,20 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class=isFluidWidth ? 'is-fluid-width'
 
 			if sectionCss
 				link(rel='stylesheet', id='section-css', href=sectionCss)
-		
+
 		if shouldUsePreconnect
 			//- Preconnect to our CDN hosts
 			link(rel='preconnect' href='//s0.wp.com')
 			if ! shouldUseSingleCDN
 				link(rel='preconnect' href='//s1.wp.com')
-			
+
 			//- Preconnect to our API.
 			link(rel='preconnect' href='https://public-api.wordpress.com')
-			
+
 			//- Preconnect for analytics scripts.
 			link(rel='preconnect' href='//stats.wp.com')
 			link(rel='preconnect' href='https://www.google-analytics.com')
-			
+
 			//- Preconnect for Google domains - especially useful for SSO.
 			if shouldUsePreconnectGoogle
 				link(rel='preconnect' href='https://google.com')
@@ -102,7 +105,7 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class=isFluidWidth ? 'is-fluid-width'
 			link(rel='preload' as='style' href='https://fonts.googleapis.com/css?family=Noto+Serif:400,400i,700,700i&subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext,vietnamese')
 			if shouldUseSingleCDN
 				link(rel='preload' as='style' href='//s0.wp.com/i/noticons/noticons.css?v=20150727')
-			else 
+			else
 				link(rel='preload' as='style' href='//s1.wp.com/i/noticons/noticons.css?v=20150727')
 
 		if shouldUseStylePreloadSection
@@ -112,7 +115,7 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class=isFluidWidth ? 'is-fluid-width'
 			else
 				if sectionCss
 					link(rel='preload' as='style' href=sectionCss)
-		
+
 		if shouldUseStylePreloadCommon
 			if isRTL
 				link(rel='preload' as='style' href=urls['style-rtl.css'])

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -37,6 +37,7 @@ const staticFiles = [
 	{ path: 'tinymce/skins/wordpress/wp-content.css' },
 	{ path: 'style-debug.css' },
 	{ path: 'style-rtl.css' },
+	{ path: 'style-debug-rtl.css' },
 ];
 
 const staticFilesUrls = staticFiles.reduce( ( result, file ) => {


### PR DESCRIPTION
This PR makes sure that dynamically loaded CSS is always loaded in intended order.

We had a bug in our codebase that could cause wrong order of stylesheets. That lead to overriding specific section styles (for example post-editor.css) by the general style.css. It looked like this for example:
 
<img width="1173" alt="screen shot 2017-11-01 at 14 14 34" src="https://user-images.githubusercontent.com/156676/32320977-f1ace680-bfbf-11e7-9c71-81bafcd0d25a.png">

The bug was race-conditioned and most importantly, was only reproducible in development in all locales other than English and also in production for RTL languages. 

The biggest problem was that all dynamically loaded stylesheets were appended to the bottom of `<head>`, regardless of needed order. This PR changes it in a way, that new CSS is inserted right after the original `<link rel="stylesheet">` that the new CSS is replacing. This way, we always have general application-wid CSS first and specific section CSS after it.