### PR TITLE
Dispatch eventMessage only when necessary

### DIFF
--- a/client/state/happychat/middleware.js
+++ b/client/state/happychat/middleware.js
@@ -59,7 +59,9 @@ export const socketMiddleware = ( connection = null ) => {
 			case HAPPYCHAT_BLUR:
 			case HAPPYCHAT_FOCUS:
 				const state = store.getState();
-				isHappychatClientConnected( state ) && isHappychatChatAssigned( state )
+				isHappychatClientConnected( state ) &&
+				isHappychatChatAssigned( state ) &&
+				eventMessage[ action.type ]
 					? store.dispatch( sendEvent( eventMessage[ action.type ] ) )
 					: noop;
 				break;

--- a/client/state/happychat/middleware.js
+++ b/client/state/happychat/middleware.js
@@ -1,6 +1,11 @@
 /** @format */
 
 /**
+ * External dependencies
+ */
+import { noop } from 'lodash';
+
+/**
  * Internal dependencies
  */
 import {
@@ -17,6 +22,8 @@ import {
 } from 'state/action-types';
 import { sendEvent } from 'state/happychat/connection/actions';
 import buildConnection from 'lib/happychat/connection';
+import isHappychatClientConnected from 'state/happychat/selectors/is-happychat-client-connected';
+import isHappychatChatAssigned from 'state/happychat/selectors/is-happychat-chat-assigned';
 
 const eventMessage = {
 	HAPPYCHAT_BLUR: 'Stopped looking at Happychat',
@@ -51,9 +58,13 @@ export const socketMiddleware = ( connection = null ) => {
 
 			case HAPPYCHAT_BLUR:
 			case HAPPYCHAT_FOCUS:
-				store.dispatch( sendEvent( eventMessage[ action.type ] ) );
+				const state = store.getState();
+				isHappychatClientConnected( state ) && isHappychatChatAssigned( state )
+					? store.dispatch( sendEvent( eventMessage[ action.type ] ) )
+					: noop;
 				break;
 		}
+
 		return next( action );
 	};
 };

--- a/client/state/happychat/test/middleware.js
+++ b/client/state/happychat/test/middleware.js
@@ -101,7 +101,7 @@ describe( 'middleware', () => {
 	} );
 
 	describe( 'eventMessage', () => {
-		test( 'is dispatched if client is connected and chat is assigned', () => {
+		test( 'is dispatched if client is connected, chat is assigned, and there is a message for the action', () => {
 			const state = {
 				happychat: {
 					connection: {
@@ -121,7 +121,7 @@ describe( 'middleware', () => {
 			);
 		} );
 
-		test( 'is not dispatched is client is not connected', () => {
+		test( 'is not dispatched if client is not connected', () => {
 			const state = {
 				happychat: {
 					connection: {
@@ -151,6 +151,23 @@ describe( 'middleware', () => {
 			};
 			store.getState.mockReturnValue( state );
 			const action = blur();
+			actionMiddleware( action );
+			expect( store.dispatch ).not.toHaveBeenCalled();
+		} );
+
+		test( 'is not dispatched if there is no message defined', () => {
+			const state = {
+				happychat: {
+					connection: {
+						status: HAPPYCHAT_CONNECTION_STATUS_CONNECTED,
+					},
+					chat: {
+						status: HAPPYCHAT_CHAT_STATUS_ASSIGNED,
+					},
+				},
+			};
+			store.getState.mockReturnValue( state );
+			const action = { type: 'HAPPYCHAT_ACTION_WITHOUT_EVENT_MESSAGE_DEFINED' };
 			actionMiddleware( action );
 			expect( store.dispatch ).not.toHaveBeenCalled();
 		} );

--- a/client/state/happychat/test/middleware.js
+++ b/client/state/happychat/test/middleware.js
@@ -15,6 +15,13 @@ import {
 	sendTyping,
 	sendNotTyping,
 } from 'state/happychat/connection/actions';
+import { blur } from 'state/happychat/ui/actions';
+import {
+	HAPPYCHAT_CHAT_STATUS_ASSIGNED,
+	HAPPYCHAT_CHAT_STATUS_NEW,
+	HAPPYCHAT_CONNECTION_STATUS_CONNECTED,
+	HAPPYCHAT_CONNECTION_STATUS_UNINITIALIZED,
+} from 'state/happychat/constants';
 
 describe( 'middleware', () => {
 	let actionMiddleware, connection, store;
@@ -90,6 +97,62 @@ describe( 'middleware', () => {
 			const action = requestTranscript( 20, 30 );
 			actionMiddleware( action );
 			expect( connection.request ).toHaveBeenCalledWith( action, action.timeout );
+		} );
+	} );
+
+	describe( 'eventMessage', () => {
+		test( 'is dispatched if client is connected and chat is assigned', () => {
+			const state = {
+				happychat: {
+					connection: {
+						status: HAPPYCHAT_CONNECTION_STATUS_CONNECTED,
+					},
+					chat: {
+						status: HAPPYCHAT_CHAT_STATUS_ASSIGNED,
+					},
+				},
+			};
+			store.getState.mockReturnValue( state );
+			const action = blur();
+			actionMiddleware( action );
+			expect( store.dispatch.mock.calls[ 0 ][ 0 ].event ).toBe( 'message' );
+			expect( store.dispatch.mock.calls[ 0 ][ 0 ].payload.text ).toBe(
+				'Stopped looking at Happychat'
+			);
+		} );
+
+		test( 'is not dispatched is client is not connected', () => {
+			const state = {
+				happychat: {
+					connection: {
+						status: HAPPYCHAT_CONNECTION_STATUS_UNINITIALIZED,
+					},
+					chat: {
+						status: HAPPYCHAT_CHAT_STATUS_ASSIGNED,
+					},
+				},
+			};
+			store.getState.mockReturnValue( state );
+			const action = blur();
+			actionMiddleware( action );
+			expect( store.dispatch ).not.toHaveBeenCalled();
+		} );
+
+		test( 'is not dispatched if chat is not assigned', () => {
+			const state = {
+				happychat: {
+					connection: {
+						status: HAPPYCHAT_CONNECTION_STATUS_CONNECTED,
+					},
+					chat: {
+						status: HAPPYCHAT_CHAT_STATUS_NEW,
+					},
+				},
+			};
+			store.getState.mockReturnValue( state );
+			const action = blur();
+			actionMiddleware( action );
+			expect( store.dispatch ).not.toHaveBeenCalled();
 		} );
 	} );
 } );

--- a/client/state/happychat/test/middleware.js
+++ b/client/state/happychat/test/middleware.js
@@ -15,11 +15,22 @@ import {
 	sendTyping,
 	sendNotTyping,
 } from 'state/happychat/connection/actions';
-import { blur } from 'state/happychat/ui/actions';
+import { blur, focus } from 'state/happychat/ui/actions';
 import {
+	HAPPYCHAT_CHAT_STATUS_ABANDONED,
 	HAPPYCHAT_CHAT_STATUS_ASSIGNED,
+	HAPPYCHAT_CHAT_STATUS_ASSIGNING,
+	HAPPYCHAT_CHAT_STATUS_BLOCKED,
+	HAPPYCHAT_CHAT_STATUS_CLOSED,
+	HAPPYCHAT_CHAT_STATUS_DEFAULT,
+	HAPPYCHAT_CHAT_STATUS_MISSED,
 	HAPPYCHAT_CHAT_STATUS_NEW,
+	HAPPYCHAT_CHAT_STATUS_PENDING,
 	HAPPYCHAT_CONNECTION_STATUS_CONNECTED,
+	HAPPYCHAT_CONNECTION_STATUS_CONNECTING,
+	HAPPYCHAT_CONNECTION_STATUS_DISCONNECTED,
+	HAPPYCHAT_CONNECTION_STATUS_RECONNECTING,
+	HAPPYCHAT_CONNECTION_STATUS_UNAUTHORIZED,
 	HAPPYCHAT_CONNECTION_STATUS_UNINITIALIZED,
 } from 'state/happychat/constants';
 
@@ -101,71 +112,81 @@ describe( 'middleware', () => {
 	} );
 
 	describe( 'eventMessage', () => {
-		test( 'is dispatched if client is connected, chat is assigned, and there is a message for the action', () => {
-			const state = {
-				happychat: {
-					connection: {
-						status: HAPPYCHAT_CONNECTION_STATUS_CONNECTED,
-					},
-					chat: {
-						status: HAPPYCHAT_CHAT_STATUS_ASSIGNED,
-					},
+		const state = {
+			happychat: {
+				connection: {
+					status: HAPPYCHAT_CONNECTION_STATUS_CONNECTED,
 				},
-			};
-			store.getState.mockReturnValue( state );
-			const action = blur();
-			actionMiddleware( action );
-			expect( store.dispatch.mock.calls[ 0 ][ 0 ].event ).toBe( 'message' );
-			expect( store.dispatch.mock.calls[ 0 ][ 0 ].payload.text ).toBe(
-				'Stopped looking at Happychat'
-			);
+				chat: {
+					status: HAPPYCHAT_CHAT_STATUS_ASSIGNED,
+				},
+			},
+		};
+
+		describe( 'is dispatched if client is connected, chat is assigned, and there is a message for the action', () => {
+			test( 'for HAPPYCHAT_BLUR', () => {
+				store.getState.mockReturnValue( state );
+				const action = blur();
+				actionMiddleware( action );
+
+				expect( store.dispatch.mock.calls[ 0 ][ 0 ].event ).toBe( 'message' );
+				expect( store.dispatch.mock.calls[ 0 ][ 0 ].payload.text ).toBe(
+					'Stopped looking at Happychat'
+				);
+			} );
+
+			test( 'for HAPPYCHAT_FOCUS', () => {
+				store.getState.mockReturnValue( state );
+				const action = focus();
+				actionMiddleware( action );
+
+				expect( store.dispatch.mock.calls[ 0 ][ 0 ].event ).toBe( 'message' );
+				expect( store.dispatch.mock.calls[ 0 ][ 0 ].payload.text ).toBe(
+					'Started looking at Happychat'
+				);
+			} );
 		} );
 
 		test( 'is not dispatched if client is not connected', () => {
-			const state = {
-				happychat: {
-					connection: {
-						status: HAPPYCHAT_CONNECTION_STATUS_UNINITIALIZED,
-					},
-					chat: {
-						status: HAPPYCHAT_CHAT_STATUS_ASSIGNED,
-					},
-				},
-			};
-			store.getState.mockReturnValue( state );
-			const action = blur();
-			actionMiddleware( action );
-			expect( store.dispatch ).not.toHaveBeenCalled();
+			[
+				HAPPYCHAT_CONNECTION_STATUS_CONNECTING,
+				HAPPYCHAT_CONNECTION_STATUS_DISCONNECTED,
+				HAPPYCHAT_CONNECTION_STATUS_RECONNECTING,
+				HAPPYCHAT_CONNECTION_STATUS_UNAUTHORIZED,
+				HAPPYCHAT_CONNECTION_STATUS_UNINITIALIZED,
+			].forEach( connectionStatus => {
+				store.getState.mockReturnValue(
+					Object.assign( state, { happychat: { connection: { status: connectionStatus } } } )
+				);
+				const action = blur();
+				actionMiddleware( action );
+
+				expect( store.dispatch ).not.toHaveBeenCalled();
+			} );
 		} );
 
 		test( 'is not dispatched if chat is not assigned', () => {
-			const state = {
-				happychat: {
-					connection: {
-						status: HAPPYCHAT_CONNECTION_STATUS_CONNECTED,
-					},
-					chat: {
-						status: HAPPYCHAT_CHAT_STATUS_NEW,
-					},
-				},
-			};
-			store.getState.mockReturnValue( state );
-			const action = blur();
-			actionMiddleware( action );
-			expect( store.dispatch ).not.toHaveBeenCalled();
+			[
+				HAPPYCHAT_CHAT_STATUS_ABANDONED,
+				HAPPYCHAT_CHAT_STATUS_ASSIGNING,
+				HAPPYCHAT_CHAT_STATUS_BLOCKED,
+				HAPPYCHAT_CHAT_STATUS_CLOSED,
+				HAPPYCHAT_CHAT_STATUS_DEFAULT,
+				HAPPYCHAT_CHAT_STATUS_NEW,
+				HAPPYCHAT_CHAT_STATUS_MISSED,
+				HAPPYCHAT_CHAT_STATUS_PENDING,
+			].forEach( chatStatus => {
+				store.getState.mockReturnValue(
+					Object.assign( state, { happychat: { chat: { status: chatStatus } } } )
+				);
+				const action = blur();
+				actionMiddleware( action );
+
+				expect( store.dispatch ).not.toHaveBeenCalled();
+			} );
 		} );
 
 		test( 'is not dispatched if there is no message defined', () => {
-			const state = {
-				happychat: {
-					connection: {
-						status: HAPPYCHAT_CONNECTION_STATUS_CONNECTED,
-					},
-					chat: {
-						status: HAPPYCHAT_CHAT_STATUS_ASSIGNED,
-					},
-				},
-			};
 			store.getState.mockReturnValue( state );
 			const action = { type: 'HAPPYCHAT_ACTION_WITHOUT_EVENT_MESSAGE_DEFINED' };
 			actionMiddleware( action );


### PR DESCRIPTION
Fixes https://github.com/Automattic/happychat/issues/922

Dispatch only if client is connected and chat is already assigned.