### PR TITLE
Store: Split dashboard rendering into setup or normal mode

### DIFF
--- a/client/extensions/woocommerce/app/dashboard/index.js
+++ b/client/extensions/woocommerce/app/dashboard/index.js
@@ -28,7 +28,7 @@ import {
 	getNewOrdersWithoutPayPalPending,
 } from 'woocommerce/state/sites/orders/selectors';
 import { fetchOrders } from 'woocommerce/state/sites/orders/actions';
-import { fetchProducts, fetchProductsFailure } from 'woocommerce/state/sites/products/actions';
+import { fetchProducts } from 'woocommerce/state/sites/products/actions';
 import { requestSettings } from 'woocommerce/state/sites/settings/mailchimp/actions';
 import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
 import {
@@ -99,11 +99,8 @@ class Dashboard extends Component {
 
 	fetchSiteProducts = siteId => {
 		const params = { page: 1 };
-		const failureAction = dispatch => {
-			dispatch( this.props.fetchProductsFailure( siteId, params ) );
-		};
 
-		this.props.fetchProducts( siteId, params, null, failureAction );
+		this.props.fetchProducts( siteId, params, null, null );
 	};
 
 	getBreadcrumb = () => {
@@ -242,7 +239,6 @@ function mapDispatchToProps( dispatch ) {
 			fetchOrders,
 			fetchSetupChoices,
 			fetchProducts,
-			fetchProductsFailure,
 			requestSettings,
 		},
 		dispatch

--- a/client/extensions/woocommerce/app/dashboard/index.js
+++ b/client/extensions/woocommerce/app/dashboard/index.js
@@ -27,7 +27,7 @@ import {
 	getNewOrdersWithoutPayPalPending,
 } from 'woocommerce/state/sites/orders/selectors';
 import { fetchOrders } from 'woocommerce/state/sites/orders/actions';
-import { fetchProducts } from 'woocommerce/state/sites/products/actions';
+import { fetchProducts, fetchProductsFailure } from 'woocommerce/state/sites/products/actions';
 import { requestSettings } from 'woocommerce/state/sites/settings/mailchimp/actions';
 import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
 import {
@@ -74,7 +74,7 @@ class Dashboard extends Component {
 			this.props.requestSettings( siteId );
 
 			if ( ! productsLoaded ) {
-				this.props.fetchProducts( siteId, { page: 1 } );
+				this.fetchSiteProducts( siteId );
 			}
 		}
 	};
@@ -91,9 +91,18 @@ class Dashboard extends Component {
 			this.props.requestSettings( newSiteId );
 
 			if ( ! productsLoaded ) {
-				this.props.fetchProducts( newSiteId, { page: 1 } );
+				this.fetchSiteProducts( newSiteId );
 			}
 		}
+	};
+
+	fetchSiteProducts = siteId => {
+		const params = { page: 1 };
+		const failureAction = dispatch => {
+			dispatch( this.props.fetchProductsFailure( siteId, params ) );
+		};
+
+		this.props.fetchProducts( siteId, params, null, failureAction );
 	};
 
 	getBreadcrumb = () => {
@@ -239,6 +248,7 @@ function mapDispatchToProps( dispatch ) {
 			fetchOrders,
 			fetchSetupChoices,
 			fetchProducts,
+			fetchProductsFailure,
 			requestSettings,
 		},
 		dispatch

--- a/client/extensions/woocommerce/app/dashboard/index.js
+++ b/client/extensions/woocommerce/app/dashboard/index.js
@@ -67,40 +67,32 @@ class Dashboard extends Component {
 	};
 
 	componentDidMount = () => {
-		const { siteId, productsLoaded } = this.props;
+		const { siteId } = this.props;
 
 		if ( siteId ) {
-			this.props.fetchSetupChoices( siteId );
-			this.props.fetchOrders( siteId );
-			this.props.requestSettings( siteId );
-
-			if ( ! productsLoaded ) {
-				this.fetchSiteProducts( siteId );
-			}
+			this.fetchStoreData();
 		}
 	};
 
-	componentWillReceiveProps = newProps => {
+	componentDidUpdate = prevProps => {
+		const { siteId } = this.props;
+		const oldSiteId = prevProps.siteId ? prevProps.siteId : null;
+
+		if ( siteId && oldSiteId !== siteId ) {
+			this.fetchStoreData();
+		}
+	};
+
+	fetchStoreData = () => {
 		const { siteId, productsLoaded } = this.props;
+		this.props.fetchSetupChoices( siteId );
+		this.props.fetchOrders( siteId );
+		this.props.requestSettings( siteId );
 
-		const newSiteId = newProps.siteId ? newProps.siteId : null;
-		const oldSiteId = siteId ? siteId : null;
-
-		if ( newSiteId && oldSiteId !== newSiteId ) {
-			this.props.fetchSetupChoices( newSiteId );
-			this.props.fetchOrders( newSiteId );
-			this.props.requestSettings( newSiteId );
-
-			if ( ! productsLoaded ) {
-				this.fetchSiteProducts( newSiteId );
-			}
+		if ( ! productsLoaded ) {
+			const params = { page: 1 };
+			this.props.fetchProducts( siteId, params, null, null );
 		}
-	};
-
-	fetchSiteProducts = siteId => {
-		const params = { page: 1 };
-
-		this.props.fetchProducts( siteId, params, null, null );
 	};
 
 	getBreadcrumb = () => {

--- a/client/extensions/woocommerce/app/dashboard/index.js
+++ b/client/extensions/woocommerce/app/dashboard/index.js
@@ -21,6 +21,7 @@ import {
 	getSetStoreAddressDuringInitialSetup,
 	getFinishedInstallOfRequiredPlugins,
 	getFinishedPageSetup,
+	isStoreSetupComplete,
 } from 'woocommerce/state/sites/setup-choices/selectors';
 import {
 	areOrdersLoading,
@@ -217,14 +218,7 @@ function mapStateToProps( state ) {
 	const finishedInstallOfRequiredPlugins = getFinishedInstallOfRequiredPlugins( state );
 	const finishedPageSetup = getFinishedPageSetup( state );
 	const setStoreAddressDuringInitialSetup = getSetStoreAddressDuringInitialSetup( state );
-
-	// This prop toggles the display of the setup steps vs the normal dashboard.
-	const isSetupComplete =
-		siteId &&
-		finishedInstallOfRequiredPlugins &&
-		finishedPageSetup &&
-		setStoreAddressDuringInitialSetup &&
-		finishedInitialSetup;
+	const isSetupComplete = isStoreSetupComplete( state );
 
 	return {
 		finishedInitialSetup,

--- a/client/extensions/woocommerce/state/data-layer/products/index.js
+++ b/client/extensions/woocommerce/state/data-layer/products/index.js
@@ -16,6 +16,7 @@ import { get, post, put } from 'woocommerce/state/data-layer/request/actions';
 import { setError } from 'woocommerce/state/sites/status/wc-api/actions';
 import {
 	fetchProducts,
+	fetchProductsFailure,
 	productUpdated,
 	productsUpdated,
 } from 'woocommerce/state/sites/products/actions';
@@ -38,8 +39,9 @@ export default {
 	],
 };
 
-function apiError( { dispatch }, action, error ) {
+export function apiError( { dispatch }, action, error ) {
 	warn( 'Products API Error: ', error );
+	dispatch( fetchProductsFailure( action.siteId, action.params ) );
 
 	if ( action.failureAction ) {
 		dispatch( action.failureAction );

--- a/client/extensions/woocommerce/state/data-layer/products/test/index.js
+++ b/client/extensions/woocommerce/state/data-layer/products/test/index.js
@@ -17,6 +17,7 @@ import {
 	productsUpdated,
 } from 'woocommerce/state/sites/products/actions';
 import {
+	apiError,
 	handleProductCreate,
 	handleProductUpdate,
 	handleProductRequest,
@@ -386,6 +387,31 @@ describe( 'handlers', () => {
 				match( {
 					type: WOOCOMMERCE_PRODUCTS_REQUEST_FAILURE,
 					siteId: 123,
+				} )
+			);
+		} );
+
+		test( 'apiError should dispatch a failure action on a failed fetchProducts', () => {
+			const dispatch = spy();
+
+			const response = {
+				code: 'rest_no_route',
+				data: { status: 404 },
+				message: 'No route was found matching the URL and request method',
+			};
+			const action = fetchProducts( 123, {} );
+			const data = {
+				status: 404,
+				body: response,
+				headers: [],
+			};
+
+			apiError( { dispatch }, action, { data } );
+			expect( dispatch ).to.have.been.calledWithMatch(
+				match( {
+					type: WOOCOMMERCE_PRODUCTS_REQUEST_FAILURE,
+					siteId: 123,
+					params: {},
 				} )
 			);
 		} );

--- a/client/extensions/woocommerce/state/sites/products/actions.js
+++ b/client/extensions/woocommerce/state/sites/products/actions.js
@@ -158,6 +158,14 @@ export function fetchProducts( siteId, params, successAction, failureAction ) {
 	};
 }
 
+export function fetchProductsFailure( siteId, params ) {
+	return {
+		type: WOOCOMMERCE_PRODUCTS_REQUEST_FAILURE,
+		siteId,
+		params,
+	};
+}
+
 export function productsUpdated( siteId, params, products, totalPages, totalProducts ) {
 	// This passed through the API layer successfully, but failed at the remote site.
 	if ( ! isArray( products ) ) {

--- a/client/extensions/woocommerce/state/sites/setup-choices/selectors.js
+++ b/client/extensions/woocommerce/state/sites/setup-choices/selectors.js
@@ -151,3 +151,20 @@ export function getCheckedTaxSetup( state, siteId = getSelectedSiteId( state ) )
 export function getSetStoreAddressDuringInitialSetup( state, siteId = getSelectedSiteId( state ) ) {
 	return isChoiceTrue( state, siteId, 'set_store_address_during_initial_setup' );
 }
+
+/**
+ * Determine if all setup steps are complete
+ *
+ * @param {Object} state Global state tree
+ * @param {Number} siteId wpcom site id. If not provided, the Site ID selected in the UI will be used
+ * @return {boolean} Whether or not the site has completed all setup tasks
+ */
+export function isStoreSetupComplete( state, siteId = getSelectedSiteId( state ) ) {
+	return (
+		siteId &&
+		getFinishedInstallOfRequiredPlugins( state, siteId ) &&
+		getFinishedPageSetup( state, siteId ) &&
+		getSetStoreAddressDuringInitialSetup( state, siteId ) &&
+		getFinishedInitialSetup( state, siteId )
+	);
+}

--- a/client/extensions/woocommerce/state/sites/setup-choices/test/selectors.js
+++ b/client/extensions/woocommerce/state/sites/setup-choices/test/selectors.js
@@ -19,6 +19,7 @@ import {
 	getSetStoreAddressDuringInitialSetup,
 	getTriedCustomizerDuringInitialSetup,
 	isDefaultShippingZoneCreated,
+	isStoreSetupComplete,
 	getCheckedTaxSetup,
 } from '../selectors';
 import { LOADING } from 'woocommerce/state/constants';
@@ -241,6 +242,20 @@ describe( 'selectors', () => {
 
 		test( 'should get whether initial setup was completed from the state (124-false).', () => {
 			expect( getSetStoreAddressDuringInitialSetup( loadedState, 124 ) ).to.eql( false );
+		} );
+
+		test( 'should get the siteId from the UI tree if not provided.', () => {
+			expect( getSetStoreAddressDuringInitialSetup( loadedStateWithUi ) ).to.eql( true );
+		} );
+	} );
+
+	describe( '#isStoreSetupComplete', () => {
+		test( 'should get whether store setup was completed from the state (123-true).', () => {
+			expect( isStoreSetupComplete( loadedState, 123 ) ).to.eql( true );
+		} );
+
+		test( 'should get whether store setup was completed from the state (124-false).', () => {
+			expect( isStoreSetupComplete( loadedState, 124 ) ).to.eql( false );
 		} );
 
 		test( 'should get the siteId from the UI tree if not provided.', () => {


### PR DESCRIPTION
Fixes #19481

This branch seeks to clear up some of the issues encountered during the testing of the new store signup flow. The first step I took was to create two different sub-render methods... one for a store that is still going through setup, and one for the normal dashboard.

Setup is determined by the following selectors: `getFinishedInitialSetup`, `getFinishedInstallOfRequiredPlugins`, `getSetStoreAddressDuringInitialSetup`, and `getFinishedPageSetup`. If any of these are falsey, the setup dashboard is rendered.

Additionally during testing I discovered that `areProductsLoaded` were stuck in a perpetually loading state. This seemed to be another remnant of the switch of products to using the data layer in #19410. The fix for this here was to properly pass in a `failureAction` to the `fetchProducts` call... since I'm still green when it comes to the data layer I'm going to /cc @ryelle  on this part of the PR specifically.

__To Test__
Since this PR touches the dashboard, really all of the random states the dashboard handles should ideally be tested. I have tested close to 20 new sites today and am feeling pretty confident in the PR... and I have also tested many of these sites in various stages of the setup wizard, and sites that are already live/configured.

Specifically though, we could really use more 👀  on the entire NUX flow:

**Before you begin testing, ensure you have the following A/B tests configured properly:**
![store_ _site_title_ _wordpress_com](https://user-images.githubusercontent.com/22080/32525576-ed9e09de-c3d9-11e7-9209-7b9948a5ac7c.png)
_signupAtomicStoreVsPressable_ set to `atomic`

![store_ _site_title_ _wordpress_com](https://user-images.githubusercontent.com/22080/32525597-0b69d362-c3da-11e7-9eee-b447ddcf8977.png)
_gsuiteUpsell_ to `hide` **This is super important** in my testing the flow completely fails when the gsuite upsell is shown ( over 50% failure rate ) - I will create a PR to disable the gsuiteUpsell if the Atomic test is true.

Also give yourself some credits... this will get expensive.

__To Actually Test__
Now that you have done the A/B test configurations above you can now:

- Visit http://calypso.localhost:3000/start/design-type-with-store-nux
- Use a low-value .blog domain during the process
- Ultimately verify that you end up on the Store Dashboard and see a loading indicator which displays the progress of the site/store being setup
- When the Store Address field is shown, that is a _great success_
- From there play with the various states of the dashboard setup wizard and make sure nothing has regressed there.