### PR TITLE
Domains: Change transfer in type translation

### DIFF
--- a/client/my-sites/domains/domain-management/edit/transfer.jsx
+++ b/client/my-sites/domains/domain-management/edit/transfer.jsx
@@ -52,7 +52,7 @@ class Transfer extends React.PureComponent {
 
 				<Card>
 					<Property label={ translate( 'Type', { context: 'A type of domain.' } ) }>
-						{ translate( 'Transfer' ) }
+						{ translate( 'Incoming Domain Transfer' ) }
 					</Property>
 
 					<SubscriptionSettings

--- a/client/my-sites/domains/domain-management/list/item.jsx
+++ b/client/my-sites/domains/domain-management/list/item.jsx
@@ -164,7 +164,7 @@ class ListItem extends React.PureComponent {
 				return translate( 'Site Redirect' );
 
 			case domainTypes.TRANSFER:
-				return translate( 'Transfer' );
+				return translate( 'Incoming Domain Transfer' );
 
 			case domainTypes.WPCOM:
 				return translate( 'Included with Site' );


### PR DESCRIPTION
Use full action name instead of just 'transfer'

Fixes https://github.com/Automattic/wp-calypso/issues/19553