### PR TITLE
Update/jetpack connect/auth logged in actions

### DIFF
--- a/client/jetpack-connect/auth-logged-in-form.jsx
+++ b/client/jetpack-connect/auth-logged-in-form.jsx
@@ -35,7 +35,10 @@ import { decodeEntities } from 'lib/formatting';
 import { externalRedirect } from 'lib/route/path';
 import { getJetpackConnectRedirectAfterAuth } from 'state/selectors';
 import { login } from 'lib/paths';
-import { authorize as authorizeAction } from 'state/jetpack-connect/actions';
+import {
+	authorize as authorizeAction,
+	goBackToWpAdmin as goBackToWpAdminAction,
+} from 'state/jetpack-connect/actions';
 
 /**
  * Constants
@@ -48,7 +51,6 @@ class LoggedInForm extends Component {
 	static propTypes = {
 		authAttempts: PropTypes.number.isRequired,
 		calypsoStartedConnection: PropTypes.bool,
-		goBackToWpAdmin: PropTypes.func.isRequired,
 		isAlreadyOnSitesList: PropTypes.bool,
 		isFetchingSites: PropTypes.bool,
 		isFetchingAuthorizationSite: PropTypes.bool,
@@ -75,6 +77,7 @@ class LoggedInForm extends Component {
 
 		// Connected props
 		authorize: PropTypes.func.isRequired,
+		goBackToWpAdmin: PropTypes.func.isRequired,
 		translate: PropTypes.func.isRequired,
 	};
 
@@ -102,7 +105,7 @@ class LoggedInForm extends Component {
 	}
 
 	componentWillReceiveProps( nextProps ) {
-		const { redirectAfterAuth } = nextProps;
+		const { goBackToWpAdmin, redirectAfterAuth } = nextProps;
 		const {
 			siteReceived,
 			queryObject,
@@ -115,7 +118,7 @@ class LoggedInForm extends Component {
 		// Instead, redirect back to admin as soon as we're connected
 		if ( nextProps.isSSO || nextProps.isWoo || this.isFromJpo( nextProps ) ) {
 			if ( ! isRedirectingToWpAdmin && authorizeSuccess ) {
-				return this.props.goBackToWpAdmin( redirectAfterAuth );
+				return goBackToWpAdmin( redirectAfterAuth );
 			}
 		} else if ( siteReceived ) {
 			return this.redirect();
@@ -140,7 +143,7 @@ class LoggedInForm extends Component {
 	}
 
 	redirect() {
-		const { redirectAfterAuth } = this.props;
+		const { goBackToWpAdmin, redirectAfterAuth } = this.props;
 		const { queryObject } = this.props.jetpackConnectAuthorize;
 
 		if ( this.props.isSSO || this.props.isWoo || this.isFromJpo( this.props ) ) {
@@ -151,7 +154,7 @@ class LoggedInForm extends Component {
 				'SSO found:',
 				this.props.isSSO
 			);
-			this.props.goBackToWpAdmin( redirectAfterAuth );
+			goBackToWpAdmin( redirectAfterAuth );
 		} else {
 			page.redirect( this.getRedirectionTarget() );
 		}
@@ -195,7 +198,7 @@ class LoggedInForm extends Component {
 	};
 
 	handleSubmit = () => {
-		const { authorize, redirectAfterAuth } = this.props;
+		const { authorize, goBackToWpAdmin, redirectAfterAuth } = this.props;
 		const { queryObject, authorizeError, authorizeSuccess } = this.props.jetpackConnectAuthorize;
 
 		if (
@@ -204,7 +207,7 @@ class LoggedInForm extends Component {
 			queryObject.already_authorized
 		) {
 			this.props.recordTracksEvent( 'calypso_jpc_back_wpadmin_click' );
-			return this.props.goBackToWpAdmin( redirectAfterAuth );
+			return goBackToWpAdmin( redirectAfterAuth );
 		}
 
 		if ( this.props.isAlreadyOnSitesList && queryObject.already_authorized ) {
@@ -547,5 +550,6 @@ export default connect(
 	} ),
 	{
 		authorize: authorizeAction,
+		goBackToWpAdmin: goBackToWpAdminAction,
 	}
 )( localize( LoggedInForm ) );

--- a/client/jetpack-connect/auth-logged-in-form.jsx
+++ b/client/jetpack-connect/auth-logged-in-form.jsx
@@ -39,6 +39,7 @@ import {
 	authorize as authorizeAction,
 	goBackToWpAdmin as goBackToWpAdminAction,
 	goToXmlrpcErrorFallbackUrl as goToXmlrpcErrorFallbackUrlAction,
+	retryAuth as retryAuthAction,
 } from 'state/jetpack-connect/actions';
 
 /**
@@ -72,16 +73,17 @@ class LoggedInForm extends Component {
 		recordTracksEvent: PropTypes.func.isRequired,
 		requestHasExpiredSecretError: PropTypes.func.isRequired,
 		requestHasXmlrpcError: PropTypes.func.isRequired,
-		retryAuth: PropTypes.func.isRequired,
 		siteSlug: PropTypes.string.isRequired,
 		user: PropTypes.object.isRequired,
 
 		// Connected props
 		authorize: PropTypes.func.isRequired,
 		goBackToWpAdmin: PropTypes.func.isRequired,
+		retryAuth: PropTypes.func.isRequired,
 		translate: PropTypes.func.isRequired,
 	};
 
+	retryingAuth = false;
 	state = { haveAuthorized: false };
 
 	componentWillMount() {
@@ -106,7 +108,7 @@ class LoggedInForm extends Component {
 	}
 
 	componentWillReceiveProps( nextProps ) {
-		const { goBackToWpAdmin, redirectAfterAuth } = nextProps;
+		const { goBackToWpAdmin, redirectAfterAuth, retryAuth } = nextProps;
 		const {
 			siteReceived,
 			queryObject,
@@ -139,7 +141,7 @@ class LoggedInForm extends Component {
 			// as controlled by MAX_AUTH_ATTEMPTS.
 			const attempts = this.props.authAttempts || 0;
 			this.retryingAuth = true;
-			return nextProps.retryAuth( queryObject.site, attempts + 1 );
+			return retryAuth( queryObject.site, attempts + 1 );
 		}
 	}
 
@@ -554,5 +556,6 @@ export default connect(
 		authorize: authorizeAction,
 		goBackToWpAdmin: goBackToWpAdminAction,
 		goToXmlrpcErrorFallbackUrl: goToXmlrpcErrorFallbackUrlAction,
+		retryAuth: retryAuthAction,
 	}
 )( localize( LoggedInForm ) );

--- a/client/jetpack-connect/auth-logged-in-form.jsx
+++ b/client/jetpack-connect/auth-logged-in-form.jsx
@@ -38,6 +38,7 @@ import { login } from 'lib/paths';
 import {
 	authorize as authorizeAction,
 	goBackToWpAdmin as goBackToWpAdminAction,
+	goToXmlrpcErrorFallbackUrl as goToXmlrpcErrorFallbackUrlAction,
 } from 'state/jetpack-connect/actions';
 
 /**
@@ -180,6 +181,7 @@ class LoggedInForm extends Component {
 	};
 
 	handleResolve = () => {
+		const { goToXmlrpcErrorFallbackUrl } = this.props;
 		const { queryObject, authorizationCode } = this.props.jetpackConnectAuthorize;
 		const authUrl = '/wp-admin/admin.php?page=jetpack&connect_url_redirect=true';
 		this.retryingAuth = false;
@@ -194,7 +196,7 @@ class LoggedInForm extends Component {
 		// To resolve, we redirect to the Jetpack Client, and attempt to complete the connection with
 		// legacy functions on the client.
 		this.props.recordTracksEvent( 'calypso_jpc_resolve_xmlrpc_error_click' );
-		this.props.goToXmlrpcErrorFallbackUrl( queryObject, authorizationCode );
+		goToXmlrpcErrorFallbackUrl( queryObject, authorizationCode );
 	};
 
 	handleSubmit = () => {
@@ -551,5 +553,6 @@ export default connect(
 	{
 		authorize: authorizeAction,
 		goBackToWpAdmin: goBackToWpAdminAction,
+		goToXmlrpcErrorFallbackUrl: goToXmlrpcErrorFallbackUrlAction,
 	}
 )( localize( LoggedInForm ) );

--- a/client/jetpack-connect/auth-logged-in-form.jsx
+++ b/client/jetpack-connect/auth-logged-in-form.jsx
@@ -79,6 +79,7 @@ class LoggedInForm extends Component {
 		// Connected props
 		authorize: PropTypes.func.isRequired,
 		goBackToWpAdmin: PropTypes.func.isRequired,
+		goToXmlrpcErrorFallbackUrl: PropTypes.func.isRequired,
 		recordTracksEvent: PropTypes.func.isRequired,
 		retryAuth: PropTypes.func.isRequired,
 		translate: PropTypes.func.isRequired,

--- a/client/jetpack-connect/auth-logged-in-form.jsx
+++ b/client/jetpack-connect/auth-logged-in-form.jsx
@@ -71,8 +71,10 @@ class LoggedInForm extends Component {
 		requestHasXmlrpcError: PropTypes.func.isRequired,
 		retryAuth: PropTypes.func.isRequired,
 		siteSlug: PropTypes.string.isRequired,
-		translate: PropTypes.func.isRequired,
 		user: PropTypes.object.isRequired,
+
+		// Connected props
+		translate: PropTypes.func.isRequired,
 	};
 
 	state = { haveAuthorized: false };

--- a/client/jetpack-connect/auth-logged-in-form.jsx
+++ b/client/jetpack-connect/auth-logged-in-form.jsx
@@ -99,33 +99,33 @@ class LoggedInForm extends Component {
 		}
 	}
 
-	componentWillReceiveProps( props ) {
-		const { redirectAfterAuth } = props;
+	componentWillReceiveProps( nextProps ) {
+		const { redirectAfterAuth } = nextProps;
 		const {
 			siteReceived,
 			queryObject,
 			isRedirectingToWpAdmin,
 			authorizeSuccess,
 			authorizeError,
-		} = props.jetpackConnectAuthorize;
+		} = nextProps.jetpackConnectAuthorize;
 
 		// For SSO, WooCommerce Services, and JPO users, do not display plans page
 		// Instead, redirect back to admin as soon as we're connected
-		if ( props.isSSO || props.isWoo || this.isFromJpo( props ) ) {
+		if ( nextProps.isSSO || nextProps.isWoo || this.isFromJpo( nextProps ) ) {
 			if ( ! isRedirectingToWpAdmin && authorizeSuccess ) {
 				return this.props.goBackToWpAdmin( redirectAfterAuth );
 			}
 		} else if ( siteReceived ) {
 			return this.redirect();
-		} else if ( props.isAlreadyOnSitesList && queryObject.already_authorized ) {
+		} else if ( nextProps.isAlreadyOnSitesList && queryObject.already_authorized ) {
 			return this.redirect();
 		}
 		if (
 			authorizeError &&
-			props.authAttempts < MAX_AUTH_ATTEMPTS &&
+			nextProps.authAttempts < MAX_AUTH_ATTEMPTS &&
 			! this.retryingAuth &&
-			! props.requestHasXmlrpcError() &&
-			! props.requestHasExpiredSecretError() &&
+			! nextProps.requestHasXmlrpcError() &&
+			! nextProps.requestHasExpiredSecretError() &&
 			queryObject.site
 		) {
 			// Expired secret errors, and XMLRPC errors will be resolved in `handleResolve`.
@@ -133,7 +133,7 @@ class LoggedInForm extends Component {
 			// as controlled by MAX_AUTH_ATTEMPTS.
 			const attempts = this.props.authAttempts || 0;
 			this.retryingAuth = true;
-			return this.props.retryAuth( queryObject.site, attempts + 1 );
+			return nextProps.retryAuth( queryObject.site, attempts + 1 );
 		}
 	}
 

--- a/client/jetpack-connect/authorize-form.jsx
+++ b/client/jetpack-connect/authorize-form.jsx
@@ -29,7 +29,6 @@ import {
 import { getCurrentUser } from 'state/current-user/selectors';
 import { recordTracksEvent, setTracksAnonymousUserId } from 'state/analytics/actions';
 import EmptyContent from 'components/empty-content';
-import { requestSites } from 'state/sites/actions';
 import { isRequestingSites, isRequestingSite } from 'state/sites/selectors';
 import MainWrapper from './main-wrapper';
 import HelpButton from './help-button';
@@ -55,7 +54,6 @@ class JetpackConnectAuthorizeForm extends Component {
 		setTracksAnonymousUserId: PropTypes.func,
 		requestHasExpiredSecretError: PropTypes.func,
 		requestHasXmlrpcError: PropTypes.func,
-		requestSites: PropTypes.func,
 		retryAuth: PropTypes.func,
 		siteSlug: PropTypes.string,
 		user: PropTypes.object,
@@ -165,7 +163,6 @@ export default connect(
 	{
 		recordTracksEvent,
 		setTracksAnonymousUserId,
-		requestSites,
 		retryAuth,
 	}
 )( localize( JetpackConnectAuthorizeForm ) );

--- a/client/jetpack-connect/authorize-form.jsx
+++ b/client/jetpack-connect/authorize-form.jsx
@@ -14,7 +14,6 @@ import { get, includes } from 'lodash';
  */
 import Main from 'components/main';
 import LoggedOutFormLinks from 'components/logged-out-form/links';
