### PR TITLE
Hide Share action for Custom Post Types

### DIFF
--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/share.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/share.jsx
@@ -44,11 +44,12 @@ class PostActionsEllipsisMenuShare extends Component {
 	}
 
 	render() {
-		const { translate, status, isPublicizeEnabled: isPublicizeEnabledForSite } = this.props;
+		const { translate, status, type, isPublicizeEnabled: isPublicizeEnabledForSite } = this.props;
 		if (
 			! config.isEnabled( 'posts/post-type-list' ) ||
 			! includes( [ 'publish' ], status ) ||
-			! isPublicizeEnabledForSite
+			! isPublicizeEnabledForSite ||
+			type.name !== 'post'
 		) {
 			return null;
 		}

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/share.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/share.jsx
@@ -17,7 +17,6 @@ import PopoverMenuItem from 'components/popover/menu-item';
 import { bumpStat as bumpAnalyticsStat } from 'state/analytics/actions';
 import { bumpStatGenerator } from './utils';
 import { getPost } from 'state/posts/selectors';
-import { getPostType } from 'state/post-types/selectors';
 import { toggleSharePanel } from 'state/ui/post-type-list/actions';
 import { isPublicizeEnabled } from 'state/selectors';
 import config from 'config';
@@ -49,7 +48,7 @@ class PostActionsEllipsisMenuShare extends Component {
 			! config.isEnabled( 'posts/post-type-list' ) ||
 			! includes( [ 'publish' ], status ) ||
 			! isPublicizeEnabledForSite ||
-			type.name !== 'post'
+			'post' !== type
 		) {
 			return null;
 		}
@@ -71,7 +70,7 @@ const mapStateToProps = ( state, { globalId } ) => {
 	return {
 		status: post.status,
 		isPublicizeEnabled: isPublicizeEnabled( state, post.site_ID, post.type ),
-		type: getPostType( state, post.site_ID, post.type ),
+		type: post.type,
 	};
 };
 


### PR DESCRIPTION
This PR hides the unsupported Share action for Custom Post Types.

![screen shot 2017-11-03 at 9 13 19 pm](https://user-images.githubusercontent.com/1017839/32394358-179f32da-c0dd-11e7-8b61-9b91ea5d64ea.png)

Share remains visible for posts.

![screen shot 2017-11-03 at 9 13 46 pm](https://user-images.githubusercontent.com/1017839/32394370-22e7d2b4-c0dd-11e7-860d-541d9d06600e.png)


Testing instructions:

- Checkout branch
- Run `ENABLE_FEATURES=posts/post-type-list npm start`
- Navigate to Blog Posts and click the action menu
- Confirm that Share is among the menu items
- Navigate to Testimonials (you may have to enable them in Settings/Writing) and click the action menu
- Confirm that Share is NOT among the menu items