### PR TITLE
Framework: Add a simple flux bridge to use when converting flux stores

### DIFF
--- a/client/state/flux-bridge/README.md
+++ b/client/state/flux-bridge/README.md
@@ -1,0 +1,2 @@
+# Flux Bridge
+This isn't really a full-fledged flux bridge. It just exposes the current redux dispatcher so that flux stores can dispatch redux actions.

--- a/client/state/flux-bridge/index.js
+++ b/client/state/flux-bridge/index.js
@@ -1,0 +1,12 @@
+/** @format */
+
+let currentStore = null;
+
+export const fluxBridgeEnhancer = next => ( reducer, initialState ) => {
+	currentStore = next( reducer, initialState );
+	return currentStore;
+};
+
+export const reduxDispatch = () => {
+	return currentStore && currentStore.dispatch;
+};

--- a/client/state/index.js
+++ b/client/state/index.js
@@ -30,6 +30,7 @@ import countryStates from './country-states/reducer';
 import currentUser from './current-user/reducer';
 import documentHead from './document-head/reducer';
 import domains from './domains/reducer';
+import fluxBridge from './flux-bridge';
 import geo from './geo/reducer';
 import googleAppsUsers from './google-apps-users/reducer';
 import help from './help/reducer';
@@ -191,6 +192,7 @@ export function createReduxStore( initialState = {} ) {
 	].filter( Boolean );
 
 	const enhancers = [
+		fluxBridge,
 		isBrowser && window.app && window.app.isDebug && consoleDispatcher,
 		applyMiddleware( ...middlewares ),
 		isBrowser && sitesSync,


### PR DESCRIPTION
This adds a simple way to expose the redux dispatcher to flux stores that need to dispatch redux actions while we're moving them over to redux.