### PR TITLE
Masterbar: Prevent Publish Button Jumping

### DIFF
--- a/client/layout/masterbar/publish.jsx
+++ b/client/layout/masterbar/publish.jsx
@@ -94,7 +94,7 @@ class MasterbarItemNew extends React.Component {
 						position={ this.getPopoverPosition() }
 					/>
 				</MasterbarItem>
-				<AsyncLoad require="layout/masterbar/drafts" />
+				<AsyncLoad require="layout/masterbar/drafts" placeholder={ null } />
 			</div>
 		);
 	}


### PR DESCRIPTION
This PR will prevent masterbar publish button from jumping around while asynchronously loading draft counter.

AsyncLoader has a default placeholder that is really not a fit for this situation. Instead of making a custom placeholder, I think it makes sense to show nothing here. That's exactly what having 0 drafts would do.

![ezgif com-gif-maker](https://user-images.githubusercontent.com/156676/32497752-e1530b9a-c3cd-11e7-9648-c75fd3a42ce4.gif)
