### PR TITLE
Hide the Label Settings section and the "Label setup" warning notice if the user isn't the plan owner

### DIFF
--- a/client/extensions/woocommerce/state/data-layer/ui/woocommerce-services/index.js
+++ b/client/extensions/woocommerce/state/data-layer/ui/woocommerce-services/index.js
@@ -28,7 +28,11 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 
 const getSaveLabelSettingsActionListSteps = ( state, siteId ) => {
 	const labelFormMeta = getLabelSettingsFormMeta( state, siteId );
-	if ( ! labelFormMeta || labelFormMeta.pristine || ! labelFormMeta.can_manage_payments ) {
+	if (
+		! labelFormMeta ||
+		labelFormMeta.pristine ||
+		( ! labelFormMeta.can_edit_settings && labelFormMeta.can_manage_payments )
+	) {
 		return [];
 	}
 

--- a/client/extensions/woocommerce/woocommerce-services/components/labels-setup-notice/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/components/labels-setup-notice/index.js
@@ -16,6 +16,7 @@ import { getLink } from 'woocommerce/lib/nav-utils';
 import {
 	areSettingsLoaded,
 	areLabelsEnabled,
+	getLabelSettingsFormMeta,
 	getSelectedPaymentMethodId,
 } from 'woocommerce/woocommerce-services/state/label-settings/selectors';
 import { isWcsEnabled } from 'woocommerce/state/selectors/plugins';
@@ -27,6 +28,7 @@ const LabelsSetupNotice = ( {
 	enabled,
 	hasLabelsPaymentMethod,
 	translate,
+	showNotice,
 } ) => {
 	if ( ! wcsEnabled ) {
 		return null;
@@ -34,6 +36,10 @@ const LabelsSetupNotice = ( {
 
 	if ( ! loaded ) {
 		return <QueryLabelSettings siteId={ site.ID } />;
+	}
+
+	if ( ! showNotice ) {
+		return null;
 	}
 
 	if ( enabled && ! hasLabelsPaymentMethod ) {
@@ -58,5 +64,6 @@ export default connect( state => {
 		loaded: areSettingsLoaded( state, site.ID ),
 		enabled: areLabelsEnabled( state, site.ID ),
 		hasLabelsPaymentMethod: Boolean( getSelectedPaymentMethodId( state, site.ID ) ),
+		showNotice: ( getLabelSettingsFormMeta( state, site.ID ) || {} ).can_manage_payments,
 	};
 } )( localize( LabelsSetupNotice ) );

--- a/client/extensions/woocommerce/woocommerce-services/views/label-settings/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/label-settings/index.js
@@ -21,7 +21,7 @@ import FormToggle from 'components/forms/form-toggle';
 import LabelSettings from './label-settings';
 import QueryLabelSettings from 'woocommerce/woocommerce-services/components/query-label-settings';
 import { setFormDataValue, restorePristineSettings } from '../../state/label-settings/actions';
-import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
 import {
 	getLabelSettingsFormData,
 	getLabelSettingsFormMeta,
@@ -34,11 +34,7 @@ class AccountSettingsRootView extends Component {
 	}
 
 	render() {
-		const { formData, formMeta, storeOptions, siteId, translate, show } = this.props;
-
-		if ( ! show ) {
-			return null;
-		}
+		const { formData, formMeta, storeOptions, siteId, translate } = this.props;
 
 		if ( ! formMeta || ( ! formMeta.isFetching && ! formMeta.can_manage_payments ) ) {
 			return <QueryLabelSettings siteId={ siteId } />;
@@ -100,7 +96,6 @@ AccountSettingsRootView.propTypes = {
 
 function mapStateToProps( state ) {
 	return {
-		show: getSelectedSite( state ).plan.user_is_owner,
 		siteId: getSelectedSiteId( state ),
 		storeOptions: getLabelSettingsStoreOptions( state ),
 		formData: getLabelSettingsFormData( state ),

--- a/client/extensions/woocommerce/woocommerce-services/views/label-settings/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/label-settings/index.js
@@ -36,7 +36,7 @@ class AccountSettingsRootView extends Component {
 	render() {
 		const { formData, formMeta, storeOptions, siteId, translate } = this.props;
 
-		if ( ! formMeta || ( ! formMeta.isFetching && ! formMeta.can_manage_payments ) ) {
+		if ( ! formMeta ) {
 			return <QueryLabelSettings siteId={ siteId } />;
 		}
 		const setValue = ( key, value ) => this.props.setFormDataValue( siteId, key, value );
@@ -61,6 +61,10 @@ class AccountSettingsRootView extends Component {
 					selectedPaymentMethod={ ( formData || {} ).selected_payment_method_id }
 					paperSize={ ( formData || {} ).paper_size }
 					storeOptions={ storeOptions }
+					canEditPayments={ formMeta.can_manage_payments }
+					canEditSettings={ Boolean( formMeta.can_manage_payments || formMeta.can_edit_settings ) }
+					masterUserName={ formMeta.master_user_name }
+					masterUserLogin={ formMeta.master_user_login }
 				/>
 			);
 		};
@@ -79,7 +83,11 @@ class AccountSettingsRootView extends Component {
 					) }
 				>
 					{ renderToggle && (
-						<FormToggle checked={ formData.enabled } onChange={ onEnabledToggle } />
+						<FormToggle
+							checked={ formData.enabled }
+							onChange={ onEnabledToggle }
+							disabled={ Boolean( ! formMeta.can_manage_payments && ! formMeta.can_edit_settings ) }
+						/>
 					) }
 				</ExtendedHeader>
 				<Card className={ classNames( 'label-settings__labels-container', { hidden } ) }>

--- a/client/extensions/woocommerce/woocommerce-services/views/label-settings/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/label-settings/index.js
@@ -21,7 +21,7 @@ import FormToggle from 'components/forms/form-toggle';
 import LabelSettings from './label-settings';
 import QueryLabelSettings from 'woocommerce/woocommerce-services/components/query-label-settings';
 import { setFormDataValue, restorePristineSettings } from '../../state/label-settings/actions';
-import { getSelectedSiteId } from 'state/ui/selectors';
+import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 import {
 	getLabelSettingsFormData,
 	getLabelSettingsFormMeta,
@@ -34,7 +34,11 @@ class AccountSettingsRootView extends Component {
 	}
 
 	render() {
-		const { formData, formMeta, storeOptions, siteId, translate } = this.props;
+		const { formData, formMeta, storeOptions, siteId, translate, show } = this.props;
+
+		if ( ! show ) {
+			return null;
+		}
 
 		if ( ! formMeta || ( ! formMeta.isFetching && ! formMeta.can_manage_payments ) ) {
 			return <QueryLabelSettings siteId={ siteId } />;
@@ -96,6 +100,7 @@ AccountSettingsRootView.propTypes = {
 
 function mapStateToProps( state ) {
 	return {
+		show: getSelectedSite( state ).plan.user_is_owner,
 		siteId: getSelectedSiteId( state ),
 		storeOptions: getLabelSettingsStoreOptions( state ),
 		formData: getLabelSettingsFormData( state ),

--- a/client/extensions/woocommerce/woocommerce-services/views/label-settings/label-settings.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/label-settings/label-settings.js
@@ -73,7 +73,7 @@ class ShippingLabels extends Component {
 		}
 
 		return (
-			<Notice status="is-warning" showDismiss={ false }>
+			<Notice showDismiss={ false }>
 				{ translate(
 					'Only the site owner can manage shipping label payment methods. Please' +
 						' contact %(ownerName)s (%(ownerLogin)s) to manage payment methods.',
@@ -95,7 +95,7 @@ class ShippingLabels extends Component {
 		}
 
 		return (
-			<Notice status="is-warning" showDismiss={ false }>
+			<Notice showDismiss={ false }>
 				{ translate(
 					'Only the site owner can change these settings. Please contact %(ownerName)s (%(ownerLogin)s)' +
 						' to change the shipping label settings.',

--- a/client/extensions/woocommerce/woocommerce-services/views/label-settings/label-settings.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/label-settings/label-settings.js
@@ -75,7 +75,8 @@ class ShippingLabels extends Component {
 		return (
 			<Notice status="is-warning" showDismiss={ false }>
 				{ translate(
-					'Only the site owner can manage shipping label payment methods. Please contact %(ownerName)s (%(ownerLogin)s) to manage payment methods.',
+					'Only the site owner can manage shipping label payment methods. Please' +
+						' contact %(ownerName)s (%(ownerLogin)s) to manage payment methods.',
 					{
 						args: {
 							ownerName: masterUserName,
@@ -96,7 +97,8 @@ class ShippingLabels extends Component {
 		return (
 			<Notice status="is-warning" showDismiss={ false }>
 				{ translate(
-					'Only the site owner can change these settings. Please contact %(ownerName)s (%(ownerLogin)s) to change the shipping label settings.',
+					'Only the site owner can change these settings. Please contact %(ownerName)s (%(ownerLogin)s)' +
+						' to change the shipping label settings.',
 					{
 						args: {
 							ownerName: masterUserName,

--- a/client/extensions/woocommerce/woocommerce-services/views/label-settings/label-settings.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/label-settings/label-settings.js
@@ -125,13 +125,13 @@ class ShippingLabels extends Component {
 				this.setState( { expanded: true } );
 			};
 
-			const { card_type: selectedType, card_digits: selectedDigits } = find( paymentMethods, {
-				payment_method_id: selectedPaymentMethod,
-			} );
-
 			let summary;
 
 			if ( selectedPaymentMethod ) {
+				const { card_type: selectedType, card_digits: selectedDigits } = find( paymentMethods, {
+					payment_method_id: selectedPaymentMethod,
+				} );
+
 				summary = translate(
 					"We'll charge the credit card on your " +
 						'account (%(card)s) to pay for the labels you print',

--- a/client/extensions/woocommerce/woocommerce-services/views/packages/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/packages/index.js
@@ -134,10 +134,10 @@ Packages.propTypes = {
 export default connect(
 	state => {
 		const siteId = getSelectedSiteId( state );
-		const form = getPackagesForm( state, siteId );
+		const form = getPackagesForm( state, siteId ) || {};
 		return {
 			siteId,
-			isFetching: ! form || ! form.packages || form.isFetching,
+			isFetching: ! form.packages || form.isFetching,
 			fetchError: isFetchError( state, siteId ),
 			form,
 			allSelectedPackages: getAllSelectedPackages( state, siteId ) || [],


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/19389
Fixes https://github.com/Automattic/wp-calypso/issues/19403

If the current user isn't the Jetpack plan's owner, the Labels Settings section must be hidden (even while loading), and the "Label Payments" warning notice shouldn't be displayed either, since the user can't do anything to fix that configuration problem.

To test:
* Start with an empty configuration, with no payment method configured for the shipping labels.
* Login as a different user than the site's "master user".
* Go to an order page, you shouldn't see a "warning" notice.
* Go to the Shipping Settings page, you shouldn't see the Labels Settings section, not even its placeholder while it loads.