### PR TITLE
Framework: Bump i18n-calypso to 1.8.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "hash.js": "1.1.3",
     "he": "0.5.0",
     "html-loader": "0.4.0",
-    "i18n-calypso": "1.8.1",
+    "i18n-calypso": "Automattic/i18n-calypso#update/interpolate-components",
     "immutability-helper": "2.4.0",
     "immutable": "3.7.6",
     "imports-loader": "0.6.5",


### PR DESCRIPTION
To a preliminary branch for now, see https://github.com/Automattic/i18n-calypso/pull/45.