### PR TITLE
Themes: Updating theme component to use gridicons

### DIFF
--- a/client/components/theme/more-button.jsx
+++ b/client/components/theme/more-button.jsx
@@ -8,6 +8,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { isFunction, map } from 'lodash';
+import Gridicon from 'gridicons';
 
 /**
  * Internal dependencies
@@ -69,7 +70,7 @@ class ThemeMoreButton extends Component {
 		return (
 			<span className={ classes }>
 				<button ref="more" onClick={ this.togglePopover }>
-					<span className="noticon noticon-ellipsis" />
+					<Gridicon icon="ellipsis" size={ 24 } />
 				</button>
 
 				<PopoverMenu

--- a/client/components/theme/style.scss
+++ b/client/components/theme/style.scss
@@ -255,8 +255,7 @@ $theme-info-height: 54px;
 		}
 	}
 
-	.noticon {
-		font-size: 24px;
+	.gridicon {
 		transition: all .15s cubic-bezier(0.175,.885,.32,1.275);
 	}
 
@@ -267,17 +266,17 @@ $theme-info-height: 54px;
 	&:hover {
 		background-color: transparentize( $gray-light, 0.7 );
 
-		.noticon {
+		.gridicon {
 			color: $blue-medium;
 		}
 
-		&.is-active .noticon {
+		&.is-active .gridicon {
 			color: $white;
 		}
 	}
 
 	&.is-open {
-		.noticon {
+		.gridicon {
 			transform: rotate(90deg);
 		}
 	}


### PR DESCRIPTION
Noticon is deprecated.

Before:

![screen shot 2017-11-03 at 2 51 56 pm](https://user-images.githubusercontent.com/618551/32393192-96c8fa50-c0a6-11e7-997b-060e336ee645.png)

After:

![screen shot 2017-11-03 at 2 51 43 pm](https://user-images.githubusercontent.com/618551/32393205-9b1e5352-c0a6-11e7-891b-838d315c0160.png)
