### PR TITLE
Store Promotions: Add free shipping

### DIFF
--- a/client/extensions/woocommerce/app/promotions/fields/checkbox-field.js
+++ b/client/extensions/woocommerce/app/promotions/fields/checkbox-field.js
@@ -1,0 +1,46 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import PropTypes from 'prop-types';
+import { omit } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import FormCheckbox from 'components/forms/form-checkbox';
+import FormField from './form-field';
+
+const CheckboxField = ( props ) => {
+	const { fieldName, explanationText, placeholderText, value, edit } = props;
+	const renderedValue = ( 'undefined' !== typeof value ? value : false );
+
+	const onChange = () => {
+		edit( fieldName, ! value );
+	};
+
+	return (
+		<FormField { ...omit( props, 'explanationText' ) } >
+			<FormCheckbox
+				id={ fieldName + '-label' }
+				aria-describedby={ explanationText && fieldName + '-description' }
+				checked={ renderedValue }
+				placeholder={ placeholderText }
+				onChange={ onChange }
+			/>
+			<span>
+				{ explanationText }
+			</span>
+		</FormField>
+	);
+};
+
+CheckboxField.PropTypes = {
+	fieldName: PropTypes.string.isRequired,
+	explanationText: PropTypes.string,
+	placeholderText: PropTypes.string,
+	value: PropTypes.bool,
+	edit: PropTypes.func.isRequired,
+};
+
+export default CheckboxField;

--- a/client/extensions/woocommerce/app/promotions/helpers.js
+++ b/client/extensions/woocommerce/app/promotions/helpers.js
@@ -19,6 +19,8 @@ export function isValidPromotion( promotion ) {
 		case 'fixed_product':
 			const validFixedDiscount = promotion.fixedDiscount && promotion.fixedDiscount > 0;
 			return validCouponCode && validFixedDiscount;
+		case 'free_shipping':
+			return validCouponCode;
 		default:
 			return false;
 	}

--- a/client/extensions/woocommerce/app/promotions/promotion-form-type-card.js
+++ b/client/extensions/woocommerce/app/promotions/promotion-form-type-card.js
@@ -23,6 +23,8 @@ function getExplanation( promotionType, translate ) {
 			return translate( 'Issue a coupon with a discount for the entire cart amount.' );
 		case 'percent':
 			return translate( 'Issue a coupon with a percentage discount for the entire cart.' );
+		case 'free_shipping':
+			return translate( 'Issue a free shipping coupon.' );
 	}
 }
 
