### PR TITLE
PostTypeList: When clicking a post the user cannot edit, open it in a new tab

### DIFF
--- a/client/blocks/post-item/index.jsx
+++ b/client/blocks/post-item/index.jsx
@@ -25,6 +25,7 @@ import {
 	isPostSelected,
 } from 'state/ui/post-type-list/selectors';
 import { hideSharePanel, togglePostSelection } from 'state/ui/post-type-list/actions';
+import ExternalLink from 'components/external-link';
 import FormInputCheckbox from 'components/forms/form-checkbox';
 import PostTime from 'blocks/post-time';
 import PostStatus from 'blocks/post-status';
@@ -129,10 +130,6 @@ class PostItem extends React.Component {
 			'is-expanded': !! expandedContent,
 		} );
 
-		const editLinkClasses = classnames( 'post-item__title-link', {
-			'is-external': externalPostLink,
-		} );
-
 		return (
 			<div className={ rootClasses } ref={ this.setDomNode }>
 				<div className={ panelClasses }>
@@ -143,14 +140,17 @@ class PostItem extends React.Component {
 							{ isAuthorVisible && <PostTypePostAuthor globalId={ globalId } /> }
 						</div>
 						<h1 className="post-item__title">
-							<a
-								href={ isPlaceholder ? null : postUrl }
-								target={ externalPostLink ? '_blank' : null }
-								rel={ externalPostLink ? 'noopener noreferrer' : null }
-								className={ editLinkClasses }
-							>
-								{ title || translate( 'Untitled' ) }
-							</a>
+							{ ! externalPostLink && (
+								<a href={ isPlaceholder ? null : postUrl } className="post-item__title-link">
+									{ title || translate( 'Untitled' ) }
+								</a>
+							) }
+							{ ! isPlaceholder &&
+							externalPostLink && (
+								<ExternalLink icon={ true } href={ postUrl } className="post-item__title-link">
+									{ title || translate( 'Untitled' ) }
+								</ExternalLink>
+							) }
 						</h1>
 						<div className="post-item__meta">
 							<PostTime globalId={ globalId } />

--- a/client/blocks/post-item/index.jsx
+++ b/client/blocks/post-item/index.jsx
@@ -147,7 +147,12 @@ class PostItem extends React.Component {
 							) }
 							{ ! isPlaceholder &&
 							externalPostLink && (
-								<ExternalLink icon={ true } href={ postUrl } className="post-item__title-link">
+								<ExternalLink
+									icon={ true }
+									href={ postUrl }
+									target="_blank"
+									className="post-item__title-link"
+								>
 									{ title || translate( 'Untitled' ) }
 								</ExternalLink>
 							) }

--- a/client/blocks/post-item/index.jsx
+++ b/client/blocks/post-item/index.jsx
@@ -109,10 +109,11 @@ class PostItem extends React.Component {
 		} = this.props;
 
 		const title = post ? post.title : null;
+		const isPlaceholder = ! globalId;
 
 		const panelClasses = classnames( 'post-item__panel', className, {
 			'is-untitled': ! title,
-			'is-placeholder': ! globalId,
+			'is-placeholder': isPlaceholder,
 			'has-large-title': largeTitle,
 			'has-wrapped-title': wrapTitle,
 		} );
@@ -143,7 +144,7 @@ class PostItem extends React.Component {
 						</div>
 						<h1 className="post-item__title">
 							<a
-								href={ postUrl }
+								href={ isPlaceholder ? null : postUrl }
 								target={ externalPostLink ? '_blank' : null }
 								rel={ externalPostLink ? 'noopener noreferrer' : null }
 								className={ editLinkClasses }

--- a/client/blocks/post-item/index.jsx
+++ b/client/blocks/post-item/index.jsx
@@ -78,7 +78,7 @@ class PostItem extends React.Component {
 		);
 	}
 
-	renderVariableHeightContent() {
+	renderExpandedContent() {
 		const { post, isCurrentSharePanelOpen } = this.props;
 
 		if ( ! post || ! isCurrentSharePanelOpen ) {
@@ -122,11 +122,10 @@ class PostItem extends React.Component {
 		const isAuthorVisible =
 			isEnabled( 'posts/post-type-list' ) && this.hasMultipleUsers() && post && post.author;
 
-		const variableHeightContent = this.renderVariableHeightContent();
-		this.hasVariableHeightContent = !! variableHeightContent;
+		const expandedContent = this.renderExpandedContent();
 
 		const rootClasses = classnames( 'post-item', {
-			'is-expanded': this.hasVariableHeightContent,
+			'is-expanded': !! expandedContent,
 		} );
 
 		const editLinkClasses = classnames( 'post-item__title-link', {
@@ -160,7 +159,7 @@ class PostItem extends React.Component {
 					<PostTypeListPostThumbnail globalId={ globalId } />
 					<PostActionsEllipsisMenu globalId={ globalId } />
 				</div>
-				{ variableHeightContent }
+				{ expandedContent }
 			</div>
 		);
 	}

--- a/client/blocks/post-item/style.scss
+++ b/client/blocks/post-item/style.scss
@@ -119,16 +119,6 @@ a.post-item__title-link:visited {
 	.post-item__panel.is-placeholder & {
 		@include placeholder;
 	}
-
-	&.is-external {
-		&:after {
-			@include noticon( '\f442' );
-			font-size: 18px;
-			padding-left: 3px;
-			vertical-align: middle;
-			color: $gray-text-min;
-		}
-	}
 }
 
 .post-item__meta {

--- a/client/blocks/post-item/style.scss
+++ b/client/blocks/post-item/style.scss
@@ -119,6 +119,16 @@ a.post-item__title-link:visited {
 	.post-item__panel.is-placeholder & {
 		@include placeholder;
 	}
+
+	&.is-external {
+		&:after {
+			@include noticon( '\f442' );
+			font-size: 18px;
+			padding-left: 3px;
+			vertical-align: middle;
+			color: $gray-text-min;
+		}
+	}
 }
 
 .post-item__meta {

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/duplicate.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/duplicate.jsx
@@ -14,10 +14,8 @@ import { get, includes } from 'lodash';
  * Internal dependencies
  */
 import PopoverMenuItem from 'components/popover/menu-item';
-import { canCurrentUser } from 'state/selectors';
 import { getPost } from 'state/posts/selectors';
-import { getPostType } from 'state/post-types/selectors';
-import { getCurrentUserId, isValidCapability } from 'state/current-user/selectors';
+import { canCurrentUserEditPost } from 'state/selectors';
 import { getEditorDuplicatePostPath } from 'state/ui/editor/selectors';
 import { isEnabled } from 'config';
 import { bumpStat as bumpAnalyticsStat } from 'state/analytics/actions';
@@ -58,19 +56,9 @@ const mapStateToProps = ( state, { globalId } ) => {
 		return {};
 	}
 
-	const type = getPostType( state, post.site_ID, post.type );
-	const userId = getCurrentUserId( state );
-	const isAuthor = get( post.author, 'ID' ) === userId;
-
-	let capability = isAuthor ? 'edit_posts' : 'edit_others_posts';
-	const typeCapability = get( type, [ 'capabilities', capability ] );
-	if ( isValidCapability( state, post.site_ID, typeCapability ) ) {
-		capability = typeCapability;
-	}
-
 	return {
+		canEdit: canCurrentUserEditPost( state, globalId ),
 		status: post.status,
-		canEdit: canCurrentUser( state, post.site_ID, capability ),
 		duplicateUrl: getEditorDuplicatePostPath( state, post.site_ID, post.ID ),
 	};
 };

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/edit.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/edit.jsx
@@ -16,19 +16,11 @@ import { get } from 'lodash';
 import PopoverMenuItem from 'components/popover/menu-item';
 import { bumpStat as bumpAnalyticsStat } from 'state/analytics/actions';
 import { bumpStatGenerator } from './utils';
-import { canCurrentUser } from 'state/selectors';
 import { getPost } from 'state/posts/selectors';
-import { getPostType } from 'state/post-types/selectors';
-import { getCurrentUserId, isValidCapability } from 'state/current-user/selectors';
+import { canCurrentUserEditPost } from 'state/selectors';
 import { getEditorPath } from 'state/ui/editor/selectors';
 
-function PostActionsEllipsisMenuEdit( {
-	translate,
-	canEdit,
-	status,
-	editUrl,
-	bumpStat,
-} ) {
+function PostActionsEllipsisMenuEdit( { translate, canEdit, status, editUrl, bumpStat } ) {
 	if ( 'trash' === status || ! canEdit ) {
 		return null;
 	}
@@ -55,18 +47,8 @@ const mapStateToProps = ( state, { globalId } ) => {
 		return {};
 	}
 
-	const type = getPostType( state, post.site_ID, post.type );
-	const userId = getCurrentUserId( state );
-	const isAuthor = get( post.author, 'ID' ) === userId;
-
-	let capability = isAuthor ? 'edit_posts' : 'edit_others_posts';
-	const typeCapability = get( type, [ 'capabilities', capability ] );
-	if ( isValidCapability( state, post.site_ID, typeCapability ) ) {
-		capability = typeCapability;
-	}
-
 	return {
-		canEdit: canCurrentUser( state, post.site_ID, capability ),
+		canEdit: canCurrentUserEditPost( state, globalId ),
 		status: post.status,
 		editUrl: getEditorPath( state, post.site_ID, post.ID ),
 	};

--- a/client/state/selectors/can-current-user-edit-post.js
+++ b/client/state/selectors/can-current-user-edit-post.js
@@ -1,0 +1,40 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { getPost } from 'state/posts/selectors';
+import { getPostType } from 'state/post-types/selectors';
+import { getCurrentUserId, isValidCapability } from 'state/current-user/selectors';
+import { canCurrentUser } from 'state/selectors';
+
+/**
+ * Returns whether the current user can edit the post with the given global ID.
+ *
+ * @param  {Object}  state    Global state tree
+ * @param  {String}  globalId Post global ID
+ * @return {Boolean}          Whether the current user can edit the given post
+ */
+export default function canCurrentUserEditPost( state, globalId ) {
+	const post = getPost( state, globalId );
+	if ( ! post ) {
+		return null;
+	}
+
+	const type = getPostType( state, post.site_ID, post.type );
+	const userId = getCurrentUserId( state );
+	const isAuthor = get( post.author, 'ID' ) === userId;
+
+	let capability = isAuthor ? 'edit_posts' : 'edit_others_posts';
+	const typeCapability = get( type, [ 'capabilities', capability ] );
+	if ( isValidCapability( state, post.site_ID, typeCapability ) ) {
+		capability = typeCapability;
+	}
+
+	return canCurrentUser( state, post.site_ID, capability );
+}

--- a/client/state/selectors/index.js
+++ b/client/state/selectors/index.js
@@ -17,6 +17,7 @@
 export areAllSitesSingleUser from './are-all-sites-single-user';
 export areSitePermalinksEditable from './are-site-permalinks-editable';
 export canCurrentUser from './can-current-user';
+export canCurrentUserEditPost from './can-current-user-edit-post';
 export canCurrentUserManagePlugins from './can-current-user-manage-plugins';
 export countPostLikes from './count-post-likes';
 export editedPostHasContent from './edited-post-has-content';

--- a/client/state/selectors/test/can-current-user-edit-post.js
+++ b/client/state/selectors/test/can-current-user-edit-post.js
@@ -1,0 +1,515 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { canCurrentUserEditPost } from '../';
+
+describe( 'canCurrentUserEditPost()', () => {
+	const fakeGlobalId = 'abcdef1234';
+	const fakeUserId = 1;
+	const fakeOtherUserId = 2;
+	const fakeSiteId = 3;
+	const fakePostId = 4;
+
+	test( 'should return null if the post is not known', () => {
+		const canEdit = canCurrentUserEditPost(
+			{
+				posts: {
+					items: {},
+					queries: {},
+				},
+			},
+			fakeGlobalId
+		);
+
+		expect( canEdit ).to.be.null;
+	} );
+
+	test( "should allow based on 'edit_posts' for unrecognized post type (author)", () => {
+		const canEdit = canCurrentUserEditPost(
+			{
+				posts: {
+					items: {
+						[ fakeGlobalId ]: [ fakeSiteId, fakePostId ],
+					},
+					queries: {
+						[ fakeSiteId ]: {
+							getItem( postId ) {
+								if ( postId === fakePostId ) {
+									return {
+										type: 'post',
+										global_ID: fakeGlobalId,
+										site_ID: fakeSiteId,
+										ID: fakePostId,
+										author: {
+											ID: fakeUserId,
+										},
+									};
+								}
+
+								return null;
+							},
+						},
+					},
+				},
+				postTypes: {
+					items: {},
+				},
+				currentUser: {
+					id: fakeUserId,
+					capabilities: {
+						[ fakeSiteId ]: {
+							edit_posts: true,
+						},
+					},
+				},
+			},
+			fakeGlobalId
+		);
+
+		expect( canEdit ).to.be.true;
+	} );
+
+	test( "should deny based on 'edit_posts' for unrecognized post type (author)", () => {
+		const canEdit = canCurrentUserEditPost(
+			{
+				posts: {
+					items: {
+						[ fakeGlobalId ]: [ fakeSiteId, fakePostId ],
+					},
+					queries: {
+						[ fakeSiteId ]: {
+							getItem( postId ) {
+								if ( postId === fakePostId ) {
+									return {
+										type: 'post',
+										global_ID: fakeGlobalId,
+										site_ID: fakeSiteId,
+										ID: fakePostId,
+										author: {
+											ID: fakeUserId,
+										},
+									};
+								}
+
+								return null;
+							},
+						},
+					},
+				},
+				postTypes: {
+					items: {},
+				},
+				currentUser: {
+					id: fakeUserId,
+					capabilities: {
+						[ fakeSiteId ]: {
+							edit_posts: false,
+						},
+					},
+				},
+			},
+			fakeGlobalId
+		);
+
+		expect( canEdit ).to.be.false;
+	} );
+
+	test( "should allow based on 'edit_others_posts' for unrecognized post type (not author)", () => {
+		const canEdit = canCurrentUserEditPost(
+			{
+				posts: {
+					items: {
+						[ fakeGlobalId ]: [ fakeSiteId, fakePostId ],
+					},
+					queries: {
+						[ fakeSiteId ]: {
+							getItem( postId ) {
+								if ( postId === fakePostId ) {
+									return {
+										type: 'post',
+										global_ID: fakeGlobalId,
+										site_ID: fakeSiteId,
+										ID: fakePostId,
+										author: {
+											ID: fakeOtherUserId,
+										},
+									};
+								}
+
+								return null;
+							},
+						},
+					},
+				},
+				postTypes: {
+					items: {},
+				},
+				currentUser: {
+					id: fakeUserId,
+					capabilities: {
+						[ fakeSiteId ]: {
+							edit_others_posts: true,
+						},
+					},
+				},
+			},
+			fakeGlobalId
+		);
+
+		expect( canEdit ).to.be.true;
+	} );
+
+	test( "should deny based on 'edit_others_posts' for unrecognized post type (not author)", () => {
+		const canEdit = canCurrentUserEditPost(
+			{
+				posts: {
+					items: {
+						[ fakeGlobalId ]: [ fakeSiteId, fakePostId ],
+					},
+					queries: {
+						[ fakeSiteId ]: {
+							getItem( postId ) {
+								if ( postId === fakePostId ) {
+									return {
+										type: 'post',
+										global_ID: fakeGlobalId,
+										site_ID: fakeSiteId,
+										ID: fakePostId,
+										author: {
+											ID: fakeOtherUserId,
+										},
+									};
+								}
+
+								return null;
+							},
+						},
+					},
+				},
+				postTypes: {
+					items: {},
+				},
+				currentUser: {
+					id: fakeUserId,
+					capabilities: {
+						[ fakeSiteId ]: {
+							edit_others_posts: false,
+						},
+					},
+				},
+			},
+			fakeGlobalId
+		);
+
+		expect( canEdit ).to.be.false;
+	} );
+
+	test( 'should allow based on post type capability (author)', () => {
+		const canEdit = canCurrentUserEditPost(
+			{
+				posts: {
+					items: {
+						[ fakeGlobalId ]: [ fakeSiteId, fakePostId ],
+					},
+					queries: {
+						[ fakeSiteId ]: {
+							getItem( postId ) {
+								if ( postId === fakePostId ) {
+									return {
+										type: 'some_cpt',
+										global_ID: fakeGlobalId,
+										site_ID: fakeSiteId,
+										ID: fakePostId,
+										author: {
+											ID: fakeUserId,
+										},
+									};
+								}
+
+								return null;
+							},
+						},
+					},
+				},
+				postTypes: {
+					items: {
+						[ fakeSiteId ]: {
+							some_cpt: {
+								capabilities: {
+									edit_posts: 'cpt_edit_posts',
+								},
+							},
+						},
+					},
+				},
+				currentUser: {
+					id: fakeUserId,
+					capabilities: {
+						[ fakeSiteId ]: {
+							cpt_edit_posts: true,
+						},
+					},
+				},
+			},
+			fakeGlobalId
+		);
+
+		expect( canEdit ).to.be.true;
+	} );
+
+	test( 'should deny based on post type capability (author)', () => {
+		const canEdit = canCurrentUserEditPost(
+			{
+				posts: {
+					items: {
+						[ fakeGlobalId ]: [ fakeSiteId, fakePostId ],
+					},
+					queries: {
+						[ fakeSiteId ]: {
+							getItem( postId ) {
+								if ( postId === fakePostId ) {
+									return {
+										type: 'some_cpt',
+										global_ID: fakeGlobalId,
+										site_ID: fakeSiteId,
+										ID: fakePostId,
+										author: {
+											ID: fakeUserId,
+										},
+									};
+								}
+
+								return null;
+							},
+						},
+					},
+				},
+				postTypes: {
+					items: {
+						[ fakeSiteId ]: {
+							some_cpt: {
+								capabilities: {
+									edit_posts: 'cpt_edit_posts',
+								},
+							},
+						},
+					},
+				},
+				currentUser: {
+					id: fakeUserId,
+					capabilities: {
+						[ fakeSiteId ]: {
+							cpt_edit_posts: false,
+						},
+					},
+				},
+			},
+			fakeGlobalId
+		);
+
+		expect( canEdit ).to.be.false;
+	} );
+
+	test( 'should allow based on post type capability (not author)', () => {
+		const canEdit = canCurrentUserEditPost(
+			{
+				posts: {
+					items: {
+						[ fakeGlobalId ]: [ fakeSiteId, fakePostId ],
+					},
+					queries: {
+						[ fakeSiteId ]: {
+							getItem( postId ) {
+								if ( postId === fakePostId ) {
+									return {
+										type: 'some_cpt',
+										global_ID: fakeGlobalId,
+										site_ID: fakeSiteId,
+										ID: fakePostId,
+										author: {
+											ID: fakeOtherUserId,
+										},
+									};
+								}
+
+								return null;
+							},
+						},
+					},
+				},
+				postTypes: {
+					items: {
+						[ fakeSiteId ]: {
+							some_cpt: {
+								capabilities: {
+									edit_others_posts: 'cpt_edit_others_posts',
+								},
+							},
+						},
+					},
+				},
+				currentUser: {
+					id: fakeUserId,
+					capabilities: {
+						[ fakeSiteId ]: {
+							cpt_edit_others_posts: true,
+						},
+					},
+				},
+			},
+			fakeGlobalId
+		);
+
+		expect( canEdit ).to.be.true;
+	} );
+
+	test( 'should deny based on post type capability (not author)', () => {
+		const canEdit = canCurrentUserEditPost(
+			{
+				posts: {
+					items: {
+						[ fakeGlobalId ]: [ fakeSiteId, fakePostId ],
+					},
+					queries: {
+						[ fakeSiteId ]: {
+							getItem( postId ) {
+								if ( postId === fakePostId ) {
+									return {
+										type: 'some_cpt',
+										global_ID: fakeGlobalId,
+										site_ID: fakeSiteId,
+										ID: fakePostId,
+										author: {
+											ID: fakeOtherUserId,
+										},
+									};
+								}
+
+								return null;
+							},
+						},
+					},
+				},
+				postTypes: {
+					items: {
+						[ fakeSiteId ]: {
+							some_cpt: {
+								capabilities: {
+									edit_others_posts: 'cpt_edit_others_posts',
+								},
+							},
+						},
+					},
+				},
+				currentUser: {
+					id: fakeUserId,
+					capabilities: {
+						[ fakeSiteId ]: {
+							cpt_edit_others_posts: false,
+						},
+					},
+				},
+			},
+			fakeGlobalId
+		);
+
+		expect( canEdit ).to.be.false;
+	} );
+
+	test( 'should return null for unknown post type and unknown capability', () => {
+		const canEdit = canCurrentUserEditPost(
+			{
+				posts: {
+					items: {
+						[ fakeGlobalId ]: [ fakeSiteId, fakePostId ],
+					},
+					queries: {
+						[ fakeSiteId ]: {
+							getItem( postId ) {
+								if ( postId === fakePostId ) {
+									return {
+										type: 'post',
+										global_ID: fakeGlobalId,
+										site_ID: fakeSiteId,
+										ID: fakePostId,
+										author: {
+											ID: fakeUserId,
+										},
+									};
+								}
+
+								return null;
+							},
+						},
+					},
+				},
+				postTypes: {
+					items: {},
+				},
+				currentUser: {
+					id: fakeUserId,
+					capabilities: {},
+				},
+			},
+			fakeGlobalId
+		);
+
+		expect( canEdit ).to.be.null;
+	} );
+
+	test( 'should return null for known post type and unknown capability', () => {
+		const canEdit = canCurrentUserEditPost(
+			{
+				posts: {
+					items: {
+						[ fakeGlobalId ]: [ fakeSiteId, fakePostId ],
+					},
+					queries: {
+						[ fakeSiteId ]: {
+							getItem( postId ) {
+								if ( postId === fakePostId ) {
+									return {
+										type: 'some_cpt',
+										global_ID: fakeGlobalId,
+										site_ID: fakeSiteId,
+										ID: fakePostId,
+										author: {
+											ID: fakeUserId,
+										},
+									};
+								}
+
+								return null;
+							},
+						},
+					},
+				},
+				postTypes: {
+					items: {
+						[ fakeSiteId ]: {
+							some_cpt: {
+								capabilities: {
+									edit_posts: 'cpt_edit_posts',
+								},
+							},
+						},
+					},
+				},
+				currentUser: {
+					id: fakeUserId,
+					capabilities: {},
+				},
+			},
+			fakeGlobalId
+		);
+
+		expect( canEdit ).to.be.null;
+	} );
+} );


### PR DESCRIPTION
This PR is behind a feature flag for the posts list (`posts/post-type-list`), will affect live code for custom post types, and is part of a larger epic (p8F9tW-vh-p2).

When clicking the post title of a post that the user cannot edit, the post should open in a new tab rather than trying to load the editor, which will fail with a (currently cryptic) error message.  We should also show a visual indicator that the link will behave this way.

Here is the new behavior when viewing such posts (for example, posts by other users as a site Contributor):

![2017-11-07t12 59 39 0800](https://user-images.githubusercontent.com/227022/32477827-0213fb94-c3bc-11e7-8fb6-9ff3bfb5c1f9.png)

The test file for the new selector `canCurrentUserEditPost` is quite long, so here is a summary of the test cases added:

```sh
$ grep -Po 'test\(.*,' client/state/selectors/test/can-current-user-edit-post.js 
test( 'should return null if the post is not known',
test( "should allow based on 'edit_posts' for unrecognized post type (author)",
test( "should deny based on 'edit_posts' for unrecognized post type (author)",
test( "should allow based on 'edit_others_posts' for unrecognized post type (not author)",
test( "should deny based on 'edit_others_posts' for unrecognized post type (not author)",
test( 'should allow based on post type capability (author)',
test( 'should deny based on post type capability (author)',
test( 'should allow based on post type capability (not author)',
test( 'should deny based on post type capability (not author)',
test( 'should return null for unknown post type and unknown capability',
test( 'should return null for known post type and unknown capability',
```