### PR TITLE
Show only domain only to paid plan upgrade discount messages

### DIFF
--- a/client/my-sites/checkout/cart/cart-plan-discount-ad.jsx
+++ b/client/my-sites/checkout/cart/cart-plan-discount-ad.jsx
@@ -55,49 +55,34 @@ class CartPlanDiscountAd extends Component {
 			plan = find( sitePlans.data, isBusiness );
 		}
 
-		if ( plan.rawDiscount === 0 ) {
+		if ( plan.rawDiscount === 0 || ! plan.isDomainUpgrade ) {
 			return null;
-		}
-
-		if ( plan.isDomainUpgrade ) {
-			return (
-				<CartAd>
-					<p className="cart__cart-plan-discount-ad-paragraph">
-						{ translate(
-							"You're getting a %(discount)s discount off the regular price of the plan (%(originalPrice)s)" +
-								', because you already paid for the domain.',
-							{
-								args: {
-									discount: plan.formattedDiscount,
-									originalPrice: plan.formattedOriginalPrice,
-								},
-							}
-						) }
-					</p>
-					<p className="cart__cart-plan-discount-ad-paragraph">
-						{ translate(
-							'The plan and the domain can be renewed together for %(originalPrice)s / year.',
-							{
-								args: {
-									originalPrice: plan.formattedOriginalPrice,
-								},
-							}
-						) }
-					</p>
-				</CartAd>
-			);
 		}
 
 		return (
 			<CartAd>
-				<strong>
-					{ translate( "You're saving %(discount)s!", {
-						args: {
-							discount: plan.formattedDiscount,
-						},
-					} ) }
-				</strong>{' '}
-				{ plan.discountReason }
+				<p className="cart__cart-plan-discount-ad-paragraph">
+					{ translate(
+						"You're getting a %(discount)s discount off the regular price of the plan (%(originalPrice)s)" +
+							', because you already paid for the domain.',
+						{
+							args: {
+								discount: plan.formattedDiscount,
+								originalPrice: plan.formattedOriginalPrice,
+							},
+						}
+					) }
+				</p>
+				<p className="cart__cart-plan-discount-ad-paragraph">
+					{ translate(
+						'The plan and the domain can be renewed together for %(originalPrice)s / year.',
+						{
+							args: {
+								originalPrice: plan.formattedOriginalPrice,
+							},
+						}
+					) }
+				</p>
 			</CartAd>
 		);
 	}


### PR DESCRIPTION
Several users have been confused by the message on the checkout screen regarding discounts when upgrading between plans.

This diff removes any discount message apart from when upgrading from domain only to a paid plan.

# Test

For a site with a personal or premium plan (purchased without credits), add a business plan to the cart.

You *should not* see the "You're saving $x!" message in the checkout:

<img width="265" alt="screen shot 2017-11-03 at 4 02 26 pm" src="https://user-images.githubusercontent.com/1926/32361896-727f6166-c0b0-11e7-84f3-e2acabebd394.png">

For a site with a domain only, add a plan to the cart.

You *should* see the "You're saving $x!" message in the checkout:

<img width="261" alt="screen shot 2017-11-03 at 4 05 44 pm" src="https://user-images.githubusercontent.com/1926/32361967-1ba06eca-c0b1-11e7-82b5-053fb5e65e80.png">
