### PR TITLE
JPC: infinite loop when connecting an editor

### DIFF
--- a/client/jetpack-connect/plans.jsx
+++ b/client/jetpack-connect/plans.jsx
@@ -81,9 +81,11 @@ class Plans extends Component {
 		}
 
 		if ( this.props.hasPlan && ! this.redirecting ) {
+			this.redirecting = true;
 			this.redirect( CALYPSO_PLANS_PAGE );
 		}
 		if ( ! this.props.canPurchasePlans && ! this.redirecting ) {
+			this.redirecting = true;
 			if ( this.props.isCalypsoStartedConnection ) {
 				this.redirect( CALYPSO_REDIRECTION_PAGE );
 			} else {


### PR DESCRIPTION
We have a regression in production right now: Everytime you try to connect a user that doesn't have the capability to buy plans, just after connecting their account a javascript exception is thrown. The account is linked correctly, but the user never gets past the "finishing up" page. It happens because we end triggering a metric ton of redux events and the memory stack overflows. This PR fixes it.

How to test:
============
0. You need a connected jetpack site, with a editor user that is not linked to wp.com
1. Being logged as that user, go to https://calypso.live/jetpack/connect/?branch=fix/jetpack-connect-editors and connect your site
2. You shouldn't see the plans page and you should end back in your wp-admin with a connected account