### PR TITLE
Reader: remove race condition from ReaderMain

### DIFF
--- a/client/blocks/like-button/button.jsx
+++ b/client/blocks/like-button/button.jsx
@@ -106,11 +106,12 @@ class LikeButton extends PureComponent {
 			</span>
 		);
 
+		const href = ! isLink ? null : `/stats/post/${ postId }/${ slug }`;
 		return React.createElement(
 			containerTag,
 			omitBy(
 				{
-					href: isLink && `/stats/post/${ postId }/${ slug }`,
+					href,
 					className: classNames( containerClasses ),
 					onClick: ! isLink && this.toggleLiked,
 				},

--- a/client/blocks/like-button/button.jsx
+++ b/client/blocks/like-button/button.jsx
@@ -106,7 +106,7 @@ class LikeButton extends PureComponent {
 			</span>
 		);
 
-		const href = ! isLink ? null : `/stats/post/${ postId }/${ slug }`;
+		const href = isLink ? `/stats/post/${ postId }/${ slug }` : null;
 		return React.createElement(
 			containerTag,
 			omitBy(

--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -250,9 +250,9 @@ class ReaderPostCard extends React.Component {
 		}
 
 		const followUrl = feed ? feed.feed_URL : post.site_URL;
-
+		const onClick = ! isPhotoPost && ! compact ? this.handleCardClick : noop;
 		return (
-			<Card className={ classes } onClick={ ! isPhotoPost && ! compact && this.handleCardClick }>
+			<Card className={ classes } onClick={ onClick }>
 				{ ! compact && postByline }
 				{ showPrimaryFollowButton &&
 				followUrl && (

--- a/client/components/reader-main/index.jsx
+++ b/client/components/reader-main/index.jsx
@@ -12,6 +12,27 @@ import React from 'react';
 import Main from 'components/main';
 import SyncReaderFollows from 'components/data/sync-reader-follows';
 
+/*
+ * We ref-count number of ReaderMains on screen in order to avoid a race condition
+ *
+ * If two pages in a row have a ReaderMain there is no guarantee as to the order of dismounting
+ * and mounting. If we naively toggled the readerPage within willMount and willDismount
+ * we could run into a weird state.
+ *
+ * A problem sequence would be:
+ * 1. land on reader (mount, 1 ref)
+ * 2. navigate to another reader page (mount new ReaderMain, 2 ref)
+ * 3. dismount old ReaderMain from the first step (dismount, 1 ref)
+ */
+let numReaderMains = 0;
+const setIsReaderPage = add => {
+	if ( add ) {
+		document.querySelector( 'body' ).classList.add( 'is-reader-page' );
+	} else if ( numReaderMains === 0 ) {
+		document.querySelector( 'body' ).classList.remove( 'is-reader-page' );
+	}
+};
+
 /**
  * A specialization of `Main` that adds a class to the body of the document
  *
@@ -20,11 +41,13 @@ import SyncReaderFollows from 'components/data/sync-reader-follows';
  */
 export default class ReaderMain extends React.Component {
 	componentWillMount() {
-		document.querySelector( 'body' ).classList.add( 'is-reader-page' );
+		numReaderMains++;
+		setIsReaderPage( true );
 	}
 
 	componentWillUnmount() {
-		document.querySelector( 'body' ).classList.remove( 'is-reader-page' );
+		numReaderMains--;
+		setIsReaderPage( false );
 	}
 
 	render() {

--- a/client/components/reader-main/index.jsx
+++ b/client/components/reader-main/index.jsx
@@ -24,11 +24,11 @@ import SyncReaderFollows from 'components/data/sync-reader-follows';
  * 2. navigate to another reader page (mount new ReaderMain, 2 ref)
  * 3. dismount old ReaderMain from the first step (dismount, 1 ref)
  */
-let numReaderMains = 0;
+let activeReaderMainRefCount = 0;
 const setIsReaderPage = add => {
 	if ( add ) {
 		document.querySelector( 'body' ).classList.add( 'is-reader-page' );
-	} else if ( numReaderMains === 0 ) {
+	} else if ( activeReaderMainRefCount === 0 ) {
 		document.querySelector( 'body' ).classList.remove( 'is-reader-page' );
 	}
 };
@@ -41,12 +41,12 @@ const setIsReaderPage = add => {
  */
 export default class ReaderMain extends React.Component {
 	componentWillMount() {
-		numReaderMains++;
+		activeReaderMainRefCount++;
 		setIsReaderPage( true );
 	}
 
 	componentWillUnmount() {
-		numReaderMains--;
+		activeReaderMainRefCount--;
 		setIsReaderPage( false );
 	}
 

--- a/client/reader/stream/post-lifecycle.jsx
+++ b/client/reader/stream/post-lifecycle.jsx
@@ -27,7 +27,7 @@ import EmptySearchRecommendedPost from './empty-search-recommended-post';
 
 const ConnectedCombinedCard = fluxPostAdapter( CombinedCard );
 
-export default class PostLifecycle extends React.PureComponent {
+export default class PostLifecycle extends React.Component {
 	static propTypes = {
 		postKey: PropTypes.object.isRequired,
 		isDiscoverStream: PropTypes.bool,


### PR DESCRIPTION
This fixes a few issues that sprung up during the [React 16 upgrade](https://github.com/Automattic/wp-calypso/pull/19083).

1. do not set href to a boolean
1. do not set onClick to a boolean
1. race condition with mounting/dismounting `ReaderMain`. I've added ref-counting