### PR TITLE
Comments: fix duplicate comment error message

### DIFF
--- a/client/blocks/comments/form.jsx
+++ b/client/blocks/comments/form.jsx
@@ -159,7 +159,7 @@ class PostCommentForm extends React.Component {
 			return null;
 		}
 
-		switch ( error.error ) {
+		switch ( this.props.errorType ) {
 			case 'comment_duplicate':
 				message = translate(
 					"Duplicate comment detected. It looks like you've already said that!"

--- a/client/blocks/comments/post-comment-with-error.jsx
+++ b/client/blocks/comments/post-comment-with-error.jsx
@@ -17,6 +17,7 @@ export default class PostCommentWithError extends React.Component {
 		const commentText = get( commentsTree, [ commentId, 'data', 'content' ] );
 		const commentParentId = get( commentsTree, [ commentId, 'data', 'parent', 'ID' ], null );
 		const placeholderError = get( commentsTree, [ commentId, 'data', 'placeholderError' ] );
+		const placeholderErrorType = get( commentsTree, [ commentId, 'data', 'placeholderErrorType' ] );
 
 		if ( activeReplyCommentId !== commentParentId ) {
 			return null;
@@ -31,6 +32,7 @@ export default class PostCommentWithError extends React.Component {
 				onUpdateCommentText={ onUpdateCommentText }
 				placeholderId={ commentId }
 				error={ placeholderError }
+				errorType={ placeholderErrorType }
 			/>
 		);
 	}

--- a/client/state/comments/reducer.js
+++ b/client/state/comments/reducer.js
@@ -145,7 +145,7 @@ export function items( state = {}, action ) {
 			};
 		case COMMENTS_RECEIVE_ERROR:
 		case COMMENTS_WRITE_ERROR:
-			const { error } = action;
+			const { error, errorType } = action;
 			return {
 				...state,
 				[ stateKey ]: map(
@@ -153,6 +153,7 @@ export function items( state = {}, action ) {
 					updateComment( commentId, {
 						placeholderState: PLACEHOLDER_STATE.ERROR,
 						placeholderError: error,
+						placeholderErrorType: errorType,
 					} )
 				),
 			};

--- a/client/state/data-layer/wpcom/sites/utils.js
+++ b/client/state/data-layer/wpcom/sites/utils.js
@@ -142,7 +142,7 @@ export const handleWriteCommentFailure = (
 		commentId: placeholderId,
 		parentCommentId,
 		error,
-		errorType: rawError.error,
+		errorType: rawError && rawError.error,
 	} );
 
 	dispatch( errorNotice( error, { duration: 5000 } ) );

--- a/client/state/data-layer/wpcom/sites/utils.js
+++ b/client/state/data-layer/wpcom/sites/utils.js
@@ -117,7 +117,8 @@ export const updatePlaceholderComment = (
  */
 export const handleWriteCommentFailure = (
 	{ dispatch, getState },
-	{ siteId, postId, parentCommentId, placeholderId }
+	{ siteId, postId, parentCommentId, placeholderId },
+	rawError
 ) => {
 	// Dispatch error notice
 	const post = getSitePost( getState(), siteId, postId );
@@ -141,6 +142,7 @@ export const handleWriteCommentFailure = (
 		commentId: placeholderId,
 		parentCommentId,
 		error,
+		errorType: rawError.error,
 	} );
 
 	dispatch( errorNotice( error, { duration: 5000 } ) );


### PR DESCRIPTION
In https://github.com/Automattic/wp-calypso/issues/18562 I noticed that we were no longer showing a different message when a duplicate comment was posted. We used to do this in the comments section of Reader before the switch to Redux.

When a duplicate comment post is attempted by the same user, the API returns a 409 with the error code `duplicate_comment`.

This PR restores the special handling and error message for this type of posting error:

<img width="750" alt="screen shot 2017-11-07 at 17 50 48" src="https://user-images.githubusercontent.com/17325/32509080-37e70ed2-c3e4-11e7-83d6-71b75cbe0e30.png">

Fixes #18562.

### To test

On a comment thread, try and make the same comment twice in succession. You should be shown the inline error as in the screenshot.