### PR TITLE
 Upgrade Prettier to version 1.7.4

### DIFF
--- a/client/blocks/author-compact-profile/index.jsx
+++ b/client/blocks/author-compact-profile/index.jsx
@@ -72,11 +72,11 @@ class AuthorCompactProfile extends React.Component {
 					<ReaderAvatar siteIcon={ siteIcon } feedIcon={ feedIcon } author={ author } />
 				</a>
 				{ hasAuthorName &&
-				! hasMatchingAuthorAndSiteNames && (
-					<ReaderAuthorLink author={ author } siteUrl={ streamUrl } post={ post }>
-						{ author.name }
-					</ReaderAuthorLink>
-				) }
+					! hasMatchingAuthorAndSiteNames && (
+						<ReaderAuthorLink author={ author } siteUrl={ streamUrl } post={ post }>
+							{ author.name }
+						</ReaderAuthorLink>
+					) }
 				{ siteName && (
 					<ReaderSiteStreamLink
 						className="author-compact-profile__site-link"

--- a/client/blocks/blog-stickers/index.jsx
+++ b/client/blocks/blog-stickers/index.jsx
@@ -27,12 +27,12 @@ const BlogStickers = ( { blogId, teams, stickers } ) => {
 	return (
 		<div className="blog-stickers">
 			{ isTeamMember &&
-			stickers &&
-			stickers.length > 0 && (
-				<InfoPopover rootClassName="blog-stickers__popover">
-					<BlogStickersList stickers={ stickers } />
-				</InfoPopover>
-			) }
+				stickers &&
+				stickers.length > 0 && (
+					<InfoPopover rootClassName="blog-stickers__popover">
+						<BlogStickersList stickers={ stickers } />
+					</InfoPopover>
+				) }
 			{ ! stickers && <QueryBlogStickers blogId={ blogId } /> }
 			{ ! teams && <QueryReaderTeams /> }
 		</div>

--- a/client/blocks/comment-button/index.jsx
+++ b/client/blocks/comment-button/index.jsx
@@ -56,14 +56,14 @@ class CommentButton extends Component {
 					<span className="comment-button__label-count">{ commentCount }</span>
 				) }
 				{ showLabel &&
-				commentCount > 0 && (
-					<span className="comment-button__label-status">
-						{ translate( 'Comment', 'Comments', {
-							context: 'noun',
-							count: commentCount,
-						} ) }
-					</span>
-				) }
+					commentCount > 0 && (
+						<span className="comment-button__label-status">
+							{ translate( 'Comment', 'Comments', {
+								context: 'noun',
+								count: commentCount,
+							} ) }
+						</span>
+					) }
 			</span>
 		);
 	}

--- a/client/blocks/comment-detail/comment-detail-actions.jsx
+++ b/client/blocks/comment-detail/comment-detail-actions.jsx
@@ -54,11 +54,15 @@ export const CommentDetailActions = ( {
 	return (
 		<CommentDetailActionsContainer { ...{ compact } }>
 			{ hasAction( commentStatus, 'reply' ) &&
-			compact && (
-				<Button compact={ compact } className="comment-detail__action-edit" onClick={ toggleReply }>
-					<Gridicon icon="reply" />
-				</Button>
-			) }
+				compact && (
+					<Button
+						compact={ compact }
+						className="comment-detail__action-edit"
+						onClick={ toggleReply }
+					>
+						<Gridicon icon="reply" />
+					</Button>
+				) }
 
 			{ hasAction( commentStatus, 'like' ) && (
 				<Button
@@ -89,16 +93,16 @@ export const CommentDetailActions = ( {
 			) }
 
 			{ hasAction( commentStatus, 'edit' ) &&
-			! compact && (
-				<Button
-					{ ...{ borderless: ! compact, compact } }
-					className="comment-detail__action-edit"
-					onClick={ toggleEditMode }
-				>
-					<Gridicon icon="pencil" />
-					{ compact || <span>{ translate( 'Edit' ) }</span> }
-				</Button>
-			) }
+				! compact && (
+					<Button
+						{ ...{ borderless: ! compact, compact } }
+						className="comment-detail__action-edit"
+						onClick={ toggleEditMode }
+					>
+						<Gridicon icon="pencil" />
+						{ compact || <span>{ translate( 'Edit' ) }</span> }
+					</Button>
+				) }
 
 			{ hasAction( commentStatus, 'spam' ) && (
 				<Button

--- a/client/blocks/comment-detail/comment-detail-header.jsx
+++ b/client/blocks/comment-detail/comment-detail-header.jsx
@@ -94,21 +94,21 @@ export class CommentDetailHeader extends Component {
 				onMouseLeave={ this.onMouseLeave }
 			>
 				{ isExpanded &&
-				isEditMode && (
-					<div className="comment-detail__header-edit-mode">
-						<div className="comment-detail__header-edit-title">
-							<Gridicon icon="pencil" />
-							<span>{ translate( 'Edit Comment' ) }</span>
+					isEditMode && (
+						<div className="comment-detail__header-edit-mode">
+							<div className="comment-detail__header-edit-title">
+								<Gridicon icon="pencil" />
+								<span>{ translate( 'Edit Comment' ) }</span>
+							</div>
+							<Button
+								borderless
+								className="comment-detail__action-collapse"
+								onClick={ toggleEditMode }
+							>
+								<Gridicon icon="cross" />
+							</Button>
 						</div>
-						<Button
-							borderless
-							className="comment-detail__action-collapse"
-							onClick={ toggleEditMode }
-						>
-							<Gridicon icon="cross" />
-						</Button>
-					</div>
-				) }
+					) }
 
 				{ ! isExpanded && (
 					<div className="comment-detail__header-content">
@@ -159,32 +159,32 @@ export class CommentDetailHeader extends Component {
 					showQuickActions &&
 					! viewport.isMobile() ) ||
 					isExpanded ) &&
-				! isEditMode && (
-					<CommentDetailActions
-						compact={ showQuickActions && ! isExpanded }
-						commentIsLiked={ commentIsLiked }
-						commentStatus={ commentStatus }
-						deleteCommentPermanently={ deleteCommentPermanently }
-						toggleReply={ toggleReply }
-						toggleApprove={ toggleApprove }
-						toggleEditMode={ toggleEditMode }
-						toggleLike={ toggleLike }
-						toggleSpam={ toggleSpam }
-						toggleTrash={ toggleTrash }
-					/>
-				) }
+					! isEditMode && (
+						<CommentDetailActions
+							compact={ showQuickActions && ! isExpanded }
+							commentIsLiked={ commentIsLiked }
+							commentStatus={ commentStatus }
+							deleteCommentPermanently={ deleteCommentPermanently }
+							toggleReply={ toggleReply }
+							toggleApprove={ toggleApprove }
+							toggleEditMode={ toggleEditMode }
+							toggleLike={ toggleLike }
+							toggleSpam={ toggleSpam }
+							toggleTrash={ toggleTrash }
+						/>
+					) }
 
 				{ ! isBulkEdit &&
-				! isEditMode && (
-					<Button
-						borderless
-						className="comment-detail__action-collapse"
-						disabled={ isEditMode }
-						onClick={ isExpanded ? toggleExpanded : noop }
-					>
-						<Gridicon icon="chevron-down" />
-					</Button>
-				) }
+					! isEditMode && (
+						<Button
+							borderless
+							className="comment-detail__action-collapse"
+							disabled={ isEditMode }
+							onClick={ isExpanded ? toggleExpanded : noop }
+						>
+							<Gridicon icon="chevron-down" />
+						</Button>
+					) }
 			</div>
 		);
 	}

--- a/client/blocks/comments/post-comment-list.jsx
+++ b/client/blocks/comments/post-comment-list.jsx
@@ -451,16 +451,16 @@ class PostCommentList extends React.Component {
 				) }
 				{ this.renderCommentsList( displayedComments ) }
 				{ showViewMoreComments &&
-				this.props.startingCommentId && (
-					<span className="comments__view-more" onClick={ this.viewLaterCommentsHandler }>
-						{ translate( 'Load more comments (Showing %(shown)d of %(total)d)', {
-							args: {
-								shown: displayedCommentsCount,
-								total: actualCommentsCount,
-							},
-						} ) }
-					</span>
-				) }
+					this.props.startingCommentId && (
+						<span className="comments__view-more" onClick={ this.viewLaterCommentsHandler }>
+							{ translate( 'Load more comments (Showing %(shown)d of %(total)d)', {
+								args: {
+									shown: displayedCommentsCount,
+									total: actualCommentsCount,
+								},
+							} ) }
+						</span>
+					) }
 				<PostCommentFormRoot
 					post={ this.props.post }
 					commentsTree={ this.props.commentsTree }

--- a/client/blocks/comments/post-comment.jsx
+++ b/client/blocks/comments/post-comment.jsx
@@ -400,17 +400,17 @@ class PostComment extends React.PureComponent {
 						className: 'comments__comment-username',
 					} ) }
 					{ this.props.showNestingReplyArrow &&
-					parentAuthorName && (
-						<span className="comments__comment-respondee">
-							<Gridicon icon="chevron-right" size={ 16 } />
-							{ this.renderAuthorTag( {
-								className: 'comments__comment-respondee-link',
-								authorName: parentAuthorName,
-								authorUrl: parentAuthorUrl,
-								commentId: parentCommentId,
-							} ) }
-						</span>
-					) }
+						parentAuthorName && (
+							<span className="comments__comment-respondee">
+								<Gridicon icon="chevron-right" size={ 16 } />
+								{ this.renderAuthorTag( {
+									className: 'comments__comment-respondee-link',
+									authorName: parentAuthorName,
+									authorUrl: parentAuthorUrl,
+									commentId: parentCommentId,
+								} ) }
+							</span>
+						) }
 					<div className="comments__comment-timestamp">
 						<a
 							href={ comment.URL }
@@ -439,14 +439,14 @@ class PostComment extends React.PureComponent {
 				) }
 
 				{ isEnabled( 'comments/moderation-tools-in-posts' ) &&
-				this.props.activeEditCommentId === this.props.commentId && (
-					<CommentEditForm
-						post={ this.props.post }
-						commentId={ this.props.commentId }
-						commentText={ comment.content }
-						onCommentSubmit={ this.props.onEditCommentCancel }
-					/>
-				) }
+					this.props.activeEditCommentId === this.props.commentId && (
+						<CommentEditForm
+							post={ this.props.post }
+							commentId={ this.props.commentId }
+							commentText={ comment.content }
+							onCommentSubmit={ this.props.onEditCommentCancel }
+						/>
+					) }
 
 				<CommentActions
 					post={ this.props.post || {} }

