### PR TITLE
PrivacyPolicy-TOS: handle new users

### DIFF
--- a/client/blocks/privacy-policy-banner/index.jsx
+++ b/client/blocks/privacy-policy-banner/index.jsx
@@ -18,7 +18,9 @@ import Banner from 'components/banner';
 import config from 'config';
 import PrivacyPolicyDialog from './privacy-policy-dialog';
 import QueryPrivacyPolicy from 'components/data/query-privacy-policy';
-import { getPrivacyPolicyByEntity } from 'state/selectors';
+
+import { getPrivacyPolicyByEntity, getCurrentUserRegisterDate } from 'state/selectors';
+
 import { AUTOMATTIC_ENTITY, PRIVACY_POLICY_PREFERENCE } from './constants';
 
 class PrivacyPolicyBanner extends Component {
@@ -102,6 +104,13 @@ class PrivacyPolicyBanner extends Component {
 			showPrivacyPolicyBanner = false;
 		}
 
+		// check if the register date of the user is after the notification period
+		const userRegisterDate = moment( this.props.userRegisterDate );
+
+		if ( userRegisterDate.isAfter( notifyFrom ) ) {
+			return null;
+		}
+
 		return (
 			<div className="privacy-policy-banner">
 				<QueryPrivacyPolicy />
@@ -143,6 +152,7 @@ const mapStateToProps = state => {
 		privacyPolicyUserStatus,
 		privacyPolicy,
 		privacyPolicyId,
+		userRegisterDate: getCurrentUserRegisterDate( state ),
 	};
 };
 

--- a/client/blocks/privacy-policy-banner/style.scss
+++ b/client/blocks/privacy-policy-banner/style.scss
@@ -1,37 +1,3 @@
-// banner
-.privacy-policy-banner {
-	max-width: 1040px;
-	margin: auto;
-}
-
-.is-reader-page .privacy-policy-banner {
-	margin: 30px auto;
-	max-width: 800px;
-}
-
-.is-section-preview .privacy-policy-banner {
-	margin: 24px;
-}
-
-// banner - editor section
-.is-section-post-editor .privacy-policy-banner {
-	margin: 60px auto 0;
-	max-width: 740px;
-
-	.card {
-		margin-left: 12px;
-		margin-right: 12px;
-	}
-}
-
-.is-section-post-editor.focus-sidebar .privacy-policy-banner {
-    @include breakpoint( ">660px" ) {
-		width: calc( 100% - ( 272px ) );
-		position: relative;
-		left: -135px;
-	}
-}
-
 // dialog
 .dialog.card.privacy-policy-banner__dialog {
 	max-width: 700px;

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -20,7 +20,6 @@ import MasterbarLoggedOut from 'layout/masterbar/logged-out';
 import observe from 'lib/mixins/data-observe';
 /* eslint-enable no-restricted-imports */
 import GlobalNotices from 'components/global-notices';
-import PrivacyPolicyBanner from 'blocks/privacy-policy-banner';
 import notices from 'notices';
 import translator from 'lib/translator-jumpstart';
 import TranslatorInvitation from './community-translator/invitation';
@@ -180,8 +179,6 @@ const Layout = createReactClass( {
 						notices={ notices.list }
 						forcePinned={ 'post' === this.props.section.name }
 					/>
-
-					<PrivacyPolicyBanner />
 
 					<div id="primary" className="layout__primary">
 						{ this.props.primary }

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -29,6 +29,7 @@ import config from 'config';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import { getSiteOption, isJetpackSite } from 'state/sites/selectors';
 import { recordGoogleEvent } from 'state/analytics/actions';
+import PrivacyPolicyBanner from 'blocks/privacy-policy-banner';
 
 class StatsSite extends Component {
 	constructor( props ) {
@@ -119,6 +120,7 @@ class StatsSite extends Component {
 
 		return (
 			<Main wideLayout={ true }>
+				<PrivacyPolicyBanner />
 				<StatsFirstView />
 				<SidebarNavigation />
 				<StatsNavigation

--- a/client/state/selectors/get-current-user-register-date.js
+++ b/client/state/selectors/get-current-user-register-date.js
@@ -1,0 +1,22 @@
+/** @format */
+/**
+ * External dependencies
+ */
+
+/**
+ * Internal dependencies
+ */
+import { getCurrentUser } from 'state/current-user/selectors';
+
+/**
+ * Returns register date of the current user
+ *
+ * @param {Object} state Global state tree
+ * @return {Number|Boolean} Timestamp registar date, false if cannot be determined
+ */
+export default function getCurrentUserRegisterDate( state ) {
+	const user = getCurrentUser( state );
+	const registerDate = user && Date.parse( user.date );
+
+	return registerDate ? registerDate : false;
+}

--- a/client/state/selectors/index.js
+++ b/client/state/selectors/index.js
@@ -42,6 +42,7 @@ export getCredentialsAutoConfigStatus from './get-credentials-auto-config-status
 export getCurrentLocaleSlug from './get-current-locale-slug';
 export getCurrentPlanPurchaseId from './get-current-plan-purchase-id';
 export getCurrentUserPaymentMethods from './get-current-user-payment-methods';
+export getCurrentUserRegisterDate from './get-current-user-register-date';
 export getImageEditorIsGreaterThanMinimumDimensions from './get-image-editor-is-greater-than-minimum-dimensions';
 export getImageEditorOriginalAspectRatio from './get-image-editor-original-aspect-ratio';
 export getJetpackConnectionStatus from './get-jetpack-connection-status';


### PR DESCRIPTION
This patch handles the situation for the new users. In short, when the registration date of the user is greater than the start date of the notification period then the banner is not shown.

Part of https://github.com/Automattic/wp-calypso/pull/18980.

### Updates

* Banner is shown only in stats section

### Testing

Since the display of the banner depends on the notification period and it's very probable that `now` is out its scope, we are overwritten the `start` and `end` date of this period when the testing flag is defined to get `now` as a valid date.
So the easier way to test this PR is:

1) Test using the live URL: https://calypso.live/?branch=add/pp-tos-new-users&flags=privacy-policy/test. In this link, we are setting the `privacy-policy/test` feature flag.
2) If you create a new user the banner should not be shown.

<img src="https://user-images.githubusercontent.com/77539/32612697-2e97d060-c569-11e7-861d-0bfa55869e3d.png" width="400px" />


3) If you use an old user the banner shows.
<img src="https://user-images.githubusercontent.com/77539/32612712-3c0aaf24-c569-11e7-880a-7ccdaa9897d8.png" width="400px" />

