### PR TITLE
Activity Log - added discarded styles and fixed up other bugs

### DIFF
--- a/client/my-sites/stats/activity-log-day/index.jsx
+++ b/client/my-sites/stats/activity-log-day/index.jsx
@@ -157,8 +157,8 @@ class ActivityLogDay extends Component {
 				primary={ 'primary' === type }
 			>
 				<Gridicon icon="history" size={ 18 } />{' '}
-				{ this.props.translate( 'Rewind {{em}}to this day{{/em}}', {
-					components: { em: <em /> },
+				{ this.props.translate( 'Rewind {{span}}to this day{{/span}}', {
+					components: { span: <span className="activity-log-day__rewind-button-extra-text" /> },
 				} ) }
 			</Button>
 		);
@@ -243,26 +243,23 @@ class ActivityLogDay extends Component {
 		);
 
 		return (
-			<div
+			<FoldableCard
 				className={ classNames( 'activity-log-day', {
 					'has-rewind-dialog': hasConfirmDialog,
 				} ) }
+				clickableHeader={ true }
+				expanded={ isToday || dayExpanded }
+				expandedSummary={ rewindButton }
+				summary={ rewindButton }
+				header={ this.renderEventsHeading() }
+				onOpen={ this.trackOpenDay }
+				onClose={ this.handleCloseDay( hasConfirmDialog ) }
 			>
-				<FoldableCard
-					clickableHeader={ true }
-					expanded={ isToday || dayExpanded }
-					expandedSummary={ rewindButton }
-					summary={ rewindButton }
-					header={ this.renderEventsHeading() }
-					onOpen={ this.trackOpenDay }
-					onClose={ this.handleCloseDay( hasConfirmDialog ) }
-				>
-					{ newer.map( log => <LogItem { ...{ key: log.activityId, log } } /> ) }
-					{ above && <LogItem { ...{ key: above.activityId, log: above, hasBreak: true } } /> }
-					{ older.length > 0 && rewindConfirmDialog }
-					{ older.map( log => <LogItem { ...{ key: log.activityId, log } } /> ) }
-				</FoldableCard>
-			</div>
+				{ newer.map( log => <LogItem { ...{ key: log.activityId, log } } /> ) }
+				{ above && <LogItem { ...{ key: above.activityId, log: above, hasBreak: true } } /> }
+				{ older.length > 0 && rewindConfirmDialog }
+				{ older.map( log => <LogItem { ...{ key: log.activityId, log } } /> ) }
+			</FoldableCard>
 		);
 	}
 }

--- a/client/my-sites/stats/activity-log-day/style.scss
+++ b/client/my-sites/stats/activity-log-day/style.scss
@@ -1,77 +1,21 @@
 // Activity Log
 .activity-log-day {
-	position: relative;
-	z-index: 2;
+	background: none;
+	box-shadow: none;
 
-	.card {
-		background: transparent;
-
-		.foldable-card__content {
-			padding: 0 0 16px;
-			background: transparent;
-		}
-	}
-
-	&.is-empty {
-		.card {
-			box-shadow: none;
-		}
-
-		.foldable-card__header {
-			background: $gray-light;
-			min-height: initial;
-			padding-bottom: 4px;
-			padding-top: 4px;
-		}
-	}
-
-	.foldable-card__header {
+	> .foldable-card__header {
 		background: $white;
-
-		.foldable-card__secondary {
-			flex: 2;
-		}
-	}
-
-	.foldable-card__main {
-		@include breakpoint( "<480px" ) {
-			flex: 3 1;
-		}
-	}
-
-	.foldable-card.card.is-expanded {
-		box-shadow: none;
-		margin: 0;
-
-		.foldable-card__header {
-			box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ),
+		box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ),
 			0 1px 2px lighten( $gray, 30% );
-		}
 	}
-}
 
