### PR TITLE
PostTypeList: Fix expanding the ellipsis menu in all-sites mode

### DIFF
--- a/client/my-sites/post-type-filter/index.jsx
+++ b/client/my-sites/post-type-filter/index.jsx
@@ -144,7 +144,7 @@ const PostTypeFilter = createReactClass( {
 
 	render() {
 		const { authorToggleHidden, jetpack, query, siteId, statusSlug } = this.props;
-		
+
 		if ( ! query ) {
 			return null;
 		}

--- a/client/my-sites/post-type-filter/index.jsx
+++ b/client/my-sites/post-type-filter/index.jsx
@@ -44,7 +44,7 @@ const PostTypeFilter = createReactClass( {
 			author: PropTypes.number, // User ID
 			status: PropTypes.string,
 			type: PropTypes.string.isRequired,
-		} ).isRequired,
+		} ),
 		jetpack: PropTypes.bool,
 		siteSlug: PropTypes.string,
 		counts: PropTypes.object,
@@ -144,6 +144,11 @@ const PostTypeFilter = createReactClass( {
 
 	render() {
 		const { authorToggleHidden, jetpack, query, siteId, statusSlug } = this.props;
+		
+		if ( ! query ) {
+			return null;
+		}
+
 		const navItems = this.getNavItems();
 		const selectedItem = find( navItems, 'selected' ) || {};
 
@@ -194,7 +199,7 @@ export default connect(
 	( state, { query } ) => {
 		const siteId = getSelectedSiteId( state );
 		let authorToggleHidden = false;
-		if ( query.type === 'post' ) {
+		if ( query && query.type === 'post' ) {
 			if ( siteId ) {
 				authorToggleHidden = isSingleUserSite( state, siteId ) || isJetpackSite( state, siteId );
 			} else {

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/duplicate.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/duplicate.jsx
@@ -88,7 +88,7 @@ const mapDispatchToProps = { bumpAnalyticsStat };
 
 const mergeProps = ( stateProps, dispatchProps, ownProps ) => {
 	const bumpStat = bumpStatGenerator(
-		stateProps.type.name,
+		get( stateProps, 'type.name' ),
 		'duplicate',
 		dispatchProps.bumpAnalyticsStat
 	);

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/duplicate.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/duplicate.jsx
@@ -14,7 +14,6 @@ import { get, includes } from 'lodash';
  * Internal dependencies
  */
 import PopoverMenuItem from 'components/popover/menu-item';
-import QueryPostTypes from 'components/data/query-post-types';
 import { canCurrentUser } from 'state/selectors';
 import { getPost } from 'state/posts/selectors';
 import { getPostType } from 'state/post-types/selectors';
@@ -29,7 +28,6 @@ function PostActionsEllipsisMenuDuplicate( {
 	siteId,
 	canEdit,
 	duplicateUrl,
-	isKnownType,
 	bumpStat,
 	status,
 } ) {
@@ -41,7 +39,6 @@ function PostActionsEllipsisMenuDuplicate( {
 
 	return (
 		<PopoverMenuItem href={ duplicateUrl } onClick={ bumpStat } icon="pages">
-			{ siteId && ! isKnownType && <QueryPostTypes siteId={ siteId } /> }
 			{ translate( 'Duplicate', { context: 'verb' } ) }
 		</PopoverMenuItem>
 	);
@@ -54,7 +51,6 @@ PostActionsEllipsisMenuDuplicate.propTypes = {
 	canEdit: PropTypes.bool,
 	status: PropTypes.string,
 	duplicateUrl: PropTypes.string,
-	isKnownType: PropTypes.bool,
 	bumpStat: PropTypes.func,
 };
 
@@ -79,8 +75,6 @@ const mapStateToProps = ( state, { globalId } ) => {
 		siteId: post.site_ID,
 		canEdit: canCurrentUser( state, post.site_ID, capability ),
 		duplicateUrl: getEditorDuplicatePostPath( state, post.site_ID, post.ID ),
-		isKnownType: !! type,
-		type,
 	};
 };
 

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/duplicate.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/duplicate.jsx
@@ -25,11 +25,10 @@ import { bumpStatGenerator } from './utils';
 
 function PostActionsEllipsisMenuDuplicate( {
 	translate,
-	siteId,
 	canEdit,
+	status,
 	duplicateUrl,
 	bumpStat,
-	status,
 } ) {
 	const validStatus = includes( [ 'draft', 'future', 'pending', 'private', 'publish' ], status );
 
@@ -47,7 +46,6 @@ function PostActionsEllipsisMenuDuplicate( {
 PostActionsEllipsisMenuDuplicate.propTypes = {
 	globalId: PropTypes.string,
 	translate: PropTypes.func.isRequired,
-	siteId: PropTypes.number,
 	canEdit: PropTypes.bool,
 	status: PropTypes.string,
 	duplicateUrl: PropTypes.string,
@@ -72,7 +70,6 @@ const mapStateToProps = ( state, { globalId } ) => {
 
 	return {
 		status: post.status,
-		siteId: post.site_ID,
 		canEdit: canCurrentUser( state, post.site_ID, capability ),
 		duplicateUrl: getEditorDuplicatePostPath( state, post.site_ID, post.ID ),
 	};

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/edit.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/edit.jsx
@@ -85,7 +85,7 @@ const mapDispatchToProps = { bumpAnalyticsStat };
 
 const mergeProps = ( stateProps, dispatchProps, ownProps ) => {
 	const bumpStat = bumpStatGenerator(
-		stateProps.type.name,
+		get( stateProps, 'type.name' ),
 		'edit',
 		dispatchProps.bumpAnalyticsStat
 	);

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/edit.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/edit.jsx
@@ -24,11 +24,9 @@ import { getEditorPath } from 'state/ui/editor/selectors';
 
 function PostActionsEllipsisMenuEdit( {
 	translate,
-	siteId,
 	canEdit,
 	status,
 	editUrl,
-	isKnownType,
 	bumpStat,
 } ) {
 	if ( 'trash' === status || ! canEdit ) {
@@ -45,7 +43,6 @@ function PostActionsEllipsisMenuEdit( {
 PostActionsEllipsisMenuEdit.propTypes = {
 	globalId: PropTypes.string,
 	translate: PropTypes.func.isRequired,
-	siteId: PropTypes.number,
 	canEdit: PropTypes.bool,
 	status: PropTypes.string,
 	editUrl: PropTypes.string,
@@ -69,7 +66,6 @@ const mapStateToProps = ( state, { globalId } ) => {
 	}
 
 	return {
-		siteId: post.site_ID,
 		canEdit: canCurrentUser( state, post.site_ID, capability ),
 		status: post.status,
 		editUrl: getEditorPath( state, post.site_ID, post.ID ),

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/edit.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/edit.jsx
@@ -14,7 +14,6 @@ import { get } from 'lodash';
  * Internal dependencies
  */
 import PopoverMenuItem from 'components/popover/menu-item';
-import QueryPostTypes from 'components/data/query-post-types';
 import { bumpStat as bumpAnalyticsStat } from 'state/analytics/actions';
 import { bumpStatGenerator } from './utils';
 import { canCurrentUser } from 'state/selectors';
@@ -38,7 +37,6 @@ function PostActionsEllipsisMenuEdit( {
 
 	return (
 		<PopoverMenuItem href={ editUrl } onClick={ bumpStat } icon="pencil">
-			{ siteId && ! isKnownType && <QueryPostTypes siteId={ siteId } /> }
 			{ translate( 'Edit', { context: 'verb' } ) }
 		</PopoverMenuItem>
 	);
@@ -51,7 +49,6 @@ PostActionsEllipsisMenuEdit.propTypes = {
 	canEdit: PropTypes.bool,
 	status: PropTypes.string,
 	editUrl: PropTypes.string,
-	isKnownType: PropTypes.bool,
 	bumpStat: PropTypes.func,
 };
 
@@ -76,8 +73,6 @@ const mapStateToProps = ( state, { globalId } ) => {
 		canEdit: canCurrentUser( state, post.site_ID, capability ),
 		status: post.status,
 		editUrl: getEditorPath( state, post.site_ID, post.ID ),
-		isKnownType: !! type,
-		type,
 	};
 };
 

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/index.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/index.jsx
@@ -3,7 +3,7 @@
  *
  * @format
  */
-
+import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import React, { Children, cloneElement } from 'react';
 
@@ -20,8 +20,17 @@ import PostActionsEllipsisMenuTrash from './trash';
 import PostActionsEllipsisMenuView from './view';
 import PostActionsEllipsisMenuRestore from './restore';
 import PostActionsEllipsisMenuDuplicate from './duplicate';
+import QueryPostTypes from 'components/data/query-post-types';
+import { getPost } from 'state/posts/selectors';
+import { getPostType } from 'state/post-types/selectors';
 
-export default function PostActionsEllipsisMenu( { globalId, includeDefaultActions, children } ) {
+function PostActionsEllipsisMenu( {
+	globalId,
+	siteId,
+	isKnownType,
+	includeDefaultActions,
+	children,
+} ) {
 	let actions = [];
 
 	if ( includeDefaultActions ) {
@@ -48,6 +57,7 @@ export default function PostActionsEllipsisMenu( { globalId, includeDefaultActio
 
 	return (
 		<div className="post-actions-ellipsis-menu">
+			{ siteId && ! isKnownType && <QueryPostTypes siteId={ siteId } /> }
 			<EllipsisMenu position="bottom left" disabled={ ! globalId }>
 				{ actions.map( action => cloneElement( action, { globalId } ) ) }
 			</EllipsisMenu>
@@ -57,6 +67,8 @@ export default function PostActionsEllipsisMenu( { globalId, includeDefaultActio
 
 PostActionsEllipsisMenu.propTypes = {
 	globalId: PropTypes.string,
+	siteId: PropTypes.number,
+	isKnownType: PropTypes.bool,
 	includeDefaultActions: PropTypes.bool,
 	children: PropTypes.node,
 };
@@ -64,3 +76,17 @@ PostActionsEllipsisMenu.propTypes = {
 PostActionsEllipsisMenu.defaultProps = {
 	includeDefaultActions: true,
 };
+
+export default connect( ( state, { globalId } ) => {
+	const post = getPost( state, globalId );
+	if ( ! post ) {
+		return {};
+	}
+
+	const type = getPostType( state, post.site_ID, post.type );
+
+	return {
+		siteId: post.site_ID,
+		isKnownType: !! type,
+	};
+} )( PostActionsEllipsisMenu );

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/publish.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/publish.jsx
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { includes } from 'lodash';
+import { get, includes } from 'lodash';
 
 /**
  * Internal dependencies
@@ -82,7 +82,7 @@ const mapDispatchToProps = { savePost, bumpAnalyticsStat };
 
 const mergeProps = ( stateProps, dispatchProps, ownProps ) => {
 	const bumpStat = bumpStatGenerator(
-		stateProps.type.name,
+		get( stateProps, 'type.name' ),
 		'publish',
 		dispatchProps.bumpAnalyticsStat
 	);

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/restore.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/restore.jsx
@@ -8,6 +8,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -89,7 +90,7 @@ const mapDispatchToProps = { restorePost, bumpAnalyticsStat };
 
 const mergeProps = ( stateProps, dispatchProps, ownProps ) => {
 	const bumpStat = bumpStatGenerator(
-		stateProps.type.name,
+		get( stateProps, 'type.name' ),
 		'restore',
 		dispatchProps.bumpAnalyticsStat
 	);

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/share.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/share.jsx
@@ -8,7 +8,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { includes } from 'lodash';
+import { get, includes } from 'lodash';
 
 /**
  * Internal dependencies
@@ -78,7 +78,7 @@ const mapDispatchToProps = { toggleSharePanel, bumpAnalyticsStat };
 
 const mergeProps = ( stateProps, dispatchProps, ownProps ) => {
 	const bumpStat = bumpStatGenerator(
-		stateProps.type.name,
+		get( stateProps, 'type.name' ),
 		'share',
 		dispatchProps.bumpAnalyticsStat
 	);

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/stats.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/stats.jsx
@@ -8,6 +8,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -71,7 +72,7 @@ const mapDispatchToProps = { bumpAnalyticsStat };
 
 const mergeProps = ( stateProps, dispatchProps, ownProps ) => {
 	const bumpStat = bumpStatGenerator(
-		stateProps.type.name,
+		get( stateProps, 'type.name' ),
 		'stats',
 		dispatchProps.bumpAnalyticsStat
 	);

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/trash.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/trash.jsx
@@ -8,6 +8,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -100,12 +101,12 @@ const mapDispatchToProps = { trashPost, deletePost, bumpAnalyticsStat };
 
 const mergeProps = ( stateProps, dispatchProps, ownProps ) => {
 	const bumpTrashStat = bumpStatGenerator(
-		stateProps.type.name,
+		get( stateProps, 'type.name' ),
 		'trash',
 		dispatchProps.bumpAnalyticsStat
 	);
 	const bumpDeleteStat = bumpStatGenerator(
-		stateProps.type.name,
+		get( stateProps, 'type.name' ),
 		'delete',
 		dispatchProps.bumpAnalyticsStat
 	);

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/utils.js
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/utils.js
@@ -1,7 +1,9 @@
 export function bumpStatGenerator( type, name, bumpStat ) {
 	return () => {
 		let group;
-		if ( type !== 'page' && type !== 'post' ) {
+		if ( ! type ) {
+			group = 'calypso_unknown_type_actions';
+		} else if ( type !== 'page' && type !== 'post' ) {
 			group = 'calypso_cpt_actions';
 		} else {
 			group = 'calypso_' + type + '_actions';

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/view.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/view.jsx
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { includes } from 'lodash';
+import { get, includes } from 'lodash';
 
 /**
  * Internal dependencies
@@ -98,7 +98,7 @@ const mapDispatchToProps = { setPreviewUrl, setLayoutFocus, bumpAnalyticsStat };
 
 const mergeProps = ( stateProps, dispatchProps, ownProps ) => {
 	const bumpStat = bumpStatGenerator(
-		stateProps.type.name,
+		get( stateProps, 'type.name' ),
 		'view',
 		dispatchProps.bumpAnalyticsStat
 	);


### PR DESCRIPTION
Ensure that we query site post types when necessary and that we do not attempt to access the `type` property of a missing post type object.

In order to test this on the CPT screen I had to fix another bug I noticed (9b6aebd) which prevented the CPT listing from loading:

![2017-11-03t00 19 57 0800](https://user-images.githubusercontent.com/227022/32337980-70b4d848-c02e-11e7-969a-095d51169589.png)
