### PR TITLE
Comments Redesign: Add the reply action

### DIFF
--- a/client/my-sites/comments/comment/comment-actions.jsx
+++ b/client/my-sites/comments/comment/comment-actions.jsx
@@ -40,6 +40,7 @@ export class CommentActions extends Component {
 	static propTypes = {
 		commentId: PropTypes.number,
 		removeFromPersisted: PropTypes.func,
+		toggleReply: PropTypes.func,
 		updatePersisted: PropTypes.func,
 	};
 
@@ -129,7 +130,7 @@ export class CommentActions extends Component {
 	};
 
 	render() {
-		const { commentIsApproved, commentIsLiked, translate } = this.props;
+		const { commentIsApproved, commentIsLiked, toggleReply, translate } = this.props;
 
 		return (
 			<div className="comment__actions">
@@ -189,6 +190,17 @@ export class CommentActions extends Component {
 					>
 						<Gridicon icon={ commentIsLiked ? 'star' : 'star-outline' } />
 						<span>{ commentIsLiked ? translate( 'Liked' ) : translate( 'Like' ) }</span>
+					</Button>
+				) }
+
+				{ this.hasAction( 'reply' ) && (
+					<Button
+						borderless
+						className="comment__action comment__action-reply"
+						onClick={ toggleReply }
+					>
+						<Gridicon icon="reply" />
+						<span>{ translate( 'Reply' ) }</span>
 					</Button>
 				) }
 			</div>

--- a/client/my-sites/comments/comment/comment-reply.jsx
+++ b/client/my-sites/comments/comment/comment-reply.jsx
@@ -34,12 +34,10 @@ const TEXTAREA_VERTICAL_BORDER = 2;
 export class CommentReply extends Component {
 	static propTypes = {
 		commentId: PropTypes.number,
-		blurReply: PropTypes.func,
-		focusReply: PropTypes.func,
-		hasReplyFocus: PropTypes.bool,
 	};
 
 	state = {
+		hasReplyFocus: false,
 		replyContent: '',
 		textareaHeight: TEXTAREA_HEIGHT_COLLAPSED,
 	};
@@ -51,6 +49,10 @@ export class CommentReply extends Component {
 	}
 
 	storeTextareaRef = textarea => ( this.textarea = textarea );
+
+	blurReply = () => this.setState( { hasReplyFocus: false } );
+
+	focusReply = () => this.setState( { hasReplyFocus: true } );
 
 	calculateTextareaHeight = () => {
 		const textareaHeight = Math.min(
@@ -81,14 +83,14 @@ export class CommentReply extends Component {
 	};
 
 	submitReply = () => {
-		const { approveComment, blurReply, commentStatus, postId, replyToComment, siteId } = this.props;
+		const { approveComment, commentStatus, postId, replyToComment, siteId } = this.props;
 		const { replyContent } = this.state;
 
 		const alsoApprove = 'approved' !== commentStatus;
 
 		replyToComment( replyContent, siteId, postId, { alsoApprove } );
 		this.setState( { replyContent: '' } );
-		blurReply();
+		this.blurReply();
 
 		if ( alsoApprove ) {
 			approveComment( siteId, postId, { previousStatus: commentStatus } );
@@ -102,8 +104,8 @@ export class CommentReply extends Component {
 	};
 
 	render() {
-		const { blurReply, currentUser, focusReply, hasReplyFocus, translate } = this.props;
-		const { replyContent, textareaHeight } = this.state;
+		const { currentUser, translate } = this.props;
+		const { hasReplyFocus, replyContent, textareaHeight } = this.state;
 
 		const hasReplyContent = replyContent.trim().length > 0;
 		// Only show the scrollbar if the textarea content exceeds the max height
@@ -138,9 +140,9 @@ export class CommentReply extends Component {
 					<AutoDirection>
 						<textarea
 							className={ textareaClasses }
-							onBlur={ blurReply }
+							onBlur={ this.blurReply }
 							onChange={ this.updateTextarea }
-							onFocus={ focusReply }
+							onFocus={ this.focusReply }
 							onKeyDown={ this.keyDownHandler }
 							placeholder={ this.getPlaceholder() }
 							ref={ this.storeTextareaRef }

--- a/client/my-sites/comments/comment/comment-reply.jsx
+++ b/client/my-sites/comments/comment/comment-reply.jsx
@@ -34,6 +34,7 @@ const TEXTAREA_VERTICAL_BORDER = 2;
 export class CommentReply extends Component {
 	static propTypes = {
 		commentId: PropTypes.number,
+		isReplyVisible: PropTypes.bool,
 	};
 
 	state = {
@@ -43,7 +44,11 @@ export class CommentReply extends Component {
 	};
 
 	componentDidMount() {
-		if ( this.props.hasReplyFocus ) {
+		this.textarea.focus();
+	}
+
+	componentDidUpdate( prevProps ) {
+		if ( ! prevProps.isReplyVisible && this.props.isReplyVisible ) {
 			this.textarea.focus();
 		}
 	}

--- a/client/my-sites/comments/comment/index.jsx
+++ b/client/my-sites/comments/comment/index.jsx
@@ -36,7 +36,6 @@ export class Comment extends Component {
 	};
 
 	state = {
-		hasReplyFocus: false,
 		isEditMode: false,
 		isExpanded: false,
 	};
@@ -48,10 +47,6 @@ export class Comment extends Component {
 	}
 
 	storeCardRef = card => ( this.commentCard = card );
-
-	blurReply = () => this.setState( { hasReplyFocus: false } );
-
-	focusReply = () => this.setState( { hasReplyFocus: true } );
 
 	keyDownHandler = event => {
 		const { isBulkMode } = this.props;
@@ -95,7 +90,7 @@ export class Comment extends Component {
 			siteId,
 			updatePersisted,
 		} = this.props;
-		const { hasReplyFocus, isEditMode, isExpanded } = this.state;
+		const { isEditMode, isExpanded } = this.state;
 
 		const showActions = isExpanded || ( ! isBulkMode && commentIsPending );
 
@@ -134,13 +129,7 @@ export class Comment extends Component {
 							/>
 						) }
 
-						{ isExpanded && (
-							<CommentReply
-								{ ...{ commentId, hasReplyFocus } }
-								blurReply={ this.blurReply }
-								focusReply={ this.focusReply }
-							/>
-						) }
+						<CommentReply { ...{ commentId } } />
 					</div>
 				) }
 			</Card>

--- a/client/my-sites/comments/comment/index.jsx
+++ b/client/my-sites/comments/comment/index.jsx
@@ -38,6 +38,7 @@ export class Comment extends Component {
 	state = {
 		isEditMode: false,
 		isExpanded: false,
+		isReplyVisible: false,
 	};
 
 	componentWillReceiveProps( nextProps ) {
@@ -71,9 +72,18 @@ export class Comment extends Component {
 
 	toggleExpanded = () => {
 		if ( ! this.props.isLoading && ! this.state.isEditMode ) {
-			this.setState( ( { isExpanded } ) => ( { isExpanded: ! isExpanded } ) );
+			this.setState( ( { isExpanded } ) => ( {
+				isExpanded: ! isExpanded,
+				isReplyVisible: false,
+			} ) );
 		}
 	};
+
+	toggleReply = () =>
+		this.setState( ( { isReplyVisible } ) => ( {
+			isExpanded: true,
+			isReplyVisible: ! isReplyVisible,
+		} ) );
 
 	toggleSelected = () => this.props.toggleSelected( this.props.minimumComment );
 
@@ -90,7 +100,7 @@ export class Comment extends Component {
 			siteId,
 			updatePersisted,
 		} = this.props;
-		const { isEditMode, isExpanded } = this.state;
+		const { isEditMode, isExpanded, isReplyVisible } = this.state;
 
 		const showActions = isExpanded || ( ! isBulkMode && commentIsPending );
 
@@ -100,6 +110,7 @@ export class Comment extends Component {
 			'is-expanded': isExpanded,
 			'is-placeholder': isLoading,
 			'is-pending': commentIsPending,
+			'is-reply-visible': isReplyVisible,
 		} );
 
 		return (
@@ -125,11 +136,12 @@ export class Comment extends Component {
 
 						{ showActions && (
 							<CommentActions
-								{ ...{ commentId, isExpanded, removeFromPersisted, updatePersisted } }
+								{ ...{ commentId, removeFromPersisted, updatePersisted } }
+								toggleReply={ this.toggleReply }
 							/>
 						) }
 
-						<CommentReply { ...{ commentId } } />
+						{ isExpanded && ! isBulkMode && <CommentReply { ...{ commentId, isReplyVisible } } /> }
 					</div>
 				) }
 			</Card>

--- a/client/my-sites/comments/comment/style.scss
+++ b/client/my-sites/comments/comment/style.scss
@@ -356,6 +356,7 @@
 .comment__reply {
 	background: $gray-light;
 	border-top: 1px solid lighten($gray, 30%);
+	display: none;
 	padding: 16px;
 }
 
@@ -528,6 +529,14 @@
 
 	&.is-pending .comment__content {
 		padding-bottom: 16px;
+	}
+}
+
+// Reply Visible
+
+.card.comment.is-reply-visible {
+	.comment__reply {
+		display: block;
 	}
 }
 


### PR DESCRIPTION
This should be deployed before #19560.

Add the Reply action button and introduce some new logics with it:

- The reply textarea focus has been moved entirely in the `CommentReply` component, as it should have been all along, considering it's entirely its responsibility to handle it.

- Introduced a new `isReplyVisible` state and `toggleReply` method in the parent `Comment` component. They take care of toggling the visibility of `CommentReply`.

- `CommentReply` is now always rendered when the comment `isExpanded` and not `isBulkMode`, regardless of its visibility state.
This way, as long as a comment is expanded, the reply textarea content won't disappear.

- Whenever `isReplyVisible` turns into `true`, `CommentReply` appears and the textarea gets focus.

![nov-08-2017 19-05-18](https://user-images.githubusercontent.com/2070010/32569016-d2e0350c-c4b7-11e7-8f94-b5e45ae6e9b9.gif)

### Testing instructions

Checkout this branch and run it with
`env ENABLE_FEATURES=comments/management/m3-design npm start`