### PR TITLE
Reader: add follow conversation button to full post

### DIFF
--- a/client/blocks/comments/helper.jsx
+++ b/client/blocks/comments/helper.jsx
@@ -1,9 +1,10 @@
-/**
- * Internal dependencies
- *
+/*
  * @format
  */
 
+/**
+ * Internal dependencies
+ */
 import * as DiscoverHelper from 'reader/discover/helper';
 
 export function shouldShowComments( post ) {

--- a/client/blocks/comments/post-comment-list.jsx
+++ b/client/blocks/comments/post-comment-list.jsx
@@ -25,6 +25,7 @@ import PostCommentFormRoot from './form-root';
 import CommentCount from './comment-count';
 import SegmentedControl from 'components/segmented-control';
 import SegmentedControlItem from 'components/segmented-control/item';
+import ConversationFollowButton from 'blocks/conversation-follow-button';
 
 /**
  * PostCommentList, as the name would suggest, displays a list of comments for a post.
@@ -55,6 +56,7 @@ class PostCommentList extends React.Component {
 		commentCount: PropTypes.number,
 		maxDepth: PropTypes.number,
 		showNestingReplyArrow: PropTypes.bool,
+		showConversationFollowButton: PropTypes.bool,
 		commentsFilter: PropTypes.string,
 
 		// To display comments with a different status but not fetch them
@@ -73,6 +75,7 @@ class PostCommentList extends React.Component {
 		showCommentCount: true,
 		maxDepth: Infinity,
 		showNestingReplyArrow: false,
+		showConversationFollowButton: false,
 	};
 
 	state = {
@@ -348,7 +351,13 @@ class PostCommentList extends React.Component {
 			return null;
 		}
 
-		const { commentsFilter, commentsTree, showFilters, commentCount } = this.props;
+		const {
+			post: { ID: postId, site_ID: siteId },
+			commentsFilter,
+			commentsTree,
+			showFilters,
+			commentCount,
+		} = this.props;
 		const {
 			haveEarlierCommentsToFetch,
 			haveLaterCommentsToFetch,
@@ -379,6 +388,13 @@ class PostCommentList extends React.Component {
 
 		return (
 			<div className="comments__comment-list">
+				{ this.props.showConversationFollowButton && (
+					<ConversationFollowButton
+						className="comments__conversation-follow-button"
+						siteId={ siteId }
+						postId={ postId }
+					/>
+				) }
 				{ ( this.props.showCommentCount || showViewMoreComments ) && (
 					<div className="comments__info-bar">
 						{ this.props.showCommentCount && <CommentCount count={ actualCommentsCount } /> }

--- a/client/blocks/comments/post-comment-list.jsx
+++ b/client/blocks/comments/post-comment-list.jsx
@@ -26,6 +26,7 @@ import CommentCount from './comment-count';
 import SegmentedControl from 'components/segmented-control';
 import SegmentedControlItem from 'components/segmented-control/item';
 import ConversationFollowButton from 'blocks/conversation-follow-button';
+import { shouldShowConversationFollowButton } from 'blocks/conversation-follow-button/helper';
 
 /**
  * PostCommentList, as the name would suggest, displays a list of comments for a post.
@@ -386,9 +387,13 @@ class PostCommentList extends React.Component {
 				? commentCount
 				: this.getCommentsCount( commentsTree.children );
 
+		const showConversationFollowButton =
+			this.props.showConversationFollowButton &&
+			shouldShowConversationFollowButton( this.props.post );
+
 		return (
 			<div className="comments__comment-list">
-				{ this.props.showConversationFollowButton && (
+				{ showConversationFollowButton && (
 					<ConversationFollowButton
 						className="comments__conversation-follow-button"
 						siteId={ siteId }

--- a/client/blocks/comments/style.scss
+++ b/client/blocks/comments/style.scss
@@ -8,6 +8,11 @@
 	.segmented-control {
 		margin: 20px;
 	}
+
+	.comments__conversation-follow-button {
+		float: right;
+		margin-top: 4px;
+	}
 }
 
 // Comment Counter
@@ -567,9 +572,4 @@ a.comments__comment-username {
 
 .comments__comment-actions-read-more-icon {
 	fill: $blue-medium;
-}
-
-.comments__conversation-follow-button {
-	float: right;
-	margin-top: 4px;
 }

--- a/client/blocks/comments/style.scss
+++ b/client/blocks/comments/style.scss
@@ -568,3 +568,8 @@ a.comments__comment-username {
 .comments__comment-actions-read-more-icon {
 	fill: $blue-medium;
 }
+
+.comments__conversation-follow-button {
+	float: right;
+	margin-top: 4px;
+}

--- a/client/blocks/conversation-follow-button/helper.js
+++ b/client/blocks/conversation-follow-button/helper.js
@@ -1,0 +1,20 @@
+/*
+ * @format
+ */
+
+/**
+ * Internal dependencies
+ */
+import { isDiscoverPost } from 'reader/discover/helper';
+import { shouldShowComments } from 'blocks/comments/helper';
+import config from 'config';
+
+export function shouldShowConversationFollowButton( post ) {
+	return (
+		config.isEnabled( 'reader/conversations' ) &&
+		post.site_ID &&
+		! post.is_external &&
+		shouldShowComments( post ) &&
+		! isDiscoverPost( post )
+	);
+}

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -451,7 +451,7 @@ export class FullPostView extends React.Component {
 										commentCount={ commentCount }
 										maxDepth={ 1 }
 										commentsFilterDisplay={ COMMENTS_FILTER_ALL }
-										showConversationFollowButton={ config.isEnabled( 'reader/conversations' ) }
+										showConversationFollowButton={ true }
 									/>
 								) }
 							</div>

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -451,6 +451,7 @@ export class FullPostView extends React.Component {
 										commentCount={ commentCount }
 										maxDepth={ 1 }
 										commentsFilterDisplay={ COMMENTS_FILTER_ALL }
+										showConversationFollowButton={ config.isEnabled( 'reader/conversations' ) }
 									/>
 								) }
 							</div>

