### PR TITLE
Post Type List: add Tracks events for trashed and deleted

### DIFF
--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/trash.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/trash.jsx
@@ -103,11 +103,15 @@ const mergeProps = ( stateProps, dispatchProps, ownProps ) => {
 	const postType = get( stateProps, 'type.name' );
 	const onTrashClick = () => (
 		bumpStatGenerator( postType, 'trash', dispatchProps.bumpStat ),
-		dispatchProps.recordTracksEvent( 'calypso_post_type_list_' + postType + '_trashed' )
+		dispatchProps.recordTracksEvent( 'calypso_post_type_list_trashed', {
+			post_type: postType,
+		} )
 	);
 	const onDeleteClick = () => (
 		bumpStatGenerator( postType, 'delete', dispatchProps.bumpStat ),
-		dispatchProps.recordTracksEvent( 'calypso_post_type_list_' + postType + '_deleted' )
+		dispatchProps.recordTracksEvent( 'calypso_post_type_list_deleted', {
+			post_type: postType,
+		} )
 	);
 	return Object.assign( {}, ownProps, stateProps, dispatchProps, {
 		onTrashClick,

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/trash.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/trash.jsx
@@ -100,13 +100,14 @@ const mapStateToProps = ( state, { globalId } ) => {
 const mapDispatchToProps = { trashPost, deletePost, bumpStat, recordTracksEvent };
 
 const mergeProps = ( stateProps, dispatchProps, ownProps ) => {
+	const postType = get( stateProps, 'type.name' );
 	const onTrashClick = () => (
-		bumpStatGenerator( get( stateProps, 'type.name' ), 'trash', dispatchProps.bumpStat ),
-		dispatchProps.recordTracksEvent( 'calypso_post_type_list_post_trashed' )
+		bumpStatGenerator( postType, 'trash', dispatchProps.bumpStat ),
+		dispatchProps.recordTracksEvent( 'calypso_post_type_list_' + postType + '_trashed' )
 	);
 	const onDeleteClick = () => (
-		bumpStatGenerator( get( stateProps, 'type.name' ), 'delete', dispatchProps.bumpStat ),
-		dispatchProps.recordTracksEvent( 'calypso_post_type_list_post_deleted' )
+		bumpStatGenerator( postType, 'delete', dispatchProps.bumpStat ),
+		dispatchProps.recordTracksEvent( 'calypso_post_type_list_' + postType + '_deleted' )
 	);
 	return Object.assign( {}, ownProps, stateProps, dispatchProps, {
 		onTrashClick,

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/trash.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/trash.jsx
@@ -14,7 +14,7 @@ import { get } from 'lodash';
  * Internal dependencies
  */
 import PopoverMenuItem from 'components/popover/menu-item';
-import { bumpStat as bumpAnalyticsStat } from 'state/analytics/actions';
+import { bumpStat, recordTracksEvent } from 'state/analytics/actions';
 import { bumpStatGenerator } from './utils';
 import { trashPost, deletePost } from 'state/posts/actions';
 import { canCurrentUser } from 'state/selectors';
@@ -32,8 +32,8 @@ class PostActionsEllipsisMenuTrash extends Component {
 		canDelete: PropTypes.bool,
 		trashPost: PropTypes.func,
 		deletePost: PropTypes.func,
-		bumpTrashStat: PropTypes.func,
-		bumpDeleteStat: PropTypes.func,
+		onTrashClick: PropTypes.func,
+		onDeleteClick: PropTypes.func,
 	};
 
 	constructor() {
@@ -49,10 +49,10 @@ class PostActionsEllipsisMenuTrash extends Component {
 		}
 
 		if ( 'trash' !== status ) {
-			this.props.bumpTrashStat();
+			this.props.onTrashClick();
 			this.props.trashPost( siteId, postId );
 		} else if ( confirm( translate( 'Are you sure you want to permanently delete this post?' ) ) ) {
-			this.props.bumpDeleteStat();
+			this.props.onDeleteClick();
 			this.props.deletePost( siteId, postId );
 		}
 	}
@@ -97,22 +97,20 @@ const mapStateToProps = ( state, { globalId } ) => {
 	};
 };
 
-const mapDispatchToProps = { trashPost, deletePost, bumpAnalyticsStat };
+const mapDispatchToProps = { trashPost, deletePost, bumpStat, recordTracksEvent };
 
 const mergeProps = ( stateProps, dispatchProps, ownProps ) => {
-	const bumpTrashStat = bumpStatGenerator(
-		get( stateProps, 'type.name' ),
-		'trash',
-		dispatchProps.bumpAnalyticsStat
+	const onTrashClick = () => (
+		bumpStatGenerator( get( stateProps, 'type.name' ), 'trash', dispatchProps.bumpStat ),
+		dispatchProps.recordTracksEvent( 'calypso_post_type_list_post_trashed' )
 	);
-	const bumpDeleteStat = bumpStatGenerator(
-		get( stateProps, 'type.name' ),
-		'delete',
-		dispatchProps.bumpAnalyticsStat
+	const onDeleteClick = () => (
+		bumpStatGenerator( get( stateProps, 'type.name' ), 'delete', dispatchProps.bumpStat ),
+		dispatchProps.recordTracksEvent( 'calypso_post_type_list_post_deleted' )
 	);
 	return Object.assign( {}, ownProps, stateProps, dispatchProps, {
-		bumpTrashStat,
-		bumpDeleteStat,
+		onTrashClick,
+		onDeleteClick,
 	} );
 };
 


### PR DESCRIPTION
This PR adds Tracks events for trashing and deleting posts from the `/posts/` screens.

Added:
- `calypso_post_type_list_trashed` event with prop `post_type` to the condensed post type list
- `calypso_post_type_list_deleted` event with prop `post_type` to the condensed post type list

ToDo:
- Add event to existing post list