### PR TITLE
Color Schemes: Add Color Scheme Support To Sidebar

### DIFF
--- a/assets/stylesheets/shared/_color-schemes.scss
+++ b/assets/stylesheets/shared/_color-schemes.scss
@@ -11,6 +11,23 @@
 	--masterbar-toggle-drafts-editor-background: darken( $blue-wordpress, 12% );
 	--masterbar-toggle-drafts-editor-border-color: darken( $blue-wordpress, 5% );
 	--masterbar-toggle-drafts-editor-hover-background: darken( $blue-wordpress, 17% );
+
+	--sidebar-color: $gray-dark;
+	--sidebar-background: lighten( $gray, 30% );
+	--sidebar-gridicon-fill: $gray;
+	--sidebar-heading-color: darken( $gray, 10% );
+	--sidebar-footer-button-color: darken( $gray, 10% );
+	--sidebar-menu-link-secondary-text-color: darken( $gray, 20% );
+	--sidebar-menu-a-first-child-after-background: hex-to-rgb( lighten( $gray, 30% ) );
+	--sidebar-menu-selected-background-color: $gray-text-min;
+	--sidebar-menu-selected-a-color: $white;
+	--sidebar-menu-selected-a-first-child-after-background: hex-to-rgb( $gray-text-min );
+
+	--button-is-borderless-color: $gray-text-min;
+	--count-border-color: $gray;
+	--count-color: $gray-text-min;
+	--current-site-switch-sites-background: lighten( $gray, 30% );
+	--profile-gravatar-user-secondary-info-color: darken( $gray, 20% );
 }
 
 //additional color schemes
@@ -27,12 +44,29 @@
 		--masterbar-toggle-drafts-editor-background: darken( $gray, 10% );
 		--masterbar-toggle-drafts-editor-border-color: lighten( $gray, 20% );
 		--masterbar-toggle-drafts-editor-hover-background: darken( $gray, 10% );
+
+		--sidebar-color: $gray-dark;
+		--sidebar-background: $white;
+		--sidebar-gridicon-fill: $gray-dark;
+		--sidebar-heading-color: lighten( $gray-dark, 10% );
+		--sidebar-footer-button-color: $gray-dark;
+		--sidebar-menu-link-secondary-text-color: $gray-dark;
+		--sidebar-menu-a-first-child-after-background: hex-to-rgb( $white );
+		--sidebar-menu-selected-background-color: lighten( $gray, 20% );
+		--sidebar-menu-selected-a-color: $gray-dark;
+		--sidebar-menu-selected-a-first-child-after-background: hex-to-rgb( lighten( $gray, 20% ) );
+
+		--button-is-borderless-color: $gray-dark;
+		--count-border-color: $gray-dark;
+		--count-color: $gray-dark;
+		--current-site-switch-sites-background: $white;
+		--profile-gravatar-user-secondary-info-color: $gray-dark;
 	}
 
 	&.is-dark {
 		--masterbar-color: $white;
 		--masterbar-background: $gray-dark;
-		--masterbar-border-color: darken( $gray, 10% );
+		--masterbar-border-color: $white;
 		--masterbar-item-hover-background: darken( $gray, 10% );
 		--masterbar-item-active-background: $gray-text-min;
 		--masterbar-item-new-color: $gray-dark;
@@ -41,5 +75,22 @@
 		--masterbar-toggle-drafts-editor-background: darken( $gray, 10% );
 		--masterbar-toggle-drafts-editor-border-color: $gray-dark;
 		--masterbar-toggle-drafts-editor-hover-background: lighten( $gray-text-min, 5% );
+
+		--sidebar-color: $white;
+		--sidebar-background: darken( $gray, 30% );
+		--sidebar-gridicon-fill: $white;
+		--sidebar-heading-color: $white;
+		--sidebar-footer-button-color: $white;
+		--sidebar-menu-link-secondary-text-color: $white;
+		--sidebar-menu-a-first-child-after-background: hex-to-rgb( darken( $gray, 30% ) );
+		--sidebar-menu-selected-background-color: $gray-dark;
+		--sidebar-menu-selected-a-color: $white;
+		--sidebar-menu-selected-a-first-child-after-background: hex-to-rgb( $gray-dark );
+
+		--button-is-borderless-color: $white;
+		--count-border-color: $white;
+		--count-color: $white;
+		--current-site-switch-sites-background: darken( $gray, 30% );
+		--profile-gravatar-user-secondary-info-color: $white;
 	}
 }

