### PR TITLE
Replace children propType element with node

### DIFF
--- a/client/blocks/calendar-button/index.jsx
+++ b/client/blocks/calendar-button/index.jsx
@@ -17,7 +17,6 @@ import AsyncLoad from 'components/async-load';
 
 class CalendarButton extends Component {
 	static propTypes = {
-		children: PropTypes.element,
 		icon: PropTypes.string,
 		popoverPosition: PropTypes.string,
 		type: PropTypes.string,

--- a/client/blocks/calendar-popover/index.jsx
+++ b/client/blocks/calendar-popover/index.jsx
@@ -18,8 +18,6 @@ import PostSchedule from 'components/post-schedule';
 
 class CalendarPopover extends Component {
 	static propTypes = {
-		children: PropTypes.element,
-
 		// connect props
 		gmtOffset: PropTypes.number,
 		timezoneValue: PropTypes.string,

--- a/client/components/auto-direction/index.jsx
+++ b/client/components/auto-direction/index.jsx
@@ -5,7 +5,6 @@
  */
 
 import React from 'react';
-import PropTypes from 'prop-types';
 import { get } from 'lodash';
 
 /**
@@ -215,10 +214,6 @@ const AutoDirection = props => {
 	const directionedChild = setChildDirection( children );
 
 	return directionedChild;
-};
-
-AutoDirection.propTypes = {
-	children: PropTypes.node,
 };
 
 export default AutoDirection;

--- a/client/components/card/index.jsx
+++ b/client/components/card/index.jsx
@@ -16,7 +16,6 @@ class Card extends Component {
 		tagName: PropTypes.string,
 		target: PropTypes.string,
 		compact: PropTypes.bool,
-		children: PropTypes.node,
 		highlight: PropTypes.oneOf( [ false, 'error', 'info', 'success', 'warning' ] ),
 	};
 

--- a/client/components/dialog/dialog-base.jsx
+++ b/client/components/dialog/dialog-base.jsx
@@ -13,7 +13,6 @@ class DialogBase extends Component {
 		autoFocus: PropTypes.bool,
 		baseClassName: PropTypes.string,
 		buttons: PropTypes.array,
-		children: PropTypes.node,
 		className: PropTypes.string,
 		isFullScreen: PropTypes.bool,
 		isVisible: PropTypes.bool,

--- a/client/components/dialog/dialog-base.jsx
+++ b/client/components/dialog/dialog-base.jsx
@@ -13,7 +13,7 @@ class DialogBase extends Component {
 		autoFocus: PropTypes.bool,
 		baseClassName: PropTypes.string,
 		buttons: PropTypes.array,
-		children: PropTypes.element,
+		children: PropTypes.node,
 		className: PropTypes.string,
 		isFullScreen: PropTypes.bool,
 		isVisible: PropTypes.bool,

--- a/client/components/domains/registrant-extra-info/fr-form.jsx
+++ b/client/components/domains/registrant-extra-info/fr-form.jsx
@@ -57,7 +57,6 @@ function renderValidationError( message ) {
 
 class RegistrantExtraInfoFrForm extends React.PureComponent {
 	static propTypes = {
-		children: PropTypes.node,
 		contactDetails: PropTypes.object,
 		contactDetailsValidationErrors: PropTypes.object,
 		isVisible: PropTypes.bool,

--- a/client/components/ellipsis-menu/index.jsx
+++ b/client/components/ellipsis-menu/index.jsx
@@ -22,7 +22,6 @@ class EllipsisMenu extends Component {
 		translate: PropTypes.func,
 		toggleTitle: PropTypes.string,
 		position: PropTypes.string,
-		children: PropTypes.node,
 		disabled: PropTypes.bool,
 		onClick: PropTypes.func,
 		onToggle: PropTypes.func,

--- a/client/components/emojify/index.jsx
+++ b/client/components/emojify/index.jsx
@@ -16,11 +16,6 @@ import config from 'config';
 
 export default class Emojify extends PureComponent {
 	static propTypes = {
-		children: PropTypes.oneOfType( [
-			PropTypes.array.isRequired,
-			PropTypes.object.isRequired,
-			PropTypes.string.isRequired,
-		] ),
 		imgClassName: PropTypes.string,
 	};
 

--- a/client/components/forms/form-toggle/index.jsx
+++ b/client/components/forms/form-toggle/index.jsx
@@ -19,7 +19,6 @@ export default class FormToggle extends PureComponent {
 		className: PropTypes.string,
 		toggling: PropTypes.bool,
 		'aria-label': PropTypes.string,
-		children: PropTypes.node,
 	};
 
 	static defaultProps = {

--- a/client/components/hr-with-text/index.jsx
+++ b/client/components/hr-with-text/index.jsx
@@ -1,10 +1,7 @@
+/** @format */
 /**
  * External dependencies
- *
- * @format
  */
-
-import PropTypes from 'prop-types';
 import React from 'react';
 
 const HrWithText = ( { children } ) => (
@@ -12,9 +9,5 @@ const HrWithText = ( { children } ) => (
 		<div>{ children }</div>
 	</div>
 );
-
-HrWithText.propTypes = {
-	children: PropTypes.node,
-};
 
 export default HrWithText;

--- a/client/components/image-preloader/index.jsx
+++ b/client/components/image-preloader/index.jsx
@@ -24,7 +24,6 @@ export default class extends React.Component {
 	static propTypes = {
 		src: PropTypes.string,
 		placeholder: PropTypes.element.isRequired,
-		children: PropTypes.node,
 		onLoad: PropTypes.func,
 		onError: PropTypes.func,
 	};

--- a/client/components/popover/menu-item.jsx
+++ b/client/components/popover/menu-item.jsx
@@ -17,7 +17,6 @@ export default class PopoverMenuItem extends Component {
 		isSelected: PropTypes.bool,
 		icon: PropTypes.string,
 		focusOnHover: PropTypes.bool,
-		children: PropTypes.node,
 	};
 
 	static defaultProps = {

--- a/client/components/root-child/index.jsx
+++ b/client/components/root-child/index.jsx
@@ -12,10 +12,6 @@ import { Provider as ReduxProvider } from 'react-redux';
 export default class extends React.Component {
 	static displayName = 'RootChild';
 
-	static propTypes = {
-		children: PropTypes.node,
-	};
-
 	static contextTypes = {
 		store: PropTypes.object,
 	};

--- a/client/components/section-nav/index.jsx
+++ b/client/components/section-nav/index.jsx
@@ -22,7 +22,6 @@ import Search from 'components/search';
  */
 class SectionNav extends Component {
 	static propTypes = {
-		children: PropTypes.node,
 		selectedText: PropTypes.node,
 		selectedCount: PropTypes.number,
 		hasPinnedItems: PropTypes.bool,

--- a/client/devdocs/docs-example/index.jsx
+++ b/client/devdocs/docs-example/index.jsx
@@ -60,7 +60,6 @@ const DocsExample = ( { children, componentUsageStats = {}, toggleHandler, toggl
 };
 
 DocsExample.propTypes = {
-	children: PropTypes.element.isRequired,
 	componentUsageStats: PropTypes.shape( {
 		count: PropTypes.number,
 	} ),

--- a/client/extensions/woocommerce/app/promotions/fields/form-field.js
+++ b/client/extensions/woocommerce/app/promotions/fields/form-field.js
@@ -77,7 +77,6 @@ FormField.PropTypes = {
 	isRequired: PropTypes.bool,
 	isEnableable: PropTypes.bool,
 	defaultValue: PropTypes.any,
-	children: PropTypes.isRequired,
 };
 
 export default FormField;

--- a/client/extensions/woocommerce/app/store-stats/store-stats-module/index.js
+++ b/client/extensions/woocommerce/app/store-stats/store-stats-module/index.js
@@ -22,7 +22,6 @@ import ErrorPanel from 'my-sites/stats/stats-error';
 
 class StoreStatsModule extends Component {
 	static propTypes = {
-		children: PropTypes.node,
 		data: PropTypes.array,
 		emptyMessage: PropTypes.string,
 		header: PropTypes.node,

--- a/client/extensions/woocommerce/components/action-header/index.js
+++ b/client/extensions/woocommerce/components/action-header/index.js
@@ -50,7 +50,6 @@ const ActionHeader = ( { children, breadcrumbs, isLoading } ) => {
 
 ActionHeader.propTypes = {
 	breadcrumbs: PropTypes.oneOfType( [ PropTypes.arrayOf( PropTypes.node ), PropTypes.node ] ),
-	children: PropTypes.oneOfType( [ PropTypes.arrayOf( PropTypes.node ), PropTypes.node ] ),
 };
 
 export default ActionHeader;

--- a/client/extensions/woocommerce/components/action-header/index.js
+++ b/client/extensions/woocommerce/components/action-header/index.js
@@ -49,7 +49,7 @@ const ActionHeader = ( { children, breadcrumbs, isLoading } ) => {
 };
 
 ActionHeader.propTypes = {
-	breadcrumbs: PropTypes.oneOfType( [ PropTypes.arrayOf( PropTypes.node ), PropTypes.node ] ),
+	breadcrumbs: PropTypes.node,
 };
 
 export default ActionHeader;

--- a/client/extensions/woocommerce/components/basic-widget/index.js
+++ b/client/extensions/woocommerce/components/basic-widget/index.js
@@ -32,7 +32,6 @@ BasicWidget.propTypes = {
 	buttonLabel: PropTypes.string,
 	buttonLink: PropTypes.string,
 	onButtonClick: PropTypes.func,
-	children: PropTypes.oneOfType( [ PropTypes.arrayOf( PropTypes.node ), PropTypes.node ] ),
 	className: PropTypes.string,
 	title: PropTypes.string,
 };

--- a/client/extensions/woocommerce/components/table/index.js
+++ b/client/extensions/woocommerce/components/table/index.js
@@ -45,7 +45,6 @@ const Table = ( {
 
 Table.propTypes = {
 	className: PropTypes.string,
-	children: PropTypes.node,
 	compact: PropTypes.bool,
 	horizontalScroll: PropTypes.bool,
 	header: PropTypes.node,

--- a/client/extensions/woocommerce/components/table/table-item/index.js
+++ b/client/extensions/woocommerce/components/table/table-item/index.js
@@ -55,7 +55,6 @@ TableItem.propTypes = {
 	isHeader: PropTypes.bool,
 	isRowHeader: PropTypes.bool,
 	isTitle: PropTypes.bool,
-	children: PropTypes.node,
 };
 
 export default TableItem;

--- a/client/extensions/woocommerce/components/table/table-row/index.js
+++ b/client/extensions/woocommerce/components/table/table-row/index.js
@@ -46,7 +46,6 @@ const TableRow = ( { className, isHeader, href, children, ...props } ) => {
 };
 
 TableRow.propTypes = {
-	children: PropTypes.node,
 	className: PropTypes.string,
 	href: PropTypes.string,
 	isHeader: PropTypes.bool,

--- a/client/extensions/woocommerce/components/widget-group/index.js
+++ b/client/extensions/woocommerce/components/widget-group/index.js
@@ -14,7 +14,6 @@ class WidgetGroup extends Component {
 	};
 
 	static propTypes = {
-		children: PropTypes.oneOfType( [ PropTypes.arrayOf( PropTypes.node ), PropTypes.node ] ),
 		className: PropTypes.string,
 		maxColumns: PropTypes.number,
 		title: PropTypes.string,

--- a/client/layout/guided-tours/config-elements/continue.js
+++ b/client/layout/guided-tours/config-elements/continue.js
@@ -19,7 +19,6 @@ export default class Continue extends Component {
 	static contextTypes = contextTypes;
 
 	static propTypes = {
-		children: PropTypes.node,
 		click: PropTypes.bool,
 		hidden: PropTypes.bool,
 		icon: PropTypes.string,

--- a/client/layout/guided-tours/config-elements/link-quit.js
+++ b/client/layout/guided-tours/config-elements/link-quit.js
@@ -17,7 +17,6 @@ import contextTypes from '../context-types';
 
 export default class LinkQuit extends Component {
 	static propTypes = {
-		children: PropTypes.node,
 		primary: PropTypes.bool,
 		subtle: PropTypes.bool,
 		href: PropTypes.string,

--- a/client/layout/guided-tours/config-elements/next.js
+++ b/client/layout/guided-tours/config-elements/next.js
@@ -17,7 +17,6 @@ import contextTypes from '../context-types';
 export default class Next extends Component {
 	static propTypes = {
 		step: PropTypes.string.isRequired,
-		children: PropTypes.node,
 	};
 
 	static contextTypes = contextTypes;

--- a/client/layout/guided-tours/config-elements/quit.js
+++ b/client/layout/guided-tours/config-elements/quit.js
@@ -16,7 +16,6 @@ import contextTypes from '../context-types';
 
 export default class Quit extends Component {
 	static propTypes = {
-		children: PropTypes.node,
 		primary: PropTypes.bool,
 		subtle: PropTypes.bool,
 	};

--- a/client/layout/sidebar/button.jsx
+++ b/client/layout/sidebar/button.jsx
@@ -21,7 +21,6 @@ class SidebarButton extends React.Component {
 		href: PropTypes.string,
 		onClick: PropTypes.func,
 		preloadSectionName: PropTypes.string,
-		children: PropTypes.node,
 	};
 
 	_preloaded = false;

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/index.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/index.jsx
@@ -70,7 +70,6 @@ PostActionsEllipsisMenu.propTypes = {
 	siteId: PropTypes.number,
 	isKnownType: PropTypes.bool,
 	includeDefaultActions: PropTypes.bool,
-	children: PropTypes.node,
 };
 
 PostActionsEllipsisMenu.defaultProps = {

--- a/client/post-editor/editor-drawer-well/index.jsx
+++ b/client/post-editor/editor-drawer-well/index.jsx
@@ -13,7 +13,6 @@ import { localize } from 'i18n-calypso';
 
 class EditorDrawerWell extends Component {
 	static propTypes = {
-		children: PropTypes.node,
 		disabled: PropTypes.bool,
 		empty: PropTypes.bool,
 		icon: PropTypes.string,

--- a/client/post-editor/editor-drawer/label.jsx
+++ b/client/post-editor/editor-drawer/label.jsx
@@ -25,7 +25,6 @@ export default function EditorDrawerLabel( { children, labelText, helpText } ) {
 }
 
 EditorDrawerLabel.propTypes = {
-	children: PropTypes.node,
 	helpText: PropTypes.string,
 	labelText: PropTypes.string,
 };


### PR DESCRIPTION
This PR fixes an apparently inaccurate propType causing warnings to display in the console.

`PropTypes.element` is used to specifically require a _single_ element child.
Children normally does not have this restriction and `PropTypes.node` is more
appropriate.

This rule was introduced in #19204

Fixes #19578