### PR TITLE
Store: Setup: Populate store address from checkout contact details if available

### DIFF
--- a/client/extensions/woocommerce/app/dashboard/index.js
+++ b/client/extensions/woocommerce/app/dashboard/index.js
@@ -133,6 +133,12 @@ class Dashboard extends Component {
 			setStoreAddressDuringInitialSetup,
 		} = this.props;
 
+		// render should not be calling renderDashboardContent unless we have a site and ID,
+		// but let's check anyways in case that should change externally
+		if ( ! selectedSite || ! selectedSite.ID ) {
+			return null;
+		}
+
 		if ( ! finishedInstallOfRequiredPlugins ) {
 			return <RequiredPluginsInstallView site={ selectedSite } />;
 		}
@@ -142,7 +148,7 @@ class Dashboard extends Component {
 		}
 
 		if ( ! setStoreAddressDuringInitialSetup && ! hasProducts ) {
-			return <PreSetupView siteId={ selectedSite.ID || null } />;
+			return <PreSetupView siteId={ selectedSite.ID } />;
 		}
 
 		if ( ! finishedInitialSetup ) {

--- a/client/extensions/woocommerce/app/dashboard/index.js
+++ b/client/extensions/woocommerce/app/dashboard/index.js
@@ -142,7 +142,7 @@ class Dashboard extends Component {
 		}
 
 		if ( ! setStoreAddressDuringInitialSetup && ! hasProducts ) {
-			return <PreSetupView site={ selectedSite } />;
+			return <PreSetupView siteId={ selectedSite.ID || null } />;
 		}
 
 		if ( ! finishedInitialSetup ) {

--- a/client/extensions/woocommerce/app/dashboard/pre-setup-view.js
+++ b/client/extensions/woocommerce/app/dashboard/pre-setup-view.js
@@ -41,7 +41,24 @@ class PreSetupView extends Component {
 	}
 
 	static propTypes = {
-		siteId: PropTypes.number,
+		siteId: PropTypes.number.isRequired,
+		contactDetails: PropTypes.shape( {
+			address1: PropTypes.string,
+			address2: PropTypes.string,
+			city: PropTypes.string,
+			state: PropTypes.string,
+			postalCode: PropTypes.string,
+			countryCode: PropTypes.string,
+		} ).isRequired,
+		settingsGeneralLoaded: PropTypes.bool.isRequired,
+		storeLocation: PropTypes.shape( {
+			street: PropTypes.string,
+			street2: PropTypes.string,
+			city: PropTypes.string,
+			state: PropTypes.string,
+			postcode: PropTypes.string,
+			country: PropTypes.string,
+		} ).isRequired,
 	};
 
 	componentWillReceiveProps = newProps => {

--- a/client/extensions/woocommerce/app/dashboard/pre-setup-view.js
+++ b/client/extensions/woocommerce/app/dashboard/pre-setup-view.js
@@ -8,6 +8,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
+import { includes, isEmpty, keys, pick } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -18,34 +19,73 @@ import {
 	areSettingsGeneralLoaded,
 	getStoreLocation,
 } from 'woocommerce/state/sites/settings/general/selectors';
+import BasicWidget from 'woocommerce/components/basic-widget';
 import { errorNotice } from 'state/notices/actions';
+import { getContactDetailsCache } from 'state/selectors';
 import { getCountryData, getCountries } from 'woocommerce/lib/countries';
 import { setSetStoreAddressDuringInitialSetup } from 'woocommerce/state/sites/setup-choices/actions';
 import SetupFooter from './setup-footer';
 import SetupHeader from './setup-header';
 import { doInitialSetup } from 'woocommerce/state/sites/settings/actions';
+import QueryContactDetailsCache from 'components/data/query-contact-details-cache';
 import QuerySettingsGeneral from 'woocommerce/components/query-settings-general';
 
 class PreSetupView extends Component {
 	constructor( props ) {
 		super( props );
 		this.state = {
-			address: props.address,
+			address: {},
 			isSaving: false,
 			userBeganEditing: false,
 		};
 	}
 
 	static propTypes = {
-		site: PropTypes.shape( {
-			ID: PropTypes.number.isRequired,
-		} ),
+		siteId: PropTypes.number,
 	};
 
 	componentWillReceiveProps = newProps => {
+		const { contactDetails, storeLocation } = newProps;
+
 		if ( ! this.state.userBeganEditing ) {
-			this.setState( { address: newProps.address } );
+			// Once store address (if any) from settings general and contact details have arrived
+			if ( contactDetails && storeLocation ) {
+				let address = {
+					street: '',
+					street2: '',
+					city: '',
+					state: 'AL',
+					postcode: '',
+					country: 'US',
+				};
+				// If the settings general country is US or CA and it has a street address, use it
+				// Otherwise, if the contact details country is US or CA and it has a street address, use it
+				if (
+					includes( [ 'US', 'CA' ], storeLocation.country ) &&
+					! isEmpty( storeLocation.street )
+				) {
+					address = pick( storeLocation, keys( address ) );
+				} else if (
+					includes( [ 'US', 'CA' ], contactDetails.countryCode ) &&
+					! isEmpty( contactDetails.address1 )
+				) {
+					address = this.getAddressFromContactDetails( contactDetails );
+				}
+				this.setState( { address } );
+			}
 		}
+	};
+
+	getAddressFromContactDetails = contactDetails => {
+		const { address1, address2, city, state, postalCode, countryCode } = contactDetails;
+		return {
+			street: address1 || '',
+			street2: address2 || '',
+			city: city || '',
+			state: state || 'AL',
+			postcode: postalCode || '',
+			country: countryCode || 'US',
+		};
 	};
 
 	onChange = event => {
@@ -65,7 +105,7 @@ class PreSetupView extends Component {
 	};
 
 	onNext = event => {
-		const { site, translate } = this.props;
+		const { siteId, translate } = this.props;
 		event.preventDefault();
 		this.setState( { isSaving: true } );
 
@@ -76,7 +116,7 @@ class PreSetupView extends Component {
 			// No need to set isSaving to false here - we're navigating away from here
 			// and setting isSaving to false will just light the button up again right
 			// before the next step's dialog displays
-			return setSetStoreAddressDuringInitialSetup( this.props.site.ID, true );
+			return setSetStoreAddressDuringInitialSetup( siteId, true );
 		};
 
 		const onFailure = () => {
@@ -103,7 +143,7 @@ class PreSetupView extends Component {
 		}
 
 		this.props.doInitialSetup(
-			site.ID,
+			siteId,
 			this.state.address.street,
 			this.state.address.street2,
 			this.state.address.city,
@@ -115,22 +155,20 @@ class PreSetupView extends Component {
 		);
 	};
 
-	render = () => {
-		const { loaded, site, translate } = this.props;
+	renderForm = () => {
+		const { contactDetails, settingsGeneralLoaded, translate } = this.props;
+		const showForm = contactDetails && settingsGeneralLoaded;
 
-		if ( ! loaded ) {
-			// TODO - maybe a loading placehoder
-			return <QuerySettingsGeneral siteId={ site && site.ID } />;
+		if ( ! showForm ) {
+			return (
+				<div className="dashboard__placeholder">
+					<BasicWidget className="dashboard__placeholder-large card" />
+				</div>
+			);
 		}
 
 		return (
-			<div className="card dashboard__setup-wrapper dashboard__location">
-				<SetupHeader
-					imageSource={ '/calypso/images/extensions/woocommerce/woocommerce-setup.svg' }
-					imageWidth={ 160 }
-					title={ translate( 'Howdy! Ready to start selling?' ) }
-					subtitle={ translate( 'First we need to know where you are in the world.' ) }
-				/>
+			<div>
 				<AddressView
 					address={ this.state.address }
 					className="dashboard__pre-setup-address"
@@ -146,20 +184,37 @@ class PreSetupView extends Component {
 			</div>
 		);
 	};
+
+	render = () => {
+		const { siteId, translate } = this.props;
+
+		return (
+			<div className="card dashboard__setup-wrapper dashboard__location">
+				<SetupHeader
+					imageSource={ '/calypso/images/extensions/woocommerce/woocommerce-setup.svg' }
+					imageWidth={ 160 }
+					title={ translate( 'Howdy! Ready to start selling?' ) }
+					subtitle={ translate( 'First we need to know where you are in the world.' ) }
+				/>
+				{ this.renderForm() }
+				<QuerySettingsGeneral siteId={ siteId } />
+				<QueryContactDetailsCache />
+			</div>
+		);
+	};
 }
 
 function mapStateToProps( state, ownProps ) {
-	let loaded = false;
-	let address = {};
+	const { siteId } = ownProps;
 
-	if ( ownProps.site ) {
-		address = getStoreLocation( state, ownProps.site.ID );
-		loaded = areSettingsGeneralLoaded( state, ownProps.site.ID );
-	}
+	const contactDetails = getContactDetailsCache( state );
+	const settingsGeneralLoaded = areSettingsGeneralLoaded( state, siteId );
+	const storeLocation = getStoreLocation( state, siteId );
 
 	return {
-		address,
-		loaded,
+		contactDetails,
+		settingsGeneralLoaded,
+		storeLocation,
 	};
 }
 

--- a/client/extensions/woocommerce/app/dashboard/pre-setup-view.js
+++ b/client/extensions/woocommerce/app/dashboard/pre-setup-view.js
@@ -49,8 +49,8 @@ class PreSetupView extends Component {
 			state: PropTypes.string,
 			postalCode: PropTypes.string,
 			countryCode: PropTypes.string,
-		} ).isRequired,
-		settingsGeneralLoaded: PropTypes.bool.isRequired,
+		} ),
+		settingsGeneralLoaded: PropTypes.bool,
 		storeLocation: PropTypes.shape( {
 			street: PropTypes.string,
 			street2: PropTypes.string,
@@ -58,7 +58,7 @@ class PreSetupView extends Component {
 			state: PropTypes.string,
 			postcode: PropTypes.string,
 			country: PropTypes.string,
-		} ).isRequired,
+		} ),
 	};
 
 	componentWillReceiveProps = newProps => {


### PR DESCRIPTION
Fixes #16432

To test (the easy way):

* Trash all your orders
* Trash all your products
* Use `https://developer.wordpress.com/docs/api/console/` to POST to `/sites/{YOURSITEID}/calypso-preferences/woocommerce` to reset `set_store_address_during_initial_setup` to 0 (see below - you can zero them all if you want)
* Navigate to http://calypso.localhost:3000/store/{YOURSITEDOMAIN}
* Observe the address prompt
* You should see your store address there - that's awesome - that's what it does today
* To force it to use your WPCOM checkout details, modify `componentWillReceiveProps` in `pre-setup-view.js` to falsify the initial conditional, i.e.

<img width="1067" alt="screen shot 2017-11-01 at 4 19 04 pm" src="https://user-images.githubusercontent.com/1595739/32302667-1b93e92a-bf21-11e7-9cfd-504573bee6f5.png">

To test (the hard way):
* Create a new WordPress.com user
* Give them some credits
* Login as them and create a new site with the business plan
* Install WooCommerce to trigger automated transfer
* When prompted for store address, note that it has pre-filled the form with your contact details you provided earlier in the checkout process (US and CA only)
