### PR TITLE
Prettier: format sass files from scripts

### DIFF
--- a/bin/pre-commit-hook.js
+++ b/bin/pre-commit-hook.js
@@ -18,6 +18,12 @@ const prettier = require( 'prettier' );
  */
 const shouldFormat = require( './utils/should-format' );
 
+/**
+ * Module constants
+ */
+const defaultPrettierConfig = undefined;
+const sassPrettierConfig = { parser: 'scss' };
+
 console.log(
 	'\nBy contributing to this project, you license the materials you contribute ' +
 		'under the GNU General Public License v2 (or later). All materials must have ' +
@@ -38,7 +44,9 @@ function parseGitDiffToPathArray( command ) {
 		.toString()
 		.split( '\n' )
 		.map( name => name.trim() )
-		.filter( name => name.endsWith( '.js' ) || name.endsWith( '.jsx' ) );
+		.filter(
+			name => name.endsWith( '.js' ) || name.endsWith( '.jsx' ) || name.endsWith( '.scss' )
+		);
 }
 
 const dirtyFiles = new Set( parseGitDiffToPathArray( 'git diff --name-only --diff-filter=ACM' ) );
@@ -57,7 +65,10 @@ files.forEach( file => {
 			return;
 		}
 
-		const formattedText = prettier.format( text, {} );
+		const formattedText = prettier.format(
+			text,
+			file.endsWith( '.scss' ) ? sassPrettierConfig : defaultPrettierConfig
+		);
 
 		// No change required.
 		if ( text === formattedText ) {
@@ -71,10 +82,14 @@ files.forEach( file => {
 } );
 
 // linting should happen after formatting
-const lintResult = spawnSync( 'eslint-eslines', [ ...files, '--', '--diff=index' ], {
-	shell: true,
-	stdio: 'inherit',
-} );
+const lintResult = spawnSync(
+	'eslint-eslines',
+	[ ...files.filter( f => ! f.endsWith( '.scss' ) ), '--', '--diff=index' ],
+	{
+		shell: true,
+		stdio: 'inherit',
+	}
+);
 
 if ( lintResult.status ) {
 	console.log(

--- a/bin/pre-commit-hook.js
+++ b/bin/pre-commit-hook.js
@@ -84,7 +84,7 @@ files.forEach( file => {
 // linting should happen after formatting
 const lintResult = spawnSync(
 	'eslint-eslines',
-	[ ...files.filter( f => ! f.endsWith( '.scss' ) ), '--', '--diff=index' ],
+	[ ...files.filter( file => ! file.endsWith( '.scss' ) ), '--', '--diff=index' ],
 	{
 		shell: true,
 		stdio: 'inherit',

--- a/bin/reformat-files.js
+++ b/bin/reformat-files.js
@@ -15,6 +15,12 @@ const prettier = require( 'prettier' );
 const shouldFormat = require( './utils/should-format' );
 
 /**
+ * Module constants
+ */
+const defaultPrettierConfig = undefined;
+const sassPrettierConfig = { parser: 'scss' };
+
+/**
  * Find all JS and JSX files in the project that have the @format tag
  * and reformat them with Prettier. Useful when upgrading Prettier to
  * a newer version.
@@ -25,7 +31,7 @@ const ignoreFile = fs.readFileSync( '.eslintignore', 'utf-8' );
 const ig = ignore().add( ignoreFile );
 
 // List .js and .jsx files in the current directory
-const files = glob.sync( '**/*.{js,jsx}', {
+const files = glob.sync( '**/*.{js,jsx,scss}', {
 	ignore: 'node_modules/**', // ignore node_modules by default
 	nodir: true,
 } );
@@ -43,7 +49,10 @@ files.forEach( file => {
 		return;
 	}
 
-	const formattedText = prettier.format( text, {} );
+	const formattedText = prettier.format(
+		text,
+		file.endsWith( '.scss' ) ? sassPrettierConfig : defaultPrettierConfig
+	);
 
 	// did the re-formatting change anything?
 	if ( formattedText === text ) {


### PR DESCRIPTION
This PR updates the `pre-commit-hook` and `reformat-files` script to `prettier` sass files in addition to JS files.

## Testing
- Verify `npm run reformat-files` formats sass files with the `@format` flag
- Verify the pre-commit hook formats sass files with the `@format` flag
- Verify other behaviors remain unaffected

Depends on `prettier@^1.7` #19519 