### PR TITLE
Deps: Update node-sass

### DIFF
--- a/client/my-sites/sharing/style.scss
+++ b/client/my-sites/sharing/style.scss
@@ -919,9 +919,9 @@
 	}
 }
 
-&.style-text .social-logo,
-&.style-text .sharing-buttons-preview-button__custom-icon,
-&.style-icon .sharing-buttons-preview-button__service {
+.style-text .social-logo,
+.style-text .sharing-buttons-preview-button__custom-icon,
+.style-icon .sharing-buttons-preview-button__service {
 	display: none;
 }
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -608,7 +608,7 @@
       "version": "1.6.0",
       "dependencies": {
         "browserslist": {
-          "version": "2.6.1"
+          "version": "2.7.0"
         },
         "semver": {
           "version": "5.4.1"
@@ -874,10 +874,10 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000756"
+      "version": "1.0.30000758"
     },
     "caniuse-lite": {
-      "version": "1.0.30000756"
+      "version": "1.0.30000758"
     },
     "cardinal": {
       "version": "1.0.0",
@@ -1274,9 +1274,6 @@
     },
     "cross-spawn": {
       "version": "5.1.0"
-    },
-    "cross-spawn-async": {
-      "version": "2.2.5"
     },
     "cryptiles": {
       "version": "3.1.2",
@@ -2217,7 +2214,7 @@
       "dev": true
     },
     "flow-parser": {
-      "version": "0.57.3",
+      "version": "0.58.0",
       "dev": true
     },
     "flux": {
@@ -4476,8 +4473,7 @@
       "version": "4.3.0"
     },
     "lodash.clonedeep": {
-      "version": "3.0.2",
-      "dev": true
+      "version": "4.5.0"
     },
     "lodash.defaults": {
       "version": "4.2.0",
@@ -4525,6 +4521,9 @@
     },
     "lodash.merge": {
       "version": "3.3.2"
+    },
+    "lodash.mergewith": {
+      "version": "4.6.0"
     },
     "lodash.pick": {
       "version": "4.4.0",
@@ -4835,7 +4834,12 @@
       }
     },
     "node-abi": {
-      "version": "2.1.1"
+      "version": "2.1.2",
+      "dependencies": {
+        "semver": {
+          "version": "5.4.1"
+        }
+      }
     },
     "node-bitmap": {
       "version": "0.0.1",
@@ -4900,13 +4904,19 @@
       }
     },
     "node-sass": {
-      "version": "3.7.0",
+      "version": "4.5.3",
       "dependencies": {
         "chalk": {
           "version": "1.1.3"
         },
+        "cross-spawn": {
+          "version": "3.0.1"
+        },
         "glob": {
           "version": "7.1.2"
+        },
+        "lodash.assign": {
+          "version": "4.2.0"
         },
         "supports-color": {
           "version": "2.0.0"
@@ -5358,7 +5368,7 @@
           "version": "2.0.0"
         },
         "postcss": {
-          "version": "6.0.13"
+          "version": "6.0.14"
         },
         "source-map": {
           "version": "0.6.1"
@@ -5405,7 +5415,7 @@
           "dev": true
         },
         "postcss": {
-          "version": "6.0.13",
+          "version": "6.0.14",
           "dev": true
         },
         "source-map": {
@@ -5533,7 +5543,7 @@
           "dev": true
         },
         "postcss": {
-          "version": "6.0.13",
+          "version": "6.0.14",
           "dev": true,
           "dependencies": {
             "ansi-styles": {
@@ -5872,6 +5882,10 @@
         },
         "jest-util": {
           "version": "17.0.2",
+          "dev": true
+        },
+        "lodash.clonedeep": {
+          "version": "3.0.2",
           "dev": true
         },
         "minimist": {
@@ -6594,6 +6608,20 @@
     "stdin": {
       "version": "0.0.1",
       "dev": true
+    },
+    "stdout-stream": {
+      "version": "1.4.0",
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.3"
+        },
+        "readable-stream": {
+          "version": "2.3.3"
+        },
+        "string_decoder": {
+          "version": "1.0.3"
+        }
+      }
     },
     "store": {
       "version": "1.3.16"

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "morgan": "1.2.0",
     "ms": "0.7.1",
     "name-all-modules-plugin": "1.0.1",
-    "node-sass": "3.7.0",
+    "node-sass": "4.5.3",
     "notifications-panel": "1.2.7",
     "npm-run-all": "4.0.2",
     "numeral": "2.0.4",


### PR DESCRIPTION
Update `node-sass` to v4. This version of `node-sass` has the correct binaries for node v8 and will be helpful for the upgrade in #19317.