### PR TITLE
Checkout: Prefill the domains contact form with geolocation data

### DIFF
--- a/client/my-sites/checkout/checkout/domain-details-form.jsx
+++ b/client/my-sites/checkout/checkout/domain-details-form.jsx
@@ -127,11 +127,10 @@ export class DomainDetailsForm extends PureComponent {
 		// only load the properties relevant to the main form fields
 		const formStateFromRedux = pick( this.props.contactDetails, this.fieldNames );
 		const { geo } = this.props;
+
 		if ( ! formStateFromRedux.countryCode ) {
 			formStateFromRedux.countryCode = get( geo, 'country_short', '' );
-		}
-		if ( ! formStateFromRedux.city ) {
-			formStateFromRedux.city = get( geo, 'city', '' );
+			formStateFromRedux.city = formStateFromRedux.city || get( geo, 'city', '' );
 		}
 
 		fn( null, formStateFromRedux );
@@ -293,8 +292,8 @@ export class DomainDetailsForm extends PureComponent {
 	}
 
 	shouldDisplayAddressFieldset() {
-		const { contactDetails } = this.props;
-		return !! ( contactDetails || {} ).countryCode;
+		const { form } = this.state;
+		return !! get( form, 'countryCode.value', '' );
 	}
 
 	renderSubmitButton() {

--- a/client/my-sites/checkout/checkout/test/domain-details-form.js
+++ b/client/my-sites/checkout/checkout/test/domain-details-form.js
@@ -52,6 +52,14 @@ describe( 'Domain Details Form', () => {
 		},
 	};
 
+	const propsWithGeoData = {
+		...defaultProps,
+		geo: {
+			country_short: 'IT',
+			city: 'Roma',
+		},
+	};
+
 	const domainProduct = domainRegistration( {
 		productSlug: 'normal_domain',
 		domain: 'test.test',
@@ -197,6 +205,40 @@ describe( 'Domain Details Form', () => {
 			);
 			expect( inputs ).to.have.length( 1 );
 			expect( inputs.get( 0 ).props.name ).to.equal( 'postal-code' );
+		} );
+	} );
+
+	describe( 'Pre-populating fields with geo data', () => {
+		test( 'should populate form state model with country code and city when contact details not available', () => {
+			const wrapper = shallow( <DomainDetailsForm { ...propsWithGeoData } /> );
+			expect( wrapper.state().form.countryCode.value ).to.equal( 'IT' );
+			expect( wrapper.state().form.city.value ).to.equal( 'Roma' );
+		} );
+
+		test( 'should not populate form state model when contact details already contain country code', () => {
+			const wrapper = shallow(
+				<DomainDetailsForm
+					{ ...propsWithGeoData }
+					contactDetails={ {
+						countryCode: 'AU',
+					} }
+				/>
+			);
+			expect( wrapper.state().form.countryCode.value ).to.equal( 'AU' );
+			expect( wrapper.state().form.city.value ).to.equal( '' );
+		} );
+
+		test( 'should give preference to contact details city', () => {
+			const wrapper = shallow(
+				<DomainDetailsForm
+					{ ...propsWithGeoData }
+					contactDetails={ {
+						city: 'Marseille',
+					} }
+				/>
+			);
+			expect( wrapper.state().form.countryCode.value ).to.equal( 'IT' );
+			expect( wrapper.state().form.city.value ).to.equal( 'Marseille' );
 		} );
 	} );
 } );


### PR DESCRIPTION
We're already fetching the [geolocation data in checkout](https://github.com/Automattic/wp-calypso/blob/e3d5a722cf1e6d303d70f2f37f601028164f3a86/client/my-sites/checkout/checkout/checkout.jsx#L466), so I figured it could be used to prefill the country and city fields for a slightly smoother checkout experience.

However, I'm not sure if I've put the code in the right place - one time, I was able to get the country and city fields per-filled, but it seems that the event change handler did not fire (?), because only the country selection field was visible, not the rest of the form (but the country _was_ selected). Pinging folks from Team Global to help verify this enhancement, as they've done some work around this form (for example, https://github.com/Automattic/wp-calypso/pull/18431 and, of course, the original reduxification of it).

### Testing
If the user has domain details already (they've purchases a domain previously or have an unfinished checkout), the country and/or city should not be overridden if they're non-empty.
For other cases, they should be automatically per-filled.
Please test with new and existing users - both the signup flow and from domains management.