-.activity-log-day__day {
-	font-weight: 600;
-}
-
-.activity-log-day__rewind-button {
-	em {
-		font-style: normal;
-
-		@include breakpoint( "<960px" ) {
-			display: none;
-		}
+	> .foldable-card__content.foldable-card__content { // Sad panda specificity override
+		padding: 24px 0 16px;
+		background: transparent;
 	}
-}
-
-.activity-log-day__events {
-	font-size: 12px;
-	color: $gray;
 }
 
 .activity-log-day__placeholder {
-	@extend .activity-log-day;
-
 	.activity-log-day__day,
 	.activity-log-day__events {
 		@include placeholder();
@@ -87,64 +31,17 @@
 	}
 }
 
-.activity-log-day, .activity-log-item {
-	position: relative;
+.activity-log-day__day {
+	font-weight: 600;
+}
 
-	&:before {
-		content: "";
-		position: absolute;
-		top: 73px;
-		height: 16px;
-		left: 33px;
-		width: 2px;
-		border-left: 2px solid lighten( $gray, 20% );
-
-		@include breakpoint( "<480px" ) {
-			left: 29px;
-		}
+.activity-log-day__rewind-button-extra-text {
+	@include breakpoint( "<960px" ) {
+		display: none;
 	}
 }
 
-.activity-log-item.is-discarded:before {
-	border-left-style: dotted;
-}
-
-.activity-log-day.is-empty:before {
-	top: 48px;
-}
-
-.activity-log-day:last-of-type:before {
-	width: 0;
-}
-
-.activity-log-item:before {
-	bottom: -16px;
-	height: auto;
-
-	@include breakpoint( "<480px" ) {
-		left: 21px;
-	}
-}
-
-.activity-log-item__restore-confirm:before {
-	bottom: 0;
-	height: auto;
-	top: 57px;
-}
-
-.activity-log-item.is-before-dialog:before {
-	content: none;
-}
-.has-rewind-dialog .activity-log-item__restore-confirm:first-child:after {
-	content: " ";
-	position: absolute;
-	top: -24px;
-	left: 33px;
-	height: 20px;
-	width: 4px;
-	background: $gray-light;
-
-	@include breakpoint( "<480px" ) {
-		left: 21px;
-	}
+.activity-log-day__events {
+	font-size: 12px;
+	color: $gray-text-min;
 }

--- a/client/my-sites/stats/activity-log-item/style.scss
+++ b/client/my-sites/stats/activity-log-item/style.scss
@@ -37,8 +37,8 @@
 		}
 	}
 
-	.foldable-card__main {
-		flex: 5 1;
+	.foldable-card__secondary {
+		flex-grow: 0;
 	}
 
 	&.is-discarded {
@@ -66,19 +66,6 @@
 				display: none;
 			}
 		}
-	}
-}
-
-.activity-log-item__card {
-	.foldable-card__content {
-		padding: 16px;
-		font-size: 14px;
-		color: darken( $gray, 20% );
-	}
-
-	.is-discarded & {
-		background: none;
-		box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 );
 	}
 }
 
@@ -141,10 +128,23 @@
 	}
 }
 
