### PR TITLE
Store Promotions: Fix htmlFor & ids on form labels

### DIFF
--- a/client/extensions/woocommerce/app/promotions/fields/currency-field.js
+++ b/client/extensions/woocommerce/app/promotions/fields/currency-field.js
@@ -24,7 +24,7 @@ const CurrencyField = ( props ) => {
 			<PriceInput
 				noWrap
 				size="4"
-				htmlFor={ fieldName + '-label' }
+				id={ fieldName + '-label' }
 				aria-describedby={ explanationText && fieldName + '-description' }
 				currency={ currency }
 				value={ renderedValue }
@@ -45,4 +45,3 @@ CurrencyField.PropTypes = {
 };
 
 export default CurrencyField;
-

--- a/client/extensions/woocommerce/app/promotions/fields/form-field.js
+++ b/client/extensions/woocommerce/app/promotions/fields/form-field.js
@@ -53,7 +53,7 @@ const FormField = ( {
 	);
 
 	const formLabel = ( enableCheckbox || labelText ) && (
-		<FormLabel id={ fieldName + '-label' } required={ isRequired }>
+		<FormLabel htmlFor={ fieldName + '-label' } required={ isRequired }>
 			{ enableCheckbox }
 			{ labelText }
 		</FormLabel>

--- a/client/extensions/woocommerce/app/promotions/fields/form-field.js
+++ b/client/extensions/woocommerce/app/promotions/fields/form-field.js
@@ -53,7 +53,7 @@ const FormField = ( {
 	);
 
 	const formLabel = ( enableCheckbox || labelText ) && (
-		<FormLabel htmlFor={ fieldName + '-label' } required={ isRequired }>
+		<FormLabel htmlFor={ enableCheckbox ? null : `${ fieldName }-label` } required={ isRequired }>
 			{ enableCheckbox }
 			{ labelText }
 		</FormLabel>

--- a/client/extensions/woocommerce/app/promotions/fields/number-field.js
+++ b/client/extensions/woocommerce/app/promotions/fields/number-field.js
@@ -30,7 +30,7 @@ const NumberField = ( props ) => {
 	return (
 		<FormField { ...props } >
 			<FormTextInput
-				htmlFor={ fieldName + '-label' }
+				id={ fieldName + '-label' }
 				aria-describedby={ explanationText && fieldName + '-description' }
 				type="number"
 				min={ minValue }
@@ -54,4 +54,3 @@ NumberField.PropTypes = {
 };
 
 export default NumberField;
-

--- a/client/extensions/woocommerce/app/promotions/fields/percent-field.js
+++ b/client/extensions/woocommerce/app/promotions/fields/percent-field.js
@@ -24,7 +24,7 @@ const PercentField = ( props ) => {
 	return (
 		<FormField { ...props } >
 			<FormTextInputWithAffixes
-				htmlFor={ fieldName + '-label' }
+				id={ fieldName + '-label' }
 				aria-describedby={ explanationText && fieldName + '-description' }
 				type="number"
 				min="0"
@@ -47,4 +47,3 @@ PercentField.PropTypes = {
 };
 
 export default PercentField;
-

--- a/client/extensions/woocommerce/app/promotions/fields/promotion-applies-to-field/applies-to-filtered-list.js
+++ b/client/extensions/woocommerce/app/promotions/fields/promotion-applies-to-field/applies-to-filtered-list.js
@@ -93,7 +93,7 @@ function renderRow( component, rowText, rowValue, imageSrc, selected, onChange )
 	const labelId = `applies-to-row-${ rowValue }-label`;
 
 	const rowComponent = React.createElement( component, {
-		htmlFor: labelId,
+		id: labelId,
 		name: 'applies_to_select',
 		value: rowValue,
 		checked: selected,
@@ -102,7 +102,7 @@ function renderRow( component, rowText, rowValue, imageSrc, selected, onChange )
 
 	return (
 		<div className="promotion-applies-to-field__row" key={ rowValue }>
-			<FormLabel id={ labelId }>
+			<FormLabel htmlFor={ labelId }>
 				{ rowComponent }
 				{ renderImage( imageSrc ) }
 				<span>{ rowText }</span>
@@ -306,4 +306,3 @@ function mapStateToProps( state ) {
 }
 
 export default connect( mapStateToProps )( AppliesToFilteredList );
-

--- a/client/extensions/woocommerce/app/promotions/fields/text-field.js
+++ b/client/extensions/woocommerce/app/promotions/fields/text-field.js
@@ -22,7 +22,7 @@ const TextField = ( props ) => {
 	return (
 		<FormField { ...props } >
 			<FormTextInput
-				htmlFor={ fieldName + '-label' }
+				id={ fieldName + '-label' }
 				aria-describedby={ explanationText && fieldName + '-description' }
 				value={ renderedValue }
 				placeholder={ placeholderText }
@@ -41,4 +41,3 @@ TextField.PropTypes = {
 };
 
 export default TextField;
-


### PR DESCRIPTION
I didn't catch this on #19092, but the `htmlFor` & `id`s are mixed up. The ID belongs on the input element, and the `htmlFor` on the label (you can remember this by thinking the label is `for` the input with the `id`). It's a quick fix, and I feel like I should have caught it the first time, so here's a PR 🙂 

I also updated how the label works on fields with `enableCheckbox`s, because the htmlFor didn't match the input checkbox, breaking the click-ability of the label.

To test:

- Visit the promotions page & edit a promo, or create a new promo to get to the form.
- Click the labels (like "Product Sale Price"), it should focus the field it belongs to
- Click the Conditions text, it should also toggle the input checkbox