### PR TITLE
Editor: Fix flash of unstyled content when loading editor

### DIFF
--- a/client/blocks/reader-share/index.jsx
+++ b/client/blocks/reader-share/index.jsx
@@ -21,9 +21,13 @@ import ReaderPopoverMenu from 'components/reader-popover/menu';
 import PopoverMenuItem from 'components/popover/menu-item';
 import Gridicon from 'gridicons';
 import * as stats from 'reader/stats';
-import { preload as preloadSection } from 'sections-preload';
+import { preload } from 'sections-preload';
 import SiteSelector from 'components/site-selector';
 import { getPrimarySiteId } from 'state/selectors';
+
+function preloadEditor() {
+	preload( 'post-editor' );
+}
 
 /**
  * Local variables
@@ -164,10 +168,6 @@ class ReaderShare extends React.Component {
 		}
 	};
 
-	preloadEditor() {
-		preloadSection( 'post-editor' );
-	}
-
 	render() {
 		const { translate } = this.props;
 		const buttonClasses = classnames( {
@@ -181,8 +181,8 @@ class ReaderShare extends React.Component {
 			{
 				className: 'reader-share',
 				onClick: this.toggle,
-				onTouchStart: this.preloadEditor,
-				onMouseEnter: this.preloadEditor,
+				onTouchStart: preloadEditor,
+				onMouseEnter: preloadEditor,
 				ref: 'shareButton',
 			},
 			[

--- a/client/components/empty-content/index.jsx
+++ b/client/components/empty-content/index.jsx
@@ -7,6 +7,7 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import classNames from 'classnames';
+import { noop } from 'lodash';
 
 class EmptyContent extends Component {
 	static propTypes = {
@@ -18,6 +19,7 @@ class EmptyContent extends Component {
 		actionURL: PropTypes.string,
 		actionCallback: PropTypes.func,
 		actionTarget: PropTypes.string,
+		actionHoverCallback: PropTypes.func,
 		secondaryAction: PropTypes.oneOfType( [ PropTypes.string, PropTypes.element ] ),
 		secondaryActionURL: PropTypes.string,
 		secondaryActionCallback: PropTypes.func,
@@ -30,6 +32,7 @@ class EmptyContent extends Component {
 		title: "You haven't created any content yet.",
 		illustration: '/calypso/images/illustrations/illustration-empty-results.svg',
 		isCompact: false,
+		actionHoverCallback: noop,
 	};
 
 	static displayName = 'EmptyContent';
@@ -45,6 +48,8 @@ class EmptyContent extends Component {
 					className="empty-content__action button is-primary"
 					onClick={ this.props.actionCallback }
 					href={ this.props.actionURL }
+					onMouseEnter={ this.props.actionHoverCallback }
+					onTouchStart={ this.props.actionHoverCallback }
 				>
 					{ this.props.action }
 				</a>
@@ -59,6 +64,8 @@ class EmptyContent extends Component {
 				<a
 					className="empty-content__action button is-primary"
 					href={ this.props.actionURL }
+					onMouseEnter={ this.props.actionHoverCallback }
+					onTouchStart={ this.props.actionHoverCallback }
 					{ ...targetProp }
 				>
 					{ this.props.action }

--- a/client/components/popover/menu-item.jsx
+++ b/client/components/popover/menu-item.jsx
@@ -7,7 +7,7 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import classnames from 'classnames';
-import { omit } from 'lodash';
+import { noop, omit } from 'lodash';
 import Gridicon from 'gridicons';
 
 export default class PopoverMenuItem extends Component {
@@ -17,33 +17,36 @@ export default class PopoverMenuItem extends Component {
 		isSelected: PropTypes.bool,
 		icon: PropTypes.string,
 		focusOnHover: PropTypes.bool,
+		onMouseOver: PropTypes.func,
 	};
 
 	static defaultProps = {
 		isSelected: false,
 		focusOnHover: true,
+		onMouseOver: noop,
 	};
 
-	focus( event ) {
-		event.target.focus();
-	}
+	handleMouseOver = ( event ) => {
+		const { focusOnHover } = this.props;
+
+		if ( focusOnHover ) {
+			event.target.focus();
+		}
+
+		this.props.onMouseOver();
+	};
 
 	render() {
-		const { children, className, focusOnHover, href, icon, isSelected } = this.props;
+		const { children, className, href, icon, isSelected } = this.props;
 		const classes = classnames( 'popover__menu-item', className, {
 			'is-selected': isSelected,
 		} );
 		const ItemComponent = href ? 'a' : 'button';
 
-		let hoverHandler;
-		if ( focusOnHover ) {
-			hoverHandler = this.focus;
-		}
-
 		return (
 			<ItemComponent
 				role="menuitem"
-				onMouseOver={ hoverHandler }
+				onMouseOver={ this.handleMouseOver }
 				tabIndex="-1"
 				{ ...omit( this.props, 'icon', 'focusOnHover', 'isSelected' ) }
 				className={ classes }

--- a/client/controller/shared.js
+++ b/client/controller/shared.js
@@ -49,12 +49,14 @@ export function setSection( section ) {
 	};
 }
 
-export function loadSectionCSS( context, next ) {
+function loadSectionCSS( context, next ) {
 	const section = getSection( context.store.getState() );
 
-	if ( section.cssUrls && typeof document !== 'undefined' ) {
-		const cssUrl = isRTL( context.store.getState() ) ? section.cssUrls.rtl : section.cssUrls.ltr;
-		switchCSS( 'section-css', cssUrl, next );
+	if ( section.css && typeof document !== 'undefined' ) {
+		const url = isRTL( context.store.getState() ) ? section.css.urls.rtl : section.css.urls.ltr;
+
+		switchCSS( 'section-css-' + section.css.id, url, next );
+
 		return;
 	}
 

--- a/client/lib/i18n-utils/switch-locale.js
+++ b/client/lib/i18n-utils/switch-locale.js
@@ -3,7 +3,6 @@
 /**
  * External dependencies
  */
