### PR TITLE
Framework: single tree rendering

### DIFF
--- a/client/auth/controller.js
+++ b/client/auth/controller.js
@@ -4,7 +4,6 @@
  * External dependencies
  */
 
-import ReactDom from 'react-dom';
 import React from 'react';
 import { startsWith } from 'lodash';
 import page from 'page';
@@ -24,16 +23,17 @@ import Main from 'components/main';
 import PulsingDot from 'components/pulsing-dot';
 
 export default {
-	oauthLogin: function() {
+	oauthLogin: function( context, next ) {
 		if ( config.isEnabled( 'oauth' ) ) {
 			if ( OAuthToken.getToken() ) {
 				page( '/' );
 			} else {
-				ReactDom.render( <OAuthLogin />, document.getElementById( 'primary' ) );
+				context.primary = <OAuthLogin />;
 			}
 		} else {
 			page( '/' );
 		}
+		next();
 	},
 
 	checkToken: function( context, next ) {
@@ -60,7 +60,7 @@ export default {
 
 	// This controller renders the API authentication screen
 	// for granting the app access to the user data using oauth
-	authorize: function() {
+	authorize: function( context, next ) {
 		let authUrl;
 
 		if ( config( 'oauth_client_id' ) ) {
@@ -78,16 +78,14 @@ export default {
 			authUrl = wpoauth.urlToConnect( { scope: 'global', blog_id: 0 } );
 		}
 
-		ReactDom.render(
-			React.createElement( ConnectComponent, {
-				authUrl: authUrl,
-			} ),
-			document.getElementById( 'primary' )
-		);
+		context.primary = React.createElement( ConnectComponent, {
+			authUrl: authUrl,
+		} );
+		next();
 	},
 
 	// Retrieve token from local storage
-	getToken: function( context ) {
+	getToken: function( context, next ) {
 		if ( context.hash && context.hash.access_token ) {
 			store.set( 'wpcom_token', context.hash.access_token );
 			wpcom.loadToken( context.hash.access_token );
@@ -98,12 +96,11 @@ export default {
 		}
 
 		// Extract this into a component...
-		ReactDom.render(
+		context.primary = (
 			<Main className="auth">
 				<p className="auth__welcome">Loading user...</p>
 				<PulsingDot active />
-			</Main>,
-			document.getElementById( 'primary' )
+			</Main>
 		);
 
 		// Fetch user and redirect to /sites on success.
@@ -117,5 +114,6 @@ export default {
 				window.location = '/';
 			}
 		} );
+		next();
 	},
 };

--- a/client/auth/index.js
+++ b/client/auth/index.js
@@ -11,13 +11,14 @@ import page from 'page';
  */
 import config from 'config';
 import controller from './controller';
+import { makeLayout, render as clientRender } from 'controller';
 
 export default () => {
 	// Always enable the /oauth-login route and redirect to /log-in if `oauth` is disabled
-	page( '/oauth-login', controller.oauthLogin );
+	page( '/oauth-login', controller.oauthLogin, makeLayout, clientRender );
 
 	if ( config.isEnabled( 'oauth' ) ) {
-		page( '/authorize', controller.authorize );
-		page( '/api/oauth/token', controller.getToken );
+		page( '/authorize', controller.authorize, makeLayout, clientRender );
+		page( '/api/oauth/token', controller.getToken, makeLayout, clientRender );
 	}
 };

--- a/client/boot/project/wordpress-com.js
+++ b/client/boot/project/wordpress-com.js
@@ -4,7 +4,7 @@
  * External dependencies
  */
 
-import { includes, startsWith } from 'lodash';
+import { startsWith } from 'lodash';
 import React from 'react';
 import ReactDom from 'react-dom';
 import store from 'store';
@@ -242,39 +242,4 @@ export function setupMiddlewares( currentUser, reduxStore ) {
 			testHelper( document.querySelector( '.environment.is-tests' ) );
 		} );
 	}
-
-	/*
-	 * Layouts with differing React mount-points will not reconcile correctly,
-	 * so remove an existing single-tree layout by re-rendering if necessary.
-	 *
-	 * TODO (@seear): Converting all of Calypso to single-tree layout will
-	 * make this unnecessary.
-	 */
-	page( '*', function( context, next ) {
-		const previousLayoutIsSingleTree = !! document.getElementsByClassName( 'wp-singletree-layout' )
-			.length;
-
-		const singleTreeSections = [
-			'account-recovery',
-			'login',
-			'posts-custom',
-			'theme',
-			'themes',
-			'preview',
-			'domain-connect-authorize',
-		];
-		const sectionName = getSectionName( context.store.getState() );
-		const isMultiTreeLayout = ! includes( singleTreeSections, sectionName );
-
-		if ( isMultiTreeLayout && previousLayoutIsSingleTree ) {
-			debug( 'Re-rendering multi-tree layout' );
-			ReactDom.unmountComponentAtNode( document.getElementById( 'wpcom' ) );
-			renderLayout( context.store );
-		} else if ( ! isMultiTreeLayout && ! previousLayoutIsSingleTree ) {
-			debug( 'Unmounting multi-tree layout' );
-			ReactDom.unmountComponentAtNode( document.getElementById( 'primary' ) );
-			ReactDom.unmountComponentAtNode( document.getElementById( 'secondary' ) );
-		}
-		next();
-	} );
 }

--- a/client/devdocs/controller.js
+++ b/client/devdocs/controller.js
@@ -4,7 +4,6 @@
  * External dependencies
  */
 
-import ReactDom from 'react-dom';
 import React from 'react';
 import qs from 'qs';
 import { debounce } from 'lodash';
@@ -27,7 +26,6 @@ import Sidebar from './sidebar';
 import FormStateExamplesComponent from './form-state-examples';
 import EmptyContent from 'components/empty-content';
 import WizardComponent from './wizard-component';
-import { renderWithReduxStore } from 'lib/react-helpers';
 
 const devdocs = {
 	/*
@@ -35,12 +33,9 @@ const devdocs = {
 	 * so #secondary needs to be cleaned up
 	 */
 	sidebar: function( context, next ) {
-		ReactDom.render(
-			React.createElement( Sidebar, {
-				path: context.path,
-			} ),
-			document.getElementById( 'secondary' )
-		);
+		context.secondary = React.createElement( Sidebar, {
+			path: context.path,
+		} );
 
 		next();
 	},
@@ -48,7 +43,7 @@ const devdocs = {
 	/*
 	 * Controller for page listing multiple developer docs
 	 */
-	devdocs: function( context ) {
+	devdocs: function( context, next ) {
 		function onSearchChange( searchTerm ) {
 			const query = context.query;
 
@@ -72,119 +67,93 @@ const devdocs = {
 			page.replace( newUrl, context.state, false, false );
 		}
 
-		renderWithReduxStore(
-			React.createElement( DocsComponent, {
-				term: context.query.term,
-				// we debounce with wait time of 0, so that the search doesn’t happen
-				// in the same tick as the keyUp event and possibly cause typing lag
-				onSearchChange: debounce( onSearchChange, 0 ),
-			} ),
-			'primary',
-			context.store
-		);
+		context.primary = React.createElement( DocsComponent, {
+			term: context.query.term,
+			// we debounce with wait time of 0, so that the search doesn’t happen
+			// in the same tick as the keyUp event and possibly cause typing lag
+			onSearchChange: debounce( onSearchChange, 0 ),
+		} );
+		next();
 	},
 
 	/*
 	 * Controller for single developer document
 	 */
-	singleDoc: function( context ) {
-		renderWithReduxStore(
-			React.createElement( SingleDocComponent, {
-				path: context.params.path,
-				term: context.query.term,
-				sectionId: Object.keys( context.hash )[ 0 ],
-			} ),
-			'primary',
-			context.store
-		);
+	singleDoc: function( context, next ) {
+		context.primary = React.createElement( SingleDocComponent, {
+			path: context.params.path,
+			term: context.query.term,
+			sectionId: Object.keys( context.hash )[ 0 ],
+		} );
+		next();
 	},
 
 	// UI components
-	design: function( context ) {
-		renderWithReduxStore(
-			React.createElement( DesignAssetsComponent, {
-				component: context.params.component,
-			} ),
-			'primary',
-			context.store
-		);
+	design: function( context, next ) {
+		context.primary = React.createElement( DesignAssetsComponent, {
+			component: context.params.component,
+		} );
+		next();
 	},
 
-	wizard: function( context ) {
-		renderWithReduxStore(
-			<WizardComponent stepName={ context.params.stepName } />,
-			'primary',
-			context.store
-		);
+	wizard: function( context, next ) {
+		context.primary = <WizardComponent stepName={ context.params.stepName } />;
+		next();
 	},
 
 	// App Blocks
-	blocks: function( context ) {
-		renderWithReduxStore(
-			React.createElement( Blocks, {
-				component: context.params.component,
-			} ),
-			'primary',
-			context.store
-		);
+	blocks: function( context, next ) {
+		context.primary = React.createElement( Blocks, {
+			component: context.params.component,
+		} );
+		next();
 	},
 
-	selectors: function( context ) {
-		renderWithReduxStore(
-			React.createElement( DocsSelectors, {
-				selector: context.params.selector,
-				search: context.query.search,
-			} ),
-			'primary',
-			context.store
-		);
+	selectors: function( context, next ) {
+		context.primary = React.createElement( DocsSelectors, {
+			selector: context.params.selector,
+			search: context.query.search,
+		} );
+		next();
 	},
 
-	typography: function( context ) {
-		renderWithReduxStore(
-			React.createElement( Typography, {
-				component: context.params.component,
-			} ),
-			'primary',
-			context.store
-		);
+	typography: function( context, next ) {
+		context.primary = React.createElement( Typography, {
+			component: context.params.component,
+		} );
+		next();
 	},
 
-	formStateExamples: function( context ) {
-		ReactDom.render(
-			React.createElement( FormStateExamplesComponent, {
-				component: context.params.component,
-			} ),
-			document.getElementById( 'primary' )
-		);
+	formStateExamples: function( context, next ) {
+		context.primary = React.createElement( FormStateExamplesComponent, {
+			component: context.params.component,
+		} );
+		next();
 	},
 
-	pleaseLogIn: function() {
+	pleaseLogIn: function( context, next ) {
 		const currentUrl = url.parse( location.href );
 		const redirectTo = currentUrl.protocol + '//' + currentUrl.host + '/devdocs/welcome';
 
-		ReactDom.unmountComponentAtNode( document.getElementById( 'secondary' ) );
-
-		ReactDom.render(
-			React.createElement( EmptyContent, {
-				title: 'Log In to start hacking',
-				line: 'Required to access the WordPress.com API',
-				action: 'Log In to WordPress.com',
-				actionURL: login( {
-					isNative: config.isEnabled( 'login/native-login-links' ),
-					redirectTo,
-				} ),
-				secondaryAction: 'Register',
-				secondaryActionURL: '/start/developer',
-				illustration: '/calypso/images/illustrations/illustration-nosites.svg',
+		context.primary = React.createElement( EmptyContent, {
+			title: 'Log In to start hacking',
+			line: 'Required to access the WordPress.com API',
+			action: 'Log In to WordPress.com',
+			actionURL: login( {
+				isNative: config.isEnabled( 'login/native-login-links' ),
+				redirectTo,
 			} ),
-			document.getElementById( 'primary' )
-		);
+			secondaryAction: 'Register',
+			secondaryActionURL: '/start/developer',
+			illustration: '/calypso/images/illustrations/illustration-nosites.svg',
+		} );
+		next();
 	},
 
 	// Welcome screen
-	welcome: function() {
-		ReactDom.render( React.createElement( DevWelcome, {} ), document.getElementById( 'primary' ) );
+	welcome: function( context, next ) {
+		context.primary = React.createElement( DevWelcome, {} );
+		next();
 	},
 };
 

--- a/client/devdocs/index.js
+++ b/client/devdocs/index.js
@@ -11,26 +11,59 @@ import config from 'config';
  * Internal dependencies
  */
 import controller from './controller';
+import { makeLayout, render as clientRender } from 'controller';
 
 export default function() {
 	if ( config.isEnabled( 'devdocs' ) ) {
-		page( '/devdocs', controller.sidebar, controller.devdocs );
+		page( '/devdocs', controller.sidebar, controller.devdocs, makeLayout, clientRender );
 		page(
 			'/devdocs/form-state-examples/:component?',
 			controller.sidebar,
-			controller.formStateExamples
+			controller.formStateExamples,
+			makeLayout,
+			clientRender
 		);
-		page( '/devdocs/design/wizard/:stepName?', controller.sidebar, controller.wizard );
-		page( '/devdocs/design/:component?', controller.sidebar, controller.design );
+		page(
+			'/devdocs/design/wizard/:stepName?',
+			controller.sidebar,
+			controller.wizard,
+			makeLayout,
+			clientRender
+		);
+		page(
+			'/devdocs/design/:component?',
+			controller.sidebar,
+			controller.design,
+			makeLayout,
+			clientRender
+		);
 		page( '/devdocs/app-components/:component?', context =>
 			page.redirect( '/devdocs/blocks/' + ( context.params.component || '' ) )
 		);
 		page( '/devdocs/app-components', '/devdocs/blocks' );
-		page( '/devdocs/blocks/:component?', controller.sidebar, controller.blocks );
-		page( '/devdocs/selectors/:selector?', controller.sidebar, controller.selectors );
-		page( '/devdocs/typography', controller.sidebar, controller.typography );
-		page( '/devdocs/start', controller.pleaseLogIn );
-		page( '/devdocs/welcome', controller.sidebar, controller.welcome );
-		page( '/devdocs/:path*', controller.sidebar, controller.singleDoc );
+		page(
+			'/devdocs/blocks/:component?',
+			controller.sidebar,
+			controller.blocks,
+			makeLayout,
+			clientRender
+		);
+		page(
+			'/devdocs/selectors/:selector?',
+			controller.sidebar,
+			controller.selectors,
+			makeLayout,
+			clientRender
+		);
+		page(
+			'/devdocs/typography',
+			controller.sidebar,
+			controller.typography,
+			makeLayout,
+			clientRender
+		);
+		page( '/devdocs/start', controller.pleaseLogIn, makeLayout, clientRender );
+		page( '/devdocs/welcome', controller.sidebar, controller.welcome, makeLayout, clientRender );
+		page( '/devdocs/:path*', controller.sidebar, controller.singleDoc, makeLayout, clientRender );
 	}
 }

--- a/client/extensions/hello-dolly/index.js
+++ b/client/extensions/hello-dolly/index.js
@@ -11,13 +11,14 @@ import React from 'react';
  * Internal dependencies
  */
 import HelloDollyPage from './hello-dolly-page';
-import { renderWithReduxStore } from 'lib/react-helpers';
 import { navigation, siteSelection } from 'my-sites/controller';
+import { makeLayout, render as clientRender } from 'controller';
 
-const render = context => {
-	renderWithReduxStore( <HelloDollyPage />, document.getElementById( 'primary' ), context.store );
+const render = ( context, next ) => {
+	context.primary = <HelloDollyPage />;
+	next();
 };
 
 export default function() {
-	page( '/hello-dolly/:site?', siteSelection, navigation, render );
+	page( '/hello-dolly/:site?', siteSelection, navigation, render, makeLayout, clientRender );
 }

--- a/client/extensions/sensei/index.js
+++ b/client/extensions/sensei/index.js
@@ -11,25 +11,24 @@ import React from 'react';
  * Internal dependencies
  */
 import { navigation, siteSelection } from 'my-sites/controller';
-import { renderWithReduxStore } from 'lib/react-helpers';
 import Main from 'components/main';
 import Card from 'components/card';
 import SectionHeader from 'components/section-header';
+import { makeLayout, render as clientRender } from 'controller';
 
-const render = context => {
-	renderWithReduxStore(
+const render = ( context, next ) => {
+	context.primary = (
 		<Main className="sensei__main">
 			<SectionHeader label="Sensei LMS" />
 			<Card>
 				<p>This is the start of something great!</p>
 				<p>This will be the home for your Sensei integration with WordPress.com.</p>
 			</Card>
-		</Main>,
-		document.getElementById( 'primary' ),
-		context.store
+		</Main>
 	);
+	next();
 };
 
 export default function() {
-	page( '/extensions/sensei/:site?', siteSelection, navigation, render );
+	page( '/extensions/sensei/:site?', siteSelection, navigation, render, makeLayout, clientRender );
 }

--- a/client/extensions/woocommerce/app/store-stats/controller.js
+++ b/client/extensions/woocommerce/app/store-stats/controller.js
@@ -10,7 +10,6 @@ import { moment, translate } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import { renderWithReduxStore } from 'lib/react-helpers';
 import AsyncLoad from 'components/async-load';
 import StatsPagePlaceholder from 'my-sites/stats/stats-page-placeholder';
 import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
@@ -28,7 +27,7 @@ function isValidParameters( context ) {
 	);
 }
 
-export default function StatsController( context ) {
+export default function StatsController( context, next ) {
 	if ( ! context.params.site || context.params.site === 'null' ) {
 		page.redirect( '/stats/day/' );
 	}
@@ -93,5 +92,6 @@ export default function StatsController( context ) {
 				{ ...props }
 			/>
 		);
-	renderWithReduxStore( asyncComponent, document.getElementById( 'primary' ), context.store );
+	context.primary = asyncComponent;
+	next();
 }

--- a/client/extensions/woocommerce/index.js
+++ b/client/extensions/woocommerce/index.js
@@ -175,46 +175,49 @@ const getStorePages = () => {
 };
 
 function addStorePage( storePage, storeNavigation ) {
-	page( storePage.path, siteSelection, storeNavigation, function( context, next ) {
-		const component = React.createElement( storePage.container, { params: context.params } );
-		const appProps =
-			( storePage.documentTitle && { documentTitle: storePage.documentTitle } ) || {};
+	page(
+		storePage.path,
+		siteSelection,
+		storeNavigation,
+		( context, next ) => {
+			const component = React.createElement( storePage.container, { params: context.params } );
+			const appProps =
+				( storePage.documentTitle && { documentTitle: storePage.documentTitle } ) || {};
 
-		let analyticsPath = storePage.path;
-		const { filter } = context.params;
-		if ( filter ) {
-			analyticsPath = analyticsPath.replace( ':filter', filter );
-		}
+			let analyticsPath = storePage.path;
+			const { filter } = context.params;
+			if ( filter ) {
+				analyticsPath = analyticsPath.replace( ':filter', filter );
+			}
 
-		let analyticsPageTitle = 'Store';
-		if ( storePage.documentTitle ) {
-			analyticsPageTitle += ` > ${ storePage.documentTitle }`;
-		} else {
-			analyticsPageTitle += ' > Dashboard';
-		}
+			let analyticsPageTitle = 'Store';
+			if ( storePage.documentTitle ) {
+				analyticsPageTitle += ` > ${ storePage.documentTitle }`;
+			} else {
+				analyticsPageTitle += ' > Dashboard';
+			}
 
-		analytics.pageView.record( analyticsPath, analyticsPageTitle );
+			analytics.pageView.record( analyticsPath, analyticsPageTitle );
 
-		context.primary = React.createElement( App, appProps, component );
-		next();
-	} );
+			context.primary = React.createElement( App, appProps, component );
+			next();
+		},
+		makeLayout,
+		clientRender
+	);
 }
 
 function createStoreNavigation( context, next, storePage ) {
-	renderWithReduxStore(
-		React.createElement( StoreSidebar, {
-			path: context.path,
-			page: storePage,
-		} ),
-		document.getElementById( 'secondary' ),
-		context.store
-	);
+	context.secondary = React.createElement( StoreSidebar, {
+		path: context.path,
+		page: storePage,
+	} );
 
 	next();
 }
 
 function notFoundError( context, next ) {
-	context.content = React.createElement( EmptyContent, {
+	context.primary = React.createElement( EmptyContent, {
 		className: 'content-404',
 		illustration: '/calypso/images/illustrations/illustration-404.svg',
 		title: translate( 'Uh oh. Page not found.' ),

--- a/client/extensions/wp-job-manager/app/controller.js
+++ b/client/extensions/wp-job-manager/app/controller.js
@@ -13,11 +13,10 @@ import { get } from 'lodash';
 import analytics from 'lib/analytics';
 import titlecase from 'to-title-case';
 import { getSiteFragment, sectionify } from 'lib/route';
-import { renderWithReduxStore } from 'lib/react-helpers';
 import Settings from '../components/settings';
 import SetupWizard from '../components/setup';
 
-export const renderTab = ( component, tab = '' ) => context => {
+export const renderTab = ( component, tab = '' ) => ( context, next ) => {
 	const siteId = getSiteFragment( context.path );
 	const basePath = sectionify( context.path );
 	let baseAnalyticsPath;
@@ -38,19 +37,13 @@ export const renderTab = ( component, tab = '' ) => context => {
 
 	analytics.pageView.record( baseAnalyticsPath, analyticsPageTitle );
 
-	renderWithReduxStore(
-		<Settings tab={ tab }>{ React.createElement( component ) }</Settings>,
-		document.getElementById( 'primary' ),
-		context.store
-	);
+	context.primary = <Settings tab={ tab }>{ React.createElement( component ) }</Settings>;
+	next();
 };
 
-export const renderSetupWizard = context => {
+export const renderSetupWizard = ( context, next ) => {
 	const stepName = get( context, [ 'params', 'stepName' ] );
 
-	renderWithReduxStore(
-		<SetupWizard stepName={ stepName } />,
-		document.getElementById( 'primary' ),
-		context.store
-	);
+	context.primary = <SetupWizard stepName={ stepName } />;
+	next();
 };

--- a/client/extensions/wp-job-manager/index.js
+++ b/client/extensions/wp-job-manager/index.js
@@ -17,6 +17,7 @@ import JobListings from './components/settings/job-listings';
 import JobSubmission from './components/settings/job-submission';
 import Pages from './components/settings/pages';
 import installActionHandlers from './state/data-layer';
+import { makeLayout, render as clientRender } from 'controller';
 
 function initExtension() {
 	installActionHandlers();
@@ -26,25 +27,38 @@ export default function() {
 	const jobSubmissionSlug = get( Tabs, 'JOB_SUBMISSION.slug', '' );
 	const pagesSlug = get( Tabs, 'PAGES.slug', '' );
 
-	page( '/extensions/wp-job-manager', sites );
-	page( '/extensions/wp-job-manager/:site', siteSelection, navigation, renderTab( JobListings ) );
+	page( '/extensions/wp-job-manager', sites, makeLayout, clientRender );
+	page(
+		'/extensions/wp-job-manager/:site',
+		siteSelection,
+		navigation,
+		renderTab( JobListings ),
+		makeLayout,
+		clientRender
+	);
 	page(
 		`/extensions/wp-job-manager/${ jobSubmissionSlug }/:site`,
 		siteSelection,
 		navigation,
-		renderTab( JobSubmission, jobSubmissionSlug )
+		renderTab( JobSubmission, jobSubmissionSlug ),
+		makeLayout,
+		clientRender
 	);
 	page(
 		`/extensions/wp-job-manager/${ pagesSlug }/:site`,
 		siteSelection,
 		navigation,
-		renderTab( Pages, pagesSlug )
+		renderTab( Pages, pagesSlug ),
+		makeLayout,
+		clientRender
 	);
 	page(
 		'/extensions/wp-job-manager/setup/:site/:stepName?',
 		siteSelection,
 		navigation,
-		renderSetupWizard
+		renderSetupWizard,
+		makeLayout,
+		clientRender
 	);
 }
 

--- a/client/extensions/wp-super-cache/app/controller.js
+++ b/client/extensions/wp-super-cache/app/controller.js
@@ -14,10 +14,9 @@ import analytics from 'lib/analytics';
 import titlecase from 'to-title-case';
 import { getSiteFragment, sectionify } from 'lib/route';
 import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
-import { renderWithReduxStore } from 'lib/react-helpers';
 import WPSuperCache from './main';
 
-export function settings( context ) {
+export function settings( context, next ) {
 	const siteId = getSiteFragment( context.path );
 	const { tab = '' } = context.params;
 
@@ -42,9 +41,6 @@ export function settings( context ) {
 
 	analytics.pageView.record( baseAnalyticsPath, analyticsPageTitle );
 
-	renderWithReduxStore(
-		<WPSuperCache tab={ tab } />,
-		document.getElementById( 'primary' ),
-		context.store
-	);
+	context.primary = <WPSuperCache tab={ tab } />;
+	next();
 }

--- a/client/extensions/wp-super-cache/index.js
+++ b/client/extensions/wp-super-cache/index.js
@@ -13,14 +13,17 @@ import { compact, map } from 'lodash';
 import { navigation, sites, siteSelection } from 'my-sites/controller';
 import { settings } from './app/controller';
 import { Tabs } from './app/constants';
+import { makeLayout, render as clientRender } from 'controller';
 
 export default function() {
 	const validTabSlugs = compact( map( Tabs, ( { slug } ) => slug ) ).join( '|' );
-	page( '/extensions/wp-super-cache', sites );
+	page( '/extensions/wp-super-cache', sites, makeLayout, clientRender );
 	page(
 		`/extensions/wp-super-cache/:tab(${ validTabSlugs })?/:site`,
 		siteSelection,
 		navigation,
-		settings
+		settings,
+		makeLayout,
+		clientRender
 	);
 }

--- a/client/extensions/zoninator/app/controller.js
+++ b/client/extensions/zoninator/app/controller.js
@@ -11,10 +11,9 @@ import React from 'react';
  */
 import analytics from 'lib/analytics';
 import { getSiteFragment, sectionify } from 'lib/route';
-import { renderWithReduxStore } from 'lib/react-helpers';
 import Settings from '../components/settings';
 
-export const renderTab = component => context => {
+export const renderTab = component => ( context, next ) => {
 	const siteId = getSiteFragment( context.path );
 	const zoneId = parseInt( context.params.zone, 10 ) || 0;
 
@@ -40,9 +39,6 @@ export const renderTab = component => context => {
 
 	analytics.pageView.record( baseAnalyticsPath, analyticsPageTitle );
 
-	renderWithReduxStore(
-		<Settings>{ React.createElement( component, { zoneId } ) }</Settings>,
-		document.getElementById( 'primary' ),
-		context.store
-	);
+	context.primary = <Settings>{ React.createElement( component, { zoneId } ) }</Settings>;
+	next();
 };

--- a/client/extensions/zoninator/index.js
+++ b/client/extensions/zoninator/index.js
@@ -15,15 +15,37 @@ import ZoneCreator from './components/settings/zone-creator';
 import Zone from './components/settings/zone';
 import ZonesDashboard from './components/settings/zones-dashboard';
 import installActionHandlers from './state/data-layer';
+import { makeLayout, render as clientRender } from 'controller';
 
 export default function() {
-	page( '/extensions/zoninator', sites );
-	page( '/extensions/zoninator/new', sites );
-	page( '/extensions/zoninator/zone', sites );
+	page( '/extensions/zoninator', sites, makeLayout, clientRender );
+	page( '/extensions/zoninator/new', sites, makeLayout, clientRender );
+	page( '/extensions/zoninator/zone', sites, makeLayout, clientRender );
 
-	page( '/extensions/zoninator/:site', siteSelection, navigation, renderTab( ZonesDashboard ) );
-	page( '/extensions/zoninator/new/:site', siteSelection, navigation, renderTab( ZoneCreator ) );
-	page( '/extensions/zoninator/zone/:site/:zone', siteSelection, navigation, renderTab( Zone ) );
+	page(
+		'/extensions/zoninator/:site',
+		siteSelection,
+		navigation,
+		renderTab( ZonesDashboard ),
+		makeLayout,
+		clientRender
+	);
+	page(
+		'/extensions/zoninator/new/:site',
+		siteSelection,
+		navigation,
+		renderTab( ZoneCreator ),
+		makeLayout,
+		clientRender
+	);
+	page(
+		'/extensions/zoninator/zone/:site/:zone',
+		siteSelection,
+		navigation,
+		renderTab( Zone ),
+		makeLayout,
+		clientRender
+	);
 }
 
 installActionHandlers();

--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -58,14 +58,13 @@ const removeSidebar = context => {
 	);
 };
 
-const jetpackNewSiteSelector = ( context, next ) => {
+const jetpackNewSiteSelector = context => {
 	removeSidebar( context );
 	context.primary = React.createElement( JetpackNewSite, {
 		path: context.path,
 		context: context,
 		locale: context.params.locale,
 	} );
-	next();
 };
 
 const getPlanSlugFromFlowType = ( type, interval = 'yearly' ) => {
@@ -108,9 +107,10 @@ export function saveQueryObject( context, next ) {
 	next();
 }
 
-export function newSite( context ) {
+export function newSite( context, next ) {
 	analytics.pageView.record( '/jetpack/new', 'Add a new site (Jetpack)' );
 	jetpackNewSiteSelector( context );
+	next();
 }
 
 export function connect( context, next ) {

--- a/client/jetpack-connect/index.js
+++ b/client/jetpack-connect/index.js
@@ -11,6 +11,7 @@ import userFactory from 'lib/user';
 import * as controller from './controller';
 import { login } from 'lib/paths';
 import { siteSelection } from 'my-sites/controller';
+import { makeLayout, render as clientRender } from 'controller';
 
 export default function() {
 	const user = userFactory();
@@ -18,32 +19,45 @@ export default function() {
 
 	page(
 		'/jetpack/connect/:type(personal|premium|pro)/:interval(yearly|monthly)?',
-		controller.connect
+		controller.connect,
+		makeLayout,
+		clientRender
 	);
 
 	page(
 		'/jetpack/connect/:type(install)/:locale?',
 		controller.redirectWithoutLocaleifLoggedIn,
-		controller.connect
+		controller.connect,
+		makeLayout,
+		clientRender
 	);
 
-	page( '/jetpack/connect', controller.connect );
+	page( '/jetpack/connect', controller.connect, makeLayout, clientRender );
 
 	page(
 		'/jetpack/connect/authorize/:localeOrInterval?',
 		controller.redirectWithoutLocaleifLoggedIn,
 		controller.saveQueryObject,
-		controller.authorizeForm
+		controller.authorizeForm,
+		makeLayout,
+		clientRender
 	);
 
 	page(
 		'/jetpack/connect/authorize/:interval/:locale',
 		controller.redirectWithoutLocaleifLoggedIn,
 		controller.saveQueryObject,
-		controller.authorizeForm
+		controller.authorizeForm,
+		makeLayout,
+		clientRender
 	);
 
-	page( '/jetpack/connect/store/:interval(yearly|monthly)?', controller.plansLanding );
+	page(
+		'/jetpack/connect/store/:interval(yearly|monthly)?',
+		controller.plansLanding,
+		makeLayout,
+		clientRender
+	);
 
 	page(
 		'/jetpack/connect/:_(akismet|plans|vaultpress)/:interval(yearly|monthly)?',
@@ -60,17 +74,21 @@ export default function() {
 	page(
 		'/jetpack/connect/plans/:interval(yearly|monthly)?/:site',
 		siteSelection,
-		controller.plansSelection
+		controller.plansSelection,
+		makeLayout,
+		clientRender
 	);
 
 	page(
 		'/jetpack/connect/:locale?',
 		controller.redirectWithoutLocaleifLoggedIn,
-		controller.connect
+		controller.connect,
+		makeLayout,
+		clientRender
 	);
 
-	page( '/jetpack/sso/:siteId?/:ssoNonce?', controller.sso );
-	page( '/jetpack/sso/*', controller.sso );
-	page( '/jetpack/new', controller.newSite );
+	page( '/jetpack/sso/:siteId?/:ssoNonce?', controller.sso, makeLayout, clientRender );
+	page( '/jetpack/sso/*', controller.sso, makeLayout, clientRender );
+	page( '/jetpack/new', controller.newSite, makeLayout, clientRender );
 	page( '/jetpack/new/*', '/jetpack/connect' );
 }

--- a/client/jetpack-onboarding/controller.js
+++ b/client/jetpack-onboarding/controller.js
@@ -3,26 +3,20 @@
  * External Dependencies
  */
 import React from 'react';
-import ReactDom from 'react-dom';
 
 /**
  * Internal Dependencies
  */
 import JetpackOnboardingMain from './main';
-import { renderWithReduxStore } from 'lib/react-helpers';
 import { setSection } from 'state/ui/actions';
 
 const removeSidebar = context => {
-	ReactDom.unmountComponentAtNode( document.getElementById( 'secondary' ) );
 	context.store.dispatch( setSection( null, { hasSidebar: false } ) );
 };
 
-export const onboarding = context => {
+export const onboarding = ( context, next ) => {
 	removeSidebar( context );
 
-	renderWithReduxStore(
-		<JetpackOnboardingMain stepName={ context.params.stepName } />,
-		'primary',
-		context.store
-	);
+	context.primary = <JetpackOnboardingMain stepName={ context.params.stepName } />;
+	next();
 };

--- a/client/jetpack-onboarding/index.js
+++ b/client/jetpack-onboarding/index.js
@@ -11,10 +11,16 @@ import { values } from 'lodash';
  */
 import { onboarding } from './controller';
 import { JETPACK_ONBOARDING_STEPS } from './constants';
+import { makeLayout, render as clientRender } from 'controller';
 
 export default function() {
 	if ( isEnabled( 'jetpack/onboarding' ) ) {
 		const validStepNames = values( JETPACK_ONBOARDING_STEPS );
-		page( `/jetpack/onboarding/:stepName(${ validStepNames.join( '|' ) })?`, onboarding );
+		page(
+			`/jetpack/onboarding/:stepName(${ validStepNames.join( '|' ) })?`,
+			onboarding,
+			makeLayout,
+			clientRender
+		);
 	}
 }

--- a/client/layout/error.jsx
+++ b/client/layout/error.jsx
@@ -7,7 +7,6 @@
 import debug from 'debug';
 import { localize } from 'i18n-calypso';
 import { assign } from 'lodash';
-import ReactDom from 'react-dom';
 import React from 'react';
 import url from 'url';
 import qs from 'querystring';
@@ -46,8 +45,8 @@ export function retry( chunkName ) {
 	}
 }
 
-export function show( chunkName ) {
+export function show( context, chunkName ) {
 	log( 'Chunk %s could not be loaded', chunkName );
 	analytics.mc.bumpStat( 'calypso_chunk_error', chunkName );
-	ReactDom.render( <LoadingErrorMessage />, document.getElementById( 'primary' ) );
+	context.primary = <LoadingErrorMessage />;
 }

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -148,7 +148,6 @@ const Layout = createReactClass( {
 				`focus-${ this.props.currentLayoutFocus }`,
 				{ 'is-support-user': this.props.isSupportUser },
 				{ 'has-no-sidebar': ! this.props.hasSidebar },
-				{ 'wp-singletree-layout': !! this.props.primary },
 				{ 'has-chat': this.props.chatIsOpen }
 			),
 			loadingClass = classnames( {

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -34,7 +34,6 @@ const LayoutLoggedOut = ( { oauth2Client, primary, section, redirectUri, useOAut
 		[ 'is-section-' + section.name ]: !! section,
 		'focus-content': true,
 		'has-no-sidebar': ! hasSidebar( section ),
-		'wp-singletree-layout': !! primary,
 	};
 
 	let masterbar = null;

--- a/client/mailing-lists/controller.js
+++ b/client/mailing-lists/controller.js
@@ -12,10 +12,9 @@ import { setSection } from 'state/ui/actions';
  * Internal Dependencies
  */
 import MainComponent from './main';
-import { renderWithReduxStore } from 'lib/react-helpers';
 
 export default {
-	unsubscribe( context ) {
+	unsubscribe( context, next ) {
 		// We don't need the sidebar here.
 		context.store.dispatch(
 			setSection(
@@ -26,15 +25,12 @@ export default {
 			)
 		);
 
-		renderWithReduxStore(
-			React.createElement( MainComponent, {
-				email: context.query.email,
-				category: context.query.category,
-				hmac: context.query.hmac,
-				context: omit( context.query, [ 'email', 'category', 'hmac' ] ),
-			} ),
-			document.getElementById( 'primary' ),
-			context.store
-		);
+		context.primary = React.createElement( MainComponent, {
+			email: context.query.email,
+			category: context.query.category,
+			hmac: context.query.hmac,
+			context: omit( context.query, [ 'email', 'category', 'hmac' ] ),
+		} );
+		next();
 	},
 };

--- a/client/mailing-lists/index.js
+++ b/client/mailing-lists/index.js
@@ -10,10 +10,11 @@ import page from 'page';
  * Internal dependencies
  */
 import controller from './controller';
+import { makeLayout, render as clientRender } from 'controller';
 
 export default function() {
 	// not putting category or email address in params, since `page`
 	// currently double-decodes the URI before doing route matching
 	// https://github.com/visionmedia/page.js/issues/306
-	page( '/mailing-lists/unsubscribe', controller.unsubscribe );
+	page( '/mailing-lists/unsubscribe', controller.unsubscribe, makeLayout, clientRender );
 }

--- a/client/me/account/controller.js
+++ b/client/me/account/controller.js
@@ -14,12 +14,11 @@ import i18n from 'i18n-calypso';
 import analytics from 'lib/analytics';
 import userSettings from 'lib/user-settings';
 import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
-import { renderWithReduxStore } from 'lib/react-helpers';
 
 const ANALYTICS_PAGE_TITLE = 'Me';
 
 export default {
-	account( context ) {
+	account( context, next ) {
 		const AccountComponent = require( 'me/account/main' );
 		const username = require( 'lib/username' );
 		const basePath = context.path;
@@ -38,15 +37,12 @@ export default {
 			analytics.pageView.record( basePath, ANALYTICS_PAGE_TITLE + ' > Account Settings' );
 		}
 
-		renderWithReduxStore(
-			React.createElement( AccountComponent, {
-				userSettings: userSettings,
-				path: context.path,
-				username: username,
-				showNoticeInitially: showNoticeInitially,
-			} ),
-			document.getElementById( 'primary' ),
-			context.store
-		);
+		context.primary = React.createElement( AccountComponent, {
+			userSettings: userSettings,
+			path: context.path,
+			username: username,
+			showNoticeInitially: showNoticeInitially,
+		} );
+		next();
 	},
 };

--- a/client/me/account/index.js
+++ b/client/me/account/index.js
@@ -11,7 +11,8 @@ import page from 'page';
  */
 import meController from 'me/controller';
 import controller from './controller';
+import { makeLayout, render as clientRender } from 'controller';
 
 export default function() {
-	page( '/me/account', meController.sidebar, controller.account );
+	page( '/me/account', meController.sidebar, controller.account, makeLayout, clientRender );
 }

--- a/client/me/billing-history/controller.js
+++ b/client/me/billing-history/controller.js
@@ -6,32 +6,21 @@
 
 import React from 'react';
 
-/**
- * Internal dependencies
- */
-import { renderWithReduxStore } from 'lib/react-helpers';
-
 export default {
-	billingHistory( context ) {
+	billingHistory( context, next ) {
 		const BillingHistoryComponent = require( './main' );
 
-		renderWithReduxStore(
-			React.createElement( BillingHistoryComponent ),
-			document.getElementById( 'primary' ),
-			context.store
-		);
+		context.primary = React.createElement( BillingHistoryComponent );
+		next();
 	},
 
-	transaction( context ) {
+	transaction( context, next ) {
 		const Receipt = require( './receipt' );
 		const receiptId = context.params.receiptId;
 
 		if ( receiptId ) {
-			renderWithReduxStore(
-				React.createElement( Receipt, { transactionId: receiptId } ),
-				document.getElementById( 'primary' ),
-				context.store
-			);
+			context.primary = React.createElement( Receipt, { transactionId: receiptId } );
 		}
+		next();
 	},
 };

--- a/client/me/concierge/controller.js
+++ b/client/me/concierge/controller.js
@@ -8,15 +8,11 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import { renderWithReduxStore } from 'lib/react-helpers';
 import ConciergeMain from './main';
 
-const concierge = context => {
-	renderWithReduxStore(
-		React.createElement( ConciergeMain, {} ),
-		document.getElementById( 'primary' ),
-		context.store
-	);
+const concierge = ( context, next ) => {
+	context.primary = React.createElement( ConciergeMain, {} );
+	next();
 };
 
 export default {

--- a/client/me/concierge/index.js
+++ b/client/me/concierge/index.js
@@ -11,9 +11,10 @@ import page from 'page';
  */
 import config from 'config';
 import controller from './controller';
+import { makeLayout, render as clientRender } from 'controller';
 
 export default () => {
 	if ( config.isEnabled( 'concierge-chats' ) ) {
-		page( '/me/concierge', controller.concierge );
+		page( '/me/concierge', controller.concierge, makeLayout, clientRender );
 	}
 };

--- a/client/me/controller.js
+++ b/client/me/controller.js
@@ -4,7 +4,6 @@
  * External dependencies
  */
 
-import ReactDom from 'react-dom';
 import React from 'react';
 import { includes } from 'lodash';
 import page from 'page';
@@ -18,7 +17,6 @@ import route from 'lib/route';
 import userSettings from 'lib/user-settings';
 import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
 import { setSection } from 'state/ui/actions';
-import { renderWithReduxStore } from 'lib/react-helpers';
 
 const ANALYTICS_PAGE_TITLE = 'Me';
 
@@ -26,18 +24,14 @@ export default {
 	sidebar( context, next ) {
 		const SidebarComponent = require( 'me/sidebar' );
 
-		renderWithReduxStore(
-			React.createElement( SidebarComponent, {
-				context: context,
-			} ),
-			document.getElementById( 'secondary' ),
-			context.store
-		);
+		context.secondary = React.createElement( SidebarComponent, {
+			context: context,
+		} );
 
 		next();
 	},
 
-	profile( context ) {
+	profile( context, next ) {
 		const ProfileComponent = require( 'me/profile' ),
 			basePath = context.path;
 
@@ -45,17 +39,14 @@ export default {
 
 		analytics.pageView.record( basePath, ANALYTICS_PAGE_TITLE + ' > My Profile' );
 
-		renderWithReduxStore(
-			React.createElement( ProfileComponent, {
-				userSettings: userSettings,
-				path: context.path,
-			} ),
-			document.getElementById( 'primary' ),
-			context.store
-		);
+		context.primary = React.createElement( ProfileComponent, {
+			userSettings: userSettings,
+			path: context.path,
+		} );
+		next();
 	},
 
-	apps( context ) {
+	apps( context, next ) {
 		const AppsComponent = require( 'me/get-apps' ).default;
 		const basePath = context.path;
 
@@ -63,17 +54,14 @@ export default {
 
 		analytics.pageView.record( basePath, ANALYTICS_PAGE_TITLE + ' > Get Apps' );
 
-		renderWithReduxStore(
-			React.createElement( AppsComponent, {
-				userSettings: userSettings,
-				path: context.path,
-			} ),
-			document.getElementById( 'primary' ),
-			context.store
-		);
+		context.primary = React.createElement( AppsComponent, {
+			userSettings: userSettings,
+			path: context.path,
+		} );
+		next();
 	},
 
-	nextSteps( context ) {
+	nextSteps( context, next ) {
 		const analyticsBasePath = route.sectionify( context.path ),
 			NextSteps = require( './next-steps' ),
 			isWelcome = 'welcome' === context.params.welcome;
@@ -81,21 +69,17 @@ export default {
 		context.store.dispatch( setTitle( i18n.translate( 'Next Steps', { textOnly: true } ) ) ); // FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
 
 		if ( isWelcome ) {
-			ReactDom.unmountComponentAtNode( document.getElementById( 'secondary' ) );
 			context.store.dispatch( setSection( null, { hasSidebar: false } ) );
 		}
 
 		analytics.tracks.recordEvent( 'calypso_me_next_view', { is_welcome: isWelcome } );
 		analytics.pageView.record( analyticsBasePath, ANALYTICS_PAGE_TITLE + ' > Next' );
 
-		renderWithReduxStore(
-			React.createElement( NextSteps, {
-				path: context.path,
-				isWelcome: isWelcome,
-			} ),
-			document.getElementById( 'primary' ),
-			context.store
-		);
+		context.primary = React.createElement( NextSteps, {
+			path: context.path,
+			isWelcome: isWelcome,
+		} );
+		next();
 	},
 
 	// Users that are redirected to `/me/next?welcome` after signup should visit

--- a/client/me/happychat/index.jsx
+++ b/client/me/happychat/index.jsx
@@ -12,19 +12,20 @@ import { translate } from 'i18n-calypso';
 /*
 	Internal deps
 */
-import { renderWithReduxStore } from 'lib/react-helpers';
 import config from 'config';
 import controller from 'me/controller';
 import Happychat from './main';
 import { setDocumentHeadTitle } from 'state/document-head/actions';
+import { makeLayout, render as clientRender } from 'controller';
 
-const renderChat = context => {
+const renderChat = ( context, next ) => {
 	context.store.dispatch( setDocumentHeadTitle( translate( 'Chat', { textOnly: true } ) ) );
-	renderWithReduxStore( <Happychat />, document.getElementById( 'primary' ), context.store );
+	context.primary = <Happychat />;
+	next();
 };
 
 export default () => {
 	if ( config.isEnabled( 'happychat' ) ) {
-		page( '/me/chat', controller.sidebar, renderChat );
+		page( '/me/chat', controller.sidebar, renderChat, makeLayout, clientRender );
 	}
 };

--- a/client/me/help/controller.js
+++ b/client/me/help/controller.js
@@ -15,7 +15,6 @@ import { login } from 'lib/paths';
 import route from 'lib/route';
 import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
 import config from 'config';
-import { renderWithReduxStore } from 'lib/react-helpers';
 import HelpComponent from './main';
 import CoursesComponent from './help-courses';
 import ContactComponent from './help-contact';
@@ -44,7 +43,7 @@ export default {
 		window.location.href = url;
 	},
 
-	help( context ) {
+	help( context, next ) {
 		const basePath = route.sectionify( context.path );
 
 		// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
@@ -52,22 +51,20 @@ export default {
 
 		analytics.pageView.record( basePath, 'Help' );
 
-		renderWithReduxStore(
-			<HelpComponent isCoursesEnabled={ config.isEnabled( 'help/courses' ) } />,
-			document.getElementById( 'primary' ),
-			context.store
-		);
+		context.primary = <HelpComponent isCoursesEnabled={ config.isEnabled( 'help/courses' ) } />;
+		next();
 	},
 
-	courses( context ) {
+	courses( context, next ) {
 		const basePath = route.sectionify( context.path );
 
 		analytics.pageView.record( basePath, 'Help > Courses' );
 
-		renderWithReduxStore( <CoursesComponent />, 'primary', context.store );
+		context.primary = <CoursesComponent />;
+		next();
 	},
 
-	contact( context ) {
+	contact( context, next ) {
 		const basePath = route.sectionify( context.path );
 
 		analytics.pageView.record( basePath, 'Help > Contact' );
@@ -77,10 +74,7 @@ export default {
 			window.scrollTo( 0, 0 );
 		}
 
-		renderWithReduxStore(
-			<ContactComponent clientSlug={ config( 'client_slug' ) } />,
-			'primary',
-			context.store
-		);
+		context.primary = <ContactComponent clientSlug={ config( 'client_slug' ) } />;
+		next();
 	},
 };

--- a/client/me/help/index.js
+++ b/client/me/help/index.js
@@ -8,14 +8,36 @@ import page from 'page';
 import config from 'config';
 import meController from 'me/controller';
 import helpController from './controller';
+import { makeLayout, render as clientRender } from 'controller';
 
 export default function() {
 	if ( config.isEnabled( 'help' ) ) {
-		page( '/help', helpController.loggedOut, meController.sidebar, helpController.help );
-		page( '/help/contact', helpController.loggedOut, meController.sidebar, helpController.contact );
+		page(
+			'/help',
+			helpController.loggedOut,
+			meController.sidebar,
+			helpController.help,
+			makeLayout,
+			clientRender
+		);
+		page(
+			'/help/contact',
+			helpController.loggedOut,
+			meController.sidebar,
+			helpController.contact,
+			makeLayout,
+			clientRender
+		);
 	}
 
 	if ( config.isEnabled( 'help/courses' ) ) {
-		page( '/help/courses', helpController.loggedOut, meController.sidebar, helpController.courses );
+		page(
+			'/help/courses',
+			helpController.loggedOut,
+			meController.sidebar,
+			helpController.courses,
+			makeLayout,
+			clientRender
+		);
 	}
 }

--- a/client/me/index.js
+++ b/client/me/index.js
@@ -11,14 +11,15 @@ import page from 'page';
  * Internal dependencies
  */
 import controller from './controller';
+import { makeLayout, render as clientRender } from 'controller';
 
 export default function() {
 	if ( config.isEnabled( 'me/my-profile' ) ) {
-		page( '/me', controller.sidebar, controller.profile );
+		page( '/me', controller.sidebar, controller.profile, makeLayout, clientRender );
 
 		// Redirect previous URLs
-		page( '/me/profile', controller.profileRedirect );
-		page( '/me/public-profile', controller.profileRedirect );
+		page( '/me/profile', controller.profileRedirect, makeLayout, clientRender );
+		page( '/me/public-profile', controller.profileRedirect, makeLayout, clientRender );
 	}
 
 	if ( config.isEnabled( 'me/next-steps' ) ) {
@@ -26,7 +27,9 @@ export default function() {
 			'/me/next/:welcome?',
 			controller.sidebar,
 			controller.nextStepsWelcomeRedirect,
-			controller.nextSteps
+			controller.nextSteps,
+			makeLayout,
+			clientRender
 		);
 	}
 
@@ -34,12 +37,12 @@ export default function() {
 	// Using a reverse config flag here to try to reflect that
 	// If they're "not enabled", then the router should not redirect them, so they will be handled in Atlas
 	if ( ! config.isEnabled( 'me/trophies' ) ) {
-		page( '/me/trophies', controller.trophiesRedirect );
+		page( '/me/trophies', controller.trophiesRedirect, makeLayout, clientRender );
 	}
 
 	if ( ! config.isEnabled( 'me/find-friends' ) ) {
-		page( '/me/find-friends', controller.findFriendsRedirect );
+		page( '/me/find-friends', controller.findFriendsRedirect, makeLayout, clientRender );
 	}
 
-	page( '/me/get-apps', controller.sidebar, controller.apps );
+	page( '/me/get-apps', controller.sidebar, controller.apps, makeLayout, clientRender );
 }

--- a/client/me/notification-settings/controller.js
+++ b/client/me/notification-settings/controller.js
@@ -13,7 +13,6 @@ import i18n from 'i18n-calypso';
 import analytics from 'lib/analytics';
 import userSettings from 'lib/user-settings';
 import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
-import { renderWithReduxStore } from 'lib/react-helpers';
 import NotificationsComponent from 'me/notification-settings/main';
 import CommentSettingsComponent from 'me/notification-settings/comment-settings';
 import WPcomSettingsComponent from 'me/notification-settings/wpcom-settings';
@@ -22,7 +21,7 @@ import NotificationSubscriptions from 'me/notification-settings/reader-subscript
 const ANALYTICS_PAGE_TITLE = 'Me';
 
 export default {
-	notifications( context ) {
+	notifications( context, next ) {
 		const basePath = context.path;
 
 		// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
@@ -30,17 +29,14 @@ export default {
 
 		analytics.pageView.record( basePath, ANALYTICS_PAGE_TITLE + ' > Notifications' );
 
-		renderWithReduxStore(
-			React.createElement( NotificationsComponent, {
-				userSettings: userSettings,
-				path: context.path,
-			} ),
-			document.getElementById( 'primary' ),
-			context.store
-		);
+		context.primary = React.createElement( NotificationsComponent, {
+			userSettings: userSettings,
+			path: context.path,
+		} );
+		next();
 	},
 
-	comments( context ) {
+	comments( context, next ) {
 		const basePath = context.path;
 
 		// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
@@ -53,16 +49,13 @@ export default {
 			ANALYTICS_PAGE_TITLE + ' > Notifications > Comments on other sites'
 		);
 
-		renderWithReduxStore(
-			React.createElement( CommentSettingsComponent, {
-				path: context.path,
-			} ),
-			document.getElementById( 'primary' ),
-			context.store
-		);
+		context.primary = React.createElement( CommentSettingsComponent, {
+			path: context.path,
+		} );
+		next();
 	},
 
-	updates( context ) {
+	updates( context, next ) {
 		const basePath = context.path;
 
 		// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
@@ -75,16 +68,13 @@ export default {
 			ANALYTICS_PAGE_TITLE + ' > Notifications > Updates from WordPress.com'
 		);
 
-		renderWithReduxStore(
-			React.createElement( WPcomSettingsComponent, {
-				path: context.path,
-			} ),
-			document.getElementById( 'primary' ),
-			context.store
-		);
+		context.primary = React.createElement( WPcomSettingsComponent, {
+			path: context.path,
+		} );
+		next();
 	},
 
-	notificationSubscriptions( context ) {
+	notificationSubscriptions( context, next ) {
 		const basePath = context.path;
 
 		// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
@@ -95,13 +85,10 @@ export default {
 			ANALYTICS_PAGE_TITLE + ' > Notifications > Comments on other sites'
 		);
 
-		renderWithReduxStore(
-			React.createElement( NotificationSubscriptions, {
-				userSettings: userSettings,
-				path: context.path,
-			} ),
-			document.getElementById( 'primary' ),
-			context.store
-		);
+		context.primary = React.createElement( NotificationSubscriptions, {
+			userSettings: userSettings,
+			path: context.path,
+		} );
+		next();
 	},
 };

--- a/client/me/notification-settings/index.js
+++ b/client/me/notification-settings/index.js
@@ -11,14 +11,35 @@ import page from 'page';
  */
 import meController from 'me/controller';
 import controller from './controller';
+import { makeLayout, render as clientRender } from 'controller';
 
 export default function() {
-	page( '/me/notifications', meController.sidebar, controller.notifications );
-	page( '/me/notifications/comments', meController.sidebar, controller.comments );
-	page( '/me/notifications/updates', meController.sidebar, controller.updates );
+	page(
+		'/me/notifications',
+		meController.sidebar,
+		controller.notifications,
+		makeLayout,
+		clientRender
+	);
+	page(
+		'/me/notifications/comments',
+		meController.sidebar,
+		controller.comments,
+		makeLayout,
+		clientRender
+	);
+	page(
+		'/me/notifications/updates',
+		meController.sidebar,
+		controller.updates,
+		makeLayout,
+		clientRender
+	);
 	page(
 		'/me/notifications/subscriptions',
 		meController.sidebar,
-		controller.notificationSubscriptions
+		controller.notificationSubscriptions,
+		makeLayout,
+		clientRender
 	);
 }

--- a/client/me/purchases/controller.jsx
+++ b/client/me/purchases/controller.jsx
@@ -22,7 +22,7 @@ import NoSitesMessage from 'components/empty-content/no-sites-message';
 import paths from './paths';
 import PurchasesHeader from './purchases-list/header';
 import PurchasesList from './purchases-list';
-import { concatTitle, recordPageView, renderWithReduxStore } from 'lib/react-helpers';
+import { concatTitle, recordPageView } from 'lib/react-helpers';
 import { setDocumentHeadTitle } from 'state/document-head/actions';
 import titles from './titles';
 import userFactory from 'lib/user';
@@ -36,100 +36,88 @@ function setTitle( context, ...title ) {
 }
 
 export default {
-	addCardDetails( context ) {
+	addCardDetails( context, next ) {
 		setTitle( context, titles.addCardDetails );
 
 		recordPurchasesPageView( paths.addCardDetails(), 'Add Card Details' );
 
-		renderWithReduxStore(
-			<AddCardDetails purchaseId={ parseInt( context.params.purchaseId, 10 ) } />,
-			document.getElementById( 'primary' ),
-			context.store
-		);
+		context.primary = <AddCardDetails purchaseId={ parseInt( context.params.purchaseId, 10 ) } />;
+		next();
 	},
 
-	addCreditCard( context ) {
+	addCreditCard( context, next ) {
 		recordPurchasesPageView( paths.addCreditCard(), 'Add Credit Card' );
 
-		renderWithReduxStore( <AddCreditCard />, document.getElementById( 'primary' ), context.store );
+		context.primary = <AddCreditCard />;
+		next();
 	},
 
-	cancelPrivacyProtection( context ) {
+	cancelPrivacyProtection( context, next ) {
 		setTitle( context, titles.cancelPrivacyProtection );
 
 		recordPurchasesPageView( paths.cancelPrivacyProtection(), 'Cancel Privacy Protection' );
 
-		renderWithReduxStore(
-			<CancelPrivacyProtection purchaseId={ parseInt( context.params.purchaseId, 10 ) } />,
-			document.getElementById( 'primary' ),
-			context.store
+		context.primary = (
+			<CancelPrivacyProtection purchaseId={ parseInt( context.params.purchaseId, 10 ) } />
 		);
+		next();
 	},
 
-	cancelPurchase( context ) {
+	cancelPurchase( context, next ) {
 		setTitle( context, titles.cancelPurchase );
 
 		recordPurchasesPageView( paths.cancelPurchase(), 'Cancel Purchase' );
 
-		renderWithReduxStore(
-			<CancelPurchase purchaseId={ parseInt( context.params.purchaseId, 10 ) } />,
-			document.getElementById( 'primary' ),
-			context.store
-		);
+		context.primary = <CancelPurchase purchaseId={ parseInt( context.params.purchaseId, 10 ) } />;
+		next();
 	},
 
-	confirmCancelDomain( context ) {
+	confirmCancelDomain( context, next ) {
 		setTitle( context, titles.confirmCancelDomain );
 
 		recordPurchasesPageView( paths.confirmCancelDomain(), 'Confirm Cancel Domain' );
 
-		renderWithReduxStore(
-			<ConfirmCancelDomain purchaseId={ parseInt( context.params.purchaseId, 10 ) } />,
-			document.getElementById( 'primary' ),
-			context.store
+		context.primary = (
+			<ConfirmCancelDomain purchaseId={ parseInt( context.params.purchaseId, 10 ) } />
 		);
+		next();
 	},
 
-	editCardDetails( context ) {
+	editCardDetails( context, next ) {
 		setTitle( context, titles.editCardDetails );
 
 		recordPurchasesPageView( paths.editCardDetails(), 'Edit Card Details' );
 
-		renderWithReduxStore(
+		context.primary = (
 			<EditCardDetails
 				cardId={ context.params.cardId }
 				purchaseId={ parseInt( context.params.purchaseId, 10 ) }
-			/>,
-			document.getElementById( 'primary' ),
-			context.store
+			/>
 		);
+		next();
 	},
 
-	list( context ) {
+	list( context, next ) {
 		setTitle( context );
 
 		recordPurchasesPageView( paths.purchasesRoot() );
 
-		renderWithReduxStore(
-			<PurchasesList noticeType={ context.params.noticeType } />,
-			document.getElementById( 'primary' ),
-			context.store
-		);
+		context.primary = <PurchasesList noticeType={ context.params.noticeType } />;
+		next();
 	},
 
-	managePurchase( context ) {
+	managePurchase( context, next ) {
 		setTitle( context, titles.managePurchase );
 
 		recordPurchasesPageView( paths.managePurchase(), 'Manage Purchase' );
 
-		renderWithReduxStore(
+		context.primary = (
 			<ManagePurchase
 				purchaseId={ parseInt( context.params.purchaseId, 10 ) }
 				destinationType={ context.params.destinationType }
-			/>,
-			document.getElementById( 'primary' ),
-			context.store
+			/>
 		);
+		next();
 	},
 
 	noSitesMessage( context, next ) {
@@ -141,13 +129,11 @@ export default {
 
 		recordPurchasesPageView( context.path, 'No Sites' );
 
-		renderWithReduxStore(
+		context.primary = (
 			<Main>
 				<PurchasesHeader section={ 'purchases' } />
 				<NoSitesMessage />
-			</Main>,
-			document.getElementById( 'primary' ),
-			context.store
+			</Main>
 		);
 	},
 };

--- a/client/me/purchases/index.js
+++ b/client/me/purchases/index.js
@@ -14,27 +14,55 @@ import meController from 'me/controller';
 import { siteSelection } from 'my-sites/controller';
 import controller from './controller';
 import paths from './paths';
+import { makeLayout, render as clientRender } from 'controller';
 
 export default function() {
 	if ( config.isEnabled( 'manage/payment-methods' ) ) {
-		page( paths.addCreditCard(), meController.sidebar, controller.addCreditCard );
+		page(
+			paths.addCreditCard(),
+			meController.sidebar,
+			controller.addCreditCard,
+			makeLayout,
+			clientRender
+		);
 
 		// redirect legacy urls
 		page( '/payment-methods/add-credit-card', () => page.redirect( paths.addCreditCard() ) );
 	}
 
-	page( paths.billingHistory(), meController.sidebar, billingController.billingHistory );
+	page(
+		paths.billingHistory(),
+		meController.sidebar,
+		billingController.billingHistory,
+		makeLayout,
+		clientRender
+	);
 
-	page( paths.billingHistoryReceipt(), meController.sidebar, billingController.transaction );
+	page(
+		paths.billingHistoryReceipt(),
+		meController.sidebar,
+		billingController.transaction,
+		makeLayout,
+		clientRender
+	);
 
-	page( paths.purchasesRoot(), meController.sidebar, controller.noSitesMessage, controller.list );
+	page(
+		paths.purchasesRoot(),
+		meController.sidebar,
+		controller.noSitesMessage,
+		controller.list,
+		makeLayout,
+		clientRender
+	);
 
 	page(
 		paths.managePurchase(),
 		meController.sidebar,
 		controller.noSitesMessage,
 		siteSelection,
-		controller.managePurchase
+		controller.managePurchase,
+		makeLayout,
+		clientRender
 	);
 
 	page(
@@ -42,7 +70,9 @@ export default function() {
 		meController.sidebar,
 		controller.noSitesMessage,
 		siteSelection,
-		controller.cancelPurchase
+		controller.cancelPurchase,
+		makeLayout,
+		clientRender
 	);
 
 	page(
@@ -50,7 +80,9 @@ export default function() {
 		meController.sidebar,
 		controller.noSitesMessage,
 		siteSelection,
-		controller.cancelPrivacyProtection
+		controller.cancelPrivacyProtection,
+		makeLayout,
+		clientRender
 	);
 
 	page(
@@ -58,7 +90,9 @@ export default function() {
 		meController.sidebar,
 		controller.noSitesMessage,
 		siteSelection,
-		controller.confirmCancelDomain
+		controller.confirmCancelDomain,
+		makeLayout,
+		clientRender
 	);
 
 	page(
@@ -66,7 +100,9 @@ export default function() {
 		meController.sidebar,
 		controller.noSitesMessage,
 		siteSelection,
-		controller.addCardDetails
+		controller.addCardDetails,
+		makeLayout,
+		clientRender
 	);
 
 	page(
@@ -74,7 +110,9 @@ export default function() {
 		meController.sidebar,
 		controller.noSitesMessage,
 		siteSelection,
-		controller.editCardDetails
+		controller.editCardDetails,
+		makeLayout,
+		clientRender
 	);
 
 	// redirect legacy urls

--- a/client/me/security/controller.js
+++ b/client/me/security/controller.js
@@ -14,12 +14,11 @@ import i18n from 'i18n-calypso';
 import analytics from 'lib/analytics';
 import notices from 'notices';
 import userSettings from 'lib/user-settings';
-import { renderWithReduxStore } from 'lib/react-helpers';
 
 const ANALYTICS_PAGE_TITLE = 'Me';
 
 export default {
-	password( context ) {
+	password( context, next ) {
 		const PasswordComponent = require( 'me/security/main' );
 		const basePath = context.path;
 		const accountPasswordData = require( 'lib/account-password-data' );
@@ -34,82 +33,67 @@ export default {
 
 		analytics.pageView.record( basePath, ANALYTICS_PAGE_TITLE + ' > Password' );
 
-		renderWithReduxStore(
-			React.createElement( PasswordComponent, {
-				userSettings: userSettings,
-				path: context.path,
-				accountPasswordData: accountPasswordData,
-			} ),
-			document.getElementById( 'primary' ),
-			context.store
-		);
+		context.primary = React.createElement( PasswordComponent, {
+			userSettings: userSettings,
+			path: context.path,
+			accountPasswordData: accountPasswordData,
+		} );
+		next();
 	},
 
-	twoStep( context ) {
+	twoStep( context, next ) {
 		const TwoStepComponent = require( 'me/two-step' ),
 			basePath = context.path,
 			appPasswordsData = require( 'lib/application-passwords-data' );
 
 		analytics.pageView.record( basePath, ANALYTICS_PAGE_TITLE + ' > Two-Step Authentication' );
 
-		renderWithReduxStore(
-			React.createElement( TwoStepComponent, {
-				userSettings: userSettings,
-				path: context.path,
-				appPasswordsData: appPasswordsData,
-			} ),
-			document.getElementById( 'primary' ),
-			context.store
-		);
+		context.primary = React.createElement( TwoStepComponent, {
+			userSettings: userSettings,
+			path: context.path,
+			appPasswordsData: appPasswordsData,
+		} );
+		next();
 	},
 
-	connectedApplications( context ) {
+	connectedApplications( context, next ) {
 		const ConnectedAppsComponent = require( 'me/connected-applications' ),
 			basePath = context.path,
 			connectedAppsData = require( 'lib/connected-applications-data' );
 
 		analytics.pageView.record( basePath, ANALYTICS_PAGE_TITLE + ' > Connected Applications' );
 
-		renderWithReduxStore(
-			React.createElement( ConnectedAppsComponent, {
-				userSettings: userSettings,
-				path: context.path,
-				connectedAppsData: connectedAppsData,
-			} ),
-			document.getElementById( 'primary' ),
-			context.store
-		);
+		context.primary = React.createElement( ConnectedAppsComponent, {
+			userSettings: userSettings,
+			path: context.path,
+			connectedAppsData: connectedAppsData,
+		} );
+		next();
 	},
 
-	accountRecovery( context ) {
+	accountRecovery( context, next ) {
 		const AccountRecoveryComponent = require( 'me/security-account-recovery' ),
 			basePath = context.path;
 
 		analytics.pageView.record( basePath, ANALYTICS_PAGE_TITLE + ' > Account Recovery' );
 
-		renderWithReduxStore(
-			React.createElement( AccountRecoveryComponent, {
-				userSettings: userSettings,
-				path: basePath,
-			} ),
-			document.getElementById( 'primary' ),
-			context.store
-		);
+		context.primary = React.createElement( AccountRecoveryComponent, {
+			userSettings: userSettings,
+			path: basePath,
+		} );
+		next();
 	},
 
-	socialLogin( context ) {
+	socialLogin( context, next ) {
 		const SocialLoginComponent = require( 'me/social-login' );
 		const basePath = context.path;
 
 		analytics.pageView.record( basePath, ANALYTICS_PAGE_TITLE + ' > Social Login' );
 
-		renderWithReduxStore(
-			React.createElement( SocialLoginComponent, {
-				userSettings: userSettings,
-				path: basePath,
-			} ),
-			document.getElementById( 'primary' ),
-			context.store
-		);
+		context.primary = React.createElement( SocialLoginComponent, {
+			userSettings: userSettings,
+			path: basePath,
+		} );
+		next();
 	},
 };

--- a/client/me/security/index.js
+++ b/client/me/security/index.js
@@ -12,24 +12,47 @@ import page from 'page';
 import config from 'config';
 import meController from 'me/controller';
 import controller from './controller';
+import { makeLayout, render as clientRender } from 'controller';
 
 export default function() {
-	page( '/me/security', meController.sidebar, controller.password );
+	page( '/me/security', meController.sidebar, controller.password, makeLayout, clientRender );
 
 	if ( config.isEnabled( 'signup/social-management' ) ) {
-		page( '/me/security/social-login', meController.sidebar, controller.socialLogin );
+		page(
+			'/me/security/social-login',
+			meController.sidebar,
+			controller.socialLogin,
+			makeLayout,
+			clientRender
+		);
 	}
 
-	page( '/me/security/two-step', meController.sidebar, controller.twoStep );
+	page(
+		'/me/security/two-step',
+		meController.sidebar,
+		controller.twoStep,
+		makeLayout,
+		clientRender
+	);
 	page(
 		'/me/security/connected-applications',
 		meController.sidebar,
-		controller.connectedApplications
+		controller.connectedApplications,
+		makeLayout,
+		clientRender
 	);
 	page(
 		'/me/security/connected-applications/:application_id',
 		meController.sidebar,
-		controller.connectedApplication
+		controller.connectedApplication,
+		makeLayout,
+		clientRender
 	);
-	page( '/me/security/account-recovery', meController.sidebar, controller.accountRecovery );
+	page(
+		'/me/security/account-recovery',
+		meController.sidebar,
+		controller.accountRecovery,
+		makeLayout,
+		clientRender
+	);
 }

--- a/client/my-sites/ads/controller.js
+++ b/client/my-sites/ads/controller.js
@@ -17,7 +17,6 @@ import titlecase from 'to-title-case';
 import { canAccessWordads } from 'lib/ads/utils';
 import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
 import { userCan } from 'lib/site/utils';
-import { renderWithReduxStore } from 'lib/react-helpers';
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
 import Ads from 'my-sites/ads/main';
@@ -49,7 +48,7 @@ export default {
 		return;
 	},
 
-	layout: function( context ) {
+	layout: function( context, next ) {
 		const site = getSelectedSite( context.store.getState() );
 		const pathSuffix = site ? '/' + site.slug : '';
 		const layoutTitle = _getLayoutTitle( context );
@@ -73,13 +72,10 @@ export default {
 			window.scrollTo( 0, 0 );
 		}
 
-		renderWithReduxStore(
-			React.createElement( Ads, {
-				section: context.params.section,
-				path: context.path,
-			} ),
-			document.getElementById( 'primary' ),
-			context.store
-		);
+		context.primary = React.createElement( Ads, {
+			section: context.params.section,
+			path: context.path,
+		} );
+		next();
 	},
 };

--- a/client/my-sites/ads/index.js
+++ b/client/my-sites/ads/index.js
@@ -9,9 +9,17 @@ import page from 'page';
  */
 import { navigation, siteSelection, sites } from 'my-sites/controller';
 import adsController from './controller';
+import { makeLayout, render as clientRender } from 'controller';
 
 export default function() {
-	page( '/ads', siteSelection, sites );
-	page( '/ads/:site_id', adsController.redirect );
-	page( '/ads/:section/:site_id', siteSelection, navigation, adsController.layout );
+	page( '/ads', siteSelection, sites, makeLayout, clientRender );
+	page( '/ads/:site_id', adsController.redirect, makeLayout, clientRender );
+	page(
+		'/ads/:section/:site_id',
+		siteSelection,
+		navigation,
+		adsController.layout,
+		makeLayout,
+		clientRender
+	);
 }

--- a/client/my-sites/checklist/controller/index.jsx
+++ b/client/my-sites/checklist/controller/index.jsx
@@ -10,9 +10,9 @@ import React from 'react';
  * Internal Dependencies
  */
 
-import { renderWithReduxStore } from 'lib/react-helpers';
 import ChecklistShow from '../checklist-show';
 
-export function show( context ) {
-	renderWithReduxStore( <ChecklistShow />, 'primary', context.store );
+export function show( context, next ) {
+	context.primary = <ChecklistShow />;
+	next();
 }

--- a/client/my-sites/checklist/index.js
+++ b/client/my-sites/checklist/index.js
@@ -12,10 +12,11 @@ import page from 'page';
 import { navigation, siteSelection, sites } from 'my-sites/controller';
 import { show } from './controller';
 import config from 'config';
+import { makeLayout, render as clientRender } from 'controller';
 
 export default function() {
 	if ( config.isEnabled( 'onboarding-checklist' ) ) {
-		page( '/checklist', siteSelection, sites );
-		page( '/checklist/:site_id', siteSelection, navigation, show );
+		page( '/checklist', siteSelection, sites, makeLayout, clientRender );
+		page( '/checklist/:site_id', siteSelection, navigation, show, makeLayout, clientRender );
 	}
 }

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -5,7 +5,6 @@
  */
 
 import i18n from 'i18n-calypso';
-import ReactDom from 'react-dom';
 import React from 'react';
 import { isEmpty } from 'lodash';
 import page, { Route } from 'page';
@@ -19,7 +18,6 @@ import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
 import { setSection } from 'state/ui/actions';
 import productsFactory from 'lib/products-list';
 import upgradesActions from 'lib/upgrades/actions';
-import { renderWithReduxStore } from 'lib/react-helpers';
 import { getSiteBySlug } from 'state/sites/selectors';
 import { getSelectedSite } from 'state/ui/selectors';
 import GsuiteNudge from 'my-sites/checkout/gsuite-nudge';
@@ -37,7 +35,7 @@ const checkoutRoutes = [
 ];
 
 export default {
-	checkout: function( context ) {
+	checkout: function( context, next ) {
 		const Checkout = require( './checkout' ),
 			CheckoutData = require( 'components/data/checkout' ),
 			CartData = require( 'components/data/cart' ),
@@ -58,7 +56,7 @@ export default {
 		// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
 		context.store.dispatch( setTitle( i18n.translate( 'Checkout' ) ) );
 
-		renderWithReduxStore(
+		context.primary = (
 			<CheckoutData>
 				<Checkout
 					product={ product }
@@ -67,21 +65,18 @@ export default {
 					selectedFeature={ selectedFeature }
 					couponCode={ context.query.code }
 				/>
-			</CheckoutData>,
-			document.getElementById( 'primary' ),
-			context.store
+			</CheckoutData>
 		);
 
-		renderWithReduxStore(
+		context.secondary = (
 			<CartData>
 				<SecondaryCart selectedSite={ selectedSite } />
-			</CartData>,
-			document.getElementById( 'secondary' ),
-			context.store
+			</CartData>
 		);
+		next();
 	},
 
-	sitelessCheckout: function( context ) {
+	sitelessCheckout: function( context, next ) {
 		const Checkout = require( './checkout' ),
 			CheckoutData = require( 'components/data/checkout' ),
 			CartData = require( 'components/data/cart' ),
@@ -92,24 +87,21 @@ export default {
 		// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
 		context.store.dispatch( setTitle( i18n.translate( 'Checkout' ) ) );
 
-		renderWithReduxStore(
+		context.primary = (
 			<CheckoutData>
 				<Checkout reduxStore={ context.store } productsList={ productsList } />
-			</CheckoutData>,
-			document.getElementById( 'primary' ),
-			context.store
+			</CheckoutData>
 		);
 
-		renderWithReduxStore(
+		context.secondary = (
 			<CartData>
 				<SecondaryCart />
-			</CartData>,
-			document.getElementById( 'secondary' ),
-			context.store
+			</CartData>
 		);
+		next();
 	},
 
-	checkoutThankYou: function( context ) {
+	checkoutThankYou: function( context, next ) {
 		const CheckoutThankYouComponent = require( './checkout-thank-you' ),
 			{ routePath, routeParams } = route.sectionifyWithRoutes( context.path, checkoutRoutes ),
 			receiptId = Number( context.params.receiptId ),
@@ -125,7 +117,7 @@ export default {
 		const state = context.store.getState();
 		const selectedSite = getSelectedSite( state );
 
-		renderWithReduxStore(
+		context.primary = (
 			<CheckoutThankYouComponent
 				productsList={ productsList }
 				receiptId={ receiptId }
@@ -133,15 +125,13 @@ export default {
 				domainOnlySiteFlow={ isEmpty( context.params.site ) }
 				selectedFeature={ context.params.feature }
 				selectedSite={ selectedSite }
-			/>,
-			document.getElementById( 'primary' ),
-			context.store
+			/>
 		);
 
-		ReactDom.unmountComponentAtNode( document.getElementById( 'secondary' ) );
+		next();
 	},
 
-	gsuiteNudge( context ) {
+	gsuiteNudge( context, next ) {
 		const { domain, site, receiptId } = context.params;
 		context.store.dispatch( setSection( { name: 'gsuite-nudge' }, { hasSidebar: false } ) );
 
@@ -167,7 +157,7 @@ export default {
 			page( `/checkout/thank-you/${ siteSlug }/${ receiptId }` );
 		};
 
-		renderWithReduxStore(
+		context.primary = (
 			<GsuiteNudge
 				domain={ domain }
 				productsList={ productsList }
@@ -175,11 +165,9 @@ export default {
 				selectedSiteId={ selectedSite.ID }
 				onAddGoogleApps={ handleAddGoogleApps }
 				onClickSkip={ handleClickSkip }
-			/>,
-			document.getElementById( 'primary' ),
-			context.store
+			/>
 		);
 
-		ReactDom.unmountComponentAtNode( document.getElementById( 'secondary' ) );
+		next();
 	},
 };

--- a/client/my-sites/checkout/index.js
+++ b/client/my-sites/checkout/index.js
@@ -10,50 +10,81 @@ import page from 'page';
 import { noSite, siteSelection } from 'my-sites/controller';
 import checkoutController from './controller';
 import SiftScience from 'lib/siftscience';
+import { makeLayout, render as clientRender } from 'controller';
 
 export default function() {
 	SiftScience.recordUser();
 
-	page( '/checkout/thank-you/no-site/:receiptId?', noSite, checkoutController.checkoutThankYou );
+	page(
+		'/checkout/thank-you/no-site/:receiptId?',
+		noSite,
+		checkoutController.checkoutThankYou,
+		makeLayout,
+		clientRender
+	);
 
 	page(
 		'/checkout/thank-you/:site/:receiptId?',
 		siteSelection,
-		checkoutController.checkoutThankYou
+		checkoutController.checkoutThankYou,
+		makeLayout,
+		clientRender
 	);
 
 	page(
 		'/checkout/thank-you/:site/:receiptId/with-gsuite/:gsuiteReceiptId',
 		siteSelection,
-		checkoutController.checkoutThankYou
+		checkoutController.checkoutThankYou,
+		makeLayout,
+		clientRender
 	);
 
 	page(
 		'/checkout/features/:feature/:domain/:plan_name?',
 		siteSelection,
-		checkoutController.checkout
+		checkoutController.checkout,
+		makeLayout,
+		clientRender
 	);
 
 	page(
 		'/checkout/thank-you/features/:feature/:site/:receiptId?',
 		siteSelection,
-		checkoutController.checkoutThankYou
+		checkoutController.checkoutThankYou,
+		makeLayout,
+		clientRender
 	);
 
-	page( '/checkout/no-site', noSite, checkoutController.sitelessCheckout );
+	page(
+		'/checkout/no-site',
+		noSite,
+		checkoutController.sitelessCheckout,
+		makeLayout,
+		clientRender
+	);
 
-	page( '/checkout/:domain/:product?', siteSelection, checkoutController.checkout );
+	page(
+		'/checkout/:domain/:product?',
+		siteSelection,
+		checkoutController.checkout,
+		makeLayout,
+		clientRender
+	);
 
 	page(
 		'/checkout/:product/renew/:purchaseId/:domain',
 		siteSelection,
-		checkoutController.checkout
+		checkoutController.checkout,
+		makeLayout,
+		clientRender
 	);
 
 	page(
 		'/checkout/:site/with-gsuite/:domain/:receiptId?',
 		siteSelection,
-		checkoutController.gsuiteNudge
+		checkoutController.gsuiteNudge,
+		makeLayout,
+		clientRender
 	);
 
 	// Visting /checkout without a plan or product should be redirected to /plans

--- a/client/my-sites/comments/controller.js
+++ b/client/my-sites/comments/controller.js
@@ -9,7 +9,6 @@ import { each, isNaN, startsWith } from 'lodash';
 /**
  * Internal dependencies
  */
-import { renderWithReduxStore } from 'lib/react-helpers';
 import route, { addQueryArgs } from 'lib/route';
 import CommentsManagement from './main';
 import CommentView from 'my-sites/comment/main';
@@ -47,7 +46,7 @@ const changePage = path => pageNumber => {
 	return page( addQueryArgs( { page: pageNumber }, path ) );
 };
 
-export const siteComments = context => {
+export const siteComments = ( context, next ) => {
 	const { params, path, query } = context;
 	const siteFragment = route.getSiteFragment( path );
 
@@ -59,19 +58,18 @@ export const siteComments = context => {
 
 	const pageNumber = sanitizeInt( query.page ) || 1;
 
-	renderWithReduxStore(
+	context.primary = (
 		<CommentsManagement
 			changePage={ changePage( path ) }
 			page={ pageNumber }
 			siteFragment={ siteFragment }
 			status={ status }
-		/>,
-		'primary',
-		context.store
+		/>
 	);
+	next();
 };
 
-export const postComments = context => {
+export const postComments = ( context, next ) => {
 	const { params, path, query } = context;
 	const siteFragment = route.getSiteFragment( path );
 
@@ -88,20 +86,19 @@ export const postComments = context => {
 
 	const pageNumber = sanitizeInt( query.page ) || 1;
 
-	renderWithReduxStore(
+	context.primary = (
 		<CommentsManagement
 			changePage={ changePage( path ) }
 			page={ pageNumber }
 			postId={ postId }
 			siteFragment={ siteFragment }
 			status={ status }
-		/>,
-		'primary',
-		context.store
+		/>
 	);
+	next();
 };
 
-export const comment = context => {
+export const comment = ( context, next ) => {
 	const { params, path, query } = context;
 	const siteFragment = route.getSiteFragment( path );
 	const commentId = sanitizeInt( params.comment );
@@ -116,11 +113,8 @@ export const comment = context => {
 	const redirectToPostView = postId => () =>
 		page.redirect( `/comments/all/${ siteFragment }/${ postId }` );
 
-	renderWithReduxStore(
-		<CommentView { ...{ action, commentId, siteFragment, redirectToPostView } } />,
-		'primary',
-		context.store
-	);
+	context.primary = <CommentView { ...{ action, commentId, siteFragment, redirectToPostView } } />;
+	next();
 };
 
 export const redirect = ( { path } ) => {

--- a/client/my-sites/comments/index.js
+++ b/client/my-sites/comments/index.js
@@ -46,10 +46,10 @@ export default function() {
 		makeLayout,
 		clientRender
 	);
-	page( '/comments/*', siteSelection, redirect, makeLayout, clientRender );
-	page( '/comments', siteSelection, redirect, makeLayout, clientRender );
-	page( '/comment/*', siteSelection, redirect, makeLayout, clientRender );
-	page( '/comment', siteSelection, redirect, makeLayout, clientRender );
+	page( '/comments/*', siteSelection, redirect );
+	page( '/comments', siteSelection, redirect );
+	page( '/comment/*', siteSelection, redirect );
+	page( '/comment', siteSelection, redirect );
 
 	// Leaving Comment Management
 	page.exit( '/comments/*', clearCommentNotices );

--- a/client/my-sites/comments/index.js
+++ b/client/my-sites/comments/index.js
@@ -10,6 +10,7 @@ import page from 'page';
 import { siteSelection, navigation, sites } from 'my-sites/controller';
 import { clearCommentNotices, comment, postComments, redirect, siteComments } from './controller';
 import config from 'config';
+import { makeLayout, render as clientRender } from 'controller';
 
 export default function() {
 	// Site View
@@ -17,7 +18,9 @@ export default function() {
 		'/comments/:status(all|pending|approved|spam|trash)/:site',
 		siteSelection,
 		navigation,
-		siteComments
+		siteComments,
+		makeLayout,
+		clientRender
 	);
 
 	// Post View
@@ -25,20 +28,28 @@ export default function() {
 		'/comments/:status(all|pending|approved|spam|trash)/:site/:post',
 		siteSelection,
 		navigation,
-		postComments
+		postComments,
+		makeLayout,
+		clientRender
 	);
 
 	// Comment View
 	if ( config.isEnabled( 'comments/management/comment-view' ) ) {
-		page( '/comment/:site/:comment', siteSelection, navigation, comment );
+		page( '/comment/:site/:comment', siteSelection, navigation, comment, makeLayout, clientRender );
 	}
 
 	// Redirect
-	page( '/comments/:status(all|pending|approved|spam|trash)', siteSelection, sites );
-	page( '/comments/*', siteSelection, redirect );
-	page( '/comments', siteSelection, redirect );
-	page( '/comment/*', siteSelection, redirect );
-	page( '/comment', siteSelection, redirect );
+	page(
+		'/comments/:status(all|pending|approved|spam|trash)',
+		siteSelection,
+		sites,
+		makeLayout,
+		clientRender
+	);
+	page( '/comments/*', siteSelection, redirect, makeLayout, clientRender );
+	page( '/comments', siteSelection, redirect, makeLayout, clientRender );
+	page( '/comment/*', siteSelection, redirect, makeLayout, clientRender );
+	page( '/comment', siteSelection, redirect, makeLayout, clientRender );
 
 	// Leaving Comment Management
 	page.exit( '/comments/*', clearCommentNotices );

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -5,7 +5,6 @@
  */
 
 import page from 'page';
-import ReactDom from 'react-dom';
 import React from 'react';
 import i18n from 'i18n-calypso';
 import { uniq, some, startsWith } from 'lodash';
@@ -32,7 +31,6 @@ import notices from 'notices';
 import config from 'config';
 import analytics from 'lib/analytics';
 import { setLayoutFocus } from 'state/ui/layout-focus/actions';
-import { renderWithReduxStore } from 'lib/react-helpers';
 import {
 	getPrimaryDomainBySiteId,
 	getPrimarySiteId,
@@ -106,22 +104,18 @@ function removeSidebar( context ) {
 			secondary: false,
 		} )
 	);
-	ReactDom.unmountComponentAtNode( document.getElementById( 'secondary' ) );
 }
 
-function renderEmptySites( context ) {
+function renderEmptySites( context, next ) {
 	const NoSitesMessage = require( 'components/empty-content/no-sites-message' );
 
 	removeSidebar( context );
 
-	renderWithReduxStore(
-		React.createElement( NoSitesMessage ),
-		document.getElementById( 'primary' ),
-		context.store
-	);
+	context.primary = React.createElement( NoSitesMessage );
+	next();
 }
 
-function renderNoVisibleSites( context ) {
+function renderNoVisibleSites( context, next ) {
 	const EmptyContentComponent = require( 'components/empty-content' );
 	const currentUser = user.get();
 	const hiddenSites = currentUser.site_count - currentUser.visible_site_count;
@@ -129,50 +123,38 @@ function renderNoVisibleSites( context ) {
 
 	removeSidebar( context );
 
-	renderWithReduxStore(
-		React.createElement( EmptyContentComponent, {
-			title: i18n.translate(
-				'You have %(hidden)d hidden WordPress site.',
-				'You have %(hidden)d hidden WordPress sites.',
-				{
-					count: hiddenSites,
-					args: { hidden: hiddenSites },
-				}
-			),
+	context.primary = React.createElement( EmptyContentComponent, {
+		title: i18n.translate(
+			'You have %(hidden)d hidden WordPress site.',
+			'You have %(hidden)d hidden WordPress sites.',
+			{
+				count: hiddenSites,
+				args: { hidden: hiddenSites },
+			}
+		),
 
-			line: i18n.translate(
-				'To manage it here, set it to visible.',
-				'To manage them here, set them to visible.',
-				{
-					count: hiddenSites,
-				}
-			),
+		line: i18n.translate(
+			'To manage it here, set it to visible.',
+			'To manage them here, set them to visible.',
+			{
+				count: hiddenSites,
+			}
+		),
 
-			action: i18n.translate( 'Change Visibility' ),
-			actionURL: '//dashboard.wordpress.com/wp-admin/index.php?page=my-blogs',
-			secondaryAction: i18n.translate( 'Create New Site' ),
-			secondaryActionURL: `${ signup_url }?ref=calypso-nosites`,
-		} ),
-		document.getElementById( 'primary' ),
-		context.store
-	);
+		action: i18n.translate( 'Change Visibility' ),
+		actionURL: '//dashboard.wordpress.com/wp-admin/index.php?page=my-blogs',
+		secondaryAction: i18n.translate( 'Create New Site' ),
+		secondaryActionURL: `${ signup_url }?ref=calypso-nosites`,
+	} );
+	next();
 }
 
 function renderSelectedSiteIsDomainOnly( reactContext, selectedSite ) {
 	const DomainOnly = require( 'my-sites/domains/domain-management/list/domain-only' );
-	const { store: reduxStore } = reactContext;
 
-	renderWithReduxStore(
-		<DomainOnly siteId={ selectedSite.ID } hasNotice={ false } />,
-		document.getElementById( 'primary' ),
-		reduxStore
-	);
+	reactContext.primary = <DomainOnly siteId={ selectedSite.ID } hasNotice={ false } />;
 
-	renderWithReduxStore(
-		createNavigation( reactContext ),
-		document.getElementById( 'secondary' ),
-		reduxStore
-	);
+	reactContext.secondary = createNavigation( reactContext );
 }
 
 function isPathAllowedForDomainOnlySite( path, slug, primaryDomain ) {
@@ -451,11 +433,7 @@ export function makeNavigation( context, next ) {
 
 export function navigation( context, next ) {
 	// Render the My Sites navigation in #secondary
-	renderWithReduxStore(
-		createNavigation( context ),
-		document.getElementById( 'secondary' ),
-		context.store
-	);
+	context.secondary = createNavigation( context );
 	next();
 }
 
@@ -467,12 +445,10 @@ export function jetPackWarning( context, next ) {
 	const selectedSite = getSelectedSite( getState() );
 
 	if ( selectedSite && selectedSite.jetpack && ! isATEnabled( selectedSite ) ) {
-		renderWithReduxStore(
+		context.primary = (
 			<Main>
 				<JetpackManageErrorPage template="noDomainsOnJetpack" siteId={ selectedSite.ID } />
-			</Main>,
-			document.getElementById( 'primary' ),
-			context.store
+			</Main>
 		);
 
 		analytics.pageView.record( basePath, '> No Domains On Jetpack' );
@@ -481,7 +457,7 @@ export function jetPackWarning( context, next ) {
 	}
 }
 
-export function sites( context ) {
+export function sites( context, next ) {
 	const { dispatch } = getStore( context );
 	if ( context.query.verified === '1' ) {
 		notices.success(
@@ -496,11 +472,8 @@ export function sites( context ) {
 	removeSidebar( context );
 	dispatch( setLayoutFocus( 'content' ) );
 
-	renderWithReduxStore(
-		createSitesComponent( context ),
-		document.getElementById( 'primary' ),
-		context.store
-	);
+	context.primary = createSitesComponent( context );
+	next();
 }
 
 /**

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -426,11 +426,6 @@ export function jetpackModuleActive( moduleId, redirect ) {
 	};
 }
 
-export function makeNavigation( context, next ) {
-	context.secondary = createNavigation( context );
-	next();
-}
-
 export function navigation( context, next ) {
 	// Render the My Sites navigation in #secondary
 	context.secondary = createNavigation( context );

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -452,8 +452,13 @@ export function jetPackWarning( context, next ) {
 	}
 }
 
+/**
+ * Middleware that adds the site selector screen to the layout.
+ *
+ * @param {object} context -- Middleware context
+ * @param {function} next -- Call next middleware in chain
+ */
 export function sites( context, next ) {
-	const { dispatch } = getStore( context );
 	if ( context.query.verified === '1' ) {
 		notices.success(
 			i18n.translate(
@@ -461,28 +466,7 @@ export function sites( context, next ) {
 			)
 		);
 	}
-	/**
-	 * Sites is rendered on #primary but it doesn't expect a sidebar to exist
-	 */
-	removeSidebar( context );
-	dispatch( setLayoutFocus( 'content' ) );
 
-	context.primary = createSitesComponent( context );
-	next();
-}
-
-/**
- * Middleware that adds the site selector screen to the layout
- * without rendering the layout. For use with isomorphic routing
- * @see {@link https://github.com/Automattic/wp-calypso/blob/master/docs/isomorphic-routing.md }
- *
- * To show the site selector screen using traditional multi-tree
- * layout, use the sites() middleware above.
- *
- * @param {object} context -- Middleware context
- * @param {function} next -- Call next middleware in chain
- */
-export function makeSites( context, next ) {
 	context.store.dispatch( setLayoutFocus( 'content' ) );
 	context.store.dispatch(
 		setSection( {

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -7,7 +7,7 @@
 import page from 'page';
 import React from 'react';
 import i18n from 'i18n-calypso';
-import { uniq, some, startsWith } from 'lodash';
+import { noop, some, startsWith, uniq } from 'lodash';
 
 /**
  * Internal Dependencies
@@ -58,6 +58,7 @@ import {
 import SitesComponent from 'my-sites/sites';
 import { isATEnabled } from 'lib/automated-transfer';
 import { warningNotice } from 'state/notices/actions';
+import { makeLayout, render as clientRender } from 'controller';
 
 /*
  * @FIXME Shorthand, but I might get rid of this.
@@ -106,16 +107,18 @@ function removeSidebar( context ) {
 	);
 }
 
-function renderEmptySites( context, next ) {
+function renderEmptySites( context ) {
 	const NoSitesMessage = require( 'components/empty-content/no-sites-message' );
 
 	removeSidebar( context );
 
 	context.primary = React.createElement( NoSitesMessage );
-	next();
+
+	makeLayout( context, noop );
+	clientRender( context );
 }
 
-function renderNoVisibleSites( context, next ) {
+function renderNoVisibleSites( context ) {
 	const EmptyContentComponent = require( 'components/empty-content' );
 	const currentUser = user.get();
 	const hiddenSites = currentUser.site_count - currentUser.visible_site_count;
@@ -146,7 +149,9 @@ function renderNoVisibleSites( context, next ) {
 		secondaryAction: i18n.translate( 'Create New Site' ),
 		secondaryActionURL: `${ signup_url }?ref=calypso-nosites`,
 	} );
-	next();
+
+	makeLayout( context, noop );
+	clientRender( context );
 }
 
 function renderSelectedSiteIsDomainOnly( reactContext, selectedSite ) {
@@ -155,6 +160,9 @@ function renderSelectedSiteIsDomainOnly( reactContext, selectedSite ) {
 	reactContext.primary = <DomainOnly siteId={ selectedSite.ID } hasNotice={ false } />;
 
 	reactContext.secondary = createNavigation( reactContext );
+
+	makeLayout( reactContext, noop );
+	clientRender( reactContext );
 }
 
 function isPathAllowedForDomainOnlySite( path, slug, primaryDomain ) {

--- a/client/my-sites/customize/controller.js
+++ b/client/my-sites/customize/controller.js
@@ -5,7 +5,6 @@
  */
 
 import i18n from 'i18n-calypso';
-import ReactDom from 'react-dom';
 import React from 'react';
 import { Provider as ReduxProvider } from 'react-redux';
 
@@ -16,7 +15,7 @@ import { sectionify } from 'lib/route/path';
 import analytics from 'lib/analytics';
 import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
 
-export function customize( context ) {
+export function customize( context, next ) {
 	const CustomizeComponent = require( 'my-sites/customize/main' ),
 		basePath = sectionify( context.path );
 
@@ -25,18 +24,16 @@ export function customize( context ) {
 	// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
 	context.store.dispatch( setTitle( i18n.translate( 'Customizer', { textOnly: true } ) ) );
 
-	ReactDom.render(
-		React.createElement(
-			ReduxProvider,
-			{ store: context.store },
-			React.createElement( CustomizeComponent, {
-				domain: context.params.domain || '',
-				pathname: context.pathname,
-				prevPath: context.prevPath || '',
-				query: context.query,
-				panel: context.params.panel,
-			} )
-		),
-		document.getElementById( 'primary' )
+	context.primary = React.createElement(
+		ReduxProvider,
+		{ store: context.store },
+		React.createElement( CustomizeComponent, {
+			domain: context.params.domain || '',
+			pathname: context.pathname,
+			prevPath: context.prevPath || '',
+			query: context.query,
+			panel: context.params.panel,
+		} )
 	);
+	next();
 }

--- a/client/my-sites/customize/controller.js
+++ b/client/my-sites/customize/controller.js
@@ -6,7 +6,6 @@
 
 import i18n from 'i18n-calypso';
 import React from 'react';
-import { Provider as ReduxProvider } from 'react-redux';
 
 /**
  * Internal Dependencies
@@ -24,16 +23,13 @@ export function customize( context, next ) {
 	// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
 	context.store.dispatch( setTitle( i18n.translate( 'Customizer', { textOnly: true } ) ) );
 
-	context.primary = React.createElement(
-		ReduxProvider,
-		{ store: context.store },
-		React.createElement( CustomizeComponent, {
-			domain: context.params.domain || '',
-			pathname: context.pathname,
-			prevPath: context.prevPath || '',
-			query: context.query,
-			panel: context.params.panel,
-		} )
-	);
+	context.primary = React.createElement( CustomizeComponent, {
+		domain: context.params.domain || '',
+		pathname: context.pathname,
+		prevPath: context.prevPath || '',
+		query: context.query,
+		panel: context.params.panel,
+	} );
+
 	next();
 }

--- a/client/my-sites/customize/index.js
+++ b/client/my-sites/customize/index.js
@@ -12,10 +12,18 @@ import page from 'page';
 import { siteSelection, sites, navigation } from 'my-sites/controller';
 import { customize } from './controller';
 import config from 'config';
+import { makeLayout, render as clientRender } from 'controller';
 
 export default function() {
 	if ( config.isEnabled( 'manage/customize' ) ) {
-		page( '/customize/:panel([^.]+)?', siteSelection, sites );
-		page( '/customize/:panel?/:domain', siteSelection, navigation, customize );
+		page( '/customize/:panel([^.]+)?', siteSelection, sites, makeLayout, clientRender );
+		page(
+			'/customize/:panel?/:domain',
+			siteSelection,
+			navigation,
+			customize,
+			makeLayout,
+			clientRender
+		);
 	}
 }

--- a/client/my-sites/domains/controller.jsx
+++ b/client/my-sites/domains/controller.jsx
@@ -19,7 +19,6 @@ import route from 'lib/route';
 import Main from 'components/main';
 import upgradesActions from 'lib/upgrades/actions';
 import productsFactory from 'lib/products-list';
-import { renderWithReduxStore } from 'lib/react-helpers';
 import { canCurrentUser } from 'state/selectors';
 import { getSelectedSiteId, getSelectedSite, getSelectedSiteSlug } from 'state/ui/selectors';
 import { getCurrentUser } from 'state/current-user/selectors';
@@ -45,7 +44,7 @@ const domainsAddRedirectHeader = ( context, next ) => {
 	next();
 };
 
-const domainSearch = context => {
+const domainSearch = ( context, next ) => {
 	const CartData = require( 'components/data/cart' );
 	const DomainSearch = require( './domain-search' );
 	const basePath = route.sectionify( context.path );
@@ -57,75 +56,71 @@ const domainSearch = context => {
 		window.scrollTo( 0, 0 );
 	}
 
-	renderWithReduxStore(
+	context.primary = (
 		<Main>
 			<DocumentHead title={ translate( 'Domain Search' ) } />
 			<CartData>
 				<DomainSearch basePath={ basePath } context={ context } />
 			</CartData>
-		</Main>,
-		document.getElementById( 'primary' ),
-		context.store
+		</Main>
 	);
+	next();
 };
 
-const siteRedirect = context => {
+const siteRedirect = ( context, next ) => {
 	const CartData = require( 'components/data/cart' );
 	const SiteRedirect = require( './domain-search/site-redirect' );
 	const basePath = route.sectionify( context.path );
 
 	analytics.pageView.record( basePath, 'Domain Search > Site Redirect' );
 
-	renderWithReduxStore(
+	context.primary = (
 		<Main>
 			<DocumentHead title={ translate( 'Redirect a Site' ) } />
 			<CartData>
 				<SiteRedirect />
 			</CartData>
-		</Main>,
-		document.getElementById( 'primary' ),
-		context.store
+		</Main>
 	);
+	next();
 };
 
-const mapDomain = context => {
+const mapDomain = ( context, next ) => {
 	const CartData = require( 'components/data/cart' );
 	const MapDomain = require( 'my-sites/domains/map-domain' ).default;
 	const basePath = route.sectionify( context.path );
 
 	analytics.pageView.record( basePath, 'Domain Search > Domain Mapping' );
-	renderWithReduxStore(
+	context.primary = (
 		<Main>
 			<DocumentHead title={ translate( 'Map a Domain' ) } />
 
 			<CartData>
 				<MapDomain initialQuery={ context.query.initialQuery } />
 			</CartData>
-		</Main>,
-		document.getElementById( 'primary' ),
-		context.store
+		</Main>
 	);
+	next();
 };
 
-const transferDomain = context => {
+const transferDomain = ( context, next ) => {
 	const CartData = require( 'components/data/cart' );
 	const TransferDomain = require( 'my-sites/domains/transfer-domain' ).default;
 	const basePath = route.sectionify( context.path );
 
 	analytics.pageView.record( basePath, 'Domain Search > Domain Transfer' );
-	renderWithReduxStore(
+	context.primary = (
 		<Main>
 			<DocumentHead title={ translate( 'Transfer a Domain' ) } />
 			<CartData>
 				<TransferDomain basePath={ basePath } initialQuery={ context.query.initialQuery } />
 			</CartData>
-		</Main>,
-		document.getElementById( 'primary' ),
-		context.store
+		</Main>
 	);
+	next();
 };
 
-const googleAppsWithRegistration = context => {
+const googleAppsWithRegistration = ( context, next ) => {
 	const CartData = require( 'components/data/cart' );
 	const GoogleApps = require( 'components/upgrades/google-apps' );
 
@@ -150,7 +145,7 @@ const googleAppsWithRegistration = context => {
 		'Domain Search > Domain Registration > Google Apps'
 	);
 
-	renderWithReduxStore(
+	context.primary = (
 		<Main>
 			<DocumentHead
 				title={ translate( 'Register %(domain)s', {
@@ -166,10 +161,9 @@ const googleAppsWithRegistration = context => {
 					onClickSkip={ handleClickSkip }
 				/>
 			</CartData>
-		</Main>,
-		document.getElementById( 'primary' ),
-		context.store
+		</Main>
 	);
+	next();
 };
 
 const redirectIfNoSite = redirectTo => {

--- a/client/my-sites/domains/domain-management/controller.jsx
+++ b/client/my-sites/domains/domain-management/controller.jsx
@@ -20,7 +20,6 @@ import EmailForwardingData from 'components/data/domain-management/email-forward
 import NameserversData from 'components/data/domain-management/nameservers';
 import paths from 'my-sites/domains/paths';
 import ProductsList from 'lib/products-list';
-import { renderWithReduxStore } from 'lib/react-helpers';
 import SiteRedirectData from 'components/data/domain-management/site-redirect';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
@@ -31,21 +30,20 @@ import { decodeURIComponentIfValid } from 'lib/url';
 const productsList = new ProductsList();
 
 export default {
-	domainManagementList( pageContext ) {
+	domainManagementList( pageContext, next ) {
 		analytics.pageView.record( paths.domainManagementList( ':site' ), 'Domain Management' );
 
-		renderWithReduxStore(
+		pageContext.primary = (
 			<DomainManagementData
 				component={ DomainManagement.List }
 				context={ pageContext }
 				productsList={ productsList }
-			/>,
-			document.getElementById( 'primary' ),
-			pageContext.store
+			/>
 		);
+		next();
 	},
 
-	domainManagementEdit( pageContext ) {
+	domainManagementEdit( pageContext, next ) {
 		analytics.pageView.record(
 			paths.domainManagementEdit( ':site', ':domain' ),
 			'Domain Management › Edit'
@@ -54,148 +52,139 @@ export default {
 		const isTransfer = includes( pageContext.path, '/transfer/in/' );
 		const component = isTransfer ? DomainManagement.TransferIn : DomainManagement.Edit;
 
-		renderWithReduxStore(
+		pageContext.primary = (
 			<DomainManagementData
 				component={ component }
 				context={ pageContext }
 				productsList={ productsList }
 				selectedDomainName={ decodeURIComponentIfValid( pageContext.params.domain ) }
-			/>,
-			document.getElementById( 'primary' ),
-			pageContext.store
+			/>
 		);
+		next();
 	},
 
-	domainManagementPrimaryDomain: function( pageContext ) {
+	domainManagementPrimaryDomain: function( pageContext, next ) {
 		analytics.pageView.record(
 			paths.domainManagementPrimaryDomain( ':site', ':domain' ),
 			'Domain Management › Set Primary Domain'
 		);
 
-		renderWithReduxStore(
-			<DomainManagement.PrimaryDomain selectedDomainName={ pageContext.params.domain } />,
-			document.getElementById( 'primary' ),
-			pageContext.store
+		pageContext.primary = (
+			<DomainManagement.PrimaryDomain selectedDomainName={ pageContext.params.domain } />
 		);
+		next();
 	},
 
-	domainManagementContactsPrivacy( pageContext ) {
+	domainManagementContactsPrivacy( pageContext, next ) {
 		analytics.pageView.record(
 			paths.domainManagementContactsPrivacy( ':site', ':domain' ),
 			'Domain Management › Contacts and Privacy'
 		);
 
-		renderWithReduxStore(
+		pageContext.primary = (
 			<WhoisData
 				component={ DomainManagement.ContactsPrivacy }
 				context={ pageContext }
 				selectedDomainName={ pageContext.params.domain }
-			/>,
-			document.getElementById( 'primary' ),
-			pageContext.store
+			/>
 		);
+		next();
 	},
 
-	domainManagementEditContactInfo( pageContext ) {
+	domainManagementEditContactInfo( pageContext, next ) {
 		analytics.pageView.record(
 			paths.domainManagementEditContactInfo( ':site', ':domain' ),
 			'Domain Management › Contacts and Privacy › Edit Contact Info'
 		);
 
-		renderWithReduxStore(
+		pageContext.primary = (
 			<WhoisData
 				component={ DomainManagement.EditContactInfo }
 				context={ pageContext }
 				selectedDomainName={ pageContext.params.domain }
-			/>,
-			document.getElementById( 'primary' ),
-			pageContext.store
+			/>
 		);
+		next();
 	},
 
-	domainManagementEmail( pageContext ) {
+	domainManagementEmail( pageContext, next ) {
 		analytics.pageView.record(
 			paths.domainManagementEmail( ':site', pageContext.params.domain ? ':domain' : undefined ),
 			'Domain Management › Email'
 		);
 
-		renderWithReduxStore(
+		pageContext.primary = (
 			<EmailData
 				component={ DomainManagement.Email }
 				productsList={ productsList }
 				selectedDomainName={ pageContext.params.domain }
 				context={ pageContext }
-			/>,
-			document.getElementById( 'primary' ),
-			pageContext.store
+			/>
 		);
+		next();
 	},
 
-	domainManagementEmailForwarding( pageContext ) {
+	domainManagementEmailForwarding( pageContext, next ) {
 		analytics.pageView.record(
 			paths.domainManagementEmailForwarding( ':site', ':domain' ),
 			'Domain Management › Email › Email Forwarding'
 		);
 
-		renderWithReduxStore(
+		pageContext.primary = (
 			<EmailForwardingData
 				component={ DomainManagement.EmailForwarding }
 				selectedDomainName={ pageContext.params.domain }
-			/>,
-			document.getElementById( 'primary' ),
-			pageContext.store
+			/>
 		);
+		next();
 	},
 
-	domainManagementDns( pageContext ) {
+	domainManagementDns( pageContext, next ) {
 		analytics.pageView.record(
 			paths.domainManagementDns( ':site', ':domain' ),
 			'Domain Management › Name Servers and DNS › DNS Records'
 		);
 
-		renderWithReduxStore(
+		pageContext.primary = (
 			<DnsData
 				component={ DomainManagement.Dns }
 				selectedDomainName={ pageContext.params.domain }
-			/>,
-			document.getElementById( 'primary' ),
-			pageContext.store
+			/>
 		);
+		next();
 	},
-	domainManagementNameServers( pageContext ) {
+	domainManagementNameServers( pageContext, next ) {
 		analytics.pageView.record(
 			paths.domainManagementNameServers( ':site', ':domain' ),
 			'Domain Management › Name Servers and DNS'
 		);
 
-		renderWithReduxStore(
+		pageContext.primary = (
 			<NameserversData
 				component={ DomainManagement.NameServers }
 				selectedDomainName={ pageContext.params.domain }
-			/>,
-			document.getElementById( 'primary' ),
-			pageContext.store
+			/>
 		);
+		next();
 	},
 
-	domainManagementPrivacyProtection( pageContext ) {
+	domainManagementPrivacyProtection( pageContext, next ) {
 		analytics.pageView.record(
 			paths.domainManagementPrivacyProtection( ':site', ':domain' ),
 			'Domain Management › Contacts and Privacy › Privacy Protection'
 		);
 
-		renderWithReduxStore(
+		pageContext.primary = (
 			<WhoisData
 				component={ DomainManagement.PrivacyProtection }
 				context={ pageContext }
 				selectedDomainName={ pageContext.params.domain }
-			/>,
-			document.getElementById( 'primary' ),
-			pageContext.store
+			/>
 		);
+		next();
 	},
 
-	domainManagementAddGoogleApps( pageContext ) {
+	domainManagementAddGoogleApps( pageContext, next ) {
 		analytics.pageView.record(
 			paths.domainManagementAddGoogleApps(
 				':site',
@@ -204,32 +193,30 @@ export default {
 			'Domain Management › Add Google Apps'
 		);
 
-		renderWithReduxStore(
+		pageContext.primary = (
 			<DomainManagementData
 				component={ DomainManagement.AddGoogleApps }
 				context={ pageContext }
 				productsList={ productsList }
 				selectedDomainName={ pageContext.params.domain }
-			/>,
-			document.getElementById( 'primary' ),
-			pageContext.store
+			/>
 		);
+		next();
 	},
 
-	domainManagementRedirectSettings( pageContext ) {
+	domainManagementRedirectSettings( pageContext, next ) {
 		analytics.pageView.record(
 			paths.domainManagementRedirectSettings( ':site', ':domain' ),
 			'Domain Management › Redirect Settings'
 		);
 
-		renderWithReduxStore(
+		pageContext.primary = (
 			<SiteRedirectData
 				component={ DomainManagement.SiteRedirect }
 				selectedDomainName={ decodeURIComponentIfValid( pageContext.params.domain ) }
-			/>,
-			document.getElementById( 'primary' ),
-			pageContext.store
+			/>
 		);
+		next();
 	},
 
 	domainManagementIndex( pageContext ) {
@@ -239,18 +226,17 @@ export default {
 		page.redirect( '/domains/manage' + ( siteSlug ? `/${ siteSlug }` : '' ) );
 	},
 
-	domainManagementTransfer( pageContext ) {
-		renderWithReduxStore(
+	domainManagementTransfer( pageContext, next ) {
+		pageContext.primary = (
 			<TransferData
 				component={ DomainManagement.Transfer }
 				selectedDomainName={ pageContext.params.domain }
-			/>,
-			document.getElementById( 'primary' ),
-			pageContext.store
+			/>
 		);
+		next();
 	},
 
-	domainManagementTransferToOtherSite( pageContext ) {
+	domainManagementTransferToOtherSite( pageContext, next ) {
 		const state = pageContext.store.getState();
 		const siteId = getSelectedSiteId( state );
 		const isAutomatedTransfer = isSiteAutomatedTransfer( state, siteId );
@@ -260,17 +246,16 @@ export default {
 			return;
 		}
 
-		renderWithReduxStore(
+		pageContext.primary = (
 			<TransferData
 				component={ DomainManagement.TransferToOtherSite }
 				selectedDomainName={ pageContext.params.domain }
-			/>,
-			document.getElementById( 'primary' ),
-			pageContext.store
+			/>
 		);
+		next();
 	},
 
-	domainManagementTransferToOtherUser( pageContext ) {
+	domainManagementTransferToOtherUser( pageContext, next ) {
 		const state = pageContext.store.getState();
 		const siteId = getSelectedSiteId( state );
 		const isAutomatedTransfer = isSiteAutomatedTransfer( state, siteId );
@@ -280,24 +265,22 @@ export default {
 			return;
 		}
 
-		renderWithReduxStore(
+		pageContext.primary = (
 			<TransferData
 				component={ DomainManagement.TransferToOtherUser }
 				selectedDomainName={ pageContext.params.domain }
-			/>,
-			document.getElementById( 'primary' ),
-			pageContext.store
+			/>
 		);
+		next();
 	},
 
-	domainManagementTransferOut( pageContext ) {
-		renderWithReduxStore(
+	domainManagementTransferOut( pageContext, next ) {
+		pageContext.primary = (
 			<TransferData
 				component={ DomainManagement.TransferOut }
 				selectedDomainName={ pageContext.params.domain }
-			/>,
-			document.getElementById( 'primary' ),
-			pageContext.store
+			/>
 		);
+		next();
 	},
 };

--- a/client/my-sites/domains/index.js
+++ b/client/my-sites/domains/index.js
@@ -13,6 +13,7 @@ import domainManagementController from './domain-management/controller';
 import SiftScience from 'lib/siftscience';
 import config from 'config';
 import paths from './paths';
+import { makeLayout, render as clientRender } from 'controller';
 
 function registerMultiPage( { paths: givenPaths, handlers } ) {
 	givenPaths.forEach( path => page( path, ...handlers ) );
@@ -37,7 +38,7 @@ function getCommonHandlers(
 export default function() {
 	SiftScience.recordUser();
 
-	page( paths.domainManagementEmail(), siteSelection, sites );
+	page( paths.domainManagementEmail(), siteSelection, sites, makeLayout, clientRender );
 
 	registerMultiPage( {
 		paths: [
@@ -61,69 +62,91 @@ export default function() {
 	page(
 		paths.domainManagementEmailForwarding( ':site', ':domain' ),
 		...getCommonHandlers(),
-		domainManagementController.domainManagementEmailForwarding
+		domainManagementController.domainManagementEmailForwarding,
+		makeLayout,
+		clientRender
 	);
 
 	page(
 		paths.domainManagementRedirectSettings( ':site', ':domain' ),
 		...getCommonHandlers(),
-		domainManagementController.domainManagementRedirectSettings
+		domainManagementController.domainManagementRedirectSettings,
+		makeLayout,
+		clientRender
 	);
 
 	page(
 		paths.domainManagementContactsPrivacy( ':site', ':domain' ),
 		...getCommonHandlers(),
-		domainManagementController.domainManagementContactsPrivacy
+		domainManagementController.domainManagementContactsPrivacy,
+		makeLayout,
+		clientRender
 	);
 
 	page(
 		paths.domainManagementEditContactInfo( ':site', ':domain' ),
 		...getCommonHandlers(),
-		domainManagementController.domainManagementEditContactInfo
+		domainManagementController.domainManagementEditContactInfo,
+		makeLayout,
+		clientRender
 	);
 
 	page(
 		paths.domainManagementDns( ':site', ':domain' ),
 		...getCommonHandlers(),
-		domainManagementController.domainManagementDns
+		domainManagementController.domainManagementDns,
+		makeLayout,
+		clientRender
 	);
 
 	page(
 		paths.domainManagementNameServers( ':site', ':domain' ),
 		...getCommonHandlers(),
-		domainManagementController.domainManagementNameServers
+		domainManagementController.domainManagementNameServers,
+		makeLayout,
+		clientRender
 	);
 
 	page(
 		paths.domainManagementTransfer( ':site', ':domain' ),
 		...getCommonHandlers(),
-		domainManagementController.domainManagementTransfer
+		domainManagementController.domainManagementTransfer,
+		makeLayout,
+		clientRender
 	);
 
 	page(
 		paths.domainManagementTransferOut( ':site', ':domain' ),
 		...getCommonHandlers(),
-		domainManagementController.domainManagementTransferOut
+		domainManagementController.domainManagementTransferOut,
+		makeLayout,
+		clientRender
 	);
 
 	page(
 		paths.domainManagementTransferToAnotherUser( ':site', ':domain' ),
 		...getCommonHandlers(),
-		domainManagementController.domainManagementTransferToOtherUser
+		domainManagementController.domainManagementTransferToOtherUser,
+		makeLayout,
+		clientRender
 	);
 
 	page(
 		paths.domainManagementTransferToOtherSite( ':site', ':domain' ),
 		...getCommonHandlers(),
-		domainManagementController.domainManagementTransferToOtherSite
+		domainManagementController.domainManagementTransferToOtherSite,
+		makeLayout,
+		clientRender
 	);
 
-	page( paths.domainManagementRoot(), siteSelection, sites );
+	page( paths.domainManagementRoot(), siteSelection, sites, makeLayout, clientRender );
 
 	page(
 		paths.domainManagementList( ':site' ),
 		...getCommonHandlers(),
-		domainManagementController.domainManagementList
+		domainManagementController.domainManagementList,
+		makeLayout,
+		clientRender
 	);
 
 	registerMultiPage( {
@@ -137,13 +160,17 @@ export default function() {
 	page(
 		paths.domainManagementPrivacyProtection( ':site', ':domain' ),
 		...getCommonHandlers( { warnIfJetpack: false } ),
-		domainManagementController.domainManagementPrivacyProtection
+		domainManagementController.domainManagementPrivacyProtection,
+		makeLayout,
+		clientRender
 	);
 
 	page(
 		paths.domainManagementPrimaryDomain( ':site', ':domain' ),
 		...getCommonHandlers(),
-		domainManagementController.domainManagementPrimaryDomain
+		domainManagementController.domainManagementPrimaryDomain,
+		makeLayout,
+		clientRender
 	);
 
 	if ( config.isEnabled( 'upgrades/domain-search' ) ) {
@@ -153,7 +180,9 @@ export default function() {
 			domainsController.domainsAddHeader,
 			domainsController.redirectToAddMappingIfVipSite(),
 			jetPackWarning,
-			sites
+			sites,
+			makeLayout,
+			clientRender
 		);
 
 		page(
@@ -161,7 +190,9 @@ export default function() {
 			siteSelection,
 			domainsController.domainsAddHeader,
 			jetPackWarning,
-			sites
+			sites,
+			makeLayout,
+			clientRender
 		);
 
 		page(
@@ -169,7 +200,9 @@ export default function() {
 			siteSelection,
 			domainsController.domainsAddHeader,
 			jetPackWarning,
-			sites
+			sites,
+			makeLayout,
+			clientRender
 		);
 
 		page(
@@ -177,7 +210,9 @@ export default function() {
 			siteSelection,
 			domainsController.domainsAddRedirectHeader,
 			jetPackWarning,
-			sites
+			sites,
+			makeLayout,
+			clientRender
 		);
 
 		page(
@@ -187,7 +222,9 @@ export default function() {
 			domainsController.redirectIfNoSite( '/domains/add' ),
 			domainsController.redirectToAddMappingIfVipSite(),
 			jetPackWarning,
-			domainsController.domainSearch
+			domainsController.domainSearch,
+			makeLayout,
+			clientRender
 		);
 
 		page(
@@ -197,7 +234,9 @@ export default function() {
 			domainsController.redirectIfNoSite( '/domains/add' ),
 			domainsController.redirectToAddMappingIfVipSite(),
 			jetPackWarning,
-			domainsController.domainSearch
+			domainsController.domainSearch,
+			makeLayout,
+			clientRender
 		);
 
 		page(
@@ -206,7 +245,9 @@ export default function() {
 			navigation,
 			domainsController.redirectIfNoSite( '/domains/add' ),
 			jetPackWarning,
-			domainsController.googleAppsWithRegistration
+			domainsController.googleAppsWithRegistration,
+			makeLayout,
+			clientRender
 		);
 
 		page(
@@ -215,7 +256,9 @@ export default function() {
 			navigation,
 			domainsController.redirectIfNoSite( '/domains/add/mapping' ),
 			jetPackWarning,
-			domainsController.mapDomain
+			domainsController.mapDomain,
+			makeLayout,
+			clientRender
 		);
 
 		page(
@@ -224,7 +267,9 @@ export default function() {
 			navigation,
 			domainsController.redirectIfNoSite( '/domains/add/site-redirect' ),
 			jetPackWarning,
-			domainsController.siteRedirect
+			domainsController.siteRedirect,
+			makeLayout,
+			clientRender
 		);
 
 		page(
@@ -233,17 +278,21 @@ export default function() {
 			navigation,
 			domainsController.redirectIfNoSite( '/domains/add/transfer' ),
 			jetPackWarning,
-			domainsController.transferDomain
+			domainsController.transferDomain,
+			makeLayout,
+			clientRender
 		);
 	}
 
-	page( '/domains', siteSelection, sites );
+	page( '/domains', siteSelection, sites, makeLayout, clientRender );
 
 	page(
 		'/domains/:site',
 		siteSelection,
 		navigation,
 		jetPackWarning,
-		domainManagementController.domainManagementIndex
+		domainManagementController.domainManagementIndex,
+		makeLayout,
+		clientRender
 	);
 }

--- a/client/my-sites/domains/index.js
+++ b/client/my-sites/domains/index.js
@@ -48,6 +48,8 @@ export default function() {
 		handlers: [
 			...getCommonHandlers( { noSitePath: paths.domainManagementEmail() } ),
 			domainManagementController.domainManagementEmail,
+			makeLayout,
+			clientRender,
 		],
 	} );
 
@@ -56,7 +58,12 @@ export default function() {
 			paths.domainManagementAddGoogleApps( ':site', ':domain' ),
 			paths.domainManagementAddGoogleApps( ':site' ),
 		],
-		handlers: [ ...getCommonHandlers(), domainManagementController.domainManagementAddGoogleApps ],
+		handlers: [
+			...getCommonHandlers(),
+			domainManagementController.domainManagementAddGoogleApps,
+			makeLayout,
+			clientRender,
+		],
 	} );
 
 	page(
@@ -154,7 +161,12 @@ export default function() {
 			paths.domainManagementEdit( ':site', ':domain' ),
 			paths.domainManagementTransferIn( ':site', ':domain' ),
 		],
-		handlers: [ ...getCommonHandlers(), domainManagementController.domainManagementEdit ],
+		handlers: [
+			...getCommonHandlers(),
+			domainManagementController.domainManagementEdit,
+			makeLayout,
+			clientRender,
+		],
 	} );
 
 	page(

--- a/client/my-sites/index.js
+++ b/client/my-sites/index.js
@@ -10,7 +10,8 @@ import page from 'page';
  * Internal dependencies
  */
 import { siteSelection, sites } from './controller';
+import { makeLayout, render as clientRender } from 'controller';
 
 export default function() {
-	page( '/sites/:sitesFilter?', siteSelection, sites );
+	page( '/sites/:sitesFilter?', siteSelection, sites, makeLayout, clientRender );
 }

--- a/client/my-sites/invites/controller.js
+++ b/client/my-sites/invites/controller.js
@@ -4,7 +4,6 @@
  * External dependencies
  */
 
-import ReactDom from 'react-dom';
 import React from 'react';
 import store from 'store';
 import page from 'page';
@@ -18,7 +17,6 @@ import i18n from 'i18n-calypso';
 import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
 import InviteAccept from 'my-sites/invites/invite-accept';
 import { setSection } from 'state/ui/actions';
-import { renderWithReduxStore } from 'lib/react-helpers';
 import { getRedirectAfterAccept } from 'my-sites/invites/utils';
 import { acceptInvite as acceptInviteAction } from 'lib/invites/actions';
 import _user from 'lib/user';
@@ -48,10 +46,9 @@ export function redirectWithoutLocaleifLoggedIn( context, next ) {
 	next();
 }
 
-export function acceptInvite( context ) {
+export function acceptInvite( context, next ) {
 	context.store.dispatch( setTitle( i18n.translate( 'Accept Invite', { textOnly: true } ) ) ); // FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
 
-	ReactDom.unmountComponentAtNode( document.getElementById( 'secondary' ) );
 	context.store.dispatch( setSection( null, { hasSidebar: false } ) );
 
 	const acceptedInvite = store.get( 'invite_accepted' );
@@ -80,16 +77,13 @@ export function acceptInvite( context ) {
 		return;
 	}
 
-	renderWithReduxStore(
-		React.createElement( InviteAccept, {
-			siteId: context.params.site_id,
-			inviteKey: context.params.invitation_key,
-			activationKey: context.params.activation_key,
-			authKey: context.params.auth_key,
-			locale: getLocale( context.params ),
-			path: context.path,
-		} ),
-		document.getElementById( 'primary' ),
-		context.store
-	);
+	context.primary = React.createElement( InviteAccept, {
+		siteId: context.params.site_id,
+		inviteKey: context.params.invitation_key,
+		activationKey: context.params.activation_key,
+		authKey: context.params.auth_key,
+		locale: getLocale( context.params ),
+		path: context.path,
+	} );
+	next();
 }

--- a/client/my-sites/invites/index.js
+++ b/client/my-sites/invites/index.js
@@ -10,11 +10,14 @@ import page from 'page';
  * Internal dependencies
  */
 import { acceptInvite, redirectWithoutLocaleifLoggedIn } from './controller';
+import { makeLayout, render as clientRender } from 'controller';
 
 export default () => {
 	page(
 		'/accept-invite/:site_id?/:invitation_key?/:activation_key?/:auth_key?/:locale?',
 		redirectWithoutLocaleifLoggedIn,
-		acceptInvite
+		acceptInvite,
+		makeLayout,
+		clientRender
 	);
 };

--- a/client/my-sites/media/controller.js
+++ b/client/my-sites/media/controller.js
@@ -13,11 +13,10 @@ import i18n from 'i18n-calypso';
 import route from 'lib/route';
 import analytics from 'lib/analytics';
 import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
-import { renderWithReduxStore } from 'lib/react-helpers';
 import { getSelectedSite } from 'state/ui/selectors';
 
 export default {
-	media: function( context ) {
+	media: function( context, next ) {
 		var MediaComponent = require( 'my-sites/media/main' ),
 			filter = context.params.filter,
 			search = context.query.s,
@@ -37,14 +36,11 @@ export default {
 		context.store.dispatch( setTitle( i18n.translate( 'Media', { textOnly: true } ) ) );
 
 		// Render
-		renderWithReduxStore(
-			React.createElement( MediaComponent, {
-				selectedSite,
-				filter: filter,
-				search: search,
-			} ),
-			document.getElementById( 'primary' ),
-			context.store
-		);
+		context.primary = React.createElement( MediaComponent, {
+			selectedSite,
+			filter: filter,
+			search: search,
+		} );
+		next();
 	},
 };

--- a/client/my-sites/media/index.js
+++ b/client/my-sites/media/index.js
@@ -12,10 +12,18 @@ import page from 'page';
 import { navigation, siteSelection, sites } from 'my-sites/controller';
 import mediaController from './controller';
 import config from 'config';
+import { makeLayout, render as clientRender } from 'controller';
 
 export default function() {
 	if ( config.isEnabled( 'manage/media' ) ) {
-		page( '/media', siteSelection, sites );
-		page( '/media/:filter?/:domain', siteSelection, navigation, mediaController.media );
+		page( '/media', siteSelection, sites, makeLayout, clientRender );
+		page(
+			'/media/:filter?/:domain',
+			siteSelection,
+			navigation,
+			mediaController.media,
+			makeLayout,
+			clientRender
+		);
 	}
 }

--- a/client/my-sites/pages/controller.js
+++ b/client/my-sites/pages/controller.js
@@ -15,10 +15,9 @@ import analytics from 'lib/analytics';
 import titlecase from 'to-title-case';
 import trackScrollPage from 'lib/track-scroll-page';
 import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
-import { renderWithReduxStore } from 'lib/react-helpers';
 
 const controller = {
-	pages: function( context ) {
+	pages: function( context, next ) {
 		var Pages = require( 'my-sites/pages/main' ),
 			siteID = route.getSiteFragment( context.path ),
 			status = context.params.status,
@@ -45,21 +44,13 @@ const controller = {
 
 		analytics.pageView.record( baseAnalyticsPath, analyticsPageTitle );
 
-		renderWithReduxStore(
-			React.createElement( Pages, {
-				siteID: siteID,
-				status: status,
-				search: search,
-				trackScrollPage: trackScrollPage.bind(
-					null,
-					baseAnalyticsPath,
-					analyticsPageTitle,
-					'Pages'
-				),
-			} ),
-			document.getElementById( 'primary' ),
-			context.store
-		);
+		context.primary = React.createElement( Pages, {
+			siteID: siteID,
+			status: status,
+			search: search,
+			trackScrollPage: trackScrollPage.bind( null, baseAnalyticsPath, analyticsPageTitle, 'Pages' ),
+		} );
+		next();
 	},
 };
 

--- a/client/my-sites/pages/index.js
+++ b/client/my-sites/pages/index.js
@@ -10,9 +10,17 @@ import page from 'page';
 import { navigation, siteSelection } from 'my-sites/controller';
 import pagesController from './controller';
 import config from 'config';
+import { makeLayout, render as clientRender } from 'controller';
 
 export default function() {
 	if ( config.isEnabled( 'manage/pages' ) ) {
-		page( '/pages/:status?/:domain?', siteSelection, navigation, pagesController.pages );
+		page(
+			'/pages/:status?/:domain?',
+			siteSelection,
+			navigation,
+			pagesController.pages,
+			makeLayout,
+			clientRender
+		);
 	}
 }

--- a/client/my-sites/paladin/controller.js
+++ b/client/my-sites/paladin/controller.js
@@ -9,15 +9,11 @@ import React from 'react';
 /**
  * Internal Dependencies
  */
-import { renderWithReduxStore } from 'lib/react-helpers';
 import PaladinComponent from './main';
 
 export default {
-	activate: function( context ) {
-		renderWithReduxStore(
-			React.createElement( PaladinComponent ),
-			document.getElementById( 'primary' ),
-			context.store
-		);
+	activate: function( context, next ) {
+		context.primary = React.createElement( PaladinComponent );
+		next();
 	},
 };

--- a/client/my-sites/paladin/index.js
+++ b/client/my-sites/paladin/index.js
@@ -12,10 +12,18 @@ import page from 'page';
 import { navigation, siteSelection, sites } from 'my-sites/controller';
 import paladinController from './controller';
 import config from 'config';
+import { makeLayout, render as clientRender } from 'controller';
 
 export default function() {
 	if ( config.isEnabled( 'paladin' ) ) {
-		page( '/paladin', siteSelection, sites );
-		page( '/paladin/:domain', siteSelection, navigation, paladinController.activate );
+		page( '/paladin', siteSelection, sites, makeLayout, clientRender );
+		page(
+			'/paladin/:domain',
+			siteSelection,
+			navigation,
+			paladinController.activate,
+			makeLayout,
+			clientRender
+		);
 	}
 }

--- a/client/my-sites/people/controller.js
+++ b/client/my-sites/people/controller.js
@@ -19,7 +19,6 @@ import titlecase from 'to-title-case';
 import PeopleLogStore from 'lib/people/log-store';
 import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
 import InvitePeople from './invite-people';
-import { renderWithReduxStore } from 'lib/react-helpers';
 import { getCurrentLayoutFocus } from 'state/ui/layout-focus/selectors';
 import { setNextLayoutFocus } from 'state/ui/layout-focus/actions';
 import { getSelectedSite } from 'state/ui/selectors';
@@ -59,48 +58,39 @@ function redirectToTeam( context ) {
 	page.redirect( '/people/team' );
 }
 
-function renderPeopleList( context ) {
+function renderPeopleList( context, next ) {
 	const filter = context.params.filter;
 
 	// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
 	context.store.dispatch( setTitle( i18n.translate( 'People', { textOnly: true } ) ) );
 
-	renderWithReduxStore(
-		React.createElement( PeopleList, {
-			peopleLog: PeopleLogStore,
-			filter: filter,
-			search: context.query.s,
-		} ),
-		document.getElementById( 'primary' ),
-		context.store
-	);
+	context.primary = React.createElement( PeopleList, {
+		peopleLog: PeopleLogStore,
+		filter: filter,
+		search: context.query.s,
+	} );
 	analytics.pageView.record( 'people/' + filter + '/:site', 'People > ' + titlecase( filter ) );
+	next();
 }
 
-function renderInvitePeople( context ) {
+function renderInvitePeople( context, next ) {
 	const state = context.store.getState();
 	const site = getSelectedSite( state );
 
 	context.store.dispatch( setTitle( i18n.translate( 'Invite People', { textOnly: true } ) ) ); // FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
 
-	renderWithReduxStore(
-		React.createElement( InvitePeople, {
-			site: site,
-		} ),
-		document.getElementById( 'primary' ),
-		context.store
-	);
+	context.primary = React.createElement( InvitePeople, {
+		site: site,
+	} );
+	next();
 }
 
-function renderSingleTeamMember( context ) {
+function renderSingleTeamMember( context, next ) {
 	context.store.dispatch( setTitle( i18n.translate( 'View Team Member', { textOnly: true } ) ) ); // FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
 
-	renderWithReduxStore(
-		React.createElement( EditTeamMember, {
-			userLogin: context.params.user_login,
-			prevPath: context.prevPath,
-		} ),
-		document.getElementById( 'primary' ),
-		context.store
-	);
+	context.primary = React.createElement( EditTeamMember, {
+		userLogin: context.params.user_login,
+		prevPath: context.prevPath,
+	} );
+	next();
 }

--- a/client/my-sites/people/controller.js
+++ b/client/my-sites/people/controller.js
@@ -36,16 +36,16 @@ export default {
 		next();
 	},
 
-	people( context ) {
-		renderPeopleList( context );
+	people( context, next ) {
+		renderPeopleList( context, next );
 	},
 
-	invitePeople( context ) {
-		renderInvitePeople( context );
+	invitePeople( context, next ) {
+		renderInvitePeople( context, next );
 	},
 
-	person( context ) {
-		renderSingleTeamMember( context );
+	person( context, next ) {
+		renderSingleTeamMember( context, next );
 	},
 };
 

--- a/client/my-sites/people/index.js
+++ b/client/my-sites/people/index.js
@@ -10,17 +10,26 @@ import page from 'page';
 import { navigation, siteSelection, sites } from 'my-sites/controller';
 import config from 'config';
 import peopleController from './controller';
+import { makeLayout, render as clientRender } from 'controller';
 
 export default function() {
 	if ( config.isEnabled( 'manage/people' ) ) {
-		page( '/people/:filter(team|followers|email-followers|viewers)', siteSelection, sites );
+		page(
+			'/people/:filter(team|followers|email-followers|viewers)',
+			siteSelection,
+			sites,
+			makeLayout,
+			clientRender
+		);
 
 		page(
 			'/people/:filter(team|followers|email-followers|viewers)/:site_id',
 			peopleController.enforceSiteEnding,
 			siteSelection,
 			navigation,
-			peopleController.people
+			peopleController.people,
+			makeLayout,
+			clientRender
 		);
 
 		page(
@@ -28,7 +37,9 @@ export default function() {
 			peopleController.enforceSiteEnding,
 			siteSelection,
 			navigation,
-			peopleController.invitePeople
+			peopleController.invitePeople,
+			makeLayout,
+			clientRender
 		);
 
 		page(
@@ -36,10 +47,18 @@ export default function() {
 			peopleController.enforceSiteEnding,
 			siteSelection,
 			navigation,
-			peopleController.person
+			peopleController.person,
+			makeLayout,
+			clientRender
 		);
 
 		// Anything else is unexpected and should be redirected to the default people management URL: /people/team
-		page( '/people/(.*)?', siteSelection, peopleController.redirectToTeam );
+		page(
+			'/people/(.*)?',
+			siteSelection,
+			peopleController.redirectToTeam,
+			makeLayout,
+			clientRender
+		);
 	}
 }

--- a/client/my-sites/plans/controller.jsx
+++ b/client/my-sites/plans/controller.jsx
@@ -7,19 +7,19 @@
 import page from 'page';
 import React from 'react';
 
+import { get } from 'lodash';
+
 /**
  * Internal Dependencies
  */
-import { renderWithReduxStore } from 'lib/react-helpers';
-import { get } from 'lodash';
 import { isValidFeatureKey } from 'lib/plans';
 
 export default {
-	plans( context ) {
+	plans( context, next ) {
 		const Plans = require( 'my-sites/plans/main' ),
 			CheckoutData = require( 'components/data/checkout' );
 
-		renderWithReduxStore(
+		context.primary = (
 			<CheckoutData>
 				<Plans
 					context={ context }
@@ -28,10 +28,9 @@ export default {
 					selectedFeature={ context.query.feature }
 					selectedPlan={ context.query.plan }
 				/>
-			</CheckoutData>,
-			document.getElementById( 'primary' ),
-			context.store
+			</CheckoutData>
 		);
+		next();
 	},
 
 	features( context ) {

--- a/client/my-sites/plans/current-plan/controller.jsx
+++ b/client/my-sites/plans/current-plan/controller.jsx
@@ -10,13 +10,12 @@ import page from 'page';
 /**
  * Internal Dependencies
  */
-import { renderWithReduxStore } from 'lib/react-helpers';
 import CurrentPlan from './';
 import { isFreePlan } from 'lib/products-values';
 import { getSelectedSite } from 'state/ui/selectors';
 
 export default {
-	currentPlan( context ) {
+	currentPlan( context, next ) {
 		const state = context.store.getState();
 
 		const selectedSite = getSelectedSite( state );
@@ -33,10 +32,7 @@ export default {
 			return null;
 		}
 
-		renderWithReduxStore(
-			<CurrentPlan context={ context } />,
-			document.getElementById( 'primary' ),
-			context.store
-		);
+		context.primary = <CurrentPlan context={ context } />;
+		next();
 	},
 };

--- a/client/my-sites/plans/index.js
+++ b/client/my-sites/plans/index.js
@@ -10,18 +10,75 @@ import page from 'page';
 import { navigation, siteSelection, sites } from 'my-sites/controller';
 import plansController from './controller';
 import currentPlanController from './current-plan/controller';
+import { makeLayout, render as clientRender } from 'controller';
 
 export default function() {
-	page( '/plans', siteSelection, sites );
-	page( '/plans/compare', siteSelection, navigation, plansController.redirectToPlans );
-	page( '/plans/compare/:domain', siteSelection, navigation, plansController.redirectToPlans );
-	page( '/plans/features', siteSelection, navigation, plansController.redirectToPlans );
-	page( '/plans/features/:domain', siteSelection, navigation, plansController.redirectToPlans );
-	page( '/plans/features/:feature/:domain', plansController.features );
-	page( '/plans/my-plan', siteSelection, sites, navigation, currentPlanController.currentPlan );
-	page( '/plans/my-plan/:site', siteSelection, navigation, currentPlanController.currentPlan );
-	page( '/plans/select/:plan/:domain', siteSelection, plansController.redirectToCheckout );
+	page( '/plans', siteSelection, sites, makeLayout, clientRender );
+	page(
+		'/plans/compare',
+		siteSelection,
+		navigation,
+		plansController.redirectToPlans,
+		makeLayout,
+		clientRender
+	);
+	page(
+		'/plans/compare/:domain',
+		siteSelection,
+		navigation,
+		plansController.redirectToPlans,
+		makeLayout,
+		clientRender
+	);
+	page(
+		'/plans/features',
+		siteSelection,
+		navigation,
+		plansController.redirectToPlans,
+		makeLayout,
+		clientRender
+	);
+	page(
+		'/plans/features/:domain',
+		siteSelection,
+		navigation,
+		plansController.redirectToPlans,
+		makeLayout,
+		clientRender
+	);
+	page( '/plans/features/:feature/:domain', plansController.features, makeLayout, clientRender );
+	page(
+		'/plans/my-plan',
+		siteSelection,
+		sites,
+		navigation,
+		currentPlanController.currentPlan,
+		makeLayout,
+		clientRender
+	);
+	page(
+		'/plans/my-plan/:site',
+		siteSelection,
+		navigation,
+		currentPlanController.currentPlan,
+		makeLayout,
+		clientRender
+	);
+	page(
+		'/plans/select/:plan/:domain',
+		siteSelection,
+		plansController.redirectToCheckout,
+		makeLayout,
+		clientRender
+	);
 
 	// This route renders the plans page for both WPcom and Jetpack sites.
-	page( '/plans/:intervalType?/:site', siteSelection, navigation, plansController.plans );
+	page(
+		'/plans/:intervalType?/:site',
+		siteSelection,
+		navigation,
+		plansController.plans,
+		makeLayout,
+		clientRender
+	);
 }

--- a/client/my-sites/plugins/controller.js
+++ b/client/my-sites/plugins/controller.js
@@ -4,7 +4,6 @@
  * External dependencies
  */
 
-import ReactDom from 'react-dom';
 import React from 'react';
 import page from 'page';
 import { capitalize, includes, some } from 'lodash';
@@ -21,7 +20,6 @@ import PluginListComponent from './main';
 import PluginComponent from './plugin';
 import PluginBrowser from './plugins-browser';
 import PluginUpload from './plugin-upload';
-import { renderWithReduxStore } from 'lib/react-helpers';
 import { setSection } from 'state/ui/actions';
 import { getSelectedSite, getSection } from 'state/ui/selectors';
 import { hasJetpackSites, getSelectedOrAllSitesWithPlugins } from 'state/selectors';
@@ -57,17 +55,13 @@ function renderSinglePlugin( context, siteUrl ) {
 	}
 
 	// Render single plugin component
-	renderWithReduxStore(
-		React.createElement( PluginComponent, {
-			path: context.path,
-			prevQuerystring: lastPluginsQuerystring,
-			prevPath,
-			pluginSlug,
-			siteUrl,
-		} ),
-		document.getElementById( 'primary' ),
-		context.store
-	);
+	context.primary = React.createElement( PluginComponent, {
+		path: context.path,
+		prevQuerystring: lastPluginsQuerystring,
+		prevPath,
+		pluginSlug,
+		siteUrl,
+	} );
 }
 
 function getPathWithoutSiteSlug( context, site ) {
@@ -85,16 +79,12 @@ function renderPluginList( context, basePath ) {
 	lastPluginsListVisited = getPathWithoutSiteSlug( context, site );
 	lastPluginsQuerystring = context.querystring;
 
-	renderWithReduxStore(
-		React.createElement( PluginListComponent, {
-			path: basePath,
-			context,
-			filter: context.params.pluginFilter,
-			search,
-		} ),
-		'primary',
-		context.store
-	);
+	context.primary = React.createElement( PluginListComponent, {
+		path: basePath,
+		context,
+		filter: context.params.pluginFilter,
+		search,
+	} );
 
 	if ( search ) {
 		analytics.ga.recordEvent( 'Plugins', 'Search', 'Search term', search );
@@ -121,7 +111,7 @@ function getCategoryForPluginsBrowser( context ) {
 	return context.params.category;
 }
 
-function renderPluginsBrowser( context ) {
+function renderPluginsBrowser( context, next ) {
 	const searchTerm = context.query.s;
 	const site = getSelectedSite( context.store.getState() );
 	const category = getCategoryForPluginsBrowser( context );
@@ -137,38 +127,31 @@ function renderPluginsBrowser( context ) {
 
 	analytics.pageView.record( baseAnalyticsPath, analyticsPageTitle );
 
-	renderWithReduxStore(
-		React.createElement( PluginBrowser, {
-			path: context.path,
-			category,
-			search: searchTerm,
-		} ),
-		document.getElementById( 'primary' ),
-		context.store
-	);
+	context.primary = React.createElement( PluginBrowser, {
+		path: context.path,
+		category,
+		search: searchTerm,
+	} );
+	next();
 }
 
-function renderPluginWarnings( context ) {
+function renderPluginWarnings( context, next ) {
 	const state = context.store.getState();
 	const site = getSelectedSite( state );
 	const pluginSlug = decodeURIComponent( context.params.plugin );
 
-	renderWithReduxStore(
-		React.createElement( PluginEligibility, {
-			siteSlug: site.slug,
-			pluginSlug,
-		} ),
-		document.getElementById( 'primary' ),
-		context.store
-	);
+	context.primary = React.createElement( PluginEligibility, {
+		siteSlug: site.slug,
+		pluginSlug,
+	} );
+	next();
 }
 
-function renderProvisionPlugins( context ) {
+function renderProvisionPlugins( context, next ) {
 	const state = context.store.getState();
 	const section = getSection( state );
 	const site = getSelectedSite( state );
 	context.store.dispatch( setSection( Object.assign( {}, section, { secondary: false } ) ) );
-	ReactDom.unmountComponentAtNode( document.getElementById( 'secondary' ) );
 	let baseAnalyticsPath = 'plugins/setup';
 	if ( site ) {
 		baseAnalyticsPath += '/:site';
@@ -176,13 +159,10 @@ function renderProvisionPlugins( context ) {
 
 	analytics.pageView.record( baseAnalyticsPath, 'Jetpack Plugins Setup' );
 
-	renderWithReduxStore(
-		React.createElement( PlanSetup, {
-			whitelist: context.query.only || false,
-		} ),
-		document.getElementById( 'primary' ),
-		context.store
-	);
+	context.primary = React.createElement( PlanSetup, {
+		whitelist: context.query.only || false,
+	} );
+	next();
 }
 
 const controller = {
@@ -224,8 +204,9 @@ const controller = {
 		renderPluginsBrowser( context );
 	},
 
-	upload( context ) {
-		renderWithReduxStore( <PluginUpload />, document.getElementById( 'primary' ), context.store );
+	upload( context, next ) {
+		context.primary = <PluginUpload />;
+		next();
 	},
 
 	jetpackCanUpdate( context, next ) {

--- a/client/my-sites/plugins/index.js
+++ b/client/my-sites/plugins/index.js
@@ -11,12 +11,25 @@ import { navigation, siteSelection, sites } from 'my-sites/controller';
 import config from 'config';
 import pluginsController from './controller';
 import { recordTracksEvent } from 'state/analytics/actions';
+import { makeLayout, render as clientRender } from 'controller';
 
 export default function() {
 	if ( config.isEnabled( 'manage/plugins/setup' ) ) {
-		page( '/plugins/setup', siteSelection, pluginsController.setupPlugins );
+		page(
+			'/plugins/setup',
+			siteSelection,
+			pluginsController.setupPlugins,
+			makeLayout,
+			clientRender
+		);
 
-		page( '/plugins/setup/:site', siteSelection, pluginsController.setupPlugins );
+		page(
+			'/plugins/setup/:site',
+			siteSelection,
+			pluginsController.setupPlugins,
+			makeLayout,
+			clientRender
+		);
 	}
 
 	if ( config.isEnabled( 'manage/plugins' ) ) {
@@ -46,18 +59,34 @@ export default function() {
 		} );
 
 		if ( config.isEnabled( 'manage/plugins/upload' ) ) {
-			page( '/plugins/upload', sites );
-			page( '/plugins/upload/:site_id', siteSelection, navigation, pluginsController.upload );
+			page( '/plugins/upload', sites, makeLayout, clientRender );
+			page(
+				'/plugins/upload/:site_id',
+				siteSelection,
+				navigation,
+				pluginsController.upload,
+				makeLayout,
+				clientRender
+			);
 		}
 
-		page( '/plugins', siteSelection, navigation, pluginsController.browsePlugins );
+		page(
+			'/plugins',
+			siteSelection,
+			navigation,
+			pluginsController.browsePlugins,
+			makeLayout,
+			clientRender
+		);
 
 		page(
 			'/plugins/manage/:site?',
 			siteSelection,
 			navigation,
 			pluginsController.redirectSimpleSitesToPluginBrowser,
-			pluginsController.plugins
+			pluginsController.plugins,
+			makeLayout,
+			clientRender
 		);
 
 		page(
@@ -66,7 +95,9 @@ export default function() {
 			navigation,
 			pluginsController.redirectSimpleSitesToPluginBrowser,
 			pluginsController.jetpackCanUpdate,
-			pluginsController.plugins
+			pluginsController.plugins,
+			makeLayout,
+			clientRender
 		);
 
 		page(
@@ -74,14 +105,18 @@ export default function() {
 			siteSelection,
 			navigation,
 			pluginsController.maybeBrowsePlugins,
-			pluginsController.plugin
+			pluginsController.plugin,
+			makeLayout,
+			clientRender
 		);
 
 		page(
 			'/plugins/:plugin/eligibility/:site_id',
 			siteSelection,
 			navigation,
-			pluginsController.eligibility
+			pluginsController.eligibility,
+			makeLayout,
+			clientRender
 		);
 
 		page.exit( '/plugins/*', ( context, next ) => {

--- a/client/my-sites/plugins/index.js
+++ b/client/my-sites/plugins/index.js
@@ -104,8 +104,7 @@ export default function() {
 			'/plugins/:plugin/:site_id?',
 			siteSelection,
 			navigation,
-			pluginsController.maybeBrowsePlugins,
-			pluginsController.plugin,
+			pluginsController.browsePluginsOrPlugin,
 			makeLayout,
 			clientRender
 		);

--- a/client/my-sites/posts/controller.js
+++ b/client/my-sites/posts/controller.js
@@ -18,14 +18,13 @@ import analytics from 'lib/analytics';
 import titlecase from 'to-title-case';
 import trackScrollPage from 'lib/track-scroll-page';
 import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
-import { renderWithReduxStore } from 'lib/react-helpers';
 import { areAllSitesSingleUser } from 'state/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { isJetpackSite, isSingleUserSite } from 'state/sites/selectors';
 import { getCurrentUserId } from 'state/current-user/selectors';
 
 export default {
-	posts: function( context ) {
+	posts: function( context, next ) {
 		const state = context.store.getState();
 		const siteId = getSelectedSiteId( state );
 
@@ -83,23 +82,15 @@ export default {
 
 		analytics.pageView.record( baseAnalyticsPath, analyticsPageTitle );
 
-		renderWithReduxStore(
-			React.createElement( Posts, {
-				context,
-				author,
-				statusSlug,
-				search,
-				category,
-				tag,
-				trackScrollPage: trackScrollPage.bind(
-					null,
-					baseAnalyticsPath,
-					analyticsPageTitle,
-					'Posts'
-				),
-			} ),
-			'primary',
-			context.store
-		);
+		context.primary = React.createElement( Posts, {
+			context,
+			author,
+			statusSlug,
+			search,
+			category,
+			tag,
+			trackScrollPage: trackScrollPage.bind( null, baseAnalyticsPath, analyticsPageTitle, 'Posts' ),
+		} );
+		next();
 	},
 };

--- a/client/my-sites/posts/index.js
+++ b/client/my-sites/posts/index.js
@@ -11,7 +11,15 @@ import page from 'page';
  */
 import { navigation, siteSelection } from 'my-sites/controller';
 import postsController from './controller';
+import { makeLayout, render as clientRender } from 'controller';
 
 export default function() {
-	page( '/posts/:author?/:status?/:domain?', siteSelection, navigation, postsController.posts );
+	page(
+		'/posts/:author?/:status?/:domain?',
+		siteSelection,
+		navigation,
+		postsController.posts,
+		makeLayout,
+		clientRender
+	);
 }

--- a/client/my-sites/preview/index.js
+++ b/client/my-sites/preview/index.js
@@ -5,10 +5,10 @@
  */
 
 import { makeLayout } from 'controller';
-import { siteSelection, sites, makeNavigation } from 'my-sites/controller';
+import { siteSelection, sites, navigation } from 'my-sites/controller';
 import { preview } from './controller';
 
 export default function( router ) {
 	router( '/view', siteSelection, sites );
-	router( '/view/:site', siteSelection, makeNavigation, preview, makeLayout );
+	router( '/view/:site', siteSelection, navigation, preview, makeLayout );
 }

--- a/client/my-sites/sharing/controller.js
+++ b/client/my-sites/sharing/controller.js
@@ -13,7 +13,6 @@ import { translate } from 'i18n-calypso';
  */
 import notices from 'notices';
 import { pageView } from 'lib/analytics';
-import { renderWithReduxStore } from 'lib/react-helpers';
 import { sectionify } from 'lib/route';
 import Sharing from './main';
 import SharingButtons from './buttons/buttons';
@@ -25,14 +24,11 @@ import versionCompare from 'lib/version-compare';
 
 const analyticsPageTitle = 'Sharing';
 
-export const layout = context => {
-	const { contentComponent, path, store } = context;
+export const layout = ( context, next ) => {
+	const { contentComponent, path } = context;
 
-	renderWithReduxStore(
-		createElement( Sharing, { contentComponent, path } ),
-		document.getElementById( 'primary' ),
-		store
-	);
+	context.primary = createElement( Sharing, { contentComponent, path } );
+	next();
 };
 
 export const connections = ( context, next ) => {

--- a/client/my-sites/sharing/index.js
+++ b/client/my-sites/sharing/index.js
@@ -11,16 +11,19 @@ import page from 'page';
  */
 import { jetpackModuleActive, navigation, sites, siteSelection } from 'my-sites/controller';
 import { buttons, connections, layout } from './controller';
+import { makeLayout, render as clientRender } from 'controller';
 
 export default function() {
-	page( /^\/sharing(\/buttons)?$/, siteSelection, sites );
+	page( /^\/sharing(\/buttons)?$/, siteSelection, sites, makeLayout, clientRender );
 	page(
 		'/sharing/:domain',
 		siteSelection,
 		navigation,
 		jetpackModuleActive( 'publicize', false ),
 		connections,
-		layout
+		layout,
+		makeLayout,
+		clientRender
 	);
 	page(
 		'/sharing/buttons/:domain',
@@ -28,6 +31,8 @@ export default function() {
 		navigation,
 		jetpackModuleActive( 'sharedaddy' ),
 		buttons,
-		layout
+		layout,
+		makeLayout,
+		clientRender
 	);
 }

--- a/client/my-sites/site-settings/controller.js
+++ b/client/my-sites/site-settings/controller.js
@@ -6,7 +6,6 @@
 
 import page from 'page';
 import React from 'react';
-import ReactDom from 'react-dom';
 
 /**
  * Internal Dependencies
@@ -17,7 +16,6 @@ import DeleteSite from './delete-site';
 import ConfirmDisconnection from './disconnect-site/confirm';
 import DisconnectSite from './disconnect-site';
 import purchasesPaths from 'me/purchases/paths';
-import { renderWithReduxStore } from 'lib/react-helpers';
 import SiteSettingsMain from 'my-sites/site-settings/main';
 import StartOver from './start-over';
 import ThemeSetup from './theme-setup';
@@ -50,7 +48,7 @@ function canDeleteSite( state, siteId ) {
 }
 
 function renderPage( context, component ) {
-	renderWithReduxStore( component, document.getElementById( 'primary' ), context.store );
+	context.primary = component;
 }
 
 const controller = {
@@ -111,14 +109,12 @@ const controller = {
 	},
 
 	disconnectSite( context ) {
-		ReactDom.unmountComponentAtNode( document.getElementById( 'secondary' ) );
 		context.store.dispatch( setSection( null, { hasSidebar: false } ) );
 		renderPage( context, <DisconnectSite reason={ context.params.reason } /> );
 	},
 
 	disconnectSiteConfirm( context ) {
 		const { reason, text } = context.query;
-		ReactDom.unmountComponentAtNode( document.getElementById( 'secondary' ) );
 		context.store.dispatch( setSection( null, { hasSidebar: false } ) );
 		renderPage( context, <ConfirmDisconnection reason={ reason } text={ text } /> );
 	},

--- a/client/my-sites/site-settings/controller.js
+++ b/client/my-sites/site-settings/controller.js
@@ -47,16 +47,12 @@ function canDeleteSite( state, siteId ) {
 	return true;
 }
 
-function renderPage( context, component ) {
-	context.primary = component;
-}
-
 const controller = {
 	redirectToGeneral() {
 		page.redirect( '/settings/general' );
 	},
 
-	redirectIfCantDeleteSite( context ) {
+	redirectIfCantDeleteSite( context, next ) {
 		const state = context.store.getState();
 		const dispatch = context.store.dispatch;
 		const siteId = getSelectedSiteId( state );
@@ -79,55 +75,56 @@ const controller = {
 				},
 			} );
 		}
+		next();
 	},
 
-	general( context ) {
-		renderPage( context, <SiteSettingsMain /> );
+	general( context, next ) {
+		context.primary = <SiteSettingsMain />;
+		next();
 	},
 
-	importSite( context ) {
-		renderPage( context, <AsyncLoad require="my-sites/site-settings/section-import" /> );
+	importSite( context, next ) {
+		context.primary = <AsyncLoad require="my-sites/site-settings/section-import" />;
+		next();
 	},
 
-	exportSite( context ) {
-		renderPage( context, <AsyncLoad require="my-sites/site-settings/section-export" /> );
+	exportSite( context, next ) {
+		context.primary = <AsyncLoad require="my-sites/site-settings/section-export" />;
+		next();
 	},
 
-	guidedTransfer( context ) {
-		renderPage(
-			context,
+	guidedTransfer( context, next ) {
+		context.primary = (
 			<AsyncLoad require="my-sites/guided-transfer" hostSlug={ context.params.host_slug } />
 		);
+		next();
 	},
 
-	deleteSite( context ) {
-		const redirectIfCantDeleteSite = controller.redirectIfCantDeleteSite;
+	deleteSite( context, next ) {
+		context.primary = <DeleteSite path={ context.path } />;
 
-		redirectIfCantDeleteSite( context );
-
-		renderPage( context, <DeleteSite path={ context.path } /> );
+		next();
 	},
 
-	disconnectSite( context ) {
+	disconnectSite( context, next ) {
 		context.store.dispatch( setSection( null, { hasSidebar: false } ) );
-		renderPage( context, <DisconnectSite reason={ context.params.reason } /> );
+		context.primary = <DisconnectSite reason={ context.params.reason } />;
+		next();
 	},
 
-	disconnectSiteConfirm( context ) {
+	disconnectSiteConfirm( context, next ) {
 		const { reason, text } = context.query;
 		context.store.dispatch( setSection( null, { hasSidebar: false } ) );
-		renderPage( context, <ConfirmDisconnection reason={ reason } text={ text } /> );
+		context.primary = <ConfirmDisconnection reason={ reason } text={ text } />;
+		next();
 	},
 
-	startOver( context ) {
-		const redirectIfCantDeleteSite = controller.redirectIfCantDeleteSite;
-
-		redirectIfCantDeleteSite( context );
-
-		renderPage( context, <StartOver path={ context.path } /> );
+	startOver( context, next ) {
+		context.primary = <StartOver path={ context.path } />;
+		next();
 	},
 
-	themeSetup( context ) {
+	themeSetup( context, next ) {
 		const site = getSelectedSite( context.store.getState() );
 		if ( site && site.jetpack ) {
 			return page.redirect( '/settings/general/' + site.slug );
@@ -137,11 +134,13 @@ const controller = {
 			return page.redirect( '/settings/general/' + site.slug );
 		}
 
-		renderPage( context, <ThemeSetup /> );
+		context.primary = <ThemeSetup />;
+		next();
 	},
 
-	manageConnection( context ) {
-		renderPage( context, <ManageConnection /> );
+	manageConnection( context, next ) {
+		context.primary = <ManageConnection />;
+		next();
 	},
 
 	legacyRedirects( context, next ) {

--- a/client/my-sites/site-settings/index.js
+++ b/client/my-sites/site-settings/index.js
@@ -12,54 +12,84 @@ import { navigation, siteSelection, sites } from 'my-sites/controller';
 import controller from 'my-sites/site-settings/controller';
 import settingsController from 'my-sites/site-settings/settings-controller';
 import { reasonComponents as reasons } from './disconnect-site';
+import { makeLayout, render as clientRender } from 'controller';
 
 export default function() {
-	page( '/settings', siteSelection, controller.redirectToGeneral );
+	page( '/settings', siteSelection, controller.redirectToGeneral, makeLayout, clientRender );
 	page(
 		'/settings/general/:site_id',
 		siteSelection,
 		navigation,
 		settingsController.setScroll,
 		settingsController.siteSettings,
-		controller.general
+		controller.general,
+		makeLayout,
+		clientRender
 	);
 
-	page( '/settings/import/:site_id', siteSelection, navigation, controller.importSite );
+	page(
+		'/settings/import/:site_id',
+		siteSelection,
+		navigation,
+		controller.importSite,
+		makeLayout,
+		clientRender
+	);
 
 	if ( config.isEnabled( 'manage/export/guided-transfer' ) ) {
 		page(
 			'/settings/export/guided/:host_slug?/:site_id',
 			siteSelection,
 			navigation,
-			controller.guidedTransfer
+			controller.guidedTransfer,
+			makeLayout,
+			clientRender
 		);
 	}
 
-	page( '/settings/export/:site_id', siteSelection, navigation, controller.exportSite );
+	page(
+		'/settings/export/:site_id',
+		siteSelection,
+		navigation,
+		controller.exportSite,
+		makeLayout,
+		clientRender
+	);
 
 	page(
 		'/settings/delete-site/:site_id',
 		siteSelection,
 		navigation,
 		settingsController.setScroll,
-		controller.deleteSite
+		controller.deleteSite,
+		makeLayout,
+		clientRender
 	);
 
 	const reasonSlugs = Object.keys( reasons );
-	page( `/settings/disconnect-site/:step(${ [ ...reasonSlugs, 'confirm' ].join( '|' ) })?`, sites );
+	page(
+		`/settings/disconnect-site/:step(${ [ ...reasonSlugs, 'confirm' ].join( '|' ) })?`,
+		sites,
+		makeLayout,
+		clientRender
+	);
 
 	page(
 		`/settings/disconnect-site/:reason(${ reasonSlugs.join( '|' ) })?/:site_id`,
 		siteSelection,
 		settingsController.setScroll,
-		controller.disconnectSite
+		controller.disconnectSite,
+		makeLayout,
+		clientRender
 	);
 
 	page(
 		'/settings/disconnect-site/confirm/:site_id',
 		siteSelection,
 		settingsController.setScroll,
-		controller.disconnectSiteConfirm
+		controller.disconnectSiteConfirm,
+		makeLayout,
+		clientRender
 	);
 
 	page(
@@ -67,14 +97,18 @@ export default function() {
 		siteSelection,
 		navigation,
 		settingsController.setScroll,
-		controller.startOver
+		controller.startOver,
+		makeLayout,
+		clientRender
 	);
 	page(
 		'/settings/theme-setup/:site_id',
 		siteSelection,
 		navigation,
 		settingsController.setScroll,
-		controller.themeSetup
+		controller.themeSetup,
+		makeLayout,
+		clientRender
 	);
 
 	page(
@@ -82,8 +116,17 @@ export default function() {
 		siteSelection,
 		navigation,
 		settingsController.setScroll,
-		controller.manageConnection
+		controller.manageConnection,
+		makeLayout,
+		clientRender
 	);
 
-	page( '/settings/:section', controller.legacyRedirects, siteSelection, sites );
+	page(
+		'/settings/:section',
+		controller.legacyRedirects,
+		siteSelection,
+		sites,
+		makeLayout,
+		clientRender
+	);
 }

--- a/client/my-sites/site-settings/index.js
+++ b/client/my-sites/site-settings/index.js
@@ -15,7 +15,7 @@ import { reasonComponents as reasons } from './disconnect-site';
 import { makeLayout, render as clientRender } from 'controller';
 
 export default function() {
-	page( '/settings', siteSelection, controller.redirectToGeneral, makeLayout, clientRender );
+	page( '/settings', siteSelection, controller.redirectToGeneral );
 	page(
 		'/settings/general/:site_id',
 		siteSelection,
@@ -61,6 +61,7 @@ export default function() {
 		siteSelection,
 		navigation,
 		settingsController.setScroll,
+		controller.redirectIfCantDeleteSite,
 		controller.deleteSite,
 		makeLayout,
 		clientRender
@@ -97,6 +98,7 @@ export default function() {
 		siteSelection,
 		navigation,
 		settingsController.setScroll,
+		controller.redirectIfCantDeleteSite,
 		controller.startOver,
 		makeLayout,
 		clientRender

--- a/client/my-sites/site-settings/settings-discussion/controller.js
+++ b/client/my-sites/site-settings/settings-discussion/controller.js
@@ -9,15 +9,11 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import { renderWithReduxStore } from 'lib/react-helpers';
 import DiscussionMain from 'my-sites/site-settings/settings-discussion/main';
 
 export default {
-	discussion( context ) {
-		renderWithReduxStore(
-			React.createElement( DiscussionMain ),
-			document.getElementById( 'primary' ),
-			context.store
-		);
+	discussion( context, next ) {
+		context.primary = React.createElement( DiscussionMain );
+		next();
 	},
 };

--- a/client/my-sites/site-settings/settings-discussion/index.js
+++ b/client/my-sites/site-settings/settings-discussion/index.js
@@ -10,6 +10,7 @@ import page from 'page';
 import controller from './controller';
 import settingsController from 'my-sites/site-settings/settings-controller';
 import { navigation, siteSelection } from 'my-sites/controller';
+import { makeLayout, render as clientRender } from 'controller';
 
 export default function() {
 	page(
@@ -17,6 +18,8 @@ export default function() {
 		siteSelection,
 		navigation,
 		settingsController.siteSettings,
-		controller.discussion
+		controller.discussion,
+		makeLayout,
+		clientRender
 	);
 }

--- a/client/my-sites/site-settings/settings-security/controller.js
+++ b/client/my-sites/site-settings/settings-security/controller.js
@@ -9,15 +9,11 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import { renderWithReduxStore } from 'lib/react-helpers';
 import SecurityMain from 'my-sites/site-settings/settings-security/main';
 
 export default {
-	security( context ) {
-		renderWithReduxStore(
-			React.createElement( SecurityMain ),
-			document.getElementById( 'primary' ),
-			context.store
-		);
+	security( context, next ) {
+		context.primary = React.createElement( SecurityMain );
+		next();
 	},
 };

--- a/client/my-sites/site-settings/settings-security/index.js
+++ b/client/my-sites/site-settings/settings-security/index.js
@@ -10,6 +10,7 @@ import page from 'page';
 import controller from './controller';
 import settingsController from 'my-sites/site-settings/settings-controller';
 import { navigation, siteSelection } from 'my-sites/controller';
+import { makeLayout, render as clientRender } from 'controller';
 
 export default function() {
 	page(
@@ -18,6 +19,8 @@ export default function() {
 		navigation,
 		settingsController.setScroll,
 		settingsController.siteSettings,
-		controller.security
+		controller.security,
+		makeLayout,
+		clientRender
 	);
 }

--- a/client/my-sites/site-settings/settings-traffic/controller.js
+++ b/client/my-sites/site-settings/settings-traffic/controller.js
@@ -9,15 +9,11 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import { renderWithReduxStore } from 'lib/react-helpers';
 import TrafficMain from 'my-sites/site-settings/settings-traffic/main';
 
 export default {
-	traffic( context ) {
-		renderWithReduxStore(
-			React.createElement( TrafficMain ),
-			document.getElementById( 'primary' ),
-			context.store
-		);
+	traffic( context, next ) {
+		context.primary = React.createElement( TrafficMain );
+		next();
 	},
 };

--- a/client/my-sites/site-settings/settings-traffic/index.js
+++ b/client/my-sites/site-settings/settings-traffic/index.js
@@ -10,6 +10,7 @@ import page from 'page';
 import controller from './controller';
 import { navigation, siteSelection } from 'my-sites/controller';
 import settingsController from 'my-sites/site-settings/settings-controller';
+import { makeLayout, render as clientRender } from 'controller';
 
 const redirectToTrafficSection = context => {
 	page.redirect( '/settings/traffic/' + ( context.params.site_id || '' ) );
@@ -21,10 +22,12 @@ export default function() {
 		siteSelection,
 		navigation,
 		settingsController.siteSettings,
-		controller.traffic
+		controller.traffic,
+		makeLayout,
+		clientRender
 	);
 
 	// redirect legacy urls
-	page( '/settings/analytics/:site_id?', redirectToTrafficSection );
-	page( '/settings/seo/:site_id?', redirectToTrafficSection );
+	page( '/settings/analytics/:site_id?', redirectToTrafficSection, makeLayout, clientRender );
+	page( '/settings/seo/:site_id?', redirectToTrafficSection, makeLayout, clientRender );
 }

--- a/client/my-sites/site-settings/settings-traffic/index.js
+++ b/client/my-sites/site-settings/settings-traffic/index.js
@@ -28,6 +28,6 @@ export default function() {
 	);
 
 	// redirect legacy urls
-	page( '/settings/analytics/:site_id?', redirectToTrafficSection, makeLayout, clientRender );
-	page( '/settings/seo/:site_id?', redirectToTrafficSection, makeLayout, clientRender );
+	page( '/settings/analytics/:site_id?', redirectToTrafficSection );
+	page( '/settings/seo/:site_id?', redirectToTrafficSection );
 }

--- a/client/my-sites/site-settings/settings-writing/controller.js
+++ b/client/my-sites/site-settings/settings-writing/controller.js
@@ -9,27 +9,20 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import { renderWithReduxStore } from 'lib/react-helpers';
 import WritingMain from 'my-sites/site-settings/settings-writing/main';
 import Taxonomies from 'my-sites/site-settings/taxonomies';
 
 export default {
-	writing( context ) {
-		renderWithReduxStore(
-			React.createElement( WritingMain ),
-			document.getElementById( 'primary' ),
-			context.store
-		);
+	writing( context, next ) {
+		context.primary = React.createElement( WritingMain );
+		next();
 	},
 
-	taxonomies( context ) {
-		renderWithReduxStore(
-			React.createElement( Taxonomies, {
-				taxonomy: context.params.taxonomy,
-				postType: 'post',
-			} ),
-			document.getElementById( 'primary' ),
-			context.store
-		);
+	taxonomies( context, next ) {
+		context.primary = React.createElement( Taxonomies, {
+			taxonomy: context.params.taxonomy,
+			postType: 'post',
+		} );
+		next();
 	},
 };

--- a/client/my-sites/site-settings/settings-writing/index.js
+++ b/client/my-sites/site-settings/settings-writing/index.js
@@ -11,6 +11,7 @@ import config from 'config';
 import controller from './controller';
 import settingsController from 'my-sites/site-settings/settings-controller';
 import { navigation, siteSelection } from 'my-sites/controller';
+import { makeLayout, render as clientRender } from 'controller';
 
 export default function() {
 	page(
@@ -18,7 +19,9 @@ export default function() {
 		siteSelection,
 		navigation,
 		settingsController.siteSettings,
-		controller.writing
+		controller.writing,
+		makeLayout,
+		clientRender
 	);
 
 	if ( config.isEnabled( 'manage/site-settings/categories' ) ) {
@@ -27,7 +30,9 @@ export default function() {
 			siteSelection,
 			navigation,
 			settingsController.setScroll,
-			controller.taxonomies
+			controller.taxonomies,
+			makeLayout,
+			clientRender
 		);
 	}
 }

--- a/client/my-sites/stats/controller.jsx
+++ b/client/my-sites/stats/controller.jsx
@@ -16,7 +16,6 @@ import route from 'lib/route';
 import analytics from 'lib/analytics';
 import titlecase from 'to-title-case';
 import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
-import { renderWithReduxStore } from 'lib/react-helpers';
 import { savePreference } from 'state/preferences/actions';
 import { getSite, isJetpackSite, getSiteOption } from 'state/sites/selectors';
 import { getCurrentLayoutFocus } from 'state/ui/layout-focus/selectors';
@@ -124,7 +123,7 @@ export default {
 		}
 	},
 
-	insights: function( context ) {
+	insights: function( context, next ) {
 		const FollowList = require( 'lib/follow-list' );
 		let siteId = context.params.site_id;
 		const basePath = route.sectionify( context.path );
@@ -139,15 +138,14 @@ export default {
 		analytics.pageView.record( basePath, analyticsPageTitle + ' > Insights' );
 
 		const props = { followList };
-		renderWithReduxStore(
+		context.primary = (
 			<AsyncLoad
 				require="my-sites/stats/stats-insights"
 				placeholder={ <StatsPagePlaceholder /> }
 				{ ...props }
-			/>,
-			document.getElementById( 'primary' ),
-			context.store
+			/>
 		);
+		next();
 	},
 
 	overview: function( context, next ) {
@@ -198,14 +196,12 @@ export default {
 				period: activeFilter.period,
 				path: context.pathname,
 			};
-			renderWithReduxStore(
+			context.primary = (
 				<AsyncLoad
 					placeholder={ <StatsPagePlaceholder /> }
 					require="my-sites/stats/overview"
 					{ ...props }
-				/>,
-				document.getElementById( 'primary' ),
-				context.store
+				/>
 			);
 		}
 	},
@@ -282,14 +278,12 @@ export default {
 				period,
 			};
 
-			renderWithReduxStore(
+			context.primary = (
 				<AsyncLoad
 					placeholder={ <StatsPagePlaceholder /> }
 					require="my-sites/stats/site"
 					{ ...siteComponentChildren }
-				/>,
-				document.getElementById( 'primary' ),
-				context.store
+				/>
 			);
 		}
 	},
@@ -384,19 +378,17 @@ export default {
 				period,
 				...extraProps,
 			};
-			renderWithReduxStore(
+			context.primary = (
 				<AsyncLoad
 					placeholder={ <StatsPagePlaceholder /> }
 					require="my-sites/stats/summary"
 					{ ...props }
-				/>,
-				document.getElementById( 'primary' ),
-				context.store
+				/>
 			);
 		}
 	},
 
-	post: function( context ) {
+	post: function( context, next ) {
 		let siteId = context.params.site_id;
 		const postId = parseInt( context.params.post_id, 10 );
 		const pathParts = context.path.split( '/' );
@@ -418,19 +410,18 @@ export default {
 				postId,
 				context,
 			};
-			renderWithReduxStore(
+			context.primary = (
 				<AsyncLoad
 					placeholder={ <StatsPagePlaceholder /> }
 					require="my-sites/stats/stats-post-detail"
 					{ ...props }
-				/>,
-				document.getElementById( 'primary' ),
-				context.store
+				/>
 			);
 		}
+		next();
 	},
 
-	follows: function( context ) {
+	follows: function( context, next ) {
 		let siteId = context.params.site_id;
 		const FollowList = require( 'lib/follow-list' );
 		let pageNum = context.params.page_num;
@@ -466,19 +457,18 @@ export default {
 				siteId,
 				followList,
 			};
-			renderWithReduxStore(
+			context.primary = (
 				<AsyncLoad
 					placeholder={ <StatsPagePlaceholder /> }
 					require="my-sites/stats/comment-follows"
 					{ ...props }
-				/>,
-				document.getElementById( 'primary' ),
-				context.store
+				/>
 			);
 		}
+		next();
 	},
 
-	activityLog: function( context ) {
+	activityLog: function( context, next ) {
 		const state = context.store.getState();
 		const siteId = getSelectedSiteId( state );
 		const isJetpack = isJetpackSite( state, siteId );
@@ -497,15 +487,14 @@ export default {
 				context,
 				startDate,
 			};
-			renderWithReduxStore(
+			context.primary = (
 				<AsyncLoad
 					placeholder={ <StatsPagePlaceholder /> }
 					require="my-sites/stats/activity-log"
 					{ ...props }
-				/>,
-				document.getElementById( 'primary' ),
-				context.store
+				/>
 			);
 		}
+		next();
 	},
 };

--- a/client/my-sites/stats/controller.jsx
+++ b/client/my-sites/stats/controller.jsx
@@ -203,6 +203,7 @@ export default {
 					{ ...props }
 				/>
 			);
+			next();
 		}
 	},
 
@@ -285,6 +286,7 @@ export default {
 					{ ...siteComponentChildren }
 				/>
 			);
+			next();
 		}
 	},
 
@@ -385,6 +387,7 @@ export default {
 					{ ...props }
 				/>
 			);
+			next();
 		}
 	},
 

--- a/client/my-sites/stats/index.js
+++ b/client/my-sites/stats/index.js
@@ -10,50 +10,179 @@ import page from 'page';
 import { navigation, siteSelection, sites } from 'my-sites/controller';
 import statsController from './controller';
 import config from 'config';
+import { makeLayout, render as clientRender } from 'controller';
 
 export default function() {
-	page( '/stats/activity/:site_id', siteSelection, navigation, statsController.activityLog );
+	page(
+		'/stats/activity/:site_id',
+		siteSelection,
+		navigation,
+		statsController.activityLog,
+		makeLayout,
+		clientRender
+	);
 
 	if ( config.isEnabled( 'manage/stats' ) ) {
 		// Stat Overview Page
-		page( '/stats', siteSelection, navigation, statsController.overview );
-		page( '/stats/day', siteSelection, navigation, statsController.overview );
-		page( '/stats/week', siteSelection, navigation, statsController.overview );
-		page( '/stats/month', siteSelection, navigation, statsController.overview );
-		page( '/stats/year', siteSelection, navigation, statsController.overview );
+		page( '/stats', siteSelection, navigation, statsController.overview, makeLayout, clientRender );
+		page(
+			'/stats/day',
+			siteSelection,
+			navigation,
+			statsController.overview,
+			makeLayout,
+			clientRender
+		);
+		page(
+			'/stats/week',
+			siteSelection,
+			navigation,
+			statsController.overview,
+			makeLayout,
+			clientRender
+		);
+		page(
+			'/stats/month',
+			siteSelection,
+			navigation,
+			statsController.overview,
+			makeLayout,
+			clientRender
+		);
+		page(
+			'/stats/year',
+			siteSelection,
+			navigation,
+			statsController.overview,
+			makeLayout,
+			clientRender
+		);
 
 		// Stat Insights Page
-		page( '/stats/insights/:site_id', siteSelection, navigation, statsController.insights );
+		page(
+			'/stats/insights/:site_id',
+			siteSelection,
+			navigation,
+			statsController.insights,
+			makeLayout,
+			clientRender
+		);
 
 		// Stat Site Pages
-		page( '/stats/day/:site_id', siteSelection, navigation, statsController.site );
-		page( '/stats/week/:site_id', siteSelection, navigation, statsController.site );
-		page( '/stats/month/:site_id', siteSelection, navigation, statsController.site );
-		page( '/stats/year/:site_id', siteSelection, navigation, statsController.site );
+		page(
+			'/stats/day/:site_id',
+			siteSelection,
+			navigation,
+			statsController.site,
+			makeLayout,
+			clientRender
+		);
+		page(
+			'/stats/week/:site_id',
+			siteSelection,
+			navigation,
+			statsController.site,
+			makeLayout,
+			clientRender
+		);
+		page(
+			'/stats/month/:site_id',
+			siteSelection,
+			navigation,
+			statsController.site,
+			makeLayout,
+			clientRender
+		);
+		page(
+			'/stats/year/:site_id',
+			siteSelection,
+			navigation,
+			statsController.site,
+			makeLayout,
+			clientRender
+		);
 
 		// Stat Summary Pages
-		page( '/stats/:module/:site_id', siteSelection, navigation, statsController.summary );
-		page( '/stats/day/:module/:site_id', siteSelection, navigation, statsController.summary );
-		page( '/stats/week/:module/:site_id', siteSelection, navigation, statsController.summary );
-		page( '/stats/month/:module/:site_id', siteSelection, navigation, statsController.summary );
-		page( '/stats/year/:module/:site_id', siteSelection, navigation, statsController.summary );
+		page(
+			'/stats/:module/:site_id',
+			siteSelection,
+			navigation,
+			statsController.summary,
+			makeLayout,
+			clientRender
+		);
+		page(
+			'/stats/day/:module/:site_id',
+			siteSelection,
+			navigation,
+			statsController.summary,
+			makeLayout,
+			clientRender
+		);
+		page(
+			'/stats/week/:module/:site_id',
+			siteSelection,
+			navigation,
+			statsController.summary,
+			makeLayout,
+			clientRender
+		);
+		page(
+			'/stats/month/:module/:site_id',
+			siteSelection,
+			navigation,
+			statsController.summary,
+			makeLayout,
+			clientRender
+		);
+		page(
+			'/stats/year/:module/:site_id',
+			siteSelection,
+			navigation,
+			statsController.summary,
+			makeLayout,
+			clientRender
+		);
 
 		// Stat Single Post Page
-		page( '/stats/post/:post_id/:site_id', siteSelection, navigation, statsController.post );
-		page( '/stats/page/:post_id/:site_id', siteSelection, navigation, statsController.post );
+		page(
+			'/stats/post/:post_id/:site_id',
+			siteSelection,
+			navigation,
+			statsController.post,
+			makeLayout,
+			clientRender
+		);
+		page(
+			'/stats/page/:post_id/:site_id',
+			siteSelection,
+			navigation,
+			statsController.post,
+			makeLayout,
+			clientRender
+		);
 
 		// Stat Follows Page
-		page( '/stats/follows/comment/:site_id', siteSelection, navigation, statsController.follows );
+		page(
+			'/stats/follows/comment/:site_id',
+			siteSelection,
+			navigation,
+			statsController.follows,
+			makeLayout,
+			clientRender
+		);
 		page(
 			'/stats/follows/comment/:page_num/:site_id',
 			siteSelection,
 			navigation,
-			statsController.follows
+			statsController.follows,
+			makeLayout,
+			clientRender
 		);
 
 		// Reset first view
 		if ( config.isEnabled( 'ui/first-view/reset-route' ) ) {
-			page( '/stats/reset-first-view', statsController.resetFirstView );
+			page( '/stats/reset-first-view', statsController.resetFirstView, makeLayout, clientRender );
 		}
 
 		// Anything else should require site-selection
@@ -62,7 +191,9 @@ export default function() {
 			siteSelection,
 			navigation,
 			statsController.redirectToDefaultSitePage,
-			sites
+			sites,
+			makeLayout,
+			clientRender
 		);
 	}
 }

--- a/client/my-sites/themes/index.web.js
+++ b/client/my-sites/themes/index.web.js
@@ -7,7 +7,7 @@
 import config from 'config';
 import userFactory from 'lib/user';
 import { makeLayout } from 'controller';
-import { makeNavigation, siteSelection, makeSites } from 'my-sites/controller';
+import { navigation, siteSelection, makeSites } from 'my-sites/controller';
 import { loggedIn, loggedOut, upload, fetchThemeFilters } from './controller';
 import { validateFilters, validateVertical } from './validate-filters';
 
@@ -23,7 +23,7 @@ export default function( router ) {
 		if ( isLoggedIn ) {
 			if ( config.isEnabled( 'manage/themes/upload' ) ) {
 				router( '/themes/upload', makeSites, makeLayout );
-				router( '/themes/upload/:site_id?', siteSelection, upload, makeNavigation, makeLayout );
+				router( '/themes/upload/:site_id?', siteSelection, upload, navigation, makeLayout );
 			}
 			const loggedInRoutes = [
 				`/themes/:tier(free|premium)?/:site_id(${ siteId })?`,
@@ -38,7 +38,7 @@ export default function( router ) {
 				validateFilters,
 				siteSelection,
 				loggedIn,
-				makeNavigation,
+				navigation,
 				makeLayout
 			);
 		} else {

--- a/client/my-sites/themes/index.web.js
+++ b/client/my-sites/themes/index.web.js
@@ -7,7 +7,7 @@
 import config from 'config';
 import userFactory from 'lib/user';
 import { makeLayout } from 'controller';
-import { navigation, siteSelection, makeSites } from 'my-sites/controller';
+import { navigation, siteSelection, sites } from 'my-sites/controller';
 import { loggedIn, loggedOut, upload, fetchThemeFilters } from './controller';
 import { validateFilters, validateVertical } from './validate-filters';
 
@@ -22,7 +22,7 @@ export default function( router ) {
 	if ( config.isEnabled( 'manage/themes' ) ) {
 		if ( isLoggedIn ) {
 			if ( config.isEnabled( 'manage/themes/upload' ) ) {
-				router( '/themes/upload', makeSites, makeLayout );
+				router( '/themes/upload', sites, makeLayout );
 				router( '/themes/upload/:site_id?', siteSelection, upload, navigation, makeLayout );
 			}
 			const loggedInRoutes = [

--- a/client/my-sites/types/index.js
+++ b/client/my-sites/types/index.js
@@ -5,7 +5,7 @@
  */
 
 import { makeLayout } from 'controller';
-import { siteSelection, makeNavigation, sites } from 'my-sites/controller';
+import { siteSelection, navigation, sites } from 'my-sites/controller';
 import { list, redirect } from './controller';
 import config from 'config';
 
@@ -14,7 +14,7 @@ export default function( router ) {
 		return;
 	}
 
-	router( '/types/:type/:status?/:site', siteSelection, makeNavigation, list, makeLayout );
+	router( '/types/:type/:status?/:site', siteSelection, navigation, list, makeLayout );
 	router( '/types/:type', siteSelection, sites, makeLayout );
 	router( '/types', redirect );
 }

--- a/client/post-editor/controller.js
+++ b/client/post-editor/controller.js
@@ -8,7 +8,6 @@ import ReactDomServer from 'react-dom/server';
 import React from 'react';
 import i18n from 'i18n-calypso';
 import page from 'page';
-import { Provider as ReduxProvider } from 'react-redux';
 import qs from 'querystring';
 import { isWebUri as isValidUrl } from 'valid-url';
 import { map, pick, reduce, startsWith } from 'lodash';
@@ -56,14 +55,10 @@ function determinePostType( context ) {
 }
 
 function renderEditor( context, next ) {
-	context.primary = React.createElement(
-		ReduxProvider,
-		{ store: context.store },
-		React.createElement( PostEditor, {
-			user: user,
-			userUtils: userUtils,
-		} )
-	);
+	context.primary = React.createElement( PostEditor, {
+		user: user,
+		userUtils: userUtils,
+	} );
 	next();
 }
 

--- a/client/post-editor/controller.js
+++ b/client/post-editor/controller.js
@@ -4,7 +4,6 @@
  * External dependencies
  */
 
-import ReactDom from 'react-dom';
 import ReactDomServer from 'react-dom/server';
 import React from 'react';
 import i18n from 'i18n-calypso';
@@ -56,19 +55,16 @@ function determinePostType( context ) {
 	return context.params.type;
 }
 
-function renderEditor( context ) {
-	ReactDom.unmountComponentAtNode( document.getElementById( 'secondary' ) );
-	ReactDom.render(
-		React.createElement(
-			ReduxProvider,
-			{ store: context.store },
-			React.createElement( PostEditor, {
-				user: user,
-				userUtils: userUtils,
-			} )
-		),
-		document.getElementById( 'primary' )
+function renderEditor( context, next ) {
+	context.primary = React.createElement(
+		ReduxProvider,
+		{ store: context.store },
+		React.createElement( PostEditor, {
+			user: user,
+			userUtils: userUtils,
+		} )
 	);
+	next();
 }
 
 function maybeRedirect( context ) {

--- a/client/post-editor/controller.js
+++ b/client/post-editor/controller.js
@@ -54,12 +54,11 @@ function determinePostType( context ) {
 	return context.params.type;
 }
 
-function renderEditor( context, next ) {
+function renderEditor( context ) {
 	context.primary = React.createElement( PostEditor, {
 		user: user,
 		userUtils: userUtils,
 	} );
-	next();
 }
 
 function maybeRedirect( context ) {
@@ -196,7 +195,7 @@ function startEditingPostCopy( site, postToCopyId, context ) {
 }
 
 export default {
-	post: function( context ) {
+	post: function( context, next ) {
 		const postType = determinePostType( context );
 		const postID = getPostID( context );
 		const postToCopyId = context.query.copy;
@@ -280,6 +279,8 @@ export default {
 		}
 
 		renderEditor( context );
+
+		next();
 	},
 
 	exitPost: function( context, next ) {

--- a/client/post-editor/index.js
+++ b/client/post-editor/index.js
@@ -10,22 +10,23 @@ import page from 'page';
 import { siteSelection, sites } from 'my-sites/controller';
 import controller from './controller';
 import config from 'config';
+import { makeLayout, render as clientRender } from 'controller';
 
 export default function() {
-	page( '/post', controller.pressThis, siteSelection, sites );
+	page( '/post', controller.pressThis, siteSelection, sites, makeLayout, clientRender );
 	page( '/post/new', () => page.redirect( '/post' ) ); // redirect from beep-beep-boop
-	page( '/post/:site?/:post?', siteSelection, controller.post );
+	page( '/post/:site?/:post?', siteSelection, controller.post, makeLayout, clientRender );
 	page.exit( '/post/:site?/:post?', controller.exitPost );
 
-	page( '/page', siteSelection, sites );
+	page( '/page', siteSelection, sites, makeLayout, clientRender );
 	page( '/page/new', () => page.redirect( '/page' ) ); // redirect from beep-beep-boop
-	page( '/page/:site?/:post?', siteSelection, controller.post );
+	page( '/page/:site?/:post?', siteSelection, controller.post, makeLayout, clientRender );
 	page.exit( '/page/:site?/:post?', controller.exitPost );
 
 	if ( config.isEnabled( 'manage/custom-post-types' ) ) {
-		page( '/edit/:type', siteSelection, sites );
+		page( '/edit/:type', siteSelection, sites, makeLayout, clientRender );
 		page( '/edit/:type/new', context => page.redirect( `/edit/${ context.params.type }` ) );
-		page( '/edit/:type/:site?/:post?', siteSelection, controller.post );
+		page( '/edit/:type/:site?/:post?', siteSelection, controller.post, makeLayout, clientRender );
 		page.exit( '/edit/:type/:site?/:post?', controller.exitPost );
 	}
 }

--- a/client/reader/controller.js
+++ b/client/reader/controller.js
@@ -2,7 +2,6 @@
 /**
  * External Dependencies
  */
-import ReactDom from 'react-dom';
 import React from 'react';
 import page from 'page';
 import i18n from 'i18n-calypso';
@@ -26,7 +25,6 @@ import StreamComponent from 'reader/following/main';
 import { getPrettyFeedUrl, getPrettySiteUrl } from 'reader/route';
 import { recordTrack } from 'reader/stats';
 import { preload } from 'sections-preload';
-import { renderWithReduxStore } from 'lib/react-helpers';
 import AsyncLoad from 'components/async-load';
 
 const analyticsPageTitle = 'Reader';
@@ -40,12 +38,9 @@ function userHasHistory( context ) {
 	return !! context.lastRoute;
 }
 
-function renderFeedError( context ) {
-	renderWithReduxStore(
-		React.createElement( FeedError ),
-		document.getElementById( 'primary' ),
-		context.store
-	);
+function renderFeedError( context, next ) {
+	context.primary = React.createElement( FeedError );
+	next();
 }
 
 const exported = {
@@ -122,21 +117,16 @@ const exported = {
 	},
 
 	sidebar( context, next ) {
-		renderWithReduxStore(
-			<AsyncLoad require="reader/sidebar" path={ context.path } />,
-			document.getElementById( 'secondary' ),
-			context.store
-		);
+		context.secondary = <AsyncLoad require="reader/sidebar" path={ context.path } />;
 
 		next();
 	},
 
 	unmountSidebar( context, next ) {
-		ReactDom.unmountComponentAtNode( document.getElementById( 'secondary' ) );
 		next();
 	},
 
-	following( context ) {
+	following( context, next ) {
 		const basePath = route.sectionify( context.path ),
 			fullAnalyticsPageTitle = analyticsPageTitle + ' > Following',
 			followingStore = feedStreamFactory( 'following' ),
@@ -153,25 +143,22 @@ const exported = {
 		setPageTitle( context, i18n.translate( 'Following' ) );
 
 		// warn: don't async load this only. we need it to keep feed-post-store in the reader bundle
-		renderWithReduxStore(
-			React.createElement( StreamComponent, {
-				key: 'following',
-				listName: i18n.translate( 'Followed Sites' ),
-				postsStore: followingStore,
-				recommendationsStore,
-				showPrimaryFollowButtonOnCards: false,
-				trackScrollPage: trackScrollPage.bind(
-					null,
-					basePath,
-					fullAnalyticsPageTitle,
-					analyticsPageTitle,
-					mcKey
-				),
-				onUpdatesShown: trackUpdatesLoaded.bind( null, mcKey ),
-			} ),
-			'primary',
-			context.store
-		);
+		context.primary = React.createElement( StreamComponent, {
+			key: 'following',
+			listName: i18n.translate( 'Followed Sites' ),
+			postsStore: followingStore,
+			recommendationsStore,
+			showPrimaryFollowButtonOnCards: false,
+			trackScrollPage: trackScrollPage.bind(
+				null,
+				basePath,
+				fullAnalyticsPageTitle,
+				analyticsPageTitle,
+				mcKey
+			),
+			onUpdatesShown: trackUpdatesLoaded.bind( null, mcKey ),
+		} );
+		next();
 	},
 
 	feedDiscovery( context, next ) {
@@ -188,7 +175,7 @@ const exported = {
 		}
 	},
 
-	feedListing( context ) {
+	feedListing( context, next ) {
 		const basePath = '/read/feeds/:feed_id',
 			fullAnalyticsPageTitle = analyticsPageTitle + ' > Feed > ' + context.params.feed_id,
 			feedStore = feedStreamFactory( 'feed:' + context.params.feed_id ),
@@ -201,7 +188,7 @@ const exported = {
 			feed_id: context.params.feed_id,
 		} );
 
-		renderWithReduxStore(
+		context.primary = (
 			<AsyncLoad
 				require="reader/feed-stream"
 				key={ 'feed-' + context.params.feed_id }
@@ -218,13 +205,12 @@ const exported = {
 				showPrimaryFollowButtonOnCards={ false }
 				suppressSiteNameLink={ true }
 				showBack={ userHasHistory( context ) }
-			/>,
-			document.getElementById( 'primary' ),
-			context.store
+			/>
 		);
+		next();
 	},
 
-	blogListing( context ) {
+	blogListing( context, next ) {
 		const basePath = '/read/blogs/:blog_id',
 			fullAnalyticsPageTitle = analyticsPageTitle + ' > Site > ' + context.params.blog_id,
 			feedStore = feedStreamFactory( 'site:' + context.params.blog_id ),
@@ -237,7 +223,7 @@ const exported = {
 			blog_id: context.params.blog_id,
 		} );
 
-		renderWithReduxStore(
+		context.primary = (
 			<AsyncLoad
 				require="reader/site-stream"
 				key={ 'site-' + context.params.blog_id }
@@ -254,13 +240,12 @@ const exported = {
 				showPrimaryFollowButtonOnCards={ false }
 				suppressSiteNameLink={ true }
 				showBack={ userHasHistory( context ) }
-			/>,
-			document.getElementById( 'primary' ),
-			context.store
+			/>
 		);
+		next();
 	},
 
-	readA8C( context ) {
+	readA8C( context, next ) {
 		const basePath = route.sectionify( context.path ),
 			fullAnalyticsPageTitle = analyticsPageTitle + ' > A8C',
 			feedStore = feedStreamFactory( 'a8c' ),
@@ -272,7 +257,7 @@ const exported = {
 
 		setPageTitle( context, 'Automattic' );
 
-		renderWithReduxStore(
+		context.primary = (
 			<AsyncLoad
 				require="reader/team/main"
 				key="read-a8c"
@@ -288,10 +273,9 @@ const exported = {
 				) }
 				showPrimaryFollowButtonOnCards={ false }
 				onUpdatesShown={ trackUpdatesLoaded.bind( null, mcKey ) }
-			/>,
-			document.getElementById( 'primary' ),
-			context.store
+			/>
 		);
+		next();
 	},
 };
 

--- a/client/reader/conversations/controller.js
+++ b/client/reader/conversations/controller.js
@@ -9,12 +9,11 @@ import React from 'react';
  */
 import route from 'lib/route';
 import { recordTrack } from 'reader/stats';
-import { renderWithReduxStore } from 'lib/react-helpers';
 import AsyncLoad from 'components/async-load';
 import { trackPageLoad, trackScrollPage, ensureStoreLoading } from 'reader/controller-helper';
 import feedStreamStore from 'lib/feed-stream-store';
 
-export function conversations( context ) {
+export function conversations( context, next ) {
 	const basePath = route.sectionify( context.path );
 	const mcKey = 'conversations';
 	const title = 'Reader > Conversations';
@@ -27,20 +26,19 @@ export function conversations( context ) {
 
 	const scrollTracker = trackScrollPage.bind( null, '/read/conversations', title, 'Reader', mcKey );
 
-	renderWithReduxStore(
+	context.primary = (
 		<AsyncLoad
 			require="reader/conversations/stream"
 			key={ 'conversations' }
 			title="Conversations"
 			store={ convoStream }
 			trackScrollPage={ scrollTracker }
-		/>,
-		document.getElementById( 'primary' ),
-		context.store
+		/>
 	);
+	next();
 }
 
-export function conversationsA8c( context ) {
+export function conversationsA8c( context, next ) {
 	const basePath = route.sectionify( context.path );
 	const mcKey = 'conversations-a8c';
 	const title = 'Reader > Conversations > Automattic';
@@ -59,15 +57,14 @@ export function conversationsA8c( context ) {
 		mcKey
 	);
 
-	renderWithReduxStore(
+	context.primary = (
 		<AsyncLoad
 			require="reader/conversations/stream"
 			key={ 'conversations' }
 			title="Conversations @ Automattic"
 			store={ convoStream }
 			trackScrollPage={ scrollTracker }
-		/>,
-		document.getElementById( 'primary' ),
-		context.store
+		/>
 	);
+	next();
 }

--- a/client/reader/conversations/index.js
+++ b/client/reader/conversations/index.js
@@ -10,6 +10,7 @@ import page from 'page';
 import config from 'config';
 import { conversations, conversationsA8c } from './controller';
 import { initAbTests, preloadReaderBundle, sidebar, updateLastRoute } from 'reader/controller';
+import { makeLayout, render as clientRender } from 'controller';
 
 export default function() {
 	if ( config.isEnabled( 'reader/conversations' ) ) {
@@ -19,7 +20,9 @@ export default function() {
 			updateLastRoute,
 			initAbTests,
 			sidebar,
-			conversations
+			conversations,
+			makeLayout,
+			clientRender
 		);
 
 		page(
@@ -28,7 +31,9 @@ export default function() {
 			updateLastRoute,
 			initAbTests,
 			sidebar,
-			conversationsA8c
+			conversationsA8c,
+			makeLayout,
+			clientRender
 		);
 	} else {
 		page( '/read/conversations', '/' );

--- a/client/reader/discover/controller.js
+++ b/client/reader/discover/controller.js
@@ -17,13 +17,12 @@ import {
 	trackUpdatesLoaded,
 	trackScrollPage,
 } from 'reader/controller-helper';
-import { renderWithReduxStore } from 'lib/react-helpers';
 import AsyncLoad from 'components/async-load';
 
 const ANALYTICS_PAGE_TITLE = 'Reader';
 
 const exported = {
-	discover( context ) {
+	discover( context, next ) {
 		const blogId = config( 'discover_blog_id' );
 		const basePath = route.sectionify( context.path );
 		const fullAnalyticsPageTitle = ANALYTICS_PAGE_TITLE + ' > Site > ' + blogId;
@@ -38,7 +37,7 @@ const exported = {
 		trackPageLoad( basePath, fullAnalyticsPageTitle, mcKey );
 		recordTrack( 'calypso_reader_discover_viewed' );
 
-		renderWithReduxStore(
+		context.primary = (
 			<AsyncLoad
 				require="reader/site-stream"
 				key={ 'site-' + blogId }
@@ -59,10 +58,9 @@ const exported = {
 				showBack={ false }
 				className="is-discover-stream is-site-stream"
 				featuredStore={ featuredStore }
-			/>,
-			document.getElementById( 'primary' ),
-			context.store
+			/>
 		);
+		next();
 	},
 };
 

--- a/client/reader/discover/index.js
+++ b/client/reader/discover/index.js
@@ -9,7 +9,17 @@ import page from 'page';
  */
 import { discover } from './controller';
 import { initAbTests, preloadReaderBundle, sidebar, updateLastRoute } from 'reader/controller';
+import { makeLayout, render as clientRender } from 'controller';
 
 export default function() {
-	page( '/discover', preloadReaderBundle, updateLastRoute, initAbTests, sidebar, discover );
+	page(
+		'/discover',
+		preloadReaderBundle,
+		updateLastRoute,
+		initAbTests,
+		sidebar,
+		discover,
+		makeLayout,
+		clientRender
+	);
 }

--- a/client/reader/following/controller.js
+++ b/client/reader/following/controller.js
@@ -11,13 +11,12 @@ import i18n from 'i18n-calypso';
 import route from 'lib/route';
 import userSettings from 'lib/user-settings';
 import { trackPageLoad, setPageTitle } from 'reader/controller-helper';
-import { renderWithReduxStore } from 'lib/react-helpers';
 import AsyncLoad from 'components/async-load';
 
 const analyticsPageTitle = 'Reader';
 
 const exported = {
-	followingManage( context ) {
+	followingManage( context, next ) {
 		const basePath = route.sectionify( context.path );
 		const fullAnalyticsPageTitle = analyticsPageTitle + ' > Manage Followed Sites';
 		const mcKey = 'following_manage';
@@ -27,7 +26,7 @@ const exported = {
 
 		trackPageLoad( basePath, fullAnalyticsPageTitle, mcKey );
 
-		renderWithReduxStore(
+		context.primary = (
 			<AsyncLoad
 				require="reader/following-manage"
 				key="following-manage"
@@ -38,10 +37,9 @@ const exported = {
 				subsSortOrder={ subsSortOrder }
 				context={ context }
 				userSettings={ userSettings }
-			/>,
-			document.getElementById( 'primary' ),
-			context.store
+			/>
 		);
+		next();
 	},
 };
 

--- a/client/reader/following/index.js
+++ b/client/reader/following/index.js
@@ -9,9 +9,10 @@ import page from 'page';
  */
 import { followingManage } from './controller';
 import { initAbTests, updateLastRoute, sidebar } from 'reader/controller';
+import { makeLayout, render as clientRender } from 'controller';
 
 export default function() {
-	page( '/following/*', initAbTests );
-	page( '/following/manage', updateLastRoute, sidebar, followingManage );
+	page( '/following/*', initAbTests, makeLayout, clientRender );
+	page( '/following/manage', updateLastRoute, sidebar, followingManage, makeLayout, clientRender );
 	page.redirect( '/following/edit*', '/following/manage' );
 }

--- a/client/reader/following/index.js
+++ b/client/reader/following/index.js
@@ -12,7 +12,7 @@ import { initAbTests, updateLastRoute, sidebar } from 'reader/controller';
 import { makeLayout, render as clientRender } from 'controller';
 
 export default function() {
-	page( '/following/*', initAbTests, makeLayout, clientRender );
+	page( '/following/*', initAbTests );
 	page( '/following/manage', updateLastRoute, sidebar, followingManage, makeLayout, clientRender );
 	page.redirect( '/following/edit*', '/following/manage' );
 }

--- a/client/reader/full-post/controller.js
+++ b/client/reader/full-post/controller.js
@@ -11,7 +11,6 @@ import { defer } from 'lodash';
  */
 import { trackPageLoad } from 'reader/controller-helper';
 import AsyncLoad from 'components/async-load';
-import { renderWithReduxStore } from 'lib/react-helpers';
 
 const analyticsPageTitle = 'Reader';
 
@@ -22,7 +21,7 @@ const scrollTopIfNoHash = () =>
 		}
 	} );
 
-export function blogPost( context ) {
+export function blogPost( context, next ) {
 	const blogId = context.params.blog,
 		postId = context.params.post,
 		basePath = '/read/blogs/:blog_id/posts/:post_id',
@@ -34,7 +33,7 @@ export function blogPost( context ) {
 	}
 	trackPageLoad( basePath, fullPageTitle, 'full_post' );
 
-	renderWithReduxStore(
+	context.primary = (
 		<AsyncLoad
 			require="blocks/reader-full-post"
 			blogId={ blogId }
@@ -44,14 +43,13 @@ export function blogPost( context ) {
 			onClose={ function() {
 				page.back( context.lastRoute || '/' );
 			} }
-		/>,
-		document.getElementById( 'primary' ),
-		context.store
+		/>
 	);
 	scrollTopIfNoHash();
+	next();
 }
 
-export function feedPost( context ) {
+export function feedPost( context, next ) {
 	const feedId = context.params.feed,
 		postId = context.params.post,
 		basePath = '/read/feeds/:feed_id/posts/:feed_item_id',
@@ -63,16 +61,15 @@ export function feedPost( context ) {
 		page.back( context.lastRoute || '/' );
 	}
 
-	renderWithReduxStore(
+	context.primary = (
 		<AsyncLoad
 			require="blocks/reader-full-post"
 			feedId={ feedId }
 			postId={ postId }
 			onClose={ closer }
 			referralStream={ context.lastRoute }
-		/>,
-		document.getElementById( 'primary' ),
-		context.store
+		/>
 	);
 	scrollTopIfNoHash();
+	next();
 }

--- a/client/reader/full-post/index.js
+++ b/client/reader/full-post/index.js
@@ -9,11 +9,26 @@ import page from 'page';
  */
 import { blogPost, feedPost } from './controller';
 import { updateLastRoute, unmountSidebar } from 'reader/controller';
+import { makeLayout, render as clientRender } from 'controller';
 
 export default function() {
 	// Feed full post
-	page( '/read/feeds/:feed/posts/:post', updateLastRoute, unmountSidebar, feedPost );
+	page(
+		'/read/feeds/:feed/posts/:post',
+		updateLastRoute,
+		unmountSidebar,
+		feedPost,
+		makeLayout,
+		clientRender
+	);
 
 	// Blog full post
-	page( '/read/blogs/:blog/posts/:post', updateLastRoute, unmountSidebar, blogPost );
+	page(
+		'/read/blogs/:blog/posts/:post',
+		updateLastRoute,
+		unmountSidebar,
+		blogPost,
+		makeLayout,
+		clientRender
+	);
 }

--- a/client/reader/index.js
+++ b/client/reader/index.js
@@ -22,6 +22,7 @@ import {
 	updateLastRoute,
 } from './controller';
 import config from 'config';
+import { makeLayout, render as clientRender } from 'controller';
 
 function forceTeamA8C( context, next ) {
 	context.params.team = 'a8c';
@@ -30,7 +31,16 @@ function forceTeamA8C( context, next ) {
 
 export default function() {
 	if ( config.isEnabled( 'reader' ) ) {
-		page( '/', preloadReaderBundle, initAbTests, updateLastRoute, sidebar, following );
+		page(
+			'/',
+			preloadReaderBundle,
+			initAbTests,
+			updateLastRoute,
+			sidebar,
+			following,
+			makeLayout,
+			clientRender
+		);
 
 		// Old and incomplete paths that should be redirected to /
 		page( '/read/following', '/' );
@@ -42,28 +52,38 @@ export default function() {
 		page( '/read/feed', '/' );
 
 		// Feed stream
-		page( '/read/*', preloadReaderBundle, initAbTests );
-		page( '/read/blog/feed/:feed_id', legacyRedirects );
-		page( '/read/feeds/:feed_id/posts', incompleteUrlRedirects );
+		page( '/read/*', preloadReaderBundle, initAbTests, makeLayout, clientRender );
+		page( '/read/blog/feed/:feed_id', legacyRedirects, makeLayout, clientRender );
+		page( '/read/feeds/:feed_id/posts', incompleteUrlRedirects, makeLayout, clientRender );
 		page(
 			'/read/feeds/:feed_id',
 			updateLastRoute,
 			prettyRedirects,
 			sidebar,
 			feedDiscovery,
-			feedListing
+			feedListing,
+			makeLayout,
+			clientRender
 		);
 
 		// Blog stream
-		page( '/read/blog/id/:blog_id', legacyRedirects );
-		page( '/read/blogs/:blog_id/posts', incompleteUrlRedirects );
-		page( '/read/blogs/:blog_id', updateLastRoute, prettyRedirects, sidebar, blogListing );
+		page( '/read/blog/id/:blog_id', legacyRedirects, makeLayout, clientRender );
+		page( '/read/blogs/:blog_id/posts', incompleteUrlRedirects, makeLayout, clientRender );
+		page(
+			'/read/blogs/:blog_id',
+			updateLastRoute,
+			prettyRedirects,
+			sidebar,
+			blogListing,
+			makeLayout,
+			clientRender
+		);
 
 		// Old full post view
-		page( '/read/post/feed/:feed_id/:post_id', legacyRedirects );
-		page( '/read/post/id/:blog_id/:post_id', legacyRedirects );
+		page( '/read/post/feed/:feed_id/:post_id', legacyRedirects, makeLayout, clientRender );
+		page( '/read/post/id/:blog_id/:post_id', legacyRedirects, makeLayout, clientRender );
 	}
 
 	// Automattic Employee Posts
-	page( '/read/a8c', updateLastRoute, sidebar, forceTeamA8C, readA8C );
+	page( '/read/a8c', updateLastRoute, sidebar, forceTeamA8C, readA8C, makeLayout, clientRender );
 }

--- a/client/reader/index.js
+++ b/client/reader/index.js
@@ -52,9 +52,9 @@ export default function() {
 		page( '/read/feed', '/' );
 
 		// Feed stream
-		page( '/read/*', preloadReaderBundle, initAbTests, makeLayout, clientRender );
-		page( '/read/blog/feed/:feed_id', legacyRedirects, makeLayout, clientRender );
-		page( '/read/feeds/:feed_id/posts', incompleteUrlRedirects, makeLayout, clientRender );
+		page( '/read/*', preloadReaderBundle, initAbTests );
+		page( '/read/blog/feed/:feed_id', legacyRedirects );
+		page( '/read/feeds/:feed_id/posts', incompleteUrlRedirects );
 		page(
 			'/read/feeds/:feed_id',
 			updateLastRoute,
@@ -67,8 +67,8 @@ export default function() {
 		);
 
 		// Blog stream
-		page( '/read/blog/id/:blog_id', legacyRedirects, makeLayout, clientRender );
-		page( '/read/blogs/:blog_id/posts', incompleteUrlRedirects, makeLayout, clientRender );
+		page( '/read/blog/id/:blog_id', legacyRedirects );
+		page( '/read/blogs/:blog_id/posts', incompleteUrlRedirects );
 		page(
 			'/read/blogs/:blog_id',
 			updateLastRoute,
@@ -80,8 +80,8 @@ export default function() {
 		);
 
 		// Old full post view
-		page( '/read/post/feed/:feed_id/:post_id', legacyRedirects, makeLayout, clientRender );
-		page( '/read/post/id/:blog_id/:post_id', legacyRedirects, makeLayout, clientRender );
+		page( '/read/post/feed/:feed_id/:post_id', legacyRedirects );
+		page( '/read/post/id/:blog_id/:post_id', legacyRedirects );
 	}
 
 	// Automattic Employee Posts

--- a/client/reader/liked-stream/controller.js
+++ b/client/reader/liked-stream/controller.js
@@ -16,12 +16,11 @@ import {
 	trackScrollPage,
 } from 'reader/controller-helper';
 import LikedPostsStream from 'reader/liked-stream/main';
-import { renderWithReduxStore } from 'lib/react-helpers';
 
 const analyticsPageTitle = 'Reader';
 
 const exported = {
-	likes( context ) {
+	likes( context, next ) {
 		const basePath = route.sectionify( context.path ),
 			fullAnalyticsPageTitle = analyticsPageTitle + ' > My Likes',
 			likedPostsStore = feedStreamFactory( 'likes' ),
@@ -31,22 +30,19 @@ const exported = {
 
 		trackPageLoad( basePath, fullAnalyticsPageTitle, mcKey );
 
-		renderWithReduxStore(
-			React.createElement( LikedPostsStream, {
-				key: 'liked',
-				postsStore: likedPostsStore,
-				trackScrollPage: trackScrollPage.bind(
-					null,
-					basePath,
-					fullAnalyticsPageTitle,
-					analyticsPageTitle,
-					mcKey
-				),
-				onUpdatesShown: trackUpdatesLoaded.bind( null, mcKey ),
-			} ),
-			document.getElementById( 'primary' ),
-			context.store
-		);
+		context.primary = React.createElement( LikedPostsStream, {
+			key: 'liked',
+			postsStore: likedPostsStore,
+			trackScrollPage: trackScrollPage.bind(
+				null,
+				basePath,
+				fullAnalyticsPageTitle,
+				analyticsPageTitle,
+				mcKey
+			),
+			onUpdatesShown: trackUpdatesLoaded.bind( null, mcKey ),
+		} );
+		next();
 	},
 };
 

--- a/client/reader/liked-stream/index.js
+++ b/client/reader/liked-stream/index.js
@@ -9,7 +9,17 @@ import page from 'page';
  */
 import { likes } from './controller';
 import { preloadReaderBundle, initAbTests, updateLastRoute, sidebar } from 'reader/controller';
+import { makeLayout, render as clientRender } from 'controller';
 
 export default function() {
-	page( '/activities/likes', preloadReaderBundle, initAbTests, updateLastRoute, sidebar, likes );
+	page(
+		'/activities/likes',
+		preloadReaderBundle,
+		initAbTests,
+		updateLastRoute,
+		sidebar,
+		likes,
+		makeLayout,
+		clientRender
+	);
 }

--- a/client/reader/list/controller.js
+++ b/client/reader/list/controller.js
@@ -15,13 +15,12 @@ import {
 	trackUpdatesLoaded,
 	trackScrollPage,
 } from 'reader/controller-helper';
-import { renderWithReduxStore } from 'lib/react-helpers';
 import AsyncLoad from 'components/async-load';
 
 const analyticsPageTitle = 'Reader';
 
 const exported = {
-	listListing( context ) {
+	listListing( context, next ) {
 		const basePath = '/read/list/:owner/:slug',
 			fullAnalyticsPageTitle =
 				analyticsPageTitle + ' > List > ' + context.params.user + ' - ' + context.params.list,
@@ -36,7 +35,7 @@ const exported = {
 			list_slug: context.params.list,
 		} );
 
-		renderWithReduxStore(
+		context.primary = (
 			<AsyncLoad
 				require="reader/list-stream"
 				key={ 'tag-' + context.params.user + '-' + context.params.list }
@@ -52,10 +51,9 @@ const exported = {
 					mcKey
 				) }
 				onUpdatesShown={ trackUpdatesLoaded.bind( null, mcKey ) }
-			/>,
-			document.getElementById( 'primary' ),
-			context.store
+			/>
 		);
+		next();
 	},
 };
 

--- a/client/reader/list/index.js
+++ b/client/reader/list/index.js
@@ -9,7 +9,8 @@ import page from 'page';
  */
 import { listListing } from './controller';
 import { sidebar, updateLastRoute } from 'reader/controller';
+import { makeLayout, render as clientRender } from 'controller';
 
 export default function() {
-	page( '/read/list/:user/:list', updateLastRoute, sidebar, listListing );
+	page( '/read/list/:user/:list', updateLastRoute, sidebar, listListing, makeLayout, clientRender );
 }

--- a/client/reader/recommendations/controller.js
+++ b/client/reader/recommendations/controller.js
@@ -17,13 +17,12 @@ import {
 import RecommendedPostsStream from 'reader/recommendations/posts';
 import route from 'lib/route';
 import feedStreamFactory from 'lib/feed-stream-store';
-import { renderWithReduxStore } from 'lib/react-helpers';
 
 const ANALYTICS_PAGE_TITLE = 'Reader';
 
 const exported = {
 	// Post Recommendations - Used by the Data team to test recommendation algorithms
-	recommendedPosts( context ) {
+	recommendedPosts( context, next ) {
 		const basePath = route.sectionify( context.path );
 
 		let fullAnalyticsPageTitle = '';
@@ -65,23 +64,20 @@ const exported = {
 
 		trackPageLoad( basePath, fullAnalyticsPageTitle, mcKey );
 
-		renderWithReduxStore(
-			React.createElement( RecommendedPostsStream, {
-				key: 'recommendations_posts',
-				postsStore: RecommendedPostsStore,
-				trackScrollPage: trackScrollPage.bind(
-					null,
-					basePath,
-					fullAnalyticsPageTitle,
-					ANALYTICS_PAGE_TITLE,
-					mcKey
-				),
-				onUpdatesShown: trackUpdatesLoaded.bind( null, mcKey ),
-				showBack: userHasHistory( context ),
-			} ),
-			document.getElementById( 'primary' ),
-			context.store
-		);
+		context.primary = React.createElement( RecommendedPostsStream, {
+			key: 'recommendations_posts',
+			postsStore: RecommendedPostsStore,
+			trackScrollPage: trackScrollPage.bind(
+				null,
+				basePath,
+				fullAnalyticsPageTitle,
+				ANALYTICS_PAGE_TITLE,
+				mcKey
+			),
+			onUpdatesShown: trackUpdatesLoaded.bind( null, mcKey ),
+			showBack: userHasHistory( context ),
+		} );
+		next();
 	},
 };
 

--- a/client/reader/search/controller.js
+++ b/client/reader/search/controller.js
@@ -17,7 +17,6 @@ import {
 	trackUpdatesLoaded,
 	trackScrollPage,
 } from 'reader/controller-helper';
-import { renderWithReduxStore } from 'lib/react-helpers';
 import AsyncLoad from 'components/async-load';
 import { SEARCH_TYPES } from 'reader/search-stream/search-stream-header';
 
@@ -33,7 +32,7 @@ function replaceSearchUrl( newValue, sort ) {
 }
 
 const exported = {
-	search: function( context ) {
+	search: function( context, next ) {
 		const basePath = '/read/search',
 			fullAnalyticsPageTitle = analyticsPageTitle + ' > Search',
 			mcKey = 'search';
@@ -70,7 +69,7 @@ const exported = {
 			replaceSearchUrl( searchSlug, newSort !== 'relevance' ? newSort : undefined );
 		}
 
-		renderWithReduxStore(
+		context.primary = (
 			<AsyncLoad
 				require="reader/search-stream"
 				key="search"
@@ -90,10 +89,9 @@ const exported = {
 				onQueryChange={ reportQueryChange }
 				onSortChange={ reportSortChange }
 				searchType={ show }
-			/>,
-			document.getElementById( 'primary' ),
-			context.store
+			/>
 		);
+		next();
 	},
 };
 

--- a/client/reader/search/index.js
+++ b/client/reader/search/index.js
@@ -10,10 +10,19 @@ import page from 'page';
 import config from 'config';
 import { search } from './controller';
 import { preloadReaderBundle, sidebar, updateLastRoute } from 'reader/controller';
+import { makeLayout, render as clientRender } from 'controller';
 
 export default function() {
 	if ( config.isEnabled( 'reader/search' ) ) {
-		page( '/read/search', preloadReaderBundle, updateLastRoute, sidebar, search );
+		page(
+			'/read/search',
+			preloadReaderBundle,
+			updateLastRoute,
+			sidebar,
+			search,
+			makeLayout,
+			clientRender
+		);
 	} else {
 		// redirect search to the root
 		page.redirect( '/read/search', '/' );

--- a/client/reader/tag-stream/controller.js
+++ b/client/reader/tag-stream/controller.js
@@ -16,13 +16,12 @@ import {
 	trackUpdatesLoaded,
 	trackScrollPage,
 } from 'reader/controller-helper';
-import { renderWithReduxStore } from 'lib/react-helpers';
 import AsyncLoad from 'components/async-load';
 import { TAG_PAGE } from 'reader/follow-sources';
 
 const analyticsPageTitle = 'Reader';
 
-export const tagListing = context => {
+export const tagListing = ( context, next ) => {
 	const basePath = '/tag/:slug';
 	const fullAnalyticsPageTitle = analyticsPageTitle + ' > Tag > ' + context.params.tag;
 	const tagSlug = trim( context.params.tag )
@@ -40,7 +39,7 @@ export const tagListing = context => {
 		tag: tagSlug,
 	} );
 
-	renderWithReduxStore(
+	context.primary = (
 		<AsyncLoad
 			require="reader/tag-stream/main"
 			key={ 'tag-' + encodedTag }
@@ -59,8 +58,7 @@ export const tagListing = context => {
 			showBack={ !! context.lastRoute }
 			showPrimaryFollowButtonOnCards={ true }
 			followSource={ TAG_PAGE }
-		/>,
-		document.getElementById( 'primary' ),
-		context.store
+		/>
 	);
+	next();
 };

--- a/client/reader/tag-stream/index.js
+++ b/client/reader/tag-stream/index.js
@@ -9,8 +9,9 @@ import page from 'page';
  */
 import { tagListing } from './controller';
 import { initAbTests, preloadReaderBundle, sidebar, updateLastRoute } from 'reader/controller';
+import { makeLayout, render as clientRender } from 'controller';
 
 export default function() {
-	page( '/tag/*', preloadReaderBundle, initAbTests );
-	page( '/tag/:tag', updateLastRoute, sidebar, tagListing );
+	page( '/tag/*', preloadReaderBundle, initAbTests, makeLayout, clientRender );
+	page( '/tag/:tag', updateLastRoute, sidebar, tagListing, makeLayout, clientRender );
 }

--- a/client/reader/tag-stream/index.js
+++ b/client/reader/tag-stream/index.js
@@ -12,6 +12,6 @@ import { initAbTests, preloadReaderBundle, sidebar, updateLastRoute } from 'read
 import { makeLayout, render as clientRender } from 'controller';
 
 export default function() {
-	page( '/tag/*', preloadReaderBundle, initAbTests, makeLayout, clientRender );
+	page( '/tag/*', preloadReaderBundle, initAbTests );
 	page( '/tag/:tag', updateLastRoute, sidebar, tagListing, makeLayout, clientRender );
 }

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -4,7 +4,6 @@
  * External dependencies
  */
 
-import ReactDom from 'react-dom';
 import React from 'react';
 import page from 'page';
 import { isEmpty } from 'lodash';
@@ -19,7 +18,6 @@ import SignupComponent from './main';
 import utils from './utils';
 import userModule from 'lib/user';
 import { setLayoutFocus } from 'state/ui/layout-focus/actions';
-import { renderWithReduxStore } from 'lib/react-helpers';
 import store from 'store';
 import SignupProgressStore from 'lib/signup/progress-store';
 
@@ -106,7 +104,7 @@ export default {
 		next();
 	},
 
-	start( context ) {
+	start( context, next ) {
 		const basePath = route.sectionify( context.path ),
 			flowName = utils.getFlowName( context.params ),
 			stepName = utils.getStepName( context.params ),
@@ -117,20 +115,16 @@ export default {
 			basePageTitle + ' > Start > ' + flowName + ' > ' + stepName
 		);
 
-		ReactDom.unmountComponentAtNode( document.getElementById( 'secondary' ) );
 		context.store.dispatch( setLayoutFocus( 'content' ) );
 
-		renderWithReduxStore(
-			React.createElement( SignupComponent, {
-				path: context.path,
-				initialContext,
-				locale: utils.getLocale( context.params ),
-				flowName: flowName,
-				stepName: stepName,
-				stepSectionName: stepSectionName,
-			} ),
-			'primary',
-			context.store
-		);
+		context.primary = React.createElement( SignupComponent, {
+			path: context.path,
+			initialContext,
+			locale: utils.getLocale( context.params ),
+			flowName: flowName,
+			stepName: stepName,
+			stepSectionName: stepSectionName,
+		} );
+		next();
 	},
 };

--- a/client/signup/index.web.js
+++ b/client/signup/index.web.js
@@ -10,6 +10,7 @@ import page from 'page';
  * Internal dependencies
  */
 import controller from './controller';
+import { makeLayout, render as clientRender } from 'controller';
 
 export default function() {
 	page(
@@ -17,6 +18,8 @@ export default function() {
 		controller.saveInitialContext,
 		controller.redirectWithoutLocaleIfLoggedIn,
 		controller.redirectToFlow,
-		controller.start
+		controller.start,
+		makeLayout,
+		clientRender
 	);
 }


### PR DESCRIPTION
Single tree render React element tree.

- [The GH project](https://github.com/Automattic/wp-calypso/projects/53)
- [Codemod](https://github.com/Automattic/wp-calypso/blob/master/bin/codemods/src/single-tree-rendering.js) that does the majority of the work here.

# Testing
Smoke test every route and every view:

- Anything that changes URL is interesting; there are no changes to UI elements like dropdowns etc.
- I’m especially curious about how Woocommerce store sections work (since those parts are built quite differently than rest of the Calypso) and domains (just tricky to test).
- Ensure all routes work. If something gets stuck, it’s probably just because of misplaced `next()` in middleware.
- Ensure sidebar is hidden (or visible) when it should.
- Ensure routes under “My sites” work when the user doesn’t have any sites, when the user has Jetpack site selected as well when the user has simple wordpress.com site selected.
- Look for warnings @ console.

# What has changed

### Previously

Calypso renders content separately in `#primary` (main content) and `#secondary` (sidebar) elements but this has many caveats.

Defining route:
```js
page( '/hello-dolly', navigation, helloDolly );
```

Controller:
```js
const navigation = ( context, next ) => {
  renderWithReduxStore(
    <Navigation />,
    document.getElementById( 'secondary' ),
    context.store
  );
  next();
};

const helloDolly = context => {
  renderWithReduxStore(
    <HelloDolly />,
    document.getElementById( 'primary' ),
    context.store
  );
};
```

### In future

Instead of rendering in multiple elements using `ReactDom.render()`, we want to render everything under single root element, i.e. a single tree.

Defining route:
```js
import { makeLayout, render as clientRender } from 'controller';

page( '/hello-dolly', navigation, helloDolly, makeLayout, clientRender );
```

Controller:
```js
const navigation = ( context, next ) => {
  context.secondary = <Navigation />;
  next();
};

const helloDolly = ( context, next ) => {
  context.primary = <HelloDollyPage />;
  next();
};
```

### What are `makeLayout` & `clientRender`?

`makeLayout` middleware builds one element from `primary` and `secondary` properties.

Little simplified but:
```js
context.layout = (
  <ReduxProvider store={ store }>
    <Layout
      primary={ primary }
      secondary={ secondary }
    />
  </ReduxProvider>
);
```

`clientRender` middleware does the final `ReactDom.render()` — that should be the only one we have anywhere.

```js
ReactDom.render(
  context.layout,
  document.getElementById( 'wpcom' )
);
```

### Don't unmount

We don't have to unmount elements anymore because everything — including the sidebar — is under single element tree and React handles reconciliation on changes. Previously sidebar would be hidden like so:

```js
ReactDom.unmountComponentAtNode( document.getElementById( 'secondary' ) );
```

In future, you simply leave `context.secondary` undefined or set it `null`.

### Don't wrap in Redux provider anymore
You don't need to wrap your components with `<ReduxProvider />` anymore since our only element tree is already wrapped with it. See `makeLayout` middleware above.

# How to re-run this codemod
This is just note to myself. If you're just testing this PR, you don't need to care about this.

1. Run prettier to confirm what files would be modified by it later, so that we can ignore them:
    ```bash
    npm run reformat-files
    ```
    Copy the list, you'll need it later, then reset modifications:
     ```bash
    git checkout HEAD -- .
    ```

1. Run the codemod
    ```bash
    npm run codemod single-tree-rendering client
    ```

1. Ignore files we don't want to codemod
    ```bash
    git checkout HEAD -- \
     ./client/boot/common.js \
     ./client/controller/index.web.js \
     ./client/boot/project/wordpress-com.js \
     ./client/lib/react-helpers/index.js \
     ./client/components/tinymce/plugins/mentions/plugin.jsx \
     ./client/layout/guided-tours/tours/main-tour.js \
     ./client/lib/accept/index.js \
     ./client/blocks/site/index.jsx
    ```

1. Run Prettier
    ```bash
    npm run reformat-files
    ```

1. Ignore files we don't want to prettify (check if your list is still up to date from the 1st step)
    ```bash
    git checkout HEAD -- \
      ./client/blocks/login/two-factor-authentication/verification-code-form.jsx \
      ./client/components/data/query-posts/index.jsx \
      ./client/components/domains/registrant-extra-info/fr-form.jsx \
      ./client/components/web-preview/toolbar.jsx \
      ./client/extensions/zoninator/components/forms/zone-content-form/post-card.jsx \
      ./client/extensions/zoninator/components/forms/zone-content-form/posts-list.jsx \
      ./client/layout/masterbar/drafts.jsx \
      ./client/login/magic-login/emailed-login-link-successfully.jsx \
      ./client/state/analytics/actions.js \
      ./client/state/analytics/test/actions.js \
      ./client/state/posts/reducer.js \
      ./client/state/posts/test/reducer.js
    ```

1. Fix these errors:
    ```bash
     client/my-sites/controller.js
       154:17  error  'reduxStore' is assigned a value but never used  no-unused-vars
     
     client/my-sites/sharing/controller.js
       28:34  error  'store' is assigned a value but never used  no-unused-vars
    ```

1. Commit.