### PR TITLE
Jetpack Connect: Rephrase Happychat button in SSO step

### DIFF
--- a/client/jetpack-connect/sso.jsx
+++ b/client/jetpack-connect/sso.jsx
@@ -457,7 +457,10 @@ class JetpackSsoForm extends Component {
 						>
 							{ this.getReturnToSiteText() }
 						</LoggedOutFormLinkItem>
-						<JetpackConnectHappychatButton eventName="calypso_jpc_sso_chat_initiated">
+						<JetpackConnectHappychatButton
+							eventName="calypso_jpc_sso_chat_initiated"
+							label={ translate( 'Chat with Jetpack support' ) }
+						>
 							<HelpButton />
 						</JetpackConnectHappychatButton>
 					</LoggedOutFormLinks>


### PR DESCRIPTION
This PR updates the wording of the Happychat button in the SSO step of Jetpack Connect to be **Chat with Jetpack support** rather than the default **Get help connecting your site**.

Fixes #19492.

To test:
* Checkout this branch
* Enable yourself in the Happychat staging HUD
* Go through the SSO flow
* Verify you can see the new, updating wording in the SSO step in Calypso.