### PR TITLE
Move `post-editor`s getAllPostsUrl to selector

### DIFF
--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -19,7 +19,6 @@ import { parse as parseUrl } from 'url';
  * Internal dependencies
  */
 import actions from 'lib/posts/actions';
-import route from 'lib/route';
 import PostEditStore from 'lib/posts/post-edit-store';
 import EditorActionBar from 'post-editor/editor-action-bar';
 import FeaturedImage from 'post-editor/editor-featured-image';
@@ -69,11 +68,13 @@ import EditorGroundControl from 'post-editor/editor-ground-control';
 import { isWithinBreakpoint } from 'lib/viewport';
 import { isSitePreviewable, getSiteDomain } from 'state/sites/selectors';
 import { removep } from 'lib/formatting';
+import getAllPostsUrl from 'state/selectors/get-all-posts-url';
 
 export const PostEditor = createReactClass( {
 	displayName: 'PostEditor',
 
 	propTypes: {
+		allPostsUrl: PropTypes.string,
 		siteId: PropTypes.number,
 		preferences: PropTypes.object,
 		setEditorModePreference: PropTypes.func,
@@ -323,8 +324,7 @@ export const PostEditor = createReactClass( {
 						userUtils={ this.props.userUtils }
 						toggleSidebar={ this.toggleSidebar }
 						onMoreInfoAboutEmailVerify={ this.onMoreInfoAboutEmailVerify }
-						allPostsUrl={ this.getAllPostsUrl() }
-						selectedRevisionId={ this.state.selectedRevisionId }
+						allPostsUrl={ this.props.allPostsUrl }
 						isSidebarOpened={ this.props.layoutFocus === 'sidebar' }
 					/>
 					<div className="post-editor__content">
@@ -613,34 +613,7 @@ export const PostEditor = createReactClass( {
 
 	onClose: function() {
 		// go back if we can, if not, hit all posts
-		page.back( this.getAllPostsUrl() );
-	},
-
-	getAllPostsUrl: function() {
-		const { type, selectedSite } = this.props;
-		const site = selectedSite;
-
-		let path;
-		switch ( type ) {
-			case 'page':
-				path = '/pages';
-				break;
-			case 'post':
-				path = '/posts';
-				break;
-			default:
-				path = `/types/${ type }`;
-		}
-
-		if ( type === 'post' && site && ! site.jetpack && ! site.single_user_site ) {
-			path += '/my';
-		}
-
-		if ( site ) {
-			path = route.addSiteFragment( path, site.slug );
-		}
-
-		return path;
+		page.back( this.props.allPostsUrl );
 	},
 
 	onMoreInfoAboutEmailVerify: function() {
@@ -783,7 +756,7 @@ export const PostEditor = createReactClass( {
 
 	onPreviewClose: function() {
 		if ( this.state.isPostPublishPreview ) {
-			page.back( this.getAllPostsUrl() );
+			page.back( this.props.allPostsUrl );
 		} else {
 			this.setState( {
 				showPreview: false,
@@ -1325,6 +1298,7 @@ const enhance = flow(
 				siteId,
 				postId,
 				type,
+				allPostsUrl: getAllPostsUrl( state, type ),
 				selectedSite: getSelectedSite( state ),
 				selectedSiteDomain: getSiteDomain( state, siteId ),
 				editorModePreference: getPreference( state, 'editor-mode' ),

--- a/client/state/selectors/get-all-posts-url.js
+++ b/client/state/selectors/get-all-posts-url.js
@@ -1,0 +1,41 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { flowRight as compose, get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import createSelector from 'lib/create-selector';
+import route from 'lib/route';
+import { getSelectedSite } from 'state/ui/selectors';
+
+const postTypeRoutes = { page: '/pages', post: '/posts' };
+
+const determineBaseUrlFromType = type => get( postTypeRoutes, type, `/types/${ type }` );
+
+const maybeAppendMyToUrl = site => url =>
+	url === postTypeRoutes.post && site && ! site.jetpack && ! site.single_user_site
+		? ( url += '/my' )
+		: url;
+
+const maybeAddSiteFragment = site => url =>
+	site ? route.addSiteFragment( url, site.slug ) : url;
+
+/**
+ * Returns a site's URL or null if the site doesn't exist or the URL is unknown
+ *
+ * @param  {Object}  state  Global state tree
+ * @param  {Number}  siteId Site ID
+ * @return {?String}        URL of site if known
+ */
+export default createSelector( ( state, postType ) => {
+	const site = getSelectedSite( state );
+
+	return compose(
+		maybeAddSiteFragment( site ),
+		maybeAppendMyToUrl( site ),
+		determineBaseUrlFromType
+	)( postType );
+} );

--- a/client/state/selectors/index.js
+++ b/client/state/selectors/index.js
@@ -33,6 +33,7 @@ export getAccountRecoveryValidationKey from './get-account-recovery-validation-k
 export getActiveReplyCommentId from './get-active-reply-comment-id';
 export getActivityLog from './get-activity-log';
 export getActivityLogs from './get-activity-logs';
+export getAllPostsUrl from './get-all-posts-url';
 export getBillingTransactions from './get-billing-transactions';
 export getBlockedSites from './get-blocked-sites';
 export getBlogStickers from './get-blog-stickers';

--- a/client/state/selectors/test/get-all-posts-url.js
+++ b/client/state/selectors/test/get-all-posts-url.js
@@ -1,0 +1,158 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { getAllPostsUrl } from '../';
+import { userState } from 'state/selectors/test/fixtures/user-state';
+
+describe( 'getAllPostsUrl()', () => {
+	describe( 'when post type is "page"', () => {
+		test( 'should have a base path of "/pages"', () => {
+			const state = {
+				...userState,
+				ui: {},
+			};
+			const actual = getAllPostsUrl( state, 'page' );
+			const expected = '/pages';
+
+			expect( actual ).to.eql( expected );
+		} );
+	} );
+
+	describe( 'when post type is "post"', () => {
+		test( 'should have a base path of "/posts"', () => {
+			const state = {
+				...userState,
+				ui: {},
+			};
+			const actual = getAllPostsUrl( state, 'post' );
+			const expected = '/posts';
+
+			expect( actual ).to.eql( expected );
+		} );
+
+		describe( 'when site is jetpack', () => {
+			test( 'should not add "/my" to the url', () => {
+				const state = {
+					...userState,
+					sites: {
+						items: {
+							2916284: {
+								ID: 2916284,
+								URL: 'https://example.com',
+								jetpack: true,
+							},
+						},
+					},
+					siteSettings: {
+						items: {},
+					},
+					ui: {
+						selectedSiteId: 2916284,
+					},
+				};
+				const actual = getAllPostsUrl( state, 'post' );
+				const expected = '/posts/example.com';
+
+				expect( actual ).to.eql( expected );
+			} );
+		} );
+
+		describe( 'when site is a single user site', () => {
+			test( 'should not add "/my" to the url', () => {
+				const state = {
+					...userState,
+					sites: {
+						items: {
+							2916284: {
+								ID: 2916284,
+								URL: 'https://example.com',
+								single_user_site: true,
+							},
+						},
+					},
+					siteSettings: {
+						items: {},
+					},
+					ui: {
+						selectedSiteId: 2916284,
+					},
+				};
+				const actual = getAllPostsUrl( state, 'post' );
+				const expected = '/posts/example.com';
+
+				expect( actual ).to.eql( expected );
+			} );
+		} );
+
+		describe( 'when site is neither jetpack or a single user site', () => {
+			test( 'should add "/my" to the url', () => {
+				const state = {
+					...userState,
+					sites: {
+						items: {
+							2916284: {
+								ID: 2916284,
+								URL: 'https://example.com',
+							},
+						},
+					},
+					siteSettings: {
+						items: {},
+					},
+					ui: {
+						selectedSiteId: 2916284,
+					},
+				};
+				const actual = getAllPostsUrl( state, 'post' );
+				const expected = '/posts/my/example.com';
+
+				expect( actual ).to.eql( expected );
+			} );
+		} );
+	} );
+	describe( 'when post type is neither "post" or "page"', () => {
+		test( 'should have a base path of "/types/" + the custom type', () => {
+			const state = {
+				...userState,
+				ui: {},
+			};
+			const actual = getAllPostsUrl( state, 'another-post-type' );
+			const expected = '/types/another-post-type';
+
+			expect( actual ).to.eql( expected );
+		} );
+	} );
+
+	describe( 'when site prop is present', () => {
+		test( 'should add the site fragment', () => {
+			const state = {
+				...userState,
+				sites: {
+					items: {
+						2916284: {
+							ID: 2916284,
+							URL: 'https://example.com',
+						},
+					},
+				},
+				siteSettings: {
+					items: {},
+				},
+				ui: {
+					selectedSiteId: 2916284,
+				},
+			};
+
+			const actual = getAllPostsUrl( state, 'page' );
+			const expected = '/pages/example.com';
+
+			expect( actual ).to.eql( expected );
+		} );
+	} );
+} );


### PR DESCRIPTION
### Summary
This PR looks to create a selector for finding the correct path to 'all posts', based on the post type of the currently-editing post's type and properties of the selected site.

### Follow up work
I'm panning to utilise this selector in the back button that currently lives in the EditorGroundControl `jsx` so that `allPostsUrl` doens't need to be passed down - especially beneficial when modularising this button.

**Note**: that I rewrote the function itself, this was purely 'for fun' and to practice writing in a more functional style - I'm happy to replace this with the original function but the fairly comprehensive test suite does pass with both versions.

### To Test
Repeat this process for a post, a page and a custom type (Portfolio on a jetpack site)...
- Go to the editor
- Click the back button (in the editor ground control bar)
- Note that you're taken back to the previous page.
- Go back to the editor. Close and reopen this tab so that you're starting with no browser history.
- Click the back button (in the editor ground control bar)
- Note that you're taken back to the 'all' view for that post type - A post should take you back to `/post/`, page should take you to `/pages/` and the custom type should take you to `/type/{ name-of-type }

