### PR TITLE
Fix single-tree-render codemod removing comments

### DIFF
--- a/bin/codemods/src/single-tree-rendering.js
+++ b/bin/codemods/src/single-tree-rendering.js
@@ -83,7 +83,7 @@ export default function transformer( file, api ) {
 		.remove();
 
 	// Find empty `import 'lib/react-helpers'`
-	let orphanImportHelpers = root
+	const orphanImportHelpers = root
 		.find( j.ImportDeclaration, {
 			source: {
 				value: 'lib/react-helpers',
@@ -93,7 +93,7 @@ export default function transformer( file, api ) {
 
 	if ( orphanImportHelpers.size() ) {
 		// Find out if import had comment above it
-		let comment = _.get( orphanImportHelpers.nodes(), '[0].comments[0]', false );
+		const comment = _.get( orphanImportHelpers.nodes(), '[0].comments[0]', false );
 
 		// Remove empty `import 'lib/react-helpers'` (and any comments with it)
 		orphanImportHelpers.remove();
@@ -104,7 +104,7 @@ export default function transformer( file, api ) {
 			root
 				.find( j.ImportDeclaration )
 				.filter( p => {
-					let importValue = _.get( p, 'value.source.value', '' );
+					const importValue = _.get( p, 'value.source.value', '' );
 					return importValue.indexOf( '/' ) > -1;
 				} )
 				.at( 0 )

--- a/bin/codemods/src/single-tree-rendering.js
+++ b/bin/codemods/src/single-tree-rendering.js
@@ -104,10 +104,17 @@ export default function transformer( file, api ) {
 			root
 				.find( j.ImportDeclaration )
 				.filter( p => {
+					const internalDepsWithoutSlash = [
+						'config',
+						'controller',
+						'dispatcher',
+						'layout',
+						'sections',
+					];
 					const importValue = _.get( p, 'value.source.value', '' );
+
 					return (
-						importValue.indexOf( '/' ) > -1 ||
-						[ 'config', 'controller', 'dispatcher', 'layout' ].indexOf( importValue ) > -1
+						importValue.indexOf( '/' ) > -1 || internalDepsWithoutSlash.indexOf( importValue ) > -1
 					);
 				} )
 				.at( 0 )

--- a/bin/codemods/src/single-tree-rendering.js
+++ b/bin/codemods/src/single-tree-rendering.js
@@ -108,8 +108,9 @@ export default function transformer( file, api ) {
 					return importValue.indexOf( '/' ) > -1;
 				} )
 				.at( 0 )
-				.forEach( p => {
+				.replaceWith( p => {
 					p.value.comments = [ comment ];
+					return p.value;
 				} );
 		}
 	}

--- a/bin/codemods/src/single-tree-rendering.js
+++ b/bin/codemods/src/single-tree-rendering.js
@@ -105,7 +105,10 @@ export default function transformer( file, api ) {
 				.find( j.ImportDeclaration )
 				.filter( p => {
 					const importValue = _.get( p, 'value.source.value', '' );
-					return importValue.indexOf( '/' ) > -1;
+					return (
+						importValue.indexOf( '/' ) > -1 ||
+						[ 'config', 'controller', 'dispatcher', 'layout' ].indexOf( importValue ) > -1
+					);
 				} )
 				.at( 0 )
 				.replaceWith( p => {


### PR DESCRIPTION
Previously `single-tree-render` codemod would remove any comments above `import 'lib/react-helpers'` line when removing the import line.

This will catch those comments, check if there are any internal dependencies left in the file and if so, places comment back above the first import.

Related to PR #19494 _"Single tree-rendering-issues"_

### To test:
#### Test A
1. Run
    ```bash
    npm run codemod single-tree-rendering ./client/me/happychat/index.jsx ./client/my-sites/plans/current-plan/controller.jsx
    ```
2. Observe _"Internal Dependencies"_ comments remain in the file above internal imports.

#### Test B
3. Run
    ```bash
    npm run codemod single-tree-rendering ./client/me/billing-history/controller.js
    ```
4. Since there are no internal imports in the file anymore, comment is removed. 💥 

#### Test C
1. Run
    ```bash
    npm run codemod single-tree-rendering ./client/my-sites/plans/controller.jsx
    ```
2. Observe _"Internal Dependencies"_ comment remain in the file above internal import, even when there was external import between two internal imports before.