### PR TITLE
Jetpack Disconnect Survey: Enable in production

### DIFF
--- a/client/my-sites/site-settings/index.js
+++ b/client/my-sites/site-settings/index.js
@@ -57,27 +57,25 @@ export default function() {
 		controller.deleteSite
 	);
 
-	if ( config.isEnabled( 'manage/site-settings/disconnect-flow' ) ) {
-		const reasonSlugs = Object.keys( reasons );
-		page(
-			`/settings/disconnect-site/:step(${ [ ...reasonSlugs, 'confirm' ].join( '|' ) })?`,
-			mySitesController.sites
-		);
+	const reasonSlugs = Object.keys( reasons );
+	page(
+		`/settings/disconnect-site/:step(${ [ ...reasonSlugs, 'confirm' ].join( '|' ) })?`,
+		mySitesController.sites
+	);
 
-		page(
-			`/settings/disconnect-site/:reason(${ reasonSlugs.join( '|' ) })?/:site_id`,
-			mySitesController.siteSelection,
-			settingsController.setScroll,
-			controller.disconnectSite
-		);
+	page(
+		`/settings/disconnect-site/:reason(${ reasonSlugs.join( '|' ) })?/:site_id`,
+		mySitesController.siteSelection,
+		settingsController.setScroll,
+		controller.disconnectSite
+	);
 
-		page(
-			'/settings/disconnect-site/confirm/:site_id',
-			mySitesController.siteSelection,
-			settingsController.setScroll,
-			controller.disconnectSiteConfirm
-		);
-	}
+	page(
+		'/settings/disconnect-site/confirm/:site_id',
+		mySitesController.siteSelection,
+		settingsController.setScroll,
+		controller.disconnectSiteConfirm
+	);
 
 	page(
 		'/settings/start-over/:site_id',

--- a/client/my-sites/site-settings/manage-connection/disconnect-site-link.jsx
+++ b/client/my-sites/site-settings/manage-connection/disconnect-site-link.jsx
@@ -25,11 +25,7 @@ class DisconnectSiteLink extends Component {
 		dialogVisible: false,
 	};
 
-	handleClick = event => {
-		if ( ! isEnabled( 'manage/site-settings/disconnect-flow' ) ) {
-			event.preventDefault();
-		}
-
+	handleClick = () => {
 		this.setState( {
 			dialogVisible: true,
 		} );
@@ -58,9 +54,7 @@ class DisconnectSiteLink extends Component {
 					href={
 						isEnabled( 'manage/site-settings/disconnect-flow' ) ? (
 							'/settings/disconnect-site/' + siteSlug
-						) : (
-							'#'
-						)
+						) : null
 					}
 					onClick={ this.handleClick }
 					title={ translate( 'Disconnect from WordPress.com' ) }

--- a/client/my-sites/site-settings/manage-connection/disconnect-site-link.jsx
+++ b/client/my-sites/site-settings/manage-connection/disconnect-site-link.jsx
@@ -4,39 +4,23 @@
  * @format
  */
 
-import React, { Component } from 'react';
+import React, { PureComponent } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
-import DisconnectJetpackDialog from 'blocks/disconnect-jetpack/dialog';
 import QuerySitePlans from 'components/data/query-site-plans';
-import { isEnabled } from 'config';
 import SiteToolsLink from 'my-sites/site-settings/site-tools/link';
 import { getSiteSlug } from 'state/sites/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { isSiteAutomatedTransfer } from 'state/selectors';
 import { recordTracksEvent } from 'state/analytics/actions';
 
-class DisconnectSiteLink extends Component {
-	state = {
-		dialogVisible: false,
-	};
-
+class DisconnectSiteLink extends PureComponent {
 	handleClick = () => {
-		this.setState( {
-			dialogVisible: true,
-		} );
-
 		this.props.recordTracksEvent( 'calypso_jetpack_disconnect_start' );
-	};
-
-	handleHideDialog = () => {
-		this.setState( {
-			dialogVisible: false,
-		} );
 	};
 
 	render() {
@@ -51,11 +35,7 @@ class DisconnectSiteLink extends Component {
 				<QuerySitePlans siteId={ siteId } />
 
 				<SiteToolsLink
-					href={
-						isEnabled( 'manage/site-settings/disconnect-flow' ) ? (
-							'/settings/disconnect-site/' + siteSlug
-						) : null
-					}
+					href={ '/settings/disconnect-site/' + siteSlug }
 					onClick={ this.handleClick }
 					title={ translate( 'Disconnect from WordPress.com' ) }
 					description={ translate(
@@ -63,16 +43,6 @@ class DisconnectSiteLink extends Component {
 					) }
 					isWarning
 				/>
-
-				{ ! isEnabled( 'manage/site-settings/disconnect-flow' ) && (
-					<DisconnectJetpackDialog
-						isVisible={ this.state.dialogVisible }
-						onClose={ this.handleHideDialog }
-						isBroken={ false }
-						siteId={ siteId }
-						disconnectHref="/stats"
-					/>
-				) }
 			</div>
 		);
 	}

--- a/client/my-sites/site-settings/manage-connection/disconnect-site-link.jsx
+++ b/client/my-sites/site-settings/manage-connection/disconnect-site-link.jsx
@@ -11,7 +11,6 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import QuerySitePlans from 'components/data/query-site-plans';
 import SiteToolsLink from 'my-sites/site-settings/site-tools/link';
 import { getSiteSlug } from 'state/sites/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
@@ -32,8 +31,6 @@ class DisconnectSiteLink extends PureComponent {
 
 		return (
 			<div className="manage-connection__disconnect-link">
-				<QuerySitePlans siteId={ siteId } />
-
 				<SiteToolsLink
 					href={ '/settings/disconnect-site/' + siteSlug }
 					onClick={ this.handleClick }

--- a/config/development.json
+++ b/config/development.json
@@ -99,7 +99,6 @@
 		"manage/security": true,
 		"manage/site-settings/analytics": true,
 		"manage/site-settings/categories": true,
-		"manage/site-settings/disconnect-flow": true,
 		"manage/stats": true,
 		"manage/stats/podcasts": true,
 		"manage/themes": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -65,7 +65,6 @@
 		"manage/security": true,
 		"manage/site-settings/analytics": true,
 		"manage/site-settings/categories": true,
-		"manage/site-settings/disconnect-flow": true,
 		"manage/stats": true,
 		"manage/themes": true,
 		"manage/themes-jetpack": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -67,7 +67,6 @@
 		"manage/security": true,
 		"manage/site-settings/analytics": true,
 		"manage/site-settings/categories": true,
-		"manage/site-settings/disconnect-flow": true,
 		"manage/stats": true,
 		"manage/stats/podcasts": true,
 		"manage/themes": true,


### PR DESCRIPTION
And remove the feature flag, and related dead code.

To test -- give it a quick spin to make sure it still works (in the `development` environment). (Start at `/settings/manage-connection/:site`, click the 'Disconnect from WordPress.com' button, verify that it triggers the survey.)

![image](https://user-images.githubusercontent.com/96308/32440778-f3745934-c2f4-11e7-98a3-ce38258325c2.png)
