### PR TITLE
Comments Redesign: Always expanded view

### DIFF
--- a/client/my-sites/comments/comment/comment-author.jsx
+++ b/client/my-sites/comments/comment/comment-author.jsx
@@ -86,8 +86,8 @@ export class CommentAuthor extends Component {
 
 					<div className="comment__author-info-element">
 						<span className="comment__date">
-							<ExternalLink href={ commentUrl }>
-								{ isExpanded ? formattedDate : relativeDate }
+							<ExternalLink href={ commentUrl } title={ formattedDate }>
+								{ relativeDate }
 							</ExternalLink>
 						</span>
 						{ authorUrl && (

--- a/client/my-sites/comments/comment/comment-author.jsx
+++ b/client/my-sites/comments/comment/comment-author.jsx
@@ -81,7 +81,7 @@ export class CommentAuthor extends Component {
 						<strong className="comment__author-name">
 							<Emojify>{ authorDisplayName || translate( 'Anonymous' ) }</Emojify>
 						</strong>
-						{ ! isExpanded && ! isPostView && <CommentPostLink { ...{ commentId } } /> }
+						{ ! isExpanded && ! isPostView && <CommentPostLink { ...{ commentId, isExpanded } } /> }
 					</div>
 
 					<div className="comment__author-info-element">

--- a/client/my-sites/comments/comment/comment-author.jsx
+++ b/client/my-sites/comments/comment/comment-author.jsx
@@ -24,7 +24,7 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 export class CommentAuthor extends Component {
 	static propTypes = {
 		commentId: PropTypes.number,
-		isExpanded: PropTypes.bool,
+		isBulkMode: PropTypes.bool,
 		isPostView: PropTypes.bool,
 	};
 
@@ -49,8 +49,7 @@ export class CommentAuthor extends Component {
 			commentType,
 			commentUrl,
 			gravatarUser,
-			isExpanded,
-			isPostView,
+			isBulkMode,
 			moment,
 			translate,
 		} = this.props;
@@ -81,7 +80,7 @@ export class CommentAuthor extends Component {
 						<strong className="comment__author-name">
 							<Emojify>{ authorDisplayName || translate( 'Anonymous' ) }</Emojify>
 						</strong>
-						{ ! isExpanded && ! isPostView && <CommentPostLink { ...{ commentId, isExpanded } } /> }
+						{ isBulkMode && <CommentPostLink { ...{ commentId, isBulkMode } } /> }
 					</div>
 
 					<div className="comment__author-info-element">

--- a/client/my-sites/comments/comment/comment-author.jsx
+++ b/client/my-sites/comments/comment/comment-author.jsx
@@ -50,6 +50,7 @@ export class CommentAuthor extends Component {
 			commentUrl,
 			gravatarUser,
 			isBulkMode,
+			isPostView,
 			moment,
 			translate,
 		} = this.props;
@@ -80,7 +81,7 @@ export class CommentAuthor extends Component {
 						<strong className="comment__author-name">
 							<Emojify>{ authorDisplayName || translate( 'Anonymous' ) }</Emojify>
 						</strong>
-						{ isBulkMode && <CommentPostLink { ...{ commentId, isBulkMode } } /> }
+						{ isBulkMode && ! isPostView && <CommentPostLink { ...{ commentId, isBulkMode } } /> }
 					</div>
 
 					<div className="comment__author-info-element">

--- a/client/my-sites/comments/comment/comment-content.jsx
+++ b/client/my-sites/comments/comment/comment-content.jsx
@@ -74,7 +74,7 @@ export class CommentContent extends Component {
 					<div className="comment__content-full">
 						{ ( commentIsPending || ! isPostView ) && (
 							<div className="comment__content-info">
-								{ ! isPostView && <CommentPostLink { ...{ commentId } } /> }
+								{ ! isPostView && <CommentPostLink { ...{ commentId, isExpanded } } /> }
 
 								{ commentIsPending && (
 									<div className="comment__status-label">{ translate( 'Pending' ) }</div>

--- a/client/my-sites/comments/comment/comment-content.jsx
+++ b/client/my-sites/comments/comment/comment-content.jsx
@@ -24,7 +24,7 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 export class CommentContent extends Component {
 	static propTypes = {
 		commentId: PropTypes.number,
-		isExpanded: PropTypes.bool,
+		isBulkMode: PropTypes.bool,
 		isPostView: PropTypes.bool,
 	};
 
@@ -32,7 +32,7 @@ export class CommentContent extends Component {
 		this.props.isJetpack ? noop : this.props.recordReaderCommentOpened();
 
 	renderInReplyTo = () => {
-		const { commentUrl, isExpanded, parentCommentContent, translate } = this.props;
+		const { commentUrl, isBulkMode, parentCommentContent, translate } = this.props;
 
 		if ( ! parentCommentContent ) {
 			return null;
@@ -40,7 +40,7 @@ export class CommentContent extends Component {
 
 		return (
 			<div className="comment__in-reply-to">
-				{ ! isExpanded && <Gridicon icon="reply" size={ 18 } /> }
+				{ isBulkMode && <Gridicon icon="reply" size={ 18 } /> }
 				<span>{ translate( 'In reply to:' ) }</span>
 				<a href={ commentUrl } onClick={ this.trackDeepReaderLinkClick }>
 					<Emojify>{ parentCommentContent }</Emojify>
@@ -54,13 +54,13 @@ export class CommentContent extends Component {
 			commentContent,
 			commentId,
 			commentIsPending,
-			isExpanded,
+			isBulkMode,
 			isPostView,
 			translate,
 		} = this.props;
 		return (
 			<div className="comment__content">
-				{ ! isExpanded && (
+				{ isBulkMode && (
 					<div className="comment__content-preview">
 						{ this.renderInReplyTo() }
 
@@ -70,11 +70,11 @@ export class CommentContent extends Component {
 					</div>
 				) }
 
-				{ isExpanded && (
+				{ ! isBulkMode && (
 					<div className="comment__content-full">
 						{ ( commentIsPending || ! isPostView ) && (
 							<div className="comment__content-info">
-								{ ! isPostView && <CommentPostLink { ...{ commentId, isExpanded } } /> }
+								{ ! isPostView && <CommentPostLink { ...{ commentId, isBulkMode } } /> }
 
 								{ commentIsPending && (
 									<div className="comment__status-label">{ translate( 'Pending' ) }</div>

--- a/client/my-sites/comments/comment/comment-content.jsx
+++ b/client/my-sites/comments/comment/comment-content.jsx
@@ -56,6 +56,7 @@ export class CommentContent extends Component {
 			commentIsPending,
 			isBulkMode,
 			isPostView,
+			parentCommentContent,
 			translate,
 		} = this.props;
 		return (
@@ -72,17 +73,17 @@ export class CommentContent extends Component {
 
 				{ ! isBulkMode && (
 					<div className="comment__content-full">
-						{ ( commentIsPending || ! isPostView ) && (
+						{ ( commentIsPending || parentCommentContent || ! isPostView ) && (
 							<div className="comment__content-info">
-								{ ! isPostView && <CommentPostLink { ...{ commentId, isBulkMode } } /> }
-
 								{ commentIsPending && (
 									<div className="comment__status-label">{ translate( 'Pending' ) }</div>
 								) }
+
+								{ ! isPostView && <CommentPostLink { ...{ commentId, isBulkMode } } /> }
+
+								{ this.renderInReplyTo() }
 							</div>
 						) }
-
-						{ this.renderInReplyTo() }
 
 						<AutoDirection>
 							<Emojify>

--- a/client/my-sites/comments/comment/comment-edit.jsx
+++ b/client/my-sites/comments/comment/comment-edit.jsx
@@ -26,7 +26,6 @@ import {
 	withAnalytics,
 } from 'state/analytics/actions';
 import { editComment } from 'state/comments/actions';
-import { getCurrentUserId } from 'state/current-user/selectors';
 import { removeNotice, successNotice } from 'state/notices/actions';
 import { getSiteComment } from 'state/selectors';
 import { getSiteSlug, isJetpackMinimumVersion, isJetpackSite } from 'state/sites/selectors';
@@ -94,7 +93,7 @@ export class CommentEdit extends Component {
 
 	render() {
 		const {
-			isAuthorEditable,
+			isAuthorRegistered,
 			isEditCommentSupported,
 			siteSlug,
 			toggleEditMode,
@@ -109,13 +108,13 @@ export class CommentEdit extends Component {
 				<div className="comment__edit-wrapper">
 					<FormFieldset>
 						<FormLabel htmlFor="author">{ translate( 'Name' ) }</FormLabel>
-						{ isAuthorEditable && (
+						{ isAuthorRegistered && (
 							<InfoPopover>
 								{ translate( "This user is registered, the name can't be edited." ) }
 							</InfoPopover>
 						) }
 						<FormTextInput
-							disabled={ ! isEditCommentSupported || isAuthorEditable }
+							disabled={ ! isEditCommentSupported || isAuthorRegistered }
 							id="author"
 							onChange={ this.setAuthorDisplayNameValue }
 							value={ authorDisplayName }
@@ -124,13 +123,13 @@ export class CommentEdit extends Component {
 
 					<FormFieldset>
 						<FormLabel htmlFor="author_url">{ translate( 'URL' ) }</FormLabel>
-						{ isAuthorEditable && (
+						{ isAuthorRegistered && (
 							<InfoPopover>
 								{ translate( "This user is registered, the URL can't be edited." ) }
 							</InfoPopover>
 						) }
 						<FormTextInput
-							disabled={ ! isEditCommentSupported || isAuthorEditable }
+							disabled={ ! isEditCommentSupported || isAuthorRegistered }
 							id="author_url"
 							onChange={ this.setAuthorUrlValue }
 							value={ authorUrl }
@@ -176,14 +175,12 @@ const mapStateToProps = ( state, { commentId } ) => {
 		! isJetpackSite( state, siteId ) || isJetpackMinimumVersion( state, siteId, '5.3' );
 	const comment = getSiteComment( state, siteId, commentId );
 	const authorDisplayName = decodeEntities( get( comment, 'author.name' ) );
-	const authorId = get( comment, 'author.ID' );
-	const isAuthorEditable = 0 !== authorId && getCurrentUserId( state ) !== authorId;
 
 	return {
 		authorDisplayName,
 		authorUrl: get( comment, 'author.URL', '' ),
 		commentContent: get( comment, 'raw_content' ),
-		isAuthorEditable,
+		isAuthorRegistered: 0 !== get( comment, 'author.ID' ),
 		isEditCommentSupported,
 		postId: get( comment, 'post.ID' ),
 		siteId,

--- a/client/my-sites/comments/comment/comment-header.jsx
+++ b/client/my-sites/comments/comment/comment-header.jsx
@@ -42,7 +42,8 @@ export class CommentHeader extends PureComponent {
 
 				{ showAuthorMoreInfo && <CommentAuthorMoreInfo { ...{ commentId } } /> }
 
-				{ ! isBulkMode && (
+				{ ! isBulkMode &&
+				isPostView && (
 					<Button
 						borderless
 						className="comment__toggle-expanded"

--- a/client/my-sites/comments/comment/comment-header.jsx
+++ b/client/my-sites/comments/comment/comment-header.jsx
@@ -4,13 +4,11 @@
  */
 import React, { PureComponent } from 'react';
 import { connect } from 'react-redux';
-import Gridicon from 'gridicons';
 import { get } from 'lodash';
 
 /**
  * Internal dependencies
  */
-import Button from 'components/button';
 import CommentAuthor from 'my-sites/comments/comment/comment-author';
 import CommentAuthorMoreInfo from 'my-sites/comments/comment/comment-author-more-info';
 import FormCheckbox from 'components/forms/form-checkbox';
@@ -19,16 +17,7 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 
 export class CommentHeader extends PureComponent {
 	render() {
-		const {
-			commentId,
-			isBulkMode,
-			isEditMode,
-			isExpanded,
-			isPostView,
-			isSelected,
-			showAuthorMoreInfo,
-			toggleExpanded,
-		} = this.props;
+		const { commentId, isBulkMode, isSelected, showAuthorMoreInfo } = this.props;
 
 		return (
 			<div className="comment__header">
@@ -38,33 +27,21 @@ export class CommentHeader extends PureComponent {
 					</label>
 				) }
 
-				<CommentAuthor { ...{ commentId, isExpanded, isPostView } } />
+				<CommentAuthor { ...{ commentId, isBulkMode } } />
 
 				{ showAuthorMoreInfo && <CommentAuthorMoreInfo { ...{ commentId } } /> }
-
-				{ ! isBulkMode &&
-				isPostView && (
-					<Button
-						borderless
-						className="comment__toggle-expanded"
-						disabled={ isEditMode }
-						onClick={ toggleExpanded }
-					>
-						<Gridicon icon="chevron-down" />
-					</Button>
-				) }
 			</div>
 		);
 	}
 }
 
-const mapStateToProps = ( state, { commentId, isExpanded } ) => {
+const mapStateToProps = ( state, { commentId, isBulkMode } ) => {
 	const siteId = getSelectedSiteId( state );
 	const comment = getSiteComment( state, siteId, commentId );
 	const commentType = get( comment, 'type', 'comment' );
 
 	return {
-		showAuthorMoreInfo: isExpanded && 'comment' === commentType,
+		showAuthorMoreInfo: ! isBulkMode && 'comment' === commentType,
 	};
 };
 

--- a/client/my-sites/comments/comment/comment-header.jsx
+++ b/client/my-sites/comments/comment/comment-header.jsx
@@ -17,7 +17,7 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 
 export class CommentHeader extends PureComponent {
 	render() {
-		const { commentId, isBulkMode, isSelected, showAuthorMoreInfo } = this.props;
+		const { commentId, isBulkMode, isPostView, isSelected, showAuthorMoreInfo } = this.props;
 
 		return (
 			<div className="comment__header">
@@ -27,7 +27,7 @@ export class CommentHeader extends PureComponent {
 					</label>
 				) }
 
-				<CommentAuthor { ...{ commentId, isBulkMode } } />
+				<CommentAuthor { ...{ commentId, isBulkMode, isPostView } } />
 
 				{ showAuthorMoreInfo && <CommentAuthorMoreInfo { ...{ commentId } } /> }
 			</div>

--- a/client/my-sites/comments/comment/comment-post-link.jsx
+++ b/client/my-sites/comments/comment/comment-post-link.jsx
@@ -18,6 +18,7 @@ import { getSitePost } from 'state/posts/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 
 const CommentPostLink = ( {
+	isExpanded,
 	isPostTitleLoaded,
 	postId,
 	postTitle,
@@ -29,7 +30,7 @@ const CommentPostLink = ( {
 	<div className="comment__post-link">
 		{ ! isPostTitleLoaded && <QueryPosts siteId={ siteId } postId={ postId } /> }
 
-		<Gridicon icon="chevron-right" size={ 18 } />
+		<Gridicon icon={ isExpanded ? 'posts' : 'chevron-right' } size={ 18 } />
 
 		<a href={ `/comments/${ status }/${ siteSlug }/${ postId }` }>
 			{ postTitle.trim() || translate( 'Untitled' ) }

--- a/client/my-sites/comments/comment/comment-post-link.jsx
+++ b/client/my-sites/comments/comment/comment-post-link.jsx
@@ -18,7 +18,7 @@ import { getSitePost } from 'state/posts/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 
 const CommentPostLink = ( {
-	isExpanded,
+	isBulkMode,
 	isPostTitleLoaded,
 	postId,
 	postTitle,
@@ -30,7 +30,7 @@ const CommentPostLink = ( {
 	<div className="comment__post-link">
 		{ ! isPostTitleLoaded && <QueryPosts siteId={ siteId } postId={ postId } /> }
 
-		<Gridicon icon={ isExpanded ? 'posts' : 'chevron-right' } size={ 18 } />
+		<Gridicon icon={ isBulkMode ? 'chevron-right' : 'posts' } size={ 18 } />
 
 		<a href={ `/comments/${ status }/${ siteSlug }/${ postId }` }>
 			{ postTitle.trim() || translate( 'Untitled' ) }

--- a/client/my-sites/comments/comment/comment-reply.jsx
+++ b/client/my-sites/comments/comment/comment-reply.jsx
@@ -13,7 +13,6 @@ import { get } from 'lodash';
  * Internal dependencies
  */
 import AutoDirection from 'components/auto-direction';
-import Gravatar from 'components/gravatar';
 import { decodeEntities } from 'lib/formatting';
 import {
 	bumpStat,
@@ -22,7 +21,6 @@ import {
 	withAnalytics,
 } from 'state/analytics/actions';
 import { changeCommentStatus, replyComment } from 'state/comments/actions';
-import { getCurrentUser } from 'state/current-user/selectors';
 import { removeNotice, successNotice } from 'state/notices/actions';
 import { getSiteComment } from 'state/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
@@ -123,24 +121,18 @@ export class CommentReply extends Component {
 	};
 
 	render() {
-		const { currentUser, translate } = this.props;
+		const { translate } = this.props;
 		const { hasReplyFocus, replyContent, textareaHeight } = this.state;
 
 		const hasReplyContent = replyContent.trim().length > 0;
 		// Only show the scrollbar if the textarea content exceeds the max height
 		const hasScrollbar = textareaHeight === TEXTAREA_MAX_HEIGHT;
 
-		const wrapperClasses = classNames( 'comment__reply-wrapper', {
-			'has-focus': hasReplyFocus,
-		} );
-
 		const buttonClasses = classNames( 'comment__reply-submit', {
 			'has-scrollbar': hasScrollbar,
 			'is-active': hasReplyContent,
 			'is-visible': hasReplyFocus || hasReplyContent,
 		} );
-
-		const gravatarClasses = classNames( { 'is-visible': ! hasReplyFocus } );
 
 		const textareaClasses = classNames( 'comment__reply-textarea', {
 			'has-content': hasReplyContent,
@@ -155,31 +147,23 @@ export class CommentReply extends Component {
 
 		return (
 			<form className="comment__reply">
-				<div className={ wrapperClasses }>
-					<AutoDirection>
-						<textarea
-							className={ textareaClasses }
-							onBlur={ this.blurReply }
-							onChange={ this.updateTextarea }
-							onFocus={ this.focusReply }
-							onKeyDown={ this.keyDownHandler }
-							placeholder={ this.getPlaceholder() }
-							ref={ this.storeTextareaRef }
-							style={ textareaStyle }
-							value={ replyContent }
-						/>
-					</AutoDirection>
+				<AutoDirection>
+					<textarea
+						className={ textareaClasses }
+						onBlur={ this.blurReply }
+						onChange={ this.updateTextarea }
+						onFocus={ this.focusReply }
+						onKeyDown={ this.keyDownHandler }
+						placeholder={ this.getPlaceholder() }
+						ref={ this.storeTextareaRef }
+						style={ textareaStyle }
+						value={ replyContent }
+					/>
+				</AutoDirection>
 
-					<Gravatar className={ gravatarClasses } size={ 24 } user={ currentUser } />
-
-					<button
-						className={ buttonClasses }
-						disabled={ ! hasReplyContent }
-						onClick={ this.submit }
-					>
-						{ translate( 'Send' ) }
-					</button>
-				</div>
+				<button className={ buttonClasses } disabled={ ! hasReplyContent } onClick={ this.submit }>
+					{ translate( 'Send' ) }
+				</button>
 			</form>
 		);
 	}
@@ -192,7 +176,6 @@ const mapStateToProps = ( state, { commentId } ) => {
 	return {
 		authorDisplayName: decodeEntities( get( comment, 'author.name' ) ),
 		commentStatus: get( comment, 'status' ),
-		currentUser: getCurrentUser( state ),
 		postId: get( comment, 'post.ID' ),
 		siteId,
 	};

--- a/client/my-sites/comments/comment/comment-reply.jsx
+++ b/client/my-sites/comments/comment/comment-reply.jsx
@@ -131,7 +131,6 @@ export class CommentReply extends Component {
 		const buttonClasses = classNames( 'comment__reply-submit', {
 			'has-scrollbar': hasScrollbar,
 			'is-active': hasReplyContent,
-			'is-visible': hasReplyFocus || hasReplyContent,
 		} );
 
 		const textareaClasses = classNames( 'comment__reply-textarea', {

--- a/client/my-sites/comments/comment/index.jsx
+++ b/client/my-sites/comments/comment/index.jsx
@@ -42,17 +42,21 @@ export class Comment extends Component {
 	};
 
 	componentWillReceiveProps( nextProps ) {
-		if ( nextProps.isPostView ) {
-			if ( ! this.props.isPostView ) {
-				this.setState( { isExpanded: false } );
-			} else if ( this.props.isBulkMode && ! nextProps.isBulkMode ) {
-				this.setState( { isExpanded: false } );
-			} else if ( ! this.props.isBulkMode && nextProps.isBulkMode ) {
-				this.setState( { isExpanded: false } );
-			}
-		} else {
-			this.setState( { isExpanded: ! nextProps.isLoading && ! nextProps.isBulkMode } );
+		const { isBulkMode: wasBulkMode, isPostView: wasPostView } = this.props;
+		const { isBulkMode, isLoading, isPostView } = nextProps;
+		const { isExpanded: wasExpanded, isReplyVisible: wasReplyVisible } = this.state;
+
+		let isExpanded = wasExpanded;
+		if ( isPostView && ( ! wasPostView || wasBulkMode !== isBulkMode ) ) {
+			isExpanded = false;
+		} else if ( ! isPostView ) {
+			isExpanded = ! isLoading && ! isBulkMode;
 		}
+
+		const isReplyVisible =
+			wasPostView !== isPostView || wasBulkMode !== isBulkMode ? false : wasReplyVisible;
+
+		this.setState( { isExpanded, isReplyVisible } );
 	}
 
 	storeCardRef = card => ( this.commentCard = card );

--- a/client/my-sites/comments/comment/index.jsx
+++ b/client/my-sites/comments/comment/index.jsx
@@ -102,7 +102,6 @@ export class Comment extends Component {
 			'is-edit-mode': isEditMode,
 			'is-placeholder': isLoading,
 			'is-pending': commentIsPending,
-			'is-post-view': isPostView,
 			'is-reply-visible': isReplyVisible,
 		} );
 
@@ -122,7 +121,7 @@ export class Comment extends Component {
 					<div className="comment__detail">
 						<CommentHeader { ...{ commentId, isBulkMode, isEditMode, isSelected } } />
 
-						<CommentContent { ...{ commentId, isPostView } } />
+						<CommentContent { ...{ commentId, isBulkMode, isPostView } } />
 
 						{ ! isBulkMode && (
 							<CommentActions

--- a/client/my-sites/comments/comment/index.jsx
+++ b/client/my-sites/comments/comment/index.jsx
@@ -43,12 +43,11 @@ export class Comment extends Component {
 	componentWillReceiveProps( nextProps ) {
 		const { isBulkMode: wasBulkMode } = this.props;
 		const { isBulkMode } = nextProps;
-		const { isEditMode: wasEditMode, isReplyVisible: wasReplyVisible } = this.state;
 
-		this.setState( {
-			isEditMode: wasBulkMode !== isBulkMode ? false : wasEditMode,
-			isReplyVisible: wasBulkMode !== isBulkMode ? false : wasReplyVisible,
-		} );
+		this.setState( ( { isEditMode, isReplyVisible } ) => ( {
+			isEditMode: wasBulkMode !== isBulkMode ? false : isEditMode,
+			isReplyVisible: wasBulkMode !== isBulkMode ? false : isReplyVisible,
+		} ) );
 	}
 
 	storeCardRef = card => ( this.commentCard = card );
@@ -72,11 +71,12 @@ export class Comment extends Component {
 		}
 	};
 
-	toggleEditMode = () =>
+	toggleEditMode = () => {
 		this.setState( ( { isEditMode } ) => ( {
 			isEditMode: ! isEditMode,
 			isReplyVisible: false,
 		} ) );
+	};
 
 	toggleReply = () =>
 		this.setState( ( { isReplyVisible } ) => ( { isReplyVisible: ! isReplyVisible } ) );

--- a/client/my-sites/comments/comment/index.jsx
+++ b/client/my-sites/comments/comment/index.jsx
@@ -129,6 +129,7 @@ export class Comment extends Component {
 			'is-expanded': isExpanded,
 			'is-placeholder': isLoading,
 			'is-pending': commentIsPending,
+			'is-post-view': isPostView,
 			'is-reply-visible': isReplyVisible,
 		} );
 

--- a/client/my-sites/comments/comment/index.jsx
+++ b/client/my-sites/comments/comment/index.jsx
@@ -42,15 +42,23 @@ export class Comment extends Component {
 	};
 
 	componentWillReceiveProps( nextProps ) {
-		if ( nextProps.isBulkMode && ! this.props.isBulkMode ) {
-			this.setState( { isExpanded: false } );
+		if ( nextProps.isPostView ) {
+			if ( ! this.props.isPostView ) {
+				this.setState( { isExpanded: false } );
+			} else if ( this.props.isBulkMode && ! nextProps.isBulkMode ) {
+				this.setState( { isExpanded: false } );
+			} else if ( ! this.props.isBulkMode && nextProps.isBulkMode ) {
+				this.setState( { isExpanded: false } );
+			}
+		} else {
+			this.setState( { isExpanded: ! nextProps.isLoading && ! nextProps.isBulkMode } );
 		}
 	}
 
 	storeCardRef = card => ( this.commentCard = card );
 
 	keyDownHandler = event => {
-		const { isBulkMode } = this.props;
+		const { isBulkMode, isPostView } = this.props;
 		const { isEditMode, isExpanded } = this.state;
 
 		const commentHasFocus =
@@ -58,7 +66,7 @@ export class Comment extends Component {
 			this.commentCard &&
 			document.activeElement === ReactDom.findDOMNode( this.commentCard );
 
-		if ( isEditMode || ( isExpanded && ! commentHasFocus ) ) {
+		if ( isEditMode || ! isPostView || ( isExpanded && ! commentHasFocus ) ) {
 			return;
 		}
 
@@ -78,7 +86,7 @@ export class Comment extends Component {
 		} ) );
 
 	toggleExpanded = () => {
-		if ( ! this.props.isLoading && ! this.state.isEditMode ) {
+		if ( ! this.props.isLoading && ! this.state.isEditMode && this.props.isPostView ) {
 			this.setState( ( { isExpanded } ) => ( {
 				isExpanded: ! isExpanded,
 				isReplyVisible: false,

--- a/client/my-sites/comments/comment/index.jsx
+++ b/client/my-sites/comments/comment/index.jsx
@@ -119,7 +119,7 @@ export class Comment extends Component {
 
 				{ ! isEditMode && (
 					<div className="comment__detail">
-						<CommentHeader { ...{ commentId, isBulkMode, isEditMode, isSelected } } />
+						<CommentHeader { ...{ commentId, isBulkMode, isEditMode, isPostView, isSelected } } />
 
 						<CommentContent { ...{ commentId, isBulkMode, isPostView } } />
 

--- a/client/my-sites/comments/comment/style.scss
+++ b/client/my-sites/comments/comment/style.scss
@@ -209,7 +209,8 @@
 		white-space: nowrap;
 
 		.gridicon {
-			display: none;
+			color: $gray;
+			margin: 0 4px -3px 0;
 		}
 	}
 
@@ -287,6 +288,8 @@
 // Comment Post Link Block
 
 .comment__post-link {
+	font-family: $serif;
+
 	a {
 		color: $gray-text-min;
 	}

--- a/client/my-sites/comments/comment/style.scss
+++ b/client/my-sites/comments/comment/style.scss
@@ -374,9 +374,8 @@
 	min-height: 47px; // 1 line
 	overflow: hidden;
 	padding: 12px 70px 12px 16px;
-	position: relative;
 	resize: vertical;
-	transition: min-height 0.15s linear, padding-left 0.2s ease-in-out;
+	transition: min-height 0.15s linear;
 	white-space: pre-wrap;
 	word-wrap: break-word;
 
@@ -388,12 +387,7 @@
 	}
 
 	&:not(:focus) {
-		padding: 12px 16px 12px 48px;
 		resize: none;
-
-		&.has-content {
-			padding-right: 70px;
-		}
 	}
 
 	&:focus,
@@ -403,17 +397,6 @@
 
 	&.has-scrollbar {
 		overflow-y: auto;
-	}
-}
-
-.comment__reply-wrapper .gravatar {
-	left: 16px;
-	position: absolute;
-	top: 12px;
-	transition: transform 0.2s ease-in-out;
-
-	&:not(.is-visible) {
-		transform: translate3d(-40px, 0, 0);
 	}
 }
 

--- a/client/my-sites/comments/comment/style.scss
+++ b/client/my-sites/comments/comment/style.scss
@@ -29,10 +29,6 @@
 	display: flex;
 	flex-flow: row;
 	flex-wrap: nowrap;
-
-	.comment__author {
-		padding: 8px;
-	}
 }
 
 .comment__bulk-select {
@@ -64,11 +60,13 @@
 }
 
 // Comment Author Block
+
 .comment__author {
 	display: flex;
 	flex-flow: row;
 	flex-grow: 1;
 	flex-wrap: nowrap;
+	padding: 8px 16px 8px 8px;
 	width: 0;
 }
 
@@ -523,6 +521,8 @@
 // Expanded View
 
 .card.comment.is-expanded {
+	margin: 16px auto;
+
 	.comment__header {
 		border-bottom: 1px solid lighten($gray, 30%);
 
@@ -582,12 +582,20 @@
 		pointer-events: none;
 	}
 
-	.comment__header .comment__author {
+	.comment__author {
 		padding-left: 0;
 	}
 
 	&.is-pending .comment__content {
 		padding-bottom: 16px;
+	}
+}
+
+// Post View
+
+.card.comment.is-post-view {
+	.comment__author {
+		padding-right: 8px;
 	}
 }
 
@@ -610,8 +618,8 @@
 		display: none;
 	}
 
-	.comment__header .comment__author {
-		padding: 8px;
+	.comment__author {
+		padding: 8px 16px 8px 8px;
 	}
 
 	.comment__author-gravatar-placeholder {

--- a/client/my-sites/comments/comment/style.scss
+++ b/client/my-sites/comments/comment/style.scss
@@ -14,7 +14,8 @@
 
 	&.is-pending {
 		background: mix($alert-yellow, $white, 8.5%);
-		border-left: 4px solid $alert-yellow;
+		box-shadow: inset 4px 0 0 0 $alert-yellow, 0 0 0 1px transparentize(lighten($gray, 20%), 0.5),
+			0 1px 2px lighten($gray, 30%);
 	}
 
 	@include breakpoint( '<960px' ) {
@@ -351,9 +352,8 @@
 // Comment Reply Block
 
 .comment__reply {
-	border-top: 1px solid lighten($gray, 30%);
 	display: none;
-	padding: 16px;
+	padding: 0 16px 16px 16px;
 }
 
 .comment__reply-wrapper {

--- a/client/my-sites/comments/comment/style.scss
+++ b/client/my-sites/comments/comment/style.scss
@@ -298,11 +298,11 @@
 .button.is-borderless.comment__action {
 	flex-basis: 0;
 	flex-grow: 1;
-	padding: 8px;
+	padding: 8px 4px;
 	text-align: center;
 
 	span {
-		display: block;
+		display: none;
 		font-weight: 400;
 		padding-top: 4px;
 	}
@@ -324,6 +324,12 @@
 	}
 	&.is-liked {
 		color: $orange-jazzy;
+	}
+
+	@include breakpoint( '>480px' ) {
+		span {
+			display: block;
+		}
 	}
 
 	@include breakpoint( '>960px' ) {

--- a/client/my-sites/comments/comment/style.scss
+++ b/client/my-sites/comments/comment/style.scss
@@ -347,17 +347,7 @@
 .comment__reply {
 	display: none;
 	padding: 0 16px 16px 16px;
-}
-
-.comment__reply-wrapper {
-	line-height: 0;
-	overflow: hidden;
 	position: relative;
-	transition: box-shadow 0.15s ease-in-out;
-
-	&.has-focus {
-		box-shadow: 0 0 0 2px $blue-light;
-	}
 }
 
 .comment__reply-textarea {
@@ -399,21 +389,13 @@
 	font-weight: 600;
 	padding: 4px;
 	position: absolute;
-	right: -70px;
-	top: 11px;
+	right: 28px;
+	top: 12px;
 	text-transform: uppercase;
-	transition: transform 0.2s ease-in-out;
 
 	&.is-active {
 		color: $blue-wordpress;
 		cursor: pointer;
-	}
-
-	&.is-visible {
-		transform: translate3d(-88px, 0, 0);
-	}
-	&.is-visible.has-scrollbar {
-		transform: translate3d(-94px, 0, 0);
 	}
 }
 

--- a/client/my-sites/comments/comment/style.scss
+++ b/client/my-sites/comments/comment/style.scss
@@ -11,6 +11,11 @@
 		box-shadow: 0 0 0 1px $blue-medium, 0 0 0 3px $blue-light;
 		z-index: z-index('root', '.card.comment.accessible-focus:focus');
 	}
+
+	&.is-pending {
+		background: mix($alert-yellow, $white, 8.5%);
+		border-left: 4px solid $alert-yellow;
+	}
 }
 
 // `transition` here is applied with less specificity to avoid overwriting ReactCSSTransitionGroup's animation.
@@ -354,7 +359,6 @@
 // Comment Reply Block
 
 .comment__reply {
-	background: $gray-light;
 	border-top: 1px solid lighten($gray, 30%);
 	display: none;
 	padding: 16px;
@@ -511,22 +515,14 @@
 // Collapsed View
 
 .card.comment.is-collapsed {
-	&.is-pending {
-		background: mix($alert-yellow, $white, 8.5%);
-		box-shadow: inset 4px 0 0 0 $alert-yellow, 0 0 0 1px transparentize(lighten($gray, 20%), 0.5),
-			0 1px 2px lighten($gray, 30%);
-
-		.comment__content {
-			padding-bottom: 8px;
-		}
+	&.is-pending .comment__content {
+		padding-bottom: 8px;
 	}
 }
 
 // Expanded View
 
 .card.comment.is-expanded {
-	margin: 16px auto;
-
 	.comment__header {
 		border-bottom: 1px solid lighten($gray, 30%);
 

--- a/client/my-sites/comments/comment/style.scss
+++ b/client/my-sites/comments/comment/style.scss
@@ -180,10 +180,6 @@
 	padding: 0 16px 16px 56px;
 
 	.comment__content-info {
-		display: flex;
-		flex-flow: row;
-		flex-wrap: nowrap;
-		justify-content: space-between;
 		margin-top: 16px;
 	}
 
@@ -200,13 +196,11 @@
 	}
 
 	.comment__status-label {
-		align-self: center;
 		background: lighten($alert-yellow, 18%);
 		border-radius: 9px;
-		flex-grow: 0;
-		flex-shrink: 0;
+		float: right;
 		font-size: 12px;
-		margin-left: auto;
+		margin-left: 8px;
 		padding: 0 10px;
 	}
 

--- a/client/my-sites/comments/comment/style.scss
+++ b/client/my-sites/comments/comment/style.scss
@@ -4,7 +4,7 @@
 
 .card.comment {
 	font-size: 14px;
-	margin: 0 auto;
+	margin: 10px auto;
 	padding: 0;
 
 	.accessible-focus &:focus {
@@ -15,6 +15,10 @@
 	&.is-pending {
 		background: mix($alert-yellow, $white, 8.5%);
 		border-left: 4px solid $alert-yellow;
+	}
+
+	@include breakpoint( '<960px' ) {
+		margin: 0 auto;
 	}
 }
 
@@ -37,25 +41,6 @@
 
 	.form-checkbox {
 		margin: 0;
-	}
-}
-
-.button.comment__toggle-expanded {
-	border-radius: 0;
-	padding-left: 16px;
-	padding-right: 16px;
-
-	.gridicon {
-		fill: $gray;
-		transform: rotate(0deg);
-		transition: transform 0.15s cubic-bezier(0.175, 0.885, 0.32, 1.275), color 0.2s ease-in;
-	}
-
-	&:focus,
-	&:hover {
-		.gridicon {
-			fill: $blue-medium;
-		}
 	}
 }
 
@@ -226,8 +211,11 @@
 	}
 
 	.comment__in-reply-to {
+		border-left: 4px solid lighten($gray, 30%);
 		color: $gray-text-min;
+		margin: 16px 0;
 		overflow: hidden;
+		padding: 2px 4px;
 		text-overflow: ellipsis;
 		white-space: nowrap;
 
@@ -303,26 +291,32 @@
 
 .comment__actions {
 	align-items: center;
+	border-top: 1px solid lighten($gray, 30%);
 	display: flex;
 	flex-flow: row;
 	flex-wrap: nowrap;
 	justify-content: space-between;
-	margin: 0 56px;
+	margin: 0 16px 0 56px;
+	padding-top: 8px;
 	padding-bottom: 8px;
 
 	@include breakpoint( '>960px' ) {
 		justify-content: flex-start;
-		margin-right: 16px;
 		margin-left: 40px;
+		padding-top: 0;
 	}
 }
 
 .button.is-borderless.comment__action {
+	flex-basis: 0;
+	flex-grow: 1;
 	padding: 8px;
+	text-align: center;
 
 	span {
-		display: none;
+		display: block;
 		font-weight: 400;
+		padding-top: 4px;
 	}
 
 	&.comment__action-approve:hover {
@@ -345,7 +339,10 @@
 	}
 
 	@include breakpoint( '>960px' ) {
+		flex-basis: auto;
+		flex-grow: 0;
 		padding: 8px 16px;
+		text-align: left;
 
 		.gridicon {
 			margin-right: 4px;
@@ -513,69 +510,11 @@
 	width: 100%;
 }
 
-// Collapsed View
-
-.card.comment.is-collapsed {
-	&.is-pending .comment__content {
-		padding-bottom: 8px;
-	}
-}
-
-// Expanded View
-
-.card.comment.is-expanded {
-	margin: 10px auto;
-
-	.comment__header {
-		border-bottom: 1px solid lighten($gray, 30%);
-
-		.button.comment__toggle-expanded {
-			border-left: 1px solid lighten($gray, 30%);
-		}
-
-		.comment__toggle-expanded .gridicon {
-			transform: rotate(180deg);
-		}
-	}
-
-	.comment__content {
-		padding-bottom: 8px;
-
-		.comment__in-reply-to {
-			border-left: 4px solid lighten($gray, 30%);
-			margin: 16px 0;
-			padding: 2px 4px;
-		}
-	}
-
-	@include breakpoint( '<960px' ) {
-		margin: 0 auto;
-
-		.comment__content {
-			padding-bottom: 16px;
-		}
-
-		.comment__actions {
-			border-top: 1px solid lighten($gray, 30%);
-			padding-top: 8px;
-		}
-
-		.comment__action {
-			flex-basis: 0;
-			flex-grow: 1;
-			text-align: center;
-
-			span {
-				display: block;
-				padding-top: 4px;
-			}
-		}
-	}
-}
-
 // Bulk Mode View
 
 .card.comment.is-bulk-mode {
+	margin: 0 auto;
+
 	&:hover {
 		box-shadow: 0 0 0 1px $gray, 0 2px 4px lighten($gray, 20%);
 		z-index: z-index('root', '.card.comment.is-bulk-mode:hover');
@@ -591,16 +530,10 @@
 		padding-left: 0;
 	}
 
-	&.is-pending .comment__content {
-		padding-bottom: 16px;
-	}
-}
-
-// Post View
-
-.card.comment.is-post-view {
-	.comment__author {
-		padding-right: 8px;
+	.comment__in-reply-to {
+		border: none;
+		margin: 0;
+		padding: 0;
 	}
 }
 
@@ -624,7 +557,7 @@
 	}
 
 	.comment__author {
-		padding: 8px 16px 8px 8px;
+		padding: 8px;
 	}
 
 	.comment__author-gravatar-placeholder {
@@ -654,17 +587,11 @@
 		}
 	}
 
-	.button.comment__toggle-expanded {
+	.comment__author-more-info {
 		display: none;
 	}
 
-	.comment__content-preview {
-		background-color: lighten($gray, 30%);
-		color: transparent;
-		height: 21px;
-	}
-
-	.comment__in-reply-to {
+	.comment__content {
 		display: none;
 	}
 

--- a/client/my-sites/comments/comment/style.scss
+++ b/client/my-sites/comments/comment/style.scss
@@ -209,7 +209,7 @@
 		white-space: nowrap;
 
 		.gridicon {
-			color: $gray;
+			color: $gray-text-min;
 			margin: 0 4px -3px 0;
 		}
 	}
@@ -524,7 +524,7 @@
 // Expanded View
 
 .card.comment.is-expanded {
-	margin: 16px auto;
+	margin: 10px auto;
 
 	.comment__header {
 		border-bottom: 1px solid lighten($gray, 30%);
@@ -549,6 +549,8 @@
 	}
 
 	@include breakpoint( '<960px' ) {
+		margin: 0 auto;
+
 		.comment__content {
 			padding-bottom: 16px;
 		}

--- a/client/my-sites/comments/comment/style.scss
+++ b/client/my-sites/comments/comment/style.scss
@@ -178,14 +178,11 @@
 // Comment Content Block
 
 .comment__content {
-	padding: 0 16px 16px 56px;
-
-	.comment__content-info {
-		margin-top: 16px;
-	}
+	padding: 8px 16px 16px 56px;
 
 	.comment__post-link {
 		font-weight: 600;
+		margin-bottom: 16px;
 		overflow: hidden;
 		text-overflow: ellipsis;
 		white-space: nowrap;
@@ -208,7 +205,7 @@
 	.comment__in-reply-to {
 		border-left: 4px solid lighten($gray, 30%);
 		color: $gray-text-min;
-		margin: 16px 0;
+		margin-bottom: 16px;
 		overflow: hidden;
 		padding: 2px 4px;
 		text-overflow: ellipsis;
@@ -230,10 +227,6 @@
 		a:hover {
 			color: $blue-wordpress;
 		}
-	}
-
-	.comment__content-body {
-		margin-top: 16px;
 	}
 
 	.comment__content-body *:last-child {
@@ -505,6 +498,10 @@
 
 	.comment__author {
 		padding-left: 0;
+	}
+
+	.comment__content {
+		padding-top: 0;
 	}
 
 	.comment__in-reply-to {


### PR DESCRIPTION
Fix #19605
Fix #19306 

Alternative take to #19472
All props to @vindl and @drw158 for bringing this forward!

Experimental branch to test the alternative approach with all comments expanded.

Also applied `pending` style to expanded view to make it look the same as collapsed.

| Big Screens | Small Screens | Bulk Mode |
| --- | --- | --- |
| <img width="770" alt="screen shot 2017-11-13 at 14 40 36" src="https://user-images.githubusercontent.com/2070010/32731113-e22e931a-c880-11e7-9482-7d579a079b48.png"> | <img width="473" alt="screen shot 2017-11-13 at 14 41 24" src="https://user-images.githubusercontent.com/2070010/32731116-e6afbc2a-c880-11e7-9419-83aafe705903.png"> | <img width="744" alt="screen shot 2017-11-13 at 14 42 15" src="https://user-images.githubusercontent.com/2070010/32731121-eac8cc70-c880-11e7-9ab5-bc05d61bd720.png"> |

### Testing instructions

Checkout this branch and run it with
`env ENABLE_FEATURES=comments/management/m3-design npm start`