### PR TITLE
Comments Redesign: Add missing forceWpcom to QueryComment

### DIFF
--- a/client/my-sites/comments/comment/index.jsx
+++ b/client/my-sites/comments/comment/index.jsx
@@ -97,7 +97,9 @@ export class Comment extends Component {
 				ref={ this.storeCardRef }
 				tabIndex="0"
 			>
-				{ refreshCommentData && <QueryComment commentId={ commentId } siteId={ siteId } /> }
+				{ refreshCommentData && (
+					<QueryComment commentId={ commentId } siteId={ siteId } forceWpcom />
+				) }
 
 				{ ! isEditMode && (
 					<div className="comment__detail">


### PR DESCRIPTION
Bring the `forceWpcom` prop [from the old `CommentDetail`](https://github.com/Automattic/wp-calypso/blob/master/client/blocks/comment-detail/index.jsx#L313-L315) onto the new `Comment` component, in order to force requesting comments data via the WPCOM API even on JP sites.

Context: https://github.com/Automattic/wp-calypso/pull/17956#issuecomment-330993149