### PR TITLE
Domains: Fix renew links to work with domain-only sites

### DIFF
--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -201,14 +201,13 @@ function isPathAllowedForDomainOnlySite( path, slug, primaryDomain ) {
 		);
 	}
 
-	const otherPaths = [ `/checkout/${ slug }` ];
-	const startsWithPaths = [ '/checkout/thank-you', `/me/purchases/${ slug }` ];
+	const startsWithPaths = [ '/checkout/', `/me/purchases/${ slug }` ];
 
 	if ( some( startsWithPaths, startsWithPath => startsWith( path, startsWithPath ) ) ) {
 		return true;
 	}
 
-	return [ ...domainManagementPaths, ...otherPaths ].indexOf( path ) > -1;
+	return domainManagementPaths.indexOf( path ) > -1;
 }
 
 function onSelectedSiteAvailable( context ) {


### PR DESCRIPTION
In p2MSmN-6ep-p2, @klasharr reported that the [renew links](https://github.com/Automattic/wp-calypso/pull/17398) for domain-only sites are not working.
After a short investigation, I've pinpointed it to the whitelisting rules we have for domain-only sites.
IMHO, they create more confusion and bugs than they fix and they are bound to cause issues like this in the future (as they have [in the past](https://github.com/Automattic/wp-calypso/pull/17398)). For now I've just loosened them up for checkout (in case the format of the links change in the future, etc.).

### Testing
Get a domain-only domain, hack [domain warnings](https://github.com/Automattic/wp-calypso/blob/e3d5a722cf1e6d303d70f2f37f601028164f3a86/client/my-sites/domains/components/domain-warnings/index.jsx#L327) to return an expiring notice (I've changed the `domain.expirySoon` part to `domain.name === 'yourtestdomain.com'`), verify that the renew link/action works:
![calypso localhost_3000_stats_day_klimerykdomainonly rocks](https://user-images.githubusercontent.com/3392497/32329227-af37e54e-bfdc-11e7-89ef-9b3e45adbdf8.png)