### PR TITLE
Create a section stylesheet for Devdocs

### DIFF
--- a/assets/stylesheets/sections/devdocs.scss
+++ b/assets/stylesheets/sections/devdocs.scss
@@ -1,0 +1,13 @@
+// Main stylesheet
+@import '../style';
+
+// Section stylesheets
+@import 'login';
+@import 'post-editor';
+@import 'reader-full-post';
+@import 'signup';
+@import 'site-settings';
+
+// Devdocs
+@import 'devdocs/design/style';
+@import 'devdocs/design/syntax';

--- a/assets/stylesheets/style.scss
+++ b/assets/stylesheets/style.scss
@@ -21,7 +21,3 @@
 @import 'extensions/wp-job-manager/style';
 @import 'extensions/wp-super-cache/style';
 @import 'extensions/zoninator/style';
-
-// Devdocs
-@import 'devdocs/design/style';
-@import 'devdocs/design/syntax';

--- a/client/sections.js
+++ b/client/sections.js
@@ -32,6 +32,7 @@ sections.push( {
 	module: 'devdocs',
 	secondary: true,
 	enableLoggedOut: true,
+	css: 'devdocs',
 } );
 
 sections.push( {
@@ -40,6 +41,7 @@ sections.push( {
 	module: 'devdocs',
 	secondary: false,
 	enableLoggedOut: true,
+	css: 'devdocs',
 } );
 
 module.exports = sections.concat( extensionSections.filter( Boolean ) );


### PR DESCRIPTION
Now that CSS splitting has been enabled and it's possible to specify a stylesheet for a section, we've run into a side-effect: Devdocs doesn't have all the styles it needs to display component examples. Specifically, https://github.com/Automattic/wp-calypso/issues/19344 reports that the ReaderFullPostHeader block is missing its styles since we split Reader full post styles into their own stylesheet in https://github.com/Automattic/wp-calypso/pull/19147.

As @stephanethomas suggested in https://github.com/Automattic/wp-calypso/issues/19344#issuecomment-341045444, this PR creates a separate section stylesheet for Devdocs that includes the main stylesheet and _all_ section stylesheets.

As an added bonus, it also removes the Devdocs styles from the main stylesheet, so only visitors to `/devdocs` will now load the Devdocs styles.

Fixes #19344.

### To test

Visit http://calypso.localhost:3000/devdocs/blocks/reader-full-post-header and ensure that the example renders as below:

<img width="686" alt="screen shot 2017-11-03 at 19 07 00" src="https://user-images.githubusercontent.com/17325/32391491-30e8de02-c0ca-11e7-871b-b01b6ce99685.png">

Ensure that there are no broken pages in Devdocs owing to missing styles.