### PR TITLE
Store: Try wideLayout on <Main />

### DIFF
--- a/client/extensions/woocommerce/app/dashboard/index.js
+++ b/client/extensions/woocommerce/app/dashboard/index.js
@@ -184,7 +184,7 @@ class Dashboard extends Component {
 		const { className, isSetupComplete, loading, selectedSite } = this.props;
 
 		return (
-			<Main className={ classNames( 'dashboard', className ) }>
+			<Main className={ classNames( 'dashboard', className ) } wideLayout>
 				<ActionHeader
 					breadcrumbs={ this.getBreadcrumb() }
 					isLoading={ loading || ! selectedSite }

--- a/client/extensions/woocommerce/app/order/index.js
+++ b/client/extensions/woocommerce/app/order/index.js
@@ -130,7 +130,7 @@ class Order extends Component {
 		}
 
 		return (
-			<Main className={ className }>
+			<Main className={ className } wideLayout>
 				<ActionHeader breadcrumbs={ breadcrumbs }>
 					{ config.isEnabled( 'woocommerce/extension-orders-edit' ) && button }
 				</ActionHeader>

--- a/client/extensions/woocommerce/app/order/order-create/index.js
+++ b/client/extensions/woocommerce/app/order/order-create/index.js
@@ -45,7 +45,7 @@ class OrderCreate extends Component {
 			<span>{ translate( 'New Order' ) }</span>,
 		];
 		return (
-			<Main className={ className }>
+			<Main className={ className } wideLayout>
 				<ActionHeader breadcrumbs={ breadcrumbs }>
 					<Button primary>{ translate( 'Save Order' ) }</Button>
 				</ActionHeader>

--- a/client/extensions/woocommerce/app/order/order-customer/style.scss
+++ b/client/extensions/woocommerce/app/order/order-customer/style.scss
@@ -42,6 +42,7 @@
 
 	.button {
 		color: $blue-wordpress;
+		padding-bottom: 0;
 
 		&:hover {
 			color: $link-highlight;

--- a/client/extensions/woocommerce/app/order/order-details/style.scss
+++ b/client/extensions/woocommerce/app/order/order-details/style.scss
@@ -37,6 +37,10 @@
 
 	.order-details__item-delete {
 		width: 1.5em;
+
+		.gridicons-trash {
+			color: $alert-red;
+		}
 	}
 }
 

--- a/client/extensions/woocommerce/app/order/style.scss
+++ b/client/extensions/woocommerce/app/order/style.scss
@@ -33,6 +33,10 @@
 			background: transparent;
 		}
 	}
+
+	.labels-setup-notice {
+		width: 100%;
+	}
 }
 
 .order-details__card {

--- a/client/extensions/woocommerce/app/order/style.scss
+++ b/client/extensions/woocommerce/app/order/style.scss
@@ -24,6 +24,26 @@
 		}
 	}
 
+	@include breakpoint( ">1040px" ) {
+		.order-details {
+			order: 1;
+			flex: 2;
+			margin-right: 16px;
+		}
+
+		.order-activity-log {
+			order: 3;
+			flex: none;
+			margin-right: 0;
+			width: 100%;
+		}
+
+		.order-customer {
+			order: 2;
+			flex: 1;
+		}
+	}
+
 	.section-header__label {
 		font-size: 16px;
 	}

--- a/client/extensions/woocommerce/app/orders/index.js
+++ b/client/extensions/woocommerce/app/orders/index.js
@@ -29,7 +29,7 @@ function Orders( { className, params, site, translate } ) {
 	}
 
 	return (
-		<Main className={ className }>
+		<Main className={ className } wideLayout>
 			<ActionHeader breadcrumbs={ <span>{ translate( 'Orders' ) }</span> }>
 				{ addButton }
 			</ActionHeader>

--- a/client/extensions/woocommerce/app/products/index.js
+++ b/client/extensions/woocommerce/app/products/index.js
@@ -117,7 +117,7 @@ class Products extends Component {
 		}
 
 		return (
-			<Main className={ classes }>
+			<Main className={ classes } wideLayout>
 				<SidebarNavigation />
 				<ActionHeader breadcrumbs={ <span>{ translate( 'Products' ) }</span> }>
 					<Button primary href={ getLink( '/store/product/:site/', site ) }>

--- a/client/extensions/woocommerce/app/products/product-create.js
+++ b/client/extensions/woocommerce/app/products/product-create.js
@@ -178,7 +178,7 @@ class ProductCreate extends React.Component {
 		const saveEnabled = isValid && ! isBusy;
 
 		return (
-			<Main className={ className }>
+			<Main className={ className } wideLayout>
 				<ProductHeader
 					site={ site }
 					product={ product }

--- a/client/extensions/woocommerce/app/products/product-form.scss
+++ b/client/extensions/woocommerce/app/products/product-form.scss
@@ -459,6 +459,10 @@
 		right: -12px;
 		top: 0;
 		background: radial-gradient( ellipse at center, rgba( $gray-dark,.125 ) 0%, rgba( $white,0 ) 75%, rgba( $white,0 ) 90% );
+
+		@include breakpoint( ">1280px" ) {
+			display: none;
+		}
 	}
 }
 

--- a/client/extensions/woocommerce/app/products/product-form.scss
+++ b/client/extensions/woocommerce/app/products/product-form.scss
@@ -239,7 +239,7 @@
 .products__product-form-images-wrapper,
 .products__product-form-details-basic {
 	@include breakpoint( ">960px" ) {
-		margin-right: 32px;
+		margin-right: 24px;
 	}
 
 	&:last-child {
@@ -275,6 +275,17 @@
 		&:last-child {
 			margin-bottom: 0;
 		}
+	}
+
+	@include breakpoint( ">1040px" ) {
+		display: flex;
+
+		>.form-fieldset {
+			width: 339px;
+			margin-right: 24px;
+			margin-bottom: 0;
+		}
+
 	}
 }
 
@@ -953,5 +964,11 @@
 				margin-bottom: 0;
 			}
 		}
+	}
+}
+
+.products__product-form-delivery-details {
+	.form-setting-explanation {
+		max-width: 500px;
 	}
 }

