### PR TITLE
Build: Replace depreceted webpack query rule with use rule

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -100,10 +100,7 @@ const webpackConfig = {
 			},
 			{
 				include: require.resolve( 'tinymce/tinymce' ),
-				loader: 'exports-loader',
-				query: {
-					window: 'tinymce'
-				}
+				use: 'exports-loader?window=tinymce',
 			},
 			{
 				test: /node_modules[\/\\]tinymce/,


### PR DESCRIPTION
It fixes a deprecation warning when building:

> DeprecationWarning: loaderUtils.parseQuery() received a non-string value which can be problematic, see https://github.com/webpack/loader-utils/issues/56
parseQuery() will be replaced with getOptions() in the next major version of loader-utils.

This change adheres to the documentation:

https://webpack.js.org/guides/shimming/#global-exports

## Testing
* Ensure tests pass (e2e and ci)
* Ensure tinymce continues to work correctly (test the post editor)
* Ensure you do not see the mentioned deprecation warning

## Screens

The warning is a bit lost in the middle of Happypack output:

<img width="1659" alt="deprecation" src="https://user-images.githubusercontent.com/841763/32521089-7b92f456-c412-11e7-9fab-fbbc8f7daed6.png">
