### PR TITLE
Reader Conversations: implement revert behaviour in data layer

### DIFF
--- a/client/state/data-layer/wpcom/read/sites/posts/follow/index.js
+++ b/client/state/data-layer/wpcom/read/sites/posts/follow/index.js
@@ -17,13 +17,15 @@ import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { errorNotice, successNotice } from 'state/notices/actions';
 import { updateConversationFollowStatus } from 'state/reader/conversations/actions';
 import { bypassDataLayer } from 'state/data-layer/utils';
+import { getReaderConversationFollowStatus } from 'state/selectors';
 
-export function requestConversationFollow( { dispatch }, action ) {
+export function requestConversationFollow( { dispatch, getState }, action ) {
 	const actionWithRevert = merge( {}, action, {
 		meta: {
-			// @todo once we've added convo follow to Redux state, use selector to get previous state
-			// hardcoded for the moment to support tests
-			previousState: 'M',
+			previousState: getReaderConversationFollowStatus( getState(), {
+				siteId: action.payload.siteId,
+				postId: action.payload.postId,
+			} ),
 		},
 	} );
 	dispatch(

--- a/client/state/data-layer/wpcom/read/sites/posts/follow/test/index.js
+++ b/client/state/data-layer/wpcom/read/sites/posts/follow/test/index.js
@@ -27,7 +27,18 @@ describe( 'conversation-follow', () => {
 					previousState: CONVERSATION_FOLLOW_STATUS_MUTING,
 				},
 			} );
-			requestConversationFollow( { dispatch }, action );
+			const getState = () => {
+				return {
+					reader: {
+						conversations: {
+							items: {
+								'123-456': 'M',
+							},
+						},
+					},
+				};
+			};
+			requestConversationFollow( { dispatch, getState }, action );
 			expect( dispatch ).toHaveBeenCalledWith(
 				http(
 					{

--- a/client/state/data-layer/wpcom/read/sites/posts/mute/index.js
+++ b/client/state/data-layer/wpcom/read/sites/posts/mute/index.js
@@ -17,13 +17,15 @@ import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { errorNotice, plainNotice } from 'state/notices/actions';
 import { updateConversationFollowStatus } from 'state/reader/conversations/actions';
 import { bypassDataLayer } from 'state/data-layer/utils';
+import { getReaderConversationFollowStatus } from 'state/selectors';
 
-export function requestConversationMute( { dispatch }, action ) {
+export function requestConversationMute( { dispatch, getState }, action ) {
 	const actionWithRevert = merge( {}, action, {
 		meta: {
-			// @todo once we've added convo follow to Redux state, use selector to get previous state
-			// hardcoded for the moment to support tests
-			previousState: 'F',
+			previousState: getReaderConversationFollowStatus( getState(), {
+				siteId: action.payload.siteId,
+				postId: action.payload.postId,
+			} ),
 		},
 	} );
 	dispatch(

--- a/client/state/data-layer/wpcom/read/sites/posts/mute/test/index.js
+++ b/client/state/data-layer/wpcom/read/sites/posts/mute/test/index.js
@@ -27,7 +27,18 @@ describe( 'conversation-mute', () => {
 					previousState: CONVERSATION_FOLLOW_STATUS_FOLLOWING,
 				},
 			} );
-			requestConversationMute( { dispatch }, action );
+			const getState = () => {
+				return {
+					reader: {
+						conversations: {
+							items: {
+								'123-456': 'F',
+							},
+						},
+					},
+				};
+			};
+			requestConversationMute( { dispatch, getState }, action );
 			expect( dispatch ).toHaveBeenCalledWith(
 				http(
 					{

--- a/client/state/selectors/get-reader-conversation-follow-status.js
+++ b/client/state/selectors/get-reader-conversation-follow-status.js
@@ -1,0 +1,24 @@
+/*
+ * @format
+ */
+
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { key } from 'state/reader/conversations/utils';
+
+/*
+ * Get the conversation following status for a given post
+ *
+ * @param  {Object}  state  Global state tree
+ * @param  {Object} params Params including siteId and postId
+ * @return {String|null} Conversation follow status (F for following, M for muting, or null)
+ */
+export default function getReaderConversationFollowStatus( state, { siteId, postId } ) {
+	return get( state, [ 'reader', 'conversations', 'items', key( siteId, postId ) ], null );
+}

--- a/client/state/selectors/index.js
+++ b/client/state/selectors/index.js
@@ -91,6 +91,7 @@ export getPublicizeConnection from './get-publicize-connection';
 export getPublicSites from './get-public-sites';
 export getRawOffsets from './get-raw-offsets';
 export getReaderAliasedFollowFeedUrl from './get-reader-aliased-follow-feed-url';
+export getReaderConversationFollowStatus from './get-reader-conversation-follow-status';
 export getReaderFeedsCountForQuery from './get-reader-feeds-count-for-query';
 export getReaderFeedsForQuery from './get-reader-feeds-for-query';
 export getReaderFollowedTags from './get-reader-followed-tags';

--- a/client/state/selectors/test/get-reader-conversation-follow-status.js
+++ b/client/state/selectors/test/get-reader-conversation-follow-status.js
@@ -1,0 +1,50 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+import { getReaderConversationFollowStatus } from '../';
+
+describe( 'getReaderConversationFollowStatus()', () => {
+	test( 'should return F for a known followed post', () => {
+		const prevState = {
+			reader: {
+				conversations: {
+					items: {
+						'123-456': 'F',
+					},
+				},
+			},
+		};
+		const nextState = getReaderConversationFollowStatus( prevState, { siteId: 123, postId: 456 } );
+		expect( nextState ).toEqual( 'F' );
+	} );
+
+	test( 'should return M for a muted post', () => {
+		const prevState = {
+			reader: {
+				conversations: {
+					items: {
+						'123-456': 'M',
+					},
+				},
+			},
+		};
+		const nextState = getReaderConversationFollowStatus( prevState, { siteId: 123, postId: 456 } );
+		expect( nextState ).toEqual( 'M' );
+	} );
+
+	test( 'should return null for an unknown post', () => {
+		const prevState = {
+			reader: {
+				conversations: {
+					items: {
+						'123-456': 'F',
+					},
+				},
+			},
+		};
+		const nextState = getReaderConversationFollowStatus( prevState, { siteId: 234, postId: 456 } );
+		expect( nextState ).toEqual( null );
+	} );
+} );


### PR DESCRIPTION
When we wrote the data layer for following and muting a conversation, we left a comment to complete the revert behaviour. This rolls back the follow status to the last known one when a follow or mute fails.

This PR implements a selector to get the follow status, and uses that selector to pass the current follow status into the action.

### To test

```
npm run test-client client/state/selectors
npm run test-client client/state/data-layer/wpcom/read/sites
```