--- a/client/blocks/conversation-caterpillar/index.jsx
+++ b/client/blocks/conversation-caterpillar/index.jsx
@@ -120,36 +120,32 @@ class ConversationCaterpillarComponent extends React.Component {
 					className="conversation-caterpillar__count"
 					onClick={ this.handleTickle }
 					title={
-						commentCount > 1 ? (
-							translate( 'View comments from %(commenterName)s and %(count)d more', {
+						commentCount > 1
+							? translate( 'View comments from %(commenterName)s and %(count)d more', {
+									args: {
+										commenterName: lastAuthorName,
+										count: commentCount - 1,
+									},
+								} )
+							: translate( 'View comment from %(commenterName)s', {
+									args: {
+										commenterName: lastAuthorName,
+									},
+								} )
+					}
+				>
+					{ commentCount > 1
+						? translate( '%(commenterName)s and %(count)d more', {
 								args: {
 									commenterName: lastAuthorName,
 									count: commentCount - 1,
 								},
 							} )
-						) : (
-							translate( 'View comment from %(commenterName)s', {
+						: translate( '%(commenterName)s commented', {
 								args: {
 									commenterName: lastAuthorName,
 								},
-							} )
-						)
-					}
-				>
-					{ commentCount > 1 ? (
-						translate( '%(commenterName)s and %(count)d more', {
-							args: {
-								commenterName: lastAuthorName,
-								count: commentCount - 1,
-							},
-						} )
-					) : (
-						translate( '%(commenterName)s commented', {
-							args: {
-								commenterName: lastAuthorName,
-							},
-						} )
-					) }
+							} ) }
 				</button>
 			</div>
 		);

--- a/client/blocks/credit-card-form/index.jsx
+++ b/client/blocks/credit-card-form/index.jsx
@@ -287,17 +287,15 @@ const CreditCardForm = createReactClass( {
 					<em>{ this.props.translate( 'All fields required' ) }</em>
 
 					<FormButton disabled={ this.state.formSubmitting } type="submit">
-						{ this.state.formSubmitting ? (
-							this.props.translate( 'Saving Card…', {
-								context: 'Button label',
-								comment: 'Credit card',
-							} )
-						) : (
-							this.props.translate( 'Save Card', {
-								context: 'Button label',
-								comment: 'Credit card',
-							} )
-						) }
+						{ this.state.formSubmitting
+							? this.props.translate( 'Saving Card…', {
+									context: 'Button label',
+									comment: 'Credit card',
+								} )
+							: this.props.translate( 'Save Card', {
+									context: 'Button label',
+									comment: 'Credit card',
+								} ) }
 					</FormButton>
 				</CompactCard>
 			</form>

--- a/client/blocks/eligibility-warnings/index.jsx
+++ b/client/blocks/eligibility-warnings/index.jsx
@@ -61,40 +61,36 @@ export const EligibilityWarnings = ( {
 				eventProperties={ { context } }
 			/>
 			{ ! hasBusinessPlan &&
-			! isJetpack && (
-				<Banner
-					description={ translate(
-						'Also get unlimited themes, advanced customization, no ads, live chat support, and more.'
-					) }
-					feature={ 'plugins' === context ? FEATURE_UPLOAD_PLUGINS : FEATURE_UPLOAD_THEMES }
-					event={
-						'plugins' === context ? (
-							'calypso-plugin-eligibility-upgrade-nudge'
-						) : (
-							'calypso-theme-eligibility-upgrade-nudge'
-						)
-					}
-					plan={ PLAN_BUSINESS }
-					title={ translate( 'Business plan required' ) }
-				/>
-			) }
+				! isJetpack && (
+					<Banner
+						description={ translate(
+							'Also get unlimited themes, advanced customization, no ads, live chat support, and more.'
+						) }
+						feature={ 'plugins' === context ? FEATURE_UPLOAD_PLUGINS : FEATURE_UPLOAD_THEMES }
+						event={
+							'plugins' === context
+								? 'calypso-plugin-eligibility-upgrade-nudge'
+								: 'calypso-theme-eligibility-upgrade-nudge'
+						}
+						plan={ PLAN_BUSINESS }
+						title={ translate( 'Business plan required' ) }
+					/>
+				) }
 			{ hasBusinessPlan &&
-			! isJetpack &&
-			includes( bannerHolds, 'NOT_USING_CUSTOM_DOMAIN' ) && (
-				<Banner
-					className="eligibility-warnings__banner"
-					description={
-						'plugins' === context ? (
-							translate( 'To install this plugin, add a free custom domain.' )
-						) : (
-							translate( 'To upload themes, add a free custom domain.' )
-						)
-					}
-					href={ `/domains/manage/${ siteSlug }` }
-					icon="domains"
-					title={ translate( 'Custom domain required' ) }
-				/>
-			) }
+				! isJetpack &&
+				includes( bannerHolds, 'NOT_USING_CUSTOM_DOMAIN' ) && (
+					<Banner
+						className="eligibility-warnings__banner"
+						description={
+							'plugins' === context
+								? translate( 'To install this plugin, add a free custom domain.' )
+								: translate( 'To upload themes, add a free custom domain.' )
+						}
+						href={ `/domains/manage/${ siteSlug }` }
+						icon="domains"
+						title={ translate( 'Custom domain required' ) }
+					/>
+				) }
 
 			{ ( isPlaceholder || listHolds.length > 0 ) && (
 				<HoldList holds={ listHolds } isPlaceholder={ isPlaceholder } siteSlug={ siteSlug } />
@@ -102,15 +98,15 @@ export const EligibilityWarnings = ( {
 			{ warnings.length > 0 && <WarningList warnings={ warnings } /> }
 
 			{ isEligible &&
-			0 === listHolds.length &&
-			0 === warnings.length && (
-				<Card className="eligibility-warnings__no-conflicts">
-					<Gridicon icon="thumbs-up" size={ 24 } />
-					<span>
-						{ translate( 'This site is eligible to install plugins and upload themes.' ) }
-					</span>
-				</Card>
-			) }
+				0 === listHolds.length &&
+				0 === warnings.length && (
+					<Card className="eligibility-warnings__no-conflicts">
+						<Gridicon icon="thumbs-up" size={ 24 } />
+						<span>
+							{ translate( 'This site is eligible to install plugins and upload themes.' ) }
+						</span>
+					</Card>
+				) }
 
 			<Card className="eligibility-warnings__confirm-box">
 				<div className="eligibility-warnings__confirm-text">

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -227,9 +227,9 @@ export class LoginForm extends Component {
 						/>
 
 						{ requestError &&
-						requestError.field === 'usernameOrEmail' && (
-							<FormInputValidation isError text={ requestError.message } />
-						) }
+							requestError.field === 'usernameOrEmail' && (
+								<FormInputValidation isError text={ requestError.message } />
+							) }
 
 						<label htmlFor="password" className="login__form-userdata-username">
 							{ this.props.translate( 'Password' ) }
@@ -250,9 +250,9 @@ export class LoginForm extends Component {
 						/>
 
 						{ requestError &&
-						requestError.field === 'password' && (
-							<FormInputValidation isError text={ requestError.message } />
-						) }
+							requestError.field === 'password' && (
+								<FormInputValidation isError text={ requestError.message } />
+							) }
 					</div>
 
 					{ config.isEnabled( 'signup/social' ) && (

--- a/client/blocks/login/two-factor-authentication/verification-code-form.jsx
+++ b/client/blocks/login/two-factor-authentication/verification-code-form.jsx
@@ -160,9 +160,9 @@ class VerificationCodeForm extends Component {
 						/>
 
 						{ requestError &&
-						requestError.field === 'twoStepCode' && (
-							<FormInputValidation isError text={ requestError.message } />
-						) }
+							requestError.field === 'twoStepCode' && (
+								<FormInputValidation isError text={ requestError.message } />
+							) }
 					</FormFieldset>
 
 					<FormButton

--- a/client/blocks/post-actions/index.jsx
+++ b/client/blocks/post-actions/index.jsx
@@ -67,46 +67,46 @@ const PostActions = ( {
 				/>
 			</li>
 			{ ! isDraft &&
-			showComments && (
-				<li className="post-actions__item">
-					{ config.isEnabled( 'comments/management/post-view' ) ? (
-						<CommentButton
-							key="comment-button"
-							post={ post }
-							showLabel={ false }
-							commentCount={ post.discussion.comment_count }
-							tagName="a"
-							link={ `/comments/all/${ siteSlug }/${ post.ID }` }
-						/>
-					) : (
-						<CommentButton
-							key="comment-button"
-							post={ post }
-							showLabel={ false }
-							commentCount={ post.discussion.comment_count }
-							onClick={ toggleComments }
-							tagName="div"
-						/>
-					) }
-				</li>
-			) }
+				showComments && (
+					<li className="post-actions__item">
+						{ config.isEnabled( 'comments/management/post-view' ) ? (
+							<CommentButton
+								key="comment-button"
+								post={ post }
+								showLabel={ false }
+								commentCount={ post.discussion.comment_count }
+								tagName="a"
+								link={ `/comments/all/${ siteSlug }/${ post.ID }` }
+							/>
+						) : (
+							<CommentButton
+								key="comment-button"
+								post={ post }
+								showLabel={ false }
+								commentCount={ post.discussion.comment_count }
+								onClick={ toggleComments }
+								tagName="div"
+							/>
+						) }
+					</li>
+				) }
 			{ ! isDraft &&
-			showLikes && (
-				<li className="post-actions__item">
-					<LikeButton
-						key="like-button"
-						siteId={ +post.site_ID }
-						postId={ +post.ID }
-						post={ post }
-					/>
-				</li>
-			) }
+				showLikes && (
+					<li className="post-actions__item">
+						<LikeButton
+							key="like-button"
+							siteId={ +post.site_ID }
+							postId={ +post.ID }
+							post={ post }
+						/>
+					</li>
+				) }
 			{ ! isDraft &&
-			showStats && (
-				<li className="post-actions__item post-actions__total-views">
-					<PostTotalViews post={ post } clickHandler={ trackTotalViewsOnClick } />
-				</li>
-			) }
+				showStats && (
+					<li className="post-actions__item post-actions__total-views">
+						<PostTotalViews post={ post } clickHandler={ trackTotalViewsOnClick } />
+					</li>
+				) }
 		</ul>
 	);
 };

--- a/client/blocks/product-purchase-features/product-purchase-features-list/advertising-removed.jsx
+++ b/client/blocks/product-purchase-features/product-purchase-features-list/advertising-removed.jsx
@@ -19,16 +19,14 @@ export default localize( ( { isBusinessPlan, translate } ) => {
 				icon={ <img src="/calypso/images/upgrades/advertising-removed.svg" /> }
 				title={ translate( 'Advertising removed' ) }
 				description={
-					isBusinessPlan ? (
-						translate(
-							'With your plan, all WordPress.com advertising has been removed from your site.'
-						)
-					) : (
-						translate(
-							'With your plan, all WordPress.com advertising has been removed from your site.' +
-								' You can upgrade to a Business plan to also remove the WordPress.com footer credit.'
-						)
-					)
+					isBusinessPlan
+						? translate(
+								'With your plan, all WordPress.com advertising has been removed from your site.'
+							)
+						: translate(
+								'With your plan, all WordPress.com advertising has been removed from your site.' +
+									' You can upgrade to a Business plan to also remove the WordPress.com footer credit.'
+							)
 				}
 			/>
 		</div>

--- a/client/blocks/reader-combined-card/index.jsx
+++ b/client/blocks/reader-combined-card/index.jsx
@@ -113,9 +113,9 @@ class ReaderCombinedCard extends React.Component {
 						</p>
 					</div>
 					{ this.props.showFollowButton &&
-					followUrl && (
-						<FollowButton siteUrl={ followUrl } followSource={ this.props.followSource } />
-					) }
+						followUrl && (
+							<FollowButton siteUrl={ followUrl } followSource={ this.props.followSource } />
+						) }
 				</header>
 				<ul className="reader-combined-card__post-list">
 					{ posts.map( post => (

--- a/client/blocks/reader-combined-card/post.jsx
+++ b/client/blocks/reader-combined-card/post.jsx
@@ -144,20 +144,20 @@ class ReaderCombinedCardPost extends React.Component {
 							</ReaderAuthorLink>
 						) }
 						{ post.date &&
-						post.URL && (
-							<span className="reader-combined-card__timestamp">
-								{ hasAuthorName && <span>, </span> }
-								<a
-									className="reader-combined-card__timestamp-link"
-									onClick={ recordDateClick }
-									href={ post.URL }
-									target="_blank"
-									rel="noopener noreferrer"
-								>
-									<PostTime date={ post.date } />
-								</a>
-							</span>
-						) }
+							post.URL && (
+								<span className="reader-combined-card__timestamp">
+									{ hasAuthorName && <span>, </span> }
+									<a
+										className="reader-combined-card__timestamp-link"
+										onClick={ recordDateClick }
+										href={ post.URL }
+										target="_blank"
+										rel="noopener noreferrer"
+									>
+										<PostTime date={ post.date } />
+									</a>
+								</span>
+							) }
 					</div>
 				</div>
 			</li>

--- a/client/blocks/reader-feed-header/index.jsx
+++ b/client/blocks/reader-feed-header/index.jsx
@@ -71,18 +71,18 @@ class FeedHeader extends Component {
 							</span>
 						) }
 						{ feed &&
-						! feed.is_error && (
-							<div className="reader-feed-header__follow-button">
-								<ReaderFollowButton siteUrl={ feed.feed_URL } iconSize={ 24 } />
-							</div>
-						) }
+							! feed.is_error && (
+								<div className="reader-feed-header__follow-button">
+									<ReaderFollowButton siteUrl={ feed.feed_URL } iconSize={ 24 } />
+								</div>
+							) }
 						{ site &&
-						following &&
-						! isEmailBlocked && (
-							<div className="reader-feed-header__email-settings">
-								<ReaderEmailSettings siteId={ site.ID } />
-							</div>
-						) }
+							following &&
+							! isEmailBlocked && (
+								<div className="reader-feed-header__email-settings">
+									<ReaderEmailSettings siteId={ site.ID } />
+								</div>
+							) }
 					</div>
 				</div>
 				<Card className="reader-feed-header__site">
@@ -103,15 +103,15 @@ class FeedHeader extends Component {
 					<div className="reader-feed-header__details">
 						<span className="reader-feed-header__description">{ description }</span>
 						{ ownerDisplayName &&
-						! isAuthorNameBlacklisted( ownerDisplayName ) && (
-							<span className="reader-feed-header__byline">
-								{ translate( 'by %(author)s', {
-									args: {
-										author: ownerDisplayName,
-									},
-								} ) }
-							</span>
-						) }
+							! isAuthorNameBlacklisted( ownerDisplayName ) && (
+								<span className="reader-feed-header__byline">
+									{ translate( 'by %(author)s', {
+										args: {
+											author: ownerDisplayName,
+										},
+									} ) }
+								</span>
+							) }
 					</div>
 				</Card>
 			</div>

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -322,8 +322,8 @@ export class FullPostView extends React.Component {
 				) }
 				{ post && post.feed_ID && <QueryReaderFeed feedId={ +post.feed_ID } /> }
 				{ post &&
-				! post.is_external &&
-				post.site_ID && <QueryReaderSite siteId={ +post.site_ID } /> }
+					! post.is_external &&
+					post.site_ID && <QueryReaderSite siteId={ +post.site_ID } /> }
 				<ReaderFullPostBack onBackClick={ this.handleBack } />
 				<div className="reader-full-post__visit-site-container">
 					<ExternalLink
@@ -341,20 +341,20 @@ export class FullPostView extends React.Component {
 					<div className="reader-full-post__sidebar">
 						{ isLoading && <AuthorCompactProfile author={ null } /> }
 						{ ! isLoading &&
-						post.author && (
-							<AuthorCompactProfile
-								author={ post.author }
-								siteIcon={ get( site, 'icon.img' ) }
-								feedIcon={ get( feed, 'image' ) }
-								siteName={ siteName }
-								siteUrl={ post.site_URL }
-								feedUrl={ get( feed, 'feed_URL' ) }
-								followCount={ site && site.subscribers_count }
-								feedId={ +post.feed_ID }
-								siteId={ +post.site_ID }
-								post={ post }
-							/>
-						) }
+							post.author && (
+								<AuthorCompactProfile
+									author={ post.author }
+									siteIcon={ get( site, 'icon.img' ) }
+									feedIcon={ get( feed, 'image' ) }
+									siteName={ siteName }
+									siteUrl={ post.site_URL }
+									feedUrl={ get( feed, 'feed_URL' ) }
+									followCount={ site && site.subscribers_count }
+									feedId={ +post.feed_ID }
+									siteId={ +post.site_ID }
+									post={ post }
+								/>
+							) }
 						{ shouldShowComments( post ) && (
 							<CommentButton
 								key="comment-button"
@@ -377,7 +377,9 @@ export class FullPostView extends React.Component {
 							<ReaderFullPostHeader post={ post } referralPost={ referralPost } />
 
 							{ post.featured_image &&
-							! isFeaturedImageInContent( post ) && <FeaturedImage src={ post.featured_image } /> }
+								! isFeaturedImageInContent( post ) && (
+									<FeaturedImage src={ post.featured_image } />
+								) }
 							{ isLoading && <ReaderFullPostContentPlaceholder /> }
 							{ post.use_excerpt ? (
 								<PostExcerpt content={ post.better_excerpt ? post.better_excerpt : post.excerpt } />
@@ -393,9 +395,9 @@ export class FullPostView extends React.Component {
 							) }
 
 							{ post.use_excerpt &&
-							! isDiscoverPost( post ) && (
-								<PostExcerptLink siteName={ siteName } postUrl={ post.URL } />
-							) }
+								! isDiscoverPost( post ) && (
+									<PostExcerptLink siteName={ siteName } postUrl={ post.URL } />
+								) }
 							{ isDiscoverSitePick( post ) && (
 								<DiscoverSiteAttribution
 									attribution={ post.discover_metadata.attribution }

--- a/client/blocks/reader-post-actions/index.jsx
+++ b/client/blocks/reader-post-actions/index.jsx
@@ -65,17 +65,17 @@ const ReaderPostActions = props => {
 				</li>
 			) }
 			{ showEdit &&
-			site &&
-			userCan( 'edit_post', post ) && (
-				<li className="reader-post-actions__item">
-					<PostEditButton
-						post={ post }
-						site={ site }
-						onClick={ onEditClick }
-						iconSize={ iconSize }
-					/>
-				</li>
-			) }
+				site &&
+				userCan( 'edit_post', post ) && (
+					<li className="reader-post-actions__item">
+						<PostEditButton
+							post={ post }
+							site={ site }
+							onClick={ onEditClick }
+							iconSize={ iconSize }
+						/>
+					</li>
+				) }
 			{ shouldShowShare( post ) && (
 				<li className="reader-post-actions__item">
 					<ShareButton post={ post } position="bottom" tagName="div" iconSize={ iconSize } />

--- a/client/blocks/reader-post-card/byline.jsx
+++ b/client/blocks/reader-post-card/byline.jsx
@@ -134,19 +134,19 @@ class PostByline extends React.Component {
 					) }
 					<div className="reader-post-card__timestamp-and-tag">
 						{ post.date &&
-						post.URL && (
-							<span className="reader-post-card__timestamp">
-								<a
-									className="reader-post-card__timestamp-link"
-									onClick={ this.recordDateClick }
-									href={ post.URL }
-									target="_blank"
-									rel="noopener noreferrer"
-								>
-									<PostTime date={ post.date } />
-								</a>
-							</span>
-						) }
+							post.URL && (
+								<span className="reader-post-card__timestamp">
+									<a
+										className="reader-post-card__timestamp-link"
+										onClick={ this.recordDateClick }
+										href={ post.URL }
+										target="_blank"
+										rel="noopener noreferrer"
+									>
+										<PostTime date={ post.date } />
+									</a>
+								</span>
+							) }
 						{ tags.length > 0 && (
 							<span className="reader-post-card__tags">
 								<Gridicon icon="tag" />

--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -242,7 +242,7 @@ class ReaderPostCard extends React.Component {
 					postKey={ postKey }
 				>
 					{ isDailyPostChallengeOrPrompt( post ) &&
-					site && <DailyPostButton post={ post } site={ site } /> }
+						site && <DailyPostButton post={ post } site={ site } /> }
 					{ discoverFollowButton }
 					{ readerPostActions }
 				</StandardPost>
@@ -255,13 +255,13 @@ class ReaderPostCard extends React.Component {
 			<Card className={ classes } onClick={ onClick }>
 				{ ! compact && postByline }
 				{ showPrimaryFollowButton &&
-				followUrl && (
-					<FollowButton
-						siteUrl={ followUrl }
-						followSource={ followSource }
-						railcar={ post.railcar }
-					/>
-				) }
+					followUrl && (
+						<FollowButton
+							siteUrl={ followUrl }
+							followSource={ followSource }
+							railcar={ post.railcar }
+						/>
+					) }
 				{ readerPostCard }
 				{ this.props.children }
 			</Card>

--- a/client/blocks/reader-post-options-menu/index.jsx
+++ b/client/blocks/reader-post-options-menu/index.jsx
@@ -148,9 +148,9 @@ class ReaderPostOptionsMenu extends React.Component {
 			<span className={ classes }>
 				{ ! feed && post && post.feed_ID && <QueryReaderFeed feedId={ +post.feed_ID } /> }
 				{ ! site &&
-				post &&
-				! post.is_external &&
-				post.site_ID && <QueryReaderSite siteId={ +post.site_ID } /> }
+					post &&
+					! post.is_external &&
+					post.site_ID && <QueryReaderSite siteId={ +post.site_ID } /> }
 				{ ! teams && <QueryReaderTeams /> }
 				<EllipsisMenu
 					className="reader-post-options-menu__ellipsis-menu"
@@ -190,7 +190,9 @@ class ReaderPostOptionsMenu extends React.Component {
 					) }
 
 					{ ( this.props.showFollow || isEditPossible || post.URL ) &&
-					( isBlockPossible || isDiscoverPost ) && <hr className="reader-post-options-menu__hr" /> }
+						( isBlockPossible || isDiscoverPost ) && (
+							<hr className="reader-post-options-menu__hr" />
+						) }
 
 					{ isBlockPossible && (
 						<PopoverMenuItem onClick={ this.blockSite }>

--- a/client/blocks/reader-related-card-v2/index.jsx
+++ b/client/blocks/reader-related-card-v2/index.jsx
@@ -38,19 +38,19 @@ function AuthorAndSiteFollow( { post, site, onSiteClick, followSource } ) {
 			</a>
 			<div className="reader-related-card-v2__byline">
 				{ authorName &&
-				authorAndSiteAreDifferent && (
-					<span className="reader-related-card-v2__byline-author">
-						<ReaderAuthorLink
-							author={ post.author }
-							siteUrl={ siteUrl }
-							post={ post }
-							onClick={ onSiteClick }
-							className="reader-related-card-v2__link"
-						>
-							{ authorName }
-						</ReaderAuthorLink>
-					</span>
-				) }
+					authorAndSiteAreDifferent && (
+						<span className="reader-related-card-v2__byline-author">
+							<ReaderAuthorLink
+								author={ post.author }
+								siteUrl={ siteUrl }
+								post={ post }
+								onClick={ onSiteClick }
+								className="reader-related-card-v2__link"
+							>
+								{ authorName }
+							</ReaderAuthorLink>
+						</span>
+					) }
 				<span className="reader-related-card-v2__byline-site">
 					<a href={ siteUrl } onClick={ onSiteClick } className="reader-related-card-v2__link">
 						{ siteName }

--- a/client/blocks/reader-subscription-list-item/index.jsx
+++ b/client/blocks/reader-subscription-list-item/index.jsx
@@ -115,23 +115,23 @@ function ReaderSubscriptionListItem( {
 				</span>
 				<div className="reader-subscription-list-item__site-excerpt">{ siteExcerpt }</div>
 				{ ! isMultiAuthor &&
-				! isEmpty( authorName ) && (
-					<span className="reader-subscription-list-item__by-text">
-						{ translate( 'by {{author/}}', {
-							components: {
-								author: (
-									<a
-										href={ streamUrl }
-										className="reader-subscription-list-item__link"
-										onClick={ recordAuthorClick }
-									>
-										{ authorName }
-									</a>
-								),
-							},
-						} ) }
-					</span>
-				) }
+					! isEmpty( authorName ) && (
+						<span className="reader-subscription-list-item__by-text">
+							{ translate( 'by {{author/}}', {
+								components: {
+									author: (
+										<a
+											href={ streamUrl }
+											className="reader-subscription-list-item__link"
+											onClick={ recordAuthorClick }
+										>
+											{ authorName }
+										</a>
+									),
+								},
+							} ) }
+						</span>
+					) }
 				{ siteUrl && (
 					<div className="reader-subscription-list-item__site-url-timestamp">
 						<a

--- a/client/blocks/site/index.jsx
+++ b/client/blocks/site/index.jsx
@@ -95,29 +95,25 @@ class Site extends React.Component {
 					data-tip-target={ this.props.tipTarget }
 					target={ this.props.externalLink && '_blank' }
 					title={
-						this.props.homeLink ? (
-							translate( 'View site %(domain)s', {
-								args: { domain: site.domain },
-							} )
-						) : (
-							translate( 'Select site %(domain)s', {
-								args: { domain: site.domain },
-							} )
-						)
+						this.props.homeLink
+							? translate( 'View site %(domain)s', {
+									args: { domain: site.domain },
+								} )
+							: translate( 'Select site %(domain)s', {
+									args: { domain: site.domain },
+								} )
 					}
 					onClick={ this.onSelect }
 					onMouseEnter={ this.onMouseEnter }
 					onMouseLeave={ this.onMouseLeave }
 					aria-label={
-						this.props.homeLink ? (
-							translate( 'View site %(domain)s', {
-								args: { domain: site.domain },
-							} )
-						) : (
-							translate( 'Select site %(domain)s', {
-								args: { domain: site.domain },
-							} )
-						)
+						this.props.homeLink
+							? translate( 'View site %(domain)s', {
+									args: { domain: site.domain },
+								} )
+							: translate( 'Select site %(domain)s', {
+									args: { domain: site.domain },
+								} )
 					}
 				>
 					<SiteIcon site={ site } size={ this.props.compact ? 24 : 32 } />
@@ -130,28 +126,28 @@ class Site extends React.Component {
 								</span>
 							) }
 							{ site.options &&
-							site.options.is_redirect && (
-								<span className="site__badge">
-									<Gridicon icon="block" size={ 14 } />
-								</span>
-							) }
+								site.options.is_redirect && (
+									<span className="site__badge">
+										<Gridicon icon="block" size={ 14 } />
+									</span>
+								) }
 							{ site.options &&
-							site.options.is_domain_only && (
-								<span className="site__badge">
-									<Gridicon icon="domains" size={ 14 } />
-								</span>
-							) }
+								site.options.is_domain_only && (
+									<span className="site__badge">
+										<Gridicon icon="domains" size={ 14 } />
+									</span>
+								) }
 							{ /* eslint-enable wpcalypso/jsx-gridicon-size */ }
 							{ site.title }
 						</div>
 						<div className="site__domain">{ site.domain }</div>
 					</div>
 					{ this.props.homeLink &&
-					this.props.showHomeIcon && (
-						<span className="site__home">
-							<Gridicon icon="house" size={ 18 } />
-						</span>
-					) }
+						this.props.showHomeIcon && (
+							<span className="site__home">
+								<Gridicon icon="house" size={ 18 } />
+							</span>
+						) }
 				</a>
 				{ this.props.indicator ? <SiteIndicator site={ site } /> : null }
 			</div>

--- a/client/blocks/taxonomy-manager/list-item.jsx
+++ b/client/blocks/taxonomy-manager/list-item.jsx
@@ -184,11 +184,11 @@ class TaxonomyManagerListItem extends Component {
 					) }
 					{ canSetAsDefault && ! isDefault && <PopoverMenuSeparator /> }
 					{ canSetAsDefault &&
-					! isDefault && (
-						<PopoverMenuItem onClick={ this.setAsDefault } icon="checkmark-circle">
-							{ translate( 'Set as default' ) }
-						</PopoverMenuItem>
-					) }
+						! isDefault && (
+							<PopoverMenuItem onClick={ this.setAsDefault } icon="checkmark-circle">
+								{ translate( 'Set as default' ) }
+							</PopoverMenuItem>
+						) }
 				</EllipsisMenu>
 				<Dialog
 					isVisible={ this.state.showDeleteDialog }

--- a/client/blocks/video-editor/index.jsx
+++ b/client/blocks/video-editor/index.jsx
@@ -174,15 +174,15 @@ class VideoEditor extends Component {
 							/>
 						</div>
 						{ uploadProgress &&
-						! error &&
-						! isSelectingFrame && (
-							<ProgressBar
-								className="video-editor__progress-bar"
-								isPulsing={ true }
-								total={ 100 }
-								value={ uploadProgress }
-							/>
-						) }
+							! error &&
+							! isSelectingFrame && (
+								<ProgressBar
+									className="video-editor__progress-bar"
+									isPulsing={ true }
+									total={ 100 }
+									value={ uploadProgress }
+								/>
+							) }
 						<span className="video-editor__text">
 							{ translate( 'Select a frame to use as the thumbnail image or upload your own.' ) }
 						</span>

--- a/client/components/clipboard-button-input/index.jsx
+++ b/client/components/clipboard-button-input/index.jsx
@@ -75,11 +75,9 @@ class ClipboardButtonInputExport extends React.Component {
 					disabled={ disabled }
 					compact
 				>
-					{ this.state.isCopied ? (
-						translate( 'Copied!' )
-					) : (
-						translate( 'Copy', { context: 'verb' } )
-					) }
+					{ this.state.isCopied
+						? translate( 'Copied!' )
+						: translate( 'Copy', { context: 'verb' } ) }
 				</ClipboardButton>
 			</span>
 		);

--- a/client/components/data/domain-management/index.jsx
+++ b/client/components/data/domain-management/index.jsx
@@ -80,8 +80,8 @@ const DomainManagementData = createReactClass( {
 					context={ this.props.context }
 				/>
 				{ this.props.selectedSite && <QuerySitePlans siteId={ this.props.selectedSite.ID } /> && (
-					<QueryContactDetailsCache />
-				) }
+						<QueryContactDetailsCache />
+					) }
 			</div>
 		);
 	},

--- a/client/components/date-picker/events-tooltip.jsx
+++ b/client/components/date-picker/events-tooltip.jsx
@@ -78,13 +78,11 @@ class EventsTooltip extends Component {
 										socialIcon={ event.socialIcon }
 										socialIconColor={ event.socialIconColor }
 										title={
-											event.title === '' ? (
-												this.props.translate( '{{em}}(No title){{/em}}', {
-													components: { em: <em /> },
-												} )
-											) : (
-												event.title
-											)
+											event.title === ''
+												? this.props.translate( '{{em}}(No title){{/em}}', {
+														components: { em: <em /> },
+													} )
+												: event.title
 										}
 									/>
 								</li>

--- a/client/components/domains/map-domain-step/index.jsx
+++ b/client/components/domains/map-domain-step/index.jsx
@@ -78,9 +78,9 @@ class MapDomainStep extends React.Component {
 	render() {
 		const suggestion = this.props.products.domain_map
 			? {
-				cost: this.props.products.domain_map.cost_display,
-				product_slug: this.props.products.domain_map.product_slug,
-			}
+					cost: this.props.products.domain_map.cost_display,
+					product_slug: this.props.products.domain_map.product_slug,
+				}
 			: { cost: null, product_slug: '' };
 		const { translate } = this.props;
 

--- a/client/components/domains/registrant-extra-info/fr-form.jsx
+++ b/client/components/domains/registrant-extra-info/fr-form.jsx
@@ -137,19 +137,17 @@ class RegistrantExtraInfoFrForm extends React.PureComponent {
 
 				{ 'organization' === registrantType && this.renderOrganizationFields() }
 
-				{ formIsValid ? (
-					this.props.children
-				) : (
-					map(
-						castArray( this.props.children ),
-						child =>
-							child.props.className.match( /submit-button/ )
-								? React.cloneElement( child, {
-										disabled: true,
-									} )
-								: child
-					)
-				) }
+				{ formIsValid
+					? this.props.children
+					: map(
+							castArray( this.props.children ),
+							child =>
+								child.props.className.match( /submit-button/ )
+									? React.cloneElement( child, {
+											disabled: true,
+										} )
+									: child
+						) }
 			</form>
 		);
 	}

--- a/client/components/happiness-support/index.jsx
+++ b/client/components/happiness-support/index.jsx
@@ -120,11 +120,9 @@ export class HappinessSupport extends Component {
 
 				<div className="happiness-support__buttons">
 					{ showLiveChatButton && <HappychatConnection /> }
-					{ showLiveChatButton && liveChatAvailable ? (
-						this.renderLiveChatButton()
-					) : (
-						this.renderContactButton()
-					) }
+					{ showLiveChatButton && liveChatAvailable
+						? this.renderLiveChatButton()
+						: this.renderContactButton() }
 					{ this.renderSupportButton() }
 				</div>
 			</div>

--- a/client/components/signup-form/index.jsx
+++ b/client/components/signup-form/index.jsx
@@ -609,7 +609,8 @@ class SignupForm extends Component {
 					<SocialSignupForm
 						handleResponse={ this.props.handleSocialResponse }
 						socialService={ this.props.socialService }
-						socialServiceResponse={ this.props.socialServiceResponse } />
+						socialServiceResponse={ this.props.socialServiceResponse }
+					/>
 				) }
 
 				{ this.props.footerLink || this.footerLink() }

--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -388,31 +388,31 @@ class SiteSelector extends Component {
 					{ this.renderRecentSites() }
 					{ this.renderSites() }
 					{ hiddenSitesCount > 0 &&
-					! this.props.sitesFound && (
-						<span className="site-selector__hidden-sites-message">
-							{ this.props.translate(
-								'%(hiddenSitesCount)d more hidden site. {{a}}Change{{/a}}.{{br/}}Use search to access it.',
-								'%(hiddenSitesCount)d more hidden sites. {{a}}Change{{/a}}.{{br/}}Use search to access them.',
-								{
-									count: hiddenSitesCount,
-									args: {
-										hiddenSitesCount: hiddenSitesCount,
-									},
-									components: {
-										br: <br />,
-										a: (
-											<a
-												href="https://dashboard.wordpress.com/wp-admin/index.php?page=my-blogs&show=hidden"
-												className="site-selector__manage-hidden-sites"
-												target="_blank"
-												rel="noopener noreferrer"
-											/>
-										),
-									},
-								}
-							) }
-						</span>
-					) }
+						! this.props.sitesFound && (
+							<span className="site-selector__hidden-sites-message">
+								{ this.props.translate(
+									'%(hiddenSitesCount)d more hidden site. {{a}}Change{{/a}}.{{br/}}Use search to access it.',
+									'%(hiddenSitesCount)d more hidden sites. {{a}}Change{{/a}}.{{br/}}Use search to access them.',
+									{
+										count: hiddenSitesCount,
+										args: {
+											hiddenSitesCount: hiddenSitesCount,
+										},
+										components: {
+											br: <br />,
+											a: (
+												<a
+													href="https://dashboard.wordpress.com/wp-admin/index.php?page=my-blogs&show=hidden"
+													className="site-selector__manage-hidden-sites"
+													target="_blank"
+													rel="noopener noreferrer"
+												/>
+											),
+										},
+									}
+								) }
+							</span>
+						) }
 				</div>
 				{ this.props.showAddNewSite && <SiteSelectorAddSite /> }
 			</div>

--- a/client/components/sites-dropdown/test/index.js
+++ b/client/components/sites-dropdown/test/index.js
@@ -99,18 +99,15 @@ describe( 'index', () => {
 	} );
 
 	describe( 'getSelectedSite', () => {
-		xit(
-			'should return a site on the basis of the component `selectedSiteSlug` state property',
-			function() {
-				const fakeState = {
-					selectedSiteId: 42,
-				};
-				const selectedSite = SitesDropdown.prototype.getSelectedSite.call( { state: fakeState } );
-				expect( selectedSite ).to.be.eql( {
-					ID: 42,
-					slug: 'foo.wordpress.com',
-				} );
-			}
-		);
+		xit( 'should return a site on the basis of the component `selectedSiteSlug` state property', function() {
+			const fakeState = {
+				selectedSiteId: 42,
+			};
+			const selectedSite = SitesDropdown.prototype.getSelectedSite.call( { state: fakeState } );
+			expect( selectedSite ).to.be.eql( {
+				ID: 42,
+				slug: 'foo.wordpress.com',
+			} );
+		} );
 	} );
 } );

--- a/client/components/social-buttons/google.js
+++ b/client/components/social-buttons/google.js
@@ -92,22 +92,24 @@ class GoogleLoginButton extends Component {
 						redirect_uri: this.props.redirectUri,
 					} )
 					.then( () =>
-						gapi.auth2.init( {
-							client_id: this.props.clientId,
-							scope: this.props.scope,
-						} ).then( () => {
-							this.setState( { isDisabled: false } );
+						gapi.auth2
+							.init( {
+								client_id: this.props.clientId,
+								scope: this.props.scope,
+							} )
+							.then( () => {
+								this.setState( { isDisabled: false } );
 
-							const googleAuth = gapi.auth2.getAuthInstance();
-							const currentUser = googleAuth.currentUser.get();
+								const googleAuth = gapi.auth2.getAuthInstance();
+								const currentUser = googleAuth.currentUser.get();
 
-							// handle social authentication response from a redirect-based oauth2 flow
-							if ( currentUser && this.props.uxMode === 'redirect' ) {
-								this.props.responseHandler( currentUser, false );
-							}
+								// handle social authentication response from a redirect-based oauth2 flow
+								if ( currentUser && this.props.uxMode === 'redirect' ) {
+									this.props.responseHandler( currentUser, false );
+								}
 
-							return gapi; // don't try to return googleAuth here, it's a thenable but not a valid promise
-						} )
+								return gapi; // don't try to return googleAuth here, it's a thenable but not a valid promise
+							} )
 					)
 			)
 			.catch( error => {

--- a/client/components/tinymce/index.jsx
+++ b/client/components/tinymce/index.jsx
@@ -550,12 +550,12 @@ export default class extends React.Component {
 		return (
 			<div className={ containerClassName }>
 				{ 'html' === mode &&
-				config.isEnabled( 'post-editor/html-toolbar' ) && (
-					<EditorHtmlToolbar
-						content={ this.refs.text }
-						onToolbarChangeContent={ this.onToolbarChangeContent }
-					/>
-				) }
+					config.isEnabled( 'post-editor/html-toolbar' ) && (
+						<EditorHtmlToolbar
+							content={ this.refs.text }
+							onToolbarChangeContent={ this.onToolbarChangeContent }
+						/>
+					) }
 				<textarea
 					ref="text"
 					className={ className }

--- a/client/components/tinymce/plugins/contact-form/dialog/navigation.jsx
+++ b/client/components/tinymce/plugins/contact-form/dialog/navigation.jsx
@@ -37,11 +37,9 @@ class ContactFormDialogNavigation extends React.Component {
 							count={ tab === 'fields' ? this.props.fieldCount : null }
 							onClick={ () => this.props.onChangeTabs( tab ) }
 						>
-							{ tab === 'fields' ? (
-								this.props.translate( 'Form Fields' )
-							) : (
-								this.props.translate( 'Settings' )
-							) }
+							{ tab === 'fields'
+								? this.props.translate( 'Form Fields' )
+								: this.props.translate( 'Settings' ) }
 						</SectionNavTabItem>
 					) ) }
 				</SectionNavTabs>

--- a/client/components/tinymce/plugins/contact-form/dialog/settings.jsx
+++ b/client/components/tinymce/plugins/contact-form/dialog/settings.jsx
@@ -47,15 +47,13 @@ class ContactFormDialogFormSettings extends React.Component {
 				<SectionHeader label={ this.props.translate( 'Contact Form Notification Settings' ) } />
 				<Card>
 					<p>
-						{ this.props.postType === 'post' ? (
-							this.props.translate(
-								'If you don’t make any changes here, feedback will be sent to the author of the post and the subject will be the name of this post.'
-							)
-						) : (
-							this.props.translate(
-								'If you don’t make any changes here, feedback will be sent to the author of the page and the subject will be the name of this page.'
-							)
-						) }
+						{ this.props.postType === 'post'
+							? this.props.translate(
+									'If you don’t make any changes here, feedback will be sent to the author of the post and the subject will be the name of this post.'
+								)
+							: this.props.translate(
+									'If you don’t make any changes here, feedback will be sent to the author of the page and the subject will be the name of this page.'
+								) }
 					</p>
 
 					<FormFieldset>

--- a/client/components/tinymce/plugins/mentions/mentions.jsx
+++ b/client/components/tinymce/plugins/mentions/mentions.jsx
@@ -263,16 +263,16 @@ export class Mentions extends Component {
 			<div ref={ this.setPopoverContext }>
 				<QueryUsersSuggestions siteId={ siteId } />
 				{ this.matchingSuggestions.length > 0 &&
-				showPopover && (
-					<SuggestionList
-						query={ query }
-						suggestions={ this.matchingSuggestions }
-						selectedSuggestionId={ selectedSuggestionId }
-						popoverContext={ popoverContext }
-						onClick={ this.insertSuggestion }
-						onClose={ this.hidePopover }
-					/>
-				) }
+					showPopover && (
+						<SuggestionList
+							query={ query }
+							suggestions={ this.matchingSuggestions }
+							selectedSuggestionId={ selectedSuggestionId }
+							popoverContext={ popoverContext }
+							onClick={ this.insertSuggestion }
+							onClose={ this.hidePopover }
+						/>
+					) }
 			</div>
 		);
 	}

--- a/client/components/wizard/index.jsx
+++ b/client/components/wizard/index.jsx
@@ -83,17 +83,17 @@ class Wizard extends Component {
 				{ component }
 
 				{ ! hideNavigation &&
-				totalSteps > 1 && (
-					<div className="wizard__navigation-links">
-						{ stepIndex > 0 && (
-							<NavigationLink direction="back" href={ backUrl } text={ backText } />
-						) }
+					totalSteps > 1 && (
+						<div className="wizard__navigation-links">
+							{ stepIndex > 0 && (
+								<NavigationLink direction="back" href={ backUrl } text={ backText } />
+							) }
 
-						{ stepIndex < totalSteps - 1 && (
-							<NavigationLink direction="forward" href={ forwardUrl } text={ forwardText } />
-						) }
-					</div>
-				) }
+							{ stepIndex < totalSteps - 1 && (
+								<NavigationLink direction="forward" href={ forwardUrl } text={ forwardText } />
+							) }
+						</div>
+					) }
 			</div>
 		);
 	}

--- a/client/devdocs/design/search-collection.jsx
+++ b/client/devdocs/design/search-collection.jsx
@@ -63,12 +63,12 @@ const Collection = ( { children, filter, section = 'design', component } ) => {
 	return (
 		<div className="design__collection">
 			{ showCounter > 1 &&
-			filter && (
-				<div className="design__instance-links">
-					<span>Showing </span>
-					{ summary }...
-				</div>
-			) }
+				filter && (
+					<div className="design__instance-links">
+						<span>Showing </span>
+						{ summary }...
+					</div>
+				) }
 			{ examples }
 		</div>
 	);

