### PR TITLE
Activity Log: scroll to the top of the page after confirming a restore

### DIFF
--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -274,6 +274,11 @@ class ActivityLog extends Component {
 		debug( 'Restore requested for after activity %o', requestedRestoreActivity );
 		recordTracksEvent( 'calypso_activitylog_restore_confirm', { rewindId } );
 		rewindRestore( siteId, rewindId );
+		scrollTo( {
+			x: 0,
+			y: 0,
+			duration: 250,
+		} );
 	};
 
 	/**


### PR DESCRIPTION
Previously, the confirmed dialog dissapeared and user was left in the same place in the page without a clue about what happened.
This PR now scrolls the user to the top to see what happened: that the restore is now in progress.

#### Test
To better appreciate this during testing: scroll to the first day of October, click the Rewind blue button in day header and then confirm.

Alternatively, to fake this without restoring, edit the file in this line 
https://github.com/Automattic/wp-calypso/pull/19437/files#diff-98688df929f51781b35643104ad2bed7R267
and add 
```js
scrollTo( {
		x: 0,
		y: 0,
		duration: 250,
} );
```
and now open the dialog and close it. After closing it, it will scroll to the top.