### PR TITLE
Domains: Remove code to recommend shortest domain name for A/B Test.

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -27,7 +27,6 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import { abtest } from 'lib/abtest';
 import wpcom from 'lib/wp';
 import Notice from 'components/notice';
 import { checkDomainAvailability, getFixedDomainSearch } from 'lib/domains';
@@ -498,27 +497,7 @@ class RegisterDomainStep extends React.Component {
 					! exactMatchBeforeTld( suggestion ) && suggestion.isRecommended !== true;
 				const availableSuggestions = reject( suggestions, isFreeOrUnknown );
 
-				let recommendedSuggestion = null;
-
-				if ( abtest( 'recommendShortestDomain' ) === 'shortest' ) {
-					const shortestDomainBase = availableSuggestions
-						.map( suggestion => {
-							const dotPos = suggestion.domain_name.indexOf( '.' );
-							return suggestion.domain_name.slice(
-								0,
-								-1 === dotPos ? suggestion.domain_name.length : dotPos
-							);
-						} )
-						.reduce( ( left, right ) => ( left.length <= right.length ? left : right ) );
-
-					const shortestDomainBeforeTld = suggestion =>
-						startsWith( suggestion.domain_name, `${ shortestDomainBase }.` );
-
-					recommendedSuggestion = find( availableSuggestions, shortestDomainBeforeTld );
-				} else {
-					recommendedSuggestion = find( availableSuggestions, exactMatchBeforeTld );
-				}
-
+				const recommendedSuggestion = find( availableSuggestions, exactMatchBeforeTld );
 				if ( recommendedSuggestion ) {
 					recommendedSuggestion.isRecommended = true;
 				} else if ( availableSuggestions.length > 0 ) {

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -80,16 +80,6 @@ export default {
 		allowExistingUsers: true,
 		localeTargets: 'any',
 	},
-	recommendShortestDomain: {
-		datestamp: '20171010',
-		variations: {
-			shortest: 50,
-			original: 50,
-		},
-		defaultVariation: 'original',
-		allowExistingUsers: true,
-		localeTargets: 'any',
-	},
 	unlimitedThemeNudge: {
 		datestamp: '20171016',
 		variations: {


### PR DESCRIPTION
This removes the code for the A/B test to recommend the shortest domain name that was added in #17974.

