### PR TITLE
Comments Redesign: Add the reply textarea

### DIFF
--- a/client/my-sites/comments/comment/comment-reply.jsx
+++ b/client/my-sites/comments/comment/comment-reply.jsx
@@ -81,12 +81,14 @@ export class CommentReply extends Component {
 	};
 
 	submitReply = () => {
-		const { approveComment, commentStatus, postId, replyToComment, siteId } = this.props;
+		const { approveComment, blurReply, commentStatus, postId, replyToComment, siteId } = this.props;
 		const { replyContent } = this.state;
 
 		const alsoApprove = 'approved' !== commentStatus;
 
 		replyToComment( replyContent, siteId, postId, { alsoApprove } );
+		this.setState( { replyContent: '' } );
+		blurReply();
 
 		if ( alsoApprove ) {
 			approveComment( siteId, postId, { previousStatus: commentStatus } );

--- a/client/my-sites/comments/comment/comment-reply.jsx
+++ b/client/my-sites/comments/comment/comment-reply.jsx
@@ -107,7 +107,11 @@ export class CommentReply extends Component {
 		// Only show the scrollbar if the textarea content exceeds the max height
 		const hasScrollbar = textareaHeight === TEXTAREA_MAX_HEIGHT;
 
-		const buttonClasses = classNames( 'comment-detail__reply-submit', {
+		const wrapperClasses = classNames( 'comment__reply-wrapper', {
+			'has-focus': isReplyMode,
+		} );
+
+		const buttonClasses = classNames( 'comment__reply-submit', {
 			'has-scrollbar': hasScrollbar,
 			'is-active': hasReplyContent,
 			'is-visible': isReplyMode || hasReplyContent,
@@ -115,7 +119,7 @@ export class CommentReply extends Component {
 
 		const gravatarClasses = classNames( { 'is-visible': ! isReplyMode } );
 
-		const textareaClasses = classNames( {
+		const textareaClasses = classNames( 'comment__reply-textarea', {
 			'has-content': hasReplyContent,
 			'has-focus': isReplyMode,
 			'has-scrollbar': hasScrollbar,
@@ -123,29 +127,36 @@ export class CommentReply extends Component {
 
 		// Without focus, force the textarea to collapse even if it was manually resized
 		const textareaStyle = {
-			height: isReplyMode ? textareaHeight : TEXTAREA_HEIGHT_COLLAPSED,
+			height: isReplyMode || hasReplyContent ? textareaHeight : TEXTAREA_HEIGHT_COLLAPSED,
 		};
 
 		return (
 			<form className="comment__reply">
-				<AutoDirection>
-					<textarea
-						className={ textareaClasses }
-						onBlur={ exitReplyMode }
-						onChange={ this.updateTextarea }
-						onFocus={ enterReplyMode }
-						onKeyDown={ this.keyDownHandler }
-						ref={ this.storeTextareaRef }
-						style={ textareaStyle }
-						value={ replyContent }
-					/>
-				</AutoDirection>
+				<div className={ wrapperClasses }>
+					<AutoDirection>
+						<textarea
+							className={ textareaClasses }
+							onBlur={ exitReplyMode }
+							onChange={ this.updateTextarea }
+							onFocus={ enterReplyMode }
+							onKeyDown={ this.keyDownHandler }
+							placeholder={ this.getPlaceholder() }
+							ref={ this.storeTextareaRef }
+							style={ textareaStyle }
+							value={ replyContent }
+						/>
+					</AutoDirection>
 
-				<Gravatar className={ gravatarClasses } size={ 24 } user={ currentUser } />
+					<Gravatar className={ gravatarClasses } size={ 24 } user={ currentUser } />
 
-				<button className={ buttonClasses } disabled={ ! hasReplyContent } onClick={ this.submit }>
-					{ translate( 'Send' ) }
-				</button>
+					<button
+						className={ buttonClasses }
+						disabled={ ! hasReplyContent }
+						onClick={ this.submit }
+					>
+						{ translate( 'Send' ) }
+					</button>
+				</div>
 			</form>
 		);
 	}

--- a/client/my-sites/comments/comment/comment-reply.jsx
+++ b/client/my-sites/comments/comment/comment-reply.jsx
@@ -1,0 +1,197 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+import classNames from 'classnames';
+import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import AutoDirection from 'components/auto-direction';
+import Gravatar from 'components/gravatar';
+import { decodeEntities } from 'lib/formatting';
+import {
+	bumpStat,
+	composeAnalytics,
+	recordTracksEvent,
+	withAnalytics,
+} from 'state/analytics/actions';
+import { changeCommentStatus, replyComment } from 'state/comments/actions';
+import { getCurrentUser } from 'state/current-user/selectors';
+import { getSiteComment } from 'state/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
+
+const TEXTAREA_HEIGHT_COLLAPSED = 47; // 1 line
+const TEXTAREA_HEIGHT_FOCUSED = 68; // 2 lines
+const TEXTAREA_MAX_HEIGHT = 236; // 10 lines
+const TEXTAREA_VERTICAL_BORDER = 2;
+
+export class CommentReply extends Component {
+	static propTypes = {
+		commentId: PropTypes.number,
+		enterReplyMode: PropTypes.func,
+		exitReplyMode: PropTypes.func,
+		isReplyMode: PropTypes.bool,
+	};
+
+	state = {
+		replyContent: '',
+		textareaHeight: TEXTAREA_HEIGHT_COLLAPSED,
+	};
+
+	componentDidMount() {
+		if ( this.props.isReplyMode ) {
+			this.textarea.focus();
+		}
+	}
+
+	storeTextareaRef = textarea => ( this.textarea = textarea );
+
+	calculateTextareaHeight = () => {
+		const textareaHeight = Math.min(
+			TEXTAREA_MAX_HEIGHT,
+			this.textarea.scrollHeight + TEXTAREA_VERTICAL_BORDER
+		);
+		return Math.max( TEXTAREA_HEIGHT_FOCUSED, textareaHeight );
+	};
+
+	getPlaceholder = () => {
+		const { authorDisplayName: commentAuthor, translate } = this.props;
+		return commentAuthor
+			? translate( 'Reply to %(commentAuthor)s…', { args: { commentAuthor } } )
+			: translate( 'Reply to comment…' );
+	};
+
+	keyDownHandler = event => {
+		// Use Ctrl+Enter to submit comment
+		if ( event.keyCode === 13 && ( event.ctrlKey || event.metaKey ) ) {
+			event.preventDefault();
+			this.submitReply();
+		}
+	};
+
+	submit = event => {
+		event.preventDefault();
+		this.submitReply();
+	};
+
+	submitReply = () => {
+		const { approveComment, commentStatus, postId, replyToComment, siteId } = this.props;
+		const { replyContent } = this.state;
+
+		const alsoApprove = 'approved' !== commentStatus;
+
+		replyToComment( replyContent, siteId, postId, { alsoApprove } );
+
+		if ( alsoApprove ) {
+			approveComment( siteId, postId, { previousStatus: commentStatus } );
+		}
+	};
+
+	updateTextarea = event => {
+		const { value: replyContent } = event.target;
+		const textareaHeight = this.calculateTextareaHeight();
+		this.setState( { replyContent, textareaHeight } );
+	};
+
+	render() {
+		const { currentUser, enterReplyMode, exitReplyMode, isReplyMode, translate } = this.props;
+		const { replyContent, textareaHeight } = this.state;
+
+		const hasReplyContent = replyContent.trim().length > 0;
+		// Only show the scrollbar if the textarea content exceeds the max height
+		const hasScrollbar = textareaHeight === TEXTAREA_MAX_HEIGHT;
+
+		const buttonClasses = classNames( 'comment-detail__reply-submit', {
+			'has-scrollbar': hasScrollbar,
+			'is-active': hasReplyContent,
+			'is-visible': isReplyMode || hasReplyContent,
+		} );
+
+		const gravatarClasses = classNames( { 'is-visible': ! isReplyMode } );
+
+		const textareaClasses = classNames( {
+			'has-content': hasReplyContent,
+			'has-focus': isReplyMode,
+			'has-scrollbar': hasScrollbar,
+		} );
+
+		// Without focus, force the textarea to collapse even if it was manually resized
+		const textareaStyle = {
+			height: isReplyMode ? textareaHeight : TEXTAREA_HEIGHT_COLLAPSED,
+		};
+
+		return (
+			<form className="comment__reply">
+				<AutoDirection>
+					<textarea
+						className={ textareaClasses }
+						onBlur={ exitReplyMode }
+						onChange={ this.updateTextarea }
+						onFocus={ enterReplyMode }
+						onKeyDown={ this.keyDownHandler }
+						ref={ this.storeTextareaRef }
+						style={ textareaStyle }
+						value={ replyContent }
+					/>
+				</AutoDirection>
+
+				<Gravatar className={ gravatarClasses } size={ 24 } user={ currentUser } />
+
+				<button className={ buttonClasses } disabled={ ! hasReplyContent } onClick={ this.submit }>
+					{ translate( 'Send' ) }
+				</button>
+			</form>
+		);
+	}
+}
+
+const mapStateToProps = ( state, { commentId } ) => {
+	const siteId = getSelectedSiteId( state );
+	const comment = getSiteComment( state, siteId, commentId );
+
+	return {
+		authorDisplayName: decodeEntities( get( comment, 'author.name' ) ),
+		commentStatus: get( comment, 'status' ),
+		currentUser: getCurrentUser( state ),
+		postId: get( comment, 'post.ID' ),
+		siteId,
+	};
+};
+
+const mapDispatchToProps = ( dispatch, { commentId } ) => ( {
+	approveComment: ( siteId, postId, analytics = {} ) =>
+		dispatch(
+			withAnalytics(
+				composeAnalytics(
+					recordTracksEvent( 'calypso_comment_management_change_status', {
+						also_unlike: false,
+						is_undo: false,
+						previous_status: analytics.previousStatus,
+						status: 'approved',
+					} ),
+					bumpStat( 'calypso_comment_management', 'comment_status_changed_to_approved' )
+				),
+				changeCommentStatus( siteId, postId, commentId, 'approved' )
+			)
+		),
+	replyToComment: ( replyContent, siteId, postId, analytics = { alsoApprove: false } ) =>
+		dispatch(
+			withAnalytics(
+				composeAnalytics(
+					recordTracksEvent( 'calypso_comment_management_reply', {
+						also_approve: analytics.alsoApprove,
+					} ),
+					bumpStat( 'calypso_comment_management', 'comment_reply' )
+				),
+				replyComment( replyContent, siteId, postId, commentId )
+			)
+		),
+} );
+
+export default connect( mapStateToProps, mapDispatchToProps )( localize( CommentReply ) );

--- a/client/my-sites/comments/comment/comment-reply.jsx
+++ b/client/my-sites/comments/comment/comment-reply.jsx
@@ -34,9 +34,9 @@ const TEXTAREA_VERTICAL_BORDER = 2;
 export class CommentReply extends Component {
 	static propTypes = {
 		commentId: PropTypes.number,
-		enterReplyMode: PropTypes.func,
-		exitReplyMode: PropTypes.func,
-		isReplyMode: PropTypes.bool,
+		blurReply: PropTypes.func,
+		focusReply: PropTypes.func,
+		hasReplyFocus: PropTypes.bool,
 	};
 
 	state = {
@@ -45,7 +45,7 @@ export class CommentReply extends Component {
 	};
 
 	componentDidMount() {
-		if ( this.props.isReplyMode ) {
+		if ( this.props.hasReplyFocus ) {
 			this.textarea.focus();
 		}
 	}
@@ -100,7 +100,7 @@ export class CommentReply extends Component {
 	};
 
 	render() {
-		const { currentUser, enterReplyMode, exitReplyMode, isReplyMode, translate } = this.props;
+		const { blurReply, currentUser, focusReply, hasReplyFocus, translate } = this.props;
 		const { replyContent, textareaHeight } = this.state;
 
 		const hasReplyContent = replyContent.trim().length > 0;
@@ -108,26 +108,26 @@ export class CommentReply extends Component {
 		const hasScrollbar = textareaHeight === TEXTAREA_MAX_HEIGHT;
 
 		const wrapperClasses = classNames( 'comment__reply-wrapper', {
-			'has-focus': isReplyMode,
+			'has-focus': hasReplyFocus,
 		} );
 
 		const buttonClasses = classNames( 'comment__reply-submit', {
 			'has-scrollbar': hasScrollbar,
 			'is-active': hasReplyContent,
-			'is-visible': isReplyMode || hasReplyContent,
+			'is-visible': hasReplyFocus || hasReplyContent,
 		} );
 
-		const gravatarClasses = classNames( { 'is-visible': ! isReplyMode } );
+		const gravatarClasses = classNames( { 'is-visible': ! hasReplyFocus } );
 
 		const textareaClasses = classNames( 'comment__reply-textarea', {
 			'has-content': hasReplyContent,
-			'has-focus': isReplyMode,
+			'has-focus': hasReplyFocus,
 			'has-scrollbar': hasScrollbar,
 		} );
 
 		// Without focus, force the textarea to collapse even if it was manually resized
 		const textareaStyle = {
-			height: isReplyMode || hasReplyContent ? textareaHeight : TEXTAREA_HEIGHT_COLLAPSED,
+			height: hasReplyFocus || hasReplyContent ? textareaHeight : TEXTAREA_HEIGHT_COLLAPSED,
 		};
 
 		return (
@@ -136,9 +136,9 @@ export class CommentReply extends Component {
 					<AutoDirection>
 						<textarea
 							className={ textareaClasses }
-							onBlur={ exitReplyMode }
+							onBlur={ blurReply }
 							onChange={ this.updateTextarea }
-							onFocus={ enterReplyMode }
+							onFocus={ focusReply }
 							onKeyDown={ this.keyDownHandler }
 							placeholder={ this.getPlaceholder() }
 							ref={ this.storeTextareaRef }

--- a/client/my-sites/comments/comment/index.jsx
+++ b/client/my-sites/comments/comment/index.jsx
@@ -36,9 +36,9 @@ export class Comment extends Component {
 	};
 
 	state = {
+		hasReplyFocus: false,
 		isEditMode: false,
 		isExpanded: false,
-		hasReplyFocus: false,
 	};
 
 	componentWillReceiveProps( nextProps ) {
@@ -92,7 +92,7 @@ export class Comment extends Component {
 			refreshCommentData,
 			siteId,
 		} = this.props;
-		const { isEditMode, isExpanded, hasReplyFocus } = this.state;
+		const { hasReplyFocus, isEditMode, isExpanded } = this.state;
 
 		const classes = classNames( 'comment', {
 			'is-bulk-mode': isBulkMode,

--- a/client/my-sites/comments/comment/index.jsx
+++ b/client/my-sites/comments/comment/index.jsx
@@ -38,7 +38,7 @@ export class Comment extends Component {
 	state = {
 		isEditMode: false,
 		isExpanded: false,
-		isReplyMode: false,
+		hasReplyFocus: false,
 	};
 
 	componentWillReceiveProps( nextProps ) {
@@ -49,9 +49,9 @@ export class Comment extends Component {
 
 	storeCardRef = card => ( this.commentCard = card );
 
-	enterReplyMode = () => this.setState( { isReplyMode: true } );
+	blurReply = () => this.setState( { hasReplyFocus: false } );
 
-	exitReplyMode = () => this.setState( { isReplyMode: false } );
+	focusReply = () => this.setState( { hasReplyFocus: true } );
 
 	keyDownHandler = event => {
 		const { isBulkMode } = this.props;
@@ -92,7 +92,7 @@ export class Comment extends Component {
 			refreshCommentData,
 			siteId,
 		} = this.props;
-		const { isEditMode, isExpanded, isReplyMode } = this.state;
+		const { isEditMode, isExpanded, hasReplyFocus } = this.state;
 
 		const classes = classNames( 'comment', {
 			'is-bulk-mode': isBulkMode,
@@ -125,9 +125,9 @@ export class Comment extends Component {
 
 						{ isExpanded && (
 							<CommentReply
-								{ ...{ commentId, isReplyMode } }
-								enterReplyMode={ this.enterReplyMode }
-								exitReplyMode={ this.exitReplyMode }
+								{ ...{ commentId, hasReplyFocus } }
+								blurReply={ this.blurReply }
+								focusReply={ this.focusReply }
 							/>
 						) }
 					</div>

--- a/client/my-sites/comments/comment/index.jsx
+++ b/client/my-sites/comments/comment/index.jsx
@@ -15,6 +15,7 @@ import { get, isUndefined } from 'lodash';
 import Card from 'components/card';
 import CommentContent from 'my-sites/comments/comment/comment-content';
 import CommentHeader from 'my-sites/comments/comment/comment-header';
+import CommentReply from 'my-sites/comments/comment/comment-reply';
 import QueryComment from 'components/data/query-comment';
 import { getMinimumComment } from 'my-sites/comments/comment/utils';
 import { getSiteComment } from 'state/selectors';
@@ -37,6 +38,7 @@ export class Comment extends Component {
 	state = {
 		isEditMode: false,
 		isExpanded: false,
+		isReplyMode: false,
 	};
 
 	componentWillReceiveProps( nextProps ) {
@@ -46,6 +48,10 @@ export class Comment extends Component {
 	}
 
 	storeCardRef = card => ( this.commentCard = card );
+
+	enterReplyMode = () => this.setState( { isReplyMode: true } );
+
+	exitReplyMode = () => this.setState( { isReplyMode: false } );
 
 	keyDownHandler = event => {
 		const { isBulkMode } = this.props;
@@ -86,7 +92,7 @@ export class Comment extends Component {
 			refreshCommentData,
 			siteId,
 		} = this.props;
-		const { isEditMode, isExpanded } = this.state;
+		const { isEditMode, isExpanded, isReplyMode } = this.state;
 
 		const classes = classNames( 'comment', {
 			'is-bulk-mode': isBulkMode,
@@ -115,7 +121,13 @@ export class Comment extends Component {
 							toggleExpanded={ this.toggleExpanded }
 						/>
 
-						<CommentContent { ...{ commentId, isBulkMode, isExpanded } } />
+						<CommentContent { ...{ commentId, isExpanded } } />
+
+						<CommentReply
+							{ ...{ commentId, isReplyMode } }
+							enterReplyMode={ this.enterReplyMode }
+							exitReplyMode={ this.exitReplyMode }
+						/>
 					</div>
 				) }
 			</Card>

--- a/client/my-sites/comments/comment/index.jsx
+++ b/client/my-sites/comments/comment/index.jsx
@@ -123,11 +123,13 @@ export class Comment extends Component {
 
 						<CommentContent { ...{ commentId, isExpanded } } />
 
-						<CommentReply
-							{ ...{ commentId, isReplyMode } }
-							enterReplyMode={ this.enterReplyMode }
-							exitReplyMode={ this.exitReplyMode }
-						/>
+						{ isExpanded && (
+							<CommentReply
+								{ ...{ commentId, isReplyMode } }
+								enterReplyMode={ this.enterReplyMode }
+								exitReplyMode={ this.exitReplyMode }
+							/>
+						) }
 					</div>
 				) }
 			</Card>

--- a/client/my-sites/comments/comment/style.scss
+++ b/client/my-sites/comments/comment/style.scss
@@ -279,6 +279,99 @@
 	}
 }
 
+// Comment Reply Block
+
+.comment__reply {
+	background: $gray-light;
+	border-top: 1px solid lighten($gray, 30%);
+	padding: 16px;
+}
+
+.comment__reply-wrapper {
+	line-height: 0;
+	overflow: hidden;
+	position: relative;
+	transition: box-shadow 0.15s ease-in-out;
+
+	&.has-focus {
+		box-shadow: 0 0 0 2px $blue-light;
+	}
+}
+
+.comment__reply-textarea {
+	font-size: 14px;
+	height: 47px; // 1 line
+	line-height: 21px;
+	min-height: 47px; // 1 line
+	overflow: hidden;
+	padding: 12px 70px 12px 16px;
+	position: relative;
+	resize: vertical;
+	transition: min-height 0.15s linear, padding-left 0.2s ease-in-out;
+	white-space: pre-wrap;
+	word-wrap: break-word;
+
+	&::placeholder {
+		color: $gray-text-min;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	&:not(:focus) {
+		padding: 12px 16px 12px 48px;
+		resize: none;
+
+		&.has-content {
+			padding-right: 70px;
+		}
+	}
+
+	&:focus,
+	&.has-focus {
+		min-height: 68px; // 2 lines
+	}
+
+	&.has-scrollbar {
+		overflow-y: auto;
+	}
+}
+
+.comment__reply-wrapper .gravatar {
+	left: 16px;
+	position: absolute;
+	top: 12px;
+	transition: transform 0.2s ease-in-out;
+
+	&:not(.is-visible) {
+		transform: translate3d(-40px, 0, 0);
+	}
+}
+
+.comment__reply-submit {
+	color: $gray;
+	font-size: 12px;
+	font-weight: 600;
+	padding: 4px;
+	position: absolute;
+	right: -70px;
+	top: 11px;
+	text-transform: uppercase;
+	transition: transform 0.2s ease-in-out;
+
+	&.is-active {
+		color: $blue-wordpress;
+		cursor: pointer;
+	}
+
+	&.is-visible {
+		transform: translate3d(-88px, 0, 0);
+	}
+	&.is-visible.has-scrollbar {
+		transform: translate3d(-94px, 0, 0);
+	}
+}
+
 // Collapsed View
 
 .card.comment.is-collapsed {


### PR DESCRIPTION
Fixes #19199

Add the `CommentReply` component into the new `Comment` card.
It is almost a 1:1 port of the old `CommentDetailReply` block, but with improved variables naming and with one [bug](https://github.com/Automattic/wp-calypso/issues/19199) fixed (cc @megsfulton).

<img width="587" alt="screen shot 2017-11-02 at 15 26 49" src="https://user-images.githubusercontent.com/2070010/32334979-b800653c-bfe3-11e7-884d-d22faeb83b60.png">

<img width="587" alt="screen shot 2017-11-02 at 15 26 59" src="https://user-images.githubusercontent.com/2070010/32334978-b7e42bba-bfe3-11e7-8821-4dd86da15d53.png">

### Testing instructions

Checkout this branch and run it with
`env ENABLE_FEATURES=comments/management/m3-design npm start`