### PR TITLE
TinyMCE: Use React.PureComponent for the WPcom View Plugin

### DIFF
--- a/client/components/tinymce/plugins/wpcom-view/resizable-view.jsx
+++ b/client/components/tinymce/plugins/wpcom-view/resizable-view.jsx
@@ -1,12 +1,9 @@
+/** @format */
 /**
  * External dependencies
- *
- * @format
  */
-
+import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import React from 'react';
-import PureComponent from 'react-pure-render/component';
 
 export default function( Component ) {
 	const componentName = Component.displayName || Component.name || '';


### PR DESCRIPTION
This was the only occurrence of `react-pure-render/component` I could find in our codebase.