### PR TITLE
PostTypeList: Simplify and fix `canCurrentUserEditPost` selector

### DIFF
--- a/client/state/selectors/can-current-user-edit-post.js
+++ b/client/state/selectors/can-current-user-edit-post.js
@@ -9,9 +9,6 @@ import { get } from 'lodash';
  * Internal dependencies
  */
 import { getPost } from 'state/posts/selectors';
-import { getPostType } from 'state/post-types/selectors';
-import { getCurrentUserId, isValidCapability } from 'state/current-user/selectors';
-import { canCurrentUser } from 'state/selectors';
 
 /**
  * Returns whether the current user can edit the post with the given global ID.
@@ -22,19 +19,5 @@ import { canCurrentUser } from 'state/selectors';
  */
 export default function canCurrentUserEditPost( state, globalId ) {
 	const post = getPost( state, globalId );
-	if ( ! post ) {
-		return null;
-	}
-
-	const type = getPostType( state, post.site_ID, post.type );
-	const userId = getCurrentUserId( state );
-	const isAuthor = get( post.author, 'ID' ) === userId;
-
-	let capability = isAuthor ? 'edit_posts' : 'edit_others_posts';
-	const typeCapability = get( type, [ 'capabilities', capability ] );
-	if ( isValidCapability( state, post.site_ID, typeCapability ) ) {
-		capability = typeCapability;
-	}
-
-	return canCurrentUser( state, post.site_ID, capability );
+	return get( post, [ 'capabilities', 'edit_post' ], null );
 }

