### PR TITLE
Reader: Add animation to Conversations caterpillar

### DIFF
--- a/client/blocks/conversation-caterpillar/style.scss
+++ b/client/blocks/conversation-caterpillar/style.scss
@@ -1,5 +1,6 @@
 .conversation-caterpillar {
 	display: flex;
+	position: relative;
 }
 
 .conversation-caterpillar__gravatars,
@@ -59,4 +60,71 @@
 
 .conversations__stream .conversation-caterpillar {
 	margin-top: 20px;
+}
+
+// Caterpillar animation
+.conversation-caterpillar {
+	animation-delay: 1.6s;
+	animation-duration: .15s;
+	animation-fill-mode: forwards;
+	animation-name: slideDownFadeOut;
+	visibility: visible;
+}
+
+@keyframes slideDownFadeOut {
+
+	0% {
+		transform: translateY( 0%) ;
+	}
+
+	100% {
+		transform: translateY( 60% );
+		opacity: 0;
+	}
+}
+
+@keyframes slideDownFadeIn {
+
+	0% {
+		transform: translateY( 0% );
+		opacity: 0;
+	}
+
+	100% {
+		transform: translateY( 60% );
+		opacity: 1;
+	}
+}
+
+// Conversations comment animation
+.comments__comment {
+	animation-delay: 1s;
+	animation-duration: .15s;
+	animation-iteration-count: 1;
+	animation-fill-mode: forwards;
+	animation-name: slideDownFadeIn;
+}
+
+@keyframes slideDownComment {
+
+	0% {
+		transform: translateY( 0% );
+	}
+
+	100% {
+		transform: translateY( 100% );
+	}
+}
+
+@keyframes slideDownFadeInComment {
+
+	0% {
+		transform: translateY( 0% );
+		opacity: 0;
+	}
+
+	100% {
+		transform: translateY( 60% );
+		opacity: 1;
+	}
 }


### PR DESCRIPTION
This addresses: https://github.com/Automattic/wp-calypso/issues/17712

## Prototype: 
https://cloudup.com/cVc61XcPRzy (You may need to download the video if it's unable to convert).

## Demo: 
https://codepen.io/jancavan/pen/NaVMPz

In the demo, I'm using `animation-delay` to chain the animations. If we were to stick with the current css, I would need help:

1. Triggering the animation and playing them in an ordered sequence once triggered.
2. The classes `conversation-caterpillar` and `comments__comment` would need to have numbers appended to stick to this order.

I'm unsure if this is the best way to go about, but if there are different solutions that can work in conjunction with this, I'd love to hear them!

/cc @blowery @bluefuton @samouri 