### PR TITLE
Store: Remove Dashboard Placeholder

### DIFF
--- a/client/extensions/woocommerce/app/dashboard/index.js
+++ b/client/extensions/woocommerce/app/dashboard/index.js
@@ -39,7 +39,6 @@ import {
 import Main from 'components/main';
 import ManageNoOrdersView from './manage-no-orders-view';
 import ManageOrdersView from './manage-orders-view';
-import Placeholder from './placeholder';
 import PreSetupView from './pre-setup-view';
 import RequiredPagesSetupView from './required-pages-setup-view';
 import RequiredPluginsInstallView from './required-plugins-install-view';
@@ -130,14 +129,9 @@ class Dashboard extends Component {
 			finishedInitialSetup,
 			hasOrders,
 			hasProducts,
-			loading,
 			selectedSite,
 			setStoreAddressDuringInitialSetup,
 		} = this.props;
-
-		if ( loading || ! selectedSite ) {
-			return <Placeholder />;
-		}
 
 		if ( ! finishedInstallOfRequiredPlugins ) {
 			return <RequiredPluginsInstallView site={ selectedSite } />;
@@ -173,6 +167,11 @@ class Dashboard extends Component {
 
 	render = () => {
 		const { className, loading, selectedSite } = this.props;
+
+		if ( loading || ! selectedSite ) {
+			// TODO reintroduce placeholder after new nux flow is finalized.
+			return null;
+		}
 
 		return (
 			<Main className={ classNames( 'dashboard', className ) }>


### PR DESCRIPTION
Reverting some of the logic introduced in #19203 - as the addition of the new Dashboard Placeholder is causing issues with the display of NUX components in the view. In lieu of trying to do a quick fix, this PR removes the Placeholder logic so we can properly launch the new NUX flow for Store.

__To Test__
- Ideally test this against a new store flow to ensure the NUX steps are displayed properly
- Also test the dashboard on an existing store site.