+.activity-log-item__card {
+	.foldable-card__content {
+		padding: 16px;
+		font-size: 14px;
+		color: darken( $gray, 20% );
+	}
+
+	.is-discarded & {
+		background: none;
+		box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 );
+	}
+}
+
 .activity-log-item__card-header {
 	display: flex;
-	flex: 1;
-	align-items: center;
+	flex-wrap: wrap;
+	margin-right: 32px;
 
 	@include breakpoint( "<960px" ) {
 		flex-direction: column;
@@ -154,23 +154,20 @@
 
 .activity-log-item__actor {
 	display: flex;
-	flex: 3 1;
-	align-items: center;
+	flex-shrink: 0;
 	margin-right: 32px;
-
-	@include breakpoint( "<960px" ) {
-		order: 2;
-	}
 
 	.gravatar,
 	.jetpack-logo {
 		float: left;
+		width: 40px;
+		height: 40px;
 		margin-right: 16px;
 		fill: darken( $gray, 10% );
 
 		@include breakpoint( "<960px" ) {
-			width: 24px;
-			height: 24px;
+			width: 32px;
+			height: 32px;
 			margin-right: 8px;
 		}
 	}
@@ -192,7 +189,8 @@
 	font-size: 14px;
 
 	@include breakpoint( "<960px" ) {
-		font-size: 13px;
+		margin-top: 2px;
+		line-height: 1;
 	}
 }
 
@@ -203,23 +201,11 @@
 }
 
 .activity-log-item__title {
-	flex: 4 1;
+	flex: 1 1 50%;
 	font-size: 14px;
 	word-break: break-word;
 
 	@include breakpoint( "<960px" ) {
-		margin-bottom: 16px;
+		margin-top: 8px;
 	}
-}
-
-.activity-log-item__action {
-	flex-basis: 25%;
-	text-align:right;
-}
-
-.activity-log-item__id {
-	margin-top: 8px;
-	font-size: 11px;
-	font-style: italic;
-	color: lighten( $gray, 20% );
 }

--- a/client/my-sites/stats/activity-log-item/style.scss
+++ b/client/my-sites/stats/activity-log-item/style.scss
@@ -1,39 +1,18 @@
 .activity-log-item {
 	display: flex;
-	flex-direction: row;
-	flex-wrap: wrap;
-	justify-content: flex-start;
-	align-content: flex-start;
-	align-items: center;
 	position: relative;
 
 	@include breakpoint( "<480px" ) {
 		margin-left: 8px;
 	}
 
-	// TODO: Remove when foldable cards become "expandable"
-	.foldable-card__header.is-clickable {
-		cursor: default;
-	}
-
-	&:first-of-type {
-		margin-top: 24px;
-	}
-
 	.card {
 		flex: 1;
+		margin-top: 8px;
 		margin-bottom: 16px;
-		background: $white;
-	}
-
-	.activity-log-item__card .foldable-card__content {
-		padding: 16px;
-		font-size: 14px;
-		color: darken( $gray, 20% );
 	}
 
 	.foldable-card {
-
 		.foldable-card__expand .gridicon {
 			transform: none;
 		}
@@ -51,6 +30,11 @@
 		@include breakpoint( "<480px" ) {
 			padding: 12px;
 		}
+
+		// TODO: Remove when foldable cards become "expandable"
+		.is-clickable {
+			cursor: default;
+		}
 	}
 
 	.foldable-card__main {
@@ -59,10 +43,42 @@
 
 	&.is-discarded {
 		margin-left: 80px;
+
+		@include breakpoint( "<480px" ) {
+			margin-left: 60px;
+		}
+
+		&:before {
+			content: '';
+			position: absolute;
+				top: 0;
+				left: 33px;
+			height: 100%;
+			border-left: 2px dotted lighten( $gray, 20% );
+
+			@include breakpoint( "<480px" ) {
+				left: 22px;
+			}
+		}
+
+		&:last-of-type {
+			&:before {
+				display: none;
+			}
+		}
+	}
+}
+
+.activity-log-item__card {
+	.foldable-card__content {
+		padding: 16px;
+		font-size: 14px;
+		color: darken( $gray, 20% );
 	}
 
-	&.is-discarded * {
-		background-color: unset;
+	.is-discarded & {
+		background: none;
+		box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 );
 	}
 }
 
@@ -72,6 +88,7 @@
 	text-align: center;
 	margin: -2px 22px 0 10px;
 	padding: 4px 0 6px;
+	z-index: 1;
 
 	@include breakpoint( "<480px" ) {
 		margin: -2px 8px 0 0px;
@@ -80,7 +97,7 @@
 
 .activity-log-item__time {
 	font-size: 11px;
-	color: $gray;
+	color: $gray-text-min;
 	text-transform: uppercase;
 	white-space: nowrap;
 
@@ -116,6 +133,12 @@
 	&.is-error {
 		background: $alert-red;
 	}
+
+	.is-discarded & {
+		color: $gray-text;
+		background: none;
+		border: 1px solid transparentize( lighten( $gray, 20% ), .5 );
+	}
 }
 
 .activity-log-item__card-header {
@@ -143,6 +166,7 @@
 	.jetpack-logo {
 		float: left;
 		margin-right: 16px;
+		fill: darken( $gray, 10% );
 
 		@include breakpoint( "<960px" ) {
 			width: 24px;
@@ -151,8 +175,16 @@
 		}
 	}
 
-	.jetpack-logo path {
-		fill: $green-jetpack;
+	.gravatar {
+		.is-discarded & {
+			filter: grayscale(1);
+		}
+	}
+
+	.jetpack-logo {
+		.is-discarded & {
+			opacity: .75;
+		}
 	}
 }
 
@@ -167,7 +199,7 @@
 .activity-log-item__actor-role {
 	text-transform: capitalize;
 	font-size: 12px;
-	color: $gray;
+	color: $gray-text-min;
 }
 
 .activity-log-item__title {

--- a/client/my-sites/stats/activity-log/style.scss
+++ b/client/my-sites/stats/activity-log/style.scss
@@ -18,12 +18,6 @@
 	}
 }
 
-
-
-
-
-
-
 .activity-log__rewind-toggle {
 	margin-bottom: 18px;
 }
@@ -50,5 +44,5 @@
 
 .activity-log__empty-day-events {
 	font-size: 12px;
-	color: $gray;
+	color: $gray-text-min;
 }

--- a/client/my-sites/stats/activity-log/style.scss
+++ b/client/my-sites/stats/activity-log/style.scss
@@ -1,5 +1,29 @@
 // Activity Log
 
+.activity-log__wrapper {
+	position: relative;
+
+	&:before {
+		content: '';
+		position: absolute;
+			top: 0;
+			left: 33px;
+		height: 100%;
+		width: 2px;
+		background: lighten( $gray, 20% );
+
+		@include breakpoint( "<480px" ) {
+			left: 29px;
+		}
+	}
+}
+
+
+
+
+
+
+
 .activity-log__rewind-toggle {
 	margin-bottom: 18px;
 }
@@ -9,18 +33,6 @@
 		margin: 32px 0;
 		max-width: 200px;
 	}
-}
-
-.rewind-requested .activity-log-day:not(.has-rewind-dialog),
-.has-rewind-dialog .activity-log-item,
-.has-rewind-dialog > .foldable-card > .foldable-card__header {
-	opacity: .5;
-}
-
-.has-rewind-dialog .activity-log-item__restore-confirm,
-.activity-log-item__restore-confirm ~ .activity-log-item,
-.rewind-requested .has-rewind-dialog ~ .activity-log-day {
-	opacity: 1;
 }
 
 .activity-log__empty-day {


### PR DESCRIPTION
This is a bit of a doozy for style changes. I tackled a bunch while I was in there since I had to shuffle some things around anyway.

#### Notes
* removed unused styles
* refactored for simpler styling
* removed unused div
* added classes to be more explicit with selectors
* added discarded styles: Fixes https://github.com/Automattic/wp-calypso/issues/19132 https://github.com/Automattic/wp-calypso/issues/18759
* rebuilt timelines to be friendlier to work with (and use fewer elements)
* converted em to span in the rewind button
* aligned items to their icons better
* made text colors a bit more accessible
* made sure text sizes matched our standards
* changed color of Jetpack icon: fixes https://github.com/Automattic/wp-calypso/issues/18862
* Removed overflowing line: Fixes https://github.com/Automattic/wp-calypso/issues/17065

#### Before
![image](https://user-images.githubusercontent.com/1123119/32301970-e580c1be-bf25-11e7-9efe-5d54ad7edf03.png)
![image](https://user-images.githubusercontent.com/1123119/32301942-be85b9d4-bf25-11e7-8947-16d1a1467a97.png)

#### After
![image](https://user-images.githubusercontent.com/1123119/32301780-f7d9f14c-bf24-11e7-9f25-00f538a5b947.png)
![image](https://user-images.githubusercontent.com/1123119/32301807-1489c218-bf25-11e7-9482-e9d5f66d8ef1.png)

#### What I wasn't able to do:
( @elio or @dmsnell maybe one of you could do one of these in a followup PR? )

1. I would like to show the cards above the rewind confirmation dialog as `is-discarded` which will detach the rewind dialog from them at the same time.  I don't think any CSS changes would be needed.

2. I would like to add an `is-discarded` class to `activity-log-day` whenever every event in the day is detached.

3. On Posts, Pages, and Comments, I would like to make the name of the post, page, or comment a link that the user can follow to the post in their dashboard (unless discarded, of course).
