### PR TITLE
Concierge Chats: Set up UI scaffolding for wizard

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -263,6 +263,7 @@
 @import 'me/application-password-item/style';
 @import 'me/application-passwords/style';
 @import 'me/billing-history/style';
+@import 'me/concierge/style';
 @import 'me/connected-application-item/style';
 @import 'me/connected-applications/style';
 @import 'me/connected-application-icon/style';

--- a/client/me/concierge/calendar-card.js
+++ b/client/me/concierge/calendar-card.js
@@ -1,0 +1,109 @@
+/** @format */
+
+/**
+ * CalendarCard represents a day of schedulable concierge chats. Each card is expandable to
+ * allow the user to select a specific time on the day. If the day has no availability, it will
+ * not be expandable. When you stack a group of these cards together you'll get the scheduling
+ * calendar view.
+ */
+
+/**
+ * External dependencies
+ */
+import Gridicon from 'gridicons';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { isEmpty } from 'lodash';
+import { localize, moment } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Button from 'components/button';
+import FoldableCard from 'components/foldable-card';
+import FormFieldset from 'components/forms/form-fieldset';
+import FormLabel from 'components/forms/form-label';
+import FormSelect from 'components/forms/form-select';
+import FormSettingExplanation from 'components/forms/form-setting-explanation';
+
+class CalendarCard extends Component {
+	static propTypes = {
+		date: PropTypes.number.isRequired,
+		onSubmit: PropTypes.func.isRequired,
+		times: PropTypes.arrayOf( PropTypes.number ).isRequired,
+	};
+
+	/**
+	 * Returns a string representing the day of the week, with certain dates using natural
+	 * language like "Today" or "Tomorrow" instead of the name of the day.
+	 *
+	 * @param {Number} date Timestamp of the date
+	 * @returns {String} The name for the day of the week
+	 */
+	getDayOfWeekString = date => {
+		const { translate } = this.props;
+		const today = moment().startOf( 'day' );
+		const dayOffset = today.diff( date.startOf( 'day' ), 'days' );
+
+		switch ( dayOffset ) {
+			case 0:
+				return translate( 'Today' );
+			case -1:
+				return translate( 'Tomorrow' );
+		}
+		return date.format( 'dddd' );
+	};
+
+	renderHeader = () => {
+		// The "Header" is that part of the foldable card that you click on to expand it.
+		const date = moment( this.props.date );
+
+		return (
+			<div className="concierge__calendar-card-header">
+				<Gridicon icon="calendar" className="concierge__calendar-card-header-icon" />
+				<span>
+					<b>{ this.getDayOfWeekString( date ) } —</b> { date.format( ' MMMM D' ) }
+				</span>
+			</div>
+		);
+	};
+
+	render() {
+		const { times, translate } = this.props;
+
+		return (
+			<FoldableCard
+				className="concierge__calendar-card"
+				clickableHeader={ ! isEmpty( times ) }
+				compact
+				disabled={ isEmpty( times ) }
+				summary={ isEmpty( times ) ? translate( 'No sessions available' ) : null }
+				header={ this.renderHeader() }
+			>
+				<FormFieldset>
+					<FormLabel htmlFor="concierge-start-time">
+						{ translate( 'Choose a starting time' ) }
+					</FormLabel>
+					<FormSelect id="concierge-start-time">
+						{ times.map( time => (
+							<option value={ time } key={ time }>
+								{ moment( time ).format( 'h:mma z' ) }
+							</option>
+						) ) }
+					</FormSelect>
+					<FormSettingExplanation>
+						{ translate( 'Sessions are 30 minutes long.' ) }
+					</FormSettingExplanation>
+				</FormFieldset>
+
+				<FormFieldset>
+					<Button primary onClick={ this.props.onSubmit }>
+						{ translate( 'Book this session' ) }
+					</Button>
+				</FormFieldset>
+			</FoldableCard>
+		);
+	}
+}
+
+export default localize( CalendarCard );

