### PR TITLE
Editor: Avoid re-binding functions in post-editor mapDispatchToProps

### DIFF
--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -7,9 +7,8 @@ import createReactClass from 'create-react-class';
 import ReactDom from 'react-dom';
 import page from 'page';
 import PropTypes from 'prop-types';
-import { debounce, flow, get, throttle } from 'lodash';
+import { debounce, flow, get, partial, throttle } from 'lodash';
 import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
 import tinyMce from 'tinymce/tinymce';
@@ -1357,25 +1356,20 @@ const enhance = flow(
 				isConfirmationSidebarEnabled: isConfirmationSidebarEnabled( state, siteId ),
 			};
 		},
-		dispatch => {
-			return bindActionCreators(
-				{
-					setEditorLastDraft,
-					resetEditorLastDraft,
-					receivePost,
-					editPost,
-					savePostSuccess,
-					setEditorModePreference: savePreference.bind( null, 'editor-mode' ),
-					setEditorSidebar: savePreference.bind( null, 'editor-sidebar' ),
-					setLayoutFocus,
-					setNextLayoutFocus,
-					saveConfirmationSidebarPreference,
-					recordTracksEvent,
-					closeEditorSidebar,
-					openEditorSidebar,
-				},
-				dispatch
-			);
+		{
+			setEditorLastDraft,
+			resetEditorLastDraft,
+			receivePost,
+			editPost,
+			savePostSuccess,
+			setEditorModePreference: partial( savePreference, 'editor-mode' ),
+			setEditorSidebar: partial( savePreference, 'editor-sidebar' ),
+			setLayoutFocus,
+			setNextLayoutFocus,
+			saveConfirmationSidebarPreference,
+			recordTracksEvent,
+			closeEditorSidebar,
+			openEditorSidebar,
 		},
 		null,
 		{ pure: false }


### PR DESCRIPTION
### Summary
This PR relates to #19294 and aims to simplify the `mapDispatchToProps` argument of `connect()` in `post-editor.js`.
Doing this allows us to avoid repeatedly rebinding `savePreference` on component updates and thus avoids the issue explained in #19320 of creating functions needlessly.

### Testing
- Select a post to edit.
- toggle the editor sidebar using the 'Post Settings' button (on the right of the editor header).
- Note that the sidebar will toggle open & closed.
- toggle the sidebar using the history button (on the left of the editor header).
- Note that the nested sidebar will toggle open & closed, leaving the regular sidebar open as the nested sidebar closes.