### PR TITLE
Jetpack connect: Drop function creation from selector

### DIFF
--- a/client/jetpack-connect/auth-logged-in-form.jsx
+++ b/client/jetpack-connect/auth-logged-in-form.jsx
@@ -557,9 +557,9 @@ class LoggedInForm extends Component {
 
 export default connect(
 	state => ( {
-		redirectAfterAuth: getJetpackConnectRedirectAfterAuth( state ),
 		hasExpiredSecretError: hasExpiredSecretErrorSelector( state ),
 		hasXmlrpcError: hasXmlrpcErrorSelector( state ),
+		redirectAfterAuth: getJetpackConnectRedirectAfterAuth( state ),
 	} ),
 	{
 		authorize: authorizeAction,

--- a/client/jetpack-connect/auth-logged-in-form.jsx
+++ b/client/jetpack-connect/auth-logged-in-form.jsx
@@ -42,6 +42,7 @@ import {
 	goToXmlrpcErrorFallbackUrl as goToXmlrpcErrorFallbackUrlAction,
 	retryAuth as retryAuthAction,
 } from 'state/jetpack-connect/actions';
+import { hasExpiredSecretError, hasXmlrpcError } from 'state/jetpack-connect/selectors';
 
 /**
  * Constants
@@ -71,8 +72,6 @@ class LoggedInForm extends Component {
 			} ).isRequired,
 			siteReceived: PropTypes.bool,
 		} ).isRequired,
-		requestHasExpiredSecretError: PropTypes.func.isRequired,
-		requestHasXmlrpcError: PropTypes.func.isRequired,
 		siteSlug: PropTypes.string.isRequired,
 		user: PropTypes.object.isRequired,
 
@@ -81,6 +80,8 @@ class LoggedInForm extends Component {
 		goBackToWpAdmin: PropTypes.func.isRequired,
 		goToXmlrpcErrorFallbackUrl: PropTypes.func.isRequired,
 		recordTracksEvent: PropTypes.func.isRequired,
+		requestHasExpiredSecretError: PropTypes.func.isRequired,
+		requestHasXmlrpcError: PropTypes.func.isRequired,
 		retryAuth: PropTypes.func.isRequired,
 		translate: PropTypes.func.isRequired,
 	};
@@ -554,6 +555,8 @@ class LoggedInForm extends Component {
 export default connect(
 	state => ( {
 		redirectAfterAuth: getJetpackConnectRedirectAfterAuth( state ),
+		requestHasExpiredSecretError: () => hasExpiredSecretError( state ),
+		requestHasXmlrpcError: () => hasXmlrpcError( state ),
 	} ),
 	{
 		authorize: authorizeAction,

--- a/client/jetpack-connect/authorize-form.jsx
+++ b/client/jetpack-connect/authorize-form.jsx
@@ -18,8 +18,6 @@ import {
 	getAuthorizationData,
 	getAuthorizationRemoteSite,
 	isCalypsoStartedConnection,
-	hasXmlrpcError,
-	hasExpiredSecretError,
 	isRemoteSiteOnSitesList,
 	getAuthAttempts,
 	getSiteIdFromQueryObject,
@@ -51,8 +49,6 @@ class JetpackConnectAuthorizeForm extends Component {
 		} ).isRequired,
 		recordTracksEvent: PropTypes.func,
 		setTracksAnonymousUserId: PropTypes.func,
-		requestHasExpiredSecretError: PropTypes.func,
-		requestHasXmlrpcError: PropTypes.func,
 		siteSlug: PropTypes.string,
 		user: PropTypes.object,
 	};
@@ -144,8 +140,6 @@ export default connect(
 	state => {
 		const remoteSiteUrl = getAuthorizationRemoteSite( state );
 		const siteSlug = urlToSlug( remoteSiteUrl );
-		const requestHasExpiredSecretError = () => hasExpiredSecretError( state );
-		const requestHasXmlrpcError = () => hasXmlrpcError( state );
 		const siteId = getSiteIdFromQueryObject( state );
 
 		return {
@@ -155,8 +149,6 @@ export default connect(
 			isFetchingAuthorizationSite: isRequestingSite( state, siteId ),
 			isFetchingSites: isRequestingSites( state ),
 			jetpackConnectAuthorize: getAuthorizationData( state ),
-			requestHasExpiredSecretError,
-			requestHasXmlrpcError,
 			siteSlug,
 			user: getCurrentUser( state ),
 			userAlreadyConnected: getUserAlreadyConnected( state ),


### PR DESCRIPTION
This PR removes the creation and invocation of an intermediate function from two selectors. It appears to serve no purpose at this point.

It also moves the error selectors to the consuming component.

This PR should contain no behavioral changes.

## Testing
1. I've included a diff below which you can apply to fake the errors. You'll need to disable the expired secret override to see the xmlrpcerror state.
1. Verify the error views are correct when on the authorize step of a connection

```diff
diff --git a/client/state/jetpack-connect/selectors.js b/client/state/jetpack-connect/selectors.js
index 6aea2b5d9..2e016d8d7 100644
--- a/client/state/jetpack-connect/selectors.js
+++ b/client/state/jetpack-connect/selectors.js
@@ -26,7 +26,10 @@ const getConnectingSite = state => {
 };
 
 const getAuthorizationData = state => {
-	return get( state, [ 'jetpackConnect', 'jetpackConnectAuthorize' ] );
+	return {
+		...get( state, [ 'jetpackConnect', 'jetpackConnectAuthorize' ] ),
+		authorizeError: { message: '' },
+	};
 };
 
 const getAuthorizationRemoteQueryData = state => {
@@ -113,6 +116,7 @@ const getUserAlreadyConnected = state => {
 const hasXmlrpcError = function( state ) {
 	const authorizeData = getAuthorizationData( state );
 
+	return true;
 	return (
 		!! get( authorizeData, 'authorizationCode', false ) &&
 		includes( get( authorizeData, [ 'authorizeError', 'message' ] ), 'error' )
@@ -126,6 +130,7 @@ const hasXmlrpcError = function( state ) {
  * @return {Boolean}       True if there's an xmlrpc error otherwise false
  */
 const hasExpiredSecretError = function( state ) {
+	return true;
 	const authorizeData = getAuthorizationData( state );
 
 	return (
```