--- a/client/devdocs/design/typography.jsx
+++ b/client/devdocs/design/typography.jsx
@@ -78,9 +78,13 @@ export default class Typography extends React.PureComponent {
 						<a href="/devdocs/typography">Typography</a>
 					</h2>
 					<h3>Interface Typography</h3>
-					<p>We use system fonts which improve the page rendering speed.<br />
-					<code>-apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen-Sans",
-						"Ubuntu", "Cantarell", "Helvetica Neue", sans-serif</code></p>
+					<p>
+						We use system fonts which improve the page rendering speed.<br />
+						<code>
+							-apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen-Sans", "Ubuntu",
+							"Cantarell", "Helvetica Neue", sans-serif
+						</code>
+					</p>
 					<Card>
 						<p style={ interfaceTitle }>Quick foxes jump nightly above wizards.</p>
 						<p style={ interfaceSubtitle }>Pack my box with five dozen liquor jugs</p>
@@ -93,7 +97,10 @@ export default class Typography extends React.PureComponent {
 						<p style={ interfaceCaption }>Views per page</p>
 					</Card>
 					<h3>Content Typography</h3>
-					<p>We use <code>Noto Serif</code> which helps to make the web more beautiful across platforms for all languages.</p>
+					<p>
+						We use <code>Noto Serif</code> which helps to make the web more beautiful across
+						platforms for all languages.
+					</p>
 					<Card>
 						<p style={ contentTitle }>Quick foxes jump nightly above wizards.</p>
 						<p style={ contentSubtitle }>Pack my box with five dozen liquor jugs</p>

--- a/client/devdocs/docs-example/index.jsx
+++ b/client/devdocs/docs-example/index.jsx
@@ -39,11 +39,11 @@ const DocsExample = ( { children, componentUsageStats = {}, toggleHandler, toggl
 		<section className="docs-example">
 			<header className="docs-example__header">
 				{ toggleHandler &&
-				toggleText && (
-					<span className="docs-example__toggle">
-						<DocsExampleToggle onClick={ toggleHandler } text={ toggleText } />
-					</span>
-				) }
+					toggleText && (
+						<span className="docs-example__toggle">
+							<DocsExampleToggle onClick={ toggleHandler } text={ toggleText } />
+						</span>
+					) }
 			</header>
 
 			<div className="docs-example__main">{ children }</div>

--- a/client/devdocs/docs-selectors/param-type.jsx
+++ b/client/devdocs/docs-selectors/param-type.jsx
@@ -20,9 +20,9 @@ export default function DocsSelectorsParamType( { expression, name, type } ) {
 		<div className="docs-selectors__param-type">
 			<code>{ get( expression, 'name', name ) }</code>
 			{ expression &&
-			REGEXP_EXPRESSION_TYPE.test( type ) && (
-				<span>({ type.match( REGEXP_EXPRESSION_TYPE )[ 1 ] })</span>
-			) }
+				REGEXP_EXPRESSION_TYPE.test( type ) && (
+					<span>({ type.match( REGEXP_EXPRESSION_TYPE )[ 1 ] })</span>
+				) }
 		</div>
 	);
 }

--- a/client/devdocs/docs-selectors/search.jsx
+++ b/client/devdocs/docs-selectors/search.jsx
@@ -63,9 +63,9 @@ export default class DocsSelectorsSearch extends Component {
 					onSearch={ this.onSearch }
 				/>
 				{ results &&
-				! results.length && (
-					<EmptyContent title="No selectors found" line="Try another search query" />
-				) }
+					! results.length && (
+						<EmptyContent title="No selectors found" line="Try another search query" />
+					) }
 				<ul className="docs-selectors__results">
 					{ map( results, ( { name, description, tags } ) => (
 						<li key={ name }>

--- a/client/extensions/woocommerce/app/orders/orders-list.js
+++ b/client/extensions/woocommerce/app/orders/orders-list.js
@@ -215,11 +215,9 @@ class Orders extends Component {
 			<div className="orders__container">
 				<OrdersFilterNav searchRef={ setSearchRef } status={ currentStatus } />
 
-				{ ! ordersLoaded || ( orders && orders.length ) ? (
-					this.renderOrderItems()
-				) : (
-					this.renderNoContent()
-				) }
+				{ ! ordersLoaded || ( orders && orders.length )
+					? this.renderOrderItems()
+					: this.renderNoContent() }
 
 				<Pagination
 					page={ currentPage }

--- a/client/extensions/woocommerce/app/products/products-list-row.js
+++ b/client/extensions/woocommerce/app/products/products-list-row.js
@@ -41,7 +41,7 @@ const ProductsListRow = ( { site, product } ) => {
 	const renderStock = () => (
 		<div>
 			{ ( product.manage_stock &&
-			'simple' === product.type && <span>{ product.stock_quantity }</span> ) || <span>-</span> }
+				'simple' === product.type && <span>{ product.stock_quantity }</span> ) || <span>-</span> }
 		</div>
 	);
 

--- a/client/extensions/woocommerce/app/promotions/promotion-create.js
+++ b/client/extensions/woocommerce/app/promotions/promotion-create.js
@@ -137,7 +137,7 @@ class PromotionCreate extends React.Component {
 			promotion,
 			hasEdits,
 			products,
-			productCategories
+			productCategories,
 		} = this.props;
 		const { busy } = this.state;
 

--- a/client/extensions/woocommerce/app/reviews/reviews-list.js
+++ b/client/extensions/woocommerce/app/reviews/reviews-list.js
@@ -191,11 +191,9 @@ class ReviewsList extends Component {
 			<div className="reviews__container">
 				<ReviewsFilterNav productId={ productId } status={ currentStatus } />
 
-				{ ! reviewsLoaded || ( reviews && reviews.length ) ? (
-					this.renderReviews()
-				) : (
-					this.renderNoContent()
-				) }
+				{ ! reviewsLoaded || ( reviews && reviews.length )
+					? this.renderReviews()
+					: this.renderNoContent() }
 
 				<Pagination
 					page={ currentPage }

--- a/client/extensions/woocommerce/app/settings/shipping/shipping-zone-list-entry.js
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-zone-list-entry.js
@@ -87,11 +87,9 @@ const ShippingZoneEntry = ( { translate, id, name, methods, currency, loaded, is
 				{ /*<p className="shipping__zones-row-location-description">{ locationDescription }</p>*/ }
 			</div>
 			<div className="shipping__zones-row-methods">
-				{ methods && methods.length ? (
-					Object.keys( methods ).map( renderMethod )
-				) : (
-					renderMethodCell( translate( 'No shipping methods' ) )
-				) }
+				{ methods && methods.length
+					? Object.keys( methods ).map( renderMethod )
+					: renderMethodCell( translate( 'No shipping methods' ) ) }
 			</div>
 			<div className="shipping__zones-row-actions">
 				<Button

--- a/client/extensions/woocommerce/app/store-stats/index.js
+++ b/client/extensions/woocommerce/app/store-stats/index.js
@@ -92,13 +92,11 @@ class StoreStats extends Component {
 						period={ unit }
 						// this is needed to counter the +1d adjustment made in DatePicker for weeks
 						date={
-							unit === 'week' ? (
-								moment( selectedDate, 'YYYY-MM-DD' )
-									.subtract( 1, 'days' )
-									.format( 'YYYY-MM-DD' )
-							) : (
-								selectedDate
-							)
+							unit === 'week'
+								? moment( selectedDate, 'YYYY-MM-DD' )
+										.subtract( 1, 'days' )
+										.format( 'YYYY-MM-DD' )
+								: selectedDate
 						}
 						query={ ordersQuery }
 						statsType="statsOrders"

--- a/client/extensions/woocommerce/app/store-stats/listview.js
+++ b/client/extensions/woocommerce/app/store-stats/listview.js
@@ -79,13 +79,11 @@ class StoreStatsListView extends Component {
 					<DatePicker
 						period={ unit }
 						date={
-							unit === 'week' ? (
-								moment( selectedDate, 'YYYY-MM-DD' )
-									.subtract( 1, 'days' )
-									.format( 'YYYY-MM-DD' )
-							) : (
-								selectedDate
-							)
+							unit === 'week'
+								? moment( selectedDate, 'YYYY-MM-DD' )
+										.subtract( 1, 'days' )
+										.format( 'YYYY-MM-DD' )
+								: selectedDate
 						}
 						query={ listviewQuery }
 						statsType={ statType }

--- a/client/extensions/woocommerce/app/store-stats/store-stats-chart/index.js
+++ b/client/extensions/woocommerce/app/store-stats/store-stats-chart/index.js
@@ -108,11 +108,9 @@ class StoreStatsChart extends Component {
 									tabClick={ this.tabClick }
 								>
 									<span className="store-stats-chart__value value">
-										{ tab.type === 'currency' ? (
-											formatCurrency( itemChartData.value, data[ selectedIndex ].currency )
-										) : (
-											Math.round( itemChartData.value * 100 ) / 100
-										) }
+										{ tab.type === 'currency'
+											? formatCurrency( itemChartData.value, data[ selectedIndex ].currency )
+											: Math.round( itemChartData.value * 100 ) / 100 }
 									</span>
 									<Delta
 										value={ `${ deltaValue }%` }

--- a/client/extensions/woocommerce/app/store-stats/store-stats-module/index.js
+++ b/client/extensions/woocommerce/app/store-stats/store-stats-module/index.js
@@ -59,11 +59,11 @@ class StoreStatsModule extends Component {
 					</Card>
 				) }
 				{ ! isLoading &&
-				hasEmptyData && (
-					<Card className="stats-module is-showing-error has-no-data">
-						<ErrorPanel message={ emptyMessage } />
-					</Card>
-				) }
+					hasEmptyData && (
+						<Card className="stats-module is-showing-error has-no-data">
+							<ErrorPanel message={ emptyMessage } />
+						</Card>
+					) }
 				{ ! isLoading && ! hasEmptyData && children }
 			</div>
 			/* eslint-enable wpcalypso/jsx-classname-namespace */

--- a/client/extensions/woocommerce/components/product-search/results.js
+++ b/client/extensions/woocommerce/components/product-search/results.js
@@ -78,13 +78,11 @@ class ProductSearchResults extends Component {
 
 		return (
 			<div className={ classes }>
-				{ products.length ? (
-					products.map( p => (
-						<ProductItem key={ p.id } onClick={ onSelect } product={ p } search={ search } />
-					) )
-				) : (
-					this.renderNotFound()
-				) }
+				{ products.length
+					? products.map( p => (
+							<ProductItem key={ p.id } onClick={ onSelect } product={ p } search={ search } />
+						) )
+					: this.renderNotFound() }
 			</div>
 		);
 	}

--- a/client/extensions/wp-super-cache/components/advanced/lock-down.jsx
+++ b/client/extensions/wp-super-cache/components/advanced/lock-down.jsx
@@ -82,17 +82,15 @@ const LockDown = ( {
 							isCompact
 							status={ cache_lock_down ? 'is-warning' : 'is-info' }
 							text={
-								cache_lock_down ? (
-									translate(
-										'WordPress is locked down. Super Cache static files will not be deleted ' +
-											'when new comments are made.'
-									)
-								) : (
-									translate(
-										'WordPress is not locked down. New comments will refresh Super Cache ' +
-											'static files as normal.'
-									)
-								)
+								cache_lock_down
+									? translate(
+											'WordPress is locked down. Super Cache static files will not be deleted ' +
+												'when new comments are made.'
+										)
+									: translate(
+											'WordPress is not locked down. New comments will refresh Super Cache ' +
+												'static files as normal.'
+										)
 							}
 						/>
 					</div>

--- a/client/extensions/wp-super-cache/components/debug/index.jsx
+++ b/client/extensions/wp-super-cache/components/debug/index.jsx
@@ -84,11 +84,9 @@ class DebugTab extends Component {
 						<div className="wp-super-cache__debug-fieldsets">
 							<FormFieldset>
 								<FormLabel htmlFor="debugLog">
-									{ wp_super_cache_debug ? (
-										translate( 'Currently logging to:' )
-									) : (
-										translate( 'Last logged to:' )
-									) }
+									{ wp_super_cache_debug
+										? translate( 'Currently logging to:' )
+										: translate( 'Last logged to:' ) }
 								</FormLabel>
 								<FormTextInput disabled id="debugLog" value={ cache_path + wp_cache_debug_log } />
 								<Button

--- a/client/extensions/wp-super-cache/components/easy/index.jsx
+++ b/client/extensions/wp-super-cache/components/easy/index.jsx
@@ -157,26 +157,22 @@ class EasyTab extends Component {
 									<ul className="wp-super-cache__cache-test-results">
 										{ Object.keys( attempts ).map( key => (
 											<li className="wp-super-cache__cache-test-results-item" key={ key }>
-												{ key === 'prime' ? (
-													translate( 'Fetching %(url)s to prime cache', {
-														args: { url: site && site.URL },
-													} )
-												) : (
-													translate( 'Fetching %(key)s copy of %(url)s', {
-														args: {
-															key: key,
-															url: site && site.URL,
-														},
-													} )
-												) }
+												{ key === 'prime'
+													? translate( 'Fetching %(url)s to prime cache', {
+															args: { url: site && site.URL },
+														} )
+													: translate( 'Fetching %(key)s copy of %(url)s', {
+															args: {
+																key: key,
+																url: site && site.URL,
+															},
+														} ) }
 												<Gridicon
 													className="wp-super-cache__cache-test-results-icon"
 													icon={
-														get( attempts[ key ], 'status', false ) ? (
-															'checkmark-circle'
-														) : (
-															'cross-circle'
-														)
+														get( attempts[ key ], 'status', false )
+															? 'checkmark-circle'
+															: 'cross-circle'
 													}
 													size={ 24 }
 												/>
@@ -208,17 +204,17 @@ class EasyTab extends Component {
 							{ translate( 'Delete Cache' ) }
 						</Button>
 						{ site.jetpack &&
-						site.is_multisite && (
-							<Button
-								compact
-								busy={ this.state.isDeletingAll }
-								disabled={ isDeleting || isReadOnly }
-								name="wp_delete_all_cache"
-								onClick={ this.deleteAllCaches }
-							>
-								{ translate( 'Delete Cache On All Blogs' ) }
-							</Button>
-						) }
+							site.is_multisite && (
+								<Button
+									compact
+									busy={ this.state.isDeletingAll }
+									disabled={ isDeleting || isReadOnly }
+									name="wp_delete_all_cache"
+									onClick={ this.deleteAllCaches }
+								>
+									{ translate( 'Delete Cache On All Blogs' ) }
+								</Button>
+							) }
 					</div>
 				</Card>
 				<QueryStatus siteId={ siteId } />

--- a/client/extensions/wp-super-cache/components/preload/index.jsx
+++ b/client/extensions/wp-super-cache/components/preload/index.jsx
@@ -225,25 +225,25 @@ class PreloadTab extends Component {
 						</FormFieldset>
 
 						{ post_count &&
-						post_count > 100 && (
-							<FormFieldset>
-								<FormLabel htmlFor="preload_posts">{ translate( 'Preload Posts' ) }</FormLabel>
-								<FormSelect
-									className="wp-super-cache__preload-posts"
-									disabled={ isRequesting || isSaving }
-									id="preload_posts"
-									name="preload_posts"
-									onChange={ handleSelect }
-									value={ preload_posts || 'all' }
-								>
-									{ this.getPreloadPostsOptions( post_count ).map( option => (
-										<option key={ option } value={ option }>
-											{ option }
-										</option>
-									) ) }
-								</FormSelect>
-							</FormFieldset>
-						) }
+							post_count > 100 && (
+								<FormFieldset>
+									<FormLabel htmlFor="preload_posts">{ translate( 'Preload Posts' ) }</FormLabel>
+									<FormSelect
+										className="wp-super-cache__preload-posts"
+										disabled={ isRequesting || isSaving }
+										id="preload_posts"
+										name="preload_posts"
+										onChange={ handleSelect }
+										value={ preload_posts || 'all' }
+									>
+										{ this.getPreloadPostsOptions( post_count ).map( option => (
+											<option key={ option } value={ option }>
+												{ option }
+											</option>
+										) ) }
+									</FormSelect>
+								</FormFieldset>
+							) }
 
 						<hr />
 

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -192,7 +192,7 @@ const Layout = createReactClass( {
 				/>
 				{ this.renderPreview() }
 				{ config.isEnabled( 'happychat' ) &&
-				this.props.chatIsOpen && <AsyncLoad require="components/happychat" /> }
+					this.props.chatIsOpen && <AsyncLoad require="components/happychat" /> }
 				{ 'development' === process.env.NODE_ENV && (
 					<AsyncLoad require="components/webpack-build-monitor" placeholder={ null } />
 				) }

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -81,11 +81,9 @@ class MasterbarLoggedIn extends React.Component {
 					} ) }
 					preloadSection={ () => preload( domainOnlySite ? 'domains' : 'stats' ) }
 				>
-					{ this.props.user.get().site_count > 1 ? (
-						translate( 'My Sites', { comment: 'Toolbar, must be shorter than ~12 chars' } )
-					) : (
-						translate( 'My Site', { comment: 'Toolbar, must be shorter than ~12 chars' } )
-					) }
+					{ this.props.user.get().site_count > 1
+						? translate( 'My Sites', { comment: 'Toolbar, must be shorter than ~12 chars' } )
+						: translate( 'My Site', { comment: 'Toolbar, must be shorter than ~12 chars' } ) }
 				</Item>
 				<Item
 					tipTarget="reader"

--- a/client/layout/sidebar/footer.jsx
+++ b/client/layout/sidebar/footer.jsx
@@ -24,9 +24,9 @@ const SidebarFooter = ( { translate, children, isHappychatButtonVisible } ) => (
 			<Gridicon icon="help-outline" />
 		</Button>
 		{ isHappychatButtonVisible &&
-		config.isEnabled( 'happychat' ) && (
-			<HappychatButton className="sidebar__footer-chat" allowMobileRedirect />
-		) }
+			config.isEnabled( 'happychat' ) && (
+				<HappychatButton className="sidebar__footer-chat" allowMobileRedirect />
+			) }
 	</div>
 );
 

--- a/client/lib/feed-stream-store/test/index.js
+++ b/client/lib/feed-stream-store/test/index.js
@@ -297,17 +297,14 @@ describe( 'FeedPostList', () => {
 			expect( filteredPosts.length ).to.equal( 3 );
 		} );
 
-		test.skip(
-			'when following origin site, filters followed x-posts, but leaves comment notices',
-			function() {
-				filteredPosts = store.filterFollowedXPosts( posts );
-				expect( filteredPosts.length ).to.equal( 3 );
-				expect( filteredPosts[ 0 ].meta.data.post.site_URL ).to.equal( 'http://foo.bar.com' );
-				expect( filteredPosts[ 1 ].meta.data.post.site_URL ).to.equal(
-					'http://dailypost.wordpress.com'
-				);
-			}
-		);
+		test.skip( 'when following origin site, filters followed x-posts, but leaves comment notices', function() {
+			filteredPosts = store.filterFollowedXPosts( posts );
+			expect( filteredPosts.length ).to.equal( 3 );
+			expect( filteredPosts[ 0 ].meta.data.post.site_URL ).to.equal( 'http://foo.bar.com' );
+			expect( filteredPosts[ 1 ].meta.data.post.site_URL ).to.equal(
+				'http://dailypost.wordpress.com'
+			);
+		} );
 
 		test.skip( 'updates sites x-posted to', function() {
 			filteredPosts = store.filterFollowedXPosts( posts );

--- a/client/lib/reader-lists/actions.js
+++ b/client/lib/reader-lists/actions.js
@@ -109,7 +109,8 @@ const ReaderListActions = {
 		wpcom.undocumented().readList( {
 			owner: owner,
 			slug: slug,
-		}, function( error, data ) {
+		},
+		function( error, data ) {
 			delete fetchingLists[ key ];
 			ReaderListsStore.setIsFetching( false );
 

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -128,7 +128,8 @@ function createSiteWithCart(
 		},
 		validate: false,
 		find_available_url: isPurchasingItem,
-	}, function( error, response ) {
+	},
+	function( error, response ) {
 		if ( error ) {
 			callback( error );
 
@@ -348,7 +349,8 @@ export default {
 				access_token,
 				id_token,
 				signup_flow_name: flowName,
-			}, ( error, response ) => {
+			},
+			( error, response ) => {
 				const errors =
 					error && error.error
 						? [ { error: error.error, message: error.message, email: get( error, 'data.email' ) } ]
@@ -381,7 +383,8 @@ export default {
 							oauth2_redirect: queryArgs.oauth2_redirect && '0@' + queryArgs.oauth2_redirect,
 						}
 					: null
-			), ( error, response ) => {
+			),
+			( error, response ) => {
 				const errors =
 						error && error.error ? [ { error: error.error, message: error.message } ] : undefined,
 					bearerToken = error && error.error ? {} : { bearer_token: response.bearer_token };

--- a/client/login/magic-login/request-login-email-form.jsx
+++ b/client/login/magic-login/request-login-email-form.jsx
@@ -111,15 +111,15 @@ class RequestLoginEmailForm extends React.Component {
 					/>
 				) }
 				{ currentUser &&
-				currentUser.username && (
-					<p>
-						{ translate( 'NOTE: You are already logged in as user: %(user)s', {
-							args: {
-								user: currentUser.username,
-							},
-						} ) }
-					</p>
-				) }
+					currentUser.username && (
+						<p>
+							{ translate( 'NOTE: You are already logged in as user: %(user)s', {
+								args: {
+									user: currentUser.username,
+								},
+							} ) }
+						</p>
+					) }
 				<LoggedOutForm onSubmit={ this.onSubmit }>
 					<p>
 						{ translate(

--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -536,12 +536,12 @@ const Account = createReactClass( {
 				{ this.communityTranslator() }
 
 				{ config.isEnabled( 'me/account/color-scheme-picker' ) &&
-				supportsCssCustomProperties() && (
-					<FormFieldset>
-						<FormLabel htmlFor="color_scheme">{ translate( 'Admin Color Scheme' ) }</FormLabel>
-						<ColorSchemePicker temporarySelection onSelection={ this.updateColorScheme } />
-					</FormFieldset>
-				) }
+					supportsCssCustomProperties() && (
+						<FormFieldset>
+							<FormLabel htmlFor="color_scheme">{ translate( 'Admin Color Scheme' ) }</FormLabel>
+							<ColorSchemePicker temporarySelection onSelection={ this.updateColorScheme } />
+						</FormFieldset>
+					) }
 
 				{ this.renderHolidaySnow() }
 
@@ -550,11 +550,9 @@ const Account = createReactClass( {
 					disabled={ isSubmitButtonDisabled }
 					onClick={ this.recordClickEvent( 'Save Account Settings Button' ) }
 				>
-					{ this.state.submittingForm ? (
-						translate( 'Saving…' )
-					) : (
-						translate( 'Save Account Settings' )
-					) }
+					{ this.state.submittingForm
+						? translate( 'Saving…' )
+						: translate( 'Save Account Settings' ) }
 				</FormButton>
 			</div>
 		);

--- a/client/me/application-passwords/index.jsx
+++ b/client/me/application-passwords/index.jsx
@@ -121,11 +121,9 @@ const ApplicationPasswords = createReactClass( {
 							disabled={ this.state.submittingForm || '' === this.state.applicationName }
 							onClick={ this.recordClickEvent( 'Generate New Application Password Button' ) }
 						>
-							{ this.state.submittingForm ? (
-								this.props.translate( 'Generating Password…' )
-							) : (
-								this.props.translate( 'Generate Password' )
-							) }
+							{ this.state.submittingForm
+								? this.props.translate( 'Generating Password…' )
+								: this.props.translate( 'Generate Password' ) }
 						</FormButton>
 						{ this.props.appPasswordsData.get().length ? (
 							<FormButton

--- a/client/me/billing-history/receipt.jsx
+++ b/client/me/billing-history/receipt.jsx
@@ -226,11 +226,9 @@ const BillingReceipt = createReactClass( {
 						</li>
 						{ this.ref() }
 						{ this.paymentMethod() }
-						{ transaction.cc_num !== 'XXXX' ? (
-							this.renderBillingDetails()
-						) : (
-							this.renderEmptyBillingDetails()
-						) }
+						{ transaction.cc_num !== 'XXXX'
+							? this.renderBillingDetails()
+							: this.renderEmptyBillingDetails() }
 					</ul>
 					{ this.renderLineItems() }
 				</Card>

--- a/client/me/help/chat-closure-notice/index.jsx
+++ b/client/me/help/chat-closure-notice/index.jsx
@@ -24,11 +24,9 @@ const Notice = localize( ( { translate, closedFrom, closedTo, reason } ) => (
 			{ title( { translate, closedFrom, closedTo, reason } ) }
 		</FormSectionHeading>
 		<div>
-			{ i18n.moment().isBefore( closedFrom ) ? (
-				upcoming( { translate, closedFrom, closedTo, reason } )
-			) : (
-				closed( { translate, closedFrom, closedTo, reason } )
-			) }
+			{ i18n.moment().isBefore( closedFrom )
+				? upcoming( { translate, closedFrom, closedTo, reason } )
+				: closed( { translate, closedFrom, closedTo, reason } ) }
 		</div>
 	</div>
 ) );

--- a/client/me/help/help-contact-closed/index.jsx
+++ b/client/me/help/help-contact-closed/index.jsx
@@ -24,30 +24,28 @@ const NonPlanPaidMessage = localize( ( { translate } ) => {
 	return (
 		<div>
 			<p>
-				{ Date.now() < closedStartDate ? (
-					translate(
-						'Private support will be closed from %(closed_start_date)s through %(closed_end_date)s, included. ' +
-							'We will reopen private support on %(support_resume_date)s.',
-						{
-							args: {
-								closed_start_date: closedStartDate.format( 'dddd, MMMM D' ),
-								closed_end_date: closedEndDate.format( 'dddd, MMMM D' ),
-								support_resume_date: supportResumeDate.format( 'dddd, MMMM D' ),
-							},
-						}
-					)
-				) : (
-					translate(
-						'Private support will be closed through %(closed_end_date)s, included. ' +
-							'We will reopen private support on %(support_resume_date)s.',
-						{
-							args: {
-								closed_end_date: closedEndDate.format( 'dddd, MMMM D' ),
-								support_resume_date: supportResumeDate.format( 'dddd, MMMM D' ),
-							},
-						}
-					)
-				) }
+				{ Date.now() < closedStartDate
+					? translate(
+							'Private support will be closed from %(closed_start_date)s through %(closed_end_date)s, included. ' +
+								'We will reopen private support on %(support_resume_date)s.',
+							{
+								args: {
+									closed_start_date: closedStartDate.format( 'dddd, MMMM D' ),
+									closed_end_date: closedEndDate.format( 'dddd, MMMM D' ),
+									support_resume_date: supportResumeDate.format( 'dddd, MMMM D' ),
+								},
+							}
+						)
+					: translate(
+							'Private support will be closed through %(closed_end_date)s, included. ' +
+								'We will reopen private support on %(support_resume_date)s.',
+							{
+								args: {
+									closed_end_date: closedEndDate.format( 'dddd, MMMM D' ),
+									support_resume_date: supportResumeDate.format( 'dddd, MMMM D' ),
+								},
+							}
+						) }
 			</p>
 			<p>
 				{ translate(
@@ -85,30 +83,28 @@ const PersonalAndPremiumPlanMessage = localize( ( { translate } ) => {
 	return (
 		<div>
 			<p>
-				{ Date.now() < closedStartDate ? (
-					translate(
-						'Live chat support will be closed from %(closed_start_date)s through %(closed_end_date)s, included. ' +
-							'Email support will be open during that time, and we will reopen live chat on %(support_resume_date)s.',
-						{
-							args: {
-								closed_start_date: closedStartDate.format( 'dddd, MMMM D' ),
-								closed_end_date: closedEndDate.format( 'dddd, MMMM D' ),
-								support_resume_date: supportResumeDate.format( 'dddd, MMMM D' ),
-							},
-						}
-					)
-				) : (
-					translate(
-						'Private support will be closed through %(closed_end_date)s, included. ' +
-							'We will reopen private support on %(support_resume_date)s.',
-						{
-							args: {
-								closed_end_date: closedEndDate.format( 'dddd, MMMM D' ),
-								support_resume_date: supportResumeDate.format( 'dddd, MMMM D' ),
-							},
-						}
-					)
-				) }
+				{ Date.now() < closedStartDate
+					? translate(
+							'Live chat support will be closed from %(closed_start_date)s through %(closed_end_date)s, included. ' +
+								'Email support will be open during that time, and we will reopen live chat on %(support_resume_date)s.',
+							{
+								args: {
+									closed_start_date: closedStartDate.format( 'dddd, MMMM D' ),
+									closed_end_date: closedEndDate.format( 'dddd, MMMM D' ),
+									support_resume_date: supportResumeDate.format( 'dddd, MMMM D' ),
+								},
+							}
+						)
+					: translate(
+							'Private support will be closed through %(closed_end_date)s, included. ' +
+								'We will reopen private support on %(support_resume_date)s.',
+							{
+								args: {
+									closed_end_date: closedEndDate.format( 'dddd, MMMM D' ),
+									support_resume_date: supportResumeDate.format( 'dddd, MMMM D' ),
+								},
+							}
+						) }
 			</p>
 			<p>
 				{ translate(
@@ -125,33 +121,31 @@ const BusinessPlanMessage = localize( ( { translate } ) => {
 	return (
 		<div>
 			<p>
-				{ Date.now() < closedStartDate ? (
-					translate(
-						'Live chat support will be closed from %(closed_start_date)s through %(closed_end_date)s, with the ' +
-							'exception of limited hours %(limited_hours_start_date)s–%(limited_hours_end_date)s. ' +
-							'Email support will be open during that time, and we will reopen live chat on %(support_resume_date)s.',
-						{
-							args: {
-								closed_start_date: closedStartDate.format( 'dddd, MMMM D' ),
-								closed_end_date: closedEndDate.format( 'dddd, MMMM D' ),
-								limited_hours_start_date: limitedHoursStartDate.format( 'MMMM D' ),
-								limited_hours_end_date: limitedHoursEndDate.format( 'D' ),
-								support_resume_date: supportResumeDate.format( 'dddd, MMMM D' ),
-							},
-						}
-					)
-				) : (
-					translate(
-						'Private support will be closed through %(closed_end_date)s, included. ' +
-							'We will reopen private support on %(support_resume_date)s.',
-						{
-							args: {
-								closed_end_date: closedEndDate.format( 'dddd, MMMM D' ),
-								support_resume_date: supportResumeDate.format( 'dddd, MMMM D' ),
-							},
-						}
-					)
-				) }
+				{ Date.now() < closedStartDate
+					? translate(
+							'Live chat support will be closed from %(closed_start_date)s through %(closed_end_date)s, with the ' +
+								'exception of limited hours %(limited_hours_start_date)s–%(limited_hours_end_date)s. ' +
+								'Email support will be open during that time, and we will reopen live chat on %(support_resume_date)s.',
+							{
+								args: {
+									closed_start_date: closedStartDate.format( 'dddd, MMMM D' ),
+									closed_end_date: closedEndDate.format( 'dddd, MMMM D' ),
+									limited_hours_start_date: limitedHoursStartDate.format( 'MMMM D' ),
+									limited_hours_end_date: limitedHoursEndDate.format( 'D' ),
+									support_resume_date: supportResumeDate.format( 'dddd, MMMM D' ),
+								},
+							}
+						)
+					: translate(
+							'Private support will be closed through %(closed_end_date)s, included. ' +
+								'We will reopen private support on %(support_resume_date)s.',
+							{
+								args: {
+									closed_end_date: closedEndDate.format( 'dddd, MMMM D' ),
+									support_resume_date: supportResumeDate.format( 'dddd, MMMM D' ),
+								},
+							}
+						) }
 			</p>
 			<p>
 				{ translate(

--- a/client/me/notification-settings/reader-subscriptions/index.jsx
+++ b/client/me/notification-settings/reader-subscriptions/index.jsx
@@ -217,11 +217,9 @@ const NotificationSubscriptions = createReactClass( {
 							disabled={ this.getDisabledState() }
 							onClick={ this.recordClickEvent( 'Save Notification Settings Button' ) }
 						>
-							{ this.state.submittingForm ? (
-								this.props.translate( 'Saving…' )
-							) : (
-								this.props.translate( 'Save Notification Settings' )
-							) }
+							{ this.state.submittingForm
+								? this.props.translate( 'Saving…' )
+								: this.props.translate( 'Save Notification Settings' ) }
 						</FormButton>
 					</form>
 				</Card>

--- a/client/me/notification-settings/settings-form/settings.jsx
+++ b/client/me/notification-settings/settings-form/settings.jsx
@@ -76,16 +76,16 @@ class NotificationSettingsForm extends PureComponent {
 						onToggle={ this.props.onToggle }
 					/>
 					{ this.props.devices &&
-					this.props.devices.length > 0 && (
-						<Stream
-							key={ streams.DEVICES }
-							blogId={ this.props.blogId }
-							devices={ this.props.devices }
-							settingKeys={ this.props.settingKeys }
-							settings={ this.props.settings.get( streams.DEVICES ) }
-							onToggle={ this.props.onToggle }
-						/>
-					) }
+						this.props.devices.length > 0 && (
+							<Stream
+								key={ streams.DEVICES }
+								blogId={ this.props.blogId }
+								devices={ this.props.devices }
+								settingKeys={ this.props.settingKeys }
+								settings={ this.props.settings.get( streams.DEVICES ) }
+								onToggle={ this.props.onToggle }
+							/>
+						) }
 					<Stream
 						key={ 'selected-stream' }
 						className={ 'selected-stream' }

--- a/client/me/profile-links-add-wordpress/index.jsx
+++ b/client/me/profile-links-add-wordpress/index.jsx
@@ -224,11 +224,9 @@ class ProfileLinksAddWordPress extends Component {
 	render() {
 		return (
 			<div>
-				{ 0 === this.props.publicSites.length ? (
-					this.renderInvitationForm()
-				) : (
-					this.renderAddableSitesForm()
-				) }
+				{ 0 === this.props.publicSites.length
+					? this.renderInvitationForm()
+					: this.renderAddableSitesForm() }
 			</div>
 		);
 	}

--- a/client/me/profile/index.jsx
+++ b/client/me/profile/index.jsx
@@ -117,11 +117,9 @@ const Profile = createReactClass( {
 								}
 								onClick={ this.recordClickEvent( 'Save Profile Details Button' ) }
 							>
-								{ this.state.submittingForm ? (
-									this.props.translate( 'Saving…' )
-								) : (
-									this.props.translate( 'Save Profile Details' )
-								) }
+								{ this.state.submittingForm
+									? this.props.translate( 'Saving…' )
+									: this.props.translate( 'Save Profile Details' ) }
 							</FormButton>
 						</p>
 					</form>

--- a/client/me/purchases/cancel-privacy-protection/index.jsx
+++ b/client/me/purchases/cancel-privacy-protection/index.jsx
@@ -138,11 +138,9 @@ class CancelPrivacyProtection extends Component {
 
 		return (
 			<strong>
-				{ isRefundable( purchase ) ? (
-					this.props.translate( 'You will receive a refund when the upgrade is cancelled.' )
-				) : (
-					this.props.translate( 'You will not receive a refund when the upgrade is cancelled.' )
-				) }
+				{ isRefundable( purchase )
+					? this.props.translate( 'You will receive a refund when the upgrade is cancelled.' )
+					: this.props.translate( 'You will not receive a refund when the upgrade is cancelled.' ) }
 			</strong>
 		);
 	};
@@ -154,11 +152,9 @@ class CancelPrivacyProtection extends Component {
 				className="cancel-privacy-protection__cancel-button"
 				disabled={ this.state.disabled }
 			>
-				{ this.state.cancelling ? (
-					this.props.translate( 'Processing…' )
-				) : (
-					this.props.translate( 'Cancel Privacy Protection' )
-				) }
+				{ this.state.cancelling
+					? this.props.translate( 'Processing…' )
+					: this.props.translate( 'Cancel Privacy Protection' ) }
 			</Button>
 		);
 	};

--- a/client/me/purchases/confirm-cancel-domain/index.jsx
+++ b/client/me/purchases/confirm-cancel-domain/index.jsx
@@ -289,11 +289,9 @@ class ConfirmCancelDomain extends React.Component {
 						className="confirm-cancel-domain__reasons-dropdown"
 						key="confirm-cancel-domain__reasons-dropdown"
 						selectedText={
-							selectedReason ? (
-								selectedReason.label
-							) : (
-								this.props.translate( 'Please let us know why you wish to cancel.' )
-							)
+							selectedReason
+								? selectedReason.label
+								: this.props.translate( 'Please let us know why you wish to cancel.' )
 						}
 						options={ cancellationReasons }
 						onSelect={ this.onReasonChange }

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -398,17 +398,15 @@ class RemovePurchase extends Component {
 						args: { productName },
 						components: { siteName: <em>{ this.props.selectedSite.domain }</em> },
 					} ) }{' '}
-					{ isGoogleApps( purchase ) ? (
-						translate(
-							'Your G Suite account will continue working without interruption. ' +
-								'You will be able to manage your G Suite billing directly through Google.'
-						)
-					) : (
-						translate(
-							'You will not be able to reuse it again without purchasing a new subscription.',
-							{ comment: "'it' refers to a product purchased by a user" }
-						)
-					) }
+					{ isGoogleApps( purchase )
+						? translate(
+								'Your G Suite account will continue working without interruption. ' +
+									'You will be able to manage your G Suite billing directly through Google.'
+							)
+						: translate(
+								'You will not be able to reuse it again without purchasing a new subscription.',
+								{ comment: "'it' refers to a product purchased by a user" }
+							) }
 				</p>
 
 				{ isPlan( purchase ) && hasIncludedDomain( purchase ) && includedDomainText }

--- a/client/me/security-2fa-backup-codes-prompt/index.jsx
+++ b/client/me/security-2fa-backup-codes-prompt/index.jsx
@@ -164,11 +164,9 @@ class Security2faBackupCodesPrompt extends React.Component {
 						analytics.ga.recordEvent( 'Me', 'Clicked On 2fa Backup Codes Verify Button' );
 					} }
 				>
-					{ this.state.submittingCode ? (
-						this.props.translate( 'Verifying…' )
-					) : (
-						this.props.translate( 'Verify' )
-					) }
+					{ this.state.submittingCode
+						? this.props.translate( 'Verifying…' )
+						: this.props.translate( 'Verify' ) }
 				</FormButton>
 			</form>
 		);

--- a/client/me/security-2fa-backup-codes/index.jsx
+++ b/client/me/security-2fa-backup-codes/index.jsx
@@ -161,11 +161,9 @@ const Security2faBackupCodes = createReactClass( {
 					</Button>
 				</SectionHeader>
 				<Card>
-					{ this.state.generatingCodes || this.state.backupCodes.length ? (
-						this.renderList()
-					) : (
-						this.renderPrompt()
-					) }
+					{ this.state.generatingCodes || this.state.backupCodes.length
+						? this.renderList()
+						: this.renderPrompt() }
 				</Card>
 			</div>
 		);

--- a/client/me/security-2fa-code-prompt/index.jsx
+++ b/client/me/security-2fa-code-prompt/index.jsx
@@ -250,11 +250,9 @@ class Security2faCodePrompt extends React.Component {
 								this.onRequestCode( event );
 							}.bind( this ) }
 						>
-							{ this.state.codeRequestPerformed ? (
-								this.props.translate( 'Resend Code' )
-							) : (
-								this.props.translate( 'Send Code via SMS' )
-							) }
+							{ this.state.codeRequestPerformed
+								? this.props.translate( 'Resend Code' )
+								: this.props.translate( 'Send Code via SMS' ) }
 						</FormButton>
 					) : null }
 

--- a/client/me/security-2fa-enable/index.jsx
+++ b/client/me/security-2fa-enable/index.jsx
@@ -334,11 +334,9 @@ class Security2faEnable extends React.Component {
 					disabled={ this.state.submittingForm }
 					name="verificationCode"
 					placeholder={
-						'sms' === this.state.method ? (
-							constants.sevenDigit2faPlaceholder
-						) : (
-							constants.sixDigit2faPlaceholder
-						)
+						'sms' === this.state.method
+							? constants.sevenDigit2faPlaceholder
+							: constants.sixDigit2faPlaceholder
 					}
 					onFocus={ function() {
 						analytics.ga.recordEvent( 'Me', 'Focused On 2fa Enable Verification Code Input' );
@@ -375,15 +373,13 @@ class Security2faEnable extends React.Component {
 						);
 					}.bind( this ) }
 				>
-					{ this.state.submittingCode ? (
-						this.props.translate( 'Enabling…', {
-							context: 'A button label used during Two-Step setup.',
-						} )
-					) : (
-						this.props.translate( 'Enable', {
-							context: 'A button label used during Two-Step setup.',
-						} )
-					) }
+					{ this.state.submittingCode
+						? this.props.translate( 'Enabling…', {
+								context: 'A button label used during Two-Step setup.',
+							} )
+						: this.props.translate( 'Enable', {
+								context: 'A button label used during Two-Step setup.',
+							} ) }
 				</FormButton>
 
 				<FormButton

--- a/client/me/security-2fa-status/index.jsx
+++ b/client/me/security-2fa-status/index.jsx
@@ -23,27 +23,25 @@ class Security2faStatus extends React.Component {
 	render() {
 		return (
 			<p>
-				{ this.props.twoStepEnabled ? (
-					this.props.translate(
-						'{{status}}Status:{{/status}} Two-Step Authentication is currently {{onOff}}on{{/onOff}}.',
-						{
-							components: {
-								status: <span className="security-2fa-status__heading" />,
-								onOff: <span className="security-2fa-status__on" />,
-							},
-						}
-					)
-				) : (
-					this.props.translate(
-						'{{status}}Status:{{/status}} Two-Step Authentication is currently {{onOff}}off{{/onOff}}.',
-						{
-							components: {
-								status: <span className="security-2fa-status__heading" />,
-								onOff: <span className="security-2fa-status__off" />,
-							},
-						}
-					)
-				) }
+				{ this.props.twoStepEnabled
+					? this.props.translate(
+							'{{status}}Status:{{/status}} Two-Step Authentication is currently {{onOff}}on{{/onOff}}.',
+							{
+								components: {
+									status: <span className="security-2fa-status__heading" />,
+									onOff: <span className="security-2fa-status__on" />,
+								},
+							}
+						)
+					: this.props.translate(
+							'{{status}}Status:{{/status}} Two-Step Authentication is currently {{onOff}}off{{/onOff}}.',
+							{
+								components: {
+									status: <span className="security-2fa-status__heading" />,
+									onOff: <span className="security-2fa-status__off" />,
+								},
+							}
+						) }
 			</p>
 		);
 	}

--- a/client/me/sidebar/index.jsx
+++ b/client/me/sidebar/index.jsx
@@ -160,11 +160,9 @@ const MeSidebar = createReactClass( {
 						<SidebarItem
 							selected={ selected === 'notifications' }
 							link={
-								config.isEnabled( 'me/notifications' ) ? (
-									'/me/notifications'
-								) : (
-									'//wordpress.com/me/notifications'
-								)
+								config.isEnabled( 'me/notifications' )
+									? '/me/notifications'
+									: '//wordpress.com/me/notifications'
 							}
 							label={ translate( 'Notification Settings' ) }
 							icon="bell"

--- a/client/my-sites/ads/form-earnings.jsx
+++ b/client/my-sites/ads/form-earnings.jsx
@@ -360,27 +360,27 @@ class AdsFormEarnings extends Component {
 						{ this.earningsBreakdown() }
 					</div>
 				</Card>
-				{ this.state.earnings && this.checkSize( this.state.earnings.wordads ) ? (
-					this.earningsTable(
-						this.state.earnings.wordads,
-						translate( 'Earnings History' ),
-						'wordads'
-					)
-				) : null }
-				{ this.state.earnings && this.checkSize( this.state.earnings.sponsored ) ? (
-					this.earningsTable(
-						this.state.earnings.sponsored,
-						translate( 'Sponsored Content History' ),
-						'sponsored'
-					)
-				) : null }
-				{ this.state.earnings && this.checkSize( this.state.earnings.adjustment ) ? (
-					this.earningsTable(
-						this.state.earnings.adjustment,
-						translate( 'Adjustments History' ),
-						'adjustment'
-					)
-				) : null }
+				{ this.state.earnings && this.checkSize( this.state.earnings.wordads )
+					? this.earningsTable(
+							this.state.earnings.wordads,
+							translate( 'Earnings History' ),
+							'wordads'
+						)
+					: null }
+				{ this.state.earnings && this.checkSize( this.state.earnings.sponsored )
+					? this.earningsTable(
+							this.state.earnings.sponsored,
+							translate( 'Sponsored Content History' ),
+							'sponsored'
+						)
+					: null }
+				{ this.state.earnings && this.checkSize( this.state.earnings.adjustment )
+					? this.earningsTable(
+							this.state.earnings.adjustment,
+							translate( 'Adjustments History' ),
+							'adjustment'
+						)
+					: null }
 			</div>
 		);
 	}

--- a/client/my-sites/ads/form-settings.jsx
+++ b/client/my-sites/ads/form-settings.jsx
@@ -328,11 +328,9 @@ class AdsFormSettings extends Component {
 						name="taxid"
 						id="taxid"
 						placeholder={
-							this.state.taxid_last4 ? (
-								'On file. Last Four Digits: '.concat( this.state.taxid_last4 )
-							) : (
-								''
-							)
+							this.state.taxid_last4
+								? 'On file. Last Four Digits: '.concat( this.state.taxid_last4 )
+								: ''
 						}
 						value={ this.state.taxid || '' }
 						onChange={ this.handleChange }

--- a/client/my-sites/checkout/cart/cart-empty.jsx
+++ b/client/my-sites/checkout/cart/cart-empty.jsx
@@ -18,11 +18,9 @@ class CartEmpty extends React.Component {
 				</div>
 				<div className="cart-buttons">
 					<button className="cart-checkout-button button is-primary" onClick={ this.handleClick }>
-						{ this.shouldShowPlanButton() ? (
-							this.props.translate( 'Add a Plan' )
-						) : (
-							this.props.translate( 'Add a Domain' )
-						) }
+						{ this.shouldShowPlanButton()
+							? this.props.translate( 'Add a Plan' )
+							: this.props.translate( 'Add a Domain' ) }
 					</button>
 				</div>
 			</div>

--- a/client/my-sites/checkout/checkout-thank-you/business-plan-details.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/business-plan-details.jsx
@@ -62,18 +62,18 @@ const BusinessPlanDetails = ( { selectedSite, sitePlans, selectedFeature, purcha
 			) }
 
 			{ ! selectedFeature &&
-			isEnabled( 'manage/plugins/upload' ) && (
-				<PurchaseDetail
-					icon={ <img src="/calypso/images/upgrades/plugins.svg" /> }
-					title={ i18n.translate( 'Add a Plugin' ) }
-					description={ i18n.translate(
-						'Search and add plugins right from your dashboard, or upload a plugin ' +
-							'from your computer with a drag-and-drop interface.'
-					) }
-					buttonText={ i18n.translate( 'Upload a plugin now' ) }
-					href={ '/plugins/upload/' + selectedSite.slug }
-				/>
-			) }
+				isEnabled( 'manage/plugins/upload' ) && (
+					<PurchaseDetail
+						icon={ <img src="/calypso/images/upgrades/plugins.svg" /> }
+						title={ i18n.translate( 'Add a Plugin' ) }
+						description={ i18n.translate(
+							'Search and add plugins right from your dashboard, or upload a plugin ' +
+								'from your computer with a drag-and-drop interface.'
+						) }
+						buttonText={ i18n.translate( 'Upload a plugin now' ) }
+						href={ '/plugins/upload/' + selectedSite.slug }
+					/>
+				) }
 
 			<PurchaseDetail
 				icon={ <img src="/calypso/images/upgrades/adwords.svg" /> }

--- a/client/my-sites/checkout/checkout-thank-you/premium-plan-details.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/premium-plan-details.jsx
@@ -46,16 +46,14 @@ const PremiumPlanDetails = ( { selectedSite, sitePlans, selectedFeature, purchas
 				icon={ <img src="/calypso/images/upgrades/advertising-removed.svg" /> }
 				title={ i18n.translate( 'Advertising Removed' ) }
 				description={
-					isPremiumPlan ? (
-						i18n.translate(
-							'With your plan, all WordPress.com advertising has been removed from your site.' +
-								' You can upgrade to a Business plan to also remove the WordPress.com footer credit.'
-						)
-					) : (
-						i18n.translate(
-							'With your plan, all WordPress.com advertising has been removed from your site.'
-						)
-					)
+					isPremiumPlan
+						? i18n.translate(
+								'With your plan, all WordPress.com advertising has been removed from your site.' +
+									' You can upgrade to a Business plan to also remove the WordPress.com footer credit.'
+							)
+						: i18n.translate(
+								'With your plan, all WordPress.com advertising has been removed from your site.'
+							)
 				}
 			/>
 

--- a/client/my-sites/checkout/checkout/checkout.jsx
+++ b/client/my-sites/checkout/checkout/checkout.jsx
@@ -5,7 +5,17 @@
  */
 
 import { connect } from 'react-redux';
-import { flatten, filter, find, findIndex, get, isEmpty, isEqual, reduce, startsWith } from 'lodash';
+import {
+	flatten,
+	filter,
+	find,
+	findIndex,
+	get,
+	isEmpty,
+	isEqual,
+	reduce,
+	startsWith,
+} from 'lodash';
 import i18n, { localize } from 'i18n-calypso';
 import page from 'page';
 import PropTypes from 'prop-types';

--- a/client/my-sites/checkout/checkout/domain-details-form.jsx
+++ b/client/my-sites/checkout/checkout/domain-details-form.jsx
@@ -281,8 +281,9 @@ export class DomainDetailsForm extends PureComponent {
 			// The keys are mapped to snake_case when going to API and camelCase when the response is parsed and we are using
 			// kebab-case for HTML, so instead of using different variations all over the place, this accepts kebab-case and
 			// converts it to camelCase which is the format stored in the formState.
-			errorMessage: ( formState.getFieldErrorMessages( form, camelCase( name ) ) || [] )
-				.join( '\n' ),
+			errorMessage: ( formState.getFieldErrorMessages( form, camelCase( name ) ) || [] ).join(
+				'\n'
+			),
 			eventFormName: 'Checkout Form',
 		};
 	};

--- a/client/my-sites/checkout/checkout/free-cart-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/free-cart-payment-box.jsx
@@ -28,22 +28,20 @@ class FreeCartPaymentBox extends React.Component {
 			<form onSubmit={ this.props.onSubmit }>
 				<div className="payment-box-section">
 					<h6>
-						{ cart.has_bundle_credit ? (
-							this.props.translate( 'You have a free domain credit!' )
-						) : (
-							this.props.translate( "Woohoo! You don't owe us anything!" )
-						) }
+						{ cart.has_bundle_credit
+							? this.props.translate( 'You have a free domain credit!' )
+							: this.props.translate( "Woohoo! You don't owe us anything!" ) }
 					</h6>
 
 					<span>
-						{ cart.has_bundle_credit ? (
-							this.props.translate(
-								'You get one free domain with your subscription to %(productName)s. Time to celebrate!',
-								{ args: { productName: this.getProductName() } }
-							)
-						) : (
-							this.props.translate( 'Just complete checkout to add these upgrades to your site.' )
-						) }
+						{ cart.has_bundle_credit
+							? this.props.translate(
+									'You get one free domain with your subscription to %(productName)s. Time to celebrate!',
+									{ args: { productName: this.getProductName() } }
+								)
+							: this.props.translate(
+									'Just complete checkout to add these upgrades to your site.'
+								) }
 					</span>
 				</div>
 

--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -487,7 +487,7 @@ export class CommentList extends Component {
 						) ) }
 
 					{ isEnabled( 'comments/management/m3-design' ) &&
-					showPlaceholder && <Comment commentId={ 0 } key="comment-detail-placeholder" /> }
+						showPlaceholder && <Comment commentId={ 0 } key="comment-detail-placeholder" /> }
 
 					{ ! isEnabled( 'comments/management/m3-design' ) &&
 						map( commentsPage, commentId => (
@@ -512,7 +512,7 @@ export class CommentList extends Component {
 						) ) }
 
 					{ ! isEnabled( 'comments/management/m3-design' ) &&
-					showPlaceholder && <CommentDetailPlaceholder key="comment-detail-placeholder" /> }
+						showPlaceholder && <CommentDetailPlaceholder key="comment-detail-placeholder" /> }
 
 					{ showEmptyContent && (
 						<EmptyContent
@@ -526,15 +526,15 @@ export class CommentList extends Component {
 				</ReactCSSTransitionGroup>
 
 				{ ! showPlaceholder &&
-				! showEmptyContent && (
-					<Pagination
-						key="comment-list-pagination"
-						page={ validPage }
-						pageClick={ this.changePage }
-						perPage={ COMMENTS_PER_PAGE }
-						total={ commentsCount }
-					/>
-				) }
+					! showEmptyContent && (
+						<Pagination
+							key="comment-list-pagination"
+							page={ validPage }
+							pageClick={ this.changePage }
+							perPage={ COMMENTS_PER_PAGE }
+							total={ commentsCount }
+						/>
+					) }
 			</div>
 		);
 	}

--- a/client/my-sites/comments/comment-navigation/index.jsx
+++ b/client/my-sites/comments/comment-navigation/index.jsx
@@ -209,27 +209,27 @@ export class CommentNavigation extends Component {
 
 				<CommentNavigationTab className="comment-navigation__actions comment-navigation__open-bulk">
 					{ isEnabled( 'comments/management/sorting' ) &&
-					isCommentsTreeSupported &&
-					hasComments && (
-						<SegmentedControl compact className="comment-navigation__sort-buttons">
-							<ControlItem
-								onClick={ setSortOrder( NEWEST_FIRST ) }
-								selected={ sortOrder === NEWEST_FIRST }
-							>
-								{ translate( 'Newest', {
-									comment: 'Chronological order for sorting the comments list.',
-								} ) }
-							</ControlItem>
-							<ControlItem
-								onClick={ setSortOrder( OLDEST_FIRST ) }
-								selected={ sortOrder === OLDEST_FIRST }
-							>
-								{ translate( 'Oldest', {
-									comment: 'Chronological order for sorting the comments list.',
-								} ) }
-							</ControlItem>
-						</SegmentedControl>
-					) }
+						isCommentsTreeSupported &&
+						hasComments && (
+							<SegmentedControl compact className="comment-navigation__sort-buttons">
+								<ControlItem
+									onClick={ setSortOrder( NEWEST_FIRST ) }
+									selected={ sortOrder === NEWEST_FIRST }
+								>
+									{ translate( 'Newest', {
+										comment: 'Chronological order for sorting the comments list.',
+									} ) }
+								</ControlItem>
+								<ControlItem
+									onClick={ setSortOrder( OLDEST_FIRST ) }
+									selected={ sortOrder === OLDEST_FIRST }
+								>
+									{ translate( 'Oldest', {
+										comment: 'Chronological order for sorting the comments list.',
+									} ) }
+								</ControlItem>
+							</SegmentedControl>
+						) }
 
 					{ hasComments && (
 						<Button compact onClick={ toggleBulkEdit }>

--- a/client/my-sites/comments/comment/comment-author.jsx
+++ b/client/my-sites/comments/comment/comment-author.jsx
@@ -69,7 +69,7 @@ export class CommentAuthor extends Component {
 					{ /* A comment can be of type 'comment', 'pingback' or 'trackback'. */ }
 					{ 'comment' === commentType && !! authorAvatarUrl && <Gravatar user={ gravatarUser } /> }
 					{ 'comment' === commentType &&
-					! authorAvatarUrl && <span className="comment__author-gravatar-placeholder" /> }
+						! authorAvatarUrl && <span className="comment__author-gravatar-placeholder" /> }
 					{ 'comment' !== commentType && <Gridicon icon="link" size={ 24 } /> }
 				</div>
 

--- a/client/my-sites/comments/main.jsx
+++ b/client/my-sites/comments/main.jsx
@@ -82,29 +82,29 @@ export class CommentsManagement extends Component {
 				) }
 				{ ! showJetpackUpdateScreen && <SidebarNavigation /> }
 				{ ! showJetpackUpdateScreen &&
-				showPermissionError && (
-					<EmptyContent
-						title={ preventWidows(
-							translate( "Oops! You don't have permission to manage comments." )
-						) }
-						line={ preventWidows(
-							translate( "If you think you should, contact this site's administrator." )
-						) }
-						illustration="/calypso/images/illustrations/illustration-500.svg"
-					/>
-				) }
+					showPermissionError && (
+						<EmptyContent
+							title={ preventWidows(
+								translate( "Oops! You don't have permission to manage comments." )
+							) }
+							line={ preventWidows(
+								translate( "If you think you should, contact this site's administrator." )
+							) }
+							illustration="/calypso/images/illustrations/illustration-500.svg"
+						/>
+					) }
 				{ ! showJetpackUpdateScreen &&
-				! showPermissionError && (
-					<CommentList
-						changePage={ changePage }
-						order={ 'desc' }
-						page={ page }
-						postId={ postId }
-						siteId={ siteId }
-						siteFragment={ siteFragment }
-						status={ status }
-					/>
-				) }
+					! showPermissionError && (
+						<CommentList
+							changePage={ changePage }
+							order={ 'desc' }
+							page={ page }
+							postId={ postId }
+							siteId={ siteId }
+							siteFragment={ siteFragment }
+							status={ status }
+						/>
+					) }
 			</Main>
 		);
 	}

--- a/client/my-sites/domains/domain-management/contacts-privacy/index.jsx
+++ b/client/my-sites/domains/domain-management/contacts-privacy/index.jsx
@@ -69,16 +69,16 @@ class ContactsPrivacy extends React.PureComponent {
 					</VerticalNavItem>
 
 					{ ! hasPrivacyProtection &&
-					privacyAvailable && (
-						<VerticalNavItem
-							path={ paths.domainManagementPrivacyProtection(
-								this.props.selectedSite.slug,
-								this.props.selectedDomainName
-							) }
-						>
-							{ translate( 'Privacy Protection' ) }
-						</VerticalNavItem>
-					) }
+						privacyAvailable && (
+							<VerticalNavItem
+								path={ paths.domainManagementPrivacyProtection(
+									this.props.selectedSite.slug,
+									this.props.selectedDomainName
+								) }
+							>
+								{ translate( 'Privacy Protection' ) }
+							</VerticalNavItem>
+						) }
 				</VerticalNav>
 			</Main>
 		);

--- a/client/my-sites/domains/domain-management/dns/email-provider.jsx
+++ b/client/my-sites/domains/domain-management/dns/email-provider.jsx
@@ -92,7 +92,9 @@ class EmailProvider extends Component {
 							placeholder={ placeholder }
 						/>
 						{ token &&
-						! isDataValid && <FormInputValidation text={ translate( 'Invalid Token' ) } isError /> }
+							! isDataValid && (
+								<FormInputValidation text={ translate( 'Invalid Token' ) } isError />
+							) }
 					</FormFieldset>
 
 					<FormFooter>

--- a/client/my-sites/domains/domain-management/edit-contact-info/form-card.jsx
+++ b/client/my-sites/domains/domain-management/edit-contact-info/form-card.jsx
@@ -330,15 +330,15 @@ class EditContactInfoFormCard extends React.Component {
 								textOnly: true,
 							} ),
 						} ) }
-						{ this.hasFaxField() ? (
-							this.getField( FormInput, {
-								name: 'fax',
-								label: translate( 'Fax', {
-									context: 'Domain Edit Contact Info form.',
-									textOnly: true,
-								} ),
-							} )
-						) : null }
+						{ this.hasFaxField()
+							? this.getField( FormInput, {
+									name: 'fax',
+									label: translate( 'Fax', {
+										context: 'Domain Edit Contact Info form.',
+										textOnly: true,
+									} ),
+								} )
+							: null }
 						{ this.getField( FormCountrySelect, {
 							countriesList,
 							name: 'country-code',
@@ -392,11 +392,9 @@ class EditContactInfoFormCard extends React.Component {
 						<FormButton
 							disabled={ isSaveButtonDisabled }
 							onClick={
-								this.requiresConfirmation() ? (
-									this.showNonDaConfirmationDialog
-								) : (
-									this.saveContactInfo
-								)
+								this.requiresConfirmation()
+									? this.showNonDaConfirmationDialog
+									: this.saveContactInfo
 							}
 						>
 							{ saveButtonLabel }

--- a/client/my-sites/domains/domain-management/edit/card/header/index.jsx
+++ b/client/my-sites/domains/domain-management/edit/card/header/index.jsx
@@ -35,13 +35,13 @@ class Header extends React.Component {
 				<DomainTransferFlag domain={ domain } />
 
 				{ this.props.selectedSite &&
-				! this.props.selectedSite.jetpack && (
-					<PrimaryDomainButton
-						domain={ domain }
-						selectedSite={ this.props.selectedSite }
-						settingPrimaryDomain={ this.props.settingPrimaryDomain }
-					/>
-				) }
+					! this.props.selectedSite.jetpack && (
+						<PrimaryDomainButton
+							domain={ domain }
+							selectedSite={ this.props.selectedSite }
+							settingPrimaryDomain={ this.props.settingPrimaryDomain }
+						/>
+					) }
 			</SectionHeader>
 		);
 	}

--- a/client/my-sites/domains/domain-management/edit/registered-domain.jsx
+++ b/client/my-sites/domains/domain-management/edit/registered-domain.jsx
@@ -220,12 +220,12 @@ const RegisteredDomain = createReactClass( {
 				{ this.domainWarnings() }
 				<div className="domain-details-card">
 					{ domain.isPendingIcannVerification &&
-					domain.currentUserCanManage && (
-						<IcannVerificationCard
-							selectedDomainName={ domain.name }
-							selectedSiteSlug={ this.props.selectedSite.slug }
-						/>
-					) }
+						domain.currentUserCanManage && (
+							<IcannVerificationCard
+								selectedDomainName={ domain.name }
+								selectedSiteSlug={ this.props.selectedSite.slug }
+							/>
+						) }
 
 					<Header { ...this.props } />
 

--- a/client/my-sites/domains/domain-management/transfer/index.jsx
+++ b/client/my-sites/domains/domain-management/transfer/index.jsx
@@ -37,13 +37,13 @@ function Transfer( props ) {
 					{ translate( 'Transfer to another registrar' ) }
 				</VerticalNavItem>
 				{ ! isAutomatedTransfer &&
-				! isDomainOnly && (
-					<VerticalNavItem
-						path={ paths.domainManagementTransferToAnotherUser( slug, selectedDomainName ) }
-					>
-						{ translate( 'Transfer to another user' ) }
-					</VerticalNavItem>
-				) }
+					! isDomainOnly && (
+						<VerticalNavItem
+							path={ paths.domainManagementTransferToAnotherUser( slug, selectedDomainName ) }
+						>
+							{ translate( 'Transfer to another user' ) }
+						</VerticalNavItem>
+					) }
 				{ ! isAutomatedTransfer && (
 					<VerticalNavItem
 						path={ paths.domainManagementTransferToOtherSite( slug, selectedDomainName ) }

--- a/client/my-sites/domains/domain-management/transfer/transfer-out/locked.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-out/locked.jsx
@@ -88,14 +88,12 @@ class Locked extends React.Component {
 				<Card className="transfer-card">
 					<div>
 						<p>
-							{ privateDomain ? (
-								translate(
-									'To transfer your domain, we must unlock it and remove Privacy Protection. ' +
-										'Your contact information will be publicly available during the transfer period.'
-								)
-							) : (
-								translate( 'To transfer your domain, we must unlock it.' )
-							) }{' '}
+							{ privateDomain
+								? translate(
+										'To transfer your domain, we must unlock it and remove Privacy Protection. ' +
+											'Your contact information will be publicly available during the transfer period.'
+									)
+								: translate( 'To transfer your domain, we must unlock it.' ) }{' '}
 							<a
 								href={ support.TRANSFER_DOMAIN_REGISTRATION }
 								target="_blank"

--- a/client/my-sites/domains/domain-management/transfer/transfer-out/unlocked.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-out/unlocked.jsx
@@ -174,11 +174,9 @@ class Unlocked extends React.Component {
 				compact
 				primary
 			>
-				{ this.state.sent ? (
-					translate( 'Resend Transfer Code' )
-				) : (
-					translate( 'Send Transfer Code' )
-				) }
+				{ this.state.sent
+					? translate( 'Resend Transfer Code' )
+					: translate( 'Send Transfer Code' ) }
 			</Button>
 		);
 	}
@@ -220,18 +218,16 @@ class Unlocked extends React.Component {
 				{ translate(
 					'The registry for your domain requires a special process for transfers. '
 				) }{' '}
-				{ sent ? (
-					translate(
-						'Our Happiness Engineers have been notified about ' +
-							'your transfer request and will be in touch shortly to help ' +
-							'you complete the process.'
-					)
-				) : (
-					translate(
-						'Please request an authorization code to notify our ' +
-							'Happiness Engineers of your intention.'
-					)
-				) }
+				{ sent
+					? translate(
+							'Our Happiness Engineers have been notified about ' +
+								'your transfer request and will be in touch shortly to help ' +
+								'you complete the process.'
+						)
+					: translate(
+							'Please request an authorization code to notify our ' +
+								'Happiness Engineers of your intention.'
+						) }
 			</p>
 		);
 	}

--- a/client/my-sites/guided-transfer/issues-notices.jsx
+++ b/client/my-sites/guided-transfer/issues-notices.jsx
@@ -26,30 +26,30 @@ class IssuesNotices extends Component {
 		return (
 			<div className="guided-transfer__issues-notices">
 				{ premiumThemeIssue &&
-				! premiumThemeIssue.prevents_transfer && (
-					<Notice status="is-warning" showDismiss={ false }>
-						{ translate(
-							`Your site uses a Premium Theme that can't be
+					! premiumThemeIssue.prevents_transfer && (
+						<Notice status="is-warning" showDismiss={ false }>
+							{ translate(
+								`Your site uses a Premium Theme that can't be
 						transferred. Continuing will automatically activate the
 						default theme, or you can
 						{{a}}choose a free theme{{/a}}.`,
-							{ components: { a: <a href={ `/themes/free/${ siteSlug }` } /> } }
-						) }
-					</Notice>
-				) }
+								{ components: { a: <a href={ `/themes/free/${ siteSlug }` } /> } }
+							) }
+						</Notice>
+					) }
 
 				{ customFontIssue &&
-				! customFontIssue.prevents_transfer && (
-					<Notice status="is-warning" showDismiss={ false }>
-						{ translate(
-							`Your site uses a custom font that can't be
+					! customFontIssue.prevents_transfer && (
+						<Notice status="is-warning" showDismiss={ false }>
+							{ translate(
+								`Your site uses a custom font that can't be
 						transferred. Continuing will automatically activate the
 						default font, or you can
 						{{a}}choose a free theme{{/a}}.`,
-							{ components: { a: <a href={ `/themes/free/${ siteSlug }` } /> } }
-						) }
-					</Notice>
-				) }
+								{ components: { a: <a href={ `/themes/free/${ siteSlug }` } /> } }
+							) }
+						</Notice>
+					) }
 			</div>
 		);
 	}

--- a/client/my-sites/invites/invite-accept-logged-in/index.jsx
+++ b/client/my-sites/invites/invite-accept-logged-in/index.jsx
@@ -100,17 +100,15 @@ class InviteAcceptLoggedIn extends React.Component {
 				<InviteFormHeader { ...this.props.invite } user={ this.props.user } matchEmailError />
 				<div className="invite-accept-logged-in__button-bar">
 					<Button onClick={ this.signInLink } href={ this.props.signInLink }>
-						{ this.props.invite.knownUser ? (
-							this.props.translate( 'Sign In as %(email)s', {
-								context: 'button',
-								args: { email: this.props.invite.sentTo },
-							} )
-						) : (
-							this.props.translate( 'Register as %(email)s', {
-								context: 'button',
-								args: { email: this.props.invite.sentTo },
-							} )
-						) }
+						{ this.props.invite.knownUser
+							? this.props.translate( 'Sign In as %(email)s', {
+									context: 'button',
+									args: { email: this.props.invite.sentTo },
+								} )
+							: this.props.translate( 'Register as %(email)s', {
+									context: 'button',
+									args: { email: this.props.invite.sentTo },
+								} ) }
 					</Button>
 				</div>
 			</Card>

--- a/client/my-sites/invites/invite-accept/index.jsx
+++ b/client/my-sites/invites/invite-accept/index.jsx
@@ -220,17 +220,17 @@ class InviteAccept extends React.Component {
 				{ this.localeSuggestions() }
 				<div className={ formClasses }>
 					{ this.isMatchEmailError() &&
-					user && (
-						<Notice
-							text={ this.props.translate( 'This invite is only valid for %(email)s.', {
-								args: { email: invite.sentTo },
-							} ) }
-							status="is-error"
-							showDismiss={ false }
-						>
-							{ this.renderNoticeAction() }
-						</Notice>
-					) }
+						user && (
+							<Notice
+								text={ this.props.translate( 'This invite is only valid for %(email)s.', {
+									args: { email: invite.sentTo },
+								} ) }
+								status="is-error"
+								showDismiss={ false }
+							>
+								{ this.renderNoticeAction() }
+							</Notice>
+						) }
 					{ ! this.isInvalidInvite() && <InviteHeader { ...invite } /> }
 					{ this.isInvalidInvite() ? this.renderError() : this.renderForm() }
 				</div>

--- a/client/my-sites/media-library/content.jsx
+++ b/client/my-sites/media-library/content.jsx
@@ -175,11 +175,9 @@ class MediaLibraryContent extends React.Component {
 			<NoticeAction
 				external={ true }
 				href={
-					upgradeNudgeFeature ? (
-						`/plans/compare/${ this.props.siteSlug }?feature=${ upgradeNudgeFeature }`
-					) : (
-						`/plans/${ this.props.siteSlug }`
-					)
+					upgradeNudgeFeature
+						? `/plans/compare/${ this.props.siteSlug }?feature=${ upgradeNudgeFeature }`
+						: `/plans/${ this.props.siteSlug }`
 				}
 				onClick={ this.recordPlansNavigation.bind(
 					this,

--- a/client/my-sites/media/main.jsx
+++ b/client/my-sites/media/main.jsx
@@ -312,25 +312,25 @@ class Media extends Component {
 					</Dialog>
 				) }
 				{ site &&
-				site.ID && (
-					<MediaLibrarySelectedData siteId={ site.ID }>
-						<MediaLibrary
-							{ ...this.props }
-							className="media__main-section"
-							onFilterChange={ this.onFilterChange }
-							site={ site }
-							single={ false }
-							filter={ this.props.filter }
-							source={ this.state.source }
-							onEditItem={ this.openDetailsModalForASingleImage }
-							onViewDetails={ this.openDetailsModalForAllSelected }
-							onDeleteItem={ this.handleDeleteMediaEvent }
-							onSourceChange={ this.handleSourceChange }
-							modal={ false }
-							containerWidth={ this.state.containerWidth }
-						/>
-					</MediaLibrarySelectedData>
-				) }
+					site.ID && (
+						<MediaLibrarySelectedData siteId={ site.ID }>
+							<MediaLibrary
+								{ ...this.props }
+								className="media__main-section"
+								onFilterChange={ this.onFilterChange }
+								site={ site }
+								single={ false }
+								filter={ this.props.filter }
+								source={ this.state.source }
+								onEditItem={ this.openDetailsModalForASingleImage }
+								onViewDetails={ this.openDetailsModalForAllSelected }
+								onDeleteItem={ this.handleDeleteMediaEvent }
+								onSourceChange={ this.handleSourceChange }
+								modal={ false }
+								containerWidth={ this.state.containerWidth }
+							/>
+						</MediaLibrarySelectedData>
+					) }
 			</div>
 		);
 	}

--- a/client/my-sites/pages/page-list.jsx
+++ b/client/my-sites/pages/page-list.jsx
@@ -314,7 +314,9 @@ const Pages = createReactClass( {
 		}
 
 		const blogPostsPage = site &&
-		status === 'published' && <BlogPostsPage key="blog-posts-page" site={ site } pages={ pages } />;
+			status === 'published' && (
+				<BlogPostsPage key="blog-posts-page" site={ site } pages={ pages } />
+			);
 
 		return (
 			<div id="pages" className="pages__page-list">

--- a/client/my-sites/pages/page/index.js
+++ b/client/my-sites/pages/page/index.js
@@ -400,11 +400,9 @@ class Page extends Component {
 						className="page__title"
 						href={ canEdit ? helpers.editLinkForPage( page, site ) : page.URL }
 						title={
-							canEdit ? (
-								translate( 'Edit %(title)s', { textOnly: true, args: { title: page.title } } )
-							) : (
-								translate( 'View %(title)s', { textOnly: true, args: { title: page.title } } )
-							)
+							canEdit
+								? translate( 'Edit %(title)s', { textOnly: true, args: { title: page.title } } )
+								: translate( 'View %(title)s', { textOnly: true, args: { title: page.title } } )
 						}
 						onClick={ this.props.recordPageTitle }
 					>

--- a/client/my-sites/people/delete-user/index.jsx
+++ b/client/my-sites/people/delete-user/index.jsx
@@ -95,22 +95,20 @@ class DeleteUser extends React.PureComponent {
 		accept(
 			<div>
 				<p>
-					{ this.props.user && this.props.user.name ? (
-						translate(
-							'If you remove %(username)s, that user will no longer be able to access this site, ' +
-								'but any content that was created by %(username)s will remain on the site.',
-							{
-								args: {
-									username: this.props.user.name,
-								},
-							}
-						)
-					) : (
-						translate(
-							'If you remove this user, he or she will no longer be able to access this site, ' +
-								'but any content that was created by this user will remain on the site.'
-						)
-					) }
+					{ this.props.user && this.props.user.name
+						? translate(
+								'If you remove %(username)s, that user will no longer be able to access this site, ' +
+									'but any content that was created by %(username)s will remain on the site.',
+								{
+									args: {
+										username: this.props.user.name,
+									},
+								}
+							)
+						: translate(
+								'If you remove this user, he or she will no longer be able to access this site, ' +
+									'but any content that was created by this user will remain on the site.'
+							) }
 				</p>
 				<p>{ translate( 'Would you still like to remove this user?' ) }</p>
 			</div>,
@@ -199,22 +197,20 @@ class DeleteUser extends React.PureComponent {
 					<FormSectionHeading>{ this.getDeleteText() }</FormSectionHeading>
 
 					<p className="delete-user__explanation">
-						{ this.props.user.name ? (
-							translate(
-								'You have the option of reassigning all content created by ' +
-									'%(username)s, or deleting the content entirely.',
-								{
-									args: {
-										username: this.props.user.name,
-									},
-								}
-							)
-						) : (
-							translate(
-								'You have the option of reassigning all content created by ' +
-									'this user, or deleting the content entirely.'
-							)
-						) }
+						{ this.props.user.name
+							? translate(
+									'You have the option of reassigning all content created by ' +
+										'%(username)s, or deleting the content entirely.',
+									{
+										args: {
+											username: this.props.user.name,
+										},
+									}
+								)
+							: translate(
+									'You have the option of reassigning all content created by ' +
+										'this user, or deleting the content entirely.'
+								) }
 					</p>
 
 					<FormFieldset>
@@ -238,15 +234,13 @@ class DeleteUser extends React.PureComponent {
 							/>
 
 							<span>
-								{ this.props.user.name ? (
-									translate( 'Delete all content created by %(username)s', {
-										args: {
-											username: this.props.user.name ? this.props.user.name : '',
-										},
-									} )
-								) : (
-									translate( 'Delete all content created by this user' )
-								) }
+								{ this.props.user.name
+									? translate( 'Delete all content created by %(username)s', {
+											args: {
+												username: this.props.user.name ? this.props.user.name : '',
+											},
+										} )
+									: translate( 'Delete all content created by this user' ) }
 							</span>
 						</FormLabel>
 					</FormFieldset>

--- a/client/my-sites/people/followers-list/index.jsx
+++ b/client/my-sites/people/followers-list/index.jsx
@@ -82,7 +82,8 @@ const Followers = localize(
 						);
 						( 'email' === this.props.type
 							? EmailFollowersActions
-							: FollowersActions ).removeFollower( this.props.site.ID, follower );
+							: FollowersActions
+						).removeFollower( this.props.site.ID, follower );
 					} else {
 						analytics.ga.recordEvent(
 							'People',
@@ -218,9 +219,9 @@ const Followers = localize(
 						label={ headerText }
 						site={ this.props.site }
 						count={
-							this.props.fetching || this.props.fetchOptions.search ? null : (
-								this.props.totalFollowers
-							)
+							this.props.fetching || this.props.fetchOptions.search
+								? null
+								: this.props.totalFollowers
 						}
 					>
 						{ downloadListLink && (

--- a/client/my-sites/people/team-list/team.jsx
+++ b/client/my-sites/people/team-list/team.jsx
@@ -99,9 +99,9 @@ class Team extends React.Component {
 					label={ headerText }
 					site={ this.props.site }
 					count={
-						this.props.fetchingUsers || this.props.fetchOptions.search ? null : (
-							this.props.totalUsers
-						)
+						this.props.fetchingUsers || this.props.fetchOptions.search
+							? null
+							: this.props.totalUsers
 					}
 				/>
 				<Card className={ listClass }>{ people }</Card>

--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -126,14 +126,14 @@ class PlanFeaturesHeader extends Component {
 				<p className={ timeframeClasses }>
 					{ ! isPlaceholder ? billingTimeFrame : '' }
 					{ isDiscounted &&
-					! isPlaceholder && (
-						<InfoPopover
-							className="plan-features__header-tip-info"
-							position={ isMobile() ? 'top' : 'bottom left' }
-						>
-							{ translate( 'Price for the next 12 months' ) }
-						</InfoPopover>
-					) }
+						! isPlaceholder && (
+							<InfoPopover
+								className="plan-features__header-tip-info"
+								position={ isMobile() ? 'top' : 'bottom left' }
+							>
+								{ translate( 'Price for the next 12 months' ) }
+							</InfoPopover>
+						) }
 				</p>
 			);
 		}

--- a/client/my-sites/plans/current-plan/header.jsx
+++ b/client/my-sites/plans/current-plan/header.jsx
@@ -76,15 +76,13 @@ class CurrentPlanHeader extends Component {
 			<Card className="current-plan__header-purchase-info-wrapper" compact>
 				<div className={ classes }>
 					<span className="current-plan__header-expires-in">
-						{ hasAutoRenew && currentPlan.autoRenewDateMoment ? (
-							translate( 'Set to Auto Renew on %s.', {
-								args: invoke( currentPlan, 'autoRenewDateMoment.format', 'LL' ),
-							} )
-						) : (
-							translate( 'Expires on %s.', {
-								args: invoke( currentPlan, 'userFacingExpiryMoment.format', 'LL' ),
-							} )
-						) }
+						{ hasAutoRenew && currentPlan.autoRenewDateMoment
+							? translate( 'Set to Auto Renew on %s.', {
+									args: invoke( currentPlan, 'autoRenewDateMoment.format', 'LL' ),
+								} )
+							: translate( 'Expires on %s.', {
+									args: invoke( currentPlan, 'userFacingExpiryMoment.format', 'LL' ),
+								} ) }
 					</span>
 					{ currentPlan.userIsOwner && (
 						<Button

--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -303,7 +303,7 @@ const PluginsMain = createReactClass( {
 		);
 
 		const morePluginsHeader = showInstalledPluginList &&
-		showSuggestedPluginsList && <h3 className="plugins__more-header">More Plugins</h3>;
+			showSuggestedPluginsList && <h3 className="plugins__more-header">More Plugins</h3>;
 
 		let searchTitle;
 		if ( search ) {

--- a/client/my-sites/plugins/plugin-automated-transfer/index.jsx
+++ b/client/my-sites/plugins/plugin-automated-transfer/index.jsx
@@ -158,14 +158,14 @@ class PluginAutomatedTransfer extends Component {
 					text={ this.getNoticeText() }
 				>
 					{ ! transferComplete &&
-					CONFLICTS === transferState && (
-						<NoticeAction href="#">
-							{ translate( 'View Conflicts', {
-								comment:
-									'Conflicts arose during an Automated Transfer started by a plugin install.',
-							} ) }
-						</NoticeAction>
-					) }
+						CONFLICTS === transferState && (
+							<NoticeAction href="#">
+								{ translate( 'View Conflicts', {
+									comment:
+										'Conflicts arose during an Automated Transfer started by a plugin install.',
+								} ) }
+							</NoticeAction>
+						) }
 				</Notice>
 				{ this.state.transferComplete && <WpAdminAutoLogin site={ this.props.site } /> }
 			</div>

--- a/client/my-sites/plugins/plugin-list-header/index.jsx
+++ b/client/my-sites/plugins/plugin-list-header/index.jsx
@@ -181,11 +181,9 @@ export class PluginsListHeader extends PureComponent {
 					key="plugin-list-header__buttons-deactivate"
 					disabled={ ! this.props.haveActiveSelected }
 					onClick={
-						isJetpackSelected ? (
-							this.props.deactiveAndDisconnectSelected
-						) : (
-							this.props.deactivateSelected
-						)
+						isJetpackSelected
+							? this.props.deactiveAndDisconnectSelected
+							: this.props.deactivateSelected
 					}
 				>
 					{ translate( 'Deactivate' ) }
@@ -317,11 +315,9 @@ export class PluginsListHeader extends PureComponent {
 						key="plugin__actions_disconnect"
 						disabled={ ! this.props.haveActiveSelected }
 						onClick={
-							isJetpackSelected ? (
-								this.props.deactiveAndDisconnectSelected
-							) : (
-								this.props.deactivateSelected
-							)
+							isJetpackSelected
+								? this.props.deactiveAndDisconnectSelected
+								: this.props.deactivateSelected
 						}
 					>
 						{ translate( 'Deactivate' ) }

--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -499,7 +499,7 @@ class PluginMeta extends Component {
 		return (
 			<div className="plugin-meta">
 				{ this.props.atEnabled &&
-				this.props.selectedSite && <QueryEligibility siteId={ this.props.selectedSite.ID } /> }
+					this.props.selectedSite && <QueryEligibility siteId={ this.props.selectedSite.ID } /> }
 				<Card>
 					{ this.displayBanner() }
 					<div className={ cardClasses }>
@@ -525,44 +525,44 @@ class PluginMeta extends Component {
 				) }
 
 				{ ! this.props.isMock &&
-				get( this.props.selectedSite, 'jetpack' ) && (
-					<PluginInformation
-						plugin={ this.props.plugin }
-						isPlaceholder={ this.props.isPlaceholder }
-						site={ this.props.selectedSite }
-						pluginVersion={ plugin && plugin.version }
-						siteVersion={
-							this.props.selectedSite && this.props.selectedSite.options.software_version
-						}
-						hasUpdate={ this.getAvailableNewVersions().length > 0 }
-					/>
-				) }
+					get( this.props.selectedSite, 'jetpack' ) && (
+						<PluginInformation
+							plugin={ this.props.plugin }
+							isPlaceholder={ this.props.isPlaceholder }
+							site={ this.props.selectedSite }
+							pluginVersion={ plugin && plugin.version }
+							siteVersion={
+								this.props.selectedSite && this.props.selectedSite.options.software_version
+							}
+							hasUpdate={ this.getAvailableNewVersions().length > 0 }
+						/>
+					) }
 
 				{ this.props.atEnabled && this.maybeDisplayUnsupportedNotice() }
 
 				{ this.props.atEnabled &&
-				this.hasBusinessPlan() &&
-				! get( this.props.selectedSite, 'jetpack' ) && (
-					<PluginAutomatedTransfer plugin={ this.props.plugin } />
-				) }
+					this.hasBusinessPlan() &&
+					! get( this.props.selectedSite, 'jetpack' ) && (
+						<PluginAutomatedTransfer plugin={ this.props.plugin } />
+					) }
 
 				{ ( ( this.props.selectedSite && get( this.props.selectedSite, 'jetpack' ) ) ||
 					this.hasBusinessPlan() ||
 					this.isWpcomPreinstalled() ) && <div style={ { marginBottom: 16 } } /> }
 
 				{ this.props.selectedSite &&
-				! get( this.props.selectedSite, 'jetpack' ) &&
-				! this.hasBusinessPlan() &&
-				! this.isWpcomPreinstalled() && (
-					<div className="plugin-meta__upgrade_nudge">
-						<Banner
-							feature={ FEATURE_UPLOAD_PLUGINS }
-							event={ 'calypso_plugin_detail_page_upgrade_nudge' }
-							plan={ PLAN_BUSINESS }
-							title={ this.props.translate( 'Upgrade to the Business plan to install plugins.' ) }
-						/>
-					</div>
-				) }
+					! get( this.props.selectedSite, 'jetpack' ) &&
+					! this.hasBusinessPlan() &&
+					! this.isWpcomPreinstalled() && (
+						<div className="plugin-meta__upgrade_nudge">
+							<Banner
+								feature={ FEATURE_UPLOAD_PLUGINS }
+								event={ 'calypso_plugin_detail_page_upgrade_nudge' }
+								plan={ PLAN_BUSINESS }
+								title={ this.props.translate( 'Upgrade to the Business plan to install plugins.' ) }
+							/>
+						</div>
+					) }
 
 				{ this.getVersionWarning() }
 				{ this.getUpdateWarning() }

--- a/client/my-sites/plugins/plugin.jsx
+++ b/client/my-sites/plugins/plugin.jsx
@@ -271,9 +271,9 @@ const SinglePlugin = createReactClass( {
 						isPlaceholder
 						notices={ this.state.notices }
 						isInstalledOnSite={
-							this.isFetchingSites() ? null : (
-								!! PluginsStore.getSitePlugin( selectedSite, this.state.plugin.slug )
-							)
+							this.isFetchingSites()
+								? null
+								: !! PluginsStore.getSitePlugin( selectedSite, this.state.plugin.slug )
 						}
 						plugin={ this.getPlugin() }
 						siteUrl={ this.props.siteUrl }
@@ -382,9 +382,9 @@ const SinglePlugin = createReactClass( {
 						sites={ this.state.sites }
 						selectedSite={ selectedSite }
 						isInstalledOnSite={
-							this.isFetchingSites() ? null : (
-								!! PluginsStore.getSitePlugin( selectedSite, this.state.plugin.slug )
-							)
+							this.isFetchingSites()
+								? null
+								: !! PluginsStore.getSitePlugin( selectedSite, this.state.plugin.slug )
 						}
 						isInstalling={ installing }
 						allowedActions={ allowedPluginActions }

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/edit.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/edit.jsx
@@ -22,13 +22,7 @@ import { getPostType } from 'state/post-types/selectors';
 import { getCurrentUserId, isValidCapability } from 'state/current-user/selectors';
 import { getEditorPath } from 'state/ui/editor/selectors';
 
-function PostActionsEllipsisMenuEdit( {
-	translate,
-	canEdit,
-	status,
-	editUrl,
-	bumpStat,
-} ) {
+function PostActionsEllipsisMenuEdit( { translate, canEdit, status, editUrl, bumpStat } ) {
 	if ( 'trash' === status || ! canEdit ) {
 		return null;
 	}

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/trash.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/trash.jsx
@@ -65,11 +65,9 @@ class PostActionsEllipsisMenuTrash extends Component {
 
 		return (
 			<PopoverMenuItem onClick={ this.trashPost } icon="trash">
-				{ 'trash' === status ? (
-					translate( 'Delete Permanently' )
-				) : (
-					translate( 'Trash', { context: 'verb' } )
-				) }
+				{ 'trash' === status
+					? translate( 'Delete Permanently' )
+					: translate( 'Trash', { context: 'verb' } ) }
 			</PopoverMenuItem>
 		);
 	}

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/view.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/view.jsx
@@ -70,11 +70,9 @@ class PostActionsEllipsisMenuView extends Component {
 				target="_blank"
 				rel="noopener noreferrer"
 			>
-				{ includes( [ 'publish', 'private' ], status ) ? (
-					translate( 'View', { context: 'verb' } )
-				) : (
-					translate( 'Preview', { context: 'verb' } )
-				) }
+				{ includes( [ 'publish', 'private' ], status )
+					? translate( 'View', { context: 'verb' } )
+					: translate( 'Preview', { context: 'verb' } ) }
 			</PopoverMenuItem>
 		);
 	}

--- a/client/my-sites/posts/post-list-wrapper.jsx
+++ b/client/my-sites/posts/post-list-wrapper.jsx
@@ -54,11 +54,9 @@ class PostListWrapper extends React.Component {
 	render() {
 		return (
 			<div>
-				{ config.isEnabled( 'posts/post-type-list' ) ? (
-					this.renderPostTypeList()
-				) : (
-					this.renderPostList()
-				) }
+				{ config.isEnabled( 'posts/post-type-list' )
+					? this.renderPostTypeList()
+					: this.renderPostList() }
 			</div>
 		);
 	}

--- a/client/my-sites/posts/post.jsx
+++ b/client/my-sites/posts/post.jsx
@@ -309,20 +309,18 @@ class Post extends Component {
 						showFilters={ isEnabled( 'comments/filters-in-posts' ) }
 						showModerationTools={ isEnabled( 'comments/moderation-tools-in-posts' ) }
 						commentsFilter={
-							config.isEnabled( 'comments/filters-in-posts' ) ? (
-								this.state.commentsFilter
-							) : (
-								'approved'
-							)
+							config.isEnabled( 'comments/filters-in-posts' )
+								? this.state.commentsFilter
+								: 'approved'
 						}
 						onFilterChange={ this.setCommentsFilter }
 						onCommentsUpdate={ noop }
 					/>
 				) }
 				{ this.state.showShare &&
-				config.isEnabled( 'republicize' ) && (
-					<PostShare post={ this.props.post } siteId={ this.props.post.site_ID } />
-				) }
+					config.isEnabled( 'republicize' ) && (
+						<PostShare post={ this.props.post } siteId={ this.props.post.site_ID } />
+					) }
 			</Card>
 		);
 	}

--- a/client/my-sites/sharing/buttons/appearance.jsx
+++ b/client/my-sites/sharing/buttons/appearance.jsx
@@ -121,11 +121,9 @@ class SharingButtonsAppearance extends Component {
 		return (
 			<fieldset className="buttons__fieldset sharing-buttons__fieldset">
 				<legend className="buttons__fieldset-heading sharing-buttons__fieldset-heading">
-					{ isJetpack ? (
-						translate( 'Like', { context: 'Sharing options: Header' } )
-					) : (
-						translate( 'Reblog & Like', { context: 'Sharing options: Header' } )
-					) }
+					{ isJetpack
+						? translate( 'Like', { context: 'Sharing options: Header' } )
+						: translate( 'Reblog & Like', { context: 'Sharing options: Header' } ) }
 				</legend>
 				{ this.getReblogOptionElement() }
 				<label>
@@ -170,11 +168,9 @@ class SharingButtonsAppearance extends Component {
 					className="button is-primary sharing-buttons__submit"
 					disabled={ this.props.saving || ! this.props.initialized }
 				>
-					{ this.props.saving ? (
-						this.props.translate( 'Saving…' )
-					) : (
-						this.props.translate( 'Save Changes' )
-					) }
+					{ this.props.saving
+						? this.props.translate( 'Saving…' )
+						: this.props.translate( 'Save Changes' ) }
 				</button>
 			</div>
 		);

--- a/client/my-sites/sharing/buttons/preview-buttons.jsx
+++ b/client/my-sites/sharing/buttons/preview-buttons.jsx
@@ -256,11 +256,9 @@ class SharingButtonsPreviewButtons extends React.Component {
 	render() {
 		return (
 			<div className="sharing-buttons-preview-buttons">
-				{ 'official' === this.props.style ? (
-					this.getOfficialPreviewElement()
-				) : (
-					this.getCustomPreviewElement()
-				) }
+				{ 'official' === this.props.style
+					? this.getOfficialPreviewElement()
+					: this.getCustomPreviewElement() }
 				{ this.getMorePreviewElement() }
 			</div>
 		);

--- a/client/my-sites/sharing/buttons/tray.jsx
+++ b/client/my-sites/sharing/buttons/tray.jsx
@@ -229,11 +229,9 @@ class SharingButtonsTray extends React.Component {
 						onClick={ this.toggleReorder }
 						disabled={ this.getButtonsOfCurrentVisibility().length <= 1 }
 					>
-						{ this.state.isReordering ? (
-							this.props.translate( 'Add / Remove' )
-						) : (
-							this.props.translate( 'Reorder' )
-						) }
+						{ this.state.isReordering
+							? this.props.translate( 'Add / Remove' )
+							: this.props.translate( 'Reorder' ) }
 					</button>
 					<button
 						type="button"

--- a/client/my-sites/sharing/connections/services-group.jsx
+++ b/client/my-sites/sharing/connections/services-group.jsx
@@ -36,19 +36,17 @@ const SharingServicesGroup = ( { isFetching, services, title } ) => {
 		<div className="sharing-services-group">
 			<SectionHeader label={ title } />
 			<ul className="sharing-services-group__services">
-				{ services.length ? (
-					services.map( service => {
-						const Component = Components.hasOwnProperty( service.ID )
-							? Components[ service.ID ]
-							: Service;
+				{ services.length
+					? services.map( service => {
+							const Component = Components.hasOwnProperty( service.ID )
+								? Components[ service.ID ]
+								: Service;
 
-						return <Component key={ service.ID } service={ service } />;
-					} )
-				) : (
-					times( NUMBER_OF_PLACEHOLDERS, index => (
-						<ServicePlaceholder key={ 'service-placeholder-' + index } />
-					) )
-				) }
+							return <Component key={ service.ID } service={ service } />;
+						} )
+					: times( NUMBER_OF_PLACEHOLDERS, index => (
+							<ServicePlaceholder key={ 'service-placeholder-' + index } />
+						) ) }
 			</ul>
 		</div>
 	);

--- a/client/my-sites/site-settings/disconnect-site/missing-feature.jsx
+++ b/client/my-sites/site-settings/disconnect-site/missing-feature.jsx
@@ -58,15 +58,15 @@ class MissingFeature extends PureComponent {
 					<Button
 						disabled={ isEmpty( this.state.tokens ) }
 						href={
-							! isEmpty( this.state.tokens ) ? (
-								addQueryArgs(
-									{
-										reason: 'missing-feature',
-										text: this.state.tokens.map( this.normalizeToken ).sort(),
-									},
-									confirmHref
-								)
-							) : null
+							! isEmpty( this.state.tokens )
+								? addQueryArgs(
+										{
+											reason: 'missing-feature',
+											text: this.state.tokens.map( this.normalizeToken ).sort(),
+										},
+										confirmHref
+									)
+								: null
 						}
 						primary
 					>

--- a/client/my-sites/site-settings/form-analytics.jsx
+++ b/client/my-sites/site-settings/form-analytics.jsx
@@ -128,32 +128,32 @@ class GoogleAnalyticsForm extends Component {
 				{ siteIsJetpack && <QueryJetpackModules siteId={ siteId } /> }
 
 				{ isJetpackUnsupported &&
-				! showUpgradeNudge && (
-					<Notice
-						status="is-warning"
-						showDismiss={ false }
-						text={ translate( 'Google Analytics require a newer version of Jetpack.' ) }
-					>
-						<NoticeAction href={ `/plugins/jetpack/${ siteSlug }` }>
-							{ translate( 'Update Now' ) }
-						</NoticeAction>
-					</Notice>
-				) }
+					! showUpgradeNudge && (
+						<Notice
+							status="is-warning"
+							showDismiss={ false }
+							text={ translate( 'Google Analytics require a newer version of Jetpack.' ) }
+						>
+							<NoticeAction href={ `/plugins/jetpack/${ siteSlug }` }>
+								{ translate( 'Update Now' ) }
+							</NoticeAction>
+						</Notice>
+					) }
 
 				{ siteIsJetpack &&
-				jetpackModuleActive === false &&
-				! isJetpackUnsupported &&
-				! showUpgradeNudge && (
-					<Notice
-						status="is-warning"
-						showDismiss={ false }
-						text={ translate( 'The Google Analytics module is disabled in Jetpack.' ) }
-					>
-						<NoticeAction onClick={ activateGoogleAnalytics }>
-							{ translate( 'Enable' ) }
-						</NoticeAction>
-					</Notice>
-				) }
+					jetpackModuleActive === false &&
+					! isJetpackUnsupported &&
+					! showUpgradeNudge && (
+						<Notice
+							status="is-warning"
+							showDismiss={ false }
+							text={ translate( 'The Google Analytics module is disabled in Jetpack.' ) }
+						>
+							<NoticeAction onClick={ activateGoogleAnalytics }>
+								{ translate( 'Enable' ) }
+							</NoticeAction>
+						</Notice>
+					) }
 
 				<SectionHeader label={ translate( 'Google Analytics' ) }>
 					{ ! showUpgradeNudge && (
@@ -171,15 +171,13 @@ class GoogleAnalyticsForm extends Component {
 				{ showUpgradeNudge ? (
 					<Banner
 						description={
-							siteIsJetpack ? (
-								translate(
-									'Upgrade to the Professional Plan and include your own analytics tracking ID.'
-								)
-							) : (
-								translate(
-									'Upgrade to the Business Plan and include your own analytics tracking ID.'
-								)
-							)
+							siteIsJetpack
+								? translate(
+										'Upgrade to the Professional Plan and include your own analytics tracking ID.'
+									)
+								: translate(
+										'Upgrade to the Business Plan and include your own analytics tracking ID.'
+									)
 						}
 						event={ 'google_analytics_settings' }
 						feature={ FEATURE_GOOGLE_ANALYTICS }

--- a/client/my-sites/site-settings/form-discussion.jsx
+++ b/client/my-sites/site-settings/form-discussion.jsx
@@ -219,11 +219,9 @@ class SiteSettingsFormDiscussion extends Component {
 				id="close_comments_days_old"
 				className="small-text"
 				value={
-					'undefined' === typeof fields.close_comments_days_old ? (
-						14
-					) : (
-						fields.close_comments_days_old
-					)
+					'undefined' === typeof fields.close_comments_days_old
+						? 14
+						: fields.close_comments_days_old
 				}
 				onChange={ onChangeField( 'close_comments_days_old' ) }
 				disabled={ isRequestingSettings || isSavingSettings }
@@ -613,21 +611,21 @@ class SiteSettingsFormDiscussion extends Component {
 				</Card>
 
 				{ isJetpack &&
-				jetpackSettingsUISupported && (
-					<div>
-						<QueryJetpackModules siteId={ siteId } />
+					jetpackSettingsUISupported && (
+						<div>
+							<QueryJetpackModules siteId={ siteId } />
 
-						{ this.renderSectionHeader( translate( 'Subscriptions' ), false ) }
+							{ this.renderSectionHeader( translate( 'Subscriptions' ), false ) }
 
-						<Subscriptions
-							onSubmitForm={ handleSubmitForm }
-							handleAutosavingToggle={ handleAutosavingToggle }
-							isSavingSettings={ isSavingSettings }
-							isRequestingSettings={ isRequestingSettings }
-							fields={ fields }
-						/>
-					</div>
-				) }
+							<Subscriptions
+								onSubmitForm={ handleSubmitForm }
+								handleAutosavingToggle={ handleAutosavingToggle }
+								isSavingSettings={ isSavingSettings }
+								isRequestingSettings={ isRequestingSettings }
+								fields={ fields }
+							/>
+						</div>
+					) }
 			</form>
 		);
 	}

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -414,18 +414,18 @@ class SiteSettingsFormGeneral extends Component {
 							</div>
 						</CompactCard>
 						{ site &&
-						! isBusiness( site.plan ) && (
-							<Banner
-								feature={ FEATURE_NO_BRANDING }
-								plan={ PLAN_BUSINESS }
-								title={ translate(
-									'Remove the footer credit entirely with WordPress.com Business'
-								) }
-								description={ translate(
-									'Upgrade to remove the footer credit, add Google Analytics and more'
-								) }
-							/>
-						) }
+							! isBusiness( site.plan ) && (
+								<Banner
+									feature={ FEATURE_NO_BRANDING }
+									plan={ PLAN_BUSINESS }
+									title={ translate(
+										'Remove the footer credit entirely with WordPress.com Business'
+									) }
+									description={ translate(
+										'Upgrade to remove the footer credit, add Google Analytics and more'
+									) }
+								/>
+							) }
 					</div>
 				) }
 			</div>

--- a/client/my-sites/site-settings/form-writing.jsx
+++ b/client/my-sites/site-settings/form-writing.jsx
@@ -81,15 +81,15 @@ class SiteSettingsFormWriting extends Component {
 				className="site-settings__general-settings"
 			>
 				{ this.props.isJetpackSite &&
-				this.props.jetpackMasterbarSupported && (
-					<div>
-						{ this.renderSectionHeader( translate( 'WordPress.com toolbar' ), false ) }
-						<Masterbar
-							isSavingSettings={ isSavingSettings }
-							isRequestingSettings={ isRequestingSettings }
-						/>
-					</div>
-				) }
+					this.props.jetpackMasterbarSupported && (
+						<div>
+							{ this.renderSectionHeader( translate( 'WordPress.com toolbar' ), false ) }
+							<Masterbar
+								isSavingSettings={ isSavingSettings }
+								isRequestingSettings={ isRequestingSettings }
+							/>
+						</div>
+					) }
 
 				{ config.isEnabled( 'manage/site-settings/categories' ) && (
 					<div className="site-settings__taxonomies">
@@ -113,19 +113,19 @@ class SiteSettingsFormWriting extends Component {
 					updateFields={ updateFields }
 				/>
 				{ this.props.isJetpackSite &&
-				this.props.jetpackSettingsUISupported && (
-					<div>
-						{ this.renderSectionHeader( translate( 'Media' ) ) }
-						<MediaSettings
-							siteId={ this.props.siteId }
-							handleAutosavingToggle={ handleAutosavingToggle }
-							onChangeField={ onChangeField }
-							isSavingSettings={ isSavingSettings }
-							isRequestingSettings={ isRequestingSettings }
-							fields={ fields }
-						/>
-					</div>
-				) }
+					this.props.jetpackSettingsUISupported && (
+						<div>
+							{ this.renderSectionHeader( translate( 'Media' ) ) }
+							<MediaSettings
+								siteId={ this.props.siteId }
+								handleAutosavingToggle={ handleAutosavingToggle }
+								onChangeField={ onChangeField }
+								isSavingSettings={ isSavingSettings }
+								isRequestingSettings={ isRequestingSettings }
+								fields={ fields }
+							/>
+						</div>
+					) }
 
 				{ this.renderSectionHeader( translate( 'Content types' ) ) }
 
@@ -138,44 +138,44 @@ class SiteSettingsFormWriting extends Component {
 				/>
 
 				{ this.props.isJetpackSite &&
-				this.props.jetpackSettingsUISupported && (
-					<div>
-						<QueryJetpackModules siteId={ this.props.siteId } />
+					this.props.jetpackSettingsUISupported && (
+						<div>
+							<QueryJetpackModules siteId={ this.props.siteId } />
 
-						<ThemeEnhancements
-							onSubmitForm={ this.props.handleSubmitForm }
-							handleAutosavingToggle={ handleAutosavingToggle }
-							handleAutosavingRadio={ handleAutosavingRadio }
-							isSavingSettings={ isSavingSettings }
-							isRequestingSettings={ isRequestingSettings }
-							fields={ fields }
-						/>
-
-						{ config.isEnabled( 'press-this' ) && (
-							<PublishingTools
+							<ThemeEnhancements
 								onSubmitForm={ this.props.handleSubmitForm }
+								handleAutosavingToggle={ handleAutosavingToggle }
+								handleAutosavingRadio={ handleAutosavingRadio }
 								isSavingSettings={ isSavingSettings }
 								isRequestingSettings={ isRequestingSettings }
 								fields={ fields }
 							/>
-						) }
-					</div>
-				) }
+
+							{ config.isEnabled( 'press-this' ) && (
+								<PublishingTools
+									onSubmitForm={ this.props.handleSubmitForm }
+									isSavingSettings={ isSavingSettings }
+									isRequestingSettings={ isRequestingSettings }
+									fields={ fields }
+								/>
+							) }
+						</div>
+					) }
 
 				{ config.isEnabled( 'press-this' ) &&
-				! this.isMobile() &&
-				! ( this.props.isJetpackSite || this.props.jetpackSettingsUISupported ) && (
-					<div>
-						{ this.renderSectionHeader(
-							translate( 'Press This', {
-								context: 'name of browser bookmarklet tool',
-							} ),
-							false
-						) }
+					! this.isMobile() &&
+					! ( this.props.isJetpackSite || this.props.jetpackSettingsUISupported ) && (
+						<div>
+							{ this.renderSectionHeader(
+								translate( 'Press This', {
+									context: 'name of browser bookmarklet tool',
+								} ),
+								false
+							) }
 
-						<PressThis />
-					</div>
-				) }
+							<PressThis />
+						</div>
+					) }
 			</form>
 		);
 	}

--- a/client/my-sites/site-settings/jetpack-credentials/credentials-form/index.jsx
+++ b/client/my-sites/site-settings/jetpack-credentials/credentials-form/index.jsx
@@ -191,11 +191,9 @@ export class CredentialsForm extends Component {
 								<FormLabel>
 									<div>{ translate( 'Private Key' ) }</div>
 									<Button disabled={ formIsSubmitting } onClick={ this.togglePrivateKeyField }>
-										{ showPrivateKeyField ? (
-											translate( 'Hide Private Key' )
-										) : (
-											translate( 'Show Private Key' )
-										) }
+										{ showPrivateKeyField
+											? translate( 'Hide Private Key' )
+											: translate( 'Show Private Key' ) }
 									</Button>
 									{ showPrivateKeyField && (
 										<div>

--- a/client/my-sites/site-settings/jetpack-sync-panel/index.jsx
+++ b/client/my-sites/site-settings/jetpack-sync-panel/index.jsx
@@ -102,11 +102,9 @@ class JetpackSyncPanel extends React.Component {
 		} else if ( syncRequestError ) {
 			errorNotice = (
 				<Notice isCompact status="is-error" className="jetpack-sync-panel__error-notice">
-					{ syncRequestError.message ? (
-						syncRequestError.message
-					) : (
-						translate( 'There was an error scheduling a full sync.' )
-					) }
+					{ syncRequestError.message
+						? syncRequestError.message
+						: translate( 'There was an error scheduling a full sync.' ) }
 					{ // We show a Try again action for a generic error on the assumption
 					// that the error was a network issue.
 					//

--- a/client/my-sites/site-settings/manage-connection/site-ownership.jsx
+++ b/client/my-sites/site-settings/manage-connection/site-ownership.jsx
@@ -71,11 +71,9 @@ class SiteOwnership extends Component {
 		return (
 			<div>
 				<FormSettingExplanation>
-					{ userIsMaster ? (
-						translate( "You are the owner of this site's connection to WordPress.com." )
-					) : (
-						translate( "Somebody else owns this site's connection to WordPress.com." )
-					) }
+					{ userIsMaster
+						? translate( "You are the owner of this site's connection to WordPress.com." )
+						: translate( "Somebody else owns this site's connection to WordPress.com." ) }
 				</FormSettingExplanation>
 				{ userIsMaster && this.renderCurrentUser() }
 			</div>

--- a/client/my-sites/site-settings/navigation.jsx
+++ b/client/my-sites/site-settings/navigation.jsx
@@ -81,15 +81,15 @@ export class SiteSettingsNavigation extends Component {
 					</NavItem>
 
 					{ config.isEnabled( 'manage/security' ) &&
-					site.jetpack && (
-						<NavItem
-							path={ `/settings/security/${ site.slug }` }
-							preloadSectionName="settings-security"
-							selected={ section === 'security' }
-						>
-							{ strings.security }
-						</NavItem>
-					) }
+						site.jetpack && (
+							<NavItem
+								path={ `/settings/security/${ site.slug }` }
+								preloadSectionName="settings-security"
+								selected={ section === 'security' }
+							>
+								{ strings.security }
+							</NavItem>
+						) }
 				</NavTabs>
 			</SectionNav>
 		);

--- a/client/my-sites/site-settings/protect.jsx
+++ b/client/my-sites/site-settings/protect.jsx
@@ -149,11 +149,9 @@ class Protect extends Component {
 									disabled={ disabled || isIpWhitelisted }
 									compact
 								>
-									{ isIpWhitelisted ? (
-										translate( 'Already in whitelist' )
-									) : (
-										translate( 'Add to whitelist' )
-									) }
+									{ isIpWhitelisted
+										? translate( 'Already in whitelist' )
+										: translate( 'Add to whitelist' ) }
 								</Button>
 							) }
 						</p>

--- a/client/my-sites/site-settings/publishing-tools/index.jsx
+++ b/client/my-sites/site-settings/publishing-tools/index.jsx
@@ -104,11 +104,9 @@ class PublishingTools extends Component {
 						moduleUnavailable
 					}
 				>
-					{ regeneratingPostByEmail ? (
-						translate( 'Regenerating…' )
-					) : (
-						translate( 'Regenerate address' )
-					) }
+					{ regeneratingPostByEmail
+						? translate( 'Regenerating…' )
+						: translate( 'Regenerate address' ) }
 				</Button>
 			</div>
 		);

--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -341,25 +341,25 @@ export class SeoForm extends React.Component {
 				{ siteIsJetpack && <QueryJetpackModules siteId={ siteId } /> }
 				<PageViewTracker path="/settings/seo/:site" title="Site Settings > SEO" />
 				{ ( isSitePrivate || isSiteHidden ) &&
-				hasBusinessPlan( site.plan ) && (
-					<Notice
-						status="is-warning"
-						showDismiss={ false }
-						text={
-							isSitePrivate ? (
-								translate(
-									"SEO settings aren't recognized by search engines while your site is Private."
-								)
-							) : (
-								translate(
-									"SEO settings aren't recognized by search engines while your site is Hidden."
-								)
-							)
-						}
-					>
-						<NoticeAction href={ generalTabUrl }>{ translate( 'Privacy Settings' ) }</NoticeAction>
-					</Notice>
-				) }
+					hasBusinessPlan( site.plan ) && (
+						<Notice
+							status="is-warning"
+							showDismiss={ false }
+							text={
+								isSitePrivate
+									? translate(
+											"SEO settings aren't recognized by search engines while your site is Private."
+										)
+									: translate(
+											"SEO settings aren't recognized by search engines while your site is Hidden."
+										)
+							}
+						>
+							<NoticeAction href={ generalTabUrl }>
+								{ translate( 'Privacy Settings' ) }
+							</NoticeAction>
+						</Notice>
+					) }
 
 				{ conflictedSeoPlugin && (
 					<Notice
@@ -387,16 +387,16 @@ export class SeoForm extends React.Component {
 				) }
 
 				{ siteIsJetpack &&
-				hasBusinessPlan( site.plan ) &&
-				isSeoToolsActive === false && (
-					<Notice
-						status="is-warning"
-						showDismiss={ false }
-						text={ translate( 'SEO Tools module is disabled in Jetpack.' ) }
-					>
-						<NoticeAction onClick={ activateSeoTools }>{ translate( 'Enable' ) }</NoticeAction>
-					</Notice>
-				) }
+					hasBusinessPlan( site.plan ) &&
+					isSeoToolsActive === false && (
+						<Notice
+							status="is-warning"
+							showDismiss={ false }
+							text={ translate( 'SEO Tools module is disabled in Jetpack.' ) }
+						>
+							<NoticeAction onClick={ activateSeoTools }>{ translate( 'Enable' ) }</NoticeAction>
+						</Notice>
+					) }
 
 				{ ! this.props.hasAdvancedSEOFeature && (
 					<Banner
@@ -412,79 +412,81 @@ export class SeoForm extends React.Component {
 
 				<form onChange={ this.props.markChanged } className="seo-settings__seo-form">
 					{ showAdvancedSeo &&
-					! conflictedSeoPlugin && (
-						<div>
-							<SectionHeader label={ translate( 'Page Title Structure' ) }>
-								{ seoSubmitButton }
-							</SectionHeader>
-							<Card compact className="seo-settings__page-title-header">
-								<img
-									className="seo-settings__page-title-header-image"
-									src="/calypso/images/seo/page-title.svg"
-								/>
-								<p className="seo-settings__page-title-header-text">
-									{ translate(
-										'You can set the structure of page titles for different sections of your site. ' +
-											'Doing this will change the way your site title is displayed in search engines, ' +
-											'social media sites, and browser tabs.'
-									) }
-								</p>
-							</Card>
-							<Card>
-								<MetaTitleEditor
-									disabled={ isFetchingSite || isSeoDisabled }
-									onChange={ this.updateTitleFormats }
-									titleFormats={ this.state.seoTitleFormats }
-								/>
-							</Card>
-						</div>
-					) }
+						! conflictedSeoPlugin && (
+							<div>
+								<SectionHeader label={ translate( 'Page Title Structure' ) }>
+									{ seoSubmitButton }
+								</SectionHeader>
+								<Card compact className="seo-settings__page-title-header">
+									<img
+										className="seo-settings__page-title-header-image"
+										src="/calypso/images/seo/page-title.svg"
+									/>
+									<p className="seo-settings__page-title-header-text">
+										{ translate(
+											'You can set the structure of page titles for different sections of your site. ' +
+												'Doing this will change the way your site title is displayed in search engines, ' +
+												'social media sites, and browser tabs.'
+										) }
+									</p>
+								</Card>
+								<Card>
+									<MetaTitleEditor
+										disabled={ isFetchingSite || isSeoDisabled }
+										onChange={ this.updateTitleFormats }
+										titleFormats={ this.state.seoTitleFormats }
+									/>
+								</Card>
+							</div>
+						) }
 
 					{ ! conflictedSeoPlugin &&
-					( showAdvancedSeo || ( ! siteIsJetpack && showWebsiteMeta ) ) && (
-						<div>
-							<SectionHeader label={ translate( 'Website Meta' ) }>
-								{ seoSubmitButton }
-							</SectionHeader>
-							<Card>
-								<p>
-									{ translate(
-										'Craft a description of your Website up to 160 characters that will be used in ' +
-											'search engine results for your front page, and when your website is shared ' +
-											'on social media sites.'
-									) }
-								</p>
-								<FormLabel htmlFor="advanced_seo_front_page_description">
-									{ translate( 'Front Page Meta Description' ) }
-								</FormLabel>
-								<CountedTextarea
-									name="advanced_seo_front_page_description"
-									type="text"
-									id="advanced_seo_front_page_description"
-									value={ frontPageMetaDescription || '' }
-									disabled={ isSeoDisabled }
-									maxLength="300"
-									acceptableLength={ 159 }
-									onChange={ this.handleMetaChange }
-									className="seo-settings__front-page-description"
-								/>
-								{ hasHtmlTagError && (
-									<FormInputValidation
-										isError={ true }
-										text={ translate( 'HTML tags are not allowed.' ) }
+						( showAdvancedSeo || ( ! siteIsJetpack && showWebsiteMeta ) ) && (
+							<div>
+								<SectionHeader label={ translate( 'Website Meta' ) }>
+									{ seoSubmitButton }
+								</SectionHeader>
+								<Card>
+									<p>
+										{ translate(
+											'Craft a description of your Website up to 160 characters that will be used in ' +
+												'search engine results for your front page, and when your website is shared ' +
+												'on social media sites.'
+										) }
+									</p>
+									<FormLabel htmlFor="advanced_seo_front_page_description">
+										{ translate( 'Front Page Meta Description' ) }
+									</FormLabel>
+									<CountedTextarea
+										name="advanced_seo_front_page_description"
+										type="text"
+										id="advanced_seo_front_page_description"
+										value={ frontPageMetaDescription || '' }
+										disabled={ isSeoDisabled }
+										maxLength="300"
+										acceptableLength={ 159 }
+										onChange={ this.handleMetaChange }
+										className="seo-settings__front-page-description"
 									/>
-								) }
-								<FormSettingExplanation>
-									<Button className="seo-settings__preview-button" onClick={ this.showPreview }>
-										{ translate( 'Show Previews' ) }
-									</Button>
-									<span className="seo-settings__preview-explanation">
-										{ translate( 'See how this will look on ' + 'Google, Facebook, and Twitter.' ) }
-									</span>
-								</FormSettingExplanation>
-							</Card>
-						</div>
-					) }
+									{ hasHtmlTagError && (
+										<FormInputValidation
+											isError={ true }
+											text={ translate( 'HTML tags are not allowed.' ) }
+										/>
+									) }
+									<FormSettingExplanation>
+										<Button className="seo-settings__preview-button" onClick={ this.showPreview }>
+											{ translate( 'Show Previews' ) }
+										</Button>
+										<span className="seo-settings__preview-explanation">
+											{ translate(
+												'See how this will look on ' + 'Google, Facebook, and Twitter.'
+											) }
+										</span>
+									</FormSettingExplanation>
+								</Card>
+							</div>
+						) }
 				</form>
 
 				<WebPreview

--- a/client/my-sites/site-settings/seo-settings/site-verification.jsx
+++ b/client/my-sites/site-settings/seo-settings/site-verification.jsx
@@ -204,11 +204,9 @@ class SiteVerification extends Component {
 			<FormInputValidation
 				isError={ true }
 				text={
-					isPasteError ? (
-						translate( 'Verification code should be copied and pasted into this field.' )
-					) : (
-						translate( 'Invalid site verification tag.' )
-					)
+					isPasteError
+						? translate( 'Verification code should be copied and pasted into this field.' )
+						: translate( 'Invalid site verification tag.' )
 				}
 			/>
 		);
@@ -304,17 +302,17 @@ class SiteVerification extends Component {
 				{ siteIsJetpack && <QueryJetpackModules siteId={ siteId } /> }
 
 				{ siteIsJetpack &&
-				isVerificationToolsActive === false && (
-					<Notice
-						status="is-warning"
-						showDismiss={ false }
-						text={ translate( 'Site Verification Services are disabled in Jetpack.' ) }
-					>
-						<NoticeAction onClick={ this.activateVerificationServices }>
-							{ translate( 'Enable' ) }
-						</NoticeAction>
-					</Notice>
-				) }
+					isVerificationToolsActive === false && (
+						<Notice
+							status="is-warning"
+							showDismiss={ false }
+							text={ translate( 'Site Verification Services are disabled in Jetpack.' ) }
+						>
+							<NoticeAction onClick={ this.activateVerificationServices }>
+								{ translate( 'Enable' ) }
+							</NoticeAction>
+						</Notice>
+					) }
 
 				<SectionHeader label={ translate( 'Site Verification Services' ) }>
 					<Button

--- a/client/my-sites/site-settings/spam-filtering-settings.jsx
+++ b/client/my-sites/site-settings/spam-filtering-settings.jsx
@@ -110,9 +110,9 @@ const SpamFilteringSettings = ( {
 						onChange={ onChangeField( 'wordpress_api_key' ) }
 					/>
 					{ ( isValidKey || isInvalidKey ) &&
-					! inTransition && (
-						<FormInputValidation isError={ isInvalidKey } text={ validationText } />
-					) }
+						! inTransition && (
+							<FormInputValidation isError={ isInvalidKey } text={ validationText } />
+						) }
 					{ ( ! wordpress_api_key || isInvalidKey || ! isValidKey ) && (
 						<FormSettingExplanation>
 							{ translate(

--- a/client/my-sites/stats/activity-log-banner/progress-banner.jsx
+++ b/client/my-sites/stats/activity-log-banner/progress-banner.jsx
@@ -50,11 +50,9 @@ function ProgressBanner( {
 		<ActivityLogBanner
 			status="info"
 			title={
-				'restore' === action ? (
-					translate( 'Currently restoring your site' )
-				) : (
-					translate( 'Currently creating a downloadable backup of your site' )
-				)
+				'restore' === action
+					? translate( 'Currently restoring your site' )
+					: translate( 'Currently creating a downloadable backup of your site' )
 			}
 		>
 			{ 'restore' === action && (
@@ -73,11 +71,9 @@ function ProgressBanner( {
 						) }
 					</p>
 					<em>
-						{ 'queued' === status ? (
-							translate( 'Your restore will start in a moment.' )
-						) : (
-							translate( "We're on it! Your site is being restored." )
-						) }
+						{ 'queued' === status
+							? translate( 'Your restore will start in a moment.' )
+							: translate( "We're on it! Your site is being restored." ) }
 					</em>
 				</div>
 			) }
@@ -97,11 +93,9 @@ function ProgressBanner( {
 						) }
 					</p>
 					<em>
-						{ 0 < percent ? (
-							translate( "We're on it! Your download is being created." )
-						) : (
-							translate( 'The creation of your backup will start in a moment.' )
-						) }
+						{ 0 < percent
+							? translate( "We're on it! Your download is being created." )
+							: translate( 'The creation of your backup will start in a moment.' ) }
 					</em>
 				</div>
 			) }

--- a/client/my-sites/stats/activity-log-banner/success-banner.jsx
+++ b/client/my-sites/stats/activity-log-banner/success-banner.jsx
@@ -70,11 +70,9 @@ class SuccessBanner extends PureComponent {
 				onDismissClick={ this.handleDismiss }
 				status="success"
 				title={
-					backupUrl ? (
-						translate( 'Your backup has been successfully created' )
-					) : (
-						translate( 'Your site has been successfully restored' )
-					)
+					backupUrl
+						? translate( 'Your backup has been successfully created' )
+						: translate( 'Your site has been successfully restored' )
 				}
 			>
 				{ backupUrl ? (
@@ -89,11 +87,11 @@ class SuccessBanner extends PureComponent {
 				) }
 				{
 					<p>
-						{ backupUrl ? (
-							translate( 'We successfully restored your site back to %s!', { args: date } )
-						) : (
-							translate( 'We successfully created a backup of your site as of %s!', { args: date } )
-						) }
+						{ backupUrl
+							? translate( 'We successfully restored your site back to %s!', { args: date } )
+							: translate( 'We successfully created a backup of your site as of %s!', {
+									args: date,
+								} ) }
 					</p>
 				}
 				{ backupUrl ? (

--- a/client/my-sites/stats/activity-log-day/index.jsx
+++ b/client/my-sites/stats/activity-log-day/index.jsx
@@ -176,24 +176,20 @@ class ActivityLogDay extends Component {
 		return (
 			<div>
 				<div className="activity-log-day__day">
-					{ isToday ? (
-						translate( '%s — Today', {
-							args: formattedDate,
-							comment: 'Long date with today indicator, i.e. "January 1, 2017 — Today"',
-						} )
-					) : (
-						formattedDate
-					) }
+					{ isToday
+						? translate( '%s — Today', {
+								args: formattedDate,
+								comment: 'Long date with today indicator, i.e. "January 1, 2017 — Today"',
+							} )
+						: formattedDate }
 				</div>
 				<div className="activity-log-day__events">
-					{ isEmpty( logs ) ? (
-						noActivityText
-					) : (
-						translate( '%d Event', '%d Events', {
-							args: logs.length,
-							count: logs.length,
-						} )
-					) }
+					{ isEmpty( logs )
+						? noActivityText
+						: translate( '%d Event', '%d Events', {
+								args: logs.length,
+								count: logs.length,
+							} ) }
 				</div>
 			</div>
 		);

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -612,13 +612,13 @@ class ActivityLog extends Component {
 					</section>
 				) }
 				{ ! isNull( logs ) &&
-				isEmpty( logs ) && (
-					<EmptyContent
-						title={ translate( 'No activity for %s', {
-							args: this.getStartMoment().format( 'MMMM YYYY' ),
-						} ) }
-					/>
-				) }
+					isEmpty( logs ) && (
+						<EmptyContent
+							title={ translate( 'No activity for %s', {
+								args: this.getStartMoment().format( 'MMMM YYYY' ),
+							} ) }
+						/>
+					) }
 				{ ! isEmpty( logs ) && (
 					<section className="activity-log__wrapper">
 						{ visualGroups

--- a/client/my-sites/stats/most-popular/index.jsx
+++ b/client/my-sites/stats/most-popular/index.jsx
@@ -69,16 +69,16 @@ class StatsMostPopular extends Component {
 							</span>
 						</div>
 						{ ! percent &&
-						! requesting && (
-							<div className="most-popular__empty">
-								<span className="most-popular__notice">
-									{ translate( 'No popular day and time recorded', {
-										context: 'Message on stats insights page when no most popular data exists.',
-										comment: 'Should be limited to 32 characters to prevent wrapping',
-									} ) }
-								</span>
-							</div>
-						) }
+							! requesting && (
+								<div className="most-popular__empty">
+									<span className="most-popular__notice">
+										{ translate( 'No popular day and time recorded', {
+											context: 'Message on stats insights page when no most popular data exists.',
+											comment: 'Should be limited to 32 characters to prevent wrapping',
+										} ) }
+									</span>
+								</div>
+							) }
 					</div>
 				</Card>
 			</div>

--- a/client/my-sites/stats/post-performance/index.jsx
+++ b/client/my-sites/stats/post-performance/index.jsx
@@ -100,7 +100,7 @@ class StatsPostPerformance extends Component {
 			<div>
 				{ siteId && <QueryPosts siteId={ siteId } query={ query } /> }
 				{ siteId &&
-				post && <QueryPostStats siteId={ siteId } postId={ post.ID } fields={ [ 'views' ] } /> }
+					post && <QueryPostStats siteId={ siteId } postId={ post.ID } fields={ [ 'views' ] } /> }
 				<SectionHeader label={ translate( 'Latest Post Summary' ) } href={ summaryUrl } />
 				<Card className={ cardClass }>
 					<StatsModulePlaceholder isLoading={ loading && ! post } />

--- a/client/my-sites/stats/stats-comment-followers-page/index.jsx
+++ b/client/my-sites/stats/stats-comment-followers-page/index.jsx
@@ -115,10 +115,10 @@ class StatModuleFollowersPage extends Component {
 				<Card className={ classNames( classes ) }>
 					<div className="module-content">
 						{ noData &&
-						! hasError &&
-						! isLoading && (
-							<ErrorPanel className="is-empty-message" message={ translate( 'No followers' ) } />
-						) }
+							! hasError &&
+							! isLoading && (
+								<ErrorPanel className="is-empty-message" message={ translate( 'No followers' ) } />
+							) }
 
 						{ paginationSummary }
 

--- a/client/my-sites/stats/stats-comments/index.jsx
+++ b/client/my-sites/stats/stats-comments/index.jsx
@@ -138,13 +138,13 @@ class StatsComments extends Component {
 				<Card className={ classes }>
 					<div className="module-content">
 						{ noData &&
-						! hasError &&
-						! requestingCommentsStats && (
-							<StatsErrorPanel
-								className="is-empty-message"
-								message={ translate( 'No comments posted' ) }
-							/>
-						) }
+							! hasError &&
+							! requestingCommentsStats && (
+								<StatsErrorPanel
+									className="is-empty-message"
+									message={ translate( 'No comments posted' ) }
+								/>
+							) }
 
 						<StatsModuleSelectDropdown options={ selectOptions } onSelect={ this.changeFilter } />
 

--- a/client/my-sites/stats/stats-date-picker/index.jsx
+++ b/client/my-sites/stats/stats-date-picker/index.jsx
@@ -173,26 +173,26 @@ class StatsDatePicker extends Component {
 					<div className="stats-section-title">
 						<h3>{ sectionTitle }</h3>
 						{ showQueryDate &&
-						isAutoRefreshAllowedForQuery( query ) && (
-							<div
-								className="stats-date-picker__refresh-status"
-								ref={ this.bindStatusIndicator }
-								onMouseEnter={ this.showTooltip }
-								onMouseLeave={ this.hideTooltip }
-							>
-								<span className="stats-date-picker__update-date">
-									{ this.renderQueryDate() }
-									<Tooltip
-										isVisible={ this.state.isTooltipVisible }
-										onClose={ this.hideTooltip }
-										position="bottom"
-										context={ this.statusIndicator }
-									>
-										{ translate( 'Auto-refreshing every 3 minutes' ) }
-									</Tooltip>
-								</span>
-							</div>
-						) }
+							isAutoRefreshAllowedForQuery( query ) && (
+								<div
+									className="stats-date-picker__refresh-status"
+									ref={ this.bindStatusIndicator }
+									onMouseEnter={ this.showTooltip }
+									onMouseLeave={ this.hideTooltip }
+								>
+									<span className="stats-date-picker__update-date">
+										{ this.renderQueryDate() }
+										<Tooltip
+											isVisible={ this.state.isTooltipVisible }
+											onClose={ this.hideTooltip }
+											position="bottom"
+											context={ this.statusIndicator }
+										>
+											{ translate( 'Auto-refreshing every 3 minutes' ) }
+										</Tooltip>
+									</span>
+								</div>
+							) }
 					</div>
 				) }
 			</div>

--- a/client/my-sites/stats/stats-download-csv/index.jsx
+++ b/client/my-sites/stats/stats-download-csv/index.jsx
@@ -74,7 +74,7 @@ class StatsDownloadCsv extends Component {
 		return (
 			<Button compact onClick={ this.downloadCsv } disabled={ disabled } borderless={ borderless }>
 				{ siteId &&
-				statType && <QuerySiteStats statType={ statType } siteId={ siteId } query={ query } /> }
+					statType && <QuerySiteStats statType={ statType } siteId={ siteId } query={ query } /> }
 				<Gridicon icon="cloud-download" />{' '}
 				{ translate( 'Download data as CSV', {
 					context: 'Action shown in stats to download data as csv.',

--- a/client/my-sites/stats/stats-followers/index.jsx
+++ b/client/my-sites/stats/stats-followers/index.jsx
@@ -131,22 +131,25 @@ class StatModuleFollowers extends Component {
 					<div className="followers">
 						<div className="module-content">
 							{ noData &&
-							! hasError &&
-							! isLoading && (
-								<ErrorPanel className="is-empty-message" message={ translate( 'No followers' ) } />
-							) }
+								! hasError &&
+								! isLoading && (
+									<ErrorPanel
+										className="is-empty-message"
+										message={ translate( 'No followers' ) }
+									/>
+								) }
 
 							{ this.filterSelect() }
 
 							<div className="tab-content wpcom-followers stats-async-metabox-wrapper">
 								<div className="module-content-text module-content-text-stat">
 									{ wpcomData &&
-									!! wpcomData.total_wpcom && (
-										<p>
-											{ translate( 'Total WordPress.com Followers' ) }:{' '}
-											{ numberFormat( wpcomData.total_wpcom ) }
-										</p>
-									) }
+										!! wpcomData.total_wpcom && (
+											<p>
+												{ translate( 'Total WordPress.com Followers' ) }:{' '}
+												{ numberFormat( wpcomData.total_wpcom ) }
+											</p>
+										) }
 								</div>
 								<StatsListLegend value={ translate( 'Since' ) } label={ translate( 'Follower' ) } />
 								{ hasWpcomFollowers && (
@@ -162,12 +165,12 @@ class StatModuleFollowers extends Component {
 							<div className="tab-content email-followers stats-async-metabox-wrapper">
 								<div className="module-content-text module-content-text-stat">
 									{ emailData &&
-									!! emailData.total_email && (
-										<p>
-											{ translate( 'Total Email Followers' ) }:{' '}
-											{ numberFormat( emailData.total_email ) }
-										</p>
-									) }
+										!! emailData.total_email && (
+											<p>
+												{ translate( 'Total Email Followers' ) }:{' '}
+												{ numberFormat( emailData.total_email ) }
+											</p>
+										) }
 								</div>
 
 								<StatsListLegend value={ translate( 'Since' ) } label={ translate( 'Follower' ) } />

--- a/client/my-sites/stats/stats-module/index.jsx
+++ b/client/my-sites/stats/stats-module/index.jsx
@@ -159,7 +159,7 @@ class StatsModule extends Component {
 		return (
 			<div>
 				{ siteId &&
-				statType && <QuerySiteStats statType={ statType } siteId={ siteId } query={ query } /> }
+					statType && <QuerySiteStats statType={ statType } siteId={ siteId } query={ query } /> }
 				{ ! isAllTime && (
 					<SectionHeader
 						className={ headerClass }
@@ -180,18 +180,18 @@ class StatsModule extends Component {
 					<StatsModulePlaceholder isLoading={ isLoading } />
 					<StatsList moduleName={ path } data={ data } />
 					{ this.props.showSummaryLink &&
-					displaySummaryLink && <StatsModuleExpand href={ summaryLink } /> }
+						displaySummaryLink && <StatsModuleExpand href={ summaryLink } /> }
 					{ summary &&
-					'countryviews' === path && (
-						<UpgradeNudge
-							title={ translate( 'Add Google Analytics' ) }
-							message={ translate(
-								'Upgrade to a Business Plan for Google Analytics integration.'
-							) }
-							event="googleAnalytics-stats-countries"
-							feature="google-analytics"
-						/>
-					) }
+						'countryviews' === path && (
+							<UpgradeNudge
+								title={ translate( 'Add Google Analytics' ) }
+								message={ translate(
+									'Upgrade to a Business Plan for Google Analytics integration.'
+								) }
+								event="googleAnalytics-stats-countries"
+								feature="google-analytics"
+							/>
+						) }
 				</Card>
 				{ isAllTime && (
 					<div className="stats-module__footer-actions">

--- a/client/my-sites/stats/stats-post-detail/index.jsx
+++ b/client/my-sites/stats/stats-post-detail/index.jsx
@@ -133,44 +133,46 @@ class StatsPostDetail extends Component {
 				<StatsPlaceholder isLoading={ isLoading } />
 
 				{ ! isLoading &&
-				countViews === 0 && (
-					<EmptyContent
-						title={ noViewsLabel }
-						line={ translate( 'Learn some tips to attract more visitors' ) }
-						action={ translate( 'Get more traffic!' ) }
-						actionURL="https://en.support.wordpress.com/getting-more-views-and-traffic/"
-						actionTarget="blank"
-						illustration="/calypso/images/stats/illustration-stats.svg"
-						illustrationWidth={ 150 }
-					/>
-				) }
+					countViews === 0 && (
+						<EmptyContent
+							title={ noViewsLabel }
+							line={ translate( 'Learn some tips to attract more visitors' ) }
+							action={ translate( 'Get more traffic!' ) }
+							actionURL="https://en.support.wordpress.com/getting-more-views-and-traffic/"
+							actionTarget="blank"
+							illustration="/calypso/images/stats/illustration-stats.svg"
+							illustrationWidth={ 150 }
+						/>
+					) }
 
 				{ ! isLoading &&
-				countViews > 0 && (
-					<div>
-						<PostSummary siteId={ siteId } postId={ postId } />
+					countViews > 0 && (
+						<div>
+							<PostSummary siteId={ siteId } postId={ postId } />
 
-						{ !! postId && <PostLikes siteId={ siteId } postId={ postId } postType={ postType } /> }
+							{ !! postId && (
+								<PostLikes siteId={ siteId } postId={ postId } postType={ postType } />
+							) }
 
-						<PostMonths
-							dataKey="years"
-							title={ translate( 'Months and Years' ) }
-							total={ translate( 'Total' ) }
-							siteId={ siteId }
-							postId={ postId }
-						/>
+							<PostMonths
+								dataKey="years"
+								title={ translate( 'Months and Years' ) }
+								total={ translate( 'Total' ) }
+								siteId={ siteId }
+								postId={ postId }
+							/>
 
-						<PostMonths
-							dataKey="averages"
-							title={ translate( 'Average per Day' ) }
-							total={ translate( 'Overall' ) }
-							siteId={ siteId }
-							postId={ postId }
-						/>
+							<PostMonths
+								dataKey="averages"
+								title={ translate( 'Average per Day' ) }
+								total={ translate( 'Overall' ) }
+								siteId={ siteId }
+								postId={ postId }
+							/>
 
-						<PostWeeks siteId={ siteId } postId={ postId } />
-					</div>
-				) }
+							<PostWeeks siteId={ siteId } postId={ postId } />
+						</div>
+					) }
 
 				<WebPreview
 					showPreview={ this.state.showPreview }

--- a/client/my-sites/themes/single-site-jetpack.jsx
+++ b/client/my-sites/themes/single-site-jetpack.jsx
@@ -91,16 +91,16 @@ const ConnectedSingleSiteJetpack = connectOptions( props => {
 			<SidebarNavigation />
 			<CurrentTheme siteId={ siteId } />
 			{ ! requestingSitePlans &&
-			! hasUnlimitedPremiumThemes && (
-				<Banner
-					plan={ PLAN_JETPACK_PREMIUM }
-					title={ translate( 'Access all our premium themes with our Professional plan!' ) }
-					description={ translate(
-						'Get advanced customization, more storage space, and video support along with all your new themes.'
-					) }
-					event="themes_plans_free_personal_premium"
-				/>
-			) }
+				! hasUnlimitedPremiumThemes && (
+					<Banner
+						plan={ PLAN_JETPACK_PREMIUM }
+						title={ translate( 'Access all our premium themes with our Professional plan!' ) }
+						description={ translate(
+							'Get advanced customization, more storage space, and video support along with all your new themes.'
+						) }
+						event="themes_plans_free_personal_premium"
+					/>
+				) }
 			<ThemeShowcase
 				{ ...props }
 				siteId={ siteId }

--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -212,13 +212,13 @@ class Upload extends React.Component {
 		return (
 			<Card>
 				{ ! inProgress &&
-				! complete && <UploadDropZone doUpload={ uploadAction } disabled={ disabled } /> }
+					! complete && <UploadDropZone doUpload={ uploadAction } disabled={ disabled } /> }
 				{ inProgress && this.renderProgressBar() }
 				{ complete && ! failed && uploadedTheme && this.renderTheme() }
 				{ complete &&
-				this.props.isSiteAutomatedTransfer && (
-					<WpAdminAutoLogin site={ this.props.selectedSite } />
-				) }
+					this.props.isSiteAutomatedTransfer && (
+						<WpAdminAutoLogin site={ this.props.selectedSite } />
+					) }
 			</Card>
 		);
 	}

--- a/client/my-sites/themes/themes-magic-search-card/index.jsx
+++ b/client/my-sites/themes/themes-magic-search-card/index.jsx
@@ -305,26 +305,26 @@ class ThemesMagicSearchCard extends React.Component {
 					>
 						{ searchField }
 						{ ! isMobile() &&
-						this.state.searchInput !== '' && (
-							<div className="themes-magic-search-card__icon">
-								<Gridicon
-									icon="cross"
-									className="themes-magic-search-card__icon-close"
-									tabIndex="0"
-									onClick={ this.clearSearch }
-									aria-controls={ 'search-component-magic-search' }
-									aria-label={ translate( 'Clear Search' ) }
-								/>
-							</div>
-						) }
+							this.state.searchInput !== '' && (
+								<div className="themes-magic-search-card__icon">
+									<Gridicon
+										icon="cross"
+										className="themes-magic-search-card__icon-close"
+										tabIndex="0"
+										onClick={ this.clearSearch }
+										aria-controls={ 'search-component-magic-search' }
+										aria-label={ translate( 'Clear Search' ) }
+									/>
+								</div>
+							) }
 						{ isPremiumThemesEnabled &&
-						showTierThemesControl && (
-							<SegmentedControl
-								initialSelected={ this.props.tier }
-								options={ tiers }
-								onSelect={ this.props.select }
-							/>
-						) }
+							showTierThemesControl && (
+								<SegmentedControl
+									initialSelected={ this.props.tier }
+									options={ tiers }
+									onSelect={ this.props.select }
+								/>
+							) }
 					</div>
 				</StickyPanel>
 				<div onClick={ this.handleClickInside }>

--- a/client/my-sites/themes/themes-site-selector-modal.jsx
+++ b/client/my-sites/themes/themes-site-selector-modal.jsx
@@ -124,11 +124,11 @@ class ThemesSiteSelectorModal extends React.Component {
 						mainAction={ this.trackAndCallAction }
 						mainActionLabel={ selectedOption.label }
 						getMainUrl={
-							selectedOption.getUrl ? (
-								function( siteId ) {
-									return selectedOption.getUrl( selectedThemeId, siteId );
-								}
-							) : null
+							selectedOption.getUrl
+								? function( siteId ) {
+										return selectedOption.getUrl( selectedThemeId, siteId );
+									}
+								: null
 						}
 					>
 						<Theme isActionable={ false } theme={ theme } />

--- a/client/my-sites/types/main.jsx
+++ b/client/my-sites/types/main.jsx
@@ -31,16 +31,16 @@ function Types( { siteId, query, postType, postTypeSupported, userCanEdit } ) {
 			<PageViewTracker path={ siteId ? '/types/:site' : '/types' } title="Custom Post Type" />
 			<SidebarNavigation />
 			{ false !== userCanEdit &&
-			false !== postTypeSupported && [
-				<PostTypeFilter key="filter" query={ userCanEdit ? query : null } />,
-				<PostTypeList
-					key="list"
-					query={ userCanEdit ? query : null }
-					largeTitles={ true }
-					wrapTitles={ true }
-					scrollContainer={ document.body }
-				/>,
-			] }
+				false !== postTypeSupported && [
+					<PostTypeFilter key="filter" query={ userCanEdit ? query : null } />,
+					<PostTypeList
+						key="list"
+						query={ userCanEdit ? query : null }
+						largeTitles={ true }
+						wrapTitles={ true }
+						scrollContainer={ document.body }
+					/>,
+				] }
 			{ false === postTypeSupported && <PostTypeUnsupported type={ query.type } /> }
 			{ false === userCanEdit && <PostTypeForbidden /> }
 		</Main>

--- a/client/post-editor/edit-post-status/index.jsx
+++ b/client/post-editor/edit-post-status/index.jsx
@@ -104,39 +104,43 @@ export class EditPostStatus extends Component {
 				{ this.renderPostScheduling() }
 				{ this.renderPostVisibility() }
 				{ this.props.type === 'post' &&
-				! isPostPrivate &&
-				! isPasswordProtected && (
-					<label className="edit-post-status__sticky">
-						<span className="edit-post-status__label-text">
-							{ translate( 'Stick to the front page' ) }
-							<InfoPopover position="top right" gaEventCategory="Editor" popoverName="Sticky Post">
-								{ translate( 'Sticky posts will appear at the top of the posts listing.' ) }
-							</InfoPopover>
-						</span>
-						<FormToggle
-							checked={ isSticky }
-							onChange={ this.toggleStickyStatus }
-							aria-label={ translate( 'Stick post to the front page' ) }
-						/>
-					</label>
-				) }
+					! isPostPrivate &&
+					! isPasswordProtected && (
+						<label className="edit-post-status__sticky">
+							<span className="edit-post-status__label-text">
+								{ translate( 'Stick to the front page' ) }
+								<InfoPopover
+									position="top right"
+									gaEventCategory="Editor"
+									popoverName="Sticky Post"
+								>
+									{ translate( 'Sticky posts will appear at the top of the posts listing.' ) }
+								</InfoPopover>
+							</span>
+							<FormToggle
+								checked={ isSticky }
+								onChange={ this.toggleStickyStatus }
+								aria-label={ translate( 'Stick post to the front page' ) }
+							/>
+						</label>
+					) }
 				{ ! isPublished &&
-				! isScheduled &&
-				canPublish && (
-					<label className="edit-post-status__pending-review">
-						<span className="edit-post-status__label-text">
-							{ translate( 'Pending review' ) }
-							<InfoPopover position="top right">
-								{ translate( 'Flag this post to be reviewed for approval.' ) }
-							</InfoPopover>
-						</span>
-						<FormToggle
-							checked={ isPending }
-							onChange={ this.togglePendingStatus }
-							aria-label={ translate( 'Request review for post' ) }
-						/>
-					</label>
-				) }
+					! isScheduled &&
+					canPublish && (
+						<label className="edit-post-status__pending-review">
+							<span className="edit-post-status__label-text">
+								{ translate( 'Pending review' ) }
+								<InfoPopover position="top right">
+									{ translate( 'Flag this post to be reviewed for approval.' ) }
+								</InfoPopover>
+							</span>
+							<FormToggle
+								checked={ isPending }
+								onChange={ this.togglePendingStatus }
+								aria-label={ translate( 'Request review for post' ) }
+							/>
+						</label>
+					) }
 				{ ( isPublished || isScheduled || ( isPending && ! canPublish ) ) && (
 					<Button
 						className="edit-post-status__revert-to-draft"

--- a/client/post-editor/editor-action-bar/index.jsx
+++ b/client/post-editor/editor-action-bar/index.jsx
@@ -67,9 +67,9 @@ class EditorActionBar extends Component {
 				</div>
 				<div className="editor-action-bar__cell is-right">
 					{ this.props.post &&
-					this.props.type === 'post' &&
-					! isPasswordProtected &&
-					! isPostPrivate && <EditorSticky /> }
+						this.props.type === 'post' &&
+						! isPasswordProtected &&
+						! isPostPrivate && <EditorSticky /> }
 					{ utils.isPublished( this.props.savedPost ) && (
 						<Button
 							href={ this.props.savedPost.URL }

--- a/client/post-editor/editor-action-bar/view-label.jsx
+++ b/client/post-editor/editor-action-bar/view-label.jsx
@@ -34,8 +34,8 @@ function EditorActionBarViewLabel( { translate, siteId, typeSlug, type } ) {
 	return (
 		<span className="editor-action-bar__view-label">
 			{ siteId &&
-			'page' !== typeSlug &&
-			'post' !== typeSlug && <QueryPostTypes siteId={ siteId } /> }
+				'page' !== typeSlug &&
+				'post' !== typeSlug && <QueryPostTypes siteId={ siteId } /> }
 			{ label }
 		</span>
 	);

--- a/client/post-editor/editor-ground-control/index.jsx
+++ b/client/post-editor/editor-ground-control/index.jsx
@@ -225,14 +225,14 @@ export class EditorGroundControl extends PureComponent {
 							</button>
 						) }
 						{ ! isSaveAvailable &&
-						showingStatusLabel && (
-							<span
-								className="editor-ground-control__save-status"
-								data-e2e-status={ isSaving ? 'Saving…' : 'Saved' }
-							>
-								{ isSaving ? translate( 'Saving…' ) : translate( 'Saved' ) }
-							</span>
-						) }
+							showingStatusLabel && (
+								<span
+									className="editor-ground-control__save-status"
+									data-e2e-status={ isSaving ? 'Saving…' : 'Saved' }
+								>
+									{ isSaving ? translate( 'Saving…' ) : translate( 'Saved' ) }
+								</span>
+							) }
 					</div>
 				) }
 				{ hasRevisions && (

--- a/client/post-editor/editor-more-options/copy-post.jsx
+++ b/client/post-editor/editor-more-options/copy-post.jsx
@@ -91,20 +91,16 @@ class EditorMoreOptionsCopyPost extends Component {
 				<EditorDrawerLabel
 					labelText={ this.isPost() ? translate( 'Copy Post' ) : translate( 'Copy Page' ) }
 					helpText={
-						this.isPost() ? (
-							translate( "Pick a post and we'll copy the title, content, tags and categories." )
-						) : (
-							translate( "Pick a page and we'll copy the title and content." )
-						)
+						this.isPost()
+							? translate( "Pick a post and we'll copy the title, content, tags and categories." )
+							: translate( "Pick a page and we'll copy the title and content." )
 					}
 				>
 					<Button borderless compact onClick={ this.openDialog }>
 						<Gridicon icon="clipboard" />
-						{ this.isPost() ? (
-							translate( 'Select a post to copy' )
-						) : (
-							translate( 'Select a page to copy' )
-						) }
+						{ this.isPost()
+							? translate( 'Select a post to copy' )
+							: translate( 'Select a page to copy' ) }
 					</Button>
 				</EditorDrawerLabel>
 				<Dialog
@@ -115,18 +111,14 @@ class EditorMoreOptionsCopyPost extends Component {
 					additionalClassNames="editor-more-options__copy-post-select-dialog"
 				>
 					<FormSectionHeading>
-						{ this.isPost() ? (
-							translate( 'Select a post to copy' )
-						) : (
-							translate( 'Select a page to copy' )
-						) }
+						{ this.isPost()
+							? translate( 'Select a post to copy' )
+							: translate( 'Select a page to copy' ) }
 					</FormSectionHeading>
 					<p>
-						{ this.isPost() ? (
-							translate( "Pick a post and we'll copy the title, content, tags and categories." )
-						) : (
-							translate( "Pick a page and we'll copy the title and content." )
-						) }
+						{ this.isPost()
+							? translate( "Pick a post and we'll copy the title, content, tags and categories." )
+							: translate( "Pick a page and we'll copy the title and content." ) }
 					</p>
 					{ siteId && (
 						<PostSelector

--- a/client/post-editor/editor-post-type/index.jsx
+++ b/client/post-editor/editor-post-type/index.jsx
@@ -57,8 +57,8 @@ function EditorPostType( { translate, siteId, typeSlug, type, globalId, isSettin
 	return (
 		<span className={ classes }>
 			{ siteId &&
-			'page' !== typeSlug &&
-			'post' !== typeSlug && <QueryPostTypes siteId={ siteId } /> }
+				'page' !== typeSlug &&
+				'post' !== typeSlug && <QueryPostTypes siteId={ siteId } /> }
 			{ label } <PostStatus globalId={ globalId } showAll showIcon={ false } />
 		</span>
 	);

--- a/client/post-editor/editor-revisions-list/item.jsx
+++ b/client/post-editor/editor-revisions-list/item.jsx
@@ -60,11 +60,11 @@ class EditorRevisionsListItem extends PureComponent {
 					) }
 
 					{ this.props.revision.changes.added === 0 &&
-					this.props.revision.changes.removed === 0 && (
-						<span className="editor-revisions-list__minor-changes">
-							{ this.props.translate( 'minor changes' ) }
-						</span>
-					) }
+						this.props.revision.changes.removed === 0 && (
+							<span className="editor-revisions-list__minor-changes">
+								{ this.props.translate( 'minor changes' ) }
+							</span>
+						) }
 				</div>
 			</button>
 		);

--- a/client/post-editor/editor-status-label/placeholder.jsx
+++ b/client/post-editor/editor-status-label/placeholder.jsx
@@ -41,8 +41,8 @@ function EditorStatusLabelPlaceholder( { translate, siteId, typeSlug, type, clas
 	return (
 		<button className={ classes }>
 			{ 'post' !== typeSlug &&
-			'page' !== typeSlug &&
-			siteId && <QueryPostTypes siteId={ siteId } /> }
+				'page' !== typeSlug &&
+				siteId && <QueryPostTypes siteId={ siteId } /> }
 			<strong>{ label }</strong>
 		</button>
 	);

--- a/client/post-editor/editor-title/index.jsx
+++ b/client/post-editor/editor-title/index.jsx
@@ -94,13 +94,13 @@ class EditorTitle extends Component {
 		return (
 			<div className={ classes }>
 				{ post &&
-				post.ID &&
-				! PostUtils.isPage( post ) && (
-					<EditorPermalink
-						path={ isPermalinkEditable ? PostUtils.getPermalinkBasePath( post ) : post.URL }
-						isEditable={ isPermalinkEditable }
-					/>
-				) }
+					post.ID &&
+					! PostUtils.isPage( post ) && (
+						<EditorPermalink
+							path={ isPermalinkEditable ? PostUtils.getPermalinkBasePath( post ) : post.URL }
+							isEditable={ isPermalinkEditable }
+						/>
+					) }
 				<TrackInputChanges onNewValue={ this.recordChangeStats }>
 					<TextareaAutosize
 						tabIndex={ tabIndex }

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -401,11 +401,9 @@ export const PostEditor = createReactClass( {
 									{ this.state.post && isPage && site ? (
 										<EditorPageSlug
 											path={
-												this.state.post.URL && this.state.post.URL !== siteURL ? (
-													utils.getPagePath( this.state.post )
-												) : (
-													siteURL
-												)
+												this.state.post.URL && this.state.post.URL !== siteURL
+													? utils.getPagePath( this.state.post )
+													: siteURL
 											}
 										/>
 									) : null }

--- a/client/reader/conversations/intro.jsx
+++ b/client/reader/conversations/intro.jsx
@@ -64,33 +64,31 @@ class ConversationsIntro extends React.Component {
 				<div className="conversations__intro-header">
 					<div className="conversations__intro-copy">
 						<span>
-							{ isInternal ? (
-								translate(
-									'{{strong}}Welcome to A8C Conversations{{/strong}}, where you can read ' +
-										'and reply to all your P2 conversations in one place. ' +
-										"Automattic P2 posts you've liked or commented on " +
-										'will appear when they have new comments. ' +
-										'{{a}}More info. {{/a}}',
-									{
-										components: {
-											strong: <strong />,
-											a: <a href="http://wp.me/p5PDj3-44u" />,
-										},
-									}
-								)
-							) : (
-								translate(
-									'{{strong}}Welcome to Conversations.{{/strong}} You can read ' +
-										'and reply to all your conversations in one place. ' +
-										"WordPress posts you've liked or commented on " +
-										'will appear when they have new comments.',
-									{
-										components: {
-											strong: <strong />,
-										},
-									}
-								)
-							) }
+							{ isInternal
+								? translate(
+										'{{strong}}Welcome to A8C Conversations{{/strong}}, where you can read ' +
+											'and reply to all your P2 conversations in one place. ' +
+											"Automattic P2 posts you've liked or commented on " +
+											'will appear when they have new comments. ' +
+											'{{a}}More info. {{/a}}',
+										{
+											components: {
+												strong: <strong />,
+												a: <a href="http://wp.me/p5PDj3-44u" />,
+											},
+										}
+									)
+								: translate(
+										'{{strong}}Welcome to Conversations.{{/strong}} You can read ' +
+											'and reply to all your conversations in one place. ' +
+											"WordPress posts you've liked or commented on " +
+											'will appear when they have new comments.',
+										{
+											components: {
+												strong: <strong />,
+											},
+										}
+									) }
 						</span>
 					</div>
 					<div className="conversations__intro-character" />

--- a/client/reader/following-manage/feed-search-results.jsx
+++ b/client/reader/following-manage/feed-search-results.jsx
@@ -93,19 +93,19 @@ class FollowingManageSearchFeedsResults extends React.Component {
 					rowRenderer={ siteRowRenderer }
 				/>
 				{ ! showMoreResults &&
-				searchResultsCount > 10 && (
-					<div className="following-manage__show-more">
-						<Button
-							compact
-							icon
-							onClick={ onShowMoreResultsClicked }
-							className="following-manage__show-more-button button"
-						>
-							<Gridicon icon="chevron-down" />
-							{ translate( 'Show more' ) }
-						</Button>
-					</div>
-				) }
+					searchResultsCount > 10 && (
+						<div className="following-manage__show-more">
+							<Button
+								compact
+								icon
+								onClick={ onShowMoreResultsClicked }
+								className="following-manage__show-more-button button"
+							>
+								<Gridicon icon="chevron-down" />
+								{ translate( 'Show more' ) }
+							</Button>
+						</div>
+					) }
 			</div>
 		);
 	}

--- a/client/reader/following-manage/index.jsx
+++ b/client/reader/following-manage/index.jsx
@@ -239,23 +239,23 @@ class FollowingManage extends Component {
 					) }
 				</div>
 				{ hasFollows &&
-				! sitesQuery && (
-					<RecommendedSites
-						sites={ take( filteredRecommendedSites, 2 ) }
-						followSource={ READER_FOLLOWING_MANAGE_RECOMMENDATION }
-					/>
-				) }
+					! sitesQuery && (
+						<RecommendedSites
+							sites={ take( filteredRecommendedSites, 2 ) }
+							followSource={ READER_FOLLOWING_MANAGE_RECOMMENDATION }
+						/>
+					) }
 				{ !! sitesQuery &&
-				! isFollowByUrlWithNoSearchResults && (
-					<FollowingManageSearchFeedsResults
-						searchResults={ searchResults }
-						showMoreResults={ showMoreResults }
-						onShowMoreResultsClicked={ this.handleShowMoreClicked }
-						width={ this.state.width }
-						searchResultsCount={ searchResultsCount }
-						query={ sitesQuery }
-					/>
-				) }
+					! isFollowByUrlWithNoSearchResults && (
+						<FollowingManageSearchFeedsResults
+							searchResults={ searchResults }
+							showMoreResults={ showMoreResults }
+							onShowMoreResultsClicked={ this.handleShowMoreClicked }
+							width={ this.state.width }
+							searchResultsCount={ searchResultsCount }
+							query={ sitesQuery }
+						/>
+					) }
 				{ showExistingSubscriptions && (
 					<FollowingManageSubscriptions
 						width={ this.state.width }

--- a/client/reader/list-stream/header.jsx
+++ b/client/reader/list-stream/header.jsx
@@ -50,16 +50,16 @@ const ListStreamHeader = ( {
 			) }
 
 			{ showEdit &&
-			editUrl && (
-				<div className="list-stream__header-edit">
-					<a href={ editUrl } rel={ isExternal( editUrl ) ? 'external' : '' }>
-						<span className="list-stream__header-action-icon">
-							<Gridicon icon="cog" size={ 24 } />
-						</span>
-						<span className="list-stream__header-action-label">{ translate( 'Edit' ) }</span>
-					</a>
-				</div>
-			) }
+				editUrl && (
+					<div className="list-stream__header-edit">
+						<a href={ editUrl } rel={ isExternal( editUrl ) ? 'external' : '' }>
+							<span className="list-stream__header-action-icon">
+								<Gridicon icon="cog" size={ 24 } />
+							</span>
+							<span className="list-stream__header-action-label">{ translate( 'Edit' ) }</span>
+						</a>
+					</div>
+				) }
 		</Card>
 	);
 };

--- a/client/reader/sidebar/index.jsx
+++ b/client/reader/sidebar/index.jsx
@@ -198,34 +198,34 @@ export const ReaderSidebar = createReactClass( {
 							) }
 							<ReaderSidebarTeams teams={ this.props.teams } path={ this.props.path } />
 							{ config.isEnabled( 'reader/conversations' ) &&
-							isAutomatticTeamMember( this.props.teams ) && (
-								<li
-									className={ ReaderSidebarHelper.itemLinkClass(
-										'/read/conversations/a8c',
-										this.props.path,
-										{
-											'sidebar-streams__conversations': true,
-										}
-									) }
-								>
-									<a
-										href="/read/conversations/a8c"
-										onClick={ this.handleReaderSidebarA8cConversationsClicked }
+								isAutomatticTeamMember( this.props.teams ) && (
+									<li
+										className={ ReaderSidebarHelper.itemLinkClass(
+											'/read/conversations/a8c',
+											this.props.path,
+											{
+												'sidebar-streams__conversations': true,
+											}
+										) }
 									>
-										<svg
-											className={ 'gridicon gridicon-automattic-conversations' }
-											width="24"
-											height="24"
-											xmlns="http://www.w3.org/2000/svg"
-											viewBox="0 0 24 24"
+										<a
+											href="/read/conversations/a8c"
+											onClick={ this.handleReaderSidebarA8cConversationsClicked }
 										>
-											<path d="M12.2 7.1c.5.3.6 1 .3 1.4L10 12.4c-.3.5-1 .7-1.4.3-.6-.3-.8-1-.4-1.5l2.5-3.9c.3-.4 1-.5 1.5-.2zM17.3 21.2h2.8c1 0 1.9-.8 1.9-1.9v-4.7c0-1-.8-1.9-1.9-1.9h-7.6c-1 .1-1.7.9-1.7 1.9v4.7c0 1 .8 1.8 1.7 1.9h2V24l2.8-2.8z" />
-											<path d="M8.8 15.2c-2.7-.7-4.1-2.9-4.1-5.2 0-5.8 5.8-5.7 5.8-5.7 5.8 0 5.8 5.7 5.8 5.7 0 .3 0 .6-.1.8H19v-.7C19 1.6 10.4 2 10.4 2c-8.6 0-8.5 8.1-8.5 8.1 0 3.5 2.7 6.8 6.9 7.5v-2.4z" />
-										</svg>
-										<span className="menu-link-text">A8C Conversations</span>
-									</a>
-								</li>
-							) }
+											<svg
+												className={ 'gridicon gridicon-automattic-conversations' }
+												width="24"
+												height="24"
+												xmlns="http://www.w3.org/2000/svg"
+												viewBox="0 0 24 24"
+											>
+												<path d="M12.2 7.1c.5.3.6 1 .3 1.4L10 12.4c-.3.5-1 .7-1.4.3-.6-.3-.8-1-.4-1.5l2.5-3.9c.3-.4 1-.5 1.5-.2zM17.3 21.2h2.8c1 0 1.9-.8 1.9-1.9v-4.7c0-1-.8-1.9-1.9-1.9h-7.6c-1 .1-1.7.9-1.7 1.9v4.7c0 1 .8 1.8 1.7 1.9h2V24l2.8-2.8z" />
+												<path d="M8.8 15.2c-2.7-.7-4.1-2.9-4.1-5.2 0-5.8 5.8-5.7 5.8-5.7 5.8 0 5.8 5.7 5.8 5.7 0 .3 0 .6-.1.8H19v-.7C19 1.6 10.4 2 10.4 2c-8.6 0-8.5 8.1-8.5 8.1 0 3.5 2.7 6.8 6.9 7.5v-2.4z" />
+											</svg>
+											<span className="menu-link-text">A8C Conversations</span>
+										</a>
+									</li>
+								) }
 
 							{ isDiscoverEnabled() ? (
 								<li

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -478,11 +478,11 @@ class ReaderStream extends React.Component {
 		return (
 			<TopLevel className={ classnames( 'following', this.props.className ) }>
 				{ this.props.isMain &&
-				this.props.showMobileBackToSidebar && (
-					<MobileBackToSidebar>
-						<h1>{ this.props.translate( 'Streams' ) }</h1>
-					</MobileBackToSidebar>
-				) }
+					this.props.showMobileBackToSidebar && (
+						<MobileBackToSidebar>
+							<h1>{ this.props.translate( 'Streams' ) }</h1>
+						</MobileBackToSidebar>
+					) }
 
 				<UpdateNotice count={ this.state.updateCount } onClick={ this.showUpdates } />
 				{ this.props.children }

--- a/client/signup/steps/site/index.jsx
+++ b/client/signup/steps/site/index.jsx
@@ -101,7 +101,8 @@ class Site extends React.Component {
 			blog_name: fields.site,
 			blog_title: fields.site,
 			validate: true,
-		}, function( error, response ) {
+		},
+		function( error, response ) {
 			let messages = {},
 				errorObject = {};
 

--- a/client/state/comments/from-api.js
+++ b/client/state/comments/from-api.js
@@ -63,7 +63,7 @@ export const fromApi = ( siteId, data ) => {
 						isLiked: Boolean( data.i_like ),
 					},
 					data.parent &&
-					data.parent.type === 'comment' && { parentId: parseInt( data.parent.ID, 10 ) },
+						data.parent.type === 'comment' && { parentId: parseInt( data.parent.ID, 10 ) },
 					{
 						postId: parseInt( data.post.ID, 10 ),
 						siteId,

--- a/client/state/data-layer/wpcom/activity-log/rewind/activate/index.js
+++ b/client/state/data-layer/wpcom/activity-log/rewind/activate/index.js
@@ -36,7 +36,7 @@ export const storeAndAnnounce = ( { dispatch }, { siteId, noticeId } ) => {
 	dispatch( {
 		type: JETPACK_CREDENTIALS_STORE,
 		credentials: { main: { type: 'auto' } }, // fake for now until data actually comes through
-		siteId
+		siteId,
 	} );
 
 	dispatch(

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -943,31 +943,7 @@
     },
     "cheerio": {
       "version": "1.0.0-rc.2",
-      "dev": true,
-      "dependencies": {
-        "entities": {
-          "version": "1.1.1",
-          "dev": true
-        },
-        "htmlparser2": {
-          "version": "3.9.2",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "2.3.3",
-          "dev": true,
-          "dependencies": {
-            "inherits": {
-              "version": "2.0.3",
-              "dev": true
-            }
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.3",
-          "dev": true
-        }
-      }
+      "dev": true
     },
     "chokidar": {
       "version": "1.7.0",
@@ -1231,11 +1207,11 @@
       "version": "1.0.2"
     },
     "cosmiconfig": {
-      "version": "2.2.2",
+      "version": "3.1.0",
       "dev": true,
       "dependencies": {
-        "minimist": {
-          "version": "1.2.0",
+        "parse-json": {
+          "version": "3.0.0",
           "dev": true
         }
       }
@@ -1532,12 +1508,11 @@
     },
     "dom-serializer": {
       "version": "0.1.0",
+      "dev": true,
       "dependencies": {
         "domelementtype": {
-          "version": "1.1.3"
-        },
-        "entities": {
-          "version": "1.1.1"
+          "version": "1.1.3",
+          "dev": true
         }
       }
     },
@@ -1545,13 +1520,16 @@
       "version": "1.1.7"
     },
     "domelementtype": {
-      "version": "1.3.0"
+      "version": "1.3.0",
+      "dev": true
     },
     "domhandler": {
-      "version": "2.3.0"
+      "version": "2.4.1",
+      "dev": true
     },
     "domutils": {
-      "version": "1.5.1"
+      "version": "1.5.1",
+      "dev": true
     },
     "dot-case": {
       "version": "1.1.2"
@@ -1670,7 +1648,8 @@
       "version": "3.4.1"
     },
     "entities": {
-      "version": "1.0.0"
+      "version": "1.1.1",
+      "dev": true
     },
     "enzyme": {
       "version": "3.1.0",
@@ -3079,7 +3058,24 @@
       "dev": true
     },
     "htmlparser2": {
-      "version": "3.8.3"
+      "version": "3.9.2",
+      "dev": true,
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.3",
+          "dev": true,
+          "dependencies": {
+            "inherits": {
+              "version": "2.0.3",
+              "dev": true
+            }
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.3",
+          "dev": true
+        }
+      }
     },
     "http-errors": {
       "version": "1.6.2",
@@ -5369,7 +5365,7 @@
       }
     },
     "postcss-less": {
-      "version": "1.1.2",
+      "version": "1.1.1",
       "dev": true
     },
     "postcss-media-query-parser": {
@@ -5426,9 +5422,7 @@
       "version": "3.3.0"
     },
     "postcss-values-parser": {
-      "version": "1.3.0",
-      "from": "git://github.com/lydell/postcss-values-parser.git#af2c80b2bb558a6e7d61540d97f068f9fa162b38",
-      "resolved": "git://github.com/lydell/postcss-values-parser.git#af2c80b2bb558a6e7d61540d97f068f9fa162b38",
+      "version": "1.3.1",
       "dev": true
     },
     "prebuild-install": {
@@ -5451,9 +5445,9 @@
       "version": "0.2.0"
     },
     "prettier": {
-      "version": "1.6.1",
-      "from": "git://github.com/automattic/calypso-prettier.git#14307ba5cc6bcfc00243f5e2d1b25c72d52c28c8",
-      "resolved": "git://github.com/automattic/calypso-prettier.git#14307ba5cc6bcfc00243f5e2d1b25c72d52c28c8",
+      "version": "1.7.4",
+      "from": "git://github.com/automattic/calypso-prettier.git#717e62ee3650aa6f8720c86474ce4dba78bd0c36",
+      "resolved": "git://github.com/automattic/calypso-prettier.git#717e62ee3650aa6f8720c86474ce4dba78bd0c36",
       "dev": true,
       "dependencies": {
         "@types/node": {
@@ -5471,11 +5465,15 @@
           }
         },
         "babylon": {
-          "version": "7.0.0-beta.22",
+          "version": "7.0.0-beta.23",
+          "dev": true
+        },
+        "camelcase": {
+          "version": "4.1.0",
           "dev": true
         },
         "chalk": {
-          "version": "2.0.1",
+          "version": "2.1.0",
           "dev": true,
           "dependencies": {
             "ansi-styles": {
@@ -5504,25 +5502,13 @@
           "version": "2.0.0",
           "dev": true
         },
-        "jest-matcher-utils": {
-          "version": "20.0.3",
-          "dev": true,
-          "dependencies": {
-            "chalk": {
-              "version": "1.1.3",
-              "dev": true
-            }
-          }
+        "jest-docblock": {
+          "version": "21.3.0-beta.8",
+          "dev": true
         },
         "jest-validate": {
-          "version": "20.0.3",
-          "dev": true,
-          "dependencies": {
-            "chalk": {
-              "version": "1.1.3",
-              "dev": true
-            }
-          }
+          "version": "21.1.0",
+          "dev": true
         },
         "leven": {
           "version": "2.1.0",
@@ -5534,42 +5520,6 @@
         },
         "parse5": {
           "version": "3.0.2",
-          "dev": true
-        },
-        "postcss": {
-          "version": "6.0.14",
-          "dev": true,
-          "dependencies": {
-            "ansi-styles": {
-              "version": "3.2.0",
-              "dev": true
-            },
-            "chalk": {
-              "version": "2.3.0",
-              "dev": true
-            },
-            "escape-string-regexp": {
-              "version": "1.0.5",
-              "dev": true
-            },
-            "supports-color": {
-              "version": "4.5.0",
-              "dev": true
-            }
-          }
-        },
-        "pretty-format": {
-          "version": "20.0.3",
-          "dev": true,
-          "dependencies": {
-            "ansi-styles": {
-              "version": "3.2.0",
-              "dev": true
-            }
-          }
-        },
-        "source-map": {
-          "version": "0.6.1",
           "dev": true
         },
         "strip-bom": {
@@ -6143,9 +6093,6 @@
     "regex-cache": {
       "version": "0.4.4"
     },
-    "regexp-quote": {
-      "version": "0.0.0"
-    },
     "regexpu": {
       "version": "1.3.0",
       "dev": true,
@@ -6226,7 +6173,7 @@
       "version": "2.1.1"
     },
     "require-from-string": {
-      "version": "1.2.1",
+      "version": "2.0.1",
       "dev": true
     },
     "require-main-filename": {
@@ -6345,9 +6292,6 @@
           "dev": true
         }
       }
-    },
-    "sanitize-html": {
-      "version": "1.11.1"
     },
     "sass-graph": {
       "version": "2.2.4",
@@ -6760,20 +6704,12 @@
           "version": "1.1.0",
           "dev": true
         },
-        "entities": {
-          "version": "1.1.1",
-          "dev": true
-        },
         "get-stdin": {
           "version": "5.0.1",
           "dev": true
         },
         "globby": {
           "version": "5.0.0",
-          "dev": true
-        },
-        "htmlparser2": {
-          "version": "3.9.2",
           "dev": true
         },
         "minimist": {
@@ -6792,22 +6728,12 @@
           "version": "0.1.9",
           "dev": true
         },
-        "readable-stream": {
-          "version": "2.3.3",
-          "dev": true,
-          "dependencies": {
-            "inherits": {
-              "version": "2.0.3",
-              "dev": true
-            }
-          }
+        "require-from-string": {
+          "version": "1.2.1",
+          "dev": true
         },
         "resolve-from": {
           "version": "2.0.0",
-          "dev": true
-        },
-        "string_decoder": {
-          "version": "1.0.3",
           "dev": true
         },
         "supports-color": {
@@ -7094,17 +7020,17 @@
       "version": "0.0.6"
     },
     "typescript": {
-      "version": "2.5.1",
+      "version": "2.5.3",
       "dev": true
     },
     "typescript-eslint-parser": {
-      "version": "6.0.1",
-      "from": "git://github.com/eslint/typescript-eslint-parser.git#801d65585af6995a223136862944095b48f5c567",
-      "resolved": "git://github.com/eslint/typescript-eslint-parser.git#801d65585af6995a223136862944095b48f5c567",
+      "version": "8.0.0",
+      "from": "git://github.com/eslint/typescript-eslint-parser.git#9c71a627da36e97da52ed2731d58509c952b67ae",
+      "resolved": "git://github.com/eslint/typescript-eslint-parser.git#9c71a627da36e97da52ed2731d58509c952b67ae",
       "dev": true,
       "dependencies": {
         "semver": {
-          "version": "5.3.0",
+          "version": "5.4.1",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -273,7 +273,7 @@
     "mixedindentlint": "1.2.0",
     "nock": "8.0.0",
     "nodemon": "1.4.1",
-    "prettier": "github:automattic/calypso-prettier#14307ba5cc6bcfc00243f5e2d1b25c72d52c28c8",
+    "prettier": "github:automattic/calypso-prettier#717e62ee",
     "pretty-bytes": "4.0.2",
     "react-codemod": "reactjs/react-codemod",
     "react-test-renderer": "15.6.2",


### PR DESCRIPTION
I rebased the Calypso fork to version 1.7.4 of upstream and reformatted Calypso files with it. Here is th e result.

- the first commit upgrades Prettier in `package.json` and `npm-shrinkwrap.json`.
- the second commit runs `npm run reformat-files`.

There are two major changes since 1.6.1:

**Indenting conditions inside JSX**
Before:
```jsx
<div>
  { something &&
  somethingElse && (
    <ShowSomething />
  ) }
</div>
```
After:
```jsx
<div>
  { something &&
    somethingElse && (
      <ShowSomething />
    ) }
</div>
```
**Fewer parens in ternaries**
Before:
```jsx
something ? (
  translate( 'Something' )
) : (
  translate( 'Other thing' )
)
```
After:
```jsx
something
  ? translate( 'Something' )
  : translate( 'Other thing' )
```
