### PR TITLE
Post Type List: a Tracks events for post actions

### DIFF
--- a/client/blocks/post-share/index.jsx
+++ b/client/blocks/post-share/index.jsx
@@ -12,6 +12,7 @@ import { get, includes, map, concat } from 'lodash';
 import { localize } from 'i18n-calypso';
 import { isEnabled } from 'config';
 import Gridicon from 'gridicons';
+import { current as currentPage } from 'page';
 
 /**
  * Internal dependencies
@@ -68,6 +69,7 @@ import SectionHeader from 'components/section-header';
 import Tooltip from 'components/tooltip';
 import analytics from 'lib/analytics';
 import TrackComponentView from 'lib/analytics/track-component-view';
+import { sectionify } from 'lib/route/path';
 
 class PostShare extends Component {
 	static propTypes = {
@@ -182,12 +184,11 @@ class PostShare extends Component {
 			},
 			{ service_all: 0 }
 		);
+		const additionalProperties = { context_path: sectionify( currentPage ) };
+		const eventProperties = { ...numberOfAccountsPerService, ...additionalProperties };
 
 		if ( this.state.scheduledDate ) {
-			analytics.tracks.recordEvent(
-				'calypso_publicize_share_schedule',
-				numberOfAccountsPerService
-			);
+			analytics.tracks.recordEvent( 'calypso_publicize_share_schedule', eventProperties );
 
 			this.props.schedulePostShareAction(
 				siteId,
@@ -197,10 +198,7 @@ class PostShare extends Component {
 				servicesToPublish.map( connection => connection.ID )
 			);
 		} else {
-			analytics.tracks.recordEvent(
-				'calypso_publicize_share_instantly',
-				numberOfAccountsPerService
-			);
+			analytics.tracks.recordEvent( 'calypso_publicize_share_instantly', eventProperties );
 			this.props.sharePost( siteId, postId, this.state.skipped, this.state.message );
 		}
 	};

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/duplicate.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/duplicate.jsx
@@ -18,7 +18,7 @@ import { getPost } from 'state/posts/selectors';
 import { canCurrentUserEditPost } from 'state/selectors';
 import { getEditorDuplicatePostPath } from 'state/ui/editor/selectors';
 import { isEnabled } from 'config';
-import { bumpStat as bumpAnalyticsStat } from 'state/analytics/actions';
+import { bumpStat, recordTracksEvent } from 'state/analytics/actions';
 import { bumpStatGenerator } from './utils';
 
 function PostActionsEllipsisMenuDuplicate( {
@@ -27,7 +27,7 @@ function PostActionsEllipsisMenuDuplicate( {
 	status,
 	type,
 	duplicateUrl,
-	bumpStat,
+	onDuplicateClick,
 } ) {
 	const validStatus = includes( [ 'draft', 'future', 'pending', 'private', 'publish' ], status );
 
@@ -36,7 +36,7 @@ function PostActionsEllipsisMenuDuplicate( {
 	}
 
 	return (
-		<PopoverMenuItem href={ duplicateUrl } onClick={ bumpStat } icon="pages">
+		<PopoverMenuItem href={ duplicateUrl } onClick={ onDuplicateClick } icon="pages">
 			{ translate( 'Duplicate', { context: 'verb' } ) }
 		</PopoverMenuItem>
 	);
@@ -49,7 +49,7 @@ PostActionsEllipsisMenuDuplicate.propTypes = {
 	status: PropTypes.string,
 	type: PropTypes.string,
 	duplicateUrl: PropTypes.string,
-	bumpStat: PropTypes.func,
+	onDuplicateClick: PropTypes.func,
 };
 
 const mapStateToProps = ( state, { globalId } ) => {
@@ -66,15 +66,16 @@ const mapStateToProps = ( state, { globalId } ) => {
 	};
 };
 
-const mapDispatchToProps = { bumpAnalyticsStat };
+const mapDispatchToProps = { bumpStat, recordTracksEvent };
 
 const mergeProps = ( stateProps, dispatchProps, ownProps ) => {
-	const bumpStat = bumpStatGenerator(
-		stateProps.type,
-		'duplicate',
-		dispatchProps.bumpAnalyticsStat
+	const onDuplicateClick = () => (
+		bumpStatGenerator( stateProps.type, 'duplicate', dispatchProps.bumpStat ),
+		dispatchProps.recordTracksEvent( 'calypso_post_type_list_duplicate', {
+			post_type: stateProps.type,
+		} )
 	);
-	return Object.assign( {}, ownProps, stateProps, dispatchProps, { bumpStat } );
+	return Object.assign( {}, ownProps, stateProps, dispatchProps, { onDuplicateClick } );
 };
 
 export default connect( mapStateToProps, mapDispatchToProps, mergeProps )(

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/publish.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/publish.jsx
@@ -14,7 +14,7 @@ import { get, includes } from 'lodash';
  * Internal dependencies
  */
 import PopoverMenuItem from 'components/popover/menu-item';
