### PR TITLE
Comments: Fix blank post title

### DIFF
--- a/client/my-sites/comments/comment-list/comment-list-header.jsx
+++ b/client/my-sites/comments/comment-list/comment-list-header.jsx
@@ -47,7 +47,9 @@ export const CommentListHeader = ( {
 				actionText={ translate( 'View Post' ) }
 				backHref={ `/comments/all/${ siteSlug }` }
 			>
-				<div className="comment-list__header-title">{ postTitle || translate( 'Untitled' ) }</div>
+				<div className="comment-list__header-title">
+					{ postTitle.trim() || translate( 'Untitled' ) }
+				</div>
 				<div className="comment-list__header-date">{ formattedDate }</div>
 			</HeaderCake>
 		</div>

--- a/client/my-sites/comments/comment-list/comment-list-header.jsx
+++ b/client/my-sites/comments/comment-list/comment-list-header.jsx
@@ -47,7 +47,7 @@ export const CommentListHeader = ( {
 				actionText={ translate( 'View Post' ) }
 				backHref={ `/comments/all/${ siteSlug }` }
 			>
-				<div className="comment-list__header-title">{ postTitle }</div>
+				<div className="comment-list__header-title">{ postTitle || translate( 'Untitled' ) }</div>
 				<div className="comment-list__header-date">{ formattedDate }</div>
 			</HeaderCake>
 		</div>

--- a/client/my-sites/comments/comment/comment-post-link.jsx
+++ b/client/my-sites/comments/comment/comment-post-link.jsx
@@ -32,7 +32,7 @@ const CommentPostLink = ( {
 		<Gridicon icon="chevron-right" size={ 18 } />
 
 		<a href={ `/comments/${ status }/${ siteSlug }/${ postId }` }>
-			{ postTitle || translate( 'Untitled' ) }
+			{ postTitle.trim() || translate( 'Untitled' ) }
 		</a>
 	</div>
 );


### PR DESCRIPTION
Fixes #18993 
Tentatively fixes #19486 (I can't seem to be able to replicate it)

By just `String.prototype.trim()`-ming the `postTitle` we remove both spaces and Unicode whitespaces from it, so that `postTitle || "Untitled"` actually works even if the title is defined but not visible.