### PR TITLE
Rewind: Format event descriptions

### DIFF
--- a/client/lib/notifications/note-block-parser.js
+++ b/client/lib/notifications/note-block-parser.js
@@ -1,0 +1,247 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { compact, find, initial } from 'lodash';
+
+/**
+ * Comparator function for sorting formatted ranges
+ *
+ * A range is considered to be before another range if:
+ *   - it's a zero-length range and the other isn't
+ *   - it starts before the other
+ *   - it has the same start but ends before the other
+ *
+ * @param {Number} aStart start index of first range
+ * @param {Number} aEnd end index of first range
+ * @param {Number} bStart start index of second range
+ * @param {Number} bEnd end index of second range
+ * @returns {Number} -1/0/1 indicating sort order
+ */
+const rangeSort = ( { indices: [ aStart, aEnd ] }, { indices: [ bStart, bEnd ] } ) => {
+	// some "invisible" tokens appear as zero-length ranges
+	// at the beginning of certain formatted blocks
+	if ( aStart === 0 && aEnd === 0 && bEnd !== 0 ) {
+		return -1;
+	}
+
+	if ( aStart < bStart ) {
+		return -1;
+	}
+
+	if ( bStart < aStart ) {
+		return 1;
+	}
+
+	return bEnd - aEnd;
+};
+
+/**
+ * Returns a function which will say if another range
+ * is "fully contained" within in: if it "encloses"
+ *
+ * A range is "enclosed" by another range if it falls
+ * entirely within the indices of another. Two ranges
+ * with the same indices will enclose one another.
+ *
+ * "inner" is the range under test
+ * "outer" is the range that may enclose "inner"
+ *
+ * The initial "invisible token" ranges are not enclosed
+ *
+ * @param {Number} innerStart start of possibly-inner range
+ * @param {Number} innerEnd end of possibly-inner range
+ * @returns {function({indices: Number[]}): Boolean} performs the check
+ */
+const encloses = ( { indices: [ innerStart, innerEnd ] } ) =>
+	/**
+	 * Indicates if the given range encloses the first "inner" range
+	 *
+	 * @param {Number} outerStart start of possibly-outer range
+	 * @param {Number} outerEnd end of possibly-outer range
+	 * @returns {Boolean} whether the "outer" range encloses the "inner" range
+	 */
+	( { indices: [ outerStart, outerEnd ] = [ 0, 0 ] } ) =>
+		innerStart !== 0 && innerEnd !== 0 && ( outerStart <= innerStart && outerEnd >= innerEnd );
+
+/**
+ * Builds a tree of ranges
+ * Converts from list of intervals to tree
+ *
+ * Formats are given as a list of ranges of attributed text.
+ * These ranges may nest within each other. We need to be
+ * able to transform from the separated list view into the
+ * more meaningful list view.
+ *
+ * This function take a tree of existing ranges, finds the
+ * nearest parent range if available, and inserts the given
+ * range into the tree.
+ *
+ * A range is a parent of another if it "encloses" the range.
+ *
+ * @param {Object[]} ranges the tree of ranges
+ * @param {Object} range the range to add
+ * @returns {Object[]} the new tree
+ */
+const addRange = ( ranges, range ) => {
+	const parent = find( ranges, encloses( range ) );
+
+	return parent
+		? [ ...initial( ranges ), { ...parent, children: addRange( parent.children, range ) } ]
+		: [ ...ranges, range ];
+};
+
+//
+// Range type mappings: extract and normalize necessary data from range objects
+//
+
+const commentNode = ( { id: commentId, post_id: postId, site_id: siteId } ) => ( {
+	type: 'comment',
+	commentId,
+	postId,
+	siteId,
+} );
+
+const linkNode = ( { url } ) => ( { type: 'link', url } );
+
+const postNode = ( { id: postId, site_id: siteId } ) => ( { type: 'post', postId, siteId } );
+
+const siteNode = ( { id: siteId } ) => ( { type: 'site', siteId } );
+
+const typedNode = ( { type } ) => ( { type } );
+
+const userNode = ( { id: userId, name, site_id: siteId } ) => ( {
+	type: 'person',
+	name,
+	siteId,
+	userId,
+} );
+
+const inferNode = range => {
+	const { type, url } = range;
+
+	if ( type ) {
+		return typedNode( range );
+	}
+
+	if ( url ) {
+		return linkNode( range );
+	}
+
+	return range;
+};
+
+//
+// End of range-type mapping
+//
+
+/**
+ * Returns function to map range to node
+ *
+ * @param {String} type type of node specified in range
+ * @returns {function(Object): Object} maps block to meta data
+ */
+const nodeMappings = type => {
+	switch ( type ) {
+		case 'comment':
+			return commentNode;
+
+		case 'post':
+			return postNode;
+
+		case 'site':
+			return siteNode;
+
+		case 'user':
+			return userNode;
+
+		default:
+			return inferNode;
+	}
+};
+
+/**
+ * Creates a node with appropriate properties
+ * extracted from text and range information
+ *
+ * @param {Object|String} text original text message
+ * @param {Object} range contains type and meta information
+ * @returns {{children: *[]}} new node
+ */
+const newNode = ( text, range = {} ) => ( {
+	...nodeMappings( range.type )( range ),
+	children: [ text ],
+} );
+
+/**
+ * Reducer to combine ongoing results with new results
+ *
+ * @param {?Array} reduced existing results
+ * @param {?Array} remainder new results
+ * @returns {Array} combined results
+ */
+const joinResults = ( [ reduced, remainder ] ) =>
+	reduced.length // eslint-disable-line no-nested-ternary
+		? compact( reduced.concat( remainder ) )
+		: remainder.length ? [ remainder ] : [];
+
+/**
+ * Parses a formatted text block into typed nodes
+ * Recursive reducer function
+ *
+ * Note: Although recursive, we don't expect to see
+ * large recursion trees here. Most blocks will have
+ * on the order of a few ranges at most so there is
+ * little fear of overflowing the call stack. If we
+ * start parsing more complicated blocks we will need
+ * to implement some kind of stack safety here such
+ * as the use of a "trampoline".
+ *
+ * @param {Array} accum.0 previously parsed results
+ * @param {String} accum.1 remaining text to parse
+ * @param {Number} accum.2 current index into text string
+ * @param {Object} nextRange next range from formatted block
+ * @returns {Array} parsed results: text and nodes
+ */
+const parse = ( [ prev, text, offset ], nextRange ) => {
+	const { indices: [ start, end ] } = nextRange;
+	const offsetStart = start - offset;
+	const offsetEnd = end - offset;
+
+	// Sometimes there's text before the first range
+	const preText = offsetStart > 0 ? [ text.slice( 0, offsetStart ) ] : [];
+
+	// recurse into the children of the top-level ranges
+	const children = joinResults(
+		nextRange.children.reduce( parse, [ [], text.slice( offsetStart, offsetEnd ), start ] )
+	);
+
+	const parsed = Object.assign(
+		newNode( text.slice( offsetStart, offsetEnd ), nextRange ),
+		children.length && { children }
+	);
+
+	return [ [ ...prev, ...preText, parsed ], text.slice( offsetEnd ), end ];
+};
+
+/**
+ * Parses a formatted text block into typed nodes
+ *
+ * Uses the recursive helper after doing some
+ * prep work on the list of block ranges.
+ *
+ * @see parse
+ *
+ * @param {Object} block the block to parse
+ * @returns {Array} list of text and node segments with children
+ */
+export const parseBlock = block =>
+	block.ranges // is it complex or unformatted text?
+		? joinResults(
+				block.ranges
+					.map( o => ( { ...o, children: [] } ) )
+					.sort( rangeSort )
+					.reduce( addRange, [] )
+					.reduce( parse, [ [], block.text, 0 ] )
+			)
+		: [ newNode( block ) ];

