### PR TITLE
State: Test serialize/deserialize 

### DIFF
--- a/client/state/test/persistence.js
+++ b/client/state/test/persistence.js
@@ -1,0 +1,17 @@
+/** @format */
+/**
+ * Internal dependencies
+ */
+import { DESERIALIZE, SERIALIZE } from 'state/action-types';
+import { createReduxStore, reducer } from 'state';
+
+describe( 'persistence', () => {
+	test( 'initial state should serialize and deserialize without errors', () => {
+		const consoleSpy = jest.spyOn( global.console, 'error' ).mockImplementation( () => () => {} );
+		const initialState = createReduxStore().getState();
+
+		reducer( reducer( initialState, { type: SERIALIZE } ), { type: DESERIALIZE } );
+
+		expect( consoleSpy.mock.calls ).toHaveLength( 0 );
+	} );
+} );


### PR DESCRIPTION
We can ensure that state serializes and deserializes without errors. This protects against cases like #19339. In this case, there was a schema error which broke persistence for several days but didn't seem to report any errors until debugging was enabled.

This test would have caught that error.

## Testing
1. Tests should pass.
1. Apply the diff below (error fixed in #19339) and ensure that tests fail


```patch
diff --git a/client/state/jetpack/credentials/schema.js b/client/state/jetpack/credentials/schema.js
index 83521f2475..3b02f994c6 100644
--- a/client/state/jetpack/credentials/schema.js
+++ b/client/state/jetpack/credentials/schema.js
@@ -8,7 +8,7 @@ export const itemsSchema = {
 			host: { type: 'string' },
 			port: { type: 'number' },
 			protocol: { type: 'string' },
-			pass: { type: 'boolean' },
+			pass: { type: 'bool' },
 			user: { type: 'string' },
 		},
 	},
```