### PR TITLE
PostTypeList: Only show duplicate menu item for posts

### DIFF
--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/duplicate.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/duplicate.jsx
@@ -8,7 +8,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { get, includes } from 'lodash';
+import { includes } from 'lodash';
 
 /**
  * Internal dependencies
@@ -25,12 +25,14 @@ function PostActionsEllipsisMenuDuplicate( {
 	translate,
 	canEdit,
 	status,
+	type,
 	duplicateUrl,
 	bumpStat,
 } ) {
 	const validStatus = includes( [ 'draft', 'future', 'pending', 'private', 'publish' ], status );
+	const validType = includes( [ 'post' ], type );
 
-	if ( ! isEnabled( 'posts/post-type-list' ) || ! canEdit || ! validStatus ) {
+	if ( ! isEnabled( 'posts/post-type-list' ) || ! canEdit || ! validStatus || ! validType ) {
 		return null;
 	}
 
@@ -46,6 +48,7 @@ PostActionsEllipsisMenuDuplicate.propTypes = {
 	translate: PropTypes.func.isRequired,
 	canEdit: PropTypes.bool,
 	status: PropTypes.string,
+	type: PropTypes.string,
 	duplicateUrl: PropTypes.string,
 	bumpStat: PropTypes.func,
 };
@@ -59,6 +62,7 @@ const mapStateToProps = ( state, { globalId } ) => {
 	return {
 		canEdit: canCurrentUserEditPost( state, globalId ),
 		status: post.status,
+		type: post.type,
 		duplicateUrl: getEditorDuplicatePostPath( state, post.site_ID, post.ID ),
 	};
 };
@@ -67,7 +71,7 @@ const mapDispatchToProps = { bumpAnalyticsStat };
 
 const mergeProps = ( stateProps, dispatchProps, ownProps ) => {
 	const bumpStat = bumpStatGenerator(
-		get( stateProps, 'type.name' ),
+		stateProps.type,
 		'duplicate',
 		dispatchProps.bumpAnalyticsStat
 	);

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/duplicate.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/duplicate.jsx
@@ -30,9 +30,8 @@ function PostActionsEllipsisMenuDuplicate( {
 	bumpStat,
 } ) {
 	const validStatus = includes( [ 'draft', 'future', 'pending', 'private', 'publish' ], status );
-	const validType = includes( [ 'post' ], type );
 
-	if ( ! isEnabled( 'posts/post-type-list' ) || ! canEdit || ! validStatus || ! validType ) {
+	if ( ! isEnabled( 'posts/post-type-list' ) || ! canEdit || ! validStatus || 'post' !== type ) {
 		return null;
 	}
 


### PR DESCRIPTION
This PR updated the ellipsis menu in `PostTypeList` such that the "Duplicate" option is only visible for posts. Prior to this PR, the option was also available for CPTs, but it did not function correctly.

![image](https://user-images.githubusercontent.com/363749/32576565-ee02709a-c49c-11e7-9d7a-542c82b2cef8.png)

![image](https://user-images.githubusercontent.com/363749/32576602-09c3813e-c49d-11e7-878d-f6206643fe39.png)

To test:

* Visit the "Blog Posts" section. Verify that "Duplicate" appears in the ellipsis menu and functions as normal.
* Visit a CPT page, such as "Testimonials" for a site that has testimonials enabled. Verify that "Duplicate" does _not_ appear in the ellipsis menu.