### PR TITLE
Store: If TaxJar plugin is active, do not show core settings

### DIFF
--- a/client/extensions/woocommerce/app/settings/taxes/index.js
+++ b/client/extensions/woocommerce/app/settings/taxes/index.js
@@ -26,8 +26,10 @@ import SettingsTaxesWooCommerceServices from './taxes-wcs';
 class SettingsTaxes extends Component {
 	static propTypes = {
 		className: PropTypes.string,
+		isRequestingSitePlugins: PropTypes.bool,
 		siteId: PropTypes.number,
 		sitePluginsLoaded: PropTypes.bool,
+		siteSlug: PropTypes.string,
 		taxJarPluginActive: PropTypes.bool,
 	};
 

--- a/client/extensions/woocommerce/app/settings/taxes/index.js
+++ b/client/extensions/woocommerce/app/settings/taxes/index.js
@@ -33,16 +33,18 @@ class SettingsTaxes extends Component {
 		taxJarPluginActive: PropTypes.bool,
 	};
 
-	maybeFetchPlugins = props => {
+	maybeFetchPlugins = ( props, force = false ) => {
 		const { isRequestingSitePlugins, siteId, sitePluginsLoaded } = props;
 
-		if ( siteId && ! isRequestingSitePlugins && ! sitePluginsLoaded ) {
-			this.props.fetchPlugins( [ siteId ] );
+		if ( siteId && ! isRequestingSitePlugins ) {
+			if ( force || ! sitePluginsLoaded ) {
+				this.props.fetchPlugins( [ siteId ] );
+			}
 		}
 	};
 
 	componentDidMount = () => {
-		this.maybeFetchPlugins( this.props );
+		this.maybeFetchPlugins( this.props, true );
 	};
 
 	componentWillReceiveProps = newProps => {

--- a/client/extensions/woocommerce/app/settings/taxes/index.js
+++ b/client/extensions/woocommerce/app/settings/taxes/index.js
@@ -33,20 +33,20 @@ class SettingsTaxes extends Component {
 		taxJarPluginActive: PropTypes.bool,
 	};
 
-	componentDidMount = () => {
-		const { isRequestingSitePlugins, siteId, sitePluginsLoaded } = this.props;
+	maybeFetchPlugins = props => {
+		const { isRequestingSitePlugins, siteId, sitePluginsLoaded } = props;
 
 		if ( siteId && ! isRequestingSitePlugins && ! sitePluginsLoaded ) {
 			this.props.fetchPlugins( [ siteId ] );
 		}
 	};
 
-	componentWillReceiveProps = newProps => {
-		const { isRequestingSitePlugins, siteId, sitePluginsLoaded } = newProps;
+	componentDidMount = () => {
+		this.maybeFetchPlugins( this.props );
+	};
 
-		if ( siteId && ! isRequestingSitePlugins && ! sitePluginsLoaded ) {
-			this.props.fetchPlugins( [ siteId ] );
-		}
+	componentWillReceiveProps = newProps => {
+		this.maybeFetchPlugins( newProps );
 	};
 
 	render = () => {

--- a/client/extensions/woocommerce/app/settings/taxes/style.scss
+++ b/client/extensions/woocommerce/app/settings/taxes/style.scss
@@ -29,7 +29,7 @@
 	a.external-link {
 		margin-left: 8px;
 	}
-	
+
 	a.external-link .gridicons-external {
 		margin-left: 4px;
 	}
@@ -47,4 +47,8 @@
 			background-color: transparent;
 		}
 	}
+}
+
+.taxes__placeholder .card {
+	@include placeholder();
 }

--- a/client/extensions/woocommerce/app/settings/taxes/style.scss
+++ b/client/extensions/woocommerce/app/settings/taxes/style.scss
@@ -52,3 +52,9 @@
 .taxes__placeholder .card {
 	@include placeholder();
 }
+
+.taxes__tax-jar-info p {
+	&:last-child {
+		margin-bottom: 0;
+	}
+}

--- a/client/extensions/woocommerce/app/settings/taxes/taxes-placeholder.js
+++ b/client/extensions/woocommerce/app/settings/taxes/taxes-placeholder.js
@@ -1,0 +1,40 @@
+/**
+ * External dependencies
+ *
+ * @format
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import ActionHeader from 'woocommerce/components/action-header';
+import { getLink } from 'woocommerce/lib/nav-utils';
+import SettingsNavigation from '../navigation';
+
+const SettingsTaxesPlaceholder = ( { siteSlug, translate } ) => {
+	const breadcrumbs = [
+		<a href={ getLink( '/store/settings/:site/', { slug: siteSlug } ) }>
+			{ translate( 'Settings' ) }
+		</a>,
+		<span>{ translate( 'Taxes' ) }</span>,
+	];
+
+	return (
+		<div>
+			<ActionHeader breadcrumbs={ breadcrumbs } />
+			<SettingsNavigation activeSection="taxes" />
+			<div className="taxes__placeholder card" />
+		</div>
+	);
+};
+
+SettingsTaxesPlaceholder.propTypes = {
+	siteSlug: PropTypes.string.isRequired,
+	translate: PropTypes.func.isRequired,
+};
+
+export default localize( SettingsTaxesPlaceholder );

--- a/client/extensions/woocommerce/app/settings/taxes/taxes-rates.js
+++ b/client/extensions/woocommerce/app/settings/taxes/taxes-rates.js
@@ -41,25 +41,21 @@ import QuerySettingsGeneral from 'woocommerce/components/query-settings-general'
 class TaxesRates extends Component {
 	static propTypes = {
 		onEnabledChange: PropTypes.func.isRequired,
-		site: PropTypes.shape( {
-			slug: PropTypes.string,
-		} ),
+		siteId: PropTypes.number.isRequired,
 	};
 
 	componentDidMount = () => {
-		const { address, loadedSettingsGeneral, loadedTaxRates, site } = this.props;
+		const { address, loadedSettingsGeneral, loadedTaxRates, siteId } = this.props;
 
-		if ( site && site.ID ) {
-			if ( loadedSettingsGeneral && ! loadedTaxRates ) {
-				this.props.fetchTaxRates( site.ID, address );
-			}
+		if ( loadedSettingsGeneral && ! loadedTaxRates ) {
+			this.props.fetchTaxRates( siteId, address );
 		}
 	};
 
 	componentWillReceiveProps = nextProps => {
 		if ( nextProps.loadedSettingsGeneral ) {
 			if ( ! nextProps.loadedTaxRates ) {
-				this.props.fetchTaxRates( nextProps.site.ID, nextProps.address );
+				this.props.fetchTaxRates( nextProps.siteId, nextProps.address );
 			}
 		}
 	};
@@ -280,7 +276,7 @@ class TaxesRates extends Component {
 
 	render = () => {
 		const {
-			site,
+			siteId,
 			loadedSettingsGeneral,
 			loadedTaxRates,
 			onEnabledChange,
@@ -289,7 +285,7 @@ class TaxesRates extends Component {
 		} = this.props;
 
 		if ( ! loadedSettingsGeneral ) {
-			return <QuerySettingsGeneral siteId={ site && site.ID } />;
+			return <QuerySettingsGeneral siteId={ siteId } />;
 		}
 
 		if ( ! loadedTaxRates ) {
@@ -317,15 +313,11 @@ class TaxesRates extends Component {
 }
 
 function mapStateToProps( state, ownProps ) {
-	let siteId = undefined;
-	if ( ownProps.site ) {
-		siteId = ownProps.site.ID;
-	}
-	const address = getStoreLocation( state, siteId );
-	const loadedSettingsGeneral = areSettingsGeneralLoaded( state, siteId );
-	const areTaxesEnabled = areTaxCalculationsEnabled( state, siteId );
-	const loadedTaxRates = areTaxRatesLoaded( state, siteId );
-	const taxRates = getTaxRates( state, siteId );
+	const address = getStoreLocation( state, ownProps.siteId );
+	const loadedSettingsGeneral = areSettingsGeneralLoaded( state, ownProps.siteId );
+	const areTaxesEnabled = areTaxCalculationsEnabled( state, ownProps.siteId );
+	const loadedTaxRates = areTaxRatesLoaded( state, ownProps.siteId );
+	const taxRates = getTaxRates( state, ownProps.siteId );
 
 	return {
 		address,

--- a/client/extensions/woocommerce/app/settings/taxes/taxes-rates.js
+++ b/client/extensions/woocommerce/app/settings/taxes/taxes-rates.js
@@ -263,8 +263,8 @@ class TaxesRates extends Component {
 		return (
 			<div className="taxes__taxes-taxjar-notice">
 				{ translate(
-					'Sales tax calculations are provided by a third party: TaxJar. By enabling this option, ' +
-						'TaxJar will have access to some of your data.'
+					'Sales tax calculations are provided by WooCommerce Services. When this option is enabled, ' +
+						'WooCommerce Services will share some of your data with a third party.'
 				) }
 				<ExternalLink
 					icon

--- a/client/extensions/woocommerce/app/settings/taxes/taxes-rates.js
+++ b/client/extensions/woocommerce/app/settings/taxes/taxes-rates.js
@@ -44,20 +44,20 @@ class TaxesRates extends Component {
 		siteId: PropTypes.number.isRequired,
 	};
 
-	componentDidMount = () => {
-		const { address, loadedSettingsGeneral, loadedTaxRates, siteId } = this.props;
+	maybeFetchRates = props => {
+		const { address, loadedSettingsGeneral, loadedTaxRates, siteId } = props;
 
 		if ( loadedSettingsGeneral && ! loadedTaxRates ) {
 			this.props.fetchTaxRates( siteId, address );
 		}
 	};
 
+	componentDidMount = () => {
+		this.maybeFetchRates( this.props );
+	};
+
 	componentWillReceiveProps = nextProps => {
-		if ( nextProps.loadedSettingsGeneral ) {
-			if ( ! nextProps.loadedTaxRates ) {
-				this.props.fetchTaxRates( nextProps.siteId, nextProps.address );
-			}
-		}
+		this.maybeFetchRates( nextProps );
 	};
 
 	renderInfo = () => {

--- a/client/extensions/woocommerce/app/settings/taxes/taxes-taxjar.js
+++ b/client/extensions/woocommerce/app/settings/taxes/taxes-taxjar.js
@@ -1,0 +1,79 @@
+/**
+ * External dependencies
+ *
+ * @format
+ */
+
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import ActionHeader from 'woocommerce/components/action-header';
+import Card from 'components/card';
+import ExtendedHeader from 'woocommerce/components/extended-header';
+import ExternalLink from 'components/external-link';
+import { getLink } from 'woocommerce/lib/nav-utils';
+import Main from 'components/main';
+import SettingsNavigation from '../navigation';
+
+class SettingsTaxesTaxJar extends Component {
+	static propTypes = {
+		className: PropTypes.string,
+		site: PropTypes.shape( {
+			options: PropTypes.shape( {
+				admin_url: PropTypes.string.isRequired,
+			} ),
+		} ),
+	};
+
+	onDeactivate = event => {
+		event.preventDefault();
+	};
+
+	render = () => {
+		const { className, site, translate } = this.props;
+
+		const breadcrumbs = [
+			<a href={ getLink( '/store/settings/:site/', site ) }>{ translate( 'Settings' ) }</a>,
+			<span>{ translate( 'Taxes' ) }</span>,
+		];
+
+		const adminUrl =
+			site.options.admin_url +
+			'admin.php?page=wc-settings&tab=integration&section=taxjar-integration';
+		const pluginUrl = getLink( '/plugins/taxjar-simplified-taxes-for-woocommerce/:site', site );
+
+		return (
+			<Main className={ classNames( 'settings-taxes', className ) }>
+				<ActionHeader breadcrumbs={ breadcrumbs } />
+				<SettingsNavigation activeSection="taxes" />
+				<div className="taxes__tax-jar">
+					<ExtendedHeader
+						label={ translate( 'Tax Plugin Detected' ) }
+						description={ translate( "A third-party plugin is managing your store's taxes." ) }
+					/>
+					<Card>
+						<p>
+							{ translate( "Your store's taxes are being managed by a third-party plugin. " ) }
+							<ExternalLink icon href={ adminUrl } rel="noopener noreferrer">
+								{ translate( 'Plugin settings' ) }
+							</ExternalLink>
+						</p>
+						<p>
+							{ translate( 'Or, if you prefer, you can {{a}}manage or remove this plugin{{/a}}. ', {
+								components: {
+									a: <a href={ pluginUrl } className="taxes__tax-jar-deactivate" />,
+								},
+							} ) }
+						</p>
+					</Card>
+				</div>
+			</Main>
+		);
+	};
+}
+export default localize( SettingsTaxesTaxJar );

--- a/client/extensions/woocommerce/app/settings/taxes/taxes-taxjar.js
+++ b/client/extensions/woocommerce/app/settings/taxes/taxes-taxjar.js
@@ -27,11 +27,7 @@ class SettingsTaxesTaxJar extends Component {
 			options: PropTypes.shape( {
 				admin_url: PropTypes.string.isRequired,
 			} ),
-		} ),
-	};
-
-	onDeactivate = event => {
-		event.preventDefault();
+		} ).isRequired,
 	};
 
 	render = () => {

--- a/client/extensions/woocommerce/app/settings/taxes/taxes-taxjar.js
+++ b/client/extensions/woocommerce/app/settings/taxes/taxes-taxjar.js
@@ -14,7 +14,6 @@ import { localize } from 'i18n-calypso';
  */
 import ActionHeader from 'woocommerce/components/action-header';
 import Card from 'components/card';
-import ExtendedHeader from 'woocommerce/components/extended-header';
 import ExternalLink from 'components/external-link';
 import { getLink } from 'woocommerce/lib/nav-utils';
 import Main from 'components/main';
@@ -48,23 +47,37 @@ class SettingsTaxesTaxJar extends Component {
 				<ActionHeader breadcrumbs={ breadcrumbs } />
 				<SettingsNavigation activeSection="taxes" />
 				<div className="taxes__tax-jar">
-					<ExtendedHeader
-						label={ translate( 'Tax Plugin Detected' ) }
-						description={ translate( "A third-party plugin is managing your store's taxes." ) }
-					/>
 					<Card>
 						<p>
-							{ translate( "Your store's taxes are being managed by a third-party plugin. " ) }
+							{ translate(
+								"Your store's taxes are being managed by the {{b}}TaxJar - Sales Tax Automation " +
+									'for WooCommerce plugin{{/b}}. This optional plugin adds automated reporting, filing and multi-nexus ' +
+									'support for your store.',
+								{
+									components: {
+										b: <strong />,
+									},
+								}
+							) }
+						</p>
+						<p>
+							{ translate(
+								'You can manage settings, including your personal TaxJar API key, in the plugin settings. '
+							) }
 							<ExternalLink icon href={ adminUrl } rel="noopener noreferrer">
 								{ translate( 'Plugin settings' ) }
 							</ExternalLink>
 						</p>
 						<p>
-							{ translate( 'Or, if you prefer, you can {{a}}manage or remove this plugin{{/a}}. ', {
-								components: {
-									a: <a href={ pluginUrl } className="taxes__tax-jar-deactivate" />,
-								},
-							} ) }
+							{ translate(
+								"Or, if you don't require those features, you can {{a}}remove this plugin{{/a}} and " +
+									"we'll automatically provide sales tax calculations for your store through WooCommerce Services.",
+								{
+									components: {
+										a: <a href={ pluginUrl } className="taxes__tax-jar-deactivate" />,
+									},
+								}
+							) }
 						</p>
 					</Card>
 				</div>

--- a/client/extensions/woocommerce/app/settings/taxes/taxes-taxjar.js
+++ b/client/extensions/woocommerce/app/settings/taxes/taxes-taxjar.js
@@ -46,8 +46,8 @@ class SettingsTaxesTaxJar extends Component {
 			<Main className={ classNames( 'settings-taxes', className ) }>
 				<ActionHeader breadcrumbs={ breadcrumbs } />
 				<SettingsNavigation activeSection="taxes" />
-				<div className="taxes__tax-jar">
-					<Card>
+				<div>
+					<Card className="taxes__tax-jar-info">
 						<p>
 							{ translate(
 								"Your store's taxes are being managed by the {{b}}TaxJar - Sales Tax Automation " +
@@ -69,7 +69,7 @@ class SettingsTaxesTaxJar extends Component {
 									"{{b}}we'll still handle sales tax calculations for you{{/b}}.",
 								{
 									components: {
-										a: <a href={ pluginUrl } className="taxes__tax-jar-deactivate" />,
+										a: <a href={ pluginUrl } />,
 										b: <strong />,
 									},
 								}

--- a/client/extensions/woocommerce/app/settings/taxes/taxes-taxjar.js
+++ b/client/extensions/woocommerce/app/settings/taxes/taxes-taxjar.js
@@ -51,8 +51,7 @@ class SettingsTaxesTaxJar extends Component {
 						<p>
 							{ translate(
 								"Your store's taxes are being managed by the {{b}}TaxJar - Sales Tax Automation " +
-									'for WooCommerce plugin{{/b}}. This optional plugin adds automated reporting, filing and multi-nexus ' +
-									'support for your store.',
+									'for WooCommerce{{/b}} plugin. This optional plugin provides features such as:',
 								{
 									components: {
 										b: <strong />,
@@ -60,24 +59,27 @@ class SettingsTaxesTaxJar extends Component {
 								}
 							) }
 						</p>
+						<ul>
+							<li>{ translate( 'Automated reporting & filing' ) }</li>
+							<li>{ translate( 'Multi-nexus support' ) }</li>
+						</ul>
 						<p>
 							{ translate(
-								'You can manage settings, including your personal TaxJar API key, in the plugin settings. '
-							) }
-							<ExternalLink icon href={ adminUrl } rel="noopener noreferrer">
-								{ translate( 'Plugin settings' ) }
-							</ExternalLink>
-						</p>
-						<p>
-							{ translate(
-								"Or, if you don't require those features, you can {{a}}remove this plugin{{/a}} and " +
-									"we'll automatically provide sales tax calculations for your store through WooCommerce Services.",
+								"If you don't need these features we recommend {{a}}removing this plugin{{/a}}. Don't worry, " +
+									"{{b}}we'll still handle sales tax calculations for you{{/b}}.",
 								{
 									components: {
 										a: <a href={ pluginUrl } className="taxes__tax-jar-deactivate" />,
+										b: <strong />,
 									},
 								}
 							) }
+						</p>
+						<p>
+							{ translate( "You can manage this plugin's settings in wp-admin. " ) }
+							<ExternalLink icon href={ adminUrl } rel="noopener noreferrer">
+								{ translate( 'Plugin settings' ) }
+							</ExternalLink>
 						</p>
 					</Card>
 				</div>

--- a/client/extensions/woocommerce/app/settings/taxes/taxes-wcs.js
+++ b/client/extensions/woocommerce/app/settings/taxes/taxes-wcs.js
@@ -1,0 +1,237 @@
+/**
+ * External dependencies
+ *
+ * @format
+ */
+
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { bindActionCreators } from 'redux';
+import classNames from 'classnames';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import ActionHeader from 'woocommerce/components/action-header';
+import {
+	areSettingsGeneralLoaded,
+	areTaxCalculationsEnabled,
+} from 'woocommerce/state/sites/settings/general/selectors';
+import {
+	areTaxSettingsLoaded,
+	getPricesIncludeTax,
+	getShippingIsTaxFree,
+} from 'woocommerce/state/sites/settings/tax/selectors';
+import ExtendedHeader from 'woocommerce/components/extended-header';
+import { updateTaxesEnabledSetting } from 'woocommerce/state/sites/settings/general/actions';
+import QuerySettingsGeneral from 'woocommerce/components/query-settings-general';
+import { fetchTaxRates } from 'woocommerce/state/sites/meta/taxrates/actions';
+import { fetchTaxSettings, updateTaxSettings } from 'woocommerce/state/sites/settings/tax/actions';
+import { getLink } from 'woocommerce/lib/nav-utils';
+import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
+import Main from 'components/main';
+import TaxSettingsSaveButton from './save-button';
+import SettingsNavigation from '../navigation';
+import { successNotice, errorNotice } from 'state/notices/actions';
+import StoreAddress from 'woocommerce/components/store-address';
+import TaxesOptions from './taxes-options';
+import TaxesRates from './taxes-rates';
+
+class SettingsTaxesWooCommerceServices extends Component {
+	constructor( props ) {
+		super( props );
+		this.state = {
+			isSaving: false,
+			pricesIncludeTaxes: props.pricesIncludeTaxes,
+			shippingIsTaxable: props.shippingIsTaxable,
+			taxesEnabled: props.taxesEnabled,
+			userBeganEditing: false,
+		};
+	}
+
+	static propTypes = {
+		site: PropTypes.shape( {
+			slug: PropTypes.string,
+			ID: PropTypes.number,
+		} ),
+		className: PropTypes.string,
+	};
+
+	componentDidMount = () => {
+		const { site } = this.props;
+
+		if ( site && site.ID ) {
+			this.props.fetchTaxSettings( site.ID );
+		}
+	};
+
+	componentWillReceiveProps = newProps => {
+		if ( ! this.state.userBeganEditing ) {
+			const { site } = this.props;
+			const newSiteId = ( newProps.site && newProps.site.ID ) || null;
+			const oldSiteId = ( site && site.ID ) || null;
+			if ( oldSiteId !== newSiteId ) {
+				this.props.fetchTaxSettings( newSiteId );
+			}
+
+			this.setState( {
+				pricesIncludeTaxes: newProps.pricesIncludeTaxes,
+				shippingIsTaxable: newProps.shippingIsTaxable,
+				taxesEnabled: newProps.taxesEnabled,
+			} );
+		}
+	};
+
+	onEnabledChange = () => {
+		this.setState( { taxesEnabled: ! this.state.taxesEnabled, userBeganEditing: true } );
+	};
+
+	onCheckboxChange = event => {
+		const option = event.target.name;
+		const value = event.target.checked;
+		this.setState( { [ option ]: value, userBeganEditing: true } );
+	};
+
+	pageHasChanges = () => {
+		return this.state.userBeganEditing;
+	};
+
+	onSave = ( event, onSuccessExtra ) => {
+		const { site, translate } = this.props;
+
+		event.preventDefault();
+		this.setState( { isSaving: true } );
+
+		const onSuccess = () => {
+			this.setState( { isSaving: false, userBeganEditing: false } );
+			if ( onSuccessExtra ) {
+				onSuccessExtra();
+			}
+			return successNotice( translate( 'Settings updated successfully.' ), {
+				duration: 4000,
+				displayOnNextPage: true,
+			} );
+		};
+
+		const onFailure = () => {
+			this.setState( { isSaving: false } );
+			return errorNotice(
+				translate( 'There was a problem saving your changes. Please try again.' )
+			);
+		};
+
+		// TODO - chain these
+
+		this.props.updateTaxesEnabledSetting( site.ID, this.state.taxesEnabled );
+
+		this.props.updateTaxSettings(
+			site.ID,
+			this.state.pricesIncludeTaxes || false,
+			! this.state.shippingIsTaxable, // note the inversion
+			onSuccess,
+			onFailure
+		);
+	};
+
+	onAddressChange = address => {
+		const { site } = this.props;
+		this.props.fetchTaxRates( site.ID, address, true );
+	};
+
+	renderAddress = () => {
+		const { translate } = this.props;
+
+		return (
+			<div className="taxes__nexus">
+				<ExtendedHeader
+					label={ translate( 'Store Address' ) }
+					description={ translate(
+						'The address of where your business is located for tax purposes.'
+					) }
+				/>
+				<StoreAddress
+					className="taxes__store-address"
+					onSetAddress={ this.onAddressChange }
+					showLabel={ false }
+				/>
+			</div>
+		);
+	};
+
+	renderRates = () => {
+		const { site } = this.props;
+
+		return (
+			<TaxesRates
+				taxesEnabled={ this.state.taxesEnabled }
+				onEnabledChange={ this.onEnabledChange }
+				site={ site }
+			/>
+		);
+	};
+
+	renderOptions = () => {
+		return (
+			<TaxesOptions
+				onCheckboxChange={ this.onCheckboxChange }
+				pricesIncludeTaxes={ this.state.pricesIncludeTaxes }
+				shippingIsTaxable={ this.state.shippingIsTaxable }
+			/>
+		);
+	};
+
+	render = () => {
+		const { className, loaded, site, translate } = this.props;
+
+		const breadcrumbs = [
+			<a href={ getLink( '/store/settings/:site/', site ) }>{ translate( 'Settings' ) }</a>,
+			<span>{ translate( 'Taxes' ) }</span>,
+		];
+
+		return (
+			<Main className={ classNames( 'settings-taxes', className ) }>
+				<ActionHeader breadcrumbs={ breadcrumbs }>
+					<TaxSettingsSaveButton onSave={ this.onSave } />
+				</ActionHeader>
+				<SettingsNavigation activeSection="taxes" />
+				<QuerySettingsGeneral siteId={ site.ID } />
+				{ loaded && this.renderAddress() }
+				{ loaded && this.renderRates() }
+				{ loaded && this.renderOptions() }
+			</Main>
+		);
+	};
+}
+
+function mapStateToProps( state ) {
+	const loaded = areTaxSettingsLoaded( state ) && areSettingsGeneralLoaded( state );
+	const site = getSelectedSiteWithFallback( state );
+	const pricesIncludeTaxes = getPricesIncludeTax( state );
+	const shippingIsTaxable = ! getShippingIsTaxFree( state ); // note the inversion
+	const taxesEnabled = areTaxCalculationsEnabled( state );
+
+	return {
+		loaded,
+		pricesIncludeTaxes,
+		shippingIsTaxable,
+		site,
+		taxesEnabled,
+	};
+}
+
+function mapDispatchToProps( dispatch ) {
+	return bindActionCreators(
+		{
+			fetchTaxRates,
+			fetchTaxSettings,
+			updateTaxesEnabledSetting,
+			updateTaxSettings,
+		},
+		dispatch
+	);
+}
+export default connect( mapStateToProps, mapDispatchToProps )(
+	localize( SettingsTaxesWooCommerceServices )
+);

--- a/client/extensions/woocommerce/app/settings/taxes/taxes-wcs.js
+++ b/client/extensions/woocommerce/app/settings/taxes/taxes-wcs.js
@@ -51,9 +51,13 @@ class SettingsTaxesWooCommerceServices extends Component {
 	}
 
 	static propTypes = {
+		className: PropTypes.string,
+		loaded: PropTypes.bool,
+		pricesIncludeTaxes: PropTypes.bool,
+		shippingIsTaxable: PropTypes.bool,
 		siteSlug: PropTypes.string.isRequired,
 		siteId: PropTypes.number.isRequired,
-		className: PropTypes.string,
+		taxesEnabled: PropTypes.bool,
 	};
 
 	componentDidMount = () => {


### PR DESCRIPTION
Fixes #17110 

To test:
* Navigate to http://calypso.localhost:3000/store/settings/taxes/{DOMAIN}
* Wait for the placeholder to pass
* You'll either be placed on a view that tells you you have the TaxJar plugin active, or a view that lets you adjust your tax settings
* Navigate to http://calypso.localhost:3000/plugins/manage/{DOMAIN} and deactivate TaxJar if active, or install and activate if not
* Return to  http://calypso.localhost:3000/store/settings/taxes/{DOMAIN}
* Ensure you see whatever view you didn't see before

cc @jeffstieler @justinshreve @kellychoffman @jameskoster 

edit: Note: I am going to submit a PR to TaxJar next to have them _not_ hook :allofthethings: unless the user has both checked the enabled setting for their plugin AND entered an API key. That should help WCS easily work around active TaxJar plugins that are not fully configured with an API key.

<img width="951" alt="screen shot 2017-11-06 at 12 46 17 pm" src="https://user-images.githubusercontent.com/1595739/32463492-e13bcd0e-c2f1-11e7-8b6e-0b506da87f39.png">

<img width="951" alt="screen shot 2017-11-06 at 12 47 02 pm" src="https://user-images.githubusercontent.com/1595739/32463493-e157b820-c2f1-11e7-8866-8ca52c9dcdc1.png">
