### PR TITLE
Concierge Chats: add concierge state reducer.

### DIFF
--- a/client/components/data/query-concierge-shifts/index.js
+++ b/client/components/data/query-concierge-shifts/index.js
@@ -1,0 +1,24 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { Component } from 'react';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import { requestConciergeShifts } from 'state/concierge/actions';
+
+class QueryConciergeShifts extends Component {
+	componentWillMount() {
+		this.props.requestConciergeShifts( this.props.scheduleId );
+	}
+
+	render() {
+		return null;
+	}
+}
+
+export default connect( state => state, { requestConciergeShifts } )( QueryConciergeShifts );

--- a/client/me/concierge/main.js
+++ b/client/me/concierge/main.js
@@ -1,13 +1,42 @@
+/** @format */
+
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
-const ConciergeMain = () => {
-	return (
-		<div>{ 'Concierge chats page placeholder.' }</div>
-	);
-};
+/**
+ * Internal dependencies
+ */
+import { fetchConciergeShifts } from 'state/concierge/actions';
+import { getConciergeShifts, isFetchingConciergeShifts } from 'state/selectors';
 
-export default localize( ConciergeMain );
+class ConciergeMain extends Component {
+	componentDidMount() {
+		// TODO: pass in the real WP.com concierge schedule id.
+		this.props.fetchConciergeShifts( 123 );
+	}
+
+	// TODO: render for real
+	render() {
+		const { isFetching, shifts } = this.props;
+
+		if ( isFetching ) {
+			return <div>{ 'Fetching ... please wait.' }</div>;
+		}
+
+		return <div>{ JSON.stringify( shifts ) }</div>;
+	}
+}
+
+export default connect(
+	state => ( {
+		shifts: getConciergeShifts( state ),
+		isFetching: isFetchingConciergeShifts( state ),
+	} ),
+	{
+		fetchConciergeShifts,
+	}
+)( localize( ConciergeMain ) );

--- a/client/me/concierge/main.js
+++ b/client/me/concierge/main.js
@@ -10,24 +10,22 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import { requestConciergeShifts } from 'state/concierge/actions';
+import QueryConciergeShifts from 'components/data/query-concierge-shifts';
 import { getConciergeShifts } from 'state/selectors';
 
 class ConciergeMain extends Component {
-	componentDidMount() {
-		// TODO: pass in the real WP.com concierge schedule id.
-		this.props.requestConciergeShifts( 123 );
-	}
-
-	// TODO: render for real
 	render() {
 		const { shifts } = this.props;
 
-		if ( ! shifts ) {
-			return <div>{ 'Fetching ... please wait.' }</div>;
-		}
-
-		return <div>{ JSON.stringify( shifts ) }</div>;
+		// TODO:
+		// 1. pass in the real scheduleId for WP.com concierge schedule.
+		// 2. render the shifts for real.
+		return (
+			<div>
+				<QueryConciergeShifts scheduleId={ 123 } />
+				<div>{ JSON.stringify( shifts ) }</div>
+			</div>
+		);
 	}
 }
 
@@ -35,7 +33,5 @@ export default connect(
 	state => ( {
 		shifts: getConciergeShifts( state ),
 	} ),
-	{
-		requestConciergeShifts,
-	}
+	{ getConciergeShifts }
 )( localize( ConciergeMain ) );

