### PR TITLE
Atomic Store: enable on staging for testing

### DIFF
--- a/config/stage.json
+++ b/config/stage.json
@@ -115,6 +115,7 @@
 		"signup/domain-first-flow": true,
 		"signup/social": true,
 		"signup/social-management": true,
+		"signup/atomic-store-flow": true,
 		"signup/wpcc": true,
 		"simple-payments": true,
 		"standalone-site-preview": true,


### PR DESCRIPTION
Before enabling Atomic Store on production, we should test it thoroughly on staging.