### PR TITLE
Jetpack connect: Connect auth logged in props

### DIFF
--- a/client/jetpack-connect/auth-logged-in-form.jsx
+++ b/client/jetpack-connect/auth-logged-in-form.jsx
@@ -48,6 +48,7 @@ import {
 	getAuthAttempts,
 	getAuthorizationRemoteSite,
 	getSiteIdFromQueryObject,
+	getUserAlreadyConnected,
 	hasExpiredSecretError as hasExpiredSecretErrorSelector,
 	hasXmlrpcError as hasXmlrpcErrorSelector,
 	isCalypsoStartedConnection,
@@ -95,6 +96,7 @@ class LoggedInForm extends Component {
 		retryAuth: PropTypes.func.isRequired,
 		siteSlug: PropTypes.string.isRequired,
 		translate: PropTypes.func.isRequired,
+		userAlreadyConnected: PropTypes.bool.isRequired,
 	};
 
 	retryingAuth = false;
@@ -579,6 +581,7 @@ export default connect(
 			isFetchingSites: isRequestingSites( state ),
 			redirectAfterAuth: getJetpackConnectRedirectAfterAuth( state ),
 			siteSlug,
+			userAlreadyConnected: getUserAlreadyConnected( state ),
 		};
 	},
 	{

--- a/client/jetpack-connect/auth-logged-in-form.jsx
+++ b/client/jetpack-connect/auth-logged-in-form.jsx
@@ -34,7 +34,7 @@ import userUtilities from 'lib/user/utils';
 import { decodeEntities } from 'lib/formatting';
 import { externalRedirect } from 'lib/route/path';
 import { getJetpackConnectRedirectAfterAuth } from 'state/selectors';
-import { isRequestingSite } from 'state/sites/selectors';
+import { isRequestingSite, isRequestingSites } from 'state/sites/selectors';
 import { login } from 'lib/paths';
 import { recordTracksEvent as recordTracksEventAction } from 'state/analytics/actions';
 import { urlToSlug } from 'lib/url';
@@ -63,7 +63,6 @@ const debug = debugModule( 'calypso:jetpack-connect:authorize-form' );
 
 class LoggedInForm extends Component {
 	static propTypes = {
-		isFetchingSites: PropTypes.bool,
 		isSSO: PropTypes.bool,
 		isWoo: PropTypes.bool,
 		jetpackConnectAuthorize: PropTypes.shape( {
@@ -90,6 +89,7 @@ class LoggedInForm extends Component {
 		hasXmlrpcError: PropTypes.bool,
 		isAlreadyOnSitesList: PropTypes.bool,
 		isFetchingAuthorizationSite: PropTypes.bool,
+		isFetchingSites: PropTypes.bool,
 		recordTracksEvent: PropTypes.func.isRequired,
 		redirectAfterAuth: PropTypes.string,
 		retryAuth: PropTypes.func.isRequired,
@@ -576,6 +576,7 @@ export default connect(
 			hasXmlrpcError: hasXmlrpcErrorSelector( state ),
 			isAlreadyOnSitesList: isRemoteSiteOnSitesList( state ),
 			isFetchingAuthorizationSite: isRequestingSite( state, siteId ),
+			isFetchingSites: isRequestingSites( state ),
 			redirectAfterAuth: getJetpackConnectRedirectAfterAuth( state ),
 			siteSlug,
 		};

--- a/client/jetpack-connect/auth-logged-in-form.jsx
+++ b/client/jetpack-connect/auth-logged-in-form.jsx
@@ -49,6 +49,7 @@ import {
 	hasExpiredSecretError as hasExpiredSecretErrorSelector,
 	hasXmlrpcError as hasXmlrpcErrorSelector,
 	isCalypsoStartedConnection,
+	isRemoteSiteOnSitesList,
 } from 'state/jetpack-connect/selectors';
 
 /**
@@ -60,7 +61,6 @@ const debug = debugModule( 'calypso:jetpack-connect:authorize-form' );
 
 class LoggedInForm extends Component {
 	static propTypes = {
-		isAlreadyOnSitesList: PropTypes.bool,
 		isFetchingAuthorizationSite: PropTypes.bool,
 		isFetchingSites: PropTypes.bool,
 		isSSO: PropTypes.bool,
@@ -87,6 +87,7 @@ class LoggedInForm extends Component {
 		goToXmlrpcErrorFallbackUrl: PropTypes.func.isRequired,
 		hasExpiredSecretError: PropTypes.bool,
 		hasXmlrpcError: PropTypes.bool,
+		isAlreadyOnSitesList: PropTypes.bool,
 		recordTracksEvent: PropTypes.func.isRequired,
 		redirectAfterAuth: PropTypes.string,
 		retryAuth: PropTypes.func.isRequired,
@@ -570,6 +571,7 @@ export default connect(
 			calypsoStartedConnection: isCalypsoStartedConnection( state, remoteSiteUrl ),
 			hasExpiredSecretError: hasExpiredSecretErrorSelector( state ),
 			hasXmlrpcError: hasXmlrpcErrorSelector( state ),
+			isAlreadyOnSitesList: isRemoteSiteOnSitesList( state ),
 			redirectAfterAuth: getJetpackConnectRedirectAfterAuth( state ),
 			siteSlug,
 		};

--- a/client/jetpack-connect/auth-logged-in-form.jsx
+++ b/client/jetpack-connect/auth-logged-in-form.jsx
@@ -34,6 +34,7 @@ import userUtilities from 'lib/user/utils';
 import { decodeEntities } from 'lib/formatting';
 import { externalRedirect } from 'lib/route/path';
 import { getJetpackConnectRedirectAfterAuth } from 'state/selectors';
+import { isRequestingSite } from 'state/sites/selectors';
 import { login } from 'lib/paths';
 import { recordTracksEvent as recordTracksEventAction } from 'state/analytics/actions';
 import { urlToSlug } from 'lib/url';
@@ -46,6 +47,7 @@ import {
 import {
 	getAuthAttempts,
 	getAuthorizationRemoteSite,
+	getSiteIdFromQueryObject,
 	hasExpiredSecretError as hasExpiredSecretErrorSelector,
 	hasXmlrpcError as hasXmlrpcErrorSelector,
 	isCalypsoStartedConnection,
@@ -61,7 +63,6 @@ const debug = debugModule( 'calypso:jetpack-connect:authorize-form' );
 
 class LoggedInForm extends Component {
 	static propTypes = {
-		isFetchingAuthorizationSite: PropTypes.bool,
 		isFetchingSites: PropTypes.bool,
 		isSSO: PropTypes.bool,
 		isWoo: PropTypes.bool,
@@ -88,6 +89,7 @@ class LoggedInForm extends Component {
 		hasExpiredSecretError: PropTypes.bool,
 		hasXmlrpcError: PropTypes.bool,
 		isAlreadyOnSitesList: PropTypes.bool,
+		isFetchingAuthorizationSite: PropTypes.bool,
 		recordTracksEvent: PropTypes.func.isRequired,
 		redirectAfterAuth: PropTypes.string,
 		retryAuth: PropTypes.func.isRequired,
@@ -564,6 +566,7 @@ class LoggedInForm extends Component {
 export default connect(
 	state => {
 		const remoteSiteUrl = getAuthorizationRemoteSite( state );
+		const siteId = getSiteIdFromQueryObject( state );
 		const siteSlug = urlToSlug( remoteSiteUrl );
 
 		return {
@@ -572,6 +575,7 @@ export default connect(
 			hasExpiredSecretError: hasExpiredSecretErrorSelector( state ),
 			hasXmlrpcError: hasXmlrpcErrorSelector( state ),
 			isAlreadyOnSitesList: isRemoteSiteOnSitesList( state ),
+			isFetchingAuthorizationSite: isRequestingSite( state, siteId ),
 			redirectAfterAuth: getJetpackConnectRedirectAfterAuth( state ),
 			siteSlug,
 		};

--- a/client/jetpack-connect/auth-logged-in-form.jsx
+++ b/client/jetpack-connect/auth-logged-in-form.jsx
@@ -85,6 +85,7 @@ class LoggedInForm extends Component {
 		hasExpiredSecretError: PropTypes.bool,
 		hasXmlrpcError: PropTypes.bool,
 		recordTracksEvent: PropTypes.func.isRequired,
+		redirectAfterAuth: PropTypes.string,
 		retryAuth: PropTypes.func.isRequired,
 		translate: PropTypes.func.isRequired,
 	};

--- a/client/jetpack-connect/authorize-form.jsx
+++ b/client/jetpack-connect/authorize-form.jsx
@@ -16,10 +16,7 @@ import Main from 'components/main';
 import LoggedOutFormLinks from 'components/logged-out-form/links';
 import {
 	getAuthorizationData,
-	getAuthorizationRemoteSite,
-	isCalypsoStartedConnection,
 	isRemoteSiteOnSitesList,
-	getAuthAttempts,
 	getSiteIdFromQueryObject,
 	getUserAlreadyConnected,
 } from 'state/jetpack-connect/selectors';
@@ -30,14 +27,11 @@ import { isRequestingSites, isRequestingSite } from 'state/sites/selectors';
 import MainWrapper from './main-wrapper';
 import HelpButton from './help-button';
 import JetpackConnectHappychatButton from './happychat-button';
-import { urlToSlug } from 'lib/url';
 import LoggedInForm from './auth-logged-in-form';
 import LoggedOutForm from './auth-logged-out-form';
 
 class JetpackConnectAuthorizeForm extends Component {
 	static propTypes = {
-		authAttempts: PropTypes.number,
-		calypsoStartedConnection: PropTypes.bool,
 		isAlreadyOnSitesList: PropTypes.bool,
 		isFetchingAuthorizationSite: PropTypes.bool,
 		isFetchingSites: PropTypes.bool,
@@ -49,7 +43,6 @@ class JetpackConnectAuthorizeForm extends Component {
 		} ).isRequired,
 		recordTracksEvent: PropTypes.func,
 		setTracksAnonymousUserId: PropTypes.func,
-		siteSlug: PropTypes.string,
 		user: PropTypes.object,
 	};
 
@@ -138,18 +131,13 @@ export { JetpackConnectAuthorizeForm as JetpackConnectAuthorizeFormTestComponent
 
 export default connect(
 	state => {
-		const remoteSiteUrl = getAuthorizationRemoteSite( state );
-		const siteSlug = urlToSlug( remoteSiteUrl );
 		const siteId = getSiteIdFromQueryObject( state );
 
 		return {
-			authAttempts: getAuthAttempts( state, siteSlug ),
-			calypsoStartedConnection: isCalypsoStartedConnection( state, remoteSiteUrl ),
 			isAlreadyOnSitesList: isRemoteSiteOnSitesList( state ),
 			isFetchingAuthorizationSite: isRequestingSite( state, siteId ),
 			isFetchingSites: isRequestingSites( state ),
 			jetpackConnectAuthorize: getAuthorizationData( state ),
-			siteSlug,
 			user: getCurrentUser( state ),
 			userAlreadyConnected: getUserAlreadyConnected( state ),
 		};

--- a/client/jetpack-connect/authorize-form.jsx
+++ b/client/jetpack-connect/authorize-form.jsx
@@ -14,15 +14,11 @@ import { get, includes } from 'lodash';
  */
 import Main from 'components/main';
 import LoggedOutFormLinks from 'components/logged-out-form/links';
-import {
-	getAuthorizationData,
-	getSiteIdFromQueryObject,
-	getUserAlreadyConnected,
-} from 'state/jetpack-connect/selectors';
+import { getAuthorizationData, getUserAlreadyConnected } from 'state/jetpack-connect/selectors';
 import { getCurrentUser } from 'state/current-user/selectors';
 import { recordTracksEvent, setTracksAnonymousUserId } from 'state/analytics/actions';
 import EmptyContent from 'components/empty-content';
-import { isRequestingSites, isRequestingSite } from 'state/sites/selectors';
+import { isRequestingSites } from 'state/sites/selectors';
 import MainWrapper from './main-wrapper';
 import HelpButton from './help-button';
 import JetpackConnectHappychatButton from './happychat-button';
@@ -31,7 +27,6 @@ import LoggedOutForm from './auth-logged-out-form';
 
 class JetpackConnectAuthorizeForm extends Component {
 	static propTypes = {
-		isFetchingAuthorizationSite: PropTypes.bool,
 		isFetchingSites: PropTypes.bool,
 		jetpackConnectAuthorize: PropTypes.shape( {
 			queryObject: PropTypes.shape( {
@@ -124,17 +119,12 @@ class JetpackConnectAuthorizeForm extends Component {
 export { JetpackConnectAuthorizeForm as JetpackConnectAuthorizeFormTestComponent };
 
 export default connect(
-	state => {
-		const siteId = getSiteIdFromQueryObject( state );
-
-		return {
-			isFetchingAuthorizationSite: isRequestingSite( state, siteId ),
-			isFetchingSites: isRequestingSites( state ),
-			jetpackConnectAuthorize: getAuthorizationData( state ),
-			user: getCurrentUser( state ),
-			userAlreadyConnected: getUserAlreadyConnected( state ),
-		};
-	},
+	state => ( {
+		isFetchingSites: isRequestingSites( state ),
+		jetpackConnectAuthorize: getAuthorizationData( state ),
+		user: getCurrentUser( state ),
+		userAlreadyConnected: getUserAlreadyConnected( state ),
+	} ),
 	{
 		recordTracksEvent,
 		setTracksAnonymousUserId,

--- a/client/jetpack-connect/authorize-form.jsx
+++ b/client/jetpack-connect/authorize-form.jsx
@@ -16,7 +16,6 @@ import Main from 'components/main';
 import LoggedOutFormLinks from 'components/logged-out-form/links';
 import {
 	getAuthorizationData,
-	isRemoteSiteOnSitesList,
 	getSiteIdFromQueryObject,
 	getUserAlreadyConnected,
 } from 'state/jetpack-connect/selectors';
@@ -32,7 +31,6 @@ import LoggedOutForm from './auth-logged-out-form';
 
 class JetpackConnectAuthorizeForm extends Component {
 	static propTypes = {
-		isAlreadyOnSitesList: PropTypes.bool,
 		isFetchingAuthorizationSite: PropTypes.bool,
 		isFetchingSites: PropTypes.bool,
 		jetpackConnectAuthorize: PropTypes.shape( {
@@ -130,7 +128,6 @@ export default connect(
 		const siteId = getSiteIdFromQueryObject( state );
 
 		return {
-			isAlreadyOnSitesList: isRemoteSiteOnSitesList( state ),
 			isFetchingAuthorizationSite: isRequestingSite( state, siteId ),
 			isFetchingSites: isRequestingSites( state ),
 			jetpackConnectAuthorize: getAuthorizationData( state ),

--- a/client/jetpack-connect/authorize-form.jsx
+++ b/client/jetpack-connect/authorize-form.jsx
@@ -14,7 +14,7 @@ import { get, includes } from 'lodash';
  */
 import Main from 'components/main';
 import LoggedOutFormLinks from 'components/logged-out-form/links';
-import { getAuthorizationData, getUserAlreadyConnected } from 'state/jetpack-connect/selectors';
+import { getAuthorizationData } from 'state/jetpack-connect/selectors';
 import { getCurrentUser } from 'state/current-user/selectors';
 import { recordTracksEvent, setTracksAnonymousUserId } from 'state/analytics/actions';
 import EmptyContent from 'components/empty-content';
@@ -120,7 +120,6 @@ export default connect(
 	state => ( {
 		jetpackConnectAuthorize: getAuthorizationData( state ),
 		user: getCurrentUser( state ),
-		userAlreadyConnected: getUserAlreadyConnected( state ),
 	} ),
 	{
 		recordTracksEvent,

--- a/client/jetpack-connect/authorize-form.jsx
+++ b/client/jetpack-connect/authorize-form.jsx
@@ -18,7 +18,6 @@ import { getAuthorizationData, getUserAlreadyConnected } from 'state/jetpack-con
 import { getCurrentUser } from 'state/current-user/selectors';
 import { recordTracksEvent, setTracksAnonymousUserId } from 'state/analytics/actions';
 import EmptyContent from 'components/empty-content';
-import { isRequestingSites } from 'state/sites/selectors';
 import MainWrapper from './main-wrapper';
 import HelpButton from './help-button';
 import JetpackConnectHappychatButton from './happychat-button';
@@ -27,7 +26,6 @@ import LoggedOutForm from './auth-logged-out-form';
 
 class JetpackConnectAuthorizeForm extends Component {
 	static propTypes = {
-		isFetchingSites: PropTypes.bool,
 		jetpackConnectAuthorize: PropTypes.shape( {
 			queryObject: PropTypes.shape( {
 				client_id: PropTypes.string,
@@ -120,7 +118,6 @@ export { JetpackConnectAuthorizeForm as JetpackConnectAuthorizeFormTestComponent
 
 export default connect(
 	state => ( {
-		isFetchingSites: isRequestingSites( state ),
 		jetpackConnectAuthorize: getAuthorizationData( state ),
 		user: getCurrentUser( state ),
 		userAlreadyConnected: getUserAlreadyConnected( state ),

--- a/client/jetpack-connect/authorize-form.jsx
+++ b/client/jetpack-connect/authorize-form.jsx
@@ -115,10 +115,6 @@ class JetpackConnectAuthorizeForm extends Component {
 			return this.renderNoQueryArgsError();
 		}
 
-		if ( queryObject && queryObject.already_authorized && ! this.props.isAlreadyOnSitesList ) {
-			this.renderForm();
-		}
-
 		return (
 			<MainWrapper>
 				<div className="jetpack-connect__authorize-form">{ this.renderForm() }</div>

--- a/client/state/jetpack-connect/selectors.js
+++ b/client/state/jetpack-connect/selectors.js
@@ -97,6 +97,12 @@ const getAuthAttempts = ( state, slug ) => {
 	return attemptsData ? attemptsData.attempt || 0 : 0;
 };
 
+/**
+ * Returns true if the user is already connected, otherwise false
+ *
+ * @param  {Object}  state Global state tree
+ * @return {boolean}       True if the user is connected otherwise false
+ */
 const getUserAlreadyConnected = state => {
 	return get( getAuthorizationData( state ), 'userAlreadyConnected', false );
 };


### PR DESCRIPTION
This PR moves several selectors which are only passed to the logged in form descendent to that component's `connect`.

## Testing 
1. Verify that the moved selectors are unused by the parent
1. Verify the logged-in connection flows continue to work as before
   - From WordPress.com `/jetpack/connect/`
   - From WP Admin