### PR TITLE
Fix: Rewind events were missing their backup point timestamps

### DIFF
--- a/client/state/activity-log/log/schema.js
+++ b/client/state/activity-log/log/schema.js
@@ -26,6 +26,7 @@ const activityItemSchema = {
 		activityStatus: {
 			oneOf: [ { type: 'string' }, { type: 'null' } ],
 		},
+		activityTargetTs: { type: 'number' },
 		activityTitle: { type: 'string' },
 		activityTs: { type: 'integer' },
 		actorAvatarUrl: { type: 'string' },

--- a/client/state/data-layer/wpcom/sites/activity/from-api.js
+++ b/client/state/data-layer/wpcom/sites/activity/from-api.js
@@ -56,6 +56,7 @@ export function processItem( item ) {
 		rewindId: item.rewind_id,
 		activityName: item.name,
 		activityStatus: item.status,
+		activityTargetTs: get( item, 'object.target_ts', undefined ),
 		activityTitle: get( item, 'summary', '' ),
 		activityTs: Date.parse( published ),
 	};

--- a/client/state/data-layer/wpcom/sites/activity/schema.json
+++ b/client/state/data-layer/wpcom/sites/activity/schema.json
@@ -79,6 +79,7 @@
 				},
 				"summary": { "type": "string" },
 				"target": { "type": "object" },
+				"target_ts": { "type": "number" },
 				"totalItems": {
 					"min": 0,
 					"type": "integer"},

--- a/client/state/data-layer/wpcom/sites/activity/test/from-api.js
+++ b/client/state/data-layer/wpcom/sites/activity/test/from-api.js
@@ -52,7 +52,7 @@ describe( 'processItem', () => {
 	test( 'should process an item', () => {
 		expect( processItem( VALID_API_ITEM ) )
 			.to.be.an( 'object' )
-			.that.has.keys( [
+			.that.contains.keys( [
 				'activityDate',
 				'activityGroup',
 				'activityIcon',


### PR DESCRIPTION
In order to calculate whether or not an event in the Activity Log has
been "discarded" by restore operations we have to know which rewind
operations have completed and which backup points they restored.

For some reason, surely my own neglect the `activityTargetTs` value
was missing from inside of Calypso despite coming over in the API
responses. Because it was missing, We thought that events restored
to backups with timestamps of `undefined` and the calculation for
`isDiscarded` was incorrect.

Now, by adding this in the calculations are fixed.

Before
![missingtargetts](https://user-images.githubusercontent.com/5431237/32522661-321e012a-c3e6-11e7-809c-631e373cabe0.gif)

After
(I accidentally clicked on "download" instead of "rewind" at first)
![withtargetts](https://user-images.githubusercontent.com/5431237/32522663-352b0066-c3e6-11e7-8f7c-e1136700f44f.gif)


**Testing**

Find a site with **Activity Log** enabled (Pressable site).

In **My Sites** > **Stats** > **Activity** make sure you have some rewind
operations already done (do them if not). After the rewind certain events
from before the rewind and after the backup should now appear as discarded.

In **master** all of the previous events will probably appear discarded, which
is incorrect. In this branch, only those events between the backup point and
the restore point should be discarded.