### PR TITLE
Store: Move placeholder below setup components in dashboard

### DIFF
--- a/client/extensions/woocommerce/app/dashboard/index.js
+++ b/client/extensions/woocommerce/app/dashboard/index.js
@@ -135,10 +135,6 @@ class Dashboard extends Component {
 			setStoreAddressDuringInitialSetup,
 		} = this.props;
 
-		if ( loading || ! selectedSite ) {
-			return <Placeholder />;
-		}
-
 		if ( ! finishedInstallOfRequiredPlugins ) {
 			return <RequiredPluginsInstallView site={ selectedSite } />;
 		}
@@ -153,6 +149,10 @@ class Dashboard extends Component {
 
 		if ( ! finishedInitialSetup ) {
 			return <SetupTasksView onFinished={ this.onStoreSetupFinished } site={ selectedSite } />;
+		}
+
+		if ( loading || ! selectedSite ) {
+			return <Placeholder />;
 		}
 
 		let manageView = <ManageOrdersView site={ selectedSite } />;


### PR DESCRIPTION
Reverting some of the logic introduced in #19203 - as the addition of the new Dashboard Placeholder is causing issues with the display of NUX components in the view. In lieu of trying to do a quick fix, this PR removes the Placeholder logic so we can properly launch the new NUX flow for Store.

__To Test__
- Ideally test this against a new store flow to ensure the NUX steps are displayed properly
- Also test the dashboard on an existing store site.