-import { retryAuth } from 'state/jetpack-connect/actions';
 import {
 	getAuthorizationData,
 	getAuthorizationRemoteSite,
@@ -54,7 +53,6 @@ class JetpackConnectAuthorizeForm extends Component {
 		setTracksAnonymousUserId: PropTypes.func,
 		requestHasExpiredSecretError: PropTypes.func,
 		requestHasXmlrpcError: PropTypes.func,
-		retryAuth: PropTypes.func,
 		siteSlug: PropTypes.string,
 		user: PropTypes.object,
 	};
@@ -163,6 +161,5 @@ export default connect(
 	{
 		recordTracksEvent,
 		setTracksAnonymousUserId,
-		retryAuth,
 	}
 )( localize( JetpackConnectAuthorizeForm ) );

--- a/client/jetpack-connect/authorize-form.jsx
+++ b/client/jetpack-connect/authorize-form.jsx
@@ -14,7 +14,7 @@ import { get, includes } from 'lodash';
  */
 import Main from 'components/main';
 import LoggedOutFormLinks from 'components/logged-out-form/links';
-import { goToXmlrpcErrorFallbackUrl, retryAuth } from 'state/jetpack-connect/actions';
+import { retryAuth } from 'state/jetpack-connect/actions';
 import {
 	getAuthorizationData,
 	getAuthorizationRemoteSite,
@@ -42,7 +42,6 @@ class JetpackConnectAuthorizeForm extends Component {
 	static propTypes = {
 		authAttempts: PropTypes.number,
 		calypsoStartedConnection: PropTypes.bool,
-		goToXmlrpcErrorFallbackUrl: PropTypes.func,
 		isAlreadyOnSitesList: PropTypes.bool,
 		isFetchingAuthorizationSite: PropTypes.bool,
 		isFetchingSites: PropTypes.bool,
@@ -164,7 +163,6 @@ export default connect(
 		};
 	},
 	{
-		goToXmlrpcErrorFallbackUrl,
 		recordTracksEvent,
 		setTracksAnonymousUserId,
 		requestSites,

--- a/client/jetpack-connect/authorize-form.jsx
+++ b/client/jetpack-connect/authorize-form.jsx
@@ -14,11 +14,7 @@ import { get, includes } from 'lodash';
  */
 import Main from 'components/main';
 import LoggedOutFormLinks from 'components/logged-out-form/links';
-import {
-	goBackToWpAdmin,
-	retryAuth,
-	goToXmlrpcErrorFallbackUrl,
-} from 'state/jetpack-connect/actions';
+import { goToXmlrpcErrorFallbackUrl, retryAuth } from 'state/jetpack-connect/actions';
 import {
 	getAuthorizationData,
 	getAuthorizationRemoteSite,
@@ -46,7 +42,6 @@ class JetpackConnectAuthorizeForm extends Component {
 	static propTypes = {
 		authAttempts: PropTypes.number,
 		calypsoStartedConnection: PropTypes.bool,
-		goBackToWpAdmin: PropTypes.func,
 		goToXmlrpcErrorFallbackUrl: PropTypes.func,
 		isAlreadyOnSitesList: PropTypes.bool,
 		isFetchingAuthorizationSite: PropTypes.bool,
@@ -169,7 +164,6 @@ export default connect(
 		};
 	},
 	{
-		goBackToWpAdmin,
 		goToXmlrpcErrorFallbackUrl,
 		recordTracksEvent,
 		setTracksAnonymousUserId,

--- a/client/jetpack-connect/authorize-form.jsx
+++ b/client/jetpack-connect/authorize-form.jsx
@@ -15,7 +15,6 @@ import { get, includes } from 'lodash';
 import Main from 'components/main';
 import LoggedOutFormLinks from 'components/logged-out-form/links';
 import {
-	authorize,
 	goBackToWpAdmin,
 	retryAuth,
 	goToXmlrpcErrorFallbackUrl,
@@ -46,7 +45,6 @@ import LoggedOutForm from './auth-logged-out-form';
 class JetpackConnectAuthorizeForm extends Component {
 	static propTypes = {
 		authAttempts: PropTypes.number,
-		authorize: PropTypes.func,
 		calypsoStartedConnection: PropTypes.bool,
 		goBackToWpAdmin: PropTypes.func,
 		goToXmlrpcErrorFallbackUrl: PropTypes.func,
@@ -171,7 +169,6 @@ export default connect(
 		};
 	},
 	{
-		authorize,
 		goBackToWpAdmin,
 		goToXmlrpcErrorFallbackUrl,
 		recordTracksEvent,


### PR DESCRIPTION
This PR explicitly adds or moves bound action creators from `JetpackConnectAuthorizeForm` (where many were unused) to its child `LoggedInForm`.

- Added
  - `recordTracksEvent`
- Moved
  - `retryAuth`
  - `goToXmlrpcErrorFallbackUrl`
  - `authorize`
  - `goBackToWpAdmin`
- Removed from parent
  - `requestSites`

This PR should make no behavioral changes. 

## Testing
- Tests should pass
- Verify that removed and moved actions are not used by `JetpackConnectAuthorizeForm` or `LoggedOutForm` (which receives `{ ...spread }` props).
- Verify that logged in connections continue to work as before:
  - From WP Admin
  - From Calypso (`/jetpack/connect`)