### PR TITLE
Atomic Store: Wire the store-nux flow into production signup

### DIFF
--- a/client/lib/signup/flow-controller.js
+++ b/client/lib/signup/flow-controller.js
@@ -306,6 +306,12 @@ assign( SignupFlowController.prototype, {
 		SignupProgressStore.reset();
 		SignupDependencyStore.reset();
 	},
+
+	changeFlowName( flowName ) {
+		this._flowName = flowName;
+		this._flow = flows.getFlow( flowName );
+		store.set( STORAGE_KEY, flowName );
+	},
 } );
 
 export default SignupFlowController;

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -5,6 +5,7 @@
  */
 
 import { assign, includes, reject } from 'lodash';
+import i18n from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -310,14 +311,22 @@ function filterDesignTypeInFlow( flow ) {
 		return flow;
 	}
 
+	let newDesignType;
+	if ( config.isEnabled( 'signup/atomic-store-flow' ) ) {
+		// Show store option to everyone if Atomic Store is enabled
+		newDesignType = 'design-type-with-store-nux';
+	} else if ( ! user.get() && 'en' === i18n.getLocaleSlug() ) {
+		// Show design type with store option only to new users with EN locale
+		newDesignType = 'design-type-with-store';
+	}
+
+	if ( ! newDesignType ) {
+		// nothing to change
+		return flow;
+	}
+
 	return assign( {}, flow, {
-		steps: flow.steps.map( stepName => {
-			if ( stepName === 'design-type' ) {
-				const isAtomicStore = config.isEnabled( 'signup/atomic-store-flow' );
-				return isAtomicStore ? 'design-type-with-store-nux' : 'design-type-with-store';
-			}
-			return stepName;
-		} ),
+		steps: flow.steps.map( stepName => ( stepName === 'design-type' ? newDesignType : stepName ) ),
 	} );
 }
 

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -302,9 +302,24 @@ function removeUserStepFromFlow( flow ) {
 	} );
 }
 
-function filterDesignTypeInFlow( flow ) {
+function filterDesignTypeInFlow( flowName, flow ) {
 	if ( ! flow ) {
 		return;
+	}
+
+	// If Atomic Store is enable, replace 'design-type-with-store' with 'design-type-with-store-nux'
+	// in flows other than 'pressable'.
+	if (
+		config.isEnabled( 'signup/atomic-store-flow' ) &&
+		flowName !== 'pressable' &&
+		includes( flow.steps, 'design-type-with-store' )
+	) {
+		return assign( {}, flow, {
+			steps: flow.steps.map(
+				stepName =>
+					stepName === 'design-type-with-store' ? 'design-type-with-store-nux' : stepName
+			),
+		} );
 	}
 
 	if ( ! includes( flow.steps, 'design-type' ) ) {
@@ -391,7 +406,7 @@ const Flows = {
 		}
 
 		// Maybe modify the design type step to a variant with store
-		flow = filterDesignTypeInFlow( flow );
+		flow = filterDesignTypeInFlow( flowName, flow );
 
 		Flows.preloadABTestVariationsForStep( flowName, currentStepName );
 

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -5,7 +5,6 @@
  */
 
 import { assign, includes, reject } from 'lodash';
-import i18n from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -312,9 +311,13 @@ function filterDesignTypeInFlow( flow ) {
 	}
 
 	return assign( {}, flow, {
-		steps: flow.steps.map(
-			stepName => ( stepName === 'design-type' ? 'design-type-with-store' : stepName )
-		),
+		steps: flow.steps.map( stepName => {
+			if ( stepName === 'design-type' ) {
+				const isAtomicStore = config.isEnabled( 'signup/atomic-store-flow' );
+				return isAtomicStore ? 'design-type-with-store-nux' : 'design-type-with-store';
+			}
+			return stepName;
+		} ),
 	} );
 }
 
@@ -378,10 +381,8 @@ const Flows = {
 			flow = removeUserStepFromFlow( flow );
 		}
 
-		// Show design type with store option only to new users with EN locale.
-		if ( ! user.get() && 'en' === i18n.getLocaleSlug() ) {
-			flow = filterDesignTypeInFlow( flow );
-		}
+		// Maybe modify the design type step to a variant with store
+		flow = filterDesignTypeInFlow( flow );
 
 		Flows.preloadABTestVariationsForStep( flowName, currentStepName );
 

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -302,47 +302,39 @@ function removeUserStepFromFlow( flow ) {
 	} );
 }
 