--- a/assets/stylesheets/shared/functions/_functions.scss
+++ b/assets/stylesheets/shared/functions/_functions.scss
@@ -1,1 +1,3 @@
+@import 'hex-to-rgb';
+@import 'overflow-gradient';
 @import 'z-index';

--- a/assets/stylesheets/shared/functions/_hex-to-rgb.scss
+++ b/assets/stylesheets/shared/functions/_hex-to-rgb.scss
@@ -1,0 +1,10 @@
+// ==========================================================================
+// Returns the individual RGB values of a given hexadecimal color value
+//
+// Values are rounded in order to make it compatible with the output of other
+// color functions like e.g. lighten()/darken().
+// ==========================================================================
+
+@function hex-to-rgb($color) {
+	@return round(red($color)), round(green($color)), round(blue($color));
+}

--- a/assets/stylesheets/shared/functions/_overflow-gradient.scss
+++ b/assets/stylesheets/shared/functions/_overflow-gradient.scss
@@ -1,0 +1,21 @@
+// ==========================================================================
+// Returns a linear gradient used to fade elements extending outside their parent
+//
+// The input value for the function must be individual RGB values. For conversion
+// of hexadecimal color values please use the hex-to-rgb() color function.
+//
+// The rgba() notation needs to be escaped in order to support CSS custom
+// properties. If it were not escaped SASS would interpret it as a SASS color
+// function which doesn't allow for CSS custom properties as input values.
+//
+// Usage:
+// background: overflow-gradient( var( --sidebar-rgba-test ) );
+// border-image: overflow-gradient( hex-to-rgb( $gray-light ), to left );
+// ==========================================================================
+@function overflow-gradient( $color, $direction: to right ) {
+	@return linear-gradient(
+		$direction,
+		#{ 'rgba(' } $color #{ ', 0 )' },
+		#{ 'rgba(' } $color #{ ', 1 )' } 50%
+	);
+}

