### PR TITLE
Sites: prevent TypeErrors in showStaleCartItemsNotice

### DIFF
--- a/client/my-sites/current-site/index.jsx
+++ b/client/my-sites/current-site/index.jsx
@@ -66,6 +66,7 @@ class CurrentSite extends Component {
 
 		// Show a notice if there are stale items in the cart and it hasn't been shown in the last 10 minutes (cart abandonment)
 		if (
+			selectedSite &&
 			cartItems.hasStaleItem( CartStore.get() ) &&
 			this.props.staleCartItemNoticeLastTimeShown < Date.now() - 10 * 60 * 1000
 		) {


### PR DESCRIPTION
The `CurrentSite` `selectedSite` prop can be `null` (eg, hit https://wordpress.com/stats/day directly) which can cause `TypeError`s to be thrown in `showStaleCartItemsNotice`. This fixes #19484.