### PR TITLE
Editor: Select post type in all components instead of passing

### DIFF
--- a/client/post-editor/controller.js
+++ b/client/post-editor/controller.js
@@ -55,7 +55,7 @@ function determinePostType( context ) {
 	return context.params.type;
 }
 
-function renderEditor( context, postType ) {
+function renderEditor( context ) {
 	ReactDom.unmountComponentAtNode( document.getElementById( 'secondary' ) );
 	ReactDom.render(
 		React.createElement(
@@ -64,7 +64,6 @@ function renderEditor( context, postType ) {
 			React.createElement( PostEditor, {
 				user: user,
 				userUtils: userUtils,
-				type: postType,
 			} )
 		),
 		document.getElementById( 'primary' )
@@ -287,7 +286,7 @@ export default {
 			unsubscribe = context.store.subscribe( startEditingOnSiteSelected );
 		}
 
-		renderEditor( context, postType );
+		renderEditor( context );
 	},
 
 	exitPost: function( context, next ) {

--- a/client/post-editor/editor-action-bar/index.jsx
+++ b/client/post-editor/editor-action-bar/index.jsx
@@ -21,7 +21,7 @@ import EditorActionBarViewLabel from './view-label';
 import EditorStatusLabel from 'post-editor/editor-status-label';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getEditorPostId } from 'state/ui/editor/selectors';
-import { getEditedPost } from 'state/posts/selectors';
+import { getEditedPost, getEditedPostValue } from 'state/posts/selectors';
 
 class EditorActionBar extends Component {
 	static propTypes = {
@@ -52,11 +52,7 @@ class EditorActionBar extends Component {
 			<div className="editor-action-bar">
 				<div className="editor-action-bar__cell is-left">
 					{ ! this.props.hasEditorNestedSidebar && (
-						<EditorStatusLabel
-							post={ this.props.savedPost }
-							advancedStatus
-							type={ this.props.type }
-						/>
+						<EditorStatusLabel post={ this.props.savedPost } advancedStatus />
 					) }
 				</div>
 				<div className="editor-action-bar__cell is-center">
@@ -105,10 +101,12 @@ export default connect( state => {
 	const siteId = getSelectedSiteId( state );
 	const postId = getEditorPostId( state );
 	const post = getEditedPost( state, siteId, postId );
+	const type = getEditedPostValue( state, siteId, postId, 'type' );
 
 	return {
 		siteId,
 		postId,
 		post,
+		type,
 	};
 } )( EditorActionBar );

--- a/client/post-editor/editor-drawer/index.jsx
+++ b/client/post-editor/editor-drawer/index.jsx
@@ -276,7 +276,7 @@ class EditorDrawer extends Component {
 			return;
 		}
 
-		return <EditorMoreOptionsCopyPost type={ type } />;
+		return <EditorMoreOptionsCopyPost />;
 	}
 
 	renderMoreOptions() {
@@ -325,7 +325,6 @@ class EditorDrawer extends Component {
 				<EditPostStatus
 					savedPost={ this.props.savedPost }
 					postDate={ postDate }
-					type={ this.props.type }
 					onSave={ this.props.onSave }
 					onTrashingPost={ this.props.onTrashingPost }
 					onPrivatePublish={ this.props.onPrivatePublish }
@@ -377,6 +376,7 @@ const enhance = flow(
 				isJetpack: isJetpackSite( state, siteId ),
 				isSeoToolsModuleActive: isJetpackModuleActive( state, siteId, 'seo-tools' ),
 				jetpackVersionSupportsSeo: isJetpackMinimumVersion( state, siteId, '4.4-beta1' ),
+				type,
 				typeObject: getPostType( state, siteId, type ),
 			};
 		},

--- a/client/post-editor/editor-ground-control/index.jsx
+++ b/client/post-editor/editor-ground-control/index.jsx
@@ -50,7 +50,6 @@ export class EditorGroundControl extends PureComponent {
 		userUtils: PropTypes.object,
 		toggleSidebar: PropTypes.func,
 		translate: PropTypes.func,
-		type: PropTypes.string,
 	};
 
 	static defaultProps = {

--- a/client/post-editor/editor-more-options/copy-post.jsx
+++ b/client/post-editor/editor-more-options/copy-post.jsx
@@ -16,6 +16,8 @@ import Gridicon from 'gridicons';
  */
 import { getSiteSlug } from 'state/sites/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
+import { getEditedPostValue } from 'state/posts/selectors';
+import { getEditorPostId } from 'state/ui/editor/selectors';
 import AccordionSection from 'components/accordion/section';
 import Button from 'components/button';
 import Dialog from 'components/dialog';
@@ -147,9 +149,13 @@ class EditorMoreOptionsCopyPost extends Component {
 }
 
 export default connect( state => {
+	const postId = getEditorPostId( state );
 	const siteId = getSelectedSiteId( state );
+	const type = getEditedPostValue( state, siteId, postId, 'type' );
+
 	return {
 		siteId,
 		siteSlug: getSiteSlug( state, siteId ),
+		type,
 	};
 } )( localize( EditorMoreOptionsCopyPost ) );

--- a/client/post-editor/editor-sidebar/index.jsx
+++ b/client/post-editor/editor-sidebar/index.jsx
@@ -29,7 +29,6 @@ export default class EditorSidebar extends Component {
 		onPublish: PropTypes.func,
 		onTrashingPost: PropTypes.func,
 		site: PropTypes.object,
-		type: PropTypes.string,
 		toggleSidebar: PropTypes.func,
 		setPostDate: PropTypes.func,
 		isPostPrivate: PropTypes.bool,
@@ -58,7 +57,6 @@ export default class EditorSidebar extends Component {
 			post,
 			savedPost,
 			site,
-			type,
 			setPostDate,
 			isPostPrivate,
 			confirmationSidebarStatus,
@@ -79,20 +77,13 @@ export default class EditorSidebar extends Component {
 					nestedSidebar={ nestedSidebar }
 					toggleSidebar={ this.headerToggleSidebar }
 				/>
-				<EditorActionBar
-					isNew={ isNew }
-					post={ post }
-					savedPost={ savedPost }
-					site={ site }
-					type={ type }
-				/>
+				<EditorActionBar isNew={ isNew } post={ post } savedPost={ savedPost } site={ site } />
 				<SidebarRegion className="editor-sidebar__parent-region">
 					<EditorDrawer
 						site={ site }
 						savedPost={ savedPost }
 						post={ post }
 						isNew={ isNew }
-						type={ type }
 						setPostDate={ setPostDate }
 						onPrivatePublish={ onPublish }
 						onSave={ onSave }

--- a/client/post-editor/editor-status-label/index.jsx
+++ b/client/post-editor/editor-status-label/index.jsx
@@ -22,7 +22,6 @@ class StatusLabel extends React.PureComponent {
 	static propTypes = {
 		onClick: PropTypes.func,
 		post: PropTypes.object,
-		type: PropTypes.string,
 		advancedStatus: PropTypes.bool,
 	};
 
@@ -30,7 +29,6 @@ class StatusLabel extends React.PureComponent {
 		onClick: null,
 		post: null,
 		advancedStatus: false,
-		type: 'post',
 	};
 
 	state = {

--- a/client/post-editor/editor-term-selector/add-term.jsx
+++ b/client/post-editor/editor-term-selector/add-term.jsx
@@ -17,6 +17,8 @@ import Gridicon from 'gridicons';
 import Button from 'components/button';
 import TermFormDialog from 'blocks/term-form-dialog';
 import { getSelectedSiteId } from 'state/ui/selectors';
+import { getEditorPostId } from 'state/ui/editor/selectors';
+import { getEditedPostValue } from 'state/posts/selectors';
 import { getPostTypeTaxonomy } from 'state/post-types/taxonomies/selectors';
 import { getTerms } from 'state/terms/selectors';
 
@@ -24,9 +26,9 @@ class TermSelectorAddTerm extends Component {
 	static propTypes = {
 		labels: PropTypes.object,
 		onSuccess: PropTypes.func,
-		postType: PropTypes.string,
 		taxonomy: PropTypes.string,
 		terms: PropTypes.array,
+		type: PropTypes.string,
 	};
 
 	static defaultProps = {
@@ -50,7 +52,7 @@ class TermSelectorAddTerm extends Component {
 	};
 
 	render() {
-		const { labels, onSuccess, postType, terms, taxonomy } = this.props;
+		const { labels, onSuccess, type, terms, taxonomy } = this.props;
 		const totalTerms = terms ? terms.length : 0;
 		const classes = classNames( 'editor-term-selector__add-term', {
 			'is-compact': totalTerms < 8,
@@ -64,7 +66,7 @@ class TermSelectorAddTerm extends Component {
 				<TermFormDialog
 					showDialog={ this.state.showDialog }
 					onClose={ this.closeDialog }
-					postType={ postType }
+					postType={ type }
 					taxonomy={ taxonomy }
 					onSuccess={ onSuccess }
 				/>
@@ -73,14 +75,16 @@ class TermSelectorAddTerm extends Component {
 	}
 }
 
-export default connect( ( state, ownProps ) => {
-	const { taxonomy, postType } = ownProps;
+export default connect( ( state, { taxonomy } ) => {
 	const siteId = getSelectedSiteId( state );
-	const taxonomyDetails = getPostTypeTaxonomy( state, siteId, postType, taxonomy );
+	const postId = getEditorPostId( state );
+	const type = getEditedPostValue( state, siteId, postId, 'type' );
+	const taxonomyDetails = getPostTypeTaxonomy( state, siteId, type, taxonomy );
 	const labels = get( taxonomyDetails, 'labels', {} );
 
 	return {
 		terms: getTerms( state, siteId, taxonomy ),
 		labels,
+		type,
 	};
 } )( TermSelectorAddTerm );

--- a/client/post-editor/editor-term-selector/index.jsx
+++ b/client/post-editor/editor-term-selector/index.jsx
@@ -25,7 +25,6 @@ class EditorTermSelector extends Component {
 		siteId: PropTypes.number,
 		postId: PropTypes.number,
 		postTerms: PropTypes.object,
-		postType: PropTypes.string,
 		taxonomyName: PropTypes.string,
 		canEditTerms: PropTypes.bool,
 		compact: PropTypes.bool,
@@ -68,7 +67,7 @@ class EditorTermSelector extends Component {
 	}
 
 	render() {
-		const { postType, siteId, taxonomyName, canEditTerms, compact } = this.props;
+		const { siteId, taxonomyName, canEditTerms, compact } = this.props;
 
 		return (
 			<div>
@@ -81,9 +80,7 @@ class EditorTermSelector extends Component {
 					multiple={ true }
 					compact={ compact }
 				/>
-				{ canEditTerms && (
-					<AddTerm taxonomy={ taxonomyName } postType={ postType } onSuccess={ this.onAddTerm } />
-				) }
+				{ canEditTerms && <AddTerm taxonomy={ taxonomyName } onSuccess={ this.onAddTerm } /> }
 			</div>
 		);
 	}
@@ -95,7 +92,6 @@ export default connect(
 		const postId = getEditorPostId( state );
 
 		return {
-			postType: getEditedPostValue( state, siteId, getEditorPostId( state ), 'type' ),
 			postTerms: getEditedPostValue( state, siteId, postId, 'terms' ),
 			canEditTerms: canCurrentUser( state, siteId, 'manage_categories' ),
 			siteId,

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -49,7 +49,7 @@ import {
 } from 'state/ui/editor/selectors';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { editPost, receivePost, savePostSuccess } from 'state/posts/actions';
-import { getPostEdits, isEditedPostDirty } from 'state/posts/selectors';
+import { getEditedPostValue, getPostEdits, isEditedPostDirty } from 'state/posts/selectors';
 import { getCurrentUserId } from 'state/current-user/selectors';
 import { hasBrokenSiteUserConnection } from 'state/selectors';
 import EditorConfirmationSidebar from 'post-editor/editor-confirmation-sidebar';
@@ -98,6 +98,7 @@ export const PostEditor = createReactClass( {
 		translate: PropTypes.func.isRequired,
 		hasBrokenPublicizeConnection: PropTypes.bool,
 		editPost: PropTypes.func,
+		type: PropTypes.string,
 	},
 
 	_previewWindow: null,
@@ -369,7 +370,6 @@ export const PostEditor = createReactClass( {
 						user={ this.props.user }
 						userUtils={ this.props.userUtils }
 						toggleSidebar={ this.toggleSidebar }
-						type={ this.props.type }
 						onMoreInfoAboutEmailVerify={ this.onMoreInfoAboutEmailVerify }
 						allPostsUrl={ this.getAllPostsUrl() }
 						nestedSidebar={ this.state.nestedSidebar }
@@ -384,7 +384,6 @@ export const PostEditor = createReactClass( {
 								onPrivatePublish={ this.onPublish }
 								savedPost={ this.state.savedPost }
 								site={ site }
-								type={ this.props.type }
 								isPostPrivate={ utils.isPrivate( this.state.post ) }
 								postAuthor={ this.state.post ? this.state.post.author : null }
 								hasEditorNestedSidebar={ this.state.nestedSidebar !== NESTED_SIDEBAR_NONE }
@@ -397,7 +396,7 @@ export const PostEditor = createReactClass( {
 									homeLink={ true }
 									externalLink={ true }
 								/>
-								<StatusLabel post={ this.state.savedPost } type={ this.props.type } />
+								<StatusLabel post={ this.state.savedPost } />
 							</div>
 							<div
 								className={ classNames( 'post-editor__inner-content', {
@@ -474,7 +473,6 @@ export const PostEditor = createReactClass( {
 						onPublish={ this.onPublish }
 						onTrashingPost={ this.onTrashingPost }
 						site={ site }
-						type={ this.props.type }
 						setPostDate={ this.setPostDate }
 						onSave={ this.onSave }
 						isPostPrivate={ utils.isPrivate( this.state.post ) }
@@ -1389,10 +1387,12 @@ export default connect(
 		const siteId = getSelectedSiteId( state );
 		const postId = getEditorPostId( state );
 		const userId = getCurrentUserId( state );
+		const type = getEditedPostValue( state, siteId, postId, 'type' );
 
 		return {
 			siteId,
 			postId,
+			type,
 			selectedSite: getSelectedSite( state ),
 			selectedSiteDomain: getSiteDomain( state, siteId ),
 			editorModePreference: getPreference( state, 'editor-mode' ),


### PR DESCRIPTION
### Summary
This PR is part of an attempt to incrementally make the PostEditor (and related components) more flexible and easier to work with. Specifically, this change set looks at selecting the `type` value of the currently editing post from state and connecting this value instead of passing it down through a chain of parent components.

### Testing
There should be no change to functionality anywhere in the editor.