### PR TITLE
Jetpack Disconnect: Disable Happychat on Free Plan

### DIFF
--- a/client/my-sites/site-settings/disconnect-site/troubleshoot.jsx
+++ b/client/my-sites/site-settings/disconnect-site/troubleshoot.jsx
@@ -16,10 +16,10 @@ import LoggedOutFormLinkItem from 'components/logged-out-form/link-item';
 import LoggedOutFormLinks from 'components/logged-out-form/links';
 import addQueryArgs from 'lib/route/add-query-args';
 import { recordTracksEvent, withAnalytics } from 'state/analytics/actions';
-import { getSiteUrl } from 'state/selectors';
+import { getSiteUrl, isSiteOnFreePlan } from 'state/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 
-const Troubleshoot = ( { siteUrl, trackDebugClick, trackSupportClick, translate } ) => (
+const Troubleshoot = ( { isFreePlan, siteUrl, trackDebugClick, trackSupportClick, translate } ) => (
 	<LoggedOutFormLinks>
 		<LoggedOutFormLinkItem
 			href={ addQueryArgs( { url: siteUrl }, 'https://jetpack.com/support/debug/' ) }
@@ -27,22 +27,33 @@ const Troubleshoot = ( { siteUrl, trackDebugClick, trackSupportClick, translate 
 		>
 			<Gridicon size={ 18 } icon="offline" /> { translate( 'Diagnose a connection problem' ) }
 		</LoggedOutFormLinkItem>
-		<JetpackConnectHappychatButton
-			label={ translate( 'Get help from our Happiness Engineers' ) }
-			eventName="calypso_jetpack_disconnect_chat_initiated"
-		>
+		{ isFreePlan ? (
 			<HelpButton
 				label={ translate( 'Get help from our Happiness Engineers' ) }
 				onClick={ trackSupportClick }
 			/>
-		</JetpackConnectHappychatButton>
+		) : (
+			<JetpackConnectHappychatButton
+				label={ translate( 'Get help from our Happiness Engineers' ) }
+				eventName="calypso_jetpack_disconnect_chat_initiated"
+			>
+				<HelpButton
+					label={ translate( 'Get help from our Happiness Engineers' ) }
+					onClick={ trackSupportClick }
+				/>
+			</JetpackConnectHappychatButton>
+		) }
 	</LoggedOutFormLinks>
 );
 
 export default connect(
-	state => ( {
-		siteUrl: getSiteUrl( state, getSelectedSiteId( state ) ),
-	} ),
+	state => {
+		const siteId = getSelectedSiteId( state );
+		return {
+			siteUrl: getSiteUrl( state, siteId ),
+			isFreePlan: isSiteOnFreePlan( state, siteId ),
+		};
+	},
 	{
 		trackDebugClick: withAnalytics( recordTracksEvent( 'calypso_jetpack_disconnect_debug_click' ) ),
 		trackSupportClick: withAnalytics(

--- a/client/state/selectors/is-site-on-free-plan.js
+++ b/client/state/selectors/is-site-on-free-plan.js
@@ -1,9 +1,14 @@
 /** @format */
 /**
+ * External dependencies
+ */
+import { includes } from 'lodash';
+
+/**
  * Internal dependencies
  */
 import { getCurrentPlan } from 'state/sites/plans/selectors';
-import { PLAN_FREE } from 'lib/plans/constants';
+import { PLAN_FREE, PLAN_JETPACK_FREE } from 'lib/plans/constants';
 
 /**
  * Returns true if site is on a free plan, false if the site is not
@@ -20,7 +25,7 @@ const isSiteOnFreePlan = ( state, siteId ) => {
 		return false;
 	}
 
-	return currentPlan.productSlug === PLAN_FREE;
+	return includes( [ PLAN_FREE, PLAN_JETPACK_FREE ], currentPlan.productSlug );
 };
 
 export default isSiteOnFreePlan;

--- a/client/state/selectors/is-site-on-free-plan.js
+++ b/client/state/selectors/is-site-on-free-plan.js
@@ -1,9 +1,7 @@
+/** @format */
 /**
  * Internal dependencies
- *
- * @format
  */
-
 import { getCurrentPlan } from 'state/sites/plans/selectors';
 import { PLAN_FREE } from 'lib/plans/constants';
 

--- a/client/state/selectors/test/is-site-on-free-plan.js
+++ b/client/state/selectors/test/is-site-on-free-plan.js
@@ -9,7 +9,7 @@ import deepFreeze from 'deep-freeze';
  * Internal dependencies
  */
 import isSiteOnFreePlan from '../is-site-on-free-plan';
-import { PLAN_BUSINESS, PLAN_FREE } from 'lib/plans/constants';
+import { PLAN_BUSINESS, PLAN_FREE, PLAN_JETPACK_FREE } from 'lib/plans/constants';
 import { getCurrentPlan } from 'state/sites/plans/selectors';
 jest.mock( 'state/sites/plans/selectors', () => ( { getCurrentPlan: require( 'sinon' ).stub() } ) );
 
@@ -28,6 +28,11 @@ describe( 'isSiteOnFreePlan', () => {
 
 	test( 'should return true when on free plan', () => {
 		getCurrentPlan.returns( { productSlug: PLAN_FREE } );
+		expect( isSiteOnFreePlan( state, 'site1' ) ).to.be.true;
+	} );
+
+	test( 'should return true when on free Jetpack plan', () => {
+		getCurrentPlan.returns( { productSlug: PLAN_JETPACK_FREE } );
 		expect( isSiteOnFreePlan( state, 'site1' ) ).to.be.true;
 	} );
 } );


### PR DESCRIPTION
As requested by @brbrr at p7rd6c-15q-p2#comment-1786:

> The only one thing I noticed that kinda confused me: I purchased the Personal plan from the beginning and then canceled it for Free plan testing. After cancellation, I still see that “Chat” icon on “Get help…” button. I expecting not to see chatting option for free plan site (as it appears on https://wordpress.com/help/contact)

![image](https://user-images.githubusercontent.com/96308/32352479-ab02b9b4-c021-11e7-8553-b86fe225979f.png)

To test:
* Try with free and non-free plans, and assure that you're logged into Happychat (JPOP).
* Navigate to `/settings/disconnect-site/:site`
* Verify that paid plans continue to offer Happychat, while on a free plan, you're taken to the contact form.

_Question:_ Should we disable support for free plans altogether (i.e. no contact form either)? /cc @annezazu -- I could've sworn this was discussed before but I can't find the p2 post right now...