### PR TITLE
Signup: Add an A/B test for button color change on the post signup landing screen.

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -117,6 +117,15 @@ export default {
 		allowExistingUsers: true,
 		localeTargets: 'any',
 	},
+	buttonsColorOnPostSignup: {
+		datestamp: '20171108',
+		variations: {
+			keep: 50,
+			change: 50,
+		},
+		defaultVariation: 'keep',
+		allowExistingUsers: true,
+	},
 	condensedPostList: {
 		datestamp: '20171113',
 		variations: {

--- a/client/signup/processing-screen/index.jsx
+++ b/client/signup/processing-screen/index.jsx
@@ -19,6 +19,7 @@ import Button from 'components/button';
 import Notice from 'components/notice';
 import analytics from 'lib/analytics';
 import { showOAuth2Layout } from 'state/ui/oauth2-clients/selectors';
+import { abtest } from 'lib/abtest';
 
 export class SignupProcessingScreen extends Component {
 	static propTypes = {
@@ -202,6 +203,7 @@ export class SignupProcessingScreen extends Component {
 
 	renderUpgradeNudge() {
 		const { translate } = this.props;
+		const isVariation = abtest( 'buttonsColorOnPostSignup' ) === 'change';
 
 		/* eslint-disable max-len, wpcalypso/jsx-classname-namespace */
 		return (
@@ -236,6 +238,7 @@ export class SignupProcessingScreen extends Component {
 					{ translate( "Looks like your new online home doesn't have its own domain name." ) }
 				</p>
 				<Button
+					primary={ isVariation }
 					disabled={ ! this.props.loginHandler }
 					className="signup-pricessing__upgrade-button"
 					onClick={ this.handleClickUpgradeButton }
@@ -252,6 +255,7 @@ export class SignupProcessingScreen extends Component {
 		const title = this.props.loginHandler
 			? translate( 'Congratulations! Your site is live.' )
 			: translate( 'Congratulations! Your website is almost ready.' );
+		const isVariation = abtest( 'buttonsColorOnPostSignup' ) === 'change';
 
 		/* eslint-disable max-len, wpcalypso/jsx-classname-namespace */
 		return (
@@ -269,14 +273,14 @@ export class SignupProcessingScreen extends Component {
 
 					{ this.props.loginHandler ? (
 						<Button
-							primary
+							primary={ ! isVariation }
 							className="email-confirmation__button"
 							onClick={ this.props.loginHandler }
 						>
 							{ translate( 'View My Site' ) }
 						</Button>
 					) : (
-						<Button primary disabled className="email-confirmation__button">
+						<Button primary={ ! isVariation } disabled className="email-confirmation__button">
 							{ translate( 'Please wait…' ) }
 						</Button>
 					) }


### PR DESCRIPTION
## Test Plan

1. Run the following code to activate the A/B test.
```
localStorage.setItem( 'ABTests', '{"buttonsColorOnPostSignup_20171108":"change"}' );
```

2. Create a new website on the free plan and see if the two buttons, "View my site" and "Upgrade Plan & Get A Domain", look like as follows:
![desktop-2-up-sell-marketing-approach-switch](https://user-images.githubusercontent.com/212034/32578923-6eb51366-c522-11e7-8434-0441ded85598.jpg)
![mobile-2-up-sell-marketing-approach-switch](https://user-images.githubusercontent.com/212034/32578928-723f28a0-c522-11e7-901b-5fd6130f809c.jpg)

"Upgrade Plan & Get A Domain" button should be blue.

See p9jf6J-3w-p2 for more information.