### PR TITLE
Reader Full Post: when posting to a moderated comment thread, show the unapproved comment immediately after posting

### DIFF
--- a/client/blocks/comments/comments-filters.js
+++ b/client/blocks/comments/comments-filters.js
@@ -1,0 +1,2 @@
+/** @format */
+export const COMMENTS_FILTER_ALL = 'all';

--- a/client/blocks/comments/post-comment-list.jsx
+++ b/client/blocks/comments/post-comment-list.jsx
@@ -55,6 +55,11 @@ class PostCommentList extends React.Component {
 		commentCount: PropTypes.number,
 		maxDepth: PropTypes.number,
 		showNestingReplyArrow: PropTypes.bool,
+		commentsFilter: PropTypes.string,
+
+		// To display comments with a different status but not fetch them
+		// e.g. Reader full post view showing unapproved comments made to a moderated site
+		commentsFilterDisplay: PropTypes.string,
 
 		// connect()ed props:
 		commentsTree: PropTypes.object,
@@ -453,7 +458,7 @@ export default connect(
 			state,
 			ownProps.post.site_ID,
 			ownProps.post.ID,
-			ownProps.commentsFilter
+			ownProps.commentsFilterDisplay ? ownProps.commentsFilterDisplay : ownProps.commentsFilter
 		),
 		commentsFetchingStatus: commentsFetchingStatus(
 			state,

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -70,6 +70,7 @@ import { getLastStore } from 'reader/controller-helper';
 import { showSelectedPost } from 'reader/utils';
 import Emojify from 'components/emojify';
 import config from 'config';
+import { COMMENTS_FILTER_ALL } from 'blocks/comments/comments-filters';
 
 export class FullPostView extends React.Component {
 	static propTypes = {
@@ -439,7 +440,7 @@ export class FullPostView extends React.Component {
 							) }
 
 							<div className="reader-full-post__comments-wrapper" ref="commentsWrapper">
-								{ shouldShowComments( post ) ? (
+								{ shouldShowComments( post ) && (
 									<Comments
 										showNestingReplyArrow={ config.isEnabled( 'reader/nesting-arrow' ) }
 										ref="commentsList"
@@ -449,8 +450,9 @@ export class FullPostView extends React.Component {
 										startingCommentId={ startingCommentId }
 										commentCount={ commentCount }
 										maxDepth={ 1 }
+										commentsFilterDisplay={ COMMENTS_FILTER_ALL }
 									/>
-								) : null }
+								) }
 							</div>
 
 							{ showRelatedPosts && (


### PR DESCRIPTION
This is a fix for #19359, in which any comment posted by the user to a moderated comment thread vanishes after posting.

PostCommentList accepts a `commentsFilter` argument, which we can set to 'all' to show comments with all statuses. Unfortunately this also attempts to fetch unapproved comments from the API, which 403s for regular users.

I've added a new prop, `commentsFilterDisplay`, which will be used instead of `commentsFilter` to get the post comments tree when available, without firing off API requests.

Fixes #19359.

### To test

Visit http://calypso.localhost:3000/read/feeds/40474296/posts/1385874605 and make a new comment. The comment should not vanish after posting, and should look like this:

<img width="314" alt="screen shot 2017-11-01 at 15 56 25" src="https://user-images.githubusercontent.com/17325/32283782-3f523a46-bf1d-11e7-9b47-1807426d0878.png">

