### PR TITLE
Cleanup: Use class name over component.displayName

### DIFF
--- a/client/components/gallery-shortcode/index.jsx
+++ b/client/components/gallery-shortcode/index.jsx
@@ -23,9 +23,7 @@ import { GalleryDefaultAttrs } from 'lib/media/constants';
  */
 const debug = debugModule( 'calypso:gallery-shortcode' );
 
-export default class extends React.Component {
-	static displayName = 'GalleryShortcode';
-
+export default class GalleryShortcode extends React.Component {
 	static propTypes = {
 		siteId: PropTypes.number.isRequired,
 		children: PropTypes.string,

--- a/client/components/image-preloader/index.jsx
+++ b/client/components/image-preloader/index.jsx
@@ -18,9 +18,7 @@ const LoadStatus = {
 	FAILED: 'FAILED',
 };
 
-export default class extends React.Component {
-	static displayName = 'ImagePreloader';
-
+export default class ImagePreloader extends React.Component {
 	static propTypes = {
 		src: PropTypes.string,
 		placeholder: PropTypes.element.isRequired,

--- a/client/components/logged-out-form/index.jsx
+++ b/client/components/logged-out-form/index.jsx
@@ -14,9 +14,7 @@ import { omit } from 'lodash';
  */
 import Card from 'components/card';
 
-export default class extends React.Component {
-	static displayName = 'LoggedOutForm';
-
+export default class LoggedOutForm extends React.Component {
 	static propTypes = {
 		children: PropTypes.node.isRequired,
 		className: PropTypes.string,

--- a/client/components/logged-out-form/links.jsx
+++ b/client/components/logged-out-form/links.jsx
@@ -9,9 +9,7 @@ import React from 'react';
 import classnames from 'classnames';
 import { omit } from 'lodash';
 
-export default class extends React.Component {
-	static displayName = 'LoggedOutFormLinks';
-
+export default class LoggedOutFormLinks extends React.Component {
 	static propTypes = {
 		children: PropTypes.node.isRequired,
 		className: PropTypes.string,

--- a/client/components/root-child/index.jsx
+++ b/client/components/root-child/index.jsx
@@ -9,9 +9,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { Provider as ReduxProvider } from 'react-redux';
 
-export default class extends React.Component {
-	static displayName = 'RootChild';
-
+export default class RootChild extends React.Component {
 	static contextTypes = {
 		store: PropTypes.object,
 	};

--- a/client/components/shortcode/index.jsx
+++ b/client/components/shortcode/index.jsx
@@ -21,7 +21,7 @@ import * as ShortcodesActions from 'lib/shortcodes/actions';
 import ShortcodeData from './data';
 import ShortcodeFrame from './frame';
 
-export default class extends React.Component {
+export default class Shortcode extends React.Component {
 	static displayName = 'Shortcode';
 
 	static propTypes = {

--- a/client/components/shortcode/index.jsx
+++ b/client/components/shortcode/index.jsx
@@ -22,8 +22,6 @@ import ShortcodeData from './data';
 import ShortcodeFrame from './frame';
 
 export default class Shortcode extends React.Component {
-	static displayName = 'Shortcode';
-
 	static propTypes = {
 		siteId: PropTypes.number.isRequired,
 		children: PropTypes.string.isRequired,

--- a/client/layout/sidebar/button.jsx
+++ b/client/layout/sidebar/button.jsx
@@ -15,8 +15,6 @@ import { isExternal } from 'lib/url';
 import { preload } from 'sections-preload';
 
 class SidebarButton extends React.Component {
-	static displayName = 'SidebarButton';
-
 	static propTypes = {
 		href: PropTypes.string,
 		onClick: PropTypes.func,


### PR DESCRIPTION
While working on #19594 I came across a lot of `displayName` usage.

This PR moves the `displayName` to be the class name where possible and removes the static property when found to be redundant.

This is not a complete removal of `displayName`, just what I happened to discover during #19594.