### PR TITLE
Atomic Store: add abtest to allow Atomic Store to max 10% of all users

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -17,13 +17,14 @@ export default {
 		},
 		defaultVariation: 'hideSurveyStep',
 	},
-	signupPressableStoreFlow: {
-		datestamp: '20171018',
+	signupAtomicStoreVsPressable: {
+		datestamp: '20171101',
 		variations: {
-			atomic: 99,
-			pressable: 1,
+			atomic: 10,
+			pressable: 90,
 		},
-		defaultVariation: 'atomic',
+		defaultVariation: 'pressable',
+		allowExistingUsers: true,
 	},
 	businessPlanDescriptionAT: {
 		datestamp: '20170605',

--- a/client/signup/steps/design-type-with-atomic-store/index.jsx
+++ b/client/signup/steps/design-type-with-atomic-store/index.jsx
@@ -114,7 +114,7 @@ class DesignTypeWithAtomicStoreStep extends Component {
 
 		if (
 			designType === DESIGN_TYPE_STORE &&
-			( abtest( 'signupPressableStoreFlow' ) === 'pressable' || ! isCountryAllowed )
+			( abtest( 'signupAtomicStoreVsPressable' ) === 'pressable' || ! isCountryAllowed )
 		) {
 			this.scrollUp();
 


### PR DESCRIPTION
As a measure to prevent 100% of users using the Atomic Store signup flow during its first weeks, we are adding an abtest which will limit the maximum number of people using the Atomic Store flow to 10%.

## Testing

Navigate to `/start` (any flow except `/start/pressable`) and select the `pressable` `signupAtomicStoreVsPressable` variation. Click on "start with online store" – the Pressable UI should be shown. Now, select `atomic` abtest variation and click on the same thing. You should continue the Atomic Store flow.