### PR TITLE
[WIP] Checkout: Add Ebanx credit card UI form fields and validation

### DIFF
--- a/client/blocks/credit-card-form/index.jsx
+++ b/client/blocks/credit-card-form/index.jsx
@@ -51,7 +51,22 @@ const CreditCardForm = createReactClass( {
 	},
 
 	_mounted: false,
-	fieldNames: [ 'name', 'number', 'cvv', 'expirationDate', 'country', 'postalCode' ],
+	fieldNames: [
+		'name',
+		'number',
+		'cvv',
+		'expirationDate',
+		'country',
+		'postalCode',
+		'streetNumber',
+		'address1',
+		'address2',
+		'phoneNumber',
+		'streetNumber',
+		'city',
+		'state',
+		'document',
+	],
 
 	componentWillMount() {
 		this._mounted = true;

--- a/client/components/credit-card-form-fields/README.md
+++ b/client/components/credit-card-form-fields/README.md
@@ -13,6 +13,12 @@ CreditCardFormFields
 
 Some of these fields use [masking](https://en.wikipedia.org/wiki/Input_mask), i.e. rules that govern what a user is allowed to enter in a text box.
 
+Brazil requires that users provide additional details when making payments. When a user selects Brazil from the country select menu, extra fields will appear:
+
+* Tax identification code, also known as [CPF](https://en.wikipedia.org/wiki/Cadastro_de_Pessoas_F%C3%ADsicas)
+* Phone number
+* Address, city and state details
+
 ## Usage
 
 ```jsx

--- a/client/components/credit-card-form-fields/index.jsx
+++ b/client/components/credit-card-form-fields/index.jsx
@@ -6,18 +6,20 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import { assign } from 'lodash';
 import { localize } from 'i18n-calypso';
+import classNames from 'classnames';
+import isEqual from 'lodash/isEqual';
 
 /**
  * Internal dependencies
  */
-import CountrySelect from 'my-sites/domains/components/form/country-select';
 import CreditCardNumberInput from 'components/upgrades/credit-card-number-input';
-import Input from 'my-sites/domains/components/form/input';
+import { CountrySelect, StateSelect, Input, HiddenInput } from 'my-sites/domains/components/form';
+import FormPhoneMediaInput from 'components/forms/form-phone-media-input';
 import { maskField, unmaskField } from 'lib/credit-card-details';
+import { isEbanx } from 'lib/credit-card-details/ebanx';
 
-class CreditCardFormFields extends React.Component {
+export class CreditCardFormFields extends React.Component {
 	static propTypes = {
 		card: PropTypes.object.isRequired,
 		countriesList: PropTypes.object.isRequired,
@@ -26,28 +28,47 @@ class CreditCardFormFields extends React.Component {
 		onFieldChange: PropTypes.func.isRequired,
 	};
 
-	field = ( fieldName, componentClass, props ) => {
+	constructor( props ) {
+		super( props );
+		this.state = {
+			countryCode: '',
+			phoneCountryCode: '',
+		};
+	}
+
+	shouldComponentUpdate( nextProps ) {
+		if ( ! isEqual( nextProps.card, this.props.card ) ) {
+			return true;
+		}
+		return false;
+	}
+
+	createField = ( fieldName, componentClass, props ) => {
 		return React.createElement(
 			componentClass,
-			assign( {}, props, {
-				additionalClasses: 'credit-card-form-fields__field',
-				eventFormName: this.props.eventFormName,
-				isError: this.props.isFieldInvalid( fieldName ),
-				name: fieldName,
-				onBlur: this.handleFieldChange,
-				onChange: this.handleFieldChange,
-				value: this.getFieldValue( fieldName ),
-				autoComplete: 'off',
-			} )
+			Object.assign(
+				{},
+				{
+					additionalClasses: 'credit-card-form-fields__field',
+					eventFormName: this.props.eventFormName,
+					isError: this.props.isFieldInvalid( fieldName ),
+					name: fieldName,
+					// onBlur: this.handleFieldChange,
+					onChange: this.handleFieldChange,
+					value: this.getFieldValue( fieldName ) || '',
+					autoComplete: 'off',
+				},
+				props
+			)
 		);
 	};
 
 	getFieldValue = fieldName => {
-		return this.props.card[ fieldName ];
+		return this.props.card[ fieldName ] || '';
 	};
 
-	handleFieldChange = event => {
-		const { name: fieldName, value: nextValue } = event.target;
+	updateFieldValues( fieldName, nextValue ) {
+		const { onFieldChange } = this.props;
 
 		const previousValue = this.getFieldValue( fieldName );
 
@@ -59,54 +80,158 @@ class CreditCardFormFields extends React.Component {
 			[ fieldName ]: maskField( fieldName, previousValue, nextValue ),
 		};
 
-		this.props.onFieldChange( rawDetails, maskedDetails );
+		onFieldChange( rawDetails, maskedDetails );
+	}
+
+	handlePhoneFieldChange = ( { value, countryCode } ) => {
+		this.setState(
+			{
+				phoneCountryCode: countryCode,
+			},
+			() => {
+				this.updateFieldValues( 'phone-number', value );
+			}
+		);
 	};
 
+	handleFieldChange = event => {
+		const { name: fieldName, value: nextValue, options, selectedIndex } = event.target;
+
+		const newState = {};
+
+		if ( fieldName === 'country' ) {
+			newState.countryCode = nextValue;
+			newState.countryName = options[ selectedIndex ].text;
+			if ( ! this.state.phoneCountryCode ) {
+				newState.phoneCountryCode = nextValue;
+			}
+		}
+
+		this.setState( newState, () => this.updateFieldValues( fieldName, nextValue ) );
+	};
+
+	shouldRenderEbanx() {
+		const { countryCode } = this.state;
+		return isEbanx( countryCode );
+	}
+
+	renderEbanxFields() {
+		const { translate, countriesList } = this.props;
+		const { countryCode, phoneCountryCode, countryName } = this.state;
+
+		return [
+			<span key="ebanx-required-fields" className="credit-card-form-fields__info-text">
+				{ translate( 'The following fields are also required for payments in %(countryName)s', {
+					args: {
+						countryName,
+					},
+					context: 'Info text for extra ebanx fields in credit card form',
+				} ) }
+			</span>,
+
+			this.createField( 'document', Input, {
+				label: translate( 'Taxpayer Identification Number', {
+					context:
+						'Individual taxpayer registry identification required ' +
+						'for Brazilian payment methods using EBANX on credit card form',
+				} ),
+				key: 'document',
+			} ),
+
+			this.createField( 'phone-number', FormPhoneMediaInput, {
+				onChange: this.handlePhoneFieldChange,
+				// onBlur: this.handlePhoneFieldChange,
+				countriesList: countriesList,
+				countryCode: phoneCountryCode,
+				label: translate( 'Phone' ),
+				key: 'phone-number',
+			} ),
+
+			this.createField( 'address-1', Input, {
+				maxLength: 40,
+				labelClass: 'credit-card-form-fields__label',
+				label: translate( 'Address' ),
+				key: 'address-1',
+			} ),
+
+			this.createField( 'street-number', Input, {
+				inputMode: 'numeric',
+				label: translate( 'Street Number', {
+					context: 'Street number associated with address on credit card form',
+				} ),
+				key: 'street-number',
+			} ),
+
+			this.createField( 'address-2', HiddenInput, {
+				maxLength: 40,
+				labelClass: 'credit-card-form-fields__label',
+				label: translate( 'Address Line 2' ),
+				text: translate( '+ Add Address Line 2' ),
+				key: 'address-2',
+			} ),
+
+			this.createField( 'city', Input, {
+				labelClass: 'credit-card-form-fields__label',
+				label: translate( 'City' ),
+				key: 'city',
+			} ),
+
+			<div className="credit-card-form-fields__state-field" key="state">
+				{ this.createField( 'state', StateSelect, {
+					countryCode: countryCode,
+					label: translate( 'State' ),
+				} ) }
+			</div>,
+		];
+	}
+
 	render() {
-		const translate = this.props.translate;
+		const { translate, countriesList } = this.props;
+		const ebanxDetailsRequired = this.shouldRenderEbanx();
+		const creditCardFormFieldsExtrasClassNames = classNames( {
+			'credit-card-form-fields__extras': true,
+			'ebanx-details-required': ebanxDetailsRequired,
+		} );
 
 		return (
 			<div className="credit-card-form-fields">
-				{ this.field( 'name', Input, {
-					labelClass: 'credit-card-form-fields__label',
+				{ this.createField( 'name', Input, {
 					autoFocus: true,
 					label: translate( 'Name on Card', {
 						context: 'Card holder name label on credit card form',
 					} ),
 				} ) }
 
-				{ this.field( 'number', CreditCardNumberInput, {
+				{ this.createField( 'number', CreditCardNumberInput, {
 					inputMode: 'numeric',
-					labelClass: 'credit-card-form-fields__label',
 					label: translate( 'Card Number', {
 						context: 'Card number label on credit card form',
 					} ),
 				} ) }
 
-				<div className="credit-card-form-fields__extras">
-					{ this.field( 'expiration-date', Input, {
+				<div className={ creditCardFormFieldsExtrasClassNames }>
+					{ this.createField( 'expiration-date', Input, {
 						inputMode: 'numeric',
-						labelClass: 'credit-card-form-fields__label',
 						label: translate( 'MM/YY', {
 							context: 'Expiry label on credit card form',
 						} ),
 					} ) }
 
-					{ this.field( 'cvv', Input, {
+					{ this.createField( 'cvv', Input, {
 						inputMode: 'numeric',
-						labelClass: 'credit-card-form-fields__label',
 						label: translate( 'CVV', {
 							context: '3 digit security number on credit card form',
 						} ),
 					} ) }
 
-					{ this.field( 'country', CountrySelect, {
+					{ this.createField( 'country', CountrySelect, {
 						label: translate( 'Country' ),
-						countriesList: this.props.countriesList,
+						countriesList: countriesList,
 					} ) }
 
-					{ this.field( 'postal-code', Input, {
-						labelClass: 'credit-card-form-fields__label',
+					{ ebanxDetailsRequired && this.renderEbanxFields() }
+
+					{ this.createField( 'postal-code', Input, {
 						label: translate( 'Postal Code', {
 							context: 'Postal code on credit card form',
 						} ),

--- a/client/components/credit-card-form-fields/style.scss
+++ b/client/components/credit-card-form-fields/style.scss
@@ -11,13 +11,19 @@
 		margin-left: 15px;
 	}
 
-	.country {
-		label {
-			display: none;
-		}
+	.credit-card-form-fields__state-field {
+		flex-basis: calc( 100% );
 	}
 
-	@include breakpoint( ">480px" ) {
+	.form__hidden-input a {
+		display: block;
+		font-size:  12px;
+		margin-top: -10px;
+		margin-left: 15px;
+		margin-bottom: 15px;
+	}
+
+	@include breakpoint( '>480px' ) {
 		.cvv,
 		.expiration-date {
 			flex-basis: calc( 50% - 15px );
@@ -29,6 +35,30 @@
 
 		.postal-code {
 			flex-basis: 8em;
+		}
+
+		&.ebanx-details-required {
+
+			.address-2,
+			.country,
+			.city {
+				flex-basis: calc( 100% - 15px );
+			}
+
+			.street-number {
+				flex-basis: calc( 33% - 15px);
+			}
+
+			.address-1 {
+				flex-basis: calc( 66% - 15px);
+			}
+
+			.document,
+			.phone,
+			.credit-card-form-fields__state-field,
+			.postal-code {
+				flex-basis: calc( 50% - 15px );
+			}
 		}
 	}
 }
@@ -42,19 +72,25 @@
 		width: 100%;
 	}
 
-	input[ disabled ] {
+	input[disabled] {
 		cursor: not-allowed;
 	}
-}
 
-.credit-card-form-fields__label {
 	label {
 		color: darken( $gray, 10% );
-		display: none;
 		font-size: 11px;
 		font-weight: bold;
 		position: absolute;
-		left: 13px;
-		top: 12px;
+		left: -1000px;
+		top: -1000px;
+		margin: 0;
 	}
+}
+
+.credit-card-form-fields__info-text {
+	margin-left: 15px;
+	color: lighten( $gray, 10% );
+	display: block;
+	font-size: 12px;
+	font-style: italic;
 }

--- a/client/components/credit-card-form-fields/test/index.js
+++ b/client/components/credit-card-form-fields/test/index.js
@@ -1,0 +1,61 @@
+/**
+ * @format
+ * @jest-environment jsdom
+ */
+
+/**
+ * External dependencies
+ */
+import { shallow } from 'enzyme';
+import React from 'react';
+import noop from 'lodash/noop';
+import identity from 'lodash/identity';
+/**
+ * Internal dependencies
+ */
+import { CreditCardFormFields } from '../';
+import { isEbanx } from 'lib/credit-card-details/ebanx';
+
+jest.mock( 'i18n-calypso', () => ( {
+	localize: x => x,
+} ) );
+
+jest.mock( 'lib/credit-card-details/ebanx', () => {
+	return {
+		isEbanx: jest.fn( false ),
+	};
+} );
+
+const defaultProps = {
+	card: {},
+	countriesList: {},
+	eventFormName: 'A fine form',
+	translate: identity,
+	isFieldInvalid: identity,
+	onFieldChange: noop,
+};
+
+describe( 'CreditCardFormFields', () => {
+	test( 'should have `CreditCardFormFields` class', () => {
+		const wrapper = shallow( <CreditCardFormFields { ...defaultProps } /> );
+		expect( wrapper.find( '.credit-card-form-fields' ) ).toHaveLength( 1 );
+	} );
+
+	describe( 'with ebanx activated', () => {
+		beforeAll( () => {
+			isEbanx.mockReturnValue( true );
+		} );
+		afterAll( () => {
+			isEbanx.mockReturnValue( false );
+		} );
+
+		test( 'should display Ebanx fields when an Ebanx payment country is selected', () => {
+			const wrapper = shallow( <CreditCardFormFields { ...defaultProps } /> );
+			wrapper.setState( { countryCode: 'BR' } );
+			// shouldComponentUpdate prevents setState from triggering a rerender in <CreditCardFormFields />
+			wrapper.setProps( { card: { country: 'BR' } } );
+			expect( wrapper.find( '.ebanx-details-required' ) ).toHaveLength( 1 );
+			expect( wrapper.find( '.credit-card-form-fields__info-text' ) ).toHaveLength( 1 );
+		} );
+	} );
+} );

--- a/client/lib/credit-card-details/constants.js
+++ b/client/lib/credit-card-details/constants.js
@@ -1,0 +1,7 @@
+/**
+ * External dependencies
+ *
+ * @format
+ */
+
+export const PAYMENT_PROCESSOR_EBANX_COUNTRY_CODES = [ 'BR' ];

--- a/client/lib/credit-card-details/ebanx.js
+++ b/client/lib/credit-card-details/ebanx.js
@@ -1,0 +1,39 @@
+/**
+ * External dependencies
+ *
+ * @format
+ */
+import includes from 'lodash/includes';
+import isString from 'lodash/isString';
+
+/**
+ * Internal dependencies
+ */
+import config from 'config';
+import { PAYMENT_PROCESSOR_EBANX_COUNTRY_CODES } from './constants';
+
+/**
+ *
+ * @param {string} countryCode - a two-letter country code, e.g., 'DE', 'BR'
+ * @returns {bool} Whether the country code requires ebanx payement processing
+ */
+export function isEbanx( countryCode = '' ) {
+	return (
+		includes( PAYMENT_PROCESSOR_EBANX_COUNTRY_CODES, countryCode ) &&
+		config.isEnabled( 'upgrades/ebanx' )
+	);
+}
+
+/**
+ * CPF number (Cadastrado de Pessoas Físicas) is the Brazilian tax identification number.
+ * Total of 11 digits: 9 numbers followed by 2 verification numbers . E.g., 188.247.019-22
+ * The following test is a weak test only. Full algorithm here: http://www.geradorcpf.com/algoritmo_do_cpf.htm
+ *
+ * See: http://www.geradorcpf.com/algoritmo_do_cpf.htm
+ * @param {string} cpf - a Brazilian tax identification number
+ * @returns {bool} Whether the cpf is valid or not
+ */
+
+export function isValidCPF( cpf = '' ) {
+	return isString( cpf ) && /^[0-9]{3}\.[0-9]{3}\.[0-9]{3}-[0-9]{2}$/.test( cpf );
+}

--- a/client/lib/credit-card-details/test/ebanx.js
+++ b/client/lib/credit-card-details/test/ebanx.js
@@ -1,0 +1,50 @@
+/**
+ * @format
+ */
+
+/**
+ * External dependencies
+ */
+
+/**
+ * Internal dependencies
+ */
+import { isEbanx, isValidCPF } from '../ebanx';
+import { isEnabled } from 'config';
+import { PAYMENT_PROCESSOR_EBANX_COUNTRY_CODES } from '../constants';
+
+jest.mock( 'config', () => {
+	const config = () => 'development';
+
+	config.isEnabled = jest.fn( false );
+
+	return config;
+} );
+
+describe( 'Ebanx payment processing methods', () => {
+	describe( 'isEbanx', () => {
+		beforeAll( () => {
+			isEnabled.mockReturnValue( true );
+		} );
+		afterAll( () => {
+			isEnabled.mockReturnValue( false );
+		} );
+
+		test( 'should return false for non-ebanx country', () => {
+			expect( isEbanx( 'AU' ) ).toEqual( false );
+		} );
+		test( 'should return true for ebanx country', () => {
+			expect( isEbanx( PAYMENT_PROCESSOR_EBANX_COUNTRY_CODES[ 0 ] ) ).toEqual( true );
+		} );
+	} );
+
+	describe( 'isValidCPF', () => {
+		test( 'should return true for valid CPF (Brazilian tax identification number)', () => {
+			expect( isValidCPF( '853.513.468-93' ) ).toEqual( true );
+		} );
+		test( 'should return false for invalid CPF', () => {
+			expect( isValidCPF( '85384484632' ) ).toEqual( false );
+			expect( isValidCPF( '853.844.846.32' ) ).toEqual( false );
+		} );
+	} );
+} );

--- a/client/lib/credit-card-details/test/validation.js
+++ b/client/lib/credit-card-details/test/validation.js
@@ -10,6 +10,14 @@ import moment from 'moment';
  * Internal dependencies
  */
 import { validateCardDetails } from '../validation';
+import { isEbanx, isValidCPF } from 'lib/credit-card-details/ebanx';
+
+jest.mock( 'lib/credit-card-details/ebanx', () => {
+	return {
+		isEbanx: jest.fn( false ),
+		isValidCPF: jest.fn( false ),
+	};
+} );
 
 describe( 'validation', () => {
 	const validCard = {
@@ -25,34 +33,168 @@ describe( 'validation', () => {
 		'postal-code': '90210',
 	};
 
+	const validBrazilianEbanxCard = {
+		name: 'Ana Santos Araujo',
+		number: '4111111111111111',
+		'expiration-date':
+			'01/' +
+			moment()
+				.add( 1, 'years' )
+				.format( 'YY' ),
+		cvv: '111',
+		country: 'BR',
+		'postal-code': '90210',
+		city: 'Maracanaú',
+		state: 'CE',
+		document: '853.513.468-93',
+		'phone-number': '+85 2284-7035',
+		'address-1': 'Rua E',
+		'street-number': '1040',
+	};
+
 	describe( '#validateCardDetails', () => {
 		test( 'should return no errors when card is valid', () => {
 			const result = validateCardDetails( validCard );
-
 			expect( result ).to.be.eql( { errors: {} } );
 		} );
 
-		test( 'should return error when card has expiration date in the past', () => {
-			const expiredCard = { ...validCard, 'expiration-date': '01/01' };
+		describe( 'validate credit card', () => {
+			test( 'should return error when card has expiration date in the past', () => {
+				const expiredCard = { ...validCard, 'expiration-date': '01/01' };
+				const result = validateCardDetails( expiredCard );
 
-			const result = validateCardDetails( expiredCard );
+				expect( result ).to.be.eql( {
+					errors: {
+						'expiration-date': [ 'Credit card expiration date is invalid' ],
+					},
+				} );
+			} );
 
-			expect( result ).to.be.eql( {
-				errors: {
-					'expiration-date': [ 'Credit card expiration date is invalid' ],
-				},
+			test( 'should return error when cvv is the wrong length', () => {
+				const invalidCVVCard = { ...validCard, cvv: '12345' };
+				const result = validateCardDetails( invalidCVVCard );
+
+				expect( result ).to.be.eql( {
+					errors: {
+						cvv: [ 'Credit card cvv code is invalid' ],
+					},
+				} );
 			} );
 		} );
 
-		test( 'should return error when cvv is the wrong length', () => {
-			const invalidCVVCard = { ...validCard, cvv: '12345' };
+		describe( 'validate basic non-credit card details', () => {
+			test( 'should return error when card holder name is missing', () => {
+				const invalidCardHolderName = { ...validCard, name: '' };
+				const result = validateCardDetails( invalidCardHolderName );
 
-			const result = validateCardDetails( invalidCVVCard );
+				expect( result ).to.be.eql( {
+					errors: {
+						name: [ 'Missing required Name on Card field' ],
+					},
+				} );
+			} );
 
-			expect( result ).to.be.eql( {
-				errors: {
-					cvv: [ 'Credit card cvv code is invalid' ],
-				},
+			test( 'should return error when Name on Card is missing', () => {
+				const invalidCardHolderName = { ...validCard, name: '' };
+				const result = validateCardDetails( invalidCardHolderName );
+
+				expect( result ).to.be.eql( {
+					errors: {
+						name: [ 'Missing required Name on Card field' ],
+					},
+				} );
+			} );
+
+			test( 'should return error when Postal Code is missing', () => {
+				const invalidCardPostCode = { ...validCard, 'postal-code': '' };
+				const result = validateCardDetails( invalidCardPostCode );
+
+				expect( result ).to.be.eql( {
+					errors: {
+						'postal-code': [ 'Missing required Postal Code field' ],
+					},
+				} );
+			} );
+		} );
+
+		describe( 'validate ebanx non-credit card details', () => {
+			beforeAll( () => {
+				isEbanx.mockReturnValue( true );
+				isValidCPF.mockReturnValue( true );
+			} );
+
+			test( 'should return no errors when details are valid', () => {
+				const result = validateCardDetails( validBrazilianEbanxCard );
+
+				expect( result ).to.be.eql( { errors: {} } );
+			} );
+
+			test( 'should return error when city is missing', () => {
+				const invalidCity = { ...validBrazilianEbanxCard, city: '' };
+				const result = validateCardDetails( invalidCity );
+
+				expect( result ).to.be.eql( {
+					errors: {
+						city: [ 'Missing required City field' ],
+					},
+				} );
+			} );
+
+			test( 'should return error when state is missing', () => {
+				const invalidState = { ...validBrazilianEbanxCard, state: '' };
+				const result = validateCardDetails( invalidState );
+
+				expect( result ).to.be.eql( {
+					errors: {
+						state: [ 'Missing required State field' ],
+					},
+				} );
+			} );
+
+			test( 'should return error when address-1 is missing', () => {
+				const invalidAddress = { ...validBrazilianEbanxCard, 'address-1': '' };
+				const result = validateCardDetails( invalidAddress );
+
+				expect( result ).to.be.eql( {
+					errors: {
+						'address-1': [ 'Missing required Address field' ],
+					},
+				} );
+			} );
+
+			test( 'should return error when street-number is missing', () => {
+				const invalidStNo = { ...validBrazilianEbanxCard, 'street-number': '' };
+				const result = validateCardDetails( invalidStNo );
+
+				expect( result ).to.be.eql( {
+					errors: {
+						'street-number': [ 'Missing required Street Number field' ],
+					},
+				} );
+			} );
+
+			test( 'should return error when phone number is missing', () => {
+				const invalidStPhNo = { ...validBrazilianEbanxCard, 'phone-number': '' };
+				const result = validateCardDetails( invalidStPhNo );
+
+				expect( result ).to.be.eql( {
+					errors: {
+						'phone-number': [ 'Missing required Phone Number field' ],
+					},
+				} );
+			} );
+
+			test( 'should return error when CPF is invalid', () => {
+				isValidCPF.mockReturnValue( false );
+				const invalidCPF = { ...validBrazilianEbanxCard, document: 'blah' };
+				const result = validateCardDetails( invalidCPF );
+				expect( result ).to.be.eql( {
+					errors: {
+						document: [
+							'Taxpayer Identification Number is invalid. Must be in format: 111.444.777-XX',
+						],
+					},
+				} );
 			} );
 		} );
 	} );

--- a/client/lib/credit-card-details/validation.js
+++ b/client/lib/credit-card-details/validation.js
@@ -8,47 +8,89 @@ import creditcards from 'creditcards';
 import { capitalize, compact, inRange, isArray, isEmpty } from 'lodash';
 import i18n from 'i18n-calypso';
 
-function creditCardFieldRules() {
+/**
+ * Internal dependencies
+ */
+import { isEbanx, isValidCPF } from 'lib/credit-card-details/ebanx';
+
+function ebanxFieldRules() {
 	return {
-		name: {
-			description: i18n.translate( 'Name on Card', {
-				context: 'Upgrades: Card holder name label on credit card form',
-				textOnly: true,
-			} ),
+		document: {
+			description: i18n.translate( 'Taxpayer Identification Number' ),
+			rules: [ 'validCPF' ],
+		},
+
+		'street-number': {
+			description: i18n.translate( 'Street Number' ),
 			rules: [ 'required' ],
 		},
 
-		number: {
-			description: i18n.translate( 'Card Number', {
-				context: 'Upgrades: Card number label on credit card form',
-				textOnly: true,
-			} ),
-			rules: [ 'required', 'validCreditCardNumber' ],
-		},
-
-		'expiration-date': {
-			description: i18n.translate( 'Credit Card Expiration Date' ),
-			rules: [ 'required', 'validExpirationDate' ],
-		},
-
-		cvv: {
-			description: i18n.translate( 'Credit Card CVV Code' ),
-			rules: [ 'required', 'validCvvNumber' ],
-		},
-
-		country: {
-			description: i18n.translate( 'Country' ),
+		'address-1': {
+			description: i18n.translate( 'Address' ),
 			rules: [ 'required' ],
 		},
 
-		'postal-code': {
-			description: i18n.translate( 'Postal Code', {
-				context: 'Upgrades: Postal code on credit card form',
-				textOnly: true,
-			} ),
+		state: {
+			description: i18n.translate( 'State' ),
+			rules: [ 'required' ],
+		},
+
+		city: {
+			description: i18n.translate( 'City' ),
+			rules: [ 'required' ],
+		},
+
+		'phone-number': {
+			description: i18n.translate( 'Phone Number' ),
 			rules: [ 'required' ],
 		},
 	};
+}
+
+function creditCardFieldRules( additionalFieldRules = {} ) {
+	return Object.assign(
+		{
+			name: {
+				description: i18n.translate( 'Name on Card', {
+					context: 'Upgrades: Card holder name label on credit card form',
+					textOnly: true,
+				} ),
+				rules: [ 'required' ],
+			},
+
+			number: {
+				description: i18n.translate( 'Card Number', {
+					context: 'Upgrades: Card number label on credit card form',
+					textOnly: true,
+				} ),
+				rules: [ 'validCreditCardNumber' ],
+			},
+
+			'expiration-date': {
+				description: i18n.translate( 'Credit Card Expiration Date' ),
+				rules: [ 'validExpirationDate' ],
+			},
+
+			cvv: {
+				description: i18n.translate( 'Credit Card CVV Code' ),
+				rules: [ 'validCvvNumber' ],
+			},
+
+			country: {
+				description: i18n.translate( 'Country' ),
+				rules: [ 'required' ],
+			},
+
+			'postal-code': {
+				description: i18n.translate( 'Postal Code', {
+					context: 'Upgrades: Postal code on credit card form',
+					textOnly: true,
+				} ),
+				rules: [ 'required' ],
+			},
+		},
+		additionalFieldRules
+	);
 }
 
 function parseExpiration( value ) {
@@ -115,8 +157,22 @@ validators.validExpirationDate = {
 	error: validationError,
 };
 
+validators.validCPF = {
+	isValid( value ) {
+		if ( ! value ) {
+			return false;
+		}
+		return isValidCPF( value );
+	},
+	error: function( description ) {
+		return i18n.translate( '%(description)s is invalid. Must be in format: 111.444.777-XX', {
+			args: { description: description },
+		} );
+	},
+};
+
 function validateCardDetails( cardDetails ) {
-	const rules = creditCardFieldRules(),
+	const rules = creditCardFieldRules( getAdditionalFieldRules( cardDetails ) ),
 		errors = Object.keys( rules ).reduce( function( allErrors, fieldName ) {
 			const field = rules[ fieldName ],
 				newErrors = getErrors( field, cardDetails[ fieldName ], cardDetails );
@@ -177,6 +233,20 @@ function getErrors( field, value, cardDetails ) {
 	);
 }
 
+/**
+ *
+ * @param {object} cardDetails - a map of credit card field key value pairs
+ * @returns {object|null} If match is found,
+ * an object containing rule sets for specific credit card processing providers,
+ * otherwise `null`
+ */
+function getAdditionalFieldRules( { country } ) {
+	if ( isEbanx( country ) ) {
+		return ebanxFieldRules();
+	}
+	return null;
+}
+
 function getValidator( rule ) {
 	if ( isArray( rule ) ) {
 		return validators[ rule[ 0 ] ].apply( null, rule.slice( 1 ) );
@@ -186,6 +256,6 @@ function getValidator( rule ) {
 }
 
 export default {
-	getCreditCardType: getCreditCardType,
-	validateCardDetails: validateCardDetails,
+	getCreditCardType,
+	validateCardDetails,
 };


### PR DESCRIPTION
This PR extends @yoavf 's  #18286 and adds the UI fields for processing Ebanx (or the equivalent) payments:

- `document`
- `phone-number`
- `street-number`
- `address`
- `city`
- `state`

In place of `address`, we've added two fields -`address-1` and `address-2` - to accommodate apartment information and so on.

<img width="728" alt="ui-fields" src="https://user-images.githubusercontent.com/6458278/32636582-92ae6f28-c609-11e7-8d70-4c649dce3ff3.png">


Initially we've started with the required fields for payments made by individuals only. 

Payments made by companies involve [extra fields and validation].(https://developers.ebanx.com/guides/create-a-payment/brazil).

The fields apply both at [checkout](https://github.com/Automattic/wp-calypso/blob/add/ebanx-credit-card-form-fields/client/my-sites/checkout/checkout/new-card-form.jsx) and when adding a [new card](https://github.com/Automattic/wp-calypso/blob/add/ebanx-credit-card-form-fields/client/blocks/credit-card-form/index.jsx).

### Where we're at

- Abstract the required fields for Brazil into a sub-component (With React 16, we'll get fragments so we can return a list of nodes that will slot into the form without losing)
- Revisit error handling (see below)
- No API integration yet

### A word on _Cadastro de Pessoas Físicas_ (CPF)
There is allegedly an 'official' [algorithm](http://www.geradorcpf.com/algoritmo_do_cpf.htm) to validate a Brazilian tax code. I thought it best to enforce weak validation, that is checking the string's format and not its constituent parts. If we decide to implement the stronger check at the API level, then there's less duplication should the validation requirements ever change. It's chunky, but I'm open to adding it on the front end as well however.

### Error handling 
The error handling for the credit card form isn't what it could be, actually it's not what it should be. Submitting empty fields create a colossal red blob that covers the form, and remains there until you dismiss it. 

We might like to take a look at whacking these errors inline, or thinking about something less intrusive.

<img width="765" alt="ui-fields-error" src="https://user-images.githubusercontent.com/6458278/32636814-90178ffa-c60a-11e7-9f53-4418f0e308ed.png">


