### PR TITLE
Rewind: Dynamically calculate `isDiscarded`

### DIFF
--- a/client/my-sites/stats/activity-log-day/index.jsx
+++ b/client/my-sites/stats/activity-log-day/index.jsx
@@ -20,9 +20,9 @@ import Button from 'components/button';
 import FoldableCard from 'components/foldable-card';
 import { recordTracksEvent as recordTracksEventAction } from 'state/analytics/actions';
 import { withAnalytics as withAnalyticsAction } from 'state/analytics/actions';
-import { getRequestedRewind } from 'state/selectors';
+import { getActivityLog, getRequestedRewind } from 'state/selectors';
 import { rewindRequestDismiss as rewindRequestDismissAction } from 'state/activity-log/actions';
-import { rewriteStream } from 'state/activity-log/log/is-discarded';
+import { ms, rewriteStream } from 'state/activity-log/log/is-discarded';
 
 /**
  * Module constants
@@ -207,6 +207,7 @@ class ActivityLogDay extends Component {
 			applySiteOffset,
 			disableRestore,
 			hideRestore,
+			isDiscardedPerspective,
 			isToday,
 			logs,
 			requestedRestoreActivityId,
@@ -226,7 +227,7 @@ class ActivityLogDay extends Component {
 		);
 
 		const rewindButton = this.renderRewindButton( hasConfirmDialog ? '' : 'primary' );
-		const events = classifyEvents( rewriteStream( logs ), requestedRestoreActivityId );
+		const events = classifyEvents( rewriteStream( logs, isDiscardedPerspective ), requestedRestoreActivityId );
 
 		const LogItem = ( { log, hasBreak } ) => (
 			<ActivityLogItem
@@ -274,8 +275,14 @@ class ActivityLogDay extends Component {
 
 export default connect(
 	( state, { siteId } ) => {
+		const requestedRewind = getRequestedRewind( state, siteId );
+		const isDiscardedPerspective = requestedRewind
+			? new Date( ms( getActivityLog( state, siteId, requestedRewind ).activityTs ) )
+			: undefined;
+
 		return {
-			requestedRewind: getRequestedRewind( state, siteId ),
+			isDiscardedPerspective,
+			requestedRewind,
 		};
 	},
 	{

--- a/client/state/activity-log/log/is-discarded/index.js
+++ b/client/state/activity-log/log/is-discarded/index.js
@@ -19,7 +19,7 @@ import { memoize } from 'lodash';
  * @param {Number} ts timestamp in 's' or 'ms'
  * @returns {Number} timestamp in 'ms'
  */
-const ms = ts =>
+export const ms = ts =>
 	ts < 946702800000 // Jan 1, 2001 @ 00:00:00
 		? ts * 1000 // convert s -> ms
 		: ts;


### PR DESCRIPTION
Previously the `isDiscarded` attribute of events in the activity log was
always being calculated from the most-recent perspective; that is, from
`Date.now()`. When we open rewind dialogs, however, in order to preview
what might happen when we restore backups it would be helpful to be able
to see which events would be discarded after the restore.

In this PR we're checking to see if any rewind dialogs are open, and if
so, we calculate the `isDiscarded` property from the perspective of the
timestamp of the current rewind being considered. This way events appear
as they would after the restore.

**Testing**

Start with a site with **Activity Log** enabled (Pressable sites…) and which
also has rewindable events in the activity stream. It'll be best to look at sites
where we already have discarded events upon page load.

Next, open a restore confirmation dialogs. The events above the dialog should
all appear discarded now, as well as any events below the dialog whose discarded
status would be altered by the restore. This can be somewhat tricky to find
because we need to find overlapping restores to see events in the past which
would change.

**Demo**

![dynamicdiscardedevents](https://user-images.githubusercontent.com/5431237/32419676-06203480-c24c-11e7-9cdd-c3d7fa7c7f19.gif)

---

@elibud I have added you here simply to demonstrate how I'm using the perspective
paramater to recalculate `isDiscarded` dynamically. No need for any specific review.