--- a/client/extensions/woocommerce/app/products/product-form.scss
+++ b/client/extensions/woocommerce/app/products/product-form.scss
@@ -166,6 +166,11 @@
 		height: 70px;
 		overflow: hidden;
 
+		@include breakpoint( ">1040px" ) {
+			width: 100px;
+			height: 100px;
+		}
+
 		img {
 			position: absolute;
 			left: 50%;
@@ -212,9 +217,14 @@
 .products__product-form-images-wrapper {
 	width: 100%;
 	margin-bottom: 16px;
+
 	@include breakpoint( ">960px" ) {
 		margin-bottom: 0;
 		width: 250px;
+	}
+
+	@include breakpoint( ">1040px" ) {
+		width: 339px;
 	}
 }
 

--- a/client/extensions/woocommerce/app/products/product-update.js
+++ b/client/extensions/woocommerce/app/products/product-update.js
@@ -185,7 +185,7 @@ class ProductUpdate extends React.Component {
 		const saveEnabled = isValid && ! isBusy && hasEdits;
 
 		return (
-			<Main className={ className }>
+			<Main className={ className } wideLayout>
 				<SidebarNavigation />
 				<ProductHeader
 					site={ site }

--- a/client/extensions/woocommerce/app/promotions/index.js
+++ b/client/extensions/woocommerce/app/promotions/index.js
@@ -105,7 +105,7 @@ class Promotions extends Component {
 		const content = isEmpty ? this.renderEmptyContent() : this.renderContent();
 
 		return (
-			<Main className={ classes }>
+			<Main className={ classes } wideLayout>
 				<SidebarNavigation />
 				<ActionHeader breadcrumbs={ <span>{ translate( 'Promotions' ) }</span> }>
 					<Button primary href={ getLink( '/store/promotion/:site/', site ) }>

--- a/client/extensions/woocommerce/app/promotions/promotion-create.js
+++ b/client/extensions/woocommerce/app/promotions/promotion-create.js
@@ -181,7 +181,7 @@ class PromotionCreate extends React.Component {
 		const { saveAttempted, busy } = this.state;
 
 		return (
-			<Main className={ className }>
+			<Main className={ className } wideLayout>
 				<PromotionHeader
 					site={ site }
 					promotion={ promotion }

--- a/client/extensions/woocommerce/app/promotions/promotion-update.js
+++ b/client/extensions/woocommerce/app/promotions/promotion-update.js
@@ -218,7 +218,7 @@ class PromotionUpdate extends React.Component {
 		const { saveAttempted, busy } = this.state;
 
 		return (
-			<Main className={ className }>
+			<Main className={ className } wideLayout>
 				<PromotionHeader
 					site={ site }
 					promotion={ promotion }

--- a/client/extensions/woocommerce/app/reviews/index.js
+++ b/client/extensions/woocommerce/app/reviews/index.js
@@ -31,7 +31,7 @@ class Reviews extends Component {
 		const classes = classNames( 'reviews__list', className );
 
 		return (
-			<Main className={ classes }>
+			<Main className={ classes } wideLayout>
 				<SidebarNavigation />
 				<ActionHeader breadcrumbs={ <span>{ translate( 'Reviews' ) }</span> } />
 				<ReviewsList

--- a/client/extensions/woocommerce/app/settings/email/index.js
+++ b/client/extensions/woocommerce/app/settings/email/index.js
@@ -37,7 +37,7 @@ const SettingsEmail = ( { site, translate, className, params, isSaving, mailChim
 	);
 
 	return (
-		<Main className={ classNames( 'email', className ) }>
+		<Main className={ classNames( 'email', className ) } wideLayout>
 			<ActionHeader breadcrumbs={ breadcrumbs } >
 				<Button primary onClick={ onSave } busy={ isSaving } disabled={ isSaving }>
 					{ translate( 'Save' ) }

--- a/client/extensions/woocommerce/app/settings/payments/index.js
+++ b/client/extensions/woocommerce/app/settings/payments/index.js
@@ -102,7 +102,7 @@ class SettingsPayments extends Component {
 
 		const saveMessage = finishedInitialSetup ? translate( 'Save' ) : translate( 'Save & Finish' );
 		return (
-			<Main className={ classNames( 'settingsPayments', className ) }>
+			<Main className={ classNames( 'settingsPayments', className ) } wideLayout>
 				<ActionHeader breadcrumbs={ breadcrumbs }>
 					<Button primary onClick={ this.onSave } busy={ isSaving } disabled={ isSaving }>
 						{ saveMessage }

--- a/client/extensions/woocommerce/app/settings/payments/style.scss
+++ b/client/extensions/woocommerce/app/settings/payments/style.scss
@@ -3,7 +3,6 @@
 	flex-direction: column;
 	flex-grow: 1;
 	max-height: 80%;
-	max-width: 600px;
 
 	.dialog__content {
 		height: 100%;
@@ -40,10 +39,6 @@
 		padding: 0;
 		box-shadow: none;
 	}
-}
-
-&.store-location__edit-dialog {
-	max-width: 600px;
 }
 
 .payments__currency-container {

--- a/client/extensions/woocommerce/app/settings/payments/style.scss
+++ b/client/extensions/woocommerce/app/settings/payments/style.scss
@@ -1,8 +1,5 @@
 &.payments__dialog {
-	display: flex;
-	flex-direction: column;
-	flex-grow: 1;
-	max-height: 80%;
+	max-width: 660px;
 
 	.dialog__content {
 		height: 100%;

--- a/client/extensions/woocommerce/app/settings/payments/style.scss
+++ b/client/extensions/woocommerce/app/settings/payments/style.scss
@@ -28,7 +28,6 @@
 	display: flex;
 	flex-direction: row;
 	flex-wrap: wrap;
-	justify-content: space-between;
 
 	@include breakpoint( "<660px" ) {
 		flex-direction: column;

--- a/client/extensions/woocommerce/app/settings/shipping/index.js
+++ b/client/extensions/woocommerce/app/settings/shipping/index.js
@@ -23,7 +23,7 @@ const Shipping = ( { className } ) => {
 	const wcsEnabled = config.isEnabled( 'woocommerce/extension-wcservices' );
 
 	return (
-		<Main className={ classNames( 'shipping', className ) }>
+		<Main className={ classNames( 'shipping', className ) } wideLayout>
 			<ShippingHeader />
 			<ShippingOrigin />
 			<ShippingZoneList />

--- a/client/extensions/woocommerce/app/settings/shipping/shipping-zone/index.js
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-zone/index.js
@@ -133,7 +133,7 @@ class Shipping extends Component {
 		const { className, isRestOfTheWorld, hasEdits, siteId } = this.props;
 
 		return (
-			<Main className={ classNames( 'shipping', className ) }>
+			<Main className={ classNames( 'shipping', className ) } wideLayout>
 				<ProtectFormGuard isChanged={ hasEdits } />
 				<QueryShippingZones siteId={ siteId } />
 				<QuerySettingsGeneral siteId={ siteId } />

--- a/client/extensions/woocommerce/app/settings/shipping/shipping-zone/style.scss
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-zone/style.scss
@@ -206,7 +206,6 @@
 }
 
 &.shipping-zone__method-dialog {
-	max-width: 600px;
 	max-height: 80%;
 	display: flex;
 	flex-direction: column;
@@ -297,7 +296,6 @@
 }
 
 &.shipping-zone__location-dialog {
-	max-width: 600px;
 	max-height: 85%;
 	display: flex;
 	flex-direction: column;

--- a/client/extensions/woocommerce/app/settings/taxes/index.js
+++ b/client/extensions/woocommerce/app/settings/taxes/index.js
@@ -59,7 +59,7 @@ class SettingsTaxes extends Component {
 		const renderPlaceholder = ! renderTaxesByTaxJar && ! renderTaxesByWCS;
 
 		return (
-			<Main className={ classNames( 'settings-taxes', className ) }>
+			<Main className={ classNames( 'settings-taxes', className ) } wideLayout>
 				{ renderPlaceholder && <SettingsTaxesPlaceholder siteSlug={ siteSlug } /> }
 				{ renderTaxesByTaxJar && <SettingsTaxesTaxJar site={ site } /> }
 				{ renderTaxesByWCS && (

--- a/client/extensions/woocommerce/app/settings/taxes/taxes-taxjar.js
+++ b/client/extensions/woocommerce/app/settings/taxes/taxes-taxjar.js
@@ -43,7 +43,7 @@ class SettingsTaxesTaxJar extends Component {
 		const pluginUrl = getLink( '/plugins/taxjar-simplified-taxes-for-woocommerce/:site', site );
 
 		return (
-			<Main className={ classNames( 'settings-taxes', className ) }>
+			<Main className={ classNames( 'settings-taxes', className ) } wideLayout>
 				<ActionHeader breadcrumbs={ breadcrumbs } />
 				<SettingsNavigation activeSection="taxes" />
 				<div>

--- a/client/extensions/woocommerce/app/settings/taxes/taxes-wcs.js
+++ b/client/extensions/woocommerce/app/settings/taxes/taxes-wcs.js
@@ -194,7 +194,7 @@ class SettingsTaxesWooCommerceServices extends Component {
 		];
 
 		return (
-			<Main className={ classNames( 'settings-taxes', className ) }>
+			<Main className={ classNames( 'settings-taxes', className ) } wideLayout>
 				<ActionHeader breadcrumbs={ breadcrumbs }>
 					<TaxSettingsSaveButton onSave={ this.onSave } />
 				</ActionHeader>

--- a/client/extensions/woocommerce/components/product-image-uploader/style.scss
+++ b/client/extensions/woocommerce/components/product-image-uploader/style.scss
@@ -11,6 +11,11 @@
 		width: 250px;
 	}
 
+	@include breakpoint( ">1040px" ) {
+		width: 337px;
+		height: 337px;
+	}
+
 	.product-image-uploader__picker {
 		position: absolute;
 		top: 0;

--- a/client/extensions/woocommerce/components/product-image-uploader/style.scss
+++ b/client/extensions/woocommerce/components/product-image-uploader/style.scss
@@ -64,6 +64,11 @@
 		margin-right: 16px;
 	}
 
+	@include breakpoint( ">1040px" ) {
+		width: 100px;
+		height: 100px;
+	}
+
 	&:nth-child( 3n ) {
 		@include breakpoint( ">960px" ) {
 			margin-right: 0;
@@ -83,6 +88,10 @@
 
 		@include breakpoint( ">960px" ) {
 			height: 72px;
+		}
+
+		@include breakpoint( ">1040px" ) {
+			height: 100px;
 		}
 
 		.gridicon {

--- a/client/extensions/woocommerce/style.scss
+++ b/client/extensions/woocommerce/style.scss
@@ -85,6 +85,10 @@
 			margin: 0px;
 		}
 	}
+
+	.layout__content {
+		padding-top: 67px;
+	}
 }
 
 .store-sidebar__sidebar {


### PR DESCRIPTION
I've been wanting to give this a _Try_ for a while now, so I figured I'd get it out there for the rest of the team to checkout. This branch updates all usages of the `<Main />` component within the woocommerce extension directory to use the `wideLayout` prop. The result of this is, on wider viewports, the `.is-wide-layout` bumps the max-width of the main div from 740px to 1040px which makes some screen much less cramped ( _i'm looking at you variant table_ ).

I thought this might add an interesting wrinkle to the dashboard/widget redesign too @jameskoster 

Various Screens, Top is Current, Bottom is Wide:

![store_ _care_for_animals_ _wordpress_com_and_store_ _care_for_animals_ _wordpress_com_and_wp-calypso_ _npm_start_ _node_ _npm_term_program_apple_terminal_shell__bin_zsh_ _209x56](https://user-images.githubusercontent.com/22080/32344404-feb59d46-bfc3-11e7-9aa4-df7e6ff75220.png)

![orders_ _care_for_animals_ _wordpress_com_and_orders_ _care_for_animals_ _wordpress_com_and_wp-calypso_ _npm_start_ _node_ _npm_term_program_apple_terminal_shell__bin_zsh_ _209x56](https://user-images.githubusercontent.com/22080/32344413-093d5f10-bfc4-11e7-8eee-688de22dcb86.png)

![order_details_ _care_for_animals_ _wordpress_com_and_order_details_ _care_for_animals_ _wordpress_com_and_wp-calypso_ _npm_start_ _node_ _npm_term_program_apple_terminal_shell__bin_zsh_ _209x56](https://user-images.githubusercontent.com/22080/32344429-1016784e-bfc4-11e7-8883-102a2cbf96e2.png)

![products_ _care_for_animals_ _wordpress_com_and_products_ _care_for_animals_ _wordpress_com_and_wp-calypso_ _npm_start_ _node_ _npm_term_program_apple_terminal_shell__bin_zsh_ _209x56](https://user-images.githubusercontent.com/22080/32344433-14181664-bfc4-11e7-89fd-0c11dce84a2a.png)

![edit_product_ _care_for_animals_ _wordpress_com_and_edit_product_ _care_for_animals_ _wordpress_com_and_wp-calypso_ _npm_start_ _node_ _npm_term_program_apple_terminal_shell__bin_zsh_ _209x56_and_listview_js_ _client](https://user-images.githubusercontent.com/22080/32344437-1aac7542-bfc4-11e7-824a-d0113a5b5e2d.png)

