### PR TITLE
Revert "Atomic Store: enable on staging for testing"

### DIFF
--- a/config/stage.json
+++ b/config/stage.json
@@ -115,7 +115,6 @@
 		"signup/domain-first-flow": true,
 		"signup/social": true,
 		"signup/social-management": true,
-		"signup/atomic-store-flow": true,
 		"signup/wpcc": true,
 		"simple-payments": true,
 		"standalone-site-preview": true,


### PR DESCRIPTION
Reverts Automattic/wp-calypso#19463.

Not ready for production.