### PR TITLE
.org Plans: Enable Happychat step in cancellation flow

### DIFF
--- a/client/components/marketing-survey/cancel-purchase-form/stepsForProductAndSurvey.js
+++ b/client/components/marketing-survey/cancel-purchase-form/stepsForProductAndSurvey.js
@@ -11,6 +11,14 @@ import * as steps from './steps';
 
 const BUSINESS_PLANS = [ plans.PLAN_BUSINESS ];
 const PERSONAL_PREMIUM_PLANS = [ plans.PLAN_PERSONAL, plans.PLAN_PREMIUM ];
+const JETPACK_PAID_PLANS = [
+	plans.PLAN_JETPACK_BUSINESS,
+	plans.PLAN_JETPACK_BUSINESS_MONTHLY,
+	plans.PLAN_JETPACK_PERSONAL,
+	plans.PLAN_JETPACK_PERSONAL_MONTHLY,
+	plans.PLAN_JETPACK_PREMIUM,
+	plans.PLAN_JETPACK_PREMIUM_MONTHLY,
+];
 
 export default function stepsForProductAndSurvey( survey, product, canChat ) {
 	if ( survey && survey.questionOneRadio === 'tooHard' ) {
@@ -33,6 +41,12 @@ export default function stepsForProductAndSurvey( survey, product, canChat ) {
 			abtest( 'ATUpgradeOnCancel' ) === 'show'
 		) {
 			return [ steps.INITIAL_STEP, steps.UPGRADE_AT_STEP, steps.FINAL_STEP ];
+		}
+	}
+
+	if ( survey && survey.questionOneRadio === 'couldNotActivate' ) {
+		if ( canChat && includesProduct( JETPACK_PAID_PLANS, product ) ) {
+			return [ steps.INITIAL_STEP, steps.HAPPYCHAT_STEP, steps.FINAL_STEP ];
 		}
 	}
 


### PR DESCRIPTION
This PR enables the Happychat step in the cancellation flow for all Jetpack paid plans. It will be shown when the user selects **I was unable to activate or use the product** in the first question (**Please tell us why you are canceling**). That step looks like this:

![](https://cldup.com/bsg-4ero6W.png)

Fixes #18904.

To test:
* Checkout this branch, or get it going on calypso.live.
* Make yourself available as an operator in the Happychat staging interface.
* Go to `/me/purchases`
* Select a Jetpack paid plan purchase.
* Click the "Remove Jetpack %plan%" button at the bottom.
* You'll see the first step of the cancellation flow.
* Select **I was unable to activate or use the product** for the first question, and a random answer in the second question. 
* Click "Next Step".
* Verify you can see the Happychat step, and it opens a live chat properly.
* Click the **I'll Keep It** button to cancel the cancellation flow.
* Refresh the particular Jetpack plan purchase page.
* Click the "Remove Jetpack %plan%" button at the bottom.
* Select an option, different from **I was unable to activate or use the product** in the first question, and select a random one for the second one.
* Verify you can see the last step, and the Happychat step is not visible.
* Click the **I'll Keep It** button to cancel the cancellation flow.
* Make yourself unavailable as an operator in the Happychat staging interface.
* Refresh the particular Jetpack plan purchase page.
* Click the "Remove Jetpack %plan%" button at the bottom.
* You'll see the first step of the cancellation flow.
* Select **I was unable to activate or use the product** for the first question, and a random answer in the second question. 
* Click "Next Step".
* Verify you can see the last step, and the Happychat step is not visible because Happychat is not available.