### PR TITLE
Update recast options for codemods to add trailing commas

### DIFF
--- a/bin/codemods/src/config.js
+++ b/bin/codemods/src/config.js
@@ -13,6 +13,11 @@ const recastOptions = {
 	objectCurlySpacing: true,
 	quote: 'single',
 	useTabs: true,
+	trailingComma: {
+		objects: true,
+		arrays: true,
+		parameters: false,
+	}
 };
 const commonArgs = {
 	'5to6': [


### PR DESCRIPTION
At [Recast options](https://github.com/Automattic/wp-calypso/blob/master/bin/codemods/src/config.js#L11-L16) used by codemods we don't define `trailingComma` setting, although [it's set](https://github.com/Automattic/eslint-config-wpcalypso/blob/master/index.js#L16) to [`always-multiline`](https://eslint.org/docs/rules/comma-dangle#always-multiline) at our eslint config.

For Recast [by default](https://github.com/benjamn/recast/blob/master/lib/options.js#L63-L76) it's set to false (= no commas).

With this change codemods will always add trailing commas to multiline objects and arrays, but not to function parameters (that would require Node 8 and we're on 6).

To test behaviour, just run this example at [astexplorer.net](http://astexplorer.net/) in "jscodeshift" transform window:
```js
export default function transformer(file, api) {
  const j = api.jscodeshift;
  const root = j(file.source);
  
  const config = {
    trailingComma: {
      objects: true,
      arrays: true,
      parameters: false
    }
  };

  let testArray = j.variableDeclaration("const", [
    j.variableDeclarator(
      j.identifier("testArray"),
      j.arrayExpression([
        j.literal("fooLoremIpsumLoremIpsumLoremIpsumLoremem"),
        j.literal("barLoremIpsumLoremIpsumLoremIpsumLoremem")
      ])
    )
  ]);

  let testObject = j.variableDeclaration("const", [
    j.variableDeclarator(
      j.identifier("testObject"),
      j.objectExpression([
        j.property("init", j.identifier("foo"), j.literal("bar")),
        j.property("init", j.identifier("bar"), j.literal("foo"))
      ])
    )
  ]);

  let testFunction = j.functionDeclaration(
    j.identifier('testFunction'),
    [
        j.identifier("fooLoremIpsumLoremIpsumLoremIpsumLoremem"),
        j.identifier("barLoremIpsumLoremIpsumLoremIpsumLoremem")
    ],
    j.blockStatement([
      j.returnStatement(
        j.literal(null)
      )
    ])
  );

  root.get().node.program.body.unshift(testFunction);
  root.get().node.program.body.unshift(testArray);
  root.get().node.program.body.unshift(testObject);

  return root.toSource(config);
}
```