### PR TITLE
Activity Log: expand today, don't show rewind button in day header

### DIFF
--- a/client/my-sites/stats/activity-log-day/index.jsx
+++ b/client/my-sites/stats/activity-log-day/index.jsx
@@ -268,10 +268,8 @@ class ActivityLogDay extends Component {
 }
 
 export default connect(
-	( state, { tsEndOfSiteDay, siteId } ) => {
-		const now = Date.now();
+	( state, { siteId } ) => {
 		return {
-			isToday: now <= tsEndOfSiteDay && tsEndOfSiteDay - DAY_IN_MILLISECONDS <= now,
 			requestedRewind: getRequestedRewind( state, siteId ),
 		};
 	},

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -533,6 +533,7 @@ class ActivityLog extends Component {
 												requestRestore={ this.handleRequestRestore }
 												siteId={ siteId }
 												tsEndOfSiteDay={ start.valueOf() }
+												isToday={ isToday }
 											/>
 										);
 								}


### PR DESCRIPTION
This PR aims to solve a bug with Activity Log: when the page loads, the current day, today, is not currently unfurled. This was initially a requirement and it was initially implemented but there was a regression recently. This PR restores this behaviour.
With the recent refactor done by @dmsnell, it's actually more efficient to pass the "today" so additional calculation is not required in ActivityLogDay.
Additionally, it also restores another requirement: not showing the blue button to rewind to this day in the current day since the day isn't over yet.

#### Test

Make sure you have activities for the current day. When you load AL:
- current day should be expanded
- it shouldn't display the blue rewind button in the current day header