### PR TITLE
Domains > Checkout form: Loading placeholder's styles not applied

### DIFF
--- a/client/my-sites/checkout/checkout/style.scss
+++ b/client/my-sites/checkout/checkout/style.scss
@@ -29,7 +29,7 @@
 			}
 		}
 
-		&.is-empty {
+		.is-empty {
 			.payment-box-section, .checkout__payment-box-section {
 				border: 1px solid lighten( $gray, 30% );
 				margin: 5px 0;


### PR DESCRIPTION

The loading placeholder for the domain details checkout forms did not have its styles applied.

The result was an empty box, inconsistent with other form placeholders in Calypso.

## The change

The placeholder styles were dependent on a parent element with the classes `.checkout__payment-box-container.is-empty`. 

This however was an impossibility since in `<PaymentBox />` applied `.is-empty` to a [child node and not its root node](https://github.com/Automattic/wp-calypso/blob/master/client/my-sites/checkout/checkout/payment-box.jsx#L123). 

The correct cascade is: `.checkout__payment-box-container .is-empty .placeholder-row`

### Before
![before](https://user-images.githubusercontent.com/6458278/32532604-9318a6d8-c49f-11e7-81a3-804eaae64369.gif)

### After

![after](https://user-images.githubusercontent.com/6458278/32532607-950773c0-c49f-11e7-9e56-1b9adddce369.gif)

## Side effects
The class combo of `.checkout__payment-box-container .is-empty` is only ever made in `<PaymentBox />` (as a child of `<SecurePaymentFormPlaceholder />`) and won't effect other components.