### PR TITLE
Store: Setup: Store Address: Avoid re-enabling save button right before navigating away

### DIFF
--- a/client/extensions/woocommerce/app/dashboard/pre-setup-view.js
+++ b/client/extensions/woocommerce/app/dashboard/pre-setup-view.js
@@ -73,7 +73,9 @@ class PreSetupView extends Component {
 		// plugins are installed and activated
 
 		const onSuccess = () => {
-			this.setState( { isSaving: false } );
+			// No need to set isSaving to false here - we're navigating away from here
+			// and setting isSaving to false will just light the button up again right
+			// before the next step's dialog displays
 			return setSetStoreAddressDuringInitialSetup( this.props.site.ID, true );
 		};
 


### PR DESCRIPTION
Fixes #16436

To test:
* Trash all your orders
* Trash all your products
* Use `https://developer.wordpress.com/docs/api/console/` to POST to `/sites/{YOURSITEID}/calypso-preferences/woocommerce` to reset `set_store_address_during_initial_setup` to 0 (see below - you can zero them all if you want)
* Navigate to http://calypso.localhost:3000/store/{YOURSITEDOMAIN}
* Observe the address prompt
* Hit Let's Go
* Ensure it doesn't re-enable (turn blue) before the Let's Set Up Your Store page appears

<img width="1013" alt="screen shot 2017-11-01 at 2 55 25 pm" src="https://user-images.githubusercontent.com/1595739/32299977-c537c97c-bf14-11e7-9f59-3df1f02be810.png">

![let-it-go](https://user-images.githubusercontent.com/1595739/32299981-ca788746-bf14-11e7-9dab-1828feb5d431.gif)
