### PR TITLE
Rewind: Refactor confirm dialog

### DIFF
--- a/client/my-sites/stats/activity-log-confirm-dialog/index.jsx
+++ b/client/my-sites/stats/activity-log-confirm-dialog/index.jsx
@@ -2,8 +2,7 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-import React, { Component } from 'react';
+import React from 'react';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -15,116 +14,57 @@ import Card from 'components/card';
 import Gridicon from 'gridicons';
 import HappychatButton from 'components/happychat/button';
 
-class ActivityLogConfirmDialog extends Component {
-	static propTypes = {
-		applySiteOffset: PropTypes.func.isRequired,
-		onClose: PropTypes.func.isRequired,
-		onConfirm: PropTypes.func.isRequired,
-		timestamp: PropTypes.number,
-		type: PropTypes.string,
-		icon: PropTypes.string,
+/* eslint-disable wpcalypso/jsx-classname-namespace */
+const ActivityLogConfirmDialog = ( {
+	children,
+	confirmTitle,
+	icon = 'history',
+	onClose,
+	onConfirm,
+	title,
+	translate,
+} ) => (
+	<div className="activity-log-item activity-log-item__restore-confirm">
+		<div className="activity-log-item__type">
+			<ActivityIcon activityIcon={ icon } />
+		</div>
+		<Card className="activity-log-item__card">
+			<h5 className="activity-log-confirm-dialog__title">{ title }</h5>
 
-		// Localize
-		translate: PropTypes.func.isRequired,
-		moment: PropTypes.func.isRequired,
-	};
+			<div className="activity-log-confirm-dialog__highlight">{ children }</div>
 
-	static defaultProps = {
-		type: 'restore',
-		icon: 'history',
-	};
-
-	handleClickCancel = () => this.props.onClose( this.props.type );
-	handleClickConfirm = () => this.props.onConfirm( this.props.type );
-
-	render() {
-		const { applySiteOffset, moment, timestamp, translate, type, icon } = this.props;
-		const activityTime = applySiteOffset( moment.utc( timestamp ) ).format( 'LLL' );
-		const strings = {};
-
-		switch ( type ) {
-			case 'restore':
-				strings.title = translate( 'Rewind Site' );
-				strings.confirm = translate( 'Confirm Rewind' );
-				strings.highlight = translate(
-					'This is the selected point for your site Rewind. ' +
-						'Are you sure you want to rewind your site back to {{b}}%(time)s{{/b}}?',
-					{
-						args: { time: activityTime },
-						components: { b: <b /> },
-					}
-				);
-				break;
-			case 'backup':
-				strings.title = translate( 'Create downloadable backup' );
-				strings.confirm = translate( 'Create download' );
-				strings.highlight = translate(
-					'We will build a downloadable backup of your site at {{b}}%(time)s{{/b}}. ' +
-						'You will get a notification when the backup is ready to download.',
-					{
-						args: { time: activityTime },
-						components: { b: <b /> },
-					}
-				);
-				break;
-		}
-
-		/* eslint-disable wpcalypso/jsx-classname-namespace */
-		return (
-			<div className="activity-log-item activity-log-item__restore-confirm">
-				<div className="activity-log-item__type">
-					<ActivityIcon activityIcon={ icon } />
+			<div className="activity-log-confirm-dialog__button-wrap">
+				<div className="activity-log-confirm-dialog__primary-actions">
+					<Button onClick={ onClose }>{ translate( 'Cancel' ) }</Button>
+					<Button primary onClick={ onConfirm }>
+						{ confirmTitle }
+					</Button>
 				</div>
-				<Card className="activity-log-item__card">
-					<h5 className="activity-log-confirm-dialog__title">{ strings.title }</h5>
-
-					<p className="activity-log-confirm-dialog__highlight">{ strings.highlight }</p>
-
-					{ 'restore' === type && (
-						<div className="activity-log-confirm-dialog__notice">
-							<Gridicon icon={ 'notice' } />
-							<span className="activity-log-confirm-dialog__notice-content">
-								{ translate(
-									'This will remove all content and options created or changed since then.'
-								) }
-							</span>
-						</div>
-					) }
-
-					<div className="activity-log-confirm-dialog__button-wrap">
-						<div className="activity-log-confirm-dialog__primary-actions">
-							<Button onClick={ this.handleClickCancel }>{ translate( 'Cancel' ) }</Button>
-							<Button primary onClick={ this.handleClickConfirm }>
-								{ strings.confirm }
-							</Button>
-						</div>
-						<div className="activity-log-confirm-dialog__secondary-actions">
-							<Button
-								borderless={ true }
-								className="activity-log-confirm-dialog__more-info-link"
-								href="https://help.vaultpress.com/one-click-restore/"
-							>
-								<Gridicon icon="notice" />
-								<span className="activity-log-confirm-dialog__more-info-link-text">
-									{ translate( 'More info' ) }
-								</span>
-							</Button>
-							<HappychatButton
-								className="activity-log-confirm-dialog__more-info-link"
-								href="https://help.vaultpress.com/one-click-restore/"
-							>
-								<Gridicon icon="chat" />
-								<span className="activity-log-confirm-dialog__more-info-link-text">
-									{ translate( 'Any Questions?' ) }
-								</span>
-							</HappychatButton>
-						</div>
-					</div>
-				</Card>
+				<div className="activity-log-confirm-dialog__secondary-actions">
+					<Button
+						borderless={ true }
+						className="activity-log-confirm-dialog__more-info-link"
+						href="https://help.vaultpress.com/one-click-restore/"
+					>
+						<Gridicon icon="notice" />
+						<span className="activity-log-confirm-dialog__more-info-link-text">
+							{ translate( 'More info' ) }
+						</span>
+					</Button>
+					<HappychatButton
+						className="activity-log-confirm-dialog__more-info-link"
+						href="https://help.vaultpress.com/one-click-restore/"
+					>
+						<Gridicon icon="chat" />
+						<span className="activity-log-confirm-dialog__more-info-link-text">
+							{ translate( 'Any Questions?' ) }
+						</span>
+					</HappychatButton>
+				</div>
 			</div>
-		);
-		/* eslint-enable wpcalypso/jsx-classname-namespace */
-	}
-}
+		</Card>
+	</div>
+);
+/* eslint-enable wpcalypso/jsx-classname-namespace */
 
 export default localize( ActivityLogConfirmDialog );