+function replaceStepInFlow( flow, oldStepName, newStepName ) {
+	// no change
+	if ( ! includes( flow.steps, oldStepName ) ) {
+		return flow;
+	}
+
+	return assign( {}, flow, {
+		steps: flow.steps.map( stepName => ( stepName === oldStepName ? newStepName : stepName ) ),
+	} );
+}
+
 function filterDesignTypeInFlow( flowName, flow ) {
 	if ( ! flow ) {
 		return;
 	}
 
-	// If Atomic Store is enable, replace 'design-type-with-store' with 'design-type-with-store-nux'
-	// in flows other than 'pressable'.
-	if (
-		config.isEnabled( 'signup/atomic-store-flow' ) &&
-		flowName !== 'pressable' &&
-		includes( flow.steps, 'design-type-with-store' )
-	) {
-		return assign( {}, flow, {
-			steps: flow.steps.map(
-				stepName =>
-					stepName === 'design-type-with-store' ? 'design-type-with-store-nux' : stepName
-			),
-		} );
-	}
-
-	if ( ! includes( flow.steps, 'design-type' ) ) {
-		return flow;
-	}
-
-	let newDesignType;
 	if ( config.isEnabled( 'signup/atomic-store-flow' ) ) {
+		// If Atomic Store is enabled, replace 'design-type-with-store' with
+		// 'design-type-with-store-nux' in flows other than 'pressable'.
+		if ( flowName !== 'pressable' && includes( flow.steps, 'design-type-with-store' ) ) {
+			return replaceStepInFlow( flow, 'design-type-with-store', 'design-type-with-store-nux' );
+		}
+
 		// Show store option to everyone if Atomic Store is enabled
-		newDesignType = 'design-type-with-store-nux';
-	} else if ( ! user.get() && 'en' === i18n.getLocaleSlug() ) {
-		// Show design type with store option only to new users with EN locale
-		newDesignType = 'design-type-with-store';
+		return replaceStepInFlow( flow, 'design-type', 'design-type-with-store-nux' );
 	}
 
-	if ( ! newDesignType ) {
-		// nothing to change
-		return flow;
+	// Show design type with store option only to new users with EN locale
+	if ( ! user.get() && 'en' === i18n.getLocaleSlug() ) {
+		return replaceStepInFlow( flow, 'design-type', 'design-type-with-store' );
 	}
 
-	return assign( {}, flow, {
-		steps: flow.steps.map( stepName => ( stepName === 'design-type' ? newDesignType : stepName ) ),
-	} );
+	return flow;
 }
 
 /**

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -348,7 +348,9 @@ class Signup extends React.Component {
 		);
 	};
 
-	goToStep = ( stepName, stepSectionName ) => {
+	// `flowName` is an optional parameter used to redirect to another flow, i.e., from `main`
+	// to `store-nux`. If not specified, the current flow (`this.props.flowName`) continues.
+	goToStep = ( stepName, stepSectionName, flowName = this.props.flowName ) => {
 		if ( this.state.scrolling ) {
 			return;
 		}
@@ -370,23 +372,23 @@ class Signup extends React.Component {
 		// redirect the user to the next step
 		scrollPromise.then( () => {
 			if ( ! this.isEveryStepSubmitted() ) {
-				page(
-					utils.getStepUrl( this.props.flowName, stepName, stepSectionName, this.props.locale )
-				);
+				page( utils.getStepUrl( flowName, stepName, stepSectionName, this.props.locale ) );
 			} else if ( this.isEveryStepSubmitted() ) {
 				this.goToFirstInvalidStep();
 			}
 		} );
 	};
 
-	goToNextStep = () => {
-		const flowSteps = flows.getFlow( this.props.flowName, this.props.stepName ).steps,
+	// `nextFlowName` is an optional parameter used to redirect to another flow, i.e., from `main`
+	// to `store-nux`. If not specified, the current flow (`this.props.flowName`) continues.
+	goToNextStep = ( nextFlowName = this.props.flowName ) => {
+		const flowSteps = flows.getFlow( nextFlowName, this.props.stepName ).steps,
 			currentStepIndex = indexOf( flowSteps, this.props.stepName ),
 			nextStepName = flowSteps[ currentStepIndex + 1 ],
 			nextProgressItem = this.state.progress[ currentStepIndex + 1 ],
 			nextStepSection = ( nextProgressItem && nextProgressItem.stepSectionName ) || '';
 
-		this.goToStep( nextStepName, nextStepSection );
+		this.goToStep( nextStepName, nextStepSection, nextFlowName );
 	};
 
 	goToFirstInvalidStep = () => {

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -372,6 +372,11 @@ class Signup extends React.Component {
 		// redirect the user to the next step
 		scrollPromise.then( () => {
 			if ( ! this.isEveryStepSubmitted() ) {
+				if ( flowName !== this.props.flowName ) {
+					// if flow is being changed, tell SignupFlowController about the change and save
+					// a new value of `signupFlowName` to local storage.
+					this.signupFlowController.changeFlowName( flowName );
+				}
 				page( utils.getStepUrl( flowName, stepName, stepSectionName, this.props.locale ) );
 			} else if ( this.isEveryStepSubmitted() ) {
 				this.goToFirstInvalidStep();

--- a/client/signup/steps/design-type-with-atomic-store/index.jsx
+++ b/client/signup/steps/design-type-with-atomic-store/index.jsx
@@ -131,7 +131,9 @@ class DesignTypeWithAtomicStoreStep extends Component {
 			designType,
 		} );
 
-		this.props.goToNextStep();
+		// If the user chooses `store` as design type, redirect to the `store-nux` flow
+		const nextFlow = designType === DESIGN_TYPE_STORE ? 'store-nux' : undefined;
+		this.props.goToNextStep( nextFlow );
 	};
 
 	renderChoice = choice => {

--- a/client/signup/steps/design-type-with-atomic-store/index.jsx
+++ b/client/signup/steps/design-type-with-atomic-store/index.jsx
@@ -131,9 +131,10 @@ class DesignTypeWithAtomicStoreStep extends Component {
 			designType,
 		} );
 
-		// If the user chooses `store` as design type, redirect to the `store-nux` flow
-		const nextFlow = designType === DESIGN_TYPE_STORE ? 'store-nux' : undefined;
-		this.props.goToNextStep( nextFlow );
+		// If the user chooses `store` as design type, redirect to the `store-nux` flow.
+		// For other choices, continue with the current flow.
+		const nextFlowName = designType === DESIGN_TYPE_STORE ? 'store-nux' : this.props.flowName;
+		this.props.goToNextStep( nextFlowName );
 	};
 
 	renderChoice = choice => {


### PR DESCRIPTION
This patch does the following two things:

**Offer the `store` design type on all flows that have the `design-type` step**

Depending on the `signup/atomic-store-flow` feature flag, replace the `design-type` step with either `design-type-with-store` or `design-type-with-store-nux`. Before this patch, store was offered only for new users with EN locale or for users who explicitly came to the `/start/store` URL. We're removing these limiting conditions.

For the `store` and `pressable` flows, the design type steps continues to be `design-type-with-store`. That means always Pressable and never Atomic Store, no matter what the `signup/atomic-store-flow` flag says.

**If `store` design type is chosen, redirect to the `store-nux` flow**

When the `store` design type is chosen in the `design-type-with-store-nux` step, we force a redirect to the `store-nux` flow. The old flow name is forgotten.

We achieve that by adding a new optional `flowName` or `nextFlowName` parameter to the `Signup.goToNextStep` and `Signup.goToStep` methods.