--- a/client/state/selectors/test/can-current-user-edit-post.js
+++ b/client/state/selectors/test/can-current-user-edit-post.js
@@ -12,10 +12,8 @@ import { canCurrentUserEditPost } from '../';
 
 describe( 'canCurrentUserEditPost()', () => {
 	const fakeGlobalId = 'abcdef1234';
-	const fakeUserId = 1;
-	const fakeOtherUserId = 2;
-	const fakeSiteId = 3;
-	const fakePostId = 4;
+	const fakeSiteId = 1;
+	const fakePostId = 2;
 
 	test( 'should return null if the post is not known', () => {
 		const canEdit = canCurrentUserEditPost(
@@ -31,7 +29,7 @@ describe( 'canCurrentUserEditPost()', () => {
 		expect( canEdit ).to.be.null;
 	} );
 
-	test( "should allow based on 'edit_posts' for unrecognized post type (author)", () => {
+	test( 'should return null if the post capabilities are not known', () => {
 		const canEdit = canCurrentUserEditPost(
 			{
 				posts: {
@@ -44,12 +42,6 @@ describe( 'canCurrentUserEditPost()', () => {
 								if ( postId === fakePostId ) {
 									return {
 										type: 'post',
-										global_ID: fakeGlobalId,
-										site_ID: fakeSiteId,
-										ID: fakePostId,
-										author: {
-											ID: fakeUserId,
-										},
 									};
 								}
 
@@ -57,405 +49,6 @@ describe( 'canCurrentUserEditPost()', () => {
 							},
 						},
 					},
-				},
-				postTypes: {
-					items: {},
-				},
-				currentUser: {
-					id: fakeUserId,
-					capabilities: {
-						[ fakeSiteId ]: {
-							edit_posts: true,
-						},
-					},
-				},
-			},
-			fakeGlobalId
-		);
-
-		expect( canEdit ).to.be.true;
-	} );
-
-	test( "should deny based on 'edit_posts' for unrecognized post type (author)", () => {
-		const canEdit = canCurrentUserEditPost(
-			{
-				posts: {
-					items: {
-						[ fakeGlobalId ]: [ fakeSiteId, fakePostId ],
-					},
-					queries: {
-						[ fakeSiteId ]: {
-							getItem( postId ) {
-								if ( postId === fakePostId ) {
-									return {
-										type: 'post',
-										global_ID: fakeGlobalId,
-										site_ID: fakeSiteId,
-										ID: fakePostId,
-										author: {
-											ID: fakeUserId,
-										},
-									};
-								}
-
-								return null;
-							},
-						},
-					},
-				},
-				postTypes: {
-					items: {},
-				},
-				currentUser: {
-					id: fakeUserId,
-					capabilities: {
-						[ fakeSiteId ]: {
-							edit_posts: false,
-						},
-					},
-				},
-			},
-			fakeGlobalId
-		);
-
-		expect( canEdit ).to.be.false;
-	} );
-
-	test( "should allow based on 'edit_others_posts' for unrecognized post type (not author)", () => {
-		const canEdit = canCurrentUserEditPost(
-			{
-				posts: {
-					items: {
-						[ fakeGlobalId ]: [ fakeSiteId, fakePostId ],
-					},
-					queries: {
-						[ fakeSiteId ]: {
-							getItem( postId ) {
-								if ( postId === fakePostId ) {
-									return {
-										type: 'post',
-										global_ID: fakeGlobalId,
-										site_ID: fakeSiteId,
-										ID: fakePostId,
-										author: {
-											ID: fakeOtherUserId,
-										},
-									};
-								}
-
-								return null;
-							},
-						},
-					},
-				},
-				postTypes: {
-					items: {},
-				},
-				currentUser: {
-					id: fakeUserId,
-					capabilities: {
-						[ fakeSiteId ]: {
-							edit_others_posts: true,
-						},
-					},
-				},
-			},
-			fakeGlobalId
-		);
-
-		expect( canEdit ).to.be.true;
-	} );
-
-	test( "should deny based on 'edit_others_posts' for unrecognized post type (not author)", () => {
-		const canEdit = canCurrentUserEditPost(
-			{
-				posts: {
-					items: {
-						[ fakeGlobalId ]: [ fakeSiteId, fakePostId ],
-					},
-					queries: {
-						[ fakeSiteId ]: {
-							getItem( postId ) {
-								if ( postId === fakePostId ) {
-									return {
-										type: 'post',
-										global_ID: fakeGlobalId,
-										site_ID: fakeSiteId,
-										ID: fakePostId,
-										author: {
-											ID: fakeOtherUserId,
-										},
-									};
-								}
-
-								return null;
-							},
-						},
-					},
-				},
-				postTypes: {
-					items: {},
-				},
-				currentUser: {
-					id: fakeUserId,
-					capabilities: {
-						[ fakeSiteId ]: {
-							edit_others_posts: false,
-						},
-					},
-				},
-			},
-			fakeGlobalId
-		);
-
-		expect( canEdit ).to.be.false;
-	} );
-
-	test( 'should allow based on post type capability (author)', () => {
-		const canEdit = canCurrentUserEditPost(
-			{
-				posts: {
-					items: {
-						[ fakeGlobalId ]: [ fakeSiteId, fakePostId ],
-					},
-					queries: {
-						[ fakeSiteId ]: {
-							getItem( postId ) {
-								if ( postId === fakePostId ) {
-									return {
-										type: 'some_cpt',
-										global_ID: fakeGlobalId,
-										site_ID: fakeSiteId,
-										ID: fakePostId,
-										author: {
-											ID: fakeUserId,
-										},
-									};
-								}
-
-								return null;
-							},
-						},
-					},
-				},
-				postTypes: {
-					items: {
-						[ fakeSiteId ]: {
-							some_cpt: {
-								capabilities: {
-									edit_posts: 'cpt_edit_posts',
-								},
-							},
-						},
-					},
-				},
-				currentUser: {
-					id: fakeUserId,
-					capabilities: {
-						[ fakeSiteId ]: {
-							cpt_edit_posts: true,
-						},
-					},
-				},
-			},
-			fakeGlobalId
-		);
-
-		expect( canEdit ).to.be.true;
-	} );
-
-	test( 'should deny based on post type capability (author)', () => {
-		const canEdit = canCurrentUserEditPost(
-			{
-				posts: {
-					items: {
-						[ fakeGlobalId ]: [ fakeSiteId, fakePostId ],
-					},
-					queries: {
-						[ fakeSiteId ]: {
-							getItem( postId ) {
-								if ( postId === fakePostId ) {
-									return {
-										type: 'some_cpt',
-										global_ID: fakeGlobalId,
-										site_ID: fakeSiteId,
-										ID: fakePostId,
-										author: {
-											ID: fakeUserId,
-										},
-									};
-								}
-
-								return null;
-							},
-						},
-					},
-				},
-				postTypes: {
-					items: {
-						[ fakeSiteId ]: {
-							some_cpt: {
-								capabilities: {
-									edit_posts: 'cpt_edit_posts',
-								},
-							},
-						},
-					},
-				},
-				currentUser: {
-					id: fakeUserId,
-					capabilities: {
-						[ fakeSiteId ]: {
-							cpt_edit_posts: false,
-						},
-					},
-				},
-			},
-			fakeGlobalId
-		);
-
-		expect( canEdit ).to.be.false;
-	} );
-
-	test( 'should allow based on post type capability (not author)', () => {
-		const canEdit = canCurrentUserEditPost(
-			{
-				posts: {
-					items: {
-						[ fakeGlobalId ]: [ fakeSiteId, fakePostId ],
-					},
-					queries: {
-						[ fakeSiteId ]: {
-							getItem( postId ) {
-								if ( postId === fakePostId ) {
-									return {
-										type: 'some_cpt',
-										global_ID: fakeGlobalId,
-										site_ID: fakeSiteId,
-										ID: fakePostId,
-										author: {
-											ID: fakeOtherUserId,
-										},
-									};
-								}
-
-								return null;
-							},
-						},
-					},
-				},
-				postTypes: {
-					items: {
-						[ fakeSiteId ]: {
-							some_cpt: {
-								capabilities: {
-									edit_others_posts: 'cpt_edit_others_posts',
-								},
-							},
-						},
-					},
-				},
-				currentUser: {
-					id: fakeUserId,
-					capabilities: {
-						[ fakeSiteId ]: {
-							cpt_edit_others_posts: true,
-						},
-					},
-				},
-			},
-			fakeGlobalId
-		);
-
-		expect( canEdit ).to.be.true;
-	} );
-
-	test( 'should deny based on post type capability (not author)', () => {
-		const canEdit = canCurrentUserEditPost(
-			{
-				posts: {
-					items: {
-						[ fakeGlobalId ]: [ fakeSiteId, fakePostId ],
-					},
-					queries: {
-						[ fakeSiteId ]: {
-							getItem( postId ) {
-								if ( postId === fakePostId ) {
-									return {
-										type: 'some_cpt',
-										global_ID: fakeGlobalId,
-										site_ID: fakeSiteId,
-										ID: fakePostId,
-										author: {
-											ID: fakeOtherUserId,
-										},
-									};
-								}
-
-								return null;
-							},
-						},
-					},
-				},
-				postTypes: {
-					items: {
-						[ fakeSiteId ]: {
-							some_cpt: {
-								capabilities: {
-									edit_others_posts: 'cpt_edit_others_posts',
-								},
-							},
-						},
-					},
-				},
-				currentUser: {
-					id: fakeUserId,
-					capabilities: {
-						[ fakeSiteId ]: {
-							cpt_edit_others_posts: false,
-						},
-					},
-				},
-			},
-			fakeGlobalId
-		);
-
-		expect( canEdit ).to.be.false;
-	} );
-
-	test( 'should return null for unknown post type and unknown capability', () => {
-		const canEdit = canCurrentUserEditPost(
-			{
-				posts: {
-					items: {
-						[ fakeGlobalId ]: [ fakeSiteId, fakePostId ],
-					},
-					queries: {
-						[ fakeSiteId ]: {
-							getItem( postId ) {
-								if ( postId === fakePostId ) {
-									return {
-										type: 'post',
-										global_ID: fakeGlobalId,
-										site_ID: fakeSiteId,
-										ID: fakePostId,
-										author: {
-											ID: fakeUserId,
-										},
-									};
-								}
-
-								return null;
-							},
-						},
-					},
-				},
-				postTypes: {
-					items: {},
-				},
-				currentUser: {
-					id: fakeUserId,
-					capabilities: {},
 				},
 			},
 			fakeGlobalId
@@ -464,7 +57,7 @@ describe( 'canCurrentUserEditPost()', () => {
 		expect( canEdit ).to.be.null;
 	} );
 
-	test( 'should return null for known post type and unknown capability', () => {
+	test( 'should allow based on the post capabilities', () => {
 		const canEdit = canCurrentUserEditPost(
 			{
 				posts: {
@@ -476,12 +69,9 @@ describe( 'canCurrentUserEditPost()', () => {
 							getItem( postId ) {
 								if ( postId === fakePostId ) {
 									return {
-										type: 'some_cpt',
-										global_ID: fakeGlobalId,
-										site_ID: fakeSiteId,
-										ID: fakePostId,
-										author: {
-											ID: fakeUserId,
+										type: 'post',
+										capabilities: {
+											edit_post: true,
 										},
 									};
 								}
@@ -491,25 +81,41 @@ describe( 'canCurrentUserEditPost()', () => {
 						},
 					},
 				},
-				postTypes: {
+			},
+			fakeGlobalId
+		);
+
+		expect( canEdit ).to.be.true;
+	} );
+
+	test( 'should deny based on the post capabilities', () => {
+		const canEdit = canCurrentUserEditPost(
+			{
+				posts: {
 					items: {
+						[ fakeGlobalId ]: [ fakeSiteId, fakePostId ],
+					},
+					queries: {
 						[ fakeSiteId ]: {
-							some_cpt: {
-								capabilities: {
-									edit_posts: 'cpt_edit_posts',
-								},
+							getItem( postId ) {
+								if ( postId === fakePostId ) {
+									return {
+										type: 'post',
+										capabilities: {
+											edit_post: false,
+										},
+									};
+								}
+
+								return null;
 							},
 						},
 					},
-				},
-				currentUser: {
-					id: fakeUserId,
-					capabilities: {},
 				},
 			},
 			fakeGlobalId
 		);
 
-		expect( canEdit ).to.be.null;
+		expect( canEdit ).to.be.false;
 	} );
 } );


### PR DESCRIPTION
This PR is behind a feature flag for the posts list (`posts/post-type-list`), will affect live code for custom post types, and is part of a larger epic (p8F9tW-vh-p2).

Follow-up to #19550; replaces logic originally introduced in #6434.

When determining whether the current user has access to edit a post in the `PostTypeList`, we should use the `capabilities` property of the post object returned from the API rather than attempting to parse through the site's capabilities logic in Calypso.  The production post list also [uses the post object](https://github.com/Automattic/wp-calypso/blob/55cfcb37ad1ad3c2018585f26a21952e9314f52b/client/lib/posts/utils.js#L73-L81) as suggested in this PR; if using the site `capabilities` object, there are [a lot more cases to handle](https://core.trac.wordpress.org/browser/tags/4.8.3/src/wp-includes/capabilities.php?marks=125-126,157-182#L141) than we were successfully accounting for, and this logic can also be modified by plugins.

One case in which this caused a bug:  users with the Contributor role cannot edit their own posts once they have been published, because they do not have the `edit_published_posts` capability.  This and other cases are accounted for by `post.capabilities.edit_post` being `false`.

The `post.capabilities` object [is present](https://github.com/Automattic/jetpack/blame/f409654b85951da78a95d746d77de38eebe27a23/json-endpoints/class.wpcom-json-api-post-v1-1-endpoint.php#L263) for all API responses going back several years, including CPTs.