### PR TITLE
Store Orders: Enable editing of the shipping total

### DIFF
--- a/client/extensions/woocommerce/app/order/order-details/table.js
+++ b/client/extensions/woocommerce/app/order/order-details/table.js
@@ -16,6 +16,7 @@ import Button from 'components/button';
 import formatCurrency from 'lib/format-currency';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import FormTextInput from 'components/forms/form-text-input';
+import { getCurrencyFormatDecimal } from 'woocommerce/lib/currency';
 import { getLink } from 'woocommerce/lib/nav-utils';
 import {
 	getOrderDiscountTax,
@@ -27,6 +28,7 @@ import {
 import {
 	getOrderItemCost,
 	getOrderRefundTotal,
+	getOrderShippingTotal,
 	getOrderTotal,
 } from 'woocommerce/lib/order-values/totals';
 import OrderAddItems from './add-items';
@@ -112,6 +114,20 @@ class OrderDetailsTable extends Component {
 		const total = subtotal;
 		const newItem = { ...item, quantity, subtotal, total };
 		this.props.onChange( { line_items: { [ index ]: newItem } } );
+	};
+
+	onShippingChange = event => {
+		const { order } = this.props;
+		const shippingLine = order.shipping_lines[ 0 ];
+		const total = event.target.value;
+		this.props.onChange( { shipping_lines: [ { ...shippingLine, total } ] } );
+	};
+
+	formatShippingValue = () => {
+		const { order } = this.props;
+		const shippingLine = order.shipping_lines[ 0 ];
+		const total = getCurrencyFormatDecimal( shippingLine.total );
+		this.props.onChange( { shipping_lines: [ { ...shippingLine, total } ] } );
 	};
 
 	onDelete = ( id, type = 'line_items' ) => {
@@ -284,9 +300,12 @@ class OrderDetailsTable extends Component {
 					<OrderTotalRow
 						currency={ order.currency }
 						label={ translate( 'Shipping' ) }
-						value={ order.shipping_total }
+						value={ getOrderShippingTotal( order ) }
 						taxValue={ getOrderShippingTax( order ) }
 						showTax={ showTax }
+						isEditable={ isEditing }
+						onChange={ this.onShippingChange }
+						onBlur={ this.formatShippingValue }
 					/>
 					<OrderTotalRow
 						className="order-details__total-full"


### PR DESCRIPTION
See #15681 – This PR enables the shipping total to be edited when editing an order.

<img width="731" alt="screen shot 2017-11-09 at 11 57 45 am" src="https://user-images.githubusercontent.com/541093/32618314-5a475326-c545-11e7-8c6b-3f168b5f9fdd.png">

**To test**

- View an order, `/store/order/:site/:orderId`
- Click "Edit Order"
- The Shipping row in the totals section should now be an editable input. As you change the value, the order total should update.
- Click "Save Order", make sure the new shipping total is updated.
- You can also check in wp-admin to make sure it's properly saved.