--- a/client/me/concierge/calendar-step.js
+++ b/client/me/concierge/calendar-step.js
@@ -1,0 +1,37 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+
+/**
+ * Internal dependencies
+ */
+import Button from 'components/button';
+import CompactCard from 'components/card/compact';
+import HeaderCake from 'components/header-cake';
+
+class CalendarStep extends Component {
+	static propTypes = {
+		onBack: PropTypes.func.isRequired,
+		onComplete: PropTypes.func.isRequired,
+	};
+
+	render() {
+		return (
+			<div>
+				<HeaderCake onClick={ this.props.onBack } />
+				<CompactCard>Here is the second step where the customer picks a date</CompactCard>
+				<CompactCard>
+					<Button primary onClick={ this.props.onComplete }>
+						Book this session
+					</Button>
+				</CompactCard>
+			</div>
+		);
+	}
+}
+
+export default CalendarStep;

--- a/client/me/concierge/calendar-step.js
+++ b/client/me/concierge/calendar-step.js
@@ -3,15 +3,48 @@
 /**
  * External dependencies
  */
-import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-
+import React, { Component } from 'react';
+import { localize, moment } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import Button from 'components/button';
+import CalendarCard from './calendar-card';
 import CompactCard from 'components/card/compact';
 import HeaderCake from 'components/header-cake';