--- a/client/my-sites/stats/activity-log-item/index.jsx
+++ b/client/my-sites/stats/activity-log-item/index.jsx
@@ -88,14 +88,81 @@ class ActivityLogItem extends Component {
 	}
 
 	renderHeader() {
-		const { log } = this.props;
+		const { applySiteOffset, log, moment } = this.props;
+		const { activityDescription, activityTitle } = log;
 
 		return (
 			<div className="activity-log-item__card-header">
 				<ActivityActor
 					{ ...pick( log, [ 'actorAvatarUrl', 'actorName', 'actorRole', 'actorType' ] ) }
 				/>
-				<div className="activity-log-item__title">{ log.activityTitle }</div>
+				<div className="activity-log-item__description">
+					{ ! activityDescription && activityTitle }
+					{ activityDescription &&
+						activityDescription.map( ( part, key ) => {
+							if ( 'string' === typeof part ) {
+								return part;
+							}
+
+							const { siteId, children, commentId, name, postId, type } = part;
+
+							switch ( type ) {
+								case 'comment':
+									return (
+										<a
+											key={ key }
+											href={ `/read/blogs/${ siteId }/posts/${ postId }#comment-${ commentId }` }
+										>
+											{ children }
+										</a>
+									);
+
+								case 'filepath':
+									return (
+										<div>
+											<code>{ children }</code>
+										</div>
+									);
+
+								case 'person':
+									return (
+										<a key={ key } href={ `/people/edit/${ siteId }/${ name }` }>
+											<strong>{ children }</strong>
+										</a>
+									);
+
+								case 'plugin':
+									return (
+										<a key={ key } href={ `/plugins/${ name }/${ siteId }` }>
+											{ children }
+										</a>
+									);
+
+								case 'post':
+									return (
+										<a key={ key } href={ `/read/blogs/${ siteId }/posts/${ postId }` }>
+											<em>{ children }</em>
+										</a>
+									);
+
+								case 'theme':
+									return (
+										<a key={ key } href={ part.url } target="_blank" rel="noopener noreferrer">
+											<strong>
+												<em>{ children }</em>
+											</strong>
+										</a>
+									);
+
+								case 'time':
+									return applySiteOffset( moment.utc( part.time ) ).format( part.format );
+
+								default:
+									return null;
+							}
+						} ) }
+					{ /*<div className="activity-log-item__event">{ eventName }</div>*/ }
+				</div>
 			</div>
 		);
 	}

