### PR TITLE
Store Promotions: Enable in production

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -129,7 +129,7 @@
 		"woocommerce/extension-orders-create": false,
 		"woocommerce/extension-orders-edit": false,
 		"woocommerce/extension-products": true,
-		"woocommerce/extension-promotions": false,
+		"woocommerce/extension-promotions": true,
 		"woocommerce/extension-reviews": true,
 		"woocommerce/extension-settings": true,
 		"woocommerce/extension-settings-email": true,


### PR DESCRIPTION
This commit enables promotions in production.

To Test:
1. `npm test`
2. `npm start`
3. Visit `http://calypso.localhost:3000/store/promotion/<site url>`
4. Try out listing, searching the list, creating a new promotion, editing it, deleting it, etc.