### PR TITLE
Activity Log - Faded or removed the trailing line for activity log timeline line

### DIFF
--- a/client/my-sites/stats/activity-log-day/style.scss
+++ b/client/my-sites/stats/activity-log-day/style.scss
@@ -2,6 +2,46 @@
 .activity-log-day {
 	background: none;
 	box-shadow: none;
+	position: relative;
+
+	// Fades out or covers up the timline line (on the left) at the end of events lists
+	&:last-of-type {
+		&:before {
+			content: '';
+			position: absolute;
+				bottom: 0;
+				left: 33px;
+			height: 72px;
+			width: 2px;
+			background-image: linear-gradient( transparent, $gray-light );
+
+			@include breakpoint( "<480px" ) {
+				left: 29px;
+			}
+		}
+
+		> .foldable-card__content.foldable-card__content {
+			padding-bottom: 0;
+		}
+
+		.activity-log-item {
+			&:last-of-type {
+				&:before {
+					content: '';
+					position: absolute;
+						bottom: 0;
+						left: 33px;
+					height: 72px;
+					width: 2px;
+					background: $gray-light;
+
+					@include breakpoint( "<480px" ) {
+						left: 21px;
+					}
+				}
+			}
+		}
+	}
 
 	> .foldable-card__header {
 		background: $white;


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/17065

### To test
* Go to the activity log on a month where you have activity on the first day of the month
* Expand the day and scroll to the bottom
* Toggle the last event's class to and from the discarded state(shown in following image)
<img width="477" alt="image" src="https://user-images.githubusercontent.com/1123119/32626066-6fffd85e-c54b-11e7-9d8e-7c06f92b1fea.png">
* Make sure other events look good and that there are no unintentional breaks in the timeline


#### Before
![image](https://user-images.githubusercontent.com/1123119/32626243-1139ebf6-c54c-11e7-9669-53debb54a68f.png)
![image](https://user-images.githubusercontent.com/1123119/32626295-2327e7dc-c54c-11e7-8c16-a5bfa37e3f21.png)
![image](https://user-images.githubusercontent.com/1123119/32626345-4ec5bffe-c54c-11e7-900f-01b763e38606.png)
![image](https://user-images.githubusercontent.com/1123119/32626365-59057ad6-c54c-11e7-969d-acf1fb192bdb.png)


#### After
![image](https://user-images.githubusercontent.com/1123119/32626186-de411ba2-c54b-11e7-95a9-58a7a91cef23.png)
![image](https://user-images.githubusercontent.com/1123119/32626165-cca5526e-c54b-11e7-9ffc-d98b7567d896.png)
![image](https://user-images.githubusercontent.com/1123119/32626122-ad3f2e40-c54b-11e7-98ea-339b6dcf965b.png)
![image](https://user-images.githubusercontent.com/1123119/32626143-bd7d7bb8-c54b-11e7-8b71-94b6e88cb553.png)
