### PR TITLE
Fix single-tree-render codemod remove extra new lines only in modified files

### DIFF
--- a/bin/codemods/src/single-tree-rendering.js
+++ b/bin/codemods/src/single-tree-rendering.js
@@ -111,5 +111,7 @@ export default function transformer( file, api ) {
 			.insertAfter( "import { makeLayout, render as clientRender } from 'controller';" );
 	}
 
-	return removeExtraNewlines( root.toSource( config.recastOptions ) );
+	const source = root.toSource( config.recastOptions );
+
+	return routeDefs.size() ? removeExtraNewlines( source ) : source;
 }


### PR DESCRIPTION
Removes extra new lines between two import statements only when file is modified.

Related to PR #19494 _"Single tree-rendering-issues"_

That `removeExtraNewlines()` turns this:
```js
import { preloadReaderBundle, sidebar, updateLastRoute } from 'reader/controller'; 

import { makeLayout, render as clientRender } from 'controller';
```
into this:
```js
import { preloadReaderBundle, sidebar, updateLastRoute } from 'reader/controller';
import { makeLayout, render as clientRender } from 'controller';
```
...since it's something Prettier doesn't do for us.

Previously in this codemod these kind of extra empty lines would be removed also from files this codemod didn't modify. Now they'll be removed only from files where we add that import `makeLayout`/`clientRender`.

Empty lines are caused by bug in `insertAfter()`: https://github.com/benjamn/recast/issues/371

### To test

```bash
npm run codemod single-tree-rendering ./client/my-sites/checkout/index.js
```
→ Adds new import, but no newlines

```bash
npm run codemod single-tree-rendering ./client/my-sites/domains/components/form/test/hidden-input.js
```
→ Doesn't add import and won't fix old empty lines between imports