### PR TITLE
Jetpack Disconnect: Add 'Other' reason, small fixes

### DIFF
--- a/client/my-sites/site-settings/disconnect-site/confirm.jsx
+++ b/client/my-sites/site-settings/disconnect-site/confirm.jsx
@@ -39,6 +39,7 @@ class ConfirmDisconnection extends PureComponent {
 		'too-difficult': 'tooHard',
 		'too-expensive': 'onlyNeedFree',
 		troubleshooting: 'troubleshooting',
+		other: 'other',
 	};
 
 	submitSurvey = () => {
@@ -61,7 +62,7 @@ class ConfirmDisconnection extends PureComponent {
 	render() {
 		const { reason, siteId, siteSlug, translate } = this.props;
 		const previousStep = find(
-			without( keys( this.constructor.reasonWhitelist ), 'troubleshooting' ), // There's no step for Troubleshooting
+			without( keys( this.constructor.reasonWhitelist ), 'troubleshooting', 'other' ), // Redirect those back to initial survey
 			r => r === reason
 		);
 

--- a/client/my-sites/site-settings/disconnect-site/disconnect-survey.jsx
+++ b/client/my-sites/site-settings/disconnect-site/disconnect-survey.jsx
@@ -31,7 +31,7 @@ const DisconnectSurvey = ( { confirmHref, isPaidPlan, siteId, siteSlug, translat
 			{ translate( 'It was too hard to configure Jetpack' ) }
 		</CompactCard>
 		<CompactCard href={ `/settings/disconnect-site/missing-feature/${ siteSlug }` }>
-			{ translate( 'I was missing a feature' ) }
+			{ translate( 'A feature I need was missing.' ) }
 		</CompactCard>
 		{ isPaidPlan && (
 			<CompactCard href={ `/settings/disconnect-site/too-expensive/${ siteSlug }` }>

--- a/client/my-sites/site-settings/disconnect-site/disconnect-survey.jsx
+++ b/client/my-sites/site-settings/disconnect-site/disconnect-survey.jsx
@@ -41,6 +41,7 @@ const DisconnectSurvey = ( { confirmHref, isPaidPlan, siteId, siteSlug, translat
 		<CompactCard href={ confirmHref + '?reason=troubleshooting' }>
 			{ translate( "Troubleshooting — I'll be reconnecting afterwards" ) }
 		</CompactCard>
+		<CompactCard href={ confirmHref + '?reason=other' }>{ translate( 'Other' ) }</CompactCard>
 	</div>
 );
 

--- a/client/my-sites/site-settings/disconnect-site/disconnect-survey.jsx
+++ b/client/my-sites/site-settings/disconnect-site/disconnect-survey.jsx
@@ -27,30 +27,18 @@ const DisconnectSurvey = ( { confirmHref, isPaidPlan, siteId, siteSlug, translat
 				}
 			) }
 		/>
-		<CompactCard
-			href={ `/settings/disconnect-site/too-difficult/${ siteSlug }` }
-			className="disconnect-site__survey-one"
-		>
+		<CompactCard href={ `/settings/disconnect-site/too-difficult/${ siteSlug }` }>
 			{ translate( 'It was too hard to configure Jetpack' ) }
 		</CompactCard>
-		<CompactCard
-			href={ `/settings/disconnect-site/missing-feature/${ siteSlug }` }
-			className="disconnect-site__survey-one"
-		>
+		<CompactCard href={ `/settings/disconnect-site/missing-feature/${ siteSlug }` }>
 			{ translate( "This plan didn't include what I needed" ) }
 		</CompactCard>
 		{ isPaidPlan && (
-			<CompactCard
-				href={ `/settings/disconnect-site/too-expensive/${ siteSlug }` }
-				className="disconnect-site__survey-one"
-			>
+			<CompactCard href={ `/settings/disconnect-site/too-expensive/${ siteSlug }` }>
 				{ translate( 'This plan is too expensive' ) }
 			</CompactCard>
 		) }
-		<CompactCard
-			href={ confirmHref + '?reason=troubleshooting' }
-			className="disconnect-site__survey-one"
-		>
+		<CompactCard href={ confirmHref + '?reason=troubleshooting' }>
 			{ translate( "Troubleshooting — I'll be reconnecting afterwards" ) }
 		</CompactCard>
 	</div>

--- a/client/my-sites/site-settings/disconnect-site/disconnect-survey.jsx
+++ b/client/my-sites/site-settings/disconnect-site/disconnect-survey.jsx
@@ -31,7 +31,7 @@ const DisconnectSurvey = ( { confirmHref, isPaidPlan, siteId, siteSlug, translat
 			{ translate( 'It was too hard to configure Jetpack' ) }
 		</CompactCard>
 		<CompactCard href={ `/settings/disconnect-site/missing-feature/${ siteSlug }` }>
-			{ translate( "This plan didn't include what I needed" ) }
+			{ translate( 'I was missing a feature' ) }
 		</CompactCard>
 		{ isPaidPlan && (
 			<CompactCard href={ `/settings/disconnect-site/too-expensive/${ siteSlug }` }>

--- a/client/my-sites/site-settings/disconnect-site/disconnect-survey.jsx
+++ b/client/my-sites/site-settings/disconnect-site/disconnect-survey.jsx
@@ -37,7 +37,7 @@ const DisconnectSurvey = ( { confirmHref, isPaidPlan, siteId, siteSlug, translat
 			href={ `/settings/disconnect-site/missing-feature/${ siteSlug }` }
 			className="disconnect-site__survey-one"
 		>
-			{ translate( 'This plan didn’t include what I needed' ) }
+			{ translate( "This plan didn't include what I needed" ) }
 		</CompactCard>
 		{ isPaidPlan && (
 			<CompactCard


### PR DESCRIPTION
Addresses @rachelmcr's feedback at p7rd6c-15q-p2 #comment-1787.

* Reword 'This plan didn’t include what I needed' to 'I was missing a feature'.
* Add 'Other' reason.


Furthermore:
* Remove unused `disconnect-site__survey-one` `className`s (grep to verify).

![image](https://user-images.githubusercontent.com/96308/32396118-6f2be802-c0e4-11e7-970d-edb2ec005b7a.png)