--- a/client/components/button/style.scss
+++ b/client/components/button/style.scss
@@ -174,7 +174,7 @@ button {
 .button.is-borderless {
 	border: none;
 	background: none;
-	color: $gray-text-min;
+	color: var( --button-is-borderless-color );
 	padding-left: 0;
 	padding-right: 0;
 

--- a/client/components/count/style.scss
+++ b/client/components/count/style.scss
@@ -1,12 +1,12 @@
 .count {
 	display: inline-block;
 	padding: 1px 6px;
-	border: solid 1px $gray;
+	border: solid 1px var( --count-border-color );
 	border-radius: 12px;
 	font-size: 11px;
 	font-weight: 600;
 	line-height: 14px;
-	color: $gray-text-min;
+	color: var( --count-color );
 	text-align: center;
 
 	&.is-primary {

--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -1,9 +1,10 @@
 .sidebar {
+	color: var( --sidebar-color );
 	display: flex;
 	flex-direction: column;
 	overflow: auto;
 	padding: 0;
-	background: $sidebar-bg-color;
+	background: var( --sidebar-background );
 	position: fixed;
 		top: 47px;
 		bottom: 0;
@@ -69,7 +70,7 @@
 
 // Sidebar group headings
 .sidebar__heading {
-	color: darken( $gray, 10% );
+	color: var( --sidebar-heading-color );
 	font-weight: 600;
 	font-size: 12px;
 	margin: 16px 8px 6px 14px;
@@ -114,12 +115,11 @@
 				right: 0;
 				bottom: 0;
 			width: 15%;
-			background: linear-gradient(
-				to right,
-				rgba( $sidebar-bg-color, 0 ),
-				rgba( $sidebar-bg-color, 1 ) 50% );
+
+			background: overflow-gradient( var( --sidebar-menu-a-first-child-after-background ) );
 
 			@include breakpoint( "<660px" ) {
+
 				background: linear-gradient(
 					to right,
 					rgba( $gray-light, 0 ),
@@ -133,7 +133,7 @@
 		line-height: 1;
 		position: relative;
 		padding: 11px 16px 11px 18px;
-		color: $sidebar-text-color;
+		color: var( --sidebar-color );
 		box-sizing: border-box;
 		white-space: nowrap;
 		overflow: hidden;
@@ -155,13 +155,13 @@
 			position: absolute;
 			right: 0;
 			z-index: z-index( 'icon-parent', '.sidebar__menu .gridicon.gridicons-external' );
-			color: darken( $gray, 20% );
+			color: var( --sidebar-menu-link-secondary-text-color );
 		}
 	}
 
 	.gridicon,
 	.jetpack-logo {
-		fill: $gray;
+		fill: var( --sidebar-gridicon-fill );
 		height: 24px;
 		width: 24px;
 		margin-right: 6px;
@@ -227,20 +227,17 @@ form.sidebar__button input {
 // Selected Menu
 @include breakpoint( ">660px" ) {
 	.sidebar__menu .selected {
-		background-color: $sidebar-selected-color;
+		background-color: var( --sidebar-menu-selected-background-color );
 
 		a {
-			color: $white;
+			color: var( --sidebar-menu-selected-a-color );
 
 			.sidebar__menu-link-secondary-text {
 				color: inherit;
 			}
 
 			&:first-child:after {
-				background: linear-gradient(
-					to right,
-					rgba( $sidebar-selected-color, 0 ),
-					rgba( $sidebar-selected-color, 1 ) 50% );
+				background: overflow-gradient( var( --sidebar-menu-selected-a-first-child-after-background ) );
 			}
 		}
 
@@ -255,7 +252,7 @@ form.sidebar__button input {
 
 		.gridicon,
 		.jetpack-logo {
-			fill: $white;
+			fill: var( --sidebar-menu-selected-a-color );
 		}
 
 		&.is-action-button-selected a {
@@ -369,7 +366,7 @@ form.sidebar__button input {
 	font-size: 11px;
 	font-weight: 600;
 	padding: 8px;
-	color: darken( $gray, 10% );
+	color: var( --sidebar-footer-button-color );
 	line-height: 2.1;
 	margin-right: auto;
 

--- a/client/me/profile-gravatar/style.scss
+++ b/client/me/profile-gravatar/style.scss
@@ -8,7 +8,7 @@
 .profile-gravatar__user-secondary-info {
 	margin-bottom: 30px;
 	text-align: center;
-	color: darken( $gray, 20% );
+	color: var( --profile-gravatar-user-secondary-info-color );
 	font-size: 14px;
 }
 

--- a/client/my-sites/current-site/style.scss
+++ b/client/my-sites/current-site/style.scss
@@ -94,7 +94,7 @@
 }
 
 .current-site__switch-sites {
-	background: $sidebar-bg-color;
+	background: var( --current-site-switch-sites-background );
 	border-bottom: 1px solid darken( $sidebar-bg-color, 5% );
 	display: block;
 	box-sizing: border-box;


### PR DESCRIPTION
### This PR 
- is part of a series of PRs aiming to provide support for Color Schemes in Calypso.
- focuses on adding Color Scheme support to the sidebar

![color-schemes-sidebar](https://user-images.githubusercontent.com/1562646/32357065-4d4400c2-c007-11e7-966e-6a24cbb8de57.gif)

### How to test
- Visit https://calypso.live/?branch=add/color-schemes/sidebar-support or test locally.
- Navigate to the `Accounts Settings` page and scroll down to the `Admin Color Scheme` section. 
- Depending on whether the browser supports CSS custom properties, the Admin Color Scheme Picker will be present or not (for browser support see http://caniuse.com/#feat=css-variables)
- Select a non-default color scheme
- The colors of the sidebar should change.
- Select the default theme again
- There should be no visual changes compared to the current default theme

### Notes

The current state of the color schemes is not intended to be the final state. The current state is supposed to serve as a basis for further research and discussion on the topic. Color schemes are hidden behind a feature flag and only visible on wpcalypso for now. __Any potential contrast issues or similar oddities are therefore "as expected" for now.__

For a more detailed description of the feature, the chosen approach and its advantages feel free to check out my post on the subject: p4TIVU-75d-p2 (internal reference).