-import { bumpStat as bumpAnalyticsStat } from 'state/analytics/actions';
+import { bumpStat, recordTracksEvent } from 'state/analytics/actions';
 import { bumpStatGenerator } from './utils';
 import { getPost } from 'state/posts/selectors';
 import { savePost } from 'state/posts/actions';
@@ -30,7 +30,7 @@ class PostActionsEllipsisMenuPublish extends Component {
 		postId: PropTypes.number,
 		canPublish: PropTypes.bool,
 		savePost: PropTypes.func,
-		bumpStat: PropTypes.func,
+		onPublishPost: PropTypes.func,
 	};
 
 	constructor() {
@@ -45,7 +45,7 @@ class PostActionsEllipsisMenuPublish extends Component {
 			return;
 		}
 
-		this.props.bumpStat();
+		this.props.onPublishPost();
 		this.props.savePost( siteId, postId, { status: 'publish' } );
 	}
 
@@ -78,15 +78,17 @@ const mapStateToProps = ( state, { globalId } ) => {
 	};
 };
 
-const mapDispatchToProps = { savePost, bumpAnalyticsStat };
+const mapDispatchToProps = { savePost, bumpStat, recordTracksEvent };
 
 const mergeProps = ( stateProps, dispatchProps, ownProps ) => {
-	const bumpStat = bumpStatGenerator(
-		get( stateProps, 'type.name' ),
-		'publish',
-		dispatchProps.bumpAnalyticsStat
+	const postType = get( stateProps, 'type.name' );
+	const onPublishPost = () => (
+		bumpStatGenerator( postType, 'publish', dispatchProps.bumpStat ),
+		dispatchProps.recordTracksEvent( 'calypso_post_type_list_publish', {
+			post_type: postType,
+		} )
 	);
-	return Object.assign( {}, ownProps, stateProps, dispatchProps, { bumpStat } );
+	return Object.assign( {}, ownProps, stateProps, dispatchProps, { onPublishPost } );
 };
 
 export default connect( mapStateToProps, mapDispatchToProps, mergeProps )(

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/trash.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/trash.jsx
@@ -14,7 +14,7 @@ import { get } from 'lodash';
  * Internal dependencies
  */
 import PopoverMenuItem from 'components/popover/menu-item';
-import { bumpStat as bumpAnalyticsStat } from 'state/analytics/actions';
+import { bumpStat, recordTracksEvent } from 'state/analytics/actions';
 import { bumpStatGenerator } from './utils';
 import { trashPost, deletePost } from 'state/posts/actions';
 import { canCurrentUser } from 'state/selectors';
@@ -32,8 +32,8 @@ class PostActionsEllipsisMenuTrash extends Component {
 		canDelete: PropTypes.bool,
 		trashPost: PropTypes.func,
 		deletePost: PropTypes.func,
-		bumpTrashStat: PropTypes.func,
-		bumpDeleteStat: PropTypes.func,
+		onTrashClick: PropTypes.func,
+		onDeleteClick: PropTypes.func,
 	};
 
 	constructor() {
@@ -49,10 +49,10 @@ class PostActionsEllipsisMenuTrash extends Component {
 		}
 
 		if ( 'trash' !== status ) {
-			this.props.bumpTrashStat();
+			this.props.onTrashClick();
 			this.props.trashPost( siteId, postId );
 		} else if ( confirm( translate( 'Are you sure you want to permanently delete this post?' ) ) ) {
-			this.props.bumpDeleteStat();
+			this.props.onDeleteClick();
 			this.props.deletePost( siteId, postId );
 		}
 	}
@@ -95,22 +95,25 @@ const mapStateToProps = ( state, { globalId } ) => {
 	};
 };
 
-const mapDispatchToProps = { trashPost, deletePost, bumpAnalyticsStat };
+const mapDispatchToProps = { trashPost, deletePost, bumpStat, recordTracksEvent };
 
 const mergeProps = ( stateProps, dispatchProps, ownProps ) => {
-	const bumpTrashStat = bumpStatGenerator(
-		get( stateProps, 'type.name' ),
-		'trash',
-		dispatchProps.bumpAnalyticsStat
+	const postType = get( stateProps, 'type.name' );
+	const onTrashClick = () => (
+		bumpStatGenerator( postType, 'trash', dispatchProps.bumpStat ),
+		dispatchProps.recordTracksEvent( 'calypso_post_type_list_trash', {
+			post_type: postType,
+		} )
 	);
-	const bumpDeleteStat = bumpStatGenerator(
-		get( stateProps, 'type.name' ),
-		'delete',
-		dispatchProps.bumpAnalyticsStat
+	const onDeleteClick = () => (
+		bumpStatGenerator( postType, 'delete', dispatchProps.bumpStat ),
+		dispatchProps.recordTracksEvent( 'calypso_post_type_list_delete', {
+			post_type: postType,
+		} )
 	);
 	return Object.assign( {}, ownProps, stateProps, dispatchProps, {
-		bumpTrashStat,
-		bumpDeleteStat,
+		onTrashClick,
+		onDeleteClick,
 	} );
 };
 

--- a/client/my-sites/posts/post.jsx
+++ b/client/my-sites/posts/post.jsx
@@ -26,7 +26,7 @@ import PostExcerpt from 'components/post-excerpt';
 import updatePostStatus from 'components/update-post-status';
 import utils from 'lib/posts/utils';
 import config from 'config';
-import { recordGoogleEvent } from 'state/analytics/actions';
+import { recordGoogleEvent, recordTracksEvent } from 'state/analytics/actions';
 import { setPreviewUrl } from 'state/ui/preview/actions';
 import { setLayoutFocus } from 'state/ui/layout-focus/actions';
 import { getPostPreviewUrl } from 'state/posts/selectors';
@@ -103,6 +103,7 @@ class Post extends Component {
 
 	publishPost = () => {
 		this.props.updatePostStatus( 'publish' );
+		this.props.recordTracksEvent( 'calypso_post_type_list_publish', { post_type: 'post' } );
 		this.props.recordPublishPost();
 	};
 
@@ -113,11 +114,13 @@ class Post extends Component {
 
 	deletePost = () => {
 		this.props.updatePostStatus( 'delete' );
+		this.props.recordTracksEvent( 'calypso_post_type_list_delete', { post_type: 'post' } );
 		this.props.recordDeletePost();
 	};
 
 	trashPost = () => {
 		this.props.updatePostStatus( 'trash' );
+		this.props.recordTracksEvent( 'calypso_post_type_list_trash', { post_type: 'post' } );
 		this.props.recordTrashPost();
 	};
 
@@ -345,6 +348,7 @@ const mapDispatch = {
 		actions[ key ] = partial( recordEvent, event );
 		return actions;
 	}, {} ),
+	recordTracksEvent,
 };
 
 export default connect( ( state, { post } ) => {


### PR DESCRIPTION
This PR adds Tracks events to the publish, duplicate, share, and trash actions on the `/posts/` page to help us gauge the value of the current expanded and proposed condensed post list views.

Ref: p8F9tW-vh-p2

**Events Added/Modified:**
- `calypso_publicize_share_schedule` (added `context_path` property)
- `calypso_publicize_share_instantly` (added `context_path` property)
- `calypso_post_type_list_duplicate` with `post_type` property
- `calypso_post_type_list_publish` with `post_type` property
- `calypso_post_type_list_trash` with `post_type` property
- `calypso_post_type_list_delete` with `post_type` property

**To Test:**
- Checkout branch or run from calypso.live link.
- Run `ENABLE_FEATURES=posts/post-type-list npm start`.
- Run `localStorage.setItem('debug', 'calypso:analytics:tracks');` in your browser console and reload the page.
- Navigate to `/posts/` and click the publish, duplicate, share*, and trash actions.
- Make sure that events fire in the console for each event.
- Return to the `/posts/` screen with the query string `?flags=-posts/post-type-list` added to the url.
- Click the publish, duplicate, share*, and trash actions.
- Make sure that events fire in the console for each event.