### PR TITLE
Jetpack connect: Translate state tests to jest

### DIFF
--- a/client/state/jetpack-connect/reducer/test/jetpack-auth-attempts.js
+++ b/client/state/jetpack-connect/reducer/test/jetpack-auth-attempts.js
@@ -1,10 +1,5 @@
 /** @format */
 /**
- * External dependencies
- */
-import { expect } from 'chai';
-
-/**
  * Internal dependencies
  */
 import jetpackAuthAttempts from '../jetpack-auth-attempts';
@@ -13,11 +8,10 @@ import { JETPACK_CONNECT_RETRY_AUTH } from 'state/action-types';
 describe( '#jetpackAuthAttempts()', () => {
 	test( 'should default to an empty object', () => {
 		const state = jetpackAuthAttempts( undefined, {} );
-		expect( state ).to.eql( {} );
+		expect( state ).toEqual( {} );
 	} );
 
 	test( 'should update the timestamp when adding an existent slug with stale timestamp', () => {
-		const nowTime = Date.now();
 		const state = jetpackAuthAttempts(
 			{ 'example.com': { timestamp: 1, attempt: 1 } },
 			{
@@ -26,9 +20,9 @@ describe( '#jetpackAuthAttempts()', () => {
 				attemptNumber: 2,
 			}
 		);
-		expect( state[ 'example.com' ] )
-			.to.have.property( 'timestamp' )
-			.to.be.at.least( nowTime );
+		expect( state[ 'example.com' ] ).toMatchObject( {
+			timestamp: expect.any( Number ),
+		} );
 	} );
 
 	test( 'should reset the attempt number to 0 when adding an existent slug with stale timestamp', () => {
@@ -41,9 +35,7 @@ describe( '#jetpackAuthAttempts()', () => {
 			}
 		);
 
-		expect( state[ 'example.com' ] )
-			.to.have.property( 'attempt' )
-			.to.equals( 0 );
+		expect( state[ 'example.com' ] ).toMatchObject( { attempt: 0 } );
 	} );
 
 	test( 'should store the attempt number when adding an existent slug with non-stale timestamp', () => {
@@ -56,8 +48,6 @@ describe( '#jetpackAuthAttempts()', () => {
 			}
 		);
 
-		expect( state[ 'example.com' ] )
-			.to.have.property( 'attempt' )
-			.to.equals( 2 );
+		expect( state[ 'example.com' ] ).toMatchObject( { attempt: 2 } );
 	} );
 } );

--- a/client/state/jetpack-connect/reducer/test/jetpack-connect-authorize.js
+++ b/client/state/jetpack-connect/reducer/test/jetpack-connect-authorize.js
@@ -2,7 +2,6 @@
 /**
  * External dependencies
  */
-import { expect } from 'chai';
 import deepFreeze from 'deep-freeze';
 
 /**
@@ -33,7 +32,7 @@ describe( '#jetpackConnectAuthorize()', () => {
 
 	test( 'should default to an empty object', () => {
 		const state = jetpackConnectAuthorize( undefined, {} );
-		expect( state ).to.eql( {} );
+		expect( state ).toEqual( {} );
 	} );
 
 	test( 'should set isAuthorizing to true when starting authorization', () => {
@@ -41,11 +40,13 @@ describe( '#jetpackConnectAuthorize()', () => {
 			type: JETPACK_CONNECT_AUTHORIZE,
 		} );
 
-		expect( state ).to.have.property( 'isAuthorizing' ).to.be.true;
-		expect( state ).to.have.property( 'authorizeSuccess' ).to.be.false;
-		expect( state ).to.have.property( 'authorizeError' ).to.be.false;
-		expect( state ).to.have.property( 'isRedirectingToWpAdmin' ).to.be.false;
-		expect( state ).to.have.property( 'autoAuthorize' ).to.be.false;
+		expect( state ).toEqual( {
+			isAuthorizing: true,
+			authorizeSuccess: false,
+			authorizeError: false,
+			isRedirectingToWpAdmin: false,
+			autoAuthorize: false,
+		} );
 	} );
 
 	test( 'should omit userData and bearerToken when starting authorization', () => {
@@ -62,8 +63,8 @@ describe( '#jetpackConnectAuthorize()', () => {
 			}
 		);
 
-		expect( state ).to.not.have.property( 'userData' );
-		expect( state ).to.not.have.property( 'bearerToken' );
+		expect( state ).not.toHaveProperty( 'userData' );
+		expect( state ).not.toHaveProperty( 'bearerToken' );
 	} );
 
 	test( 'should set authorizeSuccess to true when completed authorization successfully', () => {
@@ -75,13 +76,13 @@ describe( '#jetpackConnectAuthorize()', () => {
 			data,
 		} );
 
-		expect( state ).to.have.property( 'authorizeError' ).to.be.false;
-		expect( state ).to.have.property( 'authorizeSuccess' ).to.be.true;
-		expect( state ).to.have.property( 'autoAuthorize' ).to.be.false;
-		expect( state )
-			.to.have.property( 'plansUrl' )
-			.to.eql( data.plans_url );
-		expect( state ).to.have.property( 'siteReceived' ).to.be.false;
+		expect( state ).toMatchObject( {
+			authorizeError: false,
+			authorizeSuccess: true,
+			autoAuthorize: false,
+			plansUrl: data.plans_url,
+			siteReceived: false,
+		} );
 	} );
 
 	test( 'should set authorizeSuccess to false when an error occurred during authorization', () => {
@@ -91,12 +92,12 @@ describe( '#jetpackConnectAuthorize()', () => {
 			error,
 		} );
 
-		expect( state ).to.have.property( 'isAuthorizing' ).to.be.false;
-		expect( state )
-			.to.have.property( 'authorizeError' )
-			.to.eql( error );
-		expect( state ).to.have.property( 'authorizeSuccess' ).to.be.false;
-		expect( state ).to.have.property( 'autoAuthorize' ).to.be.false;
+		expect( state ).toEqual( {
+			isAuthorizing: false,
+			authorizeError: error,
+			authorizeSuccess: false,
+			autoAuthorize: false,
+		} );
 	} );
 
 	test( 'should set authorization code when login is completed', () => {
@@ -108,9 +109,7 @@ describe( '#jetpackConnectAuthorize()', () => {
 			},
 		} );
 
-		expect( state )
-			.to.have.property( 'authorizationCode' )
-			.to.eql( code );
+		expect( state ).toEqual( { authorizationCode: code } );
 	} );
 
 	test( 'should set siteReceived to true and omit some query object properties when received site list', () => {
@@ -131,16 +130,16 @@ describe( '#jetpackConnectAuthorize()', () => {
 			}
 		);
 
-		expect( state ).to.have.property( 'siteReceived' ).to.be.true;
-		expect( state ).to.have.property( 'isAuthorizing' ).to.be.false;
-		expect( state )
-			.to.have.property( 'queryObject' )
-			.to.eql( {
+		expect( state ).toMatchObject( {
+			siteReceived: true,
+			isAuthorizing: false,
+			queryObject: {
 				client_id: 'example.com',
 				redirect_uri: 'https://example.com/',
 				site: 'https://example.com/',
 				state: 1234567890,
-			} );
+			},
+		} );
 	} );
 
 	test( 'should use default authorize state when setting an empty connect query', () => {
@@ -148,12 +147,12 @@ describe( '#jetpackConnectAuthorize()', () => {
 			type: JETPACK_CONNECT_QUERY_SET,
 		} );
 
-		expect( state )
-			.to.have.property( 'queryObject' )
-			.to.eql( {} );
-		expect( state ).to.have.property( 'isAuthorizing' ).to.be.false;
-		expect( state ).to.have.property( 'authorizeSuccess' ).to.be.false;
-		expect( state ).to.have.property( 'authorizeError' ).to.be.false;
+		expect( state ).toMatchObject( {
+			queryObject: {},
+			isAuthorizing: false,
+			authorizeSuccess: false,
+			authorizeError: false,
+		} );
 	} );
 
 	test( 'should use new query object over default authorize state when setting a connect query', () => {
@@ -165,12 +164,12 @@ describe( '#jetpackConnectAuthorize()', () => {
 			queryObject,
 		} );
 
-		expect( state )
-			.to.have.property( 'queryObject' )
-			.to.eql( queryObject );
-		expect( state ).to.have.property( 'isAuthorizing' ).to.be.false;
-		expect( state ).to.have.property( 'authorizeSuccess' ).to.be.false;
-		expect( state ).to.have.property( 'authorizeError' ).to.be.false;
+		expect( state ).toMatchObject( {
+			queryObject: queryObject,
+			isAuthorizing: false,
+			authorizeSuccess: false,
+			authorizeError: false,
+		} );
 	} );
 
 	test( 'should set isAuthorizing and autoAuthorize to true when initiating an account creation', () => {
@@ -178,10 +177,12 @@ describe( '#jetpackConnectAuthorize()', () => {
 			type: JETPACK_CONNECT_CREATE_ACCOUNT,
 		} );
 
-		expect( state ).to.have.property( 'isAuthorizing' ).to.be.true;
-		expect( state ).to.have.property( 'authorizeSuccess' ).to.be.false;
-		expect( state ).to.have.property( 'authorizeError' ).to.be.false;
-		expect( state ).to.have.property( 'autoAuthorize' ).to.be.true;
+		expect( state ).toEqual( {
+			isAuthorizing: true,
+			authorizeSuccess: false,
+			authorizeError: false,
+			autoAuthorize: true,
+		} );
 	} );
 
 	test( 'should receive userData and bearerToken on successful account creation', () => {
@@ -198,16 +199,14 @@ describe( '#jetpackConnectAuthorize()', () => {
 			},
 		} );
 
-		expect( state ).to.have.property( 'isAuthorizing' ).to.be.true;
-		expect( state ).to.have.property( 'authorizeSuccess' ).to.be.false;
-		expect( state ).to.have.property( 'authorizeError' ).to.be.false;
-		expect( state ).to.have.property( 'autoAuthorize' ).to.be.true;
-		expect( state )
-			.to.have.property( 'userData' )
-			.to.eql( userData );
-		expect( state )
-			.to.have.property( 'bearerToken' )
-			.to.eql( bearer_token );
+		expect( state ).toMatchObject( {
+			isAuthorizing: true,
+			authorizeSuccess: false,
+			authorizeError: false,
+			autoAuthorize: true,
+			userData: userData,
+			bearerToken: bearer_token,
+		} );
 	} );
 
 	test( 'should mark authorizeError as true on unsuccessful account creation', () => {
@@ -217,10 +216,12 @@ describe( '#jetpackConnectAuthorize()', () => {
 			error,
 		} );
 
-		expect( state ).to.have.property( 'isAuthorizing' ).to.be.false;
-		expect( state ).to.have.property( 'authorizeSuccess' ).to.be.false;
-		expect( state ).to.have.property( 'authorizeError' ).to.be.true;
-		expect( state ).to.have.property( 'autoAuthorize' ).to.be.false;
+		expect( state ).toEqual( {
+			authorizeError: true,
+			authorizeSuccess: false,
+			autoAuthorize: false,
+			isAuthorizing: false,
+		} );
 	} );
 
 	test( 'should set isRedirectingToWpAdmin to true when an xmlrpc error occurs', () => {
@@ -228,7 +229,7 @@ describe( '#jetpackConnectAuthorize()', () => {
 			type: JETPACK_CONNECT_REDIRECT_XMLRPC_ERROR_FALLBACK_URL,
 		} );
 
-		expect( state ).to.have.property( 'isRedirectingToWpAdmin' ).to.be.true;
+		expect( state ).toEqual( { isRedirectingToWpAdmin: true } );
 	} );
 
 	test( 'should set isRedirectingToWpAdmin to true when a redirect to wp-admin is triggered', () => {
@@ -236,7 +237,7 @@ describe( '#jetpackConnectAuthorize()', () => {
 			type: JETPACK_CONNECT_REDIRECT_WP_ADMIN,
 		} );
 
-		expect( state ).to.have.property( 'isRedirectingToWpAdmin' ).to.be.true;
+		expect( state ).toEqual( { isRedirectingToWpAdmin: true } );
 	} );
 
 	test( 'should set clientNotResponding when a site request to current client fails', () => {
@@ -244,7 +245,7 @@ describe( '#jetpackConnectAuthorize()', () => {
 			{ queryObject: { client_id: '123' } },
 			{ type: SITE_REQUEST_FAILURE, siteId: 123 }
 		);
-		expect( state ).to.have.property( 'clientNotResponding' ).to.be.true;
+		expect( state ).toMatchObject( { clientNotResponding: true } );
 	} );
 
 	test( 'should return the given state when a site request fails on a different site', () => {
@@ -253,7 +254,7 @@ describe( '#jetpackConnectAuthorize()', () => {
 			type: SITE_REQUEST_FAILURE,
 			siteId: 234,
 		} );
-		expect( state ).to.eql( originalState );
+		expect( state ).toEqual( originalState );
 	} );
 
 	test( 'should return the given state when a site request fails and no client id is set', () => {
@@ -262,7 +263,7 @@ describe( '#jetpackConnectAuthorize()', () => {
 			type: SITE_REQUEST_FAILURE,
 			siteId: 123,
 		} );
-		expect( state ).to.eql( originalState );
+		expect( state ).toEqual( originalState );
 	} );
 
 	test( 'should return the given state when a site request fails and no query object is set', () => {
@@ -271,7 +272,7 @@ describe( '#jetpackConnectAuthorize()', () => {
 			type: SITE_REQUEST_FAILURE,
 			siteId: 123,
 		} );
-		expect( state ).to.eql( originalState );
+		expect( state ).toEqual( originalState );
 	} );
 
 	test( 'should persist state when a site request to a different client fails', () => {
@@ -279,7 +280,7 @@ describe( '#jetpackConnectAuthorize()', () => {
 			{ queryObject: { client_id: '123' } },
 			{ type: SITE_REQUEST_FAILURE, siteId: 456 }
 		);
-		expect( state ).to.eql( { queryObject: { client_id: '123' } } );
+		expect( state ).toEqual( { queryObject: { client_id: '123' } } );
 	} );
 
 	test( 'should persist state', () => {
@@ -294,7 +295,7 @@ describe( '#jetpackConnectAuthorize()', () => {
 			type: SERIALIZE,
 		} );
 
-		expect( state ).to.be.eql( originalState );
+		expect( state ).toEqual( originalState );
 	} );
 
 	test( 'should load valid persisted state', () => {
@@ -309,7 +310,7 @@ describe( '#jetpackConnectAuthorize()', () => {
 			type: DESERIALIZE,
 		} );
 
-		expect( state ).to.be.eql( originalState );
+		expect( state ).toEqual( originalState );
 	} );
 
 	test( 'should not load stale state', () => {
@@ -324,6 +325,6 @@ describe( '#jetpackConnectAuthorize()', () => {
 			type: DESERIALIZE,
 		} );
 
-		expect( state ).to.be.eql( {} );
+		expect( state ).toEqual( {} );
 	} );
 } );

--- a/client/state/jetpack-connect/reducer/test/jetpack-connect-sessions.js
+++ b/client/state/jetpack-connect/reducer/test/jetpack-connect-sessions.js
@@ -23,7 +23,9 @@ describe( '#jetpackConnectSessions()', () => {
 			url: 'https://example.wordpress.com',
 		} );
 
-		expect( typeof state ).toBe( 'object' );
+		expect( state ).toMatchObject( {
+			'example.wordpress.com': expect.any( Object ),
+		} );
 	} );
 
 	test( 'should convert forward slashes to double colon when checking a new url', () => {
@@ -32,7 +34,9 @@ describe( '#jetpackConnectSessions()', () => {
 			url: 'https://example.wordpress.com/example123',
 		} );
 
-		expect( typeof state ).toBe( 'object' );
+		expect( state ).toMatchObject( {
+			'example.wordpress.com::example123': expect.any( Object ),
+		} );
 	} );
 
 	test( 'should store a timestamp when checking a new url', () => {

--- a/client/state/jetpack-connect/reducer/test/jetpack-connect-sessions.js
+++ b/client/state/jetpack-connect/reducer/test/jetpack-connect-sessions.js
@@ -2,11 +2,6 @@
 /**
  * External dependencies
  */
-import { expect } from 'chai';
-
-/**
- * Internal dependencies
- */
 import jetpackConnectSessions from '../jetpack-connect-sessions';
 import { DESERIALIZE, JETPACK_CONNECT_CHECK_URL } from 'state/action-types';
 
@@ -19,7 +14,7 @@ describe( '#jetpackConnectSessions()', () => {
 
 	test( 'should default to an empty object', () => {
 		const state = jetpackConnectSessions( undefined, {} );
-		expect( state ).to.eql( {} );
+		expect( state ).toEqual( {} );
 	} );
 
 	test( 'should add the url slug as a new property when checking a new url', () => {
@@ -28,9 +23,7 @@ describe( '#jetpackConnectSessions()', () => {
 			url: 'https://example.wordpress.com',
 		} );
 
-		expect( state )
-			.to.have.property( 'example.wordpress.com' )
-			.to.be.a( 'object' );
+		expect( typeof state ).toBe( 'object' );
 	} );
 
 	test( 'should convert forward slashes to double colon when checking a new url', () => {
@@ -39,25 +32,19 @@ describe( '#jetpackConnectSessions()', () => {
 			url: 'https://example.wordpress.com/example123',
 		} );
 
-		expect( state )
-			.to.have.property( 'example.wordpress.com::example123' )
-			.to.be.a( 'object' );
+		expect( typeof state ).toBe( 'object' );
 	} );
 
 	test( 'should store a timestamp when checking a new url', () => {
-		const nowTime = Date.now();
 		const state = jetpackConnectSessions( undefined, {
 			type: JETPACK_CONNECT_CHECK_URL,
 			url: 'https://example.wordpress.com',
 		} );
 
-		expect( state[ 'example.wordpress.com' ] )
-			.to.have.property( 'timestamp' )
-			.to.be.at.least( nowTime );
+		expect( state[ 'example.wordpress.com' ] ).toMatchObject( { timestamp: expect.any( Number ) } );
 	} );
 
 	test( 'should update the timestamp when checking an existent url', () => {
-		const nowTime = Date.now();
 		const state = jetpackConnectSessions(
 			{ 'example.wordpress.com': { timestamp: 1 } },
 			{
@@ -66,9 +53,7 @@ describe( '#jetpackConnectSessions()', () => {
 			}
 		);
 
-		expect( state[ 'example.wordpress.com' ] )
-			.to.have.property( 'timestamp' )
-			.to.be.at.least( nowTime );
+		expect( state[ 'example.wordpress.com' ] ).toMatchObject( { timestamp: expect.any( Number ) } );
 	} );
 
 	test( 'should not restore a state with a property without a timestamp', () => {
@@ -79,7 +64,7 @@ describe( '#jetpackConnectSessions()', () => {
 			}
 		);
 
-		expect( state ).to.be.eql( {} );
+		expect( state ).toEqual( {} );
 	} );
 
 	test( 'should not restore a state with a property with a non-integer timestamp', () => {
@@ -90,7 +75,7 @@ describe( '#jetpackConnectSessions()', () => {
 			}
 		);
 
-		expect( state ).to.be.eql( {} );
+		expect( state ).toEqual( {} );
 	} );
 
 	test( 'should not restore a state with a property with a stale timestamp', () => {
@@ -101,7 +86,7 @@ describe( '#jetpackConnectSessions()', () => {
 			}
 		);
 
-		expect( state ).to.be.eql( {} );
+		expect( state ).toEqual( {} );
 	} );
 
 	test( 'should not restore a state with a session stored with extra properties', () => {
@@ -113,7 +98,7 @@ describe( '#jetpackConnectSessions()', () => {
 			}
 		);
 
-		expect( state ).to.be.eql( {} );
+		expect( state ).toEqual( {} );
 	} );
 
 	test( 'should restore a valid state', () => {
@@ -125,7 +110,7 @@ describe( '#jetpackConnectSessions()', () => {
 			}
 		);
 
-		expect( state ).to.be.eql( { 'example.wordpress.com': { timestamp } } );
+		expect( state ).toEqual( { 'example.wordpress.com': { timestamp } } );
 	} );
 
 	test( 'should restore a valid state including dashes, slashes and semicolons', () => {
@@ -137,7 +122,7 @@ describe( '#jetpackConnectSessions()', () => {
 			}
 		);
 
-		expect( state ).to.be.eql( { 'https://example.wordpress.com:3000/test-one': { timestamp } } );
+		expect( state ).toEqual( { 'https://example.wordpress.com:3000/test-one': { timestamp } } );
 	} );
 
 	test( 'should restore only sites with non-stale timestamps', () => {
@@ -152,6 +137,6 @@ describe( '#jetpackConnectSessions()', () => {
 			}
 		);
 
-		expect( state ).to.be.eql( { 'automattic.wordpress.com': { timestamp } } );
+		expect( state ).toEqual( { 'automattic.wordpress.com': { timestamp } } );
 	} );
 } );

--- a/client/state/jetpack-connect/reducer/test/jetpack-connect-sessions.js
+++ b/client/state/jetpack-connect/reducer/test/jetpack-connect-sessions.js
@@ -1,6 +1,6 @@
 /** @format */
 /**
- * External dependencies
+ * Internal dependencies
  */
 import jetpackConnectSessions from '../jetpack-connect-sessions';
 import { DESERIALIZE, JETPACK_CONNECT_CHECK_URL } from 'state/action-types';

--- a/client/state/jetpack-connect/reducer/test/jetpack-connect-site.js
+++ b/client/state/jetpack-connect/reducer/test/jetpack-connect-site.js
@@ -1,6 +1,6 @@
 /** @format */
 /**
- * External dependencies
+ * Internal dependencies
  */
 import jetpackConnectSite from '../jetpack-connect-site';
 import {

--- a/client/state/jetpack-connect/reducer/test/jetpack-connect-site.js
+++ b/client/state/jetpack-connect/reducer/test/jetpack-connect-site.js
@@ -2,11 +2,6 @@
 /**
  * External dependencies
  */
-import { expect } from 'chai';
-
-/**
- * Internal dependencies
- */
 import jetpackConnectSite from '../jetpack-connect-site';
 import {
 	JETPACK_CONNECT_CHECK_URL,
@@ -20,7 +15,7 @@ describe( '#jetpackConnectSite()', () => {
 	test( 'should default to an empty object', () => {
 		const state = jetpackConnectSite( undefined, {} );
 
-		expect( state ).to.eql( {} );
+		expect( state ).toEqual( {} );
 	} );
 
 	test( 'should add the url and mark it as currently fetching', () => {
@@ -29,16 +24,14 @@ describe( '#jetpackConnectSite()', () => {
 			url: 'https://example.wordpress.com',
 		} );
 
-		expect( state )
-			.to.have.property( 'url' )
-			.to.eql( 'https://example.wordpress.com' );
-		expect( state ).to.have.property( 'isFetching' ).to.be.true;
-		expect( state ).to.have.property( 'isFetched' ).to.be.false;
-		expect( state ).to.have.property( 'isDismissed' ).to.be.false;
-		expect( state ).to.have.property( 'installConfirmedByUser' ).to.be.null;
-		expect( state )
-			.to.have.property( 'data' )
-			.to.eql( {} );
+		expect( state ).toMatchObject( {
+			url: 'https://example.wordpress.com',
+			isFetching: true,
+			isFetched: false,
+			isDismissed: false,
+			installConfirmedByUser: null,
+			data: {},
+		} );
 	} );
 
 	test( 'should mark the url as fetched if it is the current one', () => {
@@ -58,11 +51,11 @@ describe( '#jetpackConnectSite()', () => {
 			}
 		);
 
-		expect( state ).to.have.property( 'isFetching' ).to.be.false;
-		expect( state ).to.have.property( 'isFetched' ).to.be.true;
-		expect( state )
-			.to.have.property( 'data' )
-			.to.eql( data );
+		expect( state ).toMatchObject( {
+			isFetching: false,
+			isFetched: true,
+			data: data,
+		} );
 	} );
 
 	test( 'should not mark the url as fetched if it is not the current one', () => {
@@ -82,8 +75,8 @@ describe( '#jetpackConnectSite()', () => {
 			}
 		);
 
-		expect( state ).to.eql( { url: 'https://automattic.com' } );
-		expect( state ).to.not.have.property( 'isFetched' );
+		expect( state ).toEqual( { url: 'https://automattic.com' } );
+		expect( state ).not.toHaveProperty( 'isFetched' );
 	} );
 
 	test( 'should mark the url as dismissed if it is the current one', () => {
@@ -95,8 +88,10 @@ describe( '#jetpackConnectSite()', () => {
 			}
 		);
 
-		expect( state ).to.have.property( 'installConfirmedByUser' ).to.be.null;
-		expect( state ).to.have.property( 'isDismissed' ).to.be.true;
+		expect( state ).toMatchObject( {
+			installConfirmedByUser: null,
+			isDismissed: true,
+		} );
 	} );
 
 	test( 'should not mark the url as dismissed if it is not the current one', () => {
@@ -108,7 +103,7 @@ describe( '#jetpackConnectSite()', () => {
 			}
 		);
 
-		expect( state ).to.eql( { url: 'https://automattic.com' } );
+		expect( state ).toEqual( { url: 'https://automattic.com' } );
 	} );
 
 	test( 'should schedule a redirect to the url if it is the current one', () => {
@@ -120,7 +115,7 @@ describe( '#jetpackConnectSite()', () => {
 			}
 		);
 
-		expect( state ).to.have.property( 'isRedirecting' ).to.be.true;
+		expect( state ).toMatchObject( { isRedirecting: true } );
 	} );
 
 	test( 'should not schedule a redirect to the url if it is not the current one', () => {
@@ -132,7 +127,7 @@ describe( '#jetpackConnectSite()', () => {
 			}
 		);
 
-		expect( state ).to.eql( { url: 'https://automattic.com' } );
+		expect( state ).toEqual( { url: 'https://automattic.com' } );
 	} );
 
 	test( 'should set the jetpack confirmed status to the new one', () => {
@@ -144,6 +139,6 @@ describe( '#jetpackConnectSite()', () => {
 			}
 		);
 
-		expect( state ).to.have.property( 'installConfirmedByUser' ).to.be.true;
+		expect( state ).toMatchObject( { installConfirmedByUser: true } );
 	} );
 } );

--- a/client/state/jetpack-connect/reducer/test/jetpack-sso.js
+++ b/client/state/jetpack-connect/reducer/test/jetpack-sso.js
@@ -3,7 +3,6 @@
  * External dependencies
  */
 import deepFreeze from 'deep-freeze';
-import { expect } from 'chai';
 
 /**
  * Internal dependencies
@@ -50,7 +49,7 @@ const falseSSOValidation = Object.assign( successfulSSOValidation, { success: fa
 describe( '#jetpackSSO()', () => {
 	test( 'should default to an empty object', () => {
 		const state = jetpackSSO( undefined, {} );
-		expect( state ).to.eql( {} );
+		expect( state ).toEqual( {} );
 	} );
 
 	test( 'should set isValidating to true when validating', () => {
@@ -58,7 +57,7 @@ describe( '#jetpackSSO()', () => {
 			type: JETPACK_CONNECT_SSO_VALIDATION_REQUEST,
 		} );
 
-		expect( state ).to.have.property( 'isValidating', true );
+		expect( state ).toHaveProperty( 'isValidating', true );
 	} );
 
 	test( 'should set isAuthorizing to true when authorizing', () => {
@@ -66,7 +65,7 @@ describe( '#jetpackSSO()', () => {
 			type: JETPACK_CONNECT_SSO_AUTHORIZE_REQUEST,
 		} );
 
-		expect( state ).to.have.property( 'isAuthorizing', true );
+		expect( state ).toHaveProperty( 'isAuthorizing', true );
 	} );
 
 	test( 'should set isValidating to false after validation', () => {
@@ -82,7 +81,7 @@ describe( '#jetpackSSO()', () => {
 
 		actions.forEach( action => {
 			const state = jetpackSSO( undefined, action );
-			expect( state ).to.have.property( 'isValidating', false );
+			expect( state ).toHaveProperty( 'isValidating', false );
 		} );
 	} );
 
@@ -92,22 +91,20 @@ describe( '#jetpackSSO()', () => {
 		actions.forEach( action => {
 			const originalAction = deepFreeze( action );
 			const state = jetpackSSO( undefined, originalAction );
-			expect( state ).to.have.property( 'nonceValid', originalAction.success );
+			expect( state ).toHaveProperty( 'nonceValid', originalAction.success );
 		} );
 	} );
 
 	test( 'should store blog details after validation', () => {
 		const successState = jetpackSSO( undefined, successfulSSOValidation );
-		expect( successState )
-			.to.have.property( 'blogDetails' )
-			.to.be.eql( successfulSSOValidation.blogDetails );
+		expect( successState ).toMatchObject( { blogDetails: successfulSSOValidation.blogDetails } );
 	} );
 
 	test( 'should store shared details after validation', () => {
 		const successState = jetpackSSO( undefined, successfulSSOValidation );
-		expect( successState )
-			.to.have.property( 'sharedDetails' )
-			.to.be.eql( successfulSSOValidation.sharedDetails );
+		expect( successState ).toMatchObject( {
+			sharedDetails: successfulSSOValidation.sharedDetails,
+		} );
 	} );
 
 	test( 'should set isAuthorizing to false after authorization', () => {
@@ -127,7 +124,7 @@ describe( '#jetpackSSO()', () => {
 
 		actions.forEach( action => {
 			const state = jetpackSSO( undefined, action );
-			expect( state ).to.have.property( 'isAuthorizing', false );
+			expect( state ).toHaveProperty( 'isAuthorizing', false );
 		} );
 	} );
 
@@ -140,6 +137,6 @@ describe( '#jetpackSSO()', () => {
 
 		const state = jetpackSSO( undefined, action );
 
-		expect( state ).to.have.property( 'ssoUrl', action.ssoUrl );
+		expect( state ).toHaveProperty( 'ssoUrl', action.ssoUrl );
 	} );
 } );

--- a/client/state/jetpack-connect/test/actions.js
+++ b/client/state/jetpack-connect/test/actions.js
@@ -2,16 +2,12 @@
  * @format
  * @jest-environment jsdom
  */
-
-/**
- * External dependencies
- */
-import { expect } from 'chai';
-
 /**
  * Internal dependencies
  */
 import path from 'lib/route/path';
+import useNock from 'test/helpers/use-nock';
+import { useSandbox } from 'test/helpers/use-sinon';
 import {
 	JETPACK_CONNECT_CONFIRM_JETPACK_STATUS,
 	JETPACK_CONNECT_DISMISS_URL_STATUS,
@@ -31,19 +27,16 @@ import {
 	JETPACK_CONNECT_SSO_VALIDATION_ERROR,
 	SITES_RECEIVE,
 } from 'state/action-types';
-import useNock from 'test/helpers/use-nock';
-import { useSandbox } from 'test/helpers/use-sinon';
 
 jest.mock( 'lib/localforage', () => require( 'lib/localforage/localforage-bypass' ) );
 
 describe( 'actions', () => {
-	let actions, sandbox, spy;
+	let actions, sandbox;
 	const mySitesPath =
 		'/rest/v1.1/me/sites?site_visibility=all&include_domain_only=true&site_activity=active';
 
 	useSandbox( newSandbox => {
 		sandbox = newSandbox;
-		spy = sandbox.spy();
 		sandbox.stub( path, 'externalRedirect' );
 	} );
 
@@ -53,12 +46,13 @@ describe( 'actions', () => {
 
 	describe( '#confirmJetpackInstallStatus()', () => {
 		test( 'should dispatch confirm status action when called', () => {
+			const spy = jest.fn();
 			const { confirmJetpackInstallStatus } = actions;
 			const jetpackStatus = true;
 
 			confirmJetpackInstallStatus( jetpackStatus )( spy );
 
-			expect( spy ).to.have.been.calledWith( {
+			expect( spy ).toHaveBeenCalledWith( {
 				type: JETPACK_CONNECT_CONFIRM_JETPACK_STATUS,
 				status: jetpackStatus,
 			} );
@@ -67,12 +61,13 @@ describe( 'actions', () => {
 
 	describe( '#dismissUrl()', () => {
 		test( 'should dispatch dismiss url status action when called', () => {
+			const spy = jest.fn();
 			const { dismissUrl } = actions;
 			const url = 'http://example.com';
 
 			dismissUrl( url )( spy );
 
-			expect( spy ).to.have.been.calledWith( {
+			expect( spy ).toHaveBeenCalledWith( {
 				type: JETPACK_CONNECT_DISMISS_URL_STATUS,
 				url: url,
 			} );
@@ -81,12 +76,13 @@ describe( 'actions', () => {
 
 	describe( '#goToRemoteAuth()', () => {
 		test( 'should dispatch redirect action when called', () => {
+			const spy = jest.fn();
 			const { goToRemoteAuth } = actions;
 			const url = 'http://example.com';
 
 			goToRemoteAuth( url )( spy );
 
-			expect( spy ).to.have.been.calledWith( {
+			expect( spy ).toHaveBeenCalledWith( {
 				type: JETPACK_CONNECT_REDIRECT,
 				url: url,
 			} );
@@ -95,12 +91,13 @@ describe( 'actions', () => {
 
 	describe( '#goToPluginInstall()', () => {
 		test( 'should dispatch redirect action when called', () => {
+			const spy = jest.fn();
 			const { goToPluginInstall } = actions;
 			const url = 'http://example.com';
 
 			goToPluginInstall( url )( spy );
 
-			expect( spy ).to.have.been.calledWith( {
+			expect( spy ).toHaveBeenCalledWith( {
 				type: JETPACK_CONNECT_REDIRECT,
 				url: url,
 			} );
@@ -109,12 +106,13 @@ describe( 'actions', () => {
 
 	describe( '#goToPluginActivation()', () => {
 		test( 'should dispatch redirect action when called', () => {
+			const spy = jest.fn();
 			const { goToPluginActivation } = actions;
 			const url = 'http://example.com';
 
 			goToPluginActivation( url )( spy );
 
-			expect( spy ).to.have.been.calledWith( {
+			expect( spy ).toHaveBeenCalledWith( {
 				type: JETPACK_CONNECT_REDIRECT,
 				url: url,
 			} );
@@ -123,12 +121,13 @@ describe( 'actions', () => {
 
 	describe( '#goBackToWpAdmin()', () => {
 		test( 'should dispatch redirect action when called', () => {
+			const spy = jest.fn();
 			const { goBackToWpAdmin } = actions;
 			const url = 'http://example.com';
 
 			goBackToWpAdmin( url )( spy );
 
-			expect( spy ).to.have.been.calledWith( {
+			expect( spy ).toHaveBeenCalledWith( {
 				type: JETPACK_CONNECT_REDIRECT_WP_ADMIN,
 			} );
 		} );
@@ -136,6 +135,7 @@ describe( 'actions', () => {
 
 	describe( '#goToXmlrpcErrorFallbackUrl()', () => {
 		test( 'should dispatch redirect with xmlrpc error action when called', () => {
+			const spy = jest.fn();
 			const { goToXmlrpcErrorFallbackUrl } = actions;
 			const queryObject = {
 				state: '12345678',
@@ -148,7 +148,7 @@ describe( 'actions', () => {
 
 			goToXmlrpcErrorFallbackUrl( queryObject, authorizationCode )( spy );
 
-			expect( spy ).to.have.been.calledWith( {
+			expect( spy ).toHaveBeenCalledWith( {
 				type: JETPACK_CONNECT_REDIRECT_XMLRPC_ERROR_FALLBACK_URL,
 				url,
 			} );
@@ -157,12 +157,13 @@ describe( 'actions', () => {
 
 	describe( '#retryAuth()', () => {
 		test( 'should dispatch redirect action when called', () => {
+			const spy = jest.fn();
 			const { retryAuth } = actions;
 			const url = 'http://example.com';
 
 			retryAuth( url, 0 )( spy );
 
-			expect( spy ).to.have.been.calledWith( {
+			expect( spy ).toHaveBeenCalledWith( {
 				type: JETPACK_CONNECT_RETRY_AUTH,
 				slug: 'example.com',
 				attemptNumber: 0,
@@ -238,21 +239,23 @@ describe( 'actions', () => {
 			} );
 
 			test( 'should dispatch authorize request action when thunk triggered', () => {
+				const spy = jest.fn();
 				const { authorize } = actions;
 
 				authorize( queryObject )( spy );
 
-				expect( spy ).to.have.been.calledWith( {
+				expect( spy ).toHaveBeenCalledWith( {
 					type: JETPACK_CONNECT_AUTHORIZE,
 					queryObject,
 				} );
 			} );
 
 			test( 'should dispatch login complete action when request completes', () => {
+				const spy = jest.fn();
 				const { authorize } = actions;
 
 				return authorize( queryObject )( spy ).then( () => {
-					expect( spy ).to.have.been.calledWith( {
+					expect( spy ).toHaveBeenCalledWith( {
 						type: JETPACK_CONNECT_AUTHORIZE_LOGIN_COMPLETE,
 						data: {
 							code: 'abcdefghi1234',
@@ -262,10 +265,11 @@ describe( 'actions', () => {
 			} );
 
 			test( 'should dispatch authorize receive action when request completes', () => {
+				const spy = jest.fn();
 				const { authorize } = actions;
 
 				return authorize( queryObject )( spy ).then( () => {
-					expect( spy ).to.have.been.calledWith( {
+					expect( spy ).toHaveBeenCalledWith( {
 						type: JETPACK_CONNECT_AUTHORIZE_RECEIVE,
 						siteId: client_id,
 						data: {
@@ -278,10 +282,11 @@ describe( 'actions', () => {
 			} );
 
 			test( 'should dispatch sites receive action when request completes', () => {
+				const spy = jest.fn();
 				const { authorize } = actions;
 
 				return authorize( queryObject )( spy ).then( () => {
-					expect( spy ).to.have.been.calledWith( {
+					expect( spy ).toHaveBeenCalledWith( {
 						type: SITES_RECEIVE,
 						sites: [ client_id ],
 					} );
@@ -289,10 +294,11 @@ describe( 'actions', () => {
 			} );
 
 			test( 'should dispatch authorize receive site list action when request completes', () => {
+				const spy = jest.fn();
 				const { authorize } = actions;
 
 				return authorize( queryObject )( spy ).then( () => {
-					expect( spy ).to.have.been.calledWith( {
+					expect( spy ).toHaveBeenCalledWith( {
 						type: JETPACK_CONNECT_AUTHORIZE_RECEIVE_SITE_LIST,
 						data: {
 							sites: [ client_id ],
@@ -326,10 +332,11 @@ describe( 'actions', () => {
 			} );
 
 			test( 'should dispatch authorize receive action when request completes', () => {
+				const spy = jest.fn();
 				const { authorize } = actions;
 
 				return authorize( queryObject )( spy ).then( () => {
-					expect( spy ).to.have.been.calledWith( {
+					expect( spy ).toHaveBeenCalledWith( {
 						type: JETPACK_CONNECT_AUTHORIZE_RECEIVE,
 						siteId: client_id,
 						data: null,
@@ -393,20 +400,22 @@ describe( 'actions', () => {
 			} );
 
 			test( 'should dispatch validate action when thunk triggered', () => {
+				const spy = jest.fn();
 				const { validateSSONonce } = actions;
 
 				validateSSONonce( siteId, ssoNonce )( spy );
-				expect( spy ).to.have.been.calledWith( {
+				expect( spy ).toHaveBeenCalledWith( {
 					siteId: siteId,
 					type: JETPACK_CONNECT_SSO_VALIDATION_REQUEST,
 				} );
 			} );
 
 			test( 'should dispatch receive action when request completes', () => {
+				const spy = jest.fn();
 				const { validateSSONonce } = actions;
 
 				return validateSSONonce( siteId, ssoNonce )( spy ).then( () => {
-					expect( spy ).to.have.been.calledWith( {
+					expect( spy ).toHaveBeenCalledWith( {
 						success: true,
 						blogDetails: blogDetails,
 						sharedDetails: sharedDetails,
@@ -436,10 +445,11 @@ describe( 'actions', () => {
 			} );
 
 			test( 'should dispatch receive action when request completes', () => {
+				const spy = jest.fn();
 				const { validateSSONonce } = actions;
 
 				return validateSSONonce( siteId, ssoNonce )( spy ).then( () => {
-					expect( spy ).to.have.been.calledWith( {
+					expect( spy ).toHaveBeenCalledWith( {
 						error: {
 							error: 'invalid_input',
 							message: 'sso_nonce is a required parameter for this endpoint',
@@ -476,20 +486,22 @@ describe( 'actions', () => {
 			} );
 
 			test( 'should dispatch validate action when thunk triggered', () => {
+				const spy = jest.fn();
 				const { authorizeSSO } = actions;
 
 				authorizeSSO( siteId, ssoNonce, ssoUrl )( spy );
-				expect( spy ).to.have.been.calledWith( {
+				expect( spy ).toHaveBeenCalledWith( {
 					siteId: siteId,
 					type: JETPACK_CONNECT_SSO_AUTHORIZE_REQUEST,
 				} );
 			} );
 
 			test( 'should dispatch receive action when request completes', () => {
+				const spy = jest.fn();
 				const { authorizeSSO } = actions;
 
 				return authorizeSSO( siteId, ssoNonce, ssoUrl )( spy ).then( () => {
-					expect( spy ).to.have.been.calledWith( {
+					expect( spy ).toHaveBeenCalledWith( {
 						ssoUrl,
 						siteUrl: ssoUrl,
 						type: JETPACK_CONNECT_SSO_AUTHORIZE_SUCCESS,
@@ -518,10 +530,11 @@ describe( 'actions', () => {
 			} );
 
 			test( 'should dispatch receive action when request completes', () => {
+				const spy = jest.fn();
 				const { authorizeSSO } = actions;
 
 				return authorizeSSO( siteId, ssoNonce, ssoUrl )( spy ).then( () => {
-					expect( spy ).to.have.been.calledWith( {
+					expect( spy ).toHaveBeenLastCalledWith( {
 						error: {
 							error: 'invalid_input',
 							message: 'sso_nonce is a required parameter for this endpoint',

--- a/client/state/jetpack-connect/test/actions.js
+++ b/client/state/jetpack-connect/test/actions.js
@@ -5,9 +5,8 @@
 /**
  * Internal dependencies
  */
-import path from 'lib/route/path';
+import * as actions from '../actions';
 import useNock from 'test/helpers/use-nock';
-import { useSandbox } from 'test/helpers/use-sinon';
 import {
 	JETPACK_CONNECT_CONFIRM_JETPACK_STATUS,
 	JETPACK_CONNECT_DISMISS_URL_STATUS,
@@ -31,18 +30,8 @@ import {
 jest.mock( 'lib/localforage', () => require( 'lib/localforage/localforage-bypass' ) );
 
 describe( 'actions', () => {
-	let actions, sandbox;
 	const mySitesPath =
 		'/rest/v1.1/me/sites?site_visibility=all&include_domain_only=true&site_activity=active';
-
-	useSandbox( newSandbox => {
-		sandbox = newSandbox;
-		sandbox.stub( path, 'externalRedirect' );
-	} );
-
-	beforeEach( () => {
-		actions = require( '../actions' );
-	} );
 
 	describe( '#confirmJetpackInstallStatus()', () => {
 		test( 'should dispatch confirm status action when called', () => {

--- a/client/state/jetpack-connect/test/selectors.js
+++ b/client/state/jetpack-connect/test/selectors.js
@@ -1,10 +1,4 @@
 /** @format */
-
-/**
- * External dependencies
- */
-import { expect } from 'chai';
-
 /**
  * Internal dependencies
  */
@@ -33,7 +27,7 @@ describe( 'selectors', () => {
 				jetpackConnect: {},
 			};
 
-			expect( getConnectingSite( state ) ).to.be.undefined;
+			expect( getConnectingSite( state ) ).toBeUndefined();
 		} );
 
 		test( 'should return the current connecting site if there is such', () => {
@@ -63,7 +57,7 @@ describe( 'selectors', () => {
 				},
 			};
 
-			expect( getConnectingSite( state ) ).to.eql( jetpackConnectSite );
+			expect( getConnectingSite( state ) ).toEqual( jetpackConnectSite );
 		} );
 	} );
 
@@ -73,7 +67,7 @@ describe( 'selectors', () => {
 				jetpackConnect: {},
 			};
 
-			expect( getAuthorizationData( state ) ).to.be.undefined;
+			expect( getAuthorizationData( state ) ).toBeUndefined();
 		} );
 
 		test( 'should return the current authorization object if there is such', () => {
@@ -88,7 +82,7 @@ describe( 'selectors', () => {
 				},
 			};
 
-			expect( getAuthorizationData( state ) ).to.eql( jetpackConnectAuthorize );
+			expect( getAuthorizationData( state ) ).toEqual( jetpackConnectAuthorize );
 		} );
 	} );
 
@@ -98,7 +92,7 @@ describe( 'selectors', () => {
 				jetpackConnect: {},
 			};
 
-			expect( getAuthorizationRemoteQueryData( state ) ).to.be.undefined;
+			expect( getAuthorizationRemoteQueryData( state ) ).toBeUndefined();
 		} );
 
 		test( 'should return the current authorization query object if there is such', () => {
@@ -118,7 +112,7 @@ describe( 'selectors', () => {
 				},
 			};
 
-			expect( getAuthorizationRemoteQueryData( state ) ).to.eql( queryObject );
+			expect( getAuthorizationRemoteQueryData( state ) ).toEqual( queryObject );
 		} );
 	} );
 
@@ -128,7 +122,7 @@ describe( 'selectors', () => {
 				jetpackConnect: {},
 			};
 
-			expect( isRemoteSiteOnSitesList( state ) ).to.be.false;
+			expect( isRemoteSiteOnSitesList( state ) ).toBe( false );
 		} );
 
 		test( 'should return true if the site is in the sites list', () => {
@@ -157,7 +151,7 @@ describe( 'selectors', () => {
 				},
 			};
 
-			expect( isRemoteSiteOnSitesList( state ) ).to.be.true;
+			expect( isRemoteSiteOnSitesList( state ) ).toBe( true );
 		} );
 
 		test( 'should return false if the site is in the sites list, but is not responding', () => {
@@ -181,17 +175,17 @@ describe( 'selectors', () => {
 				},
 			};
 
-			expect( isRemoteSiteOnSitesList( state ) ).to.be.false;
+			expect( isRemoteSiteOnSitesList( state ) ).toBe( false );
 		} );
 	} );
 
 	describe( '#getAuthorizationRemoteSite()', () => {
-		test( 'should return null if user has not started the authorization flow', () => {
+		test( 'should return undefined if user has not started the authorization flow', () => {
 			const state = {
 				jetpackConnect: {},
 			};
 
-			expect( getAuthorizationRemoteSite( state ) ).to.be.undefined;
+			expect( getAuthorizationRemoteSite( state ) ).toBeUndefined();
 		} );
 
 		test( 'should return the current authorization url if there is such', () => {
@@ -211,7 +205,7 @@ describe( 'selectors', () => {
 				},
 			};
 
-			expect( getAuthorizationRemoteSite( state ) ).to.eql(
+			expect( getAuthorizationRemoteSite( state ) ).toEqual(
 				state.jetpackConnect.jetpackConnectAuthorize.queryObject.site
 			);
 		} );
@@ -223,7 +217,7 @@ describe( 'selectors', () => {
 				jetpackConnect: {},
 			};
 
-			expect( getSessions( state ) ).to.be.undefined;
+			expect( getSessions( state ) ).toBeUndefined();
 		} );
 
 		test( "should return all of the user's single sign-on sessions", () => {
@@ -243,7 +237,7 @@ describe( 'selectors', () => {
 				},
 			};
 
-			expect( getSessions( state ) ).to.eql( jetpackConnectSessions );
+			expect( getSessions( state ) ).toEqual( jetpackConnectSessions );
 		} );
 	} );
 
@@ -253,7 +247,7 @@ describe( 'selectors', () => {
 				jetpackConnect: {},
 			};
 
-			expect( getSSO( state ) ).to.be.undefined;
+			expect( getSSO( state ) ).toBeUndefined();
 		} );
 
 		test( 'should return the current state of the single sign-on object', () => {
@@ -293,7 +287,7 @@ describe( 'selectors', () => {
 				},
 			};
 
-			expect( getSSO( state ) ).to.eql( jetpackSSO );
+			expect( getSSO( state ) ).toEqual( jetpackSSO );
 		} );
 	} );
 
@@ -310,7 +304,7 @@ describe( 'selectors', () => {
 				},
 			};
 
-			expect( isCalypsoStartedConnection( state, 'sitetest' ) ).to.be.true;
+			expect( isCalypsoStartedConnection( state, 'sitetest' ) ).toBe( true );
 		} );
 
 		test( 'should return true if the user has just started a session in calypso and site contains a forward slash', () => {
@@ -325,7 +319,7 @@ describe( 'selectors', () => {
 				},
 			};
 
-			expect( isCalypsoStartedConnection( state, 'example.com/example123' ) ).to.be.true;
+			expect( isCalypsoStartedConnection( state, 'example.com/example123' ) ).toBe( true );
 		} );
 
 		test( "should return false if the user haven't started a session in calypso  ", () => {
@@ -337,7 +331,7 @@ describe( 'selectors', () => {
 				},
 			};
 
-			expect( isCalypsoStartedConnection( state, 'sitetest' ) ).to.be.false;
+			expect( isCalypsoStartedConnection( state, 'sitetest' ) ).toBe( false );
 		} );
 
 		test( 'should return false if the user started a session in calypso more than an hour ago', () => {
@@ -352,7 +346,7 @@ describe( 'selectors', () => {
 				},
 			};
 
-			expect( isCalypsoStartedConnection( state, 'sitetest' ) ).to.be.false;
+			expect( isCalypsoStartedConnection( state, 'sitetest' ) ).toBe( false );
 		} );
 	} );
 
@@ -364,7 +358,7 @@ describe( 'selectors', () => {
 				},
 			};
 
-			expect( isRedirectingToWpAdmin( state ) ).to.be.false;
+			expect( isRedirectingToWpAdmin( state ) ).toBe( false );
 		} );
 
 		test( 'should return false if redirection flag is set to false', () => {
@@ -376,7 +370,7 @@ describe( 'selectors', () => {
 				},
 			};
 
-			expect( isRedirectingToWpAdmin( state ) ).to.be.false;
+			expect( isRedirectingToWpAdmin( state ) ).toBe( false );
 		} );
 
 		test( 'should return true if redirection flag is set to true', () => {
@@ -388,7 +382,7 @@ describe( 'selectors', () => {
 				},
 			};
 
-			expect( isRedirectingToWpAdmin( state ) ).to.be.true;
+			expect( isRedirectingToWpAdmin( state ) ).toBe( true );
 		} );
 	} );
 
@@ -405,7 +399,7 @@ describe( 'selectors', () => {
 				},
 			};
 
-			expect( getFlowType( state, 'sitetest' ) ).to.eql( 'pro' );
+			expect( getFlowType( state, 'sitetest' ) ).toEqual( 'pro' );
 		} );
 
 		test( 'should return the flow of the session for a site with slash in the site slug', () => {
@@ -420,7 +414,7 @@ describe( 'selectors', () => {
 				},
 			};
 
-			expect( getFlowType( state, 'example.com/example123' ) ).to.eql( 'pro' );
+			expect( getFlowType( state, 'example.com/example123' ) ).toEqual( 'pro' );
 		} );
 
 		test( "should return false if there's no session for a site", () => {
@@ -430,7 +424,7 @@ describe( 'selectors', () => {
 				},
 			};
 
-			expect( getFlowType( state, 'sitetest' ) ).to.be.false;
+			expect( getFlowType( state, 'sitetest' ) ).toBe( false );
 		} );
 	} );
 
@@ -442,7 +436,7 @@ describe( 'selectors', () => {
 				},
 			};
 
-			expect( getJetpackSiteByUrl( state, 'example.wordpress.com' ) ).to.be.null;
+			expect( getJetpackSiteByUrl( state, 'example.wordpress.com' ) ).toBeNull();
 		} );
 
 		test( 'should return false if the site is not a jetpack site', () => {
@@ -458,7 +452,7 @@ describe( 'selectors', () => {
 				},
 			};
 
-			expect( getJetpackSiteByUrl( state, 'https://example.wordpress.com/' ) ).to.be.null;
+			expect( getJetpackSiteByUrl( state, 'https://example.wordpress.com/' ) ).toBeNull();
 		} );
 
 		test( 'should return the site object if the site is a jetpack site', () => {
@@ -474,7 +468,7 @@ describe( 'selectors', () => {
 				},
 			};
 
-			expect( getJetpackSiteByUrl( state, 'https://example.wordpress.com/' ) ).to.eql(
+			expect( getJetpackSiteByUrl( state, 'https://example.wordpress.com/' ) ).toEqual(
 				state.sites.items[ 12345678 ]
 			);
 		} );
@@ -525,30 +519,30 @@ describe( 'selectors', () => {
 
 		test( 'should be false when there is an empty state', () => {
 			const hasError = hasXmlrpcError( { jetpackConnect: {} } );
-			expect( hasError ).to.be.false;
+			expect( hasError ).toBe( false );
 		} );
 
 		test( 'should be false when there is no error', () => {
 			const hasError = hasXmlrpcError( stateHasNoError );
-			expect( hasError ).to.be.false;
+			expect( hasError ).toBe( false );
 		} );
 
 		test( 'should be false when there is no authorization code', () => {
 			// An authorization code is received during the jetpack.login portion of the connection
 			// XMLRPC errors happen only during jetpack.authorize which only happens after jetpack.login is succesful
 			const hasError = hasXmlrpcError( stateHasNoAuthorizationCode );
-			expect( hasError ).to.be.false;
+			expect( hasError ).toBe( false );
 		} );
 
 		test( 'should be false if a non-xmlrpc error is found', () => {
 			// eg a user is already connected, or they've taken too long and their secret expired
 			const hasError = hasXmlrpcError( stateHasOtherError );
-			expect( hasError ).to.be.false;
+			expect( hasError ).toBe( false );
 		} );
 
 		test( 'should be true if all the conditions are met', () => {
 			const hasError = hasXmlrpcError( stateHasXmlrpcError );
-			expect( hasError ).to.be.true;
+			expect( hasError ).toBe( true );
 		} );
 	} );
 
@@ -595,30 +589,30 @@ describe( 'selectors', () => {
 
 		test( 'should be false when there is an empty state', () => {
 			const hasError = hasExpiredSecretError( { jetpackConnect: {} } );
-			expect( hasError ).to.be.false;
+			expect( hasError ).toBe( false );
 		} );
 
 		test( 'should be false when there is no error', () => {
 			const hasError = hasExpiredSecretError( stateHasNoError );
-			expect( hasError ).to.be.false;
+			expect( hasError ).toBe( false );
 		} );
 
 		test( 'should be false when there is no authorization code', () => {
 			// An authorization code is received during the jetpack.login portion of the connection
 			// Expired secret errors happen only during jetpack.authorize which only happens after jetpack.login is succesful
 			const hasError = hasExpiredSecretError( stateHasNoAuthorizationCode );
-			expect( hasError ).to.be.false;
+			expect( hasError ).toBe( false );
 		} );
 
 		test( 'should be false if no expired secret error is found', () => {
 			// eg a user is already connected, or they've taken too long and their secret expired
 			const hasError = hasExpiredSecretError( stateHasOtherError );
-			expect( hasError ).to.be.false;
+			expect( hasError ).toBe( false );
 		} );
 
 		test( 'should be true if all the conditions are met', () => {
 			const hasError = hasExpiredSecretError( stateHasExpiredSecretError );
-			expect( hasError ).to.be.true;
+			expect( hasError ).toBe( true );
 		} );
 	} );
 
@@ -630,7 +624,7 @@ describe( 'selectors', () => {
 				},
 			};
 
-			expect( getAuthAttempts( state, 'sitetest.com' ) ).to.equals( 0 );
+			expect( getAuthAttempts( state, 'sitetest.com' ) ).toBe( 0 );
 		} );
 
 		test( "should return 0 if there's stored info for the site, but it's stale", () => {
@@ -645,7 +639,7 @@ describe( 'selectors', () => {
 				},
 			};
 
-			expect( getAuthAttempts( state, 'sitetest.com' ) ).to.equals( 0 );
+			expect( getAuthAttempts( state, 'sitetest.com' ) ).toBe( 0 );
 		} );
 
 		test( "should return the attempt number if there's stored info for the site, and it's not stale", () => {
@@ -660,7 +654,7 @@ describe( 'selectors', () => {
 				},
 			};
 
-			expect( getAuthAttempts( state, 'sitetest.com' ) ).to.equals( 2 );
+			expect( getAuthAttempts( state, 'sitetest.com' ) ).toBe( 2 );
 		} );
 	} );
 
@@ -675,7 +669,7 @@ describe( 'selectors', () => {
 					},
 				},
 			};
-			expect( getSiteIdFromQueryObject( state ) ).to.equals( 123 );
+			expect( getSiteIdFromQueryObject( state ) ).toBe( 123 );
 		} );
 
 		test( 'should return null if there is no query object', () => {
@@ -684,7 +678,7 @@ describe( 'selectors', () => {
 					jetpackConnectAuthorize: {},
 				},
 			};
-			expect( getSiteIdFromQueryObject( state ) ).to.be.null;
+			expect( getSiteIdFromQueryObject( state ) ).toBeNull();
 		} );
 
 		test( 'should return null if there is no client id', () => {
@@ -695,7 +689,7 @@ describe( 'selectors', () => {
 					},
 				},
 			};
-			expect( getSiteIdFromQueryObject( state ) ).to.be.null;
+			expect( getSiteIdFromQueryObject( state ) ).toBeNull();
 		} );
 	} );
 } );

--- a/client/state/jetpack-connect/test/utils.js
+++ b/client/state/jetpack-connect/test/utils.js
@@ -1,10 +1,4 @@
 /** @format */
-
-/**
- * External dependencies
- */
-import { expect } from 'chai';
-
 /**
  * Internal dependencies
  */
@@ -13,31 +7,31 @@ import { isStale } from '../utils';
 describe( 'utils', () => {
 	describe( '#isStale()', () => {
 		test( 'should return false if the passed timestamp is null', () => {
-			expect( isStale( null ) ).to.be.false;
+			expect( isStale( null ) ).toBe( false );
 		} );
 
 		test( 'should return false if the passed timestamp is undefined', () => {
-			expect( isStale( undefined ) ).to.be.false;
+			expect( isStale( undefined ) ).toBe( false );
 		} );
 
 		test( 'should return false if the passed timestamp is not stale', () => {
-			expect( isStale( new Date().getTime() - 60 ) ).to.be.false;
+			expect( isStale( new Date().getTime() - 60 ) ).toBe( false );
 		} );
 
 		test( 'should return false if the passed timestamp is a millisecond away from being stale', () => {
-			expect( isStale( new Date().getTime() ) ).to.be.false;
+			expect( isStale( new Date().getTime() ) ).toBe( false );
 		} );
 
 		test( 'should return true if the passed timestamp is stale', () => {
-			expect( isStale( 1 ) ).to.be.true;
+			expect( isStale( 1 ) ).toBe( true );
 		} );
 
 		test( 'should return false if the timestamp is not stale with a specific expiration', () => {
-			expect( isStale( new Date().getTime(), 60 ) ).to.be.false;
+			expect( isStale( new Date().getTime(), 60 ) ).toBe( false );
 		} );
 
 		test( 'should return true if the timestamp is stale with a specific expiration', () => {
-			expect( isStale( new Date().getTime() - 61, 60 ) ).to.be.true;
+			expect( isStale( new Date().getTime() - 61, 60 ) ).toBe( true );
 		} );
 	} );
 } );


### PR DESCRIPTION
This PR rewrites Jetpack Connect tests using jest. This removes the `chai` dependency, as well as some sandboxing and spies (replace with Jest spies: `jest.fn()`).

In many cases, it results in more expressive tests with `toMatchObject` rather than a sequence of `to.have.property().to.be.equals()`.

One small sacrifice is verifying that a timestamp is `>= now`, which has been translated to `any( Number )`. This is a small sacrifice and the value lost is minimal.

## Testing
1. Tests should pass