### PR TITLE
Comments: fix long word wrapping in WebKit browsers

### DIFF
--- a/client/blocks/comments/style.scss
+++ b/client/blocks/comments/style.scss
@@ -52,6 +52,7 @@
 
 			white-space: pre-wrap;
 			word-wrap: break-word;
+			word-break: break-word;
 		}
 
 		textarea {


### PR DESCRIPTION
In https://github.com/Automattic/wp-calypso/issues/18867, @bperson reports that the comments textarea expands in a worrying manner when you write a long word (like a long URL) in some browsers:

<img src="https://user-images.githubusercontent.com/1145270/31603468-91e519a0-b260-11e7-8fa6-0b73546c3d72.gif" />

I discovered that the undocumented CSS property `word-break: break-word` does the trick in Chrome and Safari. 

From https://kenneth.io/blog/2012/03/04/word-wrapping-hypernation-using-css/:

> I discovered, that you can use word-break: break-word which seems to be an undocumented and non-standard property value in WebKit. This makes the word wrapping behave like word-wrap: break-word, but works with dynamic widths.

### To test

Open http://calypso.localhost:3000/read/feeds/40474296/posts/1385874605. Paste in a very long URL or unbroken word and make sure it wraps, like this:

<img width="768" alt="screen shot 2017-11-01 at 18 30 48" src="https://user-images.githubusercontent.com/17325/32290717-d3b1a482-bf32-11e7-8e3e-1a2e709b983d.png">