@@ -55,6 +57,9 @@ const PromotionFormTypeCard = ( {
 					</option>
 					<option value="percent" disabled={ couponTypesDisabled }>
 						{ translate( 'Percent cart discount coupon' ) }
+					</option>
+					<option value="free_shipping" disabled={ couponTypesDisabled }>
+						{ translate( 'Free shipping' ) }
 					</option>
 					<option value="product_sale" disabled={ productTypesDisabled }>
 						{ translate( 'Individual product sale' ) }

--- a/client/extensions/woocommerce/app/promotions/promotion-models.js
+++ b/client/extensions/woocommerce/app/promotions/promotion-models.js
@@ -7,6 +7,7 @@ import { translate } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import CheckboxField from './fields/checkbox-field';
 import CurrencyField from './fields/currency-field';
 import DateField from './fields/date-field';
 import FormField from './fields/form-field';
@@ -26,6 +27,17 @@ const couponCodeField = {
 	),
 	placeholderText: translate( 'Enter coupon code' ),
 	isRequired: true,
+};
+
+/**
+ * "Free shipping" field, reused for all coupon prompotion types.
+ */
+const freeShippingField = {
+	component: CheckboxField,
+	labelText: translate( 'Free shipping' ),
+	explanationText: translate(
+		'This coupon also provides free shipping'
+	),
 };
 
 /**
@@ -217,6 +229,7 @@ const fixedProductModel = {
 				...fixedDiscountField,
 				labelText: translate( 'Product Discount', { context: 'noun' } )
 			},
+			freeShipping: freeShippingField,
 		},
 	},
 	conditions: couponConditions,
@@ -236,6 +249,7 @@ const fixedCartModel = {
 				...fixedDiscountField,
 				labelText: translate( 'Cart Discount', { context: 'noun' } ),
 			},
+			freeShipping: freeShippingField,
 		},
 	},
 	conditions: couponConditions,
@@ -256,6 +270,19 @@ const percentCartModel = {
 				labelText: translate( 'Percent Cart Discount', { context: 'noun' } ),
 				isRequired: true,
 			},
+			freeShipping: freeShippingField,
+		},
+	},
+	conditions: couponConditions,
+};
+
+const freeShippingModel = {
+	appliesWhenCoupon,
+	couponCode: {
+		labelText: translate( 'Coupon' ),
+		cssClass: 'promotions__promotion-form-card-primary',
+		fields: {
+			couponCode: couponCodeField,
 		},
 	},
 	conditions: couponConditions,
@@ -271,4 +298,5 @@ export default {
 	fixed_product: fixedProductModel,
 	fixed_cart: fixedCartModel,
 	percent: percentCartModel,
+	free_shipping: freeShippingModel,
 };

--- a/client/extensions/woocommerce/app/promotions/promotions-list-row.js
+++ b/client/extensions/woocommerce/app/promotions/promotions-list-row.js
@@ -25,6 +25,8 @@ function getPromotionTypeText( promotionType, translate ) {
 			return translate( 'Percent cart discount coupon' );
 		case 'product_sale':
 			return translate( 'Individual product sale' );
+		case 'free_shipping':
+			return translate( 'Free shipping' );
 	}
 }
 

--- a/client/extensions/woocommerce/state/sites/promotions/handlers.js
+++ b/client/extensions/woocommerce/state/sites/promotions/handlers.js
@@ -91,6 +91,7 @@ export function promotionCreate( { dispatch }, action ) {
 		case 'fixed_cart':
 		case 'fixed_product':
 		case 'percent':
+		case 'free_shipping':
 			const coupon = createCouponUpdateFromPromotion( promotion );
 			dispatch( createCoupon( siteId, coupon, action.successAction, action.failureAction ) );
 			break;
@@ -112,6 +113,7 @@ export function promotionUpdate( { dispatch }, action ) {
 		case 'fixed_cart':
 		case 'fixed_product':
 		case 'percent':
+		case 'free_shipping':
 			const coupon = createCouponUpdateFromPromotion( promotion );
 			dispatch( updateCoupon( siteId, coupon, action.successAction, action.failureAction ) );
 			break;
@@ -130,6 +132,7 @@ export function promotionDelete( { dispatch }, action ) {
 		case 'fixed_cart':
 		case 'fixed_product':
 		case 'percent':
+		case 'free_shipping':
 			dispatch(
 				deleteCoupon( siteId, promotion.couponId, action.successAction, action.failureAction )
 			);


### PR DESCRIPTION
This adds both free shipping as an add-on to coupon-type promotions,
and a pseudo coupon type for free shipping.

To Test:
* Edit existing coupon-based promotion and add free shipping option.
* Create new free shipping promotion.
* Go to promotions page and hit refresh to ensure new free shipping promotion is loading correctly.
* Update existing free shipping promotion (add condition, etc.)

![promotions_ _coderkevin_ _wordpress_com](https://user-images.githubusercontent.com/945228/32588942-765ac728-c4d7-11e7-8314-446b36455235.png)

![edit_promotion_ _coderkevin_ _wordpress_com](https://user-images.githubusercontent.com/945228/32588955-902d31ea-c4d7-11e7-8a04-61feb45a3159.png)

![edit_promotion_ _coderkevin_ _wordpress_com](https://user-images.githubusercontent.com/945228/32588975-b2c8b2a6-c4d7-11e7-98d7-8a4fd4f133ed.png)
