### PR TITLE
Checkout: Disable gSuite Upsell on Atomic Store Flow.

### DIFF
--- a/client/my-sites/checkout/checkout/checkout.jsx
+++ b/client/my-sites/checkout/checkout/checkout.jsx
@@ -5,7 +5,17 @@
  */
 
 import { connect } from 'react-redux';
-import { flatten, filter, find, findIndex, get, isEmpty, isEqual, reduce, startsWith } from 'lodash';
+import {
+	flatten,
+	filter,
+	find,
+	findIndex,
+	get,
+	isEmpty,
+	isEqual,
+	reduce,
+	startsWith,
+} from 'lodash';
 import i18n, { localize } from 'i18n-calypso';
 import page from 'page';
 import PropTypes from 'prop-types';
@@ -292,7 +302,10 @@ const Checkout = createReactClass( {
 			return '/checkout/thank-you/features';
 		}
 
-		if ( abtest( 'gsuiteUpsell' ) === 'show' ) {
+		if (
+			abtest( 'gsuiteUpsell' ) === 'show' &&
+			abtest( 'signupAtomicStoreVsPressable' ) !== 'atomic'
+		) {
 			const domainReceiptId = get(
 				cartItems.getGoogleApps( cart ),
 				'0.extra.receipt_for_domain',


### PR DESCRIPTION
While testing the new Atomic Store flow, I had an extremely high ( over 50% ) failure rate of the flow. The failure would always occur when I was shown the gSuite upsell screen, and subsequently would decline:

![timmyc-devsite-016_gif](https://user-images.githubusercontent.com/22080/32526058-5036af22-c3dc-11e7-8132-9add4ba73da2.png)

Very briefly, an empty cart screen would be shown:

![timmyc-devsite-016_gif](https://user-images.githubusercontent.com/22080/32526081-61c4010e-c3dc-11e7-975b-7d4c97fdfc41.png)

And then almost immediately I would be redirected to the `/plans` page, and asked to select a site:

![timmyc-devsite-016_gif](https://user-images.githubusercontent.com/22080/32526109-7e6aecfa-c3dc-11e7-9794-6281551f3968.png)

Full .gif of the flow can [be seen here](https://cloudup.com/cC7y6TCSf9g).

This, of course, would entirely break me out of the Store signup flow that @jsnajdr and team have been working on. In this state I could navigate to the `/store` page, and pickup the nux flow from there, but this experience would be less than ideal for users who just signed up for a business plan.

Oddly enough, sometimes it would seem my checkout didn't complete, and a plan was never added to the site... other times the plan was added fine, and the AT process completed as expected.

Either way, once I added the code in this PR - effectively disabling the gSuite upsell for users in the `atomic` test of `signupAtomicStoreVsPressable` - I never encountered another issue. @taggon  it looks like you implemented the gSuite upsell so adding you in as a reviewer here.