### PR TITLE
Atomic Store: 'design-type-with-store-nux' step should provide the 'themeSlugWithRepo' dependency

### DIFF
--- a/client/signup/steps/design-type-with-atomic-store/index.jsx
+++ b/client/signup/steps/design-type-with-atomic-store/index.jsx
@@ -32,6 +32,7 @@ import PressableStoreStep from '../design-type-with-store/pressable-store';
 import QueryGeo from 'components/data/query-geo';
 import { getGeoCountryShort } from 'state/geo/selectors';
 import { getCurrentUserCountryCode } from 'state/current-user/selectors';
+import { getThemeForDesignType } from 'signup/utils';
 
 class DesignTypeWithAtomicStoreStep extends Component {
 	state = {
@@ -105,6 +106,8 @@ class DesignTypeWithAtomicStoreStep extends Component {
 
 		this.setState( { pendingStoreClick: false } );
 
+		const themeSlugWithRepo = getThemeForDesignType( designType );
+
 		this.props.setDesignType( designType );
 
 		this.props.recordTracksEvent( 'calypso_triforce_select_design', { category: designType } );
@@ -129,6 +132,7 @@ class DesignTypeWithAtomicStoreStep extends Component {
 
 		SignupActions.submitSignupStep( { stepName: this.props.stepName }, [], {
 			designType,
+			themeSlugWithRepo,
 		} );
 
 		// If the user chooses `store` as design type, redirect to the `store-nux` flow.

--- a/client/signup/steps/design-type-with-atomic-store/index.jsx
+++ b/client/signup/steps/design-type-with-atomic-store/index.jsx
@@ -24,9 +24,6 @@ import {
 import { abtest } from 'lib/abtest';
 import SignupActions from 'lib/signup/actions';
 import { setDesignType } from 'state/signup/steps/design-type/actions';
-import SignupDependencyStore from 'lib/signup/dependency-store';
-import SignupProgressStore from 'lib/signup/progress-store';
-import { getSignupDependencyStore } from 'state/signup/dependency-store/selectors';
 import { DESIGN_TYPE_STORE } from 'signup/constants';
 import PressableStoreStep from '../design-type-with-store/pressable-store';
 import QueryGeo from 'components/data/query-geo';
@@ -218,16 +215,6 @@ class DesignTypeWithAtomicStoreStep extends Component {
 		return translate( 'What kind of site do you need? Choose an option below:' );
 	}
 
-	componentWillMount() {
-		if ( this.props.signupDependencyStore.themeSlugWithRepo ) {
-			SignupDependencyStore.reset();
-		}
-
-		if ( this.props.signupProgress ) {
-			SignupProgressStore.reset();
-		}
-	}
-
 	componentDidUpdate( prevProps ) {
 		// If geoip data arrived, check if there is a pending click on a "store" choice and
 		// process it -- all data are available now to proceed.
@@ -259,7 +246,6 @@ class DesignTypeWithAtomicStoreStep extends Component {
 
 export default connect(
 	state => ( {
-		signupDependencyStore: getSignupDependencyStore( state ),
 		countryCode: getCurrentUserCountryCode( state ) || getGeoCountryShort( state ),
 	} ),
 	{

--- a/client/signup/utils.js
+++ b/client/signup/utils.js
@@ -138,6 +138,8 @@ function getThemeForDesignType( designType ) {
 			return 'pub/altofocus';
 		case 'page':
 			return 'pub/dara';
+		case 'store':
+			return 'pub/dara';
 		default:
 			return 'pub/twentyseventeen';
 	}

--- a/config/development.json
+++ b/config/development.json
@@ -161,7 +161,7 @@
 		"signup/domain-first-flow": true,
 		"signup/social": true,
 		"signup/social-management": true,
-		"signup/atomic-store-flow": false,
+		"signup/atomic-store-flow": true,
 		"signup/wpcc": true,
 		"simple-payments": true,
 		"standalone-site-preview": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -102,7 +102,7 @@
 		"signup/domain-first-flow": true,
 		"signup/social": true,
 		"signup/social-management": true,
-		"signup/atomic-store-flow": false,
+		"signup/atomic-store-flow": true,
 		"signup/wpcc": true,
 		"simple-payments": true,
 		"standalone-site-preview": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -123,7 +123,7 @@
 		"signup/domain-first-flow": true,
 		"signup/social": true,
 		"signup/social-management": true,
-		"signup/atomic-store-flow": false,
+		"signup/atomic-store-flow": true,
 		"signup/wpcc": true,
 		"simple-payments": true,
 		"standalone-site-preview": true,


### PR DESCRIPTION
The `design-type-with-store-nux` step should provide a default theme slug. Other `design-type` steps already do it since #18908, but the `store-nux` step was missing it.

The result is a buggy behavior in flows that don't contain the `themes` step. There is not step to provide the theme slug dependency and the `domains` step will wait for it forever -- the flow gets stuck.

The default theme for Store is `dara` -- I chose the same one as for the Website design type.

The second commit enables `signup/atomic-store-flow` again -- reverts #19454.

**How to test:**
1. In `development`, `wpcalypso` or `horizon`, go to `/start/main` flow.
2. Check that the first step is `design-type-with-store-nux`.
3. Go through the flow and check that it doesn't get stuck at the end -- instead of showing "Give us one minute and we’ll move right along." forever, it shows the cart with the selected items.
