### PR TITLE
Allow external urls with `page()`

### DIFF
--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -42,7 +42,7 @@ const setupContextMiddleware = reduxStore => {
 		context.prevPath = parsed.path === context.path ? false : parsed.path;
 
 		// allow external urls to pass through, by not rewriting context.path in this case
-		if ( ! startsWith( context.path, 'http' ) ) {
+		if ( /^(?!https?:\/\/)/.test( context.path ) ) {
 			context.path = parsed.path;
 		}
 

--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -38,14 +38,7 @@ const setupContextMiddleware = reduxStore => {
 	page( '*', ( context, next ) => {
 		// page.js url parsing is broken so we had to disable it with `decodeURLComponents: false`
 		const parsed = url.parse( context.canonicalPath, true );
-		context.pathname = parsed.pathname;
 		context.prevPath = parsed.path === context.path ? false : parsed.path;
-
-		// allow external urls to pass through, by not rewriting context.path in this case
-		if ( /^(?!https?:\/\/)/.test( context.path ) ) {
-			context.path = parsed.path;
-		}
-
 		context.query = parsed.query;
 
 		context.hashstring = ( parsed.hash && parsed.hash.substring( 1 ) ) || '';

--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -40,7 +40,12 @@ const setupContextMiddleware = reduxStore => {
 		const parsed = url.parse( context.canonicalPath, true );
 		context.pathname = parsed.pathname;
 		context.prevPath = parsed.path === context.path ? false : parsed.path;
-		context.path = parsed.path;
+
+		// allow external urls to pass through, by not rewriting context.path in this case
+		if ( ! startsWith( context.path, 'http' ) ) {
+			context.path = parsed.path;
+		}
+
 		context.query = parsed.query;
 
 		context.hashstring = ( parsed.hash && parsed.hash.substring( 1 ) ) || '';


### PR DESCRIPTION
Fixes #19401.
As @markryall mentioned in https://github.com/Automattic/wp-calypso/issues/19401#issuecomment-341310223 #18557 broke `page()` calls for external urls.
To be honest I didn't know this was even a feature of `page.js`. This PR allows it again. I added a comment because the code is still quite fragile here.

### Testing Instructions
- Boot this branch locally
- Go to /themes/:site_slug
- Click on the `...` menu of a theme to see actions, and choose "Activate"
- In the resulting popover modal, click "View Site"
- You should be redirected to the site

### Reviews
- [ ] Code
- [x] Product