### PR TITLE
Promotions edit: Add product price to appliesTo

### DIFF
--- a/client/extensions/woocommerce/app/promotions/fields/promotion-applies-to-field/applies-to-filtered-list.js
+++ b/client/extensions/woocommerce/app/promotions/fields/promotion-applies-to-field/applies-to-filtered-list.js
@@ -10,6 +10,7 @@ import warn from 'lib/warn';
 /**
  * Internal dependencies
  */
+import formatCurrency from 'lib/format-currency';
 import FormLabel from 'components/forms/form-label';
 import FormRadio from 'components/forms/form-radio';
 import FormCheckbox from 'components/forms/form-checkbox';
@@ -118,6 +119,7 @@ class AppliesToFilteredList extends React.Component {
 		edit: PropTypes.func.isRequired,
 		products: PropTypes.array,
 		productCategories: PropTypes.array,
+		currency: PropTypes.string,
 	};
 
 	constructor( props ) {
@@ -196,9 +198,12 @@ class AppliesToFilteredList extends React.Component {
 		);
 	}
 
-	renderProductList( singular ) {
+	renderProductList( singular, currency ) {
 		const filteredProducts = this.getFilteredProducts() || [];
-		const renderFunc = ( singular ? this.renderProductRadio : this.renderProductCheckbox );
+		const renderFunc = ( singular
+			? this.renderProductRadio( currency )
+			: this.renderProductCheckbox( currency )
+		);
 
 		return (
 			<div className="promotion-applies-to-field__list">
@@ -216,24 +221,26 @@ class AppliesToFilteredList extends React.Component {
 		return renderRow( FormCheckbox, name, id, imageSrc, selected, this.onCategoryCheckbox );
 	}
 
-	renderProductCheckbox = ( product ) => {
+	renderProductCheckbox = ( currency ) => ( product ) => {
 		const { value } = this.props;
-		const { name, id, images } = product;
+		const { name, regular_price, id, images } = product;
+		const nameWithPrice = name + ' - ' + formatCurrency( regular_price, currency );
 		const selected = isProductSelected( value, id );
 		const image = images && images[ 0 ];
 		const imageSrc = image && image.src;
 
-		return renderRow( FormCheckbox, name, id, imageSrc, selected, this.onProductCheckbox );
+		return renderRow( FormCheckbox, nameWithPrice, id, imageSrc, selected, this.onProductCheckbox );
 	}
 
-	renderProductRadio = ( product ) => {
+	renderProductRadio = ( currency ) => ( product ) => {
 		const { value } = this.props;
-		const { name, id, images } = product;
+		const { name, regular_price, id, images } = product;
+		const nameWithPrice = name + ' - ' + formatCurrency( regular_price, currency );
 		const selected = isProductSelected( value, product.id );
 		const image = images && images[ 0 ];
 		const imageSrc = image && image.src;
 
-		return renderRow( FormRadio, name, id, imageSrc, selected, this.onProductRadio );
+		return renderRow( FormRadio, nameWithPrice, id, imageSrc, selected, this.onProductRadio );
 	}
 
 	onSearch = ( searchFilter ) => {

--- a/client/extensions/woocommerce/app/promotions/fields/style.scss
+++ b/client/extensions/woocommerce/app/promotions/fields/style.scss
@@ -66,7 +66,7 @@
 		border: 1px solid lighten( $gray, 20% );
 		z-index: 0; // Keeps search from overlapping header above.
 		box-sizing: border-box;
-		z-index: 99;
+		z-index: 9;
 	}
 
 	.form-fieldset {


### PR DESCRIPTION
This adds the product price next to each product so the user can better
see what prices each product has when they choose a sale price or a
discount.

To Test:

1. npm start
2. Visit` http://calypso.localhost:3000/store/promotion/<site url>`
3. Try out a coupon type and then the different appliesTo selections to observe the results.
4. Try out a product sale and the singular product selection.

![new_promotion_ _coderkevin_ _wordpress_com](https://user-images.githubusercontent.com/945228/32301797-6af4b40c-bf2d-11e7-8171-ff0afb0d7929.png)
