### PR TITLE
PostTypeList: Change page size back to 20

### DIFF
--- a/client/my-sites/posts/post-list-wrapper.jsx
+++ b/client/my-sites/posts/post-list-wrapper.jsx
@@ -28,7 +28,7 @@ class PostListWrapper extends React.Component {
 			status: mapPostStatus( this.props.statusSlug ),
 			author: this.props.author,
 			search: this.props.search,
-			number: 40,
+			number: 20, // max supported by /me/posts endpoint for all-sites mode
 		};
 
 		if ( this.props.category ) {


### PR DESCRIPTION
This is the max supported value in all sites mode (enforced by the `/me/posts` API endpoint).  Previously, the code would attempt to load pages of 40 posts each, but the API endpoint would enforce the limitation of 20 pages.  This led to incorrect expectations in the Calypso code about how many items would be displayed, which become most evident in combination with https://github.com/Automattic/wp-calypso/pull/19025.  Without this change, the message added there would say that 400 posts were displayed when in reality only up to 200 are displayed.

Test with `?flags=posts/post-type-list` in all-sites mode (`/posts` route for example) and verify that up to 10 pages of 20 posts each are loaded.