### PR TITLE
Store Products: handle failed requests from the remote site

### DIFF
--- a/client/extensions/woocommerce/state/data-layer/products/index.js
+++ b/client/extensions/woocommerce/state/data-layer/products/index.js
@@ -116,7 +116,7 @@ export function productsRequest( { dispatch }, action ) {
 	dispatch( request( siteId, action ).getWithHeaders( `products?${ queryString }` ) );
 }
 
-function receivedProducts( { dispatch }, action, { data } ) {
+export function receivedProducts( { dispatch }, action, { data } ) {
 	const { siteId, params } = action;
 	const { body, headers } = data;
 	const totalPages = Number( headers[ 'X-WP-TotalPages' ] );

--- a/client/extensions/woocommerce/state/data-layer/products/test/index.js
+++ b/client/extensions/woocommerce/state/data-layer/products/test/index.js
@@ -343,6 +343,7 @@ describe( 'handlers', () => {
 
 			const products = [ { id: 1, name: 'Mittens' }, { id: 2, name: 'Scarf' } ];
 			const data = {
+				status: 200,
 				body: products,
 				headers: {
 					'X-WP-TotalPages': 1,
@@ -375,6 +376,7 @@ describe( 'handlers', () => {
 			};
 			const action = productsUpdated( 123, {}, response, 1, 2 );
 			const data = {
+				status: 404,
 				body: response,
 				headers: [],
 			};

--- a/client/extensions/woocommerce/state/data-layer/products/test/index.js
+++ b/client/extensions/woocommerce/state/data-layer/products/test/index.js
@@ -14,15 +14,21 @@ import {
 	updateProduct,
 	fetchProduct,
 	fetchProducts,
+	productsUpdated,
 } from 'woocommerce/state/sites/products/actions';
 import {
 	handleProductCreate,
 	handleProductUpdate,
 	handleProductRequest,
 	productsRequest,
+	receivedProducts,
 } from '../';
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { WOOCOMMERCE_API_REQUEST } from 'woocommerce/state/action-types';
+import {
+	WOOCOMMERCE_API_REQUEST,
+	WOOCOMMERCE_PRODUCTS_REQUEST_FAILURE,
+	WOOCOMMERCE_PRODUCTS_REQUEST_SUCCESS,
+} from 'woocommerce/state/action-types';
 
 describe( 'handlers', () => {
 	describe( '#handleProductCreate', () => {
@@ -327,6 +333,58 @@ describe( 'handlers', () => {
 					},
 					action
 				)
+			);
+		} );
+	} );
+
+	describe( '#receivedProducts', () => {
+		test( 'should dispatch a success action on a good response', () => {
+			const dispatch = spy();
+
+			const products = [ { id: 1, name: 'Mittens' }, { id: 2, name: 'Scarf' } ];
+			const data = {
+				body: products,
+				headers: {
+					'X-WP-TotalPages': 1,
+					'X-WP-Total': 2,
+				},
+			};
+			const action = productsUpdated( 123, {}, products, 1, 2 );
+
+			receivedProducts( { dispatch }, action, { data } );
+
+			expect( dispatch ).to.have.been.calledWithMatch(
+				match( {
+					type: WOOCOMMERCE_PRODUCTS_REQUEST_SUCCESS,
+					siteId: 123,
+					products,
+					params: {},
+					totalPages: 1,
+					totalProducts: 2,
+				} )
+			);
+		} );
+
+		test( 'should dispatch a failure action on a bad response', () => {
+			const dispatch = spy();
+
+			const response = {
+				code: 'rest_no_route',
+				data: { status: 404 },
+				message: 'No route was found matching the URL and request method',
+			};
+			const action = productsUpdated( 123, {}, response, 1, 2 );
+			const data = {
+				body: response,
+				headers: [],
+			};
+
+			receivedProducts( { dispatch }, action, { data } );
+			expect( dispatch ).to.have.been.calledWithMatch(
+				match( {
+					type: WOOCOMMERCE_PRODUCTS_REQUEST_FAILURE,
+					siteId: 123,
+				} )
 			);
 		} );
 	} );

--- a/client/extensions/woocommerce/state/sites/products/actions.js
+++ b/client/extensions/woocommerce/state/sites/products/actions.js
@@ -3,6 +3,7 @@
  *
  * @format
  */
+import { isObject } from 'lodash';
 /**
  * Internal dependencies
  */
@@ -13,6 +14,7 @@ import { setError } from '../status/wc-api/actions';
 import {
 	WOOCOMMERCE_PRODUCTS_REQUEST,
 	WOOCOMMERCE_PRODUCTS_REQUEST_SUCCESS,
+	WOOCOMMERCE_PRODUCTS_REQUEST_FAILURE,
 	WOOCOMMERCE_PRODUCT_CREATE,
 	WOOCOMMERCE_PRODUCT_DELETE,
 	WOOCOMMERCE_PRODUCT_DELETE_SUCCESS,
@@ -157,6 +159,16 @@ export function fetchProducts( siteId, params, successAction, failureAction ) {
 }
 
 export function productsUpdated( siteId, params, products, totalPages, totalProducts ) {
+	// This passed through the API layer successfully, but failed at the remote site.
+	if ( isObject( products ) && products.code ) {
+		return {
+			type: WOOCOMMERCE_PRODUCTS_REQUEST_FAILURE,
+			siteId,
+			params,
+			error: products,
+		};
+	}
+
 	const normalizedQuery = getNormalizedProductsQuery( params );
 	return {
 		type: WOOCOMMERCE_PRODUCTS_REQUEST_SUCCESS,

--- a/client/extensions/woocommerce/state/sites/products/actions.js
+++ b/client/extensions/woocommerce/state/sites/products/actions.js
@@ -3,7 +3,7 @@
  *
  * @format
  */
-import { isObject } from 'lodash';
+import { isArray } from 'lodash';
 /**
  * Internal dependencies
  */
@@ -160,7 +160,7 @@ export function fetchProducts( siteId, params, successAction, failureAction ) {
 
 export function productsUpdated( siteId, params, products, totalPages, totalProducts ) {
 	// This passed through the API layer successfully, but failed at the remote site.
-	if ( isObject( products ) && products.code ) {
+	if ( ! isArray( products ) ) {
 		return {
 			type: WOOCOMMERCE_PRODUCTS_REQUEST_FAILURE,
 			siteId,


### PR DESCRIPTION
If the remote site for a store ends up misconfigured (we can't communicate to the API for some reason), there's an error when trying to fetch products. See:

<img width="1074" alt="store-errors" src="https://user-images.githubusercontent.com/541093/32383357-2c488c30-c08e-11e7-8ed0-86a9a736be4b.png">

This PR fixes the issue by checking that the products returned is not an API error object.

**To test**

- Break your store - I disabled wc-api-dev on a Pressable (not atomic) site
- Load up the dashboard
- View in the console that there are no errors (unless you have debug on, in which case you'll see a message about the API not working)
- The dashboard should "finish" loading, it'll be blank. A future PR could put a better error message here.