### PR TITLE
Store Promotions: Add tracks for events.

### DIFF
--- a/client/extensions/woocommerce/app/promotions/promotion-header.js
+++ b/client/extensions/woocommerce/app/promotions/promotion-header.js
@@ -5,7 +5,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'gridicons';
-import { isObject } from 'lodash';
+import { isObject, noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -37,7 +37,7 @@ function renderSaveButton( onSave, promotion, isBusy, translate ) {
 	);
 
 	return (
-		<Button primary onClick={ onSave } disabled={ saveDisabled } busy={ isBusy }>
+		<Button primary onClick={ onSave || noop } disabled={ saveDisabled } busy={ isBusy }>
 			{ saveLabel }
 		</Button>
 	);

--- a/client/extensions/woocommerce/lib/analytics/README.md
+++ b/client/extensions/woocommerce/lib/analytics/README.md
@@ -1,0 +1,27 @@
+Store Analytics
+===============
+
+This library is for adding analytics code to Store on WP.com
+
+It's designed to consolidate things like verifying we're using the same prefix on
+all track event ids, and perhaps to add some common event properties automatically.
+
+### How to use:
+
+```js
+import { recordTrack } from 'woocommerce/lib/analytics';
+
+recordTrack( 'calypso_woocommerce_event_to_be_tracked', { a_parameter: '1', another_parameter: '2' } );
+```
+
+### Functions
+
+#### `recordTrack( eventName, eventProperties )`
+
+Arguments:
+* `eventName`: The name of the event, must be prefixed with `calypso_woocommerce_`.
+* `eventProperties`: The properties of the event to be tracked.
+
+Records a track event with the specified event name and properties.
+Enforces a `calypso_woocommerce_` prefix.
+

--- a/client/extensions/woocommerce/lib/analytics/index.js
+++ b/client/extensions/woocommerce/lib/analytics/index.js
@@ -1,0 +1,16 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import debugFactory from 'debug';
+
+/**
+ * Internal dependencies
+ */
+import analytics from 'lib/analytics';
+import * as tracksUtils from './tracks-utils';
+
+const debug = debugFactory( 'woocommerce:analytics' );
+
+export const recordTrack = tracksUtils.recordTrack( analytics.tracks, debug );

--- a/client/extensions/woocommerce/lib/analytics/test/tracks-utils.js
+++ b/client/extensions/woocommerce/lib/analytics/test/tracks-utils.js
@@ -1,0 +1,76 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+import { spy } from 'sinon';
+import { noop } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { recordTrack } from '../tracks-utils';
+
+describe( 'recordTrack', () => {
+	it( 'should be a function', () => {
+		expect( recordTrack ).to.be.a( 'function' );
+	} );
+
+	it( 'should curry the tracks object', () => {
+		const tracksSpy = {
+			recordEvent: spy(),
+		};
+
+		expect( recordTrack( tracksSpy, noop ) ).to.be.a( 'function' );
+	} );
+
+	it( 'should call tracks to record an event with properties', () => {
+		const tracksSpy = {
+			recordEvent: spy(),
+		};
+
+		const eventProps = {
+			a: 1,
+			b: 2.2,
+			c: '3',
+		};
+
+		recordTrack( tracksSpy, noop )( 'calypso_woocommerce_tracks_utils_test', eventProps );
+
+		expect( tracksSpy.recordEvent ).to.have.been.calledWith(
+			'calypso_woocommerce_tracks_utils_test',
+			eventProps
+		);
+	} );
+
+	it( 'should log tracks via debug', () => {
+		const debugSpy = spy();
+
+		const eventProps = { a: 1 };
+
+		recordTrack( { recordEvent: noop }, debugSpy )(
+			'calypso_woocommerce_tracks_utils_test',
+			eventProps
+		);
+
+		expect( debugSpy ).to.have.been.calledWith(
+			"track 'calypso_woocommerce_tracks_utils_test': ",
+			eventProps
+		);
+	} );
+
+	it( 'should ignore and debug log tracks with an improper event name', () => {
+		const tracksSpy = {
+			recordEvent: spy(),
+		};
+		const debugSpy = spy();
+
+		recordTrack( tracksSpy, debugSpy )( 'calypso_somethingelse_invalid_name', { a: 1 } );
+
+		expect( tracksSpy.recordEvent ).to.not.have.been.called;
+		expect( debugSpy ).to.have.been.calledWith(
+			"invalid store track name: 'calypso_somethingelse_invalid_name', must start with 'calypso_woocommerce_'"
+		);
+	} );
+} );

--- a/client/extensions/woocommerce/lib/analytics/tracks-utils.js
+++ b/client/extensions/woocommerce/lib/analytics/tracks-utils.js
@@ -1,0 +1,17 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { startsWith } from 'lodash';
+
+export const recordTrack = ( tracks, debug ) => ( eventName, eventProperties ) => {
+	if ( ! startsWith( eventName, 'calypso_woocommerce_' ) ) {
+		debug( `invalid store track name: '${ eventName }', must start with 'calypso_woocommerce_'` );
+		return;
+	}
+
+	debug( `track '${ eventName }': `, eventProperties );
+
+	tracks.recordEvent( eventName, eventProperties );
+};


### PR DESCRIPTION
This add tracks for the following events:
* When a user starts editing a new promotion
* When a user creates a new promotion
* When a user starts editing an existing promotion
* When a user updates a promotion
* When a user deletes a promotion

To Test:
1. `npm test`
2. `npm start`
3. Visit `http://calypso.localhost:3000/store/promotions/<site url>`
4. Open dev console and type in `localStorage.setItem('debug', 'woocommerce:analytics');`
5. Try editing a new promotion, you should see a debug line.
6. Save the new promotion, you should see a debug line.
7. Edit an existing promotion, you should see a debug line.
8. Save an existing promotion, you should see a debug line.
9. Delete a promotion, you should see a debug line.
