### PR TITLE
Comments Redesign: Remove the post link when in post view

### DIFF
--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -408,6 +408,7 @@ export class CommentList extends Component {
 		const {
 			isCommentsTreeSupported,
 			isLoading,
+			isPostView,
 			page,
 			postId,
 			siteBlacklist,
@@ -442,7 +443,7 @@ export class CommentList extends Component {
 				) }
 				{ isCommentsTreeSupported && <QuerySiteCommentsTree siteId={ siteId } status={ status } /> }
 
-				{ !! postId && <CommentListHeader postId={ postId } /> }
+				{ isPostView && <CommentListHeader postId={ postId } /> }
 
 				<CommentNavigation
 					commentsPage={ commentsPage }
@@ -473,6 +474,7 @@ export class CommentList extends Component {
 								key={ `comment-${ siteId }-${ commentId }` }
 								isBulkMode={ isBulkEdit }
 								isPersistent={ this.isCommentPersisted( commentId ) }
+								isPostView={ isPostView }
 								isSelected={ this.isCommentSelected( commentId ) }
 								refreshCommentData={
 									isCommentsTreeSupported &&
@@ -540,7 +542,8 @@ export class CommentList extends Component {
 
 const mapStateToProps = ( state, { postId, siteId, status } ) => {
 	const siteCommentsTree = getSiteCommentsTree( state, siteId, status );
-	const comments = !! postId
+	const isPostView = !! postId;
+	const comments = isPostView
 		? map( filter( siteCommentsTree, { postId } ), 'commentId' )
 		: map( siteCommentsTree, 'commentId' );
 
@@ -550,6 +553,7 @@ const mapStateToProps = ( state, { postId, siteId, status } ) => {
 		isCommentsTreeSupported:
 			! isJetpackSite( state, siteId ) || isJetpackMinimumVersion( state, siteId, '5.5' ),
 		isLoading,
+		isPostView,
 		siteBlacklist: getSiteSetting( state, siteId, 'blacklist_keys' ),
 		siteId,
 	};

--- a/client/my-sites/comments/comment/comment-author.jsx
+++ b/client/my-sites/comments/comment/comment-author.jsx
@@ -25,6 +25,7 @@ export class CommentAuthor extends Component {
 	static propTypes = {
 		commentId: PropTypes.number,
 		isExpanded: PropTypes.bool,
+		isPostView: PropTypes.bool,
 	};
 
 	commentHasLink = () => {
@@ -49,6 +50,7 @@ export class CommentAuthor extends Component {
 			commentUrl,
 			gravatarUser,
 			isExpanded,
+			isPostView,
 			moment,
 			translate,
 		} = this.props;
@@ -79,7 +81,7 @@ export class CommentAuthor extends Component {
 						<strong className="comment__author-name">
 							<Emojify>{ authorDisplayName || translate( 'Anonymous' ) }</Emojify>
 						</strong>
-						{ ! isExpanded && <CommentPostLink { ...{ commentId } } /> }
+						{ ! isExpanded && ! isPostView && <CommentPostLink { ...{ commentId } } /> }
 					</div>
 
 					<div className="comment__author-info-element">

--- a/client/my-sites/comments/comment/comment-content.jsx
+++ b/client/my-sites/comments/comment/comment-content.jsx
@@ -25,6 +25,7 @@ export class CommentContent extends Component {
 	static propTypes = {
 		commentId: PropTypes.number,
 		isExpanded: PropTypes.bool,
+		isPostView: PropTypes.bool,
 	};
 
 	trackDeepReaderLinkClick = () =>
@@ -49,7 +50,14 @@ export class CommentContent extends Component {
 	};
 
 	render() {
-		const { commentContent, commentId, commentStatus, isExpanded, translate } = this.props;
+		const {
+			commentContent,
+			commentId,
+			commentIsPending,
+			isExpanded,
+			isPostView,
+			translate,
+		} = this.props;
 		return (
 			<div className="comment__content">
 				{ ! isExpanded && (
@@ -64,13 +72,15 @@ export class CommentContent extends Component {
 
 				{ isExpanded && (
 					<div className="comment__content-full">
-						<div className="comment__content-info">
-							<CommentPostLink { ...{ commentId } } />
+						{ ( commentIsPending || ! isPostView ) && (
+							<div className="comment__content-info">
+								{ ! isPostView && <CommentPostLink { ...{ commentId } } /> }
 
-							{ 'unapproved' === commentStatus && (
-								<div className="comment__status-label">{ translate( 'Pending' ) }</div>
-							) }
-						</div>
+								{ commentIsPending && (
+									<div className="comment__status-label">{ translate( 'Pending' ) }</div>
+								) }
+							</div>
+						) }
 
 						{ this.renderInReplyTo() }
 
@@ -105,7 +115,7 @@ const mapStateToProps = ( state, { commentId } ) => {
 
 	return {
 		commentContent: get( comment, 'content' ),
-		commentStatus: get( comment, 'status' ),
+		commentIsPending: 'unapproved' === get( comment, 'status' ),
 		commentUrl,
 		isJetpack,
 		parentCommentContent,

--- a/client/my-sites/comments/comment/comment-header.jsx
+++ b/client/my-sites/comments/comment/comment-header.jsx
@@ -24,6 +24,7 @@ export class CommentHeader extends PureComponent {
 			isBulkMode,
 			isEditMode,
 			isExpanded,
+			isPostView,
 			isSelected,
 			showAuthorMoreInfo,
 			toggleExpanded,
@@ -37,7 +38,7 @@ export class CommentHeader extends PureComponent {
 					</label>
 				) }
 
-				<CommentAuthor { ...{ commentId, isExpanded } } />
+				<CommentAuthor { ...{ commentId, isExpanded, isPostView } } />
 
 				{ showAuthorMoreInfo && <CommentAuthorMoreInfo { ...{ commentId } } /> }
 

--- a/client/my-sites/comments/comment/index.jsx
+++ b/client/my-sites/comments/comment/index.jsx
@@ -27,16 +27,12 @@ export class Comment extends Component {
 		commentId: PropTypes.number,
 		isBulkMode: PropTypes.bool,
 		isPersistent: PropTypes.bool,
+		isPostView: PropTypes.bool,
 		isSelected: PropTypes.bool,
 		refreshCommentData: PropTypes.bool,
 		removeFromPersisted: PropTypes.func,
 		toggleSelected: PropTypes.func,
 		updatePersisted: PropTypes.func,
-	};
-
-	static defaultProps = {
-		isBulkMode: false,
-		isSelected: false,
 	};
 
 	state = {
@@ -92,6 +88,7 @@ export class Comment extends Component {
 			commentIsPending,
 			isBulkMode,
 			isLoading,
+			isPostView,
 			isSelected,
 			refreshCommentData,
 			removeFromPersisted,
@@ -125,11 +122,11 @@ export class Comment extends Component {
 				{ ! isEditMode && (
 					<div className="comment__detail">
 						<CommentHeader
-							{ ...{ commentId, isBulkMode, isEditMode, isExpanded, isSelected } }
+							{ ...{ commentId, isBulkMode, isEditMode, isExpanded, isPostView, isSelected } }
 							toggleExpanded={ this.toggleExpanded }
 						/>
 
-						<CommentContent { ...{ commentId, isExpanded } } />
+						<CommentContent { ...{ commentId, isExpanded, isPostView } } />
 
 						{ showActions && (
 							<CommentActions

--- a/client/my-sites/comments/comment/style.scss
+++ b/client/my-sites/comments/comment/style.scss
@@ -196,7 +196,7 @@
 		flex-flow: row;
 		flex-wrap: nowrap;
 		justify-content: space-between;
-		margin: 8px 0 1em 0;
+		margin-top: 16px;
 	}
 
 	.comment__post-link {
@@ -217,6 +217,7 @@
 		flex-grow: 0;
 		flex-shrink: 0;
 		font-size: 12px;
+		margin-left: auto;
 		padding: 0 10px;
 	}
 
@@ -242,6 +243,10 @@
 		a:hover {
 			color: $blue-wordpress;
 		}
+	}
+
+	.comment__content-body {
+		margin-top: 16px;
 	}
 
 	.comment__content-body *:last-child {
@@ -470,12 +475,11 @@
 	}
 
 	.comment__content {
-		padding-top: 8px;
 		padding-bottom: 8px;
 
 		.comment__in-reply-to {
 			border-left: 4px solid lighten($gray, 30%);
-			margin-bottom: 1em;
+			margin: 16px 0;
 			padding: 2px 4px;
 		}
 	}


### PR DESCRIPTION
Closes #19307

In post view we don't need to repeat the post title on every comments.
This PR takes care of hiding it.

### Screenshots

<img width="680" alt="screen shot 2017-11-06 at 12 49 35" src="https://user-images.githubusercontent.com/2070010/32441864-2120c83a-c2f1-11e7-8282-a554192820fd.png">

<img width="680" alt="screen shot 2017-11-06 at 12 49 07" src="https://user-images.githubusercontent.com/2070010/32441863-21047252-c2f1-11e7-95b4-b845764413e5.png">

### Testing instructions

Checkout this branch and run it with
`env ENABLE_FEATURES=comments/management/m3-design npm start`

To enter the Post View, just click on the post title in any comment.

### Note

In expanded view, when the comment is pending, the post link line also contains the `Pending` label.
By removing the post link, we get this:

<img width="681" alt="screen shot 2017-11-06 at 12 49 20" src="https://user-images.githubusercontent.com/2070010/32441904-460583b6-c2f1-11e7-95eb-77202df6ea54.png">

Which is not really cool.

One solution with big headache involved: make the comment content wrap around the label.

Another solution that _I think_ has been proposed already: make the comment all yellow in expanded view as it already is in collapsed view.

(I really like the another solution. 🙂 )