### PR TITLE
Jetpack Disconnect: Don't show survey if connection is broken

### DIFF
--- a/client/my-sites/plugins/disconnect-jetpack/disconnect-jetpack-button.jsx
+++ b/client/my-sites/plugins/disconnect-jetpack/disconnect-jetpack-button.jsx
@@ -13,10 +13,9 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
-import DisconnectJetpackDialog from 'blocks/disconnect-jetpack/dialog';
 import Button from 'components/button';
+import DisconnectJetpackDialog from 'blocks/disconnect-jetpack/dialog';
 import QuerySitePlans from 'components/data/query-site-plans';
-import { isEnabled } from 'config';
 import {
 	recordGoogleEvent as recordGoogleEventAction,
 	recordTracksEvent as recordTracksEventAction,
@@ -25,7 +24,8 @@ import {
 class DisconnectJetpackButton extends Component {
 	state = { dialogVisible: false };
 
-	handleClick = () => {
+	handleClick = event => {
+		event.preventDefault();
 		const { isMock, recordGoogleEvent, recordTracksEvent } = this.props;
 
 		if ( isMock ) {
@@ -64,11 +64,6 @@ class DisconnectJetpackButton extends Component {
 				/* eslint-disable wpcalypso/jsx-classname-namespace */
 				className="disconnect-jetpack-button"
 				compact
-				href={
-					isEnabled( 'manage/site-settings/disconnect-flow' ) ? (
-						'/settings/disconnect-site/' + site.slug
-					) : null
-				}
 				id={ `disconnect-jetpack-${ site.ID }` }
 				onClick={ this.handleClick }
 				scary
@@ -78,15 +73,13 @@ class DisconnectJetpackButton extends Component {
 						context: 'Jetpack: Action user takes to disconnect Jetpack site from .com',
 					} ) }
 				<QuerySitePlans siteId={ site.ID } />
-				{ ! isEnabled( 'manage/site-settings/disconnect-flow' ) && (
-					<DisconnectJetpackDialog
-						isVisible={ this.state.dialogVisible }
-						onClose={ this.hideDialog }
-						isBroken={ false }
-						siteId={ site.ID }
-						disconnectHref={ this.props.redirect }
-					/>
-				) }
+				<DisconnectJetpackDialog
+					isVisible={ this.state.dialogVisible }
+					onClose={ this.hideDialog }
+					isBroken={ false }
+					siteId={ site.ID }
+					disconnectHref={ this.props.redirect }
+				/>
 			</Button>
 		);
 	}


### PR DESCRIPTION
Reverts part of #19270, as discussed at p7rd6c-15q-p2#comment-1765:

> Personally, the one instance where I’m not entirely sure it makes sense to have the survey is the broken Jetpack indicator in the site selector scenario — what answer other than _It was broken, and I was nudged to disconnect_ do we expect? Considering reverting the behavior there to no survey, the more I think about it.

To test:

In siteslist in the sidebar, if you have a “broken” jetpack site, it will let you disconnect from the site there. (For example, rename `jetpack` plugin folder on the site.)

<img width="273" alt="screen shot 2017-06-23 at 12 41 17" src="https://user-images.githubusercontent.com/7767559/27480757-4ad41862-5811-11e7-8036-64202338667c.png">

This should no longer trigger the disconnect survey, but only the confirmation modal.