### PR TITLE
Jetpack Connect: improve marketing Copy of the Plan page 

### DIFF
--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -722,7 +722,7 @@ export const FEATURES_LIST = {
 		getSlug: () => FEATURE_ALL_PERSONAL_FEATURES,
 		getTitle: () => i18n.translate( 'All Personal features' ),
 		getDescription: () =>
-			i18n.translate( 'Also includes all features offered in the Premium plan.' ),
+			i18n.translate( 'Also includes all features offered in the Personal plan.' ),
 	},
 
 	[ FEATURE_ALL_PREMIUM_FEATURES ]: {
@@ -1350,7 +1350,7 @@ export const FEATURES_LIST = {
 
 	[ FEATURE_MARKETING_AUTOMATION ]: {
 		getSlug: () => FEATURE_MARKETING_AUTOMATION,
-		getTitle: () => i18n.translate( 'Social Media Automation.' ),
+		getTitle: () => i18n.translate( 'Social Media Automation' ),
 		getDescription: () =>
 			i18n.translate(
 				'Re-share previously published content on social media, or schedule new shares in advance.'

--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -714,16 +714,22 @@ export const FEATURES_LIST = {
 	[ FEATURE_ALL_FREE_FEATURES ]: {
 		getSlug: () => FEATURE_ALL_FREE_FEATURES,
 		getTitle: () => i18n.translate( 'All free features' ),
+		getDescription: () =>
+			i18n.translate( 'Also includes all features offered in the free version of Jetpack.' ),
 	},
 
 	[ FEATURE_ALL_PERSONAL_FEATURES ]: {
 		getSlug: () => FEATURE_ALL_PERSONAL_FEATURES,
 		getTitle: () => i18n.translate( 'All Personal features' ),
+		getDescription: () =>
+			i18n.translate( 'Also includes all features offered in the Premium plan.' ),
 	},
 
 	[ FEATURE_ALL_PREMIUM_FEATURES ]: {
 		getSlug: () => FEATURE_ALL_PREMIUM_FEATURES,
 		getTitle: () => i18n.translate( 'All Premium features' ),
+		getDescription: () =>
+			i18n.translate( 'Also includes all features offered in the Premium plan.' ),
 	},
 
 	[ FEATURE_ADVANCED_CUSTOMIZATION ]: {
@@ -794,6 +800,10 @@ export const FEATURES_LIST = {
 	[ FEATURE_VIDEO_CDN_LIMITED ]: {
 		getSlug: () => FEATURE_VIDEO_CDN_LIMITED,
 		getTitle: () => i18n.translate( '13GB Video Storage' ),
+		getDescription: () =>
+			i18n.translate(
+				'High-speed video hosting on our CDN, free of ads and watermarks, fully optimized for WordPress.'
+			),
 	},
 
 	[ FEATURE_VIDEO_CDN_UNLIMITED ]: {
@@ -804,6 +814,10 @@ export const FEATURES_LIST = {
 	[ FEATURE_SEO_PREVIEW_TOOLS ]: {
 		getSlug: () => FEATURE_SEO_PREVIEW_TOOLS,
 		getTitle: () => i18n.translate( 'SEO Tools' ),
+		getDescription: () =>
+			i18n.translate(
+				'Edit your page titles and meta descriptions, and preview how your content will appear on social media.'
+			),
 	},
 
 	[ FEATURE_GOOGLE_ANALYTICS ]: {
@@ -1330,11 +1344,17 @@ export const FEATURES_LIST = {
 	[ FEATURE_CONCIERGE_SETUP ]: {
 		getSlug: () => FEATURE_CONCIERGE_SETUP,
 		getTitle: () => i18n.translate( 'Jetpack Concierge' ),
+		getDescription: () =>
+			i18n.translate( 'A complimentary one-on-one education session with a Jetpack expert.' ),
 	},
 
 	[ FEATURE_MARKETING_AUTOMATION ]: {
 		getSlug: () => FEATURE_MARKETING_AUTOMATION,
 		getTitle: () => i18n.translate( 'Social Media Automation.' ),
+		getDescription: () =>
+			i18n.translate(
+				'Re-share previously published content on social media, or schedule new shares in advance.'
+			),
 	},
 };
 

--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -803,7 +803,7 @@ export const FEATURES_LIST = {
 
 	[ FEATURE_SEO_PREVIEW_TOOLS ]: {
 		getSlug: () => FEATURE_SEO_PREVIEW_TOOLS,
-		getTitle: () => i18n.translate( 'SEO Preview Tools' ),
+		getTitle: () => i18n.translate( 'SEO Tools' ),
 	},
 
 	[ FEATURE_GOOGLE_ANALYTICS ]: {
@@ -1329,14 +1329,12 @@ export const FEATURES_LIST = {
 
 	[ FEATURE_CONCIERGE_SETUP ]: {
 		getSlug: () => FEATURE_CONCIERGE_SETUP,
-		getTitle: () => i18n.translate( 'Concierge Setup' ),
-		hideInfoPopover: true,
+		getTitle: () => i18n.translate( 'Jetpack Concierge' ),
 	},
 
 	[ FEATURE_MARKETING_AUTOMATION ]: {
 		getSlug: () => FEATURE_MARKETING_AUTOMATION,
-		getTitle: () => i18n.translate( 'Marketing Automation' ),
-		hideInfoPopover: true,
+		getTitle: () => i18n.translate( 'Social Media Automation.' ),
 	},
 };
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/19581

Improve marketing content of the Jetpack Plans: 
- add missing information in the pop-up boxes 
- remove unnecessary on/off flags for the above
- change Copy of the features as suggested in the issue

**To test**:
- check that text appears in every `i` pop-up

Please ignore the pop-up issue for the time being:
https://github.com/Automattic/wp-calypso/issues/19666