-
 import request from 'superagent';
 import i18n from 'i18n-calypso';
 import debugFactory from 'debug';
@@ -17,7 +16,8 @@ import { isDefaultLocale, getLanguage } from './utils';
 const debug = debugFactory( 'calypso:i18n' );
 
 function languageFileUrl( localeSlug ) {
-	var protocol = typeof window === 'undefined' ? 'https://' : '//'; // use a protocol-relative path in the browser
+	const protocol = typeof window === 'undefined' ? 'https://' : '//'; // use a protocol-relative path in the browser
+
 	return `${ protocol }widgets.wp.com/languages/calypso/${ localeSlug }.json`;
 }
 
@@ -54,16 +54,29 @@ export default function switchLocale( localeSlug ) {
 			const directionFlag = language.rtl ? '-rtl' : '';
 			const debugFlag = process.env.NODE_ENV === 'development' ? '-debug' : '';
 			const cssUrl = window.app.staticUrls[ `style${ debugFlag }${ directionFlag }.css` ];
+
 			switchCSS( 'main-css', cssUrl );
 		}
 	} );
 }
 
+const bundles = {};
+
 export function switchCSS( elementId, cssUrl, callback = noop ) {
+	if ( bundles.hasOwnProperty( elementId ) && bundles[ elementId ] === cssUrl ) {
+		callback();
+
+		return;
+	}
+
+	bundles[ elementId ] = cssUrl;
+
 	const currentLink = document.getElementById( elementId );
 
 	if ( currentLink && currentLink.getAttribute( 'href' ) === cssUrl ) {
-		return callback();
+		callback();
+
+		return;
 	}
 
 	loadCSS( cssUrl, currentLink, ( error, newLink ) => {
@@ -78,7 +91,8 @@ export function switchCSS( elementId, cssUrl, callback = noop ) {
 }
 
 /**
- * Loads a css stylesheet into the page
+ * Loads a css stylesheet into the page.
+ *
  * @param {string} cssUrl - a url to a css resource to be inserted into the page
  * @param {Element} currentLink - a <link> DOM element that we want to use as a reference for stylesheet order
  * @param {Function} callback - a callback function to be called when the CSS has been loaded (after 500ms have passed).
@@ -94,6 +108,7 @@ function loadCSS( cssUrl, currentLink, callback = noop ) {
 		if ( 'onload' in link ) {
 			link.onload = null;
 		}
+
 		callback( null, link );
 	};
 

--- a/client/my-sites/pages/page-list.jsx
+++ b/client/my-sites/pages/page-list.jsx
@@ -18,6 +18,7 @@ import { flowRight } from 'lodash';
 import ListEnd from 'components/list-end';
 import QueryPosts from 'components/data/query-posts';
 import Page from './page';
+import { preload } from 'sections-preload';
 import infiniteScroll from 'lib/mixins/infinite-scroll';
 import EmptyContent from 'components/empty-content';
 import NoResults from 'my-sites/no-results';
@@ -32,6 +33,10 @@ import {
 	isSitePostsLastPageForQuery,
 } from 'state/posts/selectors';
 import { getSite } from 'state/sites/selectors';
+
+function preloadEditor() {
+	preload( 'post-editor' );
+}
 
 export default class PageList extends Component {
 	static propTypes = {
@@ -218,6 +223,7 @@ const Pages = createReactClass( {
 				line={ attributes.line }
 				action={ attributes.action }
 				actionURL={ attributes.actionURL }
+				actionHoverCallback={ preloadEditor }
 				illustration={ attributes.illustration }
 				illustrationWidth={ attributes.illustrationWidth }
 			/>

--- a/client/my-sites/pages/page/index.js
+++ b/client/my-sites/pages/page/index.js
@@ -26,6 +26,7 @@ import utils from 'lib/posts/utils';
 import classNames from 'classnames';
 import MenuSeparator from 'components/popover/menu-separator';
 import PageCardInfo from '../page-card-info';
+import { preload } from 'sections-preload';
 import { getSite, hasStaticFrontPage, isSitePreviewable } from 'state/sites/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { isFrontPage, isPostsPage } from 'state/pages/selectors';
@@ -35,6 +36,10 @@ import { setLayoutFocus } from 'state/ui/layout-focus/actions';
 import { getPreviewURL } from 'lib/posts/utils';
 
 const recordEvent = partial( recordGoogleEvent, 'Pages' );
+
+function preloadEditor() {
+	preload( 'post-editor' );
+}
 
 class Page extends Component {
 	static propTypes = {
@@ -182,7 +187,7 @@ class Page extends Component {
 		}
 
 		return (
-			<PopoverMenuItem onClick={ this.editPage }>
+			<PopoverMenuItem onClick={ this.editPage } onMouseOver={ preloadEditor }>
 				<Gridicon icon="pencil" size={ 18 } />
 				{ this.props.translate( 'Edit' ) }
 			</PopoverMenuItem>

--- a/client/my-sites/posts/post-list.jsx
+++ b/client/my-sites/posts/post-list.jsx
@@ -17,6 +17,7 @@ import debugFactory from 'debug';
 import QueryPosts from 'components/data/query-posts';
 import Post from './post';
 import PostPlaceholder from './post-placeholder';
+import { preload } from 'sections-preload';
 import EmptyContent from 'components/empty-content';
 import InfiniteList from 'components/infinite-list';
 import NoResults from 'my-sites/no-results';
@@ -33,6 +34,10 @@ import {
 const debug = debugFactory( 'calypso:my-sites:posts' );
 
 const GUESSED_POST_HEIGHT = 250;
+
+function preloadEditor() {
+	preload( 'post-editor' );
+}
 
 class PostList extends PureComponent {
 	static propTypes = {
@@ -250,6 +255,7 @@ const Posts = localize(
 					line={ attributes.line }
 					action={ attributes.action }
 					actionURL={ attributes.actionURL }
+					actionHoverCallback={ preloadEditor }
 					illustration={ attributes.illustration }
 					illustrationWidth={ attributes.illustrationWidth }
 				/>

--- a/client/sections-preload.js
+++ b/client/sections-preload.js
@@ -1,13 +1,13 @@
 /**
  * sections-preload
- * 
+ *
  * This is a simple eventbus that sections.js listens to, to know when to preload sections.
- * 
+ *
  * In days past, the preloader was part of sections.js. To preload a module you would import sections
  * and call preload directly. However, all of the require.ensure calls live in sections.js. This makes
  * webpack think that imported sections was also dependant on every other chunk. The cyclic dependencies
  * ballooned compile times and made module analysis very difficult.
- * 
+ *
  * To break the dependency cycle, we introduced the dependency-free `sections-preload`.
  *
  * @format
@@ -25,11 +25,11 @@ export const hub = {};
 emitter( hub );
 
 /**
- * Preload a section by name
+ * Preload a section by name.
  *
  * @export
- * @param {String} section The named section to load
+ * @param {String} sectionName The name of the section to load
  */
-export function preload( section ) {
-	hub.emit( 'preload', section );
+export function preload( sectionName ) {
+	hub.emit( 'preload', sectionName );
 }

--- a/server/bundler/loader.js
+++ b/server/bundler/loader.js
@@ -120,7 +120,6 @@ function splitTemplate( path, section ) {
 		'			context.store.dispatch( { type: "SECTION_SET", isLoading: false } );',
 		'			LoadingError.show( ' + sectionNameString + ' );',
 		'		}',
-		'		return;',
 		'	},',
 		sectionNameString + ' );',
 		'} );\n'
@@ -164,7 +163,6 @@ function singleEnsure( sectionName ) {
 	var result = [
 		'case ' + JSON.stringify( sectionName ) + ':',
 		'	return require.ensure([], function() {}, ' + JSON.stringify( sectionName ) + ' );',
-		'	break;\n'
 	];
 
 	return result.join( '\n' );

--- a/server/bundler/loader.js
+++ b/server/bundler/loader.js
@@ -1,13 +1,13 @@
-var config = require( 'config' ),
+const config = require( 'config' ),
 	utils = require( './utils' );
 
 function getSectionsModule( sections ) {
-	var dependencies,
-		sectionPreLoaders = '',
-		sectionLoaders = '';
+	let sectionLoaders = '';
 
 	if ( config.isEnabled( 'code-splitting' ) ) {
-		dependencies = [
+		let sectionPreLoaders = '';
+
+		const dependencies = [
 			"var config = require( 'config' ),",
 			"\tpage = require( 'page' ),",
 			"\tReact = require( 'react' ),",
@@ -19,7 +19,7 @@ function getSectionsModule( sections ) {
 			"\tswitchCSS = require( 'lib/i18n-utils/switch-locale' ).switchCSS,",
 			"\tdebug = require( 'debug' )( 'calypso:bundler:loader' );",
 			'\n',
-			'var _loadedSections = {};\n'
+			'var _loadedSections = {};\n',
 		].join( '\n' );
 
 		sections.forEach( function( section ) {
@@ -57,14 +57,14 @@ function getSectionsModule( sections ) {
 			'	load: function() {',
 			'		' + sectionLoaders,
 			'	}',
-			'};'
+			'};',
 		].join( '\n' );
 	}
 
-	dependencies = [
+	const dependencies = [
 		"var config = require( 'config' ),",
 		"\tpage = require( 'page' ),",
-		"\tcontroller = require( 'controller' );\n"
+		"\tcontroller = require( 'controller' );\n",
 	].join( '\n' );
 
 	sectionLoaders = getRequires( sections );
@@ -78,12 +78,12 @@ function getSectionsModule( sections ) {
 		'	load: function() {',
 		'		' + sectionLoaders,
 		'	}',
-		'};'
+		'};',
 	].join( '\n' );
 }
 
 function getRequires( sections ) {
-	var content = '';
+	let content = '';
 
 	sections.forEach( function( section ) {
 		content += requireTemplate( section );
@@ -93,14 +93,13 @@ function getRequires( sections ) {
 }
 
 function splitTemplate( path, section ) {
-	var pathRegex = getPathRegex( path ),
+	const pathRegex = getPathRegex( path ),
 		sectionString = JSON.stringify( section ),
 		sectionNameString = JSON.stringify( section.name ),
 		moduleString = JSON.stringify( section.module ),
-		envIdString = JSON.stringify( section.envId ),
-		result;
+		envIdString = JSON.stringify( section.envId );
 
-	result = [
+	const result = [
 		'page( ' + pathRegex + ', function( context, next ) {',
 		'	var envId = ' + envIdString + ';',
 		'	if ( envId && envId.indexOf( config( "env_id" ) ) === -1 ) {',
@@ -135,7 +134,7 @@ function splitTemplate( path, section ) {
 		'		}',
 		'	},',
 		sectionNameString + ' );',
-		'} );\n'
+		'} );\n',
 	];
 
 	return result.join( '\n' );
@@ -150,11 +149,8 @@ function getPathRegex( pathString ) {
 }
 
 function requireTemplate( section ) {
-	var pathRegex,
-		result;
-
-	result = section.paths.reduce( function( acc, path ) {
-		pathRegex = getPathRegex( path );
+	const result = section.paths.reduce( function( acc, path ) {
+		const pathRegex = getPathRegex( path );
 
 		return acc.concat( [
 			'page( ' + pathRegex + ', function( context, next ) {',
@@ -165,7 +161,7 @@ function requireTemplate( section ) {
 			'	controller.setSection( ' + JSON.stringify( section ) + ' )( context );',
 			'	require( ' + JSON.stringify( section.module ) + ' )( controller.clientRouter );',
 			'	next();',
-			'} );\n'
+			'} );\n',
 		] );
 	}, [] );
 
@@ -194,7 +190,7 @@ function getSectionPreLoaderTemplate( section ) {
 
 function sectionsWithCSSUrls( sections ) {
 	return sections.map( section => Object.assign( {}, section, section.css && {
-		cssUrls: utils.getCssUrls( section.css )
+		cssUrls: utils.getCssUrls( section.css ),
 	} ) );
 }
 

--- a/server/bundler/loader.js
+++ b/server/bundler/loader.js
@@ -3,7 +3,7 @@ var config = require( 'config' ),
 
 function getSectionsModule( sections ) {
 	var dependencies,
-		loadSection = '',
+		sectionPreLoaders = '',
 		sectionLoaders = '';
 
 	if ( config.isEnabled( 'code-splitting' ) ) {
@@ -21,7 +21,8 @@ function getSectionsModule( sections ) {
 		].join( '\n' );
 
 		sections.forEach( function( section ) {
-			loadSection += singleEnsure( section.name );
+			sectionPreLoaders += getSectionPreLoaderTemplate( section.name );
+
 			section.paths.forEach( function( path ) {
 				sectionLoaders += splitTemplate( path, section );
 			} );
@@ -31,7 +32,7 @@ function getSectionsModule( sections ) {
 			dependencies,
 			'function preload( sectionName ) {',
 			'	switch ( sectionName ) {',
-			'	' + loadSection,
+			'	' + sectionPreLoaders,
 			'	}',
 			'}',
 			'\n',
@@ -159,7 +160,7 @@ function requireTemplate( section ) {
 	return result.join( '\n' );
 }
 
-function singleEnsure( sectionName ) {
+function getSectionPreLoaderTemplate( sectionName ) {
 	var result = [
 		'case ' + JSON.stringify( sectionName ) + ':',
 		'	return require.ensure([], function() {}, ' + JSON.stringify( sectionName ) + ' );',

--- a/server/bundler/loader.js
+++ b/server/bundler/loader.js
@@ -15,7 +15,8 @@ function getSectionsModule( sections ) {
 			"\tLoadingError = require( 'layout/error' ),",
 			"\tcontroller = require( 'controller' ),",
 			"\trestoreLastSession = require( 'lib/restore-last-path' ).restoreLastSession,",
-			"\tpreloadHub = require( 'sections-preload' ).hub;",
+			"\tpreloadHub = require( 'sections-preload' ).hub,",
+			"\tdebug = require( 'debug' )( 'calypso:bundler:loader' );",
 			'\n',
 			'var _loadedSections = {};\n'
 		].join( '\n' );
@@ -161,9 +162,12 @@ function requireTemplate( section ) {
 }
 
 function getSectionPreLoaderTemplate( sectionName ) {
-	var result = [
-		'case ' + JSON.stringify( sectionName ) + ':',
-		'	return require.ensure([], function() {}, ' + JSON.stringify( sectionName ) + ' );',
+	const sectionNameString = JSON.stringify( sectionName );
+
+	const result = [
+		'case ' + sectionNameString + ':',
+		'	debug( \'Pre-loading Javascript for ' + sectionNameString + ' section\' );',
+		'	return require.ensure([], function() {}, ' + sectionNameString + ' );',
 	];
 
 	return result.join( '\n' );

--- a/server/bundler/loader.js
+++ b/server/bundler/loader.js
@@ -29,8 +29,8 @@ function getSectionsModule( sections ) {
 
 		return [
 			dependencies,
-			'function preload( section ) {',
-			'	switch ( section ) {',
+			'function preload( sectionName ) {',
+			'	switch ( sectionName ) {',
 			'	' + loadSection,
 			'	}',
 			'}',
@@ -160,10 +160,10 @@ function requireTemplate( section ) {
 	return result.join( '\n' );
 }
 
-function singleEnsure( chunkName ) {
+function singleEnsure( sectionName ) {
 	var result = [
-		'case ' + JSON.stringify( chunkName ) + ':',
-		'	return require.ensure([], function() {}, ' + JSON.stringify( chunkName ) + ' );',
+		'case ' + JSON.stringify( sectionName ) + ':',
+		'	return require.ensure([], function() {}, ' + JSON.stringify( sectionName ) + ' );',
 		'	break;\n'
 	];
 

--- a/server/bundler/loader.js
+++ b/server/bundler/loader.js
@@ -172,7 +172,7 @@ function getSectionPreLoaderTemplate( section ) {
 	let cssLoader = '', bundleTypes = 'Javascript';
 
 	if ( section.cssUrls ) {
-		cssLoader = `loadCSS( 'section-css', ${ section.cssUrls } );`;
+		cssLoader = `loadCSS( 'section-css', ${ JSON.stringify( section.cssUrls ) } );`;
 		bundleTypes += ' and CSS';
 	}
 

--- a/server/pages/index.jade
+++ b/server/pages/index.jade
@@ -70,8 +70,8 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class=isFluidWidth ? 'is-fluid-width'
 			else
 				link(rel='stylesheet', id='main-css', href=urls['style-rtl.css'])
 
-			if sectionCssRtl
-				link(rel='stylesheet', id='section-css', href=sectionCssRtl)
+			if sectionCss
+				link(rel='stylesheet', id='section-css-' + sectionCss.id, href=sectionCss.urls.rtl)
 		else
 			if 'development' === env || isDebug
 				link(rel='stylesheet', id='main-css', href=urls['style-debug.css'])
@@ -79,7 +79,7 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class=isFluidWidth ? 'is-fluid-width'
 				link(rel='stylesheet', id='main-css', href=urls['style.css'])
 
 			if sectionCss
-				link(rel='stylesheet', id='section-css', href=sectionCss)
+				link(rel='stylesheet', id='section-css-' + sectionCss.id, href=sectionCss.urls.ltr)
 
 		if shouldUsePreconnect
 			//- Preconnect to our CDN hosts
@@ -109,13 +109,11 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class=isFluidWidth ? 'is-fluid-width'
 			else
 				link(rel='preload' as='style' href='//s1.wp.com/i/noticons/noticons.css?v=20150727')
 
-		if shouldUseStylePreloadSection
+		if shouldUseStylePreloadSection && sectionCss
 			if isRTL
-				if sectionCssRtl
-					link(rel='preload' as='style' href=sectionCssRtl)
+				link(rel='preload', as='style', href=sectionCss.urls.rtl)
 			else
-				if sectionCss
-					link(rel='preload' as='style' href=sectionCss)
+				link(rel='preload', as='style', href=sectionCss.urls.ltr)
 
 		if shouldUseStylePreloadCommon
 			if isRTL

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -147,7 +147,7 @@ function getDefaultContext( request ) {
 	const cacheKey = getCacheKey( request );
 	const geoLocation = ( request.headers[ 'x-geoip-country-code' ] || '' ).toLowerCase();
 	const isDebug = calypsoEnv === 'development' || request.query.debug !== undefined;
-	let sectionCss, sectionCssRtl;
+	let sectionCss;
 
 	if ( cacheKey ) {
 		const serializeCachedServerState = stateCache.get( cacheKey ) || {};
@@ -167,9 +167,10 @@ function getDefaultContext( request ) {
 	}
 
 	if ( request.context && request.context.sectionCss ) {
-		const urls = utils.getCssUrls( request.context.sectionCss );
-		sectionCss = urls.ltr;
-		sectionCssRtl = urls.rtl;
+		sectionCss = {
+			id: request.context.sectionCss,
+			urls: utils.getCssUrls( request.context.sectionCss ),
+		};
 	}
 
 	const shouldUseSingleCDN =
@@ -205,7 +206,6 @@ function getDefaultContext( request ) {
 		shouldUseSingleCDN,
 		bodyClasses,
 		sectionCss,
-		sectionCssRtl,
 	} );
 
 	context.app = {


### PR DESCRIPTION
 This pull request addresses https://github.com/Automattic/wp-calypso/issues/18703 by fixing a [flash of unstyled content](https://en.wikipedia.org/wiki/Flash_of_unstyled_content) that would otherwise happen the first time the editor is loaded, something quite noticeable with slow connections:
 
![posteditor-flashofsidebar](https://user-images.githubusercontent.com/8658164/31400329-197a85c2-ade7-11e7-9ee2-09899521a5f6.gif)

The solution chosen consists in modifying the [Webpack loader](https://github.com/Automattic/wp-calypso/blob/addc1ccfd359d77e92e204211efac51e4c5721f7/server/bundler/loader.js) that handles [code splitting](https://github.com/Automattic/wp-calypso/tree/addc1ccfd359d77e92e204211efac51e4c5721f7/server/bundler) in order to pre-load the CSS bundle of a section at the same time its Javascript bundle is pre-loaded.

#### Testing instructions
 
Depending on your Internet connection, you may want to set [throttling](https://developers.google.com/web/tools/chrome-devtools/network-performance/reference#throttling) to `Slow 3G` - or something even slower - in the `Network` panel in the Chrome devtools. Finally do not hesitate to repeat the following steps with any [RTL language](http://calypso.localhost:3000/me/account) such as Hebrew:

1. Run `git checkout fix/editor-fouc` and start your server, or open a [live branch](https://calypso.live/?branch=fix/editor-fouc)

##### Scenario 1

2. Open the [`Reader` page](http://calypso.localhost:3000/) in a new tab
3. Click the `Write` button in the top bar
4. Assert that the editor loads with the correct styles applied right away

##### Scenario 2

2. Open the [`My Site` page](http://calypso.localhost:3000/stats/day) in a new tab
3. Click the `Add` button next to the `Sites Pages` or `Blog Posts` menu item in the sidebar
4. Assert that the editor loads with the correct styles applied right away

##### Scenario 3

2. Open the [`Blog Posts` page](http://calypso.localhost:3000/posts) in a new tab
3. Click the `Start a Post` button that appears when you haven't published any posts yet
4. Assert that the editor loads with the correct styles applied right away

##### Scenario 4

2. Open the [`Page Drafts` page](http://calypso.localhost:3000/pages/drafts) in a new tab
3. Click the `Start a Page` button that appears when you haven't published any posts yet
4. Assert that the editor loads with the correct styles applied right away

##### Scenario 5

2. Open the [`Blog Posts` page](http://calypso.localhost:3000/posts) in a new tab
3. Click the `Edit` action below any exising post
4. Assert that the editor loads with the correct styles applied right away

##### Scenario 6

2. Open the [`Site Pages` page](http://calypso.localhost:3000/pages) in a new tab
3. Click the `Edit` menu item that appears when you click the three dots in front of each page
4. Assert that the editor loads with the correct styles applied right away

##### Scenario 7

2. Open the [`Reader` page](http://calypso.localhost:3000/) in a new tab
3. Click the first post in the list
4. Move your mouse over the sharing icon located at the bottom of the post
5. Assert that the layout of the page doesn't change

#### Additional notes

You may want to review changes with [whitespaces ignored](https://github.com/Automattic/wp-calypso/pull/19396/files?w=1), or [commit by commit](https://github.com/Automattic/wp-calypso/pull/19396/commits).

This pull request changes the code generated by the Webpack loader from [this](https://gist.github.com/stephanethomas/36e15a7fd3f5281fe92a2ef782eff4d5/b2b8149479145b7a9e773d635170dd818a78deac) to [this](https://gist.github.com/stephanethomas/36e15a7fd3f5281fe92a2ef782eff4d5/491688964714a5811a94f70223cf2cccf4ee2a99). You can compare those changes by downloading these two revisions, and using your favorite diff tool.

Props to @jeremeylduvall for suggesting preloading the CSS bundles when hovering the button.

#### Reviews
 
- [ ] Code
- [ ] Product