+
+const generateMockData = () => {
+	// This is a temporary function to simulate the data that will be gathered from Redux.
+	// It's hard-coded to show some of the UI, e.g. what it looks like on a day with no
+	// available times.
+	const today = moment().startOf( 'day' );
+	const tomorrow = moment( today ).add( 1, 'day' );
+	const nextDay = moment( today ).add( 2, 'days' );
+
+	return [
+		{
+			date: today.valueOf(),
+			times: [
+				today.set( { hour: 9, minute: 30 } ).valueOf(),
+				today.set( { hour: 10, minute: 15 } ).valueOf(),
+				today.set( { hour: 21, minute: 0 } ).valueOf(),
+			],
+		},
+		{
+			date: tomorrow.valueOf(),
+			times: [],
+		},
+		{
+			date: nextDay.valueOf(),
+			times: [
+				nextDay.set( { hour: 7, minute: 0 } ).valueOf(),
+				nextDay.set( { hour: 7, minute: 45 } ).valueOf(),
+				nextDay.set( { hour: 8, minute: 0 } ).valueOf(),
+				nextDay.set( { hour: 13, minute: 15 } ).valueOf(),
+			],
+		},
+	];
+};
 
 class CalendarStep extends Component {
 	static propTypes = {
@@ -20,18 +53,29 @@ class CalendarStep extends Component {
 	};
 
 	render() {
+		const { translate } = this.props;
+		// TODO: Replace mock data with data from Redux
+		const availability = generateMockData();
+
 		return (
 			<div>
-				<HeaderCake onClick={ this.props.onBack } />
-				<CompactCard>Here is the second step where the customer picks a date</CompactCard>
+				<HeaderCake onClick={ this.props.onBack }>
+					{ translate( 'Choose Concierge Session' ) }
+				</HeaderCake>
 				<CompactCard>
-					<Button primary onClick={ this.props.onComplete }>
-						Book this session
-					</Button>
+					{ translate( 'Please select a day to have your Concierge session.' ) }
 				</CompactCard>
+				{ availability.map( ( { date, times } ) => (
+					<CalendarCard
+						date={ date }
+						times={ times }
+						onSubmit={ this.props.onComplete }
+						key={ date }
+					/>
+				) ) }
 			</div>
 		);
 	}
 }
 
-export default CalendarStep;
+export default localize( CalendarStep );

--- a/client/me/concierge/confirmation-step.js
+++ b/client/me/concierge/confirmation-step.js
@@ -1,0 +1,30 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import Button from 'components/button';
+import Card from 'components/card';
+import FormattedHeader from 'components/formatted-header';
+
+class ConfirmationStep extends Component {
+	render() {
+		// TODO: Send Button back to site's dashboard
+		return (
+			<Card>
+				<FormattedHeader
+					headerText="Your Concierge session is booked!"
+					subHeaderText="We will send you an email with information on how to get prepared"
+				/>
+				<Button href="/">Back to your dashboard</Button>
+			</Card>
+		);
+	}
+}
+
+export default ConfirmationStep;

--- a/client/me/concierge/info-step.js
+++ b/client/me/concierge/info-step.js
@@ -1,0 +1,36 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+
+/**
+ * Internal dependencies
+ */
+import Button from 'components/button';
+import CompactCard from 'components/card/compact';
+import PrimaryHeader from './primary-header';
+
+class InfoStep extends Component {
+	static propTypes = {
+		onSubmit: PropTypes.func.isRequired,
+	};
+
+	render() {
+		return (
+			<div>
+				<PrimaryHeader />
+				<CompactCard>
+					Here is the first step where the customer gives us their information
+				</CompactCard>
+				<CompactCard>
+					<Button onClick={ this.props.onComplete }>Continue to calendar</Button>
+				</CompactCard>
+			</div>
+		);
+	}
+}
+
+export default InfoStep;

--- a/client/me/concierge/info-step.js
+++ b/client/me/concierge/info-step.js
@@ -15,7 +15,7 @@ import PrimaryHeader from './primary-header';
 
 class InfoStep extends Component {
 	static propTypes = {
-		onSubmit: PropTypes.func.isRequired,
+		onComplete: PropTypes.func.isRequired,
 	};
 
 	render() {

--- a/client/me/concierge/main.js
+++ b/client/me/concierge/main.js
@@ -12,6 +12,7 @@ import { connect } from 'react-redux';
 import CalendarStep from './calendar-step';
 import ConfirmationStep from './confirmation-step';
 import InfoStep from './info-step';
+import Main from 'components/main';
 import Skeleton from './skeleton';
 import QueryConciergeShifts from 'components/data/query-concierge-shifts';
 import { getConciergeShifts } from 'state/selectors';
@@ -43,7 +44,7 @@ class ConciergeMain extends Component {
 		// 1. pass in the real scheduleId for WP.com concierge schedule.
 		// 2. render the shifts for real.
 		return (
-			<div>
+			<Main>
 				<QueryConciergeShifts scheduleId={ 123 } />
 				{ shifts ? (
 					<CurrentStep
@@ -54,7 +55,7 @@ class ConciergeMain extends Component {
 				) : (
 					<Skeleton />
 				) }
-			</div>
+			</Main>
 		);
 	}
 }

--- a/client/me/concierge/main.js
+++ b/client/me/concierge/main.js
@@ -5,16 +5,38 @@
  */
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
+import CalendarStep from './calendar-step';
+import ConfirmationStep from './confirmation-step';
+import InfoStep from './info-step';
+import Skeleton from './skeleton';
 import QueryConciergeShifts from 'components/data/query-concierge-shifts';
 import { getConciergeShifts } from 'state/selectors';
 
+const STEP_COMPONENTS = [ InfoStep, CalendarStep, ConfirmationStep ];
+
 class ConciergeMain extends Component {
+	constructor( props ) {
+		super( props );
+
+		this.state = {
+			currentStep: 0,
+		};
+	}
+
+	goToPreviousStep = () => {
+		this.setState( { currentStep: this.state.currentStep - 1 } );
+	};
+
+	goToNextStep = () => {
+		this.setState( { currentStep: this.state.currentStep + 1 } );
+	};
+
 	render() {
+		const CurrentStep = STEP_COMPONENTS[ this.state.currentStep ];
 		const { shifts } = this.props;
 
 		// TODO:
@@ -23,7 +45,15 @@ class ConciergeMain extends Component {
 		return (
 			<div>
 				<QueryConciergeShifts scheduleId={ 123 } />
-				<div>{ JSON.stringify( shifts ) }</div>
+				{ shifts ? (
+					<CurrentStep
+						shifts={ shifts }
+						onComplete={ this.goToNextStep }
+						onBack={ this.goToPreviousStep }
+					/>
+				) : (
+					<Skeleton />
+				) }
 			</div>
 		);
 	}
@@ -34,4 +64,4 @@ export default connect(
 		shifts: getConciergeShifts( state ),
 	} ),
 	{ getConciergeShifts }
-)( localize( ConciergeMain ) );
+)( ConciergeMain );

--- a/client/me/concierge/main.js
+++ b/client/me/concierge/main.js
@@ -1,6 +1,17 @@
 /** @format */
 
 /**
+ * This renders the Concierge Chats scheduling page. It is a "wizard" interface with three steps.
+ * Each step is a separate component that calls `onComplete` when the step is complete or `onBack`
+ * if the user requests to go back. This component uses those callbacks to keep track of the current
+ * step and render it.
+ *
+ * This is still a work in progress and right now it just sets up step navigation. Fetching full data
+ * and doing actual work will come later, at which point we'll determine how the step components will
+ * gather the data they need.
+ */
+
+/**
  * External dependencies
  */
 import React, { Component } from 'react';

--- a/client/me/concierge/primary-header.js
+++ b/client/me/concierge/primary-header.js
@@ -13,7 +13,6 @@ import FormattedHeader from 'components/formatted-header';
 
 class PrimaryHeader extends Component {
 	render() {
-		// TODO: Localize
 		return (
 			<Card>
 				<FormattedHeader

--- a/client/me/concierge/primary-header.js
+++ b/client/me/concierge/primary-header.js
@@ -1,0 +1,28 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import Card from 'components/card';
+import FormattedHeader from 'components/formatted-header';
+
+class PrimaryHeader extends Component {
+	render() {
+		// TODO: Localize
+		return (
+			<Card>
+				<FormattedHeader
+					headerText="WordPress.com Business Site Setup"
+					subHeaderText="In this 30 minute session we'll help you get started with your site."
+				/>
+			</Card>
+		);
+	}
+}
+
+export default PrimaryHeader;

--- a/client/me/concierge/skeleton.js
+++ b/client/me/concierge/skeleton.js
@@ -1,0 +1,28 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import CompactCard from 'components/card/compact';
+import PrimaryHeader from './primary-header';
+import SitePlaceholder from 'blocks/site/placeholder';
+
+class Skeleton extends Component {
+	render() {
+		return (
+			<div>
+				<PrimaryHeader />
+				<CompactCard>
+					<SitePlaceholder />
+				</CompactCard>
+			</div>
+		);
+	}
+}
+
+export default Skeleton;

--- a/client/me/concierge/style.scss
+++ b/client/me/concierge/style.scss
@@ -1,0 +1,18 @@
+/** @format */
+
+.concierge__calendar-card.is-expanded {
+	background: lighten($gray, 36%);
+}
+
+.concierge__calendar-card-header {
+	display: flex;
+	align-items: center;
+}
+
+.concierge__calendar-card-header-icon {
+	color: $gray;
+	border: 1px solid lighten($gray, 20%);
+	border-radius: 100%;
+	padding: 6px;
+	margin-right: 12px;
+}

--- a/client/wordpress-com.js
+++ b/client/wordpress-com.js
@@ -66,6 +66,7 @@ const sections = [
 		paths: [ '/me/concierge' ],
 		module: 'me/concierge',
 		group: 'me',
+		secondary: false,
 	},
 	{
 		name: 'media',


### PR DESCRIPTION
Ref: 457-gh-hg / 438-gh-hg

This PR sets up scaffolding for the multi-step wizard customers will use when scheduling Concierge Chats. The purpose is to get a solid framework for the wizard in place so the UI and data calls can be layered in on top.

Each of the three steps is a separate component (plus one "skeleton" view for when data is loading). `<ConciergeMain />` serves as the control center, knowing which step we're currently on and which step to show. Each step will eventually be responsible for handling their own logic, reporting back to `<ConciergeMain />` they're done with the `onComplete` prop, or asking to return a step with the `onBack` callback.

This is still a work in progress so it's not clear yet how the rest of the data should be passed in — either each step along the way will be responsible for gathering its own data from Redux, or all the concierge data will be passed to each component.

![conciergedemo](https://user-images.githubusercontent.com/518059/32590426-f62bc86e-c4df-11e7-9bad-aa02c8f4ee3b.gif)

### How to test

- Load `/me/concierge`
- Initially you should see a flash of the Skeleton screen (loading indicator)
- Once the shifts request completes you should see the first step
- You should be able to click through the three steps, including going back from the second step