### PR TITLE
Update the dns editor to use the add and delete dns endpoints

### DIFF
--- a/client/lib/upgrades/actions/domain-management.js
+++ b/client/lib/upgrades/actions/domain-management.js
@@ -250,9 +250,7 @@ function addDns( domainName, record, onComplete ) {
 		record,
 	} );
 
-	const dns = DnsStore.getByDomainName( domainName );
-
-	wpcom.updateDns( domainName, dns.records, error => {
+	wpcom.addDns( domainName, record, error => {
 		const type = ! error ? ActionTypes.DNS_ADD_COMPLETED : ActionTypes.DNS_ADD_FAILED;
 		Dispatcher.handleServerAction( {
 			type,
@@ -275,9 +273,7 @@ function deleteDns( domainName, record, onComplete ) {
 		record,
 	} );
 
-	const dns = DnsStore.getByDomainName( domainName );
-
-	wpcom.updateDns( domainName, dns.records, error => {
+	wpcom.deleteDns( domainName, record, error => {
 		const type = ! error ? ActionTypes.DNS_DELETE_COMPLETED : ActionTypes.DNS_DELETE_FAILED;
 
 		Dispatcher.handleServerAction( {

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1,10 +1,7 @@
 /**
  * External dependencies
- *
- * @format
  */
-
-import { camelCase, clone, isPlainObject, omit, pick, reject, snakeCase } from 'lodash';
+import { camelCase, clone, isPlainObject, omit, pick, snakeCase } from 'lodash';
 import debugFactory from 'debug';
 const debug = debugFactory( 'calypso:wpcom-undocumented:undocumented' );
 import url from 'url';
@@ -2040,11 +2037,12 @@ Undocumented.prototype.fetchDns = function( domainName, fn ) {
 	return this.wpcom.req.get( '/domains/' + domainName + '/dns', fn );
 };
 
-Undocumented.prototype.updateDns = function( domain, records, fn ) {
-	var filtered = reject( records, 'isBeingDeleted' ),
-		body = { dns: JSON.stringify( filtered ) };
+Undocumented.prototype.addDns = function( domainName, record, fn ) {
+	return this.wpcom.req.post( '/domains/' + domainName + '/dns/add', record, fn );
+};
 
-	return this.wpcom.req.post( '/domains/' + domain + '/dns', body, fn );
+Undocumented.prototype.deleteDns = function( domainName, record, fn ) {
+	return this.wpcom.req.post( '/domains/' + domainName + '/dns/delete', record, fn );
 };
 
 Undocumented.prototype.applyDnsTemplate = function(


### PR DESCRIPTION
Fix docblock format for code linting.
Remove the updateDns function in favor of the add / delete functions

TESTING:
Verify that adding and removing dns entries work.