--- a/client/me/concierge/main.js
+++ b/client/me/concierge/main.js
@@ -11,7 +11,7 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import { fetchConciergeShifts } from 'state/concierge/actions';
-import { getConciergeShifts, isFetchingConciergeShifts } from 'state/selectors';
+import { getConciergeShifts } from 'state/selectors';
 
 class ConciergeMain extends Component {
 	componentDidMount() {
@@ -21,9 +21,9 @@ class ConciergeMain extends Component {
 
 	// TODO: render for real
 	render() {
-		const { isFetching, shifts } = this.props;
+		const { shifts } = this.props;
 
-		if ( isFetching ) {
+		if ( ! shifts ) {
 			return <div>{ 'Fetching ... please wait.' }</div>;
 		}
 
@@ -34,7 +34,6 @@ class ConciergeMain extends Component {
 export default connect(
 	state => ( {
 		shifts: getConciergeShifts( state ),
-		isFetching: isFetchingConciergeShifts( state ),
 	} ),
 	{
 		fetchConciergeShifts,

--- a/client/me/concierge/main.js
+++ b/client/me/concierge/main.js
@@ -10,13 +10,13 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import { fetchConciergeShifts } from 'state/concierge/actions';
+import { requestConciergeShifts } from 'state/concierge/actions';
 import { getConciergeShifts } from 'state/selectors';
 
 class ConciergeMain extends Component {
 	componentDidMount() {
 		// TODO: pass in the real WP.com concierge schedule id.
-		this.props.fetchConciergeShifts( 123 );
+		this.props.requestConciergeShifts( 123 );
 	}
 
 	// TODO: render for real
@@ -36,6 +36,6 @@ export default connect(
 		shifts: getConciergeShifts( state ),
 	} ),
 	{
-		fetchConciergeShifts,
+		requestConciergeShifts,
 	}
 )( localize( ConciergeMain ) );

--- a/client/state/concierge/reducer.js
+++ b/client/state/concierge/reducer.js
@@ -1,0 +1,11 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+import { combineReducers } from 'state/utils';
+import shifts from './shifts';
+
+export default combineReducers( {
+	shifts,
+} );

--- a/client/state/concierge/reducer.js
+++ b/client/state/concierge/reducer.js
@@ -4,7 +4,7 @@
  * Internal dependencies
  */
 import { combineReducers } from 'state/utils';
-import shifts from './shifts';
+import shifts from './shifts/reducer';
 
 export default combineReducers( {
 	shifts,

--- a/client/state/concierge/shifts/reducer.js
+++ b/client/state/concierge/shifts/reducer.js
@@ -4,10 +4,10 @@
  * Internal dependencies
  */
 import { createReducer } from 'state/utils';
-import { CONCIERGE_SHIFTS_FETCH, CONCIERGE_SHIFTS_UPDATE } from 'state/action-types';
+import { CONCIERGE_SHIFTS_REQUEST, CONCIERGE_SHIFTS_UPDATE } from 'state/action-types';
 
 export const shifts = createReducer( null, {
-	[ CONCIERGE_SHIFTS_FETCH ]: () => null,
+	[ CONCIERGE_SHIFTS_REQUEST ]: () => null,
 	[ CONCIERGE_SHIFTS_UPDATE ]: ( state, { shifts } ) => shifts,
 } );
 

--- a/client/state/concierge/shifts/reducer.js
+++ b/client/state/concierge/shifts/reducer.js
@@ -1,27 +1,14 @@
 /** @format */
 
 /**
- * External dependencies
- */
-import { stubTrue, stubFalse } from 'lodash';
-
-/**
  * Internal dependencies
  */
-import { createReducer, combineReducers } from 'state/utils';
+import { createReducer } from 'state/utils';
 import { CONCIERGE_SHIFTS_FETCH, CONCIERGE_SHIFTS_UPDATE } from 'state/action-types';
 
-export const items = createReducer( null, {
+export const shifts = createReducer( null, {
 	[ CONCIERGE_SHIFTS_FETCH ]: () => null,
 	[ CONCIERGE_SHIFTS_UPDATE ]: ( state, { shifts } ) => shifts,
 } );
 
-export const isFetching = createReducer( false, {
-	[ CONCIERGE_SHIFTS_FETCH ]: stubTrue,
-	[ CONCIERGE_SHIFTS_UPDATE ]: stubFalse,
-} );
-
-export default combineReducers( {
-	items,
-	isFetching,
-} );
+export default shifts;

--- a/client/state/concierge/shifts/reducer.js
+++ b/client/state/concierge/shifts/reducer.js
@@ -1,0 +1,40 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { stubTrue, stubFalse } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { createReducer, combineReducers } from 'state/utils';
+import {
+	CONCIERGE_SHIFTS_FETCH,
+	CONCIERGE_SHIFTS_FETCH_FAILED,
+	CONCIERGE_SHIFTS_FETCH_SUCCESS,
+} from 'state/action-types';
+
+export const items = createReducer( null, {
+	[ CONCIERGE_SHIFTS_FETCH ]: () => null,
+	[ CONCIERGE_SHIFTS_FETCH_FAILED ]: state => state,
+	[ CONCIERGE_SHIFTS_FETCH_SUCCESS ]: ( state, { shifts } ) => shifts,
+} );
+
+export const isRequesting = createReducer( false, {
+	[ CONCIERGE_SHIFTS_FETCH ]: stubTrue,
+	[ CONCIERGE_SHIFTS_FETCH_FAILED ]: stubFalse,
+	[ CONCIERGE_SHIFTS_FETCH_SUCCESS ]: stubFalse,
+} );
+
+export const error = createReducer( null, {
+	[ CONCIERGE_SHIFTS_FETCH ]: () => null,
+	[ CONCIERGE_SHIFTS_FETCH_FAILED ]: ( state, action ) => action.error,
+	[ CONCIERGE_SHIFTS_FETCH_SUCCESS ]: () => null,
+} );
+
+export default combineReducers( {
+	items,
+	isRequesting,
+	error,
+} );

--- a/client/state/concierge/shifts/reducer.js
+++ b/client/state/concierge/shifts/reducer.js
@@ -9,32 +9,19 @@ import { stubTrue, stubFalse } from 'lodash';
  * Internal dependencies
  */
 import { createReducer, combineReducers } from 'state/utils';
-import {
-	CONCIERGE_SHIFTS_FETCH,
-	CONCIERGE_SHIFTS_FETCH_FAILED,
-	CONCIERGE_SHIFTS_FETCH_SUCCESS,
-} from 'state/action-types';
+import { CONCIERGE_SHIFTS_FETCH, CONCIERGE_SHIFTS_UPDATE } from 'state/action-types';
 
 export const items = createReducer( null, {
 	[ CONCIERGE_SHIFTS_FETCH ]: () => null,
-	[ CONCIERGE_SHIFTS_FETCH_FAILED ]: state => state,
-	[ CONCIERGE_SHIFTS_FETCH_SUCCESS ]: ( state, { shifts } ) => shifts,
+	[ CONCIERGE_SHIFTS_UPDATE ]: ( state, { shifts } ) => shifts,
 } );
 
-export const isRequesting = createReducer( false, {
+export const isFetching = createReducer( false, {
 	[ CONCIERGE_SHIFTS_FETCH ]: stubTrue,
-	[ CONCIERGE_SHIFTS_FETCH_FAILED ]: stubFalse,
-	[ CONCIERGE_SHIFTS_FETCH_SUCCESS ]: stubFalse,
-} );
-
-export const error = createReducer( null, {
-	[ CONCIERGE_SHIFTS_FETCH ]: () => null,
-	[ CONCIERGE_SHIFTS_FETCH_FAILED ]: ( state, action ) => action.error,
-	[ CONCIERGE_SHIFTS_FETCH_SUCCESS ]: () => null,
+	[ CONCIERGE_SHIFTS_UPDATE ]: stubFalse,
 } );
 
 export default combineReducers( {
 	items,
-	isRequesting,
-	error,
+	isFetching,
 } );

--- a/client/state/concierge/shifts/reducer.js
+++ b/client/state/concierge/shifts/reducer.js
@@ -8,7 +8,7 @@ import { CONCIERGE_SHIFTS_REQUEST, CONCIERGE_SHIFTS_UPDATE } from 'state/action-
 
 export const shifts = createReducer( null, {
 	[ CONCIERGE_SHIFTS_REQUEST ]: () => null,
-	[ CONCIERGE_SHIFTS_UPDATE ]: ( state, { shifts } ) => shifts,
+	[ CONCIERGE_SHIFTS_UPDATE ]: ( state, action ) => action.shifts,
 } );
 
 export default shifts;

--- a/client/state/concierge/shifts/test/reducer.js
+++ b/client/state/concierge/shifts/test/reducer.js
@@ -4,13 +4,13 @@
  * Internal dependencies
  */
 import { shifts } from '../reducer';
-import { CONCIERGE_SHIFTS_FETCH, CONCIERGE_SHIFTS_UPDATE } from 'state/action-types';
+import { CONCIERGE_SHIFTS_REQUEST, CONCIERGE_SHIFTS_UPDATE } from 'state/action-types';
 
 describe( 'concierge/shifts/reducer', () => {
 	const mockShifts = [ { description: 'shift1' }, { description: 'shift2' } ];
 
-	const fetchAction = {
-		type: CONCIERGE_SHIFTS_FETCH,
+	const requestAction = {
+		type: CONCIERGE_SHIFTS_REQUEST,
 	};
 
 	const updateAction = {
@@ -23,9 +23,9 @@ describe( 'concierge/shifts/reducer', () => {
 			expect( shifts( undefined, {} ) ).toBeNull();
 		} );
 
-		test( 'should be null on receiving the fetch action.', () => {
+		test( 'should be null on receiving the request action.', () => {
 			const state = mockShifts;
-			expect( shifts( state, fetchAction ) ).toBeNull();
+			expect( shifts( state, requestAction ) ).toBeNull();
 		} );
 
 		test( 'should be the received data on receiving the update action.', () => {

--- a/client/state/concierge/shifts/test/reducer.js
+++ b/client/state/concierge/shifts/test/reducer.js
@@ -3,12 +3,8 @@
 /**
  * Internal dependencies
  */
-import { items, isRequesting, error } from '../reducer';
-import {
-	CONCIERGE_SHIFTS_FETCH,
-	CONCIERGE_SHIFTS_FETCH_FAILED,
-	CONCIERGE_SHIFTS_FETCH_SUCCESS,
-} from 'state/action-types';
+import { items, isFetching } from '../reducer';
+import { CONCIERGE_SHIFTS_FETCH, CONCIERGE_SHIFTS_UPDATE } from 'state/action-types';
 
 describe( 'concierge/shifts/reducer', () => {
 	const mockShifts = [ { description: 'shift1' }, { description: 'shift2' } ];
@@ -17,17 +13,9 @@ describe( 'concierge/shifts/reducer', () => {
 		type: CONCIERGE_SHIFTS_FETCH,
 	};
 
-	const fetchSucceededAction = {
-		type: CONCIERGE_SHIFTS_FETCH_SUCCESS,
+	const updateAction = {
+		type: CONCIERGE_SHIFTS_UPDATE,
 		shifts: mockShifts,
-	};
-
-	const fetchFailedAction = {
-		type: CONCIERGE_SHIFTS_FETCH_FAILED,
-		error: {
-			status: 400,
-			message: 'something go wrong!',
-		},
 	};
 
 	describe( 'items', () => {
@@ -40,50 +28,23 @@ describe( 'concierge/shifts/reducer', () => {
 			expect( items( state, fetchAction ) ).toBeNull();
 		} );
 
-		test( 'should be unchanged on receiving the failed action.', () => {
-			const state = mockShifts;
-			expect( items( state, fetchFailedAction ) ).toEqual( mockShifts );
-		} );
-
-		test( 'should be the received data on receiving the succeeded action.', () => {
+		test( 'should be the received data on receiving the update action.', () => {
 			const state = [];
-			expect( items( state, fetchSucceededAction ) ).toEqual( mockShifts );
+			expect( items( state, updateAction ) ).toEqual( mockShifts );
 		} );
 	} );
 
-	describe( 'isRequesting', () => {
+	describe( 'isFetching', () => {
 		test( 'should be defaulted as false.', () => {
-			expect( isRequesting( undefined, {} ) ).toBe( false );
+			expect( isFetching( undefined, {} ) ).toBe( false );
 		} );
 
 		test( 'should be true on receiving the fetch action.', () => {
-			expect( isRequesting( undefined, fetchAction ) ).toBe( true );
+			expect( isFetching( undefined, fetchAction ) ).toBe( true );
 		} );
 
-		test( 'should be false on receiving the failed action.', () => {
-			expect( isRequesting( undefined, fetchFailedAction ) ).toBe( false );
-		} );
-
-		test( 'should be false on receiving the succeeded action.', () => {
-			expect( isRequesting( undefined, fetchSucceededAction ) ).toBe( false );
-		} );
-	} );
-
-	describe( 'error', () => {
-		test( 'should be defauled as null.', () => {
-			expect( error( undefined, {} ) ).toBeNull();
-		} );
-
-		test( 'should be null on receiving the fetch action.', () => {
-			expect( error( undefined, fetchAction ) ).toBeNull();
-		} );
-
-		test( 'should be the error on receiving the failed action.', () => {
-			expect( error( undefined, fetchFailedAction ) ).toEqual( fetchFailedAction.error );
-		} );
-
-		test( 'should be null on receiving the succeeded action.', () => {
-			expect( error( undefined, fetchSucceededAction ) ).toBeNull();
+		test( 'should be false on receiving the update action.', () => {
+			expect( isFetching( undefined, updateAction ) ).toBe( false );
 		} );
 	} );
 } );

--- a/client/state/concierge/shifts/test/reducer.js
+++ b/client/state/concierge/shifts/test/reducer.js
@@ -1,0 +1,89 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+import { items, isRequesting, error } from '../reducer';
+import {
+	CONCIERGE_SHIFTS_FETCH,
+	CONCIERGE_SHIFTS_FETCH_FAILED,
+	CONCIERGE_SHIFTS_FETCH_SUCCESS,
+} from 'state/action-types';
+
+describe( 'concierge/shifts/reducer', () => {
+	const mockShifts = [ { description: 'shift1' }, { description: 'shift2' } ];
+
+	const fetchAction = {
+		type: CONCIERGE_SHIFTS_FETCH,
+	};
+
+	const fetchSucceededAction = {
+		type: CONCIERGE_SHIFTS_FETCH_SUCCESS,
+		shifts: mockShifts,
+	};
+
+	const fetchFailedAction = {
+		type: CONCIERGE_SHIFTS_FETCH_FAILED,
+		error: {
+			status: 400,
+			message: 'something go wrong!',
+		},
+	};
+
+	describe( 'items', () => {
+		test( 'should be defaulted as null.', () => {
+			expect( items( undefined, {} ) ).toBeNull();
+		} );
+
+		test( 'should be null on receiving the fetch action.', () => {
+			const state = mockShifts;
+			expect( items( state, fetchAction ) ).toBeNull();
+		} );
+
+		test( 'should be unchanged on receiving the failed action.', () => {
+			const state = mockShifts;
+			expect( items( state, fetchFailedAction ) ).toEqual( mockShifts );
+		} );
+
+		test( 'should be the received data on receiving the succeeded action.', () => {
+			const state = [];
+			expect( items( state, fetchSucceededAction ) ).toEqual( mockShifts );
+		} );
+	} );
+
+	describe( 'isRequesting', () => {
+		test( 'should be defaulted as false.', () => {
+			expect( isRequesting( undefined, {} ) ).toBe( false );
+		} );
+
+		test( 'should be true on receiving the fetch action.', () => {
+			expect( isRequesting( undefined, fetchAction ) ).toBe( true );
+		} );
+
+		test( 'should be false on receiving the failed action.', () => {
+			expect( isRequesting( undefined, fetchFailedAction ) ).toBe( false );
+		} );
+
+		test( 'should be false on receiving the succeeded action.', () => {
+			expect( isRequesting( undefined, fetchSucceededAction ) ).toBe( false );
+		} );
+	} );
+
+	describe( 'error', () => {
+		test( 'should be defauled as null.', () => {
+			expect( error( undefined, {} ) ).toBeNull();
+		} );
+
+		test( 'should be null on receiving the fetch action.', () => {
+			expect( error( undefined, fetchAction ) ).toBeNull();
+		} );
+
+		test( 'should be the error on receiving the failed action.', () => {
+			expect( error( undefined, fetchFailedAction ) ).toEqual( fetchFailedAction.error );
+		} );
+
+		test( 'should be null on receiving the succeeded action.', () => {
+			expect( error( undefined, fetchSucceededAction ) ).toBeNull();
+		} );
+	} );
+} );

--- a/client/state/concierge/shifts/test/reducer.js
+++ b/client/state/concierge/shifts/test/reducer.js
@@ -3,7 +3,7 @@
 /**
  * Internal dependencies
  */
-import { items, isFetching } from '../reducer';
+import { shifts } from '../reducer';
 import { CONCIERGE_SHIFTS_FETCH, CONCIERGE_SHIFTS_UPDATE } from 'state/action-types';
 
 describe( 'concierge/shifts/reducer', () => {
@@ -18,33 +18,19 @@ describe( 'concierge/shifts/reducer', () => {
 		shifts: mockShifts,
 	};
 
-	describe( 'items', () => {
+	describe( 'shifts', () => {
 		test( 'should be defaulted as null.', () => {
-			expect( items( undefined, {} ) ).toBeNull();
+			expect( shifts( undefined, {} ) ).toBeNull();
 		} );
 
 		test( 'should be null on receiving the fetch action.', () => {
 			const state = mockShifts;
-			expect( items( state, fetchAction ) ).toBeNull();
+			expect( shifts( state, fetchAction ) ).toBeNull();
 		} );
 
 		test( 'should be the received data on receiving the update action.', () => {
 			const state = [];
-			expect( items( state, updateAction ) ).toEqual( mockShifts );
-		} );
-	} );
-
-	describe( 'isFetching', () => {
-		test( 'should be defaulted as false.', () => {
-			expect( isFetching( undefined, {} ) ).toBe( false );
-		} );
-
-		test( 'should be true on receiving the fetch action.', () => {
-			expect( isFetching( undefined, fetchAction ) ).toBe( true );
-		} );
-
-		test( 'should be false on receiving the update action.', () => {
-			expect( isFetching( undefined, updateAction ) ).toBe( false );
+			expect( shifts( state, updateAction ) ).toEqual( mockShifts );
 		} );
 	} );
 } );

--- a/client/state/index.js
+++ b/client/state/index.js
@@ -24,6 +24,7 @@ import automatedTransfer from './automated-transfer/reducer';
 import billingTransactions from './billing-transactions/reducer';
 import comments from './comments/reducer';
 import componentsUsageStats from './components-usage-stats/reducer';
+import concierge from './concierge/reducer';
 import consoleDispatcher from './console-dispatch';
 import countries from './countries/reducer';
 import countryStates from './country-states/reducer';
@@ -94,6 +95,7 @@ const reducers = {
 	billingTransactions,
 	comments,
 	componentsUsageStats,
+	concierge,
 	countries,
 	countryStates,
 	currentUser,

--- a/client/state/selectors/get-concierge-shifts.js
+++ b/client/state/selectors/get-concierge-shifts.js
@@ -5,4 +5,4 @@
  */
 import { get } from 'lodash';
 
-export default state => get( state, 'concierge.shifts.items', null );
+export default state => get( state, 'concierge.shifts', null );

--- a/client/state/selectors/get-concierge-shifts.js
+++ b/client/state/selectors/get-concierge-shifts.js
@@ -1,0 +1,8 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+export default state => get( state, 'concierge.shifts.items', null );

--- a/client/state/selectors/index.js
+++ b/client/state/selectors/index.js
@@ -200,7 +200,6 @@ export isEligibleForDomainToPaidPlanUpsell from './is-eligible-for-domain-to-pai
 export isEligibleForFreeToPaidUpsell from './is-eligible-for-free-to-paid-upsell';
 export isEmailBlacklisted from './is-email-blacklisted';
 export isFetchingAutomatedTransferStatus from './is-fetching-automated-transfer-status';
-export isFetchingConciergeShifts from './is-fetching-concierge-shifts';
 export isFetchingJetpackModules from './is-fetching-jetpack-modules';
 export isFetchingMagicLoginAuth from './is-fetching-magic-login-auth';
 export isFetchingMagicLoginEmail from './is-fetching-magic-login-email';

--- a/client/state/selectors/index.js
+++ b/client/state/selectors/index.js
@@ -36,6 +36,7 @@ export getActivityLogs from './get-activity-logs';
 export getBillingTransactions from './get-billing-transactions';
 export getBlockedSites from './get-blocked-sites';
 export getBlogStickers from './get-blog-stickers';
+export getConciergeShifts from './get-concierge-shifts';
 export getContactDetailsCache from './get-contact-details-cache';
 export getContactDetailsExtraCache from './get-contact-details-extra-cache';
 export getCredentialsAutoConfigStatus from './get-credentials-auto-config-status';
@@ -199,6 +200,7 @@ export isEligibleForDomainToPaidPlanUpsell from './is-eligible-for-domain-to-pai
 export isEligibleForFreeToPaidUpsell from './is-eligible-for-free-to-paid-upsell';
 export isEmailBlacklisted from './is-email-blacklisted';
 export isFetchingAutomatedTransferStatus from './is-fetching-automated-transfer-status';
+export isFetchingConciergeShifts from './is-fetching-concierge-shifts';
 export isFetchingJetpackModules from './is-fetching-jetpack-modules';
 export isFetchingMagicLoginAuth from './is-fetching-magic-login-auth';
 export isFetchingMagicLoginEmail from './is-fetching-magic-login-email';

--- a/client/state/selectors/is-fetching-concierge-shifts.js
+++ b/client/state/selectors/is-fetching-concierge-shifts.js
@@ -1,8 +1,0 @@
-/** @format */
-
-/**
- * External dependencies
- */
-import { get } from 'lodash';
-
-export default state => get( state, 'concierge.shifts.isFetching', false );

--- a/client/state/selectors/is-fetching-concierge-shifts.js
+++ b/client/state/selectors/is-fetching-concierge-shifts.js
@@ -1,0 +1,8 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+export default state => get( state, 'concierge.shifts.isFetching', false );

--- a/client/state/selectors/test/get-concierge-shifts.js
+++ b/client/state/selectors/test/get-concierge-shifts.js
@@ -1,0 +1,29 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+import { getConciergeShifts } from '../';
+
+describe( 'getConciergeShifts()', () => {
+	test( 'should be defaulted to null.', () => {
+		expect( getConciergeShifts( {} ) ).toBeNull();
+	} );
+
+	test( 'should return the items field under the concierge shift state tree.', () => {
+		const items = [
+			{ description: 'shift 1' },
+			{ description: 'shift 2' },
+			{ description: 'shift 3' },
+		];
+		const state = {
+			concierge: {
+				shifts: {
+					items,
+				},
+			},
+		};
+
+		expect( getConciergeShifts( state ) ).toEqual( items );
+	} );
+} );

--- a/client/state/selectors/test/get-concierge-shifts.js
+++ b/client/state/selectors/test/get-concierge-shifts.js
@@ -11,19 +11,17 @@ describe( 'getConciergeShifts()', () => {
 	} );
 
 	test( 'should return the items field under the concierge shift state tree.', () => {
-		const items = [
+		const shifts = [
 			{ description: 'shift 1' },
 			{ description: 'shift 2' },
 			{ description: 'shift 3' },
 		];
 		const state = {
 			concierge: {
-				shifts: {
-					items,
-				},
+				shifts,
 			},
 		};
 
-		expect( getConciergeShifts( state ) ).toEqual( items );
+		expect( getConciergeShifts( state ) ).toEqual( shifts );
 	} );
 } );


### PR DESCRIPTION
## Summary
This PR adds the reducer for creating the concierge chats related state tree, and connect the state to the view. `/me/concierge` now shows a placeholder page that looks like this:

![image](https://user-images.githubusercontent.com/1842898/32430536-4df47f20-c295-11e7-9e27-4c7b361463a3.png)

## Test Plan
1. `npm run test-client client/state/concierge` should pass.
1. Visit http://calypso.localhost:3000/me/concierge and you should see the placeholder page.
