### PR TITLE
Decouple Happychat UI components

### DIFF
--- a/client/components/emojify/index.jsx
+++ b/client/components/emojify/index.jsx
@@ -3,25 +3,25 @@
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
 import classNames from 'classnames';
-
-/**
- * Internal dependencies
- */
 import twemoji from 'twemoji';
-import config from 'config';
 
 export default class Emojify extends PureComponent {
 	static propTypes = {
 		imgClassName: PropTypes.string,
+		twemojiUrl: PropTypes.string,
 	};
 
 	static defaultProps = {
 		imgClassName: 'emojify__emoji',
 	};
+
+	constructor( props ) {
+		super( props );
+		this.setRef = this.setRef.bind( this );
+	}
 
 	componentDidMount() {
 		this.parseEmoji();
@@ -31,11 +31,15 @@ export default class Emojify extends PureComponent {
 		this.parseEmoji();
 	}
 
-	parseEmoji = () => {
-		const { imgClassName } = this.props;
+	setRef( component ) {
+		this.emojified = component;
+	}
 
-		twemoji.parse( this.refs.emojified, {
-			base: config( 'twemoji_cdn_url' ),
+	parseEmoji = () => {
+		const { imgClassName, twemojiUrl } = this.props;
+
+		twemoji.parse( this.emojified, {
+			base: twemojiUrl,
 			size: '72x72',
 			className: imgClassName,
 			callback: function( icon, options ) {
@@ -51,17 +55,14 @@ export default class Emojify extends PureComponent {
 	};
 
 	render() {
-		const {
-			children,
-			className,
-			imgClassName, // eslint-disable-line no-unused-vars
-			...other
-		} = this.props;
+		// We want other props to content everything but children, className, imgClassName, and twemojiUrl.
+		// We can't delete imgClassName and twemojiUrl despite they not being used here.
+		const { children, className, imgClassName, twemojiUrl, ...other } = this.props; // eslint-disable-line no-unused-vars
 
 		const classes = classNames( className, 'emojify' );
 
 		return (
-			<div className={ classes } ref="emojified" { ...other }>
+			<div className={ classes } ref={ this.setRef } { ...other }>
 				{ children }
 			</div>
 		);

--- a/client/components/emojify/test/emojify.jsx
+++ b/client/components/emojify/test/emojify.jsx
@@ -13,13 +13,17 @@ import React from 'react';
 /**
  * Internal dependencies
  */
+import config from 'config';
 import Emojify from '..';
 
 describe( 'Emojify', () => {
 	describe( 'component rendering', () => {
+		const twemojiUrl = config( 'twemoji_cdn_url' );
 		test( 'wraps a string in a div', () => {
-			const wrapper = shallow( <Emojify>Foo</Emojify>, { disableLifecycleMethods: true } );
-			expect( wrapper.find( 'div' ).getElement().ref ).to.equal( 'emojified' );
+			const wrapper = shallow( <Emojify>Foo</Emojify>, {
+				disableLifecycleMethods: true,
+			} );
+			expect( wrapper.html() ).to.equal( '<div class="emojify">Foo</div>' );
 		} );
 
 		test( 'wraps a block in a div', () => {
@@ -29,11 +33,11 @@ describe( 'Emojify', () => {
 				</Emojify>,
 				{ disableLifecycleMethods: true }
 			);
-			expect( wrapper.find( 'div' ).getElement().ref ).to.equal( 'emojified' );
+			expect( wrapper.html() ).to.equal( '<div class="emojify"><p>Bar</p></div>' );
 		} );
 
 		test( 'replaces emoji in a string', () => {
-			const wrapper = mount( <Emojify>🙂</Emojify> );
+			const wrapper = mount( <Emojify twemojiUrl={ twemojiUrl }>🙂</Emojify> );
 
 			expect( wrapper.html() ).to.equal(
 				'<div class="emojify"><img draggable="false" class="emojify__emoji" alt="🙂" ' +
@@ -43,7 +47,7 @@ describe( 'Emojify', () => {
 
 		test( 'replaces emoji in a block', () => {
 			const wrapper = mount(
-				<Emojify>
+				<Emojify twemojiUrl={ twemojiUrl }>
 					<p>🧔🏻</p>
 				</Emojify>
 			);

--- a/client/components/happiness-support/index.jsx
+++ b/client/components/happiness-support/index.jsx
@@ -17,7 +17,7 @@ import Button from 'components/button';
 import isHappychatAvailable from 'state/happychat/selectors/is-happychat-available';
 import support from 'lib/url/support';
 import HappychatButton from 'components/happychat/button';
-import HappychatConnection from 'components/happychat/connection';
+import HappychatConnection from 'components/happychat/connection-connected';
 import { recordTracksEvent } from 'state/analytics/actions';
 
 export class HappinessSupport extends Component {

--- a/client/components/happiness-support/test/index.jsx
+++ b/client/components/happiness-support/test/index.jsx
@@ -13,7 +13,7 @@ import { spy } from 'sinon';
  */
 import { HappinessSupport } from '..';
 import HappychatButton from 'components/happychat/button';
-import HappychatConnection from 'components/happychat/connection';
+import HappychatConnection from 'components/happychat/connection-connected';
 import support from 'lib/url/support';
 
 describe( 'HappinessSupport', () => {

--- a/client/components/happychat/composer.jsx
+++ b/client/components/happychat/composer.jsx
@@ -7,22 +7,16 @@ import classNames from 'classnames';
 import React from 'react';
 import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
 import { get, isEmpty, throttle } from 'lodash';
-import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
-import { sendMessage, sendTyping, sendNotTyping } from 'state/happychat/connection/actions';
-import { setCurrentMessage } from 'state/happychat/ui/actions';
-import getCurrentMessage from 'state/happychat/selectors/get-happychat-current-message';
-import canUserSendMessages from 'state/happychat/selectors/can-user-send-messages';
 import scrollbleed from './scrollbleed';
 
 const sendThrottledTyping = throttle(
-	( dispatch, msg ) => {
-		dispatch( sendTyping( msg ) );
+	( onSendTyping, msg ) => {
+		onSendTyping( msg );
 	},
 	1000,
 	{ leading: true, trailing: false }
@@ -51,7 +45,7 @@ export const Composer = createReactClass( {
 
 		const msg = get( event, 'target.value' );
 		onSetCurrentMessage( msg );
-		isEmpty( msg ) ? onSendNotTyping() : onSendTyping( msg );
+		isEmpty( msg ) ? onSendNotTyping() : sendThrottledTyping( onSendTyping, msg );
 	},
 
 	onKeyDown( event ) {
@@ -103,25 +97,3 @@ export const Composer = createReactClass( {
 		);
 	},
 } );
-
-const mapState = state => ( {
-	disabled: ! canUserSendMessages( state ),
-	message: getCurrentMessage( state ),
-} );
-
-const mapDispatch = dispatch => ( {
-	onSendTyping( msg ) {
-		sendThrottledTyping( dispatch, msg );
-	},
-	onSendNotTyping() {
-		dispatch( sendNotTyping() );
-	},
-	onSendMessage( msg ) {
-		dispatch( sendMessage( msg ) );
-	},
-	onSetCurrentMessage( msg ) {
-		dispatch( setCurrentMessage( msg ) );
-	},
-} );
-
-export default connect( mapState, mapDispatch )( localize( Composer ) );

--- a/client/components/happychat/connection-connected.jsx
+++ b/client/components/happychat/connection-connected.jsx
@@ -1,0 +1,24 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import config from 'config';
+import { getHappychatAuth } from 'state/happychat/utils';
+import isHappychatConnectionUninitialized from 'state/happychat/selectors/is-happychat-connection-uninitialized';
+import { initConnection } from 'state/happychat/connection/actions';
+import { HappychatConnection } from 'components/happychat/connection';
+
+export default connect(
+	state => ( {
+		getAuth: getHappychatAuth( state ),
+		isConnectionUninitialized: isHappychatConnectionUninitialized( state ),
+		isHappychatEnabled: config.isEnabled( 'happychat' ),
+	} ),
+	{ initConnection }
+)( HappychatConnection );

--- a/client/components/happychat/connection.jsx
+++ b/client/components/happychat/connection.jsx
@@ -5,15 +5,6 @@
  */
 import { Component } from 'react';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
-
-/**
- * Internal dependencies
- */
-import config from 'config';
-import { getHappychatAuth } from 'state/happychat/utils';
-import isHappychatConnectionUninitialized from 'state/happychat/selectors/is-happychat-connection-uninitialized';
-import { initConnection } from 'state/happychat/connection/actions';
 
 export class HappychatConnection extends Component {
 	componentDidMount() {
@@ -33,12 +24,3 @@ HappychatConnection.propTypes = {
 	isHappychatEnabled: PropTypes.bool,
 	initConnection: PropTypes.func,
 };
-
-export default connect(
-	state => ( {
-		getAuth: getHappychatAuth( state ),
-		isConnectionUninitialized: isHappychatConnectionUninitialized( state ),
-		isHappychatEnabled: config.isEnabled( 'happychat' ),
-	} ),
-	{ initConnection }
-)( HappychatConnection );

--- a/client/components/happychat/index.jsx
+++ b/client/components/happychat/index.jsx
@@ -14,7 +14,7 @@ import classnames from 'classnames';
 import { blur, focus, closeChat, minimizeChat, minimizedChat } from 'state/happychat/ui/actions';
 import isHappychatMinimizing from 'state/happychat/selectors/is-happychat-minimizing';
 import isHappychatOpen from 'state/happychat/selectors/is-happychat-open';
-import HappychatConnection from './connection';
+import HappychatConnection from './connection-connected';
 import Title from './title';
 import Composer from './composer';
 import Notices from './notices';

--- a/client/components/happychat/index.jsx
+++ b/client/components/happychat/index.jsx
@@ -12,6 +12,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import config from 'config';
 // actions
 import { sendMessage, sendNotTyping, sendTyping } from 'state/happychat/connection/actions';
 import {
@@ -78,6 +79,7 @@ export class Happychat extends Component {
 			onSetCurrentMessage,
 			timeline,
 			translate,
+			twemojiUrl,
 		} = this.props;
 
 		return (
@@ -95,6 +97,7 @@ export class Happychat extends Component {
 						isCurrentUser={ isCurrentUser }
 						timeline={ timeline }
 						translate={ translate }
+						twemojiUrl={ twemojiUrl }
 					/>
 					<Notices
 						chatStatus={ chatStatus }
@@ -123,7 +126,7 @@ Happychat.propTypes = {
 	currentUserEmail: PropTypes.string,
 	disabled: PropTypes.bool,
 	isChatOpen: PropTypes.bool,
-	isCurrentUser: PropTypes.bool,
+	isCurrentUser: PropTypes.func,
 	isMinimizing: PropTypes.bool,
 	isServerReachable: PropTypes.bool,
 	message: PropTypes.string,
@@ -138,6 +141,7 @@ Happychat.propTypes = {
 	setFocused: PropTypes.func,
 	timeline: PropTypes.array,
 	translate: PropTypes.func,
+	twemojiUrl: PropTypes.string,
 };
 
 const isCurrentUserHelper = currentUser => ( { user_id, source } ) => {
@@ -157,6 +161,7 @@ const mapState = state => {
 		isServerReachable: isHappychatServerReachable( state ),
 		message: getCurrentMessage( state ),
 		timeline: getHappychatTimeline( state ),
+		twemojiUrl: config( 'twemoji_cdn_url' ),
 	};
 };
 

--- a/client/components/happychat/index.jsx
+++ b/client/components/happychat/index.jsx
@@ -13,6 +13,7 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import config from 'config';
+import { isExternal } from 'lib/url';
 // actions
 import { sendMessage, sendNotTyping, sendTyping } from 'state/happychat/connection/actions';
 import {
@@ -70,6 +71,7 @@ export class Happychat extends Component {
 			disabled,
 			isChatOpen,
 			isCurrentUser,
+			isExternalUrl,
 			isMinimizing,
 			isServerReachable,
 			message,
@@ -95,6 +97,7 @@ export class Happychat extends Component {
 					<Timeline
 						currentUserEmail={ currentUserEmail }
 						isCurrentUser={ isCurrentUser }
+						isExternalUrl={ isExternalUrl }
 						timeline={ timeline }
 						translate={ translate }
 						twemojiUrl={ twemojiUrl }
@@ -127,6 +130,7 @@ Happychat.propTypes = {
 	disabled: PropTypes.bool,
 	isChatOpen: PropTypes.bool,
 	isCurrentUser: PropTypes.func,
+	isExternalUrl: PropTypes.func,
 	isMinimizing: PropTypes.bool,
 	isServerReachable: PropTypes.bool,
 	message: PropTypes.string,
@@ -157,6 +161,7 @@ const mapState = state => {
 		disabled: ! canUserSendMessages( state ),
 		isChatOpen: isHappychatOpen( state ),
 		isCurrentUser: isCurrentUserHelper( currentUser ), // see redux-no-bound-selectors eslint-rule
+		isExternalUrl: isExternal,
 		isMinimizing: isHappychatMinimizing( state ),
 		isServerReachable: isHappychatServerReachable( state ),
 		message: getCurrentMessage( state ),

--- a/client/components/happychat/index.jsx
+++ b/client/components/happychat/index.jsx
@@ -7,6 +7,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import classnames from 'classnames';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -15,7 +16,7 @@ import { blur, focus, closeChat, minimizeChat, minimizedChat } from 'state/happy
 import isHappychatMinimizing from 'state/happychat/selectors/is-happychat-minimizing';
 import isHappychatOpen from 'state/happychat/selectors/is-happychat-open';
 import HappychatConnection from './connection-connected';
-import Title from './title';
+import { Title } from './title';
 import Composer from './composer';
 import Notices from './notices';
 import Timeline from './timeline';
@@ -43,7 +44,7 @@ export class Happychat extends Component {
 	};
 
 	render() {
-		const { isChatOpen, isMinimizing } = this.props;
+		const { isChatOpen, isMinimizing, translate } = this.props;
 
 		return (
 			<div className="happychat">
@@ -54,7 +55,7 @@ export class Happychat extends Component {
 						'is-minimizing': isMinimizing,
 					} ) }
 				>
-					<Title onCloseChat={ this.onCloseChatTitle } />
+					<Title onCloseChat={ this.onCloseChatTitle } translate={ translate } />
 					<Timeline />
 					<Notices />
 					<Composer />
@@ -101,4 +102,4 @@ const mapDispatch = dispatch => {
 	};
 };
 
-export default connect( mapState, mapDispatch )( Happychat );
+export default connect( mapState, mapDispatch )( localize( Happychat ) );

--- a/client/components/happychat/index.jsx
+++ b/client/components/happychat/index.jsx
@@ -24,9 +24,11 @@ import {
 } from 'state/happychat/ui/actions';
 // selectors
 import canUserSendMessages from 'state/happychat/selectors/can-user-send-messages';
+import { getCurrentUser } from 'state/current-user/selectors';
 import getCurrentMessage from 'state/happychat/selectors/get-happychat-current-message';
 import getHappychatChatStatus from 'state/happychat/selectors/get-happychat-chat-status';
 import getHappychatConnectionStatus from 'state/happychat/selectors/get-happychat-connection-status';
+import getHappychatTimeline from 'state/happychat/selectors/get-happychat-timeline';
 import isHappychatMinimizing from 'state/happychat/selectors/is-happychat-minimizing';
 import isHappychatOpen from 'state/happychat/selectors/is-happychat-open';
 import isHappychatServerReachable from 'state/happychat/selectors/is-happychat-server-reachable';
@@ -35,7 +37,7 @@ import HappychatConnection from './connection-connected';
 import { Title } from './title';
 import { Composer } from './composer';
 import { Notices } from './notices';
-import Timeline from './timeline';
+import { Timeline } from './timeline';
 
 /*
  * Main chat UI component
@@ -63,8 +65,10 @@ export class Happychat extends Component {
 		const {
 			chatStatus,
 			connectionStatus,
+			currentUserEmail,
 			disabled,
 			isChatOpen,
+			isCurrentUser,
 			isMinimizing,
 			isServerReachable,
 			message,
@@ -72,6 +76,7 @@ export class Happychat extends Component {
 			onSendNotTyping,
 			onSendTyping,
 			onSetCurrentMessage,
+			timeline,
 			translate,
 		} = this.props;
 
@@ -85,7 +90,12 @@ export class Happychat extends Component {
 					} ) }
 				>
 					<Title onCloseChat={ this.onCloseChatTitle } translate={ translate } />
-					<Timeline />
+					<Timeline
+						currentUserEmail={ currentUserEmail }
+						isCurrentUser={ isCurrentUser }
+						timeline={ timeline }
+						translate={ translate }
+					/>
 					<Notices
 						chatStatus={ chatStatus }
 						connectionStatus={ connectionStatus }
@@ -113,6 +123,7 @@ Happychat.propTypes = {
 	currentUserEmail: PropTypes.string,
 	disabled: PropTypes.bool,
 	isChatOpen: PropTypes.bool,
+	isCurrentUser: PropTypes.bool,
 	isMinimizing: PropTypes.bool,
 	isServerReachable: PropTypes.bool,
 	message: PropTypes.string,
@@ -125,18 +136,29 @@ Happychat.propTypes = {
 	onSetCurrentMessage: PropTypes.func,
 	setBlurred: PropTypes.func,
 	setFocused: PropTypes.func,
+	timeline: PropTypes.array,
 	translate: PropTypes.func,
 };
 
-const mapState = state => ( {
-	chatStatus: getHappychatChatStatus( state ),
-	connectionStatus: getHappychatConnectionStatus( state ),
-	disabled: ! canUserSendMessages( state ),
-	isChatOpen: isHappychatOpen( state ),
-	isMinimizing: isHappychatMinimizing( state ),
-	isServerReachable: isHappychatServerReachable( state ),
-	message: getCurrentMessage( state ),
-} );
+const isCurrentUserHelper = currentUser => ( { user_id, source } ) => {
+	return user_id.toString() === currentUser.ID.toString() && source === 'customer';
+};
+
+const mapState = state => {
+	const currentUser = getCurrentUser( state );
+	return {
+		chatStatus: getHappychatChatStatus( state ),
+		connectionStatus: getHappychatConnectionStatus( state ),
+		currentUserEmail: currentUser.email,
+		disabled: ! canUserSendMessages( state ),
+		isChatOpen: isHappychatOpen( state ),
+		isCurrentUser: isCurrentUserHelper( currentUser ), // see redux-no-bound-selectors eslint-rule
+		isMinimizing: isHappychatMinimizing( state ),
+		isServerReachable: isHappychatServerReachable( state ),
+		message: getCurrentMessage( state ),
+		timeline: getHappychatTimeline( state ),
+	};
+};
 
 const mapDispatch = {
 	onCloseChat: closeChat,

--- a/client/components/happychat/index.jsx
+++ b/client/components/happychat/index.jsx
@@ -148,7 +148,7 @@ Happychat.propTypes = {
 	twemojiUrl: PropTypes.string,
 };
 
-const isCurrentUserHelper = currentUser => ( { user_id, source } ) => {
+const isMessageFromCurrentUser = currentUser => ( { user_id, source } ) => {
 	return user_id.toString() === currentUser.ID.toString() && source === 'customer';
 };
 
@@ -160,7 +160,7 @@ const mapState = state => {
 		currentUserEmail: currentUser.email,
 		disabled: ! canUserSendMessages( state ),
 		isChatOpen: isHappychatOpen( state ),
-		isCurrentUser: isCurrentUserHelper( currentUser ), // see redux-no-bound-selectors eslint-rule
+		isCurrentUser: isMessageFromCurrentUser( currentUser ), // see redux-no-bound-selectors eslint-rule
 		isExternalUrl: isExternal,
 		isMinimizing: isHappychatMinimizing( state ),
 		isServerReachable: isHappychatServerReachable( state ),

--- a/client/components/happychat/index.jsx
+++ b/client/components/happychat/index.jsx
@@ -12,12 +12,25 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import { blur, focus, closeChat, minimizeChat, minimizedChat } from 'state/happychat/ui/actions';
+// actions
+import { sendMessage, sendNotTyping, sendTyping } from 'state/happychat/connection/actions';
+import {
+	blur,
+	focus,
+	closeChat,
+	minimizeChat,
+	minimizedChat,
+	setCurrentMessage,
+} from 'state/happychat/ui/actions';
+// selectors
+import canUserSendMessages from 'state/happychat/selectors/can-user-send-messages';
+import getCurrentMessage from 'state/happychat/selectors/get-happychat-current-message';
 import isHappychatMinimizing from 'state/happychat/selectors/is-happychat-minimizing';
 import isHappychatOpen from 'state/happychat/selectors/is-happychat-open';
+// UI components
 import HappychatConnection from './connection-connected';
 import { Title } from './title';
-import Composer from './composer';
+import { Composer } from './composer';
 import Notices from './notices';
 import Timeline from './timeline';
 
@@ -44,7 +57,17 @@ export class Happychat extends Component {
 	};
 
 	render() {
-		const { isChatOpen, isMinimizing, translate } = this.props;
+		const {
+			disabled,
+			isChatOpen,
+			isMinimizing,
+			message,
+			onSendMessage,
+			onSendNotTyping,
+			onSendTyping,
+			onSetCurrentMessage,
+			translate,
+		} = this.props;
 
 		return (
 			<div className="happychat">
@@ -58,7 +81,15 @@ export class Happychat extends Component {
 					<Title onCloseChat={ this.onCloseChatTitle } translate={ translate } />
 					<Timeline />
 					<Notices />
-					<Composer />
+					<Composer
+						disabled={ disabled }
+						message={ message }
+						onSendMessage={ onSendMessage }
+						onSendNotTyping={ onSendNotTyping }
+						onSendTyping={ onSendTyping }
+						onSetCurrentMessage={ onSetCurrentMessage }
+						translate={ translate }
+					/>
 				</div>
 			</div>
 		);
@@ -66,40 +97,39 @@ export class Happychat extends Component {
 }
 
 Happychat.propTypes = {
+	disabled: PropTypes.bool,
 	isChatOpen: PropTypes.bool,
 	isMinimizing: PropTypes.bool,
+	message: PropTypes.string,
 	onCloseChat: PropTypes.func,
 	onMinimizeChat: PropTypes.func,
 	onMinimizedChat: PropTypes.func,
+	onSendMessage: PropTypes.func,
+	onSendNotTyping: PropTypes.func,
+	onSendTyping: PropTypes.func,
+	onSetCurrentMessage: PropTypes.func,
 	setBlurred: PropTypes.func,
 	setFocused: PropTypes.func,
+	translate: PropTypes.func,
 };
 
-const mapState = state => {
-	return {
-		isChatOpen: isHappychatOpen( state ),
-		isMinimizing: isHappychatMinimizing( state ),
-	};
-};
+const mapState = state => ( {
+	disabled: ! canUserSendMessages( state ),
+	isChatOpen: isHappychatOpen( state ),
+	isMinimizing: isHappychatMinimizing( state ),
+	message: getCurrentMessage( state ),
+} );
 
-const mapDispatch = dispatch => {
-	return {
-		onCloseChat() {
-			dispatch( closeChat() );
-		},
-		onMinimizeChat() {
-			dispatch( minimizeChat() );
-		},
-		onMinimizedChat() {
-			dispatch( minimizedChat() );
-		},
-		setBlurred() {
-			dispatch( blur() );
-		},
-		setFocused() {
-			dispatch( focus() );
-		},
-	};
+const mapDispatch = {
+	onCloseChat: closeChat,
+	onMinimizeChat: minimizeChat,
+	onMinimizedChat: minimizedChat,
+	onSendMessage: sendMessage,
+	onSendNotTyping: sendNotTyping,
+	onSendTyping: sendTyping,
+	onSetCurrentMessage: setCurrentMessage,
+	setBlurred: blur,
+	setFocused: focus,
 };
 
 export default connect( mapState, mapDispatch )( localize( Happychat ) );

--- a/client/components/happychat/index.jsx
+++ b/client/components/happychat/index.jsx
@@ -25,13 +25,16 @@ import {
 // selectors
 import canUserSendMessages from 'state/happychat/selectors/can-user-send-messages';
 import getCurrentMessage from 'state/happychat/selectors/get-happychat-current-message';
+import getHappychatChatStatus from 'state/happychat/selectors/get-happychat-chat-status';
+import getHappychatConnectionStatus from 'state/happychat/selectors/get-happychat-connection-status';
 import isHappychatMinimizing from 'state/happychat/selectors/is-happychat-minimizing';
 import isHappychatOpen from 'state/happychat/selectors/is-happychat-open';
+import isHappychatServerReachable from 'state/happychat/selectors/is-happychat-server-reachable';
 // UI components
 import HappychatConnection from './connection-connected';
 import { Title } from './title';
 import { Composer } from './composer';
-import Notices from './notices';
+import { Notices } from './notices';
 import Timeline from './timeline';
 
 /*
@@ -58,9 +61,12 @@ export class Happychat extends Component {
 
 	render() {
 		const {
+			chatStatus,
+			connectionStatus,
 			disabled,
 			isChatOpen,
 			isMinimizing,
+			isServerReachable,
 			message,
 			onSendMessage,
 			onSendNotTyping,
@@ -80,7 +86,12 @@ export class Happychat extends Component {
 				>
 					<Title onCloseChat={ this.onCloseChatTitle } translate={ translate } />
 					<Timeline />
-					<Notices />
+					<Notices
+						chatStatus={ chatStatus }
+						connectionStatus={ connectionStatus }
+						isServerReachable={ isServerReachable }
+						translate={ translate }
+					/>
 					<Composer
 						disabled={ disabled }
 						message={ message }
@@ -97,9 +108,13 @@ export class Happychat extends Component {
 }
 
 Happychat.propTypes = {
+	chatStatus: PropTypes.string,
+	connectionStatus: PropTypes.string,
+	currentUserEmail: PropTypes.string,
 	disabled: PropTypes.bool,
 	isChatOpen: PropTypes.bool,
 	isMinimizing: PropTypes.bool,
+	isServerReachable: PropTypes.bool,
 	message: PropTypes.string,
 	onCloseChat: PropTypes.func,
 	onMinimizeChat: PropTypes.func,
@@ -114,9 +129,12 @@ Happychat.propTypes = {
 };
 
 const mapState = state => ( {
+	chatStatus: getHappychatChatStatus( state ),
+	connectionStatus: getHappychatConnectionStatus( state ),
 	disabled: ! canUserSendMessages( state ),
 	isChatOpen: isHappychatOpen( state ),
 	isMinimizing: isHappychatMinimizing( state ),
+	isServerReachable: isHappychatServerReachable( state ),
 	message: getCurrentMessage( state ),
 } );
 

--- a/client/components/happychat/notices.jsx
+++ b/client/components/happychat/notices.jsx
@@ -3,9 +3,8 @@
 /**
  * External dependencies
  */
-
 import React, { Component } from 'react';
-import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
 import { get } from 'lodash';
 
 /**
@@ -22,10 +21,6 @@ import {
 	HAPPYCHAT_CONNECTION_STATUS_UNAUTHORIZED,
 	HAPPYCHAT_CONNECTION_STATUS_UNINITIALIZED,
 } from 'state/happychat/constants';
-import { localize } from 'i18n-calypso';
-import getHappychatChatStatus from 'state/happychat/selectors/get-happychat-chat-status';
-import getHappychatConnectionStatus from 'state/happychat/selectors/get-happychat-connection-status';
-import isHappychatServerReachable from 'state/happychat/selectors/is-happychat-server-reachable';
 
 /*
  * Renders any notices about the chat session to the user
@@ -88,10 +83,9 @@ export class Notices extends Component {
 	}
 }
 
-const mapState = state => ( {
-	isServerReachable: isHappychatServerReachable( state ),
-	chatStatus: getHappychatChatStatus( state ),
-	connectionStatus: getHappychatConnectionStatus( state ),
-} );
-
-export default localize( connect( mapState )( Notices ) );
+Notices.propTypes = {
+	chatStatus: PropTypes.string,
+	connectionStatus: PropTypes.string,
+	isServerReachable: PropTypes.bool,
+	translate: PropTypes.func,
+};

--- a/client/components/happychat/timeline.jsx
+++ b/client/components/happychat/timeline.jsx
@@ -8,8 +8,6 @@ import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { assign, isArray, isEmpty } from 'lodash';
-import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -18,8 +16,6 @@ import { first, when, forEach } from './functional';
 import autoscroll from './autoscroll';
 import Emojify from 'components/emojify';
 import scrollbleed from './scrollbleed';
-import { getCurrentUser } from 'state/current-user/selectors';
-import getHappychatTimeline from 'state/happychat/selectors/get-happychat-timeline';
 import { isExternal, addSchemeIfMissing, setUrlScheme } from 'lib/url';
 
 import debugFactory from 'debug';
@@ -220,16 +216,3 @@ export const Timeline = createReactClass( {
 		);
 	},
 } );
-
-const mapProps = state => {
-	const current_user = getCurrentUser( state );
-	return {
-		timeline: getHappychatTimeline( state ),
-		isCurrentUser: ( { user_id, source } ) => {
-			return user_id.toString() === current_user.ID.toString() && source === 'customer';
-		},
-		currentUserEmail: current_user.email,
-	};
-};
-
-export default connect( mapProps )( localize( Timeline ) );

--- a/client/components/happychat/timeline.jsx
+++ b/client/components/happychat/timeline.jsx
@@ -23,9 +23,9 @@ const debug = debugFactory( 'calypso:happychat:timeline' );
 
 const linksNotEmpty = ( { links } ) => ! isEmpty( links );
 
-const messageParagraph = ( { message, key } ) => (
+const messageParagraph = ( { message, key, twemojiUrl } ) => (
 	<p key={ key }>
-		<Emojify>{ message }</Emojify>
+		<Emojify twemojiUrl={ twemojiUrl }>{ message }</Emojify>
 	</p>
 );
 
@@ -87,7 +87,7 @@ const messageText = when( linksNotEmpty, messageWithLinks, messageParagraph );
  * Group messages based on user so when any user sends multiple messages they will be grouped
  * within the same message bubble until it reaches a message from a different user.
  */
-const renderGroupedMessages = ( { item, isCurrentUser }, index ) => {
+const renderGroupedMessages = ( { item, isCurrentUser, twemojiUrl }, index ) => {
 	const [ event, ...rest ] = item;
 	return (
 		<div
@@ -102,8 +102,11 @@ const renderGroupedMessages = ( { item, isCurrentUser }, index ) => {
 					name: event.name,
 					key: event.id,
 					links: event.links,
+					twemojiUrl,
 				} ) }
-				{ rest.map( ( { message, id: key, links } ) => messageText( { message, key, links } ) ) }
+				{ rest.map( ( { message, id: key, links } ) =>
+					messageText( { message, key, links, twemojiUrl } )
+				) }
 			</div>
 		</div>
 	);
@@ -165,6 +168,7 @@ const renderTimeline = ( {
 	onScrollContainer,
 	scrollbleedLock,
 	scrollbleedUnlock,
+	twemojiUrl,
 } ) => (
 	<div
 		className="happychat__conversation"
@@ -176,6 +180,7 @@ const renderTimeline = ( {
 			renderGroupedTimelineItem( {
 				item,
 				isCurrentUser: isCurrentUser( item[ 0 ] ),
+				twemojiUrl,
 			} )
 		) }
 	</div>
@@ -193,6 +198,7 @@ export const Timeline = createReactClass( {
 		onScrollContainer: PropTypes.func,
 		timeline: PropTypes.array,
 		translate: PropTypes.func,
+		twemojiUrl: PropTypes.string,
 	},
 
 	getDefaultProps() {

--- a/client/components/happychat/title.jsx
+++ b/client/components/happychat/title.jsx
@@ -5,7 +5,6 @@
  */
 import React from 'react';
 import GridIcon from 'gridicons';
-import { localize } from 'i18n-calypso';
 
 /*
  * React component for rendering title bar
@@ -20,5 +19,3 @@ export const Title = ( { onCloseChat, translate } ) => (
 		</div>
 	</div>
 );
-
-export default localize( Title );

--- a/client/components/happychat/url.js
+++ b/client/components/happychat/url.js
@@ -1,0 +1,29 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { startsWith } from 'lodash';
+
+const schemeRegex = /^\w+:\/\//;
+
+export const addSchemeIfMissing = ( url, scheme ) => {
+	if ( false === schemeRegex.test( url ) ) {
+		return scheme + '://' + url;
+	}
+	return url;
+};
+
+export const setUrlScheme = ( url, scheme ) => {
+	const schemeWithSlashes = scheme + '://';
+	if ( startsWith( url, schemeWithSlashes ) ) {
+		return url;
+	}
+
+	const newUrl = addSchemeIfMissing( url, scheme );
+	if ( newUrl !== url ) {
+		return newUrl;
+	}
+
+	return url.replace( schemeRegex, schemeWithSlashes );
+};

--- a/client/jetpack-connect/happychat-button.jsx
+++ b/client/jetpack-connect/happychat-button.jsx
@@ -16,7 +16,7 @@ import { localize } from 'i18n-calypso';
 
 import analytics from 'lib/analytics';
 import HappychatButton from 'components/happychat/button';
-import HappychatConnection from 'components/happychat/connection';
+import HappychatConnection from 'components/happychat/connection-connected';
 import { isEnabled } from 'config';
 import { getCurrentUserId } from 'state/current-user/selectors';
 import hasActiveHappychatSession from 'state/happychat/selectors/has-active-happychat-session';

--- a/client/me/happychat/main.jsx
+++ b/client/me/happychat/main.jsx
@@ -11,6 +11,7 @@ import { connect } from 'react-redux';
  * Internal dependencies
  */
 import config from 'config';
+import { isExternal } from 'lib/url';
 // actions
 import { sendMessage, sendNotTyping, sendTyping } from 'state/happychat/connection/actions';
 import { blur, focus, setCurrentMessage } from 'state/happychat/ui/actions';
@@ -47,6 +48,7 @@ export class HappychatPage extends Component {
 			currentUserEmail,
 			disabled,
 			isCurrentUser,
+			isExternalUrl,
 			isServerReachable,
 			message,
 			onSendMessage,
@@ -64,6 +66,7 @@ export class HappychatPage extends Component {
 				<Timeline
 					currentUserEmail={ currentUserEmail }
 					isCurrentUser={ isCurrentUser }
+					isExternalUrl={ isExternalUrl }
 					timeline={ timeline }
 					translate={ translate }
 					twemojiUrl={ twemojiUrl }
@@ -94,6 +97,7 @@ HappychatPage.propTypes = {
 	currentUserEmail: PropTypes.string,
 	disabled: PropTypes.bool,
 	isCurrentUser: PropTypes.func,
+	isExternalUrl: PropTypes.func,
 	isServerReachable: PropTypes.bool,
 	message: PropTypes.string,
 	onSendMessage: PropTypes.func,
@@ -119,6 +123,7 @@ const mapState = state => {
 		currentUserEmail: currentUser.email,
 		disabled: ! canUserSendMessages( state ),
 		isCurrentUser: isCurrentUserHelper( currentUser ), // see redux-no-bound-selectors eslint-rule
+		isExternalUrl: isExternal,
 		isServerReachable: isHappychatServerReachable( state ),
 		message: getCurrentMessage( state ),
 		timeline: getHappychatTimeline( state ),

--- a/client/me/happychat/main.jsx
+++ b/client/me/happychat/main.jsx
@@ -10,6 +10,7 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
+import config from 'config';
 // actions
 import { sendMessage, sendNotTyping, sendTyping } from 'state/happychat/connection/actions';
 import { blur, focus, setCurrentMessage } from 'state/happychat/ui/actions';
@@ -54,6 +55,7 @@ export class HappychatPage extends Component {
 			onSetCurrentMessage,
 			timeline,
 			translate,
+			twemojiUrl,
 		} = this.props;
 
 		return (
@@ -64,6 +66,7 @@ export class HappychatPage extends Component {
 					isCurrentUser={ isCurrentUser }
 					timeline={ timeline }
 					translate={ translate }
+					twemojiUrl={ twemojiUrl }
 				/>
 				<Notices
 					chatStatus={ chatStatus }
@@ -90,7 +93,7 @@ HappychatPage.propTypes = {
 	connectionStatus: PropTypes.string,
 	currentUserEmail: PropTypes.string,
 	disabled: PropTypes.bool,
-	isCurrentUser: PropTypes.bool,
+	isCurrentUser: PropTypes.func,
 	isServerReachable: PropTypes.bool,
 	message: PropTypes.string,
 	onSendMessage: PropTypes.func,
@@ -101,6 +104,7 @@ HappychatPage.propTypes = {
 	setFocused: PropTypes.func,
 	timeline: PropTypes.array,
 	translate: PropTypes.func,
+	twemojiUrl: PropTypes.string,
 };
 
 const isCurrentUserHelper = currentUser => ( { user_id, source } ) => {
@@ -118,6 +122,7 @@ const mapState = state => {
 		isServerReachable: isHappychatServerReachable( state ),
 		message: getCurrentMessage( state ),
 		timeline: getHappychatTimeline( state ),
+		twemojiUrl: config( 'twemoji_cdn_url' ),
 	};
 };
 

--- a/client/me/happychat/main.jsx
+++ b/client/me/happychat/main.jsx
@@ -11,7 +11,7 @@ import { connect } from 'react-redux';
  * Internal dependencies
  */
 import { blur, focus } from 'state/happychat/ui/actions';
-import HappychatConnection from 'components/happychat/connection';
+import HappychatConnection from 'components/happychat/connection-connected';
 import Composer from 'components/happychat/composer';
 import Notices from 'components/happychat/notices';
 import Timeline from 'components/happychat/timeline';

--- a/client/me/happychat/main.jsx
+++ b/client/me/happychat/main.jsx
@@ -112,7 +112,7 @@ HappychatPage.propTypes = {
 	twemojiUrl: PropTypes.string,
 };
 
-const isCurrentUserHelper = currentUser => ( { user_id, source } ) => {
+const isMessageFromCurrentUser = currentUser => ( { user_id, source } ) => {
 	return user_id.toString() === currentUser.ID.toString() && source === 'customer';
 };
 
@@ -123,7 +123,7 @@ const mapState = state => {
 		connectionStatus: getHappychatConnectionStatus( state ),
 		currentUserEmail: currentUser.email,
 		disabled: ! canUserSendMessages( state ),
-		isCurrentUser: isCurrentUserHelper( currentUser ), // see redux-no-bound-selectors eslint-rule
+		isCurrentUser: isMessageFromCurrentUser( currentUser ), // see redux-no-bound-selectors eslint-rule
 		isExternalUrl: isExternal,
 		isServerReachable: isHappychatServerReachable( state ),
 		message: getCurrentMessage( state ),

--- a/client/me/happychat/main.jsx
+++ b/client/me/happychat/main.jsx
@@ -16,10 +16,13 @@ import { blur, focus, setCurrentMessage } from 'state/happychat/ui/actions';
 // selectors
 import canUserSendMessages from 'state/happychat/selectors/can-user-send-messages';
 import getCurrentMessage from 'state/happychat/selectors/get-happychat-current-message';
+import getHappychatChatStatus from 'state/happychat/selectors/get-happychat-chat-status';
+import getHappychatConnectionStatus from 'state/happychat/selectors/get-happychat-connection-status';
+import isHappychatServerReachable from 'state/happychat/selectors/is-happychat-server-reachable';
 // UI components
 import HappychatConnection from 'components/happychat/connection-connected';
 import { Composer } from 'components/happychat/composer';
-import Notices from 'components/happychat/notices';
+import { Notices } from 'components/happychat/notices';
 import Timeline from 'components/happychat/timeline';
 
 /**
@@ -36,7 +39,10 @@ export class HappychatPage extends Component {
 
 	render() {
 		const {
+			chatStatus,
+			connectionStatus,
 			disabled,
+			isServerReachable,
 			message,
 			onSendMessage,
 			onSendNotTyping,
@@ -49,7 +55,12 @@ export class HappychatPage extends Component {
 			<div className="happychat__page" aria-live="polite" aria-relevant="additions">
 				<HappychatConnection />
 				<Timeline />
-				<Notices />
+				<Notices
+					chatStatus={ chatStatus }
+					connectionStatus={ connectionStatus }
+					isServerReachable={ isServerReachable }
+					translate={ translate }
+				/>
 				<Composer
 					disabled={ disabled }
 					message={ message }
@@ -65,7 +76,10 @@ export class HappychatPage extends Component {
 }
 
 HappychatPage.propTypes = {
+	chatStatus: PropTypes.string,
+	connectionStatus: PropTypes.string,
 	disabled: PropTypes.bool,
+	isServerReachable: PropTypes.bool,
 	message: PropTypes.string,
 	onSendMessage: PropTypes.func,
 	onSendNotTyping: PropTypes.func,
@@ -77,7 +91,10 @@ HappychatPage.propTypes = {
 };
 
 const mapState = state => ( {
+	chatStatus: getHappychatChatStatus( state ),
+	connectionStatus: getHappychatConnectionStatus( state ),
 	disabled: ! canUserSendMessages( state ),
+	isServerReachable: isHappychatServerReachable( state ),
 	message: getCurrentMessage( state ),
 } );
 

--- a/client/me/happychat/main.jsx
+++ b/client/me/happychat/main.jsx
@@ -10,9 +10,15 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
-import { blur, focus } from 'state/happychat/ui/actions';
+// actions
+import { sendMessage, sendNotTyping, sendTyping } from 'state/happychat/connection/actions';
+import { blur, focus, setCurrentMessage } from 'state/happychat/ui/actions';
+// selectors
+import canUserSendMessages from 'state/happychat/selectors/can-user-send-messages';
+import getCurrentMessage from 'state/happychat/selectors/get-happychat-current-message';
+// UI components
 import HappychatConnection from 'components/happychat/connection-connected';
-import Composer from 'components/happychat/composer';
+import { Composer } from 'components/happychat/composer';
 import Notices from 'components/happychat/notices';
 import Timeline from 'components/happychat/timeline';
 
@@ -29,25 +35,59 @@ export class HappychatPage extends Component {
 	}
 
 	render() {
+		const {
+			disabled,
+			message,
+			onSendMessage,
+			onSendNotTyping,
+			onSendTyping,
+			onSetCurrentMessage,
+			translate,
+		} = this.props;
+
 		return (
 			<div className="happychat__page" aria-live="polite" aria-relevant="additions">
 				<HappychatConnection />
 				<Timeline />
 				<Notices />
-				<Composer />
+				<Composer
+					disabled={ disabled }
+					message={ message }
+					onSendMessage={ onSendMessage }
+					onSendNotTyping={ onSendNotTyping }
+					onSendTyping={ onSendTyping }
+					onSetCurrentMessage={ onSetCurrentMessage }
+					translate={ translate }
+				/>
 			</div>
 		);
 	}
 }
 
 HappychatPage.propTypes = {
+	disabled: PropTypes.bool,
+	message: PropTypes.string,
+	onSendMessage: PropTypes.func,
+	onSendNotTyping: PropTypes.func,
+	onSendTyping: PropTypes.func,
+	onSetCurrentMessage: PropTypes.func,
 	setBlurred: PropTypes.func,
 	setFocused: PropTypes.func,
+	translate: PropTypes.func,
 };
 
+const mapState = state => ( {
+	disabled: ! canUserSendMessages( state ),
+	message: getCurrentMessage( state ),
+} );
+
 const mapDispatch = {
+	onSendMessage: sendMessage,
+	onSendNotTyping: sendNotTyping,
+	onSendTyping: sendTyping,
+	onSetCurrentMessage: setCurrentMessage,
 	setBlurred: blur,
 	setFocused: focus,
 };
 
-export default connect( null, mapDispatch )( HappychatPage );
+export default connect( mapState, mapDispatch )( HappychatPage );

--- a/client/me/happychat/main.jsx
+++ b/client/me/happychat/main.jsx
@@ -15,15 +15,17 @@ import { sendMessage, sendNotTyping, sendTyping } from 'state/happychat/connecti
 import { blur, focus, setCurrentMessage } from 'state/happychat/ui/actions';
 // selectors
 import canUserSendMessages from 'state/happychat/selectors/can-user-send-messages';
+import { getCurrentUser } from 'state/current-user/selectors';
 import getCurrentMessage from 'state/happychat/selectors/get-happychat-current-message';
 import getHappychatChatStatus from 'state/happychat/selectors/get-happychat-chat-status';
 import getHappychatConnectionStatus from 'state/happychat/selectors/get-happychat-connection-status';
+import getHappychatTimeline from 'state/happychat/selectors/get-happychat-timeline';
 import isHappychatServerReachable from 'state/happychat/selectors/is-happychat-server-reachable';
 // UI components
 import HappychatConnection from 'components/happychat/connection-connected';
 import { Composer } from 'components/happychat/composer';
 import { Notices } from 'components/happychat/notices';
-import Timeline from 'components/happychat/timeline';
+import { Timeline } from 'components/happychat/timeline';
 
 /**
  * React component for rendering a happychat client as a full page
@@ -41,20 +43,28 @@ export class HappychatPage extends Component {
 		const {
 			chatStatus,
 			connectionStatus,
+			currentUserEmail,
 			disabled,
+			isCurrentUser,
 			isServerReachable,
 			message,
 			onSendMessage,
 			onSendNotTyping,
 			onSendTyping,
 			onSetCurrentMessage,
+			timeline,
 			translate,
 		} = this.props;
 
 		return (
 			<div className="happychat__page" aria-live="polite" aria-relevant="additions">
 				<HappychatConnection />
-				<Timeline />
+				<Timeline
+					currentUserEmail={ currentUserEmail }
+					isCurrentUser={ isCurrentUser }
+					timeline={ timeline }
+					translate={ translate }
+				/>
 				<Notices
 					chatStatus={ chatStatus }
 					connectionStatus={ connectionStatus }
@@ -78,7 +88,9 @@ export class HappychatPage extends Component {
 HappychatPage.propTypes = {
 	chatStatus: PropTypes.string,
 	connectionStatus: PropTypes.string,
+	currentUserEmail: PropTypes.string,
 	disabled: PropTypes.bool,
+	isCurrentUser: PropTypes.bool,
 	isServerReachable: PropTypes.bool,
 	message: PropTypes.string,
 	onSendMessage: PropTypes.func,
@@ -87,16 +99,27 @@ HappychatPage.propTypes = {
 	onSetCurrentMessage: PropTypes.func,
 	setBlurred: PropTypes.func,
 	setFocused: PropTypes.func,
+	timeline: PropTypes.array,
 	translate: PropTypes.func,
 };
 
-const mapState = state => ( {
-	chatStatus: getHappychatChatStatus( state ),
-	connectionStatus: getHappychatConnectionStatus( state ),
-	disabled: ! canUserSendMessages( state ),
-	isServerReachable: isHappychatServerReachable( state ),
-	message: getCurrentMessage( state ),
-} );
+const isCurrentUserHelper = currentUser => ( { user_id, source } ) => {
+	return user_id.toString() === currentUser.ID.toString() && source === 'customer';
+};
+
+const mapState = state => {
+	const currentUser = getCurrentUser( state );
+	return {
+		chatStatus: getHappychatChatStatus( state ),
+		connectionStatus: getHappychatConnectionStatus( state ),
+		currentUserEmail: currentUser.email,
+		disabled: ! canUserSendMessages( state ),
+		isCurrentUser: isCurrentUserHelper( currentUser ), // see redux-no-bound-selectors eslint-rule
+		isServerReachable: isHappychatServerReachable( state ),
+		message: getCurrentMessage( state ),
+		timeline: getHappychatTimeline( state ),
+	};
+};
 
 const mapDispatch = {
 	onSendMessage: sendMessage,

--- a/client/me/happychat/main.jsx
+++ b/client/me/happychat/main.jsx
@@ -6,6 +6,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -140,4 +141,4 @@ const mapDispatch = {
 	setFocused: focus,
 };
 
-export default connect( mapState, mapDispatch )( HappychatPage );
+export default connect( mapState, mapDispatch )( localize( HappychatPage ) );

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -36,7 +36,7 @@ import {
 	isTicketSupportConfigurationReady,
 	getTicketSupportRequestError,
 } from 'state/help/ticket/selectors';
-import HappychatConnection from 'components/happychat/connection';
+import HappychatConnection from 'components/happychat/connection-connected';
 import QueryOlark from 'components/data/query-olark';
 import QueryTicketSupportConfiguration from 'components/data/query-ticket-support-configuration';
 import HelpUnverifiedWarning from '../help-unverified-warning';


### PR DESCRIPTION
Master issue #18670

This is to allow happychat-client project to use the UI components without pulling unnecessary Calypso dependencies. Note that at the end of these steps, the components will live in the happychat-client repo - this is just an intermediate step to make progress.