### PR TITLE
Atomic Store: disable on staging due to issues on Woo setup page

### DIFF
--- a/config/stage.json
+++ b/config/stage.json
@@ -115,7 +115,7 @@
 		"signup/domain-first-flow": true,
 		"signup/social": true,
 		"signup/social-management": true,
-		"signup/atomic-store-flow": true,
+		"signup/atomic-store-flow": false,
 		"signup/wpcc": true,
 		"simple-payments": true,
 		"standalone-site-preview": true,


### PR DESCRIPTION
There are some issues on the Woo setup page with tracking the loading state so we can't deploy to prod today. Disabling it from `stage`.