### PR TITLE
Concierge Chats: Add calendar UI with mock data

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -263,6 +263,7 @@
 @import 'me/application-password-item/style';
 @import 'me/application-passwords/style';
 @import 'me/billing-history/style';
+@import 'me/concierge/style';
 @import 'me/connected-application-item/style';
 @import 'me/connected-applications/style';
 @import 'me/connected-application-icon/style';

--- a/client/me/concierge/calendar-card.js
+++ b/client/me/concierge/calendar-card.js
@@ -32,11 +32,11 @@ const getDayOfWeekString = date => {
 	return date.format( 'dddd' );
 };
 
-class CalendarStep extends Component {
+class CalendarCard extends Component {
 	static propTypes = {
-		date: PropTypes.string.isRequired,
+		date: PropTypes.number.isRequired,
 		onSubmit: PropTypes.func.isRequired,
-		options: PropTypes.array.isRequired,
+		times: PropTypes.arrayOf( PropTypes.number ).isRequired,
 	};
 
 	renderHeader = () => {
@@ -53,24 +53,24 @@ class CalendarStep extends Component {
 	};
 
 	render() {
-		const { options } = this.props;
+		const { times } = this.props;
 
 		return (
 			<FoldableCard
 				className="concierge__calendar-card"
-				clickableHeader={ ! isEmpty( options ) }
+				clickableHeader={ ! isEmpty( times ) }
 				compact
-				disabled={ isEmpty( options ) }
-				summary={ isEmpty( options ) ? 'No sessions available' : null }
+				disabled={ isEmpty( times ) }
+				summary={ isEmpty( times ) ? 'No sessions available' : null }
 				header={ this.renderHeader() }
 			>
 				<form>
 					<FormFieldset>
 						<FormLabel htmlFor="concierge-start-time">Choose a starting time</FormLabel>
 						<FormSelect id="concierge-start-time">
-							{ options.map( time => (
+							{ times.map( time => (
 								<option value={ time } key={ time }>
-									{ time }
+									{ moment( time ).format( 'h:mma z' ) }
 								</option>
 							) ) }
 						</FormSelect>
@@ -88,4 +88,4 @@ class CalendarStep extends Component {
 	}
 }
 
-export default CalendarStep;
+export default CalendarCard;

--- a/client/me/concierge/calendar-card.js
+++ b/client/me/concierge/calendar-card.js
@@ -54,7 +54,7 @@ class CalendarCard extends Component {
 			<div className="concierge__calendar-card-header">
 				<Gridicon icon="calendar" className="concierge__calendar-card-header-icon" />
 				<span>
-					<b>{ getDayOfWeekString( date ) } —</b> { date.format( ' MMMM D' ) }
+					<b>{ this.getDayOfWeekString( date ) } —</b> { date.format( ' MMMM D' ) }
 				</span>
 			</div>
 		);

--- a/client/me/concierge/calendar-card.js
+++ b/client/me/concierge/calendar-card.js
@@ -1,13 +1,20 @@
 /** @format */
 
 /**
+ * CalendarCard represents a day of schedulable concierge chats. Each card is expandable to
+ * allow the user to select a specific time on the day. If the day has no availability, it will
+ * not be expandable. When you stack a group of these cards together you'll get the scheduling
+ * calendar view.
+ */
+
+/**
  * External dependencies
  */
 import Gridicon from 'gridicons';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { isEmpty } from 'lodash';
-import { moment } from 'i18n-calypso';
+import { localize, moment } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -53,7 +60,7 @@ class CalendarCard extends Component {
 	};
 
 	render() {
-		const { times } = this.props;
+		const { times, translate } = this.props;
 
 		return (
 			<FoldableCard
@@ -61,31 +68,33 @@ class CalendarCard extends Component {
 				clickableHeader={ ! isEmpty( times ) }
 				compact
 				disabled={ isEmpty( times ) }
-				summary={ isEmpty( times ) ? 'No sessions available' : null }
+				summary={ isEmpty( times ) ? translate( 'No sessions available' ) : null }
 				header={ this.renderHeader() }
 			>
-				<form>
-					<FormFieldset>
-						<FormLabel htmlFor="concierge-start-time">Choose a starting time</FormLabel>
-						<FormSelect id="concierge-start-time">
-							{ times.map( time => (
-								<option value={ time } key={ time }>
-									{ moment( time ).format( 'h:mma z' ) }
-								</option>
-							) ) }
-						</FormSelect>
-						<FormSettingExplanation>Sessions are 30 minutes long.</FormSettingExplanation>
-					</FormFieldset>
+				<FormFieldset>
+					<FormLabel htmlFor="concierge-start-time">
+						{ translate( 'Choose a starting time' ) }
+					</FormLabel>
+					<FormSelect id="concierge-start-time">
+						{ times.map( time => (
+							<option value={ time } key={ time }>
+								{ moment( time ).format( 'h:mma z' ) }
+							</option>
+						) ) }
+					</FormSelect>
+					<FormSettingExplanation>
+						{ translate( 'Sessions are 30 minutes long.' ) }
+					</FormSettingExplanation>
+				</FormFieldset>
 
-					<FormFieldset>
-						<Button primary onClick={ this.props.onSubmit }>
-							Book this session
-						</Button>
-					</FormFieldset>
-				</form>
+				<FormFieldset>
+					<Button primary onClick={ this.props.onSubmit }>
+						{ translate( 'Book this session' ) }
+					</Button>
+				</FormFieldset>
 			</FoldableCard>
 		);
 	}
 }
 
-export default CalendarCard;
+export default localize( CalendarCard );

--- a/client/me/concierge/calendar-card.js
+++ b/client/me/concierge/calendar-card.js
@@ -1,0 +1,91 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import Gridicon from 'gridicons';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { isEmpty } from 'lodash';
+import { moment } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Button from 'components/button';
+import FoldableCard from 'components/foldable-card';
+import FormFieldset from 'components/forms/form-fieldset';
+import FormLabel from 'components/forms/form-label';
+import FormSelect from 'components/forms/form-select';
+import FormSettingExplanation from 'components/forms/form-setting-explanation';
+
+const getDayOfWeekString = date => {
+	const today = moment().startOf( 'day' );
+	const dayOffset = today.diff( date.startOf( 'day' ), 'days' );
+
+	switch ( dayOffset ) {
+		case 0:
+			return 'Today';
+		case -1:
+			return 'Tomorrow';
+	}
+	return date.format( 'dddd' );
+};
+
+class CalendarStep extends Component {
+	static propTypes = {
+		date: PropTypes.string.isRequired,
+		onSubmit: PropTypes.func.isRequired,
+		options: PropTypes.array.isRequired,
+	};
+
+	renderHeader = () => {
+		const date = moment( this.props.date );
+
+		return (
+			<div className="concierge__calendar-card-header">
+				<Gridicon icon="calendar" className="concierge__calendar-card-header-icon" />
+				<span>
+					<b>{ getDayOfWeekString( date ) } —</b> { date.format( ' MMMM D' ) }
+				</span>
+			</div>
+		);
+	};
+
+	render() {
+		const { options } = this.props;
+
+		return (
+			<FoldableCard
+				className="concierge__calendar-card"
+				clickableHeader={ ! isEmpty( options ) }
+				compact
+				disabled={ isEmpty( options ) }
+				summary={ isEmpty( options ) ? 'No sessions available' : null }
+				header={ this.renderHeader() }
+			>
+				<form>
+					<FormFieldset>
+						<FormLabel htmlFor="concierge-start-time">Choose a starting time</FormLabel>
+						<FormSelect id="concierge-start-time">
+							{ options.map( time => (
+								<option value={ time } key={ time }>
+									{ time }
+								</option>
+							) ) }
+						</FormSelect>
+						<FormSettingExplanation>Sessions are 30 minutes long.</FormSettingExplanation>
+					</FormFieldset>
+
+					<FormFieldset>
+						<Button primary onClick={ this.props.onSubmit }>
+							Book this session
+						</Button>
+					</FormFieldset>
+				</form>
+			</FoldableCard>
+		);
+	}
+}
+
+export default CalendarStep;

--- a/client/me/concierge/calendar-card.js
+++ b/client/me/concierge/calendar-card.js
@@ -33,6 +33,13 @@ class CalendarCard extends Component {
 		times: PropTypes.arrayOf( PropTypes.number ).isRequired,
 	};
 
+	/**
+	 * Returns a string representing the day of the week, with certain dates using natural
+	 * language like "Today" or "Tomorrow" instead of the name of the day.
+	 *
+	 * @param {Number} date Timestamp of the date
+	 * @returns {String} The name for the day of the week
+	 */
 	getDayOfWeekString = date => {
 		const { translate } = this.props;
 		const today = moment().startOf( 'day' );
@@ -48,6 +55,7 @@ class CalendarCard extends Component {
 	};
 
 	renderHeader = () => {
+		// The "Header" is that part of the foldable card that you click on to expand it.
 		const date = moment( this.props.date );
 
 		return (

--- a/client/me/concierge/calendar-card.js
+++ b/client/me/concierge/calendar-card.js
@@ -26,24 +26,25 @@ import FormLabel from 'components/forms/form-label';
 import FormSelect from 'components/forms/form-select';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
 
-const getDayOfWeekString = date => {
-	const today = moment().startOf( 'day' );
-	const dayOffset = today.diff( date.startOf( 'day' ), 'days' );
-
-	switch ( dayOffset ) {
-		case 0:
-			return 'Today';
-		case -1:
-			return 'Tomorrow';
-	}
-	return date.format( 'dddd' );
-};
-
 class CalendarCard extends Component {
 	static propTypes = {
 		date: PropTypes.number.isRequired,
 		onSubmit: PropTypes.func.isRequired,
 		times: PropTypes.arrayOf( PropTypes.number ).isRequired,
+	};
+
+	getDayOfWeekString = date => {
+		const { translate } = this.props;
+		const today = moment().startOf( 'day' );
+		const dayOffset = today.diff( date.startOf( 'day' ), 'days' );
+
+		switch ( dayOffset ) {
+			case 0:
+				return translate( 'Today' );
+			case -1:
+				return translate( 'Tomorrow' );
+		}
+		return date.format( 'dddd' );
 	};
 
 	renderHeader = () => {

--- a/client/me/concierge/calendar-step.js
+++ b/client/me/concierge/calendar-step.js
@@ -3,13 +3,13 @@
 /**
  * External dependencies
  */
-import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 
 /**
  * Internal dependencies
  */
-import Button from 'components/button';
+import CalendarCard from './calendar-card';
 import CompactCard from 'components/card/compact';
 import HeaderCake from 'components/header-cake';
 
@@ -23,12 +23,10 @@ class CalendarStep extends Component {
 		return (
 			<div>
 				<HeaderCake onClick={ this.props.onBack } />
-				<CompactCard>Here is the second step where the customer picks a date</CompactCard>
-				<CompactCard>
-					<Button primary onClick={ this.props.onComplete }>
-						Book this session
-					</Button>
-				</CompactCard>
+				<CompactCard>Please select a day to have your Concierge session.</CompactCard>
+				<CalendarCard date="2017-11-09" options={ [ 1, 2 ] } onSubmit={ this.props.onComplete } />
+				<CalendarCard date="2017-11-10" options={ [] } onSubmit={ this.props.onComplete } />
+				<CalendarCard date="2017-11-11" options={ [ 4, 5 ] } onSubmit={ this.props.onComplete } />
 			</div>
 		);
 	}

--- a/client/me/concierge/calendar-step.js
+++ b/client/me/concierge/calendar-step.js
@@ -5,13 +5,46 @@
  */
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-
+import { moment } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
 import CalendarCard from './calendar-card';
 import CompactCard from 'components/card/compact';
 import HeaderCake from 'components/header-cake';
+
+const generateMockData = () => {
+	// This is a temporary function to simulate the data that will be gathered from Redux.
+	// It's hard-coded to show some of the UI, e.g. what it looks like on a day with no
+	// available times.
+	const today = moment().startOf( 'day' );
+	const tomorrow = moment( today ).add( 1, 'day' );
+	const nextDay = moment( today ).add( 2, 'days' );
+
+	return [
+		{
+			date: today.valueOf(),
+			times: [
+				today.set( { hour: 9, minute: 30 } ).valueOf(),
+				today.set( { hour: 10, minute: 15 } ).valueOf(),
+				today.set( { hour: 21, minute: 0 } ).valueOf(),
+			],
+		},
+		{
+			date: tomorrow.valueOf(),
+			times: [],
+		},
+		{
+			date: nextDay.valueOf(),
+			times: [
+				nextDay.set( { hour: 7, minute: 0 } ).valueOf(),
+				nextDay.set( { hour: 7, minute: 45 } ).valueOf(),
+				nextDay.set( { hour: 8, minute: 0 } ).valueOf(),
+				nextDay.set( { hour: 13, minute: 15 } ).valueOf(),
+			],
+		},
+	];
+};
 
 class CalendarStep extends Component {
 	static propTypes = {
@@ -20,13 +53,21 @@ class CalendarStep extends Component {
 	};
 
 	render() {
+		// TODO: Replace mock data with data from Redux
+		const availability = generateMockData();
+
 		return (
 			<div>
 				<HeaderCake onClick={ this.props.onBack } />
 				<CompactCard>Please select a day to have your Concierge session.</CompactCard>
-				<CalendarCard date="2017-11-09" options={ [ 1, 2 ] } onSubmit={ this.props.onComplete } />
-				<CalendarCard date="2017-11-10" options={ [] } onSubmit={ this.props.onComplete } />
-				<CalendarCard date="2017-11-11" options={ [ 4, 5 ] } onSubmit={ this.props.onComplete } />
+				{ availability.map( ( { date, times } ) => (
+					<CalendarCard
+						date={ date }
+						times={ times }
+						onSubmit={ this.props.onComplete }
+						key={ date }
+					/>
+				) ) }
 			</div>
 		);
 	}

--- a/client/me/concierge/calendar-step.js
+++ b/client/me/concierge/calendar-step.js
@@ -5,7 +5,7 @@
  */
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { moment } from 'i18n-calypso';
+import { localize, moment } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
@@ -53,13 +53,18 @@ class CalendarStep extends Component {
 	};
 
 	render() {
+		const { translate } = this.props;
 		// TODO: Replace mock data with data from Redux
 		const availability = generateMockData();
 
 		return (
 			<div>
-				<HeaderCake onClick={ this.props.onBack } />
-				<CompactCard>Please select a day to have your Concierge session.</CompactCard>
+				<HeaderCake onClick={ this.props.onBack }>
+					{ translate( 'Choose Concierge Session' ) }
+				</HeaderCake>
+				<CompactCard>
+					{ translate( 'Please select a day to have your Concierge session.' ) }
+				</CompactCard>
 				{ availability.map( ( { date, times } ) => (
 					<CalendarCard
 						date={ date }
@@ -73,4 +78,4 @@ class CalendarStep extends Component {
 	}
 }
 
-export default CalendarStep;
+export default localize( CalendarStep );

--- a/client/me/concierge/main.js
+++ b/client/me/concierge/main.js
@@ -35,7 +35,7 @@ class ConciergeMain extends Component {
 		super( props );
 
 		this.state = {
-			currentStep: 0,
+			currentStep: 1,
 		};
 	}
 

--- a/client/me/concierge/main.js
+++ b/client/me/concierge/main.js
@@ -35,7 +35,7 @@ class ConciergeMain extends Component {
 		super( props );
 
 		this.state = {
-			currentStep: 1,
+			currentStep: 0,
 		};
 	}
 

--- a/client/me/concierge/style.scss
+++ b/client/me/concierge/style.scss
@@ -1,0 +1,18 @@
+/** @format */
+
+.concierge__calendar-card.is-expanded {
+	background: lighten($gray, 36%);
+}
+
+.concierge__calendar-card-header {
+	display: flex;
+	align-items: center;
+}
+
+.concierge__calendar-card-header-icon {
+	color: $gray;
+	border: 1px solid lighten($gray, 20%);
+	border-radius: 100%;
+	padding: 6px;
+	margin-right: 12px;
+}


### PR DESCRIPTION
Ref: 457-gh-hg / 438-gh-hg

This PR sets up the Calendar Step using mock data. It doesn't take any effect, but at this point that step should feel like a fully functional UI to the user. See links above to cross-reference the mockups.

The biggest thing introduced is the `CalendarCard` which is the primary UI for this screen. The `CalendarStep` gathers data (currently mocked because the data from the API isn't robust enough to show all the UI possibilities) and then uses the data to render one Calendar card for every upcoming day. In a later PR I'll use the concierge data in Redux to populate this data.

![conciergecalendardemo](https://user-images.githubusercontent.com/518059/32632177-4117d57e-c568-11e7-8ab0-6cbca06b6d66.gif)

### To test
Click through the Calendar step. The UI should feel like it's working (even though it isn't). The design should closely match the mockups from the issues linked above.