### PR TITLE
Framework: Upgrade store to v2

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1025,7 +1025,7 @@
       "version": "2.1.0"
     },
     "clone": {
-      "version": "1.0.2",
+      "version": "1.0.3",
       "dev": true
     },
     "clone-regexp": {
@@ -1043,7 +1043,7 @@
       "version": "1.1.0"
     },
     "color-convert": {
-      "version": "1.9.0"
+      "version": "1.9.1"
     },
     "color-diff": {
       "version": "0.1.7",
@@ -2211,7 +2211,7 @@
       "dev": true
     },
     "flow-parser": {
-      "version": "0.58.0",
+      "version": "0.59.0",
       "dev": true
     },
     "flux": {
@@ -6573,7 +6573,7 @@
       }
     },
     "store": {
-      "version": "1.3.16"
+      "version": "2.0.12"
     },
     "stream-browserify": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
     "socket.io-client": "1.4.5",
     "source-map": "0.1.39",
     "source-map-support": "0.3.2",
-    "store": "1.3.16",
+    "store": "2.0.12",
     "striptags": "2.1.1",
     "superagent": "2.1.0",
     "tinymce": "4.6.3",


### PR DESCRIPTION
We've been talking about this for a while. This is supposed to not break on the server side where `document` isn't available.

[ChangeLog](https://github.com/marcuswestin/store.js/blob/master/Changelog)

To test:
Run Calypso. This thing is all over the place, so click around wildly and see if anything breaks.