### PR TITLE
Fix broken progress bar corners.

### DIFF
--- a/client/components/wizard/style.scss
+++ b/client/components/wizard/style.scss
@@ -1,10 +1,5 @@
 /* Progress Indicator */
 
-.progress-bar,
-.progress-bar__progress {
-	border-radius: 0;
-}
-
 .wizard__progress-indicator {
 	display: flex;
 	align-items: center;

--- a/client/extensions/woocommerce/app/settings/email/mailchimp/style.scss
+++ b/client/extensions/woocommerce/app/settings/email/mailchimp/style.scss
@@ -106,6 +106,11 @@
 		display: flex;
 		align-items: center;
 		background: lighten( $gray-light, 1% );
+		
+		.progress-bar,
+		.progress-bar__progress {
+			border-radius: 0;
+		}
 
 		@include breakpoint( ">480px" ) {
 			margin: 0 -24px 16px;


### PR DESCRIPTION
### Infromation

During work on MailChimp UI too broad selectors for ProgressBar were used. This resulted in changed progress bar corners shape all across the Calypso UI. 

What we wanted:
![image](https://user-images.githubusercontent.com/17271089/32398112-5b74e956-c0aa-11e7-8ce2-50ed2a80dd60.png)

What we ended up doing everywhere:
![image](https://user-images.githubusercontent.com/17271089/32398118-6ab8e282-c0aa-11e7-88eb-82e827484e2f.png)

What this PR does is that it keeps the rectangle edges only for ProgressBar in MailChimp wizard and rounded everywhere else:

![image](https://user-images.githubusercontent.com/17271089/32398138-8fcea1ba-c0aa-11e7-84bf-244664dc7b67.png)

hat tip goes to @MichaelArestad for pointing this out.