--- a/client/my-sites/stats/activity-log-item/index.jsx
+++ b/client/my-sites/stats/activity-log-item/index.jsx
@@ -96,10 +96,12 @@ class ActivityLogItem extends Component {
 				<ActivityActor
 					{ ...pick( log, [ 'actorAvatarUrl', 'actorName', 'actorRole', 'actorType' ] ) }
 				/>
-				<div className="activity-log-item__description">
-					{ ! activityDescription && activityTitle }
-					{ activityDescription &&
-						activityDescription.map( ( part, key ) => {
+				{ ! activityDescription && (
+					<div className="activity-log-item__title">{ activityTitle }</div>
+				) }
+				{ activityDescription && (
+					<div className="activity-log-item__description">
+						{ activityDescription.map( ( part, key ) => {
 							if ( 'string' === typeof part ) {
 								return part;
 							}
@@ -158,11 +160,11 @@ class ActivityLogItem extends Component {
 									return applySiteOffset( moment.utc( part.time ) ).format( part.format );
 
 								default:
-									return null;
+									return children;
 							}
 						} ) }
-					{ /*<div className="activity-log-item__event">{ eventName }</div>*/ }
-				</div>
+					</div>
+				) }
 			</div>
 		);
 	}

--- a/client/my-sites/stats/activity-log-item/style.scss
+++ b/client/my-sites/stats/activity-log-item/style.scss
@@ -209,3 +209,12 @@
 		margin-top: 8px;
 	}
 }
+
+.activity-log-item__description {
+	font-size: 14px;
+}
+
+.activity-log-item__event {
+	color: $gray-text-min;
+	font-size: 12px;
+}

