### PR TITLE
Conversations: show all conversations as 'followed' in the conversations stream

### DIFF
--- a/client/blocks/conversation-follow-button/index.jsx
+++ b/client/blocks/conversation-follow-button/index.jsx
@@ -7,7 +7,7 @@
  */
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { noop } from 'lodash';
+import { noop, includes, uniq } from 'lodash';
 import { connect } from 'react-redux';
 
 /**
@@ -18,7 +18,7 @@ import { getReaderConversationFollowStatus } from 'state/selectors';
 import { followConversation, muteConversation } from 'state/reader/conversations/actions';
 import {
 	CONVERSATION_FOLLOW_STATUS_FOLLOWING,
-	CONVERSATION_FOLLOW_STATUS_MUTING,
+	CONVERSATION_FOLLOW_STATUS_NOT_FOLLOWING,
 } from 'state/reader/conversations/follow-status';
 
 class ConversationFollowButtonContainer extends Component {
@@ -32,12 +32,15 @@ class ConversationFollowButtonContainer extends Component {
 		 * of explicitly followed posts (followStatus F) and implicitly followed posts
 		 * (followStatus null). We want to present them all as followed.
 		 */
-		showFollowingForAllUnmutedConversations: PropTypes.bool,
+		defaultConversationFollowStatus: PropTypes.oneOf( [
+			CONVERSATION_FOLLOW_STATUS_FOLLOWING,
+			CONVERSATION_FOLLOW_STATUS_NOT_FOLLOWING,
+		] ),
 	};
 
 	static defaultProps = {
 		onFollowToggle: noop,
-		showFollowingForAllUnmutedConversations: false,
+		defaultConversationFollowStatus: CONVERSATION_FOLLOW_STATUS_FOLLOWING,
 	};
 
 	handleFollowToggle = isRequestingFollow => {
@@ -53,12 +56,10 @@ class ConversationFollowButtonContainer extends Component {
 	};
 
 	render() {
-		let isFollowing = false;
-		if ( this.props.showFollowingForAllUnmutedConversations ) {
-			isFollowing = this.props.followStatus !== CONVERSATION_FOLLOW_STATUS_MUTING;
-		} else {
-			isFollowing = this.props.followStatus === CONVERSATION_FOLLOW_STATUS_FOLLOWING;
-		}
+		const isFollowing = includes(
+			uniq( [ CONVERSATION_FOLLOW_STATUS_FOLLOWING, this.props.defaultConversationFollowStatus ] ),
+			this.props.followStatus
+		);
 
 		return (
 			<ConversationFollowButton

--- a/client/blocks/conversation-follow-button/index.jsx
+++ b/client/blocks/conversation-follow-button/index.jsx
@@ -56,10 +56,11 @@ class ConversationFollowButtonContainer extends Component {
 	};
 
 	render() {
-		const isFollowing = includes(
-			uniq( [ CONVERSATION_FOLLOW_STATUS_FOLLOWING, this.props.defaultConversationFollowStatus ] ),
-			this.props.followStatus
-		);
+		const validFollowingStatuses = uniq( [
+			CONVERSATION_FOLLOW_STATUS_FOLLOWING,
+			this.props.defaultConversationFollowStatus,
+		] );
+		const isFollowing = includes( validFollowingStatuses, this.props.followStatus );
 
 		return (
 			<ConversationFollowButton

--- a/client/blocks/conversation-follow-button/index.jsx
+++ b/client/blocks/conversation-follow-button/index.jsx
@@ -7,7 +7,7 @@
  */
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { noop, includes, uniq } from 'lodash';
+import { noop } from 'lodash';
 import { connect } from 'react-redux';
 
 /**
@@ -19,6 +19,7 @@ import { followConversation, muteConversation } from 'state/reader/conversations
 import {
 	CONVERSATION_FOLLOW_STATUS_FOLLOWING,
 	CONVERSATION_FOLLOW_STATUS_NOT_FOLLOWING,
+	CONVERSATION_FOLLOW_STATUS_MUTING,
 } from 'state/reader/conversations/follow-status';
 
 class ConversationFollowButtonContainer extends Component {
@@ -27,20 +28,16 @@ class ConversationFollowButtonContainer extends Component {
 		postId: PropTypes.number.isRequired,
 		onFollowToggle: PropTypes.func,
 		tagName: PropTypes.oneOfType( [ PropTypes.string, PropTypes.func ] ),
-
-		/* This is a special prop for the Conversations stream, where we have a mixture
-		 * of explicitly followed posts (followStatus F) and implicitly followed posts
-		 * (followStatus null). We want to present them all as followed.
-		 */
 		defaultConversationFollowStatus: PropTypes.oneOf( [
 			CONVERSATION_FOLLOW_STATUS_FOLLOWING,
 			CONVERSATION_FOLLOW_STATUS_NOT_FOLLOWING,
+			CONVERSATION_FOLLOW_STATUS_MUTING,
 		] ),
 	};
 
 	static defaultProps = {
 		onFollowToggle: noop,
-		defaultConversationFollowStatus: CONVERSATION_FOLLOW_STATUS_FOLLOWING,
+		defaultConversationFollowStatus: CONVERSATION_FOLLOW_STATUS_NOT_FOLLOWING,
 	};
 
 	handleFollowToggle = isRequestingFollow => {
@@ -56,11 +53,16 @@ class ConversationFollowButtonContainer extends Component {
 	};
 
 	render() {
-		const validFollowingStatuses = uniq( [
-			CONVERSATION_FOLLOW_STATUS_FOLLOWING,
-			this.props.defaultConversationFollowStatus,
-		] );
-		const isFollowing = includes( validFollowingStatuses, this.props.followStatus );
+		let followStatus;
+
+		// If follow status is not 'F' or 'M', then use the defaultConversationFollowStatus as the status
+		if ( this.props.defaultConversationFollowStatus && ! this.props.followStatus ) {
+			followStatus = this.props.defaultConversationFollowStatus;
+		} else {
+			followStatus = this.props.followStatus;
+		}
+
+		const isFollowing = followStatus === CONVERSATION_FOLLOW_STATUS_FOLLOWING;
 
 		return (
 			<ConversationFollowButton

--- a/client/blocks/reader-post-card/compact.jsx
+++ b/client/blocks/reader-post-card/compact.jsx
@@ -14,7 +14,14 @@ import ReaderExcerpt from 'blocks/reader-excerpt';
 import ReaderPostOptionsMenu from 'blocks/reader-post-options-menu';
 import FeaturedAsset from './featured-asset';
 
-const CompactPost = ( { post, postByline, children, isDiscover, onClick } ) => {
+const CompactPost = ( {
+	post,
+	postByline,
+	children,
+	isDiscover,
+	showFollowingForAllUnmutedConversations,
+	onClick,
+} ) => {
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	return (
 		<div className="reader-post-card__post" onClick={ onClick }>
@@ -30,6 +37,7 @@ const CompactPost = ( { post, postByline, children, isDiscover, onClick } ) => {
 					showFollow={ true }
 					post={ post }
 					position="bottom"
+					showFollowingForAllUnmutedConversations={ showFollowingForAllUnmutedConversations }
 				/>
 				<AutoDirection>
 					<h1 className="reader-post-card__title">

--- a/client/blocks/reader-post-card/compact.jsx
+++ b/client/blocks/reader-post-card/compact.jsx
@@ -19,7 +19,7 @@ const CompactPost = ( {
 	postByline,
 	children,
 	isDiscover,
-	showFollowingForAllUnmutedConversations,
+	defaultConversationFollowStatus,
 	onClick,
 } ) => {
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
@@ -37,7 +37,7 @@ const CompactPost = ( {
 					showFollow={ true }
 					post={ post }
 					position="bottom"
-					showFollowingForAllUnmutedConversations={ showFollowingForAllUnmutedConversations }
+					defaultConversationFollowStatus={ defaultConversationFollowStatus }
 				/>
 				<AutoDirection>
 					<h1 className="reader-post-card__title">

--- a/client/blocks/reader-post-card/conversation-post.jsx
+++ b/client/blocks/reader-post-card/conversation-post.jsx
@@ -20,7 +20,7 @@ class ConversationPost extends React.Component {
 	render() {
 		return (
 			<div className="reader-post-card__conversation-post">
-				<CompactPostCard { ...this.props } />
+				<CompactPostCard { ...this.props } showFollowingForAllUnmutedConversations={ true } />
 				<ConversationPostList post={ this.props.post } commentIds={ this.props.commentIds } />
 			</div>
 		);

--- a/client/blocks/reader-post-card/conversation-post.jsx
+++ b/client/blocks/reader-post-card/conversation-post.jsx
@@ -10,6 +10,7 @@ import PropTypes from 'prop-types';
  */
 import ConversationPostList from 'blocks/conversations/list';
 import CompactPostCard from 'blocks/reader-post-card/compact';
+import { CONVERSATION_FOLLOW_STATUS_NOT_FOLLOWING } from 'state/reader/conversations/follow-status';
 
 class ConversationPost extends React.Component {
 	static propTypes = {
@@ -20,7 +21,10 @@ class ConversationPost extends React.Component {
 	render() {
 		return (
 			<div className="reader-post-card__conversation-post">
-				<CompactPostCard { ...this.props } showFollowingForAllUnmutedConversations={ true } />
+				<CompactPostCard
+					{ ...this.props }
+					defaultConversationFollowStatus={ CONVERSATION_FOLLOW_STATUS_NOT_FOLLOWING }
+				/>
 				<ConversationPostList post={ this.props.post } commentIds={ this.props.commentIds } />
 			</div>
 		);

--- a/client/blocks/reader-post-card/conversation-post.jsx
+++ b/client/blocks/reader-post-card/conversation-post.jsx
@@ -10,7 +10,7 @@ import PropTypes from 'prop-types';
  */
 import ConversationPostList from 'blocks/conversations/list';
 import CompactPostCard from 'blocks/reader-post-card/compact';
-import { CONVERSATION_FOLLOW_STATUS_NOT_FOLLOWING } from 'state/reader/conversations/follow-status';
+import { CONVERSATION_FOLLOW_STATUS_FOLLOWING } from 'state/reader/conversations/follow-status';
 
 class ConversationPost extends React.Component {
 	static propTypes = {
@@ -23,7 +23,7 @@ class ConversationPost extends React.Component {
 			<div className="reader-post-card__conversation-post">
 				<CompactPostCard
 					{ ...this.props }
-					defaultConversationFollowStatus={ CONVERSATION_FOLLOW_STATUS_NOT_FOLLOWING }
+					defaultConversationFollowStatus={ CONVERSATION_FOLLOW_STATUS_FOLLOWING }
 				/>
 				<ConversationPostList post={ this.props.post } commentIds={ this.props.commentIds } />
 			</div>

--- a/client/blocks/reader-post-options-menu/index.jsx
+++ b/client/blocks/reader-post-options-menu/index.jsx
@@ -38,6 +38,7 @@ class ReaderPostOptionsMenu extends React.Component {
 		onBlock: PropTypes.func,
 		showFollow: PropTypes.bool,
 		position: PropTypes.string,
+		showFollowingForAllUnmutedConversations: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -174,6 +175,9 @@ class ReaderPostOptionsMenu extends React.Component {
 							tagName={ PopoverMenuItem }
 							siteId={ siteId }
 							postId={ postId }
+							showFollowingForAllUnmutedConversations={
+								this.props.showFollowingForAllUnmutedConversations
+							}
 						/>
 					) }
 

--- a/client/blocks/reader-post-options-menu/index.jsx
+++ b/client/blocks/reader-post-options-menu/index.jsx
@@ -30,6 +30,10 @@ import { getReaderTeams } from 'state/selectors';
 import ReaderPostOptionsMenuBlogStickers from './blog-stickers';
 import ConversationFollowButton from 'blocks/conversation-follow-button';
 import { shouldShowConversationFollowButton } from 'blocks/conversation-follow-button/helper';
+import {
+	CONVERSATION_FOLLOW_STATUS_FOLLOWING,
+	CONVERSATION_FOLLOW_STATUS_NOT_FOLLOWING,
+} from 'state/reader/conversations/follow-status';
 
 class ReaderPostOptionsMenu extends React.Component {
 	static propTypes = {
@@ -38,7 +42,10 @@ class ReaderPostOptionsMenu extends React.Component {
 		onBlock: PropTypes.func,
 		showFollow: PropTypes.bool,
 		position: PropTypes.string,
-		showFollowingForAllUnmutedConversations: PropTypes.bool,
+		defaultConversationFollowStatus: PropTypes.oneOf( [
+			CONVERSATION_FOLLOW_STATUS_FOLLOWING,
+			CONVERSATION_FOLLOW_STATUS_NOT_FOLLOWING,
+		] ),
 	};
 
 	static defaultProps = {
@@ -175,9 +182,7 @@ class ReaderPostOptionsMenu extends React.Component {
 							tagName={ PopoverMenuItem }
 							siteId={ siteId }
 							postId={ postId }
-							showFollowingForAllUnmutedConversations={
-								this.props.showFollowingForAllUnmutedConversations
-							}
+							defaultConversationFollowStatus={ this.props.defaultConversationFollowStatus }
 						/>
 					) }
 

--- a/client/blocks/reader-post-options-menu/index.jsx
+++ b/client/blocks/reader-post-options-menu/index.jsx
@@ -33,6 +33,7 @@ import { shouldShowConversationFollowButton } from 'blocks/conversation-follow-b
 import {
 	CONVERSATION_FOLLOW_STATUS_FOLLOWING,
 	CONVERSATION_FOLLOW_STATUS_NOT_FOLLOWING,
+	CONVERSATION_FOLLOW_STATUS_MUTING,
 } from 'state/reader/conversations/follow-status';
 
 class ReaderPostOptionsMenu extends React.Component {
@@ -45,6 +46,7 @@ class ReaderPostOptionsMenu extends React.Component {
 		defaultConversationFollowStatus: PropTypes.oneOf( [
 			CONVERSATION_FOLLOW_STATUS_FOLLOWING,
 			CONVERSATION_FOLLOW_STATUS_NOT_FOLLOWING,
+			CONVERSATION_FOLLOW_STATUS_MUTING,
 		] ),
 	};
 


### PR DESCRIPTION
The Conversations stream shows two types of post:
- posts the user has explicitly followed (follow status _F_)
- posts the user has interacted with, and is being shown because of our algorithmic magic (followStatus _null_)

In the Conversations stream, we want to show both of the above as 'followed', giving the user the option to mute the post.

This PR adds a new prop called `defaultConversationFollowStatus` that provides this special behaviour.

### To test

Ensure that, in the Conversations stream, all posts have the 'followed' status unless they've been explicitly unfollowed/muted:

<img width="305" alt="screen shot 2017-11-08 at 17 01 17" src="https://user-images.githubusercontent.com/17325/32562396-760de8a8-c4a6-11e7-802f-1fcb531819ba.png">

Ensure that, outside the Conversations stream (full post, for example), posts only have 'followed' status if you've explicitly followed them.
