### PR TITLE
Store: Remove old unused action-header css classes

### DIFF
--- a/client/extensions/woocommerce/style.scss
+++ b/client/extensions/woocommerce/style.scss
@@ -52,20 +52,6 @@
 
 	@import 'woocommerce-services/style';
 
-	.components__action-header {
-		width: 100%;
-	}
-
-	.components__action-header-actions {
-		position: absolute;
-		top: 16px;
-		right: 24px;
-
-		.button {
-			margin-left: 8px;
-		}
-	}
-
 	.section-nav {
 		@include breakpoint( ">660px" ) {
 			margin-top: 58px;


### PR DESCRIPTION
I found some old css classes that don't map to anything anymore.
The new (correct) classes are:
	`action-header__header`
	`action-header__actions`

The header is already set to 100%, so the first class isn't needed at
all. The second old class is actually incorrect now. So this removes
them both.

To Test:
1. `npm start`
2. Bring up the store locally, nothing should be different.
