### PR TITLE
Jetpack Disconnect: Remove options from 'Missing Feature'

### DIFF
--- a/client/my-sites/site-settings/disconnect-site/missing-feature.jsx
+++ b/client/my-sites/site-settings/disconnect-site/missing-feature.jsx
@@ -24,8 +24,6 @@ class MissingFeature extends PureComponent {
 		const { translate } = this.props;
 		return {
 			themes: translate( 'Themes' ),
-			plugins: translate( 'Plugins' ),
-			support: translate( 'Support' ),
 			seo: translate( 'SEO' ),
 			ads: translate( 'Ads' ),
 			ecommerce: translate( 'Ecommerce' ),


### PR DESCRIPTION
Addresses @rachelmcr's feedback at p7rd6c-15q-p2#comment-1799:

> The suggestions that appeared when I selected the input field were neat, but they were also a bit confusing because they included things like “Support” (which Jetpack has) and “Plugins” (which Jetpack is) so I got kind of distracted by those. That said, the suggestions helped me understand that this field is for single words or short phrases, rather than a short answer field.

And quoting my reply:

> Yeah, maybe we should remove those — neither ‘Support’ nor ‘Plugins’ seems to make a lot of sense; in addition to what you said, any site that has JP installed can also install any other plugin (permissions allowing).