### PR TITLE
Comments: add single comment view

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -321,6 +321,7 @@
 @import 'my-sites/ads/style';
 @import 'my-sites/all-sites/style';
 @import 'my-sites/all-sites-icon/style';
+@import 'my-sites/comment/style';
 @import 'my-sites/comments/style';
 @import 'my-sites/comments/comment/style';
 @import 'my-sites/current-site/style';

--- a/client/blocks/comment-detail/comment-detail-author.jsx
+++ b/client/blocks/comment-detail/comment-detail-author.jsx
@@ -13,6 +13,7 @@ import { some } from 'lodash';
 /**
  * Internal dependencies
  */
+import { isEnabled } from 'config';
 import CommentDetailAuthorMoreInfo from './comment-detail-author-more-info';
 import Emojify from 'components/emojify';
 import ExternalLink from 'components/external-link';
@@ -21,6 +22,7 @@ import { urlToDomainAndPath } from 'lib/url';
 import { convertDateToUserLocation } from 'components/post-schedule/utils';
 import { gmtOffset, timezone } from 'lib/site/utils';
 import { getSite } from 'state/sites/selectors';
+import { getSelectedSiteSlug } from 'state/ui/selectors';
 
 export const CommentDetailAuthor = ( {
 	authorAvatarUrl,
@@ -109,8 +111,14 @@ export const CommentDetailAuthor = ( {
 	);
 };
 
-const mapStateToProps = ( state, { siteId } ) => ( {
-	site: getSite( state, siteId ),
-} );
+const mapStateToProps = ( state, { siteId, commentId, commentUrl } ) => {
+	const siteSlug = getSelectedSiteSlug( state );
 
+	return {
+		site: getSite( state, siteId ),
+		commentUrl: isEnabled( 'comments/management/comment-view' )
+			? `/comment/${ siteSlug }/${ commentId }`
+			: commentUrl,
+	};
+};
 export default connect( mapStateToProps )( localize( CommentDetailAuthor ) );

--- a/client/blocks/comment-detail/comment-detail-author.jsx
+++ b/client/blocks/comment-detail/comment-detail-author.jsx
@@ -13,7 +13,6 @@ import { some } from 'lodash';
 /**
  * Internal dependencies
  */
-import { isEnabled } from 'config';
 import CommentDetailAuthorMoreInfo from './comment-detail-author-more-info';
 import Emojify from 'components/emojify';
 import ExternalLink from 'components/external-link';
@@ -22,7 +21,6 @@ import { urlToDomainAndPath } from 'lib/url';
 import { convertDateToUserLocation } from 'components/post-schedule/utils';
 import { gmtOffset, timezone } from 'lib/site/utils';
 import { getSite } from 'state/sites/selectors';
-import { getSelectedSiteSlug } from 'state/ui/selectors';
 
 export const CommentDetailAuthor = ( {
 	authorAvatarUrl,
@@ -111,14 +109,8 @@ export const CommentDetailAuthor = ( {
 	);
 };
 
-const mapStateToProps = ( state, { siteId, commentId, commentUrl } ) => {
-	const siteSlug = getSelectedSiteSlug( state );
+const mapStateToProps = ( state, { siteId } ) => ( {
+	site: getSite( state, siteId ),
+} );
 
-	return {
-		site: getSite( state, siteId ),
-		commentUrl: isEnabled( 'comments/management/comment-view' )
-			? `/comment/${ siteSlug }/${ commentId }`
-			: commentUrl,
-	};
-};
 export default connect( mapStateToProps )( localize( CommentDetailAuthor ) );

--- a/client/components/data/moderate-comment/index.jsx
+++ b/client/components/data/moderate-comment/index.jsx
@@ -1,0 +1,110 @@
+/** @format */
+/**
+ * External dependencies
+ *
+ */
+import { Component } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import {
+	bumpStat,
+	composeAnalytics,
+	recordTracksEvent,
+	withAnalytics,
+} from 'state/analytics/actions';
+import { changeCommentStatus, deleteComment } from 'state/comments/actions';
+import { getSiteComment } from 'state/selectors';
+
+class ModerateComment extends Component {
+	static propTypes = {
+		siteId: PropTypes.number,
+		postId: PropTypes.number,
+		commentId: PropTypes.number.isRequired,
+		newStatus: PropTypes.string,
+		currentStatus: PropTypes.string,
+		updateCommentStatus: PropTypes.func.isRequired,
+		destroyComment: PropTypes.func.isRequired,
+	};
+
+	componentDidMount() {
+		this.moderate( this.props );
+	}
+
+	componentWillReceiveProps( nextProps ) {
+		if (
+			this.props.siteId === nextProps.siteId &&
+			this.props.postId === nextProps.postId &&
+			this.props.commentId === nextProps.commentId &&
+			this.props.newStatus === nextProps.newStatus
+		) {
+			return;
+		}
+
+		this.moderate( nextProps );
+	}
+
+	moderate( {
+		siteId,
+		postId,
+		commentId,
+		newStatus,
+		currentStatus,
+		updateCommentStatus,
+		destroyComment,
+	} ) {
+		if ( ! siteId || ! postId || ! commentId || ! newStatus || newStatus === currentStatus ) {
+			return;
+		}
+
+		if ( 'delete' === newStatus ) {
+			destroyComment();
+			return;
+		}
+
+		updateCommentStatus();
+	}
+
+	render() {
+		return null;
+	}
+}
+
+const mapStateToProps = ( state, { siteId, commentId } ) => {
+	const comment = getSiteComment( state, siteId, commentId );
+
+	return {
+		currentStatus: get( comment, 'status' ),
+	};
+};
+
+const mapDispatchToProps = ( dispatch, { siteId, postId, commentId, newStatus } ) => ( {
+	updateCommentStatus: () =>
+		dispatch(
+			withAnalytics(
+				composeAnalytics(
+					recordTracksEvent( 'calypso_comment_management_change_status_from_email', {
+						status: newStatus,
+					} ),
+					bumpStat( 'calypso_comment_management', 'comment_status_changed_to_' + newStatus )
+				),
+				changeCommentStatus( siteId, postId, commentId, newStatus )
+			)
+		),
+	destroyComment: () =>
+		dispatch(
+			withAnalytics(
+				composeAnalytics(
+					recordTracksEvent( 'calypso_comment_management_delete' ),
+					bumpStat( 'calypso_comment_management', 'comment_deleted' )
+				),
+				deleteComment( siteId, postId, commentId )
+			)
+		),
+} );
+
+export default connect( mapStateToProps, mapDispatchToProps )( ModerateComment );

--- a/client/my-sites/comment/comment-permalink.jsx
+++ b/client/my-sites/comment/comment-permalink.jsx
@@ -16,7 +16,7 @@ import SectionHeader from 'components/section-header';
 import ExternalLink from 'components/external-link';
 import { getSiteComment } from 'state/selectors';
 
-const CommentPermailnk = ( { isLoading, permaLink, translate } ) =>
+const CommentPermalink = ( { isLoading, permaLink, translate } ) =>
 	! isLoading && (
 		<Card className="comment__comment-permalink">
 			<SectionHeader label={ translate( 'Comment Permalink' ) } />
@@ -26,7 +26,7 @@ const CommentPermailnk = ( { isLoading, permaLink, translate } ) =>
 		</Card>
 	);
 
-CommentPermailnk.propTypes = {
+CommentPermalink.propTypes = {
 	siteId: PropTypes.number.isRequired,
 	commentId: PropTypes.number.isRequired,
 	isLoading: PropTypes.bool.isRequired,
@@ -43,4 +43,4 @@ const mapStateToProps = ( state, { siteId, commentId } ) => {
 	};
 };
 
-export default connect( mapStateToProps )( localize( CommentPermailnk ) );
+export default connect( mapStateToProps )( localize( CommentPermalink ) );

--- a/client/my-sites/comment/comment-permalink.jsx
+++ b/client/my-sites/comment/comment-permalink.jsx
@@ -1,0 +1,43 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import Card from 'components/card';
+import SectionHeader from 'components/section-header';
+import ExternalLink from 'components/external-link';
+import { getSiteComment } from 'state/selectors';
+
+const CommentPermailnk = ( { permaLink, translate } ) => (
+	<Card className="comment__comment-permalink">
+		<SectionHeader label={ translate( 'Comment Permalink' ) } />
+		<ExternalLink icon={ true } href={ permaLink }>
+			{ permaLink }
+		</ExternalLink>
+	</Card>
+);
+
+CommentPermailnk.propTypes = {
+	siteId: PropTypes.number.isRequired,
+	commentId: PropTypes.number.isRequired,
+	permaLink: PropTypes.string,
+	translate: PropTypes.func.isRequired,
+};
+
+const mapStateToProps = ( state, { siteId, commentId } ) => {
+	const comment = getSiteComment( state, siteId, commentId );
+
+	return {
+		permaLink: get( comment, 'URL', '' ),
+	};
+};
+
+export default connect( mapStateToProps )( localize( CommentPermailnk ) );

--- a/client/my-sites/comment/comment-permalink.jsx
+++ b/client/my-sites/comment/comment-permalink.jsx
@@ -6,7 +6,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { get } from 'lodash';
+import { get, isUndefined } from 'lodash';
 
 /**
  * Internal dependencies
@@ -16,18 +16,20 @@ import SectionHeader from 'components/section-header';
 import ExternalLink from 'components/external-link';
 import { getSiteComment } from 'state/selectors';
 
-const CommentPermailnk = ( { permaLink, translate } ) => (
-	<Card className="comment__comment-permalink">
-		<SectionHeader label={ translate( 'Comment Permalink' ) } />
-		<ExternalLink icon={ true } href={ permaLink }>
-			{ permaLink }
-		</ExternalLink>
-	</Card>
-);
+const CommentPermailnk = ( { isLoading, permaLink, translate } ) =>
+	! isLoading && (
+		<Card className="comment__comment-permalink">
+			<SectionHeader label={ translate( 'Comment Permalink' ) } />
+			<ExternalLink icon={ true } href={ permaLink }>
+				{ permaLink }
+			</ExternalLink>
+		</Card>
+	);
 
 CommentPermailnk.propTypes = {
 	siteId: PropTypes.number.isRequired,
 	commentId: PropTypes.number.isRequired,
+	isLoading: PropTypes.bool.isRequired,
 	permaLink: PropTypes.string,
 	translate: PropTypes.func.isRequired,
 };
@@ -36,6 +38,7 @@ const mapStateToProps = ( state, { siteId, commentId } ) => {
 	const comment = getSiteComment( state, siteId, commentId );
 
 	return {
+		isLoading: isUndefined( comment ),
 		permaLink: get( comment, 'URL', '' ),
 	};
 };

--- a/client/my-sites/comment/comment-permalink.jsx
+++ b/client/my-sites/comment/comment-permalink.jsx
@@ -27,7 +27,7 @@ const CommentPermalink = ( { isLoading, permaLink, translate } ) =>
 	);
 
 CommentPermalink.propTypes = {
-	siteId: PropTypes.number.isRequired,
+	siteId: PropTypes.number,
 	commentId: PropTypes.number.isRequired,
 	isLoading: PropTypes.bool.isRequired,
 	permaLink: PropTypes.string,

--- a/client/my-sites/comment/main.jsx
+++ b/client/my-sites/comment/main.jsx
@@ -68,7 +68,7 @@ const mapStateToProps = ( state, ownProps ) => {
 	const comment = getSiteComment( state, siteId, commentId );
 	const postId = get( comment, 'post.ID' );
 
-	const canModerateComments = canCurrentUser( state, siteId, 'moderate_comments' );
+	const canModerateComments = canCurrentUser( state, siteId, 'moderate_comments' ) || false;
 	// const showJetpackUpdateScreen =
 	// 	isJetpack &&
 	// 	! isJetpackMinimumVersion( state, siteId, '5.5' ) &&

--- a/client/my-sites/comment/main.jsx
+++ b/client/my-sites/comment/main.jsx
@@ -11,10 +11,8 @@ import { get } from 'lodash';
 /**
  * Internal dependencies
  */
-// import { isEnabled } from 'config';
 import EmptyContent from 'components/empty-content';
 import getSiteId from 'state/selectors/get-site-id';
-// import { isJetpackSite, isJetpackMinimumVersion } from 'state/sites/selectors';
 import Main from 'components/main';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import DocumentHead from 'components/data/document-head';
@@ -64,15 +62,10 @@ const mapStateToProps = ( state, ownProps ) => {
 	const { commentId, siteFragment } = ownProps;
 
 	const siteId = getSiteId( state, siteFragment );
-	// const isJetpack = isJetpackSite( state, siteId );
 	const comment = getSiteComment( state, siteId, commentId );
 	const postId = get( comment, 'post.ID' );
 
-	const canModerateComments = canCurrentUser( state, siteId, 'moderate_comments' ) || false;
-	// const showJetpackUpdateScreen =
-	// 	isJetpack &&
-	// 	! isJetpackMinimumVersion( state, siteId, '5.5' ) &&
-	// 	isEnabled( 'comments/management/jetpack-5.5' );
+	const canModerateComments = canCurrentUser( state, siteId, 'moderate_comments' ) !== false;
 
 	return {
 		siteId,

--- a/client/my-sites/comment/main.jsx
+++ b/client/my-sites/comment/main.jsx
@@ -1,0 +1,84 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+// import { isEnabled } from 'config';
+import EmptyContent from 'components/empty-content';
+import getSiteId from 'state/selectors/get-site-id';
+// import { isJetpackSite, isJetpackMinimumVersion } from 'state/sites/selectors';
+import Main from 'components/main';
+import PageViewTracker from 'lib/analytics/page-view-tracker';
+import DocumentHead from 'components/data/document-head';
+import Comment from 'my-sites/comments/comment';
+import CommentPermalink from 'my-sites/comment/comment-permalink';
+import CommentListHeader from 'my-sites/comments/comment-list/comment-list-header';
+import { getSiteComment, canCurrentUser } from 'state/selectors';
+import { preventWidows } from 'lib/formatting';
+
+export class CommentView extends Component {
+	static propTypes = {
+		siteId: PropTypes.number,
+		postId: PropTypes.number,
+		commentId: PropTypes.number.isRequired,
+		canModerateComments: PropTypes.bool.isRequired,
+		translate: PropTypes.func.isRequired,
+	};
+
+	render() {
+		const { siteId, postId, commentId, canModerateComments, translate } = this.props;
+
+		return (
+			// eslint-disable-next-line wpcalypso/jsx-classname-namespace
+			<Main className="comments" wideLayout>
+				<PageViewTracker path="/comment/:site" title="Comments" />
+				<DocumentHead title={ translate( 'Comment' ) } />
+				<CommentListHeader { ...{ postId } } />
+				{ ! canModerateComments && (
+					<EmptyContent
+						title={ preventWidows(
+							translate( "Oops! You don't have permission to manage comments." )
+						) }
+						line={ preventWidows(
+							translate( "If you think you should, contact this site's administrator." )
+						) }
+						illustration="/calypso/images/illustrations/illustration-500.svg"
+					/>
+				) }
+				{ canModerateComments && <Comment commentId={ commentId } refreshCommentData={ true } /> }
+				{ canModerateComments && <CommentPermalink { ...{ siteId, commentId } } /> }
+			</Main>
+		);
+	}
+}
+
+const mapStateToProps = ( state, ownProps ) => {
+	const { commentId, siteFragment } = ownProps;
+
+	const siteId = getSiteId( state, siteFragment );
+	// const isJetpack = isJetpackSite( state, siteId );
+	const comment = getSiteComment( state, siteId, commentId );
+	const postId = get( comment, 'post.ID' );
+
+	const canModerateComments = canCurrentUser( state, siteId, 'moderate_comments' );
+	// const showJetpackUpdateScreen =
+	// 	isJetpack &&
+	// 	! isJetpackMinimumVersion( state, siteId, '5.5' ) &&
+	// 	isEnabled( 'comments/management/jetpack-5.5' );
+
+	return {
+		siteId,
+		postId,
+		canModerateComments,
+	};
+};
+
+export default connect( mapStateToProps )( localize( CommentView ) );

--- a/client/my-sites/comment/main.jsx
+++ b/client/my-sites/comment/main.jsx
@@ -11,34 +11,39 @@ import { get } from 'lodash';
 /**
  * Internal dependencies
  */
-import EmptyContent from 'components/empty-content';
-import getSiteId from 'state/selectors/get-site-id';
 import Main from 'components/main';
-import PageViewTracker from 'lib/analytics/page-view-tracker';
+import EmptyContent from 'components/empty-content';
 import DocumentHead from 'components/data/document-head';
+import ModerateComment from 'components/data/moderate-comment';
 import Comment from 'my-sites/comments/comment';
 import CommentPermalink from 'my-sites/comment/comment-permalink';
 import CommentListHeader from 'my-sites/comments/comment-list/comment-list-header';
-import { getSiteComment, canCurrentUser } from 'state/selectors';
+import PageViewTracker from 'lib/analytics/page-view-tracker';
 import { preventWidows } from 'lib/formatting';
+import { getSiteComment, canCurrentUser } from 'state/selectors';
+import getSiteId from 'state/selectors/get-site-id';
 
 export class CommentView extends Component {
 	static propTypes = {
 		siteId: PropTypes.number,
 		postId: PropTypes.number,
 		commentId: PropTypes.number.isRequired,
+		action: PropTypes.string,
 		canModerateComments: PropTypes.bool.isRequired,
 		translate: PropTypes.func.isRequired,
 	};
 
 	render() {
-		const { siteId, postId, commentId, canModerateComments, translate } = this.props;
+		const { siteId, postId, commentId, action, canModerateComments, translate } = this.props;
 
 		return (
 			// eslint-disable-next-line wpcalypso/jsx-classname-namespace
 			<Main className="comments" wideLayout>
 				<PageViewTracker path="/comment/:site" title="Comments" />
 				<DocumentHead title={ translate( 'Comment' ) } />
+				{ canModerateComments && (
+					<ModerateComment { ...{ siteId, postId, commentId, newStatus: action } } />
+				) }
 				<CommentListHeader { ...{ postId } } />
 				{ ! canModerateComments && (
 					<EmptyContent

--- a/client/my-sites/comment/style.scss
+++ b/client/my-sites/comment/style.scss
@@ -1,0 +1,13 @@
+.comment__comment-permalink {
+	padding: 0;
+	margin-top: 16px;
+
+	.section-header {
+		margin: 0;
+	}
+
+	.external-link {
+		display: block;
+		padding: 24px;
+	}
+}

--- a/client/my-sites/comment/style.scss
+++ b/client/my-sites/comment/style.scss
@@ -9,5 +9,6 @@
 	.external-link {
 		display: block;
 		padding: 24px;
+		word-wrap: break-word;
 	}
 }

--- a/client/my-sites/comments/comment/comment-author.jsx
+++ b/client/my-sites/comments/comment/comment-author.jsx
@@ -12,6 +12,7 @@ import { get } from 'lodash';
 /**
  * Internal dependencies
  */
+import { isEnabled } from 'config';
 import Emojify from 'components/emojify';
 import ExternalLink from 'components/external-link';
 import Gravatar from 'components/gravatar';
@@ -19,7 +20,7 @@ import CommentPostLink from 'my-sites/comments/comment/comment-post-link';
 import { decodeEntities } from 'lib/formatting';
 import { urlToDomainAndPath } from 'lib/url';
 import { getSiteComment } from 'state/selectors';
-import { getSelectedSiteId } from 'state/ui/selectors';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 
 export class CommentAuthor extends Component {
 	static propTypes = {
@@ -107,6 +108,7 @@ export class CommentAuthor extends Component {
 
 const mapStateToProps = ( state, { commentId } ) => {
 	const siteId = getSelectedSiteId( state );
+	const siteSlug = getSelectedSiteSlug( state );
 	const comment = getSiteComment( state, siteId, commentId );
 	const authorAvatarUrl = get( comment, 'author.avatar_URL' );
 	const authorDisplayName = decodeEntities( get( comment, 'author.name' ) );
@@ -119,7 +121,9 @@ const mapStateToProps = ( state, { commentId } ) => {
 		commentContent: get( comment, 'content' ),
 		commentDate: get( comment, 'date' ),
 		commentType: get( comment, 'type', 'comment' ),
-		commentUrl: get( comment, 'URL' ),
+		commentUrl: isEnabled( 'comments/management/comment-view' )
+			? `/comment/${ siteSlug }/${ commentId }`
+			: get( comment, 'URL' ),
 		gravatarUser,
 	};
 };

--- a/client/my-sites/comments/comment/comment-author.jsx
+++ b/client/my-sites/comments/comment/comment-author.jsx
@@ -87,9 +87,9 @@ export class CommentAuthor extends Component {
 
 					<div className="comment__author-info-element">
 						<span className="comment__date">
-							<ExternalLink href={ commentUrl } title={ formattedDate }>
+							<a href={ commentUrl } title={ formattedDate }>
 								{ relativeDate }
-							</ExternalLink>
+							</a>
 						</span>
 						{ authorUrl && (
 							<span className="comment__author-url">

--- a/client/my-sites/comments/comment/comment-author.jsx
+++ b/client/my-sites/comments/comment/comment-author.jsx
@@ -87,9 +87,15 @@ export class CommentAuthor extends Component {
 
 					<div className="comment__author-info-element">
 						<span className="comment__date">
-							<a href={ commentUrl } title={ formattedDate }>
-								{ relativeDate }
-							</a>
+							{ isEnabled( 'comments/management/comment-view' ) ? (
+								<a href={ commentUrl } title={ formattedDate }>
+									{ relativeDate }
+								</a>
+							) : (
+								<ExternalLink href={ commentUrl } title={ formattedDate }>
+									{ relativeDate }
+								</ExternalLink>
+							) }
 						</span>
 						{ authorUrl && (
 							<span className="comment__author-url">

--- a/client/my-sites/comments/controller.js
+++ b/client/my-sites/comments/controller.js
@@ -2,7 +2,6 @@
 /**
  * External dependencies
  */
-import { renderWithReduxStore } from 'lib/react-helpers';
 import React from 'react';
 import page from 'page';
 import { each, isNaN, startsWith } from 'lodash';
@@ -11,16 +10,10 @@ import { each, isNaN, startsWith } from 'lodash';
  * Internal dependencies
  */
 import { isEnabled } from 'config';
+import { renderWithReduxStore } from 'lib/react-helpers';
+import route, { addQueryArgs } from 'lib/route';
 import CommentsManagement from './main';
 import CommentView from 'my-sites/comment/main';
-import route, { addQueryArgs } from 'lib/route';
-import {
-	bumpStat,
-	composeAnalytics,
-	recordTracksEvent,
-	withAnalytics,
-} from 'state/analytics/actions';
-import { changeCommentStatus, deleteComment } from 'state/comments/actions';
 import { removeNotice } from 'state/notices/actions';
 import { getNotices } from 'state/notices/selectors';
 
@@ -29,6 +22,23 @@ const mapPendingStatusToUnapproved = status => ( 'pending' === status ? 'unappro
 const sanitizeInt = number => {
 	const integer = parseInt( number, 10 );
 	return ! isNaN( integer ) && integer > 0 ? integer : false;
+};
+
+const sanitizeQueryAction = action => {
+	if ( ! action ) {
+		return null;
+	}
+
+	const validActions = {
+		approve: 'approved',
+		unapprove: 'unapproved',
+		trash: 'trash',
+		spam: 'spam',
+		delete: 'delete',
+	};
+	return validActions.hasOwnProperty( action.toLowerCase() )
+		? validActions[ action.toLowerCase() ]
+		: null;
 };
 
 const changePage = path => pageNumber => {
@@ -97,33 +107,6 @@ export const postComments = ( { params, path, query, store } ) => {
 	);
 };
 
-const sanitizeQueryAction = action => {
-	if ( ! action ) {
-		return null;
-	}
-
-	const validActions = {
-		approve: 'approved',
-		trash: 'trash',
-		spam: 'spam',
-		delete: 'delete',
-	};
-	return validActions.hasOwnProperty( action.toLowerCase() )
-		? validActions[ action.toLowerCase() ]
-		: null;
-};
-
-const updateCommentStatus = ( siteId, postId, commentId, status ) =>
-	withAnalytics(
-		composeAnalytics(
-			recordTracksEvent( 'calypso_comment_management_mail_change_status', {
-				status,
-			} ),
-			bumpStat( 'calypso_comment_management_mail', 'comment_status_changed_to_' + status )
-		),
-		changeCommentStatus( siteId, postId, commentId, status )
-	);
-
 export const comment = ( { query, params, path, store } ) => {
 	const siteFragment = route.getSiteFragment( path );
 	const commentId = sanitizeInt( params.comment );
@@ -135,22 +118,6 @@ export const comment = ( { query, params, path, store } ) => {
 	}
 
 	const action = sanitizeQueryAction( query.action );
-	const siteId = sanitizeInt( query.site_id );
-	const postId = sanitizeInt( query.post_id );
-
-	/* SECURITY WARNING
-	 *
-	 * we may not have user capabilities loaded onto state.
-	 * We trust that the API will handle user capabilities for us.
-	 */
-	if ( action && siteId && postId ) {
-		const { dispatch } = store;
-		if ( 'delete' === action ) {
-			dispatch( deleteComment( siteId, postId, commentId, { showSuccessNotice: true } ) );
-		} else {
-			dispatch( updateCommentStatus( siteId, postId, commentId, action ) );
-		}
-	}
 
 	renderWithReduxStore(
 		<CommentView { ...{ action, commentId, siteFragment } } />,

--- a/client/my-sites/sidebar/manage-menu.jsx
+++ b/client/my-sites/sidebar/manage-menu.jsx
@@ -111,6 +111,7 @@ class ManageMenu extends PureComponent {
 				queryable: true,
 				config: 'comments/management',
 				link: '/comments',
+				paths: [ '/comment', '/comments' ],
 				wpAdminLink: 'edit-comments.php',
 				showOnAllMySites: false,
 			},


### PR DESCRIPTION
Closes #18321 

Very much in progress, but hidden under a feature flag 😄 

Depends on:
- [ ] D8153-code
- [x] #19560: Comments Redesign: Always expanded view

This PR adds to new view for single comments, with the capability of performing moderation actions via query string parameters.

![screen shot 2017-11-09 at 11 27 48](https://user-images.githubusercontent.com/233601/32611139-8e10dfa8-c543-11e7-97a2-ce41e9523438.png)

What to expect


~~This PR works only with the M3 redesign feature flag and depends heavily on components that still have work in progress, so warnings and errors are expected. Also, there's a regression on the comment list that shows all panels open, until #19560 gets resolved.~~
Also, there's duplication of code until dependent PRs get merged.

What to test:

The main reason this view exists is to perform moderation actions from emails. That's the area that requires testing at the moment. Most design elements depends on other M3 redesign PRs and will adjust once they are merged.

How to test:
- Start Calypso with `ENABLE_FEATURES=comments/management/m3-design npm start`
- Navigate to a comment by clicking on the timestamp link.
- With WP.com Sandbox:
  - Sandbox a WordPress.com site.
  - Verify that comments moderation is required on _Settings_ > _Discussion_ > _Comment must be manually approved_ for the sandboxed site
  - Apply D8153-code on your sandbox
  - Create a new comment with non editor user
  - You should receive an email notification with and `Approve`, `Spam` and `Trash`
  - Clicking on any of those links should perform the corresponding action
- Without a WP.com Sandbox
  - Navigate to a comment
  - manually add to the url the following parameters as query string:
    - `action`: either `approve`, `spam`, `trash` or `delete`
    - for example`/comment/rodrigoidummyfreesite.wordpress.com/165?action=approve`