### PR TITLE
Domains: Checkout form: Changing event name to conform to analytics naming requirements.

### DIFF
--- a/client/my-sites/checkout/checkout/domain-details-form.jsx
+++ b/client/my-sites/checkout/checkout/domain-details-form.jsx
@@ -512,18 +512,12 @@ export class DomainDetailsForm extends PureComponent {
 			{
 				errors_count: ( errors && errors.length ) || 0,
 				submission_count: this.state.submissionCount + 1,
+				country_code_from_form: contactDetails.countryCode,
 			}
 		);
 
 		analytics.tracks.recordEvent( 'calypso_contact_information_form_submit', tracksEventObject );
 		this.setState( { submissionCount: this.state.submissionCount + 1 } );
-
-		analytics.tracks.recordEvent( 'calypso_contact_information_details_form_submit', {
-			city: contactDetails.city,
-			country_code: contactDetails.countryCode,
-			state: contactDetails.state,
-			postal_code: contactDetails.postalCode,
-		} );
 	}
 
 	finish() {

--- a/client/my-sites/checkout/checkout/domain-details-form.jsx
+++ b/client/my-sites/checkout/checkout/domain-details-form.jsx
@@ -518,10 +518,12 @@ export class DomainDetailsForm extends PureComponent {
 		analytics.tracks.recordEvent( 'calypso_contact_information_form_submit', tracksEventObject );
 		this.setState( { submissionCount: this.state.submissionCount + 1 } );
 
-		analytics.tracks.recordEvent(
-			'calypso_contact_information_form_submit_details',
-			pick( contactDetails, [ 'city', 'countryCode', 'state', 'postalCode' ] )
-		);
+		analytics.tracks.recordEvent( 'calypso_contact_information_details_form_submit', {
+			city: contactDetails.city,
+			country_code: contactDetails.countryCode,
+			state: contactDetails.state,
+			postal_code: contactDetails.postalCode,
+		} );
 	}
 
 	finish() {


### PR DESCRIPTION
## Why?
The event property names do not conform to the tracking requirements and are therefore not being recorded. :(

## Why are there two events running in this block?
The second event recording the location details is temporary and destined to be used in conjunction with an A/B test. I didn't want to add and then later remove properties to an existing, long-surviving event.

 