### PR TITLE
Domains: allow searches to include underscores and show correct message for single invalid characters

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -457,7 +457,7 @@ class RegisterDomainStep extends React.Component {
 								this.props.onDomainsAvailabilityChange( false );
 							} else if ( error && error.error ) {
 								error.code = error.error;
-								this.showValidationErrorMessage( domain, error );
+								this.showValidationErrorMessage( domain, error.code );
 							}
 
 							const analyticsResults = [

--- a/client/lib/domains/constants.js
+++ b/client/lib/domains/constants.js
@@ -38,6 +38,7 @@ const domainAvailability = {
 	FORBIDDEN: 'forbidden_domain',
 	FORBIDDEN_SUBDOMAIN: 'forbidden_subdomain',
 	EMPTY_QUERY: 'empty_query',
+	INVALID_QUERY: 'invalid_query',
 	INVALID: 'invalid_domain',
 	INVALID_TLD: 'invalid_tld',
 	RESTRICTED: 'restricted_domain',

--- a/client/lib/domains/index.js
+++ b/client/lib/domains/index.js
@@ -101,7 +101,8 @@ function getFixedDomainSearch( domainName ) {
 		.trim()
 		.toLowerCase()
 		.replace( /^(https?:\/\/)?(www\.)?/, '' )
-		.replace( /\/$/, '' );
+		.replace( /\/$/, '' )
+		.replace( '_', '-' );
 }
 
 function isSubdomain( domainName ) {

--- a/client/lib/domains/index.js
+++ b/client/lib/domains/index.js
@@ -102,7 +102,7 @@ function getFixedDomainSearch( domainName ) {
 		.toLowerCase()
 		.replace( /^(https?:\/\/)?(www\.)?/, '' )
 		.replace( /\/$/, '' )
-		.replace( '_', '-' );
+		.replace( /_/g, '-' );
 }
 
 function isSubdomain( domainName ) {

--- a/client/lib/domains/registration/availability-messages.js
+++ b/client/lib/domains/registration/availability-messages.js
@@ -20,10 +20,6 @@ function getAvailabilityNotice( domain, error ) {
 
 	const tld = getTld( domain );
 
-	if ( error.error ) {
-		error = error.error;
-	}
-
 	switch ( error ) {
 		case domainAvailability.NOT_REGISTRABLE:
 			if ( tld ) {

--- a/client/lib/domains/registration/availability-messages.js
+++ b/client/lib/domains/registration/availability-messages.js
@@ -20,6 +20,10 @@ function getAvailabilityNotice( domain, error ) {
 
 	const tld = getTld( domain );
 
+	if ( error.error ) {
+		error = error.error;
+	}
+
 	switch ( error ) {
 		case domainAvailability.NOT_REGISTRABLE:
 			if ( tld ) {
@@ -125,6 +129,12 @@ function getAvailabilityNotice( domain, error ) {
 
 		case domainAvailability.EMPTY_QUERY:
 			message = translate( 'Please enter a domain name or keyword.' );
+			break;
+
+		case domainAvailability.INVALID_QUERY:
+			message = translate(
+				'Your search term can only contain alphanumeric characters, spaces, dots, or hyphens.'
+			);
 			break;
 
 		default:


### PR DESCRIPTION
Fixes #19502

**Current** 

when a customer enters an underscore in a domain search term or a single invalid character like $%! the customer will see:

<img width="760" alt="underscore" src="https://user-images.githubusercontent.com/128826/32424726-0e6e7e2c-c2fa-11e7-8b6a-77ee78f20380.png">

<img width="776" alt="special character" src="https://user-images.githubusercontent.com/128826/32424745-1fcbbba8-c2fa-11e7-8ac6-db0db4f1e3e3.png">

**This PR**

Treats underscores which are invalid as same as dashes which are valid:

<img width="746" alt="screen shot 2017-11-06 at 2 07 47 pm" src="https://user-images.githubusercontent.com/128826/32425022-e3ccd8c4-c2fb-11e7-90c0-c5423ef2ab1e.png">

It also fixes the single special character error: 

<img width="746" alt="screen shot 2017-11-06 at 2 08 35 pm" src="https://user-images.githubusercontent.com/128826/32425030-021c6664-c2fc-11e7-883d-cf2b029cdb37.png">




