### PR TITLE
Jetpack Disconnect Survey: Final Touches

### DIFF
--- a/client/my-sites/site-settings/disconnect-site/confirm.jsx
+++ b/client/my-sites/site-settings/disconnect-site/confirm.jsx
@@ -5,7 +5,7 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { camelCase, compact, find, flowRight, isArray, without } from 'lodash';
+import { compact, find, flowRight, isArray, without } from 'lodash';
 import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
@@ -47,7 +47,7 @@ class ConfirmDisconnection extends PureComponent {
 
 		const surveyData = {
 			'why-cancel': {
-				response: camelCase( find( this.constructor.reasonWhitelist, r => r === reason ) ),
+				response: find( this.constructor.reasonWhitelist, r => r === reason ),
 				text: isArray( text ) ? text.join() : text,
 			},
 		};

--- a/client/my-sites/site-settings/disconnect-site/confirm.jsx
+++ b/client/my-sites/site-settings/disconnect-site/confirm.jsx
@@ -5,7 +5,7 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { compact, find, flowRight, get, isArray, keys, without } from 'lodash';
+import { camelCase, compact, find, flowRight, isArray, without } from 'lodash';
 import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
@@ -34,20 +34,20 @@ class ConfirmDisconnection extends PureComponent {
 		translate: PropTypes.func,
 	};
 
-	static reasonWhitelist = {
-		'missing-feature': 'didNotInclude',
-		'too-difficult': 'tooHard',
-		'too-expensive': 'onlyNeedFree',
-		troubleshooting: 'troubleshooting',
-		other: 'other',
-	};
+	static reasonWhitelist = [
+		'missing-feature',
+		'too-difficult',
+		'too-expensive',
+		'troubleshooting',
+		'other',
+	];
 
 	submitSurvey = () => {
 		const { moment, purchase, reason, site, siteId, text } = this.props;
 
 		const surveyData = {
 			'why-cancel': {
-				response: get( this.constructor.reasonWhitelist, reason ),
+				response: camelCase( find( this.constructor.reasonWhitelist, r => r === reason ) ),
 				text: isArray( text ) ? text.join() : text,
 			},
 		};
@@ -62,7 +62,7 @@ class ConfirmDisconnection extends PureComponent {
 	render() {
 		const { reason, siteId, siteSlug, translate } = this.props;
 		const previousStep = find(
-			without( keys( this.constructor.reasonWhitelist ), 'troubleshooting', 'other' ), // Redirect those back to initial survey
+			without( this.constructor.reasonWhitelist, 'troubleshooting', 'other' ), // Redirect those back to initial survey
 			r => r === reason
 		);
 

--- a/client/my-sites/site-settings/disconnect-site/disconnect-survey.jsx
+++ b/client/my-sites/site-settings/disconnect-site/disconnect-survey.jsx
@@ -28,20 +28,22 @@ const DisconnectSurvey = ( { confirmHref, isPaidPlan, siteId, siteSlug, translat
 			) }
 		/>
 		<CompactCard href={ `/settings/disconnect-site/too-difficult/${ siteSlug }` }>
-			{ translate( 'It was too hard to configure Jetpack' ) }
+			{ translate( 'It was too hard to configure Jetpack.' ) }
 		</CompactCard>
 		<CompactCard href={ `/settings/disconnect-site/missing-feature/${ siteSlug }` }>
 			{ translate( 'A feature I need was missing.' ) }
 		</CompactCard>
 		{ isPaidPlan && (
 			<CompactCard href={ `/settings/disconnect-site/too-expensive/${ siteSlug }` }>
-				{ translate( 'This plan is too expensive' ) }
+				{ translate( 'This plan is too expensive.' ) }
 			</CompactCard>
 		) }
 		<CompactCard href={ confirmHref + '?reason=troubleshooting' }>
-			{ translate( "Troubleshooting — I'll be reconnecting afterwards" ) }
+			{ translate( "Troubleshooting — I'll be reconnecting afterwards." ) }
 		</CompactCard>
-		<CompactCard href={ confirmHref + '?reason=other' }>{ translate( 'Other' ) }</CompactCard>
+		<CompactCard href={ confirmHref + '?reason=other' }>
+			{ translate( 'Another reason…' ) }
+		</CompactCard>
 	</div>
 );
 


### PR DESCRIPTION
* Fix punctuation by adding terminating periods to options.
* Simplify whitelist. Turns out we're free to use whatever slugs for reasons, so why not stick to the names we're using for routes and components. ~Note that I'm `camelCasing` them upon submission, for sake of consistency with the other marketing survey.~ Removed per discussion with @seear.

To test:
* `/settings/disconnect-site/:site`
* Verify that all options are terminated with a period (or 3 ellipsis dots)
* Verify that using the 'Back' button from the confirmation page still takes you back to the correct previous step.
* Verify that confirming submit the marketing survey with the reason camelCased (e.g. `too-difficult` become `tooDifficult`). (Check the 'Network' tab in your Dev Tools, Cmd+F `survey`)
