### PR TITLE
PostTypeList Share: Query site in all-sites mode.

### DIFF
--- a/client/blocks/post-share/index.jsx
+++ b/client/blocks/post-share/index.jsx
@@ -53,6 +53,7 @@ import PublicizeMessage from 'post-editor/editor-sharing/publicize-message';
 import Notice from 'components/notice';
 import {
 	hasFeature,
+	isRequestingSitePlans as siteIsRequestingPlans,
 	getSitePlanRawPrice,
 	getPlanDiscountedRawPrice,
 } from 'state/sites/plans/selectors';
@@ -537,6 +538,7 @@ class PostShare extends Component {
 		const {
 			hasRepublicizeFeature,
 			hasFetchedConnections,
+			isRequestingSitePlans,
 			postId,
 			siteId,
 			siteSlug,
@@ -550,7 +552,7 @@ class PostShare extends Component {
 		}
 
 		const classes = classNames( 'post-share__wrapper', {
-			'is-placeholder': ! hasFetchedConnections,
+			'is-placeholder': ! hasFetchedConnections || isRequestingSitePlans,
 			'has-connections': this.hasConnections(),
 			'has-republicize-scheduling-feature': hasRepublicizeFeature,
 		} );
@@ -626,6 +628,7 @@ export default connect(
 			planSlug,
 			isJetpack: isJetpackSite( state, siteId ),
 			hasFetchedConnections: siteHasFetchedConnections( state, siteId ),
+			isRequestingSitePlans: siteIsRequestingPlans( state, siteId ),
 			hasRepublicizeFeature: hasFeature( state, siteId, FEATURE_REPUBLICIZE ),
 			siteSlug: getSiteSlug( state, siteId ),
 			isPublicizeEnabled: isPublicizeEnabled( state, siteId, postType ),

--- a/client/blocks/post-share/index.jsx
+++ b/client/blocks/post-share/index.jsx
@@ -19,6 +19,7 @@ import Gridicon from 'gridicons';
 import QueryPostTypes from 'components/data/query-post-types';
 import QueryPosts from 'components/data/query-posts';
 import QueryPublicizeConnections from 'components/data/query-publicize-connections';
+import QuerySitePlans from 'components/data/query-site-plans';
 import Button from 'components/button';
 import ButtonGroup from 'components/button-group';
 import NoticeAction from 'components/notice/notice-action';
@@ -559,6 +560,7 @@ class PostShare extends Component {
 				<TrackComponentView eventName="calypso_publicize_post_share_view" />
 				<QueryPostTypes siteId={ siteId } />
 				<QueryPublicizeConnections siteId={ siteId } />
+				<QuerySitePlans siteId={ siteId } />
 
 				<div className={ classes }>
 					<div className="post-share__head">


### PR DESCRIPTION
This PR queries site plans within the share component. Prior to this change, if site plans hadn't been queried before the share component was displayed, which would happen if you visited All My Sites and attempted to share for a site which hadn't been loaded individually, the upgrade nudge would be shown.

Before:

![image](https://user-images.githubusercontent.com/363749/32332644-fd53bf10-bfb3-11e7-8089-92db20113507.png)

After:

![image](https://user-images.githubusercontent.com/363749/32390645-35e34faa-c09d-11e7-9a40-d55acc8054a1.png)


Test Plan:

1.
- Given a user viewing posts for All My Sites (/posts/my) after a full Calypso reload
- When they expand the share panel for an post on a site with a premium plan
- Then they do not get an upgrade nudge

2.
- Given a user viewing posts for All My Sites (/posts/my) after a full Calypso reload
- When they expand the share panel for an post on a site with a premium plan and sharing configured
- Then they see the sharing panel

3.
- Given a user viewing posts for All My Sites (/posts/my) after a full Calypso reload
- When they expand the share panel for an post on a site with a premium plan and sharing not configured
- Then they see the prompt to connect an account
