### PR TITLE
Domains: Update Domain Management screen in calypso to show resend email notice.

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -448,6 +448,7 @@
 @import 'notices/style';
 @import 'my-sites/domains/domain-management/style';
 @import 'my-sites/domains/domain-management/email/style';
+@import 'my-sites/domains/domain-management/components/email-verification/style';
 @import 'my-sites/domains/domain-management/components/icann-verification/style';
 @import 'notifications/style';
 @import 'post-editor/media-modal/style';

--- a/client/lib/domains/index.js
+++ b/client/lib/domains/index.js
@@ -82,6 +82,22 @@ function restartInboundTransfer( siteId, domainName, onComplete ) {
 	} );
 }
 
+function resendInboundTransferEmail( domainName, onComplete ) {
+	if ( ! domainName ) {
+		onComplete( null );
+		return;
+	}
+
+	wpcom.undocumented().resendInboundTransferEmail( domainName, function( serverError, result ) {
+		if ( serverError ) {
+			onComplete( serverError );
+			return;
+		}
+
+		onComplete( null, result );
+	} );
+}
+
 function canRedirect( siteId, domainName, onComplete ) {
 	if ( ! domainName ) {
 		onComplete( new ValidationError( 'empty_query' ) );
@@ -249,4 +265,5 @@ export {
 	isRegisteredDomain,
 	isSubdomain,
 	restartInboundTransfer,
+	resendInboundTransferEmail,
 };

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -584,6 +584,22 @@ Undocumented.prototype.restartInboundTransfer = function( siteId, domain, fn ) {
 };
 
 /**
+ * Initiates a resend of the inbound transfer verification email.
+ * @param {string} domain - The domain name to check.
+ * @param {Function} fn The callback function
+ * @returns {Promise} A promise that resolves when the request completes
+ * @api public
+ */
+Undocumented.prototype.resendInboundTransferEmail = function( domain, fn ) {
+	return this.wpcom.req.get(
+		{
+			path: `/domains/${ encodeURIComponent( domain ) }/resend-inbound-transfer-email`,
+		},
+		fn
+	);
+};
+
+/**
  * Determine whether a domain name can be used for Site Redirect
  *
  * @param {int|string} siteId The site ID

--- a/client/my-sites/domains/domain-management/components/email-verification/index.jsx
+++ b/client/my-sites/domains/domain-management/components/email-verification/index.jsx
@@ -1,0 +1,186 @@
+/**
+ * External dependencies
+ *
+ * @format
+ */
+
+import PropTypes from 'prop-types';
+import React from 'react';
+import Gridicon from 'gridicons';
+import { localize } from 'i18n-calypso';
+import { connect } from 'react-redux';
+import classNames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import Button from 'components/button';
+import Card from 'components/card';
+import { errorNotice } from 'state/notices/actions';
+import { getRegistrantWhois } from 'state/selectors';
+import QueryWhois from 'components/data/query-whois';
+
+class EmailVerificationCard extends React.Component {
+	static propTypes = {
+		changeEmailHref: PropTypes.string,
+		contactDetails: PropTypes.object,
+		getExplanation: PropTypes.func,
+		resendVerification: PropTypes.func.isRequired,
+		selectedDomainName: PropTypes.string.isRequired,
+		selectedSiteSlug: PropTypes.string.isRequired,
+	};
+
+	state = {
+		submitting: false,
+		emailSent: false,
+	};
+
+	componentWillUnmount() {
+		if ( this.timer ) {
+			clearTimeout( this.timer );
+			this.timer = null;
+		}
+	}
+
+	revertToWaitingState = () => {
+		this.timer = null;
+		this.setState( { emailSent: false } );
+	};
+
+	handleSubmit = event => {
+		const { resendVerification, selectedDomainName } = this.props;
+
+		event.preventDefault();
+
+		this.setState( { submitting: true } );
+
+		resendVerification( selectedDomainName, error => {
+			if ( error ) {
+				this.props.errorNotice( error.message );
+			} else {
+				this.timer = setTimeout( this.revertToWaitingState, 5000 );
+				this.setState( { emailSent: true } );
+			}
+
+			this.setState( { submitting: false } );
+		} );
+
+		// upgradesActions.resendIcannVerification( this.props.selectedDomainName, error => {
+		// 	if ( error ) {
+		// 		this.props.errorNotice( error.message );
+		// 	} else {
+		// 		this.timer = setTimeout( this.revertToWaitingState, 5000 );
+		// 		this.setState( { emailSent: true } );
+		// 	}
+		//
+		// 	this.setState( { submitting: false } );
+		// } );
+	};
+
+	// getExplanation() {
+	// 	const {
+	// 		translate,
+	// 		explanationContext
+	// 	} = this.props;
+	// 	if ( explanationContext === 'name-servers' ) {
+	// 		return translate(
+	// 			'You have to verify the email address used to register this domain before you ' +
+	// 				'are able to update the name servers for your domain. ' +
+	// 				'Look for the verification message in your email inbox.'
+	// 		);
+	// 	}
+	//
+	// 	return translate(
+	// 		'We need to check your contact information to make sure you can be reached. Please verify your ' +
+	// 			'details using the email we sent you, or your domain will stop working. ' +
+	// 			'{{learnMoreLink}}Learn more.{{/learnMoreLink}}',
+	// 		{
+	// 			components: {
+	// 				learnMoreLink: (
+	// 					<a
+	// 						href={ support.EMAIL_VALIDATION_AND_VERIFICATION }
+	// 						target="_blank"
+	// 						rel="noopener noreferrer"
+	// 					/>
+	// 				),
+	// 			},
+	// 		}
+	// 	);
+	// }
+
+	renderStatus() {
+		const { changeEmailHref, translate } = this.props;
+		// const changeEmailHref = domainManagementEditContactInfo( selectedSiteSlug, selectedDomainName );
+
+		const { emailSent, submitting } = this.state;
+		const statusClassNames = classNames( 'email-verification__status-container', {
+			waiting: ! emailSent,
+			sent: emailSent,
+		} );
+		let statusIcon = 'notice-outline';
+		let statusText = translate( 'Check your email — instructions sent to %(email)s.', {
+			args: { email: this.props.contactDetails.email },
+		} );
+		if ( emailSent ) {
+			statusIcon = 'mail';
+			statusText = translate( 'Sent to %(email)s. Check your email to verify.', {
+				args: { email: this.props.contactDetails.email },
+			} );
+		}
+
+		return (
+			<div className={ statusClassNames }>
+				<div className="email-verification__status">
+					<Gridicon icon={ statusIcon } size={ 36 } />
+					{ statusText }
+
+					{ ! emailSent && (
+						<div>
+							<Button
+								compact
+								busy={ submitting }
+								disabled={ submitting }
+								onClick={ this.handleSubmit }
+							>
+								{ submitting ? translate( 'Sending…' ) : translate( 'Send Again' ) }
+							</Button>
+
+							{ changeEmailHref && (
+								<Button compact href={ changeEmailHref } onClick={ this.props.onClick }>
+									{ this.props.translate( 'Change Email Address' ) }
+								</Button>
+							) }
+						</div>
+					) }
+				</div>
+			</div>
+		);
+	}
+
+	render() {
+		const { getExplanation, selectedDomainName } = this.props;
+
+		if ( ! this.props.contactDetails ) {
+			return <QueryWhois domain={ selectedDomainName } />;
+		}
+
+		return (
+			<Card compact highlight="warning" className="email-verification">
+				<QueryWhois domain={ selectedDomainName } />
+				<div className="email-verification__explanation">
+					<h1 className="email-verification__heading">Important: Verify Your Email Address</h1>
+					{ getExplanation() }
+				</div>
+
+				{ this.renderStatus() }
+			</Card>
+		);
+	}
+}
+
+export default connect(
+	( state, ownProps ) => ( {
+		contactDetails: getRegistrantWhois( state, ownProps.selectedDomainName ),
+	} ),
+	{ errorNotice }
+)( localize( EmailVerificationCard ) );

--- a/client/my-sites/domains/domain-management/components/email-verification/index.jsx
+++ b/client/my-sites/domains/domain-management/components/email-verification/index.jsx
@@ -15,14 +15,11 @@ import classNames from 'classnames';
  */
 import Button from 'components/button';
 import Card from 'components/card';
-import { errorNotice } from 'state/notices/actions';
-import { getRegistrantWhois } from 'state/selectors';
-import QueryWhois from 'components/data/query-whois';
 
 class EmailVerificationCard extends React.Component {
 	static propTypes = {
 		changeEmailHref: PropTypes.string,
-		contactDetails: PropTypes.object,
+		contactEmail: PropTypes.string.isRequired,
 		verificationExplanation: PropTypes.array.isRequired,
 		resendVerification: PropTypes.func.isRequired,
 		selectedDomainName: PropTypes.string.isRequired,
@@ -66,7 +63,7 @@ class EmailVerificationCard extends React.Component {
 	};
 
 	renderStatus() {
-		const { changeEmailHref, translate } = this.props;
+		const { changeEmailHref, contactEmail, translate } = this.props;
 		const { emailSent, submitting } = this.state;
 		const statusClassNames = classNames( 'email-verification__status-container', {
 			waiting: ! emailSent,
@@ -74,13 +71,13 @@ class EmailVerificationCard extends React.Component {
 		} );
 		let statusIcon = 'notice-outline';
 		let statusText = translate( 'Check your email — instructions sent to %(email)s.', {
-			args: { email: this.props.contactDetails.email },
+			args: { email: contactEmail },
 		} );
 
 		if ( emailSent ) {
 			statusIcon = 'mail';
 			statusText = translate( 'Sent to %(email)s. Check your email to verify.', {
-				args: { email: this.props.contactDetails.email },
+				args: { email: contactEmail },
 			} );
 		}
 
@@ -114,29 +111,16 @@ class EmailVerificationCard extends React.Component {
 	}
 
 	render() {
-		const { verificationExplanation, selectedDomainName } = this.props;
-
-		if ( ! this.props.contactDetails ) {
-			return <QueryWhois domain={ selectedDomainName } />;
-		}
-
 		return (
 			<Card highlight="warning" className="email-verification">
-				<QueryWhois domain={ selectedDomainName } />
 				<div className="email-verification__explanation">
 					<h1 className="email-verification__heading">Important: Verify Your Email Address</h1>
-					{ verificationExplanation }
+					{ this.props.verificationExplanation }
 				</div>
-
 				{ this.renderStatus() }
 			</Card>
 		);
 	}
 }
 
-export default connect(
-	( state, ownProps ) => ( {
-		contactDetails: getRegistrantWhois( state, ownProps.selectedDomainName ),
-	} ),
-	{ errorNotice }
-)( localize( EmailVerificationCard ) );
+export default localize( EmailVerificationCard );

--- a/client/my-sites/domains/domain-management/components/email-verification/index.jsx
+++ b/client/my-sites/domains/domain-management/components/email-verification/index.jsx
@@ -3,7 +3,6 @@
  *
  * @format
  */
-
 import PropTypes from 'prop-types';
 import React from 'react';
 import Gridicon from 'gridicons';
@@ -24,7 +23,7 @@ class EmailVerificationCard extends React.Component {
 	static propTypes = {
 		changeEmailHref: PropTypes.string,
 		contactDetails: PropTypes.object,
-		getExplanation: PropTypes.func,
+		verificationExplanation: PropTypes.array.isRequired,
 		resendVerification: PropTypes.func.isRequired,
 		selectedDomainName: PropTypes.string.isRequired,
 		selectedSiteSlug: PropTypes.string.isRequired,
@@ -64,54 +63,10 @@ class EmailVerificationCard extends React.Component {
 
 			this.setState( { submitting: false } );
 		} );
-
-		// upgradesActions.resendIcannVerification( this.props.selectedDomainName, error => {
-		// 	if ( error ) {
-		// 		this.props.errorNotice( error.message );
-		// 	} else {
-		// 		this.timer = setTimeout( this.revertToWaitingState, 5000 );
-		// 		this.setState( { emailSent: true } );
-		// 	}
-		//
-		// 	this.setState( { submitting: false } );
-		// } );
 	};
-
-	// getExplanation() {
-	// 	const {
-	// 		translate,
-	// 		explanationContext
-	// 	} = this.props;
-	// 	if ( explanationContext === 'name-servers' ) {
-	// 		return translate(
-	// 			'You have to verify the email address used to register this domain before you ' +
-	// 				'are able to update the name servers for your domain. ' +
-	// 				'Look for the verification message in your email inbox.'
-	// 		);
-	// 	}
-	//
-	// 	return translate(
-	// 		'We need to check your contact information to make sure you can be reached. Please verify your ' +
-	// 			'details using the email we sent you, or your domain will stop working. ' +
-	// 			'{{learnMoreLink}}Learn more.{{/learnMoreLink}}',
-	// 		{
-	// 			components: {
-	// 				learnMoreLink: (
-	// 					<a
-	// 						href={ support.EMAIL_VALIDATION_AND_VERIFICATION }
-	// 						target="_blank"
-	// 						rel="noopener noreferrer"
-	// 					/>
-	// 				),
-	// 			},
-	// 		}
-	// 	);
-	// }
 
 	renderStatus() {
 		const { changeEmailHref, translate } = this.props;
-		// const changeEmailHref = domainManagementEditContactInfo( selectedSiteSlug, selectedDomainName );
-
 		const { emailSent, submitting } = this.state;
 		const statusClassNames = classNames( 'email-verification__status-container', {
 			waiting: ! emailSent,
@@ -121,6 +76,7 @@ class EmailVerificationCard extends React.Component {
 		let statusText = translate( 'Check your email — instructions sent to %(email)s.', {
 			args: { email: this.props.contactDetails.email },
 		} );
+
 		if ( emailSent ) {
 			statusIcon = 'mail';
 			statusText = translate( 'Sent to %(email)s. Check your email to verify.', {
@@ -158,18 +114,18 @@ class EmailVerificationCard extends React.Component {
 	}
 
 	render() {
-		const { getExplanation, selectedDomainName } = this.props;
+		const { verificationExplanation, selectedDomainName } = this.props;
 
 		if ( ! this.props.contactDetails ) {
 			return <QueryWhois domain={ selectedDomainName } />;
 		}
 
 		return (
-			<Card compact highlight="warning" className="email-verification">
+			<Card highlight="warning" className="email-verification">
 				<QueryWhois domain={ selectedDomainName } />
 				<div className="email-verification__explanation">
 					<h1 className="email-verification__heading">Important: Verify Your Email Address</h1>
-					{ getExplanation() }
+					{ verificationExplanation }
 				</div>
 
 				{ this.renderStatus() }

--- a/client/my-sites/domains/domain-management/components/email-verification/index.jsx
+++ b/client/my-sites/domains/domain-management/components/email-verification/index.jsx
@@ -7,7 +7,6 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import Gridicon from 'gridicons';
 import { localize } from 'i18n-calypso';
-import { connect } from 'react-redux';
 import classNames from 'classnames';
 
 /**

--- a/client/my-sites/domains/domain-management/components/email-verification/index.jsx
+++ b/client/my-sites/domains/domain-management/components/email-verification/index.jsx
@@ -8,12 +8,14 @@ import React from 'react';
 import Gridicon from 'gridicons';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
  */
 import Button from 'components/button';
 import Card from 'components/card';
+import { errorNotice } from 'state/notices/actions';
 
 class EmailVerificationCard extends React.Component {
 	static propTypes = {
@@ -122,4 +124,4 @@ class EmailVerificationCard extends React.Component {
 	}
 }
 
-export default localize( EmailVerificationCard );
+export default connect( null, { errorNotice } )( localize( EmailVerificationCard ) );

--- a/client/my-sites/domains/domain-management/components/email-verification/style.scss
+++ b/client/my-sites/domains/domain-management/components/email-verification/style.scss
@@ -1,6 +1,4 @@
 .email-verification {
-	margin-bottom: 15px;
-
 	.button {
 		margin-bottom: 15px;
 	}

--- a/client/my-sites/domains/domain-management/components/email-verification/style.scss
+++ b/client/my-sites/domains/domain-management/components/email-verification/style.scss
@@ -1,0 +1,112 @@
+.email-verification {
+	margin-bottom: 15px;
+
+	.button {
+		margin-bottom: 15px;
+	}
+}
+
+.email-verification__explanation {
+	margin-bottom: 15px;
+}
+
+.email-verification__status {
+	font-size: 16px;
+	font-weight: 600;
+	line-height: 21px;
+	padding-left: 50px;
+	position: relative;
+	word-wrap: break-word;
+
+	.gridicon {
+		display: block;
+		margin: auto;
+		position: absolute;
+		top: 0;
+		left: 0;
+		bottom: 0;
+	}
+}
+
+.email-verification__sent-to {
+	color: 	darken( $gray, 20% );
+	font-size: 14px;
+}
+
+.email-verification__heading {
+	font-size: 21px;
+	font-weight: bold;
+	line-height: 26px;
+	margin: 0 0 10px;
+}
+
+.email-verification__status-container {
+	border-top: 1px solid lighten( $gray, 20% );
+	margin: 25px -24px -16px -21px;
+	padding: 24px 24px 24px 21px;
+	position: relative;
+	overflow: hidden;
+	transition: all 0.3s ease-out;
+
+	.button {
+		margin: 5px 10px 0 0;
+
+		&:last-child {
+			margin-right: 0;
+		}
+		&.is-busy:disabled {
+			color: 	darken( $gray, 20% );
+		}
+	}
+
+	&.waiting .gridicon {
+		color: $alert-yellow;
+	}
+
+	&.sent .gridicon {
+		color: $alert-green;
+	}
+}
+
+.sent .email-verification__status {
+	position: relative;
+	animation: fadeIn 0.3s ease-out;
+}
+
+.waiting .email-verification__status {
+	position: relative;
+	animation: fadeOut 0.3s ease-out;
+}
+
+.domain-details-card {
+	.email-verification__card {
+		margin-bottom: 16px;
+	}
+}
+
+.notice__text {
+	word-break: break-word;
+}
+
+@keyframes fadeIn {
+	0% {
+		opacity: 0;
+		bottom: -50px;
+	}
+	100% {
+		opacity: 1;
+		bottom: 0;
+	}
+}
+
+
+@keyframes fadeOut {
+	0% {
+		opacity: 0;
+		top: -20px;
+	}
+	100% {
+		opacity: 1;
+		top: 0;
+	}
+}

--- a/client/my-sites/domains/domain-management/components/icann-verification/icann-verification-card.jsx
+++ b/client/my-sites/domains/domain-management/components/icann-verification/icann-verification-card.jsx
@@ -25,6 +25,7 @@ import QueryWhois from 'components/data/query-whois';
 
 class IcannVerificationCard extends React.Component {
 	static propTypes = {
+		hideAddressChangeButton: PropTypes.bool,
 		contactDetails: PropTypes.object,
 		explanationContext: PropTypes.string,
 		selectedDomainName: PropTypes.string.isRequired,
@@ -94,7 +95,7 @@ class IcannVerificationCard extends React.Component {
 	}
 
 	renderStatus() {
-		const { translate, selectedDomainName, selectedSiteSlug } = this.props;
+		const { hideAddressChangeButton, translate, selectedDomainName, selectedSiteSlug } = this.props;
 		const changeEmailHref = domainManagementEditContactInfo( selectedSiteSlug, selectedDomainName );
 
 		const { emailSent, submitting } = this.state;
@@ -130,9 +131,11 @@ class IcannVerificationCard extends React.Component {
 								{ submitting ? translate( 'Sending…' ) : translate( 'Send Again' ) }
 							</Button>
 
-							<Button compact href={ changeEmailHref } onClick={ this.props.onClick }>
-								{ this.props.translate( 'Change Email Address' ) }
-							</Button>
+							{ ! hideAddressChangeButton && (
+								<Button compact href={ changeEmailHref } onClick={ this.props.onClick }>
+									{ this.props.translate( 'Change Email Address' ) }
+								</Button>
+							) }
 						</div>
 					) }
 				</div>

--- a/client/my-sites/domains/domain-management/components/icann-verification/icann-verification-card.jsx
+++ b/client/my-sites/domains/domain-management/components/icann-verification/icann-verification-card.jsx
@@ -6,22 +6,19 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import Gridicon from 'gridicons';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
-import classNames from 'classnames';
 
 /**
  * Internal dependencies
  */
 import support from 'lib/url/support';
-import Button from 'components/button';
-import Card from 'components/card';
 import upgradesActions from 'lib/upgrades/actions';
 import { errorNotice } from 'state/notices/actions';
 import { domainManagementEditContactInfo } from 'my-sites/domains/paths';
 import { getRegistrantWhois } from 'state/selectors';
 import QueryWhois from 'components/data/query-whois';
+import EmailVerificationCard from 'my-sites/domains/domain-management/components/email-verification';
 
 class IcannVerificationCard extends React.Component {
 	static propTypes = {
@@ -29,40 +26,6 @@ class IcannVerificationCard extends React.Component {
 		explanationContext: PropTypes.string,
 		selectedDomainName: PropTypes.string.isRequired,
 		selectedSiteSlug: PropTypes.string.isRequired,
-	};
-
-	state = {
-		submitting: false,
-		emailSent: false,
-	};
-
-	componentWillUnmount() {
-		if ( this.timer ) {
-			clearTimeout( this.timer );
-			this.timer = null;
-		}
-	}
-
-	revertToWaitingState = () => {
-		this.timer = null;
-		this.setState( { emailSent: false } );
-	};
-
-	handleSubmit = event => {
-		event.preventDefault();
-
-		this.setState( { submitting: true } );
-
-		upgradesActions.resendIcannVerification( this.props.selectedDomainName, error => {
-			if ( error ) {
-				this.props.errorNotice( error.message );
-			} else {
-				this.timer = setTimeout( this.revertToWaitingState, 5000 );
-				this.setState( { emailSent: true } );
-			}
-
-			this.setState( { submitting: false } );
-		} );
 	};
 
 	getExplanation() {
@@ -93,70 +56,24 @@ class IcannVerificationCard extends React.Component {
 		);
 	}
 
-	renderStatus() {
-		const { translate, selectedDomainName, selectedSiteSlug } = this.props;
-		const changeEmailHref = domainManagementEditContactInfo( selectedSiteSlug, selectedDomainName );
-
-		const { emailSent, submitting } = this.state;
-		const statusClassNames = classNames( 'icann-verification__status-container', {
-			waiting: ! emailSent,
-			sent: emailSent,
-		} );
-		let statusIcon = 'notice-outline';
-		let statusText = translate( 'Check your email — instructions sent to %(email)s.', {
-			args: { email: this.props.contactDetails.email },
-		} );
-		if ( emailSent ) {
-			statusIcon = 'mail';
-			statusText = translate( 'Sent to %(email)s. Check your email to verify.', {
-				args: { email: this.props.contactDetails.email },
-			} );
-		}
-
-		return (
-			<div className={ statusClassNames }>
-				<div className="icann-verification__status">
-					<Gridicon icon={ statusIcon } size={ 36 } />
-					{ statusText }
-
-					{ ! emailSent && (
-						<div>
-							<Button
-								compact
-								busy={ submitting }
-								disabled={ submitting }
-								onClick={ this.handleSubmit }
-							>
-								{ submitting ? translate( 'Sending…' ) : translate( 'Send Again' ) }
-							</Button>
-
-							<Button compact href={ changeEmailHref } onClick={ this.props.onClick }>
-								{ this.props.translate( 'Change Email Address' ) }
-							</Button>
-						</div>
-					) }
-				</div>
-			</div>
-		);
-	}
-
 	render() {
-		const { selectedDomainName } = this.props;
+		const { contactDetails, selectedDomainName, selectedSiteSlug } = this.props;
+		const changeEmailHref = domainManagementEditContactInfo( selectedSiteSlug, selectedDomainName );
+		const verificationExplanation = this.getExplanation();
 
-		if ( ! this.props.contactDetails ) {
+		if ( ! contactDetails ) {
 			return <QueryWhois domain={ selectedDomainName } />;
 		}
 
 		return (
-			<Card compact highlight="warning" className="icann-verification__card">
-				<QueryWhois domain={ selectedDomainName } />
-				<div className="icann-verification__explanation">
-					<h1 className="icann-verification__heading">Important: Verify Your Email Address</h1>
-					{ this.getExplanation() }
-				</div>
-
-				{ this.renderStatus() }
-			</Card>
+			<EmailVerificationCard
+				changeEmailHref={ changeEmailHref }
+				contactEmail={ contactDetails.email }
+				verificationExplanation={ verificationExplanation }
+				resendVerification={ upgradesActions.resendIcannVerification }
+				selectedDomainName={ selectedDomainName }
+				selectedSiteSlug={ selectedSiteSlug }
+			/>
 		);
 	}
 }

--- a/client/my-sites/domains/domain-management/components/icann-verification/icann-verification-card.jsx
+++ b/client/my-sites/domains/domain-management/components/icann-verification/icann-verification-card.jsx
@@ -25,7 +25,6 @@ import QueryWhois from 'components/data/query-whois';
 
 class IcannVerificationCard extends React.Component {
 	static propTypes = {
-		hideAddressChangeButton: PropTypes.bool,
 		contactDetails: PropTypes.object,
 		explanationContext: PropTypes.string,
 		selectedDomainName: PropTypes.string.isRequired,
@@ -95,7 +94,7 @@ class IcannVerificationCard extends React.Component {
 	}
 
 	renderStatus() {
-		const { hideAddressChangeButton, translate, selectedDomainName, selectedSiteSlug } = this.props;
+		const { translate, selectedDomainName, selectedSiteSlug } = this.props;
 		const changeEmailHref = domainManagementEditContactInfo( selectedSiteSlug, selectedDomainName );
 
 		const { emailSent, submitting } = this.state;
@@ -131,11 +130,9 @@ class IcannVerificationCard extends React.Component {
 								{ submitting ? translate( 'Sending…' ) : translate( 'Send Again' ) }
 							</Button>
 
-							{ ! hideAddressChangeButton && (
-								<Button compact href={ changeEmailHref } onClick={ this.props.onClick }>
-									{ this.props.translate( 'Change Email Address' ) }
-								</Button>
-							) }
+							<Button compact href={ changeEmailHref } onClick={ this.props.onClick }>
+								{ this.props.translate( 'Change Email Address' ) }
+							</Button>
 						</div>
 					) }
 				</div>

--- a/client/my-sites/domains/domain-management/components/icann-verification/icann-verification-card.jsx
+++ b/client/my-sites/domains/domain-management/components/icann-verification/icann-verification-card.jsx
@@ -3,7 +3,6 @@
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React from 'react';
 import { localize } from 'i18n-calypso';

--- a/client/my-sites/domains/domain-management/components/inbound-transfer-verification/index.jsx
+++ b/client/my-sites/domains/domain-management/components/inbound-transfer-verification/index.jsx
@@ -1,0 +1,50 @@
+/**
+ * External dependencies
+ *
+ */
+import PropTypes from 'prop-types';
+import React from 'react';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import EmailVerificationCard from 'my-sites/domains/domain-management/components/email-verification';
+import { resendInboundTransferEmail } from 'lib/domains';
+
+class InboundTransferEmailVerificationCard extends React.Component {
+	static propTypes = {
+		selectedDomainName: PropTypes.string.isRequired,
+		selectedSiteSlug: PropTypes.string.isRequired,
+	};
+
+	render() {
+		return (
+			<div>
+				<EmailVerificationCard
+					verificationExplanation={ this.props.translate(
+						'We need to check your contact information to make sure you can be reached. Please verify your ' +
+							'details using the email we sent you to begin transferring the domain to WordPress.com. ' +
+							'{{learnMoreLink}}Learn more.{{/learnMoreLink}}',
+						{
+							components: {
+								learnMoreLink: (
+									<a
+										href="http://support.wordpress.com"
+										target="_blank"
+										rel="noopener noreferrer"
+									/>
+								),
+							},
+						}
+					) }
+					resendVerification={ resendInboundTransferEmail }
+					selectedDomainName={ this.props.selectedDomainName }
+					selectedSiteSlug={ this.props.selectedSiteSlug }
+				/>
+			</div>
+		);
+	}
+}
+
+export default localize( InboundTransferEmailVerificationCard );

--- a/client/my-sites/domains/domain-management/components/inbound-transfer-verification/index.jsx
+++ b/client/my-sites/domains/domain-management/components/inbound-transfer-verification/index.jsx
@@ -58,30 +58,28 @@ class InboundTransferEmailVerificationCard extends React.Component {
 		}
 
 		return (
-			<div>
-				<EmailVerificationCard
-					contactEmail={ contactEmail }
-					verificationExplanation={ translate(
-						'We need to check your contact information to make sure you can be reached. Please verify your ' +
-							'details using the email we sent you to begin transferring the domain to WordPress.com. ' +
-							'{{learnMoreLink}}Learn more.{{/learnMoreLink}}',
-						{
-							components: {
-								learnMoreLink: (
-									<a
-										href="http://support.wordpress.com"
-										target="_blank"
-										rel="noopener noreferrer"
-									/>
-								),
-							},
-						}
-					) }
-					resendVerification={ resendInboundTransferEmail }
-					selectedDomainName={ selectedDomainName }
-					selectedSiteSlug={ selectedSiteSlug }
-				/>
-			</div>
+			<EmailVerificationCard
+				contactEmail={ contactEmail }
+				verificationExplanation={ translate(
+					'We need to check your contact information to make sure you can be reached. Please verify your ' +
+						'details using the email we sent you to begin transferring the domain to WordPress.com. ' +
+						'{{learnMoreLink}}Learn more.{{/learnMoreLink}}',
+					{
+						components: {
+							learnMoreLink: (
+								<a
+									href="http://support.wordpress.com"
+									target="_blank"
+									rel="noopener noreferrer"
+								/>
+							),
+						},
+					}
+				) }
+				resendVerification={ resendInboundTransferEmail }
+				selectedDomainName={ selectedDomainName }
+				selectedSiteSlug={ selectedSiteSlug }
+			/>
 		);
 	}
 }

--- a/client/my-sites/domains/domain-management/edit/index.jsx
+++ b/client/my-sites/domains/domain-management/edit/index.jsx
@@ -13,6 +13,7 @@ import page from 'page';
 import DomainMainPlaceholder from 'my-sites/domains/domain-management/components/domain/main-placeholder';
 import { getSelectedDomain } from 'lib/domains';
 import Header from 'my-sites/domains/domain-management/components/header';
+import IcannVerificationCard from 'my-sites/domains/domain-management/components/icann-verification/icann-verification-card';
 import { localize } from 'i18n-calypso';
 import Main from 'components/main';
 import MaintenanceCard from 'my-sites/domains/domain-management/components/domain/maintenance-card';
@@ -22,6 +23,7 @@ import RegisteredDomain from './registered-domain';
 import { registrar as registrarNames } from 'lib/domains/constants';
 import SiteRedirect from './site-redirect';
 import Transfer from './transfer';
+import { transferStatus } from 'lib/domains/constants';
 import { type as domainTypes } from 'lib/domains/constants';
 import WpcomDomain from './wpcom-domain';
 
@@ -42,10 +44,31 @@ class Edit extends React.Component {
 				>
 					{ this.props.translate( 'Domain Settings' ) }
 				</Header>
+				{ this.renderEmailNotice() }
 				{ this.renderDetails( domain, Details ) }
 			</Main>
 		);
 	}
+
+	renderEmailNotice = () => {
+		const domain = this.props.domains && getSelectedDomain( this.props );
+		const isPendingVerification =
+			transferStatus.PENDING_OWNER === ( domain && domain.transferStatus );
+
+		if ( ! isPendingVerification ) {
+			return null;
+		}
+
+		return (
+			<div>
+				<IcannVerificationCard
+					hideAddressChangeButton={ true }
+					selectedDomainName={ this.props.selectedDomainName }
+					selectedSiteSlug={ this.props.selectedSite.slug }
+				/>
+			</div>
+		);
+	};
 
 	getDetailsForType = type => {
 		switch ( type ) {

--- a/client/my-sites/domains/domain-management/edit/index.jsx
+++ b/client/my-sites/domains/domain-management/edit/index.jsx
@@ -13,18 +13,20 @@ import page from 'page';
 import DomainMainPlaceholder from 'my-sites/domains/domain-management/components/domain/main-placeholder';
 import { getSelectedDomain } from 'lib/domains';
 import Header from 'my-sites/domains/domain-management/components/header';
-import EmailVerificationCard from 'my-sites/domains/domain-management/components/email-verification';
+import InboundTransferEmailVerificationCard from 'my-sites/domains/domain-management/components/inbound-transfer-verification';
 import { localize } from 'i18n-calypso';
 import Main from 'components/main';
 import MaintenanceCard from 'my-sites/domains/domain-management/components/domain/maintenance-card';
 import MappedDomain from './mapped-domain';
 import paths from 'my-sites/domains/paths';
 import RegisteredDomain from './registered-domain';
-import { registrar as registrarNames } from 'lib/domains/constants';
+import {
+	registrar as registrarNames,
+	transferStatus,
+	type as domainTypes,
+} from 'lib/domains/constants';
 import SiteRedirect from './site-redirect';
 import Transfer from './transfer';
-import { transferStatus } from 'lib/domains/constants';
-import { type as domainTypes } from 'lib/domains/constants';
 import WpcomDomain from './wpcom-domain';
 
 class Edit extends React.Component {
@@ -44,33 +46,26 @@ class Edit extends React.Component {
 				>
 					{ this.props.translate( 'Domain Settings' ) }
 				</Header>
-				{ this.renderEmailNotice() }
+				{ this.renderInboundTransferEmailNotice() }
 				{ this.renderDetails( domain, Details ) }
 			</Main>
 		);
 	}
 
-	resendVerificationEmail = () => {
-		return null;
-	};
-
-	renderEmailNotice = () => {
+	renderInboundTransferEmailNotice = () => {
 		const domain = this.props.domains && getSelectedDomain( this.props );
 		const isPendingVerification =
 			transferStatus.PENDING_OWNER === ( domain && domain.transferStatus );
 
 		if ( ! isPendingVerification ) {
-			// return null;
+			return null;
 		}
 
 		return (
-			<div>
-				<EmailVerificationCard
-					resendVerification={ this.resendVerificationEmail }
-					selectedDomainName={ this.props.selectedDomainName }
-					selectedSiteSlug={ this.props.selectedSite.slug }
-				/>
-			</div>
+			<InboundTransferEmailVerificationCard
+				selectedDomainName={ this.props.selectedDomainName }
+				selectedSiteSlug={ this.props.selectedSite.slug }
+			/>
 		);
 	};
 

--- a/client/my-sites/domains/domain-management/edit/index.jsx
+++ b/client/my-sites/domains/domain-management/edit/index.jsx
@@ -13,7 +13,7 @@ import page from 'page';
 import DomainMainPlaceholder from 'my-sites/domains/domain-management/components/domain/main-placeholder';
 import { getSelectedDomain } from 'lib/domains';
 import Header from 'my-sites/domains/domain-management/components/header';
-import IcannVerificationCard from 'my-sites/domains/domain-management/components/icann-verification/icann-verification-card';
+import EmailVerificationCard from 'my-sites/domains/domain-management/components/email-verification';
 import { localize } from 'i18n-calypso';
 import Main from 'components/main';
 import MaintenanceCard from 'my-sites/domains/domain-management/components/domain/maintenance-card';
@@ -50,19 +50,23 @@ class Edit extends React.Component {
 		);
 	}
 
+	resendVerificationEmail = () => {
+		return null;
+	};
+
 	renderEmailNotice = () => {
 		const domain = this.props.domains && getSelectedDomain( this.props );
 		const isPendingVerification =
 			transferStatus.PENDING_OWNER === ( domain && domain.transferStatus );
 
 		if ( ! isPendingVerification ) {
-			return null;
+			// return null;
 		}
 
 		return (
 			<div>
-				<IcannVerificationCard
-					hideAddressChangeButton={ true }
+				<EmailVerificationCard
+					resendVerification={ this.resendVerificationEmail }
 					selectedDomainName={ this.props.selectedDomainName }
 					selectedSiteSlug={ this.props.selectedSite.slug }
 				/>

--- a/client/my-sites/domains/domain-management/edit/index.jsx
+++ b/client/my-sites/domains/domain-management/edit/index.jsx
@@ -3,9 +3,9 @@
 /**
  * External dependencies
  */
-
 import React from 'react';
 import page from 'page';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -54,8 +54,7 @@ class Edit extends React.Component {
 
 	renderInboundTransferEmailNotice = () => {
 		const domain = this.props.domains && getSelectedDomain( this.props );
-		const isPendingVerification =
-			transferStatus.PENDING_OWNER === ( domain && domain.transferStatus );
+		const isPendingVerification = transferStatus.PENDING_OWNER === get( domain, 'transferStatus' );
 
 		if ( ! isPendingVerification ) {
 			return null;


### PR DESCRIPTION
This PR takes the "core" of the `IcannVerificationCard` component and abstracts it into a more generic `EmailVerificationCard` which can be used by both the `IcannVerificationCard` and the new `InboundTransferEmailVerificationCard` components.

The `EmailVerificationCard` component handles the basic layout and styling as well as managing the button states. 

The explanation text, the contact email address, the resend method, the domain name, domain slug, and the optional change email href are all passed in as props.

In order to test this, build and run this branch locally or use calypso.live. Try to transfer in a domain. Go back to the domain edit page (ex. http://calypso.localhost:3000/domains/manage/inaparalleluniverse.net/transfer/in/a8ctest.com) You should see a notice similar to the one below:

<img width="749" alt="domain_settings_ _a8c_test_site_ _wordpress_com" src="https://user-images.githubusercontent.com/1379730/32915279-56f4a06a-cae6-11e7-91de-62a9616d812f.png">

When you click on the button to resend the email, you should see the following and receive a new copy of the transfer in email.

<img width="759" alt="domain_settings_ _a8c_test_site_ _wordpress_com" src="https://user-images.githubusercontent.com/1379730/32915374-a23f9408-cae6-11e7-8913-84dfaedf0912.png">

You should also try changing contact email address of some other domain and make sure that the IcannVerification notice:

<img width="744" alt="domain_settings_ _a8c_test_site_ _wordpress_com" src="https://user-images.githubusercontent.com/1379730/32915489-0a716d76-cae7-11e7-83a0-a66181aeac72.png">

Note that this notice should include the option to change the email address. Make sure that it will also resend the notice.
