### PR TITLE
Store Promotions: Adjust individual coupon label

### DIFF
--- a/client/extensions/woocommerce/app/promotions/promotion-models.js
+++ b/client/extensions/woocommerce/app/promotions/promotion-models.js
@@ -196,7 +196,7 @@ const couponConditions = {
 		},
 		individualUse: {
 			component: FormField,
-			labelText: translate( 'Cannot be combined with any other promotion' ),
+			labelText: translate( 'Cannot be combined with any other coupon' ),
 			isEnableable: true,
 			defaultValue: true,
 		},


### PR DESCRIPTION
Addresses #19506 

This adjusts the individual coupon label to clarify meaning.

To Test:
1. `npm start`
2. Visit `http://calypso.localhost:3000/store/promotion/<site url>`
3. Verify new text.

![new_promotion_ _coderkevin_ _wordpress_com](https://user-images.githubusercontent.com/945228/32469807-031f5404-c31a-11e7-9185-059e8e956acc.png)
