### PR TITLE
Domains checkout: resetting extra fields steps when cart items updated

### DIFF
--- a/client/my-sites/checkout/checkout/domain-details-form.jsx
+++ b/client/my-sites/checkout/checkout/domain-details-form.jsx
@@ -128,6 +128,10 @@ export class DomainDetailsForm extends PureComponent {
 		if ( ! isEqual( previousFormValues, currentFormValues ) ) {
 			this.props.updateContactDetailsCache( this.getMainFieldValues() );
 		}
+
+		if ( ! isEqual( prevProps.cart, this.props.cart ) ) {
+			this.validateSteps();
+		}
 	}
 
 	loadFormStateFromRedux = fn => {
@@ -152,6 +156,18 @@ export class DomainDetailsForm extends PureComponent {
 
 	hasAnotherStep() {
 		return this.state.currentStep !== last( this.state.steps );
+	}
+
+	validateSteps() {
+		const updatedSteps = [ 'mainForm', ...this.getRequiredExtraSteps() ];
+		const newState = {
+			steps: updatedSteps,
+		};
+		if ( updatedSteps.indexOf( this.state.currentStep ) < 0 ) {
+			debug( 'Switching to step: mainForm' );
+			newState.currentStep = 'mainForm';
+		}
+		this.setState( newState );
 	}
 
 	getCountryCode() {
@@ -258,6 +274,7 @@ export class DomainDetailsForm extends PureComponent {
 			// All we need to do to disable everything is not show the .FR form
 			return [];
 		}
+
 		return intersection( cartItems.getTlds( this.props.cart ), tldsWithAdditionalDetailsForms );
 	}
 

--- a/client/my-sites/domains/components/form/country-select.jsx
+++ b/client/my-sites/domains/components/form/country-select.jsx
@@ -85,6 +85,7 @@ const CountrySelect = createReactClass( {
 						value={ value }
 						disabled={ this.props.disabled }
 						ref="input"
+						inputRef={ this.props.inputRef }
 						onChange={ this.props.onChange }
 						onClick={ this.recordCountrySelectClick }
 						isError={ this.props.isError }


### PR DESCRIPTION
### What this PR does

This PR addresses the situations in which a user removes a `*.ca` and/or `*.fr` domain from the cart while:

1. on the main details form, and then clicks continue (See Issue: #14748)
2. viewing the extra information panel interstitial step associated with that domain.

In both cases, the extra details interstitial step is displayed despite the user having deleted the corresponding domain.

The remedy is to update the steps whenever the component receives new cart props.

If a cart item is removed while the user is currently viewing the linked step (for example, the user deletes the `*.ca` domain while viewing the Canadian citizenship checkbox), we send them back to the contact form.

![main-form](https://user-images.githubusercontent.com/6458278/32644722-8b9f6f2e-c637-11e7-82f6-2851359c8c87.gif)

### What this PR doesn't do

This change does not gracefully handle the case whereby a user purchases both a `*.ca` domain _and_ a `*.fr` domain, and removes either domain when on the interstitial step. 

The next iteration should ideally we should send the user to the next step, if one exists, or straight to the credit card form. One way to do this might be the following:

```
if ( updatedSteps.indexOf( this.state.currentStep ) < 0 ) {
    // get the next step at the current index, or the last one
    newState.currentStep = updatedSteps[ indexOf( updatedSteps, this.state.currentStep ) ] ||
        updatedSteps[ updatedSteps.length - 1 ];
}
```

The object of this PR however was to immediately correct a bad user experience. 

Another reason for avoiding more complex logic this time round is that this component is becoming increasingly hard to test; ideally we'd need to mock cartItems and its methods and spend more time testing the flow. Extracting the steps logic would help with testing the interstitial flow. 

### Testing
#### Steps
1. Add `*.ca` and `*.fr` domains, as well as a `*.com` domain to your cart. 
2. Fill in the details form and click continue
3. If you're on the **fr/ca** extra details form, delete the **fr/ca** domain
4. Repeat steps 1 
5. Fill in the details form 
6. Delete the **fr** and **ca** domains and click continue

#### Expected behaviour
You shouldn't see the interstitial step for any domain that has been deleted.


