### PR TITLE
Comments Redesign: Add success global notices

### DIFF
--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -482,10 +482,8 @@ export class CommentList extends Component {
 									isCommentsTreeSupported &&
 									! this.hasCommentJustMovedBackToCurrentStatus( commentId )
 								}
-								removeFromPersisted={ this.removeFromPersistedComments }
 								toggleSelected={ this.toggleCommentSelected }
 								updateLastUndo={ this.updateLastUndo }
-								updatePersisted={ this.updatePersistedComments }
 							/>
 						) ) }
 

--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -394,6 +394,8 @@ export class CommentList extends Component {
 
 	toggleSelectAll = selectedComments => this.setState( { selectedComments } );
 
+	updateLastUndo = commentId => this.setState( { lastUndo: commentId } );
+
 	updatePersistedComments = ( commentId, isUndo ) => {
 		if ( isUndo ) {
 			this.removeFromPersistedComments( commentId );
@@ -482,6 +484,7 @@ export class CommentList extends Component {
 								}
 								removeFromPersisted={ this.removeFromPersistedComments }
 								toggleSelected={ this.toggleCommentSelected }
+								updateLastUndo={ this.updateLastUndo }
 								updatePersisted={ this.updatePersistedComments }
 							/>
 						) ) }

--- a/client/my-sites/comments/comment/comment-actions.jsx
+++ b/client/my-sites/comments/comment/comment-actions.jsx
@@ -41,29 +41,18 @@ const commentActions = {
 export class CommentActions extends Component {
 	static propTypes = {
 		commentId: PropTypes.number,
-		removeFromPersisted: PropTypes.func,
 		toggleReply: PropTypes.func,
 		updateLastUndo: PropTypes.func,
-		updatePersisted: PropTypes.func,
 	};
 
 	delete = () => {
-		const { deletePermanently, commentId, postId, removeFromPersisted, siteId } = this.props;
-
+		const { deletePermanently, commentId, postId, siteId } = this.props;
 		deletePermanently( siteId, postId, commentId );
-
-		removeFromPersisted( commentId );
 	};
 
 	hasAction = action => includes( commentActions[ this.props.commentStatus ], action );
 
-	setSpam = () => {
-		const { commentId, removeFromPersisted } = this.props;
-
-		this.setStatus( 'spam' );
-
-		removeFromPersisted( commentId );
-	};
+	setSpam = () => this.setStatus( 'spam' );
 
 	setStatus = status => {
 		const {
@@ -93,13 +82,7 @@ export class CommentActions extends Component {
 		this.showNotice( status );
 	};
 
-	setTrash = () => {
-		const { commentId, removeFromPersisted } = this.props;
-
-		this.setStatus( 'trash' );
-
-		removeFromPersisted( commentId );
-	};
+	setTrash = () => this.setStatus( 'trash' );
 
 	showNotice = status => {
 		const { minimumComment, translate } = this.props;
@@ -127,16 +110,7 @@ export class CommentActions extends Component {
 	};
 
 	undo = ( status, previousCommentData ) => () => {
-		const {
-			changeStatus,
-			commentId,
-			like,
-			postId,
-			removeFromPersisted,
-			siteId,
-			unlike,
-			updateLastUndo,
-		} = this.props;
+		const { changeStatus, commentId, like, postId, siteId, unlike, updateLastUndo } = this.props;
 		const { isLiked: wasLiked, status: previousStatus } = previousCommentData;
 		const alsoApprove = 'approved' !== status && 'approved' === previousStatus;
 		const alsoUnlike = ! wasLiked && 'approved' !== previousStatus;
@@ -155,32 +129,13 @@ export class CommentActions extends Component {
 			unlike( siteId, postId, commentId );
 		}
 
-		removeFromPersisted( commentId );
-
 		this.props.removeNotice( 'comment-notice' );
 	};
 
-	toggleApproved = () => {
-		const { commentId, commentIsApproved, commentStatus, updatePersisted } = this.props;
-
-		this.setStatus( commentIsApproved ? 'unapproved' : 'approved' );
-
-		if ( includes( [ 'approved', 'unapproved' ], commentStatus ) ) {
-			updatePersisted( commentId );
-		}
-	};
+	toggleApproved = () => this.setStatus( this.props.commentIsApproved ? 'unapproved' : 'approved' );
 
 	toggleLike = () => {
-		const {
-			commentId,
-			commentIsLiked,
-			commentStatus,
-			like,
-			postId,
-			siteId,
-			unlike,
-			updatePersisted,
-		} = this.props;
+		const { commentId, commentIsLiked, commentStatus, like, postId, siteId, unlike } = this.props;
 
 		if ( commentIsLiked ) {
 			return unlike( siteId, postId, commentId );
@@ -192,7 +147,6 @@ export class CommentActions extends Component {
 
 		if ( alsoApprove ) {
 			this.setStatus( 'approved' );
-			updatePersisted( commentId );
 		}
 	};
 

--- a/client/my-sites/comments/comment/comment-actions.jsx
+++ b/client/my-sites/comments/comment/comment-actions.jsx
@@ -102,18 +102,7 @@ export class CommentActions extends Component {
 	};
 
 	showNotice = status => {
-		const {
-			changeStatus,
-			commentId,
-			like,
-			minimumComment,
-			postId,
-			removeFromPersisted,
-			siteId,
-			translate,
-			unlike,
-			updateLastUndo,
-		} = this.props;
+		const { minimumComment, translate } = this.props;
 
 		this.props.removeNotice( 'comment-notice' );
 
@@ -131,32 +120,44 @@ export class CommentActions extends Component {
 			button: translate( 'Undo' ),
 			id: 'comment-notice',
 			isPersistent: true,
-			onClick: () => {
-				const { isLiked: wasLiked, status: previousStatus } = minimumComment;
-				const alsoApprove = 'approved' !== status && 'approved' === previousStatus;
-				const alsoUnlike = ! wasLiked && 'approved' !== previousStatus;
-
-				updateLastUndo( commentId );
-
-				changeStatus( siteId, postId, commentId, previousStatus, {
-					alsoUnlike,
-					isUndo: true,
-					previousStatus: status,
-				} );
-
-				if ( wasLiked ) {
-					like( siteId, postId, commentId, { alsoApprove } );
-				} else if ( alsoUnlike ) {
-					unlike( siteId, postId, commentId );
-				}
-
-				removeFromPersisted( commentId );
-
-				this.props.removeNotice( 'comment-notice' );
-			},
+			onClick: this.undo( status, minimumComment ),
 		};
 
 		this.props.successNotice( message, noticeOptions );
+	};
+
+	undo = ( status, previousCommentData ) => () => {
+		const {
+			changeStatus,
+			commentId,
+			like,
+			postId,
+			removeFromPersisted,
+			siteId,
+			unlike,
+			updateLastUndo,
+		} = this.props;
+		const { isLiked: wasLiked, status: previousStatus } = previousCommentData;
+		const alsoApprove = 'approved' !== status && 'approved' === previousStatus;
+		const alsoUnlike = ! wasLiked && 'approved' !== previousStatus;
+
+		updateLastUndo( commentId );
+
+		changeStatus( siteId, postId, commentId, previousStatus, {
+			alsoUnlike,
+			isUndo: true,
+			previousStatus: status,
+		} );
+
+		if ( wasLiked ) {
+			like( siteId, postId, commentId, { alsoApprove } );
+		} else if ( alsoUnlike ) {
+			unlike( siteId, postId, commentId );
+		}
+
+		removeFromPersisted( commentId );
+
+		this.props.removeNotice( 'comment-notice' );
 	};
 
 	toggleApproved = () => {

--- a/client/my-sites/comments/comment/comment-reply.jsx
+++ b/client/my-sites/comments/comment/comment-reply.jsx
@@ -23,6 +23,7 @@ import {
 } from 'state/analytics/actions';
 import { changeCommentStatus, replyComment } from 'state/comments/actions';
 import { getCurrentUser } from 'state/current-user/selectors';
+import { removeNotice, successNotice } from 'state/notices/actions';
 import { getSiteComment } from 'state/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 
@@ -88,12 +89,25 @@ export class CommentReply extends Component {
 	};
 
 	submitReply = () => {
-		const { approveComment, commentStatus, postId, replyToComment, siteId } = this.props;
+		const { approveComment, commentStatus, postId, replyToComment, siteId, translate } = this.props;
 		const { replyContent } = this.state;
+
+		this.props.removeNotice( 'comment-notice' );
 
 		const alsoApprove = 'approved' !== commentStatus;
 
 		replyToComment( replyContent, siteId, postId, { alsoApprove } );
+
+		this.props.successNotice(
+			alsoApprove
+				? translate( 'Comment approved and reply submitted.' )
+				: translate( 'Reply submitted.' ),
+			{
+				id: 'comment-notice',
+				isPersistent: true,
+			}
+		);
+
 		this.setState( { replyContent: '' } );
 		this.blurReply();
 
@@ -200,6 +214,7 @@ const mapDispatchToProps = ( dispatch, { commentId } ) => ( {
 				changeCommentStatus( siteId, postId, commentId, 'approved' )
 			)
 		),
+	removeNotice: noticeId => dispatch( removeNotice( noticeId ) ),
 	replyToComment: ( replyContent, siteId, postId, analytics = { alsoApprove: false } ) =>
 		dispatch(
 			withAnalytics(
@@ -212,6 +227,7 @@ const mapDispatchToProps = ( dispatch, { commentId } ) => ( {
 				replyComment( replyContent, siteId, postId, commentId )
 			)
 		),
+	successNotice: ( text, options ) => dispatch( successNotice( text, options ) ),
 } );
 
 export default connect( mapStateToProps, mapDispatchToProps )( localize( CommentReply ) );

--- a/client/my-sites/comments/comment/index.jsx
+++ b/client/my-sites/comments/comment/index.jsx
@@ -30,10 +30,8 @@ export class Comment extends Component {
 		isPostView: PropTypes.bool,
 		isSelected: PropTypes.bool,
 		refreshCommentData: PropTypes.bool,
-		removeFromPersisted: PropTypes.func,
 		toggleSelected: PropTypes.func,
 		updateLastUndo: PropTypes.func,
-		updatePersisted: PropTypes.func,
 	};
 
 	state = {
@@ -97,10 +95,8 @@ export class Comment extends Component {
 			isPostView,
 			isSelected,
 			refreshCommentData,
-			removeFromPersisted,
 			siteId,
 			updateLastUndo,
-			updatePersisted,
 		} = this.props;
 		const { isEditMode, isExpanded, isReplyVisible } = this.state;
 
@@ -138,7 +134,7 @@ export class Comment extends Component {
 
 						{ showActions && (
 							<CommentActions
-								{ ...{ commentId, removeFromPersisted, updateLastUndo, updatePersisted } }
+								{ ...{ commentId, updateLastUndo } }
 								toggleReply={ this.toggleReply }
 							/>
 						) }

--- a/client/my-sites/comments/comment/index.jsx
+++ b/client/my-sites/comments/comment/index.jsx
@@ -32,6 +32,7 @@ export class Comment extends Component {
 		refreshCommentData: PropTypes.bool,
 		removeFromPersisted: PropTypes.func,
 		toggleSelected: PropTypes.func,
+		updateLastUndo: PropTypes.func,
 		updatePersisted: PropTypes.func,
 	};
 
@@ -98,6 +99,7 @@ export class Comment extends Component {
 			refreshCommentData,
 			removeFromPersisted,
 			siteId,
+			updateLastUndo,
 			updatePersisted,
 		} = this.props;
 		const { isEditMode, isExpanded, isReplyVisible } = this.state;
@@ -136,7 +138,7 @@ export class Comment extends Component {
 
 						{ showActions && (
 							<CommentActions
-								{ ...{ commentId, removeFromPersisted, updatePersisted } }
+								{ ...{ commentId, removeFromPersisted, updateLastUndo, updatePersisted } }
 								toggleReply={ this.toggleReply }
 							/>
 						) }


### PR DESCRIPTION
Add the success notices with the Undo feature for every action to the new `Comment` component.

- Approve, Unapprove, Spam, Trash
- Like and Approve (from unapproved)
- Reply, Reply and Approve (no Undo)
- Delete (no Undo) - not part of the PR, but it has the notice anyway.

Big changes from the current implementation:

- Notices don't stack anymore. We always have 1 single comment notice visible, referring to the last action performed.
- Notices don't disappear automatically after 5 seconds anymore, but have to be dismissed manually, because otherwise the first timeout time would be applied to all other notices 
I think this is caused because of how the notices timeout is implemented: 

### Notices Timeout

Notices duration is an odd beast.
As it happens, the first notice's timeout will be applied to all the following notices that appear in the same position in the timeout duration.
This, I think happens because notices are stored in an array.
So, let's say we create the first notice, with a duration of 5s.
After 3 seconds we dispatch a new notice; the first notice timeout has 2s left.
We remove the first notice because it's not relevant anymore, and add the new notice.
The second notice is added to the notices array at the same index of the first notice, and for some reasons will be unmounted when the first notice's timeout expires.
This means, that the second notice will only last 2s instead of 5s; in other words, it will expire at T+5s instead of T+8s as expected.

### Last Undo

You might notice a `lastUndo` logic brought all the way from `CommentList`.
This is a small workaround required to avoid a race condition happening when undoing persisted comments, causing the comment to disappear when is removed from the persisted list.

### Testing instructions

Checkout this branch and run it with
`ENABLE_FEATURES=comments/management/m3-design npm start`