### PR TITLE
Fix: Activity Log schema was missing `rewindId`

### DIFF
--- a/client/state/activity-log/log/schema.js
+++ b/client/state/activity-log/log/schema.js
@@ -34,6 +34,7 @@ const activityItemSchema = {
 		actorRole: { type: 'string' },
 		actorType: { type: 'string' },
 		actorWpcomId: { type: 'integer' },
+		rewindId: { type: [ 'null', 'string' ] },
 	},
 };
 


### PR DESCRIPTION
Might replace #19348 

This adds the rewind id to the persistence schema for Activity Log
events. That property wasn't added to the schema when in #19284 we
started pulling it in from the API responses (it had been added there
prior to that PR).

These events were persisting across sessions and then failed to
deserialize on account of the `additionalProperties` on the object.

**Testing**

Navigate to **Stats** > **Activity** for a site with Activity Log
events (Pressable site?). Make sure that there are events loaded
into the browser then reload.

On **master** you should find a schema validation failure for the
events and no immediate events should load, but in this branch
there should be no validation problem and the events should appear
immediately after reload.

<img width="537" alt="screen shot 2017-11-01 at 7 21 26 pm" src="https://user-images.githubusercontent.com/5431237/32302611-f0b98160-bf39-11e7-8c57-70ccef288b68.png">

---

I would have just committed to #19348 except I wasn't completely sure it
was addressing the same bug, plus I wanted to backup from some of the
changes there.