### PR TITLE
Reader: check is_following_conversation when receiving posts

### DIFF
--- a/client/lib/feed-post-store/index.js
+++ b/client/lib/feed-post-store/index.js
@@ -24,6 +24,7 @@ import {
 	CONVERSATION_FOLLOW_STATUS_FOLLOWING,
 	CONVERSATION_FOLLOW_STATUS_NOT_FOLLOWING,
 } from 'state/reader/conversations/follow-status';
+import { reduxDispatch } from 'lib/redux-bridge';
 
 /**
  * Module variables
@@ -158,16 +159,15 @@ function _setBlogPost( post ) {
 		const newFollowStatus = post.is_following_conversation
 			? CONVERSATION_FOLLOW_STATUS_FOLLOWING
 			: CONVERSATION_FOLLOW_STATUS_NOT_FOLLOWING;
-		// @todo is it a terrible idea to connect() FeedPostStore? It feels like it.
-		// dispatch(
-		// 	bypassDataLayer(
-		// 		updateConversationFollowStatus( {
-		// 			siteId: post.site_ID,
-		// 			postId: post.ID,
-		// 			followStatus: newFollowStatus,
-		// 		} )
-		// 	)
-		// );
+		reduxDispatch(
+			bypassDataLayer(
+				updateConversationFollowStatus( {
+					siteId: post.site_ID,
+					postId: post.ID,
+					followStatus: newFollowStatus,
+				} )
+			)
+		);
 	}
 
 	return true;

--- a/client/lib/feed-post-store/index.js
+++ b/client/lib/feed-post-store/index.js
@@ -156,7 +156,7 @@ function _setBlogPost( post ) {
 
 	// Send conversation follow status over to Redux
 	if ( post.hasOwnProperty( 'is_following_conversation' ) ) {
-		const newFollowStatus = post.is_following_conversation
+		const followStatus = post.is_following_conversation
 			? CONVERSATION_FOLLOW_STATUS_FOLLOWING
 			: CONVERSATION_FOLLOW_STATUS_NOT_FOLLOWING;
 		reduxDispatch(
@@ -164,7 +164,7 @@ function _setBlogPost( post ) {
 				updateConversationFollowStatus( {
 					siteId: post.site_ID,
 					postId: post.ID,
-					followStatus: newFollowStatus,
+					followStatus,
 				} )
 			)
 		);

--- a/client/lib/feed-post-store/index.js
+++ b/client/lib/feed-post-store/index.js
@@ -18,6 +18,12 @@ import { action as FeedPostActionType } from './constants';
 import { action as FeedStreamActionType } from 'lib/feed-stream-store/constants';
 import { mc } from 'lib/analytics';
 import { pageViewForPost } from 'reader/stats';
+import { updateConversationFollowStatus } from 'state/reader/conversations/actions';
+import { bypassDataLayer } from 'state/data-layer/utils';
+import {
+	CONVERSATION_FOLLOW_STATUS_FOLLOWING,
+	CONVERSATION_FOLLOW_STATUS_NOT_FOLLOWING,
+} from 'state/reader/conversations/follow-status';
 
 /**
  * Module variables
@@ -146,6 +152,24 @@ function _setBlogPost( post ) {
 	}
 
 	_postsForBlogs[ key ] = post;
+
+	// Send conversation follow status over to Redux
+	if ( post.hasOwnProperty( 'is_following_conversation' ) ) {
+		const newFollowStatus = post.is_following_conversation
+			? CONVERSATION_FOLLOW_STATUS_FOLLOWING
+			: CONVERSATION_FOLLOW_STATUS_NOT_FOLLOWING;
+		// @todo is it a terrible idea to connect() FeedPostStore? It feels like it.
+		// dispatch(
+		// 	bypassDataLayer(
+		// 		updateConversationFollowStatus( {
+		// 			siteId: post.site_ID,
+		// 			postId: post.ID,
+		// 			followStatus: newFollowStatus,
+		// 		} )
+		// 	)
+		// );
+	}
+
 	return true;
 }
 

--- a/client/state/reader/conversations/reducer.js
+++ b/client/state/reader/conversations/reducer.js
@@ -15,6 +15,7 @@ import {
 } from 'state/action-types';
 import {
 	CONVERSATION_FOLLOW_STATUS_FOLLOWING,
+	CONVERSATION_FOLLOW_STATUS_NOT_FOLLOWING,
 	CONVERSATION_FOLLOW_STATUS_MUTING,
 } from './follow-status';
 import { combineReducers, createReducer } from 'state/utils';
@@ -46,7 +47,7 @@ export const items = createReducer(
 			const stateKey = key( action.payload.siteId, action.payload.postId );
 
 			// If followStatus is null, remove the key from the state map entirely
-			if ( action.payload.followStatus === null ) {
+			if ( action.payload.followStatus === CONVERSATION_FOLLOW_STATUS_NOT_FOLLOWING ) {
 				return omit( state, stateKey );
 			}
 

--- a/client/state/reader/conversations/reducer.js
+++ b/client/state/reader/conversations/reducer.js
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import { assign, forEach } from 'lodash';
+import { assign, forEach, omit } from 'lodash';
 
 /**
  * Internal dependencies
@@ -43,8 +43,15 @@ export const items = createReducer(
 			return newState;
 		},
 		[ READER_CONVERSATION_UPDATE_FOLLOW_STATUS ]: ( state, action ) => {
+			const stateKey = key( action.payload.siteId, action.payload.postId );
+
+			// If followStatus is null, remove the key from the state map entirely
+			if ( action.payload.followStatus === null ) {
+				return omit( state, stateKey );
+			}
+
 			const newState = assign( {}, state, {
-				[ key( action.payload.siteId, action.payload.postId ) ]: action.payload.followStatus,
+				[ stateKey ]: action.payload.followStatus,
 			} );
 
 			return newState;

--- a/client/state/reader/conversations/reducer.js
+++ b/client/state/reader/conversations/reducer.js
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import { assign } from 'lodash';
+import { assign, forEach } from 'lodash';
 
 /**
  * Internal dependencies
@@ -11,6 +11,7 @@ import {
 	READER_CONVERSATION_FOLLOW,
 	READER_CONVERSATION_MUTE,
 	READER_CONVERSATION_UPDATE_FOLLOW_STATUS,
+	READER_POSTS_RECEIVE,
 } from 'state/action-types';
 import {
 	CONVERSATION_FOLLOW_STATUS_FOLLOWING,
@@ -44,6 +45,23 @@ export const items = createReducer(
 		[ READER_CONVERSATION_UPDATE_FOLLOW_STATUS ]: ( state, action ) => {
 			const newState = assign( {}, state, {
 				[ key( action.payload.siteId, action.payload.postId ) ]: action.payload.followStatus,
+			} );
+
+			return newState;
+		},
+		[ READER_POSTS_RECEIVE ]: ( state, action ) => {
+			if ( ! action.posts ) {
+				return state;
+			}
+
+			let newState = state;
+
+			forEach( action.posts, post => {
+				if ( post.is_following_conversation ) {
+					newState = assign( {}, newState, {
+						[ key( post.site_ID, post.ID ) ]: CONVERSATION_FOLLOW_STATUS_FOLLOWING,
+					} );
+				}
 			} );
 
 			return newState;

--- a/client/state/reader/conversations/reducer.js
+++ b/client/state/reader/conversations/reducer.js
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import { assign, forEach, omit } from 'lodash';
+import { assign, forEach, omit, size } from 'lodash';
 
 /**
  * Internal dependencies
@@ -62,17 +62,19 @@ export const items = createReducer(
 				return state;
 			}
 
-			let newState = state;
+			const newState = {};
 
 			forEach( action.posts, post => {
 				if ( post.is_following_conversation ) {
-					newState = assign( {}, newState, {
-						[ key( post.site_ID, post.ID ) ]: CONVERSATION_FOLLOW_STATUS_FOLLOWING,
-					} );
+					newState[ key( post.site_ID, post.ID ) ] = CONVERSATION_FOLLOW_STATUS_FOLLOWING;
 				}
 			} );
 
-			return newState;
+			if ( size( newState ) === 0 ) {
+				return state;
+			}
+
+			return { ...state, ...newState };
 		},
 	},
 	itemsSchema

--- a/client/state/reader/conversations/test/reducer.js
+++ b/client/state/reader/conversations/test/reducer.js
@@ -57,6 +57,17 @@ describe( 'reducer', () => {
 			expect( state[ '123-456' ] ).toEqual( 'F' );
 		} );
 
+		test( 'should remove the given site and post from state entirely if followStatus is null', () => {
+			const original = deepFreeze( { '123-456': 'M' } );
+
+			const state = items( original, {
+				type: READER_CONVERSATION_UPDATE_FOLLOW_STATUS,
+				payload: { siteId: 123, postId: 456, followStatus: null },
+			} );
+
+			expect( state[ '123-456' ] ).toEqual( undefined );
+		} );
+
 		test( 'should add a new follow when new posts are received', () => {
 			const original = deepFreeze( {} );
 

--- a/client/state/reader/conversations/test/reducer.js
+++ b/client/state/reader/conversations/test/reducer.js
@@ -57,7 +57,7 @@ describe( 'reducer', () => {
 			expect( state[ '123-456' ] ).toEqual( 'F' );
 		} );
 
-		test( 'should remove the given site and post from state entirely if followStatus is null', () => {
+		test( 'should remove the given site and post from state entirely if the user is not following the post', () => {
 			const original = deepFreeze( { '123-456': 'M' } );
 
 			const state = items( original, {
@@ -65,7 +65,7 @@ describe( 'reducer', () => {
 				payload: { siteId: 123, postId: 456, followStatus: null },
 			} );
 
-			expect( state[ '123-456' ] ).toEqual( undefined );
+			expect( state ).not.toHaveProperty( '123-456' );
 		} );
 
 		test( 'should add a new follow when new posts are received', () => {
@@ -83,7 +83,7 @@ describe( 'reducer', () => {
 			expect( state[ '123-789' ] ).toEqual( 'F' );
 		} );
 
-		test( 'should not a new follow when new posts are received if is_following_conversation is false', () => {
+		test( 'should not add a new follow from a post when is_following_conversation is false', () => {
 			const original = deepFreeze( {} );
 
 			const state = items( original, {

--- a/client/state/reader/conversations/test/reducer.js
+++ b/client/state/reader/conversations/test/reducer.js
@@ -91,11 +91,11 @@ describe( 'reducer', () => {
 				posts: [ { site_ID: 123, ID: 456, is_following_conversation: false } ],
 			} );
 
-			expect( state[ '123-456' ] ).toEqual( undefined );
+			expect( state ).not.toHaveProperty( '123-456' );
 		} );
 
 		test( 'should update an existing follow status when new posts are received', () => {
-			const original = deepFreeze( { '123-456': 'M' } );
+			const original = deepFreeze( { '123-456': 'M', '123-678': 'M' } );
 
 			const state = items( original, {
 				type: READER_POSTS_RECEIVE,
@@ -103,6 +103,7 @@ describe( 'reducer', () => {
 			} );
 
 			expect( state[ '123-456' ] ).toEqual( 'F' );
+			expect( state[ '123-678' ] ).toEqual( 'M' );
 		} );
 
 		test( 'will deserialize valid state', () => {

--- a/client/state/reader/conversations/test/reducer.js
+++ b/client/state/reader/conversations/test/reducer.js
@@ -12,6 +12,7 @@ import {
 	READER_CONVERSATION_FOLLOW,
 	READER_CONVERSATION_MUTE,
 	READER_CONVERSATION_UPDATE_FOLLOW_STATUS,
+	READER_POSTS_RECEIVE,
 	SERIALIZE,
 	DESERIALIZE,
 } from 'state/action-types';
@@ -51,6 +52,43 @@ describe( 'reducer', () => {
 			const state = items( original, {
 				type: READER_CONVERSATION_UPDATE_FOLLOW_STATUS,
 				payload: { siteId: 123, postId: 456, followStatus: 'F' },
+			} );
+
+			expect( state[ '123-456' ] ).toEqual( 'F' );
+		} );
+
+		test( 'should add a new follow when new posts are received', () => {
+			const original = deepFreeze( {} );
+
+			const state = items( original, {
+				type: READER_POSTS_RECEIVE,
+				posts: [
+					{ site_ID: 123, ID: 456, is_following_conversation: true },
+					{ site_ID: 123, ID: 789, is_following_conversation: true },
+				],
+			} );
+
+			expect( state[ '123-456' ] ).toEqual( 'F' );
+			expect( state[ '123-789' ] ).toEqual( 'F' );
+		} );
+
+		test( 'should not a new follow when new posts are received if is_following_conversation is false', () => {
+			const original = deepFreeze( {} );
+
+			const state = items( original, {
+				type: READER_POSTS_RECEIVE,
+				posts: [ { site_ID: 123, ID: 456, is_following_conversation: false } ],
+			} );
+
+			expect( state[ '123-456' ] ).toEqual( undefined );
+		} );
+
+		test( 'should update an existing follow status when new posts are received', () => {
+			const original = deepFreeze( { '123-456': 'M' } );
+
+			const state = items( original, {
+				type: READER_POSTS_RECEIVE,
+				posts: [ { site_ID: 123, ID: 456, is_following_conversation: true } ],
 			} );
 
 			expect( state[ '123-456' ] ).toEqual( 'F' );


### PR DESCRIPTION
In API patch D8080 we've added the `is_following_conversation` flag to Reader API endpoints.

This PR adds handling for this in the reader/conversations reducer. If a conversation is followed, we add it to state with the followed (F) flag.

### To test

```
npm run test-client client/state/reader/conversations
```

With patch D8080 installed on your sandbox, follow a conversation from the post options menu:

<img width="606" alt="screen shot 2017-11-06 at 18 24 26" src="https://user-images.githubusercontent.com/17325/32457130-d9a1573e-c31f-11e7-87ab-bbf94fd09b19.png">

Hard-refresh the page, open the post options menu and make sure you're still following it. Repeat with unfollow.