--- a/client/blocks/reader-post-options-menu/index.jsx
+++ b/client/blocks/reader-post-options-menu/index.jsx
@@ -9,7 +9,6 @@ import page from 'page';
 import classnames from 'classnames';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import config from 'config';
 
 /**
  * Internal dependencies
@@ -30,7 +29,7 @@ import { isAutomatticTeamMember } from 'reader/lib/teams';
 import { getReaderTeams } from 'state/selectors';
 import ReaderPostOptionsMenuBlogStickers from './blog-stickers';
 import ConversationFollowButton from 'blocks/conversation-follow-button';
-import { shouldShowComments } from 'blocks/comments/helper';
+import { shouldShowConversationFollowButton } from 'blocks/conversation-follow-button/helper';
 
 class ReaderPostOptionsMenu extends React.Component {
 	static propTypes = {
@@ -128,12 +127,7 @@ class ReaderPostOptionsMenu extends React.Component {
 		const isDiscoverPost = DiscoverHelper.isDiscoverPost( post );
 		const followUrl = this.getFollowUrl();
 		const isTeamMember = isAutomatticTeamMember( teams );
-		const showConversationFollow =
-			config.isEnabled( 'reader/conversations' ) &&
-			siteId &&
-			! post.is_external &&
-			shouldShowComments( post ) &&
-			! isDiscoverPost;
+		const showConversationFollowButton = shouldShowConversationFollowButton( post );
 
 		let isBlockPossible = false;
 
@@ -170,12 +164,12 @@ class ReaderPostOptionsMenu extends React.Component {
 						<FollowButton
 							tagName={ PopoverMenuItem }
 							siteUrl={ followUrl }
-							followLabel={ showConversationFollow ? translate( 'Follow Site' ) : null }
-							followingLabel={ showConversationFollow ? translate( 'Following Site' ) : null }
+							followLabel={ showConversationFollowButton ? translate( 'Follow Site' ) : null }
+							followingLabel={ showConversationFollowButton ? translate( 'Following Site' ) : null }
 						/>
 					) }
 
-					{ showConversationFollow && (
+					{ showConversationFollowButton && (
 						<ConversationFollowButton
 							tagName={ PopoverMenuItem }
 							siteId={ siteId }


### PR DESCRIPTION
Adds the 'Follow Conversation' button to the top right of comments on full post:

<img width="759" alt="screen shot 2017-11-06 at 16 55 56" src="https://user-images.githubusercontent.com/17325/32453320-cd15d69a-c313-11e7-9b6c-aa8b4d443cda.png">

### To test

Visit a full post with a comment thread like:

http://calypso.localhost:3000/read/feeds/40474296/posts/1385874605

Check the follow conversation button appears and works as expected.