### PR TITLE
Fix: Normalize Youtube embed links as HTTPS

### DIFF
--- a/client/lib/plugins/sanitize-section-content.js
+++ b/client/lib/plugins/sanitize-section-content.js
@@ -156,8 +156,9 @@ export const sanitizeSectionContent = content => {
 	while ( walker.nextNode() ) {
 		const node = walker.currentNode;
 		const tagName = node.nodeName.toLowerCase();
+		const isYoutube = isValidYoutubeEmbed( node );
 
-		if ( ! isAllowedTag( tagName ) && ! isValidYoutubeEmbed( node ) ) {
+		if ( ! isAllowedTag( tagName ) && ! isYoutube ) {
 			removeList.push( node );
 			continue;
 		}
@@ -195,6 +196,11 @@ export const sanitizeSectionContent = content => {
 		if ( 'a' === tagName && node.getAttribute( 'href' ) ) {
 			node.setAttribute( 'target', '_blank' );
 			node.setAttribute( 'rel', 'external noopener noreferrer' );
+		}
+
+		// prevent mixed-content issues from blocking Youtube embeds
+		if ( isYoutube ) {
+			node.setAttribute( 'src', node.getAttribute( 'src' ).replace( 'http://', 'https://' ) );
 		}
 	}
 

--- a/client/lib/plugins/test/sanitize-section-content.js
+++ b/client/lib/plugins/test/sanitize-section-content.js
@@ -78,6 +78,14 @@ test( 'should only set link params if href set', () => {
 	expect( clean( '<a>link</a>' ) ).toBe( '<a>link</a>' );
 } );
 
+test( 'should secure Youtube sources', () => {
+	const embed = cleanNode(
+		'<iframe type="text/html" class="youtube-player" src="http://youtube.com/123456" />'
+	);
+
+	expect( embed.getAttribute( 'src' ) ).toBe( 'https://youtube.com/123456' );
+} );
+
 test( 'should bump up header levels', () => {
 	expect( clean( '<h1>👍</h1>' ) ).toBe( '<h3>👍</h3>' );
 	expect( clean( '<h2>👍</h2>' ) ).toBe( '<h3>👍</h3>' );


### PR DESCRIPTION
In #19316 we opened up the import of Youtube embeds in plugin
descriptions. However, this brought up the possibility of trying to load
Youtube videos from `http://` URLs, which would produce mixed-content
warnings in the browser and block loading.

@samouri noted this in
https://github.com/Automattic/wp-calypso/pull/19316#issuecomment-341765660
but we failed to identify why it happened.

In this patch we're normalizing the Youtube source URLs to use `https`
to prevent those mixed-content warnings.