### PR TITLE
Store Promotions: Enable in staging and wpcalypso

### DIFF
--- a/config/stage.json
+++ b/config/stage.json
@@ -136,7 +136,7 @@
 		"woocommerce/extension-orders-create": false,
 		"woocommerce/extension-orders-edit": false,
 		"woocommerce/extension-products": true,
-		"woocommerce/extension-promotions": false,
+		"woocommerce/extension-promotions": true,
 		"woocommerce/extension-reviews": true,
 		"woocommerce/extension-settings": true,
 		"woocommerce/extension-settings-email": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -149,7 +149,7 @@
 		"woocommerce/extension-orders-create": true,
 		"woocommerce/extension-orders-edit": true,
 		"woocommerce/extension-products": true,
-		"woocommerce/extension-promotions": false,
+		"woocommerce/extension-promotions": true,
 		"woocommerce/extension-reviews": true,
 		"woocommerce/extension-settings": true,
 		"woocommerce/extension-settings-email": true,


### PR DESCRIPTION
This commit enables promotions in staging and wpcalypso in preparation
for production.

To Test:
1. `npm test`
2. `npm start`
3. Visit `http://calypso.localhost:3000/store/promotion/<site url>`
4. Try out listing, searching the list, creating a new promotion, editing it, deleting it, etc.