### PR TITLE
Store: Email remove MailChimp related config logic.

### DIFF
--- a/client/extensions/woocommerce/app/settings/navigation.js
+++ b/client/extensions/woocommerce/app/settings/navigation.js
@@ -3,7 +3,6 @@
 /**
  * External dependencies
  */
-import config from 'config';
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
@@ -36,15 +35,12 @@ export const SettingsNavigation = ( { site, activeSection, translate } ) => {
 			path: '/store/settings/taxes/:site',
 			title: translate( 'Taxes' ),
 		},
-	];
-
-	if ( config.isEnabled( 'woocommerce/extension-settings-email' ) ) {
-		items.push( {
+		{
 			id: 'email',
 			path: '/store/settings/email/:site',
 			title: translate( 'Email' ),
-		} );
-	}
+		},
+	];
 
 	const section = find( items, { id: activeSection } );
 	return (

--- a/client/extensions/woocommerce/index.js
+++ b/client/extensions/woocommerce/index.js
@@ -156,16 +156,13 @@ const getStorePages = () => {
 			documentTitle: translate( 'Tax Settings' ),
 			path: '/store/settings/taxes/:site',
 		},
-	];
-
-	if ( config.isEnabled( 'woocommerce/extension-settings-email' ) ) {
-		pages.push( {
+		{
 			container: SettingsEmail,
 			configKey: 'woocommerce/extension-settings-email',
 			documentTitle: translate( 'Email' ),
 			path: '/store/settings/email/:site/:setup?',
-		} );
-	}
+		},
+	];
 
 	return pages;
 };


### PR DESCRIPTION
### Information

Remove MailChimp related config checks. MailChimp is enabled on all configs so this checks make no sense anymore. I am not retiring the flag because it will be used for more store email development work.