### PR TITLE
Jetpack connect: Refactor has error selectors

### DIFF
--- a/client/state/jetpack-connect/selectors.js
+++ b/client/state/jetpack-connect/selectors.js
@@ -110,7 +110,10 @@ const getUserAlreadyConnected = state => {
 const hasXmlrpcError = function( state ) {
 	const authorizeData = getAuthorizationData( state );
 
-	return includes( get( authorizeData, [ 'authorizeError', 'message' ] ), 'error' );
+	return (
+		!! get( authorizeData, 'authorizationCode', false ) &&
+		includes( get( authorizeData, [ 'authorizeError', 'message' ] ), 'error' )
+	);
 };
 
 /**
@@ -122,9 +125,9 @@ const hasXmlrpcError = function( state ) {
 const hasExpiredSecretError = function( state ) {
 	const authorizeData = getAuthorizationData( state );
 
-	return includes(
-		get( authorizeData, [ 'authorizeError', 'message' ] ),
-		'verify_secrets_expired'
+	return (
+		!! get( authorizeData, 'authorizationCode', false ) &&
+		includes( get( authorizeData, [ 'authorizeError', 'message' ] ), 'verify_secrets_expired' )
 	);
 };
 

--- a/client/state/jetpack-connect/selectors.js
+++ b/client/state/jetpack-connect/selectors.js
@@ -104,6 +104,9 @@ const getUserAlreadyConnected = state => {
 /**
  * Returns true if there is an XMLRPC error.
  *
+ * XMLRPC errors can be identified by the presence of an error message, the presence of an
+ * authorization code, and if the error message contains the string 'error'.
+ *
  * @param  {object}  state Global state tree
  * @return {Boolean}       True if there's an xmlrpc error otherwise false
  */

--- a/client/state/jetpack-connect/selectors.js
+++ b/client/state/jetpack-connect/selectors.js
@@ -3,8 +3,7 @@
  *
  * @format
  */
-
-import { get } from 'lodash';
+import { get, includes } from 'lodash';
 
 /**
  * Internal dependencies
@@ -103,33 +102,29 @@ const getUserAlreadyConnected = state => {
 };
 
 /**
- * XMLRPC errors can be identified by the presence of an error message, the presence of an authorization code
- * and if the error message contains the string 'error'
+ * Returns true if there is an XMLRPC error.
  *
- * @param {object} state Global state tree
- * @returns {Boolean} If there's an xmlrpc error or not
+ * @param  {object}  state Global state tree
+ * @return {Boolean}       True if there's an xmlrpc error otherwise false
  */
 const hasXmlrpcError = function( state ) {
 	const authorizeData = getAuthorizationData( state );
 
-	return (
-		authorizeData &&
-		authorizeData.authorizeError &&
-		authorizeData.authorizeError.message &&
-		authorizeData.authorizationCode &&
-		authorizeData.authorizeError.message.indexOf( 'error' ) > -1
-	);
+	return includes( get( authorizeData, [ 'authorizeError', 'message' ] ), 'error' );
 };
 
+/**
+ * Returns true if there is an expired secret error.
+ *
+ * @param  {object}  state Global state tree
+ * @return {Boolean}       True if there's an xmlrpc error otherwise false
+ */
 const hasExpiredSecretError = function( state ) {
 	const authorizeData = getAuthorizationData( state );
 
-	return (
-		authorizeData &&
-		authorizeData.authorizeError &&
-		authorizeData.authorizeError.message &&
-		authorizeData.authorizationCode &&
-		authorizeData.authorizeError.message.indexOf( 'verify_secrets_expired' ) > -1
+	return includes(
+		get( authorizeData, [ 'authorizeError', 'message' ] ),
+		'verify_secrets_expired'
 	);
 };
 

--- a/client/state/jetpack-connect/selectors.js
+++ b/client/state/jetpack-connect/selectors.js
@@ -9,10 +9,10 @@ import { get } from 'lodash';
 /**
  * Internal dependencies
  */
+import { AUTH_ATTEMPS_TTL } from './constants';
 import { getSiteByUrl } from 'state/sites/selectors';
 import { isStale } from './utils';
 import { urlToSlug } from 'lib/url';
-import { AUTH_ATTEMPS_TTL } from './constants';
 
 const getJetpackSiteByUrl = ( state, url ) => {
 	const site = getSiteByUrl( state, url );

--- a/client/state/jetpack-connect/test/selectors.js
+++ b/client/state/jetpack-connect/test/selectors.js
@@ -9,21 +9,21 @@ import { expect } from 'chai';
  * Internal dependencies
  */
 import {
-	getConnectingSite,
+	getAuthAttempts,
 	getAuthorizationData,
 	getAuthorizationRemoteQueryData,
 	getAuthorizationRemoteSite,
+	getConnectingSite,
+	getFlowType,
+	getJetpackSiteByUrl,
 	getSessions,
+	getSiteIdFromQueryObject,
 	getSSO,
+	hasExpiredSecretError,
+	hasXmlrpcError,
 	isCalypsoStartedConnection,
 	isRedirectingToWpAdmin,
 	isRemoteSiteOnSitesList,
-	getFlowType,
-	getJetpackSiteByUrl,
-	hasXmlrpcError,
-	getAuthAttempts,
-	hasExpiredSecretError,
-	getSiteIdFromQueryObject,
 } from '../selectors';
 
 describe( 'selectors', () => {

--- a/client/state/jetpack-connect/test/selectors.js
+++ b/client/state/jetpack-connect/test/selectors.js
@@ -523,7 +523,7 @@ describe( 'selectors', () => {
 
 		test( 'should be undefined when there is an empty state', () => {
 			const hasError = hasXmlrpcError( { jetpackConnect: {} } );
-			expect( hasError ).to.be.undefined;
+			expect( hasError ).to.be.false;
 		} );
 
 		test( 'should be false when there is no error', () => {
@@ -535,7 +535,7 @@ describe( 'selectors', () => {
 			// An authorization code is received during the jetpack.login portion of the connection
 			// XMLRPC errors happen only during jetpack.authorize which only happens after jetpack.login is succesful
 			const hasError = hasXmlrpcError( stateHasNoAuthorizationCode );
-			expect( hasError ).to.be.undefined;
+			expect( hasError ).to.be.false;
 		} );
 
 		test( 'should be false if a non-xmlrpc error is found', () => {
@@ -593,7 +593,7 @@ describe( 'selectors', () => {
 
 		test( 'should be undefined when there is an empty state', () => {
 			const hasError = hasExpiredSecretError( { jetpackConnect: {} } );
-			expect( hasError ).to.be.undefined;
+			expect( hasError ).to.be.false;
 		} );
 
 		test( 'should be false when there is no error', () => {
@@ -605,7 +605,7 @@ describe( 'selectors', () => {
 			// An authorization code is received during the jetpack.login portion of the connection
 			// Expired secret errors happen only during jetpack.authorize which only happens after jetpack.login is succesful
 			const hasError = hasExpiredSecretError( stateHasNoAuthorizationCode );
-			expect( hasError ).to.be.undefined;
+			expect( hasError ).to.be.false;
 		} );
 
 		test( 'should be false if no expired secret error is found', () => {

--- a/client/state/jetpack-connect/test/selectors.js
+++ b/client/state/jetpack-connect/test/selectors.js
@@ -495,7 +495,9 @@ describe( 'selectors', () => {
 		const stateHasNoError = {
 			jetpackConnect: {
 				jetpackConnectAuthorize: {
-					authorizeError: false,
+					authorizeError: {
+						message: '',
+					},
 				},
 			},
 		};
@@ -504,7 +506,7 @@ describe( 'selectors', () => {
 			jetpackConnect: {
 				jetpackConnectAuthorize: {
 					authorizeError: {
-						message: 'Could not verify your request.',
+						message: 'There was an error.',
 					},
 				},
 			},
@@ -574,7 +576,7 @@ describe( 'selectors', () => {
 			jetpackConnect: {
 				jetpackConnectAuthorize: {
 					authorizeError: {
-						message: 'Could not verify your request.',
+						message: 'An error message including "verify_secrets_expired".',
 					},
 				},
 			},

--- a/client/state/jetpack-connect/test/selectors.js
+++ b/client/state/jetpack-connect/test/selectors.js
@@ -521,7 +521,7 @@ describe( 'selectors', () => {
 			},
 		};
 
-		test( 'should be undefined when there is an empty state', () => {
+		test( 'should be false when there is an empty state', () => {
 			const hasError = hasXmlrpcError( { jetpackConnect: {} } );
 			expect( hasError ).to.be.false;
 		} );
@@ -531,7 +531,7 @@ describe( 'selectors', () => {
 			expect( hasError ).to.be.false;
 		} );
 
-		test( 'should be undefined when there is no authorization code', () => {
+		test( 'should be false when there is no authorization code', () => {
 			// An authorization code is received during the jetpack.login portion of the connection
 			// XMLRPC errors happen only during jetpack.authorize which only happens after jetpack.login is succesful
 			const hasError = hasXmlrpcError( stateHasNoAuthorizationCode );
@@ -591,7 +591,7 @@ describe( 'selectors', () => {
 			},
 		};
 
-		test( 'should be undefined when there is an empty state', () => {
+		test( 'should be false when there is an empty state', () => {
 			const hasError = hasExpiredSecretError( { jetpackConnect: {} } );
 			expect( hasError ).to.be.false;
 		} );
@@ -601,7 +601,7 @@ describe( 'selectors', () => {
 			expect( hasError ).to.be.false;
 		} );
 
-		test( 'should be undefined when there is no authorization code', () => {
+		test( 'should be false when there is no authorization code', () => {
 			// An authorization code is received during the jetpack.login portion of the connection
 			// Expired secret errors happen only during jetpack.authorize which only happens after jetpack.login is succesful
 			const hasError = hasExpiredSecretError( stateHasNoAuthorizationCode );


### PR DESCRIPTION
This PR simplifies two selectors used in Jetpack Connect:

* `hasExpiredSecretError`
* `hasXmlrpcError`

There are three changes:
* Refactor for simplicity
* _Always_ return a boolean, no more `undefined`
* Remove dependence on `authorizeData.authorizationCode`.

It's unclear whether `authorizeData.authorizationCode` was important. Perhaps @roccotripaldi or @johnHackworth has insight 😀 

## Testing
* Do we expect to get into a state where `authorizeData.authorizationCode`?
* I audited usage of the selectors, but is there any code relying on returning `undefined`?
* Tests pass
* Connections work