### PR TITLE
Fix `load-script` lib not executing callbacks on some URLs

### DIFF
--- a/client/lib/load-script/callback-handler.js
+++ b/client/lib/load-script/callback-handler.js
@@ -52,7 +52,6 @@ export function removeScriptCallbacks( url ) {
 
 export function removeAllScriptCallbacks() {
 	debug( 'Removing all callbacks for scripts from all URLs' );
-
 	getCallbacksMap().clear();
 }
 
@@ -75,14 +74,16 @@ export function executeCallbacks( url, callbackArguments = null ) {
 }
 
 export function handleRequestSuccess( event ) {
-	const { target: { src: url } } = event;
+	const { target } = event;
+	const url = target.getAttribute( 'src' );
 	debug( `Handling successful request for "${ url }"` );
 	executeCallbacks( url );
 	this.onload = null;
 }
 
 export function handleRequestError( event ) {
-	const { target: { src: url } } = event;
+	const { target } = event;
+	const url = target.getAttribute( 'src' );
 	debug( `Handling failed request for "${ url }"` );
 	executeCallbacks( url, new Error( `Failed to load script "${ url }"` ) );
 	this.onerror = null;

--- a/client/lib/load-script/test/callback-handler.js
+++ b/client/lib/load-script/test/callback-handler.js
@@ -196,7 +196,7 @@ describe( 'loadScript/callback-handler', () => {
 	describe( 'handleRequestSuccess( event )', () => {
 		const url = '/';
 		const thisObject = {};
-		const eventObject = { target: { src: url } };
+		const eventObject = { target: { getAttribute: () => url } };
 		const callback = jest.fn();
 
 		beforeAll( function() {
@@ -216,7 +216,7 @@ describe( 'loadScript/callback-handler', () => {
 	describe( 'handleRequestError( event )', () => {
 		const url = '/';
 		const thisObject = {};
-		const eventObject = { target: { src: url } };
+		const eventObject = { target: { getAttribute: () => url } };
 		const callback = jest.fn();
 
 		beforeAll( function() {


### PR DESCRIPTION
Browsers tend to normalize `src` attributes, which means there can be a mismatch between the URL in-the-code, and the URL returned by a browser event.

For instance: `//stats.wp.com/w.js` which basically asks the browser to autofill it with the currently-used protocol will break: the callback is registered as `//stats.wp.com/w.js` but we then try to execute callback registered at `http//stats.wp.com/w.js` or `https//stats.wp.com/w.js`. As a result, we're not executing callbacks on some of our `loadScript` currently.

This fixes it by accessing the un-browser-normalized version of the URL, directly from the script tag that was insertedd, using `getAttribute('src')`.