### PR TITLE
Framework: Don't serve SSR content to logged in folks

### DIFF
--- a/server/render/index.js
+++ b/server/render/index.js
@@ -1,6 +1,8 @@
 /** @format */
 /**
  * External dependencies
+ *
+ * @format
  */
 
 import ReactDomServer from 'react-dom/server';
@@ -97,7 +99,7 @@ export function serverRender( req, res ) {
 	if (
 		config.isEnabled( 'server-side-rendering' ) &&
 		context.layout &&
-		! context.user &&
+		! context.isLoggedIn &&
 		cacheKey &&
 		isDefaultLocale( context.lang )
 	) {


### PR DESCRIPTION
Prevents a flash of logged out content when hitting /themes and allows react@16 to work.

Needs testing in docker!

This has no effect on local development because we both a) do not bootstap locally and b) the login cookie is not sent to the dev hostname, only `*.wordpress.com`. 

To test this, you must use docker and run as `wpcalypso.wordpress.com`. 

```
npm run build-docker
npm run docker
```

Then hit http://wpcalypso.wordpress.com/themes, unproxied, with a hosts entry, while already logged in. You should not see the logged out variant flash up before the logged in themes page appears. Now try in an incognito window. You should see the logged out themes page and it should have been SSR'd.