### PR TITLE
Comments: expand all comments by default

### DIFF
--- a/client/my-sites/comments/comment/comment-header.jsx
+++ b/client/my-sites/comments/comment/comment-header.jsx
@@ -4,13 +4,11 @@
  */
 import React, { PureComponent } from 'react';
 import { connect } from 'react-redux';
-import Gridicon from 'gridicons';
 import { get } from 'lodash';
 
 /**
  * Internal dependencies
  */
-import Button from 'components/button';
 import CommentAuthor from 'my-sites/comments/comment/comment-author';
 import CommentAuthorMoreInfo from 'my-sites/comments/comment/comment-author-more-info';
 import FormCheckbox from 'components/forms/form-checkbox';
@@ -19,15 +17,7 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 
 export class CommentHeader extends PureComponent {
 	render() {
-		const {
-			commentId,
-			isBulkMode,
-			isEditMode,
-			isExpanded,
-			isSelected,
-			showAuthorMoreInfo,
-			toggleExpanded,
-		} = this.props;
+		const { commentId, isBulkMode, isExpanded, isSelected, showAuthorMoreInfo } = this.props;
 
 		return (
 			<div className="comment__header">
@@ -40,17 +30,6 @@ export class CommentHeader extends PureComponent {
 				<CommentAuthor { ...{ commentId, isExpanded } } />
 
 				{ showAuthorMoreInfo && <CommentAuthorMoreInfo { ...{ commentId } } /> }
-
-				{ ! isBulkMode && (
-					<Button
-						borderless
-						className="comment__toggle-expanded"
-						disabled={ isEditMode }
-						onClick={ toggleExpanded }
-					>
-						<Gridicon icon="chevron-down" />
-					</Button>
-				) }
 			</div>
 		);
 	}

--- a/client/my-sites/comments/comment/index.jsx
+++ b/client/my-sites/comments/comment/index.jsx
@@ -15,7 +15,6 @@ import { get, isUndefined } from 'lodash';
 import Card from 'components/card';
 import CommentContent from 'my-sites/comments/comment/comment-content';
 import CommentHeader from 'my-sites/comments/comment/comment-header';
-import CommentReply from 'my-sites/comments/comment/comment-reply';
 import QueryComment from 'components/data/query-comment';
 import { getMinimumComment } from 'my-sites/comments/comment/utils';
 import { getSiteComment } from 'state/selectors';
@@ -38,12 +37,16 @@ export class Comment extends Component {
 	state = {
 		hasReplyFocus: false,
 		isEditMode: false,
-		isExpanded: false,
+		isExpanded: true,
 	};
 
 	componentWillReceiveProps( nextProps ) {
 		if ( nextProps.isBulkMode && ! this.props.isBulkMode ) {
 			this.setState( { isExpanded: false } );
+		}
+
+		if ( ! nextProps.isBulkMode && this.props.isBulkMode ) {
+			this.setState( { isExpanded: true } );
 		}
 	}
 
@@ -92,7 +95,7 @@ export class Comment extends Component {
 			refreshCommentData,
 			siteId,
 		} = this.props;
-		const { hasReplyFocus, isEditMode, isExpanded } = this.state;
+		const { isEditMode, isExpanded } = this.state;
 
 		const classes = classNames( 'comment', {
 			'is-bulk-mode': isBulkMode,
@@ -122,14 +125,6 @@ export class Comment extends Component {
 						/>
 
 						<CommentContent { ...{ commentId, isExpanded } } />
-
-						{ isExpanded && (
-							<CommentReply
-								{ ...{ commentId, hasReplyFocus } }
-								blurReply={ this.blurReply }
-								focusReply={ this.focusReply }
-							/>
-						) }
 					</div>
 				) }
 			</Card>


### PR DESCRIPTION
Experimental branch to test the alternative approach with all comments expanded.

For now I didn't wire any logic that would preserve the collapsed view on mobile devices. We can do that to if necessary, but at present time you can check out that view by running the default version of comments.

The purpose of this PR is just to test the desktop variant will all comments expanded. The only scenario in which we switch to collapsed view is when bulk editing mode is enabled. In addition to that I also removed:

- chevron down buttons - since they don't make sense in this context,
- reply fields - since I found the repetition visually problematic (we can consider opening it with focus on `Reply` button click maybe)

Just a reminder that all of the M3 design elements and controls are not yet included, so this is not a completely accurate representation of how things would look.

### Testing instructions

1. Start Calypso with: `ENABLE_FEATURES=comments/management/m3-design npm start`
2. Navigate to `comments/all`.


