### PR TITLE
Comments: enable comments post-view for wpcalypso and horizon

### DIFF
--- a/client/blocks/comment-button/README.md
+++ b/client/blocks/comment-button/README.md
@@ -18,7 +18,7 @@ render() {
 #### Props
 
 * `commentCount`: Number indicating the number of comments to be displayed next to the button.
-* `link`: String URL destination to be used with a `tagName` of `a`. Defaults to `null`.
+* `href`: String URL destination to be used with a `tagName` of `a`. Defaults to `null`.
 * `onClick`: Function to be executed when the user clicks the button.
 * `showLabel`: Boolean indicating whether or not the label with the comments count is visible. Defaults to `true`.
 * `size`: Number with the size of the comments icon to be displayed. Defaults to 24.

--- a/client/blocks/post-actions/index.jsx
+++ b/client/blocks/post-actions/index.jsx
@@ -76,7 +76,7 @@ const PostActions = ( {
 								showLabel={ false }
 								commentCount={ post.discussion.comment_count }
 								tagName="a"
-								link={ `/comments/all/${ siteSlug }/${ post.ID }` }
+								href={ `/comments/all/${ siteSlug }/${ post.ID }` }
 							/>
 						) : (
 							<CommentButton

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -25,6 +25,8 @@
 		"code-splitting": true,
 		"comments/management": true,
 		"comments/management/jetpack-5.5": false,
+		"comments/management/quick-actions": true,
+		"comments/management/post-view": true,
 		"comments/management/sorting": true,
 		"devdocs": false,
 		"domains/cctlds": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -21,6 +21,7 @@
 		"comments/management": true,
 		"comments/management/jetpack-5.5": false,
 		"comments/management/quick-actions": true,
+		"comments/management/post-view": true,
 		"comments/management/sorting": true,
 		"catch-js-errors": true,
 		"code-splitting": true,


### PR DESCRIPTION
This PR enables the post-specific view on wpcalypso and horizon so folks can more easily test this.

### Testing Instructions
- Navigate to /comments
- Select a site with comments
- Click on a post title
- We should be taken to a view of comments for just that post.