### PR TITLE
Store: add email settings component.

### DIFF
--- a/client/extensions/woocommerce/app/settings/email/email-settings/index.js
+++ b/client/extensions/woocommerce/app/settings/email/email-settings/index.js
@@ -1,0 +1,30 @@
+/**
+ * External dependencies
+ */
+import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+
+class Settings extends React.Component {
+
+	constructor( props ) {
+		super( props );
+	}
+
+	render() {
+		return (
+			<div className="email-settings">
+			</div>
+		);
+	}
+}
+
+Settings.propTypes = {
+	siteId: PropTypes.number.isRequired,
+};
+
+export default localize( Settings );

--- a/client/extensions/woocommerce/app/settings/email/email-settings/index.js
+++ b/client/extensions/woocommerce/app/settings/email/email-settings/index.js
@@ -14,13 +14,14 @@ class Settings extends React.Component {
 	constructor( props ) {
 		super( props );
 	}
-
+	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	render() {
 		return (
-			<div className="email-settings">
+			<div className="email-settings__container">
 			</div>
 		);
 	}
+	/* eslint-enable wpcalypso/jsx-classname-namespace */
 }
 
 Settings.propTypes = {

--- a/client/extensions/woocommerce/app/settings/email/index.js
+++ b/client/extensions/woocommerce/app/settings/email/index.js
@@ -44,7 +44,7 @@ const SettingsEmail = ( { site, translate, className, params, isSaving, mailChim
 				</Button>
 			</ActionHeader>
 			<SettingsNavigation activeSection="email" />
-			{ config.isEnabled( 'woocommerce/extension-settings-email' ) &&
+			{ config.isEnabled( 'woocommerce/extension-settings-email-generic' ) &&
 				<EmailSettings siteId={ site.ID } />
 			}
 			<MailChimp siteId={ site.ID } site={ site } startWizard={ startWizard } />

--- a/client/extensions/woocommerce/app/settings/email/index.js
+++ b/client/extensions/woocommerce/app/settings/email/index.js
@@ -1,25 +1,27 @@
 /**
  * External dependencies
  */
-import React from 'react';
-import PropTypes from 'prop-types';
-import classNames from 'classnames';
-import { localize } from 'i18n-calypso';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+import classNames from 'classnames';
+import config from 'config';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 /**
  * Internal dependencies
  */
-import Main from 'components/main';
-import Button from 'components/button';
-import MailChimp from './mailchimp';
-import ActionHeader from 'woocommerce/components/action-header';
-import SettingsNavigation from '../navigation';
 import { getLink } from 'woocommerce/lib/nav-utils';
 import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
 import { mailChimpSaveSettings } from 'woocommerce/state/sites/settings/mailchimp/actions';
 import { isSavingSettings } from 'woocommerce/state/sites/settings/mailchimp/selectors';
+import ActionHeader from 'woocommerce/components/action-header';
+import Button from 'components/button';
+import EmailSettings from './email-settings';
+import MailChimp from './mailchimp';
+import Main from 'components/main';
+import SettingsNavigation from '../navigation';
 
 const SettingsEmail = ( { site, translate, className, params, isSaving, mailChimpSaveSettings: saveSettings } ) => {
 	const breadcrumbs = [
@@ -42,6 +44,9 @@ const SettingsEmail = ( { site, translate, className, params, isSaving, mailChim
 				</Button>
 			</ActionHeader>
 			<SettingsNavigation activeSection="email" />
+			{ config.isEnabled( 'woocommerce/extension-settings-email' ) &&
+				<EmailSettings siteId={ site.ID } />
+			}
 			<MailChimp siteId={ site.ID } site={ site } startWizard={ startWizard } />
 		</Main>
 	);

--- a/config/development.json
+++ b/config/development.json
@@ -193,6 +193,7 @@
 		"woocommerce/extension-reviews": true,
 		"woocommerce/extension-settings": true,
 		"woocommerce/extension-settings-email": true,
+		"woocommerce/extension-settings-email-generic": true,
 		"woocommerce/extension-settings-payments": true,
 		"woocommerce/extension-settings-shipping": true,
 		"woocommerce/extension-settings-stripe-connect-flows": true,

--- a/config/production.json
+++ b/config/production.json
@@ -133,6 +133,7 @@
 		"woocommerce/extension-reviews": true,
 		"woocommerce/extension-settings": true,
 		"woocommerce/extension-settings-email": true,
+		"woocommerce/extension-settings-email-generic": false,		
 		"woocommerce/extension-settings-payments": true,
 		"woocommerce/extension-settings-shipping": true,
 		"woocommerce/extension-settings-stripe-connect-flows": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -140,6 +140,7 @@
 		"woocommerce/extension-reviews": true,
 		"woocommerce/extension-settings": true,
 		"woocommerce/extension-settings-email": true,
+		"woocommerce/extension-settings-email-generic": false,				
 		"woocommerce/extension-settings-payments": true,
 		"woocommerce/extension-settings-shipping": true,
 		"woocommerce/extension-settings-stripe-connect-flows": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -152,6 +152,7 @@
 		"woocommerce/extension-reviews": true,
 		"woocommerce/extension-settings": true,
 		"woocommerce/extension-settings-email": true,
+		"woocommerce/extension-settings-email-generic": false,
 		"woocommerce/extension-settings-payments": true,
 		"woocommerce/extension-settings-shipping": true,
 		"woocommerce/extension-settings-stripe-connect-flows": true,


### PR DESCRIPTION
### Information

This adds an empty component that will hosts email settings panel. https://github.com/Automattic/wp-calypso/issues/15040
After https://github.com/Automattic/wp-calypso/pull/19470 this will be visible only in development mode.
Add this for continuous integration purposes.
