### PR TITLE
Editor: pass type prop to post-status

### DIFF
--- a/client/post-editor/editor-drawer/index.jsx
+++ b/client/post-editor/editor-drawer/index.jsx
@@ -317,7 +317,7 @@ class EditorDrawer extends Component {
 		// TODO: REDUX - remove this logic and prop for EditPostStatus when date is moved to redux
 		const postDate = get( this.props.post, 'date', null );
 		const postStatus = get( this.props.post, 'status', null );
-		const { translate } = this.props;
+		const { translate, type } = this.props;
 
 		return (
 			<Accordion title={ translate( 'Status' ) } e2eTitle="status">
@@ -330,6 +330,7 @@ class EditorDrawer extends Component {
 					setPostDate={ this.props.setPostDate }
 					site={ this.props.site }
 					status={ postStatus }
+					type={ type }
 					isPostPrivate={ this.props.isPostPrivate }
 					confirmationSidebarStatus={ this.props.confirmationSidebarStatus }
 					selectRevision={ this.props.selectRevision }


### PR DESCRIPTION
### Summary
In part of my recent efforts to improve the post-editor I've introduced a regression and this PR fixes that - this issue was discussed in a related issue @ #18217 ([around here specifically](https://github.com/Automattic/wp-calypso/issues/18217#issuecomment-342997199) ).

Note: I've labeled this as high as there have been a number of reports around it in the past day.

Note: I've tried connecting the `type` value directly in the `EditPostStatus` component but I see errors like so: `error: attempted to update component that has already been unmounted`. This happens purely just by selecting - even without doing anything other than calling the selector.
In the interest of a quick fix I've opted for passing this prop, though it's not an ideal solution.

### Testing
- Select a post to edit (not private, not password protected)
- Open the editor sidebar and look at 'post settings'
- Ensure that the option to make sticky is there