--- a/client/my-sites/stats/activity-log-item/style.scss
+++ b/client/my-sites/stats/activity-log-item/style.scss
@@ -1,8 +1,9 @@
+/** @format */
 .activity-log-item {
 	display: flex;
 	position: relative;
 
-	@include breakpoint( "<480px" ) {
+	@include breakpoint( '<480px' ) {
 		margin-left: 8px;
 	}
 
@@ -21,13 +22,13 @@
 			margin-bottom: 24px;
 
 			.foldable-card__expand .gridicon {
-				transform: rotate( 180deg );
+				transform: rotate(180deg);
 			}
 		}
 	}
 
 	.foldable-card__header {
-		@include breakpoint( "<480px" ) {
+		@include breakpoint( '<480px' ) {
 			padding: 12px;
 		}
 
@@ -44,19 +45,19 @@
 	&.is-discarded {
 		margin-left: 80px;
 
-		@include breakpoint( "<480px" ) {
+		@include breakpoint( '<480px' ) {
 			margin-left: 60px;
 		}
 
 		&:before {
 			content: '';
 			position: absolute;
-				top: 0;
-				left: 33px;
+			top: 0;
+			left: 33px;
 			height: 100%;
-			border-left: 2px dotted lighten( $gray, 20% );
+			border-left: 2px dotted lighten($gray, 20%);
 
-			@include breakpoint( "<480px" ) {
+			@include breakpoint( '<480px' ) {
 				left: 22px;
 			}
 		}
@@ -77,7 +78,7 @@
 	padding: 4px 0 6px;
 	z-index: 1;
 
-	@include breakpoint( "<480px" ) {
+	@include breakpoint( '<480px' ) {
 		margin: -2px 8px 0 0px;
 	}
 }
@@ -88,7 +89,7 @@
 	text-transform: uppercase;
 	white-space: nowrap;
 
-	@include breakpoint( "<480px" ) {
+	@include breakpoint( '<480px' ) {
 		letter-spacing: -1px;
 	}
 }
@@ -102,7 +103,7 @@
 	padding: 12px;
 	margin-top: 2px;
 
-	@include breakpoint( "<480px" ) {
+	@include breakpoint( '<480px' ) {
 		padding: 10px;
 	}
 
@@ -124,7 +125,7 @@
 	.is-discarded & {
 		color: $gray-text;
 		background: none;
-		border: 1px solid transparentize( lighten( $gray, 20% ), .5 );
+		border: 1px solid transparentize(lighten($gray, 20%), 0.5);
 	}
 }
 
@@ -132,12 +133,12 @@
 	.foldable-card__content {
 		padding: 16px;
 		font-size: 14px;
-		color: darken( $gray, 20% );
+		color: darken($gray, 20%);
 	}
 
 	.is-discarded & {
 		background: none;
-		box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 );
+		box-shadow: 0 0 0 1px transparentize(lighten($gray, 20%), 0.5);
 	}
 }
 
@@ -146,7 +147,7 @@
 	flex-wrap: wrap;
 	margin-right: 32px;
 
-	@include breakpoint( "<960px" ) {
+	@include breakpoint( '<960px' ) {
 		flex-direction: column;
 		align-items: flex-start;
 	}
@@ -163,9 +164,9 @@
 		width: 40px;
 		height: 40px;
 		margin-right: 16px;
-		fill: darken( $gray, 10% );
+		fill: darken($gray, 10%);
 
-		@include breakpoint( "<960px" ) {
+		@include breakpoint( '<960px' ) {
 			width: 32px;
 			height: 32px;
 			margin-right: 8px;
@@ -180,7 +181,7 @@
 
 	.jetpack-logo {
 		.is-discarded & {
-			opacity: .75;
+			opacity: 0.75;
 		}
 	}
 }
@@ -188,7 +189,7 @@
 .activity-log-item__actor-name {
 	font-size: 14px;
 
-	@include breakpoint( "<960px" ) {
+	@include breakpoint( '<960px' ) {
 		margin-top: 2px;
 		line-height: 1;
 	}
@@ -205,16 +206,11 @@
 	font-size: 14px;
 	word-break: break-word;
 
-	@include breakpoint( "<960px" ) {
+	@include breakpoint( '<960px' ) {
 		margin-top: 8px;
 	}
 }
 
 .activity-log-item__description {
 	font-size: 14px;
-}
-
-.activity-log-item__event {
-	color: $gray-text-min;
-	font-size: 12px;
 }

--- a/client/state/data-layer/wpcom/sites/activity/from-api.js
+++ b/client/state/data-layer/wpcom/sites/activity/from-api.js
@@ -7,6 +7,7 @@ import { get, map } from 'lodash';
 /**
  * Internal dependencies
  */
+import { parseBlock } from 'lib/notifications/note-block-parser';
 import { makeParser } from 'state/data-layer/wpcom-http/utils';
 import apiResponseSchema from './schema';
 
@@ -37,6 +38,7 @@ export function transformer( apiResponse ) {
 export function processItem( item ) {
 	const published = item.published;
 	const actor = item.actor;
+	const isFormatted = 'string' !== typeof item.summary;
 
 	return {
 		/* activity actor */
@@ -57,8 +59,9 @@ export function processItem( item ) {
 		activityName: item.name,
 		activityStatus: item.status,
 		activityTargetTs: get( item, 'object.target_ts', undefined ),
-		activityTitle: get( item, 'summary', '' ),
+		activityTitle: isFormatted ? get( item, 'summary.text', '' ) : item.summary,
 		activityTs: Date.parse( published ),
+		activityDescription: isFormatted ? parseBlock( item.summary ) : undefined,
 	};
 }
 

--- a/client/state/data-layer/wpcom/sites/activity/schema.json
+++ b/client/state/data-layer/wpcom/sites/activity/schema.json
@@ -77,7 +77,7 @@
 						}
 					]
 				},
-				"summary": { "type": "string" },
+				"summary": { "type": [ "object", "string" ] },
 				"target": { "type": "object" },
 				"target_ts": { "type": "number" },
 				"totalItems": {


### PR DESCRIPTION
@see D8335 for API work and testing

Activity Log summaries contain references to resources in Calypso of meaningful value. Unfortunately, those references remain hidden inside the unformatted string that's displayed and customers are left without ways of conveniently acting upon those summaries.

In this PR we're adding in a system to interpret the activity summaries (with help from addition information in the API responses) such that appropriate resources are visually distinguished from the plain text around them and so that there are actionable links embedded in the message. This would, for example, allow someone to navigate directly to a post that has been published or to a plugin which was updated.

At this stage the API isn't returning the meta information needed for format, so testing should reveal no visual changes. However, if D8335 is applied and sandboxed then a few events (at the time of writing just a couple comment events and a plugin update available event) should receive formatting. This illustrates that this is a progressive enhancement and we can export more support as time continues.

~Up for review and discussion is primary the reuse of `summary` in the API response and `activityTitle` in the client. We have a structured object in one and a plain string of text in the other; will this cause problems?~ <ins>The API will eventually return the formatted object for every event even if it has no formatting, but this PR is still relevant because we can't start sending those objects until we know that Calypso won't break when it receives them.</ins>

@elibud with this implementation I have directly reused notifications block formatting code on the server. This also means that formatting is going to be handled there and as we discussed, will be manually overwritten by means of passing the language slug in the API calls.

**Before**
<img width="413" alt="screen shot 2017-11-20 at 3 17 51 pm" src="https://user-images.githubusercontent.com/5431237/33039450-a004412e-cdfd-11e7-8b46-db6a95ee0ca0.png">

**After**
<img width="419" alt="screen shot 2017-11-20 at 3 16 25 pm" src="https://user-images.githubusercontent.com/5431237/33039418-81c01eea-cdfd-11e7-903d-0af9a1d14f79.png">
