### PR TITLE
Noticons: remove from components

### DIFF
--- a/client/components/forms/sortable-list/index.jsx
+++ b/client/components/forms/sortable-list/index.jsx
@@ -10,6 +10,7 @@ import { localize } from 'i18n-calypso';
 import { assign, findIndex, fromPairs, noop } from 'lodash';
 import classNames from 'classnames';
 import debugFactory from 'debug';
+import Gridicon from 'gridicons';
 
 /**
  * Internal dependencies
@@ -328,7 +329,7 @@ class SortableList extends React.Component {
 					disabled={ null === this.state.activeIndex || this.state.activeIndex === 0 }
 				>
 					<span className="screen-reader-text">{ this.props.translate( 'Move previous' ) }</span>
-					<span className="noticon noticon-expand" />
+					<Gridicon icon="chevron-down" size={ 24 } />
 				</button>
 				<button
 					type="button"
@@ -340,7 +341,7 @@ class SortableList extends React.Component {
 					}
 				>
 					<span className="screen-reader-text">{ this.props.translate( 'Move next' ) }</span>
-					<span className="noticon noticon-collapse" />
+					<Gridicon icon="chevron-up" size={ 24 } />
 				</button>
 			</div>
 		);

--- a/client/components/forms/sortable-list/index.scss
+++ b/client/components/forms/sortable-list/index.scss
@@ -76,7 +76,7 @@
 	}
 }
 
-.sortable-list.is-horizontal .sortable-list__navigation-button .noticon {
+.sortable-list.is-horizontal .sortable-list__navigation-button .gridicon {
 	transform: rotate( 90deg ) translateX( 1px );
 }
 
@@ -96,11 +96,6 @@
 	}
 }
 
-.sortable-list.is-vertical .sortable-list__navigation-button .noticon {
+.sortable-list.is-vertical .sortable-list__navigation-button .gridicon {
 	transform: rotate( 180deg ) translateX( 1px );
-}
-
-.sortable-list__navigation-button .noticon {
-	font-size: 24px;
-	font-weight: bold;
 }

--- a/client/components/token-field/style.scss
+++ b/client/components/token-field/style.scss
@@ -146,8 +146,6 @@ input[type="text"].token-field__input {
 .token-field__remove-token {
 	cursor: pointer;
 	border-radius: 0 4px 4px 0;
-	padding: 0 6px;
-	font-size: 10px;
 	color: lighten( $gray, 20% );
 
 	&:hover {

--- a/client/components/token-field/test/__snapshots__/index.jsx.snap
+++ b/client/components/token-field/test/__snapshots__/index.jsx.snap
@@ -19,7 +19,7 @@ exports[`TokenField render should render tokens 1`] = `
         foo
       </span>
       <span
-        class="token-field__remove-token noticon noticon-close-alt"
+        class="token-field__remove-token"
       />
     </span>
     <span
@@ -32,7 +32,7 @@ exports[`TokenField render should render tokens 1`] = `
         bar
       </span>
       <span
-        class="token-field__remove-token noticon noticon-close-alt"
+        class="token-field__remove-token"
       />
     </span>
     <input

--- a/client/components/token-field/test/__snapshots__/index.jsx.snap
+++ b/client/components/token-field/test/__snapshots__/index.jsx.snap
@@ -19,7 +19,7 @@ exports[`TokenField render should render tokens 1`] = `
         foo
       </span>
       <span
-        class="token-field__remove-token"
+        class="token-field__remove-token noticon noticon-close-alt"
       />
     </span>
     <span
@@ -32,7 +32,7 @@ exports[`TokenField render should render tokens 1`] = `
         bar
       </span>
       <span
-        class="token-field__remove-token"
+        class="token-field__remove-token noticon noticon-close-alt"
       />
     </span>
     <input

--- a/client/components/token-field/test/__snapshots__/index.jsx.snap
+++ b/client/components/token-field/test/__snapshots__/index.jsx.snap
@@ -18,9 +18,19 @@ exports[`TokenField render should render tokens 1`] = `
       >
         foo
       </span>
-      <span
-        class="token-field__remove-token noticon noticon-close-alt"
-      />
+      <svg
+        class="gridicon gridicons-cross-small token-field__remove-token"
+        height="24"
+        viewBox="0 0 24 24"
+        width="24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <g>
+          <path
+            d="M17.705 7.705l-1.41-1.41L12 10.59 7.705 6.295l-1.41 1.41L10.59 12l-4.295 4.295 1.41 1.41L12 13.41l4.295 4.295 1.41-1.41L13.41 12l4.295-4.295z"
+          />
+        </g>
+      </svg>
     </span>
     <span
       class="token-field__token"
@@ -31,9 +41,19 @@ exports[`TokenField render should render tokens 1`] = `
       >
         bar
       </span>
-      <span
-        class="token-field__remove-token noticon noticon-close-alt"
-      />
+      <svg
+        class="gridicon gridicons-cross-small token-field__remove-token"
+        height="24"
+        viewBox="0 0 24 24"
+        width="24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <g>
+          <path
+            d="M17.705 7.705l-1.41-1.41L12 10.59 7.705 6.295l-1.41 1.41L10.59 12l-4.295 4.295 1.41 1.41L12 13.41l4.295 4.295 1.41-1.41L13.41 12l4.295-4.295z"
+          />
+        </g>
+      </svg>
     </span>
     <input
       class="token-field__input"

--- a/client/components/token-field/token.jsx
+++ b/client/components/token-field/token.jsx
@@ -7,6 +7,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
+import Gridicon from 'gridicons';
 
 /**
  * Internal dependencies
@@ -50,8 +51,10 @@ export default class extends React.PureComponent {
 				onMouseLeave={ this.props.onMouseLeave }
 			>
 				<span className="token-field__token-text">{ displayTransform( value ) }</span>
-				<span
-					className="token-field__remove-token noticon noticon-close-alt"
+				<Gridicon
+					icon="cross-small"
+					size={ 24 }
+					className="token-field__remove-token"
 					onClick={ ! this.props.disabled && this._onClickRemove }
 				/>
 				{ tooltip && (


### PR DESCRIPTION
Context: noticons is deprecated and this is an effort to remove a few instances.

This PR replaces noticons with gridicons in the components folder, if the noticon is **not** being displayed via css (e.g. :before elements)

I found these components by searching for `noticon` on Github and filtering by jsx files.

No distinguishable visual change.

Components affected:

- [x] Token field (client/components/token-field)
- [x] Sortable list (client/components/forms/sortable-list)

Also, I had to generate a [Jest test file](https://github.com/Automattic/wp-calypso/pull/19614/files#diff-33a4fef655103cb5b1fa08419957c5ee) in the token field component.

What to test:

- [x]  Token field section of [devdocs](https://wpcalypso.wordpress.com/devdocs/design/token-fields) 
- [x]  Adding tags in the editor
- [x]  I think the only way to test the sortable list component is by testing zoninator. I'm still working on testing this.

