### PR TITLE
Jetpack connect: Connect auth logged out actions

### DIFF
--- a/client/jetpack-connect/auth-logged-out-form.jsx
+++ b/client/jetpack-connect/auth-logged-out-form.jsx
@@ -21,6 +21,7 @@ import LoggedOutFormLinkItem from 'components/logged-out-form/link-item';
 import LoggedOutFormLinks from 'components/logged-out-form/links';
 import SignupForm from 'components/signup-form';
 import WpcomLoginForm from 'signup/wpcom-login-form';
+import { createAccount as createAccountAction } from 'state/jetpack-connect/actions';
 import { login } from 'lib/paths';
 import { recordTracksEvent as recordTracksEventAction } from 'state/analytics/actions';
 
@@ -28,7 +29,6 @@ const debug = debugFactory( 'calypso:jetpack-connect:authorize-form' );
 
 class LoggedOutForm extends Component {
 	static propTypes = {
-		createAccount: PropTypes.func.isRequired,
 		jetpackConnectAuthorize: PropTypes.shape( {
 			bearerToken: PropTypes.string,
 			isAuthorizing: PropTypes.bool,
@@ -39,6 +39,7 @@ class LoggedOutForm extends Component {
 		path: PropTypes.string,
 
 		// Connected props
+		createAccount: PropTypes.func.isRequired,
 		recordTracksEvent: PropTypes.func.isRequired,
 		translate: PropTypes.func.isRequired,
 	};
@@ -125,4 +126,5 @@ class LoggedOutForm extends Component {
 
 export default connect( null, {
 	recordTracksEvent: recordTracksEventAction,
+	createAccount: createAccountAction,
 } )( localize( LoggedOutForm ) );

--- a/client/jetpack-connect/auth-logged-out-form.jsx
+++ b/client/jetpack-connect/auth-logged-out-form.jsx
@@ -5,6 +5,7 @@
 import React, { Component } from 'react';
 import debugFactory from 'debug';
 import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
 import { get } from 'lodash';
 import { localize } from 'i18n-calypso';
 
@@ -21,6 +22,7 @@ import LoggedOutFormLinks from 'components/logged-out-form/links';
 import SignupForm from 'components/signup-form';
 import WpcomLoginForm from 'signup/wpcom-login-form';
 import { login } from 'lib/paths';
+import { recordTracksEvent as recordTracksEventAction } from 'state/analytics/actions';
 
 const debug = debugFactory( 'calypso:jetpack-connect:authorize-form' );
 
@@ -37,6 +39,7 @@ class LoggedOutForm extends Component {
 		path: PropTypes.string,
 
 		// Connected props
+		recordTracksEvent: PropTypes.func.isRequired,
 		translate: PropTypes.func.isRequired,
 	};
 
@@ -120,4 +123,6 @@ class LoggedOutForm extends Component {
 	}
 }
 
-export default localize( LoggedOutForm );
+export default connect( null, {
+	recordTracksEvent: recordTracksEventAction,
+} )( localize( LoggedOutForm ) );

--- a/client/jetpack-connect/auth-logged-out-form.jsx
+++ b/client/jetpack-connect/auth-logged-out-form.jsx
@@ -3,26 +3,26 @@
  * External dependencies
  */
 import React, { Component } from 'react';
+import debugFactory from 'debug';
 import PropTypes from 'prop-types';
-import debugModule from 'debug';
 import { get } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
+import addQueryArgs from 'lib/route/add-query-args';
+import AuthFormHeader from './auth-form-header';
 import config from 'config';
 import HelpButton from './help-button';
-import { login } from 'lib/paths';
-import LoggedOutFormLinks from 'components/logged-out-form/links';
-import LoggedOutFormLinkItem from 'components/logged-out-form/link-item';
-import addQueryArgs from 'lib/route/add-query-args';
 import LocaleSuggestions from 'components/locale-suggestions';
+import LoggedOutFormLinkItem from 'components/logged-out-form/link-item';
+import LoggedOutFormLinks from 'components/logged-out-form/links';
 import SignupForm from 'components/signup-form';
 import WpcomLoginForm from 'signup/wpcom-login-form';
-import AuthFormHeader from './auth-form-header';
+import { login } from 'lib/paths';
 
-const debug = debugModule( 'calypso:jetpack-connect:authorize-form' );
+const debug = debugFactory( 'calypso:jetpack-connect:authorize-form' );
 
 class LoggedOutForm extends Component {
 	static propTypes = {
@@ -35,6 +35,8 @@ class LoggedOutForm extends Component {
 		} ).isRequired,
 		locale: PropTypes.string,
 		path: PropTypes.string,
+
+		// Connected props
 		translate: PropTypes.func.isRequired,
 	};
 

--- a/client/jetpack-connect/authorize-form.jsx
+++ b/client/jetpack-connect/authorize-form.jsx
@@ -15,7 +15,6 @@ import { get, includes } from 'lodash';
 import Main from 'components/main';
 import LoggedOutFormLinks from 'components/logged-out-form/links';
 import {
-	createAccount,
 	authorize,
 	goBackToWpAdmin,
 	retryAuth,
@@ -49,7 +48,6 @@ class JetpackConnectAuthorizeForm extends Component {
 		authAttempts: PropTypes.number,
 		authorize: PropTypes.func,
 		calypsoStartedConnection: PropTypes.bool,
-		createAccount: PropTypes.func,
 		goBackToWpAdmin: PropTypes.func,
 		goToXmlrpcErrorFallbackUrl: PropTypes.func,
 		isAlreadyOnSitesList: PropTypes.bool,
@@ -172,7 +170,6 @@ export default connect(
 	},
 	{
 		authorize,
-		createAccount,
 		goBackToWpAdmin,
 		goToXmlrpcErrorFallbackUrl,
 		recordTracksEvent,


### PR DESCRIPTION
This PR moves opaquely spread-passed bound action creators from the parent `JetpackConnectAuthorizeForm` to the child `LoggedOutForm`.  This is a first step at making these and other connected props explicit on the consumer and removing the opaque spread props passing.

The two bound action creators that `LoggedOutForm` consumes have been explicitly connected to the component:
- `recordTracksEvent`
- `createAccount`

`createAccount` does not appear to be used by the parent and has been removed.

## Testing
- Tests should pass
- Ensure the logged out connection flow remains unchanged

