### PR TITLE
 PostTypeList: Remove unnecessary instances of `getPostType`

### DIFF
--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/duplicate.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/duplicate.jsx
@@ -1,9 +1,8 @@
+/** @format */
+
 /**
  * External dependencies
- *
- * @format
  */
-
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
@@ -69,12 +68,12 @@ const mapStateToProps = ( state, { globalId } ) => {
 const mapDispatchToProps = { bumpStat, recordTracksEvent };
 
 const mergeProps = ( stateProps, dispatchProps, ownProps ) => {
-	const onDuplicateClick = () => (
-		bumpStatGenerator( stateProps.type, 'duplicate', dispatchProps.bumpStat ),
+	const onDuplicateClick = () => {
+		bumpStatGenerator( stateProps.type, 'duplicate', dispatchProps.bumpStat );
 		dispatchProps.recordTracksEvent( 'calypso_post_type_list_duplicate', {
 			post_type: stateProps.type,
-		} )
-	);
+		} );
+	};
 	return Object.assign( {}, ownProps, stateProps, dispatchProps, { onDuplicateClick } );
 };
 

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/duplicate.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/duplicate.jsx
@@ -68,8 +68,13 @@ const mapStateToProps = ( state, { globalId } ) => {
 const mapDispatchToProps = { bumpStat, recordTracksEvent };
 
 const mergeProps = ( stateProps, dispatchProps, ownProps ) => {
+	const bumpDuplicateStat = bumpStatGenerator(
+		stateProps.type,
+		'duplicate',
+		dispatchProps.bumpStat
+	);
 	const onDuplicateClick = () => {
-		bumpStatGenerator( stateProps.type, 'duplicate', dispatchProps.bumpStat );
+		bumpDuplicateStat();
 		dispatchProps.recordTracksEvent( 'calypso_post_type_list_duplicate', {
 			post_type: stateProps.type,
 		} );

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/edit.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/edit.jsx
@@ -1,14 +1,12 @@
+/** @format */
+
 /**
  * External dependencies
- *
- * @format
  */
-
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -50,6 +48,7 @@ const mapStateToProps = ( state, { globalId } ) => {
 	return {
 		canEdit: canCurrentUserEditPost( state, globalId ),
 		status: post.status,
+		type: post.type,
 		editUrl: getEditorPath( state, post.site_ID, post.ID ),
 	};
 };
@@ -57,11 +56,7 @@ const mapStateToProps = ( state, { globalId } ) => {
 const mapDispatchToProps = { bumpAnalyticsStat };
 
 const mergeProps = ( stateProps, dispatchProps, ownProps ) => {
-	const bumpStat = bumpStatGenerator(
-		get( stateProps, 'type.name' ),
-		'edit',
-		dispatchProps.bumpAnalyticsStat
-	);
+	const bumpStat = bumpStatGenerator( stateProps.type, 'edit', dispatchProps.bumpAnalyticsStat );
 	return Object.assign( {}, ownProps, stateProps, dispatchProps, { bumpStat } );
 };
 

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/index.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/index.jsx
@@ -1,9 +1,8 @@
+/** @format */
+
 /**
  * External dependencies
- *
- * @format
  */
-import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import React, { Children, cloneElement } from 'react';
 
@@ -20,17 +19,8 @@ import PostActionsEllipsisMenuTrash from './trash';
 import PostActionsEllipsisMenuView from './view';
 import PostActionsEllipsisMenuRestore from './restore';
 import PostActionsEllipsisMenuDuplicate from './duplicate';
-import QueryPostTypes from 'components/data/query-post-types';
-import { getPost } from 'state/posts/selectors';
-import { getPostType } from 'state/post-types/selectors';
 
-function PostActionsEllipsisMenu( {
-	globalId,
-	siteId,
-	isKnownType,
-	includeDefaultActions,
-	children,
-} ) {
+export default function PostActionsEllipsisMenu( { globalId, includeDefaultActions, children } ) {
 	let actions = [];
 
 	if ( includeDefaultActions ) {
@@ -57,7 +47,6 @@ function PostActionsEllipsisMenu( {
 
 	return (
 		<div className="post-actions-ellipsis-menu">
-			{ siteId && ! isKnownType && <QueryPostTypes siteId={ siteId } /> }
 			<EllipsisMenu position="bottom left" disabled={ ! globalId }>
 				{ actions.map( action => cloneElement( action, { globalId } ) ) }
 			</EllipsisMenu>
@@ -67,25 +56,9 @@ function PostActionsEllipsisMenu( {
 
 PostActionsEllipsisMenu.propTypes = {
 	globalId: PropTypes.string,
-	siteId: PropTypes.number,
-	isKnownType: PropTypes.bool,
 	includeDefaultActions: PropTypes.bool,
 };
 
 PostActionsEllipsisMenu.defaultProps = {
 	includeDefaultActions: true,
 };
-
-export default connect( ( state, { globalId } ) => {
-	const post = getPost( state, globalId );
-	if ( ! post ) {
-		return {};
-	}
-
-	const type = getPostType( state, post.site_ID, post.type );
-
-	return {
-		siteId: post.site_ID,
-		isKnownType: !! type,
-	};
-} )( PostActionsEllipsisMenu );

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/publish.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/publish.jsx
@@ -1,14 +1,13 @@
+/** @format */
+
 /**
  * External dependencies
- *
- * @format
  */
-
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { get, includes } from 'lodash';
+import { includes } from 'lodash';
 
 /**
  * Internal dependencies
@@ -19,7 +18,6 @@ import { bumpStatGenerator } from './utils';
 import { getPost } from 'state/posts/selectors';
 import { savePost } from 'state/posts/actions';
 import { canCurrentUser } from 'state/selectors';
-import { getPostType } from 'state/post-types/selectors';
 
 class PostActionsEllipsisMenuPublish extends Component {
 	static propTypes = {
@@ -73,21 +71,20 @@ const mapStateToProps = ( state, { globalId } ) => {
 		status: post.status,
 		siteId: post.site_ID,
 		postId: post.ID,
+		type: post.type,
 		canPublish: canCurrentUser( state, post.site_ID, 'publish_posts' ),
-		type: getPostType( state, post.site_ID, post.type ),
 	};
 };
 
 const mapDispatchToProps = { savePost, bumpStat, recordTracksEvent };
 
 const mergeProps = ( stateProps, dispatchProps, ownProps ) => {
-	const postType = get( stateProps, 'type.name' );
-	const onPublishPost = () => (
-		bumpStatGenerator( postType, 'publish', dispatchProps.bumpStat ),
+	const onPublishPost = () => {
+		bumpStatGenerator( stateProps.type, 'publish', dispatchProps.bumpStat );
 		dispatchProps.recordTracksEvent( 'calypso_post_type_list_publish', {
-			post_type: postType,
-		} )
-	);
+			post_type: stateProps.type,
+		} );
+	};
 	return Object.assign( {}, ownProps, stateProps, dispatchProps, { onPublishPost } );
 };
 

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/publish.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/publish.jsx
@@ -79,8 +79,9 @@ const mapStateToProps = ( state, { globalId } ) => {
 const mapDispatchToProps = { savePost, bumpStat, recordTracksEvent };
 
 const mergeProps = ( stateProps, dispatchProps, ownProps ) => {
+	const bumpPublishStat = bumpStatGenerator( stateProps.type, 'publish', dispatchProps.bumpStat );
 	const onPublishPost = () => {
-		bumpStatGenerator( stateProps.type, 'publish', dispatchProps.bumpStat );
+		bumpPublishStat();
 		dispatchProps.recordTracksEvent( 'calypso_post_type_list_publish', {
 			post_type: stateProps.type,
 		} );

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/restore.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/restore.jsx
@@ -1,14 +1,13 @@
+/** @format */
+
 /**
  * External dependencies
  *
- * @format
  */
-
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -20,7 +19,6 @@ import { canCurrentUser } from 'state/selectors';
 import { getPost } from 'state/posts/selectors';
 import { restorePost } from 'state/posts/actions';
 import { getCurrentUserId } from 'state/current-user/selectors';
-import { getPostType } from 'state/post-types/selectors';
 
 class PostActionsEllipsisMenuRestore extends Component {
 	static propTypes = {
@@ -77,23 +75,19 @@ const mapStateToProps = ( state, { globalId } ) => {
 		siteId: post.site_ID,
 		postId: post.ID,
 		status: post.status,
+		type: post.type,
 		canRestore: canCurrentUser(
 			state,
 			post.site_ID,
 			isAuthor ? 'delete_posts' : 'delete_others_posts'
 		),
-		type: getPostType( state, post.site_ID, post.type ),
 	};
 };
 
 const mapDispatchToProps = { restorePost, bumpAnalyticsStat };
 
 const mergeProps = ( stateProps, dispatchProps, ownProps ) => {
-	const bumpStat = bumpStatGenerator(
-		get( stateProps, 'type.name' ),
-		'restore',
-		dispatchProps.bumpAnalyticsStat
-	);
+	const bumpStat = bumpStatGenerator( stateProps.type, 'restore', dispatchProps.bumpAnalyticsStat );
 	return Object.assign( {}, ownProps, stateProps, dispatchProps, { bumpStat } );
 };
 

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/share.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/share.jsx
@@ -1,14 +1,12 @@
+/** @format */
+
 /**
  * External dependencies
- *
- * @format
  */
-
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { get, includes } from 'lodash';
 
 /**
  * Internal dependencies
@@ -26,6 +24,8 @@ class PostActionsEllipsisMenuShare extends Component {
 		globalId: PropTypes.string,
 		translate: PropTypes.func.isRequired,
 		status: PropTypes.string,
+		type: PropTypes.string,
+		isPublicizeEnabled: PropTypes.bool,
 		onClick: PropTypes.func,
 		bumpStat: PropTypes.func,
 	};
@@ -46,7 +46,7 @@ class PostActionsEllipsisMenuShare extends Component {
 		const { translate, status, type, isPublicizeEnabled: isPublicizeEnabledForSite } = this.props;
 		if (
 			! config.isEnabled( 'posts/post-type-list' ) ||
-			! includes( [ 'publish' ], status ) ||
+			'publish' !== status ||
 			! isPublicizeEnabledForSite ||
 			'post' !== type
 		) {
@@ -69,19 +69,15 @@ const mapStateToProps = ( state, { globalId } ) => {
 
 	return {
 		status: post.status,
-		isPublicizeEnabled: isPublicizeEnabled( state, post.site_ID, post.type ),
 		type: post.type,
+		isPublicizeEnabled: isPublicizeEnabled( state, post.site_ID, post.type ),
 	};
 };
 
 const mapDispatchToProps = { toggleSharePanel, bumpAnalyticsStat };
 
 const mergeProps = ( stateProps, dispatchProps, ownProps ) => {
-	const bumpStat = bumpStatGenerator(
-		get( stateProps, 'type.name' ),
-		'share',
-		dispatchProps.bumpAnalyticsStat
-	);
+	const bumpStat = bumpStatGenerator( stateProps.type, 'share', dispatchProps.bumpAnalyticsStat );
 	return Object.assign( {}, ownProps, stateProps, dispatchProps, { bumpStat } );
 };
 

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/share.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/share.jsx
@@ -77,7 +77,11 @@ const mapStateToProps = ( state, { globalId } ) => {
 const mapDispatchToProps = { toggleSharePanel, bumpAnalyticsStat };
 
 const mergeProps = ( stateProps, dispatchProps, ownProps ) => {
-	const bumpStat = bumpStatGenerator( stateProps.type, 'share', dispatchProps.bumpAnalyticsStat );
+	const bumpStat = bumpStatGenerator(
+		stateProps.type,
+		'toggle_share_panel',
+		dispatchProps.bumpAnalyticsStat
+	);
 	return Object.assign( {}, ownProps, stateProps, dispatchProps, { bumpStat } );
 };
 

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/stats.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/stats.jsx
@@ -1,14 +1,12 @@
+/** @format */
+
 /**
  * External dependencies
- *
- * @format
  */
-
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -18,7 +16,6 @@ import { bumpStat as bumpAnalyticsStat } from 'state/analytics/actions';
 import { bumpStatGenerator } from './utils';
 import { getSiteSlug, isJetpackModuleActive } from 'state/sites/selectors';
 import { getPost } from 'state/posts/selectors';
-import { getPostType } from 'state/post-types/selectors';
 
 function PostActionsEllipsisMenuStats( {
 	translate,
@@ -63,19 +60,15 @@ const mapStateToProps = ( state, { globalId } ) => {
 		siteSlug: getSiteSlug( state, post.site_ID ),
 		postId: post.ID,
 		status: post.status,
+		type: post.type,
 		isStatsActive: false !== isJetpackModuleActive( state, post.site_ID, 'stats' ),
-		type: getPostType( state, post.site_ID, post.type ),
 	};
 };
 
 const mapDispatchToProps = { bumpAnalyticsStat };
 
 const mergeProps = ( stateProps, dispatchProps, ownProps ) => {
-	const bumpStat = bumpStatGenerator(
-		get( stateProps, 'type.name' ),
-		'stats',
-		dispatchProps.bumpAnalyticsStat
-	);
+	const bumpStat = bumpStatGenerator( stateProps.type, 'stats', dispatchProps.bumpAnalyticsStat );
 	return Object.assign( {}, ownProps, stateProps, dispatchProps, { bumpStat } );
 };
 

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/trash.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/trash.jsx
@@ -97,14 +97,16 @@ const mapStateToProps = ( state, { globalId } ) => {
 const mapDispatchToProps = { trashPost, deletePost, bumpStat, recordTracksEvent };
 
 const mergeProps = ( stateProps, dispatchProps, ownProps ) => {
+	const bumpTrashStat = bumpStatGenerator( stateProps.type, 'trash', dispatchProps.bumpStat );
 	const onTrashClick = () => {
-		bumpStatGenerator( stateProps.type, 'trash', dispatchProps.bumpStat );
+		bumpTrashStat();
 		dispatchProps.recordTracksEvent( 'calypso_post_type_list_trash', {
 			post_type: stateProps.type,
 		} );
 	};
+	const bumpDeleteStat = bumpStatGenerator( stateProps.type, 'delete', dispatchProps.bumpStat );
 	const onDeleteClick = () => {
-		bumpStatGenerator( stateProps.type, 'delete', dispatchProps.bumpStat );
+		bumpDeleteStat();
 		dispatchProps.recordTracksEvent( 'calypso_post_type_list_delete', {
 			post_type: stateProps.type,
 		} );

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/trash.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/trash.jsx
@@ -1,14 +1,12 @@
+/** @format */
+
 /**
  * External dependencies
- *
- * @format
  */
-
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -20,7 +18,6 @@ import { trashPost, deletePost } from 'state/posts/actions';
 import { canCurrentUser } from 'state/selectors';
 import { getPost } from 'state/posts/selectors';
 import { getCurrentUserId } from 'state/current-user/selectors';
-import { getPostType } from 'state/post-types/selectors';
 
 class PostActionsEllipsisMenuTrash extends Component {
 	static propTypes = {
@@ -65,9 +62,11 @@ class PostActionsEllipsisMenuTrash extends Component {
 
 		return (
 			<PopoverMenuItem onClick={ this.trashPost } icon="trash">
-				{ 'trash' === status
-					? translate( 'Delete Permanently' )
-					: translate( 'Trash', { context: 'verb' } ) }
+				{ 'trash' === status ? (
+					translate( 'Delete Permanently' )
+				) : (
+					translate( 'Trash', { context: 'verb' } )
+				) }
 			</PopoverMenuItem>
 		);
 	}
@@ -86,31 +85,30 @@ const mapStateToProps = ( state, { globalId } ) => {
 		postId: post.ID,
 		siteId: post.site_ID,
 		status: post.status,
+		type: post.type,
 		canDelete: canCurrentUser(
 			state,
 			post.site_ID,
 			isAuthor ? 'delete_posts' : 'delete_others_posts'
 		),
-		type: getPostType( state, post.site_ID, post.type ),
 	};
 };
 
 const mapDispatchToProps = { trashPost, deletePost, bumpStat, recordTracksEvent };
 
 const mergeProps = ( stateProps, dispatchProps, ownProps ) => {
-	const postType = get( stateProps, 'type.name' );
-	const onTrashClick = () => (
-		bumpStatGenerator( postType, 'trash', dispatchProps.bumpStat ),
+	const onTrashClick = () => {
+		bumpStatGenerator( stateProps.type, 'trash', dispatchProps.bumpStat );
 		dispatchProps.recordTracksEvent( 'calypso_post_type_list_trash', {
-			post_type: postType,
-		} )
-	);
-	const onDeleteClick = () => (
-		bumpStatGenerator( postType, 'delete', dispatchProps.bumpStat ),
+			post_type: stateProps.type,
+		} );
+	};
+	const onDeleteClick = () => {
+		bumpStatGenerator( stateProps.type, 'delete', dispatchProps.bumpStat );
 		dispatchProps.recordTracksEvent( 'calypso_post_type_list_delete', {
-			post_type: postType,
-		} )
-	);
+			post_type: stateProps.type,
+		} );
+	};
 	return Object.assign( {}, ownProps, stateProps, dispatchProps, {
 		onTrashClick,
 		onDeleteClick,

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/view.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/view.jsx
@@ -1,14 +1,13 @@
+/** @format */
+
 /**
  * External dependencies
- *
- * @format
  */
-
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { get, includes } from 'lodash';
+import { includes } from 'lodash';
 
 /**
  * Internal dependencies
@@ -17,7 +16,6 @@ import PopoverMenuItem from 'components/popover/menu-item';
 import { bumpStat as bumpAnalyticsStat } from 'state/analytics/actions';
 import { bumpStatGenerator } from './utils';
 import { getPost, getPostPreviewUrl } from 'state/posts/selectors';
-import { getPostType } from 'state/post-types/selectors';
 import { isSitePreviewable } from 'state/sites/selectors';
 import { setAllSitesPreviewSiteId, setPreviewUrl } from 'state/ui/preview/actions';
 import { setLayoutFocus } from 'state/ui/layout-focus/actions';
@@ -71,9 +69,11 @@ class PostActionsEllipsisMenuView extends Component {
 				target="_blank"
 				rel="noopener noreferrer"
 			>
-				{ includes( [ 'publish', 'private' ], status )
-					? translate( 'View', { context: 'verb' } )
-					: translate( 'Preview', { context: 'verb' } ) }
+				{ includes( [ 'publish', 'private' ], status ) ? (
+					translate( 'View', { context: 'verb' } )
+				) : (
+					translate( 'Preview', { context: 'verb' } )
+				) }
 			</PopoverMenuItem>
 		);
 	}
@@ -88,9 +88,9 @@ const mapStateToProps = ( state, { globalId } ) => {
 	return {
 		siteId: post.site_ID,
 		status: post.status,
+		type: post.type,
 		isPreviewable: false !== isSitePreviewable( state, post.site_ID ),
 		previewUrl: getPostPreviewUrl( state, post.site_ID, post.ID ),
-		type: getPostType( state, post.site_ID, post.type ),
 	};
 };
 
@@ -102,11 +102,7 @@ const mapDispatchToProps = {
 };
 
 const mergeProps = ( stateProps, dispatchProps, ownProps ) => {
-	const bumpStat = bumpStatGenerator(
-		get( stateProps, 'type.name' ),
-		'view',
-		dispatchProps.bumpAnalyticsStat
-	);
+	const bumpStat = bumpStatGenerator( stateProps.type, 'view', dispatchProps.bumpAnalyticsStat );
 	return Object.assign( {}, ownProps, stateProps, dispatchProps, { bumpStat } );
 };
 


### PR DESCRIPTION
This PR fixes multiple issues with the generation of stat names in the `PostTypeList` action menu.

We can now remove the `QueryPostTypes` call from `client/my-sites/post-type-list/post-actions-ellipsis-menu/index.jsx`.  The only remaining usage of `QueryPostTypes` in the `PostTypeList` is now in `empty-content.jsx`, where we actually need the post type labels to display custom messages.

In addition, I've updated the stat name from `share` to the more accurate `toggle_share_panel`: this stat represents the share panel being toggled on or off, rather than the actual sharing of a post.

Here is the easiest way to test this PR:

- Visit the posts list for a site that has a published post, a trashed post, a published CPT, and a trashed CPT
- Set `localStorage.debug = 'calypso:posts:*,calypso:analytics:*';` and reload Calypso
- Apply [this patch](https://gist.github.com/nylen/58929e94fc1ae7895bd508938d992be2) to disable all action menu callbacks except for toggling the sharing panel:
```sh
curl https://gist.githubusercontent.com/nylen/58929e94fc1ae7895bd508938d992be2/raw/8dc65828fb5671720b5955ddd86a4be4bf616387/post-type-list-disable-menu-callbacks.diff | git apply
```
- For each of (a published post, a trashed post, a published CPT, and a trashed CPT), click each item in the ellipsis menu and verify that the appropriate stat is bumped.  When clicking Delete, verify that the stat is only bumped if you click `OK` on the confirmation dialog.  As long as you have applied the patch above, the post will not actually be deleted.