### PR TITLE
Add skills to happychat

### DIFF
--- a/client/lib/happychat/connection-ng.js
+++ b/client/lib/happychat/connection-ng.js
@@ -48,16 +48,16 @@ class Connection {
 
 		this.openSocket = new Promise( ( resolve, reject ) => {
 			auth
-				.then( ( { url, user: { signer_user_id, jwt, locale, groups, geoLocation } } ) => {
+				.then( ( { url, user: { signer_user_id, jwt, locale, groups, skills, geoLocation } } ) => {
 					const socket = buildConnection( url );
 					socket
 						.once( 'connect', () => dispatch( receiveConnect() ) )
 						.on( 'token', handler => {
 							dispatch( receiveToken() );
-							handler( { signer_user_id, jwt, locale, groups } );
+							handler( { signer_user_id, jwt, locale, groups, skills } );
 						} )
 						.on( 'init', () => {
-							dispatch( receiveInit( { signer_user_id, locale, groups, geoLocation } ) );
+							dispatch( receiveInit( { signer_user_id, locale, groups, skills, geoLocation } ) );
 							dispatch( requestTranscript() );
 							resolve( socket );
 						} )

--- a/client/lib/happychat/connection.js
+++ b/client/lib/happychat/connection.js
@@ -48,17 +48,17 @@ class Connection {
 
 		this.openSocket = new Promise( ( resolve, reject ) => {
 			auth
-				.then( ( { url, user: { signer_user_id, jwt, locale, groups, geoLocation } } ) => {
+				.then( ( { url, user: { signer_user_id, jwt, locale, groups, skills, geoLocation } } ) => {
 					const socket = buildConnection( url );
 
 					socket
 						.once( 'connect', () => dispatch( receiveConnect() ) )
 						.on( 'token', handler => {
 							dispatch( receiveToken() );
-							handler( { signer_user_id, jwt, locale, groups } );
+							handler( { signer_user_id, jwt, locale, groups, skills } );
 						} )
 						.on( 'init', () => {
-							dispatch( receiveInit( { signer_user_id, locale, groups, geoLocation } ) );
+							dispatch( receiveInit( { signer_user_id, locale, groups, skills, geoLocation } ) );
 							dispatch( requestTranscript() );
 							resolve( socket );
 						} )

--- a/client/state/happychat/connection/actions.js
+++ b/client/state/happychat/connection/actions.js
@@ -278,13 +278,16 @@ export const sendNotTyping = () => sendTyping( false );
  *
  * @param { String } locale representing the user selected locale
  * @param { Array } groups of string happychat groups (wp.com, jpop) based on the site selected
+ * @param { Object } skills object based on product and language ( formerly group and locale )
+ *
  * @return { Object } Action object
  */
-export const sendPreferences = ( locale, groups ) => ( {
+export const sendPreferences = ( locale, groups, skills ) => ( {
 	type: HAPPYCHAT_IO_SEND_PREFERENCES,
 	event: 'preferences',
 	payload: {
 		locale,
 		groups,
+		skills,
 	},
 } );

--- a/client/state/happychat/constants.js
+++ b/client/state/happychat/constants.js
@@ -17,6 +17,12 @@ export const HAPPYCHAT_CONNECTION_STATUS_UNAUTHORIZED = 'unauthorized';
 // Max number of messages to save between refreshes
 export const HAPPYCHAT_MAX_STORED_MESSAGES = 30;
 
+// Skills
+export const HAPPYCHAT_SKILLS = {
+	PRODUCT: 'product',
+	LANGUAGE: 'language',
+};
+
 // Groups
 export const HAPPYCHAT_GROUP_JPOP = 'jpop';
 export const HAPPYCHAT_GROUP_WOO = 'woo';

--- a/client/state/happychat/constants.js
+++ b/client/state/happychat/constants.js
@@ -24,10 +24,10 @@ export const HAPPYCHAT_SKILLS = {
 };
 
 // Groups
-export const HAPPYCHAT_GROUP_JPOP = 'JPOP';
-export const HAPPYCHAT_GROUP_WOO = 'WOO';
-export const HAPPYCHAT_GROUP_JPPHP = 'JPPHP';
-export const HAPPYCHAT_GROUP_WPCOM = 'WPCOM';
+export const HAPPYCHAT_GROUP_JPOP = 'jpop';
+export const HAPPYCHAT_GROUP_WOO = 'woo';
+export const HAPPYCHAT_GROUP_JPPHP = 'jpphp';
+export const HAPPYCHAT_GROUP_WPCOM = 'WP.com';
 
 // Message types
 export const HAPPYCHAT_MESSAGE_TYPES = {

--- a/client/state/happychat/constants.js
+++ b/client/state/happychat/constants.js
@@ -24,10 +24,10 @@ export const HAPPYCHAT_SKILLS = {
 };
 
 // Groups
-export const HAPPYCHAT_GROUP_JPOP = 'jpop';
-export const HAPPYCHAT_GROUP_WOO = 'woo';
-export const HAPPYCHAT_GROUP_JPPHP = 'jpphp';
-export const HAPPYCHAT_GROUP_WPCOM = 'WP.com';
+export const HAPPYCHAT_GROUP_JPOP = 'JPOP';
+export const HAPPYCHAT_GROUP_WOO = 'WOO';
+export const HAPPYCHAT_GROUP_JPPHP = 'JPPHP';
+export const HAPPYCHAT_GROUP_WPCOM = 'WPCOM';
 
 // Message types
 export const HAPPYCHAT_MESSAGE_TYPES = {

--- a/client/state/happychat/constants.js
+++ b/client/state/happychat/constants.js
@@ -18,10 +18,8 @@ export const HAPPYCHAT_CONNECTION_STATUS_UNAUTHORIZED = 'unauthorized';
 export const HAPPYCHAT_MAX_STORED_MESSAGES = 30;
 
 // Skills
-export const HAPPYCHAT_SKILLS = {
-	PRODUCT: 'product',
-	LANGUAGE: 'language',
-};
+export const HAPPYCHAT_SKILL_PRODUCT = 'product';
+export const HAPPYCHAT_SKILL_LANGUAGE = 'language';
 
 // Groups
 export const HAPPYCHAT_GROUP_JPOP = 'jpop';

--- a/client/state/happychat/middleware-calypso.js
+++ b/client/state/happychat/middleware-calypso.js
@@ -29,6 +29,7 @@ import {
 } from 'state/action-types';
 import { sendEvent, sendLog, sendPreferences } from 'state/happychat/connection/actions';
 import { getGroups } from './selectors';
+import getSkills from 'state/happychat/selectors/get-skills';
 import isHappychatChatAssigned from 'state/happychat/selectors/is-happychat-chat-assigned';
 import isHappychatClientConnected from 'state/happychat/selectors/is-happychat-client-connected';
 import { getCurrentUser, getCurrentUserLocale } from 'state/current-user/selectors';
@@ -138,11 +139,13 @@ export default store => next => action => {
 
 	switch ( action.type ) {
 		case HELP_CONTACT_FORM_SITE_SELECT:
-			isHappychatClientConnected( state )
-				? dispatch(
-						sendPreferences( getCurrentUserLocale( state ), getGroups( state, action.siteId ) )
-					)
-				: noop;
+			if ( isHappychatClientConnected( state ) ) {
+				const locales = getCurrentUserLocale( state );
+				const groups = getGroups( state, action.siteId );
+				const skills = getSkills( state, action.siteId );
+
+				dispatch( sendPreferences( locales, groups, skills ) );
+			}
 			break;
 
 		case ROUTE_SET:

--- a/client/state/happychat/selectors/get-skills.js
+++ b/client/state/happychat/selectors/get-skills.js
@@ -1,0 +1,30 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+import { HAPPYCHAT_SKILLS } from 'state/happychat/constants';
+import { getGroups } from 'state/happychat/selectors';
+import { getCurrentUserLocale } from 'state/current-user/selectors';
+
+/**
+ * Returns an object of happychat skills array ( product - before known as groups and language )
+ *
+ * @param { Object } state Global state tree
+ * @param { String } siteId Id of the selected site used to determine the product (wpcom, jetpack)
+ *
+ * @return { String } Current user geo location
+ */
+export default ( state, siteId ) => {
+	const skills = {
+		// TODO: we should rename this to getProduct when cleaning up groups and locales
+		[ HAPPYCHAT_SKILLS.PRODUCT ]: getGroups( state, siteId ),
+	};
+
+	const language = getCurrentUserLocale( state );
+	if ( language ) {
+		skills[ HAPPYCHAT_SKILLS.LANGUAGE ] = [ language ];
+	}
+
+	return skills;
+};

--- a/client/state/happychat/selectors/get-skills.js
+++ b/client/state/happychat/selectors/get-skills.js
@@ -3,7 +3,7 @@
 /**
  * Internal dependencies
  */
-import { HAPPYCHAT_SKILLS } from 'state/happychat/constants';
+import { HAPPYCHAT_SKILL_PRODUCT, HAPPYCHAT_SKILL_LANGUAGE } from 'state/happychat/constants';
 import { getGroups } from 'state/happychat/selectors';
 import { getCurrentUserLocale } from 'state/current-user/selectors';
 
@@ -18,12 +18,12 @@ import { getCurrentUserLocale } from 'state/current-user/selectors';
 export default ( state, siteId ) => {
 	const skills = {
 		// TODO: we should rename this to getProduct when cleaning up groups and locales
-		[ HAPPYCHAT_SKILLS.PRODUCT ]: getGroups( state, siteId ),
+		[ HAPPYCHAT_SKILL_PRODUCT ]: getGroups( state, siteId ),
 	};
 
 	const language = getCurrentUserLocale( state );
 	if ( language ) {
-		skills[ HAPPYCHAT_SKILLS.LANGUAGE ] = [ language ];
+		skills[ HAPPYCHAT_SKILL_LANGUAGE ] = [ language ];
 	}
 
 	return skills;

--- a/client/state/happychat/selectors/test/get-skills.js
+++ b/client/state/happychat/selectors/test/get-skills.js
@@ -1,0 +1,115 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import {
+	HAPPYCHAT_GROUP_WPCOM,
+	HAPPYCHAT_GROUP_JPOP,
+	HAPPYCHAT_SKILLS,
+} from 'state/happychat/constants';
+import getSkills from 'state/happychat/selectors/get-skills';
+
+describe( '#getSkills()', () => {
+	let _window; // Keep a copy of the original window if any
+	const uiState = {
+		ui: {
+			section: {
+				name: 'reader',
+			},
+		},
+	};
+
+	beforeEach( () => {
+		_window = global.window;
+		global.window = {};
+	} );
+
+	afterEach( () => {
+		global.window = _window;
+	} );
+
+	test( 'should return default product for no sites', () => {
+		const siteId = 1;
+		const state = {
+			...uiState,
+			users: {
+				items: {
+					73705554: { ID: 73705554, login: 'testonesite2014', localeSlug: 'en' },
+				},
+			},
+			currentUser: {
+				id: 73705554,
+			},
+			sites: {
+				items: {},
+			},
+		};
+		expect( getSkills( state, siteId ) ).to.eql( {
+			[ HAPPYCHAT_SKILLS.PRODUCT ]: [ HAPPYCHAT_GROUP_WPCOM ],
+			[ HAPPYCHAT_SKILLS.LANGUAGE ]: [ 'en' ],
+		} );
+	} );
+
+	test( 'should ignore language if not set', () => {
+		const siteId = 1;
+		const state = {
+			...uiState,
+			users: {
+				items: {
+					73705554: { ID: 73705554, login: 'testonesite2014' },
+				},
+			},
+			currentUser: {
+				id: 73705554,
+			},
+			sites: {
+				items: {},
+			},
+		};
+		expect( getSkills( state, siteId ) ).to.eql( {
+			[ HAPPYCHAT_SKILLS.PRODUCT ]: [ HAPPYCHAT_GROUP_WPCOM ],
+		} );
+	} );
+
+	test( 'should return both product and language', () => {
+		const siteId = 1;
+		const state = {
+			...uiState,
+			users: {
+				items: {
+					1: { ID: 1, login: 'testonesite2014', localeSlug: 'fr' },
+				},
+			},
+			currentUser: {
+				id: 1,
+				capabilities: {
+					[ siteId ]: {
+						manage_options: true,
+					},
+				},
+			},
+			sites: {
+				items: {
+					[ siteId ]: {
+						jetpack: true,
+						plan: {
+							product_id: 2005,
+							product_slug: 'jetpack_personal',
+						},
+					},
+				},
+			},
+		};
+
+		expect( getSkills( state, siteId ) ).to.eql( {
+			[ HAPPYCHAT_SKILLS.PRODUCT ]: [ HAPPYCHAT_GROUP_JPOP ],
+			[ HAPPYCHAT_SKILLS.LANGUAGE ]: [ 'fr' ],
+		} );
+	} );
+} );

--- a/client/state/happychat/selectors/test/get-skills.js
+++ b/client/state/happychat/selectors/test/get-skills.js
@@ -11,12 +11,12 @@ import { expect } from 'chai';
 import {
 	HAPPYCHAT_GROUP_WPCOM,
 	HAPPYCHAT_GROUP_JPOP,
-	HAPPYCHAT_SKILLS,
+	HAPPYCHAT_SKILL_PRODUCT,
+	HAPPYCHAT_SKILL_LANGUAGE,
 } from 'state/happychat/constants';
 import getSkills from 'state/happychat/selectors/get-skills';
 
 describe( '#getSkills()', () => {
-	let _window; // Keep a copy of the original window if any
 	const uiState = {
 		ui: {
 			section: {
@@ -24,15 +24,6 @@ describe( '#getSkills()', () => {
 			},
 		},
 	};
-
-	beforeEach( () => {
-		_window = global.window;
-		global.window = {};
-	} );
-
-	afterEach( () => {
-		global.window = _window;
-	} );
 
 	test( 'should return default product for no sites', () => {
 		const siteId = 1;
@@ -51,8 +42,8 @@ describe( '#getSkills()', () => {
 			},
 		};
 		expect( getSkills( state, siteId ) ).to.eql( {
-			[ HAPPYCHAT_SKILLS.PRODUCT ]: [ HAPPYCHAT_GROUP_WPCOM ],
-			[ HAPPYCHAT_SKILLS.LANGUAGE ]: [ 'en' ],
+			[ HAPPYCHAT_SKILL_PRODUCT ]: [ HAPPYCHAT_GROUP_WPCOM ],
+			[ HAPPYCHAT_SKILL_LANGUAGE ]: [ 'en' ],
 		} );
 	} );
 
@@ -73,7 +64,7 @@ describe( '#getSkills()', () => {
 			},
 		};
 		expect( getSkills( state, siteId ) ).to.eql( {
-			[ HAPPYCHAT_SKILLS.PRODUCT ]: [ HAPPYCHAT_GROUP_WPCOM ],
+			[ HAPPYCHAT_SKILL_PRODUCT ]: [ HAPPYCHAT_GROUP_WPCOM ],
 		} );
 	} );
 
@@ -108,8 +99,8 @@ describe( '#getSkills()', () => {
 		};
 
 		expect( getSkills( state, siteId ) ).to.eql( {
-			[ HAPPYCHAT_SKILLS.PRODUCT ]: [ HAPPYCHAT_GROUP_JPOP ],
-			[ HAPPYCHAT_SKILLS.LANGUAGE ]: [ 'fr' ],
+			[ HAPPYCHAT_SKILL_PRODUCT ]: [ HAPPYCHAT_GROUP_JPOP ],
+			[ HAPPYCHAT_SKILL_LANGUAGE ]: [ 'fr' ],
 		} );
 	} );
 } );

--- a/client/state/happychat/test/middleware-calypso.js
+++ b/client/state/happychat/test/middleware-calypso.js
@@ -13,6 +13,7 @@ import middleware, {
 	sendAnalyticsLogEvent,
 	getEventMessageFromTracksData,
 } from '../middleware-calypso';
+import getSkills from 'state/happychat/selectors/get-skills';
 import { selectSiteId } from 'state/help/actions';
 import { setRoute } from 'state/ui/actions';
 import { getCurrentUserLocale } from 'state/current-user/selectors';
@@ -70,7 +71,11 @@ describe( 'middleware', () => {
 				const action = selectSiteId( state.sites.items[ 1 ].ID );
 				actionMiddleware( action );
 				expect( store.dispatch ).toHaveBeenCalledWith(
-					sendPreferences( getCurrentUserLocale( state ), getGroups( state, action.siteId ) )
+					sendPreferences(
+						getCurrentUserLocale( state ),
+						getGroups( state, action.siteId ),
+						getSkills( state, action.siteId )
+					)
 				);
 			} );
 

--- a/client/state/happychat/test/middleware.js
+++ b/client/state/happychat/test/middleware.js
@@ -85,7 +85,7 @@ describe( 'middleware', () => {
 		} );
 
 		test( 'HAPPYCHAT_IO_SEND_MESSAGE_PREFERENCES', () => {
-			const action = sendPreferences( 'locale', [] );
+			const action = sendPreferences( 'locale', [], {} );
 			actionMiddleware( action );
 			expect( connection.send ).toHaveBeenCalledWith( action );
 		} );

--- a/client/state/happychat/utils.js
+++ b/client/state/happychat/utils.js
@@ -8,6 +8,7 @@ import config from 'config';
 import { getGroups } from 'state/happychat/selectors';
 import { getCurrentUser, getCurrentUserLocale } from 'state/current-user/selectors';
 import { getHelpSelectedSite } from 'state/help/selectors';
+import getSkills from 'state/happychat/selectors/get-skills';
 
 // Promise based interface for wpcom.request
 const request = ( ...args ) =>
@@ -39,9 +40,12 @@ export const getHappychatAuth = state => () => {
 	const locale = getCurrentUserLocale( state );
 
 	let groups = getGroups( state );
+	let skills = getSkills( state );
 	const selectedSite = getHelpSelectedSite( state );
+
 	if ( selectedSite && selectedSite.ID ) {
 		groups = getGroups( state, selectedSite.ID );
+		skills = getSkills( state, selectedSite.ID );
 	}
 
 	const user = getCurrentUser( state );
@@ -50,6 +54,7 @@ export const getHappychatAuth = state => () => {
 		signer_user_id: user.ID,
 		locale,
 		groups,
+		skills,
 	};
 
 	return startSession()


### PR DESCRIPTION
## Summary
As part of moving away from groups and locales to a more streamlined `skills` object this PR creates an skills object based on groups and user locales and sends it to the happychat service on initialization and also when updating chat preferences.

## Testing
1. Open redux dev tools
2. Go to `help/contact`
3. `HAPPYCHAT_IO_RECEIVE_INIT` action should contain skills object based on groups and user locale - https://cloudup.com/cTI9rt6Sv3D
4. Open Network tab to the happychat WS
5. Select another site from the dropdown
6. A `preferences` event should be emitted containing skills based on selected site group and user locale - https://cloudup.com/cHsMYzxiO7R