--- a/client/my-sites/stats/activity-log-confirm-dialog/index.jsx
+++ b/client/my-sites/stats/activity-log-confirm-dialog/index.jsx
@@ -19,8 +19,10 @@ const ActivityLogConfirmDialog = ( {
 	children,
 	confirmTitle,
 	icon = 'history',
+	notice,
 	onClose,
 	onConfirm,
+	supportLink,
 	title,
 	translate,
 } ) => (
@@ -32,6 +34,13 @@ const ActivityLogConfirmDialog = ( {
 			<h5 className="activity-log-confirm-dialog__title">{ title }</h5>
 
 			<div className="activity-log-confirm-dialog__highlight">{ children }</div>
+
+			{ notice && (
+				<div className="activity-log-confirm-dialog__notice">
+					<Gridicon icon={ 'notice' } />
+					{ notice }
+				</div>
+			) }
 
 			<div className="activity-log-confirm-dialog__button-wrap">
 				<div className="activity-log-confirm-dialog__primary-actions">
@@ -53,7 +62,7 @@ const ActivityLogConfirmDialog = ( {
 					</Button>
 					<HappychatButton
 						className="activity-log-confirm-dialog__more-info-link"
-						href="https://help.vaultpress.com/one-click-restore/"
+						href={ supportLink }
 					>
 						<Gridicon icon="chat" />
 						<span className="activity-log-confirm-dialog__more-info-link-text">

--- a/client/my-sites/stats/activity-log-confirm-dialog/style.scss
+++ b/client/my-sites/stats/activity-log-confirm-dialog/style.scss
@@ -45,6 +45,7 @@
 	position: relative;
 	width: 100%;
 	margin-bottom: 24px;
+	margin-top: 24px;
 	box-sizing: border-box;
 	animation: appear .3s ease-in-out;
 

--- a/client/my-sites/stats/activity-log-confirm-dialog/style.scss
+++ b/client/my-sites/stats/activity-log-confirm-dialog/style.scss
@@ -45,7 +45,6 @@
 	position: relative;
 	width: 100%;
 	margin-bottom: 24px;
-	margin-top: 24px;
 	box-sizing: border-box;
 	animation: appear .3s ease-in-out;
 


### PR DESCRIPTION
This patch works to extract coupled data and functions which are passed
via React props and which are blocking our ability to
generalize/abstract things like the confirmation dialog.

The goal of this PR and related work is to remove some of the chains of
passing props _through_ components and replace them by sufficiently
reusable ways through `connect()` and generalization of the dialogs and
buttons.

There should be no functional or visual changes in this PR.

**Testing**

Open a site with Activity Log enabled and go to **My Sites** > **Stats** > **Activity**

For both preparing a backup file download and for restoring a rewind event,
try to open the dialog, cancel the dialog, and confirm the operation. They
should work identically here as in **master**