### PR TITLE
Me: replace noticons with gridicons

### DIFF
--- a/client/me/notification-settings/blogs-settings/header.jsx
+++ b/client/me/notification-settings/blogs-settings/header.jsx
@@ -9,6 +9,7 @@ import React, { PureComponent } from 'react';
 import { localize } from 'i18n-calypso';
 import Immutable from 'immutable';
 import { includes, zip } from 'lodash';
+import Gridicon from 'gridicons';
 
 /**
  * Internal dependencies
@@ -88,9 +89,12 @@ class BlogSettingsHeader extends PureComponent {
 				</div>
 				{ ! this.props.disableToggle ? (
 					<div className="blogs-settings__header-expand">
-						<a
-							className={ 'noticon noticon-' + ( this.state.isExpanded ? 'collapse' : 'expand' ) }
-						/>
+						<a>
+							<Gridicon
+								icon={ this.state.isExpanded ? 'chevron-up' : 'chevron-down' }
+								size={ 18 }
+							/>
+						</a>
 					</div>
 				) : null }
 			</header>

--- a/client/me/notification-settings/blogs-settings/placeholder.jsx
+++ b/client/me/notification-settings/blogs-settings/placeholder.jsx
@@ -5,6 +5,7 @@
  */
 
 import React from 'react';
+import Gridicon from 'gridicons';
 
 /**
  * Internal dependencies
@@ -25,7 +26,11 @@ export default class extends React.Component {
 					<div className="notification-settings-blog-settings-placeholder__blog">
 						<div className="notification-settings-blog-settings-placeholder__blog__content">
 							<div className="notification-settings-blog-settings-placeholder__blog__content__icon">
-								<span className="notification-settings-blog-settings-placeholder__blog__content__icon__noticon noticon noticon-website" />
+								<Gridicon
+									// eslint-disable-next-line wpcalypso/jsx-classname-namespace
+									className="notification-settings-blog-settings-placeholder__blog__content__icon__gridicon"
+									icon="globe"
+								/>
 							</div>
 							<div className="notification-settings-blog-settings-placeholder__blog__info">
 								<div className="notification-settings-blog-settings-placeholder__blog__info__title">

--- a/client/me/notification-settings/blogs-settings/style.scss
+++ b/client/me/notification-settings/blogs-settings/style.scss
@@ -73,17 +73,16 @@
 	border: 1px solid white;
 	height: 32px;
 	width: 32px;
-	line-height: 32px;
 	overflow: hidden;
 	align-self: center;
 	margin-right: 12px;
+	display: flex;
+	justify-content: center;
+	align-items: center;
 }
 
-.notification-settings-blog-settings-placeholder__blog__content__icon__noticon {
-	color: #fff;
-	font-size: 32px;
-	line-height: 32px;
-	width: 32px;
+.notification-settings-blog-settings-placeholder__blog__content__icon__gridicon {
+	fill: #fff;
 }
 
 .notification-settings-blog-settings-placeholder__blog__info {

--- a/client/me/security-2fa-progress/index.jsx
+++ b/client/me/security-2fa-progress/index.jsx
@@ -42,13 +42,13 @@ class Security2faProgress extends React.Component {
 
 					<ProgressItem
 						label={ this.props.translate( 'Verify Code' ) }
-						icon="send-to-phone"
+						icon="lock"
 						step={ this.stepClass( 2 ) }
 					/>
 
 					<ProgressItem
 						label={ this.props.translate( 'Generate Backup Codes' ) }
-						icon="refresh"
+						icon="sync"
 						step={ this.stepClass( 3 ) }
 					/>
 				</div>

--- a/client/me/security-2fa-progress/progress-item.jsx
+++ b/client/me/security-2fa-progress/progress-item.jsx
@@ -8,6 +8,7 @@ import React from 'react';
 import debugFactory from 'debug';
 const debug = debugFactory( 'calypso:me:security:2fa-progress' );
 import classNames from 'classnames';
+import Gridicon from 'gridicons';
 
 export default class extends React.Component {
 	static displayName = 'Security2faProgressItem';
@@ -20,11 +21,6 @@ export default class extends React.Component {
 		debug( this.constructor.displayName + ' React component will unmount.' );
 	}
 
-	noticon = () => {
-		var icon = 'noticon-' + this.props.icon;
-		return classNames( 'noticon', icon );
-	};
-
 	highlight = () => {
 		return classNames( {
 			'security-2fa-progress__item': true,
@@ -36,7 +32,7 @@ export default class extends React.Component {
 	render() {
 		return (
 			<div className={ this.highlight() }>
-				<span className={ this.noticon() } />
+				<Gridicon icon={ this.props.icon } />
 				<label>{ this.props.label } </label>
 			</div>
 		);

--- a/client/me/security-2fa-progress/style.scss
+++ b/client/me/security-2fa-progress/style.scss
@@ -36,7 +36,7 @@
 					width: 50%;
 				}
 
-				.noticon {
+				.gridicon {
 					background: $blue-wordpress;
 					color: $white;
 					border-color: $blue-wordpress;
@@ -60,7 +60,7 @@
 					width: 100%;
 				}
 
-				.noticon {
+				.gridicon {
 					background: lighten( $gray, 20% );
 					color: $gray;
 				}
@@ -70,16 +70,15 @@
 				}
 			}
 
-			.noticon {
+			.gridicon {
 				background: $white;
 				border: 1px lighten( $gray, 20% ) solid;
 				border-radius: 50%;
 				color: lighten( $gray, 20% );
 				display: block;
-				height: 48px;
 				margin: 0 auto;
 				position: relative;
-				width: 48px;
+				padding: 12px;
 
 				&:before {
 					font-size: 32px;


### PR DESCRIPTION
Context: noticons is deprecated and this is an effort to remove a few instances.

This PR replaces noticons with gridicons in Me, if the noticon is **not** being displayed via css (e.g. :before elements)

I found these instances by searching for `noticon` on Github and filtering by jsx files.

**Icons and icon placement might be slightly off, but I am prioritizing removal of noticons versus getting an exact 1:1 replacement. For example, the icon might be positioned slightly off, or we might not have an exact match for the icon.**

# Visual changes

Before|After
---|---
![screen shot 2017-11-09 at 12 55 42 pm](https://user-images.githubusercontent.com/618551/32628902-f9ad4332-c55c-11e7-9444-735a99f2a536.png)|![screen shot 2017-11-09 at 12 55 37 pm](https://user-images.githubusercontent.com/618551/32628913-0803f890-c55d-11e7-93dd-1c83d80dc7e2.png)

Before|After
---|---
![screen shot 2017-11-09 at 2 39 05 pm](https://user-images.githubusercontent.com/618551/32628845-c6dd5320-c55c-11e7-984a-64981d3d71fe.png)|![screen shot 2017-11-09 at 2 38 07 pm](https://user-images.githubusercontent.com/618551/32628862-d67af10c-c55c-11e7-93af-8144ad478940.png)

Notification setting placeholder has no distinguishable change

# Affected areas:

- [x] Notification settings (placeholder)
- [x] Notification settings (expand card icon)
- [x] 2fa setup flow.

# What to test:

- [x] Setup 2fa flow
- [x] Notification settings (placeholder and expand function)