### PR TITLE
Concierge Chats: transform and validate the API response from /concierge/schedules/{id}/shifts.

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -15,9 +15,6 @@
 	"plugins": [
 		"add-module-exports",
 		"syntax-jsx",
-		[ "transform-builtin-extend", {
-			"globals": [ "Error" ]
-		} ],
 		"transform-export-extensions",
 		"transform-react-display-name",
 		"transform-react-jsx",
@@ -31,5 +28,14 @@
 				}
 			}
 		]
-	]
+	],
+	"env": {
+		"test": {
+			"plugins": [
+				[ "transform-builtin-extend", {
+					"globals": [ "Error" ]
+				} ],
+			]
+		}
+	}
 }

--- a/.babelrc
+++ b/.babelrc
@@ -15,6 +15,9 @@
 	"plugins": [
 		"add-module-exports",
 		"syntax-jsx",
+		[ "transform-builtin-extend", {
+			"globals": [ "Error" ]
+		} ],
 		"transform-export-extensions",
 		"transform-react-display-name",
 		"transform-react-jsx",

--- a/client/state/data-layer/wpcom/concierge/schedules/shifts/from-api.js
+++ b/client/state/data-layer/wpcom/concierge/schedules/shifts/from-api.js
@@ -11,7 +11,7 @@ import { get } from 'lodash';
 import { makeParser } from 'state/data-layer/wpcom-http/utils';
 import responseSchema from './schema';
 
-export const transformShift = shift => ( {
+const transformShift = shift => ( {
 	beginTimestamp: get( shift, 'begin_timestamp' ),
 	endTimestamp: get( shift, 'end_timestamp' ),
 	scheduleId: get( shift, 'schedule_id' ),

--- a/client/state/data-layer/wpcom/concierge/schedules/shifts/from-api.js
+++ b/client/state/data-layer/wpcom/concierge/schedules/shifts/from-api.js
@@ -1,7 +1,7 @@
 /** @format */
 
 /**
- * Internal dependenceis
+ * Internal dependencies
  */
 import { makeParser } from 'state/data-layer/wpcom-http/utils';
 import responseSchema from './schema';

--- a/client/state/data-layer/wpcom/concierge/schedules/shifts/from-api.js
+++ b/client/state/data-layer/wpcom/concierge/schedules/shifts/from-api.js
@@ -1,21 +1,16 @@
 /** @format */
 
 /**
- * External dependencies
- */
-import { get } from 'lodash';
-
-/**
  * Internal dependenceis
  */
 import { makeParser } from 'state/data-layer/wpcom-http/utils';
 import responseSchema from './schema';
 
 const transformShift = shift => ( {
-	beginTimestamp: get( shift, 'begin_timestamp' ),
-	endTimestamp: get( shift, 'end_timestamp' ),
-	scheduleId: get( shift, 'schedule_id' ),
-	description: get( shift, 'description' ),
+	beginTimestamp: shift.begin_timestamp,
+	endTimestamp: shift.end_timestamp,
+	scheduleId: shift.schedule_id,
+	description: shift.description,
 } );
 
 export const transform = response => response.map( transformShift );

--- a/client/state/data-layer/wpcom/concierge/schedules/shifts/from-api.js
+++ b/client/state/data-layer/wpcom/concierge/schedules/shifts/from-api.js
@@ -6,7 +6,7 @@
 import { makeParser } from 'state/data-layer/wpcom-http/utils';
 import responseSchema from './schema';
 
-const transformShift = shift => ( {
+export const transformShift = shift => ( {
 	beginTimestamp: shift.begin_timestamp,
 	endTimestamp: shift.end_timestamp,
 	scheduleId: shift.schedule_id,

--- a/client/state/data-layer/wpcom/concierge/schedules/shifts/from-api.js
+++ b/client/state/data-layer/wpcom/concierge/schedules/shifts/from-api.js
@@ -1,0 +1,23 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * Internal dependenceis
+ */
+import { makeParser } from 'state/data-layer/wpcom-http/utils';
+import responseSchema from './schema';
+
+export const transformShift = shift => ( {
+	beginTimestamp: get( shift, 'begin_timestamp' ),
+	endTimestamp: get( shift, 'end_timestamp' ),
+	scheduleId: get( shift, 'schedule_id' ),
+	description: get( shift, 'description' ),
+} );
+
+export const transform = response => response.map( transformShift );
+
+export default makeParser( responseSchema, {}, transform );

--- a/client/state/data-layer/wpcom/concierge/schedules/shifts/index.js
+++ b/client/state/data-layer/wpcom/concierge/schedules/shifts/index.js
@@ -13,6 +13,7 @@ import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { updateConciergeShifts } from 'state/concierge/actions';
 import { errorNotice } from 'state/notices/actions';
 import { CONCIERGE_SHIFTS_REQUEST } from 'state/action-types';
+import fromApi from './from-api';
 
 export const fetchConciergeShifts = ( { dispatch }, action ) => {
 	const { scheduleId } = action;
@@ -43,7 +44,8 @@ export default {
 		dispatchRequest(
 			fetchConciergeShifts,
 			storeFetchedConciergeShifts,
-			showConciergeShiftsFetchError
+			showConciergeShiftsFetchError,
+			{ fromApi }
 		),
 	],
 };

--- a/client/state/data-layer/wpcom/concierge/schedules/shifts/schema.json
+++ b/client/state/data-layer/wpcom/concierge/schedules/shifts/schema.json
@@ -2,6 +2,11 @@
 	"type": "array",
 	"items": {
 		"type": "object",
+		"required": [
+			"begin_timestamp",
+			"end_timestamp",
+			"schedule_id"
+		],
 		"properties": {
 			"begin_timestamp": { "type": "integer" },
 			"end_timestamp": { "type": "integer" },

--- a/client/state/data-layer/wpcom/concierge/schedules/shifts/schema.json
+++ b/client/state/data-layer/wpcom/concierge/schedules/shifts/schema.json
@@ -1,0 +1,12 @@
+{
+	"type": "array",
+	"items": {
+		"type": "object",
+		"properties": {
+			"begin_timestamp": { "type": "integer" },
+			"end_timestamp": { "type": "integer" },
+			"schedule_id": { "type": "integer" },
+			"description": { "type": "string" }
+		}
+	}
+}

--- a/client/state/data-layer/wpcom/concierge/schedules/shifts/test/from-api.js
+++ b/client/state/data-layer/wpcom/concierge/schedules/shifts/test/from-api.js
@@ -1,0 +1,59 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+import { SchemaError } from 'state/data-layer/wpcom-http/utils';
+import fromApi from '../from-api';
+
+describe( 'fromApi()', () => {
+	test( 'should validate and transform the data successfully.', () => {
+		const validResponse = [
+			{
+				begin_timestamp: 100,
+				end_timestamp: 200,
+				schedule_id: 999,
+				description: 'shift 1',
+			},
+			{
+				begin_timestamp: 300,
+				end_timestamp: 400,
+				schedule_id: 999,
+				description: 'shift 2',
+			},
+		];
+
+		const expectedResult = [
+			{
+				beginTimestamp: validResponse[ 0 ].begin_timestamp,
+				endTimestamp: validResponse[ 0 ].end_timestamp,
+				scheduleId: validResponse[ 0 ].schedule_id,
+				description: validResponse[ 0 ].description,
+			},
+			{
+				beginTimestamp: validResponse[ 1 ].begin_timestamp,
+				endTimestamp: validResponse[ 1 ].end_timestamp,
+				scheduleId: validResponse[ 1 ].schedule_id,
+				description: validResponse[ 1 ].description,
+			},
+		];
+		expect( fromApi( validResponse ) ).toEqual( expectedResult );
+	} );
+
+	test( 'should invalidate unexpected field types.', () => {
+		const invalidateCall = () => {
+			const invalidFieldTypes = [
+				{
+					begin_timestamp: 'haha',
+					end_timestamp: 200,
+					schedule_id: null,
+					description: 'so wrong',
+				},
+			];
+
+			fromApi( invalidFieldTypes );
+		};
+
+		expect( invalidateCall ).toThrowError( SchemaError );
+	} );
+} );

--- a/client/state/data-layer/wpcom/concierge/schedules/shifts/test/from-api.js
+++ b/client/state/data-layer/wpcom/concierge/schedules/shifts/test/from-api.js
@@ -56,4 +56,52 @@ describe( 'fromApi()', () => {
 
 		expect( invalidateCall ).toThrowError( SchemaError );
 	} );
+
+	test( 'should invalidate missing begin_timestamp.', () => {
+		const invalidateMissingBeginTimestamp = () => {
+			const invalidResponse = [
+				{
+					end_timestamp: 400,
+					schedule_id: 999,
+					description: 'wrong',
+				},
+			];
+
+			fromApi( invalidResponse );
+		};
+
+		expect( invalidateMissingBeginTimestamp ).toThrowError( SchemaError );
+	} );
+
+	test( 'should invalidate missing end_timestamp.', () => {
+		const invalidateMissingEndTimestamp = () => {
+			const invalidResponse = [
+				{
+					begin_timestamp: 'haha',
+					schedule_id: 999,
+					description: 'wrong',
+				},
+			];
+
+			fromApi( invalidResponse );
+		};
+
+		expect( invalidateMissingEndTimestamp ).toThrowError( SchemaError );
+	} );
+
+	test( 'should invalidate missing schedule_id.', () => {
+		const invalidateMissingScheduleId = () => {
+			const invalidResponse = [
+				{
+					begin_timestamp: 'haha',
+					end_timestamp: 400,
+					description: 'wrong',
+				},
+			];
+
+			fromApi( invalidResponse );
+		};
+
+		expect( invalidateMissingScheduleId ).toThrowError( SchemaError );
+	} );
 } );

--- a/client/state/data-layer/wpcom/concierge/schedules/shifts/test/from-api.js
+++ b/client/state/data-layer/wpcom/concierge/schedules/shifts/test/from-api.js
@@ -4,7 +4,26 @@
  * Internal dependencies
  */
 import { SchemaError } from 'state/data-layer/wpcom-http/utils';
-import fromApi from '../from-api';
+import fromApi, { transformShift } from '../from-api';
+
+describe( 'transformShift()', () => {
+	test( 'should pick out expected fields and make the keys camelCase.', () => {
+		const mockShift = {
+			begin_timestamp: 100,
+			end_timestamp: 200,
+			schedule_id: 999,
+			description: 'an example',
+			not_going_to_take_this: 'should ignore this one',
+		};
+
+		expect( transformShift( mockShift ) ).toEqual( {
+			beginTimestamp: mockShift.begin_timestamp,
+			endTimestamp: mockShift.end_timestamp,
+			scheduleId: mockShift.schedule_id,
+			description: mockShift.description,
+		} );
+	} );
+} );
 
 describe( 'fromApi()', () => {
 	test( 'should validate and transform the data successfully.', () => {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "babel-loader": "7.1.1",
     "babel-plugin-add-module-exports": "0.2.1",
     "babel-plugin-syntax-jsx": "6.18.0",
+    "babel-plugin-transform-builtin-extend": "1.1.2",
     "babel-plugin-transform-class-properties": "6.24.1",
     "babel-plugin-transform-export-extensions": "6.22.0",
     "babel-plugin-transform-imports": "1.4.1",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "babel-loader": "7.1.1",
     "babel-plugin-add-module-exports": "0.2.1",
     "babel-plugin-syntax-jsx": "6.18.0",
-    "babel-plugin-transform-builtin-extend": "1.1.2",
     "babel-plugin-transform-class-properties": "6.24.1",
     "babel-plugin-transform-export-extensions": "6.22.0",
     "babel-plugin-transform-imports": "1.4.1",
@@ -242,6 +241,7 @@
   "devDependencies": {
     "5to6-codemod": "5to6/5to6-codemod#v1.7.0",
     "babel-eslint": "6.1.2",
+    "babel-plugin-transform-builtin-extend": "1.1.2",
     "cash-touch": "0.2.0",
     "chai": "3.5.0",
     "chai-enzyme": "1.0.0-beta.0",


### PR DESCRIPTION
## Summary
This PR adds `fromApi` module which validates and transforms the response from the `GET /concierge/schedules/{id}/shifts` endpoint. 

* Transform the snake case keys to camel case ones. e.g. `begin_timestamp` => `beginTimestamp`.
* Add the schema to validate each field is in the expected type.
* Introduce the babel plugin, `babel-plugin-transform-builtin-extend`, so that we can test if the validator throws the expected custom error type on failing. The reason that we need it to test properly can be found in the discussion facebook/jest#2123(toThrowError not working with custom errors and Babel) and exercism/ecmascript#280(Custom Exceptions are confusing).

## Test Plan
`npm run test-client concierge` should pass.