### PR TITLE
Atomic Store: enable on prod

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -108,6 +108,7 @@
 		"signup/domain-first-flow": true,
 		"signup/social": true,
 		"signup/social-management": true,
+		"signup/atomic-store-flow": true,
 		"signup/wpcc": true,
 		"simple-payments": true,
 		"standalone-site-preview": true,


### PR DESCRIPTION
This PR enables the Atomic Store signup flow on prod.

In case something goes bad, revert.